### PR TITLE
rib: kernel-side failover phase 5 — ECMP leg eviction on BFD failure

### DIFF
--- a/bdd/Makefile
+++ b/bdd/Makefile
@@ -76,6 +76,10 @@ ospfv3_bfd_frr:
 	mkdir -p allure-results
 	cargo test --test cucumber -- --concurrency=1 --tags "@ospfv3_bfd_frr"
 
+ecmp_bfd_evict:
+	mkdir -p allure-results
+	cargo test --test cucumber -- --concurrency=1 --tags "@ecmp_bfd_evict"
+
 isis_redist:
 	mkdir -p allure-results
 	cargo test --test cucumber -- --concurrency=1 --tags "@isis_redist"
@@ -237,4 +241,4 @@ docs/%.md: tests/features/%.feature docs/feature2md.sh FORCE
 
 FORCE:
 
-.PHONY: ospfv2_bfd_frr ospfv3_bfd_frr tilfa_bfd all run ibgp ebgp rr rib_static_ipv6 isis_ipv6 isis_srv6 isis_fragmentation_ipv6 isis_fragmentation_ipv4 isis_l1p2p isis_tilfa isis_l1l2 isis_redist isis_hello_auth_keychain isis_passive isis_afi_enable isis_endx_ipv6 isis_bfd_ipv6_p2p isis_bfd_ipv6_p2p_echo isis_bfd_ipv6_lan isis_bfd_ipv6_lan_echo isis_bfd_ipv4_p2p isis_bfd_ipv4_p2p_echo isis_bfd_ipv4_lan isis_bfd_ipv4_lan_echo ospf_clear_neighbor ospfv2_nssa ospfv2_stub ospfv2_tilfa ospfv3_nssa ospfv3_tilfa bgp_peer_down_cleanup bgp_ipv6_over_v4_session bgp_evpn_capability bgp_vrf_evpn_type5 bgp_route_map_match bgp_policy_dynamic_update bgp_community bgp_neighbor_group bgp_unnumbered_neighbor nd_show bgp_interas_option_c bgp_interas_option_a bgp_interas_option_b bgp_interas_option_ab generate open docs FORCE
+.PHONY: ecmp_bfd_evict ospfv2_bfd_frr ospfv3_bfd_frr tilfa_bfd all run ibgp ebgp rr rib_static_ipv6 isis_ipv6 isis_srv6 isis_fragmentation_ipv6 isis_fragmentation_ipv4 isis_l1p2p isis_tilfa isis_l1l2 isis_redist isis_hello_auth_keychain isis_passive isis_afi_enable isis_endx_ipv6 isis_bfd_ipv6_p2p isis_bfd_ipv6_p2p_echo isis_bfd_ipv6_lan isis_bfd_ipv6_lan_echo isis_bfd_ipv4_p2p isis_bfd_ipv4_p2p_echo isis_bfd_ipv4_lan isis_bfd_ipv4_lan_echo ospf_clear_neighbor ospfv2_nssa ospfv2_stub ospfv2_tilfa ospfv3_nssa ospfv3_tilfa bgp_peer_down_cleanup bgp_ipv6_over_v4_session bgp_evpn_capability bgp_vrf_evpn_type5 bgp_route_map_match bgp_policy_dynamic_update bgp_community bgp_neighbor_group bgp_unnumbered_neighbor nd_show bgp_interas_option_c bgp_interas_option_a bgp_interas_option_b bgp_interas_option_ab generate open docs FORCE

--- a/bdd/tests/configs/ecmp_bfd_evict/a.yaml
+++ b/bdd/tests/configs/ecmp_bfd_evict/a.yaml
@@ -1,0 +1,29 @@
+interface:
+- if-name: lo
+  ipv4:
+    address: 10.0.0.2/32
+- if-name: a-s
+  ipv4:
+    address: 10.1.0.2/30
+- if-name: a-d
+  ipv4:
+    address: 10.3.0.1/30
+router:
+  isis:
+    net: 49.0000.0000.0000.0002.00
+    hostname: a
+    is-type: level-2-only
+    interface:
+    - if-name: lo
+      ipv4:
+        enable: true
+    - if-name: a-s
+      ipv4:
+        enable: true
+      metric: 1
+      bfd:
+        enable: true
+    - if-name: a-d
+      ipv4:
+        enable: true
+      metric: 1

