### PR TITLE
bgp: implement AddPath Send for labeled-unicast v4 and v6

### DIFF
--- a/docs/design/bgp-peer-list.md
+++ b/docs/design/bgp-peer-list.md
@@ -441,12 +441,18 @@ Per-family status / notes:
   diffs at `(prefix, path-id)` granularity for AddPath members (a
   prefix-level diff would withdraw the backup paths on every refresh).
   Route id lives on each `EvpnRoute` variant.
-- **LU-v4 / LU-v6** — TODO: no per-peer cache today (direct
-  `send_packet`); the twin loops candidates and emits one UPDATE each
-  with the path-id, or adds a small cache mirroring the VPN shape.
+- **LU-v4 / LU-v6** — DONE: same internal plain/AddPath split inside
+  `route_advertise_to_peers_labelv4` / `…v6` (no call-site changes). LU
+  has no update-group cache, but `AdjRibOut` already carried unused
+  `v4lu` / `v6lu` tables — the AddPath path now populates them and
+  diffs the recorded path-ids against `selected` to withdraw exactly
+  the ids that fell out (selected empty ⇒ withdraw all). So the stale
+  "no Adj-RIB-Out yet" comment is now half-true: plain peers still
+  direct-send without tracking; AddPath peers track in `v4lu`/`v6lu`.
 - **IPv6-unicast** — separate family (group-cache shape like
   v4-unicast, not the VPN per-peer cache); subsumed by B1 historically,
-  worth a twin too but not in the user's named set.
+  worth a twin too but not in the user's named set. The only family
+  besides RTC still without AddPath Send.
 
 Wire coverage: `@bgp_addpath_ipv4` is the first end-to-end AddPath BDD
 (two paths for one prefix arrive at the receiver). It exercises the

--- a/zebra-rs/src/bgp/cap.rs
+++ b/zebra-rs/src/bgp/cap.rs
@@ -105,6 +105,8 @@ pub fn addpath_send_implemented(afi: Afi, safi: Safi) -> bool {
             | (Afi::Ip, Safi::MplsVpn)
             | (Afi::Ip6, Safi::MplsVpn)
             | (Afi::L2vpn, Safi::Evpn)
+            | (Afi::Ip, Safi::MplsLabel)
+            | (Afi::Ip6, Safi::MplsLabel)
     )
 }
 
