### PR TITLE
rib: kernel-side failover phase 1 — protection indirection groups

### DIFF
--- a/bdd/tests/features/ospfv3_tilfa.feature
+++ b/bdd/tests/features/ospfv3_tilfa.feature
@@ -170,9 +170,14 @@ Feature: OSPFv3 TI-LFA fast-reroute over SR-MPLS
     When I apply command "set router ospfv3 fast-reroute backup-as-primary" in namespace "s"
     And I wait 5 seconds
     # d's loopback route now has the label-stack repair as its best
-    # kernel entry, out the repair egress s-n2.
+    # kernel entry, out the repair egress s-n2. The protected primary
+    # references a protection indirection group (nexthop-protect
+    # phase 1), and iproute2 renders v6 group routes on two lines —
+    # route attrs (proto/metric) on the first, nexthop detail (dev)
+    # on the continuation — so assert the two halves separately.
     Then kernel route "2001:db8::8" in namespace "s" should eventually contain "encap mpls"
-    And kernel route "2001:db8::8" in namespace "s" should eventually contain "dev s-n2 proto ospf metric 2"
+    And kernel route "2001:db8::8" in namespace "s" should eventually contain "proto ospf metric 2"
+    And kernel route "2001:db8::8" in namespace "s" should eventually contain "dev s-n2"
     # End-to-end over the repair: dies if any label hop on the
     # s-n2-r1-r2-r3-d repair path fails to swap/pop/forward.
     And ping from "s" to "2001:db8::8" should succeed

--- a/docs/design/nexthop-protect-kernel-failover.md
+++ b/docs/design/nexthop-protect-kernel-failover.md
@@ -76,7 +76,33 @@ All load-bearing assumptions validated in throwaway netns
 
 Probe 2 passing means the fallback design ("Plan B": `RTM_DELNEXTHOP`
 the primary and let the kernel flush primary routes onto the shadows)
-is **not needed**.
+is **not needed** for plain/MPLS primaries.
+
+### Phase-1 BDD findings (2026-06-12) — two probe blind spots
+
+The first probes validated netlink acceptance and **rendering**, not
+end-to-end traffic through encap'd members. The phase-1 BDD run
+closed that gap:
+
+1. **seg6 `mode inline` members black-hole inside groups.** Object
+   creation, grouping, route install, and `ip route get` all succeed,
+   but the dataplane never transmits: a tcpdump probe shows the SRH
+   packet egress with a direct `nhid <member>` reference and **zero
+   packets** via `nhid <group{member}>`. seg6 `mode encap` members DO
+   forward through a group (traffic-verified), as do MPLS members
+   (BDD `@isis_tilfa` backup-as-primary ping rides `Gp{mpls}`).
+   zebra-rs SRv6 TI-LFA repairs are inline, so **SRv6-encap'd
+   primaries are excluded from indirection** (`pro.gid` stays 0,
+   direct member reference, pre-phase-1 behavior). Phase 2's SRv6
+   switchover therefore needs one of: kernel fix upstream, encap-mode
+   repairs, or per-prefix `RTM_NEWROUTE` replace for the SRv6 subset.
+2. **IPv6 group routes render with continuation lines.** `ip -6 route`
+   prints `<prefix> nhid G proto X metric M` on line 1 and
+   `nexthop ... dev D weight 1` on line 2 (IPv4 stays one line). Any
+   text assertion expecting `dev D proto X metric M` as one substring
+   breaks. Moot for SRv6 after the exclusion above; still relevant to
+   v6+MPLS protected primaries (OSPFv3/IS-IS v6 TI-LFA) — sweep
+   `bdd/` route asserts when phase 1 lands, per the show-grammar rule.
 
 ## 3. Design
 
@@ -163,9 +189,11 @@ leg) but must be called out in the phase-5 PR.
 
 ## 5. Constraints
 
+- **SRv6 primaries are NOT wrapped** (see Phase-1 BDD findings):
+  kernel 6.8 black-holes seg6-inline traffic routed through a group.
+  `resolve_nexthop_protect` skips members with a non-empty `segs`.
 - **seg6local** can't ride nexthop objects (existing constraint) —
-  irrelevant: local-SID installs aren't protected routes. SRv6 H.Encap
-  repairs work (probe 2/5).
+  irrelevant: local-SID installs aren't protected routes.
 - `show nexthop` should render `Group::Protect` (+ active member from
   phase 2). Route show output is unchanged; RIB/kernel divergence
   during a switchover is bounded by SPF reconvergence.

--- a/docs/design/nexthop-protect-kernel-failover.md
+++ b/docs/design/nexthop-protect-kernel-failover.md
@@ -19,7 +19,7 @@ paths for protected routes.
 | Slice | PR | What lands |
 | ----- | -- | ---------- |
 | 0 — `Nexthop::Protect` RIB shape | #1370, #1373 | explicit primary/backup pair, producers + consumers, v6 resolver fix |
-| 1 — indirection group | (this branch) | `Group::Protect` + `NexthopProtect.gid`; protected v4/v6 routes reference a 1-member kernel group; behavior-neutral |
+| 1 — indirection group | #1374 | `Group::Protect` + `NexthopProtect.gid`; protected v4/v6 routes reference a 1-member kernel group; behavior-neutral |
 | 2 — switchover op | — | `FibHandle::protect_switch` + `Message::ProtectSwitch` + nmap state |
 | 3 — IS-IS hook | — | BFD/adjacency-down emits `ProtectSwitch` before SPF; BDD for the link-up failure class |
 | 4 — OSPF hook | — | v2 + v3, same shape |

--- a/docs/design/nexthop-protect-kernel-failover.md
+++ b/docs/design/nexthop-protect-kernel-failover.md
@@ -96,6 +96,11 @@ closed that gap:
    direct member reference, pre-phase-1 behavior). Phase 2's SRv6
    switchover therefore needs one of: kernel fix upstream, encap-mode
    repairs, or per-prefix `RTM_NEWROUTE` replace for the SRv6 subset.
