### PR TITLE
ospf: allocate P2P Adj-SIDs dynamically from the SRLB (IS-IS parity)

### DIFF
--- a/bdd/tests/configs/ospfv2_tilfa/d.yaml
+++ b/bdd/tests/configs/ospfv2_tilfa/d.yaml
@@ -26,11 +26,7 @@ router:
         enable: true
         network-type: point-to-point
         cost: 1
-        adjacency-sid:
-          index: 82
       - if-name: d-r3
         enable: true
         network-type: point-to-point
         cost: 1
-        adjacency-sid:
-          index: 87

--- a/bdd/tests/configs/ospfv2_tilfa/n1.yaml
+++ b/bdd/tests/configs/ospfv2_tilfa/n1.yaml
@@ -32,23 +32,15 @@ router:
         enable: true
         network-type: point-to-point
         cost: 1
-        adjacency-sid:
-          index: 21
       - if-name: n1-r1
         enable: true
         network-type: point-to-point
         cost: 1
-        adjacency-sid:
-          index: 25
       - if-name: n1-r2
         enable: true
         network-type: point-to-point
         cost: 1
-        adjacency-sid:
-          index: 26
       - if-name: n1-d
         enable: true
         network-type: point-to-point
         cost: 1
-        adjacency-sid:
-          index: 28

--- a/bdd/tests/configs/ospfv2_tilfa/n2.yaml
+++ b/bdd/tests/configs/ospfv2_tilfa/n2.yaml
@@ -26,11 +26,7 @@ router:
         enable: true
         network-type: point-to-point
         cost: 1
-        adjacency-sid:
-          index: 31
       - if-name: n2-r1
         enable: true
         network-type: point-to-point
         cost: 1
-        adjacency-sid:
-          index: 35

--- a/bdd/tests/configs/ospfv2_tilfa/n3.yaml
+++ b/bdd/tests/configs/ospfv2_tilfa/n3.yaml
@@ -26,11 +26,7 @@ router:
         enable: true
         network-type: point-to-point
         cost: 1000
-        adjacency-sid:
-          index: 41
       - if-name: n3-r1
         enable: true
         network-type: point-to-point
         cost: 1000
-        adjacency-sid:
-          index: 45

--- a/bdd/tests/configs/ospfv2_tilfa/r1.yaml
+++ b/bdd/tests/configs/ospfv2_tilfa/r1.yaml
@@ -32,23 +32,15 @@ router:
         enable: true
         network-type: point-to-point
         cost: 1
-        adjacency-sid:
-          index: 52
       - if-name: r1-n2
         enable: true
         network-type: point-to-point
         cost: 1
-        adjacency-sid:
-          index: 53
       - if-name: r1-n3
         enable: true
         network-type: point-to-point
         cost: 1000
-        adjacency-sid:
-          index: 54
       - if-name: r1-r2
         enable: true
         network-type: point-to-point
         cost: 1000
-        adjacency-sid:
-          index: 56

--- a/bdd/tests/configs/ospfv2_tilfa/r2.yaml
+++ b/bdd/tests/configs/ospfv2_tilfa/r2.yaml
@@ -29,17 +29,11 @@ router:
         enable: true
         network-type: point-to-point
         cost: 1
-        adjacency-sid:
-          index: 62
       - if-name: r2-r1
         enable: true
         network-type: point-to-point
         cost: 1000
-        adjacency-sid:
-          index: 65
       - if-name: r2-r3
         enable: true
         network-type: point-to-point
         cost: 1000
-        adjacency-sid:
-          index: 67

--- a/bdd/tests/configs/ospfv2_tilfa/r3.yaml
+++ b/bdd/tests/configs/ospfv2_tilfa/r3.yaml
@@ -26,11 +26,7 @@ router:
         enable: true
         network-type: point-to-point
         cost: 1000
-        adjacency-sid:
-          index: 76
       - if-name: r3-d
         enable: true
         network-type: point-to-point
         cost: 1
