### PR TITLE
bfd: offload expiration detection to XDP/eBPF (detect-offload)

### DIFF
--- a/book/src/ch-02-08-bgp-bfd.md
+++ b/book/src/ch-02-08-bgp-bfd.md
@@ -40,6 +40,10 @@ overridden per neighbour (see [Instance-level defaults](#instance-level-defaults
 Control-packet intervals use the BFD defaults (300 ms / ×3 ⇒ ~900 ms
 detection) and are not currently tunable — see
 [Tuning intervals](ch-10-00-bfd.md#tuning-intervals) in the overview.
+In-kernel expiration detection
+([`detect-offload`](ch-10-00-bfd.md#offloading-expiration-detection-detect-offload))
+is not yet configurable on BGP neighbours — the OSPF knob landed first;
+the BGP leaf is a planned follow-up.
 
 ## Single-hop vs multi-hop — inferred by default
 
@@ -54,8 +58,9 @@ keys multi-hop off the `ebgp-multihop` setting; the two agree on the
 common directly-connected eBGP and iBGP cases.) On a point-to-point
 link the distinction is moot — the session is single-hop either way.
 
-zebra-rs does not yet have an `ebgp-multihop` knob, so **eBGP over
-loopbacks** needs the hop mode forced explicitly:
+zebra-rs does have an `ebgp-multihop` transport knob (for the BGP TCP
+session's TTL), but the BFD hop-mode inference does not read it — so
+**eBGP over loopbacks** still needs the BFD hop mode forced explicitly:
 
 ```
 router bgp {
@@ -86,7 +91,8 @@ but Echo is **single-hop only** (RFC 5883 multihop has no Echo), so it applies
 an iBGP or multihop-eBGP neighbour the `echo-mode` leaf is accepted but inert.
 Within that constraint it works like the OSPF/IS-IS form — `transmit` originates,
 `receive` advertises + reflects, `both` does both, via the per-interface
-`xdp-bfd-echo` helper:
+`xdp-bfd-echo` helper. IPv4 and IPv6 neighbours are covered alike (the Echo
+session uses the same addresses as the control session):
 
 ```
 router bgp {

--- a/book/src/ch-07-03-isis-bfd.md
+++ b/book/src/ch-07-03-isis-bfd.md
@@ -39,9 +39,38 @@ interface, overridden per interface (see
 Control-packet intervals use the BFD defaults (300 ms / ×3 ⇒ ~900 ms
 detection) and are not currently tunable — see
 [Tuning intervals](ch-10-00-bfd.md#tuning-intervals) in the overview.
+In-kernel expiration detection
+([`detect-offload`](ch-10-00-bfd.md#offloading-expiration-detection-detect-offload))
+is not yet configurable on IS-IS attachments — the OSPF knob landed
+first; the IS-IS leaf is a planned follow-up.
 
 A session is subscribed when the adjacency comes **Up** and
-unsubscribed when it goes down.
+unsubscribed when it goes down. Both IPv4 and IPv6 adjacencies are
+covered: an IPv6(-only) adjacency runs its session over the two ends'
+link-local addresses.
+
+## Hold-down while BFD is Down
+
+Tearing the adjacency down on a BFD `Down` is only half of RFC 5882;
+the other half (§3.2) is **not letting it come straight back up**. IIHs
+keep arriving from a neighbour whose forwarding path is broken — without
+a gate, the adjacency would re-form on the next Hello, BGP/SPF would
+re-converge onto the dead path, BFD would kill it again, and the link
+would flap on the Hello period.
+
+zebra-rs therefore pins a neighbour whose BFD session is `Down` at the
+**Init** state: the IIH exchange proceeds, but the final transition to
+`Up` is held until the BFD session recovers. The pin is set when BFD
+reports the session `Down` (alongside the adjacency teardown), and
+lifted the moment BFD reports it `Up` again — the next received IIH
+then promotes the neighbour normally. It applies per neighbour and
+level, and only while `bfd enable` is in effect for the interface.
+
+> To make this work, the BFD session deliberately stays subscribed
+> across the teardown — it keeps probing while the adjacency is down,
+> precisely so it can observe the recovery and lift the pin. The
+> session is released only when the neighbour ages out for good or BFD
+> is unconfigured.
 
 ## Echo
 

--- a/book/src/ch-08-02-ospf-bfd.md
+++ b/book/src/ch-08-02-ospf-bfd.md
@@ -38,9 +38,10 @@ The same `bfd {}` leaves can also be set once at the **instance level**
 |---|---|---|---|
 | `enable` | boolean | `false` | Attach (or detach) BFD for neighbours on this interface. |
 | `min-neighbor-state` | `two-way` \| `full` | `two-way` | Neighbour state at which the session starts / stops. |
-| `echo-mode` | `transmit` \| `receive` \| `both` | _(off)_ | Enable the [BFD Echo function](ch-10-00-bfd.md#echo-function) on this interface's single-hop IPv4 sessions, choosing which half is active. |
+| `echo-mode` | `transmit` \| `receive` \| `both` | _(off)_ | Enable the [BFD Echo function](ch-10-00-bfd.md#echo-function) on this interface's sessions (IPv4 on OSPFv2, IPv6 on OSPFv3), choosing which half is active. |
 | `echo-transmit-interval` | uint (ms) | `50` | Rate we originate Echo at (`transmit` / `both`). |
 | `echo-receive-interval` | uint (ms) | `50` | Advertised Required Min Echo RX (`receive` / `both`). |
+| `detect-offload` | boolean | `false` | [Offload expiration detection](ch-10-00-bfd.md#offloading-expiration-detection-detect-offload) to the in-kernel (XDP) watchdog once the session is Up. |
 
 Sessions use the BFD defaults (300 ms / ×3 ⇒ ~900 ms detection); the
 timers are not currently tunable — see
@@ -78,9 +79,11 @@ router ospf {
 ## Echo
 
 `echo-mode` turns on the [BFD Echo function](ch-10-00-bfd.md#echo-function) for
-this interface's sessions — single-hop IPv4 only (OSPFv2; on OSPFv3 the leaf is
-accepted but inert, since Echo has no IPv6 form here). The two halves are
-independent (RFC 5880 §6.4), backed by the per-interface `xdp-bfd-echo` helper:
+this interface's sessions — single-hop only, both address families: IPv4 on
+OSPFv2, and on OSPFv3 the Echo session runs over the same IPv6 link-local pair
+as the control session. The two halves are independent (RFC 5880 §6.4), backed
+by the per-interface `xdp-bfd-echo` helper, whose XDP program handles IPv4 and
+IPv6 frames alike:
 
 - **`receive`** — advertise a non-zero Required Min Echo RX and loop the peer's
   Echo back (the *peer* gets fast detection).
@@ -109,6 +112,47 @@ OSPF Hello/Dead timers. The helper needs `cap_net_admin,cap_bpf,cap_net_raw`
 and a kernel with XDP + `bpf_timer` support; if it can't start, the session
 stays up on control packets and advertises echo-rx `0`. `show bfd peers` shows
 the negotiated `Echo receive interval` / `Echo transmission interval`.
+
+## Offloading expiration detection
+
+`detect-offload true` moves the RFC 5880 §6.8.4 detection timer — the
+clock that drives the session `Down` when the neighbour's control
+packets stop arriving — into the kernel, via the same per-interface
+`xdp-bfd-echo` helper that backs Echo. The XDP program re-arms a
+per-session `bpf_timer` on every arriving control packet and the expiry
+fires in softirq, so detection neither false-fires because the daemon
+was busy (packets queued but unprocessed) nor waits on its event loop.
+The daemon still processes every packet normally; only the liveness
+timing is offloaded. See
+[the overview](ch-10-00-bfd.md#offloading-expiration-detection-detect-offload)
+for the mechanism and guard-rails.
+
+```
+router ospf {
+  area 0 {
+    interface eth0 {
+      bfd {
+        enable true;
+        detect-offload true;   // expiration detection in kernel/XDP
+      }
+    }
+  }
+}
+```
+
+The watchdog arms when the session reaches `Up` (and the helper is
+confirmed running) and disarms when it leaves `Up`; the ordinary
+userspace timer keeps running as a stretched backstop and takes over
+again if the helper dies. Works for both OSPFv2 and OSPFv3 (the
+sessions are single-hop, which is the offload's scope). Unlike Echo,
+it sends nothing on the wire — it only times what already arrives.
+
+`show bfd peers` confirms where detection runs:
+
+```
+    Detection timeout: 900ms
+    Detection runs in: kernel/XDP (900ms)
+```
 
 ## Instance-level defaults
 
@@ -144,7 +188,9 @@ OSPFv3 BFD is configured identically under `router ospfv3`. The session
 runs over the interface's IPv6 **link-local** addresses (the same
 addresses OSPFv3 sources its control packets from) and is demultiplexed
 per interface, so overlapping `fe80::` addresses on different links do
-not collide.
+not collide. The full leaf set applies: `echo-mode` runs IPv6 Echo over
+the same link-local pair, and `detect-offload` arms the in-kernel
+watchdog for the IPv6 control packets just as it does for IPv4.
 
 ## Verifying
 

--- a/book/src/ch-10-00-bfd.md
+++ b/book/src/ch-10-00-bfd.md
@@ -186,7 +186,8 @@ Each command also accepts a trailing `json` for machine-readable output.
 
 The BFD task is quiet by default. A single runtime flag turns on its
 diagnostic traces — session FSM transitions, control-packet handling, and
-the Echo reflector (`xdp-bfd-echo`) lifecycle:
+the `xdp-bfd-echo` helper lifecycle (Echo and the in-kernel expiration
+watchdog it hosts):
 
 ```
 set bfd tracing true     # enable
@@ -213,21 +214,26 @@ the BFD task itself.
 ## Echo function
 
 The BFD **Echo function** (RFC 5880 §6.4 / RFC 5881 §6) is a forwarding-plane
-liveness test: a node sends a *self-addressed* UDP/3785 packet that the peer's
-forwarding plane loops straight back, and times the round trip. Because the
-loop never enters the peer's BFD control software, it detects a forwarding
-fault even while control packets still flow — and it lets a node slow its
-control-packet rate while keeping fast detection. Echo is **single-hop IPv4
-only** (RFC 5883 multi-hop has no Echo).
+liveness test: a node sends a UDP/3785 packet crafted so the peer loops it
+straight back without its BFD software ever processing it, and times the round
+trip. Because the loop never enters the peer's BFD control software, it
+detects a forwarding fault even while control packets still flow — and it lets
+a node slow its control-packet rate while keeping fast detection. Echo is
+**single-hop only** (RFC 5883 multi-hop has no Echo); **both IPv4 and IPv6**
+are supported.
 
 The two halves are independent and zebra-rs implements both, offloaded to a
 per-interface XDP/eBPF helper, **`xdp-bfd-echo`**:
 
 - **Responder** — when we advertise a non-zero `Required Min Echo RX Interval`,
-  the helper's XDP program loops a peer's Echo back in the data plane
-  (decrementing TTL so it returns at 254, the way a forwarding hop would), so
-  the *peer* gets fast detection. We only advertise non-zero once the helper is
-  confirmed running, so the promise to loop is honest.
+  the helper's XDP program loops a peer's Echo back in the data plane, so the
+  *peer* gets fast detection. We only advertise non-zero once the helper is
+  confirmed running, so the promise to loop is honest. The loop differs per
+  family to match what real peers send: IPv4 Echo is *self-addressed* and
+  looped as a forwarding hop (TTL decremented to 254), while IPv6 Echo (as FRR
+  sends it) is *peer-addressed*, so the reflector also swaps the IPv6
+  source/destination and decrements the Hop Limit — both interop-validated
+  against FRR `echo-mode`.
 - **Originator** — the helper sends our Echo from a raw `AF_PACKET` socket and
   the XDP program arms a per-session in-kernel `bpf_timer` on each return; if
   returns stop for `interval × detect-mult`, the session goes `Down` with
@@ -235,20 +241,88 @@ per-interface XDP/eBPF helper, **`xdp-bfd-echo`**:
   the session is `Up` and the peer advertised a non-zero echo-rx (§6.8.9).
 
 The helper is reference-counted **per interface**: one `xdp-bfd-echo` process is
-spawned for each interface that has at least one Echo-enabled session, shared by
-all sessions on that link, and stopped when the last one goes away. It needs
+spawned for each interface that has at least one Echo-enabled (or
+[`detect-offload`](#offloading-expiration-detection-detect-offload)-enabled)
+session, shared by all sessions on that link, and stopped when the last one
+goes away. It needs
 `cap_net_admin,cap_bpf` (load/attach XDP) and `cap_net_raw` (the originator's
 raw socket); the packaged install grants these. A node with no Echo configured
 runs no helper and advertises `Required Min Echo RX Interval = 0`.
 
-Echo is enabled per attachment — on OSPF and IS-IS interfaces, and on
+Echo is enabled per attachment — on OSPFv2/v3 and IS-IS interfaces, and on
 single-hop eBGP neighbours, where `echo-mode` selects the role
 (`transmit` / `receive` / `both`) and `echo-transmit-interval` /
 `echo-receive-interval` set the rates; see
 [OSPF BFD](ch-08-02-ospf-bfd.md#echo), [IS-IS BFD](ch-07-03-isis-bfd.md#echo),
-and [BGP BFD](ch-02-08-bgp-bfd.md#echo).
-`show bfd peers` reports the negotiated `Echo receive interval` /
-`Echo transmission interval`.
+and [BGP BFD](ch-02-08-bgp-bfd.md#echo). An IPv6-only session (an OSPFv3 or
+IS-IS adjacency over link-locals, a v6 eBGP neighbour) runs IPv6 Echo the same
+way. Echo configuration changes apply to **live** sessions on commit — no
+session bounce. `show bfd peers` reports the negotiated
+`Echo receive interval` / `Echo transmission interval`.
+
+## Offloading expiration detection (`detect-offload`)
+
+Detection of a *silent* failure — the peer's control packets simply stop
+arriving — normally rides on a userspace timer (RFC 5880 §6.8.4): every
+valid packet resets it, and its expiry drives the session `Down` with
+`Control Detection Time Expired`. That timer races the daemon's event
+loop, which has two failure modes under load:
+
+- **false Down** — packets are *arriving* but sit unprocessed in the
+  socket queue while the daemon is busy (a BGP churn, a large SPF, a
+  config commit), so the timer fires anyway;
+- **late Down** — the peer really is gone, but the expiry event waits
+  behind the same backlog.
+
+`detect-offload` moves that timing into the kernel, using the same
+per-interface `xdp-bfd-echo` helper as the [Echo
+function](#echo-function). Once the session is `Up`, the helper's XDP
+program *observes* every BFD control packet (UDP 3784 at TTL 255) on the
+interface: it matches the packet's `Your Discriminator` against the
+session, re-arms a per-session in-kernel `bpf_timer`, and **passes the
+packet up unchanged** — the daemon still runs the full state machine,
+Poll/Final handling, and timer negotiation on every packet; only the
+liveness clock lives in the kernel. If control packets stop for the
+negotiated detection time, the timer fires in softirq and the session
+goes `Down` exactly as a userspace expiry would.
+
+Because the re-arm happens at packet *arrival* (before any socket
+queueing) and the expiry fires in softirq (no event-loop latency),
+detection neither false-fires nor waits on a busy daemon — which is
+what makes aggressive detection times honest.
+
+Notes and guard-rails:
+
+- **Up sessions only.** Before the session is established the peer may
+  send `Your Discriminator = 0`, which cannot be matched in the kernel;
+  zebra-rs arms the watchdog on the `Up` transition and disarms it when
+  the session leaves `Up`. Renegotiated timers retune the armed value
+  automatically.
+- **Single-hop only.** The helper attaches per interface; multi-hop
+  ingress is not bound to one (and its TTL floor is below the GTSM 255
+  the observer requires). IPv4 and IPv6 are both supported.
+- **The userspace timer stays as a backstop.** While the watchdog is
+  armed, the normal detection timer keeps running, stretched to 4× the
+  detection time; if the helper process ever dies, zebra-rs reverts the
+  session to ordinary userspace detection immediately.
+- **Honesty gate.** The watchdog is only armed once the helper is
+  confirmed running — if it cannot start (missing binary, capabilities,
+  kernel without XDP/`bpf_timer`), detection simply stays in userspace.
+  A watchdog-only helper needs `cap_net_admin,cap_bpf` (no `cap_net_raw`
+  — there is no transmit half; the daemon keeps sending its own control
+  packets).
+
+It is enabled per OSPF interface (or instance-wide) — see
+[OSPF BFD](ch-08-02-ospf-bfd.md#offloading-expiration-detection);
+IS-IS and BGP attachment is a planned follow-up. `show bfd peers`
+reports where detection currently runs:
+
+```
+    Detection timeout: 900ms
+    Detection runs in: kernel/XDP (900ms)
+```
+
+(`userspace` when the watchdog is not armed.)
 
 ## What happens on failure
 
@@ -267,14 +341,23 @@ native timers would allow.
   defaults; RFC 5880 §6.8.3 slow-transmit-while-not-Up with §6.8.7 Poll
   Sequences (both initiating and answering); BGP `update-source`
   inherited as the session's local address; the **Echo function**
-  (RFC 5880 §6.4, single-hop IPv4) — both reflecting a peer's Echo and
-  originating our own, offloaded to the `xdp-bfd-echo` XDP/eBPF helper
-  (see [Echo function](#echo-function) below), with per-role
-  (`transmit` / `receive` / `both`) config and an instance-level
-  `router <proto> { bfd {} }` default inherited and overridden per
-  interface / neighbour. Echo is configurable on OSPF, IS-IS, and
-  single-hop eBGP (BGP echo is inert on multihop sessions — RFC 5883 has
-  no Echo).
+  (RFC 5880 §6.4, single-hop, IPv4 **and** IPv6) — both reflecting a
+  peer's Echo and originating our own, offloaded to the `xdp-bfd-echo`
+  XDP/eBPF helper (see [Echo function](#echo-function) below), with
+  per-role (`transmit` / `receive` / `both`) config applied live on
+  commit and an instance-level `router <proto> { bfd {} }` default
+  inherited and overridden per interface / neighbour. Echo is
+  configurable on OSPFv2/v3, IS-IS, and single-hop eBGP (BGP echo is
+  inert on multihop sessions — RFC 5883 has no Echo); the IS-IS
+  attachment additionally pins a BFD-Down neighbour below `Up`
+  (RFC 5882 §3.2 hold-down — see
+  [IS-IS BFD](ch-07-03-isis-bfd.md#hold-down-while-bfd-is-down)).
+  **In-kernel expiration detection** (`detect-offload`,
+  RFC 5880 §6.8.4 evaluated in an XDP `bpf_timer` — see
+  [Offloading expiration detection](#offloading-expiration-detection-detect-offload)),
+  configurable on OSPFv2/v3 interfaces.
 - **Not yet:** configurable control-packet timers (the intervals are
   fixed at the defaults); BFD for **static routes**; per-VRF OSPF BFD;
-  a BFD `profile` mechanism.
+  a BFD `profile` mechanism; `detect-offload` on IS-IS and BGP
+  attachments (the subsystem supports it; the per-protocol knob is the
+  follow-up).

--- a/docs/design/bfd-sbfd-stamp-xdp-offload-notes.md
+++ b/docs/design/bfd-sbfd-stamp-xdp-offload-notes.md
@@ -125,6 +125,47 @@ BFD Echo は本質的に「ローカルが送出 → リモートのフォワー
 
 ---
 
+## 2b. 標準 BFD 制御パケットの expiration 監視オフロード（2026-06-12 実装）
+
+§1 末尾の「XDP の現実的な使いどころ = RX 側の detect-timer リセット・liveness
+喪失の高速検知」をそのまま実装したもの。Echo originator の `bpf_timer` 検知
+（§2）と同じ機構を、**UDP/3784 の標準 BFD 制御パケット**に適用する。
+
+- **XDP 側は純粋な観測者**: 制御パケットを TTL/HopLimit==255（GTSM, RFC 5881
+  §5）・version==1 だけ確認し、Your Discriminator で `CONTROL_TIMERS`
+  (BTF map, 値は Echo と共通の `DetectState`) を引いて `bpf_timer` を再アーム、
+  フレームは**必ず `XDP_PASS`**。FSM・Poll/Final・パラメータ再交渉はすべて
+  従来どおりデーモンが処理する（liveness タイミングだけがカーネルに移る）。
+  Echo reflector と違いパケット書き換えが無いので、検証器対策も不要だった。
+- **確立後のみアーム**: 確立前はリモートが `Your Discriminator = 0` を送るため
+  マップのキーにできない。zebra-rs は Up 遷移で `detect-add <discr>
+  <detect-us>`、Up を離れたら `detect-del` をヘルパー stdin に送る
+  （`Bfd::detect_offload_reconcile`、Echo の reconcile と同形）。再交渉で
+  detection time が変わったら `detect-add` を再送（マップ要素の置換 =
+  旧タイマーはカーネルが cancel）。
+- **userspace タイマーはバックストップに格下げ**: ウォッチドッグがアーム中は
+  4 倍（`DETECT_BACKSTOP_FACTOR`）に伸ばして保持。ヘルパー死亡
+  （`Message::HelperGone`）で即 1 倍に戻す。偽 Down（デーモンが
+  スケジュールアウトしてソケットキューに溜まったのに userspace タイマーが
+  先に発火）と検知遅延の両方を排除でき、attack 的な短い検知時間
+  （sub-10ms 級）を正直に張れるようになる。
+- **送信側はオフロードしない**: 自分の制御パケット送信はデーモンのまま。
+  デーモンが完全に停止すれば相手側の検知で落ちる（こちらの RX 検知だけが
+  カーネル化される）。
+- **スコープ**: single-hop のみ（ヘルパーは per-ifindex アタッチ。multihop は
+  入口 IF が固定でなく GTSM 床も 255 未満）。認証付きセッションは将来 BFD
+  auth が入った場合オフロード禁止にすること（XDP では MD5/SHA1 を検証
+  できない）。
+- **設定**: OSPF の `bfd { detect-offload true; }`（per-interface /
+  instance-level、echo-mode と同じ継承）。IS-IS / BGP への展開は echo-mode
+  と同様にフォローアップ。
+- **検証**: `scripts/veth-detect-test.sh` — 600ms 検知で 150ms 間隔の制御
+  パケットを 1.2 秒流し（早発 = bootstrap fallback 発火で FAIL、つまり XDP
+  再アームの実証）、停止後 ~600ms で `detect-down` が来るのを確認。
+  2026-06-12 ラボ PASS。
+
+---
+
 ## 3. S-BFD (Seamless BFD) 概要
 
 - **RFC 7880 (2016)。** classic BFD のハンドシェイク（Down→Init→Up の三方向）を排除した派生。

--- a/offload/xdp-bfd-echo/README.md
+++ b/offload/xdp-bfd-echo/README.md
@@ -1,12 +1,15 @@
-# xdp-bfd-echo — XDP BFD Echo datapath (reflector + originator)
+# xdp-bfd-echo — XDP BFD datapath (Echo reflector + originator, expiration watchdog)
 
 An XDP/eBPF program (with an [aya](https://aya-rs.dev/) userspace loader) that
 reflects **BFD Echo** frames (UDP **3785**, RFC 5880 §6.4 / RFC 5881 §4) in the
-data plane. **zebra-rs spawns and supervises it automatically** — one instance
-per interface — when the BFD Echo function is enabled on a single-hop IPv4
-session (e.g. `router ospf area 0 interface X bfd { echo-mode receive; }`), so a
-peer (FRR `echo-mode`, IOS, …) can run BFD Echo against zebra-rs. It can also be
-run standalone for testing (see [Run](#run)).
+data plane, and hosts the **control-packet expiration watchdog** — standard
+async-mode detection (RFC 5880 §6.8.4) offloaded to a kernel `bpf_timer` (see
+[Expiration watchdog](#expiration-watchdog-control-packets)). **zebra-rs spawns
+and supervises it automatically** — one instance per interface — when the BFD
+Echo function or `detect-offload` is enabled on a single-hop session (e.g.
+`router ospf area 0 interface X bfd { echo-mode receive; }`), so a peer (FRR
+`echo-mode`, IOS, …) can run BFD Echo against zebra-rs. It can also be run
+standalone for testing (see [Run](#run)).
 
 A matching IPv4 UDP/3785 frame is reflected back out the same interface
 (`XDP_TX`), acting as a **forwarding-plane hop**: swap the Ethernet
@@ -128,6 +131,14 @@ The namespace is required: if both veth ends share a namespace the kernel
 delivers `10.123.0.2 -> 10.123.0.1` locally via loopback and the frame never
 crosses the wire, so the XDP hook never fires.
 
+The expiration watchdog has its own end-to-end test — it arms a 600 ms watch,
+streams valid BFD control packets (each must re-arm the kernel timer; a
+premature `detect-down` fails the run), stops, and expects `detect-down`:
+
+```sh
+sudo bash scripts/veth-detect-test.sh
+```
+
 **Pass criteria:** the sent `udp/3785` frame reappears *inbound* on the sender's
 veth with the Ethernet source/destination swapped (`tcpdump -e` shows the swap;
 it even decodes as `BFD, Echo`), and the reflector logs `BFD Echo udp/3785
@@ -223,6 +234,32 @@ Beyond reflecting, the helper also *originates* Echo when zebra-rs asks it to
   softirq and sets a `down` flag; the helper polls it and emits `echo-down`. A
   userspace timeout covers the bootstrap window before the first return arms the
   timer.
+
+## Expiration watchdog (control packets)
+
+The same mechanism times **standard BFD control packets** (UDP/3784) once a
+session is Up, driven by two more line-protocol verbs:
+
+- `detect-add <discr> <detect-us>` / `detect-del <discr>` from zebra-rs
+  (re-issuing `detect-add` updates the detection time); `detect-down <discr>`
+  back when the watchdog fires.
+- The XDP program **observes** each control packet — TTL/Hop-Limit must be 255
+  (GTSM, RFC 5881 §5), version 1, Your Discriminator non-zero and present in
+  the `CONTROL_TIMERS` map — re-arms that session's `bpf_timer`, and always
+  `XDP_PASS`es the frame: the daemon still runs the full FSM on every packet,
+  only the liveness timing lives in the kernel. If control packets stop for
+  the programmed detection time (RFC 5880 §6.8.4), the timer fires in softirq
+  and the helper reports `detect-down`.
+- Why: detection neither false-fires because the daemon was scheduled out
+  behind a full socket queue, nor waits on its event loop — which is what
+  makes aggressive (sub-10 ms) detection times honest. zebra-rs keeps its
+  userspace detection timer armed as a stretched backstop and reverts to it if
+  the helper dies. Armed only for Up sessions: before establishment the peer
+  may send `Your Discriminator = 0`, which the map can't key. Single-hop only
+  (the program attaches per interface; multihop ingress isn't bound to one).
+- Enable per OSPF interface (or instance-wide) with
+  `bfd { detect-offload true; }`; `show bfd peers` then reports
+  `Detection runs in: kernel/XDP (600ms)`.
 
 ## Limitations / follow-ups
 

--- a/offload/xdp-bfd-echo/ebpf/src/main.rs
+++ b/offload/xdp-bfd-echo/ebpf/src/main.rs
@@ -15,8 +15,8 @@
 //! (`bfd_recv_ipv4_fp`) drops any looped frame whose TTL isn't 254. Only the
 //! IPv4 header checksum is recomputed (incrementally, RFC 1141); the UDP checksum
 //! is unaffected since TTL isn't in its pseudo-header. Everything that is not an
-//! IPv4 UDP/3785 frame is `XDP_PASS`ed, so normal traffic — including BFD
-//! *control* on UDP/3784 — is untouched.
+//! IPv4 UDP/3785 frame is `XDP_PASS`ed; BFD *control* on UDP/3784 is also
+//! passed, after optionally feeding the expiration watchdog (below).
 //!
 //! When zebra-rs also *originates* Echo on this interface, the loader fills the
 //! `OUR_LOCAL_IPS` map. An inbound Echo whose source is one of our own addresses
@@ -45,6 +45,18 @@
 //! return rather than re-reflecting it (FRR reflects only Hop Limit 255) — that
 //! decrement is what breaks the mutual-reflection loop. For our own
 //! self-addressed Echo the address swap is a harmless no-op.
+//!
+//! Beyond Echo, the program also hosts the **control-packet expiration
+//! watchdog** — standard async-mode detection (RFC 5880 §6.8.4) offloaded to
+//! the kernel once a session is Up. An inbound BFD *control* packet (UDP/3784
+//! at TTL/Hop-Limit 255, the RFC 5881 §5 GTSM requirement) is parsed just
+//! enough to read its Your Discriminator; the matching `CONTROL_TIMERS`
+//! entry's `bpf_timer` is re-armed and the frame is **passed** to the stack
+//! untouched — the daemon still runs the full FSM on every packet, only the
+//! liveness timing lives here. If control packets stop for the programmed
+//! detection time, the timer fires in softirq and the helper reports
+//! `detect-down`, so detection neither false-fires because the daemon was
+//! scheduled out behind a full socket queue nor waits on its event loop.
 
 use aya_ebpf::{
     bindings::{bpf_timer, xdp_action},
@@ -70,36 +82,47 @@ static OUR_LOCAL_IPS: HashMap<u32, u8> = HashMap::with_max_entries(256, 0);
 #[map]
 static OUR_LOCAL_IPS_V6: HashMap<[u8; 16], u8> = HashMap::with_max_entries(256, 0);
 
-/// Per-session Echo detection state, keyed by our local BFD discriminator.
+/// Per-session in-kernel detection state, keyed by our local BFD
+/// discriminator. One value layout serves both detectors: Echo-return timing
+/// ([`ECHO_TIMERS`]) and control-packet expiration ([`CONTROL_TIMERS`]).
 ///
 /// Lives in a **BTF** map (not the legacy `#[map]` kind) because the kernel
 /// locates the embedded `struct bpf_timer` by its BTF, so the value type's
 /// layout must be described in BTF. The timer is field 0 (offset 0) — the
-/// offset the kernel records and the address [`record_return`] passes to
+/// offset the kernel records and the address [`kick_timer`] passes to
 /// `bpf_timer_init`. `align_of` is 8 (the `bpf_timer`'s `[u64; 2]`), within the
 /// BTF hash map's 8-byte value-alignment ceiling.
 #[repr(C)]
-pub struct EchoState {
+pub struct DetectState {
     /// Kernel-managed one-shot timer. Initialized lazily in-kernel on the first
-    /// observed return (userspace can't `bpf_timer_init`); userspace seeds the
+    /// observed packet (userspace can't `bpf_timer_init`); userspace seeds the
     /// rest of the value zeroed and the kernel zeroes this field on update.
     timer: bpf_timer,
-    /// Detection time in nanoseconds (`echo-interval × detect-mult`). Set by
-    /// userspace at `echo-add`; the re-arm delay on every return.
+    /// Detection time in nanoseconds. Set by userspace at `echo-add` /
+    /// `detect-add`; the re-arm delay on every observed packet.
     detect_ns: u64,
     /// 0 until the timer has been `bpf_timer_init`'d + callback-set in-kernel;
     /// then 1. Read by userspace to know the kernel detector has taken over.
     armed: u8,
-    /// Set to 1 by the timer callback when returns stopped (detection fired).
-    /// Polled and cleared by userspace, which then reports `echo-down`.
+    /// Set to 1 by the timer callback when the tracked packets stopped
+    /// (detection fired). Polled and cleared by userspace, which then reports
+    /// `echo-down` / `detect-down`.
     down: u8,
     _pad: [u8; 6],
 }
 
-/// Detection state per originating session. 256 single-hop echo sessions on one
-/// interface is far beyond any real deployment.
+/// Echo-return detection state per originating session. 256 single-hop echo
+/// sessions on one interface is far beyond any real deployment.
 #[btf_map]
-static ECHO_TIMERS: BtfHashMap<u32, EchoState, 256> = BtfHashMap::new();
+static ECHO_TIMERS: BtfHashMap<u32, DetectState, 256> = BtfHashMap::new();
+
+/// Control-packet expiration state per Up session — the in-kernel detection
+/// timer for *standard* async BFD (RFC 5880 §6.8.4). The daemon seeds an
+/// entry at `detect-add` once the session is Up (before establishment the
+/// peer may send `Your Discriminator = 0`, which can't be keyed here) and
+/// removes it on `detect-del`.
+#[btf_map]
+static CONTROL_TIMERS: BtfHashMap<u32, DetectState, 256> = BtfHashMap::new();
 
 /// Ethernet II header layout.
 const ETH_HLEN: usize = 14;
@@ -125,6 +148,21 @@ const UDP_DST_OFF: usize = UDP_OFF + 2; // u16 (big-endian) destination port
 
 /// BFD Echo destination port (RFC 5881 §4). BFD control is 3784; multihop 4784.
 const BFD_ECHO_PORT: u16 = 3785;
+/// BFD single-hop control destination port (RFC 5881 §4). Control packets are
+/// only *observed* (expiration watchdog) and always passed to the stack.
+const BFD_CTRL_PORT: u16 = 3784;
+
+/// BFD control header (RFC 5880 §4.1), right after the 8-byte UDP header.
+/// Byte 0 is version(3 bits)|diag(5 bits); Your Discriminator — the receiver's
+/// session key, i.e. ours — is bytes 8..12, big-endian.
+const CTRL_OFF: usize = UDP_OFF + 8; // after an option-less IPv4 header
+const CTRL_VERS_DIAG: usize = 0;
+const CTRL_YOUR_DISC: usize = 8;
+const BFD_VERSION: u8 = 1;
+/// TTL / Hop Limit required on a received single-hop control packet
+/// (GTSM, RFC 5881 §5). The daemon enforces the same floor, so a packet that
+/// fails it must not feed the watchdog either.
+const CTRL_TTL: u8 = 255;
 
 /// Our Echo payload (a "local matter", RFC 5880 §5) sits right after the 8-byte
 /// UDP header: `{ magic:u32, discr:u32, seq:u32, tx_ts:u64 }`, big-endian. The
@@ -154,6 +192,8 @@ const UDP6_DST_OFF: usize = UDP6_OFF + 2; // u16 (big-endian) destination port
 const PAYLOAD6_OFF: usize = UDP6_OFF + 8;
 const PL6_MAGIC_OFF: usize = PAYLOAD6_OFF; // u32 (big-endian) "zbfd"
 const PL6_DISCR_OFF: usize = PAYLOAD6_OFF + 4; // u32 (big-endian) our discriminator
+/// BFD control header after the fixed IPv6 header (cf. [`CTRL_OFF`]).
+const CTRL6_OFF: usize = UDP6_OFF + 8;
 
 /// Read a `u8` at `off` bytes into the frame, after a verifier-friendly bounds
 /// check against `data_end`.
@@ -296,18 +336,48 @@ unsafe fn decrement_hop_limit(ctx: &XdpContext) -> Result<(), ()> {
     Ok(())
 }
 
-/// `bpf_timer` callback: fires `detect_ns` after the last return, i.e. when our
-/// originated Echo stopped coming back. Runs in softirq with the timed-out map
-/// element as `value`. It is one-shot (not re-armed here), so it sets the `down`
-/// flag for userspace and returns; the next return (if any) re-arms via
-/// [`record_return`]. Signature is the kernel timer-callback ABI
-/// `(map, key, value)`.
-unsafe extern "C" fn echo_timeout(_map: *mut c_void, _key: *mut c_void, value: *mut c_void) -> i32 {
+/// `bpf_timer` callback: fires `detect_ns` after the last observed packet —
+/// our originated Echo stopped coming back ([`ECHO_TIMERS`]) or the peer's
+/// control packets stopped arriving ([`CONTROL_TIMERS`]). Runs in softirq with
+/// the timed-out map element as `value`. It is one-shot (not re-armed here), so
+/// it sets the `down` flag for userspace and returns; the next observed packet
+/// (if any) re-arms via [`kick_timer`]. Signature is the kernel timer-callback
+/// ABI `(map, key, value)`.
+unsafe extern "C" fn detect_timeout(
+    _map: *mut c_void,
+    _key: *mut c_void,
+    value: *mut c_void,
+) -> i32 {
     if !value.is_null() {
-        let st = value as *mut EchoState;
+        let st = value as *mut DetectState;
         unsafe { core::ptr::write_volatile(core::ptr::addr_of_mut!((*st).down), 1) };
     }
     0
+}
+
+/// A tracked packet for `st` just arrived: arm (first time) or re-arm the
+/// session's detection timer. `map` must be the pointer of the map `st` lives
+/// in — `bpf_timer_init` binds the timer to its owning map.
+#[inline(always)]
+unsafe fn kick_timer(st: *mut DetectState, map: *mut c_void) {
+    unsafe {
+        let timer = core::ptr::addr_of_mut!((*st).timer);
+        if core::ptr::read_volatile(core::ptr::addr_of!((*st).armed)) == 0 {
+            // First sighting: init the timer against its own map and bind the
+            // callback. Userspace can't do this (no `bpf_timer_init` from the
+            // syscall side), so it happens here, once.
+            if bpf_timer_init(timer, map, 0) == 0 {
+                let cb: unsafe extern "C" fn(*mut c_void, *mut c_void, *mut c_void) -> i32 =
+                    detect_timeout;
+                bpf_timer_set_callback(timer, cb as *mut c_void);
+                core::ptr::write_volatile(core::ptr::addr_of_mut!((*st).armed), 1);
+            }
+        }
+        // Healthy packet: clear any stale down flag and (re)start the one-shot.
+        core::ptr::write_volatile(core::ptr::addr_of_mut!((*st).down), 0);
+        let detect = core::ptr::read_volatile(core::ptr::addr_of!((*st).detect_ns));
+        bpf_timer_start(timer, detect, 0);
+    }
 }
 
 /// Our own Echo, looped back by the peer, just arrived. Verify the payload magic,
@@ -326,27 +396,44 @@ unsafe fn record_return(ctx: &XdpContext, magic_off: usize, discr_off: usize) ->
     let Some(st) = ECHO_TIMERS.get_ptr_mut(&discr) else {
         return Ok(());
     };
-    unsafe {
-        let timer = core::ptr::addr_of_mut!((*st).timer);
-        if core::ptr::read_volatile(core::ptr::addr_of!((*st).armed)) == 0 {
-            // First sighting: init the timer against its own map and bind the
-            // callback. Userspace can't do this (no `bpf_timer_init` from the
-            // syscall side), so it happens here, once.
-            let map = core::ptr::from_ref(&ECHO_TIMERS)
-                .cast_mut()
-                .cast::<c_void>();
-            if bpf_timer_init(timer, map, 0) == 0 {
-                let cb: unsafe extern "C" fn(*mut c_void, *mut c_void, *mut c_void) -> i32 =
-                    echo_timeout;
-                bpf_timer_set_callback(timer, cb as *mut c_void);
-                core::ptr::write_volatile(core::ptr::addr_of_mut!((*st).armed), 1);
-            }
-        }
-        // Healthy return: clear any stale down flag and (re)start the one-shot.
-        core::ptr::write_volatile(core::ptr::addr_of_mut!((*st).down), 0);
-        let detect = core::ptr::read_volatile(core::ptr::addr_of!((*st).detect_ns));
-        bpf_timer_start(timer, detect, 0);
+    let map = core::ptr::from_ref(&ECHO_TIMERS)
+        .cast_mut()
+        .cast::<c_void>();
+    unsafe { kick_timer(st, map) };
+    Ok(())
+}
+
+/// A BFD *control* packet (UDP/3784) is passing through: re-arm the session's
+/// expiration watchdog. Purely an observation — the caller always `XDP_PASS`es
+/// the frame so the daemon runs the full FSM on it; only the liveness timing is
+/// taken over (RFC 5880 §6.8.4 evaluated in-kernel). The packet is matched by
+/// its Your Discriminator against entries the daemon seeded at `detect-add`
+/// (Up sessions only — before establishment the field may be 0). The TTL /
+/// Hop-Limit must be 255 (GTSM, RFC 5881 §5): the daemon drops anything else,
+/// so it must not feed the watchdog. Validation is deliberately loose beyond
+/// that (version + discriminator match); the discriminator is random per
+/// RFC 5880 §6.8.1, and the daemon remains the arbiter of packet validity.
+#[inline(always)]
+unsafe fn observe_control(ctx: &XdpContext, ttl_off: usize, ctrl_off: usize) -> Result<(), ()> {
+    if unsafe { load_u8(ctx, ttl_off)? } != CTRL_TTL {
+        return Ok(());
     }
+    if unsafe { load_u8(ctx, ctrl_off + CTRL_VERS_DIAG)? } >> 5 != BFD_VERSION {
+        return Ok(());
+    }
+    let discr = unsafe { load_u32_be(ctx, ctrl_off + CTRL_YOUR_DISC)? };
+    if discr == 0 {
+        // Bootstrap packet (the peer doesn't know our discriminator yet) —
+        // only the daemon can demux it; nothing to time here.
+        return Ok(());
+    }
+    let Some(st) = CONTROL_TIMERS.get_ptr_mut(&discr) else {
+        return Ok(());
+    };
+    let map = core::ptr::from_ref(&CONTROL_TIMERS)
+        .cast_mut()
+        .cast::<c_void>();
+    unsafe { kick_timer(st, map) };
     Ok(())
 }
 
@@ -424,8 +511,9 @@ fn try_reflect(ctx: &XdpContext) -> Result<u32, ()> {
     match unsafe { load_u16_be(ctx, ETH_TYPE_OFF)? } {
         ETHERTYPE_IPV4 => try_reflect_v4(ctx),
         ETHERTYPE_IPV6 => try_reflect_v6(ctx),
-        // Anything that isn't IP — and any non-Echo UDP, including BFD *control*
-        // on 3784 — is left for the stack.
+        // Anything that isn't IP is left for the stack. BFD *control* on 3784
+        // is observed (expiration watchdog) inside the per-family handlers and
+        // then passed too.
         _ => Ok(xdp_action::XDP_PASS),
     }
 }
@@ -439,8 +527,16 @@ fn try_reflect_v4(ctx: &XdpContext) -> Result<u32, ()> {
     if unsafe { load_u8(ctx, IP_PROTO_OFF)? } != IPPROTO_UDP {
         return Ok(xdp_action::XDP_PASS);
     }
-    if unsafe { load_u16_be(ctx, UDP_DST_OFF)? } != BFD_ECHO_PORT {
-        return Ok(xdp_action::XDP_PASS);
+    match unsafe { load_u16_be(ctx, UDP_DST_OFF)? } {
+        BFD_ECHO_PORT => {}
+        // BFD control: feed the expiration watchdog, then ALWAYS hand the
+        // packet to the stack — the daemon runs the FSM on it. A parse
+        // failure (truncated frame) just skips the observation.
+        BFD_CTRL_PORT => {
+            let _ = unsafe { observe_control(ctx, IP_TTL_OFF, CTRL_OFF) };
+            return Ok(xdp_action::XDP_PASS);
+        }
+        _ => return Ok(xdp_action::XDP_PASS),
     }
 
     // Our own originated Echo, looped back by the peer, is self-addressed to one
@@ -468,8 +564,15 @@ fn try_reflect_v6(ctx: &XdpContext) -> Result<u32, ()> {
     if unsafe { load_u8(ctx, IP6_NEXTHDR_OFF)? } != IPPROTO_UDP {
         return Ok(xdp_action::XDP_PASS);
     }
-    if unsafe { load_u16_be(ctx, UDP6_DST_OFF)? } != BFD_ECHO_PORT {
-        return Ok(xdp_action::XDP_PASS);
+    match unsafe { load_u16_be(ctx, UDP6_DST_OFF)? } {
+        BFD_ECHO_PORT => {}
+        // BFD control over IPv6: observe for the expiration watchdog (Hop
+        // Limit takes the GTSM role), then pass to the stack.
+        BFD_CTRL_PORT => {
+            let _ = unsafe { observe_control(ctx, IP6_HOPLIMIT_OFF, CTRL6_OFF) };
+            return Ok(xdp_action::XDP_PASS);
+        }
+        _ => return Ok(xdp_action::XDP_PASS),
     }
 
     // Our own originated Echo, looped back by the peer (self-addressed to one of

--- a/offload/xdp-bfd-echo/loader/src/main.rs
+++ b/offload/xdp-bfd-echo/loader/src/main.rs
@@ -95,8 +95,9 @@ async fn main() -> anyhow::Result<()> {
     // Take the XDP maps for userspace to drive (the loaded program keeps using
     // the same kernel maps); `ebpf` itself stays in scope so the XDP link
     // persists until exit. `OUR_LOCAL_IPS` teaches the program our source IPs;
-    // `ECHO_TIMERS` holds the per-session bpf_timer detection state we seed and
-    // poll.
+    // `ECHO_TIMERS` (Echo returns) and `CONTROL_TIMERS` (control-packet
+    // expiration watchdog) hold the per-session bpf_timer detection state we
+    // seed and poll.
     let local_ips = aya::maps::HashMap::try_from(
         ebpf.take_map("OUR_LOCAL_IPS")
             .context("OUR_LOCAL_IPS map missing from object")?,
@@ -109,7 +110,11 @@ async fn main() -> anyhow::Result<()> {
         ebpf.take_map("ECHO_TIMERS")
             .context("ECHO_TIMERS map missing from object")?,
     )?;
-    let mut engine = sender::EchoEngine::new(&iface, local_ips, local_ips_v6, timers)?;
+    let ctrl_timers = aya::maps::HashMap::try_from(
+        ebpf.take_map("CONTROL_TIMERS")
+            .context("CONTROL_TIMERS map missing from object")?,
+    )?;
+    let mut engine = sender::EchoEngine::new(&iface, local_ips, local_ips_v6, timers, ctrl_timers)?;
 
     info!("BFD Echo datapath up on {iface} (reflect + originate); Ctrl-C/SIGTERM to exit");
 

--- a/offload/xdp-bfd-echo/loader/src/sender.rs
+++ b/offload/xdp-bfd-echo/loader/src/sender.rs
@@ -20,8 +20,19 @@
 //! covered by a userspace bootstrap fallback: if the timer hasn't armed within
 //! the detection time of `echo-add`, the tick reports `echo-down` itself.
 //!
+//! The same engine also fronts the **control-packet expiration watchdog**
+//! (`detect-add <discr> <detect-us>` / `detect-del <discr>`): it seeds the
+//! XDP `CONTROL_TIMERS` map entry whose `bpf_timer` the program re-arms on
+//! every inbound BFD control packet for that discriminator, and the tick polls
+//! the entry's `down` flag, reporting `detect-down <discr>` when control
+//! packets stopped (RFC 5880 §6.8.4, evaluated in-kernel). There is no
+//! transmit half — the daemon keeps sending its own control packets — so this
+//! path needs no `AF_PACKET` socket. The same bootstrap fallback applies
+//! before the first packet arms the kernel timer.
+//!
 //! The `AF_PACKET` socket (which needs `CAP_NET_RAW`) is opened lazily on the
-//! first `echo-add`, so a reflector-only / standalone run never touches it.
+//! first `echo-add`, so a reflector-only / watchdog-only / standalone run
+//! never touches it.
 
 use std::collections::HashMap;
 use std::io::Write;
@@ -34,30 +45,45 @@ use aya::Pod;
 use aya::maps::{HashMap as BpfHashMap, MapData};
 use log::{debug, warn};
 
-/// Userspace mirror of the eBPF `EchoState` value in the `ECHO_TIMERS` map.
-/// Byte-identical layout (`#[repr(C)]`, 32 bytes, 8-byte aligned). Userspace
-/// seeds an entry at `echo-add` with the `timer` zeroed (the kernel manages and
+/// Userspace mirror of the eBPF `DetectState` value shared by the
+/// `ECHO_TIMERS` and `CONTROL_TIMERS` maps. Byte-identical layout
+/// (`#[repr(C)]`, 32 bytes, 8-byte aligned). Userspace seeds an entry at
+/// `echo-add` / `detect-add` with the `timer` zeroed (the kernel manages and
 /// re-zeroes it; only XDP may `bpf_timer_init` it) and reads back `armed` /
 /// `down` each tick.
 #[repr(C)]
 #[derive(Clone, Copy)]
-pub struct EchoState {
+pub struct DetectState {
     /// Opaque kernel `struct bpf_timer` (`[u64; 2]`). Never touched here.
     timer: [u64; 2],
     /// Detection time in nanoseconds; the timer's re-arm delay (set by us).
     detect_ns: u64,
     /// 1 once XDP has init'd + started the timer (it took over detection).
     armed: u8,
-    /// 1 when the timer fired (returns stopped). Polled here, reset by XDP on
-    /// the next return.
+    /// 1 when the timer fired (tracked packets stopped). Polled here, reset by
+    /// XDP on the next observed packet.
     down: u8,
     _pad: [u8; 6],
 }
 
-// SAFETY: `EchoState` is `#[repr(C)]`, `Copy`, and contains only integer fields
-// with no padding beyond the explicit `_pad`, so it is safe to read/write as raw
-// bytes to/from a BPF map (the contract of `aya::Pod`).
-unsafe impl Pod for EchoState {}
+// SAFETY: `DetectState` is `#[repr(C)]`, `Copy`, and contains only integer
+// fields with no padding beyond the explicit `_pad`, so it is safe to
+// read/write as raw bytes to/from a BPF map (the contract of `aya::Pod`).
+unsafe impl Pod for DetectState {}
+
+impl DetectState {
+    /// A fresh entry to seed: zeroed timer (only XDP may init it), the
+    /// detection time, not yet armed, not down.
+    fn seed(detect: Duration) -> Self {
+        Self {
+            timer: [0, 0],
+            detect_ns: detect.as_nanos().min(u64::MAX as u128) as u64,
+            armed: 0,
+            down: 0,
+            _pad: [0; 6],
+        }
+    }
+}
 
 /// Tags our Echo payload so the RX path only ever matches our own frames (a
 /// peer's Echo carries the peer's own opaque payload). ASCII "zbfd".
@@ -106,6 +132,19 @@ struct EchoSession {
     down: bool,
 }
 
+/// One control-packet expiration watch, keyed by our local discriminator. The
+/// timing itself lives in the kernel (`CONTROL_TIMERS`); this is only what the
+/// poll loop needs: the bootstrap deadline and the reported-down latch.
+struct DetectWatch {
+    /// Detection time — the bootstrap fallback window from `added` until the
+    /// first observed control packet arms the kernel timer.
+    detect: Duration,
+    /// When `detect-add` (re)created this watch.
+    added: Instant,
+    /// `detect-down` already reported (don't re-report before `detect-del`).
+    down: bool,
+}
+
 pub struct EchoEngine {
     iface: String,
     ifindex: u32,
@@ -118,11 +157,16 @@ pub struct EchoEngine {
     local_ips_v6: BpfHashMap<MapData, In6Key, u8>,
     /// The XDP `ECHO_TIMERS` map (key = discriminator). We seed an entry per
     /// session and poll its `down`/`armed` flags; the kernel owns the timer.
-    timers: BpfHashMap<MapData, u32, EchoState>,
+    timers: BpfHashMap<MapData, u32, DetectState>,
+    /// The XDP `CONTROL_TIMERS` map (key = discriminator) — the control-packet
+    /// expiration watchdog. Same seed/poll contract as `timers`.
+    ctrl_timers: BpfHashMap<MapData, u32, DetectState>,
     /// Refcount of originating sessions per local IP (map entry added on first,
     /// removed on last).
     ip_refs: HashMap<IpAddr, u32>,
     sessions: HashMap<u32, EchoSession>,
+    /// Active control-packet expiration watches, keyed by discriminator.
+    detects: HashMap<u32, DetectWatch>,
 }
 
 impl EchoEngine {
@@ -130,7 +174,8 @@ impl EchoEngine {
         iface: &str,
         local_ips: BpfHashMap<MapData, u32, u8>,
         local_ips_v6: BpfHashMap<MapData, In6Key, u8>,
-        timers: BpfHashMap<MapData, u32, EchoState>,
+        timers: BpfHashMap<MapData, u32, DetectState>,
+        ctrl_timers: BpfHashMap<MapData, u32, DetectState>,
     ) -> Result<Self> {
         Ok(Self {
             ifindex: if_nametoindex(iface)?,
@@ -139,8 +184,10 @@ impl EchoEngine {
             local_ips,
             local_ips_v6,
             timers,
+            ctrl_timers,
             ip_refs: HashMap::new(),
             sessions: HashMap::new(),
+            detects: HashMap::new(),
         })
     }
 
@@ -200,6 +247,8 @@ impl EchoEngine {
     /// Handle one stdin line from zebra-rs.
     ///   `echo-add <discr> <local-ip> <peer-ip> <tx-us> <detect-mult>`
     ///   `echo-del <discr>`
+    ///   `detect-add <discr> <detect-us>`
+    ///   `detect-del <discr>`
     pub fn handle_command(&mut self, line: &str) {
         if let Err(e) = self.try_command(line) {
             warn!("bfd echo sender: bad command {line:?}: {e}");
@@ -222,6 +271,15 @@ impl EchoEngine {
                 let discr: u32 = it.next().context("discr")?.parse()?;
                 self.del(discr);
             }
+            Some("detect-add") => {
+                let discr: u32 = it.next().context("discr")?.parse()?;
+                let detect_us: u64 = it.next().context("detect-us")?.parse()?;
+                self.detect_add(discr, detect_us);
+            }
+            Some("detect-del") => {
+                let discr: u32 = it.next().context("discr")?.parse()?;
+                self.detect_del(discr);
+            }
             other => bail!("unknown command {other:?}"),
         }
         Ok(())
@@ -242,14 +300,7 @@ impl EchoEngine {
         // Seed the kernel detector. The timer stays zeroed (uninitialized) until
         // XDP arms it on the first return; the kernel re-zeroes the timer region
         // on this update regardless. `detect_ns` is the re-arm delay.
-        let st = EchoState {
-            timer: [0, 0],
-            detect_ns: detect.as_nanos().min(u64::MAX as u128) as u64,
-            armed: 0,
-            down: 0,
-            _pad: [0; 6],
-        };
-        if let Err(e) = self.timers.insert(discr, st, 0) {
+        if let Err(e) = self.timers.insert(discr, DetectState::seed(detect), 0) {
             warn!("bfd echo sender: ECHO_TIMERS insert discr={discr}: {e}");
         }
         self.sessions.insert(
@@ -290,10 +341,71 @@ impl EchoEngine {
         debug!("bfd echo sender: del discr={discr}");
     }
 
-    /// Periodic work: transmit due Echoes and poll the kernel detector. Emits
-    /// `echo-down <discr>` (once per failure) to `out`. No-op until the socket
-    /// is open (i.e. until the first session originates).
+    /// Start (or retune) the control-packet expiration watchdog for `discr`.
+    /// Re-issuing `detect-add` doubles as an update: replacing the map element
+    /// cancels any armed `bpf_timer` (the kernel frees embedded timers on
+    /// update) and re-enters the bootstrap window, which the `added` reset
+    /// below re-covers.
+    fn detect_add(&mut self, discr: u32, detect_us: u64) {
+        let detect = Duration::from_micros(detect_us.max(1));
+        if let Err(e) = self.ctrl_timers.insert(discr, DetectState::seed(detect), 0) {
+            warn!("bfd detect: CONTROL_TIMERS insert discr={discr}: {e}");
+        }
+        self.detects.insert(
+            discr,
+            DetectWatch {
+                detect,
+                added: Instant::now(),
+                down: false,
+            },
+        );
+        debug!("bfd detect: add discr={discr} detect={detect_us}us");
+    }
+
+    /// Stop watching `discr`. Removing the map entry frees its embedded
+    /// `bpf_timer` — the kernel cancels any pending fire.
+    fn detect_del(&mut self, discr: u32) {
+        if self.detects.remove(&discr).is_some() {
+            let _ = self.ctrl_timers.remove(&discr);
+            debug!("bfd detect: del discr={discr}");
+        }
+    }
+
+    /// Poll the control-packet expiration watchdog: report `detect-down`
+    /// (once per failure) when a session's kernel timer fired, or when no
+    /// control packet armed it within the bootstrap window.
+    fn tick_detect(&mut self, out: &mut impl Write) {
+        let now = Instant::now();
+        for (discr, w) in self.detects.iter_mut() {
+            if w.down {
+                continue;
+            }
+            let fired = match self.ctrl_timers.get(discr, 0) {
+                Ok(st) => st.down != 0 || (st.armed == 0 && now.duration_since(w.added) > w.detect),
+                // Entry vanished (shouldn't happen between add and del): treat
+                // as a bootstrap timeout so we don't silently stop detecting.
+                Err(_) => now.duration_since(w.added) > w.detect,
+            };
+            if fired {
+                w.down = true;
+                let _ = writeln!(out, "detect-down {discr}");
+                let _ = out.flush();
+            }
+        }
+    }
+
+    /// Periodic work: poll the expiration watchdog, then transmit due Echoes
+    /// and poll the Echo detector. Emits `echo-down` / `detect-down <discr>`
+    /// (once per failure) to `out`.
     pub fn tick(&mut self, out: &mut impl Write) {
+        // The watchdog half needs no socket — poll it even when Echo is idle
+        // (or when CAP_NET_RAW is missing).
+        self.tick_detect(out);
+        if self.sessions.is_empty() {
+            // No originating Echo session ⇒ don't open (or poll) the
+            // AF_PACKET socket at all.
+            return;
+        }
         let Some((fd, if_mac)) = self.io() else {
             return;
         };
@@ -721,6 +833,19 @@ mod tests {
         let pl = ETH_HLEN + IP_HLEN + UDP_HLEN;
         frame[pl] ^= 0xff; // corrupt the magic
         assert_eq!(parse_return(&frame), None);
+    }
+
+    /// The userspace mirror must stay byte-identical to the eBPF `DetectState`
+    /// (32 bytes, 8-byte aligned, timer at offset 0) — the kernel locates the
+    /// embedded `bpf_timer` by the BTF of the eBPF side, and we read/write the
+    /// value as raw bytes.
+    #[test]
+    fn detect_state_layout() {
+        assert_eq!(core::mem::size_of::<DetectState>(), 32);
+        assert_eq!(core::mem::align_of::<DetectState>(), 8);
+        let st = DetectState::seed(Duration::from_micros(900_000));
+        assert_eq!(st.detect_ns, 900_000_000);
+        assert_eq!((st.armed, st.down), (0, 0));
     }
 
     #[test]

--- a/offload/xdp-bfd-echo/scripts/veth-detect-test.sh
+++ b/offload/xdp-bfd-echo/scripts/veth-detect-test.sh
@@ -1,0 +1,128 @@
+#!/usr/bin/env bash
+#
+# End-to-end test for the in-kernel BFD control-packet expiration watchdog.
+#
+# Topology (same rationale as veth-test.sh — the sender end lives in its own
+# namespace so frames actually cross the veth pair and hit the XDP hook):
+#
+#   sender (ns) --udp/3784, TTL 255--> veth-root [XDP: observe_control,
+#   re-arm CONTROL_TIMERS bpf_timer, XDP_PASS]
+#
+# Flow:
+#   1. `detect-add <discr> 600000` over the helper's stdin (600 ms detection).
+#   2. Stream valid BFD control packets carrying that Your Discriminator every
+#      150 ms for ~1.2 s. Each one must re-arm the kernel timer, so NO
+#      `detect-down` may appear — if the XDP observe path were broken, the
+#      helper's userspace bootstrap fallback would fire at 600 ms *during* the
+#      stream and the test fails right here.
+#   3. Stop sending. The bpf_timer fires ~600 ms later in softirq and the
+#      helper must report `detect-down <discr>` on stdout.
+#
+# Run as root:
+#   sudo bash offload/xdp-bfd-echo/scripts/veth-detect-test.sh
+set -u
+
+NS=bfddet-ns
+V0=bfdd0            # root-ns end — the helper attaches its XDP program here
+V1=bfdd1            # namespace end — the control-packet sender
+IP0=10.124.0.1
+IP1=10.124.0.2
+PORT=3784
+DISCR=3735928559    # 0xdeadbeef — Your Discriminator the watchdog is keyed on
+DETECT_US=600000
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+BIN="$SCRIPT_DIR/../target/release/xdp-bfd-echo"
+CTL=/tmp/bfddet_ctl
+OUT=/tmp/bfddet_events.out
+LOG=/tmp/bfddet_helper.log
+
+HELPER_PID=""
+cleanup() {
+    [ -n "$HELPER_PID" ] && kill -INT "$HELPER_PID" 2>/dev/null
+    sleep 0.3
+    exec 9>&- 2>/dev/null
+    rm -f "$CTL"
+    ip netns del "$NS" 2>/dev/null
+    ip link del "$V0" 2>/dev/null
+}
+trap cleanup EXIT
+
+if [ "$(id -u)" -ne 0 ]; then echo "ERROR: run as root (sudo)"; exit 1; fi
+if [ ! -x "$BIN" ]; then
+    echo "ERROR: binary not found: $BIN"
+    echo "       build it first:  (cd $SCRIPT_DIR/.. && cargo build --release)"
+    exit 1
+fi
+
+echo "== 1. fresh veth pair + namespace =="
+ip netns del "$NS" 2>/dev/null; ip link del "$V0" 2>/dev/null   # clean slate
+ip netns add "$NS"
+ip link add "$V0" type veth peer name "$V1"
+ip link set "$V1" netns "$NS"
+ip addr add "$IP0/24" dev "$V0"
+ip link set "$V0" up
+ip netns exec "$NS" ip addr add "$IP1/24" dev "$V1"
+ip netns exec "$NS" ip link set "$V1" up
+ip netns exec "$NS" ip link set lo up
+echo "   root ns: $V0 ($IP0)   |   $NS: $V1 ($IP1)"
+
+echo "== 2. attach helper on $V0 (SKB mode) and arm the watchdog =="
+rm -f "$CTL" "$OUT"; mkfifo "$CTL"
+# Event lines (detect-down) go to stdout; env_logger goes to stderr.
+RUST_LOG=info "$BIN" -i "$V0" -m skb <"$CTL" >"$OUT" 2>"$LOG" &
+HELPER_PID=$!
+exec 9>"$CTL"       # hold the control pipe open for the whole run
+sleep 2
+if ! kill -0 "$HELPER_PID" 2>/dev/null; then
+    echo "ERROR: helper exited early:"; cat "$LOG"; exit 1
+fi
+grep -iE 'attached|mode' "$LOG" | sed 's/^/   /'
+echo "detect-add $DISCR $DETECT_US" >&9
+echo "   detect-add $DISCR ${DETECT_US}us sent"
+
+echo "== 3. stream BFD control packets (each must re-arm the kernel timer) =="
+ip netns exec "$NS" python3 - <<PY
+import struct, time
+from socket import socket, AF_INET, SOCK_DGRAM, IPPROTO_IP, IP_TTL
+s = socket(AF_INET, SOCK_DGRAM)
+s.setsockopt(IPPROTO_IP, IP_TTL, 255)        # GTSM — the observer requires 255
+s.bind(("$IP1", 49152))
+# RFC 5880 §4.1: vers 1 | diag 0, state Up, mult 3, len 24, my/your discr,
+# desired-tx / required-rx / echo-rx.
+pkt = struct.pack("!BBBBIIIII", 0x20, 0xc0, 3, 24, 0x11112222, $DISCR,
+                  300000, 300000, 0)
+for _ in range(8):
+    s.sendto(pkt, ("$IP0", $PORT)); time.sleep(0.15)
+print("   sent 8x udp/$PORT (TTL 255) over ~1.2s")
+PY
+
+# 1.2 s of traffic > 600 ms detection: a premature detect-down means the XDP
+# observe path never re-armed the timer (the bootstrap fallback fired instead).
+if grep -q "detect-down" "$OUT"; then
+    echo
+    echo "FAIL: detect-down fired WHILE control packets were flowing"
+    echo "-- events --"; sed 's/^/   /' "$OUT"
+    echo "-- helper log --"; sed 's/^/   /' "$LOG"
+    exit 2
+fi
+echo "   no detect-down while traffic flowed (kernel timer kept re-arming)"
+
+echo "== 4. stop the stream; expect detect-down within ~${DETECT_US}us =="
+deadline=$(( $(date +%s) + 5 ))
+while [ "$(date +%s)" -lt "$deadline" ]; do
+    grep -q "detect-down $DISCR" "$OUT" && break
+    sleep 0.1
+done
+
+echo "-- events --"; sed 's/^/   /' "$OUT"
+if grep -q "detect-down $DISCR" "$OUT"; then
+    echo
+    echo "PASS: kernel expiration watchdog re-armed on traffic and fired after it stopped"
+    exit 0
+else
+    echo
+    echo "FAIL: no detect-down after the stream stopped"
+    echo "-- helper log --"; sed 's/^/   /' "$LOG"
+    exit 2
+fi

--- a/zebra-rs/src/bfd/inst.rs
+++ b/zebra-rs/src/bfd/inst.rs
@@ -108,9 +108,10 @@ impl Default for ClientReqChannel {
 pub enum ClientReq {
     /// Register interest in `key`. If no session yet exists for that
     /// key, BFD creates one using `params`; otherwise the existing
-    /// session is reused and the Echo-affecting fields of `params` are
-    /// applied to it live (`Bfd::update_echo_params`) — so clients
-    /// re-send `Subscribe` to push `bfd { echo-* }` config changes.
+    /// session is reused and the offload-affecting fields of `params`
+    /// (Echo roles + detect-offload) are applied to it live
+    /// (`Bfd::update_offload_params`) — so clients re-send `Subscribe`
+    /// to push `bfd { echo-* | detect-offload }` config changes.
     /// State-change events for the session are forwarded to `notifier`
     /// until the matching [`ClientReq::Unsubscribe`] arrives.
     Subscribe {
@@ -123,6 +124,12 @@ pub enum ClientReq {
     /// unsubscribes, BFD tears the session down.
     Unsubscribe { client: ClientId, key: SessionKey },
 }
+
+/// While the in-kernel expiration watchdog owns detection for a session, its
+/// userspace detection timer stays armed at this multiple of the real
+/// detection time — a backstop that fires only if the helper/kernel path
+/// failed without us noticing. Restored to 1× whenever the watchdog disarms.
+const DETECT_BACKSTOP_FACTOR: u32 = 4;
 
 /// Holds the per-session timer task and its command channel. Dropping
 /// the `Task` aborts the timer loop; the `cmd_tx` is used to update
@@ -154,12 +161,24 @@ pub enum Message {
     /// jittered interval (RFC 5880 §6.8.7) the timer just scheduled, stored on
     /// the session for `show bfd peers` ("actual with jitter").
     TxTick { key: SessionKey, actual_tx_us: u32 },
-    /// Detection timer fired for `key`.
+    /// Detection timer fired for `key`. With the in-kernel expiration
+    /// watchdog armed this is the stretched *backstop* firing (helper dead or
+    /// wedged); otherwise it is the primary RFC 5880 §6.8.4 detection.
     DetectExpired { key: SessionKey },
     /// The per-interface helper reported that our originated Echo for the
     /// session with this local discriminator stopped returning (Echo detection
     /// timeout). Drives the session Down with `EchoFunctionFailed`.
     EchoDown { discr: u32 },
+    /// The per-interface helper reported that the in-kernel expiration
+    /// watchdog fired for this local discriminator: no control packet arrived
+    /// at the interface within the programmed detection time (RFC 5880 §6.8.4
+    /// evaluated in XDP/`bpf_timer`). Drives the same transition as the
+    /// userspace detection timer.
+    DetectDown { discr: u32 },
+    /// The IPC channel to the helper on `ifindex` closed (child died or was
+    /// released). Sessions still counting on its kernel watchdog revert to
+    /// userspace detection.
+    HelperGone { ifindex: u32 },
 }
 
 /// Lifecycle events emitted by the instance for clients (tests today,
@@ -333,12 +352,12 @@ impl Bfd {
 
     /// Add `client` as a subscriber on `key`. Creates the underlying
     /// session if it does not yet exist; otherwise the session is
-    /// reused and the Echo-affecting fields of `params` are applied to
-    /// it live (see [`Self::update_echo_params`]) — clients re-drive
-    /// `Subscribe` from their `bfd {}` config callbacks, so a commit
-    /// that flips `echo-mode` lands here. If the session is already
-    /// Up, the new subscriber is informed via an immediate synthetic
-    /// [`BfdEvent::StateChange`].
+    /// reused and the offload-affecting fields of `params` are applied
+    /// to it live (see [`Self::update_offload_params`]) — clients
+    /// re-drive `Subscribe` from their `bfd {}` config callbacks, so a
+    /// commit that flips `echo-mode` or `detect-offload` lands here. If
+    /// the session is already Up, the new subscriber is informed via an
+    /// immediate synthetic [`BfdEvent::StateChange`].
     pub fn subscribe(
         &mut self,
         client: ClientId,
@@ -347,13 +366,14 @@ impl Bfd {
         notifier: UnboundedSender<BfdEvent>,
     ) {
         // Lazy create the session on the first subscriber. Subsequent
-        // Subscribes reuse the existing session, applying only the Echo
-        // params — where several clients share a session the last
-        // writer wins (control-plane timing stays create-time-only).
+        // Subscribes reuse the existing session, applying only the
+        // offload params (Echo + detect-offload) — where several clients
+        // share a session the last writer wins (control-plane timing
+        // stays create-time-only).
         if self.sessions.get_by_key(&key).is_none() {
             self.add_session(key, params);
         } else {
-            self.update_echo_params(&key, &params);
+            self.update_offload_params(&key, &params);
         }
         // Mirror the current state to the new subscriber so it can
         // act on already-Up sessions without waiting for the next
@@ -394,13 +414,15 @@ impl Bfd {
     pub fn add_session(&mut self, key: SessionKey, params: SessionParams) -> u32 {
         let disc = self.sessions.insert(key, params);
 
-        // Echo is single-hop only; both IPv4 and IPv6 are handled (the XDP helper
-        // reflects either family). Any active Echo role needs the per-interface
-        // helper: `receive` reflects a peer's Echo, `transmit` sends + detects
-        // ours. Bring it up and mark the session `echo_ready` once the child is
-        // confirmed running — until then we advertise 0 (an honest promise to
-        // actually loop Echo back).
-        if !params.echo_mode.is_off() && !key.multihop {
+        // Echo and the expiration watchdog are single-hop only; both IPv4 and
+        // IPv6 are handled (the XDP helper reflects/observes either family).
+        // Any active Echo role or a detect-offload intent needs the
+        // per-interface helper: `receive` reflects a peer's Echo, `transmit`
+        // sends + detects ours, `detect-offload` times the peer's control
+        // packets in-kernel. Bring it up and mark the session `echo_ready`
+        // once the child is confirmed running — until then we advertise 0 (an
+        // honest promise to actually loop Echo back).
+        if (!params.echo_mode.is_off() || params.detect_offload) && !key.multihop {
             self.reflectors.acquire(key.ifindex);
             let ready = self.reflectors.is_ready(key.ifindex);
             if ready && let Some(s) = self.sessions.get_by_key_mut(&key) {
@@ -432,29 +454,32 @@ impl Bfd {
         disc
     }
 
-    /// Apply the Echo-affecting fields of `params` to an existing session —
-    /// the runtime path for `bfd { echo-mode | echo-*-interval }` config
-    /// changes, which clients re-drive via `Subscribe` on commit. Control
-    /// timing (`desired_min_tx_us` / `required_min_rx_us` / `detect_mult`)
-    /// stays create-time-only: a live change would need an RFC 5880 §6.8.3
-    /// Poll Sequence, and every client wires only the Echo fields today.
+    /// Apply the offload-affecting fields of `params` — the Echo roles and
+    /// the expiration-detect offload intent — to an existing session: the
+    /// runtime path for `bfd { echo-mode | echo-*-interval | detect-offload }`
+    /// config changes, which clients re-drive via `Subscribe` on commit.
+    /// Control timing (`desired_min_tx_us` / `required_min_rx_us` /
+    /// `detect_mult`) stays create-time-only: a live change would need an
+    /// RFC 5880 §6.8.3 Poll Sequence, and every client wires only these
+    /// fields today.
     ///
-    /// The reflector-helper refcount tracks "Echo configured on this
-    /// single-hop session" (the `add_session` / `remove_session` predicate),
-    /// so it is adjusted here on every off↔on edge to stay symmetric while
-    /// `echo_mode` mutates.
-    fn update_echo_params(&mut self, key: &SessionKey, params: &SessionParams) {
+    /// The reflector-helper refcount tracks "Echo or detect-offload
+    /// configured on this single-hop session" (the `add_session` /
+    /// `remove_session` predicate), so it is adjusted here on every off↔on
+    /// edge to stay symmetric while the fields mutate.
+    fn update_offload_params(&mut self, key: &SessionKey, params: &SessionParams) {
         let Some(s) = self.sessions.get_by_key(key) else {
             return;
         };
         if s.echo_mode == params.echo_mode
             && s.required_min_echo_rx_us == params.required_min_echo_rx_us
             && s.echo_transmit_us == params.echo_transmit_us
+            && s.detect_offload == params.detect_offload
         {
             return;
         }
-        let was_active = !s.echo_mode.is_off() && !key.multihop;
-        let now_active = !params.echo_mode.is_off() && !key.multihop;
+        let was_active = (!s.echo_mode.is_off() || s.detect_offload) && !key.multihop;
+        let now_active = (!params.echo_mode.is_off() || params.detect_offload) && !key.multihop;
         // A change to the transmit role or rate invalidates a running
         // originator: stop it now, while the helper is guaranteed alive
         // (originating ⇒ `was_active` ⇒ we still hold a reflector
@@ -477,6 +502,7 @@ impl Bfd {
             s.echo_mode = params.echo_mode;
             s.required_min_echo_rx_us = params.required_min_echo_rx_us;
             s.echo_transmit_us = params.echo_transmit_us;
+            s.detect_offload = params.detect_offload;
             s.echo_ready = ready;
             if restart {
                 s.echo_originating = false;
@@ -488,8 +514,12 @@ impl Bfd {
         // transmitted, so a role drop always sets `restart`). The new
         // advertised echo-rx goes out on the next periodic control Tx.
         self.echo_originate_reconcile(*key);
-        // Release last: if this was the interface's final Echo session the
-        // helper is torn down, so any `echo-del` had to precede it.
+        // Likewise re-aim the expiration watchdog: arms it on a gained
+        // detect-offload (session already Up), disarms on a dropped one —
+        // and the disarm's `detect-del` must precede the release below.
+        self.detect_offload_reconcile(*key);
+        // Release last: if this was the interface's final helper session the
+        // child is torn down, so any `echo-del`/`detect-del` had to precede it.
         if was_active && !now_active {
             self.reflectors.release(key.ifindex);
         }
@@ -502,19 +532,24 @@ impl Bfd {
             let _ = h.cmd_tx.send(TimerCmd::Shutdown);
         }
         let removed = self.sessions.remove(key);
-        // Mirror the `add_session` acquire predicate exactly. `echo_mode` can
-        // mutate at runtime (`update_echo_params`), but that path adjusts the
-        // reflector refcount on every off↔on edge, so releasing on the
-        // *current* mode stays symmetric.
+        // Mirror the `add_session` acquire predicate exactly. The fields can
+        // mutate at runtime (`update_offload_params`), but that path adjusts
+        // the reflector refcount on every off↔on edge, so releasing on the
+        // *current* values stays symmetric.
         if let Some(s) = &removed
-            && !s.echo_mode.is_off()
+            && (!s.echo_mode.is_off() || s.detect_offload)
             && !s.key.multihop
         {
-            // Stop any originator first, while the helper is still alive — the
-            // release below may be the last reference and tear the child down.
+            // Stop any originator / armed watchdog first, while the helper is
+            // still alive — the release below may be the last reference and
+            // tear the child down.
             if s.echo_originating {
                 self.reflectors
                     .send_command(s.key.ifindex, format!("echo-del {}", s.local_disc));
+            }
+            if s.kernel_detect_us > 0 {
+                self.reflectors
+                    .send_command(s.key.ifindex, format!("detect-del {}", s.local_disc));
             }
             self.reflectors.release(s.key.ifindex);
         }
@@ -558,6 +593,8 @@ impl Bfd {
                     Message::TxTick { key, actual_tx_us } => self.on_tx_tick(key, actual_tx_us),
                     Message::DetectExpired { key } => self.on_detect_expired(key),
                     Message::EchoDown { discr } => self.on_echo_down(discr),
+                    Message::DetectDown { discr } => self.on_detect_down(discr),
+                    Message::HelperGone { ifindex } => self.on_helper_gone(ifindex),
                 },
                 // BFD's only config is the top-level `bfd { tracing }` flag;
                 // every other commit broadcast is drained here (we register as
@@ -647,7 +684,7 @@ impl Bfd {
             }
         }
 
-        let (change, new_tx_us, new_detect_us, new_detect_mult) = {
+        let (change, new_tx_us, new_detect_us, new_detect_mult, offloaded) = {
             let session = self
                 .sessions
                 .get_by_key_mut(&key)
@@ -658,16 +695,25 @@ impl Bfd {
                 session.tx_interval_us(),
                 session.detection_time_us(),
                 session.detect_mult,
+                session.kernel_detect_us > 0,
             )
         };
 
         // Every valid Rx must reset the detection timer (RFC 5880
         // §6.8.4). When intervals are also negotiated freshly, the
         // Update command implicitly does the reset as part of arming.
+        // While the in-kernel expiration watchdog owns detection, the
+        // userspace timer is only a backstop — keep it stretched so the
+        // kernel verdict (or its absence) always wins.
         if let Some(h) = self.timer_handles.get(&key) {
+            let detection_time_us = if offloaded {
+                new_detect_us.saturating_mul(DETECT_BACKSTOP_FACTOR)
+            } else {
+                new_detect_us
+            };
             let _ = h.cmd_tx.send(TimerCmd::Update {
                 tx_interval_us: new_tx_us,
-                detection_time_us: new_detect_us,
+                detection_time_us,
                 detect_mult: new_detect_mult,
             });
         }
@@ -696,6 +742,9 @@ impl Bfd {
         // (Re)evaluate the §6.8.9 originate gate: a transition to/from Up, or a
         // freshly-learned non-zero peer echo-rx, can start or stop our Echo.
         self.echo_originate_reconcile(key);
+        // Likewise the expiration watchdog: arm on the Up transition, disarm
+        // on leaving Up, retune when negotiation changed the detection time.
+        self.detect_offload_reconcile(key);
     }
 
     /// Find an existing session that matches an incoming packet whose
@@ -781,6 +830,9 @@ impl Bfd {
         if let Some(change) = change {
             self.notify_state_change(key, change);
         }
+        // If the kernel watchdog was armed, this was the backstop firing —
+        // the session left Up either way, so disarm it.
+        self.detect_offload_reconcile(key);
     }
 
     /// The per-interface helper reported that our originated Echo for the
@@ -799,6 +851,119 @@ impl Bfd {
             self.notify_state_change(key, change);
         }
         self.echo_originate_reconcile(key);
+        self.detect_offload_reconcile(key);
+    }
+
+    /// The per-interface helper reported that the in-kernel expiration
+    /// watchdog fired for the session with local discriminator `discr`: no
+    /// control packet arrived at the interface within the programmed
+    /// detection time (RFC 5880 §6.8.4, evaluated in XDP/`bpf_timer`). Drive
+    /// the same `DetectExpired` transition as the userspace detection timer
+    /// (Down, `ControlDetectionTimeExpired`), then reconcile: the session
+    /// left Up, so the watchdog disarms and Echo stops originating.
+    fn on_detect_down(&mut self, discr: u32) {
+        let Some(key) = self.sessions.get_by_disc(discr).map(|s| s.key) else {
+            return;
+        };
+        let change = self
+            .sessions
+            .get_by_key_mut(&key)
+            .and_then(|s| s.handle_event(Event::DetectExpired));
+        if let Some(change) = change {
+            self.notify_state_change(key, change);
+        }
+        self.echo_originate_reconcile(key);
+        self.detect_offload_reconcile(key);
+    }
+
+    /// The helper's IPC channel on `ifindex` closed — the child died or was
+    /// released. Any session still counting on its kernel watchdog reverts to
+    /// userspace detection: the reconcile sees the helper not-ready, clears
+    /// the armed marker, and restores the unstretched detection timer. The
+    /// normal release paths disarm sessions *before* dropping the last
+    /// reference, so this only acts after an unexpected death.
+    fn on_helper_gone(&mut self, ifindex: u32) {
+        let armed: Vec<SessionKey> = self
+            .sessions
+            .iter()
+            .filter(|(k, s)| k.ifindex == ifindex && s.kernel_detect_us > 0)
+            .map(|(k, _)| *k)
+            .collect();
+        for key in armed {
+            bfd_warn!(
+                ?key,
+                ifindex,
+                "bfd: xdp helper gone; session reverts to userspace detection",
+            );
+            self.detect_offload_reconcile(key);
+        }
+    }
+
+    /// Arm, retune, or disarm the in-kernel expiration watchdog for `key` —
+    /// the XDP helper's `CONTROL_TIMERS` `bpf_timer`, re-armed by every
+    /// control packet arriving for our discriminator (see
+    /// `offload/xdp-bfd-echo`). Mirrors [`Self::echo_originate_reconcile`]:
+    /// the desired kernel detection time is compared to the armed one
+    /// (`Session::kernel_detect_us`) and `detect-add`/`detect-del` are sent
+    /// exactly on the edges; a changed value re-sends `detect-add`, which the
+    /// helper applies as an update.
+    ///
+    /// Armed only while the session is **Up** — before establishment the
+    /// peer may send `Your Discriminator = 0`, which the XDP program cannot
+    /// key — and only single-hop: the helper attaches per interface, and
+    /// multihop ingress isn't bound to one (its TTL floor is also below the
+    /// GTSM 255 the observer requires). While armed, the userspace detection
+    /// timer is stretched to a backstop ([`DETECT_BACKSTOP_FACTOR`]) so the
+    /// kernel verdict normally wins; on disarm it is restored to primary.
+    fn detect_offload_reconcile(&mut self, key: SessionKey) {
+        let Some(s) = self.sessions.get_by_key(&key) else {
+            return;
+        };
+        let gates_open = s.detect_offload
+            && !s.key.multihop
+            && s.local_state == bfd_packet::State::Up
+            && s.detection_time_us() > 0;
+        let (ifindex, discr, armed_us) = (s.key.ifindex, s.local_disc, s.kernel_detect_us);
+        // The helper must be confirmed running before we hand detection to it
+        // (and stretch the userspace timer on that promise).
+        let want_us = if gates_open && self.reflectors.is_ready(ifindex) {
+            self.sessions
+                .get_by_key(&key)
+                .map_or(0, |s| s.detection_time_us())
+        } else {
+            0
+        };
+        if want_us == armed_us {
+            return;
+        }
+        if want_us > 0 {
+            self.reflectors
+                .send_command(ifindex, format!("detect-add {discr} {want_us}"));
+        } else {
+            self.reflectors
+                .send_command(ifindex, format!("detect-del {discr}"));
+        }
+        // Re-aim the userspace detection timer for the new role: stretched
+        // backstop while the kernel watchdog is armed, primary (1×) when not.
+        // `Update` also re-arms the detection deadline, which is harmless —
+        // this path runs right after a state change or a received packet.
+        if let Some(h) = self.timer_handles.get(&key)
+            && let Some(s) = self.sessions.get_by_key(&key)
+        {
+            let detection_time_us = if want_us > 0 {
+                s.detection_time_us().saturating_mul(DETECT_BACKSTOP_FACTOR)
+            } else {
+                s.detection_time_us()
+            };
+            let _ = h.cmd_tx.send(TimerCmd::Update {
+                tx_interval_us: s.tx_interval_us(),
+                detection_time_us,
+                detect_mult: s.detect_mult,
+            });
+        }
+        if let Some(s) = self.sessions.get_by_key_mut(&key) {
+            s.kernel_detect_us = want_us;
+        }
     }
 
     /// RFC 5880 §6.8.9 — start or stop *originating* Echo for `key` based on the
@@ -1494,5 +1659,167 @@ mod tests {
             Some(2),
             "both clients stay subscribed",
         );
+    }
+
+    // ---- expiration-detect offload (`Bfd::detect_offload_reconcile`) --------
+
+    fn detect_params() -> SessionParams {
+        SessionParams {
+            detect_offload: true,
+            ..SessionParams::default()
+        }
+    }
+
+    /// Force the watchdog gates open: session Up with remote timing learned
+    /// (default 300 ms × 3 ⇒ a 900 ms detection time).
+    fn force_up_with_remote_timing(bfd: &mut Bfd, key: &SessionKey) {
+        let s = bfd.sessions.get_by_key_mut(key).unwrap();
+        s.local_state = bfd_packet::State::Up;
+        s.remote_detect_mult = 3;
+        s.remote_min_tx_us = 300_000;
+    }
+
+    /// A single-hop subscribe with detect-offload configured refcounts the
+    /// per-interface helper even with Echo off; the last unsubscribe
+    /// releases it. Multihop never does.
+    #[tokio::test]
+    async fn detect_offload_refcounts_reflector() {
+        let mut bfd = fresh_bfd();
+        let key = echo_key(30);
+        let (tx, _rx) = mpsc::unbounded_channel();
+        bfd.subscribe("ospf".into(), key, detect_params(), tx);
+        assert_eq!(bfd.reflectors.refcount(ECHO_TEST_IFINDEX), 1);
+        bfd.unsubscribe("ospf", &key);
+        assert_eq!(bfd.reflectors.refcount(ECHO_TEST_IFINDEX), 0);
+
+        let mut mh_key = echo_key(31);
+        mh_key.multihop = true;
+        let (tx, _rx) = mpsc::unbounded_channel();
+        bfd.subscribe("bgp".into(), mh_key, detect_params(), tx);
+        assert_eq!(
+            bfd.reflectors.refcount(ECHO_TEST_IFINDEX),
+            0,
+            "multihop never brings the helper up",
+        );
+    }
+
+    /// The watchdog arms only while Up with the helper confirmed running,
+    /// carries the negotiated detection time, retunes when negotiation
+    /// changes it, and disarms when the session leaves Up.
+    #[tokio::test]
+    async fn detect_offload_arms_retunes_and_disarms() {
+        let mut bfd = fresh_bfd();
+        let key = echo_key(32);
+        let (tx, _rx) = mpsc::unbounded_channel();
+        bfd.subscribe("ospf".into(), key, detect_params(), tx);
+
+        // Up but helper not confirmed → stays in userspace.
+        force_up_with_remote_timing(&mut bfd, &key);
+        bfd.detect_offload_reconcile(key);
+        assert_eq!(
+            bfd.sessions.get_by_key(&key).unwrap().kernel_detect_us,
+            0,
+            "no arming on an unconfirmed helper",
+        );
+
+        // Helper confirmed → arm with the negotiated detection time.
+        bfd.reflectors.set_ready_for_test(ECHO_TEST_IFINDEX);
+        bfd.detect_offload_reconcile(key);
+        assert_eq!(
+            bfd.sessions.get_by_key(&key).unwrap().kernel_detect_us,
+            900_000,
+        );
+
+        // Renegotiation (peer slows to 500 ms) retunes the armed value.
+        bfd.sessions.get_by_key_mut(&key).unwrap().remote_min_tx_us = 500_000;
+        bfd.detect_offload_reconcile(key);
+        assert_eq!(
+            bfd.sessions.get_by_key(&key).unwrap().kernel_detect_us,
+            1_500_000,
+        );
+
+        // Leaving Up disarms.
+        bfd.sessions.get_by_key_mut(&key).unwrap().local_state = bfd_packet::State::Down;
+        bfd.detect_offload_reconcile(key);
+        assert_eq!(bfd.sessions.get_by_key(&key).unwrap().kernel_detect_us, 0);
+    }
+
+    /// `detect-down` from the helper (the kernel watchdog fired) drives the
+    /// session Down with ControlDetectionTimeExpired — the same transition as
+    /// the userspace detection timer — and the watchdog disarms.
+    #[tokio::test]
+    async fn detect_down_drives_session_down() {
+        let mut bfd = fresh_bfd();
+        let key = echo_key(33);
+        let (tx, _rx) = mpsc::unbounded_channel();
+        bfd.subscribe("ospf".into(), key, detect_params(), tx);
+        bfd.reflectors.set_ready_for_test(ECHO_TEST_IFINDEX);
+        force_up_with_remote_timing(&mut bfd, &key);
+        bfd.detect_offload_reconcile(key);
+        let disc = bfd.sessions.get_by_key(&key).unwrap().local_disc;
+        assert!(bfd.sessions.get_by_key(&key).unwrap().kernel_detect_us > 0);
+
+        bfd.on_detect_down(disc);
+
+        let s = bfd.sessions.get_by_key(&key).unwrap();
+        assert_eq!(s.local_state, bfd_packet::State::Down);
+        assert_eq!(s.local_diag, bfd_packet::Diag::ControlDetectionTimeExpired);
+        assert_eq!(s.kernel_detect_us, 0, "watchdog disarmed on Down");
+    }
+
+    /// Helper death (`HelperGone`) reverts armed sessions to userspace
+    /// detection without touching their state.
+    #[tokio::test]
+    async fn helper_gone_reverts_to_userspace_detection() {
+        let mut bfd = fresh_bfd();
+        let key = echo_key(34);
+        let (tx, _rx) = mpsc::unbounded_channel();
+        bfd.subscribe("ospf".into(), key, detect_params(), tx);
+        bfd.reflectors.set_ready_for_test(ECHO_TEST_IFINDEX);
+        force_up_with_remote_timing(&mut bfd, &key);
+        bfd.detect_offload_reconcile(key);
+        assert!(bfd.sessions.get_by_key(&key).unwrap().kernel_detect_us > 0);
+
+        bfd.reflectors.clear_ready_for_test(ECHO_TEST_IFINDEX);
+        bfd.on_helper_gone(ECHO_TEST_IFINDEX);
+
+        let s = bfd.sessions.get_by_key(&key).unwrap();
+        assert_eq!(s.kernel_detect_us, 0, "reverted to userspace detection");
+        assert_eq!(
+            s.local_state,
+            bfd_packet::State::Up,
+            "session state untouched by the revert",
+        );
+    }
+
+    /// Re-subscribing with detect-offload turned off disarms a live watchdog
+    /// and releases the helper reference (and vice versa for turning it on).
+    #[tokio::test]
+    async fn resubscribe_flips_detect_offload_live() {
+        let mut bfd = fresh_bfd();
+        let key = echo_key(35);
+        let (tx, _rx) = mpsc::unbounded_channel();
+        bfd.subscribe("ospf".into(), key, detect_params(), tx);
+        bfd.reflectors.set_ready_for_test(ECHO_TEST_IFINDEX);
+        force_up_with_remote_timing(&mut bfd, &key);
+        bfd.detect_offload_reconcile(key);
+        assert!(bfd.sessions.get_by_key(&key).unwrap().kernel_detect_us > 0);
+        assert_eq!(bfd.reflectors.refcount(ECHO_TEST_IFINDEX), 1);
+
+        // Turn it off live.
+        let (tx2, _rx2) = mpsc::unbounded_channel();
+        bfd.subscribe("ospf".into(), key, SessionParams::default(), tx2);
+        let s = bfd.sessions.get_by_key(&key).unwrap();
+        assert!(!s.detect_offload);
+        assert_eq!(s.kernel_detect_us, 0, "watchdog disarmed");
+        assert_eq!(bfd.reflectors.refcount(ECHO_TEST_IFINDEX), 0);
+
+        // And back on: re-acquires and re-arms on the still-Up session.
+        let (tx3, _rx3) = mpsc::unbounded_channel();
+        bfd.subscribe("ospf".into(), key, detect_params(), tx3);
+        let s = bfd.sessions.get_by_key(&key).unwrap();
+        assert!(s.detect_offload);
+        assert_eq!(s.kernel_detect_us, 900_000, "re-armed live");
+        assert_eq!(bfd.reflectors.refcount(ECHO_TEST_IFINDEX), 1);
     }
 }

--- a/zebra-rs/src/bfd/integration.rs
+++ b/zebra-rs/src/bfd/integration.rs
@@ -76,6 +76,7 @@ async fn two_instances_reach_up() {
         echo_mode: EchoMode::Off,
         required_min_echo_rx_us: 0,
         echo_transmit_us: 0,
+        detect_offload: false,
     };
 
     bfd_a.subscribe("test".into(), loopback_key(), params(port_b), tx_a);

--- a/zebra-rs/src/bfd/reflector.rs
+++ b/zebra-rs/src/bfd/reflector.rs
@@ -82,9 +82,15 @@ pub struct EchoReflectors {
     by_ifindex: HashMap<u32, Reflector>,
     bin: PathBuf,
     mode: String,
-    /// Cloned into each child's IPC task to deliver `echo-down` into the BFD
-    /// event loop as [`Message::EchoDown`].
+    /// Cloned into each child's IPC task to deliver `echo-down` /
+    /// `detect-down` / `HelperGone` into the BFD event loop.
     main_tx: UnboundedSender<Message>,
+    /// Test-only readiness override: tests can't spawn a real helper child
+    /// (no interface, no binary), so the readiness-gated paths (Echo
+    /// advertisement, expiration-watchdog arming) would be untestable
+    /// without it.
+    #[cfg(test)]
+    ready_override: std::collections::HashSet<u32>,
 }
 
 impl EchoReflectors {
@@ -94,6 +100,8 @@ impl EchoReflectors {
             bin: resolve_bin(),
             mode: std::env::var(MODE_ENV).unwrap_or_else(|_| "auto".to_string()),
             main_tx,
+            #[cfg(test)]
+            ready_override: std::collections::HashSet::new(),
         }
     }
 
@@ -136,8 +144,13 @@ impl EchoReflectors {
     }
 
     /// Whether the reflector for `ifindex` is confirmed running — the gate for
-    /// honestly advertising a non-zero echo-rx on sessions over this interface.
+    /// honestly advertising a non-zero echo-rx on sessions over this interface
+    /// and for arming the in-kernel expiration watchdog.
     pub fn is_ready(&mut self, ifindex: u32) -> bool {
+        #[cfg(test)]
+        if self.ready_override.contains(&ifindex) {
+            return true;
+        }
         self.by_ifindex
             .get_mut(&ifindex)
             .map(Reflector::is_alive)
@@ -149,6 +162,19 @@ impl EchoReflectors {
     #[cfg(test)]
     pub fn refcount(&self, ifindex: u32) -> u32 {
         self.by_ifindex.get(&ifindex).map_or(0, |r| r.refcount)
+    }
+
+    /// Test-only: pretend the helper on `ifindex` is up, so tests can drive
+    /// the readiness-gated paths without spawning a child.
+    #[cfg(test)]
+    pub fn set_ready_for_test(&mut self, ifindex: u32) {
+        self.ready_override.insert(ifindex);
+    }
+
+    /// Test-only: undo [`Self::set_ready_for_test`] (simulates helper death).
+    #[cfg(test)]
+    pub fn clear_ready_for_test(&mut self, ifindex: u32) {
+        self.ready_override.remove(&ifindex);
     }
 
     fn spawn(&self, ifindex: u32) -> Reflector {
@@ -184,6 +210,7 @@ impl EchoReflectors {
                         let (tx, rx) = mpsc::unbounded_channel::<String>();
                         let task = Task::spawn(child_io(
                             ifname.clone(),
+                            ifindex,
                             stdin,
                             stdout,
                             rx,
@@ -218,12 +245,16 @@ impl EchoReflectors {
     }
 }
 
-/// Per-child IPC task: forwards `echo-down <discr>` from the helper's stdout
-/// into the event loop, and writes queued command lines to its stdin. Ends when
-/// the child's stdout closes (child gone) or the command sender is dropped
-/// (reflector released).
+/// Per-child IPC task: forwards `echo-down` / `detect-down <discr>` events
+/// from the helper's stdout into the event loop, and writes queued command
+/// lines to its stdin. Ends when the child's stdout closes (child gone) or the
+/// command sender is dropped (reflector released) — either way it reports
+/// [`Message::HelperGone`] so sessions counting on the in-kernel expiration
+/// watchdog revert to userspace detection (a no-op after a normal release,
+/// which disarms sessions first).
 async fn child_io(
     ifname: String,
+    ifindex: u32,
     mut stdin: ChildStdin,
     stdout: ChildStdout,
     mut cmd_rx: UnboundedReceiver<String>,
@@ -234,8 +265,8 @@ async fn child_io(
         tokio::select! {
             line = lines.next_line() => match line {
                 Ok(Some(l)) => {
-                    if let Some(discr) = parse_echo_down(&l) {
-                        let _ = main_tx.send(Message::EchoDown { discr });
+                    if let Some(event) = parse_helper_event(&l) {
+                        let _ = main_tx.send(event);
                     }
                 }
                 _ => break,
@@ -253,16 +284,22 @@ async fn child_io(
             },
         }
     }
+    let _ = main_tx.send(Message::HelperGone { ifindex });
     bfd_debug!("bfd echo: IPC task for {ifname} ended");
 }
 
-/// Parse a `echo-down <discr>` event line from the helper.
-fn parse_echo_down(line: &str) -> Option<u32> {
+/// Parse one event line from the helper: `echo-down <discr>` (its Echo
+/// detection fired) or `detect-down <discr>` (the in-kernel control-packet
+/// expiration watchdog fired).
+fn parse_helper_event(line: &str) -> Option<Message> {
     let mut it = line.split_whitespace();
-    if it.next() != Some("echo-down") {
-        return None;
+    let verb = it.next()?;
+    let discr: u32 = it.next()?.parse().ok()?;
+    match verb {
+        "echo-down" => Some(Message::EchoDown { discr }),
+        "detect-down" => Some(Message::DetectDown { discr }),
+        _ => None,
     }
-    it.next()?.parse().ok()
 }
 
 /// Resolve the reflector binary path: `$ZEBRA_XDP_BFD_ECHO_BIN`, else the dev
@@ -328,6 +365,21 @@ mod tests {
         let mut r = EchoReflectors::new(tx);
         r.release(12345); // must not panic / underflow
         assert!(r.by_ifindex.is_empty());
+    }
+
+    #[test]
+    fn helper_event_lines_parse() {
+        assert!(matches!(
+            parse_helper_event("echo-down 42"),
+            Some(Message::EchoDown { discr: 42 })
+        ));
+        assert!(matches!(
+            parse_helper_event("detect-down 7"),
+            Some(Message::DetectDown { discr: 7 })
+        ));
+        assert!(parse_helper_event("detect-down").is_none());
+        assert!(parse_helper_event("detect-down nope").is_none());
+        assert!(parse_helper_event("bogus 1").is_none());
     }
 
     #[test]

--- a/zebra-rs/src/bfd/session.rs
+++ b/zebra-rs/src/bfd/session.rs
@@ -106,6 +106,14 @@ pub struct SessionParams {
     /// [`EchoMode::transmits`]. Clamped up to the peer's advertised
     /// `Required Min Echo RX` at send time (RFC 5880 §6.8.9).
     pub echo_transmit_us: u32,
+    /// Offload control-packet expiration detection (RFC 5880 §6.8.4) to the
+    /// per-interface XDP helper once the session is Up: the kernel re-arms a
+    /// per-session `bpf_timer` on every arriving control packet and reports
+    /// `detect-down` when they stop — immune to daemon scheduling latency.
+    /// Single-hop only. The userspace detection timer stays armed as a
+    /// stretched backstop while the watchdog is active; see
+    /// `Bfd::detect_offload_reconcile`.
+    pub detect_offload: bool,
 }
 
 impl Default for SessionParams {
@@ -129,6 +137,9 @@ impl Default for SessionParams {
             echo_mode: EchoMode::Off,
             required_min_echo_rx_us: 0,
             echo_transmit_us: 0,
+            // Expiration detection runs in userspace unless explicitly
+            // offloaded — arming the kernel watchdog needs the helper.
+            detect_offload: false,
         }
     }
 }
@@ -197,6 +208,15 @@ pub struct Session {
     /// `echo-add`/`echo-del` exactly on the edges; see
     /// `Bfd::echo_originate_reconcile`.
     pub echo_originating: bool,
+    /// Configured intent to offload expiration detection to the per-interface
+    /// XDP helper (from `SessionParams`; updated live on re-Subscribe like the
+    /// Echo fields).
+    pub detect_offload: bool,
+    /// Detection time (microseconds) currently programmed into the in-kernel
+    /// expiration watchdog — 0 while detection runs in userspace. Non-zero
+    /// means a `detect-add` for this discriminator is outstanding at the
+    /// helper; see `Bfd::detect_offload_reconcile`.
+    pub kernel_detect_us: u32,
 
     /// UDP destination port to send to (3784 single-hop, 4784 multi-hop).
     pub dst_port: u16,
@@ -267,6 +287,8 @@ impl Session {
             echo_transmit_us: params.echo_transmit_us,
             echo_ready: false,
             echo_originating: false,
+            detect_offload: params.detect_offload,
+            kernel_detect_us: 0,
             remote_min_tx_us: 0,
             remote_min_rx_us: 0,
             remote_detect_mult: 0,

--- a/zebra-rs/src/bfd/show.rs
+++ b/zebra-rs/src/bfd/show.rs
@@ -219,6 +219,9 @@ struct BfdPeerDetailJson {
     /// scheduled; 0 until the first tick or while transmission is suspended.
     actual_transmit_interval_us: u32,
     detection_time_us: u32,
+    /// Detection time programmed into the in-kernel (XDP) expiration
+    /// watchdog; 0 while detection runs in userspace.
+    kernel_detection_time_us: u32,
     /// `Required Min Echo RX Interval` we advertise (0 = disabled). Non-zero
     /// only while the XDP reflector is up on a single-hop session.
     echo_receive_interval_us: u32,
@@ -270,6 +273,7 @@ fn detail_json(key: &SessionKey, s: &Session) -> BfdPeerDetailJson {
         negotiated_transmit_interval_us: s.tx_interval_us(),
         actual_transmit_interval_us: s.actual_tx_us,
         detection_time_us: s.detection_time_us(),
+        kernel_detection_time_us: s.kernel_detect_us,
         echo_receive_interval_us: s.advertised_echo_rx_us(),
         echo_transmission_interval_us: s.echo_transmit_interval_us(),
         echo_transmit_active: s.echo_originating,
@@ -366,6 +370,15 @@ fn render_detail(buf: &mut String, key: &SessionKey, s: &Session) -> fmt::Result
         ms(detect)
     };
     writeln!(buf, "            Detection timeout: {}", detect)?;
+    // Where expiration detection runs: in the XDP helper's bpf_timer
+    // (kernel, with the userspace timer as a stretched backstop) or in
+    // userspace as usual.
+    let detect_where = if s.kernel_detect_us > 0 {
+        format!("kernel/XDP ({})", ms(s.kernel_detect_us))
+    } else {
+        "userspace".to_string()
+    };
+    writeln!(buf, "            Detection runs in: {}", detect_where)?;
     writeln!(
         buf,
         "            Echo receive interval: {}",

--- a/zebra-rs/src/ospf/config.rs
+++ b/zebra-rs/src/ospf/config.rs
@@ -71,6 +71,10 @@ impl Ospf {
             "/area/interface/bfd/echo-receive-interval",
             config_ospf_interface_bfd_echo_receive_interval,
         );
+        self.ospf_add(
+            "/area/interface/bfd/detect-offload",
+            config_ospf_interface_bfd_detect_offload,
+        );
         // Instance-level `router ospf { redistribute connected ... }`.
         self.ospf_add("/redistribute/connected", config_ospf_redist_connected);
         self.ospf_add(
@@ -96,6 +100,7 @@ impl Ospf {
             "/bfd/echo-receive-interval",
             config_ospf_bfd_echo_receive_interval,
         );
+        self.ospf_add("/bfd/detect-offload", config_ospf_bfd_detect_offload);
         self.ospf_add(
             "/area/interface/network-type",
             config_ospf_interface_network_type,
@@ -855,6 +860,30 @@ pub(super) fn config_ospf_interface_bfd_echo_receive_interval<V: OspfVersion>(
     Some(())
 }
 
+/// `interface <if> bfd detect-offload <bool>` — offload control-packet
+/// expiration detection to the per-interface XDP helper once the session is
+/// Up (RFC 5880 §6.8.4 evaluated in-kernel). Reconciles the link; the BFD
+/// instance arms/disarms the watchdog on live sessions.
+pub(super) fn config_ospf_interface_bfd_detect_offload<V: OspfVersion>(
+    ospf: &mut Ospf<V>,
+    mut args: Args,
+    op: ConfigOp,
+) -> Option<()> {
+    let _area_id = parse_area_id(&args.string()?)?;
+    let name = args.string()?;
+    let offload = args.boolean()?;
+
+    let ifindex = {
+        let link = ospf_link_get_mut_by_name(&mut ospf.links, &name)?;
+        // `None` ⇒ inherit the instance-level `bfd { detect-offload }`;
+        // `Some(false)` explicitly opts this interface out.
+        link.config.bfd.detect_offload = op.is_set().then_some(offload);
+        link.index
+    };
+    ospf.bfd_reconcile_link(ifindex);
+    Some(())
+}
+
 /// `interface <if> bfd min-neighbor-state <two-way|full>` — the NFSM
 /// state at which the session is started/torn down. Default `two-way`
 /// (FRR-style). Reconciles existing neighbors so a live flip takes
@@ -961,6 +990,19 @@ pub(super) fn config_ospf_bfd_echo_receive_interval<V: OspfVersion>(
 ) -> Option<()> {
     let interval = args.u32()?;
     ospf.bfd.echo_receive_ms = op.is_set().then_some(interval);
+    ospf.bfd_reconcile_all();
+    Some(())
+}
+
+/// `router ospf bfd detect-offload <bool>` — instance default for offloading
+/// expiration detection to the XDP helper (overridable per interface).
+pub(super) fn config_ospf_bfd_detect_offload<V: OspfVersion>(
+    ospf: &mut Ospf<V>,
+    mut args: Args,
+    op: ConfigOp,
+) -> Option<()> {
+    let offload = args.boolean()?;
+    ospf.bfd.detect_offload = op.is_set().then_some(offload);
     ospf.bfd_reconcile_all();
     Some(())
 }

--- a/zebra-rs/src/ospf/config_v3.rs
+++ b/zebra-rs/src/ospf/config_v3.rs
@@ -13,9 +13,10 @@ use super::area::{AreaTypeKind, ExternalMetricType, NssaTranslatorRole, RedistEn
 use super::config::{
     Callback, apply_link_enable_transition, area_no_summary_set, area_nssa_default_originate_set,
     area_nssa_suppress_fa_set, area_nssa_translator_role_set, area_type_set,
-    config_ospf_bfd_echo_mode, config_ospf_bfd_echo_receive_interval,
-    config_ospf_bfd_echo_transmit_interval, config_ospf_bfd_enable,
-    config_ospf_bfd_min_neighbor_state, config_ospf_interface_bfd_echo_mode,
+    config_ospf_bfd_detect_offload, config_ospf_bfd_echo_mode,
+    config_ospf_bfd_echo_receive_interval, config_ospf_bfd_echo_transmit_interval,
+    config_ospf_bfd_enable, config_ospf_bfd_min_neighbor_state,
+    config_ospf_interface_bfd_detect_offload, config_ospf_interface_bfd_echo_mode,
     config_ospf_interface_bfd_echo_receive_interval,
     config_ospf_interface_bfd_echo_transmit_interval, config_ospf_interface_bfd_enable,
     config_ospf_interface_bfd_min_neighbor_state, link_should_enable, ospf_link_get_mut_by_name,
@@ -86,6 +87,10 @@ impl Ospf<Ospfv3> {
                 "/area/interface/bfd/echo-receive-interval",
                 config_ospf_interface_bfd_echo_receive_interval,
             ),
+            (
+                "/area/interface/bfd/detect-offload",
+                config_ospf_interface_bfd_detect_offload,
+            ),
             // Instance-level `router ospfv3 { bfd { ... } }` defaults.
             ("/bfd/enable", config_ospf_bfd_enable),
             (
@@ -101,6 +106,7 @@ impl Ospf<Ospfv3> {
                 "/bfd/echo-receive-interval",
                 config_ospf_bfd_echo_receive_interval,
             ),
+            ("/bfd/detect-offload", config_ospf_bfd_detect_offload),
             (
                 "/area/interface/network-type",
                 config_ospfv3_interface_network_type,

--- a/zebra-rs/src/ospf/inst.rs
+++ b/zebra-rs/src/ospf/inst.rs
@@ -441,8 +441,9 @@ impl<V: OspfVersion> Ospf<V> {
             None => return,
         };
         // Echo role + intervals. `echo-mode` selects which half is active; the
-        // BFD instance further gates Echo to single-hop IPv4 with a live
-        // reflector, so this is inert for v3 (IPv6). No `echo-mode` ⇒ Echo off.
+        // BFD instance further gates Echo to single-hop with a live reflector.
+        // Both families work — v2 sessions run IPv4 Echo, v3 sessions IPv6
+        // Echo over the link-local pair. No `echo-mode` ⇒ Echo off.
         let (echo_mode, echo_rx_us, echo_tx_us) = match eff.echo_mode {
             Some(mode) => (
                 mode,
@@ -478,6 +479,7 @@ impl<V: OspfVersion> Ospf<V> {
             echo_mode,
             required_min_echo_rx_us: echo_rx_us,
             echo_transmit_us: echo_tx_us,
+            detect_offload: eff.detect_offload,
             ..crate::bfd::session::SessionParams::default()
         };
         let desired_params = desired.map(|_| params);

--- a/zebra-rs/src/ospf/link.rs
+++ b/zebra-rs/src/ospf/link.rs
@@ -236,6 +236,11 @@ pub struct OspfLinkBfdConfig {
     /// Advertised Required Min Echo RX Interval (milliseconds)
     /// (`receive` / `both`). `None` ⇒ inherit / [`DEFAULT_ECHO_INTERVAL_MS`].
     pub echo_receive_ms: Option<u32>,
+    /// Offload control-packet expiration detection (RFC 5880 §6.8.4) to the
+    /// per-interface XDP helper once the session is Up — detection immune to
+    /// daemon scheduling latency. `None` ⇒ inherit (hard default `false`:
+    /// detection in userspace).
+    pub detect_offload: Option<bool>,
 }
 
 /// The effective BFD settings for one interface after merging its
@@ -248,6 +253,7 @@ pub struct ResolvedBfd {
     pub echo_mode: Option<EchoMode>,
     pub echo_transmit_ms: u32,
     pub echo_receive_ms: u32,
+    pub detect_offload: bool,
 }
 
 impl OspfLinkBfdConfig {
@@ -270,6 +276,10 @@ impl OspfLinkBfdConfig {
                 .echo_receive_ms
                 .or(default.echo_receive_ms)
                 .unwrap_or(DEFAULT_ECHO_INTERVAL_MS),
+            detect_offload: self
+                .detect_offload
+                .or(default.detect_offload)
+                .unwrap_or(false),
         }
     }
 }
@@ -688,6 +698,7 @@ mod bfd_resolve_tests {
             echo_mode: Some(EchoMode::Receive),
             echo_transmit_ms: Some(100),
             echo_receive_ms: None, // → hard default 50
+            detect_offload: Some(true),
         };
 
         // Interface that sets nothing → inherits everything from the default.
@@ -697,16 +708,20 @@ mod bfd_resolve_tests {
         assert_eq!(inherit.echo_mode, Some(EchoMode::Receive));
         assert_eq!(inherit.echo_transmit_ms, 100);
         assert_eq!(inherit.echo_receive_ms, DEFAULT_ECHO_INTERVAL_MS);
+        assert!(inherit.detect_offload, "inherits the instance default");
 
-        // Interface overrides: opt out of the blanket enable, change echo role.
+        // Interface overrides: opt out of the blanket enable, change echo
+        // role, opt out of the instance-wide detect offload.
         let override_link = OspfLinkBfdConfig {
             enable: Some(false),
             echo_mode: Some(EchoMode::Both),
+            detect_offload: Some(false),
             ..OspfLinkBfdConfig::default()
         };
         let eff = override_link.resolve(&default);
         assert!(!eff.enable, "per-interface enable=false opts out");
         assert_eq!(eff.echo_mode, Some(EchoMode::Both));
+        assert!(!eff.detect_offload, "per-interface override wins");
         // Unset leaves still inherit the instance default.
         assert_eq!(eff.min_neighbor_state, NbrStateThreshold::Full);
         assert_eq!(eff.echo_transmit_ms, 100);
@@ -722,6 +737,7 @@ mod bfd_resolve_tests {
         assert_eq!(eff.echo_mode, None);
         assert_eq!(eff.echo_transmit_ms, DEFAULT_ECHO_INTERVAL_MS);
         assert_eq!(eff.echo_receive_ms, DEFAULT_ECHO_INTERVAL_MS);
+        assert!(!eff.detect_offload, "hard default: userspace detection");
     }
 }
 

--- a/zebra-rs/yang/zebra-ospf-bfd.yang
+++ b/zebra-rs/yang/zebra-ospf-bfd.yang
@@ -51,8 +51,21 @@ module zebra-ospf-bfd {
      neighbors are directly connected, so the session is always
      single-hop (UDP/3784, GTSM TTL=255) — there is no multihop knob.
 
-     OSPFv3 BFD runs over IPv6 link-local; Echo (single-hop IPv4) is
-     accepted for v3 but inert.";
+     OSPFv3 BFD runs over IPv6 link-local; Echo works there too — the
+     XDP helper reflects and originates both IPv4 and IPv6 Echo.";
+
+  revision 2026-06-12 {
+    description
+      "Add `detect-offload`: offload control-packet expiration detection
+       (the RFC 5880 §6.8.4 detection timer) to the per-interface
+       XDP/eBPF helper once the session is Up. Also correct the stale
+       `echo-mode` descriptions: Echo supports IPv6 (OSPFv3 link-local
+       sessions) since the helper gained the v6 reflect/originate paths;
+       it is no longer 'inert for v3'.";
+    reference
+      "RFC 5880 §6.8.4 (Calculating the Detection Time); RFC 5881 §5
+       (GTSM).";
+  }
 
   revision 2026-06-01 {
     description
@@ -132,9 +145,9 @@ module zebra-ospf-bfd {
       description
         "Enable the BFD Echo function (RFC 5880 §6.4) on this interface's
          single-hop sessions, choosing which half (or both) is active.
-         Backed by the per-interface `xdp-bfd-echo` XDP/eBPF helper.
-         Single-hop IPv4 only: honoured for OSPFv2, inert for OSPFv3
-         (IPv6). Absent ⇒ Echo off.";
+         Backed by the per-interface `xdp-bfd-echo` XDP/eBPF helper,
+         which handles both address families: IPv4 on OSPFv2, IPv6 (the
+         link-local pair) on OSPFv3. Absent ⇒ Echo off.";
     }
 
     leaf echo-transmit-interval {
@@ -155,6 +168,20 @@ module zebra-ospf-bfd {
         "Value advertised as `Required Min Echo RX Interval` (echo-mode
          `receive` / `both`) — the rate at which we tell the peer it may
          loop Echo back. Hard default 50 ms when unset.";
+    }
+
+    leaf detect-offload {
+      ext:help "Offload expiration detection to the XDP helper (kernel)";
+      type boolean;
+      description
+        "Once the session is Up, detect missing control packets in the
+         kernel: the per-interface XDP/eBPF helper re-arms a per-session
+         timer on every arriving BFD control packet (UDP/3784, TTL 255)
+         and drives the session Down with Control Detection Time Expired
+         when they stop (RFC 5880 §6.8.4) — immune to daemon scheduling
+         latency. The userspace detection timer stays armed as a
+         stretched backstop. Single-hop sessions only. Absent ⇒ false
+         (detection in userspace).";
     }
   }
 


### PR DESCRIPTION
## Summary

Extends the `xdp-bfd-echo` helper with an **in-kernel expiration watchdog** for standard async BFD (RFC 5880 §6.8.4). Once a session is Up, the XDP program observes each BFD control packet (UDP/3784, GTSM TTL/Hop-Limit 255, v4+v6), re-arms a per-session `bpf_timer` in the new `CONTROL_TIMERS` BTF map keyed by Your Discriminator, and `XDP_PASS`es the frame — the daemon still runs the full FSM on every packet; only the liveness timing moves to the kernel. On expiry the helper reports `detect-down` and the session goes Down with `Control Detection Time Expired`.

Detection becomes immune to daemon scheduling latency in both directions: no false Down when packets sit in a backlogged socket queue, no late Down waiting on the event loop — which is what makes aggressive detection times honest.

- **eBPF**: control-packet observe path (always-PASS), `EchoState` → shared `DetectState`, factored `kick_timer`; no packet rewrite, reuses the lab-proven `bpf_timer` recipe
- **Helper**: `detect-add <discr> <detect-us>` / `detect-del` in, `detect-down` out; bootstrap fallback before the first packet arms the timer; watchdog-only runs need no `AF_PACKET`/`cap_net_raw`
- **zebra-rs**: `detect_offload_reconcile` arms on the Up edge (pre-establishment `Your Disc = 0` can't be keyed), disarms on leaving Up, retunes on renegotiation; userspace timer kept as a 4× stretched backstop, restored on helper death (`HelperGone`); single-hop only
- **Config**: OSPFv2/v3 `bfd { detect-offload true; }` per interface + instance-level inheritance (echo-mode pattern); IS-IS/BGP knobs are follow-ups
- **Show**: `Detection runs in: kernel/XDP (900ms)` + JSON `kernel_detection_time_us`
- **Docs**: book BFD chapters swept to current status (detect-offload; IPv6 Echo no longer "IPv4 only"/"inert for v3"; IS-IS RFC 5882 §3.2 hold-down section; BGP `ebgp-multihop` wording) + YANG/comment consistency fixes

## Test plan

- [x] `cargo test --workspace --exclude bdd` — all green (1137 + per-crate targets)
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean; offload workspace clippy clean
- [x] BFD unit tests incl. new lifecycle coverage (arm/retune/disarm, detect-down → `ControlDetectionTimeExpired`, helper-death revert, live re-subscribe flips, refcounting); `yang_load` guard
- [x] eBPF object verified: `CONTROL_TIMERS`/`DetectState` in BTF, 8 `bpf_timer_*` helper calls
- [x] **Live veth validation** (`scripts/veth-detect-test.sh`): 600 ms watchdog armed, 8 control packets over 1.2 s → no premature fire (proves XDP re-arming; a broken observe path would trip the bootstrap fallback mid-stream), then `detect-down` ~600 ms after the stream stops — PASS
- [x] Echo reflect regression (`scripts/veth-test.sh`) — PASS

Generated with [Claude Code](https://claude.com/claude-code)