### PR TITLE
bgp: implement AddPath Send for EVPN (per-candidate twins)

### DIFF
--- a/docs/design/bgp-peer-list.md
+++ b/docs/design/bgp-peer-list.md
@@ -431,9 +431,16 @@ Per-family status / notes:
   `route_withdraw_vpnv6_addpath`; reuses `send_vpnv6` /
   `cache_remove_vpnv6` (id rides in the NLRI, cache keys on it); no
   soft-out path for VPNv6. Closest analog to VPNv4.
-- **EVPN** — TODO: reuses `send_evpn`; EVPN *does* have a soft-out
-  (`route_soft_out_peer_table_evpn`) that needs the twin too. Route id
-  lives on each `EvpnRoute` variant.
+- **EVPN** — DONE: handled by an *internal* plain/AddPath split inside
+  `route_advertise_evpn_to_peers` / `route_withdraw_evpn_to_peers` /
+  `route_soft_out_peer_table_evpn` (shared `evpn_advertise_one` /
+  `evpn_withdraw_one` helpers), so the 8 call sites are unchanged. The
+  advertise function already receives the full `selected` candidate
+  set; the withdraw enumerates the path-ids recorded in the
+  Adj-RIB-Out; the soft-out re-evaluates `cands` (all candidates) and
+  diffs at `(prefix, path-id)` granularity for AddPath members (a
+  prefix-level diff would withdraw the backup paths on every refresh).
+  Route id lives on each `EvpnRoute` variant.
 - **LU-v4 / LU-v6** — TODO: no per-peer cache today (direct
   `send_packet`); the twin loops candidates and emits one UPDATE each
   with the path-id, or adds a small cache mirroring the VPN shape.
@@ -441,8 +448,12 @@ Per-family status / notes:
   v4-unicast, not the VPN per-peer cache); subsumed by B1 historically,
   worth a twin too but not in the user's named set.
 
-No end-to-end AddPath BDD exists yet (true for v4/VPNv4 too) — the
-families are control-plane-validated (cap negotiation +
-`addpath_send_implemented` unit tests + full suite). A multi-path
-topology BDD asserting two paths arrive with distinct path-ids is a
-worthwhile cross-cutting follow-up for all AddPath families.
+Wire coverage: `@bgp_addpath_ipv4` is the first end-to-end AddPath BDD
+(two paths for one prefix arrive at the receiver). It exercises the
+shared mechanism (membership split, per-candidate fan-out, path-id
+stamping) that every family reuses. A per-family multi-path BDD is
+worthwhile but, for EVPN especially, the multi-path-of-one-NLRI case
+needs an awkward topology (same RD from two sources / a reflector with
+two cluster paths) since per-PE RDs normally make each MAC a distinct
+NLRI; deferred. Until then the family twins are control-plane-validated
+(cap negotiation + `addpath_send_implemented` unit tests + full suite).

