### PR TITLE
isis: dedup v4/v6 code — TLV splitters, IIH address TLVs, NLPID gate

### DIFF
--- a/zebra-rs/src/isis/ifsm.rs
+++ b/zebra-rs/src/isis/ifsm.rs
@@ -43,6 +43,42 @@ pub fn proto_supported(enable: &Afis<bool>) -> IsisTlvProtoSupported {
     IsisTlvProtoSupported { nlpids }
 }
 
+/// Interface Address TLVs for an outbound IIH: IPv4 (RFC 1195 TLV
+/// 132) plus IPv6 (RFC 5308 TLV 232 for link-local; non-standard TLV
+/// 233 for global) — each family only when IS-IS for that family is
+/// enabled on this link, so we don't advertise a capability we won't
+/// honor. Shared by the LAN and P2P Hello generators.
+fn push_if_addr_tlvs(tlvs: &mut Vec<IsisTlv>, link: &LinkTop) {
+    if link.config.enable.v4 {
+        for prefix in &link.state.v4addr {
+            tlvs.push(
+                IsisTlvIpv4IfAddr {
+                    addr: prefix.addr(),
+                }
+                .into(),
+            );
+        }
+    }
+    if link.config.enable.v6 {
+        for prefix in &link.state.v6laddr {
+            tlvs.push(
+                IsisTlvIpv6IfAddr {
+                    addr: prefix.addr(),
+                }
+                .into(),
+            );
+        }
+        for prefix in &link.state.v6addr {
+            tlvs.push(
+                IsisTlvIpv6GlobalIfAddr {
+                    addr: prefix.addr(),
+                }
+                .into(),
+            );
+        }
+    }
+}
+
 /// RFC 5306 §3.1 — when this instance is staged for restart, every
 /// outbound IIH carries a Restart TLV with RR=1. Remaining Time
 /// echoes the operator-requested grace period so helpers can seed