-        adjacency-sid:
-          index: 78

--- a/bdd/tests/configs/ospfv2_tilfa/s-nofrr.yaml
+++ b/bdd/tests/configs/ospfv2_tilfa/s-nofrr.yaml
@@ -27,17 +27,11 @@ router:
         enable: true
         network-type: point-to-point
         cost: 1
-        adjacency-sid:
-          index: 12
       - if-name: s-n2
         enable: true
         network-type: point-to-point
         cost: 1
-        adjacency-sid:
-          index: 13
       - if-name: s-n3
         enable: true
         network-type: point-to-point
         cost: 1000
-        adjacency-sid:
-          index: 14

--- a/bdd/tests/configs/ospfv2_tilfa/s-nosr.yaml
+++ b/bdd/tests/configs/ospfv2_tilfa/s-nosr.yaml
@@ -27,17 +27,11 @@ router:
         enable: true
         network-type: point-to-point
         cost: 1
-        adjacency-sid:
-          index: 12
       - if-name: s-n2
         enable: true
         network-type: point-to-point
         cost: 1
-        adjacency-sid:
-          index: 13
       - if-name: s-n3
         enable: true
         network-type: point-to-point
         cost: 1000
-        adjacency-sid:
-          index: 14

--- a/bdd/tests/configs/ospfv2_tilfa/s.yaml
+++ b/bdd/tests/configs/ospfv2_tilfa/s.yaml
@@ -29,17 +29,11 @@ router:
         enable: true
         network-type: point-to-point
         cost: 1
-        adjacency-sid:
-          index: 12
       - if-name: s-n2
         enable: true
         network-type: point-to-point
         cost: 1
-        adjacency-sid:
-          index: 13
       - if-name: s-n3
         enable: true
         network-type: point-to-point
         cost: 1000
-        adjacency-sid:
-          index: 14

--- a/bdd/tests/configs/ospfv3_tilfa/d.yaml
+++ b/bdd/tests/configs/ospfv3_tilfa/d.yaml
@@ -26,11 +26,7 @@ router:
         enable: true
         network-type: point-to-point
         cost: 1
-        adjacency-sid:
-          index: 82
       - if-name: d-r3
         enable: true
         network-type: point-to-point
         cost: 1
-        adjacency-sid:
-          index: 87

--- a/bdd/tests/configs/ospfv3_tilfa/n1.yaml
+++ b/bdd/tests/configs/ospfv3_tilfa/n1.yaml
@@ -32,23 +32,15 @@ router:
         enable: true
         network-type: point-to-point
         cost: 1
-        adjacency-sid:
-          index: 21
       - if-name: n1-r1
         enable: true
         network-type: point-to-point
         cost: 1
-        adjacency-sid:
-          index: 25
       - if-name: n1-r2
         enable: true
         network-type: point-to-point
         cost: 1
-        adjacency-sid:
-          index: 26
       - if-name: n1-d
         enable: true
         network-type: point-to-point
         cost: 1
-        adjacency-sid:
-          index: 28

--- a/bdd/tests/configs/ospfv3_tilfa/n2.yaml
+++ b/bdd/tests/configs/ospfv3_tilfa/n2.yaml
@@ -26,11 +26,7 @@ router:
         enable: true
         network-type: point-to-point
         cost: 1
-        adjacency-sid:
-          index: 31
       - if-name: n2-r1
         enable: true
         network-type: point-to-point
         cost: 1
-        adjacency-sid:
-          index: 35

--- a/bdd/tests/configs/ospfv3_tilfa/n3.yaml
+++ b/bdd/tests/configs/ospfv3_tilfa/n3.yaml
@@ -26,11 +26,7 @@ router:
         enable: true
         network-type: point-to-point
         cost: 1000
-        adjacency-sid:
-          index: 41
       - if-name: n3-r1
         enable: true
         network-type: point-to-point
         cost: 1000
