### PR TITLE
rib: kernel-side failover phase 2 — the switchover op

### DIFF
--- a/docs/design/nexthop-protect-kernel-failover.md
+++ b/docs/design/nexthop-protect-kernel-failover.md
@@ -20,7 +20,7 @@ paths for protected routes.
 | ----- | -- | ---------- |
 | 0 — `Nexthop::Protect` RIB shape | #1370, #1373 | explicit primary/backup pair, producers + consumers, v6 resolver fix |
 | 1 — indirection group | #1374 | `Group::Protect` + `NexthopProtect.gid`; protected v4/v6 routes reference a 1-member kernel group; behavior-neutral |
-| 2 — switchover op | — | `FibHandle::protect_switch` + `Message::ProtectSwitch` + nmap state |
+| 2 — switchover op | #1377 | `Message::ProtectSwitch` + `GroupProtect.active` + atomic group re-send; revert-on-reassert |
 | 3 — IS-IS hook | — | BFD/adjacency-down emits `ProtectSwitch` before SPF; BDD for the link-up failure class |
 | 4 — OSPF hook | — | v2 + v3, same shape |
 | 5 — ECMP leg-level replace | — | per-leg repair on `Multi` primaries |
@@ -172,16 +172,29 @@ leg) but must be called out in the phase-5 PR.
   mirroring `NexthopMulti.gid`. `gid == 0` means "no kernel
   indirection" (Multi primary, or `use_nhid` off).
 - `NexthopMap` gains `Group::Protect(GroupProtect)`:
-  `GroupCommon` + `primary_gid` + `backup_gid`, keyed via
+  `GroupCommon` + `primary_gid` + `backup_gid` +
+  `active: Primary | Switched` (phase 2), keyed via
   `fetch_protect((primary_gid, backup_gid))`. Holds refcnts on both
-  members so GC ordering is safe. Phase 2 adds the
-  `active: Primary | Switched` state.
+  members so GC ordering is safe.
 - Resolver (`rib_resolve_nexthop{,_v6}` Protect blocks): after
   resolving both members, allocate `Gp` when the primary is `Uni`.
 - `FibHandle::nexthop_add`: `Group::Protect` arm installs a 1-member
-  `NHA_GROUP` (same encoding as `Multi`, one entry). Install order:
-  members first, then `Gp` (`nexthop_sync` ordering); delete in
-  reverse (`nexthop_unsync`).
+  `NHA_GROUP` (same encoding as `Multi`, one entry) holding the
+  ACTIVE member. Install order: members first, then `Gp`
+  (`nexthop_sync` ordering); delete in reverse (`nexthop_unsync`).
+  There is no separate `protect_switch` FIB method: the install
+  request already carries `NLM_F_REPLACE`, so re-sending the group
+  after an `active` flip IS the atomic switchover.
+- Switchover flow (phase 2): `Message::ProtectSwitch { addr }`
+  (table-scoped) → `route::protect_switch` walks
+  `protect_switch_candidates` (active primary matches the failed
+  adjacency, backup is a live non-seg6 Uni) → flips
+  `active = Switched` → re-sends the group. Revert is driven by the
+  producer: re-adding the same (primary, backup) pair —
+  the post-flap SPF — resets `active` to `Primary` with a pending
+  re-install, and the next sync re-sends the group with the primary
+  member (same REPLACE mechanics). Validity in the sync passes
+  follows the active member.
 - `route_ipv{4,6}_add/del` Protect arm: the primary route's `Nhid`
   becomes `pro.gid` (when non-zero) instead of the member gid; the
   shadow route is unchanged. With `use_nhid` off, everything stays

--- a/zebra-rs/src/fib/netlink/handle.rs
+++ b/zebra-rs/src/fib/netlink/handle.rs
@@ -140,10 +140,11 @@ fn fmt_group_for_trace(group: &Group) -> String {
             )
         }
         Group::Protect(p) => format!(
-            "Group::Protect{{gid={} primary={} backup={} valid={} installed={}}}",
+            "Group::Protect{{gid={} primary={} backup={} active={:?} valid={} installed={}}}",
             p.gid(),
             p.primary_gid,
             p.backup_gid,
+            p.active,
             p.is_valid(),
             p.is_installed(),
         ),
