### PR TITLE
bgp: show bgp neighbors <X> advertised/received-routes ipv6

### DIFF
--- a/bdd/tests/configs/bgp_neighbor_adj_rib_v6/z1.yaml
+++ b/bdd/tests/configs/bgp_neighbor_adj_rib_v6/z1.yaml
@@ -1,0 +1,42 @@
+# Originator side. Dual-stack point-to-point link, eBGP over the IPv4
+# transport with both ipv4 and ipv6 afi-safi negotiated; both sides
+# redistribute connected so the loopback + link v6 prefixes populate
+# the v6 Loc-RIB and, in turn, each peer's v6 Adj-RIB-Out / In — the
+# subject of the `advertised-routes ipv6` / `received-routes ipv6` show
+# commands. adv-interval is pinned to 1s so the dump flushes promptly.
+interface:
+- if-name: lo
+  ipv4:
+    address: 10.0.0.1/32
+  ipv6:
+    address: 2001:db8::1/128
+- if-name: z1-z2
+  ipv4:
+    address: 192.168.0.1/30
+  ipv6:
+    address: 2001:db8:12::1/64
+router:
+  bgp:
+    global:
+      as: 65001
+      router-id: 10.0.0.1
+    timer:
+      adv-interval:
+        ibgp: 1
+        ebgp: 1
+    neighbor:
+    - remote-address: 192.168.0.2
+      remote-as: 65002
+      enabled: true
+      afi-safi:
+      - name: ipv4
+        enabled: true
+      - name: ipv6
+        enabled: true
+    afi-safi:
+    - name: ipv4
+      redistribute:
+        connected: {}
+    - name: ipv6
+      redistribute:
+        connected: {}

--- a/bdd/tests/configs/bgp_neighbor_adj_rib_v6/z2.yaml
+++ b/bdd/tests/configs/bgp_neighbor_adj_rib_v6/z2.yaml
@@ -1,0 +1,37 @@
+# Receiver side — mirror of z1 with flipped addressing.
+interface:
+- if-name: lo
+  ipv4:
+    address: 10.0.0.2/32
+  ipv6:
+    address: 2001:db8::2/128
+- if-name: z2-z1
+  ipv4:
+    address: 192.168.0.2/30
+  ipv6:
+    address: 2001:db8:12::2/64
+router:
+  bgp:
+    global:
+      as: 65002
+      router-id: 10.0.0.2
+    timer:
+      adv-interval:
+        ibgp: 1
+        ebgp: 1
+    neighbor:
+    - remote-address: 192.168.0.1
+      remote-as: 65001
+      enabled: true
+      afi-safi:
+      - name: ipv4
+        enabled: true
+      - name: ipv6
+        enabled: true
+    afi-safi:
+    - name: ipv4
+      redistribute:
+        connected: {}
+    - name: ipv6
+      redistribute:
+        connected: {}

