### PR TITLE
ospf: kernel-side failover phase 4 — BFD-down switchover hook (v2+v3)

### DIFF
--- a/bdd/Makefile
+++ b/bdd/Makefile
@@ -68,6 +68,14 @@ tilfa_bfd:
 	mkdir -p allure-results
 	cargo test --test cucumber -- --concurrency=1 --tags "@tilfa_bfd"
 
+ospfv2_bfd_frr:
+	mkdir -p allure-results
+	cargo test --test cucumber -- --concurrency=1 --tags "@ospfv2_bfd_frr"
+
+ospfv3_bfd_frr:
+	mkdir -p allure-results
+	cargo test --test cucumber -- --concurrency=1 --tags "@ospfv3_bfd_frr"
+
 isis_redist:
 	mkdir -p allure-results
 	cargo test --test cucumber -- --concurrency=1 --tags "@isis_redist"
@@ -229,4 +237,4 @@ docs/%.md: tests/features/%.feature docs/feature2md.sh FORCE
 
 FORCE:
 
-.PHONY: tilfa_bfd all run ibgp ebgp rr rib_static_ipv6 isis_ipv6 isis_srv6 isis_fragmentation_ipv6 isis_fragmentation_ipv4 isis_l1p2p isis_tilfa isis_l1l2 isis_redist isis_hello_auth_keychain isis_passive isis_afi_enable isis_endx_ipv6 isis_bfd_ipv6_p2p isis_bfd_ipv6_p2p_echo isis_bfd_ipv6_lan isis_bfd_ipv6_lan_echo isis_bfd_ipv4_p2p isis_bfd_ipv4_p2p_echo isis_bfd_ipv4_lan isis_bfd_ipv4_lan_echo ospf_clear_neighbor ospfv2_nssa ospfv2_stub ospfv2_tilfa ospfv3_nssa ospfv3_tilfa bgp_peer_down_cleanup bgp_ipv6_over_v4_session bgp_evpn_capability bgp_vrf_evpn_type5 bgp_route_map_match bgp_policy_dynamic_update bgp_community bgp_neighbor_group bgp_unnumbered_neighbor nd_show bgp_interas_option_c bgp_interas_option_a bgp_interas_option_b bgp_interas_option_ab generate open docs FORCE
+.PHONY: ospfv2_bfd_frr ospfv3_bfd_frr tilfa_bfd all run ibgp ebgp rr rib_static_ipv6 isis_ipv6 isis_srv6 isis_fragmentation_ipv6 isis_fragmentation_ipv4 isis_l1p2p isis_tilfa isis_l1l2 isis_redist isis_hello_auth_keychain isis_passive isis_afi_enable isis_endx_ipv6 isis_bfd_ipv6_p2p isis_bfd_ipv6_p2p_echo isis_bfd_ipv6_lan isis_bfd_ipv6_lan_echo isis_bfd_ipv4_p2p isis_bfd_ipv4_p2p_echo isis_bfd_ipv4_lan isis_bfd_ipv4_lan_echo ospf_clear_neighbor ospfv2_nssa ospfv2_stub ospfv2_tilfa ospfv3_nssa ospfv3_tilfa bgp_peer_down_cleanup bgp_ipv6_over_v4_session bgp_evpn_capability bgp_vrf_evpn_type5 bgp_route_map_match bgp_policy_dynamic_update bgp_community bgp_neighbor_group bgp_unnumbered_neighbor nd_show bgp_interas_option_c bgp_interas_option_a bgp_interas_option_b bgp_interas_option_ab generate open docs FORCE

--- a/bdd/tests/configs/ospfv2_bfd_frr/d.yaml
+++ b/bdd/tests/configs/ospfv2_bfd_frr/d.yaml
@@ -1,0 +1,32 @@
+interface:
+- if-name: lo
+  ipv4:
+    address: 10.0.0.8/32
+- if-name: d-n1
+  ipv4:
+    address: 192.168.0.37/30
+- if-name: d-r3
+  ipv4:
+    address: 192.168.0.41/30
+router:
+  ospf:
+    router-id: 10.0.0.8
+    segment-routing:
+      mpls: {}
+    fast-reroute:
+      ti-lfa: {}
+    area:
+    - area-id: 0.0.0.0
+      interface:
+      - if-name: lo
+        enable: true
+        prefix-sid:
+          index: 800
+      - if-name: d-n1
+        enable: true
+        network-type: point-to-point
+        cost: 1
+      - if-name: d-r3
+        enable: true
+        network-type: point-to-point
+        cost: 1

