### PR TITLE
ospfv3: SRv6 End.X SIDs per Full adjacency with global nexthops

### DIFF
--- a/bdd/tests/features/ospfv3_srv6.feature
+++ b/bdd/tests/features/ospfv3_srv6.feature
@@ -63,6 +63,29 @@ Feature: OSPFv3 SRv6 locator origination (RFC 9513)
     And kernel route "fcbb:bbbb:1::/48" in namespace "z1" should eventually contain "seg6local"
     And kernel route "2001:db8:f:2::" in namespace "z2" should eventually contain "seg6local"
 
+  Scenario: Each Full adjacency carves an End.X SID with a global nexthop
+    Given the test topology exists
+    # z1's uSID locator carves a uA for the adjacency plus its LIB
+    # twin (the block:function entry a NEXT-C-SID carrier hits after
+    # the uN shift); z2's classic locator carves a plain End.X.
+    Then show command "show segment-routing srv6 sid" in namespace "z1" should contain "uA"
+    And show command "show segment-routing srv6 sid" in namespace "z1" should contain "uA(LIB)"
+    And show command "show segment-routing srv6 sid" in namespace "z2" should contain "End.X"
+    # The End.X SID is advertised on the Router-Link TLV of the
+    # per-link E-Router-LSA and floods to the peer.
+    And show command "show ospfv3 database detail" in namespace "z2" should contain "SRv6 End.X SID Sub-TLV:"
+    And show command "show ospfv3 database detail" in namespace "z1" should contain "SRv6 End.X SID Sub-TLV:"
+    # The kernel entries forward to the NEIGHBOR'S GLOBAL address —
+    # learned from its Link-LSA LA-bit /128, upgraded from the
+    # hello link-local once that LSA arrives. Linux's seg6local
+    # End.X resolves nh6 by the packet's ingress interface, so a
+    # link-local nexthop would blackhole (the #1361 lesson).
+    And kernel route "fcbb:bbbb:1:e000::" in namespace "z1" should eventually contain "nh6 2001:db8:12::2"
+    And kernel route "2001:db8:f:2:e000::" in namespace "z2" should eventually contain "nh6 2001:db8:12::1"
+    # The uSID LIB twin installs as a block:function prefix with the
+    # NEXT-CSID flavor.
+    And kernel route "fcbb:bbbb:e000::/48" in namespace "z1" should eventually contain "flavors next-csid"
+
   Scenario: Removing the locator flushes the LSA and withdraws the SID
     Given the test topology exists
     When I apply command "delete router ospfv3 segment-routing srv6 locator LOC1" in namespace "z1"
@@ -70,7 +93,9 @@ Feature: OSPFv3 SRv6 locator origination (RFC 9513)
     # z1 stops originating: its registry row and kernel route go, and
     # the flushed LSA disappears from the peer too (MaxAge flood).
     Then show command "show segment-routing srv6 sid" in namespace "z1" should not contain "uN"
+    And show command "show segment-routing srv6 sid" in namespace "z1" should not contain "uA"
     And kernel route "fcbb:bbbb:1::/48" in namespace "z1" should eventually be gone
+    And kernel route "fcbb:bbbb:1:e000::" in namespace "z1" should eventually be gone
     And show command "show ospfv3 database detail" in namespace "z2" should not contain "SRv6 Locator TLV: fcbb:bbbb:1::/48"
     # z2's own origination is untouched.
     And show command "show ospfv3 database detail" in namespace "z2" should contain "SRv6 Locator TLV: 2001:db8:f:2::/64"

--- a/zebra-rs/src/ospf/inst.rs
+++ b/zebra-rs/src/ospf/inst.rs
@@ -1,5 +1,5 @@
 use std::collections::{BTreeMap, BTreeSet, HashMap};
