### PR TITLE
bgp: flush NOTIFICATIONs on conn teardown + local-as BDD

### DIFF
--- a/bdd/Makefile
+++ b/bdd/Makefile
@@ -234,6 +234,10 @@ bgp_ip_transparent:
 	mkdir -p allure-results
 	cargo test --test cucumber -- --concurrency=1 --tags "@bgp_ip_transparent"
 
+bgp_local_as:
+	mkdir -p allure-results
+	cargo test --test cucumber -- --concurrency=1 --tags "@bgp_local_as"
+
 generate:
 	rm -rf allure-report
 	allure generate
@@ -253,4 +257,4 @@ docs/%.md: tests/features/%.feature docs/feature2md.sh FORCE
 
 FORCE:
 
-.PHONY: ecmp_bfd_evict ospfv2_bfd_frr ospfv3_bfd_frr tilfa_bfd all run ibgp ebgp rr rib_static_ipv6 isis_ipv6 isis_srv6 isis_fragmentation_ipv6 isis_fragmentation_ipv4 isis_l1p2p isis_tilfa isis_l1l2 isis_redist isis_hello_auth_keychain isis_passive isis_afi_enable isis_endx_ipv6 isis_bfd_ipv6_p2p isis_bfd_ipv6_p2p_echo isis_bfd_ipv6_lan isis_bfd_ipv6_lan_echo isis_bfd_ipv4_p2p isis_bfd_ipv4_p2p_echo isis_bfd_ipv4_lan isis_bfd_ipv4_lan_echo ospf_clear_neighbor ospfv2_nssa ospfv2_stub ospfv2_tilfa ospfv3_nssa ospfv3_tilfa bgp_peer_down_cleanup bgp_ipv6_over_v4_session bgp_evpn_capability bgp_vrf_evpn_type5 bgp_route_map_match bgp_policy_dynamic_update bgp_table_map bgp_v6_table_map bgp_community bgp_neighbor_group bgp_unnumbered_neighbor nd_show bgp_interas_option_c bgp_interas_option_a bgp_interas_option_b bgp_interas_option_ab bgp_port bgp_ip_transparent generate open docs FORCE
+.PHONY: ecmp_bfd_evict ospfv2_bfd_frr ospfv3_bfd_frr tilfa_bfd all run ibgp ebgp rr rib_static_ipv6 isis_ipv6 isis_srv6 isis_fragmentation_ipv6 isis_fragmentation_ipv4 isis_l1p2p isis_tilfa isis_l1l2 isis_redist isis_hello_auth_keychain isis_passive isis_afi_enable isis_endx_ipv6 isis_bfd_ipv6_p2p isis_bfd_ipv6_p2p_echo isis_bfd_ipv6_lan isis_bfd_ipv6_lan_echo isis_bfd_ipv4_p2p isis_bfd_ipv4_p2p_echo isis_bfd_ipv4_lan isis_bfd_ipv4_lan_echo ospf_clear_neighbor ospfv2_nssa ospfv2_stub ospfv2_tilfa ospfv3_nssa ospfv3_tilfa bgp_peer_down_cleanup bgp_ipv6_over_v4_session bgp_evpn_capability bgp_vrf_evpn_type5 bgp_route_map_match bgp_policy_dynamic_update bgp_table_map bgp_v6_table_map bgp_community bgp_neighbor_group bgp_unnumbered_neighbor nd_show bgp_interas_option_c bgp_interas_option_a bgp_interas_option_b bgp_interas_option_ab bgp_port bgp_ip_transparent bgp_local_as generate open docs FORCE