--- a/bdd/tests/configs/ospfv2_bfd_frr/n1.yaml
+++ b/bdd/tests/configs/ospfv2_bfd_frr/n1.yaml
@@ -1,0 +1,48 @@
+interface:
+- if-name: lo
+  ipv4:
+    address: 10.0.0.2/32
+- if-name: n1-s
+  ipv4:
+    address: 192.168.0.2/30
+- if-name: n1-r1
+  ipv4:
+    address: 192.168.0.13/30
+- if-name: n1-r2
+  ipv4:
+    address: 192.168.0.26/30
+- if-name: n1-d
+  ipv4:
+    address: 192.168.0.38/30
+router:
+  ospf:
+    router-id: 10.0.0.2
+    segment-routing:
+      mpls: {}
+    fast-reroute:
+      ti-lfa: {}
+    area:
+    - area-id: 0.0.0.0
+      interface:
+      - if-name: lo
+        enable: true
+        prefix-sid:
+          index: 200
+      - if-name: n1-s
+        enable: true
+        network-type: point-to-point
+        cost: 1
+        bfd:
+          enable: true
+      - if-name: n1-r1
+        enable: true
+        network-type: point-to-point
+        cost: 1
+      - if-name: n1-r2
+        enable: true
+        network-type: point-to-point
+        cost: 1
+      - if-name: n1-d
+        enable: true
+        network-type: point-to-point
+        cost: 1

--- a/bdd/tests/configs/ospfv2_bfd_frr/n2.yaml
+++ b/bdd/tests/configs/ospfv2_bfd_frr/n2.yaml
@@ -1,0 +1,32 @@
+interface:
+- if-name: lo
+  ipv4:
+    address: 10.0.0.3/32
+- if-name: n2-s
+  ipv4:
+    address: 192.168.0.6/30
+- if-name: n2-r1
+  ipv4:
+    address: 192.168.0.17/30
+router:
+  ospf:
+    router-id: 10.0.0.3
+    segment-routing:
+      mpls: {}
+    fast-reroute:
+      ti-lfa: {}
+    area:
+    - area-id: 0.0.0.0
+      interface:
+      - if-name: lo
+        enable: true
+        prefix-sid:
+          index: 300
+      - if-name: n2-s
+        enable: true
+        network-type: point-to-point
+        cost: 1
+      - if-name: n2-r1
+        enable: true
+        network-type: point-to-point
+        cost: 1

--- a/bdd/tests/configs/ospfv2_bfd_frr/n3.yaml
+++ b/bdd/tests/configs/ospfv2_bfd_frr/n3.yaml
@@ -1,0 +1,32 @@
+interface:
+- if-name: lo
+  ipv4:
+    address: 10.0.0.4/32
+- if-name: n3-s
+  ipv4:
+    address: 192.168.0.10/30
+- if-name: n3-r1
+  ipv4:
+    address: 192.168.0.21/30
+router:
+  ospf:
+    router-id: 10.0.0.4
+    segment-routing:
+      mpls: {}
+    fast-reroute:
+      ti-lfa: {}
+    area:
+    - area-id: 0.0.0.0
+      interface:
+      - if-name: lo
+        enable: true
+        prefix-sid:
+          index: 400
+      - if-name: n3-s
+        enable: true
+        network-type: point-to-point
+        cost: 1000
+      - if-name: n3-r1
+        enable: true
+        network-type: point-to-point
+        cost: 1000

--- a/bdd/tests/configs/ospfv2_bfd_frr/r1.yaml
+++ b/bdd/tests/configs/ospfv2_bfd_frr/r1.yaml
@@ -1,0 +1,46 @@
+interface:
+- if-name: lo
+  ipv4:
+    address: 10.0.0.5/32
+- if-name: r1-n1
+  ipv4:
+    address: 192.168.0.14/30
+- if-name: r1-n2
+  ipv4:
+    address: 192.168.0.18/30
+- if-name: r1-n3
+  ipv4:
+    address: 192.168.0.22/30
+- if-name: r1-r2
+  ipv4:
+    address: 192.168.0.30/30
+router:
+  ospf:
+    router-id: 10.0.0.5
+    segment-routing:
+      mpls: {}
+    fast-reroute:
+      ti-lfa: {}
+    area:
+    - area-id: 0.0.0.0
+      interface:
+      - if-name: lo
+        enable: true
+        prefix-sid:
+          index: 500
+      - if-name: r1-n1
+        enable: true
+        network-type: point-to-point
+        cost: 1
+      - if-name: r1-n2
+        enable: true
+        network-type: point-to-point
+        cost: 1
+      - if-name: r1-n3
+        enable: true
+        network-type: point-to-point
+        cost: 1000
+      - if-name: r1-r2
+        enable: true
+        network-type: point-to-point
+        cost: 1000

--- a/bdd/tests/configs/ospfv2_bfd_frr/r2.yaml
+++ b/bdd/tests/configs/ospfv2_bfd_frr/r2.yaml
@@ -1,0 +1,39 @@
+interface:
+- if-name: lo
+  ipv4:
+    address: 10.0.0.6/32
+- if-name: r2-n1
+  ipv4:
+    address: 192.168.0.25/30
+- if-name: r2-r1
+  ipv4:
+    address: 192.168.0.29/30
+- if-name: r2-r3
+  ipv4:
+    address: 192.168.0.33/30
+router:
+  ospf:
+    router-id: 10.0.0.6
+    segment-routing:
+      mpls: {}
+    fast-reroute:
+      ti-lfa: {}
+    area:
+    - area-id: 0.0.0.0
+      interface:
+      - if-name: lo
+        enable: true
+        prefix-sid:
+          index: 600
+      - if-name: r2-n1
+        enable: true
+        network-type: point-to-point
+        cost: 1
+      - if-name: r2-r1
+        enable: true
+        network-type: point-to-point
+        cost: 1000
+      - if-name: r2-r3
+        enable: true
+        network-type: point-to-point
+        cost: 1000

