### PR TITLE
bgp: strip iBGP-only attrs from eBGP advertisements

### DIFF
--- a/bdd/tests/configs/bgp_rr_ebgp_strip/z1.yaml
+++ b/bdd/tests/configs/bgp_rr_ebgp_strip/z1.yaml
@@ -1,0 +1,25 @@
+router:
+  bgp:
+    global:
+      as: 65001
+      router-id: 10.0.0.1
+    timer:
+      adv-interval:
+        ebgp: 3
+    neighbor:
+    - remote-address: 192.168.0.2
+      afi-safi:
+      - name: ipv4
+        enabled: true
+      enabled: true
+      remote-as: 65001
+      route-reflector:
+        client: true
+    - remote-address: 192.168.0.3
+      afi-safi:
+      - name: ipv4
+        enabled: true
+      enabled: true
+      remote-as: 65001
+      route-reflector:
+        client: true

--- a/bdd/tests/configs/bgp_rr_ebgp_strip/z2.yaml
+++ b/bdd/tests/configs/bgp_rr_ebgp_strip/z2.yaml
@@ -1,0 +1,16 @@
+router:
+  bgp:
+    global:
+      as: 65001
+      router-id: 10.0.0.2
+    neighbor:
+    - remote-address: 192.168.0.1
+      afi-safi:
+      - name: ipv4
+        enabled: true
+      enabled: true
+      remote-as: 65001
+    afi-safi:
+    - name: ipv4
+      network:
+      - prefix: 10.10.10.0/24

--- a/bdd/tests/configs/bgp_rr_ebgp_strip/z3.yaml
+++ b/bdd/tests/configs/bgp_rr_ebgp_strip/z3.yaml
@@ -1,0 +1,21 @@
+router:
+  bgp:
+    global:
+      as: 65001
+      router-id: 10.0.0.3
+    timer:
+      adv-interval:
+        ebgp: 3
+    neighbor:
+    - remote-address: 192.168.0.1
+      afi-safi:
+      - name: ipv4
+        enabled: true
+      enabled: true
+      remote-as: 65001
+    - remote-address: 192.168.0.4
+      afi-safi:
+      - name: ipv4
+        enabled: true
+      enabled: true
+      remote-as: 65002

--- a/bdd/tests/configs/bgp_rr_ebgp_strip/z4.yaml
+++ b/bdd/tests/configs/bgp_rr_ebgp_strip/z4.yaml
@@ -1,0 +1,15 @@
+router:
+  bgp:
+    global:
+      as: 65002
+      router-id: 10.0.0.4
+    timer:
+      adv-interval:
+        ebgp: 3
+    neighbor:
+    - remote-address: 192.168.0.3
+      afi-safi:
+      - name: ipv4
+        enabled: true
+      enabled: true
+      remote-as: 65001