+   Note the gate is two-sided: a *plain* primary with an SRv6 *backup*
+   (normal-mode ospfv3 SRv6 TI-LFA, #1375) gets its indirection group
+   in phase 1, but phase 2 must NOT group-swap it onto the seg6
+   member — that swap would re-create the black-hole. The swap path
+   has to check the backup's encap and fall back to route replace.
 2. **IPv6 group routes render with continuation lines.** `ip -6 route`
    prints `<prefix> nhid G proto X metric M` on line 1 and
    `nexthop ... dev D weight 1` on line 2 (IPv4 stays one line). Any

--- a/docs/design/nexthop-protect-kernel-failover.md
+++ b/docs/design/nexthop-protect-kernel-failover.md
@@ -1,0 +1,186 @@
+# Kernel-Side Failover for `Nexthop::Protect` — Design & Phasing Plan
+
+Tracks moving TI-LFA failover from daemon-mediated reconvergence to
+kernel-side switchover, built on the `Nexthop::Protect` primary+backup
+pair introduced in #1370 (and the v6 resolver fix in #1373). This is
+the living plan + status: the failure-class analysis, the kernel
+primitives (probe-validated on the target kernel), the architecture,
+and the phase-by-phase slice so a contributor can resume without the
+conversation history.
+
+Read this first if you're touching `rib/nexthop/inst.rs`
+(`NexthopProtect`), `rib/nexthop/group.rs` / `map.rs`
+(`Group::Protect`, `fetch_protect`), `rib/route.rs`
+(`rib_resolve_nexthop{,_v6}`), or the `fib/netlink/handle.rs` install
+paths for protected routes.
+
+## Status (updated 2026-06-12)
+
+| Slice | PR | What lands |
+| ----- | -- | ---------- |
+| 0 — `Nexthop::Protect` RIB shape | #1370, #1373 | explicit primary/backup pair, producers + consumers, v6 resolver fix |
+| 1 — indirection group | (this branch) | `Group::Protect` + `NexthopProtect.gid`; protected v4/v6 routes reference a 1-member kernel group; behavior-neutral |
+| 2 — switchover op | — | `FibHandle::protect_switch` + `Message::ProtectSwitch` + nmap state |
+| 3 — IS-IS hook | — | BFD/adjacency-down emits `ProtectSwitch` before SPF; BDD for the link-up failure class |
+| 4 — OSPF hook | — | v2 + v3, same shape |
+| 5 — ECMP leg-level replace | — | per-leg repair on `Multi` primaries |
+
+## 1. Problem
+
+Two failure classes behave very differently today:
+
+| Failure | Detection | Who restores traffic today | Cost |
+| --- | --- | --- | --- |
+| Local link down | kernel netdev event | **kernel** — deletes the dead nexthop object and every route referencing it; the pre-installed `metric+1` repair route takes over | ~instant, autonomous |
+| Remote failure, link up (neighbor crash, unidirectional loss) | BFD | **daemon** — BFD down → adjacency down → full SPF → per-prefix `RTM_NEWROUTE`/`DELROUTE` | O(prefixes) netlink ops, after SPF |
+
+The second row is the gap: for BFD-detected failures the pre-installed
+repair route is never used, because the primary route (lower metric) is
+still in the FIB pointing at a dead gateway the kernel knows nothing
+about. The pre-installed TI-LFA state buys nothing in exactly the case
+TI-LFA exists for.
+
+**Goal:** traffic restored in O(failed adjacencies) — one netlink
+message each — independent of prefix count (PIC-style), with SPF
+reconvergence happening afterwards at its own pace.
+
+## 2. Kernel primitives
+
+Upstream Linux (incl. 6.8) has **no native backup-member semantics in
+nexthop groups** — group types are `mpath` and `resilient` only. FRR's
+"backup nexthops" exist only in dataplanes that support them
+(SAI/DPDK), not in the kernel netlink API. The design therefore
+composes two primitives the kernel does have:
+
+1. **Atomic group-membership replace** — `RTM_NEWNEXTHOP` +
+   `NLM_F_REPLACE` on a group id swaps membership (RCU); every route
+   referencing the id forwards via the new members immediately, with
+   no route churn.
+2. **Autonomous flush on link down** — the kernel deletes nexthop
+   objects on a downed device, removes them from groups, deletes a
+   group when its last member dies, and deletes routes referencing the
+   deleted group.
+
+### Probe results (6.8.0-124-generic, 2026-06-12)
+
+All load-bearing assumptions validated in throwaway netns
+(veth pairs, `ip nexthop` + live ping with per-device RX counters):
+
+| # | Probe | Result |
+| - | ----- | ------ |
+| 1 | single-member `NHA_GROUP` | pass — `ip nexthop add id 100 group 1` accepted |
+| 2 | encap'd nexthop as group member | pass — MPLS (`16002/16005`) and seg6 (H.Encap) members both accepted |
+| 3 | atomic replace under live traffic | pass — RX counters flipped 6/0 → 0/6 across one `ip nexthop replace`; route object untouched (`nhid 100`); replace **onto the MPLS-encap member** (the real switchover op) accepted, route dump shows inherited label stack |
+| 4 | link-down autonomy | pass — device down flushed the member, deleted the empty group **and** the primary route; the `metric+1` shadow route survived and forwarded (fib lookup + ping) with no userspace action |
+| 5 | v6 route via group + replace onto seg6 member | pass — same semantics for IPv6 routes |
+
+Probe 2 passing means the fallback design ("Plan B": `RTM_DELNEXTHOP`
+the primary and let the kernel flush primary routes onto the shadows)
+is **not needed**.
+
+## 3. Design
+
+### Steady state
+
+```
+route 10.0.0.0/24 metric m    --Nhid--> Gp (mpath group) --> { U_primary }
+route 10.0.0.0/24 metric m+1  --Nhid--> U_repair
+```
+
+- `Gp` is a 1-member indirection group per protected primary,
+  allocated in `NexthopMap` like any gid and keyed by
+  `(primary_gid, backup_gid)` — two prefixes sharing a primary but
+  carrying different repairs get distinct groups, so each switches to
+  *its own* repair.
+- `U_primary` / `U_repair` are the existing `Group::Uni` objects. The
+  repair's MPLS stack / SRv6 segs already ride on the nexthop object
+  (`fib/netlink/handle.rs` `nexthop_add`), so a membership swap
+  carries the full repair encap (probe 3).
+- The `metric+1` shadow route **stays**: it is the autonomous
+  link-down path (probe 4) and covers the daemon-crash window.
+
+### BFD-down fast path
+
+```
+BFD down on adjacency A
+  → IGP sends Message::ProtectSwitch{ table_id, primary key } (before SPF)
+  → RIB looks up affected Gp's in NexthopMap
+  → one RTM_NEWNEXTHOP REPLACE id=Gp group={U_repair} per Gp
+  → every protected prefix via A forwards over its repair
+  → SPF runs; post-convergence routes replace everything as usual
+```
+
+Failover becomes detection-bounded (BFD interval ×3) plus
+microseconds, instead of detection + SPF + per-prefix FIB churn.
+
+### Recovery
+
+No in-place revert. The switchover is a bridge; normal SPF
+reconvergence supersedes it — `diff_apply` installs fresh routes and
+the old `Gp`s drain via the existing refcnt GC. (`backup-as-primary`
+already covers the "stay on repair" operator intent; flap damping can
+come later if ever needed.)
+
+### ECMP primaries
+
+Kernel groups can't nest, so a `Multi` primary's ECMP group **is** the
+switch point — no extra indirection:
+
+- leg-level BFD down: `REPLACE Gmulti {leg1, leg2} → {repair1, leg2}`
+  (per-primary repair, correct TI-LFA semantics);
+- leg link down stays autonomous (kernel shrinks the group).
+
+Caveat for phase 5: a `Multi` group is keyed by member set and may be
+shared by unprotected routes with the same ECMP set; replacing its
+members rewires those too. Semantically acceptable (they lose a dead
+leg) but must be called out in the phase-5 PR.
+
+## 4. Data-model changes (phase 1–2)
+
+- `NexthopProtect` gains `gid: usize` — the indirection-group id,
+  mirroring `NexthopMulti.gid`. `gid == 0` means "no kernel
+  indirection" (Multi primary, or `use_nhid` off).
+- `NexthopMap` gains `Group::Protect(GroupProtect)`:
+  `GroupCommon` + `primary_gid` + `backup_gid`, keyed via
+  `fetch_protect((primary_gid, backup_gid))`. Holds refcnts on both
+  members so GC ordering is safe. Phase 2 adds the
+  `active: Primary | Switched` state.
+- Resolver (`rib_resolve_nexthop{,_v6}` Protect blocks): after
+  resolving both members, allocate `Gp` when the primary is `Uni`.
+- `FibHandle::nexthop_add`: `Group::Protect` arm installs a 1-member
+  `NHA_GROUP` (same encoding as `Multi`, one entry). Install order:
+  members first, then `Gp` (`nexthop_sync` ordering); delete in
+  reverse (`nexthop_unsync`).
+- `route_ipv{4,6}_add/del` Protect arm: the primary route's `Nhid`
+  becomes `pro.gid` (when non-zero) instead of the member gid; the
+  shadow route is unchanged. With `use_nhid` off, everything stays
+  exactly as today (gateways embedded per route) — the feature is
+  inherently gated on nexthop-object support (kernel ≥ 5.3).
+- Self-heal: probe 4 shows the kernel deletes `Gp` behind our back on
+  link down — `Group::Protect` must join the existing
+  `nexthop_force_reinstall` / re-resolve machinery from the start
+  (same "kernel silently dropped the object" pattern as `Uni`/`Multi`).
+
+## 5. Constraints
+
+- **seg6local** can't ride nexthop objects (existing constraint) —
+  irrelevant: local-SID installs aren't protected routes. SRv6 H.Encap
+  repairs work (probe 2/5).
+- `show nexthop` should render `Group::Protect` (+ active member from
+  phase 2). Route show output is unchanged; RIB/kernel divergence
+  during a switchover is bounded by SPF reconvergence.
+- Legacy kernels (`use_nhid == false`): no indirection, no fast path;
+  behavior identical to pre-phase-1.
+
+## 6. Test plan
+
+- Unit: `fetch_protect` allocation/dedup/refcnt; resolver stamps
+  `pro.gid` (v4 + v6 — see #1373 for why both paths need pinning);
+  install-order in `nexthop_sync`.
+- BDD (phase 1): existing `@isis_tilfa`, `@isis_tilfa_srv6*`,
+  `@ospfv2_tilfa`, `@ospfv3_tilfa` must stay green — phase 1 is
+  behavior-neutral apart from the indirection level.
+- BDD (phase 3+): new scenario for the link-up failure class —
+  ip6tables-style drop (the BFD hold-down pattern from the IS-IS BFD
+  series) asserting forwarding is restored via the repair label stack
+  *before* IGP reconvergence rewrites the FIB.

--- a/zebra-rs/src/fib/netlink/handle.rs
+++ b/zebra-rs/src/fib/netlink/handle.rs
@@ -139,7 +139,32 @@ fn fmt_group_for_trace(group: &Group) -> String {
                 members.join(", ")
             )
         }
+        Group::Protect(p) => format!(
+            "Group::Protect{{gid={} primary={} backup={} valid={} installed={}}}",
+            p.gid(),
+            p.primary_gid,
+            p.backup_gid,
+            p.is_valid(),
+            p.is_installed(),
+        ),
     }
