### PR TITLE
bdd: OSPF v2+v3 TI-LFA compute-mode scenarios (OSPF PR-2)

### DIFF
--- a/bdd/tests/features/ospfv2_tilfa.feature
+++ b/bdd/tests/features/ospfv2_tilfa.feature
@@ -147,6 +147,41 @@ Feature: OSPFv2 TI-LFA fast-reroute over SR-MPLS
     # Primary restored once the adjacency re-forms.
     Then ping from "s" to "10.0.0.8" should succeed
 
+  Scenario: TI-LFA compute-mode aggressive computes the same repair in parallel
+    Given the test topology exists
+    # Switch the TI-LFA scheduler to the parallel map-reduce mode
+    # (docs/design/isis-tilfa-parallel-spf.md §13 for the OSPF
+    # specifics). The config handler re-runs SPF on its own; results
+    # are identical across modes — only the CPU scheduling differs.
+    When I apply command "set router ospf fast-reroute ti-lfa compute-mode aggressive" in namespace "s"
+    And I wait 5 seconds
+    # The repair list is still computed after the parallel run...
+    Then show command "show ospf ti-lfa" in namespace "s" should contain "Node-SID"
+    # ...and the telemetry proves the aggressive scheduler ran it.
+    And show command "show ospf" in namespace "s" should contain "mode=aggressive"
+
+  Scenario: TI-LFA compute-mode sharding bounds parallelism and still protects
+    Given the test topology exists
+    When I apply command "set router ospf fast-reroute ti-lfa compute-shards 2" in namespace "s"
+    And I apply command "set router ospf fast-reroute ti-lfa compute-mode sharding" in namespace "s"
+    And I wait 5 seconds
+    Then show command "show ospf ti-lfa" in namespace "s" should contain "Node-SID"
+    And show command "show ospf" in namespace "s" should contain "mode=sharding(2)"
+    # The sharded recompute still protects for real: fail the primary
+    # link and reach d over the repair / post-convergence path.
+    When I make namespace "s" interface "s-n1" down
+    And I wait 5 seconds
+    Then ping from "s" to "10.0.0.8" should succeed
+    When I make namespace "s" interface "s-n1" up
+    And I wait 30 seconds
+    Then ping from "s" to "10.0.0.8" should succeed
+    # Runtime leaf deletes (value-carrying) reset the scheduler to the
+    # stock serial mode for the remaining scenarios.
+    When I apply command "delete router ospf fast-reroute ti-lfa compute-mode sharding" in namespace "s"
+    And I apply command "delete router ospf fast-reroute ti-lfa compute-shards 2" in namespace "s"
+    And I wait 5 seconds
+    Then show command "show ospf" in namespace "s" should contain "mode=serial"
+
   Scenario: Promoted backup actually forwards over the SR-MPLS repair
     Given the test topology exists
     # `backup-as-primary` swaps the metric-sort offset so each TI-LFA

--- a/bdd/tests/features/ospfv3_tilfa.feature
+++ b/bdd/tests/features/ospfv3_tilfa.feature
@@ -156,6 +156,40 @@ Feature: OSPFv3 TI-LFA fast-reroute over SR-MPLS
     # Primary restored once the adjacency re-forms.
     Then ping from "s" to "2001:db8::8" should succeed
 
+  Scenario: TI-LFA compute-mode aggressive computes the same repair in parallel
+    Given the test topology exists
+    # Switch the TI-LFA scheduler to the parallel map-reduce mode —
+    # v3 sibling of the v2 scenario; the summary (`show ospfv3`)
+    # carries the compute telemetry.
+    When I apply command "set router ospfv3 fast-reroute ti-lfa compute-mode aggressive" in namespace "s"
+    And I wait 5 seconds
+    # The repair list is still computed after the parallel run...
+    Then show command "show ospfv3 ti-lfa" in namespace "s" should contain "Node-SID"
+    # ...and the telemetry proves the aggressive scheduler ran it.
+    And show command "show ospfv3" in namespace "s" should contain "mode=aggressive"
+
+  Scenario: TI-LFA compute-mode sharding bounds parallelism and still protects
+    Given the test topology exists
+    When I apply command "set router ospfv3 fast-reroute ti-lfa compute-shards 2" in namespace "s"
+    And I apply command "set router ospfv3 fast-reroute ti-lfa compute-mode sharding" in namespace "s"
+    And I wait 5 seconds
+    Then show command "show ospfv3 ti-lfa" in namespace "s" should contain "Node-SID"
+    And show command "show ospfv3" in namespace "s" should contain "mode=sharding(2)"
+    # The sharded recompute still protects for real: fail the primary
+    # link and reach d over the repair / post-convergence path.
+    When I make namespace "s" interface "s-n1" down
+    And I wait 5 seconds
+    Then ping from "s" to "2001:db8::8" should succeed
+    When I make namespace "s" interface "s-n1" up
+    And I wait 30 seconds
+    Then ping from "s" to "2001:db8::8" should succeed
+    # Runtime leaf deletes (value-carrying) reset the scheduler to the
+    # stock serial mode for the remaining scenarios.
+    When I apply command "delete router ospfv3 fast-reroute ti-lfa compute-mode sharding" in namespace "s"
+    And I apply command "delete router ospfv3 fast-reroute ti-lfa compute-shards 2" in namespace "s"
+    And I wait 5 seconds
+    Then show command "show ospfv3" in namespace "s" should contain "mode=serial"
+
   Scenario: Promoted backup actually forwards over the SR-MPLS repair
     Given the test topology exists
     # `backup-as-primary` swaps the metric-sort offset so each TI-LFA


### PR DESCRIPTION
## Summary

Final PR of the OSPF TI-LFA parallel-compute port (#1399; series design `docs/design/isis-tilfa-parallel-spf.md`). Mirrors the IS-IS scenarios (#1395) in both `ospfv2_tilfa.feature` and `ospfv3_tilfa.feature`:

- *aggressive*: runtime `set router ospf(v3) fast-reroute ti-lfa compute-mode aggressive`, assert the repair list is still computed (`show ospf(v3) ti-lfa` → `Node-SID`) and the compute telemetry reports `mode=aggressive` (`show ospf` / bare `show ospfv3` summary).
- *sharding*: `compute-shards 2` + `compute-mode sharding`, assert `mode=sharding(2)`, run a full link-down/up fast-reroute cycle proving the sharded recompute still protects, then value-carrying runtime leaf deletes resetting to `mode=serial`.

No new feature tags (scenarios join the existing features; teardown stays the last scenario).

## Test plan

- Live BDD against the #1399 binary: **ospfv2_tilfa 10/10, ospfv3_tilfa 10/10** (`--concurrency=1`); all six mode-telemetry assertions confirmed non-vacuous in the run logs.
- Feature files only — no Rust changes; fmt/clippy/test unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)