### PR TITLE
bdd: TI-LFA compute-mode scenarios + perf harness (PR-C)

### DIFF
--- a/bdd/tests/features/isis_tilfa.feature
+++ b/bdd/tests/features/isis_tilfa.feature
@@ -104,6 +104,45 @@ Feature: IS-IS TI-LFA fast-reroute over SR-MPLS
     # Primary restored.
     Then ping from "s" to "10.0.0.8" should succeed
 
+  Scenario: TI-LFA compute-mode aggressive computes the same repair in parallel
+    Given the test topology exists
+    # Switch the TI-LFA scheduler to the parallel map-reduce mode
+    # (docs/design/isis-tilfa-parallel-spf.md). The config handler
+    # re-runs SPF on its own; results are identical across modes by
+    # design — only the CPU scheduling differs.
+    When I apply command "set router isis fast-reroute ti-lfa compute-mode aggressive" in namespace "s"
+    And I wait 5 seconds
+    # The repair tunnel is still computed after the parallel run...
+    Then show command "show isis route detail" in namespace "s" should contain "Backup path: TI-LFA"
+    # ...and the SPF telemetry proves the aggressive scheduler ran it
+    # (q = one reverse SPF per protected destination, pc deduped per
+    # protected first-hop node).
+    And show command "show isis spf" in namespace "s" should contain "mode=aggressive"
+
+  Scenario: TI-LFA compute-mode sharding bounds parallelism and still protects
+    Given the test topology exists
+    When I apply command "set router isis fast-reroute ti-lfa compute-shards 2" in namespace "s"
+    And I apply command "set router isis fast-reroute ti-lfa compute-mode sharding" in namespace "s"
+    And I wait 5 seconds
+    Then show command "show isis route detail" in namespace "s" should contain "Backup path: TI-LFA"
+    And show command "show isis spf" in namespace "s" should contain "mode=sharding(2)"
+    # The sharded recompute still protects for real: fail the primary
+    # link and reach d over the repair / post-convergence path.
+    When I make namespace "s" interface "s-n1" down
+    And I wait 5 seconds
+    Then ping from "s" to "10.0.0.8" should succeed
+    When I make namespace "s" interface "s-n1" up
+    And I wait 10 seconds
+    Then ping from "s" to "10.0.0.8" should succeed
+    # Surgical runtime deletes exercise the handlers' reset-to-default
+    # path; the next full-file apply would wipe these leaves anyway
+    # (file applies are whole-config replaces). Leaf deletes carry the
+    # current value, like `delete … bfd echo-mode transmit`.
+    When I apply command "delete router isis fast-reroute ti-lfa compute-mode sharding" in namespace "s"
+    And I apply command "delete router isis fast-reroute ti-lfa compute-shards 2" in namespace "s"
+    And I wait 5 seconds
+    Then show command "show isis spf" in namespace "s" should contain "mode=serial"
+
   Scenario: no-php sets the P (no-PHP) flag and makes the penultimate hop swap
     Given the test topology exists
     # By default s advertises its loopback Prefix-SID (10.0.0.1/32, SID

--- a/docs/design/isis-tilfa-parallel-spf.md
+++ b/docs/design/isis-tilfa-parallel-spf.md
@@ -1,6 +1,9 @@
 # TI-LFA Parallel SPF Computation — Design (IS-IS first)
 
-Status: ACCEPTED (2026-06-12). Branch: `ti-lfa-scaling`.
+Status: ACCEPTED (2026-06-12). Shipped: PR-A #1384 (spf refactor +
+oracle tests), PR-B #1390 (modes + IS-IS wiring + config + telemetry).
+PR-C adds the BDD scenarios (`bdd/tests/features/isis_tilfa.feature`)
+and the `tilfa_perf_modes` ignored harness.
 Decisions: rayon substrate; default mode `serial`; **no redundant SPF
 in any mode** — serial is the sequential 2-SPF-per-target loop, not the
 legacy 3-SPF path (see §6.0, §15).