@@ -122,38 +158,7 @@ pub fn hello_generate(link: &LinkTop, level: Level) -> IsisHello {
     let tlv = IsisTlvAreaAddr { area_addr };
     hello.tlvs.push(tlv.into());
 
-    if link.config.enable.v4 {
-        for prefix in &link.state.v4addr {
-            hello.tlvs.push(
-                IsisTlvIpv4IfAddr {
-                    addr: prefix.addr(),
-                }
-                .into(),
-            );
-        }
-    }
-
-    // IPv6 Interface Address TLVs (RFC 5308 TLV 232 for link-local; non-standard
-    // TLV 233 for global) — only when IS-IS IPv6 is enabled on this link, so we
-    // don't advertise an IPv6 capability we won't honor.
-    if link.config.enable.v6 {
-        for prefix in &link.state.v6laddr {
-            hello.tlvs.push(
-                IsisTlvIpv6IfAddr {
-                    addr: prefix.addr(),
-                }
-                .into(),
-            );
-        }
-        for prefix in &link.state.v6addr {
-            hello.tlvs.push(
-                IsisTlvIpv6GlobalIfAddr {
-                    addr: prefix.addr(),
-                }
-                .into(),
-            );
-        }
-    }
+    push_if_addr_tlvs(&mut hello.tlvs, link);
 
     let mut neighbors = Vec::new();
     for (_, nbr) in link.state.nbrs.get(&level).iter() {
@@ -214,38 +219,7 @@ pub fn hello_p2p_generate(link: &LinkTop, level: Level) -> IsisP2pHello {
     let tlv = IsisTlvAreaAddr { area_addr };
     hello.tlvs.push(tlv.into());
 
-    // Add IPv4 interface addresses
-    if link.config.enable.v4 {
-        for prefix in &link.state.v4addr {
-            hello.tlvs.push(
-                IsisTlvIpv4IfAddr {
-                    addr: prefix.addr(),
-                }
-                .into(),
-            );
-        }
-    }
-
-    // IPv6 Interface Address TLVs (RFC 5308 TLV 232 for link-local; non-standard
-    // TLV 233 for global) — only when IS-IS IPv6 is enabled on this link.
-    if link.config.enable.v6 {
-        for prefix in &link.state.v6laddr {
-            hello.tlvs.push(
-                IsisTlvIpv6IfAddr {
-                    addr: prefix.addr(),
-                }
-                .into(),
-            );
-        }
-        for prefix in &link.state.v6addr {
-            hello.tlvs.push(
-                IsisTlvIpv6GlobalIfAddr {
-                    addr: prefix.addr(),
-                }
-                .into(),
-            );
-        }
-    }
+    push_if_addr_tlvs(&mut hello.tlvs, link);
 
     // Three-way handshake (RFC 5303). On a point-to-point circuit the
     // adjacency is per-circuit, not per-level: one neighbor is reachable

--- a/zebra-rs/src/isis/lsp.rs
+++ b/zebra-rs/src/isis/lsp.rs
@@ -114,108 +114,99 @@ pub fn resolve_dis_ifindex(
         })
 }
 
-/// Split a TLV 135 (Extended IP Reachability) whose serialized
-/// value would overflow the 8-bit Length field into multiple TLV
-/// instances of type 135, each ≤ 255 value-bytes. Entries are
-/// distributed left-to-right; placement is stable per entry order.
-fn split_ext_ip_reach(t: IsisTlvExtIpReach) -> Vec<IsisTlv> {
-    let mut out: Vec<IsisTlv> = Vec::new();
-    let mut current = IsisTlvExtIpReach::default();
-    for entry in t.entries.into_iter() {
-        current.entries.push(entry);
-        let probe: IsisTlv = current.clone().into();
-        if probe.wire_len() > TLV_WIRE_MAX {
-            let latest = current.entries.pop().expect("just pushed");
-            if !current.entries.is_empty() {
-                out.push(current.into());
-            }
-            current = IsisTlvExtIpReach::default();
-            current.entries.push(latest);
-        }
-    }
-    if !current.entries.is_empty() {
-        out.push(current.into());
-    }
-    out
+/// Entry-bearing TLV the splitter below can shard into multiple
+/// instances of the same TLV type. `fresh` clones the per-instance
+/// header (the 2-byte MT ID on TLV 222/237) with an empty entry
+/// list.
+trait SplittableTlv: Clone + Into<IsisTlv> {
+    type Entry;
+    fn fresh(&self) -> Self;
+    fn entries_mut(&mut self) -> &mut Vec<Self::Entry>;
+    fn into_entries(self) -> Vec<Self::Entry>;
 }
 
-/// Same split as `split_ext_ip_reach` but for TLV 236 (IPv6
-/// Reachability).
-fn split_ipv6_reach(t: IsisTlvIpv6Reach) -> Vec<IsisTlv> {
-    let mut out: Vec<IsisTlv> = Vec::new();
-    let mut current = IsisTlvIpv6Reach::default();
-    for entry in t.entries.into_iter() {
-        current.entries.push(entry);
-        let probe: IsisTlv = current.clone().into();
-        if probe.wire_len() > TLV_WIRE_MAX {
-            let latest = current.entries.pop().expect("just pushed");
-            if !current.entries.is_empty() {
-                out.push(current.into());
-            }
-            current = IsisTlvIpv6Reach::default();
-            current.entries.push(latest);
-        }
+impl SplittableTlv for IsisTlvExtIpReach {
+    type Entry = IsisTlvExtIpReachEntry;
+    fn fresh(&self) -> Self {
+        Self::default()
     }
-    if !current.entries.is_empty() {
-        out.push(current.into());
+    fn entries_mut(&mut self) -> &mut Vec<Self::Entry> {
+        &mut self.entries
     }
-    out
+    fn into_entries(self) -> Vec<Self::Entry> {
+        self.entries
+    }
 }
 
-/// Same split as above, for TLV 222 (MT IS Reachability). The 2-byte
-/// MT ID prefix is preserved on every output instance.
-fn split_mt_is_reach(t: IsisTlvMtIsReach) -> Vec<IsisTlv> {
-    let mt = t.mt;
-    let mut out: Vec<IsisTlv> = Vec::new();
-    let mut current = IsisTlvMtIsReach {
-        mt,
-        entries: Vec::new(),
-    };
-    for entry in t.entries.into_iter() {
-        current.entries.push(entry);
-        let probe: IsisTlv = current.clone().into();
-        if probe.wire_len() > TLV_WIRE_MAX {
-            let latest = current.entries.pop().expect("just pushed");
-            if !current.entries.is_empty() {
-                out.push(current.into());
-            }
-            current = IsisTlvMtIsReach {
-                mt,
-                entries: Vec::new(),
-            };
-            current.entries.push(latest);
-        }
+impl SplittableTlv for IsisTlvIpv6Reach {
+    type Entry = IsisTlvIpv6ReachEntry;
+    fn fresh(&self) -> Self {
+        Self::default()
     }
-    if !current.entries.is_empty() {
-        out.push(current.into());
+    fn entries_mut(&mut self) -> &mut Vec<Self::Entry> {
+        &mut self.entries
     }
-    out
+    fn into_entries(self) -> Vec<Self::Entry> {
+        self.entries
+    }
 }
 
-/// Same split, for TLV 237 (MT IPv6 Reachability).
-fn split_mt_ipv6_reach(t: IsisTlvMtIpv6Reach) -> Vec<IsisTlv> {
-    let mt = t.mt;
-    let mut out: Vec<IsisTlv> = Vec::new();
-    let mut current = IsisTlvMtIpv6Reach {
-        mt,
-        entries: Vec::new(),
-    };
-    for entry in t.entries.into_iter() {
-        current.entries.push(entry);
-        let probe: IsisTlv = current.clone().into();
-        if probe.wire_len() > TLV_WIRE_MAX {
-            let latest = current.entries.pop().expect("just pushed");
-            if !current.entries.is_empty() {
-                out.push(current.into());
-            }
-            current = IsisTlvMtIpv6Reach {
-                mt,
-                entries: Vec::new(),
-            };
-            current.entries.push(latest);
+impl SplittableTlv for IsisTlvMtIsReach {
+    type Entry = IsisTlvExtIsReachEntry;
+    fn fresh(&self) -> Self {
+        Self {
+            mt: self.mt,
+            entries: Vec::new(),
         }
     }
-    if !current.entries.is_empty() {
+    fn entries_mut(&mut self) -> &mut Vec<Self::Entry> {
+        &mut self.entries
+    }
+    fn into_entries(self) -> Vec<Self::Entry> {
+        self.entries
+    }
+}
+
+impl SplittableTlv for IsisTlvMtIpv6Reach {
+    type Entry = IsisTlvIpv6ReachEntry;
+    fn fresh(&self) -> Self {
+        Self {
+            mt: self.mt,
+            entries: Vec::new(),
+        }
+    }
+    fn entries_mut(&mut self) -> &mut Vec<Self::Entry> {
+        &mut self.entries
+    }
+    fn into_entries(self) -> Vec<Self::Entry> {
+        self.entries
+    }
+}
+
+/// Split a TLV whose serialized value would overflow the 8-bit
+/// Length field into multiple TLV instances of the same type, each
+/// ≤ 255 value-bytes. Entries are distributed left-to-right;
+/// placement is stable per entry order. Covers TLV 135 (Extended IP
+/// Reachability), 236 (IPv6 Reachability), 222 (MT IS Reachability)
+/// and 237 (MT IPv6 Reachability); the MT variants keep their MT ID
+/// prefix on every output instance.
+fn split_tlv_entries<T: SplittableTlv>(t: T) -> Vec<IsisTlv> {
+    let template = t.fresh();
+    let mut out: Vec<IsisTlv> = Vec::new();
+    let mut current = template.clone();
+    for entry in t.into_entries() {
+        current.entries_mut().push(entry);
+        let probe: IsisTlv = current.clone().into();
+        if probe.wire_len() > TLV_WIRE_MAX {
+            let latest = current.entries_mut().pop().expect("just pushed");
+            if !current.entries_mut().is_empty() {
+                out.push(current.into());
+            }
+            current = template.clone();
+            current.entries_mut().push(latest);
+        }
+    }
+    if !current.entries_mut().is_empty() {
         out.push(current.into());
     }
     out
@@ -233,10 +224,10 @@ fn split_distributable_at_255(tlv: IsisTlv) -> Vec<IsisTlv> {
         return vec![tlv];
     }
     match tlv {
-        IsisTlv::ExtIpReach(t) => split_ext_ip_reach(t),
-        IsisTlv::Ipv6Reach(t) => split_ipv6_reach(t),
-        IsisTlv::MtIsReach(t) => split_mt_is_reach(t),
-        IsisTlv::MtIpv6Reach(t) => split_mt_ipv6_reach(t),
+        IsisTlv::ExtIpReach(t) => split_tlv_entries(t),
+        IsisTlv::Ipv6Reach(t) => split_tlv_entries(t),
+        IsisTlv::MtIsReach(t) => split_tlv_entries(t),
+        IsisTlv::MtIpv6Reach(t) => split_tlv_entries(t),
         other => vec![other],
     }
 }
@@ -1683,7 +1674,7 @@ mod tests {
             entries: (0..40).map(v4_entry).collect(),
         };
         let expected = tlv.entries.len();
-        let shards = split_ext_ip_reach(tlv);
+        let shards = split_tlv_entries(tlv);
         assert!(
             shards.len() >= 2,
             "40 entries × ~9B exceed the 255-byte TLV value ceiling — expected ≥ 2 shards"

--- a/zebra-rs/src/isis/rib.rs
+++ b/zebra-rs/src/isis/rib.rs
@@ -1010,8 +1010,9 @@ fn build_rib_from_spf<F: IsisRibFamily>(
 
 // Walk the LSDB and collect SysIds whose Protocols-Supported TLV (TLV 129)
 // includes the IPv6 NLPID (0x8E). Used by strict NLPID gating in
-// build_rib_from_spf_v6.
-fn ipv6_capable_set(lsdb: &Lsdb) -> BTreeSet<IsisSysId> {
+// build_rib_from_spf_v6 and by show.rs to mirror that gate in the
+// SPF-tree renderers.
+pub(super) fn ipv6_capable_set(lsdb: &Lsdb) -> BTreeSet<IsisSysId> {
     let ipv6_proto: u8 = IsisProto::Ipv6.into();
     let mut set = BTreeSet::new();
     for (lsp_id, lsa) in lsdb.iter() {

--- a/zebra-rs/src/isis/show.rs
+++ b/zebra-rs/src/isis/show.rs
@@ -2,13 +2,13 @@ use std::collections::{BTreeMap, BTreeSet};
 use std::fmt::Write;
 
 use ipnet::{Ipv4Net, Ipv6Net};
-use isis_packet::{IsisProto, IsisSysId, IsisTlv, Nsap};
+use isis_packet::{IsisSysId, Nsap};
 use prefix_trie::PrefixMap;
 use serde::Serialize;
 
 use super::Hostname;
 use super::lsdb::Lsdb;
-use super::rib::{IsisRibFamily, SpfNexthop, SpfRoute, V4, V6};
+use super::rib::{IsisRibFamily, SpfNexthop, SpfRoute, V4, V6, ipv6_capable_set};
 use super::tilfa::{RepairPathMpls, RepairPathSrv6};
 use super::{Isis, inst::ShowCallback};
 
@@ -972,7 +972,7 @@ fn spf_tree_json(
     mt2_mode: bool,
 ) -> Vec<TopoVertexJson> {
     let ipv6_capable = if ipv6 && !mt2_mode {
-        Some(ipv6_capable_set_show(isis, level))
+        Some(ipv6_capable_set(isis.lsdb.get(level)))
     } else {
         None
     };
@@ -1335,21 +1335,6 @@ fn ifname_for_neighbor(isis: &Isis, level: &Level, sys_id: &IsisSysId) -> String
     String::from("-")
 }
 
-fn ipv6_capable_set_show(isis: &Isis, level: &Level) -> BTreeSet<IsisSysId> {
-    let ipv6_proto: u8 = IsisProto::Ipv6.into();
-    let mut set = BTreeSet::new();
-    for (lsp_id, lsa) in isis.lsdb.get(level).iter() {
-        for tlv in &lsa.lsp.tlvs {
-            if let IsisTlv::ProtoSupported(ps) = tlv
-                && ps.nlpids.contains(&ipv6_proto)
-            {
-                set.insert(lsp_id.sys_id());
-            }
-        }
-    }
-    set
-}
-
 #[allow(clippy::too_many_arguments)]
 fn write_spf_tree(
     buf: &mut String,
@@ -1390,7 +1375,7 @@ fn write_spf_tree(
     // already filtered to MT-2-capable peers (TLV 229 is the
     // stricter signal), so the NLPID gate is redundant — skip it.
     let ipv6_capable = if ipv6 && !mt2_mode {
-        Some(ipv6_capable_set_show(isis, level))
+        Some(ipv6_capable_set(isis.lsdb.get(level)))
     } else {
         None
     };


### PR DESCRIPTION
First slice of the IS-IS v4/v6 dedup pass — the three mechanical, behavior-preserving items from the duplication scan.

## Changes

1. **lsp.rs** — `split_ext_ip_reach` / `split_ipv6_reach` / `split_mt_is_reach` / `split_mt_ipv6_reach` were four copies of the same shard-at-255-bytes algorithm. Replaced with one `split_tlv_entries` generic over a small `SplittableTlv` trait; `fresh()` preserves the MT ID header on the TLV 222/237 variants.
2. **ifsm.rs** — the LAN and P2P Hello generators carried byte-identical blocks pushing IPv4/IPv6 Interface Address TLVs (132 / 232 / 233). Extracted `push_if_addr_tlvs`, called from both.
3. **rib.rs + show.rs** — `show.rs::ipv6_capable_set_show` duplicated `rib.rs::ipv6_capable_set` (RFC 1195 §5 NLPID gate). The rib version is now `pub(super)` and both show-side SPF-tree renderers call it.

No behavior change intended; entry distribution, TLV ordering, and gate semantics are unchanged.

## Testing

- `cargo fmt --check`, `cargo clippy --workspace --all-targets -- -D warnings` clean
- `cargo test --workspace --exclude bdd` — all green (incl. the existing splitter/packer shard tests in lsp.rs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)