### PR TITLE
isis: kernel-side failover phase 3 — BFD-down switchover hook

### DIFF
--- a/bdd/Makefile
+++ b/bdd/Makefile
@@ -64,6 +64,10 @@ isis_l1l2:
 	mkdir -p allure-results
 	cargo test --test cucumber -- --concurrency=1 --tags "@isis_l1l2"
 
+tilfa_bfd:
+	mkdir -p allure-results
+	cargo test --test cucumber -- --concurrency=1 --tags "@tilfa_bfd"
+
 isis_redist:
 	mkdir -p allure-results
 	cargo test --test cucumber -- --concurrency=1 --tags "@isis_redist"
@@ -225,4 +229,4 @@ docs/%.md: tests/features/%.feature docs/feature2md.sh FORCE
 
 FORCE:
 
-.PHONY: all run ibgp ebgp rr rib_static_ipv6 isis_ipv6 isis_srv6 isis_fragmentation_ipv6 isis_fragmentation_ipv4 isis_l1p2p isis_tilfa isis_l1l2 isis_redist isis_hello_auth_keychain isis_passive isis_afi_enable isis_endx_ipv6 isis_bfd_ipv6_p2p isis_bfd_ipv6_p2p_echo isis_bfd_ipv6_lan isis_bfd_ipv6_lan_echo isis_bfd_ipv4_p2p isis_bfd_ipv4_p2p_echo isis_bfd_ipv4_lan isis_bfd_ipv4_lan_echo ospf_clear_neighbor ospfv2_nssa ospfv2_stub ospfv2_tilfa ospfv3_nssa ospfv3_tilfa bgp_peer_down_cleanup bgp_ipv6_over_v4_session bgp_evpn_capability bgp_vrf_evpn_type5 bgp_route_map_match bgp_policy_dynamic_update bgp_community bgp_neighbor_group bgp_unnumbered_neighbor nd_show bgp_interas_option_c bgp_interas_option_a bgp_interas_option_b bgp_interas_option_ab generate open docs FORCE
+.PHONY: tilfa_bfd all run ibgp ebgp rr rib_static_ipv6 isis_ipv6 isis_srv6 isis_fragmentation_ipv6 isis_fragmentation_ipv4 isis_l1p2p isis_tilfa isis_l1l2 isis_redist isis_hello_auth_keychain isis_passive isis_afi_enable isis_endx_ipv6 isis_bfd_ipv6_p2p isis_bfd_ipv6_p2p_echo isis_bfd_ipv6_lan isis_bfd_ipv6_lan_echo isis_bfd_ipv4_p2p isis_bfd_ipv4_p2p_echo isis_bfd_ipv4_lan isis_bfd_ipv4_lan_echo ospf_clear_neighbor ospfv2_nssa ospfv2_stub ospfv2_tilfa ospfv3_nssa ospfv3_tilfa bgp_peer_down_cleanup bgp_ipv6_over_v4_session bgp_evpn_capability bgp_vrf_evpn_type5 bgp_route_map_match bgp_policy_dynamic_update bgp_community bgp_neighbor_group bgp_unnumbered_neighbor nd_show bgp_interas_option_c bgp_interas_option_a bgp_interas_option_b bgp_interas_option_ab generate open docs FORCE

--- a/bdd/tests/configs/tilfa_bfd/d.yaml
+++ b/bdd/tests/configs/tilfa_bfd/d.yaml
@@ -1,0 +1,32 @@
+interface:
+- if-name: lo
+  ipv4:
+    address: 10.0.0.8/32
+- if-name: d-n1
+  ipv4:
+    address: 192.168.0.37/30
+- if-name: d-r3
+  ipv4:
+    address: 192.168.0.41/30
+router:
+  isis:
+    net: 49.0000.0000.0000.0008.00
+    hostname: d
+    interface:
+    - if-name: lo
+      ipv4:
+        enable: true
+        prefix-sid:
+          index: 800
+    - if-name: d-n1
+      ipv4:
+        enable: true
+      metric: 1
+    - if-name: d-r3
+      ipv4:
+        enable: true
+      metric: 1
+    is-type: level-2-only
+    segment-routing: mpls
+    fast-reroute: ti-lfa
+    te-router-id: 10.0.0.8

