### PR TITLE
ospfv3: SRv6 TI-LFA repairs with shared carrier compression

### DIFF
--- a/bdd/tests/configs/classic_tilfa_v3/d.yaml
+++ b/bdd/tests/configs/classic_tilfa_v3/d.yaml
@@ -1,0 +1,37 @@
+# Classic-SID sibling of configs/srv6_tilfa_v3: the locator omits
+# `behavior: usid`, so SIDs use the RFC 8986 full-SID layout.
+interface:
+- if-name: lo
+  ipv6:
+    address: 2001:db8::8/128
+- if-name: d-n1
+  ipv6:
+    address: 2001:db8:10::2/64
+- if-name: d-r3
+  ipv6:
+    address: 2001:db8:11::2/64
+segment-routing:
+  locator:
+  - name: LOC8
+    prefix: fcbb:bbbb:8::/48
+router:
+  ospfv3:
+    router-id: 10.0.0.8
+    segment-routing:
+      srv6:
+        locator: LOC8
+    fast-reroute:
+      ti-lfa: {}
+    area:
+    - area-id: 0.0.0.0
+      interface:
+      - if-name: lo
+        enable: true
+      - if-name: d-n1
+        enable: true
+        network-type: point-to-point
+        cost: 1
+      - if-name: d-r3
+        enable: true
+        network-type: point-to-point
+        cost: 1

--- a/bdd/tests/configs/classic_tilfa_v3/n1.yaml
+++ b/bdd/tests/configs/classic_tilfa_v3/n1.yaml
@@ -1,0 +1,51 @@
+# Classic-SID sibling of configs/srv6_tilfa_v3: the locator omits
+# `behavior: usid`, so SIDs use the RFC 8986 full-SID layout.
+interface:
+- if-name: lo
+  ipv6:
+    address: 2001:db8::2/128
+- if-name: n1-s
+  ipv6:
+    address: 2001:db8:1::2/64
+- if-name: n1-r1
+  ipv6:
+    address: 2001:db8:4::1/64
+- if-name: n1-r2
+  ipv6:
+    address: 2001:db8:7::1/64
+- if-name: n1-d
+  ipv6:
+    address: 2001:db8:10::1/64
+segment-routing:
+  locator:
+  - name: LOC2
+    prefix: fcbb:bbbb:2::/48
+router:
+  ospfv3:
+    router-id: 10.0.0.2
+    segment-routing:
+      srv6:
+        locator: LOC2
+    fast-reroute:
+      ti-lfa: {}
+    area:
+    - area-id: 0.0.0.0
+      interface:
+      - if-name: lo
+        enable: true
+      - if-name: n1-s
+        enable: true
+        network-type: point-to-point
+        cost: 1
+      - if-name: n1-r1
+        enable: true
+        network-type: point-to-point
+        cost: 1
+      - if-name: n1-r2
+        enable: true
+        network-type: point-to-point
+        cost: 1
+      - if-name: n1-d
+        enable: true
+        network-type: point-to-point
+        cost: 1

--- a/bdd/tests/configs/classic_tilfa_v3/n2.yaml
+++ b/bdd/tests/configs/classic_tilfa_v3/n2.yaml
@@ -1,0 +1,37 @@
+# Classic-SID sibling of configs/srv6_tilfa_v3: the locator omits
+# `behavior: usid`, so SIDs use the RFC 8986 full-SID layout.
+interface:
+- if-name: lo
+  ipv6:
+    address: 2001:db8::3/128
+- if-name: n2-s
+  ipv6:
+    address: 2001:db8:2::2/64
+- if-name: n2-r1
+  ipv6:
+    address: 2001:db8:5::1/64
+segment-routing:
+  locator:
+  - name: LOC3
+    prefix: fcbb:bbbb:3::/48
+router:
+  ospfv3:
+    router-id: 10.0.0.3
+    segment-routing:
+      srv6:
+        locator: LOC3
+    fast-reroute:
+      ti-lfa: {}
+    area:
+    - area-id: 0.0.0.0
+      interface:
+      - if-name: lo
+        enable: true
+      - if-name: n2-s
+        enable: true
+        network-type: point-to-point
+        cost: 1
+      - if-name: n2-r1
+        enable: true
+        network-type: point-to-point
+        cost: 1

--- a/bdd/tests/configs/classic_tilfa_v3/n3.yaml
+++ b/bdd/tests/configs/classic_tilfa_v3/n3.yaml
@@ -1,0 +1,37 @@
+# Classic-SID sibling of configs/srv6_tilfa_v3: the locator omits
+# `behavior: usid`, so SIDs use the RFC 8986 full-SID layout.
+interface:
+- if-name: lo
+  ipv6:
+    address: 2001:db8::4/128
+- if-name: n3-s
+  ipv6:
+    address: 2001:db8:3::2/64
+- if-name: n3-r1
+  ipv6:
+    address: 2001:db8:6::1/64
+segment-routing:
+  locator:
+  - name: LOC4
+    prefix: fcbb:bbbb:4::/48
+router:
+  ospfv3:
+    router-id: 10.0.0.4
+    segment-routing:
+      srv6:
+        locator: LOC4
+    fast-reroute:
+      ti-lfa: {}
+    area:
+    - area-id: 0.0.0.0
+      interface:
+      - if-name: lo
+        enable: true
+      - if-name: n3-s
+        enable: true
+        network-type: point-to-point
+        cost: 1000
+      - if-name: n3-r1
+        enable: true
+        network-type: point-to-point
+        cost: 1000

--- a/bdd/tests/configs/classic_tilfa_v3/r1.yaml
+++ b/bdd/tests/configs/classic_tilfa_v3/r1.yaml
@@ -1,0 +1,51 @@
+# Classic-SID sibling of configs/srv6_tilfa_v3: the locator omits
+# `behavior: usid`, so SIDs use the RFC 8986 full-SID layout.
+interface:
+- if-name: lo
+  ipv6:
+    address: 2001:db8::5/128
+- if-name: r1-n1
+  ipv6:
+    address: 2001:db8:4::2/64
+- if-name: r1-n2
+  ipv6:
+    address: 2001:db8:5::2/64
+- if-name: r1-n3
+  ipv6:
+    address: 2001:db8:6::2/64
+- if-name: r1-r2
+  ipv6:
+    address: 2001:db8:8::1/64
+segment-routing:
+  locator:
+  - name: LOC5
+    prefix: fcbb:bbbb:5::/48
+router:
+  ospfv3:
+    router-id: 10.0.0.5
+    segment-routing:
+      srv6:
+        locator: LOC5
+    fast-reroute:
+      ti-lfa: {}
+    area:
+    - area-id: 0.0.0.0
+      interface:
+      - if-name: lo
+        enable: true
+      - if-name: r1-n1
+        enable: true
+        network-type: point-to-point
+        cost: 1
+      - if-name: r1-n2
+        enable: true
+        network-type: point-to-point
+        cost: 1
+      - if-name: r1-n3
+        enable: true
+        network-type: point-to-point
+        cost: 1000
+      - if-name: r1-r2
+        enable: true
+        network-type: point-to-point
+        cost: 1000

--- a/bdd/tests/configs/classic_tilfa_v3/r2.yaml
+++ b/bdd/tests/configs/classic_tilfa_v3/r2.yaml
@@ -1,0 +1,44 @@
+# Classic-SID sibling of configs/srv6_tilfa_v3: the locator omits
+# `behavior: usid`, so SIDs use the RFC 8986 full-SID layout.
+interface:
+- if-name: lo
+  ipv6:
+    address: 2001:db8::6/128
+- if-name: r2-n1
+  ipv6:
+    address: 2001:db8:7::2/64
+- if-name: r2-r1
+  ipv6:
+    address: 2001:db8:8::2/64
+- if-name: r2-r3
+  ipv6:
+    address: 2001:db8:9::1/64
+segment-routing:
+  locator:
+  - name: LOC6
+    prefix: fcbb:bbbb:6::/48
+router:
+  ospfv3:
+    router-id: 10.0.0.6
+    segment-routing:
+      srv6:
+        locator: LOC6
+    fast-reroute:
+      ti-lfa: {}
+    area:
+    - area-id: 0.0.0.0
+      interface:
+      - if-name: lo
+        enable: true
+      - if-name: r2-n1
+        enable: true
+        network-type: point-to-point
+        cost: 1
+      - if-name: r2-r1
+        enable: true
+        network-type: point-to-point
+        cost: 1000
+      - if-name: r2-r3
+        enable: true
+        network-type: point-to-point
+        cost: 1000

--- a/bdd/tests/configs/classic_tilfa_v3/r3.yaml
+++ b/bdd/tests/configs/classic_tilfa_v3/r3.yaml
@@ -1,0 +1,37 @@
+# Classic-SID sibling of configs/srv6_tilfa_v3: the locator omits
+# `behavior: usid`, so SIDs use the RFC 8986 full-SID layout.
+interface:
+- if-name: lo
+  ipv6:
+    address: 2001:db8::7/128
+- if-name: r3-r2
+  ipv6:
+    address: 2001:db8:9::2/64
+- if-name: r3-d
+  ipv6:
+    address: 2001:db8:11::1/64
+segment-routing:
+  locator:
+  - name: LOC7
+    prefix: fcbb:bbbb:7::/48
+router:
+  ospfv3:
+    router-id: 10.0.0.7
+    segment-routing:
+      srv6:
+        locator: LOC7
+    fast-reroute:
+      ti-lfa: {}
+    area:
+    - area-id: 0.0.0.0
+      interface:
+      - if-name: lo
+        enable: true
+      - if-name: r3-r2
+        enable: true
+        network-type: point-to-point
+        cost: 1000
+      - if-name: r3-d
+        enable: true
+        network-type: point-to-point
+        cost: 1

