### PR TITLE
rib: remove the seg6 protection exclusions — black-hole claim refuted

### DIFF
--- a/bdd/tests/features/isis_tilfa_srv6.feature
+++ b/bdd/tests/features/isis_tilfa_srv6.feature
@@ -181,7 +181,12 @@ Feature: IS-IS TI-LFA fast-reroute over SRv6 with BGP L3 service traffic
     # kernel entry: out the repair egress s-n2 at metric 12 (2 path +
     # 10 for d's loopback prefix), demoted plain primary behind at 13.
     Then kernel route "2001:db8::8" in namespace "s" should eventually contain "mode inline"
-    And kernel route "2001:db8::8" in namespace "s" should eventually contain "dev s-n2 proto isis metric 12"
+    # The promoted SRv6 repair is the protected primary and references
+    # a protection indirection group; iproute2 renders v6 group routes
+    # on two lines (route attrs on the first, nexthop detail on the
+    # continuation), so assert the two halves separately.
+    And kernel route "2001:db8::8" in namespace "s" should eventually contain "proto isis metric 12"
+    And kernel route "2001:db8::8" in namespace "s" should eventually contain "dev s-n2"
     # NEXT-C-SID compression: the three repair uSIDs (uN of the P node
     # plus two uAs) ride one 128-bit carrier, so the inserted SRH is
     # carrier + original destination — 2 segments, not 4.

--- a/bdd/tests/features/isis_tilfa_srv6_classic.feature
+++ b/bdd/tests/features/isis_tilfa_srv6_classic.feature
@@ -180,7 +180,12 @@ Feature: IS-IS TI-LFA fast-reroute over SRv6 classic (full) SIDs with BGP L3 ser
     # kernel entry: out the repair egress s-n2 at metric 12 (2 path +
     # 10 for d's loopback prefix), demoted plain primary behind at 13.
     Then kernel route "2001:db8::8" in namespace "s" should eventually contain "mode inline"
-    And kernel route "2001:db8::8" in namespace "s" should eventually contain "dev s-n2 proto isis metric 12"
+    # The promoted SRv6 repair is the protected primary and references
+    # a protection indirection group; iproute2 renders v6 group routes
+    # on two lines (route attrs on the first, nexthop detail on the
+    # continuation), so assert the two halves separately.
+    And kernel route "2001:db8::8" in namespace "s" should eventually contain "proto isis metric 12"
+    And kernel route "2001:db8::8" in namespace "s" should eventually contain "dev s-n2"
     # End-to-end over the repair: the IGP loopback path and the
     # BGP/SRv6 LAN-to-LAN service traffic, whose H.Encaps outer
     # destination resolves via the promoted locator route. These die

--- a/bdd/tests/features/ospfv3_tilfa_srv6.feature
+++ b/bdd/tests/features/ospfv3_tilfa_srv6.feature
@@ -118,7 +118,12 @@ Feature: OSPFv3 TI-LFA fast-reroute over SRv6
     # d's loopback now has the SRH-insert repair as its best kernel
     # entry, out the repair egress s-n2 at metric 2, demoted plain
     # primary behind it at 3.
-    Then kernel route "2001:db8::8" in namespace "s" should eventually contain "dev s-n2 proto ospf metric 2"
+    # The promoted SRv6 repair is the protected primary and references
+    # a protection indirection group; iproute2 renders v6 group routes
+    # on two lines (route attrs on the first, nexthop detail on the
+    # continuation), so assert the two halves separately.
+    Then kernel route "2001:db8::8" in namespace "s" should eventually contain "proto ospf metric 2"
+    And kernel route "2001:db8::8" in namespace "s" should eventually contain "dev s-n2"
     And kernel route "2001:db8::8" in namespace "s" should eventually contain "segs 2 ["
     # End-to-end over the carrier-encoded repair: dies if any uN/uA
     # hop (or the LIB twin install) fails to forward.

--- a/bdd/tests/features/ospfv3_tilfa_srv6_classic.feature
+++ b/bdd/tests/features/ospfv3_tilfa_srv6_classic.feature
@@ -118,7 +118,12 @@ Feature: OSPFv3 TI-LFA fast-reroute over SRv6 classic (full) SIDs
     # all installed with neighbor-global nexthops) forwards.
     When I apply command "set router ospfv3 fast-reroute backup-as-primary" in namespace "s"
     And I wait 5 seconds