@@ -199,9 +201,11 @@ mod tests {
 
     /// The supported-set itself, pinned. Growing it is deliberate —
     /// each family must be added WITH its per-candidate
-    /// advertise/withdraw twins (VPNv6 and EVPN each landed alongside
-    /// theirs). Labeled-unicast v4/v6 are the remaining families to
-    /// wire up; RTC is the one family that stays excluded by design.
+    /// advertise/withdraw twins (VPNv6, EVPN, and labeled-unicast v4/v6
+    /// each landed alongside theirs). IPv6 unicast is the remaining
+    /// unicast family (separate group-cache shape); RTC is the one
+    /// family that stays excluded by design (its NLRI carry no per-path
+    /// semantics).
     #[test]
     fn addpath_send_implemented_set() {
         for (afi, safi) in [
@@ -209,6 +213,8 @@ mod tests {
             (Afi::Ip, Safi::MplsVpn),
             (Afi::Ip6, Safi::MplsVpn),
             (Afi::L2vpn, Safi::Evpn),
+            (Afi::Ip, Safi::MplsLabel),
+            (Afi::Ip6, Safi::MplsLabel),
         ] {
             assert!(
                 addpath_send_implemented(afi, safi),
@@ -217,8 +223,6 @@ mod tests {
         }
         for (afi, safi) in [
             (Afi::Ip6, Safi::Unicast),
-            (Afi::Ip, Safi::MplsLabel),
-            (Afi::Ip6, Safi::MplsLabel),
             (Afi::Ip, Safi::Flowspec),
             (Afi::Ip6, Safi::Flowspec),
             (Afi::Ip, Safi::Rtc),

--- a/zebra-rs/src/bgp/route.rs
+++ b/zebra-rs/src/bgp/route.rs
@@ -7208,9 +7208,9 @@ pub(super) fn route_advertise_to_peers_labelv4(
     let new_best = selected.last();
     let (afi, safi) = (Afi::Ip, Safi::MplsLabel);
 
-    let peer_idents: Vec<usize> = peers.established_idents(afi, safi);
-
-    for ident in peer_idents {
+    // Non-AddPath members: best-path only; `None` ⇒ one id-less
+    // MP_UNREACH for the prefix.
+    for ident in peers.established_plain_idents(afi, safi) {
         let peer = peers.get_mut_by_idx(ident).expect("peer exists");
         match new_best {
             Some(best) if best.ident != peer.ident => {
@@ -7218,9 +7218,8 @@ pub(super) fn route_advertise_to_peers_labelv4(
                 if llgr_blocks_advertisement(best.stale, &peer.cap_recv, afi, safi) {
                     continue;
                 }
-                let add_path = peer.opt.is_add_path_send(afi, safi);
                 let Some((nlri, attr, nhop, label)) =
-                    route_update_labelv4(peer, &prefix, best, bgp, add_path)
+                    route_update_labelv4(peer, &prefix, best, bgp, false)
                 else {
                     continue;
                 };
@@ -7246,6 +7245,58 @@ pub(super) fn route_advertise_to_peers_labelv4(
             }
         }
     }
+
+    // AddPath members: every candidate, each NLRI carrying its path-id.
+    // LU has no update-group cache, so the per-peer LU Adj-RIB-Out
+    // (`v4lu`) is the record of what was sent — diff it against the new
+    // candidate set to withdraw exactly the path-ids that fell out
+    // (selected empty ⇒ withdraw them all).
+    for ident in peers.established_addpath_idents(afi, safi) {
+        let peer = peers.get_mut_by_idx(ident).expect("peer exists");
+        let was: Vec<u32> = peer
+            .adj_out
+            .v4lu
+            .0
+            .get(&prefix)
+            .map(|c| c.iter().map(|r| r.local_id).collect())
+            .unwrap_or_default();
+        let mut newly: BTreeSet<u32> = BTreeSet::new();
+        for cand in selected {
+            if cand.ident == peer.ident {
+                continue; // split-horizon
+            }
+            if llgr_blocks_advertisement(cand.stale, &peer.cap_recv, afi, safi) {
+                continue;
+            }
+            let Some((nlri, attr, nhop, label)) =
+                route_update_labelv4(peer, &prefix, cand, bgp, true)
+            else {
+                continue;
+            };
+            let mut update = UpdatePacket::with_max_packet_size(peer.max_packet_size());
+            update.bgp_attr = Some(attr);
+            update.mp_update = Some(MpReachAttr::Labelv4 {
+                snpa: 0,
+                nhop,
+                updates: vec![Labelv4Nlri { label, nlri }],
+            });
+            peer.send_packet(update.into());
+            peer.adj_out.v4lu.add(prefix, cand.clone());
+            newly.insert(cand.local_id);
+        }
+        for id in was {
+            if newly.contains(&id) {
+                continue;
+            }
+            let mut update = UpdatePacket::with_max_packet_size(peer.max_packet_size());
+            update.mp_withdraw = Some(MpUnreachAttr::Labelv4(vec![Labelv4Nlri {
+                label: Label::default(),
+                nlri: Ipv4Nlri { id, prefix },
+            }]));
+            peer.send_packet(update.into());
+            peer.adj_out.v4lu.remove(prefix, id);
+        }
+    }
 }
 
 /// IPv6 Labeled-Unicast (incl. 6PE) advertise — the v6 counterpart of
@@ -7259,9 +7310,9 @@ pub(super) fn route_advertise_to_peers_labelv6(
     let new_best = selected.last();
     let (afi, safi) = (Afi::Ip6, Safi::MplsLabel);
 
-    let peer_idents: Vec<usize> = peers.established_idents(afi, safi);
-
-    for ident in peer_idents {
+    // Non-AddPath members: best-path only; `None` ⇒ one id-less
+    // MP_UNREACH for the prefix.
+    for ident in peers.established_plain_idents(afi, safi) {
         let peer = peers.get_mut_by_idx(ident).expect("peer exists");
         match new_best {
             Some(best) if best.ident != peer.ident => {
@@ -7269,9 +7320,8 @@ pub(super) fn route_advertise_to_peers_labelv6(
                 if llgr_blocks_advertisement(best.stale, &peer.cap_recv, afi, safi) {
                     continue;
                 }
-                let add_path = peer.opt.is_add_path_send(afi, safi);
                 let Some((nlri, attr, nhop, label)) =
-                    route_update_labelv6(peer, &prefix, best, bgp, add_path)
+                    route_update_labelv6(peer, &prefix, best, bgp, false)
                 else {
                     continue;
                 };
@@ -7295,6 +7345,56 @@ pub(super) fn route_advertise_to_peers_labelv6(
                 }]));
                 peer.send_packet(update.into());
             }
+        }
+    }
+
+    // AddPath members: every candidate with its path-id; the per-peer
+    // LU Adj-RIB-Out (`v6lu`) records what was sent so removed path-ids
+    // can be withdrawn precisely (the v6 twin of the `labelv4` path).
+    for ident in peers.established_addpath_idents(afi, safi) {
+        let peer = peers.get_mut_by_idx(ident).expect("peer exists");
+        let was: Vec<u32> = peer
+            .adj_out
+            .v6lu
+            .0
+            .get(&prefix)
+            .map(|c| c.iter().map(|r| r.local_id).collect())
+            .unwrap_or_default();
+        let mut newly: BTreeSet<u32> = BTreeSet::new();
+        for cand in selected {
+            if cand.ident == peer.ident {
+                continue; // split-horizon
+            }
+            if llgr_blocks_advertisement(cand.stale, &peer.cap_recv, afi, safi) {
+                continue;
+            }
+            let Some((nlri, attr, nhop, label)) =
+                route_update_labelv6(peer, &prefix, cand, bgp, true)
+            else {
+                continue;
+            };
+            let mut update = UpdatePacket::with_max_packet_size(peer.max_packet_size());
+            update.bgp_attr = Some(attr);
+            update.mp_update = Some(MpReachAttr::Labelv6 {
+                snpa: 0,
+                nhop,
+                updates: vec![Labelv6Nlri { label, nlri }],
+            });
+            peer.send_packet(update.into());
+            peer.adj_out.v6lu.add(prefix, cand.clone());
+            newly.insert(cand.local_id);
+        }
+        for id in was {
+            if newly.contains(&id) {
+                continue;
+            }
+            let mut update = UpdatePacket::with_max_packet_size(peer.max_packet_size());
+            update.mp_withdraw = Some(MpUnreachAttr::Labelv6(vec![Labelv6Nlri {
+                label: Label::default(),
+                nlri: Ipv6Nlri { id, prefix },
+            }]));
+            peer.send_packet(update.into());
+            peer.adj_out.v6lu.remove(prefix, id);
         }
     }
 }


### PR DESCRIPTION
## Summary

The last two B3 follow-through families (`docs/design/bgp-peer-list.md` §10), **completing the user's named set** (VPNv6 #1432, EVPN #1434, LU-v4, LU-v6). AddPath Send was *masked off* for both LU families because they sent best-path only and withdrew with path-id 0 — malformed on a negotiated-AddPath session (RFC 7911 §3).

### Changes
Same internal plain/AddPath split as EVPN, inside `route_advertise_to_peers_labelv4` / `…labelv6` — all ~12 call sites unchanged:

- **Plain members** keep the best-path send (`None` ⇒ one id-less MP_UNREACH).
- **AddPath members** get every candidate in `selected`, each NLRI carrying its path-id (`route_update_label{v4,v6}` stamps `id = local_id`).

LU has no update-group cache, but **`AdjRibOut` already carried unused `v4lu` / `v6lu` tables** — the AddPath path now populates them and diffs the recorded path-ids against the new candidate set, withdrawing exactly the ids that fell out (`selected` empty ⇒ withdraw all). That replaces the old behaviour where a withdraw was an id-0 MP_UNREACH to every LU peer (the "no Adj-RIB-Out yet" comment is now half-true: plain peers still direct-send untracked; AddPath peers track in `v4lu`/`v6lu`).

- **`addpath_send_implemented`** grows to include `(Ip, MplsLabel)` and `(Ip6, MplsLabel)`, same change as the twins (the B3 invariant). Only IPv6-unicast (separate group-cache family) and RTC remain excluded.

**Purely additive** for plain LU peers (best-path path unchanged; no AddPath LU peers existed before).

## Testing

- `cargo fmt` / `cargo clippy --workspace --all-targets -- -D warnings` clean
- `cargo test --workspace --exclude bdd` green; `bgp::cap` implemented-set test updated (LU v4/v6 now implemented)
- **Regression** against the rebuilt binary: `@bgp_interas_option_c` (labeled-unicast inter-AS, 7 scenarios) passes — the labelv4/v6 rewrite preserves non-AddPath LU. No leftover daemons.

With this, AddPath Send is implemented for every advertise family **except IPv6-unicast** (a separate group-cache-shaped family, not in the named set) **and RTC** (excluded by design). Shared mechanism wire-tested by `@bgp_addpath_ipv4` (#1433).

🤖 Generated with [Claude Code](https://claude.com/claude-code)