### PR TITLE
bgp: implement AddPath Send for VPNv6 (per-candidate twins)

### DIFF
--- a/docs/design/bgp-peer-list.md
+++ b/docs/design/bgp-peer-list.md
@@ -400,3 +400,49 @@ entirely with the membership-index snapshots
 (`established_idents` / `established_plain_idents` /
 `established_addpath_idents`), so the table's line numbers and
 "AddPath handling" column describe the pre-refactor code.
+
+## 10. AddPath Send completion (B3 follow-through)
+
+B3 was first contained by *masking*: `addpath_send_implemented()`
+refused to negotiate AddPath Send for any family without a
+per-candidate advertise/withdraw twin (originally v4-unicast + VPNv4
+only). The follow-through is to *build* the twins so AddPath Send is
+supported everywhere it's meaningful. Target: every advertise family
+**except RTC** (`(Ip|Ip6, Rtc)` — Route Target Constraint NLRI carry
+no per-path semantics).
+
+**Invariant:** a family joins the `addpath_send_implemented()`
+allowlist in the SAME change that adds its twin — never before, or B3
+reopens (RFC 7911 §3 binds every NLRI of a negotiated family to a
+path-id, so a half-wired family emits malformed/ineffective
+withdraws).
+
+Each family follows the proven v4/VPNv4 twin shape:
+- split the existing best-path advertise to `established_plain_idents`;
+- add a per-candidate reach twin over `established_addpath_idents`
+  (one call per changed path, NLRI stamped `id = rib.local_id`);
+- add a withdraw twin keyed on `removed.local_id`;
+- wire both into the family's update / withdraw (and soft-out, where
+  one exists) call sites — clone the inbound `rib` before it moves
+  into the Loc-RIB `update`, carry `next_id`.
+
+Per-family status / notes:
+- **VPNv6** — DONE: `route_advertise_to_peers_vpnv6_addpath` /
+  `route_withdraw_vpnv6_addpath`; reuses `send_vpnv6` /
+  `cache_remove_vpnv6` (id rides in the NLRI, cache keys on it); no
+  soft-out path for VPNv6. Closest analog to VPNv4.
+- **EVPN** — TODO: reuses `send_evpn`; EVPN *does* have a soft-out
+  (`route_soft_out_peer_table_evpn`) that needs the twin too. Route id
+  lives on each `EvpnRoute` variant.
+- **LU-v4 / LU-v6** — TODO: no per-peer cache today (direct
+  `send_packet`); the twin loops candidates and emits one UPDATE each
+  with the path-id, or adds a small cache mirroring the VPN shape.
+- **IPv6-unicast** — separate family (group-cache shape like
+  v4-unicast, not the VPN per-peer cache); subsumed by B1 historically,
+  worth a twin too but not in the user's named set.
+
+No end-to-end AddPath BDD exists yet (true for v4/VPNv4 too) — the
+families are control-plane-validated (cap negotiation +
+`addpath_send_implemented` unit tests + full suite). A multi-path
+topology BDD asserting two paths arrive with distinct path-ids is a
+worthwhile cross-cutting follow-up for all AddPath families.

