### PR TITLE
rib: introduce NexthopProtect for IS-IS/OSPF TI-LFA backup routes

### DIFF
--- a/zebra-rs/src/fib/netlink/handle.rs
+++ b/zebra-rs/src/fib/netlink/handle.rs
@@ -97,6 +97,17 @@ fn fmt_nexthop_for_trace(nh: &Nexthop) -> String {
                 .collect();
             format!("List[{}]", members.join(", "))
         }
+        Nexthop::Protect(p) => {
+            let fmt_member = |m: &NexthopMember| match m {
+                NexthopMember::Uni(u) => format!("Uni{}", fmt_uni(u)),
+                NexthopMember::Multi(mm) => fmt_multi(mm),
+            };
+            format!(
+                "Protect[primary={} backup={}]",
+                fmt_member(&p.primary),
+                fmt_member(&p.backup)
+            )
+        }
         Nexthop::Link(ifindex) => format!("Link(ifindex={ifindex})"),
     }
 }
@@ -506,6 +517,17 @@ impl FibHandle {
                 }
                 ok
             }
+            Nexthop::Protect(pro) => {
+                // Primary and backup install as two kernel routes at
+                // their own metrics, exactly like the List members.
+                let mut ok = true;
+                for member in pro.members() {
+                    ok &= self
+                        .route_ipv4_add_uni(prefix, entry, &member.as_nexthop(), table_id)
+                        .await;
+                }
+                ok
+            }
             _ => true,
         }
     }
@@ -626,6 +648,12 @@ impl FibHandle {
             }
             Nexthop::List(list) => {
                 for member in &list.nexthops {
+                    self.route_ipv4_del_uni(prefix, entry, &member.as_nexthop(), table_id)
+                        .await;
+                }
+            }
+            Nexthop::Protect(pro) => {
+                for member in pro.members() {
                     self.route_ipv4_del_uni(prefix, entry, &member.as_nexthop(), table_id)
                         .await;
                 }
@@ -873,6 +901,17 @@ impl FibHandle {
                 }
                 ok
             }
+            Nexthop::Protect(pro) => {
+                // Primary and backup install as two kernel routes at
+                // their own metrics, exactly like the List members.
+                let mut ok = true;
+                for member in pro.members() {
+                    ok &= self
+                        .route_ipv6_add_uni(prefix, entry, &member.as_nexthop(), table_id)
+                        .await;
+                }
+                ok
+            }
             _ => true,
         }
     }
@@ -1013,6 +1052,12 @@ impl FibHandle {
             }
             Nexthop::List(list) => {
                 for member in &list.nexthops {
+                    self.route_ipv6_del_uni(prefix, entry, &member.as_nexthop(), table_id)
+                        .await;
+                }
+            }
+            Nexthop::Protect(pro) => {
+                for member in pro.members() {
                     self.route_ipv6_del_uni(prefix, entry, &member.as_nexthop(), table_id)
                         .await;
                 }

--- a/zebra-rs/src/isis/rib.rs
+++ b/zebra-rs/src/isis/rib.rs
@@ -412,11 +412,11 @@ impl<F: IsisRibFamily> PartialEq for SpfNexthop<F> {
 }
 
 /// Sort offset between the primary nhop's metric and its TI-LFA
-/// backup's metric inside a `NexthopList`. The value is RIB-internal
-/// and never reaches the wire — it only governs the metric-sort that
-/// puts the primary at `.nexthops[0]`. See the design discussion that
-/// landed PR #489: blanket `+1` keeps show output legible and avoids
-/// `u32::MAX` sentinels.
+/// backup's metric inside a `NexthopProtect`. The value is RIB-internal
+/// and never reaches the wire — it only governs the metric grouping
+/// that makes the lower-metric group the `primary` member. See the
+/// design discussion that landed PR #489: blanket `+1` keeps show
+/// output legible and avoids `u32::MAX` sentinels.
 pub const BACKUP_METRIC_OFFSET: u32 = 1;
 
 pub type DiffResult<'a, F> = spf::TableDiffResult<'a, <F as IsisRibFamily>::Prefix, SpfRoute<F>>;
@@ -461,7 +461,7 @@ fn make_rib_entry<F: IsisRibFamily>(route: &SpfRoute<F>, level: Level) -> rib::e
     rib.metric = route.metric;
     // Flatten primaries and (when present) their TI-LFA repair backups
     // into a single Vec at distinct metrics; build_rib_nexthop groups
-    // them by metric and routes Multi-vs-List dispatch from there.
+    // them by metric and routes Multi-vs-Protect dispatch from there.
     //
     // `backup_as_primary` flips the metric-sort offset: when set, the
     // repair installs at route.metric (sorted first) and the SPF
@@ -496,15 +496,19 @@ fn make_rib_entry<F: IsisRibFamily>(route: &SpfRoute<F>, level: Level) -> rib::e
 //   - 0 groups          -> Nexthop::default()
 //   - 1 group, 1 nhop   -> Nexthop::Uni
 //   - 1 group, N nhops  -> Nexthop::Multi (ECMP)
-//   - >1 groups         -> Nexthop::List, one member per metric:
+//   - 2 groups          -> Nexthop::Protect, the lower-metric group as
+//                          the primary and the offset group as the
+//                          TI-LFA backup:
 //                            * single-nhop group -> NexthopMember::Uni
 //                            * multi-nhop group  -> NexthopMember::Multi
 //
-// Today every caller passes all primaries at route.metric, so only
-// the first three arms fire. The grouped-List arm is the slot TI-LFA
-// repair install will populate when it appends backup nhops at
-// primary.metric + 1; ECMP-primary + ECMP-backup naturally collapses
-// to a List of two Multi members.
+// Without TI-LFA every nhop sits at route.metric, so only the first
+// three arms fire. A stamped backup adds the second metric group
+// (primary.metric + BACKUP_METRIC_OFFSET, or swapped under
+// backup-as-primary); ECMP-primary + ECMP-backup naturally collapses
+// to a Protect of two Multi members. The caller only ever feeds two
+// distinct metrics, so >2 groups can't happen — the List fallback is
+// defensive.
 fn build_rib_nexthop(nhops: Vec<rib::NexthopUni>) -> rib::Nexthop {
     if nhops.is_empty() {
         return rib::Nexthop::default();
@@ -525,7 +529,7 @@ fn build_rib_nexthop(nhops: Vec<rib::NexthopUni>) -> rib::Nexthop {
             })
         }
     } else {
-        let members: Vec<_> = groups
+        let mut members: Vec<_> = groups
             .into_iter()
             .map(|(metric, mut grp)| {
                 if grp.len() == 1 {
@@ -539,7 +543,13 @@ fn build_rib_nexthop(nhops: Vec<rib::NexthopUni>) -> rib::Nexthop {
                 }
             })
             .collect();
-        rib::Nexthop::List(rib::NexthopList { nexthops: members })
+        if members.len() == 2 {
+            let backup = members.pop().unwrap();
+            let primary = members.pop().unwrap();
+            rib::Nexthop::Protect(rib::NexthopProtect { primary, backup })
+        } else {
+            rib::Nexthop::List(rib::NexthopList { nexthops: members })
+        }
     }
 }
 
@@ -1936,27 +1946,25 @@ mod tests {
     }
 
     #[test]
