### PR TITLE
bdd: add missing Teardown scenario to bgp_evpn_capability

### DIFF
--- a/bdd/docs/bgp_evpn_capability.md
+++ b/bdd/docs/bgp_evpn_capability.md
@@ -44,3 +44,4 @@ Both peers enable two AFI/SAFIs:
 |----------|--------|
 | Setup topology and establish iBGP session with EVPN capability | |
 | L2VPN/EVPN capability is advertised and received on both sides | |
+| Teardown topology | |

--- a/bdd/tests/features/bgp_evpn_capability.feature
+++ b/bdd/tests/features/bgp_evpn_capability.feature
@@ -51,3 +51,12 @@ Feature: BGP L2VPN/EVPN capability negotiation
     Given the test topology exists
     Then show command "show bgp neighbors 192.168.0.2" in namespace "z1" should contain "L2VPN EVPN: advertised and received"
     And show command "show bgp neighbors 192.168.0.1" in namespace "z2" should contain "L2VPN EVPN: advertised and received"
+
+  Scenario: Teardown topology
+    Given the test topology exists
+    When I stop zebra-rs in namespace "z1"
+    And I stop zebra-rs in namespace "z2"
+    And I delete namespace "z1"
+    And I delete namespace "z2"
+    And I delete bridge "br0"
+    Then the test environment should be clean


### PR DESCRIPTION
## Summary

`bgp_evpn_capability.feature` was the only BGP feature without an explicit `Scenario: Teardown topology` — it relied on the next run's `Given a clean test environment` sweep, leaking two root zebra-rs daemons, the z1/z2 namespaces, and br0 between features in a single run. One of those leaked daemons held `/usr/bin/zebra-rs` open and broke binary installs with `Text file busy` during the peer-list series work.

Mirrors the `bgp_basic_ibgp` teardown shape: stop both daemons, delete both namespaces, delete the bridge, assert `the test environment should be clean`. `bdd/docs/bgp_evpn_capability.md` regenerated via `make docs`.

## Testing

- BDD: `@bgp_evpn_capability` — 3 scenarios (setup, capability assertion, teardown) all passed; verified zero leftover daemons/namespaces/bridge on the host afterward.

🤖 Generated with [Claude Code](https://claude.com/claude-code)