### PR TITLE
bgp: implement AddPath Send for IPv6 unicast (+ wire BDD)

### DIFF
--- a/bdd/docs/bgp_addpath_ipv6.md
+++ b/bdd/docs/bgp_addpath_ipv6.md
@@ -1,0 +1,41 @@
+# BGP AddPath Send for IPv6 unicast (RFC 7911)
+
+## Overview
+
+As a network operator
+I want a BGP speaker with two paths for one IPv6 prefix to advertise
+BOTH of them — each with its own path identifier — to a neighbor that
+negotiated AddPath, instead of only the best path.
+The IPv6-unicast twin of @bgp_addpath_ipv4. It exercises the
+IPv6-specific AddPath path: the per-candidate fan-out bucketed into
+the update-group cache (`flush_ipv6`) and the `adj_out.v6` path-id
+tracking used to withdraw precisely.
+
+## Test Topology
+
+```
+     2001:db8:beef::/64        2001:db8:beef::/64
+      (origin AS65001)          (origin AS65002)
+           z1 ──┐                  ┌── z2
+       2001:db8: │  2001:db8:      │  2001:db8:
+          ::1/64 └──→  ::3/64  ←───┘     ::2/64
+                       z3 (AS65003)
+                        │  add-path send-receive
+                        ↓
+                       z4 (AS65004)  2001:db8::4/64
+```
+
+## Notes
+
+z3 learns 2001:db8:beef::/64 over eBGP from BOTH z1 (AS_PATH 65001)
+and z2 (AS_PATH 65002), so its Loc-RIB holds two candidate paths.
+With AddPath Send negotiated toward z4, z3 advertises both — so z4
+sees TWO paths for the prefix, not just the best one.
+
+## Test Scenarios
+
+| Scenario | Result |
+|----------|--------|
+| Setup topology and establish sessions | |
+| The AddPath receiver sees both paths for the prefix | |
+| Teardown topology | |

--- a/bdd/tests/configs/bgp_addpath_ipv6/z1.yaml
+++ b/bdd/tests/configs/bgp_addpath_ipv6/z1.yaml
@@ -1,0 +1,24 @@
+interface:
+- if-name: i1
+  ipv6:
+    address: 2001:db8::1/64
+router:
+  bgp:
+    global:
+      as: 65001
+      router-id: 10.0.0.1
+    timer:
+      adv-interval:
+        ibgp: 1
+        ebgp: 1
+    neighbor:
+    - remote-address: 2001:db8::3
+      afi-safi:
+      - name: ipv6
+        enabled: true
+      enabled: true
+      remote-as: 65003
+    afi-safi:
+    - name: ipv6
+      network:
+      - prefix: 2001:db8:beef::/64

--- a/bdd/tests/configs/bgp_addpath_ipv6/z2.yaml
+++ b/bdd/tests/configs/bgp_addpath_ipv6/z2.yaml
@@ -1,0 +1,24 @@
+interface:
+- if-name: i1
+  ipv6:
+    address: 2001:db8::2/64
+router:
+  bgp:
+    global:
+      as: 65002
+      router-id: 10.0.0.2
+    timer:
+      adv-interval:
+        ibgp: 1
+        ebgp: 1
+    neighbor:
+    - remote-address: 2001:db8::3
+      afi-safi:
+      - name: ipv6
+        enabled: true
+      enabled: true
+      remote-as: 65003
+    afi-safi:
+    - name: ipv6
+      network:
+      - prefix: 2001:db8:beef::/64

--- a/bdd/tests/configs/bgp_addpath_ipv6/z3.yaml
+++ b/bdd/tests/configs/bgp_addpath_ipv6/z3.yaml
@@ -1,0 +1,33 @@
+interface:
+- if-name: i1
+  ipv6:
+    address: 2001:db8::3/64
+router:
+  bgp:
+    global:
+      as: 65003
+      router-id: 10.0.0.3
+    timer:
+      adv-interval:
+        ibgp: 1
+        ebgp: 1
+    neighbor:
+    - remote-address: 2001:db8::1
+      afi-safi:
+      - name: ipv6
+        enabled: true
+      enabled: true
+      remote-as: 65001
+    - remote-address: 2001:db8::2
+      afi-safi:
+      - name: ipv6
+        enabled: true
+      enabled: true
+      remote-as: 65002
+    - remote-address: 2001:db8::4
+      afi-safi:
+      - name: ipv6
+        enabled: true
+        add-path: send-receive
+      enabled: true
+      remote-as: 65004

