### PR TITLE
bdd: sync generated feature docs

### DIFF
--- a/bdd/docs/bgp_ipv6_over_v4_session.md
+++ b/bdd/docs/bgp_ipv6_over_v4_session.md
@@ -1,0 +1,27 @@
+# IPv6 NLRI over a v4-addressed BGP session carries a usable next-hop
+
+## Overview
+
+As a network operator
+I want IPv6 routes advertised across an IPv4-addressed BGP session to
+carry a real IPv6 next-hop (RFC 2545 §2), so the receiver can resolve,
+install and forward them — not just display them.
+Regression guard: next-hop-self only fired when the session's local
+end was itself IPv6, so v6 NLRI over v4 transport went out with `::`
+as the MP_REACH next-hop. The receiver kept those routes best-path
+selected but could never install them. The fix sources the next-hop
+from the session interface's global IPv6 (the v4 local end's owning
+interface), and skips the advertisement entirely when no usable v6
+next-hop exists rather than emitting `::`.
+Topology: one dual-stack point-to-point link, eBGP over the IPv4
+addresses with both ipv4 and ipv6 afi-safi negotiated, both sides
+redistributing connected (loopbacks 10.0.0.X/32 + 2001:db8::X/128,
+link 192.168.0.0/30 + 2001:db8:12::/64).
+
+## Test Scenarios
+
+| Scenario | Result |
+|----------|--------|
+| v6 routes arrive with the peer's interface global as next-hop | |
+| The v6 routes resolve, install into the RIB and forward | |
+| Teardown topology | |

--- a/bdd/docs/bgp_neighbor_group.md
+++ b/bdd/docs/bgp_neighbor_group.md
@@ -32,6 +32,7 @@ unit tests in #764.
 - z1-1.yaml: AS 65001, neighbor-group "RR" with remote-as 65002,
 - z1-2.yaml: same shape, but RR's remote-as is 65099 (wrong) —
 - z2-1.yaml: plain AS 65002 peer to 192.168.0.1 remote-as 65001.
+- z1-3.yaml / z2-2.yaml: GTSM round — z1 inherits ttl-security
 
 ## Test Scenarios
 
@@ -41,4 +42,5 @@ unit tests in #764.
 | Inheritance — peer with only a neighbor-group reference establishes | |
 | Reactive sweep — changing the group's remote-as drops the session | |
 | Reactive sweep — restoring the group's remote-as brings it back | |
+| Inherited ttl-security — group GTSM interoperates with a per-neighbor GTSM far end | |
 | Teardown topology | |

--- a/bdd/docs/bgp_peer_down_cleanup.md
+++ b/bdd/docs/bgp_peer_down_cleanup.md
@@ -1,0 +1,27 @@
+# BGP session loss withdraws every AFI/SAFI the peer contributed
+
+## Overview
+
+As a network operator
+I want a BGP session that leaves Established to take all of that
+neighbour's routes with it — across every negotiated AFI/SAFI — so
+that traffic never follows a route whose only source is a dead peer.
+Regression guard: `route_clean` (the leaving-Established hook) used
+to cover IPv4 unicast, VPNv4, EVPN and labeled-unicast but skipped
+IPv6 unicast entirely — a session drop left the peer's IPv6 routes
+best-path-selected forever, while the same peer's IPv4 routes were
+correctly withdrawn. The fix also swept the same gap for VPNv6,
+Flowspec, BGP-LS and SR Policy; this feature pins the dual-stack
+unicast behaviour end to end.
+Topology: one dual-stack point-to-point link, eBGP over the IPv4
+addresses with both ipv4 and ipv6 afi-safi negotiated, both sides
+redistributing connected (loopbacks 10.0.0.X/32 + 2001:db8::X/128).
+
+## Test Scenarios
+
+| Scenario | Result |
+|----------|--------|
+| Establish the dual-stack session and learn both AFIs | |
+| Killing the peer withdraws IPv4 AND IPv6 routes | |
+| The session re-establishes and both AFIs are re-learned | |
+| Teardown topology | |