--- a/bdd/tests/features/bgp_rr_ebgp_strip.feature
+++ b/bdd/tests/features/bgp_rr_ebgp_strip.feature
@@ -1,0 +1,109 @@
+@serial
+@bgp_rr_ebgp_strip
+Feature: BGP iBGP-only attributes are stripped on eBGP egress
+  As a network operator
+  I want the iBGP-only path attributes — ORIGINATOR_ID, CLUSTER_LIST and
+  LOCAL_PREF — to stay inside the AS
+  So that an iBGP-learned route re-advertised to an eBGP peer does not leak
+  attributes that have meaning only within the local AS.
+
+  RFC 4456 §8 defines ORIGINATOR_ID (type 9) and CLUSTER_LIST (type 10) as
+  optional NON-TRANSITIVE attributes that carry meaning only within the
+  local AS (the originating router-id and the intra-AS reflection path).
+  They MUST NOT cross an AS boundary: leaking them risks spurious loop
+  drops at a remote AS that happens to share a router-id / cluster-id.
+  RFC 4271 §5.1.5 likewise forbids sending LOCAL_PREF to external peers.
+
+  Test Topology:
+  ```
+  ┌────────────────────────────────────────────────────────────────────────┐
+  │                                  br0                                   │
+  └────────┬──────────────────┬──────────────────┬──────────────────┬─────┘
+           │                  │                  │                  │
+      ┌────┴────┐        ┌────┴────┐        ┌────┴────┐        ┌────┴────┐
+      │   z1    │  iBGP  │   z2    │        │   z3    │  eBGP  │   z4    │
+      │  (RR)   │◀──────▶│(client) │        │(client) │◀──────▶│ (peer)  │
+      │ AS65001 │        │ AS65001 │        │+ border │        │ AS65002 │
+      │id 10.0. │        │id 10.0. │        │ AS65001 │        │id 10.0. │
+      │   0.1   │        │   0.2   │        │id 10.0. │        │   0.4   │
+      │192.168. │        │192.168. │        │   0.3   │        │192.168. │
+      │  0.1/24 │        │  0.2/24 │        │192.168. │        │  0.4/24 │
+      └────┬────┘        └─────────┘        │  0.3/24 │        └─────────┘
+           │ iBGP (RR client)               └────┬────┘
+           └─────────────────────────────────────┘
+  ```
+  - z1 is the route reflector; z2 and z3 are its clients (same AS 65001).
+  - z2 originates 10.10.10.0/24 and advertises it to the RR (z1).
+  - z1 REFLECTS the route to client z3, stamping ORIGINATOR_ID (z2's
+    router-id 10.0.0.2) and CLUSTER_LIST (z1's cluster-id). z3 therefore
+    sees the route WITH the route-reflection attributes — the positive
+    control proving the route really traversed a reflector.
+  - z3 re-advertises the route to its eBGP peer z4 (AS 65002). z4 MUST
+    receive the route WITHOUT ORIGINATOR_ID / CLUSTER_LIST.
+
+  Config files:
+  - z1.yaml: RR — iBGP to z2 and z3, both route-reflector clients.
+  - z2.yaml: client — iBGP to z1; originates 10.10.10.0/24.
+  - z3.yaml: client + border — iBGP to z1, eBGP to z4.
+  - z4.yaml: eBGP peer — eBGP to z3 only.
+
+  Scenario: Setup topology and establish BGP sessions
+    Given a clean test environment
+    When I create bridge "br0"
+    And I create namespace "z1" with IP "192.168.0.1/24" on bridge "br0"
+    And I create namespace "z2" with IP "192.168.0.2/24" on bridge "br0"
+    And I create namespace "z3" with IP "192.168.0.3/24" on bridge "br0"
+    And I create namespace "z4" with IP "192.168.0.4/24" on bridge "br0"
+    And I start zebra-rs in namespace "z1"
+    And I start zebra-rs in namespace "z2"
+    And I start zebra-rs in namespace "z3"
+    And I start zebra-rs in namespace "z4"
+    And I apply config "z1.yaml" to namespace "z1"
+    And I apply config "z2.yaml" to namespace "z2"
+    And I apply config "z3.yaml" to namespace "z3"
+    And I apply config "z4.yaml" to namespace "z4"
+    And I wait 5 seconds for BGP to operate
+    Then BGP session in "z1" to "192.168.0.2" should be "Established"
+    And BGP session in "z1" to "192.168.0.3" should be "Established"
+    And BGP session in "z2" to "192.168.0.1" should be "Established"
+    And BGP session in "z3" to "192.168.0.1" should be "Established"
+    And BGP session in "z3" to "192.168.0.4" should be "Established"
+    And BGP session in "z4" to "192.168.0.3" should be "Established"
+
+  Scenario: RR client z3 receives the reflected route WITH the iBGP-only attributes
+    Given the test topology exists
+    When I wait 15 seconds for BGP to operate
+    Then BGP route in "z3" has "10.10.10.0/24"
+    And show command "show bgp ipv4 10.10.10.0/24" in namespace "z3" should eventually contain "BGP routing table entry for 10.10.10.0/24"
+    # ORIGINATOR_ID / CLUSTER_LIST stamped by the reflector (RFC 4456), and
+    # LOCAL_PREF carried across the iBGP path (RFC 4271 §5.1.5).
+    And show command "show bgp ipv4 10.10.10.0/24" in namespace "z3" should eventually contain "Originator: 10.0.0.2"
+    And show command "show bgp ipv4 10.10.10.0/24" in namespace "z3" should contain "Cluster list:"
+    And show command "show bgp ipv4 10.10.10.0/24" in namespace "z3" should contain "localpref"
+
+  Scenario: eBGP peer z4 receives the route but NOT the iBGP-only attributes
+    Given the test topology exists
+    When I wait 15 seconds for BGP to operate
+    # Positive guard first: prove the route is actually present (an unmatched
+    # show command returns empty output, which would make a bare "should not
+    # contain" pass vacuously).
+    Then BGP route in "z4" has "10.10.10.0/24"
+    And show command "show bgp ipv4 10.10.10.0/24" in namespace "z4" should eventually contain "BGP routing table entry for 10.10.10.0/24"
+    # The iBGP-only attributes must not cross the AS boundary: ORIGINATOR_ID /
+    # CLUSTER_LIST (RFC 4456) and LOCAL_PREF (RFC 4271 §5.1.5).
+    And show command "show bgp ipv4 10.10.10.0/24" in namespace "z4" should not contain "Originator:"
+    And show command "show bgp ipv4 10.10.10.0/24" in namespace "z4" should not contain "Cluster list:"
+    And show command "show bgp ipv4 10.10.10.0/24" in namespace "z4" should not contain "localpref"
+
+  Scenario: Teardown topology
+    Given the test topology exists
+    When I stop zebra-rs in namespace "z1"
+    And I stop zebra-rs in namespace "z2"
+    And I stop zebra-rs in namespace "z3"
+    And I stop zebra-rs in namespace "z4"
+    And I delete namespace "z1"
+    And I delete namespace "z2"
+    And I delete namespace "z3"
+    And I delete namespace "z4"
+    And I delete bridge "br0"
+    Then the test environment should be clean

--- a/zebra-rs/src/bgp/route.rs
+++ b/zebra-rs/src/bgp/route.rs
@@ -3640,6 +3640,13 @@ pub fn route_update_evpn(
     if peer.is_ibgp() && attrs.local_pref.is_none() {
         attrs.local_pref = Some(LocalPref::default());
     }
+    // Strip the iBGP-only attributes (RR attrs + LOCAL_PREF) on the eBGP
+    // egress path — AFI/SAFI-agnostic: an iBGP-learned EVPN route reflected by
+    // an upstream RR carries them through the cloned attrs. See
+    // `strip_ibgp_only_attrs`.
+    if peer.is_ebgp() {
+        strip_ibgp_only_attrs(&mut attrs);
+    }
 
     Some((route, attrs))
 }
@@ -6298,6 +6305,11 @@ pub fn route_update_flowspec(
     if peer.is_ibgp() && attrs.local_pref.is_none() {
         attrs.local_pref = Some(LocalPref::default());
     }
+    // Strip the iBGP-only attributes (RR attrs + LOCAL_PREF) on the eBGP
+    // egress path (AFI/SAFI-agnostic — see `strip_ibgp_only_attrs`).
+    if peer.is_ebgp() {
+        strip_ibgp_only_attrs(&mut attrs);
+    }
     // Flow specs have no next-hop in MP_REACH; don't emit a NEXT_HOP.
     attrs.nexthop = None;
 
@@ -7610,6 +7622,30 @@ fn llgr_blocks_advertisement(
     rib_stale && !cap_recv.llgr.contains_key(&AfiSafi::new(afi, safi))
 }
 
+/// Strip the iBGP-only path attributes that MUST NOT cross an AS boundary,
+/// for use on the eBGP egress path. An iBGP-learned route re-advertised to an
+/// eBGP peer carries these through the cloned `rib.attr`, so they have to be
+/// removed here:
+///
+/// - ORIGINATOR_ID / CLUSTER_LIST (RFC 4456 §8): optional *non-transitive*
+///   attributes that only carry meaning within the local AS — the route's
+///   originator router-id and the intra-AS reflection path used for loop
+///   prevention. Leaking them risks spurious loop drops at a remote AS that
+///   happens to share a router-id (ORIGINATOR_ID match) or cluster-id
+///   (CLUSTER_LIST match).
+/// - LOCAL_PREF (RFC 4271 §5.1.5): a well-known attribute a BGP speaker "MUST
+///   NOT include … in UPDATE messages it sends to external peers" (the
+///   confederation exception does not apply — zebra-rs has no confederation
+///   peering, so every `PeerType::EBGP` is a true AS boundary).
+///
+/// Mirrors BIRD (UNSET when `!is_internal`) and GoBGP (delPathAttr for
+/// non-internal peers).
+fn strip_ibgp_only_attrs(attrs: &mut BgpAttr) {
+    attrs.originator_id = None;
+    attrs.cluster_list = None;
+    attrs.local_pref = None;
+}
+
 pub fn route_update_ipv4(
     ctx: &SyncCtx,
     prefix: &Ipv4Net,
@@ -7744,6 +7780,13 @@ pub fn route_update_ipv4(
         }
     }
 
+    // 8. Strip the iBGP-only attributes (ORIGINATOR_ID / CLUSTER_LIST /
+    // LOCAL_PREF) before they cross the AS boundary. Mutually exclusive with
+    // the iBGP stamping/local-pref-default above; see `strip_ibgp_only_attrs`.
+    if ctx.peer_type.is_ebgp() {
+        strip_ibgp_only_attrs(&mut attrs);
+    }
+
     Some((nlri, attrs))
 }
 
@@ -7870,6 +7913,11 @@ pub fn route_update_ipv6(
             cluster_list.list.push(*bgp.router_id);
             attrs.cluster_list = Some(cluster_list);
         }
+    }
+    // Strip the iBGP-only attributes (RR attrs + LOCAL_PREF) on the eBGP
+    // egress path; see `strip_ibgp_only_attrs`.
+    if peer.is_ebgp() {
+        strip_ibgp_only_attrs(&mut attrs);
     }
 
     // The two SRv6 hooks below apply only to plain IPv6 unicast rows.
