### PR TITLE
bgp: reset the session on a TCP-AO in-chain key rotation

### DIFF
--- a/bdd/docs/bgp_tcp_ao_auth.md
+++ b/bdd/docs/bgp_tcp_ao_auth.md
@@ -38,4 +38,6 @@ Requires Linux kernel >= 6.7 on both peers.
 | Establish a TCP-AO authenticated BGP session | |
 | Switching to a mismatched key-chain drops the session | |
 | Restoring the matching key-chain re-establishes the session | |
+| Rotating the key-string within the same chain drops the session | |
+| Restoring the original key-string re-establishes the session | |
 | Teardown topology | |

--- a/bdd/tests/configs/bgp_tcp_ao_auth/z2-3.yaml
+++ b/bdd/tests/configs/bgp_tcp_ao_auth/z2-3.yaml
@@ -1,0 +1,26 @@
+key-chains:
+  key-chain:
+  - name: BGP-AO
+    key:
+    - key-id: 100
+      crypto-algorithm: hmac-sha-1
+      send-id: 100
+      recv-id: 100
+      key-string:
+        keystring: "rotated-ao-secret"
+
+router:
+  bgp:
+    global:
+      as: 65002
+      router-id: 192.168.0.2
+    neighbor:
+    - remote-address: 192.168.0.1
+      afi-safi:
+      - name: ipv4
+        enabled: true
+      enabled: true
+      remote-as: 65001
+      tcp-ao:
+        key-chain: BGP-AO
+        include-tcp-options: true

--- a/bdd/tests/cucumber.rs
+++ b/bdd/tests/cucumber.rs
@@ -645,6 +645,87 @@ async fn verify_bgp_session_not(
     );
 }
 
+/// Poll `show bgp neighbors <addr>` (JSON) until the addressed peer's
+/// `state` matches `expected` (`want_match = true`) or stops matching it
+/// (`want_match = false`). Returns `(satisfied, last_output)`.
+///
+/// The polling siblings of [`verify_bgp_session`] /
+/// [`verify_bgp_session_not`]: a state *transition* driven by a config
+/// change (an auth-key bounce, say) reaches the reconfigured speaker
+/// promptly but the far side only reflects it once the teardown or
+/// re-handshake propagates, so a single fixed-wait check races. Polling
+/// absorbs that lag.
+async fn poll_bgp_session_state(
+    scoped: &str,
+    neighbor: &str,
+    expected: &str,
+    want_match: bool,
+) -> (bool, String) {
+    const ATTEMPTS: u32 = 30;
+    let cmd = format!("show bgp neighbors {}", neighbor);
+    let mut last = String::new();
+    for i in 0..ATTEMPTS {
+        last = netns::exec_in_netns(scoped, "vtyctl", &["show", "-j", &cmd])
+            .await
+            .expect("Failed to get BGP neighbor state");
+        let matched = serde_json::from_str::<Value>(&last)
+            .ok()
+            .and_then(|v| {
+                v.get("state")
+                    .and_then(|s| s.as_str())
+                    .map(|s| s.eq_ignore_ascii_case(expected))
+            })
+            .unwrap_or(false);
+        if matched == want_match {
+            return (true, last);
+        }
+        if i + 1 < ATTEMPTS {
+            tokio::time::sleep(tokio::time::Duration::from_secs(1)).await;
+        }
+    }
+    (false, last)
+}
+
+#[then(expr = "BGP session in {string} to {string} should eventually be {string}")]
+async fn verify_bgp_session_eventually(
+    world: &mut World,
+    namespace: String,
+    neighbor: String,
+    expected_state: String,
+) {
+    let scoped = world.ns(&namespace);
+    let (ok, last) = poll_bgp_session_state(&scoped, &neighbor, &expected_state, true).await;
+    assert!(
+        ok,
+        "BGP session {} -> {} never reached {}; last output:\n{}",
+        scoped, neighbor, expected_state, last
+    );
+    println!(
+        "✓ BGP session {} -> {} reached {}",
+        scoped, neighbor, expected_state
+    );
+}
+
+#[then(expr = "BGP session in {string} to {string} should eventually not be {string}")]
+async fn verify_bgp_session_eventually_not(
+    world: &mut World,
+    namespace: String,
+    neighbor: String,
+    unexpected_state: String,
+) {
+    let scoped = world.ns(&namespace);
+    let (ok, last) = poll_bgp_session_state(&scoped, &neighbor, &unexpected_state, false).await;
+    assert!(
+        ok,
+        "BGP session {} -> {} stayed {}; last output:\n{}",
+        scoped, neighbor, unexpected_state, last
+    );
+    println!(
+        "✓ BGP session {} -> {} is no longer {}",
+        scoped, neighbor, unexpected_state
+    );
+}
+
 /// Poll `show bgp neighbors` (all peers, JSON) until some peer's
 /// `state` matches `expected` (`want_match = true`) or no peer matches
 /// it (`want_match = false`). Returns `(satisfied, last_output)`.

