### PR TITLE
ospfv3: RFC 9513 SRv6 codec — Locator LSA, End/End.X SIDs, capabilities

### DIFF
--- a/crates/ospf-packet/src/lib.rs
+++ b/crates/ospf-packet/src/lib.rs
@@ -37,5 +37,13 @@ pub use v3::{
     Ospfv3SrLocalBlockTlv, Ospfv3SubTlv, ospfv3_compute_checksum, ospfv3_prefix_wire_len,
     ospfv3_verify_checksum, parse_v3,
 };
+pub use v3::{
+    OSPFV3_EXT_TLV_SRV6_CAPABILITIES, OSPFV3_SRV6_CAP_FLAG_O, OSPFV3_SRV6_LOCATOR_LSA_TYPE,
+    OSPFV3_SRV6_LOCATOR_SUB_TLV_END_SID, OSPFV3_SRV6_LOCATOR_SUB_TLV_SID_STRUCTURE,
+    OSPFV3_SRV6_LOCATOR_TLV, OSPFV3_SUB_TLV_SRV6_ENDX_SID, OSPFV3_SUB_TLV_SRV6_LAN_ENDX_SID,
+    OSPFV3_SUB_TLV_SRV6_SID_STRUCTURE, Ospfv3Srv6CapabilitiesTlv, Ospfv3Srv6EndSidSubTlv,
+    Ospfv3Srv6EndXSidSubTlv, Ospfv3Srv6LanEndXSidSubTlv, Ospfv3Srv6LocatorLsa,
+    Ospfv3Srv6LocatorLsaTlv, Ospfv3Srv6LocatorSubTlv, Ospfv3Srv6LocatorTlv, Ospfv3Srv6SidStructure,
+};
 
 pub use packet_utils::many0_complete;