--- a/bdd/tests/configs/ospfv2_bfd_frr/r3.yaml
+++ b/bdd/tests/configs/ospfv2_bfd_frr/r3.yaml
@@ -1,0 +1,32 @@
+interface:
+- if-name: lo
+  ipv4:
+    address: 10.0.0.7/32
+- if-name: r3-r2
+  ipv4:
+    address: 192.168.0.34/30
+- if-name: r3-d
+  ipv4:
+    address: 192.168.0.42/30
+router:
+  ospf:
+    router-id: 10.0.0.7
+    segment-routing:
+      mpls: {}
+    fast-reroute:
+      ti-lfa: {}
+    area:
+    - area-id: 0.0.0.0
+      interface:
+      - if-name: lo
+        enable: true
+        prefix-sid:
+          index: 700
+      - if-name: r3-r2
+        enable: true
+        network-type: point-to-point
+        cost: 1000
+      - if-name: r3-d
+        enable: true
+        network-type: point-to-point
+        cost: 1

--- a/bdd/tests/configs/ospfv2_bfd_frr/s.yaml
+++ b/bdd/tests/configs/ospfv2_bfd_frr/s.yaml
@@ -1,0 +1,41 @@
+interface:
+- if-name: lo
+  ipv4:
+    address: 10.0.0.1/32
+- if-name: s-n1
+  ipv4:
+    address: 192.168.0.1/30
+- if-name: s-n2
+  ipv4:
+    address: 192.168.0.5/30
+- if-name: s-n3
+  ipv4:
+    address: 192.168.0.9/30
+router:
+  ospf:
+    router-id: 10.0.0.1
+    segment-routing:
+      mpls: {}
+    fast-reroute:
+      ti-lfa: {}
+    area:
+    - area-id: 0.0.0.0
+      interface:
+      - if-name: lo
+        enable: true
+        prefix-sid:
+          index: 100
+      - if-name: s-n1
+        enable: true
+        network-type: point-to-point
+        cost: 1
+        bfd:
+          enable: true
+      - if-name: s-n2
+        enable: true
+        network-type: point-to-point
+        cost: 1
+      - if-name: s-n3
+        enable: true
+        network-type: point-to-point
+        cost: 1000

--- a/bdd/tests/configs/ospfv3_bfd_frr/d.yaml
+++ b/bdd/tests/configs/ospfv3_bfd_frr/d.yaml
@@ -1,0 +1,32 @@
+interface:
+- if-name: lo
+  ipv6:
+    address: 2001:db8::8/128
+- if-name: d-n1
+  ipv6:
+    address: 2001:db8:10::2/64
+- if-name: d-r3
+  ipv6:
+    address: 2001:db8:11::2/64
+router:
+  ospfv3:
+    router-id: 10.0.0.8
+    segment-routing:
+      mpls: {}
+    fast-reroute:
+      ti-lfa: {}
+    area:
+    - area-id: 0.0.0.0
+      interface:
+      - if-name: lo
+        enable: true
+        prefix-sid:
+          index: 800
+      - if-name: d-n1
+        enable: true
+        network-type: point-to-point
+        cost: 1
+      - if-name: d-r3
+        enable: true
+        network-type: point-to-point
+        cost: 1

--- a/bdd/tests/configs/ospfv3_bfd_frr/n1.yaml
+++ b/bdd/tests/configs/ospfv3_bfd_frr/n1.yaml
@@ -1,0 +1,48 @@
+interface:
+- if-name: lo
+  ipv6:
+    address: 2001:db8::2/128
+- if-name: n1-s
+  ipv6:
+    address: 2001:db8:1::2/64
+- if-name: n1-r1
+  ipv6:
+    address: 2001:db8:4::1/64
+- if-name: n1-r2
+  ipv6:
+    address: 2001:db8:7::1/64
+- if-name: n1-d
+  ipv6:
+    address: 2001:db8:10::1/64
+router:
+  ospfv3:
+    router-id: 10.0.0.2
+    segment-routing:
+      mpls: {}
+    fast-reroute:
+      ti-lfa: {}
+    area:
+    - area-id: 0.0.0.0
+      interface:
+      - if-name: lo
+        enable: true
+        prefix-sid:
+          index: 200
+      - if-name: n1-s
+        enable: true
+        network-type: point-to-point
+        cost: 1
+        bfd:
+          enable: true
+      - if-name: n1-r1
+        enable: true
+        network-type: point-to-point
+        cost: 1
+      - if-name: n1-r2
+        enable: true
+        network-type: point-to-point
+        cost: 1
+      - if-name: n1-d
+        enable: true
+        network-type: point-to-point
+        cost: 1

--- a/bdd/tests/configs/ospfv3_bfd_frr/n2.yaml
+++ b/bdd/tests/configs/ospfv3_bfd_frr/n2.yaml
@@ -1,0 +1,32 @@
+interface:
+- if-name: lo
+  ipv6:
+    address: 2001:db8::3/128
+- if-name: n2-s
+  ipv6:
+    address: 2001:db8:2::2/64
+- if-name: n2-r1
+  ipv6:
+    address: 2001:db8:5::1/64
+router:
+  ospfv3:
+    router-id: 10.0.0.3
+    segment-routing:
+      mpls: {}
+    fast-reroute:
+      ti-lfa: {}
+    area:
+    - area-id: 0.0.0.0
+      interface:
+      - if-name: lo
+        enable: true
+        prefix-sid:
+          index: 300
+      - if-name: n2-s
+        enable: true
+        network-type: point-to-point
+        cost: 1
+      - if-name: n2-r1
+        enable: true
+        network-type: point-to-point
+        cost: 1

