### PR TITLE
bgp: fix dead incremental IPv6 unicast advertise + no-op v6 redistribute withdraw

### DIFF
--- a/bdd/docs/bgp_v6_incremental.md
+++ b/bdd/docs/bgp_v6_incremental.md
@@ -1,0 +1,30 @@
+# IPv6 unicast routes appearing after session establishment are advertised
+
+## Overview
+
+As a network operator
+I want an IPv6 route that shows up while a BGP session is already
+Established to be advertised to that peer, so convergence does not
+depend on session resets.
+Regression guard: the incremental v6 advertise path
+(`route_advertise_to_peers_v6`) emits reach only through the
+per-update-group `cache_ipv6`, but `(Ip6, Unicast)` was never in
+`TRACKED_AFI_SAFIS`, so `update_group::attach` never enrolled any
+peer and the group lookup always missed — incremental v6 reach was
+silently dropped. Only the initial `route_sync_ipv6` dump at
+establishment delivered v6 routes, which is why every pre-existing
+feature (config applied before the session comes up) kept passing.
+Topology: one dual-stack point-to-point link, eBGP over the IPv4
+addresses with both ipv4 and ipv6 afi-safi negotiated, both sides
+redistributing connected. adv-interval is pinned to 1s. The route
+under test is injected via a dummy interface created only AFTER the
+session is verified Established, so it can only reach the peer
+through the incremental path.
+
+## Test Scenarios
+
+| Scenario | Result |
+|----------|--------|
+| A connected v6 prefix added after Established reaches the peer | |
+| Withdrawing the prefix after Established removes it from the peer | |
+| Teardown topology | |

--- a/bdd/tests/configs/bgp_v6_incremental/z1.yaml
+++ b/bdd/tests/configs/bgp_v6_incremental/z1.yaml
@@ -1,0 +1,40 @@
+# Originator side. adv-interval is pinned to 1s on both peer types so
+# the post-establish incremental advertisement (the subject of the
+# test) flushes promptly — the eBGP default of 30s would outlive the
+# scenario's wait.
+interface:
+- if-name: lo
+  ipv4:
+    address: 10.0.0.1/32
+  ipv6:
+    address: 2001:db8::1/128
+- if-name: z1-z2
+  ipv4:
+    address: 192.168.0.1/30
+  ipv6:
+    address: 2001:db8:12::1/64
+router:
+  bgp:
+    global:
+      as: 65001
+      router-id: 10.0.0.1
+    timer:
+      adv-interval:
+        ibgp: 1
+        ebgp: 1
+    neighbor:
+    - remote-address: 192.168.0.2
+      remote-as: 65002
+      enabled: true
+      afi-safi:
+      - name: ipv4
+        enabled: true
+      - name: ipv6
+        enabled: true
+    afi-safi:
+    - name: ipv4
+      redistribute:
+        connected: {}
+    - name: ipv6
+      redistribute:
+        connected: {}

--- a/bdd/tests/configs/bgp_v6_incremental/z2.yaml
+++ b/bdd/tests/configs/bgp_v6_incremental/z2.yaml
@@ -1,0 +1,37 @@
+# Receiver side — mirror of z1 with flipped addressing.
+interface:
+- if-name: lo
+  ipv4:
+    address: 10.0.0.2/32
+  ipv6:
+    address: 2001:db8::2/128
+- if-name: z2-z1
+  ipv4:
+    address: 192.168.0.2/30
+  ipv6:
+    address: 2001:db8:12::2/64
+router:
+  bgp:
+    global:
+      as: 65002
+      router-id: 10.0.0.2
+    timer:
+      adv-interval:
+        ibgp: 1
+        ebgp: 1
+    neighbor:
+    - remote-address: 192.168.0.1
+      remote-as: 65001
+      enabled: true
+      afi-safi:
+      - name: ipv4
+        enabled: true
+      - name: ipv6
+        enabled: true
+    afi-safi:
+    - name: ipv4
+      redistribute:
+        connected: {}
+    - name: ipv6
+      redistribute:
+        connected: {}