--- a/bdd/tests/configs/tilfa_bfd/n1.yaml
+++ b/bdd/tests/configs/tilfa_bfd/n1.yaml
@@ -1,0 +1,48 @@
+interface:
+- if-name: lo
+  ipv4:
+    address: 10.0.0.2/32
+- if-name: n1-s
+  ipv4:
+    address: 192.168.0.2/30
+- if-name: n1-r1
+  ipv4:
+    address: 192.168.0.13/30
+- if-name: n1-r2
+  ipv4:
+    address: 192.168.0.26/30
+- if-name: n1-d
+  ipv4:
+    address: 192.168.0.38/30
+router:
+  isis:
+    net: 49.0000.0000.0000.0002.00
+    hostname: n1
+    is-type: level-2-only
+    segment-routing: mpls
+    fast-reroute: ti-lfa
+    te-router-id: 10.0.0.2
+    interface:
+    - if-name: lo
+      ipv4:
+        enable: true
+        prefix-sid:
+          index: 200
+    - if-name: n1-s
+      ipv4:
+        enable: true
+      metric: 1
+      bfd:
+        enable: true
+    - if-name: n1-r1
+      ipv4:
+        enable: true
+      metric: 1
+    - if-name: n1-r2
+      ipv4:
+        enable: true
+      metric: 1
+    - if-name: n1-d
+      ipv4:
+        enable: true
+      metric: 1

--- a/bdd/tests/configs/tilfa_bfd/n2.yaml
+++ b/bdd/tests/configs/tilfa_bfd/n2.yaml
@@ -1,0 +1,32 @@
+interface:
+- if-name: lo
+  ipv4:
+    address: 10.0.0.3/32
+- if-name: n2-s
+  ipv4:
+    address: 192.168.0.6/30
+- if-name: n2-r1
+  ipv4:
+    address: 192.168.0.17/30
+router:
+  isis:
+    net: 49.0000.0000.0000.0003.00
+    hostname: n2
+    is-type: level-2-only
+    segment-routing: mpls
+    fast-reroute: ti-lfa
+    te-router-id: 10.0.0.3
+    interface:
+    - if-name: lo
+      ipv4:
+        enable: true
+        prefix-sid:
+          index: 300
+    - if-name: n2-s
+      ipv4:
+        enable: true
+      metric: 1
+    - if-name: n2-r1
+      ipv4:
+        enable: true
+      metric: 1

--- a/bdd/tests/configs/tilfa_bfd/n3.yaml
+++ b/bdd/tests/configs/tilfa_bfd/n3.yaml
@@ -1,0 +1,32 @@
+interface:
+- if-name: lo
+  ipv4:
+    address: 10.0.0.4/32
+- if-name: n3-s
+  ipv4:
+    address: 192.168.0.10/30
+- if-name: n3-r1
+  ipv4:
+    address: 192.168.0.21/30
+router:
+  isis:
+    net: 49.0000.0000.0000.0004.00
+    hostname: n3
+    interface:
+    - if-name: lo
+      ipv4:
+        enable: true
+        prefix-sid:
+          index: 400
+    - if-name: n3-s
+      ipv4:
+        enable: true
+      metric: 1000
+    - if-name: n3-r1
+      ipv4:
+        enable: true
+      metric: 1000
+    is-type: level-2-only
+    segment-routing: mpls
+    fast-reroute: ti-lfa
+    te-router-id: 10.0.0.4

--- a/bdd/tests/configs/tilfa_bfd/r1.yaml
+++ b/bdd/tests/configs/tilfa_bfd/r1.yaml
@@ -1,0 +1,46 @@
+interface:
+- if-name: lo
+  ipv4:
+    address: 10.0.0.5/32
+- if-name: r1-n1
+  ipv4:
+    address: 192.168.0.14/30
+- if-name: r1-n2
+  ipv4:
+    address: 192.168.0.18/30
+- if-name: r1-n3
+  ipv4:
+    address: 192.168.0.22/30
+- if-name: r1-r2
+  ipv4:
+    address: 192.168.0.30/30
+router:
+  isis:
+    net: 49.0000.0000.0000.0005.00
+    hostname: r1
+    interface:
+    - if-name: lo
+      ipv4:
+        enable: true
+        prefix-sid:
+          index: 500
+    - if-name: r1-n1
+      ipv4:
+        enable: true
+      metric: 1
+    - if-name: r1-n2
+      ipv4:
+        enable: true
+      metric: 1
+    - if-name: r1-n3
+      ipv4:
+        enable: true
+      metric: 1000
+    - if-name: r1-r2
+      ipv4:
+        enable: true
+      metric: 1000
+    is-type: level-2-only
+    segment-routing: mpls
+    fast-reroute: ti-lfa
+    te-router-id: 10.0.0.5

