### PR TITLE
bgp: convert advertise fan-outs to consume the peer membership index

### DIFF
--- a/docs/design/bgp-peer-list.md
+++ b/docs/design/bgp-peer-list.md
@@ -350,9 +350,21 @@ of B.
    `interface_neighbor.rs` interface-neighbor delete, `inst.rs`
    dynamic-peer GC) now also call `update_group::detach` explicitly
    — update-groups live outside `PeerMap`, so their member sets do
-   not purge by construction. Remaining: convert the fourteen
-   fan-outs in §9 to consume `peers.membership().family(afi, safi)`
-   instead of scan-and-filter.
+   not purge by construction.
+
+   *Status — fan-outs converted.* All fourteen §9 sites now consume
+   the index via three `PeerMap` snapshot helpers:
+   `established_idents` (union), `established_plain_idents`
+   (best-path-only pipeline), `established_addpath_idents`
+   (per-candidate pipeline). The index maintenance moved to flip in
+   lockstep with `peer.state` itself — *before* `fsm_effect` and
+   `route_clean`, both of which fan out — so withdraw-before-clean
+   excludes the dying peer exactly as the live `is_established()`
+   filters did. The `update_group::attach`/`detach` calls stay at
+   the tail of `fsm` (detach intentionally after `route_clean` for
+   observability), and `debug_verify_membership` still runs on every
+   FSM transition. Step 4 is complete; the per-prefix scans are
+   gone.
 
 Steps 1–3 are independent small PRs per the
 smallest-possible-PR-first rule; step 4 should not start until the
@@ -380,5 +392,11 @@ direction is confirmed on review of this document.
 Single-peer guards (not fan-outs): `route_soft_out_peer`
 (`route.rs:2953`), `route_soft_in_peer` (`route.rs:3225`).
 
-All fourteen fan-outs use `peers.iter()` (addr-keyed only — B2) and
-none can reach an interface-keyed peer.
+*Historical note* — at the time of the analysis, all fourteen
+fan-outs used `peers.iter()` (addr-keyed only — B2) and none could
+reach an interface-keyed peer. #1414 converted them to ident-based
+`iter_all()` scans; the step-4 refactor then replaced the scans
+entirely with the membership-index snapshots
+(`established_idents` / `established_plain_idents` /
+`established_addpath_idents`), so the table's line numbers and
+"AddPath handling" column describe the pre-refactor code.

--- a/zebra-rs/src/bgp/peer.rs
+++ b/zebra-rs/src/bgp/peer.rs
@@ -1506,6 +1506,24 @@ pub fn fsm(bgp_ref: &mut BgpTop, peer_map: &mut PeerMap, id: usize, event: Event
         (prev_state, effect)
     };
 
+    // Keep the membership index in lockstep with the live
+    // `state.is_established()` predicate the fan-outs used to scan:
+    // the index must flip together with the state set above, before
+    // the FSM effect and route_clean below can fan anything out —
+    // withdraw-before-clean excludes the dying peer exactly as the
+    // live-state filters did.
+    {
+        let now_established = peer_map
+            .get_by_idx(id)
+            .map(|p| p.state.is_established())
+            .unwrap_or(false);
+        if prev_state.is_established() && !now_established {
+            peer_map.membership_withdraw(id);
+        } else if !prev_state.is_established() && now_established {
+            peer_map.membership_enroll(id);
+        }
+    }
+
     // Execute side effects that need peer_map.
     fsm_effect(id, effect, bgp_ref, peer_map);
 
@@ -1530,11 +1548,12 @@ pub fn fsm(bgp_ref: &mut BgpTop, peer_map: &mut PeerMap, id: usize, event: Event
         route_clean(id, bgp_ref, peer_map);
     }
 