-        adjacency-sid:
-          index: 45

--- a/bdd/tests/configs/ospfv3_tilfa/r1.yaml
+++ b/bdd/tests/configs/ospfv3_tilfa/r1.yaml
@@ -32,23 +32,15 @@ router:
         enable: true
         network-type: point-to-point
         cost: 1
-        adjacency-sid:
-          index: 52
       - if-name: r1-n2
         enable: true
         network-type: point-to-point
         cost: 1
-        adjacency-sid:
-          index: 53
       - if-name: r1-n3
         enable: true
         network-type: point-to-point
         cost: 1000
-        adjacency-sid:
-          index: 54
       - if-name: r1-r2
         enable: true
         network-type: point-to-point
         cost: 1000
-        adjacency-sid:
-          index: 56

--- a/bdd/tests/configs/ospfv3_tilfa/r2.yaml
+++ b/bdd/tests/configs/ospfv3_tilfa/r2.yaml
@@ -29,17 +29,11 @@ router:
         enable: true
         network-type: point-to-point
         cost: 1
-        adjacency-sid:
-          index: 62
       - if-name: r2-r1
         enable: true
         network-type: point-to-point
         cost: 1000
-        adjacency-sid:
-          index: 65
       - if-name: r2-r3
         enable: true
         network-type: point-to-point
         cost: 1000
-        adjacency-sid:
-          index: 67

--- a/bdd/tests/configs/ospfv3_tilfa/r3.yaml
+++ b/bdd/tests/configs/ospfv3_tilfa/r3.yaml
@@ -26,11 +26,7 @@ router:
         enable: true
         network-type: point-to-point
         cost: 1000
-        adjacency-sid:
-          index: 76
       - if-name: r3-d
         enable: true
         network-type: point-to-point
         cost: 1
-        adjacency-sid:
-          index: 78

--- a/bdd/tests/configs/ospfv3_tilfa/s-nofrr.yaml
+++ b/bdd/tests/configs/ospfv3_tilfa/s-nofrr.yaml
@@ -27,17 +27,11 @@ router:
         enable: true
         network-type: point-to-point
         cost: 1
-        adjacency-sid:
-          index: 12
       - if-name: s-n2
         enable: true
         network-type: point-to-point
         cost: 1
-        adjacency-sid:
-          index: 13
       - if-name: s-n3
         enable: true
         network-type: point-to-point
         cost: 1000
-        adjacency-sid:
-          index: 14

--- a/bdd/tests/configs/ospfv3_tilfa/s-nosr.yaml
+++ b/bdd/tests/configs/ospfv3_tilfa/s-nosr.yaml
@@ -27,17 +27,11 @@ router:
         enable: true
         network-type: point-to-point
         cost: 1
-        adjacency-sid:
-          index: 12
       - if-name: s-n2
         enable: true
         network-type: point-to-point
         cost: 1
-        adjacency-sid:
-          index: 13
       - if-name: s-n3
         enable: true
         network-type: point-to-point
         cost: 1000
-        adjacency-sid:
-          index: 14

--- a/bdd/tests/configs/ospfv3_tilfa/s.yaml
+++ b/bdd/tests/configs/ospfv3_tilfa/s.yaml
@@ -29,17 +29,11 @@ router:
         enable: true
         network-type: point-to-point
         cost: 1
-        adjacency-sid:
-          index: 12
       - if-name: s-n2
         enable: true
         network-type: point-to-point
         cost: 1
-        adjacency-sid:
-          index: 13
       - if-name: s-n3
         enable: true
         network-type: point-to-point
         cost: 1000
-        adjacency-sid:
-          index: 14