--- a/bdd/docs/bgp_local_as.md
+++ b/bdd/docs/bgp_local_as.md
@@ -1,0 +1,50 @@
+# BGP local-as presents a substitute AS to one neighbor (AS migration)
+
+## Overview
+
+As a network operator
+I want `neighbor X local-as ASN [no-prepend] [replace-as] [dual-as]`
+So a router migrated to a new global AS keeps its sessions with peers
+that still expect the old AS, and each peer migrates on its own schedule.
+
+## Test Topology
+
+```
+   ┌─────────┐  192.168.0.0/24  ┌─────────┐
+   │   z1    │ i1────────────i1 │   z2    │
+   │ AS65100 │                  │ AS65001 │
+   │  .0.1   │   local-as       │  .0.2   │
+   └─────────┘   64999 →        └─────────┘
+```
+
+## Notes
+
+z1's global AS is 65100 but z2's `remote-as` names the pre-migration
+AS 64999 — only z1's `local-as 64999` lets the session establish: the
+OPEN carries 64999, outbound routes are prepended "64999 65100"
+(`replace-as` hides the real AS → "64999"), and inbound routes from
+z2 get 64999 prepended at ingress (`no-prepend` turns that off).
+`dual-as` closes the migration: once z2 flips its remote-as to 65100,
+one Bad Peer AS round trip makes z1's next OPEN present the global
+AS. z2 is passive throughout so z1 always dials — the dual-as
+retry exchange stays a single deterministic connection stream.
+
+## Config Files
+
+- z1-base.yaml:      z1 with bare `local-as 64999`, originates 10.0.0.1/32
+- z1-replace.yaml:   z1 with `local-as 64999 replace-as true`
+- z1-noprepend.yaml: z1 with `local-as 64999 no-prepend true`
+- z1-dualas.yaml:    z1 with `local-as 64999 dual-as true`
+- z2.yaml:           z2 expecting remote-as 64999 (passive), originates 10.0.0.2/32
+- z2-globalas.yaml:  z2 migrated to remote-as 65100 (passive)
+
+## Test Scenarios
+
+| Scenario | Result |
+|----------|--------|
+| Setup topology — the session establishes under the substitute AS | |
+| Bare form prepends the substitute on both directions | |
+| replace-as hides the real AS on egress | |
+| no-prepend leaves inbound routes untouched | |
+| dual-as re-establishes under the global AS after the peer migrates | |
+| Teardown topology | |

--- a/bdd/tests/configs/bgp_local_as/z1-base.yaml
+++ b/bdd/tests/configs/bgp_local_as/z1-base.yaml
@@ -1,0 +1,29 @@
+interface:
+- if-name: i1
+  ipv4:
+    address: 192.168.0.1/24
+router:
+  bgp:
+    global:
+      as: 65100
+      router-id: 192.168.0.1
+    timer:
+      adv-interval:
+        ibgp: 1
+        ebgp: 1
+    neighbor:
+    - remote-address: 192.168.0.2
+      afi-safi:
+      - name: ipv4
+        enabled: true
+      enabled: true
+      remote-as: 65001
+      # Bare local-as: the session presents AS 64999 (z2's remote-as
+      # only accepts 64999), egress prepends "64999 65100", ingress
+      # prepends 64999 to routes received from z2.
+      local-as:
+      - as-number: 64999
+    afi-safi:
+    - name: ipv4
+      network:
+      - prefix: 10.0.0.1/32

--- a/bdd/tests/configs/bgp_local_as/z1-dualas.yaml
+++ b/bdd/tests/configs/bgp_local_as/z1-dualas.yaml
@@ -1,0 +1,31 @@
+interface:
+- if-name: i1
+  ipv4:
+    address: 192.168.0.1/24
+router:
+  bgp:
+    global:
+      as: 65100
+      router-id: 192.168.0.1
+    timer:
+      adv-interval:
+        ibgp: 1
+        ebgp: 1
+    neighbor:
+    - remote-address: 192.168.0.2
+      afi-safi:
+      - name: ipv4
+        enabled: true
+      enabled: true
+      remote-as: 65001
+      # dual-as: z2 may peer with either 64999 or the global 65100.
+      # When z2 flips its remote-as to 65100, z1's OPEN with 64999
+      # draws a Bad Peer AS NOTIFICATION and the next attempt
+      # presents 65100 — the no-coordination migration step.
+      local-as:
+      - as-number: 64999
+        dual-as: true
+    afi-safi:
+    - name: ipv4
+      network:
+      - prefix: 10.0.0.1/32

