### PR TITLE
bgp: IPv6 unicast table-map

### DIFF
--- a/bdd/Makefile
+++ b/bdd/Makefile
@@ -190,6 +190,10 @@ bgp_table_map:
 	mkdir -p allure-results
 	cargo test --test cucumber -- --concurrency=1 --tags "@bgp_table_map"
 
+bgp_v6_table_map:
+	mkdir -p allure-results
+	cargo test --test cucumber -- --concurrency=1 --tags "@bgp_v6_table_map"
+
 bgp_community:
 	mkdir -p allure-results
 	cargo test --test cucumber -- --concurrency=1 --tags "@bgp_community"
@@ -249,4 +253,4 @@ docs/%.md: tests/features/%.feature docs/feature2md.sh FORCE
 
 FORCE:
 
-.PHONY: ecmp_bfd_evict ospfv2_bfd_frr ospfv3_bfd_frr tilfa_bfd all run ibgp ebgp rr rib_static_ipv6 isis_ipv6 isis_srv6 isis_fragmentation_ipv6 isis_fragmentation_ipv4 isis_l1p2p isis_tilfa isis_l1l2 isis_redist isis_hello_auth_keychain isis_passive isis_afi_enable isis_endx_ipv6 isis_bfd_ipv6_p2p isis_bfd_ipv6_p2p_echo isis_bfd_ipv6_lan isis_bfd_ipv6_lan_echo isis_bfd_ipv4_p2p isis_bfd_ipv4_p2p_echo isis_bfd_ipv4_lan isis_bfd_ipv4_lan_echo ospf_clear_neighbor ospfv2_nssa ospfv2_stub ospfv2_tilfa ospfv3_nssa ospfv3_tilfa bgp_peer_down_cleanup bgp_ipv6_over_v4_session bgp_evpn_capability bgp_vrf_evpn_type5 bgp_route_map_match bgp_policy_dynamic_update bgp_table_map bgp_community bgp_neighbor_group bgp_unnumbered_neighbor nd_show bgp_interas_option_c bgp_interas_option_a bgp_interas_option_b bgp_interas_option_ab bgp_port bgp_ip_transparent generate open docs FORCE
+.PHONY: ecmp_bfd_evict ospfv2_bfd_frr ospfv3_bfd_frr tilfa_bfd all run ibgp ebgp rr rib_static_ipv6 isis_ipv6 isis_srv6 isis_fragmentation_ipv6 isis_fragmentation_ipv4 isis_l1p2p isis_tilfa isis_l1l2 isis_redist isis_hello_auth_keychain isis_passive isis_afi_enable isis_endx_ipv6 isis_bfd_ipv6_p2p isis_bfd_ipv6_p2p_echo isis_bfd_ipv6_lan isis_bfd_ipv6_lan_echo isis_bfd_ipv4_p2p isis_bfd_ipv4_p2p_echo isis_bfd_ipv4_lan isis_bfd_ipv4_lan_echo ospf_clear_neighbor ospfv2_nssa ospfv2_stub ospfv2_tilfa ospfv3_nssa ospfv3_tilfa bgp_peer_down_cleanup bgp_ipv6_over_v4_session bgp_evpn_capability bgp_vrf_evpn_type5 bgp_route_map_match bgp_policy_dynamic_update bgp_table_map bgp_v6_table_map bgp_community bgp_neighbor_group bgp_unnumbered_neighbor nd_show bgp_interas_option_c bgp_interas_option_a bgp_interas_option_b bgp_interas_option_ab bgp_port bgp_ip_transparent generate open docs FORCE

--- a/bdd/tests/configs/bgp_v6_table_map/z1.yaml
+++ b/bdd/tests/configs/bgp_v6_table_map/z1.yaml
@@ -1,0 +1,29 @@
+interface:
+- if-name: z1-z2
+  ipv4:
+    address: 192.168.0.1/30
+  ipv6:
+    address: 2001:db8:12::1/64
+router:
+  bgp:
+    global:
+      as: 65001
+      router-id: 10.0.0.1
+    neighbor:
+    - remote-address: 192.168.0.2
+      remote-as: 65002
+      enabled: true
+      afi-safi:
+      - name: ipv4
+        enabled: true
+      - name: ipv6
+        enabled: true
+    afi-safi:
+    - name: ipv4
+      network:
+      - prefix: 1.1.1.1/32
+    - name: ipv6
+      network:
+      - prefix: 2001:db8:100::/48
+      - prefix: 2001:db8:200::/48
+      - prefix: 2001:db8:300::/48