--- a/bdd/tests/configs/ospfv3_bfd_frr/n3.yaml
+++ b/bdd/tests/configs/ospfv3_bfd_frr/n3.yaml
@@ -1,0 +1,32 @@
+interface:
+- if-name: lo
+  ipv6:
+    address: 2001:db8::4/128
+- if-name: n3-s
+  ipv6:
+    address: 2001:db8:3::2/64
+- if-name: n3-r1
+  ipv6:
+    address: 2001:db8:6::1/64
+router:
+  ospfv3:
+    router-id: 10.0.0.4
+    segment-routing:
+      mpls: {}
+    fast-reroute:
+      ti-lfa: {}
+    area:
+    - area-id: 0.0.0.0
+      interface:
+      - if-name: lo
+        enable: true
+        prefix-sid:
+          index: 400
+      - if-name: n3-s
+        enable: true
+        network-type: point-to-point
+        cost: 1000
+      - if-name: n3-r1
+        enable: true
+        network-type: point-to-point
+        cost: 1000

--- a/bdd/tests/configs/ospfv3_bfd_frr/r1.yaml
+++ b/bdd/tests/configs/ospfv3_bfd_frr/r1.yaml
@@ -1,0 +1,46 @@
+interface:
+- if-name: lo
+  ipv6:
+    address: 2001:db8::5/128
+- if-name: r1-n1
+  ipv6:
+    address: 2001:db8:4::2/64
+- if-name: r1-n2
+  ipv6:
+    address: 2001:db8:5::2/64
+- if-name: r1-n3
+  ipv6:
+    address: 2001:db8:6::2/64
+- if-name: r1-r2
+  ipv6:
+    address: 2001:db8:8::1/64
+router:
+  ospfv3:
+    router-id: 10.0.0.5
+    segment-routing:
+      mpls: {}
+    fast-reroute:
+      ti-lfa: {}
+    area:
+    - area-id: 0.0.0.0
+      interface:
+      - if-name: lo
+        enable: true
+        prefix-sid:
+          index: 500
+      - if-name: r1-n1
+        enable: true
+        network-type: point-to-point
+        cost: 1
+      - if-name: r1-n2
+        enable: true
+        network-type: point-to-point
+        cost: 1
+      - if-name: r1-n3
+        enable: true
+        network-type: point-to-point
+        cost: 1000
+      - if-name: r1-r2
+        enable: true
+        network-type: point-to-point
+        cost: 1000

--- a/bdd/tests/configs/ospfv3_bfd_frr/r2.yaml
+++ b/bdd/tests/configs/ospfv3_bfd_frr/r2.yaml
@@ -1,0 +1,39 @@
+interface:
+- if-name: lo
+  ipv6:
+    address: 2001:db8::6/128
+- if-name: r2-n1
+  ipv6:
+    address: 2001:db8:7::2/64
+- if-name: r2-r1
+  ipv6:
+    address: 2001:db8:8::2/64
+- if-name: r2-r3
+  ipv6:
+    address: 2001:db8:9::1/64
+router:
+  ospfv3:
+    router-id: 10.0.0.6
+    segment-routing:
+      mpls: {}
+    fast-reroute:
+      ti-lfa: {}
+    area:
+    - area-id: 0.0.0.0
+      interface:
+      - if-name: lo
+        enable: true
+        prefix-sid:
+          index: 600
+      - if-name: r2-n1
+        enable: true
+        network-type: point-to-point
+        cost: 1
+      - if-name: r2-r1
+        enable: true
+        network-type: point-to-point
+        cost: 1000
+      - if-name: r2-r3
+        enable: true
+        network-type: point-to-point
+        cost: 1000

--- a/bdd/tests/configs/ospfv3_bfd_frr/r3.yaml
+++ b/bdd/tests/configs/ospfv3_bfd_frr/r3.yaml
@@ -1,0 +1,32 @@
+interface:
+- if-name: lo
+  ipv6:
+    address: 2001:db8::7/128
+- if-name: r3-r2
+  ipv6:
+    address: 2001:db8:9::2/64
+- if-name: r3-d
+  ipv6:
+    address: 2001:db8:11::1/64
+router:
+  ospfv3:
+    router-id: 10.0.0.7
+    segment-routing:
+      mpls: {}
+    fast-reroute:
+      ti-lfa: {}
+    area:
+    - area-id: 0.0.0.0
+      interface:
+      - if-name: lo
+        enable: true
+        prefix-sid:
+          index: 700
+      - if-name: r3-r2
+        enable: true
+        network-type: point-to-point
+        cost: 1000
+      - if-name: r3-d
+        enable: true
+        network-type: point-to-point
+        cost: 1

