### PR TITLE
bgp: include interface-keyed peers in every advertise fan-out

### DIFF
--- a/bdd/docs/bgp_unnumbered_incremental.md
+++ b/bdd/docs/bgp_unnumbered_incremental.md
@@ -1,0 +1,33 @@
+# Routes appearing after establishment reach an IPv6-unnumbered peer
+
+## Overview
+
+As a network operator running BGP over IPv6-only point-to-point links
+I want routes that show up while an interface-keyed (unnumbered)
+session is already Established to be advertised to that peer, so
+convergence on unnumbered fabrics does not depend on session resets.
+Regression guard: every incremental advertise fan-out collected
+peers by remote address (`PeerMap::iter()` + `get_mut(&addr)`),
+which silently skips `PeerKey::Interface` peers — an unnumbered
+peer's remote link-local is never written into the address map. An
+interface-keyed session received the initial `route_sync` dump at
+establishment and then nothing: no reach, no withdraws, in any
+family. The fan-outs now collect peer idents over `iter_all()`,
+which is key-agnostic.
+Topology: the bgp_unnumbered_neighbor P2P link (link-local only,
+RA-discovered interface-neighbor on both ends, IPv4 carried via
+RFC 8950 ENHE). The route under test is a `network` statement
+applied only AFTER the session is verified Established, so it can
+only reach the peer through the incremental path (initial-config
+networks ride the route_sync dump, which always worked).
+adv-interval is pinned to 1s in the configs — the incremental
+reach flushes through the update-group debounce.
+
+## Test Scenarios
+
+| Scenario | Result |
+|----------|--------|
+| Setup topology | |
+| A network added after Established reaches the unnumbered peer | |
+| A network removed after Established is withdrawn from the unnumbered peer | |
+| Teardown topology | |

--- a/bdd/tests/configs/bgp_unnumbered_incremental/z1-base.yaml
+++ b/bdd/tests/configs/bgp_unnumbered_incremental/z1-base.yaml
@@ -1,0 +1,13 @@
+# Phase 1 of the two-step bring-up: a bare `router bgp` block with no
+# neighbors. Applying this first spawns the ND subsystem (ND is spawned
+# eagerly on the first `router bgp` line) so it subscribes to the RIB
+# and learns interface i1 BEFORE the next commit enables RA on it. The
+# per-interface `send-advertisements` callback silently drops if ND
+# hasn't yet learned the link, and it is not re-evaluated on a later
+# link-add — so without this warm-up the RA-enable could lose the race
+# against the RIB link replay and never arm the transmitter.
+router:
+  bgp:
+    global:
+      as: 65001
+      router-id: 1.1.1.1

--- a/bdd/tests/configs/bgp_unnumbered_incremental/z1-full.yaml
+++ b/bdd/tests/configs/bgp_unnumbered_incremental/z1-full.yaml
@@ -1,0 +1,27 @@
+# Phase 2: RA on, interface-keyed neighbor declared, one initial
+# network. adv-interval is pinned to 1s: the route this feature
+# injects AFTER the session is Established reaches the peer through
+# the update-group debounce flush, and the eBGP default of 30s would
+# outlive the scenario waits. (The initial network below rides the
+# route_sync dump instead and never needed the timer.)
+interface:
+- if-name: i1
+  ipv6:
+    router-advertisements:
+      send-advertisements: true
+router:
+  bgp:
+    global:
+      as: 65001
+      router-id: 1.1.1.1
+    timer:
+      adv-interval:
+        ibgp: 1
+        ebgp: 1
+    interface-neighbor:
+    - interface: i1
+      remote-as: 65002
+    afi-safi:
+    - name: ipv4
+      network:
+      - prefix: 10.0.0.1/32

--- a/bdd/tests/configs/bgp_unnumbered_incremental/z2-base.yaml
+++ b/bdd/tests/configs/bgp_unnumbered_incremental/z2-base.yaml
@@ -1,0 +1,6 @@
+# Phase 1 for z2 — see z1-base.yaml for the warm-up rationale.
+router:
+  bgp:
+    global:
+      as: 65002
+      router-id: 2.2.2.2

