### PR TITLE
STAMP (RFC 8762) Phase 1: link-delay measurement feeding IGP TE metrics

### DIFF
--- a/bdd/Makefile
+++ b/bdd/Makefile
@@ -170,6 +170,10 @@ ospfv3_tilfa:
 	mkdir -p allure-results
 	cargo test --test cucumber -- --concurrency=1 --tags "@ospfv3_tilfa"
 
+stamp_te_metric:
+	mkdir -p allure-results
+	cargo test --test cucumber -- --concurrency=1 --tags "@stamp_te_metric"
+
 bgp_evpn_capability:
 	mkdir -p allure-results
 	cargo test --test cucumber -- --concurrency=1 --tags "@bgp_evpn_capability"
@@ -257,4 +261,4 @@ docs/%.md: tests/features/%.feature docs/feature2md.sh FORCE
 
 FORCE:
 
-.PHONY: ecmp_bfd_evict ospfv2_bfd_frr ospfv3_bfd_frr tilfa_bfd all run ibgp ebgp rr rib_static_ipv6 isis_ipv6 isis_srv6 isis_fragmentation_ipv6 isis_fragmentation_ipv4 isis_l1p2p isis_tilfa isis_l1l2 isis_redist isis_hello_auth_keychain isis_passive isis_afi_enable isis_endx_ipv6 isis_bfd_ipv6_p2p isis_bfd_ipv6_p2p_echo isis_bfd_ipv6_lan isis_bfd_ipv6_lan_echo isis_bfd_ipv4_p2p isis_bfd_ipv4_p2p_echo isis_bfd_ipv4_lan isis_bfd_ipv4_lan_echo ospf_clear_neighbor ospfv2_nssa ospfv2_stub ospfv2_tilfa ospfv3_nssa ospfv3_tilfa bgp_peer_down_cleanup bgp_ipv6_over_v4_session bgp_evpn_capability bgp_vrf_evpn_type5 bgp_route_map_match bgp_policy_dynamic_update bgp_table_map bgp_v6_table_map bgp_community bgp_neighbor_group bgp_unnumbered_neighbor nd_show bgp_interas_option_c bgp_interas_option_a bgp_interas_option_b bgp_interas_option_ab bgp_port bgp_ip_transparent bgp_local_as generate open docs FORCE
+.PHONY: ecmp_bfd_evict ospfv2_bfd_frr ospfv3_bfd_frr tilfa_bfd all run ibgp ebgp rr rib_static_ipv6 isis_ipv6 isis_srv6 isis_fragmentation_ipv6 isis_fragmentation_ipv4 isis_l1p2p isis_tilfa isis_l1l2 isis_redist isis_hello_auth_keychain isis_passive isis_afi_enable isis_endx_ipv6 isis_bfd_ipv6_p2p isis_bfd_ipv6_p2p_echo isis_bfd_ipv6_lan isis_bfd_ipv6_lan_echo isis_bfd_ipv4_p2p isis_bfd_ipv4_p2p_echo isis_bfd_ipv4_lan isis_bfd_ipv4_lan_echo ospf_clear_neighbor ospfv2_nssa ospfv2_stub ospfv2_tilfa ospfv3_nssa ospfv3_tilfa stamp_te_metric bgp_peer_down_cleanup bgp_ipv6_over_v4_session bgp_evpn_capability bgp_vrf_evpn_type5 bgp_route_map_match bgp_policy_dynamic_update bgp_table_map bgp_v6_table_map bgp_community bgp_neighbor_group bgp_unnumbered_neighbor nd_show bgp_interas_option_c bgp_interas_option_a bgp_interas_option_b bgp_interas_option_ab bgp_port bgp_ip_transparent bgp_local_as generate open docs FORCE

--- a/bdd/docs/stamp_te_metric.md
+++ b/bdd/docs/stamp_te_metric.md
@@ -1,0 +1,31 @@
+# STAMP link-delay measurement feeding IGP TE metrics
+
+## Overview
+
+As a network operator running delay-based traffic engineering, I want
+each P2P link's delay measured actively (STAMP, RFC 8762) and the
+damped min/max/avg values advertised by the IGPs — IS-IS RFC 8570 and
+OSPFv2 RFC 7471 link-delay sub-TLVs — without configuring static
+te-metric values per link.
+Two zebra-rs instances share one P2P link. Both run IS-IS and OSPFv2
+on it with `te-metric measurement` enabled (probe interval 100 ms,
+damping period 2 s — lab values; defaults are 1 s / 30 s). Each
+daemon's STAMP Session-Sender probes its neighbor's implicit
+Session-Reflector; both IGPs share the one measurement session per
+link (multi-client). After the first damping period the measured
+values appear as "Min/Max Unidirectional Link Delay" in both LSDBs
+(the OSPF Extended-Link Opaque LSA is gated on segment-routing mpls).
+Topology:
+
+## Config Files
+
+
+## Test Scenarios
+
+| Scenario | Result |
+|----------|--------|
+| Build the measured topology | |
+| STAMP sessions form and measure the link | |
+| IS-IS advertises the measured link delay | |
+| OSPFv2 advertises the measured link delay | |
+| Teardown topology | |

--- a/bdd/tests/configs/stamp_te_metric/st1.yaml
+++ b/bdd/tests/configs/stamp_te_metric/st1.yaml
@@ -1,0 +1,43 @@
+interface:
+- if-name: lo
+  ipv4:
+    address: 10.61.0.1/32
+- if-name: st1-st2
+  ipv4:
+    address: 192.168.61.1/30
+
+router:
+  isis:
+    net: 49.0061.0000.0000.0001.00
+    hostname: st1
+    is-type: level-2-only
+    interface:
+    - if-name: lo
+      ipv4:
+        enable: true
+    - if-name: st1-st2
+      network-type: point-to-point
+      ipv4:
+        enable: true
+      te-metric:
+        measurement:
+          enable: true
+          interval: 100
+          damping-period: 2
+  ospf:
+    router-id: 10.61.0.1
+    segment-routing:
+      mpls: {}
+    area:
+    - area-id: 0.0.0.0
+      interface:
+      - if-name: lo
+        enable: true
+      - if-name: st1-st2
+        enable: true
+        network-type: point-to-point
+        te-metric:
+          measurement:
+            enable: true
+            interval: 100
+            damping-period: 2

--- a/bdd/tests/configs/stamp_te_metric/st2.yaml
+++ b/bdd/tests/configs/stamp_te_metric/st2.yaml
@@ -1,0 +1,43 @@
+interface:
+- if-name: lo
+  ipv4:
+    address: 10.61.0.2/32
+- if-name: st2-st1
+  ipv4:
+    address: 192.168.61.2/30
+
+router:
+  isis:
+    net: 49.0061.0000.0000.0002.00
+    hostname: st2
+    is-type: level-2-only
+    interface:
+    - if-name: lo
+      ipv4:
+        enable: true
+    - if-name: st2-st1
+      network-type: point-to-point
+      ipv4:
+        enable: true
+      te-metric:
+        measurement:
+          enable: true
+          interval: 100
+          damping-period: 2
+  ospf:
+    router-id: 10.61.0.2
+    segment-routing:
+      mpls: {}
+    area:
+    - area-id: 0.0.0.0
+      interface:
+      - if-name: lo
+        enable: true
+      - if-name: st2-st1
+        enable: true
+        network-type: point-to-point
+        te-metric:
+          measurement:
+            enable: true
+            interval: 100
+            damping-period: 2

--- a/bdd/tests/cucumber.rs
+++ b/bdd/tests/cucumber.rs
@@ -954,6 +954,47 @@ async fn show_command_eventually_not_contains(
     );
 }
 
