### PR TITLE
bgp: add neighbor ip-transparent (IP_TRANSPARENT session socket)

### DIFF
--- a/bdd/Makefile
+++ b/bdd/Makefile
@@ -226,6 +226,10 @@ bgp_port:
 	mkdir -p allure-results
 	cargo test --test cucumber -- --concurrency=1 --tags "@bgp_port"
 
+bgp_ip_transparent:
+	mkdir -p allure-results
+	cargo test --test cucumber -- --concurrency=1 --tags "@bgp_ip_transparent"
+
 generate:
 	rm -rf allure-report
 	allure generate
@@ -245,4 +249,4 @@ docs/%.md: tests/features/%.feature docs/feature2md.sh FORCE
 
 FORCE:
 
-.PHONY: ecmp_bfd_evict ospfv2_bfd_frr ospfv3_bfd_frr tilfa_bfd all run ibgp ebgp rr rib_static_ipv6 isis_ipv6 isis_srv6 isis_fragmentation_ipv6 isis_fragmentation_ipv4 isis_l1p2p isis_tilfa isis_l1l2 isis_redist isis_hello_auth_keychain isis_passive isis_afi_enable isis_endx_ipv6 isis_bfd_ipv6_p2p isis_bfd_ipv6_p2p_echo isis_bfd_ipv6_lan isis_bfd_ipv6_lan_echo isis_bfd_ipv4_p2p isis_bfd_ipv4_p2p_echo isis_bfd_ipv4_lan isis_bfd_ipv4_lan_echo ospf_clear_neighbor ospfv2_nssa ospfv2_stub ospfv2_tilfa ospfv3_nssa ospfv3_tilfa bgp_peer_down_cleanup bgp_ipv6_over_v4_session bgp_evpn_capability bgp_vrf_evpn_type5 bgp_route_map_match bgp_policy_dynamic_update bgp_table_map bgp_community bgp_neighbor_group bgp_unnumbered_neighbor nd_show bgp_interas_option_c bgp_interas_option_a bgp_interas_option_b bgp_interas_option_ab generate open docs FORCE
+.PHONY: ecmp_bfd_evict ospfv2_bfd_frr ospfv3_bfd_frr tilfa_bfd all run ibgp ebgp rr rib_static_ipv6 isis_ipv6 isis_srv6 isis_fragmentation_ipv6 isis_fragmentation_ipv4 isis_l1p2p isis_tilfa isis_l1l2 isis_redist isis_hello_auth_keychain isis_passive isis_afi_enable isis_endx_ipv6 isis_bfd_ipv6_p2p isis_bfd_ipv6_p2p_echo isis_bfd_ipv6_lan isis_bfd_ipv6_lan_echo isis_bfd_ipv4_p2p isis_bfd_ipv4_p2p_echo isis_bfd_ipv4_lan isis_bfd_ipv4_lan_echo ospf_clear_neighbor ospfv2_nssa ospfv2_stub ospfv2_tilfa ospfv3_nssa ospfv3_tilfa bgp_peer_down_cleanup bgp_ipv6_over_v4_session bgp_evpn_capability bgp_vrf_evpn_type5 bgp_route_map_match bgp_policy_dynamic_update bgp_table_map bgp_community bgp_neighbor_group bgp_unnumbered_neighbor nd_show bgp_interas_option_c bgp_interas_option_a bgp_interas_option_b bgp_interas_option_ab bgp_port bgp_ip_transparent generate open docs FORCE

--- a/bdd/docs/bgp_ip_transparent.md
+++ b/bdd/docs/bgp_ip_transparent.md
@@ -1,0 +1,56 @@
+# BGP neighbor ip-transparent (peer as an address the host does not own)
+
+## Overview
+
+As a network operator
+I want a BGP session sourced from an address the host does not own
+(`update-source <foreign-addr>`) to stay down by default — the kernel
+refuses the non-local bind — and to establish once `ip-transparent`
+puts IP_TRANSPARENT on the session socket, confirming the knob
+end-to-end (FRR 10.4 `neighbor X ip-transparent`, mirroring its
+bgp_tcp_ip_transparent topotest).
+
+## Test Topology
+
+```
+  ┌─────────────────────────────────────────┐
+  │                   br0                    │
+  └─────────────┬───────────────┬───────────┘
+                │               │
+           ┌────┴────┐     ┌────┴────────────┐
+           │   z1    │     │   z2            │
+           │ AS65001 │     │ AS65002         │
+           │ 10.0.0. │     │ 10.0.0.2/24     │
+           │  1/24   │     │ peers AS        │
+           │         │     │ 10.255.0.99     │
+           │         │     │ (owned by NOBODY)│
+           └─────────┘     └─────────────────┘
+```
+
+## Notes
+
+z2 dials z1 sourcing the session from 10.255.0.99 — an address that is
+configured on no interface anywhere. z1 peers with 10.255.0.99 and has
+a static return route toward it via z2's real address. z2 carries the
+TPROXY-style return-path policy routing (inbound TCP fwmark → table
+100 `local default dev lo`, installed by a harness step) so packets to
+the phantom address reach its sockets; the ONLY remaining blocker is
+the kernel's non-local bind / source checks, which is precisely what
+`ip-transparent` lifts — making it the discriminating knob of the
+scenario pair. z1's own active side is held by the eBGP connected
+check (10.255.0.99 is not on a connected subnet), so z2 owns the
+connect direction.
+
+## Config Files
+
+- z1.yaml: neighbor 10.255.0.99, static return route.
+- z2-base.yaml: update-source 10.255.0.99, no ip-transparent.
+- z2-transparent.yaml: same, plus `ip-transparent`.
+
+## Test Scenarios
+
+| Scenario | Result |
+|----------|--------|
+| A non-local update-source keeps the session down without ip-transparent | |
+| ip-transparent lets the session establish from the foreign address | |
+| Teardown topology | |

--- a/bdd/tests/configs/bgp_ip_transparent/z1.yaml
+++ b/bdd/tests/configs/bgp_ip_transparent/z1.yaml
@@ -1,0 +1,37 @@
+# z1 (AS 65001) — the "normal" end. Its neighbor is 10.255.0.99, an
+# address that is configured NOWHERE: z2 sources the session from it via
+# `update-source` + `ip-transparent`. The static route is z1's return
+# path toward that phantom address (SYN-ACK / data back to z2). z1 never
+# dials it — 10.255.0.99 is not on a connected subnet, so the eBGP
+# connected check holds z1's active side down and z2 owns the connect
+# direction; z1 only accepts.
+interface:
+- if-name: lo
+  ipv4:
+    address: 10.255.0.1/32
+router:
+  static:
+    ipv4:
+      route:
+      - prefix: 10.255.0.99/32
+        nexthop:
+        - address: 10.0.0.2
+  bgp:
+    global:
+      as: 65001
+      router-id: 10.255.0.1
+    timer:
+      adv-interval:
+        ibgp: 1
+        ebgp: 1
+    neighbor:
+    - remote-address: 10.255.0.99
+      afi-safi:
+      - name: ipv4
+        enabled: true
+      enabled: true
+      remote-as: 65002
+    afi-safi:
+    - name: ipv4
+      network:
+      - prefix: 10.1.1.1/32