@@ -8197,6 +8245,11 @@ fn route_update_labelv4(
             attrs.cluster_list = Some(cluster_list);
         }
     }
+    // Strip the iBGP-only attributes (RR attrs + LOCAL_PREF) on the eBGP
+    // egress path; see `strip_ibgp_only_attrs`.
+    if peer.is_ebgp() {
+        strip_ibgp_only_attrs(&mut attrs);
+    }
 
     attrs.nexthop = None;
     // Next-hop-self makes us the forwarding hop: advertise our per-prefix
@@ -8270,6 +8323,11 @@ fn route_update_labelv6(
             cluster_list.list.push(*bgp.router_id);
             attrs.cluster_list = Some(cluster_list);
         }
+    }
+    // Strip the iBGP-only attributes (RR attrs + LOCAL_PREF) on the eBGP
+    // egress path; see `strip_ibgp_only_attrs`.
+    if peer.is_ebgp() {
+        strip_ibgp_only_attrs(&mut attrs);
     }
 
     attrs.nexthop = None;

--- a/zebra-rs/src/bgp/sr_policy.rs
+++ b/zebra-rs/src/bgp/sr_policy.rs
@@ -765,6 +765,9 @@ pub fn config_srp_segment_srv6_sid(bgp: &mut Bgp, mut args: Args, op: ConfigOp) 
 /// - On an iBGP→iBGP reflection the ORIGINATOR_ID is stamped (with the
 ///   original advertiser's router-id if absent) and the local router-id
 ///   is prepended to the CLUSTER_LIST.