--- a/crates/ospf-packet/src/v3.rs
+++ b/crates/ospf-packet/src/v3.rs
@@ -1825,7 +1825,17 @@ pub enum Ospfv3SubTlv {
     AdjSid(Ospfv3AdjSidSubTlv),
     LanAdjSid(Ospfv3LanAdjSidSubTlv),
     Asla(Ospfv3AslaSubTlv),
-    Unknown { typ: u16, value: Vec<u8> },
+    /// RFC 9513 §9.1 — SRv6 End.X SID (Extended-LSA sub-TLV 31).
+    Srv6EndXSid(Ospfv3Srv6EndXSidSubTlv),
+    /// RFC 9513 §9.2 — SRv6 LAN End.X SID (Extended-LSA sub-TLV 32).
+    Srv6LanEndXSid(Ospfv3Srv6LanEndXSidSubTlv),
+    /// RFC 9513 §10 — SRv6 SID Structure (Extended-LSA sub-TLV 30,
+    /// nested under the End.X / LAN End.X sub-TLVs).
+    Srv6SidStructure(Ospfv3Srv6SidStructure),
+    Unknown {
+        typ: u16,
+        value: Vec<u8>,
+    },
 }
 
 impl Ospfv3SubTlv {
@@ -1835,6 +1845,9 @@ impl Ospfv3SubTlv {
             Ospfv3SubTlv::AdjSid(s) => s.value_len() as usize,
             Ospfv3SubTlv::LanAdjSid(s) => s.value_len() as usize,
             Ospfv3SubTlv::Asla(s) => s.value_len(),
+            Ospfv3SubTlv::Srv6EndXSid(s) => s.value_len() as usize,
+            Ospfv3SubTlv::Srv6LanEndXSid(s) => s.value_len() as usize,
+            Ospfv3SubTlv::Srv6SidStructure(s) => s.value_len() as usize,
             Ospfv3SubTlv::Unknown { value, .. } => value.len(),
         };
         4 + ((value_len + 3) & !3)
@@ -1846,6 +1859,9 @@ impl Ospfv3SubTlv {
             Ospfv3SubTlv::AdjSid(s) => (OSPFV3_SUB_TLV_ADJ_SID, s.value_len()),
             Ospfv3SubTlv::LanAdjSid(s) => (OSPFV3_SUB_TLV_LAN_ADJ_SID, s.value_len()),
             Ospfv3SubTlv::Asla(s) => (OSPFV3_SUB_TLV_ASLA, s.value_len() as u16),
+            Ospfv3SubTlv::Srv6EndXSid(s) => (OSPFV3_SUB_TLV_SRV6_ENDX_SID, s.value_len()),
+            Ospfv3SubTlv::Srv6LanEndXSid(s) => (OSPFV3_SUB_TLV_SRV6_LAN_ENDX_SID, s.value_len()),
+            Ospfv3SubTlv::Srv6SidStructure(s) => (OSPFV3_SUB_TLV_SRV6_SID_STRUCTURE, s.value_len()),
             Ospfv3SubTlv::Unknown { typ, value } => (*typ, value.len() as u16),
         };
         buf.put_u16(typ);
@@ -1855,6 +1871,9 @@ impl Ospfv3SubTlv {
             Ospfv3SubTlv::AdjSid(s) => s.emit(buf),
             Ospfv3SubTlv::LanAdjSid(s) => s.emit(buf),
             Ospfv3SubTlv::Asla(s) => s.emit(buf),
+            Ospfv3SubTlv::Srv6EndXSid(s) => s.emit(buf),
+            Ospfv3SubTlv::Srv6LanEndXSid(s) => s.emit(buf),
+            Ospfv3SubTlv::Srv6SidStructure(s) => s.emit(buf),
             Ospfv3SubTlv::Unknown { value, .. } => buf.put_slice(value),
         }
         let value_len = value_len as usize;
@@ -1885,6 +1904,18 @@ impl Ospfv3SubTlv {
             OSPFV3_SUB_TLV_ASLA => {
                 let (_, s) = Ospfv3AslaSubTlv::parse_be(value)?;
                 Ospfv3SubTlv::Asla(s)
+            }
+            OSPFV3_SUB_TLV_SRV6_ENDX_SID => {
+                let (_, s) = Ospfv3Srv6EndXSidSubTlv::parse_be(value)?;
+                Ospfv3SubTlv::Srv6EndXSid(s)
+            }
+            OSPFV3_SUB_TLV_SRV6_LAN_ENDX_SID => {
+                let (_, s) = Ospfv3Srv6LanEndXSidSubTlv::parse_be(value)?;
+                Ospfv3SubTlv::Srv6LanEndXSid(s)
+            }
+            OSPFV3_SUB_TLV_SRV6_SID_STRUCTURE => {
+                let (_, s) = Ospfv3Srv6SidStructure::parse_be(value)?;
+                Ospfv3SubTlv::Srv6SidStructure(s)
             }
             _ => Ospfv3SubTlv::Unknown {
                 typ,
@@ -2537,7 +2568,15 @@ pub enum Ospfv3ExtTlv {
     SidLabelRange(Ospfv3SidLabelRangeTlv),
     SrLocalBlock(Ospfv3SrLocalBlockTlv),
     Fad(Ospfv3FadTlv),
-    Unknown { typ: u16, value: Vec<u8> },
+    /// RFC 9513 §2 — SRv6 Capabilities (RI TLV 20). Rides the SR-info
+    /// E-Router-LSA alongside SR-Algorithm / SRGB / SRLB, the same
+    /// in-house convention those RI TLVs already use (no standalone
+    /// Router Information LSA in this implementation).
+    Srv6Capabilities(Ospfv3Srv6CapabilitiesTlv),
+    Unknown {
+        typ: u16,
+        value: Vec<u8>,
+    },
 }
 
 impl Ospfv3ExtTlv {
@@ -2552,6 +2591,7 @@ impl Ospfv3ExtTlv {
             Ospfv3ExtTlv::SidLabelRange(t) => t.value_len(),
             Ospfv3ExtTlv::SrLocalBlock(t) => t.value_len(),
             Ospfv3ExtTlv::Fad(t) => t.value_len(),
+            Ospfv3ExtTlv::Srv6Capabilities(t) => t.value_len() as usize,
             Ospfv3ExtTlv::Unknown { value, .. } => value.len(),
         };
         4 + ((value_len + 3) & !3)
@@ -2565,6 +2605,9 @@ impl Ospfv3ExtTlv {
             Ospfv3ExtTlv::SidLabelRange(t) => (OSPFV3_EXT_TLV_SID_LABEL_RANGE, t.value_len()),
             Ospfv3ExtTlv::SrLocalBlock(t) => (OSPFV3_EXT_TLV_LOCAL_BLOCK, t.value_len()),
             Ospfv3ExtTlv::Fad(t) => (OSPFV3_EXT_TLV_FAD, t.value_len()),
+            Ospfv3ExtTlv::Srv6Capabilities(t) => {
+                (OSPFV3_EXT_TLV_SRV6_CAPABILITIES, t.value_len() as usize)
+            }
             Ospfv3ExtTlv::Unknown { typ, value } => (*typ, value.len()),
         };
         buf.put_u16(typ);
@@ -2576,6 +2619,7 @@ impl Ospfv3ExtTlv {
             Ospfv3ExtTlv::SidLabelRange(t) => t.emit(buf),
             Ospfv3ExtTlv::SrLocalBlock(t) => t.emit(buf),
             Ospfv3ExtTlv::Fad(t) => t.emit(buf),
+            Ospfv3ExtTlv::Srv6Capabilities(t) => t.emit(buf),
             Ospfv3ExtTlv::Unknown { value, .. } => buf.put_slice(value),
         }
         // Pad to 4-byte alignment.
@@ -2614,6 +2658,10 @@ impl Ospfv3ExtTlv {
             OSPFV3_EXT_TLV_FAD => {
                 let (_, t) = Ospfv3FadTlv::parse_be(value)?;
                 Ospfv3ExtTlv::Fad(t)
+            }
+            OSPFV3_EXT_TLV_SRV6_CAPABILITIES => {
+                let (_, t) = Ospfv3Srv6CapabilitiesTlv::parse_be(value)?;
+                Ospfv3ExtTlv::Srv6Capabilities(t)
             }
             _ => Ospfv3ExtTlv::Unknown {
                 typ,
@@ -2687,6 +2735,10 @@ pub enum Ospfv3LsBody {
     EAsExternal(Ospfv3ELsaBody),
     ELink(Ospfv3ELsaBody),
     EIntraAreaPrefix(Ospfv3ELsaBody),
+    /// RFC 9513 §7 SRv6 Locator LSA — function code 42, area scope.
+    /// Own top-level TLV namespace (the "OSPFv3 SRv6 Locator LSA
+    /// TLVs" registry), not the Extended-LSA TLV space.
+    Srv6Locator(Ospfv3Srv6LocatorLsa),
     /// Unrecognised LS Type — bytes preserved verbatim.
     Unknown(Vec<u8>),
 }
@@ -2710,6 +2762,7 @@ impl Ospfv3LsBody {
             | Ospfv3LsBody::EAsExternal(b)
             | Ospfv3LsBody::ELink(b)
             | Ospfv3LsBody::EIntraAreaPrefix(b) => b.emit(buf),
+            Ospfv3LsBody::Srv6Locator(b) => b.emit(buf),
             Ospfv3LsBody::Unknown(bytes) => buf.put_slice(bytes),
         }
     }
@@ -2784,6 +2837,10 @@ impl Ospfv3LsBody {
             OSPFV3_E_INTRA_AREA_PREFIX_LSA_TYPE => {
                 let (rest, b) = Ospfv3ELsaBody::parse_be(input)?;
                 Ok((rest, Ospfv3LsBody::EIntraAreaPrefix(b)))
+            }
+            OSPFV3_SRV6_LOCATOR_LSA_TYPE => {
+                let (rest, b) = Ospfv3Srv6LocatorLsa::parse_be(input)?;
+                Ok((rest, Ospfv3LsBody::Srv6Locator(b)))
             }
             _ => Ok((&[][..], Ospfv3LsBody::Unknown(input.to_vec()))),
         }
@@ -2956,6 +3013,497 @@ impl ParseBe<Ospfv3LsAck> for Ospfv3LsAck {
         let (input, lsa_headers) = many0_complete(Ospfv3LsaHeader::parse_be).parse(input)?;
         Ok((input, Ospfv3LsAck { lsa_headers }))
     }
+}
+
+// ---------------------------------------------------------------------
+// RFC 9513 — OSPFv3 Extensions for SRv6
+// ---------------------------------------------------------------------
+
+/// SRv6 Locator LSA (RFC 9513 §7): U-bit set (flood even when
+/// unrecognised), area scope, LSA function code 42.
+pub const OSPFV3_SRV6_LOCATOR_LSA_TYPE: u16 = 0xA02A;
+
+/// SRv6 Capabilities TLV (RFC 9513 §2) — RI TLV type 20, carried in
+/// this implementation's SR-info E-Router-LSA (see `Ospfv3ExtTlv`).
+pub const OSPFV3_EXT_TLV_SRV6_CAPABILITIES: u16 = 20;
+
+/// Extended-LSA sub-TLV types (RFC 9513 §§9-10).
+pub const OSPFV3_SUB_TLV_SRV6_SID_STRUCTURE: u16 = 30;
+pub const OSPFV3_SUB_TLV_SRV6_ENDX_SID: u16 = 31;
+pub const OSPFV3_SUB_TLV_SRV6_LAN_ENDX_SID: u16 = 32;
+
+/// SRv6 Locator LSA's own TLV / sub-TLV registries (RFC 9513 §13).
+pub const OSPFV3_SRV6_LOCATOR_TLV: u16 = 1;
+pub const OSPFV3_SRV6_LOCATOR_SUB_TLV_END_SID: u16 = 1;
+pub const OSPFV3_SRV6_LOCATOR_SUB_TLV_SID_STRUCTURE: u16 = 10;
+
+/// O-flag of the SRv6 Capabilities TLV (RFC 9513 §2): the router
+/// supports the O-bit in the Segment Routing Header.
+pub const OSPFV3_SRV6_CAP_FLAG_O: u16 = 0x4000;
+
+/// SRv6 Capabilities TLV (RFC 9513 §2).
+///
+/// Wire layout: `Flags (2) | Reserved (2)` followed by optional
+/// sub-TLVs (none defined today; preserved verbatim is unnecessary —
+/// senders we interop with emit none, and RFC 9513 defines none).
+#[derive(Debug, Clone, PartialEq, Default)]
+pub struct Ospfv3Srv6CapabilitiesTlv {
+    pub flags: u16,
+}
+
+impl Ospfv3Srv6CapabilitiesTlv {
+    pub fn value_len(&self) -> u16 {
+        4
+    }
+
+    fn emit(&self, buf: &mut BytesMut) {
+        buf.put_u16(self.flags);
+        buf.put_u16(0); // reserved
+    }
+
+    fn parse_be(input: &[u8]) -> IResult<&[u8], Self> {
+        let (input, flags) = be_u16(input)?;
+        let (input, _reserved) = be_u16(input)?;
+        Ok((input, Self { flags }))
+    }
+}
+
+/// SRv6 SID Structure (RFC 9513 §10): how the 128-bit SID splits into
+/// Locator-Block / Locator-Node / Function / Argument lengths. The
+/// same 4-octet body appears in two registries — Extended-LSA
+/// sub-TLV 30 (under End.X / LAN End.X) and Locator-LSA sub-TLV 10
+/// (under the End SID); one struct serves both homes.
+#[derive(Debug, Clone, Copy, PartialEq, Default)]
+pub struct Ospfv3Srv6SidStructure {
+    pub lb_len: u8,
+    pub ln_len: u8,
+    pub fun_len: u8,
+    pub arg_len: u8,
+}
+
+impl Ospfv3Srv6SidStructure {
+    pub fn value_len(&self) -> u16 {
+        4
+    }
+
+    fn emit(&self, buf: &mut BytesMut) {
+        buf.put_u8(self.lb_len);
+        buf.put_u8(self.ln_len);
+        buf.put_u8(self.fun_len);
+        buf.put_u8(self.arg_len);
+    }
+
+    fn parse_be(input: &[u8]) -> IResult<&[u8], Self> {
+        let (input, lb_len) = be_u8(input)?;
+        let (input, ln_len) = be_u8(input)?;
+        let (input, fun_len) = be_u8(input)?;
+        let (input, arg_len) = be_u8(input)?;
+        Ok((
+            input,
+            Self {
+                lb_len,
+                ln_len,
+                fun_len,
+                arg_len,
+            },
+        ))
+    }
+}
+
+/// SRv6 End.X SID sub-TLV (RFC 9513 §9.1) — per-adjacency SID on a
+/// Router-Link TLV of the E-Router-LSA. The endpoint behavior is the
+/// raw IANA "SRv6 Endpoint Behaviors" codepoint (protocol-neutral;
+/// the daemon maps it through `isis_packet::Behavior`).
+///
+/// Wire: `Behavior (2) | Flags (1) | Rsv (1) | Algo (1) | Weight (1) |
+/// Rsv (2) | SID (16)` + nested sub-TLVs (SID Structure, type 30).
+#[derive(Debug, Clone, PartialEq)]
+pub struct Ospfv3Srv6EndXSidSubTlv {
+    pub behavior: u16,
+    pub flags: u8,
+    pub algo: u8,
+    pub weight: u8,
+    pub sid: Ipv6Addr,
+    pub subs: Vec<Ospfv3SubTlv>,
+}
+
+impl Ospfv3Srv6EndXSidSubTlv {
+    pub fn value_len(&self) -> u16 {
+        let subs: usize = self.subs.iter().map(|s| s.wire_len()).sum();
+        24 + subs as u16
+    }
+
+    fn emit(&self, buf: &mut BytesMut) {
+        buf.put_u16(self.behavior);
+        buf.put_u8(self.flags);
+        buf.put_u8(0); // reserved1
+        buf.put_u8(self.algo);
+        buf.put_u8(self.weight);
+        buf.put_u16(0); // reserved2
+        buf.put_slice(&self.sid.octets());
+        for sub in &self.subs {
+            sub.emit(buf);
+        }
+    }
+
+    fn parse_be(input: &[u8]) -> IResult<&[u8], Self> {
+        let (input, behavior) = be_u16(input)?;
+        let (input, flags) = be_u8(input)?;
+        let (input, _rsv1) = be_u8(input)?;
+        let (input, algo) = be_u8(input)?;
+        let (input, weight) = be_u8(input)?;
+        let (input, _rsv2) = be_u16(input)?;
+        let (mut input, sid) = parse_ipv6_sid(input)?;
+        let mut subs = Vec::new();
+        while !input.is_empty() {
+            let (rest, sub) = Ospfv3SubTlv::parse_be(input)?;
+            subs.push(sub);
+            input = rest;
+        }
+        Ok((
+            input,
+            Self {
+                behavior,
+                flags,
+                algo,
+                weight,
+                sid,
+                subs,
+            },
+        ))
+    }
+}
+
+/// SRv6 LAN End.X SID sub-TLV (RFC 9513 §9.2) — the broadcast / NBMA
+/// sibling: same body as End.X plus the Neighbor Router-ID that
+/// identifies which LAN member the adjacency points at.
+#[derive(Debug, Clone, PartialEq)]
+pub struct Ospfv3Srv6LanEndXSidSubTlv {
+    pub behavior: u16,
+    pub flags: u8,
+    pub algo: u8,
+    pub weight: u8,
+    pub neighbor_router_id: Ipv4Addr,
+    pub sid: Ipv6Addr,
+    pub subs: Vec<Ospfv3SubTlv>,
+}
+
+impl Ospfv3Srv6LanEndXSidSubTlv {
+    pub fn value_len(&self) -> u16 {
+        let subs: usize = self.subs.iter().map(|s| s.wire_len()).sum();
+        28 + subs as u16
+    }
+
+    fn emit(&self, buf: &mut BytesMut) {
+        buf.put_u16(self.behavior);
+        buf.put_u8(self.flags);
+        buf.put_u8(0); // reserved1
+        buf.put_u8(self.algo);
+        buf.put_u8(self.weight);
+        buf.put_u16(0); // reserved2
+        buf.put_slice(&self.neighbor_router_id.octets());
+        buf.put_slice(&self.sid.octets());
+        for sub in &self.subs {
+            sub.emit(buf);
+        }
+    }
+
+    fn parse_be(input: &[u8]) -> IResult<&[u8], Self> {
+        let (input, behavior) = be_u16(input)?;
+        let (input, flags) = be_u8(input)?;
+        let (input, _rsv1) = be_u8(input)?;
+        let (input, algo) = be_u8(input)?;
+        let (input, weight) = be_u8(input)?;
+        let (input, _rsv2) = be_u16(input)?;
+        let (input, neighbor_router_id) = Ipv4Addr::parse_be(input)?;
+        let (mut input, sid) = parse_ipv6_sid(input)?;
+        let mut subs = Vec::new();
+        while !input.is_empty() {
+            let (rest, sub) = Ospfv3SubTlv::parse_be(input)?;
+            subs.push(sub);
+            input = rest;
+        }
+        Ok((
+            input,
+            Self {
+                behavior,
+                flags,
+                algo,
+                weight,
+                neighbor_router_id,
+                sid,
+                subs,
+            },
+        ))
+    }
+}
+
+/// Sub-TLVs of the SRv6 Locator TLV — RFC 9513's own sub-registry
+/// (NOT the Extended-LSA sub-TLV space): End SID is type 1 here and
+/// the SID Structure is type 10. Types 2-5 (forwarding address,
+/// route tag, prefix source) are preserved as `Unknown`.
+#[derive(Debug, Clone, PartialEq)]
+pub enum Ospfv3Srv6LocatorSubTlv {
+    EndSid(Ospfv3Srv6EndSidSubTlv),
+    SidStructure(Ospfv3Srv6SidStructure),
+    Unknown { typ: u16, value: Vec<u8> },
+}
+
+impl Ospfv3Srv6LocatorSubTlv {
+    fn wire_len(&self) -> usize {
+        let value_len = match self {
+            Ospfv3Srv6LocatorSubTlv::EndSid(s) => s.value_len() as usize,
+            Ospfv3Srv6LocatorSubTlv::SidStructure(s) => s.value_len() as usize,
+            Ospfv3Srv6LocatorSubTlv::Unknown { value, .. } => value.len(),
+        };
+        4 + ((value_len + 3) & !3)
+    }
+
+    fn emit(&self, buf: &mut BytesMut) {
+        let (typ, value_len) = match self {
+            Ospfv3Srv6LocatorSubTlv::EndSid(s) => {
+                (OSPFV3_SRV6_LOCATOR_SUB_TLV_END_SID, s.value_len())
+            }
+            Ospfv3Srv6LocatorSubTlv::SidStructure(s) => {
+                (OSPFV3_SRV6_LOCATOR_SUB_TLV_SID_STRUCTURE, s.value_len())
+            }
+            Ospfv3Srv6LocatorSubTlv::Unknown { typ, value } => (*typ, value.len() as u16),
+        };
+        buf.put_u16(typ);
+        buf.put_u16(value_len);
+        match self {
+            Ospfv3Srv6LocatorSubTlv::EndSid(s) => s.emit(buf),
+            Ospfv3Srv6LocatorSubTlv::SidStructure(s) => s.emit(buf),
+            Ospfv3Srv6LocatorSubTlv::Unknown { value, .. } => buf.put_slice(value),
+        }
+        let value_len = value_len as usize;
+        let pad = ((value_len + 3) & !3) - value_len;
+        for _ in 0..pad {
+            buf.put_u8(0);
+        }
+    }
+
+    fn parse_be(input: &[u8]) -> IResult<&[u8], Self> {
+        let (input, typ) = be_u16(input)?;
+        let (input, len) = be_u16(input)?;
+        let len = len as usize;
+        let (input, value) = take(len)(input)?;
+        let parsed = match typ {
+            OSPFV3_SRV6_LOCATOR_SUB_TLV_END_SID => {
+                let (_, s) = Ospfv3Srv6EndSidSubTlv::parse_be(value)?;
+                Ospfv3Srv6LocatorSubTlv::EndSid(s)
+            }
+            OSPFV3_SRV6_LOCATOR_SUB_TLV_SID_STRUCTURE => {
+                let (_, s) = Ospfv3Srv6SidStructure::parse_be(value)?;
+                Ospfv3Srv6LocatorSubTlv::SidStructure(s)
+            }
+            _ => Ospfv3Srv6LocatorSubTlv::Unknown {
+                typ,
+                value: value.to_vec(),
+            },
+        };
+        let padded = (len + 3) & !3;
+        let (input, _) = take(padded - len)(input)?;
+        Ok((input, parsed))
+    }
+}
+
+/// SRv6 End SID sub-TLV (RFC 9513 §8) — the locator's node SID,
+/// nested in the SRv6 Locator TLV. Wire: `Flags (1) | Rsv (1) |
+/// Behavior (2) | SID (16)` + sub-TLVs (SID Structure, type 10 in
+/// the locator registry).
+#[derive(Debug, Clone, PartialEq)]
+pub struct Ospfv3Srv6EndSidSubTlv {
+    pub flags: u8,
+    pub behavior: u16,
+    pub sid: Ipv6Addr,
+    pub subs: Vec<Ospfv3Srv6LocatorSubTlv>,
+}
+
+impl Ospfv3Srv6EndSidSubTlv {
+    pub fn value_len(&self) -> u16 {
+        let subs: usize = self.subs.iter().map(|s| s.wire_len()).sum();
+        20 + subs as u16
+    }
+
+    fn emit(&self, buf: &mut BytesMut) {
+        buf.put_u8(self.flags);
+        buf.put_u8(0); // reserved
+        buf.put_u16(self.behavior);
+        buf.put_slice(&self.sid.octets());
+        for sub in &self.subs {
+            sub.emit(buf);
+        }
+    }
+
+    fn parse_be(input: &[u8]) -> IResult<&[u8], Self> {
+        let (input, flags) = be_u8(input)?;
+        let (input, _rsv) = be_u8(input)?;
+        let (input, behavior) = be_u16(input)?;
+        let (mut input, sid) = parse_ipv6_sid(input)?;
+        let mut subs = Vec::new();
+        while !input.is_empty() {
+            let (rest, sub) = Ospfv3Srv6LocatorSubTlv::parse_be(input)?;
+            subs.push(sub);
+            input = rest;
+        }
+        Ok((
+            input,
+            Self {
+                flags,
+                behavior,
+                sid,
+                subs,
+            },
+        ))
+    }
+}
+
+/// SRv6 Locator TLV (RFC 9513 §7.1) — one locator prefix with its
+/// route type / algorithm / metric and the End SIDs allocated from
+/// it. The locator prefix is encoded like every other v3 prefix:
+/// `ceil(locator_length / 32) * 4` octets, zero-padded.
+#[derive(Debug, Clone, PartialEq)]
+pub struct Ospfv3Srv6LocatorTlv {
+    pub route_type: u8,
+    pub algorithm: u8,
+    pub locator_length: u8,
+    pub prefix_options: u8,
+    pub metric: u32,
+    pub locator: Ipv6Addr,
+    pub subs: Vec<Ospfv3Srv6LocatorSubTlv>,
+}
+
+impl Ospfv3Srv6LocatorTlv {
+    pub fn value_len(&self) -> u16 {
+        let subs: usize = self.subs.iter().map(|s| s.wire_len()).sum();
+        (8 + ospfv3_prefix_wire_len(self.locator_length) + subs) as u16
+    }
+
+    fn emit(&self, buf: &mut BytesMut) {
+        buf.put_u8(self.route_type);
+        buf.put_u8(self.algorithm);
+        buf.put_u8(self.locator_length);
+        buf.put_u8(self.prefix_options);
+        buf.put_u32(self.metric);
+        let wire = ospfv3_prefix_wire_len(self.locator_length);
+        buf.put_slice(&self.locator.octets()[..wire]);
+        for sub in &self.subs {
+            sub.emit(buf);
+        }
+    }
+
+    fn parse_be(input: &[u8]) -> IResult<&[u8], Self> {
+        let (input, route_type) = be_u8(input)?;
+        let (input, algorithm) = be_u8(input)?;
+        let (input, locator_length) = be_u8(input)?;
+        let (input, prefix_options) = be_u8(input)?;
+        let (input, metric) = be_u32(input)?;
+        let wire = ospfv3_prefix_wire_len(locator_length);
+        let (mut input, raw) = take(wire)(input)?;
+        let mut octets = [0u8; 16];
+        octets[..wire].copy_from_slice(raw);
+        let locator = Ipv6Addr::from(octets);
+        let mut subs = Vec::new();
+        while !input.is_empty() {
+            let (rest, sub) = Ospfv3Srv6LocatorSubTlv::parse_be(input)?;
+            subs.push(sub);
+            input = rest;
+        }
+        Ok((
+            input,
+            Self {
+                route_type,
+                algorithm,
+                locator_length,
+                prefix_options,
+                metric,
+                locator,
+                subs,
+            },
+        ))
+    }
+}
+
+/// Top-level TLVs of the SRv6 Locator LSA (its own registry; type 1
+/// is the only one defined).
+#[derive(Debug, Clone, PartialEq)]
+pub enum Ospfv3Srv6LocatorLsaTlv {
+    Locator(Ospfv3Srv6LocatorTlv),
+    Unknown { typ: u16, value: Vec<u8> },
+}
+
+impl Ospfv3Srv6LocatorLsaTlv {
+    fn emit(&self, buf: &mut BytesMut) {
+        let (typ, value_len) = match self {
+            Ospfv3Srv6LocatorLsaTlv::Locator(t) => (OSPFV3_SRV6_LOCATOR_TLV, t.value_len()),
+            Ospfv3Srv6LocatorLsaTlv::Unknown { typ, value } => (*typ, value.len() as u16),
+        };
+        buf.put_u16(typ);
+        buf.put_u16(value_len);
+        match self {
+            Ospfv3Srv6LocatorLsaTlv::Locator(t) => t.emit(buf),
+            Ospfv3Srv6LocatorLsaTlv::Unknown { value, .. } => buf.put_slice(value),
+        }
+        let value_len = value_len as usize;
+        let pad = ((value_len + 3) & !3) - value_len;
+        for _ in 0..pad {
+            buf.put_u8(0);
+        }
+    }
+
+    fn parse_be(input: &[u8]) -> IResult<&[u8], Self> {
+        let (input, typ) = be_u16(input)?;
+        let (input, len) = be_u16(input)?;
+        let len = len as usize;
+        let (input, value) = take(len)(input)?;
+        let parsed = match typ {
+            OSPFV3_SRV6_LOCATOR_TLV => {
+                let (_, t) = Ospfv3Srv6LocatorTlv::parse_be(value)?;
+                Ospfv3Srv6LocatorLsaTlv::Locator(t)
+            }
+            _ => Ospfv3Srv6LocatorLsaTlv::Unknown {
+                typ,
+                value: value.to_vec(),
+            },
+        };
+        let padded = (len + 3) & !3;
+        let (input, _) = take(padded - len)(input)?;
+        Ok((input, parsed))
+    }
+}
+
+/// SRv6 Locator LSA body (RFC 9513 §7) — a TLV stream like the
+/// Extended LSAs, but in its own TLV namespace.
+#[derive(Debug, Clone, PartialEq, Default)]
+pub struct Ospfv3Srv6LocatorLsa {
+    pub tlvs: Vec<Ospfv3Srv6LocatorLsaTlv>,
+}
+
+impl Ospfv3Srv6LocatorLsa {
+    pub fn emit(&self, buf: &mut BytesMut) {
+        for tlv in &self.tlvs {
+            tlv.emit(buf);
+        }
+    }
+
+    pub fn parse_be(mut input: &[u8]) -> IResult<&[u8], Self> {
+        let mut tlvs = Vec::new();
+        while !input.is_empty() {
+            let (rest, tlv) = Ospfv3Srv6LocatorLsaTlv::parse_be(input)?;
+            tlvs.push(tlv);
+            input = rest;
+        }
+        Ok((input, Self { tlvs }))
+    }
+}
+
+/// Take 16 octets as an SRv6 SID.
+fn parse_ipv6_sid(input: &[u8]) -> IResult<&[u8], Ipv6Addr> {
+    let (input, raw) = take(16usize)(input)?;
+    let mut octets = [0u8; 16];
+    octets.copy_from_slice(raw);
+    Ok((input, Ipv6Addr::from(octets)))
 }
 
 #[cfg(test)]
@@ -4715,5 +5263,149 @@ mod tests {
             subs: Vec::new(),
         };
         assert!(!asla.is_flex_algo());
+    }
+
+    // ---- RFC 9513 SRv6 codec round-trips ----------------------------
+
+    #[test]
+    fn srv6_capabilities_tlv_roundtrip() {
+        let tlv = Ospfv3ExtTlv::Srv6Capabilities(Ospfv3Srv6CapabilitiesTlv {
+            flags: OSPFV3_SRV6_CAP_FLAG_O,
+        });
+        let mut buf = BytesMut::new();
+        tlv.emit(&mut buf);
+        // Type 20, length 4, flags, reserved.
+        assert_eq!(buf.len(), 8);
+        let (rest, parsed) = Ospfv3ExtTlv::parse_be(&buf).unwrap();
+        assert!(rest.is_empty());
+        assert_eq!(parsed, tlv);
+    }
+
+    #[test]
+    fn srv6_locator_lsa_roundtrip() {
+        // A uSID locator (fcbb:bbbb:5::/48) advertising its End SID
+        // (= locator base, behavior uN/EndCSID = 48) with the SID
+        // structure both at the End-SID level and the locator level.
+        let structure = Ospfv3Srv6SidStructure {
+            lb_len: 32,
+            ln_len: 16,
+            fun_len: 16,
+            arg_len: 0,
+        };
+        let end_sid = Ospfv3Srv6EndSidSubTlv {
+            flags: 0,
+            behavior: 48,
+            sid: "fcbb:bbbb:5::".parse().unwrap(),
+            subs: vec![Ospfv3Srv6LocatorSubTlv::SidStructure(structure)],
+        };
+        let locator = Ospfv3Srv6LocatorTlv {
+            route_type: 1,
+            algorithm: 0,
+            locator_length: 48,
+            prefix_options: 0,
+            metric: 0,
+            locator: "fcbb:bbbb:5::".parse().unwrap(),
+            subs: vec![Ospfv3Srv6LocatorSubTlv::EndSid(end_sid)],
+        };
+        let body = Ospfv3Srv6LocatorLsa {
+            tlvs: vec![Ospfv3Srv6LocatorLsaTlv::Locator(locator)],
+        };
+        let mut buf = BytesMut::new();
+        body.emit(&mut buf);
+        let (rest, parsed) = Ospfv3Srv6LocatorLsa::parse_be(&buf).unwrap();
+        assert!(rest.is_empty());
+        assert_eq!(parsed, body);
+
+        // The /48 locator must encode as 8 prefix octets (ceil(48/32)*4),
+        // not the full 16: TLV header 4 + fixed 8 + prefix 8 = 20, then
+        // the End SID sub-TLV: header 4 + fixed 20 + nested structure 8.
+        assert_eq!(buf.len(), 4 + 8 + 8 + 4 + 20 + 8);
+    }
+
+    #[test]
+    fn srv6_locator_lsa_parses_via_ls_body_dispatch() {
+        let locator = Ospfv3Srv6LocatorTlv {
+            route_type: 1,
+            algorithm: 0,
+            locator_length: 64,
+            prefix_options: 0,
+            metric: 10,
+            locator: "2001:db8:0:5::".parse().unwrap(),
+            subs: vec![],
+        };
+        let body = Ospfv3Srv6LocatorLsa {
+            tlvs: vec![Ospfv3Srv6LocatorLsaTlv::Locator(locator)],
+        };
+        let mut buf = BytesMut::new();
+        body.emit(&mut buf);
+        let (_, parsed) = Ospfv3LsBody::parse_be(&buf, OSPFV3_SRV6_LOCATOR_LSA_TYPE).unwrap();
+        match parsed {
+            Ospfv3LsBody::Srv6Locator(b) => assert_eq!(b, body),
+            other => panic!("expected Srv6Locator body, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn srv6_endx_sid_sub_tlv_roundtrip() {
+        let endx = Ospfv3SubTlv::Srv6EndXSid(Ospfv3Srv6EndXSidSubTlv {
+            behavior: 43, // End.X with NEXT-CSID (uA)
+            flags: 0,
+            algo: 0,
+            weight: 0,
+            sid: "fcbb:bbbb:5:e003::".parse().unwrap(),
+            subs: vec![Ospfv3SubTlv::Srv6SidStructure(Ospfv3Srv6SidStructure {
+                lb_len: 32,
+                ln_len: 16,
+                fun_len: 16,
+                arg_len: 0,
+            })],
+        });
+        let mut buf = BytesMut::new();
+        endx.emit(&mut buf);
+        let (rest, parsed) = Ospfv3SubTlv::parse_be(&buf).unwrap();
+        assert!(rest.is_empty());
+        assert_eq!(parsed, endx);
+    }
+
+    #[test]
+    fn srv6_lan_endx_sid_sub_tlv_roundtrip() {
+        let lan = Ospfv3SubTlv::Srv6LanEndXSid(Ospfv3Srv6LanEndXSidSubTlv {
+            behavior: 5, // classic End.X
+            flags: 0,
+            algo: 0,
+            weight: 10,
+            neighbor_router_id: Ipv4Addr::new(10, 0, 0, 5),
+            sid: "2001:db8:5:e000::".parse().unwrap(),
+            subs: vec![],
+        });
+        let mut buf = BytesMut::new();
+        lan.emit(&mut buf);
+        let (rest, parsed) = Ospfv3SubTlv::parse_be(&buf).unwrap();
+        assert!(rest.is_empty());
+        assert_eq!(parsed, lan);
+    }
+
+    #[test]
+    fn srv6_locator_unknown_sub_tlv_preserved() {
+        // Route-Tag (locator sub-TLV 3) is not modeled — it must
+        // survive a parse/emit cycle verbatim inside the locator.
+        let locator = Ospfv3Srv6LocatorTlv {
+            route_type: 1,
+            algorithm: 0,
+            locator_length: 48,
+            prefix_options: 0,
+            metric: 0,
+            locator: "fcbb:bbbb:7::".parse().unwrap(),
+            subs: vec![Ospfv3Srv6LocatorSubTlv::Unknown {
+                typ: 3,
+                value: vec![0, 0, 0, 99],
+            }],
+        };
+        let tlv = Ospfv3Srv6LocatorLsaTlv::Locator(locator);
+        let mut buf = BytesMut::new();
+        tlv.emit(&mut buf);
+        let (rest, parsed) = Ospfv3Srv6LocatorLsaTlv::parse_be(&buf).unwrap();
+        assert!(rest.is_empty());
+        assert_eq!(parsed, tlv);
     }
 }

--- a/docs/design/ospfv3-srv6-plan.md
+++ b/docs/design/ospfv3-srv6-plan.md
@@ -1,0 +1,92 @@
+# OSPFv3 SRv6 (RFC 9513) — implementation plan
+
+Locked 2026-06-12. Brings OSPFv3 to parity with the IS-IS SRv6 stack:
+locator origination, End/End.X SIDs, SRv6 TI-LFA repairs with
+NEXT-C-SID carrier compression. The IS-IS implementation is the
+blueprint throughout — every dataplane lesson it validated applies
+verbatim, because the FIB/RIB layers are shared:
+
+- **End.X nh6 must be the neighbor's GLOBAL address** (PR #1361):
+  Linux's seg6local End.X re-resolves nh6 with iif = the packet's
+  ingress interface, so a link-local nh6 blackholes. OSPFv3 learns
+  neighbor addresses from Link-LSAs (link-local) — the global must
+  come from the neighbor's Intra-Area-Prefix/Link-LSA prefixes that
+  fall on the shared link.
+- **uA installs classic /128; the NEXT-CSID flavor goes on the
+  LIB twin** (`block:function` prefix entry, PR #1364) and on the uN
+  prefix entry only.
+- **Repairs are SRH insertion (H.Insert), never H.Encap** — transit
+  End/End.X repair segments have no decap terminator (memory of the
+  original IS-IS validation; `EncapType::HInsert` plumbing shared).
+- **BDD must include the promoted-backup scenario from day one** —
+  link-down scenarios never exercise SRH forwarding (PR #1361's bug
+  survived two "passing" features that way).
+
+## Wire model (RFC 9513)
+
+| Item | Registry | Value |
+|---|---|---|
+| SRv6 Capabilities TLV | OSPF RI TLVs | 20 |
+| SRv6 Locator LSA | OSPFv3 LSA Function Codes | 42 (area scope, U=1 → ls_type 0xA02A) |
+| SRv6 Locator TLV | new: OSPFv3 SRv6 Locator LSA TLVs | 1 |
+| SRv6 End SID sub-TLV | new: OSPFv3 SRv6 Locator LSA Sub-TLVs | 1 |
+| SRv6 SID Structure (locator home) | OSPFv3 SRv6 Locator LSA Sub-TLVs | 10 |
+| SRv6 SID Structure (E-LSA home) | OSPFv3 Extended-LSA Sub-TLVs | 30 |
+| SRv6 End.X SID sub-TLV | OSPFv3 Extended-LSA Sub-TLVs | 31 |
+| SRv6 LAN End.X SID sub-TLV | OSPFv3 Extended-LSA Sub-TLVs | 32 |
+
+In-house conventions carried over:
+
+- zebra-rs has no standalone Router Information LSA for v3; RI-style
+  TLVs (SR-Algorithm, SID/Label Range, SRLB, FAD) ride a dedicated
+  E-Router-LSA instance (`SR_INFO_LSID`). The SRv6 Capabilities TLV
+  (type 20 — collision-free with the in-house Ext-TLV numbers) joins
+  that LSA rather than introducing an RI LSA.
+- Endpoint behaviors stay raw `u16` in the codec (the IANA "SRv6
+  Endpoint Behaviors" registry is protocol-neutral); the daemon maps
+  them through `isis_packet::Behavior`, which already models the full
+  registry including the NEXT-C-SID variants.
+
+## Phases
+
+1. **Codec** (this PR): all RFC 9513 wire types in
+   `crates/ospf-packet/src/v3.rs` — SRv6 Capabilities Ext-TLV, the
+   SRv6 Locator LSA (own TLV/sub-TLV registries: Locator TLV,
+   End SID sub-TLV, SID Structure 10), and the Extended-LSA sub-TLVs
+   (SID Structure 30, End.X SID 31, LAN End.X SID 32, with nested
+   structure sub-TLVs). Parse/emit round-trip tests; LSDB/show accept
+   the new ls_type without choking.
+2. **Config + locator origination**: `router ospfv3 segment-routing
+   srv6 locator <name>` (YANG mirror of IS-IS), watch the RIB locator
+   registry, originate the SRv6 Locator LSA (End SID = locator base,
+   behavior End/uN by locator mode) + SRv6 Capabilities; install the
+   End/uN SID via `SidAdd` (registry, kernel install, show — all
+   shared with IS-IS).
+3. **End.X origination**: one End.X/uA per Full neighbor from the
+   ELIB function pool (share `isis::srv6::ElibPool` or lift it to a
+   common home); advertise sub-TLV 31/32 on the Router-Link TLV;
+   install with global nh6 + drift re-install + LIB twin for uSID
+   locators (ports of `reconcile_endx_sid` / `reconcile_endx_lib_sid`).
+4. **Receive side**: parse neighbors' Locator LSAs in the LSDB
+   rebuild, feed locator prefixes into the v3 route calculation
+   (route_type/algorithm/metric semantics per §7.1), and collect
+   per-neighbor End/End.X SIDs + structures (the v3 sibling of
+   `srv6_end_map`).
+5. **TI-LFA SRv6**: v3 sibling of `build_repair_path_srv6` — resolve
+   `spf::RepairPath` segments to SRv6 SIDs from the maps of phase 4,
+   reuse the NEXT-C-SID carrier packer (lift `pack_carriers` out of
+   `isis::tilfa` into a shared module), install as `HInsert` repairs.
+6. **BDD + show**: `ospfv3_tilfa_srv6.feature` mirroring
+   `isis_tilfa_srv6.feature` (eight routers, e1/e2 LAN hosts if BGP
+   service traffic is included, uSID + classic variants as needed),
+   including the promoted-backup forwarding scenario from the start;
+   `show ipv6 ospf` SRv6 blocks.
+
+## Deferred / out of scope
+
+- Algorithm ≠ 0 locators (Flex-Algo SRv6) — locator TLV carries the
+  algorithm field; consumption beyond algo 0 deferred.
+- Anycast locators (AC-bit prefix option, also allocated by RFC 9513).
+- SRv6 in `router ospf` (v2) — SRv6 is v6-native; not applicable.
+- Locator LSA sub-TLVs 2–5 (forwarding address, route tag, prefix
+  source) — parsed as Unknown, not consumed.

--- a/zebra-rs/src/ospf/show_v3.rs
+++ b/zebra-rs/src/ospf/show_v3.rs
@@ -86,6 +86,7 @@ fn ls_type_name(ls_type: u16) -> &'static str {
         OSPFV3_E_ROUTER_LSA_TYPE, OSPFV3_GRACE_LSA_TYPE, OSPFV3_INTER_AREA_PREFIX_LSA_TYPE,
         OSPFV3_INTER_AREA_ROUTER_LSA_TYPE, OSPFV3_INTRA_AREA_PREFIX_LSA_TYPE, OSPFV3_LINK_LSA_TYPE,
         OSPFV3_NETWORK_LSA_TYPE, OSPFV3_NSSA_LSA_TYPE, OSPFV3_ROUTER_LSA_TYPE,
+        OSPFV3_SRV6_LOCATOR_LSA_TYPE,
     };
     match ls_type {
         OSPFV3_ROUTER_LSA_TYPE => "Router-LSA",
@@ -98,6 +99,7 @@ fn ls_type_name(ls_type: u16) -> &'static str {
         OSPFV3_INTRA_AREA_PREFIX_LSA_TYPE => "Intra-Area-Prefix-LSA",
         OSPFV3_GRACE_LSA_TYPE => "Grace-LSA",
         OSPFV3_E_ROUTER_LSA_TYPE => "E-Router-LSA",
+        OSPFV3_SRV6_LOCATOR_LSA_TYPE => "SRv6-Locator-LSA",
         OSPFV3_E_NETWORK_LSA_TYPE => "E-Network-LSA",
         OSPFV3_E_INTER_AREA_PREFIX_LSA_TYPE => "E-Inter-Area-Prefix-LSA",
         OSPFV3_E_INTER_AREA_ROUTER_LSA_TYPE => "E-Inter-Area-Router-LSA",
@@ -961,6 +963,9 @@ fn write_lsa_detail(
                 writeln!(out, "  Restart Reason: {:?}", reason)?;
             }
         }
+        Ospfv3LsBody::Srv6Locator(b) => {
+            write_srv6_locator_body(out, b)?;
+        }
         Ospfv3LsBody::Unknown(bytes) => {
             writeln!(out, "  (Unrecognized LSA body, {} bytes)", bytes.len())?;
         }
@@ -1069,6 +1074,60 @@ fn write_v3_asla_sub(
     Ok(())
 }
 
+/// Render an RFC 9513 SRv6 Locator LSA body TLV-by-TLV.
+fn write_srv6_locator_body(
+    out: &mut String,
+    body: &ospf_packet::Ospfv3Srv6LocatorLsa,
+) -> Result<(), std::fmt::Error> {
+    use ospf_packet::{Ospfv3Srv6LocatorLsaTlv, Ospfv3Srv6LocatorSubTlv};
+    for tlv in &body.tlvs {
+        match tlv {
+            Ospfv3Srv6LocatorLsaTlv::Locator(loc) => {
+                writeln!(
+                    out,
+                    "  SRv6 Locator TLV: {}/{}",
+                    loc.locator, loc.locator_length
+                )?;
+                writeln!(out, "    Route Type: {}", loc.route_type)?;
+                writeln!(out, "    Algorithm: {}", loc.algorithm)?;
+                writeln!(out, "    Metric: {}", loc.metric)?;
+                for sub in &loc.subs {
+                    match sub {
+                        Ospfv3Srv6LocatorSubTlv::EndSid(es) => {
+                            writeln!(out, "    SRv6 End SID Sub-TLV:")?;
+                            writeln!(out, "      Endpoint Behavior: {}", es.behavior)?;
+                            writeln!(out, "      SID: {}", es.sid)?;
+                            for s2 in &es.subs {
+                                if let Ospfv3Srv6LocatorSubTlv::SidStructure(st) = s2 {
+                                    writeln!(
+                                        out,
+                                        "      SID Structure: LB {} LN {} Fun {} Arg {}",
+                                        st.lb_len, st.ln_len, st.fun_len, st.arg_len
+                                    )?;
+                                }
+                            }
+                        }
+                        Ospfv3Srv6LocatorSubTlv::SidStructure(st) => {
+                            writeln!(
+                                out,
+                                "    SID Structure Sub-TLV: LB {} LN {} Fun {} Arg {}",
+                                st.lb_len, st.ln_len, st.fun_len, st.arg_len
+                            )?;
+                        }
+                        Ospfv3Srv6LocatorSubTlv::Unknown { typ, value } => {
+                            writeln!(out, "    Unknown Sub-TLV: type={} len={}", typ, value.len())?;
+                        }
+                    }
+                }
+            }
+            Ospfv3Srv6LocatorLsaTlv::Unknown { typ, value } => {
+                writeln!(out, "  Unknown TLV: type={} len={}", typ, value.len())?;
+            }
+        }
+    }
+    Ok(())
+}
+
 /// Render one RFC 8362 sub-TLV nested under a Router-Link or
 /// Intra-Area-Prefix TLV.
 fn write_v3_sub_tlv(
@@ -1103,6 +1162,36 @@ fn write_v3_sub_tlv(
         }
         Ospfv3SubTlv::Asla(asla) => {
             write_v3_asla_sub(out, asla)?;
+        }
+        Ospfv3SubTlv::Srv6EndXSid(endx) => {
+            writeln!(out, "    SRv6 End.X SID Sub-TLV:")?;
+            writeln!(out, "      Endpoint Behavior: {}", endx.behavior)?;
+            writeln!(out, "      Flags: 0x{:02x}", endx.flags)?;
+            writeln!(out, "      Algorithm: {}", endx.algo)?;
+            writeln!(out, "      Weight: {}", endx.weight)?;
+            writeln!(out, "      SID: {}", endx.sid)?;
+            for sub in &endx.subs {
+                write_v3_sub_tlv(out, sub)?;
+            }
+        }
+        Ospfv3SubTlv::Srv6LanEndXSid(lan) => {
+            writeln!(out, "    SRv6 LAN End.X SID Sub-TLV:")?;
+            writeln!(out, "      Endpoint Behavior: {}", lan.behavior)?;
+            writeln!(out, "      Flags: 0x{:02x}", lan.flags)?;
+            writeln!(out, "      Algorithm: {}", lan.algo)?;
+            writeln!(out, "      Weight: {}", lan.weight)?;
+            writeln!(out, "      Neighbor Router ID: {}", lan.neighbor_router_id)?;
+            writeln!(out, "      SID: {}", lan.sid)?;
+            for sub in &lan.subs {
+                write_v3_sub_tlv(out, sub)?;
+            }
+        }
+        Ospfv3SubTlv::Srv6SidStructure(st) => {
+            writeln!(
+                out,
+                "    SRv6 SID Structure Sub-TLV: LB {} LN {} Fun {} Arg {}",
+                st.lb_len, st.ln_len, st.fun_len, st.arg_len
+            )?;
         }
         Ospfv3SubTlv::Unknown { typ, value } => {
             writeln!(out, "    Unknown Sub-TLV: type={} len={}", typ, value.len())?;
@@ -1217,6 +1306,9 @@ fn write_ext_lsa_body(
                         }
                     }
                 }
+            }
+            Ospfv3ExtTlv::Srv6Capabilities(cap) => {
+                writeln!(out, "  SRv6 Capabilities TLV: Flags: 0x{:04x}", cap.flags)?;
             }
             Ospfv3ExtTlv::Unknown { typ, value } => {
                 writeln!(out, "  Unknown TLV: type={} len={}", typ, value.len())?;
@@ -2049,7 +2141,7 @@ mod tests {
             OSPFV3_E_AS_EXTERNAL_LSA_TYPE, OSPFV3_E_INTER_AREA_PREFIX_LSA_TYPE,
             OSPFV3_E_INTER_AREA_ROUTER_LSA_TYPE, OSPFV3_E_INTRA_AREA_PREFIX_LSA_TYPE,
             OSPFV3_E_LINK_LSA_TYPE, OSPFV3_E_NETWORK_LSA_TYPE, OSPFV3_E_ROUTER_LSA_TYPE,
-            OSPFV3_GRACE_LSA_TYPE, OSPFV3_NSSA_LSA_TYPE,
+            OSPFV3_GRACE_LSA_TYPE, OSPFV3_NSSA_LSA_TYPE, OSPFV3_SRV6_LOCATOR_LSA_TYPE,
         };
         assert_eq!(ls_type_name(OSPFV3_ROUTER_LSA_TYPE), "Router-LSA");
         assert_eq!(ls_type_name(OSPFV3_NETWORK_LSA_TYPE), "Network-LSA");
@@ -2070,6 +2162,10 @@ mod tests {
         );
         assert_eq!(ls_type_name(OSPFV3_GRACE_LSA_TYPE), "Grace-LSA");
         assert_eq!(ls_type_name(OSPFV3_E_ROUTER_LSA_TYPE), "E-Router-LSA");
+        assert_eq!(
+            ls_type_name(OSPFV3_SRV6_LOCATOR_LSA_TYPE),
+            "SRv6-Locator-LSA"
+        );
         assert_eq!(ls_type_name(OSPFV3_E_NETWORK_LSA_TYPE), "E-Network-LSA");
         assert_eq!(
             ls_type_name(OSPFV3_E_INTER_AREA_PREFIX_LSA_TYPE),


### PR DESCRIPTION
## Summary
- **Phase 1 of OSPFv3 SRv6** (plan: `docs/design/ospfv3-srv6-plan.md`, six phases mirroring the IS-IS SRv6 stack with all its validated dataplane lessons baked in — global nh6, classic /128 uA + flavored LIB twin, H.Insert repairs, promoted-backup BDD from day one).
- Codec for every RFC 9513 wire construct, codepoints verified against the RFC's IANA section: SRv6 Locator LSA (function code 42 → `0xA02A`, own TLV/sub-TLV registries: Locator TLV 1, End SID 1, SID Structure 10), Extended-LSA sub-TLVs (SID Structure 30, End.X SID 31, LAN End.X SID 32, nested structures), and the SRv6 Capabilities TLV (RI TLV 20) riding the in-house SR-info E-Router-LSA.
- Behaviors stay raw IANA `u16` in the codec (protocol-neutral registry); the daemon maps them through `isis_packet::Behavior` in later phases.
- `show ipv6 ospf database` names the new LSA and renders its TLV detail.

## Testing
- 6 new round-trip unit tests (incl. LsBody dispatch, /48 prefix wire-length pinning, unknown-sub-TLV preservation); `ls_type_name` coverage test extended.
- Full suite: 1619 passed, 0 failed; clippy `--workspace --all-targets -D warnings` clean; fmt clean.
- Codec-only — no daemon behavior change (nothing originates the new LSA yet), so no BDD impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)