--- a/bdd/tests/configs/bgp_unnumbered_incremental/z2-full.yaml
+++ b/bdd/tests/configs/bgp_unnumbered_incremental/z2-full.yaml
@@ -1,0 +1,22 @@
+# Phase 2 for z2 — mirror of z1-full.yaml with the AS numbers swapped.
+interface:
+- if-name: i1
+  ipv6:
+    router-advertisements:
+      send-advertisements: true
+router:
+  bgp:
+    global:
+      as: 65002
+      router-id: 2.2.2.2
+    timer:
+      adv-interval:
+        ibgp: 1
+        ebgp: 1
+    interface-neighbor:
+    - interface: i1
+      remote-as: 65001
+    afi-safi:
+    - name: ipv4
+      network:
+      - prefix: 10.0.0.2/32

--- a/bdd/tests/features/bgp_unnumbered_incremental.feature
+++ b/bdd/tests/features/bgp_unnumbered_incremental.feature
@@ -1,0 +1,73 @@
+@serial
+@bgp_unnumbered_incremental
+Feature: Routes appearing after establishment reach an IPv6-unnumbered peer
+  As a network operator running BGP over IPv6-only point-to-point links
+  I want routes that show up while an interface-keyed (unnumbered)
+  session is already Established to be advertised to that peer, so
+  convergence on unnumbered fabrics does not depend on session resets.
+
+  Regression guard: every incremental advertise fan-out collected
+  peers by remote address (`PeerMap::iter()` + `get_mut(&addr)`),
+  which silently skips `PeerKey::Interface` peers — an unnumbered
+  peer's remote link-local is never written into the address map. An
+  interface-keyed session received the initial `route_sync` dump at
+  establishment and then nothing: no reach, no withdraws, in any
+  family. The fan-outs now collect peer idents over `iter_all()`,
+  which is key-agnostic.
+
+  Topology: the bgp_unnumbered_neighbor P2P link (link-local only,
+  RA-discovered interface-neighbor on both ends, IPv4 carried via
+  RFC 8950 ENHE). The route under test is a `network` statement
+  applied only AFTER the session is verified Established, so it can
+  only reach the peer through the incremental path (initial-config
+  networks ride the route_sync dump, which always worked).
+  adv-interval is pinned to 1s in the configs — the incremental
+  reach flushes through the update-group debounce.
+
+  Scenario: Setup topology
+    Given a clean test environment
+    When I create namespace "z1"
+    And I create namespace "z2"
+    And I connect namespace "z1" interface "i1" to namespace "z2" interface "i1"
+    And I start zebra-rs in namespace "z1"
+    And I start zebra-rs in namespace "z2"
+    And I apply config "z1-base.yaml" to namespace "z1"
+    And I apply config "z2-base.yaml" to namespace "z2"
+    And I wait 2 seconds
+    And I apply config "z1-full.yaml" to namespace "z1"
+    And I apply config "z2-full.yaml" to namespace "z2"
+    Then BGP session in namespace "z1" should eventually be "Established"
+    And BGP session in namespace "z2" should eventually be "Established"
+    And I wait 5 seconds
+    # Baseline: the initial-config networks crossed via route_sync
+    # (this path always worked — it is not the subject of the test).
+    And BGP route in "z2" has "10.0.0.1/32"
+    And BGP route in "z1" has "10.0.0.2/32"
+
+  Scenario: A network added after Established reaches the unnumbered peer
+    Given the test topology exists
+    When I apply command "set router bgp afi-safi ipv4 network 10.99.1.0/24" in namespace "z1"
+    And I wait 8 seconds
+    # Origination on z1.
+    Then BGP route in "z1" has "10.99.1.0/24"
+    # The incremental advertisement must arrive at the interface-keyed
+    # peer: before the fix the addr-keyed fan-out never visited it and
+    # this prefix never arrived.
+    And BGP route in "z2" has "10.99.1.0/24"
+
+  Scenario: A network removed after Established is withdrawn from the unnumbered peer
+    Given the test topology exists
+    When I apply command "delete router bgp afi-safi ipv4 network 10.99.1.0/24" in namespace "z1"
+    And I wait 8 seconds
+    Then show command "show ip bgp" in namespace "z2" should not contain "10.99.1.0/24"
+    # Guard against a vacuous pass of the negative assertion above: the
+    # same table must still carry z1's initial network.
+    And show command "show ip bgp" in namespace "z2" should contain "10.0.0.1/32"
+
+  Scenario: Teardown topology
+    Given the test topology exists
+    When I stop zebra-rs in namespace "z1"
+    And I stop zebra-rs in namespace "z2"
+    And I delete namespace "z1"
+    And I delete namespace "z2"
+    Then the test environment should be clean