+}
+
+/// The primary member of a `NexthopProtect` as the `Nexthop` the
+/// per-route install/delete paths consume. When the resolver
+/// allocated a protection indirection group, the route must reference
+/// *its* gid instead of the member's own — that id is the handle the
+/// switchover swaps. Only the gid changes; address, metric, and encap
+/// stay the member's (and on `use_nhid == false` kernels the gid is
+/// never read, so this is inert there).
+fn protect_primary_nexthop(pro: &crate::rib::nexthop::NexthopProtect) -> Nexthop {
+    let mut nh = pro.primary.as_nexthop();
+    if pro.gid != 0
+        && let Nexthop::Uni(u) = &mut nh
+    {
+        u.gid = pro.gid;
+    }
+    nh
 }
 
 /// Modern rtnetlink multicast group for nexthop objects
@@ -519,13 +544,17 @@ impl FibHandle {
             }
             Nexthop::Protect(pro) => {
                 // Primary and backup install as two kernel routes at
-                // their own metrics, exactly like the List members.
+                // their own metrics. The primary references the
+                // protection indirection group (when allocated) so a
+                // future membership swap rewires every protected
+                // prefix at once; the backup keeps its member gid.
                 let mut ok = true;
-                for member in pro.members() {
-                    ok &= self
-                        .route_ipv4_add_uni(prefix, entry, &member.as_nexthop(), table_id)
-                        .await;
-                }
+                ok &= self
+                    .route_ipv4_add_uni(prefix, entry, &protect_primary_nexthop(pro), table_id)
+                    .await;
+                ok &= self
+                    .route_ipv4_add_uni(prefix, entry, &pro.backup.as_nexthop(), table_id)
+                    .await;
                 ok
             }
             _ => true,
@@ -653,10 +682,12 @@ impl FibHandle {
                 }
             }
             Nexthop::Protect(pro) => {
-                for member in pro.members() {
-                    self.route_ipv4_del_uni(prefix, entry, &member.as_nexthop(), table_id)
-                        .await;
-                }
+                // Mirror the add path: the primary route was keyed to
+                // the indirection gid, so the delete must name it too.
+                self.route_ipv4_del_uni(prefix, entry, &protect_primary_nexthop(pro), table_id)
+                    .await;
+                self.route_ipv4_del_uni(prefix, entry, &pro.backup.as_nexthop(), table_id)
+                    .await;
             }
         }
     }