+/// - On an eBGP egress the iBGP-only attributes are stripped: ORIGINATOR_ID
+///   and CLUSTER_LIST (RFC 4456: non-transitive, intra-AS-only) and LOCAL_PREF
+///   (RFC 4271 §5.1.5: never sent to external peers).
 pub fn reflect_attr(
     attr: &BgpAttr,
     source_ibgp: bool,
@@ -796,6 +799,15 @@ pub fn reflect_attr(
                 out.cluster_list = Some(cl);
             }
         }
+    } else if !dest_ibgp {
+        // Strip the iBGP-only attributes before reflecting to an eBGP peer (an
+        // iBGP-learned policy carries them through the cloned attr):
+        // ORIGINATOR_ID / CLUSTER_LIST are non-transitive intra-AS attributes
+        // (RFC 4456) and LOCAL_PREF must not cross an AS boundary (RFC 4271
+        // §5.1.5).
+        out.originator_id = None;
+        out.cluster_list = None;
+        out.local_pref = None;
     }
     Some(out)
 }
@@ -1343,6 +1355,27 @@ mod tests {
         let out = reflect_attr(&attr, false, v4("2.2.2.2"), true, false, v4("1.1.1.1")).unwrap();
         assert!(out.originator_id.is_none());
         assert!(out.cluster_list.is_none());
+    }
+
+    #[test]
+    fn reflect_attr_strips_ibgp_only_attrs_to_ebgp() {
+        // An iBGP-learned policy carries the iBGP-only attributes; when it is
+        // advertised to an eBGP peer they MUST be stripped: ORIGINATOR_ID /
+        // CLUSTER_LIST (RFC 4456, non-transitive intra-AS) and LOCAL_PREF
+        // (RFC 4271 §5.1.5, never sent to external peers).
+        let attr = BgpAttr {
+            originator_id: Some(OriginatorId::new(v4("9.9.9.9"))),
+            cluster_list: Some(ClusterList {
+                list: vec![v4("3.3.3.3")],
+            }),
+            local_pref: Some(bgp_packet::LocalPref::new(200)),
+            ..Default::default()
+        };
+        // source iBGP, dest eBGP (dest_ibgp = false).
+        let out = reflect_attr(&attr, true, v4("2.2.2.2"), false, false, v4("1.1.1.1")).unwrap();
+        assert!(out.originator_id.is_none());
+        assert!(out.cluster_list.is_none());
+        assert!(out.local_pref.is_none());
     }
 
     #[test]