-    // Maintain update-group membership and the per-family membership
-    // index across the Established boundary. Detach must run *after*
-    // route_clean so observability sees the peer leave the group only
-    // once routes have been torn down; attach runs after route_sync
-    // so the group reflects the post-sync state.
+    // Maintain update-group membership across the Established
+    // boundary. Detach must run *after* route_clean so observability
+    // sees the peer leave the group only once routes have been torn
+    // down; attach runs after route_sync so the group reflects the
+    // post-sync state. (The membership index flipped earlier, with
+    // the state itself.)
     {
         let now_established = peer_map
             .get_by_idx(id)
@@ -1542,10 +1561,8 @@ pub fn fsm(bgp_ref: &mut BgpTop, peer_map: &mut PeerMap, id: usize, event: Event
             .unwrap_or(false);
         if prev_state.is_established() && !now_established {
             super::update_group::detach(bgp_ref.update_groups, peer_map, id);
-            peer_map.membership_withdraw(id);
         } else if !prev_state.is_established() && now_established {
             super::update_group::attach(bgp_ref.update_groups, peer_map, id);
-            peer_map.membership_enroll(id);
         }
         peer_map.debug_verify_membership();
     }

--- a/zebra-rs/src/bgp/peer_map.rs
+++ b/zebra-rs/src/bgp/peer_map.rs
@@ -1,7 +1,7 @@
 use std::collections::BTreeMap;
 use std::net::IpAddr;
 
-use bgp_packet::AfiSafi;
+use bgp_packet::{Afi, AfiSafi, Safi};
 
 use super::membership::PeerMembership;
 use super::peer::Peer;
@@ -93,6 +93,36 @@ impl PeerMap {
     /// [`Self::get_mut_by_idx`].
     pub fn membership(&self) -> &PeerMembership {
         &self.membership
+    }
+
+    /// Snapshot of every Established peer that negotiated `(afi,
+    /// safi)` — both AddPath-send and plain members. The fan-out
+    /// idiom: iterate this, re-look-up mutably via
+    /// [`Self::get_mut_by_idx`].
+    pub fn established_idents(&self, afi: Afi, safi: Safi) -> Vec<usize> {
+        self.membership
+            .family(afi, safi)
+            .map(|fam| fam.iter_all().collect())
+            .unwrap_or_default()
+    }
+
+    /// Established `(afi, safi)` peers WITHOUT AddPath Send — the
+    /// best-path-only pipeline's audience.
+    pub fn established_plain_idents(&self, afi: Afi, safi: Safi) -> Vec<usize> {
+        self.membership
+            .family(afi, safi)
+            .map(|fam| fam.plain.iter().copied().collect())
+            .unwrap_or_default()
+    }
+
+    /// Established `(afi, safi)` peers WITH AddPath Send negotiated —
+    /// the per-candidate pipeline's audience (every NLRI to them
+    /// carries a path-id, RFC 7911 §3).
+    pub fn established_addpath_idents(&self, afi: Afi, safi: Safi) -> Vec<usize> {
+        self.membership
+            .family(afi, safi)
+            .map(|fam| fam.addpath_tx.iter().copied().collect())
+            .unwrap_or_default()
     }
 
     /// (Re)compute `idx`'s family membership from its negotiated
@@ -347,6 +377,54 @@ mod tests {
         assert!(
             m.membership().family(Afi::Ip, Safi::MplsVpn).is_none(),
             "non-negotiated family must not be enrolled"
+        );
+    }
+
+    /// The fan-out entry points: `established_addpath_idents` /
+    /// `established_plain_idents` partition the family,
+    /// `established_idents` is their union, and a family nobody
+    /// negotiated yields an empty Vec (not a panic).
+    #[test]
+    fn established_ident_snapshots_partition_by_addpath() {
+        let mut m = PeerMap::new();
+
+        let a: IpAddr = Ipv4Addr::new(10, 0, 0, 1).into();
+        let mut peer = make_peer(a);
+        peer.state = State::Established;
+        negotiate(&mut peer, Afi::Ip, Safi::Unicast, true);
+        m.insert(a, peer);
+        let a_idx = m.get(&a).unwrap().ident;
+        m.membership_enroll(a_idx);
+
+        let b: IpAddr = Ipv4Addr::new(10, 0, 0, 2).into();
+        let mut peer = make_peer(b);
+        peer.state = State::Established;
+        negotiate(&mut peer, Afi::Ip, Safi::Unicast, false);
+        m.insert(b, peer);
+        let b_idx = m.get(&b).unwrap().ident;
+        m.membership_enroll(b_idx);
+
+        assert_eq!(
+            m.established_addpath_idents(Afi::Ip, Safi::Unicast),
+            vec![a_idx]
+        );
+        assert_eq!(
+            m.established_plain_idents(Afi::Ip, Safi::Unicast),
+            vec![b_idx]
+        );
+        let mut all = m.established_idents(Afi::Ip, Safi::Unicast);
+        all.sort_unstable();
+        assert_eq!(all, vec![a_idx, b_idx]);
+
+        // A family nobody negotiated: every snapshot is empty.
+        assert!(m.established_idents(Afi::Ip6, Safi::Unicast).is_empty());
+        assert!(
+            m.established_plain_idents(Afi::Ip6, Safi::Unicast)
+                .is_empty()
+        );
+        assert!(
+            m.established_addpath_idents(Afi::Ip6, Safi::Unicast)
+                .is_empty()
         );
     }
 

--- a/zebra-rs/src/bgp/route.rs
+++ b/zebra-rs/src/bgp/route.rs
@@ -2408,13 +2408,7 @@ fn route_advertise_to_addpath(
     };
     let afi_safi = AfiSafi::new(afi, safi);
 
-    let peer_idents: Vec<usize> = peers
-        .iter_all()
-        .filter(|(_, p)| p.state.is_established())
-        .filter(|(_, p)| p.is_afi_safi(afi, safi))
-        .filter(|(_, p)| p.opt.is_add_path_send(afi, safi))
-        .map(|(_, p)| p.ident)
-        .collect();
+    let peer_idents: Vec<usize> = peers.established_addpath_idents(afi, safi);
 
     for ident in peer_idents {
         let peer = peers.get_mut_by_idx(ident).expect("peer exists");
@@ -2485,13 +2479,7 @@ fn route_withdraw_from_addpath(
     };
     let afi_safi = AfiSafi::new(afi, safi);
 
-    let peer_idents: Vec<usize> = peers
-        .iter_all()
-        .filter(|(_, p)| p.state.is_established())
-        .filter(|(_, p)| p.is_afi_safi(afi, safi))
-        .filter(|(_, p)| p.opt.is_add_path_send(afi, safi))
-        .map(|(_, p)| p.ident)
-        .collect();
+    let peer_idents: Vec<usize> = peers.established_addpath_idents(afi, safi);
 
     for ident in peer_idents {
         let peer = peers.get_mut_by_idx(ident).expect("peer exists");
@@ -2592,13 +2580,7 @@ pub(super) fn route_advertise_to_peers(
     };
     let afi_safi = AfiSafi::new(afi, safi);
 
-    let peer_idents: Vec<usize> = peers
-        .iter_all()
-        .filter(|(_, p)| p.state.is_established())
-        .filter(|(_, p)| p.is_afi_safi(afi, safi))
-        .filter(|(_, p)| !p.opt.is_add_path_send(afi, safi))
-        .map(|(_, p)| p.ident)
-        .collect();
+    let peer_idents: Vec<usize> = peers.established_plain_idents(afi, safi);
 
     // Per-call memo: outcome cached per update-group id for the
     // span of this advertisement only. Members of the same group
@@ -2848,12 +2830,7 @@ pub fn route_withdraw_evpn_to_peers(
     prefix: EvpnPrefix,
     peers: &mut PeerMap,
 ) {
-    let peer_idents: Vec<usize> = peers
-        .iter_all()
-        .filter(|(_, p)| p.state.is_established())
-        .filter(|(_, p)| p.is_afi_safi(Afi::L2vpn, Safi::Evpn))
-        .map(|(_, p)| p.ident)
-        .collect();
+    let peer_idents: Vec<usize> = peers.established_idents(Afi::L2vpn, Safi::Evpn);
 
     for ident in peer_idents {
         let peer = peers.get_mut_by_idx(ident).expect("peer exists");
@@ -2943,12 +2920,7 @@ pub fn route_advertise_evpn_to_peers(
         return;
     };
 
-    let peer_idents: Vec<usize> = peers
-        .iter_all()
-        .filter(|(_, p)| p.state.is_established())
-        .filter(|(_, p)| p.is_afi_safi(Afi::L2vpn, Safi::Evpn))
-        .map(|(_, p)| p.ident)
-        .collect();
+    let peer_idents: Vec<usize> = peers.established_idents(Afi::L2vpn, Safi::Evpn);
 
     for ident in peer_idents {
         let peer = peers.get_mut_by_idx(ident).expect("peer exists");
@@ -4790,13 +4762,8 @@ fn srpolicy_reflect(
     };
     let (source_ibgp, source_rid) = (src.is_ibgp(), src.remote_id);
 
-    let dests: Vec<usize> = peers
-        .iter_all()
-        .filter(|(_, p)| p.ident != source_ident)
-        .filter(|(_, p)| p.state.is_established())
-        .filter(|(_, p)| p.is_afi_safi(afi, Safi::SrTePolicy))
-        .map(|(_, p)| p.ident)
-        .collect();
+    let mut dests: Vec<usize> = peers.established_idents(afi, Safi::SrTePolicy);
+    dests.retain(|&ident| ident != source_ident);
     for ident in dests {
         let Some(peer) = peers.get_mut_by_idx(ident) else {
             continue;
@@ -4834,13 +4801,8 @@ fn srpolicy_reflect_withdraw(source_ident: usize, nlri: &SrPolicyNlri, peers: &m
         return;
     };
     let source_ibgp = src.is_ibgp();
-    let dests: Vec<usize> = peers
-        .iter_all()
-        .filter(|(_, p)| p.ident != source_ident)
-        .filter(|(_, p)| p.state.is_established())
-        .filter(|(_, p)| p.is_afi_safi(afi, Safi::SrTePolicy))
-        .map(|(_, p)| p.ident)
-        .collect();
+    let mut dests: Vec<usize> = peers.established_idents(afi, Safi::SrTePolicy);
+    dests.retain(|&ident| ident != source_ident);
     for ident in dests {
         let Some(peer) = peers.get_mut_by_idx(ident) else {
             continue;
@@ -5070,14 +5032,9 @@ pub(super) fn srpolicy_origin_sync(bgp: &mut Bgp, name: &str) {
     }
 }
 
-/// Addresses of established peers that negotiated SAFI 73 for `afi`.
+/// Idents of established peers that negotiated SAFI 73 for `afi`.
 fn srpolicy_peer_idents(bgp: &Bgp, afi: Afi) -> Vec<usize> {
-    bgp.peers
-        .iter_all()
-        .filter(|(_, p)| p.state.is_established())
-        .filter(|(_, p)| p.is_afi_safi(afi, Safi::SrTePolicy))
-        .map(|(_, p)| p.ident)
-        .collect()
+    bgp.peers.established_idents(afi, Safi::SrTePolicy)
 }
 
 /// Advertise one local SR Policy NLRI + attribute to every established
@@ -5362,12 +5319,7 @@ pub fn route_advertise_flowspec_to_peers(
     bgp: &mut BgpTop,
     peers: &mut PeerMap,
 ) {
-    let peer_idents: Vec<usize> = peers
-        .iter_all()
-        .filter(|(_, p)| p.state.is_established())
-        .filter(|(_, p)| p.is_afi_safi(afi, Safi::Flowspec))
-        .map(|(_, p)| p.ident)
-        .collect();
+    let peer_idents: Vec<usize> = peers.established_idents(afi, Safi::Flowspec);
 
     for ident in peer_idents {
         let peer = peers.get_mut_by_idx(ident).expect("peer exists");
@@ -5388,12 +5340,7 @@ pub fn route_advertise_flowspec_to_peers(
 /// Withdraw a flow spec from every peer to which it was advertised
 /// (tracked via Adj-RIB-Out), sending one MP_UNREACH UPDATE each.
 pub fn route_withdraw_flowspec_to_peers(afi: Afi, nlri: &FlowspecNlri, peers: &mut PeerMap) {
-    let peer_idents: Vec<usize> = peers
-        .iter_all()
-        .filter(|(_, p)| p.state.is_established())
-        .filter(|(_, p)| p.is_afi_safi(afi, Safi::Flowspec))
-        .map(|(_, p)| p.ident)
-        .collect();
+    let peer_idents: Vec<usize> = peers.established_idents(afi, Safi::Flowspec);
 
     for ident in peer_idents {
         let peer = peers.get_mut_by_idx(ident).expect("peer exists");
@@ -6947,13 +6894,7 @@ pub(super) fn route_advertise_to_peers_v6(
     let (afi, safi) = (Afi::Ip6, Safi::Unicast);
     let afi_safi = AfiSafi::new(afi, safi);
 
-    let peer_idents: Vec<usize> = peers
-        .iter_all()
-        .filter(|(_, p)| p.state.is_established())
-        .filter(|(_, p)| p.is_afi_safi(afi, safi))
-        .filter(|(_, p)| !p.opt.is_add_path_send(afi, safi))
-        .map(|(_, p)| p.ident)
-        .collect();
+    let peer_idents: Vec<usize> = peers.established_plain_idents(afi, safi);
 
     for ident in peer_idents {
         let peer = peers.get_mut_by_idx(ident).expect("peer exists");
@@ -7042,12 +6983,7 @@ pub(super) fn route_advertise_to_peers_vpnv6(
     let new_best = selected.last();
     let (afi, safi) = (Afi::Ip6, Safi::MplsVpn);
 
-    let peer_idents: Vec<usize> = peers
-        .iter_all()
-        .filter(|(_, p)| p.state.is_established())
-        .filter(|(_, p)| p.is_afi_safi(afi, safi))
-        .map(|(_, p)| p.ident)
-        .collect();
+    let peer_idents: Vec<usize> = peers.established_idents(afi, safi);
 
     for ident in peer_idents {
         let peer = peers.get_mut_by_idx(ident).expect("peer exists");
@@ -7270,12 +7206,7 @@ pub(super) fn route_advertise_to_peers_labelv4(
     let new_best = selected.last();
     let (afi, safi) = (Afi::Ip, Safi::MplsLabel);
 
-    let peer_idents: Vec<usize> = peers
-        .iter_all()
-        .filter(|(_, p)| p.state.is_established())
-        .filter(|(_, p)| p.is_afi_safi(afi, safi))
-        .map(|(_, p)| p.ident)
-        .collect();
+    let peer_idents: Vec<usize> = peers.established_idents(afi, safi);
 
     for ident in peer_idents {
         let peer = peers.get_mut_by_idx(ident).expect("peer exists");
@@ -7326,12 +7257,7 @@ pub(super) fn route_advertise_to_peers_labelv6(
     let new_best = selected.last();
     let (afi, safi) = (Afi::Ip6, Safi::MplsLabel);
 
-    let peer_idents: Vec<usize> = peers
-        .iter_all()
-        .filter(|(_, p)| p.state.is_established())
-        .filter(|(_, p)| p.is_afi_safi(afi, safi))
-        .map(|(_, p)| p.ident)
-        .collect();
+    let peer_idents: Vec<usize> = peers.established_idents(afi, safi);
 
     for ident in peer_idents {
         let peer = peers.get_mut_by_idx(ident).expect("peer exists");


### PR DESCRIPTION
## Summary

Final slice of step 4 in `docs/design/bgp-peer-list.md` (Option B), on top of #1418. All fourteen fan-out sites in `route.rs` drop the per-prefix scan-and-filter (Established × negotiated family × AddPath) in favor of three `PeerMap` snapshot helpers over the membership index:

| Helper | Audience | Consumers |
|---|---|---|
| `established_addpath_idents` | AddPath-send half (RFC 7911 path-ids) | v4/VPNv4 per-candidate twins |
| `established_plain_idents` | best-path-only half | v4/VPNv4 best-path, v6-unicast |
| `established_idents` | union | EVPN, VPNv6, LU v4/v6, flowspec, SR Policy (×3 incl. reflect pair + helper) |

The union sites are structurally identical to the scans they replace: AddPath Send cannot negotiate for those families (`addpath_send_implemented`, #1413), so their `addpath_tx` half is always empty.

**Ordering change that matters:** index maintenance moves to flip in lockstep with `peer.state` itself — before `fsm_effect` and `route_clean`, both of which fan out — so the index agrees with the live `is_established()` predicate at every downstream site. In particular, withdraw-before-`route_clean` excludes the dying peer from the clean's withdraw fan-out exactly as the live-state filters did. `update_group::attach`/`detach` stay at the `fsm` tail (detach intentionally after `route_clean` for observability), and `debug_verify_membership` still cross-checks index↔peers on every FSM transition in debug builds.

Design doc §8/§9 updated (step 4 complete; §9 table marked historical).

## Testing

- `cargo fmt` / `cargo clippy --workspace --all-targets -- -D warnings` clean
- `cargo test --workspace --exclude bdd`: all green (new test pins the three snapshot helpers' partition/union/empty-family semantics)
- BDD, 7 features / 26 scenarios, all passed against the rebuilt binary: `@bgp_v6_incremental`, `@bgp_unnumbered_incremental`, `@bgp_peer_down_cleanup` (exercises the withdraw-before-clean ordering directly), `@bgp_update_group_ipv4`, `@bgp_vrf_evpn_type5`, `@bgp_vrf_vpnv4_export`, `@bgp_basic_rr`

🤖 Generated with [Claude Code](https://claude.com/claude-code)