### PR TITLE
book: IPv6 section in the table-map chapter

### DIFF
--- a/book/src/ch-02-28-bgp-table-map.md
+++ b/book/src/ch-02-28-bgp-table-map.md
@@ -35,7 +35,10 @@ Typical uses:
 ## Configuration
 
 `table-map` takes the name of a [policy](ch-05-00-policy.md) and sits
-directly under the global `afi-safi` entry, bare-leaf FRR-style:
+directly under the global `afi-safi` entry, bare-leaf FRR-style. Each
+address family binds its own policy independently — `afi-safi ipv4
+table-map A` and `afi-safi ipv6 table-map B` never see each other's
+routes. The IPv4 walk-through first:
 
 ```yaml
 prefix-set:
@@ -96,6 +99,51 @@ Remember the [policy control flow](ch-05-01-policy-control-flow.md):
 a policy ends in an implicit deny, so a table-map consisting only of
 deny entries filters *everything* — close with a bare `permit` entry
 (number 30 above) for "and install the rest".
+
+### IPv6
+
+The IPv6 binding is the same shape under `afi-safi ipv6`, and the
+policy matches v6 prefix-sets — `prefix-set` entries are
+family-agnostic, so a dedicated v6 policy is just one whose sets hold
+v6 prefixes:
+
+```yaml
+prefix-set:
+- name: DENY6
+  prefixes:
+  - prefix: 2001:db8:100::/48
+policy:
+- name: TMAP6
+  entry:
+  - number: 10
+    action: deny
+    match:
+      prefix: DENY6
+  - number: 20
+    action: permit
+router:
+  bgp:
+    afi-safi:
+    - name: ipv6
+      table-map: TMAP6
+```
+
+```
+set router bgp afi-safi ipv6 table-map TMAP6
+```
+
+With this on a router also carrying the IPv4 table-map above, the two
+filters operate side by side: `2001:db8:100::/48` stays out of the v6
+kernel table while every v4 install follows TMAP, and removing one
+binding leaves the other untouched. Verification is the v6 spelling
+of the same disagreement — the prefix is present in `show bgp ipv6`
+but absent from `ip -6 route show`, and a `set med` lands as the
+kernel metric:
+
+```
+$ ip -6 route show 2001:db8:200::/48
+2001:db8:200::/48 via 2001:db8:12::1 dev z2-z1 proto bgp metric 50
+```
 
 ## Semantics
 


### PR DESCRIPTION
## Summary

Documentation follow-up to #1393: the table-map chapter's configuration walk-through and verification were still IPv4-only after the v6 feature landed.

- Configuration intro now states the per-family independence of the bindings (`afi-safi ipv4 table-map A` / `afi-safi ipv6 table-map B`).
- New **IPv6** subsection with a config example mirroring the `@bgp_v6_table_map` BDD (DENY6 prefix-set + TMAP6 policy), the CLI spelling, side-by-side operation with the v4 filter, and verification via `ip -6 route show` (incl. `set med` landing as the kernel metric).

`mdbook build` passes locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)