### PR TITLE
docs: refresh IS-IS v4/v6 generics status doc

### DIFF
--- a/docs/design/isis-ipv4-ipv6-generics-remaining.md
+++ b/docs/design/isis-ipv4-ipv6-generics-remaining.md
@@ -1,152 +1,137 @@
-# IS-IS IPv4/IPv6 Generics — Remaining Items
+# IS-IS IPv4/IPv6 Generics — Status & Remaining Items
 
-Branch: `isis-ipv4-ipv6-generics`
+Last updated: 2026-06-12 (after PRs #1417, #1419, #1422).
 
-## Completed (Items 1–9)
+The IS-IS v4/v6 unification effort is **substantially complete**. The
+core data path (`build_rib_from_spf<F>`), the show renderers, the LSP
+TLV machinery, and the link/neighbor address handling are all either
+generic over the `IsisRibFamily` / `IsisRibFamilyShow` traits or
+collapsed to a single code path. What remains is a short list of
+duplication that is **deliberately not unified** because the two
+families genuinely diverge there, plus a few **one-family-only**
+functions that will mint a v6 twin the day their missing feature
+lands.
+
+---
+
+## Completed
+
+### Original generics pass (Items 1–12, branch `isis-ipv4-ipv6-generics`)
 
 | # | What | Files |
 |---|------|-------|
 | 1–4 | `SpfRoute<F>`, `SpfNexthop<F>`, `make_rib_entry<F>`, `diff_apply<F>`, `DiffResult<F>` | `rib.rs` |
-| 5 | `ReachMap<E>` generic + `ReachMapV4`/`ReachMapV6` aliases; manual `Default` | `graph.rs`, `inst.rs`, `lsdb.rs`, `link.rs` |
+| 5 | `ReachMap<E>` generic + `ReachMapV4`/`ReachMapV6` aliases | `graph.rs`, `inst.rs`, `lsdb.rs`, `link.rs` |
 | 6 | `summarize_frr<F>` (adds `backup_sr_len` to `IsisRibFamily`) | `show.rs`, `rib.rs` |
 | 7 | `write_rib_detail<F>` | `show.rs` |
-| 8 | `write_rib_table<F>` + `IsisRibFamilyShow` trait (`W_PREFIX`, `W_NEXTHOP`, `label_col`) | `show.rs` |
-| 9 | `write_isis_nhop_detail<F>` (`write_nhop_extra`, `write_sid_block`, `write_backup`) | `show.rs` |
+| 8 | `write_rib_table<F>` + `IsisRibFamilyShow` trait | `show.rs` |
+| 9 | `write_isis_nhop_detail<F>` | `show.rs` |
+| 10 | `build_rib_from_spf<F>` — the central SPF→RIB loop, generic over family + MT-2 mode (trait methods `nhop_addrs`, `reach_entries`, `resolve_sid`, `build_repair`) | `rib.rs:836` |
+| 11 | `ip_reach(net: IpNet)` (was `ipv4_reach`/`ipv6_reach`) | `bgp_ls.rs:54` |
+| 12 | `prefix_object(…, net: IpNet, …)` (was `ipv4_prefix_object`/`ipv6_prefix_object`) | `bgp_ls.rs:125` |
+
+### Dedup pass (PRs #1417 / #1419 / #1422, 2026-06-12)
+
+| PR | What | Files |
+|----|------|-------|
+| #1417 | `SplittableTlv` trait + `split_tlv_entries` (one shard-at-255 routine for TLV 135/236/222/237); `push_if_addr_tlvs` shared by LAN + P2P Hello; `ipv6_capable_set` shared between rib and show | `lsp.rs`, `ifsm.rs`, `rib.rs`, `show.rs` |
+| #1419 | `write_spf_tree<F>` / `spf_tree_json<F>` / `collect_repair_rows_family<F>` — SPF-tree + repair-list renderers generic over `IsisRibFamilyShow` (new methods `spf_capable_set`, `reach_entries_show`, `spf_prefix_type`, `FAMILY`, `rib`, `backup_*`) | `show.rs` |
+| #1422 | Dropped dead `NeighborAddr6.label` → `addr6` is now `BTreeSet<Ipv6Addr>`, struct deleted; `ext_ip_reach_entry`/`ipv6_reach_entry` builders + `collect_redist_entries<P,R,E>` generic for the network/redistribute loops; `addr_add`/`addr_del` merged into `addr_update` + `addr_list_update` | `packet.rs`, `neigh.rs`, `inst.rs`, `lsp.rs`, `link.rs` |
 
 ---
 
-## Remaining Items
+## Deliberately NOT unified
 
-### Item 10 — `build_rib_from_spf` / `build_rib_from_spf_v6`
+These are duplications that the scan surfaced but which should be left
+as-is. Forcing a shared abstraction here would obscure intent or hide
+genuinely different logic behind a misleading "shared" name.
 
-**File:** `rib.rs:647` and `rib.rs:894`  
-**Difficulty:** Hard
+### TI-LFA repair builders — `build_repair_path_mpls` / `build_repair_path_srv6`
 
-The two biggest functions in `rib.rs`. Structurally identical loop shape (walk SPF result, build nhop map, merge reach entries by metric, post-loop TI-LFA backup pass) but with these differences:
+**File:** `tilfa.rs:72` / `tilfa.rs:124`
 
-| Aspect | V4 | V6 |
-|--------|----|----|
-| Extra parameter | — | `mt2_mode: bool` |
-| Reach map | `top.reach_map.get(level).get(&Afi::Ip).get(sys_id)` | `top.reach_map_v6` or `top.mt2_reach_map_v6` |
-| NLPID gating | None | `ipv6_capable_set` gate per RFC 1195 §5 (legacy mode only) |
-| Nexthop addresses | `nbr.addr4.iter()` keys | `nbr.addr6l.iter()` |
-| Prefix-SID | Full SRGB lookup → `sid`/`prefix_sid`/`no_php` | All `None` (deferred) |
-| TI-LFA backup | `build_repair_path_mpls` | `build_repair_path_srv6` |
+Only the tail (~30 lines: first-hop link lookup, pseudonode handling,
+neighbor-address pick) is shared; the heart is fundamentally
+different. MPLS resolves a **flat label stack** via
+`repair_segments_to_mpls_labels`; SRv6 walks each segment building a
+**CSID carrier-packed** SID list (`NodeSid`→End, `AdjSid`→End.X,
+`pack_carriers`). The `Backup` associated type already abstracts the
+*output* (`RepairPathMpls` vs `RepairPathSrv6`) at the
+`IsisRibFamily::build_repair` boundary, which is the right seam.
+A shared first-hop-address helper parameterized by the neighbor
+accessor (`addr4.keys().next()` vs `addr6l.first()`) is the only
+worthwhile extraction, and it is marginal.
 
-**Suggested approach:**  
-Extend `IsisRibFamily` with:
+### Backup-detail show writers — `write_isis_backup_v4_detail` / `..._v6_detail`
 
-```rust
-// Address iterator over the neighbor's addresses for this family.
-fn nhop_addrs<'a>(nbr: &'a Nbr) -> impl Iterator<Item = &'a Self::Addr>;
+**File:** `show.rs`
 
-// Reach entries for `sys_id` in the given reach map.
-fn reach_entries<'a>(
-    top: &'a IsisTop,
-    level: Level,
-    sys_id: &IsisSysId,
-    mt2_mode: bool,
-) -> Option<&'a Vec<…>>;
+Already dispatched per family via `IsisRibFamilyShow::write_backup`.
+The bodies look similar but the content genuinely differs: v4 renders
+an MPLS label stack and resolves the P-node from the first label's
+SRGB owner; v6 renders an SRv6 SID list plus encap type. No shared
+abstraction to add.
 
-// Resolve Prefix-SID to absolute label (None for V6 until SRv6 Prefix-SID lands).
-fn resolve_sid(
-    top: &IsisTop,
-    level: Level,
-    sys_id: &IsisSysId,
-    entry: &Self::TlvEntry,
-) -> (Option<u32>, Option<(SidLabelValue, LabelConfig)>, bool); // (sid, prefix_sid, no_php)
+### Graph builders — `graph` / `graph_mt2` / `graph_flex_algo`
 
-// Build TI-LFA repair path.
-fn build_repair_path(
-    top: &mut IsisTop,
-    level: Level,
-    repair: &spf::RepairPath,
-) -> Option<Self::Backup>;
-```
+**File:** `graph.rs:108` / `275` / `548` (+ `create_graph_vertex_mt2`,
+`process_outgoing_links_mt2`)
 
-Then `build_rib_from_spf<F: IsisRibFamily>` takes an additional `mt2_mode: bool` and is
-generic over `F`.
+These are **topology variants, not address families**. The near-
+identical edge-walking differs by TLV filter (TLV 22 `ExtIsReach` vs
+TLV 222 `MtIsReach`), MT-2 membership gating (RFC 5120, IPv6-unicast-
+only), and per-link affinity/metric gates (flex-algo). A
+visitor/filter parameterization is possible but would bury the
+RFC 5120 intent and sits on the SPF-critical hot path — high
+regression risk for low payoff. Leave separate.
 
-**Complication:** The NLPID gating loop (`'next_path:` with per-hop IPv6 check) is V6-only.
-The cleanest route is to move it into a family-specific `filter_path` trait method:
-```rust
-fn path_allowed(top: &IsisTop, level: Level, p: &[usize], mt2_mode: bool) -> bool;
-```
-`V4` returns `true` unconditionally; `V6` does the NLPID walk.
+### `lsp_generate` connected-prefix loop (v4 only path)
 
-The `TlvEntry` associated type (`IsisTlvExtIpReachEntry` vs `IsisTlvIpv6ReachEntry`) is the
-trickiest bound — both need `prefix()`, `metric()`, and optionally `prefix_sid()`.
-Either introduce a `ReachEntry` trait in `isis_packet`, or keep the entry-specific SID
-plumbing behind the `resolve_sid` trait method and pass the entry as `&dyn Any` (unclean) —
-prefer the trait.
+**File:** `lsp.rs` (the v4 connected loop, ~`lsp.rs:1058`)
 
----
+The `network`-statement and redistribute loops are now shared via
+`ext_ip_reach_entry`/`ipv6_reach_entry` + `collect_redist_entries`
+(PR #1422). The **connected** loops were left per-family because the
+v4 one interleaves Prefix-SID and per-algo flex-algo sub-TLVs into the
+reach entry, which the v6 path has no analogue for (yet). Unifying
+would mean threading sub-TLV builders through a generic, for a single
+caller each.
 
-### Item 11 — `ipv4_reach` / `ipv6_reach` in `bgp_ls.rs`
+### Neighbor address display loops
 
-**File:** `bgp_ls.rs:57` and `bgp_ls.rs:67`  
-**Difficulty:** Easy
+**File:** `neigh.rs` (detail show)
 
-Bodies are byte-for-byte identical; only the input type differs (`Ipv4Net` vs `Ipv6Net`).
-Unify into a single `ip_reach(net: IpNet) -> LsPrefixDescriptor` using the `ipnet::IpNet`
-enum (both `Ipv4Net` and `Ipv6Net` implement `Into<IpNet>`):
-
-```rust
-fn ip_reach(net: IpNet) -> LsPrefixDescriptor {
-    let prefix_len = net.prefix_len();
-    let nbytes = prefix_len.div_ceil(8) as usize;
-    let octets: Vec<u8> = match net {
-        IpNet::V4(n) => n.network().octets().to_vec(),
-        IpNet::V6(n) => n.network().octets().to_vec(),
-    };
-    LsPrefixDescriptor::IpReachability { prefix_len, prefix: octets[..nbytes].to_vec() }
-}
-```
-
-Call sites change from `ipv4_reach(&e.prefix)` / `ipv6_reach(&e.prefix)` to
-`ip_reach(e.prefix.into())`.
+Three short `writeln!` loops with different section headers. Below the
+threshold where abstraction pays.
 
 ---
 
-### Item 12 — `ipv4_prefix_object` / `ipv6_prefix_object` in `bgp_ls.rs`
+## Future duplication risk (one-family-only today)
 
-**File:** `bgp_ls.rs:138` and `bgp_ls.rs:152`  
-**Difficulty:** Easy
+These functions are IPv4-only because the corresponding v6 feature is
+not implemented. They are fine as-is, but when the v6 twin lands the
+implementer should put them on a trait rather than copy-paste a second
+~50–115-line function. Each is flagged here so that's a conscious
+choice.
 
-Differ only in the NLRI variant (`Ipv4Prefix` vs `Ipv6Prefix`) and the inner descriptor
-function (`ipv4_reach` → `ip_reach` after Item 11).  Can be unified once Item 11 is done:
+| Function | File | Blocked on |
+|----------|------|------------|
+| `build_rib_from_flex_algo` | `rib.rs:1504` | Flex-Algo IPv6 (re-implements the core of `build_rib_from_spf` without the trait — **biggest** risk) |
+| `update_self_sid_ilm` | `rib.rs:1653` | IPv6 Prefix-SID (SRv6) |
+| `build_adjacency_ilm` | `rib.rs:775` | SRv6 Adjacency-SID (Adj-SID is MPLS-only today) |
 
-```rust
-fn prefix_object(
-    proto: LsProtocolId,
-    local: &IsisSysId,
-    net: IpNet,
-    metric: u32,
-) -> Object {
-    let nlri_variant = match net {
-        IpNet::V4(_) => |inner| BgpLsNlri::Ipv4Prefix(inner),
-        IpNet::V6(_) => |inner| BgpLsNlri::Ipv6Prefix(inner),
-    };
-    let nlri = nlri_variant(LsPrefixNlri {
-        protocol_id: proto,
-        identifier: 0,
-        local_node: node_descriptor(local),
-        prefix_descs: vec![ip_reach(net)],
-    });
-    (nlri, prefix_attr(metric))
-}
-```
-
-Items 11 and 12 are best done together in one PR since they're both in `bgp_ls.rs`.
+When any of these gains a v6 counterpart, extend `IsisRibFamily`
+(or a sibling trait) with the family-specific accessor it needs —
+`V6::resolve_sid` already returns `(None, None, false)` as the
+placeholder seam for the Prefix-SID case.
 
 ---
 
-## Suggested Order
+## Summary
 
-```
-Items 11+12  (bgp_ls.rs — trivial, isolated, low-risk)
-Item 10      (rib.rs — the big one; do last, needs trait extension design)
-```
-
-Item 10 is the last significant duplication.  After it lands the codebase will have a
-single generic `build_rib_from_spf<F>` that covers both address families and MT-2 mode.
+The generic data path and renderers are done. No further unification
+work is recommended on the current feature set: the remaining
+duplication is either intrinsic (different algorithms / topologies) or
+gated on features that don't exist yet. The doc above is the record of
+*why* each remaining seam was left, so a future pass doesn't mistake
+it for unfinished work.


### PR DESCRIPTION
Docs-only. The `isis-ipv4-ipv6-generics-remaining.md` design doc predated the generic `build_rib_from_spf<F>`, the `bgp_ls.rs` `IpNet` unification, and the #1417/#1419/#1422 dedup pass — its "remaining" Items 10–12 are all done.

Rewrites it as the current-state record:
- **Completed** — original Items 1–12 plus the three dedup PRs, each with the trait/helper introduced and files touched.
- **Deliberately NOT unified** — TI-LFA repair builders (flat MPLS stack vs CSID carrier-packed SRv6), backup-detail show writers (already trait-dispatched), graph topology variants (RFC 5120, SPF hot path), the v4 connected-prefix sub-TLV loop — each with rationale.
- **Future duplication risk** — the one-family-only functions (`build_rib_from_flex_algo`, `update_self_sid_ilm`, `build_adjacency_ilm`) and what each is blocked on.

## Testing

Docs-only; no code change. (fmt/clippy/test unaffected.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)