-    Then kernel route "2001:db8::8" in namespace "s" should eventually contain "dev s-n2 proto ospf metric 2"
+    # The promoted SRv6 repair is the protected primary and references
+    # a protection indirection group; iproute2 renders v6 group routes
+    # on two lines (route attrs on the first, nexthop detail on the
+    # continuation), so assert the two halves separately.
+    Then kernel route "2001:db8::8" in namespace "s" should eventually contain "proto ospf metric 2"
+    And kernel route "2001:db8::8" in namespace "s" should eventually contain "dev s-n2"
     And kernel route "2001:db8::8" in namespace "s" should eventually contain "segs 4 ["
     And ping from "s" to "2001:db8::8" should eventually succeed
     # Restore install-side ordering.

--- a/docs/design/nexthop-protect-kernel-failover.md
+++ b/docs/design/nexthop-protect-kernel-failover.md
@@ -84,30 +84,34 @@ The first probes validated netlink acceptance and **rendering**, not
 end-to-end traffic through encap'd members. The phase-1 BDD run
 closed that gap:
 
-1. **seg6 `mode inline` members black-hole inside groups.** Object
-   creation, grouping, route install, and `ip route get` all succeed,
-   but the dataplane never transmits: a tcpdump probe shows the SRH
-   packet egress with a direct `nhid <member>` reference and **zero
-   packets** via `nhid <group{member}>`. seg6 `mode encap` members DO
-   forward through a group (traffic-verified), as do MPLS members
-   (BDD `@isis_tilfa` backup-as-primary ping rides `Gp{mpls}`).
-   zebra-rs SRv6 TI-LFA repairs are inline, so **SRv6-encap'd
-   primaries are excluded from indirection** (`pro.gid` stays 0,
-   direct member reference, pre-phase-1 behavior). Phase 2's SRv6
-   switchover therefore needs one of: kernel fix upstream, encap-mode
-   repairs, or per-prefix `RTM_NEWROUTE` replace for the SRv6 subset.
-   Note the gate is two-sided: a *plain* primary with an SRv6 *backup*
-   (normal-mode ospfv3 SRv6 TI-LFA, #1375) gets its indirection group
-   in phase 1, but phase 2 must NOT group-swap it onto the seg6
-   member — that swap would re-create the black-hole. The swap path
-   has to check the backup's encap and fall back to route replace.
+1. **[REFUTED 2026-06-12 — see correction below]** ~~seg6 `mode
+   inline` members black-hole inside groups~~. The original claim
+   rested on a single tcpdump that captured zero packets and was
+   never reproduced. A later deep dive (kernel source walk +
+   `skb:kfree_skb` drop-reason tracing on the live 6.8 kernel)
+   showed group-wrapped inline members emit byte-identical SRH
+   packets to direct references, and the atomic group-replace ONTO
+   an inline member works under live traffic. The kernel makes this
+   structural: the lwtstate lives on the member `fib6_nh`
+   (`nh_info->fib6_nh.fib_nh_lws`) and `ip6_rt_init_dst`
+   (net/ipv6/route.c) copies it from the SELECTED member identically
+   for group and direct lookups — no group-conditional branch can
+   lose it. The seg6 exclusions added on the back of the bad probe
+   (phase-1 primary gate, phase-2 backup gate) are REMOVED; SRv6
+   TI-LFA gets the same kernel fast path as MPLS. Post-mortem: the
+   BDD failure that seeded the theory was finding 2 below (the
+   rendering split), and the "confirming" 100%-loss pings were
+   meaningless — a sandbox peer can't answer SRH-routed echoes, so
+   loss is 100% even when forwarding works. Silent-drop claims
+   require drop-reason tracing plus a reproduced capture.
 2. **IPv6 group routes render with continuation lines.** `ip -6 route`
    prints `<prefix> nhid G proto X metric M` on line 1 and
    `nexthop ... dev D weight 1` on line 2 (IPv4 stays one line). Any
    text assertion expecting `dev D proto X metric M` as one substring
-   breaks. Moot for SRv6 after the exclusion above; still relevant to
-   v6+MPLS protected primaries (OSPFv3/IS-IS v6 TI-LFA) — sweep
-   `bdd/` route asserts when phase 1 lands, per the show-grammar rule.
+   breaks. Applies to every wrapped v6 primary — MPLS and (after the
+   un-exclusion) SRv6 alike — sweep `bdd/` route asserts per the
+   show-grammar rule; the combined asserts in the four SRv6 tilfa
+   features were split when the exclusion was removed.
 
 ## 3. Design
 
@@ -207,11 +211,10 @@ leg) but must be called out in the phase-5 PR.
 
 ## 5. Constraints
 