--- a/bdd/tests/configs/bgp_addpath_ipv6/z4.yaml
+++ b/bdd/tests/configs/bgp_addpath_ipv6/z4.yaml
@@ -1,0 +1,21 @@
+interface:
+- if-name: i1
+  ipv6:
+    address: 2001:db8::4/64
+router:
+  bgp:
+    global:
+      as: 65004
+      router-id: 10.0.0.4
+    timer:
+      adv-interval:
+        ibgp: 1
+        ebgp: 1
+    neighbor:
+    - remote-address: 2001:db8::3
+      afi-safi:
+      - name: ipv6
+        enabled: true
+        add-path: send-receive
+      enabled: true
+      remote-as: 65003

--- a/bdd/tests/features/bgp_addpath_ipv6.feature
+++ b/bdd/tests/features/bgp_addpath_ipv6.feature
@@ -1,0 +1,73 @@
+@serial
+@bgp_addpath_ipv6
+Feature: BGP AddPath Send for IPv6 unicast (RFC 7911)
+  As a network operator
+  I want a BGP speaker with two paths for one IPv6 prefix to advertise
+  BOTH of them — each with its own path identifier — to a neighbor that
+  negotiated AddPath, instead of only the best path.
+
+  The IPv6-unicast twin of @bgp_addpath_ipv4. It exercises the
+  IPv6-specific AddPath path: the per-candidate fan-out bucketed into
+  the update-group cache (`flush_ipv6`) and the `adj_out.v6` path-id
+  tracking used to withdraw precisely.
+
+  Test Topology (all on br0, sessions over IPv6):
+  ```
+     2001:db8:beef::/64        2001:db8:beef::/64
+      (origin AS65001)          (origin AS65002)
+           z1 ──┐                  ┌── z2
+       2001:db8: │  2001:db8:      │  2001:db8:
+          ::1/64 └──→  ::3/64  ←───┘     ::2/64
+                       z3 (AS65003)
+                        │  add-path send-receive
+                        ↓
+                       z4 (AS65004)  2001:db8::4/64
+  ```
+
+  z3 learns 2001:db8:beef::/64 over eBGP from BOTH z1 (AS_PATH 65001)
+  and z2 (AS_PATH 65002), so its Loc-RIB holds two candidate paths.
+  With AddPath Send negotiated toward z4, z3 advertises both — so z4
+  sees TWO paths for the prefix, not just the best one.
+
+  Scenario: Setup topology and establish sessions
+    Given a clean test environment
+    When I create bridge "br0"
+    And I create namespace "z1" with IP "2001:db8::1/64" on bridge "br0"
+    And I create namespace "z2" with IP "2001:db8::2/64" on bridge "br0"
+    And I create namespace "z3" with IP "2001:db8::3/64" on bridge "br0"
+    And I create namespace "z4" with IP "2001:db8::4/64" on bridge "br0"
+    And I start zebra-rs in namespace "z1"
+    And I start zebra-rs in namespace "z2"
+    And I start zebra-rs in namespace "z3"
+    And I start zebra-rs in namespace "z4"
+    And I apply config "z1.yaml" to namespace "z1"
+    And I apply config "z2.yaml" to namespace "z2"
+    And I apply config "z3.yaml" to namespace "z3"
+    And I apply config "z4.yaml" to namespace "z4"
+    And I wait 5 seconds for BGP to operate
+    Then BGP session in "z3" to "2001:db8::1" should be "Established"
+    And BGP session in "z3" to "2001:db8::2" should be "Established"
+    And BGP session in "z3" to "2001:db8::4" should be "Established"
+    And BGP session in "z4" to "2001:db8::3" should be "Established"
+
+  Scenario: The AddPath receiver sees both paths for the prefix
+    Given the test topology exists
+    # z3 holds two candidate paths and, because z4 negotiated AddPath,
+    # advertises BOTH — so z4's table shows the prefix twice, once per
+    # originating AS. Without AddPath Send z4 would hold exactly the
+    # single best path (one AS_PATH only).
+    Then show command "show bgp ipv6 2001:db8:beef::/64" in namespace "z4" should eventually contain "65003 65001"
+    And show command "show bgp ipv6 2001:db8:beef::/64" in namespace "z4" should eventually contain "65003 65002"
+
+  Scenario: Teardown topology
+    Given the test topology exists
+    When I stop zebra-rs in namespace "z1"
+    And I stop zebra-rs in namespace "z2"
+    And I stop zebra-rs in namespace "z3"
+    And I stop zebra-rs in namespace "z4"
+    And I delete namespace "z1"
+    And I delete namespace "z2"
+    And I delete namespace "z3"
+    And I delete namespace "z4"
+    And I delete bridge "br0"
+    Then the test environment should be clean