--- a/bdd/tests/configs/bgp_ip_transparent/z2-base.yaml
+++ b/bdd/tests/configs/bgp_ip_transparent/z2-base.yaml
@@ -1,0 +1,28 @@
+# z2 (AS 65002) — the transparent end, WITHOUT `ip-transparent` yet. It
+# dials z1 (10.0.0.1, on the connected subnet) sourcing the session from
+# 10.255.0.99 — an address z2 does not own. Without IP_TRANSPARENT the
+# kernel refuses the bind() to the non-local update-source, every dial
+# fails, and the session must stay down: the negative half of the BDD.
+# The return-path policy routing (fwmark → table 100 local) is installed
+# by the harness step, so the socket option is the only missing piece.
+router:
+  bgp:
+    global:
+      as: 65002
+      router-id: 10.0.0.2
+    timer:
+      adv-interval:
+        ibgp: 1
+        ebgp: 1
+    neighbor:
+    - remote-address: 10.0.0.1
+      afi-safi:
+      - name: ipv4
+        enabled: true
+      enabled: true
+      remote-as: 65001
+      update-source: 10.255.0.99
+    afi-safi:
+    - name: ipv4
+      network:
+      - prefix: 10.2.2.2/32

--- a/bdd/tests/configs/bgp_ip_transparent/z2-transparent.yaml
+++ b/bdd/tests/configs/bgp_ip_transparent/z2-transparent.yaml
@@ -1,0 +1,27 @@
+# z2 with `ip-transparent` added (full restatement of z2-base): the
+# IP_TRANSPARENT socket option lets the kernel accept the bind() to the
+# non-local update-source 10.255.0.99 and emit the SYN with that source,
+# so the session to 10.0.0.1 establishes — peering as an address this
+# host does not own (FRR 10.4 `neighbor X ip-transparent`).
+router:
+  bgp:
+    global:
+      as: 65002
+      router-id: 10.0.0.2
+    timer:
+      adv-interval:
+        ibgp: 1
+        ebgp: 1
+    neighbor:
+    - remote-address: 10.0.0.1
+      afi-safi:
+      - name: ipv4
+        enabled: true
+      enabled: true
+      remote-as: 65001
+      update-source: 10.255.0.99
+      ip-transparent: {}
+    afi-safi:
+    - name: ipv4
+      network:
+      - prefix: 10.2.2.2/32

--- a/bdd/tests/cucumber.rs
+++ b/bdd/tests/cucumber.rs
@@ -1421,6 +1421,58 @@ async fn drop_bfd_control_packets(world: &mut World, namespace: String) {
     );
 }
 
+/// Make a namespace deliver inbound TCP destined to addresses it does not
+/// own: mark all inbound TCP in mangle PREROUTING, send marked packets to
+/// routing table 100, and give that table a single `local default dev lo`
+/// route — the TPROXY-style policy-routing recipe from FRR's
+/// bgp_tcp_ip_transparent topotest. With this in place, the only thing
+/// still standing between a `neighbor X update-source <foreign-addr>` BGP
+/// session and Established is IP_TRANSPARENT on the socket (the kernel's
+/// bind / source-address checks) — which is exactly what `ip-transparent`
+/// must provide, so the feature is isolated as the discriminating knob.
+/// Per-netns iptables rules, ip rules and routing tables vanish with the
+/// namespace, so no cleanup step is needed.
+#[given(expr = "I enable transparent return-path routing in namespace {string}")]
+#[when(expr = "I enable transparent return-path routing in namespace {string}")]
+async fn enable_transparent_return_path(world: &mut World, namespace: String) {
+    let scoped = world.ns(&namespace);
+    netns::exec_in_netns(
+        &scoped,
+        "iptables",
+        &[
+            "-t",
+            "mangle",
+            "-A",
+            "PREROUTING",
+            "-p",
+            "tcp",
+            "-j",
+            "MARK",
+            "--set-mark",
+            "0x100",
+        ],
+    )
+    .await
+    .unwrap_or_else(|e| panic!("Failed to install transparent mangle MARK rule: {}", e));
+    netns::exec_in_netns(
+        &scoped,
+        "ip",
+        &["rule", "add", "fwmark", "0x100", "lookup", "100"],
+    )
+    .await
+    .unwrap_or_else(|e| panic!("Failed to add fwmark ip rule: {}", e));
+    netns::exec_in_netns(
+        &scoped,
+        "ip",
+        &[
+            "route", "add", "local", "default", "dev", "lo", "table", "100",
+        ],
+    )
+    .await
+    .unwrap_or_else(|e| panic!("Failed to add local default route in table 100: {}", e));
+    println!("✓ Transparent return-path routing enabled in {}", scoped);
+}
+
 /// Remove the BFD-control drop rules installed by the step above (both address
 /// families), letting the session re-establish and IS-IS lift the hold-down.
 #[when(expr = "I restore bfd control packets in namespace {string}")]

--- a/bdd/tests/features/bgp_ip_transparent.feature
+++ b/bdd/tests/features/bgp_ip_transparent.feature
@@ -1,0 +1,77 @@
+@serial
+@bgp_ip_transparent
+Feature: BGP neighbor ip-transparent (peer as an address the host does not own)
+  As a network operator
+  I want a BGP session sourced from an address the host does not own
+  (`update-source <foreign-addr>`) to stay down by default — the kernel
+  refuses the non-local bind — and to establish once `ip-transparent`
+  puts IP_TRANSPARENT on the session socket, confirming the knob
+  end-to-end (FRR 10.4 `neighbor X ip-transparent`, mirroring its
+  bgp_tcp_ip_transparent topotest).
+
+  Test Topology:
+  ```
+  ┌─────────────────────────────────────────┐
+  │                   br0                    │
+  └─────────────┬───────────────┬───────────┘
+                │               │
+           ┌────┴────┐     ┌────┴────────────┐
+           │   z1    │     │   z2            │
+           │ AS65001 │     │ AS65002         │
+           │ 10.0.0. │     │ 10.0.0.2/24     │
+           │  1/24   │     │ peers AS        │
+           │         │     │ 10.255.0.99     │
+           │         │     │ (owned by NOBODY)│
+           └─────────┘     └─────────────────┘
+  ```
+
+  z2 dials z1 sourcing the session from 10.255.0.99 — an address that is
+  configured on no interface anywhere. z1 peers with 10.255.0.99 and has
+  a static return route toward it via z2's real address. z2 carries the
+  TPROXY-style return-path policy routing (inbound TCP fwmark → table
+  100 `local default dev lo`, installed by a harness step) so packets to
+  the phantom address reach its sockets; the ONLY remaining blocker is
+  the kernel's non-local bind / source checks, which is precisely what
+  `ip-transparent` lifts — making it the discriminating knob of the
+  scenario pair. z1's own active side is held by the eBGP connected
+  check (10.255.0.99 is not on a connected subnet), so z2 owns the
+  connect direction.
+
+  Config files:
+  - z1.yaml: neighbor 10.255.0.99, static return route.
+  - z2-base.yaml: update-source 10.255.0.99, no ip-transparent.
+  - z2-transparent.yaml: same, plus `ip-transparent`.
+
+  Scenario: A non-local update-source keeps the session down without ip-transparent
+    Given a clean test environment
+    When I create bridge "br0"
+    And I create namespace "z1" with IP "10.0.0.1/24" on bridge "br0"
+    And I create namespace "z2" with IP "10.0.0.2/24" on bridge "br0"
+    And I enable transparent return-path routing in namespace "z2"
+    And I start zebra-rs in namespace "z1"
+    And I start zebra-rs in namespace "z2"
+    And I apply config "z1.yaml" to namespace "z1"
+    And I apply config "z2-base.yaml" to namespace "z2"
+    And I wait 10 seconds for BGP to operate
+    Then BGP session in "z2" to "10.0.0.1" should not be "Established"
+    And BGP session in "z1" to "10.255.0.99" should not be "Established"
+    And BGP route in "z2" does not have "10.1.1.1/32"
+
+  Scenario: ip-transparent lets the session establish from the foreign address
+    Given the test topology exists
+    When I apply config "z2-transparent.yaml" to namespace "z2"
+    And I wait 20 seconds for BGP to operate
+    Then BGP session in "z2" to "10.0.0.1" should be "Established"
+    And BGP session in "z1" to "10.255.0.99" should be "Established"
+    And BGP route in "z1" has "10.2.2.2/32"
+    And BGP route in "z2" has "10.1.1.1/32"
+    And show command "show bgp neighbors" in namespace "z2" should contain "IP transparent enabled"
+
+  Scenario: Teardown topology
+    Given the test topology exists
+    When I stop zebra-rs in namespace "z1"
+    And I stop zebra-rs in namespace "z2"
+    And I delete namespace "z1"
+    And I delete namespace "z2"
+    And I delete bridge "br0"
+    Then the test environment should be clean