--- a/bdd/tests/configs/tilfa_bfd/r2.yaml
+++ b/bdd/tests/configs/tilfa_bfd/r2.yaml
@@ -1,0 +1,39 @@
+interface:
+- if-name: lo
+  ipv4:
+    address: 10.0.0.6/32
+- if-name: r2-n1
+  ipv4:
+    address: 192.168.0.25/30
+- if-name: r2-r1
+  ipv4:
+    address: 192.168.0.29/30
+- if-name: r2-r3
+  ipv4:
+    address: 192.168.0.33/30
+router:
+  isis:
+    net: 49.0000.0000.0000.0006.00
+    hostname: r2
+    interface:
+    - if-name: lo
+      ipv4:
+        enable: true
+        prefix-sid:
+          index: 600
+    - if-name: r2-n1
+      ipv4:
+        enable: true
+      metric: 1
+    - if-name: r2-r1
+      ipv4:
+        enable: true
+      metric: 1000
+    - if-name: r2-r3
+      ipv4:
+        enable: true
+      metric: 1000
+    is-type: level-2-only
+    segment-routing: mpls
+    fast-reroute: ti-lfa
+    te-router-id: 10.0.0.6

--- a/bdd/tests/configs/tilfa_bfd/r3.yaml
+++ b/bdd/tests/configs/tilfa_bfd/r3.yaml
@@ -1,0 +1,32 @@
+interface:
+- if-name: lo
+  ipv4:
+    address: 10.0.0.7/32
+- if-name: r3-r2
+  ipv4:
+    address: 192.168.0.34/30
+- if-name: r3-d
+  ipv4:
+    address: 192.168.0.42/30
+router:
+  isis:
+    net: 49.0000.0000.0000.0007.00
+    hostname: r3
+    interface:
+    - if-name: lo
+      ipv4:
+        enable: true
+        prefix-sid:
+          index: 700
+    - if-name: r3-r2
+      ipv4:
+        enable: true
+      metric: 1000
+    - if-name: r3-d
+      ipv4:
+        enable: true
+      metric: 1
+    is-type: level-2-only
+    segment-routing: mpls
+    fast-reroute: ti-lfa
+    te-router-id: 10.0.0.7

--- a/bdd/tests/configs/tilfa_bfd/s.yaml
+++ b/bdd/tests/configs/tilfa_bfd/s.yaml
@@ -1,0 +1,41 @@
+interface:
+- if-name: lo
+  ipv4:
+    address: 10.0.0.1/32
+- if-name: s-n1
+  ipv4:
+    address: 192.168.0.1/30
+- if-name: s-n2
+  ipv4:
+    address: 192.168.0.5/30
+- if-name: s-n3
+  ipv4:
+    address: 192.168.0.9/30
+router:
+  isis:
+    net: 49.0000.0000.0000.0001.00
+    hostname: s
+    interface:
+    - if-name: lo
+      ipv4:
+        enable: true
+        prefix-sid:
+          index: 100
+    - if-name: s-n1
+      ipv4:
+        enable: true
+      metric: 1
+      bfd:
+        enable: true
+    - if-name: s-n2
+      ipv4:
+        enable: true
+      metric: 1
+    - if-name: s-n3
+      ipv4:
+        enable: true
+      metric: 1000
+    is-type: level-2-only
+    segment-routing: mpls
+    fast-reroute: ti-lfa
+    te-router-id: 10.0.0.1

--- a/bdd/tests/cucumber.rs
+++ b/bdd/tests/cucumber.rs
@@ -1734,6 +1734,48 @@ async fn kernel_route_eventually_contains(
     );
 }
 