--- a/bdd/tests/configs/classic_tilfa_v3/s.yaml
+++ b/bdd/tests/configs/classic_tilfa_v3/s.yaml
@@ -1,0 +1,44 @@
+# Classic-SID sibling of configs/srv6_tilfa_v3: the locator omits
+# `behavior: usid`, so SIDs use the RFC 8986 full-SID layout.
+interface:
+- if-name: lo
+  ipv6:
+    address: 2001:db8::1/128
+- if-name: s-n1
+  ipv6:
+    address: 2001:db8:1::1/64
+- if-name: s-n2
+  ipv6:
+    address: 2001:db8:2::1/64
+- if-name: s-n3
+  ipv6:
+    address: 2001:db8:3::1/64
+segment-routing:
+  locator:
+  - name: LOC1
+    prefix: fcbb:bbbb:1::/48
+router:
+  ospfv3:
+    router-id: 10.0.0.1
+    segment-routing:
+      srv6:
+        locator: LOC1
+    fast-reroute:
+      ti-lfa: {}
+    area:
+    - area-id: 0.0.0.0
+      interface:
+      - if-name: lo
+        enable: true
+      - if-name: s-n1
+        enable: true
+        network-type: point-to-point
+        cost: 1
+      - if-name: s-n2
+        enable: true
+        network-type: point-to-point
+        cost: 1
+      - if-name: s-n3
+        enable: true
+        network-type: point-to-point
+        cost: 1000

--- a/bdd/tests/configs/srv6_tilfa_v3/d.yaml
+++ b/bdd/tests/configs/srv6_tilfa_v3/d.yaml
@@ -1,0 +1,38 @@
+# d — SRv6 sibling of configs/ospfv3_tilfa: SR-MPLS and
+# Prefix-SIDs replaced by a uSID locator; same costs and topology.
+interface:
+- if-name: lo
+  ipv6:
+    address: 2001:db8::8/128
+- if-name: d-n1
+  ipv6:
+    address: 2001:db8:10::2/64
+- if-name: d-r3
+  ipv6:
+    address: 2001:db8:11::2/64
+segment-routing:
+  locator:
+  - name: LOC8
+    prefix: fcbb:bbbb:8::/48
+    behavior: usid
+router:
+  ospfv3:
+    router-id: 10.0.0.8
+    segment-routing:
+      srv6:
+        locator: LOC8
+    fast-reroute:
+      ti-lfa: {}
+    area:
+    - area-id: 0.0.0.0
+      interface:
+      - if-name: lo
+        enable: true
+      - if-name: d-n1
+        enable: true
+        network-type: point-to-point
+        cost: 1
+      - if-name: d-r3
+        enable: true
+        network-type: point-to-point
+        cost: 1

--- a/bdd/tests/configs/srv6_tilfa_v3/n1.yaml
+++ b/bdd/tests/configs/srv6_tilfa_v3/n1.yaml
@@ -1,0 +1,52 @@
+# n1 — SRv6 sibling of configs/ospfv3_tilfa: SR-MPLS and
+# Prefix-SIDs replaced by a uSID locator; same costs and topology.
+interface:
+- if-name: lo
+  ipv6:
+    address: 2001:db8::2/128
+- if-name: n1-s
+  ipv6:
+    address: 2001:db8:1::2/64
+- if-name: n1-r1
+  ipv6:
+    address: 2001:db8:4::1/64
+- if-name: n1-r2
+  ipv6:
+    address: 2001:db8:7::1/64
+- if-name: n1-d
+  ipv6:
+    address: 2001:db8:10::1/64
+segment-routing:
+  locator:
+  - name: LOC2
+    prefix: fcbb:bbbb:2::/48
+    behavior: usid
+router:
+  ospfv3:
+    router-id: 10.0.0.2
+    segment-routing:
+      srv6:
+        locator: LOC2
+    fast-reroute:
+      ti-lfa: {}
+    area:
+    - area-id: 0.0.0.0
+      interface:
+      - if-name: lo
+        enable: true
+      - if-name: n1-s
+        enable: true
+        network-type: point-to-point
+        cost: 1
+      - if-name: n1-r1
+        enable: true
+        network-type: point-to-point
+        cost: 1
+      - if-name: n1-r2
+        enable: true
+        network-type: point-to-point
+        cost: 1
+      - if-name: n1-d
+        enable: true
+        network-type: point-to-point
+        cost: 1

--- a/bdd/tests/configs/srv6_tilfa_v3/n2.yaml
+++ b/bdd/tests/configs/srv6_tilfa_v3/n2.yaml
@@ -1,0 +1,38 @@
+# n2 — SRv6 sibling of configs/ospfv3_tilfa: SR-MPLS and
+# Prefix-SIDs replaced by a uSID locator; same costs and topology.
+interface:
+- if-name: lo
+  ipv6:
+    address: 2001:db8::3/128
+- if-name: n2-s
+  ipv6:
+    address: 2001:db8:2::2/64
+- if-name: n2-r1
+  ipv6:
+    address: 2001:db8:5::1/64
+segment-routing:
+  locator:
+  - name: LOC3
+    prefix: fcbb:bbbb:3::/48
+    behavior: usid
+router:
+  ospfv3:
+    router-id: 10.0.0.3
+    segment-routing:
+      srv6:
+        locator: LOC3
+    fast-reroute:
+      ti-lfa: {}
+    area:
+    - area-id: 0.0.0.0
+      interface:
+      - if-name: lo
+        enable: true
+      - if-name: n2-s
+        enable: true
+        network-type: point-to-point
+        cost: 1
+      - if-name: n2-r1
+        enable: true
+        network-type: point-to-point
+        cost: 1

--- a/bdd/tests/configs/srv6_tilfa_v3/n3.yaml
+++ b/bdd/tests/configs/srv6_tilfa_v3/n3.yaml
@@ -1,0 +1,38 @@
+# n3 — SRv6 sibling of configs/ospfv3_tilfa: SR-MPLS and
+# Prefix-SIDs replaced by a uSID locator; same costs and topology.
+interface:
+- if-name: lo
+  ipv6:
+    address: 2001:db8::4/128
+- if-name: n3-s
+  ipv6:
+    address: 2001:db8:3::2/64
+- if-name: n3-r1
+  ipv6:
+    address: 2001:db8:6::1/64
+segment-routing:
+  locator:
+  - name: LOC4
+    prefix: fcbb:bbbb:4::/48
+    behavior: usid
+router:
+  ospfv3:
+    router-id: 10.0.0.4
+    segment-routing:
+      srv6:
+        locator: LOC4
+    fast-reroute:
+      ti-lfa: {}
+    area:
+    - area-id: 0.0.0.0
+      interface:
+      - if-name: lo
+        enable: true
+      - if-name: n3-s
+        enable: true
+        network-type: point-to-point
+        cost: 1000
+      - if-name: n3-r1
+        enable: true
+        network-type: point-to-point
+        cost: 1000

--- a/bdd/tests/configs/srv6_tilfa_v3/r1.yaml
+++ b/bdd/tests/configs/srv6_tilfa_v3/r1.yaml
@@ -1,0 +1,52 @@
+# r1 — SRv6 sibling of configs/ospfv3_tilfa: SR-MPLS and
+# Prefix-SIDs replaced by a uSID locator; same costs and topology.
+interface:
+- if-name: lo
+  ipv6:
+    address: 2001:db8::5/128
+- if-name: r1-n1
+  ipv6:
+    address: 2001:db8:4::2/64
+- if-name: r1-n2
+  ipv6:
+    address: 2001:db8:5::2/64
+- if-name: r1-n3
+  ipv6:
+    address: 2001:db8:6::2/64
+- if-name: r1-r2
+  ipv6:
+    address: 2001:db8:8::1/64
+segment-routing:
+  locator:
+  - name: LOC5
+    prefix: fcbb:bbbb:5::/48
+    behavior: usid
+router:
+  ospfv3:
+    router-id: 10.0.0.5
+    segment-routing:
+      srv6:
+        locator: LOC5
+    fast-reroute:
+      ti-lfa: {}
+    area:
+    - area-id: 0.0.0.0
+      interface:
+      - if-name: lo
+        enable: true
+      - if-name: r1-n1
+        enable: true
+        network-type: point-to-point
+        cost: 1
+      - if-name: r1-n2
+        enable: true
+        network-type: point-to-point
+        cost: 1
+      - if-name: r1-n3
+        enable: true
+        network-type: point-to-point
+        cost: 1000
+      - if-name: r1-r2
+        enable: true
+        network-type: point-to-point
+        cost: 1000

