### PR TITLE
ospfv3: route to remote SRv6 locators from the Locator LSA

### DIFF
--- a/bdd/tests/features/ospfv3_srv6.feature
+++ b/bdd/tests/features/ospfv3_srv6.feature
@@ -86,6 +86,18 @@ Feature: OSPFv3 SRv6 locator origination (RFC 9513)
     # NEXT-CSID flavor.
     And kernel route "fcbb:bbbb:e000::/48" in namespace "z1" should eventually contain "flavors next-csid"
 
+  Scenario: Remote locators are reachable via the SRv6 Locator LSA
+    Given the test topology exists
+    # Locator prefixes ride only the SRv6 Locator LSA — they are not
+    # interface subnets and appear in no Intra-Area-Prefix-LSA — so
+    # these routes prove the RFC 9513 §7 receive-side processing:
+    # each router computes a route to the peer's locator through the
+    # SPF cost to the advertising router.
+    Then kernel route "2001:db8:f:2::/64" in namespace "z1" should eventually contain "proto ospf"
+    And kernel route "fcbb:bbbb:1::/48" in namespace "z2" should eventually contain "proto ospf"
+    And show command "show ospfv3 route" in namespace "z1" should contain "2001:db8:f:2::/64"
+    And show command "show ospfv3 route" in namespace "z2" should contain "fcbb:bbbb:1::/48"
+
   Scenario: Removing the locator flushes the LSA and withdraws the SID
     Given the test topology exists
     When I apply command "delete router ospfv3 segment-routing srv6 locator LOC1" in namespace "z1"
@@ -97,6 +109,7 @@ Feature: OSPFv3 SRv6 locator origination (RFC 9513)
     And kernel route "fcbb:bbbb:1::/48" in namespace "z1" should eventually be gone
     And kernel route "fcbb:bbbb:1:e000::" in namespace "z1" should eventually be gone
     And show command "show ospfv3 database detail" in namespace "z2" should not contain "SRv6 Locator TLV: fcbb:bbbb:1::/48"
+    And kernel route "fcbb:bbbb:1::/48" in namespace "z2" should eventually be gone
     # z2's own origination is untouched.
     And show command "show ospfv3 database detail" in namespace "z2" should contain "SRv6 Locator TLV: 2001:db8:f:2::/64"
 

--- a/zebra-rs/src/ospf/inst.rs
+++ b/zebra-rs/src/ospf/inst.rs
@@ -10887,6 +10887,14 @@ fn build_rib6_from_spf(
         add_nssa_routes_v3(top, area_id, spf_result, &mut rib);
     }
 
+    // RFC 9513 §7: SRv6 locator reachability. Locator prefixes ride
+    // their own LSA (not any Intra-Area-Prefix-LSA), so without this
+    // pass remote locators — and every SID carved from them — are
+    // unreachable. Runs before the TI-LFA pass so locator routes
+    // carry dest_vertex and pick up repair backups like any other
+    // single-nexthop prefix.
+    add_srv6_locator_routes_v3(top, area_id, source, spf_result, &mut rib);
+
     // TI-LFA second pass: stamp the post-convergence repair backup onto
     // single-primary routes (ECMP skipped — surviving legs already
     // protect). v3 sibling of the v2 second pass in `build_rib_from_spf`;
@@ -10913,6 +10921,99 @@ fn build_rib6_from_spf(
     }
 
     rib