+/// Poll the namespace's daemon log (`logs/<scoped>.log`, where
+/// `start_zebra_rs` pointed --log-file) for a substring. This is how a
+/// scenario asserts on internal events that leave no stable external
+/// state — e.g. the fast-reroute switchover, whose kernel effect is
+/// superseded by SPF reconvergence within milliseconds while the log
+/// line is durable. Stacked given/when/then so utility use anywhere in
+/// a scenario can't trip the cucumber-rs keyword-context skip.
+#[given(expr = "daemon log in namespace {string} should eventually contain {string}")]
+#[when(expr = "daemon log in namespace {string} should eventually contain {string}")]
+#[then(expr = "daemon log in namespace {string} should eventually contain {string}")]
+async fn daemon_log_eventually_contains(world: &mut World, namespace: String, needle: String) {
+    let scoped = world.ns(&namespace);
+    let path = format!("logs/{}.log", scoped);
+    const ATTEMPTS: u32 = 30;
+    let mut last_len = 0usize;
+    for i in 0..ATTEMPTS {
+        let content = fs::read_to_string(&path).unwrap_or_default();
+        if content.contains(&needle) {
+            println!("✓ daemon log {} contains '{}'", path, needle);
+            return;
+        }
+        last_len = content.len();
+        if i + 1 < ATTEMPTS {
+            tokio::time::sleep(tokio::time::Duration::from_secs(1)).await;
+        }
+    }
+    let tail: String = fs::read_to_string(&path)
+        .unwrap_or_default()
+        .lines()
+        .rev()
+        .take(20)
+        .collect::<Vec<_>>()
+        .into_iter()
+        .rev()
+        .collect::<Vec<_>>()
+        .join("\n");
+    panic!(
+        "daemon log {} ({} bytes) did not contain '{}' after {} attempts; last lines:\n{}",
+        path, last_len, needle, ATTEMPTS, tail
+    );
+}
+
 /// Negative sibling: poll until `ip route show <prefix>` returns
 /// nothing — the route has been withdrawn from the kernel FIB.
 #[then(expr = "kernel route {string} in namespace {string} should eventually be gone")]

