### PR TITLE
ospfv3: SRv6 locator config, End/uN SID install, Locator LSA origination

### DIFF
--- a/bdd/tests/configs/ospfv3_srv6/z1.yaml
+++ b/bdd/tests/configs/ospfv3_srv6/z1.yaml
@@ -1,0 +1,29 @@
+# z1 — OSPFv3 SRv6 originator with a uSID locator: advertises the
+# SRv6 Locator LSA (End SID = fcbb:bbbb:1::, behavior uN) and the
+# SRv6 Capabilities TLV in its SR-info E-Router-LSA.
+interface:
+- if-name: lo
+  ipv6:
+    address: 2001:db8::1/128
+- if-name: i2
+  ipv6:
+    address: 2001:db8:12::1/64
+segment-routing:
+  locator:
+  - name: LOC1
+    prefix: fcbb:bbbb:1::/48
+    behavior: usid
+router:
+  ospfv3:
+    router-id: 10.0.0.1
+    segment-routing:
+      srv6:
+        locator: LOC1
+    area:
+    - area-id: 0.0.0.0
+      interface:
+      - if-name: lo
+        enable: true
+      - if-name: i2
+        enable: true
+        network-type: point-to-point

--- a/bdd/tests/configs/ospfv3_srv6/z2.yaml
+++ b/bdd/tests/configs/ospfv3_srv6/z2.yaml
@@ -1,0 +1,27 @@
+# z2 — classic-locator sibling: End SID at the locator base with the
+# classic RFC 8986 layout (behavior End, LB capped at 40).
+interface:
+- if-name: lo
+  ipv6:
+    address: 2001:db8::2/128
+- if-name: i1
+  ipv6:
+    address: 2001:db8:12::2/64
+segment-routing:
+  locator:
+  - name: LOC2
+    prefix: 2001:db8:f:2::/64
+router:
+  ospfv3:
+    router-id: 10.0.0.2
+    segment-routing:
+      srv6:
+        locator: LOC2
+    area:
+    - area-id: 0.0.0.0
+      interface:
+      - if-name: lo
+        enable: true
+      - if-name: i1
+        enable: true
+        network-type: point-to-point

