### PR TITLE
isis: dedup v4/v6 — neighbor addr6, LSP origination, addr add/del

### DIFF
--- a/zebra-rs/src/isis/inst.rs
+++ b/zebra-rs/src/isis/inst.rs
@@ -2408,9 +2408,7 @@ impl Isis {
                 }
                 match key.remote {
                     std::net::IpAddr::V4(r) => nbr.addr4.contains_key(&r),
-                    std::net::IpAddr::V6(r) => {
-                        nbr.addr6l.contains(&r) || nbr.addr6.contains_key(&r)
-                    }
+                    std::net::IpAddr::V6(r) => nbr.addr6l.contains(&r) || nbr.addr6.contains(&r),
                 }
             });
             if let Some((sys_id, _)) = found {

--- a/zebra-rs/src/isis/link.rs
+++ b/zebra-rs/src/isis/link.rs
@@ -848,7 +848,19 @@ impl Isis {
     }
 
     pub fn addr_add(&mut self, addr: LinkAddr) {
-        // println!("ISIS: AddrAdd {} {}", addr.addr, addr.ifindex);
+        self.addr_update(addr, true);
+    }
+
+    pub fn addr_del(&mut self, addr: LinkAddr) {
+        self.addr_update(addr, false);
+    }
+
+    /// Shared body of `addr_add` / `addr_del`: route the prefix to
+    /// the link's per-family address list (v4 skipping loopbacks, v6
+    /// split into link-local vs global), apply the add/remove, and
+    /// re-originate the Hello so the interface-address TLVs track the
+    /// kernel.
+    fn addr_update(&mut self, addr: LinkAddr, add: bool) {
         let Some(link) = self.links.get_mut(&addr.ifindex) else {
             return;
         };
@@ -856,24 +868,16 @@ impl Isis {
         match addr.addr {
             IpNet::V4(prefix) => {
                 if !prefix.addr().is_loopback() {
-                    // Push only when prefix does not exist
-                    if !link.state.v4addr.contains(&prefix) {
-                        link.state.v4addr.push(prefix);
-                    }
+                    addr_list_update(&mut link.state.v4addr, prefix, add);
                 }
             }
             IpNet::V6(prefix) => {
-                if prefix.addr().is_unicast_link_local() {
-                    // Push only when prefix does not exist
-                    if !link.state.v6laddr.contains(&prefix) {
-                        link.state.v6laddr.push(prefix);
-                    }
+                let list = if prefix.addr().is_unicast_link_local() {
+                    &mut link.state.v6laddr
                 } else {
-                    // Push only when prefix does not exist
-                    if !link.state.v6addr.contains(&prefix) {
-                        link.state.v6addr.push(prefix);
-                    }
-                }
+                    &mut link.state.v6addr
+                };
+                addr_list_update(list, prefix, add);
             }
         }
 
@@ -882,31 +886,17 @@ impl Isis {
             let _ = self.tx.send(msg);
         }
     }
+}
 
-    pub fn addr_del(&mut self, addr: LinkAddr) {
-        let Some(link) = self.links.get_mut(&addr.ifindex) else {
-            return;
-        };
-
-        match addr.addr {
-            IpNet::V4(prefix) => {
-                if !prefix.addr().is_loopback() {
-                    link.state.v4addr.retain(|p| p != &prefix);
-                }
-            }
-            IpNet::V6(prefix) => {
-                if prefix.addr().is_unicast_link_local() {
-                    link.state.v6laddr.retain(|p| p != &prefix);
-                } else {
-                    link.state.v6addr.retain(|p| p != &prefix);
-                }
-            }
+/// Ensure `item` is present in (add) or absent from (remove) `list`
+/// — an order-preserving Vec used as a small set.
+fn addr_list_update<T: PartialEq>(list: &mut Vec<T>, item: T, add: bool) {
+    if add {
+        if !list.contains(&item) {
+            list.push(item);
         }
-
-        if link.config.enabled() {
-            let msg = Message::Ifsm(IfsmEvent::HelloOriginate, addr.ifindex, None);
-            let _ = self.tx.send(msg);
-        }
+    } else {
+        list.retain(|p| p != &item);
     }
 }
 

--- a/zebra-rs/src/isis/lsp.rs
+++ b/zebra-rs/src/isis/lsp.rs
@@ -2,12 +2,15 @@ use std::collections::BTreeMap;
 use std::net::Ipv4Addr;
 
 use bytes::BytesMut;
+use ipnet::{Ipv4Net, Ipv6Net};
 use isis_packet::neigh::{self, IsisSubAdjSid};
 use isis_packet::prefix::{self, Ipv4ControlInfo, Ipv6ControlInfo};
 use isis_packet::*;
 
 use crate::context::Timer;
-use crate::isis::config::{IsisRedistAfi, IsisRedistLevel, IsisRedistMetricType, IsisRedistSource};
+use crate::isis::config::{
+    IsisRedistAfi, IsisRedistLevel, IsisRedistMetricType, IsisRedistSource, IsisRedistribute,
+};
 use crate::isis_event_trace;
 use crate::rib::util::IpNetExt;
 use crate::rib::{DEFAULT_BLOCK_NAME, LocatorBehavior, MacAddr};
@@ -1106,18 +1109,12 @@ pub fn lsp_generate(top: &mut IsisTop, level: Level, seq_floor: Option<u32>) -> 
     // local connected prefixes above (`metric: 10` in the link loop),
     // so a `network` entry looks like an interface route in receivers'
     // RIBs rather than a zero-cost shortcut.
-    for prefix in top.config.networks_v4.iter() {
-        let flags = Ipv4ControlInfo::new()
-            .with_prefixlen(prefix.prefix_len() as usize)
-            .with_sub_tlv(false)
-            .with_distribution(false);
-        ext_ip_reach.entries.push(IsisTlvExtIpReachEntry {
-            metric: 10,
-            flags,
-            prefix: *prefix,
-            subs: vec![],
-        });
-    }
+    ext_ip_reach.entries.extend(
+        top.config
+            .networks_v4
+            .iter()
+            .map(|prefix| ext_ip_reach_entry(*prefix, 10)),
+    );
     // Redistributed IPv4 prefixes (`router isis / afi-safi ipv4 /
     // redistribute / <source>`). For each route delivered by RIB into
     // `top.redist_v4`, look up the per-(afi, source) override in
@@ -1126,28 +1123,14 @@ pub fn lsp_generate(top: &mut IsisTop, level: Level, seq_floor: Option<u32>) -> 
     // (rib-metric-as-* uses the RIB cost; internal/external set is
     // for the IPv6 X-bit / legacy TLV split — TLV 135 has no I/E bit
     // so the type only affects metric source for IPv4).
-    for ((rtype, prefix), route) in top.redist_v4.iter() {
-        let Some(source) = redist_source_from_rtype(*rtype) else {
-            continue;
-        };
-        let Some(cfg) = top.config.redistribute.get(&(IsisRedistAfi::Ipv4, source)) else {
-            continue;
-        };
-        if !redist_level_matches(cfg.level, level) {
-            continue;
-        }
-        let metric = redist_metric(cfg.metric, cfg.metric_type, route.metric);
-        let flags = Ipv4ControlInfo::new()
-            .with_prefixlen(prefix.prefix_len() as usize)
-            .with_sub_tlv(false)
-            .with_distribution(false);
-        ext_ip_reach.entries.push(IsisTlvExtIpReachEntry {
-            metric,
-            flags,
-            prefix: *prefix,
-            subs: vec![],
-        });
-    }
+    ext_ip_reach.entries.extend(collect_redist_entries(
+        top.redist_v4,
+        &top.config.redistribute,
+        IsisRedistAfi::Ipv4,
+        level,
+        |route| route.metric,
+        |prefix, metric, _| ext_ip_reach_entry(prefix, metric),
+    ));
     if !ext_ip_reach.entries.is_empty() {
         distributable.push(ext_ip_reach.into());
     }
@@ -1158,15 +1141,9 @@ pub fn lsp_generate(top: &mut IsisTop, level: Level, seq_floor: Option<u32>) -> 
         if link.config.enable.v6 && has_level(link.state.level(), level) {
             for v6addr in link.state.v6addr.iter() {
                 if !v6addr.addr().is_loopback() {
-                    let sub_tlv = false;
-                    let flags = Ipv6ControlInfo::new().with_sub_tlv(sub_tlv);
-                    let entry = IsisTlvIpv6ReachEntry {
-                        metric: 10,
-                        flags,
-                        prefix: *v6addr,
-                        subs: Vec::new(),
-                    };
-                    ipv6_reach.entries.push(entry);
+                    ipv6_reach
+                        .entries
+                        .push(ipv6_reach_entry(*v6addr, 10, false));
                 }
             }
         }
@@ -1180,50 +1157,30 @@ pub fn lsp_generate(top: &mut IsisTop, level: Level, seq_floor: Option<u32>) -> 
         && let Some(locator) = top.sr_locator.as_ref()
         && let Some(prefix) = locator.prefix
     {
-        let flags = Ipv6ControlInfo::new().with_sub_tlv(false);
-        ipv6_reach.entries.push(IsisTlvIpv6ReachEntry {
-            metric: 0,
-            flags,
-            prefix,
-            subs: Vec::new(),
-        });
+        ipv6_reach.entries.push(ipv6_reach_entry(prefix, 0, false));
     }
     // Operator-configured IPv6 `network` prefixes — sibling of the
     // IPv4 path above. Same metric-10 default for the same reason.
-    for prefix in top.config.networks_v6.iter() {
-        let flags = Ipv6ControlInfo::new().with_sub_tlv(false);
-        ipv6_reach.entries.push(IsisTlvIpv6ReachEntry {
-            metric: 10,
-            flags,
-            prefix: *prefix,
-            subs: Vec::new(),
-        });
-    }
+    ipv6_reach.entries.extend(
+        top.config
+            .networks_v6
+            .iter()
+            .map(|prefix| ipv6_reach_entry(*prefix, 10, false)),
+    );
     // Redistributed IPv6 prefixes — sibling of the IPv4 path above.
     // `metric-type external | rib-metric-as-external` sets the X bit
     // (RFC 5308 §2) so receivers can tell the prefix originated from
     // a different routing protocol.
-    for ((rtype, prefix), route) in top.redist_v6.iter() {
-        let Some(source) = redist_source_from_rtype(*rtype) else {
-            continue;
-        };
-        let Some(cfg) = top.config.redistribute.get(&(IsisRedistAfi::Ipv6, source)) else {
-            continue;
-        };
-        if !redist_level_matches(cfg.level, level) {
-            continue;
-        }
-        let metric = redist_metric(cfg.metric, cfg.metric_type, route.metric);
-        let flags = Ipv6ControlInfo::new()
-            .with_sub_tlv(false)
-            .with_dist_internal(redist_external_bit(cfg.metric_type));
-        ipv6_reach.entries.push(IsisTlvIpv6ReachEntry {
-            metric,
-            flags,
-            prefix: *prefix,
-            subs: Vec::new(),
-        });
-    }
+    ipv6_reach.entries.extend(collect_redist_entries(
+        top.redist_v6,
+        &top.config.redistribute,
+        IsisRedistAfi::Ipv6,
+        level,
+        |route| route.metric,
+        |prefix, metric, metric_type| {
+            ipv6_reach_entry(prefix, metric, redist_external_bit(metric_type))
+        },
+    ));
     if !ipv6_reach.entries.is_empty() {
         if top.config.mt_enabled && top.config.mt_topologies.contains(&MtId::Ipv6Unicast) {
             // MT 2 mode: same entries, MT-keyed TLV 237 instead of
@@ -1584,6 +1541,72 @@ fn redist_external_bit(metric_type: Option<IsisRedistMetricType>) -> bool {
         metric_type,
         Some(IsisRedistMetricType::External) | Some(IsisRedistMetricType::RibAsExternal)
     )
+}
+
+/// TLV 135 entry of the plain shape shared by `network` statements
+/// and redistributed prefixes: metric + prefix, no sub-TLVs. TLV 135
+/// has no I/E bit, so external-ness never shows on the wire for
+/// IPv4.
+fn ext_ip_reach_entry(prefix: Ipv4Net, metric: u32) -> IsisTlvExtIpReachEntry {
+    let flags = Ipv4ControlInfo::new()
+        .with_prefixlen(prefix.prefix_len() as usize)
+        .with_sub_tlv(false)
+        .with_distribution(false);
+    IsisTlvExtIpReachEntry {
+        metric,
+        flags,
+        prefix,
+        subs: vec![],
+    }
+}
+
+/// TLV 236 entry sibling of `ext_ip_reach_entry`. `external` sets
+/// the RFC 5308 §2 X bit so receivers can tell the prefix originated
+/// in another routing protocol; connected / `network` / locator
+/// entries pass false.
+fn ipv6_reach_entry(prefix: Ipv6Net, metric: u32, external: bool) -> IsisTlvIpv6ReachEntry {
+    let flags = Ipv6ControlInfo::new()
+        .with_sub_tlv(false)
+        .with_dist_internal(external);
+    IsisTlvIpv6ReachEntry {
+        metric,
+        flags,
+        prefix,
+        subs: Vec::new(),
+    }
+}
+
+/// Walk a per-family redistributed-route map and build one reach
+/// entry per route whose (afi, source) has redistribution configured
+/// at this generation level, resolving the metric from the
+/// per-source override / metric-type. `make` builds the family's
+/// entry from (prefix, resolved metric, configured metric-type).
+fn collect_redist_entries<P, R, E>(
+    redist: &BTreeMap<(crate::rib::RibType, P), R>,
+    redistribute: &BTreeMap<(IsisRedistAfi, IsisRedistSource), IsisRedistribute>,
+    afi: IsisRedistAfi,
+    level: Level,
+    rib_metric: impl Fn(&R) -> u32,
+    make: impl Fn(P, u32, Option<IsisRedistMetricType>) -> E,
+) -> Vec<E>
+where
+    P: Copy,
+{
+    let mut out = Vec::new();
+    for ((rtype, prefix), route) in redist.iter() {
+        let Some(source) = redist_source_from_rtype(*rtype) else {
+            continue;
+        };
+        let Some(cfg) = redistribute.get(&(afi, source)) else {
+            continue;
+        };
+        if !redist_level_matches(cfg.level, level) {
+            continue;
+        }
+        let metric = redist_metric(cfg.metric, cfg.metric_type, rib_metric(route));
+        out.push(make(*prefix, metric, cfg.metric_type));
+    }
+    out
 }
 
 #[cfg(test)]

--- a/zebra-rs/src/isis/lsp.rs
+++ b/zebra-rs/src/isis/lsp.rs
@@ -947,7 +947,7 @@ pub fn lsp_generate(top: &mut IsisTop, level: Level, seq_floor: Option<u32>) -> 
                     .nbrs
                     .get(&level)
                     .values()
-                    .flat_map(|nbr| nbr.addr6.keys().copied())
+                    .flat_map(|nbr| nbr.addr6.iter().copied())
                     .next();
                 if let (Some(local_v6), Some(remote_v6)) = (local_v6, remote_v6) {
                     for chunk in values.chunks(IsisTlvIpv6Srlg::MAX_VALUES_PER_TLV) {

--- a/zebra-rs/src/isis/neigh.rs
+++ b/zebra-rs/src/isis/neigh.rs
@@ -1,4 +1,4 @@
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet};
 use std::fmt::Write;
 use std::net::{Ipv4Addr, Ipv6Addr};
 
@@ -17,7 +17,7 @@ use crate::rib::{Locator, Sid, SidAllocationType, SidBehavior, SidContext, SidOw
 use super::adj::AdjGrState;
 use super::link::NetworkType;
 use super::nfsm::NfsmState;
-use super::{Isis, Level, Message, NeighborAddr4, NeighborAddr6};
+use super::{Isis, Level, Message, NeighborAddr4};
 
 // IS-IS Neighbor
 #[derive(Debug)]
@@ -38,7 +38,7 @@ pub struct Neighbor {
     pub proto: Option<IsisTlvProtoSupported>,
     // Addrs
     pub addr4: BTreeMap<Ipv4Addr, NeighborAddr4>,
-    pub addr6: BTreeMap<Ipv6Addr, NeighborAddr6>,
+    pub addr6: BTreeSet<Ipv6Addr>,
     pub addr6l: Vec<Ipv6Addr>,
     pub mac: Option<MacAddr>,
     //
@@ -93,7 +93,7 @@ impl Neighbor {
             ifindex,
             state: NfsmState::Down,
             addr4: BTreeMap::new(),
-            addr6: BTreeMap::new(),
+            addr6: BTreeSet::new(),
             addr6l: Vec::new(),
             mac,
             proto: None,
@@ -151,8 +151,7 @@ impl Neighbor {
     /// resolves via the connected prefix to the correct egress link.
     fn endx_nh6(&self) -> Option<Ipv6Addr> {
         self.addr6
-            .keys()
-            .next()
+            .first()
             .copied()
             .or_else(|| self.addr6l.first().copied())
     }
@@ -523,8 +522,8 @@ fn show_entry(buf: &mut String, top: &Isis, nbr: &Neighbor, level: Level) -> std
     if !nbr.addr6.is_empty() {
         writeln!(buf, "    IPv6 Prefixes")?;
     }
-    for value in nbr.addr6.values() {
-        writeln!(buf, "      {}", value.addr)?;
+    for addr in nbr.addr6.iter() {
+        writeln!(buf, "      {}", addr)?;
     }
 
     writeln!(buf)?;
@@ -560,10 +559,10 @@ fn neighbor_to_detail(top: &Isis, nbr: &Neighbor, level: Level) -> NeighborDetai
     let ipv6_link_locals = nbr.addr6l.iter().map(|addr| addr.to_string()).collect();
     let ipv6_prefixes = nbr
         .addr6
-        .values()
-        .map(|value| IpPrefix {
-            address: value.addr.to_string(),
-            label: value.label,
+        .iter()
+        .map(|addr| IpPrefix {
+            address: addr.to_string(),
+            label: None,
         })
         .collect();
 
@@ -689,7 +688,7 @@ mod tests {
         assert_eq!(nbr.endx_nh6(), Some(ll));
 
         // Global learned later → preferred over the link-local.
-        nbr.addr6.insert(global, NeighborAddr6::new(global));
+        nbr.addr6.insert(global);
         assert_eq!(nbr.endx_nh6(), Some(global));
     }
 }

--- a/zebra-rs/src/isis/packet.rs
+++ b/zebra-rs/src/isis/packet.rs
@@ -1,5 +1,5 @@
 use std::cmp::Ordering;
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet};
 use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
 
 use anyhow::Error;
@@ -175,18 +175,6 @@ impl NeighborAddr4 {
     }
 }
 
-#[derive(Debug)]
-pub struct NeighborAddr6 {
-    pub addr: Ipv6Addr,
-    pub label: Option<u32>,
-}
-
-impl NeighborAddr6 {
-    pub fn new(addr: Ipv6Addr) -> Self {
-        Self { addr, label: None }
-    }
-}
-
 pub fn nbr_hello_interpret(
     nbr: &mut Neighbor,
     tlvs: &[IsisTlv],
@@ -200,7 +188,7 @@ pub fn nbr_hello_interpret(
     let mut helper_edge = HelperEdge::None;
 
     let mut addr4 = BTreeMap::new();
-    let mut addr6 = BTreeMap::new();
+    let mut addr6 = BTreeSet::new();
     let mut laddr6 = vec![];
 
     for tlv in tlvs.iter() {
@@ -220,7 +208,7 @@ pub fn nbr_hello_interpret(
                 addr4.insert(ifaddr.addr, NeighborAddr4::new(ifaddr.addr, None));
             }
             IsisTlv::Ipv6GlobalIfAddr(ifaddr) => {
-                addr6.insert(ifaddr.addr, NeighborAddr6::new(ifaddr.addr));
+                addr6.insert(ifaddr.addr);
             }
             IsisTlv::Ipv6IfAddr(ifaddr) => laddr6.push(ifaddr.addr),
             IsisTlv::ProtoSupported(tlv) => {
@@ -271,23 +259,9 @@ pub fn nbr_hello_interpret(
             e.insert(NeighborAddr4::new(key, label));
         }
     }
-    nbr.addr6.retain(|key, value| {
-        let keep = addr6.contains_key(key);
-        if !keep {
-            // Release the label before removing
-            if let Some(label) = value.label
-                && let Some(local_pool) = local_pool
-            {
-                local_pool.release(label as usize);
-            }
-        }
-        keep
-    });
-    for (&key, _) in addr6.iter() {
-        nbr.addr6
-            .entry(key)
-            .or_insert_with(|| NeighborAddr6::new(key));
-    }
+    // v6 globals carry no per-address state (no SR label is allocated
+    // for them), so the reconcile is a plain replace.
+    nbr.addr6 = addr6;
 
     nbr.addr6l = laddr6;
 


### PR DESCRIPTION
Third slice of the IS-IS v4/v6 dedup pass (follows #1417, #1419): items #6, #7, #8 from the duplication scan, one commit each.

## Changes

1. **packet.rs / neigh.rs** — `NeighborAddr6.label` was only ever constructed as `None`: the v4-style release-on-retain in `nbr_hello_interpret` was dead code, and nothing allocates SR labels for a neighbor's v6 globals. Dropped the field, which left a one-field wrapper around its own map key — so `addr6` is now `BTreeSet<Ipv6Addr>` and the struct is deleted. The hello reconcile becomes a plain replace. The v6 neighbor-detail JSON keeps emitting `label: null` as before.
2. **lsp.rs** — the `network`-statement and redistribute loops in `lsp_generate` were near-identical per family. Added `ext_ip_reach_entry` / `ipv6_reach_entry` builders (the latter carrying the RFC 5308 X bit) plus a `collect_redist_entries` generic owning the source/level/metric resolution. The v6 connected/locator blocks now use the builder too; the v4 connected loop stays separate (it interleaves Prefix-SID / flex-algo sub-TLVs).
3. **link.rs** — `addr_add`/`addr_del` shared the link lookup, v4-loopback gate, v6 link-local/global split, and HelloOriginate tail, differing only in push-vs-retain. Merged into `addr_update` with an `addr_list_update` helper.

No behavior change intended: TLV contents/order, show output, and JSON shapes are unchanged.

## Testing

- `cargo fmt --check`, `cargo clippy --workspace --all-targets -- -D warnings` clean
- `cargo test --workspace --exclude bdd` — all green (re-run after rebasing onto current main)

🤖 Generated with [Claude Code](https://claude.com/claude-code)