--- a/bdd/tests/features/isis_tilfa_bfd.feature
+++ b/bdd/tests/features/isis_tilfa_bfd.feature
@@ -1,0 +1,126 @@
+@tilfa_bfd
+@isis
+@bfd
+Feature: IS-IS TI-LFA kernel-side fast-reroute on BFD failure
+  As a network operator
+  I want a BFD-detected primary failure (the link stays up, so the
+  kernel cannot see it) to rewire the pre-installed protection
+  indirection groups onto their TI-LFA repairs in one atomic kernel
+  operation per failed adjacency, BEFORE SPF reconvergence rewrites
+  the routes — phase 3 of docs/design/nexthop-protect-kernel-failover.md.
+
+  The topology is the isis_tilfa SR-MPLS ring with BFD enabled on the
+  protected s<->n1 adjacency. BFD-down is induced by dropping inbound
+  UDP/3784 in namespace s: the veth link stays up and IIHs (ISO L2
+  PDUs, not IP) keep flowing, so the teardown is provably BFD's doing
+  — the exact failure class the kernel's autonomous link-down path
+  cannot cover.
+
+  The switchover itself is observable only in the daemon log (the
+  "rewired N protection group(s) onto repairs" line is emitted ONLY
+  when at least one group actually moved): its kernel state is
+  superseded within milliseconds by the post-convergence SPF routes,
+  which is by design — the switchover is a bridge, not a steady state.
+
+  Test Topology (same wiring and metrics as isis_tilfa):
+  ```
+                 s (10.0.0.1)
+             1 / 1 \      \ 1000
+              n1    n2     n3        s-n1 carries BFD; protecting it
+          1 / |1 \1  \1     \1000    requires an SR repair through
+       d ─┘ 1 |   \    \      \      the r-plane (no plain LFA).
+    (10.0.0.8)│    \1000\      \
+          1 \ │     r1───────── (r1-n3 1000)
+             r3    /  \1000
+          1000\   /1   \(r1-r2 1000)
+               r2 ──────┘
+                 \1000
+                  r3 (r3-d 1)
+  ```
+
+  Scenario: Build the topology and confirm adjacency, BFD, and repairs
+    Given a clean test environment
+    When I create namespace "s"
+    And I create namespace "n1"
+    And I create namespace "n2"
+    And I create namespace "n3"
+    And I create namespace "r1"
+    And I create namespace "r2"
+    And I create namespace "r3"
+    And I create namespace "d"
+    And I connect namespace "s" interface "s-n1" to namespace "n1" interface "n1-s"
+    And I connect namespace "s" interface "s-n2" to namespace "n2" interface "n2-s"
+    And I connect namespace "s" interface "s-n3" to namespace "n3" interface "n3-s"
+    And I connect namespace "n1" interface "n1-r1" to namespace "r1" interface "r1-n1"
+    And I connect namespace "n2" interface "n2-r1" to namespace "r1" interface "r1-n2"
+    And I connect namespace "n3" interface "n3-r1" to namespace "r1" interface "r1-n3"
+    And I connect namespace "n1" interface "n1-r2" to namespace "r2" interface "r2-n1"
+    And I connect namespace "r1" interface "r1-r2" to namespace "r2" interface "r2-r1"
+    And I connect namespace "r2" interface "r2-r3" to namespace "r3" interface "r3-r2"
+    And I connect namespace "n1" interface "n1-d" to namespace "d" interface "d-n1"
+    And I connect namespace "r3" interface "r3-d" to namespace "d" interface "d-r3"
+    And I start zebra-rs in namespace "s"
+    And I start zebra-rs in namespace "n1"
+    And I start zebra-rs in namespace "n2"
+    And I start zebra-rs in namespace "n3"
+    And I start zebra-rs in namespace "r1"
+    And I start zebra-rs in namespace "r2"
+    And I start zebra-rs in namespace "r3"
+    And I start zebra-rs in namespace "d"
+    And I apply config "s.yaml" to namespace "s"
+    And I apply config "n1.yaml" to namespace "n1"
+    And I apply config "n2.yaml" to namespace "n2"
+    And I apply config "n3.yaml" to namespace "n3"
+    And I apply config "r1.yaml" to namespace "r1"
+    And I apply config "r2.yaml" to namespace "r2"
+    And I apply config "r3.yaml" to namespace "r3"
+    And I apply config "d.yaml" to namespace "d"
+    And I wait 10 seconds
+    Then bfd session in namespace "s" on interface "s-n1" should be up
+    And show command "show isis route detail" in namespace "s" should contain "Backup path: TI-LFA"
+    And ping from "s" to "10.0.0.8" should succeed
+    And ping from "d" to "10.0.0.1" should succeed
+
+  Scenario: BFD-down with the link up triggers the kernel-side switchover
+    Given the test topology exists
+    Then ping from "s" to "10.0.0.8" should succeed
+    # Kill BFD only: the link stays up (no autonomous kernel flush) and
+    # IIHs keep flowing (no IS-IS hold-timer expiry) — s must learn of
+    # the failure from BFD and bridge traffic onto the repairs itself.
+    When I drop bfd control packets in namespace "s"
+    Then bfd session in namespace "s" on interface "s-n1" should be down
+    # The switchover fired: at least one protection group was rewired
+    # onto its repair (this exact line is only logged when N > 0).
+    And daemon log in namespace "s" should eventually contain "rewired"
+    And daemon log in namespace "s" should eventually contain "protection group(s) onto repairs"
+    # SPF reconvergence then re-routes around n1 entirely: d is reached
+    # out the s-n2 plane, and forwarding is healthy end to end.
+    And kernel route "10.0.0.8" in namespace "s" should eventually contain "dev s-n2"
+    And ping from "s" to "10.0.0.8" should succeed
+    # Recovery: BFD re-establishes, the hold-down lifts, and the
+    # primary path through n1 comes back.
+    When I restore bfd control packets in namespace "s"
+    And I wait 15 seconds
+    Then bfd session in namespace "s" on interface "s-n1" should be up
+    And kernel route "10.0.0.8" in namespace "s" should eventually contain "dev s-n1"
+    And ping from "s" to "10.0.0.8" should succeed
+
+  Scenario: Teardown topology
+    Given the test topology exists
+    When I stop zebra-rs in namespace "s"
+    And I stop zebra-rs in namespace "n1"
+    And I stop zebra-rs in namespace "n2"
+    And I stop zebra-rs in namespace "n3"
+    And I stop zebra-rs in namespace "r1"
+    And I stop zebra-rs in namespace "r2"
+    And I stop zebra-rs in namespace "r3"
+    And I stop zebra-rs in namespace "d"
+    And I delete namespace "s"
+    And I delete namespace "n1"
+    And I delete namespace "n2"
+    And I delete namespace "n3"
+    And I delete namespace "r1"
+    And I delete namespace "r2"
+    And I delete namespace "r3"
+    And I delete namespace "d"
+    Then the test environment should be clean