-    fn build_rib_nexthop_mixed_metric_yields_list_sorted() {
-        // Mixed metrics signal primary + backup — Nexthop::List is
-        // the FRR slot TI-LFA fills, sorted ascending so .nexthops[0]
-        // is the primary. Singleton-per-metric groups become Uni
-        // members.
+    fn build_rib_nexthop_mixed_metric_yields_protect() {
+        // Mixed metrics signal primary + backup — Nexthop::Protect
+        // with the lower-metric group as the primary member.
+        // Singleton-per-metric groups become Uni members.
         let primary = mk_uni("10.0.0.1", 20);
         let backup = mk_uni("10.0.0.5", 21);
-        // Insert backup first to exercise sort.
+        // Insert backup first to exercise the metric grouping.
         let nh = build_rib_nexthop(vec![backup.clone(), primary.clone()]);
-        let rib::Nexthop::List(list) = nh else {
-            panic!("expected List, got {nh:?}");
+        let rib::Nexthop::Protect(pro) = nh else {
+            panic!("expected Protect, got {nh:?}");
         };
-        assert_eq!(list.nexthops.len(), 2);
-        assert_eq!(list.nexthops[0], rib::NexthopMember::Uni(primary));
-        assert_eq!(list.nexthops[1], rib::NexthopMember::Uni(backup));
+        assert_eq!(pro.primary, rib::NexthopMember::Uni(primary));
+        assert_eq!(pro.backup, rib::NexthopMember::Uni(backup));
     }
 
     #[test]
-    fn build_rib_nexthop_ecmp_primary_plus_ecmp_backup_yields_list_of_multi() {
+    fn build_rib_nexthop_ecmp_primary_plus_ecmp_backup_yields_protect_of_multi() {
         // Two ECMP primaries at metric 20 + two backups at metric 21
-        // collapse into a List of two Multi members: one per metric
+        // collapse into a Protect of two Multi members: one per metric
         // group, ECMP-aware. This is the shape TI-LFA emits when
         // both the primary and the post-convergence path are
         // multi-pathed.
@@ -1966,19 +1974,18 @@ mod tests {
         let b2 = mk_uni("10.0.0.6", 21);
         // Insert mixed order to exercise BTreeMap grouping + sort.
         let nh = build_rib_nexthop(vec![b1.clone(), p1.clone(), b2.clone(), p2.clone()]);
-        let rib::Nexthop::List(list) = nh else {
-            panic!("expected List, got {nh:?}");
+        let rib::Nexthop::Protect(pro) = nh else {
+            panic!("expected Protect, got {nh:?}");
         };
-        assert_eq!(list.nexthops.len(), 2);
 
-        let rib::NexthopMember::Multi(primary_grp) = &list.nexthops[0] else {
-            panic!("expected Multi primary, got {:?}", list.nexthops[0]);
+        let rib::NexthopMember::Multi(primary_grp) = &pro.primary else {
+            panic!("expected Multi primary, got {:?}", pro.primary);
         };
         assert_eq!(primary_grp.metric, 20);
         assert_eq!(primary_grp.nexthops.len(), 2);
 
-        let rib::NexthopMember::Multi(backup_grp) = &list.nexthops[1] else {
-            panic!("expected Multi backup, got {:?}", list.nexthops[1]);
+        let rib::NexthopMember::Multi(backup_grp) = &pro.backup else {
+            panic!("expected Multi backup, got {:?}", pro.backup);
         };
         assert_eq!(backup_grp.metric, 21);
         assert_eq!(backup_grp.nexthops.len(), 2);
@@ -2077,11 +2084,11 @@ mod tests {
     }
 
     #[test]
-    fn make_rib_entry_with_mpls_backup_yields_list_at_metric_plus_one() {
-        // SpfNexthop with backup -> List([primary at 20, backup at 21]).
-        // Verifies BACKUP_METRIC_OFFSET + the flat_map plumbing in
-        // make_rib_entry feed build_rib_nexthop a mixed-metric Vec
-        // that collapses to a sorted List.
+    fn make_rib_entry_with_mpls_backup_yields_protect_at_metric_plus_one() {
+        // SpfNexthop with backup -> Protect(primary at 20, backup at
+        // 21). Verifies BACKUP_METRIC_OFFSET + the flat_map plumbing
+        // in make_rib_entry feed build_rib_nexthop a mixed-metric Vec
+        // that collapses to a Protect.
         let primary_addr: Ipv4Addr = "10.0.0.1".parse().unwrap();
         let backup_addr: Ipv4Addr = "10.0.0.5".parse().unwrap();
         let mut nhops = BTreeMap::new();
@@ -2109,19 +2116,18 @@ mod tests {
         };
         let entry = make_rib_entry(&route, Level::L2);
 
-        let rib::Nexthop::List(list) = &entry.nexthop else {
-            panic!("expected List, got {:?}", entry.nexthop);
+        let rib::Nexthop::Protect(pro) = &entry.nexthop else {
+            panic!("expected Protect, got {:?}", entry.nexthop);
         };
-        assert_eq!(list.nexthops.len(), 2);
 
-        let rib::NexthopMember::Uni(p) = &list.nexthops[0] else {
-            panic!("expected Uni primary, got {:?}", list.nexthops[0]);
+        let rib::NexthopMember::Uni(p) = &pro.primary else {
+            panic!("expected Uni primary, got {:?}", pro.primary);
         };
         assert_eq!(p.metric, 20);
         assert_eq!(p.addr, std::net::IpAddr::V4(primary_addr));
 
-        let rib::NexthopMember::Uni(b) = &list.nexthops[1] else {
-            panic!("expected Uni backup, got {:?}", list.nexthops[1]);
+        let rib::NexthopMember::Uni(b) = &pro.backup else {
+            panic!("expected Uni backup, got {:?}", pro.backup);
         };
         assert_eq!(b.metric, 21);
         assert_eq!(b.addr, std::net::IpAddr::V4(backup_addr));
@@ -2161,21 +2167,20 @@ mod tests {
         };
         let entry = make_rib_entry(&route, Level::L2);
 
-        let rib::Nexthop::List(list) = &entry.nexthop else {
-            panic!("expected List, got {:?}", entry.nexthop);
+        let rib::Nexthop::Protect(pro) = &entry.nexthop else {
+            panic!("expected Protect, got {:?}", entry.nexthop);
         };
-        assert_eq!(list.nexthops.len(), 2);
 
-        // First member is the backup (now at the lower metric).
-        let rib::NexthopMember::Uni(b) = &list.nexthops[0] else {
-            panic!("expected Uni backup, got {:?}", list.nexthops[0]);
+        // The repair takes the primary slot (now at the lower metric).
+        let rib::NexthopMember::Uni(b) = &pro.primary else {
+            panic!("expected Uni repair, got {:?}", pro.primary);
         };
         assert_eq!(b.metric, 20);
         assert_eq!(b.addr, std::net::IpAddr::V4(backup_addr));
 
-        // Second member is the SPF primary (now at metric+offset).
-        let rib::NexthopMember::Uni(p) = &list.nexthops[1] else {
-            panic!("expected Uni primary, got {:?}", list.nexthops[1]);
+        // The SPF primary takes the backup slot (at metric+offset).
+        let rib::NexthopMember::Uni(p) = &pro.backup else {
+            panic!("expected Uni SPF-primary, got {:?}", pro.backup);
         };
         assert_eq!(p.metric, 21);
         assert_eq!(p.addr, std::net::IpAddr::V4(primary_addr));
@@ -2253,12 +2258,11 @@ mod tests {
         };
         let entry = make_rib_entry::<V6>(&route, Level::L1);
 
-        let rib::Nexthop::List(list) = &entry.nexthop else {
-            panic!("expected List, got {:?}", entry.nexthop);
+        let rib::Nexthop::Protect(pro) = &entry.nexthop else {
+            panic!("expected Protect, got {:?}", entry.nexthop);
         };
-        assert_eq!(list.nexthops.len(), 2);
-        let rib::NexthopMember::Uni(b) = &list.nexthops[1] else {
-            panic!("expected Uni backup, got {:?}", list.nexthops[1]);
+        let rib::NexthopMember::Uni(b) = &pro.backup else {
+            panic!("expected Uni backup, got {:?}", pro.backup);
         };
         assert_eq!(b.metric, 21);
         assert_eq!(b.segs, vec![end_sid, endx_sid]);

--- a/zebra-rs/src/ospf/inst.rs
+++ b/zebra-rs/src/ospf/inst.rs
@@ -10662,7 +10662,7 @@ fn backup_v3_to_nexthop_uni(backup: &RepairPathMplsV3, metric: u32) -> rib::Next
 /// Build a `rib::entry::RibEntry` from a `SpfRouteV3`. Flattens the
 /// primaries and (when present) their TI-LFA repair backups into one
 /// Vec at distinct metrics; `build_rib_nexthop` groups by metric and
-/// dispatches Uni / Multi / List. Mirrors v2's `make_rib_entry`.
+/// dispatches Uni / Multi / Protect. Mirrors v2's `make_rib_entry`.
 fn make_rib6_entry(route: &SpfRouteV3) -> rib::entry::RibEntry {
     let offset_metric = route.metric.saturating_add(BACKUP_METRIC_OFFSET);
     let (primary_metric, backup_metric) = if route.backup_as_primary {
@@ -11190,7 +11190,7 @@ fn make_rib_entry(route: &SpfRoute) -> rib::entry::RibEntry {
 
     // Flatten primaries and (when present) their TI-LFA repair backups
     // into one Vec at distinct metrics; `build_rib_nexthop` groups by
-    // metric and dispatches Uni / Multi / List from there.
+    // metric and dispatches Uni / Multi / Protect from there.
     //
     // `backup_as_primary` flips the offset: when set, the repair
     // installs at route.metric (sorted first) and the SPF primary at
@@ -11225,11 +11225,15 @@ fn make_rib_entry(route: &SpfRoute) -> rib::entry::RibEntry {
 //   - 0 groups          -> Nexthop::default()
 //   - 1 group, 1 nhop   -> Nexthop::Uni
 //   - 1 group, N nhops  -> Nexthop::Multi (ECMP)
-//   - >1 groups         -> Nexthop::List, one member per metric.
+//   - 2 groups          -> Nexthop::Protect: the lower-metric group is
+//                          the primary, the offset group the TI-LFA
+//                          backup.
 //
 // Mirrors IS-IS's `build_rib_nexthop`. With TI-LFA off every nhop sits
 // at route.metric, so only the first three arms fire; a stamped backup
-// adds a second metric group and produces a List (primary then repair).
+// adds the second metric group. The caller only ever feeds two
+// distinct metrics, so >2 groups can't happen — the List fallback is
+// defensive.
 fn build_rib_nexthop(nhops: Vec<rib::NexthopUni>) -> rib::Nexthop {
     if nhops.is_empty() {
         return rib::Nexthop::default();
@@ -11250,7 +11254,7 @@ fn build_rib_nexthop(nhops: Vec<rib::NexthopUni>) -> rib::Nexthop {
             })
         }
     } else {
-        let members: Vec<_> = groups
+        let mut members: Vec<_> = groups
             .into_iter()
             .map(|(metric, mut grp)| {
                 if grp.len() == 1 {
@@ -11264,7 +11268,13 @@ fn build_rib_nexthop(nhops: Vec<rib::NexthopUni>) -> rib::Nexthop {
                 }
             })
             .collect();
-        rib::Nexthop::List(rib::NexthopList { nexthops: members })
+        if members.len() == 2 {
+            let backup = members.pop().unwrap();
+            let primary = members.pop().unwrap();
+            rib::Nexthop::Protect(rib::NexthopProtect { primary, backup })
+        } else {
+            rib::Nexthop::List(rib::NexthopList { nexthops: members })
+        }
     }
 }
 

--- a/zebra-rs/src/rib/entry.rs
+++ b/zebra-rs/src/rib/entry.rs
@@ -99,6 +99,9 @@ impl RibEntry {
             Nexthop::List(pro) => pro
                 .iter_unis()
                 .any(|nhop| nmap.get(nhop.gid).is_some_and(|group| group.is_valid())),
+            Nexthop::Protect(pro) => pro
+                .iter_unis()
+                .any(|nhop| nmap.get(nhop.gid).is_some_and(|group| group.is_valid())),
             _ => false,
         }
     }
@@ -115,15 +118,12 @@ impl RibEntry {
         }
         if let Nexthop::List(pro) = &mut self.nexthop {
             for member in pro.nexthops.iter_mut() {
-                match member {
-                    NexthopMember::Uni(uni) => uni_group_sync(uni, nmap, fib).await,
-                    NexthopMember::Multi(multi) => {
-                        for uni in multi.nexthops.iter_mut() {
-                            uni_group_sync(uni, nmap, fib).await;
-                        }
-                        multi_group_sync(multi, nmap, fib).await;
-                    }
-                }
+                member_group_sync(member, nmap, fib).await;
+            }
+        }
+        if let Nexthop::Protect(pro) = &mut self.nexthop {
+            for member in pro.members_mut() {
+                member_group_sync(member, nmap, fib).await;
             }
         }
     }
@@ -148,17 +148,31 @@ impl RibEntry {
             }
             Nexthop::List(pro) => {
                 for member in &pro.nexthops {
-                    match member {
-                        NexthopMember::Uni(uni) => {
-                            self.handle_nexthop_group(nmap, fib, uni.gid).await;
-                        }
-                        NexthopMember::Multi(multi) => {
-                            self.handle_nexthop_group(nmap, fib, multi.gid).await;
-                            for uni in &multi.nexthops {
-                                self.handle_nexthop_group(nmap, fib, uni.gid).await;
-                            }
-                        }
-                    }
+                    self.member_nexthop_unsync(member, nmap, fib).await;
+                }
+            }
+            Nexthop::Protect(pro) => {
+                for member in pro.members() {
+                    self.member_nexthop_unsync(member, nmap, fib).await;
+                }
+            }
+        }
+    }
+
+    async fn member_nexthop_unsync(
+        &self,
+        member: &NexthopMember,
+        nmap: &mut NexthopMap,
+        fib: &FibHandle,
+    ) {
+        match member {
+            NexthopMember::Uni(uni) => {
+                self.handle_nexthop_group(nmap, fib, uni.gid).await;
+            }
+            NexthopMember::Multi(multi) => {
+                self.handle_nexthop_group(nmap, fib, multi.gid).await;
+                for uni in &multi.nexthops {
+                    self.handle_nexthop_group(nmap, fib, uni.gid).await;
                 }
             }
         }
@@ -189,6 +203,18 @@ async fn uni_group_sync(uni: &NexthopUni, nmap: &mut NexthopMap, fib: &FibHandle
     }
     fib.nexthop_add(group).await;
     group.set_installed(true);
+}
+
+async fn member_group_sync(member: &mut NexthopMember, nmap: &mut NexthopMap, fib: &FibHandle) {
+    match member {
+        NexthopMember::Uni(uni) => uni_group_sync(uni, nmap, fib).await,
+        NexthopMember::Multi(multi) => {
+            for uni in multi.nexthops.iter_mut() {
+                uni_group_sync(uni, nmap, fib).await;
+            }
+            multi_group_sync(multi, nmap, fib).await;
+        }
+    }
 }
 
 async fn multi_group_sync(multi: &NexthopMulti, nmap: &mut NexthopMap, fib: &FibHandle) {

--- a/zebra-rs/src/rib/nexthop/disp.rs
+++ b/zebra-rs/src/rib/nexthop/disp.rs
@@ -1,6 +1,6 @@
 use std::fmt::{Display, Formatter, Result};
 
-use super::{Nexthop, NexthopList, NexthopMulti, NexthopUni};
+use super::{Nexthop, NexthopList, NexthopMulti, NexthopProtect, NexthopUni};
 
 impl Display for Nexthop {
     fn fmt(&self, f: &mut Formatter<'_>) -> Result {
@@ -15,6 +15,9 @@ impl Display for Nexthop {
                 write!(f, "{}", multi)
             }
             Nexthop::List(pro) => {
+                write!(f, "{}", pro)
+            }
+            Nexthop::Protect(pro) => {
                 write!(f, "{}", pro)
             }
         }
@@ -45,6 +48,12 @@ impl Display for NexthopMulti {
 }
 
 impl Display for NexthopList {
+    fn fmt(&self, f: &mut Formatter<'_>) -> Result {
+        write!(f, "protect")
+    }
+}
+
+impl Display for NexthopProtect {
     fn fmt(&self, f: &mut Formatter<'_>) -> Result {
         write!(f, "protect")
     }

--- a/zebra-rs/src/rib/nexthop/inst.rs
+++ b/zebra-rs/src/rib/nexthop/inst.rs
@@ -112,6 +112,7 @@ pub enum Nexthop {
     Uni(NexthopUni),
     Multi(NexthopMulti),
     List(NexthopList),
+    Protect(NexthopProtect),
 }
 
 impl Default for Nexthop {
@@ -125,11 +126,12 @@ pub struct NexthopList {
     pub nexthops: Vec<NexthopMember>,
 }
 
-// A path within a NexthopList. Uni is a single nexthop at one metric
-// (the only shape produced today, since every existing caller is the
-// inter-protocol merge that combines two single-nexthop entries at
-// different distances). Multi is an ECMP group at one shared metric —
-// the slot TI-LFA's "ECMP primary + per-primary repair" install fills.
+// A path within a NexthopList or NexthopProtect. Uni is a single
+// nexthop at one metric (NexthopList's only shape today, since its
+// remaining caller is the inter-protocol merge that combines two
+// single-nexthop entries at different distances). Multi is an ECMP
+// group at one shared metric — the slot TI-LFA's "ECMP primary +
+// per-primary repair" install fills via NexthopProtect.
 // `#[serde(untagged)]` so JSON output preserves the pre-refactor flat
 // shape: each member serializes as its inner type.
 #[derive(Debug, Clone, PartialEq, serde::Serialize)]
@@ -155,6 +157,67 @@ impl NexthopMember {
             Self::Uni(u) => Nexthop::Uni(u.clone()),
             Self::Multi(m) => Nexthop::Multi(m.clone()),
         }
+    }
+
+    /// Walk this member's `NexthopUni` leaves: a Uni yields itself,
+    /// a Multi yields each ECMP leg in turn.
+    pub fn iter_unis(&self) -> std::slice::Iter<'_, NexthopUni> {
+        match self {
+            Self::Uni(u) => std::slice::from_ref(u).iter(),
+            Self::Multi(m) => m.nexthops.iter(),
+        }
+    }
+
+    /// Mutable counterpart of `iter_unis`, used by the resolver.
+    pub fn iter_unis_mut(&mut self) -> std::slice::IterMut<'_, NexthopUni> {
+        match self {
+            Self::Uni(u) => std::slice::from_mut(u).iter_mut(),
+            Self::Multi(m) => m.nexthops.iter_mut(),
+        }
+    }
+}
+
+/// A primary path with its TI-LFA repair. Where `NexthopList` is an
+/// ordered set of paths at distinct metrics whose roles are inferred
+/// from sort position (member 0 = primary), the two roles here are
+/// explicit fields. Produced by the IS-IS / OSPF TI-LFA install; the
+/// backup goes into the kernel alongside the primary at a higher
+/// route metric and takes over when the primary's nexthop group is
+/// invalidated. Either member may be an ECMP group (`Multi`).
+#[derive(Debug, Clone, PartialEq, serde::Serialize)]
+pub struct NexthopProtect {
+    pub primary: NexthopMember,
+    pub backup: NexthopMember,
+}
+
+impl NexthopProtect {
+    /// Members in install order with their protection role, as
+    /// `(member, is_backup)`. Keeps the role decision in one place
+    /// for the show / JSON renderers.
+    pub fn roles(&self) -> [(&NexthopMember, bool); 2] {
+        [(&self.primary, false), (&self.backup, true)]
+    }
+
+    /// Members in install order, primary first.
+    pub fn members(&self) -> [&NexthopMember; 2] {
+        [&self.primary, &self.backup]
+    }
+
+    /// Mutable counterpart of `members`.
+    pub fn members_mut(&mut self) -> [&mut NexthopMember; 2] {
+        [&mut self.primary, &mut self.backup]
+    }
+
+    /// Walk every `NexthopUni` leaf, primary member first.
+    pub fn iter_unis(&self) -> impl Iterator<Item = &NexthopUni> + '_ {
+        self.primary.iter_unis().chain(self.backup.iter_unis())
+    }
+
+    /// Mutable counterpart of `iter_unis`, used by the resolver.
+    pub fn iter_unis_mut(&mut self) -> impl Iterator<Item = &mut NexthopUni> + '_ {
+        self.primary
+            .iter_unis_mut()
+            .chain(self.backup.iter_unis_mut())
     }
 }
 
@@ -251,6 +314,36 @@ mod tests {
         };
         let addrs: Vec<_> = list.iter_unis().map(|u| u.addr.to_string()).collect();
         assert_eq!(addrs, vec!["10.0.0.1", "10.0.0.5", "10.0.0.6"]);
+    }
+
+    #[test]
+    fn protect_iter_unis_walks_primary_then_backup() {
+        // ECMP primary + Uni backup: leaves come out primary-first so
+        // the resolver's "first valid uni wins" keeps preferring the
+        // primary, matching the sorted NexthopList behavior.
+        let multi = NexthopMulti {
+            metric: 20,
+            nexthops: vec![mk_uni("10.0.0.1", 20), mk_uni("10.0.0.2", 20)],
+            ..Default::default()
+        };
+        let pro = NexthopProtect {
+            primary: NexthopMember::Multi(multi),
+            backup: NexthopMember::Uni(mk_uni("10.0.0.5", 21)),
+        };
+        let addrs: Vec<_> = pro.iter_unis().map(|u| u.addr.to_string()).collect();
+        assert_eq!(addrs, vec!["10.0.0.1", "10.0.0.2", "10.0.0.5"]);
+    }
+
+    #[test]
+    fn protect_roles_tags_backup_member() {
+        let pro = NexthopProtect {
+            primary: NexthopMember::Uni(mk_uni("10.0.0.1", 20)),
+            backup: NexthopMember::Uni(mk_uni("10.0.0.5", 21)),
+        };
+        let roles: Vec<bool> = pro.roles().iter().map(|(_, b)| *b).collect();
+        assert_eq!(roles, vec![false, true]);
+        assert_eq!(pro.roles()[0].0, &pro.primary);
+        assert_eq!(pro.roles()[1].0, &pro.backup);
     }
 
     #[test]

--- a/zebra-rs/src/rib/nht.rs
+++ b/zebra-rs/src/rib/nht.rs
@@ -201,6 +201,7 @@ fn entry_unis(nexthop: &Nexthop) -> Vec<&NexthopUni> {
         Nexthop::Uni(u) => vec![u],
         Nexthop::Multi(m) => m.nexthops.iter().collect(),
         Nexthop::List(l) => l.iter_unis().collect(),
+        Nexthop::Protect(p) => p.iter_unis().collect(),
         _ => Vec::new(),
     }
 }

--- a/zebra-rs/src/rib/redist.rs
+++ b/zebra-rs/src/rib/redist.rs
@@ -222,6 +222,11 @@ fn first_v4_nexthop(nh: &Nexthop) -> Option<std::net::Ipv4Addr> {
                 })
             }
         }),
+        // Redistribute the protected (primary) path, never the repair.
+        Nexthop::Protect(p) => p.primary.iter_unis().next().and_then(|u| match u.addr {
+            std::net::IpAddr::V4(a) => Some(a),
+            _ => None,
+        }),
         Nexthop::Link(_) => None,
     }
 }
@@ -247,6 +252,11 @@ fn first_v6_nexthop(nh: &Nexthop) -> Option<std::net::Ipv6Addr> {
                     _ => None,
                 })
             }
+        }),
+        // Redistribute the protected (primary) path, never the repair.
+        Nexthop::Protect(p) => p.primary.iter_unis().next().and_then(|u| match u.addr {
+            std::net::IpAddr::V6(a) => Some(a),
+            _ => None,
         }),
         Nexthop::Link(_) => None,
     }

--- a/zebra-rs/src/rib/resolve.rs
+++ b/zebra-rs/src/rib/resolve.rs
@@ -65,6 +65,7 @@ fn entry_nexthop_ifindex(entry: &RibEntry) -> Option<u32> {
         Nexthop::Uni(uni) if uni.ifindex().is_some() => uni.ifindex(),
         Nexthop::Multi(multi) => first_ifindex(&multi.nexthops),
         Nexthop::List(list) => list.iter_unis().find_map(|u| u.ifindex()),
+        Nexthop::Protect(pro) => pro.iter_unis().find_map(|u| u.ifindex()),
         _ => None,
     }
 }
@@ -84,6 +85,11 @@ fn entry_nexthop_addr(entry: &RibEntry) -> Option<IpAddr> {
             .filter(|u| u.ifindex().is_none())
             .map(|u| u.addr),
         Nexthop::List(list) => list
+            .iter_unis()
+            .next()
+            .filter(|u| u.ifindex().is_none())
+            .map(|u| u.addr),
+        Nexthop::Protect(pro) => pro
             .iter_unis()
             .next()
             .filter(|u| u.ifindex().is_none())

--- a/zebra-rs/src/rib/route.rs
+++ b/zebra-rs/src/rib/route.rs
@@ -1363,18 +1363,27 @@ fn nexthop_force_reinstall(nexthop: &Nexthop, nmap: &mut NexthopMap) {
         }
         Nexthop::List(list) => {
             for member in &list.nexthops {
-                match member {
-                    NexthopMember::Uni(uni) => force(nmap, uni.gid),
-                    NexthopMember::Multi(multi) => {
-                        force(nmap, multi.gid);
-                        for uni in &multi.nexthops {
-                            force(nmap, uni.gid);
-                        }
-                    }
-                }
+                member_force_reinstall(member, nmap);
+            }
+        }
+        Nexthop::Protect(pro) => {
+            for member in pro.members() {
+                member_force_reinstall(member, nmap);
             }
         }
         _ => {}
+    }
+
+    fn member_force_reinstall(member: &NexthopMember, nmap: &mut NexthopMap) {
+        match member {
+            NexthopMember::Uni(uni) => force(nmap, uni.gid),
+            NexthopMember::Multi(multi) => {
+                force(nmap, multi.gid);
+                for uni in &multi.nexthops {
+                    force(nmap, uni.gid);
+                }
+            }
+        }
     }
 }
 