+}
+
+/// RFC 9513 §7: install routes toward remote SRv6 locators. Walks the
+/// area's SRv6 Locator LSAs; each algo-0 intra-area Locator TLV
+/// installs at `cost(advertising router) + locator metric` with the
+/// same nexthops as any other prefix of that router. Self-originated
+/// Locator LSAs are skipped — the local End/uN SID install already
+/// covers the prefix in the FIB. Non-zero algorithms (Flex-Algo
+/// SRv6) and inter-area route types are deferred per the plan.
+fn add_srv6_locator_routes_v3(
+    top: &Ospf<Ospfv3>,
+    area_id: Ipv4Addr,
+    source: usize,
+    spf_result: &BTreeMap<usize, spf::Path>,
+    rib: &mut PrefixMap<ipnet::Ipv6Net, SpfRouteV3>,
+) {
+    use crate::ospf::lsdb::OSPF_MAX_AGE;
+    use ospf_packet::{OSPFV3_SRV6_LOCATOR_LSA_TYPE, Ospfv3LsBody, Ospfv3Srv6LocatorLsaTlv};
+
+    let Some(area) = top.areas.get(area_id) else {
+        return;
+    };
+    for (_key, lsa) in area.lsdb.iter_by_raw_type(OSPFV3_SRV6_LOCATOR_LSA_TYPE) {
+        if lsa.data.h.ls_age >= OSPF_MAX_AGE {
+            continue;
+        }
+        let Ospfv3LsBody::Srv6Locator(ref body) = lsa.data.body else {
+            continue;
+        };
+        let Some(vertex) = top.lsp_map.lookup(lsa.data.h.advertising_router) else {
+            continue;
+        };
+        if vertex == source {
+            continue;
+        }
+        let Some(path) = spf_result.get(&vertex) else {
+            continue;
+        };
+        let nhops = collect_v3_nexthops(top, path);
+        if nhops.is_empty() {
+            continue;
+        }
+        let nhops_map: BTreeMap<std::net::Ipv6Addr, SpfNexthopV3> = nhops
+            .into_iter()
+            .map(|(addr, ifindex)| {
+                (
+                    addr,
+                    SpfNexthopV3 {
+                        ifindex,
+                        adjacency: false,
+                        backup: None,
+                    },
+                )
+            })
+            .collect();
+
+        for tlv in &body.tlvs {
+            let Ospfv3Srv6LocatorLsaTlv::Locator(loc) = tlv else {
+                continue;
+            };
+            if loc.algorithm != 0 {
+                continue;
+            }
+            let Ok(net) = ipnet::Ipv6Net::new(loc.locator, loc.locator_length) else {
+                continue;
+            };
+            let net = net.trunc();
+            let entry = SpfRouteV3 {
+                metric: path.cost.saturating_add(loc.metric),
+                nhops: nhops_map.clone(),
+                sid: None,
+                prefix_sid: None,
+                dest_vertex: Some(vertex),
+                backup_as_primary: top.fast_reroute_backup_as_primary,
+            };
+            // Same lowest-metric / equal-cost-ECMP merge as the
+            // Intra-Area-Prefix pass.
+            match rib.get_mut(&net) {
+                None => {
+                    rib.insert(net, entry);
+                }
+                Some(curr) => {
+                    if curr.metric > entry.metric {
+                        *curr = entry;
+                    } else if curr.metric == entry.metric {
+                        for (addr, nhop) in entry.nhops {
+                            curr.nhops.insert(addr, nhop);
+                        }
+                    }
+                }
+            }
+        }
+    }
 }
 
 /// Walk v3 Type-5 (AS-External, 0x4005) entries in `lsdb_as` and


### PR DESCRIPTION
## Summary
- **Phase 4 of OSPFv3 SRv6** (`docs/design/ospfv3-srv6-plan.md`): the receive side. `add_srv6_locator_routes_v3` installs routes toward remote locators during the v3 route build — `cost(advertising router) + locator metric`, advertising router's SPF nexthops, the same lowest-metric/ECMP merge as the Intra-Area-Prefix pass. Locator prefixes appear in no other LSA, so this pass is what makes remote locators (and every SID carved from them) reachable.
- Runs before the TI-LFA second pass and stamps `dest_vertex`, so locator routes inherit repair backups automatically — Phase 5's SRv6 repairs protect locator reachability for free.
- Deferred per plan: non-zero algorithms (Flex-Algo SRv6), inter-area route types. Remote End/End.X SID resolution lands with its consumer (the Phase 5 repair builder reads the LSDB directly, like the MPLS Adj-SID resolver).

## Testing
- `ospfv3_srv6` BDD: 6/6 scenarios, 56/56 steps — new scenario pins each router's kernel `proto ospf` route to the **peer's** locator + `show ospfv3 route` rows; the flush scenario now asserts the route disappears with the LSA.
- Full suite 1629 passed; clippy `-D warnings` + fmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)