### PR TITLE
bgp: per-AFI table-map — policy gate/rewrite at BGP-to-RIB install

### DIFF
--- a/bdd/Makefile
+++ b/bdd/Makefile
@@ -186,6 +186,10 @@ bgp_policy_dynamic_update:
 	mkdir -p allure-results
 	cargo test --test cucumber -- --concurrency=1 --tags "@bgp_policy_dynamic_update"
 
+bgp_table_map:
+	mkdir -p allure-results
+	cargo test --test cucumber -- --concurrency=1 --tags "@bgp_table_map"
+
 bgp_community:
 	mkdir -p allure-results
 	cargo test --test cucumber -- --concurrency=1 --tags "@bgp_community"
@@ -241,4 +245,4 @@ docs/%.md: tests/features/%.feature docs/feature2md.sh FORCE
 
 FORCE:
 
-.PHONY: ecmp_bfd_evict ospfv2_bfd_frr ospfv3_bfd_frr tilfa_bfd all run ibgp ebgp rr rib_static_ipv6 isis_ipv6 isis_srv6 isis_fragmentation_ipv6 isis_fragmentation_ipv4 isis_l1p2p isis_tilfa isis_l1l2 isis_redist isis_hello_auth_keychain isis_passive isis_afi_enable isis_endx_ipv6 isis_bfd_ipv6_p2p isis_bfd_ipv6_p2p_echo isis_bfd_ipv6_lan isis_bfd_ipv6_lan_echo isis_bfd_ipv4_p2p isis_bfd_ipv4_p2p_echo isis_bfd_ipv4_lan isis_bfd_ipv4_lan_echo ospf_clear_neighbor ospfv2_nssa ospfv2_stub ospfv2_tilfa ospfv3_nssa ospfv3_tilfa bgp_peer_down_cleanup bgp_ipv6_over_v4_session bgp_evpn_capability bgp_vrf_evpn_type5 bgp_route_map_match bgp_policy_dynamic_update bgp_community bgp_neighbor_group bgp_unnumbered_neighbor nd_show bgp_interas_option_c bgp_interas_option_a bgp_interas_option_b bgp_interas_option_ab generate open docs FORCE
+.PHONY: ecmp_bfd_evict ospfv2_bfd_frr ospfv3_bfd_frr tilfa_bfd all run ibgp ebgp rr rib_static_ipv6 isis_ipv6 isis_srv6 isis_fragmentation_ipv6 isis_fragmentation_ipv4 isis_l1p2p isis_tilfa isis_l1l2 isis_redist isis_hello_auth_keychain isis_passive isis_afi_enable isis_endx_ipv6 isis_bfd_ipv6_p2p isis_bfd_ipv6_p2p_echo isis_bfd_ipv6_lan isis_bfd_ipv6_lan_echo isis_bfd_ipv4_p2p isis_bfd_ipv4_p2p_echo isis_bfd_ipv4_lan isis_bfd_ipv4_lan_echo ospf_clear_neighbor ospfv2_nssa ospfv2_stub ospfv2_tilfa ospfv3_nssa ospfv3_tilfa bgp_peer_down_cleanup bgp_ipv6_over_v4_session bgp_evpn_capability bgp_vrf_evpn_type5 bgp_route_map_match bgp_policy_dynamic_update bgp_table_map bgp_community bgp_neighbor_group bgp_unnumbered_neighbor nd_show bgp_interas_option_c bgp_interas_option_a bgp_interas_option_b bgp_interas_option_ab generate open docs FORCE

--- a/bdd/tests/configs/bgp_table_map/z1.yaml
+++ b/bdd/tests/configs/bgp_table_map/z1.yaml
@@ -1,0 +1,18 @@
+router:
+  bgp:
+    global:
+      as: 65001
+      router-id: 192.168.0.1
+    neighbor:
+    - remote-address: 192.168.0.2
+      afi-safi:
+      - name: ipv4
+        enabled: true
+      enabled: true
+      remote-as: 65002
+    afi-safi:
+    - name: ipv4
+      network:
+      - prefix: 1.1.1.1/32
+      - prefix: 2.2.2.2/32
+      - prefix: 3.3.3.3/32

--- a/bdd/tests/configs/bgp_table_map/z2-deny-more.yaml
+++ b/bdd/tests/configs/bgp_table_map/z2-deny-more.yaml
@@ -1,0 +1,39 @@
+prefix-set:
+- name: DENY
+  prefixes:
+  - prefix: 1.1.1.1/32
+  - prefix: 3.3.3.3/32
+- name: MED
+  prefixes:
+  - prefix: 2.2.2.2/32
+policy:
+- name: TMAP
+  entry:
+  - number: 10
+    action: deny
+    match:
+      prefix: DENY
+  - number: 20
+    action: permit
+    match:
+      prefix: MED
+    set:
+      med:
+        set: 50
+  - number: 30
+    action: permit
+router:
+  bgp:
+    global:
+      as: 65002
+      router-id: 192.168.0.2
+    neighbor:
+    - remote-address: 192.168.0.1
+      afi-safi:
+      - name: ipv4
+        enabled: true
+      enabled: true
+      remote-as: 65001
+    afi-safi:
+    - name: ipv4
+      table-map: TMAP

