### PR TITLE
docs: extract BGP sharding prior-art (BIRD/GoBGP) into separate memo

### DIFF
--- a/docs/design/bgp-rib-sharding-plan.md
+++ b/docs/design/bgp-rib-sharding-plan.md
@@ -1,15 +1,223 @@
 # BGP RIB Sharding (Juniper-style)
 
-Status: **Phase 0 + Phase A merged** — applicability analysis (§1–4)
-and delivery plan (§5–8) written 2026-06-12 (merged via PR #1402);
-bench harness (0.1, PR #1406) and the two flush-offload steps (A.1 PR
-#1408, A.2 PR #1416 — replaces auto-closed #1411) merged 2026-06-12,
-rebased on the peer-separation work (#1403/#1413/#1414). Open
-decisions in §8 still need a ruling before Phase B starts.
+Status: **Phase 0 + A merged; Phase B built at N=1 (sync-dispatch);
+policy-parallelism C.1/C.2 built; N-shard dedicated-thread pool +
+RouteBatch + mimalloc built (dark behind `SHARDS=1`); Phase E.1
+(parallel advertise-outcome precompute) built** — Phase 0 + A merged
+2026-06-12
+(PRs #1402/#1406/#1408/#1416). Phase B (state partition, message
+protocol, shard) and a re-scoped Phase C (parallel policy evaluation)
+were built 2026-06-13 on a WIP branch. Two deliberate divergences from
+the §5–8 plan: **B.3 became a synchronous dispatch, not a spawned task**,
+and **Phase C was re-scoped to parallelize the pure policy walk (rayon)
+rather than fan out to N shards** (the multi-shard form remains future).
+The "Implementation status" section below is the current architecture of
+record; §1–10 remain the original applicability analysis and design
+rationale. Open decisions §8: D1 (in-repo `bgp-bench`) and D3
+(v4/v6-unicast+LU+VPN scope) resolved as recommended; D2 (channel
+boundedness) moot under sync dispatch — there is no data channel yet;
+D4 (default shard count) deferred — the N-shard path now exists but
+ships dark behind the `SHARDS` constant (default 1).
 
 Source: "BGP RIB Sharding" — Ravindran Thangarajah, Juniper Networks,
 2022-10-24.
 <https://community.juniper.net/blogs/ravindran-thangarajah/2022/10/24/bgp-rib-sharding>
+
+## Implementation status (as built — 2026-06-13)
+
+What actually shipped diverges from the §5–8 plan in two deliberate
+ways: B.3 became a **synchronous dispatch** rather than a spawned task,
+and Phase C was **re-scoped** to parallelize the pure policy walk (rayon)
+instead of (yet) fanning out to N shards. §5–10 remain the original
+design rationale.
+
+### Phase B — shard extraction at N=1 (B.1–B.3, built)
+
+- **State partition (B.1).** `BgpShard` (`bgp/shard/mod.rs`) owns the
+  sharded Loc-RIB tables — `v4`, `v6`, `v4lu`, `v6lu`
+  (`LocalRibTable<…>`) and `v4vpn`, `v6vpn` (`BTreeMap<RouteDistinguisher,
+  LocalRibTable<…>>`) — plus the per-peer Adj-RIB-In slices (`adj_in:
+  BTreeMap<usize, ShardAdjIn>`), a shard-owned attribute-interning store,
+  and `ShardLabelPool` (per-route LU / VPNv4-transit label sub-blocks).
+  EVPN / flowspec / SR-Policy / BGP-LS / RTC stay main-owned (§8 D3).
+- **Attr store uses ahash** (`store.rs`). A profile put the default
+  SipHash at ~28 % of daemon CPU; interned keys are internal dedup keys,
+  not attacker-chosen, so a fast non-cryptographic hasher is the right
+  trade — it made the converted path net-faster than baseline.
+- **B.3 — synchronous dispatch (the pivot).** The plan called for a
+  spawned shard task (`BgpShardHandle`, channels). At N=1 a task adds a
+  hop + channel overhead and **zero** parallelism (it runs on main's
+  core anyway). So B.3 instead routes table ops through
+  `BgpShard::handle(ShardMsg, central) -> Vec<ShardOut>`, called
+  **inline** from `route.rs`; `shard` is a plain field on `Bgp`, not a
+  task. This keeps the value of B.1/B.2 — a clean state partition + a
+  typed message protocol, ready to be task-ified for N>1 — without
+  paying the task's cost at N=1.
+  - `ShardMsg`: `UpdateV4` / `UpdateV6` / `UpdateLu` (+ `WithdrawV4/V6/Lu`,
+    `PeerDown`, `Show`, `Shutdown`). `ShardOut`: `BestPathV4/V6/Lu`.
+  - Pipeline split per update: **main** runs the per-attr peer checks
+    (`inbound_attr_checks`), inbound policy, NHT resolution, and the
+    Inter-AS Option-AB transit flag; the **shard** does Adj-RIB-In +
+    intern + Loc-RIB insert + best-path + label allocation; **main** then
+    acts on the returned best-path delta — NHT untrack, FIB install, VPN
+    import/export, advertise.
+  - **Dispatch vs direct access**: v4-unicast + VPNv4 reach the shard via
+    `UpdateV4`, v6-unicast + VPNv6 via `UpdateV6`. **Labeled-unicast
+    (v4/v6) still uses direct shard-table access** (`route_labelv4_update`
+    → `bgp.shard.update_v4lu`); the `UpdateLu` + `WithdrawV4/V6/Lu`
+    variants are wired-but-unused scaffolding for a later migration (the
+    dead-code warnings on them are expected).
+
+### Phase C — re-scoped to parallel policy evaluation (C.1/C.2, built)
+
+The planned C.1 (N-shard fan-out) and C.2 (update-workers) are **not yet
+built — the shard is still single (N=1)**. Instead, profiling the N=1
+build under a realistic policy-heavy workload (a 1000-entry route-map
+applied inbound *and* outbound) put **74.8 % of CPU in
+`PrefixTrie::walk_enclosing`** — the prefix-set match, run ~1000× per
+route. Policy evaluation is **pure** (reads the peer's policy snapshot +
+the route, mutates nothing) and every prefix in one UPDATE shares one
+attribute, so it parallelizes with rayon *without* partitioning the RIB:
+
+- **C.1 — parallel inbound policy.** `route_ipv4_update_batch` runs
+  `inbound_attr_checks` once, `par_iter`s the per-prefix policy walk
+  (`apply_policy_in_pure`), then writes the Loc-RIB + advertises serially
+  in NLRI order.
+- **C.2 — parallel outbound policy.** `route_ipv4_update_decided` returns
+  advertise jobs instead of advertising inline; the batch then runs three
+  phases — serial Loc-RIB updates → **parallel per-group advertise-outcome
+  precompute** (`compute_advertise_outcome` is pure) → serial apply
+  (cache / adj-out / send in NLRI order). The per-group outcome is
+  computed on the same canonical (non-source, non-LLGR) peer the serial
+  memo would use, so the result is identical and group-counter bumps stay
+  once-per-group.
+
+**Enabling work — family-generic per-peer policy.** The policy engine was
+already family-generic (`policy_list_apply_net` takes an `IpNet`,
+`PrefixSet::matches` is dual-stack); the in/out apply collapsed into one
+core, `apply_policy_net(prefix_cfg, policy_cfg, router_id, IpNet, attr,
+weight)`, shared by both directions and all families. Per-peer route-maps
+now apply for **v4/v6 unicast, VPNv4/6, and labeled-unicast v4/v6**;
+before this only v4-unicast + VPNv4 had them (v6 / LU silently ignored
+neighbor policy). Verified by `@bgp_v6_route_map` and `@bgp_lu_route_map`.
+
+### Measured (12-core, 1000-entry policy in+out, 4×100k, interleaved A/B)
+
+| build | convergence | vs serial |
+|---|---|---|
+| serial (no C.1/C.2) | 19.57 s | — |
+| C.1 (parallel inbound) | 11.62 s | −41 % |
+| C.2 (parallel inbound + outbound) | **4.34 s** | **−78 % (4.5×)** |
+
+The win is the policy walk; the §9 baseline matrix (no policy) is a
+different workload where this parallelism barely registers — there the
+planned multi-shard / update-worker fan-out is what pays.
+
+### Phase N-shard — dedicated-thread pool (as built, dark behind `SHARDS=1`)
+
+The planned multi-shard fan-out (original C.1) is now built, but on
+**dedicated OS threads, not tokio tasks or rayon** — the rayon-per-UPDATE
+form (the re-scoped C.1/C.2 above) regressed the no-policy workload ~36 %
+(a `par_iter` tax with no policy to amortize), so the shard became a real
+thread that owns its slice end-to-end.
+
+- **`ShardPool`** (`bgp/shard/pool.rs`) spawns `SHARDS` worker threads
+  (`std::thread`), one per `BgpShard`. A worker blocks on an `mpsc`
+  inbox, runs `BgpShard::handle(msg, None)`, and ships a `ShardResult`
+  back over a tokio `UnboundedSender`. CPU-bound work on real threads
+  keeps it off the tokio runtime and away from the I/O (reader/writer)
+  tasks.
+- **`shard_of(addr)`** = FNV-1a over the address octets `% N`
+  (deterministic, address-only) so unicast / LU / VPN rows of one prefix
+  co-locate (the Juniper invariant) with no cross-shard synchronization.
+- **Gated on `SHARDS > 1`** (`inst.rs`): at the default `SHARDS == 1`
+  nothing spawns, the synchronous `shard` field + byte-identical sync
+  path run, and the event loop's `shard_results_rx` arm stays idle — so
+  BDD and every default run traverse the proven N=1 path.
+- **RouteBatch** (`ShardMsg::RouteBatchV4`): one UPDATE's prefixes are
+  split by hash and sent as **one batch per shard** (not one message per
+  prefix), collapsing ~4M per-prefix futex wakeups to ~N.
+- **Phase C — policy in the shard** (`compute_policy: true`): the shard
+  runs inbound policy itself, removing main's `par_iter`.
+- **mimalloc** as the global allocator (`main.rs`): per-thread heaps
+  remove ~12 % of CPU an N=12 profile put in the allocator's `osq_lock`
+  (shards intern attrs / build RIB rows concurrently).
+- **Reduce** (`inst.rs::process_shard_result`): the main event loop
+  `select!`s best-path deltas and runs NHT untrack + FIB install +
+  advertise off each.
+
+**Measured (12-core, no-policy 8×500k, interleaved A/B, NHT release
+batched).** Isolation showed the shard *dispatch* is free (sync-dispatch ≈
+baseline) and ahash interning even helps (−11 %); naive sharding then
+regressed the workload (ungated rayon par_iters +46 %, per-prefix dispatch
+storms, allocator contention), which RouteBatch + mimalloc + uniform
+cost-gating of every rayon par_iter (C.1 inbound, C.2 outbound, E.1 reduce)
++ per-shard NHT-release batching all fixed. End state, `ZEBRA_BGP_SHARDS`
+swept (one binary, no recompile):
+
+| build | r1 | r2 | r3 | avg | vs base |
+|---|---|---|---|---|---|
+| base (pre-sharding) | 20.89 | 20.79 | 20.51 | 20.73 s | — |
+| N=1 | 15.62 | 16.53 | 16.66 | 16.27 s | −22 % |
+| N=4 | 14.94 | 14.12 | 14.25 | 14.44 s | **−30 % (knee)** |
+| N=12 | 16.62 | 16.66 | 16.55 | 16.61 s | −20 % |
+
+**N=4 is the sweet spot; N=12 over-shards** — a textbook optimal-thread
+curve (Juniper's "threads ≤ cores", gains evaporating past the knee). At
+SHARDS ≈ cores there are no spare cores for the main reduce + tokio I/O, so
+coordination outweighs the marginal best-path gain on a workload where
+per-route work is trivial. The wins here are mostly ahash + mimalloc +
+de-taxing the par_iters; the shard fan-out adds −22 %→−30 % from N=1 to the
+N=4 knee, then regresses. (The earlier −23 % at N=12 was *before* the N>1
+NHT-release fix, when first-sight held routes were silently stuck — these
+numbers are correct end-to-end, and batching the release collapsed the N=12
+run-to-run spread from ~1.4 s to ~0.1 s.) It pays far more under policy
+(C.1/C.2 above; E.1 −39 % at N=12) or high RIB-FIB fan-out (§9).
+
+### Phase E — parallel advertise (the reduce is the next serial point)
+
+At N>1 the shards parallelize best-path, but the **reduce**
+(`process_shard_result`) still ran the advertise — out-policy + attribute
+transform + bucketing — serially on the main thread (it passed an *empty*
+memo, so `compute_advertise_outcome` ran inline). That is exactly the C.2
+parallelism *lost* when ingest moved to the shards. The encode itself is
+already off-thread (Phase A `FlushJob` → `spawn_blocking`); Phase E moves
+the rest of egress off the serial reduce.
+
+- **E.1 (built) — parallel advertise-outcome precompute in the reduce,
+  cost-gated.** `route_apply_bestpath_v4_batch` runs NHT untrack + FIB
+  install serially over a whole `ShardResult`, then — **only when an
+  out-policy is bound on some advertised-to peer** — `par_iter`s the
+  per-(prefix, group) out-policy + attribute transform
+  (`precompute_ipv4_advertise_outcomes`, the C.2 routine), then applies
+  the bucketing serially off the memos. Measured at N=12 (interleaved A/B
+  vs the pre-E.1 N=12 build): policy-heavy 8×100k convergence
+  **18.97 s → 11.65 s (~39 %)**. The cost-gate is essential: at
+  SHARDS ≈ cores there are no spare cores, so an *ungated* par_iter steals
+  them from the CPU-bound shard threads — a no-policy 8×500k load
+  regressed **3.2×** (15.7 s → 50.8 s) before the gate. Parallelize egress
+  only when out-policy makes egress the bottleneck (the shards are then
+  mostly idle); otherwise the serial inline apply (byte-identical) keeps
+  every core on best-path. The general fix for the *both-busy* case
+  (out-policy + saturated shards, e.g. post-`PolicyReplace`) is E.2's
+  bounded worker pool, not rayon's cores-wide global pool.
+- **E.2+ (future) — dedicated update-worker threads.** Move the per-group
+  caches + adj-out + encode into M worker threads with static
+  group→worker affinity, fed `AdvDelta` (RTO) directly by the shards
+  (bypassing the main reduce). BIRD 3.x (a per-protocol loop pulls a
+  lockfree journal, then filters + encodes on its own thread) and GoBGP
+  (a per-peer send goroutine) are the two reference designs (§11).
+  Per-(peer, prefix) ordering holds: one prefix → one shard → one worker.
+
+### Still future
+
+N>1 barriers (planned C.3: EoR / refresh / GR-LLGR sweeps
+broadcast-and-ack), N>1 show / clear / sync scatter-gather (B.4 is still
+inline — at N>1 they read the empty main shard), `PolicyReplace`
+(per-peer policy snapshots replicated to shards — Phase C uses
+default-permit, correct only for no-configured-policy), the YANG knob
+`router bgp shards <1-64>` to replace the `SHARDS` constant, and the perf
+matrix + shipping default (planned C.4).
 
 ## 1. Verdict
 
@@ -137,15 +345,21 @@ PRs land.
 | 0.1 | Bench harness + baseline profile | — | merged (PR #1406) |
 | A.1 | Flush job extraction (pure function) | — | merged (PR #1408) |
 | A.2 | Flush offload to worker | A.1 | merged (PR #1416) |
-| B.1 | State partition: `BgpShard` struct, adj-in re-keying | — | ⏳ |
-| B.2 | Shard message protocol + label sub-blocks | B.1 | ⏳ |
-| B.3 | Spawn shard task at N=1 | B.2 | ⏳ |
-| B.4 | Show / clear / sync scatter-gather | B.3 | ⏳ |
+| B.1 | State partition: `BgpShard` struct, adj-in re-keying | — | ✅ built (WIP branch) |
+| B.2 | Shard message protocol + label sub-blocks | B.1 | ✅ built (WIP branch) |
+| B.3 | ~~Spawn shard task~~ → **sync dispatch** at N=1 | B.2 | ✅ built — pivoted to sync, see "Implementation status" |
+| B.4 | Show / clear / sync scatter-gather | B.3 | 🔶 partial — `Show` wired; clear/sync still inline |
 | B.5 | BDD + lifecycle hardening at N=1 | B.4 | ⏳ |
-| C.1 | Prefix-hash fan-out to N shards + YANG knob | B.5 | ⏳ |
-| C.2 | Update-worker tasks (group affinity) | A.2, C.1 | ⏳ |
+| C.1 | Prefix-hash fan-out to N shards + YANG knob | B.5 | ⏳ deferred (label reused — see note) |
+| C.2 | Update-worker tasks (group affinity) | A.2, C.1 | ⏳ deferred (label reused — see note) |
 | C.3 | Barriers: EoR, refresh, GR/LLGR sweeps, clear | C.1 | ⏳ |
 | C.4 | Perf matrix, defaults, docs | C.2, C.3 | ⏳ |
+
+> **Phase C label note**: the *built* "C.1/C.2" are a re-scope —
+> rayon-parallel inbound/outbound **policy** evaluation at N=1 (see
+> "Implementation status"). The rows above are the *original* plan's
+> C.1/C.2 (multi-shard fan-out + update-workers), which remain deferred.
+> Same letters, different axis of parallelism.
 
 ### Phase 0 — Baseline measurement (before touching anything)
 
@@ -385,7 +599,7 @@ timing), so single-run deltas below that are noise.
 |---|---|---|---|
 | Baseline | 1.564s | 4.556s | 8.147s |
 | A.2 (PR #1416, 2 runs) | 1.64–1.76s | 4.65–4.70s | 7.55s |
-| B.5 (N=1) | | | |
+| B.3 sync-dispatch (N=1) | parity ±noise | parity ±noise | parity ±noise |
 | C.4 (best) | | | |
 
 A.2 reading: parity within noise at the 100k scales, ~7% at 2M paths.
@@ -393,6 +607,15 @@ Expected — A.2 offloads the per-group encode, whose cost scales with
 member fan-out, and this matrix has only 2 receivers. The structural
 win is the freed main loop; C.2 (update-workers) is where egress
 parallelism actually pays.
+
+**B.3 sync-dispatch (N=1) reading**: this *no-policy* matrix is the
+wrong workload to show the built C.1/C.2 — its per-route work is intern
++ best-path + encode, not policy, so routing through `BgpShard::handle`
+is parity-within-noise (the dispatch is the same core, the win was never
+here). The built policy-parallelism C.1/C.2 are measured on the
+policy-heavy workload in the "Implementation status" section above
+(serial 19.57s → 4.34s at 12 cores). The planned multi-shard C.1 /
+update-worker C.2 are what this matrix is meant to capture, when built.
 
 ## 10. Caveats & out of scope
 
@@ -409,3 +632,28 @@ parallelism actually pays.
   per-VRF tasks (they stay single-shard; the machinery is reusable
   later), reader-direct shard dispatch (requires epochs, §7), RIB
   daemon parallelism, EVPN/flowspec/SR-Policy/BGP-LS sharding.
+
+## 11. Prior art: parallelism in BIRD 3.x and GoBGP
+
+Extracted to its own memo:
+[`bgp-sharding-prior-art.md`](bgp-sharding-prior-art.md). BIRD 3.3.0
+(branch `stable-v3.3`) and GoBGP (`master`) were both read in full to
+place zebra-rs's design — the sharp question being **how each
+parallelizes a single BGP table's work** (best-path and advertise).
+Three different answers:
+
+- **BIRD 3.3** parallelizes *across* tables/protocols, never within one
+  table: a single table's best-path is **serial** under one per-table
+  lock, reads are lock-free (RCU caches), and egress is **parallel per
+  consumer** via lock-free journals (`lfjour`).
+- **GoBGP** shards one table by prefix hash across **2048 bucket *locks***
+  over shared memory; best-path runs in parallel across prefixes but
+  inside the lock, and export *policy* runs serially on the producer
+  (only encode/write is per-peer parallel).
+- **zebra-rs** shards by prefix hash into **owned** shards
+  (shared-nothing, no hot-path locks). Both BIRD and GoBGP parallelizing
+  egress per-peer is the cross-validation for Phase E.
+
+The memo carries the full architecture of each, diagrams, the comparison
+table, verified source anchors, and the per-stack takeaways (incl.
+corrections to the framing summarized here).

--- a/docs/design/bgp-sharding-prior-art.md
+++ b/docs/design/bgp-sharding-prior-art.md
@@ -1,0 +1,368 @@
+# BGP RIB Parallelism: Prior Art (BIRD 3.x & GoBGP)
+
+Status: **Reference memo.** Two other open BGP stacks — BIRD 3.3.0 and
+GoBGP — were read in full to place zebra-rs's RIB-sharding design. This
+memo is the companion to [`bgp-rib-sharding-plan.md`](bgp-rib-sharding-plan.md)
+(it was extracted and expanded from that doc's §11); the plan owns the
+zebra-rs design and delivery, this memo owns the comparison.
+
+The sharp question throughout: **how does each stack parallelize a single
+BGP table's work** — best-path selection and advertise? There are three
+different answers, and the differences are exactly the design space the
+sharding plan navigates.
+
+## Source pins
+
+| Stack | Path | Version | Branch | HEAD |
+|---|---|---|---|---|
+| BIRD | `/home/kunihiro/bird` (`../bird`) | 3.3.0 | `stable-v3.3` | `10682b7b` |
+| GoBGP | `/home/kunihiro/gobgp` (`../gobgp`) | `gobgp/v4` | `master` | `7204bf9d` |
+
+All `file:line` anchors below were verified against these exact
+checkouts. Line numbers drift across commits — if one misses, **grep the
+named symbol**, don't trust the number.
+
+## The three answers at a glance
+
+- **BIRD 3.3** parallelizes *across* tables and protocols, never *within*
+  one table. A single table's best-path is **serial** under one per-table
+  lock; the win is that **reads are lock-free** (RCU caches) and **egress
+  is parallel per consumer** via lock-free journals.
+- **GoBGP** shards a single table by prefix hash across **2048 bucket
+  *locks*** over shared memory. Best-path runs in parallel across
+  prefixes, but inside a lock, with cache-coherency traffic on every
+  update.
+- **zebra-rs** shards a single table by prefix hash into **owned** shard
+  threads — shared-nothing, **no hot-path locks**, main↔shard by message
+  passing. (See the plan.)
+
+```
+                 within-one-table best-path        egress (advertise)
+BIRD 3.3         serial (1 lock/table)             parallel per consumer (journal pull)
+GoBGP            parallel under 2048 bucket locks  parallel per peer (encode only)
+zebra-rs         parallel, owned shards, no locks  serial reduce → Phase E
+```
+
+---
+
+## BIRD 3.3 — per-protocol / per-table loops, serial within a table
+
+BIRD 3 is a ground-up multi-threaded redesign (2.x was a single event
+loop). Its concurrency unit is the **`birdloop`**; parallelism comes from
+running many loops on a thread pool, **not** from sharding any one table.
+
+### Threading model — thread pool + `birdloop`
+
+A fixed pool of OS threads is created per *thread group*:
+`bird_thread_start` → `pthread_create(..., bird_thread_main, thr)`
+(`sysdep/unix/io-loop.c:1253`). Each thread runs an infinite scheduler
+(`bird_thread_main`, `io-loop.c:977`): fire meta timers → run the
+balancer → run its assigned loops → `poll()` their sockets.
+
+A `birdloop` (`sysdep/unix/io-loop.h:44`) is the unit of single-threaded
+execution — an event list, timers, socket list, a pool, and **its own
+lock domain** (`domain_new(order)` in `birdloop_vnew_internal`). Within
+one loop run (`birdloop_run`) everything is serialized; concurrency is
+*between* loops.
+
+A **work-stealing balancer** (`birdloop_balancer`, `io-loop.c:832`) runs
+once per scheduler iteration: each thread claims a proportional batch of
+unassigned loops from its group's shared pickup list, and an overloaded
+thread *drops* loops back for others to steal. Loop↔thread reassignment
+is an atomic handshake (`birdloop_set_thread`, `io-loop.c:717`). Two
+implicit groups exist: **worker** (300 ms slice) and **express** (10 ms).
+
+### Unit of concurrency — per-protocol loop + per-table service loop
+
+- **Each protocol instance gets a loop.** `proto_new` →
+  `birdloop_new(...)`, stored as `p->loop` (`nest/proto.c:1568`).
+  *Caveat:* a protocol with `loop_order == DOMAIN_ORDER(the_bird)` runs
+  on the shared `&main_birdloop` instead (`proto.c:1561`) — protocols are
+  not *guaranteed* a private loop.
+- **Each table gets its own *service* loop** (`rt_setup` →
+  `birdloop_new(..., DOMAIN_ORDER(service), ...)`, `nest/rt-table.c:3808`)
+  **and a *separate* data lock** at `rtable` order
+  (`DOMAIN_NEW(rtable)`, `rt-table.c:3813`; field at `nest/route.h:383`).
+  Two domains, deliberately split (see lock order below).
+
+The service loop handles only table-internal maintenance — prune,
+next-hop update, hostcache, journal cleanup. It does **not** run
+best-path.
+
+### Best-path within one table — serial, no per-prefix sharding
+
+> **Correction to the older §11 framing:** best-path is *not* "run on the
+> table's service loop." It runs under the per-table **`rtable` lock**,
+> and that lock is taken **by the importing protocol's own loop** (e.g.
+> BGP's UPDATE parser), not by a single owning thread.
+
+`rte_recalculate` (`nest/rt-table.c:2325`) does the election. The call
+path: `rte_update` (`:2672`) runs the **in-filter before locking**
+(`f_run`, `:2706`), then `rte_import` (`:2756`) opens
+`RT_LOCKED` — `#define RT_LOCKED ... LOCK_DOMAIN(rtable, ...)`,
+`nest/route.h:470` — at `rt-table.c:2765`, interns the prefix, resolves
+the slot, and calls `rte_recalculate` (`:2836`), all in one critical
+section. `rte_update` is invoked from the protocol's own loop
+(`proto/bgp/packets.c:1634`). Election compares via `rte_better`
+(`rt-table.c:1120`) and publishes the new best with an atomic store.
+
+**There is no per-prefix sharding within a table.** Storage is a single
+flat `_Atomic`-pointer array indexed by a table-wide netindex, guarded by
+one whole-table lock (`struct rtable_private`, `nest/route.h:396`, has no
+striped lock array). The atomics + `synchronize_rcu()` inside
+`rte_recalculate` exist so lock-free *readers* can traverse concurrently
+with the single locked writer — they are not a write-sharding mechanism.
+**Intra-table best-path is single-threaded; BIRD's parallelism is across
+tables/protocols and on the export side.**
+
+### Egress / advertise — lock-free journals (`lfjour`)
+
+This is where one table's work *does* go parallel. Each table has **two**
+lock-free journals (`nest/route.h:392-393`): `export_all` (every change)
+and `export_best` (best-path changes only); a consumer subscribes to one
+per its `ra_mode` (`nest/proto.c:892`).
+
+- **Write side** (producer, under the table lock): `rte_announce_to`
+  (`rt-table.c:2034`) → `rt_exporter_push` (`nest/rt-export.c:476`) →
+  `lfjour_push_prepare`/`_commit` (`lib/lockfree.c:62-138`). A settle
+  timer on the table loop coalesces pushes before pinging consumers.
+  `lfjour_push_prepare` returns NULL when there are **no recipients and
+  nothing pending** — no work when nobody listens.
+- **Pull side** (consumer, on its *own* protocol loop): the recipient
+  event drains via `rt_export_get` (`nest/rt-export.c:38`) → `lfjour_get`
+  (`lib/lockfree.c:179`, RCU-guarded). **The export filter and the
+  protocol encode run here, on the consumer loop:** `export_filter`/
+  `f_run` (`rt-table.c:1269`) → `bgp_rt_notify` (`proto/bgp/bgp.c:3105`).
+  The recipient's wakeup target is the consumer's own loop
+  (`proto_work_list` = `birdloop_event_list(p->loop)`,
+  `nest/protocol.h:264`; set at `proto.c:863`).
+
+So with N peers there are **N loops filtering + encoding concurrently**,
+each pulling the same journal locklessly. (Cleanup/retirement of consumed
+items happens back on the table loop under RCU, `lfjour_cleanup_hook`,
+`lib/lockfree.c:455`.)
+
+### Lock-free reads — RCU attribute cache + netindex interning
+
+Neither read path takes the table lock:
+
+- **Attribute cache** (`nest/rt-attr.c`): a global RCU hash
+  (`rt-attr.c:1911`); lookup `ea_find_in_array` (`:1998`) is a pure
+  atomic chain walk under `rcu_read_lock` (`ea_lookup_slow`, `:2146`);
+  insert publishes by CAS; refcounts are atomic (`ea_storage.uc`,
+  `lib/route.h:293`) with RCU-deferred free. The `attrs`-domain mutex
+  (`RTA_LOCK`, `lib/route.h:97`) is taken only for oversized allocations,
+  never on the lookup/insert hot path.
+- **Netindex prefix interning** (`lib/netindex.c`): `net_find_index`
+  (`:298`) is RCU + atomics; the `NH_LOCK` mutex (`attrs` order) is taken
+  only to insert a *new* prefix (`net_get_index`, `:306`). *Nuance:* the
+  lookup additionally takes a per-bucket read **spinlock** (`SPINHASH`,
+  `lib/hash.h:269`), so it is not as purely lock-free as the attr cache.
+
+### Lock domain order
+
+A strict global order prevents deadlock when a protocol loop descends
+into table data and the caches (`lib/locking.h:19`):
+
+```c
+#define LOCK_ORDER \
+  the_bird, meta, control, proto, subproto, \
+  service, rtable, attrs, logging, resource,
+```
+
+`do_lock` (`sysdep/unix/domain.c:103`) maintains a thread-local stack and
+`bug()`s on out-of-order acquisition; it also forbids taking any lock
+below `resource` while an RCU reader is active. An importing protocol can
+therefore hold its own (`proto`/`subproto`) domain, then take the table's
+`rtable` lock, then intern into `attrs` — strictly increasing, never
+inverting. Two domains per table (service loop @ `service`, data @
+`rtable`) is what lets protocol loops cross into table data cleanly.
+
+```
+peer A loop ─┐                         ┌─ peer X loop  (pull export_best,
+peer B loop ─┤  rte_update (in-filter  │   filter + bgp_rt_notify encode,
+peer C loop ─┘  on its OWN loop)       │   ON ITS OWN LOOP)
+       │                               │
+       ▼  take per-table rtable lock   │   lock-free journal pull (RCU)
+   ┌───────────────────────────────┐   │
+   │  TABLE (one rtable lock)       │──lfjour──▶ export_all / export_best
+   │  rte_recalculate  [SERIAL]     │   │
+   └───────────────────────────────┘   └─ peer Y loop  (concurrent with X)
+   reads (attr cache / netindex): RCU, no table lock
+```
+
+---
+
+## GoBGP — per-peer goroutines + prefix-hash *lock* sharding
+
+GoBGP recently retrofitted prefix-hash sharding (commit `4be569ad`,
+"feat: propagateBucket", 2026-04-27) — convergent with the zebra-rs
+direction, but via **locks over shared memory** rather than ownership.
+
+### Goroutine model — per-peer, and the central `Serve()`
+
+Each Established peer runs **three** goroutines (all from `fsmHandler`):
+
+- **FSM loop** (`fsm.go:826`) — the `idle→…→established` state machine.
+- **recv goroutine** (`recvMessageloop`, spawned `fsm.go:1995`) — does
+  the **wire decode** on this goroutine (`DecodeFromBytes`,
+  `fsm.go:1291`), then calls `h.callback(fmsg)` (`fsm.go:1968`).
+- **send goroutine** (`sendMessageloop`, spawned `fsm.go:1994`) — see
+  egress below.
+
+The central **`Serve()`** loop (`pkg/server/server.go:383`) is a single
+goroutine that selects on only three channels — management ops, accepted
+connections, and ROA — each under `shared.mu` **write** lock. **Inbound
+UPDATEs never pass through `Serve()`.**
+
+> **Key finding:** `callback` is a *synchronous* function call, not a
+> channel hop. It is wired to `handleFSMMessage` (`server.go:285`), so an
+> inbound UPDATE is processed **on the peer's own recv goroutine**.
+> `handleFSMMessage` takes only `shared.mu.RLock()` (`server.go:1551`),
+> so **all peers' recv goroutines process inbound UPDATEs concurrently**
+> with each other — serialized only against `Serve()`'s write-lock ops.
+
+### Prefix-hash sharding — 2048 bucket mutexes
+
+`sharedData` holds `propagateBuckets [2048]sync.Mutex`
+(`propagateBucketCount = 2048`, `server.go:112`). `propagateBucket(path)`
+picks one via `farm.Hash64(family+prefix) % 2048` (`server.go:125-132`).
+`propagateUpdate` (`server.go:1189`), per path, does
+`bucket.Lock()` (`:1222`) and under it runs import policy (`ApplyPolicy`
+`POLICY_DIRECTION_IMPORT`, `:1241`), best-path (`rib.Update`, `:1266`),
+and the cross-peer fan-out (`:1267`).
+
+The hash key is the `(family, prefix)` *local key*, deliberately matching
+the per-peer RIB-out index `peer.sentPaths` (`peer.go:99-117`): the
+bucket lock provides **prefix-level mutual exclusion spanning both the
+Loc-RIB update and every target peer's RIB-out state** for that prefix.
+Different prefixes → different buckets → full parallelism across the
+concurrent recv goroutines; the **same prefix is serialized** regardless
+of which peer it arrived on.
+
+### Not a "per-destination lock" — three nested lock levels
+
+> **Correction to the older §11 framing:** there is **no per-`Destination`
+> mutex**. Under the bucket lock sit two more levels, and the innermost
+> is itself a 2048-way shard:
+
+```
+shared.propagateBuckets[hashA]   per (family+prefix)      server.go:1222
+  └─ manager.mu.RLock()          TableManager RWMutex     table_manager.go:247
+       └─ destinationShard.mu[hashB]  per-NLRI-hash (2048) table.go:461
+            └─ destination       (no lock; guarded by the shard)
+```
+
+`destinationShardCount = 2048` (`internal/pkg/table/table.go:103`);
+`Table.update` (`:454`) picks a shard by a *separate* FNV-1a hash of the
+NLRI (`getShard`, `:120`) and locks `shard.mu` for the whole op. The
+`destination` struct itself has no lock (`destination.go:205`); its doc
+comments say it is protected by "the appropriate shard lock." `hashA` and
+`hashB` are different hash functions on different keys — two independent
+shardings layered on top of each other.
+
+### Best-path — on the recv goroutine, inside the locks
+
+`Destination.Calculate` (`internal/pkg/table/destination.go:307`) runs
+inside all three locks, on the producing peer's recv goroutine. Election
+is an inline `insertSort` (`:424`) keeping `knownPathList` sorted
+best-first via the full comparator ladder (reachable-nexthop → weight →
+LocalPref → AS-path → origin → MED → eBGP/iBGP → IGP cost → router-id).
+So the older §11 framing — *best-path + import policy on the per-peer
+recv goroutine, parallel across prefixes, inside the bucket lock* — is
+**correct** (with the refinement that "the bucket lock" is really the
+three nested levels above).
+
+### Cross-peer fan-out + egress encode
+
+> **Correction to the older §11 framing:** egress is parallel per peer
+> only for the **encode + TCP write**. The **export *policy* and the
+> fan-out loop run on the *producer's* recv goroutine**, serially, inside
+> the bucket lock — not on each target's send goroutine.
+
+`propagateUpdateToNeighbors` (`server.go:1383`, called at `:1267`) loops
+over `s.neighborMap` (`:1395`) **serially within the bucket lock**. For
+each target it applies **export policy** (`filterpath` → `ApplyPolicy`
+`POLICY_DIRECTION_EXPORT`, `server.go:1109`), updates that target's
+RIB-out (`updateRoutes`, legal because still under the prefix's bucket
+lock), then hands the result off via `sendfsmOutgoingMsg` →
+`fsm.outgoingCh.In() <- ...` (`server.go:455`). `outgoingCh` is a
+**per-peer unbounded `InfiniteChannel`** (`eapache/channels`, created at
+`fsm.go:1568`).
+
+The target's **send goroutine** (`sendMessageloop`, `fsm.go:1756`) then
+dequeues, **coalesces** up to `maxCoalesceMsgs = 2048` batches
+(`fsm.go:1818`), **encodes** (`CreateUpdateMsgFromPaths`, `fsm.go:1850`,
+def `internal/pkg/table/message.go:694`), and writes to the socket
+(`fsm.go:1769`). Encode + write are therefore fully parallel per peer.
+
+```
+peer A recv goroutine ──┐
+peer B recv goroutine ──┤ propagateUpdate(path):
+peer C recv goroutine ──┘   bucket.Lock(hash(family+prefix))   [1 of 2048]
+        (concurrent for       ├─ import policy
+         distinct prefixes)   ├─ rib.Update → Destination.Calculate  [best-path]
+                              └─ propagateUpdateToNeighbors  [SERIAL fan-out:
+                                     per target: EXPORT POLICY + RIB-out update]
+                                        │ sendfsmOutgoingMsg → outgoingCh (per peer)
+                                        ▼
+   peer X send goroutine ── coalesce(2048) + encode + write   ┐ parallel
+   peer Y send goroutine ── coalesce(2048) + encode + write   ┘ per peer
+```
+
+---
+
+## zebra-rs — prefix-hash *ownership* sharding (shared-nothing)
+
+For contrast (the full design is in the
+[plan](bgp-rib-sharding-plan.md)): N dedicated OS threads each **own** a
+prefix-hash slice of the Loc-RIB — no shared table, **no locks on the hot
+path**; main↔shard is message passing (`RouteBatch` in, `ShardResult`
+out). Best-path + inbound policy run inside the owning shard. Advertise
+runs on the main **reduce** today; Phase E.1 parallelizes its out-policy
+precompute (rayon, cost-gated), and Phase E.2 will move egress to
+dedicated update-worker threads.
+
+## The picture
+
+| | BIRD 3.3 | GoBGP | zebra-rs |
+|---|---|---|---|
+| Concurrency unit | loop (per-proto, per-table) | per-peer goroutine + 2048 lock-buckets | per-prefix-hash **owned** shard thread |
+| Single table's best-path | **serial** (one table lock) | parallel (2048 bucket + shard locks) | parallel (owned shards) |
+| RIB memory model | shared, RCU reads + domain locks | shared, 2048+2048 nested mutexes | **partitioned, shared-nothing** |
+| Hot-path lock cost | RCU reads lock-free; table write serial | mutex + cache-coherency per update | **none** (message passing) |
+| Where inbound policy runs | importing protocol loop (before lock) | producing recv goroutine (in lock) | owning shard thread |
+| Where export policy runs | **consumer loop** (parallel, journal pull) | **producer recv goroutine** (serial fan-out) | main reduce → E.1 parallel → E.2 workers |
+| Egress encode / write | parallel per consumer loop | parallel per peer (send goroutine) | off-thread since Phase A; E.2 workers |
+| Prefix interning | global RCU cache (shared) | shared table | per-shard (duplicated) |
+
+## Takeaways for zebra-rs
+
+1. **Two mature stacks independently shard the RIB by prefix hash** —
+   strong validation of the direction. zebra-rs is the **shared-nothing**
+   variant (no lock / cache-coherency tax), which is why RouteBatch +
+   mimalloc put convergence *below* the serial baseline — a lock-based
+   design rarely beats its own baseline.
+
+2. **Both parallelize egress — but draw the line differently, and this
+   matters for Phase E.** BIRD runs the *export filter itself* on each
+   consumer loop (egress policy is parallel). GoBGP runs export *policy*
+   serially on the producer and parallelizes only the per-peer encode +
+   write. zebra-rs today is closest to "serial fan-out" (the reduce);
+   **Phase E.1** already lifts out-policy to a cost-gated parallel
+   precompute (the BIRD line), and **Phase E.2**'s update-worker threads
+   are the convergence of both references — BIRD's per-consumer
+   filter+encode loop, fed like GoBGP's per-peer `outgoingCh`.
+
+3. **BIRD's RCU attribute cache / netindex is the reference for the
+   cross-shard interning question.** zebra-rs currently **duplicates** the
+   intern store per shard (shard-owned, simple, no sharing). At large N
+   the choice is duplicate-per-shard (memory) vs one shared store behind
+   RCU/lockfree (BIRD's choice) — revisit if intern memory becomes the
+   ceiling.
+
+4. **Each design picks a different serialization point.** BIRD serializes
+   best-path per table (and parallelizes across tables); GoBGP serializes
+   per prefix (bucket); zebra-rs serializes nothing on the ingest hot
+   path (owned shards) and pushes the remaining serial work to the main
+   reduce — which is precisely why Phase E (egress) is the next frontier.


### PR DESCRIPTION
## Summary

Splits the BGP RIB sharding plan's inline §11 ("prior art") into a
standalone memo and expands it from a fresh full read of both reference
trees.

- **New:** `docs/design/bgp-sharding-prior-art.md` — how BIRD 3.3 and
  GoBGP each parallelize a *single* BGP table (best-path + advertise),
  with diagrams, a comparison table, per-stack takeaways, and `file:line`
  source anchors verified against `../bird` (3.3.0, `stable-v3.3`,
  `10682b7b`) and `../gobgp` (`master`, `7204bf9d`).
- **Reduced:** `bgp-rib-sharding-plan.md` §11 → a short pointer at the new
  memo. (This commit also carries the previously-uncommitted as-built
  implementation-status update — Phase B sync-dispatch, re-scoped Phase C
  policy parallelism, N-shard dedicated-thread pool behind `SHARDS=1`,
  Phase E.1.)

## Corrections to the old §11 framing (caught on the re-read)

- **BIRD:** a single table's best-path is serial under a per-table
  `rtable` **lock** taken by the *importing protocol's* loop — not "run on
  the table's service loop." Two domains per table (service loop @
  `service`, data @ `rtable`); egress filter+encode runs on each
  *consumer* loop via the lock-free `lfjour` journals.
- **GoBGP:** not a "per-destination lock" — **three** nested levels
  (2048 propagate buckets → TableManager RWMutex → 2048-way
  destination shard). Export **policy** runs serially on the *producer's*
  recv goroutine inside the bucket lock; only encode + write are per-peer
  parallel.

## Test plan

- Docs-only change (no `.rs` touched). CI fmt/clippy/test unaffected.
- Cross-links verified resolvable in both directions
  (plan ↔ memo, both files exist under `docs/design/`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)