-- **SRv6 primaries are NOT wrapped** (see Phase-1 BDD findings):
-  kernel 6.8 black-holes seg6-inline traffic routed through a group.
-  `resolve_nexthop_protect` skips members with a non-empty `segs`.
 - **seg6local** can't ride nexthop objects (existing constraint) —
-  irrelevant: local-SID installs aren't protected routes.
+  irrelevant: local-SID installs aren't protected routes. (SRv6
+  *encap'd* primaries and backups participate fully — the temporary
+  exclusion is gone, see the corrected Phase-1 findings.)
 - `show nexthop` should render `Group::Protect` (+ active member from
   phase 2). Route show output is unchanged; RIB/kernel divergence
   during a switchover is bounded by SPF reconvergence.

--- a/zebra-rs/src/rib/nexthop/map.rs
+++ b/zebra-rs/src/rib/nexthop/map.rs
@@ -229,13 +229,15 @@ impl NexthopMap {
     ///   - still be on its primary (an already-switched group has
     ///     nothing left to protect with),
     ///   - have a Uni backup member (a Multi backup can't be a group
-    ///     member — kernel groups don't nest; deferred to the ECMP
-    ///     phase),
-    ///   - have a non-SRv6 backup (kernel 6.8 black-holes seg6
-    ///     members inside groups — see the design doc; that subset
-    ///     waits for SPF reconvergence exactly as before phase 2),
+    ///     member — kernel groups don't nest; ECMP primaries are
+    ///     served by leg eviction instead),
     ///   - have that backup's kernel object alive (valid +
     ///     installed), or the swap would point routes at nothing.
+    ///
+    /// SRv6 backups are eligible like any other: seg6 lwtunnel
+    /// members forward correctly through groups (the earlier
+    /// "inline-in-group black-hole" claim was refuted by kfree_skb
+    /// drop-reason tracing — see the design doc correction).
     pub fn protect_switch_candidates(&self, table_id: u32, addr: IpAddr) -> Vec<usize> {
         self.groups
             .iter()
@@ -252,13 +254,6 @@ impl NexthopMap {
                     return None;
                 }
                 let backup = self.get_uni(pro.backup_gid)?;
-                if !backup.segs.is_empty() {
-                    tracing::info!(
-                        "protect_switch: gid {} skipped — seg6 backup can't join a group",
-                        pro.gid(),
-                    );
-                    return None;
-                }
                 if !backup.is_valid() || !backup.is_installed() {
                     return None;
                 }

--- a/zebra-rs/src/rib/route.rs
+++ b/zebra-rs/src/rib/route.rs
@@ -1604,18 +1604,6 @@ fn resolve_nexthop_protect(pro: &mut NexthopProtect, nmap: &mut NexthopMap) {
     if primary.gid == 0 {
         return;
     }
-    // Kernel 6.8 silently DROPS traffic when a seg6-inline-lwtunnel
-    // nexthop sits inside a group: object creation, grouping, route
-    // install, and `ip route get` all succeed, but the dataplane
-    // never transmits (verified 2026-06-12 in netns; direct member
-    // reference forwards fine, and BDD tilfa_srv6 backup-as-primary
-    // black-holed through the wrapper). SRv6 repairs are inline by
-    // default, so SRv6-encap'd primaries keep the direct member
-    // reference — plain and MPLS-encap'd primaries (group forwarding
-    // BDD- and probe-verified) get the indirection.
-    if !primary.segs.is_empty() {
-        return;
-    }
     let backup_gid = match &pro.backup {
         NexthopMember::Uni(u) => u.gid,
         NexthopMember::Multi(m) => m.gid,
@@ -2827,11 +2815,12 @@ mod tests {
         assert!(nmap.protect_switch_candidates(0, addr).is_empty());
     }
 
-    /// Phase 2: a seg6 repair can't join a kernel group (6.8
-    /// black-holes it), so such pairs are never switchover candidates
-    /// — they wait for SPF reconvergence as before.
+    /// A seg6 repair is switchover-eligible like any other live Uni
+    /// backup: seg6 members forward correctly through groups (the
+    /// black-hole theory was refuted — design doc correction), so
+    /// SRv6 TI-LFA gets the same kernel fast path.
     #[test]
-    fn protect_switch_candidates_skip_seg6_backup() {
+    fn protect_switch_candidates_include_seg6_backup() {
         use super::super::entry::RibEntry;
         use super::super::nexthop::{GroupTrait, NexthopProtect, NexthopUni};
         use super::super::{Nexthop, NexthopMap, NexthopMember};
@@ -2864,10 +2853,10 @@ mod tests {
             panic!("backup Uni");
         };
         nmap.get_mut(b.gid).unwrap().set_installed(true);
-        assert!(
-            nmap.protect_switch_candidates(254, "fe80::1".parse().unwrap())
-                .is_empty(),
-            "seg6 backup must never be swapped into the group"
+        assert_eq!(
+            nmap.protect_switch_candidates(254, "fe80::1".parse().unwrap()),
+            vec![pro.gid],
+            "a live seg6 repair is a switchover candidate"
         );
     }
 
@@ -2999,13 +2988,13 @@ mod tests {
         assert_eq!(m.set.len(), 2, "configured membership untouched");
     }
 
-    /// Kernel 6.8 drops seg6-inline traffic routed through a nexthop
-    /// group (the object/route install succeeds — only the dataplane
-    /// black-holes), so an SRv6-encap'd primary must keep its direct
-    /// member reference: `pro.gid` stays 0. Caught live by the
-    /// `@tilfa_srv6` backup-as-primary scenario.
+    /// SRv6-encap'd primaries get the indirection group like any
+    /// other Uni primary. (They were excluded for a while on a
+    /// "seg6-inline-in-group black-holes" theory that kfree_skb
+    /// drop-reason tracing later refuted — see the design doc
+    /// correction; this test pins the un-exclusion.)
     #[test]
-    fn protect_srv6_primary_gets_no_indirection_group() {
+    fn protect_srv6_primary_gets_indirection_group() {
         use super::super::entry::RibEntry;
         use super::super::nexthop::{NexthopProtect, NexthopUni};
         use super::super::{Nexthop, NexthopMap, NexthopMember};
@@ -3040,10 +3029,10 @@ mod tests {
         let NexthopMember::Uni(p) = &pro.primary else {
             panic!("primary stays Uni");
         };
-        assert_ne!(p.gid, 0, "the seg6 member itself still gets its group");
-        assert_eq!(
+        assert_ne!(p.gid, 0, "the seg6 member gets its own group");
+        assert_ne!(
             pro.gid, 0,
-            "SRv6 primary must NOT be wrapped in an indirection group"
+            "SRv6 primary is wrapped in an indirection group like any other"
         );
     }
 


### PR DESCRIPTION
## Summary

Follow-up to the kernel deep dive: the "seg6 inline-mode nexthops black-hole inside groups" finding that introduced the SRv6 exclusions (#1374's fix commit, #1377's two-sided gate) was **wrong** — a probe artifact, not a kernel behavior.

**The investigation:** a source walk of the lookup path (`nexthop_select_path` → `nexthop_path_fib6_result` → `ip6_rt_init_dst`) shows the lwtstate is copied from the *selected member's* `fib6_nh` identically for group and direct references — there is no group-conditional branch that can lose it. Live `skb:kfree_skb` drop-reason tracing on 6.8 then showed the supposedly black-holed packet actually crossing the veth and dying in the *peer* namespace (`IP_INNOROUTES` — the sandbox peer had no route for the SRH destination, by construction). Controlled re-captures: group and direct emit byte-identical `RT6` SRH packets; the atomic group-replace **onto** an inline member works under live traffic. The original evidence was one unreproducible zero-packet capture + a BDD failure actually caused by iproute2's two-line v6 group-route rendering + 100%-loss pings that are meaningless against a peer that can't answer SRH-routed echoes.

## Changes

- Remove `resolve_nexthop_protect`'s seg6-primary gate and `protect_switch_candidates`' seg6-backup gate: **SRv6 TI-LFA now gets the same kernel fast path as MPLS** — indirection groups for promoted repairs and BFD-down switchover onto seg6 repairs.
- Invert the two pinning unit tests (SRv6 primary *gets* its group; a live seg6 repair *is* a switchover candidate).
- Design doc: "Phase-1 BDD findings" item 1 rewritten as a dated refutation with the post-mortem and kernel-source explanation; constraints section updated.
- BDD sweep: the four SRv6 tilfa features' combined one-line route asserts split (promoted repairs now render as two-line v6 group routes), matching the ospfv3_tilfa precedent.

## Testing

- Local BDD on an md5-stable binary — the decisive end-to-end check: `@tilfa_srv6`, `@tilfa_classic_srv6`, `@srv6_tilfa_v3`, `@classic_tilfa_v3` all pass **with their promoted-repair pings riding group-wrapped inline-seg6 members on real multi-hop topologies**, plus `@tilfa_bfd` and `@isis_tilfa` regressions green.
- `cargo test --workspace --exclude bdd` green (17 protect tests), workspace clippy `-D warnings` clean, fmt applied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)