--- a/docs/design/bgp-peer-list.md
+++ b/docs/design/bgp-peer-list.md
@@ -449,10 +449,15 @@ Per-family status / notes:
   the ids that fell out (selected empty ⇒ withdraw all). So the stale
   "no Adj-RIB-Out yet" comment is now half-true: plain peers still
   direct-send without tracking; AddPath peers track in `v4lu`/`v6lu`.
-- **IPv6-unicast** — separate family (group-cache shape like
-  v4-unicast, not the VPN per-peer cache); subsumed by B1 historically,
-  worth a twin too but not in the user's named set. The only family
-  besides RTC still without AddPath Send.
+- **IPv6-unicast** — DONE: internal plain/AddPath split inside
+  `route_advertise_to_peers_v6` (no call-site changes, and v6 unicast
+  has no soft-out, so the inline `None` arm is the only withdraw site).
+  Reach is bucketed into the AddPath-signature update-group cache via
+  `send_ipv6` (group-cache shape, like v4-unicast); the withdraw uses
+  the per-peer `adj_out.v6` table (already present, previously unused
+  for the out direction) to diff advertised path-ids against the
+  candidate set. With this **every advertise family except RTC has
+  AddPath Send** — the supported set the user asked for.
 
 Wire coverage: `@bgp_addpath_ipv4` is the first end-to-end AddPath BDD
 (two paths for one prefix arrive at the receiver). It exercises the