--- a/bdd/tests/configs/srv6_tilfa_v3/r2.yaml
+++ b/bdd/tests/configs/srv6_tilfa_v3/r2.yaml
@@ -1,0 +1,45 @@
+# r2 — SRv6 sibling of configs/ospfv3_tilfa: SR-MPLS and
+# Prefix-SIDs replaced by a uSID locator; same costs and topology.
+interface:
+- if-name: lo
+  ipv6:
+    address: 2001:db8::6/128
+- if-name: r2-n1
+  ipv6:
+    address: 2001:db8:7::2/64
+- if-name: r2-r1
+  ipv6:
+    address: 2001:db8:8::2/64
+- if-name: r2-r3
+  ipv6:
+    address: 2001:db8:9::1/64
+segment-routing:
+  locator:
+  - name: LOC6
+    prefix: fcbb:bbbb:6::/48
+    behavior: usid
+router:
+  ospfv3:
+    router-id: 10.0.0.6
+    segment-routing:
+      srv6:
+        locator: LOC6
+    fast-reroute:
+      ti-lfa: {}
+    area:
+    - area-id: 0.0.0.0
+      interface:
+      - if-name: lo
+        enable: true
+      - if-name: r2-n1
+        enable: true
+        network-type: point-to-point
+        cost: 1
+      - if-name: r2-r1
+        enable: true
+        network-type: point-to-point
+        cost: 1000
+      - if-name: r2-r3
+        enable: true
+        network-type: point-to-point
+        cost: 1000

--- a/bdd/tests/configs/srv6_tilfa_v3/r3.yaml
+++ b/bdd/tests/configs/srv6_tilfa_v3/r3.yaml
@@ -1,0 +1,38 @@
+# r3 — SRv6 sibling of configs/ospfv3_tilfa: SR-MPLS and
+# Prefix-SIDs replaced by a uSID locator; same costs and topology.
+interface:
+- if-name: lo
+  ipv6:
+    address: 2001:db8::7/128
+- if-name: r3-r2
+  ipv6:
+    address: 2001:db8:9::2/64
+- if-name: r3-d
+  ipv6:
+    address: 2001:db8:11::1/64
+segment-routing:
+  locator:
+  - name: LOC7
+    prefix: fcbb:bbbb:7::/48
+    behavior: usid
+router:
+  ospfv3:
+    router-id: 10.0.0.7
+    segment-routing:
+      srv6:
+        locator: LOC7
+    fast-reroute:
+      ti-lfa: {}
+    area:
+    - area-id: 0.0.0.0
+      interface:
+      - if-name: lo
+        enable: true
+      - if-name: r3-r2
+        enable: true
+        network-type: point-to-point
+        cost: 1000
+      - if-name: r3-d
+        enable: true
+        network-type: point-to-point
+        cost: 1

--- a/bdd/tests/configs/srv6_tilfa_v3/s.yaml
+++ b/bdd/tests/configs/srv6_tilfa_v3/s.yaml
@@ -1,0 +1,45 @@
+# s — SRv6 sibling of configs/ospfv3_tilfa: SR-MPLS and
+# Prefix-SIDs replaced by a uSID locator; same costs and topology.
+interface:
+- if-name: lo
+  ipv6:
+    address: 2001:db8::1/128
+- if-name: s-n1
+  ipv6:
+    address: 2001:db8:1::1/64
+- if-name: s-n2
+  ipv6:
+    address: 2001:db8:2::1/64
+- if-name: s-n3
+  ipv6:
+    address: 2001:db8:3::1/64
+segment-routing:
+  locator:
+  - name: LOC1
+    prefix: fcbb:bbbb:1::/48
+    behavior: usid
+router:
+  ospfv3:
+    router-id: 10.0.0.1
+    segment-routing:
+      srv6:
+        locator: LOC1
+    fast-reroute:
+      ti-lfa: {}
+    area:
+    - area-id: 0.0.0.0
+      interface:
+      - if-name: lo
+        enable: true
+      - if-name: s-n1
+        enable: true
+        network-type: point-to-point
+        cost: 1
+      - if-name: s-n2
+        enable: true
+        network-type: point-to-point
+        cost: 1
+      - if-name: s-n3
+        enable: true
+        network-type: point-to-point
+        cost: 1000

--- a/bdd/tests/features/ospfv3_tilfa_srv6.feature
+++ b/bdd/tests/features/ospfv3_tilfa_srv6.feature
@@ -1,0 +1,149 @@
+@srv6_tilfa_v3
+Feature: OSPFv3 TI-LFA fast-reroute over SRv6
+  As a network operator
+  I want eight zebra-rs instances running OSPFv3 with SRv6 locators
+  (RFC 9513) and TI-LFA (RFC 9490) to pre-compute a topology-
+  independent repair for the source's primary path as an SRv6 SID
+  list — End/uN of the P-node plus uA hops, NEXT-C-SID-compressed and
+  SRH-inserted — so that when the primary link fails the source still
+  reaches the destination.
+
+  Phases 5+6 of `docs/design/ospfv3-srv6-plan.md`: the OSPFv3 sibling
+  of `isis_tilfa_srv6.feature` (same eight-router RFC 9855 §5
+  topology and metrics as `ospfv3_tilfa.feature`, with the SR-MPLS
+  machinery replaced by uSID locators fcbb:bbbb:X::/48). Repairs ride
+  the carriers validated for IS-IS in #1364, the End.X kernel entries
+  carry neighbor-global nexthops per #1361, and the promoted-backup
+  scenario proves the repair dataplane genuinely forwards — the
+  coverage rule every TI-LFA feature carries since #1361.
+
+  Test Topology (cost shown where != 1; loopback 2001:db8::X /
+  locator fcbb:bbbb:X::/48 / router-id 10.0.0.X):
+  ```
+                 s (2001:db8::1)
+             1 / 1 \      \ 1000
+              n1    n2     n3
+          1 / |1 \1  \1     \1000
+       d ─┘ 1 |   \    \      \
+ (2001:db8::8)│    \1000\      \
+          1 \ │     r1───────── (r1-n3 1000)
+             r3    /  \1000
+          1000\   /1   \(r1-r2 1000)
+               r2 ──────┘
+                 \1000
+                  r3 (r3-d 1)
+    s-n1 1  s-n2 1  s-n3 1000   n1-r1 1  n2-r1 1  n3-r1 1000
+    n1-r2 1 r1-r2 1000 r2-r3 1000  n1-d 1  r3-d 1
+  ```
+
+  Scenario: Build the TI-LFA topology and confirm adjacencies + SRv6
+    Given a clean test environment
+    When I create namespace "s"
+    And I create namespace "n1"
+    And I create namespace "n2"
+    And I create namespace "n3"
+    And I create namespace "r1"
+    And I create namespace "r2"
+    And I create namespace "r3"
+    And I create namespace "d"
+    And I connect namespace "s" interface "s-n1" to namespace "n1" interface "n1-s"
+    And I connect namespace "s" interface "s-n2" to namespace "n2" interface "n2-s"
+    And I connect namespace "s" interface "s-n3" to namespace "n3" interface "n3-s"
+    And I connect namespace "n1" interface "n1-r1" to namespace "r1" interface "r1-n1"
+    And I connect namespace "n2" interface "n2-r1" to namespace "r1" interface "r1-n2"
+    And I connect namespace "n3" interface "n3-r1" to namespace "r1" interface "r1-n3"
+    And I connect namespace "n1" interface "n1-r2" to namespace "r2" interface "r2-n1"
+    And I connect namespace "r1" interface "r1-r2" to namespace "r2" interface "r2-r1"
+    And I connect namespace "r2" interface "r2-r3" to namespace "r3" interface "r3-r2"
+    And I connect namespace "n1" interface "n1-d" to namespace "d" interface "d-n1"
+    And I connect namespace "r3" interface "r3-d" to namespace "d" interface "d-r3"
+    And I start zebra-rs in namespace "s"
+    And I start zebra-rs in namespace "n1"
+    And I start zebra-rs in namespace "n2"
+    And I start zebra-rs in namespace "n3"
+    And I start zebra-rs in namespace "r1"
+    And I start zebra-rs in namespace "r2"
+    And I start zebra-rs in namespace "r3"
+    And I start zebra-rs in namespace "d"
+    And I apply config "s.yaml" to namespace "s"
+    And I apply config "n1.yaml" to namespace "n1"
+    And I apply config "n2.yaml" to namespace "n2"
+    And I apply config "n3.yaml" to namespace "n3"
+    And I apply config "r1.yaml" to namespace "r1"
+    And I apply config "r2.yaml" to namespace "r2"
+    And I apply config "r3.yaml" to namespace "r3"
+    And I apply config "d.yaml" to namespace "d"
+    And I wait 30 seconds
+    # Direct adjacency over s-n1, then d's loopback across the area.
+    Then ping from "s" to "2001:db8:1::2" should succeed
+    And ping from "s" to "2001:db8::8" should eventually succeed
+    And ping from "d" to "2001:db8::1" should eventually succeed
+
+  Scenario: SRv6 SIDs exist and a TI-LFA SRv6 repair is installed
+    Given the test topology exists
+    # s owns its uN plus a uA (and its LIB twin) per Full adjacency.
+    Then show command "show segment-routing srv6 sid" in namespace "s" should contain "uN"
+    And show command "show segment-routing srv6 sid" in namespace "s" should contain "uA"
+    And show command "show segment-routing srv6 sid" in namespace "s" should contain "uA(LIB)"
+    # The graph repairs resolved to SRv6 segments, not labels.
+    And show command "show ospfv3 repair-list detail" in namespace "s" should contain "srv6"
+    And show command "show ospfv3 repair-list detail" in namespace "s" should not contain "sr-mpls"
+    And show command "show ospfv3 repair-list" in namespace "s" should contain "2001:db8::8/128"
+    # The s-n1-protected route to d carries the repair as an SRH
+    # insertion in the kernel: the three repair uSIDs (uN of r1 + two
+    # uAs) compress into one carrier, so the inserted SRH is carrier
+    # + original destination = 2 segments.
+    And kernel route "2001:db8::8" in namespace "s" should eventually contain "mode inline"
+    And kernel route "2001:db8::8" in namespace "s" should eventually contain "segs 2 ["
+
+  Scenario: Fast-reroute survives the primary link failure (s-n1)
+    Given the test topology exists
+    Then ping from "s" to "2001:db8::8" should succeed
+    When I make namespace "s" interface "s-n1" down
+    And I wait 5 seconds
+    # Restored over the SRv6 repair / post-convergence path, out a
+    # different interface than the failed s-n1.
+    Then ping from "s" to "2001:db8::8" should succeed
+    When I make namespace "s" interface "s-n1" up
+    And I wait 30 seconds
+    Then ping from "s" to "2001:db8::8" should eventually succeed
+
+  Scenario: Promoted backup actually forwards over the SRv6 repair
+    Given the test topology exists
+    # Pin traffic onto the repair with every link up — the only test
+    # that exercises the SID list itself (by ping time after a real
+    # failure, SPF has already reconverged onto a plain primary).
+    When I apply command "set router ospfv3 fast-reroute backup-as-primary" in namespace "s"
+    And I wait 5 seconds
+    # d's loopback now has the SRH-insert repair as its best kernel
+    # entry, out the repair egress s-n2 at metric 2, demoted plain
+    # primary behind it at 3.
+    Then kernel route "2001:db8::8" in namespace "s" should eventually contain "dev s-n2 proto ospf metric 2"
+    And kernel route "2001:db8::8" in namespace "s" should eventually contain "segs 2 ["
+    # End-to-end over the carrier-encoded repair: dies if any uN/uA
+    # hop (or the LIB twin install) fails to forward.
+    And ping from "s" to "2001:db8::8" should eventually succeed
+    # Restore install-side ordering.
+    When I apply command "delete router ospfv3 fast-reroute backup-as-primary" in namespace "s"
+    And I wait 5 seconds
+    Then ping from "s" to "2001:db8::8" should eventually succeed
+
+  Scenario: Teardown topology
+    Given the test topology exists
+    When I stop zebra-rs in namespace "s"
+    And I stop zebra-rs in namespace "n1"
+    And I stop zebra-rs in namespace "n2"
+    And I stop zebra-rs in namespace "n3"
+    And I stop zebra-rs in namespace "r1"
+    And I stop zebra-rs in namespace "r2"
+    And I stop zebra-rs in namespace "r3"
+    And I stop zebra-rs in namespace "d"
+    And I delete namespace "s"
+    And I delete namespace "n1"
+    And I delete namespace "n2"
+    And I delete namespace "n3"
+    And I delete namespace "r1"
+    And I delete namespace "r2"
+    And I delete namespace "r3"
+    And I delete namespace "d"
+    Then the test environment should be clean