--- a/zebra-rs/src/bgp/cap.rs
+++ b/zebra-rs/src/bgp/cap.rs
@@ -101,7 +101,7 @@ pub fn cap_register_recv(bgp_cap: &BgpCap, cap_map: &mut CapAfiMap) {
 pub fn addpath_send_implemented(afi: Afi, safi: Safi) -> bool {
     matches!(
         (afi, safi),
-        (Afi::Ip, Safi::Unicast) | (Afi::Ip, Safi::MplsVpn)
+        (Afi::Ip, Safi::Unicast) | (Afi::Ip, Safi::MplsVpn) | (Afi::Ip6, Safi::MplsVpn)
     )
 }
 
@@ -176,9 +176,9 @@ mod tests {
         // Implemented families negotiate send.
         assert!(opt.is_add_path_send(Afi::Ip, Safi::Unicast));
         assert!(opt.is_add_path_send(Afi::Ip, Safi::MplsVpn));
+        assert!(opt.is_add_path_send(Afi::Ip6, Safi::MplsVpn));
         // Unimplemented families are masked to receive-only.
         assert!(!opt.is_add_path_send(Afi::Ip6, Safi::Unicast));
-        assert!(!opt.is_add_path_send(Afi::Ip6, Safi::MplsVpn));
         // Receive negotiates for every family (parsing is generic).
         for (afi, safi) in [
             (Afi::Ip, Safi::Unicast),
@@ -194,25 +194,37 @@ mod tests {
         }
     }
 
-    /// The supported-set itself, pinned: exactly IPv4 unicast + VPNv4
-    /// today. Growing it is deliberate — it must come WITH the
-    /// per-candidate advertise/withdraw twins for the new family.
+    /// The supported-set itself, pinned. Growing it is deliberate —
+    /// each family must be added WITH its per-candidate
+    /// advertise/withdraw twins (VPNv6 landed alongside its
+    /// `route_advertise_to_peers_vpnv6_addpath` twin). EVPN and
+    /// labeled-unicast v4/v6 are the remaining families to wire up;
+    /// RTC is the one family that stays excluded by design.
     #[test]
-    fn addpath_send_implemented_set_is_v4_unicast_and_vpnv4() {
-        assert!(addpath_send_implemented(Afi::Ip, Safi::Unicast));
-        assert!(addpath_send_implemented(Afi::Ip, Safi::MplsVpn));
+    fn addpath_send_implemented_set() {
+        for (afi, safi) in [
+            (Afi::Ip, Safi::Unicast),
+            (Afi::Ip, Safi::MplsVpn),
+            (Afi::Ip6, Safi::MplsVpn),
+        ] {
+            assert!(
+                addpath_send_implemented(afi, safi),
+                "{afi} {safi} has a per-path advertise pipeline"
+            );
+        }
         for (afi, safi) in [
             (Afi::Ip6, Safi::Unicast),
-            (Afi::Ip6, Safi::MplsVpn),
             (Afi::L2vpn, Safi::Evpn),
             (Afi::Ip, Safi::MplsLabel),
             (Afi::Ip6, Safi::MplsLabel),
             (Afi::Ip, Safi::Flowspec),
             (Afi::Ip6, Safi::Flowspec),
+            (Afi::Ip, Safi::Rtc),
+            (Afi::Ip6, Safi::Rtc),
         ] {
             assert!(
                 !addpath_send_implemented(afi, safi),
-                "{afi} {safi} has no per-path advertise pipeline"
+                "{afi} {safi} has no per-path advertise pipeline yet"
             );
         }
     }

--- a/zebra-rs/src/bgp/route.rs
+++ b/zebra-rs/src/bgp/route.rs
@@ -3444,7 +3444,16 @@ pub fn route_ipv6_update(
     {
         rib.vrf_transit_only = true;
     }
-    let (replaced, selected, _next_id) = match rd {
+    // VPNv6 AddPath needs the just-updated path plus its allocated
+    // `local_id` to advertise it as one of several candidates; keep a
+    // clone (cheap Arc bump) only for VPNv6 — v6-unicast AddPath is a
+    // separate family with no twin yet.
+    let rib_addpath = if rd.is_some() {
+        Some(rib.clone())
+    } else {
+        None
+    };
+    let (replaced, selected, next_id) = match rd {
         Some(rd) => bgp.shard.update_v6vpn(rd, nlri.prefix, rib),
         None => bgp.shard.update_v6(nlri.prefix, rib),
     };
@@ -3507,6 +3516,13 @@ pub fn route_ipv6_update(
             }
             if !selected.is_empty() {
                 route_advertise_to_peers_vpnv6(rd, nlri.prefix, &selected, bgp, peers);
+            }
+            // AddPath members get the just-updated candidate path itself
+            // (with its allocated local_id), independent of whether it
+            // won best-path.
+            if let Some(mut rib_ap) = rib_addpath {
+                rib_ap.local_id = next_id;
+                route_advertise_to_peers_vpnv6_addpath(rd, nlri.prefix, &rib_ap, bgp, peers);
             }
         }
     }
@@ -3582,6 +3598,11 @@ pub fn route_ipv6_withdraw(
             // Empty `selected` → MP_UNREACH to PE peers; a replacement
             // winner → re-advertise. Both handled by the helper.
             route_advertise_to_peers_vpnv6(rd, nlri.prefix, &selected, bgp, peers);
+            // AddPath members: withdraw exactly the path that left (by
+            // its local_id); any remaining candidates stay advertised.
+            if let Some(gone) = removed.first() {
+                route_withdraw_vpnv6_addpath(rd, nlri.prefix, gone, peers);
+            }
         }
         None => {
             let removed = bgp.shard.remove_v6(nlri.prefix, nlri.id, ident);
@@ -6853,7 +6874,10 @@ pub(super) fn route_advertise_to_peers_vpnv6(
     let new_best = selected.last();
     let (afi, safi) = (Afi::Ip6, Safi::MplsVpn);
 
-    let peer_idents: Vec<usize> = peers.established_idents(afi, safi);
+    // Best-path only, to the non-AddPath members. AddPath peers receive
+    // every candidate path (each with its own path-id) through
+    // [`route_advertise_to_peers_vpnv6_addpath`] instead.
+    let peer_idents: Vec<usize> = peers.established_plain_idents(afi, safi);
 
     for ident in peer_idents {
         let peer = peers.get_mut_by_idx(ident).expect("peer exists");
@@ -6889,6 +6913,74 @@ pub(super) fn route_advertise_to_peers_vpnv6(
                 route_withdraw_vpnv6(peer, rd, prefix, 0);
             }
         }
+    }
+}
+
+/// VPNv6 AddPath twin of [`route_advertise_to_peers_vpnv6`] — the v6
+/// counterpart of the `rd.is_some()` branch of
+/// [`route_advertise_to_addpath`]. Called once per changed candidate
+/// path with that path's `rib` (its `local_id` already stamped), it
+/// advertises the path — not just the best — to every AddPath-Send
+/// member, each NLRI carrying the path-id (RFC 7911 §3). Split-horizon
+/// excludes the path's own source peer.
+pub(super) fn route_advertise_to_peers_vpnv6_addpath(
+    rd: RouteDistinguisher,
+    prefix: Ipv6Net,
+    rib: &BgpRib,
+    bgp: &mut BgpTop,
+    peers: &mut PeerMap,
+) {
+    let (afi, safi) = (Afi::Ip6, Safi::MplsVpn);
+
+    let peer_idents: Vec<usize> = peers.established_addpath_idents(afi, safi);
+
+    for ident in peer_idents {
+        let peer = peers.get_mut_by_idx(ident).expect("peer exists");
+        // Split-horizon: never reflect a path back to the peer that
+        // sourced it.
+        if rib.ident == peer.ident {
+            continue;
+        }
+        // RFC 9494 §4.3: stale routes only go to LLGR peers.
+        if llgr_blocks_advertisement(rib.stale, &peer.cap_recv, afi, safi) {
+            continue;
+        }
+        let Some((nlri, attr)) = route_update_ipv6(peer, &prefix, rib, bgp, true) else {
+            continue;
+        };
+        let attr = bgp.attr_store.intern(attr);
+        // RTC: skip without withdrawing when the peer's IPv6
+        // route-target constraint set doesn't admit this route.
+        if !peer.rtcv6.is_empty() && !rtc_match(&peer.rtcv6, &attr.ecom) {
+            continue;
+        }
+        let vpnv6_nlri = Vpnv6Nlri {
+            label: rib.label.unwrap_or_default(),
+            rd,
+            nlri,
+        };
+        peer.send_vpnv6(vpnv6_nlri, attr, true);
+    }
+}
+
+/// VPNv6 AddPath withdraw twin — emit an MP_UNREACH carrying the
+/// withdrawn path's `local_id` to every AddPath-Send member, and drop
+/// the matching entry from each peer's pending cache. The other paths
+/// for the prefix stay advertised (they carry different path-ids).
+pub(super) fn route_withdraw_vpnv6_addpath(
+    rd: RouteDistinguisher,
+    prefix: Ipv6Net,
+    removed: &BgpRib,
+    peers: &mut PeerMap,
+) {
+    let (afi, safi) = (Afi::Ip6, Safi::MplsVpn);
+
+    let peer_idents: Vec<usize> = peers.established_addpath_idents(afi, safi);
+
+    for ident in peer_idents {
+        let peer = peers.get_mut_by_idx(ident).expect("peer exists");
+        peer.cache_remove_vpnv6(rd, prefix, removed.local_id);
+        route_withdraw_vpnv6(peer, rd, prefix, removed.local_id);
     }
 }
 


### PR DESCRIPTION
## Summary

First of the **B3 follow-through** families (`docs/design/bgp-peer-list.md` §10). AddPath Send was *masked off* for VPNv6 by `addpath_send_implemented()` because the family had no per-candidate advertise/withdraw pipeline — it sent best-path only, and its withdraw hardcoded path-id 0, which is malformed on a negotiated-AddPath session (RFC 7911 §3 binds every NLRI of the family to a path-id). This adds the VPNv6 twins, mirroring the proven VPNv4 pair.

### Changes
- **`route_advertise_to_peers_vpnv6`** now serves only the non-AddPath members (`established_plain_idents`) — best-path as before.
- **`route_advertise_to_peers_vpnv6_addpath`** (reach twin): per-changed-candidate fan-out over `established_addpath_idents`, each NLRI stamped with the path's `local_id` (`route_update_ipv6(.., add_path=true)`), split-horizon on the source peer, reusing `send_vpnv6` (the path-id rides in the NLRI; the VPNv6 cache keys on it so candidates coexist).
- **`route_withdraw_vpnv6_addpath`** (withdraw twin): MP_UNREACH carrying the withdrawn path's `local_id` + the matching `cache_remove_vpnv6`; other candidates stay advertised.
- Wired into `route_ipv6` update (clone the inbound `rib` before it moves into `update_v6vpn`, carry `next_id`) and `route_ipv6_withdraw` (withdraw `removed.first()`'s `local_id`). VPNv6 has no soft-out path, so those two sites are the full set.
- **`addpath_send_implemented`** grows to include `(Ip6, MplsVpn)` in the *same change* as the twin — the B3 invariant (a family joins the allowlist only with its working pipeline). Tests updated; RTC pinned as the intentionally-excluded family.

**Purely additive:** non-AddPath VPNv6 peers still go through the plain path unchanged, and there were no AddPath VPNv6 peers before this (the family was masked). No regression surface.

### Remaining (separate PRs, §10)
EVPN (has a soft-out path to also wire), labeled-unicast v4/v6 (no per-peer cache today). RTC stays excluded by design.

## Testing

- `cargo fmt` / `cargo clippy --workspace --all-targets -- -D warnings` clean
- `cargo test --workspace --exclude bdd` green; `bgp::cap` tests updated (VPNv6 now in the implemented set; negotiation test asserts VPNv6 Send negotiates)
- BDD `@bgp_peer_down_cleanup` (exercises the VPNv6 route_clean path) passes against the rebuilt binary

Control-plane-validated (matching the existing v4/VPNv4 AddPath posture, which also has no end-to-end BDD). A multi-path AddPath wire BDD is noted in §10 as a cross-cutting follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)