### PR TITLE
bgp: route whole-peer transport reconcilers through a general ident sweep

### DIFF
--- a/zebra-rs/src/bgp/config.rs
+++ b/zebra-rs/src/bgp/config.rs
@@ -940,9 +940,24 @@ fn config_local_as_dual_as(bgp: &mut Bgp, args: Args, op: ConfigOp) -> Option<()
 /// `minimum-ttl` is not part of the key; changing it on an already-up
 /// session needs a bounce (BFD applies params only at session
 /// creation), consistent with how intervals / profile behave.
+/// Addressed-neighbor entry point: resolve the address to its stable
+/// ident and reconcile. Used by the per-`neighbor <addr>` config
+/// callbacks. Interface-keyed (unnumbered) peers reach the same core
+/// via [`bfd_apply_ident`] — they cannot be found by `get(&addr)`,
+/// since their map key is the ifindex, not the link-local.
 pub(super) fn bfd_apply(bgp: &mut Bgp, addr: IpAddr) -> Option<()> {
+    let ident = bgp.peers.get(&addr)?.ident;
+    bfd_apply_ident(bgp, ident)
+}
+
+/// Reconcile the BFD session for one peer by its stable ident. The
+/// BFD remote / session key derive from `peer.address` read here, so
+/// this also works for an interface-keyed peer whose link-local is not
+/// a map key.
+pub(super) fn bfd_apply_ident(bgp: &mut Bgp, ident: usize) -> Option<()> {
+    let addr = bgp.peers.get_by_idx(ident)?.address;
     let (enable, desired_key, params) = {
-        let peer = bgp.peers.get(&addr)?;
+        let peer = bgp.peers.get_by_idx(ident)?;
         // Effective enable + Echo = the per-neighbor `bfd {}` merged over the
         // instance-level `router bgp { bfd {} }` default (blanket enable +
         // per-neighbor override). Hop-mode / min-ttl stay per-neighbor.
@@ -1016,7 +1031,7 @@ pub(super) fn bfd_apply(bgp: &mut Bgp, addr: IpAddr) -> Option<()> {
 
     let (current, current_params) = bgp
         .peers
-        .get(&addr)
+        .get_by_idx(ident)
         .map(|p| (p.bfd_session_key, p.bfd_session_params))
         .unwrap_or((None, None));
     let want = enable.then_some(desired_key);
@@ -1059,7 +1074,7 @@ pub(super) fn bfd_apply(bgp: &mut Bgp, addr: IpAddr) -> Option<()> {
         });
     }
 
-    if let Some(peer) = bgp.peers.get_mut(&addr) {
+    if let Some(peer) = bgp.peers.get_mut_by_idx(ident) {
         peer.bfd_session_key = want;
         peer.bfd_session_params = want_params;
     }
@@ -1177,9 +1192,8 @@ fn config_peer_bfd_detect_offload(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -
 /// reconcile that diffs against the recorded session key, so this is just a
 /// fan-out (a no-op per neighbor when nothing changed).
 pub(super) fn bfd_reconcile_all(bgp: &mut Bgp) {
-    let addrs: Vec<IpAddr> = bgp.peers.keys().copied().collect();
-    for addr in addrs {
-        bfd_apply(bgp, addr);
+    for ident in bgp.peers.idents() {
+        bfd_apply_ident(bgp, ident);
     }
 }
 
@@ -2345,12 +2359,18 @@ pub(super) fn apply_tcp_mss(peer: &mut Peer, want: Option<u16>) -> bool {
 pub(super) fn apply_tcp_mss_refresh_all(bgp: &mut Bgp) {
     let mut min_v4: Option<u16> = None;
     let mut min_v6: Option<u16> = None;
-    let addrs: Vec<IpAddr> = bgp.peers.keys().copied().collect();
-    for addr in &addrs {
-        let Some(mss) = bgp.peers.get(addr).and_then(|p| p.config.transport.tcp_mss) else {
+    // Every peer regardless of key variant: an interface-keyed
+    // (unnumbered) peer's configured `tcp-mss` must fold into the
+    // listener-wide minimum like any other. The session family comes
+    // from `peer.address` (a v6 link-local for unnumbered peers).
+    for ident in bgp.peers.idents() {
+        let Some(peer) = bgp.peers.get_by_idx(ident) else {
             continue;
         };
-        let slot = if addr.is_ipv4() {
+        let Some(mss) = peer.config.transport.tcp_mss else {
+            continue;
+        };
+        let slot = if peer.address.is_ipv4() {
             &mut min_v4
         } else {
             &mut min_v6
@@ -2664,6 +2684,43 @@ pub(super) fn apply_md5_password(peer: &mut Peer, want: Option<String>) -> bool 
 /// when there is no listener fd yet — `apply_md5_refresh_all` from
 /// `listen()` will fill in once the bind completes.
 pub(super) fn apply_md5_refresh_for(bgp: &mut Bgp, addr: IpAddr) {
+    match bgp.peers.get(&addr).map(|p| p.ident) {
+        Some(ident) => apply_md5_refresh_for_ident(bgp, ident),
+        // Peer absent (defensive delete path): clear any stale listener
+        // key for this address with an empty key.
+        None => md5_set_on_listener(bgp, addr, &[]),
+    }
+}
+
+/// Reconcile the listener TCP MD5 key for one peer by its stable
+/// ident. Reads the source address from `peer.address`, so an
+/// interface-keyed (unnumbered) peer is serviced too — its link-local
+/// is not a map key, so an addr re-lookup would silently drop it. A
+/// dormant peer (unspecified address, no session yet) is skipped:
+/// there is no source address to key the listener on.
+pub(super) fn apply_md5_refresh_for_ident(bgp: &mut Bgp, ident: usize) {
+    let Some(peer) = bgp.peers.get_by_idx(ident) else {
+        return;
+    };
+    let addr = peer.address;
+    if addr.is_unspecified() {
+        return;
+    }
+    let password_bytes: Vec<u8> = peer
+        .config
+        .transport
+        .md5_password
+        .as_ref()
+        .map(|s| s.as_bytes().to_vec())
+        .unwrap_or_default();
+    md5_set_on_listener(bgp, addr, &password_bytes);
+}
+
+/// Install (or, with an empty key, remove) the listener TCP MD5 entry
+/// for `addr` on the address-family-matching listening socket. Silent
+/// when there is no listener fd yet — the post-bind reconciler in
+/// `listen()` fills it in.
+fn md5_set_on_listener(bgp: &Bgp, addr: IpAddr, password_bytes: &[u8]) {
     let listen_fd = match addr {
         IpAddr::V4(_) => bgp.listen_fd_v4,
         IpAddr::V6(_) => bgp.listen_fd_v6,
@@ -2674,16 +2731,7 @@ pub(super) fn apply_md5_refresh_for(bgp: &mut Bgp, addr: IpAddr) {
         return;
     };
 
-    // Empty key removes the entry. Either the peer has no password
-    // set, or the peer doesn't exist in the map (delete path).
-    let password_bytes: Vec<u8> = bgp
-        .peers
-        .get(&addr)
-        .and_then(|p| p.config.transport.md5_password.as_ref())
-        .map(|s| s.as_bytes().to_vec())
-        .unwrap_or_default();
-
-    match super::auth::set_tcp_md5_key(fd, addr, &password_bytes) {
+    match super::auth::set_tcp_md5_key(fd, addr, password_bytes) {
         Ok(()) => {
             if !password_bytes.is_empty() {
                 tracing::debug!(
@@ -2717,9 +2765,8 @@ pub(super) fn apply_md5_refresh_for(bgp: &mut Bgp, addr: IpAddr) {
 /// Safe to call repeatedly — `setsockopt(TCP_MD5SIG)` is idempotent
 /// for the same (addr, key) tuple.
 pub(super) fn apply_md5_refresh_all(bgp: &mut Bgp) {
-    let addrs: Vec<IpAddr> = bgp.peers.keys().copied().collect();
-    for addr in addrs {
-        apply_md5_refresh_for(bgp, addr);
+    for ident in bgp.peers.idents() {
+        apply_md5_refresh_for_ident(bgp, ident);
     }
 }
 
@@ -2765,11 +2812,20 @@ pub(super) fn apply_ao_refresh_all(bgp: &mut Bgp) {
     // iterating peers mutably.
     let key_chains = bgp.key_chains.clone();
 
-    let addrs: Vec<IpAddr> = bgp.peers.keys().copied().collect();
-    for addr in addrs {
-        let Some(peer) = bgp.peers.get_mut(&addr) else {
+    // Every peer regardless of key variant. The listener entry is
+    // keyed by the peer's source address read from `peer.address`, so
+    // an interface-keyed (unnumbered) peer is serviced too — it cannot
+    // be round-tripped through `get(&addr)`. A dormant peer
+    // (unspecified address, no session yet) is skipped: there is no
+    // source address to key on.
+    for ident in bgp.peers.idents() {
+        let Some(peer) = bgp.peers.get_mut_by_idx(ident) else {
             continue;
         };
+        let addr = peer.address;
+        if addr.is_unspecified() {
+            continue;
+        }
 
         let fd = match addr {
             IpAddr::V4(_) => fd_v4,

--- a/zebra-rs/src/bgp/neighbor_group.rs
+++ b/zebra-rs/src/bgp/neighbor_group.rs
@@ -1054,8 +1054,11 @@ pub(super) fn sweep_members_inherit(bgp: &mut Bgp, name: &str) {
     let policy_tx = bgp.policy_tx.clone();
     let mut stops: Vec<usize> = Vec::new();
     let mut mss_refresh = false;
-    let mut md5_addrs: Vec<IpAddr> = Vec::new();
-    let mut bfd_addrs: Vec<IpAddr> = Vec::new();
+    // Collect idents, not addresses: the MD5 / BFD reconcilers must be
+    // able to reach an interface-keyed (unnumbered) member, whose
+    // link-local is not a map key (`get(&peer.address)` would miss it).
+    let mut md5_idents: Vec<usize> = Vec::new();
+    let mut bfd_idents: Vec<usize> = Vec::new();
     for (_, peer) in bgp.peers.iter_mut_all() {
         if peer.config.neighbor_group.as_deref() != Some(name) {
             continue;
@@ -1066,10 +1069,10 @@ pub(super) fn sweep_members_inherit(bgp: &mut Bgp, name: &str) {
         }
         mss_refresh |= outcome.mss_refresh;
         if outcome.md5_refresh {
-            md5_addrs.push(peer.address);
+            md5_idents.push(peer.ident);
         }
         if outcome.bfd_reapply {
-            bfd_addrs.push(peer.address);
+            bfd_idents.push(peer.ident);
         }
     }
     for ident in stops {
@@ -1082,11 +1085,11 @@ pub(super) fn sweep_members_inherit(bgp: &mut Bgp, name: &str) {
     // group-delete cascade, where a deleted `ip-transparent` opinion
     // must drop out of the listener union.
     super::config::apply_ip_transparent_refresh_all(bgp);
-    for addr in md5_addrs {
-        super::config::apply_md5_refresh_for(bgp, addr);
+    for ident in md5_idents {
+        super::config::apply_md5_refresh_for_ident(bgp, ident);
     }
-    for addr in bfd_addrs {
-        let _ = super::config::bfd_apply(bgp, addr);
+    for ident in bfd_idents {
+        let _ = super::config::bfd_apply_ident(bgp, ident);
     }
 }
 

--- a/zebra-rs/src/bgp/peer_map.rs
+++ b/zebra-rs/src/bgp/peer_map.rs
@@ -95,6 +95,25 @@ impl PeerMap {
         &self.membership
     }
 
+    /// Snapshot of every live peer's ident, regardless of key variant
+    /// — the general, interface-keyed-safe replacement for the
+    /// addr-only `keys()` sweep. Whole-peer-set reconcilers (BFD,
+    /// listener TCP-MSS / MD5 / TCP-AO) must use this and re-look-up
+    /// via [`Self::get_by_idx`] / [`Self::get_mut_by_idx`]: a
+    /// `PeerKey::Interface` (IPv6 unnumbered) peer cannot be
+    /// round-tripped through `get(&peer.address)` — its stored key is
+    /// the ifindex, not the link-local — so any helper that re-looks-up
+    /// by address silently drops it. `keys()` stays for the few
+    /// genuinely addr-only consumers (CLI completion of typeable
+    /// neighbor addresses).
+    pub fn idents(&self) -> Vec<usize> {
+        self.map
+            .values()
+            .filter(|&&idx| self.peers[idx].is_some())
+            .copied()
+            .collect()
+    }
+
     /// Snapshot of every Established peer that negotiated `(afi,
     /// safi)` — both AddPath-send and plain members. The fan-out
     /// idiom: iterate this, re-look-up mutably via
@@ -506,5 +525,42 @@ mod tests {
 
         let keys: Vec<IpAddr> = m.keys().copied().collect();
         assert_eq!(keys, vec![a]);
+    }
+
+    /// `idents()` is the general, interface-keyed-safe sweep accessor:
+    /// unlike `keys()` it must include `PeerKey::Interface` peers, and
+    /// it must drop tombstoned slots. This is the contract the
+    /// transport reconcilers (BFD / TCP-MSS / MD5 / TCP-AO) rely on.
+    #[test]
+    fn idents_includes_interface_keyed_and_skips_tombstones() {
+        let mut m = PeerMap::new();
+        let a: IpAddr = Ipv4Addr::new(10, 0, 0, 1).into();
+        m.insert(a, make_peer(a));
+        let a_idx = m.get(&a).unwrap().ident;
+        m.insert_with_key(
+            PeerKey::Interface(11),
+            make_peer(Ipv4Addr::UNSPECIFIED.into()),
+        );
+        let if_idx = m.get_by_key(&PeerKey::Interface(11)).unwrap().ident;
+
+        let mut idents = m.idents();
+        idents.sort_unstable();
+        assert_eq!(
+            idents,
+            {
+                let mut v = vec![a_idx, if_idx];
+                v.sort_unstable();
+                v
+            },
+            "idents() must include both addr- and interface-keyed peers"
+        );
+
+        // Tombstone the addr-keyed peer: its slot must drop out.
+        m.remove(&a);
+        assert_eq!(
+            m.idents(),
+            vec![if_idx],
+            "idents() must skip tombstoned slots"
+        );
     }
 }


### PR DESCRIPTION
## Summary

The four whole-peer-set transport reconcilers — BFD, listener TCP-MSS, TCP-MD5, TCP-AO — each swept `bgp.peers.keys()` (addr-keyed only) and then re-looked-up every peer via `get(&addr)`. **Both halves silently drop an interface-keyed (IPv6 unnumbered) peer:** its map key is the ifindex, not the link-local, so it never appears in `keys()` *and* cannot be round-tripped through `get(&peer.address)`. The same trap bit the neighbor-group inherit sweep, which iterates `iter_mut_all()` correctly but then fed `peer.address` back into the addr-keyed helpers — so an unnumbered member that inherited `bfd` / `tcp-mss` / `password` from its group got nothing applied.

This is the same class as the `iter()`/`iter_mut()` trap removed earlier; this PR closes the `keys()` + `get(&peer.address)` variant and consolidates the sweep into one general method.

### Changes
- **`PeerMap::idents()`** — a general, interface-keyed-safe snapshot of every live peer's ident, the documented replacement for the addr-only `keys()` sweep. `keys()` stays for the one genuinely addr-only consumer: CLI completion (`peer_comps`), which yields typeable neighbor addresses and adds interface-neighbor *names* separately.
- **Ident-based helper cores** — `bfd_apply` / `apply_md5_refresh_for` gain `*_ident` cores that read the source address *from* the peer (so an interface-keyed peer's link-local is used, not used as the lookup key). The addr-taking wrappers stay for the per-`neighbor <addr>` config callbacks; the MD5 wrapper preserves the defensive empty-key removal for an absent address. MSS and AO iterate `idents()` inline. The MD5/AO cores skip an unspecified address (a dormant unnumbered peer with no session yet — nothing to key the listener on).
- **Neighbor-group inherit sweep** collects idents, not addresses, and calls the `*_ident` cores.

**No behavior change for addressed neighbors:** the kernel sockopt calls are byte-identical (`addr == peer.address`). Interface-keyed peers are now serviced instead of silently skipped.

## Testing

- `cargo fmt` / `cargo clippy --workspace --all-targets -- -D warnings` clean
- `cargo test --workspace --exclude bdd` green; new `idents_includes_interface_keyed_and_skips_tombstones` unit test pins the general-method contract
- BDD against the rebuilt binary: `@bgp_tcp_ao_auth`, `@bgp_tcp_mss`, `@bgp_neighbor_group`, `@bgp_unnumbered_neighbor` all pass

### Pre-existing failure (NOT introduced here)
`@bgp_tcp_md5_auth` scenario "Mismatched password drops the session" fails — z1→z2 stays Established after a mismatched password instead of dropping. **Verified identical on the `origin/main` baseline binary**, so it is pre-existing (BDD is CI-excluded, so it went unnoticed). Root cause: changing the listener MD5 key does not tear down the already-established TCP child socket, and the password-change callback issues no session bounce, so the session survives the 5s wait until holdtimer expiry. FRR treats an MD5 password change as a `peer_change_reset` (bounce). Worth a separate fix; out of scope for this consolidation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)