--- a/bdd/tests/features/bgp_tcp_ao_auth.feature
+++ b/bdd/tests/features/bgp_tcp_ao_auth.feature
@@ -48,16 +48,35 @@ Feature: BGP TCP Authentication Option (RFC 5925 / RFC 5926)
     # key-chain callback now bounces it — otherwise the old session
     # would survive under the old key until the hold timer expired.
     When I apply config "z2-2.yaml" to namespace "z2"
-    And I wait 5 seconds for BGP to operate
-    Then BGP session in "z1" to "192.168.0.2" should not be "Established"
-    And BGP session in "z2" to "192.168.0.1" should not be "Established"
+    Then BGP session in "z1" to "192.168.0.2" should eventually not be "Established"
+    And BGP session in "z2" to "192.168.0.1" should eventually not be "Established"
 
   Scenario: Restoring the matching key-chain re-establishes the session
     Given the test topology exists
     When I apply config "z2-1.yaml" to namespace "z2"
-    And I wait 5 seconds for BGP to operate
-    Then BGP session in "z1" to "192.168.0.2" should be "Established"
-    And BGP session in "z2" to "192.168.0.1" should be "Established"
+    Then BGP session in "z1" to "192.168.0.2" should eventually be "Established"
+    And BGP session in "z2" to "192.168.0.1" should eventually be "Established"
+
+  Scenario: Rotating the key-string within the same chain drops the session
+    Given the test topology exists
+    # z2 keeps its neighbor pointed at the SAME chain name (BGP-AO) and
+    # the SAME send-id/recv-id, but rotates the key-string
+    # (shared-ao-secret -> rotated-ao-secret). This edits the chain
+    # content, so it arrives via the policy key-chain callback rather
+    # than the neighbor tcp-ao callback. apply_ao_refresh_all re-installs
+    # the new MKT on the listener under the unchanged (addr, send-id,
+    # recv-id) tuple, so the established session would survive on the old
+    # key until the hold timer expired — unless the resolved-key delta
+    # bounces it.
+    When I apply config "z2-3.yaml" to namespace "z2"
+    Then BGP session in "z1" to "192.168.0.2" should eventually not be "Established"
+    And BGP session in "z2" to "192.168.0.1" should eventually not be "Established"
+
+  Scenario: Restoring the original key-string re-establishes the session
+    Given the test topology exists
+    When I apply config "z2-1.yaml" to namespace "z2"
+    Then BGP session in "z1" to "192.168.0.2" should eventually be "Established"
+    And BGP session in "z2" to "192.168.0.1" should eventually be "Established"
 
   Scenario: Teardown topology
     Given the test topology exists

