### PR TITLE
bdd: promoted-backup forwarding scenario for SR-MPLS TI-LFA

### DIFF
--- a/bdd/tests/features/isis_tilfa.feature
+++ b/bdd/tests/features/isis_tilfa.feature
@@ -179,6 +179,28 @@ Feature: IS-IS TI-LFA fast-reroute over SR-MPLS
     Then show command "show isis interface detail" in namespace "s" should not contain "exceeds interface MTU"
     And show command "show isis route" in namespace "n1" should contain "100.99.0.1/32"
 
+  Scenario: Promoted backup actually forwards over the SR-MPLS repair
+    Given the test topology exists
+    # `backup-as-primary` swaps the metric-sort offset so each TI-LFA
+    # repair installs as the active route and the SPF primary demotes
+    # to metric+1; `clear isis spf` recomputes and reinstalls with the
+    # flag applied. Traffic is pinned onto the repair label stack while
+    # every link stays up — proving the repair genuinely forwards,
+    # which the link-failure scenario cannot (by ping time SPF has
+    # already reconverged onto a plain post-convergence primary).
+    # s is running s-lspmtu-ok.yaml here, which keeps segment-routing
+    # mpls + fast-reroute ti-lfa, so the repair is still computed.
+    When I apply command "set router isis fast-reroute backup-as-primary" in namespace "s"
+    And I run "clear isis spf" in namespace "s"
+    # d's loopback route now has the label-stack repair as its best
+    # kernel entry: out the repair egress s-n2 at metric 12 (2 path +
+    # 10 for d's loopback prefix), demoted plain primary behind at 13.
+    Then kernel route "10.0.0.8" in namespace "s" should eventually contain "encap mpls"
+    And kernel route "10.0.0.8" in namespace "s" should eventually contain "dev s-n2 proto isis metric 12"
+    # End-to-end over the repair: dies if any label hop on the repair
+    # path fails to swap/pop/forward.
+    And ping from "s" to "10.0.0.8" should succeed
+
   Scenario: Teardown topology
     Given the test topology exists
     When I stop zebra-rs in namespace "s"


### PR DESCRIPTION
## Summary
- Adds the `backup-as-primary` + `clear isis spf` scenario to `isis_tilfa.feature`, mirroring the SRv6 siblings but adapted to SR-MPLS: traffic is pinned onto the TI-LFA repair label stack with all links up, asserting the promoted `encap mpls` kernel route (repair egress `s-n2`, metric 12 = 2 path + 10 loopback prefix) and an end-to-end ping over it.
- Placed just before teardown; at that point `s` runs `s-lspmtu-ok.yaml`, which keeps `segment-routing mpls` + `fast-reroute ti-lfa`, so the repair is still computed.
- Closes the same coverage gap fixed for SRv6 in #1361: the link-failure scenario only pings after SPF has reconverged onto a plain primary, so the repair label stack itself was never exercised. (The MPLS dataplane passes as-is — the End.X blackhole was SRv6-specific.)

## Testing
- Full `@isis_tilfa` feature run locally: 12/12 scenarios passed (108 steps), including the new scenario; environment clean after teardown.

🤖 Generated with [Claude Code](https://claude.com/claude-code)