--- a/bdd/tests/configs/bgp_v6_table_map/z2-deny-more.yaml
+++ b/bdd/tests/configs/bgp_v6_table_map/z2-deny-more.yaml
@@ -1,0 +1,47 @@
+interface:
+- if-name: z2-z1
+  ipv4:
+    address: 192.168.0.2/30
+  ipv6:
+    address: 2001:db8:12::2/64
+prefix-set:
+- name: DENY6
+  prefixes:
+  - prefix: 2001:db8:100::/48
+  - prefix: 2001:db8:300::/48
+- name: MED6
+  prefixes:
+  - prefix: 2001:db8:200::/48
+policy:
+- name: TMAP6
+  entry:
+  - number: 10
+    action: deny
+    match:
+      prefix: DENY6
+  - number: 20
+    action: permit
+    match:
+      prefix: MED6
+    set:
+      med:
+        set: 50
+  - number: 30
+    action: permit
+router:
+  bgp:
+    global:
+      as: 65002
+      router-id: 10.0.0.2
+    neighbor:
+    - remote-address: 192.168.0.1
+      remote-as: 65001
+      enabled: true
+      afi-safi:
+      - name: ipv4
+        enabled: true
+      - name: ipv6
+        enabled: true
+    afi-safi:
+    - name: ipv6
+      table-map: TMAP6

--- a/bdd/tests/configs/bgp_v6_table_map/z2.yaml
+++ b/bdd/tests/configs/bgp_v6_table_map/z2.yaml
@@ -1,0 +1,46 @@
+interface:
+- if-name: z2-z1
+  ipv4:
+    address: 192.168.0.2/30
+  ipv6:
+    address: 2001:db8:12::2/64
+prefix-set:
+- name: DENY6
+  prefixes:
+  - prefix: 2001:db8:100::/48
+- name: MED6
+  prefixes:
+  - prefix: 2001:db8:200::/48
+policy:
+- name: TMAP6
+  entry:
+  - number: 10
+    action: deny
+    match:
+      prefix: DENY6
+  - number: 20
+    action: permit
+    match:
+      prefix: MED6
+    set:
+      med:
+        set: 50
+  - number: 30
+    action: permit
+router:
+  bgp:
+    global:
+      as: 65002
+      router-id: 10.0.0.2
+    neighbor:
+    - remote-address: 192.168.0.1
+      remote-as: 65001
+      enabled: true
+      afi-safi:
+      - name: ipv4
+        enabled: true
+      - name: ipv6
+        enabled: true
+    afi-safi:
+    - name: ipv6
+      table-map: TMAP6

