### PR TITLE
nd: IPv6 ND observability — NS/NA codec, counters, show ipv6 nd, BGP discovery state, BDD

### DIFF
--- a/bdd/Makefile
+++ b/bdd/Makefile
@@ -182,6 +182,10 @@ bgp_unnumbered_neighbor:
 	mkdir -p allure-results
 	cargo test --test cucumber -- --concurrency=1 --tags "@bgp_unnumbered_neighbor"
 
+nd_show:
+	mkdir -p allure-results
+	cargo test --test cucumber -- --concurrency=1 --tags "@nd_show"
+
 bgp_interas_option_c:
 	mkdir -p allure-results
 	cargo test --test cucumber -- --concurrency=1 --tags "@bgp_interas_option_c"
@@ -221,4 +225,4 @@ docs/%.md: tests/features/%.feature docs/feature2md.sh FORCE
 
 FORCE:
 
-.PHONY: all run ibgp ebgp rr rib_static_ipv6 isis_ipv6 isis_srv6 isis_fragmentation_ipv6 isis_fragmentation_ipv4 isis_l1p2p isis_tilfa isis_l1l2 isis_redist isis_hello_auth_keychain isis_passive isis_afi_enable isis_endx_ipv6 isis_bfd_ipv6_p2p isis_bfd_ipv6_p2p_echo isis_bfd_ipv6_lan isis_bfd_ipv6_lan_echo isis_bfd_ipv4_p2p isis_bfd_ipv4_p2p_echo isis_bfd_ipv4_lan isis_bfd_ipv4_lan_echo ospf_clear_neighbor ospfv2_nssa ospfv2_stub ospfv2_tilfa ospfv3_nssa ospfv3_tilfa bgp_peer_down_cleanup bgp_ipv6_over_v4_session bgp_evpn_capability bgp_vrf_evpn_type5 bgp_route_map_match bgp_policy_dynamic_update bgp_community bgp_neighbor_group bgp_unnumbered_neighbor bgp_interas_option_c bgp_interas_option_a bgp_interas_option_b bgp_interas_option_ab generate open docs FORCE
+.PHONY: all run ibgp ebgp rr rib_static_ipv6 isis_ipv6 isis_srv6 isis_fragmentation_ipv6 isis_fragmentation_ipv4 isis_l1p2p isis_tilfa isis_l1l2 isis_redist isis_hello_auth_keychain isis_passive isis_afi_enable isis_endx_ipv6 isis_bfd_ipv6_p2p isis_bfd_ipv6_p2p_echo isis_bfd_ipv6_lan isis_bfd_ipv6_lan_echo isis_bfd_ipv4_p2p isis_bfd_ipv4_p2p_echo isis_bfd_ipv4_lan isis_bfd_ipv4_lan_echo ospf_clear_neighbor ospfv2_nssa ospfv2_stub ospfv2_tilfa ospfv3_nssa ospfv3_tilfa bgp_peer_down_cleanup bgp_ipv6_over_v4_session bgp_evpn_capability bgp_vrf_evpn_type5 bgp_route_map_match bgp_policy_dynamic_update bgp_community bgp_neighbor_group bgp_unnumbered_neighbor nd_show bgp_interas_option_c bgp_interas_option_a bgp_interas_option_b bgp_interas_option_ab generate open docs FORCE

--- a/bdd/docs/nd_show.md
+++ b/bdd/docs/nd_show.md
@@ -1,0 +1,46 @@
+# show ipv6 nd exposes ND counters, neighbors, and BGP discovery state
+
+## Overview
+
+As a network operator running BGP unnumbered over IPv6 link-locals
+I want `show ipv6 nd` to report per-interface RA scheduler state,
+sent/received ND packet counters, and the per-source neighbor table,
+and `show bgp neighbors` to report when the interface peer's
+link-local was discovered via ND — so the RA exchange that underpins
+peer discovery is observable instead of a black box.
+This exercises the ND show pipeline end-to-end: the engine's counters
+and neighbor table fill from live RA traffic, the show channel routes
+`show ipv6 nd` to the ND task, and the BGP peer carries the ND
+discovery timestamps stamped at materialization.
+
+## Test Topology
+
+```
+        (i1)                                   (i1)
+    ┌────┴────┐                            ┌────┴────┐
+    │   z1    │────────── P2P ─────────────│   z2    │
+    │ AS65001 │       fe80:: <-> fe80::    │ AS65002 │
+    │ id 1.1. │                            │ id 2.2. │
+    │   1.1   │                            │   2.2   │
+    └─────────┘                            └─────────┘
+```
+
+## Notes
+
+Config files mirror the @bgp_unnumbered_neighbor two-step bring-up
+(base then full) so RA-enable cannot lose the race against ND's RIB
+link replay; see z1-base.yaml for the rationale.
+The session reaching Established proves both ends sent AND received
+at least one RA (each side materializes its peer from the other's
+RA), so the counter/neighbor assertions that follow are
+deterministic — no fixed-delay waits are needed beyond the
+session-establishment step itself.
+
+## Test Scenarios
+
+| Scenario | Result |
+|----------|--------|
+| Setup topology | |
+| ND state is visible once the unnumbered session establishes | |
+| BGP neighbor detail reports the ND discovery | |
+| Teardown topology | |

--- a/bdd/tests/configs/nd_show/z1-base.yaml
+++ b/bdd/tests/configs/nd_show/z1-base.yaml
@@ -1,0 +1,13 @@
+# Phase 1 of the two-step bring-up: a bare `router bgp` block with no
+# neighbors. Applying this first spawns the ND subsystem (ND is spawned
+# eagerly on the first `router bgp` line) so it subscribes to the RIB
+# and learns interface i1 BEFORE the next commit enables RA on it. The
+# per-interface `send-advertisements` callback silently drops if ND
+# hasn't yet learned the link, and it is not re-evaluated on a later
+# link-add — so without this warm-up the RA-enable could lose the race
+# against the RIB link replay and never arm the transmitter.
+router:
+  bgp:
+    global:
+      as: 65001
+      router-id: 1.1.1.1

--- a/bdd/tests/configs/nd_show/z1-full.yaml
+++ b/bdd/tests/configs/nd_show/z1-full.yaml
@@ -1,0 +1,25 @@
+# Phase 2: enable Router Advertisements on i1 and declare the
+# interface-keyed (IPv6 unnumbered) neighbor. The peer is materialized
+# only when an RA is received on i1 (the peer's link-local is learned
+# from it), so RA send must be on at BOTH ends. `remote-as` is numeric
+# (not `external`) because the `external` placeholder leaves the peer
+# dormant until OPEN-side AS backfill lands. The IPv4 network is
+# advertised over the link-local session via RFC 8950 ENHE, which is
+# auto-negotiated for interface-keyed peers.
+interface:
+- if-name: i1
+  ipv6:
+    router-advertisements:
+      send-advertisements: true
+router:
+  bgp:
+    global:
+      as: 65001
+      router-id: 1.1.1.1
+    interface-neighbor:
+    - interface: i1
+      remote-as: 65002
+    afi-safi:
+    - name: ipv4
+      network:
+      - prefix: 10.0.0.1/32

--- a/bdd/tests/configs/nd_show/z2-base.yaml
+++ b/bdd/tests/configs/nd_show/z2-base.yaml
@@ -1,0 +1,6 @@
+# Phase 1 for z2 — see z1-base.yaml for the warm-up rationale.
+router:
+  bgp:
+    global:
+      as: 65002
+      router-id: 2.2.2.2

--- a/bdd/tests/configs/nd_show/z2-full.yaml
+++ b/bdd/tests/configs/nd_show/z2-full.yaml
@@ -1,0 +1,18 @@
+# Phase 2 for z2 — mirror of z1-full.yaml with the AS numbers swapped.
+interface:
+- if-name: i1
+  ipv6:
+    router-advertisements:
+      send-advertisements: true
+router:
+  bgp:
+    global:
+      as: 65002
+      router-id: 2.2.2.2
+    interface-neighbor:
+    - interface: i1
+      remote-as: 65001
+    afi-safi:
+    - name: ipv4
+      network:
+      - prefix: 10.0.0.2/32

--- a/bdd/tests/features/nd_show.feature
+++ b/bdd/tests/features/nd_show.feature
@@ -1,0 +1,77 @@
+@serial
+@nd_show
+Feature: show ipv6 nd exposes ND counters, neighbors, and BGP discovery state
+  As a network operator running BGP unnumbered over IPv6 link-locals
+  I want `show ipv6 nd` to report per-interface RA scheduler state,
+  sent/received ND packet counters, and the per-source neighbor table,
+  and `show bgp neighbors` to report when the interface peer's
+  link-local was discovered via ND — so the RA exchange that underpins
+  peer discovery is observable instead of a black box.
+
+  This exercises the ND show pipeline end-to-end: the engine's counters
+  and neighbor table fill from live RA traffic, the show channel routes
+  `show ipv6 nd` to the ND task, and the BGP peer carries the ND
+  discovery timestamps stamped at materialization.
+
+  Test Topology (point-to-point veth, link-local only — no global addrs):
+  ```
+        (i1)                                   (i1)
+    ┌────┴────┐                            ┌────┴────┐
+    │   z1    │────────── P2P ─────────────│   z2    │
+    │ AS65001 │       fe80:: <-> fe80::    │ AS65002 │
+    │ id 1.1. │                            │ id 2.2. │
+    │   1.1   │                            │   2.2   │
+    └─────────┘                            └─────────┘
+  ```
+
+  Config files mirror the @bgp_unnumbered_neighbor two-step bring-up
+  (base then full) so RA-enable cannot lose the race against ND's RIB
+  link replay; see z1-base.yaml for the rationale.
+
+  The session reaching Established proves both ends sent AND received
+  at least one RA (each side materializes its peer from the other's
+  RA), so the counter/neighbor assertions that follow are
+  deterministic — no fixed-delay waits are needed beyond the
+  session-establishment step itself.
+
+  Scenario: Setup topology
+    Given a clean test environment
+    When I create namespace "z1"
+    And I create namespace "z2"
+    And I connect namespace "z1" interface "i1" to namespace "z2" interface "i1"
+    And I start zebra-rs in namespace "z1"
+    And I start zebra-rs in namespace "z2"
+    And I apply config "z1-base.yaml" to namespace "z1"
+    And I apply config "z2-base.yaml" to namespace "z2"
+    And I wait 2 seconds
+
+  Scenario: ND state is visible once the unnumbered session establishes
+    Given the test topology exists
+    When I apply config "z1-full.yaml" to namespace "z1"
+    And I apply config "z2-full.yaml" to namespace "z2"
+    Then BGP session in namespace "z1" should eventually be "Established"
+    And BGP session in namespace "z2" should eventually be "Established"
+    # Summary lists the interface.
+    And show command "show ipv6 nd" in namespace "z1" should contain "i1"
+    # Detail: RA send is armed on i1 ...
+    And show command "show ipv6 nd interface i1" in namespace "z1" should contain "Interface i1 (ifindex"
+    And show command "show ipv6 nd interface i1" in namespace "z1" should contain "Router advertisement: enabled"
+    # ... we transmitted at least one RA (z2 learned us from it) ...
+    And show command "show ipv6 nd interface i1" in namespace "z1" should not contain "last multicast never"
+    # ... and z2's link-local sits in the neighbor table with a
+    # recorded last-RA snapshot (proof of a non-zero received-RA count).
+    And show command "show ipv6 nd interface i1" in namespace "z1" should contain "fe80::"
+    And show command "show ipv6 nd interface i1" in namespace "z1" should contain "last RA: lifetime"
+
+  Scenario: BGP neighbor detail reports the ND discovery
+    Given the test topology exists
+    Then show command "show bgp neighbors i1" in namespace "z1" should contain "Interface peer: link-local learned via IPv6 ND router advertisement"
+    And show command "show bgp neighbors i1" in namespace "z1" should contain "Discovered "
+
+  Scenario: Teardown topology
+    Given the test topology exists
+    When I stop zebra-rs in namespace "z1"
+    And I stop zebra-rs in namespace "z2"
+    And I delete namespace "z1"
+    And I delete namespace "z2"
+    Then the test environment should be clean

--- a/crates/nd-packet/src/lib.rs
+++ b/crates/nd-packet/src/lib.rs
@@ -1,11 +1,15 @@
 //! IPv6 Neighbor Discovery packet codec (RFC 4861).
 //!
-//! Scoped to the two message types BGP unnumbered needs: Router
-//! Advertisement (134) and Router Solicitation (133), plus the
-//! options the codec recognises (Source/Target Link-Layer Address,
-//! Prefix Information, MTU). Neighbor Solicitation / Advertisement
-//! are intentionally omitted — the host kernel handles the NDP
-//! cache, this crate only deals with the RA exchange.
+//! Covers all four RFC 4861 ICMPv6 message types:
+//! Router Solicitation (133), Router Advertisement (134),
+//! Neighbor Solicitation (135), and Neighbor Advertisement (136),
+//! plus the ND options the codec recognises (Source/Target
+//! Link-Layer Address, Prefix Information, MTU).
+//!
+//! NS/NA support exists for passive observation (counters/diagnostics)
+//! — the host kernel still owns the NDP cache and this crate never
+//! originates NS/NA in production; [`NeighborSolicit::emit`] and
+//! [`NeighborAdvert::emit`] exist for symmetry and tests.
 //!
 //! ICMPv6 checksums are computed by [`emit_with_checksum`] given the
 //! IPv6 source / destination addresses; on parse, [`parse`] verifies
@@ -21,7 +25,7 @@ mod typ;
 pub use checksum::compute_icmp6_checksum;
 pub use option::{LinkLayerAddress, NdOption, OptionType, PrefixInfo, PrefixInfoFlags};
 pub use packet::{
-    MAX_INITIAL_RTR_ADVERTISEMENTS, MIN_RA_LEN, MIN_RS_LEN, ParseError, RaFlags, RouterAdvert,
-    RouterSolicit,
+    MAX_INITIAL_RTR_ADVERTISEMENTS, MIN_NA_LEN, MIN_NS_LEN, MIN_RA_LEN, MIN_RS_LEN, NaFlags,
+    NeighborAdvert, NeighborSolicit, ParseError, RaFlags, RouterAdvert, RouterSolicit,
 };
 pub use typ::Icmp6Type;

--- a/crates/nd-packet/src/packet.rs
+++ b/crates/nd-packet/src/packet.rs
@@ -1,5 +1,6 @@
-//! ICMPv6 packet structs: Router Advertisement (134) and Router
-//! Solicitation (133). RFC 4861 §4.1 / §4.2.
+//! ICMPv6 packet structs for all four RFC 4861 message types:
+//! Router Solicitation (133), Router Advertisement (134),
+//! Neighbor Solicitation (135), and Neighbor Advertisement (136).
 
 use std::net::Ipv6Addr;
 
@@ -161,6 +162,28 @@ impl RouterAdvert {
     }
 }
 
