### PR TITLE
ospf: move OSPFv3 show commands from "show ipv6 ospf" to "show ospfv3"

### DIFF
--- a/bdd/tests/features/ospfv3_adjacency.feature
+++ b/bdd/tests/features/ospfv3_adjacency.feature
@@ -40,11 +40,11 @@ Feature: OSPFv3 two-router adjacency forms over a point-to-point link
     And I wait 30 seconds
 
     # o1 (slave) sees o2 (master) Full.
-    Then show command "show ipv6 ospf neighbor" in namespace "o1" should contain "10.0.0.2"
-    And show command "show ipv6 ospf neighbor" in namespace "o1" should contain "Full"
+    Then show command "show ospfv3 neighbor" in namespace "o1" should contain "10.0.0.2"
+    And show command "show ospfv3 neighbor" in namespace "o1" should contain "Full"
     # o2 (master) sees o1 (slave) Full — both ends complete the exchange.
-    And show command "show ipv6 ospf neighbor" in namespace "o2" should contain "10.0.0.1"
-    And show command "show ipv6 ospf neighbor" in namespace "o2" should contain "Full"
+    And show command "show ospfv3 neighbor" in namespace "o2" should contain "10.0.0.1"
+    And show command "show ospfv3 neighbor" in namespace "o2" should contain "Full"
 
     # Teardown.
     When I stop zebra-rs in namespace "o1"

--- a/bdd/tests/features/ospfv3_nssa.feature
+++ b/bdd/tests/features/ospfv3_nssa.feature
@@ -63,26 +63,26 @@ Feature: OSPFv3 NSSA (Not-So-Stubby Area) Type-7 origination and translation
 
     # --- Adjacencies are Full on every link (the NSSA links require the
     #     N-bit to match between a and c / a and d). ---
-    Then show command "show ipv6 ospf neighbor" in namespace "a" should contain "Full"
-    And show command "show ipv6 ospf neighbor" in namespace "a" should contain "10.0.0.2"
-    And show command "show ipv6 ospf neighbor" in namespace "a" should contain "10.0.0.3"
-    And show command "show ipv6 ospf neighbor" in namespace "a" should contain "10.0.0.4"
-    And show command "show ipv6 ospf neighbor" in namespace "c" should contain "Full"
-    And show command "show ipv6 ospf neighbor" in namespace "c" should contain "10.0.0.1"
+    Then show command "show ospfv3 neighbor" in namespace "a" should contain "Full"
+    And show command "show ospfv3 neighbor" in namespace "a" should contain "10.0.0.2"
+    And show command "show ospfv3 neighbor" in namespace "a" should contain "10.0.0.3"
+    And show command "show ospfv3 neighbor" in namespace "a" should contain "10.0.0.4"
+    And show command "show ospfv3 neighbor" in namespace "c" should contain "Full"
+    And show command "show ospfv3 neighbor" in namespace "c" should contain "10.0.0.1"
 
     # --- Type-7 inside the NSSA: d installs the external prefix straight
     #     from c's Type-7. ---
-    And show command "show ipv6 ospf route" in namespace "d" should contain "2001:db8:dead::/64"
+    And show command "show ospfv3 route" in namespace "d" should contain "2001:db8:dead::/64"
 
     # --- The headline: Type-7 -> Type-5 translation at the ABR. b is in
     #     the backbone only, so it can learn 2001:db8:dead::/64 ONLY as a
     #     translated Type-5 (the Type-7 never leaves the NSSA). ---
-    And show command "show ipv6 ospf route" in namespace "b" should contain "2001:db8:dead::/64"
+    And show command "show ospfv3 route" in namespace "b" should contain "2001:db8:dead::/64"
 
     # --- ABR default-originate: a injects a default Type-7 into the NSSA,
     #     so both internal routers hold a ::/0. ---
-    And show command "show ipv6 ospf route" in namespace "c" should contain "::/0"
-    And show command "show ipv6 ospf route" in namespace "d" should contain "::/0"
+    And show command "show ospfv3 route" in namespace "c" should contain "::/0"
+    And show command "show ospfv3 route" in namespace "d" should contain "::/0"
 
     # Teardown.
     When I stop zebra-rs in namespace "a"
@@ -121,10 +121,10 @@ Feature: OSPFv3 NSSA (Not-So-Stubby Area) Type-7 origination and translation
     And I wait 60 seconds
 
     # --- Intra-NSSA Type-7 install is unchanged: d still learns it. ---