@@ -1278,8 +1279,12 @@ impl FibHandle {
             }
             Group::Protect(pro) => {
                 // Protection indirection: a 1-member mpath group
-                // holding the primary. Same encoding as Multi —
-                // GroupType 0, kernel weight is value+1 so 0 = 1.
+                // holding the ACTIVE member (primary in steady state,
+                // repair after a switchover). Same encoding as Multi —
+                // GroupType 0, kernel weight is value+1 so 0 = 1. The
+                // request carries NLM_F_REPLACE, so re-sending after
+                // an `active` flip IS the atomic switchover: every
+                // route referencing this gid moves in one message.
                 gid = pro.gid();
                 refcnt = pro.refcnt();
 
@@ -1292,7 +1297,7 @@ impl FibHandle {
                 msg.attributes.push(attr);
 
                 let grp = NexthopGroup {
-                    id: pro.primary_gid as u32,
+                    id: pro.active_gid() as u32,
                     weight: 0,
                     ..Default::default()
                 };

--- a/zebra-rs/src/rib/client.rs
+++ b/zebra-rs/src/rib/client.rs
@@ -130,6 +130,16 @@ impl RibClient {
         })
     }
 
+    /// Trigger the fast-reroute switchover for every protection
+    /// indirection group whose primary rides the failed adjacency at
+    /// `addr` (phase 2 of the kernel-failover design). Protocols call
+    /// this on a BFD-down-with-link-up detection, BEFORE starting
+    /// SPF, so traffic moves to the pre-installed TI-LFA repairs in
+    /// O(adjacencies) while reconvergence runs.
+    pub fn protect_switch(&self, addr: std::net::IpAddr) -> Result<(), SendError<RibInbound>> {
+        self.send(Message::ProtectSwitch { addr })
+    }
+
     /// Toggle FIB-install suppression for this client and every clone
     /// that shares its `Arc`. Idempotent.
     pub fn set_suppress_install(&self, suppress: bool) {

--- a/zebra-rs/src/rib/client.rs
+++ b/zebra-rs/src/rib/client.rs
@@ -136,6 +136,10 @@ impl RibClient {
     /// this on a BFD-down-with-link-up detection, BEFORE starting
     /// SPF, so traffic moves to the pre-installed TI-LFA repairs in
     /// O(adjacencies) while reconvergence runs.
+    // Callers are the phase-3/4 IGP BFD hooks; `expect` forces this
+    // annotation off when the first one lands (zebra-rs is a bin
+    // crate, so `pub` alone doesn't exempt it from dead-code).
+    #[expect(dead_code)]
     pub fn protect_switch(&self, addr: std::net::IpAddr) -> Result<(), SendError<RibInbound>> {
         self.send(Message::ProtectSwitch { addr })
     }

--- a/zebra-rs/src/rib/inst.rs
+++ b/zebra-rs/src/rib/inst.rs
@@ -138,6 +138,10 @@ pub enum Message {
     /// adjacency onto its repair — one atomic kernel group-replace
     /// per group, independent of prefix count. The sender's normal
     /// SPF reconvergence then supersedes the bridge.
+    // Constructed by RibClient::protect_switch; the protocol-side
+    // callers are the phase-3/4 slices. The `expect` forces this
+    // annotation's removal the moment the first hook lands.
+    #[expect(dead_code)]
     ProtectSwitch {
         addr: IpAddr,
     },

--- a/zebra-rs/src/rib/inst.rs
+++ b/zebra-rs/src/rib/inst.rs
@@ -138,10 +138,9 @@ pub enum Message {
     /// adjacency onto its repair — one atomic kernel group-replace
     /// per group, independent of prefix count. The sender's normal
     /// SPF reconvergence then supersedes the bridge.
-    // Constructed by RibClient::protect_switch; the protocol-side
-    // callers are the phase-3/4 slices. The `expect` forces this
-    // annotation's removal the moment the first hook lands.
-    #[expect(dead_code)]
+    // Constructed by RibClient::protect_switch, whose own
+    // expect(dead_code) (callers land in phase 3/4) roots it — and
+    // the construction inside keeps this variant live with it.
     ProtectSwitch {
         addr: IpAddr,
     },

--- a/zebra-rs/src/rib/inst.rs
+++ b/zebra-rs/src/rib/inst.rs
@@ -130,6 +130,17 @@ pub enum Message {
         proto: String,
         nh: std::net::IpAddr,
     },
+    /// Fast-reroute switchover trigger (phase 2 of
+    /// `docs/design/nexthop-protect-kernel-failover.md`): the sender
+    /// detected a primary-adjacency failure the kernel can't see (BFD
+    /// down while the link stays up) at gateway `addr`. RIB rewires
+    /// every protection indirection group whose primary rides that
+    /// adjacency onto its repair — one atomic kernel group-replace
+    /// per group, independent of prefix count. The sender's normal
+    /// SPF reconvergence then supersedes the bridge.
+    ProtectSwitch {
+        addr: IpAddr,
+    },
     /// Drop `proto`'s interest in `nh`; the tracking entry is removed
     /// once its last watcher unregisters.
     NexthopUnregister {
@@ -1563,6 +1574,12 @@ impl Rib {
             }
             Message::NexthopRegister { proto, nh } => {
                 self.nht_register(proto, nh);
+            }
+            Message::ProtectSwitch { addr } => {
+                let n =
+                    super::route::protect_switch(&mut self.nmap, &self.fib_handle, table_id, addr)
+                        .await;
+                tracing::info!("ProtectSwitch {addr} table {table_id}: {n} group(s) rewired");
             }
             Message::NexthopUnregister { proto, nh } => {
                 self.nht.unregister(&proto, nh);

--- a/zebra-rs/src/rib/nexthop/group.rs
+++ b/zebra-rs/src/rib/nexthop/group.rs
@@ -205,20 +205,30 @@ impl GroupTrait for GroupMulti {
     }
 }
 
+/// Which member a protection indirection group currently holds in
+/// the kernel: the SPF primary, or (after a fast-reroute switchover)
+/// the TI-LFA repair.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ProtectActive {
+    Primary,
+    Switched,
+}
+
 /// Kernel indirection group for a protected primary (see
 /// `docs/design/nexthop-protect-kernel-failover.md`). Installs as a
-/// single-member `NHA_GROUP` containing `primary_gid`; protected
-/// routes reference this gid instead of the member's, so the phase-2
-/// switchover can move every route onto `backup_gid` with one atomic
-/// `RTM_NEWNEXTHOP` replace. Valid iff the primary member's group is
-/// valid — on link down the kernel flushes the member, the emptied
-/// group, and the routes referencing it (probe-validated), leaving
-/// the metric-offset shadow route forwarding.
+/// single-member `NHA_GROUP` containing the active member's object;
+/// protected routes reference this gid instead of the member's, so
+/// the switchover can move every route onto `backup_gid` with one
+/// atomic `RTM_NEWNEXTHOP` replace. Valid iff the active member's
+/// group is valid — on link down the kernel flushes the member, the
+/// emptied group, and the routes referencing it (probe-validated),
+/// leaving the metric-offset shadow route forwarding.
 #[derive(Debug, Clone)]
 pub struct GroupProtect {
     common: GroupCommon,
     pub primary_gid: usize,
     pub backup_gid: usize,
+    pub active: ProtectActive,
 }
 
 impl GroupProtect {
@@ -227,6 +237,17 @@ impl GroupProtect {
             common: GroupCommon::new(gid),
             primary_gid,
             backup_gid,
+            active: ProtectActive::Primary,
+        }
+    }
+
+    /// The member gid the kernel group currently holds (or should
+    /// hold on the next install): primary in steady state, backup
+    /// after a switchover.
+    pub fn active_gid(&self) -> usize {
+        match self.active {
+            ProtectActive::Primary => self.primary_gid,
+            ProtectActive::Switched => self.backup_gid,
         }
     }
 }

--- a/zebra-rs/src/rib/nexthop/map.rs
+++ b/zebra-rs/src/rib/nexthop/map.rs
@@ -221,6 +221,52 @@ impl NexthopMap {
         self.get_mut(gid)
     }
 
+    /// Protection groups eligible for a fast-reroute switchover onto
+    /// their repair because their ACTIVE side rides the failed
+    /// primary `(table_id, addr)`. Pure selection — the caller flips
+    /// the state and issues the kernel replace. A candidate must:
+    ///
+    ///   - still be on its primary (an already-switched group has
+    ///     nothing left to protect with),
+    ///   - have a Uni backup member (a Multi backup can't be a group
+    ///     member — kernel groups don't nest; deferred to the ECMP
+    ///     phase),
+    ///   - have a non-SRv6 backup (kernel 6.8 black-holes seg6
+    ///     members inside groups — see the design doc; that subset
+    ///     waits for SPF reconvergence exactly as before phase 2),
+    ///   - have that backup's kernel object alive (valid +
+    ///     installed), or the swap would point routes at nothing.
+    pub fn protect_switch_candidates(&self, table_id: u32, addr: IpAddr) -> Vec<usize> {
+        self.groups
+            .iter()
+            .flatten()
+            .filter_map(|grp| {
+                let Group::Protect(pro) = grp else {
+                    return None;
+                };
+                if pro.active != super::ProtectActive::Primary {
+                    return None;
+                }
+                let primary = self.get_uni(pro.primary_gid)?;
+                if primary.table_id != table_id || primary.addr != addr {
+                    return None;
+                }
+                let backup = self.get_uni(pro.backup_gid)?;
+                if !backup.segs.is_empty() {
+                    tracing::info!(
+                        "protect_switch: gid {} skipped — seg6 backup can't join a group",
+                        pro.gid(),
+                    );
+                    return None;
+                }
+                if !backup.is_valid() || !backup.is_installed() {
+                    return None;
+                }
+                Some(pro.gid())
+            })
+            .collect()
+    }
+
     pub fn fetch_multi(&mut self, set: &BTreeSet<(usize, u8)>) -> Option<&mut Group> {
         let gid = if let Some(&gid) = self.set.get(set) {
             let update = self.groups.get_mut(gid)?;

--- a/zebra-rs/src/rib/nexthop/show.rs
+++ b/zebra-rs/src/rib/nexthop/show.rs
@@ -60,16 +60,18 @@ pub fn nexthop_show(rib: &Rib, _args: Args, _json: bool) -> String {
                 }
             }
             Group::Protect(pro) => {
-                // Indirection group for a protected primary: the
-                // member list is the primary; the backup is what the
-                // switchover would swap in.
+                // Indirection group for a protected primary. The `*`
+                // marks the active member — the one the kernel group
+                // currently holds; the switchover swaps it.
+                let active = pro.active_gid();
                 for (role, gid) in [("primary", pro.primary_gid), ("backup", pro.backup_gid)] {
+                    let marker = if gid == active { "*" } else { " " };
                     if let Some(Group::Uni(uni)) = rib.nmap.get(gid) {
-                        write!(buf, "  {} [{}] ", role, gid).unwrap();
+                        write!(buf, " {}{} [{}] ", marker, role, gid).unwrap();
                         write_via(&mut buf, uni);
                         writeln!(buf, ", {}", rib.link_name(uni.ifindex().unwrap_or(0))).unwrap();
                     } else {
-                        writeln!(buf, "  {} [{}]", role, gid).unwrap();
+                        writeln!(buf, " {}{} [{}]", marker, role, gid).unwrap();
                     }
                 }
             }

--- a/zebra-rs/src/rib/route.rs
+++ b/zebra-rs/src/rib/route.rs
@@ -14,8 +14,9 @@ use super::nexthop::NexthopUni;
 use super::tracing::{rib_interface, rib_nexthop, rib_route};
 use super::{
     Group, GroupTrait, Message, NexthopList, NexthopMap, NexthopMember, NexthopMulti,
-    NexthopProtect, RibEntries, RibType,
+    NexthopProtect, ProtectActive, RibEntries, RibType,
 };
+use std::net::IpAddr;
 
 /// Hold-down policy for kernel-driven address recovery.
 ///
@@ -1198,7 +1199,9 @@ async fn protect_groups_sync(nmap: &mut NexthopMap, fib: &FibHandle) {
     let mut cache: Vec<(usize, bool)> = Vec::new();
     for (idx, nhop) in nmap.groups.iter().enumerate() {
         if let Some(Group::Protect(pro)) = nhop {
-            let valid = nmap.get(pro.primary_gid).is_some_and(|g| g.is_valid());
+            // Validity follows whichever member the kernel group
+            // holds — after a switchover that's the repair.
+            let valid = nmap.get(pro.active_gid()).is_some_and(|g| g.is_valid());
             cache.push((idx, valid));
         }
     }
@@ -1624,9 +1627,55 @@ fn resolve_nexthop_protect(pro: &mut NexthopProtect, nmap: &mut NexthopMap) {
     let Some(group) = nmap.fetch_protect(primary_gid, backup_gid) else {
         return;
     };
+    if let Group::Protect(gp) = &mut *group
+        && gp.active == ProtectActive::Switched
+    {
+        // The producer re-asserted this pair, so it believes the
+        // primary is healthy again (post-flap SPF). Revert: clearing
+        // `installed` makes the next protect_group_sync re-send the
+        // group with the primary as member — NLM_F_REPLACE makes
+        // that the atomic swap back. (A pre-failure route add racing
+        // the switchover can revert early; the SPF output right
+        // behind it settles the question either way.)
+        gp.active = ProtectActive::Primary;
+        gp.set_installed(false);
+    }
     group.set_valid(primary_valid);
     group.refcnt_inc();
     pro.gid = group.gid();
+}
+
+/// Fast-reroute switchover (phase 2 of the kernel-failover design):
+/// rewire every protection indirection group whose primary rides the
+/// failed `(table_id, addr)` adjacency onto its repair — one atomic
+/// `RTM_NEWNEXTHOP` replace per group, O(protected adjacencies) and
+/// independent of how many prefixes reference each group. SPF
+/// reconvergence then replaces the routes at its own pace; a re-add
+/// of the same (primary, backup) pair reverts the group (see
+/// `resolve_nexthop_protect`). Returns how many groups switched.
+pub async fn protect_switch(
+    nmap: &mut NexthopMap,
+    fib: &FibHandle,
+    table_id: u32,
+    addr: IpAddr,
+) -> usize {
+    let candidates = nmap.protect_switch_candidates(table_id, addr);
+    let mut switched = 0;
+    for gid in candidates {
+        let Some(Group::Protect(pro)) = nmap.get_mut(gid) else {
+            continue;
+        };
+        pro.active = ProtectActive::Switched;
+        let snapshot = Group::Protect(pro.clone());
+        // CREATE|REPLACE on the same id = atomic membership swap.
+        fib.nexthop_add(&snapshot).await;
+        if let Some(group) = nmap.get_mut(gid) {
+            group.set_installed(true);
+            group.set_valid(true);
+        }
+        switched += 1;
+    }
+    switched
 }
 
 fn resolve_nexthop_member(
@@ -2682,6 +2731,172 @@ mod tests {
         };
         assert_eq!(pro_a.gid, pro_b.gid, "same (primary, backup) pair dedupes");
         assert_eq!(nmap.get(pro_b.gid).unwrap().refcnt(), 2);
+    }
+
+    /// Phase 2: candidate selection for the switchover walks only
+    /// protection groups whose ACTIVE primary rides the failed
+    /// (table, addr) adjacency and whose repair is actually usable.
+    #[test]
+    fn protect_switch_candidates_match_and_gate() {
+        use super::super::entry::RibEntry;
+        use super::super::nexthop::{GroupTrait, NexthopProtect, NexthopUni, ProtectActive};
+        use super::super::{Group, Nexthop, NexthopMap, NexthopMember};
+        use super::super::{RibEntries, RibType};
+        use super::rib_resolve_nexthop;
+        use ipnet::Ipv4Net;
+        use prefix_trie::PrefixMap;
+
+        let mut primary = NexthopUni::new("10.0.0.1".parse().unwrap(), 20, vec![]);
+        primary.ifindex_origin = Some(10);
+        let mut backup = NexthopUni::new("10.0.0.5".parse().unwrap(), 21, vec![]);
+        backup.ifindex_origin = Some(20);
+        let mut entry = RibEntry::new(RibType::Isis);
+        entry.nexthop = Nexthop::Protect(NexthopProtect {
+            primary: NexthopMember::Uni(primary),
+            backup: NexthopMember::Uni(backup),
+            gid: 0,
+        });
+
+        let mut nmap = NexthopMap::default();
+        let table: PrefixMap<Ipv4Net, RibEntries> = PrefixMap::new();
+        rib_resolve_nexthop(&mut entry, &table, &mut nmap, 0);
+        let Nexthop::Protect(pro) = &entry.nexthop else {
+            panic!("still Protect");
+        };
+        let (pro_gid, backup_gid) = match (&pro.backup, pro.gid) {
+            (NexthopMember::Uni(b), gid) => (gid, b.gid),
+            _ => panic!("backup stays Uni"),
+        };
+
+        // Repair not yet installed in the kernel: not a candidate.
+        let addr: std::net::IpAddr = "10.0.0.1".parse().unwrap();
+        assert!(nmap.protect_switch_candidates(0, addr).is_empty());
+
+        // Live repair: candidate, keyed by the primary's (table, addr).
+        nmap.get_mut(backup_gid).unwrap().set_installed(true);
+        assert_eq!(nmap.protect_switch_candidates(0, addr), vec![pro_gid]);
+        assert!(
+            nmap.protect_switch_candidates(0, "10.0.0.9".parse().unwrap())
+                .is_empty(),
+            "other gateways unaffected"
+        );
+        assert!(
+            nmap.protect_switch_candidates(254, addr).is_empty(),
+            "other tables unaffected"
+        );
+
+        // Already switched: nothing left to protect with.
+        if let Some(Group::Protect(gp)) = nmap.get_mut(pro_gid) {
+            gp.active = ProtectActive::Switched;
+        }
+        assert!(nmap.protect_switch_candidates(0, addr).is_empty());
+    }
+
+    /// Phase 2: a seg6 repair can't join a kernel group (6.8
+    /// black-holes it), so such pairs are never switchover candidates
+    /// — they wait for SPF reconvergence as before.
+    #[test]
+    fn protect_switch_candidates_skip_seg6_backup() {
+        use super::super::entry::RibEntry;
+        use super::super::nexthop::{GroupTrait, NexthopProtect, NexthopUni};
+        use super::super::{Nexthop, NexthopMap, NexthopMember};
+        use super::super::{RibEntries, RibType};
+        use super::rib_resolve_nexthop_v6;
+        use ipnet::Ipv6Net;
+        use prefix_trie::PrefixMap;
+
+        let mut primary = NexthopUni::new("fe80::1".parse().unwrap(), 2, vec![]);
+        primary.ifindex_origin = Some(10);
+        let mut backup = NexthopUni::new("fe80::2".parse().unwrap(), 3, vec![]);
+        backup.ifindex_origin = Some(20);
+        backup.segs = vec!["fcbb:bbbb:8::".parse().unwrap()];
+        backup.encap_type = Some(isis_packet::srv6::EncapType::HInsert);
+        let mut entry = RibEntry::new(RibType::Ospf);
+        entry.nexthop = Nexthop::Protect(NexthopProtect {
+            primary: NexthopMember::Uni(primary),
+            backup: NexthopMember::Uni(backup),
+            gid: 0,
+        });
+
+        let mut nmap = NexthopMap::default();
+        let table: PrefixMap<Ipv6Net, RibEntries> = PrefixMap::new();
+        rib_resolve_nexthop_v6(&mut entry, &table, &mut nmap, 254);
+        let Nexthop::Protect(pro) = &entry.nexthop else {
+            panic!("still Protect");
+        };
+        assert_ne!(pro.gid, 0, "plain primary still gets its group");
+        let NexthopMember::Uni(b) = &pro.backup else {
+            panic!("backup Uni");
+        };
+        nmap.get_mut(b.gid).unwrap().set_installed(true);
+        assert!(
+            nmap.protect_switch_candidates(254, "fe80::1".parse().unwrap())
+                .is_empty(),
+            "seg6 backup must never be swapped into the group"
+        );
+    }
+
+    /// Phase 2: a switched group encodes the repair as its kernel
+    /// member, and a producer re-adding the same pair (post-flap SPF)
+    /// reverts it to the primary with a pending re-install.
+    #[test]
+    fn protect_switch_flips_active_and_reassert_reverts() {
+        use super::super::entry::RibEntry;
+        use super::super::nexthop::{GroupTrait, NexthopProtect, NexthopUni, ProtectActive};
+        use super::super::{Group, Nexthop, NexthopMap, NexthopMember};
+        use super::super::{RibEntries, RibType};
+        use super::rib_resolve_nexthop;
+        use ipnet::Ipv4Net;
+        use prefix_trie::PrefixMap;
+
+        let mk_entry = || {
+            let mut primary = NexthopUni::new("10.0.0.1".parse().unwrap(), 20, vec![]);
+            primary.ifindex_origin = Some(10);
+            let mut backup = NexthopUni::new("10.0.0.5".parse().unwrap(), 21, vec![]);
+            backup.ifindex_origin = Some(20);
+            let mut entry = RibEntry::new(RibType::Isis);
+            entry.nexthop = Nexthop::Protect(NexthopProtect {
+                primary: NexthopMember::Uni(primary),
+                backup: NexthopMember::Uni(backup),
+                gid: 0,
+            });
+            entry
+        };
+
+        let mut nmap = NexthopMap::default();
+        let table: PrefixMap<Ipv4Net, RibEntries> = PrefixMap::new();
+        let mut entry = mk_entry();
+        rib_resolve_nexthop(&mut entry, &table, &mut nmap, 0);
+        let Nexthop::Protect(pro) = &entry.nexthop else {
+            panic!("still Protect");
+        };
+        let (primary_gid, backup_gid) = match (&pro.primary, &pro.backup) {
+            (NexthopMember::Uni(p), NexthopMember::Uni(b)) => (p.gid, b.gid),
+            _ => panic!("members stay Uni"),
+        };
+
+        // Simulate the switchover state flip.
+        let Some(Group::Protect(gp)) = nmap.get_mut(pro.gid) else {
+            panic!("protect group");
+        };
+        assert_eq!(gp.active_gid(), primary_gid, "steady state holds primary");
+        gp.active = ProtectActive::Switched;
+        gp.set_installed(true);
+        assert_eq!(gp.active_gid(), backup_gid, "switched state holds repair");
+
+        // Same pair re-added (the producer believes the primary is
+        // healthy again): the group reverts and queues a re-install.
+        let pro_gid = pro.gid;
+        let mut entry2 = mk_entry();
+        rib_resolve_nexthop(&mut entry2, &table, &mut nmap, 0);
+        let Some(Group::Protect(gp)) = nmap.get_mut(pro_gid) else {
+            panic!("protect group");
+        };
+        assert_eq!(gp.active, ProtectActive::Primary, "reassert reverts");
+        assert!(
+            !gp.is_installed(),
+            "pending re-install so the sync pass re-sends the group"
+        );
     }
 
     /// Kernel 6.8 drops seg6-inline traffic routed through a nexthop


### PR DESCRIPTION
## Summary

Phase 2 of `docs/design/nexthop-protect-kernel-failover.md`: the actual fast-reroute switchover.

`Message::ProtectSwitch { addr }` (table-scoped) rewires every protection indirection group whose active primary rides the failed adjacency onto its TI-LFA repair. `GroupProtect` gains `active: Primary | Switched`; `nexthop_add` encodes the **active** member; and because the install request already carries `NLM_F_REPLACE`, re-sending the group after the flip *is* the atomic switchover (probe 3 of the design doc validated this under live traffic) — one netlink message per protected adjacency, O(1) in prefixes.

## Semantics

- **Candidate gates** (`NexthopMap::protect_switch_candidates`, pure + unit-tested): primary matches the failed `(table, addr)`; group still on `Primary`; backup is a Uni (kernel groups don't nest — ECMP backups are phase 5); backup is **non-seg6** (the 6.8 inline-in-group black-hole from phase 1 — that subset keeps waiting for SPF reconvergence exactly as today); backup's kernel object is valid + installed.
- **Revert is producer-driven**: re-adding the same (primary, backup) pair — i.e. the post-flap SPF still believes in that primary — resets `active` to `Primary` with a pending re-install; the next sync re-sends the group with the primary member, same REPLACE mechanics. No timers, no extra state machine.
- Validity in both family sync passes now follows the active member, so a switched group tracks its repair's health.
- `show nexthop` marks the active member with `*`; the trace formatter carries `active`.

## Testing

- New unit tests: candidate matching by (table, addr) + all four gates (uninstalled backup, seg6 backup, already-switched, wrong table/addr); `active_gid` flip; revert-on-reassert with pending re-install.
- `cargo test --workspace --exclude bdd` green (1128 in zebra-rs), workspace clippy `-D warnings` clean (with touched-file re-lint), fmt applied.
- The kernel-side membership swap under live traffic is covered by design-doc probe 3; end-to-end BDD for the link-up failure class lands with phase 3 (the IS-IS trigger), which is what makes it externally observable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)