### PR TITLE
bgp: add per-AFI/SAFI Established-peer membership index to PeerMap

### DIFF
--- a/docs/design/bgp-peer-list.md
+++ b/docs/design/bgp-peer-list.md
@@ -337,6 +337,23 @@ of B.
    consolidation — convert site by site with the `debug_assert`
    cross-check active; include detach-on-remove.
 
+   *Status — index landed.* `bgp/membership.rs` holds
+   `FamilyMembers { addpath_tx, plain }` keyed by `AfiSafi`. The
+   structure lives **inside `PeerMap`** (not `BgpTop`, which has 36
+   construction sites) so peer removal purges membership by
+   construction — that closes the ident-reuse ABA hazard
+   structurally rather than by convention. Enroll/withdraw run at
+   the FSM chokepoint next to `update_group::attach`/`detach`, and
+   `PeerMap::debug_verify_membership` cross-checks both directions
+   (index↔peers) on every FSM state transition in debug builds. The
+   three `peers.remove` sites (`config.rs` neighbor delete,
+   `interface_neighbor.rs` interface-neighbor delete, `inst.rs`
+   dynamic-peer GC) now also call `update_group::detach` explicitly
+   — update-groups live outside `PeerMap`, so their member sets do
+   not purge by construction. Remaining: convert the fourteen
+   fan-outs in §9 to consume `peers.membership().family(afi, safi)`
+   instead of scan-and-filter.
+
 Steps 1–3 are independent small PRs per the
 smallest-possible-PR-first rule; step 4 should not start until the
 direction is confirmed on review of this document.

--- a/zebra-rs/src/bgp/config.rs
+++ b/zebra-rs/src/bgp/config.rs
@@ -156,6 +156,11 @@ fn config_peer(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Option<()> {
             lu_labels: None,
         };
         route_clean(peer_idx, &mut bgp_ref, &mut bgp.peers);
+        // Update-groups live outside `PeerMap`: removal below purges
+        // the membership index by construction, but the group member
+        // sets must be detached explicitly or the freed ident lingers
+        // and a future slot reuse inherits the group.
+        super::update_group::detach(&mut bgp.update_groups, &mut bgp.peers, peer_idx);
         bgp.peers.remove(&addr);
     }
     // Keep the shared listener's TCP MSS minimum in step with the peer

--- a/zebra-rs/src/bgp/inst.rs
+++ b/zebra-rs/src/bgp/inst.rs
@@ -1484,6 +1484,12 @@ impl Bgp {
             return;
         }
         let addr = peer.address;
+        // Idempotent safety net: the FSM detach already ran when the
+        // session left Established (OpenSent/OpenConfirm sessions were
+        // never attached), but a GC'd ident must never linger in a
+        // group's member set — the slot is reused when the same source
+        // re-materializes.
+        super::update_group::detach(&mut self.update_groups, &mut self.peers, ident);
         self.peers.remove(&addr);
         self.dynamic_peer_count = self.dynamic_peer_count.saturating_sub(1);
     }

--- a/zebra-rs/src/bgp/interface_neighbor.rs
+++ b/zebra-rs/src/bgp/interface_neighbor.rs
@@ -285,6 +285,12 @@ pub fn config_interface_neighbor(bgp: &mut Bgp, mut args: Args, op: ConfigOp) ->
                         lu_labels: None,
                     };
                     super::route::route_clean(peer_idx, &mut bgp_ref, &mut bgp.peers);
+                    // Update-groups live outside `PeerMap`: the
+                    // removal below purges the membership index by
+                    // construction, but the group member sets need an
+                    // explicit detach or the freed ident lingers and a
+                    // future slot reuse inherits the group.
+                    super::update_group::detach(&mut bgp.update_groups, &mut bgp.peers, peer_idx);
                 }
                 bgp.peers.remove_by_key(&PeerKey::Interface(ifindex));
             }

