### PR TITLE
isis: NEXT-C-SID carrier compression for TI-LFA SRv6 repair paths

### DIFF
--- a/bdd/tests/features/isis_tilfa_srv6.feature
+++ b/bdd/tests/features/isis_tilfa_srv6.feature
@@ -120,6 +120,9 @@ Feature: IS-IS TI-LFA fast-reroute over SRv6 with BGP L3 service traffic
     # for each IPv6-capable adjacency.
     Then show command "show segment-routing srv6 sid" in namespace "s" should contain "uN"
     And show command "show segment-routing srv6 sid" in namespace "s" should contain "uA"
+    # Each uA also installs its LIB twin — the block:function prefix
+    # entry a NEXT-C-SID carrier hits after the local uN shift.
+    And show command "show segment-routing srv6 sid" in namespace "s" should contain "uA(LIB)"
     # The s-n1-protected IPv6 routes carry a pre-computed TI-LFA repair
     # expressed as an SRv6 SID list, installed by SRH insertion: the
     # repair segments are transit End/End.X SIDs, so the original
@@ -179,6 +182,10 @@ Feature: IS-IS TI-LFA fast-reroute over SRv6 with BGP L3 service traffic
     # 10 for d's loopback prefix), demoted plain primary behind at 13.
     Then kernel route "2001:db8::8" in namespace "s" should eventually contain "mode inline"
     And kernel route "2001:db8::8" in namespace "s" should eventually contain "dev s-n2 proto isis metric 12"
+    # NEXT-C-SID compression: the three repair uSIDs (uN of the P node
+    # plus two uAs) ride one 128-bit carrier, so the inserted SRH is
+    # carrier + original destination — 2 segments, not 4.
+    And kernel route "2001:db8::8" in namespace "s" should eventually contain "segs 2 ["
     # End-to-end over the repair: the IGP loopback path and the
     # BGP/SRv6 LAN-to-LAN service traffic, whose H.Encaps outer
     # destination resolves via the promoted locator route. These die

--- a/crates/isis-packet/src/sub/srv6.rs
+++ b/crates/isis-packet/src/sub/srv6.rs
@@ -79,6 +79,44 @@ pub enum Behavior {
     Resv(u16),
 }
 