--- a/bdd/tests/features/ospfv3_tilfa_srv6_classic.feature
+++ b/bdd/tests/features/ospfv3_tilfa_srv6_classic.feature
@@ -1,0 +1,147 @@
+@classic_tilfa_v3
+Feature: OSPFv3 TI-LFA fast-reroute over SRv6 classic (full) SIDs
+  As a network operator
+  I want eight zebra-rs instances running OSPFv3 with classic
+  (RFC 8986 full-SID) SRv6 locators and TI-LFA (RFC 9490) to
+  pre-compute a topology-independent repair as an SRv6 SID list, so
+  that when the primary link fails the source still reaches the
+  destination.
+
+  This is the classic-SID sibling of `ospfv3_tilfa_srv6.feature`
+  (same RFC 9855 §5 topology and costs). The only configuration
+  difference is the locator: `behavior usid` is omitted, so SIDs use
+  the classic RFC 8986 full-SID layout. Observable consequences this
+  feature pins:
+  - `show segment-routing srv6 sid` lists `End` / `End.X` — never the
+    micro-SID `uN` / `uA` forms, and no `uA(LIB)` twin rows;
+  - the repair SID list does NOT compress: each segment is a full
+    128-bit SID, so the inserted SRH for the protected route to d is
+    [End(r1), End.X(r1-r2), End.X(r2-r3)] + the original destination
+    = 4 segments, where the uSID sibling carries 2;
+  - everything else is unchanged: H.Insert encap, neighbor-global
+    End.X nexthops, and the promoted-backup forwarding proof.
+
+  Test Topology (cost shown where != 1; loopback 2001:db8::X /
+  locator fcbb:bbbb:X::/48 classic / router-id 10.0.0.X):
+  ```
+                 s (2001:db8::1)
+             1 / 1 \      \ 1000
+              n1    n2     n3
+          1 / |1 \1  \1     \1000
+       d ─┘ 1 |   \    \      \
+ (2001:db8::8)│    \1000\      \
+          1 \ │     r1───────── (r1-n3 1000)
+             r3    /  \1000
+          1000\   /1   \(r1-r2 1000)
+               r2 ──────┘
+                 \1000
+                  r3 (r3-d 1)
+    s-n1 1  s-n2 1  s-n3 1000   n1-r1 1  n2-r1 1  n3-r1 1000
+    n1-r2 1 r1-r2 1000 r2-r3 1000  n1-d 1  r3-d 1
+  ```
+
+  Scenario: Build the classic-SID TI-LFA topology and confirm adjacencies
+    Given a clean test environment
+    When I create namespace "s"
+    And I create namespace "n1"
+    And I create namespace "n2"
+    And I create namespace "n3"
+    And I create namespace "r1"
+    And I create namespace "r2"
+    And I create namespace "r3"
+    And I create namespace "d"
+    And I connect namespace "s" interface "s-n1" to namespace "n1" interface "n1-s"
+    And I connect namespace "s" interface "s-n2" to namespace "n2" interface "n2-s"
+    And I connect namespace "s" interface "s-n3" to namespace "n3" interface "n3-s"
+    And I connect namespace "n1" interface "n1-r1" to namespace "r1" interface "r1-n1"
+    And I connect namespace "n2" interface "n2-r1" to namespace "r1" interface "r1-n2"
+    And I connect namespace "n3" interface "n3-r1" to namespace "r1" interface "r1-n3"
+    And I connect namespace "n1" interface "n1-r2" to namespace "r2" interface "r2-n1"
+    And I connect namespace "r1" interface "r1-r2" to namespace "r2" interface "r2-r1"
+    And I connect namespace "r2" interface "r2-r3" to namespace "r3" interface "r3-r2"
+    And I connect namespace "n1" interface "n1-d" to namespace "d" interface "d-n1"
+    And I connect namespace "r3" interface "r3-d" to namespace "d" interface "d-r3"
+    And I start zebra-rs in namespace "s"
+    And I start zebra-rs in namespace "n1"
+    And I start zebra-rs in namespace "n2"
+    And I start zebra-rs in namespace "n3"
+    And I start zebra-rs in namespace "r1"
+    And I start zebra-rs in namespace "r2"
+    And I start zebra-rs in namespace "r3"
+    And I start zebra-rs in namespace "d"
+    And I apply config "s.yaml" to namespace "s"
+    And I apply config "n1.yaml" to namespace "n1"
+    And I apply config "n2.yaml" to namespace "n2"
+    And I apply config "n3.yaml" to namespace "n3"
+    And I apply config "r1.yaml" to namespace "r1"
+    And I apply config "r2.yaml" to namespace "r2"
+    And I apply config "r3.yaml" to namespace "r3"
+    And I apply config "d.yaml" to namespace "d"
+    And I wait 30 seconds
+    Then ping from "s" to "2001:db8:1::2" should succeed
+    And ping from "s" to "2001:db8::8" should eventually succeed
+    And ping from "d" to "2001:db8::1" should eventually succeed
+
+  Scenario: Classic End/End.X SIDs exist and the repair is uncompressed
+    Given the test topology exists
+    # Classic full SIDs — the show output must say End / End.X, never
+    # the micro-SID uN / uA forms (and no LIB twin rows, which only
+    # uSID locators install).
+    Then show command "show segment-routing srv6 sid" in namespace "s" should contain "End"
+    And show command "show segment-routing srv6 sid" in namespace "s" should contain "End.X"
+    And show command "show segment-routing srv6 sid" in namespace "s" should not contain "uN"
+    And show command "show segment-routing srv6 sid" in namespace "s" should not contain "uA"
+    # Repairs resolved to SRv6 segments.
+    And show command "show ospfv3 repair-list detail" in namespace "s" should contain "srv6"
+    And show command "show ospfv3 repair-list" in namespace "s" should contain "2001:db8::8/128"
+    # No NEXT-C-SID packing for classic behaviors: the repair to d
+    # rides one full 128-bit SID per segment — 3 repair segments plus
+    # the original destination = an SRH of 4 segments (the uSID
+    # sibling compresses the same repair into a single carrier).
+    And kernel route "2001:db8::8" in namespace "s" should eventually contain "mode inline"
+    And kernel route "2001:db8::8" in namespace "s" should eventually contain "segs 4 ["
+
+  Scenario: Fast-reroute survives the primary link failure (s-n1)
+    Given the test topology exists
+    Then ping from "s" to "2001:db8::8" should succeed
+    When I make namespace "s" interface "s-n1" down
+    And I wait 5 seconds
+    Then ping from "s" to "2001:db8::8" should succeed
+    When I make namespace "s" interface "s-n1" up
+    And I wait 30 seconds
+    Then ping from "s" to "2001:db8::8" should eventually succeed
+
+  Scenario: Promoted backup actually forwards over the classic SRv6 repair
+    Given the test topology exists
+    # Pin traffic onto the repair with every link up — proving each
+    # full-SID hop (classic End at r1, classic End.X at r1 and r2,
+    # all installed with neighbor-global nexthops) forwards.
+    When I apply command "set router ospfv3 fast-reroute backup-as-primary" in namespace "s"
+    And I wait 5 seconds
+    Then kernel route "2001:db8::8" in namespace "s" should eventually contain "dev s-n2 proto ospf metric 2"
+    And kernel route "2001:db8::8" in namespace "s" should eventually contain "segs 4 ["
+    And ping from "s" to "2001:db8::8" should eventually succeed
+    # Restore install-side ordering.
+    When I apply command "delete router ospfv3 fast-reroute backup-as-primary" in namespace "s"
+    And I wait 5 seconds
+    Then ping from "s" to "2001:db8::8" should eventually succeed
+
+  Scenario: Teardown topology
+    Given the test topology exists
+    When I stop zebra-rs in namespace "s"
+    And I stop zebra-rs in namespace "n1"
+    And I stop zebra-rs in namespace "n2"
+    And I stop zebra-rs in namespace "n3"
+    And I stop zebra-rs in namespace "r1"
+    And I stop zebra-rs in namespace "r2"
+    And I stop zebra-rs in namespace "r3"
+    And I stop zebra-rs in namespace "d"
+    And I delete namespace "s"
+    And I delete namespace "n1"
+    And I delete namespace "n2"
+    And I delete namespace "n3"
+    And I delete namespace "r1"
+    And I delete namespace "r2"
+    And I delete namespace "r3"
+    And I delete namespace "d"
+    Then the test environment should be clean