--- a/bdd/tests/features/ospfv2_tilfa.feature
+++ b/bdd/tests/features/ospfv2_tilfa.feature
@@ -14,9 +14,11 @@ Feature: OSPFv2 TI-LFA fast-reroute over SR-MPLS
   IS-IS sub-TLVs). All links are point-to-point; every router enables
   `segment-routing mpls` and `fast-reroute ti-lfa`. Loopback
   Prefix-SIDs index 100..800 resolve against the default SRGB (base
-  16000), and each link carries an Adjacency-SID (index = <from><to>
-  digit pair, s=1 n1=2 n2=3 n3=4 r1=5 r2=6 r3=7 d=8) — the repair
-  encodes its mid-path hops as Adj-SID segments.
+  16000). Adjacency-SIDs are NOT configured: each router allocates
+  one per Full adjacency out of its SRLB (base 15000) automatically
+  and advertises it as a local (V|L) Adj-SID — IS-IS-parity dynamic
+  allocation — and the repair encodes its mid-path hops as those
+  Adj-SID segments.
 
   The metrics are tuned so a simple LFA is impossible: s reaches d via
   s-n1 (cost 2); the only other neighbours (n2, n3) are equidistant /
@@ -28,7 +30,8 @@ Feature: OSPFv2 TI-LFA fast-reroute over SR-MPLS
   legs already protect the prefix), so repairs exist exactly for r2,
   r3 and d — the single-nexthop destinations behind n1. Per RFC 9855
   §5.3, the repair for d is <Node-SID(r1), Adj-SID(r1-r2),
-  Adj-SID(r2-r3)> via first-hop n2: labels [16500, 16056, 16067].
+  Adj-SID(r2-r3)> via first-hop n2: labels [16500, 15xxx, 15yyy] —
+  the Adj-SID values are whatever r1 / r2 carved from their SRLBs.
 
   Test Topology (metric shown where != 1; loopback 10.0.0.X / SID X00
   / router-id 10.0.0.X):
@@ -113,11 +116,13 @@ Feature: OSPFv2 TI-LFA fast-reroute over SR-MPLS
     # And the repairs are installed against the single-nexthop
     # loopbacks behind n1: r2, r3 and d (r1 itself is ECMP via n1/n2
     # and self-protects). Every repair starts with r1's node-SID label
-    # 16500.
+    # 16500, followed by dynamically allocated SRLB Adj-SID labels
+    # (15xxx — exact values depend on each router's allocation order,
+    # so the assertion pins the SRLB range, not a specific label).
     And show command "show ip ospf repair-list" in namespace "s" should contain "10.0.0.6/32"
     And show command "show ip ospf repair-list" in namespace "s" should contain "10.0.0.7/32"
     And show command "show ip ospf repair-list" in namespace "s" should contain "10.0.0.8/32"
-    And show command "show ip ospf repair-list" in namespace "s" should contain "16500"
+    And show command "show ip ospf repair-list" in namespace "s" should contain "[16500, 15"
     And show command "show ip ospf repair-list detail" in namespace "s" should contain "sr-mpls"
 
   Scenario: Source reaches the destination over the primary path

--- a/bdd/tests/features/ospfv3_tilfa.feature
+++ b/bdd/tests/features/ospfv3_tilfa.feature
@@ -14,10 +14,11 @@ Feature: OSPFv3 TI-LFA fast-reroute over SR-MPLS
   machinery (RFC 8362 E-LSAs instead of v2's Opaque LSAs). All links
   are point-to-point; every router enables `segment-routing mpls` and
   `fast-reroute ti-lfa`. Loopback Prefix-SIDs index 100..800 resolve
-  against the default SRGB (base 16000), and each link carries an
-  Adjacency-SID (index = <from><to> digit pair, s=1 n1=2 n2=3 n3=4
-  r1=5 r2=6 r3=7 d=8) — the repair encodes its mid-path hops as
-  Adj-SID segments.
+  against the default SRGB (base 16000). Adjacency-SIDs are NOT
+  configured: each router allocates one per Full adjacency out of its
+  SRLB (base 15000) automatically and advertises it as a local (V|L)
+  Adj-SID — IS-IS-parity dynamic allocation — and the repair encodes
+  its mid-path hops as those Adj-SID segments.
 
   The metrics are tuned so a simple LFA is impossible: s reaches d via
   s-n1 (cost 2); the only other neighbours (n2, n3) are equidistant /
@@ -29,7 +30,8 @@ Feature: OSPFv3 TI-LFA fast-reroute over SR-MPLS
   legs already protect the prefix), so repairs exist exactly for r2,
   r3 and d — the single-nexthop destinations behind n1. Per RFC 9855
   §5.3, the repair for d is <Node-SID(r1), Adj-SID(r1-r2),