--- a/bdd/tests/configs/bgp_table_map/z2.yaml
+++ b/bdd/tests/configs/bgp_table_map/z2.yaml
@@ -1,0 +1,38 @@
+prefix-set:
+- name: DENY
+  prefixes:
+  - prefix: 1.1.1.1/32
+- name: MED
+  prefixes:
+  - prefix: 2.2.2.2/32
+policy:
+- name: TMAP
+  entry:
+  - number: 10
+    action: deny
+    match:
+      prefix: DENY
+  - number: 20
+    action: permit
+    match:
+      prefix: MED
+    set:
+      med:
+        set: 50
+  - number: 30
+    action: permit
+router:
+  bgp:
+    global:
+      as: 65002
+      router-id: 192.168.0.2
+    neighbor:
+    - remote-address: 192.168.0.1
+      afi-safi:
+      - name: ipv4
+        enabled: true
+      enabled: true
+      remote-as: 65001
+    afi-safi:
+    - name: ipv4
+      table-map: TMAP

--- a/bdd/tests/features/bgp_table_map.feature
+++ b/bdd/tests/features/bgp_table_map.feature
@@ -1,0 +1,86 @@
+@serial
+@bgp_table_map
+Feature: BGP table-map gates and rewrites RIB installs without touching the Loc-RIB
+  As a network operator
+  I want `router bgp afi-safi ipv4 table-map <policy>` to filter and
+  rewrite BGP best paths at the point they are installed into the
+  kernel RIB, while the BGP table itself (and what peers are
+  advertised) stays complete — FRR's table-map semantics.
+
+  The exercise: z1 advertises three prefixes. z2 binds table-map TMAP:
+  entry 10 denies 1.1.1.1/32, entry 20 permits 2.2.2.2/32 with
+  `set med 50` (MED lands in the kernel route metric), entry 30
+  permits the rest. All three prefixes must stay visible in z2's BGP
+  table throughout; only the kernel routes move. Live policy edits
+  must resync the FIB without a session clear, a rebind to a
+  nonexistent policy must deny every install (FRR parity), and
+  deleting the table-map must restore unfiltered installs.
+
+  Test Topology:
+  ```
+  ┌─────────────────────────────────────────┐
+  │                   br0                   │
+  └─────────────┬───────────────┬───────────┘
+                │               │
+           ┌────┴────┐     ┌────┴────┐
+           │   z1    │     │   z2    │
+           │ AS65001 │     │ AS65002 │
+           │192.168. │     │192.168. │
+           │  0.1/24 │     │  0.2/24 │
+           └─────────┘     └─────────┘
+  ```
+
+  Config files:
+  - z1.yaml: AS 65001, advertises 1.1.1.1/32 + 2.2.2.2/32 + 3.3.3.3/32.
+  - z2.yaml: prefix-set DENY = { 1.1.1.1/32 }, MED = { 2.2.2.2/32 };
+    policy TMAP = deny DENY / permit MED set med 50 / permit;
+    `afi-safi ipv4 table-map TMAP`.
+  - z2-deny-more.yaml: DENY = { 1.1.1.1/32, 3.3.3.3/32 } (added).
+
+  Scenario: Setup topology and verify install-time filter and MED rewrite
+    Given a clean test environment
+    When I create bridge "br0"
+    And I create namespace "z1" with IP "192.168.0.1/24" on bridge "br0"
+    And I create namespace "z2" with IP "192.168.0.2/24" on bridge "br0"
+    And I start zebra-rs in namespace "z1"
+    And I start zebra-rs in namespace "z2"
+    And I apply config "z1.yaml" to namespace "z1"
+    And I apply config "z2.yaml" to namespace "z2"
+    And I wait 10 seconds for BGP to operate
+    Then BGP session in "z1" to "192.168.0.2" should be "Established"
+    And BGP session in "z2" to "192.168.0.1" should be "Established"
+    And BGP route in "z2" has "1.1.1.1/32"
+    And BGP route in "z2" has "2.2.2.2/32"
+    And BGP route in "z2" has "3.3.3.3/32"
+    And kernel route "1.1.1.1/32" in namespace "z2" should eventually be gone
+    And kernel route "2.2.2.2/32" in namespace "z2" should eventually contain "metric 50"
+    And kernel route "3.3.3.3/32" in namespace "z2" should eventually contain "192.168.0.1"
+
+  Scenario: Editing the referenced policy resyncs the FIB without a session reset
+    Given the test topology exists
+    When I apply config "z2-deny-more.yaml" to namespace "z2"
+    Then kernel route "3.3.3.3/32" in namespace "z2" should eventually be gone
+    And kernel route "2.2.2.2/32" in namespace "z2" should eventually contain "metric 50"
+    And BGP route in "z2" has "3.3.3.3/32"
+
+  Scenario: Rebinding to a nonexistent policy denies every install
+    Given the test topology exists
+    When I apply command "set router bgp afi-safi ipv4 table-map NOSUCH" in namespace "z2"
+    Then kernel route "2.2.2.2/32" in namespace "z2" should eventually be gone
+    And BGP route in "z2" has "2.2.2.2/32"
+
+  Scenario: Deleting the table-map restores unfiltered installs
+    Given the test topology exists
+    When I apply command "delete router bgp afi-safi ipv4 table-map NOSUCH" in namespace "z2"
+    Then kernel route "1.1.1.1/32" in namespace "z2" should eventually contain "192.168.0.1"
+    And kernel route "2.2.2.2/32" in namespace "z2" should eventually contain "192.168.0.1"
+    And kernel route "3.3.3.3/32" in namespace "z2" should eventually contain "192.168.0.1"
+
+  Scenario: Teardown topology
+    Given the test topology exists
+    When I stop zebra-rs in namespace "z1"
+    And I stop zebra-rs in namespace "z2"
+    And I delete namespace "z1"
+    And I delete namespace "z2"
+    And I delete bridge "br0"
+    Then the test environment should be clean