--- a/bdd/tests/features/bgp_neighbor_adj_rib_v6.feature
+++ b/bdd/tests/features/bgp_neighbor_adj_rib_v6.feature
@@ -1,0 +1,75 @@
+@serial
+@bgp_neighbor_adj_rib_v6
+Feature: show bgp neighbors <X> advertised-routes / received-routes ipv6
+  As a network operator
+  I want to inspect a single neighbor's IPv6-unicast Adj-RIB-Out and
+  Adj-RIB-In, so I can see exactly what was advertised to, and received
+  from, that peer for the v6 address family.
+
+  These are the v6-unicast twins of the existing (bare) v4 forms:
+  `advertised-routes ipv6` reads the peer's `adj_out.v6`, and
+  `received-routes ipv6` reads its `adj_in.v6`. The IPv6 Adj-RIB-Out
+  always lives on the peer (the per-peer egress task is v4-only) and the
+  IPv6 Adj-RIB-In lives in main's shard (v6 ingest never moves to the
+  pool), so both reads are correct at any shard count.
+
+  Topology: one dual-stack point-to-point link, eBGP over the IPv4
+  transport with both ipv4 and ipv6 afi-safi negotiated, both sides
+  redistributing connected. The session is keyed by the IPv4 transport
+  address; the `ipv6` keyword selects the v6 Adj-RIB on that peer.
+
+  Scenario: A neighbor's v6 Adj-RIB-Out and Adj-RIB-In are visible per peer
+    Given a clean test environment
+    When I create namespace "z1"
+    And I create namespace "z2"
+    And I connect namespace "z1" interface "z1-z2" to namespace "z2" interface "z2-z1"
+    And I start zebra-rs in namespace "z1"
+    And I start zebra-rs in namespace "z2"
+    And I apply config "z1.yaml" to namespace "z1"
+    And I apply config "z2.yaml" to namespace "z2"
+    And I wait 10 seconds
+    Then show command "show bgp summary" in namespace "z1" should contain "Established"
+    # Sanity: the v6 routes converged across the session.
+    And show command "show bgp ipv6" in namespace "z2" should contain "2001:db8::1/128"
+    # Adj-RIB-Out, z1 -> z2 (the IPv4-transport peer): z1's own loopback
+    # was advertised to z2 over the v6 AFI.
+    And show command "show bgp neighbors 192.168.0.2 advertised-routes ipv6" in namespace "z1" should contain "2001:db8::1/128"
+    # The Adj-RIB-Out is per-peer, not a whole-table dump: z2's own
+    # loopback (learned FROM z2) is never advertised back to z2. The
+    # positive assertion above on the same command guards this negative
+    # from passing vacuously (an unparsed command returns empty output).
+    And show command "show bgp neighbors 192.168.0.2 advertised-routes ipv6" in namespace "z1" should not contain "2001:db8::2/128"
+    # Adj-RIB-In, z2 <- z1: z2 received z1's loopback and the shared link
+    # prefix from neighbor 192.168.0.1. Both present => the v6 Adj-RIB-In
+    # read is complete, and the negative below is non-vacuous.
+    And show command "show bgp neighbors 192.168.0.1 received-routes ipv6" in namespace "z2" should contain "2001:db8::1/128"
+    And show command "show bgp neighbors 192.168.0.1 received-routes ipv6" in namespace "z2" should contain "2001:db8:12::/64"
+
+  Scenario: A post-establishment v6 prefix appears, then withdraws, from the Adj-RIBs
+    Given the test topology exists
+    # Inject a fresh connected v6 prefix on z1 with the session already
+    # up, so it can only reach z2 through the incremental advertise path.
+    When I create dummy interface "cust0" with address "2001:db8:cafe::1/64" in namespace "z1"
+    And I wait 8 seconds
+    # It is recorded in z1's v6 Adj-RIB-Out toward z2 and z2's v6
+    # Adj-RIB-In from z1.
+    Then show command "show bgp neighbors 192.168.0.2 advertised-routes ipv6" in namespace "z1" should contain "2001:db8:cafe::/64"
+    And show command "show bgp neighbors 192.168.0.1 received-routes ipv6" in namespace "z2" should contain "2001:db8:cafe::/64"
+    # Downing the dummy flushes its v6 address (kernel semantics), so z1
+    # withdraws the origination. The MP_UNREACH must clear it from both
+    # Adj-RIBs. The link prefix stays as the positive control so neither
+    # negative assertion passes vacuously.
+    When I make namespace "z1" interface "cust0" down
+    And I wait 8 seconds
+    Then show command "show bgp neighbors 192.168.0.2 advertised-routes ipv6" in namespace "z1" should not contain "2001:db8:cafe::/64"
+    And show command "show bgp neighbors 192.168.0.2 advertised-routes ipv6" in namespace "z1" should contain "2001:db8:12::/64"
+    And show command "show bgp neighbors 192.168.0.1 received-routes ipv6" in namespace "z2" should not contain "2001:db8:cafe::/64"
+    And show command "show bgp neighbors 192.168.0.1 received-routes ipv6" in namespace "z2" should contain "2001:db8:12::/64"
+
+  Scenario: Teardown topology
+    Given the test topology exists
+    When I stop zebra-rs in namespace "z1"
+    And I stop zebra-rs in namespace "z2"
+    And I delete namespace "z1"
+    And I delete namespace "z2"
+    Then the test environment should be clean