--- a/bdd/tests/configs/bgp_local_as/z1-noprepend.yaml
+++ b/bdd/tests/configs/bgp_local_as/z1-noprepend.yaml
@@ -1,0 +1,30 @@
+interface:
+- if-name: i1
+  ipv4:
+    address: 192.168.0.1/24
+router:
+  bgp:
+    global:
+      as: 65100
+      router-id: 192.168.0.1
+    timer:
+      adv-interval:
+        ibgp: 1
+        ebgp: 1
+    neighbor:
+    - remote-address: 192.168.0.2
+      afi-safi:
+      - name: ipv4
+        enabled: true
+      enabled: true
+      remote-as: 65001
+      # no-prepend: skip the ingress prepend — routes from z2 keep
+      # their original AS_PATH "65001" in z1's table. Egress is back
+      # to the bare two-AS form (apply-replace removes replace-as).
+      local-as:
+      - as-number: 64999
+        no-prepend: true
+    afi-safi:
+    - name: ipv4
+      network:
+      - prefix: 10.0.0.1/32

--- a/bdd/tests/configs/bgp_local_as/z1-replace.yaml
+++ b/bdd/tests/configs/bgp_local_as/z1-replace.yaml
@@ -1,0 +1,29 @@
+interface:
+- if-name: i1
+  ipv4:
+    address: 192.168.0.1/24
+router:
+  bgp:
+    global:
+      as: 65100
+      router-id: 192.168.0.1
+    timer:
+      adv-interval:
+        ibgp: 1
+        ebgp: 1
+    neighbor:
+    - remote-address: 192.168.0.2
+      afi-safi:
+      - name: ipv4
+        enabled: true
+      enabled: true
+      remote-as: 65001
+      # replace-as: egress prepends only the substitute — z2 sees
+      # "64999" with the real AS 65100 hidden entirely.
+      local-as:
+      - as-number: 64999
+        replace-as: true
+    afi-safi:
+    - name: ipv4
+      network:
+      - prefix: 10.0.0.1/32

--- a/bdd/tests/configs/bgp_local_as/z2-globalas.yaml
+++ b/bdd/tests/configs/bgp_local_as/z2-globalas.yaml
@@ -1,0 +1,29 @@
+interface:
+- if-name: i1
+  ipv4:
+    address: 192.168.0.2/24
+router:
+  bgp:
+    global:
+      as: 65001
+      router-id: 192.168.0.2
+    timer:
+      adv-interval:
+        ibgp: 1
+        ebgp: 1
+    neighbor:
+    # The peer has migrated: remote-as now names z1's real global AS.
+    # z1 (dual-as) re-establishes under 65100 after one Bad Peer AS
+    # round trip.
+    - remote-address: 192.168.0.1
+      afi-safi:
+      - name: ipv4
+        enabled: true
+      enabled: true
+      remote-as: 65100
+      transport:
+        passive-mode: true
+    afi-safi:
+    - name: ipv4
+      network:
+      - prefix: 10.0.0.2/32

--- a/bdd/tests/configs/bgp_local_as/z2.yaml
+++ b/bdd/tests/configs/bgp_local_as/z2.yaml
@@ -1,0 +1,31 @@
+interface:
+- if-name: i1
+  ipv4:
+    address: 192.168.0.2/24
+router:
+  bgp:
+    global:
+      as: 65001
+      router-id: 192.168.0.2
+    timer:
+      adv-interval:
+        ibgp: 1
+        ebgp: 1
+    neighbor:
+    # The legacy peer: it still expects z1 under its pre-migration AS
+    # 64999 — only z1's local-as substitution lets the session form.
+    # Passive pins the connect direction (z1 dials) so the dual-as
+    # Bad-Peer-AS/retry exchange later in the feature stays a single
+    # deterministic connection stream.
+    - remote-address: 192.168.0.1
+      afi-safi:
+      - name: ipv4
+        enabled: true
+      enabled: true
+      remote-as: 64999
+      transport:
+        passive-mode: true
+    afi-safi:
+    - name: ipv4
+      network:
+      - prefix: 10.0.0.2/32