--- a/zebra-rs/src/isis/tilfa.rs
+++ b/zebra-rs/src/isis/tilfa.rs
@@ -7,6 +7,7 @@ use isis_packet::{IsisNeighborId, IsisSysId, IsisTlv, SidLabelValue};
 
 use crate::rib;
 use crate::spf;
+use crate::spf::srv6::{CsidBits, RepairSeg, pack_carriers, sid_bits, sid_block};
 
 use super::graph::LspMap;
 use super::inst::IsisTop;
@@ -518,52 +519,6 @@ pub(super) fn tilfa_repair_path(
     tilfa_result
 }
 
-/// One resolved SRv6 repair segment plus the NEXT-C-SID metadata the
-/// carrier packer needs. `sid` is always the full advertised address,
-/// usable verbatim when the segment can't ride in a carrier.
-#[derive(Debug)]
-struct RepairSeg {
-    sid: Ipv6Addr,
-    /// Vertex the packet sits on once this segment is consumed —
-    /// the SID's owner for an End/uN, the adjacency's far end for an
-    /// End.X/uA. Drives the LIB-continuity check below.
-    landing: usize,
-    /// `Some` when the SID was advertised with a NEXT-C-SID behavior
-    /// and a usable structure; `None` forces full-SID encoding.
-    csid: Option<CsidBits>,
-}
-
-/// The bits a segment contributes to a uSID carrier.
-#[derive(Debug, Clone, Copy, PartialEq)]
-struct CsidBits {
-    /// The shared uSID block — the SID's first `lb` bits, masked.
-    block: u128,
-    lb: u8,
-    /// The identifier consumed at the owner: locator-node bits for a
-    /// uN, function bits for a uA. Right-aligned value.
-    id: u128,
-    width: u8,
-    /// For a uA: the vertex that owns the adjacency. A LIB identifier
-    /// is only locally significant, so it may only follow a segment
-    /// that lands the packet on its owner; `None` for a uN, which is
-    /// globally routable via the locator prefix.
-    lib_owner: Option<usize>,
-}
-
-fn sid_bits(sid: Ipv6Addr, start: u32, width: u32) -> u128 {
-    if width == 0 || start + width > 128 {
-        return 0;
-    }
-    (u128::from(sid) >> (128 - start - width)) & ((1u128 << width) - 1)
-}
-
-fn sid_block(sid: Ipv6Addr, lb: u8) -> u128 {
-    if lb == 0 {
-        return 0;
-    }
-    u128::from(sid) & (u128::MAX << (128 - lb as u32))
-}
-
 /// Carrier metadata for a uN: the identifier is the locator-node
 /// portion (bits `[lb, lb+ln)`).
 fn csid_bits_end(info: &super::srv6::Srv6EndSidInfo) -> Option<CsidBits> {
@@ -603,93 +558,6 @@ fn csid_bits_endx(endx: &Srv6EndXInfo, owner: usize) -> Option<CsidBits> {
         width: st.fun_len,
         lib_owner: Some(owner),
     })
-}
-
-/// In-progress uSID carrier: block bits up front, identifiers appended
-/// left-to-right in traversal order, zero-padded tail (the zero
-/// remainder is what triggers each node's end-of-carrier fallback).
-struct Carrier {
-    val: u128,
-    block: u128,
-    lb: u8,
-    /// Next free bit position (starts at `lb`).
-    pos: u32,
-    /// Identifiers packed so far — a single-id carrier is re-emitted
-    /// as the segment's full SID instead (identical forwarding, and it
-    /// doesn't depend on the owner having LIB entries installed).
-    ids: u8,
-    first_sid: Ipv6Addr,
-}
-
-impl Carrier {
-    fn flush(self, out: &mut Vec<Ipv6Addr>) {
-        if self.ids == 1 {
-            out.push(self.first_sid);
-        } else {
-            out.push(Ipv6Addr::from(self.val));
-        }
-    }
-}
-
-/// Pack a resolved SRv6 repair list into NEXT-C-SID carriers (RFC
-/// 9800). Consecutive segments whose SIDs were advertised with uSID
-/// behaviors and a shared locator block collapse into one 128-bit
-/// carrier — block + 16-bit identifiers — instead of one full SID per
-/// SRH segment. Anything that can't ride a carrier (classic behavior,
-/// no structure, zero identifier, block change, LIB continuity break,
-/// carrier full) is emitted as its full SID; mixed lists degrade
-/// per-segment, never wholesale.
-fn pack_carriers(parts: &[RepairSeg]) -> Vec<Ipv6Addr> {
-    let mut out: Vec<Ipv6Addr> = Vec::with_capacity(parts.len());
-    let mut cur: Option<Carrier> = None;
-    let mut prev_landing: Option<usize> = None;
-
-    for part in parts {
-        let packable = part.csid.as_ref().filter(|c| {
-            // A zero identifier would read as end-of-carrier on the
-            // wire; never pack one. LIB (uA) identifiers additionally
-            // require the previous segment to land on their owner —
-            // that holds across carrier boundaries and full-SID
-            // predecessors alike, since either way the packet sits on
-            // the owner when the identifier becomes active.
-            c.id != 0 && c.lib_owner.is_none_or(|owner| prev_landing == Some(owner))
-        });
-        match packable {
-            Some(c) => {
-                let fits = cur.as_ref().is_some_and(|car| {
-                    car.block == c.block && car.lb == c.lb && car.pos + c.width as u32 <= 128
-                });
-                if !fits {
-                    if let Some(car) = cur.take() {
-                        car.flush(&mut out);
-                    }
-                    cur = Some(Carrier {
-                        val: c.block,
-                        block: c.block,
-                        lb: c.lb,
-                        pos: c.lb as u32,
-                        ids: 0,
-                        first_sid: part.sid,
-                    });
-                }
-                let car = cur.as_mut().expect("carrier was just ensured");
-                car.val |= c.id << (128 - car.pos - c.width as u32);
-                car.pos += c.width as u32;
-                car.ids += 1;
-            }
-            None => {
-                if let Some(car) = cur.take() {
-                    car.flush(&mut out);
-                }
-                out.push(part.sid);
-            }
-        }
-        prev_landing = Some(part.landing);
-    }
-    if let Some(car) = cur.take() {
-        car.flush(&mut out);
-    }
-    out
 }
 
 #[cfg(test)]