--- a/zebra-rs/src/bgp/inst.rs
+++ b/zebra-rs/src/bgp/inst.rs
@@ -864,7 +864,7 @@ impl Bgp {
         }
         self.hostname = value;
         let resolved = self.hostname();
-        for (_, peer) in self.peers.iter_mut() {
+        for (_, peer) in self.peers.iter_mut_all() {
             peer.local_hostname = resolved.clone();
         }
     }
@@ -1226,7 +1226,7 @@ impl Bgp {
         }
 
         self.router_id = router_id;
-        for (_, peer) in self.peers.iter_mut() {
+        for (_, peer) in self.peers.iter_mut_all() {
             peer.router_id = router_id;
         }
 

--- a/zebra-rs/src/bgp/peer_map.rs
+++ b/zebra-rs/src/bgp/peer_map.rs
@@ -70,37 +70,19 @@ impl PeerMap {
         self.peers[idx].take()
     }
 
-    /// Iterate over peers keyed by remote address. Interface-keyed
-    /// peers (when they exist) are skipped — use [`Self::iter_all`]
-    /// for full iteration including those.
-    pub fn iter(&self) -> impl Iterator<Item = (&IpAddr, &Peer)> {
-        self.map.iter().filter_map(move |(key, &idx)| match key {
-            PeerKey::Addr(addr) => self.peers[idx].as_ref().map(|peer| (addr, peer)),
-            PeerKey::Interface(_) => None,
-        })
-    }
+    // NOTE: there is deliberately no addr-only `iter()`/`iter_mut()`.
+    // Both existed and were a recurring trap: they silently skipped
+    // `PeerKey::Interface` (IPv6 unnumbered) peers, which excluded
+    // those sessions from show output, config sweeps, and — worst —
+    // the entire incremental advertise fan-out. All-peers walks must
+    // use [`Self::iter_all`] / [`Self::iter_mut_all`]; addr-keyed
+    // lookups go through [`Self::get`] / [`Self::keys`].
 
-    pub fn iter_mut(&mut self) -> impl Iterator<Item = (&IpAddr, &mut Peer)> {
-        let map = &self.map;
-        self.peers
-            .iter_mut()
-            .enumerate()
-            .filter_map(move |(idx, slot)| {
-                let peer = slot.as_mut()?;
-                map.iter()
-                    .find(|(_, mapped_idx)| **mapped_idx == idx)
-                    .and_then(|(key, _)| match key {
-                        PeerKey::Addr(addr) => Some((addr, peer)),
-                        PeerKey::Interface(_) => None,
-                    })
-            })
-    }
-
-    /// Iterate every peer regardless of key variant. Unlike
-    /// [`Self::iter`], this includes `PeerKey::Interface` (IPv6
-    /// unnumbered) peers — `show ip bgp neighbors` needs them so an
-    /// operator can observe an interface-keyed session whose remote
-    /// link-local address isn't something they can name.
+    /// Iterate every peer regardless of key variant, including
+    /// `PeerKey::Interface` (IPv6 unnumbered) peers — `show ip bgp
+    /// neighbors` needs them so an operator can observe an
+    /// interface-keyed session whose remote link-local address isn't
+    /// something they can name.
     pub fn iter_all(&self) -> impl Iterator<Item = (&PeerKey, &Peer)> {
         self.map
             .iter()
@@ -171,7 +153,7 @@ mod tests {
     }
 
     #[test]
-    fn insert_with_interface_key_does_not_appear_in_iter() {
+    fn iter_all_includes_interface_keyed_peers() {
         let mut m = PeerMap::new();
         let a: IpAddr = Ipv4Addr::new(10, 0, 0, 1).into();
         m.insert(a, make_peer(a));
@@ -180,7 +162,6 @@ mod tests {
             make_peer(Ipv4Addr::UNSPECIFIED.into()),
         );
 
-        assert_eq!(m.iter().count(), 1, "addr-only iter skips interface peer");
         assert_eq!(m.iter_all().count(), 2, "iter_all includes interface peer");
         assert_eq!(m.iter_mut_all().count(), 2, "iter_mut_all includes both");
         assert_eq!(m.len(), 2);

--- a/zebra-rs/src/bgp/route.rs
+++ b/zebra-rs/src/bgp/route.rs
@@ -2408,16 +2408,16 @@ fn route_advertise_to_addpath(
     };
     let afi_safi = AfiSafi::new(afi, safi);
 
-    let peer_addrs: Vec<IpAddr> = peers
-        .iter()
+    let peer_idents: Vec<usize> = peers
+        .iter_all()
         .filter(|(_, p)| p.state.is_established())
         .filter(|(_, p)| p.is_afi_safi(afi, safi))
         .filter(|(_, p)| p.opt.is_add_path_send(afi, safi))
-        .map(|(addr, _)| *addr)
+        .map(|(_, p)| p.ident)
         .collect();
 
-    for peer_addr in peer_addrs {
-        let peer = peers.get_mut(&peer_addr).expect("peer exists");
+    for ident in peer_idents {
+        let peer = peers.get_mut_by_idx(ident).expect("peer exists");
 
         // RFC 9494 §4.3: stale routes only go to LLGR peers.
         if llgr_blocks_advertisement(rib.stale, &peer.cap_recv, afi, safi) {
@@ -2485,16 +2485,16 @@ fn route_withdraw_from_addpath(
     };
     let afi_safi = AfiSafi::new(afi, safi);
 
-    let peer_addrs: Vec<IpAddr> = peers
-        .iter()
+    let peer_idents: Vec<usize> = peers
+        .iter_all()
         .filter(|(_, p)| p.state.is_established())
         .filter(|(_, p)| p.is_afi_safi(afi, safi))
         .filter(|(_, p)| p.opt.is_add_path_send(afi, safi))
-        .map(|(addr, _)| *addr)
+        .map(|(_, p)| p.ident)
         .collect();
 
-    for peer_addr in peer_addrs {
-        let peer = peers.get_mut(&peer_addr).expect("peer exists");
+    for ident in peer_idents {
+        let peer = peers.get_mut_by_idx(ident).expect("peer exists");
 
         if let Some(ref rd) = rd {
             peer.cache_remove_vpnv4(*rd, prefix, removed.local_id);
@@ -2584,7 +2584,7 @@ pub(super) fn route_advertise_to_peers(
     // Get the new best path (last entry in selected vector)
     let new_best = selected.last();
 
-    // Collect peer addresses that need updates to avoid borrow checker issues
+    // Collect peer idents that need updates to avoid borrow checker issues
     let (afi, safi) = if rd.is_some() {
         (Afi::Ip, Safi::MplsVpn)
     } else {
@@ -2592,12 +2592,12 @@ pub(super) fn route_advertise_to_peers(
     };
     let afi_safi = AfiSafi::new(afi, safi);
 
-    let peer_addrs: Vec<IpAddr> = peers
-        .iter()
+    let peer_idents: Vec<usize> = peers
+        .iter_all()
         .filter(|(_, p)| p.state.is_established())
         .filter(|(_, p)| p.is_afi_safi(afi, safi))
         .filter(|(_, p)| !p.opt.is_add_path_send(afi, safi))
-        .map(|(addr, _)| *addr)
+        .map(|(_, p)| p.ident)
         .collect();
 
     // Per-call memo: outcome cached per update-group id for the
@@ -2607,8 +2607,8 @@ pub(super) fn route_advertise_to_peers(
     // is always run on a non-source peer).
     let mut memo: BTreeMap<super::update_group::UpdateGroupId, AdvertiseOutcome> = BTreeMap::new();
 
-    for peer_addr in peer_addrs {
-        let peer = peers.get_mut(&peer_addr).expect("peer exists");
+    for ident in peer_idents {
+        let peer = peers.get_mut_by_idx(ident).expect("peer exists");
 
         let add_path = peer.opt.is_add_path_send(afi, safi);
         let group_id = peer.update_group_id.get(&afi_safi).cloned();
@@ -2848,15 +2848,15 @@ pub fn route_withdraw_evpn_to_peers(
     prefix: EvpnPrefix,
     peers: &mut PeerMap,
 ) {
-    let peer_addrs: Vec<IpAddr> = peers
-        .iter()
+    let peer_idents: Vec<usize> = peers
+        .iter_all()
         .filter(|(_, p)| p.state.is_established())
         .filter(|(_, p)| p.is_afi_safi(Afi::L2vpn, Safi::Evpn))
-        .map(|(addr, _)| *addr)
+        .map(|(_, p)| p.ident)
         .collect();
 
-    for peer_addr in peer_addrs {
-        let peer = peers.get_mut(&peer_addr).expect("peer exists");
+    for ident in peer_idents {
+        let peer = peers.get_mut_by_idx(ident).expect("peer exists");
         let route = evpn_route_from_prefix(&rd, &prefix, 0);
         // Drop a queued advertise for the same route from the peer's
         // cache so flush_evpn doesn't ship a now-stale add after we
@@ -2943,15 +2943,15 @@ pub fn route_advertise_evpn_to_peers(
         return;
     };
 
-    let peer_addrs: Vec<IpAddr> = peers
-        .iter()
+    let peer_idents: Vec<usize> = peers
+        .iter_all()
         .filter(|(_, p)| p.state.is_established())
         .filter(|(_, p)| p.is_afi_safi(Afi::L2vpn, Safi::Evpn))
-        .map(|(addr, _)| *addr)
+        .map(|(_, p)| p.ident)
         .collect();
 
-    for peer_addr in peer_addrs {
-        let peer = peers.get_mut(&peer_addr).expect("peer exists");
+    for ident in peer_idents {
+        let peer = peers.get_mut_by_idx(ident).expect("peer exists");
         let add_path = peer.opt.is_add_path_send(Afi::L2vpn, Safi::Evpn);
 
         // RFC 9494 §4.3: stale routes only go to LLGR peers.
@@ -4751,15 +4751,15 @@ fn srpolicy_reflect(
     };
     let (source_ibgp, source_rid) = (src.is_ibgp(), src.remote_id);
 
-    let dests: Vec<IpAddr> = peers
-        .iter()
+    let dests: Vec<usize> = peers
+        .iter_all()
         .filter(|(_, p)| p.ident != source_ident)
         .filter(|(_, p)| p.state.is_established())
         .filter(|(_, p)| p.is_afi_safi(afi, Safi::SrTePolicy))
-        .map(|(addr, _)| *addr)
+        .map(|(_, p)| p.ident)
         .collect();
-    for daddr in dests {
-        let Some(peer) = peers.get_mut(&daddr) else {
+    for ident in dests {
+        let Some(peer) = peers.get_mut_by_idx(ident) else {
             continue;
         };
         let Some(out_attr) = super::sr_policy::reflect_attr(
@@ -4795,15 +4795,15 @@ fn srpolicy_reflect_withdraw(source_ident: usize, nlri: &SrPolicyNlri, peers: &m
         return;
     };
     let source_ibgp = src.is_ibgp();
-    let dests: Vec<IpAddr> = peers
-        .iter()
+    let dests: Vec<usize> = peers
+        .iter_all()
         .filter(|(_, p)| p.ident != source_ident)
         .filter(|(_, p)| p.state.is_established())
         .filter(|(_, p)| p.is_afi_safi(afi, Safi::SrTePolicy))
-        .map(|(addr, _)| *addr)
+        .map(|(_, p)| p.ident)
         .collect();
-    for daddr in dests {
-        let Some(peer) = peers.get_mut(&daddr) else {
+    for ident in dests {
+        let Some(peer) = peers.get_mut_by_idx(ident) else {
             continue;
         };
         if !super::sr_policy::reflect_withdraw_to(
@@ -5032,12 +5032,12 @@ pub(super) fn srpolicy_origin_sync(bgp: &mut Bgp, name: &str) {
 }
 
 /// Addresses of established peers that negotiated SAFI 73 for `afi`.
-fn srpolicy_peer_addrs(bgp: &Bgp, afi: Afi) -> Vec<IpAddr> {
+fn srpolicy_peer_idents(bgp: &Bgp, afi: Afi) -> Vec<usize> {
     bgp.peers
-        .iter()
+        .iter_all()
         .filter(|(_, p)| p.state.is_established())
         .filter(|(_, p)| p.is_afi_safi(afi, Safi::SrTePolicy))
-        .map(|(addr, _)| *addr)
+        .map(|(_, p)| p.ident)
         .collect()
 }
 
@@ -5046,8 +5046,8 @@ fn srpolicy_peer_addrs(bgp: &Bgp, afi: Afi) -> Vec<IpAddr> {
 pub(super) fn srpolicy_origin_reach(bgp: &mut Bgp, nlri: SrPolicyNlri, attr: BgpAttr) {
     let afi = nlri.afi();
     let nhop = IpAddr::V4(bgp.router_id);
-    for paddr in srpolicy_peer_addrs(bgp, afi) {
-        let Some(peer) = bgp.peers.get_mut(&paddr) else {
+    for ident in srpolicy_peer_idents(bgp, afi) {
+        let Some(peer) = bgp.peers.get_mut_by_idx(ident) else {
             continue;
         };
         let mut update = UpdatePacket::with_max_packet_size(peer.max_packet_size());
@@ -5069,8 +5069,8 @@ pub(super) fn srpolicy_origin_reach(bgp: &mut Bgp, nlri: SrPolicyNlri, attr: Bgp
 /// Withdraw one local SR Policy NLRI from every established SAFI-73 peer.
 pub(super) fn srpolicy_origin_withdraw(bgp: &mut Bgp, nlri: SrPolicyNlri) {
     let afi = nlri.afi();
-    for paddr in srpolicy_peer_addrs(bgp, afi) {
-        let Some(peer) = bgp.peers.get_mut(&paddr) else {
+    for ident in srpolicy_peer_idents(bgp, afi) {
+        let Some(peer) = bgp.peers.get_mut_by_idx(ident) else {
             continue;
         };
         let mut update = UpdatePacket::with_max_packet_size(peer.max_packet_size());
@@ -5323,15 +5323,15 @@ pub fn route_advertise_flowspec_to_peers(
     bgp: &mut BgpTop,
     peers: &mut PeerMap,
 ) {
-    let peer_addrs: Vec<IpAddr> = peers
-        .iter()
+    let peer_idents: Vec<usize> = peers
+        .iter_all()
         .filter(|(_, p)| p.state.is_established())
         .filter(|(_, p)| p.is_afi_safi(afi, Safi::Flowspec))
-        .map(|(addr, _)| *addr)
+        .map(|(_, p)| p.ident)
         .collect();
 
-    for peer_addr in peer_addrs {
-        let peer = peers.get_mut(&peer_addr).expect("peer exists");
+    for ident in peer_idents {
+        let peer = peers.get_mut_by_idx(ident).expect("peer exists");
         let add_path = peer.opt.is_add_path_send(afi, Safi::Flowspec);
 
         let Some((out_nlri, attr)) = route_update_flowspec(peer, nlri, best, add_path) else {
@@ -5349,15 +5349,15 @@ pub fn route_advertise_flowspec_to_peers(
 /// Withdraw a flow spec from every peer to which it was advertised
 /// (tracked via Adj-RIB-Out), sending one MP_UNREACH UPDATE each.
 pub fn route_withdraw_flowspec_to_peers(afi: Afi, nlri: &FlowspecNlri, peers: &mut PeerMap) {
-    let peer_addrs: Vec<IpAddr> = peers
-        .iter()
+    let peer_idents: Vec<usize> = peers
+        .iter_all()
         .filter(|(_, p)| p.state.is_established())
         .filter(|(_, p)| p.is_afi_safi(afi, Safi::Flowspec))
-        .map(|(addr, _)| *addr)
+        .map(|(_, p)| p.ident)
         .collect();
 
-    for peer_addr in peer_addrs {
-        let peer = peers.get_mut(&peer_addr).expect("peer exists");
+    for ident in peer_idents {
+        let peer = peers.get_mut_by_idx(ident).expect("peer exists");
         // Only withdraw what we actually advertised (skips the source
         // peer and any peer the announce-side policy suppressed).
         let advertised = {
@@ -6886,16 +6886,16 @@ pub(super) fn route_advertise_to_peers_v6(
     let (afi, safi) = (Afi::Ip6, Safi::Unicast);
     let afi_safi = AfiSafi::new(afi, safi);
 
-    let peer_addrs: Vec<IpAddr> = peers
-        .iter()
+    let peer_idents: Vec<usize> = peers
+        .iter_all()
         .filter(|(_, p)| p.state.is_established())
         .filter(|(_, p)| p.is_afi_safi(afi, safi))
         .filter(|(_, p)| !p.opt.is_add_path_send(afi, safi))
-        .map(|(addr, _)| *addr)
+        .map(|(_, p)| p.ident)
         .collect();
 
-    for peer_addr in peer_addrs {
-        let peer = peers.get_mut(&peer_addr).expect("peer exists");
+    for ident in peer_idents {
+        let peer = peers.get_mut_by_idx(ident).expect("peer exists");
         let add_path = peer.opt.is_add_path_send(afi, safi);
         let group_id = peer.update_group_id.get(&afi_safi).cloned();
 
@@ -6981,15 +6981,15 @@ pub(super) fn route_advertise_to_peers_vpnv6(
     let new_best = selected.last();
     let (afi, safi) = (Afi::Ip6, Safi::MplsVpn);
 
-    let peer_addrs: Vec<IpAddr> = peers
-        .iter()
+    let peer_idents: Vec<usize> = peers
+        .iter_all()
         .filter(|(_, p)| p.state.is_established())
         .filter(|(_, p)| p.is_afi_safi(afi, safi))
-        .map(|(addr, _)| *addr)
+        .map(|(_, p)| p.ident)
         .collect();
 
-    for peer_addr in peer_addrs {
-        let peer = peers.get_mut(&peer_addr).expect("peer exists");
+    for ident in peer_idents {
+        let peer = peers.get_mut_by_idx(ident).expect("peer exists");
         match new_best {
             Some(best) if best.ident != peer.ident => {
                 // RFC 9494 §4.3: stale routes only go to LLGR peers.
@@ -7209,15 +7209,15 @@ pub(super) fn route_advertise_to_peers_labelv4(
     let new_best = selected.last();
     let (afi, safi) = (Afi::Ip, Safi::MplsLabel);
 
-    let peer_addrs: Vec<IpAddr> = peers
-        .iter()
+    let peer_idents: Vec<usize> = peers
+        .iter_all()
         .filter(|(_, p)| p.state.is_established())
         .filter(|(_, p)| p.is_afi_safi(afi, safi))
-        .map(|(addr, _)| *addr)
+        .map(|(_, p)| p.ident)
         .collect();
 
-    for peer_addr in peer_addrs {
-        let peer = peers.get_mut(&peer_addr).expect("peer exists");
+    for ident in peer_idents {
+        let peer = peers.get_mut_by_idx(ident).expect("peer exists");
         match new_best {
             Some(best) if best.ident != peer.ident => {
                 // RFC 9494 §4.3: stale routes only go to LLGR peers.
@@ -7265,15 +7265,15 @@ pub(super) fn route_advertise_to_peers_labelv6(
     let new_best = selected.last();
     let (afi, safi) = (Afi::Ip6, Safi::MplsLabel);
 
-    let peer_addrs: Vec<IpAddr> = peers
-        .iter()
+    let peer_idents: Vec<usize> = peers
+        .iter_all()
         .filter(|(_, p)| p.state.is_established())
         .filter(|(_, p)| p.is_afi_safi(afi, safi))
-        .map(|(addr, _)| *addr)
+        .map(|(_, p)| p.ident)
         .collect();
 
-    for peer_addr in peer_addrs {
-        let peer = peers.get_mut(&peer_addr).expect("peer exists");
+    for ident in peer_idents {
+        let peer = peers.get_mut_by_idx(ident).expect("peer exists");
         match new_best {
             Some(best) if best.ident != peer.ident => {
                 // RFC 9494 §4.3: stale routes only go to LLGR peers.


### PR DESCRIPTION
## Summary

**B2** from the peer-membership-list plan (`docs/design/bgp-peer-list.md` §8 step 2). Replaces #1412, which was auto-closed when its stack base (#1409's branch) was deleted on merge — same head branch, now exactly one commit ahead of `main`.

Every incremental advertise/withdraw fan-out collected peers by remote address (`PeerMap::iter()` → `Vec<IpAddr>` → `get_mut(&addr)`), and `iter()` skips `PeerKey::Interface` peers by design — an unnumbered peer's remote link-local is never in the address map, so the idiom can't even name them. **An interface-keyed session got the initial `route_sync` dump and then nothing — no reach, no withdraws, any family — until session reset.**

### Changes

- All 13 fan-out collection sites in `route.rs` + `srpolicy_peer_addrs` → collect **peer idents** over `iter_all()`, re-look-up via `get_mut_by_idx` (key-agnostic, cheaper than the BTreeMap addr walk).
- The two all-peers config sweeps in `inst.rs` (hostname, router-id) → `iter_mut_all()` — they were also skipping unnumbered peers, and were the last users of the accidentally-quadratic `iter_mut()`.
- `PeerMap::iter()` / `iter_mut()` **removed** (zero callers left). This is the 4th bite of the addr-only-iterator trap (show gap, remote-as sweep, afi-safi sweep, now the whole advertise plane) — all-peers walks must now choose `iter_all()` explicitly.
- Deferred (noted in commit): `bfd_reconcile_all` / `apply_tcp_mss_refresh_all` still sweep by `keys()` — BFD/MSS for unnumbered peers is a separate follow-up.

### BDD

New `@bgp_unnumbered_incremental` — the unnumbered twin of `@bgp_v6_incremental`: RA-discovered interface-neighbor link, verify Established **first**, then `set … network 10.99.1.0/24` at runtime → must arrive at the unnumbered peer (pins the ident-based enqueue through the update-group flush); then `delete` it → peer must lose it (positive guard against vacuous negative asserts).

## Verification

- `cargo test --workspace --exclude bdd`: 1685 passed; workspace clippy clean
- BDD on the rebuilt binary: new feature 4/4; regression sweep `bgp_basic_ebgp`, `bgp_update_group_ipv4`, `bgp_unnumbered_neighbor`, `bgp_v6_incremental`, `bgp_ipv6_over_v4_session`, `bgp_evpn_capability`, `bgp_vrf_evpn_type5`, `bgp_interas_option_c` — **8 features / 38 scenarios green** (inter-AS option C exercises the VPNv4 + labeled-unicast fan-outs end-to-end)

🤖 Generated with [Claude Code](https://claude.com/claude-code)