--- a/bdd/tests/features/bgp_local_as.feature
+++ b/bdd/tests/features/bgp_local_as.feature
@@ -1,0 +1,115 @@
+@serial
+@bgp_local_as
+Feature: BGP local-as presents a substitute AS to one neighbor (AS migration)
+  As a network operator
+  I want `neighbor X local-as ASN [no-prepend] [replace-as] [dual-as]`
+  So a router migrated to a new global AS keeps its sessions with peers
+  that still expect the old AS, and each peer migrates on its own schedule.
+
+  Test Topology (z1 migrated to AS 65100; z2 still expects the old AS 64999):
+  ```
+   ┌─────────┐  192.168.0.0/24  ┌─────────┐
+   │   z1    │ i1────────────i1 │   z2    │
+   │ AS65100 │                  │ AS65001 │
+   │  .0.1   │   local-as       │  .0.2   │
+   └─────────┘   64999 →        └─────────┘
+  ```
+
+  z1's global AS is 65100 but z2's `remote-as` names the pre-migration
+  AS 64999 — only z1's `local-as 64999` lets the session establish: the
+  OPEN carries 64999, outbound routes are prepended "64999 65100"
+  (`replace-as` hides the real AS → "64999"), and inbound routes from
+  z2 get 64999 prepended at ingress (`no-prepend` turns that off).
+  `dual-as` closes the migration: once z2 flips its remote-as to 65100,
+  one Bad Peer AS round trip makes z1's next OPEN present the global
+  AS. z2 is passive throughout so z1 always dials — the dual-as
+  retry exchange stays a single deterministic connection stream.
+
+  Config files:
+  - z1-base.yaml:      z1 with bare `local-as 64999`, originates 10.0.0.1/32
+  - z1-replace.yaml:   z1 with `local-as 64999 replace-as true`
+  - z1-noprepend.yaml: z1 with `local-as 64999 no-prepend true`
+  - z1-dualas.yaml:    z1 with `local-as 64999 dual-as true`
+  - z2.yaml:           z2 expecting remote-as 64999 (passive), originates 10.0.0.2/32
+  - z2-globalas.yaml:  z2 migrated to remote-as 65100 (passive)
+
+  Scenario: Setup topology — the session establishes under the substitute AS
+    Given a clean test environment
+    When I create namespace "z1"
+    And I create namespace "z2"
+    And I connect namespace "z1" interface "i1" to namespace "z2" interface "i1"
+    And I start zebra-rs in namespace "z1"
+    And I start zebra-rs in namespace "z2"
+    And I apply config "z1-base.yaml" to namespace "z1"
+    And I apply config "z2.yaml" to namespace "z2"
+    And I wait 20 seconds for BGP to operate
+    # z2 only accepts remote-as 64999, so Established proves the OPEN
+    # carried the substitute, not z1's global AS 65100.
+    Then BGP session in "z1" to "192.168.0.2" should be "Established"
+    And BGP session in "z2" to "192.168.0.1" should be "Established"
+
+  Scenario: Bare form prepends the substitute on both directions
+    Given the test topology exists
+    # Egress: z2 sees the substitute stacked over the real AS.
+    Then BGP route in "z2" has "10.0.0.1/32" with "as_path" value "64999 65100"
+    # Ingress: z1 prepends the substitute to routes received from z2,
+    # so the rest of the network still sees the path through the old
+    # AS. One occurrence is within the loop-check budget — the route
+    # must be accepted.
+    And BGP route in "z1" has "10.0.0.2/32" with "as_path" value "64999 65001"
+    And show command "show bgp neighbors" in namespace "z1" should contain "Local AS substitution: local-as 64999"
+
+  Scenario: replace-as hides the real AS on egress
+    Given the test topology exists
+    When I apply config "z1-replace.yaml" to namespace "z1"
+    # The modifier doesn't bounce the session; clear it so both
+    # directions re-exchange under the new policy.
+    And I run "clear bgp ipv4 neighbor 192.168.0.2" in namespace "z1"
+    And I wait 20 seconds for BGP to operate
+    Then BGP session in "z1" to "192.168.0.2" should be "Established"
+    And BGP route in "z2" has "10.0.0.1/32" with "as_path" value "64999"
+    # Ingress is unaffected by replace-as.
+    And BGP route in "z1" has "10.0.0.2/32" with "as_path" value "64999 65001"
+
+  Scenario: no-prepend leaves inbound routes untouched
+    Given the test topology exists
+    When I apply config "z1-noprepend.yaml" to namespace "z1"
+    And I run "clear bgp ipv4 neighbor 192.168.0.2" in namespace "z1"
+    And I wait 20 seconds for BGP to operate
+    Then BGP session in "z1" to "192.168.0.2" should be "Established"
+    # Ingress: no substitute prepend — z2's path arrives as sent.
+    And BGP route in "z1" has "10.0.0.2/32" with "as_path" value "65001"
+    # Egress went back to the bare two-AS form (apply-replace removed
+    # replace-as together with setting no-prepend).
+    And BGP route in "z2" has "10.0.0.1/32" with "as_path" value "64999 65100"
+
+  Scenario: dual-as re-establishes under the global AS after the peer migrates
+    Given the test topology exists
+    When I apply config "z1-dualas.yaml" to namespace "z1"
+    # z2 migrates: its remote-as flips to z1's real global AS. z1's
+    # next OPEN still carries 64999, draws a Bad Peer AS NOTIFICATION,
+    # and the dual-as fallback flips the following OPEN to 65100.
+    And I apply config "z2-globalas.yaml" to namespace "z2"
+    And I wait 20 seconds for BGP to operate
+    # The post-notification redial can park on conservative timers;
+    # clear restarts the dial immediately with the toggled AS.
+    And I run "clear bgp ipv4 neighbor 192.168.0.2" in namespace "z1"
+    And I wait 20 seconds for BGP to operate
+    Then BGP session in "z1" to "192.168.0.2" should be "Established"
+    And BGP session in "z2" to "192.168.0.1" should be "Established"
+    # With the substitute inactive the session behaves unconfigured:
+    # normal real-AS prepend on egress, no ingress prepend.
+    And BGP route in "z2" has "10.0.0.1/32" with "as_path" value "65100"
+    And BGP route in "z1" has "10.0.0.2/32" with "as_path" value "65001"
+    And show command "show bgp neighbors" in namespace "z1" should contain "dual-as fallback active"
+
+  # Pure P2P topology (no bridge): deleting each namespace destroys the
+  # veth pair ends it holds, so only the daemons and namespaces need
+  # teardown.
+  Scenario: Teardown topology
+    Given the test topology exists
+    When I stop zebra-rs in namespace "z1"
+    And I stop zebra-rs in namespace "z2"
+    And I delete namespace "z1"
+    And I delete namespace "z2"
+    Then the test environment should be clean