--- a/zebra-rs/src/bgp/config.rs
+++ b/zebra-rs/src/bgp/config.rs
@@ -1672,7 +1672,7 @@ pub(super) fn config_table_map(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> O
     if op.is_set() {
         let new = args.string()?;
         let tm = bgp.local_rib.table_map.entry(afi_safi).or_default();
-        let prior = std::mem::replace(&mut tm.name, Some(new.clone()));
+        let prior = tm.name.replace(new.clone());
         policy_attach_msgs(
             &bgp.policy_tx,
             ident,

--- a/zebra-rs/src/bgp/config.rs
+++ b/zebra-rs/src/bgp/config.rs
@@ -414,9 +414,10 @@ pub(super) fn apply_peer_policy_ref(
         policy::PolicyType::PolicyListOut => &mut peer.policy_list.get_mut(&InOut::Output).name,
         policy::PolicyType::PrefixSetIn => &mut peer.prefix_set.get_mut(&InOut::Input).name,
         policy::PolicyType::PrefixSetOut => &mut peer.prefix_set.get_mut(&InOut::Output).name,
-        // Key-chain subscriptions ride a different registry and never
-        // reach this helper.
-        policy::PolicyType::KeyChain(_) => return,
+        // Key-chain subscriptions ride a different registry, and
+        // table-map subscriptions are AFI-scoped rather than
+        // peer-scoped; neither reaches this helper.
+        policy::PolicyType::KeyChain(_) | policy::PolicyType::TableMap => return,
     };
     let prior = match &want {
         Some(n) => slot.replace(n.clone()),
@@ -1625,6 +1626,74 @@ pub(super) fn config_redistribute_ospf_match_type(
         true,
         bgp_set_ospf_match,
     )
+}
+
+/// Families `table-map` accepts today. The YANG augment attaches the
+/// leaf to every afi-safi list entry, so filter at the callback —
+/// returning `None` surfaces as a commit failure. v4 unicast only
+/// until the policy-apply path grows a v6 NLRI form.
+fn table_map_afi_valid(afi_safi: &AfiSafi) -> bool {
+    matches!((afi_safi.afi, afi_safi.safi), (Afi::Ip, Safi::Unicast))
+}
+
+/// `ident` slot a table-map binding uses on the policy watch
+/// registry: there's no peer behind it, so the AFI/SAFI itself is
+/// encoded. The codec already spans v6 for the follow-up.
+pub(super) fn table_map_ident(afi_safi: &AfiSafi) -> Option<usize> {
+    match (afi_safi.afi, afi_safi.safi) {
+        (Afi::Ip, Safi::Unicast) => Some(0),
+        (Afi::Ip6, Safi::Unicast) => Some(1),
+        _ => None,
+    }
+}
+
+pub(super) fn table_map_ident_decode(ident: usize) -> Option<AfiSafi> {
+    match ident {
+        0 => Some(AfiSafi::new(Afi::Ip, Safi::Unicast)),
+        1 => Some(AfiSafi::new(Afi::Ip6, Safi::Unicast)),
+        _ => None,
+    }
+}
+
+/// `router bgp afi-safi <af> table-map <policy>`
+/// (zebra-bgp-table-map.yang). Stores the binding on
+/// `local_rib.table_map`, (un)registers the policy watch via
+/// [`policy_attach_msgs`], and reconciles the FIB. Set defers the
+/// resync to the `PolicyRx` reply — always sent for
+/// `PolicyType::TableMap`, even when the name doesn't resolve — so
+/// the FIB flips exactly once, on the definitive answer. Delete
+/// resyncs immediately (nothing will reply).
+pub(super) fn config_table_map(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Option<()> {
+    let afi_safi: AfiSafi = args.afi_safi()?;
+    if !table_map_afi_valid(&afi_safi) {
+        return None;
+    }
+    let ident = table_map_ident(&afi_safi)?;
+    if op.is_set() {
+        let new = args.string()?;
+        let tm = bgp.local_rib.table_map.entry(afi_safi).or_default();
+        let prior = std::mem::replace(&mut tm.name, Some(new.clone()));
+        policy_attach_msgs(
+            &bgp.policy_tx,
+            ident,
+            policy::PolicyType::TableMap,
+            prior,
+            Some(new),
+        );
+    } else {
+        let Some(tm) = bgp.local_rib.table_map.remove(&afi_safi) else {
+            return Some(());
+        };
+        policy_attach_msgs(
+            &bgp.policy_tx,
+            ident,
+            policy::PolicyType::TableMap,
+            tm.name,
+            None,
+        );
+        bgp.table_map_resync(afi_safi);
+    }
+    Some(())
 }
 
 fn config_add_path(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Option<()> {
@@ -3029,6 +3098,10 @@ impl Bgp {
             config_redistribute_ospf_match_type,
         );
 
+        // Per-AFI table-map (zebra-bgp-table-map.yang): policy gate /
+        // rewrite at BGP-to-RIB install time.
+        self.callback_add("/router/bgp/afi-safi/table-map", config_table_map);
+
         // Applying policy.
         self.callback_peer("/policy/in", config_policy_in);
         self.callback_peer("/policy/out", config_policy_out);
@@ -3077,6 +3150,41 @@ impl Bgp {
         // left-most AS_PATH segment begins with the neighbor's own AS
         // (eBGP only).
         self.callback_peer("/enforce-first-as", config_enforce_first_as);
+    }
+}
+
+#[cfg(test)]
+mod table_map_ident_tests {
+    use super::*;
+
+    /// The watch `ident` must survive the round trip for every family
+    /// the codec covers — a drift here silently misroutes `PolicyRx`
+    /// pushes and the table-map never refreshes.
+    #[test]
+    fn ident_roundtrip() {
+        for afi_safi in [
+            AfiSafi::new(Afi::Ip, Safi::Unicast),
+            AfiSafi::new(Afi::Ip6, Safi::Unicast),
+        ] {
+            let ident = table_map_ident(&afi_safi).expect("codec covers the family");
+            assert_eq!(table_map_ident_decode(ident), Some(afi_safi));
+        }
+        assert_eq!(
+            table_map_ident(&AfiSafi::new(Afi::Ip, Safi::MplsVpn)),
+            None,
+            "uncovered families must not register a watch"
+        );
+        assert_eq!(table_map_ident_decode(999), None);
+    }
+
+    /// v4 unicast is the only family the callback accepts today; the
+    /// YANG augment attaches the leaf to every afi-safi entry, so the
+    /// gate is what rejects the rest at commit time.
+    #[test]
+    fn afi_gate_is_v4_unicast_only() {
+        assert!(table_map_afi_valid(&AfiSafi::new(Afi::Ip, Safi::Unicast)));
+        assert!(!table_map_afi_valid(&AfiSafi::new(Afi::Ip6, Safi::Unicast)));
+        assert!(!table_map_afi_valid(&AfiSafi::new(Afi::Ip, Safi::MplsVpn)));
     }
 }
 

--- a/zebra-rs/src/bgp/inst.rs
+++ b/zebra-rs/src/bgp/inst.rs
@@ -2847,11 +2847,32 @@ impl Bgp {
                 }
             }
             policy::PolicyRx::PolicyList {
-                name: _,
+                name,
                 ident,
                 policy_type,
                 policy_list,
             } => {
+                // Table-map bindings aren't peer-scoped — `ident`
+                // encodes the AFI/SAFI — so route them before the
+                // peer lookup. The refresh step is a FIB resync, not
+                // a soft-reconfiguration: table-map never changes
+                // best-path or what peers are advertised.
+                if policy_type == policy::PolicyType::TableMap {
+                    let Some(afi_safi) = super::config::table_map_ident_decode(ident) else {
+                        return;
+                    };
+                    let Some(tm) = self.local_rib.table_map.get_mut(&afi_safi) else {
+                        return;
+                    };
+                    // Drop a stale in-flight push from a name the
+                    // operator has since rebound away from.
+                    if tm.name.as_deref() != Some(name.as_str()) {
+                        return;
+                    }
+                    tm.policy = policy_list;
+                    self.table_map_resync(afi_safi);
+                    return;
+                }
                 let Some(peer) = self.peers.get_mut_by_idx(ident) else {
                     return;
                 };
@@ -2883,6 +2904,50 @@ impl Bgp {
                 }
                 super::config::apply_ao_refresh_all(self);
             }
+        }
+    }
+
+    /// Re-run the FIB install for every Loc-RIB winner of `afi_safi`
+    /// after a `table-map` binding or its policy content changed.
+    /// Install-only sweep: best-path selection and egress attributes
+    /// are unaffected by table-map, so nothing is re-advertised. The
+    /// `Selected` side of the Loc-RIB table is authoritative for
+    /// "currently has a winner" — prefixes absent from it have no FIB
+    /// state to reconcile (their withdraw fired when the winner
+    /// disappeared).
+    pub(super) fn table_map_resync(&mut self, afi_safi: bgp_packet::AfiSafi) {
+        use bgp_packet::{Afi, Safi};
+        // v4 unicast only today, matching `table_map_afi_valid`.
+        if (afi_safi.afi, afi_safi.safi) != (Afi::Ip, Safi::Unicast) {
+            return;
+        }
+        let winners: Vec<(ipnet::Ipv4Net, super::route::BgpRib)> = self
+            .local_rib
+            .v4
+            .1
+            .iter()
+            .map(|(p, best)| (p, best.clone()))
+            .collect();
+        let top = super::peer::BgpTop {
+            router_id: &self.router_id,
+            srv6_ipv6_export: self.srv6_ipv6_export.as_ref(),
+            local_rib: &mut self.local_rib,
+            tx: &self.tx,
+            rib_client: &self.ctx.rib,
+            attr_store: &mut self.attr_store,
+            update_groups: &mut self.update_groups,
+            interface_addrs: &self.interface_addrs,
+            color_policy: Some(&self.color_policy),
+            flex_algo_routes: Some(&self.flex_algo_routes),
+            vrf_export: None,
+            vrf_import: None,
+            nexthop_cache: None,
+            vrf_transport_v4: None,
+            vrf_transport_v6: None,
+            lu_labels: None,
+        };
+        for (prefix, best) in &winners {
+            super::route::fib_install_v4(&top, *prefix, std::slice::from_ref(best));
         }
     }
 

--- a/zebra-rs/src/bgp/route.rs
+++ b/zebra-rs/src/bgp/route.rs
@@ -351,6 +351,37 @@ fn select_fib_entry_v4(
     }
 }
 
+/// Run the v4-unicast `table-map` over a best path about to be FIB-
+/// installed. Pass-through when no binding exists for the family.
+/// With a binding: an unresolved policy denies everything (FRR
+/// parity), a policy deny returns `None` (the caller's withdraw
+/// branch reconciles the FIB), and a permit returns a rewritten
+/// *copy* of the `BgpRib` — the Loc-RIB original and what peers see
+/// are never touched. Useful set clauses at install time are
+/// `set med` (-> RIB metric) and `set next-hop`; others execute
+/// harmlessly on the discarded copy.
+fn table_map_apply_v4<'a>(
+    table_map: &BTreeMap<AfiSafi, BgpTableMap>,
+    router_id: Ipv4Addr,
+    prefix: Ipv4Net,
+    best: Option<&'a BgpRib>,
+) -> Option<std::borrow::Cow<'a, BgpRib>> {
+    use std::borrow::Cow;
+    let Some(tm) = table_map.get(&AfiSafi::new(Afi::Ip, Safi::Unicast)) else {
+        return best.map(Cow::Borrowed);
+    };
+    let best = best?;
+    // Bound name doesn't resolve to a policy: deny-all.
+    let policy = tm.policy.as_ref()?;
+    let nlri = Ipv4Nlri { id: 0, prefix };
+    let decision = policy_list_apply(policy, &nlri, (*best.attr).clone(), best.weight, router_id)?;
+    let mut mapped = best.clone();
+    // Transient install-time copy — never enters the attr store or
+    // the Loc-RIB, so a free-floating Arc is fine.
+    mapped.attr = Arc::new(decision.attr);
+    Some(Cow::Owned(mapped))
+}
+
 /// Reconcile the kernel FIB state for `prefix` with the BGP best-path
 /// outcome. `selected` is the `select_best_path` return: at most one
 /// `BgpRib` after best-path selection. Empty means every candidate