-    Then show command "show ipv6 ospf route" in namespace "d" should contain "2001:db8:dead::/64"
+    Then show command "show ospfv3 route" in namespace "d" should contain "2001:db8:dead::/64"
     # --- But with translation disabled the prefix never reaches the
     #     backbone: b must NOT contain it. ---
-    And show command "show ipv6 ospf route" in namespace "b" should not contain "2001:db8:dead::/64"
+    And show command "show ospfv3 route" in namespace "b" should not contain "2001:db8:dead::/64"
 
     When I stop zebra-rs in namespace "a"
     And I stop zebra-rs in namespace "b"

--- a/bdd/tests/features/ospfv3_tilfa.feature
+++ b/bdd/tests/features/ospfv3_tilfa.feature
@@ -91,7 +91,7 @@ Feature: OSPFv3 TI-LFA fast-reroute over SR-MPLS
     And I apply config "d.yaml" to namespace "d"
     And I wait 30 seconds
     # The configured costs surface on the interface (new v3 knob) ...
-    Then show command "show ipv6 ospf interface" in namespace "s" should contain "Cost: 1000"
+    Then show command "show ospfv3 interface" in namespace "s" should contain "Cost: 1000"
     # ... and shape the SPF: directly-connected adjacency over s-n1,
     # then a multi-hop loopback (d, two hops away) over the converged
     # v3 RIB.
@@ -113,20 +113,20 @@ Feature: OSPFv3 TI-LFA fast-reroute over SR-MPLS
     # The graph-level TI-LFA computation found repairs that need an SR
     # tunnel: a Node-SID to reach the P-node r1 past the failure, then
     # Adj-SIDs walking the expensive r-plane links.
-    And show command "show ipv6 ospf ti-lfa" in namespace "s" should contain "OSPFv3 TI-LFA repair paths:"
-    And show command "show ipv6 ospf ti-lfa" in namespace "s" should contain "Node-SID"
-    And show command "show ipv6 ospf ti-lfa" in namespace "s" should contain "Adj-SID"
+    And show command "show ospfv3 ti-lfa" in namespace "s" should contain "OSPFv3 TI-LFA repair paths:"
+    And show command "show ospfv3 ti-lfa" in namespace "s" should contain "Node-SID"
+    And show command "show ospfv3 ti-lfa" in namespace "s" should contain "Adj-SID"
     # And the repairs are installed against the single-nexthop
     # loopbacks behind n1: r2, r3 and d (r1 itself is ECMP via n1/n2
     # and self-protects). Every repair starts with r1's node-SID label
     # 16500, followed by dynamically allocated SRLB Adj-SID labels
     # (15xxx — exact values depend on each router's allocation order,
     # so the assertion pins the SRLB range, not a specific label).
-    And show command "show ipv6 ospf repair-list" in namespace "s" should contain "2001:db8::6/128"
-    And show command "show ipv6 ospf repair-list" in namespace "s" should contain "2001:db8::7/128"
-    And show command "show ipv6 ospf repair-list" in namespace "s" should contain "2001:db8::8/128"
-    And show command "show ipv6 ospf repair-list" in namespace "s" should contain "[16500, 15"
-    And show command "show ipv6 ospf repair-list detail" in namespace "s" should contain "sr-mpls"
+    And show command "show ospfv3 repair-list" in namespace "s" should contain "2001:db8::6/128"
+    And show command "show ospfv3 repair-list" in namespace "s" should contain "2001:db8::7/128"
+    And show command "show ospfv3 repair-list" in namespace "s" should contain "2001:db8::8/128"
+    And show command "show ospfv3 repair-list" in namespace "s" should contain "[16500, 15"
+    And show command "show ospfv3 repair-list detail" in namespace "s" should contain "sr-mpls"
 
   Scenario: Source reaches the destination over the primary path
     Given the test topology exists
@@ -184,14 +184,14 @@ Feature: OSPFv3 TI-LFA fast-reroute over SR-MPLS
   Scenario: Disabling fast-reroute clears the repair-list
     Given the test topology exists
     # s still holds TI-LFA backups from the previous scenarios.
-    Then show command "show ipv6 ospf repair-list" in namespace "s" should contain "16500"
+    Then show command "show ospfv3 repair-list" in namespace "s" should contain "16500"
     # Re-apply s without `fast-reroute ti-lfa` (SR-MPLS stays on).
     When I apply config "s-nofrr.yaml" to namespace "s"
     And I wait 5 seconds
     # The toggle re-runs SPF without the TI-LFA pass: no graph repairs,
     # no installed backups — while the SR labels stay in the LFIB.