--- a/zebra-rs/src/bgp/cap.rs
+++ b/zebra-rs/src/bgp/cap.rs
@@ -102,6 +102,7 @@ pub fn addpath_send_implemented(afi: Afi, safi: Safi) -> bool {
     matches!(
         (afi, safi),
         (Afi::Ip, Safi::Unicast)
+            | (Afi::Ip6, Safi::Unicast)
             | (Afi::Ip, Safi::MplsVpn)
             | (Afi::Ip6, Safi::MplsVpn)
             | (Afi::L2vpn, Safi::Evpn)
@@ -153,7 +154,7 @@ mod tests {
     }
 
     /// Negotiated AddPath *send* is gated on the family having the
-    /// per-path advertise pipeline. A VPNv6 (or any unimplemented
+    /// per-path advertise pipeline. An RTC (or any unimplemented
     /// family) `add-path send` config against a peer offering Receive
     /// must come out send=false — RFC 7911 §3 would otherwise oblige
     /// us to path-id every NLRI of a family whose withdraw path can't.
@@ -166,6 +167,9 @@ mod tests {
             (Afi::Ip, Safi::MplsVpn),
             (Afi::Ip6, Safi::Unicast),
             (Afi::Ip6, Safi::MplsVpn),
+            // RTC stays excluded by design — its NLRI carry no per-path
+            // semantics, so send must never negotiate for it.
+            (Afi::Ip, Safi::Rtc),
         ] {
             let key = AfiSafi::new(afi, safi);
             // Peer offers both directions; we configure send-receive.
@@ -180,16 +184,18 @@ mod tests {
 
         // Implemented families negotiate send.
         assert!(opt.is_add_path_send(Afi::Ip, Safi::Unicast));
+        assert!(opt.is_add_path_send(Afi::Ip6, Safi::Unicast));
         assert!(opt.is_add_path_send(Afi::Ip, Safi::MplsVpn));
         assert!(opt.is_add_path_send(Afi::Ip6, Safi::MplsVpn));
         // Unimplemented families are masked to receive-only.
-        assert!(!opt.is_add_path_send(Afi::Ip6, Safi::Unicast));
+        assert!(!opt.is_add_path_send(Afi::Ip, Safi::Rtc));
         // Receive negotiates for every family (parsing is generic).
         for (afi, safi) in [
             (Afi::Ip, Safi::Unicast),
             (Afi::Ip, Safi::MplsVpn),
             (Afi::Ip6, Safi::Unicast),
             (Afi::Ip6, Safi::MplsVpn),
+            (Afi::Ip, Safi::Rtc),
         ] {
             let key = AfiSafi::new(afi, safi);
             assert!(
@@ -201,15 +207,15 @@ mod tests {
 
     /// The supported-set itself, pinned. Growing it is deliberate —
     /// each family must be added WITH its per-candidate
-    /// advertise/withdraw twins (VPNv6, EVPN, and labeled-unicast v4/v6
-    /// each landed alongside theirs). IPv6 unicast is the remaining
-    /// unicast family (separate group-cache shape); RTC is the one
-    /// family that stays excluded by design (its NLRI carry no per-path
-    /// semantics).
+    /// advertise/withdraw twins. Every advertise family is now
+    /// implemented; only RTC stays excluded by design (its NLRI carry
+    /// no per-path semantics) along with the exact-match families
+    /// (flowspec) that have no candidate set.
     #[test]
     fn addpath_send_implemented_set() {
         for (afi, safi) in [
             (Afi::Ip, Safi::Unicast),
+            (Afi::Ip6, Safi::Unicast),
             (Afi::Ip, Safi::MplsVpn),
             (Afi::Ip6, Safi::MplsVpn),
             (Afi::L2vpn, Safi::Evpn),
@@ -222,7 +228,6 @@ mod tests {
             );
         }
         for (afi, safi) in [
-            (Afi::Ip6, Safi::Unicast),
             (Afi::Ip, Safi::Flowspec),
             (Afi::Ip6, Safi::Flowspec),
             (Afi::Ip, Safi::Rtc),
@@ -230,7 +235,7 @@ mod tests {
         ] {
             assert!(
                 !addpath_send_implemented(afi, safi),
-                "{afi} {safi} has no per-path advertise pipeline yet"
+                "{afi} {safi} has no per-path advertise pipeline"
             );
         }
     }

--- a/zebra-rs/src/bgp/route.rs
+++ b/zebra-rs/src/bgp/route.rs
@@ -6879,6 +6879,65 @@ pub(super) fn route_advertise_to_peers_v6(
             }
         }
     }
+
+    // AddPath members: every candidate path, each NLRI carrying its
+    // path-id, bucketed into the (AddPath-signature) update-group cache.
+    // v6 unicast has no per-peer batch cache, so the per-peer v6
+    // Adj-RIB-Out (`adj_out.v6`) is the record of what was sent — diff
+    // it against the new candidate set to withdraw exactly the path-ids
+    // that fell out (selected empty ⇒ withdraw them all).
+    for ident in peers.established_addpath_idents(afi, safi) {
+        let peer = peers.get_mut_by_idx(ident).expect("peer exists");
+        let group_id = peer.update_group_id.get(&afi_safi).cloned();
+        let was: Vec<u32> = peer
+            .adj_out
+            .v6
+            .0
+            .get(&prefix)
+            .map(|c| c.iter().map(|r| r.local_id).collect())
+            .unwrap_or_default();
+        let mut newly: BTreeSet<u32> = BTreeSet::new();
+        for cand in selected {
+            if cand.ident == peer.ident {
+                continue; // split-horizon
+            }
+            if llgr_blocks_advertisement(cand.stale, &peer.cap_recv, afi, safi) {
+                continue;
+            }
+            let Some((nlri, attr)) = route_update_ipv6(peer, &prefix, cand, bgp, true) else {
+                continue;
+            };
+            let attr = bgp.attr_store.intern(attr);
+            if let Some(gid) = &group_id
+                && let Some(af) = bgp.update_groups.get_mut(&afi_safi)
+                && let Some(group) = af.group_by_id_mut(gid)
+            {
+                super::update_group::send_ipv6(group, nlri, attr, cand.ident, bgp.tx, true);
+            } else {
+                tracing::warn!(
+                    peer = %peer.address,
+                    prefix = %prefix,
+                    "IPv6 AddPath advertise: peer Established but not in any update-group; advertise skipped"
+                );
+                continue;
+            }
+            peer.adj_out.v6.add(prefix, cand.clone());
+            newly.insert(cand.local_id);
+        }
+        for id in was {
+            if newly.contains(&id) {
+                continue;
+            }
+            if let Some(gid) = &group_id
+                && let Some(af) = bgp.update_groups.get_mut(&afi_safi)
+                && let Some(group) = af.group_by_id_mut(gid)
+            {
+                super::update_group::cache_remove_ipv6(group, prefix, id);
+            }
+            withdraw_ipv6_deferrable(bgp.update_groups, peer, prefix, id);
+            peer.adj_out.v6.remove(prefix, id);
+        }
+    }
 }
 
 /// Per-peer VPNv6 withdraw — emit an MP_UNREACH(AFI=2, SAFI=128) for


### PR DESCRIPTION
## Summary

**Completes AddPath Send across every advertise family except RTC.** IPv6 unicast was the last one masked off (best-path only, withdraw with path-id 0 — malformed on a negotiated-AddPath session, RFC 7911 §3).

### Changes
Like EVPN/LU, the plain/AddPath split lives inside `route_advertise_to_peers_v6` — no call-site changes (v6 unicast has no soft-out, so the inline `None` arm is the only withdraw site):

- **Plain members**: best-path via the update-group cache, as before.
- **AddPath members**: every candidate bucketed into the AddPath-signature update-group cache via `send_ipv6` (group-cache reach, like v4-unicast), each NLRI carrying its path-id. The per-peer **`adj_out.v6`** table (already present, previously unused for the out direction) records advertised path-ids; the loop diffs it against the candidate set to withdraw exactly the ids that fell out (`selected` empty ⇒ withdraw all).
- **`addpath_send_implemented`** grows to include `(Ip6, Unicast)`, same change as the twin (the B3 invariant). With this, only **RTC** and the exact-match families (flowspec, no candidate set) stay excluded. Cap tests updated; RTC pinned as the masked control.

### New wire test
**`@bgp_addpath_ipv6`** (the v6 twin of `@bgp_addpath_ipv4`): two eBGP originators feed one v6 prefix to a speaker with `add-path send-receive` toward the receiver; the receiver's table shows BOTH AS_PATHs (`65003 65001` and `65003 65002`). This validates the v6 group-cache flush + `adj_out.v6` path-id tracking that the v4 BDD doesn't cover. Both path assertions poll (`should eventually contain`) since the two paths flush via the adv-interval-debounced group timer.

**Purely additive** for plain v6 peers (best-path path unchanged; no AddPath v6 peers existed before).

## Testing

- `cargo fmt` / `cargo clippy --workspace --all-targets -- -D warnings` clean
- `cargo test --workspace --exclude bdd` green; `bgp::cap` tests updated (v6 unicast now implemented; RTC pinned as the excluded control)
- BDD `@bgp_addpath_ipv6` — 3 scenarios, two consecutive clean runs (first run caught a real race that the polling assertion fixes), zero leftover daemons

### AddPath Send — now complete
Every advertise family has AddPath Send: IPv4/IPv6 unicast, VPNv4/VPNv6, EVPN, LU-v4/v6. Only RTC (no per-path semantics — your instruction) and the exact-match flowspec families stay excluded. Wire-tested for v4 (#1433) and v6 (this PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)