@@ -1419,6 +1428,24 @@ fn entry_resolve(entry: &mut RibEntry, nmap: &NexthopMap, _ifdown: bool) {
                 nexthop_uni_resolve(uni, nmap);
             }
             for uni in list.iter_unis() {
+                if uni.valid {
+                    entry.metric = uni.metric;
+                    entry.valid = uni.valid;
+                    return;
+                }
+            }
+            entry.metric = 0;
+            entry.valid = false;
+        }
+        // Primary first, then the repair — the first valid leaf wins,
+        // so the entry stays at the primary's metric while the
+        // primary's group is alive and falls back to the repair's
+        // when it is not.
+        Nexthop::Protect(pro) => {
+            for uni in pro.iter_unis_mut() {
+                nexthop_uni_resolve(uni, nmap);
+            }
+            for uni in pro.iter_unis() {
                 if uni.valid {
                     entry.metric = uni.metric;
                     entry.valid = uni.valid;
@@ -1512,25 +1539,40 @@ fn rib_resolve_nexthop(
         // `gid` at 0, which makes the FIB install fail with ENODEV
         // (Nhid(0)) at RTM_NEWROUTE time.
         for member in pro.nexthops.iter_mut() {
-            match member {
-                NexthopMember::Uni(uni) => {
-                    let _ = resolve_nexthop_uni(uni, nmap, table, table_id);
-                }
-                NexthopMember::Multi(multi) => {
-                    let mut set = BTreeSet::<(usize, u8)>::new();
-                    for uni in multi.nexthops.iter_mut() {
-                        let valid = resolve_nexthop_uni(uni, nmap, table, table_id);
-                        if valid {
-                            set.insert((uni.gid, uni.weight));
-                        }
-                    }
-                    resolve_nexthop_multi(multi, nmap, set);
-                }
-            }
+            resolve_nexthop_member(member, nmap, table, table_id);
+        }
+    }
+    if let Nexthop::Protect(pro) = &mut entry.nexthop {
+        // Same member-wise walk as List, for the same Nhid(0) reason.
+        for member in pro.members_mut() {
+            resolve_nexthop_member(member, nmap, table, table_id);
         }
     }
     // If one of nexthop is valid, the entry is valid.
     entry.set_valid(entry.is_valid_nexthop(nmap));
+}
+
+fn resolve_nexthop_member(
+    member: &mut NexthopMember,
+    nmap: &mut NexthopMap,
+    table: &PrefixMap<Ipv4Net, RibEntries>,
+    table_id: u32,
+) {
+    match member {
+        NexthopMember::Uni(uni) => {
+            let _ = resolve_nexthop_uni(uni, nmap, table, table_id);
+        }
+        NexthopMember::Multi(multi) => {
+            let mut set = BTreeSet::<(usize, u8)>::new();
+            for uni in multi.nexthops.iter_mut() {
+                let valid = resolve_nexthop_uni(uni, nmap, table, table_id);
+                if valid {
+                    set.insert((uni.gid, uni.weight));
+                }
+            }
+            resolve_nexthop_multi(multi, nmap, set);
+        }
+    }
 }
 
 fn rib_rtype(entries: &[RibEntry], rtype: RibType) -> Option<usize> {
@@ -1638,6 +1680,8 @@ fn rib_replace_system(
             // For connected routes, only replace if the interface index matches
             e.ifindex == entry.ifindex
         }
+        // System (kernel) routes are never primary+backup protected.
+        Nexthop::Protect(_) => false,
     };
     // println!("replace {}", replace);
     if replace {
@@ -1907,6 +1951,8 @@ fn rib_replace_system_v6(
             // For connected routes, only replace if the interface index matches
             e.ifindex == entry.ifindex
         }
+        // System (kernel) routes are never primary+backup protected.
+        Nexthop::Protect(_) => false,
     };
     if replace {
         return rib_replace_v6(table, prefix, entry.rtype);
@@ -2422,5 +2468,57 @@ mod tests {
         for leg in &multi_member.nexthops {
             assert!(leg.gid != 0, "each leg also gets a gid");
         }
+    }
+
+    /// `Nexthop::Protect` twin of the test above: the ECMP primary
+    /// member must get its kernel-side Multi group allocated, and the
+    /// Uni backup its own group, when the IGPs hand the RIB a
+    /// primary+repair pair.
+    #[test]
+    fn protect_with_nested_multi_resolves_multi_gid() {
+        use super::super::entry::RibEntry;
+        use super::super::nexthop::{NexthopProtect, NexthopUni};
+        use super::super::{Nexthop, NexthopMap, NexthopMember, NexthopMulti};
+        use super::super::{RibEntries, RibType};
+        use super::rib_resolve_nexthop;
+        use ipnet::Ipv4Net;
+        use prefix_trie::PrefixMap;
+
+        let leg_a = NexthopUni::new("10.0.0.1".parse().unwrap(), 1011, vec![]);
+        let leg_b = NexthopUni::new("10.0.0.2".parse().unwrap(), 1011, vec![]);
+        let multi = NexthopMulti {
+            metric: 1011,
+            nexthops: vec![leg_a, leg_b],
+            ..Default::default()
+        };
+        let backup = NexthopUni::new("10.0.0.3".parse().unwrap(), 1012, vec![]);
+
+        let mut entry = RibEntry::new(RibType::Isis);
+        entry.nexthop = Nexthop::Protect(NexthopProtect {
+            primary: NexthopMember::Multi(multi),
+            backup: NexthopMember::Uni(backup),
+        });
+
+        let mut nmap = NexthopMap::default();
+        let table: PrefixMap<Ipv4Net, RibEntries> = PrefixMap::new();
+        rib_resolve_nexthop(&mut entry, &table, &mut nmap, 0);
+
+        let Nexthop::Protect(pro) = &entry.nexthop else {
+            panic!("entry.nexthop should still be Protect");
+        };
+        let NexthopMember::Multi(multi_member) = &pro.primary else {
+            panic!("primary Multi preserved");
+        };
+        assert!(
+            multi_member.gid != 0,
+            "primary Multi must get a kernel-side group allocated (gid != 0)"
+        );
+        for leg in &multi_member.nexthops {
+            assert!(leg.gid != 0, "each leg also gets a gid");
+        }
+        let NexthopMember::Uni(backup_uni) = &pro.backup else {
+            panic!("backup Uni preserved");
+        };
+        assert!(backup_uni.gid != 0, "backup Uni gets its own group");
     }
 }

--- a/zebra-rs/src/rib/show.rs
+++ b/zebra-rs/src/rib/show.rs
@@ -4,7 +4,10 @@ use serde_json::Value;
 
 use crate::{
     config::{Args, Builder},
-    rib::{Label, Nexthop, nexthop::NexthopList, nexthop::NexthopMember, nexthop::NexthopUni},
+    rib::{
+        Label, Nexthop,
+        nexthop::{NexthopList, NexthopMember, NexthopProtect, NexthopUni},
+    },
 };
 
 use super::{
@@ -106,11 +109,11 @@ pub struct NexthopJson {
     pub weight: Option<u8>,
     pub metric: Option<u32>,
     pub mpls_labels: Vec<Value>,
-    /// True when this nexthop is a backup entry inside a
-    /// `Nexthop::List`: anything in the list beyond the first
-    /// member (the primary at the lowest metric) is a TI-LFA-style
-    /// repair path. Omitted from JSON when false so non-FRR routes
-    /// keep their pre-flag schema.
+    /// True when this nexthop is a repair path: the `backup` member
+    /// of a `Nexthop::Protect`, or anything beyond the first member
+    /// (the primary at the lowest metric) in a `Nexthop::List`.
+    /// Omitted from JSON when false so non-FRR routes keep their
+    /// pre-flag schema.
     #[serde(skip_serializing_if = "std::ops::Not::not")]
     pub backup: bool,
 }
@@ -198,30 +201,18 @@ fn rib_entry_to_json(rib: &Rib, prefix: &Ipv4Net, e: &RibEntry) -> RouteEntry {
             .enumerate()
             .flat_map(|(idx, member)| {
                 let is_backup = idx > 0;
-                let unis: Vec<&NexthopUni> = match member {
-                    NexthopMember::Uni(u) => vec![u],
-                    NexthopMember::Multi(m) => m.nexthops.iter().collect(),
-                };
-                unis.into_iter().map(move |uni| NexthopJson {
-                    address: Some(uni.addr.to_string()),
-                    interface: rib.link_name(uni.ifindex().unwrap_or(0)),
-                    weight: Some(uni.weight),
-                    metric: Some(uni.metric),
-                    mpls_labels: uni
-                        .mpls
-                        .iter()
-                        .map(|label| match label {
-                            Label::Implicit(l) => serde_json::json!({
-                                "label": l,
-                                "label_type": "implicit"
-                            }),
-                            Label::Explicit(l) => serde_json::json!({
-                                "label": l
-                            }),
-                        })
-                        .collect(),
-                    backup: is_backup,
-                })
+                member
+                    .iter_unis()
+                    .map(move |uni| nexthop_uni_to_json(rib, uni, is_backup))
+            })
+            .collect(),
+        Nexthop::Protect(pro) => pro
+            .roles()
+            .into_iter()
+            .flat_map(|(member, is_backup)| {
+                member
+                    .iter_unis()
+                    .map(move |uni| nexthop_uni_to_json(rib, uni, is_backup))
             })
             .collect(),
     };
@@ -243,6 +234,32 @@ fn rib_entry_to_json(rib: &Rib, prefix: &Ipv4Net, e: &RibEntry) -> RouteEntry {
         metric: e.metric,
         nexthops,
         interface_name,
+    }
+}
+
+/// One `NexthopUni` leaf as JSON, with its protection role. Shared by
+/// the `Nexthop::List` and `Nexthop::Protect` arms of the IPv4 / IPv6
+/// JSON converters.
+fn nexthop_uni_to_json(rib: &Rib, uni: &NexthopUni, is_backup: bool) -> NexthopJson {
+    NexthopJson {
+        address: Some(uni.addr.to_string()),
+        interface: rib.link_name(uni.ifindex().unwrap_or(0)),
+        weight: Some(uni.weight),
+        metric: Some(uni.metric),
+        mpls_labels: uni
+            .mpls
+            .iter()
+            .map(|label| match label {
+                Label::Implicit(l) => serde_json::json!({
+                    "label": l,
+                    "label_type": "implicit"
+                }),
+                Label::Explicit(l) => serde_json::json!({
+                    "label": l
+                }),
+            })
+            .collect(),
+        backup: is_backup,
     }
 }
 
@@ -324,30 +341,18 @@ fn rib_entry_to_json_v6(rib: &Rib, prefix: &Ipv6Net, e: &RibEntry) -> RouteEntry
             .enumerate()
             .flat_map(|(idx, member)| {
                 let is_backup = idx > 0;
-                let unis: Vec<&NexthopUni> = match member {
-                    NexthopMember::Uni(u) => vec![u],
-                    NexthopMember::Multi(m) => m.nexthops.iter().collect(),
-                };
-                unis.into_iter().map(move |uni| NexthopJson {
-                    address: Some(uni.addr.to_string()),
-                    interface: rib.link_name(uni.ifindex().unwrap_or(0)),
-                    weight: Some(uni.weight),
-                    metric: Some(uni.metric),
-                    mpls_labels: uni
-                        .mpls
-                        .iter()
-                        .map(|label| match label {
-                            Label::Implicit(l) => serde_json::json!({
-                                "label": l,
-                                "label_type": "implicit"
-                            }),
-                            Label::Explicit(l) => serde_json::json!({
-                                "label": l
-                            }),
-                        })
-                        .collect(),
-                    backup: is_backup,
-                })
+                member
+                    .iter_unis()
+                    .map(move |uni| nexthop_uni_to_json(rib, uni, is_backup))
+            })
+            .collect(),
+        Nexthop::Protect(pro) => pro
+            .roles()
+            .into_iter()
+            .flat_map(|(member, is_backup)| {
+                member
+                    .iter_unis()
+                    .map(move |uni| nexthop_uni_to_json(rib, uni, is_backup))
             })
             .collect(),
     };
@@ -396,10 +401,10 @@ pub fn rib_entry_show(
     write!(buf, "{} {}", e.selected(), prefix)?;
     let bracket_col = buf.len() + 1;
 
-    // `Nexthop::List` prints a per-path bracket in its own arm (each
-    // repair path can carry a different metric), so skip the shared
-    // route-level bracket for it.
-    if !e.is_connected() && !matches!(e.nexthop, Nexthop::List(_)) {
+    // `Nexthop::List` / `Nexthop::Protect` print a per-path bracket in
+    // their own arm (each repair path can carry a different metric),
+    // so skip the shared route-level bracket for them.
+    if !e.is_connected() && !matches!(e.nexthop, Nexthop::List(_) | Nexthop::Protect(_)) {
         write!(buf, " [{}/{}]", &e.distance, &e.metric).unwrap();
     }
 
@@ -461,6 +466,9 @@ pub fn rib_entry_show(
             Nexthop::List(pro) => {
                 write_nexthop_list(&mut buf, rib, e, pro, marker_col, bracket_col, &uptime);
             }
+            Nexthop::Protect(pro) => {
+                write_nexthop_protect(&mut buf, rib, e, pro, marker_col, bracket_col, &uptime);
+            }
         }
     }
     Ok(buf)
@@ -483,10 +491,10 @@ pub fn rib_entry_show_v6(
     write!(buf, "{} {}", e.selected(), prefix)?;
     let bracket_col = buf.len() + 1;
 
-    // `Nexthop::List` prints a per-path bracket in its own arm (each
-    // repair path can carry a different metric), so skip the shared
-    // route-level bracket for it.
-    if !e.is_connected() && !matches!(e.nexthop, Nexthop::List(_)) {
+    // `Nexthop::List` / `Nexthop::Protect` print a per-path bracket in
+    // their own arm (each repair path can carry a different metric),
+    // so skip the shared route-level bracket for them.
+    if !e.is_connected() && !matches!(e.nexthop, Nexthop::List(_) | Nexthop::Protect(_)) {
         write!(buf, " [{}/{}]", &e.distance, &e.metric).unwrap();
     }
 
@@ -570,19 +578,16 @@ pub fn rib_entry_show_v6(
             Nexthop::List(pro) => {
                 write_nexthop_list(&mut buf, rib, e, pro, marker_col, bracket_col, &uptime);
             }
+            Nexthop::Protect(pro) => {
+                write_nexthop_protect(&mut buf, rib, e, pro, marker_col, bracket_col, &uptime);
+            }
         }
     }
     Ok(buf)
 }
 
 /// Render the `Nexthop::List` arm shared by the IPv4 and IPv6 one-line
-/// route views. Each path prints on its own line carrying its own
-/// `[distance/metric]` bracket — the metric is per-nexthop, so a TI-LFA
-/// repair path can advertise a higher cost than the primary. Backup
-/// paths (every member past the first) drop the FIB `*>` marker for a
-/// `?` repair marker in the same column, e.g.:
-///   L2 *> 10.0.0.0/24 [0/100] via 10.211.55.1, enp0s5, 00:04:15
-///      *?             [0/1002] via 10.211.55.1, enp0s5, 00:04:15
+/// route views: every member past the first is a backup.
 fn write_nexthop_list(
     buf: &mut String,
     rib: &Rib,
@@ -592,17 +597,52 @@ fn write_nexthop_list(
     bracket_col: usize,
     uptime: &str,
 ) {
+    let members: Vec<(&NexthopMember, bool)> = pro
+        .nexthops
+        .iter()
+        .enumerate()
+        .map(|(idx, m)| (m, idx > 0))
+        .collect();
+    write_protected_paths(buf, rib, e, &members, marker_col, bracket_col, uptime);
+}
+
+/// `Nexthop::Protect` sibling: the roles come off the struct's fields
+/// instead of the sort position.
+fn write_nexthop_protect(
+    buf: &mut String,
+    rib: &Rib,
+    e: &RibEntry,
+    pro: &NexthopProtect,
+    marker_col: usize,
+    bracket_col: usize,
+    uptime: &str,
+) {
+    write_protected_paths(buf, rib, e, &pro.roles(), marker_col, bracket_col, uptime);
+}
+
+/// Render a primary-plus-repair path set in the one-line route views.
+/// Each path prints on its own line carrying its own
+/// `[distance/metric]` bracket — the metric is per-nexthop, so a TI-LFA
+/// repair path can advertise a higher cost than the primary. Backup
+/// paths drop the FIB `*>` marker for a `?` repair marker in the same
+/// column, e.g.:
+///   L2 *> 10.0.0.0/24 [0/100] via 10.211.55.1, enp0s5, 00:04:15
+///      *?             [0/1002] via 10.211.55.1, enp0s5, 00:04:15
+fn write_protected_paths(
+    buf: &mut String,
+    rib: &Rib,
+    e: &RibEntry,
+    members: &[(&NexthopMember, bool)],
+    marker_col: usize,
+    bracket_col: usize,
+    uptime: &str,
+) {
     // Backups keep the route's FIB state in the marker column and add a
     // `?` to flag the repair path: `*? ` (FIB) or ` ? ` (not).
     let backup_marker = if e.fib { "*? " } else { " ? " };
     let mut row = 0;
-    for (member_idx, member) in pro.nexthops.iter().enumerate() {
-        let is_backup = member_idx > 0;
-        let unis: Vec<&NexthopUni> = match member {
-            NexthopMember::Uni(u) => vec![u],
-            NexthopMember::Multi(m) => m.nexthops.iter().collect(),
-        };
-        for uni in unis {
+    for (member, is_backup) in members {
+        for uni in member.iter_unis() {
             if row == 0 {
                 // First path shares the line already carrying the tag,
                 // FIB marker and prefix; just append its bracket.
@@ -610,8 +650,8 @@ fn write_nexthop_list(
             } else {
                 // Continuation path: rebuild the marker and bracket
                 // columns so each line shows its own [distance/metric]
-                // aligned under the first, with backups marked by `>>`.
-                let marker = if is_backup { backup_marker } else { "" };
+                // aligned under the first, with backups marked by `?`.
+                let marker = if *is_backup { backup_marker } else { "" };
                 buf.push_str(&list_continuation_prefix(
                     marker_col,
                     bracket_col,
@@ -702,10 +742,16 @@ fn fmt_srv6_segs(segs: &[std::net::Ipv6Addr]) -> String {
 /// offset convention. Plain `Nexthop::Uni` / `Multi` callers always
 /// pass index 0.
 fn fmt_protection_role(idx: usize) -> &'static str {
-    if idx == 0 {
-        "Protected"
-    } else {
+    protection_role(idx > 0)
+}
+
+/// Protection role from an explicit backup flag — the `Nexthop::
+/// Protect` form, where the role is a field rather than a position.
+fn protection_role(is_backup: bool) -> &'static str {
+    if is_backup {
         "Backup (TI-LFA)"
+    } else {
+        "Protected"
     }
 }
 
@@ -759,6 +805,7 @@ fn entry_has_mpls(e: &RibEntry) -> bool {
             NexthopMember::Uni(u) => uni_has(u),
             NexthopMember::Multi(mm) => mm.nexthops.iter().any(uni_has),
         }),
+        Nexthop::Protect(p) => p.iter_unis().any(uni_has),
         Nexthop::Link(_) => false,
     }
 }
@@ -776,6 +823,7 @@ fn entry_has_srv6(e: &RibEntry) -> bool {
             NexthopMember::Uni(u) => uni_has(u),
             NexthopMember::Multi(mm) => mm.nexthops.iter().any(uni_has),
         }),
+        Nexthop::Protect(p) => p.iter_unis().any(uni_has),
         Nexthop::Link(_) => false,
     }
 }
@@ -857,13 +905,16 @@ fn write_nexthop_blocks_v4(buf: &mut String, rib: &Rib, nh: &Nexthop) {
         Nexthop::List(list) => {
             for (idx, member) in list.nexthops.iter().enumerate() {
                 let role = fmt_protection_role(idx);
-                match member {
-                    NexthopMember::Uni(u) => write_descriptor_block_v4(buf, rib, u, role),
-                    NexthopMember::Multi(m) => {
-                        for u in m.nexthops.iter() {
-                            write_descriptor_block_v4(buf, rib, u, role);
-                        }
-                    }
+                for u in member.iter_unis() {
+                    write_descriptor_block_v4(buf, rib, u, role);
+                }
+            }
+        }
+        Nexthop::Protect(pro) => {
+            for (member, is_backup) in pro.roles() {
+                let role = protection_role(is_backup);
+                for u in member.iter_unis() {
+                    write_descriptor_block_v4(buf, rib, u, role);
                 }
             }
         }
@@ -884,13 +935,16 @@ fn write_nexthop_blocks_v6(buf: &mut String, rib: &Rib, nh: &Nexthop) {
         Nexthop::List(list) => {
             for (idx, member) in list.nexthops.iter().enumerate() {
                 let role = fmt_protection_role(idx);
-                match member {
-                    NexthopMember::Uni(u) => write_descriptor_block_v6(buf, rib, u, role),
-                    NexthopMember::Multi(m) => {
-                        for u in m.nexthops.iter() {
-                            write_descriptor_block_v6(buf, rib, u, role);
-                        }
-                    }
+                for u in member.iter_unis() {
+                    write_descriptor_block_v6(buf, rib, u, role);
+                }
+            }
+        }
+        Nexthop::Protect(pro) => {
+            for (member, is_backup) in pro.roles() {
+                let role = protection_role(is_backup);
+                for u in member.iter_unis() {
+                    write_descriptor_block_v6(buf, rib, u, role);
                 }
             }
         }


### PR DESCRIPTION
## Summary

Adds a new `Nexthop::Protect(NexthopProtect)` variant next to `NexthopList`:

```rust
pub struct NexthopProtect {
    pub primary: NexthopMember,
    pub backup: NexthopMember,
}
```

The primary/backup roles are explicit fields instead of being inferred from metric-sort position. `NexthopList` is kept as is for its remaining caller, the inter-protocol (kernel/system) metric merge.

## Producer switch

IS-IS and OSPF (v2 + v3) `build_rib_nexthop` now emit `Protect` for the two-metric-group TI-LFA case:

- primary at `route.metric`, repair at `metric + BACKUP_METRIC_OFFSET`
- under `backup-as-primary` the repair takes the `primary` slot (lower metric), preserving the existing promotion behavior
- ECMP primary + ECMP repair becomes a Protect of two `Multi` members
- the `>2 groups` List fallback is kept but unreachable (producers only ever feed two metrics)

## Consumer plumbing

Protect arms with the same semantics as the List ones:

- `rib/entry.rs` — group sync/unsync, `is_valid_nexthop`
- `rib/route.rs` — resolver (member-wise walk so the nested `Multi` gets its kernel group, avoiding `Nhid(0)`/ENODEV), force-reinstall, system-merge declines Protect
- `rib/resolve.rs`, `rib/nht.rs` — recursive resolution targets and NHT flattening
- `rib/redist.rs` — redistribute the protected (primary) path, never the repair
- `fib/netlink/handle.rs` — install/delete each member at its own metric (kernel state identical to the List form), trace formatter
- `rib/show.rs` — one-line (`*?` repair marker), JSON (`backup` flag), and descriptor-block (`Protected` / `Backup (TI-LFA)`) renderers; List and Protect share `write_protected_paths`

Show output and kernel FIB contents are unchanged from the List-based install.

## Testing

- `cargo test --workspace --exclude bdd` — all green (1115 in zebra-rs)
- ported the IS-IS make_rib_entry/build_rib_nexthop tests to the Protect shape, including the backup-as-primary swap and SRv6 backup
- added a Protect twin of the nested-Multi gid-resolution regression test
- `cargo fmt` + `cargo clippy --workspace --all-targets -- -D warnings` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)