-    Then show command "show ipv6 ospf ti-lfa" in namespace "s" should contain "(no TI-LFA repair paths computed)"
-    And show command "show ipv6 ospf repair-list" in namespace "s" should contain "(no TI-LFA repair-list entries)"
+    Then show command "show ospfv3 ti-lfa" in namespace "s" should contain "(no TI-LFA repair paths computed)"
+    And show command "show ospfv3 repair-list" in namespace "s" should contain "(no TI-LFA repair-list entries)"
     And mpls ilm in namespace "s" should contain label 16800
 
   Scenario: Deleting segment-routing mpls clears all MPLS ILM entries

--- a/book/src/ch-08-03-ospf-clear.md
+++ b/book/src/ch-08-03-ospf-clear.md
@@ -41,7 +41,7 @@ clear ospf neighbor          # reset all OSPFv2 adjacencies
 ```
 
 The OSPFv3 commands behave identically; for OSPFv3 the Router-ID is the
-neighbor identity shown by `show ipv6 ospf neighbor` (RFC 5340 §10
+neighbor identity shown by `show ospfv3 neighbor` (RFC 5340 §10
 keys neighbors by Router-ID rather than by interface address).
 
 What a clear triggers, as a side effect of the adjacency dropping and

--- a/docs/design/ospf-flex-algo-recap.md
+++ b/docs/design/ospf-flex-algo-recap.md
@@ -108,7 +108,7 @@ first. OSPFv2 follows the standard RI/Ext-Link/Ext-Prefix Opaque LSAs.
 | #1101 | SR-Algorithm participation + FAD origination (`build_fad_v3`) |
 | #1102 | Per-link ASLA origination (`build_link_asla_v3`) |
 | #1103 | Per-algo Prefix-SID origination (E-Intra-Area-Prefix-LSA) |
-| #1104 | Per-algo SPF compute (`graph_v3_flex_algo`) + `show ipv6 ospf flex-algo` |
+| #1104 | Per-algo SPF compute (`graph_v3_flex_algo`) + `show ospfv3 flex-algo` |
 | #1105 | Per-algo IPv6 RIB (`build_rib6_from_flex_algo`, `rib6_flex_algo`) |
 | #1106 | Per-algo Prefix-SID `ilm6` kernel install |
 

--- a/docs/design/ospf-graceful-restart-plan.md
+++ b/docs/design/ospf-graceful-restart-plan.md
@@ -92,7 +92,7 @@ config-surface change.
    link-local flooding scope `0x0008`; same first two sub-TLVs
    (no v3 IP Interface Address — RFC 5187 §2.1).
 4. Decode-only `show ospf database opaque-link` /
-   `show ipv6 ospf database link` rendering (mirror existing
+   `show ospfv3 database link` rendering (mirror existing
    `show_router_info_detail` shape in `show.rs:1282`).
 5. Fixture decode tests under `crates/ospf-packet/tests/`. Use
    the FRR-emitted Grace LSA as the golden capture if available;

--- a/docs/design/ospfv3-followups.md
+++ b/docs/design/ospfv3-followups.md
@@ -17,7 +17,7 @@ slice; reading their diffs is the fastest way to learn the file
 layout if you're new to the v3 path.
 
 - **#806** — `Ospf<Ospfv3>` IPv6 RIB diff/apply + `top.rib6` shadow.
-  `show ipv6 ospf route` walks the shadow.
+  `show ospfv3 route` walks the shadow.
 - **#807** — Drop `IPV6_V6ONLY` on the v3 raw socket (Linux returns
   `EINVAL` on raw sockets with non-TCP/UDP protocols).
 - **#808** — Retransmit-list bookkeeping for area-scope flooding +

--- a/docs/design/ospfv3-srv6-plan.md
+++ b/docs/design/ospfv3-srv6-plan.md
@@ -80,7 +80,7 @@ In-house conventions carried over:
    `isis_tilfa_srv6.feature` (eight routers, e1/e2 LAN hosts if BGP
    service traffic is included, uSID + classic variants as needed),
    including the promoted-backup forwarding scenario from the start;
-   `show ipv6 ospf` SRv6 blocks.
+   `show ospfv3` SRv6 blocks.
 
 ## Deferred / out of scope
 

--- a/zebra-rs/src/config/manager.rs
+++ b/zebra-rs/src/config/manager.rs
@@ -1076,21 +1076,12 @@ fn is_ospf(paths: &[CommandPath]) -> bool {
     paths.iter().any(|x| x.name == "ospf")
 }
 
-/// True for `show ipv6 ospf ...` paths, routed to the `"ospfv3"`
-/// subscriber. Must be checked BEFORE [`is_ospf`] — every v3 show
-/// path also contains an `"ospf"` segment, so `is_ospf` matches as
-/// well and would otherwise win.
+/// True for `show ospfv3 ...` paths, routed to the `"ospfv3"`
+/// subscriber. The segment name is `ospfv3` (not `ospf`), so this
+/// never overlaps [`is_ospf`]; it's still checked first in
+/// [`show_proto`] to keep the most-specific-first ordering explicit.
 fn is_ospfv3(paths: &[CommandPath]) -> bool {
-    let mut has_ipv6 = false;
-    let mut has_ospf = false;
-    for p in paths {
-        if p.name == "ipv6" {
-            has_ipv6 = true;
-        } else if p.name == "ospf" {
-            has_ospf = true;
-        }
-    }
-    has_ipv6 && has_ospf
+    paths.iter().any(|x| x.name == "ospfv3")
 }
 
 fn is_isis(paths: &[CommandPath]) -> bool {

--- a/zebra-rs/src/config/parse.rs
+++ b/zebra-rs/src/config/parse.rs
@@ -1285,10 +1285,9 @@ mod tests {
 
     /// The OSPFv2 show tree moved from `show ip ospf …` to a
     /// top-level `show ospf …` (matching `show isis`); the legacy
-    /// `ip` spellings must no longer parse. OSPFv3 keeps
-    /// `show ipv6 ospf …`. Pinned with parse() tests because the
-    /// vtyctl show surface is garbage-tolerant: an unwired grammar
-    /// returns empty output instead of erroring.
+    /// `ip` spellings must no longer parse. Pinned with parse()
+    /// tests because the vtyctl show surface is garbage-tolerant:
+    /// an unwired grammar returns empty output instead of erroring.
     #[test]
     fn show_ospf_moved_out_of_show_ip() {
         use crate::config::path_from_command;
@@ -1338,15 +1337,63 @@ mod tests {
             let (code, _comps, _state) = parse(cmd, entry.clone(), None, State::new());
             assert_ne!(code, ExecCode::Success, "`{cmd}` must not be a command");
         }
+    }
 
-        // OSPFv3 is untouched by the move.
-        let (code, _comps, _state) =
-            parse("show ipv6 ospf neighbor", entry.clone(), None, State::new());
-        assert_eq!(
-            code,
-            ExecCode::Success,
-            "`show ipv6 ospf neighbor` must still parse"
-        );
+    /// The OSPFv3 show tree moved the same way: `show ipv6 ospf …`
+    /// became a top-level `show ospfv3 …` (the container is renamed,
+    /// so the dispatch segment is `ospfv3`, never colliding with
+    /// v2's `ospf`). The legacy `ipv6` spellings must no longer
+    /// parse; v2's `show ospf` is untouched.
+    #[test]
+    fn show_ospfv3_moved_out_of_show_ipv6() {
+        use crate::config::path_from_command;
+        let entry = exec_entry();
+
+        let cases: Vec<(&str, &str, Vec<&str>)> = vec![
+            ("show ospfv3", "/show/ospfv3", vec![]),
+            ("show ospfv3 interface", "/show/ospfv3/interface", vec![]),
+            ("show ospfv3 neighbor", "/show/ospfv3/neighbor", vec![]),
+            (
+                "show ospfv3 neighbor detail",
+                "/show/ospfv3/neighbor/detail",
+                vec![],
+            ),
+            ("show ospfv3 database", "/show/ospfv3/database", vec![]),
+            ("show ospfv3 route", "/show/ospfv3/route", vec![]),
+            ("show ospfv3 ti-lfa", "/show/ospfv3/ti-lfa", vec![]),
+            ("show ospfv3 vrf blue", "/show/ospfv3/vrf", vec!["blue"]),
+            (
+                "show ospfv3 vrf blue route",
+                "/show/ospfv3/vrf/route",
+                vec!["blue"],
+            ),
+        ];
+
+        for &(cmd, want_path, ref want_args) in &cases {
+            let (code, _comps, state) = parse(cmd, entry.clone(), None, State::new());
+            assert_eq!(code, ExecCode::Success, "parse `{cmd}`");
+            let (path, args) = path_from_command(&state.paths);
+            assert_eq!(path, want_path, "path for `{cmd}`");
+            let got: Vec<&str> = args.0.iter().map(|s| s.as_str()).collect();
+            assert_eq!(&got, want_args, "args for `{cmd}`");
+        }
+
+        // The legacy `show ipv6 ospf …` spellings are gone.
+        for cmd in [
+            "show ipv6 ospf",
+            "show ipv6 ospf neighbor",
+            "show ipv6 ospf route",
+            "show ipv6 ospf vrf blue",
+        ] {
+            let (code, _comps, _state) = parse(cmd, entry.clone(), None, State::new());
+            assert_ne!(code, ExecCode::Success, "`{cmd}` must not be a command");
+        }
+
+        // v2 (`show ospf`) and the other `show ipv6` trees survive.
+        for cmd in ["show ospf neighbor", "show ipv6 route", "show ipv6 nd"] {
+            let (code, _comps, _state) = parse(cmd, entry.clone(), None, State::new());
+            assert_eq!(code, ExecCode::Success, "`{cmd}` must still parse");
+        }
     }
 
     /// `show bgp ipv4 <tab>` surfaces the union arms of the key —

--- a/zebra-rs/src/ospf/inst.rs
+++ b/zebra-rs/src/ospf/inst.rs
@@ -10141,7 +10141,7 @@ fn apply_v3_spf_result(top: &mut Ospf<Ospfv3>, output: SpfOutput) {
     top.graph = Some(graph);
     top.tilfa_result = Some(tilfa_result);
 
-    // Per-algo SPF trees, for `show ipv6 ospf flex-algo`.
+    // Per-algo SPF trees, for `show ospfv3 flex-algo`.
     top.spf_flex_algo = flex_algos
         .into_iter()
         .map(|o| (o.algo, o.spf_result))
@@ -10172,7 +10172,7 @@ fn apply_v3_spf_result(top: &mut Ospf<Ospfv3>, output: SpfOutput) {
 /// our own. The FIB picks between this OSPF route (admin distance
 /// 110) and the kernel's connected route (0), so the connected
 /// route always wins for the directly-attached prefix; the OSPF
-/// route table still shows the prefix for `show ipv6 ospf route`
+/// route table still shows the prefix for `show ospfv3 route`
 /// symmetry across DR-role flips.
 fn build_rib6_from_spf(
     top: &Ospf<Ospfv3>,

--- a/zebra-rs/src/ospf/show_v3.rs
+++ b/zebra-rs/src/ospf/show_v3.rs
@@ -1,7 +1,7 @@
-//! OSPFv3 `show ipv6 ospf ...` command handlers.
+//! OSPFv3 `show ospfv3 ...` command handlers.
 //!
 //! Sibling of v2's `show.rs`. Mirrors the v2 dispatch shape — one
-//! handler per `/show/ipv6/ospf/...` path, registered through
+//! handler per `/show/ospfv3/...` path, registered through
 //! `Ospf<Ospfv3>::show_build`, dispatched by the v3 event loop's
 //! `process_show_msg` arm. Output formatting is plain text by
 //! default; the `json` flag carried by `ShowCallback` produces a
@@ -32,33 +32,33 @@ impl Ospf<Ospfv3> {
     /// `show_build` shape and command set.
     pub fn show_build(&mut self) {
         self.show_cb = Builder::<ShowCallback<Ospfv3>>::default()
-            .path("/show/ipv6/ospf")
+            .path("/show/ospfv3")
             .set(show_ospfv3_summary)
-            .path("/show/ipv6/ospf/interface")
+            .path("/show/ospfv3/interface")
             .set(show_ospfv3_interface)
-            .path("/show/ipv6/ospf/neighbor")
+            .path("/show/ospfv3/neighbor")
             .set(show_ospfv3_neighbor)
-            .path("/show/ipv6/ospf/neighbor/detail")
+            .path("/show/ospfv3/neighbor/detail")
             .set(show_ospfv3_neighbor_detail)
-            .path("/show/ipv6/ospf/database")
+            .path("/show/ospfv3/database")
             .set(show_ospfv3_database)
-            .path("/show/ipv6/ospf/database/detail")
+            .path("/show/ospfv3/database/detail")
             .set(show_ospfv3_database_detail)
-            .path("/show/ipv6/ospf/route")
+            .path("/show/ospfv3/route")
             .set(show_ospfv3_route)
-            .path("/show/ipv6/ospf/spf")
+            .path("/show/ospfv3/spf")
             .set(show_ospfv3_spf)
-            .path("/show/ipv6/ospf/graph")
+            .path("/show/ospfv3/graph")
             .set(show_ospfv3_graph)
-            .path("/show/ipv6/ospf/ti-lfa")
+            .path("/show/ospfv3/ti-lfa")
             .set(show_ospfv3_tilfa)
-            .path("/show/ipv6/ospf/repair-list")
+            .path("/show/ospfv3/repair-list")
             .set(show_ospfv3_repair_list)
-            .path("/show/ipv6/ospf/repair-list/detail")
+            .path("/show/ospfv3/repair-list/detail")
             .set(show_ospfv3_repair_list_detail)
-            .path("/show/ipv6/ospf/segment-routing")
+            .path("/show/ospfv3/segment-routing")
             .set(show_ospfv3_segment_routing)
-            .path("/show/ipv6/ospf/flex-algo")
+            .path("/show/ospfv3/flex-algo")
             .set(show_ospfv3_flex_algo)
             .map();
     }
@@ -111,8 +111,8 @@ fn ls_type_name(ls_type: u16) -> &'static str {
 }
 
 // ---- TI-LFA (RFC 9490) ------------------------------------------
-// `show ipv6 ospf ti-lfa` (graph-level per-destination repair lists)
-// and `show ipv6 ospf repair-list` (repair backups installed on the
+// `show ospfv3 ti-lfa` (graph-level per-destination repair lists)
+// and `show ospfv3 repair-list` (repair backups installed on the
 // v6 RIB). v3 siblings of the v2 handlers in `show.rs`.
 
 fn label_value_str_v3(label: &crate::rib::Label) -> String {
@@ -382,7 +382,7 @@ fn show_ospfv3_tilfa(
     Ok(buf)
 }
 
-// ---- show ipv6 ospf (instance summary) --------------------------
+// ---- show ospfv3 (instance summary) --------------------------
 
 #[derive(Serialize)]
 struct Ospfv3AreaGateJson {
@@ -451,7 +451,7 @@ fn show_ospfv3_summary(
     render_or(json, &summary, text)
 }
 
-// ---- show ipv6 ospf interface -----------------------------------
+// ---- show ospfv3 interface -----------------------------------
 
 #[derive(Serialize)]
 struct Ospfv3InterfaceJson {
@@ -516,7 +516,7 @@ fn show_ospfv3_interface(
     render_or(json, &entries, text)
 }
 
-// ---- show ipv6 ospf neighbor ------------------------------------
+// ---- show ospfv3 neighbor ------------------------------------
 
 #[derive(Serialize)]
 struct Ospfv3NeighborJson {
@@ -590,7 +590,7 @@ fn show_ospfv3_neighbor_detail(
     render_or(json, &entries, text)
 }
 
-// ---- show ipv6 ospf database ------------------------------------
+// ---- show ospfv3 database ------------------------------------
 
 #[derive(Serialize)]
 struct Ospfv3LsaHeaderJson {
@@ -1427,7 +1427,7 @@ fn format_v3_prefix(prefix_length: u8, bytes: &[u8]) -> String {
     }
 }
 
-// ---- show ipv6 ospf route ---------------------------------------
+// ---- show ospfv3 route ---------------------------------------
 
 #[derive(Serialize)]
 struct Ospfv3RouteNexthopJson {
@@ -1498,7 +1498,7 @@ fn show_ospfv3_route(
     render_or(json, &entries, text)
 }
 
-// ---- show ipv6 ospf spf -----------------------------------------
+// ---- show ospfv3 spf -----------------------------------------
 
 #[derive(Serialize)]
 struct Ospfv3SpfPathJson {
@@ -1554,7 +1554,7 @@ fn show_ospfv3_spf(top: &Ospf<Ospfv3>, _args: Args, json: bool) -> Result<String
     render_or(json, &entries, text)
 }
 
-/// `show ipv6 ospf flex-algo` — for each configured Flexible Algorithm
+/// `show ospfv3 flex-algo` — for each configured Flexible Algorithm
 /// (RFC 9350): its local definition plus the FAD-filtered per-algo SPF
 /// tree (the routers reachable under that algorithm's constraints).
 /// v3 sibling of v2's `show_ospf_flex_algo`. Per-algo v6 routes land
@@ -1659,7 +1659,7 @@ fn show_ospfv3_flex_algo(
     Ok(buf)
 }
 
-// ---- show ipv6 ospf graph ---------------------------------------
+// ---- show ospfv3 graph ---------------------------------------
 
 #[derive(Serialize)]
 struct Ospfv3GraphLinkJson {
@@ -1716,7 +1716,7 @@ fn show_ospfv3_graph(
     render_or(json, &entries, text)
 }
 
-// ---- show ipv6 ospf segment-routing -----------------------------
+// ---- show ospfv3 segment-routing -----------------------------
 
 #[derive(Serialize)]
 struct Ospfv3SrLanAdjSidJson {
@@ -2131,7 +2131,7 @@ mod tests {
     use super::*;
 
     /// Pin the LS-Type → display-name map for every codepoint we
-    /// originate or parse, so `show ipv6 ospf database` never falls
+    /// originate or parse, so `show ospfv3 database` never falls
     /// back to "Unknown" for our own LSAs again (the RFC 8362 E-LSA
     /// family regressed this way once: SR-enabled LSDBs listed 38
     /// "Unknown" entries).
@@ -2199,7 +2199,7 @@ mod tests {
     }
 
     /// The SR-capabilities E-Router-LSA must render the SRGB / SRLB
-    /// ranges and the algorithm list — `show ipv6 ospf database
+    /// ranges and the algorithm list — `show ospfv3 database
     /// detail` regressed to bare TLV names once; these pin the
     /// field-level output.
     #[test]

