### PR TITLE
bgp: implement neighbor local-as (no-prepend / replace-as / dual-as)

### DIFF
--- a/zebra-rs/src/bgp/config.rs
+++ b/zebra-rs/src/bgp/config.rs
@@ -19,7 +19,8 @@ use super::{
     BGP_PORT, Bgp,
     inst::Callback,
     peer::{
-        ALLOWAS_IN_DEFAULT_COUNT, AllowAsIn, PasswordEncoding, Peer, PeerType, RemovePrivateAs,
+        ALLOWAS_IN_DEFAULT_COUNT, AllowAsIn, LocalAs, PasswordEncoding, Peer, PeerType,
+        RemovePrivateAs,
     },
     timer,
 };
@@ -786,6 +787,135 @@ fn config_enforce_first_as(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Optio
 pub(super) fn apply_enforce_first_as(peer: &mut Peer, want: bool) -> bool {
     peer.config.enforce_first_as = want;
     false
+}
+
+/// Resolve the `local-as` entry the callbacks below may write to,
+/// enforcing the two commit-time rules from zebra-bgp-local-as.yang:
+/// the substitute must differ from the router's global AS (FRR's
+/// "Cannot have local-as same as BGP AS number"), and the list is
+/// single-instance — the YANG `max-elements 1` is not engine-enforced,
+/// so a second key is refused here with a warning and the
+/// first-configured entry wins (delete it before setting another).
+/// Returns the entry, seeded with all modifiers off when new, so the
+/// list-node and flag callbacks stay order-independent within a
+/// commit.
+fn local_as_entry<'a>(bgp_asn: u32, peer: &'a mut Peer, key: u32) -> Option<&'a mut LocalAs> {
+    if key == bgp_asn {
+        tracing::warn!(
+            peer = %peer.display_name(),
+            "bgp: cannot have local-as {key} same as the BGP AS number; ignoring",
+        );
+        return None;
+    }
+    if let Some(existing) = &peer.config.local_as
+        && existing.as_number != key
+    {
+        tracing::warn!(
+            peer = %peer.display_name(),
+            "bgp: local-as is single-instance (already {}); delete it before setting {key}",
+            existing.as_number,
+        );
+        return None;
+    }
+    Some(peer.config.local_as.get_or_insert(LocalAs {
+        as_number: key,
+        no_prepend: false,
+        replace_as: false,
+        dual_as: false,
+    }))
+}
+
+/// `set router bgp neighbor X local-as <ASN>` — the list node
+/// (zebra-bgp-local-as.yang): present the substitute AS to this
+/// neighbor. Creating or removing the entry changes the OPEN's My-AS
+/// field, so an already-running session is bounced with `Event::Stop`
+/// (the `clear ... hard` teardown) to renegotiate under the new AS; a
+/// peer still Idle picks it up on its first connect. The modifier
+/// leaves ride their own callbacks and do not bounce.
+fn config_local_as(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Option<()> {
+    let addr = args.addr()?;
+    let key = args.u32();
+    let bgp_asn = bgp.asn;
+    let (ident, bounce) = {
+        let peer = bgp.peers.get_mut(&addr)?;
+        let changed = if op.is_set() {
+            let key = key?;
+            let before = peer.config.local_as;
+            local_as_entry(bgp_asn, peer, key)?;
+            peer.config.local_as != before
+        } else {
+            // Be liberal about the delete spelling: a keyed delete only
+            // removes the matching entry, an unkeyed one clears the lot
+            // (there is at most one).
+            match (key, peer.config.local_as) {
+                (Some(k), Some(existing)) if existing.as_number != k => false,
+                _ => peer.config.local_as.take().is_some(),
+            }
+        };
+        if !changed {
+            return Some(());
+        }
+        // The substitute the session presents changed — restart the
+        // dual-as retry state from the configured side.
+        peer.local_as_dual_fallback = false;
+        peer.start();
+        (peer.ident, !matches!(peer.state, super::peer::State::Idle))
+    };
+    if bounce {
+        let _ = bgp
+            .tx
+            .try_send(super::inst::Message::Event(ident, super::peer::Event::Stop));
+    }
+    Some(())
+}
+
+/// Shared body for the three `local-as` modifier leaves
+/// (`no-prepend` / `replace-as` / `dual-as`): boolean, default false,
+/// keyed by the list's AS number. A Set writes the flag (seeding the
+/// entry when the flag line lands before the list node within a
+/// commit); a Delete reverts it to false. No session bounce — the
+/// modifiers steer route processing and the retry policy, not the
+/// OPEN itself.
+fn config_local_as_flag(
+    bgp: &mut Bgp,
+    mut args: Args,
+    op: ConfigOp,
+    write: impl Fn(&mut LocalAs, bool),
+) -> Option<()> {
+    let addr = args.addr()?;
+    let key = args.u32()?;
+    let bgp_asn = bgp.asn;
+    let peer = bgp.peers.get_mut(&addr)?;
+    if op.is_set() {
+        let flag = args.boolean()?;
+        let entry = local_as_entry(bgp_asn, peer, key)?;
+        write(entry, flag);
+    } else {
+        // Revert to the default without seeding: a flag delete must
+        // not resurrect an entry the same commit already removed.
+        let entry = peer
+            .config
+            .local_as
+            .as_mut()
+            .filter(|la| la.as_number == key)?;
+        write(entry, false);
+    }
+    // Any local-as edit restarts the dual-as retry from the
+    // configured side.
+    peer.local_as_dual_fallback = false;
+    Some(())
+}
+
+fn config_local_as_no_prepend(bgp: &mut Bgp, args: Args, op: ConfigOp) -> Option<()> {
+    config_local_as_flag(bgp, args, op, |la, v| la.no_prepend = v)
+}
+
+fn config_local_as_replace_as(bgp: &mut Bgp, args: Args, op: ConfigOp) -> Option<()> {
+    config_local_as_flag(bgp, args, op, |la, v| la.replace_as = v)
+}
+
+fn config_local_as_dual_as(bgp: &mut Bgp, args: Args, op: ConfigOp) -> Option<()> {
+    config_local_as_flag(bgp, args, op, |la, v| la.dual_as = v)
 }
 
 /// `set router bgp neighbor X bfd enable true|false` — flips the
@@ -3316,6 +3446,14 @@ impl Bgp {
         // left-most AS_PATH segment begins with the neighbor's own AS
         // (eBGP only).
         self.callback_peer("/enforce-first-as", config_enforce_first_as);
+
+        // Per-neighbor local-as (zebra-bgp-local-as.yang): a
+        // single-entry list keyed by the substitute AS number, with
+        // three independent boolean modifier leaves.
+        self.callback_peer("/local-as", config_local_as);
+        self.callback_peer("/local-as/no-prepend", config_local_as_no_prepend);
+        self.callback_peer("/local-as/replace-as", config_local_as_replace_as);
+        self.callback_peer("/local-as/dual-as", config_local_as_dual_as);
     }
 }
 