@@ -367,7 +398,13 @@ pub(super) fn fib_install_v4(bgp: &super::peer::BgpTop, prefix: Ipv4Net, selecte
         .vrf_transport_v4
         .and_then(|m| m.get(&prefix))
         .map(|v| v.as_slice());
-    let best = selected.first();
+    let best = table_map_apply_v4(
+        &bgp.local_rib.table_map,
+        *bgp.router_id,
+        prefix,
+        selected.first(),
+    );
+    let best = best.as_deref();
     let entry = best.and_then(|b| select_fib_entry_v4(b, transport));
     match entry {
         Some(mut rib_entry) => {
@@ -1537,6 +1574,24 @@ impl LocalRibBgpLsTable {
     }
 }
 
+/// Per-AFI `table-map` binding (zebra-bgp-table-map.yang
+/// `router bgp afi-safi <af> table-map <name>`): a policy applied to
+/// best paths at BGP-to-RIB install time only. Deny keeps the route
+/// out of the FIB; permit-side set clauses rewrite the installed
+/// entry (MED -> metric, next-hop) without touching the Loc-RIB or
+/// what peers are advertised.
+#[derive(Debug, Default, Clone)]
+pub struct BgpTableMap {
+    /// Configured policy name (the `table-map` leaf value).
+    pub name: Option<String>,
+    /// Resolved snapshot, pushed by the policy actor via
+    /// `PolicyRx::PolicyList` (`PolicyType::TableMap`). `None` while
+    /// the name doesn't resolve — which denies every install for the
+    /// family (FRR parity: a missing referenced route-map filters
+    /// everything).
+    pub policy: Option<PolicyList>,
+}
+
 #[derive(Debug, Default)]
 pub struct LocalRib {
     pub v4: LocalRibTable<Ipv4Net>,
@@ -1575,6 +1630,14 @@ pub struct LocalRib {
     /// table keyed by `BgpLsNlri`; the v4/v6 prefix distinction lives inside
     /// the NLRI, so one table holds Node, Link, and Prefix objects.
     pub bgp_ls: LocalRibBgpLsTable,
+
+    /// Per-AFI `table-map` bindings (zebra-bgp-table-map.yang).
+    /// Lives here — like `sr_policy_local` — so both the config
+    /// callbacks (`&mut Bgp`) and `fib_install_v4`/`v6` (`BgpTop`)
+    /// reach it without threading a new `BgpTop` field. Per-VRF
+    /// tasks own a separate `LocalRib` whose map stays empty, so
+    /// VRF installs are unaffected until table-map grows VRF config.
+    pub table_map: BTreeMap<AfiSafi, BgpTableMap>,
 }
 
 impl LocalRib {
@@ -10381,6 +10444,134 @@ mod color_aware_nht_tests {
         assert_eq!(
             resolve_flex_algo_label_inner(&cp, &shadow, &attr, "10.0.0.5".parse().unwrap()),
             Some(17128)
+        );
+    }
+}
+
+/// `table-map` semantics at the BGP-to-RIB install seam
+/// (zebra-bgp-table-map.yang): no binding passes through, an
+/// unresolved binding denies everything (FRR parity), a policy deny
+/// filters, and permit-side set clauses rewrite only the install-time
+/// copy — never the Loc-RIB original.
+#[cfg(test)]
+mod table_map_tests {
+    use std::borrow::Cow;
+    use std::net::Ipv4Addr;
+    use std::str::FromStr;
+
+    use bgp_packet::{Afi, AfiSafi, BgpAttr, BgpNexthop, Med, Safi};
+    use ipnet::Ipv4Net;
+
+    use super::*;
+    use crate::policy::{NumericSet, PolicyAction, PolicyList, PrefixSet};
+
+    fn binding(policy: Option<PolicyList>) -> BTreeMap<AfiSafi, BgpTableMap> {
+        let mut map = BTreeMap::new();
+        map.insert(
+            AfiSafi::new(Afi::Ip, Safi::Unicast),
+            BgpTableMap {
+                name: Some("TM".into()),
+                policy,
+            },
+        );
+        map
+    }
+
+    fn rib_with_med(med: Option<u32>) -> BgpRib {
+        let mut attr = BgpAttr::new();
+        attr.nexthop = Some(BgpNexthop::Ipv4(Ipv4Addr::new(10, 0, 0, 1)));
+        attr.med = med.map(|m| Med { med: m });
+        BgpRib::new(
+            1,
+            Ipv4Addr::new(192, 0, 2, 1),
+            BgpRibType::EBGP,
+            0,
+            0,
+            &attr,
+            None,
+            None,
+            false,
+        )
+    }
+
+    fn p(s: &str) -> Ipv4Net {
+        Ipv4Net::from_str(s).unwrap()
+    }
+
+    #[test]
+    fn no_binding_passes_through() {
+        let map = BTreeMap::new();
+        let best = rib_with_med(Some(7));
+        let out = table_map_apply_v4(&map, Ipv4Addr::UNSPECIFIED, p("10.0.0.0/8"), Some(&best))
+            .expect("no binding must not filter");
+        assert!(
+            matches!(out, Cow::Borrowed(_)),
+            "pass-through must not clone the winner"
+        );
+        assert!(
+            table_map_apply_v4(&map, Ipv4Addr::UNSPECIFIED, p("10.0.0.0/8"), None).is_none(),
+            "no winner stays no winner"
+        );
+    }
+
+    #[test]
+    fn unresolved_policy_denies_all() {
+        let map = binding(None);
+        let best = rib_with_med(None);
+        assert!(
+            table_map_apply_v4(&map, Ipv4Addr::UNSPECIFIED, p("10.0.0.0/8"), Some(&best)).is_none(),
+            "a bound but unresolved table-map filters every install (FRR parity)"
+        );
+    }
+
+    #[test]
+    fn policy_deny_filters_matching_prefix_only() {
+        // seq 10: deny 10.0.0.0/8 (and longer); seq 20: permit any.
+        let mut list = PolicyList::default();
+        let mut pset = PrefixSet::default();
+        pset.entry(p("10.0.0.0/8").into());
+        let entry = list.entry(10);
+        entry.prefix_set = Some(pset);
+        entry.action = PolicyAction::Deny;
+        let _ = list.entry(20);
+        let map = binding(Some(list));
+        let best = rib_with_med(None);
+
+        assert!(
+            table_map_apply_v4(&map, Ipv4Addr::UNSPECIFIED, p("10.1.0.0/16"), Some(&best))
+                .is_none(),
+            "denied prefix must not install"
+        );
+        assert!(
+            table_map_apply_v4(
+                &map,
+                Ipv4Addr::UNSPECIFIED,
+                p("192.168.0.0/16"),
+                Some(&best)
+            )
+            .is_some(),
+            "non-matching prefix falls through to the permit entry"
+        );
+    }
+
+    #[test]
+    fn set_med_rewrites_install_copy_only() {
+        let mut list = PolicyList::default();
+        list.entry(10).med = Some(NumericSet::Set(50));
+        let map = binding(Some(list));
+        let best = rib_with_med(Some(7));
+
+        let out = table_map_apply_v4(&map, Ipv4Addr::UNSPECIFIED, p("10.0.0.0/8"), Some(&best))
+            .expect("permit");
+        assert_eq!(
+            out.attr.med.as_ref().map(|m| m.med),
+            Some(50),
+            "install copy carries the rewritten MED"
+        );
+        assert_eq!(
+            best.attr.med.as_ref().map(|m| m.med),
+            Some(7),
+            "Loc-RIB original is untouched"
         );
     }
 }

--- a/zebra-rs/src/config/manager.rs
+++ b/zebra-rs/src/config/manager.rs
@@ -1429,6 +1429,42 @@ mod yang_load_tests {
         );
     }
 
+    /// `table-map <name>` (zebra-bgp-table-map.yang) sits bare,
+    /// FRR-style, directly under the global afi-safi list entry —
+    /// no wrapping container. Pin the spelling so an augment-path
+    /// slip is caught here, not at daemon startup. (Only the `set`
+    /// spelling is pinnable: `delete` completion resolves against
+    /// the running config tree, not the schema, so it Nomatches in
+    /// this harness — same for every delete-subtree augment.)
+    #[test]
+    fn bgp_table_map_parses() {
+        use crate::config::ExecCode;
+        use crate::config::parse::{State, parse};
+        use libyang::to_entry;
+
+        let mut yang = YangStore::new();
+        yang.add_path(concat!(env!("CARGO_MANIFEST_DIR"), "/yang"));
+        yang.read_with_resolve("configure")
+            .expect("configure mode loads");
+        yang.identity_resolve();
+        let module = yang
+            .find_module("configure")
+            .expect("configure module present");
+        let entry = to_entry(&yang, module);
+
+        let (code, _comps, _state) = parse(
+            "set router bgp afi-safi ipv4 table-map RIB-FILTER",
+            entry,
+            None,
+            State::new(),
+        );
+        assert_eq!(
+            code,
+            ExecCode::Success,
+            "table-map must parse as a settable path"
+        );
+    }
+
     /// The `neighbor-group` list inherits the per-neighbor knob set
     /// (zebra-bgp-neighbor-group.yang reuses the feature modules'
     /// groupings via cross-module `uses`, plus inline mirrors for

--- a/zebra-rs/src/policy/inst.rs
+++ b/zebra-rs/src/policy/inst.rs
@@ -21,6 +21,14 @@ pub enum PolicyType {
     PrefixSetOut,
     PolicyListIn,
     PolicyListOut,
+    /// A BGP per-AFI `table-map` binding (zebra-bgp-table-map.yang).
+    /// Rides the same policy-list watch registry as
+    /// `PolicyListIn`/`Out`, but `ident` encodes the AFI/SAFI rather
+    /// than a peer index, and `Register` always answers — even with
+    /// `policy_list: None` — because an unresolved table-map is
+    /// deny-all (FRR parity) and the subscriber needs the definitive
+    /// answer to resync its FIB installs exactly once.
+    TableMap,
     /// Subscription to a named `/key-chains/key-chain <name>`. The
     /// inner `KeyChainScope` lets the subscribed protocol
     /// demultiplex updates back to the right per-link / per-neighbor
@@ -311,15 +319,21 @@ impl Policy {
                         };
                         self.watch_prefix.entry(name).or_default().push(watch);
                     }
-                    PolicyType::PolicyListIn | PolicyType::PolicyListOut => {
-                        if let Some(policy_list) = self.policy_config.config.get(&name)
+                    PolicyType::PolicyListIn | PolicyType::PolicyListOut | PolicyType::TableMap => {
+                        // Peer policies only answer when the list
+                        // exists (absent = permit-all, nothing to
+                        // replay). A table-map answers even with
+                        // `None`: unresolved is deny-all, and the
+                        // subscriber resyncs on the reply.
+                        let policy_list = self.policy_config.config.get(&name).cloned();
+                        if (policy_list.is_some() || policy_type == PolicyType::TableMap)
                             && let Some(tx) = self.clients.get(&proto)
                         {
                             let msg = PolicyRx::PolicyList {
                                 name: name.clone(),
                                 ident,
                                 policy_type,
-                                policy_list: Some(policy_list.clone()),
+                                policy_list,
                             };
                             let _ = tx.send(msg);
                         }
@@ -359,7 +373,9 @@ impl Policy {
             } => {
                 let map = match policy_type {
                     PolicyType::PrefixSetIn | PolicyType::PrefixSetOut => &mut self.watch_prefix,
-                    PolicyType::PolicyListIn | PolicyType::PolicyListOut => &mut self.watch_policy,
+                    PolicyType::PolicyListIn | PolicyType::PolicyListOut | PolicyType::TableMap => {
+                        &mut self.watch_policy
+                    }
                     PolicyType::KeyChain(_) => &mut self.watch_keychain,
                 };
                 if let Some(watches) = map.get_mut(&name) {

--- a/zebra-rs/yang/config.yang
+++ b/zebra-rs/yang/config.yang
@@ -44,6 +44,10 @@ module config {
     prefix zbr;
   }
 
+  import zebra-bgp-table-map {
+    prefix zbtm;
+  }
+
   import zebra-bgp-transport {
     prefix zbt;
   }

--- a/zebra-rs/yang/zebra-bgp-table-map.yang
+++ b/zebra-rs/yang/zebra-bgp-table-map.yang
@@ -1,0 +1,84 @@
+module zebra-bgp-table-map {
+  yang-version "1";
+
+  namespace "urn:ietf:params:xml:ns:yang:zebra-bgp-table-map";
+  prefix "zbtm";
+
+  import ietf-bgp {
+    prefix bgp;
+  }
+
+  import config {
+    prefix config;
+  }
+
+  import configure {
+    prefix configure;
+  }
+
+  organization
+    "zebra-rs";
+
+  contact
+    "https://github.com/zebra-rs";
+
+  description
+    "BGP table-map: gate and rewrite BGP best paths at the point they
+     are installed from BGP into the RIB. A policy deny keeps the
+     route out of the RIB; permit-side set clauses rewrite only the
+     installed entry (MED -> RIB metric, next-hop). The BGP Loc-RIB
+     and advertisements to peers are unaffected either way.
+
+     Resulting config shape (FRR-parity bare form):
+
+       router bgp {
+         afi-safi ipv4 {
+           table-map RIB-FILTER;
+         }
+       }
+
+     Modeling notes:
+       - `table-map` is a plain string (not a leafref to /policy/name)
+         so it can be staged before the policy is committed — same
+         convention as the redistribute and `srv6 / locator`
+         references. Unlike those, a table-map whose policy does NOT
+         resolve denies every install for the family (FRR parity:
+         a missing referenced route-map filters everything).
+       - ipv4 unicast only today; the Rust callback rejects other
+         families at commit time. ipv6 follows once the policy-apply
+         path grows a v6 NLRI form.";
+
+  reference
+    "FRR bgpd `table-map WORD` under `address-family` —
+     bgp_route.c (config) / bgp_zebra.c bgp_table_map_apply()
+     (announce-time filter and metric/tag rewrite).";
+
+  grouping bgp-afi-safi-table-map {
+    description
+      "Attached to every global afi-safi list entry.";
+    leaf table-map {
+      type string;
+      description
+        "Name of a top-level `policy` applied to best paths at
+         BGP-to-RIB install time.";
+    }
+  }
+
+  /* =========================================================
+   * Augments into the zebra-rs configure tree
+   * ========================================================= */
+
+  augment "/configure:set/config:router/bgp:bgp/bgp:afi-safi" {
+    description
+      "Attach the table-map leaf to the global afi-safi list in the
+       candidate-set subtree.";
+    uses bgp-afi-safi-table-map;
+  }
+
+  augment "/configure:delete/config:router/bgp:bgp/bgp:afi-safi" {
+    description
+      "Same attachment for the delete subtree so
+       `delete router bgp afi-safi ipv4 table-map` is path-valid.";
+    uses bgp-afi-safi-table-map;
+  }
+}


### PR DESCRIPTION
## Summary

FRR's `table-map` for zebra-rs: `set router bgp afi-safi ipv4 table-map <policy>` applies a policy to BGP best paths at the single point they become FIB installs (`fib_install_v4`), without touching the Loc-RIB or what peers are advertised.

- **Deny** keeps the route out of the kernel RIB.
- **`set med`** lands in the kernel route metric; **`set next-hop`** rewrites the installed next-hop. Both act on a transient copy of the winner.
- **Unresolved policy name = deny-all** (FRR parity — a missing referenced route-map filters everything), unlike peer `policy in/out` which passes through.

## Design

- **YANG**: new `zebra-bgp-table-map.yang`, bare `leaf table-map { type string; }` augmented onto the global afi-safi list (FRR-style CLI, no wrapping container). v4 unicast only; the callback rejects other families at commit — v6 follows once policy apply grows a v6 NLRI form.
- **Storage**: `LocalRib.table_map` (the `sr_policy_local` placement trick) so config callbacks (`&mut Bgp`) and `fib_install_v4` (`BgpTop`) both reach it with zero `BgpTop` churn; per-VRF tasks own a separate empty map and stay inert.
- **Resolution**: new `PolicyType::TableMap` on the existing policy-list watch registry, `ident` encodes the AFI/SAFI. `Register` always answers (with `None` when unresolved) so the FIB flips exactly once, on the definitive answer — no transient deny-all flash when binding to an existing policy.
- **Refresh**: bind/unbind/content-edit (including the prefix-set→policy cascade) trigger `table_map_resync` — an install-only sweep over the Selected map; nothing is re-advertised since best-path and egress attributes are unaffected.

## Testing

- Unit: `table_map_apply_v4` semantics (pass-through / unresolved deny-all / deny filter / MED rewrite on the copy only), ident codec roundtrip, AFI gate, CLI parse pinning.
- `cargo test --workspace --exclude bdd` green; fmt + workspace clippy clean.
- BDD `@bgp_table_map`: install-time filter + MED-in-kernel-metric, live policy edit resync without session reset, rebind-to-nonexistent-policy deny-all, delete restores unfiltered installs, teardown. *(Local run pending — another worktree's BDD session currently owns the shared `/usr/bin/zebra-rs`; will run once the box frees up and report here.)*

🤖 Generated with [Claude Code](https://claude.com/claude-code)