### PR TITLE
isis: TI-LFA parallel compute modes — serial/conservative/aggressive/sharding (PR-B)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,6 +36,7 @@ license = "AGPL-3.0-or-later"
 [workspace.dependencies]
 anyhow = "1.0"
 prost = "0.14"
+rayon = "1"
 tokio = { version = "1", features = ["full"] }
 tokio-stream = "0.1"
 tonic = "0.14"

--- a/zebra-rs/Cargo.toml
+++ b/zebra-rs/Cargo.toml
@@ -14,6 +14,7 @@ anyhow.workspace = true
 bytes = "1"
 ipnet = "2.9"
 prost.workspace = true
+rayon.workspace = true
 tokio.workspace = true
 tokio-stream.workspace = true
 tonic.workspace = true

--- a/zebra-rs/src/config/manager.rs
+++ b/zebra-rs/src/config/manager.rs
@@ -1331,6 +1331,56 @@ mod yang_load_tests {
         }
     }
 
+    /// TI-LFA parallel-computation knobs: `fast-reroute ti-lfa
+    /// compute-mode <serial|conservative|aggressive|sharding>` plus
+    /// `compute-shards <1..256>`. Pinned because vtyctl apply is
+    /// garbage-tolerant — an unwired grammar silently no-ops instead
+    /// of erroring.
+    #[test]
+    fn isis_tilfa_compute_grammar() {
+        use crate::config::ExecCode;
+        use crate::config::parse::{State, parse};
+        use libyang::to_entry;
+
+        let mut yang = YangStore::new();
+        yang.add_path(concat!(env!("CARGO_MANIFEST_DIR"), "/yang"));
+        yang.read_with_resolve("configure")
+            .expect("configure mode loads");
+        yang.identity_resolve();
+        let module = yang
+            .find_module("configure")
+            .expect("configure module present");
+        let entry = to_entry(&yang, module);
+
+        for cmd in [
+            "set router isis fast-reroute ti-lfa compute-mode serial",
+            "set router isis fast-reroute ti-lfa compute-mode conservative",
+            "set router isis fast-reroute ti-lfa compute-mode aggressive",
+            "set router isis fast-reroute ti-lfa compute-mode sharding",
+            "set router isis fast-reroute ti-lfa compute-shards 4",
+        ] {
+            let (code, _comps, _state) = parse(cmd, entry.clone(), None, State::new());
+            assert_eq!(
+                code,
+                ExecCode::Success,
+                "should parse as a settable path: {cmd}"
+            );
+        }
+
+        // An unknown mode keyword must not resolve to a settable path.
+        let (code, _comps, _state) = parse(
+            "set router isis fast-reroute ti-lfa compute-mode turbo",
+            entry.clone(),
+            None,
+            State::new(),
+        );
+        assert_ne!(
+            code,
+            ExecCode::Success,
+            "`compute-mode turbo` must not parse"
+        );
+    }
+
     /// `router bgp global router-id` is zebra-rs's rename of the IETF
     /// model's `global/identifier` leaf (vendored ietf-bgp edit), so the
     /// BGP surface matches every other router-id knob. The leaf lives in

--- a/zebra-rs/src/isis/config.rs
+++ b/zebra-rs/src/isis/config.rs
@@ -7,6 +7,7 @@ use isis_packet::{IsLevel, Nsap};
 use strum_macros::{Display, EnumString};
 
 use crate::config::{Args, ConfigOp};
+use crate::spf;
 
 use super::Isis;
 use super::ifsm::has_level;
@@ -138,6 +139,14 @@ impl Isis {
             config_sr_srv6_locator,
         );
         self.callback_add("/router/isis/fast-reroute/ti-lfa", config_ti_lfa);