--- a/zebra-rs/src/bgp/peer.rs
+++ b/zebra-rs/src/bgp/peer.rs
@@ -1646,19 +1646,26 @@ fn close_collision(collision: CollisionConn, code: NotifyCode, sub_code: u8) {
     let notif = NotificationPacket::new(code, sub_code, Vec::new());
     let bytes: BytesMut = notif.into();
     let _ = collision.packet_tx.send(bytes);
-    // Dropping the CollisionConn drops packet_tx (writer task drains
-    // its channel and exits) and the reader/writer task handles
-    // (cancelling them).
-    drop(collision);
+    // Drop packet_tx to close the writer's channel, cancel the
+    // reader, and *detach* the writer so it drains the NOTIFICATION
+    // onto the wire and exits — dropping it would abort the task
+    // with the frame still queued, sending a bare FIN instead.
+    let CollisionConn { reader, writer, .. } = collision;
+    drop(reader);
+    writer.detach();
 }
 
-/// Tear down the primary connection in place (send NOTIFICATION first,
-/// then drop the reader/writer/packet_tx triple).
+/// Tear down the primary connection in place (send NOTIFICATION
+/// first, then release the reader/writer/packet_tx triple — the
+/// writer is detached, not aborted, so the NOTIFICATION drains onto
+/// the wire before the socket closes).
 fn close_primary(peer: &mut Peer, code: NotifyCode, sub_code: u8) {
     peer_send_notification(peer, code, sub_code, Vec::new());
     peer.packet_tx = None;
     peer.task.reader = None;
-    peer.task.writer = None;
+    if let Some(writer) = peer.task.writer.take() {
+        writer.detach();
+    }
     peer.primary_role = None;
     peer.primary_conn_id = None;
 }