--- a/zebra-rs/src/bgp/cap.rs
+++ b/zebra-rs/src/bgp/cap.rs
@@ -101,7 +101,10 @@ pub fn cap_register_recv(bgp_cap: &BgpCap, cap_map: &mut CapAfiMap) {
 pub fn addpath_send_implemented(afi: Afi, safi: Safi) -> bool {
     matches!(
         (afi, safi),
-        (Afi::Ip, Safi::Unicast) | (Afi::Ip, Safi::MplsVpn) | (Afi::Ip6, Safi::MplsVpn)
+        (Afi::Ip, Safi::Unicast)
+            | (Afi::Ip, Safi::MplsVpn)
+            | (Afi::Ip6, Safi::MplsVpn)
+            | (Afi::L2vpn, Safi::Evpn)
     )
 }
 
@@ -196,16 +199,16 @@ mod tests {
 
     /// The supported-set itself, pinned. Growing it is deliberate —
     /// each family must be added WITH its per-candidate
-    /// advertise/withdraw twins (VPNv6 landed alongside its
-    /// `route_advertise_to_peers_vpnv6_addpath` twin). EVPN and
-    /// labeled-unicast v4/v6 are the remaining families to wire up;
-    /// RTC is the one family that stays excluded by design.
+    /// advertise/withdraw twins (VPNv6 and EVPN each landed alongside
+    /// theirs). Labeled-unicast v4/v6 are the remaining families to
+    /// wire up; RTC is the one family that stays excluded by design.
     #[test]
     fn addpath_send_implemented_set() {
         for (afi, safi) in [
             (Afi::Ip, Safi::Unicast),
             (Afi::Ip, Safi::MplsVpn),
             (Afi::Ip6, Safi::MplsVpn),
+            (Afi::L2vpn, Safi::Evpn),
         ] {
             assert!(
                 addpath_send_implemented(afi, safi),
@@ -214,7 +217,6 @@ mod tests {
         }
         for (afi, safi) in [
             (Afi::Ip6, Safi::Unicast),
-            (Afi::L2vpn, Safi::Evpn),
             (Afi::Ip, Safi::MplsLabel),
             (Afi::Ip6, Safi::MplsLabel),
             (Afi::Ip, Safi::Flowspec),

--- a/zebra-rs/src/bgp/route.rs
+++ b/zebra-rs/src/bgp/route.rs
@@ -2652,33 +2652,55 @@ fn route_withdraw_evpn(peer: &mut Peer, route: EvpnRoute) {
 /// without this, a quick add/remove cycle would leave a stale
 /// announce in the cache that fires after the withdraw wins on the
 /// wire.
+/// Withdraw one EVPN `(rd, prefix)` path identified by `id` from a
+/// single `peer`: drop any queued advertise from its cache, drop the
+/// Adj-RIB-Out entry, and emit the MP_UNREACH. `id == 0` is the
+/// non-AddPath sentinel (no path-id on the wire, whole-prefix
+/// Adj-RIB-Out clear); a non-zero `id` withdraws exactly that path.
+fn evpn_withdraw_one(peer: &mut Peer, rd: &RouteDistinguisher, prefix: &EvpnPrefix, id: u32) {
+    let route = evpn_route_from_prefix(rd, prefix, id);
+    // Drop a queued advertise for the same route from the peer's cache
+    // so flush_evpn doesn't ship a now-stale add after the withdraw.
+    if let Some(attr) = peer.cache_evpn_rev.remove(&route)
+        && let Some(set) = peer.cache_evpn.get_mut(&attr)
+    {
+        set.remove(&route);
+        if set.is_empty() {
+            peer.cache_evpn.remove(&attr);
+        }
+    }
+    // Drop the Adj-RIB-Out entry so soft-out's baseline reflects
+    // reality — without this a follow-up policy change would think the
+    // route is still advertised and emit a redundant withdraw.
+    peer.adj_out.remove_evpn(*rd, prefix, id);
+    route_withdraw_evpn(peer, route);
+}
+
 pub fn route_withdraw_evpn_to_peers(
     rd: RouteDistinguisher,
     prefix: EvpnPrefix,
     peers: &mut PeerMap,
 ) {
-    let peer_idents: Vec<usize> = peers.established_idents(Afi::L2vpn, Safi::Evpn);
-
-    for ident in peer_idents {
+    // Non-AddPath members: a single id-less MP_UNREACH clears the prefix.
+    for ident in peers.established_plain_idents(Afi::L2vpn, Safi::Evpn) {
         let peer = peers.get_mut_by_idx(ident).expect("peer exists");
-        let route = evpn_route_from_prefix(&rd, &prefix, 0);
-        // Drop a queued advertise for the same route from the peer's
-        // cache so flush_evpn doesn't ship a now-stale add after we
-        // ship the withdraw.
-        if let Some(attr) = peer.cache_evpn_rev.remove(&route)
-            && let Some(set) = peer.cache_evpn.get_mut(&attr)
-        {
-            set.remove(&route);
-            if set.is_empty() {
-                peer.cache_evpn.remove(&attr);
-            }
+        evpn_withdraw_one(peer, &rd, &prefix, 0);
+    }
+
+    // AddPath members: withdraw every path-id we advertised for this
+    // prefix (read from the Adj-RIB-Out, the record of what was sent).
+    for ident in peers.established_addpath_idents(Afi::L2vpn, Safi::Evpn) {
+        let peer = peers.get_mut_by_idx(ident).expect("peer exists");
+        let ids: Vec<u32> = peer
+            .adj_out
+            .evpn
+            .get(&rd)
+            .and_then(|t| t.0.get(&prefix))
+            .map(|cands| cands.iter().map(|r| r.local_id).collect())
+            .unwrap_or_default();
+        for id in ids {
+            evpn_withdraw_one(peer, &rd, &prefix, id);
         }
-        // Drop the Adj-RIB-Out entry so soft-out's baseline reflects
-        // reality — without this a follow-up policy change would
-        // think the route is still advertised and emit a redundant
-        // withdraw.
-        peer.adj_out.remove_evpn(rd, &prefix, 0);
-        route_withdraw_evpn(peer, route);
     }
 }
 
@@ -2732,10 +2754,46 @@ fn evpn_route_from_prefix(rd: &RouteDistinguisher, prefix: &EvpnPrefix, id: u32)
     }
 }
 
-/// Fan out an EVPN best-path selection to every peer with the
-/// `(L2vpn, Evpn)` AFI/SAFI established. Skips peers filtered by
-/// split-horizon / iBGP rules inside `route_update_evpn`. Pairs with
-/// `route_withdraw_evpn_to_peers` for the inverse direction.
+/// Advertise one EVPN candidate `rib` of `(rd, prefix)` to a single
+/// `peer`: run the split-horizon / iBGP / community gate
+/// (`route_update_evpn`, which stamps the path-id when `add_path`),
+/// the outbound policy, record the Adj-RIB-Out entry, and queue the
+/// send. Shared by the best-path (plain) and per-candidate (AddPath)
+/// fan-outs and by the EVPN soft-out. No-op when any gate rejects.
+fn evpn_advertise_one(
+    peer: &mut Peer,
+    rd: &RouteDistinguisher,
+    prefix: &EvpnPrefix,
+    rib: &BgpRib,
+    bgp: &mut BgpTop,
+    add_path: bool,
+) -> bool {
+    // RFC 9494 §4.3: stale routes only go to LLGR peers.
+    if llgr_blocks_advertisement(rib.stale, &peer.cap_recv, Afi::L2vpn, Safi::Evpn) {
+        return false;
+    }
+    let Some((route, attr)) = route_update_evpn(peer, rd, prefix, rib, bgp, add_path) else {
+        return false;
+    };
+    let Some(decision) = route_apply_policy_out_evpn(peer, &route, attr, rib.weight) else {
+        return false;
+    };
+    let attr = bgp.attr_store.intern(decision.attr);
+    // Record what we advertised so a later policy change can diff the
+    // Adj-RIB-Out against the Loc-RIB and withdraw what the new policy
+    // now denies. Keyed by path-id, so AddPath candidates coexist.
+    let mut adj = rib.clone();
+    adj.attr = attr.clone();
+    peer.adj_out.add_evpn(*rd, prefix.clone(), adj);
+    peer.send_evpn(route, attr, true);
+    true
+}
+
+/// Fan out an EVPN selection to every Established `(L2vpn, Evpn)` peer.
+/// Plain members receive only the best path; AddPath members receive
+/// every candidate in `selected`, each NLRI carrying its own path-id
+/// (RFC 7911 §3). Split-horizon / iBGP rules are applied per candidate
+/// inside `route_update_evpn`. Pairs with `route_withdraw_evpn_to_peers`.
 pub fn route_advertise_evpn_to_peers(
     rd: RouteDistinguisher,
     prefix: EvpnPrefix,
@@ -2747,34 +2805,18 @@ pub fn route_advertise_evpn_to_peers(
         return;
     };
 
-    let peer_idents: Vec<usize> = peers.established_idents(Afi::L2vpn, Safi::Evpn);
-
-    for ident in peer_idents {
+    // Non-AddPath members: the best path only.
+    for ident in peers.established_plain_idents(Afi::L2vpn, Safi::Evpn) {
         let peer = peers.get_mut_by_idx(ident).expect("peer exists");
-        let add_path = peer.opt.is_add_path_send(Afi::L2vpn, Safi::Evpn);
+        evpn_advertise_one(peer, &rd, &prefix, new_best, bgp, false);
+    }
 
-        // RFC 9494 §4.3: stale routes only go to LLGR peers.
-        if llgr_blocks_advertisement(new_best.stale, &peer.cap_recv, Afi::L2vpn, Safi::Evpn) {
-            continue;
+    // AddPath members: every candidate path, each with its path-id.
+    for ident in peers.established_addpath_idents(Afi::L2vpn, Safi::Evpn) {
+        for rib in selected {
+            let peer = peers.get_mut_by_idx(ident).expect("peer exists");
+            evpn_advertise_one(peer, &rd, &prefix, rib, bgp, true);
         }
-        let Some((route, attr)) = route_update_evpn(peer, &rd, &prefix, new_best, bgp, add_path)
-        else {
-            continue;
-        };
-
-        let Some(decision) = route_apply_policy_out_evpn(peer, &route, attr, new_best.weight)
-        else {
-            continue;
-        };
-
-        let attr = bgp.attr_store.intern(decision.attr);
-        // Record what we advertised so a later policy change can
-        // diff the Adj-RIB-Out against the Loc-RIB and withdraw
-        // anything that the new policy now denies.
-        let mut adj = new_best.clone();
-        adj.attr = attr.clone();
-        peer.adj_out.add_evpn(rd, prefix.clone(), adj);
-        peer.send_evpn(route, attr, true);
     }
 }
 
@@ -3027,78 +3069,76 @@ fn route_soft_out_peer_table_evpn(
     bgp: &mut BgpTop,
     peers: &mut PeerMap,
 ) {
-    // Snapshot Loc-RIB selected EVPN routes for this RD so iteration
-    // outlives later mutable borrows of `bgp` (attr_store.intern,
-    // send paths).
-    let selected: Vec<(EvpnPrefix, BgpRib)> = bgp
+    // AddPath member: re-evaluate every candidate path and diff the
+    // Adj-RIB-Out at (prefix, path-id) granularity. A plain member
+    // keeps the best-path-per-prefix shape, with the sentinel path-id 0.
+    let add_path = peers
+        .get_by_idx(peer_idx)
+        .map(|p| p.opt.is_add_path_send(Afi::L2vpn, Safi::Evpn))
+        .unwrap_or(false);
+
+    // Snapshot the (prefix, rib) set to (re)advertise so iteration
+    // outlives later mutable borrows of `bgp` (attr_store.intern, send
+    // paths): every candidate for AddPath, best-path-per-prefix
+    // otherwise.
+    let candidates: Vec<(EvpnPrefix, BgpRib)> = bgp
         .local_rib
         .evpn
         .get(&rd)
         .map(|t| {
-            t.selected
-                .iter()
-                .map(|(p, r)| (p.clone(), r.clone()))
-                .collect()
+            if add_path {
+                t.cands
+                    .iter()
+                    .flat_map(|(p, v)| v.iter().map(move |r| (p.clone(), r.clone())))
+                    .collect()
+            } else {
+                t.selected
+                    .iter()
+                    .map(|(p, r)| (p.clone(), r.clone()))
+                    .collect()
+            }
         })
         .unwrap_or_default();
 
-    // What's currently in this peer's Adj-RIB-Out for the RD —
-    // anything in here but missing from the post-policy newly-
-    // advertised set needs a withdraw.
-    let was_advertised: BTreeSet<EvpnPrefix> = {
+    // What's currently in this peer's Adj-RIB-Out for the RD, keyed by
+    // (prefix, path-id) — anything here but missing from the post-policy
+    // newly-advertised set needs a withdraw. Plain members use the
+    // sentinel id 0 (whole-prefix); AddPath members use each advertised
+    // candidate's local_id.
+    let was_advertised: BTreeSet<(EvpnPrefix, u32)> = {
         let peer = peers.get_mut_by_idx(peer_idx).expect("peer exists");
         peer.adj_out
             .evpn
             .get(&rd)
-            .map(|t| t.0.keys().cloned().collect())
+            .map(|t| {
+                if add_path {
+                    t.0.iter()
+                        .flat_map(|(p, v)| v.iter().map(move |r| (p.clone(), r.local_id)))
+                        .collect()
+                } else {
+                    t.0.keys().map(|p| (p.clone(), 0)).collect()
+                }
+            })
             .unwrap_or_default()
     };
 
-    let mut newly_advertised: BTreeSet<EvpnPrefix> = BTreeSet::new();
+    let mut newly_advertised: BTreeSet<(EvpnPrefix, u32)> = BTreeSet::new();
 
-    for (prefix, rib) in &selected {
+    for (prefix, rib) in &candidates {
         let peer = peers.get_mut_by_idx(peer_idx).expect("peer exists");
-        let add_path = peer.opt.is_add_path_send(Afi::L2vpn, Safi::Evpn);
-
-        // RFC 9494 §4.3: stale routes only go to LLGR peers; falls out
-        // of `newly_advertised`, so the diff below withdraws it.
-        if llgr_blocks_advertisement(rib.stale, &peer.cap_recv, Afi::L2vpn, Safi::Evpn) {
-            continue;
+        let id = if add_path { rib.local_id } else { 0 };
+        if evpn_advertise_one(peer, &rd, prefix, rib, bgp, add_path) {
+            newly_advertised.insert((prefix.clone(), id));
         }
-        let Some((route, attr)) = route_update_evpn(peer, &rd, prefix, rib, bgp, add_path) else {
-            continue;
-        };
-        let Some(decision) = route_apply_policy_out_evpn(peer, &route, attr, rib.weight) else {
-            continue;
-        };
-        let attr = bgp.attr_store.intern(decision.attr);
-        let mut adj = rib.clone();
-        adj.attr = attr.clone();
-        peer.adj_out.add_evpn(rd, prefix.clone(), adj);
-        peer.send_evpn(route, attr, true);
-        newly_advertised.insert(prefix.clone());
     }
 
-    let to_withdraw: Vec<EvpnPrefix> = was_advertised
+    let to_withdraw: Vec<(EvpnPrefix, u32)> = was_advertised
         .difference(&newly_advertised)
         .cloned()
         .collect();
-    for prefix in to_withdraw {
+    for (prefix, id) in to_withdraw {
         let peer = peers.get_mut_by_idx(peer_idx).expect("peer exists");
-        let route = evpn_route_from_prefix(&rd, &prefix, 0);
-        // Drop any queued advertise so flush_evpn doesn't ship a
-        // stale add after the withdraw; mirrors the same cache
-        // drain in route_withdraw_evpn_to_peers.
-        if let Some(attr) = peer.cache_evpn_rev.remove(&route)
-            && let Some(set) = peer.cache_evpn.get_mut(&attr)
-        {
-            set.remove(&route);
-            if set.is_empty() {
-                peer.cache_evpn.remove(&attr);
-            }
-        }
-        peer.adj_out.remove_evpn(rd, &prefix, 0);
-        route_withdraw_evpn(peer, route);
+        evpn_withdraw_one(peer, &rd, &prefix, id);
     }
 }
 


### PR DESCRIPTION
## Summary

Second B3 follow-through family (after VPNv6 #1432, `docs/design/bgp-peer-list.md` §10). AddPath Send was *masked off* for EVPN because the family sent best-path only and its withdraw hardcoded path-id 0 — malformed on a negotiated-AddPath session (RFC 7911 §3).

### Why EVPN is shaped differently
Unlike the VPNv4/VPNv6 twins (single-rib, per-call-site), EVPN's advertise function already receives the full `selected` candidate set, and there are **8 call sites** (receive + 3 self-origination advertise/withdraw pairs + soft-out). So the plain/AddPath split lives **inside** the three functions, via shared `evpn_advertise_one` / `evpn_withdraw_one` helpers — every call site is unchanged.

- **`route_advertise_evpn_to_peers`**: plain members get best-path; AddPath members get every candidate in `selected`, each NLRI stamped with its `local_id` (`route_update_evpn` already does split-horizon + id per candidate).
- **`route_withdraw_evpn_to_peers`**: plain members get one id-less MP_UNREACH (whole-prefix); AddPath members get a withdraw per path-id, read from the Adj-RIB-Out (the record of what was sent).
- **`route_soft_out_peer_table_evpn`**: for an AddPath peer, re-evaluate `cands` (all candidates, not just best) and diff the Adj-RIB-Out at `(prefix, path-id)` granularity — a prefix-level diff would withdraw the backup paths on every Route-Refresh.
- **`addpath_send_implemented`** grows to include `(L2vpn, Evpn)` in the same change as the twin (the B3 invariant). Tests updated.

**Purely additive:** non-AddPath EVPN peers keep the best-path path unchanged, and there were no AddPath EVPN peers before (the family was masked).

### Remaining (§10)
LU-v4 / LU-v6 (direct-send, no cache). RTC stays excluded by design.

## Testing

- `cargo fmt` / `cargo clippy --workspace --all-targets -- -D warnings` clean
- `cargo test --workspace --exclude bdd` green; `bgp::cap` implemented-set test updated (EVPN now implemented)
- **Regression** against the rebuilt binary: `@bgp_vrf_evpn_type5` (4 scenarios) + `@bgp_evpn_capability` (3) both pass — the rewrite of the three EVPN functions preserves non-AddPath EVPN. No leftover daemons.

Control-plane-validated, matching the existing AddPath posture. An EVPN multi-path wire BDD is deferred (the multi-path-of-one-NLRI case needs an awkward topology since per-PE RDs normally make each MAC a distinct NLRI — noted in §10); the shared mechanism is covered by `@bgp_addpath_ipv4` (#1433).

🤖 Generated with [Claude Code](https://claude.com/claude-code)