-  Adj-SID(r2-r3)> via first-hop n2: labels [16500, 16056, 16067].
+  Adj-SID(r2-r3)> via first-hop n2: labels [16500, 15xxx, 15yyy] —
+  the Adj-SID values are whatever r1 / r2 carved from their SRLBs.
 
   Test Topology (metric shown where != 1; loopback 2001:db8::X /
   SID X00 / router-id 10.0.0.X):
@@ -117,11 +119,13 @@ Feature: OSPFv3 TI-LFA fast-reroute over SR-MPLS
     # And the repairs are installed against the single-nexthop
     # loopbacks behind n1: r2, r3 and d (r1 itself is ECMP via n1/n2
     # and self-protects). Every repair starts with r1's node-SID label
-    # 16500.
+    # 16500, followed by dynamically allocated SRLB Adj-SID labels
+    # (15xxx — exact values depend on each router's allocation order,
+    # so the assertion pins the SRLB range, not a specific label).
     And show command "show ipv6 ospf repair-list" in namespace "s" should contain "2001:db8::6/128"
     And show command "show ipv6 ospf repair-list" in namespace "s" should contain "2001:db8::7/128"
     And show command "show ipv6 ospf repair-list" in namespace "s" should contain "2001:db8::8/128"
-    And show command "show ipv6 ospf repair-list" in namespace "s" should contain "16500"
+    And show command "show ipv6 ospf repair-list" in namespace "s" should contain "[16500, 15"
     And show command "show ipv6 ospf repair-list detail" in namespace "s" should contain "sr-mpls"
 
   Scenario: Source reaches the destination over the primary path

--- a/zebra-rs/src/ospf/config.rs
+++ b/zebra-rs/src/ospf/config.rs
@@ -1463,13 +1463,14 @@ fn config_ospf_sr_mpls(ospf: &mut Ospf, _args: Args, op: ConfigOp) -> Option<()>
         ospf.ext_prefix_lsa_originate(ifindex);
     }
 
-    // Same for Extended Link LSAs (Adj-SID).
-    let ifindexes: Vec<u32> = ospf
-        .links
-        .iter()
-        .filter(|(_, link)| link.config.adjacency_sid.is_some())
-        .map(|(ifindex, _)| *ifindex)
-        .collect();
+    // Same for Extended Link LSAs (Adj-SID) — sweep every link
+    // unconditionally; the originator gates on mode + warrant itself
+    // (and flushes otherwise). Filtering on a configured
+    // `adjacency_sid` here broke both toggle directions once
+    // Adj-SIDs went dynamic: enable-after-Full never originated the
+    // P2P LSAs, and disable never flushed them (leaving stale
+    // self-ILM pops behind).
+    let ifindexes: Vec<u32> = ospf.links.keys().copied().collect();
     for ifindex in ifindexes {
         ospf.ext_link_lsa_originate(ifindex);
     }

--- a/zebra-rs/src/ospf/config_v3.rs
+++ b/zebra-rs/src/ospf/config_v3.rs
@@ -865,23 +865,15 @@ fn config_ospfv3_sr_mpls(ospf: &mut Ospf<Ospfv3>, _args: Args, op: ConfigOp) -> 
         ospf.ext_intra_area_prefix_v3_lsa_originate(ifindex);
     }
 