@@ -3388,6 +3395,40 @@ mod fsm_idle_hold_tests {
         peer.local_as_dual_fallback = false;
         fsm_bgp_notification(&mut peer, ConnTag::Primary, bad_peer_as());
         assert_eq!(peer.open_local_as(), 64999);
+    }
+
+    /// A connection writer that is *detached* (the teardown path for
+    /// connections with a queued NOTIFICATION) must drain its channel
+    /// onto the wire before the socket closes — the receiver sees the
+    /// frame, then FIN. The abort path used to send a bare FIN with
+    /// the NOTIFICATION still queued, so the peer never learned why
+    /// the session died (and `local-as dual-as` never saw the Bad
+    /// Peer AS that drives its retry).
+    #[tokio::test]
+    async fn detached_writer_drains_queued_frames_before_fin() {
+        use tokio::io::AsyncReadExt;
+        use tokio::net::{TcpListener, TcpStream};
+
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let client = TcpStream::connect(addr).await.unwrap();
+        let (mut server, _) = listener.accept().await.unwrap();
+
+        let (_read_half, write_half) = client.into_split();
+        let (tx, rx) = mpsc::unbounded_channel::<BytesMut>();
+        let writer = peer_start_writer(write_half, rx);
+
+        // Queue a frame, close the channel, detach — mirroring
+        // `close_primary` / the Idle-entry teardown ordering.
+        tx.send(BytesMut::from(&b"NOTIFICATION"[..])).unwrap();
+        drop(tx);
+        writer.detach();
+
+        // read_to_end returns only at FIN, so a successful read of the
+        // full frame proves frame-before-FIN ordering.
+        let mut buf = Vec::new();
+        server.read_to_end(&mut buf).await.unwrap();
+        assert_eq!(&buf[..], b"NOTIFICATION");
     }
 
     /// A KEEPALIVE from a still-parked (unpromoted) collision conn is