--- a/bdd/tests/configs/ecmp_bfd_evict/b.yaml
+++ b/bdd/tests/configs/ecmp_bfd_evict/b.yaml
@@ -1,0 +1,27 @@
+interface:
+- if-name: lo
+  ipv4:
+    address: 10.0.0.3/32
+- if-name: b-s
+  ipv4:
+    address: 10.2.0.2/30
+- if-name: b-d
+  ipv4:
+    address: 10.4.0.1/30
+router:
+  isis:
+    net: 49.0000.0000.0000.0003.00
+    hostname: b
+    is-type: level-2-only
+    interface:
+    - if-name: lo
+      ipv4:
+        enable: true
+    - if-name: b-s
+      ipv4:
+        enable: true
+      metric: 1
+    - if-name: b-d
+      ipv4:
+        enable: true
+      metric: 1

--- a/bdd/tests/configs/ecmp_bfd_evict/d.yaml
+++ b/bdd/tests/configs/ecmp_bfd_evict/d.yaml
@@ -1,0 +1,27 @@
+interface:
+- if-name: lo
+  ipv4:
+    address: 10.0.0.4/32
+- if-name: d-a
+  ipv4:
+    address: 10.3.0.2/30
+- if-name: d-b
+  ipv4:
+    address: 10.4.0.2/30
+router:
+  isis:
+    net: 49.0000.0000.0000.0004.00
+    hostname: d
+    is-type: level-2-only
+    interface:
+    - if-name: lo
+      ipv4:
+        enable: true
+    - if-name: d-a
+      ipv4:
+        enable: true
+      metric: 1
+    - if-name: d-b
+      ipv4:
+        enable: true
+      metric: 1

--- a/bdd/tests/configs/ecmp_bfd_evict/s.yaml
+++ b/bdd/tests/configs/ecmp_bfd_evict/s.yaml
@@ -1,0 +1,29 @@
+interface:
+- if-name: lo
+  ipv4:
+    address: 10.0.0.1/32
+- if-name: s-a
+  ipv4:
+    address: 10.1.0.1/30
+- if-name: s-b
+  ipv4:
+    address: 10.2.0.1/30
+router:
+  isis:
+    net: 49.0000.0000.0000.0001.00
+    hostname: s
+    is-type: level-2-only
+    interface:
+    - if-name: lo
+      ipv4:
+        enable: true
+    - if-name: s-a
+      ipv4:
+        enable: true
+      metric: 1
+      bfd:
+        enable: true
+    - if-name: s-b
+      ipv4:
+        enable: true
+      metric: 1

