### PR TITLE
bfd: detect-offload for IS-IS and BGP + connected-ifindex BGP session keys

### DIFF
--- a/book/src/SUMMARY.md
+++ b/book/src/SUMMARY.md
@@ -58,6 +58,7 @@
 ## Failure Detection
 
 - [Bidirectional Forwarding Detection (BFD)](ch-10-00-bfd.md)
+  - [The XDP/eBPF Data-Plane Helper](ch-10-01-bfd-xdp-helper.md)
 
 ## Fast Reroute
 

--- a/book/src/ch-02-08-bgp-bfd.md
+++ b/book/src/ch-02-08-bgp-bfd.md
@@ -36,14 +36,11 @@ overridden per neighbour (see [Instance-level defaults](#instance-level-defaults
 | `echo-mode` | `transmit` \| `receive` \| `both` | _(off)_ | [Echo function](ch-10-00-bfd.md#echo-function) role — **single-hop only** (see [Echo](#echo)). |
 | `echo-transmit-interval` | uint (ms) | `50` | Echo TX rate (`transmit` / `both`). |
 | `echo-receive-interval` | uint (ms) | `50` | Advertised Required Min Echo RX (`receive` / `both`). |
+| `detect-offload` | boolean | `false` | [Offload expiration detection](ch-10-00-bfd.md#offloading-expiration-detection-detect-offload) to the in-kernel (XDP) watchdog — **single-hop only** (inert on multihop). |
 
 Control-packet intervals use the BFD defaults (300 ms / ×3 ⇒ ~900 ms
 detection) and are not currently tunable — see
 [Tuning intervals](ch-10-00-bfd.md#tuning-intervals) in the overview.
-In-kernel expiration detection
-([`detect-offload`](ch-10-00-bfd.md#offloading-expiration-detection-detect-offload))
-is not yet configurable on BGP neighbours — the OSPF knob landed first;
-the BGP leaf is a planned follow-up.
 
 ## Single-hop vs multi-hop — inferred by default
 
@@ -107,6 +104,34 @@ router bgp {
   }
 }
 ```
+
+## Offloading expiration detection
+
+`detect-offload true` moves the RFC 5880 §6.8.4 detection timer into the
+kernel via the per-interface `xdp-bfd-echo` helper — **single-hop
+neighbours only** (the helper attaches per interface; on iBGP / multihop
+eBGP the leaf is accepted but inert, like `echo-mode`). See
+[the overview](ch-10-00-bfd.md#offloading-expiration-detection-detect-offload)
+for the mechanism and guard-rails.
+
+```
+router bgp {
+  neighbor 10.0.0.2 {        // directly-connected eBGP
+    remote-as 65002;
+    bfd {
+      enable true;
+      detect-offload true;   // expiration detection in kernel/XDP
+    }
+  }
+}
+```
+
+To place the helper, a single-hop session is keyed by the **connected
+interface** the neighbour lives on (resolved from the interface
+addresses the RIB reports). If BFD is enabled before that address is
+known, the session starts un-keyed (helper-backed features off) and is
+re-keyed automatically the moment the covering address is learned — the
+same keying also lets the Echo helper attach for BGP neighbours.
 
 ## Instance-level defaults
 

--- a/book/src/ch-07-03-isis-bfd.md
+++ b/book/src/ch-07-03-isis-bfd.md
@@ -35,14 +35,11 @@ interface, overridden per interface (see
 | `echo-mode` | `transmit` \| `receive` \| `both` | _(off)_ | Enable the [BFD Echo function](ch-10-00-bfd.md#echo-function) on this interface's single-hop adjacencies (IPv4 or IPv6). |
 | `echo-transmit-interval` | uint (ms) | `50` | Rate we originate Echo at (`transmit` / `both`). |
 | `echo-receive-interval` | uint (ms) | `50` | Advertised Required Min Echo RX (`receive` / `both`). |
+| `detect-offload` | boolean | `false` | [Offload expiration detection](ch-10-00-bfd.md#offloading-expiration-detection-detect-offload) to the in-kernel (XDP) watchdog once the session is Up. |
 
 Control-packet intervals use the BFD defaults (300 ms / ×3 ⇒ ~900 ms
 detection) and are not currently tunable — see
 [Tuning intervals](ch-10-00-bfd.md#tuning-intervals) in the overview.
-In-kernel expiration detection
-([`detect-offload`](ch-10-00-bfd.md#offloading-expiration-detection-detect-offload))
-is not yet configurable on IS-IS attachments — the OSPF knob landed
-first; the IS-IS leaf is a planned follow-up.
 
 A session is subscribed when the adjacency comes **Up** and
 unsubscribed when it goes down. Both IPv4 and IPv6 adjacencies are
@@ -90,6 +87,29 @@ router isis {
       echo-mode both;
       echo-transmit-interval 50;
       echo-receive-interval 50;
+    }
+  }
+}
+```
+
+## Offloading expiration detection
+
+`detect-offload true` moves the RFC 5880 §6.8.4 detection timer into the
+kernel via the same per-interface `xdp-bfd-echo` helper that backs Echo:
+the XDP program re-arms a per-session timer on every arriving control
+packet and the expiry fires in softirq, immune to daemon scheduling
+latency. The adjacency teardown on expiry — and the
+[hold-down](#hold-down-while-bfd-is-down) that follows — work exactly as
+with userspace detection. See
+[the overview](ch-10-00-bfd.md#offloading-expiration-detection-detect-offload)
+for the mechanism and guard-rails.
+
+```
+router isis {
+  interface eth0 {
+    bfd {
+      enable true;
+      detect-offload true;   // expiration detection in kernel/XDP
     }
   }
 }

--- a/book/src/ch-10-00-bfd.md
+++ b/book/src/ch-10-00-bfd.md
@@ -312,9 +312,13 @@ Notes and guard-rails:
   — there is no transmit half; the daemon keeps sending its own control
   packets).
 
-It is enabled per OSPF interface (or instance-wide) — see
-[OSPF BFD](ch-08-02-ospf-bfd.md#offloading-expiration-detection);
-IS-IS and BGP attachment is a planned follow-up. `show bfd peers`
+It is enabled per attachment, with the same per-interface /
+per-neighbour + instance-level inheritance as `echo-mode` — see
+[OSPF BFD](ch-08-02-ospf-bfd.md#offloading-expiration-detection),
+[IS-IS BFD](ch-07-03-isis-bfd.md#offloading-expiration-detection), and
+[BGP BFD](ch-02-08-bgp-bfd.md#offloading-expiration-detection)
+(single-hop neighbours; BGP sessions are keyed by the connected
+interface so the helper knows where to attach). `show bfd peers`
 reports where detection currently runs:
 
 ```
@@ -355,9 +359,8 @@ native timers would allow.
   **In-kernel expiration detection** (`detect-offload`,
   RFC 5880 §6.8.4 evaluated in an XDP `bpf_timer` — see
   [Offloading expiration detection](#offloading-expiration-detection-detect-offload)),
-  configurable on OSPFv2/v3 interfaces.
+  configurable on OSPFv2/v3 and IS-IS interfaces and on single-hop BGP
+  neighbours.
 - **Not yet:** configurable control-packet timers (the intervals are
   fixed at the defaults); BFD for **static routes**; per-VRF OSPF BFD;
-  a BFD `profile` mechanism; `detect-offload` on IS-IS and BGP
-  attachments (the subsystem supports it; the per-protocol knob is the
-  follow-up).
+  a BFD `profile` mechanism.

--- a/book/src/ch-10-00-bfd.md
+++ b/book/src/ch-10-00-bfd.md
@@ -247,7 +247,9 @@ session, shared by all sessions on that link, and stopped when the last one
 goes away. It needs
 `cap_net_admin,cap_bpf` (load/attach XDP) and `cap_net_raw` (the originator's
 raw socket); the packaged install grants these. A node with no Echo configured
-runs no helper and advertises `Required Min Echo RX Interval = 0`.
+runs no helper and advertises `Required Min Echo RX Interval = 0`. Deployment,
+attach modes, and troubleshooting are covered in
+[The XDP/eBPF Data-Plane Helper](ch-10-01-bfd-xdp-helper.md).
 
 Echo is enabled per attachment — on OSPFv2/v3 and IS-IS interfaces, and on
 single-hop eBGP neighbours, where `echo-mode` selects the role
@@ -310,7 +312,9 @@ Notes and guard-rails:
   kernel without XDP/`bpf_timer`), detection simply stays in userspace.
   A watchdog-only helper needs `cap_net_admin,cap_bpf` (no `cap_net_raw`
   — there is no transmit half; the daemon keeps sending its own control
-  packets).
+  packets). See
+  [The XDP/eBPF Data-Plane Helper](ch-10-01-bfd-xdp-helper.md) for
+  requirements and troubleshooting.
 
 It is enabled per attachment, with the same per-interface /
 per-neighbour + instance-level inheritance as `echo-mode` — see

--- a/book/src/ch-10-01-bfd-xdp-helper.md
+++ b/book/src/ch-10-01-bfd-xdp-helper.md
@@ -1,0 +1,144 @@
+# The XDP/eBPF Data-Plane Helper (`xdp-bfd-echo`)
+
+Two BFD features run partly *outside* the daemon, in the kernel data
+plane: the [Echo function](ch-10-00-bfd.md#echo-function) and
+[expiration-detection offload](ch-10-00-bfd.md#offloading-expiration-detection-detect-offload)
+(`detect-offload`). Both are backed by one helper program,
+**`xdp-bfd-echo`** — an XDP/eBPF program with a small userspace loader
+that zebra-rs spawns and supervises automatically, one process per
+interface that needs it.
+
+This chapter is the operational view: what runs where, what the helper
+needs from the system, how its lifecycle works, and what to check when
+it doesn't come up. The protocol-facing configuration lives in the
+per-protocol BFD chapters; the deeper design rationale (including the
+S-BFD / STAMP roadmap the same scaffolding is meant to carry) is in
+`docs/design/bfd-sbfd-stamp-xdp-offload-notes.md` in the repository.
+
+## Division of labor
+
+The split follows one rule: **anything that must react to a received
+packet at line rate lives in XDP; anything that must originate packets
+or run protocol logic lives in userspace.** XDP programs cannot send
+packets on their own — they only react — so every transmit path stays
+in software, while every receive-side deadline moves into the kernel.
+
+| Function | Where | How |
+|---|---|---|
+| Echo reflect (peer's Echo, UDP/3785) | XDP | Rewrite in place (MAC swap, TTL/Hop-Limit decrement, IPv6 src/dst swap for FRR-style peers), `XDP_TX` back out the same interface |
+| Echo originate (our Echo) | helper userspace | `AF_PACKET` raw socket, self-addressed frames on a jittered timer |
+| Echo detection (our returns stop) | XDP + `bpf_timer` | Each return re-arms a per-session kernel timer; expiry fires in softirq |
+| Control-packet expiration (`detect-offload`, UDP/3784) | XDP + `bpf_timer` | Each control packet for an Up session re-arms the timer; the frame is **always passed** to the daemon |
+| BFD state machine, Poll/Final, negotiation, control TX | zebra-rs | Unchanged — the helper never makes protocol decisions |
+
+The daemon and the helper talk over a one-line-per-message stdin/stdout
+protocol: `echo-add <discr> <local> <peer> <tx-us> <mult>` / `echo-del`
+and `detect-add <discr> <detect-us>` / `detect-del` go down;
+`echo-down <discr>` / `detect-down <discr>` come back when a kernel
+timer fires. You never drive this by hand in production, but the verbs
+appear in traces and are handy to know when debugging.
+
+## What the helper needs
+
+- **Kernel**: XDP support, and `bpf_timer` (Linux ≥ 5.15) for the two
+  detection offloads. The reflect-only path works without `bpf_timer`.
+- **Capabilities**: `cap_net_admin,cap_bpf` to load and attach the XDP
+  program, plus `cap_net_raw` only if Echo *origination* is used (the
+  `AF_PACKET` socket). The packaged `.deb` install grants all three via
+  postinstall; a hand-installed binary needs
+  `setcap cap_net_admin,cap_bpf,cap_net_raw+ep` (or root).
+- **Binary**: resolved in this order —
+  `$ZEBRA_XDP_BFD_ECHO_BIN` → `~/.zebra/bin/xdp-bfd-echo` →
+  `/usr/sbin/xdp-bfd-echo` (the packaged location).
+- **Attach mode**: `$ZEBRA_XDP_BFD_ECHO_MODE` = `auto` (default) |
+  `native` | `skb`. `auto` tries native/driver XDP and falls back to
+  generic (SKB) mode.
+
+> **Virtual NICs and veth need SKB mode.** On veth pairs and most
+> virtual NICs, native XDP *attaches successfully* but frames never
+> reach the program — a classic silent failure. Set
+> `ZEBRA_XDP_BFD_ECHO_MODE=skb` in labs and VMs. Physical NICs with
+> real driver support (mlx5, i40e/ice, ixgbe, …) should use native mode
+> for the lowest reflect jitter.
+
+The helper tree lives in `offload/xdp-bfd-echo/` and is **excluded from
+the main cargo workspace** — building it needs the nightly toolchain,
+`bpf-linker`, and LLVM (see its `README.md`). The packaged build does
+this for you; `cargo build` of zebra-rs alone never touches it.
+
+## Lifecycle
+
+The helper is **reference-counted per interface**. The first session on
+an interface that needs it — any Echo role, or `detect-offload` —
+spawns one process attached to that interface; further sessions share
+it; the last one to go away stops it (SIGTERM, which detaches the XDP
+program cleanly). A node where neither feature is configured runs no
+helper at all.
+
+Everything the helper does is gated on it being **confirmed running**
+("honesty gates"):
+
+- A non-zero `Required Min Echo RX Interval` — the promise to loop a
+  peer's Echo — is only advertised once the child is up.
+- The `detect-offload` watchdog is only armed once the child is up;
+  until then (and on any helper death) detection runs in userspace as
+  usual, and the stretched backstop timer is restored to normal
+  immediately.
+
+So a missing binary, missing capabilities, or an unsupported kernel
+never breaks BFD — the affected sessions simply behave as if the
+feature were not configured, and the daemon logs why.
+
+## Verifying and troubleshooting
+
+`show bfd peers` tells you per session what the helper is doing:
+
+```
+    Detection timeout: 900ms
+    Detection runs in: kernel/XDP (900ms)     ← detect-offload armed
+    Echo receive interval: 50ms               ← we advertise + reflect
+    Echo transmission interval: 50ms          ← we originate
+```
+
+`Detection runs in: userspace` with `detect-offload true` configured,
+or an Echo interval stuck at `disabled`, means the helper is not up for
+that interface. Check in order:
+
+1. **Is the process running?** `pgrep -a xdp-bfd-echo` — one per
+   expected interface, with `-i <ifname>` in the arguments.
+2. **Binary present and executable** at one of the resolution paths
+   above, with the capabilities set (`getcap /usr/sbin/xdp-bfd-echo`).
+3. **Attach mode**: on veth/VM NICs, force `skb` (see above). The
+   helper's own log line says which mode actually attached.
+4. **Kernel support**: `bpf_timer` needs ≥ 5.15; the verifier rejects
+   the program on older kernels.
+5. **Traces**: `set bfd tracing true` makes the daemon log helper
+   spawn/stop, the IPC verbs, and session state changes; the helper
+   itself logs to stderr (`RUST_LOG=info`).
+
+The helper can also be run standalone for testing (`xdp-bfd-echo -i
+<iface> -m skb`), and the repository ships two self-contained veth
+tests that exercise the data plane end to end as root:
+`offload/xdp-bfd-echo/scripts/veth-test.sh` (Echo reflect) and
+`scripts/veth-detect-test.sh` (the expiration watchdog: streams control
+packets, asserts the kernel timer re-arms, then fires after the stream
+stops).
+
+## Scope and limits
+
+- **Single-hop sessions only.** The helper attaches per interface;
+  multihop ingress is not bound to one (and multihop's TTL floor is
+  below the GTSM 255 the watchdog requires). Multihop sessions simply
+  keep full userspace behavior.
+- **BGP neighbours** are covered via the connected-interface keying
+  described in [BGP BFD](ch-02-08-bgp-bfd.md#offloading-expiration-detection):
+  the session is keyed by the interface whose subnet covers the
+  neighbour, learned from the RIB's interface addresses.
+- **IPv4 and IPv6** are both handled by the same program, including
+  FRR's peer-addressed IPv6 Echo dialect.
+- **No authentication.** If BFD authentication is added in the future,
+  authenticated sessions must not be offloaded — XDP cannot verify
+  MD5/SHA digests. Today zebra-rs has no BFD auth, so this is moot.
+- The same process/scaffolding is designed to grow the **S-BFD**
+  (UDP 7784/7785) and **STAMP** (UDP 862) reflectors later; see the
+  design notes for that roadmap.

--- a/docs/design/bfd-sbfd-stamp-xdp-offload-notes.md
+++ b/docs/design/bfd-sbfd-stamp-xdp-offload-notes.md
@@ -156,9 +156,17 @@ BFD Echo は本質的に「ローカルが送出 → リモートのフォワー
   入口 IF が固定でなく GTSM 床も 255 未満）。認証付きセッションは将来 BFD
   auth が入った場合オフロード禁止にすること（XDP では MD5/SHA1 を検証
   できない）。
-- **設定**: OSPF の `bfd { detect-offload true; }`（per-interface /
-  instance-level、echo-mode と同じ継承）。IS-IS / BGP への展開は echo-mode
-  と同様にフォローアップ。
+- **設定**: OSPF / IS-IS / BGP の `bfd { detect-offload true; }`
+  （per-interface または per-neighbor / instance-level、echo-mode と同じ
+  継承）。BGP は single-hop のみ（multihop では inert）。
+- **BGP の ifindex 解決（フォローアップ PR で追加）**: BGP の BFD
+  SessionKey は従来 `ifindex: 0` 固定 — per-ifindex アタッチのヘルパーが
+  **一度も起動できず**、BGP echo は実質 inert だった。`ConnectedSubnets` に
+  記録元 ifindex を持たせ（`ifindex_for`、v6 link-local は除外）、single-hop
+  セッションを connected interface でキーする。アドレス学習が `bfd enable`
+  より後なら `RibRx::AddrAdd` フックの `bfd_reconcile_all` が再キー
+  （unsubscribe→subscribe）。これで BGP の echo / detect-offload 両方が
+  実際に機能する。
 - **検証**: `scripts/veth-detect-test.sh` — 600ms 検知で 150ms 間隔の制御
   パケットを 1.2 秒流し（早発 = bootstrap fallback 発火で FAIL、つまり XDP
   再アームの実証）、停止後 ~600ms で `detect-down` が来るのを確認。

--- a/docs/design/bfd-sbfd-stamp-xdp-offload-notes.md
+++ b/docs/design/bfd-sbfd-stamp-xdp-offload-notes.md
@@ -1,51 +1,52 @@
-# BFD / S-BFD / STAMP の XDP/eBPF オフロード検討メモ
+# BFD / S-BFD / STAMP XDP/eBPF Offload — Design Notes
 
-> zebra-rs / zebra-agent 向け技術リファレンス
-> 内容: Linux 上での BFD/Echo/S-BFD/STAMP のデータプレーンオフロード可能性、商用ルータの対応状況、ディスクリミネータ運用、実装方針
-> 注: 各社の対応状況・既定値はリリース/プラットフォーム依存。実装前に最新ドキュメントで再確認すること。
-
----
-
-## 0. 要点サマリ（先に結論）
-
-- **純 XDP で BFD/Echo/S-BFD/STAMP を「丸ごと」実装した成熟プロジェクトは存在しない。** 最大の障害は **TX タイマー**（XDP は RX 起動のみで、自発的な周期送信ができない）。
-- **role を分けると整理できる**:
-  - **Reflector（折り返し側）= ステートレス → XDP の好適ユースケース**（`XDP_TX`）。
-  - **Originator/Sender（送出・検知側）= TX タイマーとタイムアウト検知が必要 → `bpf_timer`（5.15+）かユーザ空間が必須**。RX 検証は XDP が得意。
-- **S-BFD は SR-TE / SR Policy のパス継続性チェック用途が実態。** Initiator が能動、Reflector がステートレス。
-- **SRv6 では各社でアプローチが割れる**:
-  - **Cisco**: S-BFD は SR-MPLS/IPv4 専用。SRv6 liveness は **STAMP ベースの Performance Measurement (PM/IPM)**。
-  - **Juniper**: SRv6 TE パスに **S-BFD 対応**（IPv6 ディスクリミネータ）。
-  - **Nokia**: SRv6 Policy に **S-BFD 対応**。
-- **zebra-rs 実装方針**: 制御プレーン（Rust / aya ユーザ空間）と データプレーン（aya-ebpf / XDP）を分離。Reflector を XDP に置き、Originator/Sender 側はタイマー部分をユーザ空間 or `bpf_timer`。フル機能（高精度・認証・SRv6 encap）が要る所は **AF_XDP** に寄せる。
+> Technical reference for zebra-rs / zebra-agent
+> Scope: feasibility of data-plane offload for BFD/Echo/S-BFD/STAMP on Linux, commercial-router support status, discriminator management, implementation strategy
+> Note: vendor support and defaults are release/platform dependent. Re-check current documentation before implementing.
 
 ---
 
-## 1. Linux における BFD の eBPF/XDP 実装の現状
+## 0. Executive summary (conclusions first)
 
-- 純 XDP/eBPF だけで完結する成熟した BFD 実装は無い。periodic TX（ms 単位の自発送信）を eBPF が起こせないのが根本問題。
-- 既存の Linux BFD はすべてユーザ空間 or カーネルモジュール:
-  - **FRRouting `bfdd`**: 事実上の標準。BGP/OSPF/IS-IS と連携。
-  - **OpenBFDD / FreeBFD / aiobfd(Python)**: スタンドアロンのユーザ空間デーモン。
-  - **kbfd**: 旧 Quagga/zebra 時代のカーネルモジュール（メンテ停止）。
-- Cilium の BGP Control Plane への BFD 追加議論でも「純 eBPF 実装の最大の障害はタイマー送信」と明記されている。
-- **XDP の現実的な使いどころ**: セッション状態と TX タイマーはユーザ空間（or `bpf_timer`）に置き、XDP は **RX 側の高速化**（BFD 制御パケットのパース・discriminator のマップ照合・detect-timer リセット・liveness 喪失の高速検知）に使う。
+- **No mature project implements BFD/Echo/S-BFD/STAMP "wholesale" in pure XDP.** The biggest obstacle is the **TX timer** (XDP is RX-triggered only and cannot originate periodic transmission on its own).
+- **Splitting by role clarifies the picture**:
+  - **Reflector (loop-back side) = stateless → an ideal XDP use case** (`XDP_TX`).
+  - **Originator/Sender (transmit + detect side) = needs TX timers and timeout detection → requires `bpf_timer` (5.15+) or userspace.** RX validation is where XDP shines.
+- **S-BFD is, in practice, a path-continuity check for SR-TE / SR Policy.** The Initiator is active; the Reflector is stateless.
+- **For SRv6 the vendors diverge**:
+  - **Cisco**: S-BFD is SR-MPLS/IPv4 only. SRv6 liveness uses **STAMP-based Performance Measurement (PM/IPM)**.
+  - **Juniper**: **S-BFD supported** on SRv6 TE paths (IPv6 discriminators).
+  - **Nokia**: **S-BFD supported** on SRv6 Policy.
+- **zebra-rs implementation strategy**: separate the control plane (Rust / aya userspace) from the data plane (aya-ebpf / XDP). Put the Reflector in XDP; on the Originator/Sender side keep the timer half in userspace or `bpf_timer`. Where full features are needed (high-precision timestamps, authentication, SRv6 encap), lean on **AF_XDP**.
 
 ---
 
-## 2. BFD Echo と XDP（reflector / originator の分離）
+## 1. State of BFD eBPF/XDP implementations on Linux
 
-BFD Echo は本質的に「ローカルが送出 → リモートのフォワーディング面が折り返し → ローカルが戻りを見て判定」。
+- There is no mature BFD implementation that lives entirely in pure XDP/eBPF. The root problem is that eBPF cannot originate periodic TX (millisecond-interval self-clocked transmission).
+- Every existing Linux BFD is userspace or a kernel module:
+  - **FRRouting `bfdd`**: the de-facto standard. Integrates with BGP/OSPF/IS-IS.
+  - **OpenBFDD / FreeBFD / aiobfd (Python)**: standalone userspace daemons.
+  - **kbfd**: a kernel module from the old Quagga/zebra era (unmaintained).
+- The Cilium discussion about adding BFD to its BGP Control Plane states the same: "the biggest obstacle to a pure eBPF implementation is timer-driven transmission."
+- **Where XDP realistically helps**: keep session state and TX timers in userspace (or `bpf_timer`), and use XDP to **accelerate the RX side** — parsing BFD control packets, matching discriminators against a map, resetting the detect timer, and fast detection of liveness loss.
 
-### Reflector 側 = 純 XDP で完全実装可能（最良ケース）
-- UDP 3785 宛を受けたら、宛先/送信元 MAC を入れ替えて受信 IF へ `XDP_TX` で送り返すだけ。
-- L2 折り返し（MAC スワップのみ）なら理屈上は IP/UDP チェックサム再計算も TTL デクリメントも不要。
-  **【2026-06-01 訂正】** ただし実機相互接続では成り立たない。BFD Echo の折り返しは「リモートの
-  **フォワーディング面**が返す」= 1 ホップであり、FRR の forwarding-plane Echo 受信
-  (`bfd_recv_ipv4_fp`) は折り返しフレームの **TTL=254（255 から 1 減算）を必須**とし、それ以外は
-  破棄する。したがって reflector は **TTL を 1 減算し IPv4 ヘッダチェックサムを再計算（RFC 1141:
-  チェックサム += 0x0100 / 桁上げ畳み込み）する必要がある**（UDP チェックサムは TTL を含まないため
-  不変）。zebra-rs の XDP reflector は実装済み・FRR `echo-mode` と相互接続検証済み。
+---
+
+## 2. BFD Echo and XDP (separating reflector / originator)
+
+BFD Echo is essentially "local sends → the remote's forwarding plane loops it back → local watches the returns and judges."
+
+### Reflector side = fully implementable in pure XDP (the best case)
+- On receiving a packet to UDP 3785, just swap the source/destination MAC and send it back out the receiving interface with `XDP_TX`.
+- With a pure L2 loop (MAC swap only), in theory neither an IP/UDP checksum recomputation nor a TTL decrement is needed.
+  **[2026-06-01 correction]** That theory does not survive real interop. The BFD Echo loop is performed by the remote's
+  **forwarding plane** — i.e. one hop — and FRR's forwarding-plane Echo receiver
+  (`bfd_recv_ipv4_fp`) **requires TTL=254 (255 minus one decrement)** on the looped frame and
+  discards anything else. The reflector therefore **must decrement the TTL and recompute the IPv4
+  header checksum (RFC 1141: checksum += 0x0100 with end-around carry)** — the UDP checksum is
+  unaffected since TTL is not part of its pseudo-header. The zebra-rs XDP reflector implements
+  this and is interop-validated against FRR `echo-mode`.
 
   **[2026-06-07 update — FRR Echo addressing is asymmetric across IPv4/IPv6; the
   reflector must treat each differently. Found via a real-world IPv6 loop against
@@ -106,268 +107,275 @@ BFD Echo は本質的に「ローカルが送出 → リモートのフォワー
     does not break standards-compliant peers. The old code/README premise "IPv6
     Echo is self-addressed, so no swap needed" held only for our own originator;
     FRR originators are peer-addressed.
-- 「unaffiliated BFD echo」のリフレクタ概念に一致（BFD スタックを持たない機器の前段に小さな XDP リフレクタを置く構成が可能）。
+- This matches the "unaffiliated BFD echo" reflector concept (a small XDP reflector can be placed in front of a device that has no BFD stack at all).
 
-### Originator 側 = XDP 単体では不可
-- Echo の定期送出（TX）→ `bpf_timer` かユーザ空間。
-- 折り返してきた Echo の受信・検証（RX）→ XDP が得意（マップに last-seen / seq を持って照合）。
-- detect タイムアウト（戻ってこない → Down）→ タイマー起動が必要なので XDP 単体不可。
+### Originator side = not possible in XDP alone
+- Periodic Echo transmission (TX) → `bpf_timer` or userspace.
+- Receiving and validating the looped-back Echo (RX) → XDP's strength (keep last-seen / seq in a map and match).
+- Detect timeout (returns stop → Down) → needs a timer to fire, so XDP alone cannot do it.
 
-> **実装済み（as-built）**: reflector / originator とも実装済みで、ヘルパは
-> **`xdp-bfd-echo`**（旧 `bfd-echo-reflector`）に統合。ここの予測どおり TX は
-> ユーザ空間 `AF_PACKET`、detect は XDP が戻り Echo ごとに per-session
-> `bpf_timer` を arm する方式（戻りが止まると `Down` + `EchoFunctionFailed`）。
-> `bpf_timer`-from-XDP のカーネル検証はラボ確認待ち。
+> **As-built**: both reflector and originator are implemented; the helper is
+> consolidated as **`xdp-bfd-echo`** (formerly `bfd-echo-reflector`). As predicted
+> here, TX lives in userspace over `AF_PACKET`, and detection is XDP arming a
+> per-session `bpf_timer` on every returned Echo (returns stop → `Down` +
+> `EchoFunctionFailed`). The `bpf_timer`-from-XDP kernel recipe has since been
+> lab-confirmed.
 
-### 実装メモ
-- Echo ペイロードは RFC 5880 §6.4 で **"a local matter"**（送出側裁量）。自分の discriminator + seq + 送出タイムスタンプを詰めておくと RX 側 XDP のマップ照合が安価。
-- 性能は折り返しジッタが検知タイマーの攻め具合を左右 → reflector は native モード（i40e/ice/ixgbe/mlx5 等）が望ましい。
-
----
-
-## 2b. 標準 BFD 制御パケットの expiration 監視オフロード（2026-06-12 実装）
-
-§1 末尾の「XDP の現実的な使いどころ = RX 側の detect-timer リセット・liveness
-喪失の高速検知」をそのまま実装したもの。Echo originator の `bpf_timer` 検知
-（§2）と同じ機構を、**UDP/3784 の標準 BFD 制御パケット**に適用する。
-
-- **XDP 側は純粋な観測者**: 制御パケットを TTL/HopLimit==255（GTSM, RFC 5881
-  §5）・version==1 だけ確認し、Your Discriminator で `CONTROL_TIMERS`
-  (BTF map, 値は Echo と共通の `DetectState`) を引いて `bpf_timer` を再アーム、
-  フレームは**必ず `XDP_PASS`**。FSM・Poll/Final・パラメータ再交渉はすべて
-  従来どおりデーモンが処理する（liveness タイミングだけがカーネルに移る）。
-  Echo reflector と違いパケット書き換えが無いので、検証器対策も不要だった。
-- **確立後のみアーム**: 確立前はリモートが `Your Discriminator = 0` を送るため
-  マップのキーにできない。zebra-rs は Up 遷移で `detect-add <discr>
-  <detect-us>`、Up を離れたら `detect-del` をヘルパー stdin に送る
-  （`Bfd::detect_offload_reconcile`、Echo の reconcile と同形）。再交渉で
-  detection time が変わったら `detect-add` を再送（マップ要素の置換 =
-  旧タイマーはカーネルが cancel）。
-- **userspace タイマーはバックストップに格下げ**: ウォッチドッグがアーム中は
-  4 倍（`DETECT_BACKSTOP_FACTOR`）に伸ばして保持。ヘルパー死亡
-  （`Message::HelperGone`）で即 1 倍に戻す。偽 Down（デーモンが
-  スケジュールアウトしてソケットキューに溜まったのに userspace タイマーが
-  先に発火）と検知遅延の両方を排除でき、attack 的な短い検知時間
-  （sub-10ms 級）を正直に張れるようになる。
-- **送信側はオフロードしない**: 自分の制御パケット送信はデーモンのまま。
-  デーモンが完全に停止すれば相手側の検知で落ちる（こちらの RX 検知だけが
-  カーネル化される）。
-- **スコープ**: single-hop のみ（ヘルパーは per-ifindex アタッチ。multihop は
-  入口 IF が固定でなく GTSM 床も 255 未満）。認証付きセッションは将来 BFD
-  auth が入った場合オフロード禁止にすること（XDP では MD5/SHA1 を検証
-  できない）。
-- **設定**: OSPF / IS-IS / BGP の `bfd { detect-offload true; }`
-  （per-interface または per-neighbor / instance-level、echo-mode と同じ
-  継承）。BGP は single-hop のみ（multihop では inert）。
-- **BGP の ifindex 解決（フォローアップ PR で追加）**: BGP の BFD
-  SessionKey は従来 `ifindex: 0` 固定 — per-ifindex アタッチのヘルパーが
-  **一度も起動できず**、BGP echo は実質 inert だった。`ConnectedSubnets` に
-  記録元 ifindex を持たせ（`ifindex_for`、v6 link-local は除外）、single-hop
-  セッションを connected interface でキーする。アドレス学習が `bfd enable`
-  より後なら `RibRx::AddrAdd` フックの `bfd_reconcile_all` が再キー
-  （unsubscribe→subscribe）。これで BGP の echo / detect-offload 両方が
-  実際に機能する。
-- **検証**: `scripts/veth-detect-test.sh` — 600ms 検知で 150ms 間隔の制御
-  パケットを 1.2 秒流し（早発 = bootstrap fallback 発火で FAIL、つまり XDP
-  再アームの実証）、停止後 ~600ms で `detect-down` が来るのを確認。
-  2026-06-12 ラボ PASS。
+### Implementation notes
+- The Echo payload is **"a local matter"** per RFC 5880 §6.4 (sender's discretion). Packing our discriminator + seq + transmit timestamp makes the RX-side XDP map match cheap.
+- Loop-back jitter bounds how aggressively the detection timer can be set → the reflector should run in native XDP mode where possible (i40e/ice/ixgbe/mlx5 etc.).
 
 ---
 
-## 3. S-BFD (Seamless BFD) 概要
+## 2b. Expiration-watchdog offload for standard BFD control packets (implemented 2026-06-12)
 
-- **RFC 7880 (2016)。** classic BFD のハンドシェイク（Down→Init→Up の三方向）を排除した派生。
-- **事前配布された 32bit ディスクリミネータ**を使う。Initiator は対向の reflector discriminator を既知なので、ネゴ抜きで即パケット送出 → 即反射で到達性確認（1 往復で完結）。
-- **非対称な 2 役割**:
-  - **Initiator**: 能動。状態機械を持ち送出・判定。
-  - **Reflector**: ステートレス。自分の discriminator 宛パケットを受けたら my/your discriminator を入れ替えて返すだけ。
-- **ポート**: UDP 7784（S-BFD 制御） / 7785（S-BFD Echo）。※ classic は 3784/3785。
-- **用途**: オンデマンド到達性確認、**SR-TE / SR Policy のパス検証**（特定のセグメントリストに沿って流して反射を見る）。
-- **XDP 向きな理由**: reflector がステートレス（UDP 7784 一致 → your discriminator をマップ照合 → my/your 入替＋state 設定 → MAC/IP 入替 → UDP チェックサム増分更新 → `XDP_TX`）。discriminator 書換とチェックサム修正の分だけ classic echo の MAC スワップより一手間多い。
-- **関連 RFC**: 7880(コア) / 7881(IPv4/IPv6/MPLS カプセル化) / 7882(ユースケース) / 7883(IS-IS でのディスクリミネータ広告) / 7884(OSPF 拡張)。
+This implements exactly the "realistic XDP use" from the end of §1 — RX-side
+detect-timer reset and fast liveness-loss detection. It applies the same
+mechanism as the Echo originator's `bpf_timer` detection (§2) to **standard
+BFD control packets on UDP/3784**.
+
+- **The XDP side is a pure observer**: a control packet is checked only for
+  TTL/Hop-Limit == 255 (GTSM, RFC 5881 §5) and version == 1, its Your
+  Discriminator is looked up in `CONTROL_TIMERS` (a BTF map whose value is the
+  `DetectState` shared with Echo), the `bpf_timer` is re-armed, and the frame
+  is **always `XDP_PASS`ed**. The FSM, Poll/Final handling, and parameter
+  renegotiation all stay in the daemon as before (only the liveness timing
+  moves into the kernel). Unlike the Echo reflector there is no packet
+  rewriting, so no verifier workarounds were needed either.
+- **Armed only after establishment**: before establishment the remote may send
+  `Your Discriminator = 0`, which cannot key the map. zebra-rs sends
+  `detect-add <discr> <detect-us>` to the helper's stdin on the Up transition
+  and `detect-del` on leaving Up (`Bfd::detect_offload_reconcile`, same shape
+  as the Echo reconcile). When renegotiation changes the detection time,
+  `detect-add` is re-sent (a map-element replace — the kernel cancels the old
+  timer).
+- **The userspace timer is demoted to a backstop**: while the watchdog is
+  armed it is kept stretched ×4 (`DETECT_BACKSTOP_FACTOR`); on helper death
+  (`Message::HelperGone`) it is immediately restored to 1×. This eliminates
+  both false Downs (the daemon scheduled out with packets piling up in the
+  socket queue while the userspace timer fires anyway) and late detection —
+  which is what makes aggressively short detection times (sub-10 ms class)
+  honest.
+- **The transmit side is not offloaded**: our own control-packet transmission
+  stays in the daemon. If the daemon halts entirely, the peer's detection
+  takes the session down (only our RX detection is kernel-resident).
+- **Scope**: single-hop only (the helper attaches per ifindex; multihop has no
+  fixed ingress interface and its GTSM floor is below 255). If BFD
+  **authentication** ever lands, authenticated sessions must NOT be offloaded
+  (XDP cannot verify MD5/SHA1).
+- **Configuration**: `bfd { detect-offload true; }` on OSPF / IS-IS / BGP
+  (per-interface or per-neighbor, plus instance level, with the same
+  inheritance as echo-mode). BGP is single-hop only (inert on multihop).
+- **BGP ifindex resolution (added in a follow-up PR)**: BGP BFD SessionKeys
+  used to be hardcoded `ifindex: 0` — the per-ifindex helper could **never
+  start**, so BGP echo was effectively inert. `ConnectedSubnets` now keeps the
+  recording ifindex (`ifindex_for`, v6 link-locals excluded), and single-hop
+  sessions are keyed by the connected interface. If the address is learned
+  after `bfd enable`, the `RibRx::AddrAdd` hook's `bfd_reconcile_all` re-keys
+  the session (unsubscribe → subscribe). With this, both BGP echo and BGP
+  detect-offload actually work.
+- **Validation**: `scripts/veth-detect-test.sh` — with a 600 ms detection
+  time, stream control packets at 150 ms intervals for 1.2 s (a premature fire
+  = the bootstrap fallback tripping = FAIL, which is what proves the XDP
+  re-arm works), then stop and expect `detect-down` ~600 ms later.
+  Lab PASS 2026-06-12.
 
 ---
 
-## 4. 商用ルータの S-BFD 対応状況（SR-TE / SR Policy 文脈）
+## 3. S-BFD (Seamless BFD) overview
 
-> 4 社とも対応。実態は「SR-TE/SR Policy のヘッドエンドが initiator、テールが stateless reflector」。汎用リンク BFD（OSPF/IS-IS/BGP ネイバー監視）は classic BFD のまま、という住み分けが共通。
+- **RFC 7880 (2016).** A derivative that eliminates classic BFD's handshake (the three-way Down→Init→Up).
+- Uses **pre-distributed 32-bit discriminators**. The Initiator already knows the peer's reflector discriminator, so it transmits immediately without negotiation → immediate reflection confirms reachability (completes in one round trip).
+- **Two asymmetric roles**:
+  - **Initiator**: active. Owns the state machine, transmits and judges.
+  - **Reflector**: stateless. On receiving a packet addressed to its discriminator, it just swaps my/your discriminators and returns it.
+- **Ports**: UDP 7784 (S-BFD control) / 7785 (S-BFD Echo). (Classic BFD is 3784/3785.)
+- **Uses**: on-demand reachability checks, **SR-TE / SR Policy path validation** (send along a specific segment list and watch the reflection).
+- **Why it suits XDP**: the reflector is stateless (match UDP 7784 → look up your-discriminator in a map → swap my/your + set state → swap MAC/IP → incrementally update the UDP checksum → `XDP_TX`). The discriminator rewrite and checksum fix make it one step heavier than classic Echo's MAC swap.
+- **Related RFCs**: 7880 (core) / 7881 (IPv4/IPv6/MPLS encapsulation) / 7882 (use cases) / 7883 (discriminator advertisement in IS-IS) / 7884 (OSPF extension).
 
-| ベンダー | 対応 | 主な制約・メモ |
+---
+
+## 4. Commercial-router S-BFD support (in the SR-TE / SR Policy context)
+
+> All four vendors support it. In practice "the SR-TE/SR Policy headend is the initiator, the tail is a stateless reflector." Generic link BFD (OSPF/IS-IS/BGP neighbor monitoring) stays classic BFD everywhere — the division of labor is common across vendors.
+
+| Vendor | Support | Main constraints / notes |
 |---|---|---|
-| **Cisco IOS-XE (ASR1000)** | ○ | SR-TE で S-BFD。**IPv4 のみ / シングルホップのみ**。テールが reflector |
-| **Cisco IOS-XR (NCS5500)** | ✗ | **Seamless BFD 非対応** と明記。機種差が大きい（要個別確認） |
-| **Cisco IOS-XR (ASR9000 等)** | ○ | SR-TE で sBFD reflector/initiator 設定あり |
-| **Juniper (Junos / Evolved)** | ◎ | colored/non-colored SR LSP、SR policy。23.2R1〜 S-BFD FRR（MX）。Evolved 22.4R1〜 PTX で remote discriminator 自動導出 |
-| **Nokia (SR-OS)** | ◎ | SR-TE LSP は 19.10.R1〜。**CPM-NP 必須、最小 10ms**。static/BGP SR policy 対応 |
-| **Arista (EOS)** | ○ | EOS 4.24.1F〜（SR-TE/SR Policy）。新しめのリリースで **S-BFD Hold-down Timer**（4.34/4.35/4.36F） |
+| **Cisco IOS-XE (ASR1000)** | Yes | S-BFD with SR-TE. **IPv4 only / single-hop only**. Tail is the reflector |
+| **Cisco IOS-XR (NCS5500)** | No | Explicitly documented as **no Seamless BFD support**. Large per-platform differences (verify individually) |
+| **Cisco IOS-XR (ASR9000 etc.)** | Yes | sBFD reflector/initiator configuration exists for SR-TE |
+| **Juniper (Junos / Evolved)** | Yes (broad) | Colored/non-colored SR LSPs, SR policy. S-BFD FRR from 23.2R1 (MX). Evolved 22.4R1+ auto-derives the remote discriminator on PTX |
+| **Nokia (SR-OS)** | Yes (broad) | SR-TE LSPs since 19.10.R1. **Requires CPM-NP, 10 ms minimum**. static/BGP SR policy supported |
+| **Arista (EOS)** | Yes | EOS 4.24.1F+ (SR-TE/SR Policy). Recent releases add an **S-BFD Hold-down Timer** (4.34/4.35/4.36F) |
 
 ---
 
-## 5. SRv6 に絞った対応（Cisco / Juniper / Nokia）と End.X 監視
+## 5. SRv6-specific support (Cisco / Juniper / Nokia) and End.X monitoring
 
-### Cisco（IOS-XR）: SRv6 では S-BFD を使わない
-- S-BFD は **SR-MPLS / IPv4 専用**（制御パケットは順逆ともラベルスイッチ）。
-- SRv6 liveness は **Performance Measurement (PM) の liveness detection = STAMP (RFC 8762/8972) ベース**。
-  - MPLS 以外の IPv4/IPv6/SRv6 に共通適用。**loopback measurement-mode**（ヘッドエンドが宛先を自分のループバックに設定、SR ポリシーと同じカプセルで注入）。
-  - SRv6 では **SRH 内フローラベル(20bit)** で ECMP パスごとの活性を監視。
-  - 商用名 **Integrated Performance Measurement (IPM)**。STAMP 準拠、uSID ポリシー統合。
-- 背景: S-BFD(接続性) と STAMP(性能) の併用は複雑/高コスト → 統合提案 `draft-gandhi-spring-sr-enhanced-plm`。
+### Cisco (IOS-XR): no S-BFD on SRv6
+- S-BFD is **SR-MPLS / IPv4 only** (control packets are label-switched in both directions).
+- SRv6 liveness uses **Performance Measurement (PM) liveness detection = STAMP (RFC 8762/8972) based**.
+  - Applies uniformly to non-MPLS IPv4/IPv6/SRv6. **Loopback measurement-mode** (the headend sets the destination to its own loopback and injects with the same encapsulation as the SR policy).
+  - On SRv6, the **flow label (20 bits) inside the SRH** monitors liveness per ECMP path.
+  - Commercial name: **Integrated Performance Measurement (IPM)**. STAMP-conformant, integrated with uSID policies.
+- Background: running S-BFD (connectivity) and STAMP (performance) side by side is complex/costly → consolidation proposal `draft-gandhi-spring-sr-enhanced-plm`.
 
-### Juniper（Junos / Evolved）: SRv6 でも S-BFD 可
-- SRv6 TE パスに S-BFD 対応:
-  - ingress: `[edit protocols bfd] sbfd local-discriminator`、SRv6 TE パス側 `bfd-liveness-detection` 配下に `sbfd remote-discriminator`。
-  - egress(responder): `sbfd local-discriminator <n> local-ipv6-address <addr>`。responder の local = ingress の remote と一致必須。
-  - IPv6 ローカルホストアドレス限定の responder 向けに `bfd-liveness-detection sbfd destination-ipv6-local-host`。
-- STAMP/TWAMP/RPM も別途あり（性能測定）。
+### Juniper (Junos / Evolved): S-BFD works on SRv6 too
+- S-BFD on SRv6 TE paths:
+  - Ingress: `[edit protocols bfd] sbfd local-discriminator`; on the SRv6 TE path, `sbfd remote-discriminator` under `bfd-liveness-detection`.
+  - Egress (responder): `sbfd local-discriminator <n> local-ipv6-address <addr>`. The responder's local must equal the ingress's remote.
+  - `bfd-liveness-detection sbfd destination-ipv6-local-host` for responders limited to the IPv6 local-host address.
+- STAMP/TWAMP/RPM exist separately (performance measurement).
 
-### Nokia（SR-OS）: SRv6 Policy に S-BFD
-- SRv6 Policy への Seamless BFD で「silent」やデータパス障害を高速検知。
-- アクティブポリシーのセグメントリストで S-BFD ダウン → フェイルオーバー。全 S-BFD ダウン → SRv6 最短パスへフォールバック。
+### Nokia (SR-OS): S-BFD on SRv6 Policy
+- Seamless BFD on SRv6 Policies for fast detection of "silent" data-path failures.
+- S-BFD down on the active policy's segment list → failover. All S-BFD down → fall back to the SRv6 shortest path.
 
-### 参考: Huawei / H3C
-- SRv6 TE policy に S-BFD（静的セッションのみ、remote discriminator 手動必須）。
+### Reference: Huawei / H3C
+- S-BFD on SRv6 TE policy (static sessions only; remote discriminator must be manual).
 
-### End.X（隣接 SID）監視について（重要）
-- 上記 S-BFD/PM はいずれも **エンドツーエンドのセグメントリスト（SR ポリシー）単位**の監視。「特定 End.X SID だけを専用セッションで」という機能ではない。
-- 個々の End.X（uSID 表記では uA SID）の死活は **IGP(IS-IS) 隣接状態に従属**:
-  - リンク/隣接ダウン → IGP が End.X SID を withdraw → 保護付きなら TI-LFA バックアップへ。
-- したがって **End.X 単位の高速検知 = リンクの classic BFD ＋ IGP withdraw ＋ TI-LFA**、End.X を含む特定パスの到達性 = S-BFD/PM で端から端まで監視、という二層構成。
-- SRv6 で BFD/S-BFD の**返り経路を決定的にしたい**場合、SRH に順方向＋逆方向の SID リストを両方入れて返りパスを固定する手法あり（特定 End.X 経由パスのピンポイント監視に有効）。
+### About End.X (adjacency SID) monitoring (important)
+- All the S-BFD/PM above monitor **end-to-end segment lists (SR policies)**. There is no "dedicated session for one particular End.X SID" feature.
+- The liveness of an individual End.X (uA SID in uSID notation) **follows the IGP (IS-IS) adjacency state**:
+  - Link/adjacency down → the IGP withdraws the End.X SID → with protection, traffic shifts to the TI-LFA backup.
+- So the two-layer structure is: **per-End.X fast detection = classic link BFD + IGP withdraw + TI-LFA**, and reachability of a specific path containing that End.X = S-BFD/PM end to end.
+- To make the BFD/S-BFD **return path deterministic** on SRv6, one can put both the forward and reverse SID lists in the SRH to pin the return path (useful for pinpoint monitoring of a path through a specific End.X).
 
 ---
 
-## 6. ディスクリミネータの取得方法（各社）
+## 6. How discriminators are obtained (per vendor)
 
-> 取得方法は大きく 3 系統: 手動設定 / IP アドレス由来 / IGP 広告による自動配布。
+> Three broad families: manual configuration / derived from an IP address / automatic distribution via IGP advertisement.
 
-### 標準（自動配布の土台）
-- 32bit 値、管理ドメイン内で一意（RFC 7880）。
-- **RFC 7883**: IS-IS の Router CAPABILITY TLV で広告。
-- **RFC 7884**: OSPF の Router Information (RI) TLV（**Type 11**）で広告（OSPFv2/v3）。情報変更は SPF を起こさない。
-- 上記を **BGP-LS** でコントローラへエクスポート可能。
+### Standards (the basis for automatic distribution)
+- 32-bit value, unique within the administrative domain (RFC 7880).
+- **RFC 7883**: advertised in the IS-IS Router CAPABILITY TLV.
+- **RFC 7884**: advertised in the OSPF Router Information (RI) TLV (**Type 11**) (OSPFv2/v3). Information changes do not trigger SPF.
+- Both can be exported to a controller via **BGP-LS**.
 
-### ベンダー別
-| ベンダー | 手動 | IP 由来 | IGP 広告(7883/7884) | メモ |
+### Per vendor
+| Vendor | Manual | IP-derived | IGP advert (7883/7884) | Notes |
 |---|---|---|---|---|
-| **Cisco IOS-XR** | ○ | ○ | （明示確認できず） | reflector: `local-discriminator {ipv4-address \| 32bit \| dynamic \| interface}`。initiator: **RTI テーブル**で宛先→remote discriminator マッピング（`remote-target ipv4 <addr>`）。IPv4 宛なら宛先アドレスをそのまま remote discriminator に使える。XRv9k は S-BFD 非対応 |
-| **Juniper** | ○ | ○ | - | Evolved 22.4R1〜 `set protocols bfd sbfd local-discriminator-ip` でトンネルエンドポイントから remote 自動導出、共通 sBFD テンプレート |
-| **Nokia SR-OS** | ○ | - | **○（最も自動化）** | 7883/7884 で IGP リンクステートに opaque 情報としてエンコード → BGP-LS でエクスポート |
-| **Huawei/H3C** | ○（必須） | ○(整数変換) | - | SRv6 でも静的のみ、remote discriminator 手動必須 |
+| **Cisco IOS-XR** | Yes | Yes | (not explicitly confirmed) | reflector: `local-discriminator {ipv4-address \| 32bit \| dynamic \| interface}`. initiator: **RTI table** maps destination → remote discriminator (`remote-target ipv4 <addr>`). For IPv4 targets the destination address itself can be the remote discriminator. XRv9k does not support S-BFD |
+| **Juniper** | Yes | Yes | - | Evolved 22.4R1+ `set protocols bfd sbfd local-discriminator-ip` auto-derives the remote from the tunnel endpoint; common sBFD template |
+| **Nokia SR-OS** | Yes | - | **Yes (most automated)** | Encoded as opaque info in the IGP link state per 7883/7884 → exported via BGP-LS |
+| **Huawei/H3C** | Yes (required) | Yes (integer conversion) | - | Even on SRv6, static only; manual remote discriminator required |
 
 ---
 
-## 7. Classic BFD Echo の片方向運用
+## 7. Running classic BFD Echo one-way
 
-- **可能。Echo は本質的にシステム単位で独立した非対称機能。** 片側(A)だけが Echo を運用し、対向(B)は折り返しに徹する、が自然な形。
-- A の Echo は A→B→A と往復するので物理両方向を試験するが、**死活が分かるのは A だけ**。B も欲しければ B が独立に B→A→B を回す（= 2 本の独立した片方向 Echo）。
-- **ネゴシエーション上の注意 `Required Min Echo RX Interval`**:
-  - 「自分が Echo 受信(折り返し処理)をどの最小間隔まで支えられるか」を相手に伝える値。
-  - **0 = Echo 受信非対応** → 相手は Echo を送ってはいけない。
-  - 片方向 Echo 成立条件: A は Echo 有効化、B は自分の Echo は不要だが **Echo 受信サポート（非ゼロ）を広告**する必要あり。
-- **前提**: classic Echo は単独セッションではなく、**先に非同期制御セッションが Up している前提**の補助機能。Echo 活性時は制御パケットレートを下げてよい。
-- **単一ホップ専用**（RFC 5881）。マルチホップ BFD（RFC 5883）に Echo は無い。
-- → この非対称性が「originator / reflector」分離そのもの。B(折り返し) = XDP_TX 折り返しに乗る側。
-
----
-
-## 8. FRR の BFD Echo 既定値と「分散BFD」
-
-### FRR の Echo 既定
-- **`echo-mode`（Echo 送信）= デフォルト off（無効）。**
-- `echo receive-interval`（対向 Echo の折り返し受け入れ能力）= **デフォルト 50ms（非ゼロ）**。
-  - → FRR は既定で「自分から Echo は起こさないが、相手の Echo は折り返す」reflector 的状態。
-- `show bfd peers` の既定表示は `Echo transmission interval: disabled`。
-- **FRR 固有の注意**: 分散 BFD でない限り、**Echo は対向も FRR のときだけ機能**（FRR が折り返しをソフトウェアで処理する実装都合）。商用ルータ相手に FRR Echo を当てにしない。
-- 対比: 古い classic Cisco IOS は **Echo デフォルト on**。既定の向きはベンダーで割れるので相互接続時は両端確認。
-
-### 分散 BFD（distributed BFD）とは
-2 つの意味:
-1. **一般的意味**: BFD セッションの周期送受信と検知タイマーを **ラインカード/データプレーン（ASIC/NPU）にオフロード**。RP は生成/削除と状態通知のみ。→ スケール、サブ 10ms タイマー、RP 切替/GR 中も BFD 維持。
-2. **FRR の意味**: 制御プレーン(`bfdd`) と データプレーンを分離。**独自の BFD Data Plane Protocol (`bfddp`)**（`bfdd/bfddp_packet.h`）で外部データプレーン（HW/SmartNIC/別ソフトフォワーダ/ASIC）と session 設定・状態を交換。制御は FRR、足回りは外部、という分担。
-- → zebra-rs 設計に直結: Rust 制御ロジック + XDP/eBPF データプレーン = まさに bfddp 分離の XDP 実装。Echo/S-BFD reflector の XDP オフロードはその「データプレーン側」。
+- **Possible. Echo is inherently an asymmetric, per-system-independent function.** One side (A) running Echo while the other (B) only loops it back is a natural deployment.
+- A's Echo round-trips A→B→A, so it exercises both physical directions, but **only A learns liveness**. If B wants it too, B independently runs B→A→B (= two independent one-way Echos).
+- **Negotiation caveat — `Required Min Echo RX Interval`**:
+  - The value tells the peer "the minimum interval at which I can support receiving (looping) Echo."
+  - **0 = no Echo receive support** → the peer must not send Echo.
+  - One-way Echo requires: A enables Echo; B doesn't need its own Echo but **must advertise non-zero Echo receive support**.
+- **Precondition**: classic Echo is not a standalone session — it is an auxiliary function that assumes **an async control session is already Up**. While Echo is active, the control-packet rate may be lowered.
+- **Single-hop only** (RFC 5881). Multihop BFD (RFC 5883) has no Echo.
+- → This asymmetry *is* the originator/reflector split. B (the loop side) is the side that rides the XDP_TX reflect.
 
 ---
 
-## 9. TWAMP Light / STAMP の XDP オフロード実現性
+## 8. FRR's BFD Echo defaults and "distributed BFD"
 
-> STAMP = Simple Two-way Active Measurement Protocol (RFC 8762/8972)。TWAMP Light と合わせて制御チャネル省略 + Sender/Reflector の 2 役。
+### FRR's Echo defaults
+- **`echo-mode` (Echo transmission) = off by default.**
+- `echo receive-interval` (ability to loop the peer's Echo) = **50 ms by default (non-zero)**.
+  - → Out of the box, FRR is in a reflector-ish state: "I won't originate Echo, but I'll loop yours back."
+- `show bfd peers` shows `Echo transmission interval: disabled` by default.
+- **FRR-specific caveat**: unless distributed BFD is used, **Echo only works when the peer is also FRR** (an implementation artifact — FRR loops the return in software). Don't count on FRR Echo against commercial routers.
+- Contrast: old classic Cisco IOS had **Echo on by default**. Defaults differ per vendor, so check both ends when interoperating.
 
-### 結論
-- **liveness だけが目的**なら Reflector は純 XDP で十分実現可能（BFD echo reflector に近い）。
-- **正確な遅延/ロス測定**まで狙うと XDP 単体ではタイムスタンプ精度で頭打ち → HW タイムスタンプ統合か AF_XDP へ。
+### What "distributed BFD" means
+Two senses:
+1. **The general sense**: offload the periodic TX/RX and detection timers of BFD sessions **to line cards / the data plane (ASIC/NPU)**. The RP only creates/deletes sessions and receives state notifications. → Scale, sub-10 ms timers, BFD survives RP switchover/GR.
+2. **The FRR sense**: separate the control plane (`bfdd`) from the data plane. Exchange session config and state with an external data plane (HW/SmartNIC/another software forwarder/ASIC) over FRR's own **BFD Data Plane Protocol (`bfddp`)** (`bfdd/bfddp_packet.h`). FRR does control; the muscle is external.
+- → Directly relevant to the zebra-rs design: Rust control logic + XDP/eBPF data plane = exactly the bfddp split, implemented with XDP. The Echo/S-BFD reflector XDP offload is the "data-plane side" of that split.
 
-### Reflector 側（BFD echo より一段重い）
-- やること: 受信時刻 T2 取得、Sender の Seq/Timestamp/Error Estimate を「Sender〜」フィールドへコピー、Reflector の Seq(stateless=Sender seq / stateful=マップ) と TX 時刻 T3 埋め込み、src/dst IP・port・MAC 入替、IP/UDP チェックサム増分修正、`XDP_TX`。
-- **XDP 有利な点**: Sender パケットはパディング(MBZ)を持ち、Reflector の追加フィールドがその中に収まる設計 → **パケット長を変えず in-place 上書き可**（`bpf_xdp_adjust_tail` 不要）。固定レイアウトで bounds check も素直。
-- **難所**:
-  - **タイムスタンプ精度**: RX は XDP がドライバ直後なので良好、対応ドライバなら `bpf_xdp_metadata_rx_timestamp` で HW RX 時刻。TX は `XDP_TX` で実送出前に T3 を書くため原理的誤差。HW TX タイムスタンプの反映は実用上困難。
-  - **クロックドメイン**: STAMP は NTP/PTP 形式。`bpf_ktime_get_ns` は単調時計。PHC 同期環境では HW タイムスタンプ側が正確。純 XDP は SW 時計ベース → Error Estimate で不確かさを大きめ申告。
-  - **認証(HMAC-SHA256)**: XDP データパスで非現実的 → **authenticated は XDP 不可、unauth のみ**。
-  - **TLV(RFC 8972)**: 可変長 TLV ループは verifier 制約と相性悪。Direct Measurement(統計読出)等は XDP で扱いにくい。ベース(TLV なし)はトリビアル。
-  - **SRv6 encap**: IPv6+SRH+UDP+STAMP のパース、返り経路で逆 SR Policy を積むなら `bpf_xdp_adjust_head` で SRH push（重い）。loopback モードなら通常 SRv6 フォワーディングに任せられて軽い。
+---
 
-### Sender 側（BFD originator と同じ）
-- 周期送信 → `bpf_timer` / ユーザ空間。RX 検証と detect-timer リセットは XDP 可。遅延/ロス計算が要るならユーザ空間へ punt。
+## 9. Feasibility of TWAMP Light / STAMP offload in XDP
 
-### 用途別実現性
-| 用途 | 純 XDP | 備考 |
+> STAMP = Simple Two-way Active Measurement Protocol (RFC 8762/8972). Together with TWAMP Light: control channel omitted, two roles (Sender/Reflector).
+
+### Conclusion
+- If **liveness is the only goal**, the Reflector is perfectly feasible in pure XDP (close to the BFD echo reflector).
+- Aiming for **accurate delay/loss measurement** hits a timestamp-precision ceiling in XDP alone → integrate HW timestamps or move to AF_XDP.
+
+### Reflector side (one notch heavier than BFD echo)
+- Work: capture RX time T2; copy the Sender's Seq/Timestamp/Error Estimate into the "Sender…" fields; fill in the Reflector Seq (stateless = Sender seq / stateful = from a map) and TX time T3; swap src/dst IP, port, MAC; incrementally fix the IP/UDP checksums; `XDP_TX`.
+- **XDP-friendly aspects**: the Sender packet carries padding (MBZ) sized so the Reflector's added fields fit inside it → **in-place overwrite without changing packet length** (no `bpf_xdp_adjust_tail` needed). Fixed layout keeps bounds checks straightforward.
+- **Hard parts**:
+  - **Timestamp precision**: RX is good (XDP sits right after the driver; with a capable driver, `bpf_xdp_metadata_rx_timestamp` gives HW RX time). TX writes T3 before the actual `XDP_TX` transmission, an inherent error. Reflecting HW TX timestamps is practically infeasible.
+  - **Clock domain**: STAMP uses NTP/PTP formats. `bpf_ktime_get_ns` is a monotonic clock. In PHC-synced environments the HW timestamps are the accurate ones. Pure XDP is SW-clock based → declare larger uncertainty in the Error Estimate.
+  - **Authentication (HMAC-SHA256)**: unrealistic in the XDP datapath → **authenticated mode is not XDP-able; unauth only**.
+  - **TLVs (RFC 8972)**: variable-length TLV loops fight the verifier. Direct Measurement (statistics readout) etc. are awkward in XDP. The base (no TLVs) is trivial.
+  - **SRv6 encap**: parsing IPv6+SRH+UDP+STAMP; if the return needs a reverse SR Policy pushed, `bpf_xdp_adjust_head` for the SRH push (heavy). In loopback mode the normal SRv6 forwarding handles it — light.
+
+### Sender side (same as the BFD originator)
+- Periodic transmission → `bpf_timer` / userspace. RX validation and detect-timer reset are XDP-able. If delay/loss computation is needed, punt to userspace.
+
+### Feasibility by use case
+| Use case | Pure XDP | Notes |
 |---|---|---|
-| liveness のみ (unauth, TLV なし, IPv4/単一ホップ IPv6) | ◎ | BFD echo reflector 並み。SW 時計で十分 |
-| 粗い遅延/ロス測定 | ○ | HW RX タイムスタンプ推奨、TX 精度は割り切り |
-| 高精度遅延(PTP 級) | △ | HW タイムスタンプ必須、TX 側に原理的誤差 |
-| authenticated / TLV リッチ / 逆 SRH encap | ✗ | AF_XDP / ハイブリッドへ |
+| Liveness only (unauth, no TLVs, IPv4 / single-hop IPv6) | Excellent | On par with the BFD echo reflector. SW clock suffices |
+| Coarse delay/loss measurement | Good | HW RX timestamp recommended; accept TX imprecision |
+| High-precision delay (PTP class) | Marginal | HW timestamps required; inherent TX-side error |
+| Authenticated / TLV-rich / reverse SRH encap | No | Go AF_XDP / hybrid |
 
-### 現実解: AF_XDP ハイブリッド
-- XDP で対象 UDP（STAMP 既定 UDP 862）だけ AF_XDP(XSK) へ redirect → ユーザ空間高速パスで書換・タイムスタンプ(PHC)・HMAC/TLV/逆 SRH encap。性能と機能の両立。
+### The pragmatic answer: AF_XDP hybrid
+- Use XDP to redirect only the target UDP (STAMP default UDP 862) to AF_XDP (XSK) → a userspace fast path does the rewriting, timestamps (PHC), HMAC/TLVs, reverse SRH encap. Balances performance and features.
 
-### 環境注意
-- Parallels on Apple Silicon の仮想 NIC は HW タイムスタンプも native XDP metadata も期待不可 → ラボは SW 時計＋generic/native XDP 止まり前提。精度評価は実機 NIC(mlx5 等)。
-
----
-
-## 10. aya（Rust eBPF ライブラリ）
-
-- Rust で eBPF を書くためのライブラリ/フレームワーク。**libbpf/bcc 非依存、純 Rust、syscall は libc crate のみ。**
-- **2 crate 構成**: ユーザ空間 `aya`（ロード/マップ管理/アタッチ/イベント受信）+ カーネル空間 `aya-ebpf`（旧 aya-bpf、eBPF プログラム本体）。両者でデータ構造を共有可。
-- **利点**: C ツールチェーン/カーネルヘッダ/カーネルビルド不要、ビルド高速。**BTF → CO-RE**（再コンパイル不要で別カーネルで動く）。musl リンクで単一自己完結バイナリ。ユーザ空間は tokio/async-std で async 対応。
-- 対応: XDP / TC / kprobe / tracepoint / cgroup_skb、hash map / array / ring buffer 等。
-- ドキュメント: aya-rs.dev（Aya Book）。
-- → 「ユーザ空間(aya)=制御プレーン、カーネル(aya-ebpf)=データプレーン」が分散 BFD の control/data 分離と対応。zebra-agent(nftables→eBPF) の延長で reflector データパスを追加していく形。
+### Environment note
+- The virtual NICs under Parallels on Apple Silicon offer neither HW timestamps nor native XDP metadata → the lab tops out at SW clock + generic/native XDP. Precision evaluation needs real NICs (mlx5 etc.).
 
 ---
 
-## 11. zebra-rs 実装に向けたまとめ・次アクション
+## 10. aya (Rust eBPF library)
 
-### アーキテクチャ方針
-- **制御プレーン**: zebra-rs / Rust（セッション管理、IGP/BGP クライアント通知、discriminator マッピングテーブル）。
-- **データプレーン**: aya-ebpf / XDP（reflector の折り返し、RX 検証、detect-timer リセット）。
-- **TX タイマー / タイムアウト検知**: `bpf_timer`(5.15+) かユーザ空間。
-- **フル機能（高精度測定・認証・SRv6 逆 encap）**: AF_XDP に redirect。
-
-### 相互接続の整合ポイント（discriminator）
-- reflector の local discriminator を **IPv6 ループバック由来**で持つ → Cisco/Juniper/Huawei と噛む。
-- initiator 側で **エンドポイント IP → remote discriminator マッピング表**（Cisco の RTI 相当）。
-- Nokia 流の完全自動運用に合わせるなら、**IS-IS 実装に RFC 7883 の S-BFD Discriminator sub-TLV** 送受信を追加 → BGP-LS に載せる（zebra-rs は IS-IS/BGP-LS 既にあるので自然な拡張）。
-
-### SRv6 相手別の必要実装
-- **Nokia / Juniper 相手**: SRv6 上の **S-BFD**（reflector/initiator、IPv6 discriminator）。
-- **Cisco（IOS-XR）相手の SRv6**: 先方は S-BFD を話さず **STAMP ベース PM liveness** → zebra-rs 側も **STAMP (RFC 8762/8972, TWAMP-light) responder/sender** が必要。
-  - → Nokia/Juniper 向けは S-BFD reflector の XDP オフロード、Cisco SRv6 向けは STAMP reflector を検討。
-
-### 段階的実装案（XDP/aya）
-1. **第 1 段**: unauth STAMP（or S-BFD）liveness reflector を純 XDP（in-place 書換＋`XDP_TX`）。Cisco SRv6 の loopback liveness / Nokia/Juniper の S-BFD に当てる。
-2. **第 2 段**: 精度/機能が要る所だけ AF_XDP へ redirect。
-3. 並行して originator/sender 側の TX タイマー（`bpf_timer` or ユーザ空間）と detect タイムアウト。
-
-### 未着手 / 深掘り候補
-- IS-IS RFC 7883 の Router CAPABILITY TLV 内 S-BFD Discriminator sub-TLV のエンコード仕様。
-- unauth STAMP reflector の XDP パケット書換骨子（フィールドオフセット、チェックサム増分、aya/Rust ローダ）。
-- SRv6 loopback モードでの返り経路設計。
-- FRR `bfddp` メッセージ仕様（互換にするか独自データプレーンプロトコルにするか）。
+- A library/framework for writing eBPF in Rust. **No libbpf/bcc dependency, pure Rust; syscalls only via the libc crate.**
+- **Two-crate structure**: userspace `aya` (loading / map management / attach / event receipt) + kernel-space `aya-ebpf` (formerly aya-bpf; the eBPF program itself). Data structures can be shared between the two.
+- **Advantages**: no C toolchain / kernel headers / kernel build needed; fast builds. **BTF → CO-RE** (runs on different kernels without recompilation). musl linking gives a single self-contained binary. Userspace is async-ready with tokio/async-std.
+- Supports: XDP / TC / kprobe / tracepoint / cgroup_skb; hash maps / arrays / ring buffers, etc.
+- Documentation: aya-rs.dev (the Aya Book).
+- → "Userspace (aya) = control plane, kernel (aya-ebpf) = data plane" maps directly onto distributed BFD's control/data split. The reflector datapath extends naturally from zebra-agent (nftables→eBPF).
 
 ---
 
-## 参考リンク（一次情報優先）
+## 11. Summary and next actions for zebra-rs
+
+### Architecture direction
+- **Control plane**: zebra-rs / Rust (session management, IGP/BGP client notifications, discriminator mapping tables).
+- **Data plane**: aya-ebpf / XDP (reflector loops, RX validation, detect-timer reset).
+- **TX timers / timeout detection**: `bpf_timer` (5.15+) or userspace.
+- **Full features (high-precision measurement, authentication, SRv6 reverse encap)**: redirect to AF_XDP.
+
+### Interop alignment points (discriminators)
+- Hold the reflector's local discriminator **derived from an IPv6 loopback** → meshes with Cisco/Juniper/Huawei.
+- On the initiator side, an **endpoint-IP → remote-discriminator mapping table** (Cisco's RTI equivalent).
+- To match Nokia-style fully automatic operation, add **RFC 7883 S-BFD Discriminator sub-TLV** send/receive to the IS-IS implementation → carry it into BGP-LS (zebra-rs already has IS-IS and BGP-LS, so this is a natural extension).
+
+### Required work per SRv6 peer
+- **Against Nokia / Juniper**: **S-BFD over SRv6** (reflector/initiator, IPv6 discriminators).
+- **Against Cisco (IOS-XR) SRv6**: they don't speak S-BFD — they use **STAMP-based PM liveness** → zebra-rs also needs a **STAMP (RFC 8762/8972, TWAMP-light) responder/sender**.
+  - → For Nokia/Juniper: XDP offload of an S-BFD reflector. For Cisco SRv6: consider a STAMP reflector.
+
+### Staged implementation plan (XDP/aya)
+1. **Stage 1**: an unauth STAMP (or S-BFD) liveness reflector in pure XDP (in-place rewrite + `XDP_TX`). Targets Cisco SRv6 loopback liveness / Nokia/Juniper S-BFD.
+2. **Stage 2**: redirect to AF_XDP only where precision/features demand it.
+3. In parallel: the originator/sender TX timers (`bpf_timer` or userspace) and detect timeouts.
+
+### Not yet started / deep-dive candidates
+- Encoding details of the S-BFD Discriminator sub-TLV inside the IS-IS Router CAPABILITY TLV (RFC 7883).
+- The XDP packet-rewrite skeleton for an unauth STAMP reflector (field offsets, incremental checksums, aya/Rust loader).
+- Return-path design for SRv6 loopback mode.
+- The FRR `bfddp` message spec (stay compatible, or define our own data-plane protocol?).
+
+---
+
+## References (primary sources first)
 
 ### RFC / IETF
 - RFC 5880 BFD / RFC 5881 BFD for IPv4/IPv6 single-hop / RFC 5883 Multihop BFD
@@ -378,7 +386,7 @@ BFD Echo は本質的に「ローカルが送出 → リモートのフォワー
 - RFC 8762 STAMP / RFC 8972 STAMP Optional Extensions / RFC 8986 SRv6 Network Programming
 - draft-gandhi-spring-sr-enhanced-plm: https://datatracker.ietf.org/doc/html/draft-gandhi-spring-sr-enhanced-plm
 
-### ベンダードキュメント
+### Vendor documentation
 - Cisco IOS-XE S-BFD with SR: https://www.cisco.com/c/en/us/td/docs/ios-xml/ios/seg_routing/configuration/xe-17/segrt-xe-17-book/m_sr-smlsbfd-sspf.html
 - Cisco SRv6 Performance Measurement: https://www.cisco.com/c/en/us/td/docs/iosxr/cisco8000/srv6/b-srv6-configuration-guide/m-performance-measurement.html
 - Cisco IOS-XR BFD Commands (discriminator): https://www.cisco.com/c/en/us/td/docs/iosxr/ncs5500/routing/b-ncs5500-routing-cli-reference/b-ncs5500-routing-cli-reference_chapter_0111.html
@@ -389,7 +397,7 @@ BFD Echo は本質的に「ローカルが送出 → リモートのフォワー
 - Arista EOS BFD/S-BFD: https://www.arista.com/en/um-eos/eos-bidirectional-forwarding-detection
 
 ### FRR / eBPF / aya
-- FRR BFD (echo-mode 既定, distributed BFD): https://docs.frrouting.org/en/latest/bfd.html
+- FRR BFD (echo-mode defaults, distributed BFD): https://docs.frrouting.org/en/latest/bfd.html
 - FRR bfd.rst (bfddp): https://github.com/FRRouting/frr/blob/master/doc/user/bfd.rst
 - aya: https://github.com/aya-rs/aya / https://aya-rs.dev/ / https://docs.rs/aya
-- Cilium BFD 議論: https://github.com/cilium/cilium/issues/22394
+- Cilium BFD discussion: https://github.com/cilium/cilium/issues/22394

--- a/zebra-rs/src/bgp/config.rs
+++ b/zebra-rs/src/bgp/config.rs
@@ -823,15 +823,28 @@ pub(super) fn bfd_apply(bgp: &mut Bgp, addr: IpAddr) -> Option<()> {
         } else {
             255 // GTSM (RFC 5881 §5): single-hop accepts only TTL 255.
         };
+        // Key single-hop sessions by the connected interface when we know it
+        // (from `RibRx::AddrAdd`): the per-interface XDP helper — the Echo
+        // reflector and the expiration watchdog — attaches by ifindex, so an
+        // ifindex-0 key can never bring it up. Unknown (no address info yet,
+        // or a v6 link-local peer) falls back to 0 — the session still works,
+        // helper-backed features stay off; the `RibRx::AddrAdd` hook
+        // re-reconciles once the interface is learned. Multihop has no single
+        // egress interface.
+        let ifindex = if multihop {
+            0
+        } else {
+            bgp.connected_subnets.ifindex_for(addr).unwrap_or(0)
+        };
         let key = SessionKey {
             local,
             remote: addr,
-            ifindex: 0,
+            ifindex,
             multihop,
         };
         // Echo is single-hop only (RFC 5883 multihop has no Echo), so it's
         // requested only for non-multihop neighbors; the BFD instance gates it
-        // further to IPv4 with a live reflector.
+        // further to a live reflector (both address families work).
         let (echo_mode, echo_rx_us, echo_tx_us) = match eff.echo_mode {
             Some(mode) if !multihop => (
                 mode,
@@ -850,6 +863,10 @@ pub(super) fn bfd_apply(bgp: &mut Bgp, addr: IpAddr) -> Option<()> {
             echo_mode,
             required_min_echo_rx_us: echo_rx_us,
             echo_transmit_us: echo_tx_us,
+            // Like Echo, the expiration watchdog is single-hop only (the XDP
+            // helper attaches per interface) — keep the params honest rather
+            // than relying on the BFD instance's own multihop gate.
+            detect_offload: eff.detect_offload && !multihop,
             // Detect-mult still comes from the defaults; the peer's `bfd
             // profile` is stored but not yet resolved (a separate follow-up
             // needing cross-task BfdConfig access).
@@ -997,12 +1014,30 @@ fn config_peer_bfd_echo_rx(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Optio
     bfd_apply(bgp, addr)
 }
 
+/// `set router bgp neighbor X bfd detect-offload <bool>` — offload
+/// control-packet expiration detection (RFC 5880 §6.8.4) to the
+/// per-interface XDP helper once the session is Up. Single-hop only
+/// (inert on multihop sessions).
+fn config_peer_bfd_detect_offload(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Option<()> {
+    let addr = args.addr()?;
+    let offload = args.boolean()?;
+    {
+        let peer = bgp.peers.get_mut(&addr)?;
+        // `None` ⇒ inherit `router bgp { bfd { detect-offload } }`;
+        // `Some(false)` explicitly opts this neighbor out.
+        peer.config.bfd.detect_offload = op.is_set().then_some(offload);
+    }
+    bfd_apply(bgp, addr)
+}
+
 /// Re-reconcile BFD for every neighbor — used by the instance-level
 /// `router bgp { bfd {} }` callbacks, whose defaults (notably a blanket
-/// `enable`) affect neighbors that set nothing of their own. `bfd_apply` is a
-/// per-neighbor reconcile that diffs against the recorded session key, so this
-/// is just a fan-out.
-fn bfd_reconcile_all(bgp: &mut Bgp) {
+/// `enable`) affect neighbors that set nothing of their own, and by the
+/// `RibRx::AddrAdd`/`AddrDel` handlers, whose connected-interface knowledge
+/// feeds the single-hop session key's ifindex. `bfd_apply` is a per-neighbor
+/// reconcile that diffs against the recorded session key, so this is just a
+/// fan-out (a no-op per neighbor when nothing changed).
+pub(super) fn bfd_reconcile_all(bgp: &mut Bgp) {
     let addrs: Vec<IpAddr> = bgp.peers.keys().copied().collect();
     for addr in addrs {
         bfd_apply(bgp, addr);
@@ -1039,6 +1074,15 @@ fn config_bgp_bfd_echo_tx(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Option
 fn config_bgp_bfd_echo_rx(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Option<()> {
     let interval = args.u32()?;
     bgp.bfd.echo_receive_ms = op.is_set().then_some(interval);
+    Some(())
+}
+
+/// `router bgp bfd detect-offload <bool>` — instance default for offloading
+/// expiration detection to the XDP helper (overridable per neighbor).
+fn config_bgp_bfd_detect_offload(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Option<()> {
+    let offload = args.boolean()?;
+    bgp.bfd.detect_offload = op.is_set().then_some(offload);
+    bfd_reconcile_all(bgp);
     Some(())
 }
 
@@ -2954,6 +2998,7 @@ impl Bgp {
         self.callback_peer("/bfd/echo-mode", config_peer_bfd_echo_mode);
         self.callback_peer("/bfd/echo-transmit-interval", config_peer_bfd_echo_tx);
         self.callback_peer("/bfd/echo-receive-interval", config_peer_bfd_echo_rx);
+        self.callback_peer("/bfd/detect-offload", config_peer_bfd_detect_offload);
         // Instance-level `router bgp { bfd { ... } }` defaults.
         self.callback_add("/router/bgp/bfd/enable", config_bgp_bfd_enable);
         self.callback_add("/router/bgp/bfd/echo-mode", config_bgp_bfd_echo_mode);
@@ -2964,6 +3009,10 @@ impl Bgp {
         self.callback_add(
             "/router/bgp/bfd/echo-receive-interval",
             config_bgp_bfd_echo_rx,
+        );
+        self.callback_add(
+            "/router/bgp/bfd/detect-offload",
+            config_bgp_bfd_detect_offload,
         );
         self.callback_peer("/tcp-ao/key-chain", config_peer_tcp_ao_key_chain);
         self.callback_peer(
@@ -3310,6 +3359,75 @@ mod bfd_wiring_tests {
                 assert!(!key.multihop, "eBGP without override is single-hop");
                 assert_eq!(params.dst_port, BFD_SINGLE_HOP_PORT);
                 assert_eq!(params.min_ttl, 255);
+            }
+            other => panic!("expected Subscribe, got {other:?}"),
+        }
+    }
+
+    /// A single-hop session is keyed by the connected interface once the
+    /// covering address is known, and `detect-offload` rides the params —
+    /// both feed the per-interface XDP helper. An address learned AFTER
+    /// `bfd enable` re-keys the session (unsubscribe + resubscribe).
+    #[tokio::test]
+    async fn single_hop_key_carries_connected_ifindex_and_detect_offload() {
+        let (mut bgp, mut bfd_rx) = fresh_bgp_with_bfd();
+        config_peer(&mut bgp, arg_words(&["10.0.0.5"]), ConfigOp::Set).unwrap();
+        let addr = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 5));
+        bgp.peers.get_mut(&addr).unwrap().peer_type = PeerType::EBGP;
+
+        // Enable before any address knowledge → ifindex 0, helper-less.
+        config_peer_bfd_detect_offload(&mut bgp, arg_words(&["10.0.0.5", "true"]), ConfigOp::Set);
+        config_peer_bfd_enable(&mut bgp, arg_words(&["10.0.0.5", "true"]), ConfigOp::Set).unwrap();
+        match bfd_rx.try_recv().expect("initial subscribe") {
+            ClientReq::Subscribe { key, params, .. } => {
+                assert_eq!(key.ifindex, 0, "no connected info yet");
+                assert!(params.detect_offload, "knob rides the params");
+            }
+            other => panic!("expected Subscribe, got {other:?}"),
+        }
+
+        // The covering interface address arrives → re-keyed onto ifindex 3.
+        let net: ipnet::Ipv4Net = "10.0.0.1/24".parse().unwrap();
+        bgp.connected_subnets.record(&crate::rib::link::LinkAddr {
+            addr: ipnet::IpNet::V4(net),
+            ifindex: 3,
+            secondary: false,
+            config: false,
+            fib: true,
+        });
+        bfd_reconcile_all(&mut bgp);
+
+        match bfd_rx
+            .try_recv()
+            .expect("re-key unsubscribes the stale key")
+        {
+            ClientReq::Unsubscribe { key, .. } => assert_eq!(key.ifindex, 0),
+            other => panic!("expected Unsubscribe, got {other:?}"),
+        }
+        match bfd_rx.try_recv().expect("re-key resubscribes") {
+            ClientReq::Subscribe { key, params, .. } => {
+                assert_eq!(key.ifindex, 3, "keyed by the connected interface");
+                assert!(params.detect_offload);
+            }
+            other => panic!("expected Subscribe, got {other:?}"),
+        }
+    }
+
+    /// `detect-offload` is single-hop only: a multihop session keeps
+    /// `detect_offload: false` in its params (and ifindex 0) even when the
+    /// leaf is set — mirroring the Echo gate.
+    #[tokio::test]
+    async fn detect_offload_inert_on_multihop() {
+        let (mut bgp, mut bfd_rx) = fresh_bgp_with_bfd();
+        config_peer(&mut bgp, arg_words(&["10.0.0.6"]), ConfigOp::Set).unwrap();
+        // Default peer type is iBGP ⇒ inferred multihop.
+        config_peer_bfd_detect_offload(&mut bgp, arg_words(&["10.0.0.6", "true"]), ConfigOp::Set);
+        config_peer_bfd_enable(&mut bgp, arg_words(&["10.0.0.6", "true"]), ConfigOp::Set).unwrap();
+        match bfd_rx.try_recv().expect("subscribe") {
+            ClientReq::Subscribe { key, params, .. } => {
+                assert!(key.multihop);
+                assert_eq!(key.ifindex, 0, "multihop has no single egress");
+                assert!(!params.detect_offload, "inert on multihop");
             }
             other => panic!("expected Subscribe, got {other:?}"),
         }

--- a/zebra-rs/src/bgp/connected.rs
+++ b/zebra-rs/src/bgp/connected.rs
@@ -23,10 +23,20 @@ use ipnet::IpNet;
 
 use crate::rib::link::LinkAddr;
 
+/// One reference-counted connected network and the interface it lives on.
+#[derive(Debug)]
+struct SubnetRef {
+    count: usize,
+    /// The recording address's ifindex. With several addresses in one subnet
+    /// the last writer wins — a subnet spanning *different* interfaces is a
+    /// pathological config we don't try to disambiguate.
+    ifindex: u32,
+}
+
 /// Reference-counted set of directly-connected networks.
 #[derive(Debug, Default)]
 pub struct ConnectedSubnets {
-    nets: BTreeMap<IpNet, usize>,
+    nets: BTreeMap<IpNet, SubnetRef>,
 }
 
 impl ConnectedSubnets {
@@ -40,16 +50,21 @@ impl ConnectedSubnets {
     /// contributes only itself, which is exactly what we want — it does
     /// not make a different peer "connected".
     pub fn record(&mut self, addr: &LinkAddr) {
-        *self.nets.entry(addr.addr.trunc()).or_default() += 1;
+        let entry = self.nets.entry(addr.addr.trunc()).or_insert(SubnetRef {
+            count: 0,
+            ifindex: addr.ifindex,
+        });
+        entry.count += 1;
+        entry.ifindex = addr.ifindex;
     }
 
     /// Forget an interface address previously passed to [`Self::record`].
     /// The subnet is dropped only when its last contributing address goes.
     pub fn forget(&mut self, addr: &LinkAddr) {
         let net = addr.addr.trunc();
-        if let Some(count) = self.nets.get_mut(&net) {
-            *count -= 1;
-            if *count == 0 {
+        if let Some(entry) = self.nets.get_mut(&net) {
+            entry.count -= 1;
+            if entry.count == 0 {
                 self.nets.remove(&net);
             }
         }
@@ -66,6 +81,23 @@ impl ConnectedSubnets {
     /// cover an IPv6 address).
     pub fn covers(&self, ip: IpAddr) -> bool {
         self.nets.keys().any(|net| net.contains(&ip))
+    }
+
+    /// The interface a directly-connected `ip` lives on, if known — used to
+    /// key single-hop BFD sessions so the per-interface XDP helper (Echo
+    /// reflector + expiration watchdog) can attach to the right link.
+    /// IPv6 link-locals are excluded: `fe80::/64` is recorded by *every*
+    /// v6 interface, so a covering match would be meaningless (link-local
+    /// peering is the interface-peer machinery's job).
+    pub fn ifindex_for(&self, ip: IpAddr) -> Option<u32> {
+        if matches!(ip, IpAddr::V6(a) if a.is_unicast_link_local()) {
+            return None;
+        }
+        self.nets
+            .iter()
+            .find(|(net, _)| net.contains(&ip))
+            .map(|(_, r)| r.ifindex)
+            .filter(|&ifindex| ifindex != 0)
     }
 }
 
@@ -162,5 +194,34 @@ mod tests {
         assert!(!t.covers(ip("2001:db8:1::2")));
         // An IPv6 subnet never covers an IPv4 address and vice versa.
         assert!(!t.covers(ip("10.0.0.2")));
+    }
+
+    fn v4_on(addr: &str, prefix: u8, ifindex: u32) -> LinkAddr {
+        LinkAddr {
+            ifindex,
+            ..v4(addr, prefix)
+        }
+    }
+
+    /// `ifindex_for` resolves a covered peer to the recording interface —
+    /// the key the per-interface XDP helper (Echo / expiration watchdog)
+    /// needs — and returns `None` for uncovered peers, link-local v6, and
+    /// after the subnet's last address is forgotten.
+    #[test]
+    fn ifindex_for_resolves_connected_interface() {
+        let mut t = ConnectedSubnets::new();
+        t.record(&v4_on("10.0.0.1", 24, 7));
+        t.record(&v6("2001:db8::1", 64)); // helper ifindex 1
+
+        assert_eq!(t.ifindex_for(ip("10.0.0.2")), Some(7));
+        assert_eq!(t.ifindex_for(ip("2001:db8::2")), Some(1));
+        assert_eq!(t.ifindex_for(ip("10.99.0.2")), None, "not connected");
+        // fe80::/64 is on every v6 interface — a covering match would be
+        // meaningless, so link-locals never resolve.
+        t.record(&v6("fe80::1", 64));
+        assert_eq!(t.ifindex_for(ip("fe80::2")), None);
+
+        t.forget(&v4_on("10.0.0.1", 24, 7));
+        assert_eq!(t.ifindex_for(ip("10.0.0.2")), None, "subnet gone");
     }
 }

--- a/zebra-rs/src/bgp/inst.rs
+++ b/zebra-rs/src/bgp/inst.rs
@@ -1996,11 +1996,17 @@ impl Bgp {
                 self.interface_addrs.record(&addr);
                 self.connected_subnets.record(&addr);
                 self.refresh_connected();
+                // The connected ifindex keys single-hop BFD sessions (the
+                // per-interface XDP helper attaches by it): re-reconcile so a
+                // session subscribed before this address was learned picks up
+                // its concrete ifindex. Per-neighbor no-op when unchanged.
+                super::config::bfd_reconcile_all(self);
             }
             RibRx::AddrDel(addr) => {
                 self.interface_addrs.forget(&addr);
                 self.connected_subnets.forget(&addr);
                 self.refresh_connected();
+                super::config::bfd_reconcile_all(self);
             }
             RibRx::RouterIdUpdate(router_id) => {
                 // RIB-derived router-id (`system router-id` config

--- a/zebra-rs/src/bgp/peer.rs
+++ b/zebra-rs/src/bgp/peer.rs
@@ -299,6 +299,11 @@ pub struct PeerBfdConfig {
     /// Advertised Required Min Echo RX (ms); `None` ⇒
     /// [`DEFAULT_ECHO_INTERVAL_MS`].
     pub echo_receive_ms: Option<u32>,
+    /// Offload control-packet expiration detection (RFC 5880 §6.8.4) to the
+    /// per-interface XDP helper once the session is Up. Single-hop only —
+    /// inert on multihop sessions (the helper attaches per interface).
+    /// `None` ⇒ inherit (hard default `false`: detection in userspace).
+    pub detect_offload: Option<bool>,
 }
 
 /// FRR default Echo interval (ms) — the hard default for the Echo intervals
@@ -314,12 +319,14 @@ pub struct ResolvedPeerBfd {
     pub echo_mode: Option<EchoMode>,
     pub echo_transmit_ms: u32,
     pub echo_receive_ms: u32,
+    pub detect_offload: bool,
 }
 
 impl PeerBfdConfig {
     /// Resolve `self` (per-neighbor) over `default` (instance-level
     /// `router bgp { bfd {} }`), per leaf, for the inheritable bits
-    /// (enable + Echo). Hop-mode / min-ttl stay per-neighbor (read directly).
+    /// (enable + Echo + detect-offload). Hop-mode / min-ttl stay
+    /// per-neighbor (read directly).
     pub fn resolve(&self, default: &PeerBfdConfig) -> ResolvedPeerBfd {
         ResolvedPeerBfd {
             enable: self.enable.or(default.enable).unwrap_or(false),
@@ -332,6 +339,10 @@ impl PeerBfdConfig {
                 .echo_receive_ms
                 .or(default.echo_receive_ms)
                 .unwrap_or(DEFAULT_ECHO_INTERVAL_MS),
+            detect_offload: self
+                .detect_offload
+                .or(default.detect_offload)
+                .unwrap_or(false),
         }
     }
 }

--- a/zebra-rs/src/isis/config.rs
+++ b/zebra-rs/src/isis/config.rs
@@ -293,6 +293,10 @@ impl Isis {
             "/router/isis/interface/bfd/echo-receive-interval",
             link::config_bfd_echo_receive_interval,
         );
+        self.callback_add(
+            "/router/isis/interface/bfd/detect-offload",
+            link::config_bfd_detect_offload,
+        );
         // Instance-level `router isis { bfd { ... } }` defaults.
         self.callback_add("/router/isis/bfd/enable", link::config_isis_bfd_enable);
         self.callback_add(
@@ -306,6 +310,10 @@ impl Isis {
         self.callback_add(
             "/router/isis/bfd/echo-receive-interval",
             link::config_isis_bfd_echo_receive_interval,
+        );
+        self.callback_add(
+            "/router/isis/bfd/detect-offload",
+            link::config_isis_bfd_detect_offload,
         );
         // Per-interface hello-authentication.
         self.callback_add(

--- a/zebra-rs/src/isis/inst.rs
+++ b/zebra-rs/src/isis/inst.rs
@@ -1889,10 +1889,11 @@ impl Isis {
             }
             return;
         };
-        // Resolve the interface's effective Echo config (per-interface `bfd {}`
-        // merged over the instance-level `router isis { bfd {} }` default) and
-        // pass it in the session params. The BFD instance gates Echo further to
-        // single-hop IPv4 with a live reflector, so it's inert on v6 adjacencies.
+        // Resolve the interface's effective offload config (per-interface
+        // `bfd {}` merged over the instance-level `router isis { bfd {} }`
+        // default) and pass it in the session params. The BFD instance gates
+        // Echo further to single-hop with a live reflector; both families
+        // work (a v6 adjacency runs Echo over the link-local pair).
         let eff = self
             .links
             .get(&key.ifindex)
@@ -1909,12 +1910,13 @@ impl Isis {
         let _ = tx.send(crate::bfd::inst::ClientReq::Subscribe {
             client: "isis".to_string(),
             key,
-            // Only Echo params are wired here; everything else uses the BFD
-            // session defaults.
+            // Only the offload params (Echo + detect-offload) are wired here;
+            // everything else uses the BFD session defaults.
             params: crate::bfd::session::SessionParams {
                 echo_mode,
                 required_min_echo_rx_us: echo_rx_us,
                 echo_transmit_us: echo_tx_us,
+                detect_offload: eff.detect_offload,
                 ..crate::bfd::session::SessionParams::default()
             },
             notifier: self.bfd_event_tx.clone(),

--- a/zebra-rs/src/isis/link.rs
+++ b/zebra-rs/src/isis/link.rs
@@ -338,13 +338,18 @@ pub struct LinkBfdConfig {
     pub enable: Option<bool>,
     /// BFD Echo role for adjacencies on this interface
     /// (`transmit` / `receive` / `both`); `None` ⇒ inherit (off if unset
-    /// everywhere). Single-hop IPv4 only — inert on IPv6-only adjacencies.
+    /// everywhere). Single-hop only; both families (an IPv6-only adjacency
+    /// runs Echo over the two ends' link-locals).
     pub echo_mode: Option<EchoMode>,
     /// Echo transmit interval (ms); `None` ⇒ [`DEFAULT_ECHO_INTERVAL_MS`].
     pub echo_transmit_ms: Option<u32>,
     /// Advertised Required Min Echo RX (ms); `None` ⇒
     /// [`DEFAULT_ECHO_INTERVAL_MS`].
     pub echo_receive_ms: Option<u32>,
+    /// Offload control-packet expiration detection (RFC 5880 §6.8.4) to the
+    /// per-interface XDP helper once the session is Up. `None` ⇒ inherit
+    /// (hard default `false`: detection in userspace).
+    pub detect_offload: Option<bool>,
 }
 
 /// FRR default Echo interval (ms) — the hard default for the transmit/receive
@@ -360,6 +365,7 @@ pub struct ResolvedBfd {
     pub echo_mode: Option<EchoMode>,
     pub echo_transmit_ms: u32,
     pub echo_receive_ms: u32,
+    pub detect_offload: bool,
 }
 
 impl LinkBfdConfig {
@@ -376,6 +382,10 @@ impl LinkBfdConfig {
                 .echo_receive_ms
                 .or(default.echo_receive_ms)
                 .unwrap_or(DEFAULT_ECHO_INTERVAL_MS),
+            detect_offload: self
+                .detect_offload
+                .or(default.detect_offload)
+                .unwrap_or(false),
         }
     }
 }
@@ -982,6 +992,21 @@ pub fn config_bfd_echo_receive_interval(
     Some(())
 }
 
+/// `interface X bfd detect-offload <bool>` — offload control-packet expiration
+/// detection (RFC 5880 §6.8.4) to the per-interface XDP helper once the
+/// session is Up. Overrides the instance default; the BFD instance arms /
+/// disarms the in-kernel watchdog on live sessions.
+pub fn config_bfd_detect_offload(isis: &mut Isis, mut args: Args, op: ConfigOp) -> Option<()> {
+    let name = args.string()?;
+    let offload = args.boolean()?;
+    let link = isis.links.get_mut_by_name(&name)?;
+    // `None` ⇒ inherit `router isis { bfd { detect-offload } }`; `Some(false)`
+    // explicitly opts this interface out.
+    link.config.bfd.detect_offload = op.is_set().then_some(offload);
+    isis.bfd_reconcile_all();
+    Some(())
+}
+
 // ---- instance-level `router isis { bfd { ... } }` defaults ------------------
 
 /// `router isis bfd enable <bool>` — blanket-enable BFD on every IS-IS
@@ -1021,6 +1046,15 @@ pub fn config_isis_bfd_echo_receive_interval(
 ) -> Option<()> {
     let interval = args.u32()?;
     isis.config.bfd.echo_receive_ms = op.is_set().then_some(interval);
+    isis.bfd_reconcile_all();
+    Some(())
+}
+
+/// `router isis bfd detect-offload <bool>` — instance default for offloading
+/// expiration detection to the XDP helper (overridable per interface).
+pub fn config_isis_bfd_detect_offload(isis: &mut Isis, mut args: Args, op: ConfigOp) -> Option<()> {
+    let offload = args.boolean()?;
+    isis.config.bfd.detect_offload = op.is_set().then_some(offload);
     isis.bfd_reconcile_all();
     Some(())
 }
@@ -2333,6 +2367,7 @@ mod bfd_config_tests {
             enable: Some(true), // blanket
             echo_mode: Some(EchoMode::Receive),
             echo_transmit_ms: Some(100),
+            detect_offload: Some(true),
             ..LinkBfdConfig::default()
         };
         // Interface sets nothing → inherits.
@@ -2341,16 +2376,22 @@ mod bfd_config_tests {
         assert_eq!(inherit.echo_mode, Some(EchoMode::Receive));
         assert_eq!(inherit.echo_transmit_ms, 100);
         assert_eq!(inherit.echo_receive_ms, DEFAULT_ECHO_INTERVAL_MS);
-        // Interface overrides: opt out + change role.
+        assert!(inherit.detect_offload, "inherits the instance default");
+        // Interface overrides: opt out + change role + keep detection local.
         let over = LinkBfdConfig {
             enable: Some(false),
             echo_mode: Some(EchoMode::Both),
+            detect_offload: Some(false),
             ..LinkBfdConfig::default()
         };
         let eff = over.resolve(&default);
         assert!(!eff.enable);
         assert_eq!(eff.echo_mode, Some(EchoMode::Both));
         assert_eq!(eff.echo_transmit_ms, 100); // still inherits
+        assert!(!eff.detect_offload, "per-interface override wins");
+        // Unset everywhere → hard default off (userspace detection).
+        let bare = LinkBfdConfig::default().resolve(&LinkBfdConfig::default());
+        assert!(!bare.detect_offload);
     }
 }
 

--- a/zebra-rs/yang/config.yang
+++ b/zebra-rs/yang/config.yang
@@ -1334,8 +1334,8 @@ module config {
             }
             description
               "Instance-default BFD Echo role for every interface
-               (RFC 5880 §6.4; single-hop IPv4). Overridable per
-               interface; absent ⇒ Echo off.";
+               (RFC 5880 §6.4; single-hop, IPv4 or IPv6). Overridable
+               per interface; absent ⇒ Echo off.";
           }
           leaf echo-transmit-interval {
             ext:help "Default Echo transmit interval (ms)";
@@ -1346,6 +1346,15 @@ module config {
             ext:help "Default advertised Required Min Echo RX (ms)";
             type uint32;
             units "milliseconds";
+          }
+          leaf detect-offload {
+            ext:help "Default: offload expiration detection to XDP (kernel)";
+            type boolean;
+            description
+              "Instance default for offloading control-packet expiration
+               detection (RFC 5880 §6.8.4) to the per-interface XDP/eBPF
+               helper once a session is Up. Overridable per interface;
+               absent ⇒ false (detection in userspace).";
           }
         }
 
@@ -2024,9 +2033,10 @@ module config {
               }
               description
                 "Enable the BFD Echo function (RFC 5880 §6.4) on this
-                 interface's single-hop IPv4 adjacencies, choosing which
-                 half is active. Backed by the per-interface `xdp-bfd-echo`
-                 helper. Overrides the instance default; absent ⇒ inherit.";
+                 interface's single-hop adjacencies (IPv4, or IPv6 over
+                 the link-local pair), choosing which half is active.
+                 Backed by the per-interface `xdp-bfd-echo` helper.
+                 Overrides the instance default; absent ⇒ inherit.";
             }
             leaf echo-transmit-interval {
               ext:help "Echo transmit interval (ms)";
@@ -2043,6 +2053,20 @@ module config {
               description
                 "Advertised Required Min Echo RX (echo-mode
                  `receive`/`both`). Hard default 50 ms when unset.";
+            }
+            leaf detect-offload {
+              ext:help "Offload expiration detection to the XDP helper (kernel)";
+              type boolean;
+              description
+                "Once the session is Up, detect missing BFD control
+                 packets in the kernel: the per-interface XDP/eBPF helper
+                 re-arms a per-session timer on every arriving control
+                 packet (UDP/3784, TTL 255) and drives the session Down
+                 with Control Detection Time Expired when they stop
+                 (RFC 5880 §6.8.4) — immune to daemon scheduling latency.
+                 The userspace detection timer stays armed as a stretched
+                 backstop. Overrides the instance default; absent ⇒
+                 inherit (false: detection in userspace).";
             }
           }
 

--- a/zebra-rs/yang/zebra-bgp-bfd.yang
+++ b/zebra-rs/yang/zebra-bgp-bfd.yang
@@ -55,6 +55,18 @@ module zebra-bgp-bfd {
      (iBGP and multihop eBGP). Hop-mode (`multihop`) and `minimum-ttl` are
      per-neighbor only.";
 
+  revision 2026-06-12 {
+    description
+      "Add `detect-offload`: offload control-packet expiration detection
+       (the RFC 5880 §6.8.4 detection timer) to the per-interface
+       XDP/eBPF helper once the session is Up. Single-hop only. Also
+       correct the stale `echo-mode` description: Echo supports IPv6
+       single-hop sessions, not only IPv4.";
+    reference
+      "RFC 5880 §6.8.4 (Calculating the Detection Time); RFC 5881 §5
+       (GTSM).";
+  }
+
   revision 2026-06-01 {
     description
       "Add instance-level `router bgp { bfd {} }` defaults with
@@ -98,8 +110,9 @@ module zebra-bgp-bfd {
       description
         "Enable the BFD Echo function (RFC 5880 §6.4). **Single-hop only**
          — RFC 5883 multihop has no Echo, so this is inert on multihop
-         sessions (iBGP / multihop eBGP). Single-hop IPv4 only. Overrides
-         the instance default; absent ⇒ inherit (Echo off if unset).";
+         sessions (iBGP / multihop eBGP). Both IPv4 and IPv6 single-hop
+         sessions are supported. Overrides the instance default; absent ⇒
+         inherit (Echo off if unset).";
     }
     leaf echo-transmit-interval {
       ext:help "Echo transmit interval (ms)";
@@ -116,6 +129,20 @@ module zebra-bgp-bfd {
       description
         "Advertised Required Min Echo RX (echo-mode `receive`/`both`).
          Hard default 50 ms when unset.";
+    }
+    leaf detect-offload {
+      ext:help "Offload expiration detection to the XDP helper (kernel)";
+      type boolean;
+      description
+        "Once the session is Up, detect missing BFD control packets in
+         the kernel: the per-interface XDP/eBPF helper re-arms a
+         per-session timer on every arriving control packet (UDP/3784,
+         TTL 255) and drives the session Down with Control Detection
+         Time Expired when they stop (RFC 5880 §6.8.4) — immune to
+         daemon scheduling latency. The userspace detection timer stays
+         armed as a stretched backstop. **Single-hop only** — inert on
+         multihop sessions (the helper attaches per interface). Absent ⇒
+         inherit (false: detection in userspace).";
     }
   }
 


### PR DESCRIPTION
## Summary

Completes the `detect-offload` rollout started in #1387 (OSPF), following the echo-mode pattern:

- **IS-IS**: `bfd { detect-offload true; }` per interface with instance-level inheritance — arms the in-kernel expiration watchdog (RFC 5880 §6.8.4 in an XDP `bpf_timer`) once the adjacency's session is Up.
- **BGP**: the same knob per neighbor with instance-level inheritance; **single-hop only** (gated off on multihop in the params, mirroring Echo).

### BGP fix: sessions keyed by the connected interface

Wiring BGP exposed a pre-existing gap: BGP BFD `SessionKey`s were hardcoded `ifindex: 0`, so the per-ifindex XDP helper could never spawn for them — BGP `echo-mode` has been inert in practice. This PR:

- teaches `ConnectedSubnets` to remember the recording interface (`ifindex_for`; v6 link-locals excluded — `fe80::/64` is on every interface),
- keys single-hop BGP sessions by the connected interface,
- re-runs `bfd_reconcile_all` from the `RibRx::AddrAdd`/`AddrDel` handlers, so a session subscribed before the covering address was learned is re-keyed automatically (per-neighbor no-op when nothing changed).

Both `detect-offload` **and** `echo-mode` are now actually functional for directly-connected BGP neighbors.

Also fixes stale "single-hop IPv4 only" Echo texts in the IS-IS YANG/comments (IPv6 Echo landed 2026-06-07) and updates the book (IS-IS/BGP detect-offload sections, BGP connected-keying note, overview roadmap).

## Test plan

- [x] `cargo test --workspace --exclude bdd` — 1658 passed, 0 failed
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean; `cargo fmt`
- [x] New tests: IS-IS + BGP resolver merge (inherit/override/hard-default), `ifindex_for` (covering, link-local exclusion, forget), BGP wiring re-key flow (Unsubscribe ifindex-0 → Subscribe ifindex-3 on AddrAdd) and multihop inert gate
- [x] `yang_load` guard green (both YANG modules extended)
- [x] mdbook build + anchor verification
- [x] No eBPF/helper changes — the kernel path is unchanged from #1387's live veth validation

Generated with [Claude Code](https://claude.com/claude-code)