--- a/bdd/tests/configs/ospfv3_bfd_frr/s.yaml
+++ b/bdd/tests/configs/ospfv3_bfd_frr/s.yaml
@@ -1,0 +1,41 @@
+interface:
+- if-name: lo
+  ipv6:
+    address: 2001:db8::1/128
+- if-name: s-n1
+  ipv6:
+    address: 2001:db8:1::1/64
+- if-name: s-n2
+  ipv6:
+    address: 2001:db8:2::1/64
+- if-name: s-n3
+  ipv6:
+    address: 2001:db8:3::1/64
+router:
+  ospfv3:
+    router-id: 10.0.0.1
+    segment-routing:
+      mpls: {}
+    fast-reroute:
+      ti-lfa: {}
+    area:
+    - area-id: 0.0.0.0
+      interface:
+      - if-name: lo
+        enable: true
+        prefix-sid:
+          index: 100
+      - if-name: s-n1
+        enable: true
+        network-type: point-to-point
+        cost: 1
+        bfd:
+          enable: true
+      - if-name: s-n2
+        enable: true
+        network-type: point-to-point
+        cost: 1
+      - if-name: s-n3
+        enable: true
+        network-type: point-to-point
+        cost: 1000

--- a/bdd/tests/features/ospfv2_bfd_frr.feature
+++ b/bdd/tests/features/ospfv2_bfd_frr.feature
@@ -1,0 +1,108 @@
+@serial
+@ospfv2_bfd_frr
+Feature: OSPFv2 TI-LFA kernel-side fast-reroute on BFD failure
+  As a network operator
+  I want a BFD-detected primary failure (the link stays up, so the
+  kernel cannot see it) to rewire the pre-installed protection
+  indirection groups onto their TI-LFA repairs in one atomic kernel
+  operation per failed adjacency, BEFORE SPF reconvergence rewrites
+  the routes — phase 4 of docs/design/nexthop-protect-kernel-failover.md,
+  the OSPFv2 sibling of isis_tilfa_bfd.feature.
+
+  The topology is the ospfv2_tilfa SR-MPLS ring with BFD
+  enabled on the protected s<->n1 adjacency. BFD-down is induced by
+  dropping inbound UDP/3784 in namespace s: the veth link stays up and
+  hellos keep flowing, so the teardown is provably BFD's doing — the
+  failure class the kernel's autonomous link-down flush cannot cover.
+  The switchover is observable only in the daemon log ("rewired N
+  protection group(s) onto repairs" is emitted ONLY when at least one
+  group moved): its kernel state is superseded within milliseconds by
+  the post-convergence SPF routes, by design.
+
+  Scenario: Build the topology and confirm adjacency, BFD, and repairs
+    Given a clean test environment
+    When I create namespace "s"
+    And I create namespace "n1"
+    And I create namespace "n2"
+    And I create namespace "n3"
+    And I create namespace "r1"
+    And I create namespace "r2"
+    And I create namespace "r3"
+    And I create namespace "d"
+    And I connect namespace "s" interface "s-n1" to namespace "n1" interface "n1-s"
+    And I connect namespace "s" interface "s-n2" to namespace "n2" interface "n2-s"
+    And I connect namespace "s" interface "s-n3" to namespace "n3" interface "n3-s"
+    And I connect namespace "n1" interface "n1-r1" to namespace "r1" interface "r1-n1"
+    And I connect namespace "n2" interface "n2-r1" to namespace "r1" interface "r1-n2"
+    And I connect namespace "n3" interface "n3-r1" to namespace "r1" interface "r1-n3"
+    And I connect namespace "n1" interface "n1-r2" to namespace "r2" interface "r2-n1"
+    And I connect namespace "r1" interface "r1-r2" to namespace "r2" interface "r2-r1"
+    And I connect namespace "r2" interface "r2-r3" to namespace "r3" interface "r3-r2"
+    And I connect namespace "n1" interface "n1-d" to namespace "d" interface "d-n1"
+    And I connect namespace "r3" interface "r3-d" to namespace "d" interface "d-r3"
+    And I start zebra-rs in namespace "s"
+    And I start zebra-rs in namespace "n1"
+    And I start zebra-rs in namespace "n2"
+    And I start zebra-rs in namespace "n3"
+    And I start zebra-rs in namespace "r1"
+    And I start zebra-rs in namespace "r2"
+    And I start zebra-rs in namespace "r3"
+    And I start zebra-rs in namespace "d"
+    And I apply config "s.yaml" to namespace "s"
+    And I apply config "n1.yaml" to namespace "n1"
+    And I apply config "n2.yaml" to namespace "n2"
+    And I apply config "n3.yaml" to namespace "n3"
+    And I apply config "r1.yaml" to namespace "r1"
+    And I apply config "r2.yaml" to namespace "r2"
+    And I apply config "r3.yaml" to namespace "r3"
+    And I apply config "d.yaml" to namespace "d"
+    And I wait 30 seconds
+    # Gate on full convergence (SPF + SR labels + install) before the
+    # single-shot show asserts — the kernel-route step polls.
+    Then kernel route "10.0.0.8" in namespace "s" should eventually contain "proto ospf"
+    And bfd session in namespace "s" on interface "s-n1" should be up
+    And show command "show ospf ti-lfa" in namespace "s" should contain "Adj-SID"
+    And ping from "s" to "10.0.0.8" should succeed
+    And ping from "d" to "10.0.0.1" should succeed
+
+  Scenario: BFD-down with the link up triggers the kernel-side switchover
+    Given the test topology exists
+    Then ping from "s" to "10.0.0.8" should succeed
+    # Kill BFD only: the link stays up (no autonomous kernel flush) and
+    # hellos keep flowing (no dead-timer expiry for ~40s) — s must learn
+    # of the failure from BFD and bridge traffic onto the repairs.
+    When I drop bfd control packets in namespace "s"
+    Then bfd session in namespace "s" on interface "s-n1" should be down
+    # The switchover fired: at least one protection group was rewired
+    # onto its repair (this exact line is only logged when N > 0).
+    And daemon log in namespace "s" should eventually contain "rewired"
+    And daemon log in namespace "s" should eventually contain "protection group(s) onto repairs"
+    # SPF reconvergence then re-routes around n1 entirely.
+    And kernel route "10.0.0.8" in namespace "s" should eventually contain "dev s-n2"
+    And ping from "s" to "10.0.0.8" should succeed
+    # Recovery: BFD re-establishes and the primary path returns.
+    When I restore bfd control packets in namespace "s"
+    And I wait 15 seconds
+    Then bfd session in namespace "s" on interface "s-n1" should be up
+    And kernel route "10.0.0.8" in namespace "s" should eventually contain "dev s-n1"
+    And ping from "s" to "10.0.0.8" should succeed
+
+  Scenario: Teardown topology
+    Given the test topology exists
+    When I stop zebra-rs in namespace "s"
+    And I stop zebra-rs in namespace "n1"
+    And I stop zebra-rs in namespace "n2"
+    And I stop zebra-rs in namespace "n3"
+    And I stop zebra-rs in namespace "r1"
+    And I stop zebra-rs in namespace "r2"
+    And I stop zebra-rs in namespace "r3"
+    And I stop zebra-rs in namespace "d"
+    And I delete namespace "s"
+    And I delete namespace "n1"
+    And I delete namespace "n2"
+    And I delete namespace "n3"
+    And I delete namespace "r1"
+    And I delete namespace "r2"
+    And I delete namespace "r3"
+    And I delete namespace "d"
+    Then the test environment should be clean

