### PR TITLE
bdd: first end-to-end AddPath Send test (IPv4 unicast)

### DIFF
--- a/bdd/docs/bgp_addpath_ipv4.md
+++ b/bdd/docs/bgp_addpath_ipv4.md
@@ -1,0 +1,42 @@
+# BGP AddPath Send for IPv4 unicast (RFC 7911)
+
+## Overview
+
+As a network operator
+I want a BGP speaker with two paths for one prefix to advertise BOTH
+of them — each carrying its own path identifier — to a neighbor that
+negotiated AddPath, instead of the single best path.
+This is the first end-to-end AddPath wire test in the suite: it
+exercises the per-candidate advertise twin
+(`route_advertise_to_addpath`), the AddPath-Send membership split,
+and the path-id stamping. The same shape validates the VPNv6 / EVPN /
+labeled-unicast twins as those land.
+
+## Test Topology
+
+```
+        10.10.10.0/24          10.10.10.0/24
+       (origin AS65001)       (origin AS65002)
+            z1 ──┐               ┌── z2
+       192.168.   │   192.168.   │   192.168.
+        0.1/24    └──→  0.3/24  ←─┘    0.2/24
+                       z3 (AS65003)
+                        │  add-path send-receive
+                        ↓
+                       z4 (AS65004)  192.168.0.4/24
+```
+
+## Notes
+
+z3 learns 10.10.10.0/24 over eBGP from BOTH z1 (AS_PATH 65001) and
+z2 (AS_PATH 65002), so its Loc-RIB holds two candidate paths. With
+AddPath Send negotiated toward z4, z3 advertises both — so z4 sees
+TWO available paths for the prefix, not just the best one.
+
+## Test Scenarios
+
+| Scenario | Result |
+|----------|--------|
+| Setup topology and establish sessions | |
+| The AddPath receiver sees both paths for the prefix | |
+| Teardown topology | |

--- a/bdd/tests/configs/bgp_addpath_ipv4/z1.yaml
+++ b/bdd/tests/configs/bgp_addpath_ipv4/z1.yaml
@@ -1,0 +1,24 @@
+interface:
+- if-name: i1
+  ipv4:
+    address: 192.168.0.1/24
+router:
+  bgp:
+    global:
+      as: 65001
+      router-id: 192.168.0.1
+    timer:
+      adv-interval:
+        ibgp: 1
+        ebgp: 1
+    neighbor:
+    - remote-address: 192.168.0.3
+      afi-safi:
+      - name: ipv4
+        enabled: true
+      enabled: true
+      remote-as: 65003
+    afi-safi:
+    - name: ipv4
+      network:
+      - prefix: 10.10.10.0/24

--- a/bdd/tests/configs/bgp_addpath_ipv4/z2.yaml
+++ b/bdd/tests/configs/bgp_addpath_ipv4/z2.yaml
@@ -1,0 +1,24 @@
+interface:
+- if-name: i1
+  ipv4:
+    address: 192.168.0.2/24
+router:
+  bgp:
+    global:
+      as: 65002
+      router-id: 192.168.0.2
+    timer:
+      adv-interval:
+        ibgp: 1
+        ebgp: 1
+    neighbor:
+    - remote-address: 192.168.0.3
+      afi-safi:
+      - name: ipv4
+        enabled: true
+      enabled: true
+      remote-as: 65003
+    afi-safi:
+    - name: ipv4
+      network:
+      - prefix: 10.10.10.0/24

--- a/bdd/tests/configs/bgp_addpath_ipv4/z3.yaml
+++ b/bdd/tests/configs/bgp_addpath_ipv4/z3.yaml
@@ -1,0 +1,33 @@
+interface:
+- if-name: i1
+  ipv4:
+    address: 192.168.0.3/24
+router:
+  bgp:
+    global:
+      as: 65003
+      router-id: 192.168.0.3
+    timer:
+      adv-interval:
+        ibgp: 1
+        ebgp: 1
+    neighbor:
+    - remote-address: 192.168.0.1
+      afi-safi:
+      - name: ipv4
+        enabled: true
+      enabled: true
+      remote-as: 65001
+    - remote-address: 192.168.0.2
+      afi-safi:
+      - name: ipv4
+        enabled: true
+      enabled: true
+      remote-as: 65002
+    - remote-address: 192.168.0.4
+      afi-safi:
+      - name: ipv4
+        enabled: true
+        add-path: send-receive
+      enabled: true
+      remote-as: 65004

--- a/bdd/tests/configs/bgp_addpath_ipv4/z4.yaml
+++ b/bdd/tests/configs/bgp_addpath_ipv4/z4.yaml
@@ -1,0 +1,21 @@
+interface:
+- if-name: i1
+  ipv4:
+    address: 192.168.0.4/24
+router:
+  bgp:
+    global:
+      as: 65004
+      router-id: 192.168.0.4
+    timer:
+      adv-interval:
+        ibgp: 1
+        ebgp: 1
+    neighbor:
+    - remote-address: 192.168.0.3
+      afi-safi:
+      - name: ipv4
+        enabled: true
+        add-path: send-receive
+      enabled: true
+      remote-as: 65003