--- a/bdd/docs/bgp_table_map.md
+++ b/bdd/docs/bgp_table_map.md
@@ -1,0 +1,48 @@
+# BGP table-map gates and rewrites RIB installs without touching the Loc-RIB
+
+## Overview
+
+As a network operator
+I want `router bgp afi-safi ipv4 table-map <policy>` to filter and
+rewrite BGP best paths at the point they are installed into the
+kernel RIB, while the BGP table itself (and what peers are
+advertised) stays complete — FRR's table-map semantics.
+The exercise: z1 advertises three prefixes. z2 binds table-map TMAP:
+entry 10 denies 1.1.1.1/32, entry 20 permits 2.2.2.2/32 with
+`set med 50` (MED lands in the kernel route metric), entry 30
+permits the rest. All three prefixes must stay visible in z2's BGP
+table throughout; only the kernel routes move. Live policy edits
+must resync the FIB without a session clear, a rebind to a
+nonexistent policy must deny every install (FRR parity), and
+deleting the table-map must restore unfiltered installs.
+
+## Test Topology
+
+```
+  ┌─────────────────────────────────────────┐
+  │                   br0                   │
+  └─────────────┬───────────────┬───────────┘
+                │               │
+           ┌────┴────┐     ┌────┴────┐
+           │   z1    │     │   z2    │
+           │ AS65001 │     │ AS65002 │
+           │192.168. │     │192.168. │
+           │  0.1/24 │     │  0.2/24 │
+           └─────────┘     └─────────┘
+```
+
+## Config Files
+
+- z1.yaml: AS 65001, advertises 1.1.1.1/32 + 2.2.2.2/32 + 3.3.3.3/32.
+- z2.yaml: prefix-set DENY = { 1.1.1.1/32 }, MED = { 2.2.2.2/32 };
+- z2-deny-more.yaml: DENY = { 1.1.1.1/32, 3.3.3.3/32 } (added).
+
+## Test Scenarios
+
+| Scenario | Result |
+|----------|--------|
+| Setup topology and verify install-time filter and MED rewrite | |
+| Editing the referenced policy resyncs the FIB without a session reset | |
+| Rebinding to a nonexistent policy denies every install | |
+| Deleting the table-map restores unfiltered installs | |
+| Teardown topology | |

--- a/bdd/docs/bgp_unnumbered_afi_safi.md
+++ b/bdd/docs/bgp_unnumbered_afi_safi.md
@@ -1,0 +1,32 @@
+# BGP neighbor-group afi-safi inheritance on an IPv6 unnumbered iBGP session
+
+## Overview
+
+As a network operator
+I want an interface-keyed (IPv6 unnumbered) neighbor to inherit its
+enabled address families from a referenced neighbor-group, so that a
+fleet of unnumbered peers shares one afi-safi definition — and a
+later change to the group (disable IPv4) takes effect at the next
+capability negotiation (`clear bgp`), exactly like the per-neighbor
+`afi-safi <name> enabled` knob.
+Configuration shape under test (flattened `neighbor-group` list —
+no `neighbor-groups` container level):
+Test Topology (point-to-point veth, link-local only — no global addrs,
+both routers in AS 65001, `remote-as internal` = iBGP):
+```
+```
+
+## Config Files
+
+- z1-base.yaml / z2-base.yaml: bare `router bgp` block (two-step
+- z1-full.yaml / z2-full.yaml: RA on, `neighbor-group dynamic` with
+- z1-v4off.yaml / z2-v4off.yaml: flip the group's ipv4 opinion to
+
+## Test Scenarios
+
+| Scenario | Result |
+|----------|--------|
+| Setup topology | |
+| Group-inherited IPv4+IPv6 capabilities negotiate and both families exchange routes | |
+| Disabling IPv4 in the group applies on clear — IPv6-only session remains | |
+| Teardown topology | |

--- a/bdd/docs/bgp_unnumbered_neighbor.md
+++ b/bdd/docs/bgp_unnumbered_neighbor.md
@@ -5,26 +5,23 @@
 As a network operator running BGP over IPv6-only point-to-point links
 I want a peer keyed by its outbound interface (no configured remote
 address) to be discovered from the neighbour's Router Advertisement,
-establish a session over the link-local, and carry IPv4 routes via
-RFC 8950 Extended Next Hop Encoding.
+establish a session over the link-local, carry IPv4 routes via
+RFC 8950 Extended Next Hop Encoding, and forward IPv4 traffic
+through the kernel FIB over the IPv6 link-local next-hop (RFC 5549
+style `via inet6 fe80::.. dev i1`).
 This exercises the full unnumbered path end-to-end through the
 YAML/YANG/CLI stack — ND RA send + receive, NeighborDiscovered →
 interface-keyed Peer materialization, the active-connect over
 fe80::%ifindex AND the passive accept that binds an inbound
 link-local connection back to its interface-keyed peer (both ends
 connect actively and accept passively, so a collision must resolve
-into a single Established session), and ENHE-carried IPv4 routes.
-
-## Test Topology
-
+into a single Established session), ENHE-carried IPv4 routes, and
+the v4-over-v6 dataplane: each router owns an IPv4 LAN prefix on a
+dummy interface, learns the other's via ENHE, installs it in the
+kernel with the v6 link-local gateway, and pings across.
+Test Topology (P2P veth, link-local only — no v4/global-v6 addrs on
+i1; the LAN prefixes live on dummy interfaces):
 ```
-        (i1)                                   (i1)
-    ┌────┴────┐                            ┌────┴────┐
-    │   z1    │────────── P2P ─────────────│   z2    │
-    │ AS65001 │       fe80:: <-> fe80::    │ AS65002 │
-    │ id 1.1. │                            │ id 2.2. │
-    │   1.1   │                            │   2.2   │
-    └─────────┘                            └─────────┘
 ```
 
 ## Config Files
