### PR TITLE
bgp: never negotiate AddPath send for families without a per-path pipeline

### DIFF
--- a/docs/design/bgp-peer-list.md
+++ b/docs/design/bgp-peer-list.md
@@ -320,11 +320,19 @@ of B.
    `attach`, or add the v4-style fallback + `warn!`.
 2. **Bug-fix PR (B2):** ident-based collection in the fan-out sites so
    interface-keyed peers are reachable.
-3. **Bug-fix PR (B3):** decide per family: either implement the
-   per-candidate AddPath twins for VPNv6/EVPN/LU, or guard the scans
-   with `!is_add_path_send` + `warn!` (wire-safe, capability inert)
-   until the twins exist. The malformed-withdraw hazard argues for
-   doing at least the guard immediately.
+3. **Bug-fix PR (B3):** mask the *capability*, not the scans. The
+   original idea here — guard the fan-outs with `!is_add_path_send` —
+   turned out not to be wire-safe: RFC 7911 §3 binds every NLRI of a
+   *negotiated* family to carry a path-id, so once Send is negotiated,
+   both "send id-less" and "send nothing" are protocol violations;
+   the only coherent cheap fix is to never negotiate Send for a
+   family without the per-path pipeline. Landed as
+   `addpath_send_implemented()` (v4-unicast + VPNv4 only): the OPEN
+   build withholds/downgrades the Send half for other families and
+   `cap_addpath_recv` mirrors the gate, both with `warn!`s. The
+   half-stamped advertise code in VPNv6/EVPN/LU becomes unreachable
+   and stands as the hook for the real per-candidate twins, which
+   must grow the supported set when they land.
 4. **Refactor (Option B):** now a pure no-behavior-change
    consolidation — convert site by site with the `debug_assert`
    cross-check active; include detach-on-remove.

--- a/zebra-rs/src/bgp/cap.rs
+++ b/zebra-rs/src/bgp/cap.rs
@@ -86,15 +86,134 @@ pub fn cap_register_recv(bgp_cap: &BgpCap, cap_map: &mut CapAfiMap) {
     }
 }
 