+        self.callback_add(
+            "/router/isis/fast-reroute/ti-lfa/compute-mode",
+            config_ti_lfa_compute_mode,
+        );
+        self.callback_add(
+            "/router/isis/fast-reroute/ti-lfa/compute-shards",
+            config_ti_lfa_compute_shards,
+        );
         self.callback_add(
             "/router/isis/fast-reroute/backup-as-primary",
             config_fast_reroute_backup_as_primary,
@@ -477,6 +486,21 @@ pub struct IsisConfig {
     /// is false (no repair gets stamped in the first place).
     pub fast_reroute_backup_as_primary: bool,
 
+    /// /router/isis/fast-reroute/ti-lfa/compute-mode — how the
+    /// per-destination TI-LFA computation is scheduled (serial
+    /// default; conservative/aggressive/sharding fan out on the rayon
+    /// pool). Kept as the payload-free YANG mirror; the
+    /// `compute-shards` count joins in [`Self::tilfa_compute_mode`].
+    /// Results are identical across modes — only CPU scheduling
+    /// differs.
+    pub ti_lfa_compute_mode: TilfaComputeModeConfig,
+
+    /// /router/isis/fast-reroute/ti-lfa/compute-shards — the
+    /// operator's hard upper bound on TI-LFA parallelism, consulted
+    /// only when `compute-mode sharding` is set. Default 8, matching
+    /// the YANG default.
+    pub ti_lfa_compute_shards: u16,
+
     /// Instance-level BFD defaults (`router isis { bfd {} }`), inherited by
     /// every interface and overridden per interface (see
     /// [`super::link::LinkBfdConfig::resolve`]).
@@ -686,6 +710,23 @@ impl IsisAuthConfig {
     }
 }
 
+/// YANG mirror of `/router/isis/fast-reroute/ti-lfa/compute-mode`
+/// (payload-free — the sharding count lives in the sibling
+/// `compute-shards` leaf; [`IsisConfig::tilfa_compute_mode`] joins
+/// them into the scheduler-facing `spf::TilfaComputeMode`).
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq, EnumString, Display)]
+pub enum TilfaComputeModeConfig {
+    #[default]
+    #[strum(serialize = "serial")]
+    Serial,
+    #[strum(serialize = "conservative")]
+    Conservative,
+    #[strum(serialize = "aggressive")]
+    Aggressive,
+    #[strum(serialize = "sharding")]
+    Sharding,
+}
+
 impl Default for IsisConfig {
     // Manual rather than derived because `gr_helper_enabled` defaults
     // to `true` (matches the YANG default for
@@ -721,6 +762,9 @@ impl Default for IsisConfig {
             sr_srv6_flex_algo_locators: Default::default(),
             ti_lfa_enabled: Default::default(),
             fast_reroute_backup_as_primary: Default::default(),
+            ti_lfa_compute_mode: Default::default(),
+            // Matches the YANG `default 8` on compute-shards.
+            ti_lfa_compute_shards: 8,
             mt_enabled: Default::default(),
             mt_topologies: Default::default(),
             networks_v4: Default::default(),
@@ -761,6 +805,20 @@ impl IsisConfig {
 
     pub fn is_type(&self) -> IsLevel {
         self.is_type.unwrap_or(IsLevel::L1L2)
+    }
+
+    /// Combine the `compute-mode` and `compute-shards` leaves into the
+    /// scheduler-facing [`spf::TilfaComputeMode`], snapshotted into
+    /// `SpfInput` at graph-build time.
+    pub fn tilfa_compute_mode(&self) -> spf::TilfaComputeMode {
+        match self.ti_lfa_compute_mode {
+            TilfaComputeModeConfig::Serial => spf::TilfaComputeMode::Serial,
+            TilfaComputeModeConfig::Conservative => spf::TilfaComputeMode::Conservative,
+            TilfaComputeModeConfig::Aggressive => spf::TilfaComputeMode::Aggressive,
+            TilfaComputeModeConfig::Sharding => {
+                spf::TilfaComputeMode::Sharding(self.ti_lfa_compute_shards)
+            }
+        }
     }
 
     /// Resolve the hostname to advertise in TLV 137. Configured hostname
@@ -1337,6 +1395,41 @@ fn config_ti_lfa(isis: &mut Isis, _args: Args, op: ConfigOp) -> Option<()> {
     let _ = isis.tx.send(Message::LspOriginate(Level::L2, None));
     // Recompute SPF so the RIB picks up repair paths (on enable) or
     // drops them (on disable) for every prefix in this instance.
+    let _ = isis.tx.send(Message::SpfCalc(Level::L1));
+    let _ = isis.tx.send(Message::SpfCalc(Level::L2));
+    Some(())
+}
+
+/// `/router/isis/fast-reroute/ti-lfa/compute-mode`. Picks how the
+/// TI-LFA computation is scheduled across cores (see
+/// `spf::TilfaComputeMode`). Results are identical across modes, so
+/// nothing advertised changes — no LSP re-origination. The SPF re-run
+/// makes the change observable immediately in `show isis spf` stats.
+fn config_ti_lfa_compute_mode(isis: &mut Isis, mut args: Args, op: ConfigOp) -> Option<()> {
+    let prev = isis.config.tilfa_compute_mode();
+    isis.config.ti_lfa_compute_mode = if op.is_set() {
+        args.string()?.parse().ok()?
+    } else {
+        TilfaComputeModeConfig::default()
+    };
+    if isis.config.tilfa_compute_mode() == prev {
+        return Some(());
+    }
+    let _ = isis.tx.send(Message::SpfCalc(Level::L1));
+    let _ = isis.tx.send(Message::SpfCalc(Level::L2));
+    Some(())
+}
+
+/// `/router/isis/fast-reroute/ti-lfa/compute-shards`. Upper bound on
+/// TI-LFA parallelism; consulted only when `compute-mode sharding`
+/// is configured (the effective-mode comparison below keeps the SPF
+/// re-run suppressed otherwise).
+fn config_ti_lfa_compute_shards(isis: &mut Isis, mut args: Args, op: ConfigOp) -> Option<()> {
+    let prev = isis.config.tilfa_compute_mode();
+    isis.config.ti_lfa_compute_shards = if op.is_set() { args.u16()? } else { 8 };
+    if isis.config.tilfa_compute_mode() == prev {
+        return Some(());
+    }
     let _ = isis.tx.send(Message::SpfCalc(Level::L1));
     let _ = isis.tx.send(Message::SpfCalc(Level::L2));
     Some(())

--- a/zebra-rs/src/isis/inst.rs
+++ b/zebra-rs/src/isis/inst.rs
@@ -272,6 +272,11 @@ pub struct Isis {
     /// None until the first SPF completes for the level. Surfaced by
     /// `show isis spf` as "Last SPF: N s ago".
     pub spf_last: Levels<Option<std::time::Instant>>,
+    /// TI-LFA compute telemetry for the most recent SPF run (legacy +
+    /// MT2 merged), written by `apply_spf_result` from
+    /// `SpfOutput::tilfa_stats`. None until TI-LFA runs (and cleared
+    /// when it is disabled). Surfaced by `show isis spf`.
+    pub tilfa_stats: Levels<Option<spf::TilfaStats>>,
     /// LSP-gen coalescing slot. None means no run is currently pending;
     /// Some(Timer) means a LspGenFire is armed and additional
     /// LspOriginate events will fold into the same run.
@@ -528,6 +533,8 @@ pub struct IsisTop<'a> {
     pub spf_duration: &'a mut Levels<Option<std::time::Duration>>,
     /// Last SPF completion instant per level — see `Isis::spf_last`.
     pub spf_last: &'a mut Levels<Option<std::time::Instant>>,
+    /// Last TI-LFA compute telemetry per level — see `Isis::tilfa_stats`.
+    pub tilfa_stats: &'a mut Levels<Option<spf::TilfaStats>>,
     pub graph: &'a mut Levels<Option<spf::Graph>>,
     pub spf_result: &'a mut Levels<Option<BTreeMap<usize, spf::Path>>>,
     pub tilfa_result: &'a mut Levels<Option<BTreeMap<usize, Vec<spf::RepairPath>>>>,
@@ -670,6 +677,7 @@ impl Isis {
                 spf_pending: Levels::<bool>::default(),
                 spf_duration: Levels::<Option<std::time::Duration>>::default(),
                 spf_last: Levels::<Option<std::time::Instant>>::default(),
+                tilfa_stats: Levels::<Option<spf::TilfaStats>>::default(),
                 lsp_gen_timer: Levels::<Option<Timer>>::default(),
                 lsp_gen_throttle: Levels::<Throttle>::default(),
                 lsp_gen_pending_floor: Levels::<Option<u32>>::default(),
@@ -2589,6 +2597,7 @@ impl Isis {
             spf_pending: &mut self.spf_pending,
             spf_duration: &mut self.spf_duration,
             spf_last: &mut self.spf_last,
+            tilfa_stats: &mut self.tilfa_stats,
             graph: &mut self.graph,
             spf_result: &mut self.spf_result,
             tilfa_result: &mut self.tilfa_result,

--- a/zebra-rs/src/isis/rib.rs
+++ b/zebra-rs/src/isis/rib.rs
@@ -1085,6 +1085,11 @@ pub(super) struct SpfInput {
     /// run without borrowing `IsisTop`.
     lsp_map: LspMap,
     ti_lfa_enabled: bool,
+    /// How the TI-LFA computation is scheduled
+    /// (`fast-reroute ti-lfa compute-mode` / `compute-shards`),
+    /// snapshotted from config at build time so a mid-run change
+    /// cleanly applies to the next run.
+    tilfa_mode: spf::TilfaComputeMode,
     mt2: Option<Mt2Input>,
     flex_algos: Vec<FlexAlgoInput>,
 }
@@ -1109,6 +1114,10 @@ pub struct SpfOutput {
     adjacency_sids: BTreeMap<u32, IsisSysId>,
     spf_result: BTreeMap<usize, spf::Path>,
     tilfa_result: BTreeMap<usize, Vec<spf::RepairPath>>,
+    /// TI-LFA compute telemetry (legacy + MT2 merged), None when
+    /// TI-LFA is disabled. Stashed on `IsisTop::tilfa_stats[level]`
+    /// for `show isis spf`.
+    tilfa_stats: Option<spf::TilfaStats>,
     mt2: Option<Mt2Output>,
     flex_algos: Vec<FlexAlgoOutput>,
     /// Wall-clock time `compute_spf` spent running Dijkstra + TI-LFA.
@@ -1214,6 +1223,7 @@ pub(super) fn build_spf_input(top: &mut IsisTop, level: Level) -> Option<SpfInpu
         adjacency_sids,
         lsp_map,
         ti_lfa_enabled: top.config.ti_lfa_enabled,
+        tilfa_mode: top.config.tilfa_compute_mode(),
         mt2,
         flex_algos,
     })
@@ -1230,6 +1240,7 @@ pub(super) fn compute_spf(input: SpfInput) -> SpfOutput {
         adjacency_sids,
         lsp_map,
         ti_lfa_enabled,
+        tilfa_mode,
         mt2,
         flex_algos,
     } = input;
@@ -1246,8 +1257,12 @@ pub(super) fn compute_spf(input: SpfInput) -> SpfOutput {
     // TI-LFA repair path. Gated on `fast-reroute ti-lfa` — when the
     // knob is off we still install the primary RIB built from
     // `spf_result`, just without the per-destination repair list.
+    let mut tilfa_stats: Option<spf::TilfaStats> = None;
     let tilfa_result = if ti_lfa_enabled {
-        tilfa_repair_path(&legacy_graph, &lsp_map, source, &spf_result)
+        let (result, stats) =
+            tilfa_repair_path(&legacy_graph, &lsp_map, source, &spf_result, tilfa_mode);
+        tilfa_stats = Some(stats);
+        result
     } else {
         BTreeMap::new()
     };
@@ -1258,7 +1273,10 @@ pub(super) fn compute_spf(input: SpfInput) -> SpfOutput {
             Some(src) => {
                 let mt2_spf = spf::spf(&graph, src, &spf::SpfOpt::full_path());
                 let mt2_tilfa = if ti_lfa_enabled {
-                    tilfa_repair_path(&graph, &lsp_map, src, &mt2_spf)
+                    let (result, stats) =
+                        tilfa_repair_path(&graph, &lsp_map, src, &mt2_spf, tilfa_mode);
+                    tilfa_stats = Some(tilfa_stats.map_or(stats, |prev| prev.merge(stats)));
+                    result
                 } else {
                     BTreeMap::new()
                 };
@@ -1299,6 +1317,7 @@ pub(super) fn compute_spf(input: SpfInput) -> SpfOutput {
         adjacency_sids,
         spf_result,
         tilfa_result,
+        tilfa_stats,
         mt2,
         flex_algos,
         duration,
@@ -1317,6 +1336,7 @@ pub(super) fn apply_spf_result(top: &mut IsisTop, output: SpfOutput) {
         adjacency_sids,
         spf_result,
         tilfa_result,
+        tilfa_stats,
         mt2,
         flex_algos,
         duration,
@@ -1329,6 +1349,9 @@ pub(super) fn apply_spf_result(top: &mut IsisTop, output: SpfOutput) {
     // the RIB-publish work below isn't counted in `duration`.
     *top.spf_duration.get_mut(&level) = Some(duration);
     *top.spf_last.get_mut(&level) = Some(last);
+    // TI-LFA compute telemetry rides the same path; None (TI-LFA
+    // disabled) clears any stale stats from a previous enable.
+    *top.tilfa_stats.get_mut(&level) = tilfa_stats;
 
     // Build Adjacency ILM seed from the SIDs collected during graph build.
     let mut ilm = build_adjacency_ilm(top, level, &adjacency_sids);

--- a/zebra-rs/src/isis/show.rs
+++ b/zebra-rs/src/isis/show.rs
@@ -2897,6 +2897,22 @@ fn write_spf_status_banner(isis: &Isis, buf: &mut String) {
                 );
             }
         }
+        // TI-LFA compute telemetry for the same run (legacy + MT2
+        // merged). None while TI-LFA is disabled or before the first
+        // protected run, so the block stays quiet in the common case.
+        if let Some(stats) = isis.tilfa_stats.get(&level) {
+            let _ = writeln!(
+                buf,
+                "      ti-lfa: targets={} mode={} workers={} spf{{q={} pc={} dedup-saved={}}} took {}",
+                stats.targets,
+                stats.mode,
+                stats.width,
+                stats.q_spf,
+                stats.pc_spf,
+                stats.pc_deduped,
+                format_compute_duration(stats.duration),
+            );
+        }
     }
 }
 

--- a/zebra-rs/src/isis/tilfa.rs
+++ b/zebra-rs/src/isis/tilfa.rs
@@ -460,18 +460,19 @@ fn repair_segments_to_mpls_labels(
     Some(labels)
 }
 
-/// Per-destination TI-LFA repair computation. For every destination
-/// in `spf_result` that isn't `source` and has a single primary
-/// first-hop (ECMP at the SPF level is skipped — see PR #547 for the
-/// design rationale), call `spf::tilfa()` to compute the post-conv
-/// repair list. The returned map is keyed by destination vertex id.
-pub(super) fn tilfa_repair_path(
+/// Plan the TI-LFA targets from the primary SPF result: every
+/// destination that isn't `source`, has a single primary first-hop
+/// (ECMP at the SPF level is skipped — see PR #547 for the design
+/// rationale), and isn't a pseudonode, paired with the protected
+/// vertex X. Pure planning — the SPF work happens in
+/// `spf::tilfa_compute`.
+pub(super) fn tilfa_targets(
     graph: &spf::Graph,
     lsp_map: &LspMap,
     source: usize,
     spf_result: &BTreeMap<usize, spf::Path>,
-) -> BTreeMap<usize, Vec<spf::RepairPath>> {
-    let mut tilfa_result = BTreeMap::new();
+) -> Vec<spf::TilfaTarget> {
+    let mut targets = Vec::new();
 
     for (d, path) in spf_result.iter() {
         // Source is skipped.
@@ -497,8 +498,10 @@ pub(super) fn tilfa_repair_path(
         // `first[1]` so LAN matches P2P's node-protection model, and
         // so that a destination equal to the physical neighbor is
         // skipped via the empty-modified-SPF path (same as P2P, where
-        // `d == x` makes `spf::tilfa` return `vec![]`).
-        let first = &path.paths[0];
+        // `d == x` yields no PC path and an empty repair list).
+        let Some(first) = path.paths.first() else {
+            continue;
+        };
         if first.is_empty() {
             continue;
         }
@@ -511,12 +514,25 @@ pub(super) fn tilfa_repair_path(
             first[0]
         };
 
-        let repair_paths = spf::tilfa(graph, source, *d, &[x]);
-        if !repair_paths.is_empty() {
-            tilfa_result.insert(*d, repair_paths);
-        }
+        targets.push(spf::TilfaTarget { d: *d, x });
     }
-    tilfa_result
+    targets
+}
+
+/// Per-destination TI-LFA repair computation: plan the targets, then
+/// hand them to `spf::tilfa_compute`, which schedules the P/Q/PC SPF
+/// jobs per the configured compute mode (serial by default). The
+/// returned map is keyed by destination vertex id; destinations with
+/// no computable repair are absent.
+pub(super) fn tilfa_repair_path(
+    graph: &spf::Graph,
+    lsp_map: &LspMap,
+    source: usize,
+    spf_result: &BTreeMap<usize, spf::Path>,
+    mode: spf::TilfaComputeMode,
+) -> (BTreeMap<usize, Vec<spf::RepairPath>>, spf::TilfaStats) {
+    let targets = tilfa_targets(graph, lsp_map, source, spf_result);
+    spf::tilfa_compute(graph, source, spf_result, &targets, mode)
 }
 
 /// Carrier metadata for a uN: the identifier is the locator-node

--- a/zebra-rs/src/spf/calc.rs
+++ b/zebra-rs/src/spf/calc.rs
@@ -651,10 +651,211 @@ fn write_first_hop_links(buf: &mut String, links: &HashSet<(usize, u32)>) {
     let _ = writeln!(buf, "  first_hop_links: {:?}", sorted);
 }
 
+/// Shared test topologies for the TI-LFA unit tests here and in
+/// `spf::tilfa_par`. Test-only.
+#[cfg(test)]
+pub(crate) mod fixtures {
+    use super::*;
+
+    pub(crate) fn tilfa_graph() -> Graph {
+        let mut graph = BTreeMap::new();
+
+        // Insert vertices
+        let vertices = [
+            Vertex::new_node("S", 0),
+            Vertex::new_node("N1", 1),
+            Vertex::new_node("N2", 2),
+            Vertex::new_node("N3", 3),
+            Vertex::new_node("R1", 4),
+            Vertex::new_node("R2", 5),
+            Vertex::new_node("R3", 6),
+            Vertex::new_node("D", 7),
+        ];
+
+        for vertex in vertices.iter() {
+            graph.insert(vertex.id, vertex.clone());
+        }
+
+        // Define links
+        let links = vec![
+            // S
+            (0, 1, 1),    // N1
+            (0, 2, 1),    // N2
+            (0, 3, 1000), // N3
+            // N1
+            (1, 0, 1), // S
+            (1, 4, 1), // R1
+            (1, 5, 1), // R2
+            (1, 7, 1), // D
+            // N2
+            (2, 0, 1), // S
+            (2, 4, 1), // R1
+            // N3
+            (3, 0, 1000), // S
+            (3, 4, 1000), // R1
+            // R1
+            (4, 1, 1),    // N1
+            (4, 2, 1),    // N2
+            (4, 3, 1000), // N3
+            (4, 5, 1000), // R2
+            // R2
+            (5, 1, 1),    // N1
+            (5, 4, 1000), // R1
+            (5, 6, 1000), // R3
+            // R3
+            (6, 5, 1000), // R2
+            (6, 7, 1),    // D
+            // D
+            (7, 1, 1), // N1
+            (7, 6, 1), // R3
+        ];
+
+        // Insert links into vertices
+        for (from, to, cost) in links {
+            graph
+                .get_mut(&from)
+                .unwrap()
+                .olinks
+                .push(Link::new(from, to, cost));
+            graph
+                .get_mut(&to)
+                .unwrap()
+                .ilinks
+                .push(Link::new(from, to, cost));
+        }
+        graph
+    }
+
+    /// Attach a pseudonode (one per IS-IS LAN) to the graph.
+    ///
+    /// `members` is a list of (router_id, router-side cost). For each
+    /// member the helper appends:
+    ///   router → PN  with the router's interface cost
+    ///   PN     → router  with cost 0  (always — IS-IS LAN modelling)
+    /// olinks/ilinks stay symmetric so reverse SPF (used by Q-space)
+    /// works the same as for P2P links.
+    pub(crate) fn add_lan(graph: &mut Graph, pn_id: usize, name: &str, members: &[(usize, u32)]) {
+        graph.insert(pn_id, Vertex::new_pseudo_node(name, pn_id));
+        for &(rtr, cost) in members {
+            graph
+                .get_mut(&rtr)
+                .unwrap()
+                .olinks
+                .push(Link::new(rtr, pn_id, cost));
+            graph
+                .get_mut(&pn_id)
+                .unwrap()
+                .ilinks
+                .push(Link::new(rtr, pn_id, cost));
+            graph
+                .get_mut(&pn_id)
+                .unwrap()
+                .olinks
+                .push(Link::new(pn_id, rtr, 0));
+            graph
+                .get_mut(&rtr)
+                .unwrap()
+                .ilinks
+                .push(Link::new(pn_id, rtr, 0));
+        }
+    }
+
+    /// Same systems as `tilfa_graph()`, but each underlying point-to-point
+    /// link is rebuilt as an IS-IS LAN with one pseudonode (ids 8..=18).
+    /// SPF cost between any two routers is preserved by construction.
+    pub(crate) fn isis_lan_graph() -> Graph {
+        let mut graph = BTreeMap::new();
+
+        for r in [
+            Vertex::new_node("S", 0),
+            Vertex::new_node("N1", 1),
+            Vertex::new_node("N2", 2),
+            Vertex::new_node("N3", 3),
+            Vertex::new_node("R1", 4),
+            Vertex::new_node("R2", 5),
+            Vertex::new_node("R3", 6),
+            Vertex::new_node("D", 7),
+        ] {
+            graph.insert(r.id, r);
+        }
+
+        // 11 LANs, one pseudonode each. Costs mirror tilfa_graph().
+        add_lan(&mut graph, 8, "PN_S_N1", &[(0, 1), (1, 1)]);
+        add_lan(&mut graph, 9, "PN_S_N2", &[(0, 1), (2, 1)]);
+        add_lan(&mut graph, 10, "PN_S_N3", &[(0, 1000), (3, 1000)]);
+        add_lan(&mut graph, 11, "PN_N1_R1", &[(1, 1), (4, 1)]);
+        add_lan(&mut graph, 12, "PN_N1_R2", &[(1, 1), (5, 1)]);
+        add_lan(&mut graph, 13, "PN_N1_D", &[(1, 1), (7, 1)]);
+        add_lan(&mut graph, 14, "PN_N2_R1", &[(2, 1), (4, 1)]);
+        add_lan(&mut graph, 15, "PN_N3_R1", &[(3, 1000), (4, 1000)]);
+        add_lan(&mut graph, 16, "PN_R1_R2", &[(4, 1000), (5, 1000)]);
+        add_lan(&mut graph, 17, "PN_R2_R3", &[(5, 1000), (6, 1000)]);
+        add_lan(&mut graph, 18, "PN_R3_D", &[(6, 1), (7, 1)]);
+
+        graph
+    }
+
+    /// Mixed LAN/P2P topology drawn from a live IS-IS LSDB
+    /// ("TI-LFA Draft with Link#"). Reproduces the scenario where the
+    /// only LANs sit between {s,n2}, {s,n1}, {n2,r1}, {r1,n1}, and the
+    /// r1↔r2 / r2↔r3 / r3↔d links are point-to-point. SPF cost from s:
+    /// every LAN crossing costs s=10 / others=1; P2P r1↔r2 and r2↔r3
+    /// are metric 1000; n1↔r2, n1↔d, r3↔d are metric 1. With X=n1,
+    /// r1 has equal-cost paths from s with and without n1 — required
+    /// to land r1 in P-space and trigger the pending_via leak below.
+    pub(crate) fn mixed_lan_p2p_graph() -> Graph {
+        let mut graph = BTreeMap::new();
+        for v in [
+            Vertex::new_node("s", 0),
+            Vertex::new_node("n1", 1),
+            Vertex::new_node("n2", 2),
+            Vertex::new_node("r1", 3),
+            Vertex::new_node("r2", 4),
+            Vertex::new_node("r3", 5),
+            Vertex::new_node("d", 6),
+        ] {
+            graph.insert(v.id, v);
+        }
+
+        // LANs (DIS-based pseudonode naming matches the LSDB).
+        add_lan(&mut graph, 7, "s.04", &[(0, 10), (2, 1)]);
+        add_lan(&mut graph, 8, "n1.03", &[(1, 1), (0, 10)]);
+        add_lan(&mut graph, 9, "n2.04", &[(2, 1), (3, 1)]);
+        add_lan(&mut graph, 10, "r1.04", &[(3, 1), (1, 1)]);
+
+        // P2P links (symmetric metric in both directions).
+        let p2p = [(1, 4, 1), (1, 6, 1), (3, 4, 1000), (4, 5, 1000), (5, 6, 1)];
+        for &(a, b, cost) in &p2p {
+            graph
+                .get_mut(&a)
+                .unwrap()
+                .olinks
+                .push(Link::new(a, b, cost));
+            graph
+                .get_mut(&b)
+                .unwrap()
+                .ilinks
+                .push(Link::new(a, b, cost));
+            graph
+                .get_mut(&b)
+                .unwrap()
+                .olinks
+                .push(Link::new(b, a, cost));
+            graph
+                .get_mut(&a)
+                .unwrap()
+                .ilinks
+                .push(Link::new(b, a, cost));
+        }
+        graph
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use std::collections::BTreeSet;
 
+    use super::fixtures::*;
     use super::*;
 
     // RFC 9855 §5 TI-LFA topology, modelled as all-LAN. Each
@@ -856,144 +1057,6 @@ mod tests {
         assert_eq!(n.cost, 20);
         assert_eq!(n.paths.len(), 1);
         assert_eq!(*n.paths.first().unwrap(), vec![1, 3]);
-    }
-
-    fn tilfa_graph() -> Graph {
-        let mut graph = BTreeMap::new();
-
-        // Insert vertices
-        let vertices = [
-            Vertex::new_node("S", 0),
-            Vertex::new_node("N1", 1),
-            Vertex::new_node("N2", 2),
-            Vertex::new_node("N3", 3),
-            Vertex::new_node("R1", 4),
-            Vertex::new_node("R2", 5),
-            Vertex::new_node("R3", 6),
-            Vertex::new_node("D", 7),
-        ];
-
-        for vertex in vertices.iter() {
-            graph.insert(vertex.id, vertex.clone());
-        }
-
-        // Define links
-        let links = vec![
-            // S
-            (0, 1, 1),    // N1
-            (0, 2, 1),    // N2
-            (0, 3, 1000), // N3
-            // N1
-            (1, 0, 1), // S
-            (1, 4, 1), // R1
-            (1, 5, 1), // R2
-            (1, 7, 1), // D
-            // N2
-            (2, 0, 1), // S
-            (2, 4, 1), // R1
-            // N3
-            (3, 0, 1000), // S
-            (3, 4, 1000), // R1
-            // R1
-            (4, 1, 1),    // N1
-            (4, 2, 1),    // N2
-            (4, 3, 1000), // N3
-            (4, 5, 1000), // R2
-            // R2
-            (5, 1, 1),    // N1
-            (5, 4, 1000), // R1
-            (5, 6, 1000), // R3
-            // R3
-            (6, 5, 1000), // R2
-            (6, 7, 1),    // D
-            // D
-            (7, 1, 1), // N1
-            (7, 6, 1), // R3
-        ];
-
-        // Insert links into vertices
-        for (from, to, cost) in links {
-            graph
-                .get_mut(&from)
-                .unwrap()
-                .olinks
-                .push(Link::new(from, to, cost));
-            graph
-                .get_mut(&to)
-                .unwrap()
-                .ilinks
-                .push(Link::new(from, to, cost));
-        }
-        graph
-    }
-
-    /// Attach a pseudonode (one per IS-IS LAN) to the graph.
-    ///
-    /// `members` is a list of (router_id, router-side cost). For each
-    /// member the helper appends:
-    ///   router → PN  with the router's interface cost
-    ///   PN     → router  with cost 0  (always — IS-IS LAN modelling)
-    /// olinks/ilinks stay symmetric so reverse SPF (used by Q-space)
-    /// works the same as for P2P links.
-    fn add_lan(graph: &mut Graph, pn_id: usize, name: &str, members: &[(usize, u32)]) {
-        graph.insert(pn_id, Vertex::new_pseudo_node(name, pn_id));
-        for &(rtr, cost) in members {
-            graph
-                .get_mut(&rtr)
-                .unwrap()
-                .olinks
-                .push(Link::new(rtr, pn_id, cost));
-            graph
-                .get_mut(&pn_id)
-                .unwrap()
-                .ilinks
-                .push(Link::new(rtr, pn_id, cost));
-            graph
-                .get_mut(&pn_id)
-                .unwrap()
-                .olinks
-                .push(Link::new(pn_id, rtr, 0));
-            graph
-                .get_mut(&rtr)
-                .unwrap()
-                .ilinks
-                .push(Link::new(pn_id, rtr, 0));
-        }
-    }
-
-    /// Same systems as `tilfa_graph()`, but each underlying point-to-point
-    /// link is rebuilt as an IS-IS LAN with one pseudonode (ids 8..=18).
-    /// SPF cost between any two routers is preserved by construction.
-    fn isis_lan_graph() -> Graph {
-        let mut graph = BTreeMap::new();
-
-        for r in [
-            Vertex::new_node("S", 0),
-            Vertex::new_node("N1", 1),
-            Vertex::new_node("N2", 2),
-            Vertex::new_node("N3", 3),
-            Vertex::new_node("R1", 4),
-            Vertex::new_node("R2", 5),
-            Vertex::new_node("R3", 6),
-            Vertex::new_node("D", 7),
-        ] {
-            graph.insert(r.id, r);
-        }
-
-        // 11 LANs, one pseudonode each. Costs mirror tilfa_graph().
-        add_lan(&mut graph, 8, "PN_S_N1", &[(0, 1), (1, 1)]);
-        add_lan(&mut graph, 9, "PN_S_N2", &[(0, 1), (2, 1)]);
-        add_lan(&mut graph, 10, "PN_S_N3", &[(0, 1000), (3, 1000)]);
-        add_lan(&mut graph, 11, "PN_N1_R1", &[(1, 1), (4, 1)]);
-        add_lan(&mut graph, 12, "PN_N1_R2", &[(1, 1), (5, 1)]);
-        add_lan(&mut graph, 13, "PN_N1_D", &[(1, 1), (7, 1)]);
-        add_lan(&mut graph, 14, "PN_N2_R1", &[(2, 1), (4, 1)]);
-        add_lan(&mut graph, 15, "PN_N3_R1", &[(3, 1000), (4, 1000)]);
-        add_lan(&mut graph, 16, "PN_R1_R2", &[(4, 1000), (5, 1000)]);
-        add_lan(&mut graph, 17, "PN_R2_R3", &[(5, 1000), (6, 1000)]);
-        add_lan(&mut graph, 18, "PN_R3_D", &[(6, 1), (7, 1)]);
-
-        graph
     }
 
     fn seg_disp(graph: &Graph, seg: &SrSegment) -> String {
@@ -1452,61 +1515,6 @@ mod tests {
             BTreeSet::from([(1, 10)]),
             "B must inherit A's first_hop_links (root→A link_id), not the A→B link's id"
         );
-    }
-
-    /// Mixed LAN/P2P topology drawn from a live IS-IS LSDB
-    /// ("TI-LFA Draft with Link#"). Reproduces the scenario where the
-    /// only LANs sit between {s,n2}, {s,n1}, {n2,r1}, {r1,n1}, and the
-    /// r1↔r2 / r2↔r3 / r3↔d links are point-to-point. SPF cost from s:
-    /// every LAN crossing costs s=10 / others=1; P2P r1↔r2 and r2↔r3
-    /// are metric 1000; n1↔r2, n1↔d, r3↔d are metric 1. With X=n1,
-    /// r1 has equal-cost paths from s with and without n1 — required
-    /// to land r1 in P-space and trigger the pending_via leak below.
-    fn mixed_lan_p2p_graph() -> Graph {
-        let mut graph = BTreeMap::new();
-        for v in [
-            Vertex::new_node("s", 0),
-            Vertex::new_node("n1", 1),
-            Vertex::new_node("n2", 2),
-            Vertex::new_node("r1", 3),
-            Vertex::new_node("r2", 4),
-            Vertex::new_node("r3", 5),
-            Vertex::new_node("d", 6),
-        ] {
-            graph.insert(v.id, v);
-        }
-
-        // LANs (DIS-based pseudonode naming matches the LSDB).
-        add_lan(&mut graph, 7, "s.04", &[(0, 10), (2, 1)]);
-        add_lan(&mut graph, 8, "n1.03", &[(1, 1), (0, 10)]);
-        add_lan(&mut graph, 9, "n2.04", &[(2, 1), (3, 1)]);
-        add_lan(&mut graph, 10, "r1.04", &[(3, 1), (1, 1)]);
-
-        // P2P links (symmetric metric in both directions).
-        let p2p = [(1, 4, 1), (1, 6, 1), (3, 4, 1000), (4, 5, 1000), (5, 6, 1)];
-        for &(a, b, cost) in &p2p {
-            graph
-                .get_mut(&a)
-                .unwrap()
-                .olinks
-                .push(Link::new(a, b, cost));
-            graph
-                .get_mut(&b)
-                .unwrap()
-                .ilinks
-                .push(Link::new(a, b, cost));
-            graph
-                .get_mut(&b)
-                .unwrap()
-                .olinks
-                .push(Link::new(b, a, cost));
-            graph
-                .get_mut(&a)
-                .unwrap()
-                .ilinks
-                .push(Link::new(b, a, cost));
-        }
-        graph
     }
 
     /// Regression: `make_repair_list` used to leak `pending_via`

--- a/zebra-rs/src/spf/mod.rs
+++ b/zebra-rs/src/spf/mod.rs
@@ -1,6 +1,9 @@
 pub mod calc;
 pub use calc::*;
 
+pub mod tilfa_par;
+pub use tilfa_par::*;
+
 pub mod diff;
 pub use diff::*;
 

--- a/zebra-rs/src/spf/tilfa_par.rs
+++ b/zebra-rs/src/spf/tilfa_par.rs
@@ -1,0 +1,614 @@
+//! Parallel TI-LFA computation (design:
+//! `docs/design/isis-tilfa-parallel-spf.md`).
+//!
+//! The per-destination TI-LFA work decomposes into jobs with two
+//! exact identities (verified by the PR-A oracle tests in `calc.rs`):
+//!
+//! * **I1** — the P-space SPF is byte-identical to the primary
+//!   reachability SPF; only the per-`x` filter differs. No mode here
+//!   runs it: every mode derives P-space via
+//!   [`p_space_from_spf`] over the caller's primary SPF result.
+//! * **I2** — the PC-path (x-excluded) SPF depends on the protected
+//!   node `x` only, not the destination; destinations behind the same
+//!   first hop can share one tree.
+//!
+//! What remains per destination is the Q-space reverse SPF plus the
+//! SPF-free reduce ([`repair_from_parts`]). The
+//! [`TilfaComputeMode`]s differ in how those jobs are scheduled on
+//! the rayon global pool — see each variant. All modes return the
+//! same map; equivalence against the [`super::calc::tilfa`] reference
+//! is pinned by the tests at the bottom.
+
+use std::collections::{BTreeMap, BTreeSet, HashMap};
+use std::time::{Duration, Instant};
+
+use rayon::prelude::*;
+
+use super::calc::{
+    Graph, Path, RepairPath, SpfDirect, SpfOpt, p_space_from_spf, q_space_vertices,
+    repair_from_parts, spf_calc,
+};
+
+/// How the per-destination TI-LFA computation is executed.
+/// Operator-facing via `fast-reroute ti-lfa compute-mode` (plus
+/// `compute-shards` for [`Self::Sharding`]).
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+pub enum TilfaComputeMode {
+    /// Sequential loop on the SPF worker thread; rayon is never
+    /// touched. 2 SPFs per target.
+    #[default]
+    Serial,
+    /// One parallel task per destination running the serial loop's
+    /// body — 2 SPFs per task, no shared SPF work between tasks.
+    Conservative,
+    /// SPF-granularity map-reduce: phase A computes the PC tree per
+    /// distinct protected node in parallel, phase B runs each
+    /// target's Q SPF with the reduce fused in. Full PC dedup
+    /// (`N + |X|` SPFs), fastest wall clock.
+    Aggressive,
+    /// Targets grouped by protected node and LPT-bin-packed into at
+    /// most this many parallel shards — the operator's hard upper
+    /// bound on TI-LFA parallelism. Each shard computes a group's PC
+    /// tree once, so the SPF count matches Aggressive.
+    Sharding(u16),
+}
+
+impl std::fmt::Display for TilfaComputeMode {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            TilfaComputeMode::Serial => write!(f, "serial"),
+            TilfaComputeMode::Conservative => write!(f, "conservative"),
+            TilfaComputeMode::Aggressive => write!(f, "aggressive"),
+            TilfaComputeMode::Sharding(k) => write!(f, "sharding({k})"),
+        }
+    }
+}
+
+/// One TI-LFA computation target, as planned by the protocol caller
+/// (IS-IS: `isis::tilfa::tilfa_targets`): a destination vertex and
+/// the protected vertex `x` (its primary first-hop node).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct TilfaTarget {
+    pub d: usize,
+    pub x: usize,
+}
+
+/// Per-run TI-LFA compute telemetry, surfaced by `show isis spf`.
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+pub struct TilfaStats {
+    /// Scheduling mode this run executed under.
+    pub mode: TilfaComputeMode,
+    /// Protected destinations computed this run.
+    pub targets: usize,
+    /// Q-space reverse SPFs run (one per target).
+    pub q_spf: usize,
+    /// PC-path (x-excluded) SPFs run.
+    pub pc_spf: usize,
+    /// PC SPFs avoided by sharing one tree across the destinations
+    /// behind the same protected node (`targets - distinct x`).
+    pub pc_deduped: usize,
+    /// Maximum worker parallelism for the run (1 = sequential).
+    pub width: usize,
+    /// Wall-clock time of the whole TI-LFA computation.
+    pub duration: Duration,
+}
+
+impl TilfaStats {
+    /// Fold another run's stats in (legacy + MT2 topologies run
+    /// sequentially within one SPF cycle, so durations add and the
+    /// width is whichever run fanned out wider).
+    pub fn merge(self, other: TilfaStats) -> TilfaStats {
+        TilfaStats {
+            mode: self.mode,
+            targets: self.targets + other.targets,
+            q_spf: self.q_spf + other.q_spf,
+            pc_spf: self.pc_spf + other.pc_spf,
+            pc_deduped: self.pc_deduped + other.pc_deduped,
+            width: self.width.max(other.width),
+            duration: self.duration + other.duration,
+        }
+    }
+}
+
+/// An x-group: one protected node and the targets behind it — the
+/// PC-SPF sharing unit for the sharding mode.
+type XGroup = (usize, Vec<TilfaTarget>);
+
+/// Compute TI-LFA repair paths for `targets`, scheduling the work per
+/// `mode`. `spf_result` must be the primary full-path SPF tree rooted
+/// at `source` on this `graph` (it seeds the P-space filters — I1).
+/// Destinations whose repair list comes back empty are omitted from
+/// the map, matching the historical per-destination loop.
+pub fn tilfa_compute(
+    graph: &Graph,
+    source: usize,
+    spf_result: &BTreeMap<usize, Path>,
+    targets: &[TilfaTarget],
+    mode: TilfaComputeMode,
+) -> (BTreeMap<usize, Vec<RepairPath>>, TilfaStats) {
+    let start = Instant::now();
+    if targets.is_empty() {
+        let stats = TilfaStats {
+            mode,
+            width: 1,
+            duration: start.elapsed(),
+            ..TilfaStats::default()
+        };
+        return (BTreeMap::new(), stats);
+    }
+
+    // P-space per distinct protected node — filters over the primary
+    // SPF result, no SPF (I1). Cheap; shared read-only by every mode.
+    let p_sets: HashMap<usize, BTreeSet<usize>> = targets
+        .iter()
+        .map(|t| t.x)
+        .collect::<BTreeSet<_>>()
+        .into_iter()
+        .map(|x| (x, p_space_from_spf(spf_result, source, &[x])))
+        .collect();
+
+    let (result, mut stats) = match mode {
+        TilfaComputeMode::Serial => run_per_target(graph, source, targets, &p_sets, false),
+        TilfaComputeMode::Conservative => run_per_target(graph, source, targets, &p_sets, true),
+        TilfaComputeMode::Aggressive => run_aggressive(graph, source, targets, &p_sets),
+        TilfaComputeMode::Sharding(k) => run_sharded(graph, source, targets, &p_sets, k),
+    };
+    stats.mode = mode;
+    stats.targets = targets.len();
+    stats.duration = start.elapsed();
+    (result, stats)
+}
+
+/// One target's computation: Q-space reverse SPF + PC-path SPF +
+/// reduce. The body shared by the serial and conservative modes (the
+/// PC tree is *recomputed* per target here — that is conservative's
+/// no-shared-state simplicity tradeoff; aggressive/sharding share it
+/// per `x` instead).
+fn per_target(
+    graph: &Graph,
+    source: usize,
+    p: &BTreeSet<usize>,
+    t: TilfaTarget,
+) -> (usize, Vec<RepairPath>) {
+    let q = q_space_vertices(graph, t.d, &[t.x]);
+    let pc = spf_calc(
+        graph,
+        source,
+        &[t.x],
+        &SpfOpt::full_path(),
+        &SpfDirect::Normal,
+    );
+    let repairs = pc
+        .get(&t.d)
+        .map(|dp| repair_from_parts(graph, source, p, &q, &dp.paths, &dp.first_hop_links))
+        .unwrap_or_default();
+    (t.d, repairs)
+}
+
+fn run_per_target(
+    graph: &Graph,
+    source: usize,
+    targets: &[TilfaTarget],
+    p_sets: &HashMap<usize, BTreeSet<usize>>,
+    parallel: bool,
+) -> (BTreeMap<usize, Vec<RepairPath>>, TilfaStats) {
+    let pairs: Vec<(usize, Vec<RepairPath>)> = if parallel {
+        targets
+            .par_iter()
+            .map(|t| per_target(graph, source, &p_sets[&t.x], *t))
+            .collect()
+    } else {
+        targets
+            .iter()
+            .map(|t| per_target(graph, source, &p_sets[&t.x], *t))
+            .collect()
+    };
+    let stats = TilfaStats {
+        q_spf: targets.len(),
+        pc_spf: targets.len(),
+        pc_deduped: 0,
+        width: if parallel {
+            rayon::current_num_threads()
+        } else {
+            1
+        },
+        ..TilfaStats::default()
+    };
+    (collect_nonempty(pairs), stats)
+}
+
+fn run_aggressive(
+    graph: &Graph,
+    source: usize,
+    targets: &[TilfaTarget],
+    p_sets: &HashMap<usize, BTreeSet<usize>>,
+) -> (BTreeMap<usize, Vec<RepairPath>>, TilfaStats) {
+    // Phase A: one x-excluded PC SPF per distinct protected node (I2).
+    let xs: Vec<usize> = p_sets.keys().copied().collect();
+    let pc_trees: HashMap<usize, BTreeMap<usize, Path>> = xs
+        .par_iter()
+        .map(|&x| {
+            (
+                x,
+                spf_calc(
+                    graph,
+                    source,
+                    &[x],
+                    &SpfOpt::full_path(),
+                    &SpfDirect::Normal,
+                ),
+            )
+        })
+        .collect();
+
+    // Phase B: per-target Q SPF with the reduce fused in, so no
+    // N-sized intermediate barrier — each task drops its Q set on
+    // emit.
+    let pairs: Vec<(usize, Vec<RepairPath>)> = targets
+        .par_iter()
+        .map(|t| {
+            let q = q_space_vertices(graph, t.d, &[t.x]);
+            let repairs = pc_trees[&t.x]
+                .get(&t.d)
+                .map(|dp| {
+                    repair_from_parts(
+                        graph,
+                        source,
+                        &p_sets[&t.x],
+                        &q,
+                        &dp.paths,
+                        &dp.first_hop_links,
+                    )
+                })
+                .unwrap_or_default();
+            (t.d, repairs)
+        })
+        .collect();
+
+    let stats = TilfaStats {
+        q_spf: targets.len(),
+        pc_spf: xs.len(),
+        pc_deduped: targets.len() - xs.len(),
+        width: rayon::current_num_threads(),
+        ..TilfaStats::default()
+    };
+    (collect_nonempty(pairs), stats)
+}
+
+fn run_sharded(
+    graph: &Graph,
+    source: usize,
+    targets: &[TilfaTarget],
+    p_sets: &HashMap<usize, BTreeSet<usize>>,
+    k: u16,
+) -> (BTreeMap<usize, Vec<RepairPath>>, TilfaStats) {
+    let k = (k.max(1)) as usize;
+    let groups = group_by_x(targets);
+    let group_count = groups.len();
+    let shards = lpt_binpack(groups, k);
+
+    let per_shard: Vec<Vec<(usize, Vec<RepairPath>)>> = shards
+        .par_iter()
+        .map(|shard| {
+            let mut out = Vec::new();
+            for (x, ts) in shard {
+                // One PC tree per group; dropped at group end so a
+                // shard keeps at most one tree alive.
+                let pc = spf_calc(
+                    graph,
+                    source,
+                    &[*x],
+                    &SpfOpt::full_path(),
+                    &SpfDirect::Normal,
+                );
+                let p = &p_sets[x];
+                for t in ts {
+                    let q = q_space_vertices(graph, t.d, &[t.x]);
+                    let repairs = pc
+                        .get(&t.d)
+                        .map(|dp| {
+                            repair_from_parts(graph, source, p, &q, &dp.paths, &dp.first_hop_links)
+                        })
+                        .unwrap_or_default();
+                    out.push((t.d, repairs));
+                }
+            }
+            out
+        })
+        .collect();
+
+    let stats = TilfaStats {
+        q_spf: targets.len(),
+        pc_spf: group_count,
+        pc_deduped: targets.len() - group_count,
+        width: k.min(rayon::current_num_threads()),
+        ..TilfaStats::default()
+    };
+    (
+        collect_nonempty(per_shard.into_iter().flatten().collect()),
+        stats,
+    )
+}
+
+/// Insert-if-nonempty, matching the historical per-destination loop:
+/// a destination with no computable repair is absent from the map,
+/// not present-with-empty.
+fn collect_nonempty(pairs: Vec<(usize, Vec<RepairPath>)>) -> BTreeMap<usize, Vec<RepairPath>> {
+    pairs
+        .into_iter()
+        .filter(|(_, repairs)| !repairs.is_empty())
+        .collect()
+}
+
+/// Group targets by protected node, sorted by `x` for determinism.
+fn group_by_x(targets: &[TilfaTarget]) -> Vec<XGroup> {
+    let mut groups: BTreeMap<usize, Vec<TilfaTarget>> = BTreeMap::new();
+    for t in targets {
+        groups.entry(t.x).or_default().push(*t);
+    }
+    groups.into_iter().collect()
+}
+
+/// Longest-processing-time bin packing: groups sorted by target count
+/// (descending, `x` ascending as the deterministic tie-break), each
+/// placed into the currently least-loaded bin (lowest index on ties).
+/// Returns at most `k` non-empty bins; a group is never split, which
+/// is what keeps the per-shard PC-tree sharing exact.
+fn lpt_binpack(mut groups: Vec<XGroup>, k: usize) -> Vec<Vec<XGroup>> {
+    groups.sort_by(|a, b| b.1.len().cmp(&a.1.len()).then(a.0.cmp(&b.0)));
+    let bins = k.min(groups.len()).max(1);
+    let mut shards: Vec<Vec<XGroup>> = vec![Vec::new(); bins];
+    let mut loads = vec![0usize; bins];
+    for group in groups {
+        let lightest = loads
+            .iter()
+            .enumerate()
+            .min_by_key(|(idx, load)| (**load, *idx))
+            .map(|(idx, _)| idx)
+            .unwrap_or(0);
+        loads[lightest] += group.1.len();
+        shards[lightest].push(group);
+    }
+    shards.retain(|shard| !shard.is_empty());
+    shards
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::spf::calc::fixtures::*;
+    use crate::spf::calc::{Link, Vertex, spf, tilfa};
+
+    /// Deterministic splitmix-style generator — no rand dependency,
+    /// stable across platforms so the random-graph cases are
+    /// reproducible from the seed alone.
+    struct Lcg(u64);
+
+    impl Lcg {
+        fn next(&mut self) -> u64 {
+            self.0 = self
+                .0
+                .wrapping_mul(6364136223846793005)
+                .wrapping_add(1442695040888963407);
+            self.0 >> 33
+        }
+    }
+
+    /// Strongly-connected random graph: a bidirectional ring backbone
+    /// plus ~2n extra random edges. No parallel duplicate edges and
+    /// `link_id` 0 everywhere, so repair-path equality is exact (the
+    /// `first_hop_links` HashSet pick is degenerate at a single
+    /// link_id value).
+    fn random_graph(seed: u64, n: usize) -> Graph {
+        let mut graph: Graph = BTreeMap::new();
+        for i in 0..n {
+            graph.insert(i, Vertex::new_node(&format!("N{i}"), i));
+        }
+        let mut rng = Lcg(seed);
+        let mut edges = BTreeSet::new();
+        for i in 0..n {
+            edges.insert((i, (i + 1) % n));
+            edges.insert(((i + 1) % n, i));
+        }
+        for _ in 0..2 * n {
+            let a = (rng.next() as usize) % n;
+            let b = (rng.next() as usize) % n;
+            if a != b {
+                edges.insert((a, b));
+                edges.insert((b, a));
+            }
+        }
+        for (a, b) in edges {
+            let cost = 1 + (rng.next() % 10) as u32;
+            graph
+                .get_mut(&a)
+                .unwrap()
+                .olinks
+                .push(Link::new(a, b, cost));
+            graph
+                .get_mut(&b)
+                .unwrap()
+                .ilinks
+                .push(Link::new(a, b, cost));
+        }
+        graph
+    }
+
+    /// IS-IS-style target derivation (mirrors
+    /// `isis::tilfa::tilfa_targets` minus the lsp_map pseudonode-
+    /// destination skip, which doesn't affect mode equivalence).
+    fn derive_targets(
+        graph: &Graph,
+        source: usize,
+        primary: &BTreeMap<usize, Path>,
+    ) -> Vec<TilfaTarget> {
+        let mut targets = Vec::new();
+        for (d, path) in primary {
+            if *d == source || path.paths.len() > 1 {
+                continue;
+            }
+            let Some(first) = path.paths.first() else {
+                continue;
+            };
+            if first.is_empty() {
+                continue;
+            }
+            let x = if graph.get(&first[0]).is_some_and(|v| v.is_pseudo_node()) {
+                first.get(1).copied().unwrap_or(first[0])
+            } else {
+                first[0]
+            };
+            targets.push(TilfaTarget { d: *d, x });
+        }
+        targets
+    }
+
+    /// The reference: the historical per-destination `spf::tilfa`
+    /// loop (3 SPFs per destination, insert-if-nonempty).
+    fn reference(
+        graph: &Graph,
+        source: usize,
+        targets: &[TilfaTarget],
+    ) -> BTreeMap<usize, Vec<RepairPath>> {
+        let mut out = BTreeMap::new();
+        for t in targets {
+            let repairs = tilfa(graph, source, t.d, &[t.x]);
+            if !repairs.is_empty() {
+                out.insert(t.d, repairs);
+            }
+        }
+        out
+    }
+
+    #[test]
+    fn modes_match_reference() {
+        let mut cases: Vec<Graph> = vec![tilfa_graph(), isis_lan_graph(), mixed_lan_p2p_graph()];
+        for seed in 1..=5u64 {
+            cases.push(random_graph(seed, 20 + (seed as usize) * 4));
+        }
+
+        let modes = [
+            TilfaComputeMode::Serial,
+            TilfaComputeMode::Conservative,
+            TilfaComputeMode::Aggressive,
+            TilfaComputeMode::Sharding(1),
+            TilfaComputeMode::Sharding(2),
+            TilfaComputeMode::Sharding(7),
+        ];
+
+        for (idx, graph) in cases.iter().enumerate() {
+            let source = 0;
+            let primary = spf(graph, source, &SpfOpt::full_path());
+            let targets = derive_targets(graph, source, &primary);
+            assert!(!targets.is_empty(), "case {idx}: no targets derived");
+            let want = reference(graph, source, &targets);
+            for mode in modes {
+                let (got, stats) = tilfa_compute(graph, source, &primary, &targets, mode);
+                assert_eq!(got, want, "case {idx} mode {mode:?}");
+                assert_eq!(stats.targets, targets.len(), "case {idx} mode {mode:?}");
+            }
+        }
+    }
+
+    /// SPF counters per mode on the RFC 9855 fixture: 6 targets over
+    /// 3 distinct protected nodes (d=4 is ECMP-skipped). Serial and
+    /// conservative recompute PC per target; aggressive and sharding
+    /// share it per x.
+    #[test]
+    fn stats_reflect_spf_sharing() {
+        let graph = tilfa_graph();
+        let primary = spf(&graph, 0, &SpfOpt::full_path());
+        let targets = derive_targets(&graph, 0, &primary);
+        assert_eq!(targets.len(), 6);
+        let distinct_x: BTreeSet<usize> = targets.iter().map(|t| t.x).collect();
+        assert_eq!(distinct_x.len(), 3);
+
+        let (_, serial) = tilfa_compute(&graph, 0, &primary, &targets, TilfaComputeMode::Serial);
+        assert_eq!((serial.q_spf, serial.pc_spf, serial.pc_deduped), (6, 6, 0));
+        assert_eq!(serial.width, 1);
+
+        let (_, aggr) = tilfa_compute(&graph, 0, &primary, &targets, TilfaComputeMode::Aggressive);
+        assert_eq!((aggr.q_spf, aggr.pc_spf, aggr.pc_deduped), (6, 3, 3));
+
+        let (_, shard) =
+            tilfa_compute(&graph, 0, &primary, &targets, TilfaComputeMode::Sharding(2));
+        assert_eq!((shard.q_spf, shard.pc_spf, shard.pc_deduped), (6, 3, 3));
+        assert!(shard.width <= 2);
+    }
+
+    #[test]
+    fn empty_targets_short_circuit() {
+        let graph = tilfa_graph();
+        let primary = spf(&graph, 0, &SpfOpt::full_path());
+        for mode in [
+            TilfaComputeMode::Serial,
+            TilfaComputeMode::Conservative,
+            TilfaComputeMode::Aggressive,
+            TilfaComputeMode::Sharding(4),
+        ] {
+            let (got, stats) = tilfa_compute(&graph, 0, &primary, &[], mode);
+            assert!(got.is_empty());
+            assert_eq!(stats.targets, 0);
+        }
+    }
+
+    fn group(x: usize, n: usize) -> XGroup {
+        (
+            x,
+            (0..n).map(|i| TilfaTarget { d: 100 * x + i, x }).collect(),
+        )
+    }
+
+    #[test]
+    fn lpt_binpack_balances_without_splitting_groups() {
+        // Sizes 5,4,3,2,1 into 2 bins → LPT loads 8/7.
+        let groups = vec![
+            group(1, 5),
+            group(2, 4),
+            group(3, 3),
+            group(4, 2),
+            group(5, 1),
+        ];
+        let shards = lpt_binpack(groups, 2);
+        assert_eq!(shards.len(), 2);
+        let mut loads: Vec<usize> = shards
+            .iter()
+            .map(|s| s.iter().map(|(_, ts)| ts.len()).sum())
+            .collect();
+        loads.sort();
+        assert_eq!(loads, vec![7, 8]);
+        // Every group lands in exactly one shard (no split, no loss).
+        let mut xs: Vec<usize> = shards
+            .iter()
+            .flat_map(|s| s.iter().map(|(x, _)| *x))
+            .collect();
+        xs.sort();
+        assert_eq!(xs, vec![1, 2, 3, 4, 5]);
+    }
+
+    #[test]
+    fn lpt_binpack_bounds() {
+        // k = 1 → everything in one shard.
+        let shards = lpt_binpack(vec![group(1, 3), group(2, 2)], 1);
+        assert_eq!(shards.len(), 1);
+        // k > group count → one group per shard, no empties.
+        let shards = lpt_binpack(vec![group(1, 3), group(2, 2)], 8);
+        assert_eq!(shards.len(), 2);
+        assert!(shards.iter().all(|s| s.len() == 1));
+    }
+
+    #[test]
+    fn group_by_x_is_sorted_and_lossless() {
+        let targets = vec![
+            TilfaTarget { d: 9, x: 3 },
+            TilfaTarget { d: 5, x: 1 },
+            TilfaTarget { d: 6, x: 3 },
+            TilfaTarget { d: 7, x: 1 },
+        ];
+        let groups = group_by_x(&targets);
+        let xs: Vec<usize> = groups.iter().map(|(x, _)| *x).collect();
+        assert_eq!(xs, vec![1, 3]);
+        let total: usize = groups.iter().map(|(_, ts)| ts.len()).sum();
+        assert_eq!(total, targets.len());
+    }
+}

--- a/zebra-rs/yang/config.yang
+++ b/zebra-rs/yang/config.yang
@@ -1508,6 +1508,38 @@ module config {
             // SR-MPLS labels, so segment-routing/mpls must also be
             // enabled for the repair to install in the dataplane.
             presence "Enable Topology-Independent LFA (TI-LFA)";
+
+            leaf compute-mode {
+              ext:help "How the TI-LFA computation is scheduled";
+              // Execution scheduling for the per-destination TI-LFA
+              // computation (design: docs/design/isis-tilfa-parallel-
+              // spf.md). Results are identical across modes — only
+              // CPU usage and wall-clock differ. `serial` runs on the
+              // SPF worker thread; `conservative` fans out one task
+              // per destination; `aggressive` additionally shares the
+              // PC-path SPF across destinations behind the same
+              // protected node; `sharding` is the aggressive work
+              // split into at most `compute-shards` parallel shards.
+              type enumeration {
+                enum serial;
+                enum conservative;
+                enum aggressive;
+                enum sharding;
+              }
+              default "serial";
+            }
+
+            leaf compute-shards {
+              ext:help "Max parallel TI-LFA shards (sharding mode)";
+              // Hard upper bound on TI-LFA parallelism, consulted
+              // only when `compute-mode sharding` is set. Lets an
+              // operator reserve cores for other daemons on a shared
+              // box.
+              type uint16 {
+                range "1..256";
+              }
+              default "8";
+            }
           }
           container backup-as-primary {
             // Swap the metric-sort offset between the SPF primary


### PR DESCRIPTION
## Summary

Second PR of the TI-LFA parallel SPF series (design: `docs/design/isis-tilfa-parallel-spf.md`; PR-A was #1384). Schedules the per-destination TI-LFA computation across cores, with the mode operator-configurable.

**Modes** (`spf/tilfa_par.rs`, rayon global pool, run inside the existing `compute_spf` `spawn_blocking` worker — message flow, inflight latch, and `apply_spf_result` untouched):

| mode | SPFs | max concurrent | notes |
|---|---|---|---|
| `serial` (default) | 2N | 1 | sequential; rayon never touched |
| `conservative` | 2N | min(N, cores) | one task per destination, no shared SPF work |
| `aggressive` | N+\|X\| | min(N, cores) | PC tree per protected node (phase A), Q SPF + fused reduce per target (phase B) |
| `sharding(K)` | N+\|X\| | min(K, cores) | x-groups LPT-bin-packed into ≤K shards — operator's parallelism cap |

Per the locked decisions, **no mode runs the redundant P-space SPF** (it is byte-identical to the primary SPF; each mode filters the existing result per protected node). `spf::tilfa` survives as the reference implementation / test oracle and OSPF's API until the OSPF conversion.

**Wiring**: `tilfa_targets` planner split out of `isis/tilfa.rs`; mode snapshotted into `SpfInput`; `TilfaStats` (targets, mode, workers, q/pc SPF counts, dedup savings, duration) rides `SpfOutput` → `IsisTop` → `show isis spf`. Legacy + MT2 stats merged.

**Config**: `fast-reroute ti-lfa compute-mode <serial|conservative|aggressive|sharding>` + `compute-shards <1..256>` (default 8). Mode changes re-run SPF (results identical; makes the stats observable) and re-originate nothing. VRF instances inherit via config forwarding; all instances share the rayon pool, so the process-wide ceiling stays ≈ core count.

## Test plan

- `modes_match_reference`: every mode equals the `spf::tilfa` reference loop on the three fixture topologies + 5 seeded random graphs (LCG, no new dev-dep), sharding K ∈ {1, 2, 7}.
- Planner units (x-grouping, LPT balance/bounds), stats counters (6 targets / 3 protected nodes fixture), empty-target short-circuit.
- `set`-grammar parse() pins for both new CLI paths (+ unknown-keyword rejection) in `manager.rs`.
- `cargo fmt`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo test --workspace --exclude bdd` all green locally.

BDD scenarios + the perf harness land in PR-C per the design's rollout plan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)