--- a/bdd/tests/features/bgp_v6_table_map.feature
+++ b/bdd/tests/features/bgp_v6_table_map.feature
@@ -1,0 +1,76 @@
+@serial
+@bgp_v6_table_map
+Feature: BGP table-map for IPv6 unicast gates RIB installs per address family
+  As a network operator
+  I want `router bgp afi-safi ipv6 table-map <policy>` to filter and
+  rewrite IPv6 best paths at the kernel-install boundary — with the
+  same semantics as the IPv4 table-map, and strictly scoped to its
+  own address family: a v6 binding must never touch v4 installs.
+
+  The exercise: a single v4 BGP session carries both families
+  (ipv4 + ipv6 afi-safi). z1 advertises three v6 prefixes and one v4
+  prefix. z2 binds table-map TMAP6 under `afi-safi ipv6` only:
+  entry 10 denies 2001:db8:100::/48, entry 20 permits
+  2001:db8:200::/48 with `set med 50`, entry 30 permits the rest.
+  All three v6 prefixes stay visible in `show bgp ipv6` throughout;
+  only the kernel routes move — and the v4 route installs untouched.
+
+  Test Topology:
+  ```
+  ┌─────────────────┐  192.168.0.0/30   ┌─────────────────┐
+  │       z1        │  2001:db8:12::/64 │       z2        │
+  │     AS65001     ├───────────────────┤     AS65002     │
+  │ .1 / 12::1      │                   │ .2 / 12::2      │
+  └─────────────────┘                   └─────────────────┘
+  ```
+
+  Config files:
+  - z1.yaml: AS 65001, networks 2001:db8:100::/48 + 2001:db8:200::/48
+    + 2001:db8:300::/48 (ipv6) and 1.1.1.1/32 (ipv4).
+  - z2.yaml: prefix-set DENY6 = { 2001:db8:100::/48 },
+    MED6 = { 2001:db8:200::/48 }; policy TMAP6 = deny DENY6 /
+    permit MED6 set med 50 / permit; `afi-safi ipv6 table-map TMAP6`;
+    ipv4 afi-safi enabled with NO table-map.
+  - z2-deny-more.yaml: DENY6 = { 2001:db8:100::/48,
+    2001:db8:300::/48 } (added).
+
+  Scenario: Setup topology and verify v6 install filter, MED rewrite, and v4 isolation
+    Given a clean test environment
+    When I create namespace "z1"
+    And I create namespace "z2"
+    And I connect namespace "z1" interface "z1-z2" to namespace "z2" interface "z2-z1"
+    And I start zebra-rs in namespace "z1"
+    And I start zebra-rs in namespace "z2"
+    And I apply config "z1.yaml" to namespace "z1"
+    And I apply config "z2.yaml" to namespace "z2"
+    And I wait 10 seconds for BGP to operate
+    Then show command "show bgp summary" in namespace "z2" should contain "Established"
+    And show command "show bgp ipv6" in namespace "z2" should contain "2001:db8:100::/48"
+    And show command "show bgp ipv6" in namespace "z2" should contain "2001:db8:200::/48"
+    And show command "show bgp ipv6" in namespace "z2" should contain "2001:db8:300::/48"
+    And kernel route "2001:db8:100::/48" in namespace "z2" should eventually be gone
+    And kernel route "2001:db8:200::/48" in namespace "z2" should eventually contain "metric 50"
+    And kernel route "2001:db8:300::/48" in namespace "z2" should eventually contain "2001:db8:12::1"
+    And kernel route "1.1.1.1/32" in namespace "z2" should eventually contain "192.168.0.1"
+
+  Scenario: Editing the referenced policy resyncs the v6 FIB without a session reset
+    Given the test topology exists
+    When I apply config "z2-deny-more.yaml" to namespace "z2"
+    Then kernel route "2001:db8:300::/48" in namespace "z2" should eventually be gone
+    And kernel route "2001:db8:200::/48" in namespace "z2" should eventually contain "metric 50"
+    And show command "show bgp ipv6" in namespace "z2" should contain "2001:db8:300::/48"
+
+  Scenario: Deleting the v6 table-map restores unfiltered v6 installs
+    Given the test topology exists
+    When I apply command "delete router bgp afi-safi ipv6 table-map TMAP6" in namespace "z2"
+    Then kernel route "2001:db8:100::/48" in namespace "z2" should eventually contain "2001:db8:12::1"
+    And kernel route "2001:db8:200::/48" in namespace "z2" should eventually contain "2001:db8:12::1"
+    And kernel route "2001:db8:300::/48" in namespace "z2" should eventually contain "2001:db8:12::1"
+
+  Scenario: Teardown topology
+    Given the test topology exists
+    When I stop zebra-rs in namespace "z1"
+    And I stop zebra-rs in namespace "z2"
+    And I delete namespace "z1"
+    And I delete namespace "z2"
+    Then the test environment should be clean

--- a/book/src/ch-02-28-bgp-table-map.md
+++ b/book/src/ch-02-28-bgp-table-map.md
@@ -124,9 +124,13 @@ where an unresolved name passes routes through unchanged. Deleting
 the `table-map` — not just fixing the name — is what restores
 unfiltered installs.
 
-**Scope.** IPv4 unicast on the global instance today; committing a
-`table-map` under another address family is rejected. IPv6 follows
-once the policy engine grows a v6 match path.
+**Scope.** IPv4 and IPv6 unicast on the global instance, each family
+bound independently (`afi-safi ipv4 table-map A`,
+`afi-safi ipv6 table-map B`) — a binding never touches the other
+family's installs. Committing a `table-map` under the labeled / VPN /
+EVPN families is rejected; they install through their own paths. For
+IPv6, `set med` works as for IPv4; the `set next-hop` rewrite is
+IPv4-only for now.
 
 ## Verification
 