--- a/bdd/tests/features/ospfv3_bfd_frr.feature
+++ b/bdd/tests/features/ospfv3_bfd_frr.feature
@@ -1,0 +1,108 @@
+@serial
+@ospfv3_bfd_frr
+Feature: OSPFv3 TI-LFA kernel-side fast-reroute on BFD failure
+  As a network operator
+  I want a BFD-detected primary failure (the link stays up, so the
+  kernel cannot see it) to rewire the pre-installed protection
+  indirection groups onto their TI-LFA repairs in one atomic kernel
+  operation per failed adjacency, BEFORE SPF reconvergence rewrites
+  the routes — phase 4 of docs/design/nexthop-protect-kernel-failover.md,
+  the OSPFv3 sibling of isis_tilfa_bfd.feature.
+
+  The topology is the ospfv3_tilfa SR-MPLS ring with BFD
+  enabled on the protected s<->n1 adjacency. BFD-down is induced by
+  dropping inbound UDP/3784 in namespace s: the veth link stays up and
+  hellos keep flowing, so the teardown is provably BFD's doing — the
+  failure class the kernel's autonomous link-down flush cannot cover.
+  The switchover is observable only in the daemon log ("rewired N
+  protection group(s) onto repairs" is emitted ONLY when at least one
+  group moved): its kernel state is superseded within milliseconds by
+  the post-convergence SPF routes, by design.
+
+  Scenario: Build the topology and confirm adjacency, BFD, and repairs
+    Given a clean test environment
+    When I create namespace "s"
+    And I create namespace "n1"
+    And I create namespace "n2"
+    And I create namespace "n3"
+    And I create namespace "r1"
+    And I create namespace "r2"
+    And I create namespace "r3"
+    And I create namespace "d"
+    And I connect namespace "s" interface "s-n1" to namespace "n1" interface "n1-s"
+    And I connect namespace "s" interface "s-n2" to namespace "n2" interface "n2-s"
+    And I connect namespace "s" interface "s-n3" to namespace "n3" interface "n3-s"
+    And I connect namespace "n1" interface "n1-r1" to namespace "r1" interface "r1-n1"
+    And I connect namespace "n2" interface "n2-r1" to namespace "r1" interface "r1-n2"
+    And I connect namespace "n3" interface "n3-r1" to namespace "r1" interface "r1-n3"
+    And I connect namespace "n1" interface "n1-r2" to namespace "r2" interface "r2-n1"
+    And I connect namespace "r1" interface "r1-r2" to namespace "r2" interface "r2-r1"
+    And I connect namespace "r2" interface "r2-r3" to namespace "r3" interface "r3-r2"
+    And I connect namespace "n1" interface "n1-d" to namespace "d" interface "d-n1"
+    And I connect namespace "r3" interface "r3-d" to namespace "d" interface "d-r3"
+    And I start zebra-rs in namespace "s"
+    And I start zebra-rs in namespace "n1"
+    And I start zebra-rs in namespace "n2"
+    And I start zebra-rs in namespace "n3"
+    And I start zebra-rs in namespace "r1"
+    And I start zebra-rs in namespace "r2"
+    And I start zebra-rs in namespace "r3"
+    And I start zebra-rs in namespace "d"
+    And I apply config "s.yaml" to namespace "s"
+    And I apply config "n1.yaml" to namespace "n1"
+    And I apply config "n2.yaml" to namespace "n2"
+    And I apply config "n3.yaml" to namespace "n3"
+    And I apply config "r1.yaml" to namespace "r1"
+    And I apply config "r2.yaml" to namespace "r2"
+    And I apply config "r3.yaml" to namespace "r3"
+    And I apply config "d.yaml" to namespace "d"
+    And I wait 30 seconds
+    # Gate on full convergence (SPF + SR labels + install) before the
+    # single-shot show asserts — the kernel-route step polls.
+    Then kernel route "2001:db8::8" in namespace "s" should eventually contain "proto ospf"
+    And bfd session in namespace "s" on interface "s-n1" should be up
+    And show command "show ospfv3 ti-lfa" in namespace "s" should contain "Adj-SID"
+    And ping from "s" to "2001:db8::8" should succeed
+    And ping from "d" to "2001:db8::1" should succeed
+
+  Scenario: BFD-down with the link up triggers the kernel-side switchover
+    Given the test topology exists
+    Then ping from "s" to "2001:db8::8" should succeed
+    # Kill BFD only: the link stays up (no autonomous kernel flush) and
+    # hellos keep flowing (no dead-timer expiry for ~40s) — s must learn
+    # of the failure from BFD and bridge traffic onto the repairs.
+    When I drop bfd control packets in namespace "s"
+    Then bfd session in namespace "s" on interface "s-n1" should be down
+    # The switchover fired: at least one protection group was rewired
+    # onto its repair (this exact line is only logged when N > 0).
+    And daemon log in namespace "s" should eventually contain "rewired"
+    And daemon log in namespace "s" should eventually contain "protection group(s) onto repairs"
+    # SPF reconvergence then re-routes around n1 entirely.
+    And kernel route "2001:db8::8" in namespace "s" should eventually contain "dev s-n2"
+    And ping from "s" to "2001:db8::8" should succeed
+    # Recovery: BFD re-establishes and the primary path returns.
+    When I restore bfd control packets in namespace "s"
+    And I wait 15 seconds
+    Then bfd session in namespace "s" on interface "s-n1" should be up
+    And kernel route "2001:db8::8" in namespace "s" should eventually contain "dev s-n1"
+    And ping from "s" to "2001:db8::8" should succeed
+
+  Scenario: Teardown topology
+    Given the test topology exists
+    When I stop zebra-rs in namespace "s"
+    And I stop zebra-rs in namespace "n1"
+    And I stop zebra-rs in namespace "n2"
+    And I stop zebra-rs in namespace "n3"
+    And I stop zebra-rs in namespace "r1"
+    And I stop zebra-rs in namespace "r2"
+    And I stop zebra-rs in namespace "r3"
+    And I stop zebra-rs in namespace "d"
+    And I delete namespace "s"
+    And I delete namespace "n1"
+    And I delete namespace "n2"
+    And I delete namespace "n3"
+    And I delete namespace "r1"
+    And I delete namespace "r2"
+    And I delete namespace "r3"
+    And I delete namespace "d"
+    Then the test environment should be clean