+/// Families whose advertise plane actually implements the AddPath
+/// *send* direction — per-candidate fan-out with allocated path-ids on
+/// reach AND withdraw (`route_advertise_to_addpath` /
+/// `route_withdraw_from_addpath`). RFC 7911 §3 makes negotiated Send a
+/// hard wire contract: every NLRI of that family must then carry a
+/// path identifier, so a family without the full per-path pipeline
+/// must not negotiate Send at all. The other families today either
+/// exclude AddPath peers from their only advertise path (IPv6 unicast)
+/// or half-stamp ids (reach with `local_id`, withdraw with 0 — which
+/// encodes as *no* path-id field: a malformed MP_UNREACH on an
+/// AddPath session) — VPNv6, EVPN, labeled-unicast. Receive is
+/// unaffected: parsing path-ids is family-generic (`ParseOption`).
+pub fn addpath_send_implemented(afi: Afi, safi: Safi) -> bool {
+    matches!(
+        (afi, safi),
+        (Afi::Ip, Safi::Unicast) | (Afi::Ip, Safi::MplsVpn)
+    )
+}
+
 pub fn cap_addpath_recv(bgp_cap: &BgpCap, opt: &mut ParseOption, configs: &AfiSafis<AddPathValue>) {
     for (_, cap) in bgp_cap.addpath.iter() {
         for (_, config) in configs.iter() {
             if cap.afi == config.afi && cap.safi == config.safi {
-                let send = cap.send_receive.is_receive() && config.send_receive.is_send();
+                // Send is additionally gated on the family having a
+                // real per-path advertise pipeline. The OPEN we sent
+                // already withheld Send for these families (see the
+                // capability build in `peer.rs`), so this also keeps
+                // the negotiated state honest against a remote that
+                // offers Receive regardless.
+                let implemented = addpath_send_implemented(cap.afi, cap.safi);
+                let send =
+                    cap.send_receive.is_receive() && config.send_receive.is_send() && implemented;
+                if cap.send_receive.is_receive() && config.send_receive.is_send() && !implemented {
+                    tracing::warn!(
+                        afi = %cap.afi,
+                        safi = %cap.safi,
+                        "add-path send is configured but not implemented for this family; \
+                         negotiating receive-only"
+                    );
+                }
                 let recv = cap.send_receive.is_send() && config.send_receive.is_receive();
                 let afi_safi = AfiSafi::new(cap.afi, cap.safi);
                 opt.add_path.insert(afi_safi, Direct { recv, send });
             }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use bgp_packet::AddPathSendReceive;
+
+    fn addpath_cap(afi: Afi, safi: Safi, dir: AddPathSendReceive) -> AddPathValue {
+        AddPathValue {
+            afi,
+            safi,
+            send_receive: dir,
+        }
+    }
+
+    /// Negotiated AddPath *send* is gated on the family having the
+    /// per-path advertise pipeline. A VPNv6 (or any unimplemented
+    /// family) `add-path send` config against a peer offering Receive
+    /// must come out send=false — RFC 7911 §3 would otherwise oblige
+    /// us to path-id every NLRI of a family whose withdraw path can't.
+    #[test]
+    fn addpath_send_negotiates_only_for_implemented_families() {
+        let mut bgp_cap = BgpCap::default();
+        let mut configs: AfiSafis<AddPathValue> = AfiSafis::new();
+        for (afi, safi) in [
+            (Afi::Ip, Safi::Unicast),
+            (Afi::Ip, Safi::MplsVpn),
+            (Afi::Ip6, Safi::Unicast),
+            (Afi::Ip6, Safi::MplsVpn),
+        ] {
+            let key = AfiSafi::new(afi, safi);
+            // Peer offers both directions; we configure send-receive.
+            bgp_cap
+                .addpath
+                .insert(key, addpath_cap(afi, safi, AddPathSendReceive::SendReceive));
+            configs.insert(key, addpath_cap(afi, safi, AddPathSendReceive::SendReceive));
+        }
+
+        let mut opt = ParseOption::default();
+        cap_addpath_recv(&bgp_cap, &mut opt, &configs);
+
+        // Implemented families negotiate send.
+        assert!(opt.is_add_path_send(Afi::Ip, Safi::Unicast));
+        assert!(opt.is_add_path_send(Afi::Ip, Safi::MplsVpn));
+        // Unimplemented families are masked to receive-only.
+        assert!(!opt.is_add_path_send(Afi::Ip6, Safi::Unicast));
+        assert!(!opt.is_add_path_send(Afi::Ip6, Safi::MplsVpn));
+        // Receive negotiates for every family (parsing is generic).
+        for (afi, safi) in [
+            (Afi::Ip, Safi::Unicast),
+            (Afi::Ip, Safi::MplsVpn),
+            (Afi::Ip6, Safi::Unicast),
+            (Afi::Ip6, Safi::MplsVpn),
+        ] {
+            let key = AfiSafi::new(afi, safi);
+            assert!(
+                opt.add_path.get(&key).is_some_and(|d| d.recv),
+                "receive must negotiate for {afi} {safi}"
+            );
+        }
+    }
+
+    /// The supported-set itself, pinned: exactly IPv4 unicast + VPNv4
+    /// today. Growing it is deliberate — it must come WITH the
+    /// per-candidate advertise/withdraw twins for the new family.
+    #[test]
+    fn addpath_send_implemented_set_is_v4_unicast_and_vpnv4() {
+        assert!(addpath_send_implemented(Afi::Ip, Safi::Unicast));
+        assert!(addpath_send_implemented(Afi::Ip, Safi::MplsVpn));
+        for (afi, safi) in [
+            (Afi::Ip6, Safi::Unicast),
+            (Afi::Ip6, Safi::MplsVpn),
+            (Afi::L2vpn, Safi::Evpn),
+            (Afi::Ip, Safi::MplsLabel),
+            (Afi::Ip6, Safi::MplsLabel),
+            (Afi::Ip, Safi::Flowspec),
+            (Afi::Ip6, Safi::Flowspec),
+        ] {
+            assert!(
+                !addpath_send_implemented(afi, safi),
+                "{afi} {safi} has no per-path advertise pipeline"
+            );
         }
     }
 }

--- a/zebra-rs/src/bgp/peer.rs
+++ b/zebra-rs/src/bgp/peer.rs
@@ -2426,7 +2426,43 @@ fn build_open_packet(peer: &mut Peer) -> BytesMut {
         bgp_cap.fqdn = Some(CapFqdn::new(name, ""));
     }
     for (key, addpath) in peer.config.addpath.iter() {
-        bgp_cap.addpath.insert(*key, addpath.clone());
+        // RFC 7911 §3: a negotiated Send obliges us to stamp a path-id
+        // on every NLRI of that family. Only IPv4 unicast and VPNv4
+        // have the per-path advertise pipeline, so withhold the Send
+        // half for every other family — advertising it would negotiate
+        // a session we then feed malformed (id-less withdraw) or no
+        // (excluded-from-fan-out) UPDATEs. The Receive half is
+        // family-generic and passes through.
+        let value = if super::cap::addpath_send_implemented(key.afi, key.safi) {
+            addpath.clone()
+        } else {
+            match addpath.send_receive {
+                AddPathSendReceive::Send => {
+                    tracing::warn!(
+                        afi = %key.afi,
+                        safi = %key.safi,
+                        "add-path send is not implemented for this family; \
+                         capability not advertised"
+                    );
+                    continue;
+                }
+                AddPathSendReceive::SendReceive => {
+                    tracing::warn!(
+                        afi = %key.afi,
+                        safi = %key.safi,
+                        "add-path send is not implemented for this family; \
+                         advertising receive only"
+                    );
+                    AddPathValue {
+                        afi: key.afi,
+                        safi: key.safi,
+                        send_receive: AddPathSendReceive::Receive,
+                    }
+                }
+                _ => addpath.clone(),
+            }
+        };
+        bgp_cap.addpath.insert(*key, value);
     }
     for (key, sub) in peer.config.sub.iter() {
         if let Some(_restart_time) = sub.graceful_restart {


### PR DESCRIPTION
## Summary

**B3** from the peer-membership-list plan (`docs/design/bgp-peer-list.md` §8 step 3). Independent of #1409/#1412 (capability layer only).

RFC 7911 §3 makes negotiated Send a hard wire contract — every NLRI of the family must carry a path-id. Only IPv4-unicast and VPNv4 have the per-candidate twins that honor it. The families that could nevertheless negotiate Send were incoherent:

- **VPNv6 / EVPN / LU-v4 / LU-v6**: reach stamps `local_id`, withdraw hardcodes `0` — which the emitters encode as **no path-id field** → malformed MP_UNREACH on an AddPath session (RFC 7606 treat-as-withdraw / session reset on a conformant peer); tolerant peers accumulate stale paths forever.
- **IPv6-unicast**: AddPath peers are excluded from the only incremental path, no twin exists → nothing after the initial dump.

`add-path` is configurable on every family (no YANG `when`), so one config line armed this.

### Fix — at the capability layer

- `addpath_send_implemented()` pins the supported set (v4-unicast, VPNv4), with a test that forces the set to grow only together with real per-family twins.
- OPEN build: pure `send` config on an unsupported family → capability withheld; `send-receive` → downgraded to `receive`; both `warn!`.
- `cap_addpath_recv` mirrors the gate (negotiated state stays honest against any remote).
- Receive is untouched — path-id parsing is family-generic.

The doc's originally sketched alternative (guard the fan-out scans) is **not wire-safe** — once Send is negotiated, both id-less sends and silence violate the contract; §8.3 updated accordingly.

## Verification

- `cargo test --workspace --exclude bdd`: 1686 passed (2 new); workspace clippy clean
- BDD smoke `@bgp_basic_ebgp` + `@bgp_update_group_ipv4` green on the rebuilt binary

### Note for reviewers
The B2 regression sweep surfaced that `bgp_evpn_capability.feature` has **no Teardown scenario** — it leaked two root daemons + namespaces into my later runs. Trivial follow-up PR if you want it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)