-    // Re-originate / flush E-Router-LSAs for every link with either
-    // a configured P2P adjacency-SID or any LAN Adj-SID labels just
-    // allocated above. Using both criteria covers static-config P2P
-    // and dynamic-allocation broadcast in one pass.
-    let ifindexes: Vec<u32> = ospf
-        .links
-        .iter()
-        .filter(|(ifindex, link)| {
-            link.config.adjacency_sid.is_some()
-                || ospf
-                    .lan_adj_sids
-                    .range((**ifindex, std::net::Ipv4Addr::UNSPECIFIED)..)
-                    .next()
-                    .is_some_and(|((idx, _), _)| idx == *ifindex)
-        })
-        .map(|(ifindex, _)| *ifindex)
-        .collect();
+    // Re-originate / flush the per-link E-Router-LSA on every link.
+    // The originator gates on mode + warrant itself (and flushes
+    // otherwise), so sweeping unconditionally covers all four cases:
+    // enable/disable x configured/dynamic Adj-SID. Filtering by
+    // `adjacency_sid.is_some() || lan_adj_sids non-empty` here broke
+    // the disable path once Adj-SIDs went dynamic — the map is
+    // cleared just above, so no link matched and the stale LSAs
+    // (and their self-ILM pops) survived the SR-MPLS delete.
+    let ifindexes: Vec<u32> = ospf.links.keys().copied().collect();
     for ifindex in ifindexes {
         ospf.e_router_v3_lsa_originate(ifindex);
     }