@@ -36,7 +33,7 @@ Note: the interface-keyed peer's remote address is a kernel-assigned
 link-local that the scenario can't name, so the session is asserted
 with the address-agnostic "BGP session in namespace … should
 eventually be …" step (it reads `show bgp neighbors`, which lists
-interface-keyed peers).
+interface-keyed peers), and the FIB assertion pins the substring
 
 ## Test Scenarios
 
@@ -44,5 +41,7 @@ interface-keyed peers).
 |----------|--------|
 | Setup topology | |
 | RA discovery establishes the unnumbered session and exchanges IPv4 routes | |
+| IPv4 LAN prefixes forward over the IPv6 link-local next-hop | |
+| The unnumbered peer is listed in summaries and addressable by interface name | |
 | Removing the interface-neighbor tears the session down | |
 | Teardown topology | |

--- a/bdd/docs/bgp_unnumbered_summary.md
+++ b/bdd/docs/bgp_unnumbered_summary.md
@@ -1,0 +1,25 @@
+# BGP unnumbered neighbor visible in summaries before any session
+
+## Overview
+
+As a network operator bringing up BGP over IPv6-only point-to-point
+links, I want a configured `interface-neighbor` to appear in
+`show bgp summary` (as Idle) even when the remote node has never been
+reachable, so that mis-cabled or not-yet-deployed neighbors are
+diagnosable from the summary instead of silently absent.
+Interface-keyed peers are normally materialized only when the
+remote's Router Advertisement surfaces its link-local. This feature
+pins the dormant-materialization path: config + link knowledge alone
+must create the operator-visible peer (FRR behaves the same way).
+Test Topology (point-to-point veth; z2 exists only to hold the other
+veth end — it never runs zebra-rs, so z1 never sees an RA):
+```
+```
+
+## Test Scenarios
+
+| Scenario | Result |
+|----------|--------|
+| Setup topology | |
+| A never-connected interface-neighbor is listed as a dormant Idle peer | |
+| Teardown topology | |