--- a/zebra-rs/yang/configure.yang
+++ b/zebra-rs/yang/configure.yang
@@ -253,7 +253,7 @@ module configure {
       // `clear ospfv3 neighbor [<router-id>]` — v3 sibling of the
       // `clear ospf neighbor` surface. Bare (presence) resets every
       // OSPFv3 adjacency; with a value it resets only the neighbor
-      // whose OSPF Router-ID (the "Neighbor ID" in `show ipv6 ospf
+      // whose OSPF Router-ID (the "Neighbor ID" in `show ospfv3
       // neighbor`) matches. The Router-ID is a dotted-quad, so the
       // arg stays `inet:ipv4-address`; for v3 it is also the
       // `OspfLink.nbrs` map key (RFC 5340 §10). Same presence-list

--- a/zebra-rs/yang/exec.yang
+++ b/zebra-rs/yang/exec.yang
@@ -743,91 +743,92 @@ module exec {
           }
         }
       }
-      container ospf {
-        ext:help "OSPFv3 commands";
-        presence "OSPFv3 instance";
+    }
+
+    container ospfv3 {
+      ext:help "OSPFv3 commands";
+      presence "OSPFv3 instance";
+      leaf interface {
+        ext:help "OSPFv3 interface";
+        type empty;
+      }
+      container neighbor {
+        ext:help "OSPFv3 neighbor";
+        presence "OSPFv3 neighbor";
+        leaf detail {
+          type empty;
+        }
+      }
+      container database {
+        ext:help "OSPFv3 LSDB";
+        presence "OSPFv3 LSDB";
+        leaf detail {
+          type empty;
+        }
+      }
+      leaf route {
+        type empty;
+      }
+      leaf graph {
+        type empty;
+      }
+      leaf spf {
+        type empty;
+      }
+      leaf ti-lfa {
+        ext:help "OSPFv3 TI-LFA per-destination repair paths (graph-level view)";
+        type empty;
+      }
+      container repair-list {
+        ext:help "OSPFv3 TI-LFA repair-list";
+        presence "OSPFv3 repair-list";
+        leaf detail {
+          ext:help "OSPFv3 repair-list detail (per-segment label breakdown)";
+          type empty;
+        }
+      }
+      leaf flex-algo {
+        ext:help "OSPFv3 Flexible Algorithm (RFC 9350) state";
+        type empty;
+      }
+      leaf segment-routing {
+        type empty;
+      }
+      list vrf {
+        // Per-VRF OSPFv3 show. `show ospfv3 vrf <name> <cmd>` is
+        // redirected by the config manager into the per-VRF task's
+        // show channel registered as `"ospfv3:vrf:<name>"`; the
+        // stripped command renders via the child's handlers (a bare
+        // `... vrf <name>` maps to the summary).
+        ext:help "Per-VRF OSPFv3 instance";
+        ext:presence "Show this VRF's OSPFv3 summary";
+        key name;
+        leaf name {
+          ext:help "VRF name";
+          ext:dynamic "rib:vrf";
+          type string;
+        }
         leaf interface {
-          ext:help "OSPFv3 interface";
+          ext:help "OSPFv3 interfaces in this VRF";
           type empty;
         }
         container neighbor {
-          ext:help "OSPFv3 neighbor";
+          ext:help "OSPFv3 neighbors in this VRF";
           presence "OSPFv3 neighbor";
           leaf detail {
             type empty;
           }
         }
         container database {
-          ext:help "OSPFv3 LSDB";
-          presence "OSPFv3 LSDB";
+          ext:help "OSPFv3 database in this VRF";
+          presence "OSPFv3 database";
           leaf detail {
             type empty;
           }
         }
         leaf route {
+          ext:help "OSPFv3 routes in this VRF";
           type empty;
-        }
-        leaf graph {
-          type empty;
-        }
-        leaf spf {
-          type empty;
-        }
-        leaf ti-lfa {
-          ext:help "OSPFv3 TI-LFA per-destination repair paths (graph-level view)";
-          type empty;
-        }
-        container repair-list {
-          ext:help "OSPFv3 TI-LFA repair-list";
-          presence "OSPFv3 repair-list";
-          leaf detail {
-            ext:help "OSPFv3 repair-list detail (per-segment label breakdown)";
-            type empty;
-          }
-        }
-        leaf flex-algo {
-          ext:help "OSPFv3 Flexible Algorithm (RFC 9350) state";
-          type empty;
-        }
-        leaf segment-routing {
-          type empty;
-        }
-        list vrf {
-          // Per-VRF OSPFv3 show. `show ipv6 ospf vrf <name> <cmd>` is
-          // redirected by the config manager into the per-VRF task's
-          // show channel registered as `"ospfv3:vrf:<name>"`; the
-          // stripped command renders via the child's handlers (a bare
-          // `... vrf <name>` maps to the summary).
-          ext:help "Per-VRF OSPFv3 instance";
-          ext:presence "Show this VRF's OSPFv3 summary";
-          key name;
-          leaf name {
-            ext:help "VRF name";
-            ext:dynamic "rib:vrf";
-            type string;
-          }
-          leaf interface {
-            ext:help "OSPFv3 interfaces in this VRF";
-            type empty;
-          }
-          container neighbor {
-            ext:help "OSPFv3 neighbors in this VRF";
-            presence "OSPFv3 neighbor";
-            leaf detail {
-              type empty;
-            }
-          }
-          container database {
-            ext:help "OSPFv3 database in this VRF";
-            presence "OSPFv3 database";
-            leaf detail {
-              type empty;
-            }
-          }
-          leaf route {
-            ext:help "OSPFv3 routes in this VRF";
-            type empty;
-          }
         }
       }
     }