--- a/docs/design/nexthop-protect-kernel-failover.md
+++ b/docs/design/nexthop-protect-kernel-failover.md
@@ -21,7 +21,7 @@ paths for protected routes.
 | 0 — `Nexthop::Protect` RIB shape | #1370, #1373 | explicit primary/backup pair, producers + consumers, v6 resolver fix |
 | 1 — indirection group | #1374 | `Group::Protect` + `NexthopProtect.gid`; protected v4/v6 routes reference a 1-member kernel group; behavior-neutral |
 | 2 — switchover op | #1377 | `Message::ProtectSwitch` + `GroupProtect.active` + atomic group re-send; revert-on-reassert |
-| 3 — IS-IS hook | — | BFD/adjacency-down emits `ProtectSwitch` before SPF; BDD for the link-up failure class |
+| 3 — IS-IS hook | #1378 | `process_bfd_down` emits `ProtectSwitch` per failed nexthop addr before SPF; `@tilfa_bfd` BDD for the link-up failure class |
 | 4 — OSPF hook | — | v2 + v3, same shape |
 | 5 — ECMP leg-level replace | — | per-leg repair on `Multi` primaries |
 

--- a/zebra-rs/src/isis/inst.rs
+++ b/zebra-rs/src/isis/inst.rs
@@ -2479,6 +2479,16 @@ impl Isis {
                 "isis: tearing down adjacency on bfd-down (RFC 5882 §5)",
             );
         }
+        // Capture the neighbour's nexthop addresses BEFORE the teardown
+        // removes the entry — these are the exact keys SPF used for this
+        // adjacency's routes (v4: interface addrs from TLV 132, v6: the
+        // link-locals from TLV 232), i.e. the addresses the RIB's
+        // protection groups key their primaries on.
+        let mut failed_nhops: Vec<std::net::IpAddr> = Vec::new();
+        if let Some(nbr) = link.state.nbrs.get(&level).get(&sys_id) {
+            failed_nhops.extend(nbr.addr4.keys().copied().map(std::net::IpAddr::V4));
+            failed_nhops.extend(nbr.addr6l.iter().copied().map(std::net::IpAddr::V6));
+        }
         // Tear the adjacency but keep the BFD session probing. This clears any
         // prior hold-down pin, so set the pin afterwards.
         nbr_hold_timer_expire(&mut link, level, sys_id, false);
@@ -2487,6 +2497,16 @@ impl Isis {
         // if the neighbour entry is absent from `nbrs` at that point (race:
         // BFD Up fires before the next IIH re-creates the entry).
         link.state.bfd_holddown_nbr.insert(*key, (level, sys_id));
+        drop(link);
+        // Fast-reroute switchover (kernel-failover phase 3): rewire the
+        // pre-installed protection groups onto their TI-LFA repairs NOW,
+        // before the LSP regeneration / SPF / per-prefix reinstall pipeline
+        // even starts. One message per failed nexthop address; the RIB
+        // no-ops when nothing is protected. Channel ordering guarantees
+        // this lands before the post-convergence route updates.
+        for addr in failed_nhops {
+            let _ = self.ctx.rib.protect_switch(addr);
+        }
     }
 
     /// BFD session came Up: lift any hold-down pin for the neighbour so the