--- a/bdd/docs/bgp_v6_table_map.md
+++ b/bdd/docs/bgp_v6_table_map.md
@@ -1,0 +1,41 @@
+# BGP table-map for IPv6 unicast gates RIB installs per address family
+
+## Overview
+
+As a network operator
+I want `router bgp afi-safi ipv6 table-map <policy>` to filter and
+rewrite IPv6 best paths at the kernel-install boundary — with the
+same semantics as the IPv4 table-map, and strictly scoped to its
+own address family: a v6 binding must never touch v4 installs.
+The exercise: a single v4 BGP session carries both families
+(ipv4 + ipv6 afi-safi). z1 advertises three v6 prefixes and one v4
+prefix. z2 binds table-map TMAP6 under `afi-safi ipv6` only:
+entry 10 denies 2001:db8:100::/48, entry 20 permits
+2001:db8:200::/48 with `set med 50`, entry 30 permits the rest.
+All three v6 prefixes stay visible in `show bgp ipv6` throughout;
+only the kernel routes move — and the v4 route installs untouched.
+
+## Test Topology
+
+```
+  ┌─────────────────┐  192.168.0.0/30   ┌─────────────────┐
+  │       z1        │  2001:db8:12::/64 │       z2        │
+  │     AS65001     ├───────────────────┤     AS65002     │
+  │ .1 / 12::1      │                   │ .2 / 12::2      │
+  └─────────────────┘                   └─────────────────┘
+```
+
+## Config Files
+
+- z1.yaml: AS 65001, networks 2001:db8:100::/48 + 2001:db8:200::/48
+- z2.yaml: prefix-set DENY6 = { 2001:db8:100::/48 },
+- z2-deny-more.yaml: DENY6 = { 2001:db8:100::/48,
+
+## Test Scenarios
+
+| Scenario | Result |
+|----------|--------|
+| Setup topology and verify v6 install filter, MED rewrite, and v4 isolation | |
+| Editing the referenced policy resyncs the v6 FIB without a session reset | |
+| Deleting the v6 table-map restores unfiltered v6 installs | |
+| Teardown topology | |

--- a/bdd/docs/ecmp_bfd_evict.md
+++ b/bdd/docs/ecmp_bfd_evict.md
@@ -1,0 +1,41 @@
+# ECMP leg eviction on BFD failure
+
+## Overview
+
+As a network operator
+I want a BFD-detected failure of one ECMP leg (the link stays up,
+so the kernel cannot see it) to evict that leg from the kernel
+nexthop groups in one atomic replace per group, BEFORE SPF
+reconvergence rewrites the routes — phase 5 of
+docs/design/nexthop-protect-kernel-failover.md.
+TI-LFA deliberately computes no repair for SPF-level ECMP
+destinations: the surviving legs ARE the protection. This feature
+proves that holds for the link-up failure class too — without the
+eviction, the kernel would keep hashing flows onto the dead leg
+until SPF finishes.
+Like the switchover, the eviction is observable only in the daemon
+log ("evicted failed leg from N ECMP group(s)" is emitted ONLY when
+at least one group shrank): SPF supersedes its kernel state within
+milliseconds, by design.
+
+## Test Topology
+
+```
+        s (10.0.0.1)
+       / \
+     s-a  s-b          BFD runs on the s<->a leg only.
+     /      \
+    a        b
+     \      /
+     a-d  b-d
+       \ /
+        d (10.0.0.4)
+```
+
+## Test Scenarios
+
+| Scenario | Result |
+|----------|--------|
+| Build the diamond and confirm ECMP, BFD, and reachability | |
+| BFD-down on one leg evicts it from the kernel ECMP group | |
+| Teardown topology | |

--- a/bdd/docs/isis_tilfa.md
+++ b/bdd/docs/isis_tilfa.md
@@ -44,10 +44,13 @@ through the r-plane rather than a plain loop-free alternate.
 | SR-MPLS labels and a TI-LFA repair are installed on the source | |
 | Source reaches the destination over the primary path | |
 | Fast-reroute survives the primary link failure (s-n1) | |
+| TI-LFA compute-mode aggressive computes the same repair in parallel | |
+| TI-LFA compute-mode sharding bounds parallelism and still protects | |
 | no-php sets the P (no-PHP) flag and makes the penultimate hop swap | |
 | no-local-prefix-sid suppresses only the local Prefix-SID in the LFIB | |
 | Deleting segment-routing mpls clears all MPLS ILM entries | |
 | lsp-mtu above the link MTU is flagged on the source's interfaces | |
 | lsp-mtu above the link MTU drops s's LSP so n1 never learns the new prefix | |
 | Lowering lsp-mtu under the link MTU lets s's LSP flood to n1 | |
+| Promoted backup actually forwards over the SR-MPLS repair | |
 | Teardown topology | |

--- a/bdd/docs/isis_tilfa_bfd.md
+++ b/bdd/docs/isis_tilfa_bfd.md
@@ -1,0 +1,46 @@
+# IS-IS TI-LFA kernel-side fast-reroute on BFD failure
+
+## Overview
+
+As a network operator
+I want a BFD-detected primary failure (the link stays up, so the
+kernel cannot see it) to rewire the pre-installed protection
+indirection groups onto their TI-LFA repairs in one atomic kernel
+operation per failed adjacency, BEFORE SPF reconvergence rewrites
+the routes — phase 3 of docs/design/nexthop-protect-kernel-failover.md.
+The topology is the isis_tilfa SR-MPLS ring with BFD enabled on the
+protected s<->n1 adjacency. BFD-down is induced by dropping inbound
+UDP/3784 in namespace s: the veth link stays up and IIHs (ISO L2
+PDUs, not IP) keep flowing, so the teardown is provably BFD's doing
+— the exact failure class the kernel's autonomous link-down path
+cannot cover.
+The switchover itself is observable only in the daemon log (the
+"rewired N protection group(s) onto repairs" line is emitted ONLY
+when at least one group actually moved): its kernel state is
+superseded within milliseconds by the post-convergence SPF routes,
+which is by design — the switchover is a bridge, not a steady state.
+
+## Test Topology
+
+```
+                 s (10.0.0.1)
+             1 / 1 \      \ 1000
+              n1    n2     n3        s-n1 carries BFD; protecting it
+          1 / |1 \1  \1     \1000    requires an SR repair through
+       d ─┘ 1 |   \    \      \      the r-plane (no plain LFA).
+    (10.0.0.8)│    \1000\      \
+          1 \ │     r1───────── (r1-n3 1000)
+             r3    /  \1000
+          1000\   /1   \(r1-r2 1000)
+               r2 ──────┘
+                 \1000
+                  r3 (r3-d 1)
+```
+
+## Test Scenarios
+
+| Scenario | Result |
+|----------|--------|
+| Build the topology and confirm adjacency, BFD, and repairs | |
+| BFD-down with the link up triggers the kernel-side switchover | |
+| Teardown topology | |

--- a/bdd/docs/isis_tilfa_srv6_classic.md
+++ b/bdd/docs/isis_tilfa_srv6_classic.md
@@ -1,4 +1,4 @@
-# IS-IS TI-LFA fast-reroute over SRv6 with BGP L3 service traffic
+# IS-IS TI-LFA fast-reroute over SRv6 classic (full) SIDs with BGP L3 service traffic
 
 ## Overview
 
@@ -10,12 +10,15 @@ End.X SIDs, SRH-inserted), so that when the primary link fails the
 source still reaches the destination — including BGP-carried SRv6
 service traffic between LAN segments behind the source and the
 destination.