+/// Minimum size of a Neighbor Solicitation (RFC 4861 §4.3). ICMPv6
+/// header (4) + reserved (4) + target address (16).
+pub const MIN_NS_LEN: usize = 24;
+
+/// Minimum size of a Neighbor Advertisement (RFC 4861 §4.4). ICMPv6
+/// header (4) + flags/reserved (4) + target address (16).
+pub const MIN_NA_LEN: usize = 24;
+
+bitflags::bitflags! {
+    /// Flags from the Neighbor Advertisement header (RFC 4861 §4.4).
+    /// These occupy the first byte of the 4-byte flags/reserved word.
+    #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Default)]
+    pub struct NaFlags: u8 {
+        /// Router flag — sender is a router.
+        const R = 0b1000_0000;
+        /// Solicited flag — sent in response to a Neighbor Solicitation.
+        const S = 0b0100_0000;
+        /// Override flag — should override an existing cache entry.
+        const O = 0b0010_0000;
+    }
+}
+
 /// Router Solicitation (RFC 4861 §4.1).
 #[derive(Debug, Clone, PartialEq, Eq, Default)]
 pub struct RouterSolicit {
@@ -218,6 +241,171 @@ impl RouterSolicit {
         buf.put_u8(0); // code
         buf.put_u16(0); // checksum placeholder
         buf.put_u32(0); // reserved
+        for opt in &self.options {
+            opt.emit(buf);
+        }
+    }
+}
+
+/// Neighbor Solicitation (RFC 4861 §4.3).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct NeighborSolicit {
+    pub target: Ipv6Addr,
+    pub options: Vec<NdOption>,
+}
+
+impl NeighborSolicit {
+    /// Parse a Neighbor Solicitation from `payload`. If `verify_against`
+    /// is `Some((src, dst))`, the ICMPv6 checksum is verified using
+    /// those addresses; pass `None` if the socket already validated
+    /// (e.g. via `IPV6_CHECKSUM`).
+    pub fn parse(
+        payload: &[u8],
+        verify_against: Option<(Ipv6Addr, Ipv6Addr)>,
+    ) -> Result<Self, ParseError> {
+        if payload.len() < MIN_NS_LEN {
+            return Err(ParseError::TooShort);
+        }
+        let typ = payload[0];
+        if typ != Icmp6Type::NeighborSolicit.into() {
+            return Err(ParseError::UnsupportedType(typ));
+        }
+        let code = payload[1];
+        if code != 0 {
+            return Err(ParseError::NonZeroCode(code));
+        }
+        if let Some((src, dst)) = verify_against {
+            let mut zeroed = payload.to_vec();
+            zeroed[2] = 0;
+            zeroed[3] = 0;
+            let computed = compute_icmp6_checksum(src, dst, &zeroed);
+            let on_wire = u16::from_be_bytes([payload[2], payload[3]]);
+            if computed != on_wire {
+                return Err(ParseError::ChecksumMismatch);
+            }
+        }
+        // payload[4..8] is reserved per RFC 4861 §4.3.
+        let mut target_bytes = [0u8; 16];
+        target_bytes.copy_from_slice(&payload[8..24]);
+        let target = Ipv6Addr::from(target_bytes);
+
+        let mut options = Vec::new();
+        let mut rest = &payload[MIN_NS_LEN..];
+        while !rest.is_empty() {
+            let (opt, next) = NdOption::parse(rest)?;
+            options.push(opt);
+            rest = next;
+        }
+        Ok(Self { target, options })
+    }
+
+    /// Emit the NS into `buf` with the ICMPv6 checksum filled in for
+    /// the given source / destination addresses.
+    pub fn emit(&self, buf: &mut BytesMut, src: Ipv6Addr, dst: Ipv6Addr) {
+        let start = buf.len();
+        self.emit_without_checksum(buf);
+        let end = buf.len();
+        let cksum = compute_icmp6_checksum(src, dst, &buf[start..end]);
+        buf[start + 2] = (cksum >> 8) as u8;
+        buf[start + 3] = (cksum & 0xff) as u8;
+    }
+
+    /// Emit the NS into `buf` with the checksum field left as zero.
+    /// Useful when the kernel computes the checksum (`IPV6_CHECKSUM`
+    /// on `IPPROTO_ICMPV6` sockets).
+    pub fn emit_without_checksum(&self, buf: &mut BytesMut) {
+        buf.put_u8(Icmp6Type::NeighborSolicit.into());
+        buf.put_u8(0); // code
+        buf.put_u16(0); // checksum placeholder
+        buf.put_u32(0); // reserved
+        buf.put_slice(&self.target.octets());
+        for opt in &self.options {
+            opt.emit(buf);
+        }
+    }
+}
+
+/// Neighbor Advertisement (RFC 4861 §4.4).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct NeighborAdvert {
+    pub flags: NaFlags,
+    pub target: Ipv6Addr,
+    pub options: Vec<NdOption>,
+}
+
+impl NeighborAdvert {
+    /// Parse a Neighbor Advertisement from `payload`. If `verify_against`
+    /// is `Some((src, dst))`, the ICMPv6 checksum is verified using
+    /// those addresses; pass `None` if the socket already validated
+    /// (e.g. via `IPV6_CHECKSUM`).
+    pub fn parse(
+        payload: &[u8],
+        verify_against: Option<(Ipv6Addr, Ipv6Addr)>,
+    ) -> Result<Self, ParseError> {
+        if payload.len() < MIN_NA_LEN {
+            return Err(ParseError::TooShort);
+        }
+        let typ = payload[0];
+        if typ != Icmp6Type::NeighborAdvert.into() {
+            return Err(ParseError::UnsupportedType(typ));
+        }
+        let code = payload[1];
+        if code != 0 {
+            return Err(ParseError::NonZeroCode(code));
+        }
+        if let Some((src, dst)) = verify_against {
+            let mut zeroed = payload.to_vec();
+            zeroed[2] = 0;
+            zeroed[3] = 0;
+            let computed = compute_icmp6_checksum(src, dst, &zeroed);
+            let on_wire = u16::from_be_bytes([payload[2], payload[3]]);
+            if computed != on_wire {
+                return Err(ParseError::ChecksumMismatch);
+            }
+        }
+        // payload[4] = flags byte; payload[5..8] = reserved per RFC 4861 §4.4.
+        let flags = NaFlags::from_bits_truncate(payload[4]);
+        let mut target_bytes = [0u8; 16];
+        target_bytes.copy_from_slice(&payload[8..24]);
+        let target = Ipv6Addr::from(target_bytes);
+
+        let mut options = Vec::new();
+        let mut rest = &payload[MIN_NA_LEN..];
+        while !rest.is_empty() {
+            let (opt, next) = NdOption::parse(rest)?;
+            options.push(opt);
+            rest = next;
+        }
+        Ok(Self {
+            flags,
+            target,
+            options,
+        })
+    }
+
+    /// Emit the NA into `buf` with the ICMPv6 checksum filled in for
+    /// the given source / destination addresses.
+    pub fn emit(&self, buf: &mut BytesMut, src: Ipv6Addr, dst: Ipv6Addr) {
+        let start = buf.len();
+        self.emit_without_checksum(buf);
+        let end = buf.len();
+        let cksum = compute_icmp6_checksum(src, dst, &buf[start..end]);
+        buf[start + 2] = (cksum >> 8) as u8;
+        buf[start + 3] = (cksum & 0xff) as u8;
+    }
+
+    /// Emit the NA into `buf` with the checksum field left as zero.
+    /// Useful when the kernel computes the checksum (`IPV6_CHECKSUM`
+    /// on `IPPROTO_ICMPV6` sockets).
+    pub fn emit_without_checksum(&self, buf: &mut BytesMut) {
+        buf.put_u8(Icmp6Type::NeighborAdvert.into());
+        buf.put_u8(0); // code
+        buf.put_u16(0); // checksum placeholder
+        buf.put_u8(self.flags.bits());
+        buf.put_u8(0); // reserved[0]
+        buf.put_u8(0); // reserved[1]
+        buf.put_u8(0); // reserved[2]
+        buf.put_slice(&self.target.octets());
         for opt in &self.options {
             opt.emit(buf);
         }
@@ -348,5 +536,181 @@ mod tests {
     fn ra_too_short_is_rejected() {
         let wire = hex!("86 00 00 00");
         assert_eq!(RouterAdvert::parse(&wire, None), Err(ParseError::TooShort));
+    }
+
+    // ── Neighbor Solicitation tests ──────────────────────────────────────
+
+    #[test]
+    fn ns_minimal_round_trip() {
+        // NS to solicited-node multicast for fe80::2 (ff02::1:ff00:2).
+        let target: Ipv6Addr = "fe80::2".parse().unwrap();
+        let src = ll("fe80::1");
+        let dst: Ipv6Addr = "ff02::1:ff00:2".parse().unwrap();
+        let ns = NeighborSolicit {
+            target,
+            options: vec![],
+        };
+        let mut buf = BytesMut::new();
+        ns.emit(&mut buf, src, dst);
+        assert_eq!(buf.len(), MIN_NS_LEN);
+
+        let parsed = NeighborSolicit::parse(&buf, Some((src, dst))).unwrap();
+        assert_eq!(parsed, ns);
+    }
+
+    #[test]
+    fn ns_with_source_lla() {
+        let target: Ipv6Addr = "fe80::2".parse().unwrap();
+        let src = ll("fe80::1");
+        let dst: Ipv6Addr = "ff02::1:ff00:2".parse().unwrap();
+        let ns = NeighborSolicit {
+            target,
+            options: vec![NdOption::SourceLinkLayerAddress(
+                LinkLayerAddress::ethernet([0x52, 0x54, 0x00, 0xab, 0xcd, 0xef]),
+            )],
+        };
+        let mut buf = BytesMut::new();
+        ns.emit(&mut buf, src, dst);
+        let parsed = NeighborSolicit::parse(&buf, Some((src, dst))).unwrap();
+        assert_eq!(parsed, ns);
+    }
+
+    #[test]
+    fn ns_dad_unspecified_source() {
+        // DAD: source is ::, destination is the solicited-node multicast
+        // address of the tentative address. The codec is address-agnostic
+        // and should round-trip cleanly.
+        let target: Ipv6Addr = "fe80::2".parse().unwrap();
+        let src: Ipv6Addr = "::".parse().unwrap();
+        let dst: Ipv6Addr = "ff02::1:ff00:2".parse().unwrap();
+        let ns = NeighborSolicit {
+            target,
+            options: vec![],
+        };
+        let mut buf = BytesMut::new();
+        ns.emit(&mut buf, src, dst);
+        let parsed = NeighborSolicit::parse(&buf, Some((src, dst))).unwrap();
+        assert_eq!(parsed, ns);
+    }
+
+    #[test]
+    fn ns_rejects_non_zero_code() {
+        let target: Ipv6Addr = "fe80::2".parse().unwrap();
+        let ns = NeighborSolicit {
+            target,
+            options: vec![],
+        };
+        let mut buf = BytesMut::new();
+        ns.emit_without_checksum(&mut buf);
+        buf[1] = 1; // bad code
+        let res = NeighborSolicit::parse(&buf, None);
+        assert_eq!(res, Err(ParseError::NonZeroCode(1)));
+    }
+
+    #[test]
+    fn ns_too_short_is_rejected() {
+        // 0x87 = 135 (NS type), but only 8 bytes — shorter than MIN_NS_LEN (24).
+        let wire = hex!("87 00 00 00 00 00 00 00");
+        assert_eq!(
+            NeighborSolicit::parse(&wire, None),
+            Err(ParseError::TooShort)
+        );
+    }
+
+    // ── Neighbor Advertisement tests ─────────────────────────────────────
+
+    #[test]
+    fn na_round_trip_with_flags_and_tlla() {
+        // Solicited reply: S + O flags, target fe80::2, TLLA option.
+        let target: Ipv6Addr = "fe80::2".parse().unwrap();
+        let src = ll("fe80::2");
+        let dst = ll("fe80::1");
+        let na = NeighborAdvert {
+            flags: NaFlags::S | NaFlags::O,
+            target,
+            options: vec![NdOption::TargetLinkLayerAddress(
+                LinkLayerAddress::ethernet([0x52, 0x54, 0x00, 0xab, 0xcd, 0xef]),
+            )],
+        };
+        let mut buf = BytesMut::new();
+        na.emit(&mut buf, src, dst);
+        let parsed = NeighborAdvert::parse(&buf, Some((src, dst))).unwrap();
+        assert_eq!(parsed, na);
+    }
+
+    #[test]
+    fn na_flags_wire_position() {
+        // Emit NA with only R flag and no checksum; assert that byte[4]
+        // is 0x80 (R bit) and bytes[5..8] are all zero — pins the flag
+        // byte position per RFC 4861 §4.4.
+        let target: Ipv6Addr = "fe80::2".parse().unwrap();
+        let na = NeighborAdvert {
+            flags: NaFlags::R,
+            target,
+            options: vec![],
+        };
+        let mut buf = BytesMut::new();
+        na.emit_without_checksum(&mut buf);
+        assert_eq!(buf[4], 0x80);
+        assert_eq!(buf[5], 0x00);
+        assert_eq!(buf[6], 0x00);
+        assert_eq!(buf[7], 0x00);
+    }
+
+    #[test]
+    fn na_checksum_mismatch_is_caught() {
+        let target: Ipv6Addr = "fe80::2".parse().unwrap();
+        let src = ll("fe80::2");
+        let dst = ll("fe80::1");
+        let na = NeighborAdvert {
+            flags: NaFlags::S | NaFlags::O,
+            target,
+            options: vec![],
+        };
+        let mut buf = BytesMut::new();
+        na.emit(&mut buf, src, dst);
+        // Verify against wrong destination — checksum should fail.
+        let res = NeighborAdvert::parse(&buf, Some((src, ll("fe80::2"))));
+        assert_eq!(res, Err(ParseError::ChecksumMismatch));
+    }
+
+    #[test]
+    fn na_rejects_wrong_type() {
+        // Feed an NS wire image (type 0x87 = 135) to NeighborAdvert::parse.
+        // The message is MIN_NA_LEN bytes long so it passes the length check.
+        let target: Ipv6Addr = "fe80::2".parse().unwrap();
+        let ns = NeighborSolicit {
+            target,
+            options: vec![],
+        };
+        let mut buf = BytesMut::new();
+        ns.emit_without_checksum(&mut buf);
+        let res = NeighborAdvert::parse(&buf, None);
+        assert_eq!(res, Err(ParseError::UnsupportedType(135)));
+    }
+
+    #[test]
+    fn na_parse_known_wire() {
+        // Hand-crafted NA wire image:
+        //   type=0x88 (136), code=0x00, checksum=0x0000 (skipped),
+        //   flags=0x60 (S|O), reserved=0x00 0x00 0x00,
+        //   target=fe80::2 (fe80:0000:...:0002),
+        //   TLLA option: type=02 len=01 mac=52:54:00:ab:cd:ef
+        let wire = hex!(
+            "88 00 00 00 "          // type, code, checksum
+            "60 00 00 00 "          // flags=S|O, reserved
+            "fe 80 00 00 00 00 00 00 00 00 00 00 00 00 00 02 " // target fe80::2
+            "02 01 52 54 00 ab cd ef" // TLLA option
+        );
+        let na = NeighborAdvert::parse(&wire, None).unwrap();
+        assert_eq!(na.flags, NaFlags::S | NaFlags::O);
+        assert_eq!(na.target, "fe80::2".parse::<Ipv6Addr>().unwrap());
+        assert_eq!(na.options.len(), 1);
+        assert_eq!(
+            na.options[0],
+            NdOption::TargetLinkLayerAddress(LinkLayerAddress::ethernet([
+                0x52, 0x54, 0x00, 0xab, 0xcd, 0xef
+            ]))
+        );
     }
 }

--- a/crates/nd-packet/src/typ.rs
+++ b/crates/nd-packet/src/typ.rs
@@ -4,6 +4,8 @@
 pub enum Icmp6Type {
     RouterSolicit = 133,
     RouterAdvert = 134,
+    NeighborSolicit = 135,
+    NeighborAdvert = 136,
 }
 
 impl Icmp6Type {
@@ -11,6 +13,8 @@ impl Icmp6Type {
         match v {
             133 => Some(Self::RouterSolicit),
             134 => Some(Self::RouterAdvert),
+            135 => Some(Self::NeighborSolicit),
+            136 => Some(Self::NeighborAdvert),
             _ => None,
         }
     }

--- a/docs/design/nd-show-commands-plan.md
+++ b/docs/design/nd-show-commands-plan.md
@@ -1,0 +1,304 @@
+# IPv6 ND Show Commands — Blueprint and Plan
+
+Goal: expose the internal state of the IPv6 Neighbor Discovery subsystem —
+especially Neighbor Advertisement (NA) and Neighbor Solicitation (NS)
+packet counts, sent and received, broken down by interface and by source
+link-local address — and tie that visibility into the BGP
+`interface-neighbor` (unnumbered) story.
+
+## 1. Current state
+
+What exists today (branch `nd-show-commands`, 2026-06-10):
+
+| Aspect | Status | Anchor |
+|---|---|---|
+| ND module | RS (133) / RA (134) only | `zebra-rs/src/nd/` |
+| NS (135) / NA (136) | blocked at the kernel ICMP6 filter, no codec | `nd/socket.rs:90`, `crates/nd-packet/src/typ.rs` |
+| Counters | none anywhere in the ND module | — |
+| Learned neighbors | not stored; `NdEvent::NeighborDiscovered` is fire-and-forget to BGP | `nd/engine.rs:122-137` |
+| Show infrastructure | none (no ShowChannel, no `show nd` grammar, `show_proto` falls back to `"rib"`) | `config/manager.rs:1112` |
+| BGP interface peer | stores `ifname`, learned link-local in `address`, `scope_id` | `bgp/interface_neighbor.rs:88` (`materialize_peer`) |
+| `show bgp neighbors` for interface peers | prints `BGP neighbor on <ifname>: <link-local>` only — nothing about ND | `bgp/show.rs:2036-2041` |
+
+Key physical constraints that shape the design:
+
+1. **The daemon never sends NS/NA.** The host kernel owns the NDP cache
+   (deliberate — see the `nd-packet` crate comment). A raw ICMPv6 socket
+   only delivers *received* packets, so "NS/NA sent" can never be counted
+   from the socket. The kernel's per-interface counters at
+   `/proc/net/dev_snmp6/<ifname>` (`Icmp6InNeighborSolicits`,
+   `Icmp6OutNeighborAdvertisements`, and the six siblings covering
+   RS/RA/NS/NA × in/out) are the authoritative source for kernel-side
+   totals — but they have no per-source breakdown.
+2. **The daemon CAN passively observe received NS/NA.** Widening the
+   ICMP6 filter to pass 135/136 delivers *copies* to the raw socket; the
+   kernel still processes NDP itself. This is how we get the per-source
+   link-local breakdown the operator asked for.
+3. **Multicast loopback is OFF** (`nd/socket.rs:83`), so our own RA
+   transmissions are not seen on the receive path. TX counting must
+   happen at the emission point in `NdEngine::tick`, not on the socket.
+4. The hop-limit-255 check at `network.rs:75` applies equally to NS/NA
+   (RFC 4861 requires 255 for all four message types) — no change needed.
+
+So the design exposes **two complementary counter sets**:
+
+* **Daemon-observed** (per interface AND per source address): rx RS/RA/NS/NA,
+  tx RA (split unsolicited/solicited), plus drop counters.
+* **Kernel totals** (per interface only, read from `dev_snmp6` at show
+  time, no state kept): sent+received for all four types — this is the
+  only place "NS/NA sent" can come from.
+
+## 2. Blueprint
+
+### 2.1 nd-packet codec: NS/NA types
+
+`crates/nd-packet`:
+
+* `Icmp6Type`: add `NeighborSolicit = 135`, `NeighborAdvert = 136`.
+* New structs mirroring `RouterSolicit`/`RouterAdvert`:
+  * `NeighborSolicit { target: Ipv6Addr, options: Vec<NdOption> }`
+  * `NeighborAdvert { flags: NaFlags /* R|S|O */, target: Ipv6Addr, options: Vec<NdOption> }`
+* `parse()` + `emit_without_checksum()` + round-trip unit tests (emit is
+  only used by tests today; the engine never originates NS/NA).
+* Reuse the existing `NdOption` parser (SLLA/TLLA options appear in both).
+
+### 2.2 Engine state: counters + neighbor table (pure, unit-testable)
+
+All state lives in `NdEngine` (pure logic, no I/O) so it is testable the
+same way the existing engine tests are.
+
+```rust
+// nd/engine.rs
+#[derive(Default)]
+pub struct NdIfCounters {
+    pub tx_ra_unsolicited: u64,
+    pub tx_ra_solicited: u64,
+    pub rx_ra: u64,
+    pub rx_rs: u64,
+    pub rx_ns: u64,
+    pub rx_na: u64,
+    pub rx_drop_hop_limit: u64,
+    pub rx_drop_malformed: u64,
+    pub untracked_sources: u64,   // neighbor-table cap overflow
+}
+
+pub struct NdNeighbor {
+    pub first_seen: Instant,
+    pub last_seen: Instant,
+    pub rx_ra: u64,
+    pub rx_rs: u64,
+    pub rx_ns: u64,
+    pub rx_na: u64,
+    pub last_ra: Option<LastRa>,  // lifetime, cur_hop_limit, M/O flags
+}
+
+// added to NdEngine:
+counters:  BTreeMap<u32, NdIfCounters>,                 // keyed by ifindex
+neighbors: BTreeMap<u32, BTreeMap<Ipv6Addr, NdNeighbor>>,
+```
+
+Notes:
+
+* `counters`/`neighbors` are independent of `senders` — NS/NA arrive on
+  interfaces that have no RA sender configured, and we still want to
+  count and attribute them.
+* The neighbor table is capped per interface (proposal: 256 sources;
+  beyond that increment `untracked_sources` instead of inserting) so a
+  large or hostile segment can't grow memory unboundedly.
+* DAD probes arrive with source `::` — they get a table entry like any
+  other source and render with a `(duplicate address detection)` note.
+* TX counting happens inside `NdEngine::tick` where `RaEvent::SendUnsolicited`
+  vs `SendSolicited` is still distinguishable.
+
+**Keeping drop counters pure:** hop-limit and parse drops currently
+happen silently inside the read task (`network.rs:75-96`), outside the
+engine. Rather than sprinkling atomics into the I/O task, extend the
+channel message so the engine counts everything:
+
+```rust
+// nd/mod.rs
+pub enum NdRecv {
+    RouterAdvert  { ifindex: u32, src: Ipv6Addr, ra: RouterAdvert },
+    RouterSolicit { ifindex: u32, src: Ipv6Addr, rs: RouterSolicit },
+    NeighborSolicit { ifindex: u32, src: Ipv6Addr, ns: NeighborSolicit },
+    NeighborAdvert  { ifindex: u32, src: Ipv6Addr, na: NeighborAdvert },
+    Dropped { ifindex: u32, reason: DropReason },   // HopLimit | Malformed
+}
+```
+
+`read_packet` gains arms for types 135/136 and sends `Dropped` where it
+silently `return Ok(())` today; `NdEngine::on_recv` becomes the single
+place where every counter increments. Existing behavior (RA → notify
+BGP, RS → schedule reply) is unchanged; NS/NA are count-and-record only.
+
+`socket.rs:90` becomes `Icmp6Filter::pass_only(&[133, 134, 135, 136])`.
+
+`RaSender` gains read accessors for show: `cfg()`, `initial_remaining()`,
+`next_unsolicited_at()`, `pending_solicited_at()`, `last_multicast_at()`.
+
+### 2.3 Show command: `show ipv6 nd [interface [IFNAME]]`
+
+Grammar (`zebra-rs/yang/exec.yang`, inside the existing `container ipv6`
+at line ~697):
+
+```yang
+container nd {
+  ext:help "IPv6 neighbor discovery";
+  presence "Show IPv6 ND status";
+  list interface {
+    ext:help "ND status per interface";
+    ext:presence "Show all interfaces";
+    key if-name;
+    leaf if-name {
+      ext:dynamic "rib:interface";
+      type string;
+    }
+  }
+}
+```
+
+* `show ipv6 nd` → `/show/ipv6/nd`, summary: one line per interface
+  (RA enabled?, neighbor count, rx/tx totals).
+* `show ipv6 nd interface` → `/show/ipv6/nd/interface`, args `[]`: full
+  detail for all interfaces.
+* `show ipv6 nd interface eth0` → same path, args `["eth0"]`.
+
+Plumbing (mirror the BFD pattern exactly — it is the nearest
+conditionally-spawned protocol):
+
+1. `config/manager.rs`: add `is_nd()` (any path segment `"nd"`) to
+   `show_proto()` and to the fallback protocol-name chain, so an
+   un-spawned ND answers `"ND is not configured or running"` via the
+   existing Layer-1 fallback. (In practice ND spawns eagerly with
+   `router bgp` — manager.rs:547 — so BGP-unnumbered users always have
+   it running.)
+2. `nd/inst.rs`: add `show: ShowChannel`, `show_cb: HashMap<String, ShowCallback>`,
+   `show_build()`, `process_show_msg()`, and the
+   `Some(msg) = self.show.rx.recv()` select arm.
+3. `config/nd.rs` (`spawn_nd`): `config.subscribe_show("nd", nd.show.tx.clone())`.
+4. New `nd/show.rs`: renderers, text + JSON (`json: bool` flag per the
+   house convention — serde structs for JSON, `write!` for text).
+5. Kernel counters: a small helper reads
+   `/proc/net/dev_snmp6/<ifname>` at show time and extracts the eight
+   `Icmp6{In,Out}{Router,Neighbor}{Solicits,Advertisements}` lines.
+   Stateless, namespace-correct, and tolerant of the file being absent
+   (interface gone): render `-`.
+
+Text output sketch:
+
+```
+Interface enp0s5 (ifindex 2)
+  Router advertisement: enabled
+    interval 200-600s, lifetime 1800s, hop-limit 64, managed=0 other=0
+    initial advertisements remaining 0, next unsolicited in 134s
+    solicited reply pending: no, last multicast 27s ago
+  Counters (daemon-observed)        Sent  Received
+    Router solicitations               -         2
+    Router advertisements             14        13
+    Neighbor solicitations             -         5
+    Neighbor advertisements            -         5
+    dropped: hop-limit 0, malformed 0, untracked sources 0
+  Counters (kernel)                 Sent  Received
+    Router solicitations               0         2
+    Router advertisements             14        13
+    Neighbor solicitations             9         5
+    Neighbor advertisements            5         9
+  Neighbors (4):
+    fe80::a8aa:aaff:feaa:1   RA 13  RS 0  NS 3  NA 5   first 05:31 ago, last 27s ago
+      last RA: lifetime 1800s hop-limit 64 M=0 O=0
+    ::                       NS 2 (duplicate address detection)
+```
+
+Grammar pinning: parse() tests in `config/parse.rs` (using
+`exec_entry()`) for the three spellings above; `yang_load_tests` guards
+the schema edit automatically.
+
+### 2.4 BGP integration: ND visibility on interface peers
+
+`bgp/peer.rs` — new fields on `Peer`:
+
+```rust
+pub nd_discovered_at: Option<Instant>,   // first NeighborDiscovered
+pub nd_refreshed_at: Option<Instant>,    // most recent one
+pub nd_event_count: u64,
+```
+
+Set/updated in `materialize_peer()` (`bgp/interface_neighbor.rs:88`) for
+both the create and the refresh path.
+
+`bgp/show.rs` — for interface-keyed peers, `show bgp neighbors` (and the
+single-neighbor form) gains a block right under the identity line, text
+and JSON:
+
+```
+BGP neighbor on enp0s5: fe80::a8aa:aaff:feaa:1, remote AS 65001, ...
+  Interface peer: link-local learned via IPv6 ND router advertisement
+  Discovered 05:31 ago, refreshed 13 times (last 27s ago)
+```
+
+Registered through the existing show `Builder` chain — no new paths, only
+renderer changes.
+
+### 2.5 BDD
+
+New `bdd/features/nd_show.feature` (tag must not be a prefix of any
+existing tag — verify with a grep before naming; `@nd_show` proposed):
+
+* Two namespaces, veth pair, `ipv6 router-advertisements` +
+  `interface-neighbor` both sides (reuse the `@bgp_unnumbered_neighbor`
+  topology; keep its two-phase apply to dodge the link-learn race).
+* Assert `show ipv6 nd interface <if>` contains the peer's link-local
+  and a non-zero received-RA count (allow the documented up-to-16 s
+  initial-RA delay before asserting).
+* Assert `show bgp neighbors` contains the `Discovered ... ago` line.
+* End with the mandatory `Scenario: Teardown topology`.
+
+Known step traps (from prior sessions): the `show command "<cmd>"` step
+needs the literal `show` inside the quotes; stack given/when/then on
+utility steps; rebuild + reinstall `/usr/bin/zebra-rs` and verify the
+binary is yours immediately before the run.
+
+## 3. Step-by-step plan (PR slices)
+
+Each PR: `cargo fmt`, workspace-wide clippy, full test suite before push.
+
+1. **PR 1 — nd-packet: NS/NA codec.** `Icmp6Type` 135/136,
+   `NeighborSolicit`/`NeighborAdvert` structs, parse/emit, round-trip
+   tests. Pure codec, zero behavior change. (small)
+2. **PR 2 — ND core: observe + count + remember.** Widen the ICMP6
+   filter; `NdRecv` gains `NeighborSolicit`/`NeighborAdvert`/`Dropped`
+   variants; `NdIfCounters` + `NdNeighbor` table (capped) in `NdEngine`;
+   TX counting in `tick`; `RaSender` accessors. Engine unit tests for
+   every counter and the cap/DAD edge cases. (medium)
+3. **PR 3 — `show ipv6 nd`.** exec.yang grammar, `is_nd` routing,
+   ShowChannel on `Nd`, `nd/show.rs` text+JSON renderers, `dev_snmp6`
+   reader, parse() grammar tests. (medium)
+4. **PR 4 — BGP neighbor ND block.** `Peer` discovery-tracking fields,
+   `materialize_peer` updates, `show bgp neighbors` text+JSON rendering
+   for interface peers. (small)
+5. **PR 5 — BDD.** `@nd_show` feature as in §2.5, with teardown. (small)
+
+PR 1 and the grammar half of PR 3 are independent of PR 2; the rest is
+sequential. PR 1 in particular is a self-contained warm-up.
+
+## 4. Deferred (explicitly out of scope)
+
+* `clear ipv6 nd counters`.
+* Actively transmitting RS when an `interface-neighbor` is configured
+  (would speed up peer discovery; the RS send path is already plumbed
+  but unused in the engine).
+* Unicast solicited RA replies (engine comment at `engine.rs:173`).
+* Neighbor expiry / `NeighborLost` event on RA lifetime timeout → BGP
+  peer teardown (today a vanished peer only dies via hold-time).
+* Socket-level send-failure counters in the write task.
+* Exposing the kernel NDP cache itself (`ip -6 neigh` equivalent) —
+  different data source (netlink dump), separate command if wanted.
+
+## 5. Decision points (recommendations baked into the plan)
+
+1. **Command spelling** — `show ipv6 nd …` (recommended; short, matches
+   the module name) vs `show ipv6 neighbor-discovery …`.
+2. **Kernel counters in the output** — recommended yes; it is the only
+   source for "NS/NA sent" and costs no state. Could be dropped to a
+   later PR if the dual table feels noisy.
+3. **Neighbor-table cap** — 256 sources/interface proposed.

--- a/zebra-rs/src/bgp/interface_neighbor.rs
+++ b/zebra-rs/src/bgp/interface_neighbor.rs
@@ -6,6 +6,7 @@
 
 use std::collections::BTreeMap;
 use std::net::Ipv6Addr;
+use std::time::Instant;
 
 use super::Bgp;
 use super::peer::Peer;
@@ -125,6 +126,7 @@ fn materialize(
     if let Some(existing) = bgp.peers.get_mut_by_key(&PeerKey::Interface(ifindex)) {
         if let Some(link_local) = link_local {
             existing.address = link_local.into();
+            nd_mark_refreshed(existing, Instant::now());
             // No-op on a running peer (`start()` gates on `!active`);
             // a dormant one leaves Idle now that it can dial.
             existing.start();
@@ -157,6 +159,11 @@ fn materialize(
     // path in `peer_start_connection` reads this back out and
     // builds the SocketAddrV6 accordingly.
     peer.scope_id = Some(ifindex);
+    // Record the ND discovery timestamp only when an RA-learned
+    // link-local is being set (not for dormant pre-RA peers).
+    if link_local.is_some() {
+        nd_mark_discovered(&mut peer, Instant::now());
+    }
     // Stamp the group back-reference whenever the cfg carries one —
     // it drives every inheritable attribute (afi-safi today), not just
     // remote-as, so the reactive sweeps on group changes can find this
@@ -191,6 +198,34 @@ fn materialize(
     // (no RA yet — the RA path upgrades them in place).
     peer.start();
     Some(peer.ident)
+}
+
+/// Stamp the initial ND discovery fields on a freshly created
+/// interface-keyed peer. Called exactly once — on the create path
+/// when a link-local is available (`link_local.is_some()`).
+///
+/// Extracted so unit tests can exercise the field-update semantics
+/// on a plain `Peer` without constructing a full `Bgp`.
+fn nd_mark_discovered(peer: &mut super::peer::Peer, now: Instant) {
+    peer.nd_discovered_at = Some(now);
+    peer.nd_refreshed_at = Some(now);
+    peer.nd_event_count = 1;
+}
+
+/// Update the ND refresh timestamp on an already-materialized
+/// interface-keyed peer when a subsequent RA arrives with a
+/// (possibly new) link-local.
+///
+/// `nd_discovered_at` is intentionally left unchanged — it records
+/// the first event only.
+fn nd_mark_refreshed(peer: &mut super::peer::Peer, now: Instant) {
+    // If the peer was created dormant (no RA yet), treat this first
+    // RA as the discovery event so both timestamps are set.
+    if peer.nd_discovered_at.is_none() {
+        peer.nd_discovered_at = Some(now);
+    }
+    peer.nd_refreshed_at = Some(now);
+    peer.nd_event_count = peer.nd_event_count.saturating_add(1);
 }
 
 /// `set router bgp interface-neighbor <name>` — list-key callback.
@@ -321,5 +356,77 @@ mod tests {
     #[test]
     fn materialize_unset_returns_none() {
         assert_eq!(RemoteAsSpec::Unset.materialize(64512), None);
+    }
+
+    /// Build a minimal Peer suitable for testing nd_mark_* helpers.
+    /// Uses a parked channel and a no-RIB context — no sockets are
+    /// opened and no timers fire during these synchronous tests.
+    fn make_peer() -> super::super::peer::Peer {
+        let (tx, rx) = tokio::sync::mpsc::channel(1);
+        Box::leak(Box::new(rx));
+        super::super::peer::Peer::new(
+            0,
+            65001,
+            "1.1.1.1".parse().unwrap(),
+            65002,
+            "fe80::1".parse::<std::net::IpAddr>().unwrap(),
+            None,
+            tx,
+            crate::context::ProtoContext::default_table_no_rib(),
+        )
+    }
+
+    /// After `nd_mark_discovered`: count == 1, both timestamps set
+    /// and equal.
+    #[test]
+    fn nd_mark_discovered_sets_all_three_fields() {
+        let mut peer = make_peer();
+        assert!(peer.nd_discovered_at.is_none());
+        assert_eq!(peer.nd_event_count, 0);
+
+        let t0 = Instant::now();
+        nd_mark_discovered(&mut peer, t0);
+
+        assert_eq!(peer.nd_event_count, 1);
+        assert_eq!(peer.nd_discovered_at, Some(t0));
+        assert_eq!(peer.nd_refreshed_at, Some(t0));
+    }
+
+    /// After a subsequent `nd_mark_refreshed`: count increments,
+    /// `nd_refreshed_at` advances, `nd_discovered_at` stays.
+    #[test]
+    fn nd_mark_refreshed_increments_count_and_updates_refresh_only() {
+        let mut peer = make_peer();
+        let t0 = Instant::now();
+        nd_mark_discovered(&mut peer, t0);
+
+        // Simulate a later RA arriving.
+        let t1 = t0 + std::time::Duration::from_secs(60);
+        nd_mark_refreshed(&mut peer, t1);
+
+        assert_eq!(peer.nd_event_count, 2);
+        // Discovery timestamp must not change.
+        assert_eq!(peer.nd_discovered_at, Some(t0));
+        // Refresh timestamp must advance.
+        assert_eq!(peer.nd_refreshed_at, Some(t1));
+    }
+
+    /// A dormant peer (created at config time, no RA yet) has all
+    /// three fields at their zero values. When its first RA arrives
+    /// via `nd_mark_refreshed`, both timestamps are set (treating
+    /// the first refresh as discovery).
+    #[test]
+    fn nd_mark_refreshed_on_dormant_peer_sets_discovered_at() {
+        let mut peer = make_peer();
+        // Dormant: no RA yet.
+        assert!(peer.nd_discovered_at.is_none());
+        assert_eq!(peer.nd_event_count, 0);
+
+        let t0 = Instant::now();
+        nd_mark_refreshed(&mut peer, t0);
+
+        assert_eq!(peer.nd_event_count, 1);
+        assert_eq!(peer.nd_discovered_at, Some(t0));
+        assert_eq!(peer.nd_refreshed_at, Some(t0));
     }
 }

--- a/zebra-rs/src/bgp/peer.rs
+++ b/zebra-rs/src/bgp/peer.rs
@@ -823,6 +823,22 @@ pub struct Peer {
     /// show path gates on state rather than clearing this on teardown.
     /// `None` until the first session comes up. See [`super::mss`].
     pub tcp_mss_synced: Option<u16>,
+
+    /// When the first `NdEvent::NeighborDiscovered` materialized this
+    /// interface-keyed peer. `None` for address-keyed peers and for
+    /// dormant peers created at config time before any RA has arrived.
+    pub nd_discovered_at: Option<Instant>,
+    /// Timestamp of the most recent `NdEvent::NeighborDiscovered` for
+    /// this peer. Updated on every RA that refreshes the remote
+    /// link-local; equal to `nd_discovered_at` right after the first
+    /// event.  `None` in the same cases as `nd_discovered_at`.
+    pub nd_refreshed_at: Option<Instant>,
+    /// Running total of `NdEvent::NeighborDiscovered` events applied to
+    /// this peer. 0 for address-keyed and dormant peers; 1 after the
+    /// first RA; incremented on every subsequent refresh. The render
+    /// path reports `nd_event_count.saturating_sub(1)` as the refresh
+    /// count (events after the initial discovery).
+    pub nd_event_count: u64,
 }
 
 impl Peer {
@@ -901,6 +917,9 @@ impl Peer {
             tracing: super::tracing::BgpTracing::default(),
             tracing_instance: super::tracing::BgpTracing::default(),
             tcp_mss_synced: None,
+            nd_discovered_at: None,
+            nd_refreshed_at: None,
+            nd_event_count: 0,
         };
         peer.config
             .mp

--- a/zebra-rs/src/bgp/show.rs
+++ b/zebra-rs/src/bgp/show.rs
@@ -1829,6 +1829,22 @@ struct Neighbor<'a> {
     #[serde(skip_serializing_if = "Option::is_none")]
     neighbor_group: Option<String>,
     remote_as_inherited: bool,
+
+    /// Seconds elapsed since the first `NdEvent::NeighborDiscovered`
+    /// materialized this interface-keyed peer. `None` for
+    /// address-keyed peers and dormant peers that have never seen an
+    /// RA. Serialized in JSON for consumers that want the raw value.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    nd_discovered_secs_ago: Option<u64>,
+    /// Number of RA refresh events applied to this peer after the
+    /// initial discovery (`nd_event_count - 1`). `None` in the same
+    /// cases as `nd_discovered_secs_ago`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    nd_refresh_count: Option<u64>,
+    /// Seconds elapsed since the most recent RA refresh. `None` in
+    /// the same cases as `nd_discovered_secs_ago`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    nd_refreshed_secs_ago: Option<u64>,
 }
 
 const ONE_DAY_SECOND: u64 = 60 * 60 * 24;
@@ -1940,6 +1956,20 @@ fn fetch(peer: &Peer) -> Neighbor<'_> {
         .unwrap_or_else(|| peer.config.timer.idle_hold_time());
     let connect_retry_timer_rem = peer.timer.connect_retry.as_ref().map(|t| t.rem_sec());
 
+    // Snapshot now once so all ND elapsed-time calculations are
+    // consistent within a single fetch call.
+    let now = Instant::now();
+    let nd_discovered_secs_ago = peer
+        .nd_discovered_at
+        .map(|t| now.saturating_duration_since(t).as_secs());
+    let nd_refresh_count = peer
+        .nd_event_count
+        .checked_sub(1)
+        .filter(|_| peer.nd_discovered_at.is_some());
+    let nd_refreshed_secs_ago = peer
+        .nd_refreshed_at
+        .map(|t| now.saturating_duration_since(t).as_secs());
+
     let mut n = Neighbor {
         address: peer.address,
         interface: peer.ifname.as_deref(),
@@ -1987,6 +2017,9 @@ fn fetch(peer: &Peer) -> Neighbor<'_> {
         disable_connected_check: peer.config.transport.disable_connected_check,
         neighbor_group: peer.config.neighbor_group.clone(),
         remote_as_inherited: peer.config.remote_as_inherited,
+        nd_discovered_secs_ago,
+        nd_refresh_count,
+        nd_refreshed_secs_ago,
     };
 
     // Timers.
@@ -2007,6 +2040,27 @@ fn fetch(peer: &Peer) -> Neighbor<'_> {
     };
     n.count.insert("total", total);
     n
+}
+
+/// Format a number of seconds as `NhNmNs` (or just `Ns` / `NmNs`
+/// depending on magnitude).  Used for the ND discovery / refresh
+/// elapsed-time lines in `show bgp neighbors`.
+///
+/// Examples:
+/// * 27 → `"27s"`
+/// * 331 → `"5m31s"`
+/// * 3661 → `"1h1m1s"`
+fn format_nd_elapsed(secs: u64) -> String {
+    let h = secs / 3600;
+    let m = (secs % 3600) / 60;
+    let s = secs % 60;
+    if h > 0 {
+        format!("{}h{}m{}s", h, m, s)
+    } else if m > 0 {
+        format!("{}m{}s", m, s)
+    } else {
+        format!("{}s", s)
+    }
 }
 
 fn render(out: &mut String, neighbor: &Neighbor) -> std::fmt::Result {
@@ -2065,6 +2119,34 @@ fn render(out: &mut String, neighbor: &Neighbor) -> std::fmt::Result {
         neighbor.timer_recv.hold_time,
         neighbor.timer_recv.keepalive,
     )?;
+
+    // ND discovery block — interface-keyed (unnumbered) peers only.
+    if let Some(discovered_secs) = neighbor.nd_discovered_secs_ago {
+        writeln!(
+            out,
+            "  Interface peer: link-local learned via IPv6 ND router advertisement"
+        )?;
+        let discovered_ago = format_nd_elapsed(discovered_secs);
+        match neighbor.nd_refresh_count {
+            Some(0) | None => {
+                writeln!(out, "  Discovered {} ago", discovered_ago)?;
+            }
+            Some(refreshes) => {
+                let refreshed_ago = neighbor
+                    .nd_refreshed_secs_ago
+                    .map(format_nd_elapsed)
+                    .unwrap_or_default();
+                writeln!(
+                    out,
+                    "  Discovered {} ago, refreshed {} time{} (last {} ago)",
+                    discovered_ago,
+                    refreshes,
+                    if refreshes == 1 { "" } else { "s" },
+                    refreshed_ago,
+                )?;
+            }
+        }
+    }
 
     // Display timer expiry information
     if let Some(keepalive_rem) = neighbor.keepalive_timer_rem {
@@ -3344,6 +3426,141 @@ Neighbor        V         AS   MsgRcvd   MsgSent   TblVer  InQ OutQ  Up/Down Sta
             "unknown name reports cleanly:\n{out}"
         );
     }
+
+    /// Build a `Neighbor` DTO directly (all-`None` ND fields) and
+    /// verify that `render` does NOT emit any ND block — address-keyed
+    /// peers must be unaffected.
+    #[test]
+    fn nd_block_absent_for_address_keyed_peer() {
+        let mut out = String::new();
+        let n = minimal_neighbor(None);
+        render(&mut out, &n).unwrap();
+        assert!(
+            !out.contains("Interface peer:"),
+            "address-keyed peer must not get ND block:\n{out}"
+        );
+    }
+
+    /// An interface-keyed peer with ND discovery data (no refreshes
+    /// yet) renders the "Discovered N ago" line but not the refresh
+    /// clause.
+    #[test]
+    fn nd_block_discovery_only_no_refresh() {
+        let mut out = String::new();
+        let mut n = minimal_neighbor(Some("enp0s5"));
+        // 331 seconds = 5m31s
+        n.nd_discovered_secs_ago = Some(331);
+        n.nd_refresh_count = Some(0);
+        n.nd_refreshed_secs_ago = Some(331);
+        render(&mut out, &n).unwrap();
+        assert!(
+            out.contains("Interface peer: link-local learned via IPv6 ND router advertisement"),
+            "ND header line missing:\n{out}"
+        );
+        assert!(
+            out.contains("Discovered 5m31s ago"),
+            "discovery line missing:\n{out}"
+        );
+        assert!(
+            !out.contains("refreshed"),
+            "no refresh clause when count is 0:\n{out}"
+        );
+    }
+
+    /// An interface-keyed peer with multiple refresh events renders
+    /// the full "Discovered … ago, refreshed N times (last … ago)" form.
+    #[test]
+    fn nd_block_with_refreshes() {
+        let mut out = String::new();
+        let mut n = minimal_neighbor(Some("enp0s5"));
+        n.nd_discovered_secs_ago = Some(331); // 5m31s
+        n.nd_refresh_count = Some(12);
+        n.nd_refreshed_secs_ago = Some(27); // 27s
+        render(&mut out, &n).unwrap();
+        assert!(
+            out.contains("Discovered 5m31s ago, refreshed 12 times (last 27s ago)"),
+            "full refresh line missing:\n{out}"
+        );
+    }
+
+    /// JSON output for an interface-keyed peer carries the three ND
+    /// fields; an address-keyed peer must not carry them.
+    #[test]
+    fn nd_fields_in_json_interface_peer_only() {
+        // Interface-keyed peer with ND data.
+        let mut n = minimal_neighbor(Some("enp0s5"));
+        n.nd_discovered_secs_ago = Some(331);
+        n.nd_refresh_count = Some(12);
+        n.nd_refreshed_secs_ago = Some(27);
+        let json_str = serde_json::to_string(&n).unwrap();
+        let v: serde_json::Value = serde_json::from_str(&json_str).unwrap();
+        assert_eq!(v["nd_discovered_secs_ago"], 331);
+        assert_eq!(v["nd_refresh_count"], 12);
+        assert_eq!(v["nd_refreshed_secs_ago"], 27);
+
+        // Address-keyed peer: ND fields must be absent.
+        let n2 = minimal_neighbor(None);
+        let json_str2 = serde_json::to_string(&n2).unwrap();
+        let v2: serde_json::Value = serde_json::from_str(&json_str2).unwrap();
+        assert!(
+            v2.get("nd_discovered_secs_ago").is_none(),
+            "address-keyed peer must not carry nd_discovered_secs_ago"
+        );
+        assert!(
+            v2.get("nd_refresh_count").is_none(),
+            "address-keyed peer must not carry nd_refresh_count"
+        );
+        assert!(
+            v2.get("nd_refreshed_secs_ago").is_none(),
+            "address-keyed peer must not carry nd_refreshed_secs_ago"
+        );
+    }
+
+    /// Helper: build a minimal `Neighbor<'static>` with placeholder
+    /// values — only the fields under test need to be non-default.
+    fn minimal_neighbor(interface: Option<&'static str>) -> Neighbor<'static> {
+        use std::collections::HashMap as HM;
+        Neighbor {
+            address: "10.0.0.1".parse().unwrap(),
+            interface,
+            peer_type: "internal",
+            local_as: 65001,
+            remote_as: 65002,
+            local_router_id: Ipv4Addr::UNSPECIFIED,
+            remote_router_id: Ipv4Addr::UNSPECIFIED,
+            state: "Idle",
+            uptime: String::from("never"),
+            timer: PeerParam::default(),
+            timer_sent: PeerParam::default(),
+            timer_recv: PeerParam::default(),
+            keepalive_timer_rem: None,
+            hold_timer_rem: None,
+            idle_hold_timer_rem: None,
+            idle_hold_timer_next: 0,
+            connect_retry_timer_rem: None,
+            cap_send: BgpCap::default(),
+            cap_recv: BgpCap::default(),
+            cap_map: CapAfiMap::new(),
+            count: HM::default(),
+            reflector_client: false,
+            soft_reconfig_in: false,
+            allowas_in: None,
+            as_override: false,
+            remove_private_as: None,
+            enforce_first_as: false,
+            encapsulation_type_ipv6: None,
+            ttl_security: false,
+            ebgp_multihop: None,
+            tcp_mss: None,
+            tcp_mss_synced: None,
+            disable_connected_check: false,
+            neighbor_group: None,
+            remote_as_inherited: false,
+            nd_discovered_secs_ago: None,
+            nd_refresh_count: None,
+            nd_refreshed_secs_ago: None,
+        }
+    }
 }
 
 #[cfg(test)]
@@ -4227,5 +4444,30 @@ impl Bgp {
             .path("/show/bgp/vrf/ipv6/longer-prefix")
             .set(show_bgp_vrf_not_running)
             .map();
+    }
+}
+
+#[cfg(test)]
+mod nd_elapsed_tests {
+    use super::format_nd_elapsed;
+
+    #[test]
+    fn seconds_only() {
+        assert_eq!(format_nd_elapsed(0), "0s");
+        assert_eq!(format_nd_elapsed(27), "27s");
+        assert_eq!(format_nd_elapsed(59), "59s");
+    }
+
+    #[test]
+    fn minutes_and_seconds() {
+        assert_eq!(format_nd_elapsed(60), "1m0s");
+        assert_eq!(format_nd_elapsed(331), "5m31s");
+        assert_eq!(format_nd_elapsed(3599), "59m59s");
+    }
+
+    #[test]
+    fn hours_minutes_seconds() {
+        assert_eq!(format_nd_elapsed(3600), "1h0m0s");
+        assert_eq!(format_nd_elapsed(3661), "1h1m1s");
     }
 }

--- a/zebra-rs/src/config/manager.rs
+++ b/zebra-rs/src/config/manager.rs
@@ -953,6 +953,8 @@ impl ConfigManager {
                                 "BGP"
                             } else if is_bfd(&paths) {
                                 "BFD"
+                            } else if is_nd(&paths) {
+                                "ND"
                             } else if is_policy(&paths) {
                                 "Policy"
                             } else {
@@ -1099,6 +1101,10 @@ fn is_bfd(paths: &[CommandPath]) -> bool {
     paths.iter().any(|x| x.name == "bfd")
 }
 
+fn is_nd(paths: &[CommandPath]) -> bool {
+    paths.iter().any(|x| x.name == "nd")
+}
+
 fn is_policy(paths: &[CommandPath]) -> bool {
     paths
         .iter()
@@ -1120,6 +1126,8 @@ fn show_proto(paths: &[CommandPath]) -> &'static str {
         "isis"
     } else if is_bfd(paths) {
         "bfd"
+    } else if is_nd(paths) {
+        "nd"
     } else if is_policy(paths) {
         "policy"
     } else {

--- a/zebra-rs/src/config/nd.rs
+++ b/zebra-rs/src/config/nd.rs
@@ -46,6 +46,7 @@ pub fn spawn_nd(config: &ConfigManager) {
     let (_rib_client, rib_rx) = config.subscribe_to_rib("nd");
     let nd = inst::Nd::new(socket, rib_rx);
     config.subscribe("nd", nd.cm.tx.clone());
+    config.subscribe_show("nd", nd.show.tx.clone());
     // Publish the ND client-request channel so other protocol modules
     // (BGP unnumbered) can attach a subscriber for `NeighborDiscovered`
     // events at their own spawn time.

--- a/zebra-rs/src/config/parse.rs
+++ b/zebra-rs/src/config/parse.rs
@@ -1121,6 +1121,34 @@ mod tests {
         }
     }
 
+    /// Pin the `show ipv6 nd` grammar: three spellings — bare summary,
+    /// all-interfaces detail, single-interface detail — must parse to the
+    /// expected paths and arg vectors.
+    #[test]
+    fn show_ipv6_nd_grammar() {
+        use crate::config::path_from_command;
+        let entry = exec_entry();
+
+        let cases: Vec<(&str, &str, Vec<&str>)> = vec![
+            ("show ipv6 nd", "/show/ipv6/nd", vec![]),
+            ("show ipv6 nd interface", "/show/ipv6/nd/interface", vec![]),
+            (
+                "show ipv6 nd interface eth0",
+                "/show/ipv6/nd/interface",
+                vec!["eth0"],
+            ),
+        ];
+
+        for &(cmd, want_path, ref want_args) in &cases {
+            let (code, _comps, state) = parse(cmd, entry.clone(), None, State::new());
+            assert_eq!(code, ExecCode::Success, "parse `{cmd}`");
+            let (path, args) = path_from_command(&state.paths);
+            assert_eq!(path, want_path, "path for `{cmd}`");
+            let got: Vec<&str> = args.0.iter().map(|s| s.as_str()).collect();
+            assert_eq!(&got, want_args, "args for `{cmd}`");
+        }
+    }
+
     /// The VPNv4 / EVPN RIB views moved from the legacy `show ip bgp`
     /// tree to `show bgp …`; the old spellings must no longer parse.
     /// The per-neighbor views (and their `vpnv4` / `evpn` Adj-RIB

--- a/zebra-rs/src/nd/engine.rs
+++ b/zebra-rs/src/nd/engine.rs
@@ -17,10 +17,12 @@ use std::collections::BTreeMap;
 use std::net::Ipv6Addr;
 use std::time::Instant;
 
+use nd_packet::RaFlags;
+
 use crate::rib::link::Link;
 
 use super::send::{RaEvent, RaSendConfig, RaSender};
-use super::{NdRecv, NdSend};
+use super::{DropReason, NdRecv, NdSend};
 
 /// Lifecycle events emitted by [`NdEngine`] for downstream consumers.
 /// One subscriber today (BGP unnumbered will plug in here); a
@@ -33,6 +35,77 @@ pub enum NdEvent {
     /// debouncing repeats.
     NeighborDiscovered { ifindex: u32, src: Ipv6Addr },
 }
+
+/// Per-interface packet counters observed at the daemon's raw socket.
+///
+/// Note: kernel-originated NS/NA are invisible here because the host
+/// kernel owns the NDP cache and multicast loopback is disabled on the
+/// ND socket. Only packets received on the wire and our own RA
+/// transmissions are counted.
+#[derive(Debug, Default, Clone, PartialEq, Eq)]
+pub struct NdIfCounters {
+    /// Unsolicited RAs we transmitted (periodic).
+    pub tx_ra_unsolicited: u64,
+    /// Solicited RAs we transmitted (in response to RS).
+    pub tx_ra_solicited: u64,
+    /// Router Advertisements received.
+    pub rx_ra: u64,
+    /// Router Solicitations received.
+    pub rx_rs: u64,
+    /// Neighbor Solicitations received.
+    pub rx_ns: u64,
+    /// Neighbor Advertisements received.
+    pub rx_na: u64,
+    /// Packets discarded because the IPv6 hop limit was not 255
+    /// (RFC 4861 §6.1.2 MUST silently discard).
+    pub rx_drop_hop_limit: u64,
+    /// Packets discarded due to a parse error (too short, non-zero
+    /// ICMPv6 code, malformed option, etc.).
+    pub rx_drop_malformed: u64,
+    /// Sources that arrived when the per-interface neighbor table was
+    /// full (see [`MAX_TRACKED_SOURCES`]). Counted per packet, not per
+    /// unique source.
+    pub untracked_sources: u64,
+}
+
+/// Snapshot of the most recently received Router Advertisement from a
+/// given source. Stored in [`NdNeighbor`] so the show command can
+/// render lifetime / flags without re-parsing.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LastRa {
+    pub router_lifetime: u16,
+    pub cur_hop_limit: u8,
+    pub flags: RaFlags,
+}
+
+/// Per-source observation record in the neighbor table.
+///
+/// Keyed by the IPv6 source address of received ND messages. The
+/// source may be `::` for DAD (Duplicate Address Detection) probes
+/// — those get a table entry like any other source.
+#[derive(Debug, Clone)]
+pub struct NdNeighbor {
+    /// Wall-clock time the first packet from this source was seen.
+    pub first_seen: Instant,
+    /// Wall-clock time the most recent packet from this source was seen.
+    pub last_seen: Instant,
+    /// Router Advertisements received from this source.
+    pub rx_ra: u64,
+    /// Router Solicitations received from this source.
+    pub rx_rs: u64,
+    /// Neighbor Solicitations received from this source.
+    pub rx_ns: u64,
+    /// Neighbor Advertisements received from this source.
+    pub rx_na: u64,
+    /// Fields from the most recently received RA, if any.
+    pub last_ra: Option<LastRa>,
+}
+
+/// Per-interface neighbor-table cap. When the table is full, additional
+/// *new* sources are not inserted; instead `untracked_sources` on the
+/// interface counters is incremented. Existing sources continue to be
+/// updated even when the table is at capacity.
+pub const MAX_TRACKED_SOURCES: usize = 256;
 
 pub struct NdEngine {
     senders: BTreeMap<u32, RaSender>,
@@ -55,6 +128,13 @@ pub struct NdEngine {
     /// long after the commit — instead of silently dropping config
     /// that raced ahead of the dump.
     ra_config_by_name: BTreeMap<String, RaSendConfig>,
+    /// Per-interface packet counters. Independent of `senders` — NS/NA
+    /// arrive on interfaces with no RA sender configured and must still
+    /// be counted.
+    counters: BTreeMap<u32, NdIfCounters>,
+    /// Per-interface, per-source observation records. Independent of
+    /// `senders` for the same reason as `counters`.
+    neighbors: BTreeMap<u32, BTreeMap<Ipv6Addr, NdNeighbor>>,
 }
 
 impl NdEngine {
@@ -65,6 +145,8 @@ impl NdEngine {
             ifindex_by_name: BTreeMap::new(),
             name_by_ifindex: BTreeMap::new(),
             ra_config_by_name: BTreeMap::new(),
+            counters: BTreeMap::new(),
+            neighbors: BTreeMap::new(),
         }
     }
 
@@ -166,13 +248,57 @@ impl NdEngine {
         self.senders.values().map(|s| s.next_wakeup()).min()
     }
 
-    /// Handle an inbound ND frame: emit a [`NdEvent::NeighborDiscovered`]
-    /// for the RA case (the BGP unnumbered hand-off), and forward RS
-    /// events into the matching sender so a solicited reply gets
-    /// scheduled.
+    // ── Read accessors (used by the upcoming show command) ──────────────
+
+    /// All per-interface counters, keyed by ifindex.
+    pub fn counters(&self) -> &BTreeMap<u32, NdIfCounters> {
+        &self.counters
+    }
+
+    /// All per-interface neighbor tables, keyed by ifindex then source
+    /// address.
+    pub fn neighbors(&self) -> &BTreeMap<u32, BTreeMap<Ipv6Addr, NdNeighbor>> {
+        &self.neighbors
+    }
+
+    /// The [`RaSender`] for `ifindex`, if RA is enabled on that
+    /// interface.
+    pub fn sender(&self, ifindex: u32) -> Option<&RaSender> {
+        self.senders.get(&ifindex)
+    }
+
+    /// All active [`RaSender`]s, keyed by ifindex.
+    pub fn senders(&self) -> &BTreeMap<u32, RaSender> {
+        &self.senders
+    }
+
+    /// Handle an inbound ND frame: update counters, update the
+    /// neighbor table, emit [`NdEvent::NeighborDiscovered`] for RA
+    /// (the BGP unnumbered hand-off), and forward RS events into the
+    /// matching sender so a solicited reply gets scheduled.
     pub fn on_recv(&mut self, recv: NdRecv, now: Instant) {
         match recv {
-            NdRecv::RouterAdvert { ifindex, src, .. } => {
+            NdRecv::RouterAdvert { ifindex, src, ra } => {
+                // Update counters and neighbor table first using
+                // disjoint field borrows — doing this before the
+                // senders.get_mut call avoids a borrow-checker conflict.
+                self.counters.entry(ifindex).or_default().rx_ra += 1;
+                let last_ra = Some(LastRa {
+                    router_lifetime: ra.router_lifetime,
+                    cur_hop_limit: ra.cur_hop_limit,
+                    flags: ra.flags,
+                });
+                Self::record_neighbor(
+                    &mut self.neighbors,
+                    &mut self.counters,
+                    ifindex,
+                    src,
+                    now,
+                    |nb| {
+                        nb.rx_ra += 1;
+                        nb.last_ra = last_ra.clone();
+                    },
+                );
                 if let Some(tx) = &self.notifier {
                     // Ignore SendError — a closed subscriber just
                     // means nobody's listening, not a fatal state.
@@ -180,8 +306,46 @@ impl NdEngine {
                 }
             }
             NdRecv::RouterSolicit { ifindex, src, .. } => {
+                self.counters.entry(ifindex).or_default().rx_rs += 1;
+                Self::record_neighbor(
+                    &mut self.neighbors,
+                    &mut self.counters,
+                    ifindex,
+                    src,
+                    now,
+                    |nb| nb.rx_rs += 1,
+                );
                 if let Some(sender) = self.senders.get_mut(&ifindex) {
                     sender.on_router_solicit(src, now);
+                }
+            }
+            NdRecv::NeighborSolicit { ifindex, src, .. } => {
+                self.counters.entry(ifindex).or_default().rx_ns += 1;
+                Self::record_neighbor(
+                    &mut self.neighbors,
+                    &mut self.counters,
+                    ifindex,
+                    src,
+                    now,
+                    |nb| nb.rx_ns += 1,
+                );
+            }
+            NdRecv::NeighborAdvert { ifindex, src, .. } => {
+                self.counters.entry(ifindex).or_default().rx_na += 1;
+                Self::record_neighbor(
+                    &mut self.neighbors,
+                    &mut self.counters,
+                    ifindex,
+                    src,
+                    now,
+                    |nb| nb.rx_na += 1,
+                );
+            }
+            NdRecv::Dropped { ifindex, reason } => {
+                let c = self.counters.entry(ifindex).or_default();
+                match reason {
+                    DropReason::HopLimit => c.rx_drop_hop_limit += 1,
+                    DropReason::Malformed => c.rx_drop_malformed += 1,
                 }
             }
         }
@@ -195,20 +359,70 @@ impl NdEngine {
         for (&ifindex, sender) in self.senders.iter_mut() {
             for ev in sender.tick(now) {
                 match ev {
-                    RaEvent::SendUnsolicited { ra } => out.push(NdSend::RouterAdvert {
-                        ifindex,
-                        dst: ALL_NODES,
-                        ra,
-                    }),
-                    RaEvent::SendSolicited { ra } => out.push(NdSend::RouterAdvert {
-                        ifindex,
-                        dst: ALL_NODES,
-                        ra,
-                    }),
+                    RaEvent::SendUnsolicited { ra } => {
+                        // Disjoint field borrow: `senders` is mutably
+                        // borrowed by the iterator; `counters` is a
+                        // separate field so this compiles.
+                        self.counters.entry(ifindex).or_default().tx_ra_unsolicited += 1;
+                        out.push(NdSend::RouterAdvert {
+                            ifindex,
+                            dst: ALL_NODES,
+                            ra,
+                        });
+                    }
+                    RaEvent::SendSolicited { ra } => {
+                        self.counters.entry(ifindex).or_default().tx_ra_solicited += 1;
+                        out.push(NdSend::RouterAdvert {
+                            ifindex,
+                            dst: ALL_NODES,
+                            ra,
+                        });
+                    }
                 }
             }
         }
         out
+    }
+
+    /// Update (or insert) the per-source observation record for `src`
+    /// on `ifindex`. If the table is already at [`MAX_TRACKED_SOURCES`]
+    /// and `src` is a new entry, increment `untracked_sources` instead.
+    ///
+    /// `update` is a closure that bumps the appropriate per-type counter
+    /// and sets any additional fields (e.g. `last_ra`) on the record.
+    ///
+    /// Takes `neighbors` and `counters` as explicit parameters so the
+    /// borrow checker can see they are disjoint fields — this function
+    /// is called from `on_recv` while `self.senders` may also be
+    /// accessed.
+    fn record_neighbor(
+        neighbors: &mut BTreeMap<u32, BTreeMap<Ipv6Addr, NdNeighbor>>,
+        counters: &mut BTreeMap<u32, NdIfCounters>,
+        ifindex: u32,
+        src: Ipv6Addr,
+        now: Instant,
+        update: impl FnOnce(&mut NdNeighbor),
+    ) {
+        let table = neighbors.entry(ifindex).or_default();
+        if let Some(nb) = table.get_mut(&src) {
+            nb.last_seen = now;
+            update(nb);
+        } else if table.len() < MAX_TRACKED_SOURCES {
+            let mut nb = NdNeighbor {
+                first_seen: now,
+                last_seen: now,
+                rx_ra: 0,
+                rx_rs: 0,
+                rx_ns: 0,
+                rx_na: 0,
+                last_ra: None,
+            };
+            update(&mut nb);
+            table.insert(src, nb);
+        } else {
+            // Table full — count the overflow but don't insert.
+            counters.entry(ifindex).or_default().untracked_sources += 1;
+        }
     }
 }
 
@@ -229,7 +443,7 @@ mod tests {
     use super::*;
     use crate::nd::send::RaSendConfig;
     use crate::rib::link::{Link, LinkType};
-    use nd_packet::{RouterAdvert, RouterSolicit};
+    use nd_packet::{NaFlags, NeighborAdvert, NeighborSolicit, RouterAdvert, RouterSolicit};
     use netlink_packet_route::link::LinkFlags;
     use tokio::sync::mpsc;
 
@@ -260,6 +474,36 @@ mod tests {
             mtu_error: None,
         }
     }
+
+    fn make_ra() -> RouterAdvert {
+        RouterAdvert {
+            cur_hop_limit: 64,
+            flags: Default::default(),
+            router_lifetime: 1800,
+            reachable_time: 0,
+            retrans_timer: 0,
+            options: vec![],
+        }
+    }
+
+    fn make_ns() -> NeighborSolicit {
+        let target: Ipv6Addr = "fe80::ffff".parse().unwrap();
+        NeighborSolicit {
+            target,
+            options: vec![],
+        }
+    }
+
+    fn make_na() -> NeighborAdvert {
+        let target: Ipv6Addr = "fe80::ffff".parse().unwrap();
+        NeighborAdvert {
+            flags: NaFlags::empty(),
+            target,
+            options: vec![],
+        }
+    }
+
+    // ── Existing tests (unmodified) ──────────────────────────────────────
 
     #[test]
     fn no_interfaces_means_no_wakeup() {
@@ -301,14 +545,7 @@ mod tests {
             NdRecv::RouterAdvert {
                 ifindex: 5,
                 src: ll("fe80::1"),
-                ra: RouterAdvert {
-                    cur_hop_limit: 64,
-                    flags: Default::default(),
-                    router_lifetime: 1800,
-                    reachable_time: 0,
-                    retrans_timer: 0,
-                    options: vec![],
-                },
+                ra: make_ra(),
             },
             t0(),
         );
@@ -518,5 +755,397 @@ mod tests {
 
         eng.process_link_add(&link("swp1", 7), start);
         assert!(eng.is_enabled(7));
+    }
+
+    // ── New tests for PR 2 ───────────────────────────────────────────────
+
+    #[test]
+    fn rx_counters_increment_per_type() {
+        let start = t0();
+        let mut eng = NdEngine::new();
+
+        eng.on_recv(
+            NdRecv::RouterAdvert {
+                ifindex: 5,
+                src: ll("fe80::1"),
+                ra: make_ra(),
+            },
+            start,
+        );
+        eng.on_recv(
+            NdRecv::RouterSolicit {
+                ifindex: 5,
+                src: ll("fe80::2"),
+                rs: RouterSolicit::default(),
+            },
+            start,
+        );
+        eng.on_recv(
+            NdRecv::NeighborSolicit {
+                ifindex: 5,
+                src: ll("fe80::3"),
+                ns: make_ns(),
+            },
+            start,
+        );
+        eng.on_recv(
+            NdRecv::NeighborAdvert {
+                ifindex: 5,
+                src: ll("fe80::4"),
+                na: make_na(),
+            },
+            start,
+        );
+
+        let c = &eng.counters()[&5];
+        assert_eq!(c.rx_ra, 1);
+        assert_eq!(c.rx_rs, 1);
+        assert_eq!(c.rx_ns, 1);
+        assert_eq!(c.rx_na, 1);
+        assert_eq!(c.rx_drop_hop_limit, 0);
+        assert_eq!(c.rx_drop_malformed, 0);
+    }
+
+    #[test]
+    fn dropped_reasons_map_to_counters() {
+        let start = t0();
+        let mut eng = NdEngine::new();
+
+        eng.on_recv(
+            NdRecv::Dropped {
+                ifindex: 5,
+                reason: DropReason::HopLimit,
+            },
+            start,
+        );
+        eng.on_recv(
+            NdRecv::Dropped {
+                ifindex: 5,
+                reason: DropReason::HopLimit,
+            },
+            start,
+        );
+        eng.on_recv(
+            NdRecv::Dropped {
+                ifindex: 5,
+                reason: DropReason::Malformed,
+            },
+            start,
+        );
+
+        let c = &eng.counters()[&5];
+        assert_eq!(c.rx_drop_hop_limit, 2);
+        assert_eq!(c.rx_drop_malformed, 1);
+    }
+
+    #[test]
+    fn neighbor_table_records_per_source() {
+        use std::time::Duration;
+        let start = t0();
+        let later = start + Duration::from_secs(5);
+        let mut eng = NdEngine::new();
+
+        // Source A: one NS at start, one NA at start.
+        eng.on_recv(
+            NdRecv::NeighborSolicit {
+                ifindex: 5,
+                src: ll("fe80::a"),
+                ns: make_ns(),
+            },
+            start,
+        );
+        eng.on_recv(
+            NdRecv::NeighborAdvert {
+                ifindex: 5,
+                src: ll("fe80::a"),
+                na: make_na(),
+            },
+            start,
+        );
+
+        // Source B: one RA at later.
+        eng.on_recv(
+            NdRecv::RouterAdvert {
+                ifindex: 5,
+                src: ll("fe80::b"),
+                ra: make_ra(),
+            },
+            later,
+        );
+
+        let table = &eng.neighbors()[&5];
+        let a = &table[&ll("fe80::a")];
+        assert_eq!(a.rx_ns, 1);
+        assert_eq!(a.rx_na, 1);
+        assert_eq!(a.rx_ra, 0);
+        // both packets arrived at `start` so first_seen == last_seen
+        assert_eq!(a.first_seen, a.last_seen);
+
+        // Now send another packet from A at `later` — last_seen advances.
+        let mut eng2 = NdEngine::new();
+        eng2.on_recv(
+            NdRecv::NeighborSolicit {
+                ifindex: 5,
+                src: ll("fe80::a"),
+                ns: make_ns(),
+            },
+            start,
+        );
+        eng2.on_recv(
+            NdRecv::NeighborSolicit {
+                ifindex: 5,
+                src: ll("fe80::a"),
+                ns: make_ns(),
+            },
+            later,
+        );
+        let table2 = &eng2.neighbors()[&5];
+        let a2 = &table2[&ll("fe80::a")];
+        assert!(a2.first_seen < a2.last_seen);
+        assert_eq!(a2.rx_ns, 2);
+
+        let b = &table[&ll("fe80::b")];
+        assert_eq!(b.rx_ra, 1);
+    }
+
+    #[test]
+    fn last_ra_updates_on_each_ra() {
+        let start = t0();
+        let mut eng = NdEngine::new();
+        let src = ll("fe80::1:1");
+
+        eng.on_recv(
+            NdRecv::RouterAdvert {
+                ifindex: 5,
+                src,
+                ra: RouterAdvert {
+                    cur_hop_limit: 64,
+                    flags: nd_packet::RaFlags::empty(),
+                    router_lifetime: 1800,
+                    reachable_time: 0,
+                    retrans_timer: 0,
+                    options: vec![],
+                },
+            },
+            start,
+        );
+
+        // Second RA with lifetime=0 (router going away).
+        eng.on_recv(
+            NdRecv::RouterAdvert {
+                ifindex: 5,
+                src,
+                ra: RouterAdvert {
+                    cur_hop_limit: 64,
+                    flags: nd_packet::RaFlags::empty(),
+                    router_lifetime: 0,
+                    reachable_time: 0,
+                    retrans_timer: 0,
+                    options: vec![],
+                },
+            },
+            start,
+        );
+
+        let table = &eng.neighbors()[&5];
+        let nb = &table[&src];
+        assert_eq!(nb.rx_ra, 2);
+        let lr = nb.last_ra.as_ref().expect("last_ra should be set");
+        // Latest RA wins.
+        assert_eq!(lr.router_lifetime, 0);
+    }
+
+    #[test]
+    fn dad_unspecified_source_is_tracked() {
+        let start = t0();
+        let mut eng = NdEngine::new();
+        let unspec: Ipv6Addr = "::".parse().unwrap();
+
+        eng.on_recv(
+            NdRecv::NeighborSolicit {
+                ifindex: 5,
+                src: unspec,
+                ns: make_ns(),
+            },
+            start,
+        );
+
+        let table = &eng.neighbors()[&5];
+        assert!(
+            table.contains_key(&unspec),
+            "DAD probe from :: should create a table entry"
+        );
+        assert_eq!(table[&unspec].rx_ns, 1);
+    }
+
+    #[test]
+    fn source_cap_overflows_to_untracked() {
+        let start = t0();
+        let mut eng = NdEngine::new();
+
+        // Fill the table with MAX_TRACKED_SOURCES distinct sources.
+        for i in 0u32..MAX_TRACKED_SOURCES as u32 {
+            // Build fe80::0001, fe80::0002, … — unique per i.
+            let addr = Ipv6Addr::new(0xfe80, 0, 0, 0, 0, 0, 0, (i + 1) as u16);
+            eng.on_recv(
+                NdRecv::NeighborSolicit {
+                    ifindex: 5,
+                    src: addr,
+                    ns: make_ns(),
+                },
+                start,
+            );
+        }
+
+        let table_len_before = eng.neighbors()[&5].len();
+        assert_eq!(table_len_before, MAX_TRACKED_SOURCES);
+
+        // One more NEW source — should be untracked.
+        let new_src = Ipv6Addr::new(0xfe80, 0, 0, 0, 0, 0, 0xdead, 0xbeef);
+        eng.on_recv(
+            NdRecv::NeighborSolicit {
+                ifindex: 5,
+                src: new_src,
+                ns: make_ns(),
+            },
+            start,
+        );
+
+        assert_eq!(eng.counters()[&5].untracked_sources, 1);
+        // Table didn't grow.
+        assert_eq!(eng.neighbors()[&5].len(), MAX_TRACKED_SOURCES);
+
+        // An EXISTING source must still update even when the table is full.
+        let existing = Ipv6Addr::new(0xfe80, 0, 0, 0, 0, 0, 0, 1);
+        let old_ns = eng.neighbors()[&5][&existing].rx_ns;
+        use std::time::Duration;
+        eng.on_recv(
+            NdRecv::NeighborSolicit {
+                ifindex: 5,
+                src: existing,
+                ns: make_ns(),
+            },
+            start + Duration::from_secs(1),
+        );
+        // Counter bumped, untracked_sources unchanged.
+        assert_eq!(
+            eng.neighbors()[&5][&existing].rx_ns,
+            old_ns + 1,
+            "existing source should still update when table is full"
+        );
+        assert_eq!(
+            eng.counters()[&5].untracked_sources,
+            1,
+            "untracked_sources should not grow for an existing source"
+        );
+    }
+
+    #[test]
+    fn counters_on_interface_without_sender() {
+        let start = t0();
+        let mut eng = NdEngine::new();
+
+        // ifindex 42 has no RA sender configured.
+        eng.on_recv(
+            NdRecv::NeighborSolicit {
+                ifindex: 42,
+                src: ll("fe80::1"),
+                ns: make_ns(),
+            },
+            start,
+        );
+
+        assert_eq!(eng.counters()[&42].rx_ns, 1);
+        assert!(eng.neighbors()[&42].contains_key(&ll("fe80::1")));
+        assert!(!eng.is_enabled(42), "no sender should have been created");
+    }
+
+    #[test]
+    fn tx_counters_split_unsolicited_solicited() {
+        use crate::nd::send::RaSendConfig;
+        use std::time::Duration;
+
+        // (a) Unsolicited: enable + tick at the scheduled wakeup.
+        {
+            let start = t0();
+            let mut eng = NdEngine::new();
+            eng.enable_interface(5, RaSendConfig::default(), start);
+            let wakeup = eng.next_wakeup().unwrap();
+            let frames = eng.tick(wakeup);
+            assert_eq!(frames.len(), 1);
+            assert_eq!(eng.counters()[&5].tx_ra_unsolicited, 1);
+            assert_eq!(eng.counters()[&5].tx_ra_solicited, 0);
+        }
+
+        // (b) Solicited: enable, send RS before any tick, tick at the
+        //     solicited wakeup → tx_ra_solicited == 1.
+        //
+        // We need a deterministic RNG so we know exactly when the
+        // solicited reply will fire. Use RaSender::with_rng with a
+        // FixedRng that returns a very long initial delay so the first
+        // tick we care about is the solicited one.
+        {
+            // We drive this sub-test entirely through NdEngine's public
+            // API. The trick: enable the interface with a large
+            // max_interval so the first unsolicited fires far in the
+            // future; then send an RS; the solicited wakeup is within
+            // MAX_RA_DELAY_TIME (500ms) of `start`.
+            use crate::nd::send::{MAX_RA_DELAY_TIME, MIN_DELAY_BETWEEN_RAS};
+
+            let start = t0();
+            let mut eng = NdEngine::new();
+            // Large intervals push the unsolicited RA far into the future.
+            let cfg = RaSendConfig {
+                min_interval: Duration::from_secs(3600),
+                max_interval: Duration::from_secs(7200),
+                ..RaSendConfig::default()
+            };
+            eng.enable_interface(5, cfg, start);
+            let initial_wakeup = eng.next_wakeup().unwrap();
+
+            // Receive an RS — this schedules a solicited reply.
+            eng.on_recv(
+                NdRecv::RouterSolicit {
+                    ifindex: 5,
+                    src: ll("fe80::c1"),
+                    rs: RouterSolicit::default(),
+                },
+                start,
+            );
+
+            let solicited_wakeup = eng.next_wakeup().unwrap();
+            assert!(
+                solicited_wakeup < initial_wakeup,
+                "solicited wakeup should be earlier than the unsolicited one"
+            );
+            // Solicited wakeup must be within MAX_RA_DELAY_TIME of start
+            // (plus MIN_DELAY_BETWEEN_RAS in case we just sent — but we
+            // haven't sent yet so the rate-limit doesn't apply).
+            assert!(
+                solicited_wakeup <= start + MAX_RA_DELAY_TIME + MIN_DELAY_BETWEEN_RAS,
+                "solicited wakeup should be within the delay window"
+            );
+
+            let frames = eng.tick(solicited_wakeup);
+            // The solicited RA should fire; the unsolicited one should not.
+            assert!(!frames.is_empty(), "expected at least one frame");
+            assert_eq!(
+                eng.counters()
+                    .get(&5)
+                    .map(|c| c.tx_ra_solicited)
+                    .unwrap_or(0),
+                1,
+                "tx_ra_solicited should be 1"
+            );
+            // Unsolicited counter must still be 0.
+            assert_eq!(
+                eng.counters()
+                    .get(&5)
+                    .map(|c| c.tx_ra_unsolicited)
+                    .unwrap_or(0),
+                0,
+                "tx_ra_unsolicited should remain 0"
+            );
+        }
     }
 }

--- a/zebra-rs/src/nd/inst.rs
+++ b/zebra-rs/src/nd/inst.rs
@@ -17,7 +17,9 @@ use tokio::io::unix::AsyncFd;
 use tokio::sync::mpsc::{self, UnboundedReceiver, UnboundedSender};
 use tokio::time::sleep_until;
 
-use crate::config::{ConfigChannel, ConfigRequest, path_from_command};
+use crate::config::{
+    Args, ConfigChannel, ConfigRequest, DisplayRequest, ShowChannel, path_from_command,
+};
 use crate::context::Task;
 use crate::rib::api::RibRx;
 
@@ -26,6 +28,11 @@ use super::engine::{NdEngine, NdEvent};
 use super::network::{read_packet, write_packet};
 use super::send::RaSendConfig;
 use super::{NdRecv, NdSend};
+
+/// `show nd ...` dispatch handler. Mirrors [`crate::bfd::inst::ShowCallback`]:
+/// given the Nd instance, parsed trailing [`Args`], and the JSON flag,
+/// renders the response text.
+pub type ShowCallback = fn(&Nd, Args, bool) -> Result<String, std::fmt::Error>;
 
 /// Control requests from external clients (the YANG callback layer
 /// in RA-5, BGP unnumbered for the `SetNotifier` variant, and tests).
@@ -57,6 +64,14 @@ pub struct Nd {
     /// Config-manager subscription endpoints. The receive half drains
     /// in the event loop and feeds [`Self::process_cm_msg`].
     pub cm: ConfigChannel,
+    /// `show ipv6 nd ...` subscription endpoints. The receive half
+    /// drains in the event loop and dispatches through
+    /// [`Self::show_cb`].
+    pub show: ShowChannel,
+    /// Show callback table — path → handler — populated by
+    /// [`Self::show_build`] (in `super::show`) and consulted by
+    /// [`Self::process_show_msg`].
+    pub show_cb: HashMap<String, ShowCallback>,
     /// Callback table — path → handler — populated by
     /// [`Self::callback_build`] (in `super::config`) and consumed by
     /// [`Self::process_cm_msg`].
@@ -102,11 +117,14 @@ impl Nd {
             client_tx,
             rib_rx,
             cm: ConfigChannel::new(),
+            show: ShowChannel::new(),
+            show_cb: HashMap::new(),
             callbacks: HashMap::new(),
             _read_task: read_task,
             _write_task: write_task,
         };
         nd.callback_build();
+        nd.show_build();
         nd
     }
 
@@ -164,6 +182,9 @@ impl Nd {
                 Some(cmsg) = self.cm.rx.recv() => {
                     self.process_cm_msg(cmsg);
                 }
+                Some(smsg) = self.show.rx.recv() => {
+                    self.process_show_msg(smsg).await;
+                }
                 _ = sleep_until_opt(wakeup) => {
                     let now = Instant::now();
                     for frame in self.engine.tick(now) {
@@ -191,6 +212,17 @@ impl Nd {
         let (path, args) = path_from_command(&msg.paths);
         if let Some(f) = self.callbacks.get(&path).copied() {
             f(self, args, msg.op);
+        }
+    }
+
+    async fn process_show_msg(&self, msg: DisplayRequest) {
+        let (path, args) = path_from_command(&msg.paths);
+        if let Some(f) = self.show_cb.get(&path) {
+            let output = match f(self, args, msg.json) {
+                Ok(result) => result,
+                Err(e) => format!("Error formatting output: {}", e),
+            };
+            let _ = msg.resp.send(output).await;
         }
     }
 

--- a/zebra-rs/src/nd/mod.rs
+++ b/zebra-rs/src/nd/mod.rs
@@ -4,8 +4,11 @@
 //! This module is the runtime counterpart to the `nd-packet` crate: it
 //! brings up a raw `IPPROTO_ICMPV6` socket configured per RFC 4861
 //! §6.1 (hop limit = 255 on both send and receive, ICMP6_FILTER scoped
-//! to RS + RA only) and provides async read / write tasks that hand
-//! parsed packets to the rest of the daemon via channels.
+//! to RS + RA + NS + NA) and provides async read / write tasks that
+//! hand parsed packets to the rest of the daemon via channels.
+//!
+//! NS (135) and NA (136) are passively observed for counters and
+//! diagnostics; the host kernel still owns the NDP cache.
 //!
 //! Higher-level concerns (per-interface RA send state machine, RIB
 //! integration, BGP unnumbered hand-off) live in follow-up PRs. The
@@ -15,7 +18,7 @@
 
 use std::net::Ipv6Addr;
 
-use nd_packet::{RouterAdvert, RouterSolicit};
+use nd_packet::{NeighborAdvert, NeighborSolicit, RouterAdvert, RouterSolicit};
 
 pub mod config;
 pub mod engine;
@@ -37,6 +40,32 @@ pub enum NdRecv {
         src: Ipv6Addr,
         rs: RouterSolicit,
     },
+    NeighborSolicit {
+        ifindex: u32,
+        src: Ipv6Addr,
+        ns: NeighborSolicit,
+    },
+    NeighborAdvert {
+        ifindex: u32,
+        src: Ipv6Addr,
+        na: NeighborAdvert,
+    },
+    /// A packet failed RFC 4861 receive validation (hop-limit ≠ 255 or
+    /// malformed payload) and was dropped. Carried up so the engine can
+    /// count drops per interface without touching any atomics in the I/O
+    /// task.
+    Dropped { ifindex: u32, reason: DropReason },
+}
+
+/// Reason a received ICMPv6 ND packet was discarded before delivery.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DropReason {
+    /// IPv6 hop limit was not 255 — RFC 4861 §6.1.2 MUST silently
+    /// discard.
+    HopLimit,
+    /// Packet was too short, had a non-zero ICMPv6 code, or an option
+    /// was malformed.
+    Malformed,
 }
 
 /// Outbound ND messages consumed by [`network::write_packet`].

--- a/zebra-rs/src/nd/mod.rs
+++ b/zebra-rs/src/nd/mod.rs
@@ -25,6 +25,7 @@ pub mod engine;
 pub mod inst;
 pub mod network;
 pub mod send;
+pub mod show;
 pub mod socket;
 
 /// Inbound ND messages produced by [`network::read_packet`].

--- a/zebra-rs/src/nd/network.rs
+++ b/zebra-rs/src/nd/network.rs
@@ -93,6 +93,10 @@ pub async fn read_packet(sock: Arc<AsyncFd<Socket>>, tx: UnboundedSender<NdRecv>
                         Ok(rs) => NdRecv::RouterSolicit { ifindex, src, rs },
                         Err(_) => return Ok(()),
                     },
+                    // NS/NA are filtered out at the socket (ICMP6_FILTER in
+                    // socket.rs) and will be handled when the ND engine grows
+                    // counters — for now drop, preserving current behaviour.
+                    Some(_) => return Ok(()),
                     None => return Ok(()),
                 };
 

--- a/zebra-rs/src/nd/network.rs
+++ b/zebra-rs/src/nd/network.rs
@@ -4,11 +4,14 @@
 //! `crate::ospf::network` so the runtime wiring (channels, cmsg
 //! plumbing, `AsyncFd::async_io`) is familiar.
 //!
-//! Inbound packets are filtered to ICMPv6 RA + RS by the kernel
-//! (`ICMP6_FILTER` was set in [`super::socket::nd_socket`]); we add
-//! one more application-layer check here: drop anything whose
-//! IPv6 hop limit isn't 255, per RFC 4861 §6.1.2. The kernel can't
-//! enforce that on raw sockets, so it's our job.
+//! Inbound packets are filtered to ICMPv6 RS + RA + NS + NA by the
+//! kernel (`ICMP6_FILTER` was set in [`super::socket::nd_socket`]); we
+//! add one more application-layer check here: drop anything whose IPv6
+//! hop limit isn't 255, per RFC 4861 §6.1.2. The kernel can't enforce
+//! that on raw sockets, so it's our job.
+//!
+//! Drops are surfaced as [`NdRecv::Dropped`] so the engine (not the I/O
+//! task) is the single place where every counter increments.
 #![allow(dead_code)]
 
 use std::io::{ErrorKind, IoSlice, IoSliceMut};
@@ -17,14 +20,14 @@ use std::os::fd::AsRawFd;
 use std::sync::Arc;
 
 use bytes::BytesMut;
-use nd_packet::{Icmp6Type, RouterAdvert, RouterSolicit};
+use nd_packet::{Icmp6Type, NeighborAdvert, NeighborSolicit, RouterAdvert, RouterSolicit};
 use nix::sys::socket::{self, ControlMessageOwned, SockaddrIn6};
 use socket2::Socket;
 use tokio::io::Interest;
 use tokio::io::unix::AsyncFd;
 use tokio::sync::mpsc::{UnboundedReceiver, UnboundedSender};
 
-use super::{NdRecv, NdSend};
+use super::{DropReason, NdRecv, NdSend};
 
 /// Hop limit required by RFC 4861 §6.1.2 — anything else is dropped.
 const REQUIRED_HOP_LIMIT: i32 = 255;
@@ -33,9 +36,9 @@ const REQUIRED_HOP_LIMIT: i32 = 255;
 const ALL_ROUTERS: Ipv6Addr = Ipv6Addr::new(0xff02, 0, 0, 0, 0, 0, 0, 0x2);
 
 /// Read loop: parse ICMPv6 packets off the raw socket, deliver
-/// [`NdRecv`] messages on `tx`. Drops malformed packets and packets
-/// failing the hop-limit-255 check silently — both situations are
-/// "MUST silently discard" in RFC 4861.
+/// [`NdRecv`] messages on `tx`. Drops are surfaced as
+/// [`NdRecv::Dropped`] so the engine counts them; the read task never
+/// increments counters directly.
 pub async fn read_packet(sock: Arc<AsyncFd<Socket>>, tx: UnboundedSender<NdRecv>) {
     let mut buf = [0u8; 1500];
     let mut iov = [IoSliceMut::new(&mut buf)];
@@ -73,7 +76,13 @@ pub async fn read_packet(sock: Arc<AsyncFd<Socket>>, tx: UnboundedSender<NdRecv>
                     return Err(ErrorKind::InvalidData.into());
                 };
                 if hop_limit != REQUIRED_HOP_LIMIT {
-                    // RFC 4861 §6.1.2: silently drop.
+                    // RFC 4861 §6.1.2: MUST silently discard any ND
+                    // message with a hop limit other than 255. Surface
+                    // this as a Dropped message so the engine counts it.
+                    let _ = tx.send(NdRecv::Dropped {
+                        ifindex,
+                        reason: DropReason::HopLimit,
+                    });
                     return Ok(());
                 }
 
@@ -87,16 +96,49 @@ pub async fn read_packet(sock: Arc<AsyncFd<Socket>>, tx: UnboundedSender<NdRecv>
                 let parsed = match Icmp6Type::from_u8(payload[0]) {
                     Some(Icmp6Type::RouterAdvert) => match RouterAdvert::parse(payload, None) {
                         Ok(ra) => NdRecv::RouterAdvert { ifindex, src, ra },
-                        Err(_) => return Ok(()),
+                        Err(_) => {
+                            let _ = tx.send(NdRecv::Dropped {
+                                ifindex,
+                                reason: DropReason::Malformed,
+                            });
+                            return Ok(());
+                        }
                     },
                     Some(Icmp6Type::RouterSolicit) => match RouterSolicit::parse(payload, None) {
                         Ok(rs) => NdRecv::RouterSolicit { ifindex, src, rs },
-                        Err(_) => return Ok(()),
+                        Err(_) => {
+                            let _ = tx.send(NdRecv::Dropped {
+                                ifindex,
+                                reason: DropReason::Malformed,
+                            });
+                            return Ok(());
+                        }
                     },
-                    // NS/NA are filtered out at the socket (ICMP6_FILTER in
-                    // socket.rs) and will be handled when the ND engine grows
-                    // counters — for now drop, preserving current behaviour.
-                    Some(_) => return Ok(()),
+                    Some(Icmp6Type::NeighborSolicit) => {
+                        match NeighborSolicit::parse(payload, None) {
+                            Ok(ns) => NdRecv::NeighborSolicit { ifindex, src, ns },
+                            Err(_) => {
+                                let _ = tx.send(NdRecv::Dropped {
+                                    ifindex,
+                                    reason: DropReason::Malformed,
+                                });
+                                return Ok(());
+                            }
+                        }
+                    }
+                    Some(Icmp6Type::NeighborAdvert) => match NeighborAdvert::parse(payload, None) {
+                        Ok(na) => NdRecv::NeighborAdvert { ifindex, src, na },
+                        Err(_) => {
+                            let _ = tx.send(NdRecv::Dropped {
+                                ifindex,
+                                reason: DropReason::Malformed,
+                            });
+                            return Ok(());
+                        }
+                    },
+                    // Unknown numeric type — `from_u8` returns None for
+                    // anything outside 133-136. The ICMP6_FILTER in
+                    // socket.rs makes this path unreachable in production.
                     None => return Ok(()),
                 };
 

--- a/zebra-rs/src/nd/send.rs
+++ b/zebra-rs/src/nd/send.rs
@@ -147,6 +147,35 @@ impl<R: RngSource> RaSender<R> {
         }
     }
 
+    // ── Read accessors for show ──────────────────────────────────────────
+
+    /// The current RA send configuration template.
+    pub fn cfg(&self) -> &RaSendConfig {
+        &self.cfg
+    }
+
+    /// Number of initial RAs still to send before switching to the
+    /// periodic schedule (counts down from
+    /// [`MAX_INITIAL_RTR_ADVERTISEMENTS`]).
+    pub fn initial_remaining(&self) -> u32 {
+        self.initial_remaining
+    }
+
+    /// Scheduled time for the next unsolicited RA.
+    pub fn next_unsolicited_at(&self) -> Instant {
+        self.next_unsolicited_at
+    }
+
+    /// Scheduled time for the pending solicited reply, if any.
+    pub fn pending_solicited_at(&self) -> Option<Instant> {
+        self.pending_solicited_at
+    }
+
+    /// Time of the most recent multicast RA we sent, if any.
+    pub fn last_multicast_at(&self) -> Option<Instant> {
+        self.last_multicast_at
+    }
+
     /// Update the template fields (router lifetime, options, etc.).
     /// Doesn't reschedule — operators tweaking timers don't expect a
     /// burst of RAs.

--- a/zebra-rs/src/nd/show.rs
+++ b/zebra-rs/src/nd/show.rs
@@ -1,0 +1,853 @@
+//! `show ipv6 nd ...` command handlers.
+//!
+//! Mirrors the show-command pattern used by [`crate::bfd::show`]:
+//! [`Nd::show_build`] registers a handler per path, the event loop
+//! dispatches through [`super::inst::Nd::process_show_msg`], and each
+//! handler renders read-only state from the live [`super::engine::NdEngine`].
+//!
+//! Two commands are exposed:
+//!   * `show ipv6 nd`                     — one-line-per-interface summary.
+//!   * `show ipv6 nd interface [IFNAME]`  — detailed block(s), all or one.
+//!
+//! Every command also accepts a trailing `json` keyword (surfaced as
+//! the `json` flag) for machine-readable output.
+
+use std::collections::BTreeSet;
+use std::fmt::Write;
+use std::time::Instant;
+
+use serde::Serialize;
+
+use crate::config::{Args, Builder};
+
+use super::engine::{NdIfCounters, NdNeighbor};
+use super::inst::{Nd, ShowCallback};
+
+impl Nd {
+    pub fn show_build(&mut self) {
+        self.show_cb = Builder::<ShowCallback>::default()
+            .path("/show/ipv6/nd")
+            .set(show_nd_summary)
+            .path("/show/ipv6/nd/interface")
+            .set(show_nd_interface)
+            .map();
+    }
+}
+
+// ── Kernel /proc/net/dev_snmp6 reader ───────────────────────────────────────
+
+/// Eight counters extracted from `/proc/net/dev_snmp6/<ifname>`.
+///
+/// A `None` for the whole struct means the file was unreadable (interface
+/// missing or permission denied); rendered as `-` in text output.
+#[derive(Debug, Default, Clone, Serialize)]
+pub struct KernelNdCounters {
+    pub in_router_solicits: u64,
+    pub out_router_solicits: u64,
+    pub in_router_advertisements: u64,
+    pub out_router_advertisements: u64,
+    pub in_neighbor_solicits: u64,
+    pub out_neighbor_solicits: u64,
+    pub in_neighbor_advertisements: u64,
+    pub out_neighbor_advertisements: u64,
+}
+
+/// Parse the whitespace-separated `Name\tValue` lines from
+/// `/proc/net/dev_snmp6/<ifname>` content, extracting the eight
+/// ICMPv6 ND counters. Unrecognised lines are silently ignored.
+pub fn parse_dev_snmp6(content: &str) -> KernelNdCounters {
+    let mut c = KernelNdCounters::default();
+    for line in content.lines() {
+        let mut parts = line.split_whitespace();
+        let name = match parts.next() {
+            Some(n) => n,
+            None => continue,
+        };
+        let value: u64 = match parts.next().and_then(|v| v.parse().ok()) {
+            Some(v) => v,
+            None => continue,
+        };
+        match name {
+            "Icmp6InRouterSolicits" => c.in_router_solicits = value,
+            "Icmp6OutRouterSolicits" => c.out_router_solicits = value,
+            "Icmp6InRouterAdvertisements" => c.in_router_advertisements = value,
+            "Icmp6OutRouterAdvertisements" => c.out_router_advertisements = value,
+            "Icmp6InNeighborSolicits" => c.in_neighbor_solicits = value,
+            "Icmp6OutNeighborSolicits" => c.out_neighbor_solicits = value,
+            "Icmp6InNeighborAdvertisements" => c.in_neighbor_advertisements = value,
+            "Icmp6OutNeighborAdvertisements" => c.out_neighbor_advertisements = value,
+            _ => {}
+        }
+    }
+    c
+}
+
+/// Read `/proc/net/dev_snmp6/<ifname>` and parse it. Returns `None`
+/// when the file is absent or unreadable (interface gone, no
+/// `CAP_NET_ADMIN`, etc.).
+fn read_kernel_counters(ifname: &str) -> Option<KernelNdCounters> {
+    let path = format!("/proc/net/dev_snmp6/{}", ifname);
+    let content = std::fs::read_to_string(path).ok()?;
+    Some(parse_dev_snmp6(&content))
+}
+
+// ── Duration formatting helper ───────────────────────────────────────────────
+
+/// Format a `u64` seconds value as a human-readable duration string.
+/// `0` → `"0s"`, `65` → `"1m5s"`, `3661` → `"1h1m1s"`.
+fn fmt_duration(secs: u64) -> String {
+    if secs < 60 {
+        format!("{}s", secs)
+    } else if secs < 3600 {
+        let m = secs / 60;
+        let s = secs % 60;
+        if s == 0 {
+            format!("{}m", m)
+        } else {
+            format!("{}m{}s", m, s)
+        }
+    } else {
+        let h = secs / 3600;
+        let m = (secs % 3600) / 60;
+        let s = secs % 60;
+        if m == 0 && s == 0 {
+            format!("{}h", h)
+        } else if s == 0 {
+            format!("{}h{}m", h, m)
+        } else {
+            format!("{}h{}m{}s", h, m, s)
+        }
+    }
+}
+
+/// Render the number of seconds since `past` relative to `now`.
+/// Uses `saturating_duration_since` so the result is always ≥ 0.
+fn ago(now: Instant, past: Instant) -> String {
+    let secs = now.saturating_duration_since(past).as_secs();
+    format!("{} ago", fmt_duration(secs))
+}
+
+/// Render the number of seconds until `future` relative to `now`.
+/// If `future` is already past, renders `"0s"`.
+fn until(now: Instant, future: Instant) -> String {
+    let secs = future.saturating_duration_since(now).as_secs();
+    fmt_duration(secs)
+}
+
+// ── JSON DTO structs ─────────────────────────────────────────────────────────
+
+#[derive(Serialize)]
+struct JsonNeighbor {
+    address: String,
+    first_seen_secs: u64,
+    last_seen_secs: u64,
+    rx_ra: u64,
+    rx_rs: u64,
+    rx_ns: u64,
+    rx_na: u64,
+    last_ra_lifetime: Option<u16>,
+    last_ra_hop_limit: Option<u8>,
+    last_ra_managed: Option<bool>,
+    last_ra_other: Option<bool>,
+}
+
+#[derive(Serialize)]
+struct JsonCounters {
+    tx_ra_unsolicited: u64,
+    tx_ra_solicited: u64,
+    rx_ra: u64,
+    rx_rs: u64,
+    rx_ns: u64,
+    rx_na: u64,
+    rx_drop_hop_limit: u64,
+    rx_drop_malformed: u64,
+    untracked_sources: u64,
+}
+
+#[derive(Serialize)]
+struct JsonRaScheduler {
+    min_interval_secs: u64,
+    max_interval_secs: u64,
+    router_lifetime: u16,
+    cur_hop_limit: u8,
+    managed: bool,
+    other: bool,
+    initial_remaining: u32,
+    next_unsolicited_in_secs: u64,
+    solicited_pending: bool,
+    last_multicast_secs_ago: Option<u64>,
+}
+
+#[derive(Serialize)]
+struct JsonInterface {
+    name: String,
+    ifindex: u32,
+    ra_enabled: bool,
+    ra_scheduler: Option<JsonRaScheduler>,
+    counters: JsonCounters,
+    kernel_counters: Option<KernelNdCounters>,
+    neighbors: Vec<JsonNeighbor>,
+}
+
+#[derive(Serialize)]
+struct JsonSummaryRow {
+    name: String,
+    ifindex: u32,
+    ra_enabled: bool,
+    neighbor_count: usize,
+    rx_total: u64,
+    tx_total: u64,
+}
+
+// ── Per-interface render helper ──────────────────────────────────────────────
+
+/// Collect all ifindexes that appear in any of the three maps:
+/// senders, counters, neighbors.
+fn all_ifindexes(nd: &super::engine::NdEngine) -> BTreeSet<u32> {
+    let mut set = BTreeSet::new();
+    for &k in nd.senders().keys() {
+        set.insert(k);
+    }
+    for &k in nd.counters().keys() {
+        set.insert(k);
+    }
+    for &k in nd.neighbors().keys() {
+        set.insert(k);
+    }
+    set
+}
+
+/// Render one interface's detail block (text).
+fn render_interface_text(
+    out: &mut String,
+    nd: &super::engine::NdEngine,
+    ifindex: u32,
+    now: Instant,
+) -> std::fmt::Result {
+    let ifname = nd
+        .ifname_of(ifindex)
+        .map(|s| s.to_string())
+        .unwrap_or_else(|| format!("if{}", ifindex));
+
+    writeln!(out, "Interface {} (ifindex {})", ifname, ifindex)?;
+
+    // ── RA scheduler ────────────────────────────────────────────────────
+    if let Some(sender) = nd.sender(ifindex) {
+        let cfg = sender.cfg();
+        let flags = cfg.flags;
+        let managed = if flags.contains(nd_packet::RaFlags::M) {
+            1
+        } else {
+            0
+        };
+        let other = if flags.contains(nd_packet::RaFlags::O) {
+            1
+        } else {
+            0
+        };
+        writeln!(out, "  Router advertisement: enabled")?;
+        writeln!(
+            out,
+            "    interval {}-{}s, lifetime {}s, hop-limit {}, managed={} other={}",
+            cfg.min_interval.as_secs(),
+            cfg.max_interval.as_secs(),
+            cfg.router_lifetime,
+            cfg.cur_hop_limit,
+            managed,
+            other
+        )?;
+        let next_in = until(now, sender.next_unsolicited_at());
+        writeln!(
+            out,
+            "    initial advertisements remaining {}, next unsolicited in {}",
+            sender.initial_remaining(),
+            next_in
+        )?;
+        let solicited = match sender.pending_solicited_at() {
+            Some(_) => "yes".to_string(),
+            None => "no".to_string(),
+        };
+        let last_mc = match sender.last_multicast_at() {
+            Some(t) => ago(now, t),
+            None => "never".to_string(),
+        };
+        writeln!(
+            out,
+            "    solicited reply pending: {}, last multicast {}",
+            solicited, last_mc
+        )?;
+    } else {
+        writeln!(out, "  Router advertisement: disabled")?;
+    }
+
+    // ── Daemon-observed counters ─────────────────────────────────────────
+    let empty_counters = NdIfCounters::default();
+    let c = nd.counters().get(&ifindex).unwrap_or(&empty_counters);
+    let tx_ra = c.tx_ra_unsolicited + c.tx_ra_solicited;
+
+    writeln!(out, "  Counters (daemon-observed)        Sent  Received")?;
+    writeln!(
+        out,
+        "    Router solicitations         {:>7}  {:>8}",
+        "-", c.rx_rs
+    )?;
+    writeln!(
+        out,
+        "    Router advertisements        {:>7}  {:>8}",
+        tx_ra, c.rx_ra
+    )?;
+    writeln!(
+        out,
+        "    Neighbor solicitations       {:>7}  {:>8}",
+        "-", c.rx_ns
+    )?;
+    writeln!(
+        out,
+        "    Neighbor advertisements      {:>7}  {:>8}",
+        "-", c.rx_na
+    )?;
+    writeln!(
+        out,
+        "    dropped: hop-limit {}, malformed {}, untracked sources {}",
+        c.rx_drop_hop_limit, c.rx_drop_malformed, c.untracked_sources
+    )?;
+
+    // ── Kernel counters ─────────────────────────────────────────────────
+    writeln!(out, "  Counters (kernel)                 Sent  Received")?;
+    match read_kernel_counters(&ifname) {
+        Some(k) => {
+            writeln!(
+                out,
+                "    Router solicitations         {:>7}  {:>8}",
+                k.out_router_solicits, k.in_router_solicits
+            )?;
+            writeln!(
+                out,
+                "    Router advertisements        {:>7}  {:>8}",
+                k.out_router_advertisements, k.in_router_advertisements
+            )?;
+            writeln!(
+                out,
+                "    Neighbor solicitations       {:>7}  {:>8}",
+                k.out_neighbor_solicits, k.in_neighbor_solicits
+            )?;
+            writeln!(
+                out,
+                "    Neighbor advertisements      {:>7}  {:>8}",
+                k.out_neighbor_advertisements, k.in_neighbor_advertisements
+            )?;
+        }
+        None => {
+            writeln!(out, "    (unavailable)")?;
+        }
+    }
+
+    // ── Neighbor table ───────────────────────────────────────────────────
+    let empty_table = std::collections::BTreeMap::new();
+    let table = nd.neighbors().get(&ifindex).unwrap_or(&empty_table);
+    writeln!(out, "  Neighbors ({}):", table.len())?;
+    for (addr, nb) in table {
+        render_neighbor_text(out, addr, nb, now)?;
+    }
+
+    Ok(())
+}
+
+fn render_neighbor_text(
+    out: &mut String,
+    addr: &std::net::Ipv6Addr,
+    nb: &NdNeighbor,
+    now: Instant,
+) -> std::fmt::Result {
+    let first = ago(now, nb.first_seen);
+    let last = ago(now, nb.last_seen);
+    let is_dad = *addr == std::net::Ipv6Addr::UNSPECIFIED;
+
+    if is_dad {
+        writeln!(
+            out,
+            "    {:<24} RA {}  RS {}  NS {}  NA {}   first {}, last {} (duplicate address detection)",
+            addr, nb.rx_ra, nb.rx_rs, nb.rx_ns, nb.rx_na, first, last
+        )?;
+    } else {
+        writeln!(
+            out,
+            "    {:<24} RA {}  RS {}  NS {}  NA {}   first {}, last {}",
+            addr, nb.rx_ra, nb.rx_rs, nb.rx_ns, nb.rx_na, first, last
+        )?;
+    }
+
+    if let Some(lr) = &nb.last_ra {
+        let managed = if lr.flags.contains(nd_packet::RaFlags::M) {
+            1
+        } else {
+            0
+        };
+        let other = if lr.flags.contains(nd_packet::RaFlags::O) {
+            1
+        } else {
+            0
+        };
+        writeln!(
+            out,
+            "      last RA: lifetime {}s hop-limit {} M={} O={}",
+            lr.router_lifetime, lr.cur_hop_limit, managed, other
+        )?;
+    }
+
+    Ok(())
+}
+
+/// Build the JSON DTO for a single interface.
+fn build_interface_json(nd: &super::engine::NdEngine, ifindex: u32, now: Instant) -> JsonInterface {
+    let ifname = nd
+        .ifname_of(ifindex)
+        .map(|s| s.to_string())
+        .unwrap_or_else(|| format!("if{}", ifindex));
+
+    let ra_enabled = nd.sender(ifindex).is_some();
+
+    let ra_scheduler = nd.sender(ifindex).map(|sender| {
+        let cfg = sender.cfg();
+        JsonRaScheduler {
+            min_interval_secs: cfg.min_interval.as_secs(),
+            max_interval_secs: cfg.max_interval.as_secs(),
+            router_lifetime: cfg.router_lifetime,
+            cur_hop_limit: cfg.cur_hop_limit,
+            managed: cfg.flags.contains(nd_packet::RaFlags::M),
+            other: cfg.flags.contains(nd_packet::RaFlags::O),
+            initial_remaining: sender.initial_remaining(),
+            next_unsolicited_in_secs: sender
+                .next_unsolicited_at()
+                .saturating_duration_since(now)
+                .as_secs(),
+            solicited_pending: sender.pending_solicited_at().is_some(),
+            last_multicast_secs_ago: sender
+                .last_multicast_at()
+                .map(|t| now.saturating_duration_since(t).as_secs()),
+        }
+    });
+
+    let empty_c = NdIfCounters::default();
+    let c = nd.counters().get(&ifindex).unwrap_or(&empty_c);
+    let counters = JsonCounters {
+        tx_ra_unsolicited: c.tx_ra_unsolicited,
+        tx_ra_solicited: c.tx_ra_solicited,
+        rx_ra: c.rx_ra,
+        rx_rs: c.rx_rs,
+        rx_ns: c.rx_ns,
+        rx_na: c.rx_na,
+        rx_drop_hop_limit: c.rx_drop_hop_limit,
+        rx_drop_malformed: c.rx_drop_malformed,
+        untracked_sources: c.untracked_sources,
+    };
+
+    let kernel_counters = read_kernel_counters(&ifname);
+
+    let empty_table = std::collections::BTreeMap::new();
+    let table = nd.neighbors().get(&ifindex).unwrap_or(&empty_table);
+    let neighbors: Vec<JsonNeighbor> = table
+        .iter()
+        .map(|(addr, nb)| {
+            let (lr_lifetime, lr_hop_limit, lr_managed, lr_other) = if let Some(lr) = &nb.last_ra {
+                (
+                    Some(lr.router_lifetime),
+                    Some(lr.cur_hop_limit),
+                    Some(lr.flags.contains(nd_packet::RaFlags::M)),
+                    Some(lr.flags.contains(nd_packet::RaFlags::O)),
+                )
+            } else {
+                (None, None, None, None)
+            };
+            JsonNeighbor {
+                address: addr.to_string(),
+                first_seen_secs: now.saturating_duration_since(nb.first_seen).as_secs(),
+                last_seen_secs: now.saturating_duration_since(nb.last_seen).as_secs(),
+                rx_ra: nb.rx_ra,
+                rx_rs: nb.rx_rs,
+                rx_ns: nb.rx_ns,
+                rx_na: nb.rx_na,
+                last_ra_lifetime: lr_lifetime,
+                last_ra_hop_limit: lr_hop_limit,
+                last_ra_managed: lr_managed,
+                last_ra_other: lr_other,
+            }
+        })
+        .collect();
+
+    JsonInterface {
+        name: ifname,
+        ifindex,
+        ra_enabled,
+        ra_scheduler,
+        counters,
+        kernel_counters,
+        neighbors,
+    }
+}
+
+// ── Show handlers ────────────────────────────────────────────────────────────
+
+/// `show ipv6 nd` — one-line-per-interface summary.
+fn show_nd_summary(nd: &Nd, _args: Args, json: bool) -> Result<String, std::fmt::Error> {
+    let engine = nd.engine();
+    let ifindexes = all_ifindexes(engine);
+
+    if json {
+        let rows: Vec<JsonSummaryRow> = ifindexes
+            .iter()
+            .map(|&ifindex| {
+                let ifname = engine
+                    .ifname_of(ifindex)
+                    .map(|s| s.to_string())
+                    .unwrap_or_else(|| format!("if{}", ifindex));
+                let ra_enabled = engine.sender(ifindex).is_some();
+                let empty_table = std::collections::BTreeMap::new();
+                let table = engine.neighbors().get(&ifindex).unwrap_or(&empty_table);
+                let neighbor_count = table.len();
+                let empty_c = NdIfCounters::default();
+                let c = engine.counters().get(&ifindex).unwrap_or(&empty_c);
+                let rx_total = c.rx_ra + c.rx_rs + c.rx_ns + c.rx_na;
+                let tx_total = c.tx_ra_unsolicited + c.tx_ra_solicited;
+                JsonSummaryRow {
+                    name: ifname,
+                    ifindex,
+                    ra_enabled,
+                    neighbor_count,
+                    rx_total,
+                    tx_total,
+                }
+            })
+            .collect();
+        let s = serde_json::to_string_pretty(&rows)
+            .unwrap_or_else(|e| format!("{{\"error\":\"{}\"}}", e));
+        return Ok(s);
+    }
+
+    let mut out = String::new();
+    if ifindexes.is_empty() {
+        writeln!(out, "No ND interfaces.")?;
+        return Ok(out);
+    }
+
+    writeln!(
+        out,
+        "{:<20} {:<4} {:>9} {:>10} {:>8} {:>8}",
+        "Interface", "RA", "Neighbors", "RX-total", "TX-total", "Ifindex"
+    )?;
+    for &ifindex in &ifindexes {
+        let ifname = engine
+            .ifname_of(ifindex)
+            .map(|s| s.to_string())
+            .unwrap_or_else(|| format!("if{}", ifindex));
+        let ra_label = if engine.sender(ifindex).is_some() {
+            "on"
+        } else {
+            "off"
+        };
+        let empty_table = std::collections::BTreeMap::new();
+        let table = engine.neighbors().get(&ifindex).unwrap_or(&empty_table);
+        let neighbor_count = table.len();
+        let empty_c = NdIfCounters::default();
+        let c = engine.counters().get(&ifindex).unwrap_or(&empty_c);
+        let rx_total = c.rx_ra + c.rx_rs + c.rx_ns + c.rx_na;
+        let tx_total = c.tx_ra_unsolicited + c.tx_ra_solicited;
+        writeln!(
+            out,
+            "{:<20} {:<4} {:>9} {:>10} {:>8} {:>8}",
+            ifname, ra_label, neighbor_count, rx_total, tx_total, ifindex
+        )?;
+    }
+    Ok(out)
+}
+
+/// `show ipv6 nd interface [IFNAME]` — detailed block(s).
+fn show_nd_interface(nd: &Nd, mut args: Args, json: bool) -> Result<String, std::fmt::Error> {
+    let engine = nd.engine();
+    let now = Instant::now();
+
+    // Optional interface name filter.
+    let ifname_filter = args.string();
+
+    if json {
+        let ifindexes: Vec<u32> = if let Some(ref name) = ifname_filter {
+            match engine.ifindex_of(name) {
+                Some(idx) => vec![idx],
+                None => {
+                    let msg =
+                        serde_json::json!({ "error": format!("interface {} not found", name) });
+                    return Ok(serde_json::to_string_pretty(&msg)
+                        .unwrap_or_else(|e| format!("{{\"error\":\"{}\"}}", e)));
+                }
+            }
+        } else {
+            all_ifindexes(engine).into_iter().collect()
+        };
+
+        let interfaces: Vec<JsonInterface> = ifindexes
+            .iter()
+            .map(|&idx| build_interface_json(engine, idx, now))
+            .collect();
+        let s = serde_json::to_string_pretty(&interfaces)
+            .unwrap_or_else(|e| format!("{{\"error\":\"{}\"}}", e));
+        return Ok(s);
+    }
+
+    let ifindexes: Vec<u32> = if let Some(ref name) = ifname_filter {
+        match engine.ifindex_of(name) {
+            Some(idx) => vec![idx],
+            None => {
+                return Ok(format!("% interface {} not found\n", name));
+            }
+        }
+    } else {
+        all_ifindexes(engine).into_iter().collect()
+    };
+
+    let mut out = String::new();
+    for (i, &ifindex) in ifindexes.iter().enumerate() {
+        if i > 0 {
+            writeln!(out)?;
+        }
+        render_interface_text(&mut out, engine, ifindex, now)?;
+    }
+    Ok(out)
+}
+
+// ── Unit tests ────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use std::net::Ipv6Addr;
+    use std::time::Instant;
+
+    use nd_packet::{NaFlags, NeighborAdvert, NeighborSolicit, RouterAdvert};
+
+    use crate::nd::engine::NdEngine;
+    use crate::nd::send::RaSendConfig;
+    use crate::nd::{DropReason, NdRecv};
+    use crate::rib::link::{Link, LinkType};
+    use netlink_packet_route::link::LinkFlags;
+
+    use super::*;
+
+    // ── helper builders ──────────────────────────────────────────────────
+
+    fn t0() -> Instant {
+        Instant::now()
+    }
+
+    fn ll(s: &str) -> Ipv6Addr {
+        s.parse().unwrap()
+    }
+
+    fn link(name: &str, index: u32) -> Link {
+        Link {
+            index,
+            name: name.to_string(),
+            mtu: 1500,
+            original_mtu: 1500,
+            metric: 1,
+            flags: LinkFlags::default(),
+            link_type: LinkType::Ethernet,
+            label: false,
+            mac: None,
+            addr4: Vec::new(),
+            addr6: Vec::new(),
+            master: None,
+            vni: None,
+            vxlan_local: None,
+            mtu_error: None,
+        }
+    }
+
+    fn make_ra() -> RouterAdvert {
+        RouterAdvert {
+            cur_hop_limit: 64,
+            flags: nd_packet::RaFlags::empty(),
+            router_lifetime: 1800,
+            reachable_time: 0,
+            retrans_timer: 0,
+            options: vec![],
+        }
+    }
+
+    fn make_ns() -> NeighborSolicit {
+        NeighborSolicit {
+            target: "fe80::ffff".parse().unwrap(),
+            options: vec![],
+        }
+    }
+
+    fn make_na() -> NeighborAdvert {
+        NeighborAdvert {
+            flags: NaFlags::empty(),
+            target: "fe80::ffff".parse().unwrap(),
+            options: vec![],
+        }
+    }
+
+    // ── parse_dev_snmp6 ──────────────────────────────────────────────────
+
+    #[test]
+    fn parse_dev_snmp6_extracts_nd_fields() {
+        let content = "\
+Icmp6InMsgs                         \t7
+Icmp6OutMsgs                        \t12
+Icmp6InRouterSolicits               \t2
+Icmp6OutRouterSolicits              \t0
+Icmp6InRouterAdvertisements         \t13
+Icmp6OutRouterAdvertisements        \t14
+Icmp6InNeighborSolicits             \t5
+Icmp6OutNeighborSolicits            \t9
+Icmp6InNeighborAdvertisements       \t5
+Icmp6OutNeighborAdvertisements      \t5
+Icmp6InUnrelated                    \t99
+";
+        let c = parse_dev_snmp6(content);
+        assert_eq!(c.in_router_solicits, 2);
+        assert_eq!(c.out_router_solicits, 0);
+        assert_eq!(c.in_router_advertisements, 13);
+        assert_eq!(c.out_router_advertisements, 14);
+        assert_eq!(c.in_neighbor_solicits, 5);
+        assert_eq!(c.out_neighbor_solicits, 9);
+        assert_eq!(c.in_neighbor_advertisements, 5);
+        assert_eq!(c.out_neighbor_advertisements, 5);
+    }
+
+    #[test]
+    fn parse_dev_snmp6_ignores_unrelated_lines() {
+        let content = "SomeOtherCounter\t42\nIcmp6InNeighborSolicits\t7\n";
+        let c = parse_dev_snmp6(content);
+        assert_eq!(c.in_neighbor_solicits, 7);
+        // All others stay at zero.
+        assert_eq!(c.in_router_solicits, 0);
+    }
+
+    #[test]
+    fn parse_dev_snmp6_empty_input() {
+        let c = parse_dev_snmp6("");
+        assert_eq!(c.in_neighbor_solicits, 0);
+        assert_eq!(c.out_router_advertisements, 0);
+    }
+
+    // ── text render ─────────────────────────────────────────────────────
+
+    fn build_engine_with_traffic() -> NdEngine {
+        let start = t0();
+        let mut eng = NdEngine::new();
+
+        // Register a link.
+        eng.process_link_add(&link("eth0", 2), start);
+        // Enable RA on it.
+        eng.enable_interface(2, RaSendConfig::default(), start);
+
+        // Receive an RA from a peer.
+        eng.on_recv(
+            NdRecv::RouterAdvert {
+                ifindex: 2,
+                src: ll("fe80::a8aa:aaff:feaa:1"),
+                ra: make_ra(),
+            },
+            start,
+        );
+        // Receive an NS from the same peer.
+        eng.on_recv(
+            NdRecv::NeighborSolicit {
+                ifindex: 2,
+                src: ll("fe80::a8aa:aaff:feaa:1"),
+                ns: make_ns(),
+            },
+            start,
+        );
+        // Receive a DAD probe.
+        eng.on_recv(
+            NdRecv::NeighborSolicit {
+                ifindex: 2,
+                src: "::".parse().unwrap(),
+                ns: make_ns(),
+            },
+            start,
+        );
+        // A drop.
+        eng.on_recv(
+            NdRecv::Dropped {
+                ifindex: 2,
+                reason: DropReason::HopLimit,
+            },
+            start,
+        );
+        eng
+    }
+
+    #[test]
+    fn detail_text_contains_interface_line_and_counters() {
+        let eng = build_engine_with_traffic();
+        let now = t0();
+        let mut out = String::new();
+        render_interface_text(&mut out, &eng, 2, now).unwrap();
+
+        assert!(
+            out.contains("Interface eth0 (ifindex 2)"),
+            "interface header"
+        );
+        // RA counter: we received 1 RA.
+        assert!(out.contains("1"), "rx_ra counter");
+        // NS counter: we received 2 NS.
+        assert!(out.contains("2"), "rx_ns counter");
+        // Neighbor address should appear.
+        assert!(
+            out.contains("fe80::a8aa:aaff:feaa:1"),
+            "neighbor address in output"
+        );
+        // DAD entry.
+        assert!(
+            out.contains("duplicate address detection"),
+            "DAD annotation"
+        );
+        // drop counter.
+        assert!(out.contains("hop-limit 1"), "drop hop-limit counter");
+    }
+
+    #[test]
+    fn detail_text_unknown_ifname_filter_returns_error() {
+        let eng = NdEngine::new();
+
+        // Wrap in a minimal Nd-like call by directly testing the engine path.
+        // We test the ifindex_of lookup logic that show_nd_interface uses.
+        assert!(
+            eng.ifindex_of("nonexistent").is_none(),
+            "unknown interface returns None"
+        );
+    }
+
+    // ── JSON render ──────────────────────────────────────────────────────
+
+    #[test]
+    fn json_interface_parses_back() {
+        let eng = build_engine_with_traffic();
+        let now = t0();
+        let iface = build_interface_json(&eng, 2, now);
+        let json_str = serde_json::to_string_pretty(&iface).unwrap();
+        let v: serde_json::Value = serde_json::from_str(&json_str).unwrap();
+
+        assert_eq!(v["name"], "eth0");
+        assert_eq!(v["ifindex"], 2);
+        assert_eq!(v["ra_enabled"], true);
+        // counters should have rx_ra = 1.
+        assert_eq!(v["counters"]["rx_ra"], 1);
+        // neighbors array should have 2 entries (fe80::... and ::).
+        assert_eq!(v["neighbors"].as_array().unwrap().len(), 2);
+    }
+
+    #[test]
+    fn fmt_duration_formats_correctly() {
+        assert_eq!(fmt_duration(0), "0s");
+        assert_eq!(fmt_duration(59), "59s");
+        assert_eq!(fmt_duration(60), "1m");
+        assert_eq!(fmt_duration(65), "1m5s");
+        assert_eq!(fmt_duration(3600), "1h");
+        assert_eq!(fmt_duration(3661), "1h1m1s");
+        assert_eq!(fmt_duration(7260), "2h1m");
+    }
+}

--- a/zebra-rs/src/nd/socket.rs
+++ b/zebra-rs/src/nd/socket.rs
@@ -8,9 +8,9 @@
 //!     same check on inbound packets.
 //!   * `IPV6_RECVPKTINFO` on so the receive side learns the
 //!     destination address and arriving ifindex.
-//!   * `ICMP6_FILTER` scoped to RS (133) + RA (134) so neighbor
-//!     solicitation / advertisement (135 / 136) and the kernel's NDP
-//!     cache are left alone.
+//!   * `ICMP6_FILTER` scoped to RS (133) + RA (134) + NS (135) + NA
+//!     (136) so the daemon can passively observe NS/NA for counters
+//!     and diagnostics while leaving the kernel's NDP cache alone.
 //!
 //! Note: there is no `IPV6_CHECKSUM` setsockopt here on purpose. Linux
 //! returns `EINVAL` for `IPV6_CHECKSUM` on raw `IPPROTO_ICMPV6`
@@ -87,7 +87,7 @@ pub fn nd_socket() -> Result<AsyncFd<Socket>, SocketError> {
     // Note: no `IPV6_CHECKSUM` here — Linux returns EINVAL for that
     // option on raw ICMPv6 sockets; the kernel does the checksum for
     // us. See module-level docs.
-    let filter = Icmp6Filter::pass_only(&[133, 134]);
+    let filter = Icmp6Filter::pass_only(&[133, 134, 135, 136]);
     apply_icmp6_filter(&socket, &filter).map_err(SocketError::Filter)?;
 
     AsyncFd::new(socket).map_err(SocketError::AsyncFd)
@@ -227,11 +227,12 @@ mod tests {
 
     #[test]
     fn filter_pass_only_passes_listed_types() {
-        let f = Icmp6Filter::pass_only(&[133, 134]);
+        // The production socket now passes all four ND types.
+        let f = Icmp6Filter::pass_only(&[133, 134, 135, 136]);
         assert!(f.will_pass(133));
         assert!(f.will_pass(134));
-        assert!(!f.will_pass(135));
-        assert!(!f.will_pass(136));
+        assert!(f.will_pass(135));
+        assert!(f.will_pass(136));
         assert!(!f.will_pass(128));
         assert!(!f.will_pass(0));
     }

--- a/zebra-rs/yang/exec.yang
+++ b/zebra-rs/yang/exec.yang
@@ -730,6 +730,19 @@ module exec {
           }
         }
       }
+      container nd {
+        ext:help "IPv6 neighbor discovery";
+        presence "Show IPv6 ND status";
+        list interface {
+          ext:help "ND status per interface";
+          ext:presence "Show all interfaces";
+          key if-name;
+          leaf if-name {
+            ext:dynamic "rib:interface";
+            type string;
+          }
+        }
+      }
       container ospf {
         ext:help "OSPFv3 commands";
         presence "OSPFv3 instance";


### PR DESCRIPTION
## Summary

Consolidates the five-PR IPv6 ND show-commands series into a single PR (supersedes #1342, #1344, #1347, #1350; design doc: `docs/design/nd-show-commands-plan.md`, included here). Six commits, each one phase:

1. **docs** — blueprint + step-by-step plan.
2. **nd-packet: NS/NA codec** — `NeighborSolicit` (135) / `NeighborAdvert` (136) with parse/emit, `NaFlags` (R/S/O), round-trip tests incl. DAD unspecified-source and a wire image pinning the flag byte (RFC 4861 §4.3/§4.4).
3. **nd: counters + neighbor table** — ICMP6 filter widened so the daemon **passively observes** NS/NA (kernel still owns the NDP cache); all counting in the pure `NdEngine`: per-interface `NdIfCounters` (rx RS/RA/NS/NA, tx RA unsolicited/solicited, hop-limit + malformed drops) and a per-source neighbor table (first/last seen, per-type counts, last-RA snapshot) capped at 256 sources/interface with overflow counted. The read task surfaces drops as `NdRecv::Dropped` channel messages — no atomics in the I/O task.
4. **show ipv6 nd [interface [IFNAME]]** — text + JSON; RA scheduler state, daemon counters, kernel `/proc/net/dev_snmp6` counters, neighbor table with DAD annotation. Plumbing mirrors BFD (`ShowChannel` + `is_nd` routing + manager fallback "ND is not configured or running"). Grammar pinned with parse() tests. **Note**: Linux does not bump per-type `Icmp6Out*` counters for raw-socket sends, so the daemon and kernel tables are complementary planes (verified live).
5. **bgp: ND discovery on interface neighbors** — `Peer` gains `nd_discovered_at` / `nd_refreshed_at` / `nd_event_count` (display-only), stamped in `materialize_peer` (dormant-peer first-RA upgrade handled); `show bgp neighbors` renders `Interface peer: link-local learned via IPv6 ND router advertisement / Discovered … ago, refreshed N times (last … ago)` for interface-keyed peers only, text + JSON.
6. **bdd: @nd_show** — reuses the `@bgp_unnumbered_neighbor` two-namespace topology; once Established (proving RAs flowed both ways) asserts the ND summary/detail output, the learned `fe80::` neighbor with last-RA snapshot, a transmitted multicast, and the BGP discovery block; standard teardown; `make nd_show` target + generated doc.

## Test plan

- Unit: 25 new tests across nd-packet codec, engine counters/cap/DAD, show renderers + dev_snmp6 parser, BGP helpers/renderer/JSON, and grammar parse() pins. `cargo test --workspace --exclude bdd` green; clippy workspace clean; fmt clean.
- Live-tested against a root debug daemon: `show ipv6 nd` fallback → enabled-path (summary/detail/JSON rendering the live RFC 4861 initial burst), `% interface X not found`.
- BDD: `✓ nd_show (4 scenario(s)) — 1 feature(s) ran, 1 passed, 0 failed` against the md5-verified release binary; no leaked namespaces/daemons.

🤖 Generated with [Claude Code](https://claude.com/claude-code)