--- a/zebra-rs/src/bgp/config.rs
+++ b/zebra-rs/src/bgp/config.rs
@@ -1677,10 +1677,14 @@ pub(super) fn config_redistribute_ospf_match_type(
 
 /// Families `table-map` accepts today. The YANG augment attaches the
 /// leaf to every afi-safi list entry, so filter at the callback —
-/// returning `None` surfaces as a commit failure. v4 unicast only
-/// until the policy-apply path grows a v6 NLRI form.
+/// returning `None` surfaces as a commit failure. v4 + v6 unicast;
+/// the labeled / VPN / EVPN families install through their own paths
+/// and have no table-map hook.
 fn table_map_afi_valid(afi_safi: &AfiSafi) -> bool {
-    matches!((afi_safi.afi, afi_safi.safi), (Afi::Ip, Safi::Unicast))
+    matches!(
+        (afi_safi.afi, afi_safi.safi),
+        (Afi::Ip, Safi::Unicast) | (Afi::Ip6, Safi::Unicast)
+    )
 }
 
 /// `ident` slot a table-map binding uses on the policy watch
@@ -3343,14 +3347,18 @@ mod table_map_ident_tests {
         assert_eq!(table_map_ident_decode(999), None);
     }
 
-    /// v4 unicast is the only family the callback accepts today; the
+    /// v4 + v6 unicast are the families the callback accepts; the
     /// YANG augment attaches the leaf to every afi-safi entry, so the
     /// gate is what rejects the rest at commit time.
     #[test]
-    fn afi_gate_is_v4_unicast_only() {
+    fn afi_gate_is_unicast_only() {
         assert!(table_map_afi_valid(&AfiSafi::new(Afi::Ip, Safi::Unicast)));
-        assert!(!table_map_afi_valid(&AfiSafi::new(Afi::Ip6, Safi::Unicast)));
+        assert!(table_map_afi_valid(&AfiSafi::new(Afi::Ip6, Safi::Unicast)));
         assert!(!table_map_afi_valid(&AfiSafi::new(Afi::Ip, Safi::MplsVpn)));
+        assert!(!table_map_afi_valid(&AfiSafi::new(
+            Afi::Ip,
+            Safi::MplsLabel
+        )));
     }
 }
 

--- a/zebra-rs/src/bgp/inst.rs
+++ b/zebra-rs/src/bgp/inst.rs
@@ -2928,17 +2928,33 @@ impl Bgp {
     /// disappeared).
     pub(super) fn table_map_resync(&mut self, afi_safi: bgp_packet::AfiSafi) {
         use bgp_packet::{Afi, Safi};
-        // v4 unicast only today, matching `table_map_afi_valid`.
-        if (afi_safi.afi, afi_safi.safi) != (Afi::Ip, Safi::Unicast) {
-            return;
-        }
-        let winners: Vec<(ipnet::Ipv4Net, super::route::BgpRib)> = self
-            .local_rib
-            .v4
-            .1
-            .iter()
-            .map(|(p, best)| (p, best.clone()))
-            .collect();
+        // Unicast families only, matching `table_map_afi_valid`.
+        let afi = match (afi_safi.afi, afi_safi.safi) {
+            (afi @ (Afi::Ip | Afi::Ip6), Safi::Unicast) => afi,
+            _ => return,
+        };
+        // Snapshot the winners first — building the `BgpTop` below
+        // takes `&mut local_rib`.
+        let winners_v4: Vec<(ipnet::Ipv4Net, super::route::BgpRib)> = if afi == Afi::Ip {
+            self.local_rib
+                .v4
+                .1
+                .iter()
+                .map(|(p, best)| (p, best.clone()))
+                .collect()
+        } else {
+            Vec::new()
+        };
+        let winners_v6: Vec<(ipnet::Ipv6Net, super::route::BgpRib)> = if afi == Afi::Ip6 {
+            self.local_rib
+                .v6
+                .1
+                .iter()
+                .map(|(p, best)| (p, best.clone()))
+                .collect()
+        } else {
+            Vec::new()
+        };
         let top = super::peer::BgpTop {
             router_id: &self.router_id,
             srv6_ipv6_export: self.srv6_ipv6_export.as_ref(),
@@ -2957,8 +2973,11 @@ impl Bgp {
             vrf_transport_v6: None,
             lu_labels: None,
         };
-        for (prefix, best) in &winners {
+        for (prefix, best) in &winners_v4 {
             super::route::fib_install_v4(&top, *prefix, std::slice::from_ref(best));
+        }
+        for (prefix, best) in &winners_v6 {
+            super::route::fib_install_v6(&top, *prefix, std::slice::from_ref(best));
         }
     }
 

--- a/zebra-rs/src/bgp/route.rs
+++ b/zebra-rs/src/bgp/route.rs
@@ -351,30 +351,37 @@ fn select_fib_entry_v4(
     }
 }
 
-/// Run the v4-unicast `table-map` over a best path about to be FIB-
-/// installed. Pass-through when no binding exists for the family.
-/// With a binding: an unresolved policy denies everything (FRR
-/// parity), a policy deny returns `None` (the caller's withdraw
-/// branch reconciles the FIB), and a permit returns a rewritten
-/// *copy* of the `BgpRib` — the Loc-RIB original and what peers see
-/// are never touched. Useful set clauses at install time are
-/// `set med` (-> RIB metric) and `set next-hop`; others execute
-/// harmlessly on the discarded copy.
-fn table_map_apply_v4<'a>(
+/// Run the family's `table-map` over a best path about to be FIB-
+/// installed. The family is the prefix's: `IpNet::V4` consults the
+/// v4-unicast binding, `IpNet::V6` the v6-unicast one. Pass-through
+/// when no binding exists for the family. With a binding: an
+/// unresolved policy denies everything (FRR parity), a policy deny
+/// returns `None` (the caller's withdraw branch reconciles the FIB),
+/// and a permit returns a rewritten *copy* of the `BgpRib` — the
+/// Loc-RIB original and what peers see are never touched. Useful set
+/// clauses at install time are `set med` (-> RIB metric) and
+/// `set next-hop` (v4 routes; the v6 next-hop rewrite waits on the
+/// same plumbing as `policy in/out`); others execute harmlessly on
+/// the discarded copy.
+fn table_map_apply<'a>(
     table_map: &BTreeMap<AfiSafi, BgpTableMap>,
     router_id: Ipv4Addr,
-    prefix: Ipv4Net,
+    prefix: IpNet,
     best: Option<&'a BgpRib>,
 ) -> Option<std::borrow::Cow<'a, BgpRib>> {
     use std::borrow::Cow;
-    let Some(tm) = table_map.get(&AfiSafi::new(Afi::Ip, Safi::Unicast)) else {
+    let afi = match prefix {
+        IpNet::V4(_) => Afi::Ip,
+        IpNet::V6(_) => Afi::Ip6,
+    };
+    let Some(tm) = table_map.get(&AfiSafi::new(afi, Safi::Unicast)) else {
         return best.map(Cow::Borrowed);
     };
     let best = best?;
     // Bound name doesn't resolve to a policy: deny-all.
     let policy = tm.policy.as_ref()?;
-    let nlri = Ipv4Nlri { id: 0, prefix };
-    let decision = policy_list_apply(policy, &nlri, (*best.attr).clone(), best.weight, router_id)?;
+    let decision =
+        policy_list_apply_net(policy, prefix, (*best.attr).clone(), best.weight, router_id)?;
     let mut mapped = best.clone();
     // Transient install-time copy — never enters the attr store or
     // the Loc-RIB, so a free-floating Arc is fine.
@@ -398,10 +405,10 @@ pub(super) fn fib_install_v4(bgp: &super::peer::BgpTop, prefix: Ipv4Net, selecte
         .vrf_transport_v4
         .and_then(|m| m.get(&prefix))
         .map(|v| v.as_slice());
-    let best = table_map_apply_v4(
+    let best = table_map_apply(
         &bgp.local_rib.table_map,
         *bgp.router_id,
-        prefix,
+        IpNet::V4(prefix),
         selected.first(),
     );
     let best = best.as_deref();
@@ -561,8 +568,14 @@ pub(super) fn fib_install_v6(bgp: &super::peer::BgpTop, prefix: Ipv6Net, selecte
         .vrf_transport_v6
         .and_then(|m| m.get(&prefix))
         .map(|v| v.as_slice());
-    match selected
-        .first()
+    let best = table_map_apply(
+        &bgp.local_rib.table_map,
+        *bgp.router_id,
+        IpNet::V6(prefix),
+        selected.first(),
+    );
+    match best
+        .as_deref()
         .and_then(|b| select_fib_entry_v6(b, transport))
     {
         Some(rib_entry) => {
@@ -7418,13 +7431,33 @@ pub fn policy_list_apply(
     weight: u32,
     local_addr: Ipv4Addr,
 ) -> Option<PolicyDecision> {
+    policy_list_apply_net(
+        policy_list,
+        IpNet::V4(nlri.prefix),
+        bgp_attr,
+        weight,
+        local_addr,
+    )
+}
+
+/// Family-generic core of [`policy_list_apply`]: the prefix arrives
+/// as an `IpNet` so the same entry walk serves IPv4 and IPv6 routes
+/// (`PrefixSet::matches` is already dual-stack). The v6 table-map is
+/// the first v6 consumer; per-peer v6 policy can join later.
+pub fn policy_list_apply_net(
+    policy_list: &PolicyList,
+    prefix: IpNet,
+    bgp_attr: BgpAttr,
+    weight: u32,
+    local_addr: Ipv4Addr,
+) -> Option<PolicyDecision> {
     use crate::policy::{PolicyAction, SetNextHop};
     let mut decision = PolicyDecision {
         attr: bgp_attr,
         weight,
     };
     for (_, entry) in policy_list.entry.iter() {
-        if !entry_matches(entry, nlri, &decision.attr, decision.weight) {
+        if !entry_matches(entry, prefix, &decision.attr, decision.weight) {
             continue;
         }
         match entry.action {
@@ -7493,12 +7526,12 @@ pub fn policy_list_apply(
 
 fn entry_matches(
     entry: &crate::policy::PolicyEntry,
-    nlri: &Ipv4Nlri,
+    prefix: IpNet,
     bgp_attr: &BgpAttr,
     weight: u32,
 ) -> bool {
     if let Some(prefix_set) = &entry.prefix_set
-        && !prefix_set.matches(nlri.prefix)
+        && !prefix_set.matches(prefix)
     {
         return false;
     }
@@ -10451,24 +10484,24 @@ mod color_aware_nht_tests {
 /// `table-map` semantics at the BGP-to-RIB install seam
 /// (zebra-bgp-table-map.yang): no binding passes through, an
 /// unresolved binding denies everything (FRR parity), a policy deny
-/// filters, and permit-side set clauses rewrite only the install-time
-/// copy — never the Loc-RIB original.
+/// filters, permit-side set clauses rewrite only the install-time
+/// copy — never the Loc-RIB original — and the v4/v6 bindings are
+/// consulted strictly by the prefix's family.
 #[cfg(test)]
 mod table_map_tests {
     use std::borrow::Cow;
-    use std::net::Ipv4Addr;
+    use std::net::{Ipv4Addr, Ipv6Addr};
     use std::str::FromStr;
 
     use bgp_packet::{Afi, AfiSafi, BgpAttr, BgpNexthop, Med, Safi};
-    use ipnet::Ipv4Net;
 
     use super::*;
     use crate::policy::{NumericSet, PolicyAction, PolicyList, PrefixSet};
 
-    fn binding(policy: Option<PolicyList>) -> BTreeMap<AfiSafi, BgpTableMap> {
+    fn binding(afi: Afi, policy: Option<PolicyList>) -> BTreeMap<AfiSafi, BgpTableMap> {
         let mut map = BTreeMap::new();
         map.insert(
-            AfiSafi::new(Afi::Ip, Safi::Unicast),
+            AfiSafi::new(afi, Safi::Unicast),
             BgpTableMap {
                 name: Some("TM".into()),
                 policy,
@@ -10494,34 +10527,61 @@ mod table_map_tests {
         )
     }
 
-    fn p(s: &str) -> Ipv4Net {
-        Ipv4Net::from_str(s).unwrap()
+    fn rib_v6_with_med(med: Option<u32>) -> BgpRib {
+        let mut attr = BgpAttr::new();
+        attr.nexthop = Some(BgpNexthop::Ipv6(Ipv6Addr::from_str("2001:db8::1").unwrap()));
+        attr.med = med.map(|m| Med { med: m });
+        BgpRib::new(
+            1,
+            Ipv4Addr::new(192, 0, 2, 1),
+            BgpRibType::EBGP,
+            0,
+            0,
+            &attr,
+            None,
+            None,
+            false,
+        )
+    }
+
+    fn p(s: &str) -> IpNet {
+        IpNet::from_str(s).unwrap()
+    }
+
+    /// Deny-everything policy: a single deny entry plus nothing else,
+    /// so any prefix that reaches it is filtered.
+    fn deny_all_list() -> PolicyList {
+        let mut list = PolicyList::default();
+        list.entry(10).action = PolicyAction::Deny;
+        list
     }
 
     #[test]
     fn no_binding_passes_through() {
         let map = BTreeMap::new();
         let best = rib_with_med(Some(7));
-        let out = table_map_apply_v4(&map, Ipv4Addr::UNSPECIFIED, p("10.0.0.0/8"), Some(&best))
+        let out = table_map_apply(&map, Ipv4Addr::UNSPECIFIED, p("10.0.0.0/8"), Some(&best))
             .expect("no binding must not filter");
         assert!(
             matches!(out, Cow::Borrowed(_)),
             "pass-through must not clone the winner"
         );
         assert!(
-            table_map_apply_v4(&map, Ipv4Addr::UNSPECIFIED, p("10.0.0.0/8"), None).is_none(),
+            table_map_apply(&map, Ipv4Addr::UNSPECIFIED, p("10.0.0.0/8"), None).is_none(),
             "no winner stays no winner"
         );
     }
 
     #[test]
     fn unresolved_policy_denies_all() {
-        let map = binding(None);
-        let best = rib_with_med(None);
-        assert!(
-            table_map_apply_v4(&map, Ipv4Addr::UNSPECIFIED, p("10.0.0.0/8"), Some(&best)).is_none(),
-            "a bound but unresolved table-map filters every install (FRR parity)"
-        );
+        for (afi, prefix) in [(Afi::Ip, p("10.0.0.0/8")), (Afi::Ip6, p("2001:db8::/32"))] {
+            let map = binding(afi, None);
+            let best = rib_with_med(None);
+            assert!(
+                table_map_apply(&map, Ipv4Addr::UNSPECIFIED, prefix, Some(&best)).is_none(),
+                "a bound but unresolved table-map filters every install (FRR parity)"
+            );
+        }
     }
 
     #[test]
@@ -10529,21 +10589,20 @@ mod table_map_tests {
         // seq 10: deny 10.0.0.0/8 (and longer); seq 20: permit any.
         let mut list = PolicyList::default();
         let mut pset = PrefixSet::default();
-        pset.entry(p("10.0.0.0/8").into());
+        pset.entry(p("10.0.0.0/8"));
         let entry = list.entry(10);
         entry.prefix_set = Some(pset);
         entry.action = PolicyAction::Deny;
         let _ = list.entry(20);
-        let map = binding(Some(list));
+        let map = binding(Afi::Ip, Some(list));
         let best = rib_with_med(None);
 
         assert!(
-            table_map_apply_v4(&map, Ipv4Addr::UNSPECIFIED, p("10.1.0.0/16"), Some(&best))
-                .is_none(),
+            table_map_apply(&map, Ipv4Addr::UNSPECIFIED, p("10.1.0.0/16"), Some(&best)).is_none(),
             "denied prefix must not install"
         );
         assert!(
-            table_map_apply_v4(
+            table_map_apply(
                 &map,
                 Ipv4Addr::UNSPECIFIED,
                 p("192.168.0.0/16"),
@@ -10558,10 +10617,10 @@ mod table_map_tests {
     fn set_med_rewrites_install_copy_only() {
         let mut list = PolicyList::default();
         list.entry(10).med = Some(NumericSet::Set(50));
-        let map = binding(Some(list));
+        let map = binding(Afi::Ip, Some(list));
         let best = rib_with_med(Some(7));
 
-        let out = table_map_apply_v4(&map, Ipv4Addr::UNSPECIFIED, p("10.0.0.0/8"), Some(&best))
+        let out = table_map_apply(&map, Ipv4Addr::UNSPECIFIED, p("10.0.0.0/8"), Some(&best))
             .expect("permit");
         assert_eq!(
             out.attr.med.as_ref().map(|m| m.med),
@@ -10572,6 +10631,93 @@ mod table_map_tests {
             best.attr.med.as_ref().map(|m| m.med),
             Some(7),
             "Loc-RIB original is untouched"
+        );
+    }
+
+    #[test]
+    fn v6_policy_deny_filters_matching_prefix_only() {
+        // seq 10: deny 2001:db8::/32 (and longer); seq 20: permit any.
+        let mut list = PolicyList::default();
+        let mut pset = PrefixSet::default();
+        pset.entry(p("2001:db8::/32"));
+        let entry = list.entry(10);
+        entry.prefix_set = Some(pset);
+        entry.action = PolicyAction::Deny;
+        let _ = list.entry(20);
+        let map = binding(Afi::Ip6, Some(list));
+        let best = rib_v6_with_med(None);
+
+        assert!(
+            table_map_apply(
+                &map,
+                Ipv4Addr::UNSPECIFIED,
+                p("2001:db8:1::/48"),
+                Some(&best)
+            )
+            .is_none(),
+            "denied v6 prefix must not install"
+        );
+        assert!(
+            table_map_apply(
+                &map,
+                Ipv4Addr::UNSPECIFIED,
+                p("2001:dead::/32"),
+                Some(&best)
+            )
+            .is_some(),
+            "non-matching v6 prefix falls through to the permit entry"
+        );
+    }
+
+    #[test]
+    fn v6_set_med_rewrites_install_copy_only() {
+        let mut list = PolicyList::default();
+        list.entry(10).med = Some(NumericSet::Set(50));
+        let map = binding(Afi::Ip6, Some(list));
+        let best = rib_v6_with_med(Some(7));
+
+        let out = table_map_apply(&map, Ipv4Addr::UNSPECIFIED, p("2001:db8::/32"), Some(&best))
+            .expect("permit");
+        assert_eq!(
+            out.attr.med.as_ref().map(|m| m.med),
+            Some(50),
+            "install copy carries the rewritten MED"
+        );
+        assert_eq!(
+            best.attr.med.as_ref().map(|m| m.med),
+            Some(7),
+            "Loc-RIB original is untouched"
+        );
+    }
+
+    #[test]
+    fn bindings_are_per_family() {
+        // A deny-all bound to v4-unicast must not touch v6 installs,
+        // and vice versa.
+        let v4_map = binding(Afi::Ip, Some(deny_all_list()));
+        let v6_best = rib_v6_with_med(None);
+        assert!(
+            table_map_apply(
+                &v4_map,
+                Ipv4Addr::UNSPECIFIED,
+                p("2001:db8::/32"),
+                Some(&v6_best)
+            )
+            .is_some(),
+            "a v4-only binding must pass v6 installs through"
+        );
+
+        let v6_map = binding(Afi::Ip6, Some(deny_all_list()));
+        let v4_best = rib_with_med(None);
+        assert!(
+            table_map_apply(
+                &v6_map,
+                Ipv4Addr::UNSPECIFIED,
+                p("10.0.0.0/8"),
+                Some(&v4_best)
+            )
+            .is_some(),
+            "a v6-only binding must pass v4 installs through"
         );
     }
 }

--- a/zebra-rs/src/config/manager.rs
+++ b/zebra-rs/src/config/manager.rs
@@ -1502,17 +1502,17 @@ mod yang_load_tests {
             .expect("configure module present");
         let entry = to_entry(&yang, module);
 
-        let (code, _comps, _state) = parse(
+        for cmd in [
             "set router bgp afi-safi ipv4 table-map RIB-FILTER",
-            entry,
-            None,
-            State::new(),
-        );
-        assert_eq!(
-            code,
-            ExecCode::Success,
-            "table-map must parse as a settable path"
-        );
+            "set router bgp afi-safi ipv6 table-map RIB-FILTER",
+        ] {
+            let (code, _comps, _state) = parse(cmd, entry.clone(), None, State::new());
+            assert_eq!(
+                code,
+                ExecCode::Success,
+                "table-map must parse as a settable path: {cmd}"
+            );
+        }
     }
 
     /// The `neighbor-group` list inherits the per-neighbor knob set

--- a/zebra-rs/yang/zebra-bgp-table-map.yang
+++ b/zebra-rs/yang/zebra-bgp-table-map.yang
@@ -44,9 +44,9 @@ module zebra-bgp-table-map {
          references. Unlike those, a table-map whose policy does NOT
          resolve denies every install for the family (FRR parity:
          a missing referenced route-map filters everything).
-       - ipv4 unicast only today; the Rust callback rejects other
-         families at commit time. ipv6 follows once the policy-apply
-         path grows a v6 NLRI form.";
+       - ipv4 and ipv6 unicast; the Rust callback rejects the
+         labeled / VPN / EVPN families at commit time (they install
+         through their own paths and have no table-map hook).";
 
   reference
     "FRR bgpd `table-map WORD` under `address-family` —


### PR DESCRIPTION
## Summary

Extends table-map (#1385) to `set router bgp afi-safi ipv6 table-map <policy>`.

- **Policy core genericized**: new `policy_list_apply_net(IpNet, …)` — `entry_matches` only ever used the NLRI for `PrefixSet::matches`, which was already dual-stack. The existing `policy_list_apply(Ipv4Nlri, …)` remains as a thin wrapper, so every peer-policy call site and test is untouched. This also unblocks future per-peer v6 policy.
- **Install hooks**: `table_map_apply` (ex-`_v4`) selects the binding by the prefix's family; `fib_install_v6` gets the same gate/rewrite as v4; `table_map_resync` grows a v6 arm over the v6 Selected map.
- **Gate widened**: `table_map_afi_valid` accepts v4 + v6 unicast; labeled/VPN/EVPN families still rejected at commit. The watch-ident codec already covered v6.
- **Strict per-family scoping**: a v6 binding never touches v4 installs and vice versa — unit-tested and BDD-asserted.
- `set med` lands in the v6 kernel route metric. The v6 `set next-hop` rewrite stays unwired (same plumbing gap as peer policy); book scope section updated accordingly.

## Testing

- Unit: v6 deny-filter / v6 set-med-on-copy-only / unresolved deny-all for both families / per-family isolation, AFI-gate update, ipv6 CLI parse pinning.
- `cargo test --workspace --exclude bdd` green; fmt + workspace clippy clean; `mdbook build` passes.
- BDD `@bgp_v6_table_map` (both families over one v4 session): v6 install filter + MED-in-kernel-metric + v4-isolation assert, live policy-edit resync without session reset, table-map delete restoring installs, teardown. Local run + v4 `@bgp_table_map` regression to follow; will report here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)