--- a/docs/design/nexthop-protect-kernel-failover.md
+++ b/docs/design/nexthop-protect-kernel-failover.md
@@ -22,7 +22,7 @@ paths for protected routes.
 | 1 — indirection group | #1374 | `Group::Protect` + `NexthopProtect.gid`; protected v4/v6 routes reference a 1-member kernel group; behavior-neutral |
 | 2 — switchover op | #1377 | `Message::ProtectSwitch` + `GroupProtect.active` + atomic group re-send; revert-on-reassert |
 | 3 — IS-IS hook | #1378 | `process_bfd_down` emits `ProtectSwitch` per failed nexthop addr before SPF; `@tilfa_bfd` BDD for the link-up failure class |
-| 4 — OSPF hook | — | v2 + v3, same shape |
+| 4 — OSPF hook | #1379 | `process_bfd_event` (generic v2+v3) emits `ProtectSwitch` via `OspfVersion::prefix_ip`; `@ospfv2_bfd_frr` + `@ospfv3_bfd_frr` BDD |
 | 5 — ECMP leg-level replace | — | per-leg repair on `Multi` primaries |
 
 ## 1. Problem

--- a/zebra-rs/src/ospf/inst.rs
+++ b/zebra-rs/src/ospf/inst.rs
@@ -567,11 +567,11 @@ impl<V: OspfVersion> Ospf<V> {
         }
 
         let ifindex = key.ifindex;
