### PR TITLE
ospf: dedup per-link address list on AddrAdd (v2 + v3)

### DIFF
--- a/zebra-rs/src/ospf/addr.rs
+++ b/zebra-rs/src/ospf/addr.rs
@@ -25,3 +25,59 @@ where
         }
     }
 }
+
+/// Append `addr` to a link's address list only when no entry with the
+/// same prefix exists; returns whether it pushed.
+///
+/// The RIB redistributes every AddrAdd *event*, not every address —
+/// one configured address arrives several times (config-exec push,
+/// kernel netlink echo, DAD re-notify, link-bounce re-install), so
+/// consumers must be idempotent (IS-IS guards the same way in
+/// `isis::link::addr_add`). Without this, every duplicate delivery
+/// adds another copy of the prefix to the Router-LSA stub networks
+/// (v2) / Intra-Area-Prefix-LSA (v3).
+pub fn link_addr_push_unique<V: OspfVersion>(
+    addrs: &mut Vec<OspfAddr<V>>,
+    addr: OspfAddr<V>,
+) -> bool {
+    if addrs.iter().any(|a| a.prefix == addr.prefix) {
+        return false;
+    }
+    addrs.push(addr);
+    true
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::ospf::version::{Ospfv2, Ospfv3};
+
+    #[test]
+    fn push_unique_dedups_v6_prefix() {
+        let mut addrs: Vec<OspfAddr<Ospfv3>> = Vec::new();
+        let lo: ipnet::Ipv6Net = "2001:db8::1/128".parse().unwrap();
+        let transit: ipnet::Ipv6Net = "2001:db8:1::1/64".parse().unwrap();
+
+        assert!(link_addr_push_unique(&mut addrs, OspfAddr { prefix: lo }));
+        // Same prefix delivered again (kernel echo / DAD re-notify) —
+        // must not grow the list.
+        assert!(!link_addr_push_unique(&mut addrs, OspfAddr { prefix: lo }));
+        assert_eq!(addrs.len(), 1);
+
+        assert!(link_addr_push_unique(
+            &mut addrs,
+            OspfAddr { prefix: transit }
+        ));
+        assert_eq!(addrs.len(), 2);
+    }
+
+    #[test]
+    fn push_unique_dedups_v4_prefix() {
+        let mut addrs: Vec<OspfAddr<Ospfv2>> = Vec::new();
+        let p: ipnet::Ipv4Net = "10.0.0.1/24".parse().unwrap();
+
+        assert!(link_addr_push_unique(&mut addrs, OspfAddr { prefix: p }));
+        assert!(!link_addr_push_unique(&mut addrs, OspfAddr { prefix: p }));
+        assert_eq!(addrs.len(), 1);
+    }
+}

--- a/zebra-rs/src/ospf/inst.rs
+++ b/zebra-rs/src/ospf/inst.rs
@@ -4346,8 +4346,11 @@ impl Ospf<Ospfv2> {
         let IpNet::V4(prefix) = &addr.addr else {
             return;
         };
+        // Duplicate-delivery guard — see `link_addr_push_unique` for
+        // why the same address arrives multiple times. Without it the
+        // Router-LSA repeats the stub network once per delivery.
         let ospf_addr = OspfAddr::from(&addr, prefix);
-        link.addr.push(ospf_addr);
+        super::addr::link_addr_push_unique(&mut link.addr, ospf_addr);
         link.ident.prefix = *prefix;
 
         // If this address made an enabled-but-Down interface usable,
@@ -5216,8 +5219,11 @@ impl Ospf<Ospfv3> {
         let IpNet::V6(prefix) = &addr.addr else {
             return;
         };
+        // Duplicate-delivery guard — see `link_addr_push_unique` for
+        // why the same address arrives multiple times. Without it the
+        // Intra-Area-Prefix-LSA repeats the prefix once per delivery.
         let ospf_addr = OspfAddr::<Ospfv3>::from(&addr, prefix);
-        link.addr.push(ospf_addr);
+        super::addr::link_addr_push_unique(&mut link.addr, ospf_addr);
 
         if link.enabled && link.state == IfsmState::Down {
             let _ = self


### PR DESCRIPTION
## Problem

On the `@ospfv3_tilfa` topology, every router's self-originated Intra-Area-Prefix-LSA advertised each **configured** prefix three times (e.g. 13 prefixes where only 5 are distinct), while the kernel-automatic `::1/128` appeared once. The kernel held each address exactly once — the duplication was daemon-side.

## Root cause

- The RIB redistributes every AddrAdd **event**, not every address: `link_addr_update` (`rib/link.rs`) dedups the RIB's own `link.addr4/addr6` state, but `addr_add` then calls `api_addr_add` unconditionally — even when the address was already known.
- One configured address legitimately produces several deliveries: the config-exec push (`rib.addr_add(addr, true)`), the kernel netlink echo of the install, the IPv6 DAD/flag-change re-notify, and the link-bounce re-install.
- Consumers are expected to be idempotent — IS-IS already guards its push (`isis::link::addr_add`, "Push only when prefix does not exist") — but OSPF v2 and v3 `addr_add` appended blindly, so `link.addr` accumulated one entry per delivery. v3's Intra-Area-Prefix-LSA and v2's Router-LSA stub networks then repeat the prefix once per copy.

`addr_del` uses `retain()` (removes all matching entries), so deletes were already self-healing; only the add path needed the guard.

## Fix

Shared `link_addr_push_unique` helper in `ospf::addr`, called from both the v2 and v3 `addr_add`; skips the push when an entry with the same prefix already exists (same predicate `addr_del` uses). Unit tests pin the dedup for both address families.

The RIB-side alternative (suppress redistribution of known addresses) was deliberately avoided — it would change delivery semantics for all subscribers (BGP unnumbered, ND, IS-IS).

## Verification

Live single router (lo `2001:db8::99/128` + veth `2001:db8:99::1/64`), same config before/after:

- pre-fix: `Number of Prefixes: 6` — `2001:db8::99/128` ×3, `2001:db8:99::/64` ×2, `::1/128` ×1
- post-fix: `Number of Prefixes: 3` — each prefix exactly once

Gates: `cargo fmt` clean, `cargo clippy --workspace --all-targets -- -D warnings` clean, `cargo test --workspace --exclude bdd` all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)