### PR TITLE
ospf: TI-LFA parallel compute modes for v2+v3 (OSPF PR-1)

### DIFF
--- a/zebra-rs/src/config/manager.rs
+++ b/zebra-rs/src/config/manager.rs
@@ -1358,6 +1358,10 @@ mod yang_load_tests {
             "set router isis fast-reroute ti-lfa compute-mode aggressive",
             "set router isis fast-reroute ti-lfa compute-mode sharding",
             "set router isis fast-reroute ti-lfa compute-shards 4",
+            "set router ospf fast-reroute ti-lfa compute-mode aggressive",
+            "set router ospf fast-reroute ti-lfa compute-shards 4",
+            "set router ospfv3 fast-reroute ti-lfa compute-mode sharding",
+            "set router ospfv3 fast-reroute ti-lfa compute-shards 2",
         ] {
             let (code, _comps, _state) = parse(cmd, entry.clone(), None, State::new());
             assert_eq!(

--- a/zebra-rs/src/isis/config.rs
+++ b/zebra-rs/src/isis/config.rs
@@ -8,6 +8,7 @@ use strum_macros::{Display, EnumString};
 
 use crate::config::{Args, ConfigOp};
 use crate::spf;
+use crate::spf::TilfaComputeModeConfig;
 
 use super::Isis;
 use super::ifsm::has_level;
@@ -718,23 +719,6 @@ impl IsisAuthConfig {
     }
 }
 
-/// YANG mirror of `/router/isis/fast-reroute/ti-lfa/compute-mode`
-/// (payload-free — the sharding count lives in the sibling
-/// `compute-shards` leaf; [`IsisConfig::tilfa_compute_mode`] joins
-/// them into the scheduler-facing `spf::TilfaComputeMode`).
-#[derive(Debug, Default, Clone, Copy, PartialEq, Eq, EnumString, Display)]
-pub enum TilfaComputeModeConfig {
-    #[default]
-    #[strum(serialize = "serial")]
-    Serial,
-    #[strum(serialize = "conservative")]
-    Conservative,
-    #[strum(serialize = "aggressive")]
-    Aggressive,
-    #[strum(serialize = "sharding")]
-    Sharding,
-}
-
 impl Default for IsisConfig {
     // Manual rather than derived because `gr_helper_enabled` defaults
     // to `true` (matches the YANG default for
@@ -819,14 +803,8 @@ impl IsisConfig {
     /// scheduler-facing [`spf::TilfaComputeMode`], snapshotted into
     /// `SpfInput` at graph-build time.
     pub fn tilfa_compute_mode(&self) -> spf::TilfaComputeMode {
-        match self.ti_lfa_compute_mode {
-            TilfaComputeModeConfig::Serial => spf::TilfaComputeMode::Serial,
-            TilfaComputeModeConfig::Conservative => spf::TilfaComputeMode::Conservative,
-            TilfaComputeModeConfig::Aggressive => spf::TilfaComputeMode::Aggressive,
-            TilfaComputeModeConfig::Sharding => {
-                spf::TilfaComputeMode::Sharding(self.ti_lfa_compute_shards)
-            }
-        }
+        self.ti_lfa_compute_mode
+            .with_shards(self.ti_lfa_compute_shards)
     }
 
     /// Resolve the hostname to advertise in TLV 137. Configured hostname

--- a/zebra-rs/src/ospf/config.rs
+++ b/zebra-rs/src/ospf/config.rs
@@ -200,6 +200,14 @@ impl Ospf {
         self.ospf_add("/segment-routing/mpls", config_ospf_sr_mpls);
         self.ospf_add("/fast-reroute/ti-lfa", config_ospf_ti_lfa);
         self.ospf_add(
+            "/fast-reroute/ti-lfa/compute-mode",
+            config_ospf_ti_lfa_compute_mode,
+        );
+        self.ospf_add(
+            "/fast-reroute/ti-lfa/compute-shards",
+            config_ospf_ti_lfa_compute_shards,
+        );
+        self.ospf_add(
             "/fast-reroute/backup-as-primary",
             config_ospf_fast_reroute_backup_as_primary,
         );
@@ -1409,6 +1417,51 @@ fn config_ospf_ti_lfa(ospf: &mut Ospf, _args: Args, op: ConfigOp) -> Option<()> 
     let prev = ospf.ti_lfa_enabled;
     ospf.ti_lfa_enabled = op.is_set();
     if ospf.ti_lfa_enabled == prev {
+        return Some(());
+    }
+    let area_ids: Vec<Ipv4Addr> = ospf.areas.iter().map(|(id, _)| *id).collect();
+    for id in area_ids {
+        let _ = ospf.tx.send(Message::SpfCalc(id));
+    }
+    Some(())
+}
+
+/// `/router/ospf/fast-reroute/ti-lfa/compute-mode`. Picks how the
+/// TI-LFA computation is scheduled across cores (see
+/// `spf::TilfaComputeMode`). Results are identical across modes —
+/// nothing advertised changes, no LSA re-origination. The SPF re-run
+/// makes the change observable immediately in the telemetry.
+fn config_ospf_ti_lfa_compute_mode(ospf: &mut Ospf, mut args: Args, op: ConfigOp) -> Option<()> {
+    let prev = ospf.ti_lfa_compute_mode;
+    ospf.ti_lfa_compute_mode = if op.is_set() {
+        args.string()?.parse().ok()?
+    } else {
+        crate::spf::TilfaComputeModeConfig::default()
+    };
+    if ospf.ti_lfa_compute_mode == prev {
+        return Some(());
+    }
+    let area_ids: Vec<Ipv4Addr> = ospf.areas.iter().map(|(id, _)| *id).collect();
+    for id in area_ids {
+        let _ = ospf.tx.send(Message::SpfCalc(id));
+    }
+    Some(())
+}
+
+/// `/router/ospf/fast-reroute/ti-lfa/compute-shards`. Upper bound on
+/// TI-LFA parallelism; consulted only when `compute-mode sharding` is
+/// configured (the effective-mode comparison keeps the SPF re-run
+/// suppressed otherwise).
+fn config_ospf_ti_lfa_compute_shards(ospf: &mut Ospf, mut args: Args, op: ConfigOp) -> Option<()> {
+    let prev = ospf
+        .ti_lfa_compute_mode
+        .with_shards(ospf.ti_lfa_compute_shards);
+    ospf.ti_lfa_compute_shards = if op.is_set() { args.u16()? } else { 8 };
+    if ospf
+        .ti_lfa_compute_mode
+        .with_shards(ospf.ti_lfa_compute_shards)
+        == prev
+    {
         return Some(());
     }
     let area_ids: Vec<Ipv4Addr> = ospf.areas.iter().map(|(id, _)| *id).collect();

--- a/zebra-rs/src/ospf/config_v3.rs
+++ b/zebra-rs/src/ospf/config_v3.rs
@@ -158,6 +158,14 @@ impl Ospf<Ospfv3> {
             ("/segment-routing/srv6/locator", config_ospfv3_srv6_locator),
             ("/fast-reroute/ti-lfa", config_ospfv3_ti_lfa),
             (
+                "/fast-reroute/ti-lfa/compute-mode",
+                config_ospfv3_ti_lfa_compute_mode,
+            ),
+            (
+                "/fast-reroute/ti-lfa/compute-shards",
+                config_ospfv3_ti_lfa_compute_shards,
+            ),
+            (
                 "/fast-reroute/backup-as-primary",
                 config_ospfv3_fast_reroute_backup_as_primary,
             ),
@@ -177,6 +185,55 @@ fn config_ospfv3_ti_lfa(ospf: &mut Ospf<Ospfv3>, _args: Args, op: ConfigOp) -> O
     let prev = ospf.ti_lfa_enabled;
     ospf.ti_lfa_enabled = op.is_set();
     if ospf.ti_lfa_enabled == prev {
+        return Some(());
+    }
+    let area_ids: Vec<std::net::Ipv4Addr> = ospf.areas.iter().map(|(id, _)| *id).collect();
+    for id in area_ids {
+        let _ = ospf.tx.send(Message::SpfCalc(id));
+    }
+    Some(())
+}
+
+/// `/router/ospfv3/fast-reroute/ti-lfa/compute-mode` — v3 sibling of
+/// the v2 callback. Results are identical across modes; the SPF
+/// re-run makes the change observable in the telemetry.
+fn config_ospfv3_ti_lfa_compute_mode(
+    ospf: &mut Ospf<Ospfv3>,
+    mut args: Args,
+    op: ConfigOp,
+) -> Option<()> {
+    let prev = ospf.ti_lfa_compute_mode;
+    ospf.ti_lfa_compute_mode = if op.is_set() {
+        args.string()?.parse().ok()?
+    } else {
+        crate::spf::TilfaComputeModeConfig::default()
+    };
+    if ospf.ti_lfa_compute_mode == prev {
+        return Some(());
+    }
+    let area_ids: Vec<std::net::Ipv4Addr> = ospf.areas.iter().map(|(id, _)| *id).collect();
+    for id in area_ids {
+        let _ = ospf.tx.send(Message::SpfCalc(id));
+    }
+    Some(())
+}
+
+/// `/router/ospfv3/fast-reroute/ti-lfa/compute-shards` — v3 sibling of
+/// the v2 callback. Consulted only in sharding mode.
+fn config_ospfv3_ti_lfa_compute_shards(
+    ospf: &mut Ospf<Ospfv3>,
+    mut args: Args,
+    op: ConfigOp,
+) -> Option<()> {
+    let prev = ospf
+        .ti_lfa_compute_mode
+        .with_shards(ospf.ti_lfa_compute_shards);
+    ospf.ti_lfa_compute_shards = if op.is_set() { args.u16()? } else { 8 };
+    if ospf
+        .ti_lfa_compute_mode
+        .with_shards(ospf.ti_lfa_compute_shards)
+        == prev
+    {
         return Some(());
     }
     let area_ids: Vec<std::net::Ipv4Addr> = ospf.areas.iter().map(|(id, _)| *id).collect();

--- a/zebra-rs/src/ospf/inst.rs
+++ b/zebra-rs/src/ospf/inst.rs
@@ -117,6 +117,20 @@ pub struct Ospf<V: OspfVersion = Ospfv2> {
     /// primary. A protection-testing knob; no effect when
     /// `ti_lfa_enabled` is off (there is no repair to promote).
     pub fast_reroute_backup_as_primary: bool,
+    /// `/router/ospf/fast-reroute/ti-lfa/compute-mode` — how the
+    /// per-destination TI-LFA computation is scheduled (serial
+    /// default; conservative/aggressive/sharding fan out on the rayon
+    /// pool). Joined with `ti_lfa_compute_shards` at SPF-input build
+    /// time. Results are identical across modes.
+    pub ti_lfa_compute_mode: spf::TilfaComputeModeConfig,
+    /// `/router/ospf/fast-reroute/ti-lfa/compute-shards` — hard upper
+    /// bound on TI-LFA parallelism, consulted only in sharding mode.
+    /// Default 8, matching the YANG default.
+    pub ti_lfa_compute_shards: u16,
+    /// TI-LFA compute telemetry for the most recent SPF run, stamped
+    /// by `apply_spf_result` like `spf_duration` (last-area-wins).
+    /// None until TI-LFA runs (and cleared when it is disabled).
+    pub tilfa_stats: Option<spf::TilfaStats>,
     /// Per-destination TI-LFA repair paths from the most recent SPF
     /// (keyed by destination vertex id), mirror of `spf_result`'s
     /// single-area snapshot. Produced graph-only on the SPF worker;
@@ -1043,6 +1057,10 @@ impl Ospf<Ospfv2> {
             spf_result: None,
             graph: None,
             ti_lfa_enabled: false,
+            ti_lfa_compute_mode: spf::TilfaComputeModeConfig::default(),
+            // Matches the YANG `default 8` on compute-shards.
+            ti_lfa_compute_shards: 8,
+            tilfa_stats: None,
             fast_reroute_backup_as_primary: false,
             tilfa_result: None,
             spf_flex_algo: BTreeMap::new(),
@@ -5050,6 +5068,10 @@ impl Ospf<Ospfv3> {
             spf_result: None,
             graph: None,
             ti_lfa_enabled: false,
+            ti_lfa_compute_mode: spf::TilfaComputeModeConfig::default(),
+            // Matches the YANG `default 8` on compute-shards.
+            ti_lfa_compute_shards: 8,
+            tilfa_stats: None,
             fast_reroute_backup_as_primary: false,
             tilfa_result: None,
             spf_flex_algo: BTreeMap::new(),
@@ -10639,6 +10661,9 @@ fn build_v3_spf_input(top: &mut Ospf<Ospfv3>, area_id: Ipv4Addr) -> Option<SpfIn
         graph,
         source,
         ti_lfa_enabled: top.ti_lfa_enabled,
+        tilfa_mode: top
+            .ti_lfa_compute_mode
+            .with_shards(top.ti_lfa_compute_shards),
         flex_algos,
     })
 }
@@ -10654,12 +10679,14 @@ fn apply_v3_spf_result(top: &mut Ospf<Ospfv3>, output: SpfOutput) {
         source,
         spf_result,
         tilfa_result,
+        tilfa_stats,
         duration,
         last,
         flex_algos,
     } = output;
     top.spf_duration = Some(duration);
     top.spf_last = Some(last);
+    top.tilfa_stats = tilfa_stats;
     ospf_event_trace!(
         top.tracing,
         Spf,
@@ -11588,6 +11615,10 @@ struct SpfInput {
     /// `/router/ospf/fast-reroute/ti-lfa` snapshot. Gates the
     /// graph-only TI-LFA repair computation on the worker.
     ti_lfa_enabled: bool,
+    /// TI-LFA compute scheduling (`compute-mode` + `compute-shards`
+    /// joined), snapshotted from config at build time so a mid-run
+    /// change cleanly applies to the next run.
+    tilfa_mode: spf::TilfaComputeMode,
     /// One per configured Flex-Algorithm: its FAD-filtered graph and
     /// source vertex (None if the algo's graph had no source).
     flex_algos: Vec<FlexAlgoSpfInput>,
@@ -11612,6 +11643,10 @@ pub struct SpfOutput {
     /// disabled. Resolved to MPLS labels + stamped onto the RIB on the
     /// main task in `apply_spf_result`.
     tilfa_result: BTreeMap<usize, Vec<spf::RepairPath>>,
+    /// TI-LFA compute telemetry, None when TI-LFA is disabled.
+    /// Stamped onto `Ospf::tilfa_stats` for `show ospf` / `show
+    /// ospfv3 summary`.
+    tilfa_stats: Option<spf::TilfaStats>,
     duration: Duration,
     last: Instant,
     flex_algos: Vec<FlexAlgoSpfOutput>,
@@ -11655,6 +11690,9 @@ fn build_spf_input(top: &mut Ospf, area_id: Ipv4Addr) -> Option<SpfInput> {
         graph,
         source,
         ti_lfa_enabled: top.ti_lfa_enabled,
+        tilfa_mode: top
+            .ti_lfa_compute_mode
+            .with_shards(top.ti_lfa_compute_shards),
         flex_algos,
     })
 }
@@ -11667,6 +11705,7 @@ fn compute_spf(input: SpfInput) -> SpfOutput {
         graph,
         source,
         ti_lfa_enabled,
+        tilfa_mode,
         flex_algos,
     } = input;
     let start = Instant::now();
@@ -11676,10 +11715,11 @@ fn compute_spf(input: SpfInput) -> SpfOutput {
     // when off, the SPF primary RIB still installs — only the repair
     // backups are skipped. Resolution to MPLS labels happens on the
     // main task in `apply_spf_result` (it needs the LSDB).
-    let tilfa_result = if ti_lfa_enabled {
-        tilfa_repair_path(&graph, source, &spf_result)
+    let (tilfa_result, tilfa_stats) = if ti_lfa_enabled {
+        let (result, stats) = tilfa_repair_path(&graph, source, &spf_result, tilfa_mode);
+        (result, Some(stats))
     } else {
-        BTreeMap::new()
+        (BTreeMap::new(), None)
     };
 
     let flex_algos = flex_algos
@@ -11703,6 +11743,7 @@ fn compute_spf(input: SpfInput) -> SpfOutput {
         source,
         spf_result,
         tilfa_result,
+        tilfa_stats,
         duration,
         last,
         flex_algos,
@@ -11720,12 +11761,14 @@ fn apply_spf_result(top: &mut Ospf, output: SpfOutput) {
         source,
         spf_result,
         tilfa_result,
+        tilfa_stats,
         duration,
         last,
         flex_algos,
     } = output;
     top.spf_duration = Some(duration);
     top.spf_last = Some(last);
+    top.tilfa_stats = tilfa_stats;
     ospf_event_trace!(
         top.tracing,
         Spf,

--- a/zebra-rs/src/ospf/show.rs
+++ b/zebra-rs/src/ospf/show.rs
@@ -517,6 +517,21 @@ fn show_ospf(
     if let Some(spf_duration) = ospf.spf_duration {
         writeln!(buf, " Last SPF duration {} usecs", spf_duration.as_micros())?;
     }
+    // TI-LFA compute telemetry for the same run (last-area-wins, like
+    // `spf_duration`). None while TI-LFA is disabled.
+    if let Some(stats) = &ospf.tilfa_stats {
+        writeln!(
+            buf,
+            " TI-LFA compute: targets={} mode={} workers={} spf{{q={} pc={} dedup-saved={}}} took {} usecs",
+            stats.targets,
+            stats.mode,
+            stats.width,
+            stats.q_spf,
+            stats.pc_spf,
+            stats.pc_deduped,
+            stats.duration.as_micros(),
+        )?;
+    }
     // Per-area offload gates. The instance-level `spf_last` /
     // `spf_duration` above reflect the most-recent area's run
     // (`apply_spf_result` stamps the instance fields unconditionally);

--- a/zebra-rs/src/ospf/show_v3.rs
+++ b/zebra-rs/src/ospf/show_v3.rs
@@ -417,6 +417,10 @@ struct Ospfv3SummaryJson {
     link_count: usize,
     spf_last_ms_ago: Option<u128>,
     spf_duration_us: Option<u128>,
+    /// TI-LFA compute telemetry for the most-recent run, preformatted
+    /// (`targets=… mode=… workers=… spf{…} took … us`). None until
+    /// TI-LFA runs (and cleared when it is disabled).
+    tilfa_compute: Option<String>,
     /// Per-area SPF-offload gates. The instance-level
     /// `spf_last_ms_ago` / `spf_duration_us` reflect the most-recent
     /// area's run; these tell automation which area's worker is still
@@ -444,6 +448,18 @@ fn show_ospfv3_summary(
         link_count: top.links.len(),
         spf_last_ms_ago: top.spf_last.map(|t| t.elapsed().as_millis()),
         spf_duration_us: top.spf_duration.map(|d| d.as_micros()),
+        tilfa_compute: top.tilfa_stats.as_ref().map(|s| {
+            format!(
+                "targets={} mode={} workers={} spf{{q={} pc={} dedup-saved={}}} took {} us",
+                s.targets,
+                s.mode,
+                s.width,
+                s.q_spf,
+                s.pc_spf,
+                s.pc_deduped,
+                s.duration.as_micros(),
+            )
+        }),
         spf_offload_gates,
     };
     let mut text = String::new();
@@ -456,6 +472,9 @@ fn show_ospfv3_summary(
     }
     if let Some(us) = summary.spf_duration_us {
         writeln!(text, "  SPF duration: {} us", us)?;
+    }
+    if let Some(tilfa) = &summary.tilfa_compute {
+        writeln!(text, "  TI-LFA compute: {}", tilfa)?;
     }
     if !summary.spf_offload_gates.is_empty() {
         writeln!(text, "  SPF offload gates:")?;

--- a/zebra-rs/src/ospf/tilfa.rs
+++ b/zebra-rs/src/ospf/tilfa.rs
@@ -4,10 +4,12 @@
 //! The post-convergence repair *list* (a sequence of Node-SID /
 //! Adj-SID segments) is computed graph-only by [`tilfa_repair_path`]
 //! on the SPF worker — it mirrors the IS-IS path and reuses the
-//! protocol-agnostic [`crate::spf::tilfa`]. Turning those segments
-//! into an installable SR-MPLS label stack ([`build_repair_path_mpls`])
-//! needs the LSDB (peer SRGBs, Extended-Prefix / Extended-Link Opaque
-//! LSAs) and so runs on the main task during RIB build.
+//! protocol-agnostic [`crate::spf::tilfa_compute`] scheduler (serial
+//! by default; `fast-reroute ti-lfa compute-mode` fans it out on the
+//! rayon pool). Turning those segments into an installable SR-MPLS
+//! label stack ([`build_repair_path_mpls`]) needs the LSDB (peer
+//! SRGBs, Extended-Prefix / Extended-Link Opaque LSAs) and so runs on
+//! the main task during RIB build.
 //!
 //! Unlike IS-IS, OSPF collapses a transit network into a direct mesh
 //! of router→router edges (there is no pseudonode vertex in the SPF
@@ -42,22 +44,18 @@ pub struct RepairPathMpls {
     pub labels: Vec<rib::Label>,
 }
 
-/// Per-destination TI-LFA repair computation (graph-only). For every
-/// destination in `spf_result` other than the source that has a single
-/// primary first-hop (SPF-level ECMP is skipped — the remaining legs
-/// already protect the prefix), call [`spf::tilfa`] to compute the
-/// post-convergence repair list, protecting against the first-hop node
-/// (`X`). The returned map is keyed by destination vertex id.
-///
-/// Runs on the SPF worker, so it borrows nothing but the graph and the
-/// SPF result. The graph must carry `ilinks` (reverse edges) — the
-/// OSPF graph builder populates them for exactly this Q-space step.
-pub(super) fn tilfa_repair_path(
-    graph: &spf::Graph,
+/// Plan the TI-LFA targets from the primary SPF result: every
+/// destination other than the source with a single primary first-hop
+/// (SPF-level ECMP is skipped — the remaining legs already protect
+/// the prefix), paired with the protected vertex X (the first-hop
+/// node). Pure planning — the SPF work happens in
+/// `spf::tilfa_compute`. No pseudonode handling: OSPF collapses
+/// transit networks into a direct router→router mesh.
+pub(super) fn tilfa_targets(
     source: usize,
     spf_result: &BTreeMap<usize, spf::Path>,
-) -> BTreeMap<usize, Vec<spf::RepairPath>> {
-    let mut tilfa_result = BTreeMap::new();
+) -> Vec<spf::TilfaTarget> {
+    let mut targets = Vec::new();
     for (d, path) in spf_result.iter() {
         if *d == source {
             continue;
@@ -70,18 +68,52 @@ pub(super) fn tilfa_repair_path(
             continue;
         }
         // X — the protected element: the single primary first-hop node.
-        // `spf::tilfa` returns an empty vec when `d == x` (the
-        // destination *is* the protected neighbor), so that case
-        // self-skips below.
+        // The `d == x` case (destination *is* the protected neighbor)
+        // self-skips downstream: the x-excluded SPF can't reach d, so
+        // the repair list comes back empty and the destination is
+        // omitted from the result map.
         let Some(&x) = path.nexthops.iter().next().and_then(|seq| seq.first()) else {
             continue;
         };
-        let repair_paths = spf::tilfa(graph, source, *d, &[x]);
-        if !repair_paths.is_empty() {
-            tilfa_result.insert(*d, repair_paths);
-        }
+        targets.push(spf::TilfaTarget { d: *d, x });
     }
-    tilfa_result
+    targets
+}
+
+/// Per-destination TI-LFA repair computation (graph-only): plan the
+/// targets, then hand them to `spf::tilfa_compute`, which schedules
+/// the Q/PC SPF jobs per the configured compute mode (serial by
+/// default). The returned map is keyed by destination vertex id;
+/// destinations with no computable repair are absent.
+///
+/// Unlike IS-IS, OSPF's primary SPF runs in nexthop mode
+/// (`SpfOpt::default()`), and the P-space filter inside
+/// `tilfa_compute` needs full paths — so one extra full-path SPF on
+/// the unmodified graph is run here. It is independent of the
+/// protected node, so a single run is shared across every target
+/// (the design doc's `N + |X| + 1` count for OSPF).
+///
+/// Runs on the SPF worker, so it borrows nothing but the graph and the
+/// SPF result. The graph must carry `ilinks` (reverse edges) — the
+/// OSPF graph builder populates them for exactly this Q-space step.
+pub(super) fn tilfa_repair_path(
+    graph: &spf::Graph,
+    source: usize,
+    spf_result: &BTreeMap<usize, spf::Path>,
+    mode: spf::TilfaComputeMode,
+) -> (BTreeMap<usize, Vec<spf::RepairPath>>, spf::TilfaStats) {
+    let targets = tilfa_targets(source, spf_result);
+    if targets.is_empty() {
+        // Skip the full-path SPF when there is nothing to protect.
+        let stats = spf::TilfaStats {
+            mode,
+            width: 1,
+            ..spf::TilfaStats::default()
+        };
+        return (BTreeMap::new(), stats);
+    }
+    let full_path_spf = spf::spf(graph, source, &spf::SpfOpt::full_path());
+    spf::tilfa_compute(graph, source, &full_path_spf, &targets, mode)
 }
 
 /// Translate a graph-level `spf::RepairPath` into the FIB-ready
@@ -672,4 +704,59 @@ fn csid_bits_endx_v3(info: &Srv6SidInfoV3, owner: usize) -> Option<crate::spf::s
         width: st.fun_len,
         lib_owner: Some(owner),
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::spf::calc::fixtures::tilfa_graph;
+
+    /// The OSPF pipeline equals the legacy per-destination
+    /// `spf::tilfa` loop. OSPF's primary SPF runs in nexthop mode, so
+    /// this specifically pins the full-path-SPF substitution inside
+    /// `tilfa_repair_path` (the P-space filter must see the same tree
+    /// `p_space_vertices` computed internally), on top of the mode
+    /// equivalence already pinned in `spf::tilfa_par`.
+    #[test]
+    fn repair_path_matches_reference_loop() {
+        let graph = tilfa_graph();
+        let source = 0;
+        // Nexthop mode — exactly what OSPF's `compute_spf` passes.
+        let primary = spf::spf(&graph, source, &spf::SpfOpt::default());
+        let targets = tilfa_targets(source, &primary);
+        assert!(!targets.is_empty(), "fixture must produce targets");
+
+        let mut want = BTreeMap::new();
+        for t in &targets {
+            let repairs = spf::tilfa(&graph, source, t.d, &[t.x]);
+            if !repairs.is_empty() {
+                want.insert(t.d, repairs);
+            }
+        }
+
+        for mode in [
+            spf::TilfaComputeMode::Serial,
+            spf::TilfaComputeMode::Conservative,
+            spf::TilfaComputeMode::Aggressive,
+            spf::TilfaComputeMode::Sharding(2),
+        ] {
+            let (got, stats) = tilfa_repair_path(&graph, source, &primary, mode);
+            assert_eq!(got, want, "mode {mode:?}");
+            assert_eq!(stats.targets, targets.len(), "mode {mode:?}");
+        }
+    }
+
+    /// A topology with nothing to protect (single router) short-
+    /// circuits before the extra full-path SPF and returns empty
+    /// zeroed stats.
+    #[test]
+    fn empty_targets_skip_compute() {
+        let mut graph: spf::Graph = BTreeMap::new();
+        graph.insert(0, spf::Vertex::new_node("S", 0));
+        let primary = spf::spf(&graph, 0, &spf::SpfOpt::default());
+        let (got, stats) = tilfa_repair_path(&graph, 0, &primary, spf::TilfaComputeMode::Serial);
+        assert!(got.is_empty());
+        assert_eq!(stats.targets, 0);
+        assert_eq!(stats.q_spf, 0);
+    }
 }

--- a/zebra-rs/src/spf/calc.rs
+++ b/zebra-rs/src/spf/calc.rs
@@ -339,6 +339,10 @@ pub fn p_space_from_spf(spf: &BTreeMap<usize, Path>, s: usize, x: &[usize]) -> B
         .collect::<BTreeSet<_>>()
 }
 
+/// Self-contained P-space (runs its own SPF). Test-only since the
+/// protocol pipelines moved to `tilfa_compute` + `p_space_from_spf`;
+/// kept as part of the [`tilfa`] reference implementation.
+#[allow(dead_code)]
 pub fn p_space_vertices(graph: &Graph, s: usize, x: &[usize]) -> BTreeSet<usize> {
     let spf = spf(graph, s, &SpfOpt::full_path());
     p_space_from_spf(&spf, s, x)
@@ -358,6 +362,11 @@ pub fn q_space_vertices(graph: &Graph, d: usize, x: &[usize]) -> BTreeSet<usize>
         .collect::<BTreeSet<_>>()
 }
 
+/// Single-destination PC-path extraction (runs its own x-excluded
+/// SPF). Test-only since the protocol pipelines moved to
+/// `tilfa_compute`, which shares one tree per protected node; kept as
+/// part of the [`tilfa`] reference implementation.
+#[allow(dead_code)]
 pub fn pc_paths(
     graph: &Graph,
     s: usize,
@@ -600,7 +609,9 @@ pub fn repair_from_parts(
 /// implementation and oracle for the parallel pipeline, which avoids
 /// the per-destination P-space SPF ([`p_space_from_spf`] over the
 /// primary SPF result) and shares the PC SPF across destinations
-/// behind the same protected node.
+/// behind the same protected node. Test-only since both the IS-IS
+/// and OSPF pipelines moved to `tilfa_compute`.
+#[allow(dead_code)]
 pub fn tilfa(graph: &Graph, s: usize, d: usize, x: &[usize]) -> Vec<RepairPath> {
     let p_vertices = p_space_vertices(graph, s, x);
     let q_vertices = q_space_vertices(graph, d, x);

--- a/zebra-rs/src/spf/tilfa_par.rs
+++ b/zebra-rs/src/spf/tilfa_par.rs
@@ -64,6 +64,39 @@ impl std::fmt::Display for TilfaComputeMode {
     }
 }
 
+/// YANG mirror of the `fast-reroute/ti-lfa/compute-mode` leaf
+/// (payload-free — the sharding count lives in the sibling
+/// `compute-shards` leaf; [`Self::with_shards`] joins them into the
+/// scheduler-facing [`TilfaComputeMode`]). Shared by the IS-IS and
+/// OSPF config layers, which carry the same two leaves.
+#[derive(
+    Debug, Default, Clone, Copy, PartialEq, Eq, strum_macros::EnumString, strum_macros::Display,
+)]
+pub enum TilfaComputeModeConfig {
+    #[default]
+    #[strum(serialize = "serial")]
+    Serial,
+    #[strum(serialize = "conservative")]
+    Conservative,
+    #[strum(serialize = "aggressive")]
+    Aggressive,
+    #[strum(serialize = "sharding")]
+    Sharding,
+}
+
+impl TilfaComputeModeConfig {
+    /// Combine with the `compute-shards` leaf value into the
+    /// scheduler-facing mode (the count only matters for sharding).
+    pub fn with_shards(self, shards: u16) -> TilfaComputeMode {
+        match self {
+            TilfaComputeModeConfig::Serial => TilfaComputeMode::Serial,
+            TilfaComputeModeConfig::Conservative => TilfaComputeMode::Conservative,
+            TilfaComputeModeConfig::Aggressive => TilfaComputeMode::Aggressive,
+            TilfaComputeModeConfig::Sharding => TilfaComputeMode::Sharding(shards),
+        }
+    }
+}
+
 /// One TI-LFA computation target, as planned by the protocol caller
 /// (IS-IS: `isis::tilfa::tilfa_targets`): a destination vertex and
 /// the protected vertex `x` (its primary first-hop node).

--- a/zebra-rs/yang/config.yang
+++ b/zebra-rs/yang/config.yang
@@ -810,6 +810,32 @@ module config {
             // must also be enabled for the repair to install in the
             // dataplane.
             presence "Enable Topology-Independent LFA (TI-LFA)";
+
+            leaf compute-mode {
+              ext:help "How the TI-LFA computation is scheduled";
+              // Execution scheduling for the per-destination TI-LFA
+              // computation; same modes and semantics as
+              // `router isis fast-reroute ti-lfa compute-mode` (see
+              // docs/design/isis-tilfa-parallel-spf.md, §13 for the
+              // OSPF specifics).
+              type enumeration {
+                enum serial;
+                enum conservative;
+                enum aggressive;
+                enum sharding;
+              }
+              default "serial";
+            }
+
+            leaf compute-shards {
+              ext:help "Max parallel TI-LFA shards (sharding mode)";
+              // Hard upper bound on TI-LFA parallelism, consulted
+              // only when `compute-mode sharding` is set.
+              type uint16 {
+                range "1..256";
+              }
+              default "8";
+            }
           }
           container backup-as-primary {
             // Swap the metric-sort offset between the SPF primary
@@ -1230,6 +1256,29 @@ module config {
             // Topology-Independent Loop-Free Alternate (TI-LFA,
             // RFC 9490). Post-convergence repair over the v3 LSDB.
             presence "Enable Topology-Independent LFA (TI-LFA)";
+
+            leaf compute-mode {
+              ext:help "How the TI-LFA computation is scheduled";
+              // Same modes and semantics as `router ospf
+              // fast-reroute ti-lfa compute-mode`.
+              type enumeration {
+                enum serial;
+                enum conservative;
+                enum aggressive;
+                enum sharding;
+              }
+              default "serial";
+            }
+
+            leaf compute-shards {
+              ext:help "Max parallel TI-LFA shards (sharding mode)";
+              // Hard upper bound on TI-LFA parallelism, consulted
+              // only when `compute-mode sharding` is set.
+              type uint16 {
+                range "1..256";
+              }
+              default "8";
+            }
           }
           container backup-as-primary {
             // Swap the metric-sort offset between the SPF primary and


### PR DESCRIPTION
## Summary

Ports the IS-IS TI-LFA compute-mode scheduling (#1390) to OSPF, per `docs/design/isis-tilfa-parallel-spf.md` §13. v2 and v3 share `SpfInput`/`SpfOutput`/`compute_spf`, so one plumbing change covers both.

- **`ospf/tilfa.rs`** — split into `tilfa_targets` (nexthop-mode planner; no pseudonodes in OSPF graphs) + `tilfa_repair_path` calling the shared `spf::tilfa_compute`. The §13 caveat is handled here: OSPF's primary SPF runs in **nexthop mode** and the P-space filter needs full paths, so one extra *x-independent* full-path SPF runs per cycle, shared across every target (`N + |X| + 1` SPFs in aggressive/sharding vs `3N` before — still a ~3× CPU cut on top of the parallelism). Skipped entirely when there is nothing to protect.
- **Shared config mirror** — `TilfaComputeModeConfig` moves from `isis/config.rs` to `spf/tilfa_par.rs` (`with_shards()` joins the two leaves); IS-IS now imports it.
- **Config** — `fast-reroute ti-lfa compute-mode <serial|conservative|aggressive|sharding>` + `compute-shards <1..256>` under both `router ospf` and `router ospfv3` (default `serial`, identical results across modes). Handlers re-run SPF per area on effective-mode change; no LSA re-origination.
- **Telemetry** — `TilfaStats` ride `SpfOutput` onto `Ospf::tilfa_stats` (last-area-wins, like `spf_duration`); rendered by `show ospf` and `show ospfv3 summary` (text + JSON `tilfa_compute` field).
- `spf::tilfa`/`p_space_vertices`/`pc_paths` are now test-only (OSPF was their last production caller) — kept as the reference oracle with `#[allow(dead_code)]` per repo convention.

## Test plan

- `ospf::tilfa::tests::repair_path_matches_reference_loop`: the new pipeline equals the legacy per-destination 3-SPF loop across serial/conservative/aggressive/sharding(2), specifically pinning the nexthop-mode → full-path-SPF substitution; plus the empty-target short-circuit.
- Mode equivalence on large/random graphs already pinned protocol-neutrally in `spf::tilfa_par` (#1390).
- `set`-grammar parse() pins for the four new OSPF CLI paths (manager.rs).
- `cargo fmt`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo test --workspace --exclude bdd` green locally.

OSPF PR-2 adds BDD scenarios to `ospfv2_tilfa.feature` / `ospfv3_tilfa.feature` mirroring the IS-IS ones (#1395).

🤖 Generated with [Claude Code](https://claude.com/claude-code)