--- a/bdd/tests/features/bgp_v6_incremental.feature
+++ b/bdd/tests/features/bgp_v6_incremental.feature
@@ -1,0 +1,68 @@
+@serial
+@bgp_v6_incremental
+Feature: IPv6 unicast routes appearing after session establishment are advertised
+  As a network operator
+  I want an IPv6 route that shows up while a BGP session is already
+  Established to be advertised to that peer, so convergence does not
+  depend on session resets.
+
+  Regression guard: the incremental v6 advertise path
+  (`route_advertise_to_peers_v6`) emits reach only through the
+  per-update-group `cache_ipv6`, but `(Ip6, Unicast)` was never in
+  `TRACKED_AFI_SAFIS`, so `update_group::attach` never enrolled any
+  peer and the group lookup always missed — incremental v6 reach was
+  silently dropped. Only the initial `route_sync_ipv6` dump at
+  establishment delivered v6 routes, which is why every pre-existing
+  feature (config applied before the session comes up) kept passing.
+
+  Topology: one dual-stack point-to-point link, eBGP over the IPv4
+  addresses with both ipv4 and ipv6 afi-safi negotiated, both sides
+  redistributing connected. adv-interval is pinned to 1s. The route
+  under test is injected via a dummy interface created only AFTER the
+  session is verified Established, so it can only reach the peer
+  through the incremental path.
+
+  Scenario: A connected v6 prefix added after Established reaches the peer
+    Given a clean test environment
+    When I create namespace "z1"
+    And I create namespace "z2"
+    And I connect namespace "z1" interface "z1-z2" to namespace "z2" interface "z2-z1"
+    And I start zebra-rs in namespace "z1"
+    And I start zebra-rs in namespace "z2"
+    And I apply config "z1.yaml" to namespace "z1"
+    And I apply config "z2.yaml" to namespace "z2"
+    And I wait 10 seconds
+    Then show command "show bgp summary" in namespace "z1" should contain "Established"
+    # Baseline: initial-sync routes made it across (this path always
+    # worked — it is not the subject of the test).
+    And show command "show bgp ipv6" in namespace "z2" should contain "2001:db8::1/128"
+    # Inject a new connected prefix only now, with the session up.
+    When I create dummy interface "cust0" with address "2001:db8:cafe::1/64" in namespace "z1"
+    And I wait 8 seconds
+    # Origination on z1 (kernel AddrAdd -> redistribute connected).
+    Then show command "show bgp ipv6" in namespace "z1" should contain "2001:db8:cafe::/64"
+    # The incremental advertisement must arrive at z2: bucketed into
+    # the v6 update-group cache and debounce-flushed. Before the fix
+    # the group gate always missed and this prefix never arrived.
+    And show command "show bgp ipv6" in namespace "z2" should contain "2001:db8:cafe::/64"
+    And show command "show ipv6 route" in namespace "z2" should contain "2001:db8:cafe::/64"
+
+  Scenario: Withdrawing the prefix after Established removes it from the peer
+    Given the test topology exists
+    # Downing the dummy flushes its v6 address (kernel semantics for
+    # IPv6), so z1 sees AddrDel, the origination is withdrawn, and the
+    # incremental MP_UNREACH must clear the route on z2.
+    When I make namespace "z1" interface "cust0" down
+    And I wait 8 seconds
+    Then show command "show bgp ipv6" in namespace "z2" should not contain "2001:db8:cafe::/64"
+    # Guard against a vacuous pass of the negative assertion above: the
+    # same table must still carry the unrelated link prefix.
+    And show command "show bgp ipv6" in namespace "z2" should contain "2001:db8:12::/64"
+
+  Scenario: Teardown topology
+    Given the test topology exists
+    When I stop zebra-rs in namespace "z1"
+    And I stop zebra-rs in namespace "z2"
+    And I delete namespace "z1"
+    And I delete namespace "z2"
+    Then the test environment should be clean

--- a/zebra-rs/src/bgp/inst.rs
+++ b/zebra-rs/src/bgp/inst.rs
@@ -2794,7 +2794,7 @@ impl Bgp {
                     self.redist_v6.remove(&(rtype, prefix));
                     // Withdraw from both v6 targets unconditionally (the
                     // config row may already be gone), mirroring the v4 path.
-                    self.route_redist_withdraw_v6(prefix);
+                    self.route_redist_withdraw_v6(rtype, prefix);
                     self.route_redist_withdraw_labelv6(rtype, prefix);
                 }
             }