--- a/zebra-rs/src/ospf/inst.rs
+++ b/zebra-rs/src/ospf/inst.rs
@@ -186,8 +186,10 @@ pub struct Ospf<V: OspfVersion = Ospfv2> {
     /// kill — the origination side resolves the address back to a
     /// router-id at LSA build time.
     /// Used to drive LAN Adj-SID origination on broadcast/NBMA links
-    /// (RFC 8665 §6) and the matching local ILM install. Cleared when
-    /// SR-MPLS is disabled.
+    /// (RFC 8665 §6), the dynamic P2P Adj-SID fallback (advertised as
+    /// a local V|L label when no `adjacency-sid` is configured —
+    /// IS-IS-parity automatic allocation), and the matching local ILM
+    /// install. Cleared when SR-MPLS is disabled.
     pub lan_adj_sids: BTreeMap<(u32, Ipv4Addr), u32>,
     /// v3 IPv6 RIB shadow. Populated by
     /// `apply_routing_updates_v3` after each SPF run; diffed
@@ -1880,8 +1882,10 @@ impl Ospf<Ospfv2> {
     ///
     /// Originates when SR-MPLS is enabled, the link is enabled, has at
     /// least one Full neighbor, and either of:
-    ///   * P2P link with an `adjacency_sid` configured — one
-    ///     `AdjSidSubTlv` carrying the configured value.
+    ///   * P2P link — one `AdjSidSubTlv` carrying the configured
+    ///     `adjacency_sid` or, when none is configured, the SRLB
+    ///     label dynamically allocated on the Full transition
+    ///     (advertised as a local V|L Adj-SID, IS-IS parity).
     ///   * Broadcast / NBMA link with a known DR and at least one
     ///     entry in `lan_adj_sids` — one `LanAdjSidSubTlv` per Full
     ///     neighbor that has a label allocated, per RFC 8665 §6.
@@ -1927,6 +1931,14 @@ impl Ospf<Ospfv2> {
                         let mut subs = Vec::new();
                         if let Some(adjacency_sid) = link.config.adjacency_sid {
                             subs.push(super::srmpls::build_p2p_adj_sub(&adjacency_sid));
+                        } else if let Some(label) =
+                            self.lan_adj_sids.get(&(ifindex, nbr.ident.prefix.addr()))
+                        {
+                            // Dynamic SRLB Adj-SID fallback — see the
+                            // v3 sibling in `e_router_v3_lsa_originate`.
+                            subs.push(super::srmpls::build_p2p_adj_sub(
+                                &super::link::AdjacencySid::Absolute(*label),
+                            ));
                         }
                         if let Some(asla) = asla {
                             subs.push(asla);
@@ -3328,9 +3340,10 @@ impl Ospf<Ospfv2> {
         // Adjacency-SID label allocation. Each Full adjacency claims
         // one label out of the SRLB on transition into Full and
         // releases it on regression. The label is consumed by LAN
-        // Adj-SID origination (broadcast / NBMA links) and the matching
-        // local ILM install. Pool is only present when SR-MPLS is
-        // enabled, so this is a no-op otherwise.
+        // Adj-SID origination (broadcast / NBMA links), by the dynamic
+        // P2P Adj-SID fallback (no `adjacency-sid` configured), and by
+        // the matching local ILM install. Pool is only present when
+        // SR-MPLS is enabled, so this is a no-op otherwise.
         if new_state == NfsmState::Full
             && let Some(pool) = self.local_pool.as_mut()
             && let Some(label) = pool.allocate()
@@ -7249,8 +7262,10 @@ impl Ospf<Ospfv3> {
     ///
     /// Originates when SR-MPLS is on, the link is enabled, has at
     /// least one Full neighbor, and either of:
-    ///   * P2P link with an `adjacency_sid` configured -- one
-    ///     `AdjSid` sub-TLV with the configured value.
+    ///   * P2P link -- one `AdjSid` sub-TLV with the configured
+    ///     `adjacency_sid` or, when none is configured, the SRLB
+    ///     label dynamically allocated on the Full transition
+    ///     (advertised as a local V|L Adj-SID, IS-IS parity).
     ///   * Broadcast / NBMA link with a known DR and at least one
     ///     entry in `lan_adj_sids` -- one `LanAdjSid` sub-TLV per
     ///     Full neighbor that has a label allocated (RFC 8666 §6.2).
@@ -7291,6 +7306,16 @@ impl Ospf<Ospfv3> {
                         let mut subs = Vec::new();
                         if let Some(adjacency_sid) = link.config.adjacency_sid {
                             subs.push(super::srmpls::build_v3_p2p_adj_sub(&adjacency_sid));
+                        } else if let Some(label) =
+                            self.lan_adj_sids.get(&(ifindex, nbr.ident.router_id))
+                        {
+                            // No configured Adj-SID: advertise the SRLB
+                            // label allocated on the Full transition as
+                            // a local (V|L) Adj-SID — IS-IS-parity
+                            // dynamic allocation, no config needed.
+                            subs.push(super::srmpls::build_v3_p2p_adj_sub(
+                                &super::link::AdjacencySid::Absolute(*label),
+                            ));
                         }
                         if let Some(a) = asla.clone() {
                             subs.push(a);
@@ -7566,8 +7591,10 @@ impl Ospf<Ospfv3> {
         // Adjacency-SID label allocation. Mirrors v2 (#850): each Full
         // adjacency claims one label out of the SRLB on transition
         // into Full and releases it on regression. Consumed by the
-        // LAN-Adj-SID origination path (broadcast / NBMA links).
-        // No-op when SR-MPLS is disabled (no pool present).
+        // LAN-Adj-SID origination path (broadcast / NBMA links) and
+        // by the dynamic P2P Adj-SID fallback (no `adjacency-sid`
+        // configured). No-op when SR-MPLS is disabled (no pool
+        // present).
         if new_state == NfsmState::Full
             && let Some(pool) = self.local_pool.as_mut()
             && let Some(label) = pool.allocate()

--- a/zebra-rs/src/ospf/show.rs
+++ b/zebra-rs/src/ospf/show.rs
@@ -2417,7 +2417,7 @@ fn show_ospf_checkpoint(
             )?;
         }
     }
-    writeln!(buf, "  LAN Adj-SIDs: {}", cp.lan_adj_sids.len())?;
+    writeln!(buf, "  Adj-SID labels: {}", cp.lan_adj_sids.len())?;
     for ((ifindex, addr), label) in &cp.lan_adj_sids {
         writeln!(buf, "    if{} {} -> label {}", ifindex, addr, label)?;
     }

--- a/zebra-rs/src/ospf/show_v3.rs
+++ b/zebra-rs/src/ospf/show_v3.rs
@@ -1595,10 +1595,13 @@ fn show_ospfv3_segment_routing(
             iface.prefix_sid.as_deref().unwrap_or("-"),
             iface.adjacency_sid.as_deref().unwrap_or("-"),
         )?;
+        // Dynamically allocated per-adjacency labels — LAN Adj-SIDs
+        // on broadcast/NBMA segments, plain Adj-SIDs on P2P links
+        // with no configured `adjacency-sid`; don't tag them "LAN".
         for lan in &iface.lan_adj_sids {
             writeln!(
                 text,
-                "  {:<12}  {:<14}  {:<14}  LAN nbr={} lbl={}",
+                "  {:<12}  {:<14}  {:<14}  nbr={} lbl={}",
                 "", "", "", lan.neighbor_router_id, lan.label
             )?;
         }


### PR DESCRIPTION
## Problem

IS-IS allocates a local Adj-SID per Full adjacency out of the SRLB (base 15000) with no configuration. OSPF v2/v3 advertised a P2P Adj-SID **only when `adjacency-sid` was configured**, so the TI-LFA BDD topologies carried index-form (global, SRGB-resolved) Adj-SIDs — repair lists showed 16056/16067 where IS-IS shows 15xxx.

## Changes

**Dynamic allocation (the feature).** The infrastructure already existed — every Full adjacency claims a label from the SRLB pool (15000-15999) regardless of network type; only the LAN origination arm consumed it. The Ext-Link (v2) / E-Router (v3) P2P arms now fall back to that label when no `adjacency-sid` is configured, advertising it as a **local (V|L) Adj-SID** per RFC 8665/8666 §6.1. A configured `adjacency-sid` still wins. ILM install and TI-LFA segment resolution already handled the Label form (the LAN path exercised them), so no consumer changes.

**SR-toggle sweep fix (found by BDD).** The `segment-routing mpls` toggle re-origination sweeps filtered on `adjacency_sid.is_some()` (v2) / `…|| lan_adj_sids non-empty` (v3). With dynamic Adj-SIDs, the **disable** path matched no links (the map is cleared just before the sweep), leaving stale per-link LSAs whose self-ILM pops survived the SR delete — the ospfv2_tilfa "Deleting segment-routing mpls clears all MPLS ILM entries" scenario caught it. The sweeps now cover every link unconditionally; the originators gate-and-flush internally.

**Show cleanup.** Per-neighbor label rows in `show … segment-routing` drop the misleading `LAN` tag (they now cover P2P too); GR checkpoint dump likewise.

## BDD updates

- All 56 `adjacency-sid` stanzas removed from `ospfv2_tilfa` / `ospfv3_tilfa` configs (the knob itself is unchanged and still honored).
- Repair-list assertions pin `"[16500, 15"` — node-SID first segment plus SRLB-range mid-path segments — instead of baked indexed labels, since dynamic values depend on per-router allocation order.
- Feature preambles updated to describe the dynamic allocation.

## Verification

- `ospfv2_tilfa`: 7/7 scenarios, 95/95 steps green (was 1 failing before the sweep fix).
- `ospfv3_tilfa`: 7/7 scenarios, 96/96 steps green.
- Live topology: r1 advertises SRLB `[15000/15999]`, allocated Adj-SIDs 15000-15003 (one per Full adjacency), and the kernel LFIB has the matching `15000-15003 via inet6 <link-local> dev <iface> proto ospf` pop-and-forward entries.
- `cargo fmt` / `cargo clippy --workspace --all-targets -- -D warnings` / `cargo test --workspace --exclude bdd` all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)