### PR TITLE
bgp: reset the session on a TCP-MD5 password change

### DIFF
--- a/zebra-rs/src/bgp/config.rs
+++ b/zebra-rs/src/bgp/config.rs
@@ -2626,12 +2626,22 @@ fn config_peer_tcp_md5_password(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> 
     } else {
         None
     };
+    let mut bounce_ident = None;
     if let Some(peer) = bgp.peers.get_mut(&addr) {
         peer.config.knobs_explicit.password = explicit;
         let want = super::neighbor_group::resolve_knob(&bgp.neighbor_groups, &peer.config, |k| {
             k.password.clone()
         });
-        apply_md5_password(peer, want);
+        // A password change resets the session (FRR's `peer_change_reset`):
+        // the listener / connect-socket key only takes effect on a fresh
+        // connection, so a session authenticated under the old key would
+        // otherwise survive a new, removed, or mismatched password until
+        // the hold timer eventually expires. Bounce a live session with
+        // `Event::Stop` (the `clear … hard` teardown); an Idle peer picks
+        // the new key up on its first connect.
+        if apply_md5_password(peer, want) && !matches!(peer.state, super::peer::State::Idle) {
+            bounce_ident = Some(peer.ident);
+        }
     }
 
     // Reconcile the listener state for this peer regardless of
@@ -2641,15 +2651,22 @@ fn config_peer_tcp_md5_password(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> 
     // (we run apply_md5_refresh_all from config_peer too).
     apply_md5_refresh_for(bgp, addr);
 
+    if let Some(ident) = bounce_ident {
+        let _ = bgp
+            .tx
+            .try_send(super::inst::Message::Event(ident, super::peer::Event::Stop));
+    }
+
     Some(())
 }
 
 /// Write a resolved TCP MD5 password onto the peer. The active
 /// connect path reads it at dial time and the listener key is owned
-/// by [`apply_md5_refresh_for`] — no bounce, parity with the
-/// per-neighbor callback (the live session keeps its key until it
-/// resets). Returns `true` when the stored value changed — the
-/// caller owes a listener re-key for this peer's address.
+/// by [`apply_md5_refresh_for`]. Returns `true` when the stored value
+/// changed — the caller owes a listener re-key for this peer's address
+/// and, for a live session, a reset (`Event::Stop`) so the new key
+/// takes effect on the next connection (the per-neighbor callback and
+/// the group inherit sweep both honour this).
 pub(super) fn apply_md5_password(peer: &mut Peer, want: Option<String>) -> bool {
     if peer.config.transport.md5_password == want {
         return false;

--- a/zebra-rs/src/bgp/neighbor_group.rs
+++ b/zebra-rs/src/bgp/neighbor_group.rs
@@ -1017,6 +1017,12 @@ pub(super) fn apply_inherited(
     outcome.bfd_reapply = super::config::apply_update_source(peer, update_source);
     outcome.mss_refresh = super::config::apply_tcp_mss(peer, tcp_mss);
     outcome.md5_refresh = super::config::apply_md5_password(peer, password);
+    // A password change must reset the session, like the per-neighbor
+    // path: the listener / connect-socket key only takes effect on a
+    // fresh connection, so a live session under the old key must bounce.
+    // (`tcp-mss` is a clamp on new segments and does not break auth, so
+    // it stays out of the bounce set.)
+    bounce |= outcome.md5_refresh;
     super::config::apply_peer_policy_ref(
         policy_tx,
         peer,


### PR DESCRIPTION
## Summary

A TCP-MD5 password change (set / remove / mismatch) only takes effect on a **fresh** connection: the listener key and the active-connect key are read at accept/dial time, and Linux does not retro-key an already-established child socket. The per-neighbor callback installed the new listener key but never reset a live session — so an Established session authenticated under the old password survived a new, removed, or mismatched one until the hold timer eventually expired (~minutes), instead of the immediate drop an operator (and FRR's `peer_change_reset`) expects.

This was surfaced as a pre-existing failure while validating #1429: `@bgp_tcp_md5_auth` scenario "Mismatched password drops the session" stayed Established. (I confirmed it failed identically on the `origin/main` baseline; BDD is CI-excluded, so it went unnoticed.)

### Fix
Bounce a live session with `Event::Stop` (the `clear … hard` teardown) whenever the resolved password actually changes, on both paths:

- **`config_peer_tcp_md5_password`** (per-`neighbor <addr>` leaf): capture the `apply_md5_password` changed-bool and stop the peer if it is not Idle, after the listener re-key.
- **`apply_inherited`** (neighbor-group inherit sweep): fold `md5_refresh` into the bounce set so an inherited group password change resets members too. The sweep already gates the stop on `!Idle`. `tcp-mss` stays out of the bounce set — a clamp on new segments doesn't break auth.

Follows the existing bounce-on-change pattern (`config_local_as`, `config_peer_port`): diff-gate → `Event::Stop` if changed and not Idle.

### TCP-AO
TCP-AO has the same shape (a key change doesn't reset the session) but is left for a separate change — its RFC 5925 in-session rekey (SendID/RecvID) is more subtle, and it has no mismatch-drop BDD coverage yet.

## Testing

- `cargo fmt` / `cargo clippy --workspace --all-targets -- -D warnings` clean
- `cargo test --workspace --exclude bdd` green
- BDD: `@bgp_tcp_md5_auth` now **4/4 scenarios pass** (28/28 steps) — the mismatch-drop step that previously failed now drops the session; establish + restore stay green. `@bgp_neighbor_group` (6 scenarios) regression-clean for the `apply_inherited` edit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)