+impl Behavior {
+    /// RFC 9800 NEXT-C-SID flavor of End (uN), any PSP/USP/USD
+    /// combination. A SID advertised with one of these consumes a
+    /// locator-node-sized identifier from a uSID carrier.
+    pub fn is_end_next_csid(&self) -> bool {
+        use Behavior::*;
+        matches!(
+            self,
+            EndCSID
+                | EndCSIDPSP
+                | EndCSIDUSP
+                | EndCSIDPSPUSP
+                | EndCSIDUSD
+                | EndCSIDPSPUSD
+                | EndCSIDUSPUSD
+                | EndCSIDPSPUSPUSD
+        )
+    }
+
+    /// RFC 9800 NEXT-C-SID flavor of End.X (uA), any PSP/USP/USD
+    /// combination. A SID advertised with one of these consumes a
+    /// function-sized identifier from a uSID carrier.
+    pub fn is_endx_next_csid(&self) -> bool {
+        use Behavior::*;
+        matches!(
+            self,
+            EndXCSID
+                | EndXCSIDPSP
+                | EndXCSIDUSP
+                | EndXCSIDPSPUSP
+                | EndXCSIDUSD
+                | EndXCSIDPSPUSD
+                | EndXCSIDUSPUSD
+                | EndXCSIDPSPUSPUSD
+        )
+    }
+}
+
 impl From<Behavior> for u16 {
     fn from(typ: Behavior) -> Self {
         use Behavior::*;

--- a/zebra-rs/src/fib/netlink/handle.rs
+++ b/zebra-rs/src/fib/netlink/handle.rs
@@ -215,6 +215,22 @@ fn sid_route_target(
             )
         }
         SidBehavior::UA => (RouteHeader::RT_TABLE_MAIN, RouteType::Unicast, 128, addr),
+        // LIB twin of a uA: a block:function prefix entry that matches
+        // the uA when it is the carrier's *active* uSID (post-uN-shift
+        // DA). /(LB+Fun) with the NEXT-CSID flavor — verified live on
+        // 6.8 (shift while uSIDs remain, classic End.X at end-of-
+        // carrier).
+        SidBehavior::UALib => {
+            let plen = structure
+                .map(|s| s.lb_bits.saturating_add(s.fun_bits))
+                .unwrap_or(128);
+            (
+                RouteHeader::RT_TABLE_MAIN,
+                RouteType::Unicast,
+                plen,
+                mask_v6(addr, plen),
+            )
+        }
         // End.DT4 / End.DT6 / End.DT46 are terminal decap+lookup
         // actions. Same FIB shape as End.X — a /128 host route in
         // table=main with kind=Unicast, pointed at sr0 by the static

--- a/zebra-rs/src/fib/netlink/srv6.rs
+++ b/zebra-rs/src/fib/netlink/srv6.rs
@@ -119,7 +119,7 @@ fn build_srh(segments: &[Ipv6Addr]) -> Ipv6SrHdr {
 fn seg6local_action(behavior: SidBehavior) -> Seg6LocalAction {
     match behavior {
         SidBehavior::End | SidBehavior::UN => Seg6LocalAction::End,
-        SidBehavior::EndX | SidBehavior::UA => Seg6LocalAction::EndX,
+        SidBehavior::EndX | SidBehavior::UA | SidBehavior::UALib => Seg6LocalAction::EndX,
         SidBehavior::EndDT4 => Seg6LocalAction::EndDt4,
         SidBehavior::EndDT6 => Seg6LocalAction::EndDt6,
         SidBehavior::EndDT46 => Seg6LocalAction::EndDt46,
@@ -149,20 +149,22 @@ fn build_seg6local_flavors(
     behavior: SidBehavior,
     structure: Option<SidStructure>,
 ) -> Option<RouteSeg6LocalIpTunnel> {
-    if !matches!(behavior, SidBehavior::UN) {
-        return None;
-    }
+    // Nflen is the width of the uSID identifier being consumed at this
+    // entry — the bits the kernel shifts out to expose the next uSID.
+    // Lblen is the shared block portion that stays put. For uN that
+    // identifier is the locator-node id (LN); for the LIB twin of a uA
+    // it is the function. The remaining bits to the right are the
+    // carrier's pending uSIDs.
+    let nflen = match behavior {
+        SidBehavior::UN => structure?.ln_bits,
+        SidBehavior::UALib => structure?.fun_bits,
+        _ => return None,
+    };
     let s = structure?;
-    // Nflen is the *node* portion of a uSID — the bits the kernel
-    // shifts on each hop to expose the next uSID identifier. The
-    // function bits belong to the uSID that's being consumed (they
-    // pick the action), not to the next one's position, so they don't
-    // count toward the shift width. Lblen is the shared block portion
-    // that stays put.
     Some(RouteSeg6LocalIpTunnel::Flavors(vec![
         Seg6LocalFlavors::Operation(Seg6LocalFlavorOps::NextCsid),
         Seg6LocalFlavors::Lblen(s.lb_bits),
-        Seg6LocalFlavors::Nflen(s.ln_bits),
+        Seg6LocalFlavors::Nflen(nflen),
     ]))
 }
 
@@ -195,7 +197,10 @@ fn build_seg6local_lwtunnel(
 ) -> Option<Vec<RouteLwTunnelEncap>> {
     let mut attrs: Vec<RouteSeg6LocalIpTunnel> =
         vec![RouteSeg6LocalIpTunnel::Action(seg6local_action(behavior))];
-    if matches!(behavior, SidBehavior::EndX | SidBehavior::UA) {
+    if matches!(
+        behavior,
+        SidBehavior::EndX | SidBehavior::UA | SidBehavior::UALib
+    ) {
         let nh = nh6?;
         attrs.push(RouteSeg6LocalIpTunnel::Nh6(nh));
     }

--- a/zebra-rs/src/isis/inst.rs
+++ b/zebra-rs/src/isis/inst.rs
@@ -1,6 +1,6 @@
 use std::collections::{BTreeMap, BTreeSet, HashMap};
 use std::fmt::Display;
-use std::net::{Ipv4Addr, Ipv6Addr};
+use std::net::Ipv4Addr;
 
 use ipnet::{Ipv4Net, Ipv6Net};
 use isis_packet::*;
@@ -199,7 +199,7 @@ pub struct Isis {
     /// sub-TLV `IsisSubSrv6EndSid` carried inside each peer's LSP
     /// (parallel to label_map for SR-MPLS). Used by TI-LFA to
     /// assemble the SRH segment list for a 1-segment repair.
-    pub srv6_end_map: Levels<BTreeMap<IsisSysId, Ipv6Addr>>,
+    pub srv6_end_map: Levels<BTreeMap<IsisSysId, super::srv6::Srv6EndSidInfo>>,
 
     /// Per-peer Flex-Algorithm Definition store. Outer key is peer
     /// sys-id; inner key is the algo identifier (128..=255). Populated
@@ -487,7 +487,7 @@ pub struct IsisTop<'a> {
     pub mt2_reach_map_v6: &'a mut Levels<ReachMapV6>,
     pub mt_membership: &'a mut Levels<BTreeMap<IsisSysId, BTreeSet<MtId>>>,
     pub label_map: &'a mut Levels<IsisLabelMap>,
-    pub srv6_end_map: &'a mut Levels<BTreeMap<IsisSysId, Ipv6Addr>>,
+    pub srv6_end_map: &'a mut Levels<BTreeMap<IsisSysId, super::srv6::Srv6EndSidInfo>>,
     /// Per-peer FAD store (see `Isis::peer_fad`). Threaded through
     /// IsisTop so the LSDB rebuild path can populate it from peer
     /// Router Capability TLVs.
@@ -645,7 +645,7 @@ impl Isis {
                 mt2_reach_map_v6: Levels::<ReachMapV6>::default(),
                 mt_membership: Levels::<BTreeMap<IsisSysId, BTreeSet<MtId>>>::default(),
                 label_map: Levels::<IsisLabelMap>::default(),
-                srv6_end_map: Levels::<BTreeMap<IsisSysId, Ipv6Addr>>::default(),
+                srv6_end_map: Levels::<BTreeMap<IsisSysId, super::srv6::Srv6EndSidInfo>>::default(),
                 peer_fad: Levels::<
                     BTreeMap<IsisSysId, BTreeMap<u8, isis_packet::IsisSubFlexAlgoDef>>,
                 >::default(),

--- a/zebra-rs/src/isis/link.rs
+++ b/zebra-rs/src/isis/link.rs
@@ -141,7 +141,8 @@ pub struct LinkTop<'a> {
     pub mt_membership:
         &'a mut Levels<std::collections::BTreeMap<IsisSysId, std::collections::BTreeSet<MtId>>>,
     pub label_map: &'a mut Levels<IsisLabelMap>,
-    pub srv6_end_map: &'a mut Levels<std::collections::BTreeMap<IsisSysId, std::net::Ipv6Addr>>,
+    pub srv6_end_map:
+        &'a mut Levels<std::collections::BTreeMap<IsisSysId, super::srv6::Srv6EndSidInfo>>,
     pub peer_fad: &'a mut Levels<
         std::collections::BTreeMap<
             IsisSysId,

--- a/zebra-rs/src/isis/lsdb.rs
+++ b/zebra-rs/src/isis/lsdb.rs
@@ -1,6 +1,5 @@
 use std::collections::btree_map::{Iter, Values};
 use std::collections::{BTreeMap, BTreeSet};
-use std::net::Ipv6Addr;
 use std::time::{Duration, Instant};
 
 use ipnet::Ipv4Net;
@@ -180,7 +179,7 @@ pub(super) struct SysStateRefs<'a> {
     pub reach_v6: &'a mut ReachMapV6,
     pub mt_membership: &'a mut BTreeMap<IsisSysId, BTreeSet<MtId>>,
     pub mt2_reach_v6: &'a mut ReachMapV6,
-    pub srv6_end_map: &'a mut BTreeMap<IsisSysId, Ipv6Addr>,
+    pub srv6_end_map: &'a mut BTreeMap<IsisSysId, super::srv6::Srv6EndSidInfo>,
     /// Per-peer Flex-Algorithm Definition store. Outer key is peer
     /// sys-id, inner key is the FAD's `flex_algorithm` field
     /// (128..=255). RFC 9350 §5.1 places FADs inside Router
@@ -436,7 +435,7 @@ pub(super) fn rebuild_sys_state(
     let mut v4_entries: Vec<IsisTlvExtIpReachEntry> = Vec::new();
     let mut v6_entries: Vec<IsisTlvIpv6ReachEntry> = Vec::new();
     let mut mt2_v6_entries: Vec<IsisTlvIpv6ReachEntry> = Vec::new();
-    let mut end_sid: Option<Ipv6Addr> = None;
+    let mut end_sid: Option<super::srv6::Srv6EndSidInfo> = None;
 
     for f in &frags {
         for tlv in &f.tlvs {
@@ -450,7 +449,21 @@ pub(super) fn rebuild_sys_state(
                     'outer: for locator in &t.locators {
                         for sub in &locator.subs {
                             if let prefix::IsisSubTlv::Srv6EndSid(es) = sub {
-                                end_sid = Some(es.sid);
+                                // Keep behavior + SID structure alongside the
+                                // address: the TI-LFA encoder needs them to
+                                // decide NEXT-C-SID carrier membership.
+                                let structure = es.sub2s.iter().find_map(|s2| {
+                                    if let isis_packet::IsisSub2Tlv::SidStructure(st) = s2 {
+                                        Some(st.clone())
+                                    } else {
+                                        None
+                                    }
+                                });
+                                end_sid = Some(super::srv6::Srv6EndSidInfo {
+                                    sid: es.sid,
+                                    behavior: es.behavior,
+                                    structure,
+                                });
                                 break 'outer;
                             }
                         }
@@ -803,7 +816,8 @@ mod tests {
         let mut reach_v6 = ReachMapV6::default();
         let mut mt_membership: BTreeMap<IsisSysId, BTreeSet<MtId>> = BTreeMap::new();
         let mut mt2_reach_v6 = ReachMapV6::default();
-        let mut srv6_end_map: BTreeMap<IsisSysId, Ipv6Addr> = BTreeMap::new();
+        let mut srv6_end_map: BTreeMap<IsisSysId, crate::isis::srv6::Srv6EndSidInfo> =
+            BTreeMap::new();
         let mut peer_fad: BTreeMap<IsisSysId, BTreeMap<u8, IsisSubFlexAlgoDef>> = BTreeMap::new();
         let mut peer_link_affinity: BTreeMap<IsisSysId, BTreeMap<IsisNeighborId, ExtAdminGroup>> =
             BTreeMap::new();
@@ -917,7 +931,8 @@ mod tests {
         let mut reach_v6 = ReachMapV6::default();
         let mut mt_membership: BTreeMap<IsisSysId, BTreeSet<MtId>> = BTreeMap::new();
         let mut mt2_reach_v6 = ReachMapV6::default();
-        let mut srv6_end_map: BTreeMap<IsisSysId, Ipv6Addr> = BTreeMap::new();
+        let mut srv6_end_map: BTreeMap<IsisSysId, crate::isis::srv6::Srv6EndSidInfo> =
+            BTreeMap::new();
         let mut peer_fad: BTreeMap<IsisSysId, BTreeMap<u8, IsisSubFlexAlgoDef>> = BTreeMap::new();
         let mut peer_link_affinity: BTreeMap<IsisSysId, BTreeMap<IsisNeighborId, ExtAdminGroup>> =
             BTreeMap::new();
@@ -991,7 +1006,8 @@ mod tests {
         let mut reach_v6 = ReachMapV6::default();
         let mut mt_membership: BTreeMap<IsisSysId, BTreeSet<MtId>> = BTreeMap::new();
         let mut mt2_reach_v6 = ReachMapV6::default();
-        let mut srv6_end_map: BTreeMap<IsisSysId, Ipv6Addr> = BTreeMap::new();
+        let mut srv6_end_map: BTreeMap<IsisSysId, crate::isis::srv6::Srv6EndSidInfo> =
+            BTreeMap::new();
         let mut peer_fad: BTreeMap<IsisSysId, BTreeMap<u8, IsisSubFlexAlgoDef>> = BTreeMap::new();
         let mut peer_link_affinity: BTreeMap<IsisSysId, BTreeMap<IsisNeighborId, ExtAdminGroup>> =
             BTreeMap::new();
@@ -1108,7 +1124,8 @@ mod tests {
         let mut reach_v6 = ReachMapV6::default();
         let mut mt_membership: BTreeMap<IsisSysId, BTreeSet<MtId>> = BTreeMap::new();
         let mut mt2_reach_v6 = ReachMapV6::default();
-        let mut srv6_end_map: BTreeMap<IsisSysId, Ipv6Addr> = BTreeMap::new();
+        let mut srv6_end_map: BTreeMap<IsisSysId, crate::isis::srv6::Srv6EndSidInfo> =
+            BTreeMap::new();
         let mut peer_fad: BTreeMap<IsisSysId, BTreeMap<u8, IsisSubFlexAlgoDef>> = BTreeMap::new();
         let mut peer_link_affinity: BTreeMap<IsisSysId, BTreeMap<IsisNeighborId, ExtAdminGroup>> =
             BTreeMap::new();
@@ -1207,7 +1224,8 @@ mod tests {
         let mut reach_v6 = ReachMapV6::default();
         let mut mt_membership: BTreeMap<IsisSysId, BTreeSet<MtId>> = BTreeMap::new();
         let mut mt2_reach_v6 = ReachMapV6::default();
-        let mut srv6_end_map: BTreeMap<IsisSysId, Ipv6Addr> = BTreeMap::new();
+        let mut srv6_end_map: BTreeMap<IsisSysId, crate::isis::srv6::Srv6EndSidInfo> =
+            BTreeMap::new();
         let mut peer_fad: BTreeMap<IsisSysId, BTreeMap<u8, IsisSubFlexAlgoDef>> = BTreeMap::new();
         let mut peer_link_affinity: BTreeMap<IsisSysId, BTreeMap<IsisNeighborId, ExtAdminGroup>> =
             BTreeMap::new();
@@ -1295,7 +1313,8 @@ mod tests {
         let mut reach_v6 = ReachMapV6::default();
         let mut mt_membership: BTreeMap<IsisSysId, BTreeSet<MtId>> = BTreeMap::new();
         let mut mt2_reach_v6 = ReachMapV6::default();
-        let mut srv6_end_map: BTreeMap<IsisSysId, Ipv6Addr> = BTreeMap::new();
+        let mut srv6_end_map: BTreeMap<IsisSysId, crate::isis::srv6::Srv6EndSidInfo> =
+            BTreeMap::new();
         let mut peer_fad: BTreeMap<IsisSysId, BTreeMap<u8, IsisSubFlexAlgoDef>> = BTreeMap::new();
         let mut peer_link_affinity: BTreeMap<IsisSysId, BTreeMap<IsisNeighborId, ExtAdminGroup>> =
             BTreeMap::new();

--- a/zebra-rs/src/isis/neigh.rs
+++ b/zebra-rs/src/isis/neigh.rs
@@ -9,7 +9,7 @@ use tokio::sync::mpsc::UnboundedSender;
 
 use crate::config::Args;
 use crate::context::Timer;
-use crate::isis::srv6::{ElibPool, function_addr};
+use crate::isis::srv6::{ElibPool, function_addr, lib_addr};
 use crate::rib;
 use crate::rib::MacAddr;
 use crate::rib::{Locator, Sid, SidAllocationType, SidBehavior, SidContext, SidOwner};
@@ -51,6 +51,13 @@ pub struct Neighbor {
     /// registry). `None` until the locator is resolved and the first
     /// allocator pass picks a function.
     pub endx_sid: Option<(u16, Ipv6Addr)>,
+
+    /// LIB twin of the End.X SID — the `block:function` prefix entry
+    /// that matches the uA when it is a NEXT-C-SID carrier's active
+    /// uSID (post-uN-shift DA). Only allocated for uSID locators;
+    /// `None` for classic. Tracked so release / nexthop-drift handle
+    /// both kernel entries in lockstep.
+    pub endx_lib_sid: Option<Ipv6Addr>,
 
     /// The nexthop the installed End.X SID currently forwards to.
     /// Tracked separately from `endx_sid` because the SID address is
@@ -96,6 +103,7 @@ impl Neighbor {
             hold_time: 0,
             network_type,
             endx_sid: None,
+            endx_lib_sid: None,
             endx_installed_nh6: None,
             gr: AdjGrState::default(),
             created: true,
@@ -216,7 +224,7 @@ impl Neighbor {
         // global is preferred over the link-local.
         let nh6 = self.endx_nh6();
 
-        if let Some((_, addr)) = self.endx_sid {
+        if let Some((function, addr)) = self.endx_sid {
             // SID already allocated. The SID address never changes for
             // the life of the adjacency, but the preferred nexthop can
             // (the neighbor's first Hello often carries only the
@@ -226,9 +234,12 @@ impl Neighbor {
             if self.endx_installed_nh6 == nh6 {
                 return;
             }
-            let sid = self.endx_sid_entry(ifname, locator, loc_name, addr, nh6);
+            let sid = self.endx_sid_entry(ifname, locator, loc_name.clone(), addr, nh6);
             let _ = rib_client.send(rib::Message::SidDel { addr });
             let _ = rib_client.send(rib::Message::SidAdd { sid });
+            self.reconcile_endx_lib_sid(
+                ifname, locator, loc_name, prefix, function, nh6, rib_client,
+            );
             self.endx_installed_nh6 = nh6;
             // The advertised SID is unchanged — no LSP re-origination.
             return;
@@ -243,11 +254,58 @@ impl Neighbor {
             elib.release(function);
             return;
         };
-        let sid = self.endx_sid_entry(ifname, locator, loc_name, addr, nh6);
+        let sid = self.endx_sid_entry(ifname, locator, loc_name.clone(), addr, nh6);
         let _ = rib_client.send(rib::Message::SidAdd { sid });
+        self.reconcile_endx_lib_sid(ifname, locator, loc_name, prefix, function, nh6, rib_client);
         self.endx_sid = Some((function, addr));
         self.endx_installed_nh6 = nh6;
         self.reoriginate_endx_if_up();
+    }
+
+    /// (Re-)install the LIB twin of this neighbor's uA — the
+    /// `block:function` prefix entry a NEXT-C-SID carrier hits after
+    /// the local uN shift. No-op (beyond clearing any stale twin) for
+    /// classic locators: only uSID SIDs ride in carriers. Never
+    /// advertised — the LSP carries the full uA; the twin is pure
+    /// local FIB plumbing, so no LSP re-origination either.
+    #[allow(clippy::too_many_arguments)]
+    fn reconcile_endx_lib_sid(
+        &mut self,
+        ifname: &str,
+        locator: &Locator,
+        loc_name: String,
+        prefix: ipnet::Ipv6Net,
+        function: u16,
+        nh6: Option<Ipv6Addr>,
+        rib_client: &crate::rib::client::RibClient,
+    ) {
+        if let Some(addr) = self.endx_lib_sid.take() {
+            let _ = rib_client.send(rib::Message::SidDel { addr });
+        }
+        if !matches!(locator.behavior, Some(crate::rib::LocatorBehavior::Usid)) {
+            return;
+        }
+        let Some(structure) = locator.sid_structure() else {
+            return;
+        };
+        let Some(addr) = lib_addr(prefix, structure.lb_bits, function) else {
+            return;
+        };
+        let sid = Sid {
+            addr,
+            behavior: SidBehavior::UALib,
+            context: SidContext::Interface(ifname.to_string()),
+            owner: SidOwner::new("isis", 0),
+            locator: loc_name,
+            allocation_type: SidAllocationType::Dynamic,
+            ifindex: self.ifindex,
+            nh6,
+            structure: Some(structure),
+            table_id: 0,
+            segs: Vec::new(),
+        };
+        let _ = rib_client.send(rib::Message::SidAdd { sid });
+        self.endx_lib_sid = Some(addr);
     }
 
     /// Build the RIB registry entry for this neighbor's End.X SID.
@@ -290,6 +348,9 @@ impl Neighbor {
         if let Some((function, addr)) = self.endx_sid.take() {
             elib.release(function);
             self.endx_installed_nh6 = None;
+            let _ = rib_client.send(rib::Message::SidDel { addr });
+        }
+        if let Some(addr) = self.endx_lib_sid.take() {
             let _ = rib_client.send(rib::Message::SidDel { addr });
         }
     }

--- a/zebra-rs/src/isis/srv6.rs
+++ b/zebra-rs/src/isis/srv6.rs
@@ -89,6 +89,38 @@ pub fn function_addr(prefix: Ipv6Net, function: u16) -> Option<Ipv6Addr> {
     Some(Ipv6Addr::from(base | ((function as u128) << shift)))
 }
 
+/// Build the LIB (compressed-shape) address of a uA: the 16-bit
+/// function placed immediately after the locator BLOCK — no
+/// locator-node bits. This is how the uA appears as the carrier's
+/// active uSID after the owner's uN shift, so it's the address the
+/// flavored End.X FIB twin anchors at. Returns `None` when the block
+/// is too long to fit a 16-bit function.
+///
+/// Example: locator fcbb:bbbb:5::/48 (LB 32) + 0xE003 →
+/// fcbb:bbbb:e003:: — note the node id (5) is gone.
+pub fn lib_addr(prefix: Ipv6Net, lb_bits: u8, function: u16) -> Option<Ipv6Addr> {
+    let lb = lb_bits as u32;
+    if lb + 16 > 128 {
+        return None;
+    }
+    let base: u128 = u128::from(prefix.network());
+    let block_mask: u128 = if lb == 0 { 0 } else { u128::MAX << (128 - lb) };
+    let shift = 128 - lb - 16;
+    Some(Ipv6Addr::from(
+        (base & block_mask) | ((function as u128) << shift),
+    ))
+}
+
+/// A peer's SRv6 End SID as learned from its SRv6 Locator TLV —
+/// the SID plus the endpoint behavior and SID structure needed to
+/// decide NEXT-C-SID carrier membership when encoding repair lists.
+#[derive(Debug, Clone, PartialEq)]
+pub struct Srv6EndSidInfo {
+    pub sid: Ipv6Addr,
+    pub behavior: isis_packet::Behavior,
+    pub structure: Option<isis_packet::IsisSub2SidStructure>,
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -121,6 +153,29 @@ mod tests {
         pool.reset();
         assert_eq!(pool.allocate(), Some(0xE000));
         assert!(!pool.is_used(0xE001));
+    }
+
+    // The LIB form drops the locator-node bits: function right after
+    // the block, exactly where a carrier exposes it post-uN-shift.
+    #[test]
+    fn lib_addr_places_function_after_block() {
+        let prefix: Ipv6Net = "fcbb:bbbb:5::/48".parse().unwrap();
+        let sid = lib_addr(prefix, 32, 0xE003).unwrap();
+        assert_eq!(sid, "fcbb:bbbb:e003::".parse::<Ipv6Addr>().unwrap());
+    }
+
+    // Host bits beyond the block must not leak into the LIB address.
+    #[test]
+    fn lib_addr_masks_node_bits_out_of_the_block() {
+        let prefix: Ipv6Net = "fcbb:bbbb:ffff::/48".parse().unwrap();
+        let sid = lib_addr(prefix, 32, 0x0001).unwrap();
+        assert_eq!(sid, "fcbb:bbbb:1::".parse::<Ipv6Addr>().unwrap());
+    }
+
+    #[test]
+    fn lib_addr_rejects_block_too_long_for_function() {
+        let prefix: Ipv6Net = "fcbb::/128".parse().unwrap();
+        assert_eq!(lib_addr(prefix, 120, 0xE000), None);
     }
 
     #[test]

--- a/zebra-rs/src/isis/tilfa.rs
+++ b/zebra-rs/src/isis/tilfa.rs
@@ -126,25 +126,35 @@ pub(super) fn build_repair_path_srv6(
     rp: &spf::RepairPath,
 ) -> Option<RepairPathSrv6> {
     let lsp_map = top.lsp_map.get(&level);
-    let mut segs: Vec<Ipv6Addr> = Vec::with_capacity(rp.segs.len());
+    let mut parts: Vec<RepairSeg> = Vec::with_capacity(rp.segs.len());
     for (idx, seg) in rp.segs.iter().enumerate() {
         let resolved = match seg {
             spf::SrSegment::NodeSid(v) => lsp_map
                 .resolve(*v)
-                .and_then(|sys_id| top.srv6_end_map.get(&level).get(sys_id).copied()),
+                .and_then(|sys_id| top.srv6_end_map.get(&level).get(sys_id).cloned())
+                .map(|info| RepairSeg {
+                    sid: info.sid,
+                    landing: *v,
+                    csid: csid_bits_end(&info),
+                }),
             spf::SrSegment::AdjSid(from, to, via) => {
-                srv6_endx_sid_for_link(top, level, *from, *to, *via)
+                srv6_endx_sid_for_link(top, level, *from, *to, *via).map(|endx| RepairSeg {
+                    sid: endx.sid,
+                    landing: *to,
+                    csid: csid_bits_endx(&endx, *from),
+                })
             }
         };
-        let Some(sid) = resolved else {
+        let Some(part) = resolved else {
             tracing::debug!(
                 "[tilfa] {level:?} repair segment[{idx}] {seg:?} failed to resolve to an SRv6 \
-                 SID; dropping repair list (partial: {segs:?})"
+                 SID; dropping repair list (partial: {parts:?})"
             );
             return None;
         };
-        segs.push(sid);
+        parts.push(part);
     }
+    let segs = pack_carriers(&parts);
 
     let ifindex = (rp.first_hop_link_id != 0).then_some(rp.first_hop_link_id)?;
     let link = top.links.get(&ifindex)?;
@@ -177,6 +187,25 @@ pub(super) fn build_repair_path_srv6(
     })
 }
 
+/// SRv6 End.X SID as advertised in an IS-reach sub-TLV: the SID plus
+/// the endpoint behavior and SID structure the carrier packer needs.
+#[derive(Debug, Clone)]
+struct Srv6EndXInfo {
+    sid: Ipv6Addr,
+    behavior: isis_packet::Behavior,
+    structure: Option<isis_packet::IsisSub2SidStructure>,
+}
+
+fn endx_structure(sub2s: &[isis_packet::IsisSub2Tlv]) -> Option<isis_packet::IsisSub2SidStructure> {
+    sub2s.iter().find_map(|s2| {
+        if let isis_packet::IsisSub2Tlv::SidStructure(st) = s2 {
+            Some(st.clone())
+        } else {
+            None
+        }
+    })
+}
+
 /// Look up the SRv6 End.X SID `from` advertises for the link to `to`
 /// — the SRv6 sibling of `adj_sid_label_for_link`. For LAN
 /// adjacencies (`via_pseudonode = Some(pn)`) the IS Reach entry's
@@ -190,7 +219,7 @@ fn srv6_endx_sid_for_link(
     from_vertex: usize,
     to_vertex: usize,
     via_pseudonode: Option<usize>,
-) -> Option<Ipv6Addr> {
+) -> Option<Srv6EndXInfo> {
     let from_sys = *top.lsp_map.get(&level).resolve(from_vertex)?;
     let target_neighbor_id = if let Some(via_v) = via_pseudonode {
         *top.lsp_map.get(&level).resolve_neighbor(via_v)?
@@ -218,14 +247,22 @@ fn srv6_endx_sid_for_link(
                 for sub in &entry.subs {
                     match sub {
                         neigh::IsisSubTlv::Srv6EndXSid(endx) => {
-                            return Some(endx.sid);
+                            return Some(Srv6EndXInfo {
+                                sid: endx.sid,
+                                behavior: endx.behavior,
+                                structure: endx_structure(&endx.sub2s),
+                            });
                         }
                         neigh::IsisSubTlv::Srv6LanEndXSid(lan_endx) => {
                             let Some(to_sys) = top.lsp_map.get(&level).resolve(to_vertex) else {
                                 continue;
                             };
                             if &lan_endx.system_id == to_sys {
-                                return Some(lan_endx.sid);
+                                return Some(Srv6EndXInfo {
+                                    sid: lan_endx.sid,
+                                    behavior: lan_endx.behavior,
+                                    structure: endx_structure(&lan_endx.sub2s),
+                                });
                             }
                         }
                         _ => {}
@@ -479,4 +516,376 @@ pub(super) fn tilfa_repair_path(
         }
     }
     tilfa_result
+}
+
+/// One resolved SRv6 repair segment plus the NEXT-C-SID metadata the
+/// carrier packer needs. `sid` is always the full advertised address,
+/// usable verbatim when the segment can't ride in a carrier.
+#[derive(Debug)]
+struct RepairSeg {
+    sid: Ipv6Addr,
+    /// Vertex the packet sits on once this segment is consumed —
+    /// the SID's owner for an End/uN, the adjacency's far end for an
+    /// End.X/uA. Drives the LIB-continuity check below.
+    landing: usize,
+    /// `Some` when the SID was advertised with a NEXT-C-SID behavior
+    /// and a usable structure; `None` forces full-SID encoding.
+    csid: Option<CsidBits>,
+}
+
+/// The bits a segment contributes to a uSID carrier.
+#[derive(Debug, Clone, Copy, PartialEq)]
+struct CsidBits {
+    /// The shared uSID block — the SID's first `lb` bits, masked.
+    block: u128,
+    lb: u8,
+    /// The identifier consumed at the owner: locator-node bits for a
+    /// uN, function bits for a uA. Right-aligned value.
+    id: u128,
+    width: u8,
+    /// For a uA: the vertex that owns the adjacency. A LIB identifier
+    /// is only locally significant, so it may only follow a segment
+    /// that lands the packet on its owner; `None` for a uN, which is
+    /// globally routable via the locator prefix.
+    lib_owner: Option<usize>,
+}
+
+fn sid_bits(sid: Ipv6Addr, start: u32, width: u32) -> u128 {
+    if width == 0 || start + width > 128 {
+        return 0;
+    }
+    (u128::from(sid) >> (128 - start - width)) & ((1u128 << width) - 1)
+}
+
+fn sid_block(sid: Ipv6Addr, lb: u8) -> u128 {
+    if lb == 0 {
+        return 0;
+    }
+    u128::from(sid) & (u128::MAX << (128 - lb as u32))
+}
+
+/// Carrier metadata for a uN: the identifier is the locator-node
+/// portion (bits `[lb, lb+ln)`).
+fn csid_bits_end(info: &super::srv6::Srv6EndSidInfo) -> Option<CsidBits> {
+    if !info.behavior.is_end_next_csid() {
+        return None;
+    }
+    let st = info.structure.as_ref()?;
+    let (lb, ln) = (st.lb_len as u32, st.ln_len as u32);
+    if ln == 0 || lb + ln > 128 {
+        return None;
+    }
+    Some(CsidBits {
+        block: sid_block(info.sid, st.lb_len),
+        lb: st.lb_len,
+        id: sid_bits(info.sid, lb, ln),
+        width: st.ln_len,
+        lib_owner: None,
+    })
+}
+
+/// Carrier metadata for a uA: the identifier is the function portion
+/// (bits `[lb+ln, lb+ln+fun)`); the node bits are implicit because a
+/// packed uA only becomes active once the packet sits on its owner.
+fn csid_bits_endx(endx: &Srv6EndXInfo, owner: usize) -> Option<CsidBits> {
+    if !endx.behavior.is_endx_next_csid() {
+        return None;
+    }
+    let st = endx.structure.as_ref()?;
+    let (lb, ln, fun) = (st.lb_len as u32, st.ln_len as u32, st.fun_len as u32);
+    if fun == 0 || lb + ln + fun > 128 {
+        return None;
+    }
+    Some(CsidBits {
+        block: sid_block(endx.sid, st.lb_len),
+        lb: st.lb_len,
+        id: sid_bits(endx.sid, lb + ln, fun),
+        width: st.fun_len,
+        lib_owner: Some(owner),
+    })
+}
+
+/// In-progress uSID carrier: block bits up front, identifiers appended
+/// left-to-right in traversal order, zero-padded tail (the zero
+/// remainder is what triggers each node's end-of-carrier fallback).
+struct Carrier {
+    val: u128,
+    block: u128,
+    lb: u8,
+    /// Next free bit position (starts at `lb`).
+    pos: u32,
+    /// Identifiers packed so far — a single-id carrier is re-emitted
+    /// as the segment's full SID instead (identical forwarding, and it
+    /// doesn't depend on the owner having LIB entries installed).
+    ids: u8,
+    first_sid: Ipv6Addr,
+}
+
+impl Carrier {
+    fn flush(self, out: &mut Vec<Ipv6Addr>) {
+        if self.ids == 1 {
+            out.push(self.first_sid);
+        } else {
+            out.push(Ipv6Addr::from(self.val));
+        }
+    }
+}
+
+/// Pack a resolved SRv6 repair list into NEXT-C-SID carriers (RFC
+/// 9800). Consecutive segments whose SIDs were advertised with uSID
+/// behaviors and a shared locator block collapse into one 128-bit
+/// carrier — block + 16-bit identifiers — instead of one full SID per
+/// SRH segment. Anything that can't ride a carrier (classic behavior,
+/// no structure, zero identifier, block change, LIB continuity break,
+/// carrier full) is emitted as its full SID; mixed lists degrade
+/// per-segment, never wholesale.
+fn pack_carriers(parts: &[RepairSeg]) -> Vec<Ipv6Addr> {
+    let mut out: Vec<Ipv6Addr> = Vec::with_capacity(parts.len());
+    let mut cur: Option<Carrier> = None;
+    let mut prev_landing: Option<usize> = None;
+
+    for part in parts {
+        let packable = part.csid.as_ref().filter(|c| {
+            // A zero identifier would read as end-of-carrier on the
+            // wire; never pack one. LIB (uA) identifiers additionally
+            // require the previous segment to land on their owner —
+            // that holds across carrier boundaries and full-SID
+            // predecessors alike, since either way the packet sits on
+            // the owner when the identifier becomes active.
+            c.id != 0 && c.lib_owner.is_none_or(|owner| prev_landing == Some(owner))
+        });
+        match packable {
+            Some(c) => {
+                let fits = cur.as_ref().is_some_and(|car| {
+                    car.block == c.block && car.lb == c.lb && car.pos + c.width as u32 <= 128
+                });
+                if !fits {
+                    if let Some(car) = cur.take() {
+                        car.flush(&mut out);
+                    }
+                    cur = Some(Carrier {
+                        val: c.block,
+                        block: c.block,
+                        lb: c.lb,
+                        pos: c.lb as u32,
+                        ids: 0,
+                        first_sid: part.sid,
+                    });
+                }
+                let car = cur.as_mut().expect("carrier was just ensured");
+                car.val |= c.id << (128 - car.pos - c.width as u32);
+                car.pos += c.width as u32;
+                car.ids += 1;
+            }
+            None => {
+                if let Some(car) = cur.take() {
+                    car.flush(&mut out);
+                }
+                out.push(part.sid);
+            }
+        }
+        prev_landing = Some(part.landing);
+    }
+    if let Some(car) = cur.take() {
+        car.flush(&mut out);
+    }
+    out
+}
+
+#[cfg(test)]
+mod carrier_tests {
+    use super::*;
+
+    fn st(lb: u8, ln: u8, fun: u8) -> isis_packet::IsisSub2SidStructure {
+        isis_packet::IsisSub2SidStructure {
+            lb_len: lb,
+            ln_len: ln,
+            fun_len: fun,
+            arg_len: 0,
+        }
+    }
+
+    fn un(sid: &str, landing: usize) -> RepairSeg {
+        let info = crate::isis::srv6::Srv6EndSidInfo {
+            sid: sid.parse().unwrap(),
+            behavior: isis_packet::Behavior::EndCSID,
+            structure: Some(st(32, 16, 16)),
+        };
+        RepairSeg {
+            sid: info.sid,
+            landing,
+            csid: csid_bits_end(&info),
+        }
+    }
+
+    fn ua(sid: &str, owner: usize, landing: usize) -> RepairSeg {
+        let endx = Srv6EndXInfo {
+            sid: sid.parse().unwrap(),
+            behavior: isis_packet::Behavior::EndXCSID,
+            structure: Some(st(32, 16, 16)),
+        };
+        RepairSeg {
+            sid: endx.sid,
+            landing,
+            csid: csid_bits_endx(&endx, owner),
+        }
+    }
+
+    fn classic(sid: &str, landing: usize) -> RepairSeg {
+        RepairSeg {
+            sid: sid.parse().unwrap(),
+            landing,
+            csid: None,
+        }
+    }
+
+    // The observed @tilfa_srv6 repair: uN(r1) + uA(r1->r2) + uA(r2->r3)
+    // collapses into one carrier — block, node id, two functions.
+    #[test]
+    fn packs_un_ua_ua_into_one_carrier() {
+        let parts = [
+            un("fcbb:bbbb:5::", 1),
+            ua("fcbb:bbbb:5:e003::", 1, 2),
+            ua("fcbb:bbbb:6:e002::", 2, 3),
+        ];
+        let segs = pack_carriers(&parts);
+        assert_eq!(
+            segs,
+            vec!["fcbb:bbbb:5:e003:e002::".parse::<Ipv6Addr>().unwrap()]
+        );
+    }
+
+    // A classic segment splits the list: carrier, full SID, and the
+    // trailing uA can't pack (its owner isn't where the previous
+    // segment lands the packet for LIB purposes — it is, actually, so
+    // it opens a fresh single-id carrier and re-emits its full SID).
+    #[test]
+    fn classic_segment_breaks_the_carrier() {
+        let parts = [
+            un("fcbb:bbbb:5::", 1),
+            ua("fcbb:bbbb:5:e003::", 1, 2),
+            classic("2001:db8:9::1", 3),
+            ua("fcbb:bbbb:7:e001::", 3, 4),
+        ];
+        let segs = pack_carriers(&parts);
+        assert_eq!(
+            segs,
+            vec![
+                "fcbb:bbbb:5:e003::".parse::<Ipv6Addr>().unwrap(),
+                "2001:db8:9::1".parse().unwrap(),
+                "fcbb:bbbb:7:e001::".parse().unwrap(),
+            ]
+        );
+    }
+
+    // A lone uN stays in its advertised full form (identical bytes for
+    // a single-id carrier, but the rule also covers the lone-uA case).
+    #[test]
+    fn single_segment_is_emitted_as_full_sid() {
+        let parts = [un("fcbb:bbbb:5::", 1)];
+        assert_eq!(
+            pack_carriers(&parts),
+            vec!["fcbb:bbbb:5::".parse::<Ipv6Addr>().unwrap()]
+        );
+    }
+
+    // A uA whose owner is NOT where the previous segment lands cannot
+    // be packed (its LIB identifier would be looked up on the wrong
+    // node) — it falls back to the full, globally-routable SID.
+    #[test]
+    fn ua_without_continuity_falls_back_to_full_sid() {
+        let parts = [un("fcbb:bbbb:5::", 1), ua("fcbb:bbbb:7:e001::", 3, 4)];
+        let segs = pack_carriers(&parts);
+        assert_eq!(
+            segs,
+            vec![
+                "fcbb:bbbb:5::".parse::<Ipv6Addr>().unwrap(),
+                "fcbb:bbbb:7:e001::".parse().unwrap(),
+            ]
+        );
+    }
+
+    // A leading uA (no predecessor) must stay full-SID: the initial DA
+    // is routed by the IGP and a LIB identifier is not routable.
+    #[test]
+    fn leading_ua_stays_full_sid() {
+        let parts = [ua("fcbb:bbbb:5:e003::", 1, 2), un("fcbb:bbbb:6::", 2)];
+        let segs = pack_carriers(&parts);
+        assert_eq!(
+            segs,
+            vec![
+                "fcbb:bbbb:5:e003::".parse::<Ipv6Addr>().unwrap(),
+                "fcbb:bbbb:6::".parse().unwrap(),
+            ]
+        );
+    }
+
+    // A different locator block starts a new carrier.
+    #[test]
+    fn block_change_splits_carriers() {
+        let parts = [
+            un("fcbb:bbbb:5::", 1),
+            un("fcbb:bbbb:6::", 2),
+            un("fcbb:cccc:7::", 3),
+            un("fcbb:cccc:8::", 4),
+        ];
+        let segs = pack_carriers(&parts);
+        assert_eq!(
+            segs,
+            vec![
+                "fcbb:bbbb:5:6::".parse::<Ipv6Addr>().unwrap(),
+                "fcbb:cccc:7:8::".parse().unwrap(),
+            ]
+        );
+    }
+
+    // Capacity: a 32-bit block fits six 16-bit identifiers; the
+    // seventh spills into a second carrier.
+    #[test]
+    fn full_carrier_spills_into_a_second() {
+        let parts: Vec<RepairSeg> = (1..=7)
+            .map(|i| un(&format!("fcbb:bbbb:{i}::"), i))
+            .collect();
+        let segs = pack_carriers(&parts);
+        assert_eq!(
+            segs,
+            vec![
+                "fcbb:bbbb:1:2:3:4:5:6".parse::<Ipv6Addr>().unwrap(),
+                "fcbb:bbbb:7::".parse().unwrap(),
+            ]
+        );
+    }
+
+    // Zero identifiers would read as end-of-carrier on the wire; they
+    // are never packed.
+    #[test]
+    fn zero_identifier_is_never_packed() {
+        let parts = [un("fcbb:bbbb:5::", 1), un("fcbb:bbbb::", 2)];
+        let segs = pack_carriers(&parts);
+        assert_eq!(
+            segs,
+            vec![
+                "fcbb:bbbb:5::".parse::<Ipv6Addr>().unwrap(),
+                "fcbb:bbbb::".parse().unwrap(),
+            ]
+        );
+    }
+
+    // Classic behaviors (no NEXT-C-SID) never produce carrier bits, so
+    // the classic-SID feature keeps its one-SID-per-segment encoding.
+    #[test]
+    fn classic_behavior_yields_no_csid_bits() {
+        let info = crate::isis::srv6::Srv6EndSidInfo {
+            sid: "fcbb:bbbb:5::".parse().unwrap(),
+            behavior: isis_packet::Behavior::End,
+            structure: Some(st(40, 8, 16)),
+        };
+        assert_eq!(csid_bits_end(&info), None);
+        let endx = Srv6EndXInfo {
+            sid: "fcbb:bbbb:5:e003::".parse().unwrap(),
+            behavior: isis_packet::Behavior::EndX,
+            structure: Some(st(40, 8, 16)),
+        };
+        assert_eq!(csid_bits_endx(&endx, 1), None);
+    }
 }

--- a/zebra-rs/src/rib/segment_routing/sid.rs
+++ b/zebra-rs/src/rib/segment_routing/sid.rs
@@ -31,6 +31,15 @@ pub enum SidBehavior {
     /// forwarding as End.X with the additional uSID shift; carries a
     /// [`SidStructure`].
     UA,
+    /// LIB twin of a uA — the same adjacency cross-connect anchored at
+    /// `block:function` (no locator-node bits), which is how the uA
+    /// appears as the *active* uSID inside a NEXT-C-SID carrier after
+    /// the owner's uN shift. Installs as a /(LB+Fun) prefix with the
+    /// NEXT-CSID flavor (shift while uSIDs remain, classic End.X
+    /// fallback at end-of-carrier). Only locally significant — every
+    /// node reuses the same LIB function space. Dynamic-only; not a
+    /// config-facing behavior.
+    UALib,
     /// End.DT4 — RFC 8986 §4.6. Decapsulates and looks up the inner
     /// IPv4 packet in a configured table. Today only operator-
     /// configured static routes use it; the table-id arg isn't
@@ -60,6 +69,7 @@ impl fmt::Display for SidBehavior {
             Self::EndX => write!(f, "End.X"),
             Self::UN => write!(f, "uN"),
             Self::UA => write!(f, "uA"),
+            Self::UALib => write!(f, "uA(LIB)"),
             Self::EndDT4 => write!(f, "End.DT4"),
             Self::EndDT6 => write!(f, "End.DT6"),
             Self::EndDT46 => write!(f, "End.DT46"),
@@ -79,6 +89,8 @@ impl FromStr for SidBehavior {
             "End" => Ok(Self::End),
             "End.X" => Ok(Self::EndX),
             "uN" => Ok(Self::UN),
+            // UALib is deliberately absent: it is derived from a uA at
+            // install time, never named in config.
             "uA" => Ok(Self::UA),
             "End.DT4" => Ok(Self::EndDT4),
             "End.DT6" => Ok(Self::EndDT6),
@@ -229,6 +241,15 @@ impl Sid {
             | SidBehavior::EndDT46
             | SidBehavior::EndB6Encap => {
                 Ipv6Net::new(self.addr, 128).expect("/128 is always valid")
+            }
+            SidBehavior::UALib => {
+                let plen = self
+                    .structure
+                    .map(|s| s.lb_bits.saturating_add(s.fun_bits))
+                    .unwrap_or(128);
+                let masked = mask_v6(self.addr, plen);
+                Ipv6Net::new(masked, plen)
+                    .unwrap_or_else(|_| Ipv6Net::new(self.addr, 128).expect("/128 is always valid"))
             }
             SidBehavior::UN => {
                 let plen = self


### PR DESCRIPTION
## Summary
- **Encoder**: `build_repair_path_srv6` now resolves each repair segment with its advertised endpoint behavior + SID structure (kept in `srv6_end_map`, returned by the End.X sub-TLV lookup) and packs consecutive same-block uSID segments into RFC 9800 carriers. The @tilfa_srv6 repair (uN + 2×uA) shrinks from a 4-segment SRH to carrier + original destination (`segs 2`, 72→40 bytes of insertion). uA identifiers are LIB-scoped, so they pack only when the previous segment lands on their owner; classic behaviors, zero IDs, block changes, and full carriers fall back per-segment to full SIDs (mixed lists degrade gracefully, single-ID carriers re-emit the full SID).
- **Receive side**: every uA installs a LIB twin — `SidBehavior::UALib` at `block:function`, a `/(LB+Fun)` prefix with the kernel End.X NEXT-CSID flavor (shift mid-carrier, classic End.X fallback at end-of-carrier; functionally verified on Linux 6.8.0-124 in a scratch lab before wiring). Shares the global-nh6 selection + drift re-install from #1361; renders as `uA(LIB)` in `show segment-routing srv6 sid`. The `/128` advertised uA stays classic (the #1361-era rule still holds for that shape).
- **Caveat**: packing keys off advertised uN/uA behaviors, which older builds advertise without LIB twins — upgrade uSID routers together.

## Testing
- 12 new unit tests (9 packer cases: carrier shape, LIB continuity breaks, block splits, six-ID capacity spill, zero-ID guard, classic exclusion; 3 `lib_addr` bit-math). Full suite 1613 passed, clippy/fmt clean.
- `@tilfa_srv6` 6/6 scenarios on the new binary, including new assertions: `uA(LIB)` registry rows, promoted-backup kernel route `segs 2 [`, pings end-to-end over the compressed repair.
- `@tilfa_classic_srv6` 6/6 — classic SIDs keep the uncompressed encoding, no LIB rows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)