### PR DESCRIPTION
## Summary

OSPFv3 sibling of #1367 (which moved `show ip ospf` → `show ospf`).

- Moves the OSPFv3 show tree out of `show ipv6` to a top-level `show ospfv3` container in `exec.yang`. Unlike the v2 move this is a rename as well as a relocation, so the config-manager dispatch changes: `is_ospfv3()` drops the `ipv6`+`ospf` segment-pair scan for a plain `ospfv3` segment match, which can never collide with v2's `ospf` segment.
- Handler registrations in `ospf/show_v3.rs` follow (`/show/ipv6/ospf/...` → `/show/ospfv3/...`). The per-VRF redirect (`show ospfv3 vrf <name> ...` → `"ospfv3:vrf:<name>"`) works unchanged.
- Sweeps every baked spelling: v3 BDD features (`ospfv3_adjacency`, `ospfv3_nssa`, `ospfv3_tilfa`), book chapter, design docs, and code comments.
- Adds a parse() grammar test mirroring the v2 one: each `show ospfv3 ...` spelling resolves to the expected path/args, the legacy `show ipv6 ospf ...` spellings are rejected, and `show ospf` / `show ipv6 route` / `show ipv6 nd` still parse. The v2 test's now-stale "OSPFv3 keeps `show ipv6 ospf`" cross-check is dropped.

## Test plan

- `cargo test --workspace --exclude bdd` — all green (includes `show_ospfv3_moved_out_of_show_ipv6` and the updated v2 grammar test)
- `cargo clippy --workspace --all-targets -- -D warnings` — clean
- `cargo fmt --check` — clean
- Live BDD against the rebuilt binary + installed YANG: `ospfv3_adjacency` and `ospfv3_nssa` both pass (3 scenarios total), exercising `show ospfv3 neighbor` / `show ospfv3 route` assertions end to end

🤖 Generated with [Claude Code](https://claude.com/claude-code)