--- a/zebra-rs/src/isis/inst.rs
+++ b/zebra-rs/src/isis/inst.rs
@@ -2497,7 +2497,6 @@ impl Isis {
         // if the neighbour entry is absent from `nbrs` at that point (race:
         // BFD Up fires before the next IIH re-creates the entry).
         link.state.bfd_holddown_nbr.insert(*key, (level, sys_id));
-        drop(link);
         // Fast-reroute switchover (kernel-failover phase 3): rewire the
         // pre-installed protection groups onto their TI-LFA repairs NOW,
         // before the LSP regeneration / SPF / per-prefix reinstall pipeline

--- a/zebra-rs/src/rib/client.rs
+++ b/zebra-rs/src/rib/client.rs
@@ -136,10 +136,6 @@ impl RibClient {
     /// this on a BFD-down-with-link-up detection, BEFORE starting
     /// SPF, so traffic moves to the pre-installed TI-LFA repairs in
     /// O(adjacencies) while reconvergence runs.
-    // Callers are the phase-3/4 IGP BFD hooks; `expect` forces this
-    // annotation off when the first one lands (zebra-rs is a bin
-    // crate, so `pub` alone doesn't exempt it from dead-code).
-    #[expect(dead_code)]
     pub fn protect_switch(&self, addr: std::net::IpAddr) -> Result<(), SendError<RibInbound>> {
         self.send(Message::ProtectSwitch { addr })
     }

--- a/zebra-rs/src/rib/inst.rs
+++ b/zebra-rs/src/rib/inst.rs
@@ -1582,7 +1582,16 @@ impl Rib {
                 let n =
                     super::route::protect_switch(&mut self.nmap, &self.fib_handle, table_id, addr)
                         .await;
-                tracing::info!("ProtectSwitch {addr} table {table_id}: {n} group(s) rewired");
+                // Distinct info line ONLY when something actually moved —
+                // the BDD log assertion keys on this exact phrasing, so a
+                // zero-candidate no-op must not be able to satisfy it.
+                if n > 0 {
+                    tracing::info!(
+                        "ProtectSwitch {addr} table {table_id}: rewired {n} protection group(s) onto repairs"
+                    );
+                } else {
+                    tracing::debug!("ProtectSwitch {addr} table {table_id}: no eligible groups");
+                }
             }
             Message::NexthopUnregister { proto, nh } => {
                 self.nht.unregister(&proto, nh);


### PR DESCRIPTION
## Summary

Phase 3 of `docs/design/nexthop-protect-kernel-failover.md`: the IS-IS trigger that makes the fast path real, end to end.

`process_bfd_down` captures the failing neighbour's nexthop addresses (`addr4` keys + `addr6l` link-locals — exactly the keys SPF used for this adjacency's routes, so they match the protection groups' primary keying) before the adjacency teardown, then sends `RibClient::protect_switch` for each. Channel ordering guarantees the switchover lands at the RIB before any post-convergence route update: traffic bridges onto the pre-installed TI-LFA repairs in **one atomic kernel group-replace per failed adjacency**, prefix-count-independent, while LSP regeneration → SPF → reinstall runs at its own pace.

- VRF instances inherit through their table-bound `RibClient`.
- The `#[expect(dead_code)]` gate from #1377 comes off, as designed.
- The handler logs `rewired N protection group(s) onto repairs` **only when N > 0** — a zero-candidate no-op cannot satisfy the BDD assertion.

## BDD

The switchover leaves no stable external state (SPF supersedes its kernel effect within milliseconds — by design, it's a bridge), so:

- New step: `daemon log in namespace {ns} should eventually contain {needle}` (polling, given/when/then-stacked per the keyword-context gotcha).
- New `@tilfa_bfd` feature: the isis_tilfa SR-MPLS ring with BFD on the protected s↔n1 adjacency. Dropping inbound UDP/3784 kills BFD while **the link and IIHs stay up** — the exact failure class the kernel's autonomous link-down flush cannot cover, and the gap row in the design doc's failure-class table. Asserts: BFD down → switchover log line → SPF re-route out `s-n2` → recovery restores `s-n1`. Explicit teardown scenario included; tag `tilfa_bfd` has no prefix relation with any scoping tag.

## Testing

- Local BDD, md5-stable binary: `@tilfa_bfd` 3/3 scenarios, `@isis_tilfa` 8/8 (TI-LFA regression), `@isis_bfd_ipv4_p2p` no-echo (the modified BFD-down path no-ops cleanly without TI-LFA).
- `cargo test --workspace --exclude bdd` green; workspace clippy `-D warnings` clean with all changed files touch-relinted; fmt applied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)