--- a/zebra-rs/src/bgp/route.rs
+++ b/zebra-rs/src/bgp/route.rs
@@ -9018,13 +9018,17 @@ impl Bgp {
     }
 
     /// Withdraw a redistributed IPv6 unicast route (the v6 counterpart of
-    /// [`Bgp::route_redist_withdraw`]). The v6 Loc-RIB `remove_v6` keys on
-    /// `(prefix, ident)` rather than the `remote_id` the v4 path uses, so
-    /// a prefix redistributed from more than one source shares one
-    /// originated row — acceptable for the common single-source case.
-    pub fn route_redist_withdraw_v6(&mut self, prefix: Ipv6Net) {
+    /// [`Bgp::route_redist_withdraw`]). Like the v4 path and the labeled
+    /// twins, the Loc-RIB row is keyed on `(ident, remote_id)` where
+    /// `remote_id` is the per-source discriminator from
+    /// [`Bgp::redist_remote_id`] — this used to pass a literal `0`, which
+    /// matches no redistributed source (Connected=1, Static=2, …), so the
+    /// withdraw was a silent no-op and a deleted route stayed originated
+    /// and advertised until the daemon restarted.
+    pub fn route_redist_withdraw_v6(&mut self, rtype: crate::rib::RibType, prefix: Ipv6Net) {
         let ident = ORIGINATED_PEER;
-        let removed = self.local_rib.remove_v6(prefix, 0, ident);
+        let remote_id = Self::redist_remote_id(rtype);
+        let removed = self.local_rib.remove_v6(prefix, remote_id, ident);
 
         let mut bgp_ref = BgpTop {
             router_id: &self.router_id,

--- a/zebra-rs/src/bgp/route.rs
+++ b/zebra-rs/src/bgp/route.rs
@@ -6916,6 +6916,18 @@ pub(super) fn route_advertise_to_peers_v6(
                     && let Some(group) = af.group_by_id_mut(&gid)
                 {
                     super::update_group::send_ipv6(group, nlri, attr, source_ident, bgp.tx, true);
+                } else {
+                    // Established peer with no IPv6 unicast group is a
+                    // bug — `update_group::attach` is supposed to
+                    // enroll every negotiated family. Surface it
+                    // rather than dropping the reach on the floor
+                    // (which is exactly how the missing-enrollment
+                    // bug stayed invisible).
+                    tracing::warn!(
+                        peer = %peer.address,
+                        prefix = %prefix,
+                        "IPv6 advertise: peer is Established but not in any update-group; advertise skipped"
+                    );
                 }
             }
             Some(_) => {

--- a/zebra-rs/src/bgp/update_group.rs
+++ b/zebra-rs/src/bgp/update_group.rs
@@ -43,10 +43,15 @@ use crate::context::Timer;
 /// in `show bgp update-group` so a stale view is detectable.
 pub const SIGNATURE_VERSION: u32 = 3;
 
-/// Address families the v1 grouping logic considers. The advertise
-/// pipeline today only fans out to these three.
-pub const TRACKED_AFI_SAFIS: [(Afi, Safi); 3] = [
+/// Address families the grouping logic considers — every family whose
+/// advertise pipeline consults `peer.update_group_id`. IPv6 unicast
+/// joined late: the v6 advertise path (`route_advertise_to_peers_v6`)
+/// has bucketed reach into the per-group `cache_ipv6` since it was
+/// built, but the family was never enrolled here, so the group lookup
+/// always missed and incremental v6 reach was silently dropped.
+pub const TRACKED_AFI_SAFIS: [(Afi, Safi); 4] = [
     (Afi::Ip, Safi::Unicast),
+    (Afi::Ip6, Safi::Unicast),
     (Afi::Ip, Safi::MplsVpn),
     (Afi::L2vpn, Safi::Evpn),
 ];
@@ -69,6 +74,7 @@ impl UpdateGroupId {
     pub fn afi_safi_tag(afi: Afi, safi: Safi) -> &'static str {
         match (afi, safi) {
             (Afi::Ip, Safi::Unicast) => "ipv4-unicast",
+            (Afi::Ip6, Safi::Unicast) => "ipv6-unicast",
             (Afi::Ip, Safi::MplsVpn) => "vpnv4",
             (Afi::L2vpn, Safi::Evpn) => "evpn",
             _ => "other",
@@ -1216,10 +1222,112 @@ mod tests {
     fn id_format_matches_iosxr_style() {
         let id = UpdateGroupId::new(Afi::Ip, Safi::Unicast, 0);
         assert_eq!(id.to_string(), "ipv4-unicast.0");
+        let id = UpdateGroupId::new(Afi::Ip6, Safi::Unicast, 1);
+        assert_eq!(id.to_string(), "ipv6-unicast.1");
         let id = UpdateGroupId::new(Afi::Ip, Safi::MplsVpn, 7);
         assert_eq!(id.to_string(), "vpnv4.7");
         let id = UpdateGroupId::new(Afi::L2vpn, Safi::Evpn, 2);
         assert_eq!(id.to_string(), "evpn.2");
+    }
+
+    fn attach_test_peer(addr: std::net::IpAddr) -> Peer {
+        let (tx, _rx) = mpsc::channel(1);
+        // The attach path never touches sockets; a parked ProtoContext
+        // over a leaked inbound channel is enough (mirrors the PeerMap
+        // test scaffolding).
+        let (inbound_tx, inbound_rx) = tokio::sync::mpsc::unbounded_channel();
+        Box::leak(Box::new(inbound_rx));
+        let rib = crate::rib::client::RibClient::new(
+            inbound_tx,
+            crate::rib::client::ProtoId::from_raw(0),
+        );
+        let ctx = crate::context::ProtoContext::default_table(rib);
+        Peer::new(
+            0,
+            65000,
+            std::net::Ipv4Addr::new(1, 1, 1, 1),
+            65000,
+            addr,
+            None,
+            tx,
+            ctx,
+        )
+    }
+
+    fn negotiate(peer: &mut Peer, afi: Afi, safi: Safi) {
+        let key = bgp_packet::CapMultiProtocol::new(&afi, &safi);
+        let entry = peer
+            .cap_map
+            .entries
+            .get_mut(&key)
+            .expect("family pre-seeded in CapAfiMap");
+        entry.send = true;
+        entry.recv = true;
+    }
+
+    /// `attach` must enroll a peer into one group per *negotiated*
+    /// tracked family — pinning IPv6 unicast in particular, whose
+    /// missing enrollment silently killed incremental v6 reach (the
+    /// advertise path gates on `update_group_id[(Ip6, Unicast)]`).
+    #[test]
+    fn attach_enrolls_negotiated_v6_unicast() {
+        let mut peers = PeerMap::new();
+
+        // Dual-stack peer: v4 + v6 unicast negotiated.
+        let dual: IpAddr = std::net::Ipv4Addr::new(10, 0, 0, 1).into();
+        let mut peer = attach_test_peer(dual);
+        negotiate(&mut peer, Afi::Ip, Safi::Unicast);
+        negotiate(&mut peer, Afi::Ip6, Safi::Unicast);
+        peers.insert(dual, peer);
+        let dual_idx = peers.get(&dual).unwrap().ident;
+
+        // v4-only peer: must not be enrolled in a v6 group.
+        let v4only: IpAddr = std::net::Ipv4Addr::new(10, 0, 0, 2).into();
+        let mut peer = attach_test_peer(v4only);
+        negotiate(&mut peer, Afi::Ip, Safi::Unicast);
+        peers.insert(v4only, peer);
+        let v4only_idx = peers.get(&v4only).unwrap().ident;
+
+        let mut groups = empty_map();
+        attach(&mut groups, &mut peers, dual_idx);
+        attach(&mut groups, &mut peers, v4only_idx);
+
+        let v4_key = AfiSafi::new(Afi::Ip, Safi::Unicast);
+        let v6_key = AfiSafi::new(Afi::Ip6, Safi::Unicast);
+
+        let dual_peer = peers.get(&dual).unwrap();
+        assert!(dual_peer.update_group_id.contains_key(&v4_key));
+        let v6_id = dual_peer
+            .update_group_id
+            .get(&v6_key)
+            .expect("v6-unicast must be enrolled — its advertise path is group-gated");
+        assert_eq!(v6_id.to_string(), "ipv6-unicast.0");
+        assert!(
+            groups
+                .get(&v6_key)
+                .and_then(|af| af.groups.values().find(|g| g.members.contains(&dual_idx)))
+                .is_some(),
+            "dual-stack peer must be a member of an ipv6-unicast group"
+        );
+
+        let v4only_peer = peers.get(&v4only).unwrap();
+        assert!(v4only_peer.update_group_id.contains_key(&v4_key));
+        assert!(
+            !v4only_peer.update_group_id.contains_key(&v6_key),
+            "non-negotiated family must not be enrolled"
+        );
+
+        // detach must clear both memberships symmetrically.
+        detach(&mut groups, &mut peers, dual_idx);
+        let dual_peer = peers.get(&dual).unwrap();
+        assert!(dual_peer.update_group_id.is_empty());
+        assert!(
+            groups
+                .get(&v6_key)
+                .map(|af| af.groups.is_empty())
+                .unwrap_or(true),
+            "emptied v6 group must be dropped"
+        );
     }
 
     /// The counter-bump path uses `group_by_id_mut` to find the


### PR DESCRIPTION
## Summary

First two bug-fix PR-items from the peer-membership-list plan (`docs/design/bgp-peer-list.md` §8, steps 0–1 — B1 plus the withdraw defect its BDD scenario exposed). Three commits:

### 1. Enroll IPv6 unicast in update groups (B1)

`route_advertise_to_peers_v6` emits reach **only** through the per-group `cache_ipv6`, gated on `update_group_id[(Ip6, Unicast)]` — but `attach()` never enrolled the family (`TRACKED_AFI_SAFIS` was v4-unicast/VPNv4/EVPN only), so the gate always missed and **every incremental IPv6 unicast reach was silently dropped** since the v6 pipeline landed (7b307f65). Only the initial `route_sync_ipv6` dump delivered v6 routes — which is why all config-before-establish BDD features kept passing.

Fix: add `(Ip6, Unicast)` to `TRACKED_AFI_SAFIS` (+ `ipv6-unicast` show tag). The signature/flush machinery was already family-generic and wired in both serve loops. New unit test pins enrollment + detach symmetry.

### 2. Fix v6 redistribute withdraw — `remote_id 0` matched no source

`route_redist_withdraw_v6` removed the originated row with `remove_v6(prefix, 0, ident)`, but `LocalRibTable::remove` matches on `(ident, remote_id)` and every source injects with a non-zero discriminator (Connected=1, Static=2, …). The withdraw was a **silent no-op**: a deleted/ifdown'd v6 route stayed originated and advertised until daemon restart. v4 and both labeled twins already passed `redist_remote_id(rtype)`; v6 unicast was the odd one out. Thread `rtype` through and match like the others.

### 3. Warn on group-less v6 advertise + `@bgp_v6_incremental` BDD

- v4-parity `warn!` when an Established peer has no v6 group (the silent gate is how bug 1 stayed invisible).
- New BDD feature closes the coverage gap that hid both bugs: verify Established **first**, then inject a connected v6 prefix (dummy interface) → must arrive + install at the peer (pins fix 1); down the interface → peer must lose the route (pins fix 2), with a positive assertion guarding the negative one. adv-interval pinned to 1s so the debounce flush lands inside the waits.

## Verification

- `cargo test --workspace --exclude bdd`: 1685 passed, 0 failed
- `cargo clippy --workspace --all-targets -- -D warnings`: clean
- BDD `@bgp_v6_incremental`: 3/3 scenarios green on the rebuilt release binary (scenario 1 fails without commit 1; scenario 2 fails without commit 2 — both observed live during development)
- `make docs` synced for the new feature

🤖 Generated with [Claude Code](https://claude.com/claude-code)