--- a/bdd/tests/features/bgp_addpath_ipv4.feature
+++ b/bdd/tests/features/bgp_addpath_ipv4.feature
@@ -1,0 +1,74 @@
+@serial
+@bgp_addpath_ipv4
+Feature: BGP AddPath Send for IPv4 unicast (RFC 7911)
+  As a network operator
+  I want a BGP speaker with two paths for one prefix to advertise BOTH
+  of them — each carrying its own path identifier — to a neighbor that
+  negotiated AddPath, instead of the single best path.
+
+  This is the first end-to-end AddPath wire test in the suite: it
+  exercises the per-candidate advertise twin
+  (`route_advertise_to_addpath`), the AddPath-Send membership split,
+  and the path-id stamping. The same shape validates the VPNv6 / EVPN /
+  labeled-unicast twins as those land.
+
+  Test Topology (all on br0):
+  ```
+        10.10.10.0/24          10.10.10.0/24
+       (origin AS65001)       (origin AS65002)
+            z1 ──┐               ┌── z2
+       192.168.   │   192.168.   │   192.168.
+        0.1/24    └──→  0.3/24  ←─┘    0.2/24
+                       z3 (AS65003)
+                        │  add-path send-receive
+                        ↓
+                       z4 (AS65004)  192.168.0.4/24
+  ```
+
+  z3 learns 10.10.10.0/24 over eBGP from BOTH z1 (AS_PATH 65001) and
+  z2 (AS_PATH 65002), so its Loc-RIB holds two candidate paths. With
+  AddPath Send negotiated toward z4, z3 advertises both — so z4 sees
+  TWO available paths for the prefix, not just the best one.
+
+  Scenario: Setup topology and establish sessions
+    Given a clean test environment
+    When I create bridge "br0"
+    And I create namespace "z1" with IP "192.168.0.1/24" on bridge "br0"
+    And I create namespace "z2" with IP "192.168.0.2/24" on bridge "br0"
+    And I create namespace "z3" with IP "192.168.0.3/24" on bridge "br0"
+    And I create namespace "z4" with IP "192.168.0.4/24" on bridge "br0"
+    And I start zebra-rs in namespace "z1"
+    And I start zebra-rs in namespace "z2"
+    And I start zebra-rs in namespace "z3"
+    And I start zebra-rs in namespace "z4"
+    And I apply config "z1.yaml" to namespace "z1"
+    And I apply config "z2.yaml" to namespace "z2"
+    And I apply config "z3.yaml" to namespace "z3"
+    And I apply config "z4.yaml" to namespace "z4"
+    And I wait 5 seconds for BGP to operate
+    Then BGP session in "z3" to "192.168.0.1" should be "Established"
+    And BGP session in "z3" to "192.168.0.2" should be "Established"
+    And BGP session in "z3" to "192.168.0.4" should be "Established"
+    And BGP session in "z4" to "192.168.0.3" should be "Established"
+
+  Scenario: The AddPath receiver sees both paths for the prefix
+    Given the test topology exists
+    # z3 holds two candidate paths and, because z4 negotiated AddPath,
+    # advertises BOTH — so z4's table shows the prefix twice, once per
+    # originating AS. Without AddPath Send z4 would hold exactly the
+    # single best path (one AS_PATH only).
+    Then show command "show ip bgp 10.10.10.0/24" in namespace "z4" should eventually contain "65003 65001"
+    And show command "show ip bgp 10.10.10.0/24" in namespace "z4" should contain "65003 65002"
+
+  Scenario: Teardown topology
+    Given the test topology exists
+    When I stop zebra-rs in namespace "z1"
+    And I stop zebra-rs in namespace "z2"
+    And I stop zebra-rs in namespace "z3"
+    And I stop zebra-rs in namespace "z4"
+    And I delete namespace "z1"
+    And I delete namespace "z2"
+    And I delete namespace "z3"
+    And I delete namespace "z4"
+    And I delete bridge "br0"
+    Then the test environment should be clean


### PR DESCRIPTION
## Summary

The AddPath advertise pipeline (`route_advertise_to_addpath`) had **no wire test anywhere in the suite** — capability negotiation was unit-tested, but nothing proved a speaker holding two paths actually advertises BOTH to an AddPath peer. This is the first end-to-end AddPath Send test; the same shape will validate the VPNv6 / EVPN / labeled-unicast twins as those land (#1432 onward).

### Topology (4 nodes on br0)
```
  10.10.10.0/24 (AS65001)          10.10.10.0/24 (AS65002)
        z1 ──┐                        ┌── z2
             └──→  z3 (AS65003)  ←────┘
                    │  add-path send-receive
                    ↓
                   z4 (AS65004)
```
z3 learns `10.10.10.0/24` over eBGP from **both** z1 (AS_PATH 65001) and z2 (AS_PATH 65002), so its Loc-RIB holds two candidate paths. With AddPath Send negotiated toward z4, z3 advertises both.

### Assertion
z4's `show ip bgp 10.10.10.0/24` contains **both** AS_PATHs — `65003 65001` *and* `65003 65002` — proving two distinct paths reached the receiver, not one path twice. Without AddPath Send, z4 would hold only the single best path (one AS_PATH).

Ends with the mandatory Teardown scenario; `make docs` regenerated.

## Testing

- `@bgp_addpath_ipv4` — 3 scenarios (setup/establish, the two-path assertion, teardown) all pass; verified zero leftover daemons/namespaces. (Run against an origin/main-equivalent binary; v4-unicast AddPath is unchanged by the in-flight VPNv6 work.)

Independent of #1432 — this tests the long-standing v4 AddPath pipeline, which was simply never covered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)