-This is the SRv6 sibling of @isis_tilfa (same eight-router topology
-and metrics, IPv6-only). Differences from the SR-MPLS version:
-- every IS-IS circuit is `network-type point-to-point`;
-- `segment-routing srv6 locator LOCx` replaces `segment-routing
-- the TI-LFA repair resolves to an SRv6 SID list — End SID of the
-- s and d each have a stub LAN segment (a host namespace e1 / e2);
+This is the classic-SID sibling of @tilfa_srv6 (same eight-router
+topology, metrics and addressing). The only configuration difference
+is the locator: `behavior usid` is omitted, so every router's
+locator fcbb:bbbb:X::/48 allocates SIDs in the classic RFC 8986
+full-SID layout instead of the RFC 9800 NEXT-C-SID (micro-SID)
+format. Observable consequences this feature pins:
+- `show segment-routing srv6 sid` lists the node SID as `End` and
+- the End SID is the locator network address installed as a /128
+- everything else is unchanged: the repair is still an SRH
 The metrics are tuned so a simple LFA is impossible: s reaches d via
 s-n1 (cost 2); protecting the s-n1 link requires an SR repair tunnel
 through the r-plane rather than a plain loop-free alternate.
@@ -45,8 +48,8 @@ through the r-plane rather than a plain loop-free alternate.
 
 | Scenario | Result |
 |----------|--------|
-| Build the SRv6 TI-LFA topology and confirm IS-IS + BGP | |
-| SRv6 End/End.X SIDs exist and a TI-LFA SRv6 repair is installed | |
+| Build the classic-SID SRv6 TI-LFA topology and confirm IS-IS + BGP | |
+| Classic SRv6 End/End.X SIDs exist and a TI-LFA SRv6 repair is installed | |
 | BGP carries the LAN prefixes as SRv6 End.DT6 service routes | |
 | Fast-reroute survives the primary link failure (s-n1) | |
 | Promoted backup actually forwards over the SRv6 repair | |

--- a/bdd/docs/ospfv2_bfd_frr.md
+++ b/bdd/docs/ospfv2_bfd_frr.md
@@ -1,0 +1,28 @@
+# OSPFv2 TI-LFA kernel-side fast-reroute on BFD failure
+
+## Overview
+
+As a network operator
+I want a BFD-detected primary failure (the link stays up, so the
+kernel cannot see it) to rewire the pre-installed protection
+indirection groups onto their TI-LFA repairs in one atomic kernel
+operation per failed adjacency, BEFORE SPF reconvergence rewrites
+the routes — phase 4 of docs/design/nexthop-protect-kernel-failover.md,
+the OSPFv2 sibling of isis_tilfa_bfd.feature.
+The topology is the ospfv2_tilfa SR-MPLS ring with BFD
+enabled on the protected s<->n1 adjacency. BFD-down is induced by
+dropping inbound UDP/3784 in namespace s: the veth link stays up and
+hellos keep flowing, so the teardown is provably BFD's doing — the
+failure class the kernel's autonomous link-down flush cannot cover.
+The switchover is observable only in the daemon log ("rewired N
+protection group(s) onto repairs" is emitted ONLY when at least one
+group moved): its kernel state is superseded within milliseconds by
+the post-convergence SPF routes, by design.
+
+## Test Scenarios
+
+| Scenario | Result |
+|----------|--------|
+| Build the topology and confirm adjacency, BFD, and repairs | |
+| BFD-down with the link up triggers the kernel-side switchover | |
+| Teardown topology | |

--- a/bdd/docs/ospfv2_tilfa.md
+++ b/bdd/docs/ospfv2_tilfa.md
@@ -1,0 +1,51 @@
+# OSPFv2 TI-LFA fast-reroute over SR-MPLS
+
+## Overview
+
+As a network operator
+I want eight zebra-rs instances running OSPFv2 with SR-MPLS (RFC 8665)
+and TI-LFA (RFC 9490) to pre-compute a topology-independent loop-free
+repair for the source's primary path, so that when the primary link
+fails the source still reaches the destination over the SR repair /
+post-convergence path.
+IPv4 OSPFv2 sibling of `isis_tilfa.feature` — the same eight-node
+RFC 9855 §5 topology, addressing, and metrics, with the v2 SR
+machinery (Extended-Prefix / Extended-Link Opaque LSAs instead of
+IS-IS sub-TLVs). All links are point-to-point; every router enables
+`segment-routing mpls` and `fast-reroute ti-lfa`. Loopback
+Prefix-SIDs index 100..800 resolve against the default SRGB (base
+16000). Adjacency-SIDs are NOT configured: each router allocates
+one per Full adjacency out of its SRLB (base 15000) automatically
+and advertises it as a local (V|L) Adj-SID — IS-IS-parity dynamic
+allocation — and the repair encodes its mid-path hops as those
+Adj-SID segments.
+The metrics are tuned so a simple LFA is impossible: s reaches d via
+s-n1 (cost 2); the only other neighbours (n2, n3) are equidistant /
+expensive, so protecting the s-n1 first hop requires an SR repair
+tunnel through the r-plane rather than a plain loop-free alternate.
+OSPFv2 TI-LFA excludes the primary first-hop *vertex* (node
+protection) and skips SPF-level ECMP destinations (the remaining
+legs already protect the prefix), so repairs exist exactly for r2,
+r3 and d — the single-nexthop destinations behind n1. Per RFC 9855
+§5.3, the repair for d is <Node-SID(r1), Adj-SID(r1-r2),
+Adj-SID(r2-r3)> via first-hop n2: labels [16500, 15xxx, 15yyy] —
+the Adj-SID values are whatever r1 / r2 carved from their SRLBs.
+Test Topology (metric shown where != 1; loopback 10.0.0.X / SID X00
+/ router-id 10.0.0.X):
+```
+```
+
+## Test Scenarios
+
+| Scenario | Result |
+|----------|--------|
+| Build the TI-LFA topology and confirm adjacencies + routes | |
+| SR-MPLS labels and a TI-LFA repair are installed on the source | |
+| Source reaches the destination over the primary path | |
+| Fast-reroute survives the primary link failure (s-n1) | |
+| TI-LFA compute-mode aggressive computes the same repair in parallel | |
+| TI-LFA compute-mode sharding bounds parallelism and still protects | |
+| Promoted backup actually forwards over the SR-MPLS repair | |
+| Disabling fast-reroute clears the repair-list | |
+| Deleting segment-routing mpls clears all MPLS ILM entries | |
+| Teardown topology | |

--- a/bdd/docs/ospfv3_bfd_frr.md
+++ b/bdd/docs/ospfv3_bfd_frr.md
@@ -1,0 +1,28 @@
+# OSPFv3 TI-LFA kernel-side fast-reroute on BFD failure
+
+## Overview
+
+As a network operator
+I want a BFD-detected primary failure (the link stays up, so the
+kernel cannot see it) to rewire the pre-installed protection
+indirection groups onto their TI-LFA repairs in one atomic kernel
+operation per failed adjacency, BEFORE SPF reconvergence rewrites
+the routes — phase 4 of docs/design/nexthop-protect-kernel-failover.md,
+the OSPFv3 sibling of isis_tilfa_bfd.feature.
+The topology is the ospfv3_tilfa SR-MPLS ring with BFD
+enabled on the protected s<->n1 adjacency. BFD-down is induced by
+dropping inbound UDP/3784 in namespace s: the veth link stays up and
+hellos keep flowing, so the teardown is provably BFD's doing — the
+failure class the kernel's autonomous link-down flush cannot cover.
+The switchover is observable only in the daemon log ("rewired N
+protection group(s) onto repairs" is emitted ONLY when at least one
+group moved): its kernel state is superseded within milliseconds by
+the post-convergence SPF routes, by design.
+
+## Test Scenarios
+
+| Scenario | Result |
+|----------|--------|
+| Build the topology and confirm adjacency, BFD, and repairs | |
+| BFD-down with the link up triggers the kernel-side switchover | |
+| Teardown topology | |

--- a/bdd/docs/ospfv3_srv6.md
+++ b/bdd/docs/ospfv3_srv6.md
@@ -1,0 +1,33 @@
+# OSPFv3 SRv6 locator origination (RFC 9513)
+
+## Overview
+
+As a network operator
+I want an OSPFv3 router configured with `segment-routing srv6
+locator <name>` to resolve the locator from the global registry,
+install its End/uN SID, and originate the SRv6 Locator LSA
+(function code 42) plus the SRv6 Capabilities TLV, so that SRv6
+state floods through the area exactly like the IS-IS sibling.
+Phase 2 of `docs/design/ospfv3-srv6-plan.md`: origination only —
+receive-side locator routes and TI-LFA SRv6 repairs are later
+phases, so reachability assertions stay out of scope here.
+
+## Test Topology
+
+```
+   z1 ──────────────── z2
+   i2  2001:db8:12::/64  i1
+   lo 2001:db8::1/128    lo 2001:db8::2/128
+   LOC1 fcbb:bbbb:1::/48 (usid)   LOC2 2001:db8:f:2::/64 (classic)
+```
+
+## Test Scenarios
+
+| Scenario | Result |
+|----------|--------|
+| Build the topology and confirm SRv6 LSA origination | |
+| The locator's End/uN SID is installed in the SID registry | |
+| Each Full adjacency carves an End.X SID with a global nexthop | |
+| Remote locators are reachable via the SRv6 Locator LSA | |
+| Removing the locator flushes the LSA and withdraws the SID | |
+| Teardown topology | |

--- a/bdd/docs/ospfv3_tilfa.md
+++ b/bdd/docs/ospfv3_tilfa.md
@@ -1,0 +1,66 @@
+# OSPFv3 TI-LFA fast-reroute over SR-MPLS
+
+## Overview
+
+As a network operator
+I want eight zebra-rs instances running OSPFv3 with SR-MPLS (RFC 8666)
+and TI-LFA (RFC 9490) to pre-compute a topology-independent loop-free
+repair for the source's primary path, so that when the primary link
+fails the source still reaches the destination over the SR repair /
+post-convergence path.
+IPv6 OSPFv3 sibling of `ospfv2_tilfa.feature` / `isis_tilfa.feature`
+— the same eight-node RFC 9855 §5 topology and metrics, expressed
+through the (new) per-interface `cost` knob, with the v3 SR
+machinery (RFC 8362 E-LSAs instead of v2's Opaque LSAs). All links
+are point-to-point; every router enables `segment-routing mpls` and
+`fast-reroute ti-lfa`. Loopback Prefix-SIDs index 100..800 resolve
+against the default SRGB (base 16000). Adjacency-SIDs are NOT
+configured: each router allocates one per Full adjacency out of its
+SRLB (base 15000) automatically and advertises it as a local (V|L)
+Adj-SID — IS-IS-parity dynamic allocation — and the repair encodes
+its mid-path hops as those Adj-SID segments.
+The metrics are tuned so a simple LFA is impossible: s reaches d via
+s-n1 (cost 2); the only other neighbours (n2, n3) are equidistant /
+expensive, so protecting the s-n1 first hop requires an SR repair
+tunnel through the r-plane rather than a plain loop-free alternate.
+OSPFv3 TI-LFA excludes the primary first-hop *vertex* (node
+protection) and skips SPF-level ECMP destinations (the remaining
+legs already protect the prefix), so repairs exist exactly for r2,
+r3 and d — the single-nexthop destinations behind n1. Per RFC 9855
+§5.3, the repair for d is <Node-SID(r1), Adj-SID(r1-r2),
+Adj-SID(r2-r3)> via first-hop n2: labels [16500, 15xxx, 15yyy] —
+the Adj-SID values are whatever r1 / r2 carved from their SRLBs.
+
+## Test Topology
+
+```
+                 s (2001:db8::1)
+             1 / 1 \      \ 1000
+              n1    n2     n3
+          1 / |1 \1  \1     \1000
+       d ─┘ 1 |   \    \      \
+ (2001:db8::8)│    \1000\      \
+          1 \ │     r1───────── (r1-n3 1000)
+             r3    /  \1000
+          1000\   /1   \(r1-r2 1000)
+               r2 ──────┘
+                 \1000
+                  r3 (r3-d 1)
+    s-n1 1  s-n2 1  s-n3 1000   n1-r1 1  n2-r1 1  n3-r1 1000
+    n1-r2 1 r1-r2 1000 r2-r3 1000  n1-d 1  r3-d 1
+```
+
+## Test Scenarios
+
+| Scenario | Result |
+|----------|--------|
+| Build the TI-LFA topology and confirm adjacencies + routes | |
+| SR-MPLS labels and a TI-LFA repair are installed on the source | |
+| Source reaches the destination over the primary path | |
+| Fast-reroute survives the primary link failure (s-n1) | |
+| TI-LFA compute-mode aggressive computes the same repair in parallel | |
+| TI-LFA compute-mode sharding bounds parallelism and still protects | |
+| Promoted backup actually forwards over the SR-MPLS repair | |
+| Disabling fast-reroute clears the repair-list | |
+| Deleting segment-routing mpls clears all MPLS ILM entries | |
+| Teardown topology | |

--- a/bdd/docs/ospfv3_tilfa_srv6.md
+++ b/bdd/docs/ospfv3_tilfa_srv6.md
@@ -1,0 +1,48 @@
+# OSPFv3 TI-LFA fast-reroute over SRv6
+
+## Overview
+
+As a network operator
+I want eight zebra-rs instances running OSPFv3 with SRv6 locators
+(RFC 9513) and TI-LFA (RFC 9490) to pre-compute a topology-
+independent repair for the source's primary path as an SRv6 SID
+list — End/uN of the P-node plus uA hops, NEXT-C-SID-compressed and
+SRH-inserted — so that when the primary link fails the source still
+reaches the destination.
+Phases 5+6 of `docs/design/ospfv3-srv6-plan.md`: the OSPFv3 sibling
+of `isis_tilfa_srv6.feature` (same eight-router RFC 9855 §5
+topology and metrics as `ospfv3_tilfa.feature`, with the SR-MPLS
+machinery replaced by uSID locators fcbb:bbbb:X::/48). Repairs ride
+the carriers validated for IS-IS in #1364, the End.X kernel entries
+carry neighbor-global nexthops per #1361, and the promoted-backup
+scenario proves the repair dataplane genuinely forwards — the
+coverage rule every TI-LFA feature carries since #1361.
+
+## Test Topology
+
+```
+                 s (2001:db8::1)
+             1 / 1 \      \ 1000
+              n1    n2     n3
+          1 / |1 \1  \1     \1000
+       d ─┘ 1 |   \    \      \
+ (2001:db8::8)│    \1000\      \
+          1 \ │     r1───────── (r1-n3 1000)
+             r3    /  \1000
+          1000\   /1   \(r1-r2 1000)
+               r2 ──────┘
+                 \1000
+                  r3 (r3-d 1)
+    s-n1 1  s-n2 1  s-n3 1000   n1-r1 1  n2-r1 1  n3-r1 1000
+    n1-r2 1 r1-r2 1000 r2-r3 1000  n1-d 1  r3-d 1
+```
+
+## Test Scenarios
+
+| Scenario | Result |
+|----------|--------|
+| Build the TI-LFA topology and confirm adjacencies + SRv6 | |
+| SRv6 SIDs exist and a TI-LFA SRv6 repair is installed | |
+| Fast-reroute survives the primary link failure (s-n1) | |
+| Promoted backup actually forwards over the SRv6 repair | |
+| Teardown topology | |

--- a/bdd/docs/ospfv3_tilfa_srv6_classic.md
+++ b/bdd/docs/ospfv3_tilfa_srv6_classic.md
@@ -1,0 +1,47 @@
+# OSPFv3 TI-LFA fast-reroute over SRv6 classic (full) SIDs
+
+## Overview
+
+As a network operator
+I want eight zebra-rs instances running OSPFv3 with classic
+(RFC 8986 full-SID) SRv6 locators and TI-LFA (RFC 9490) to
+pre-compute a topology-independent repair as an SRv6 SID list, so
+that when the primary link fails the source still reaches the
+destination.
+This is the classic-SID sibling of `ospfv3_tilfa_srv6.feature`
+(same RFC 9855 §5 topology and costs). The only configuration
+difference is the locator: `behavior usid` is omitted, so SIDs use
+the classic RFC 8986 full-SID layout. Observable consequences this
+feature pins:
+- `show segment-routing srv6 sid` lists `End` / `End.X` — never the
+- the repair SID list does NOT compress: each segment is a full
+- everything else is unchanged: H.Insert encap, neighbor-global
+
+## Test Topology
+
+```
+                 s (2001:db8::1)
+             1 / 1 \      \ 1000
+              n1    n2     n3
+          1 / |1 \1  \1     \1000
+       d ─┘ 1 |   \    \      \
+ (2001:db8::8)│    \1000\      \
+          1 \ │     r1───────── (r1-n3 1000)
+             r3    /  \1000
+          1000\   /1   \(r1-r2 1000)
+               r2 ──────┘
+                 \1000
+                  r3 (r3-d 1)
+    s-n1 1  s-n2 1  s-n3 1000   n1-r1 1  n2-r1 1  n3-r1 1000
+    n1-r2 1 r1-r2 1000 r2-r3 1000  n1-d 1  r3-d 1
+```
+
+## Test Scenarios
+
+| Scenario | Result |
+|----------|--------|
+| Build the classic-SID TI-LFA topology and confirm adjacencies | |
+| Classic End/End.X SIDs exist and the repair is uncompressed | |
+| Fast-reroute survives the primary link failure (s-n1) | |
+| Promoted backup actually forwards over the classic SRv6 repair | |
+| Teardown topology | |


### PR DESCRIPTION
## Summary

`(cd bdd; make docs)` and commit the result — `bdd/docs/` had drifted from `bdd/tests/features/`:

- **4 stale docs regenerated**: `bgp_neighbor_group`, `bgp_unnumbered_neighbor`, `isis_tilfa`, `isis_tilfa_srv6` — their features gained scenarios (e.g. the TI-LFA compute-mode additions) after the docs were committed.
- **16 missing docs added**: features whose generated doc was never committed (`bgp_table_map`, `bgp_v6_table_map`, `bgp_peer_down_cleanup`, `bgp_ipv6_over_v4_session`, the `bgp_unnumbered_*` pair, `ecmp_bfd_evict`, `isis_tilfa_bfd`, `isis_tilfa_srv6_classic`, and the `ospfv2`/`ospfv3` BFD + TI-LFA + SRv6 family).

All content is `docs/feature2md.sh` output — no hand-written changes.

## Testing

Generated-docs-only change; no code touched. `make docs` re-run is idempotent (clean tree afterward).

🤖 Generated with [Claude Code](https://claude.com/claude-code)