### PR TITLE
bgp: reset the session on a TCP-AO key-chain change

### DIFF
--- a/bdd/docs/bgp_tcp_ao_auth.md
+++ b/bdd/docs/bgp_tcp_ao_auth.md
@@ -36,4 +36,6 @@ Requires Linux kernel >= 6.7 on both peers.
 | Scenario | Result |
 |----------|--------|
 | Establish a TCP-AO authenticated BGP session | |
+| Switching to a mismatched key-chain drops the session | |
+| Restoring the matching key-chain re-establishes the session | |
 | Teardown topology | |

--- a/bdd/tests/configs/bgp_tcp_ao_auth/z2-2.yaml
+++ b/bdd/tests/configs/bgp_tcp_ao_auth/z2-2.yaml
@@ -1,0 +1,26 @@
+key-chains:
+  key-chain:
+  - name: BGP-AO-WRONG
+    key:
+    - key-id: 100
+      crypto-algorithm: hmac-sha-1
+      send-id: 100
+      recv-id: 100
+      key-string:
+        keystring: "mismatched-ao-secret"
+
+router:
+  bgp:
+    global:
+      as: 65002
+      router-id: 192.168.0.2
+    neighbor:
+    - remote-address: 192.168.0.1
+      afi-safi:
+      - name: ipv4
+        enabled: true
+      enabled: true
+      remote-as: 65001
+      tcp-ao:
+        key-chain: BGP-AO-WRONG
+        include-tcp-options: true

--- a/bdd/tests/features/bgp_tcp_ao_auth.feature
+++ b/bdd/tests/features/bgp_tcp_ao_auth.feature
@@ -40,6 +40,25 @@ Feature: BGP TCP Authentication Option (RFC 5925 / RFC 5926)
     Then BGP session in "z1" to "192.168.0.2" should be "Established"
     And BGP session in "z2" to "192.168.0.1" should be "Established"
 
+  Scenario: Switching to a mismatched key-chain drops the session
+    Given the test topology exists
+    # z2 swaps its tcp-ao key-chain reference (BGP-AO -> BGP-AO-WRONG,
+    # a different key-string). The MKT is installed on the listener at
+    # accept time, so the key change only resets the session because the
+    # key-chain callback now bounces it — otherwise the old session
+    # would survive under the old key until the hold timer expired.
+    When I apply config "z2-2.yaml" to namespace "z2"
+    And I wait 5 seconds for BGP to operate
+    Then BGP session in "z1" to "192.168.0.2" should not be "Established"
+    And BGP session in "z2" to "192.168.0.1" should not be "Established"
+
+  Scenario: Restoring the matching key-chain re-establishes the session
+    Given the test topology exists
+    When I apply config "z2-1.yaml" to namespace "z2"
+    And I wait 5 seconds for BGP to operate
+    Then BGP session in "z1" to "192.168.0.2" should be "Established"
+    And BGP session in "z2" to "192.168.0.1" should be "Established"
+
   Scenario: Teardown topology
     Given the test topology exists
     When I stop zebra-rs in namespace "z1"

--- a/zebra-rs/src/bgp/config.rs
+++ b/zebra-rs/src/bgp/config.rs
@@ -2948,10 +2948,32 @@ fn config_peer_tcp_ao_key_chain(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> 
         &bgp.policy_tx,
         peer_ident,
         policy::PolicyType::KeyChain(policy::KeyChainScope::BgpNeighbor),
-        prior,
-        new,
+        prior.clone(),
+        new.clone(),
     );
     apply_ao_refresh_all(bgp);
+
+    // A key-chain change resets the session, like the TCP-MD5 password
+    // path: the AO MKT is installed on the listener / active-connect
+    // socket at accept/dial time, so a session authenticated under the
+    // old key-chain would otherwise survive a new, removed, or
+    // mismatched one until the hold timer eventually expires. Bounce a
+    // live session with `Event::Stop` (the `clear … hard` teardown); an
+    // Idle peer picks the new key-chain up on its first connect.
+    // (A *content* change within the same chain — key rotation — flows
+    // through the policy `KeyChain` path, not this callback.)
+    if prior != new {
+        let live = bgp
+            .peers
+            .get(&addr)
+            .is_some_and(|p| !matches!(p.state, super::peer::State::Idle));
+        if live {
+            let _ = bgp.tx.try_send(super::inst::Message::Event(
+                peer_ident,
+                super::peer::Event::Stop,
+            ));
+        }
+    }
     Some(())
 }
 


### PR DESCRIPTION
## Summary

The TCP-AO sibling of the TCP-MD5 password-reset fix (#1430). Like MD5, the AO MKT is installed on the **listener** fd (and the active-connect socket) at accept/dial time, so an already-established session keeps using the key it was set up with: changing the peer's `tcp-ao key-chain` reference reconciled the listener MKTs (`apply_ao_refresh_all`) but never reset the live session — so a new / removed / mismatched key-chain survived under the old key until the hold timer eventually expired, not the immediate drop an operator expects.

### Fix
`config_peer_tcp_ao_key_chain` already captured the `prior` and `new` key-chain names; bounce the peer with `Event::Stop` (the `clear … hard` teardown) when they differ and the session is not Idle, after the listener re-key. An Idle peer picks the new key-chain up on its first connect. Follows the exact pattern of #1430 (and `config_local_as` / `config_peer_port`).

A *content* change within the same chain (key rotation) flows through the policy `KeyChain` path, not this callback — left as a separate follow-up (and arguably wants RFC 5925 in-session MKT rollover rather than a bounce).

### Test
Adds **mismatch + restore** scenarios to `@bgp_tcp_ao_auth` (z2 swaps to a `BGP-AO-WRONG` chain with a different key-string): the session drops on both sides and re-establishes when the matching chain is restored. Mirrors the MD5 feature shape — and unlike #1430 (where the mismatch scenario pre-existed), this PR both adds the coverage *and* makes it pass.

## Testing

- `cargo fmt` / `cargo clippy --workspace --all-targets -- -D warnings` clean
- `cargo test --workspace --exclude bdd` green
- BDD `@bgp_tcp_ao_auth` — **4/4 scenarios** (establish, mismatch-drops, restore-reestablishes, teardown), 28 steps, against the rebuilt binary; no leftover daemons. (TCP-AO needs kernel ≥ 6.7; host is 6.8.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)