### PR TITLE
bgp: router bgp shards YANG knob (RIB sharding C.4)

### DIFF
--- a/bdd/tests/configs/bgp_shard_config_knob/z1-base.yaml
+++ b/bdd/tests/configs/bgp_shard_config_knob/z1-base.yaml
@@ -1,0 +1,15 @@
+router:
+  bgp:
+    global:
+      as: 65001
+      router-id: 10.0.0.1
+    timer:
+      adv-interval:
+        ebgp: 1
+    neighbor:
+    - remote-address: 10.0.0.2
+      afi-safi:
+      - name: ipv4
+        enabled: true
+      enabled: true
+      remote-as: 65002

--- a/bdd/tests/configs/bgp_shard_config_knob/z1-routes.yaml
+++ b/bdd/tests/configs/bgp_shard_config_knob/z1-routes.yaml
@@ -1,0 +1,20 @@
+router:
+  bgp:
+    global:
+      as: 65001
+      router-id: 10.0.0.1
+    timer:
+      adv-interval:
+        ebgp: 1
+    neighbor:
+    - remote-address: 10.0.0.2
+      afi-safi:
+      - name: ipv4
+        enabled: true
+      enabled: true
+      remote-as: 65002
+    afi-safi:
+    - name: ipv4
+      network:
+      - prefix: 10.10.10.0/24
+      - prefix: 10.10.11.0/24

--- a/bdd/tests/configs/bgp_shard_config_knob/z2.yaml
+++ b/bdd/tests/configs/bgp_shard_config_knob/z2.yaml
@@ -1,0 +1,22 @@
+router:
+  bgp:
+    global:
+      as: 65002
+      router-id: 10.0.0.2
+    shards: 4
+    timer:
+      adv-interval:
+        ebgp: 1
+    neighbor:
+    - remote-address: 10.0.0.1
+      afi-safi:
+      - name: ipv4
+        enabled: true
+      enabled: true
+      remote-as: 65001
+    - remote-address: 10.0.0.3
+      afi-safi:
+      - name: ipv4
+        enabled: true
+      enabled: true
+      remote-as: 65003

--- a/bdd/tests/configs/bgp_shard_config_knob/z3.yaml
+++ b/bdd/tests/configs/bgp_shard_config_knob/z3.yaml
@@ -1,0 +1,15 @@
+router:
+  bgp:
+    global:
+      as: 65003
+      router-id: 10.0.0.3
+    timer:
+      adv-interval:
+        ebgp: 1
+    neighbor:
+    - remote-address: 10.0.0.2
+      afi-safi:
+      - name: ipv4
+        enabled: true
+      enabled: true
+      remote-as: 65002

--- a/bdd/tests/cucumber.rs
+++ b/bdd/tests/cucumber.rs
@@ -581,6 +581,22 @@ async fn stop_zebra_rs(world: &mut World, namespace: String) {
     );
 }
 
