### PR TITLE
IS-IS TI-LFA over SRv6: End.X repair resolution, H.Insert encap, @tilfa_srv6 BDD

### DIFF
--- a/bdd/docs/isis_tilfa_srv6.md
+++ b/bdd/docs/isis_tilfa_srv6.md
@@ -1,0 +1,52 @@
+# IS-IS TI-LFA fast-reroute over SRv6 with BGP L3 service traffic
+
+## Overview
+
+As a network operator
+I want eight zebra-rs instances running IS-IS Level-2 with SRv6
+locators and TI-LFA (RFC 9490) to pre-compute a topology-independent
+repair for the source's primary path as an SRv6 SID list (End /
+End.X SIDs, SRH-inserted), so that when the primary link fails the
+source still reaches the destination — including BGP-carried SRv6
+service traffic between LAN segments behind the source and the
+destination.
+This is the SRv6 sibling of @isis_tilfa (same eight-router topology
+and metrics, IPv6-only). Differences from the SR-MPLS version:
+- every IS-IS circuit is `network-type point-to-point`;
+- `segment-routing srv6 locator LOCx` replaces `segment-routing
+- the TI-LFA repair resolves to an SRv6 SID list — End SID of the
+- s and d each have a stub LAN segment (a host namespace sh / dh);
+The metrics are tuned so a simple LFA is impossible: s reaches d via
+s-n1 (cost 2); protecting the s-n1 link requires an SR repair tunnel
+through the r-plane rather than a plain loop-free alternate.
+
+## Test Topology
+
+```
+   sh ── s (2001:db8::1, fcbb:bbbb:1::/48)
+             1 / 1 \      \ 1000
+              n1    n2     n3        (n1 ::2, n2 ::3, n3 ::4)
+          1 / |1 \1  \1     \1000
+       d ─┘ 1 |   \    \      \
+  (2001:db8::8)│    \1000\      \
+    fcbb:8::/48│     r1───────── (r1-n3 1000)   (r1 ::5)
+   dh ── d 1 \ │    /  \1000
+              r3   /1   \(r1-r2 1000)           (r2 ::6)
+          1000\   /      \
+               r2 ────────┘                     (r3 ::7)
+                 \1000
+                  r3 (r3-d 1)
+    s-n1 1  s-n2 1  s-n3 1000   n1-r1 1  n2-r1 1  n3-r1 1000
+    n1-r2 1 r1-r2 1000 r2-r3 1000  n1-d 1  r3-d 1
+    s-LAN: 2001:db8:100::/64 (sh)   d-LAN: 2001:db8:200::/64 (dh)
+```
+
+## Test Scenarios
+
+| Scenario | Result |
+|----------|--------|
+| Build the SRv6 TI-LFA topology and confirm IS-IS + BGP | |
+| SRv6 End/End.X SIDs exist and a TI-LFA SRv6 repair is installed | |
+| BGP carries the LAN prefixes as SRv6 End.DT6 service routes | |
+| Fast-reroute survives the primary link failure (s-n1) | |
+| Teardown topology | |

--- a/bdd/tests/configs/tilfa_srv6/d.yaml
+++ b/bdd/tests/configs/tilfa_srv6/d.yaml
@@ -1,0 +1,69 @@
+# d — TI-LFA destination. Mirror of s: IS-IS L2 + LOC8, iBGP back to
+# s's loopback carrying the d-LAN stub prefix with an End.DT6 from LOC8.
+interface:
+- if-name: lo
+  ipv6:
+    address: 2001:db8::8/128
+- if-name: d-n1
+  ipv6:
+    address: 2001:db8:0:10::2/64
+- if-name: d-r3
+  ipv6:
+    address: 2001:db8:0:11::2/64
+- if-name: lan0
+  ipv6:
+    address: 2001:db8:200::1/64
+segment-routing:
+  locator:
+  - name: LOC8
+    prefix: fcbb:bbbb:8::/48
+    behavior: usid
+router:
+  isis:
+    net: 49.0000.0000.0000.0008.00
+    hostname: d
+    is-type: level-2-only
+    segment-routing:
+      srv6:
+        locator: LOC8
+    fast-reroute:
+      ti-lfa: {}
+    interface:
+    - if-name: lo
+      ipv6:
+        enable: true
+    - if-name: d-n1
+      network-type: point-to-point
+      metric: 1
+      ipv6:
+        enable: true
+    - if-name: d-r3
+      network-type: point-to-point
+      metric: 1
+      ipv6:
+        enable: true
+  bgp:
+    global:
+      as: 65000
+      router-id: 10.0.0.8
+    timer:
+      adv-interval:
+        ibgp: 1
+        ebgp: 1
+    segment-routing:
+      srv6:
+        locator: LOC8
+        ipv6-unicast: {}
+    neighbor:
+    - remote-address: 2001:db8::1
+      remote-as: 65000
+      update-source: 2001:db8::8
+      enabled: true
+      afi-safi:
+      - name: ipv6
+        enabled: true
+        encapsulation-type: srv6
+    afi-safi:
+    - name: ipv6
+      redistribute:
+        connected: {}

--- a/bdd/tests/configs/tilfa_srv6/n1.yaml
+++ b/bdd/tests/configs/tilfa_srv6/n1.yaml
@@ -1,0 +1,56 @@
+# n1 — the primary-path midpoint s protects against (s-n1 link / n1 node).
+interface:
+- if-name: lo
+  ipv6:
+    address: 2001:db8::2/128
+- if-name: n1-s
+  ipv6:
+    address: 2001:db8:0:1::2/64
+- if-name: n1-r1
+  ipv6:
+    address: 2001:db8:0:4::1/64
+- if-name: n1-r2
+  ipv6:
+    address: 2001:db8:0:7::1/64
+- if-name: n1-d
+  ipv6:
+    address: 2001:db8:0:10::1/64
+segment-routing:
+  locator:
+  - name: LOC2
+    prefix: fcbb:bbbb:2::/48
+    behavior: usid
+router:
+  isis:
+    net: 49.0000.0000.0000.0002.00
+    hostname: n1
+    is-type: level-2-only
+    segment-routing:
+      srv6:
+        locator: LOC2
+    fast-reroute:
+      ti-lfa: {}
+    interface:
+    - if-name: lo
+      ipv6:
+        enable: true
+    - if-name: n1-s
+      network-type: point-to-point
+      metric: 1
+      ipv6:
+        enable: true
+    - if-name: n1-r1
+      network-type: point-to-point
+      metric: 1
+      ipv6:
+        enable: true
+    - if-name: n1-r2
+      network-type: point-to-point
+      metric: 1
+      ipv6:
+        enable: true
+    - if-name: n1-d
+      network-type: point-to-point
+      metric: 1
+      ipv6:
+        enable: true

--- a/bdd/tests/configs/tilfa_srv6/n2.yaml
+++ b/bdd/tests/configs/tilfa_srv6/n2.yaml
@@ -1,0 +1,40 @@
+# n2 — the post-convergence first hop when s-n1 fails (P-node side).
+interface:
+- if-name: lo
+  ipv6:
+    address: 2001:db8::3/128
+- if-name: n2-s
+  ipv6:
+    address: 2001:db8:0:2::2/64
+- if-name: n2-r1
+  ipv6:
+    address: 2001:db8:0:5::1/64
+segment-routing:
+  locator:
+  - name: LOC3
+    prefix: fcbb:bbbb:3::/48
+    behavior: usid
+router:
+  isis:
+    net: 49.0000.0000.0000.0003.00
+    hostname: n2
+    is-type: level-2-only
+    segment-routing:
+      srv6:
+        locator: LOC3
+    fast-reroute:
+      ti-lfa: {}
+    interface:
+    - if-name: lo
+      ipv6:
+        enable: true
+    - if-name: n2-s
+      network-type: point-to-point
+      metric: 1
+      ipv6:
+        enable: true
+    - if-name: n2-r1
+      network-type: point-to-point
+      metric: 1
+      ipv6:
+        enable: true

--- a/bdd/tests/configs/tilfa_srv6/n3.yaml
+++ b/bdd/tests/configs/tilfa_srv6/n3.yaml
@@ -1,0 +1,40 @@
+# n3 — expensive third neighbour of s; makes a plain LFA impossible.
+interface:
+- if-name: lo
+  ipv6:
+    address: 2001:db8::4/128
+- if-name: n3-s
+  ipv6:
+    address: 2001:db8:0:3::2/64
+- if-name: n3-r1
+  ipv6:
+    address: 2001:db8:0:6::1/64
+segment-routing:
+  locator:
+  - name: LOC4
+    prefix: fcbb:bbbb:4::/48
+    behavior: usid
+router:
+  isis:
+    net: 49.0000.0000.0000.0004.00
+    hostname: n3
+    is-type: level-2-only
+    segment-routing:
+      srv6:
+        locator: LOC4
+    fast-reroute:
+      ti-lfa: {}
+    interface:
+    - if-name: lo
+      ipv6:
+        enable: true
+    - if-name: n3-s
+      network-type: point-to-point
+      metric: 1000
+      ipv6:
+        enable: true
+    - if-name: n3-r1
+      network-type: point-to-point
+      metric: 1000
+      ipv6:
+        enable: true

--- a/bdd/tests/configs/tilfa_srv6/r1.yaml
+++ b/bdd/tests/configs/tilfa_srv6/r1.yaml
@@ -1,0 +1,56 @@
+# r1 — hub of the r-plane the repair tunnel traverses.
+interface:
+- if-name: lo
+  ipv6:
+    address: 2001:db8::5/128
+- if-name: r1-n1
+  ipv6:
+    address: 2001:db8:0:4::2/64
+- if-name: r1-n2
+  ipv6:
+    address: 2001:db8:0:5::2/64
+- if-name: r1-n3
+  ipv6:
+    address: 2001:db8:0:6::2/64
+- if-name: r1-r2
+  ipv6:
+    address: 2001:db8:0:8::1/64
+segment-routing:
+  locator:
+  - name: LOC5
+    prefix: fcbb:bbbb:5::/48
+    behavior: usid
+router:
+  isis:
+    net: 49.0000.0000.0000.0005.00
+    hostname: r1
+    is-type: level-2-only
+    segment-routing:
+      srv6:
+        locator: LOC5
+    fast-reroute:
+      ti-lfa: {}
+    interface:
+    - if-name: lo
+      ipv6:
+        enable: true
+    - if-name: r1-n1
+      network-type: point-to-point
+      metric: 1
+      ipv6:
+        enable: true
+    - if-name: r1-n2
+      network-type: point-to-point
+      metric: 1
+      ipv6:
+        enable: true
+    - if-name: r1-n3
+      network-type: point-to-point
+      metric: 1000
+      ipv6:
+        enable: true
+    - if-name: r1-r2
+      network-type: point-to-point
+      metric: 1000
+      ipv6:
+        enable: true

--- a/bdd/tests/configs/tilfa_srv6/r2.yaml
+++ b/bdd/tests/configs/tilfa_srv6/r2.yaml
@@ -1,0 +1,48 @@
+# r2 — r-plane transit between r1 and r3.
+interface:
+- if-name: lo
+  ipv6:
+    address: 2001:db8::6/128
+- if-name: r2-n1
+  ipv6:
+    address: 2001:db8:0:7::2/64
+- if-name: r2-r1
+  ipv6:
+    address: 2001:db8:0:8::2/64
+- if-name: r2-r3
+  ipv6:
+    address: 2001:db8:0:9::1/64
+segment-routing:
+  locator:
+  - name: LOC6
+    prefix: fcbb:bbbb:6::/48
+    behavior: usid
+router:
+  isis:
+    net: 49.0000.0000.0000.0006.00
+    hostname: r2
+    is-type: level-2-only
+    segment-routing:
+      srv6:
+        locator: LOC6
+    fast-reroute:
+      ti-lfa: {}
+    interface:
+    - if-name: lo
+      ipv6:
+        enable: true
+    - if-name: r2-n1
+      network-type: point-to-point
+      metric: 1
+      ipv6:
+        enable: true
+    - if-name: r2-r1
+      network-type: point-to-point
+      metric: 1000
+      ipv6:
+        enable: true
+    - if-name: r2-r3
+      network-type: point-to-point
+      metric: 1000
+      ipv6:
+        enable: true

--- a/bdd/tests/configs/tilfa_srv6/r3.yaml
+++ b/bdd/tests/configs/tilfa_srv6/r3.yaml
@@ -1,0 +1,40 @@
+# r3 — last r-plane hop before d (Q-node side).
+interface:
+- if-name: lo
+  ipv6:
+    address: 2001:db8::7/128
+- if-name: r3-r2
+  ipv6:
+    address: 2001:db8:0:9::2/64
+- if-name: r3-d
+  ipv6:
+    address: 2001:db8:0:11::1/64
+segment-routing:
+  locator:
+  - name: LOC7
+    prefix: fcbb:bbbb:7::/48
+    behavior: usid
+router:
+  isis:
+    net: 49.0000.0000.0000.0007.00
+    hostname: r3
+    is-type: level-2-only
+    segment-routing:
+      srv6:
+        locator: LOC7
+    fast-reroute:
+      ti-lfa: {}
+    interface:
+    - if-name: lo
+      ipv6:
+        enable: true
+    - if-name: r3-r2
+      network-type: point-to-point
+      metric: 1000
+      ipv6:
+        enable: true
+    - if-name: r3-d
+      network-type: point-to-point
+      metric: 1
+      ipv6:
+        enable: true

--- a/bdd/tests/configs/tilfa_srv6/s.yaml
+++ b/bdd/tests/configs/tilfa_srv6/s.yaml
@@ -1,0 +1,78 @@
+# s — TI-LFA source. IS-IS L2, SRv6 locator LOC1, all circuits P2P.
+# iBGP to d's loopback with redistribute connected + SRv6 ipv6-unicast,
+# so the lan0 stub prefix is carried with an End.DT6 SID from LOC1.
+interface:
+- if-name: lo
+  ipv6:
+    address: 2001:db8::1/128
+- if-name: s-n1
+  ipv6:
+    address: 2001:db8:0:1::1/64
+- if-name: s-n2
+  ipv6:
+    address: 2001:db8:0:2::1/64
+- if-name: s-n3
+  ipv6:
+    address: 2001:db8:0:3::1/64
+- if-name: lan0
+  ipv6:
+    address: 2001:db8:100::1/64
+segment-routing:
+  locator:
+  - name: LOC1
+    prefix: fcbb:bbbb:1::/48
+    behavior: usid
+router:
+  isis:
+    net: 49.0000.0000.0000.0001.00
+    hostname: s
+    is-type: level-2-only
+    segment-routing:
+      srv6:
+        locator: LOC1
+    fast-reroute:
+      ti-lfa: {}
+    interface:
+    - if-name: lo
+      ipv6:
+        enable: true
+    - if-name: s-n1
+      network-type: point-to-point
+      metric: 1
+      ipv6:
+        enable: true
+    - if-name: s-n2
+      network-type: point-to-point
+      metric: 1
+      ipv6:
+        enable: true
+    - if-name: s-n3
+      network-type: point-to-point
+      metric: 1000
+      ipv6:
+        enable: true
+  bgp:
+    global:
+      as: 65000
+      router-id: 10.0.0.1
+    timer:
+      adv-interval:
+        ibgp: 1
+        ebgp: 1
+    segment-routing:
+      srv6:
+        locator: LOC1
+        ipv6-unicast: {}
+    neighbor:
+    - remote-address: 2001:db8::8
+      remote-as: 65000
+      update-source: 2001:db8::1
+      enabled: true
+      afi-safi:
+      - name: ipv6
+        enabled: true
+        encapsulation-type: srv6
+    afi-safi:
+    - name: ipv6
+      redistribute:
+        connected: {}

--- a/bdd/tests/cucumber.rs
+++ b/bdd/tests/cucumber.rs
@@ -1613,6 +1613,23 @@ async fn add_address_to_interface(
     );
 }
 
+/// Add a static route inside a namespace, family inferred from the
+/// prefix (use `::/0` for an IPv6 default). Gives plain host
+/// namespaces — LAN endpoints with no routing daemon — their route
+/// toward the segment's router in dataplane end-to-end tests.
+#[given(expr = "I add route {string} via {string} in namespace {string}")]
+#[when(expr = "I add route {string} via {string} in namespace {string}")]
+async fn add_route_via(world: &mut World, prefix: String, via: String, namespace: String) {
+    let scoped = world.ns(&namespace);
+    netns::exec_in_netns(&scoped, "ip", &["route", "add", &prefix, "via", &via])
+        .await
+        .expect("Failed to add route");
+    println!(
+        "✓ Added route {} via {} in namespace {}",
+        prefix, via, scoped
+    );
+}
+
 /// Create a standalone dummy interface (not wired into any OSPF/IS-IS
 /// area) and give it an address. The resulting connected route is a
 /// genuine *external* prefix for redistribution tests — unlike an

--- a/bdd/tests/features/isis_tilfa_srv6.feature
+++ b/bdd/tests/features/isis_tilfa_srv6.feature
@@ -1,0 +1,186 @@
+@tilfa_srv6
+@isis
+Feature: IS-IS TI-LFA fast-reroute over SRv6 with BGP L3 service traffic
+  As a network operator
+  I want eight zebra-rs instances running IS-IS Level-2 with SRv6
+  locators and TI-LFA (RFC 9490) to pre-compute a topology-independent
+  repair for the source's primary path as an SRv6 SID list (End /
+  End.X SIDs, SRH-inserted), so that when the primary link fails the
+  source still reaches the destination — including BGP-carried SRv6
+  service traffic between LAN segments behind the source and the
+  destination.
+
+  This is the SRv6 sibling of @isis_tilfa (same eight-router topology
+  and metrics, IPv6-only). Differences from the SR-MPLS version:
+  - every IS-IS circuit is `network-type point-to-point`;
+  - `segment-routing srv6 locator LOCx` replaces `segment-routing
+    mpls`; each router owns locator fcbb:bbbb:X::/48 (behavior usid);
+  - the TI-LFA repair resolves to an SRv6 SID list — End SID of the
+    P-node plus End.X SIDs along the post-convergence path — installed
+    as an SRH insertion (H.Insert) so the final End.X hop forwards the
+    original packet on by plain IPv6 (no decap terminator needed);
+  - s and d each have a stub LAN segment (a host namespace sh / dh);
+    s and d speak iBGP over their loopbacks with `redistribute
+    connected` and `segment-routing srv6 ipv6-unicast`, so each LAN
+    prefix is carried in BGP with an End.DT6 service SID and the
+    ingress H.Encaps LAN-to-LAN traffic onto the SRv6 underlay that
+    TI-LFA protects.
+
+  The metrics are tuned so a simple LFA is impossible: s reaches d via
+  s-n1 (cost 2); protecting the s-n1 link requires an SR repair tunnel
+  through the r-plane rather than a plain loop-free alternate.
+
+  Test Topology (metric shown where != 1; loopback 2001:db8::X,
+  locator fcbb:bbbb:X::/48):
+  ```
+   sh ── s (2001:db8::1, fcbb:bbbb:1::/48)
+             1 / 1 \      \ 1000
+              n1    n2     n3        (n1 ::2, n2 ::3, n3 ::4)
+          1 / |1 \1  \1     \1000
+       d ─┘ 1 |   \    \      \
+  (2001:db8::8)│    \1000\      \
+    fcbb:8::/48│     r1───────── (r1-n3 1000)   (r1 ::5)
+   dh ── d 1 \ │    /  \1000
+              r3   /1   \(r1-r2 1000)           (r2 ::6)
+          1000\   /      \
+               r2 ────────┘                     (r3 ::7)
+                 \1000
+                  r3 (r3-d 1)
+    s-n1 1  s-n2 1  s-n3 1000   n1-r1 1  n2-r1 1  n3-r1 1000
+    n1-r2 1 r1-r2 1000 r2-r3 1000  n1-d 1  r3-d 1
+    s-LAN: 2001:db8:100::/64 (sh)   d-LAN: 2001:db8:200::/64 (dh)
+  ```
+
+  Scenario: Build the SRv6 TI-LFA topology and confirm IS-IS + BGP
+    Given a clean test environment
+    When I create namespace "s"
+    And I create namespace "n1"
+    And I create namespace "n2"
+    And I create namespace "n3"
+    And I create namespace "r1"
+    And I create namespace "r2"
+    And I create namespace "r3"
+    And I create namespace "d"
+    And I create namespace "sh"
+    And I create namespace "dh"
+    And I connect namespace "s" interface "s-n1" to namespace "n1" interface "n1-s"
+    And I connect namespace "s" interface "s-n2" to namespace "n2" interface "n2-s"
+    And I connect namespace "s" interface "s-n3" to namespace "n3" interface "n3-s"
+    And I connect namespace "n1" interface "n1-r1" to namespace "r1" interface "r1-n1"
+    And I connect namespace "n2" interface "n2-r1" to namespace "r1" interface "r1-n2"
+    And I connect namespace "n3" interface "n3-r1" to namespace "r1" interface "r1-n3"
+    And I connect namespace "n1" interface "n1-r2" to namespace "r2" interface "r2-n1"
+    And I connect namespace "r1" interface "r1-r2" to namespace "r2" interface "r2-r1"
+    And I connect namespace "r2" interface "r2-r3" to namespace "r3" interface "r3-r2"
+    And I connect namespace "n1" interface "n1-d" to namespace "d" interface "d-n1"
+    And I connect namespace "r3" interface "r3-d" to namespace "d" interface "d-r3"
+    And I connect namespace "s" interface "lan0" to namespace "sh" interface "eth0"
+    And I connect namespace "d" interface "lan0" to namespace "dh" interface "eth0"
+    And I add address "2001:db8:100::2/64" to interface "eth0" in namespace "sh"
+    And I add address "2001:db8:200::2/64" to interface "eth0" in namespace "dh"
+    And I add route "::/0" via "2001:db8:100::1" in namespace "sh"
+    And I add route "::/0" via "2001:db8:200::1" in namespace "dh"
+    And I start zebra-rs in namespace "s"
+    And I start zebra-rs in namespace "n1"
+    And I start zebra-rs in namespace "n2"
+    And I start zebra-rs in namespace "n3"
+    And I start zebra-rs in namespace "r1"
+    And I start zebra-rs in namespace "r2"
+    And I start zebra-rs in namespace "r3"
+    And I start zebra-rs in namespace "d"
+    And I apply config "s.yaml" to namespace "s"
+    And I apply config "n1.yaml" to namespace "n1"
+    And I apply config "n2.yaml" to namespace "n2"
+    And I apply config "n3.yaml" to namespace "n3"
+    And I apply config "r1.yaml" to namespace "r1"
+    And I apply config "r2.yaml" to namespace "r2"
+    And I apply config "r3.yaml" to namespace "r3"
+    And I apply config "d.yaml" to namespace "d"
+    And I wait 25 seconds
+    # The s<->d iBGP session dials loopback-to-loopback. The first
+    # connect raced the IGP (no route to the peer loopback yet), and a
+    # failed dial parks the FSM in ConnectRetry (120s RFC default) —
+    # clear both sides now that the IGP has converged so the session
+    # re-dials immediately.
+    When I run "clear bgp ipv6 neighbor 2001:db8::8" in namespace "s"
+    And I run "clear bgp ipv6 neighbor 2001:db8::1" in namespace "d"
+    And I wait 15 seconds
+    # Directly-connected adjacency over s-n1, then loopbacks across the
+    # IS-IS IPv6 domain.
+    Then ping from "s" to "2001:db8:0:1::2" should succeed
+    And ping from "s" to "2001:db8::2" should succeed
+    And ping from "s" to "2001:db8::8" should succeed
+    And ping from "d" to "2001:db8::1" should succeed
+    And BGP session in "s" to "2001:db8::8" should be "Established"
+    And BGP session in "d" to "2001:db8::1" should be "Established"
+
+  Scenario: SRv6 End/End.X SIDs exist and a TI-LFA SRv6 repair is installed
+    Given the test topology exists
+    # s owns its locator's End (uN) SID and carved an End.X (uA) SID
+    # for each IPv6-capable adjacency.
+    Then show command "show segment-routing srv6 sid" in namespace "s" should contain "uN"
+    And show command "show segment-routing srv6 sid" in namespace "s" should contain "uA"
+    # The s-n1-protected IPv6 routes carry a pre-computed TI-LFA repair
+    # expressed as an SRv6 SID list, installed by SRH insertion: the
+    # repair segments are transit End/End.X SIDs, so the original
+    # destination must remain the SRH's final segment (H.Encap would
+    # blackhole at the last SID — Linux has no USD flavor).
+    And show command "show isis route detail" in namespace "s" should contain "Backup path: TI-LFA"
+    And show command "show isis route detail" in namespace "s" should contain "SID list"
+    And show command "show isis route detail" in namespace "s" should contain "Encap: H.Insert"
+
+  Scenario: BGP carries the LAN prefixes as SRv6 End.DT6 service routes
+    Given the test topology exists
+    # d redistributes its connected LAN prefix with an End.DT6 SID
+    # carved from its locator; s (encapsulation-type srv6) accepts it
+    # and installs an H.Encaps ingress route toward the SID.
+    Then show command "show bgp ipv6 2001:db8:200::/64" in namespace "s" should contain "Remote SID"
+    And show command "show bgp ipv6 2001:db8:200::/64" in namespace "s" should contain "End.DT6"
+    And show command "show ipv6 route 2001:db8:200::/64" in namespace "s" should contain "via seg6"
+    And show command "show bgp ipv6 2001:db8:100::/64" in namespace "d" should contain "Remote SID"
+    # LAN-to-LAN service traffic rides the SRv6 underlay end-to-end:
+    # sh -> s (H.Encaps to d's End.DT6) -> IGP -> d (decap) -> dh, and
+    # the reply mirrors it via s's End.DT6.
+    And ping from "sh" to "2001:db8:200::2" should succeed
+    And ping from "dh" to "2001:db8:100::2" should succeed
+
+  Scenario: Fast-reroute survives the primary link failure (s-n1)
+    Given the test topology exists
+    Then ping from "s" to "2001:db8::8" should succeed
+    And ping from "sh" to "2001:db8:200::2" should succeed
+    When I make namespace "s" interface "s-n1" down
+    And I wait 5 seconds
+    # Reachability restored over the SRv6 repair / post-convergence
+    # path (out a different interface than the failed s-n1) — both the
+    # IGP loopback route and the BGP/SRv6 LAN-to-LAN service traffic,
+    # whose H.Encaps outer destination resolves via the protected
+    # locator route.
+    Then ping from "s" to "2001:db8::8" should succeed
+    And ping from "sh" to "2001:db8:200::2" should succeed
+    When I make namespace "s" interface "s-n1" up
+    And I wait 10 seconds
+    # Primary restored.
+    Then ping from "s" to "2001:db8::8" should succeed
+    And ping from "sh" to "2001:db8:200::2" should succeed
+
+  Scenario: Teardown topology
+    Given the test topology exists
+    When I stop zebra-rs in namespace "s"
+    And I stop zebra-rs in namespace "n1"
+    And I stop zebra-rs in namespace "n2"
+    And I stop zebra-rs in namespace "n3"
+    And I stop zebra-rs in namespace "r1"
+    And I stop zebra-rs in namespace "r2"
+    And I stop zebra-rs in namespace "r3"
+    And I stop zebra-rs in namespace "d"
+    And I delete namespace "s"
+    And I delete namespace "n1"
+    And I delete namespace "n2"
+    And I delete namespace "n3"
+    And I delete namespace "r1"
+    And I delete namespace "r2"
+    And I delete namespace "r3"
+    And I delete namespace "d"
+    And I delete namespace "sh"
+    And I delete namespace "dh"
+    Then the test environment should be clean

--- a/crates/isis-packet/src/sub/srv6.rs
+++ b/crates/isis-packet/src/sub/srv6.rs
@@ -307,6 +307,16 @@ pub enum EncapType {
     HEncapRed,
     HEncapL2,
     HEncapL2Red,
+    /// SRH insertion (H.Insert, kernel `seg6 mode inline`): the segment
+    /// list is inserted into the existing IPv6 packet with the original
+    /// destination appended as the final segment, instead of pushing an
+    /// outer IPv6 header. Unlike H.Encap*, the segment list needs no
+    /// decapsulating terminator — after the last listed segment the
+    /// packet continues to its original destination by plain IPv6
+    /// forwarding. TI-LFA repair paths use this: their segments are
+    /// transit End / End.X SIDs, which on Linux drop encapsulated
+    /// traffic at SL=0 (no USD flavor support).
+    HInsert,
 }
 
 impl EncapType {
@@ -316,6 +326,7 @@ impl EncapType {
             EncapType::HEncapRed => "H.Encap.Red",
             EncapType::HEncapL2 => "H.Encap.L2",
             EncapType::HEncapL2Red => "H.Encap.L2.Red",
+            EncapType::HInsert => "H.Insert",
         }
     }
 }
@@ -339,6 +350,7 @@ impl FromStr for EncapType {
             "H.Encap.Red" => Ok(EncapType::HEncapRed),
             "H.Encap.L2" => Ok(EncapType::HEncapL2),
             "H.Encap.L2.Red" => Ok(EncapType::HEncapL2Red),
+            "H.Insert" => Ok(EncapType::HInsert),
             other => Err(ParseEncapTypeError(other.to_string())),
         }
     }

--- a/zebra-rs/src/fib/netlink/srv6.rs
+++ b/zebra-rs/src/fib/netlink/srv6.rs
@@ -16,9 +16,11 @@ use crate::rib::{SidBehavior, SidStructure};
 //
 // HEncap carries every segment in the SRH. HEncapRed (RFC 8986 §5.2) drops
 // the first segment from the SRH because the kernel's outer IPv6 destination
-// already encodes it; the remaining segments must be non-empty. Other
-// EncapType variants are rejected here so callers surface a useful error
-// instead of silently flattening behavior.
+// already encodes it; the remaining segments must be non-empty. HInsert
+// (kernel `mode inline`) inserts the SRH into the existing IPv6 packet with
+// the original destination as the final segment — see build_srh_inline.
+// Other EncapType variants are rejected here so callers surface a useful
+// error instead of silently flattening behavior.
 pub fn build_seg6_lwtunnel(
     segments: &[Ipv6Addr],
     encap_type: EncapType,
@@ -26,20 +28,20 @@ pub fn build_seg6_lwtunnel(
     if segments.is_empty() {
         bail!("SRv6 encap requires at least one segment");
     }
-    let sr_segments: Vec<Ipv6Addr> = match encap_type {
-        EncapType::HEncap => segments.to_vec(),
+    let (mode, ipv6_sr_hdr) = match encap_type {
+        EncapType::HEncap => (Seg6IpTunnelMode::Encap, build_srh(segments)),
         EncapType::HEncapRed => {
             if segments.len() < 2 {
                 bail!("H.Encap.Red requires at least two segments");
             }
-            segments[1..].to_vec()
+            (Seg6IpTunnelMode::Encap, build_srh(&segments[1..]))
         }
+        EncapType::HInsert => (Seg6IpTunnelMode::Inline, build_srh_inline(segments)),
         other => bail!("unsupported SRv6 encap type: {other}"),
     };
 
-    let ipv6_sr_hdr = build_srh(&sr_segments);
     let seg6 = Seg6IpTunnelEncap {
-        mode: Seg6IpTunnelMode::Encap,
+        mode,
         ipv6_sr_hdr: VecIpv6SrHdr(vec![ipv6_sr_hdr]),
     };
     Ok(RouteLwTunnelEncap::Seg6(RouteSeg6IpTunnel::Seg6IpTunnel(
@@ -60,6 +62,33 @@ pub fn build_seg6_attrs(
         RouteAttribute::Encap(vec![lwencap]),
         RouteAttribute::EncapType(RouteLwEnCapType::Seg6),
     ))
+}
+
+// Build the tunnel-info SRH for the inline (H.Insert) mode. The kernel
+// inserts this SRH into the existing IPv6 packet and overwrites
+// segments[0] with the packet's original destination, so the wire
+// layout is
+//   segments = [orig-DA placeholder, s_n, ..., s_1]
+//   segments_left = first_segment = n
+// (the active segment indexes from the top, so the initial destination
+// rewrite lands on s_1, and the original destination becomes the final
+// segment). `segments` arrives in forwarding order (s_1 first).
+fn build_srh_inline(segments: &[Ipv6Addr]) -> Ipv6SrHdr {
+    let n = segments.len() as u8;
+    let mut segs: Vec<Ipv6Addr> = Vec::with_capacity(segments.len() + 1);
+    segs.push(Ipv6Addr::UNSPECIFIED);
+    segs.extend(segments.iter().rev().copied());
+    Ipv6SrHdr {
+        nexthdr: 0,
+        hdrlen: (n + 1).saturating_mul(2),
+        typ: 4,
+        segments_left: n,
+        first_segment: n,
+        flags: 0,
+        tag: 0,
+        segments: segs,
+        ..Default::default()
+    }
 }
 
 // Build the SRH (`Ipv6SrHdr`) carrying `segments` in forwarding order,
@@ -103,11 +132,24 @@ fn seg6local_action(behavior: SidBehavior) -> Seg6LocalAction {
 // knows where to split the destination address when shifting the next
 // uSID into position. Returns None for classic behaviors — they don't
 // need a Flavors attribute at all.
+//
+// Only uN gets the flavor. uN is a *prefix* install (LB+LN), so a uSID
+// carrier with more bits after the node id legitimately matches it and
+// must shift; a carrier whose argument is exhausted falls back to
+// classic End, which also processes a full-SID SRH hop correctly. uA
+// installs at /128 — only the exact B:N:F address can match, so there
+// is never a next uSID to shift into position. Worse, NEXT-CSID with
+// nflen covering only the node bits makes the kernel read the uA's
+// *function* bits as a pending argument and "shift" the DA into the
+// garbage address LB:F:: instead of running End.X — so a uA referenced
+// as a full SID from an SRH (e.g. a TI-LFA repair list) blackholes.
+// Classic End.X is the correct kernel programming for a /128 full-SID
+// install.
 fn build_seg6local_flavors(
     behavior: SidBehavior,
     structure: Option<SidStructure>,
 ) -> Option<RouteSeg6LocalIpTunnel> {
-    if !matches!(behavior, SidBehavior::UN | SidBehavior::UA) {
+    if !matches!(behavior, SidBehavior::UN) {
         return None;
     }
     let s = structure?;
@@ -292,5 +334,61 @@ mod tests {
     fn end_b6_encaps_without_segments_skips_install() {
         // No segment list → no SRH to push → skip the FIB install.
         assert!(build_seg6local_lwtunnel(SidBehavior::EndB6Encap, None, None, 0, &[]).is_none());
+    }
+
+    #[test]
+    fn h_insert_builds_inline_srh_with_orig_da_placeholder() {
+        // TI-LFA repair: forwarding-order [s1, s2] must become the wire
+        // layout [::, s2, s1] with SL = first_segment = 2 — the kernel
+        // overwrites segments[0] with the packet's original destination
+        // and starts at s1.
+        let s1: Ipv6Addr = "fcbb:bbbb:2::".parse().unwrap();
+        let s2: Ipv6Addr = "fcbb:bbbb:2:e000::".parse().unwrap();
+        let encap = build_seg6_lwtunnel(&[s1, s2], EncapType::HInsert).expect("encap built");
+        let RouteLwTunnelEncap::Seg6(RouteSeg6IpTunnel::Seg6IpTunnel(seg6)) = encap else {
+            panic!("expected seg6 iptunnel encap");
+        };
+        assert_eq!(seg6.mode, Seg6IpTunnelMode::Inline);
+        let srh = &seg6.ipv6_sr_hdr.0[0];
+        assert_eq!(srh.segments, vec![Ipv6Addr::UNSPECIFIED, s2, s1]);
+        assert_eq!(srh.segments_left, 2);
+        assert_eq!(srh.first_segment, 2);
+        assert_eq!(srh.hdrlen, 6);
+    }
+
+    #[test]
+    fn ua_installs_classic_end_x_without_flavors() {
+        // A uA is a /128 full-SID install: NEXT-CSID would misread the
+        // function bits as a shift argument and forward to LB:F::
+        // instead of running End.X, so the flavor must be omitted.
+        let nh6: Ipv6Addr = "fe80::2".parse().unwrap();
+        let structure = Some(SidStructure {
+            lb_bits: 32,
+            ln_bits: 16,
+            fun_bits: 16,
+            arg_bits: 64,
+        });
+        let encaps = build_seg6local_lwtunnel(SidBehavior::UA, Some(nh6), structure, 0, &[])
+            .expect("encap built");
+        assert!(
+            !encaps.iter().any(|e| matches!(
+                e,
+                RouteLwTunnelEncap::Seg6Local(RouteSeg6LocalIpTunnel::Flavors(_))
+            )),
+            "uA must not carry a NEXT-CSID Flavors attribute"
+        );
+        assert!(encaps.iter().any(|e| matches!(
+            e,
+            RouteLwTunnelEncap::Seg6Local(RouteSeg6LocalIpTunnel::Action(Seg6LocalAction::EndX))
+        )));
+
+        // uN keeps the flavor — it is a prefix install where carriers
+        // with a remaining argument legitimately shift.
+        let encaps = build_seg6local_lwtunnel(SidBehavior::UN, None, structure, 0, &[])
+            .expect("encap built");
+        assert!(encaps.iter().any(|e| matches!(
+            e,
+            RouteLwTunnelEncap::Seg6Local(RouteSeg6LocalIpTunnel::Flavors(_))
+        )));
     }
 }

--- a/zebra-rs/src/isis/rib.rs
+++ b/zebra-rs/src/isis/rib.rs
@@ -2238,7 +2238,7 @@ mod tests {
                     ifindex: 20,
                     addr: backup_addr,
                     segs: vec![end_sid, endx_sid],
-                    encap: EncapType::HEncap,
+                    encap: EncapType::HInsert,
                 }),
             },
         );
@@ -2262,7 +2262,7 @@ mod tests {
         };
         assert_eq!(b.metric, 21);
         assert_eq!(b.segs, vec![end_sid, endx_sid]);
-        assert_eq!(b.encap_type, Some(EncapType::HEncap));
+        assert_eq!(b.encap_type, Some(EncapType::HInsert));
         assert!(b.mpls.is_empty());
     }
 

--- a/zebra-rs/src/isis/show.rs
+++ b/zebra-rs/src/isis/show.rs
@@ -1788,7 +1788,7 @@ fn write_isis_backup_v6_detail(
     } else {
         writeln!(
             buf,
-            "      SID list {}, Encap: {:?}",
+            "      SID list {}, Encap: {}",
             fmt_isis_srv6_segs(&backup.segs),
             backup.encap,
         )?;

--- a/zebra-rs/src/isis/tilfa.rs
+++ b/zebra-rs/src/isis/tilfa.rs
@@ -26,7 +26,12 @@ pub struct RepairPathMpls {
 
 /// TI-LFA SRv6 repair path. The segment list expresses the post-
 /// convergence path as IPv6 endpoint SIDs — typically
-/// `[End(P), End.X(P→Q)]` for the 2-segment case.
+/// `[End(P), End.X(P→Q)]` for the 2-segment case — in forwarding
+/// order. The encap is `HInsert` (SRH insertion): the repair segments
+/// are transit End / End.X SIDs with no decapsulating terminator, so
+/// the original destination must ride along as the SRH's final
+/// segment; H.Encap would blackhole at the last SID (Linux drops
+/// End / End.X at SL=0 without USD-flavor support).
 #[derive(Debug, Clone, PartialEq)]
 pub struct RepairPathSrv6 {
     pub ifindex: u32,
@@ -103,15 +108,14 @@ pub(super) fn build_repair_path_mpls(
 }
 
 /// SRv6 sibling of `build_repair_path_mpls`. Resolves the SR segment
-/// list to a list of End SIDs (from `top.srv6_end_map`) and pins the
-/// post-conv first-hop's IPv6 link-local egress. Encap defaults to
-/// `HEncap` (full SRH push); `HEncap.Red` is an opt-in per project
-/// default and would be selected at install time.
-///
-/// Only the empty and 1-segment-NodeSid cases are supported today —
-/// multi-segment SRv6 repairs need End.X (adjacency) SID resolution
-/// which isn't yet wired (no `srv6_endx_map` analogous to
-/// `srv6_end_map`). Multi-segment cases return `None` for now.
+/// list to IPv6 SIDs — NodeSids to the originator's End SID (from
+/// `top.srv6_end_map`), AdjSids to the advertiser's End.X SID (from
+/// its IS-reach sub-TLVs, RFC 9352 §8) — and pins the post-conv
+/// first-hop's IPv6 link-local egress. Returns `None` when any
+/// segment fails to resolve: a partial SID list would diverge from
+/// the post-convergence path the algorithm computed. The encap is
+/// `HInsert` — see `RepairPathSrv6` for why insertion rather than
+/// H.Encap.
 ///
 /// LAN trivial-repair (empty segs, first_hop is a pseudonode) is
 /// skipped for the same reason as in the MPLS sibling — `RepairPath`
@@ -122,15 +126,25 @@ pub(super) fn build_repair_path_srv6(
     rp: &spf::RepairPath,
 ) -> Option<RepairPathSrv6> {
     let lsp_map = top.lsp_map.get(&level);
-    let segs: Vec<Ipv6Addr> = match rp.segs.as_slice() {
-        [] => vec![],
-        [spf::SrSegment::NodeSid(v)] => {
-            let sys_id = lsp_map.resolve(*v)?;
-            let end_sid = top.srv6_end_map.get(&level).get(sys_id).copied()?;
-            vec![end_sid]
-        }
-        _ => return None,
-    };
+    let mut segs: Vec<Ipv6Addr> = Vec::with_capacity(rp.segs.len());
+    for (idx, seg) in rp.segs.iter().enumerate() {
+        let resolved = match seg {
+            spf::SrSegment::NodeSid(v) => lsp_map
+                .resolve(*v)
+                .and_then(|sys_id| top.srv6_end_map.get(&level).get(sys_id).copied()),
+            spf::SrSegment::AdjSid(from, to, via) => {
+                srv6_endx_sid_for_link(top, level, *from, *to, *via)
+            }
+        };
+        let Some(sid) = resolved else {
+            tracing::debug!(
+                "[tilfa] {level:?} repair segment[{idx}] {seg:?} failed to resolve to an SRv6 \
+                 SID; dropping repair list (partial: {segs:?})"
+            );
+            return None;
+        };
+        segs.push(sid);
+    }
 
     let ifindex = (rp.first_hop_link_id != 0).then_some(rp.first_hop_link_id)?;
     let link = top.links.get(&ifindex)?;
@@ -159,8 +173,68 @@ pub(super) fn build_repair_path_srv6(
         ifindex,
         addr,
         segs,
-        encap: EncapType::HEncap,
+        encap: EncapType::HInsert,
     })
+}
+
+/// Look up the SRv6 End.X SID `from` advertises for the link to `to`
+/// — the SRv6 sibling of `adj_sid_label_for_link`. For LAN
+/// adjacencies (`via_pseudonode = Some(pn)`) the IS Reach entry's
+/// neighbor_id matches the pseudonode and the LAN End.X sub-TLV's
+/// `system_id` field identifies the LAN member; for P2P adjacencies
+/// the neighbor_id is `(to_sys, 0)` and any End.X sub-TLV under it
+/// qualifies (RFC 9352 §8.1 / §8.2).
+fn srv6_endx_sid_for_link(
+    top: &IsisTop,
+    level: Level,
+    from_vertex: usize,
+    to_vertex: usize,
+    via_pseudonode: Option<usize>,
+) -> Option<Ipv6Addr> {
+    let from_sys = *top.lsp_map.get(&level).resolve(from_vertex)?;
+    let target_neighbor_id = if let Some(via_v) = via_pseudonode {
+        *top.lsp_map.get(&level).resolve_neighbor(via_v)?
+    } else {
+        let to_sys = *top.lsp_map.get(&level).resolve(to_vertex)?;
+        IsisNeighborId::from_sys_id(&to_sys, 0)
+    };
+
+    // Walk every non-pseudonode fragment originated by `from_sys` at
+    // this level — with send-side LSP fragmentation the IS-reach
+    // entry carrying the End.X can live in any fragment (same rule
+    // as adj_sid_label_for_link).
+    for (lsp_id, lsa) in top.lsdb.get(&level).iter() {
+        if lsp_id.sys_id() != from_sys || lsp_id.is_pseudo() {
+            continue;
+        }
+        for tlv in &lsa.lsp.tlvs {
+            let IsisTlv::ExtIsReach(reach) = tlv else {
+                continue;
+            };
+            for entry in &reach.entries {
+                if entry.neighbor_id != target_neighbor_id {
+                    continue;
+                }
+                for sub in &entry.subs {
+                    match sub {
+                        neigh::IsisSubTlv::Srv6EndXSid(endx) => {
+                            return Some(endx.sid);
+                        }
+                        neigh::IsisSubTlv::Srv6LanEndXSid(lan_endx) => {
+                            let Some(to_sys) = top.lsp_map.get(&level).resolve(to_vertex) else {
+                                continue;
+                            };
+                            if &lan_endx.system_id == to_sys {
+                                return Some(lan_endx.sid);
+                            }
+                        }
+                        _ => {}
+                    }
+                }
+            }
+        }
+    }
+    None
 }
 
 /// Resolve a peer-advertised SID to an absolute MPLS label, using


### PR DESCRIPTION
## Summary

Makes IS-IS TI-LFA work over the SRv6 dataplane end-to-end and adds the `@tilfa_srv6` BDD — the SRv6 sibling of `@isis_tilfa` (same eight-router topology and metrics, IPv6-only, all circuits P2P), with stub LAN segments behind `s` and `d` exchanged over iBGP `redistribute connected` + `segment-routing srv6 ipv6-unicast`.

### isis: multi-segment SRv6 repair resolution
`build_repair_path_srv6` only handled the empty and 1-segment-NodeSid shapes; any repair needing adjacency steering (the normal TI-LFA case) was dropped. Every segment now resolves — NodeSid → originator End SID (`srv6_end_map`), AdjSid → advertiser End.X SID via a new `srv6_endx_sid_for_link` that walks IS-reach `Srv6EndXSid`/`Srv6LanEndXSid` sub-TLVs (RFC 9352 §8), mirroring `adj_sid_label_for_link` (all-fragment scan, LAN system-id match, all-or-nothing).

### fib: two kernel-semantics fixes (validated in a scratch-netns probe on 6.8)
- **`EncapType::HInsert` → seg6 `mode inline`.** Repair lists are transit End/End.X SIDs with no decap terminator, and Linux drops End/End.X at SL=0 (no USD flavor) — H.Encap-style repairs blackhole at the last SID. Insertion keeps the original destination as the SRH's final segment. This also fixes the previously-shipped 1-segment repair shape.
- **uA installs as classic End.X (no NEXT-CSID flavor).** A uA is a /128 exact-match full-SID; with `nflen` covering only the node bits the kernel misreads the function bits as a pending shift argument and rewrites the DA to garbage `LB:F::`, so any SRH referencing the uA blackholes. uN keeps the flavor (prefix install; arg-zero falls back to classic End).

### bdd: `@tilfa_srv6`
Asserts the repair installs as an SRv6 SID list with `Encap: H.Insert` (in this topology every repair-carrying destination needs the multi-segment End/End.X form, so the assertion pins the new resolution), that the LAN prefixes arrive as End.DT6 service routes with seg6 ingress, that LAN-to-LAN pings ride the SRv6 underlay both ways, and that reachability survives the `s-n1` failure. LAN endpoints are host namespaces (`sh`/`dh`) because End.DT6 decap looks the inner packet up in table main, which can't deliver to a decapper-local address. New generic harness step `I add route <prefix> via <nh> in namespace <ns>` for the daemon-less hosts.

## Testing
- `@tilfa_srv6`: 5/5 scenarios, 98/98 steps
- Regression: `@isis_tilfa` (SR-MPLS, 11 scenarios), `@isis_srv6`, `@isis_endx_ipv6` (exercises the changed uA install), `@bgp_srv6_redistribute` — all green
- `cargo test --workspace --exclude bdd`, workspace clippy `-D warnings`, `cargo fmt` — clean
- New unit tests: inline-SRH wire layout (placeholder + reversed segs, SL=first_segment=n), uA-without-flavors/uN-with-flavors

🤖 Generated with [Claude Code](https://claude.com/claude-code)