--- a/zebra-rs/src/bgp/auth.rs
+++ b/zebra-rs/src/bgp/auth.rs
@@ -319,7 +319,7 @@ impl Default for AoConfig {
 /// pass into `set_tcp_ao_key`. Cached on `PeerTransportConfig` so the
 /// active-side `peer_connect` can apply it without needing to walk
 /// the `Bgp` registry at spawn time.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ResolvedAoKey {
     pub alg_name: &'static str,
     pub key_material: Vec<u8>,

--- a/zebra-rs/src/bgp/config.rs
+++ b/zebra-rs/src/bgp/config.rs
@@ -2822,12 +2822,28 @@ fn config_peer_tcp_md5_encoding(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> 
 ///
 /// Called from every TCP-AO callback (peer-side and key-chain-side)
 /// after the change has been absorbed into `Bgp`.
+///
+/// A live (non-Idle) session whose *resolved* key materially changes —
+/// new algorithm, key material, SendID/RecvID, or include-tcp-options —
+/// is bounced with `Event::Stop`. The MKT is installed on the listener
+/// and inherited by the established child socket, so re-installing a
+/// rotated key here does not reset the connection by itself; without the
+/// bounce the session would keep authenticating with the old key until
+/// the hold timer expired. This single, delta-gated check covers every
+/// caller: a per-neighbor key-chain *name* change, a key-chain *content*
+/// rotation pushed through the policy actor, and an include-tcp-options
+/// edit all funnel through here, and repeated calls are idempotent (the
+/// second sees `resolved_ao_key` already updated, so no delta).
 pub(super) fn apply_ao_refresh_all(bgp: &mut Bgp) {
     let fd_v4 = bgp.listen_fd_v4;
     let fd_v6 = bgp.listen_fd_v6;
     // Snapshot key_chains to release the immutable borrow before
     // iterating peers mutably.
     let key_chains = bgp.key_chains.clone();
+
+    // Peers whose resolved key changed under a live session; bounced
+    // after the loop so `bgp.tx` is borrowed clear of the peer iteration.
+    let mut bounce: Vec<usize> = Vec::new();
 
     // Every peer regardless of key variant. The listener entry is
     // keyed by the peer's source address read from `peer.address`, so
@@ -2855,14 +2871,30 @@ pub(super) fn apply_ao_refresh_all(bgp: &mut Bgp) {
             .ao_config
             .as_ref()
             .and_then(|ao| ao.resolve(&key_chains));
+
+        // Did the resolved key materially change from what we last
+        // cached? Drives both the live-session bounce and the
+        // del-before-set below. Captured before we overwrite the cache.
+        let changed = peer.config.transport.resolved_ao_key != resolved;
+
+        // Queue a bounce if a session is live under a key that just
+        // changed. An Idle peer just adopts the new key on its next
+        // connect.
+        if changed && !matches!(peer.state, super::peer::State::Idle) {
+            bounce.push(ident);
+        }
         peer.config.transport.resolved_ao_key = resolved.clone();
 
         let new_ids = resolved.as_ref().map(|r| (r.send_id, r.recv_id));
 
-        // Remove the stale listener entry if the resolved key now
-        // disappears or uses different SendID/RecvID.
+        // Remove the stale listener entry when the resolved key
+        // disappears, switches SendID/RecvID, OR rotates its material
+        // under the *same* SendID/RecvID. The kernel keys MKTs by
+        // (address, send_id, recv_id) and `TCP_AO_ADD_KEY` returns
+        // EEXIST on a duplicate, so a same-id rotation must del before it
+        // can re-add — otherwise the listener keeps serving the old key.
         if let (Some(prev_ids), Some(fd)) = (peer.last_ao_installed, fd)
-            && new_ids != Some(prev_ids)
+            && (new_ids != Some(prev_ids) || changed)
         {
             if let Err(e) = super::auth::del_tcp_ao_key(fd, addr, prev_ids.0, prev_ids.1) {
                 tracing::warn!(
@@ -2882,6 +2914,12 @@ pub(super) fn apply_ao_refresh_all(bgp: &mut Bgp) {
         let Some(fd) = fd else {
             continue;
         };
+        // Already installed and unchanged: skip the redundant
+        // `TCP_AO_ADD_KEY`, which would only return EEXIST. Any real
+        // change cleared `last_ao_installed` in the del step above.
+        if peer.last_ao_installed == Some((r.send_id, r.recv_id)) {
+            continue;
+        }
         match super::auth::set_tcp_ao_key(
             fd,
             addr,
@@ -2900,6 +2938,15 @@ pub(super) fn apply_ao_refresh_all(bgp: &mut Bgp) {
                 );
             }
         }
+    }
+
+    // Bounce the sessions whose key changed. `Event::Stop` is the
+    // `clear … hard` teardown; the peer re-handshakes from Idle under
+    // the new key.
+    for ident in bounce {
+        let _ = bgp
+            .tx
+            .try_send(super::inst::Message::Event(ident, super::peer::Event::Stop));
     }
 }
 
@@ -2934,46 +2981,29 @@ fn config_peer_tcp_ao_key_chain(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> 
             ao.key_chain = chain_name.clone();
             (ident, prior, Some(chain_name))
         } else {
+            // Leave `resolved_ao_key` for `apply_ao_refresh_all` to
+            // clear: dropping it here would hide the Some→None delta it
+            // uses to bounce a live session off a removed key.
             peer.config.transport.ao_config = None;
-            peer.config.transport.resolved_ao_key = None;
             (ident, prior, None)
         }
     };
     // Subscribe (or rebind) the peer's interest in the chain so the
-    // policy actor pushes future `PolicyRx::KeyChain` updates for it;
-    // `apply_ao_refresh_all` reconciles the live listener entries
-    // using the snapshot we already have for `Set` cases and for
-    // `Delete`s that need to del a stale MKT.
+    // policy actor pushes future `PolicyRx::KeyChain` updates for it.
+    // `apply_ao_refresh_all` then reconciles the live listener entries
+    // and bounces the session if its resolved key changed — a key-chain
+    // *name* change here, a removal, or an in-chain content rotation
+    // pushed through the policy actor all funnel through that one
+    // delta-gated check, so this callback no longer resets the session
+    // itself.
     policy_attach_msgs(
         &bgp.policy_tx,
         peer_ident,
         policy::PolicyType::KeyChain(policy::KeyChainScope::BgpNeighbor),
-        prior.clone(),
-        new.clone(),
+        prior,
+        new,
     );
     apply_ao_refresh_all(bgp);
-
-    // A key-chain change resets the session, like the TCP-MD5 password
-    // path: the AO MKT is installed on the listener / active-connect
-    // socket at accept/dial time, so a session authenticated under the
-    // old key-chain would otherwise survive a new, removed, or
-    // mismatched one until the hold timer eventually expires. Bounce a
-    // live session with `Event::Stop` (the `clear … hard` teardown); an
-    // Idle peer picks the new key-chain up on its first connect.
-    // (A *content* change within the same chain — key rotation — flows
-    // through the policy `KeyChain` path, not this callback.)
-    if prior != new {
-        let live = bgp
-            .peers
-            .get(&addr)
-            .is_some_and(|p| !matches!(p.state, super::peer::State::Idle));
-        if live {
-            let _ = bgp.tx.try_send(super::inst::Message::Event(
-                peer_ident,
-                super::peer::Event::Stop,
-            ));
-        }
-    }
     Some(())
 }
 

--- a/zebra-rs/src/bgp/inst.rs
+++ b/zebra-rs/src/bgp/inst.rs
@@ -2931,9 +2931,14 @@ impl Bgp {
             } => {
                 // Apply the snapshot delta first so any downstream
                 // resolve() sees the new state. Then reconcile the
-                // TCP-AO MKTs installed on the listening sockets so
-                // a key edit lands on the kernel before the peer's
-                // next SYN arrives.
+                // TCP-AO MKTs installed on the listening sockets so a key
+                // edit lands on the kernel before the peer's next SYN
+                // arrives. `apply_ao_refresh_all` also bounces any live
+                // session whose resolved key materially changed — that is
+                // how an in-chain key-string rotation (same chain name,
+                // same SendID/RecvID, new material) resets the session
+                // instead of surviving on the old key until the hold
+                // timer expires.
                 if let Some(kc) = key_chain {
                     self.key_chains.insert(name, kc);
                 } else {


### PR DESCRIPTION
## Summary

Completes the TCP-AO session-reset story. PR #1438 bounced an established session on a key-chain *name* change, but rotating the key-string **within** the same chain (the common operational case) did not reset the session — the peer kept authenticating with the old key until the hold timer expired.

This was the deferred follow-up flagged in #1438. The user asked for the bounce; getting it to actually work surfaced an underlying listener bug, fixed here too.

## What was broken

**1. `TCP_AO_ADD_KEY` EEXIST on same-id rotation.** The kernel keys MKTs by `(address, send_id, recv_id)` and rejects a duplicate with `EEXIST`. The del-before-set in `apply_ao_refresh_all` only deleted the old entry when the SendID/RecvID *changed*. A key-string rotation keeps the same ids, so the new material **never installed on the listener** — the listener kept serving the old key (and every periodic reconcile logged an EEXIST warning re-adding an already-present key). The session could not mismatch because nothing on the wire actually changed.

**2. The bounce compared chain names.** The reset lived in the per-neighbor key-chain callback and compared chain *names*, so a content rotation (same name, new material, routed through the policy `KeyChain` callback) never triggered it.

## Fix

- **Listener:** delete the old MKT before re-adding whenever the resolved key *materially* changed (not just on an id switch); skip the redundant add when an unchanged key is already installed (kills the EEXIST noise).
- **Bounce:** centralized into `apply_ao_refresh_all` and gated on the resolved-key delta (algorithm, key material, SendID, RecvID, include-tcp-options). A neighbor name change, a removal, an include-tcp-options edit, and a policy-driven in-chain rotation now all funnel through one delta-gated check. Repeated calls are idempotent (the second sees `resolved_ao_key` already updated). `ResolvedAoKey` gains `PartialEq`/`Eq`.

## Test

`bgp_tcp_ao_auth` gains two scenarios: rotate z2's key-string within `BGP-AO` (same send/recv-id) → session drops; restore → re-establishes. The feature's session-state assertions move to new polling step variants (`BGP session in … should eventually [not] be …`) — a config-driven teardown reaches the reconfigured speaker promptly but the far side reflects it asynchronously, which raced the old fixed 5 s wait.

- `cargo clippy --workspace --all-targets -- -D warnings` clean
- `cargo test -p zebra-rs --bins` — 1243 passed
- `@bgp_tcp_ao_auth` BDD — 6/6 scenarios, stable across 3 consecutive runs, clean teardown

🤖 Generated with [Claude Code](https://claude.com/claude-code)