### PR TITLE
bgp: re-key Adj-RIB-In into BgpShard ident slices (sharding B.1)

### DIFF
--- a/zebra-rs/src/bgp/adj_rib.rs
+++ b/zebra-rs/src/bgp/adj_rib.rs
@@ -293,7 +293,30 @@ impl<D: RibDirection, P: Ord> Default for AdjRibTable<D, P> {
     }
 }
 
-impl AdjRib<In> {
+/// Per-peer Adj-RIB-In slice for the shard-scope families (RIB
+/// sharding plan B.1 / D3): v4/v6 unicast, v4/v6 labeled-unicast,
+/// VPNv4/v6. Lives in [`super::shard::BgpShard::adj_in`] keyed by
+/// peer `ident` — `Peer` stays main-owned, so its received routes
+/// for the sharded tables are stored beside the Loc-RIB tables a
+/// future shard task will own. The main-only families stay on the
+/// peer in [`MainAdjIn`].
+#[derive(Debug, Default)]
+pub struct ShardAdjIn {
+    // IPv4 unicast
+    pub v4: AdjRibTable<In>,
+    // IPv6 unicast
+    pub v6: AdjRibTable<In, Ipv6Net>,
+    // IPv4 Labeled-Unicast (SAFI 4)
+    pub v4lu: AdjRibTable<In>,
+    // IPv6 Labeled-Unicast (SAFI 4)
+    pub v6lu: AdjRibTable<In, Ipv6Net>,
+    // IPv4 VPN
+    pub v4vpn: BTreeMap<RouteDistinguisher, AdjRibTable<In>>,
+    // IPv6 VPN
+    pub v6vpn: BTreeMap<RouteDistinguisher, AdjRibTable<In, Ipv6Net>>,
+}
+
+impl ShardAdjIn {
     // Add a route to Adj-RIB-In
     pub fn add(
         &mut self,
@@ -366,6 +389,43 @@ impl AdjRib<In> {
         self.v6vpn.entry(rd).or_default().remove(prefix, id)
     }
 
+    /// Received-prefix count for a sharded AFI/SAFI; 0 for families
+    /// owned by [`MainAdjIn`] (the two counts are disjoint, so show
+    /// paths may sum them for any AFI/SAFI).
+    pub fn count(&self, afi: Afi, safi: Safi) -> usize {
+        match (afi, safi) {
+            (Afi::Ip, Safi::Unicast) => self.v4.0.len(),
+            (Afi::Ip6, Safi::Unicast) => self.v6.0.len(),
+            (Afi::Ip, Safi::MplsLabel) => self.v4lu.0.len(),
+            (Afi::Ip6, Safi::MplsLabel) => self.v6lu.0.len(),
+            (Afi::Ip, Safi::MplsVpn) => self.v4vpn.values().map(|table| table.0.len()).sum(),
+            (Afi::Ip6, Safi::MplsVpn) => self.v6vpn.values().map(|table| table.0.len()).sum(),
+            (_, _) => 0,
+        }
+    }
+}
+
+/// Per-peer Adj-RIB-In for the main-owned families (RIB sharding
+/// plan D3): EVPN, flowspec, BGP-LS. Stays on [`super::peer::Peer`];
+/// the sharded families live in [`ShardAdjIn`] under
+/// `BgpShard::adj_in`.
+#[derive(Debug, Default)]
+pub struct MainAdjIn {
+    // EVPN, per Route Distinguisher
+    pub evpn: BTreeMap<RouteDistinguisher, AdjRibEvpnTable<In>>,
+    // IPv4 Flow Specification (AFI 1, SAFI 133)
+    pub flowspec_v4: AdjRibFlowspecTable<In>,
+    // IPv6 Flow Specification (AFI 2, SAFI 133)
+    pub flowspec_v6: AdjRibFlowspecTable<In>,
+    // BGP Link-State (AFI 16388, SAFI 71)
+    pub bgp_ls: AdjRibBgpLsTable<In>,
+}
+
+impl MainAdjIn {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
     // EVPN add/remove ---------------------------------------------------------
 
     pub fn add_evpn(
@@ -412,14 +472,10 @@ impl AdjRib<In> {
         self.bgp_ls.remove(nlri, id)
     }
 
+    /// Received-prefix count for a main-owned AFI/SAFI; 0 for the
+    /// sharded families (see [`ShardAdjIn::count`]).
     pub fn count(&self, afi: Afi, safi: Safi) -> usize {
         match (afi, safi) {
-            (Afi::Ip, Safi::Unicast) => self.v4.0.len(),
-            (Afi::Ip6, Safi::Unicast) => self.v6.0.len(),
-            (Afi::Ip, Safi::MplsLabel) => self.v4lu.0.len(),
-            (Afi::Ip6, Safi::MplsLabel) => self.v6lu.0.len(),
-            (Afi::Ip, Safi::MplsVpn) => self.v4vpn.values().map(|table| table.0.len()).sum(),
-            (Afi::Ip6, Safi::MplsVpn) => self.v6vpn.values().map(|table| table.0.len()).sum(),
             (Afi::L2vpn, Safi::Evpn) => self.evpn.values().map(|table| table.0.len()).sum(),
             (Afi::Ip, Safi::Flowspec) => self.flowspec_v4.0.len(),
             (Afi::Ip6, Safi::Flowspec) => self.flowspec_v6.0.len(),

--- a/zebra-rs/src/bgp/peer.rs
+++ b/zebra-rs/src/bgp/peer.rs
@@ -24,7 +24,7 @@ use crate::bfd::session::{EchoMode, SessionKey, SessionParams};
 use crate::bgp::cap::cap_register_recv;
 use crate::bgp::route::{route_clean, route_sync};
 use crate::bgp::tracing::{Direction, PacketKind};
-use crate::bgp::{AdjRib, In, Out};
+use crate::bgp::{AdjRib, MainAdjIn, Out};
 use crate::bgp::{stale_route_withdraw, timer};
 use crate::bgp_packet_trace;
 use crate::config::Args;
@@ -809,7 +809,11 @@ pub struct Peer {
     pub cap_send: BgpCap,
     pub cap_recv: BgpCap,
     pub cap_map: CapAfiMap,
-    pub adj_in: AdjRib<In>,
+    /// Adj-RIB-In for the main-owned families (EVPN, flowspec,
+    /// BGP-LS). The sharded families' received routes live in
+    /// `BgpShard::adj_in` keyed by this peer's `ident` (RIB sharding
+    /// plan B.1 / D3).
+    pub adj_in: MainAdjIn,
     pub adj_out: AdjRib<Out>,
     pub opt: ParseOption,
     pub policy_list: InOuts<PolicyListValue>,
@@ -960,7 +964,7 @@ impl Peer {
             cap_send: BgpCap::default(),
             cap_recv: BgpCap::default(),
             cap_map: CapAfiMap::new(),
-            adj_in: AdjRib::new(),
+            adj_in: MainAdjIn::new(),
             adj_out: AdjRib::new(),
             opt: ParseOption::default(),
             policy_list: InOuts::<PolicyListValue>::default(),

--- a/zebra-rs/src/bgp/route.rs
+++ b/zebra-rs/src/bgp/route.rs
@@ -2070,7 +2070,9 @@ pub fn route_ipv4_update(
     // Register to peer's AdjRibIn and update stats
     let decision = {
         let peer = peers.get_mut_by_idx(ident).expect("peer must exist");
-        peer.adj_in.add(rd, nlri.prefix, rib.clone());
+        bgp.shard
+            .adj_in_mut(peer.ident)
+            .add(rd, nlri.prefix, rib.clone());
 
         // Apply policy. Carry the rib's current weight (0 here,
         // since this is the first time the route enters the local
@@ -3152,7 +3154,10 @@ pub fn route_soft_in_peer(peer_idx: usize, bgp: &mut BgpTop, peers: &mut PeerMap
         let do_v4 = peer.is_afi_safi(Afi::Ip, Safi::Unicast);
         let do_vpn = peer.is_afi_safi(Afi::Ip, Safi::MplsVpn);
         let rds: Vec<RouteDistinguisher> = if do_vpn {
-            peer.adj_in.v4vpn.keys().copied().collect()
+            bgp.shard
+                .adj_in(peer.ident)
+                .map(|a| a.v4vpn.keys().copied().collect())
+                .unwrap_or_default()
         } else {
             Vec::new()
         };
@@ -3178,15 +3183,16 @@ fn route_soft_in_peer_table(
     // fan-out) don't conflict with the iteration.
     let entries: Vec<(Ipv4Net, Vec<BgpRib>)> = {
         let peer = peers.get_mut_by_idx(peer_idx).expect("peer exists");
+        let Some(adj_in) = bgp.shard.adj_in(peer.ident) else {
+            return;
+        };
         match rd {
-            Some(rd) => peer
-                .adj_in
+            Some(rd) => adj_in
                 .v4vpn
                 .get(&rd)
                 .map(|t| t.0.iter().map(|(p, ribs)| (*p, ribs.clone())).collect())
                 .unwrap_or_default(),
-            None => peer
-                .adj_in
+            None => adj_in
                 .v4
                 .0
                 .iter()
@@ -3255,7 +3261,9 @@ pub fn route_ipv4_withdraw(
     {
         if rib_in {
             let peer = peers.get_mut_by_idx(ident).expect("peer must exist");
-            peer.adj_in.remove(rd, nlri.prefix, nlri.id);
+            bgp.shard
+                .adj_in_mut(peer.ident)
+                .remove(rd, nlri.prefix, nlri.id);
         }
     }
 
@@ -3439,8 +3447,14 @@ pub fn route_ipv6_update(
     {
         let peer = peers.get_mut_by_idx(ident).expect("peer must exist");
         match rd {
-            Some(rd) => peer.adj_in.add_v6vpn(rd, nlri.prefix, rib.clone()),
-            None => peer.adj_in.add_v6(nlri.prefix, rib.clone()),
+            Some(rd) => bgp
+                .shard
+                .adj_in_mut(peer.ident)
+                .add_v6vpn(rd, nlri.prefix, rib.clone()),
+            None => bgp
+                .shard
+                .adj_in_mut(peer.ident)
+                .add_v6(nlri.prefix, rib.clone()),
         };
     }
 
@@ -3545,8 +3559,14 @@ pub fn route_ipv6_withdraw(
     if rib_in {
         let peer = peers.get_mut_by_idx(ident).expect("peer must exist");
         match rd {
-            Some(rd) => peer.adj_in.remove_v6vpn(rd, nlri.prefix, nlri.id),
-            None => peer.adj_in.remove_v6(nlri.prefix, nlri.id),
+            Some(rd) => bgp
+                .shard
+                .adj_in_mut(peer.ident)
+                .remove_v6vpn(rd, nlri.prefix, nlri.id),
+            None => bgp
+                .shard
+                .adj_in_mut(peer.ident)
+                .remove_v6(nlri.prefix, nlri.id),
         };
     }
 
@@ -3697,7 +3717,9 @@ pub fn route_labelv4_update(
 
     {
         let peer = peers.get_mut_by_idx(ident).expect("peer must exist");
-        peer.adj_in.add_v4lu(lu.nlri.prefix, rib.clone());
+        bgp.shard
+            .adj_in_mut(peer.ident)
+            .add_v4lu(lu.nlri.prefix, rib.clone());
     }
 
     rib.attr = bgp.attr_store.intern(attr);
@@ -3795,7 +3817,9 @@ pub fn route_labelv6_update(
 
     {
         let peer = peers.get_mut_by_idx(ident).expect("peer must exist");
-        peer.adj_in.add_v6lu(lu.nlri.prefix, rib.clone());
+        bgp.shard
+            .adj_in_mut(peer.ident)
+            .add_v6lu(lu.nlri.prefix, rib.clone());
     }
 
     rib.attr = bgp.attr_store.intern(attr);
@@ -3834,7 +3858,9 @@ pub fn route_labelv4_withdraw(
 ) {
     if rib_in {
         let peer = peers.get_mut_by_idx(ident).expect("peer must exist");
-        peer.adj_in.remove_v4lu(nlri.prefix, nlri.id);
+        bgp.shard
+            .adj_in_mut(peer.ident)
+            .remove_v4lu(nlri.prefix, nlri.id);
     }
     let removed = bgp.shard.remove_v4lu(nlri.prefix, nlri.id, ident);
     if bgp.nexthop_cache.is_some() {
@@ -3880,7 +3906,9 @@ pub fn route_labelv6_withdraw(
 ) {
     if rib_in {
         let peer = peers.get_mut_by_idx(ident).expect("peer must exist");
-        peer.adj_in.remove_v6lu(nlri.prefix, nlri.id);
+        bgp.shard
+            .adj_in_mut(peer.ident)
+            .remove_v6lu(nlri.prefix, nlri.id);
     }
     let removed = bgp.shard.remove_v6lu(nlri.prefix, nlri.id, ident);
     if bgp.nexthop_cache.is_some() {
@@ -5669,15 +5697,15 @@ pub fn route_clean(peer_id: usize, bgp: &mut BgpTop, peers: &mut PeerMap) {
     // IPv4 unicast.
     let withdrawn = {
         let mut withdrawn: Vec<Ipv4Nlri> = vec![];
-        let peer = peers.get_mut_by_idx(peer_id).expect("peer must exist");
-
-        for (prefix, ribs) in peer.adj_in.v4.0.iter() {
-            for rib in ribs.iter() {
-                let withdraw = Ipv4Nlri {
-                    id: rib.remote_id,
-                    prefix: *prefix,
-                };
-                withdrawn.push(withdraw);
+        if let Some(adj_in) = bgp.shard.adj_in(peer_id) {
+            for (prefix, ribs) in adj_in.v4.0.iter() {
+                for rib in ribs.iter() {
+                    let withdraw = Ipv4Nlri {
+                        id: rib.remote_id,
+                        prefix: *prefix,
+                    };
+                    withdrawn.push(withdraw);
+                }
             }
         }
         withdrawn
@@ -5685,8 +5713,8 @@ pub fn route_clean(peer_id: usize, bgp: &mut BgpTop, peers: &mut PeerMap) {
     for withdraw in withdrawn.iter() {
         route_ipv4_withdraw(peer_id, withdraw, None, None, bgp, peers, true);
     }
+    bgp.shard.adj_in_mut(peer_id).v4.0.clear();
     let peer = peers.get_mut_by_idx(peer_id).expect("peer must exist");
-    peer.adj_in.v4.0.clear();
     peer.adj_out.v4.0.clear();
 
     peer.cache_vpnv4.clear();
@@ -5699,13 +5727,14 @@ pub fn route_clean(peer_id: usize, bgp: &mut BgpTop, peers: &mut PeerMap) {
     // leaving Established kept its v6 routes selected forever.
     let withdrawn_v6 = {
         let mut withdrawn: Vec<Ipv6Nlri> = vec![];
-        let peer = peers.get_mut_by_idx(peer_id).expect("peer must exist");
-        for (prefix, ribs) in peer.adj_in.v6.0.iter() {
-            for rib in ribs.iter() {
-                withdrawn.push(Ipv6Nlri {
-                    id: rib.remote_id,
-                    prefix: *prefix,
-                });
+        if let Some(adj_in) = bgp.shard.adj_in(peer_id) {
+            for (prefix, ribs) in adj_in.v6.0.iter() {
+                for rib in ribs.iter() {
+                    withdrawn.push(Ipv6Nlri {
+                        id: rib.remote_id,
+                        prefix: *prefix,
+                    });
+                }
             }
         }
         withdrawn
@@ -5713,8 +5742,8 @@ pub fn route_clean(peer_id: usize, bgp: &mut BgpTop, peers: &mut PeerMap) {
     for withdraw in withdrawn_v6.iter() {
         route_ipv6_withdraw(peer_id, withdraw, None, bgp, peers, true);
     }
+    bgp.shard.adj_in_mut(peer_id).v6.0.clear();
     let peer = peers.get_mut_by_idx(peer_id).expect("peer must exist");
-    peer.adj_in.v6.0.clear();
     peer.adj_out.v6.0.clear();
 
     // IPv4 VPN.
@@ -5733,7 +5762,7 @@ pub fn route_clean(peer_id: usize, bgp: &mut BgpTop, peers: &mut PeerMap) {
         // them per normal RFC 4271 operation; only the rest go stale.
         let no_llgr: Vec<Vpnv4Nlri> = {
             let mut out = Vec::new();
-            for (rd, table) in peer.adj_in.v4vpn.iter_mut() {
+            for (rd, table) in bgp.shard.adj_in_mut(peer_id).v4vpn.iter_mut() {
                 for (prefix, ribs) in table.0.iter_mut() {
                     ribs.retain(|rib| {
                         let refuse = attr_refuses_llgr(&rib.attr);
@@ -5764,9 +5793,7 @@ pub fn route_clean(peer_id: usize, bgp: &mut BgpTop, peers: &mut PeerMap) {
                 true,
             );
         }
-        let peer = peers.get_mut_by_idx(peer_id).expect("peer must exist");
-
-        for (_rd, table) in peer.adj_in.v4vpn.iter_mut() {
+        for (_rd, table) in bgp.shard.adj_in_mut(peer_id).v4vpn.iter_mut() {
             for (_prefix, ribs) in table.0.iter_mut() {
                 for rib in ribs.iter_mut() {
                     rib.stale = true;
@@ -5795,7 +5822,7 @@ pub fn route_clean(peer_id: usize, bgp: &mut BgpTop, peers: &mut PeerMap) {
             Option<VpnNexthop>,
         )> = {
             let mut updates = Vec::new();
-            for (rd, table) in peer.adj_in.v4vpn.iter() {
+            for (rd, table) in bgp.shard.adj_in_mut(peer_id).v4vpn.iter() {
                 for (prefix, ribs) in table.0.iter() {
                     for rib in ribs.iter() {
                         let nlri = Ipv4Nlri {
@@ -5833,9 +5860,7 @@ pub fn route_clean(peer_id: usize, bgp: &mut BgpTop, peers: &mut PeerMap) {
     } else {
         let withdrawn = {
             let mut withdrawn: Vec<Vpnv4Nlri> = vec![];
-            let peer = peers.get_mut_by_idx(peer_id).expect("peer must exist");
-
-            for (rd, table) in peer.adj_in.v4vpn.iter() {
+            for (rd, table) in bgp.shard.adj_in_mut(peer_id).v4vpn.iter() {
                 for (prefix, ribs) in table.0.iter() {
                     for rib in ribs.iter() {
                         let withdraw = Vpnv4Nlri {
@@ -5863,8 +5888,7 @@ pub fn route_clean(peer_id: usize, bgp: &mut BgpTop, peers: &mut PeerMap) {
                 true,
             );
         }
-        let peer = peers.get_mut_by_idx(peer_id).expect("peer must exist");
-        peer.adj_in.v4vpn.clear();
+        bgp.shard.adj_in_mut(peer_id).v4vpn.clear();
     }
 
     let peer = peers.get_mut_by_idx(peer_id).expect("peer must exist");
@@ -5888,7 +5912,7 @@ pub fn route_clean(peer_id: usize, bgp: &mut BgpTop, peers: &mut PeerMap) {
         // withdraw them; only the rest go stale.
         let no_llgr: Vec<Vpnv6Nlri> = {
             let mut out = Vec::new();
-            for (rd, table) in peer.adj_in.v6vpn.iter_mut() {
+            for (rd, table) in bgp.shard.adj_in_mut(peer_id).v6vpn.iter_mut() {
                 for (prefix, ribs) in table.0.iter_mut() {
                     ribs.retain(|rib| {
                         let refuse = attr_refuses_llgr(&rib.attr);
@@ -5911,9 +5935,7 @@ pub fn route_clean(peer_id: usize, bgp: &mut BgpTop, peers: &mut PeerMap) {
         for withdraw in no_llgr.iter() {
             route_ipv6_withdraw(peer_id, &withdraw.nlri, Some(withdraw.rd), bgp, peers, true);
         }
-        let peer = peers.get_mut_by_idx(peer_id).expect("peer must exist");
-
-        for (_rd, table) in peer.adj_in.v6vpn.iter_mut() {
+        for (_rd, table) in bgp.shard.adj_in_mut(peer_id).v6vpn.iter_mut() {
             for (_prefix, ribs) in table.0.iter_mut() {
                 for rib in ribs.iter_mut() {
                     rib.stale = true;
@@ -5943,7 +5965,7 @@ pub fn route_clean(peer_id: usize, bgp: &mut BgpTop, peers: &mut PeerMap) {
             Option<VpnNexthop>,
         )> = {
             let mut updates = Vec::new();
-            for (rd, table) in peer.adj_in.v6vpn.iter() {
+            for (rd, table) in bgp.shard.adj_in_mut(peer_id).v6vpn.iter() {
                 for (prefix, ribs) in table.0.iter() {
                     for rib in ribs.iter() {
                         let nlri = Ipv6Nlri {
@@ -5978,9 +6000,7 @@ pub fn route_clean(peer_id: usize, bgp: &mut BgpTop, peers: &mut PeerMap) {
     } else {
         let withdrawn = {
             let mut withdrawn: Vec<Vpnv6Nlri> = vec![];
-            let peer = peers.get_mut_by_idx(peer_id).expect("peer must exist");
-
-            for (rd, table) in peer.adj_in.v6vpn.iter() {
+            for (rd, table) in bgp.shard.adj_in_mut(peer_id).v6vpn.iter() {
                 for (prefix, ribs) in table.0.iter() {
                     for rib in ribs.iter() {
                         withdrawn.push(Vpnv6Nlri {
@@ -5999,8 +6019,7 @@ pub fn route_clean(peer_id: usize, bgp: &mut BgpTop, peers: &mut PeerMap) {
         for withdraw in withdrawn.iter() {
             route_ipv6_withdraw(peer_id, &withdraw.nlri, Some(withdraw.rd), bgp, peers, true);
         }
-        let peer = peers.get_mut_by_idx(peer_id).expect("peer must exist");
-        peer.adj_in.v6vpn.clear();
+        bgp.shard.adj_in_mut(peer_id).v6vpn.clear();
     }
 
     let peer = peers.get_mut_by_idx(peer_id).expect("peer must exist");
@@ -6128,8 +6147,7 @@ pub fn route_clean(peer_id: usize, bgp: &mut BgpTop, peers: &mut PeerMap) {
     // Adj-RIB tables, mirroring the unicast block above.
     let withdrawn_v4lu = {
         let mut withdrawn: Vec<Ipv4Nlri> = vec![];
-        let peer = peers.get_mut_by_idx(peer_id).expect("peer must exist");
-        for (prefix, ribs) in peer.adj_in.v4lu.0.iter() {
+        for (prefix, ribs) in bgp.shard.adj_in_mut(peer_id).v4lu.0.iter() {
             for rib in ribs.iter() {
                 withdrawn.push(Ipv4Nlri {
                     id: rib.remote_id,
@@ -6144,8 +6162,7 @@ pub fn route_clean(peer_id: usize, bgp: &mut BgpTop, peers: &mut PeerMap) {
     }
     let withdrawn_v6lu = {
         let mut withdrawn: Vec<Ipv6Nlri> = vec![];
-        let peer = peers.get_mut_by_idx(peer_id).expect("peer must exist");
-        for (prefix, ribs) in peer.adj_in.v6lu.0.iter() {
+        for (prefix, ribs) in bgp.shard.adj_in_mut(peer_id).v6lu.0.iter() {
             for rib in ribs.iter() {
                 withdrawn.push(Ipv6Nlri {
                     id: rib.remote_id,
@@ -6158,9 +6175,12 @@ pub fn route_clean(peer_id: usize, bgp: &mut BgpTop, peers: &mut PeerMap) {
     for withdraw in withdrawn_v6lu.iter() {
         route_labelv6_withdraw(peer_id, withdraw, bgp, peers, true);
     }
+    {
+        let adj_in = bgp.shard.adj_in_mut(peer_id);
+        adj_in.v4lu.0.clear();
+        adj_in.v6lu.0.clear();
+    }
     let peer = peers.get_mut_by_idx(peer_id).expect("peer must exist");
-    peer.adj_in.v4lu.0.clear();
-    peer.adj_in.v6lu.0.clear();
     peer.adj_out.v4lu.0.clear();
     peer.adj_out.v6lu.0.clear();
 
@@ -6235,6 +6255,25 @@ pub fn route_clean(peer_id: usize, bgp: &mut BgpTop, peers: &mut PeerMap) {
     peer.rtcv4.clear();
     peer.rtcv6.clear();
     peer.eor.clear();
+
+    // Drop the peer's sharded-family Adj-RIB-In slice once every
+    // table in it is empty. The VPNv4/v6 LLGR branches above retain
+    // stale-marked entries, so the slice must survive those.
+    if bgp
+        .shard
+        .adj_in(peer_id)
+        .map(|a| {
+            a.v4.0.is_empty()
+                && a.v6.0.is_empty()
+                && a.v4lu.0.is_empty()
+                && a.v6lu.0.is_empty()
+                && a.v4vpn.values().all(|t| t.0.is_empty())
+                && a.v6vpn.values().all(|t| t.0.is_empty())
+        })
+        .unwrap_or(false)
+    {
+        bgp.shard.adj_in_drop(peer_id);
+    }
 }
 
 /// Reconstruct the wire `EvpnRoute` from a Loc-RIB / Adj-RIB entry,
@@ -6287,10 +6326,11 @@ fn build_evpn_route(
 pub fn stale_route_withdraw(peer_id: usize, bgp: &mut BgpTop, peers: &mut PeerMap) {
     // Fetch all of route which has stale flag.
     let withdrawn = {
-        let peer = peers.get_by_idx(peer_id).expect("peer must exist");
         let mut withdrawn: Vec<Vpnv4Nlri> = vec![];
-
-        for (rd, table) in peer.adj_in.v4vpn.iter() {
+        let Some(adj_in) = bgp.shard.adj_in(peer_id) else {
+            return;
+        };
+        for (rd, table) in adj_in.v4vpn.iter() {
             for (prefix, ribs) in table.0.iter() {
                 for rib in ribs.iter() {
                     if rib.stale {

--- a/zebra-rs/src/bgp/shard.rs
+++ b/zebra-rs/src/bgp/shard.rs
@@ -9,9 +9,9 @@
 //! routes don't even hash by IP prefix).
 //!
 //! Today `BgpShard` is a plain field on `Bgp` / `BgpVrf`, mutated
-//! inline by the single event loop — no behavior change. Later B.1
-//! slices move the shard-side `BgpAttrStore` and the per-`ident`
-//! adj-in slices here; Phase B.3 gives it its own task.
+//! inline by the single event loop — no behavior change. The
+//! shard-side `BgpAttrStore` lands as a later B.1 slice; Phase B.3
+//! gives the shard its own task.
 
 use std::collections::{BTreeMap, BTreeSet};
 use std::net::IpAddr;
@@ -19,6 +19,9 @@ use std::net::IpAddr;
 use bgp_packet::RouteDistinguisher;
 use ipnet::{Ipv4Net, Ipv6Net};
 
+use bgp_packet::{Afi, Safi};
+
+use super::adj_rib::ShardAdjIn;
 use super::route::{BgpRib, LocalRibTable};
 
 #[derive(Debug, Default)]
@@ -36,9 +39,40 @@ pub struct BgpShard {
     pub v4vpn: BTreeMap<RouteDistinguisher, LocalRibTable<Ipv4Net>>,
 
     pub v6vpn: BTreeMap<RouteDistinguisher, LocalRibTable<Ipv6Net>>,
+
+    /// Per-peer Adj-RIB-In slices for the sharded families, keyed by
+    /// peer `ident` ([`super::peer::Peer`] stays main-owned). The
+    /// main-only families' adj-in stays on the peer as
+    /// [`super::adj_rib::MainAdjIn`].
+    pub adj_in: BTreeMap<usize, ShardAdjIn>,
 }
 
 impl BgpShard {
+    /// The peer's Adj-RIB-In slice, if it has ever stored a route.
+    pub fn adj_in(&self, ident: usize) -> Option<&ShardAdjIn> {
+        self.adj_in.get(&ident)
+    }
+
+    /// The peer's Adj-RIB-In slice, created on first use.
+    pub fn adj_in_mut(&mut self, ident: usize) -> &mut ShardAdjIn {
+        self.adj_in.entry(ident).or_default()
+    }
+
+    /// Drop the peer's entire Adj-RIB-In slice (peer-down sweep).
+    pub fn adj_in_drop(&mut self, ident: usize) {
+        self.adj_in.remove(&ident);
+    }
+
+    /// Received-prefix count for a sharded AFI/SAFI (0 for main-owned
+    /// families and for peers with no slice — disjoint with
+    /// [`super::adj_rib::MainAdjIn::count`], so show paths sum both).
+    pub fn adj_in_count(&self, ident: usize, afi: Afi, safi: Safi) -> usize {
+        self.adj_in
+            .get(&ident)
+            .map(|a| a.count(afi, safi))
+            .unwrap_or(0)
+    }
+
     // Update LocalRIB route.
     pub fn update(
         &mut self,

--- a/zebra-rs/src/bgp/show.rs
+++ b/zebra-rs/src/bgp/show.rs
@@ -173,7 +173,13 @@ fn write_summary_header_row(buf: &mut String) -> std::fmt::Result {
     )
 }
 
-fn write_summary_peer_row(buf: &mut String, peer: &Peer, afi: Afi, safi: Safi) -> std::fmt::Result {
+fn write_summary_peer_row(
+    buf: &mut String,
+    shard: &super::shard::BgpShard,
+    peer: &Peer,
+    afi: Afi,
+    safi: Safi,
+) -> std::fmt::Result {
     let mut msg_sent: u64 = 0;
     let mut msg_rcvd: u64 = 0;
     for counter in peer.counter.iter() {
@@ -190,7 +196,9 @@ fn write_summary_peer_row(buf: &mut String, peer: &Peer, afi: Afi, safi: Safi) -
     } else if !negotiated {
         "NoNeg".to_string()
     } else {
-        let pr = peer.adj_in.count(afi, safi);
+        // Sharded and main-owned family counts are disjoint, so the
+        // sum is the peer's received count for any AFI/SAFI.
+        let pr = shard.adj_in_count(peer.ident, afi, safi) + peer.adj_in.count(afi, safi);
         let ps = peer.adj_out.count(afi, safi);
         format!("{}/{}", pr, ps)
     };
@@ -264,7 +272,7 @@ fn write_summary_section<V: BgpShowView>(
 
     write_summary_header_row(buf)?;
     for peer in peers.iter() {
-        write_summary_peer_row(buf, peer, afi_safi.afi, afi_safi.safi)?;
+        write_summary_peer_row(buf, bgp.shard(), peer, afi_safi.afi, afi_safi.safi)?;
     }
 
     writeln!(buf)?;
@@ -993,8 +1001,14 @@ fn show_bgp_received_vpnv4(
         None => return Ok(format!("% No such neighbor: {}", addr)),
     };
 
-    // Display Adj-RIB-Out routes (routes to be advertised after policy application)
-    show_adj_rib_routes_vpnv4(&peer.adj_in.v4vpn, bgp.router_id, json)
+    // Display Adj-RIB-In routes (received routes before policy application)
+    let empty = BTreeMap::new();
+    let tables = bgp
+        .shard
+        .adj_in(peer.ident)
+        .map(|a| &a.v4vpn)
+        .unwrap_or(&empty);
+    show_adj_rib_routes_vpnv4(tables, bgp.router_id, json)
 }
 
 use crate::rib::util::IpAddrExt;
@@ -1592,7 +1606,13 @@ fn show_bgp_received(
     };
 
     // Display Adj-RIB-In routes (received routes before policy application)
-    show_adj_rib_routes(&peer.adj_in.v4.0, bgp.router_id, json)
+    let empty = BTreeMap::new();
+    let table = bgp
+        .shard
+        .adj_in(peer.ident)
+        .map(|a| &a.v4.0)
+        .unwrap_or(&empty);
+    show_adj_rib_routes(table, bgp.router_id, json)
 }
 
 /// The "BGP router identifier" field of the summary headers.
@@ -1604,7 +1624,12 @@ fn summary_router_id<V: BgpShowView>(bgp: &V) -> String {
     }
 }
 
-fn summary_peer_row_json(peer: &Peer, afi: Afi, safi: Safi) -> BgpPeerSummaryJson {
+fn summary_peer_row_json(
+    shard: &super::shard::BgpShard,
+    peer: &Peer,
+    afi: Afi,
+    safi: Safi,
+) -> BgpPeerSummaryJson {
     let mut msg_sent: u64 = 0;
     let mut msg_rcvd: u64 = 0;
     for counter in peer.counter.iter() {
@@ -1612,7 +1637,8 @@ fn summary_peer_row_json(peer: &Peer, afi: Afi, safi: Safi) -> BgpPeerSummaryJso
         msg_rcvd += counter.rcvd;
     }
 
-    let pfx_rcvd = peer.adj_in.count(afi, safi) as u64;
+    let pfx_rcvd =
+        (shard.adj_in_count(peer.ident, afi, safi) + peer.adj_in.count(afi, safi)) as u64;
     let pfx_sent = peer.adj_out.count(afi, safi) as u64;
 
     // FRR-style State/PfxRcd column: an Established session shows its
@@ -1645,7 +1671,7 @@ fn summary_section_json<V: BgpShowView>(bgp: &V, afi_safi: AfiSafi) -> BgpAfiSaf
             .peers()
             .iter_all()
             .filter(|(_, peer)| peer.config.mp.has(&afi_safi))
-            .map(|(_, peer)| summary_peer_row_json(peer, afi_safi.afi, afi_safi.safi))
+            .map(|(_, peer)| summary_peer_row_json(bgp.shard(), peer, afi_safi.afi, afi_safi.safi))
             .collect(),
     }
 }


### PR DESCRIPTION
Second B.1 slice of the RIB sharding plan (follows #1421): received routes for the sharded families move off `Peer` into the shard, since `Peer` stays main-owned when the shard becomes a task (B.3).

`AdjRib<In>` splits along the D3 boundary:
- **`ShardAdjIn`** (v4/v6 unicast, LU, VPNv4/v6 + their add/remove/count methods, moved verbatim) lives in `BgpShard::adj_in: BTreeMap<usize, ShardAdjIn>` keyed by peer ident, behind `adj_in` / `adj_in_mut` / `adj_in_drop` / `adj_in_count` accessors.
- **`Peer.adj_in` becomes `MainAdjIn`** (EVPN, flowspec, BGP-LS) — those ingest/withdraw/clean/show call sites are untouched.
- `AdjRib<D>` itself survives unchanged as `Peer.adj_out`'s type (adj-out moves to update workers only in C.2).

Rewritten call sites:
- ingest/withdraw for all six sharded families,
- soft-in replay snapshots,
- `route_clean` per-family sweeps — incl. the VPNv4/v6 LLGR stale-mark walks, which now borrow `bgp.shard` and `bgp.attr_store` as disjoint `BgpTop` fields,
- the GR stale sweep (`stale_route_withdraw`),
- summary prefix counts (shard + main counts are disjoint by family, so they sum for any AFI/SAFI),
- received-routes shows (empty-table fallback for peers with no slice).

`route_clean` drops the peer's whole slice once every table in it is empty; LLGR-retained stale entries keep it alive until the stale timer sweeps them.

No behavior change intended.

## Test plan
- `cargo test --workspace --exclude bdd` — 1703 tests green, zero failures.
- `cargo clippy --workspace --all-targets -- -D warnings` clean (cache-busted).
- Remaining B.1 slice: shard-side `BgpAttrStore`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)