--- a/zebra-rs/src/bgp/show.rs
+++ b/zebra-rs/src/bgp/show.rs
@@ -1608,8 +1608,8 @@ fn show_bgp_ipv6_longer<V: BgpShowView>(
 }
 
 // Common helper function for displaying Adj-RIB routes
-pub(super) fn show_adj_rib_routes(
-    routes: &std::collections::BTreeMap<ipnet::Ipv4Net, Vec<crate::bgp::route::BgpRib>>,
+pub(super) fn show_adj_rib_routes<P: std::fmt::Display>(
+    routes: &std::collections::BTreeMap<P, Vec<crate::bgp::route::BgpRib>>,
     router_id: Ipv4Addr,
     json: bool,
 ) -> std::result::Result<String, std::fmt::Error> {
@@ -1755,6 +1755,57 @@ fn show_bgp_received(
         .shard
         .adj_in(peer.ident)
         .map(|a| &a.v4.0)
+        .unwrap_or(&empty);
+    show_adj_rib_routes(table, bgp.router_id, json)
+}
+
+/// `show bgp neighbors <X> advertised-routes ipv6` — the v6-unicast twin
+/// of [`show_bgp_advertised`]. The IPv6 Adj-RIB-Out always lives on the
+/// peer (`adj_out.v6`); unlike the v4 path, v6 egress is never moved to
+/// the per-peer egress task (PET is v4-only), so this reads the peer copy
+/// directly at any shard count.
+fn show_bgp_advertised_ipv6(
+    bgp: &Bgp,
+    mut args: Args,
+    json: bool,
+) -> std::result::Result<String, std::fmt::Error> {
+    let addr = match args.addr() {
+        Some(addr) => addr,
+        None => return Ok(String::from("% No neighbor address specified")),
+    };
+
+    let peer = match bgp.peers.get(&addr) {
+        Some(peer) => peer,
+        None => return Ok(format!("% No such neighbor: {}", addr)),
+    };
+
+    show_adj_rib_routes(&peer.adj_out.v6.0, bgp.router_id, json)
+}
+
+/// `show bgp neighbors <X> received-routes ipv6` — the v6-unicast twin of
+/// [`show_bgp_received`]. The IPv6 Adj-RIB-In lives in main's `bgp.shard`
+/// (`route_ipv6_update` runs on `bgp.shard`, not the pool), so it is read
+/// directly with no scatter-gather — the v4 N>1 pool path has no v6 twin.
+fn show_bgp_received_ipv6(
+    bgp: &Bgp,
+    mut args: Args,
+    json: bool,
+) -> std::result::Result<String, std::fmt::Error> {
+    let addr = match args.addr() {
+        Some(addr) => addr,
+        None => return Ok(String::from("% No neighbor address specified")),
+    };
+
+    let peer = match bgp.peers.get(&addr) {
+        Some(peer) => peer,
+        None => return Ok(format!("% No such neighbor: {}", addr)),
+    };
+
+    let empty = BTreeMap::new();
+    let table = bgp
+        .shard
+        .adj_in(peer.ident)
+        .map(|a| &a.v6.0)
         .unwrap_or(&empty);
     show_adj_rib_routes(table, bgp.router_id, json)
 }
@@ -4622,12 +4673,16 @@ impl Bgp {
             .set(show_bgp_neighbor::<Bgp>)
             .path("/show/bgp/neighbors/advertised-routes")
             .set(show_bgp_advertised)
+            .path("/show/bgp/neighbors/advertised-routes/ipv6")
+            .set(show_bgp_advertised_ipv6)
             .path("/show/bgp/neighbors/advertised-routes/vpnv4")
             .set(show_bgp_advertised_vpnv4)
             .path("/show/bgp/neighbors/advertised-routes/evpn")
             .set(show_bgp_advertised_evpn)
             .path("/show/bgp/neighbors/received-routes")
             .set(show_bgp_received)
+            .path("/show/bgp/neighbors/received-routes/ipv6")
+            .set(show_bgp_received_ipv6)
             .path("/show/bgp/neighbors/received-routes/vpnv4")
             .set(show_bgp_received_vpnv4)
             .path("/show/bgp/neighbors/received-routes/evpn")

--- a/zebra-rs/src/config/parse.rs
+++ b/zebra-rs/src/config/parse.rs
@@ -1210,6 +1210,25 @@ mod tests {
                 "/show/bgp/neighbors",
                 vec!["2001:db8::1"],
             ),
+            // The v6-unicast Adj-RIB views: an `ipv6` leaf under each of
+            // the `advertised-routes` / `received-routes` containers. The
+            // neighbor key keeps the peer (a v6 address or interface name)
+            // as the only arg; `ipv6` is a child path element, not an arg.
+            (
+                "show bgp neighbors 2001:db8::1 advertised-routes ipv6",
+                "/show/bgp/neighbors/advertised-routes/ipv6",
+                vec!["2001:db8::1"],
+            ),
+            (
+                "show bgp neighbors 2001:db8::1 received-routes ipv6",
+                "/show/bgp/neighbors/received-routes/ipv6",
+                vec!["2001:db8::1"],
+            ),
+            (
+                "show bgp neighbors i1 received-routes ipv6",
+                "/show/bgp/neighbors/received-routes/ipv6",
+                vec!["i1"],
+            ),
         ];
 
         for &(cmd, want_path, ref want_args) in &cases {

--- a/zebra-rs/yang/exec.yang
+++ b/zebra-rs/yang/exec.yang
@@ -270,6 +270,10 @@ module exec {
         }
         container advertised-routes {
           presence "";
+          leaf ipv6 {
+            ext:help "IPv6 unicast Adj-RIB-Out";
+            type empty;
+          }
           leaf vpnv4 {
             type empty;
           }
@@ -280,6 +284,10 @@ module exec {
         }
         container received-routes {
           presence "";
+          leaf ipv6 {
+            ext:help "IPv6 unicast Adj-RIB-In";
+            type empty;
+          }
           leaf vpnv4 {
             type empty;
           }


### PR DESCRIPTION
## Summary

Adds the IPv6-unicast twins of the bare-IPv4 per-neighbor Adj-RIB views, alongside the existing `vpnv4` / `evpn` filters:

- `show bgp neighbors <X> advertised-routes ipv6` — IPv6 Adj-RIB-Out (`peer.adj_out.v6`)
- `show bgp neighbors <X> received-routes ipv6` — IPv6 Adj-RIB-In (`bgp.shard.adj_in(ident).v6`)

### Changes
- **`exec.yang`** — an `ipv6` leaf on the `advertised-routes` / `received-routes` containers.
- **`show.rs`** — `show_adj_rib_routes` made generic over the prefix type (it only renders `key.to_string()`, and `show_nexthop` already handles v6 nexthops); two v6 handlers + dispatch registration.
- **`parse.rs`** — parse() pins for the new spellings.
- **BDD** (`@bgp_neighbor_adj_rib_v6`) — 2-node v6 eBGP feature.

### Design note
Unlike v4, IPv6 egress always stays on the peer (`adj_out.v6` — the per-peer egress task is v4-only) and IPv6 ingest always stays in main's shard (`route_ipv6_update` never dispatches to the pool), so both reads are correct at any shard count — no PET/pool gather paths are needed.

## Test plan
- `cargo fmt` ✓, `cargo clippy --workspace --all-targets -- -D warnings` ✓
- `yang_load_tests` (25) ✓, full `zebra-rs` unit suite (1266) ✓ — including the new parse pins
- Live BDD: `✓ bgp_neighbor_adj_rib_v6 (3 scenarios) — 1 passed, 0 failed`, clean teardown

🤖 Generated with [Claude Code](https://claude.com/claude-code)