--- a/zebra-rs/src/spf/tilfa_par.rs
+++ b/zebra-rs/src/spf/tilfa_par.rs
@@ -321,7 +321,9 @@ fn run_sharded(
         q_spf: targets.len(),
         pc_spf: group_count,
         pc_deduped: targets.len() - group_count,
-        width: k.min(rayon::current_num_threads()),
+        // Groups are never split, so the effective parallelism is also
+        // capped by the group count, not just K and the pool.
+        width: k.min(group_count).min(rayon::current_num_threads()),
         ..TilfaStats::default()
     };
     (
@@ -549,6 +551,59 @@ mod tests {
             let (got, stats) = tilfa_compute(&graph, 0, &primary, &[], mode);
             assert!(got.is_empty());
             assert_eq!(stats.targets, 0);
+        }
+    }
+
+    /// Manual perf harness — not a correctness gate (CI never runs
+    /// ignored tests). Compares the legacy 3-SPF reference loop and
+    /// every compute mode on a ~400-vertex random graph:
+    ///
+    ///   cargo test --release -p zebra-rs tilfa_perf -- --ignored --nocapture
+    ///
+    /// Debug builds are ~10× slower and skew the comparison; use
+    /// `--release`. The mode outputs are also cross-checked for
+    /// equality so a perf run doubles as a large-graph equivalence
+    /// run.
+    #[test]
+    #[ignore = "manual perf harness; run with --release --ignored --nocapture"]
+    fn tilfa_perf_modes() {
+        let n = 400;
+        let graph = random_graph(42, n);
+        let primary = spf(&graph, 0, &SpfOpt::full_path());
+        let targets = derive_targets(&graph, 0, &primary);
+        let distinct_x: BTreeSet<usize> = targets.iter().map(|t| t.x).collect();
+        println!(
+            "graph: {n} vertices, {} targets, {} protected first-hops",
+            targets.len(),
+            distinct_x.len()
+        );
+
+        let t0 = Instant::now();
+        let want = reference(&graph, 0, &targets);
+        println!(
+            "{:<20} {:>12?}  (3 SPFs per target)",
+            "reference",
+            t0.elapsed()
+        );
+
+        for mode in [
+            TilfaComputeMode::Serial,
+            TilfaComputeMode::Conservative,
+            TilfaComputeMode::Aggressive,
+            TilfaComputeMode::Sharding(2),
+            TilfaComputeMode::Sharding(8),
+        ] {
+            let t0 = Instant::now();
+            let (got, stats) = tilfa_compute(&graph, 0, &primary, &targets, mode);
+            println!(
+                "{:<20} {:>12?}  spf{{q={} pc={}}} width={}",
+                mode.to_string(),
+                t0.elapsed(),
+                stats.q_spf,
+                stats.pc_spf,
+                stats.width
+            );
+            assert_eq!(got, want, "mode {mode:?} diverged from reference");
         }
     }
 


### PR DESCRIPTION
## Summary

Final PR of the TI-LFA parallel SPF series (design: `docs/design/isis-tilfa-parallel-spf.md`; PR-A #1384, PR-B #1390).

- **BDD** — two scenarios added to `isis_tilfa.feature` (no new feature tag, so no sweep-prefix concerns; teardown unchanged as the last scenario):
  - *aggressive*: runtime `set … compute-mode aggressive`, assert the repair is still computed (`Backup path: TI-LFA`) and the `show isis spf` telemetry reports `mode=aggressive`.
  - *sharding*: `compute-shards 2` + `compute-mode sharding`, assert `mode=sharding(2)`, then a full link-down/up fast-reroute cycle proving the sharded recompute still protects, then runtime leaf deletes (value-carrying, per the `delete … echo-mode transmit` convention) resetting to `mode=serial`.
- **Perf harness** — `tilfa_perf_modes`, `#[ignore]`d (CI never runs it): compares the legacy 3-SPF reference loop and every mode on a 400-vertex seeded random graph, and cross-checks outputs for equality so a perf run doubles as a large-graph equivalence run.
- Sharding `width` stat now also capped by the x-group count (groups are never split).
- Design doc status updated with the shipped PR numbers.

## Measured (5-core box, `--release`)

```
graph: 400 vertices, 281 targets, 2 protected first-hops
reference     195.0ms  (3 SPFs per target — pre-series behavior)
serial        125.0ms  spf{q=281 pc=281} width=1
conservative   28.8ms  spf{q=281 pc=281} width=5
aggressive     15.9ms  spf{q=281 pc=2}   width=5   (~12x vs reference)
sharding(2)    33.8ms  spf{q=281 pc=2}   width=2
```

## Test plan

- Live BDD: all 14 `@isis_tilfa` scenarios pass against the rebuilt binary (`--concurrency=1`), binary md5 verified stable across the run.
- `cargo fmt`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo test --workspace --exclude bdd` green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)