### PR TITLE
bgp: partition shard-scope Loc-RIB tables into BgpShard (sharding B.1)

### DIFF
--- a/zebra-rs/src/bgp/config.rs
+++ b/zebra-rs/src/bgp/config.rs
@@ -141,6 +141,7 @@ fn config_peer(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Option<()> {
             router_id: &bgp.router_id,
             srv6_ipv6_export: bgp.srv6_ipv6_export.as_ref(),
             local_rib: &mut bgp.local_rib,
+            shard: &mut bgp.shard,
             tx: &bgp.tx,
             rib_client: &bgp.ctx.rib,
             attr_store: &mut bgp.attr_store,

--- a/zebra-rs/src/bgp/flowspec.rs
+++ b/zebra-rs/src/bgp/flowspec.rs
@@ -25,7 +25,7 @@ use bgp_packet::{
 };
 use ipnet::{IpNet, Ipv6Net};
 
-use super::route::{BgpRib, LocalRib};
+use super::route::BgpRib;
 
 /// Outcome of validating a received flow spec.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -133,11 +133,11 @@ fn originator_matches(unicast: &BgpRib, fs: &BgpRib) -> bool {
 
 /// Validate one received flow spec against the unicast Loc-RIB per
 /// RFC 9117. `rib` is the flow spec's Adj-RIB-In / Loc-RIB entry,
-/// carrying its path attributes and advertising peer. Takes `&LocalRib`
-/// directly so both the show path (`&Bgp`) and the route layer
-/// (`&mut BgpTop`) can call it.
+/// carrying its path attributes and advertising peer. Takes
+/// `&BgpShard` (the unicast Loc-RIB tables) directly so both the
+/// show path (`&Bgp`) and the route layer (`&mut BgpTop`) can call it.
 pub fn flowspec_validate(
-    local_rib: &LocalRib,
+    shard: &super::shard::BgpShard,
     nlri: &FlowspecNlri,
     rib: &BgpRib,
 ) -> FlowspecValidation {
@@ -154,8 +154,8 @@ pub fn flowspec_validate(
         return FlowspecValidation::InvalidNoUnicastRoute;
     };
     let best = match dst {
-        IpNet::V4(p) => local_rib.v4.1.get_lpm(&p).map(|(_, r)| r),
-        IpNet::V6(p) => local_rib.v6.1.get_lpm(&p).map(|(_, r)| r),
+        IpNet::V4(p) => shard.v4.1.get_lpm(&p).map(|(_, r)| r),
+        IpNet::V6(p) => shard.v6.1.get_lpm(&p).map(|(_, r)| r),
     };
     match best {
         None => FlowspecValidation::InvalidNoUnicastRoute,
@@ -168,7 +168,7 @@ pub fn flowspec_validate(
 /// toggle (RFC 9117 §6, configurable). When `validation_enabled` is
 /// false the flow spec is accepted without checks (trusted neighbor).
 pub fn flowspec_validate_with_mode(
-    local_rib: &LocalRib,
+    shard: &super::shard::BgpShard,
     nlri: &FlowspecNlri,
     rib: &BgpRib,
     validation_enabled: bool,
@@ -176,7 +176,7 @@ pub fn flowspec_validate_with_mode(
     if !validation_enabled {
         return FlowspecValidation::ValidDisabled;
     }
-    flowspec_validate(local_rib, nlri, rib)
+    flowspec_validate(shard, nlri, rib)
 }
 
 #[cfg(test)]
@@ -213,10 +213,10 @@ mod tests {
     fn validate_with_mode_disabled_accepts_anything() {
         // Validation off ⇒ feasible without any RFC 9117 check (even a
         // flow spec with no destination prefix).
-        let local_rib = LocalRib::default();
+        let shard = super::super::shard::BgpShard::default();
         let nlri = FlowspecNlri::new(Afi::Ip, vec![]);
         let rib = ebgp_rib(&BgpAttr::default());
-        let v = flowspec_validate_with_mode(&local_rib, &nlri, &rib, false);
+        let v = flowspec_validate_with_mode(&shard, &nlri, &rib, false);
         assert_eq!(v, FlowspecValidation::ValidDisabled);
         assert!(v.is_valid());
     }
@@ -224,11 +224,11 @@ mod tests {
     #[test]
     fn validate_with_mode_enabled_runs_rfc9117() {
         // Validation on, dest prefix present, empty AS_PATH ⇒ b.2 valid.
-        let local_rib = LocalRib::default();
+        let shard = super::super::shard::BgpShard::default();
         let nlri = v4_dst("10.0.0.0/24");
         let rib = ebgp_rib(&BgpAttr::default());
         assert_eq!(
-            flowspec_validate_with_mode(&local_rib, &nlri, &rib, true),
+            flowspec_validate_with_mode(&shard, &nlri, &rib, true),
             FlowspecValidation::ValidAsPathLocal
         );
     }

--- a/zebra-rs/src/bgp/inst.rs
+++ b/zebra-rs/src/bgp/inst.rs
@@ -1,6 +1,7 @@
 use super::peer::{BgpTop, Event, PeerBfdConfig, fsm};
 use super::peer_map::PeerMap;
 use super::route::LocalRib;
+use super::shard::BgpShard;
 use super::{BGP_PORT, BgpAttrStore};
 use crate::bgp::peer::accept;
 use crate::bgp::tracing::{Direction, PacketKind};
@@ -213,7 +214,7 @@ fn srv6_l3_service_prefix_sid(
 /// pair — RFC 4360 §4.1 puts the sub-type at `low_type = 0x02`.
 /// Routes with no RT extcomms match no VRF; routes with RTs that
 /// no configured VRF imports match no VRF either (and the global
-/// VPNv4 row sits in `local_rib.v4vpn` unimported).
+/// VPNv4 row sits in `shard.v4vpn` unimported).
 pub(crate) fn matching_import_vrfs(
     vrf_index: &BTreeMap<String, RibKnownVrf>,
     ecom: &Option<bgp_packet::ExtCommunity>,
@@ -459,6 +460,9 @@ pub struct Bgp {
     pub pcallbacks: HashMap<String, PCallback>,
     /// BGP Local RIB (Loc-RIB) for best path selection
     pub local_rib: LocalRib,
+    /// Shard-scope Loc-RIB tables (unicast/LU/VPN) — see
+    /// [`super::shard::BgpShard`] for the sharding-plan partition.
+    pub shard: BgpShard,
     /// `router bgp port <0-65535>`: TCP port the BGP listener binds
     /// (IPv4 and IPv6 both), default [`BGP_PORT`] (179). 0 disables
     /// listening entirely — no server socket is open, so every session
@@ -778,6 +782,7 @@ impl Bgp {
             tx,
             rx,
             local_rib: LocalRib::default(),
+            shard: BgpShard::default(),
             ctx,
             rib_rx,
             nexthop_cache: super::nht::NexthopCache::default(),
@@ -1358,6 +1363,7 @@ impl Bgp {
                     router_id: &self.router_id,
                     srv6_ipv6_export: self.srv6_ipv6_export.as_ref(),
                     local_rib: &mut self.local_rib,
+                    shard: &mut self.shard,
                     tx: &self.tx,
                     rib_client: &self.ctx.rib,
                     attr_store: &mut self.attr_store,
@@ -1962,7 +1968,7 @@ impl Bgp {
         // Snapshot the originated rows (clone to release the `local_rib`
         // borrow before mutating it / `peers` below).
         let rows: Vec<(ipnet::Ipv4Net, super::route::BgpRib)> = self
-            .local_rib
+            .shard
             .v4vpn
             .get(&rd)
             .map(|t| {
@@ -1987,11 +1993,12 @@ impl Bgp {
             }
             let tagged = tag_attr_with_export_rts(attr, &export_rts);
             rib.attr = self.attr_store.intern(tagged);
-            let (_, selected, _) = self.local_rib.update(Some(rd), prefix, rib);
+            let (_, selected, _) = self.shard.update(Some(rd), prefix, rib);
             let mut top = super::peer::BgpTop {
                 router_id: &self.router_id,
                 srv6_ipv6_export: self.srv6_ipv6_export.as_ref(),
                 local_rib: &mut self.local_rib,
+                shard: &mut self.shard,
                 tx: &self.tx,
                 rib_client: &self.ctx.rib,
                 attr_store: &mut self.attr_store,
@@ -2366,7 +2373,7 @@ impl Bgp {
         let transport = self.nexthop_cache.transport_for(nh);
         match dep {
             NhtDep::V4vpn(rd, p) => {
-                let selected = self.local_rib.select_best_path_vpn(&rd, p);
+                let selected = self.shard.select_best_path_vpn(&rd, p);
                 if let Some(winner) = selected.first() {
                     let label = winner.label.map(|l| l.label).unwrap_or(0);
                     super::vrf::dispatch_import_v4(
@@ -2388,7 +2395,7 @@ impl Bgp {
                 );
             }
             NhtDep::V6vpn(rd, p) => {
-                let selected = self.local_rib.select_best_path_vpn_v6(&rd, p);
+                let selected = self.shard.select_best_path_vpn_v6(&rd, p);
                 if let Some(winner) = selected.first() {
                     let label = winner.label.map(|l| l.label).unwrap_or(0);
                     super::vrf::dispatch_import_v6(
@@ -2437,7 +2444,7 @@ impl Bgp {
             // still reachable; re-install the FIB label-push entry with
             // the fresh transport. No re-advertise (best-path unchanged).
             NhtDep::V4lu(p) => {
-                let selected = self.local_rib.select_best_path_v4lu(p);
+                let selected = self.shard.select_best_path_v4lu(p);
                 super::route::fib_install_labelv4(
                     &self.ctx.rib,
                     Some(&self.nexthop_cache),
@@ -2446,7 +2453,7 @@ impl Bgp {
                 );
             }
             NhtDep::V6lu(p) => {
-                let selected = self.local_rib.select_best_path_v6lu(p);
+                let selected = self.shard.select_best_path_v6lu(p);
                 super::route::fib_install_labelv6(
                     &self.ctx.rib,
                     Some(&self.nexthop_cache),
@@ -2481,36 +2488,36 @@ impl Bgp {
         // Refresh gate flags + re-select (mutates `local_rib`).
         let selected = match &dep {
             NhtDep::V4(p) => {
-                self.local_rib.v4.set_nexthop_reachable(*p, nh, reachable);
-                self.local_rib.v4.select_best_path(*p)
+                self.shard.v4.set_nexthop_reachable(*p, nh, reachable);
+                self.shard.v4.select_best_path(*p)
             }
             NhtDep::V6(p) => {
-                self.local_rib.v6.set_nexthop_reachable(*p, nh, reachable);
-                self.local_rib.v6.select_best_path(*p)
+                self.shard.v6.set_nexthop_reachable(*p, nh, reachable);
+                self.shard.v6.select_best_path(*p)
             }
             NhtDep::V4lu(p) => {
-                self.local_rib.v4lu.set_nexthop_reachable(*p, nh, reachable);
-                self.local_rib.v4lu.select_best_path(*p)
+                self.shard.v4lu.set_nexthop_reachable(*p, nh, reachable);
+                self.shard.v4lu.select_best_path(*p)
             }
             NhtDep::V6lu(p) => {
-                self.local_rib.v6lu.set_nexthop_reachable(*p, nh, reachable);
-                self.local_rib.v6lu.select_best_path(*p)
+                self.shard.v6lu.set_nexthop_reachable(*p, nh, reachable);
+                self.shard.v6lu.select_best_path(*p)
             }
             NhtDep::V4vpn(rd, p) => {
-                self.local_rib
+                self.shard
                     .v4vpn
                     .entry(*rd)
                     .or_default()
                     .set_nexthop_reachable(*p, nh, reachable);
-                self.local_rib.select_best_path_vpn(rd, *p)
+                self.shard.select_best_path_vpn(rd, *p)
             }
             NhtDep::V6vpn(rd, p) => {
-                self.local_rib
+                self.shard
                     .v6vpn
                     .entry(*rd)
                     .or_default()
                     .set_nexthop_reachable(*p, nh, reachable);
-                self.local_rib.select_best_path_vpn_v6(rd, *p)
+                self.shard.select_best_path_vpn_v6(rd, *p)
             }
             // EVPN Type-5 best-path isn't gated on next-hop reachability
             // (the VRF FIB install is gated by transport availability in
@@ -2525,6 +2532,7 @@ impl Bgp {
             router_id: &self.router_id,
             srv6_ipv6_export: self.srv6_ipv6_export.as_ref(),
             local_rib: &mut self.local_rib,
+            shard: &mut self.shard,
             tx: &self.tx,
             rib_client: &self.ctx.rib,
             attr_store: &mut self.attr_store,
@@ -2618,11 +2626,8 @@ impl Bgp {
                         transport,
                         None,
                     );
-                } else if let Some(attr) = self
-                    .local_rib
-                    .v4vpn
-                    .get(rd)
-                    .and_then(|t| t.candidate_attr(*p))
+                } else if let Some(attr) =
+                    self.shard.v4vpn.get(rd).and_then(|t| t.candidate_attr(*p))
                 {
                     super::vrf::dispatch_withdraw_import_v4(&dispatcher, *rd, *p, &attr, None);
                 }
@@ -2662,11 +2667,8 @@ impl Bgp {
                         transport,
                         None,
                     );
-                } else if let Some(attr) = self
-                    .local_rib
-                    .v6vpn
-                    .get(rd)
-                    .and_then(|t| t.candidate_attr(*p))
+                } else if let Some(attr) =
+                    self.shard.v6vpn.get(rd).and_then(|t| t.candidate_attr(*p))
                 {
                     super::vrf::dispatch_withdraw_import_v6(&dispatcher, *rd, *p, &attr, None);
                 }
@@ -2975,7 +2977,7 @@ impl Bgp {
         // Snapshot the winners first — building the `BgpTop` below
         // takes `&mut local_rib`.
         let winners_v4: Vec<(ipnet::Ipv4Net, super::route::BgpRib)> = if afi == Afi::Ip {
-            self.local_rib
+            self.shard
                 .v4
                 .1
                 .iter()
@@ -2985,7 +2987,7 @@ impl Bgp {
             Vec::new()
         };
         let winners_v6: Vec<(ipnet::Ipv6Net, super::route::BgpRib)> = if afi == Afi::Ip6 {
-            self.local_rib
+            self.shard
                 .v6
                 .1
                 .iter()
@@ -2998,6 +3000,7 @@ impl Bgp {
             router_id: &self.router_id,
             srv6_ipv6_export: self.srv6_ipv6_export.as_ref(),
             local_rib: &mut self.local_rib,
+            shard: &mut self.shard,
             tx: &self.tx,
             rib_client: &self.ctx.rib,
             attr_store: &mut self.attr_store,
@@ -3210,13 +3213,13 @@ impl Bgp {
                     vrf_transit_only: false,
                 };
 
-                let (_, selected, _gen) = self.local_rib.update(Some(rd), prefix, rib);
+                let (_, selected, _gen) = self.shard.update(Some(rd), prefix, rib);
                 let selected_len = selected.len();
 
                 // Local intra-router leak. The remote-VPNv4 ingress
                 // path (`route_ipv4_update`) fans an accepted VPNv4
                 // winner out to every importing VRF; the direct
-                // `local_rib.update` above bypasses that hook, so a
+                // `shard.update` above bypasses that hook, so a
                 // route exported by one local VRF would never reach a
                 // sibling VRF on the same box. Replicate the fan-out
                 // here, skipping the originating VRF so a `rt both`
@@ -3252,6 +3255,7 @@ impl Bgp {
                     router_id: &self.router_id,
                     srv6_ipv6_export: self.srv6_ipv6_export.as_ref(),
                     local_rib: &mut self.local_rib,
+                    shard: &mut self.shard,
                     tx: &self.tx,
                     rib_client: &self.ctx.rib,
                     attr_store: &mut self.attr_store,
@@ -3314,16 +3318,16 @@ impl Bgp {
                 // ORIGINATED_PEER` and `local_id == 0` (the values used in
                 // the matching Export); the remove path uses that tuple to
                 // identify the row.
-                let removed =
-                    self.local_rib
-                        .remove(Some(rd), prefix, 0, super::route::ORIGINATED_PEER);
+                let removed = self
+                    .shard
+                    .remove(Some(rd), prefix, 0, super::route::ORIGINATED_PEER);
 
                 // Re-run best-path so any remaining candidate at
                 // (rd, prefix) becomes the new selected winner.
                 // Pass that result to `route_advertise_to_peers` —
                 // empty `selected` triggers the Withdraw branch
                 // there (`peer.adj_out` cleanup, MP_UNREACH emit).
-                let selected = self.local_rib.select_best_path_vpn(&rd, prefix);
+                let selected = self.shard.select_best_path_vpn(&rd, prefix);
 
                 // Local intra-router leak, symmetric with the Export
                 // handler. If a replacement candidate survives at
@@ -3361,6 +3365,7 @@ impl Bgp {
                     router_id: &self.router_id,
                     srv6_ipv6_export: self.srv6_ipv6_export.as_ref(),
                     local_rib: &mut self.local_rib,
+                    shard: &mut self.shard,
                     tx: &self.tx,
                     rib_client: &self.ctx.rib,
                     attr_store: &mut self.attr_store,
@@ -3487,7 +3492,7 @@ impl Bgp {
                     vrf_transit_only: false,
                 };
 
-                let (_, selected, _gen) = self.local_rib.update_v6vpn(rd, prefix, rib);
+                let (_, selected, _gen) = self.shard.update_v6vpn(rd, prefix, rib);
                 let winners = selected.len();
 
                 // Local intra-router leak — the v6 analog of the VPNv4
@@ -3517,6 +3522,7 @@ impl Bgp {
                     router_id: &self.router_id,
                     srv6_ipv6_export: self.srv6_ipv6_export.as_ref(),
                     local_rib: &mut self.local_rib,
+                    shard: &mut self.shard,
                     tx: &self.tx,
                     rib_client: &self.ctx.rib,
                     attr_store: &mut self.attr_store,
@@ -3565,10 +3571,10 @@ impl Bgp {
                 let Some(rd) = self.vrfs.get(&vrf).and_then(|cfg| cfg.rd) else {
                     return;
                 };
-                let removed =
-                    self.local_rib
-                        .remove_v6vpn(rd, prefix, 0, super::route::ORIGINATED_PEER);
-                let selected = self.local_rib.select_best_path_vpn_v6(&rd, prefix);
+                let removed = self
+                    .shard
+                    .remove_v6vpn(rd, prefix, 0, super::route::ORIGINATED_PEER);
+                let selected = self.shard.select_best_path_vpn_v6(&rd, prefix);
 
                 // Local intra-router leak, symmetric with the ExportV6
                 // handler: a surviving winner re-imports into sibling
@@ -3604,6 +3610,7 @@ impl Bgp {
                     router_id: &self.router_id,
                     srv6_ipv6_export: self.srv6_ipv6_export.as_ref(),
                     local_rib: &mut self.local_rib,
+                    shard: &mut self.shard,
                     tx: &self.tx,
                     rib_client: &self.ctx.rib,
                     attr_store: &mut self.attr_store,

--- a/zebra-rs/src/bgp/interface_neighbor.rs
+++ b/zebra-rs/src/bgp/interface_neighbor.rs
@@ -270,6 +270,7 @@ pub fn config_interface_neighbor(bgp: &mut Bgp, mut args: Args, op: ConfigOp) ->
                         router_id: &bgp.router_id,
                         srv6_ipv6_export: bgp.srv6_ipv6_export.as_ref(),
                         local_rib: &mut bgp.local_rib,
+                        shard: &mut bgp.shard,
                         tx: &bgp.tx,
                         rib_client: &bgp.ctx.rib,
                         attr_store: &mut bgp.attr_store,

--- a/zebra-rs/src/bgp/mod.rs
+++ b/zebra-rs/src/bgp/mod.rs
@@ -43,6 +43,8 @@ pub use policy::*;
 pub mod route;
 pub use route::*;
 
+pub mod shard;
+
 pub mod nht;
 
 pub mod flowspec;

--- a/zebra-rs/src/bgp/nht.rs
+++ b/zebra-rs/src/bgp/nht.rs
@@ -26,7 +26,7 @@ use crate::rib::nht::{NexthopResolution, ResolvedNexthop};
 pub enum NhtDep {
     V4(Ipv4Net),
     V6(Ipv6Net),
-    /// IPv4 / IPv6 Labeled-Unicast (SAFI 4) route in `local_rib.v4lu` /
+    /// IPv4 / IPv6 Labeled-Unicast (SAFI 4) route in `shard.v4lu` /
     /// `v6lu`. The BGP next-hop is tracked so the FIB label-push entry
     /// re-installs (and best-path re-gates) when the next-hop's
     /// reachability or transport changes — like the VPN deps, but the

--- a/zebra-rs/src/bgp/peer.rs
+++ b/zebra-rs/src/bgp/peer.rs
@@ -1265,6 +1265,10 @@ impl Peer {
 pub struct BgpTop<'a> {
     pub router_id: &'a Ipv4Addr,
     pub local_rib: &'a mut LocalRib,
+    /// Shard-scope Loc-RIB tables (unicast/LU/VPN). Split from
+    /// `local_rib` per the RIB sharding plan's B.1/D3 partition —
+    /// these are the tables a future shard task will own.
+    pub shard: &'a mut super::shard::BgpShard,
     pub tx: &'a mpsc::Sender<Message>,
     pub rib_client: &'a crate::rib::client::RibClient,
     pub attr_store: &'a mut BgpAttrStore,
@@ -2836,6 +2840,7 @@ pub fn apply_soft_in_peer(bgp: &mut Bgp, peer_idx: usize) {
             router_id: &bgp.router_id,
             srv6_ipv6_export: bgp.srv6_ipv6_export.as_ref(),
             local_rib: &mut bgp.local_rib,
+            shard: &mut bgp.shard,
             tx: &bgp.tx,
             rib_client: &bgp.ctx.rib,
             attr_store: &mut bgp.attr_store,
@@ -2874,6 +2879,7 @@ pub fn apply_soft_out_peer(bgp: &mut Bgp, peer_idx: usize) {
         router_id: &bgp.router_id,
         srv6_ipv6_export: bgp.srv6_ipv6_export.as_ref(),
         local_rib: &mut bgp.local_rib,
+        shard: &mut bgp.shard,
         tx: &bgp.tx,
         rib_client: &bgp.ctx.rib,
         attr_store: &mut bgp.attr_store,

--- a/zebra-rs/src/bgp/route.rs
+++ b/zebra-rs/src/bgp/route.rs
@@ -1653,22 +1653,11 @@ pub struct BgpTableMap {
     pub policy: Option<PolicyList>,
 }
 
+/// Main-task-owned Loc-RIB tables. The prefix-hashable tables
+/// (v4/v6 unicast, LU, VPNv4/v6) live in [`super::shard::BgpShard`]
+/// instead — see the RIB sharding plan (B.1 / D3) for the partition.
 #[derive(Debug, Default)]
 pub struct LocalRib {
-    pub v4: LocalRibTable<Ipv4Net>,
-
-    pub v6: LocalRibTable<Ipv6Net>,
-
-    /// IPv4 / IPv6 Labeled-Unicast (SAFI 4) Loc-RIB. Same prefix key as
-    /// unicast; each `BgpRib` carries the per-prefix label.
-    pub v4lu: LocalRibTable<Ipv4Net>,
-
-    pub v6lu: LocalRibTable<Ipv6Net>,
-
-    pub v4vpn: BTreeMap<RouteDistinguisher, LocalRibTable<Ipv4Net>>,
-
-    pub v6vpn: BTreeMap<RouteDistinguisher, LocalRibTable<Ipv6Net>>,
-
     /// Per-RD EVPN Loc-RIB tables.
     pub evpn: BTreeMap<RouteDistinguisher, LocalRibEvpnTable>,
 
@@ -1702,170 +1691,6 @@ pub struct LocalRib {
 }
 
 impl LocalRib {
-    // Update LocalRIB route.
-    pub fn update(
-        &mut self,
-        rd: Option<RouteDistinguisher>,
-        prefix: Ipv4Net,
-        rib: BgpRib,
-    ) -> (Vec<BgpRib>, Vec<BgpRib>, u32) {
-        match rd {
-            Some(rd) => self.v4vpn.entry(rd).or_default().update(prefix, rib),
-            None => self.v4.update(prefix, rib),
-        }
-    }
-
-    pub fn remove(
-        &mut self,
-        rd: Option<RouteDistinguisher>,
-        prefix: Ipv4Net,
-        id: u32,
-        ident: usize,
-    ) -> Vec<BgpRib> {
-        match rd {
-            Some(rd) => self.v4vpn.entry(rd).or_default().remove(prefix, id, ident),
-            None => self.v4.remove(prefix, id, ident),
-        }
-    }
-
-    // Return selected best path, not the change history.
-    pub fn select_best_path(&mut self, prefix: Ipv4Net) -> Vec<BgpRib> {
-        self.v4.select_best_path(prefix)
-    }
-
-    // Return selected best path, not the change history.
-    pub fn select_best_path_vpn(
-        &mut self,
-        rd: &RouteDistinguisher,
-        prefix: Ipv4Net,
-    ) -> Vec<BgpRib> {
-        self.v4vpn.entry(*rd).or_default().select_best_path(prefix)
-    }
-
-    // IPv6 unicast accessors. VPNv6 (`v6vpn`) lands with layer 2c, so
-    // these take no RD — the global/default v6 unicast Loc-RIB only.
-    pub fn update_v6(&mut self, prefix: Ipv6Net, rib: BgpRib) -> (Vec<BgpRib>, Vec<BgpRib>, u32) {
-        self.v6.update(prefix, rib)
-    }
-
-    pub fn remove_v6(&mut self, prefix: Ipv6Net, id: u32, ident: usize) -> Vec<BgpRib> {
-        self.v6.remove(prefix, id, ident)
-    }
-
-    pub fn select_best_path_v6(&mut self, prefix: Ipv6Net) -> Vec<BgpRib> {
-        self.v6.select_best_path(prefix)
-    }
-
-    // IPv4 / IPv6 Labeled-Unicast (SAFI 4) accessors. Same Loc-RIB
-    // engine as unicast; the per-prefix label travels on each `BgpRib`.
-    pub fn update_v4lu(&mut self, prefix: Ipv4Net, rib: BgpRib) -> (Vec<BgpRib>, Vec<BgpRib>, u32) {
-        self.v4lu.update(prefix, rib)
-    }
-
-    pub fn remove_v4lu(&mut self, prefix: Ipv4Net, id: u32, ident: usize) -> Vec<BgpRib> {
-        self.v4lu.remove(prefix, id, ident)
-    }
-
-    pub fn select_best_path_v4lu(&mut self, prefix: Ipv4Net) -> Vec<BgpRib> {
-        self.v4lu.select_best_path(prefix)
-    }
-
-    pub fn update_v6lu(&mut self, prefix: Ipv6Net, rib: BgpRib) -> (Vec<BgpRib>, Vec<BgpRib>, u32) {
-        self.v6lu.update(prefix, rib)
-    }
-
-    pub fn remove_v6lu(&mut self, prefix: Ipv6Net, id: u32, ident: usize) -> Vec<BgpRib> {
-        self.v6lu.remove(prefix, id, ident)
-    }
-
-    pub fn select_best_path_v6lu(&mut self, prefix: Ipv6Net) -> Vec<BgpRib> {
-        self.v6lu.select_best_path(prefix)
-    }
-
-    // VPNv6 accessors — per-RD `v6vpn` tables, mirroring the v4vpn
-    // ones. (Best-path-for-advertise of VPNv6 winners lands in 2c-ii.)
-    pub fn update_v6vpn(
-        &mut self,
-        rd: RouteDistinguisher,
-        prefix: Ipv6Net,
-        rib: BgpRib,
-    ) -> (Vec<BgpRib>, Vec<BgpRib>, u32) {
-        self.v6vpn.entry(rd).or_default().update(prefix, rib)
-    }
-
-    pub fn remove_v6vpn(
-        &mut self,
-        rd: RouteDistinguisher,
-        prefix: Ipv6Net,
-        id: u32,
-        ident: usize,
-    ) -> Vec<BgpRib> {
-        self.v6vpn.entry(rd).or_default().remove(prefix, id, ident)
-    }
-
-    pub fn select_best_path_vpn_v6(
-        &mut self,
-        rd: &RouteDistinguisher,
-        prefix: Ipv6Net,
-    ) -> Vec<BgpRib> {
-        self.v6vpn.entry(*rd).or_default().select_best_path(prefix)
-    }
-
-    /// Distinct BGP next-hops still in use by surviving candidates for a
-    /// v4 (`rd == None`) / VPNv4 (`rd == Some`) prefix — for NHT untrack
-    /// to avoid releasing a next-hop another path still needs.
-    pub fn candidate_nexthops_v4(
-        &self,
-        rd: Option<RouteDistinguisher>,
-        prefix: Ipv4Net,
-    ) -> std::collections::BTreeSet<IpAddr> {
-        let cands = match rd {
-            Some(rd) => self.v4vpn.get(&rd).map(|t| t.candidates(prefix)),
-            None => Some(self.v4.candidates(prefix)),
-        };
-        cands
-            .into_iter()
-            .flatten()
-            .filter_map(|r| super::nht::bgp_nexthop_ip(&r.attr))
-            .collect()
-    }
-
-    /// IPv6 counterpart of [`Self::candidate_nexthops_v4`].
-    pub fn candidate_nexthops_v6(
-        &self,
-        rd: Option<RouteDistinguisher>,
-        prefix: Ipv6Net,
-    ) -> std::collections::BTreeSet<IpAddr> {
-        let cands = match rd {
-            Some(rd) => self.v6vpn.get(&rd).map(|t| t.candidates(prefix)),
-            None => Some(self.v6.candidates(prefix)),
-        };
-        cands
-            .into_iter()
-            .flatten()
-            .filter_map(|r| super::nht::bgp_nexthop_ip(&r.attr))
-            .collect()
-    }
-
-    /// Labeled-Unicast (SAFI 4) counterparts: the distinct BGP next-hops
-    /// among the `v4lu` / `v6lu` candidates for `prefix` (for NHT untrack
-    /// after a displaced path).
-    pub fn candidate_nexthops_v4lu(&self, prefix: Ipv4Net) -> std::collections::BTreeSet<IpAddr> {
-        self.v4lu
-            .candidates(prefix)
-            .iter()
-            .filter_map(|r| super::nht::bgp_nexthop_ip(&r.attr))
-            .collect()
-    }
-
-    pub fn candidate_nexthops_v6lu(&self, prefix: Ipv6Net) -> std::collections::BTreeSet<IpAddr> {
-        self.v6lu
-            .candidates(prefix)
-            .iter()
-            .filter_map(|r| super::nht::bgp_nexthop_ip(&r.attr))
-            .collect()
-    }
-
     // EVPN dispatch ----------------------------------------------------------
 
     pub fn update_evpn(
@@ -2299,14 +2124,14 @@ pub fn route_ipv4_update(
     {
         rib.vrf_transit_only = true;
     }
-    let (replaced, selected, next_id) = bgp.local_rib.update(rd, nlri.prefix, rib.clone());
+    let (replaced, selected, next_id) = bgp.shard.update(rd, nlri.prefix, rib.clone());
     // If this update changed the path's next-hop, the displaced row's
     // old next-hop is no longer tracked by it; release it (unless
     // another surviving path still uses it). Survivors are read *after*
     // the update, so the new next-hop is in the set and an unchanged
     // next-hop is correctly skipped.
     if bgp.nexthop_cache.is_some() && !replaced.is_empty() {
-        let survivor_nhs = bgp.local_rib.candidate_nexthops_v4(rd, nlri.prefix);
+        let survivor_nhs = bgp.shard.candidate_nexthops_v4(rd, nlri.prefix);
         nht_untrack_withdrawn(bgp, &replaced, &survivor_nhs, dep);
     }
 
@@ -2355,7 +2180,7 @@ pub fn route_ipv4_update(
     }
 
     // Plain IPv4 unicast best-path winners are installed to the kernel
-    // FIB via RIB. VPNv4 lives in `local_rib.v4vpn`; a transit ASBR with
+    // FIB via RIB. VPNv4 lives in `shard.v4vpn`; a transit ASBR with
     // no importing VRF installs no IP route, but it does program a swap
     // ILM for the local label it advertises with next-hop-self (Inter-AS
     // Option B) — `reconcile_swap_ilm` is a no-op when no local label was
@@ -3062,7 +2887,7 @@ pub fn route_soft_out_peer(peer_idx: usize, bgp: &mut BgpTop, peers: &mut PeerMa
         let do_vpn = peer.is_afi_safi(Afi::Ip, Safi::MplsVpn);
         let do_evpn = peer.is_afi_safi(Afi::L2vpn, Safi::Evpn);
         let v4vpn_rds: Vec<RouteDistinguisher> = if do_vpn {
-            bgp.local_rib.v4vpn.keys().copied().collect()
+            bgp.shard.v4vpn.keys().copied().collect()
         } else {
             Vec::new()
         };
@@ -3107,18 +2932,12 @@ fn route_soft_out_peer_table(
     // mutable borrows of `bgp` (attr_store.intern, send paths).
     let selected: Vec<(Ipv4Net, BgpRib)> = match rd {
         Some(rd) => bgp
-            .local_rib
+            .shard
             .v4vpn
             .get(&rd)
             .map(|t| t.1.iter().map(|(p, r)| (p, r.clone())).collect())
             .unwrap_or_default(),
-        None => bgp
-            .local_rib
-            .v4
-            .1
-            .iter()
-            .map(|(p, r)| (p, r.clone()))
-            .collect(),
+        None => bgp.shard.v4.1.iter().map(|(p, r)| (p, r.clone())).collect(),
     };
 
     // Snapshot what's currently in this peer's Adj-RIB-Out so we can
@@ -3404,7 +3223,7 @@ fn route_soft_in_peer_table(
                     let mut new_rib = stored.clone();
                     new_rib.attr = bgp.attr_store.intern(decision.attr);
                     new_rib.weight = decision.weight;
-                    let (_, selected, next_id) = bgp.local_rib.update(rd, prefix, new_rib.clone());
+                    let (_, selected, next_id) = bgp.shard.update(rd, prefix, new_rib.clone());
 
                     // Policy-in change may have shifted the best path
                     // for this prefix; reconcile the FIB so the kernel
@@ -3441,12 +3260,12 @@ pub fn route_ipv4_withdraw(
     }
 
     // BGP Path selection - this may select a new best path
-    let mut removed = bgp.local_rib.remove(rd, nlri.prefix, nlri.id, ident);
+    let mut removed = bgp.shard.remove(rd, nlri.prefix, nlri.id, ident);
 
     // NHT untrack: release the withdrawn path's next-hop(s) unless a
     // surviving candidate still uses them.
     if bgp.nexthop_cache.is_some() {
-        let survivor_nhs = bgp.local_rib.candidate_nexthops_v4(rd, nlri.prefix);
+        let survivor_nhs = bgp.shard.candidate_nexthops_v4(rd, nlri.prefix);
         let dep = match rd {
             Some(rd) => super::nht::NhtDep::V4vpn(rd, nlri.prefix),
             None => super::nht::NhtDep::V4(nlri.prefix),
@@ -3456,9 +3275,9 @@ pub fn route_ipv4_withdraw(
 
     // Re-run best path selection and advertise changes
     let selected = if let Some(ref rd) = rd {
-        bgp.local_rib.select_best_path_vpn(rd, nlri.prefix)
+        bgp.shard.select_best_path_vpn(rd, nlri.prefix)
     } else {
-        bgp.local_rib.select_best_path(nlri.prefix)
+        bgp.shard.select_best_path(nlri.prefix)
     };
     // Reconcile FIB after the withdraw: empty `selected` means the
     // last candidate just disappeared and we should withdraw from
@@ -3538,7 +3357,7 @@ pub fn route_ipv4_withdraw(
 /// [`route_ipv4_update`]. The MP_REACH next-hop is carried in
 /// `attr.nexthop` as `BgpNexthop::Ipv6` (stamped by the dispatch
 /// site), drives the FIB install, and the route lands in
-/// `local_rib.v6`.
+/// `shard.v6`.
 ///
 /// Scope (layer 2b-i): receive → Adj-RIB-In → Loc-RIB → FIB. Inbound
 /// policy is **not** applied yet (the policy engine is IPv4-typed),
@@ -3644,13 +3463,13 @@ pub fn route_ipv6_update(
         rib.vrf_transit_only = true;
     }
     let (replaced, selected, _next_id) = match rd {
-        Some(rd) => bgp.local_rib.update_v6vpn(rd, nlri.prefix, rib),
-        None => bgp.local_rib.update_v6(nlri.prefix, rib),
+        Some(rd) => bgp.shard.update_v6vpn(rd, nlri.prefix, rib),
+        None => bgp.shard.update_v6(nlri.prefix, rib),
     };
     // Release the displaced row's old next-hop if this update changed it
     // (see the v4 path). Survivors read after the update.
     if bgp.nexthop_cache.is_some() && !replaced.is_empty() {
-        let survivor_nhs = bgp.local_rib.candidate_nexthops_v6(rd, nlri.prefix);
+        let survivor_nhs = bgp.shard.candidate_nexthops_v6(rd, nlri.prefix);
         nht_untrack_withdrawn(bgp, &replaced, &survivor_nhs, dep);
     }
 
@@ -3733,9 +3552,9 @@ pub fn route_ipv6_withdraw(
 
     match rd {
         Some(rd) => {
-            let removed = bgp.local_rib.remove_v6vpn(rd, nlri.prefix, nlri.id, ident);
+            let removed = bgp.shard.remove_v6vpn(rd, nlri.prefix, nlri.id, ident);
             if bgp.nexthop_cache.is_some() {
-                let survivor_nhs = bgp.local_rib.candidate_nexthops_v6(Some(rd), nlri.prefix);
+                let survivor_nhs = bgp.shard.candidate_nexthops_v6(Some(rd), nlri.prefix);
                 nht_untrack_withdrawn(
                     bgp,
                     &removed,
@@ -3743,7 +3562,7 @@ pub fn route_ipv6_withdraw(
                     super::nht::NhtDep::V6vpn(rd, nlri.prefix),
                 );
             }
-            let selected = bgp.local_rib.select_best_path_vpn_v6(&rd, nlri.prefix);
+            let selected = bgp.shard.select_best_path_vpn_v6(&rd, nlri.prefix);
 
             // Remote VPNv6 withdraw → per-VRF import update/withdraw
             // (global task only). A surviving winner re-imports with
@@ -3777,9 +3596,9 @@ pub fn route_ipv6_withdraw(
             route_advertise_to_peers_vpnv6(rd, nlri.prefix, &selected, bgp, peers);
         }
         None => {
-            let removed = bgp.local_rib.remove_v6(nlri.prefix, nlri.id, ident);
+            let removed = bgp.shard.remove_v6(nlri.prefix, nlri.id, ident);
             if bgp.nexthop_cache.is_some() {
-                let survivor_nhs = bgp.local_rib.candidate_nexthops_v6(None, nlri.prefix);
+                let survivor_nhs = bgp.shard.candidate_nexthops_v6(None, nlri.prefix);
                 nht_untrack_withdrawn(
                     bgp,
                     &removed,
@@ -3787,7 +3606,7 @@ pub fn route_ipv6_withdraw(
                     super::nht::NhtDep::V6(nlri.prefix),
                 );
             }
-            let selected = bgp.local_rib.select_best_path_v6(nlri.prefix);
+            let selected = bgp.shard.select_best_path_v6(nlri.prefix);
             fib_install_v6(bgp, nlri.prefix, &selected);
 
             // VRF export, symmetric with route_ipv6_update: a
@@ -3894,9 +3713,9 @@ pub fn route_labelv4_update(
         .lu_labels
         .as_mut()
         .and_then(|ll| ll.label_v4(lu.nlri.prefix));
-    let (replaced, selected, _next_id) = bgp.local_rib.update_v4lu(lu.nlri.prefix, rib);
+    let (replaced, selected, _next_id) = bgp.shard.update_v4lu(lu.nlri.prefix, rib);
     if bgp.nexthop_cache.is_some() && !replaced.is_empty() {
-        let survivor_nhs = bgp.local_rib.candidate_nexthops_v4lu(lu.nlri.prefix);
+        let survivor_nhs = bgp.shard.candidate_nexthops_v4lu(lu.nlri.prefix);
         nht_untrack_withdrawn(bgp, &replaced, &survivor_nhs, dep);
     }
     // Ingress LSR: install the received label toward the resolved
@@ -3986,9 +3805,9 @@ pub fn route_labelv6_update(
         .lu_labels
         .as_mut()
         .and_then(|ll| ll.label_v6(lu.nlri.prefix));
-    let (replaced, selected, _next_id) = bgp.local_rib.update_v6lu(lu.nlri.prefix, rib);
+    let (replaced, selected, _next_id) = bgp.shard.update_v6lu(lu.nlri.prefix, rib);
     if bgp.nexthop_cache.is_some() && !replaced.is_empty() {
-        let survivor_nhs = bgp.local_rib.candidate_nexthops_v6lu(lu.nlri.prefix);
+        let survivor_nhs = bgp.shard.candidate_nexthops_v6lu(lu.nlri.prefix);
         nht_untrack_withdrawn(bgp, &replaced, &survivor_nhs, dep);
     }
     fib_install_labelv6(
@@ -4017,9 +3836,9 @@ pub fn route_labelv4_withdraw(
         let peer = peers.get_mut_by_idx(ident).expect("peer must exist");
         peer.adj_in.remove_v4lu(nlri.prefix, nlri.id);
     }
-    let removed = bgp.local_rib.remove_v4lu(nlri.prefix, nlri.id, ident);
+    let removed = bgp.shard.remove_v4lu(nlri.prefix, nlri.id, ident);
     if bgp.nexthop_cache.is_some() {
-        let survivor_nhs = bgp.local_rib.candidate_nexthops_v4lu(nlri.prefix);
+        let survivor_nhs = bgp.shard.candidate_nexthops_v4lu(nlri.prefix);
         nht_untrack_withdrawn(
             bgp,
             &removed,
@@ -4027,7 +3846,7 @@ pub fn route_labelv4_withdraw(
             super::nht::NhtDep::V4lu(nlri.prefix),
         );
     }
-    let selected = bgp.local_rib.select_best_path_v4lu(nlri.prefix);
+    let selected = bgp.shard.select_best_path_v4lu(nlri.prefix);
     // Prefix fully gone: release its local label and tear down the swap
     // ILM. (A surviving winner keeps the same per-prefix label, whose ILM
     // `fib_install_labelv4` reconciles below.)
@@ -4063,9 +3882,9 @@ pub fn route_labelv6_withdraw(
         let peer = peers.get_mut_by_idx(ident).expect("peer must exist");
         peer.adj_in.remove_v6lu(nlri.prefix, nlri.id);
     }
-    let removed = bgp.local_rib.remove_v6lu(nlri.prefix, nlri.id, ident);
+    let removed = bgp.shard.remove_v6lu(nlri.prefix, nlri.id, ident);
     if bgp.nexthop_cache.is_some() {
-        let survivor_nhs = bgp.local_rib.candidate_nexthops_v6lu(nlri.prefix);
+        let survivor_nhs = bgp.shard.candidate_nexthops_v6lu(nlri.prefix);
         nht_untrack_withdrawn(
             bgp,
             &removed,
@@ -4073,7 +3892,7 @@ pub fn route_labelv6_withdraw(
             super::nht::NhtDep::V6lu(nlri.prefix),
         );
     }
-    let selected = bgp.local_rib.select_best_path_v6lu(nlri.prefix);
+    let selected = bgp.shard.select_best_path_v6lu(nlri.prefix);
     if selected.is_empty()
         && let Some(local) = bgp
             .lu_labels
@@ -5296,7 +5115,7 @@ fn route_flowspec_propagate(
         .map(|p| p.config.flowspec_validation)
         .unwrap_or(true);
     let valid =
-        super::flowspec::flowspec_validate_with_mode(bgp.local_rib, nlri, best, validation_enabled)
+        super::flowspec::flowspec_validate_with_mode(bgp.shard, nlri, best, validation_enabled)
             .is_valid();
     if valid {
         route_advertise_flowspec_to_peers(afi, nlri, best, bgp, peers);
@@ -8041,14 +7860,14 @@ pub fn route_sync_ipv4(peer: &mut Peer, bgp: &mut BgpTop) {
 
     // Collect all routes first to avoid borrow checker issues
     let routes: Vec<(Ipv4Net, BgpRib)> = if add_path {
-        bgp.local_rib
+        bgp.shard
             .v4
             .0
             .iter()
             .flat_map(|(prefix, ribs)| ribs.iter().map(move |rib| (prefix, rib.clone())))
             .collect()
     } else {
-        bgp.local_rib
+        bgp.shard
             .v4
             .1
             .iter()
@@ -8103,14 +7922,14 @@ pub fn route_sync_ipv6(peer: &mut Peer, bgp: &mut BgpTop) {
 
     // Collect first to avoid borrowing `bgp.local_rib` across the loop.
     let routes: Vec<(Ipv6Net, BgpRib)> = if add_path {
-        bgp.local_rib
+        bgp.shard
             .v6
             .0
             .iter()
             .flat_map(|(prefix, ribs)| ribs.iter().map(move |rib| (prefix, rib.clone())))
             .collect()
     } else {
-        bgp.local_rib
+        bgp.shard
             .v6
             .1
             .iter()
@@ -8147,7 +7966,7 @@ pub fn route_sync_vpnv4(peer: &mut Peer, bgp: &mut BgpTop) {
 
     // Collect all VPNv4 routes first to avoid borrow checker issues
     let all_routes: Vec<(RouteDistinguisher, Vec<(Ipv4Net, BgpRib)>)> = if add_path {
-        bgp.local_rib
+        bgp.shard
             .v4vpn
             .iter()
             .map(|(rd, table)| {
@@ -8160,7 +7979,7 @@ pub fn route_sync_vpnv4(peer: &mut Peer, bgp: &mut BgpTop) {
             })
             .collect()
     } else {
-        bgp.local_rib
+        bgp.shard
             .v4vpn
             .iter()
             .map(|(rd, table)| {
@@ -8413,7 +8232,7 @@ pub fn route_sync_evpn(peer: &mut Peer, bgp: &mut BgpTop) {
 pub fn route_sync_labelv4(peer: &mut Peer, bgp: &mut BgpTop) {
     let add_path = peer.opt.is_add_path_send(Afi::Ip, Safi::MplsLabel);
     let mut routes: Vec<(Ipv4Net, BgpRib)> = Vec::new();
-    for (prefix, ribs) in bgp.local_rib.v4lu.0.iter() {
+    for (prefix, ribs) in bgp.shard.v4lu.0.iter() {
         if add_path {
             routes.extend(ribs.iter().map(|rib| (prefix, rib.clone())));
         } else if let Some(best) = ribs.last() {
@@ -8446,7 +8265,7 @@ pub fn route_sync_labelv4(peer: &mut Peer, bgp: &mut BgpTop) {
 pub fn route_sync_labelv6(peer: &mut Peer, bgp: &mut BgpTop) {
     let add_path = peer.opt.is_add_path_send(Afi::Ip6, Safi::MplsLabel);
     let mut routes: Vec<(Ipv6Net, BgpRib)> = Vec::new();
-    for (prefix, ribs) in bgp.local_rib.v6lu.0.iter() {
+    for (prefix, ribs) in bgp.shard.v6lu.0.iter() {
         if add_path {
             routes.extend(ribs.iter().map(|rib| (prefix, rib.clone())));
         } else if let Some(best) = ribs.last() {
@@ -8543,13 +8362,14 @@ impl Bgp {
             None,
             false,
         );
-        let (_replaced, selected, next_id) = self.local_rib.update(None, prefix, rib.clone());
+        let (_replaced, selected, next_id) = self.shard.update(None, prefix, rib.clone());
         rib.local_id = next_id;
 
         let mut bgp_ref = BgpTop {
             router_id: &self.router_id,
             srv6_ipv6_export: self.srv6_ipv6_export.as_ref(),
             local_rib: &mut self.local_rib,
+            shard: &mut self.shard,
             tx: &self.tx,
             rib_client: &self.ctx.rib,
             attr_store: &mut self.attr_store,
@@ -8588,12 +8408,13 @@ impl Bgp {
     pub fn route_del(&mut self, prefix: Ipv4Net) {
         let ident = ORIGINATED_PEER;
         let id = 0;
-        let removed = self.local_rib.remove(None, prefix, id, ident);
+        let removed = self.shard.remove(None, prefix, id, ident);
 
         let mut bgp_ref = BgpTop {
             router_id: &self.router_id,
             srv6_ipv6_export: self.srv6_ipv6_export.as_ref(),
             local_rib: &mut self.local_rib,
+            shard: &mut self.shard,
             tx: &self.tx,
             rib_client: &self.ctx.rib,
             attr_store: &mut self.attr_store,
@@ -8609,7 +8430,7 @@ impl Bgp {
             lu_labels: None,
         };
 
-        let selected = bgp_ref.local_rib.select_best_path(prefix);
+        let selected = bgp_ref.shard.select_best_path(prefix);
         // When the originated route disappears, a peer route may now
         // be the best (or no path may remain). Reconcile so the FIB
         // matches Loc-RIB.
@@ -8653,12 +8474,13 @@ impl Bgp {
             None,
             false,
         );
-        let (_replaced, selected, _next_id) = self.local_rib.update_v6(prefix, rib);
+        let (_replaced, selected, _next_id) = self.shard.update_v6(prefix, rib);
 
         let mut bgp_ref = BgpTop {
             router_id: &self.router_id,
             srv6_ipv6_export: self.srv6_ipv6_export.as_ref(),
             local_rib: &mut self.local_rib,
+            shard: &mut self.shard,
             tx: &self.tx,
             rib_client: &self.ctx.rib,
             attr_store: &mut self.attr_store,
@@ -8684,12 +8506,13 @@ impl Bgp {
     pub fn route_del_v6(&mut self, prefix: Ipv6Net) {
         self.networks_v6.remove(&prefix);
         let ident = ORIGINATED_PEER;
-        let removed = self.local_rib.remove_v6(prefix, 0, ident);
+        let removed = self.shard.remove_v6(prefix, 0, ident);
 
         let mut bgp_ref = BgpTop {
             router_id: &self.router_id,
             srv6_ipv6_export: self.srv6_ipv6_export.as_ref(),
             local_rib: &mut self.local_rib,
+            shard: &mut self.shard,
             tx: &self.tx,
             rib_client: &self.ctx.rib,
             attr_store: &mut self.attr_store,
@@ -8705,7 +8528,7 @@ impl Bgp {
             lu_labels: None,
         };
 
-        let selected = bgp_ref.local_rib.select_best_path_v6(prefix);
+        let selected = bgp_ref.shard.select_best_path_v6(prefix);
         fib_install_v6(&bgp_ref, prefix, &selected);
 
         if !selected.is_empty() || !removed.is_empty() {
@@ -8733,13 +8556,14 @@ impl Bgp {
             None,
             false,
         );
-        let (_replaced, selected, next_id) = self.local_rib.update_v4lu(prefix, rib.clone());
+        let (_replaced, selected, next_id) = self.shard.update_v4lu(prefix, rib.clone());
         rib.local_id = next_id;
 
         let mut bgp_ref = BgpTop {
             router_id: &self.router_id,
             srv6_ipv6_export: self.srv6_ipv6_export.as_ref(),
             local_rib: &mut self.local_rib,
+            shard: &mut self.shard,
             tx: &self.tx,
             rib_client: &self.ctx.rib,
             attr_store: &mut self.attr_store,
@@ -8770,12 +8594,13 @@ impl Bgp {
 
     pub fn route_del_label_v4(&mut self, prefix: Ipv4Net) {
         let ident = ORIGINATED_PEER;
-        let removed = self.local_rib.remove_v4lu(prefix, 0, ident);
+        let removed = self.shard.remove_v4lu(prefix, 0, ident);
 
         let mut bgp_ref = BgpTop {
             router_id: &self.router_id,
             srv6_ipv6_export: self.srv6_ipv6_export.as_ref(),
             local_rib: &mut self.local_rib,
+            shard: &mut self.shard,
             tx: &self.tx,
             rib_client: &self.ctx.rib,
             attr_store: &mut self.attr_store,
@@ -8791,7 +8616,7 @@ impl Bgp {
             lu_labels: None,
         };
 
-        let selected = bgp_ref.local_rib.select_best_path_v4lu(prefix);
+        let selected = bgp_ref.shard.select_best_path_v4lu(prefix);
         // Reconcile the FIB: removing a self-originated route may reveal
         // a received label winner that now needs its label-push entry.
         fib_install_labelv4(
@@ -8824,13 +8649,14 @@ impl Bgp {
             None,
             false,
         );
-        let (_replaced, selected, next_id) = self.local_rib.update_v6lu(prefix, rib.clone());
+        let (_replaced, selected, next_id) = self.shard.update_v6lu(prefix, rib.clone());
         rib.local_id = next_id;
 
         let mut bgp_ref = BgpTop {
             router_id: &self.router_id,
             srv6_ipv6_export: self.srv6_ipv6_export.as_ref(),
             local_rib: &mut self.local_rib,
+            shard: &mut self.shard,
             tx: &self.tx,
             rib_client: &self.ctx.rib,
             attr_store: &mut self.attr_store,
@@ -8859,12 +8685,13 @@ impl Bgp {
 
     pub fn route_del_label_v6(&mut self, prefix: Ipv6Net) {
         let ident = ORIGINATED_PEER;
-        let removed = self.local_rib.remove_v6lu(prefix, 0, ident);
+        let removed = self.shard.remove_v6lu(prefix, 0, ident);
 
         let mut bgp_ref = BgpTop {
             router_id: &self.router_id,
             srv6_ipv6_export: self.srv6_ipv6_export.as_ref(),
             local_rib: &mut self.local_rib,
+            shard: &mut self.shard,
             tx: &self.tx,
             rib_client: &self.ctx.rib,
             attr_store: &mut self.attr_store,
@@ -8880,7 +8707,7 @@ impl Bgp {
             lu_labels: None,
         };
 
-        let selected = bgp_ref.local_rib.select_best_path_v6lu(prefix);
+        let selected = bgp_ref.shard.select_best_path_v6lu(prefix);
         fib_install_labelv6(
             bgp_ref.rib_client,
             Some(&self.nexthop_cache),
@@ -8945,13 +8772,14 @@ impl Bgp {
             None,
             false,
         );
-        let (_replaced, selected, next_id) = self.local_rib.update(None, prefix, rib.clone());
+        let (_replaced, selected, next_id) = self.shard.update(None, prefix, rib.clone());
         rib.local_id = next_id;
 
         let mut bgp_ref = BgpTop {
             router_id: &self.router_id,
             srv6_ipv6_export: self.srv6_ipv6_export.as_ref(),
             local_rib: &mut self.local_rib,
+            shard: &mut self.shard,
             tx: &self.tx,
             rib_client: &self.ctx.rib,
             attr_store: &mut self.attr_store,
@@ -8988,12 +8816,13 @@ impl Bgp {
     pub fn route_redist_withdraw(&mut self, rtype: crate::rib::RibType, prefix: Ipv4Net) {
         let ident = ORIGINATED_PEER;
         let remote_id = Self::redist_remote_id(rtype);
-        let removed = self.local_rib.remove(None, prefix, remote_id, ident);
+        let removed = self.shard.remove(None, prefix, remote_id, ident);
 
         let mut bgp_ref = BgpTop {
             router_id: &self.router_id,
             srv6_ipv6_export: self.srv6_ipv6_export.as_ref(),
             local_rib: &mut self.local_rib,
+            shard: &mut self.shard,
             tx: &self.tx,
             rib_client: &self.ctx.rib,
             attr_store: &mut self.attr_store,
@@ -9009,7 +8838,7 @@ impl Bgp {
             lu_labels: None,
         };
 
-        let selected = bgp_ref.local_rib.select_best_path(prefix);
+        let selected = bgp_ref.shard.select_best_path(prefix);
         // A peer route may now be best again (or nothing's left);
         // reconcile the FIB.
         fib_install_v4(&bgp_ref, prefix, &selected);
@@ -9061,13 +8890,14 @@ impl Bgp {
             None,
             false,
         );
-        let (_replaced, selected, next_id) = self.local_rib.update_v6(prefix, rib.clone());
+        let (_replaced, selected, next_id) = self.shard.update_v6(prefix, rib.clone());
         rib.local_id = next_id;
 
         let mut bgp_ref = BgpTop {
             router_id: &self.router_id,
             srv6_ipv6_export: self.srv6_ipv6_export.as_ref(),
             local_rib: &mut self.local_rib,
+            shard: &mut self.shard,
             tx: &self.tx,
             rib_client: &self.ctx.rib,
             attr_store: &mut self.attr_store,
@@ -9101,12 +8931,13 @@ impl Bgp {
     pub fn route_redist_withdraw_v6(&mut self, rtype: crate::rib::RibType, prefix: Ipv6Net) {
         let ident = ORIGINATED_PEER;
         let remote_id = Self::redist_remote_id(rtype);
-        let removed = self.local_rib.remove_v6(prefix, remote_id, ident);
+        let removed = self.shard.remove_v6(prefix, remote_id, ident);
 
         let mut bgp_ref = BgpTop {
             router_id: &self.router_id,
             srv6_ipv6_export: self.srv6_ipv6_export.as_ref(),
             local_rib: &mut self.local_rib,
+            shard: &mut self.shard,
             tx: &self.tx,
             rib_client: &self.ctx.rib,
             attr_store: &mut self.attr_store,
@@ -9122,7 +8953,7 @@ impl Bgp {
             lu_labels: None,
         };
 
-        let selected = bgp_ref.local_rib.select_best_path_v6(prefix);
+        let selected = bgp_ref.shard.select_best_path_v6(prefix);
         fib_install_v6(&bgp_ref, prefix, &selected);
 
         if !selected.is_empty() || !removed.is_empty() {
@@ -9157,13 +8988,14 @@ impl Bgp {
             None,
             false,
         );
-        let (_replaced, selected, next_id) = self.local_rib.update_v4lu(prefix, rib.clone());
+        let (_replaced, selected, next_id) = self.shard.update_v4lu(prefix, rib.clone());
         rib.local_id = next_id;
 
         let mut bgp_ref = BgpTop {
             router_id: &self.router_id,
             srv6_ipv6_export: self.srv6_ipv6_export.as_ref(),
             local_rib: &mut self.local_rib,
+            shard: &mut self.shard,
             tx: &self.tx,
             rib_client: &self.ctx.rib,
             attr_store: &mut self.attr_store,
@@ -9195,12 +9027,13 @@ impl Bgp {
     pub fn route_redist_withdraw_labelv4(&mut self, rtype: crate::rib::RibType, prefix: Ipv4Net) {
         let ident = ORIGINATED_PEER;
         let remote_id = Self::redist_remote_id(rtype);
-        let removed = self.local_rib.remove_v4lu(prefix, remote_id, ident);
+        let removed = self.shard.remove_v4lu(prefix, remote_id, ident);
 
         let mut bgp_ref = BgpTop {
             router_id: &self.router_id,
             srv6_ipv6_export: self.srv6_ipv6_export.as_ref(),
             local_rib: &mut self.local_rib,
+            shard: &mut self.shard,
             tx: &self.tx,
             rib_client: &self.ctx.rib,
             attr_store: &mut self.attr_store,
@@ -9216,7 +9049,7 @@ impl Bgp {
             lu_labels: None,
         };
 
-        let selected = bgp_ref.local_rib.select_best_path_v4lu(prefix);
+        let selected = bgp_ref.shard.select_best_path_v4lu(prefix);
         // Reconcile the FIB: removing a self-originated route may reveal
         // a received label winner that now needs its label-push entry.
         fib_install_labelv4(
@@ -9253,13 +9086,14 @@ impl Bgp {
             None,
             false,
         );
-        let (_replaced, selected, next_id) = self.local_rib.update_v6lu(prefix, rib.clone());
+        let (_replaced, selected, next_id) = self.shard.update_v6lu(prefix, rib.clone());
         rib.local_id = next_id;
 
         let mut bgp_ref = BgpTop {
             router_id: &self.router_id,
             srv6_ipv6_export: self.srv6_ipv6_export.as_ref(),
             local_rib: &mut self.local_rib,
+            shard: &mut self.shard,
             tx: &self.tx,
             rib_client: &self.ctx.rib,
             attr_store: &mut self.attr_store,
@@ -9289,12 +9123,13 @@ impl Bgp {
     pub fn route_redist_withdraw_labelv6(&mut self, rtype: crate::rib::RibType, prefix: Ipv6Net) {
         let ident = ORIGINATED_PEER;
         let remote_id = Self::redist_remote_id(rtype);
-        let removed = self.local_rib.remove_v6lu(prefix, remote_id, ident);
+        let removed = self.shard.remove_v6lu(prefix, remote_id, ident);
 
         let mut bgp_ref = BgpTop {
             router_id: &self.router_id,
             srv6_ipv6_export: self.srv6_ipv6_export.as_ref(),
             local_rib: &mut self.local_rib,
+            shard: &mut self.shard,
             tx: &self.tx,
             rib_client: &self.ctx.rib,
             attr_store: &mut self.attr_store,
@@ -9310,7 +9145,7 @@ impl Bgp {
             lu_labels: None,
         };
 
-        let selected = bgp_ref.local_rib.select_best_path_v6lu(prefix);
+        let selected = bgp_ref.shard.select_best_path_v6lu(prefix);
         fib_install_labelv6(
             bgp_ref.rib_client,
             Some(&self.nexthop_cache),
@@ -9431,6 +9266,7 @@ impl Bgp {
             router_id: &self.router_id,
             srv6_ipv6_export: self.srv6_ipv6_export.as_ref(),
             local_rib: &mut self.local_rib,
+            shard: &mut self.shard,
             tx: &self.tx,
             rib_client: &self.ctx.rib,
             attr_store: &mut self.attr_store,
@@ -9549,6 +9385,7 @@ impl Bgp {
             router_id: &self.router_id,
             srv6_ipv6_export: self.srv6_ipv6_export.as_ref(),
             local_rib: &mut self.local_rib,
+            shard: &mut self.shard,
             tx: &self.tx,
             rib_client: &self.ctx.rib,
             attr_store: &mut self.attr_store,
@@ -9654,6 +9491,7 @@ impl Bgp {
             router_id: &self.router_id,
             srv6_ipv6_export: self.srv6_ipv6_export.as_ref(),
             local_rib: &mut self.local_rib,
+            shard: &mut self.shard,
             tx: &self.tx,
             rib_client: &self.ctx.rib,
             attr_store: &mut self.attr_store,
@@ -11696,7 +11534,7 @@ mod tests {
 
     #[test]
     fn candidate_nexthops_v4_collects_distinct_survivors() {
-        use super::{BgpRib, BgpRibType, LocalRib};
+        use super::{BgpRib, BgpRibType};
         let mk = |ident: usize, nh: Ipv4Addr| {
             let attr = BgpAttr {
                 nexthop: Some(BgpNexthop::Ipv4(nh)),
@@ -11715,7 +11553,7 @@ mod tests {
             )
         };
         let prefix: Ipv4Net = "10.0.0.0/24".parse().unwrap();
-        let mut rib = LocalRib::default();
+        let mut rib = super::super::shard::BgpShard::default();
         rib.update(None, prefix, mk(1, Ipv4Addr::new(192, 0, 2, 1)));
         rib.update(None, prefix, mk(2, Ipv4Addr::new(192, 0, 2, 2)));
 

--- a/zebra-rs/src/bgp/shard.rs
+++ b/zebra-rs/src/bgp/shard.rs
@@ -1,0 +1,205 @@
+//! Shard-owned BGP state (RIB sharding plan B.1, first slice).
+//!
+//! [`BgpShard`] holds exactly the state a future shard task will own
+//! end-to-end: the Loc-RIB tables that partition by prefix hash. Per
+//! the plan's D3 ruling (`docs/design/bgp-rib-sharding-plan.md` §8),
+//! that scope is v4/v6 unicast, v4/v6 labeled-unicast, and VPNv4/v6 —
+//! EVPN, flowspec, SR-Policy, BGP-LS, RTC, and table-map stay
+//! main-owned in [`super::route::LocalRib`] (small tables; EVPN MAC
+//! routes don't even hash by IP prefix).
+//!
+//! Today `BgpShard` is a plain field on `Bgp` / `BgpVrf`, mutated
+//! inline by the single event loop — no behavior change. Later B.1
+//! slices move the shard-side `BgpAttrStore` and the per-`ident`
+//! adj-in slices here; Phase B.3 gives it its own task.
+
+use std::collections::{BTreeMap, BTreeSet};
+use std::net::IpAddr;
+
+use bgp_packet::RouteDistinguisher;
+use ipnet::{Ipv4Net, Ipv6Net};
+
+use super::route::{BgpRib, LocalRibTable};
+
+#[derive(Debug, Default)]
+pub struct BgpShard {
+    pub v4: LocalRibTable<Ipv4Net>,
+
+    pub v6: LocalRibTable<Ipv6Net>,
+
+    /// IPv4 / IPv6 Labeled-Unicast (SAFI 4) Loc-RIB. Same prefix key as
+    /// unicast; each `BgpRib` carries the per-prefix label.
+    pub v4lu: LocalRibTable<Ipv4Net>,
+
+    pub v6lu: LocalRibTable<Ipv6Net>,
+
+    pub v4vpn: BTreeMap<RouteDistinguisher, LocalRibTable<Ipv4Net>>,
+
+    pub v6vpn: BTreeMap<RouteDistinguisher, LocalRibTable<Ipv6Net>>,
+}
+
+impl BgpShard {
+    // Update LocalRIB route.
+    pub fn update(
+        &mut self,
+        rd: Option<RouteDistinguisher>,
+        prefix: Ipv4Net,
+        rib: BgpRib,
+    ) -> (Vec<BgpRib>, Vec<BgpRib>, u32) {
+        match rd {
+            Some(rd) => self.v4vpn.entry(rd).or_default().update(prefix, rib),
+            None => self.v4.update(prefix, rib),
+        }
+    }
+
+    pub fn remove(
+        &mut self,
+        rd: Option<RouteDistinguisher>,
+        prefix: Ipv4Net,
+        id: u32,
+        ident: usize,
+    ) -> Vec<BgpRib> {
+        match rd {
+            Some(rd) => self.v4vpn.entry(rd).or_default().remove(prefix, id, ident),
+            None => self.v4.remove(prefix, id, ident),
+        }
+    }
+
+    // Return selected best path, not the change history.
+    pub fn select_best_path(&mut self, prefix: Ipv4Net) -> Vec<BgpRib> {
+        self.v4.select_best_path(prefix)
+    }
+
+    // Return selected best path, not the change history.
+    pub fn select_best_path_vpn(
+        &mut self,
+        rd: &RouteDistinguisher,
+        prefix: Ipv4Net,
+    ) -> Vec<BgpRib> {
+        self.v4vpn.entry(*rd).or_default().select_best_path(prefix)
+    }
+
+    // IPv6 unicast accessors. VPNv6 (`v6vpn`) lands with layer 2c, so
+    // these take no RD — the global/default v6 unicast Loc-RIB only.
+    pub fn update_v6(&mut self, prefix: Ipv6Net, rib: BgpRib) -> (Vec<BgpRib>, Vec<BgpRib>, u32) {
+        self.v6.update(prefix, rib)
+    }
+
+    pub fn remove_v6(&mut self, prefix: Ipv6Net, id: u32, ident: usize) -> Vec<BgpRib> {
+        self.v6.remove(prefix, id, ident)
+    }
+
+    pub fn select_best_path_v6(&mut self, prefix: Ipv6Net) -> Vec<BgpRib> {
+        self.v6.select_best_path(prefix)
+    }
+
+    // IPv4 / IPv6 Labeled-Unicast (SAFI 4) accessors. Same Loc-RIB
+    // engine as unicast; the per-prefix label travels on each `BgpRib`.
+    pub fn update_v4lu(&mut self, prefix: Ipv4Net, rib: BgpRib) -> (Vec<BgpRib>, Vec<BgpRib>, u32) {
+        self.v4lu.update(prefix, rib)
+    }
+
+    pub fn remove_v4lu(&mut self, prefix: Ipv4Net, id: u32, ident: usize) -> Vec<BgpRib> {
+        self.v4lu.remove(prefix, id, ident)
+    }
+
+    pub fn select_best_path_v4lu(&mut self, prefix: Ipv4Net) -> Vec<BgpRib> {
+        self.v4lu.select_best_path(prefix)
+    }
+
+    pub fn update_v6lu(&mut self, prefix: Ipv6Net, rib: BgpRib) -> (Vec<BgpRib>, Vec<BgpRib>, u32) {
+        self.v6lu.update(prefix, rib)
+    }
+
+    pub fn remove_v6lu(&mut self, prefix: Ipv6Net, id: u32, ident: usize) -> Vec<BgpRib> {
+        self.v6lu.remove(prefix, id, ident)
+    }
+
+    pub fn select_best_path_v6lu(&mut self, prefix: Ipv6Net) -> Vec<BgpRib> {
+        self.v6lu.select_best_path(prefix)
+    }
+
+    // VPNv6 accessors — per-RD `v6vpn` tables, mirroring the v4vpn
+    // ones. (Best-path-for-advertise of VPNv6 winners lands in 2c-ii.)
+    pub fn update_v6vpn(
+        &mut self,
+        rd: RouteDistinguisher,
+        prefix: Ipv6Net,
+        rib: BgpRib,
+    ) -> (Vec<BgpRib>, Vec<BgpRib>, u32) {
+        self.v6vpn.entry(rd).or_default().update(prefix, rib)
+    }
+
+    pub fn remove_v6vpn(
+        &mut self,
+        rd: RouteDistinguisher,
+        prefix: Ipv6Net,
+        id: u32,
+        ident: usize,
+    ) -> Vec<BgpRib> {
+        self.v6vpn.entry(rd).or_default().remove(prefix, id, ident)
+    }
+
+    pub fn select_best_path_vpn_v6(
+        &mut self,
+        rd: &RouteDistinguisher,
+        prefix: Ipv6Net,
+    ) -> Vec<BgpRib> {
+        self.v6vpn.entry(*rd).or_default().select_best_path(prefix)
+    }
+
+    /// Distinct BGP next-hops still in use by surviving candidates for a
+    /// v4 (`rd == None`) / VPNv4 (`rd == Some`) prefix — for NHT untrack
+    /// to avoid releasing a next-hop another path still needs.
+    pub fn candidate_nexthops_v4(
+        &self,
+        rd: Option<RouteDistinguisher>,
+        prefix: Ipv4Net,
+    ) -> BTreeSet<IpAddr> {
+        let cands = match rd {
+            Some(rd) => self.v4vpn.get(&rd).map(|t| t.candidates(prefix)),
+            None => Some(self.v4.candidates(prefix)),
+        };
+        cands
+            .into_iter()
+            .flatten()
+            .filter_map(|r| super::nht::bgp_nexthop_ip(&r.attr))
+            .collect()
+    }
+
+    /// IPv6 counterpart of [`Self::candidate_nexthops_v4`].
+    pub fn candidate_nexthops_v6(
+        &self,
+        rd: Option<RouteDistinguisher>,
+        prefix: Ipv6Net,
+    ) -> BTreeSet<IpAddr> {
+        let cands = match rd {
+            Some(rd) => self.v6vpn.get(&rd).map(|t| t.candidates(prefix)),
+            None => Some(self.v6.candidates(prefix)),
+        };
+        cands
+            .into_iter()
+            .flatten()
+            .filter_map(|r| super::nht::bgp_nexthop_ip(&r.attr))
+            .collect()
+    }
+
+    /// Labeled-Unicast (SAFI 4) counterparts: the distinct BGP next-hops
+    /// among the `v4lu` / `v6lu` candidates for `prefix` (for NHT untrack
+    /// after a displaced path).
+    pub fn candidate_nexthops_v4lu(&self, prefix: Ipv4Net) -> BTreeSet<IpAddr> {
+        self.v4lu
+            .candidates(prefix)
+            .iter()
+            .filter_map(|r| super::nht::bgp_nexthop_ip(&r.attr))
+            .collect()
+    }
+
+    pub fn candidate_nexthops_v6lu(&self, prefix: Ipv6Net) -> BTreeSet<IpAddr> {
+        self.v6lu
+            .candidates(prefix)
+            .iter()
+            .filter_map(|r| super::nht::bgp_nexthop_ip(&r.attr))
+            .collect()
+    }
+}

--- a/zebra-rs/src/bgp/show.rs
+++ b/zebra-rs/src/bgp/show.rs
@@ -26,6 +26,7 @@ use crate::config::{DisplayRequest, path_from_command};
 /// `Bgp` and a per-VRF `BgpVrf`.
 pub trait BgpShowView {
     fn local_rib(&self) -> &LocalRib;
+    fn shard(&self) -> &super::shard::BgpShard;
     fn peers(&self) -> &PeerMap;
     fn router_id(&self) -> Ipv4Addr;
     fn asn(&self) -> u32;
@@ -34,6 +35,9 @@ pub trait BgpShowView {
 impl BgpShowView for Bgp {
     fn local_rib(&self) -> &LocalRib {
         &self.local_rib
+    }
+    fn shard(&self) -> &super::shard::BgpShard {
+        &self.shard
     }
     fn peers(&self) -> &PeerMap {
         &self.peers
@@ -49,6 +53,9 @@ impl BgpShowView for Bgp {
 impl BgpShowView for BgpVrf {
     fn local_rib(&self) -> &LocalRib {
         &self.local_rib
+    }
+    fn shard(&self) -> &super::shard::BgpShard {
+        &self.shard
     }
     fn peers(&self) -> &PeerMap {
         &self.peers
@@ -127,11 +134,11 @@ fn configured_afi_safis<V: BgpShowView>(bgp: &V) -> Vec<AfiSafi> {
 /// Count Loc-RIB entries for a given AFI/SAFI.
 fn rib_entries_count<V: BgpShowView>(bgp: &V, afi_safi: &AfiSafi) -> usize {
     match (afi_safi.afi, afi_safi.safi) {
-        (Afi::Ip, Safi::Unicast) => bgp.local_rib().v4.0.len(),
-        (Afi::Ip6, Safi::Unicast) => bgp.local_rib().v6.0.len(),
-        (Afi::Ip, Safi::MplsLabel) => bgp.local_rib().v4lu.0.len(),
-        (Afi::Ip6, Safi::MplsLabel) => bgp.local_rib().v6lu.0.len(),
-        (Afi::Ip, Safi::MplsVpn) => bgp.local_rib().v4vpn.values().map(|t| t.0.len()).sum(),
+        (Afi::Ip, Safi::Unicast) => bgp.shard().v4.0.len(),
+        (Afi::Ip6, Safi::Unicast) => bgp.shard().v6.0.len(),
+        (Afi::Ip, Safi::MplsLabel) => bgp.shard().v4lu.0.len(),
+        (Afi::Ip6, Safi::MplsLabel) => bgp.shard().v6lu.0.len(),
+        (Afi::Ip, Safi::MplsVpn) => bgp.shard().v4vpn.values().map(|t| t.0.len()).sum(),
         (Afi::L2vpn, Safi::Evpn) => bgp.local_rib().evpn.values().map(|t| t.cands.len()).sum(),
         (Afi::LinkState, Safi::LinkState) => bgp.local_rib().bgp_ls.selected.len(),
         _ => 0,
@@ -542,7 +549,7 @@ fn show_bgp<V: BgpShowView>(
     _args: Args,
     json: bool,
 ) -> std::result::Result<String, std::fmt::Error> {
-    render_unicast_table(&bgp.local_rib().v4.0, json)
+    render_unicast_table(&bgp.shard().v4.0, json)
 }
 
 /// `show ip bgp labeled-unicast` — render the IPv4 and IPv6
@@ -562,13 +569,13 @@ fn show_bgp_labeled(
     buf.push_str(SHOW_BGP_HEADER);
 
     writeln!(buf, "IPv4 Labeled Unicast:")?;
-    for (key, value) in bgp.local_rib.v4lu.0.iter() {
+    for (key, value) in bgp.shard.v4lu.0.iter() {
         for rib in value.iter() {
             show_labeled_row(&mut buf, &key.to_string(), rib)?;
         }
     }
     writeln!(buf, "IPv6 Labeled Unicast:")?;
-    for (key, value) in bgp.local_rib.v6lu.0.iter() {
+    for (key, value) in bgp.shard.v6lu.0.iter() {
         for rib in value.iter() {
             show_labeled_row(&mut buf, &key.to_string(), rib)?;
         }
@@ -635,7 +642,7 @@ fn show_bgp_vpnv4_table(bgp: &Bgp, json: bool) -> std::result::Result<String, st
     if json {
         let mut routes: Vec<BgpVpnv4RouteJson> = Vec::new();
 
-        for (rd, value) in bgp.local_rib.v4vpn.iter() {
+        for (rd, value) in bgp.shard.v4vpn.iter() {
             for (prefix, ribs) in value.0.iter() {
                 for rib in ribs.iter() {
                     let aspath_str = show_aspath(&rib.attr);
@@ -690,7 +697,7 @@ fn show_bgp_vpnv4_table(bgp: &Bgp, json: bool) -> std::result::Result<String, st
         buf,
         "     Network          Next Hop            Metric LocPrf Weight Path"
     );
-    for (key, value) in bgp.local_rib.v4vpn.iter() {
+    for (key, value) in bgp.shard.v4vpn.iter() {
         if !value.0.is_empty() {
             writeln!(buf, "Route Distinguisher: {}", key)?;
         }
@@ -1000,7 +1007,7 @@ fn show_bgp_vpnv4_entry(bgp: &Bgp, tok: &str) -> std::result::Result<String, std
     if tok.contains('/') {
         match tok.parse::<Ipv4Net>() {
             Ok(net) => {
-                for (rd, table) in bgp.local_rib.v4vpn.iter() {
+                for (rd, table) in bgp.shard.v4vpn.iter() {
                     if let Some(ribs) = table.0.get(&net) {
                         write_vpnv4_entry_detail(&mut out, bgp, rd, &net.to_string(), ribs)?;
                     }
@@ -1012,7 +1019,7 @@ fn show_bgp_vpnv4_entry(bgp: &Bgp, tok: &str) -> std::result::Result<String, std
         match tok.parse::<Ipv4Addr>() {
             Ok(addr) => {
                 let host = addr.to_host_prefix();
-                for (rd, table) in bgp.local_rib.v4vpn.iter() {
+                for (rd, table) in bgp.shard.v4vpn.iter() {
                     if let Some((prefix, ribs)) = table.0.get_lpm(&host) {
                         write_vpnv4_entry_detail(&mut out, bgp, rd, &prefix.to_string(), ribs)?;
                     }
@@ -1303,7 +1310,7 @@ fn show_bgp_route_entry(
         Some(addr) => addr,
         None => return Ok(String::from("% No BGP route exists")),
     };
-    if let Some((prefix, ribs)) = bgp.local_rib.v4.0.get_lpm(&addr.to_host_prefix()) {
+    if let Some((prefix, ribs)) = bgp.shard.v4.0.get_lpm(&addr.to_host_prefix()) {
         write_bgp_entry_detail(&mut out, bgp, &prefix.to_string(), ribs)?;
     }
     Ok(out)
@@ -1318,7 +1325,7 @@ fn show_bgp_ipv4<V: BgpShowView>(
     json: bool,
 ) -> std::result::Result<String, std::fmt::Error> {
     let Some(tok) = args.string() else {
-        return render_unicast_table(&bgp.local_rib().v4.0, json);
+        return render_unicast_table(&bgp.shard().v4.0, json);
     };
     // `summary` arrives as the list-key value (an enum arm of the key
     // union — see exec.yang), not as a separate path element.
@@ -1329,7 +1336,7 @@ fn show_bgp_ipv4<V: BgpShowView>(
     if tok.contains('/') {
         match tok.parse::<Ipv4Net>() {
             Ok(net) => {
-                if let Some(ribs) = bgp.local_rib().v4.0.get(&net) {
+                if let Some(ribs) = bgp.shard().v4.0.get(&net) {
                     write_bgp_entry_detail(&mut out, bgp, &net.to_string(), ribs)?;
                 }
             }
@@ -1338,7 +1345,7 @@ fn show_bgp_ipv4<V: BgpShowView>(
     } else {
         match tok.parse::<Ipv4Addr>() {
             Ok(addr) => {
-                if let Some((prefix, ribs)) = bgp.local_rib().v4.0.get_lpm(&addr.to_host_prefix()) {
+                if let Some((prefix, ribs)) = bgp.shard().v4.0.get_lpm(&addr.to_host_prefix()) {
                     write_bgp_entry_detail(&mut out, bgp, &prefix.to_string(), ribs)?;
                 }
             }
@@ -1369,7 +1376,7 @@ fn show_bgp_ipv4_longer<V: BgpShowView>(
         return Ok(out);
     };
     out.push_str(SHOW_BGP_HEADER);
-    for (prefix, ribs) in bgp.local_rib().v4.0.children(&net) {
+    for (prefix, ribs) in bgp.shard().v4.0.children(&net) {
         for rib in ribs.iter() {
             write_bgp_route_line(&mut out, &prefix.to_string(), rib)?;
         }
@@ -1385,7 +1392,7 @@ fn show_bgp_ipv6<V: BgpShowView>(
     json: bool,
 ) -> std::result::Result<String, std::fmt::Error> {
     let Some(tok) = args.string() else {
-        return render_unicast_table(&bgp.local_rib().v6.0, json);
+        return render_unicast_table(&bgp.shard().v6.0, json);
     };
     if tok == "summary" {
         return show_bgp_summary_one(bgp, AfiSafi::new(Afi::Ip6, Safi::Unicast), json);
@@ -1394,7 +1401,7 @@ fn show_bgp_ipv6<V: BgpShowView>(
     if tok.contains('/') {
         match tok.parse::<Ipv6Net>() {
             Ok(net) => {
-                if let Some(ribs) = bgp.local_rib().v6.0.get(&net) {
+                if let Some(ribs) = bgp.shard().v6.0.get(&net) {
                     write_bgp_entry_detail(&mut out, bgp, &net.to_string(), ribs)?;
                 }
             }
@@ -1403,7 +1410,7 @@ fn show_bgp_ipv6<V: BgpShowView>(
     } else {
         match tok.parse::<Ipv6Addr>() {
             Ok(addr) => {
-                if let Some((prefix, ribs)) = bgp.local_rib().v6.0.get_lpm(&addr.to_host_prefix()) {
+                if let Some((prefix, ribs)) = bgp.shard().v6.0.get_lpm(&addr.to_host_prefix()) {
                     write_bgp_entry_detail(&mut out, bgp, &prefix.to_string(), ribs)?;
                 }
             }
@@ -1434,7 +1441,7 @@ fn show_bgp_ipv6_longer<V: BgpShowView>(
         return Ok(out);
     };
     out.push_str(SHOW_BGP_HEADER);
-    for (prefix, ribs) in bgp.local_rib().v6.0.children(&net) {
+    for (prefix, ribs) in bgp.shard().v6.0.children(&net) {
         for rib in ribs.iter() {
             write_bgp_route_line(&mut out, &prefix.to_string(), rib)?;
         }
@@ -2957,12 +2964,8 @@ fn show_bgp_flowspec(
         // `*` marks a valid flow spec.
         let source = bgp.peers.get_by_idx(rib.ident);
         let validation_enabled = source.map(|p| p.config.flowspec_validation).unwrap_or(true);
-        let validation = super::flowspec::flowspec_validate_with_mode(
-            &bgp.local_rib,
-            nlri,
-            rib,
-            validation_enabled,
-        );
+        let validation =
+            super::flowspec::flowspec_validate_with_mode(&bgp.shard, nlri, rib, validation_enabled);
         let mark = if validation.is_valid() { "*" } else { " " };
         let from = source
             .map(|p| p.address.to_string())
@@ -3299,11 +3302,15 @@ Neighbor        V         AS   MsgRcvd   MsgSent   TblVer  InQ OutQ  Up/Down Sta
 
     struct TestView {
         rib: LocalRib,
+        shard: super::super::shard::BgpShard,
         peers: PeerMap,
     }
     impl BgpShowView for TestView {
         fn local_rib(&self) -> &LocalRib {
             &self.rib
+        }
+        fn shard(&self) -> &super::super::shard::BgpShard {
+            &self.shard
         }
         fn peers(&self) -> &PeerMap {
             &self.peers
@@ -3355,6 +3362,7 @@ Neighbor        V         AS   MsgRcvd   MsgSent   TblVer  InQ OutQ  Up/Down Sta
 
         TestView {
             rib: LocalRib::default(),
+            shard: super::super::shard::BgpShard::default(),
             peers,
         }
     }
@@ -3399,6 +3407,7 @@ Neighbor        V         AS   MsgRcvd   MsgSent   TblVer  InQ OutQ  Up/Down Sta
         peers.insert_with_key(PeerKey::Interface(7), iface_peer);
         let view = TestView {
             rib: LocalRib::default(),
+            shard: super::super::shard::BgpShard::default(),
             peers,
         };
 
@@ -3620,11 +3629,15 @@ mod detail_tests {
     /// `PeerMap` is enough (unknown idents resolve to "self").
     struct TestView {
         rib: LocalRib,
+        shard: super::super::shard::BgpShard,
         peers: PeerMap,
     }
     impl BgpShowView for TestView {
         fn local_rib(&self) -> &LocalRib {
             &self.rib
+        }
+        fn shard(&self) -> &super::super::shard::BgpShard {
+            &self.shard
         }
         fn peers(&self) -> &PeerMap {
             &self.peers
@@ -3640,6 +3653,7 @@ mod detail_tests {
     fn test_view() -> TestView {
         TestView {
             rib: LocalRib::default(),
+            shard: super::super::shard::BgpShard::default(),
             peers: PeerMap::new(),
         }
     }

--- a/zebra-rs/src/bgp/vrf/inst.rs
+++ b/zebra-rs/src/bgp/vrf/inst.rs
@@ -18,6 +18,7 @@ use super::super::Message;
 use super::super::interface_addrs::InterfaceAddrs;
 use super::super::peer_map::PeerMap;
 use super::super::route::LocalRib;
+use super::super::shard::BgpShard;
 use super::super::store::BgpAttrStore;
 use super::super::update_group::UpdateGroupMap;
 use super::msg::{BgpGlobalMsg, BgpVrfMsg};
@@ -43,6 +44,9 @@ pub struct BgpVrf {
     /// RIB holds only the CE-facing surface plus routes imported
     /// from the global Loc-RIB via [`BgpVrfMsg::ImportV4`].
     pub local_rib: LocalRib,
+    /// Shard-scope Loc-RIB tables (unicast/LU/VPN) — the per-VRF
+    /// twin of [`crate::bgp::shard::BgpShard`] on the global task.
+    pub shard: BgpShard,
     /// Per-VRF BGP router-id. Defaults to the global router-id at
     /// spawn time; the operator may override via
     /// `set router bgp vrf <name> router-id <addr>`, in which case
@@ -228,7 +232,7 @@ pub struct VrfImportDispatcher<'a> {
 /// Fan a freshly best-path-selected VPNv4 route out to every
 /// VRF whose `import_rts_v4` intersects the route's RT extcomms.
 /// Called from the shared `route_ipv4_update` after
-/// `local_rib.update(Some(rd), ...)` returns. `label = 0` means
+/// `shard.update(Some(rd), ...)` returns. `label = 0` means
 /// "no per-VRF label" — the receiving VRF treats it the same way
 /// the Export side does (skip the install).
 ///
@@ -355,6 +359,7 @@ impl BgpVrf {
             ctx,
             peers: PeerMap::new(),
             local_rib: LocalRib::default(),
+            shard: BgpShard::default(),
             router_id,
             cm: ConfigChannel::new(),
             show: ShowChannel::new(),
@@ -445,6 +450,7 @@ impl BgpVrf {
                     router_id: &self.router_id,
                     srv6_ipv6_export: None,
                     local_rib: &mut self.local_rib,
+                    shard: &mut self.shard,
                     tx: &self.tx,
                     rib_client: &self.ctx.rib,
                     attr_store: &mut self.attr_store,
@@ -597,7 +603,7 @@ impl BgpVrf {
             vrf_transit_only: false,
         };
 
-        let (_, selected, _gen) = self.local_rib.update(None, prefix, rib);
+        let (_, selected, _gen) = self.shard.update(None, prefix, rib);
         let winners = selected.len();
 
         // Persist the resolved transport for this prefix so `fib_install`
@@ -614,6 +620,7 @@ impl BgpVrf {
             router_id: &self.router_id,
             srv6_ipv6_export: None,
             local_rib: &mut self.local_rib,
+            shard: &mut self.shard,
             tx: &self.tx,
             rib_client: &self.ctx.rib,
             attr_store: &mut self.attr_store,
@@ -688,9 +695,9 @@ impl BgpVrf {
         prefix: ipnet::Ipv4Net,
     ) {
         let removed = self
-            .local_rib
+            .shard
             .remove(None, prefix, 0, super::super::route::ORIGINATED_PEER);
-        let selected = self.local_rib.select_best_path(prefix);
+        let selected = self.shard.select_best_path(prefix);
         let removed_n = removed.len();
         let winners = selected.len();
 
@@ -701,6 +708,7 @@ impl BgpVrf {
             router_id: &self.router_id,
             srv6_ipv6_export: None,
             local_rib: &mut self.local_rib,
+            shard: &mut self.shard,
             tx: &self.tx,
             rib_client: &self.ctx.rib,
             attr_store: &mut self.attr_store,
@@ -815,7 +823,7 @@ impl BgpVrf {
             vrf_transit_only: false,
         };
 
-        let (_, selected, _gen) = self.local_rib.update_v6(prefix, rib);
+        let (_, selected, _gen) = self.shard.update_v6(prefix, rib);
         let winners = selected.len();
 
         // Persist the resolved transport (see `handle_import_v4`).
@@ -829,6 +837,7 @@ impl BgpVrf {
             router_id: &self.router_id,
             srv6_ipv6_export: None,
             local_rib: &mut self.local_rib,
+            shard: &mut self.shard,
             tx: &self.tx,
             rib_client: &self.ctx.rib,
             attr_store: &mut self.attr_store,
@@ -886,9 +895,9 @@ impl BgpVrf {
         prefix: ipnet::Ipv6Net,
     ) {
         let removed = self
-            .local_rib
+            .shard
             .remove_v6(prefix, 0, super::super::route::ORIGINATED_PEER);
-        let selected = self.local_rib.select_best_path_v6(prefix);
+        let selected = self.shard.select_best_path_v6(prefix);
         let removed_n = removed.len();
         let winners = selected.len();
 
@@ -898,6 +907,7 @@ impl BgpVrf {
             router_id: &self.router_id,
             srv6_ipv6_export: None,
             local_rib: &mut self.local_rib,
+            shard: &mut self.shard,
             tx: &self.tx,
             rib_client: &self.ctx.rib,
             attr_store: &mut self.attr_store,

--- a/zebra-rs/src/bgp/vrf/spawn.rs
+++ b/zebra-rs/src/bgp/vrf/spawn.rs
@@ -186,7 +186,7 @@ pub fn spawn_bgp_vrf(
 
     // Self-originated networks from
     // `router bgp vrf X afi-safi ipv4-unicast network <p>` land
-    // in `vrf.local_rib.v4` as `BgpRibType::Originated` and
+    // in `vrf.shard.v4` as `BgpRibType::Originated` and
     // emit a `BgpGlobalMsg::Export` so the global instance
     // promotes them to VPNv4 advertisements toward PE peers.
     let network_count = materialize_self_originated_networks(&mut vrf, cfg);
@@ -386,7 +386,7 @@ fn materialize_self_originated_networks(vrf: &mut BgpVrf, cfg: &BgpVrfConfig) ->
             vrf_transit_only: false,
         };
 
-        let (_, selected, _) = vrf.local_rib.update(None, *prefix, rib);
+        let (_, selected, _) = vrf.shard.update(None, *prefix, rib);
         // Best-path runs as part of `update`. A freshly-inserted
         // self-originated row always wins (nothing else exists),
         // so `selected.first()` carries the winner; emit Export.


### PR DESCRIPTION
First slice of the RIB sharding plan's **B.1 state partition** (`docs/design/bgp-rib-sharding-plan.md` §6), following the D2/D3 rulings.

Per **D3**, the prefix-hashable Loc-RIB tables — v4/v6 unicast, v4/v6 labeled-unicast, VPNv4/v6 — move out of `LocalRib` into a new `BgpShard` struct (`bgp/shard.rs`), together with their 21 accessor methods, verbatim. EVPN, flowspec, SR-Policy, BGP-LS, and table-map stay main-owned in `LocalRib` (small tables; EVPN MAC routes don't hash by IP prefix).

Plumbing:
- `Bgp`, `BgpVrf`, and the `BgpTop` borrow-bundle each carry a `shard` field alongside `local_rib` (36 construction sites).
- `BgpShowView` gains a `shard()` accessor for the route-table shows.
- `flowspec_validate` / `flowspec_validate_with_mode` take `&BgpShard` — their RFC 9117 best-match check reads the unicast tables.

Pure re-homing, no behavior change; the compiler audits the partition. Adj-in re-keying (`ident -> AdjRib` slices off `Peer`) and the shard-side `BgpAttrStore` land as later B.1 slices.

## Test plan
- `cargo test --workspace --exclude bdd` — 1696 tests green, zero failures.
- `cargo clippy --workspace --all-targets -- -D warnings` clean (cache-busted re-run).
- No functional delta intended — A.1 flush goldens and all existing BGP tests pass unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)