@@ -903,13 +934,17 @@ impl FibHandle {
             }
             Nexthop::Protect(pro) => {
                 // Primary and backup install as two kernel routes at
-                // their own metrics, exactly like the List members.
+                // their own metrics. The primary references the
+                // protection indirection group (when allocated) so a
+                // future membership swap rewires every protected
+                // prefix at once; the backup keeps its member gid.
                 let mut ok = true;
-                for member in pro.members() {
-                    ok &= self
-                        .route_ipv6_add_uni(prefix, entry, &member.as_nexthop(), table_id)
-                        .await;
-                }
+                ok &= self
+                    .route_ipv6_add_uni(prefix, entry, &protect_primary_nexthop(pro), table_id)
+                    .await;
+                ok &= self
+                    .route_ipv6_add_uni(prefix, entry, &pro.backup.as_nexthop(), table_id)
+                    .await;
                 ok
             }
             _ => true,
@@ -1057,10 +1092,12 @@ impl FibHandle {
                 }
             }
             Nexthop::Protect(pro) => {
-                for member in pro.members() {
-                    self.route_ipv6_del_uni(prefix, entry, &member.as_nexthop(), table_id)
-                        .await;
-                }
+                // Mirror the add path: the primary route was keyed to
+                // the indirection gid, so the delete must name it too.
+                self.route_ipv6_del_uni(prefix, entry, &protect_primary_nexthop(pro), table_id)
+                    .await;
+                self.route_ipv6_del_uni(prefix, entry, &pro.backup.as_nexthop(), table_id)
+                    .await;
             }
         }
     }
@@ -1237,6 +1274,29 @@ impl FibHandle {
                     vec.push(grp);
                 }
                 let attr = NexthopAttribute::Group(vec);
+                msg.attributes.push(attr);
+            }
+            Group::Protect(pro) => {
+                // Protection indirection: a 1-member mpath group
+                // holding the primary. Same encoding as Multi —
+                // GroupType 0, kernel weight is value+1 so 0 = 1.
+                gid = pro.gid();
+                refcnt = pro.refcnt();
+
+                msg.header.address_family = AddressFamily::Unspec;
+
+                let attr = NexthopAttribute::Id(pro.gid() as u32);
+                msg.attributes.push(attr);
+
+                let attr = NexthopAttribute::GroupType(0);
+                msg.attributes.push(attr);
+
+                let grp = NexthopGroup {
+                    id: pro.primary_gid as u32,
+                    weight: 0,
+                    ..Default::default()
+                };
+                let attr = NexthopAttribute::Group(vec![grp]);
                 msg.attributes.push(attr);
             }
         }