--- a/zebra-rs/src/bgp/timer.rs
+++ b/zebra-rs/src/bgp/timer.rs
@@ -226,9 +226,21 @@ pub fn update_timers(peer: &mut Peer) {
             // deliver a Connected event for a session the FSM just
             // tore down (e.g. Event::Stop while connecting).
             peer.task.connect = None;
-            peer.task.writer = None;
-            peer.task.reader = None;
+            // Flush, don't abort, the writer: the transition into
+            // Idle often *just queued* a NOTIFICATION (Bad Peer AS,
+            // FSM error, hold-timer expiry) on its channel. Dropping
+            // packet_tx closes the channel; the detached writer
+            // drains the queue onto the wire and exits, so the FIN
+            // follows the NOTIFICATION. Aborting it here sent the
+            // FIN *instead of* the NOTIFICATION — the peer never
+            // learned why the session died, and a `local-as dual-as`
+            // peer never saw the Bad Peer AS that tells it to retry
+            // under its other AS number.
             peer.packet_tx = None;
+            if let Some(writer) = peer.task.writer.take() {
+                writer.detach();
+            }
+            peer.task.reader = None;
             peer.primary_role = None;
             peer.primary_conn_id = None;
             // A pending §6.8 collision conn is meaningless once the

--- a/zebra-rs/src/context/task.rs
+++ b/zebra-rs/src/context/task.rs
@@ -6,7 +6,9 @@ use tokio::task;
 
 #[derive(Debug)]
 pub struct Task<T> {
-    join_handle: task::JoinHandle<T>,
+    /// `None` after [`Task::detach`] — the abort-on-drop is disarmed
+    /// and the spawned future runs to completion in the background.
+    join_handle: Option<task::JoinHandle<T>>,
 }
 
 impl<T> Task<T> {
@@ -16,14 +18,27 @@ impl<T> Task<T> {
         Fut::Output: Send + 'static,
     {
         Task {
-            join_handle: task::spawn(future),
+            join_handle: Some(task::spawn(future)),
         }
+    }
+
+    /// Consume the handle without aborting the task: the spawned
+    /// future keeps running to completion in the background (tokio
+    /// detaches a task when its `JoinHandle` is dropped). Used where
+    /// a teardown must let the task finish in-flight work — e.g. a
+    /// BGP connection writer draining a queued NOTIFICATION onto the
+    /// wire before the socket closes; aborting it there sent the FIN
+    /// *instead of* the NOTIFICATION.
+    pub fn detach(mut self) {
+        let _ = self.join_handle.take();
     }
 }
 
 impl<T> Drop for Task<T> {
     fn drop(&mut self) {
-        self.join_handle.abort();
+        if let Some(join_handle) = &self.join_handle {
+            join_handle.abort();
+        }
     }
 }
 


### PR DESCRIPTION
## Summary

The `@bgp_local_as` BDD (third slice of the local-as series, after #1386 schema and #1398 wire behavior) — and the core bug its dual-as scenario exposed.

### The bug: NOTIFICATIONs were never reaching the wire

Every "send NOTIFICATION then tear down" path queued the frame on the connection writer's unbounded channel, then the teardown **aborted the writer task** (`Task` aborts on drop) before it flushed. tcpdump showed the OPEN followed by a bare FIN — never the NOTIFICATION. Sender-side counters lie here: they increment at queue time (z2 said `notification sent: 59`, z1 said `rcvd: 0`).

Three sites: `update_timers`' Idle-entry arm (the main FSM funnel), `close_primary`, and `close_collision` (whose comment claimed the writer drains). `reject_connection` was always correct. Consequence beyond protocol hygiene: `local-as dual-as` depends on *receiving* Bad Peer AS to retry under the other AS number, so two zebra-rs nodes could never converge.

### The fix

- `Task::detach()` — Option-wrapped JoinHandle; dropping a tokio handle detaches, the wrapper's abort-on-drop was the problem.
- At the three teardowns: drop `packet_tx` **first** (closes the channel so the drain terminates), then detach the writer — it drains the queued NOTIFICATION onto the wire, exits, and the FIN follows the frame. The reader is still aborted.
- Regression test `detached_writer_drains_queued_frames_before_fin`: socket-pair, `read_to_end` returns the full frame — proving frame-before-FIN ordering.

### The BDD

Two-router topology where z2 still expects the pre-migration AS (`remote-as 64999`, passive so the dial direction is deterministic):

1. **Setup** — Established proves the OPEN carries the substitute (z2 accepts nothing else).
2. **Bare form** — egress `64999 65100`, ingress `64999 65001` (also proves the loop-check budget admits our own ingress prepend), `Local AS substitution` in show.
3. **replace-as** — egress `64999`, ingress unchanged.
4. **no-prepend** — ingress `65001`, egress back to the two-AS form (apply-replace semantics).
5. **dual-as** — z2 flips `remote-as` to 65100; one Bad Peer AS round trip later the session re-establishes under the global AS, paths show no trace of the substitute, `dual-as fallback active` in show.
6. **Teardown** — explicit stop/delete/clean.

## Testing

- `make bgp_local_as`: all 6 scenarios pass against the installed release binary (and the dual-as scenario fails without the drain fix — that's how the bug was found, via tcpdump).
- `cargo test --workspace --exclude bdd` green; `cargo clippy --workspace --all-targets -- -D warnings` clean; `cargo fmt` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)