--- a/zebra-rs/src/bgp/membership.rs
+++ b/zebra-rs/src/bgp/membership.rs
@@ -1,0 +1,165 @@
+//! Per-AFI/SAFI membership index over Established peers.
+//!
+//! Every advertise fan-out asks the same three questions of every
+//! peer: is the session Established, is the family negotiated, and is
+//! AddPath Send on. All three are session constants — they change
+//! only when a session enters or leaves Established (the capability
+//! intersection is fixed by the OPEN exchange, and RFC 7911 has no
+//! mid-session AddPath renegotiation). This index answers them once,
+//! at the FSM chokepoint, instead of per-prefix in every fan-out.
+//!
+//! Ownership: the index lives inside `PeerMap` so peer removal purges
+//! membership by construction — a freed ident can never linger here
+//! and be inherited by the next peer that reuses the slot (`PeerMap`
+//! reuses indices on same-key re-insert, so a stale ident is an ABA
+//! hazard, not just a leak). The update-groups structure lives outside
+//! `PeerMap` and needs an explicit `update_group::detach` at every
+//! removal site instead.
+//!
+//! See `docs/design/bgp-peer-list.md` (Option B) for the full design.
+
+use std::collections::{BTreeMap, BTreeSet};
+
+use bgp_packet::{Afi, AfiSafi, Safi};
+
+/// The Established peers of one address family, split by negotiated
+/// AddPath Send. The split mirrors the two advertise pipelines — the
+/// per-candidate fan-out that stamps allocated path-ids on every NLRI
+/// (RFC 7911) versus best-path-only — so a fan-out walks exactly the
+/// set whose wire contract it implements.
+#[derive(Debug, Default, Clone)]
+pub struct FamilyMembers {
+    /// AddPath Send negotiated: every NLRI of this family sent to
+    /// these peers must carry a path identifier.
+    pub addpath_tx: BTreeSet<usize>,
+    /// Best-path-only peers — no path-id field on the wire.
+    pub plain: BTreeSet<usize>,
+}
+
+impl FamilyMembers {
+    pub fn is_empty(&self) -> bool {
+        self.addpath_tx.is_empty() && self.plain.is_empty()
+    }
+
+    /// `Some(true)` if `ident` is enrolled in the AddPath-send half,
+    /// `Some(false)` if in the plain half, `None` if absent.
+    pub fn classification(&self, ident: usize) -> Option<bool> {
+        if self.addpath_tx.contains(&ident) {
+            Some(true)
+        } else if self.plain.contains(&ident) {
+            Some(false)
+        } else {
+            None
+        }
+    }
+
+    /// Every member of the family — the AddPath-send half first, then
+    /// plain, each ascending by ident.
+    pub fn iter_all(&self) -> impl Iterator<Item = usize> + '_ {
+        self.addpath_tx.iter().chain(self.plain.iter()).copied()
+    }
+}
+
+/// AFI/SAFI → Established members. Maintained exclusively by
+/// `PeerMap` (`membership_enroll` / `membership_withdraw` at the FSM
+/// Established boundary, auto-purge on removal); fan-outs read it via
+/// `PeerMap::membership`.
+#[derive(Debug, Default)]
+pub struct PeerMembership {
+    families: BTreeMap<AfiSafi, FamilyMembers>,
+}
+
+impl PeerMembership {
+    /// Enroll `ident` into `(afi, safi)` under the given AddPath-send
+    /// classification. Re-enrolling moves the ident between halves
+    /// when the classification differs, so a stale entry cannot
+    /// survive a re-enroll.
+    pub fn enroll(&mut self, afi_safi: AfiSafi, ident: usize, addpath_tx: bool) {
+        let fam = self.families.entry(afi_safi).or_default();
+        if addpath_tx {
+            fam.plain.remove(&ident);
+            fam.addpath_tx.insert(ident);
+        } else {
+            fam.addpath_tx.remove(&ident);
+            fam.plain.insert(ident);
+        }
+    }
+
+    /// Remove `ident` from every family; emptied families are
+    /// dropped. Idempotent.
+    pub fn withdraw(&mut self, ident: usize) {
+        self.families.retain(|_, fam| {
+            fam.addpath_tx.remove(&ident);
+            fam.plain.remove(&ident);
+            !fam.is_empty()
+        });
+    }
+
+    /// The members of one family, or `None` when no Established peer
+    /// has it negotiated.
+    pub fn family(&self, afi: Afi, safi: Safi) -> Option<&FamilyMembers> {
+        self.families.get(&AfiSafi::new(afi, safi))
+    }
+
+    pub fn iter(&self) -> impl Iterator<Item = (&AfiSafi, &FamilyMembers)> {
+        self.families.iter()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn enroll_splits_addpath_and_plain() {
+        let mut m = PeerMembership::default();
+        let v4 = AfiSafi::new(Afi::Ip, Safi::Unicast);
+        m.enroll(v4, 1, true);
+        m.enroll(v4, 2, false);
+
+        let fam = m.family(Afi::Ip, Safi::Unicast).expect("family exists");
+        assert_eq!(fam.classification(1), Some(true));
+        assert_eq!(fam.classification(2), Some(false));
+        assert_eq!(fam.classification(3), None);
+        assert_eq!(fam.iter_all().collect::<Vec<_>>(), vec![1, 2]);
+    }
+
+    #[test]
+    fn re_enroll_moves_between_halves() {
+        let mut m = PeerMembership::default();
+        let v4 = AfiSafi::new(Afi::Ip, Safi::Unicast);
+        m.enroll(v4, 1, false);
+        m.enroll(v4, 1, true);
+
+        let fam = m.family(Afi::Ip, Safi::Unicast).expect("family exists");
+        assert_eq!(
+            fam.classification(1),
+            Some(true),
+            "re-enroll must not leave the ident in both halves"
+        );
+        assert_eq!(fam.iter_all().count(), 1);
+    }
+
+    #[test]
+    fn withdraw_purges_every_family_and_drops_empty() {
+        let mut m = PeerMembership::default();
+        let v4 = AfiSafi::new(Afi::Ip, Safi::Unicast);
+        let v6 = AfiSafi::new(Afi::Ip6, Safi::Unicast);
+        m.enroll(v4, 1, true);
+        m.enroll(v6, 1, false);
+        m.enroll(v6, 2, false);
+
+        m.withdraw(1);
+        assert!(
+            m.family(Afi::Ip, Safi::Unicast).is_none(),
+            "emptied family must be dropped"
+        );
+        let fam = m.family(Afi::Ip6, Safi::Unicast).expect("v6 still has 2");
+        assert_eq!(fam.classification(1), None);
+        assert_eq!(fam.classification(2), Some(false));
+
+        // Idempotent.
+        m.withdraw(1);
+        assert_eq!(m.iter().count(), 1);
+    }
+}

--- a/zebra-rs/src/bgp/mod.rs
+++ b/zebra-rs/src/bgp/mod.rs
@@ -10,6 +10,7 @@ pub mod connected;
 pub mod dynamic_neighbors;
 pub mod interface_addrs;
 pub mod interface_neighbor;
+pub mod membership;
 pub mod neighbor_group;
 pub mod peer;
 pub mod peer_key;

--- a/zebra-rs/src/bgp/peer.rs
+++ b/zebra-rs/src/bgp/peer.rs
@@ -1530,11 +1530,11 @@ pub fn fsm(bgp_ref: &mut BgpTop, peer_map: &mut PeerMap, id: usize, event: Event
         route_clean(id, bgp_ref, peer_map);
     }
 
-    // Maintain update-group membership across the Established
-    // boundary. Detach must run *after* route_clean so observability
-    // sees the peer leave the group only once routes have been torn
-    // down; attach runs after route_sync so the group reflects the
-    // post-sync state.
+    // Maintain update-group membership and the per-family membership
+    // index across the Established boundary. Detach must run *after*
+    // route_clean so observability sees the peer leave the group only
+    // once routes have been torn down; attach runs after route_sync
+    // so the group reflects the post-sync state.
     {
         let now_established = peer_map
             .get_by_idx(id)
@@ -1542,9 +1542,12 @@ pub fn fsm(bgp_ref: &mut BgpTop, peer_map: &mut PeerMap, id: usize, event: Event
             .unwrap_or(false);
         if prev_state.is_established() && !now_established {
             super::update_group::detach(bgp_ref.update_groups, peer_map, id);
+            peer_map.membership_withdraw(id);
         } else if !prev_state.is_established() && now_established {
             super::update_group::attach(bgp_ref.update_groups, peer_map, id);
+            peer_map.membership_enroll(id);
         }
+        peer_map.debug_verify_membership();
     }
 }
 

--- a/zebra-rs/src/bgp/peer_map.rs
+++ b/zebra-rs/src/bgp/peer_map.rs
@@ -1,6 +1,9 @@
 use std::collections::BTreeMap;
 use std::net::IpAddr;
 
+use bgp_packet::AfiSafi;
+
+use super::membership::PeerMembership;
 use super::peer::Peer;
 use super::peer_key::PeerKey;
 
@@ -8,6 +11,10 @@ use super::peer_key::PeerKey;
 pub struct PeerMap {
     map: BTreeMap<PeerKey, usize>,
     peers: Vec<Option<Peer>>,
+    /// Per-AFI/SAFI index of Established peers, maintained at the FSM
+    /// Established boundary and purged on removal — see
+    /// [`super::membership`] for why it lives inside `PeerMap`.
+    membership: PeerMembership,
 }
 
 impl PeerMap {
@@ -52,6 +59,10 @@ impl PeerMap {
     pub fn insert_with_key(&mut self, key: PeerKey, mut peer: Peer) {
         if let Some(&idx) = self.map.get(&key) {
             peer.ident = idx;
+            // Replacing the slot's occupant: any membership held under
+            // this ident belongs to the previous session, not the new
+            // peer.
+            self.membership.withdraw(idx);
             self.peers[idx] = Some(peer);
         } else {
             let idx = self.peers.len();
@@ -67,7 +78,119 @@ impl PeerMap {
 
     pub fn remove_by_key(&mut self, key: &PeerKey) -> Option<Peer> {
         let &idx = self.map.get(key)?;
-        self.peers[idx].take()
+        let removed = self.peers[idx].take();
+        if removed.is_some() {
+            // The slot's ident is reused by a same-key re-insert;
+            // purge here so the next occupant can't inherit the old
+            // session's membership (the ABA hazard).
+            self.membership.withdraw(idx);
+        }
+        removed
+    }
+
+    /// Read access for fan-outs: walk `membership().family(afi,
+    /// safi)`, snapshot the idents, then re-look-up mutably via
+    /// [`Self::get_mut_by_idx`].
+    pub fn membership(&self) -> &PeerMembership {
+        &self.membership
+    }
+
+    /// (Re)compute `idx`'s family membership from its negotiated
+    /// capabilities. Called from the FSM chokepoint when the session
+    /// enters Established — the criteria (capability intersection,
+    /// AddPath Send) are session constants fixed by the OPEN exchange,
+    /// so enrolling once per session is sound.
+    pub fn membership_enroll(&mut self, idx: usize) {
+        let Some(peer) = self.peers.get(idx).and_then(|slot| slot.as_ref()) else {
+            return;
+        };
+        let families: Vec<(AfiSafi, bool)> = peer
+            .cap_map
+            .entries
+            .iter()
+            .filter(|(_, sr)| sr.send && sr.recv)
+            .map(|(mp, _)| {
+                (
+                    AfiSafi::new(mp.afi, mp.safi),
+                    peer.opt.is_add_path_send(mp.afi, mp.safi),
+                )
+            })
+            .collect();
+        // Withdraw first: a re-enroll (new session on a reused slot)
+        // must not retain families only the previous session
+        // negotiated.
+        self.membership.withdraw(idx);
+        for (afi_safi, addpath_tx) in families {
+            self.membership.enroll(afi_safi, idx, addpath_tx);
+        }
+    }
+
+    /// Drop `idx` from every family. Called from the FSM chokepoint on
+    /// leaving Established; removal paths purge automatically.
+    pub fn membership_withdraw(&mut self, idx: usize) {
+        self.membership.withdraw(idx);
+    }
+
+    /// Cross-check the membership index against ground truth: every
+    /// enrolled ident must be a live Established peer with the family
+    /// negotiated and the AddPath half matching, and every Established
+    /// peer's negotiated families must be enrolled. Runtime no-op in
+    /// release builds; called from the FSM chokepoint while the
+    /// fan-outs migrate from scan-and-filter to the index.
+    pub fn debug_verify_membership(&self) {
+        if !cfg!(debug_assertions) {
+            return;
+        }
+        // Index → peers.
+        for (afi_safi, fam) in self.membership().iter() {
+            for ident in fam.iter_all() {
+                let peer = self
+                    .peers
+                    .get(ident)
+                    .and_then(|slot| slot.as_ref())
+                    .unwrap_or_else(|| panic!("membership {afi_safi:?} holds dead ident {ident}"));
+                assert!(
+                    peer.state.is_established(),
+                    "membership {afi_safi:?} holds non-Established peer {}",
+                    peer.address
+                );
+                assert!(
+                    peer.is_afi_safi(afi_safi.afi, afi_safi.safi),
+                    "membership {afi_safi:?} holds peer {} without the family negotiated",
+                    peer.address
+                );
+                assert_eq!(
+                    fam.classification(ident),
+                    Some(peer.opt.is_add_path_send(afi_safi.afi, afi_safi.safi)),
+                    "membership {afi_safi:?} AddPath half disagrees for peer {}",
+                    peer.address
+                );
+            }
+        }
+        // Peers → index.
+        for peer in self.peers.iter().flatten() {
+            if !peer.state.is_established() {
+                continue;
+            }
+            for (mp, sr) in peer.cap_map.entries.iter() {
+                if !(sr.send && sr.recv) {
+                    continue;
+                }
+                let expected = peer.opt.is_add_path_send(mp.afi, mp.safi);
+                let got = self
+                    .membership()
+                    .family(mp.afi, mp.safi)
+                    .and_then(|fam| fam.classification(peer.ident));
+                assert_eq!(
+                    got,
+                    Some(expected),
+                    "Established peer {} negotiated {}/{} but the index disagrees",
+                    peer.address,
+                    mp.afi,
+                    mp.safi
+                );
+            }
+        }
     }
 
     // NOTE: there is deliberately no addr-only `iter()`/`iter_mut()`.
@@ -125,7 +248,8 @@ impl PeerMap {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::bgp::peer::Peer;
+    use crate::bgp::peer::{Peer, State};
+    use bgp_packet::{Afi, CapMultiProtocol, Direct, Safi};
     use std::net::Ipv4Addr;
     use tokio::sync::mpsc;
 
@@ -177,6 +301,119 @@ mod tests {
         let removed = m.remove_by_key(&k);
         assert!(removed.is_some());
         assert!(m.get_by_key(&k).is_none());
+    }
+
+    /// Mark `(afi, safi)` negotiated on the peer (cap intersection),
+    /// optionally with AddPath Send — the two inputs
+    /// `membership_enroll` classifies on.
+    fn negotiate(peer: &mut Peer, afi: Afi, safi: Safi, addpath_tx: bool) {
+        let key = CapMultiProtocol::new(&afi, &safi);
+        let entry = peer
+            .cap_map
+            .entries
+            .get_mut(&key)
+            .expect("family pre-seeded in CapAfiMap");
+        entry.send = true;
+        entry.recv = true;
+        if addpath_tx {
+            peer.opt.add_path.insert(
+                AfiSafi::new(afi, safi),
+                Direct {
+                    send: true,
+                    recv: false,
+                },
+            );
+        }
+    }
+
+    #[test]
+    fn membership_enroll_classifies_per_negotiated_family() {
+        let mut m = PeerMap::new();
+        let a: IpAddr = Ipv4Addr::new(10, 0, 0, 1).into();
+        let mut peer = make_peer(a);
+        peer.state = State::Established;
+        negotiate(&mut peer, Afi::Ip, Safi::Unicast, true);
+        negotiate(&mut peer, Afi::Ip6, Safi::Unicast, false);
+        m.insert(a, peer);
+        let idx = m.get(&a).unwrap().ident;
+
+        m.membership_enroll(idx);
+        m.debug_verify_membership();
+
+        let v4 = m.membership().family(Afi::Ip, Safi::Unicast).unwrap();
+        assert_eq!(v4.classification(idx), Some(true), "AddPath-send half");
+        let v6 = m.membership().family(Afi::Ip6, Safi::Unicast).unwrap();
+        assert_eq!(v6.classification(idx), Some(false), "plain half");
+        assert!(
+            m.membership().family(Afi::Ip, Safi::MplsVpn).is_none(),
+            "non-negotiated family must not be enrolled"
+        );
+    }
+
+    #[test]
+    fn membership_withdraw_clears_every_family() {
+        let mut m = PeerMap::new();
+        let a: IpAddr = Ipv4Addr::new(10, 0, 0, 1).into();
+        let mut peer = make_peer(a);
+        peer.state = State::Established;
+        negotiate(&mut peer, Afi::Ip, Safi::Unicast, false);
+        negotiate(&mut peer, Afi::Ip6, Safi::Unicast, false);
+        m.insert(a, peer);
+        let idx = m.get(&a).unwrap().ident;
+        m.membership_enroll(idx);
+
+        // What the FSM chokepoint does on leaving Established.
+        m.get_mut(&a).unwrap().state = State::Idle;
+        m.membership_withdraw(idx);
+        m.debug_verify_membership();
+
+        assert!(m.membership().family(Afi::Ip, Safi::Unicast).is_none());
+        assert!(m.membership().family(Afi::Ip6, Safi::Unicast).is_none());
+    }
+
+    #[test]
+    fn remove_purges_membership_against_slot_reuse() {
+        let mut m = PeerMap::new();
+        let a: IpAddr = Ipv4Addr::new(10, 0, 0, 1).into();
+        let mut peer = make_peer(a);
+        peer.state = State::Established;
+        negotiate(&mut peer, Afi::Ip, Safi::Unicast, true);
+        m.insert(a, peer);
+        let idx = m.get(&a).unwrap().ident;
+        m.membership_enroll(idx);
+
+        // Remove WITHOUT an explicit withdraw — the purge must be
+        // structural, or the reused ident below inherits membership.
+        m.remove(&a);
+        assert!(
+            m.membership().family(Afi::Ip, Safi::Unicast).is_none(),
+            "removal must purge membership"
+        );
+
+        // Same key → same slot/ident. The fresh (non-Established,
+        // nothing negotiated) peer must start with no membership.
+        m.insert(a, make_peer(a));
+        assert_eq!(m.get(&a).unwrap().ident, idx, "slot is reused");
+        m.debug_verify_membership();
+        assert!(m.membership().family(Afi::Ip, Safi::Unicast).is_none());
+    }
+
+    #[test]
+    fn insert_over_live_slot_purges_membership() {
+        let mut m = PeerMap::new();
+        let a: IpAddr = Ipv4Addr::new(10, 0, 0, 1).into();
+        let mut peer = make_peer(a);
+        peer.state = State::Established;
+        negotiate(&mut peer, Afi::Ip, Safi::Unicast, false);
+        m.insert(a, peer);
+        let idx = m.get(&a).unwrap().ident;
+        m.membership_enroll(idx);
+
+        // Re-insert over the live slot (no remove in between) — the
+        // replacement must not inherit the old session's membership.
+        m.insert(a, make_peer(a));
+        m.debug_verify_membership();
+        assert!(m.membership().family(Afi::Ip, Safi::Unicast).is_none());
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Step 4 of `docs/design/bgp-peer-list.md` (Option B), first slice: the membership index itself. Every advertise fan-out re-derives the same three session constants per peer per prefix — Established, family negotiated, AddPath Send. This PR computes them once at the FSM Established boundary and stores them in an index; converting the fourteen fan-outs to consume it is the follow-up PR.

- **`bgp/membership.rs`**: `FamilyMembers { addpath_tx, plain }` keyed by `AfiSafi`. The split mirrors the two advertise pipelines (per-candidate fan-out stamping allocated path-ids per RFC 7911 vs best-path-only), so a fan-out walks exactly the set whose wire contract it implements.
- **Index lives inside `PeerMap`** (not `BgpTop`, which has 36 construction sites): `remove_by_key` and insert-over-a-live-slot purge membership by construction, closing the ident-reuse ABA hazard structurally rather than by convention.
- **FSM chokepoint** (`peer.rs::fsm`): `membership_enroll` / `membership_withdraw` run next to `update_group::attach`/`detach`; `PeerMap::debug_verify_membership` cross-checks index↔peers in both directions on every FSM state transition (debug builds only, runtime no-op in release) while the fan-outs migrate.
- **Detach-on-remove**: the three `peers.remove` sites (`config.rs` neighbor delete, `interface_neighbor.rs` interface-neighbor delete, `inst.rs` dynamic-peer GC) now call `update_group::detach` explicitly — update-groups live outside `PeerMap`, so a removed peer's ident would otherwise linger in group member sets and be inherited by the next occupant of the reused slot.
- Design doc §8 step 4 updated with the landed status.

No behavior change in release builds.

## Testing

- `cargo fmt` / `cargo clippy --workspace --all-targets -- -D warnings` clean
- `cargo test --workspace --exclude bdd`: all green (membership: 3 new unit tests; peer_map: 4 new tests covering enroll classification, withdraw, removal purge against slot reuse, insert-over-live-slot purge)
- BDD: `@bgp_v6_incremental` (3 scenarios), `@bgp_unnumbered_incremental` (4), `@bgp_neighbor_group` (6) — all passed against the rebuilt binary

🤖 Generated with [Claude Code](https://claude.com/claude-code)