+#[then(expr = "the zebra-rs log in namespace {string} should contain {string}")]
+async fn log_should_contain(world: &mut World, namespace: String, needle: String) {
+    let scoped = world.ns(&namespace);
+    let log_file = format!("logs/{}.log", scoped);
+    let contents = std::fs::read_to_string(&log_file)
+        .unwrap_or_else(|e| panic!("failed to read zebra-rs log {log_file}: {e}"));
+    assert!(
+        contents.contains(&needle),
+        "zebra-rs log {} for namespace {} does not contain {:?}",
+        log_file,
+        scoped,
+        needle
+    );
+    println!("✓ log {} contains {:?}", log_file, needle);
+}
+
 #[when(expr = "I apply config {string} to namespace {string}")]
 async fn apply_config(world: &mut World, config_file: String, namespace: String) {
     let config_path = format!("tests/configs/{}/{}", world.feature_tag, config_file);

--- a/bdd/tests/features/bgp_shard_config_knob.feature
+++ b/bdd/tests/features/bgp_shard_config_knob.feature
@@ -1,0 +1,74 @@
+@serial
+@bgp_shard_config_knob
+Feature: BGP RIB sharding configured via the router bgp shards YANG knob
+
+  Validates the C.4 shipping form of RIB sharding: the shard count comes
+  from config (`router bgp shards <1-64>`, zebra-bgp-sharding.yang) instead
+  of the `ZEBRA_BGP_SHARDS` environment variable. The sharded device z2 is
+  started with the PLAIN `start zebra-rs` step — no env var — and gets its
+  shard count purely from `shards: 4` in its applied config.
+
+  Sharding is behavior-transparent (the same correct result at N=1 and
+  N>1), so a correctness matrix alone cannot prove the knob actually
+  activated N=4 — it would pass even if the daemon silently fell back to
+  N=1. The decisive assertion is therefore the startup log line
+  `BGP RIB sharding: 4 shards (from config)`, emitted by `init_shard_count`
+  when `spawn_bgp` reads the leaf — which is true only if the knob resolved
+  to 4 from config. The route-propagation scenario then confirms the
+  config-sharded daemon ingests and forwards correctly end to end.
+
+  The env-driven N>1 read-path matrix (mirror, late-peer sync,
+  received-routes gather, withdraw, peer-down) is covered by the
+  bgp_shard_v4_sync feature; this one focuses on the config-knob plumbing.
+
+  Test Topology:
+  ```
+  z1 (AS65001) ── z2 (AS65002) ── z3 (AS65003)
+   10.0.0.1/24    10.0.0.2/24     10.0.0.3/24
+   origin         shards: 4       peer
+                  (from config)
+  ```
+  All three on bridge br0. z1 originates 10.10.10.0/24 + 10.10.11.0/24.
+
+  Scenario: z2 is sharded by config (not env) and the speakers establish
+    Given a clean test environment
+    When I create bridge "br0"
+    And I create namespace "z1" with IP "10.0.0.1/24" on bridge "br0"
+    And I create namespace "z2" with IP "10.0.0.2/24" on bridge "br0"
+    And I create namespace "z3" with IP "10.0.0.3/24" on bridge "br0"
+    And I start zebra-rs in namespace "z1"
+    And I start zebra-rs in namespace "z2"
+    And I start zebra-rs in namespace "z3"
+    And I apply config "z1-base.yaml" to namespace "z1"
+    And I apply config "z2.yaml" to namespace "z2"
+    And I apply config "z3.yaml" to namespace "z3"
+    And I wait 10 seconds for BGP to operate
+    # The decisive proof: z2 read `shards: 4` from its config (no env var was
+    # set) and spawned the pool with 4 shards. This line is emitted only when
+    # the knob resolves to 4 from config — N=1 would log "1 shard".
+    Then the zebra-rs log in namespace "z2" should contain "BGP RIB sharding: 4 shards (from config)"
+    And BGP session in "z2" to "10.0.0.1" should be "Established"
+    And BGP session in "z2" to "10.0.0.3" should be "Established"
+
+  Scenario: routes propagate through the config-sharded z2
+    Given the test topology exists
+    # z1 originates; the config-sharded z2 must ingest (pool), best-path, and
+    # advertise to z3 — proving the knob's pool is functional, not just
+    # spawned. z2's own `show bgp ipv4` reads the N>1 read-replica mirror.
+    When I apply config "z1-routes.yaml" to namespace "z1"
+    And I wait 10 seconds for BGP to operate
+    Then show command "show bgp ipv4" in namespace "z2" should contain "10.10.10.0/24"
+    And show command "show bgp ipv4" in namespace "z2" should contain "10.10.11.0/24"
+    And show command "show bgp ipv4" in namespace "z3" should contain "10.10.10.0/24"
+    And show command "show bgp ipv4" in namespace "z3" should contain "10.10.11.0/24"
+
+  Scenario: Teardown topology
+    Given the test topology exists
+    When I stop zebra-rs in namespace "z1"
+    And I stop zebra-rs in namespace "z2"
+    And I stop zebra-rs in namespace "z3"
+    And I delete namespace "z1"
+    And I delete namespace "z2"
+    And I delete namespace "z3"
+    And I delete bridge "br0"
+    Then the test environment should be clean

--- a/zebra-rs/src/bgp/inst.rs
+++ b/zebra-rs/src/bgp/inst.rs
@@ -383,19 +383,56 @@ pub struct RibKnownVrf {
     pub inter_as_hybrid: bool,
 }
 
-/// Number of parallel RIB shards (RIB sharding Phase C), read once from
-/// the `ZEBRA_BGP_SHARDS` environment variable at instance construction.
-/// `1` (default, and when unset/invalid) keeps the synchronous
-/// single-shard path (BDD-safe); `> 1` spawns that many worker threads and
-/// fans ingest out by prefix hash. Startup-only — live resharding is out
-/// of scope (the pool spawns in [`Bgp::new`] before any route state). The
-/// value is clamped to `1..=64`.
-pub fn shard_count() -> usize {
+/// Process-global shard count, frozen once at BGP instance spawn by
+/// [`init_shard_count`]. A `OnceLock` (not a per-call env read) so the value
+/// the shard pool spawns with is the exact same one `egress_pool()`
+/// (route.rs) reads when sizing itself — they must agree or shards + egress
+/// workers oversubscribe the cores (the Phase E.2 invariant).
+static SHARD_COUNT: std::sync::OnceLock<usize> = std::sync::OnceLock::new();
+
+/// The `ZEBRA_BGP_SHARDS` environment variable (the pre-C.4 form, now the
+/// fallback when the YANG `shards` leaf is unset). `None` if unset/invalid.
+fn shard_count_env() -> Option<usize> {
     std::env::var("ZEBRA_BGP_SHARDS")
         .ok()
         .and_then(|s| s.parse::<usize>().ok())
+}
+
+/// Pure resolution policy (unit-tested): the YANG `router bgp shards <n>`
+/// leaf (C.4) wins over the env var, which wins over the default `1`. The
+/// chosen value is clamped to `1..=64` (so `0` and out-of-range fold to the
+/// nearest valid degree).
+fn resolve_shard_count(config_shards: Option<usize>, env_shards: Option<usize>) -> usize {
+    config_shards
+        .or(env_shards)
         .map(|n| n.clamp(1, 64))
         .unwrap_or(1)
+}
+
+/// Freeze the shard count at instance spawn from the YANG `shards` leaf
+/// (else `ZEBRA_BGP_SHARDS`, else `1`). Called once from `spawn_bgp` before
+/// [`Bgp::new`] constructs the pool; the result is stored process-globally
+/// so [`shard_count`] returns it everywhere (the shard pool and the egress
+/// pool alike). Idempotent — `spawn_bgp` short-circuits a re-spawn, and the
+/// first frozen value wins regardless.
+pub fn init_shard_count(config_shards: Option<usize>) -> usize {
+    let n = resolve_shard_count(config_shards, shard_count_env());
+    let _ = SHARD_COUNT.set(n);
+    shard_count()
+}
+
+/// Number of parallel RIB shards (RIB sharding Phase C). Returns the value
+/// frozen at spawn by [`init_shard_count`]; before any instance spawns
+/// (unit tests / env-only paths) it falls back to `ZEBRA_BGP_SHARDS`, then
+/// `1`. `1` keeps the synchronous single-shard path (BDD-safe); `> 1` fans
+/// ingest out by prefix hash across that many worker threads. Startup-only —
+/// live resharding is out of scope (the pool spawns in [`Bgp::new`] before
+/// any route state). Always in `1..=64`.
+pub fn shard_count() -> usize {
+    SHARD_COUNT
+        .get()
+        .copied()
+        .unwrap_or_else(|| resolve_shard_count(None, shard_count_env()))
 }
 
 /// A2 step ① — per-`req_id` barrier for in-flight `DumpV4` dumps. Each
@@ -4335,6 +4372,22 @@ mod tests {
 
     fn addr(s: &str) -> IpAddr {
         s.parse().unwrap()
+    }
+
+    #[test]
+    fn shard_count_resolution_policy() {
+        use super::resolve_shard_count;
+        // C.4: the YANG `shards` leaf wins over the env var...
+        assert_eq!(resolve_shard_count(Some(4), Some(8)), 4);
+        // ...the env var is the fallback when the leaf is unset...
+        assert_eq!(resolve_shard_count(None, Some(8)), 8);
+        // ...and `1` (synchronous) is the default when neither is set.
+        assert_eq!(resolve_shard_count(None, None), 1);
+        // The chosen value is clamped to 1..=64 from either source.
+        assert_eq!(resolve_shard_count(Some(100), None), 64);
+        assert_eq!(resolve_shard_count(Some(0), None), 1);
+        assert_eq!(resolve_shard_count(None, Some(0)), 1);
+        assert_eq!(resolve_shard_count(None, Some(999)), 64);
     }
 
     #[test]

--- a/zebra-rs/src/bgp/inst.rs
+++ b/zebra-rs/src/bgp/inst.rs
@@ -418,7 +418,20 @@ fn resolve_shard_count(config_shards: Option<usize>, env_shards: Option<usize>) 
 pub fn init_shard_count(config_shards: Option<usize>) -> usize {
     let n = resolve_shard_count(config_shards, shard_count_env());
     let _ = SHARD_COUNT.set(n);
-    shard_count()
+    let n = shard_count();
+    let source = if config_shards.is_some() {
+        "config"
+    } else if shard_count_env().is_some() {
+        "ZEBRA_BGP_SHARDS"
+    } else {
+        "default"
+    };
+    if n > 1 {
+        tracing::info!("BGP RIB sharding: {n} shards (from {source})");
+    } else {
+        tracing::info!("BGP RIB sharding: 1 shard, synchronous (from {source})");
+    }
+    n
 }
 
 /// Number of parallel RIB shards (RIB sharding Phase C). Returns the value

--- a/zebra-rs/src/config/bgp.rs
+++ b/zebra-rs/src/config/bgp.rs
@@ -9,6 +9,20 @@ pub fn spawn_bgp(config: &ConfigManager) {
     // replace the live task and tear down every BGP session + Loc-RIB.
     // Config reaches the running instance via its `cm` subscription.
     if config.protocol_tasks.borrow().contains_key("bgp") {
+        // Already spawned. The shard count (C.4 `router bgp shards <n>`) is
+        // frozen at spawn — the pool can't be resized without re-hashing the
+        // whole RIB — so warn rather than silently diverge if the operator
+        // changes it on the live instance.
+        if let Some(requested) = configured_shards(config) {
+            let live = inst::shard_count();
+            if requested.clamp(1, 64) != live {
+                tracing::warn!(
+                    "router bgp shards {requested} ignored: the shard count is fixed \
+                     at {live} for the BGP instance lifetime — clear `router bgp` or \
+                     restart the daemon to re-shard"
+                );
+            }
+        }
         return;
     }
     // Capture BFD / ND client handles so per-neighbor `bfd { enable }`
@@ -23,6 +37,9 @@ pub fn spawn_bgp(config: &ConfigManager) {
     let nd_client_tx = config.nd_client_tx.borrow().clone();
     let (rib_client, rib_rx) = config.subscribe_to_rib("bgp");
     let ctx = crate::context::ProtoContext::default_table(rib_client);
+    // C.4: freeze the shard count from the `router bgp shards <n>` leaf (else
+    // `ZEBRA_BGP_SHARDS`, else 1) before `Bgp::new` spawns the pool.
+    inst::init_shard_count(configured_shards(config));
     let bgp = inst::Bgp::new(
         ctx,
         rib_rx,
@@ -53,4 +70,58 @@ pub fn despawn_bgp(config: &ConfigManager) {
     let _ = config.rib_tx.send(rib::Message::ProtoCleanup {
         proto: "bgp".to_string(),
     });
+}
+
+/// Read the `router bgp shards <n>` leaf (RIB sharding C.4) from the
+/// committed candidate config, if set. Scans the flattened config lines —
+/// the same text `commit_config`'s `proto_in_candidate` reads — rather than
+/// the diff, so the value is visible at spawn regardless of where the
+/// `shards` line sits in the triggering commit (no node-ordering or
+/// "evaluate before `router bgp`" dependency). `None` ⇒ the caller falls
+/// back to `ZEBRA_BGP_SHARDS` / the default.
+fn configured_shards(config: &ConfigManager) -> Option<usize> {
+    let mut text = String::new();
+    config.store.candidate.borrow().list(&mut text);
+    shards_from_config_text(&text)
+}
+
+/// Pure line-scan (unit-tested): pull the `shards` value out of the
+/// flattened config text. The leaf augments `router bgp` directly, so the
+/// `Config::list` line is `router bgp shards <n>` — the same flattened form
+/// `proto_in_candidate` matches and the `bgp_shards_grammar` parse test
+/// pins.
+fn shards_from_config_text(text: &str) -> Option<usize> {
+    text.lines().find_map(|line| {
+        line.strip_prefix("router bgp shards ")?
+            .trim()
+            .parse::<usize>()
+            .ok()
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::shards_from_config_text;
+
+    #[test]
+    fn shards_line_scan() {
+        // Picked out among other `router bgp` lines.
+        assert_eq!(
+            shards_from_config_text(
+                "router bgp shards 4\nrouter bgp neighbor 10.0.0.1 remote-as 65000\n"
+            ),
+            Some(4)
+        );
+        // Order-independent — a preceding unrelated line doesn't hide it.
+        assert_eq!(
+            shards_from_config_text("interface eth0\nrouter bgp shards 8\n"),
+            Some(8)
+        );
+        // Absent ⇒ None (caller falls back to env / default).
+        assert_eq!(
+            shards_from_config_text("router bgp neighbor 10.0.0.1 remote-as 65000\n"),
+            None
+        );
+        assert_eq!(shards_from_config_text(""), None);
+    }
 }

--- a/zebra-rs/src/config/manager.rs
+++ b/zebra-rs/src/config/manager.rs
@@ -1378,6 +1378,45 @@ mod yang_load_tests {
         }
     }
 
+    /// C.4 `router bgp shards <1-64>` — the shipping form of the
+    /// `ZEBRA_BGP_SHARDS` env var (`zebra-bgp-sharding.yang`). Pinned
+    /// because vtyctl apply is garbage-tolerant — an unwired grammar
+    /// silently no-ops, and `configured_shards` reads this leaf at spawn,
+    /// so a broken path would just fall back to the env/default with no
+    /// visible error.
+    #[test]
+    fn bgp_shards_grammar() {
+        use crate::config::ExecCode;
+        use crate::config::parse::{State, parse};
+        use libyang::to_entry;
+
+        let mut yang = YangStore::new();
+        yang.add_path(concat!(env!("CARGO_MANIFEST_DIR"), "/yang"));
+        yang.read_with_resolve("configure")
+            .expect("configure mode loads");
+        yang.identity_resolve();
+        let module = yang
+            .find_module("configure")
+            .expect("configure module present");
+        let entry = to_entry(&yang, module);
+
+        // The shards leaf must be a settable path directly under `router
+        // bgp` across the valid range — this is the exact text
+        // `configured_shards` scans for (`router bgp shards <n>`).
+        for cmd in [
+            "set router bgp shards 1",
+            "set router bgp shards 4",
+            "set router bgp shards 64",
+        ] {
+            let (code, _comps, _state) = parse(cmd, entry.clone(), None, State::new());
+            assert_eq!(
+                code,
+                ExecCode::Success,
+                "should parse as a settable path: {cmd}"
+            );
+        }
+    }
+
     /// TI-LFA parallel-computation knobs: `fast-reroute ti-lfa
     /// compute-mode <serial|conservative|aggressive|sharding>` plus
     /// `compute-shards <1..256>`. Pinned because vtyctl apply is

--- a/zebra-rs/yang/config.yang
+++ b/zebra-rs/yang/config.yang
@@ -32,6 +32,10 @@ module config {
     prefix zba;
   }
 
+  import zebra-bgp-sharding {
+    prefix zbsh;
+  }
+
   import zebra-bgp-vrf {
     prefix zbv;
   }

--- a/zebra-rs/yang/zebra-bgp-sharding.yang
+++ b/zebra-rs/yang/zebra-bgp-sharding.yang
@@ -1,0 +1,84 @@
+module zebra-bgp-sharding {
+  yang-version "1";
+
+  namespace "urn:ietf:params:xml:ns:yang:zebra-bgp-sharding";
+  prefix "zbsh";
+
+  import config {
+    prefix config;
+  }
+
+  import ietf-bgp {
+    prefix bgp;
+  }
+
+  import configure {
+    prefix configure;
+  }
+
+  import extension {
+    prefix ext;
+  }
+
+  organization
+    "zebra-rs";
+
+  contact
+    "https://github.com/zebra-rs";
+
+  description
+    "BGP RIB sharding degree (RIB sharding Phase C / C.4) — the shipping
+     form of the ZEBRA_BGP_SHARDS environment variable. Sets the number of
+     parallel worker shards the BGP speaker fans plain IPv4-unicast ingest /
+     best-path / egress across, hashed by prefix. `1` (default) keeps the
+     synchronous single-shard path; `> 1` spawns that many dedicated worker
+     threads.
+
+     Startup-only: the shard pool is created when the BGP instance spawns
+     (the first `router bgp` commit), so the value is read once and fixed for
+     the instance's lifetime — the pool cannot be resized without re-hashing
+     the whole RIB. Changing it on a live instance is ignored with a warning;
+     clear `router bgp` (which tears the instance down) or restart the daemon
+     to re-shard. When this leaf is unset the daemon falls back to the
+     `ZEBRA_BGP_SHARDS` environment variable, then to `1`.
+
+     Resulting config shape:
+
+       router bgp {
+         shards 4;
+       }";
+
+  grouping bgp-sharding-extension {
+    description
+      "Sharding degree leaf hung off `router bgp`.";
+    leaf shards {
+      ext:help "Number of parallel RIB shards (1-64, default 1)";
+      type uint8 {
+        range "1..64";
+      }
+      description
+        "Number of parallel BGP RIB worker shards. 1 = synchronous
+         single-shard path (default when unset). Read once at instance
+         spawn and immutable thereafter (live resharding is out of scope).
+         No YANG default is declared on purpose: an unset leaf must stay
+         absent so it does not shadow the ZEBRA_BGP_SHARDS fallback.";
+    }
+  }
+
+  /* =========================================================
+   * Augments into the zebra-rs configure tree
+   * ========================================================= */
+
+  augment "/configure:set/config:router/bgp:bgp" {
+    description
+      "Attach the shards leaf in the candidate-set subtree.";
+    uses bgp-sharding-extension;
+  }
+
+  augment "/configure:delete/config:router/bgp:bgp" {
+    description
+      "Same attachment for the delete subtree so
+       `delete router bgp shards` is path-valid.";
+    uses bgp-sharding-extension;
+  }
+}


### PR DESCRIPTION
## Summary

Adds `router bgp shards <1-64>` — the shipping (C.4) form of RIB sharding,
replacing the `ZEBRA_BGP_SHARDS` environment variable with a YANG config
knob (`zebra-bgp-sharding.yang`, augmenting `/config:router/bgp:bgp`).

The chicken-and-egg — the shard pool spawns inside `Bgp::new`, before
steady-state config consumption — is resolved without any node-ordering /
priority mechanism: `spawn_bgp` already holds the whole atomically-committed
config, so `configured_shards` reads the value at the single spawn point
regardless of where the line sits in the commit. `init_shard_count` freezes
the resolved degree (leaf > env > 1, clamped 1..=64) into a process-global
`OnceLock` before `Bgp::new`, so the shard pool and the Phase E.2
`egress_pool()` agree on the count automatically.

Startup-only by nature (the pool can't be resized without re-hashing the
whole RIB): a `shards` change on a live instance is ignored with a warning
(clear `router bgp` or restart), not silently diverged. The env var remains
the fallback, so the existing env-based BDDs are unchanged.

A startup INFO line reports the resolved count and its source
(`config` / `ZEBRA_BGP_SHARDS` / `default`) — operator visibility, and the
observable the BDD asserts on.

## Test plan

- **Unit** (`cargo test --workspace --exclude bdd`, all green): `resolve_shard_count`
  precedence + clamp; `shards_from_config_text` line scan; `bgp_shards_grammar`
  pins `set router bgp shards <n>` as a settable path; `configure_mode_loads`
  validates the new module + augments resolve.
- **BDD `@bgp_shard_config_knob`** (3/3): the sharded device is started with
  the *plain* step (no env var) and sharded purely via `shards: 4` in its
  config. Since sharding is behavior-transparent, the decisive assertion is
  the startup log `BGP RIB sharding: 4 shards (from config)` — true only if
  the knob resolved to 4 from config — plus end-to-end route propagation.
- **Regression**: `@bgp_shard_v4_sync` (env path) stays 7/7.
- fmt + `cargo clippy --workspace --all-targets -- -D warnings` clean.

Note: BDD is excluded from CI; the daemon loads YANG from the installed
`/etc/zebra-rs/yang`, so running the BDD locally needs the new module synced
there (`make` install target / `sudo cp zebra-rs/yang/*.yang /etc/zebra-rs/yang/`).

Generated with [Claude Code](https://claude.com/claude-code)