--- a/bdd/tests/features/ospfv3_srv6.feature
+++ b/bdd/tests/features/ospfv3_srv6.feature
@@ -1,0 +1,84 @@
+@ospfv3_srv6
+Feature: OSPFv3 SRv6 locator origination (RFC 9513)
+  As a network operator
+  I want an OSPFv3 router configured with `segment-routing srv6
+  locator <name>` to resolve the locator from the global registry,
+  install its End/uN SID, and originate the SRv6 Locator LSA
+  (function code 42) plus the SRv6 Capabilities TLV, so that SRv6
+  state floods through the area exactly like the IS-IS sibling.
+
+  Phase 2 of `docs/design/ospfv3-srv6-plan.md`: origination only —
+  receive-side locator routes and TI-LFA SRv6 repairs are later
+  phases, so reachability assertions stay out of scope here.
+
+  Test Topology:
+  ```
+   z1 ──────────────── z2
+   i2  2001:db8:12::/64  i1
+   lo 2001:db8::1/128    lo 2001:db8::2/128
+   LOC1 fcbb:bbbb:1::/48 (usid)   LOC2 2001:db8:f:2::/64 (classic)
+  ```
+
+  Scenario: Build the topology and confirm SRv6 LSA origination
+    Given a clean test environment
+    When I create namespace "z1"
+    And I create namespace "z2"
+    And I connect namespace "z1" interface "i2" to namespace "z2" interface "i1"
+    And I start zebra-rs in namespace "z1"
+    And I start zebra-rs in namespace "z2"
+    And I apply config "z1.yaml" to namespace "z1"
+    And I apply config "z2.yaml" to namespace "z2"
+    And I wait 30 seconds
+    # Both routers originate the new LSA into their own LSDB...
+    Then show command "show ospfv3 database" in namespace "z1" should contain "SRv6-Locator-LSA"
+    # ...and area flooding carries it to the peer: z1's LSDB holds
+    # z2's Locator LSA and vice versa (both advertising routers
+    # appear, so the count is 2 — asserted via the detail dump
+    # containing both locator prefixes).
+    And show command "show ospfv3 database detail" in namespace "z1" should contain "SRv6 Locator TLV: fcbb:bbbb:1::/48"
+    And show command "show ospfv3 database detail" in namespace "z1" should contain "SRv6 Locator TLV: 2001:db8:f:2::/64"
+    And show command "show ospfv3 database detail" in namespace "z2" should contain "SRv6 Locator TLV: fcbb:bbbb:1::/48"
+    # The End SID rides inside the Locator TLV with its structure:
+    # uN (End with NEXT-CSID, codepoint 48) for z1's uSID locator,
+    # classic End (codepoint 1) for z2's.
+    And show command "show ospfv3 database detail" in namespace "z1" should contain "SRv6 End SID Sub-TLV:"
+    And show command "show ospfv3 database detail" in namespace "z1" should contain "SID: fcbb:bbbb:1::"
+    And show command "show ospfv3 database detail" in namespace "z1" should contain "SID Structure: LB 32 LN 16 Fun 16 Arg 0"
+    And show command "show ospfv3 database detail" in namespace "z2" should contain "SID Structure: LB 40 LN 24 Fun 16 Arg 0"
+    # The SRv6 Capabilities TLV rides the SR-info E-Router-LSA.
+    And show command "show ospfv3 database detail" in namespace "z1" should contain "SRv6 Capabilities TLV"
+
+  Scenario: The locator's End/uN SID is installed in the SID registry
+    Given the test topology exists
+    # z1's uSID locator carves a uN; z2's classic locator an End —
+    # both owned by ospfv3 in the shared SID registry.
+    Then show command "show segment-routing srv6 sid" in namespace "z1" should contain "uN"
+    And show command "show segment-routing srv6 sid" in namespace "z1" should contain "ospfv3"
+    And show command "show segment-routing srv6 sid" in namespace "z1" should contain "fcbb:bbbb:1::"
+    And show command "show segment-routing srv6 sid" in namespace "z2" should contain "End"
+    And show command "show segment-routing srv6 sid" in namespace "z2" should contain "ospfv3"
+    # And the kernel holds the seg6local install: uN is a prefix
+    # (LB+LN = /48) route with the NEXT-CSID flavor, classic End an
+    # exact /128.
+    And kernel route "fcbb:bbbb:1::/48" in namespace "z1" should eventually contain "seg6local"
+    And kernel route "2001:db8:f:2::" in namespace "z2" should eventually contain "seg6local"
+
+  Scenario: Removing the locator flushes the LSA and withdraws the SID
+    Given the test topology exists
+    When I apply command "delete router ospfv3 segment-routing srv6 locator LOC1" in namespace "z1"
+    And I wait 10 seconds
+    # z1 stops originating: its registry row and kernel route go, and
+    # the flushed LSA disappears from the peer too (MaxAge flood).
+    Then show command "show segment-routing srv6 sid" in namespace "z1" should not contain "uN"
+    And kernel route "fcbb:bbbb:1::/48" in namespace "z1" should eventually be gone
+    And show command "show ospfv3 database detail" in namespace "z2" should not contain "SRv6 Locator TLV: fcbb:bbbb:1::/48"
+    # z2's own origination is untouched.
+    And show command "show ospfv3 database detail" in namespace "z2" should contain "SRv6 Locator TLV: 2001:db8:f:2::/64"
+
+  Scenario: Teardown topology
+    Given the test topology exists
+    When I stop zebra-rs in namespace "z1"
+    And I stop zebra-rs in namespace "z2"
+    And I delete namespace "z1"
+    And I delete namespace "z2"
+    Then the test environment should be clean

--- a/zebra-rs/src/ospf/config_v3.rs
+++ b/zebra-rs/src/ospf/config_v3.rs
@@ -149,6 +149,7 @@ impl Ospf<Ospfv3> {
                 config_ospfv3_interface_flex_algo_prefix_sid_absolute,
             ),
             ("/segment-routing/mpls", config_ospfv3_sr_mpls),