-        let Some(nbr_addr) = self.links.get(&ifindex).and_then(|link| {
+        let Some((nbr_addr, protect_addr)) = self.links.get(&ifindex).and_then(|link| {
             link.nbrs
                 .iter()
                 .find(|(_, n)| n.bfd_session_key == Some(key))
-                .map(|(addr, _)| *addr)
+                .map(|(addr, n)| (*addr, V::prefix_ip(&n.ident.prefix)))
         }) else {
             tracing::debug!(
                 ?key,
@@ -604,6 +604,14 @@ impl<V: OspfVersion> Ospf<V> {
             nbr.bfd_session_key = None;
             nbr.bfd_session_params = None;
         }
+        // Fast-reroute switchover (kernel-failover phase 4): rewire the
+        // pre-installed protection groups onto their TI-LFA repairs NOW,
+        // before the teardown-driven SPF / per-prefix reinstall pipeline
+        // starts. The address is the neighbour's hello source — exactly
+        // what SPF keyed this adjacency's route nexthops on. The RIB
+        // no-ops when nothing is protected; channel ordering lands this
+        // before the post-convergence route updates.
+        let _ = self.ctx.rib.protect_switch(protect_addr);
         let _ = self.tx.send(Message::Nfsm(
             ifindex,
             nbr_addr,

--- a/zebra-rs/src/ospf/version.rs
+++ b/zebra-rs/src/ospf/version.rs
@@ -109,6 +109,13 @@ pub trait OspfVersion: 'static + Send + Sync + Copy + Clone + PartialEq + Eq {
     /// `{FLEX_ALGO_PREFIX}/...`.
     const FLEX_ALGO_PREFIX: &'static str;
 
+    /// A neighbor's `ident.prefix` as a plain `IpAddr` — the exact
+    /// address SPF keys this adjacency's route nexthops on (v2: the
+    /// hello source / interface address, v3: the link-local), and
+    /// therefore the key the RIB's protection groups use for their
+    /// primaries. Drives the BFD-down fast-reroute switchover.
+    fn prefix_ip(prefix: &Self::Prefix) -> std::net::IpAddr;
+
     /// Proto label base for this version — `"ospf"` (v2) or
     /// `"ospfv3"` (v3). Used as the default instance's RIB / policy
     /// registration name and as the prefix for per-VRF labels
@@ -368,6 +375,10 @@ impl OspfVersion for Ospfv2 {
     type LsRequest = OspfLsRequest;
     type LsRequestEntry = OspfLsRequestEntry;
     const FLEX_ALGO_PREFIX: &'static str = "/router/ospf/flex-algo";
+
+    fn prefix_ip(prefix: &Ipv4Net) -> std::net::IpAddr {
+        std::net::IpAddr::V4(prefix.addr())
+    }
     const PROTO: &'static str = "ospf";
 
     fn spawn_vrf(
@@ -505,6 +516,10 @@ impl OspfVersion for Ospfv3 {
     type LsRequest = Ospfv3LsRequest;
     type LsRequestEntry = Ospfv3LsRequestEntry;
     const FLEX_ALGO_PREFIX: &'static str = "/router/ospfv3/flex-algo";
+
+    fn prefix_ip(prefix: &Ipv6Net) -> std::net::IpAddr {
+        std::net::IpAddr::V6(prefix.addr())
+    }
     const PROTO: &'static str = "ospfv3";
 
     fn spawn_vrf(


### PR DESCRIPTION
## Summary

Phase 4 of `docs/design/nexthop-protect-kernel-failover.md` — the OSPF sibling of the IS-IS hook (#1378), covering both versions through the generic instance.

`process_bfd_event` resolves the failing neighbour and sends `RibClient::protect_switch` with the neighbour's hello-source address **before** dispatching the `InactivityTimer` teardown. The address comes from the new `OspfVersion::prefix_ip` (v2: interface source address, v3: link-local) — exactly what `spf_nexthops`/`collect_v3_nexthops` keyed this adjacency's routes on, so it matches the protection groups' primary keying. One trait fn, one capture in the existing neighbour lookup, one send: the rest is the phase-2 machinery.

## BDD

New `@ospfv2_bfd_frr` / `@ospfv3_bfd_frr` features — the respective tilfa SR-MPLS rings with **per-interface** BFD on the protected s↔n1 adjacency (instance-wide BFD would put sessions on every link and the drop test would tear them all). Same link-up failure shape as `@tilfa_bfd`: drop UDP/3784 → BFD down → switchover log line (only emitted when N > 0) → SPF re-route out `s-n2` → recovery restores `s-n1`. Explicit teardowns; tags prefix-collision-checked.

One iteration during validation: the features initially copied the IS-IS 10s convergence wait and failed on empty repair lists — OSPF needs the 30s its sibling features use, plus a polling kernel-route gate before the single-shot show asserts.

## Testing

- Local BDD (md5-stable binary): `@ospfv2_bfd_frr` 3/3 and `@ospfv3_bfd_frr` 3/3 — both with the `rewired N protection group(s) onto repairs` line present, v3 confirming the link-local keying end to end — plus `@ospfv2_tilfa`, `@ospfv3_tilfa`, `@tilfa_bfd` regressions green.
- `cargo test --workspace --exclude bdd` green; workspace clippy `-D warnings` clean (all changed files touch-relinted); fmt applied.

With this, the fast path is live for all three IGP surfaces (IS-IS, OSPFv2, OSPFv3). Remaining: phase 5 (ECMP leg-level replace on `Multi` primaries).

🤖 Generated with [Claude Code](https://claude.com/claude-code)