### PR TITLE
bdd: promoted-backup scenarios for OSPFv2/v3 TI-LFA + polled ping

### DIFF
--- a/bdd/tests/cucumber.rs
+++ b/bdd/tests/cucumber.rs
@@ -290,6 +290,41 @@ async fn ping_should_succeed(world: &mut World, namespace: String, target: Strin
     println!("✓ ping from {} to {} succeeded", scoped, target);
 }
 
+/// Polled sibling of `ping … should succeed` for assertions that race
+/// protocol convergence — e.g. the reverse direction of a path right
+/// after topology bring-up, where the forward direction converged
+/// first. The plain step is a single 3-packet probe; this one retries
+/// a 1-packet ping every second for up to 30 seconds.
+#[then(expr = "ping from {string} to {string} should eventually succeed")]
+async fn ping_eventually_succeeds(world: &mut World, namespace: String, target: String) {
+    let scoped = world.ns(&namespace);
+    const ATTEMPTS: u32 = 30;
+    for i in 0..ATTEMPTS {
+        let ok = if target.contains(':') {
+            netns::ping6(&scoped, &target, 1, 1).await
+        } else {
+            netns::ping4(&scoped, &target, 1, 1).await
+        }
+        .unwrap_or(false);
+        if ok {
+            println!(
+                "✓ ping from {} to {} succeeded (attempt {})",
+                scoped,
+                target,
+                i + 1
+            );
+            return;
+        }
+        if i + 1 < ATTEMPTS {
+            tokio::time::sleep(tokio::time::Duration::from_secs(1)).await;
+        }
+    }
+    panic!(
+        "ping from {} to {} did not succeed within {} attempts",
+        scoped, target, ATTEMPTS
+    );
+}
+
 #[then(expr = "ping from {string} to {string} should fail")]
 async fn ping_should_fail(world: &mut World, namespace: String, target: String) {
     let scoped = world.ns(&namespace);

--- a/bdd/tests/features/ospfv2_tilfa.feature
+++ b/bdd/tests/features/ospfv2_tilfa.feature
@@ -147,6 +147,30 @@ Feature: OSPFv2 TI-LFA fast-reroute over SR-MPLS
     # Primary restored once the adjacency re-forms.
     Then ping from "s" to "10.0.0.8" should succeed
 
+  Scenario: Promoted backup actually forwards over the SR-MPLS repair
+    Given the test topology exists
+    # `backup-as-primary` swaps the metric-sort offset so each TI-LFA
+    # repair installs as the active route and the SPF primary demotes
+    # to metric+1; the toggle re-runs SPF itself. Traffic is pinned
+    # onto the repair label stack while every link stays up — proving
+    # the repair tunnel genuinely forwards, which the link-failure
+    # scenario cannot (by ping time SPF has already reconverged onto a
+    # plain post-convergence primary). Must run before the s-nofrr /
+    # s-nosr scenarios strip the repair machinery from s.
+    When I apply command "set router ospf fast-reroute backup-as-primary" in namespace "s"
+    And I wait 5 seconds
+    # d's loopback route now has the label-stack repair as its best
+    # kernel entry, out the repair egress s-n2.
+    Then kernel route "10.0.0.8" in namespace "s" should eventually contain "encap mpls"
+    And kernel route "10.0.0.8" in namespace "s" should eventually contain "dev s-n2 proto ospf metric 2"
+    # End-to-end over the repair: dies if any label hop on the repair
+    # path fails to swap/pop/forward.
+    And ping from "s" to "10.0.0.8" should succeed
+    # Restore install-side ordering for the scenarios that follow.
+    When I apply command "delete router ospf fast-reroute backup-as-primary" in namespace "s"
+    And I wait 5 seconds
+    Then ping from "s" to "10.0.0.8" should succeed
+
   Scenario: Disabling fast-reroute clears the repair-list
     Given the test topology exists
     # s still holds TI-LFA backups from the previous scenarios.

--- a/bdd/tests/features/ospfv3_tilfa.feature
+++ b/bdd/tests/features/ospfv3_tilfa.feature
@@ -132,7 +132,13 @@ Feature: OSPFv3 TI-LFA fast-reroute over SR-MPLS
     Given the test topology exists
     # s -> d primary is s-n1-d (cost 2).
     Then ping from "s" to "2001:db8::8" should succeed
-    And ping from "d" to "2001:db8::1" should succeed
+    # The reverse direction races full-mesh convergence: d's best
+    # route to s flips from the expensive r3 path to the n1 path only
+    # once every E-LSA has flooded and n1's ILM for s's node-SID
+    # (16100, kept end-to-end by the v3 NP flag) settles — observed
+    # ~40s after config, right at this scenario's runtime. Poll
+    # instead of single-shot.
+    And ping from "d" to "2001:db8::1" should eventually succeed
 
   Scenario: Fast-reroute survives the primary link failure (s-n1)
     Given the test topology exists
@@ -148,6 +154,31 @@ Feature: OSPFv3 TI-LFA fast-reroute over SR-MPLS
     When I make namespace "s" interface "s-n1" up
     And I wait 30 seconds
     # Primary restored once the adjacency re-forms.
+    Then ping from "s" to "2001:db8::8" should succeed
+
+  Scenario: Promoted backup actually forwards over the SR-MPLS repair
+    Given the test topology exists
+    # `backup-as-primary` swaps the metric-sort offset so each TI-LFA
+    # repair installs as the active route and the SPF primary demotes
+    # to metric+1; the toggle re-runs SPF itself. Traffic is pinned
+    # onto the repair label stack while every link stays up — proving
+    # the [Node-SID(r1), Adj-SID, Adj-SID] tunnel genuinely forwards,
+    # which the link-failure scenario cannot (by ping time SPF has
+    # already reconverged onto a plain post-convergence primary).
+    # Must run before the s-nofrr / s-nosr scenarios strip the
+    # repair machinery from s.
+    When I apply command "set router ospfv3 fast-reroute backup-as-primary" in namespace "s"
+    And I wait 5 seconds
+    # d's loopback route now has the label-stack repair as its best
+    # kernel entry, out the repair egress s-n2.
+    Then kernel route "2001:db8::8" in namespace "s" should eventually contain "encap mpls"
+    And kernel route "2001:db8::8" in namespace "s" should eventually contain "dev s-n2 proto ospf metric 2"
+    # End-to-end over the repair: dies if any label hop on the
+    # s-n2-r1-r2-r3-d repair path fails to swap/pop/forward.
+    And ping from "s" to "2001:db8::8" should succeed
+    # Restore install-side ordering for the scenarios that follow.
+    When I apply command "delete router ospfv3 fast-reroute backup-as-primary" in namespace "s"
+    And I wait 5 seconds
     Then ping from "s" to "2001:db8::8" should succeed
 
   Scenario: Disabling fast-reroute clears the repair-list


### PR DESCRIPTION
## Summary
- Ports the `backup-as-primary` promoted-backup scenario (#1363 pattern) to `ospfv2_tilfa` and `ospfv3_tilfa`: traffic is pinned onto the TI-LFA repair label stack with all links up, asserting the promoted `encap mpls` kernel route (repair egress `s-n2`, metric 2) plus an end-to-end ping — then the knob is deleted so the later disable/teardown scenarios see default ordering. Placed before `s-nofrr`/`s-nosr`, which strip the repair machinery. The OSPF knobs self-trigger SPF, so no `clear` step is needed.
- This closes the OSPF half of the review: it was the only IS-IS TI-LFA update applicable to OSPFv3 — OSPF has no SRv6 in zebra-rs, so the End.X global-nh6 fix (#1361) and NEXT-C-SID compression (#1364) have nothing to attach to there.
- De-flakes `ospfv3_tilfa` scenario 3: the `d → s` ping is a single 3-packet probe, but full v3 convergence takes ~40s (probe-captured: d's best route to s flips from the expensive r3 path to the n1 path only after all E-LSAs flood and n1's ILM for 16100 settles — the NP flag keeps the label end-to-end). It failed 2 of 3 runs at exactly that boundary. New harness step `ping … should eventually succeed` polls a 1-packet ping up to 30×1s.

## Testing
- `@ospfv2_tilfa`: 8/8 scenarios passed (including the new promoted-backup, 9/9 steps).
- `@ospfv3_tilfa`: 8/8 scenarios passed after the de-flake (the new scenario passed 9/9 in all three runs; only the pre-existing reverse-ping raced).
- `cargo fmt` clean, `cargo clippy --workspace --all-targets -- -D warnings` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)