+            ("/segment-routing/srv6/locator", config_ospfv3_srv6_locator),
             ("/fast-reroute/ti-lfa", config_ospfv3_ti_lfa),
             (
                 "/fast-reroute/backup-as-primary",
@@ -804,6 +805,24 @@ fn config_ospfv3_interface_flex_algo_prefix_sid_absolute(
 /// configured SR-MPLS attribute so the matching E-LSAs are
 /// originated (on enable) or flushed (on disable). Mirrors v2's
 /// `config_ospf_sr_mpls`.
+/// `/router/ospfv3/segment-routing/srv6/locator` — name of a locator
+/// from the global /segment-routing/locator list (RFC 9513 Phase 2,
+/// `docs/design/ospfv3-srv6-plan.md`). Mirrors the IS-IS staging
+/// convention: the name is held as a string and only resolves once
+/// the global locator commits — `reconcile_locator_watch` registers
+/// at the RIB and the snapshot reply drives End/uN SID install plus
+/// SRv6 Locator LSA origination.
+fn config_ospfv3_srv6_locator(ospf: &mut Ospf<Ospfv3>, mut args: Args, op: ConfigOp) -> Option<()> {
+    if op.is_set() {
+        let name = args.string()?;
+        ospf.srv6_locator_name = Some(name);
+    } else {
+        ospf.srv6_locator_name = None;
+    }
+    ospf.reconcile_locator_watch();
+    Some(())
+}
+
 fn config_ospfv3_sr_mpls(ospf: &mut Ospf<Ospfv3>, _args: Args, op: ConfigOp) -> Option<()> {
     use super::srmpls::{SRLB_RANGE, SRLB_START, SegmentRoutingMode};
     use crate::spf::label_pool::LabelPool;

--- a/zebra-rs/src/ospf/inst.rs
+++ b/zebra-rs/src/ospf/inst.rs
@@ -199,6 +199,19 @@ pub struct Ospf<V: OspfVersion = Ospfv2> {
     pub rib6: PrefixMap<ipnet::Ipv6Net, SpfRouteV3>,
     pub tracing: OspfTracing,
     pub segment_routing: super::srmpls::SegmentRoutingMode,
+
+    /// SRv6 (RFC 9513) — name of the locator configured under
+    /// `segment-routing srv6 locator`, the name currently watched at
+    /// the RIB, the resolved snapshot, and the installed End/uN SID.
+    /// v3-only: the config handler exists only in `config_v3.rs`, so
+    /// these stay `None` on an `Ospf<Ospfv2>` instance.
+    pub srv6_locator_name: Option<String>,
+    pub watched_locator: Option<String>,
+    pub sr_locator: Option<crate::rib::Locator>,
+    pub sr_end_sid: Option<std::net::Ipv6Addr>,
+    /// SR snapshot channel from the RIB (`SrSubscribe`); only the v3
+    /// event loop polls it.
+    pub sr_rx: UnboundedReceiver<crate::rib::RibSrRx>,
     /// Per-instance graceful-restart helper policy (RFC 3623 §3.1).
     /// Defaults: helper enabled, max grace 1800s, strict LSA
     /// checking on — same as the YANG model's defaults.
@@ -989,6 +1002,10 @@ impl Ospf<Ospfv2> {
 
         let (tx, rx) = mpsc::unbounded_channel();
         let (ptx, prx) = mpsc::unbounded_channel();
+        // v2 never watches SRv6 locators; the channel exists only
+        // because the field is shared with v3. Dropping the tx makes
+        // it permanently silent (and the v2 loop never polls it).
+        let (_sr_tx, sr_rx) = mpsc::unbounded_channel();
         let mut ospf = Self {
             tx,
             rx,
@@ -1025,6 +1042,11 @@ impl Ospf<Ospfv2> {
             rib6: PrefixMap::new(),
             tracing: OspfTracing::default(),
             segment_routing: super::srmpls::SegmentRoutingMode::default(),
+            srv6_locator_name: None,
+            watched_locator: None,
+            sr_locator: None,
+            sr_end_sid: None,
+            sr_rx,
             gr_config: super::neigh::GracefulRestartConfig::default(),
             restarting: None,
             key_chains: BTreeMap::new(),
@@ -4958,6 +4980,15 @@ impl Ospf<Ospfv3> {
         let (tx, rx) = mpsc::unbounded_channel();
         let (ptx, _prx) = mpsc::unbounded_channel();
 
+        // SR snapshot subscription (locator watches for RFC 9513).
+        // One-time registration keyed by the instance's proto label so
+        // VRF children don't stomp the parent's channel.
+        let (sr_tx, sr_rx) = mpsc::unbounded_channel();
+        let _ = ctx.rib.send(crate::rib::Message::SrSubscribe {
+            proto: proto_label.clone(),
+            tx: sr_tx,
+        });
+
         // v3 raw-IPv6 packet path. `read_packet_v6` recvmsg's,
         // verifies the RFC 5340 §4.4 pseudo-header checksum, parses
         // `Ospfv3Packet`, and pushes `Ospfv3Recv` items. `write_packet_v6`
@@ -5016,6 +5047,11 @@ impl Ospf<Ospfv3> {
             rib6: PrefixMap::new(),
             tracing: OspfTracing::default(),
             segment_routing: super::srmpls::SegmentRoutingMode::default(),
+            srv6_locator_name: None,
+            watched_locator: None,
+            sr_locator: None,
+            sr_end_sid: None,
+            sr_rx,
             gr_config: super::neigh::GracefulRestartConfig::default(),
             restarting: None,
             key_chains: BTreeMap::new(),
@@ -6881,6 +6917,11 @@ impl Ospf<Ospfv3> {
                         t if t == OSPFV3_E_ROUTER_LSA_TYPE && ls_id == SR_INFO_LSID => {
                             self.e_router_v3_sr_info_lsa_originate(area)
                         }
+                        // SRv6 Locator LSA (RFC 9513) — single
+                        // instance, ls_id == SRV6_LOCATOR_LSID.
+                        t if t == ospf_packet::OSPFV3_SRV6_LOCATOR_LSA_TYPE => {
+                            self.srv6_locator_lsa_originate(area)
+                        }
                         t if t == OSPFV3_E_ROUTER_LSA_TYPE => self.e_router_v3_lsa_originate(ls_id),
                         // E-Intra-Area-Prefix-LSA (RFC 8362 §3.7 /
                         // RFC 8666 §5) carries the per-link
@@ -7465,15 +7506,169 @@ impl Ospf<Ospfv3> {
 
         let key: super::lsdb::OspfLsaKey = (OSPFV3_E_ROUTER_LSA_TYPE, SR_INFO_LSID, self.router_id);
 
-        if self.segment_routing == SegmentRoutingMode::Mpls && self.areas.get(area_id).is_some() {
+        let srv6 = self.srv6_active();
+        if (self.segment_routing == SegmentRoutingMode::Mpls || srv6)
+            && self.areas.get(area_id).is_some()
+        {
             let algos = crate::flex_algo::sr_algorithms(&self.flex_algo);
             let fads = super::flex_algo::build_fad_v3(
                 &self.flex_algo,
                 &self.affinity_map,
                 &self.srlg_groups,
             );
-            let mut lsa = super::srmpls::e_router_v3_sr_info_lsa_build(self.router_id, algos, fads);
+            let mut lsa =
+                super::srmpls::e_router_v3_sr_info_lsa_build(self.router_id, algos, fads, srv6);
 
+            if let Some(area) = self.areas.get(area_id)
+                && let Some(prev_seq) = area
+                    .lsdb
+                    .lookup_by_raw_key(key)
+                    .map(|prev| prev.h.ls_seq_number)
+            {
+                lsa.h.ls_seq_number = seq_max(lsa.h.ls_seq_number, prev_seq.saturating_add(1));
+            }
+            lsa.update();
+
+            let flood_lsa = lsa.clone();
+            if let Some(area) = self.areas.get_mut(area_id) {
+                area.lsdb.install_originated(lsa, &self.tx, Some(area_id));
+            }
+            self.flood_self_originated_lsa(area_id, &flood_lsa);
+        } else {
+            let flushed = if let Some(area) = self.areas.get_mut(area_id) {
+                area.lsdb.flush_lsa_by_raw_key(key, &self.tx, Some(area_id))
+            } else {
+                None
+            };
+            if let Some(lsa) = flushed {
+                self.flood_self_originated_lsa(area_id, &lsa);
+            }
+        }
+    }
+
+    /// SRv6 is active once the watched locator resolved with a prefix
+    /// — the gate for Locator-LSA origination and the SRv6
+    /// Capabilities TLV.
+    fn srv6_active(&self) -> bool {
+        self.sr_locator.as_ref().is_some_and(|l| l.prefix.is_some())
+    }
+
+    /// Align the RIB locator watch with `srv6_locator_name` —
+    /// the OSPFv3 sibling of `Isis::reconcile_locator_watch`.
+    /// Unwatching drops the resolved snapshot, withdraws the End/uN
+    /// SID, and flushes the Locator LSA; watching triggers an
+    /// immediate snapshot reply from the RIB which re-originates.
+    pub fn reconcile_locator_watch(&mut self) {
+        let desired = self.srv6_locator_name.clone();
+        if desired == self.watched_locator {
+            return;
+        }
+        if let Some(prev) = self.watched_locator.take() {
+            let _ = self.ctx.rib.send(rib::Message::SrLocatorUnwatch {
+                proto: self.proto_label.clone(),
+                name: prev,
+            });
+            self.sr_locator = None;
+            self.update_srv6_end_sid();
+        }
+        if let Some(next) = desired {
+            let _ = self.ctx.rib.send(rib::Message::SrLocatorWatch {
+                proto: self.proto_label.clone(),
+                name: next.clone(),
+            });
+            self.watched_locator = Some(next);
+        }
+        self.srv6_originate_all_areas();
+    }
+
+    /// SR snapshot from the RIB (`SrSubscribe` channel). A locator
+    /// update re-installs the End/uN SID against the new snapshot and
+    /// re-originates the SRv6 LSAs in every area.
+    pub fn process_sr_rx(&mut self, msg: crate::rib::RibSrRx) {
+        match msg {
+            crate::rib::RibSrRx::Locator { name, locator } => {
+                if self.watched_locator.as_deref() != Some(name.as_str()) {
+                    return;
+                }
+                self.sr_locator = locator;
+                self.update_srv6_end_sid();
+                self.srv6_originate_all_areas();
+            }
+            // OSPF's SRGB / SRLB are fixed constants today; no block
+            // watches are registered, so nothing arrives here.
+            crate::rib::RibSrRx::Block { .. } => {}
+        }
+    }
+
+    /// Re-originate (or flush) the SRv6 Locator LSA and the SR-info
+    /// E-Router-LSA (which carries the SRv6 Capabilities TLV) in
+    /// every configured area.
+    fn srv6_originate_all_areas(&mut self) {
+        let area_ids: Vec<Ipv4Addr> = self.areas.iter().map(|(id, _)| *id).collect();
+        for id in area_ids {
+            self.srv6_locator_lsa_originate(id);
+            self.e_router_v3_sr_info_lsa_originate(id);
+        }
+    }
+
+    /// Install / withdraw the End (classic) or uN (uSID) SID derived
+    /// from the resolved locator — the OSPFv3 sibling of
+    /// `Isis::update_end_sid`. Always del-then-add: the address can
+    /// survive a classic↔uSID flip while behavior/structure change,
+    /// and the FIB needs the updated install.
+    fn update_srv6_end_sid(&mut self) {
+        use crate::rib::{
+            LocatorBehavior, Sid, SidAllocationType, SidBehavior, SidContext, SidOwner,
+        };
+        if let Some(prev) = self.sr_end_sid.take() {
+            let _ = self.ctx.rib.send(rib::Message::SidDel { addr: prev });
+        }
+        if let Some(locator) = self.sr_locator.as_ref()
+            && let Some(addr) = locator.node_sid_addr()
+            && let Some(loc_name) = self.watched_locator.clone()
+        {
+            let (behavior, structure) = match locator.behavior {
+                Some(LocatorBehavior::Usid) => (SidBehavior::UN, locator.sid_structure()),
+                None => (SidBehavior::End, None),
+            };
+            let sid = Sid {
+                addr,
+                behavior,
+                context: SidContext::None,
+                owner: SidOwner::new("ospfv3", 0),
+                locator: loc_name,
+                allocation_type: SidAllocationType::Dynamic,
+                // End / uN is local-processing; ifindex=0 lets the RIB
+                // resolve to the sr0 dummy. nh6 has no meaning here.
+                ifindex: 0,
+                nh6: None,
+                structure,
+                table_id: 0,
+                segs: Vec::new(),
+            };
+            let _ = self.ctx.rib.send(rib::Message::SidAdd { sid });
+            self.sr_end_sid = Some(addr);
+        }
+    }
+
+    /// Originate (locator resolved) or flush (not) the SRv6 Locator
+    /// LSA in `area_id` — the same keyed install/flush shape as
+    /// `e_router_v3_sr_info_lsa_originate`.
+    pub fn srv6_locator_lsa_originate(&mut self, area_id: Ipv4Addr) {
+        use ospf_packet::OSPFV3_SRV6_LOCATOR_LSA_TYPE;
+
+        let key: super::lsdb::OspfLsaKey = (
+            OSPFV3_SRV6_LOCATOR_LSA_TYPE,
+            super::srv6::SRV6_LOCATOR_LSID,
+            self.router_id,
+        );
+
+        let built = self
+            .sr_locator
+            .as_ref()
+            .filter(|_| self.areas.get(area_id).is_some())
+            .and_then(|loc| super::srv6::srv6_locator_lsa_build(self.router_id, loc));
+        if let Some(mut lsa) = built {
             if let Some(area) = self.areas.get(area_id)
                 && let Some(prev_seq) = area
                     .lsdb
@@ -8070,6 +8265,9 @@ impl Ospf<Ospfv3> {
                 }
                 Some(recv) = v3_recv_rx.recv() => {
                     self.process_recv(recv);
+                }
+                Some(msg) = self.sr_rx.recv() => {
+                    self.process_sr_rx(msg);
                 }
                 Some(msg) = self.policy_rx.recv() => {
                     self.process_policy_msg(msg);

--- a/zebra-rs/src/ospf/mod.rs
+++ b/zebra-rs/src/ospf/mod.rs
@@ -53,6 +53,7 @@ pub mod flood;
 pub use flood::*;
 
 pub mod srmpls;
+pub mod srv6;
 
 pub mod tilfa;
 

--- a/zebra-rs/src/ospf/nfsm.rs
+++ b/zebra-rs/src/ospf/nfsm.rs
@@ -433,6 +433,12 @@ pub fn ospfv3_populate_initial_db_summary(
         OSPFV3_E_INTER_AREA_PREFIX_LSA_TYPE,
         OSPFV3_E_INTER_AREA_ROUTER_LSA_TYPE,
         OSPFV3_E_INTRA_AREA_PREFIX_LSA_TYPE,
+        // RFC 9513 SRv6 Locator LSA — same area scope, same rule, same
+        // failure mode as the E-LSAs above: it is originated at
+        // configuration time, usually BEFORE any adjacency exists, so
+        // the initial DBD summary is the only path that carries it to
+        // a neighbor that adjacencies later.
+        ospf_packet::OSPFV3_SRV6_LOCATOR_LSA_TYPE,
     ] {
         ospf_db_summary_add_table(nbr, oi.lsdb.iter_by_raw_type(ls_type).map(|(_, lsa)| lsa));
     }

--- a/zebra-rs/src/ospf/show_v3.rs
+++ b/zebra-rs/src/ospf/show_v3.rs
@@ -721,6 +721,8 @@ fn show_ospfv3_database_detail(
         ospf_packet::OSPFV3_E_INTER_AREA_PREFIX_LSA_TYPE,
         ospf_packet::OSPFV3_E_INTER_AREA_ROUTER_LSA_TYPE,
         ospf_packet::OSPFV3_E_INTRA_AREA_PREFIX_LSA_TYPE,
+        // RFC 9513 SRv6 Locator LSA — area scope, own function code.
+        ospf_packet::OSPFV3_SRV6_LOCATOR_LSA_TYPE,
     ];
 
     for (area_id, area) in top.areas.iter() {
@@ -2209,8 +2211,12 @@ mod tests {
         };
         use ospf_packet::Algo;
 
-        let lsa =
-            e_router_v3_sr_info_lsa_build("10.0.0.1".parse().unwrap(), vec![Algo::Spf], Vec::new());
+        let lsa = e_router_v3_sr_info_lsa_build(
+            "10.0.0.1".parse().unwrap(),
+            vec![Algo::Spf],
+            Vec::new(),
+            false,
+        );
         let out = render_ext_body(&lsa);
         assert!(out.contains("SR-Algorithm TLV:"), "{out}");
         assert!(out.contains("Algorithm 0: SPF"), "{out}");

--- a/zebra-rs/src/ospf/srmpls.rs
+++ b/zebra-rs/src/ospf/srmpls.rs
@@ -297,6 +297,7 @@ pub fn e_router_v3_sr_info_lsa_build(
     router_id: Ipv4Addr,
     algos: Vec<Algo>,
     fads: Vec<Ospfv3FadTlv>,
+    srv6: bool,
 ) -> Ospfv3Lsa {
     let sr_algo = Ospfv3ExtTlv::SrAlgorithm(Ospfv3SrAlgorithmTlv { algos });
     let sid_range = Ospfv3ExtTlv::SidLabelRange(Ospfv3SidLabelRangeTlv {
@@ -310,6 +311,14 @@ pub fn e_router_v3_sr_info_lsa_build(
 
     let mut tlvs = vec![sr_algo, sid_range, local_block];
     tlvs.extend(fads.into_iter().map(Ospfv3ExtTlv::Fad));
+    if srv6 {
+        // RFC 9513 §2 SRv6 Capabilities (RI TLV 20), riding this
+        // SR-info E-Router-LSA like the other RI-style TLVs. No O-bit
+        // support, no sub-TLVs — flags 0.
+        tlvs.push(Ospfv3ExtTlv::Srv6Capabilities(
+            ospf_packet::Ospfv3Srv6CapabilitiesTlv { flags: 0 },
+        ));
+    }
 
     let body = Ospfv3ELsaBody { tlvs };
 
@@ -678,6 +687,7 @@ mod tests {
             Ipv4Addr::new(10, 0, 0, 1),
             vec![Algo::Spf, Algo::FlexAlgo(128), Algo::FlexAlgo(200)],
             vec![fad.clone()],
+            false,
         );
         let Ospfv3LsBody::ERouter(body) = &lsa.body else {
             panic!("expected ERouter body");

--- a/zebra-rs/src/ospf/srv6.rs
+++ b/zebra-rs/src/ospf/srv6.rs
@@ -1,0 +1,172 @@
+//! OSPFv3 SRv6 (RFC 9513) — SRv6 Locator LSA origination. Phase 2 of
+//! `docs/design/ospfv3-srv6-plan.md`: the locator configured under
+//! `router ospfv3 segment-routing srv6 locator <name>` resolves
+//! against the RIB locator registry and is advertised as an SRv6
+//! Locator LSA carrying the End SID (= the locator base, behavior
+//! End or uN by locator mode) plus its SID structure.
+
+use std::net::Ipv4Addr;
+
+use ospf_packet::{
+    OSPFV3_SRV6_LOCATOR_LSA_TYPE, Ospfv3LsBody, Ospfv3Lsa, Ospfv3LsaHeader, Ospfv3Srv6EndSidSubTlv,
+    Ospfv3Srv6LocatorLsa, Ospfv3Srv6LocatorLsaTlv, Ospfv3Srv6LocatorSubTlv, Ospfv3Srv6LocatorTlv,
+    Ospfv3Srv6SidStructure,
+};
+
+use crate::rib::{Locator, LocatorBehavior};
+
+/// Link-state ID of the (single) SRv6 Locator LSA. One locator per
+/// instance today, mirroring IS-IS; multi-locator support would key
+/// further instances off this base.
+pub const SRV6_LOCATOR_LSID: u32 = 0;
+
+/// Intra-Area route type in the SRv6 Locator TLV (RFC 9513 §7.1).
+const SRV6_LOCATOR_ROUTE_TYPE_INTRA_AREA: u8 = 1;
+
+/// Build the SRv6 Locator LSA for a resolved locator snapshot.
+/// Returns `None` while the locator has no prefix (configured name
+/// not committed globally yet) — callers flush instead.
+///
+/// The endpoint behavior is the raw IANA codepoint, mapped through
+/// `isis_packet::Behavior` (the registry is protocol-neutral): plain
+/// `End` for a classic locator, `End with NEXT-CSID` (uN) for a uSID
+/// one. The SID structure is advertised for both, exactly like the
+/// IS-IS LSP advertisement, so receivers can pack carriers.
+pub fn srv6_locator_lsa_build(router_id: Ipv4Addr, locator: &Locator) -> Option<Ospfv3Lsa> {
+    let prefix = locator.prefix?;
+    let end_sid = locator.node_sid_addr()?;
+
+    let behavior = match locator.behavior {
+        Some(LocatorBehavior::Usid) => u16::from(isis_packet::Behavior::EndCSID),
+        None => u16::from(isis_packet::Behavior::End),
+    };
+    let structure = locator.sid_structure().map(|s| Ospfv3Srv6SidStructure {
+        lb_len: s.lb_bits,
+        ln_len: s.ln_bits,
+        fun_len: s.fun_bits,
+        arg_len: s.arg_bits,
+    });
+
+    let mut end_subs = Vec::new();
+    if let Some(st) = structure {
+        end_subs.push(Ospfv3Srv6LocatorSubTlv::SidStructure(st));
+    }
+    let end = Ospfv3Srv6EndSidSubTlv {
+        flags: 0,
+        behavior,
+        sid: end_sid,
+        subs: end_subs,
+    };
+    let locator_tlv = Ospfv3Srv6LocatorTlv {
+        route_type: SRV6_LOCATOR_ROUTE_TYPE_INTRA_AREA,
+        algorithm: 0,
+        locator_length: prefix.prefix_len(),
+        prefix_options: 0,
+        metric: 0,
+        locator: prefix.network(),
+        subs: vec![Ospfv3Srv6LocatorSubTlv::EndSid(end)],
+    };
+    let body = Ospfv3Srv6LocatorLsa {
+        tlvs: vec![Ospfv3Srv6LocatorLsaTlv::Locator(locator_tlv)],
+    };
+
+    let mut lsa = Ospfv3Lsa {
+        h: Ospfv3LsaHeader {
+            ls_age: 0,
+            ls_type: OSPFV3_SRV6_LOCATOR_LSA_TYPE,
+            link_state_id: SRV6_LOCATOR_LSID,
+            advertising_router: router_id,
+            ls_seq_number: 0x8000_0001,
+            ls_checksum: 0,
+            length: 0,
+        },
+        body: Ospfv3LsBody::Srv6Locator(body),
+        raw: None,
+    };
+    lsa.update();
+    Some(lsa)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ipnet::Ipv6Net;
+
+    fn locator(prefix: &str, usid: bool) -> Locator {
+        Locator {
+            prefix: Some(prefix.parse::<Ipv6Net>().unwrap()),
+            behavior: usid.then_some(LocatorBehavior::Usid),
+        }
+    }
+
+    #[test]
+    fn usid_locator_advertises_un_behavior_and_structure() {
+        let lsa = srv6_locator_lsa_build(
+            "10.0.0.1".parse().unwrap(),
+            &locator("fcbb:bbbb:5::/48", true),
+        )
+        .unwrap();
+        assert_eq!(lsa.h.ls_type, OSPFV3_SRV6_LOCATOR_LSA_TYPE);
+        let Ospfv3LsBody::Srv6Locator(body) = &lsa.body else {
+            panic!("expected SRv6 Locator body");
+        };
+        let Ospfv3Srv6LocatorLsaTlv::Locator(loc) = &body.tlvs[0] else {
+            panic!("expected Locator TLV");
+        };
+        assert_eq!(loc.locator_length, 48);
+        assert_eq!(
+            loc.locator,
+            "fcbb:bbbb:5::".parse::<std::net::Ipv6Addr>().unwrap()
+        );
+        let Ospfv3Srv6LocatorSubTlv::EndSid(end) = &loc.subs[0] else {
+            panic!("expected End SID sub-TLV");
+        };
+        // uN = End with NEXT-CSID, codepoint via the shared registry.
+        assert_eq!(end.behavior, u16::from(isis_packet::Behavior::EndCSID));
+        assert_eq!(
+            end.sid,
+            "fcbb:bbbb:5::".parse::<std::net::Ipv6Addr>().unwrap()
+        );
+        let Ospfv3Srv6LocatorSubTlv::SidStructure(st) = &end.subs[0] else {
+            panic!("expected SID Structure");
+        };
+        // uSID geometry: LB capped at 32 → /48 splits 32/16, 16-bit fn.
+        assert_eq!(
+            (st.lb_len, st.ln_len, st.fun_len, st.arg_len),
+            (32, 16, 16, 0)
+        );
+    }
+
+    #[test]
+    fn classic_locator_advertises_end_behavior() {
+        let lsa = srv6_locator_lsa_build(
+            "10.0.0.1".parse().unwrap(),
+            &locator("2001:db8:f:1::/64", false),
+        )
+        .unwrap();
+        let Ospfv3LsBody::Srv6Locator(body) = &lsa.body else {
+            panic!("expected SRv6 Locator body");
+        };
+        let Ospfv3Srv6LocatorLsaTlv::Locator(loc) = &body.tlvs[0] else {
+            panic!("expected Locator TLV");
+        };
+        let Ospfv3Srv6LocatorSubTlv::EndSid(end) = &loc.subs[0] else {
+            panic!("expected End SID sub-TLV");
+        };
+        assert_eq!(end.behavior, u16::from(isis_packet::Behavior::End));
+        let Ospfv3Srv6LocatorSubTlv::SidStructure(st) = &end.subs[0] else {
+            panic!("expected SID Structure");
+        };
+        // Classic geometry: LB capped at 40 → /64 splits 40/24.
+        assert_eq!((st.lb_len, st.ln_len), (40, 24));
+    }
+
+    #[test]
+    fn unresolved_locator_builds_nothing() {
+        let unresolved = Locator {
+            prefix: None,
+            behavior: None,
+        };
+        assert!(srv6_locator_lsa_build("10.0.0.1".parse().unwrap(), &unresolved).is_none());
+    }
+}


### PR DESCRIPTION
## Summary
- **Phase 2 of OSPFv3 SRv6** (`docs/design/ospfv3-srv6-plan.md`): `router ospfv3 segment-routing srv6 locator <name>` now resolves the locator from the RIB registry, installs the End/uN SID (shared registry + kernel seg6local: uN as `/(LB+LN)` prefix with the NEXT-CSID flavor, classic End as /128), and originates the RFC 9513 SRv6 Locator LSA per area plus the SRv6 Capabilities TLV on the SR-info E-Router-LSA (which now also originates in SRv6-only configs).
- The v3 instance subscribes to RIB SR snapshots keyed by its proto label (VRF-safe), reconciles the locator watch on config change, and re-originates/flushes on every snapshot — the IS-IS `reconcile_locator_watch`/`update_end_sid` mirror.
- **Two bugs found by the new BDD, fixed here**: the `show ospfv3 database detail` fixed type-allowlist made the phase-1 Locator-LSA renderer unreachable; and the v3 initial **DBD summary** type list lacked the new LSA — since it's originated at config time (before adjacencies exist), the DBD exchange is the only delivery path, so neighbors silently never learned it (the same failure mode as the historical E-LSA omission documented above that list).

## Testing
- New `ospfv3_srv6` BDD feature (uSID + classic locators): cross-flooded Locator LSAs with End SID/structure detail, capabilities TLV, registry + kernel installs, flush/withdraw on locator delete — 4/4 scenarios, 39/39 steps on the rebased (post-#1368 `show ospfv3`) main.
- 3 new unit tests for the LSA builder; full suite 1624 passed, clippy `-D warnings` clean, fmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)