--- a/zebra-rs/src/ospf/inst.rs
+++ b/zebra-rs/src/ospf/inst.rs
@@ -42,8 +42,7 @@ use super::network::{read_packet, write_packet};
 use super::nfsm::{NfsmEvent, ospf_nfsm};
 use super::socket::ospf_socket_ipv4;
 use super::tilfa::{
-    RepairPathMpls, RepairPathMplsV3, build_repair_path_mpls, build_repair_path_mpls_v3,
-    tilfa_repair_path,
+    RepairPathMpls, build_repair_path_mpls, build_repair_path_mpls_v3, tilfa_repair_path,
 };
 use super::tracing::OspfTracing;
 use super::version::{OspfVersion, Ospfv3};
@@ -9345,7 +9344,7 @@ pub struct SpfNexthopV3 {
     /// TI-LFA second pass; `None` otherwise (ILM/adjacency nexthops,
     /// ECMP, TI-LFA off, or unresolved). v3 sibling of
     /// `SpfNexthop::backup`.
-    pub backup: Option<RepairPathMplsV3>,
+    pub backup: Option<super::tilfa::RepairBackupV3>,
 }
 
 /// v3 sibling of `SpfIlm`. Same role -- one entry in the SR-MPLS
@@ -10911,7 +10910,15 @@ fn build_rib6_from_spf(
             let Some(repair) = tilfa_result.get(&dest).and_then(|paths| paths.first()) else {
                 continue;
             };
-            let Some(backup) = build_repair_path_mpls_v3(top, area, repair) else {
+            // SRv6 repair when the locator is active (RFC 9513 SID
+            // list, H.Insert); SR-MPLS label stack otherwise.
+            let backup = if top.srv6_active() {
+                super::tilfa::build_repair_path_srv6_v3(top, area, repair)
+                    .map(super::tilfa::RepairBackupV3::Srv6)
+            } else {
+                build_repair_path_mpls_v3(top, area, repair).map(super::tilfa::RepairBackupV3::Mpls)
+            };
+            let Some(backup) = backup else {
                 continue;
             };
             if let Some(nhop) = route.nhops.values_mut().next() {
@@ -11290,14 +11297,23 @@ fn nhop_v3_to_nexthop_uni(
 /// A v3 TI-LFA repair as a backup `NexthopUni`: the repair's v6
 /// link-local, the resolved SR-MPLS label stack, and the egress
 /// ifindex, at `metric`. v3 sibling of `backup_to_nexthop_uni`.
-fn backup_v3_to_nexthop_uni(backup: &RepairPathMplsV3, metric: u32) -> rib::NexthopUni {
-    let mut uni = rib::NexthopUni::new(
-        std::net::IpAddr::V6(backup.addr),
-        metric,
-        backup.labels.clone(),
-    );
-    uni.ifindex_origin = (backup.ifindex != 0).then_some(backup.ifindex);
-    uni
+fn backup_v3_to_nexthop_uni(backup: &super::tilfa::RepairBackupV3, metric: u32) -> rib::NexthopUni {
+    use super::tilfa::RepairBackupV3;
+    match backup {
+        RepairBackupV3::Mpls(b) => {
+            let mut uni =
+                rib::NexthopUni::new(std::net::IpAddr::V6(b.addr), metric, b.labels.clone());
+            uni.ifindex_origin = (b.ifindex != 0).then_some(b.ifindex);
+            uni
+        }
+        RepairBackupV3::Srv6(b) => {
+            let mut uni = rib::NexthopUni::new(std::net::IpAddr::V6(b.addr), metric, vec![]);
+            uni.ifindex_origin = (b.ifindex != 0).then_some(b.ifindex);
+            uni.segs = b.segs.clone();
+            uni.encap_type = Some(b.encap);
+            uni
+        }
+    }
 }
 
 /// Build a `rib::entry::RibEntry` from a `SpfRouteV3`. Flattens the

--- a/zebra-rs/src/ospf/show_v3.rs
+++ b/zebra-rs/src/ospf/show_v3.rs
@@ -174,21 +174,38 @@ fn collect_ospfv3_repair_rows(top: &Ospf<Ospfv3>) -> Vec<RepairRowV3Json> {
             let Some(backup) = nhop.backup.as_ref() else {
                 continue;
             };
-            let segments = backup
-                .labels
-                .iter()
-                .map(|label| RepairSegmentV3Json {
-                    kind: "sr-mpls",
-                    value: label_value_str_v3(label),
-                })
-                .collect();
+            use crate::ospf::tilfa::RepairBackupV3;
+            let (segments, repair_nexthop, repair_ifindex) = match backup {
+                RepairBackupV3::Mpls(b) => (
+                    b.labels
+                        .iter()
+                        .map(|label| RepairSegmentV3Json {
+                            kind: "sr-mpls",
+                            value: label_value_str_v3(label),
+                        })
+                        .collect(),
+                    b.addr.to_string(),
+                    b.ifindex,
+                ),
+                RepairBackupV3::Srv6(b) => (
+                    b.segs
+                        .iter()
+                        .map(|sid| RepairSegmentV3Json {
+                            kind: "srv6",
+                            value: sid.to_string(),
+                        })
+                        .collect(),
+                    b.addr.to_string(),
+                    b.ifindex,
+                ),
+            };
             rows.push(RepairRowV3Json {
                 prefix: prefix.to_string(),
                 primary_nexthop: addr.to_string(),
                 primary_ifindex: nhop.ifindex,
                 primary_metric: route.metric,
-                repair_nexthop: backup.addr.to_string(),
-                repair_ifindex: backup.ifindex,
+                repair_nexthop,
+                repair_ifindex,
                 repair_metric: route
                     .metric
                     .saturating_add(super::inst::BACKUP_METRIC_OFFSET),

--- a/zebra-rs/src/ospf/tilfa.rs
+++ b/zebra-rs/src/ospf/tilfa.rs
@@ -433,3 +433,243 @@ fn adj_sid_label_for_link_v3(
     }
     None
 }
+
+// ---------------------------------------------------------------------
+// SRv6 TI-LFA repairs (RFC 9513) — Phase 5 of
+// docs/design/ospfv3-srv6-plan.md.
+// ---------------------------------------------------------------------
+
+/// A resolved v3 TI-LFA repair, in whichever encoding the instance's
+/// dataplane runs: an SR-MPLS label stack or an SRv6 SID list. The
+/// route builder picks SRv6 whenever the locator is active, else
+/// MPLS — the two modes can in principle coexist, but a repair only
+/// needs one encoding.
+#[derive(Debug, Clone, PartialEq)]
+pub enum RepairBackupV3 {
+    Mpls(RepairPathMplsV3),
+    Srv6(RepairPathSrv6V3),
+}
+
+/// SRv6 TI-LFA repair for one v3 route — the OSPFv3 sibling of
+/// `isis::tilfa::RepairPathSrv6`. The SID list is SRH-inserted
+/// (H.Insert): repair segments are transit End/End.X SIDs with no
+/// decap terminator, so the original destination must stay the SRH's
+/// final segment (H.Encap would blackhole at the last SID).
+#[derive(Debug, Clone, PartialEq)]
+pub struct RepairPathSrv6V3 {
+    pub ifindex: u32,
+    pub addr: Ipv6Addr,
+    pub segs: Vec<Ipv6Addr>,
+    pub encap: isis_packet::srv6::EncapType,
+}
+
+/// Resolve a graph-level repair to an SRv6 SID list from the v3 LSDB
+/// and pack it into NEXT-C-SID carriers — the OSPFv3 sibling of
+/// `isis::tilfa::build_repair_path_srv6`. NodeSids resolve to the
+/// vertex router's End SID (its SRv6 Locator LSA), AdjSids to the
+/// advertiser's End.X SID (sub-TLV 31/32 on its E-Router-LSA
+/// Router-Link TLVs). Returns `None` when any segment fails to
+/// resolve — a partial SID list would diverge from the
+/// post-convergence path.
+pub(super) fn build_repair_path_srv6_v3(
+    top: &Ospf<Ospfv3>,
+    area: &OspfArea<Ospfv3>,
+    rp: &spf::RepairPath,
+) -> Option<RepairPathSrv6V3> {
+    use crate::spf::srv6::{RepairSeg, pack_carriers};
+
+    let mut parts: Vec<RepairSeg> = Vec::with_capacity(rp.segs.len());
+    for seg in &rp.segs {
+        let part = match seg {
+            spf::SrSegment::NodeSid(v) => {
+                let info = srv6_end_sid_for_vertex_v3(top, area, *v)?;
+                RepairSeg {
+                    sid: info.sid,
+                    landing: *v,
+                    csid: csid_bits_end_v3(&info),
+                }
+            }
+            spf::SrSegment::AdjSid(from, to, _via) => {
+                let info = srv6_endx_sid_for_link_v3(top, area, *from, *to)?;
+                RepairSeg {
+                    sid: info.sid,
+                    landing: *to,
+                    csid: csid_bits_endx_v3(&info, *from),
+                }
+            }
+        };
+        parts.push(part);
+    }
+    let segs = pack_carriers(&parts);
+
+    let first_hop_router = *top.lsp_map.resolve(rp.first_hop)?;
+    let (ifindex, addr) = resolve_first_hop_egress_v3(top, first_hop_router)?;
+    Some(RepairPathSrv6V3 {
+        ifindex,
+        addr,
+        segs,
+        encap: isis_packet::srv6::EncapType::HInsert,
+    })
+}
+
+/// An SRv6 SID with its endpoint behavior and structure, as resolved
+/// from the v3 LSDB for repair encoding.
+struct Srv6SidInfoV3 {
+    sid: Ipv6Addr,
+    behavior: u16,
+    structure: Option<ospf_packet::Ospfv3Srv6SidStructure>,
+}
+
+/// The vertex router's End SID from its SRv6 Locator LSA (algo-0
+/// Locator TLV → End SID sub-TLV, structure from the locator-registry
+/// SID Structure sub-TLV).
+fn srv6_end_sid_for_vertex_v3(
+    top: &Ospf<Ospfv3>,
+    area: &OspfArea<Ospfv3>,
+    vertex: usize,
+) -> Option<Srv6SidInfoV3> {
+    use ospf_packet::{
+        OSPFV3_SRV6_LOCATOR_LSA_TYPE, Ospfv3LsBody, Ospfv3Srv6LocatorLsaTlv,
+        Ospfv3Srv6LocatorSubTlv,
+    };
+    let router_id = *top.lsp_map.resolve(vertex)?;
+    for ((_ls_id, adv_router), lsa) in area.lsdb.iter_by_raw_type(OSPFV3_SRV6_LOCATOR_LSA_TYPE) {
+        if lsa.data.h.ls_age >= OSPF_MAX_AGE || adv_router != router_id {
+            continue;
+        }
+        let Ospfv3LsBody::Srv6Locator(ref body) = lsa.data.body else {
+            continue;
+        };
+        for tlv in &body.tlvs {
+            let Ospfv3Srv6LocatorLsaTlv::Locator(loc) = tlv else {
+                continue;
+            };
+            if loc.algorithm != 0 {
+                continue;
+            }
+            for sub in &loc.subs {
+                let Ospfv3Srv6LocatorSubTlv::EndSid(end) = sub else {
+                    continue;
+                };
+                let structure = end.subs.iter().find_map(|s| {
+                    if let Ospfv3Srv6LocatorSubTlv::SidStructure(st) = s {
+                        Some(*st)
+                    } else {
+                        None
+                    }
+                });
+                return Some(Srv6SidInfoV3 {
+                    sid: end.sid,
+                    behavior: end.behavior,
+                    structure,
+                });
+            }
+        }
+    }
+    None
+}
+
+/// `from`'s End.X SID toward `to`, from the Router-Link TLVs of its
+/// per-link E-Router-LSAs — the SRv6 sibling of
+/// `adj_sid_label_for_link_v3`. P2P links carry sub-TLV 31; LAN
+/// links sub-TLV 32 qualified by the Neighbor Router-ID.
+fn srv6_endx_sid_for_link_v3(
+    top: &Ospf<Ospfv3>,
+    area: &OspfArea<Ospfv3>,
+    from_vertex: usize,
+    to_vertex: usize,
+) -> Option<Srv6SidInfoV3> {
+    use ospf_packet::{OSPFV3_E_ROUTER_LSA_TYPE, Ospfv3ExtTlv, Ospfv3LsBody, Ospfv3SubTlv};
+    let from_router = *top.lsp_map.resolve(from_vertex)?;
+    let to_router = *top.lsp_map.resolve(to_vertex)?;
+
+    fn nested_structure(subs: &[Ospfv3SubTlv]) -> Option<ospf_packet::Ospfv3Srv6SidStructure> {
+        subs.iter().find_map(|s| {
+            if let Ospfv3SubTlv::Srv6SidStructure(st) = s {
+                Some(*st)
+            } else {
+                None
+            }
+        })
+    }
+
+    for ((_ls_id, adv_router), lsa) in area.lsdb.iter_by_raw_type(OSPFV3_E_ROUTER_LSA_TYPE) {
+        if lsa.data.h.ls_age >= OSPF_MAX_AGE || adv_router != from_router {
+            continue;
+        }
+        let Ospfv3LsBody::ERouter(ref body) = lsa.data.body else {
+            continue;
+        };
+        for tlv in &body.tlvs {
+            let Ospfv3ExtTlv::RouterLink(rl) = tlv else {
+                continue;
+            };
+            if rl.link.neighbor_router_id != to_router {
+                continue;
+            }
+            for sub in &rl.subs {
+                match sub {
+                    Ospfv3SubTlv::Srv6EndXSid(endx) => {
+                        return Some(Srv6SidInfoV3 {
+                            sid: endx.sid,
+                            behavior: endx.behavior,
+                            structure: nested_structure(&endx.subs),
+                        });
+                    }
+                    Ospfv3SubTlv::Srv6LanEndXSid(lan) if lan.neighbor_router_id == to_router => {
+                        return Some(Srv6SidInfoV3 {
+                            sid: lan.sid,
+                            behavior: lan.behavior,
+                            structure: nested_structure(&lan.subs),
+                        });
+                    }
+                    _ => {}
+                }
+            }
+        }
+    }
+    None
+}
+
+/// Carrier metadata for a v3-advertised End/uN SID — identifier is
+/// the locator-node portion. `None` (full-SID fallback) for classic
+/// behaviors or missing/degenerate structures.
+fn csid_bits_end_v3(info: &Srv6SidInfoV3) -> Option<crate::spf::srv6::CsidBits> {
+    use crate::spf::srv6::{CsidBits, sid_bits, sid_block};
+    if !isis_packet::Behavior::from(info.behavior).is_end_next_csid() {
+        return None;
+    }
+    let st = info.structure.as_ref()?;
+    let (lb, ln) = (st.lb_len as u32, st.ln_len as u32);
+    if ln == 0 || lb + ln > 128 {
+        return None;
+    }
+    Some(CsidBits {
+        block: sid_block(info.sid, st.lb_len),
+        lb: st.lb_len,
+        id: sid_bits(info.sid, lb, ln),
+        width: st.ln_len,
+        lib_owner: None,
+    })
+}
+
+/// Carrier metadata for a v3-advertised End.X/uA SID — identifier is
+/// the function portion, locally significant to `owner`.
+fn csid_bits_endx_v3(info: &Srv6SidInfoV3, owner: usize) -> Option<crate::spf::srv6::CsidBits> {
+    use crate::spf::srv6::{CsidBits, sid_bits, sid_block};
+    if !isis_packet::Behavior::from(info.behavior).is_endx_next_csid() {
+        return None;
+    }
+    let st = info.structure.as_ref()?;
+    let (lb, ln, fun) = (st.lb_len as u32, st.ln_len as u32, st.fun_len as u32);
+    if fun == 0 || lb + ln + fun > 128 {
+        return None;
+    }
+    Some(CsidBits {
+        block: sid_block(info.sid, st.lb_len),
+        lb: st.lb_len,
+        id: sid_bits(info.sid, lb + ln, fun),
+        width: st.fun_len,
+        lib_owner: Some(owner),
+    })
+}

--- a/zebra-rs/src/rib/route.rs
+++ b/zebra-rs/src/rib/route.rs
@@ -2080,6 +2080,8 @@ fn rib_resolve_nexthop_v6(
     entry.set_valid(entry.is_valid_nexthop(nmap));
 }
 
+/// v6 sibling of `resolve_nexthop_member`: resolve one List / Protect
+/// member, allocating the kernel-side Multi group for ECMP members.
 fn resolve_nexthop_member_v6(
     member: &mut NexthopMember,
     nmap: &mut NexthopMap,
@@ -2591,5 +2593,53 @@ mod tests {
             panic!("backup Uni preserved");
         };
         assert!(backup_uni.gid != 0, "backup Uni gets its own group");
+    }
+
+    /// Sibling of the test above with the SRv6 TI-LFA member shape:
+    /// a link-local primary plus a seg6-encap (H.Insert carrier)
+    /// backup must resolve both members and validate the entry, or
+    /// the protected route never installs.
+    #[test]
+    fn protect_v6_with_seg6_backup_resolves_and_validates() {
+        use super::super::entry::RibEntry;
+        use super::super::nexthop::{NexthopProtect, NexthopUni};
+        use super::super::{Nexthop, NexthopMap, NexthopMember};
+        use super::super::{RibEntries, RibType};
+        use super::rib_resolve_nexthop_v6;
+        use ipnet::Ipv6Net;
+        use prefix_trie::PrefixMap;
+
+        let mut primary = NexthopUni::new("fe80::1".parse().unwrap(), 2, vec![]);
+        primary.ifindex_origin = Some(10);
+        let mut backup = NexthopUni::new("fe80::2".parse().unwrap(), 3, vec![]);
+        backup.ifindex_origin = Some(11);
+        backup.segs = vec!["fcbb:bbbb:5:e003:e002::".parse().unwrap()];
+        backup.encap_type = Some(isis_packet::srv6::EncapType::HInsert);
+
+        let mut entry = RibEntry::new(RibType::Ospf);
+        entry.nexthop = Nexthop::Protect(NexthopProtect {
+            primary: NexthopMember::Uni(primary),
+            backup: NexthopMember::Uni(backup),
+        });
+
+        let mut nmap = NexthopMap::default();
+        let table: PrefixMap<Ipv6Net, RibEntries> = PrefixMap::new();
+        rib_resolve_nexthop_v6(&mut entry, &table, &mut nmap, 254);
+
+        let Nexthop::Protect(pro) = &entry.nexthop else {
+            panic!("entry.nexthop should still be Protect");
+        };
+        let NexthopMember::Uni(p) = &pro.primary else {
+            panic!("primary Uni preserved");
+        };
+        let NexthopMember::Uni(b) = &pro.backup else {
+            panic!("backup Uni preserved");
+        };
+        assert!(p.gid != 0, "primary resolves to a group");
+        assert!(b.gid != 0, "seg6 backup resolves to its own group");
+        assert!(
+            entry.is_valid(),
+            "a Protect route with resolvable members must validate"
+        );
     }
 }

--- a/zebra-rs/src/spf/mod.rs
+++ b/zebra-rs/src/spf/mod.rs
@@ -5,5 +5,6 @@ pub mod diff;
 pub use diff::*;
 
 pub mod label_block;
+pub mod srv6;
 
 pub mod label_pool;

--- a/zebra-rs/src/spf/srv6.rs
+++ b/zebra-rs/src/spf/srv6.rs
@@ -1,0 +1,143 @@
+//! Shared NEXT-C-SID (RFC 9800) carrier packing for TI-LFA SRv6
+//! repair lists — used by every IGP that encodes repairs as SRv6 SID
+//! lists (IS-IS, OSPFv3). The protocol-specific halves (extracting
+//! `CsidBits` from each protocol's advertised SID wire formats) live
+//! with their protocols; this module owns the encoding rules:
+//! same-block runs collapse into 128-bit carriers, uA identifiers
+//! require LIB continuity, zero identifiers and single-id carriers
+//! fall back to the full SID, mixed lists degrade per-segment.
+
+use std::net::Ipv6Addr;
+
+/// One resolved SRv6 repair segment plus the NEXT-C-SID metadata the
+/// carrier packer needs. `sid` is always the full advertised address,
+/// usable verbatim when the segment can't ride in a carrier.
+#[derive(Debug)]
+pub(crate) struct RepairSeg {
+    pub(crate) sid: Ipv6Addr,
+    /// Vertex the packet sits on once this segment is consumed —
+    /// the SID's owner for an End/uN, the adjacency's far end for an
+    /// End.X/uA. Drives the LIB-continuity check below.
+    pub(crate) landing: usize,
+    /// `Some` when the SID was advertised with a NEXT-C-SID behavior
+    /// and a usable structure; `None` forces full-SID encoding.
+    pub(crate) csid: Option<CsidBits>,
+}
+
+/// The bits a segment contributes to a uSID carrier.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub(crate) struct CsidBits {
+    /// The shared uSID block — the SID's first `lb` bits, masked.
+    pub(crate) block: u128,
+    pub(crate) lb: u8,
+    /// The identifier consumed at the owner: locator-node bits for a
+    /// uN, function bits for a uA. Right-aligned value.
+    pub(crate) id: u128,
+    pub(crate) width: u8,
+    /// For a uA: the vertex that owns the adjacency. A LIB identifier
+    /// is only locally significant, so it may only follow a segment
+    /// that lands the packet on its owner; `None` for a uN, which is
+    /// globally routable via the locator prefix.
+    pub(crate) lib_owner: Option<usize>,
+}
+
+pub(crate) fn sid_bits(sid: Ipv6Addr, start: u32, width: u32) -> u128 {
+    if width == 0 || start + width > 128 {
+        return 0;
+    }
+    (u128::from(sid) >> (128 - start - width)) & ((1u128 << width) - 1)
+}
+
+pub(crate) fn sid_block(sid: Ipv6Addr, lb: u8) -> u128 {
+    if lb == 0 {
+        return 0;
+    }
+    u128::from(sid) & (u128::MAX << (128 - lb as u32))
+}
+
+/// In-progress uSID carrier: block bits up front, identifiers appended
+/// left-to-right in traversal order, zero-padded tail (the zero
+/// remainder is what triggers each node's end-of-carrier fallback).
+struct Carrier {
+    val: u128,
+    block: u128,
+    lb: u8,
+    /// Next free bit position (starts at `lb`).
+    pos: u32,
+    /// Identifiers packed so far — a single-id carrier is re-emitted
+    /// as the segment's full SID instead (identical forwarding, and it
+    /// doesn't depend on the owner having LIB entries installed).
+    ids: u8,
+    first_sid: Ipv6Addr,
+}
+
+impl Carrier {
+    fn flush(self, out: &mut Vec<Ipv6Addr>) {
+        if self.ids == 1 {
+            out.push(self.first_sid);
+        } else {
+            out.push(Ipv6Addr::from(self.val));
+        }
+    }
+}
+
+/// Pack a resolved SRv6 repair list into NEXT-C-SID carriers (RFC
+/// 9800). Consecutive segments whose SIDs were advertised with uSID
+/// behaviors and a shared locator block collapse into one 128-bit
+/// carrier — block + 16-bit identifiers — instead of one full SID per
+/// SRH segment. Anything that can't ride a carrier (classic behavior,
+/// no structure, zero identifier, block change, LIB continuity break,
+/// carrier full) is emitted as its full SID; mixed lists degrade
+/// per-segment, never wholesale.
+pub(crate) fn pack_carriers(parts: &[RepairSeg]) -> Vec<Ipv6Addr> {
+    let mut out: Vec<Ipv6Addr> = Vec::with_capacity(parts.len());
+    let mut cur: Option<Carrier> = None;
+    let mut prev_landing: Option<usize> = None;
+
+    for part in parts {
+        let packable = part.csid.as_ref().filter(|c| {
+            // A zero identifier would read as end-of-carrier on the
+            // wire; never pack one. LIB (uA) identifiers additionally
+            // require the previous segment to land on their owner —
+            // that holds across carrier boundaries and full-SID
+            // predecessors alike, since either way the packet sits on
+            // the owner when the identifier becomes active.
+            c.id != 0 && c.lib_owner.is_none_or(|owner| prev_landing == Some(owner))
+        });
+        match packable {
+            Some(c) => {
+                let fits = cur.as_ref().is_some_and(|car| {
+                    car.block == c.block && car.lb == c.lb && car.pos + c.width as u32 <= 128
+                });
+                if !fits {
+                    if let Some(car) = cur.take() {
+                        car.flush(&mut out);
+                    }
+                    cur = Some(Carrier {
+                        val: c.block,
+                        block: c.block,
+                        lb: c.lb,
+                        pos: c.lb as u32,
+                        ids: 0,
+                        first_sid: part.sid,
+                    });
+                }
+                let car = cur.as_mut().expect("carrier was just ensured");
+                car.val |= c.id << (128 - car.pos - c.width as u32);
+                car.pos += c.width as u32;
+                car.ids += 1;
+            }
+            None => {
+                if let Some(car) = cur.take() {
+                    car.flush(&mut out);
+                }
+                out.push(part.sid);
+            }
+        }
+        prev_landing = Some(part.landing);
+    }
+    if let Some(car) = cur.take() {
+        car.flush(&mut out);
+    }
+    out
+}


### PR DESCRIPTION
## Summary
- **Phases 5+6 of OSPFv3 SRv6** (`docs/design/ospfv3-srv6-plan.md`): TI-LFA repairs as SRv6 SID lists — `build_repair_path_srv6_v3` resolves NodeSids from SRv6 Locator LSAs and AdjSids from End.X/LAN-End.X sub-TLVs, packs NEXT-C-SID carriers via the packer now shared in `spf::srv6` (lifted from `isis::tilfa`, all nine packing tests intact), installs as H.Insert. `RepairBackupV3` (Mpls|Srv6) picks the encoding by locator state; `show ospfv3 repair-list detail` tags `srv6` vs `sr-mpls`.
- **Main regression fix**: `rib_resolve_nexthop_v6` lacked the `Nexthop::Protect` arm (v4 got it when `NexthopProtect` landed in `daf16807`) — members kept `gid 0`/invalid, so **every v6 TI-LFA-protected route (IS-IS and OSPFv3) silently never installed**. The new feature's empty kernel table flushed it out; fixed with the List-style member walk + a v6 unit test mirroring the v4 Protect test.

## Testing
- New `ospfv3_tilfa_srv6.feature` (uSID): 5/5 — kernel `segs 2` carrier compression, srv6 repair list, link-failure survival, promoted-backup forwarding.
- New `ospfv3_tilfa_srv6_classic.feature`: 5/5 — pins the uncompressed `segs 4` repair with full SIDs, promoted backup forwards.
- Regression confirmations on this build: `tilfa_srv6`, `tilfa_classic_srv6`, `ospfv3_tilfa` — all three latently broken on main, all green again.
- Full suite 1631 passed (incl. the new Protect-v6 test); clippy `-D warnings` + fmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)