--- a/zebra-rs/src/isis/rib.rs
+++ b/zebra-rs/src/isis/rib.rs
@@ -546,7 +546,11 @@ fn build_rib_nexthop(nhops: Vec<rib::NexthopUni>) -> rib::Nexthop {
         if members.len() == 2 {
             let backup = members.pop().unwrap();
             let primary = members.pop().unwrap();
-            rib::Nexthop::Protect(rib::NexthopProtect { primary, backup })
+            rib::Nexthop::Protect(rib::NexthopProtect {
+                primary,
+                backup,
+                gid: 0,
+            })
         } else {
             rib::Nexthop::List(rib::NexthopList { nexthops: members })
         }

--- a/zebra-rs/src/ospf/inst.rs
+++ b/zebra-rs/src/ospf/inst.rs
@@ -11928,7 +11928,11 @@ fn build_rib_nexthop(nhops: Vec<rib::NexthopUni>) -> rib::Nexthop {
         if members.len() == 2 {
             let backup = members.pop().unwrap();
             let primary = members.pop().unwrap();
-            rib::Nexthop::Protect(rib::NexthopProtect { primary, backup })
+            rib::Nexthop::Protect(rib::NexthopProtect {
+                primary,
+                backup,
+                gid: 0,
+            })
         } else {
             rib::Nexthop::List(rib::NexthopList { nexthops: members })
         }

--- a/zebra-rs/src/rib/entry.rs
+++ b/zebra-rs/src/rib/entry.rs
@@ -125,6 +125,9 @@ impl RibEntry {
             for member in pro.members_mut() {
                 member_group_sync(member, nmap, fib).await;
             }
+            // The indirection group references the primary member's
+            // kernel object, so it must install after the members.
+            protect_group_sync(pro.gid, nmap, fib).await;
         }
     }
 
@@ -152,6 +155,12 @@ impl RibEntry {
                 }
             }
             Nexthop::Protect(pro) => {
+                // Drop the indirection group before its members so
+                // member deletion can't cascade-empty it in the
+                // kernel out from under the explicit delete.
+                if pro.gid != 0 {
+                    self.handle_nexthop_group(nmap, fib, pro.gid).await;
+                }
                 for member in pro.members() {
                     self.member_nexthop_unsync(member, nmap, fib).await;
                 }
@@ -196,6 +205,23 @@ impl RibEntry {
 
 async fn uni_group_sync(uni: &NexthopUni, nmap: &mut NexthopMap, fib: &FibHandle) {
     let Some(group) = nmap.get_mut(uni.gid) else {
+        return;
+    };
+    if !group.is_valid() || group.is_installed() {
+        return;
+    }
+    fib.nexthop_add(group).await;
+    group.set_installed(true);
+}
+
+/// Install the protection indirection group once it's valid — same
+/// gate as the Uni/Multi sync helpers. `gid == 0` means no
+/// indirection was allocated (Multi primary).
+async fn protect_group_sync(gid: usize, nmap: &mut NexthopMap, fib: &FibHandle) {
+    if gid == 0 {
+        return;
+    }
+    let Some(group) = nmap.get_mut(gid) else {
         return;
     };
     if !group.is_valid() || group.is_installed() {

--- a/zebra-rs/src/rib/nexthop/group.rs
+++ b/zebra-rs/src/rib/nexthop/group.rs
@@ -16,6 +16,7 @@ use crate::rib::tracing::rib_nexthop;
 pub enum Group {
     Uni(GroupUni),
     Multi(GroupMulti),
+    Protect(GroupProtect),
 }
 
 #[derive(Default, Debug, Clone)]
@@ -204,6 +205,42 @@ impl GroupTrait for GroupMulti {
     }
 }
 
+/// Kernel indirection group for a protected primary (see
+/// `docs/design/nexthop-protect-kernel-failover.md`). Installs as a
+/// single-member `NHA_GROUP` containing `primary_gid`; protected
+/// routes reference this gid instead of the member's, so the phase-2
+/// switchover can move every route onto `backup_gid` with one atomic
+/// `RTM_NEWNEXTHOP` replace. Valid iff the primary member's group is
+/// valid — on link down the kernel flushes the member, the emptied
+/// group, and the routes referencing it (probe-validated), leaving
+/// the metric-offset shadow route forwarding.
+#[derive(Debug, Clone)]
+pub struct GroupProtect {
+    common: GroupCommon,
+    pub primary_gid: usize,
+    pub backup_gid: usize,
+}
+
+impl GroupProtect {
+    pub fn new(gid: usize, primary_gid: usize, backup_gid: usize) -> Self {
+        Self {
+            common: GroupCommon::new(gid),
+            primary_gid,
+            backup_gid,
+        }
+    }
+}
+
+impl GroupTrait for GroupProtect {
+    fn common(&self) -> &GroupCommon {
+        &self.common
+    }
+
+    fn common_mut(&mut self) -> &mut GroupCommon {
+        &mut self.common
+    }
+}
+
 pub trait GroupTrait {
     fn common(&self) -> &GroupCommon;
 
@@ -255,6 +292,7 @@ impl GroupTrait for Group {
         match self {
             Uni(uni) => &uni.common,
             Multi(multi) => &multi.common,
+            Protect(pro) => &pro.common,
         }
     }
 
@@ -262,6 +300,7 @@ impl GroupTrait for Group {
         match self {
             Uni(uni) => &mut uni.common,
             Multi(multi) => &mut multi.common,
+            Protect(pro) => &mut pro.common,
         }
     }
 
@@ -269,6 +308,7 @@ impl GroupTrait for Group {
         match self {
             Group::Uni(uni) => uni.refcnt(),
             Group::Multi(multi) => multi.refcnt(),
+            Group::Protect(pro) => pro.refcnt(),
         }
     }
 }

--- a/zebra-rs/src/rib/nexthop/inst.rs
+++ b/zebra-rs/src/rib/nexthop/inst.rs
@@ -188,6 +188,15 @@ impl NexthopMember {
 pub struct NexthopProtect {
     pub primary: NexthopMember,
     pub backup: NexthopMember,
+
+    // Kernel id of the protection indirection group (a 1-member
+    // NHA_GROUP holding the primary) that protected routes reference
+    // instead of the member's own gid — the handle the phase-2
+    // switchover swaps. 0 = no indirection: producers always emit 0
+    // and the resolver allocates one only for a Uni primary (groups
+    // can't nest, so a Multi primary's ECMP group is itself the
+    // switch point). See docs/design/nexthop-protect-kernel-failover.md.
+    pub gid: usize,
 }
 
 impl NexthopProtect {
@@ -329,6 +338,7 @@ mod tests {
         let pro = NexthopProtect {
             primary: NexthopMember::Multi(multi),
             backup: NexthopMember::Uni(mk_uni("10.0.0.5", 21)),
+            gid: 0,
         };
         let addrs: Vec<_> = pro.iter_unis().map(|u| u.addr.to_string()).collect();
         assert_eq!(addrs, vec!["10.0.0.1", "10.0.0.2", "10.0.0.5"]);
@@ -339,6 +349,7 @@ mod tests {
         let pro = NexthopProtect {
             primary: NexthopMember::Uni(mk_uni("10.0.0.1", 20)),
             backup: NexthopMember::Uni(mk_uni("10.0.0.5", 21)),
+            gid: 0,
         };
         let roles: Vec<bool> = pro.roles().iter().map(|(_, b)| *b).collect();
         assert_eq!(roles, vec![false, true]);

--- a/zebra-rs/src/rib/nexthop/map.rs
+++ b/zebra-rs/src/rib/nexthop/map.rs
@@ -7,7 +7,7 @@ use isis_packet::srv6::EncapType;
 
 use crate::fib::FibHandle;
 
-use super::{Group, GroupMulti, GroupTrait, GroupUni, NexthopUni};
+use super::{Group, GroupMulti, GroupProtect, GroupTrait, GroupUni, NexthopUni};
 
 // Dedupe key for SRv6-encapsulated nexthops. Two NexthopUnis with the same
 // outer destination, segment list, and endpoint behavior share one entry —
@@ -26,6 +26,10 @@ pub struct NexthopMap {
     mpls: BTreeMap<(IpAddr, Vec<u32>), usize>,
     seg6: BTreeMap<Seg6Key, usize>,
     seg6local: BTreeMap<Seg6LocalKey, usize>,
+    // Dedupe key for protection indirection groups: (primary gid,
+    // backup gid). Two prefixes sharing a primary but with different
+    // repairs get distinct groups so each switches to its own repair.
+    protect: BTreeMap<(usize, usize), usize>,
     pub groups: Vec<Option<Group>>,
 }
 
@@ -43,6 +47,7 @@ impl Default for NexthopMap {
             mpls: BTreeMap::new(),
             seg6: BTreeMap::new(),
             seg6local: BTreeMap::new(),
+            protect: BTreeMap::new(),
             groups: Vec::new(),
         };
         nmap.groups.push(None);
@@ -190,6 +195,32 @@ impl NexthopMap {
         }
     }
 
+    /// Fetch (or create) the protection indirection group for a
+    /// (primary, backup) member pair. Protected routes reference this
+    /// gid; phase 2's switchover replaces its membership in place.
+    pub fn fetch_protect(&mut self, primary_gid: usize, backup_gid: usize) -> Option<&mut Group> {
+        let key = (primary_gid, backup_gid);
+        if let Some(&gid) = self.protect.get(&key) {
+            let entry = self.groups.get_mut(gid)?;
+            if entry.is_none() {
+                *entry = Some(Group::Protect(GroupProtect::new(
+                    gid,
+                    primary_gid,
+                    backup_gid,
+                )));
+            }
+            return self.get_mut(gid);
+        }
+
+        let gid = self.new_gid();
+        let group = Group::Protect(GroupProtect::new(gid, primary_gid, backup_gid));
+
+        self.protect.insert(key, gid);
+        self.groups.push(Some(group));
+
+        self.get_mut(gid)
+    }
+
     pub fn fetch_multi(&mut self, set: &BTreeSet<(usize, u8)>) -> Option<&mut Group> {
         let gid = if let Some(&gid) = self.set.get(set) {
             let update = self.groups.get_mut(gid)?;
@@ -213,6 +244,17 @@ impl NexthopMap {
     }
 
     pub async fn shutdown(&mut self, fib: &FibHandle) {
+        // Indirection groups first — a group must leave the kernel
+        // before its members so member deletion can't cascade-empty
+        // it behind our back.
+        for (_, id) in self.protect.iter() {
+            let entry = self.get(*id);
+            if let Some(grp) = entry
+                && grp.is_installed()
+            {
+                fib.nexthop_del(grp).await;
+            }
+        }
         for (_, id) in self.set.iter() {
             let entry = self.get(*id);
             if let Some(grp) = entry
@@ -281,6 +323,7 @@ mod tests {
         match grp {
             Group::Uni(uni) => uni.gid(),
             Group::Multi(multi) => multi.gid(),
+            Group::Protect(pro) => pro.gid(),
         }
     }
 

--- a/zebra-rs/src/rib/nexthop/show.rs
+++ b/zebra-rs/src/rib/nexthop/show.rs
@@ -59,6 +59,20 @@ pub fn nexthop_show(rib: &Rib, _args: Args, _json: bool) -> String {
                     }
                 }
             }
+            Group::Protect(pro) => {
+                // Indirection group for a protected primary: the
+                // member list is the primary; the backup is what the
+                // switchover would swap in.
+                for (role, gid) in [("primary", pro.primary_gid), ("backup", pro.backup_gid)] {
+                    if let Some(Group::Uni(uni)) = rib.nmap.get(gid) {
+                        write!(buf, "  {} [{}] ", role, gid).unwrap();
+                        write_via(&mut buf, uni);
+                        writeln!(buf, ", {}", rib.link_name(uni.ifindex().unwrap_or(0))).unwrap();
+                    } else {
+                        writeln!(buf, "  {} [{}]", role, gid).unwrap();
+                    }
+                }
+            }
         }
     }
     buf

--- a/zebra-rs/src/rib/route.rs
+++ b/zebra-rs/src/rib/route.rs
@@ -13,8 +13,8 @@ use super::inst::{IlmEntry, RT_TABLE_MAIN, Rib};
 use super::nexthop::NexthopUni;
 use super::tracing::{rib_interface, rib_nexthop, rib_route};
 use super::{
-    Group, GroupTrait, Message, NexthopList, NexthopMap, NexthopMember, NexthopMulti, RibEntries,
-    RibType,
+    Group, GroupTrait, Message, NexthopList, NexthopMap, NexthopMember, NexthopMulti,
+    NexthopProtect, RibEntries, RibType,
 };
 
 /// Hold-down policy for kernel-driven address recovery.
@@ -1185,6 +1185,41 @@ pub async fn ipv4_nexthop_sync(
             }
         }
     }
+
+    protect_groups_sync(nmap, fib).await;
+}
+
+/// Re-derive each protection indirection group's validity from its
+/// primary member and (re)install on the valid transition. Family-
+/// agnostic, but called from BOTH the v4 and v6 nexthop syncs: the v4
+/// pass runs before v6 Uni groups revalidate, so a v6-primaried
+/// protect group synced only there would lag a cycle behind.
+async fn protect_groups_sync(nmap: &mut NexthopMap, fib: &FibHandle) {
+    let mut cache: Vec<(usize, bool)> = Vec::new();
+    for (idx, nhop) in nmap.groups.iter().enumerate() {
+        if let Some(Group::Protect(pro)) = nhop {
+            let valid = nmap.get(pro.primary_gid).is_some_and(|g| g.is_valid());
+            cache.push((idx, valid));
+        }
+    }
+    for (idx, valid) in cache {
+        if let Some(Some(Group::Protect(pro))) = nmap.groups.get_mut(idx) {
+            if valid {
+                pro.set_valid(true);
+                if !pro.is_installed() {
+                    fib.nexthop_add(&Group::Protect(pro.clone())).await;
+                    pro.set_installed(true);
+                }
+            } else {
+                // The member died (link down) — the kernel flushed it,
+                // the emptied group, and the routes referencing it
+                // (probe 4 in the design doc); sync our view so the
+                // next valid transition re-creates the object.
+                pro.set_valid(false);
+                pro.set_installed(false);
+            }
+        }
+    }
 }
 
 /// Per-prefix selected-entry transition produced by a sync pass:
@@ -1346,7 +1381,7 @@ fn nexthop_force_reinstall(nexthop: &Nexthop, nmap: &mut NexthopMap) {
         if let Some(group) = nmap.get_mut(gid) {
             match group {
                 Group::Uni(_) => group.set_installed(false),
-                Group::Multi(_) => {
+                Group::Multi(_) | Group::Protect(_) => {
                     group.set_valid(false);
                     group.set_installed(false);
                 }
@@ -1367,6 +1402,7 @@ fn nexthop_force_reinstall(nexthop: &Nexthop, nmap: &mut NexthopMap) {
             }
         }
         Nexthop::Protect(pro) => {
+            force(nmap, pro.gid);
             for member in pro.members() {
                 member_force_reinstall(member, nmap);
             }
@@ -1547,9 +1583,38 @@ fn rib_resolve_nexthop(
         for member in pro.members_mut() {
             resolve_nexthop_member(member, nmap, table, table_id);
         }
+        resolve_nexthop_protect(pro, nmap);
     }
     // If one of nexthop is valid, the entry is valid.
     entry.set_valid(entry.is_valid_nexthop(nmap));
+}
+
+/// Allocate (or refetch) the kernel indirection group for a protected
+/// primary and stamp its id into `pro.gid`. Only a Uni primary gets
+/// one — kernel groups can't nest, so a Multi primary's ECMP group is
+/// itself the future switch point and `pro.gid` stays 0 (routes then
+/// reference the member gids directly, exactly as before phase 1).
+fn resolve_nexthop_protect(pro: &mut NexthopProtect, nmap: &mut NexthopMap) {
+    let NexthopMember::Uni(primary) = &pro.primary else {
+        return;
+    };
+    if primary.gid == 0 {
+        return;
+    }
+    let backup_gid = match &pro.backup {
+        NexthopMember::Uni(u) => u.gid,
+        NexthopMember::Multi(m) => m.gid,
+    };
+    let primary_gid = primary.gid;
+    // The indirection group is installable exactly when its sole
+    // member is — the sync passes keep this in step afterwards.
+    let primary_valid = nmap.get(primary_gid).is_some_and(|g| g.is_valid());
+    let Some(group) = nmap.fetch_protect(primary_gid, backup_gid) else {
+        return;
+    };
+    group.set_valid(primary_valid);
+    group.refcnt_inc();
+    pro.gid = group.gid();
 }
 
 fn resolve_nexthop_member(
@@ -2075,6 +2140,7 @@ fn rib_resolve_nexthop_v6(
         for member in pro.members_mut() {
             resolve_nexthop_member_v6(member, nmap, table, table_id);
         }
+        resolve_nexthop_protect(pro, nmap);
     }
     // If one of nexthop is valid, the entry is valid.
     entry.set_valid(entry.is_valid_nexthop(nmap));
@@ -2242,6 +2308,8 @@ pub async fn ipv6_nexthop_sync(
             }
         }
     }
+    protect_groups_sync(nmap, fib).await;
+
     if rib_nexthop() {
         println!("[ipv6_nexthop_sync] done");
     }
@@ -2517,6 +2585,7 @@ mod tests {
         entry.nexthop = Nexthop::Protect(NexthopProtect {
             primary: NexthopMember::Multi(multi),
             backup: NexthopMember::Uni(backup),
+            gid: 0,
         });
 
         let mut nmap = NexthopMap::default();
@@ -2540,6 +2609,107 @@ mod tests {
             panic!("backup Uni preserved");
         };
         assert!(backup_uni.gid != 0, "backup Uni gets its own group");
+    }
+
+    /// Phase 1 of the kernel-failover design: a Uni primary gets a
+    /// protection indirection group allocated and stamped into
+    /// `pro.gid`; the same (primary, backup) pair on a second entry
+    /// dedupes onto the same gid (that sharing is what makes the
+    /// phase-2 switchover O(1) in prefixes).
+    #[test]
+    fn protect_uni_primary_allocates_indirection_group() {
+        use super::super::entry::RibEntry;
+        use super::super::nexthop::{GroupTrait, NexthopProtect, NexthopUni};
+        use super::super::{Group, Nexthop, NexthopMap, NexthopMember};
+        use super::super::{RibEntries, RibType};
+        use super::rib_resolve_nexthop;
+        use ipnet::Ipv4Net;
+        use prefix_trie::PrefixMap;
+
+        let mk_entry = || {
+            let mut primary = NexthopUni::new("10.0.0.1".parse().unwrap(), 20, vec![]);
+            primary.ifindex_origin = Some(10);
+            let mut backup = NexthopUni::new("10.0.0.5".parse().unwrap(), 21, vec![]);
+            backup.ifindex_origin = Some(20);
+            let mut entry = RibEntry::new(RibType::Isis);
+            entry.nexthop = Nexthop::Protect(NexthopProtect {
+                primary: NexthopMember::Uni(primary),
+                backup: NexthopMember::Uni(backup),
+                gid: 0,
+            });
+            entry
+        };
+
+        let mut nmap = NexthopMap::default();
+        let table: PrefixMap<Ipv4Net, RibEntries> = PrefixMap::new();
+
+        let mut entry_a = mk_entry();
+        rib_resolve_nexthop(&mut entry_a, &table, &mut nmap, 0);
+        let Nexthop::Protect(pro_a) = &entry_a.nexthop else {
+            panic!("still Protect");
+        };
+        assert_ne!(pro_a.gid, 0, "Uni primary must get an indirection group");
+
+        let Some(Group::Protect(grp)) = nmap.get(pro_a.gid) else {
+            panic!("Group::Protect allocated in nmap");
+        };
+        let (NexthopMember::Uni(p), NexthopMember::Uni(b)) = (&pro_a.primary, &pro_a.backup) else {
+            panic!("members stay Uni");
+        };
+        assert_eq!(grp.primary_gid, p.gid);
+        assert_eq!(grp.backup_gid, b.gid);
+        // ifindex_origin pinned both members valid, so the wrapper is
+        // installable straight away.
+        assert!(grp.is_valid());
+
+        // Second entry with the same pair: same indirection gid.
+        let mut entry_b = mk_entry();
+        rib_resolve_nexthop(&mut entry_b, &table, &mut nmap, 0);
+        let Nexthop::Protect(pro_b) = &entry_b.nexthop else {
+            panic!("still Protect");
+        };
+        assert_eq!(pro_a.gid, pro_b.gid, "same (primary, backup) pair dedupes");
+        assert_eq!(nmap.get(pro_b.gid).unwrap().refcnt(), 2);
+    }
+
+    /// The nesting constraint: a Multi (ECMP) primary gets NO
+    /// indirection group — its own ECMP group is the future switch
+    /// point — so `pro.gid` stays 0 and routes reference member gids
+    /// exactly as before phase 1.
+    #[test]
+    fn protect_multi_primary_gets_no_indirection_group() {
+        use super::super::entry::RibEntry;
+        use super::super::nexthop::{NexthopProtect, NexthopUni};
+        use super::super::{Nexthop, NexthopMap, NexthopMember, NexthopMulti};
+        use super::super::{RibEntries, RibType};
+        use super::rib_resolve_nexthop;
+        use ipnet::Ipv4Net;
+        use prefix_trie::PrefixMap;
+
+        let leg_a = NexthopUni::new("10.0.0.1".parse().unwrap(), 20, vec![]);
+        let leg_b = NexthopUni::new("10.0.0.2".parse().unwrap(), 20, vec![]);
+        let multi = NexthopMulti {
+            metric: 20,
+            nexthops: vec![leg_a, leg_b],
+            ..Default::default()
+        };
+        let backup = NexthopUni::new("10.0.0.5".parse().unwrap(), 21, vec![]);
+
+        let mut entry = RibEntry::new(RibType::Isis);
+        entry.nexthop = Nexthop::Protect(NexthopProtect {
+            primary: NexthopMember::Multi(multi),
+            backup: NexthopMember::Uni(backup),
+            gid: 0,
+        });
+
+        let mut nmap = NexthopMap::default();
+        let table: PrefixMap<Ipv4Net, RibEntries> = PrefixMap::new();
+        rib_resolve_nexthop(&mut entry, &table, &mut nmap, 0);
+
+        let Nexthop::Protect(pro) = &entry.nexthop else {
+            panic!("still Protect");
+        };
+        assert_eq!(pro.gid, 0, "Multi primary: ECMP group is the switch point");
     }
 
     /// Regression: the v6 resolver was missing the `Protect` block
@@ -2570,6 +2740,7 @@ mod tests {
         entry.nexthop = Nexthop::Protect(NexthopProtect {
             primary: NexthopMember::Multi(multi),
             backup: NexthopMember::Uni(backup),
+            gid: 0,
         });
 
         let mut nmap = NexthopMap::default();

--- a/zebra-rs/src/rib/route.rs
+++ b/zebra-rs/src/rib/route.rs
@@ -1601,6 +1601,18 @@ fn resolve_nexthop_protect(pro: &mut NexthopProtect, nmap: &mut NexthopMap) {
     if primary.gid == 0 {
         return;
     }
+    // Kernel 6.8 silently DROPS traffic when a seg6-inline-lwtunnel
+    // nexthop sits inside a group: object creation, grouping, route
+    // install, and `ip route get` all succeed, but the dataplane
+    // never transmits (verified 2026-06-12 in netns; direct member
+    // reference forwards fine, and BDD tilfa_srv6 backup-as-primary
+    // black-holed through the wrapper). SRv6 repairs are inline by
+    // default, so SRv6-encap'd primaries keep the direct member
+    // reference — plain and MPLS-encap'd primaries (group forwarding
+    // BDD- and probe-verified) get the indirection.
+    if !primary.segs.is_empty() {
+        return;
+    }
     let backup_gid = match &pro.backup {
         NexthopMember::Uni(u) => u.gid,
         NexthopMember::Multi(m) => m.gid,
@@ -2670,6 +2682,54 @@ mod tests {
         };
         assert_eq!(pro_a.gid, pro_b.gid, "same (primary, backup) pair dedupes");
         assert_eq!(nmap.get(pro_b.gid).unwrap().refcnt(), 2);
+    }
+
+    /// Kernel 6.8 drops seg6-inline traffic routed through a nexthop
+    /// group (the object/route install succeeds — only the dataplane
+    /// black-holes), so an SRv6-encap'd primary must keep its direct
+    /// member reference: `pro.gid` stays 0. Caught live by the
+    /// `@tilfa_srv6` backup-as-primary scenario.
+    #[test]
+    fn protect_srv6_primary_gets_no_indirection_group() {
+        use super::super::entry::RibEntry;
+        use super::super::nexthop::{NexthopProtect, NexthopUni};
+        use super::super::{Nexthop, NexthopMap, NexthopMember};
+        use super::super::{RibEntries, RibType};
+        use super::rib_resolve_nexthop_v6;
+        use ipnet::Ipv6Net;
+        use prefix_trie::PrefixMap;
+
+        // Repair promoted to primary (backup-as-primary): inline SRH
+        // via the repair neighbor.
+        let mut primary = NexthopUni::new("2001:db8:0:2::2".parse().unwrap(), 12, vec![]);
+        primary.ifindex_origin = Some(10);
+        primary.segs = vec!["fcbb:bbbb:8::".parse().unwrap()];
+        primary.encap_type = Some(isis_packet::srv6::EncapType::HInsert);
+        let mut backup = NexthopUni::new("2001:db8:0:1::2".parse().unwrap(), 13, vec![]);
+        backup.ifindex_origin = Some(20);
+
+        let mut entry = RibEntry::new(RibType::Isis);
+        entry.nexthop = Nexthop::Protect(NexthopProtect {
+            primary: NexthopMember::Uni(primary),
+            backup: NexthopMember::Uni(backup),
+            gid: 0,
+        });
+
+        let mut nmap = NexthopMap::default();
+        let table: PrefixMap<Ipv6Net, RibEntries> = PrefixMap::new();
+        rib_resolve_nexthop_v6(&mut entry, &table, &mut nmap, 0);
+
+        let Nexthop::Protect(pro) = &entry.nexthop else {
+            panic!("still Protect");
+        };
+        let NexthopMember::Uni(p) = &pro.primary else {
+            panic!("primary stays Uni");
+        };
+        assert_ne!(p.gid, 0, "the seg6 member itself still gets its group");
+        assert_eq!(
+            pro.gid, 0,
+            "SRv6 primary must NOT be wrapped in an indirection group"
+        );
     }
 
     /// The nesting constraint: a Multi (ECMP) primary gets NO

--- a/zebra-rs/src/rib/route.rs
+++ b/zebra-rs/src/rib/route.rs
@@ -2851,6 +2851,7 @@ mod tests {
         entry.nexthop = Nexthop::Protect(NexthopProtect {
             primary: NexthopMember::Uni(primary),
             backup: NexthopMember::Uni(backup),
+            gid: 0,
         });
 
         let mut nmap = NexthopMap::default();


### PR DESCRIPTION
## Summary

First slice of `docs/design/nexthop-protect-kernel-failover.md` (committed here, with the kernel probe results from 6.8.0-124 baked in): a Uni-primary `Nexthop::Protect` now allocates a **protection indirection group** — a 1-member kernel `NHA_GROUP` holding the primary — and the protected route references its gid instead of the member's own.

Behavior-neutral by design:
- the kernel forwards identically through the group;
- link-down autonomy is unchanged — member flush empties the group, the kernel deletes it and the primary route, the `metric+1` shadow route forwards (probe 4);
- on `use_nhid == false` kernels nothing changes at all.

The gid is the handle phase 2's atomic membership swap (`RTM_NEWNEXTHOP` + `NLM_F_REPLACE`) will use to move every protected prefix onto its repair in one message per failed adjacency — O(1) in prefixes.

## Changes

- `NexthopProtect.gid` + `resolve_nexthop_protect` in both family resolvers, keyed `(primary_gid, backup_gid)` so each pair switches to its own repair. Multi primaries keep `gid = 0`: kernel groups can't nest, so their ECMP group is itself the future switch point.
- `Group::Protect` + `NexthopMap::fetch_protect` dedup; install-after-members / delete-before-members ordering (`nexthop_sync` / `nexthop_unsync` / `shutdown`); `protect_groups_sync` revalidates from the primary member in **both** family sync passes (the v4 pass runs before v6 Uni revalidation); `nexthop_force_reinstall` integration for the kernel-deleted-object self-heal.
- FIB: `NHA_GROUP` install arm (same encoding as Multi, single member), `protect_primary_nexthop` gid override on the primary route add/del, trace + `show nexthop` output.

## Testing

- `cargo test --workspace --exclude bdd` green (1123 in zebra-rs); new tests: indirection allocation + (primary, backup) dedup + refcnt, Multi-primary keeps gid 0, plus the existing v4/v6 Protect resolution regressions.
- `cargo clippy --workspace --all-targets -- -D warnings` clean, `cargo fmt` applied.
- **Pending: local BDD TI-LFA suite** (`@isis_tilfa`, `@isis_tilfa_srv6*`, `@ospfv2_tilfa`, `@ospfv3_tilfa`) — the box currently has a live `srv6_tilfa_v3` topology, so the shared `/usr/bin/zebra-rs` can't be reinstalled yet. Will run before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)