--- a/bdd/tests/features/ecmp_bfd_evict.feature
+++ b/bdd/tests/features/ecmp_bfd_evict.feature
@@ -1,0 +1,96 @@
+@ecmp_bfd_evict
+@isis
+@bfd
+Feature: ECMP leg eviction on BFD failure
+  As a network operator
+  I want a BFD-detected failure of one ECMP leg (the link stays up,
+  so the kernel cannot see it) to evict that leg from the kernel
+  nexthop groups in one atomic replace per group, BEFORE SPF
+  reconvergence rewrites the routes — phase 5 of
+  docs/design/nexthop-protect-kernel-failover.md.
+
+  TI-LFA deliberately computes no repair for SPF-level ECMP
+  destinations: the surviving legs ARE the protection. This feature
+  proves that holds for the link-up failure class too — without the
+  eviction, the kernel would keep hashing flows onto the dead leg
+  until SPF finishes.
+
+  Like the switchover, the eviction is observable only in the daemon
+  log ("evicted failed leg from N ECMP group(s)" is emitted ONLY when
+  at least one group shrank): SPF supersedes its kernel state within
+  milliseconds, by design.
+
+  Test Topology (diamond, all metrics 1 — s reaches d ECMP via a and b):
+  ```
+        s (10.0.0.1)
+       / \
+     s-a  s-b          BFD runs on the s<->a leg only.
+     /      \
+    a        b
+     \      /
+     a-d  b-d
+       \ /
+        d (10.0.0.4)
+  ```
+
+  Scenario: Build the diamond and confirm ECMP, BFD, and reachability
+    Given a clean test environment
+    When I create namespace "s"
+    And I create namespace "a"
+    And I create namespace "b"
+    And I create namespace "d"
+    And I connect namespace "s" interface "s-a" to namespace "a" interface "a-s"
+    And I connect namespace "s" interface "s-b" to namespace "b" interface "b-s"
+    And I connect namespace "a" interface "a-d" to namespace "d" interface "d-a"
+    And I connect namespace "b" interface "b-d" to namespace "d" interface "d-b"
+    And I start zebra-rs in namespace "s"
+    And I start zebra-rs in namespace "a"
+    And I start zebra-rs in namespace "b"
+    And I start zebra-rs in namespace "d"
+    And I apply config "s.yaml" to namespace "s"
+    And I apply config "a.yaml" to namespace "a"
+    And I apply config "b.yaml" to namespace "b"
+    And I apply config "d.yaml" to namespace "d"
+    And I wait 10 seconds
+    # d's loopback is ECMP across both legs in the kernel.
+    Then kernel route "10.0.0.4" in namespace "s" should eventually contain "dev s-a"
+    And kernel route "10.0.0.4" in namespace "s" should eventually contain "dev s-b"
+    And bfd session in namespace "s" on interface "s-a" should be up
+    And ping from "s" to "10.0.0.4" should succeed
+
+  Scenario: BFD-down on one leg evicts it from the kernel ECMP group
+    Given the test topology exists
+    Then ping from "s" to "10.0.0.4" should succeed
+    # Kill BFD only: the link stays up (no autonomous kernel flush) and
+    # IIHs keep flowing — s must learn of the dead leg from BFD and
+    # shrink the ECMP membership itself.
+    When I drop bfd control packets in namespace "s"
+    Then bfd session in namespace "s" on interface "s-a" should be down
+    # The eviction fired: at least one ECMP group shrank (this exact
+    # line is only logged when N > 0).
+    And daemon log in namespace "s" should eventually contain "evicted failed leg from"
+    And daemon log in namespace "s" should eventually contain "ECMP group(s)"
+    # SPF reconvergence then drops the a-plane entirely; forwarding
+    # stays healthy on the surviving leg throughout.
+    And kernel route "10.0.0.4" in namespace "s" should eventually contain "dev s-b"
+    And ping from "s" to "10.0.0.4" should succeed
+    # Recovery: BFD re-establishes, the adjacency re-forms, and the
+    # evicted leg returns to the ECMP set (exercises the drain-and-
+    # recreate lifecycle of the marked-invalid member group).
+    When I restore bfd control packets in namespace "s"
+    And I wait 15 seconds
+    Then bfd session in namespace "s" on interface "s-a" should be up
+    And kernel route "10.0.0.4" in namespace "s" should eventually contain "dev s-a"
+    And ping from "s" to "10.0.0.4" should succeed
+
+  Scenario: Teardown topology
+    Given the test topology exists
+    When I stop zebra-rs in namespace "s"
+    And I stop zebra-rs in namespace "a"
+    And I stop zebra-rs in namespace "b"
+    And I stop zebra-rs in namespace "d"
+    And I delete namespace "s"
+    And I delete namespace "a"
+    And I delete namespace "b"
+    And I delete namespace "d"
+    Then the test environment should be clean

