### PR TITLE
bgp: per-shard label sub-block allocator (sharding B.2)

### DIFF
--- a/zebra-rs/src/bgp/config.rs
+++ b/zebra-rs/src/bgp/config.rs
@@ -154,7 +154,7 @@ fn config_peer(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Option<()> {
             nexthop_cache: None,
             vrf_transport_v4: None,
             vrf_transport_v6: None,
-            lu_labels: None,
+            central_label_alloc: None,
         };
         route_clean(peer_idx, &mut bgp_ref, &mut bgp.peers);
         // Update-groups live outside `PeerMap`: removal below purges

--- a/zebra-rs/src/bgp/inst.rs
+++ b/zebra-rs/src/bgp/inst.rs
@@ -572,18 +572,11 @@ pub struct Bgp {
     /// initial request and any on-demand extension so a burst of
     /// label-less VRFs asks the RIB label manager for only one block.
     vrf_label_request_pending: bool,
-    /// Per-prefix local labels assigned to received Labeled-Unicast
-    /// (SAFI 4) routes we re-advertise with next-hop-self. Drawn from the
-    /// same dynamic pool as `vrf_label_alloc`. The label is advertised in
-    /// the NLRI and swap-programmed via an ILM (`local → received`).
-    pub lu_label_v4: std::collections::BTreeMap<ipnet::Ipv4Net, u32>,
-    pub lu_label_v6: std::collections::BTreeMap<ipnet::Ipv6Net, u32>,
-    /// Per-`(RD, prefix)` local labels for received VPNv4 (SAFI 128)
-    /// routes we re-advertise with next-hop-self — the Inter-AS Option B
-    /// transit case. Same dynamic pool; the label is advertised in the
-    /// VPNv4 NLRI and swap-programmed via an ILM (`local → received`).
-    pub vpn_label_v4:
-        std::collections::BTreeMap<(bgp_packet::RouteDistinguisher, ipnet::Ipv4Net), u32>,
+    // The per-prefix LU/VPNv4 local-label caches moved to
+    // `BgpShard::labels` (RIB sharding B.2): they pair with the shard's
+    // sub-block allocator, which refills by carving from
+    // `vrf_label_alloc` above. `vrf_label_alloc` itself stays here — it
+    // is the central pool and still serves the per-VRF-spawn labels.
     /// Configured SRv6 locator name (`router bgp segment-routing
     /// srv6 locator <name>`). When set, BGP watches this locator on the
     /// RIB and (in a follow-up) carves per-VRF End.DT46 service SIDs
@@ -811,9 +804,6 @@ impl Bgp {
             rib_subscriber,
             vrf_label_alloc: None,
             vrf_label_request_pending: false,
-            lu_label_v4: BTreeMap::new(),
-            lu_label_v6: BTreeMap::new(),
-            vpn_label_v4: BTreeMap::new(),
             srv6_locator_name: None,
             srv6_locator_rx,
             srv6_locator: None,
@@ -1376,12 +1366,7 @@ impl Bgp {
                     nexthop_cache: Some(&mut self.nexthop_cache),
                     vrf_transport_v4: None,
                     vrf_transport_v6: None,
-                    lu_labels: Some(super::peer::LuLabels {
-                        alloc: &mut self.vrf_label_alloc,
-                        v4: &mut self.lu_label_v4,
-                        v6: &mut self.lu_label_v6,
-                        vpn_v4: &mut self.vpn_label_v4,
-                    }),
+                    central_label_alloc: self.vrf_label_alloc.as_mut(),
                 };
 
                 fsm(&mut bgp_ref, &mut self.peers, ident, event);
@@ -2011,7 +1996,7 @@ impl Bgp {
                 nexthop_cache: None,
                 vrf_transport_v4: None,
                 vrf_transport_v6: None,
-                lu_labels: None,
+                central_label_alloc: None,
             };
             super::route::route_advertise_to_peers(
                 Some(rd),
@@ -2545,7 +2530,7 @@ impl Bgp {
             nexthop_cache: None,
             vrf_transport_v4: None,
             vrf_transport_v6: None,
-            lu_labels: None,
+            central_label_alloc: None,
         };
         match &dep {
             NhtDep::V4(p) => {
@@ -3013,7 +2998,7 @@ impl Bgp {
             nexthop_cache: None,
             vrf_transport_v4: None,
             vrf_transport_v6: None,
-            lu_labels: None,
+            central_label_alloc: None,
         };
         for (prefix, best) in &winners_v4 {
             super::route::fib_install_v4(&top, *prefix, std::slice::from_ref(best));
@@ -3268,7 +3253,7 @@ impl Bgp {
                     nexthop_cache: None,
                     vrf_transport_v4: None,
                     vrf_transport_v6: None,
-                    lu_labels: None,
+                    central_label_alloc: None,
                 };
                 super::route::route_advertise_to_peers(
                     Some(rd),
@@ -3378,7 +3363,7 @@ impl Bgp {
                     nexthop_cache: None,
                     vrf_transport_v4: None,
                     vrf_transport_v6: None,
-                    lu_labels: None,
+                    central_label_alloc: None,
                 };
                 super::route::route_advertise_to_peers(
                     Some(rd),
@@ -3535,7 +3520,7 @@ impl Bgp {
                     nexthop_cache: None,
                     vrf_transport_v4: None,
                     vrf_transport_v6: None,
-                    lu_labels: None,
+                    central_label_alloc: None,
                 };
                 super::route::route_advertise_to_peers_vpnv6(
                     rd,
@@ -3623,7 +3608,7 @@ impl Bgp {
                     nexthop_cache: None,
                     vrf_transport_v4: None,
                     vrf_transport_v6: None,
-                    lu_labels: None,
+                    central_label_alloc: None,
                 };
                 super::route::route_advertise_to_peers_vpnv6(
                     rd,

--- a/zebra-rs/src/bgp/interface_neighbor.rs
+++ b/zebra-rs/src/bgp/interface_neighbor.rs
@@ -283,7 +283,7 @@ pub fn config_interface_neighbor(bgp: &mut Bgp, mut args: Args, op: ConfigOp) ->
                         nexthop_cache: None,
                         vrf_transport_v4: None,
                         vrf_transport_v6: None,
-                        lu_labels: None,
+                        central_label_alloc: None,
                     };
                     super::route::route_clean(peer_idx, &mut bgp_ref, &mut bgp.peers);
                     // Update-groups live outside `PeerMap`: the

--- a/zebra-rs/src/bgp/peer.rs
+++ b/zebra-rs/src/bgp/peer.rs
@@ -1325,13 +1325,16 @@ pub struct BgpTop<'a> {
             prefix_trie::PrefixMap<ipnet::Ipv4Net, crate::rib::api::FlexAlgoNexthop>,
         >,
     >,
-    /// BGP Labeled-Unicast (SAFI 4) local-label allocation context.
-    /// `Some` only in the receive `BgpTop` (the site that ingests
-    /// received routes); `None` in every advertise / originate / NHT
-    /// BgpTop — self-originated FECs advertise implicit-null and need no
-    /// local label. A received route advertised with next-hop-self gets
-    /// a local label here, swap-programmed via an ILM.
-    pub lu_labels: Option<LuLabels<'a>>,
+    /// Central MPLS label allocator (`Bgp::vrf_label_alloc`), borrowed
+    /// for the receive `BgpTop` so the shard can refill its per-route
+    /// label sub-block by [carving][super::vrf::VrfLabelAllocator::carve]
+    /// from it (RIB sharding B.2). `Some` only on the receive path —
+    /// the per-prefix label caches and the sub-block itself live on
+    /// `BgpShard::labels`; this is just the refill source. `None` in
+    /// every advertise / originate / NHT `BgpTop` (self-originated FECs
+    /// advertise implicit-null and need no local label) and on per-VRF
+    /// tasks.
+    pub central_label_alloc: Option<&'a mut super::vrf::VrfLabelAllocator>,
     /// Precomputed global-IPv6 SRv6 export data (`segment-routing srv6
     /// ipv6-unicast`), borrowed from the owning [`super::inst::Bgp`].
     /// `Some` only when origination is enabled and the locator has
@@ -1339,86 +1342,6 @@ pub struct BgpTop<'a> {
     /// locally-originated routes with its End.DT6 Prefix-SID + locator
     /// next-hop. `None` on per-VRF tasks and whenever origination is off.
     pub srv6_ipv6_export: Option<&'a super::inst::Srv6Ipv6Export>,
-}
-
-/// Per-prefix local-label state for BGP Labeled Unicast, borrowed into
-/// the receive [`BgpTop`]. Labels are drawn from the shared dynamic-label
-/// allocator (the same pool that serves per-VRF labels).
-pub struct LuLabels<'a> {
-    pub alloc: &'a mut Option<super::vrf::VrfLabelAllocator>,
-    pub v4: &'a mut std::collections::BTreeMap<ipnet::Ipv4Net, u32>,
-    pub v6: &'a mut std::collections::BTreeMap<ipnet::Ipv6Net, u32>,
-    /// Per-`(RD, prefix)` local labels for received VPNv4 (SAFI 128)
-    /// routes — the Inter-AS Option B transit case. A transit ASBR that
-    /// re-advertises a VPNv4 route with next-hop-self advertises this
-    /// label and swap-programs it (our label → received label) via an
-    /// ILM, so the VPN crosses the AS boundary on MPLS. The RD is part
-    /// of the key because the same IP prefix can live in many VPNs.
-    pub vpn_v4: &'a mut std::collections::BTreeMap<(RouteDistinguisher, ipnet::Ipv4Net), u32>,
-}
-
-impl LuLabels<'_> {
-    /// Local label for an IPv4 LU prefix, allocating one on first use.
-    /// `None` if the dynamic pool is empty (the caller advertises the
-    /// received label as a fallback until a block is granted).
-    pub fn label_v4(&mut self, prefix: ipnet::Ipv4Net) -> Option<u32> {
-        if let Some(l) = self.v4.get(&prefix) {
-            return Some(*l);
-        }
-        let label = self.alloc.as_mut().and_then(|a| a.alloc())?;
-        self.v4.insert(prefix, label);
-        Some(label)
-    }
-
-    /// Local label for a received VPNv4 `(RD, prefix)`, allocating one on
-    /// first use. Mirrors [`label_v4`](Self::label_v4); `None` until a
-    /// dynamic block is granted (the caller advertises the received
-    /// label until then).
-    pub fn label_vpn_v4(&mut self, rd: RouteDistinguisher, prefix: ipnet::Ipv4Net) -> Option<u32> {
-        if let Some(l) = self.vpn_v4.get(&(rd, prefix)) {
-            return Some(*l);
-        }
-        let label = self.alloc.as_mut().and_then(|a| a.alloc())?;
-        self.vpn_v4.insert((rd, prefix), label);
-        Some(label)
-    }
-
-    /// Release the label for a withdrawn VPNv4 `(RD, prefix)`; returns it
-    /// so the caller can tear down the swap ILM.
-    pub fn free_vpn_v4(&mut self, rd: RouteDistinguisher, prefix: ipnet::Ipv4Net) -> Option<u32> {
-        let label = self.vpn_v4.remove(&(rd, prefix))?;
-        if let Some(a) = self.alloc.as_mut() {
-            a.free(label);
-        }
-        Some(label)
-    }
-
-    pub fn label_v6(&mut self, prefix: ipnet::Ipv6Net) -> Option<u32> {
-        if let Some(l) = self.v6.get(&prefix) {
-            return Some(*l);
-        }
-        let label = self.alloc.as_mut().and_then(|a| a.alloc())?;
-        self.v6.insert(prefix, label);
-        Some(label)
-    }
-
-    /// Release the label for a withdrawn IPv4 LU prefix; returns it so
-    /// the caller can tear down the swap ILM.
-    pub fn free_v4(&mut self, prefix: ipnet::Ipv4Net) -> Option<u32> {
-        let label = self.v4.remove(&prefix)?;
-        if let Some(a) = self.alloc.as_mut() {
-            a.free(label);
-        }
-        Some(label)
-    }
-
-    pub fn free_v6(&mut self, prefix: ipnet::Ipv6Net) -> Option<u32> {
-        let label = self.v6.remove(&prefix)?;
-        if let Some(a) = self.alloc.as_mut() {
-            a.free(label);
-        }
-        Some(label)
-    }
 }
 
 /// Resolve a connection identity against the peer's current slots.
@@ -2874,7 +2797,7 @@ pub fn apply_soft_in_peer(bgp: &mut Bgp, peer_idx: usize) {
             nexthop_cache: None,
             vrf_transport_v4: None,
             vrf_transport_v6: None,
-            lu_labels: None,
+            central_label_alloc: None,
         };
         super::route::route_soft_in_peer(peer_idx, &mut bgp_ref, &mut bgp.peers);
     } else if supports_refresh {
@@ -2913,7 +2836,7 @@ pub fn apply_soft_out_peer(bgp: &mut Bgp, peer_idx: usize) {
         nexthop_cache: None,
         vrf_transport_v4: None,
         vrf_transport_v6: None,
-        lu_labels: None,
+        central_label_alloc: None,
     };
     super::route::route_soft_out_peer(peer_idx, &mut bgp_ref, &mut bgp.peers);
 }

--- a/zebra-rs/src/bgp/route.rs
+++ b/zebra-rs/src/bgp/route.rs
@@ -2109,10 +2109,10 @@ pub fn route_ipv4_update(
     // swap ILM below forwards it down the LSP. `None` until a dynamic block
     // is granted (advertise the received label as a fallback until then).
     if let Some(rd) = rd {
-        rib.local_label = bgp
-            .lu_labels
-            .as_mut()
-            .and_then(|ll| ll.label_vpn_v4(rd, nlri.prefix));
+        rib.local_label =
+            bgp.shard
+                .labels
+                .label_vpn_v4(bgp.central_label_alloc.as_deref_mut(), rd, nlri.prefix);
     }
     // Inter-AS Option AB: a received VPNv4 route an `inter-as-hybrid` VRF
     // imports is relayed only by that VRF's re-export (Originated,
@@ -3269,11 +3269,7 @@ pub fn route_ipv4_withdraw(
         // keeps the same per-(RD,prefix) label, whose ILM is reconciled
         // for the (possibly new) winner's received label / transport.
         if selected.is_empty() {
-            if let Some(local) = bgp
-                .lu_labels
-                .as_mut()
-                .and_then(|ll| ll.free_vpn_v4(rd, nlri.prefix))
-            {
+            if let Some(local) = bgp.shard.labels.free_vpn_v4(rd, nlri.prefix) {
                 ilm_swap_remove(bgp.rib_client, local);
             }
         } else {
@@ -3704,9 +3700,9 @@ pub fn route_labelv4_update(
     // dynamic block is granted yet — advertise the received label until
     // then.
     rib.local_label = bgp
-        .lu_labels
-        .as_mut()
-        .and_then(|ll| ll.label_v4(lu.nlri.prefix));
+        .shard
+        .labels
+        .label_lu_v4(bgp.central_label_alloc.as_deref_mut(), lu.nlri.prefix);
     let (replaced, selected, _next_id) = bgp.shard.update_v4lu(lu.nlri.prefix, rib);
     if bgp.nexthop_cache.is_some() && !replaced.is_empty() {
         let survivor_nhs = bgp.shard.candidate_nexthops_v4lu(lu.nlri.prefix);
@@ -3798,9 +3794,9 @@ pub fn route_labelv6_update(
     let dep = super::nht::NhtDep::V6lu(lu.nlri.prefix);
     nht_track_received(bgp, &mut rib, dep.clone());
     rib.local_label = bgp
-        .lu_labels
-        .as_mut()
-        .and_then(|ll| ll.label_v6(lu.nlri.prefix));
+        .shard
+        .labels
+        .label_lu_v6(bgp.central_label_alloc.as_deref_mut(), lu.nlri.prefix);
     let (replaced, selected, _next_id) = bgp.shard.update_v6lu(lu.nlri.prefix, rib);
     if bgp.nexthop_cache.is_some() && !replaced.is_empty() {
         let survivor_nhs = bgp.shard.candidate_nexthops_v6lu(lu.nlri.prefix);
@@ -3849,10 +3845,7 @@ pub fn route_labelv4_withdraw(
     // ILM. (A surviving winner keeps the same per-prefix label, whose ILM
     // `fib_install_labelv4` reconciles below.)
     if selected.is_empty()
-        && let Some(local) = bgp
-            .lu_labels
-            .as_mut()
-            .and_then(|ll| ll.free_v4(nlri.prefix))
+        && let Some(local) = bgp.shard.labels.free_lu_v4(nlri.prefix)
     {
         ilm_swap_remove(bgp.rib_client, local);
     }
@@ -3894,10 +3887,7 @@ pub fn route_labelv6_withdraw(
     }
     let selected = bgp.shard.select_best_path_v6lu(nlri.prefix);
     if selected.is_empty()
-        && let Some(local) = bgp
-            .lu_labels
-            .as_mut()
-            .and_then(|ll| ll.free_v6(nlri.prefix))
+        && let Some(local) = bgp.shard.labels.free_lu_v6(nlri.prefix)
     {
         ilm_swap_remove(bgp.rib_client, local);
     }
@@ -8369,7 +8359,7 @@ impl Bgp {
             nexthop_cache: None,
             vrf_transport_v4: None,
             vrf_transport_v6: None,
-            lu_labels: None,
+            central_label_alloc: None,
         };
 
         // An originated route lacks a v4 NEXT_HOP attribute, so when
@@ -8414,7 +8404,7 @@ impl Bgp {
             nexthop_cache: None,
             vrf_transport_v4: None,
             vrf_transport_v6: None,
-            lu_labels: None,
+            central_label_alloc: None,
         };
 
         let selected = bgp_ref.shard.select_best_path(prefix);
@@ -8480,7 +8470,7 @@ impl Bgp {
             nexthop_cache: None,
             vrf_transport_v4: None,
             vrf_transport_v6: None,
-            lu_labels: None,
+            central_label_alloc: None,
         };
 
         fib_install_v6(&bgp_ref, prefix, &selected);
@@ -8512,7 +8502,7 @@ impl Bgp {
             nexthop_cache: None,
             vrf_transport_v4: None,
             vrf_transport_v6: None,
-            lu_labels: None,
+            central_label_alloc: None,
         };
 
         let selected = bgp_ref.shard.select_best_path_v6(prefix);
@@ -8563,7 +8553,7 @@ impl Bgp {
             nexthop_cache: None,
             vrf_transport_v4: None,
             vrf_transport_v6: None,
-            lu_labels: None,
+            central_label_alloc: None,
         };
 
         // Reconcile the FIB: a self-originated winner withdraws any BGP
@@ -8600,7 +8590,7 @@ impl Bgp {
             nexthop_cache: None,
             vrf_transport_v4: None,
             vrf_transport_v6: None,
-            lu_labels: None,
+            central_label_alloc: None,
         };
 
         let selected = bgp_ref.shard.select_best_path_v4lu(prefix);
@@ -8656,7 +8646,7 @@ impl Bgp {
             nexthop_cache: None,
             vrf_transport_v4: None,
             vrf_transport_v6: None,
-            lu_labels: None,
+            central_label_alloc: None,
         };
 
         fib_install_labelv6(
@@ -8691,7 +8681,7 @@ impl Bgp {
             nexthop_cache: None,
             vrf_transport_v4: None,
             vrf_transport_v6: None,
-            lu_labels: None,
+            central_label_alloc: None,
         };
 
         let selected = bgp_ref.shard.select_best_path_v6lu(prefix);
@@ -8779,7 +8769,7 @@ impl Bgp {
             nexthop_cache: None,
             vrf_transport_v4: None,
             vrf_transport_v6: None,
-            lu_labels: None,
+            central_label_alloc: None,
         };
 
         // Same logic as `route_add`: the redistributed BGP route has
@@ -8822,7 +8812,7 @@ impl Bgp {
             nexthop_cache: None,
             vrf_transport_v4: None,
             vrf_transport_v6: None,
-            lu_labels: None,
+            central_label_alloc: None,
         };
 
         let selected = bgp_ref.shard.select_best_path(prefix);
@@ -8897,7 +8887,7 @@ impl Bgp {
             nexthop_cache: None,
             vrf_transport_v4: None,
             vrf_transport_v6: None,
-            lu_labels: None,
+            central_label_alloc: None,
         };
 
         fib_install_v6(&bgp_ref, prefix, &selected);
@@ -8937,7 +8927,7 @@ impl Bgp {
             nexthop_cache: None,
             vrf_transport_v4: None,
             vrf_transport_v6: None,
-            lu_labels: None,
+            central_label_alloc: None,
         };
 
         let selected = bgp_ref.shard.select_best_path_v6(prefix);
@@ -8995,7 +8985,7 @@ impl Bgp {
             nexthop_cache: None,
             vrf_transport_v4: None,
             vrf_transport_v6: None,
-            lu_labels: None,
+            central_label_alloc: None,
         };
 
         // Reconcile the FIB: a self-originated winner withdraws any BGP
@@ -9033,7 +9023,7 @@ impl Bgp {
             nexthop_cache: None,
             vrf_transport_v4: None,
             vrf_transport_v6: None,
-            lu_labels: None,
+            central_label_alloc: None,
         };
 
         let selected = bgp_ref.shard.select_best_path_v4lu(prefix);
@@ -9093,7 +9083,7 @@ impl Bgp {
             nexthop_cache: None,
             vrf_transport_v4: None,
             vrf_transport_v6: None,
-            lu_labels: None,
+            central_label_alloc: None,
         };
 
         fib_install_labelv6(
@@ -9129,7 +9119,7 @@ impl Bgp {
             nexthop_cache: None,
             vrf_transport_v4: None,
             vrf_transport_v6: None,
-            lu_labels: None,
+            central_label_alloc: None,
         };
 
         let selected = bgp_ref.shard.select_best_path_v6lu(prefix);
@@ -9266,7 +9256,7 @@ impl Bgp {
             nexthop_cache: None,
             vrf_transport_v4: None,
             vrf_transport_v6: None,
-            lu_labels: None,
+            central_label_alloc: None,
         };
 
         if !selected.is_empty() {
@@ -9385,7 +9375,7 @@ impl Bgp {
             nexthop_cache: None,
             vrf_transport_v4: None,
             vrf_transport_v6: None,
-            lu_labels: None,
+            central_label_alloc: None,
         };
 
         if !selected.is_empty() {
@@ -9491,7 +9481,7 @@ impl Bgp {
             nexthop_cache: None,
             vrf_transport_v4: None,
             vrf_transport_v6: None,
-            lu_labels: None,
+            central_label_alloc: None,
         };
 
         if !selected.is_empty() {

--- a/zebra-rs/src/bgp/shard.rs
+++ b/zebra-rs/src/bgp/shard.rs
@@ -24,6 +24,132 @@ use bgp_packet::{Afi, BgpAttr, Safi};
 use super::adj_rib::ShardAdjIn;
 use super::route::{BgpRib, LocalRibTable};
 use super::store::BgpAttrStore;
+use super::vrf::VrfLabelAllocator;
+
+/// Labels a shard carves from the central allocator per refill (RIB
+/// sharding B.2). A shard mints local labels in the per-route hot
+/// path, so it can't ask the main task per label; it draws a chunk
+/// up front and refills when spent. The 20-bit space is vast, so the
+/// chunk only trades a little frontier headroom for far fewer carves.
+const SHARD_LABEL_CHUNK: u32 = 1024;
+
+/// A shard's local MPLS label allocator for the families that mint a
+/// per-route *local* label in the hot path: Labeled-Unicast (v4/v6,
+/// next-hop-self) and the Inter-AS Option B VPNv4 transit case. The
+/// pool starts empty and is filled by carving sub-ranges from the
+/// central [`VrfLabelAllocator`] on `Bgp` (which still serves the
+/// per-VRF-spawn labels); a carve leaves the central frontier, so the
+/// two never collide. This is the inline (N=1) form of the plan's
+/// per-shard sub-block; at B.3 the carve becomes a `LabelBlockLow`
+/// request to the main task.
+#[derive(Debug)]
+pub struct ShardLabelPool {
+    /// Sub-block allocator — seeded empty, grown by [`carve`] refills.
+    ///
+    /// [`carve`]: VrfLabelAllocator::carve
+    pool: VrfLabelAllocator,
+    /// Per-prefix IPv4 / IPv6 Labeled-Unicast local labels
+    /// (allocate-on-first-use, freed on withdraw).
+    lu_v4: BTreeMap<Ipv4Net, u32>,
+    lu_v6: BTreeMap<Ipv6Net, u32>,
+    /// Per-`(RD, prefix)` VPNv4 transit local labels (Inter-AS
+    /// Option B): the swap ILM forwards `our label → received label`.
+    vpn_v4: BTreeMap<(RouteDistinguisher, Ipv4Net), u32>,
+}
+
+impl Default for ShardLabelPool {
+    fn default() -> Self {
+        Self {
+            pool: VrfLabelAllocator::empty(),
+            lu_v4: BTreeMap::new(),
+            lu_v6: BTreeMap::new(),
+            vpn_v4: BTreeMap::new(),
+        }
+    }
+}
+
+impl ShardLabelPool {
+    /// Allocate one label, refilling the sub-block from `central`
+    /// (a [`carve`](VrfLabelAllocator::carve)) when it runs dry.
+    /// `None` if `central` is absent or can't grant more.
+    fn alloc(&mut self, central: Option<&mut VrfLabelAllocator>) -> Option<u32> {
+        if let Some(label) = self.pool.alloc() {
+            return Some(label);
+        }
+        let central = central?;
+        let (start, end) = central.carve(SHARD_LABEL_CHUNK)?;
+        self.pool.extend(start, end);
+        self.pool.alloc()
+    }
+
+    /// Local label for an IPv4 LU prefix, allocating on first use.
+    /// `None` if the dynamic pool is exhausted (the caller advertises
+    /// the received label as a fallback until a block is granted).
+    pub fn label_lu_v4(
+        &mut self,
+        central: Option<&mut VrfLabelAllocator>,
+        prefix: Ipv4Net,
+    ) -> Option<u32> {
+        if let Some(l) = self.lu_v4.get(&prefix) {
+            return Some(*l);
+        }
+        let label = self.alloc(central)?;
+        self.lu_v4.insert(prefix, label);
+        Some(label)
+    }
+
+    /// Local label for an IPv6 LU prefix; mirrors [`label_lu_v4`](Self::label_lu_v4).
+    pub fn label_lu_v6(
+        &mut self,
+        central: Option<&mut VrfLabelAllocator>,
+        prefix: Ipv6Net,
+    ) -> Option<u32> {
+        if let Some(l) = self.lu_v6.get(&prefix) {
+            return Some(*l);
+        }
+        let label = self.alloc(central)?;
+        self.lu_v6.insert(prefix, label);
+        Some(label)
+    }
+
+    /// Local label for a received VPNv4 `(RD, prefix)`, allocating on
+    /// first use (Inter-AS Option B transit).
+    pub fn label_vpn_v4(
+        &mut self,
+        central: Option<&mut VrfLabelAllocator>,
+        rd: RouteDistinguisher,
+        prefix: Ipv4Net,
+    ) -> Option<u32> {
+        if let Some(l) = self.vpn_v4.get(&(rd, prefix)) {
+            return Some(*l);
+        }
+        let label = self.alloc(central)?;
+        self.vpn_v4.insert((rd, prefix), label);
+        Some(label)
+    }
+
+    /// Release the label for a withdrawn IPv4 LU prefix; returns it so
+    /// the caller can tear down the swap ILM.
+    pub fn free_lu_v4(&mut self, prefix: Ipv4Net) -> Option<u32> {
+        let label = self.lu_v4.remove(&prefix)?;
+        self.pool.free(label);
+        Some(label)
+    }
+
+    /// Release the label for a withdrawn IPv6 LU prefix.
+    pub fn free_lu_v6(&mut self, prefix: Ipv6Net) -> Option<u32> {
+        let label = self.lu_v6.remove(&prefix)?;
+        self.pool.free(label);
+        Some(label)
+    }
+
+    /// Release the label for a withdrawn VPNv4 `(RD, prefix)`.
+    pub fn free_vpn_v4(&mut self, rd: RouteDistinguisher, prefix: Ipv4Net) -> Option<u32> {
+        let label = self.vpn_v4.remove(&(rd, prefix))?;
+        self.pool.free(label);
+        Some(label)
+    }
+}
 
 #[derive(Debug, Default)]
 pub struct BgpShard {
@@ -57,6 +183,13 @@ pub struct BgpShard {
     /// of which store interned it, so the split is purely about which
     /// store owns the dedup entry.
     pub attr_store: BgpAttrStore,
+
+    /// Per-route local-label allocator + caches for the sharded
+    /// families that mint labels in the hot path (LU v4/v6, VPNv4
+    /// transit). Draws from a sub-block carved out of the central
+    /// [`VrfLabelAllocator`] on `Bgp`. Empty on per-VRF shards — the
+    /// LU/VPN label path is global-instance-only today.
+    pub labels: ShardLabelPool,
 }
 
 impl BgpShard {
@@ -268,6 +401,72 @@ mod tests {
         let b = shard.intern(BgpAttr::default());
         assert!(Arc::ptr_eq(&a, &b), "same content interns to one Arc");
         assert_eq!(shard.attr_store.len(), 1);
+    }
+
+    fn v4(s: &str) -> Ipv4Net {
+        s.parse().unwrap()
+    }
+
+    #[test]
+    fn label_pool_refills_from_central_then_dedups() {
+        let mut central = VrfLabelAllocator::bounded(1000, 1_000_000);
+        let mut pool = ShardLabelPool::default();
+        // First alloc carves a chunk from central and hands out its start.
+        let l1 = pool
+            .label_lu_v4(Some(&mut central), v4("10.0.0.0/24"))
+            .unwrap();
+        assert_eq!(l1, 1000);
+        // Same prefix → cache hit, same label.
+        assert_eq!(
+            pool.label_lu_v4(Some(&mut central), v4("10.0.0.0/24")),
+            Some(1000)
+        );
+        // New prefix → next label from the already-carved chunk (no re-carve).
+        assert_eq!(
+            pool.label_lu_v4(Some(&mut central), v4("10.0.1.0/24")),
+            Some(1001)
+        );
+    }
+
+    #[test]
+    fn label_pool_and_central_never_collide() {
+        let mut central = VrfLabelAllocator::bounded(1000, 1_000_000);
+        let mut pool = ShardLabelPool::default();
+        // Central mints a per-VRF-spawn label; the shard mints a route
+        // label — disjoint, because the carve advanced central's frontier.
+        let vrf_label = central.alloc().unwrap();
+        let route_label = pool
+            .label_lu_v4(Some(&mut central), v4("10.0.0.0/24"))
+            .unwrap();
+        assert_eq!(vrf_label, 1000);
+        assert_eq!(route_label, 1001, "carved from the frontier after 1000");
+        // Central resumes past the whole carved chunk.
+        assert_eq!(central.alloc(), Some(1001 + SHARD_LABEL_CHUNK));
+    }
+
+    #[test]
+    fn label_pool_free_returns_label_for_reuse() {
+        let mut central = VrfLabelAllocator::bounded(1000, 1_000_000);
+        let mut pool = ShardLabelPool::default();
+        let l = pool
+            .label_lu_v4(Some(&mut central), v4("10.0.0.0/24"))
+            .unwrap();
+        assert_eq!(pool.free_lu_v4(v4("10.0.0.0/24")), Some(l));
+        // The freed label comes back out of the shard pool — no central
+        // touch needed (pass None to prove it).
+        assert_eq!(
+            pool.label_lu_v4(None, v4("10.9.9.0/24")),
+            Some(l),
+            "freed label reused from the shard sub-block"
+        );
+    }
+
+    #[test]
+    fn label_pool_without_central_is_none_when_empty() {
+        let mut pool = ShardLabelPool::default();
+        // Empty sub-block and no central to carve from → no label (the
+        // caller falls back to advertising the received label).
+        assert_eq!(pool.label_lu_v4(None, v4("10.0.0.0/24")), None);
     }
 
     #[test]

--- a/zebra-rs/src/bgp/vrf/inst.rs
+++ b/zebra-rs/src/bgp/vrf/inst.rs
@@ -467,7 +467,7 @@ impl BgpVrf {
                     nexthop_cache: None,
                     vrf_transport_v4: Some(&self.transport_v4),
                     vrf_transport_v6: Some(&self.transport_v6),
-                    lu_labels: None,
+                    central_label_alloc: None,
                 };
                 fsm(&mut top, &mut self.peers, ident, event);
             }
@@ -635,7 +635,7 @@ impl BgpVrf {
             nexthop_cache: None,
             vrf_transport_v4: Some(&self.transport_v4),
             vrf_transport_v6: Some(&self.transport_v6),
-            lu_labels: None,
+            central_label_alloc: None,
         };
         super::super::route::route_advertise_to_peers(
             None,
@@ -721,7 +721,7 @@ impl BgpVrf {
             nexthop_cache: None,
             vrf_transport_v4: Some(&self.transport_v4),
             vrf_transport_v6: Some(&self.transport_v6),
-            lu_labels: None,
+            central_label_alloc: None,
         };
         super::super::route::route_advertise_to_peers(
             None,
@@ -850,7 +850,7 @@ impl BgpVrf {
             nexthop_cache: None,
             vrf_transport_v4: Some(&self.transport_v4),
             vrf_transport_v6: Some(&self.transport_v6),
-            lu_labels: None,
+            central_label_alloc: None,
         };
         super::super::route::route_advertise_to_peers_v6(
             prefix,
@@ -920,7 +920,7 @@ impl BgpVrf {
             nexthop_cache: None,
             vrf_transport_v4: Some(&self.transport_v4),
             vrf_transport_v6: Some(&self.transport_v6),
-            lu_labels: None,
+            central_label_alloc: None,
         };
         super::super::route::route_advertise_to_peers_v6(
             prefix,

--- a/zebra-rs/src/bgp/vrf/label.rs
+++ b/zebra-rs/src/bgp/vrf/label.rs
@@ -76,6 +76,40 @@ impl VrfLabelAllocator {
         });
     }
 
+    /// An allocator with no blocks — hands out nothing until one is
+    /// added via [`Self::extend`]. The seed for a shard's sub-block
+    /// pool (RIB sharding B.2): it starts empty and is filled by
+    /// [carving][Self::carve] sub-ranges from the central allocator.
+    pub fn empty() -> Self {
+        Self {
+            blocks: Vec::new(),
+            free: BTreeSet::new(),
+        }
+    }
+
+    /// Reserve `n` consecutive never-allocated labels from the
+    /// frontier of the first block with room, returning the half-open
+    /// range `[start, start + n)` for a shard to seed / extend its own
+    /// pool with (RIB sharding B.2). The reserved range leaves this
+    /// allocator's frontier, so neither [`alloc`](Self::alloc) (the
+    /// per-VRF-spawn labels) nor a later `carve` (another shard
+    /// sub-block) can ever hand the same label out twice — the carve
+    /// and the central allocator share one monotonic frontier. `None`
+    /// when no single block has `n` contiguous room left.
+    pub fn carve(&mut self, n: u32) -> Option<(u32, u32)> {
+        if n == 0 {
+            return None;
+        }
+        for block in self.blocks.iter_mut() {
+            if block.end - block.next >= n {
+                let start = block.next;
+                block.next += n;
+                return Some((start, start + n));
+            }
+        }
+        None
+    }
+
     /// Unbounded over the whole usable label space — kept for tests
     /// and as a fallback; the running BGP instance uses [`Self::bounded`]
     /// with the RIB-allocated block.
@@ -244,6 +278,42 @@ mod tests {
         a.free(501);
         assert_eq!(a.alloc(), Some(100));
         assert_eq!(a.alloc(), Some(501));
+    }
+
+    #[test]
+    fn empty_allocator_hands_out_nothing_until_extended() {
+        let mut a = VrfLabelAllocator::empty();
+        assert_eq!(a.alloc(), None, "no blocks yet");
+        assert_eq!(a.carve(4), None, "nothing to carve from");
+        a.extend(1000, 1004); // [1000, 1004)
+        assert_eq!(a.alloc(), Some(1000));
+    }
+
+    #[test]
+    fn carve_reserves_a_disjoint_subrange() {
+        // A shard carving a sub-block from the central pool: the
+        // carved range and the central allocator's own labels never
+        // collide because both advance one shared frontier.
+        let mut central = VrfLabelAllocator::bounded(100, 110); // [100, 110)
+        assert_eq!(central.alloc(), Some(100), "central VRF-spawn label");
+        // Shard carves 4 labels — taken from the frontier after 100.
+        assert_eq!(central.carve(4), Some((101, 105)));
+        // Central's next alloc resumes *past* the carved range.
+        assert_eq!(central.alloc(), Some(105), "no overlap with carve");
+        // A second carve continues the frontier.
+        assert_eq!(central.carve(3), Some((106, 109)));
+        assert_eq!(central.alloc(), Some(109));
+        assert_eq!(central.alloc(), None, "block spent");
+        assert_eq!(central.carve(1), None, "nothing left to carve");
+    }
+
+    #[test]
+    fn carve_rejects_a_request_larger_than_any_block() {
+        let mut a = VrfLabelAllocator::bounded(100, 104); // 4 labels
+        assert_eq!(a.carve(5), None, "no single block has 5 contiguous");
+        assert_eq!(a.carve(0), None, "zero is a no-op");
+        // The failed carves left the frontier untouched.
+        assert_eq!(a.alloc(), Some(100));
     }
 
     #[test]


### PR DESCRIPTION
First B.2 slice of the RIB sharding plan (follows the B.1 trio #1421/#1425/#1427). The per-route local-label allocation that runs in the shard's hot path — Labeled-Unicast v4/v6 (next-hop-self) and the Inter-AS Option B VPNv4 transit case — now draws from a **shard-owned sub-block** instead of the central allocator directly, so when the shard becomes a task (B.3) it mints labels without an RPC to main per route (the plan flags this as the one thing that "cannot RPC to main per route").

**The no-collision design (why this needed no label-space partitioning):** `VrfLabelAllocator` gains `empty()` (a pool with no blocks) and `carve(n)` (reserve `n` consecutive labels from the never-allocated *frontier*, returning the range). A carve and the central allocator's own `alloc()` advance **one shared monotonic frontier**, so the per-VRF-spawn labels (still served by the central pool on `Bgp`) and the shard's route labels provably never hand out the same label — no pre-split of the 20-bit space, no reservation config.

**Changes:**
- New `ShardLabelPool` on `BgpShard`: the sub-block allocator + the three per-prefix caches (LU v4/v6, VPNv4 transit) that moved off `Bgp`. Allocate-on-first-use; refills via `carve(1024)` when the sub-block runs dry.
- `LuLabels` (the old borrow-bundle of central-alloc + caches) is **deleted**. The receive `BgpTop` now carries just `central_label_alloc` (the refill source); the six hot-path call sites go through `bgp.shard.labels`, passing the central pool as a disjoint-field borrow for refill.
- The three label-cache fields removed from `Bgp`; `vrf_label_alloc` stays as the central pool (per-VRF-spawn labels unchanged).

Inline at N=1 this is behaviourally identical to drawing from the central pool — the structure is what B.3 consumes.

## Test plan
- `cargo test --workspace --exclude bdd` — 1749 green, zero failures.
- New unit tests: `carve`/`empty` (3), and `ShardLabelPool` refill / dedup / free-reuse / no-collision-with-central / empty-without-central (5).
- `cargo clippy --workspace --all-targets -- -D warnings` clean (cache-busted).

Next B.2 slice: the `ShardMsg`/`ShardOut` protocol types — I plan to land those alongside B.3 where their consumers live, rather than as dead-code enums.

🤖 Generated with [Claude Code](https://claude.com/claude-code)