-use std::net::Ipv4Addr;
+use std::net::{Ipv4Addr, Ipv6Addr};
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
@@ -209,6 +209,13 @@ pub struct Ospf<V: OspfVersion = Ospfv2> {
     pub watched_locator: Option<String>,
     pub sr_locator: Option<crate::rib::Locator>,
     pub sr_end_sid: Option<std::net::Ipv6Addr>,
+    /// ELIB function pool for End.X allocation — shared allocator
+    /// implementation with IS-IS (RFC 9352 reserves the same upper
+    /// half of the 16-bit function space).
+    pub elib: crate::isis::srv6::ElibPool,
+    /// Per-adjacency End.X SIDs, keyed like `lan_adj_sids` by
+    /// `(ifindex, neighbor router-id)`.
+    pub endx_sids: BTreeMap<(u32, Ipv4Addr), super::srv6::EndxSidState>,
     /// SR snapshot channel from the RIB (`SrSubscribe`); only the v3
     /// event loop polls it.
     pub sr_rx: UnboundedReceiver<crate::rib::RibSrRx>,
@@ -1046,6 +1053,8 @@ impl Ospf<Ospfv2> {
             watched_locator: None,
             sr_locator: None,
             sr_end_sid: None,
+            elib: crate::isis::srv6::ElibPool::new(),
+            endx_sids: BTreeMap::new(),
             sr_rx,
             gr_config: super::neigh::GracefulRestartConfig::default(),
             restarting: None,
@@ -5051,6 +5060,8 @@ impl Ospf<Ospfv3> {
             watched_locator: None,
             sr_locator: None,
             sr_end_sid: None,
+            elib: crate::isis::srv6::ElibPool::new(),
+            endx_sids: BTreeMap::new(),
             sr_rx,
             gr_config: super::neigh::GracefulRestartConfig::default(),
             restarting: None,
@@ -5518,7 +5529,7 @@ impl Ospf<Ospfv3> {
         // address octets truncated to `ceil(prefix_len / 8)`,
         // then padded to a 32-bit boundary by
         // `ospfv3_prefix_wire_len`.
-        let prefixes: Vec<Ospfv3LinkLsaPrefix> = link
+        let mut prefixes: Vec<Ospfv3LinkLsaPrefix> = link
             .addr
             .iter()
             .filter(|a| a.prefix.addr().segments()[0] != 0xfe80)
@@ -5537,6 +5548,29 @@ impl Ospf<Ospfv3> {
                 }
             })
             .collect();
+
+        // RFC 5340 §4.4.3.8 LA-bit: additionally advertise each global
+        // interface address as a /128 host prefix. Peers use it as the
+        // SRv6 End.X nexthop — Linux's seg6local End.X cannot resolve
+        // a link-local nexthop correctly (it re-looks nh6 up with the
+        // packet's ingress iif, PR #1361), so the global is the only
+        // reliable kernel programming and OSPFv3 has no other channel
+        // that carries neighbor global addresses.
+        prefixes.extend(
+            link.addr
+                .iter()
+                .map(|a| a.prefix.addr())
+                .filter(|a| a.segments()[0] != 0xfe80)
+                .map(|addr| {
+                    let mut options = Ospfv3PrefixOptions::default();
+                    options.set_la(true);
+                    Ospfv3LinkLsaPrefix {
+                        prefix_length: 128,
+                        prefix_options: options,
+                        address_prefix: addr.octets().to_vec(),
+                    }
+                }),
+        );
 
         let body = Ospfv3LinkLsa {
             priority: link.priority(),
@@ -6849,6 +6883,26 @@ impl Ospf<Ospfv3> {
             Message::Retransmit(ifindex, router_id) => {
                 self.process_retransmit(ifindex, router_id);
             }
+            Message::Srv6EndxReconcile(ifindex) => {
+                // A Link-LSA landed on this interface — the neighbor's
+                // global /128 may have just become available. Sweep
+                // the link's Full neighbors so any installed End.X
+                // drifts its nexthop to the global.
+                let rids: Vec<Ipv4Addr> = self
+                    .links
+                    .get(&ifindex)
+                    .map(|l| {
+                        l.nbrs
+                            .values()
+                            .filter(|n| n.state == NfsmState::Full)
+                            .map(|n| n.ident.router_id)
+                            .collect()
+                    })
+                    .unwrap_or_default();
+                for rid in rids {
+                    self.reconcile_endx_sid(ifindex, rid);
+                }
+            }
             Message::DdRetransmit(ifindex, router_id) => {
                 self.process_dd_retransmit(ifindex, router_id);
             }
@@ -7326,7 +7380,8 @@ impl Ospf<Ospfv3> {
         // Build the (area, link_type, metric, my_iid, peer_iid,
         // peer_rid, subs) tuple if origination is warranted, else
         // fall through to the flush path.
-        let build_inputs = if self.segment_routing == SegmentRoutingMode::Mpls
+        let srv6 = self.srv6_active();
+        let build_inputs = if (self.segment_routing == SegmentRoutingMode::Mpls || srv6)
             && let Some(link) = self.links.get(&ifindex)
             && link.enabled
             && link.nbrs.values().any(|n| n.state == NfsmState::Full)
@@ -7345,18 +7400,30 @@ impl Ospf<Ospfv3> {
                 OspfNetworkType::PointToPoint => {
                     if let Some(nbr) = link.nbrs.values().find(|n| n.state == NfsmState::Full) {
                         let mut subs = Vec::new();
-                        if let Some(adjacency_sid) = link.config.adjacency_sid {
-                            subs.push(super::srmpls::build_v3_p2p_adj_sub(&adjacency_sid));
-                        } else if let Some(label) =
-                            self.lan_adj_sids.get(&(ifindex, nbr.ident.router_id))
-                        {
-                            // No configured Adj-SID: advertise the SRLB
-                            // label allocated on the Full transition as
-                            // a local (V|L) Adj-SID — IS-IS-parity
-                            // dynamic allocation, no config needed.
-                            subs.push(super::srmpls::build_v3_p2p_adj_sub(
-                                &super::link::AdjacencySid::Absolute(*label),
-                            ));
+                        if self.segment_routing == SegmentRoutingMode::Mpls {
+                            if let Some(adjacency_sid) = link.config.adjacency_sid {
+                                subs.push(super::srmpls::build_v3_p2p_adj_sub(&adjacency_sid));
+                            } else if let Some(label) =
+                                self.lan_adj_sids.get(&(ifindex, nbr.ident.router_id))
+                            {
+                                // No configured Adj-SID: advertise the SRLB
+                                // label allocated on the Full transition as
+                                // a local (V|L) Adj-SID — IS-IS-parity
+                                // dynamic allocation, no config needed.
+                                subs.push(super::srmpls::build_v3_p2p_adj_sub(
+                                    &super::link::AdjacencySid::Absolute(*label),
+                                ));
+                            }
+                        }
+                        // RFC 9513 §9.1: the SRv6 End.X SID for this
+                        // adjacency, carved from the locator on the
+                        // Full transition.
+                        if let (true, Some(locator), Some(endx)) = (
+                            srv6,
+                            self.sr_locator.as_ref(),
+                            self.endx_sids.get(&(ifindex, nbr.ident.router_id)),
+                        ) {
+                            subs.push(super::srv6::build_v3_endx_sub(locator, endx.addr));
                         }
                         if let Some(a) = asla.clone() {
                             subs.push(a);
@@ -7408,19 +7475,40 @@ impl Ospf<Ospfv3> {
                         // used to index `link.nbrs`), not the v6
                         // interface address — RFC 5340 keys v3
                         // neighbor state machines by router-id.
-                        let mut subs: Vec<_> = link
-                            .nbrs
-                            .values()
-                            .filter(|n| n.state == NfsmState::Full)
-                            .filter_map(|nbr| {
-                                let label =
-                                    *self.lan_adj_sids.get(&(ifindex, nbr.ident.router_id))?;
-                                Some(super::srmpls::build_v3_lan_adj_sub(
-                                    nbr.ident.router_id,
-                                    label,
-                                ))
-                            })
-                            .collect();
+                        let mut subs: Vec<_> = if self.segment_routing == SegmentRoutingMode::Mpls {
+                            link.nbrs
+                                .values()
+                                .filter(|n| n.state == NfsmState::Full)
+                                .filter_map(|nbr| {
+                                    let label =
+                                        *self.lan_adj_sids.get(&(ifindex, nbr.ident.router_id))?;
+                                    Some(super::srmpls::build_v3_lan_adj_sub(
+                                        nbr.ident.router_id,
+                                        label,
+                                    ))
+                                })
+                                .collect()
+                        } else {
+                            Vec::new()
+                        };
+                        // RFC 9513 §9.2: one LAN End.X SID per Full
+                        // neighbor on the segment.
+                        if srv6 && let Some(locator) = self.sr_locator.as_ref() {
+                            subs.extend(
+                                link.nbrs
+                                    .values()
+                                    .filter(|n| n.state == NfsmState::Full)
+                                    .filter_map(|nbr| {
+                                        let endx =
+                                            self.endx_sids.get(&(ifindex, nbr.ident.router_id))?;
+                                        Some(super::srv6::build_v3_lan_endx_sub(
+                                            locator,
+                                            nbr.ident.router_id,
+                                            endx.addr,
+                                        ))
+                                    }),
+                            );
+                        }
                         if let Some(a) = asla.clone() {
                             subs.push(a);
                         }
@@ -7570,6 +7658,7 @@ impl Ospf<Ospfv3> {
             });
             self.sr_locator = None;
             self.update_srv6_end_sid();
+            self.clear_all_endx_sids();
         }
         if let Some(next) = desired {
             let _ = self.ctx.rib.send(rib::Message::SrLocatorWatch {
@@ -7592,6 +7681,14 @@ impl Ospf<Ospfv3> {
                 }
                 self.sr_locator = locator;
                 self.update_srv6_end_sid();
+                // Locator snapshot churned: every End.X address
+                // computed against the previous prefix is stale. Drop
+                // them all, then sweep current Full neighbors so they
+                // re-allocate from the fresh pool (the sweep also
+                // covers adjacencies that reached Full before the
+                // locator resolved).
+                self.clear_all_endx_sids();
+                self.sweep_endx_sids();
                 self.srv6_originate_all_areas();
             }
             // OSPF's SRGB / SRLB are fixed constants today; no block
@@ -7693,6 +7790,235 @@ impl Ospf<Ospfv3> {
             if let Some(lsa) = flushed {
                 self.flood_self_originated_lsa(area_id, &lsa);
             }
+        }
+    }
+
+    /// The neighbor's global IPv6 address on `ifindex`, learned from
+    /// the LA-bit /128 prefixes in its Link-LSA. Falls back to `None`
+    /// when the Link-LSA hasn't arrived (or carries no global) — the
+    /// caller then uses the hello-source link-local, and the
+    /// Link-LSA-arrival reconcile upgrades the install later.
+    ///
+    /// The preference is the same Linux kernel constraint as IS-IS
+    /// (PR #1361): seg6local End.X resolves nh6 with iif = the
+    /// packet's ingress interface, so a link-local nexthop matches
+    /// fe80::/64 on the wrong link and blackholes.
+    fn neighbor_global_nh6(&self, ifindex: u32, nbr_router_id: Ipv4Addr) -> Option<Ipv6Addr> {
+        use ospf_packet::{OSPFV3_LINK_LSA_TYPE, Ospfv3LsBody};
+        let link = self.links.get(&ifindex)?;
+        let nbr = link.nbrs.get(&nbr_router_id)?;
+        let key: super::lsdb::OspfLsaKey = (OSPFV3_LINK_LSA_TYPE, nbr.interface_id, nbr_router_id);
+        let lsa = link.lsdb.lookup_by_raw_key(key)?;
+        let Ospfv3LsBody::Link(body) = &lsa.body else {
+            return None;
+        };
+        body.prefixes.iter().find_map(|p| {
+            if !p.prefix_options.la() || p.prefix_length != 128 || p.address_prefix.len() < 16 {
+                return None;
+            }
+            let mut octets = [0u8; 16];
+            octets.copy_from_slice(&p.address_prefix[..16]);
+            let addr = Ipv6Addr::from(octets);
+            (addr.segments()[0] != 0xfe80).then_some(addr)
+        })
+    }
+
+    /// Reconcile the End.X SID for one neighbor — the OSPFv3 port of
+    /// `isis::Neighbor::reconcile_endx_sid`. Eligible while SRv6 is
+    /// active and the neighbor is Full:
+    ///
+    /// - no SID yet → allocate an ELIB function, install the
+    ///   advertised SID (global nh6 preferred, hello link-local as
+    ///   fallback) plus the LIB twin for uSID locators, and
+    ///   re-originate the per-link E-Router-LSA;
+    /// - SID held but the preferred nexthop drifted (the neighbor's
+    ///   Link-LSA with its global /128 typically lands after Full) →
+    ///   delete-then-add both kernel entries with the new nexthop;
+    /// - not eligible → release.
+    pub fn reconcile_endx_sid(&mut self, ifindex: u32, nbr_router_id: Ipv4Addr) {
+        let eligible = self.srv6_active()
+            && self
+                .links
+                .get(&ifindex)
+                .and_then(|l| l.nbrs.get(&nbr_router_id))
+                .is_some_and(|n| n.state == NfsmState::Full);
+        if !eligible {
+            if self.release_endx_sid(ifindex, nbr_router_id) {
+                self.e_router_v3_lsa_originate(ifindex);
+            }
+            return;
+        }
+
+        let Some(locator) = self.sr_locator.clone() else {
+            return;
+        };
+        let Some(prefix) = locator.prefix else {
+            return;
+        };
+
+        // Preferred nexthop: the neighbor's global from its Link-LSA,
+        // else its hello-source link-local.
+        let nh6 = self
+            .neighbor_global_nh6(ifindex, nbr_router_id)
+            .or_else(|| {
+                self.links
+                    .get(&ifindex)
+                    .and_then(|l| l.nbrs.get(&nbr_router_id))
+                    .map(|n| n.ident.prefix.addr())
+            });
+
+        if let Some(state) = self.endx_sids.get(&(ifindex, nbr_router_id)).cloned() {
+            if state.nh6 == nh6 {
+                return;
+            }
+            // Nexthop drifted: reinstall both kernel entries. The
+            // advertised SID is unchanged, so no LSA re-origination.
+            let _ = self.ctx.rib.send(rib::Message::SidDel { addr: state.addr });
+            if let Some(lib) = state.lib_addr {
+                let _ = self.ctx.rib.send(rib::Message::SidDel { addr: lib });
+            }
+            let lib_addr = self.install_endx_kernel(ifindex, &locator, state.addr, nh6);
+            self.endx_sids.insert(
+                (ifindex, nbr_router_id),
+                super::srv6::EndxSidState {
+                    function: state.function,
+                    addr: state.addr,
+                    lib_addr,
+                    nh6,
+                },
+            );
+            return;
+        }
+
+        let Some(function) = self.elib.allocate() else {
+            return;
+        };
+        let Some(addr) = crate::isis::srv6::function_addr(prefix, function) else {
+            self.elib.release(function);
+            return;
+        };
+        let lib_addr = self.install_endx_kernel(ifindex, &locator, addr, nh6);
+        self.endx_sids.insert(
+            (ifindex, nbr_router_id),
+            super::srv6::EndxSidState {
+                function,
+                addr,
+                lib_addr,
+                nh6,
+            },
+        );
+        self.e_router_v3_lsa_originate(ifindex);
+    }
+
+    /// Send the SidAdd pair for an End.X: the advertised /128 (classic
+    /// End.X or uA) and, for uSID locators, the LIB twin at
+    /// block:function with the NEXT-CSID flavor (PR #1364 semantics).
+    /// Returns the LIB twin address when one was installed.
+    fn install_endx_kernel(
+        &self,
+        ifindex: u32,
+        locator: &crate::rib::Locator,
+        addr: Ipv6Addr,
+        nh6: Option<Ipv6Addr>,
+    ) -> Option<Ipv6Addr> {
+        use crate::rib::{
+            LocatorBehavior, Sid, SidAllocationType, SidBehavior, SidContext, SidOwner,
+        };
+        let ifname = self
+            .links
+            .get(&ifindex)
+            .map(|l| l.name.clone())
+            .unwrap_or_default();
+        let loc_name = self.watched_locator.clone().unwrap_or_default();
+        let (behavior, structure) = match locator.behavior {
+            Some(LocatorBehavior::Usid) => (SidBehavior::UA, locator.sid_structure()),
+            None => (SidBehavior::EndX, None),
+        };
+        let sid = Sid {
+            addr,
+            behavior,
+            context: SidContext::Interface(ifname.clone()),
+            owner: SidOwner::new("ospfv3", 0),
+            locator: loc_name.clone(),
+            allocation_type: SidAllocationType::Dynamic,
+            ifindex,
+            nh6,
+            structure,
+            table_id: 0,
+            segs: Vec::new(),
+        };
+        let _ = self.ctx.rib.send(rib::Message::SidAdd { sid });
+
+        if !matches!(locator.behavior, Some(LocatorBehavior::Usid)) {
+            return None;
+        }
+        let prefix = locator.prefix?;
+        let structure = locator.sid_structure()?;
+        // Extract the 16-bit function back out of the full SID — the
+        // bits right after the locator prefix.
+        let fun = ((u128::from(addr) >> (128 - prefix.prefix_len() as u32 - 16)) & 0xffff) as u16;
+        let lib = crate::isis::srv6::lib_addr(prefix, structure.lb_bits, fun)?;
+        let sid = Sid {
+            addr: lib,
+            behavior: SidBehavior::UALib,
+            context: SidContext::Interface(ifname),
+            owner: SidOwner::new("ospfv3", 0),
+            locator: loc_name,
+            allocation_type: SidAllocationType::Dynamic,
+            ifindex,
+            nh6,
+            structure: Some(structure),
+            table_id: 0,
+            segs: Vec::new(),
+        };
+        let _ = self.ctx.rib.send(rib::Message::SidAdd { sid });
+        Some(lib)
+    }
+
+    /// Release one neighbor's End.X SID (kernel entries + ELIB
+    /// function). Returns true when something was held.
+    fn release_endx_sid(&mut self, ifindex: u32, nbr_router_id: Ipv4Addr) -> bool {
+        let Some(state) = self.endx_sids.remove(&(ifindex, nbr_router_id)) else {
+            return false;
+        };
+        self.elib.release(state.function);
+        let _ = self.ctx.rib.send(rib::Message::SidDel { addr: state.addr });
+        if let Some(lib) = state.lib_addr {
+            let _ = self.ctx.rib.send(rib::Message::SidDel { addr: lib });
+        }
+        true
+    }
+
+    /// Withdraw every End.X SID and reset the ELIB pool — locator
+    /// changed or SRv6 unconfigured; every issued address is invalid.
+    /// The follow-up sweep re-allocates for current Full neighbors.
+    fn clear_all_endx_sids(&mut self) {
+        let keys: Vec<(u32, Ipv4Addr)> = self.endx_sids.keys().cloned().collect();
+        for (ifindex, rid) in keys {
+            self.release_endx_sid(ifindex, rid);
+        }
+        self.elib.reset();
+    }
+
+    /// Allocate End.X SIDs for every Full neighbor on every link —
+    /// the catch-up sweep after a locator resolves (adjacencies may
+    /// have reached Full before SRv6 was active). Enumerates ALL
+    /// links unconditionally: filtering on config/state here is the
+    /// PR #1358 disable-after-teardown trap.
+    fn sweep_endx_sids(&mut self) {
+        let pairs: Vec<(u32, Ipv4Addr)> = self
+            .links
+            .iter()
+            .flat_map(|(ifindex, link)| {
+                link.nbrs
+                    .values()
+                    .filter(|n| n.state == NfsmState::Full)
+                    .map(|n| (*ifindex, n.ident.router_id))
+                    .collect::<Vec<_>>()
+            })
+            .collect();
+        for (ifindex, rid) in pairs {
+            self.reconcile_endx_sid(ifindex, rid);
         }
     }
 
@@ -7825,6 +8151,15 @@ impl Ospf<Ospfv3> {
             // branch handles the gate, but it needs the call.
             self.network_intra_area_prefix_lsa_originate(ifindex);
         }
+
+        // SRv6 End.X follows the same Full lifecycle as the Adj-SID:
+        // allocate + advertise on the transition into Full, release on
+        // regression. Re-originate our Link-LSA too — it now carries
+        // our global /128 (LA-bit) so the peer can upgrade its End.X
+        // nexthop from our link-local to the global, and link-scope
+        // floods at interface-up reached nobody.
+        self.reconcile_endx_sid(ifindex, nbr_addr);
+        self.link_lsa_originate(ifindex);
 
         // SR-MPLS E-Router-LSA tracks the per-link P2P Adj-SID, which
         // is only meaningful while the link has a Full neighbor.
@@ -8350,6 +8685,13 @@ pub enum Message<V: OspfVersion = Ospfv2> {
     /// Flood AS-scoped LSA through all normal areas, excluding source neighbor.
     /// (lsa, source_ifindex, source_nbr_addr)
     FloodAs(V::Lsa, u32, V::Addr),
+    /// A link-scope LSA (Link-LSA) was installed on this interface —
+    /// re-evaluate SRv6 End.X nexthops, because the neighbor's global
+    /// address (LA-bit /128 in its Link-LSA) may have just arrived
+    /// and the kernel End.X entry must drift from the link-local to
+    /// it (Linux resolves End.X nh6 by ingress iif — PR #1361).
+    /// v3-only; the v2 handler ignores it.
+    Srv6EndxReconcile(u32),
     /// Retransmit LSAs to a specific neighbor.
     /// (ifindex, nbr_addr)
     Retransmit(u32, Ipv4Addr),

--- a/zebra-rs/src/ospf/packet_v3.rs
+++ b/zebra-rs/src/ospf/packet_v3.rs
@@ -1422,6 +1422,10 @@ fn ospfv3_ls_upd_proc(
             }
             Ospfv3LsaScope::Link => {
                 oi.link_lsdb.install_lsa(cloned, oi.tx, Some(area_id));
+                // A peer Link-LSA can carry the neighbor's global /128
+                // (LA-bit) — the preferred SRv6 End.X nexthop. Nudge
+                // the instance to re-evaluate installs on this link.
+                let _ = oi.tx.send(Message::Srv6EndxReconcile(nbr.ifindex));
             }
             Ospfv3LsaScope::Reserved => {
                 return LsaProcessResult::DiscardNoAck;

--- a/zebra-rs/src/ospf/srv6.rs
+++ b/zebra-rs/src/ospf/srv6.rs
@@ -170,3 +170,118 @@ mod tests {
         assert!(srv6_locator_lsa_build("10.0.0.1".parse().unwrap(), &unresolved).is_none());
     }
 }
+
+/// Per-adjacency End.X SID state — one entry per Full neighbor, keyed
+/// like `lan_adj_sids` by `(ifindex, neighbor router-id)`. Tracks the
+/// allocated ELIB function, the advertised SID, the LIB twin (uSID
+/// locators only), and the nexthop the kernel entry currently
+/// forwards to, so a later-arriving neighbor global (Link-LSA) can
+/// drift-reinstall — same shape as the IS-IS `Neighbor::endx_sid` +
+/// `endx_installed_nh6` pair.
+#[derive(Debug, Clone)]
+pub struct EndxSidState {
+    pub function: u16,
+    pub addr: std::net::Ipv6Addr,
+    pub lib_addr: Option<std::net::Ipv6Addr>,
+    pub nh6: Option<std::net::Ipv6Addr>,
+}
+
+/// Endpoint behavior codepoint for an End.X carved from `locator` —
+/// `End.X with NEXT-CSID` (uA) for uSID locators, plain `End.X`
+/// otherwise. Shared by the LSA advertisement and the show side.
+pub fn endx_behavior(locator: &Locator) -> u16 {
+    match locator.behavior {
+        Some(LocatorBehavior::Usid) => u16::from(isis_packet::Behavior::EndXCSID),
+        None => u16::from(isis_packet::Behavior::EndX),
+    }
+}
+
+/// Nested SID-Structure sub-TLV (Extended-LSA registry type 30) for
+/// SIDs carved from `locator`, advertised for both classic and uSID
+/// modes like the IS-IS LSP emit.
+fn endx_structure_sub(locator: &Locator) -> Option<ospf_packet::Ospfv3SubTlv> {
+    locator.sid_structure().map(|s| {
+        ospf_packet::Ospfv3SubTlv::Srv6SidStructure(Ospfv3Srv6SidStructure {
+            lb_len: s.lb_bits,
+            ln_len: s.ln_bits,
+            fun_len: s.fun_bits,
+            arg_len: s.arg_bits,
+        })
+    })
+}
+
+/// SRv6 End.X SID sub-TLV (RFC 9513 §9.1) for a P2P Router-Link TLV.
+pub fn build_v3_endx_sub(locator: &Locator, sid: std::net::Ipv6Addr) -> ospf_packet::Ospfv3SubTlv {
+    ospf_packet::Ospfv3SubTlv::Srv6EndXSid(ospf_packet::Ospfv3Srv6EndXSidSubTlv {
+        behavior: endx_behavior(locator),
+        flags: 0,
+        algo: 0,
+        weight: 0,
+        sid,
+        subs: endx_structure_sub(locator).into_iter().collect(),
+    })
+}
+
+/// SRv6 LAN End.X SID sub-TLV (RFC 9513 §9.2) for broadcast / NBMA
+/// links — the Neighbor Router-ID picks which LAN member the
+/// adjacency points at.
+pub fn build_v3_lan_endx_sub(
+    locator: &Locator,
+    neighbor_router_id: Ipv4Addr,
+    sid: std::net::Ipv6Addr,
+) -> ospf_packet::Ospfv3SubTlv {
+    ospf_packet::Ospfv3SubTlv::Srv6LanEndXSid(ospf_packet::Ospfv3Srv6LanEndXSidSubTlv {
+        behavior: endx_behavior(locator),
+        flags: 0,
+        algo: 0,
+        weight: 0,
+        neighbor_router_id,
+        sid,
+        subs: endx_structure_sub(locator).into_iter().collect(),
+    })
+}
+
+#[cfg(test)]
+mod endx_tests {
+    use super::*;
+    use ipnet::Ipv6Net;
+
+    fn usid_locator() -> Locator {
+        Locator {
+            prefix: Some("fcbb:bbbb:1::/48".parse::<Ipv6Net>().unwrap()),
+            behavior: Some(LocatorBehavior::Usid),
+        }
+    }
+
+    #[test]
+    fn endx_sub_carries_ua_behavior_and_structure() {
+        let sub = build_v3_endx_sub(&usid_locator(), "fcbb:bbbb:1:e000::".parse().unwrap());
+        let ospf_packet::Ospfv3SubTlv::Srv6EndXSid(endx) = &sub else {
+            panic!("expected End.X sub-TLV");
+        };
+        assert_eq!(endx.behavior, u16::from(isis_packet::Behavior::EndXCSID));
+        assert_eq!(endx.subs.len(), 1);
+        let ospf_packet::Ospfv3SubTlv::Srv6SidStructure(st) = &endx.subs[0] else {
+            panic!("expected nested SID structure");
+        };
+        assert_eq!((st.lb_len, st.ln_len, st.fun_len), (32, 16, 16));
+    }
+
+    #[test]
+    fn lan_endx_sub_names_the_neighbor() {
+        let classic = Locator {
+            prefix: Some("2001:db8:f:2::/64".parse::<Ipv6Net>().unwrap()),
+            behavior: None,
+        };
+        let sub = build_v3_lan_endx_sub(
+            &classic,
+            Ipv4Addr::new(10, 0, 0, 5),
+            "2001:db8:f:2:e000::".parse().unwrap(),
+        );
+        let ospf_packet::Ospfv3SubTlv::Srv6LanEndXSid(lan) = &sub else {
+            panic!("expected LAN End.X sub-TLV");
+        };
+        assert_eq!(lan.behavior, u16::from(isis_packet::Behavior::EndX));
+        assert_eq!(lan.neighbor_router_id, Ipv4Addr::new(10, 0, 0, 5));
+    }
+}


### PR DESCRIPTION
## Summary
- **Phase 3 of OSPFv3 SRv6** (`docs/design/ospfv3-srv6-plan.md`): per-adjacency End.X/uA SIDs — ELIB allocation on the Full transition (pool shared with IS-IS), release on regression / locator change (with the full-sweep re-allocation rule from #1358), advertisement as RFC 9513 §9.1/§9.2 sub-TLVs on the per-link E-Router-LSA (which now originates in SRv6-only configs), and kernel installs incl. the `uA(LIB)` NEXT-CSID twin (#1364).
- **Global nexthop discovery**: OSPFv3 carries no neighbor globals anywhere, so the Link-LSA now additionally advertises interface globals as LA-bit /128s (RFC 5340 §4.4.3.8) and re-originates on Full; End.X installs prefer the neighbor's Link-LSA global with hello link-local fallback, and a new `Srv6EndxReconcile` message drift-reinstalls when the global arrives later — the #1361 kernel lesson (End.X nh6 resolves by ingress iif; link-locals blackhole) ported faithfully.

## Testing
- `ospfv3_srv6` BDD: 5/5 scenarios, 50/50 steps — including kernel `nh6 = <neighbor global>` assertions on both routers (validating the drift upgrade, as the peer's Link-LSA lands after Full), the flavored LIB twin, and End.X withdrawal on locator removal.
- 2 new unit tests for the sub-TLV builders; full suite 1626 passed; clippy `-D warnings` + fmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)