--- a/book/src/SUMMARY.md
+++ b/book/src/SUMMARY.md
@@ -27,6 +27,7 @@
   - [Enforce First AS](ch-02-15-bgp-enforce-first-as.md)
   - [Well-Known Communities](ch-02-24-bgp-well-known-communities.md)
   - [disable-connected-check](ch-02-16-bgp-disable-connected-check.md)
+  - [ip-transparent (non-local update-source)](ch-02-28-bgp-ip-transparent.md)
   - [SRv6 Encapsulation Type (per-neighbor)](ch-02-17-bgp-srv6-encapsulation-type.md)
   - [Timer Configuration](ch-02-03-bgp-timers.md)
   - [L3VPN and Per-VRF Labels](ch-02-04-bgp-l3vpn.md)

--- a/book/src/ch-02-16-bgp-disable-connected-check.md
+++ b/book/src/ch-02-16-bgp-disable-connected-check.md
@@ -99,7 +99,12 @@ set router bgp neighbor 10.255.0.2 disable-connected-check
 ```
 
 `update-source` is normally configured alongside it so the session sources
-from the loopback the neighbor expects.
+from the loopback the neighbor expects. If that source is an address the
+host does not even own (container peering, a VRRP VIP), you additionally
+need [`ip-transparent`](ch-02-28-bgp-ip-transparent.md) — the two knobs
+solve complementary halves: this one lifts the *neighbor-side* connected
+check, ip-transparent lifts the kernel's *local-side* non-local-bind
+check.
 
 Toggling `disable-connected-check` on a session that is already up bounces
 it (the same teardown `clear bgp <peer>` performs): enabling it lets a held

--- a/book/src/ch-02-28-bgp-ip-transparent.md
+++ b/book/src/ch-02-28-bgp-ip-transparent.md
@@ -1,0 +1,118 @@
+# ip-transparent (peer as an address you don't own)
+
+`ip-transparent` sets the **IP_TRANSPARENT** (IPv4) / **IPV6_TRANSPARENT**
+(IPv6) socket option on one neighbor's TCP session. With it, the session
+can use a local address that is **not configured anywhere on the host**:
+normally the kernel rejects a `bind()` to a non-local address and refuses
+to emit packets with a non-local source; IP_TRANSPARENT (which requires
+`CAP_NET_ADMIN`) bypasses both checks. The address itself comes from
+[`update-source`](ch-02-11-bgp-ttl-security.md), so the two are configured
+together: **`update-source` names the address you don't own,
+`ip-transparent` makes the kernel accept it.**
+
+This mirrors FRR 10.4 `neighbor PEER ip-transparent`
+(FRRouting/frr PR #18789).
+
+## When you need it
+
+- **Containers** — bgpd runs in a netns that does not have the router's
+  loopback plumbed, but must peer *as* the loopback address.
+- **Hitless VRRP/keepalived takeover** — the standby pre-binds the virtual
+  IP and establishes immediately after failover, instead of waiting for
+  the VIP to be plumbed and then re-dialing. Pairs naturally with
+  `passive`: pre-bind, wait, accept once traffic arrives.
+- **Transparent firewalls** — a bump-in-the-wire box terminating or
+  originating BGP with addresses that belong to the devices around it.
+
+## The caveat: return traffic is your problem
+
+IP_TRANSPARENT only liberates the **local socket**. The kernel still has
+to deliver inbound packets destined to the non-local address to the
+daemon, and nothing on the host does that by default — outbound SYNs
+leave with the foreign source, but the SYN-ACK coming back is *forwarded*
+(or dropped), never delivered locally. You need one of the usual
+mechanisms on top:
+
+- an AnyIP-style local route: `ip route add local 10.255.0.0/24 dev lo`;
+- TPROXY-style policy routing:
+
+  ```
+  iptables -t mangle -A PREROUTING -p tcp -j MARK --set-mark 0x100
+  ip rule add fwmark 0x100 lookup 100
+  ip route add local default dev lo table 100
+  ```
+
+- or, in the VRRP case, the fact that the peer simply does not route to
+  the VIP until this node owns it.
+
+Path-side anti-spoofing (uRPF on the upstream, etc.) must also tolerate
+the non-local source.
+
+## Configuration
+
+`ip-transparent` is a per-neighbor presence flag:
+
+```yaml
+router:
+  bgp:
+    global:
+      as: 65002
+      router-id: 10.0.0.2
+    neighbor:
+    - remote-address: 10.0.0.1
+      remote-as: 65001
+      enabled: true
+      afi-safi:
+      - name: ipv4
+        enabled: true
+      update-source: 10.255.0.99   # an address this host does NOT own
+      ip-transparent: {}
+```
+
+The CLI form is the same path:
+
+```
+set router bgp neighbor 10.0.0.1 ip-transparent
+```
+
+Like the other per-neighbor knobs, `ip-transparent` can also be set on a
+[neighbor-group](ch-02-26-bgp-neighbor-group.md) and inherited by every
+member; a statement on the neighbor itself wins.
+
+Semantics worth knowing:
+
+- On the **active connect** path the option is applied only when
+  `update-source` is also configured (matching FRR's gate) — without a
+  foreign source address there is nothing for it to liberate. A
+  `setsockopt` failure (daemon lacking `CAP_NET_ADMIN`) fails the dial
+  loudly rather than surfacing as a confusing `EADDRNOTAVAIL` from the
+  bind.
+- The flag is also folded onto the **BGP listening sockets** while any
+  neighbor of that address family has it, so a passively accepted session
+  destined to a non-local address (e.g. one steered to the daemon with
+  the TPROXY recipe above) can be accepted and answered. The option is
+  inert for ordinary inbound sessions. (FRR leaves its listener alone;
+  zebra-rs covers the passive scenarios too.)
+- **Toggling the flag bounces a live session** (the same teardown
+  `clear bgp <peer>` performs): the option must be on the socket before
+  `bind()`/`connect()`, so only a reconnect can apply it.
+- The connected check still applies: a single-hop eBGP neighbor that is
+  not on a connected subnet additionally needs
+  [`disable-connected-check`](ch-02-16-bgp-disable-connected-check.md)
+  (or `ebgp-multihop` where genuinely multi-hop).
+
+## Verification
+
+`show ip bgp neighbor <addr>` reports the active policy:
+
+```
+  IP transparent enabled (session may use a non-local update-source address)
+```
+
+The classic symptom of a **missing** `ip-transparent` is a session with a
+non-local `update-source` that never leaves `Active`/`Connect`: every dial
+dies on `bind()` with `EADDRNOTAVAIL` before a single SYN is sent. The
+classic symptom of missing **return-path delivery** is the opposite —
+SYNs leave with the foreign source (visible in `tcpdump`), the peer
+answers, and the SYN-ACK is forwarded onward or dropped instead of
+reaching the daemon.

--- a/zebra-rs/src/bgp/config.rs
+++ b/zebra-rs/src/bgp/config.rs
@@ -162,6 +162,9 @@ fn config_peer(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Option<()> {
     // current minimum without the per-leaf `/tcp-mss` delete firing (the
     // same gap `clear_peer_listener_auth` covers for MD5/AO).
     apply_tcp_mss_refresh_all(bgp);
+    // Same reconciliation for the listener IP_TRANSPARENT union — the
+    // deleted peer may have been the last one holding the flag.
+    apply_ip_transparent_refresh_all(bgp);
     Some(())
 }
 
@@ -2310,6 +2313,112 @@ pub(super) fn apply_disable_connected_check(peer: &mut Peer, want: bool) -> bool
     !matches!(peer.state, super::peer::State::Idle)
 }
 
+/// `[no] router bgp neighbor <addr> ip-transparent` (presence container,
+/// FRR 10.4 PR #18789) — set IP_TRANSPARENT / IPV6_TRANSPARENT on this
+/// neighbor's TCP socket so the session can use a local address the
+/// host does not own (the address itself comes from `update-source`;
+/// the two are used together). Consumed at connect time by
+/// `peer_connect` (before bind, gated on update-source — FRR's
+/// both-flags gate) and reconciled onto the shared listeners by
+/// [`apply_ip_transparent_refresh_all`] so a TPROXY-steered passive
+/// session to a non-local address can be answered. Like the sibling
+/// TTL knobs, a change on a live session bounces it (`Event::Stop`,
+/// FRR `peer_change_reset`): the option must be on the socket before
+/// bind()/connect(), so only a reconnect can apply it. An Idle peer
+/// picks it up on its first connect.
+fn config_ip_transparent(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Option<()> {
+    let addr = args.addr()?;
+    let (ident, bounce) = {
+        let peer = bgp.peers.get_mut(&addr)?;
+        // Record the verbatim statement (a presence flag: presence
+        // means "on"), then resolve through the neighbor-group
+        // precedence: the explicit statement wins, a Delete falls back
+        // to the group's opinion (or the off default).
+        peer.config.knobs_explicit.ip_transparent = op.is_set().then_some(true);
+        let want = super::neighbor_group::resolve_knob(&bgp.neighbor_groups, &peer.config, |k| {
+            k.ip_transparent
+        })
+        .unwrap_or(false);
+        (peer.ident, apply_ip_transparent(peer, want))
+    };
+    // Reconcile the listeners unconditionally — cheap, idempotent, and
+    // immune to the diff-gate (the per-AF union may change even when
+    // this peer's resolved value did not, e.g. a redundant statement
+    // after a group flip).
+    apply_ip_transparent_refresh_all(bgp);
+    if bounce {
+        let _ = bgp
+            .tx
+            .try_send(super::inst::Message::Event(ident, super::peer::Event::Stop));
+    }
+    Some(())
+}
+
+/// Write a resolved `ip-transparent` value onto the peer, preserving
+/// the per-neighbor ritual: the no-change diff-gate, `start()` for a
+/// dormant peer, and the bounce-if-live decision (returned to the
+/// caller, which owns the `Event::Stop` send — only an established /
+/// in-progress session needs the explicit bounce; bouncing an Idle peer
+/// here could race the idle-hold timer `start()` just armed and strand
+/// it). Shared by the per-neighbor callback and the neighbor-group
+/// sweep.
+pub(super) fn apply_ip_transparent(peer: &mut Peer, want: bool) -> bool {
+    if peer.config.transport.ip_transparent == want {
+        // No actual change — don't disturb a live session.
+        return false;
+    }
+    peer.config.transport.ip_transparent = want;
+    peer.start();
+    !matches!(peer.state, super::peer::State::Idle)
+}
+
+/// Reconcile IP_TRANSPARENT / IPV6_TRANSPARENT on the shared BGP
+/// listeners: set while any neighbor of the address family resolves
+/// `ip-transparent` on, cleared when none does. A listening socket
+/// carries one flag for all peers, so this is the per-AF union — the
+/// option is inert for ordinary inbound connections, it only also
+/// permits TPROXY-steered connections destined to non-local addresses
+/// to be accepted and answered. A neighbor-group opinion counts toward
+/// both families: a dynamic (listen-range) member inherits it and must
+/// find the flag on the listener *before* its SYN arrives — i.e.
+/// before any member peer exists. Safe to call repeatedly; silent when
+/// a listener fd is not bound yet — `listen()` re-runs it once the
+/// bind completes.
+pub(super) fn apply_ip_transparent_refresh_all(bgp: &mut Bgp) {
+    let mut want_v4 = false;
+    let mut want_v6 = false;
+    for (_, peer) in bgp.peers.iter_all() {
+        if peer.config.transport.ip_transparent {
+            if peer.address.is_ipv4() {
+                want_v4 = true;
+            } else {
+                want_v6 = true;
+            }
+        }
+    }
+    if bgp
+        .neighbor_groups
+        .values()
+        .any(|g| g.knobs.ip_transparent == Some(true))
+    {
+        want_v4 = true;
+        want_v6 = true;
+    }
+    for (fd, is_v4, want) in [
+        (bgp.listen_fd_v4, true, want_v4),
+        (bgp.listen_fd_v6, false, want_v6),
+    ] {
+        let Some(fd) = fd else { continue };
+        if let Err(e) = super::transparent::set_ip_transparent(fd, is_v4, want) {
+            tracing::warn!(
+                error = %e,
+                want,
+                "bgp: failed to set IP_TRANSPARENT on BGP listener (CAP_NET_ADMIN required)",
+            );
+        }
+    }
+}
+
 fn config_peer_tcp_md5_password(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Option<()> {
     let addr = if let Some(addr) = args.v4addr() {
         IpAddr::V4(addr)
@@ -2693,6 +2802,10 @@ impl Bgp {
             super::neighbor_group::config_neighbor_group_disable_connected_check,
         );
         self.callback_add(
+            "/router/bgp/neighbor-group/ip-transparent",
+            super::neighbor_group::config_neighbor_group_ip_transparent,
+        );
+        self.callback_add(
             "/router/bgp/neighbor-group/passive",
             super::neighbor_group::config_neighbor_group_passive,
         );
@@ -2936,6 +3049,10 @@ impl Bgp {
         // zebra-bgp-transport.yang. Exempts a single-hop eBGP neighbor from
         // the directly-connected-network check (Peer::connected_check_ok).
         self.callback_peer("/disable-connected-check", config_disable_connected_check);
+        // FRR 10.4 `neighbor X ip-transparent` from
+        // zebra-bgp-transport.yang: IP_TRANSPARENT on the session socket
+        // so a non-local `update-source` can be used.
+        self.callback_peer("/ip-transparent", config_ip_transparent);
         self.callback_peer("/tcp-md5/password", config_peer_tcp_md5_password);
         self.callback_peer("/tcp-md5/encoding", config_peer_tcp_md5_encoding);
         // FRR / IOS-XR flat alias from zebra-bgp-password.yang. Same
@@ -4033,6 +4150,106 @@ mod neighbor_group_wiring_tests {
             drain_stop_events(&mut bgp).len(),
             1,
             "disabling on a live session must bounce it",
+        );
+    }
+
+    /// `ip-transparent` is a presence flag with FRR `peer_change_reset`
+    /// semantics: Set/Delete toggle it, a change to a live session is
+    /// bounced (the option must be on the socket before bind/connect),
+    /// and a no-op set does not bounce.
+    #[tokio::test]
+    async fn ip_transparent_toggles_field_and_bounces_live_session() {
+        use crate::bgp::peer::State;
+        let mut bgp = fresh_bgp();
+        config_peer(&mut bgp, arg_words(&["10.0.0.1"]), ConfigOp::Set).unwrap();
+        config_remote_as(&mut bgp, arg_words(&["10.0.0.1", "65001"]), ConfigOp::Set).unwrap();
+        let _ = drain_stop_events(&mut bgp);
+        bgp.peers.get_mut(&peer_addr()).unwrap().state = State::Established;
+
+        config_ip_transparent(&mut bgp, arg_words(&["10.0.0.1"]), ConfigOp::Set).unwrap();
+        assert!(
+            bgp.peers
+                .get(&peer_addr())
+                .unwrap()
+                .config
+                .transport
+                .ip_transparent,
+            "set must enable the flag",
+        );
+        assert_eq!(
+            drain_stop_events(&mut bgp).len(),
+            1,
+            "enabling on a live session must bounce it",
+        );
+
+        config_ip_transparent(&mut bgp, arg_words(&["10.0.0.1"]), ConfigOp::Set).unwrap();
+        assert!(
+            drain_stop_events(&mut bgp).is_empty(),
+            "a no-op set must not bounce the session",
+        );
+
+        config_ip_transparent(&mut bgp, arg_words(&["10.0.0.1"]), ConfigOp::Delete).unwrap();
+        assert!(
+            !bgp.peers
+                .get(&peer_addr())
+                .unwrap()
+                .config
+                .transport
+                .ip_transparent,
+            "delete must clear the flag",
+        );
+        assert_eq!(
+            drain_stop_events(&mut bgp).len(),
+            1,
+            "disabling on a live session must bounce it",
+        );
+    }
+
+    /// The group spelling of `ip-transparent` propagates to members
+    /// through the explicit-wins resolution: a group Set flips a member
+    /// without its own statement; the member's explicit statement keeps
+    /// it on across a group Delete.
+    #[tokio::test]
+    async fn neighbor_group_ip_transparent_inherits_and_explicit_wins() {
+        let mut bgp = fresh_bgp();
+        config_peer(&mut bgp, arg_words(&["10.0.0.1"]), ConfigOp::Set).unwrap();
+        config_remote_as(&mut bgp, arg_words(&["10.0.0.1", "65001"]), ConfigOp::Set).unwrap();
+        config_peer_neighbor_group(&mut bgp, arg_words(&["10.0.0.1", "G"]), ConfigOp::Set).unwrap();
+        let _ = drain_stop_events(&mut bgp);
+
+        super::super::neighbor_group::config_neighbor_group_ip_transparent(
+            &mut bgp,
+            arg_words(&["G"]),
+            ConfigOp::Set,
+        )
+        .unwrap();
+        assert!(
+            bgp.peers
+                .get(&peer_addr())
+                .unwrap()
+                .config
+                .transport
+                .ip_transparent,
+            "a member without its own statement must inherit the group's flag",
+        );
+
+        // An explicit per-neighbor statement survives the group losing
+        // its opinion.
+        config_ip_transparent(&mut bgp, arg_words(&["10.0.0.1"]), ConfigOp::Set).unwrap();
+        super::super::neighbor_group::config_neighbor_group_ip_transparent(
+            &mut bgp,
+            arg_words(&["G"]),
+            ConfigOp::Delete,
+        )
+        .unwrap();
+        assert!(
+            bgp.peers
+                .get(&peer_addr())
+                .unwrap()
+                .config
+                .transport
+                .ip_transparent,
+            "the explicit per-neighbor flag must outlive the group opinion",
         );
     }
 

--- a/zebra-rs/src/bgp/inst.rs
+++ b/zebra-rs/src/bgp/inst.rs
@@ -1834,6 +1834,11 @@ impl Bgp {
         // not clamp the listener, so a passively-accepted peer would
         // otherwise negotiate the default MSS.
         super::config::apply_tcp_mss_refresh_all(self);
+        // And the listener IP_TRANSPARENT union (`ip-transparent`
+        // knobs that were configured before the bind), so a
+        // TPROXY-steered passive session to a non-local address can be
+        // accepted and answered.
+        super::config::apply_ip_transparent_refresh_all(self);
 
         Ok(())
     }

--- a/zebra-rs/src/bgp/mod.rs
+++ b/zebra-rs/src/bgp/mod.rs
@@ -34,6 +34,8 @@ pub mod ttl;
 
 pub mod mss;
 
+pub mod transparent;
+
 pub mod policy;
 pub use policy::*;
 

--- a/zebra-rs/src/bgp/neighbor_group.rs
+++ b/zebra-rs/src/bgp/neighbor_group.rs
@@ -51,9 +51,9 @@ use crate::config::{Args, ConfigOp};
 /// field-wise `explicit.or(group)` via [`resolve_knob`]; when both are
 /// `None` the per-knob default applies. Presence-style knobs
 /// (`ttl-security`, `as-override`, `remove-private-as`,
-/// `enforce-first-as`, `disable-connected-check`, `allowas-in`) can
-/// only be stated "on" — exactly the expressiveness the per-neighbor
-/// YANG has.
+/// `enforce-first-as`, `disable-connected-check`, `ip-transparent`,
+/// `allowas-in`) can only be stated "on" — exactly the expressiveness
+/// the per-neighbor YANG has.
 #[derive(Debug, Default, Clone, PartialEq)]
 pub struct InheritableKnobs {
     pub passive: Option<bool>,
@@ -64,6 +64,7 @@ pub struct InheritableKnobs {
     pub tcp_mss: Option<u16>,
     pub password: Option<String>,
     pub disable_connected_check: Option<bool>,
+    pub ip_transparent: Option<bool>,
     pub policy_in: Option<String>,
     pub policy_out: Option<String>,
     pub prefix_set_in: Option<String>,
@@ -382,6 +383,34 @@ pub fn config_neighbor_group_disable_connected_check(
             resolve_knob(groups, &peer.config, |k| k.disable_connected_check).unwrap_or(false);
         super::config::apply_disable_connected_check(peer, want)
     });
+    Some(())
+}
+
+/// `set router bgp neighbor-group <name> ip-transparent`
+/// (presence container).
+///
+/// Stores the opinion and re-resolves every member through the same
+/// apply ritual as the per-neighbor callback (diff-gate, start,
+/// bounce-if-live), then reconciles the listener flag — the group
+/// opinion alone counts toward the per-AF union so a dynamic
+/// (listen-range) member finds IP_TRANSPARENT on the listener before
+/// it materializes.
+pub fn config_neighbor_group_ip_transparent(
+    bgp: &mut Bgp,
+    mut args: Args,
+    op: ConfigOp,
+) -> Option<()> {
+    let name = args.string()?;
+    bgp.neighbor_groups
+        .entry(name.clone())
+        .or_default()
+        .knobs
+        .ip_transparent = op.is_set().then_some(true);
+    sweep_members(bgp, &name, |groups, peer| {
+        let want = resolve_knob(groups, &peer.config, |k| k.ip_transparent).unwrap_or(false);
+        super::config::apply_ip_transparent(peer, want)
+    });
+    super::config::apply_ip_transparent_refresh_all(bgp);
     Some(())
 }
 
@@ -924,6 +953,7 @@ pub(super) fn apply_inherited(
         tcp_mss: resolve_knob(groups, &peer.config, |k| k.tcp_mss),
         password: resolve_knob(groups, &peer.config, |k| k.password.clone()),
         disable_connected_check: resolve_knob(groups, &peer.config, |k| k.disable_connected_check),
+        ip_transparent: resolve_knob(groups, &peer.config, |k| k.ip_transparent),
         policy_in: resolve_knob(groups, &peer.config, |k| k.policy_in.clone()),
         policy_out: resolve_knob(groups, &peer.config, |k| k.policy_out.clone()),
         prefix_set_in: resolve_knob(groups, &peer.config, |k| k.prefix_set_in.clone()),
@@ -947,6 +977,7 @@ pub(super) fn apply_inherited(
         tcp_mss,
         password,
         disable_connected_check,
+        ip_transparent,
         policy_in,
         policy_out,
         prefix_set_in,
@@ -972,6 +1003,11 @@ pub(super) fn apply_inherited(
         peer,
         disable_connected_check.unwrap_or(false),
     );
+    // No listener-refresh outcome flag needed: the listener union folds
+    // group opinions in directly, so a peer↔group binding change alone
+    // never alters it — only the knob callbacks / group delete do, and
+    // those reconcile the listeners themselves.
+    bounce |= super::config::apply_ip_transparent(peer, ip_transparent.unwrap_or(false));
     super::config::apply_passive(peer, passive.unwrap_or(false));
     super::config::apply_allowas_in(peer, allowas_in);
     super::config::apply_as_override(peer, as_override.unwrap_or(false));
@@ -1042,6 +1078,10 @@ pub(super) fn sweep_members_inherit(bgp: &mut Bgp, name: &str) {
     if mss_refresh {
         super::config::apply_tcp_mss_refresh_all(bgp);
     }
+    // Unconditional (cheap, idempotent): this sweep also serves the
+    // group-delete cascade, where a deleted `ip-transparent` opinion
+    // must drop out of the listener union.
+    super::config::apply_ip_transparent_refresh_all(bgp);
     for addr in md5_addrs {
         super::config::apply_md5_refresh_for(bgp, addr);
     }

--- a/zebra-rs/src/bgp/peer.rs
+++ b/zebra-rs/src/bgp/peer.rs
@@ -251,6 +251,18 @@ pub struct PeerTransportConfig {
     /// for multihop / GTSM sessions (they are never gated). Consulted by
     /// [`Peer::connected_check_ok`]. See `zebra-bgp-transport.yang`.
     pub disable_connected_check: bool,
+    /// `ip-transparent` (FRR 10.4): set IP_TRANSPARENT /
+    /// IPV6_TRANSPARENT on this neighbor's TCP socket so the session
+    /// can use a local address the host does not own. Applied on the
+    /// active connect socket before bind() (`peer_connect`, gated on
+    /// `update_source` being set — without a foreign source there is
+    /// nothing to liberate) and folded onto the shared listener while
+    /// any peer of the address family has it
+    /// (`config::apply_ip_transparent_refresh_all`). A change bounces a
+    /// live session (FRR `peer_change_reset`) — the option must precede
+    /// bind()/connect(). See `super::transparent` and
+    /// `zebra-bgp-transport.yang`.
+    pub ip_transparent: bool,
     // TCP MD5 (RFC 2385) shared secret. When Some, installed on the
     // listening socket (for the peer's address) and on the active
     // TcpSocket before connect(). The encoding determines how the
@@ -2089,6 +2101,9 @@ pub fn peer_start_connection(peer: &mut Peer) -> Task<()> {
     // `neighbor X port <1-65535>` — TCP destination port for the dial;
     // the IANA 179 unless overridden.
     let port = peer.config.transport.port.unwrap_or(BGP_PORT);
+    // `ip-transparent` — IP_TRANSPARENT before bind so a non-local
+    // `update-source` is accepted (see `peer_connect`).
+    let ip_transparent = peer.config.transport.ip_transparent;
     let ctx = peer.ctx.clone();
     Task::spawn(async move {
         let tx = tx.clone();
@@ -2115,6 +2130,7 @@ pub fn peer_start_connection(peer: &mut Peer) -> Task<()> {
             ao_key,
             ttl,
             tcp_mss,
+            ip_transparent,
         )
         .await;
         match result {
@@ -2138,6 +2154,7 @@ async fn peer_connect(
     ao_key: Option<super::auth::ResolvedAoKey>,
     ttl: u8,
     tcp_mss: Option<u16>,
+    ip_transparent: bool,
 ) -> std::io::Result<TcpStream> {
     // Address family of the source must match the remote when specified.
     if let Some(src) = update_source
@@ -2173,6 +2190,26 @@ async fn peer_connect(
             key.recv_id,
             key.include_tcp_options,
         )?;
+    }
+
+    // IP_TRANSPARENT must precede the bind: it is what makes the kernel
+    // accept a bind to the non-local `update-source` address and emit
+    // the SYN with that source. Gated on update-source being present —
+    // without a foreign source there is nothing to liberate (FRR's
+    // bgp_connect() applies the same both-flags gate). NOT best-effort:
+    // a failure (no CAP_NET_ADMIN) is surfaced as a dial failure,
+    // because the bind below would fail with EADDRNOTAVAIL anyway and
+    // this error names the actual cause.
+    if ip_transparent && update_source.is_some() {
+        super::transparent::set_ip_transparent(socket.as_raw_fd(), remote.is_ipv4(), true)
+            .inspect_err(|e| {
+                tracing::warn!(
+                    peer = %remote.ip(),
+                    error = %e,
+                    "bgp: failed to set IP_TRANSPARENT before connect \
+                     (CAP_NET_ADMIN required); cannot dial from a non-local update-source",
+                );
+            })?;
     }
 
     if let Some(src) = update_source {

--- a/zebra-rs/src/bgp/show.rs
+++ b/zebra-rs/src/bgp/show.rs
@@ -1822,6 +1822,11 @@ struct Neighbor<'a> {
     /// e.g. a loopback, may be dialed at TTL 1). Mirrors
     /// `peer.config.transport.disable_connected_check`.
     disable_connected_check: bool,
+    /// `ip-transparent` (FRR 10.4): when true, IP_TRANSPARENT /
+    /// IPV6_TRANSPARENT is set on the session socket so a non-local
+    /// `update-source` address can be used. Mirrors
+    /// `peer.config.transport.ip_transparent`.
+    ip_transparent: bool,
     /// Name of the IOS-XR-style `neighbor-group` this peer inherits
     /// from, if any. `remote_as_inherited` says whether the peer's
     /// `remote_as` actually came off the group (vs. an explicit
@@ -2015,6 +2020,7 @@ fn fetch(peer: &Peer) -> Neighbor<'_> {
             None
         },
         disable_connected_check: peer.config.transport.disable_connected_check,
+        ip_transparent: peer.config.transport.ip_transparent,
         neighbor_group: peer.config.neighbor_group.clone(),
         remote_as_inherited: peer.config.remote_as_inherited,
         nd_discovered_secs_ago,
@@ -2248,6 +2254,13 @@ fn render(out: &mut String, neighbor: &Neighbor) -> std::fmt::Result {
         writeln!(
             out,
             "  Connected-network check disabled (eBGP peer may be unconnected at TTL 1)"
+        )?;
+    }
+
+    if neighbor.ip_transparent {
+        writeln!(
+            out,
+            "  IP transparent enabled (session may use a non-local update-source address)"
         )?;
     }
 
@@ -3554,6 +3567,7 @@ Neighbor        V         AS   MsgRcvd   MsgSent   TblVer  InQ OutQ  Up/Down Sta
             tcp_mss: None,
             tcp_mss_synced: None,
             disable_connected_check: false,
+            ip_transparent: false,
             neighbor_group: None,
             remote_as_inherited: false,
             nd_discovered_secs_ago: None,
@@ -4067,6 +4081,8 @@ struct NeighborGroupKnobsJson {
     #[serde(skip_serializing_if = "Option::is_none")]
     disable_connected_check: Option<bool>,
     #[serde(skip_serializing_if = "Option::is_none")]
+    ip_transparent: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     policy_in: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     policy_out: Option<String>,
@@ -4101,6 +4117,7 @@ impl NeighborGroupKnobsJson {
             tcp_mss: k.tcp_mss,
             password: k.password.as_ref().map(|_| true),
             disable_connected_check: k.disable_connected_check,
+            ip_transparent: k.ip_transparent,
             policy_in: k.policy_in.clone(),
             policy_out: k.policy_out.clone(),
             prefix_set_in: k.prefix_set_in.clone(),
@@ -4290,6 +4307,9 @@ fn show_bgp_neighbor_group_detail(
     }
     if k.disable_connected_check == Some(true) {
         writeln!(buf, "  Disable-connected-check: enabled")?;
+    }
+    if k.ip_transparent == Some(true) {
+        writeln!(buf, "  IP-transparent: enabled")?;
     }
     // Policy: emit one combined line listing configured directions.
     {

--- a/zebra-rs/src/bgp/transparent.rs
+++ b/zebra-rs/src/bgp/transparent.rs
@@ -1,0 +1,127 @@
+// BGP `neighbor X ip-transparent` (FRR 10.4, FRRouting/frr PR #18789):
+// the IP_TRANSPARENT / IPV6_TRANSPARENT socket option, which lets a BGP
+// session use a local address the host does not own.
+//
+// Normally the kernel rejects a bind() to a non-local address and
+// refuses to emit packets with a non-local source. IP_TRANSPARENT
+// (CAP_NET_ADMIN required) bypasses both checks, so a peer configured
+// with `update-source <addr-we-do-not-own>` + `ip-transparent` can dial
+// from that address — the container-peering / VRRP-VIP-takeover /
+// transparent-firewall use cases. The option only liberates the local
+// socket: delivery of return traffic destined to the non-local address
+// is the operator's problem (AnyIP local route, TPROXY/fwmark policy
+// routing, or VRRP ownership).
+//
+// Two application sites:
+// - the active connect socket, before bind() (`peer::peer_connect`) —
+//   gated on `update-source` being configured, matching FRR's
+//   both-flags check in `bgp_connect()`;
+// - the listening sockets, while any neighbor of that address family
+//   has the knob (`config::apply_ip_transparent_refresh_all`), so a
+//   passively accepted session destined to a non-local address (e.g.
+//   TPROXY-steered) can be answered. FRR leaves its listener alone;
+//   this side is what makes the documented passive scenarios work
+//   without an AnyIP route.
+//
+// Linux-primary, like `ttl.rs` / `mss.rs`: IP_TRANSPARENT is a Linux
+// option and the daemon is built for Linux.
+
+use std::io;
+use std::os::fd::RawFd;
+use std::os::raw::c_int;
+
+/// Set (or clear) IP_TRANSPARENT (IPv4) / IPV6_TRANSPARENT (IPv6) on
+/// `fd`. The option must be applied before bind()/connect() to affect a
+/// session — hence the bounce-on-change semantics of the config knob —
+/// and requires CAP_NET_ADMIN (EPERM otherwise).
+pub fn set_ip_transparent(fd: RawFd, is_ipv4: bool, on: bool) -> io::Result<()> {
+    let value = on as c_int;
+    if is_ipv4 {
+        super::ttl::setsockopt_int(fd, libc::IPPROTO_IP, libc::IP_TRANSPARENT, value)
+    } else {
+        super::ttl::setsockopt_int(fd, libc::IPPROTO_IPV6, libc::IPV6_TRANSPARENT, value)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::os::fd::AsRawFd;
+
+    fn getsockopt_int(fd: RawFd, level: c_int, optname: c_int) -> c_int {
+        let mut val: c_int = 0;
+        let mut len = std::mem::size_of::<c_int>() as libc::socklen_t;
+        let rc = unsafe {
+            libc::getsockopt(
+                fd,
+                level,
+                optname,
+                &mut val as *mut c_int as *mut libc::c_void,
+                &mut len,
+            )
+        };
+        assert!(rc >= 0, "getsockopt failed: {}", io::Error::last_os_error());
+        val
+    }
+
+    /// IP_TRANSPARENT needs CAP_NET_ADMIN, so the observable behaviour
+    /// differs by privilege — assert the right one either way so the
+    /// test is meaningful both in an unprivileged dev run and a root
+    /// (BDD-style) run: privileged, the flag must read back set and
+    /// clear again; unprivileged, the set must fail cleanly (EPERM)
+    /// rather than silently no-op.
+    #[test]
+    fn set_ip_transparent_v4_respects_privilege() {
+        use socket2::{Domain, Socket, Type};
+        let sock = Socket::new(Domain::IPV4, Type::STREAM, None).unwrap();
+        let fd = sock.as_raw_fd();
+
+        match set_ip_transparent(fd, true, true) {
+            Ok(()) => {
+                assert_eq!(
+                    getsockopt_int(fd, libc::IPPROTO_IP, libc::IP_TRANSPARENT),
+                    1,
+                    "flag must read back set after a privileged set",
+                );
+                set_ip_transparent(fd, true, false).unwrap();
+                assert_eq!(
+                    getsockopt_int(fd, libc::IPPROTO_IP, libc::IP_TRANSPARENT),
+                    0,
+                    "flag must read back clear after clearing",
+                );
+            }
+            Err(e) => {
+                assert_eq!(
+                    e.raw_os_error(),
+                    Some(libc::EPERM),
+                    "without CAP_NET_ADMIN the only acceptable failure is EPERM, got: {e}",
+                );
+            }
+        }
+    }
+
+    /// Same privilege split for the IPv6 variant (IPV6_TRANSPARENT).
+    #[test]
+    fn set_ip_transparent_v6_respects_privilege() {
+        use socket2::{Domain, Socket, Type};
+        let sock = Socket::new(Domain::IPV6, Type::STREAM, None).unwrap();
+        let fd = sock.as_raw_fd();
+
+        match set_ip_transparent(fd, false, true) {
+            Ok(()) => {
+                assert_eq!(
+                    getsockopt_int(fd, libc::IPPROTO_IPV6, libc::IPV6_TRANSPARENT),
+                    1,
+                    "flag must read back set after a privileged set",
+                );
+            }
+            Err(e) => {
+                assert_eq!(
+                    e.raw_os_error(),
+                    Some(libc::EPERM),
+                    "without CAP_NET_ADMIN the only acceptable failure is EPERM, got: {e}",
+                );
+            }
+        }
+    }
+}

--- a/zebra-rs/src/bgp/ttl.rs
+++ b/zebra-rs/src/bgp/ttl.rs
@@ -67,7 +67,14 @@ pub fn set_min_ttl(fd: RawFd, is_ipv4: bool, min: u8) -> io::Result<()> {
 }
 
 /// Thin `setsockopt(2)` wrapper for a single `c_int`-valued option.
-fn setsockopt_int(fd: RawFd, level: c_int, optname: c_int, value: c_int) -> io::Result<()> {
+/// Shared with the sibling per-session socket-option modules
+/// (`super::transparent`).
+pub(super) fn setsockopt_int(
+    fd: RawFd,
+    level: c_int,
+    optname: c_int,
+    value: c_int,
+) -> io::Result<()> {
     let rc = unsafe {
         libc::setsockopt(
             fd,

--- a/zebra-rs/src/config/manager.rs
+++ b/zebra-rs/src/config/manager.rs
@@ -1598,6 +1598,41 @@ mod yang_load_tests {
         );
     }
 
+    /// `neighbor X ip-transparent` (zebra-bgp-transport.yang) must be a
+    /// settable path on the neighbor and on the neighbor-group (the
+    /// group reuses the transport grouping via `uses`). Guards against
+    /// the silent-augment-drop name collision described on the
+    /// disable-connected-check test above.
+    #[test]
+    fn bgp_neighbor_ip_transparent_is_settable() {
+        use crate::config::ExecCode;
+        use crate::config::parse::{State, parse};
+        use libyang::to_entry;
+
+        let mut yang = YangStore::new();
+        yang.add_path(concat!(env!("CARGO_MANIFEST_DIR"), "/yang"));
+        yang.read_with_resolve("configure")
+            .expect("configure mode loads");
+        yang.identity_resolve();
+        let module = yang
+            .find_module("configure")
+            .expect("configure module present");
+        let entry = to_entry(&yang, module);
+
+        for cmd in [
+            "set router bgp neighbor 10.0.0.1 ip-transparent",
+            "set router bgp neighbor-group G ip-transparent",
+        ] {
+            let (code, _comps, _state) = parse(cmd, entry.clone(), None, State::new());
+            assert_eq!(
+                code,
+                ExecCode::Success,
+                "`{cmd}` must be a valid path — a silent name collision \
+                 with an ietf-bgp leaf would show up here as a parse failure",
+            );
+        }
+    }
+
     /// `neighbor X port <1-65535>` and the instance-level
     /// `router bgp port <0-65535>` (zebra-bgp-transport.yang) must both
     /// be settable paths. The neighbor leaf's range starts at 1, so

--- a/zebra-rs/yang/zebra-bgp-transport.yang
+++ b/zebra-rs/yang/zebra-bgp-transport.yang
@@ -52,6 +52,16 @@ module zebra-bgp-transport {
      site in `peer_connect`. Operators using the FRR vocabulary get
      the flat form without giving up the IETF tree.";
 
+  revision 2026-06-12 {
+    description
+      "Add per-neighbor `ip-transparent` (presence container): set
+       IP_TRANSPARENT / IPV6_TRANSPARENT on the neighbor's TCP socket
+       so the session can use a local address the host does not own
+       (paired with `update-source`).";
+    reference
+      "FRR 10.4 `neighbor X ip-transparent` (FRRouting/frr PR #18789).";
+  }
+
   revision 2026-06-09 {
     description
       "Add per-neighbor `port <1-65535>` (TCP destination port used to
@@ -216,6 +226,49 @@ module zebra-bgp-transport {
       reference
         "RFC 4271: A Border Gateway Protocol 4 (BGP-4), Section 8
          (TCP port 179).";
+    }
+
+    container ip-transparent {
+      ext:help "Allow this session to use a local address the host does not own (with update-source)";
+      presence "Set IP_TRANSPARENT on this neighbor's TCP socket";
+      description
+        "When present, set the IP_TRANSPARENT (IPv4) / IPV6_TRANSPARENT
+         (IPv6) socket option on this neighbor's TCP socket. The option
+         lets the session bind to — and emit packets from — a local
+         address that is not configured on the host: normally the kernel
+         rejects a bind() to a non-local address and refuses a non-local
+         source on output; IP_TRANSPARENT (which requires CAP_NET_ADMIN)
+         bypasses both checks. The source address itself comes from
+         `update-source`, so the two are used together: update-source
+         names the address the host does not own, ip-transparent makes
+         the kernel accept it. On the active connect path the option is
+         applied only when `update-source` is also configured (matching
+         FRR); without it there is nothing for the option to liberate.
+         The option is also folded onto the BGP listening sockets while
+         any neighbor of that address family has it, so a passively
+         accepted session destined to a non-local address (e.g. one
+         steered to the daemon with TPROXY-style policy routing) can be
+         answered.
+
+         Typical uses: running bgpd in a container that peers as a
+         loopback address not plumbed inside that netns; hitless
+         takeover of a keepalived/VRRP virtual IP (pre-bind on the
+         standby, establish instantly after failover); a
+         bump-in-the-wire box terminating BGP with addresses owned by
+         the devices around it.
+
+         The option only liberates the local socket — the operator must
+         still arrange for return traffic destined to the non-local
+         address to reach the daemon (an AnyIP-style `ip route add
+         local … dev lo`, TPROXY/fwmark policy routing, or — for a VIP —
+         the peer simply not routing here until the VIP is owned).
+
+         A change on a live session bounces it (FRR `peer_change_reset`):
+         the option must be on the socket before bind()/connect(), so
+         only a reconnect can apply it.";
+      reference
+        "FRR 10.4 `neighbor X ip-transparent` (FRRouting/frr PR #18789).
+         Linux ip(7) IP_TRANSPARENT; ipv6(7) IPV6_TRANSPARENT.";
     }
 
     container disable-connected-check {


### PR DESCRIPTION
## Summary

Per-neighbor presence knob mirroring FRR 10.4 `neighbor X ip-transparent` (FRRouting/frr PR #18789): set `IP_TRANSPARENT` (IPv4) / `IPV6_TRANSPARENT` (IPv6) on the neighbor's TCP socket so the session can use a local address the host does not own — the address itself comes from `update-source`, so the two are configured together.

```
set router bgp neighbor 10.0.0.1 update-source 10.255.0.99
set router bgp neighbor 10.0.0.1 ip-transparent
```

Use cases: peering as a loopback not plumbed inside a container netns, hitless VRRP-VIP takeover (pre-bind on the standby), transparent bump-in-the-wire firewalls.

## Design

- **Active connect** (`peer_connect`): option applied **before `bind()`**, gated on `update-source` being configured — FRR's both-flags gate in `bgp_connect()`. A setsockopt failure (daemon lacking CAP_NET_ADMIN) fails the dial loudly instead of falling through to a confusing `EADDRNOTAVAIL` from the bind.
- **Listeners**: per-AF union of resolved peer knobs + neighbor-group opinions reconciled onto `listen_fd_v4/v6` (`apply_ip_transparent_refresh_all`), so a TPROXY-steered passive session destined to a non-local address can be accepted and answered. Group opinions count toward both AFs so a dynamic (listen-range) member finds the flag on the listener before its SYN arrives. Refreshed from the knob callbacks, the inherit sweep (covers group delete), whole-neighbor delete, and `listen()`. FRR leaves its listener alone; this side covers the documented passive (VRRP pre-bind) scenarios.
- **Bounce on change** (FRR `peer_change_reset`): the option must be on the socket before `bind()`/`connect()`, so a change on a live session sends `Event::Stop`; the usual diff-gate / Idle-peer rules apply.
- **Inheritable through neighbor-group**: `InheritableKnobs.ip_transparent` with the explicit-wins resolution; the YANG side is free via the existing `uses zbt:bgp-neighbor-transport-extension`.
- **Show**: `show bgp neighbor` prints `IP transparent enabled (…)`; group detail/JSON include the knob.
- **YANG**: `container ip-transparent { presence … }` in `zebra-bgp-transport.yang` — checked for (and free of) the ietf-bgp augment name collision; settable-path parse test pins both the neighbor and neighbor-group spellings.

## Testing

- 5 new unit tests: sockopt readback (privilege-aware: asserts set/clear as root, clean EPERM unprivileged), FSM toggle/bounce ritual, group inheritance + explicit-wins, parse pins.
- Full workspace suite: **1645 passed / 0 failed**; `cargo clippy --workspace --all-targets -- -D warnings` clean; `cargo fmt` applied.
- New BDD `@bgp_ip_transparent` (passed locally, 3/3 scenarios) mirroring FRR's `bgp_tcp_ip_transparent` topotest: z2 dials z1 sourcing from a phantom 10.255.0.99 behind a new fwmark→local-table return-path harness step; **without** the knob the session must stay down (kernel refuses the non-local bind), **with** it the session establishes from the foreign address, routes flow both ways, and `show bgp neighbors` reports the flag. Explicit teardown scenario included.
- Book chapter `ch-02-28-bgp-ip-transparent.md` documents the knob, the return-traffic caveat (AnyIP / TPROXY / VRRP), and the failure symptoms.

🤖 Generated with [Claude Code](https://claude.com/claude-code)