### PR TITLE
bgp: give BgpShard its own attr store (sharding B.1)

### DIFF
--- a/zebra-rs/src/bgp/inst.rs
+++ b/zebra-rs/src/bgp/inst.rs
@@ -1992,7 +1992,7 @@ impl Bgp {
                 }
             }
             let tagged = tag_attr_with_export_rts(attr, &export_rts);
-            rib.attr = self.attr_store.intern(tagged);
+            rib.attr = self.shard.intern(tagged);
             let (_, selected, _) = self.shard.update(Some(rd), prefix, rib);
             let mut top = super::peer::BgpTop {
                 router_id: &self.router_id,
@@ -3153,7 +3153,7 @@ impl Bgp {
                 // mutated independently; this is the only place
                 // the global instance interns it.
                 let tagged = tag_attr_with_export_rts(attr, &export_rts);
-                let interned = self.attr_store.intern(tagged);
+                let interned = self.shard.intern(tagged);
                 // Capture the export-RT-tagged attribute (incl. any SRv6
                 // Prefix-SID) for a parallel EVPN Type-5 origination,
                 // before `interned` is moved into the VPNv4 BgpRib below.
@@ -3441,7 +3441,7 @@ impl Bgp {
                 let srv6_nexthop = self.srv6_export_nexthop(&vrf, &mut attr);
 
                 let tagged = tag_attr_with_export_rts(attr, &export_rts);
-                let interned = self.attr_store.intern(tagged);
+                let interned = self.shard.intern(tagged);
                 let evpn_attr = advertise_type5.then(|| (*interned).clone());
 
                 let label_obj = if label != 0 && srv6_nexthop.is_none() {

--- a/zebra-rs/src/bgp/route.rs
+++ b/zebra-rs/src/bgp/route.rs
@@ -2086,7 +2086,7 @@ pub fn route_ipv4_update(
         route_ipv4_withdraw(ident, nlri, rd, None, bgp, peers, false);
         return;
     };
-    rib.attr = bgp.attr_store.intern(decision.attr);
+    rib.attr = bgp.shard.intern(decision.attr);
     rib.weight = decision.weight;
     let dep = match rd {
         Some(rd) => super::nht::NhtDep::V4vpn(rd, nlri.prefix),
@@ -3199,7 +3199,7 @@ fn route_soft_in_peer_table(
                 }
                 Some(decision) => {
                     let mut new_rib = stored.clone();
-                    new_rib.attr = bgp.attr_store.intern(decision.attr);
+                    new_rib.attr = bgp.shard.intern(decision.attr);
                     new_rib.weight = decision.weight;
                     let (_, selected, next_id) = bgp.shard.update(rd, prefix, new_rib.clone());
 
@@ -3430,7 +3430,7 @@ pub fn route_ipv6_update(
         };
     }
 
-    rib.attr = bgp.attr_store.intern(attr.clone());
+    rib.attr = bgp.shard.intern(attr.clone());
     let dep = match rd {
         Some(rd) => super::nht::NhtDep::V6vpn(rd, nlri.prefix),
         None => super::nht::NhtDep::V6(nlri.prefix),
@@ -3694,7 +3694,7 @@ pub fn route_labelv4_update(
             .add_v4lu(lu.nlri.prefix, rib.clone());
     }
 
-    rib.attr = bgp.attr_store.intern(attr);
+    rib.attr = bgp.shard.intern(attr);
     // Next-Hop Tracking: gate best-path on the BGP next-hop's
     // reachability and resolve its transport for the FIB label-push.
     let dep = super::nht::NhtDep::V4lu(lu.nlri.prefix);
@@ -3794,7 +3794,7 @@ pub fn route_labelv6_update(
             .add_v6lu(lu.nlri.prefix, rib.clone());
     }
 
-    rib.attr = bgp.attr_store.intern(attr);
+    rib.attr = bgp.shard.intern(attr);
     let dep = super::nht::NhtDep::V6lu(lu.nlri.prefix);
     nht_track_received(bgp, &mut rib, dep.clone());
     rib.local_label = bgp
@@ -5740,22 +5740,33 @@ pub fn route_clean(peer_id: usize, bgp: &mut BgpTop, peers: &mut PeerMap) {
                 true,
             );
         }
-        for (_rd, table) in bgp.shard.adj_in_mut(peer_id).v4vpn.iter_mut() {
-            for (_prefix, ribs) in table.0.iter_mut() {
-                for rib in ribs.iter_mut() {
-                    rib.stale = true;
-                    let mut new_attr = (*rib.attr).clone();
-                    match &mut new_attr.com {
-                        Some(com) => {
-                            com.insert(CommunityValue::LLGR_STALE.value());
-                        }
-                        None => {
-                            let mut com = Community::new();
-                            com.insert(CommunityValue::LLGR_STALE.value());
-                            new_attr.com = Some(com);
+        {
+            // Disjoint borrows of two `BgpShard` fields: the adj-in
+            // slice we mutate in place and the shard attr store we
+            // re-intern into. (`adj_in_mut(..)` would borrow all of
+            // `shard`, conflicting with `shard.intern`.)
+            let super::shard::BgpShard {
+                adj_in, attr_store, ..
+            } = &mut *bgp.shard;
+            if let Some(slice) = adj_in.get_mut(&peer_id) {
+                for (_rd, table) in slice.v4vpn.iter_mut() {
+                    for (_prefix, ribs) in table.0.iter_mut() {
+                        for rib in ribs.iter_mut() {
+                            rib.stale = true;
+                            let mut new_attr = (*rib.attr).clone();
+                            match &mut new_attr.com {
+                                Some(com) => {
+                                    com.insert(CommunityValue::LLGR_STALE.value());
+                                }
+                                None => {
+                                    let mut com = Community::new();
+                                    com.insert(CommunityValue::LLGR_STALE.value());
+                                    new_attr.com = Some(com);
+                                }
+                            }
+                            rib.attr = attr_store.intern(new_attr);
                         }
                     }
-                    rib.attr = bgp.attr_store.intern(new_attr);
                 }
             }
         }
@@ -5882,22 +5893,32 @@ pub fn route_clean(peer_id: usize, bgp: &mut BgpTop, peers: &mut PeerMap) {
         for withdraw in no_llgr.iter() {
             route_ipv6_withdraw(peer_id, &withdraw.nlri, Some(withdraw.rd), bgp, peers, true);
         }
-        for (_rd, table) in bgp.shard.adj_in_mut(peer_id).v6vpn.iter_mut() {
-            for (_prefix, ribs) in table.0.iter_mut() {
-                for rib in ribs.iter_mut() {
-                    rib.stale = true;
-                    let mut new_attr = (*rib.attr).clone();
-                    match &mut new_attr.com {
-                        Some(com) => {
-                            com.insert(CommunityValue::LLGR_STALE.value());
-                        }
-                        None => {
-                            let mut com = Community::new();
-                            com.insert(CommunityValue::LLGR_STALE.value());
-                            new_attr.com = Some(com);
+        {
+            // Disjoint borrows of two `BgpShard` fields (see the v4
+            // VPN block above for why `adj_in_mut` + `shard.intern`
+            // would conflict).
+            let super::shard::BgpShard {
+                adj_in, attr_store, ..
+            } = &mut *bgp.shard;
+            if let Some(slice) = adj_in.get_mut(&peer_id) {
+                for (_rd, table) in slice.v6vpn.iter_mut() {
+                    for (_prefix, ribs) in table.0.iter_mut() {
+                        for rib in ribs.iter_mut() {
+                            rib.stale = true;
+                            let mut new_attr = (*rib.attr).clone();
+                            match &mut new_attr.com {
+                                Some(com) => {
+                                    com.insert(CommunityValue::LLGR_STALE.value());
+                                }
+                                None => {
+                                    let mut com = Community::new();
+                                    com.insert(CommunityValue::LLGR_STALE.value());
+                                    new_attr.com = Some(com);
+                                }
+                            }
+                            rib.attr = attr_store.intern(new_attr);
                         }
                     }
-                    rib.attr = bgp.attr_store.intern(new_attr);
                 }
             }
         }

--- a/zebra-rs/src/bgp/shard.rs
+++ b/zebra-rs/src/bgp/shard.rs
@@ -9,20 +9,21 @@
 //! routes don't even hash by IP prefix).
 //!
 //! Today `BgpShard` is a plain field on `Bgp` / `BgpVrf`, mutated
-//! inline by the single event loop — no behavior change. The
-//! shard-side `BgpAttrStore` lands as a later B.1 slice; Phase B.3
+//! inline by the single event loop — no behavior change. Phase B.3
 //! gives the shard its own task.
 
 use std::collections::{BTreeMap, BTreeSet};
 use std::net::IpAddr;
+use std::sync::Arc;
 
 use bgp_packet::RouteDistinguisher;
 use ipnet::{Ipv4Net, Ipv6Net};
 
-use bgp_packet::{Afi, Safi};
+use bgp_packet::{Afi, BgpAttr, Safi};
 
 use super::adj_rib::ShardAdjIn;
 use super::route::{BgpRib, LocalRibTable};
+use super::store::BgpAttrStore;
 
 #[derive(Debug, Default)]
 pub struct BgpShard {
@@ -45,9 +46,27 @@ pub struct BgpShard {
     /// main-only families' adj-in stays on the peer as
     /// [`super::adj_rib::MainAdjIn`].
     pub adj_in: BTreeMap<usize, ShardAdjIn>,
+
+    /// Attribute-interning store for the sharded families' RIBs. The
+    /// `Arc<BgpAttr>` held by every entry in the tables and adj-in
+    /// slices above is interned here, so when the shard becomes a
+    /// task (B.3) it interns its own RIB attributes without touching
+    /// the main [`super::store::BgpAttrStore`]. The egress / advertise
+    /// path and the main-only families (EVPN, flowspec, BGP-LS, VRF
+    /// re-tag) keep using the main store; an `Arc` is valid regardless
+    /// of which store interned it, so the split is purely about which
+    /// store owns the dedup entry.
+    pub attr_store: BgpAttrStore,
 }
 
 impl BgpShard {
+    /// Intern a sharded-family RIB attribute. Delegates to the
+    /// shard's own [`BgpAttrStore`] — see the field doc for why
+    /// sharded RIB storage interns here rather than in the main store.
+    pub fn intern(&mut self, attr: BgpAttr) -> Arc<BgpAttr> {
+        self.attr_store.intern(attr)
+    }
+
     /// The peer's Adj-RIB-In slice, if it has ever stored a route.
     pub fn adj_in(&self, ident: usize) -> Option<&ShardAdjIn> {
         self.adj_in.get(&ident)
@@ -235,5 +254,35 @@ impl BgpShard {
             .iter()
             .filter_map(|r| super::nht::bgp_nexthop_ip(&r.attr))
             .collect()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn intern_dedups_within_shard_store() {
+        let mut shard = BgpShard::default();
+        let a = shard.intern(BgpAttr::default());
+        let b = shard.intern(BgpAttr::default());
+        assert!(Arc::ptr_eq(&a, &b), "same content interns to one Arc");
+        assert_eq!(shard.attr_store.len(), 1);
+    }
+
+    #[test]
+    fn shard_stores_are_independent() {
+        // Two shards intern the same attr into distinct Arcs — the
+        // split is per-store dedup, which is exactly why an Arc's
+        // validity never depends on which store interned it (so
+        // classifying a site to the "wrong" store can't break
+        // correctness, only dedup locality / accounting).
+        let mut a = BgpShard::default();
+        let mut b = BgpShard::default();
+        let ra = a.intern(BgpAttr::default());
+        let rb = b.intern(BgpAttr::default());
+        assert!(!Arc::ptr_eq(&ra, &rb));
+        assert_eq!(a.attr_store.len(), 1);
+        assert_eq!(b.attr_store.len(), 1);
     }
 }

--- a/zebra-rs/src/bgp/show.rs
+++ b/zebra-rs/src/bgp/show.rs
@@ -3816,18 +3816,26 @@ fn show_bgp_attributes(
     _json: bool,
 ) -> std::result::Result<String, std::fmt::Error> {
     let mut buf = String::new();
+    // Two stores since RIB sharding B.1: the main store (egress
+    // encode + EVPN/flowspec/BGP-LS/VRF re-tag) and the shard store
+    // (sharded-family RIB attributes). Report combined totals, then
+    // dump each store's live entries under its own heading.
     writeln!(
         buf,
-        "BGP Attribute Store: {} entries ({} active)",
+        "BGP Attribute Store: {} entries ({} active) [main {} / shard {}]",
+        bgp.attr_store.len() + bgp.shard.attr_store.len(),
+        bgp.attr_store.refcnt_all() + bgp.shard.attr_store.refcnt_all(),
         bgp.attr_store.len(),
-        bgp.attr_store.refcnt_all()
+        bgp.shard.attr_store.len(),
     )?;
     writeln!(buf)?;
-    for (attr, weak) in bgp.attr_store.iter() {
-        let refcnt = weak.strong_count();
-        if refcnt > 0 {
-            writeln!(buf, "Refcnt: {}", refcnt)?;
-            write!(buf, "{}", attr)?;
+    for (label, store) in [("main", &bgp.attr_store), ("shard", &bgp.shard.attr_store)] {
+        for (attr, weak) in store.iter() {
+            let refcnt = weak.strong_count();
+            if refcnt > 0 {
+                writeln!(buf, "Refcnt: {} ({})", refcnt, label)?;
+                write!(buf, "{}", attr)?;
+            }
         }
     }
     Ok(buf)

--- a/zebra-rs/src/bgp/vrf/inst.rs
+++ b/zebra-rs/src/bgp/vrf/inst.rs
@@ -560,7 +560,7 @@ impl BgpVrf {
         // Rewrite the next-hop to "self" (the VRF's router-id)
         // so CE peers receive a reachable v4 address.
         attr.nexthop = Some(bgp_packet::BgpNexthop::Ipv4(self.router_id));
-        let interned = self.attr_store.intern(attr);
+        let interned = self.shard.intern(attr);
 
         let label_obj = if label != 0 {
             Some(bgp_packet::Label {
@@ -783,7 +783,7 @@ impl BgpVrf {
         transport: &[crate::rib::nht::ResolvedNexthop],
     ) {
         attr.nexthop = None;
-        let interned = self.attr_store.intern(attr);
+        let interned = self.shard.intern(attr);
 
         let label_obj = if label != 0 {
             Some(bgp_packet::Label {

--- a/zebra-rs/src/bgp/vrf/spawn.rs
+++ b/zebra-rs/src/bgp/vrf/spawn.rs
@@ -364,7 +364,7 @@ fn materialize_self_originated_networks(vrf: &mut BgpVrf, cfg: &BgpVrfConfig) ->
         let mut attr = BgpAttr::new();
         attr.origin = Some(Origin::Igp);
         attr.nexthop = Some(BgpNexthop::Ipv4(vrf.router_id));
-        let interned = vrf.attr_store.intern(attr);
+        let interned = vrf.shard.intern(attr);
 
         let rib = super::super::route::BgpRib {
             remote_id: 0,


### PR DESCRIPTION
Final B.1 slice of the RIB sharding plan (follows #1421, #1425): the sharded families' RIB attributes intern into a shard-owned `BgpAttrStore` rather than the main one, so when the shard becomes a task (B.3) it interns its own loc-rib / adj-in attributes without touching main's store.

**Split principle:** an intern call uses the shard store iff its result is stored into `bgp.shard` (sharded loc-rib) or `bgp.shard.adj_in` (sharded adj-in). Everything else — egress/advertise encode, the main-only families (EVPN, flowspec, BGP-LS), and the VRF export re-tag — keeps the main store.

**Why this is safe:** an `Arc<BgpAttr>` is valid regardless of which store interned it, and nothing anywhere relies on attr `Arc` pointer-identity (`grep ptr_eq` is empty). So the split is purely about *which store owns the dedup entry* — misclassifying a site can't break correctness, only dedup locality/accounting. Functionally a no-op.

Shard-store sites: `route_ipv4/ipv6/labelv4/labelv6_update`, soft-in replay, the VPNv4/v6 LLGR stale-marks in `route_clean`, the VPNv4 export-RT re-tag race fix, the global VPNv4/v6 VRF-import re-intern, and the per-VRF import/self-originate paths. The two LLGR stale-mark loops iterate `shard.adj_in` while interning, so they take a disjoint-field borrow of `shard.adj_in` + `shard.attr_store` (the `adj_in_mut` accessor would borrow all of `shard` and conflict).

`show bgp attr` now reports both stores (combined totals + per-store breakdown, each entry tagged `main`/`shard`).

This completes **B.1 (state partition)** — loc-rib (#1421), adj-in (#1425), and attr-store are all shard-owned now. Next is B.2 (shard message protocol + per-shard label sub-blocks).

## Test plan
- `cargo test --workspace --exclude bdd` — 1704 tests green, zero failures.
- New unit tests pin shard-store dedup + per-store independence.
- `cargo clippy --workspace --all-targets -- -D warnings` clean (cache-busted).

🤖 Generated with [Claude Code](https://claude.com/claude-code)