--- a/docs/design/nexthop-protect-kernel-failover.md
+++ b/docs/design/nexthop-protect-kernel-failover.md
@@ -23,7 +23,7 @@ paths for protected routes.
 | 2 — switchover op | #1377 | `Message::ProtectSwitch` + `GroupProtect.active` + atomic group re-send; revert-on-reassert |
 | 3 — IS-IS hook | #1378 | `process_bfd_down` emits `ProtectSwitch` per failed nexthop addr before SPF; `@tilfa_bfd` BDD for the link-up failure class |
 | 4 — OSPF hook | #1379 | `process_bfd_event` (generic v2+v3) emits `ProtectSwitch` via `OspfVersion::prefix_ip`; `@ospfv2_bfd_frr` + `@ospfv3_bfd_frr` BDD |
-| 5 — ECMP leg-level replace | — | per-leg repair on `Multi` primaries |
+| 5 — ECMP leg eviction | #1380 | TI-LFA skips ECMP destinations (surviving legs are the protection), so the fast path evicts the BFD-dead leg from kernel ECMP groups; `@ecmp_bfd_evict` BDD |
 
 ## 1. Problem
 

--- a/zebra-rs/src/rib/inst.rs
+++ b/zebra-rs/src/rib/inst.rs
@@ -1579,17 +1579,23 @@ impl Rib {
                 self.nht_register(proto, nh);
             }
             Message::ProtectSwitch { addr } => {
-                let n =
+                let (rewired, evicted) =
                     super::route::protect_switch(&mut self.nmap, &self.fib_handle, table_id, addr)
                         .await;
-                // Distinct info line ONLY when something actually moved —
-                // the BDD log assertion keys on this exact phrasing, so a
-                // zero-candidate no-op must not be able to satisfy it.
-                if n > 0 {
+                // Distinct info lines ONLY when something actually moved —
+                // the BDD log assertions key on these exact phrasings, so a
+                // zero-candidate no-op must not be able to satisfy them.
+                if rewired > 0 {
                     tracing::info!(
-                        "ProtectSwitch {addr} table {table_id}: rewired {n} protection group(s) onto repairs"
+                        "ProtectSwitch {addr} table {table_id}: rewired {rewired} protection group(s) onto repairs"
                     );
-                } else {
+                }
+                if evicted > 0 {
+                    tracing::info!(
+                        "ProtectSwitch {addr} table {table_id}: evicted failed leg from {evicted} ECMP group(s)"
+                    );
+                }
+                if rewired == 0 && evicted == 0 {
                     tracing::debug!("ProtectSwitch {addr} table {table_id}: no eligible groups");
                 }
             }

--- a/zebra-rs/src/rib/nexthop/map.rs
+++ b/zebra-rs/src/rib/nexthop/map.rs
@@ -267,6 +267,38 @@ impl NexthopMap {
             .collect()
     }
 
+    /// ECMP groups eligible for leg eviction on a BFD-detected
+    /// failure of `(table_id, addr)`: every `Multi` whose LIVE
+    /// membership still carries a member uni at that address.
+    /// Returns `(multi_gid, member_gid)` pairs.
+    ///
+    /// TI-LFA deliberately computes no repair for SPF-level ECMP
+    /// destinations — the surviving legs ARE the protection — so for
+    /// Multi nexthops the fast path is eviction, not a repair swap.
+    /// This intentionally covers Multi groups shared with routes the
+    /// caller didn't know about: they lose the same dead leg, which
+    /// is the correct outcome (design doc, shared-group note).
+    pub fn protect_evict_candidates(&self, table_id: u32, addr: IpAddr) -> Vec<(usize, usize)> {
+        self.groups
+            .iter()
+            .flatten()
+            .filter_map(|grp| {
+                let Group::Multi(multi) = grp else {
+                    return None;
+                };
+                for (m, _w) in multi.valid.iter() {
+                    if let Some(uni) = self.get_uni(*m)
+                        && uni.table_id == table_id
+                        && uni.addr == addr
+                    {
+                        return Some((multi.gid(), *m));
+                    }
+                }
+                None
+            })
+            .collect()
+    }
+
     pub fn fetch_multi(&mut self, set: &BTreeSet<(usize, u8)>) -> Option<&mut Group> {
         let gid = if let Some(&gid) = self.set.get(set) {
             let update = self.groups.get_mut(gid)?;

--- a/zebra-rs/src/rib/route.rs
+++ b/zebra-rs/src/rib/route.rs
@@ -1658,7 +1658,7 @@ pub async fn protect_switch(
     fib: &FibHandle,
     table_id: u32,
     addr: IpAddr,
-) -> usize {
+) -> (usize, usize) {
     let candidates = nmap.protect_switch_candidates(table_id, addr);
     let mut switched = 0;
     for gid in candidates {
@@ -1675,7 +1675,42 @@ pub async fn protect_switch(
         }
         switched += 1;
     }
-    switched
+
+    // ECMP leg eviction (phase 5): TI-LFA computes no repair for
+    // SPF-level ECMP destinations — the surviving legs are the
+    // protection — so for Multi groups the fast path is dropping the
+    // dead leg from the kernel membership, one atomic replace per
+    // group. The failed member is marked invalid exactly as the
+    // link-down path would mark it (BFD is just another down
+    // detector), so the sync passes don't resurrect the leg before
+    // SPF replaces these routes; across the failure the member and
+    // group drain via refcnt and are recreated fresh on recovery.
+    let evict = nmap.protect_evict_candidates(table_id, addr);
+    for (_, member_gid) in evict.iter() {
+        if let Some(member) = nmap.get_mut(*member_gid) {
+            member.set_valid(false);
+        }
+    }
+    let mut evicted = 0;
+    for (gid, member_gid) in evict {
+        let Some(Group::Multi(multi)) = nmap.get_mut(gid) else {
+            continue;
+        };
+        multi.valid.retain(|(m, _)| *m != member_gid);
+        if multi.valid.is_empty() {
+            // Last leg died: there is nothing usable to re-send, and
+            // deleting the group would cascade-remove its routes out
+            // from under the route sync. Mark it invalid and let the
+            // teardown-driven SPF replace the routes (same blackhole
+            // window as before phase 5).
+            multi.set_valid(false);
+            continue;
+        }
+        let snapshot = Group::Multi(multi.clone());
+        fib.nexthop_add(&snapshot).await;
+        evicted += 1;
+    }
+    (switched, evicted)
 }
 
 fn resolve_nexthop_member(
@@ -2897,6 +2932,71 @@ mod tests {
             !gp.is_installed(),
             "pending re-install so the sync pass re-sends the group"
         );
+    }
+
+    /// Phase 5: a BFD-dead leg makes its ECMP groups eviction
+    /// candidates, keyed by the leg's (table, addr); the leg itself
+    /// is marked invalid so the sync passes can't resurrect it.
+    #[test]
+    fn protect_evict_candidates_match_ecmp_groups() {
+        use super::super::entry::RibEntry;
+        use super::super::nexthop::{GroupTrait, NexthopUni};
+        use super::super::{Group, Nexthop, NexthopMap, NexthopMulti};
+        use super::super::{RibEntries, RibType};
+        use super::rib_resolve_nexthop;
+        use ipnet::Ipv4Net;
+        use prefix_trie::PrefixMap;
+
+        let mut leg_a = NexthopUni::new("10.1.0.2".parse().unwrap(), 10, vec![]);
+        leg_a.ifindex_origin = Some(10);
+        let mut leg_b = NexthopUni::new("10.2.0.2".parse().unwrap(), 10, vec![]);
+        leg_b.ifindex_origin = Some(20);
+        let multi = NexthopMulti {
+            metric: 10,
+            nexthops: vec![leg_a, leg_b],
+            ..Default::default()
+        };
+        let mut entry = RibEntry::new(RibType::Isis);
+        entry.nexthop = Nexthop::Multi(multi);
+
+        let mut nmap = NexthopMap::default();
+        let table: PrefixMap<Ipv4Net, RibEntries> = PrefixMap::new();
+        rib_resolve_nexthop(&mut entry, &table, &mut nmap, 0);
+        let Nexthop::Multi(multi) = &entry.nexthop else {
+            panic!("still Multi");
+        };
+        let (a_gid, b_gid, multi_gid) = (multi.nexthops[0].gid, multi.nexthops[1].gid, multi.gid);
+        assert_ne!(multi_gid, 0, "ECMP group allocated");
+
+        let addr_a: std::net::IpAddr = "10.1.0.2".parse().unwrap();
+        assert_eq!(
+            nmap.protect_evict_candidates(0, addr_a),
+            vec![(multi_gid, a_gid)]
+        );
+        assert!(
+            nmap.protect_evict_candidates(254, addr_a).is_empty(),
+            "other tables unaffected"
+        );
+        assert!(
+            nmap.protect_evict_candidates(0, "10.9.9.9".parse().unwrap())
+                .is_empty(),
+            "other gateways unaffected"
+        );
+
+        // Simulate the eviction state change the async path performs.
+        nmap.get_mut(a_gid).unwrap().set_valid(false);
+        if let Some(Group::Multi(m)) = nmap.get_mut(multi_gid) {
+            m.valid.retain(|(g, _)| *g != a_gid);
+        }
+        // The dead leg left the LIVE membership: no longer a candidate
+        // (idempotence), and the surviving leg is intact.
+        assert!(nmap.protect_evict_candidates(0, addr_a).is_empty());
+        let Some(Group::Multi(m)) = nmap.get(multi_gid) else {
+            panic!("multi group survives");
+        };
+        assert_eq!(m.valid.len(), 1);
+        assert!(m.valid.iter().any(|(g, _)| *g == b_gid));
+        assert_eq!(m.set.len(), 2, "configured membership untouched");
     }
 
     /// Kernel 6.8 drops seg6-inline traffic routed through a nexthop


### PR DESCRIPTION
## Summary

Final slice of `docs/design/nexthop-protect-kernel-failover.md`.

Scope finding first: TI-LFA computes no repair for SPF-level ECMP destinations (`ospf/tilfa.rs` skips `nexthops.len() != 1` — "the remaining legs already protect the prefix"), so Multi-primary `Protect` pairs never exist and the doc's original "leg-level repair swap" has no producer. Phase 5 instead makes the remaining-legs assumption hold for the **link-up failure class**: on `ProtectSwitch`, the BFD-dead leg is evicted from every kernel ECMP group whose live membership carries it — one atomic `NHA_GROUP` replace per group, before SPF rewrites anything.

## Semantics

- `NexthopMap::protect_evict_candidates` (pure, unit-tested): Multi groups matched by the failed member's `(table, addr)`. Shared groups are covered **intentionally** — every route through the group loses the same dead leg, which is the correct outcome (the design doc's shared-group caveat, promoted to intended behavior).
- The dead member is marked invalid exactly as the link-down path marks it (BFD is just another down-detector), so sync passes can't resurrect the leg pre-SPF; across the failure the member/group drain via refcnt and are recreated fresh on recovery.
- Last-leg case: the group is marked invalid but never re-sent empty or deleted (cascade-remove hazard) — same blackhole window as before this PR, resolved by SPF.
- Handler logs `evicted failed leg from N ECMP group(s)` only when N > 0, keeping the BDD assertion no-op-proof. `protect_switch` returns `(rewired, evicted)`.

## BDD

New `@ecmp_bfd_evict`: 4-node IS-IS diamond, s→d ECMP across two legs, BFD on one. Drop UDP/3784 (link up, IIHs flowing) → eviction log line → forwarding healthy on the survivor → restore → **the evicted leg returns** to the kernel ECMP set, which is the deliberate test of the drain-and-recreate lifecycle.

## Testing

- Local BDD (md5-stable binary): `@ecmp_bfd_evict` 3/3, plus `@tilfa_bfd` 3/3 and `@ospfv2_bfd_frr` 3/3 regressions (both exercise the changed `protect_switch` path).
- `cargo test --workspace --exclude bdd` green (17 protect tests), workspace clippy `-D warnings` clean, fmt applied.

This completes the series: phases 0–5 — Protect shape, indirection groups, atomic switchover, IS-IS + OSPFv2/v3 triggers, and ECMP eviction. Deferred (recorded in the doc): the SRv6 switchover subset, blocked on the kernel seg6-inline-in-group gap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)