### PR DESCRIPTION
## Summary

ORIGINATOR_ID and CLUSTER_LIST (RFC 4456 §8) are optional **non-transitive** attributes that only carry meaning within the local AS, and LOCAL_PREF (RFC 4271 §5.1.5) must **never** be sent to external peers. Each BGP egress builder clones the route's stored attributes, so an iBGP-learned route re-advertised to an eBGP peer **leaked all three across the AS boundary** — risking spurious loop drops at a remote AS that shares a router-id / cluster-id.

This adds a `strip_ibgp_only_attrs` helper and calls it on the eBGP egress path of **every** builder — v4/v6 unicast, labeled-v4/v6, EVPN, Flowspec — plus the SR-Policy `reflect_attr` eBGP branch.

No confederation peering exists in zebra-rs (`ebgp_egress_aspath` only ever prepends an AS_SEQUENCE, and `PeerType` is just `{IBGP, EBGP}`), so the RFC 4271 §5.1.5 confederation carve-out does not apply — every `PeerType::EBGP` is a true AS boundary. Mirrors BIRD (`UNSET` when `!is_internal`) and GoBGP (`delPathAttr` for non-internal peers).

## Test plan

- **New BDD `bgp_rr_ebgp_strip.feature`** — 4-node hierarchical-RR topology (z2 originates → RR z1 reflects to client z3 → z3 re-advertises over eBGP to z4). Non-vacuous positive control: z3 shows `Originator: 10.0.0.2`, `Cluster list:` and `localpref`; z4 receives the route but **none** of the three. 4 scenarios / 46 steps pass.
- Broadened `reflect_attr` unit test (`reflect_attr_strips_ibgp_only_attrs_to_ebgp`).
- Full zebra-rs unit suite: 1267 passed, 0 failed.
- `cargo fmt --check` and `cargo clippy --workspace --all-targets -- -D warnings` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)