### PR TITLE
isis: fix SRv6 End.X blackhole — prefer neighbor global for nh6

### DIFF
--- a/bdd/tests/cucumber.rs
+++ b/bdd/tests/cucumber.rs
@@ -1658,6 +1658,14 @@ async fn create_dummy_interface(world: &mut World, iface: String, addr: String, 
 /// `via inet6 fe80::` pins the RFC 8950/5549 v4-over-v6 install.
 /// Polls because the install crosses the zebra-rs RIB task and a
 /// netlink round-trip after the BGP-table assertion that precedes it.
+/// Address-family flag for `ip route show <prefix>`. `ip` does NOT
+/// infer the family from the prefix argument — without `-6` an IPv6
+/// prefix silently returns nothing, which would make the negative
+/// (`should eventually be gone`) step pass vacuously.
+fn route_family_flag(prefix: &str) -> &'static str {
+    if prefix.contains(':') { "-6" } else { "-4" }
+}
+
 #[then(expr = "kernel route {string} in namespace {string} should eventually contain {string}")]
 async fn kernel_route_eventually_contains(
     world: &mut World,
@@ -1666,10 +1674,11 @@ async fn kernel_route_eventually_contains(
     needle: String,
 ) {
     let scoped = world.ns(&namespace);
+    let family = route_family_flag(&prefix);
     const ATTEMPTS: u32 = 30;
     let mut last_output = String::new();
     for i in 0..ATTEMPTS {
-        last_output = netns::exec_in_netns(&scoped, "ip", &["route", "show", &prefix])
+        last_output = netns::exec_in_netns(&scoped, "ip", &[family, "route", "show", &prefix])
             .await
             .expect("Failed to run ip route show");
         if last_output.contains(&needle) {
@@ -1695,10 +1704,11 @@ async fn kernel_route_eventually_contains(
 #[then(expr = "kernel route {string} in namespace {string} should eventually be gone")]
 async fn kernel_route_eventually_gone(world: &mut World, prefix: String, namespace: String) {
     let scoped = world.ns(&namespace);
+    let family = route_family_flag(&prefix);
     const ATTEMPTS: u32 = 30;
     let mut last_output = String::new();
     for i in 0..ATTEMPTS {
-        last_output = netns::exec_in_netns(&scoped, "ip", &["route", "show", &prefix])
+        last_output = netns::exec_in_netns(&scoped, "ip", &[family, "route", "show", &prefix])
             .await
             .expect("Failed to run ip route show");
         if last_output.trim().is_empty() {

--- a/bdd/tests/features/isis_tilfa_srv6.feature
+++ b/bdd/tests/features/isis_tilfa_srv6.feature
@@ -163,6 +163,30 @@ Feature: IS-IS TI-LFA fast-reroute over SRv6 with BGP L3 service traffic
     Then ping from "s" to "2001:db8::8" should succeed
     And ping from "sh" to "2001:db8:200::2" should succeed
 
+  Scenario: Promoted backup actually forwards over the SRv6 repair
+    Given the test topology exists
+    # `backup-as-primary` swaps the metric-sort offset so each TI-LFA
+    # repair installs as the active route and the SPF primary demotes
+    # to metric+1; `clear isis spf` recomputes and reinstalls with the
+    # flag applied. Traffic is pinned onto the SRv6 repair while every
+    # link stays up — proving the uN/uA SID list genuinely forwards,
+    # which the link-failure scenario cannot (by ping time SPF has
+    # already reconverged onto a plain post-convergence primary).
+    When I apply command "set router isis fast-reroute backup-as-primary" in namespace "s"
+    And I run "clear isis spf" in namespace "s"
+    # d's loopback route now has the SRH-insert repair as its best
+    # kernel entry: out the repair egress s-n2 at metric 12 (2 path +
+    # 10 for d's loopback prefix), demoted plain primary behind at 13.
+    Then kernel route "2001:db8::8" in namespace "s" should eventually contain "mode inline"
+    And kernel route "2001:db8::8" in namespace "s" should eventually contain "dev s-n2 proto isis metric 12"
+    # End-to-end over the repair: the IGP loopback path and the
+    # BGP/SRv6 LAN-to-LAN service traffic, whose H.Encaps outer
+    # destination resolves via the promoted locator route. These die
+    # if any repair-segment uN/uA hop fails to forward (e.g. the
+    # kernel End.X nh6 lookup resolving on the wrong link).
+    And ping from "s" to "2001:db8::8" should succeed
+    And ping from "sh" to "2001:db8:200::2" should succeed
+
   Scenario: Teardown topology
     Given the test topology exists
     When I stop zebra-rs in namespace "s"

--- a/bdd/tests/features/isis_tilfa_srv6_classic.feature
+++ b/bdd/tests/features/isis_tilfa_srv6_classic.feature
@@ -165,6 +165,30 @@ Feature: IS-IS TI-LFA fast-reroute over SRv6 classic (full) SIDs with BGP L3 ser
     Then ping from "s" to "2001:db8::8" should succeed
     And ping from "e1" to "2001:db8:200::2" should succeed
 
+  Scenario: Promoted backup actually forwards over the SRv6 repair
+    Given the test topology exists
+    # `backup-as-primary` swaps the metric-sort offset so each TI-LFA
+    # repair installs as the active route and the SPF primary demotes
+    # to metric+1; `clear isis spf` recomputes and reinstalls with the
+    # flag applied. Traffic is pinned onto the SRv6 repair while every
+    # link stays up — proving the SID list genuinely forwards, which
+    # the link-failure scenario cannot (by ping time SPF has already
+    # reconverged onto a plain post-convergence primary).
+    When I apply command "set router isis fast-reroute backup-as-primary" in namespace "s"
+    And I run "clear isis spf" in namespace "s"
+    # d's loopback route now has the SRH-insert repair as its best
+    # kernel entry: out the repair egress s-n2 at metric 12 (2 path +
+    # 10 for d's loopback prefix), demoted plain primary behind at 13.
+    Then kernel route "2001:db8::8" in namespace "s" should eventually contain "mode inline"
+    And kernel route "2001:db8::8" in namespace "s" should eventually contain "dev s-n2 proto isis metric 12"
+    # End-to-end over the repair: the IGP loopback path and the
+    # BGP/SRv6 LAN-to-LAN service traffic, whose H.Encaps outer
+    # destination resolves via the promoted locator route. These die
+    # if any repair-segment End/End.X hop fails to forward (e.g. the
+    # kernel End.X nh6 lookup resolving on the wrong link).
+    And ping from "s" to "2001:db8::8" should succeed
+    And ping from "e1" to "2001:db8:200::2" should succeed
+
   Scenario: Teardown topology
     Given the test topology exists
     When I stop zebra-rs in namespace "s"

--- a/zebra-rs/src/isis/neigh.rs
+++ b/zebra-rs/src/isis/neigh.rs
@@ -52,6 +52,14 @@ pub struct Neighbor {
     /// allocator pass picks a function.
     pub endx_sid: Option<(u16, Ipv6Addr)>,
 
+    /// The nexthop the installed End.X SID currently forwards to.
+    /// Tracked separately from `endx_sid` because the SID address is
+    /// stable for the life of the adjacency while the preferred
+    /// nexthop can drift across Hellos (the neighbor gains or loses a
+    /// global address); `reconcile_endx_sid` re-installs the FIB entry
+    /// when [`Neighbor::endx_nh6`] stops matching this.
+    pub endx_installed_nh6: Option<Ipv6Addr>,
+
     /// Graceful Restart observation (RFC 5306). Records the peer's
     /// most recent Restart TLV and drives helper-side behavior
     /// (refresh hold once, send RA, suppress teardown).
@@ -88,6 +96,7 @@ impl Neighbor {
             hold_time: 0,
             network_type,
             endx_sid: None,
+            endx_installed_nh6: None,
             gr: AdjGrState::default(),
             created: true,
         }
@@ -121,6 +130,25 @@ impl Neighbor {
         self.advertises_ipv6() && !self.addr6l.is_empty()
     }
 
+    /// Nexthop for this neighbor's End.X SID: prefer a global address
+    /// from its IPv6 Global Interface Address TLV (233, on-link by
+    /// definition), falling back to its link-local (TLV 232).
+    ///
+    /// The preference is a Linux kernel constraint, not a taste call.
+    /// seg6local `End.X` (`input_action_end_x`) ignores the route's
+    /// `dev` and resolves `nh6` with a fresh FIB lookup whose iif is
+    /// the packet's INGRESS interface — a link-local nh6 therefore
+    /// matches the fe80::/64 route of the wrong (ingress) link and the
+    /// repair traffic blackholes behind an unanswered NS. A global nh6
+    /// resolves via the connected prefix to the correct egress link.
+    fn endx_nh6(&self) -> Option<Ipv6Addr> {
+        self.addr6
+            .keys()
+            .next()
+            .copied()
+            .or_else(|| self.addr6l.first().copied())
+    }
+
     /// Re-originate the self-LSP (both levels; the per-level guard in
     /// `process_lsp_originate` drops the one this instance doesn't run)
     /// when the adjacency is already Up, so an End.X SID allocated or
@@ -146,6 +174,10 @@ impl Neighbor {
     ///   IPv6, or withdrew its IPv6 link-local) → release it so our LSP
     ///   stops advertising an End.X we have no IPv6 nexthop to forward
     ///   over.
+    /// - Eligible with a SID already held → re-install the FIB entry if
+    ///   the preferred nexthop ([`Neighbor::endx_nh6`]) drifted, e.g. a
+    ///   global address arrived in a later Hello than the link-local
+    ///   the SID was first installed against.
     ///
     /// Called on every Hello (after `nbr_hello_interpret` refreshes the
     /// neighbor's protocols / addresses), so a change in the neighbor's
@@ -170,9 +202,6 @@ impl Neighbor {
             return;
         }
 
-        if self.endx_sid.is_some() {
-            return;
-        }
         let Some(locator) = sr_locator.as_ref() else {
             return;
         };
@@ -182,6 +211,29 @@ impl Neighbor {
         let Some(loc_name) = watched_locator.clone() else {
             return;
         };
+        // `endx_eligible` guarantees at least a link-local, so this
+        // nexthop is always present here. See `endx_nh6` for why a
+        // global is preferred over the link-local.
+        let nh6 = self.endx_nh6();
+
+        if let Some((_, addr)) = self.endx_sid {
+            // SID already allocated. The SID address never changes for
+            // the life of the adjacency, but the preferred nexthop can
+            // (the neighbor's first Hello often carries only the
+            // link-local; a global learned later must upgrade the FIB
+            // entry). Delete-then-add rather than a bare re-add so the
+            // RIB walks back the old nexthop-group reference.
+            if self.endx_installed_nh6 == nh6 {
+                return;
+            }
+            let sid = self.endx_sid_entry(ifname, locator, loc_name, addr, nh6);
+            let _ = rib_client.send(rib::Message::SidDel { addr });
+            let _ = rib_client.send(rib::Message::SidAdd { sid });
+            self.endx_installed_nh6 = nh6;
+            // The advertised SID is unchanged — no LSP re-origination.
+            return;
+        }
+
         let Some(function) = elib.allocate() else {
             return;
         };
@@ -191,15 +243,27 @@ impl Neighbor {
             elib.release(function);
             return;
         };
-        // End.X forwards to the neighbor's IPv6 link-local (from its
-        // IPv6 IIH address TLV). `endx_eligible` guarantees `addr6l` is
-        // non-empty, so this nexthop is always present here.
-        let nh6 = self.addr6l.first().copied();
+        let sid = self.endx_sid_entry(ifname, locator, loc_name, addr, nh6);
+        let _ = rib_client.send(rib::Message::SidAdd { sid });
+        self.endx_sid = Some((function, addr));
+        self.endx_installed_nh6 = nh6;
+        self.reoriginate_endx_if_up();
+    }
+
+    /// Build the RIB registry entry for this neighbor's End.X SID.
+    fn endx_sid_entry(
+        &self,
+        ifname: &str,
+        locator: &Locator,
+        loc_name: String,
+        addr: Ipv6Addr,
+        nh6: Option<Ipv6Addr>,
+    ) -> Sid {
         let (behavior, structure) = match locator.behavior {
             Some(crate::rib::LocatorBehavior::Usid) => (SidBehavior::UA, locator.sid_structure()),
             None => (SidBehavior::EndX, None),
         };
-        let sid = Sid {
+        Sid {
             addr,
             behavior,
             context: SidContext::Interface(ifname.to_string()),
@@ -212,10 +276,7 @@ impl Neighbor {
             // End.X is a local cross-connect, not a table decap.
             table_id: 0,
             segs: Vec::new(),
-        };
-        let _ = rib_client.send(rib::Message::SidAdd { sid });
-        self.endx_sid = Some((function, addr));
-        self.reoriginate_endx_if_up();
+        }
     }
 
     /// Release the neighbor's End.X SID, sending a SidDel and freeing
@@ -228,6 +289,7 @@ impl Neighbor {
     ) {
         if let Some((function, addr)) = self.endx_sid.take() {
             elib.release(function);
+            self.endx_installed_nh6 = None;
             let _ = rib_client.send(rib::Message::SidDel { addr });
         }
     }
@@ -547,5 +609,26 @@ mod tests {
         // eligibility again — the re-evaluation path that releases a SID.
         nbr.proto = Some(IsisTlvProtoSupported { nlpids: vec![v4] });
         assert!(!nbr.endx_eligible());
+    }
+
+    // End.X nexthop selection: a global address (IIH TLV 233) must win
+    // over the link-local because Linux's seg6local End.X resolves nh6
+    // by FIB lookup with the packet's ingress iif — a link-local nh6
+    // binds fe80::/64 to the wrong link and blackholes the repair.
+    #[test]
+    fn endx_nh6_prefers_global_over_linklocal() {
+        let ll: Ipv6Addr = "fe80::1".parse().unwrap();
+        let global: Ipv6Addr = "2001:db8:0:8::2".parse().unwrap();
+
+        let mut nbr = test_neighbor();
+        assert_eq!(nbr.endx_nh6(), None);
+
+        // Link-local only (the common first-Hello state) → fall back.
+        nbr.addr6l = vec![ll];
+        assert_eq!(nbr.endx_nh6(), Some(ll));
+
+        // Global learned later → preferred over the link-local.
+        nbr.addr6.insert(global, NeighborAddr6::new(global));
+        assert_eq!(nbr.endx_nh6(), Some(global));
     }
 }


### PR DESCRIPTION
## Summary
- **Root cause** (found by live tracing on the `@tilfa_classic_srv6` topology): the SRv6 TI-LFA backup path never forwarded. zebra-rs installed `seg6local action End.X nh6 <link-local>`, but Linux's End.X handler (`input_action_end_x` → `seg6_lookup_nexthop`) ignores the route's `dev` and re-resolves `nh6` with a FIB lookup keyed by the packet's **ingress** interface — the link-local nh6 matched `fe80::/64` on the wrong link, the NS went out the ingress interface unanswered, and every repair-segment End.X hop blackholed. Hidden until now because the link-failure scenario pings after SPF has reconverged onto a plain primary, never exercising the SID list itself.
- **Fix**: prefer a global address from the neighbor's IPv6 Global Interface Address TLV (233, RFC 6119 — on-link by definition) for the End.X nexthop, falling back to the link-local. The kernel then resolves the nexthop via the connected prefix onto the correct egress link. Since the first Hello often carries only the link-local, `reconcile_endx_sid` now detects nexthop drift and re-installs the FIB entry (delete-then-add so the RIB walks back the old nexthop-group reference); the advertised SID is unchanged, so no LSP re-origination. Applies to classic `End.X` and `uA` alike.
- **BDD**: new scenario in `isis_tilfa_srv6_classic.feature` pins traffic onto the repair without failing a link (`set router isis fast-reroute backup-as-primary` + `clear isis spf`) and asserts the promoted seg6 kernel route plus end-to-end pings — fails on the old binary, passes with the fix. The `kernel route` harness steps now pick `-4`/`-6` from the prefix: `ip route show` does not infer family, so IPv6 prefixes silently returned nothing (and the negative step passed vacuously).

## Testing
- Live root-cause proof: swapping r1/r2 End.X routes to global nh6 by hand made the repair forward end-to-end (IGP loopback + LAN-to-LAN BGP/SRv6 service traffic); restored afterward.
- Full `@tilfa_classic_srv6` feature against the fixed binary: 6/6 scenarios, 107/107 steps (including the new promoted-backup scenario).
- `cargo fmt` clean, `cargo clippy --workspace --all-targets -- -D warnings` clean, `cargo test --workspace --exclude bdd`: 1601 passed, 0 failed (includes new `endx_nh6_prefers_global_over_linklocal` unit test).

🤖 Generated with [Claude Code](https://claude.com/claude-code)