--- a/zebra-rs/src/bgp/config.rs
+++ b/zebra-rs/src/bgp/config.rs
@@ -799,7 +799,7 @@ pub(super) fn apply_enforce_first_as(peer: &mut Peer, want: bool) -> bool {
 /// Returns the entry, seeded with all modifiers off when new, so the
 /// list-node and flag callbacks stay order-independent within a
 /// commit.
-fn local_as_entry<'a>(bgp_asn: u32, peer: &'a mut Peer, key: u32) -> Option<&'a mut LocalAs> {
+fn local_as_entry(bgp_asn: u32, peer: &mut Peer, key: u32) -> Option<&mut LocalAs> {
     if key == bgp_asn {
         tracing::warn!(
             peer = %peer.display_name(),

--- a/zebra-rs/src/bgp/peer.rs
+++ b/zebra-rs/src/bgp/peer.rs
@@ -400,6 +400,40 @@ pub struct RemovePrivateAs {
     pub replace_as: bool,
 }
 
+/// Per-neighbor `local-as` (zebra-bgp-local-as.yang): present a
+/// substitute AS number to this neighbor instead of the router's
+/// global AS — the RFC 7705 AS-migration tool. The bare form changes
+/// three planes of the session:
+///
+/// - OPEN: the My-AS field (and the AS4 capability) carry
+///   [`Self::as_number`];
+/// - outbound eBGP updates: the real AS is prepended first, then the
+///   substitute (the receiver sees `substitute, real, …`);
+/// - inbound updates from this peer: the substitute is prepended at
+///   ingress so the rest of the network still sees the path through
+///   the old AS.
+///
+/// The three boolean modifiers are independent, one per plane
+/// (`no_prepend` = inbound, `replace_as` = outbound, `dual_as` =
+/// session); FRR's CLI nests them but its northbound model does not.
+/// `None` on [`PeerConfig`] disables the feature. The substitute must
+/// differ from the router's global AS (config-callback-enforced).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+pub struct LocalAs {
+    /// The substitute AS presented to this neighbor.
+    pub as_number: u32,
+    /// Inbound: skip the ingress prepend of the substitute AS on
+    /// routes received from this neighbor.
+    pub no_prepend: bool,
+    /// Outbound: prepend only the substitute AS, hiding the real AS.
+    pub replace_as: bool,
+    /// Session: allow the neighbor to peer with either the real AS or
+    /// the substitute — a Bad Peer AS NOTIFICATION makes the next OPEN
+    /// retry with the other AS number (see
+    /// [`Peer::local_as_dual_fallback`]).
+    pub dual_as: bool,
+}
+
 #[derive(Debug, Clone)]
 pub struct PeerConfig {
     pub transport: PeerTransportConfig,
@@ -485,6 +519,10 @@ pub struct PeerConfig {
     /// that forwards routes without prepending its AS. Ignored for iBGP
     /// peers (which never prepend). Default `false`.
     pub enforce_first_as: bool,
+    /// Per-neighbor `local-as` (zebra-bgp-local-as.yang). `None` runs
+    /// the session under the router's global AS; `Some` presents the
+    /// substitute AS to this neighbor (see [`LocalAs`]).
+    pub local_as: Option<LocalAs>,
 }
 
 impl Default for PeerConfig {
@@ -512,6 +550,7 @@ impl Default for PeerConfig {
             as_override: false,
             remove_private_as: None,
             enforce_first_as: false,
+            local_as: None,
         }
     }
 }
@@ -707,6 +746,14 @@ pub struct Peer {
     pub remote_id: Ipv4Addr,
     pub local_as: u32,
     pub remote_as: u32,
+    /// `local-as … dual-as` runtime state: `true` after a Bad Peer AS
+    /// NOTIFICATION flipped the session back to the router's global AS
+    /// (the neighbor's `remote-as` no longer expects the substitute).
+    /// The next Bad Peer AS flips it again, so the session oscillates
+    /// between the two until one is accepted — FRR's retry scheme.
+    /// Only consulted while `config.local_as` has `dual_as` set; reset
+    /// whenever the `local-as` configuration changes.
+    pub local_as_dual_fallback: bool,
     /// Local BGP speaker's hostname snapshot used to populate the FQDN
     /// capability in OPEN. Set at peer creation from `Bgp::hostname()`
     /// and refreshed by the global hostname callback so that re-opened
@@ -880,6 +927,7 @@ impl Peer {
             router_id,
             local_as,
             remote_as,
+            local_as_dual_fallback: false,
             local_hostname,
             address,
             ctx,
@@ -1033,6 +1081,26 @@ impl Peer {
 
     pub fn is_ibgp(&self) -> bool {
         self.peer_type.is_ibgp()
+    }
+
+    /// The active `local-as` substitute for this session, if any.
+    /// `None` when the knob is off — and also while the `dual-as`
+    /// fallback has flipped the session to the router's global AS, so
+    /// every consumer (OPEN, ingress/egress prepends, update-group
+    /// signature) degrades to normal behavior in lockstep, mirroring
+    /// FRR's `peer->change_local_as` toggling.
+    pub fn change_local_as(&self) -> Option<u32> {
+        match self.config.local_as {
+            Some(la) if !(la.dual_as && self.local_as_dual_fallback) => Some(la.as_number),
+            _ => None,
+        }
+    }
+
+    /// The AS number this session presents in its OPEN (My-AS field
+    /// and AS4 capability): the `local-as` substitute when active, the
+    /// router's global AS otherwise.
+    pub fn open_local_as(&self) -> u32 {
+        self.change_local_as().unwrap_or(self.local_as)
     }
 
     /// Egress IP TTL / IPv6 Hop Limit for this session, per the BGP TTL
@@ -1745,8 +1813,23 @@ pub fn fsm_bgp_open(peer: &mut Peer, conn: ConnTag, packet: OpenPacket) -> State
     State::OpenConfirm
 }
 
-pub fn fsm_bgp_notification(peer: &mut Peer, conn: ConnTag, _packet: NotificationPacket) -> State {
+pub fn fsm_bgp_notification(peer: &mut Peer, conn: ConnTag, packet: NotificationPacket) -> State {
     peer.counter[BgpType::Notification as usize].rcvd += 1;
+    // `local-as … dual-as` (RFC 7705 migration aid): a Bad Peer AS
+    // means the neighbor's `remote-as` expects the other one of our
+    // two AS numbers — flip which one the next OPEN presents. FRR
+    // retries the same way on this NOTIFICATION (bgp_packet.c).
+    if packet.code == NotifyCode::OpenMsgError
+        && packet.sub_code == u8::from(OpenError::BadPeerAS)
+        && peer.config.local_as.is_some_and(|la| la.dual_as)
+    {
+        peer.local_as_dual_fallback = !peer.local_as_dual_fallback;
+        tracing::info!(
+            peer = %peer.display_name(),
+            "bgp: Bad Peer AS with local-as dual-as — next OPEN presents AS {}",
+            peer.open_local_as(),
+        );
+    }
     // NOTIFICATION on the collision conn just kills that conn; the
     // primary session is unaffected.
     if conn == ConnTag::Collision
@@ -2302,7 +2385,7 @@ fn build_open_packet(peer: &mut Peer) -> BytesMut {
         bgp_cap.mp.insert(*afi_safi, cap);
     }
     if peer.config.four_octet {
-        let cap = CapAs4::new(peer.local_as);
+        let cap = CapAs4::new(peer.open_local_as());
         bgp_cap.as4 = Some(cap);
     }
     if peer.config.route_refresh {
@@ -2357,7 +2440,13 @@ fn build_open_packet(peer: &mut Peer) -> BytesMut {
     peer.param_tx.hold_time = hold_time;
     peer.param_tx.keepalive = hold_time / 3;
 
-    let open = OpenPacket::new(header, peer.local_as as u16, hold_time, &router_id, bgp_cap);
+    let open = OpenPacket::new(
+        header,
+        peer.open_local_as() as u16,
+        hold_time,
+        &router_id,
+        bgp_cap,
+    );
     let bytes: BytesMut = open.into();
     bytes
 }
@@ -3250,6 +3339,55 @@ mod fsm_idle_hold_tests {
             State::Established,
             "stale NOTIFICATION must be ignored"
         );
+    }
+
+    /// `local-as … dual-as`: a Bad Peer AS NOTIFICATION toggles which
+    /// of the two AS numbers the next OPEN presents (substitute ⇄
+    /// global), and a second one toggles back. Without `dual-as` the
+    /// substitute is pinned.
+    #[tokio::test]
+    async fn bad_peer_as_notification_toggles_dual_as_fallback() {
+        let bad_peer_as = || {
+            NotificationPacket::new(
+                NotifyCode::OpenMsgError,
+                OpenError::BadPeerAS.into(),
+                Vec::new(),
+            )
+        };
+        let mut peer = test_peer(false);
+        peer.config.local_as = Some(LocalAs {
+            as_number: 64999,
+            no_prepend: false,
+            replace_as: false,
+            dual_as: true,
+        });
+        assert_eq!(peer.open_local_as(), 64999);
+
+        fsm_bgp_notification(&mut peer, ConnTag::Primary, bad_peer_as());
+        assert_eq!(peer.open_local_as(), 65001, "fallback to the global AS");
+        assert!(
+            peer.change_local_as().is_none(),
+            "substitute fully inactive"
+        );
+
+        fsm_bgp_notification(&mut peer, ConnTag::Primary, bad_peer_as());
+        assert_eq!(peer.open_local_as(), 64999, "second toggle flips back");
+
+        // A non-Bad-Peer-AS NOTIFICATION must not touch the state.
+        let cease = NotificationPacket::new(NotifyCode::Cease, 0, Vec::new());
+        fsm_bgp_notification(&mut peer, ConnTag::Primary, cease);
+        assert_eq!(peer.open_local_as(), 64999);
+
+        // Without dual-as the substitute is pinned.
+        peer.config.local_as = Some(LocalAs {
+            as_number: 64999,
+            no_prepend: false,
+            replace_as: false,
+            dual_as: false,
+        });
+        peer.local_as_dual_fallback = false;
+        fsm_bgp_notification(&mut peer, ConnTag::Primary, bad_peer_as());
+        assert_eq!(peer.open_local_as(), 64999);
     }
 
     /// A KEEPALIVE from a still-parked (unpromoted) collision conn is

--- a/zebra-rs/src/bgp/route.rs
+++ b/zebra-rs/src/bgp/route.rs
@@ -61,6 +61,41 @@ fn aspath_local_as_loop(aspath: &As4Path, local_as: u32, allow: Option<AllowAsIn
     }
 }
 
+/// RFC 4271 inbound AS_PATH loop detection for `peer`, covering both
+/// the router's own AS and — when a `local-as` substitute is active on
+/// the session — the substitute AS (FRR's "AS path local-as loop
+/// check" in `bgp_update`, bgp_route.c). Returns `true` when the
+/// update must be dropped.
+///
+/// The substitute check's occurrence budget mirrors FRR: a configured
+/// `allowas-in` count replaces it; otherwise it is 1 while the ingress
+/// prepend is on (the prepend in [`route_from_peer`] put exactly one
+/// occurrence there) and 0 under `no-prepend`. One deliberate
+/// divergence: with `allowas-in origin` and the ingress prepend both
+/// active, FRR's budget of 0 drops every route from the peer (our own
+/// leftmost prepend can never be at the origin); the substitute check
+/// is skipped instead.
+fn aspath_own_as_loop(peer: &Peer, aspath: &As4Path) -> bool {
+    if aspath_local_as_loop(aspath, peer.local_as, peer.config.allowas_in) {
+        return true;
+    }
+    let Some(substitute) = peer.change_local_as() else {
+        return false;
+    };
+    let no_prepend = peer.config.local_as.is_some_and(|la| la.no_prepend);
+    let allow = match peer.config.allowas_in {
+        // FRR parity: a configured allowas-in budget replaces the
+        // prepend allowance (the ingress prepend counts against it).
+        Some(AllowAsIn::Count(n)) => Some(AllowAsIn::Count(n)),
+        Some(AllowAsIn::Origin) if !no_prepend => return false,
+        Some(AllowAsIn::Origin) => Some(AllowAsIn::Origin),
+        // The ingress prepend itself put one occurrence in the path.
+        None if !no_prepend => Some(AllowAsIn::Count(1)),
+        None => None,
+    };
+    aspath_local_as_loop(aspath, substitute, allow)
+}
+
 /// True when every occurrence of `local_as` is the trailing originating
 /// AS (prepends at the origin are allowed) — i.e. it never appears as a
 /// transit AS. Used by [`AllowAsIn::Origin`].
@@ -122,7 +157,11 @@ fn aspath_first_as_mismatch(aspath: Option<&As4Path>, expected_as: u32) -> bool 
 /// 2. `as-override`: replace the peer's own AS with the local AS so its
 ///    RFC 4271 loop check accepts a route that transited its AS. Mirrors
 ///    FRR's `bgp_peer_as_override`, which runs after remove-private-as.
-/// 3. the mandatory local-AS prepend.
+/// 3. the mandatory local-AS prepend. With a `local-as` substitute
+///    active on the session, the real AS is prepended first and the
+///    substitute on top of it (the receiver sees `substitute, real, …`);
+///    `replace-as` skips the real AS so only the substitute appears.
+///    Mirrors FRR's `bgp_packet_attribute` (bgp_attr.c).
 ///
 /// Call this at every eBGP egress site instead of prepending inline, so
 /// the transforms apply uniformly across address families.
@@ -146,7 +185,16 @@ fn ebgp_egress_aspath(peer: &Peer, attrs: &mut BgpAttr) {
     if peer.config.as_override {
         aspath.replace_as_mut(peer.remote_as, peer.local_as);
     }
-    aspath.prepend_mut(As4Path::from(vec![peer.local_as]));
+    match peer.change_local_as() {
+        Some(substitute) => {
+            let replace_as = peer.config.local_as.is_some_and(|la| la.replace_as);
+            if !replace_as {
+                aspath.prepend_mut(As4Path::from(vec![peer.local_as]));
+            }
+            aspath.prepend_mut(As4Path::from(vec![substitute]));
+        }
+        None => aspath.prepend_mut(As4Path::from(vec![peer.local_as])),
+    }
 }
 
 /// Build a `rib::entry::RibEntry` from the BGP best-path winner for an
@@ -2106,7 +2154,7 @@ pub fn route_ipv4_update(
         // RFC 4271: Drop update if local AS appears in AS_PATH (loop detection for EBGP)
         // This prevents routing loops by detecting if the route has already passed through this AS
         if let Some(ref aspath) = attr.aspath
-            && aspath_local_as_loop(aspath, peer.local_as, peer.config.allowas_in)
+            && aspath_own_as_loop(peer, aspath)
         {
             eprintln!(
                 "Dropping update for {} from peer {} - local AS {} found in AS_PATH",
@@ -3460,7 +3508,7 @@ pub fn route_ipv6_update(
 
         // RFC 4271 / 4456 loop detection — identical to the v4 path.
         if let Some(ref aspath) = attr.aspath
-            && aspath_local_as_loop(aspath, peer.local_as, peer.config.allowas_in)
+            && aspath_own_as_loop(peer, aspath)
         {
             return;
         }
@@ -3727,7 +3775,7 @@ pub fn route_labelv4_update(
 
         // RFC 4271 / 4456 loop detection — identical to the unicast path.
         if let Some(ref aspath) = attr.aspath
-            && aspath_local_as_loop(aspath, peer.local_as, peer.config.allowas_in)
+            && aspath_own_as_loop(peer, aspath)
         {
             return;
         }
@@ -3827,7 +3875,7 @@ pub fn route_labelv6_update(
         let peer = peers.get_mut_by_idx(ident).expect("peer must exist");
 
         if let Some(ref aspath) = attr.aspath
-            && aspath_local_as_loop(aspath, peer.local_as, peer.config.allowas_in)
+            && aspath_own_as_loop(peer, aspath)
         {
             return;
         }
@@ -4339,7 +4387,7 @@ pub fn route_evpn_update(
         let peer = peers.get_mut_by_idx(ident).expect("peer must exist");
 
         if let Some(ref aspath) = attr.aspath
-            && aspath_local_as_loop(aspath, peer.local_as, peer.config.allowas_in)
+            && aspath_own_as_loop(peer, aspath)
         {
             return;
         }
@@ -4486,7 +4534,7 @@ pub fn route_flowspec_update(
         let peer = peers.get_mut_by_idx(ident).expect("peer must exist");
 
         if let Some(ref aspath) = attr.aspath
-            && aspath_local_as_loop(aspath, peer.local_as, peer.config.allowas_in)
+            && aspath_own_as_loop(peer, aspath)
         {
             return;
         }
@@ -4595,7 +4643,7 @@ pub fn route_srpolicy_update(
     {
         let peer = peers.get_by_idx(ident).expect("peer must exist");
         if let Some(ref aspath) = attr.aspath
-            && aspath_local_as_loop(aspath, peer.local_as, peer.config.allowas_in)
+            && aspath_own_as_loop(peer, aspath)
         {
             return;
         }
@@ -4789,7 +4837,7 @@ pub fn route_bgpls_update(
         let peer = peers.get_mut_by_idx(ident).expect("peer must exist");
 
         if let Some(ref aspath) = attr.aspath
-            && aspath_local_as_loop(aspath, peer.local_as, peer.config.allowas_in)
+            && aspath_own_as_loop(peer, aspath)
         {
             return;
         }
@@ -5397,7 +5445,7 @@ fn withdraw_mp_reach(peer_id: usize, mp: MpReachAttr, bgp: &mut BgpTop, peers: &
 
 pub fn route_from_peer(
     peer_id: usize,
-    packet: UpdatePacket,
+    mut packet: UpdatePacket,
     bgp: &mut BgpTop,
     peers: &mut PeerMap,
 ) {
@@ -5408,6 +5456,24 @@ pub fn route_from_peer(
             withdraws = packet.ipv4_withdraw.len(),
             "recv UPDATE NLRI"
         );
+    }
+    // `local-as` ingress prepend (FRR does this at the attribute-parse
+    // stage, bgp_attr.c): routes received from an eBGP neighbor with an
+    // active substitute AS get the substitute prepended once, so the
+    // rest of the network sees the path as if it still transited the
+    // old AS; `no-prepend` turns it off. Done here — once per UPDATE,
+    // before the per-family dispatch — because every family handler
+    // below shares `packet.bgp_attr`. Adj-RIB-In stores the
+    // post-prepend attrs, so soft-reconfig replays (which start from
+    // `peer.adj_in`, not from here) never prepend twice.
+    if let Some(peer) = peers.get_by_idx(peer_id)
+        && peer.is_ebgp()
+        && let Some(substitute) = peer.change_local_as()
+        && !peer.config.local_as.is_some_and(|la| la.no_prepend)
+        && let Some(attr) = packet.bgp_attr.as_mut()
+        && let Some(aspath) = attr.aspath.as_mut()
+    {
+        aspath.prepend_mut(As4Path::from(vec![substitute]));
     }
     // Convert UpdatePacket to BgpAttr.
     // let attr = BgpAttr::from(&packet.attrs);
@@ -11665,6 +11731,129 @@ mod allowas_in_tests {
         assert!(loops("65001 65002 65001", Some(AllowAsIn::Origin)));
         // No local AS at all ⇒ no loop.
         assert!(!loops("65002 65003", Some(AllowAsIn::Origin)));
+    }
+}
+
+/// `local-as` AS_PATH behavior (zebra-bgp-local-as.yang): the egress
+/// prepend forms and the substitute-AS leg of the inbound loop check.
+#[cfg(test)]
+mod local_as_tests {
+    use std::net::Ipv4Addr;
+    use std::str::FromStr;
+
+    use bgp_packet::{As4Path, BgpAttr};
+    use tokio::sync::mpsc;
+
+    use super::super::peer::{LocalAs, Peer, PeerType};
+    use super::{aspath_own_as_loop, ebgp_egress_aspath};
+
+    const REAL_AS: u32 = 65100;
+    const SUBSTITUTE: u32 = 64999;
+    const PEER_AS: u32 = 65001;
+
+    fn test_peer(local_as: Option<LocalAs>) -> Peer {
+        let (tx, rx) = mpsc::channel(8);
+        Box::leak(Box::new(rx));
+        let mut peer = Peer::new(
+            1,
+            REAL_AS,
+            Ipv4Addr::new(10, 255, 0, 1),
+            PEER_AS,
+            "10.0.0.2".parse().unwrap(),
+            None,
+            tx,
+            crate::context::ProtoContext::default_table_no_rib(),
+        );
+        peer.peer_type = PeerType::EBGP;
+        peer.config.local_as = local_as;
+        peer
+    }
+
+    fn local_as(no_prepend: bool, replace_as: bool) -> Option<LocalAs> {
+        Some(LocalAs {
+            as_number: SUBSTITUTE,
+            no_prepend,
+            replace_as,
+            dual_as: false,
+        })
+    }
+
+    /// Run the egress transform and flatten the resulting AS_PATH.
+    fn egress(peer: &Peer, path: &str) -> String {
+        let mut attrs = BgpAttr {
+            aspath: Some(As4Path::from_str(path).unwrap()),
+            ..Default::default()
+        };
+        ebgp_egress_aspath(peer, &mut attrs);
+        attrs
+            .aspath
+            .unwrap()
+            .segs
+            .iter()
+            .flat_map(|seg| seg.asn.iter())
+            .map(|asn| asn.to_string())
+            .collect::<Vec<_>>()
+            .join(" ")
+    }
+
+    #[test]
+    fn egress_without_local_as_prepends_real() {
+        assert_eq!(egress(&test_peer(None), "65010"), "65100 65010");
+    }
+
+    #[test]
+    fn egress_bare_prepends_substitute_over_real() {
+        // The receiver sees `substitute, real, …` — both ASes visible.
+        assert_eq!(
+            egress(&test_peer(local_as(false, false)), "65010"),
+            "64999 65100 65010"
+        );
+    }
+
+    #[test]
+    fn egress_replace_as_hides_real() {
+        assert_eq!(
+            egress(&test_peer(local_as(false, true)), "65010"),
+            "64999 65010"
+        );
+    }
+
+    #[test]
+    fn egress_dual_as_fallback_degrades_to_real() {
+        // While the dual-as fallback presents the global AS, the
+        // substitute must vanish from the egress prepend too.
+        let mut peer = test_peer(Some(LocalAs {
+            as_number: SUBSTITUTE,
+            no_prepend: false,
+            replace_as: true,
+            dual_as: true,
+        }));
+        peer.local_as_dual_fallback = true;
+        assert_eq!(egress(&peer, "65010"), "65100 65010");
+    }
+
+    fn loops(peer: &Peer, path: &str) -> bool {
+        aspath_own_as_loop(peer, &As4Path::from_str(path).unwrap())
+    }
+
+    #[test]
+    fn loop_budget_allows_the_ingress_prepend() {
+        let peer = test_peer(local_as(false, false));
+        // One substitute occurrence is our own ingress prepend.
+        assert!(!loops(&peer, "64999 65001 65010"));
+        // Two means the route really looped through the old AS.
+        assert!(loops(&peer, "64999 65001 64999"));
+        // The real AS is still checked strictly.
+        assert!(loops(&peer, "64999 65001 65100"));
+    }
+
+    #[test]
+    fn loop_budget_zero_under_no_prepend() {
+        // Without the ingress prepend any substitute occurrence came
+        // from the network — strict.
+        let peer = test_peer(local_as(true, false));
+        assert!(loops(&peer, "64999 65001"));
+        assert!(!loops(&peer, "65001 65010"));
     }
 }
 

--- a/zebra-rs/src/bgp/show.rs
+++ b/zebra-rs/src/bgp/show.rs
@@ -12,7 +12,7 @@ use super::cap::CapAfiMap;
 use super::inst::{Bgp, ShowCallback};
 use super::neighbor_group::InheritableKnobs;
 use super::peer::{
-    AfiSafiEncapType, AllowAsIn, Peer, PeerCounter, PeerParam, RemovePrivateAs, State,
+    AfiSafiEncapType, AllowAsIn, LocalAs, Peer, PeerCounter, PeerParam, RemovePrivateAs, State,
 };
 use super::peer_map::PeerMap;
 use super::route::LocalRib;
@@ -1788,6 +1788,15 @@ struct Neighbor<'a> {
     /// `replace_as`, rewrites) private ASNs on outbound eBGP UPDATEs.
     #[serde(skip_serializing_if = "Option::is_none")]
     remove_private_as: Option<RemovePrivateAs>,
+    /// FRR-style `neighbor X local-as` (zebra-bgp-local-as.yang), if
+    /// configured: the substitute AS presented to this neighbor plus
+    /// the three modifiers.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    local_as_config: Option<LocalAs>,
+    /// `true` while the `dual-as` fallback has the session presenting
+    /// the router's global AS instead of the substitute.
+    #[serde(skip_serializing_if = "std::ops::Not::not")]
+    local_as_dual_fallback: bool,
     /// FRR-style `neighbor X enforce-first-as` flag
     /// (zebra-bgp-enforce-first-as.yang). When true, an inbound eBGP
     /// UPDATE is dropped unless its AS_PATH begins with this neighbor's
@@ -1979,7 +1988,9 @@ fn fetch(peer: &Peer) -> Neighbor<'_> {
         address: peer.address,
         interface: peer.ifname.as_deref(),
         remote_as: peer.remote_as,
-        local_as: peer.local_as,
+        // The AS this session presents — the `local-as` substitute when
+        // one is active (FRR prints change_local_as here too).
+        local_as: peer.open_local_as(),
         peer_type: peer.peer_type.to_str(),
         local_router_id: peer.router_id,
         remote_router_id: peer.remote_id,
@@ -2002,6 +2013,8 @@ fn fetch(peer: &Peer) -> Neighbor<'_> {
         allowas_in: peer.config.allowas_in,
         as_override: peer.config.as_override,
         remove_private_as: peer.config.remove_private_as,
+        local_as_config: peer.config.local_as,
+        local_as_dual_fallback: peer.local_as_dual_fallback,
         enforce_first_as: peer.config.enforce_first_as,
         encapsulation_type_ipv6: peer
             .config
@@ -2209,6 +2222,24 @@ fn render(out: &mut String, neighbor: &Neighbor) -> std::fmt::Result {
             form.push_str(" replace-AS");
         }
         writeln!(out, "  Private AS removal: {form} (outbound)")?;
+    }
+
+    if let Some(la) = neighbor.local_as_config {
+        // Echo the configured form, e.g. "local-as 64999 no-prepend".
+        let mut form = format!("local-as {}", la.as_number);
+        if la.no_prepend {
+            form.push_str(" no-prepend");
+        }
+        if la.replace_as {
+            form.push_str(" replace-as");
+        }
+        if la.dual_as {
+            form.push_str(" dual-as");
+        }
+        writeln!(out, "  Local AS substitution: {form}")?;
+        if neighbor.local_as_dual_fallback {
+            writeln!(out, "    dual-as fallback active: presenting the global AS")?;
+        }
     }
 
     if neighbor.enforce_first_as {
@@ -3560,6 +3591,8 @@ Neighbor        V         AS   MsgRcvd   MsgSent   TblVer  InQ OutQ  Up/Down Sta
             allowas_in: None,
             as_override: false,
             remove_private_as: None,
+            local_as_config: None,
+            local_as_dual_fallback: false,
             enforce_first_as: false,
             encapsulation_type_ipv6: None,
             ttl_security: false,

--- a/zebra-rs/src/bgp/show_update_group.rs
+++ b/zebra-rs/src/bgp/show_update_group.rs
@@ -46,6 +46,11 @@ struct SigView {
     /// only): the modifiers in force and the AS kept for loop
     /// prevention. `None` (the common case) means no stripping.
     remove_private_as: Option<RemovePrivateAsView>,
+    /// `Some((substitute, replace_as))` when a `local-as` substitute
+    /// is active on the members (eBGP only): the egress prepend is
+    /// `substitute, real` — or just `substitute` with `replace_as`.
+    /// `None` (the common case) means the normal real-AS prepend.
+    local_as_substitute: Option<(u32, bool)>,
     capabilities: CapsView,
     signature_version: u32,
 }
@@ -151,6 +156,7 @@ fn build_view(bgp: &Bgp, afi_safi: AfiSafi, group: &UpdateGroup) -> GroupView {
             prefix_set_out: group.sig.prefix_set_out_name.clone(),
             as_override_target: group.sig.as_override_target,
             remove_private_as: group.sig.remove_private_as.map(Into::into),
+            local_as_substitute: group.sig.local_as_substitute,
             capabilities: CapsView {
                 as4_negotiated: group.sig.as4_negotiated,
                 extended_message: group.sig.extended_message,
@@ -304,6 +310,20 @@ fn render_detail_text(view: &GroupView) -> Result<String, std::fmt::Error> {
                     s.push_str(" replace-AS");
                 }
                 format!("{s} (keep {})", rpa.keep_as)
+            })
+            .unwrap_or_else(|| "—".to_string())
+    )?;
+    writeln!(
+        out,
+        "    Local-AS substitute:        {}",
+        view.signature
+            .local_as_substitute
+            .map(|(asn, replace_as)| {
+                if replace_as {
+                    format!("{asn} replace-as")
+                } else {
+                    asn.to_string()
+                }
             })
             .unwrap_or_else(|| "—".to_string())
     )?;

--- a/zebra-rs/src/bgp/update_group.rs
+++ b/zebra-rs/src/bgp/update_group.rs
@@ -134,6 +134,13 @@ pub struct UpdateGroupSig {
     /// (the common case). See [`RemovePrivateAsKey`] for why the mode
     /// and the kept AS must shard the group.
     pub remove_private_as: Option<RemovePrivateAsKey>,
+    /// Per-neighbor `local-as` substitute active on the session (eBGP
+    /// only; `None` when off or while the dual-as fallback presents
+    /// the global AS). The egress prepend becomes `substitute, real`
+    /// — or just `substitute` with `replace_as` — so peers under a
+    /// different substitute (or none) cannot share canonical UPDATE
+    /// bytes. `(substitute, replace_as)`.
+    pub local_as_substitute: Option<(u32, bool)>,
     // Negotiated wire-format capabilities (intersection of cap_send
     // and cap_recv on the peer). Anything that changes encoded
     // UPDATE bytes belongs here.
@@ -267,6 +274,16 @@ pub fn signature_of(peer: &Peer, afi: Afi, safi: Safi) -> Option<UpdateGroupSig>
                 replace_as: rpa.replace_as,
                 keep_as: peer.remote_as,
             })
+        } else {
+            None
+        },
+        // local-as changes what the egress prepend writes; fold the
+        // active substitute and the replace-as modifier into the key
+        // (eBGP only — iBGP never prepends, so the substitute is a
+        // no-op there and must not split iBGP groups).
+        local_as_substitute: if peer.is_ebgp() {
+            peer.change_local_as()
+                .map(|asn| (asn, peer.config.local_as.is_some_and(|la| la.replace_as)))
         } else {
             None
         },
@@ -1085,6 +1102,7 @@ mod tests {
             prefix_set_out_name: None,
             as_override_target: None,
             remove_private_as: None,
+            local_as_substitute: None,
             as4_negotiated: true,
             extended_message: true,
             addpath_send: false,
@@ -1157,6 +1175,20 @@ mod tests {
             replace_as: false,
             keep_as: 65003,
         });
+        assert_ne!(a, c);
+
+        let mut a = base.clone();
+        a.local_as_substitute = Some((64999, false));
+        assert_ne!(base, a);
+
+        // A different substitute, or the same substitute with
+        // replace-as flipped, writes a different egress AS_PATH and
+        // must shard the group.
+        let mut b = a.clone();
+        b.local_as_substitute = Some((64998, false));
+        assert_ne!(a, b);
+        let mut c = a.clone();
+        c.local_as_substitute = Some((64999, true));
         assert_ne!(a, c);
 
         let mut a = base.clone();


### PR DESCRIPTION
## Summary

Wire behavior for the `local-as` schema that landed in #1386, mirroring FRR across the three planes:

**Session**
- The OPEN My-AS field and the AS4 capability carry the substitute AS (`Peer::open_local_as()`).
- `dual-as`: a Bad Peer AS NOTIFICATION flips which AS the next OPEN presents (substitute ⇄ global) — FRR's retry scheme (`bgp_packet.c`). The new `Peer::change_local_as()` accessor returns `None` both when the knob is off and while the fallback is active, so OPEN, both prepends, and the update-group signature all degrade together.

**Inbound**
- The substitute is prepended once per UPDATE at the top of `route_from_peer` (FRR prepends at attr-parse), unless `no-prepend`. Every family handler shares `packet.bgp_attr`, and Adj-RIB-In stores the post-prepend attrs, so soft-reconfig replays never double-prepend.
- The 8 inbound loop-check sites now go through `aspath_own_as_loop`, adding FRR's substitute-AS loop check with its budget rule (`bgp_route.c`): 1 while the ingress prepend is active (the prepend itself), 0 under `no-prepend`, a configured `allowas-in` replaces it. One documented divergence: `allowas-in origin` + active prepend skips the substitute check instead of FRR's drop-everything edge.

**Outbound**
- `ebgp_egress_aspath` ends with FRR's three-way prepend: `substitute, real` (bare), `substitute` only (`replace-as`), or the normal real-AS prepend.

**Cross-cutting**
- `UpdateGroupSig` gains `local_as_substitute: Option<(u32, bool)>` (eBGP only) — peers under different substitutes (or replace-as flags) must not share canonical UPDATE bytes; the signature-fields-distinguish test covers it.
- Config callbacks enforce the two commit-time rules from the YANG (substitute ≠ global AS, single-instance list) by warning and keeping the existing entry. Creating/removing the entry bounces a live session with the `clear … hard` teardown (the OPEN changes); the three modifier leaves don't bounce.
- Show: neighbor detail prints `Local AS substitution: local-as 64999 [flags]` plus a dual-as fallback indicator, the header's `local AS` shows the effective AS (FRR prints `change_local_as` there too), and `show bgp update-group` displays the substitute in the signature block.

Deferred to follow-ups: BDD feature, neighbor-group inheritance, VRF instances (consistent with the other per-neighbor knobs).

## Testing

- 7 new unit tests: egress prepend forms (bare / replace-as / off / dual-as-fallback), ingress loop budgets (prepend allowance, strict under no-prepend), the dual-as FSM toggle, and the update-group signature sharding cases.
- `cargo test --workspace --exclude bdd` — green.
- `cargo clippy --workspace --all-targets -- -D warnings` — clean; `cargo fmt` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)