+/// Positive polling sibling of `show_command_eventually_not_contains`:
+/// assert the `vtyctl show` output comes to contain the substring within
+/// the attempt budget. Used when the value arrives asynchronously after
+/// convergence — e.g. a STAMP-measured te-metric needs a full damping
+/// period of probes before the sub-TLVs appear in the LSDB.
+#[then(expr = "show command {string} in namespace {string} should eventually contain {string}")]
+async fn show_command_eventually_contains(
+    world: &mut World,
+    show_cmd: String,
+    namespace: String,
+    needle: String,
+) {
+    let scoped = world.ns(&namespace);
+    const ATTEMPTS: u32 = 60;
+    let mut found = false;
+    let mut last_output = String::new();
+    for i in 0..ATTEMPTS {
+        last_output = netns::exec_in_netns(&scoped, "vtyctl", &["show", &show_cmd])
+            .await
+            .expect("Failed to run show command");
+        if last_output.contains(&needle) {
+            found = true;
+            break;
+        }
+        if i + 1 < ATTEMPTS {
+            tokio::time::sleep(tokio::time::Duration::from_secs(1)).await;
+        }
+    }
+    if !found {
+        let diag = route_failure_diagnostics(&scoped).await;
+        panic!(
+            "show '{}' in namespace {} did not contain '{}' after {} attempts\nlast output:\n{}\n{}",
+            show_cmd, scoped, needle, ATTEMPTS, last_output, diag
+        );
+    }
+    println!(
+        "✓ show '{}' in namespace {} eventually contains '{}'",
+        show_cmd, scoped, needle
+    );
+}
+
 #[then(expr = "show command {string} in namespace {string} should not contain {string}")]
 async fn show_command_not_contains(
     world: &mut World,

--- a/bdd/tests/features/stamp_te_metric.feature
+++ b/bdd/tests/features/stamp_te_metric.feature
@@ -1,0 +1,70 @@
+@stamp_te_metric
+Feature: STAMP link-delay measurement feeding IGP TE metrics
+  As a network operator running delay-based traffic engineering, I want
+  each P2P link's delay measured actively (STAMP, RFC 8762) and the
+  damped min/max/avg values advertised by the IGPs — IS-IS RFC 8570 and
+  OSPFv2 RFC 7471 link-delay sub-TLVs — without configuring static
+  te-metric values per link.
+
+  Two zebra-rs instances share one P2P link. Both run IS-IS and OSPFv2
+  on it with `te-metric measurement` enabled (probe interval 100 ms,
+  damping period 2 s — lab values; defaults are 1 s / 30 s). Each
+  daemon's STAMP Session-Sender probes its neighbor's implicit
+  Session-Reflector; both IGPs share the one measurement session per
+  link (multi-client). After the first damping period the measured
+  values appear as "Min/Max Unidirectional Link Delay" in both LSDBs
+  (the OSPF Extended-Link Opaque LSA is gated on segment-routing mpls).
+
+  Topology:
+
+    st1 (10.61.0.1)                      st2 (10.61.0.2)
+      st1-st2  192.168.61.1/30 ---- 192.168.61.2/30  st2-st1
+
+  Config files: st1.yaml  st2.yaml
+
+  Scenario: Build the measured topology
+    Given a clean test environment
+    When I create namespace "st1"
+    And I create namespace "st2"
+    And I connect namespace "st1" interface "st1-st2" to namespace "st2" interface "st2-st1"
+    And I start zebra-rs in namespace "st1"
+    And I start zebra-rs in namespace "st2"
+    And I apply config "st1.yaml" to namespace "st1"
+    And I apply config "st2.yaml" to namespace "st2"
+    And I wait 10 seconds
+    Then ping from "st1" to "192.168.61.2" should succeed
+
+  Scenario: STAMP sessions form and measure the link
+    Given the test topology exists
+    # One shared session per direction, keyed by the link addresses.
+    Then show command "show stamp" in namespace "st1" should eventually contain "192.168.61.2"
+    And show command "show stamp" in namespace "st2" should eventually contain "192.168.61.1"
+    # Replies are coming back (sender state goes Active), so the
+    # implicit reflector on the peer is answering.
+    And show command "show stamp" in namespace "st1" should eventually contain "Active"
+    And show command "show stamp session" in namespace "st1" should eventually contain "Min delay"
+
+  Scenario: IS-IS advertises the measured link delay
+    Given the test topology exists
+    # RFC 8570 sub-TLV 34 rendered from the self-originated LSP — only
+    # present once a measured export landed (no static te-metric is
+    # configured anywhere in this feature).
+    Then show command "show isis database detail" in namespace "st1" should eventually contain "Min/Max Unidirectional Link Delay"
+    And show command "show isis database detail" in namespace "st2" should eventually contain "Min/Max Unidirectional Link Delay"
+
+  Scenario: OSPFv2 advertises the measured link delay
+    Given the test topology exists
+    # RFC 7471 sub-TLV 28 inside the Extended-Link Opaque LSA's ASLA.
+    Then show command "show ospf database detail" in namespace "st1" should eventually contain "Min/Max Unidirectional Link Delay"
+    And show command "show ospf database detail" in namespace "st2" should eventually contain "Min/Max Unidirectional Link Delay"
+
+  # Pure P2P topology (no bridge): deleting each namespace destroys the
+  # veth pair ends it holds, so only the daemons and namespaces need
+  # teardown.
+  Scenario: Teardown topology
+    Given the test topology exists
+    When I stop zebra-rs in namespace "st1"
+    And I stop zebra-rs in namespace "st2"
+    And I delete namespace "st1"
+    And I delete namespace "st2"
+    Then the test environment should be clean

--- a/docs/design/bfd-sbfd-stamp-xdp-offload-notes.md
+++ b/docs/design/bfd-sbfd-stamp-xdp-offload-notes.md
@@ -333,6 +333,179 @@ Two senses:
 
 ---
 
+## 9b. [2026-06-12] STAMP link TE-metric measurement — applicability review against the as-built helper
+
+§9 was written with **liveness** as the lens. The Phase-1 plan
+([stamp-phase1-implementation-plan.md](./stamp-phase1-implementation-plan.md)) uses STAMP for
+**link delay numbers advertised into the IGP** (RFC 8570/7471 → Flex-Algo metric-type 1), which
+changes what offload is *for*: not detection latency, but **measurement error**. This section
+quantifies that, maps the work onto the as-built `xdp-bfd-echo` infrastructure (§2/§2b), and
+fixes the staging.
+
+### 9b.1 Error budget — what userspace timestamps actually cost
+
+Define the four stack residues around the RFC 8762 timestamps:
+`a` = sender T1-stamp → frame on wire, `b` = wire → reflector T2-stamp,
+`c` = reflector T3-stamp → wire, `d` = wire → sender T4-stamp. Expanding the Phase-1 D1 math:
+
+```
+delay_est = [(T4−T1) − (T3−T2)] / 2  =  (fwd_wire + rev_wire)/2  +  (a+b+c+d)/2
+```
+
+The `(T3−T2)` subtraction removes only the *measured* reflector residence; the four boundary
+residues survive, halved. In a tokio daemon each RX boundary (`b`, `d`) is a
+softirq→socket-queue→epoll-wake→task-poll chain — order 10–50 µs idle, **ms-class tails under
+load**; TX boundaries (`a`, `c`) are a few µs plus qdisc. Consequences for the exported fields:
+
+- **min-delay** (the Flex-Algo edge cost) is naturally robust: the window minimum picks the
+  luckiest probe, so its error converges to the *floor* of `(a+b+c+d)/2` — tens of µs.
+- **max-delay and delay-variation absorb the scheduling tails.** On links faster than ~1 ms,
+  those two fields measure daemon scheduling, not the network.
+
+So: pure-userspace Phase 1 is honest for **WAN/metro ms-class delay TE** (the primary
+Flex-Algo use case) and progressively dishonest toward **µs-class fabric** discrimination —
+which is exactly the regime where offload pays.
+
+One important cancellation: for RTT-mode senders (zebra-rs), the reflector's **absolute clock
+offset cancels** out of the math — only its *rate* matters across a µs residence. Absolute
+T2/T3 accuracy matters only to external **one-way-delay** consumers with synced clocks
+(Cisco IPM style). An offloaded reflector should therefore still publish wall-clock NTP time
+(recipe below), but its quality only affects third-party senders, not our own measurements.
+
+### 9b.2 Reflector offload (helps the *peer's* numbers) — direct §2 descendant
+
+The Phase-1 implicit reflector is a pure packet transformation; the XDP version removes `b`
+and `c` from the peer's budget (T2 at driver RX — or HW RX time via
+`bpf_xdp_metadata_rx_timestamp`, kernel 6.3+, mlx5/ice-class drivers; T3 written immediately
+before `XDP_TX`, residual = driver TX only):
+
+- **Match**: IPv4/UDP dst 862 → `(local, remote)` allow-list map (interface-scoped — the
+  helper attaches per ifindex, same as Echo). In-kernel allow-list is also the anti-abuse
+  gate: reflection is 1:1 in size (RFC 6038, no amplification) but still an unsolicited-reply
+  primitive — exact-pair match, optional per-entry token bucket.
+- **Rewrite in place, no length change**: sender and reflector base packets are both 44
+  octets (`stamp-packet::BASE_LEN`); the reflector fields overwrite the sender MBZ
+  ([16..44]) — §9's "no `bpf_xdp_adjust_tail`" observation, now confirmed against our codec.
+  Swap MAC/IP/ports (pseudo-header-sum-invariant), fill T2/T3 + reflector error estimate,
+  `sender_ttl` ← received TTL, reply TTL ← 255 (incremental IP-csum fix, same RFC 1141
+  machinery the Echo reflector ships). UDP checksum: incremental update over the 28 rewritten
+  payload bytes (`bpf_csum_diff` + fold); v4-only escape hatch = checksum 0 (legal per
+  RFC 768, but some receivers are strict — prefer incremental).
+- **Hybrid fallthrough resolves §9's "TLVs fight the verifier"**: don't fight — any probe
+  that isn't base-44 unauthenticated (TLV'd, authenticated, encapsulated) gets `XDP_PASS`
+  and lands on the userspace 862 socket, which handles it correctly (incl. RFC 6038 symmetric
+  padding). XDP owns the hot common case only. This also makes helper death a non-event:
+  no program attached ⇒ probes reach userspace ⇒ reflection continues (a *better* fallback
+  story than BFD Echo, where a dead helper falsifies an advertised promise).
+- **Wall clock in BPF**: there is no CLOCK_REALTIME helper. Recipe: userspace publishes
+  `realtime − monotonic` (ns) into an array map at ~1 Hz; program computes
+  `real = bpf_ktime_get_ns() + offset`, then NTP sec = `real/10⁹ + 2 208 988 800`,
+  frac = `(real % 10⁹) · 2³² / 10⁹` (fits u64). Staleness between refreshes is rate-bounded:
+  sub-µs/s on a disciplined steady-state clock, large only during aggressive slews
+  (chrony `maxslewrate`) — and immune for RTT-mode peers per §9b.1. Kernel ≥ 6.1 alternatively
+  offers `bpf_ktime_get_tai_ns` (CLOCK_TAI, no leap smearing) with a userspace-published TAI
+  offset. Set the reflected Error Estimate (S/scale/multiplier) honestly from this quality.
+- **Stateful mode** (Phase-4 directional loss): reflector seq = one atomic counter per
+  allow-list entry. Trivial in a map.
+
+### 9b.3 Sender-side: the accuracy ladder — eBPF is rung 3, not rung 1
+
+Before XDP, two plain-socket rungs remove most of `a`/`d` with no helper at all:
+
+| Rung | Mechanism | Removes | Cost |
+|---|---|---|---|
+| 0 | Phase 1 as planned (userspace stamps; min-statistics filter) | — | — |
+| 1 | `SO_TIMESTAMPING` RX software (`SCM_TIMESTAMPING` cmsg on the sender's connected socket) → kernel-stamped T4 | scheduling part of `d` | ~tens of lines, no eBPF — **recommended first follow-up after Phase 1** |
+| 2 | `SO_TIMESTAMPING` TX software + `MSG_ERRQUEUE` (`OPT_ID` keyed by seq) → corrected T1′ used in *our* math (in-packet T1 still goes out for the reflector copy) | most of `a` | moderate (errqueue plumbing, late pairing) |
+| 3 | **XDP sender-RX fastpath** (the detect-offload analog): per-session map `{count, sum, min, max, last, jitter_accum}`; program computes the full D1 math from packet fields + the offset map, `XDP_DROP`s the frame; userspace export tick reads-and-resets via a helper command | all of `d` + per-packet wakeups (scale) | helper extension; session flips to "kernel-fed" (DROP ⇒ userspace must *not* also count; on `HelperGone` revert to socket path) |
+| 4 | HW RX timestamps via metadata kfunc; PHC↔realtime mapping | driver/IRQ jitter | real NICs only — not veth/BDD (§9 environment note stands) |
+
+**Probe origination stays in userspace permanently**: XDP is RX-triggered, `bpf_timer`
+cannot emit packets, and origination accuracy is already fixed by rung 2 (interval jitter
+does not bias per-sample delay). Same conclusion as §1/§2 for BFD TX. AF_XDP's niche
+narrows accordingly: rungs 1–4 cover precision; AF_XDP remains relevant only for
+feature-rich fast paths (TLV processing, SRv6 reverse-encap) — a refinement of §9's
+"pragmatic answer".
+
+**`bpf_timer` detection has no analog in the TE-metric role** (loss is window-counted, not
+liveness). It *returns* in SR-Policy PM liveness (draft-ietf-spring-stamp-srpm: N missing
+replies ⇒ invalidate path) — that is a straight reuse of the §2b `DetectState` recipe.
+
+### 9b.4 Integration with the as-built helper — one architectural constraint
+
+**Only one XDP program attaches per interface** (absent an xdp-dispatcher), and
+`xdp-bfd-echo` already owns the hook wherever BFD Echo / detect-offload runs. Therefore
+STAMP matching cannot ship as a second loader binary on shared interfaces — it must join the
+**same program object**, and the per-ifindex child becomes shared infrastructure:
+
+- Extend `offload/xdp-bfd-echo/` with the STAMP branch (port 862 reflect + sense maps),
+  feature-gated by map contents exactly like echo/detect today. Command-line protocol grows
+  verbs: `stamp-reflect-add|del <local> <remote> [port]`, `stamp-sense-add|del …`,
+  plus a stats-readout line for `show stamp statistics` truthfulness when offloaded.
+- **Prerequisite refactor**: `EchoReflectors` (`bfd/reflector.rs`) is `Bfd`-private; two
+  supervisors would double-spawn the child and the second XDP attach fails. Promote it to a
+  shared offload supervisor (refcounts per ifindex across BFD + STAMP clients, one stdin/stdout
+  IPC task) before STAMP offload lands. The acquire/release/ready-gate/`HelperGone` semantics
+  carry over unchanged.
+- Inherited gotchas: veth needs `-m skb` (BDD), stale aya build cache, SIGTERM-detach,
+  `ZEBRA_XDP_BFD_ECHO_BIN`-style env override.
+
+### 9b.5 Staging verdict
+
+1. **Phase 1 (now)**: pure userspace — correct, interoperable, testable; honest for ms-class
+   links. Keep it offload-ready structurally (pure `build_reply` as the executable spec for
+   the future BPF program, allow-list as plain data, single T1/T4 capture points, one
+   `record_delay` entry into stats, per-session reflector counters) — encoded as §7 of the
+   Phase-1 plan.
+2. **Phase 1.5**: rung 1 (RX `SO_TIMESTAMPING`), optionally rung 2. No eBPF, biggest
+   accuracy-per-effort.
+3. **Offload stage A** (with/after the Phase-2 configured reflector): XDP base-44 reflector +
+   PASS-fallthrough, behind the shared-supervisor refactor.
+4. **Offload stage B**: sender-RX aggregate fastpath (rung 3) when session counts/rates or
+   tail-taming demand it.
+5. **Offload stage C**: HW timestamps (rung 4) on capable NICs; AF_XDP only if TLV/SRv6-encap
+   fast paths materialize (parent plan Phase 3+).
+
+### 9b.6 The pro case for eBPF integration, distilled
+
+Q&A distillation of §9b.1–9b.5: *what does putting part of STAMP into eBPF actually buy?*
+The advantages are real but regime-specific.
+
+1. **Measurement fidelity where it's currently impossible.** The error term `(a+b+c+d)/2` —
+   the four userspace stamp-to-wire residues — drops from "tens of µs with ms-class tails" to
+   roughly µs-level (generic XDP) or sub-µs (native XDP + HW timestamps). This specifically
+   rescues **max-delay and delay-variation**, which on fast links otherwise measure tokio
+   scheduling rather than the network. It is what makes Flex-Algo delay routing *meaningful*
+   on µs-class fabrics (DC/metro), where real path-delay differences are smaller than the
+   userspace noise floor. On the reflector side, stamping T2/T3 at the driver boundary makes
+   the residence-time subtraction nearly exact — a cooperative win: both ends offload, both
+   ends' advertised numbers tighten.
+2. **Honesty under control-plane load.** Without offload, the advertised delay/jitter spikes
+   exactly when the router is busy (BGP churn, SPF storms) — fabricated TE signals that can
+   flap delay-routed paths network-wide. Damping cannot tell "real network jitter" from "my
+   own scheduling jitter"; eBPF removes the latter at the source. Same rationale as BFD
+   detect-offload: timing immune to daemon scheduling.
+3. **Scale.** With the sender-RX fastpath, per-probe work leaves userspace entirely — no
+   wakeup per packet; userspace reads one aggregate per session per export period (~30 s)
+   instead of processing every probe. Reflection via `XDP_TX` never allocates an skb or
+   enters the IP stack. Hundreds of links × 10–100 Hz probing becomes a non-event.
+4. **Robustness / security.** The in-kernel allow-list drops unsolicited probes before the
+   stack ever sees them, with optional per-source rate limiting in a map — the reflector
+   cannot be used to load the daemon. Degradation is clean: helper dies → probes fall through
+   to the userspace 862 socket → reflection continues.
+5. **Low marginal cost in this codebase.** Per-ifindex helper supervision, the aya toolchain,
+   the IPC protocol, and the interop lessons are already production-validated from the BFD
+   Echo/detect work (§2/§2b). STAMP joins the same program object rather than building new
+   infrastructure.
+
+**Counterweight:** for ms-class WAN TE (the primary use case) userspace accuracy is already
+sufficient; the cheapest accuracy gains are plain `SO_TIMESTAMPING`, not eBPF; and
+auth/TLV/SRv6-encap paths cannot go XDP anyway. eBPF integration is justified by **µs-class
+fabrics, load immunity, scale, and line-rate reflection for external controllers** — not by
+the Phase-1 baseline.
+
+---
+
 ## 10. aya (Rust eBPF library)
 
 - A library/framework for writing eBPF in Rust. **No libbpf/bcc dependency, pure Rust; syscalls only via the libc crate.**

--- a/docs/design/stamp-phase1-implementation-plan.md
+++ b/docs/design/stamp-phase1-implementation-plan.md
@@ -1,0 +1,370 @@
+# STAMP Phase 1 — Step-by-Step Implementation Plan
+
+> **Status:** implementation plan, awaiting review (2026-06-12)
+> **Parent doc:** [stamp-sr-mpls-te-plan.md](./stamp-sr-mpls-te-plan.md) — this document turns its
+> "Phase 1 — Link TE metrics" row into concrete, ordered steps against the current tree.
+> **Branch:** `stamp-phase1`
+
+---
+
+## 1. Scope
+
+Phase 1 closes the loop **probe → stats → damping → IGP `te-metric` → LSP/LSA → Flex-Algo SPF**
+for IPv4 point-to-point links, in both IS-IS and OSPFv2:
+
+- New `zebra-rs/src/stamp/` task: RFC 8762 unauthenticated Session-Sender + per-session stats,
+  damping, and a BFD-style client API.
+- A **minimal implicit Session-Reflector** for registered IGP sessions (deviation from the parent
+  plan, see §2).
+- IGP hooks: register a session when a P2P adjacency reaches Up/Full, store the measured
+  snapshot on the link, merge static-over-measured at origination.
+- Config: `te-metric { measurement { enable; interval; damping-period; } }` on IS-IS and
+  OSPFv2 interfaces.
+- Show: `show stamp`, `show stamp session`, `show stamp statistics`.
+- Tests: unit (stats/damping/timestamp/reflector), in-process loopback integration test,
+  one BDD feature, YANG parse pins.
+
+**Out of scope (deferred, per parent plan):** configured external-facing reflector
+(`services monitoring stamp`), LAN circuits, IPv6 sessions, RFC 8972 TLVs / RFC 9503 return
+path, authenticated modes, loss export to the IGP, VRF sessions, OSPFv3.
+
+---
+
+## 2. Deviation from the parent plan: implicit reflector in Phase 1
+
+The parent plan defers the reflector to Phase 2. But with **no** reflector, two zebra-rs
+routers cannot measure each other — Phase 1's "close the loop on a lab topology" goal and any
+BDD would require an external Cisco/Juniper reflector. So Phase 1 ships a minimal **stateless**
+reflector with an **implicit allow-list**: the wildcard `0.0.0.0:862` socket reflects a probe
+only when its source IP matches the remote address of a *registered* session (i.e. measurement
+is enabled on both ends of the link — the Cisco SR-PM model). The Phase-2 item stays: the
+*configured* 4-tuple allow-list for external controllers.
+
+---
+
+## 3. Design decisions (locked before coding)
+
+| # | Decision | Rationale |
+|---|----------|-----------|
+| D1 | Delay = `((T4−T1) − (T3−T2)) / 2` µs | RFC 8762 four-timestamp two-way delay; the `(T3−T2)` reflector-residence term uses only the peer's clock, so clock offset cancels. No clock-sync requirement. Discard samples that compute negative or > 10 s (wall-clock step guard). |
+| D2 | Timestamps: NTP 64-bit format, `Z=0`, `S=0` (unsynced) | RFC 8762 §4.6 default; TWAMP-Light interop per parent plan §9. From `SystemTime` (+2208988800 s epoch shift). |
+| D3 | Per-session **connected** UDP sender socket, ephemeral source port, dst 862 | Kernel does reply demux per 4-tuple; no SSID-based global demux needed. Source IP = the link address from the session key (bind). TTL 255 on egress. |
+| D4 | One wildcard reflector socket `0.0.0.0:862`, `IP_RECVTTL` + `IP_PKTINFO`, replies via `sendmsg` stamping src addr = probe's dst, egress pinned to ingress ifindex | Mirrors `bfd/socket.rs` + `bfd/network.rs` exactly; reply source must equal the probed address for the sender's connected-socket demux to accept it. |
+| D5 | Stateless reflector mode: reflected `seq` = sender `seq`; `ssid` echoed; RFC 6038 symmetric size via Extra-Padding TLV when the request is longer than the 44-octet base | RFC 8762 §4.3; stateful (directional loss) is Phase 4 in the parent plan. |
+| D6 | Stats window = samples accumulated per damping period; snapshot = `{min, max, avg, variation}`; `variation` = mean absolute difference of consecutive samples | Min/max are what Flex-Algo metric-type 1 and sub-TLV 28/34 need (parent plan §6); avg fills `unidirectional-delay`, variation fills sub-TLV 29/35. |
+| D7 | Damping: at each period tick, export iff (first export) or (clear) or any field moved by more than `max(old/10, 50 µs)` | Suppresses LSP/LSA churn from µs-noise on stable links; the absolute floor stops sub-500 µs links from re-originating every period. Constants in `damping.rs`, config knobs later if needed. |
+| D8 | A period with **zero** samples after a previous export ⇒ export `None` (clear) | Measured values must not go stale when the peer stops reflecting; clearing withdraws the sub-TLVs so the link is pruned from metric-type-1 topology (RFC 9350 §15) or falls back to static config. |
+| D9 | Loss: `sent`/`received` counters kept per window for `show stamp`, **not** exported to the IGP | Per parent plan §6 — loss needs stateful tracking for accuracy; a 30-sample window is too noisy to advertise. |
+| D10 | Merge precedence at origination: **static config field wins over measured, per field** | Parent plan §7.4 recommendation — operator override. Implemented as `te_metric_effective()` on the link, never mutating `config.te_metric`. |
+| D11 | Sessions are shared across protocols: one `SessionKey {local, remote, ifindex}`, BFD-style `subscribers: HashMap<SessionKey, BTreeMap<ClientId, notifier>>` | IS-IS and OSPF on the same link measure once; both get `MetricUpdate`s. First Subscribe creates the session with its params; a later Subscribe with different params retunes the live probe/export timers (documented last-writer-wins, cheaper than BFD's Poll-Sequence constraint). |
+| D12 | `stamp` task is **eager-spawned** in the `router ospf` / `router isis` arms of `commit_config`, before `spawn_ospf` / `spawn_isis`; despawned when neither proto remains in candidate | Identical to BFD: the IGPs capture `stamp_client_tx` by value at spawn (`config/manager.rs:487-535` pattern, despawn block at `:627-640`). Port-862 bind failure is non-fatal (`warn!`, task not inserted — same as `spawn_nd`). |
+| D13 | IPv4 sessions only; IS-IS derives the pair from `v4addr` × neighbor `addr4`, OSPF from `V::bfd_addrs` (v2: v4 pair, v3: `None`) | Mirrors BFD's history (v6 was a follow-up series). `SessionKey` already holds `IpAddr` so v6 is additive later. A v6-only IS-IS adjacency simply forms no session. |
+| D14 | P2P circuits only (`is_p2p()` / `network_type == PointToPoint`) | Parent plan Phase 1 row; LAN neighbor addressing is Phase 2. |
+| D15 | VRF children pass `stamp_client_tx = None` | Sessions are default-VRF only in Phase 1; a VRF session needs a per-VRF 862 socket (`SO_BINDTODEVICE`), deferred. |
+| D16 | SSID: nonzero, table-allocated u16 per session, validated on replies | Cheap integrity check on top of the connected-socket demux. |
+
+---
+
+## 4. Step-by-step plan
+
+### Step 0 — Branch + dependency
+
+1. Branch `stamp-phase1` off `main` (done).
+2. `zebra-rs/Cargo.toml`: add `stamp-packet = { path = "../crates/stamp-packet" }`.
+   The crate is complete for our needs (verified): `SenderPacket`/`ReflectorPacket`
+   `parse`/`emit`, `StampTimestamp{seconds,fraction}`, `ErrorEstimate{synced,format,scale,multiplier}`,
+   `TimestampFormat::Ntp`, `StampTlv::ExtraPadding`, `STAMP_UDP_PORT = 862`, `BASE_LEN = 44`.
+
+### Step 1 — `zebra-rs/src/stamp/` core module
+
+New files, mirroring `bfd/` file-for-file where a sibling exists:
+
+| File | Contents |
+|------|----------|
+| `mod.rs` | module decls + `#[cfg(test)] mod integration;` (narrow `#[allow(dead_code)]` only if needed, with comment — repo convention) |
+| `timestamp.rs` | `now_ntp() -> StampTimestamp` (UNIX→NTP epoch shift 2 208 988 800 s, fraction = ns·2³²/10⁹); `delta_micros(later, earlier) -> i64`; unit tests (round-trip, fraction math, negative delta) |
+| `session.rs` | `SessionKey { local: IpAddr, remote: IpAddr, ifindex: u32 }` (Ord/Hash/Copy); `SessionParams { interval_ms: u32, damping_secs: u32, dst_port: u16 }` (+ `Default` = 1000 / 30 / 862, `PartialEq` for diff-gating); `MeasurementConfig { enable, interval_ms, damping_period_secs }` (the YANG mirror both IGPs embed, with `resolve() -> SessionParams`); `Session` (key, params, ssid, next_seq, sender sock `Arc<AsyncFd<Socket>>`, counters `tx/rx/rx_invalid`, `StatsWindow`, `Damping`, `last_export: Option<MetricSnapshot>`, `last_rx: Option<Instant>`, created `Instant`); `SessionTable` (BTreeMap by key + nonzero-u16 ssid allocator) |
+| `stats.rs` | `MetricSnapshot { min, max, avg, variation: u32 }` (µs); `StatsWindow { delays: Vec<u32>, sent: u32, received: u32 }` with `record_*`, `snapshot() -> Option<MetricSnapshot>`, `reset()`, `loss_pct()`; unit tests |
+| `damping.rs` | `Damping { last: Option<MetricSnapshot> }`; `should_export(new: Option<&MetricSnapshot>) -> bool` per D7/D8; `const THRESHOLD_DIVISOR: u32 = 10; const THRESHOLD_FLOOR_US: u32 = 50;` unit tests (suppressed / fired / first / clear) |
+| `socket.rs` | `stamp_reflector_socket(ctx, bind: SocketAddrV4)` — UDP via `ctx.udp_socket_unbound`, nonblocking, reuse, TTL 255, `IP_RECVTTL`, `IP_PKTINFO`, bind (copy of `bfd_socket_ipv4`, `bfd/socket.rs:38-49`); `stamp_sender_socket(ctx, local: SocketAddrV4, remote: SocketAddrV4)` — UDP, nonblocking, TTL 255, bind `(local_ip, 0)`, `connect(remote)` |
+| `network.rs` | `reflector_read(sock, tx)` — `recvmsg` loop with `Ipv4PacketInfo` + `Ipv4Ttl` cmsgs (copy of `bfd/network.rs:48-109`), parses `SenderPacket`, stamps `rx_ts = now_ntp()` at receipt, sends `Message::ProbeRecv{probe, src, dst, ifindex, ttl, rx_ts}`; `ReflectRequest { reply: ReflectorPacket, dst: SocketAddr, src: Option<IpAddr>, ifindex: Option<u32> }` + `reflector_write(sock, rx)` — `sendmsg` with `in_pktinfo` (copy of `bfd/network.rs:117-166`); `sender_read(key, sock, tx)` — plain `recv` on the connected socket, parses `ReflectorPacket`, stamps T4, sends `Message::ReplyRecv{key, reply, t4}` |
+| `sender.rs` | `session_prober(key, params, cmd_rx, main_tx)` — one tokio task per session driving two `tokio::time::interval`s (probe tick → `Message::TxTick{key}`, export tick → `Message::ExportTick{key}`) and a `ProberCmd { Retune(SessionParams), Shutdown }` channel; `ProberHandle { cmd_tx, _task: Task<()> }` |
+| `reflector.rs` | `build_reply(probe: &SenderPacket, rx_ts, ttl, req_len) -> ReflectorPacket` — stateless copy semantics per D5, symmetric-size padding; unit tests (field copies, padding size, sub-4-byte-pad skip) |
+| `client.rs` | `ClientId = String`; `ClientReq::{Subscribe{client,key,params,notifier}, Unsubscribe{client,key}}`; `ClientReqChannel` (copy of `bfd/inst.rs:87-103`); `StampEvent::MetricUpdate { key, snapshot: Option<MetricSnapshot> }` (`None` = clear, D8) |
+| `inst.rs` | `Stamp` struct: `rx`, `sessions`, `cm: ConfigChannel`, `show: ShowChannel`, `show_cb`, `client_req`, `subscribers`, `main_tx`, `reflect_tx`, `probers: HashMap<SessionKey, ProberHandle>`, reflector counters, `local_addr` (test introspection); `Message::{ProbeRecv, ReplyRecv, TxTick, ExportTick}`; `new(ctx)` binds 862 / `new_with(ctx, bind)` for tests; `subscribe`/`unsubscribe`/`process_client_req` (subscribe mirrors current `last_export` to the new subscriber, BFD-style); `on_tx_tick` (build `SenderPacket`, nonblocking direct `send` on the connected socket, `seq+=1`); `on_reply_recv` (ssid check, D1 math, outlier discard, record); `on_export_tick` (snapshot → damping → fan `MetricUpdate` → `window.reset()`); `on_probe_recv` (allow-list per §2, `build_reply`, `reflect_tx`); `process_cm_msg` (drain; no own config in Phase 1), `process_show_msg`, `event_loop` (select rx / cm.rx / show.rx / client_req.rx), `serve()` |
+| `show.rs` | `show_build()` registering `/show/stamp`, `/show/stamp/session`, `/show/stamp/statistics` via `Builder` (copy of `bfd/show.rs:30-39`); text + `json` (serde rows) renderers: summary (iface, local→remote, state Active/Idle by `last_rx` age vs 3×interval, sent/recv, loss %, last export), per-session detail, sender+reflector counters |
+| `integration.rs` | `#[cfg(test)]` loopback test mirroring `bfd/integration.rs`: one `Stamp::new_with(127.0.0.1:0)`, subscribe `{local:127.0.0.1, remote:127.0.0.1, ifindex:0}` with `dst_port = instance reflector port`, `interval 50 ms`, `damping 1 s`; assert a `MetricUpdate` with `Some(snapshot)`, `min ≤ avg ≤ max`, within 10 s |
+
+### Step 2 — Daemon wiring
+
+1. `zebra-rs/src/main.rs`: add `mod stamp;` (alphabetical, after `srv6`... it sits with the
+   other proto mods; place after `spf`/`srv6` like the existing list style).
+2. New `zebra-rs/src/config/stamp.rs`: `spawn_stamp` / `despawn_stamp` — line-for-line mirror
+   of `config/bfd.rs` (idempotent via `protocol_tasks["stamp"]`,
+   `ProtoContext::default_table_no_rib()`, publish `stamp_client_tx`, non-fatal bind failure).
+3. `zebra-rs/src/config/manager.rs`:
+   - field `pub stamp_client_tx: RefCell<Option<UnboundedSender<crate::stamp::client::ClientReq>>>`
+     next to `bfd_client_tx` (`:216`), init in `new` (`:270`).
+   - `commit_config`: seed a `stamp` running-flag from `cm_clients` (like `bfd` at `:446`);
+     in the `router ospf` (`:498`) and `router isis` (`:510`) arms call `spawn_stamp(self)`
+     before `spawn_ospf`/`spawn_isis` (the `router ospfv3` arm does **not** spawn it — v3 has
+     no measurement YANG; `spawn_ospfv3` still forwards whatever handle exists).
+   - despawn block (after `:624`): drop `stamp` when neither `router ospf` (prefix also
+     covers ospfv3 — conservative, harmless) nor `router isis` remains.
+4. `zebra-rs/src/config/mod.rs`: `mod stamp;` + re-export beside the bfd ones (match whatever
+   `config/mod.rs` does for `bfd`).
+
+### Step 3 — YANG
+
+1. `zebra-rs/yang/config.yang` — inside **both** te-metric containers
+   (OSPF `:643-703`, IS-IS `:2158-2215`) add:
+
+   ```yang
+   container measurement {
+     ext:help "Measure this link's delay dynamically (STAMP, RFC 8762)";
+     description
+       "Active performance measurement of this link. When enabled, a
+        STAMP Session-Sender (RFC 8762, unauthenticated) probes the
+        P2P neighbor once the adjacency is up; the damped min/max/avg
+        delay and delay variation populate the same te-metric fields
+        as static configuration (a static leaf, when set, overrides
+        the measured value per field). The probes are answered by the
+        neighbor's implicit Session-Reflector, so measurement must be
+        enabled on both ends of the link.";
+     leaf enable {
+       type boolean;
+       description "Activate measurement on this interface.";
+     }
+     leaf interval {
+       type uint32 { range "100..60000"; }
+       units "milliseconds";
+       description "Probe transmit interval. Default 1000 ms.";
+     }
+     leaf damping-period {
+       type uint32 { range "1..3600"; }
+       units "seconds";
+       description
+         "Minimum spacing between exports to the IGP; each period's
+          samples form the advertised min/max/avg window. Default 30 s.";
+     }
+   }
+   ```
+
+   (No YANG `default` statements — sibling leaves here use code-side defaults; keeps
+   the config diff/display behavior consistent.)
+
+2. `zebra-rs/yang/exec.yang` — after the `bfd` container (`:201-217`):
+
+   ```yang
+   container stamp {
+     ext:help "STAMP (RFC 8762) link delay measurement";
+     presence "Show STAMP session summary";
+     leaf session {
+       ext:help "Per-session detail";
+       type empty;
+     }
+     leaf statistics {
+       ext:help "Sender and reflector packet counters";
+       type empty;
+     }
+   }
+   ```
+
+3. Pin with parse tests in `config/manager.rs` `yang_load_tests` (`:1263`, the
+   `remove_private_as` test is the template): one config path per protocol
+   (`set router isis interface eth0 te-metric measurement enable true`,
+   `set router ospf area 0 interface eth0 te-metric measurement interval 100`) and the three
+   show paths. (`configure_mode_loads` / `exec_mode_loads` already gate schema validity.)
+
+### Step 4 — IS-IS integration
+
+1. `isis/link.rs`:
+   - `LinkConfig`: add `pub te_metric_measurement: MeasurementConfig` (after `te_metric`, `:308`).
+   - `LinkState`: add `pub measured_te_metric: LinkTeMetric` and
+     `pub stamp_session: Option<(stamp::session::SessionKey, stamp::session::SessionParams)>`
+     (tracked subscription, OSPF-neighbor-style diff-gate).
+   - `impl IsisLink { pub fn te_metric_effective(&self) -> LinkTeMetric }` — per-field
+     `config.or(measured)` (D10) + unit test (config wins, measured fills gaps).
+   - Config callbacks `config_te_measurement_{enable,interval,damping_period}` —
+     parse ifname + value, store, then send the new `Message::StampReconcile(ifindex)`;
+     on disable also clear `measured_te_metric` + `LspOriginate` both levels (mirror
+     `config_te_metric`, `:1275-1288`).
+2. `isis/config.rs` (`:364-383` block): register the three new callback paths
+   `/router/isis/interface/te-metric/measurement/{enable,interval,damping-period}`.
+3. `isis/inst.rs`:
+   - `Isis` fields: `stamp_client_tx`, `stamp_event_tx`, `stamp_event_rx` (next to the bfd
+     trio, `:414-429`); `Isis::new` gains `stamp_client_tx` param (after `bfd_client_tx`,
+     `:606`) — update `config/isis.rs::spawn_isis` and `isis/vrf.rs` child construction
+     (children pass `None`, D15).
+   - `Message::StampReconcile(u32)` variant (+ `Display` arm near `:3029`).
+   - `stamp_reconcile_link(&mut self, ifindex)` — compute desired
+     `(SessionKey, SessionParams)`: measurement enabled ∧ `is_p2p` ∧ an Up adjacency on
+     either level ∧ v4 pair (`link.state.v4addr.first()` × `nbr.addr4.keys().next()`,
+     same selection as `bfd_reconcile_all`, `:1947-1976`); diff against
+     `link.state.stamp_session`; Unsubscribe stale / Subscribe new with
+     `notifier = stamp_event_tx`; store. `stamp_reconcile_all()` = loop over links.
+   - `process_cm_msg` CommitEnd hook (`:751-763`): add `self.stamp_reconcile_all()` —
+     one robust hook covers every config path that can flip a session (enable, interval,
+     network-type, afi enable...).
+   - `process_stamp_event(&mut self, ev)`: `MetricUpdate{key, snapshot}` → link by
+     `key.ifindex`, verify tracked key, map snapshot →
+     `LinkTeMetric { unidirectional_delay: avg, min_delay, max_delay, delay_variation: variation, loss: None }`
+     (or `default()` on `None`), store in `state.measured_te_metric`, `LspOriginate` L1+L2.
+   - `event_loop` (`:2324-2346`): add `stamp_event_rx` arm; `process_msg`: handle
+     `StampReconcile`.
+4. Runtime triggers:
+   - `isis/packet.rs` — in `bfd_nfsm_dispatch`'s caller path (the Up-edge dispatch, `:85-103`):
+     also send `Message::StampReconcile(link.ifindex)` on an NFSM transition to/from Up.
+   - `isis/nfsm.rs::nbr_hold_timer_expire` (`:51-146`): send `StampReconcile(ifindex)` after
+     teardown (the reconcile sees the removed neighbor and unsubscribes).
+5. Origination merge:
+   - `isis/lsp.rs` `:815-827` (TLV 22) and `:1005-1019` (TLV 222): build
+     `let te_metric = link.te_metric_effective();` once and use it for both the ASLA build
+     and the inline `sub_tlvs()` extend.
+   - `isis/graph.rs` `:664` (flex-algo local-link min-delay):
+     `.and_then(|link| link.te_metric_effective().min_delay)`.
+
+### Step 5 — OSPFv2 integration (generic over `Ospf<V>`, active for v2)
+
+1. `ospf/link.rs`:
+   - `LinkConfig`: add `pub te_metric_measurement: MeasurementConfig` (after `:125`).
+   - `OspfLink`: add `pub measured_te_metric: LinkTeMetric`,
+     `pub stamp_session: Option<(SessionKey, SessionParams)>` (+ init in `OspfLink::from`).
+   - `te_metric_effective()` + unit test (mirror IS-IS).
+2. `ospf/config.rs`: register
+   `/area/interface/te-metric/measurement/{enable,interval,damping-period}` (`ospf_add`
+   block `:111-130`); callbacks parse area-id + ifname + value (template
+   `config_ospf_interface_te_metric`, `:705-722`), store, call
+   `ospf.stamp_reconcile_link(ifindex)`; disable also clears `measured_te_metric` +
+   `ext_link_lsa_originate(ifindex)`. **v2 only** (no `config_v3.rs` registration).
+3. `ospf/inst.rs`:
+   - `Ospf<V>` fields: `stamp_client_tx`, `stamp_event_tx`, `stamp_event_rx` (next to bfd
+     trio `:346-351`); both constructors (`Ospfv2::new` `:1015`, v3 `:5005`) gain the
+     param — update `config/ospf.rs::spawn_ospf`/`spawn_ospfv3` and `ospf/vrf.rs`
+     (children: `None`).
+   - `stamp_reconcile_link(&mut self, ifindex)` (generic impl block near
+     `bfd_reconcile_nbr` `:448`): desired iff measurement enabled ∧
+     `network_type == PointToPoint` ∧ a Full neighbor ∧ `V::bfd_addrs` yields a pair
+     (v3 returns `None` ⇒ inert); diff-gate against `link.stamp_session`;
+     subscribe/unsubscribe; store.
+   - `process_stamp_event`: store measured on link, `ext_link_lsa_originate(ifindex)`.
+   - Trigger sites: after the existing `bfd_reconcile_nbr` calls in the NFSM arms
+     (`:4725` v2, `:6849` v3) add `self.stamp_reconcile_link(index)`; in
+     `nfsm_kill_neighbor` (`:3470` v2, `:8066` v3) after neighbor removal.
+   - Event-loop arms in both loops (`:4933` v2, `:8641` v3).
+4. Origination merge: `ext_link_lsa_originate` `:1984` →
+   `link.te_metric_effective().asla_sub_subs()`. (Flex-algo SPF consumption needs no change:
+   `flex_algo_link_delay` reads the LSDB, which now carries merged values from our own LSA.)
+
+### Step 6 — Workspace tests
+
+- Unit tests embedded per Step-1 file (timestamp, stats, damping, reflector, session table).
+- `te_metric_effective` tests in both `isis/link.rs` (`te_metric_tests` `:2399`) and
+  `ospf/link.rs` (`:745`) modules.
+- Stamp loopback integration test (Step 1, `integration.rs`).
+- YANG parse pins (Step 3.3).
+
+### Step 7 — BDD
+
+1. New step in `bdd/tests/cucumber.rs`:
+   `show command {string} in namespace {string} should eventually contain {string}` —
+   positive polling sibling of `show_command_eventually_not_contains` (`:917-955`),
+   60 × 1 s, with the same diagnostics-on-failure.
+2. Feature `bdd/tests/features/stamp_te_metric.feature`, tag `@stamp_te_metric`
+   (verify no tag-prefix collision with `grep -rh "^@" bdd/tests/features/`), configs under
+   `bdd/tests/configs/stamp_te_metric/{st1,st2}.yaml`:
+   - Two namespaces `st1`/`st2`, one veth pair (feature-unique interface names
+     `st1-st2`/`st2-st1`), addresses `192.168.61.0/30` range + loopbacks.
+   - Both routers run **both** `router isis` (P2P, ipv4 enable) and `router ospf`
+     (area 0, `network-type: point-to-point`, `segment-routing: mpls` — required for the
+     Extended-Link LSA gate) with
+     `te-metric: { measurement: { enable: true, interval: 100, damping-period: 2 } }`
+     on the link interface — deliberately exercising the shared-session/multi-client path (D11).
+   - Scenario 1 (bring-up): clean env, namespaces, veth, start, apply, wait, ping across.
+   - Scenario 2 (IS-IS): `show isis database detail` **eventually contains**
+     `"Min/Max Unidirectional Link Delay"` (renderer string verified at
+     `crates/isis-packet/src/sub/neigh_disp.rs:84`); `show stamp` contains the remote addr.
+   - Scenario 3 (OSPF): `show ospf database detail` eventually contains
+     `"Min/Max Unidirectional Link Delay"` (`ospf/show.rs:1609`).
+   - Scenario 4 (static override): not in Phase-1 BDD — covered by unit tests (keeps the
+     feature fast).
+   - Final scenario: **Teardown topology** — stop zebra-rs in each ns, delete each ns,
+     `the test environment should be clean` (repo rule).
+3. `bdd/Makefile`: `stamp_te_metric:` target; regenerate docs (`make docs` →
+   `bdd/docs/stamp_te_metric.md`).
+
+### Step 8 — Verification & delivery
+
+1. `cargo build` + full `cargo test --workspace --exclude bdd` (CI parity), `cargo fmt`,
+   `cargo clippy --workspace --all-targets -- -D warnings` (touch new files if cache-stale).
+2. BDD run: `cargo build --release`, **md5 the binary, install to `/usr/bin/zebra-rs` +
+   sync `zebra-rs/yang/ → /etc/zebra-rs/yang/`** (manual-install gotcha; other worktrees can
+   stomp these — re-check md5 immediately before the run), then
+   `cd bdd && make stamp_te_metric`. Also re-run one existing IS-IS + one OSPF feature
+   (e.g. `make isis_l1p2p ospfv2_tilfa`) to catch origination regressions from the
+   `te_metric_effective` refactor.
+3. Update the parent plan doc's §3 status table (measurement runtime: Phase 1 done) in the
+   same PR.
+4. Single PR from `stamp-phase1` with commits ordered: core module → wiring/YANG → IS-IS →
+   OSPF → tests/BDD/docs. PR description lists D1-D16 and the §2 deviation explicitly.
+
+---
+
+## 5. Risks / open questions
+
+| Risk | Mitigation |
+|------|------------|
+| Port 862 already bound on a host (external TWAMP daemon) | Non-fatal spawn (warn + no task), like ND's raw-socket failure; sender-only operation still impossible Phase 1 (reflector socket is the instance gate) — acceptable, logged clearly. |
+| LSP/LSA churn if damping thresholds mis-tuned | D7 constants + BDD uses damping 2 s only in the lab; defaults 30 s. Verification checklist row "LSP seq not changing on every probe" from the parent plan §11 checked manually during the BDD run. |
+| `te_metric_effective()` refactor touches 6 origination/SPF sites | Existing static-te-metric unit tests (`isis/link.rs:2399`, `ospf/link.rs:745`) plus existing flex-algo BDDs re-run in Step 8.2. |
+| Both-IGPs-one-link BDD is a new config shape | If flaky, fall back to two scenarios with separate veth pairs — decided at Step 7 execution time. |
+| Shared-session params (D11) surprise (isis interval 100 vs ospf 200) | Last-writer-wins documented in `client.rs` + Subscribe handler; both IGPs in the BDD use identical params. |
+| `rx_invalid` on clock step (NTP slew during probe) | D1 outlier discard; counted and visible in `show stamp statistics`. |
+
+---
+
+## 6. Explicitly deferred (tracked for Phase 2+)
+
+- Configured reflector block (`services monitoring stamp`) + external-controller allow-list.
+- LAN circuits; IPv6 sessions (incl. IS-IS v6-only adjacencies); VRF sessions (per-VRF 862).
+- Loss export to the IGP; anomalous-flag raising on threshold crossing (`asla_sub_subs()`
+  comments already anticipate the parameter).
+- RFC 8972 TLVs beyond Extra-Padding; RFC 9503 return path / SR-MPLS encap (Phase 3).
+- `stamp { tracing }` config + dedicated trace module (BFD-style) if debug volume warrants.
+- Accuracy/offload ladder (see §7): sender `SO_TIMESTAMPING` (Phase 1.5), XDP reflector +
+  sender-RX fastpath, HW timestamps
+  ([offload notes §9b](./bfd-sbfd-stamp-xdp-offload-notes.md)).
+
+---
+
+## 7. XDP/eBPF offload readiness (analysis summary)
+
+Full analysis: [bfd-sbfd-stamp-xdp-offload-notes.md §9b](./bfd-sbfd-stamp-xdp-offload-notes.md)
+(2026-06-12). The conclusions that bind Phase 1:
+
+**Why it matters here:** the D1 math cancels only the *measured* reflector residence; the four
+userspace stamp-to-wire residues survive, halved:
+`delay_est = wire/2 + (a+b+c+d)/2`. Min-delay (the Flex-Algo edge cost) self-filters via the
+window minimum; **max-delay and delay-variation absorb daemon-scheduling tails** — honest on
+ms-class WAN links, scheduling-dominated on µs-class fabric. Offload (and cheaper socket
+timestamping) exists to shrink those residues; Phase 1 ships userspace anyway because the
+primary delay-TE regime is ms-class and correctness/interop come first.
+
+**Phase-1 structural requirements** (all already implied by §4 design, made binding here):
+
+| R | Requirement | Why |
+|---|-------------|-----|
+| R1 | `reflector.rs::build_reply` stays a pure function with byte-level unit tests | It is the executable spec a future XDP program mirrors (in-place 44-octet rewrite — both base packets are `BASE_LEN`, reflector fields overwrite sender MBZ) |
+| R2 | Reflector allow-list kept as plain per-session data `(local, remote)` | Becomes a BPF map keyed the same way; also the future in-kernel anti-abuse gate |
+| R3 | T1 stamped at one build site; T4 captured at one read-task boundary | `SO_TIMESTAMPING` cmsg (rung 1/2) or kernel-map timestamps (rung 3) swap in at a single seam |
+| R4 | All samples enter stats through `StatsWindow::record_delay` | A kernel-aggregate mode later feeds `{min,max,sum,count,jitter}` per export period beneath the same damping layer |
+| R5 | Reflector counters tracked per session/source, not only globals | Substituted by helper map readouts when XDP consumes probes |
+| R6 | `SessionKey` keeps `ifindex` | Per-ifindex helper acquire/release keys off it (BFD `EchoReflectors` model) |
+
+**Two facts that shape the later offload work** (no Phase-1 action, recorded so they aren't
+re-discovered): (1) only one XDP program attaches per interface and `xdp-bfd-echo` already
+owns that hook wherever BFD Echo/detect runs — STAMP matching must join the *same* program
+object, which makes promoting `Bfd`-private `EchoReflectors` into a shared offload supervisor
+a prerequisite refactor; (2) the cheapest accuracy wins are not eBPF at all —
+`SO_TIMESTAMPING` RX (then TX/errqueue) on the existing sockets — recommended as the first
+post-Phase-1 follow-up.

--- a/docs/design/stamp-sr-mpls-te-plan.md
+++ b/docs/design/stamp-sr-mpls-te-plan.md
@@ -53,17 +53,33 @@ The two planes meet at one seam: per-interface **`te-metric`**. The measurement 
 | Flex-Algo metric-type 1 SPF | `isis/graph.rs` | `ospf/inst.rs` `graph_flex_algo` |
 | Show | `show isis database`, `show isis flex-algo` | `show ospf database detail`, `show ospf flex-algo` |
 
-### 3.2 Implemented — wire codec only
+### 3.2 Implemented — wire codec
 
 - **`crates/stamp-packet`** — RFC 8762 base packets, RFC 8972 TLV framework, RFC 9503 return-path sub-TLVs.
-- Not yet linked into `zebra-rs` (`stamp-packet` is not in `zebra-rs/Cargo.toml`).
+- Linked into `zebra-rs` since Phase 1 (see §3.3).
 
-### 3.3 Not implemented — measurement runtime
+### 3.3 Implemented — measurement runtime (Phase 1, 2026-06)
 
-- No `stamp/` (or `pm/`) module in `main.rs`.
-- No `spawn_stamp` in `config/manager.rs` (unlike `spawn_bfd`, `spawn_nd`).
-- `te_metric` lives only on **`LinkConfig`** (static YANG config); comments still reference a future TWAMP/STAMP task.
-- No runtime `measured_te_metric`, no damping, no IGP client API.
+Built per [stamp-phase1-implementation-plan.md](./stamp-phase1-implementation-plan.md)
+(decisions D1–D16, implicit-reflector deviation §2):
+
+- `zebra-rs/src/stamp/` — RFC 8762 unauthenticated Session-Sender (one
+  connected socket + prober per session), implicit stateless
+  Session-Reflector on `0.0.0.0:862` (allow-list = registered sessions'
+  remotes), per-period stats window, export damping
+  (`max(old/10, 50 µs)` per field; empty period ⇒ clear), BFD-style
+  Subscribe/Unsubscribe client API shared across protocols.
+- `spawn_stamp` / `despawn_stamp` in `config/stamp.rs`, eager-spawned by
+  the `router isis` / `router ospf` commit arms; `stamp_client_tx` on
+  `ConfigManager`.
+- `te-metric measurement { enable; interval; damping-period }` on IS-IS
+  and OSPFv2 interfaces; runtime `measured_te_metric` on the link with
+  static-wins-per-field merge (`te_metric_effective()`) consumed by
+  LSP/Extended-Link-LSA origination and flex-algo metric-type-1 SPF.
+- `show stamp` / `show stamp session` / `show stamp statistics`; BDD
+  `@stamp_te_metric`.
+- Phase-1 scope limits: IPv4 P2P links, default VRF, no loss export, no
+  configured external reflector (Phase 2+, §6 of the phase-1 plan).
 
 ### 3.4 Patterns to follow when implementing
 
@@ -247,9 +263,15 @@ At origination, **merge** with documented precedence (recommended: static leaf o
 
 ## 8. Phased delivery
 
-### Phase 1 — Link TE metrics (Tier 1 specs)
+### Phase 1 — Link TE metrics (Tier 1 specs) — **DONE** (2026-06)
 
 **Goal:** Close the loop from probe → Flex-Algo SPF on a lab topology.
+
+> Shipped per [stamp-phase1-implementation-plan.md](./stamp-phase1-implementation-plan.md),
+> including a minimal **implicit** stateless reflector (registered-peer
+> allow-list) pulled forward from Phase 2 so two zebra-rs routers can
+> measure each other; the *configured* external-reflector block stays
+> in Phase 2.
 
 | Work item | Detail |
 |-----------|--------|

--- a/zebra-rs/Cargo.toml
+++ b/zebra-rs/Cargo.toml
@@ -54,6 +54,7 @@ isis-macros = { path = "../crates/isis-macros" }
 packet-utils = { path = "../crates/packet-utils" }
 bfd-packet = { path = "../crates/bfd-packet" }
 nd-packet = { path = "../crates/nd-packet" }
+stamp-packet = { path = "../crates/stamp-packet" }
 bitfield-struct = "0.13"
 rand = "0.10"
 chrono = { version = "0.4", features = ["serde"] }

--- a/zebra-rs/src/config/isis.rs
+++ b/zebra-rs/src/config/isis.rs
@@ -19,6 +19,9 @@ pub fn spawn_isis(config: &ConfigManager) {
     // `bfd { … }` block exists. Callers that bypass `commit_config`
     // may still see `None`.
     let bfd_client_tx = config.bfd_client_tx.borrow().clone();
+    // Same contract for the STAMP measurement handle (`te-metric
+    // measurement`): `commit_config` spawns STAMP eagerly before IS-IS.
+    let stamp_client_tx = config.stamp_client_tx.borrow().clone();
     // BGP-LS producer (RFC 9552): the IS-IS task pushes Link-State routes
     // to BGP over this sender. Captured by value — `None` if `router bgp`
     // is committed after `router isis` (cross-commit), matching the
@@ -35,6 +38,7 @@ pub fn spawn_isis(config: &ConfigManager) {
         ctx,
         rib_rx,
         bfd_client_tx,
+        stamp_client_tx,
         bgp_tx,
         config.policy_tx.clone(),
         "isis".to_string(),

--- a/zebra-rs/src/config/manager.rs
+++ b/zebra-rs/src/config/manager.rs
@@ -992,6 +992,8 @@ impl ConfigManager {
                                 "BGP"
                             } else if is_bfd(&paths) {
                                 "BFD"
+                            } else if is_stamp(&paths) {
+                                "STAMP"
                             } else if is_nd(&paths) {
                                 "ND"
                             } else if is_policy(&paths) {
@@ -1131,6 +1133,10 @@ fn is_bfd(paths: &[CommandPath]) -> bool {
     paths.iter().any(|x| x.name == "bfd")
 }
 
+fn is_stamp(paths: &[CommandPath]) -> bool {
+    paths.iter().any(|x| x.name == "stamp")
+}
+
 fn is_nd(paths: &[CommandPath]) -> bool {
     paths.iter().any(|x| x.name == "nd")
 }
@@ -1156,6 +1162,8 @@ fn show_proto(paths: &[CommandPath]) -> &'static str {
         "isis"
     } else if is_bfd(paths) {
         "bfd"
+    } else if is_stamp(paths) {
+        "stamp"
     } else if is_nd(paths) {
         "nd"
     } else if is_policy(paths) {

--- a/zebra-rs/src/config/manager.rs
+++ b/zebra-rs/src/config/manager.rs
@@ -14,6 +14,7 @@ use super::ospf::{despawn_ospf, despawn_ospfv3, spawn_ospf, spawn_ospfv3};
 use super::parse::State;
 use super::parse::parse;
 use super::paths::{path_try_trim, paths_str, vrf_redirect_split};
+use super::stamp::{despawn_stamp, spawn_stamp};
 use super::util::trim_first_line;
 use super::vty::CommandPath;
 use super::yaml::yaml_parse;
@@ -214,6 +215,14 @@ pub struct ConfigManager {
     /// instance. `None` indicates BFD has not (yet) been spawned — clients
     /// with a `None` handle silently skip their BFD attach logic.
     pub bfd_client_tx: RefCell<Option<UnboundedSender<crate::bfd::inst::ClientReq>>>,
+    /// Sender side of the STAMP client-request channel. Same contract
+    /// as `bfd_client_tx`: populated by [`super::stamp::spawn_stamp`]
+    /// (eager-spawned by the OSPF / IS-IS commit arms before those
+    /// protocols), cleared by `despawn_stamp` when the last consumer
+    /// is gone, captured by value at protocol spawn time. `None` means
+    /// STAMP is not running (never configured, or its reflector port
+    /// could not be bound) — consumers silently skip measurement.
+    pub stamp_client_tx: RefCell<Option<UnboundedSender<crate::stamp::client::ClientReq>>>,
     /// Sender side of the ND client-request channel. Populated by
     /// [`super::nd::spawn_nd`] on either the first
     /// `ipv6 router-advertisements` line or the first `router bgp`
@@ -268,6 +277,7 @@ impl ConfigManager {
             next_proto_id: std::sync::Arc::new(std::sync::atomic::AtomicU32::new(0)),
             policy_tx,
             bfd_client_tx: RefCell::new(None),
+            stamp_client_tx: RefCell::new(None),
             nd_client_tx: RefCell::new(None),
             protocol_tasks: RefCell::new(HashMap::new()),
             yang_service_accounts,
@@ -430,6 +440,7 @@ impl ConfigManager {
         let mut isis = false;
         let mut bgp = false;
         let mut bfd = false;
+        let mut stamp = false;
         let mut nd = false;
         for (proto, tx) in self.cm_clients.borrow().iter() {
             tx.send(ConfigRequest::new(Vec::new(), ConfigOp::CommitStart))
@@ -445,6 +456,9 @@ impl ConfigManager {
             }
             if proto == "bfd" {
                 bfd = true;
+            }
+            if proto == "stamp" {
+                stamp = true;
             }
             if proto == "nd" {
                 nd = true;
@@ -505,6 +519,15 @@ impl ConfigManager {
                     bfd = true;
                     spawn_bfd(self);
                 }
+                // OSPF captures `stamp_client_tx` by value at spawn,
+                // same contract as `bfd_client_tx` — bring STAMP up
+                // first so `te-metric measurement` works regardless of
+                // commit order. (The ospfv3 arm doesn't: OSPFv3 has no
+                // measurement YANG in Phase 1.)
+                if !stamp {
+                    stamp = true;
+                    spawn_stamp(self);
+                }
                 spawn_ospf(self);
             }
             if !isis && op == ConfigOp::Set && line.starts_with("router isis") {
@@ -519,6 +542,12 @@ impl ConfigManager {
                 if !bfd {
                     bfd = true;
                     spawn_bfd(self);
+                }
+                // Same by-value capture for `stamp_client_tx` (see the
+                // `router ospf` arm above).
+                if !stamp {
+                    stamp = true;
+                    spawn_stamp(self);
                 }
                 // Pre-spawn BGP if this commit will set it, so IS-IS
                 // captures a live `bgp_tx` for the BGP-LS producer (the
@@ -637,6 +666,16 @@ impl ConfigManager {
             && !proto_in_candidate("ospf")
         {
             despawn_bfd(self);
+        }
+        // STAMP follows the same eager-consumer lifecycle as BFD, with
+        // OSPF / IS-IS as its only consumers. The ospf prefix check
+        // also matching `router ospfv3` is conservative but harmless —
+        // an idle instance is one bound socket.
+        if self.protocol_tasks.borrow().contains_key("stamp")
+            && !proto_in_candidate("isis")
+            && !proto_in_candidate("ospf")
+        {
+            despawn_stamp(self);
         }
 
         self.store.commit();
@@ -1383,6 +1422,64 @@ mod yang_load_tests {
             ExecCode::Success,
             "`compute-mode turbo` must not parse"
         );
+    }
+
+    /// STAMP Phase 1 grammar: the `te-metric measurement` block on
+    /// both IGP interfaces (configure mode) and the `show stamp`
+    /// surface (exec mode). Pinned because vtyctl apply/show are
+    /// garbage-tolerant — an unwired grammar silently no-ops.
+    #[test]
+    fn stamp_measurement_grammar() {
+        use crate::config::ExecCode;
+        use crate::config::parse::{State, parse};
+        use libyang::to_entry;
+
+        let mut yang = YangStore::new();
+        yang.add_path(concat!(env!("CARGO_MANIFEST_DIR"), "/yang"));
+        yang.read_with_resolve("configure")
+            .expect("configure mode loads");
+        yang.identity_resolve();
+        let module = yang
+            .find_module("configure")
+            .expect("configure module present");
+        let entry = to_entry(&yang, module);
+
+        for cmd in [
+            "set router isis interface eth0 te-metric measurement enable true",
+            "set router isis interface eth0 te-metric measurement interval 100",
+            "set router isis interface eth0 te-metric measurement damping-period 2",
+            "set router ospf area 0 interface eth0 te-metric measurement enable true",
+            "set router ospf area 0 interface eth0 te-metric measurement interval 100",
+            "set router ospf area 0 interface eth0 te-metric measurement damping-period 2",
+        ] {
+            let (code, _comps, _state) = parse(cmd, entry.clone(), None, State::new());
+            assert_eq!(
+                code,
+                ExecCode::Success,
+                "should parse as a settable path: {cmd}"
+            );
+        }
+
+        // An out-of-range interval must not parse (100..60000 ms).
+        let (code, _comps, _state) = parse(
+            "set router isis interface eth0 te-metric measurement interval 50",
+            entry.clone(),
+            None,
+            State::new(),
+        );
+        assert_ne!(code, ExecCode::Success, "interval 50 is below the range");
+
+        let mut yang = YangStore::new();
+        yang.add_path(concat!(env!("CARGO_MANIFEST_DIR"), "/yang"));
+        yang.read_with_resolve("exec").expect("exec mode loads");
+        yang.identity_resolve();
+        let module = yang.find_module("exec").expect("exec module present");
+        let entry = to_entry(&yang, module);
+
+        for cmd in ["show stamp", "show stamp session", "show stamp statistics"] {
+            let (code, _comps, _state) = parse(cmd, entry.clone(), None, State::new());
+            assert_eq!(code, ExecCode::Success, "should parse: {cmd}");
+        }
     }
 
     /// `router bgp global router-id` is zebra-rs's rename of the IETF

--- a/zebra-rs/src/config/mod.rs
+++ b/zebra-rs/src/config/mod.rs
@@ -47,6 +47,7 @@ mod nd;
 mod nsap;
 mod ospf;
 mod parse;
+mod stamp;
 mod token;
 mod util;
 mod yaml;

--- a/zebra-rs/src/config/ospf.rs
+++ b/zebra-rs/src/config/ospf.rs
@@ -21,6 +21,9 @@ pub fn spawn_ospf(config: &ConfigManager) {
     // BFD is eager-spawned before OSPF in `commit_config`, so this
     // handle is live; threaded in so per-interface `bfd` can subscribe.
     let bfd_client_tx = config.bfd_client_tx.borrow().clone();
+    // Same contract for the STAMP measurement handle (`te-metric
+    // measurement`): eager-spawned before OSPF.
+    let stamp_client_tx = config.stamp_client_tx.borrow().clone();
     let ospf = inst::Ospf::<crate::ospf::Ospfv2>::new(
         ctx,
         rib_rx,
@@ -29,6 +32,7 @@ pub fn spawn_ospf(config: &ConfigManager) {
         config.rib_subscriber(),
         config.tx.clone(),
         bfd_client_tx,
+        stamp_client_tx,
     );
     config.subscribe("ospf", ospf.cm.tx.clone());
     config.subscribe_show("ospf", ospf.show.tx.clone());
@@ -70,6 +74,9 @@ pub fn spawn_ospfv3(config: &ConfigManager) {
     // `"ospfv3"` default label; per-VRF children get
     // `"ospfv3:vrf:<name>"`. See `spawn_ospf` for the rationale.
     let bfd_client_tx = config.bfd_client_tx.borrow().clone();
+    // Forwarded for shape uniformity; v3 has no measurement YANG so
+    // the handle is never used (the v2 instance owns all sessions).
+    let stamp_client_tx = config.stamp_client_tx.borrow().clone();
     let ospf = inst::Ospf::<crate::ospf::Ospfv3>::new(
         ctx,
         rib_rx,
@@ -78,6 +85,7 @@ pub fn spawn_ospfv3(config: &ConfigManager) {
         config.rib_subscriber(),
         config.tx.clone(),
         bfd_client_tx,
+        stamp_client_tx,
     );
     config.subscribe("ospfv3", ospf.cm.tx.clone());
     config.subscribe_show("ospfv3", ospf.show.tx.clone());

--- a/zebra-rs/src/config/stamp.rs
+++ b/zebra-rs/src/config/stamp.rs
@@ -1,0 +1,44 @@
+use crate::context::ProtoContext;
+use crate::rib;
+use crate::stamp::inst;
+
+use super::ConfigManager;
+
+/// Spawn the STAMP instance. Mirrors [`super::bfd::spawn_bfd`]:
+/// eager-spawned by the `router ospf` / `router isis` arms in
+/// `commit_config` (those protocols capture `stamp_client_tx` by value
+/// at their own spawn), so it must be idempotent. A bind failure on
+/// the well-known reflector port (862 already taken by an external
+/// TWAMP/STAMP daemon) is non-fatal: warn and leave the task out —
+/// consumers see a `None` handle and skip measurement.
+pub fn spawn_stamp(config: &ConfigManager) {
+    if config.protocol_tasks.borrow().contains_key("stamp") {
+        return;
+    }
+    match inst::Stamp::new(ProtoContext::default_table_no_rib()) {
+        Ok(stamp) => {
+            config.subscribe("stamp", stamp.cm.tx.clone());
+            config.subscribe_show("stamp", stamp.show.tx.clone());
+            *config.stamp_client_tx.borrow_mut() = Some(stamp.client_req_tx());
+            let task = inst::serve(stamp);
+            config
+                .protocol_tasks
+                .borrow_mut()
+                .insert("stamp".to_string(), task);
+        }
+        Err(e) => tracing::warn!("stamp: failed to start instance: {e}"),
+    }
+}
+
+/// Tear the STAMP instance down once neither consumer protocol
+/// (OSPF / IS-IS) remains in the candidate config. Dropping the task
+/// aborts the event loop and with it every prober / read task.
+pub fn despawn_stamp(config: &ConfigManager) {
+    config.cm_clients.borrow_mut().remove("stamp");
+    config.show_clients.borrow_mut().remove("stamp");
+    config.protocol_tasks.borrow_mut().remove("stamp");
+    *config.stamp_client_tx.borrow_mut() = None;
+    let _ = config.rib_tx.send(rib::Message::ProtoCleanup {
+        proto: "stamp".to_string(),
+    });
+}

--- a/zebra-rs/src/isis/config.rs
+++ b/zebra-rs/src/isis/config.rs
@@ -382,6 +382,18 @@ impl Isis {
             link::config_te_loss,
         );
         self.callback_add(
+            "/router/isis/interface/te-metric/measurement/enable",
+            link::config_te_measurement_enable,
+        );
+        self.callback_add(
+            "/router/isis/interface/te-metric/measurement/interval",
+            link::config_te_measurement_interval,
+        );
+        self.callback_add(
+            "/router/isis/interface/te-metric/measurement/damping-period",
+            link::config_te_measurement_damping_period,
+        );
+        self.callback_add(
             "/router/isis/interface/ipv4/flex-algo-prefix-sid",
             link::config_ipv4_flex_algo_prefix_sid,
         );

--- a/zebra-rs/src/isis/graph.rs
+++ b/zebra-rs/src/isis/graph.rs
@@ -661,7 +661,7 @@ pub fn graph_flex_algo(
                         local_adj_to_ifindex
                             .get(&entry_reach.neighbor_id)
                             .and_then(|ifx| top.links.get(ifx))
-                            .and_then(|link| link.config.te_metric.min_delay)
+                            .and_then(|link| link.te_metric_effective().min_delay)
                     } else {
                         entry_reach.subs.iter().find_map(|sub| match sub {
                             neigh::IsisSubTlv::Asla(asla) => {

--- a/zebra-rs/src/isis/inst.rs
+++ b/zebra-rs/src/isis/inst.rs
@@ -427,6 +427,19 @@ pub struct Isis {
     /// [`Self::event_loop`]. Events are logged and drive adjacency
     /// teardown on `BfdEvent::Down`.
     pub bfd_event_rx: UnboundedReceiver<crate::bfd::inst::BfdEvent>,
+    /// Handle into the STAMP instance's client-request channel — used
+    /// by [`Self::stamp_reconcile_link`] to (un)subscribe measurement
+    /// sessions for `te-metric measurement` interfaces. Same capture
+    /// contract as `bfd_client_tx`; `None` for per-VRF children
+    /// (sessions are default-VRF only in Phase 1).
+    pub stamp_client_tx: Option<UnboundedSender<crate::stamp::client::ClientReq>>,
+    /// Sender half of the per-instance `StampEvent` channel, handed to
+    /// STAMP as the `notifier` on every `Subscribe`.
+    pub stamp_event_tx: UnboundedSender<crate::stamp::client::StampEvent>,
+    /// Receive half drained by the event loop; `MetricUpdate`s land in
+    /// [`Self::process_stamp_event`], which stores the measured
+    /// te-metric on the link and re-originates.
+    pub stamp_event_rx: UnboundedReceiver<crate::stamp::client::StampEvent>,
     /// Snapshot of `/key-chains/key-chain <name>` entries the policy
     /// actor has pushed to this IS-IS instance via
     /// `PolicyRx::KeyChain`. The canonical map lives in
@@ -604,6 +617,7 @@ impl Isis {
         ctx: ProtoContext,
         rib_rx: UnboundedReceiver<RibRx>,
         bfd_client_tx: Option<UnboundedSender<crate::bfd::inst::ClientReq>>,
+        stamp_client_tx: Option<UnboundedSender<crate::stamp::client::ClientReq>>,
         bgp_tx: Option<mpsc::Sender<crate::bgp::inst::Message>>,
         policy_tx: UnboundedSender<crate::policy::Message>,
         proto_label: String,
@@ -627,6 +641,7 @@ impl Isis {
 
         let (tx, rx) = mpsc::unbounded_channel();
         let (bfd_event_tx, bfd_event_rx) = mpsc::unbounded_channel();
+        let (stamp_event_tx, stamp_event_rx) = mpsc::unbounded_channel();
         let mut isis =
             Self {
                 tx,
@@ -710,10 +725,13 @@ impl Isis {
                 srlg_config: SrlgGroupBuilder::new(),
                 srlg_groups: BTreeMap::new(),
                 bfd_client_tx,
+                stamp_client_tx,
                 bgp_tx,
                 bgp_ls_advertised: std::collections::BTreeMap::new(),
                 bfd_event_tx,
                 bfd_event_rx,
+                stamp_event_tx,
+                stamp_event_rx,
                 key_chains: BTreeMap::new(),
                 policy_tx,
                 policy_rx: policy_chan.rx,
@@ -751,6 +769,11 @@ impl Isis {
         if msg.op == ConfigOp::CommitEnd {
             self.vrf_commit_end();
             self.commit_srlg();
+            // Reconcile STAMP measurement sessions against the
+            // just-committed config — one robust hook covers every
+            // config path that can flip a session (measurement
+            // enable/interval, network-type, afi enable, ...).
+            self.stamp_reconcile_all();
             // Reconcile the local Prefix-SID ILM against the just-committed
             // config. This is what withdraws the pop entry when
             // `prefix-sid` / `segment-routing mpls` is removed or
@@ -1843,6 +1866,9 @@ impl Isis {
             Message::BfdUnsubscribe(key) => {
                 self.process_bfd_unsubscribe(key);
             }
+            Message::StampReconcile(ifindex) => {
+                self.stamp_reconcile_link(ifindex);
+            }
             Message::GrRestartExit => {
                 // Drain window elapsed. The supervisor (systemd /
                 // operator) is trusted to restart us. Kernel routes
@@ -1994,6 +2020,148 @@ impl Isis {
             client: "isis".to_string(),
             key,
         });
+    }
+
+    /// Re-evaluate the STAMP measurement session for every interface —
+    /// the `ConfigOp::CommitEnd` hook, so any committed change that can
+    /// flip a session (measurement enable/interval, network-type, afi
+    /// enable, ...) is reconciled without per-callback wiring.
+    pub(crate) fn stamp_reconcile_all(&mut self) {
+        if self.stamp_client_tx.is_none() {
+            return;
+        }
+        let ifindexes: Vec<u32> = self.links.iter().map(|(ifindex, _)| *ifindex).collect();
+        for ifindex in ifindexes {
+            self.stamp_reconcile_link(ifindex);
+        }
+    }
+
+    /// Diff the measurement session this link *should* hold (config
+    /// enabled ∧ P2P circuit ∧ an Up adjacency ∧ an IPv4 address pair)
+    /// against the tracked subscription, and (un)subscribe on the
+    /// edges only. Tearing a session down also clears the link's
+    /// measured values — they must not survive into the next adjacency
+    /// (or stay advertised after a disable) — and re-originates.
+    pub(crate) fn stamp_reconcile_link(&mut self, ifindex: u32) {
+        if self.stamp_client_tx.is_none() {
+            return;
+        }
+        let Some(link) = self.links.get(&ifindex) else {
+            return;
+        };
+
+        // Desired session for the current config + adjacency state.
+        // Same v4 selection as `bfd_reconcile_all`: first interface
+        // address × first address of the first Up neighbor (P2P has at
+        // most one neighbor per level).
+        let desired = if link.config.te_metric_measurement.enabled() && link.is_p2p() {
+            let local_v4 = link.state.v4addr.first().map(|p| p.addr());
+            let remote_v4 = [Level::L1, Level::L2].iter().find_map(|level| {
+                link.state
+                    .nbrs
+                    .get(level)
+                    .values()
+                    .find(|nbr| nbr.state == NfsmState::Up)
+                    .and_then(|nbr| nbr.addr4.keys().next().copied())
+            });
+            match (local_v4, remote_v4) {
+                (Some(local), Some(remote)) => Some((
+                    crate::stamp::session::SessionKey {
+                        local: std::net::IpAddr::V4(local),
+                        remote: std::net::IpAddr::V4(remote),
+                        ifindex,
+                    },
+                    link.config.te_metric_measurement.resolve(),
+                )),
+                _ => None,
+            }
+        } else {
+            None
+        };
+
+        if desired == link.state.stamp_session {
+            return;
+        }
+        let stale = link.state.stamp_session;
+        if let Some((key, _)) = stale {
+            self.stamp_unsubscribe(key);
+        }
+        if let Some((key, params)) = desired {
+            self.stamp_subscribe(key, params);
+        }
+        let Some(link) = self.links.get_mut(&ifindex) else {
+            return;
+        };
+        link.state.stamp_session = desired;
+        // A torn-down session's measured values are stale the moment
+        // the subscription ends — clear and re-advertise (static
+        // config, if any, takes back over via `te_metric_effective`).
+        if stale.is_some() && link.state.measured_te_metric != super::link::LinkTeMetric::default()
+        {
+            link.state.measured_te_metric = super::link::LinkTeMetric::default();
+            let _ = self.tx.send(Message::LspOriginate(Level::L1, None));
+            let _ = self.tx.send(Message::LspOriginate(Level::L2, None));
+        }
+    }
+
+    fn stamp_subscribe(
+        &self,
+        key: crate::stamp::session::SessionKey,
+        params: crate::stamp::session::SessionParams,
+    ) {
+        let Some(tx) = self.stamp_client_tx.as_ref() else {
+            return;
+        };
+        let _ = tx.send(crate::stamp::client::ClientReq::Subscribe {
+            client: self.proto_label.clone(),
+            key,
+            params,
+            notifier: self.stamp_event_tx.clone(),
+        });
+    }
+
+    fn stamp_unsubscribe(&self, key: crate::stamp::session::SessionKey) {
+        let Some(tx) = self.stamp_client_tx.as_ref() else {
+            return;
+        };
+        let _ = tx.send(crate::stamp::client::ClientReq::Unsubscribe {
+            client: self.proto_label.clone(),
+            key,
+        });
+    }
+
+    /// A damped STAMP export arrived: store the measured values on the
+    /// link and re-originate so the RFC 8570 sub-TLVs (and flex-algo
+    /// metric-type-1 SPF inputs) reflect them. A `None` snapshot
+    /// clears — the sub-TLVs are withdrawn unless static config backs
+    /// them ([`super::link::IsisLink::te_metric_effective`]).
+    pub(crate) fn process_stamp_event(&mut self, event: crate::stamp::client::StampEvent) {
+        let crate::stamp::client::StampEvent::MetricUpdate { key, snapshot } = event;
+        let Some(link) = self.links.get_mut(&key.ifindex) else {
+            return;
+        };
+        // Only the tracked session may write — a late event from a
+        // just-unsubscribed key must not resurrect stale values.
+        if link.state.stamp_session.map(|(k, _)| k) != Some(key) {
+            return;
+        }
+        link.state.measured_te_metric = match snapshot {
+            Some(snap) => super::link::LinkTeMetric {
+                unidirectional_delay: Some(snap.avg),
+                min_delay: Some(snap.min),
+                max_delay: Some(snap.max),
+                delay_variation: Some(snap.variation),
+                loss: None,
+            },
+            None => super::link::LinkTeMetric::default(),
+        };
+        tracing::info!(
+            ifindex = key.ifindex,
+            ?snapshot,
+            "isis: stamp metric update applied"
+        );
+        let _ = self.tx.send(Message::LspOriginate(Level::L1, None));
+        let _ = self.tx.send(Message::LspOriginate(Level::L2, None));
     }
 
     fn process_lsp_originate(&mut self, level: Level, seq_floor: Option<u32>) {
@@ -2339,6 +2507,9 @@ impl Isis {
                 }
                 Some(event) = self.bfd_event_rx.recv() => {
                     self.process_bfd_event(event);
+                }
+                Some(event) = self.stamp_event_rx.recv() => {
+                    self.process_stamp_event(event);
                 }
                 Some(msg) = self.policy_rx.recv() => {
                     self.process_policy_msg(msg);
@@ -2990,6 +3161,12 @@ pub enum Message {
     /// the interface had `bfd { enable }` removed; release the BFD
     /// session by sending `ClientReq::Unsubscribe`.
     BfdUnsubscribe(crate::bfd::session::SessionKey),
+    /// Something that can flip this interface's STAMP measurement
+    /// session changed at runtime (an NFSM transition to/from Up,
+    /// adjacency teardown). The handler re-runs
+    /// [`Isis::stamp_reconcile_link`]; config-driven changes go
+    /// through the `CommitEnd` `stamp_reconcile_all` instead.
+    StampReconcile(u32),
 }
 
 impl Display for Message {
@@ -3031,6 +3208,9 @@ impl Display for Message {
             }
             Message::BfdUnsubscribe(key) => {
                 write!(f, "[Message::BfdUnsubscribe({:?})]", key.remote)
+            }
+            Message::StampReconcile(ifindex) => {
+                write!(f, "[Message::StampReconcile({})]", ifindex)
             }
             Message::LspSeqWrapClear(level, frag_id) => {
                 write!(f, "[Message::LspSeqWrapClear({}, frag={})]", level, frag_id)
@@ -3112,6 +3292,7 @@ mod bfd_wiring_tests {
             ctx,
             rib_rx,
             Some(bfd_client_tx),
+            /* stamp_client_tx */ None,
             None,
             policy_tx,
             "isis".to_string(),
@@ -3167,6 +3348,7 @@ mod bfd_wiring_tests {
             ctx,
             rib_rx,
             None,
+            /* stamp_client_tx */ None,
             None,
             policy_tx,
             "isis".to_string(),

--- a/zebra-rs/src/isis/link.rs
+++ b/zebra-rs/src/isis/link.rs
@@ -302,10 +302,18 @@ pub struct LinkConfig {
     /// Statically configured RFC 8570 TE link metrics (unidirectional
     /// delay, min/max delay, delay variation, link loss) for this link,
     /// from /router/isis/interface/<name>/te-metric. Emitted as
-    /// sub-TLVs on the link's Extended IS Reachability entry. A future
-    /// performance-measurement (TWAMP/STAMP) task will populate the
-    /// same fields dynamically.
+    /// sub-TLVs on the link's Extended IS Reachability entry. Merged
+    /// with the measured values (static wins per field) by
+    /// [`IsisLink::te_metric_effective`].
     pub te_metric: LinkTeMetric,
+
+    /// STAMP measurement config for this link, from
+    /// /router/isis/interface/<name>/te-metric/measurement. When
+    /// enabled (and the circuit is P2P with an Up adjacency carrying a
+    /// v4 pair), `Isis::stamp_reconcile_link` keeps a measurement
+    /// session subscribed; its damped exports land in
+    /// `LinkState::measured_te_metric`.
+    pub te_metric_measurement: crate::stamp::session::MeasurementConfig,
 
     /// Per-Flex-Algorithm Prefix-SID for this link's IPv4 address(es).
     /// Populated from
@@ -439,6 +447,19 @@ impl LinkTeMetric {
             }));
         }
         subs
+    }
+
+    /// Per-field merge of `self` (static config) over `fallback`
+    /// (measured values): a configured field always wins, an
+    /// unconfigured one takes the measurement.
+    pub fn merged_over(&self, fallback: &LinkTeMetric) -> LinkTeMetric {
+        LinkTeMetric {
+            unidirectional_delay: self.unidirectional_delay.or(fallback.unidirectional_delay),
+            min_delay: self.min_delay.or(fallback.min_delay),
+            max_delay: self.max_delay.or(fallback.max_delay),
+            delay_variation: self.delay_variation.or(fallback.delay_variation),
+            loss: self.loss.or(fallback.loss),
+        }
     }
 }
 
@@ -657,6 +678,20 @@ pub struct LinkState {
 
     // TODO: need to fix.
     pub hello: Levels<Option<IsisPdu>>,
+
+    /// Last STAMP measurement exported for this link (all fields
+    /// `None` when no measurement is active or the last export was a
+    /// clear). Merged under the static config per field by
+    /// [`IsisLink::te_metric_effective`].
+    pub measured_te_metric: LinkTeMetric,
+
+    /// The STAMP subscription this link currently holds, tracked so
+    /// `Isis::stamp_reconcile_link` can diff desired-vs-actual and
+    /// only (un)subscribe on a real change.
+    pub stamp_session: Option<(
+        crate::stamp::session::SessionKey,
+        crate::stamp::session::SessionParams,
+    )>,
 }
 
 impl LinkState {
@@ -724,6 +759,26 @@ impl IsisLink {
         });
 
         Ok(is_link)
+    }
+
+    /// Same circuit-type resolution as [`LinkTop::is_p2p`]: explicit
+    /// `network-type` config wins, otherwise the kernel POINTOPOINT
+    /// interface flag decides.
+    pub fn is_p2p(&self) -> bool {
+        if let Some(network_type) = self.config.network_type {
+            return network_type == NetworkType::P2p;
+        }
+        (self.flags & LinkFlags::Pointopoint) == LinkFlags::Pointopoint
+    }
+
+    /// The TE metrics this link advertises: statically configured
+    /// values win over measured ones, per field — an operator override
+    /// never gets clobbered by measurement, while unconfigured fields
+    /// track the live measurement (or fall silent when it clears).
+    pub fn te_metric_effective(&self) -> LinkTeMetric {
+        self.config
+            .te_metric
+            .merged_over(&self.state.measured_te_metric)
     }
 }
 
@@ -1305,6 +1360,51 @@ pub fn config_te_delay_variation(isis: &mut Isis, args: Args, op: ConfigOp) -> O
 
 pub fn config_te_loss(isis: &mut Isis, args: Args, op: ConfigOp) -> Option<()> {
     config_te_metric(isis, args, op, |t, v| t.loss = v)
+}
+
+// `/router/isis/interface/<ifname>/te-metric/measurement/*` — the
+// STAMP measurement block. Callbacks only mutate the config mirror;
+// the session itself is reconciled by `Isis::stamp_reconcile_all` on
+// `ConfigOp::CommitEnd` (one robust hook covers enable flips, interval
+// changes, and every other config path that can affect a session —
+// network-type, afi enable, ...). The disable path's measured-value
+// clear + re-origination also lives in the reconcile.
+fn config_te_measurement(
+    isis: &mut Isis,
+    mut args: Args,
+    set: impl FnOnce(&mut crate::stamp::session::MeasurementConfig, &mut Args) -> Option<()>,
+) -> Option<()> {
+    let ifname = args.string()?;
+    let link = isis.links.get_mut_by_name(&ifname)?;
+    set(&mut link.config.te_metric_measurement, &mut args)
+}
+
+pub fn config_te_measurement_enable(isis: &mut Isis, args: Args, op: ConfigOp) -> Option<()> {
+    config_te_measurement(isis, args, |m, args| {
+        let value = args.boolean()?;
+        m.enable = op.is_set().then_some(value);
+        Some(())
+    })
+}
+
+pub fn config_te_measurement_interval(isis: &mut Isis, args: Args, op: ConfigOp) -> Option<()> {
+    config_te_measurement(isis, args, |m, args| {
+        let value = args.u32()?;
+        m.interval_ms = op.is_set().then_some(value);
+        Some(())
+    })
+}
+
+pub fn config_te_measurement_damping_period(
+    isis: &mut Isis,
+    args: Args,
+    op: ConfigOp,
+) -> Option<()> {
+    config_te_measurement(isis, args, |m, args| {
+        let value = args.u32()?;
+        m.damping_period_secs = op.is_set().then_some(value);
+        Some(())
+    })
 }
 
 pub fn config_metric(isis: &mut Isis, mut args: Args, op: ConfigOp) -> Option<()> {
@@ -2465,5 +2565,41 @@ mod te_metric_tests {
     fn default_is_empty() {
         assert!(LinkTeMetric::default().sub_tlvs().is_empty());
         assert_eq!(LinkConfig::default().te_metric, LinkTeMetric::default());
+    }
+
+    /// `merged_over` (the [`IsisLink::te_metric_effective`] core):
+    /// static config wins per field, measured fills the gaps, and a
+    /// cleared measurement leaves only the static fields.
+    #[test]
+    fn merged_over_static_wins_measured_fills() {
+        let config = LinkTeMetric {
+            min_delay: Some(500), // operator override
+            loss: Some(3),
+            ..Default::default()
+        };
+        let measured = LinkTeMetric {
+            unidirectional_delay: Some(120),
+            min_delay: Some(100),
+            max_delay: Some(150),
+            delay_variation: Some(10),
+            loss: None,
+        };
+        let effective = config.merged_over(&measured);
+        assert_eq!(effective.min_delay, Some(500), "config wins");
+        assert_eq!(effective.unidirectional_delay, Some(120), "measured fills");
+        assert_eq!(effective.max_delay, Some(150));
+        assert_eq!(effective.delay_variation, Some(10));
+        assert_eq!(effective.loss, Some(3));
+
+        // Measurement cleared (D8): only static fields remain.
+        let effective = config.merged_over(&LinkTeMetric::default());
+        assert_eq!(
+            effective,
+            LinkTeMetric {
+                min_delay: Some(500),
+                loss: Some(3),
+                ..Default::default()
+            }
+        );
     }
 }

--- a/zebra-rs/src/isis/lsp.rs
+++ b/zebra-rs/src/isis/lsp.rs
@@ -811,20 +811,21 @@ pub fn lsp_generate(top: &mut IsisTop, level: Level, seq_floor: Option<u32>) -> 
         // path computation. Receivers intersect the bitmap with any
         // FAD's include-any/include-all/exclude-any constraint and read
         // the delay metrics for metric-type-1 SPF (RFC 9350 §6.3). Only
-        // emitted when affinity or a TE metric is present.
+        // emitted when affinity or a TE metric is present. The metrics
+        // are the static-over-measured merge: STAMP measurement fills
+        // any field the operator left unconfigured.
+        let te_metric = link.te_metric_effective();
         if let Some(asla) = super::flex_algo::build_link_asla(
             &link.config.affinity,
             top.affinity_map,
-            link.config.te_metric.sub_tlvs(),
+            te_metric.sub_tlvs(),
         ) {
             is_reach.subs.push(neigh::IsisSubTlv::Asla(asla));
         }
         // Per-link RFC 8570 TE metrics (unidirectional / min-max delay,
         // delay variation, link loss), also advertised inline for
-        // general TE visibility (non-flex-algo consumers). Statically
-        // configured today; a TWAMP/STAMP measurement task will feed
-        // these dynamically in a later phase.
-        is_reach.subs.extend(link.config.te_metric.sub_tlvs());
+        // general TE visibility (non-flex-algo consumers).
+        is_reach.subs.extend(te_metric.sub_tlvs());
         // Neighbor
         for (_, nbr) in link.state.nbrs.get(&level).iter() {
             for (_key, value) in nbr.addr4.iter() {
@@ -1005,18 +1006,20 @@ pub fn lsp_generate(top: &mut IsisTop, level: Level, seq_floor: Option<u32>) -> 
             };
             // Per-link ASLA carries the same affinity bitmap and TE
             // metrics on the MT IS-reach entry as on the legacy TLV 22
-            // entry — both are MT-agnostic in the YANG model.
+            // entry — both are MT-agnostic in the YANG model. Same
+            // static-over-measured merge as TLV 22.
+            let te_metric = link.te_metric_effective();
             if let Some(asla) = super::flex_algo::build_link_asla(
                 &link.config.affinity,
                 top.affinity_map,
-                link.config.te_metric.sub_tlvs(),
+                te_metric.sub_tlvs(),
             ) {
                 entry.subs.push(neigh::IsisSubTlv::Asla(asla));
             }
             // Same RFC 8570 TE metrics as the legacy TLV 22 entry above,
             // also advertised inline for general TE visibility — link
             // delay/loss are MT-agnostic physical properties.
-            entry.subs.extend(link.config.te_metric.sub_tlvs());
+            entry.subs.extend(te_metric.sub_tlvs());
             for (_, nbr) in link.state.nbrs.get(&level).iter() {
                 if let Some((_, sid_addr)) = nbr.endx_sid {
                     if nbr.network_type.is_p2p() {

--- a/zebra-rs/src/isis/nfsm.rs
+++ b/zebra-rs/src/isis/nfsm.rs
@@ -142,5 +142,12 @@ pub fn nbr_hold_timer_expire(
         let _ = link.tx.send(Message::BfdUnsubscribe(key));
     }
 
+    // The Up adjacency is gone — let the STAMP reconcile see the
+    // removed neighbor and release the measurement session (diff-gated
+    // no-op when none exists).
+    if was_up {
+        let _ = link.tx.send(Message::StampReconcile(link.ifindex));
+    }
+
     spf_schedule(link, level);
 }

--- a/zebra-rs/src/isis/packet.rs
+++ b/zebra-rs/src/isis/packet.rs
@@ -102,6 +102,18 @@ fn bfd_nfsm_dispatch(
     }
 }
 
+/// Kick the STAMP measurement reconcile on any NFSM transition that
+/// crosses the Up boundary — the session's existence is gated on an Up
+/// adjacency (the remote address comes from it, and probing a
+/// non-adjacent peer is pointless). The reconcile itself
+/// (`Isis::stamp_reconcile_link`) diffs desired-vs-tracked, so firing
+/// it is cheap and needs no enable gate here.
+fn stamp_nfsm_dispatch(link: &super::link::LinkTop<'_>, was_up: bool, state: NfsmState) {
+    if was_up != (state == NfsmState::Up) {
+        let _ = link.tx.send(Message::StampReconcile(link.ifindex));
+    }
+}
+
 use super::Level;
 use super::flood;
 use super::ifsm::has_level;
@@ -582,6 +594,7 @@ pub fn hello_recv(link: &mut LinkTop, level: Level, pdu: IsisHello, mac: Option<
     // RFC 5882 §5 BFD attachment, post-FSM. nbr has been dropped so
     // we can read link.state.v4addr / link.config.bfd freely.
     bfd_nfsm_dispatch(link, bfd_peer_v4, bfd_peer_v6ll, was_up, state);
+    stamp_nfsm_dispatch(link, was_up, state);
 
     // CSNP + SRM kick on first RR. Deferred to here so we can take
     // `&mut link` after the `nbr` borrow has expired.
@@ -805,6 +818,7 @@ pub fn hello_p2p_recv(link: &mut LinkTop, pdu: IsisP2pHello, mac: Option<MacAddr
         // borrow is gone so we can read link.state / link.config
         // freely.
         bfd_nfsm_dispatch(link, bfd_peer_v4, bfd_peer_v6ll, was_up, state);
+        stamp_nfsm_dispatch(link, was_up, state);
 
         // CSNP+SRM kick on first RR. P2P always wins the
         // helper_elected_for_csnp predicate, so this fires every

--- a/zebra-rs/src/isis/vrf.rs
+++ b/zebra-rs/src/isis/vrf.rs
@@ -109,6 +109,7 @@ pub fn spawn_isis_vrf(
         ctx,
         rib_rx,
         /* bfd_client_tx */ None,
+        /* stamp_client_tx (default-VRF only in Phase 1) */ None,
         /* bgp_tx */ None,
         policy_tx.clone(),
         proto.clone(),

--- a/zebra-rs/src/main.rs
+++ b/zebra-rs/src/main.rs
@@ -24,6 +24,7 @@ use rib::{LogFormatType, LogOutputType, Rib, logging_config, tracing_set};
 mod ospf;
 mod spf;
 mod srv6;
+mod stamp;
 mod version;
 
 #[derive(Parser)]

--- a/zebra-rs/src/ospf/config.rs
+++ b/zebra-rs/src/ospf/config.rs
@@ -128,6 +128,21 @@ impl Ospf {
             "/area/interface/te-metric/loss",
             config_ospf_interface_te_loss,
         );
+        // STAMP measurement block — v2 only (this `callback_build` is
+        // `impl Ospf<Ospfv2>`; `config_v3.rs` registers nothing here,
+        // so the v3 instance never enables measurement).
+        self.ospf_add(
+            "/area/interface/te-metric/measurement/enable",
+            config_ospf_interface_te_measurement_enable,
+        );
+        self.ospf_add(
+            "/area/interface/te-metric/measurement/interval",
+            config_ospf_interface_te_measurement_interval,
+        );
+        self.ospf_add(
+            "/area/interface/te-metric/measurement/damping-period",
+            config_ospf_interface_te_measurement_damping_period,
+        );
         self.ospf_add(
             "/area/interface/hello-interval",
             config_ospf_interface_hello_interval,
@@ -747,6 +762,61 @@ fn config_ospf_interface_te_delay_variation(
 
 fn config_ospf_interface_te_loss(ospf: &mut Ospf, args: Args, op: ConfigOp) -> Option<()> {
     config_ospf_interface_te_metric(ospf, args, op, |m, v| m.loss = v)
+}
+
+// `/router/ospf/area/interface/te-metric/measurement/*` — the STAMP
+// measurement block. Each leaf updates the config mirror and re-runs
+// the session reconcile, which (un)subscribes on real changes and —
+// on a teardown — clears the measured values and refreshes the
+// Extended-Link LSA.
+fn config_ospf_interface_te_measurement(
+    ospf: &mut Ospf,
+    mut args: Args,
+    set: impl FnOnce(&mut crate::stamp::session::MeasurementConfig, &mut Args) -> Option<()>,
+) -> Option<()> {
+    let _area_id = parse_area_id(&args.string()?)?;
+    let name = args.string()?;
+    let link = ospf_link_get_mut_by_name(&mut ospf.links, &name)?;
+    let ifindex = link.index;
+    set(&mut link.config.te_metric_measurement, &mut args)?;
+    ospf.stamp_reconcile_and_originate(ifindex);
+    Some(())
+}
+
+fn config_ospf_interface_te_measurement_enable(
+    ospf: &mut Ospf,
+    args: Args,
+    op: ConfigOp,
+) -> Option<()> {
+    config_ospf_interface_te_measurement(ospf, args, |m, args| {
+        let value = args.boolean()?;
+        m.enable = op.is_set().then_some(value);
+        Some(())
+    })
+}
+
+fn config_ospf_interface_te_measurement_interval(
+    ospf: &mut Ospf,
+    args: Args,
+    op: ConfigOp,
+) -> Option<()> {
+    config_ospf_interface_te_measurement(ospf, args, |m, args| {
+        let value = args.u32()?;
+        m.interval_ms = op.is_set().then_some(value);
+        Some(())
+    })
+}
+
+fn config_ospf_interface_te_measurement_damping_period(
+    ospf: &mut Ospf,
+    args: Args,
+    op: ConfigOp,
+) -> Option<()> {
+    config_ospf_interface_te_measurement(ospf, args, |m, args| {
+        let value = args.u32()?;
+        m.damping_period_secs = op.is_set().then_some(value);
+        Some(())
+    })
 }
 
 fn config_ospf_interface_hello_interval(

--- a/zebra-rs/src/ospf/inst.rs
+++ b/zebra-rs/src/ospf/inst.rs
@@ -349,6 +349,20 @@ pub struct Ospf<V: OspfVersion = Ospfv2> {
     /// the event loop into [`Ospf::process_bfd_event`].
     pub bfd_event_tx: UnboundedSender<crate::bfd::inst::BfdEvent>,
     pub bfd_event_rx: UnboundedReceiver<crate::bfd::inst::BfdEvent>,
+
+    /// STAMP client handle, captured at spawn (STAMP is eager-spawned
+    /// before OSPF). Used by [`Ospf::stamp_reconcile_link`] to
+    /// (un)subscribe per-link measurement sessions for `te-metric
+    /// measurement` interfaces. `None` for per-VRF children (sessions
+    /// are default-VRF only in Phase 1) or if STAMP failed to start.
+    /// Only v2 ever subscribes — the v3 config tree has no
+    /// measurement block.
+    pub stamp_client_tx: Option<UnboundedSender<crate::stamp::client::ClientReq>>,
+    /// Notifier STAMP fans `MetricUpdate`s back on; cloned into every
+    /// Subscribe. The receiver is drained by the v2 event loop into
+    /// [`Ospf::process_stamp_event`].
+    pub stamp_event_tx: UnboundedSender<crate::stamp::client::StampEvent>,
+    pub stamp_event_rx: UnboundedReceiver<crate::stamp::client::StampEvent>,
 }
 
 // OSPF inteface structure which points out upper layer struct members.
@@ -561,6 +575,114 @@ impl<V: OspfVersion> Ospf<V> {
         for nbr_addr in nbrs {
             self.bfd_reconcile_nbr(ifindex, nbr_addr);
         }
+    }
+
+    /// Diff the STAMP measurement session this link *should* hold
+    /// (measurement enabled ∧ point-to-point ∧ a Full neighbor ∧ an
+    /// IPv4 address pair — `V::bfd_addrs` yields link-locals on v3, so
+    /// the v4 gate keeps v3 inert on top of it having no measurement
+    /// YANG) against the tracked subscription, and (un)subscribe on
+    /// the edges only. Tearing a session down also clears the link's
+    /// measured values — they must not survive into the next adjacency
+    /// or outlive a disable. Returns `true` when measured values were
+    /// cleared, so the (version-specific) caller re-originates the
+    /// Extended-Link LSA.
+    pub(crate) fn stamp_reconcile_link(&mut self, ifindex: u32) -> bool {
+        if self.stamp_client_tx.is_none() {
+            return false;
+        }
+        let Some(link) = self.links.get(&ifindex) else {
+            return false;
+        };
+
+        let desired = if link.config.te_metric_measurement.enabled()
+            && link.network_type == super::link::OspfNetworkType::PointToPoint
+        {
+            link.nbrs
+                .values()
+                .find(|n| n.state == NfsmState::Full)
+                .and_then(|nbr| V::bfd_addrs(&link.addr, nbr))
+                .and_then(|(local, remote)| match (local, remote) {
+                    (std::net::IpAddr::V4(_), std::net::IpAddr::V4(_)) => Some((
+                        crate::stamp::session::SessionKey {
+                            local,
+                            remote,
+                            ifindex,
+                        },
+                        link.config.te_metric_measurement.resolve(),
+                    )),
+                    _ => None,
+                })
+        } else {
+            None
+        };
+
+        if desired == link.stamp_session {
+            return false;
+        }
+        let stale = link.stamp_session;
+        let Some(client_tx) = self.stamp_client_tx.as_ref() else {
+            return false;
+        };
+        if let Some((key, _)) = stale {
+            let _ = client_tx.send(crate::stamp::client::ClientReq::Unsubscribe {
+                client: V::PROTO.to_string(),
+                key,
+            });
+        }
+        if let Some((key, params)) = desired {
+            let _ = client_tx.send(crate::stamp::client::ClientReq::Subscribe {
+                client: V::PROTO.to_string(),
+                key,
+                params,
+                notifier: self.stamp_event_tx.clone(),
+            });
+        }
+        let Some(link) = self.links.get_mut(&ifindex) else {
+            return false;
+        };
+        link.stamp_session = desired;
+        // A torn-down session's measured values are stale the moment
+        // the subscription ends — clear them; static config (if any)
+        // takes back over via `te_metric_effective`.
+        if stale.is_some() && link.measured_te_metric != super::link::LinkTeMetric::default() {
+            link.measured_te_metric = super::link::LinkTeMetric::default();
+            return true;
+        }
+        false
+    }
+
+    /// Store a damped STAMP export on its link. Returns the ifindex
+    /// when the link's measured values changed (the version-specific
+    /// caller re-originates), `None` for stale/unknown sessions.
+    pub(crate) fn stamp_apply_metric_update(
+        &mut self,
+        event: crate::stamp::client::StampEvent,
+    ) -> Option<u32> {
+        let crate::stamp::client::StampEvent::MetricUpdate { key, snapshot } = event;
+        let link = self.links.get_mut(&key.ifindex)?;
+        // Only the tracked session may write — a late event from a
+        // just-unsubscribed key must not resurrect stale values.
+        if link.stamp_session.map(|(k, _)| k) != Some(key) {
+            return None;
+        }
+        link.measured_te_metric = match snapshot {
+            Some(snap) => super::link::LinkTeMetric {
+                unidirectional_delay: Some(snap.avg),
+                min_delay: Some(snap.min),
+                max_delay: Some(snap.max),
+                delay_variation: Some(snap.variation),
+                loss: None,
+            },
+            None => super::link::LinkTeMetric::default(),
+        };
+        tracing::info!(
+            ifindex = key.ifindex,
+            ?snapshot,
+            "{}: stamp metric update applied",
+            V::PROTO,
+        );
+        Some(key.ifindex)
     }
 
     /// React to a BFD session state change. On Down, tear the matching
@@ -1020,9 +1142,11 @@ impl Ospf<Ospfv2> {
         rib_subscriber: RibSubscriber,
         config_tx: tokio::sync::mpsc::Sender<crate::config::Message>,
         bfd_client_tx: Option<UnboundedSender<crate::bfd::inst::ClientReq>>,
+        stamp_client_tx: Option<UnboundedSender<crate::stamp::client::ClientReq>>,
     ) -> Self {
         let sock = Arc::new(AsyncFd::new(ospf_socket_ipv4(&ctx).unwrap()).unwrap());
         let (bfd_event_tx, bfd_event_rx) = mpsc::unbounded_channel();
+        let (stamp_event_tx, stamp_event_rx) = mpsc::unbounded_channel();
 
         let policy_chan = crate::policy::PolicyRxChannel::new();
         let _ = policy_tx.send(crate::policy::Message::Subscribe {
@@ -1110,6 +1234,9 @@ impl Ospf<Ospfv2> {
             bfd_client_tx,
             bfd_event_tx,
             bfd_event_rx,
+            stamp_client_tx,
+            stamp_event_tx,
+            stamp_event_rx,
         };
         ospf.callback_build();
         ospf.show_build();
@@ -1973,15 +2100,17 @@ impl Ospf<Ospfv2> {
         {
             let our_addr = addr.prefix.addr();
             // Per-link ASLA carrying this link's flex-algo affinity
-            // (RFC 9492 / RFC 9350 §6.3) and any static RFC 7471 TE
-            // metrics, independent of Adj-SID: a link with affinity or
-            // TE metrics but no Adj-SID still originates an Extended-Link
+            // (RFC 9492 / RFC 9350 §6.3) and the RFC 7471 TE metrics,
+            // independent of Adj-SID: a link with affinity or TE
+            // metrics but no Adj-SID still originates an Extended-Link
             // LSA so peers can run the FAD constraints / read the
-            // metrics.
+            // metrics. The metrics are the static-over-measured merge:
+            // STAMP measurement fills any field the operator left
+            // unconfigured.
             let asla = super::flex_algo::build_link_asla(
                 &link.config.affinity,
                 &self.affinity_map,
-                link.config.te_metric.asla_sub_subs(),
+                link.te_metric_effective().asla_sub_subs(),
             );
             match link.network_type {
                 OspfNetworkType::PointToPoint => {
@@ -3505,6 +3634,31 @@ impl Ospf<Ospfv2> {
                 .tx
                 .send(Message::Ifsm(ifindex, IfsmEvent::NeighborChange));
         }
+
+        // The Full neighbor (if it was one) is gone — release the STAMP
+        // measurement session (diff-gated no-op when none exists).
+        self.stamp_reconcile_and_originate(ifindex);
+    }
+
+    /// v2 wrapper around the generic [`Self::stamp_reconcile_link`]:
+    /// when the reconcile cleared measured values, refresh the
+    /// Extended-Link Opaque LSA so the stale sub-TLVs are withdrawn.
+    pub(crate) fn stamp_reconcile_and_originate(&mut self, ifindex: u32) {
+        if self.stamp_reconcile_link(ifindex) {
+            self.ext_link_lsa_originate(ifindex);
+        }
+    }
+
+    /// A damped STAMP export arrived: store the measured values on the
+    /// link and refresh the Extended-Link Opaque LSA so the RFC 7471
+    /// sub-TLVs (and flex-algo metric-type-1 SPF inputs) reflect them.
+    /// A `None` snapshot clears — the sub-TLVs are withdrawn unless
+    /// static config backs them
+    /// ([`super::link::OspfLink::te_metric_effective`]).
+    pub(crate) fn process_stamp_event(&mut self, event: crate::stamp::client::StampEvent) {
+        if let Some(ifindex) = self.stamp_apply_metric_update(event) {
+            self.ext_link_lsa_originate(ifindex);
+        }
     }
 
     /// Grace-period expiry handler (RFC 3623 §3.2 bullet 1).
@@ -4723,6 +4877,10 @@ impl Ospf<Ospfv2> {
                         // threshold (the reconcile reads the now-current
                         // neighbor state, so it covers both 2-Way and Full).
                         self.bfd_reconcile_nbr(index, src);
+                        // Likewise the STAMP measurement session, which is
+                        // gated on a Full neighbor (and tears down the
+                        // moment Full is lost).
+                        self.stamp_reconcile_and_originate(index);
                     }
                 }
             }
@@ -4933,6 +5091,9 @@ impl Ospf<Ospfv2> {
                 Some(event) = self.bfd_event_rx.recv() => {
                     self.process_bfd_event(event);
                 }
+                Some(event) = self.stamp_event_rx.recv() => {
+                    self.process_stamp_event(event);
+                }
             }
         }
     }
@@ -5003,9 +5164,11 @@ impl Ospf<Ospfv3> {
         rib_subscriber: RibSubscriber,
         config_tx: tokio::sync::mpsc::Sender<crate::config::Message>,
         bfd_client_tx: Option<UnboundedSender<crate::bfd::inst::ClientReq>>,
+        stamp_client_tx: Option<UnboundedSender<crate::stamp::client::ClientReq>>,
     ) -> Self {
         let sock = Arc::new(AsyncFd::new(super::socket::ospf_socket_ipv6(&ctx).unwrap()).unwrap());
         let (bfd_event_tx, bfd_event_rx) = mpsc::unbounded_channel();
+        let (stamp_event_tx, stamp_event_rx) = mpsc::unbounded_channel();
 
         let policy_chan = crate::policy::PolicyRxChannel::new();
         let _ = policy_tx.send(crate::policy::Message::Subscribe {
@@ -5121,6 +5284,9 @@ impl Ospf<Ospfv3> {
             bfd_client_tx,
             bfd_event_tx,
             bfd_event_rx,
+            stamp_client_tx,
+            stamp_event_tx,
+            stamp_event_rx,
         };
         ospf.tracing.proto = Ospfv3::PROTO;
         ospf.callback_build();

--- a/zebra-rs/src/ospf/link.rs
+++ b/zebra-rs/src/ospf/link.rs
@@ -120,9 +120,17 @@ pub struct LinkConfig {
     pub affinity: BTreeSet<String>,
     /// Static RFC 7471 TE link metrics (delay/jitter/loss) advertised in
     /// this link's ASLA sub-TLV on the Extended-Link Opaque LSA. Mirrors
-    /// `isis::LinkConfig::te_metric`; a future TWAMP/STAMP task will
-    /// populate these dynamically.
+    /// `isis::LinkConfig::te_metric`. Merged with the measured values
+    /// (static wins per field) by [`OspfLink::te_metric_effective`].
     pub te_metric: LinkTeMetric,
+    /// STAMP measurement config for this link, from
+    /// `area <a> interface <if> te-metric measurement {}`. When enabled
+    /// (P2P network type, Full neighbor, v4 pair),
+    /// `Ospf::stamp_reconcile_link` keeps a measurement session
+    /// subscribed; its damped exports land in
+    /// `OspfLink::measured_te_metric`. v2-only — the v3 config tree
+    /// has no measurement block, so it stays default (inert) there.
+    pub te_metric_measurement: crate::stamp::session::MeasurementConfig,
     /// Per-interface BFD attachment (zebra-ospf-bfd.yang).
     pub bfd: OspfLinkBfdConfig,
 }
@@ -178,6 +186,20 @@ impl LinkTeMetric {
             }));
         }
         subs
+    }
+
+    /// Per-field merge of `self` (static config) over `fallback`
+    /// (measured values): a configured field always wins, an
+    /// unconfigured one takes the measurement. Mirrors
+    /// `isis::LinkTeMetric::merged_over`.
+    pub fn merged_over(&self, fallback: &LinkTeMetric) -> LinkTeMetric {
+        LinkTeMetric {
+            unidirectional_delay: self.unidirectional_delay.or(fallback.unidirectional_delay),
+            min_delay: self.min_delay.or(fallback.min_delay),
+            max_delay: self.max_delay.or(fallback.max_delay),
+            delay_variation: self.delay_variation.or(fallback.delay_variation),
+            loss: self.loss.or(fallback.loss),
+        }
     }
 }
 
@@ -441,6 +463,18 @@ pub struct OspfLink<V: OspfVersion = Ospfv2> {
     /// (no link-scope LSA types exist in RFC 2328) but the field
     /// stays generic for shape simplicity.
     pub lsdb: super::lsdb::Lsdb<V>,
+    /// Last STAMP measurement exported for this link (all fields
+    /// `None` when no measurement is active or the last export was a
+    /// clear). Merged under the static config per field by
+    /// [`Self::te_metric_effective`]. Only ever populated on v2.
+    pub measured_te_metric: LinkTeMetric,
+    /// The STAMP subscription this link currently holds, tracked so
+    /// `Ospf::stamp_reconcile_link` can diff desired-vs-actual and
+    /// only (un)subscribe on a real change.
+    pub stamp_session: Option<(
+        crate::stamp::session::SessionKey,
+        crate::stamp::session::SessionParams,
+    )>,
 }
 
 #[derive(Default)]
@@ -500,6 +534,8 @@ where
             ls_ack_delayed: Vec::new(),
             interface_id: link.index,
             lsdb: super::lsdb::Lsdb::new(),
+            measured_te_metric: LinkTeMetric::default(),
+            stamp_session: None,
         }
     }
 }
@@ -507,6 +543,14 @@ where
 impl<V: OspfVersion> OspfLink<V> {
     pub fn priority(&self) -> u8 {
         self.config.priority.unwrap_or(OSPF_DEFAULT_PRIORITY)
+    }
+
+    /// The TE metrics this link advertises: statically configured
+    /// values win over measured ones, per field — an operator override
+    /// never gets clobbered by measurement, while unconfigured fields
+    /// track the live measurement (or fall silent when it clears).
+    pub fn te_metric_effective(&self) -> LinkTeMetric {
+        self.config.te_metric.merged_over(&self.measured_te_metric)
     }
 
     pub fn hello_interval(&self) -> u16 {
@@ -794,5 +838,42 @@ mod te_metric_tests {
     #[test]
     fn default_is_empty() {
         assert!(LinkTeMetric::default().asla_sub_subs().is_empty());
+    }
+
+    /// `merged_over` (the [`OspfLink::te_metric_effective`] core):
+    /// static config wins per field, measured fills the gaps, and a
+    /// cleared measurement leaves only the static fields.
+    #[test]
+    fn merged_over_static_wins_measured_fills() {
+        let config = LinkTeMetric {
+            min_delay: Some(500), // operator override
+            loss: Some(3),
+            ..Default::default()
+        };
+        let measured = LinkTeMetric {
+            unidirectional_delay: Some(120),
+            min_delay: Some(100),
+            max_delay: Some(150),
+            delay_variation: Some(10),
+            loss: None,
+        };
+        let effective = config.merged_over(&measured);
+        assert_eq!(effective.min_delay, Some(500), "config wins");
+        assert_eq!(effective.unidirectional_delay, Some(120), "measured fills");
+        assert_eq!(effective.max_delay, Some(150));
+        assert_eq!(effective.delay_variation, Some(10));
+        assert_eq!(effective.loss, Some(3));
+
+        // Measurement cleared (no replies for a period): only static
+        // fields remain.
+        let effective = config.merged_over(&LinkTeMetric::default());
+        assert_eq!(
+            effective,
+            LinkTeMetric {
+                min_delay: Some(500),
+                loss: Some(3),
+                ..Default::default()
+            }
+        );
     }
 }

--- a/zebra-rs/src/ospf/vrf.rs
+++ b/zebra-rs/src/ospf/vrf.rs
@@ -120,6 +120,8 @@ pub fn spawn_ospf_vrf_v2(
         // Per-VRF OSPF BFD is deferred (the BFD instance is default-table
         // only); `None` makes per-interface `bfd` inert in a VRF for now.
         None,
+        // Per-VRF STAMP likewise (sessions are default-VRF only, Phase 1).
+        None,
     );
     let cm_tx = ospf.cm.tx.clone();
     let show_tx = ospf.show.tx.clone();
@@ -148,6 +150,8 @@ pub fn spawn_ospf_vrf_v3(
         rib_subscriber.clone(),
         config_tx.clone(),
         // Per-VRF OSPFv3 BFD deferred (see `spawn_ospf_vrf_v2`).
+        None,
+        // Per-VRF STAMP likewise.
         None,
     );
     let cm_tx = ospf.cm.tx.clone();

--- a/zebra-rs/src/stamp/client.rs
+++ b/zebra-rs/src/stamp/client.rs
@@ -1,0 +1,76 @@
+//! Client API — how the IGPs attach to STAMP sessions.
+//!
+//! Modelled on BFD's client registry: a protocol module obtains the
+//! instance's [`ClientReq`] sender from the ConfigManager at spawn
+//! time and submits `Subscribe` / `Unsubscribe` keyed by
+//! [`SessionKey`]. Sessions are shared — IS-IS and OSPF measuring the
+//! same link drive one prober and both receive every
+//! [`StampEvent::MetricUpdate`]. A `Subscribe` against an existing
+//! session whose params differ retunes the live session
+//! (last-writer-wins; cheaper than a BFD-style Poll Sequence since
+//! nothing is negotiated with the peer).
+
+use tokio::sync::mpsc::{self, UnboundedReceiver, UnboundedSender};
+
+use super::session::{SessionKey, SessionParams};
+use super::stats::MetricSnapshot;
+
+/// Identifier for a STAMP subscriber — conventionally the proto name
+/// ("isis", "ospf").
+pub type ClientId = String;
+
+/// Sender/receiver pair for the inbound client-request channel.
+/// Mirrors [`crate::bfd::inst::ClientReqChannel`].
+#[derive(Debug)]
+pub struct ClientReqChannel {
+    pub tx: UnboundedSender<ClientReq>,
+    pub rx: UnboundedReceiver<ClientReq>,
+}
+
+impl ClientReqChannel {
+    pub fn new() -> Self {
+        let (tx, rx) = mpsc::unbounded_channel();
+        Self { tx, rx }
+    }
+}
+
+impl Default for ClientReqChannel {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// Requests sent to the STAMP instance by protocol modules.
+#[derive(Debug)]
+pub enum ClientReq {
+    /// Register interest in measuring `key`. The first subscriber
+    /// creates the session with `params`; later subscribers reuse it,
+    /// retuning the live probe/export timers when their `params`
+    /// differ (last-writer-wins). `MetricUpdate`s flow to `notifier`
+    /// until the matching `Unsubscribe`; if the session has already
+    /// exported a value, it is mirrored to the new subscriber
+    /// immediately.
+    Subscribe {
+        client: ClientId,
+        key: SessionKey,
+        params: SessionParams,
+        notifier: UnboundedSender<StampEvent>,
+    },
+    /// Drop `client`'s interest in `key`. The last unsubscribe tears
+    /// the session (prober, sockets, read task) down.
+    Unsubscribe { client: ClientId, key: SessionKey },
+}
+
+/// Events emitted to subscribers.
+#[derive(Debug, Clone, Copy)]
+pub enum StampEvent {
+    /// A damped export: the link's measured delay changed enough to
+    /// re-advertise. `None` clears — the measurement went stale (no
+    /// replies for a whole export period); the IGP must withdraw the
+    /// measured sub-TLVs (falling back to static config where present,
+    /// else pruning the link from delay-metric topologies).
+    MetricUpdate {
+        key: SessionKey,
+        snapshot: Option<MetricSnapshot>,
+    },
+}

--- a/zebra-rs/src/stamp/damping.rs
+++ b/zebra-rs/src/stamp/damping.rs
@@ -1,0 +1,143 @@
+//! Export damping — the gate between measured snapshots and IGP
+//! re-origination.
+//!
+//! Every LSP/LSA re-origination floods domain-wide, so a measured
+//! value that wiggles by a few microseconds each period must not be
+//! re-advertised each period. The gate exports when:
+//!
+//!   * this is the first snapshot since (re)start or since a clear, or
+//!   * the window produced no samples but a value stands advertised —
+//!     exported as a **clear** (`None`) so measured values never go
+//!     stale when the peer stops reflecting; the IGP withdraws the
+//!     sub-TLVs and metric-type-1 topologies prune the link
+//!     (RFC 9350 §15), or
+//!   * any field moved by more than `max(old/10, 50 µs)` against the
+//!     last exported snapshot.
+//!
+//! The relative threshold suppresses noise on stable links; the
+//! absolute floor stops sub-500 µs links from re-originating on every
+//! period's worth of scheduler jitter.
+
+use super::stats::MetricSnapshot;
+
+/// Re-export when a field moves by more than `old / THRESHOLD_DIVISOR`.
+const THRESHOLD_DIVISOR: u32 = 10;
+
+/// ... but never require less movement than this many microseconds.
+const THRESHOLD_FLOOR_US: u32 = 50;
+
+/// Last exported snapshot, `None` before the first export or after a
+/// clear. One per session.
+#[derive(Debug, Default)]
+pub struct Damping {
+    last: Option<MetricSnapshot>,
+}
+
+impl Damping {
+    /// Decide whether `new` (the period's snapshot; `None` = empty
+    /// window) must be exported. On `true` the internal comparison
+    /// basis is updated — the caller is expected to actually export.
+    pub fn should_export(&mut self, new: Option<MetricSnapshot>) -> bool {
+        let export = match (&self.last, &new) {
+            (None, None) => false,
+            (None, Some(_)) => true, // first value
+            (Some(_), None) => true, // clear — withdraw stale value
+            (Some(old), Some(new)) => significant(old, new),
+        };
+        if export {
+            self.last = new;
+        }
+        export
+    }
+
+    /// Test-only introspection of the comparison basis (production
+    /// readers use `Session::last_export`, which mirrors it).
+    #[cfg(test)]
+    pub fn last(&self) -> Option<&MetricSnapshot> {
+        self.last.as_ref()
+    }
+}
+
+/// Any field moved by more than `max(old/10, 50 µs)`?
+fn significant(old: &MetricSnapshot, new: &MetricSnapshot) -> bool {
+    moved(old.min, new.min)
+        || moved(old.max, new.max)
+        || moved(old.avg, new.avg)
+        || moved(old.variation, new.variation)
+}
+
+fn moved(old: u32, new: u32) -> bool {
+    let threshold = (old / THRESHOLD_DIVISOR).max(THRESHOLD_FLOOR_US);
+    old.abs_diff(new) > threshold
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn snap(min: u32, max: u32, avg: u32, variation: u32) -> MetricSnapshot {
+        MetricSnapshot {
+            min,
+            max,
+            avg,
+            variation,
+        }
+    }
+
+    #[test]
+    fn first_snapshot_exports() {
+        let mut d = Damping::default();
+        assert!(d.should_export(Some(snap(100, 200, 150, 10))));
+        assert_eq!(d.last().unwrap().min, 100);
+    }
+
+    #[test]
+    fn no_samples_and_nothing_advertised_stays_quiet() {
+        let mut d = Damping::default();
+        assert!(!d.should_export(None));
+        assert!(!d.should_export(None));
+    }
+
+    #[test]
+    fn small_wiggle_suppressed() {
+        let mut d = Damping::default();
+        assert!(d.should_export(Some(snap(1000, 2000, 1500, 100))));
+        // Every field within 10% of the old value — suppressed.
+        assert!(!d.should_export(Some(snap(1050, 2100, 1450, 105))));
+        // The comparison basis is the *exported* snapshot, not the
+        // suppressed one.
+        assert_eq!(d.last().unwrap().min, 1000);
+    }
+
+    #[test]
+    fn floor_suppresses_microsecond_noise_on_fast_links() {
+        let mut d = Damping::default();
+        assert!(d.should_export(Some(snap(20, 40, 30, 5))));
+        // 10% of 20 µs is 2 µs, but the 50 µs floor applies: a move to
+        // 60 µs (Δ40) stays quiet ...
+        assert!(!d.should_export(Some(snap(60, 40, 30, 5))));
+        // ... while a move past the floor (Δ51) fires.
+        assert!(d.should_export(Some(snap(71, 40, 30, 5))));
+    }
+
+    #[test]
+    fn single_field_move_fires() {
+        let mut d = Damping::default();
+        assert!(d.should_export(Some(snap(1000, 2000, 1500, 100))));
+        // Only `max` moves (>10%): export.
+        assert!(d.should_export(Some(snap(1000, 2300, 1500, 100))));
+    }
+
+    #[test]
+    fn empty_window_clears_then_first_export_again() {
+        let mut d = Damping::default();
+        assert!(d.should_export(Some(snap(1000, 2000, 1500, 100))));
+        // Peer stopped reflecting: clear.
+        assert!(d.should_export(None));
+        assert!(d.last().is_none());
+        // Still nothing: quiet.
+        assert!(!d.should_export(None));
+        // Peer back: first-export semantics again.
+        assert!(d.should_export(Some(snap(1010, 2020, 1510, 101))));
+    }
+}

--- a/zebra-rs/src/stamp/inst.rs
+++ b/zebra-rs/src/stamp/inst.rs
@@ -1,0 +1,710 @@
+//! STAMP instance — Session-Sender, implicit Session-Reflector, and
+//! the client-subscription registry.
+//!
+//! One instance per daemon (default VRF), spawned eagerly by the
+//! `router isis` / `router ospf` commit arms so the IGPs can pick up
+//! `stamp_client_tx` at their own spawn time — the same lifecycle as
+//! BFD. The instance owns:
+//!
+//!   * the wildcard reflector socket (`0.0.0.0:862`) with its
+//!     read/write tasks — the **implicit reflector**: a probe is
+//!     answered iff its source is the remote of a registered session
+//!     (measurement enabled on both ends of the link, plan §2);
+//!   * one connected sender socket + reply-read task + prober task per
+//!     session;
+//!   * the per-session subscriber registry fanning damped
+//!     [`StampEvent::MetricUpdate`]s out to the IGPs.
+//!
+//! Delay math (plan D1): `delay = ((T4−T1) − (T3−T2)) / 2` — the
+//! reflector residence term uses only the peer's clock, so the clock
+//! offset between the two systems cancels; no synchronisation is
+//! required. Samples that compute negative or over 10 s (a wall-clock
+//! step mid-probe) are discarded and counted.
+
+use std::collections::{BTreeMap, HashMap};
+use std::net::{IpAddr, Ipv4Addr, SocketAddr, SocketAddrV4};
+use std::sync::Arc;
+
+use stamp_packet::{ErrorEstimate, ReflectorPacket, SenderPacket, StampTimestamp};
+use tokio::io::unix::AsyncFd;
+use tokio::sync::mpsc::{self, UnboundedReceiver, UnboundedSender};
+
+use crate::config::{
+    Args, ConfigChannel, ConfigRequest, DisplayRequest, ShowChannel, path_from_command,
+};
+use crate::context::{ProtoContext, Task};
+
+use super::client::{ClientId, ClientReq, ClientReqChannel, StampEvent};
+use super::network::{ReflectRequest, reflector_read, reflector_write, sender_read};
+use super::reflector::build_reply;
+use super::sender::{ProberCmd, ProberHandle, session_prober};
+use super::session::{Session, SessionKey, SessionParams, SessionTable};
+use super::socket::{stamp_reflector_socket, stamp_sender_socket};
+use super::timestamp::{delta_micros, now_ntp};
+
+/// `show <path>` dispatch handler — mirrors [`crate::bfd::inst::ShowCallback`].
+pub type ShowCallback = fn(&Stamp, Args, bool) -> Result<String, std::fmt::Error>;
+
+/// Discard a computed delay above this (10 s): the wall clock stepped
+/// while the probe was in flight.
+const MAX_PLAUSIBLE_DELAY_US: i64 = 10_000_000;
+
+/// The Error Estimate this implementation advertises (RFC 8762 §4.2.1):
+/// unsynchronised (`S=0`), NTP format (`Z=0`), and the coarsest honest
+/// accuracy claim — `Multiplier` must be non-zero per RFC 4656 §4.1.2.
+pub fn local_error_estimate() -> ErrorEstimate {
+    ErrorEstimate {
+        synced: false,
+        format: stamp_packet::TimestampFormat::Ntp,
+        scale: 0,
+        multiplier: 1,
+    }
+}
+
+/// Reflector-side packet counters for `show stamp statistics`. The
+/// per-source halves live on the matching [`Session`]
+/// (`reflected_count`) so an XDP helper can substitute per-session map
+/// readouts later (offload notes §9b R5).
+#[derive(Debug, Default)]
+pub struct ReflectorStats {
+    /// Parsed probes that reached the event loop.
+    pub rx: u64,
+    /// Probes answered.
+    pub reflected: u64,
+    /// Probes dropped by the implicit allow-list (source is not a
+    /// registered session's remote).
+    pub unauthorized: u64,
+}
+
+#[derive(Debug)]
+pub enum Message {
+    /// A Session-Sender probe arrived on the reflector socket. `rx_ts`
+    /// (T2) was stamped at the socket read; `len` is the UDP payload
+    /// length for RFC 6038 symmetric-size replies.
+    ProbeRecv {
+        probe: SenderPacket,
+        src: SocketAddr,
+        dst: Option<IpAddr>,
+        ifindex: u32,
+        ttl: u8,
+        rx_ts: StampTimestamp,
+        len: usize,
+    },
+    /// A reflected reply arrived on `key`'s connected socket; `t4` was
+    /// stamped at the socket read.
+    ReplyRecv {
+        key: SessionKey,
+        reply: ReflectorPacket,
+        t4: StampTimestamp,
+    },
+    /// Probe transmit timer fired for `key`.
+    TxTick { key: SessionKey },
+    /// Export (damping-period) timer fired for `key`.
+    ExportTick { key: SessionKey },
+}
+
+/// Top-level STAMP instance.
+pub struct Stamp {
+    pub rx: UnboundedReceiver<Message>,
+    /// Socket factory context, kept for per-session sender sockets
+    /// created at subscribe time.
+    ctx: ProtoContext,
+    pub sessions: SessionTable,
+    /// Local address the reflector socket was bound to — tests bind
+    /// ephemeral ports and need to learn the kernel's choice.
+    pub local_addr: SocketAddrV4,
+    /// Config-manager subscription endpoints. STAMP has no own config
+    /// in Phase 1; every commit broadcast is drained (registering as a
+    /// config client also lets the manager see the task is running).
+    pub cm: ConfigChannel,
+    /// `show stamp ...` endpoints, dispatched through [`Self::show_cb`].
+    pub show: ShowChannel,
+    pub show_cb: HashMap<String, ShowCallback>,
+    /// Inbound client request channel — the IGPs send
+    /// [`ClientReq::Subscribe`] / `Unsubscribe` here.
+    pub client_req: ClientReqChannel,
+    subscribers: HashMap<SessionKey, BTreeMap<ClientId, UnboundedSender<StampEvent>>>,
+    main_tx: UnboundedSender<Message>,
+    reflect_tx: UnboundedSender<ReflectRequest>,
+    probers: HashMap<SessionKey, ProberHandle>,
+    pub reflector_stats: ReflectorStats,
+}
+
+impl Stamp {
+    /// Production constructor — binds the reflector to `0.0.0.0:862`.
+    pub fn new(ctx: ProtoContext) -> std::io::Result<Self> {
+        Self::new_with(
+            ctx,
+            SocketAddrV4::new(Ipv4Addr::UNSPECIFIED, stamp_packet::STAMP_UDP_PORT),
+        )
+    }
+
+    /// Explicit constructor letting the caller pick the reflector bind
+    /// address (the integration test runs on a loopback ephemeral
+    /// port and aims a session's `dst_port` at it).
+    pub fn new_with(ctx: ProtoContext, bind: SocketAddrV4) -> std::io::Result<Self> {
+        let sock = stamp_reflector_socket(&ctx, bind)?;
+        let local_addr = sock
+            .local_addr()?
+            .as_socket_ipv4()
+            .ok_or_else(|| std::io::Error::other("bound socket has no IPv4 local address"))?;
+        let sock = Arc::new(AsyncFd::new(sock)?);
+
+        let (main_tx, rx) = mpsc::unbounded_channel::<Message>();
+        let (reflect_tx, reflect_rx) = mpsc::unbounded_channel::<ReflectRequest>();
+
+        let read_sock = sock.clone();
+        let read_tx = main_tx.clone();
+        tokio::spawn(async move {
+            reflector_read(read_sock, read_tx).await;
+        });
+        tokio::spawn(async move {
+            reflector_write(sock, reflect_rx).await;
+        });
+
+        let mut stamp = Self {
+            rx,
+            ctx,
+            sessions: SessionTable::new(),
+            local_addr,
+            cm: ConfigChannel::new(),
+            show: ShowChannel::new(),
+            show_cb: HashMap::new(),
+            client_req: ClientReqChannel::new(),
+            subscribers: HashMap::new(),
+            main_tx,
+            reflect_tx,
+            probers: HashMap::new(),
+            reflector_stats: ReflectorStats::default(),
+        };
+        stamp.show_build();
+        Ok(stamp)
+    }
+
+    /// Clone the inbound client-request sender for distribution to the
+    /// IGPs (published on the ConfigManager by `spawn_stamp`).
+    pub fn client_req_tx(&self) -> UnboundedSender<ClientReq> {
+        self.client_req.tx.clone()
+    }
+
+    /// Apply a [`ClientReq`]. Public so pre-`serve` callers (the
+    /// integration test) can drive the API directly.
+    pub fn process_client_req(&mut self, req: ClientReq) {
+        match req {
+            ClientReq::Subscribe {
+                client,
+                key,
+                params,
+                notifier,
+            } => self.subscribe(client, key, params, notifier),
+            ClientReq::Unsubscribe { client, key } => self.unsubscribe(&client, &key),
+        }
+    }
+
+    /// Add `client` as a subscriber on `key`, creating the session on
+    /// the first subscriber and retuning it on a params change
+    /// (last-writer-wins, plan D11). The current exported value, if
+    /// any, is mirrored to the new subscriber so a late-joining IGP
+    /// advertises without waiting a full damping period.
+    pub fn subscribe(
+        &mut self,
+        client: ClientId,
+        key: SessionKey,
+        params: SessionParams,
+        notifier: UnboundedSender<StampEvent>,
+    ) {
+        if self.sessions.get(&key).is_none() {
+            if let Err(e) = self.add_session(key, params) {
+                tracing::warn!(?key, error = %e, "stamp: cannot create session");
+                // Keep the subscription anyway: unsubscribe stays
+                // symmetric for the IGP, it just never hears updates.
+            }
+        } else {
+            self.update_params(&key, params);
+        }
+        if let Some(session) = self.sessions.get(&key)
+            && session.last_export.is_some()
+        {
+            let _ = notifier.send(StampEvent::MetricUpdate {
+                key,
+                snapshot: session.last_export,
+            });
+        }
+        self.subscribers
+            .entry(key)
+            .or_default()
+            .insert(client, notifier);
+    }
+
+    /// Drop `client`'s subscription on `key`; the last unsubscribe
+    /// tears the session down.
+    pub fn unsubscribe(&mut self, client: &str, key: &SessionKey) {
+        let now_empty = if let Some(subs) = self.subscribers.get_mut(key) {
+            subs.remove(client);
+            subs.is_empty()
+        } else {
+            return;
+        };
+        if now_empty {
+            self.subscribers.remove(key);
+            self.remove_session(key);
+        }
+    }
+
+    /// Create the session: connected sender socket, reply-read task,
+    /// prober task.
+    fn add_session(&mut self, key: SessionKey, params: SessionParams) -> std::io::Result<()> {
+        let (IpAddr::V4(local), IpAddr::V4(remote)) = (key.local, key.remote) else {
+            return Err(std::io::Error::other(
+                "stamp: IPv6 sessions are not supported yet",
+            ));
+        };
+        let sock = stamp_sender_socket(
+            &self.ctx,
+            SocketAddrV4::new(local, 0),
+            SocketAddrV4::new(remote, params.dst_port),
+        )?;
+        let sock = Arc::new(AsyncFd::new(sock)?);
+
+        let read_sock = sock.clone();
+        let read_tx = self.main_tx.clone();
+        let read_task = Task::spawn(async move {
+            sender_read(key, read_sock, read_tx).await;
+        });
+
+        let ssid = self.sessions.alloc_ssid();
+        self.sessions
+            .insert(Session::new(key, params, ssid, sock, read_task));
+
+        let (cmd_tx, cmd_rx) = mpsc::unbounded_channel();
+        let main_tx = self.main_tx.clone();
+        let task = Task::spawn(session_prober(key, params, cmd_rx, main_tx));
+        self.probers.insert(
+            key,
+            ProberHandle {
+                cmd_tx,
+                _task: task,
+            },
+        );
+        tracing::info!(?key, ssid, "stamp: session created");
+        Ok(())
+    }
+
+    /// A later `Subscribe` carried different params: retune the live
+    /// timers. A `dst_port` change needs a socket reconnect, so that
+    /// (test-only) case recreates the session outright — counters and
+    /// the current window restart, the exported value survives in the
+    /// subscribers' hands.
+    fn update_params(&mut self, key: &SessionKey, params: SessionParams) {
+        let Some(session) = self.sessions.get_mut(key) else {
+            return;
+        };
+        if session.params == params {
+            return;
+        }
+        if session.params.dst_port != params.dst_port {
+            self.remove_session(key);
+            if let Err(e) = self.add_session(*key, params) {
+                tracing::warn!(?key, error = %e, "stamp: session recreate failed");
+            }
+            return;
+        }
+        session.params = params;
+        if let Some(h) = self.probers.get(key) {
+            let _ = h.cmd_tx.send(ProberCmd::Retune(params));
+        }
+    }
+
+    fn remove_session(&mut self, key: &SessionKey) {
+        if let Some(h) = self.probers.remove(key) {
+            let _ = h.cmd_tx.send(ProberCmd::Shutdown);
+        }
+        if self.sessions.remove(key).is_some() {
+            tracing::info!(?key, "stamp: session removed");
+        }
+    }
+
+    /// Probe transmit timer fired: build and send one Session-Sender
+    /// packet. T1 is stamped here — the single T1 build site (offload
+    /// notes §9b R3). Direct nonblocking `send` on the connected
+    /// socket: a full socket buffer drops the probe (counted), it must
+    /// not delay the event loop.
+    fn on_tx_tick(&mut self, key: SessionKey) {
+        let Some(session) = self.sessions.get_mut(&key) else {
+            return;
+        };
+        let packet = SenderPacket {
+            seq: session.next_seq,
+            timestamp: now_ntp(), // T1
+            error_estimate: local_error_estimate(),
+            ssid: session.ssid,
+            tlvs: vec![],
+        };
+        let mut buf = bytes::BytesMut::new();
+        packet.emit(&mut buf);
+        use std::os::fd::AsRawFd;
+        let sent = nix::sys::socket::send(
+            session.sock.get_ref().as_raw_fd(),
+            &buf,
+            nix::sys::socket::MsgFlags::empty(),
+        );
+        match sent {
+            Ok(_) => {
+                session.next_seq = session.next_seq.wrapping_add(1);
+                session.tx_count += 1;
+                session.window.record_sent();
+            }
+            Err(e) => {
+                session.tx_failed_count += 1;
+                tracing::debug!(?key, error = %e, "stamp: probe send failed");
+            }
+        }
+    }
+
+    /// A reflected reply came back on `key`'s connected socket: verify
+    /// the SSID, compute the two-way delay (plan D1), record it.
+    fn on_reply_recv(&mut self, key: SessionKey, reply: ReflectorPacket, t4: StampTimestamp) {
+        let Some(session) = self.sessions.get_mut(&key) else {
+            return;
+        };
+        if reply.ssid != session.ssid {
+            session.rx_invalid_count += 1;
+            tracing::debug!(
+                ?key,
+                got = reply.ssid,
+                want = session.ssid,
+                "stamp: reply SSID mismatch"
+            );
+            return;
+        }
+        // delay = ((T4−T1) − (T3−T2)) / 2. T1/T4 are this node's
+        // clock, T2/T3 the reflector's — each difference is
+        // same-clock, so the inter-node offset cancels.
+        let rtt = delta_micros(t4, reply.sender_timestamp);
+        let residence = delta_micros(reply.timestamp, reply.receive_timestamp);
+        let delay = (rtt - residence) / 2;
+        if !(0..=MAX_PLAUSIBLE_DELAY_US).contains(&delay) {
+            session.rx_invalid_count += 1;
+            tracing::debug!(?key, delay, "stamp: implausible delay sample discarded");
+            return;
+        }
+        session.rx_count += 1;
+        session.last_rx = Some(std::time::Instant::now());
+        session.window.record_delay(delay as u32);
+    }
+
+    /// Export timer fired: snapshot the window, run the damping gate,
+    /// fan the update out, start a fresh window.
+    fn on_export_tick(&mut self, key: SessionKey) {
+        let Some(session) = self.sessions.get_mut(&key) else {
+            return;
+        };
+        let snapshot = session.window.snapshot();
+        session.window.reset();
+        if !session.damping.should_export(snapshot) {
+            return;
+        }
+        session.last_export = snapshot;
+        tracing::info!(?key, ?snapshot, "stamp: exporting metric update");
+        if let Some(subs) = self.subscribers.get(&key) {
+            for tx in subs.values() {
+                let _ = tx.send(StampEvent::MetricUpdate { key, snapshot });
+            }
+        }
+    }
+
+    /// A probe hit the reflector socket. Implicit allow-list (plan
+    /// §2): reflect iff the source is a registered session's remote.
+    /// The reply's source address is forced to the probed address and
+    /// egress is pinned to the ingress interface — both required for
+    /// the peer's connected-socket demux to accept the reply.
+    fn on_probe_recv(
+        &mut self,
+        probe: SenderPacket,
+        src: SocketAddr,
+        dst: Option<IpAddr>,
+        ifindex: u32,
+        ttl: u8,
+        rx_ts: StampTimestamp,
+        len: usize,
+    ) {
+        self.reflector_stats.rx += 1;
+        let Some(session_key) = self.sessions.reflect_allowed(src.ip()) else {
+            self.reflector_stats.unauthorized += 1;
+            tracing::debug!(?src, "stamp: probe from unregistered source dropped");
+            return;
+        };
+        let reply = build_reply(&probe, rx_ts, ttl, len);
+        let _ = self.reflect_tx.send(ReflectRequest {
+            reply,
+            dst: src,
+            src: dst,
+            ifindex: (ifindex != 0).then_some(ifindex),
+        });
+        self.reflector_stats.reflected += 1;
+        if let Some(session) = self.sessions.get_mut(&session_key) {
+            session.reflected_count += 1;
+        }
+    }
+
+    /// STAMP has no own config in Phase 1 — drain every broadcast.
+    fn process_cm_msg(&mut self, _msg: ConfigRequest) {}
+
+    async fn process_show_msg(&self, msg: DisplayRequest) {
+        let (path, args) = path_from_command(&msg.paths);
+        if let Some(f) = self.show_cb.get(&path) {
+            let output = match f(self, args, msg.json) {
+                Ok(result) => result,
+                Err(e) => format!("Error formatting output: {}", e),
+            };
+            let _ = msg.resp.send(output).await;
+        }
+    }
+
+    pub async fn event_loop(&mut self) {
+        loop {
+            tokio::select! {
+                Some(msg) = self.rx.recv() => match msg {
+                    Message::ProbeRecv { probe, src, dst, ifindex, ttl, rx_ts, len } =>
+                        self.on_probe_recv(probe, src, dst, ifindex, ttl, rx_ts, len),
+                    Message::ReplyRecv { key, reply, t4 } => self.on_reply_recv(key, reply, t4),
+                    Message::TxTick { key } => self.on_tx_tick(key),
+                    Message::ExportTick { key } => self.on_export_tick(key),
+                },
+                Some(msg) = self.cm.rx.recv() => self.process_cm_msg(msg),
+                Some(msg) = self.show.rx.recv() => {
+                    self.process_show_msg(msg).await;
+                }
+                Some(req) = self.client_req.rx.recv() => {
+                    self.process_client_req(req);
+                }
+            }
+        }
+    }
+}
+
+/// Spawn the event loop; dropping the returned [`Task`] aborts it
+/// (see [`crate::config::stamp::despawn_stamp`]).
+pub fn serve(mut stamp: Stamp) -> Task<()> {
+    Task::spawn(async move {
+        stamp.event_loop().await;
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn fresh_stamp() -> Stamp {
+        Stamp::new_with(
+            ProtoContext::default_table_no_rib(),
+            SocketAddrV4::new(Ipv4Addr::LOCALHOST, 0),
+        )
+        .expect("bind loopback")
+    }
+
+    fn loopback_key(remote_octet: u8) -> SessionKey {
+        SessionKey {
+            local: IpAddr::V4(Ipv4Addr::LOCALHOST),
+            remote: IpAddr::V4(Ipv4Addr::new(127, 0, 0, remote_octet)),
+            ifindex: 0,
+        }
+    }
+
+    fn reply_for(session_ssid: u16, t1: StampTimestamp) -> ReflectorPacket {
+        ReflectorPacket {
+            ssid: session_ssid,
+            sender_timestamp: t1,
+            // Zero residence: T2 == T3.
+            receive_timestamp: StampTimestamp::default(),
+            timestamp: StampTimestamp::default(),
+            ..ReflectorPacket::default()
+        }
+    }
+
+    /// First subscribe creates the session (socket, ssid, prober);
+    /// last unsubscribe removes it. A second client shares it.
+    #[tokio::test]
+    async fn subscribe_lifecycle_shares_session() {
+        let mut stamp = fresh_stamp();
+        let key = loopback_key(2);
+        let (tx_a, _rx_a) = mpsc::unbounded_channel();
+        let (tx_b, _rx_b) = mpsc::unbounded_channel();
+
+        stamp.subscribe("isis".into(), key, SessionParams::default(), tx_a);
+        assert_eq!(stamp.sessions.len(), 1);
+        let ssid = stamp.sessions.get(&key).unwrap().ssid;
+        assert_ne!(ssid, 0);
+
+        stamp.subscribe("ospf".into(), key, SessionParams::default(), tx_b);
+        assert_eq!(stamp.sessions.len(), 1, "same key shares one session");
+        assert_eq!(stamp.sessions.get(&key).unwrap().ssid, ssid);
+
+        stamp.unsubscribe("isis", &key);
+        assert_eq!(stamp.sessions.len(), 1, "one subscriber remains");
+        stamp.unsubscribe("ospf", &key);
+        assert_eq!(stamp.sessions.len(), 0, "last unsubscribe tears down");
+        assert!(stamp.probers.is_empty());
+    }
+
+    /// A later Subscribe with different timing retunes the stored
+    /// params (last-writer-wins, D11).
+    #[tokio::test]
+    async fn second_subscribe_retunes_params() {
+        let mut stamp = fresh_stamp();
+        let key = loopback_key(2);
+        let (tx_a, _rx_a) = mpsc::unbounded_channel();
+        let (tx_b, _rx_b) = mpsc::unbounded_channel();
+
+        stamp.subscribe("isis".into(), key, SessionParams::default(), tx_a);
+        let faster = SessionParams {
+            interval_ms: 100,
+            damping_secs: 2,
+            ..SessionParams::default()
+        };
+        stamp.subscribe("ospf".into(), key, faster, tx_b);
+        assert_eq!(stamp.sessions.get(&key).unwrap().params, faster);
+    }
+
+    /// A subscriber joining after an export immediately hears the
+    /// current value.
+    #[tokio::test]
+    async fn late_subscriber_gets_mirror() {
+        let mut stamp = fresh_stamp();
+        let key = loopback_key(2);
+        let (tx_a, _rx_a) = mpsc::unbounded_channel();
+        stamp.subscribe("isis".into(), key, SessionParams::default(), tx_a);
+
+        // Feed two samples and force an export tick.
+        let t1 = StampTimestamp {
+            seconds: 100,
+            fraction: 0,
+        };
+        let t4 = StampTimestamp {
+            seconds: 100,
+            fraction: 4_294_967, // ~1000 µs
+        };
+        let ssid = stamp.sessions.get(&key).unwrap().ssid;
+        stamp.on_reply_recv(key, reply_for(ssid, t1), t4);
+        stamp.on_export_tick(key);
+        assert!(stamp.sessions.get(&key).unwrap().last_export.is_some());
+
+        let (tx_b, mut rx_b) = mpsc::unbounded_channel();
+        stamp.subscribe("ospf".into(), key, SessionParams::default(), tx_b);
+        let StampEvent::MetricUpdate { snapshot, .. } = rx_b.try_recv().expect("mirrored export");
+        assert!(snapshot.is_some());
+    }
+
+    /// D1 math: rtt 1000 µs with 400 µs residence → 300 µs one-way
+    /// estimate. SSID mismatches and negative delays are counted
+    /// invalid and recorded nowhere.
+    #[tokio::test]
+    async fn reply_validation_and_delay_math() {
+        let mut stamp = fresh_stamp();
+        let key = loopback_key(2);
+        let (tx, _rx) = mpsc::unbounded_channel();
+        stamp.subscribe("isis".into(), key, SessionParams::default(), tx);
+        let ssid = stamp.sessions.get(&key).unwrap().ssid;
+
+        let us = |micros: u64| StampTimestamp {
+            seconds: 100,
+            fraction: ((micros << 32) / 1_000_000) as u32,
+        };
+        // T1=0, T2=200, T3=600, T4=1000 (µs into second 100).
+        let reply = ReflectorPacket {
+            ssid,
+            sender_timestamp: us(0),
+            receive_timestamp: us(200),
+            timestamp: us(600),
+            ..ReflectorPacket::default()
+        };
+        stamp.on_reply_recv(key, reply, us(1000));
+        {
+            let s = stamp.sessions.get(&key).unwrap();
+            assert_eq!(s.rx_count, 1);
+            let snap = s.window.snapshot().unwrap();
+            assert!((299..=301).contains(&snap.min), "delay {}", snap.min);
+        }
+
+        // Wrong SSID → invalid.
+        stamp.on_reply_recv(key, reply_for(ssid.wrapping_add(1), us(0)), us(1000));
+        // Negative delay (T4 before T1) → invalid.
+        stamp.on_reply_recv(key, reply_for(ssid, us(1000)), us(0));
+        let s = stamp.sessions.get(&key).unwrap();
+        assert_eq!(s.rx_invalid_count, 2);
+        assert_eq!(s.rx_count, 1);
+    }
+
+    /// The implicit reflector only answers registered remotes: an
+    /// unknown source bumps `unauthorized`, a registered one
+    /// `reflected` plus the session's own counter.
+    #[tokio::test]
+    async fn reflector_allow_list() {
+        let mut stamp = fresh_stamp();
+        let key = loopback_key(2);
+        let (tx, _rx) = mpsc::unbounded_channel();
+        stamp.subscribe("isis".into(), key, SessionParams::default(), tx);
+
+        let probe = SenderPacket::default();
+        let unknown = SocketAddr::V4(SocketAddrV4::new(Ipv4Addr::new(127, 0, 0, 99), 5000));
+        stamp.on_probe_recv(
+            probe.clone(),
+            unknown,
+            None,
+            0,
+            255,
+            StampTimestamp::default(),
+            stamp_packet::BASE_LEN,
+        );
+        assert_eq!(stamp.reflector_stats.unauthorized, 1);
+        assert_eq!(stamp.reflector_stats.reflected, 0);
+
+        let registered = SocketAddr::V4(SocketAddrV4::new(Ipv4Addr::new(127, 0, 0, 2), 5000));
+        stamp.on_probe_recv(
+            probe,
+            registered,
+            Some(IpAddr::V4(Ipv4Addr::LOCALHOST)),
+            0,
+            255,
+            StampTimestamp::default(),
+            stamp_packet::BASE_LEN,
+        );
+        assert_eq!(stamp.reflector_stats.reflected, 1);
+        assert_eq!(stamp.sessions.get(&key).unwrap().reflected_count, 1);
+    }
+
+    /// Export ticks respect damping: identical windows export once;
+    /// an empty window after an export clears (None) exactly once.
+    #[tokio::test]
+    async fn export_damping_and_clear() {
+        let mut stamp = fresh_stamp();
+        let key = loopback_key(2);
+        let (tx, mut rx) = mpsc::unbounded_channel();
+        stamp.subscribe("isis".into(), key, SessionParams::default(), tx);
+        let ssid = stamp.sessions.get(&key).unwrap().ssid;
+
+        let us = |micros: u64| StampTimestamp {
+            seconds: 100,
+            fraction: ((micros << 32) / 1_000_000) as u32,
+        };
+        let feed = |stamp: &mut Stamp| {
+            stamp.on_reply_recv(key, reply_for(ssid, us(0)), us(1000));
+        };
+
+        feed(&mut stamp);
+        stamp.on_export_tick(key); // first export
+        feed(&mut stamp);
+        stamp.on_export_tick(key); // same value → damped
+        stamp.on_export_tick(key); // empty window → clear
+        stamp.on_export_tick(key); // still empty → quiet
+
+        let mut updates = Vec::new();
+        while let Ok(StampEvent::MetricUpdate { snapshot, .. }) = rx.try_recv() {
+            updates.push(snapshot);
+        }
+        assert_eq!(updates.len(), 2, "one export + one clear, got {updates:?}");
+        assert!(updates[0].is_some());
+        assert!(updates[1].is_none());
+        assert!(stamp.sessions.get(&key).unwrap().last_export.is_none());
+    }
+}

--- a/zebra-rs/src/stamp/integration.rs
+++ b/zebra-rs/src/stamp/integration.rs
@@ -1,0 +1,80 @@
+//! Single-instance loopback integration test.
+//!
+//! One STAMP instance on a loopback ephemeral port measures *itself*:
+//! the session's `dst_port` is aimed at the instance's own reflector
+//! socket, so the probe path exercises sender socket → reflector read
+//! (allow-list, T2) → `build_reply` → reflector write (source stamp)
+//! → connected-socket demux → T4 → D1 delay math → stats window →
+//! damping → `MetricUpdate` fan-out, end to end over real sockets.
+
+use std::net::{IpAddr, Ipv4Addr, SocketAddrV4};
+use std::time::Duration;
+
+use tokio::sync::mpsc;
+
+use super::client::StampEvent;
+use super::inst::{Stamp, serve};
+use super::session::{SessionKey, SessionParams};
+use crate::context::ProtoContext;
+
+const LOOPBACK: Ipv4Addr = Ipv4Addr::LOCALHOST;
+
+/// Subscribe a fake IGP client and assert a populated `MetricUpdate`
+/// arrives within the deadline, with internally consistent fields.
+#[tokio::test]
+async fn loopback_session_exports_metrics() {
+    let stamp = Stamp::new_with(
+        ProtoContext::default_table_no_rib(),
+        SocketAddrV4::new(LOOPBACK, 0),
+    )
+    .expect("bind loopback reflector");
+    let reflector_port = stamp.local_addr.port();
+
+    let key = SessionKey {
+        local: IpAddr::V4(LOOPBACK),
+        remote: IpAddr::V4(LOOPBACK),
+        ifindex: 0,
+    };
+    let params = SessionParams {
+        interval_ms: 50,
+        damping_secs: 1,
+        dst_port: reflector_port,
+    };
+    let (tx, mut rx) = mpsc::unbounded_channel();
+
+    // Subscribe through the channel so the running event loop creates
+    // the session — the production path.
+    let client_req = stamp.client_req_tx();
+    let _task = serve(stamp);
+    client_req
+        .send(super::client::ClientReq::Subscribe {
+            client: "test".into(),
+            key,
+            params,
+            notifier: tx,
+        })
+        .expect("event loop alive");
+
+    // First export needs one damping period (1 s) of 50 ms probes.
+    let deadline = Duration::from_secs(10);
+    let update = tokio::time::timeout(deadline, rx.recv())
+        .await
+        .expect("no MetricUpdate within deadline")
+        .expect("notifier channel closed");
+
+    let StampEvent::MetricUpdate {
+        key: got_key,
+        snapshot,
+    } = update;
+    assert_eq!(got_key, key);
+    let snap = snapshot.expect("first export carries a value, not a clear");
+    assert!(snap.min <= snap.avg, "min {} <= avg {}", snap.min, snap.avg);
+    assert!(snap.avg <= snap.max, "avg {} <= max {}", snap.avg, snap.max);
+    // Loopback round-trips are fast; anything near the 10 s outlier
+    // guard would mean the timestamps are broken.
+    assert!(
+        snap.max < 1_000_000,
+        "implausible loopback delay {}",
+        snap.max
+    );
+}

--- a/zebra-rs/src/stamp/mod.rs
+++ b/zebra-rs/src/stamp/mod.rs
@@ -1,0 +1,24 @@
+//! STAMP (RFC 8762) active link-delay measurement.
+//!
+//! Phase 1 of the SR-MPLS TE plan (`docs/design/stamp-sr-mpls-te-plan.md`,
+//! steps in `docs/design/stamp-phase1-implementation-plan.md`): an
+//! unauthenticated Session-Sender per measured P2P link plus an
+//! implicit Session-Reflector for registered peers. The damped
+//! per-link delay snapshots feed the IGPs' `te-metric` fields — IS-IS
+//! (RFC 8570) and OSPFv2 (RFC 7471) link-delay sub-TLVs and
+//! Flex-Algorithm metric-type-1 SPF.
+
+pub mod client;
+pub mod damping;
+pub mod inst;
+pub mod network;
+pub mod reflector;
+pub mod sender;
+pub mod session;
+pub mod show;
+pub mod socket;
+pub mod stats;
+pub mod timestamp;
+
+#[cfg(test)]
+mod integration;

--- a/zebra-rs/src/stamp/network.rs
+++ b/zebra-rs/src/stamp/network.rs
@@ -1,0 +1,193 @@
+//! STAMP socket read/write tasks.
+//!
+//! Three loops, mirroring `bfd/network.rs`:
+//!
+//!   * [`reflector_read`] — `recvmsg` on the wildcard reflector socket
+//!     with `IP_PKTINFO` + `IP_RECVTTL` ancillary data; stamps the
+//!     receive timestamp (T2) at the earliest userspace point and
+//!     forwards parsed probes to the event loop;
+//!   * [`reflector_write`] — drains [`ReflectRequest`]s, sending each
+//!     reply via `sendmsg` with the source address forced to the
+//!     probed address (the sender's connected socket only accepts
+//!     replies from exactly the address it probed) and egress pinned
+//!     to the ingress interface;
+//!   * [`sender_read`] — plain `recv` on one session's connected
+//!     socket; stamps T4 at receipt and forwards parsed reflector
+//!     packets keyed by the session.
+
+use std::io::{ErrorKind, IoSlice, IoSliceMut};
+use std::net::{IpAddr, Ipv4Addr, SocketAddr, SocketAddrV4};
+use std::os::fd::AsRawFd;
+use std::sync::Arc;
+
+use bytes::BytesMut;
+use nix::sys::socket::{self, ControlMessageOwned, MsgFlags, SockaddrIn};
+use socket2::Socket;
+use tokio::io::Interest;
+use tokio::io::unix::AsyncFd;
+use tokio::sync::mpsc::{UnboundedReceiver, UnboundedSender};
+
+use super::inst::Message;
+use super::session::SessionKey;
+use super::timestamp::now_ntp;
+
+/// One reflected reply queued for [`reflector_write`].
+#[derive(Debug)]
+pub struct ReflectRequest {
+    pub reply: stamp_packet::ReflectorPacket,
+    /// The probe's source — where the reply goes.
+    pub dst: SocketAddr,
+    /// Source address to stamp (the probe's destination — the probed
+    /// link address). `None` lets the kernel pick, which is only safe
+    /// when the socket is bound to a concrete address (tests).
+    pub src: Option<IpAddr>,
+    /// Egress pinned to the probe's ingress interface.
+    pub ifindex: Option<u32>,
+}
+
+/// Reflector receive loop. Parses [`stamp_packet::SenderPacket`]s and
+/// forwards them as [`Message::ProbeRecv`] with the receive timestamp
+/// (T2) taken here — the single T2 capture point; a cmsg-timestamp or
+/// kernel-map source swaps in at this seam (offload notes §9b R3).
+pub async fn reflector_read(sock: Arc<AsyncFd<Socket>>, tx: UnboundedSender<Message>) {
+    let mut buf = [0u8; 1500];
+    let mut iov = [IoSliceMut::new(&mut buf)];
+    let mut cmsgspace = nix::cmsg_space!(libc::in_pktinfo, libc::c_int);
+
+    loop {
+        let _ = sock
+            .async_io(Interest::READABLE, |sock| {
+                let msg = socket::recvmsg::<SockaddrIn>(
+                    sock.as_raw_fd(),
+                    &mut iov,
+                    Some(&mut cmsgspace),
+                    MsgFlags::empty(),
+                )?;
+                let rx_ts = now_ntp();
+
+                let Some(src) = msg.address else {
+                    return Err(ErrorKind::AddrNotAvailable.into());
+                };
+                let src = SocketAddr::V4(SocketAddrV4::new(src.ip(), src.port()));
+
+                let mut dst: Option<Ipv4Addr> = None;
+                let mut ifindex: u32 = 0;
+                let mut ttl: u8 = 0;
+                for cmsg in msg.cmsgs()? {
+                    match cmsg {
+                        ControlMessageOwned::Ipv4PacketInfo(pi) => {
+                            dst = Some(Ipv4Addr::from(pi.ipi_addr.s_addr.to_be()));
+                            ifindex = pi.ipi_ifindex as u32;
+                        }
+                        ControlMessageOwned::Ipv4Ttl(v) => ttl = v.clamp(0, 255) as u8,
+                        _ => {}
+                    }
+                }
+
+                let Some(payload) = msg.iovs().next() else {
+                    return Err(ErrorKind::UnexpectedEof.into());
+                };
+                let len = payload.len();
+
+                let probe = match stamp_packet::SenderPacket::parse(payload) {
+                    Ok(p) => p,
+                    Err(e) => {
+                        tracing::debug!(?src, error = %e, "stamp: invalid sender packet");
+                        return Ok(());
+                    }
+                };
+
+                let _ = tx.send(Message::ProbeRecv {
+                    probe,
+                    src,
+                    dst: dst.map(IpAddr::V4),
+                    ifindex,
+                    ttl,
+                    rx_ts,
+                    len,
+                });
+                Ok(())
+            })
+            .await;
+    }
+}
+
+/// Reflector send loop. The source-address stamp works exactly like
+/// BFD's: `ipi_spec_dst` names the *source* of an outgoing datagram.
+pub async fn reflector_write(
+    sock: Arc<AsyncFd<Socket>>,
+    mut rx: UnboundedReceiver<ReflectRequest>,
+) {
+    while let Some(req) = rx.recv().await {
+        let SocketAddr::V4(dst) = req.dst else {
+            continue; // IPv4 only in Phase 1
+        };
+        let mut buf = BytesMut::new();
+        req.reply.emit(&mut buf);
+        let iov = [IoSlice::new(&buf)];
+        let sockaddr: SockaddrIn = dst.into();
+
+        let spec_dst = match req.src {
+            Some(IpAddr::V4(a)) => u32::from_ne_bytes(a.octets()),
+            _ => 0,
+        };
+        let pktinfo = (req.ifindex.is_some() || spec_dst != 0).then(|| libc::in_pktinfo {
+            ipi_ifindex: req.ifindex.unwrap_or(0) as i32,
+            ipi_spec_dst: libc::in_addr { s_addr: spec_dst },
+            ipi_addr: libc::in_addr { s_addr: 0 },
+        });
+        let cmsg_storage;
+        let cmsgs: &[socket::ControlMessage<'_>] = if let Some(ref pi) = pktinfo {
+            cmsg_storage = [socket::ControlMessage::Ipv4PacketInfo(pi)];
+            &cmsg_storage
+        } else {
+            &[]
+        };
+
+        let _ = sock
+            .async_io(Interest::WRITABLE, |sock| {
+                socket::sendmsg(
+                    sock.as_raw_fd(),
+                    &iov,
+                    cmsgs,
+                    MsgFlags::empty(),
+                    Some(&sockaddr),
+                )
+                .map_err(std::io::Error::from)?;
+                Ok(())
+            })
+            .await;
+    }
+}
+
+/// Per-session reply read loop on the connected sender socket. The
+/// kernel already demuxed by 4-tuple, so a plain `recv` suffices. T4
+/// is taken here — the single T4 capture point (offload notes §9b R3).
+pub async fn sender_read(
+    key: SessionKey,
+    sock: Arc<AsyncFd<Socket>>,
+    tx: UnboundedSender<Message>,
+) {
+    let mut buf = [0u8; 1500];
+
+    loop {
+        let _ = sock
+            .async_io(Interest::READABLE, |sock| {
+                let n = socket::recv(sock.as_raw_fd(), &mut buf, MsgFlags::empty())
+                    .map_err(std::io::Error::from)?;
+                let t4 = now_ntp();
+
+                let reply = match stamp_packet::ReflectorPacket::parse(&buf[..n]) {
+                    Ok(p) => p,
+                    Err(e) => {
+                        tracing::debug!(?key, error = %e, "stamp: invalid reflector packet");
+                        return Ok(());
+                    }
+                };
+
+                let _ = tx.send(Message::ReplyRecv { key, reply, t4 });
+                Ok(())
+            })
+            .await;
+    }
+}

--- a/zebra-rs/src/stamp/reflector.rs
+++ b/zebra-rs/src/stamp/reflector.rs
@@ -1,0 +1,131 @@
+//! Stateless Session-Reflector reply construction (RFC 8762 §4.3).
+//!
+//! [`build_reply`] is deliberately a pure function of the received
+//! probe: it is the executable specification a future XDP reflector
+//! mirrors as an in-place packet rewrite (offload notes §9b R1 — both
+//! base packets are 44 octets, so the reflector fields overwrite the
+//! sender's MBZ region byte-for-byte). Keep it free of session state
+//! and side effects.
+
+use stamp_packet::{
+    BASE_LEN, ReflectorPacket, SenderPacket, StampTimestamp, StampTlv, StampTlvValue,
+    TLV_HEADER_LEN,
+};
+
+/// Build the stateless reflection of `probe`.
+///
+/// Stateless mode (RFC 8762 §4.3): the reflector's own sequence number
+/// is a copy of the sender's, the SSID is echoed, and no per-session
+/// reflector state exists. `rx_ts` is the receive timestamp (T2, taken
+/// at the socket read); the caller stamps T3 immediately before
+/// transmission — here, since build-to-send is one synchronous path.
+/// `ttl` is the probe's received TTL, copied into the Sender TTL field.
+///
+/// Symmetric size (RFC 8762 §4.3 / RFC 6038): when the probe was
+/// longer than the 44-octet base, the reply is padded to the same
+/// length with an Extra Padding TLV (RFC 8972 §4.1). A 1–3 octet
+/// shortfall cannot be expressed (the TLV header alone is 4 octets) —
+/// those replies stay at base length, which only mis-sizes probes that
+/// were themselves padded by less than one TLV header.
+pub fn build_reply(
+    probe: &SenderPacket,
+    rx_ts: StampTimestamp,
+    ttl: u8,
+    req_len: usize,
+) -> ReflectorPacket {
+    let mut tlvs = Vec::new();
+    if req_len >= BASE_LEN + TLV_HEADER_LEN {
+        // A 4-octet shortfall is a zero-length Extra Padding TLV.
+        let pad = req_len - BASE_LEN - TLV_HEADER_LEN;
+        tlvs.push(StampTlv::new(StampTlvValue::ExtraPadding(vec![0u8; pad])));
+    }
+    ReflectorPacket {
+        seq: probe.seq,                         // stateless: copy of the sender's
+        timestamp: super::timestamp::now_ntp(), // T3
+        error_estimate: super::inst::local_error_estimate(),
+        ssid: probe.ssid,
+        receive_timestamp: rx_ts, // T2
+        sender_seq: probe.seq,
+        sender_timestamp: probe.timestamp,
+        sender_error_estimate: probe.error_estimate,
+        sender_ttl: ttl,
+        tlvs,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use bytes::BytesMut;
+    use stamp_packet::ErrorEstimate;
+
+    use super::*;
+
+    fn probe(seq: u32, ssid: u16) -> SenderPacket {
+        SenderPacket {
+            seq,
+            timestamp: StampTimestamp {
+                seconds: 0xAABB_CCDD,
+                fraction: 0x1122_3344,
+            },
+            error_estimate: ErrorEstimate {
+                synced: true,
+                multiplier: 7,
+                ..ErrorEstimate::default()
+            },
+            ssid,
+            tlvs: vec![],
+        }
+    }
+
+    fn rx_ts() -> StampTimestamp {
+        StampTimestamp {
+            seconds: 0xDEAD_BEEF,
+            fraction: 0x0BAD_F00D,
+        }
+    }
+
+    /// Every sender field lands in its reflector slot (RFC 8762 §4.3):
+    /// seq copied twice (stateless), timestamp/error-estimate/ssid/TTL
+    /// echoed, T2 = the receive timestamp.
+    #[test]
+    fn sender_fields_copied() {
+        let p = probe(42, 0x0102);
+        let r = build_reply(&p, rx_ts(), 255, BASE_LEN);
+        assert_eq!(r.seq, 42, "stateless mode copies the sender seq");
+        assert_eq!(r.sender_seq, 42);
+        assert_eq!(r.ssid, 0x0102);
+        assert_eq!(r.receive_timestamp, rx_ts());
+        assert_eq!(r.sender_timestamp, p.timestamp);
+        assert_eq!(r.sender_error_estimate, p.error_estimate);
+        assert_eq!(r.sender_ttl, 255);
+        assert!(r.tlvs.is_empty(), "base-length probe needs no padding");
+    }
+
+    /// A padded probe gets a same-length reply (RFC 6038 symmetric
+    /// size): emit and compare byte counts.
+    #[test]
+    fn symmetric_size_padding() {
+        let p = probe(1, 1);
+        for req_len in [BASE_LEN + 4, BASE_LEN + 20, BASE_LEN + 200] {
+            let r = build_reply(&p, rx_ts(), 255, req_len);
+            let mut buf = BytesMut::new();
+            r.emit(&mut buf);
+            assert_eq!(buf.len(), req_len, "reply length for request {req_len}");
+        }
+    }
+
+    /// A 1–3 octet shortfall can't be expressed with a 4-octet TLV
+    /// header — the reply stays at base length instead of panicking or
+    /// over-padding. (Exactly 4 octets *is* expressible: a zero-length
+    /// Extra Padding TLV — covered by `symmetric_size_padding`.)
+    #[test]
+    fn sub_header_pad_skipped() {
+        let p = probe(1, 1);
+        for req_len in [BASE_LEN + 1, BASE_LEN + 2, BASE_LEN + 3] {
+            let r = build_reply(&p, rx_ts(), 255, req_len);
+            let mut buf = BytesMut::new();
+            r.emit(&mut buf);
+            assert_eq!(buf.len(), BASE_LEN, "no expressible pad for {req_len}");
+        }
+    }
+}

--- a/zebra-rs/src/stamp/sender.rs
+++ b/zebra-rs/src/stamp/sender.rs
@@ -1,0 +1,162 @@
+//! Per-session prober task.
+//!
+//! One task per session drives two periodic timers and reports the
+//! ticks to the event loop, which owns all session state (mirroring
+//! the BFD `session_timer` split):
+//!
+//!   * the **probe** timer fires every `interval_ms` →
+//!     [`Message::TxTick`] → the event loop builds and sends one
+//!     Session-Sender packet;
+//!   * the **export** timer fires every `damping_secs` →
+//!     [`Message::ExportTick`] → the event loop snapshots the stats
+//!     window, runs the damping gate, and fans `MetricUpdate`s out.
+//!
+//! [`ProberCmd::Retune`] re-arms both timers — the runtime path for a
+//! `Subscribe` carrying changed params (shared sessions are
+//! last-writer-wins, plan D11).
+
+use std::time::Duration;
+
+use tokio::sync::mpsc::{UnboundedReceiver, UnboundedSender};
+use tokio::time::{Instant, interval_at};
+
+use crate::context::Task;
+
+use super::inst::Message;
+use super::session::{SessionKey, SessionParams};
+
+/// Commands the event loop sends to a session's prober task.
+#[derive(Debug, Clone, Copy)]
+pub enum ProberCmd {
+    /// Params changed (a later `Subscribe` with a different tuple);
+    /// re-arm both timers at the new rates.
+    Retune(SessionParams),
+    /// Shut the task down. Equivalent to dropping the cmd channel.
+    Shutdown,
+}
+
+/// Holds one session's prober task and its command channel. Dropping
+/// the [`Task`] aborts the loop.
+#[derive(Debug)]
+pub struct ProberHandle {
+    pub cmd_tx: UnboundedSender<ProberCmd>,
+    pub _task: Task<()>,
+}
+
+/// Prober task body. Runs until the cmd channel closes or
+/// [`ProberCmd::Shutdown`] arrives.
+pub async fn session_prober(
+    key: SessionKey,
+    params: SessionParams,
+    mut cmd_rx: UnboundedReceiver<ProberCmd>,
+    event_tx: UnboundedSender<Message>,
+) {
+    let (mut probe, mut export) = arm(params);
+
+    loop {
+        tokio::select! {
+            _ = probe.tick() => {
+                if event_tx.send(Message::TxTick { key }).is_err() {
+                    return; // event loop gone
+                }
+            }
+            _ = export.tick() => {
+                if event_tx.send(Message::ExportTick { key }).is_err() {
+                    return;
+                }
+            }
+            cmd = cmd_rx.recv() => match cmd {
+                None | Some(ProberCmd::Shutdown) => return,
+                Some(ProberCmd::Retune(p)) => (probe, export) = arm(p),
+            }
+        }
+    }
+}
+
+/// Build both interval timers. `interval_at` with a one-period initial
+/// delay: an immediate first probe would race link bring-up for
+/// nothing, and an immediate first export would always be an empty
+/// window. Missed ticks (event-loop stall) are skipped, not bursted —
+/// a burst of back-to-back probes measures the daemon, not the link.
+fn arm(params: SessionParams) -> (tokio::time::Interval, tokio::time::Interval) {
+    let probe_period = Duration::from_millis(params.interval_ms.max(1) as u64);
+    let export_period = Duration::from_secs(params.damping_secs.max(1) as u64);
+    let mut probe = interval_at(Instant::now() + probe_period, probe_period);
+    let mut export = interval_at(Instant::now() + export_period, export_period);
+    probe.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+    export.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+    (probe, export)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::net::{IpAddr, Ipv4Addr};
+
+    use tokio::sync::mpsc;
+
+    use super::*;
+
+    fn key() -> SessionKey {
+        SessionKey {
+            local: IpAddr::V4(Ipv4Addr::LOCALHOST),
+            remote: IpAddr::V4(Ipv4Addr::new(127, 0, 0, 2)),
+            ifindex: 0,
+        }
+    }
+
+    /// Probe ticks arrive at roughly the configured interval, and the
+    /// export tick fires once per damping period.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn ticks_fire_at_configured_rates() {
+        let params = SessionParams {
+            interval_ms: 10,
+            damping_secs: 1,
+            ..SessionParams::default()
+        };
+        let (_cmd_tx, cmd_rx) = mpsc::unbounded_channel();
+        let (event_tx, mut event_rx) = mpsc::unbounded_channel();
+        let task = tokio::spawn(session_prober(key(), params, cmd_rx, event_tx));
+
+        tokio::time::sleep(Duration::from_millis(250)).await;
+        let (mut tx_ticks, mut export_ticks) = (0u32, 0u32);
+        while let Ok(msg) = event_rx.try_recv() {
+            match msg {
+                Message::TxTick { .. } => tx_ticks += 1,
+                Message::ExportTick { .. } => export_ticks += 1,
+                _ => {}
+            }
+        }
+        assert!(tx_ticks >= 10, "expected ≥10 probe ticks, got {tx_ticks}");
+        assert_eq!(export_ticks, 0, "export period (1s) not yet reached");
+        task.abort();
+    }
+
+    /// Retune takes effect: after switching from a slow to a fast
+    /// probe interval, ticks speed up.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn retune_changes_rate() {
+        let params = SessionParams {
+            interval_ms: 10_000,
+            damping_secs: 3600,
+            ..SessionParams::default()
+        };
+        let (cmd_tx, cmd_rx) = mpsc::unbounded_channel();
+        let (event_tx, mut event_rx) = mpsc::unbounded_channel();
+        let task = tokio::spawn(session_prober(key(), params, cmd_rx, event_tx));
+
+        cmd_tx
+            .send(ProberCmd::Retune(SessionParams {
+                interval_ms: 10,
+                damping_secs: 3600,
+                ..SessionParams::default()
+            }))
+            .unwrap();
+        tokio::time::sleep(Duration::from_millis(150)).await;
+
+        let tx_ticks = std::iter::from_fn(|| event_rx.try_recv().ok())
+            .filter(|m| matches!(m, Message::TxTick { .. }))
+            .count();
+        assert!(tx_ticks >= 5, "retuned rate not applied: {tx_ticks} ticks");
+        task.abort();
+    }
+}

--- a/zebra-rs/src/stamp/session.rs
+++ b/zebra-rs/src/stamp/session.rs
@@ -1,0 +1,266 @@
+//! STAMP session state and the per-instance session table.
+//!
+//! One [`Session`] per measured link direction: this node is the
+//! Session-Sender, the `remote` end reflects. Sessions are created on
+//! the first client [`Subscribe`](super::client::ClientReq::Subscribe)
+//! and shared by every IGP measuring the same link (the key carries no
+//! protocol). The table also allocates the per-session SSID
+//! (RFC 8972 §3) — non-zero so a reply that lost its session context
+//! can never validate against a fresh one by accident.
+
+use std::collections::BTreeMap;
+use std::net::IpAddr;
+use std::sync::Arc;
+use std::time::Instant;
+
+use socket2::Socket;
+use tokio::io::unix::AsyncFd;
+
+use crate::context::Task;
+
+use super::damping::Damping;
+use super::stats::{MetricSnapshot, StatsWindow};
+
+/// Identifies one measurement session at this system. `ifindex` is the
+/// local interface the measured link hangs off — it keys the IGP-side
+/// lookup on `MetricUpdate` and any future per-ifindex XDP helper
+/// (offload notes §9b).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct SessionKey {
+    pub local: IpAddr,
+    pub remote: IpAddr,
+    pub ifindex: u32,
+}
+
+/// Per-session probe/export timing as resolved from config.
+/// `PartialEq` so IGP-side reconciles can diff a desired tuple against
+/// the tracked one and re-`Subscribe` only on a real change.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct SessionParams {
+    /// Probe transmit interval.
+    pub interval_ms: u32,
+    /// Export (damping) period — the stats window length.
+    pub damping_secs: u32,
+    /// Destination UDP port. Production sessions probe the well-known
+    /// STAMP port (862); tests aim at an instance's ephemeral port.
+    pub dst_port: u16,
+}
+
+impl Default for SessionParams {
+    fn default() -> Self {
+        Self {
+            interval_ms: DEFAULT_INTERVAL_MS,
+            damping_secs: DEFAULT_DAMPING_SECS,
+            dst_port: stamp_packet::STAMP_UDP_PORT,
+        }
+    }
+}
+
+/// Default probe interval (Cisco SR-PM probes at 3 s, Juniper TWAMP at
+/// 1 s; 1 s gives ~30 samples per default export window).
+pub const DEFAULT_INTERVAL_MS: u32 = 1000;
+
+/// Default export / damping period.
+pub const DEFAULT_DAMPING_SECS: u32 = 30;
+
+/// The `te-metric { measurement {...} }` config block both IGPs embed
+/// per interface — the YANG mirror. Leaves are `Option` so "configured
+/// vs defaulted" stays visible (matching the sibling static te-metric
+/// leaves); [`Self::resolve`] applies the defaults.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct MeasurementConfig {
+    pub enable: Option<bool>,
+    pub interval_ms: Option<u32>,
+    pub damping_period_secs: Option<u32>,
+}
+
+impl MeasurementConfig {
+    pub fn enabled(&self) -> bool {
+        self.enable.unwrap_or(false)
+    }
+
+    pub fn resolve(&self) -> SessionParams {
+        SessionParams {
+            interval_ms: self.interval_ms.unwrap_or(DEFAULT_INTERVAL_MS),
+            damping_secs: self.damping_period_secs.unwrap_or(DEFAULT_DAMPING_SECS),
+            dst_port: stamp_packet::STAMP_UDP_PORT,
+        }
+    }
+}
+
+/// One Session-Sender. The connected UDP socket does the reply demux
+/// (the kernel matches the 4-tuple); `ssid` is a cheap integrity check
+/// on top. The read task feeds replies to the event loop and dies with
+/// the session (dropping [`Task`] aborts it).
+#[derive(Debug)]
+pub struct Session {
+    pub key: SessionKey,
+    pub params: SessionParams,
+    /// Non-zero STAMP Session Identifier (RFC 8972 §3), allocated by
+    /// the table, validated on every reply.
+    pub ssid: u16,
+    /// Sequence number for the next probe.
+    pub next_seq: u32,
+    /// Connected sender socket; egress for probes, ingress (via the
+    /// per-session read task) for replies.
+    pub sock: Arc<AsyncFd<Socket>>,
+    pub tx_count: u64,
+    pub tx_failed_count: u64,
+    pub rx_count: u64,
+    /// Replies that failed validation: SSID mismatch, or a delay that
+    /// computed negative / absurd (clock step during the probe).
+    pub rx_invalid_count: u64,
+    /// Probes from `key.remote` answered by the implicit reflector —
+    /// the per-session half of the reflector counters.
+    pub reflected_count: u64,
+    pub window: StatsWindow,
+    pub damping: Damping,
+    /// Last snapshot actually exported to subscribers (`None` before
+    /// the first export or after a clear). Mirrored to late
+    /// subscribers and rendered by `show stamp`.
+    pub last_export: Option<MetricSnapshot>,
+    pub last_rx: Option<Instant>,
+    pub created: Instant,
+    /// Reply read task; aborted when the session drops.
+    _read_task: Task<()>,
+}
+
+impl Session {
+    pub fn new(
+        key: SessionKey,
+        params: SessionParams,
+        ssid: u16,
+        sock: Arc<AsyncFd<Socket>>,
+        read_task: Task<()>,
+    ) -> Self {
+        Self {
+            key,
+            params,
+            ssid,
+            next_seq: 0,
+            sock,
+            tx_count: 0,
+            tx_failed_count: 0,
+            rx_count: 0,
+            rx_invalid_count: 0,
+            reflected_count: 0,
+            window: StatsWindow::default(),
+            damping: Damping::default(),
+            last_export: None,
+            last_rx: None,
+            created: Instant::now(),
+            _read_task: read_task,
+        }
+    }
+
+    /// Sender liveness for `show stamp`: Active while a reply arrived
+    /// within the last three probe intervals.
+    pub fn is_active(&self) -> bool {
+        self.last_rx
+            .is_some_and(|t| t.elapsed().as_millis() <= 3 * self.params.interval_ms as u128)
+    }
+}
+
+/// All sessions, ordered by key for stable show output, plus the SSID
+/// allocator.
+#[derive(Debug, Default)]
+pub struct SessionTable {
+    sessions: BTreeMap<SessionKey, Session>,
+    next_ssid: u16,
+}
+
+impl SessionTable {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Allocate a non-zero SSID no live session uses. Wraps at u16;
+    /// with realistic session counts (one per measured link) the loop
+    /// terminates immediately.
+    pub fn alloc_ssid(&mut self) -> u16 {
+        loop {
+            self.next_ssid = self.next_ssid.wrapping_add(1);
+            if self.next_ssid == 0 {
+                continue;
+            }
+            if !self.sessions.values().any(|s| s.ssid == self.next_ssid) {
+                return self.next_ssid;
+            }
+        }
+    }
+
+    pub fn insert(&mut self, session: Session) {
+        self.sessions.insert(session.key, session);
+    }
+
+    pub fn remove(&mut self, key: &SessionKey) -> Option<Session> {
+        self.sessions.remove(key)
+    }
+
+    pub fn get(&self, key: &SessionKey) -> Option<&Session> {
+        self.sessions.get(key)
+    }
+
+    pub fn get_mut(&mut self, key: &SessionKey) -> Option<&mut Session> {
+        self.sessions.get_mut(key)
+    }
+
+    pub fn iter(&self) -> impl Iterator<Item = (&SessionKey, &Session)> {
+        self.sessions.iter()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.sessions.is_empty()
+    }
+
+    pub fn len(&self) -> usize {
+        self.sessions.len()
+    }
+
+    /// The implicit-reflector allow-list (plan §2): a probe is
+    /// reflected only when its source is the remote of a registered
+    /// session — i.e. measurement is enabled on both ends of the link.
+    /// Returns the matching key so the per-session reflected counter
+    /// can tick. Kept as plain per-session data so a future XDP
+    /// offload can mirror it into a BPF map (offload notes §9b R2).
+    pub fn reflect_allowed(&self, src: IpAddr) -> Option<SessionKey> {
+        self.sessions.keys().find(|k| k.remote == src).copied()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn measurement_config_resolves_defaults() {
+        let c = MeasurementConfig::default();
+        assert!(!c.enabled());
+        let p = c.resolve();
+        assert_eq!(p.interval_ms, DEFAULT_INTERVAL_MS);
+        assert_eq!(p.damping_secs, DEFAULT_DAMPING_SECS);
+        assert_eq!(p.dst_port, stamp_packet::STAMP_UDP_PORT);
+
+        let c = MeasurementConfig {
+            enable: Some(true),
+            interval_ms: Some(100),
+            damping_period_secs: Some(2),
+        };
+        assert!(c.enabled());
+        let p = c.resolve();
+        assert_eq!(p.interval_ms, 100);
+        assert_eq!(p.damping_secs, 2);
+    }
+
+    #[test]
+    fn ssid_allocation_is_nonzero_and_advances() {
+        let mut t = SessionTable::new();
+        let a = t.alloc_ssid();
+        let b = t.alloc_ssid();
+        assert_ne!(a, 0);
+        assert_ne!(b, 0);
+        // Without intervening inserts the allocator just advances; the
+        // collision scan only matters once sessions hold SSIDs.
+        assert_ne!(a, b);
+    }
+}

--- a/zebra-rs/src/stamp/show.rs
+++ b/zebra-rs/src/stamp/show.rs
@@ -1,0 +1,345 @@
+//! `show stamp ...` command handlers.
+//!
+//! Mirrors `bfd/show.rs`: [`Stamp::show_build`] registers a handler
+//! per path, the event loop dispatches via `process_show_msg`, every
+//! command takes a trailing `json` flag.
+//!
+//!   * `show stamp`            — one line per session: link, state,
+//!     window counters, last exported snapshot.
+//!   * `show stamp session`    — per-session detail block.
+//!   * `show stamp statistics` — sender and reflector packet counters.
+
+use std::fmt::{self, Write};
+
+use serde::Serialize;
+
+use crate::config::{Args, Builder};
+
+use super::inst::{ShowCallback, Stamp};
+use super::session::{Session, SessionKey};
+use super::stats::MetricSnapshot;
+
+impl Stamp {
+    pub fn show_build(&mut self) {
+        self.show_cb = Builder::<ShowCallback>::default()
+            .path("/show/stamp")
+            .set(show_stamp)
+            .path("/show/stamp/session")
+            .set(show_stamp_session)
+            .path("/show/stamp/statistics")
+            .set(show_stamp_statistics)
+            .map();
+    }
+}
+
+/// Resolve the session's ifindex to a name, like BFD's show output.
+fn iface_str(key: &SessionKey) -> String {
+    if key.ifindex == 0 {
+        return "-".to_string();
+    }
+    let mut buf = [0u8; libc::IF_NAMESIZE];
+    let ptr = unsafe { libc::if_indextoname(key.ifindex, buf.as_mut_ptr() as *mut libc::c_char) };
+    if !ptr.is_null() {
+        let cstr = unsafe { std::ffi::CStr::from_ptr(ptr) };
+        cstr.to_string_lossy().into_owned()
+    } else {
+        format!("if{}", key.ifindex)
+    }
+}
+
+fn state_str(s: &Session) -> &'static str {
+    if s.is_active() { "Active" } else { "Idle" }
+}
+
+/// `min/avg/max (var)` µs, or `-` before the first export.
+fn export_str(snap: &Option<MetricSnapshot>) -> String {
+    match snap {
+        Some(s) => format!("{}/{}/{}us ({}us)", s.min, s.avg, s.max, s.variation),
+        None => "-".to_string(),
+    }
+}
+
+#[derive(Serialize)]
+struct StampSessionJson {
+    interface: String,
+    local: String,
+    remote: String,
+    state: String,
+    ssid: u16,
+    interval_ms: u32,
+    damping_period_secs: u32,
+    tx_count: u64,
+    rx_count: u64,
+    rx_invalid_count: u64,
+    tx_failed_count: u64,
+    reflected_count: u64,
+    window_sent: u32,
+    window_received: u32,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    window_loss_pct: Option<u32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    last_export: Option<MetricSnapshot>,
+    uptime_secs: u64,
+}
+
+fn session_json(key: &SessionKey, s: &Session) -> StampSessionJson {
+    StampSessionJson {
+        interface: iface_str(key),
+        local: key.local.to_string(),
+        remote: key.remote.to_string(),
+        state: state_str(s).to_string(),
+        ssid: s.ssid,
+        interval_ms: s.params.interval_ms,
+        damping_period_secs: s.params.damping_secs,
+        tx_count: s.tx_count,
+        rx_count: s.rx_count,
+        rx_invalid_count: s.rx_invalid_count,
+        tx_failed_count: s.tx_failed_count,
+        reflected_count: s.reflected_count,
+        window_sent: s.window.sent,
+        window_received: s.window.received,
+        window_loss_pct: s.window.loss_pct(),
+        last_export: s.last_export,
+        uptime_secs: s.created.elapsed().as_secs(),
+    }
+}
+
+fn show_stamp(stamp: &Stamp, _args: Args, json: bool) -> Result<String, fmt::Error> {
+    if json {
+        let list: Vec<StampSessionJson> = stamp
+            .sessions
+            .iter()
+            .map(|(k, s)| session_json(k, s))
+            .collect();
+        return Ok(serde_json::to_string_pretty(&list)
+            .unwrap_or_else(|e| format!("{{\"error\": \"{}\"}}", e)));
+    }
+
+    let mut buf = String::new();
+    if stamp.sessions.is_empty() {
+        writeln!(buf, "No STAMP sessions")?;
+        return Ok(buf);
+    }
+    writeln!(
+        buf,
+        "{:<10} {:<16} {:<16} {:<8} {:>8} {:>8} {:>6}  Last export (min/avg/max)",
+        "Interface", "Local", "Remote", "State", "Sent", "Recv", "Loss%"
+    )?;
+    for (key, s) in stamp.sessions.iter() {
+        let loss = s
+            .window
+            .loss_pct()
+            .map(|p| p.to_string())
+            .unwrap_or_else(|| "-".to_string());
+        writeln!(
+            buf,
+            "{:<10} {:<16} {:<16} {:<8} {:>8} {:>8} {:>6}  {}",
+            iface_str(key),
+            key.local.to_string(),
+            key.remote.to_string(),
+            state_str(s),
+            s.tx_count,
+            s.rx_count,
+            loss,
+            export_str(&s.last_export),
+        )?;
+    }
+    Ok(buf)
+}
+
+fn show_stamp_session(stamp: &Stamp, _args: Args, json: bool) -> Result<String, fmt::Error> {
+    if json {
+        // Same rows as the summary — detail adds nothing structured yet.
+        let list: Vec<StampSessionJson> = stamp
+            .sessions
+            .iter()
+            .map(|(k, s)| session_json(k, s))
+            .collect();
+        return Ok(serde_json::to_string_pretty(&list)
+            .unwrap_or_else(|e| format!("{{\"error\": \"{}\"}}", e)));
+    }
+
+    let mut buf = String::new();
+    writeln!(buf, "STAMP Sessions:")?;
+    if stamp.sessions.is_empty() {
+        writeln!(buf, "    No STAMP sessions")?;
+        return Ok(buf);
+    }
+    for (key, s) in stamp.sessions.iter() {
+        writeln!(
+            buf,
+            "    session {} -> {} ({})",
+            key.local,
+            key.remote,
+            iface_str(key)
+        )?;
+        writeln!(buf, "        SSID: {}", s.ssid)?;
+        writeln!(buf, "        State: {}", state_str(s))?;
+        writeln!(buf, "        Probe interval: {}ms", s.params.interval_ms)?;
+        writeln!(buf, "        Damping period: {}s", s.params.damping_secs)?;
+        writeln!(
+            buf,
+            "        Uptime: {} second(s)",
+            s.created.elapsed().as_secs()
+        )?;
+        writeln!(
+            buf,
+            "        Counters: tx {} rx {} rx-invalid {} tx-failed {} reflected {}",
+            s.tx_count, s.rx_count, s.rx_invalid_count, s.tx_failed_count, s.reflected_count
+        )?;
+        writeln!(
+            buf,
+            "        Current window: sent {} received {}",
+            s.window.sent, s.window.received
+        )?;
+        match &s.last_export {
+            Some(e) => {
+                writeln!(buf, "        Last export:")?;
+                writeln!(buf, "            Min delay: {} usec", e.min)?;
+                writeln!(buf, "            Max delay: {} usec", e.max)?;
+                writeln!(buf, "            Average delay: {} usec", e.avg)?;
+                writeln!(buf, "            Delay variation: {} usec", e.variation)?;
+            }
+            None => writeln!(buf, "        Last export: none")?,
+        }
+    }
+    Ok(buf)
+}
+
+#[derive(Serialize)]
+struct StampStatisticsJson {
+    sessions: usize,
+    sender_tx: u64,
+    sender_rx: u64,
+    sender_rx_invalid: u64,
+    sender_tx_failed: u64,
+    reflector_rx: u64,
+    reflector_reflected: u64,
+    reflector_unauthorized: u64,
+}
+
+fn show_stamp_statistics(stamp: &Stamp, _args: Args, json: bool) -> Result<String, fmt::Error> {
+    let (mut tx, mut rx, mut rx_invalid, mut tx_failed) = (0u64, 0u64, 0u64, 0u64);
+    for (_, s) in stamp.sessions.iter() {
+        tx += s.tx_count;
+        rx += s.rx_count;
+        rx_invalid += s.rx_invalid_count;
+        tx_failed += s.tx_failed_count;
+    }
+    if json {
+        let stats = StampStatisticsJson {
+            sessions: stamp.sessions.len(),
+            sender_tx: tx,
+            sender_rx: rx,
+            sender_rx_invalid: rx_invalid,
+            sender_tx_failed: tx_failed,
+            reflector_rx: stamp.reflector_stats.rx,
+            reflector_reflected: stamp.reflector_stats.reflected,
+            reflector_unauthorized: stamp.reflector_stats.unauthorized,
+        };
+        return Ok(serde_json::to_string_pretty(&stats)
+            .unwrap_or_else(|e| format!("{{\"error\": \"{}\"}}", e)));
+    }
+
+    let mut buf = String::new();
+    writeln!(buf, "STAMP statistics:")?;
+    writeln!(buf, "    Reflector socket: {}", stamp.local_addr)?;
+    writeln!(buf, "    Sessions: {}", stamp.sessions.len())?;
+    writeln!(buf, "    Sender:")?;
+    writeln!(buf, "        Probes sent: {}", tx)?;
+    writeln!(buf, "        Replies received: {}", rx)?;
+    writeln!(buf, "        Replies invalid: {}", rx_invalid)?;
+    writeln!(buf, "        Send failures: {}", tx_failed)?;
+    writeln!(buf, "    Reflector:")?;
+    writeln!(buf, "        Probes received: {}", stamp.reflector_stats.rx)?;
+    writeln!(
+        buf,
+        "        Probes reflected: {}",
+        stamp.reflector_stats.reflected
+    )?;
+    writeln!(
+        buf,
+        "        Probes unauthorized: {}",
+        stamp.reflector_stats.unauthorized
+    )?;
+    Ok(buf)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::VecDeque;
+    use std::net::{IpAddr, Ipv4Addr, SocketAddrV4};
+
+    use tokio::sync::mpsc;
+
+    use super::*;
+    use crate::context::ProtoContext;
+    use crate::stamp::session::SessionParams;
+
+    fn fresh_stamp() -> Stamp {
+        Stamp::new_with(
+            ProtoContext::default_table_no_rib(),
+            SocketAddrV4::new(Ipv4Addr::LOCALHOST, 0),
+        )
+        .expect("bind loopback")
+    }
+
+    fn no_args() -> Args {
+        Args(VecDeque::new())
+    }
+
+    fn key() -> SessionKey {
+        SessionKey {
+            local: IpAddr::V4(Ipv4Addr::LOCALHOST),
+            remote: IpAddr::V4(Ipv4Addr::new(127, 0, 0, 2)),
+            ifindex: 0,
+        }
+    }
+
+    #[tokio::test]
+    async fn empty_table_renders_placeholder() {
+        let stamp = fresh_stamp();
+        assert!(
+            show_stamp(&stamp, no_args(), false)
+                .unwrap()
+                .contains("No STAMP sessions")
+        );
+        let detail = show_stamp_session(&stamp, no_args(), false).unwrap();
+        assert!(detail.contains("STAMP Sessions:"));
+        assert!(detail.contains("No STAMP sessions"));
+        let stats = show_stamp_statistics(&stamp, no_args(), false).unwrap();
+        assert!(stats.contains("Sessions: 0"));
+    }
+
+    #[tokio::test]
+    async fn summary_and_detail_render_session() {
+        let mut stamp = fresh_stamp();
+        let (tx, _rx) = mpsc::unbounded_channel();
+        stamp.subscribe("isis".into(), key(), SessionParams::default(), tx);
+
+        let out = show_stamp(&stamp, no_args(), false).unwrap();
+        assert!(out.contains("127.0.0.2"), "remote address:\n{out}");
+        assert!(out.contains("Idle"), "no reply yet => Idle:\n{out}");
+
+        let detail = show_stamp_session(&stamp, no_args(), false).unwrap();
+        assert!(detail.contains("session 127.0.0.1 -> 127.0.0.2"));
+        assert!(detail.contains("Probe interval: 1000ms"));
+        assert!(detail.contains("Last export: none"));
+    }
+
+    #[tokio::test]
+    async fn json_outputs_are_well_formed() {
+        let mut stamp = fresh_stamp();
+        let (tx, _rx) = mpsc::unbounded_channel();
+        stamp.subscribe("isis".into(), key(), SessionParams::default(), tx);
+
+        let v: serde_json::Value =
+            serde_json::from_str(&show_stamp(&stamp, no_args(), true).unwrap()).unwrap();
+        assert_eq!(v[0]["remote"], "127.0.0.2");
+        assert_eq!(v[0]["state"], "Idle");
+
+        let v: serde_json::Value =
+            serde_json::from_str(&show_stamp_statistics(&stamp, no_args(), true).unwrap()).unwrap();
+        assert_eq!(v["sessions"], 1);
+    }
+}

--- a/zebra-rs/src/stamp/socket.rs
+++ b/zebra-rs/src/stamp/socket.rs
@@ -1,0 +1,95 @@
+//! STAMP UDP socket construction.
+//!
+//! Two socket shapes, both IPv4 (Phase 1):
+//!
+//!   * one wildcard **reflector** socket per instance, normally bound
+//!     to `0.0.0.0:862`, with `IP_RECVTTL` + `IP_PKTINFO` so replies
+//!     can be stamped with the probed address as source and pinned to
+//!     the ingress interface — a copy of `bfd_socket_ipv4`;
+//!   * one **connected sender** socket per session, bound to the link
+//!     address with an ephemeral port and `connect()`ed to the
+//!     reflector — the kernel then does reply demux per 4-tuple, so no
+//!     SSID-based global demux is needed.
+//!
+//! Egress TTL is 255 on both: probes between direct IGP neighbors
+//! should arrive with TTL 255, and the received TTL is surfaced for
+//! `show stamp` (a GTSM-style floor is *not* enforced in Phase 1 — the
+//! reflector allow-list is the admission gate).
+
+use std::net::SocketAddrV4;
+use std::os::fd::AsRawFd;
+use std::os::raw::c_int;
+
+use socket2::{Domain, Socket};
+
+use crate::context::ProtoContext;
+
+/// Build the wildcard reflector socket. Mirrors
+/// [`crate::bfd::socket::bfd_socket_ipv4`]; see the module docs for the
+/// option rationale. Production callers pass `(0.0.0.0, 862)`; tests an
+/// ephemeral loopback port.
+pub fn stamp_reflector_socket(ctx: &ProtoContext, bind: SocketAddrV4) -> std::io::Result<Socket> {
+    let socket = ctx.udp_socket_unbound(Domain::IPV4)?;
+
+    socket.set_nonblocking(true)?;
+    socket.set_reuse_address(true)?;
+    socket.set_ttl_v4(255)?;
+    set_ipv4_recvttl(&socket)?;
+    set_ipv4_pktinfo(&socket)?;
+
+    socket.bind(&bind.into())?;
+    Ok(socket)
+}
+
+/// Build one session's connected sender socket: bound to the link
+/// address (ephemeral port), connected to the reflector. After
+/// `connect()` the kernel delivers only datagrams from exactly
+/// `remote` to this socket and `send()` needs no address.
+pub fn stamp_sender_socket(
+    ctx: &ProtoContext,
+    local: SocketAddrV4,
+    remote: SocketAddrV4,
+) -> std::io::Result<Socket> {
+    let socket = ctx.udp_socket_unbound(Domain::IPV4)?;
+
+    socket.set_nonblocking(true)?;
+    socket.set_ttl_v4(255)?;
+
+    socket.bind(&local.into())?;
+    socket.connect(&remote.into())?;
+    Ok(socket)
+}
+
+fn set_ipv4_recvttl(socket: &Socket) -> std::io::Result<()> {
+    let on: c_int = 1;
+    let rc = unsafe {
+        libc::setsockopt(
+            socket.as_raw_fd(),
+            libc::IPPROTO_IP,
+            libc::IP_RECVTTL,
+            &on as *const _ as *const libc::c_void,
+            std::mem::size_of::<c_int>() as libc::socklen_t,
+        )
+    };
+    if rc < 0 {
+        return Err(std::io::Error::last_os_error());
+    }
+    Ok(())
+}
+
+fn set_ipv4_pktinfo(socket: &Socket) -> std::io::Result<()> {
+    let on: c_int = 1;
+    let rc = unsafe {
+        libc::setsockopt(
+            socket.as_raw_fd(),
+            libc::IPPROTO_IP,
+            libc::IP_PKTINFO,
+            &on as *const _ as *const libc::c_void,
+            std::mem::size_of::<c_int>() as libc::socklen_t,
+        )
+    };
+    if rc < 0 {
+        return Err(std::io::Error::last_os_error());
+    }
+    Ok(())
+}

--- a/zebra-rs/src/stamp/stats.rs
+++ b/zebra-rs/src/stamp/stats.rs
@@ -1,0 +1,158 @@
+//! Per-session delay statistics window.
+//!
+//! Each STAMP session accumulates one [`StatsWindow`] per damping
+//! period. At every export tick the window is condensed into a
+//! [`MetricSnapshot`] — the min/max/avg delay and delay variation the
+//! IGPs advertise (RFC 8570 / RFC 7471 sub-TLVs) — and then reset, so
+//! consecutive periods are independent samples of the link.
+
+use serde::Serialize;
+
+/// One damping period's worth of delay measurements, condensed.
+/// All fields are microseconds, matching both the IGP sub-TLV units
+/// (RFC 8570 §4 / RFC 7471 §4 advertise 24-bit microsecond values)
+/// and the existing static `te-metric` config leaves.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+pub struct MetricSnapshot {
+    pub min: u32,
+    pub max: u32,
+    pub avg: u32,
+    /// Average delay variation: mean absolute difference between
+    /// consecutive samples in the window (RFC 8570 §4.3's "delay
+    /// variation" is implementation-defined; consecutive-difference
+    /// is the common interpretation and is robust to slow drift).
+    pub variation: u32,
+}
+
+/// Accumulates samples between export ticks. `sent` / `received`
+/// count probes during the current window for the `show stamp` loss
+/// figure; they are *not* exported to the IGP (a one-window sample is
+/// too noisy to advertise — parent plan §6).
+#[derive(Debug, Default)]
+pub struct StatsWindow {
+    delays: Vec<u32>,
+    pub sent: u32,
+    pub received: u32,
+}
+
+impl StatsWindow {
+    pub fn record_sent(&mut self) {
+        self.sent = self.sent.saturating_add(1);
+    }
+
+    /// Record one valid two-way delay sample (microseconds). The single
+    /// entry point for samples — a future kernel-aggregate mode feeds
+    /// pre-reduced `{min,max,sum,count}` through the same seam
+    /// (offload notes §9b).
+    pub fn record_delay(&mut self, delay_us: u32) {
+        self.received = self.received.saturating_add(1);
+        self.delays.push(delay_us);
+    }
+
+    /// Condense the window. `None` when no sample arrived — the caller
+    /// turns that into a "clear" export so stale values never linger.
+    pub fn snapshot(&self) -> Option<MetricSnapshot> {
+        if self.delays.is_empty() {
+            return None;
+        }
+        let min = *self.delays.iter().min().unwrap();
+        let max = *self.delays.iter().max().unwrap();
+        let sum: u64 = self.delays.iter().map(|&d| d as u64).sum();
+        let avg = (sum / self.delays.len() as u64) as u32;
+        let variation = if self.delays.len() < 2 {
+            0
+        } else {
+            let total: u64 = self
+                .delays
+                .windows(2)
+                .map(|w| w[0].abs_diff(w[1]) as u64)
+                .sum();
+            (total / (self.delays.len() - 1) as u64) as u32
+        };
+        Some(MetricSnapshot {
+            min,
+            max,
+            avg,
+            variation,
+        })
+    }
+
+    /// Start a fresh window (export tick).
+    pub fn reset(&mut self) {
+        self.delays.clear();
+        self.sent = 0;
+        self.received = 0;
+    }
+
+    /// Probe loss within the current window, percent. `None` until a
+    /// probe has been sent.
+    pub fn loss_pct(&self) -> Option<u32> {
+        if self.sent == 0 {
+            return None;
+        }
+        let lost = self.sent.saturating_sub(self.received);
+        Some(lost * 100 / self.sent)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn empty_window_has_no_snapshot() {
+        let w = StatsWindow::default();
+        assert_eq!(w.snapshot(), None);
+        assert_eq!(w.loss_pct(), None);
+    }
+
+    #[test]
+    fn single_sample_snapshot() {
+        let mut w = StatsWindow::default();
+        w.record_delay(500);
+        let s = w.snapshot().unwrap();
+        assert_eq!(s.min, 500);
+        assert_eq!(s.max, 500);
+        assert_eq!(s.avg, 500);
+        assert_eq!(s.variation, 0);
+    }
+
+    #[test]
+    fn min_max_avg_variation() {
+        let mut w = StatsWindow::default();
+        for d in [100u32, 200, 150, 250] {
+            w.record_delay(d);
+        }
+        let s = w.snapshot().unwrap();
+        assert_eq!(s.min, 100);
+        assert_eq!(s.max, 250);
+        assert_eq!(s.avg, 175);
+        // |100−200| + |200−150| + |150−250| = 250; / 3 = 83.
+        assert_eq!(s.variation, 83);
+    }
+
+    #[test]
+    fn reset_clears_everything() {
+        let mut w = StatsWindow::default();
+        w.record_sent();
+        w.record_delay(100);
+        w.reset();
+        assert_eq!(w.snapshot(), None);
+        assert_eq!(w.sent, 0);
+        assert_eq!(w.received, 0);
+    }
+
+    #[test]
+    fn loss_pct_counts_unanswered_probes() {
+        let mut w = StatsWindow::default();
+        for _ in 0..4 {
+            w.record_sent();
+        }
+        w.record_delay(100);
+        assert_eq!(w.loss_pct(), Some(75));
+        w.record_delay(100);
+        w.record_delay(100);
+        w.record_delay(100);
+        assert_eq!(w.loss_pct(), Some(0));
+    }
+}

--- a/zebra-rs/src/stamp/timestamp.rs
+++ b/zebra-rs/src/stamp/timestamp.rs
@@ -1,0 +1,106 @@
+//! NTP 64-bit timestamp helpers (RFC 8762 §4.1.1).
+//!
+//! STAMP timestamps default to the NTP 64-bit format (RFC 5905):
+//! seconds since 1900-01-01 plus a 32-bit binary fraction of a second.
+//! The codec ([`stamp_packet::StampTimestamp`]) stores the raw words;
+//! these helpers do the epoch shift from `SystemTime` (UNIX epoch) and
+//! the signed microsecond arithmetic the RFC 8762 §4.2 two-way delay
+//! computation needs. Clock synchronisation is *not* assumed — the
+//! caller advertises `S=0` in the Error Estimate and the delay math
+//! ([`crate::stamp::inst`]) only ever differences timestamps taken on
+//! the same clock.
+
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use stamp_packet::StampTimestamp;
+
+/// Seconds between the NTP epoch (1900-01-01) and the UNIX epoch
+/// (1970-01-01): 70 years, 17 of them leap years.
+const NTP_UNIX_OFFSET_SECS: u64 = 2_208_988_800;
+
+/// Current wall-clock time as an NTP 64-bit STAMP timestamp.
+pub fn now_ntp() -> StampTimestamp {
+    let since_unix = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default();
+    // fraction = ns · 2³² / 10⁹, computed in u64 (ns < 10⁹ so the
+    // product fits comfortably).
+    let fraction = ((since_unix.subsec_nanos() as u64) << 32) / 1_000_000_000;
+    StampTimestamp {
+        seconds: (since_unix.as_secs().wrapping_add(NTP_UNIX_OFFSET_SECS)) as u32,
+        fraction: fraction as u32,
+    }
+}
+
+/// Signed difference `later − earlier` in microseconds.
+///
+/// Both operands are treated as 64-bit NTP values (seconds ‖ fraction);
+/// the subtraction is exact and the result is scaled to microseconds in
+/// i128 so neither overflow nor precision loss can occur for any pair
+/// of timestamps within the same NTP era.
+pub fn delta_micros(later: StampTimestamp, earlier: StampTimestamp) -> i64 {
+    let a = ((later.seconds as u64) << 32) | later.fraction as u64;
+    let b = ((earlier.seconds as u64) << 32) | earlier.fraction as u64;
+    let diff = a as i64 - b as i64; // signed; era wrap is out of scope
+    ((diff as i128 * 1_000_000) >> 32) as i64
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn ts(seconds: u32, fraction: u32) -> StampTimestamp {
+        StampTimestamp { seconds, fraction }
+    }
+
+    /// `now_ntp` must land in the NTP era that contains today: its
+    /// seconds field, shifted back to the UNIX epoch, has to be within
+    /// a second of `SystemTime::now()`.
+    #[test]
+    fn now_is_epoch_shifted() {
+        let unix_now = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_secs();
+        let ntp = now_ntp();
+        let back = (ntp.seconds as u64).wrapping_sub(NTP_UNIX_OFFSET_SECS);
+        assert!(
+            back.abs_diff(unix_now) <= 1,
+            "ntp seconds {back} vs unix {unix_now}"
+        );
+    }
+
+    /// One whole second is exactly 1 000 000 µs.
+    #[test]
+    fn delta_whole_seconds() {
+        assert_eq!(delta_micros(ts(101, 0), ts(100, 0)), 1_000_000);
+        assert_eq!(delta_micros(ts(100, 0), ts(101, 0)), -1_000_000);
+    }
+
+    /// A half-second fraction (2³¹) is 500 000 µs.
+    #[test]
+    fn delta_fraction_math() {
+        assert_eq!(delta_micros(ts(100, 1 << 31), ts(100, 0)), 500_000);
+        // Borrow across the seconds boundary: 100.75 − 100.25 = 0.5 s.
+        assert_eq!(delta_micros(ts(100, 3 << 30), ts(100, 1 << 30)), 500_000);
+        // 1 µs is ~4294.97 fraction units; 4295 rounds down to 1 µs.
+        assert_eq!(delta_micros(ts(100, 4295), ts(100, 0)), 1);
+    }
+
+    /// Negative deltas (clock step or reordered timestamps) come back
+    /// signed so the caller can discard them.
+    #[test]
+    fn delta_negative() {
+        assert!(delta_micros(ts(100, 0), ts(100, 1 << 31)) < 0);
+    }
+
+    /// Round-trip: a fraction built from nanoseconds converts back to
+    /// the same microsecond count.
+    #[test]
+    fn fraction_round_trip() {
+        let ns = 123_456_789u64; // 123 456.789 µs
+        let fraction = ((ns << 32) / 1_000_000_000) as u32;
+        let got = delta_micros(ts(100, fraction), ts(100, 0));
+        assert!((got - 123_456).abs() <= 1, "got {got}");
+    }
+}

--- a/zebra-rs/yang/config.yang
+++ b/zebra-rs/yang/config.yang
@@ -700,6 +700,41 @@ module config {
                    encoded in units of 0.000003 %; the maximum 16777214
                    (0xFFFFFE) is ~50.33 %.";
               }
+              container measurement {
+                ext:help "Measure this link's delay dynamically (STAMP, RFC 8762)";
+                description
+                  "Active performance measurement of this link. When
+                   enabled, a STAMP Session-Sender (RFC 8762,
+                   unauthenticated) probes the P2P neighbor once the
+                   adjacency reaches Full; the damped min/max/avg delay
+                   and delay variation populate the same te-metric
+                   fields as static configuration (a static leaf, when
+                   set, overrides the measured value per field). The
+                   probes are answered by the neighbor's implicit
+                   Session-Reflector, so measurement must be enabled on
+                   both ends of the link.";
+                leaf enable {
+                  type boolean;
+                  description "Activate measurement on this interface.";
+                }
+                leaf interval {
+                  type uint32 {
+                    range "100..60000";
+                  }
+                  units "milliseconds";
+                  description "Probe transmit interval. Default 1000 ms.";
+                }
+                leaf damping-period {
+                  type uint32 {
+                    range "1..3600";
+                  }
+                  units "seconds";
+                  description
+                    "Minimum spacing between exports to the IGP; each
+                     period's samples form the advertised min/max/avg
+                     window. Default 30 s.";
+                }
+              }
             }
           }
         }
@@ -2211,6 +2246,41 @@ module config {
                 "Unidirectional link loss (RFC 8570 §4.4, sub-TLV 36),
                  encoded in units of 0.000003 %; the maximum 16777214
                  (0xFFFFFE) is ~50.33 %.";
+            }
+            container measurement {
+              ext:help "Measure this link's delay dynamically (STAMP, RFC 8762)";
+              description
+                "Active performance measurement of this link. When
+                 enabled, a STAMP Session-Sender (RFC 8762,
+                 unauthenticated) probes the P2P neighbor once the
+                 adjacency is up; the damped min/max/avg delay and
+                 delay variation populate the same te-metric fields as
+                 static configuration (a static leaf, when set,
+                 overrides the measured value per field). The probes
+                 are answered by the neighbor's implicit
+                 Session-Reflector, so measurement must be enabled on
+                 both ends of the link.";
+              leaf enable {
+                type boolean;
+                description "Activate measurement on this interface.";
+              }
+              leaf interval {
+                type uint32 {
+                  range "100..60000";
+                }
+                units "milliseconds";
+                description "Probe transmit interval. Default 1000 ms.";
+              }
+              leaf damping-period {
+                type uint32 {
+                  range "1..3600";
+                }
+                units "seconds";
+                description
+                  "Minimum spacing between exports to the IGP; each
+                   period's samples form the advertised min/max/avg
+                   window. Default 30 s.";
+              }
             }
           }
 

--- a/zebra-rs/yang/exec.yang
+++ b/zebra-rs/yang/exec.yang
@@ -215,6 +215,18 @@ module exec {
         type empty;
       }
     }
+    container stamp {
+      ext:help "STAMP (RFC 8762) link delay measurement";
+      presence "Show STAMP session summary";
+      leaf session {
+        ext:help "Per-session detail";
+        type empty;
+      }
+      leaf statistics {
+        ext:help "Sender and reflector packet counters";
+        type empty;
+      }
+    }
     container bgp {
       ext:help "BGP information";
       // `show bgp` with no AFI keyword is IPv4 unicast. A bare address


### PR DESCRIPTION
## Summary

Phase 1 of the STAMP SR-MPLS TE plan (`docs/design/stamp-sr-mpls-te-plan.md`): the measurement plane. Closes the loop **probe → stats → damping → IGP te-metric → LSP/LSA → Flex-Algo metric-type-1 SPF** for IPv4 P2P links in both IS-IS (RFC 8570) and OSPFv2 (RFC 7471).

Step-by-step plan with locked design decisions D1–D16: `docs/design/stamp-phase1-implementation-plan.md` (first commit).

## What's new

- **`zebra-rs/src/stamp/`** — RFC 8762 unauthenticated Session-Sender: one connected UDP socket per session (kernel demuxes replies per 4-tuple), per-session prober task, NTP-64 timestamps with `S=0`/`Z=0`. Two-way delay `((T4−T1) − (T3−T2))/2` — the reflector-residence term cancels the inter-node clock offset, so no clock sync is required; negative/>10 s samples are discarded as wall-clock steps (D1).
- **Implicit Session-Reflector** (deviation from the parent plan, §2 of the phase-1 doc): wildcard `0.0.0.0:862` answers a probe only when its source is a registered session's remote — i.e. measurement is enabled on **both** ends (Cisco SR-PM model). Without this, two zebra-rs routers can't measure each other in Phase 1. Replies stamp the probed address as source and pin egress to the ingress ifindex; RFC 6038 symmetric size via Extra Padding. `build_reply` is a pure function — the executable spec for a future XDP offload (notes §9b, R1–R6 seams all in place).
- **Damping** (D7/D8): export to the IGP only on first value, clear, or any field moving more than `max(old/10, 50 µs)`; an empty period exports a **clear** so stale measurements withdraw and metric-type-1 topologies prune the link (RFC 9350 §15).
- **Shared sessions** (D11): IS-IS and OSPF measuring the same link drive one session (BFD-style subscriber registry, ClientId per protocol); a later Subscribe with different params retunes live (last-writer-wins).
- **Config**: `te-metric measurement { enable; interval 100..60000ms; damping-period 1..3600s }` on IS-IS and OSPFv2 interfaces (defaults 1 s / 30 s). Static te-metric leaves override measured values **per field** (D10, `te_metric_effective()`).
- **Lifecycle**: `spawn_stamp`/`despawn_stamp` mirror BFD — eager-spawned by the `router isis`/`router ospf` commit arms, torn down with the last consumer; port-862 bind failure is non-fatal. VRF children pass `None` (default-VRF only, D15).
- **Reconciles**: IS-IS diff-gates a tracked `(SessionKey, SessionParams)` per link, re-evaluated on `CommitEnd` + NFSM Up-edges + hold-timer expiry; OSPFv2 mirrors `bfd_reconcile_nbr` (Full-neighbor gated, Extended-Link LSA refresh, SR-MPLS gated). OSPFv3 stays inert by construction (no measurement YANG + v4-pair gate).
- **Show**: `show stamp`, `show stamp session`, `show stamp statistics`.

## Out of scope (deferred per parent plan)

Configured external-facing reflector + 4-tuple allow-list, LAN circuits, IPv6 sessions, VRF sessions, loss export to the IGP, RFC 8972 TLVs beyond Extra Padding, RFC 9503 return path, authenticated modes. First accuracy follow-up: sender `SO_TIMESTAMPING` (offload notes §9b).

## Testing

- 38 new unit tests (timestamp math, stats window, damping gate, reflector reply/symmetric-size, session lifecycle/SSID, show renderers, per-IGP `te_metric_effective` merge) + an in-process loopback integration test exercising the full socket path.
- YANG parse pins for the new config/show grammar (incl. out-of-range rejection).
- New BDD `@stamp_te_metric`: two namespaces, **both** IGPs on one P2P link (exercising the shared-session path), no static te-metric anywhere — asserts sessions go Active and `Min/Max Unidirectional Link Delay` appears in both LSDBs; explicit teardown. **Passed 5/5 scenarios.**
- Regression BDDs on the same binary: `isis_l1p2p` 7/7, `ospfv2_tilfa` 10/10.
- `cargo test --workspace --exclude bdd` green; `cargo fmt`; `cargo clippy --workspace --all-targets -- -D warnings` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)