### PR TITLE
stamp: IPv6 link-local sessions for IS-IS (v4-preferred / v6-LL fallback)

### DIFF
--- a/bdd/Makefile
+++ b/bdd/Makefile
@@ -174,6 +174,10 @@ stamp_te_metric:
 	mkdir -p allure-results
 	cargo test --test cucumber -- --concurrency=1 --tags "@stamp_te_metric"
 
+stamp_v6_te_metric:
+	mkdir -p allure-results
+	cargo test --test cucumber -- --concurrency=1 --tags "@stamp_v6_te_metric"
+
 bgp_evpn_capability:
 	mkdir -p allure-results
 	cargo test --test cucumber -- --concurrency=1 --tags "@bgp_evpn_capability"
@@ -261,4 +265,4 @@ docs/%.md: tests/features/%.feature docs/feature2md.sh FORCE
 
 FORCE:
 
-.PHONY: ecmp_bfd_evict ospfv2_bfd_frr ospfv3_bfd_frr tilfa_bfd all run ibgp ebgp rr rib_static_ipv6 isis_ipv6 isis_srv6 isis_fragmentation_ipv6 isis_fragmentation_ipv4 isis_l1p2p isis_tilfa isis_l1l2 isis_redist isis_hello_auth_keychain isis_passive isis_afi_enable isis_endx_ipv6 isis_bfd_ipv6_p2p isis_bfd_ipv6_p2p_echo isis_bfd_ipv6_lan isis_bfd_ipv6_lan_echo isis_bfd_ipv4_p2p isis_bfd_ipv4_p2p_echo isis_bfd_ipv4_lan isis_bfd_ipv4_lan_echo ospf_clear_neighbor ospfv2_nssa ospfv2_stub ospfv2_tilfa ospfv3_nssa ospfv3_tilfa stamp_te_metric bgp_peer_down_cleanup bgp_ipv6_over_v4_session bgp_evpn_capability bgp_vrf_evpn_type5 bgp_route_map_match bgp_policy_dynamic_update bgp_table_map bgp_v6_table_map bgp_community bgp_neighbor_group bgp_unnumbered_neighbor nd_show bgp_interas_option_c bgp_interas_option_a bgp_interas_option_b bgp_interas_option_ab bgp_port bgp_ip_transparent bgp_local_as generate open docs FORCE
+.PHONY: ecmp_bfd_evict ospfv2_bfd_frr ospfv3_bfd_frr tilfa_bfd all run ibgp ebgp rr rib_static_ipv6 isis_ipv6 isis_srv6 isis_fragmentation_ipv6 isis_fragmentation_ipv4 isis_l1p2p isis_tilfa isis_l1l2 isis_redist isis_hello_auth_keychain isis_passive isis_afi_enable isis_endx_ipv6 isis_bfd_ipv6_p2p isis_bfd_ipv6_p2p_echo isis_bfd_ipv6_lan isis_bfd_ipv6_lan_echo isis_bfd_ipv4_p2p isis_bfd_ipv4_p2p_echo isis_bfd_ipv4_lan isis_bfd_ipv4_lan_echo ospf_clear_neighbor ospfv2_nssa ospfv2_stub ospfv2_tilfa ospfv3_nssa ospfv3_tilfa stamp_te_metric stamp_v6_te_metric bgp_peer_down_cleanup bgp_ipv6_over_v4_session bgp_evpn_capability bgp_vrf_evpn_type5 bgp_route_map_match bgp_policy_dynamic_update bgp_table_map bgp_v6_table_map bgp_community bgp_neighbor_group bgp_unnumbered_neighbor nd_show bgp_interas_option_c bgp_interas_option_a bgp_interas_option_b bgp_interas_option_ab bgp_port bgp_ip_transparent bgp_local_as generate open docs FORCE

--- a/bdd/tests/configs/stamp_v6_te_metric/st1.yaml
+++ b/bdd/tests/configs/stamp_v6_te_metric/st1.yaml
@@ -1,0 +1,26 @@
+interface:
+- if-name: lo
+  ipv6:
+    address: 2001:db8:0:ff61::1/128
+- if-name: st1-st2
+  ipv6:
+    address: 2001:db8:61::1/64
+
+router:
+  isis:
+    net: 49.0061.0000.0000.0001.00
+    hostname: st1
+    is-type: level-2-only
+    interface:
+    - if-name: lo
+      ipv6:
+        enable: true
+    - if-name: st1-st2
+      network-type: point-to-point
+      ipv6:
+        enable: true
+      te-metric:
+        measurement:
+          enable: true
+          interval: 100
+          damping-period: 2

--- a/bdd/tests/configs/stamp_v6_te_metric/st2.yaml
+++ b/bdd/tests/configs/stamp_v6_te_metric/st2.yaml
@@ -1,0 +1,26 @@
+interface:
+- if-name: lo
+  ipv6:
+    address: 2001:db8:0:ff61::2/128
+- if-name: st2-st1
+  ipv6:
+    address: 2001:db8:61::2/64
+
+router:
+  isis:
+    net: 49.0061.0000.0000.0002.00
+    hostname: st2
+    is-type: level-2-only
+    interface:
+    - if-name: lo
+      ipv6:
+        enable: true
+    - if-name: st2-st1
+      network-type: point-to-point
+      ipv6:
+        enable: true
+      te-metric:
+        measurement:
+          enable: true
+          interval: 100
+          damping-period: 2

--- a/bdd/tests/features/stamp_v6_te_metric.feature
+++ b/bdd/tests/features/stamp_v6_te_metric.feature
@@ -1,0 +1,77 @@
+@stamp_v6_te_metric
+@isis
+Feature: STAMP link-delay measurement over an IPv6-only IS-IS link
+  As a network operator running delay-based traffic engineering on an
+  IPv6 fabric, I want each P2P link's delay measured actively (STAMP,
+  RFC 8762) and advertised by IS-IS (RFC 8570 link-delay sub-TLVs) even
+  when the link carries no IPv4 — so dual-stack and v6-only links are
+  measured the same way.
+
+  Two zebra-rs instances share one IPv6-only P2P link (global addresses
+  for routing, link-locals for the adjacency — no IPv4 anywhere on the
+  measured interface). Both run IS-IS with `te-metric measurement`
+  enabled (probe interval 100 ms, damping period 2 s). Because no shared
+  IPv4 pair exists, the one STAMP session per link falls back to the
+  IPv6 link-local pair (the same v4-preferred / v6-LL-fallback rule BFD
+  uses), scoped by the link's ifindex. After the first damping period
+  the measured values appear as "Min/Max Unidirectional Link Delay" in
+  both LSDBs.
+
+  OSPF is intentionally absent: OSPFv2 is IPv4-only on the wire and
+  OSPFv3 has no TE-metric origination, so there is nowhere on the OSPF
+  side to publish an IPv6 delay (see docs/design/stamp-ipv6-plan.md §1).
+
+  Topology:
+
+    st1                                    st2
+      st1-st2  2001:db8:61::1/64 ---- 2001:db8:61::2/64  st2-st1
+      lo 2001:db8:0:ff61::1/128            lo 2001:db8:0:ff61::2/128
+
+  Config files: st1.yaml  st2.yaml
+
+  Scenario: Build the IPv6-only measured topology
+    Given a clean test environment
+    When I create namespace "st1"
+    And I create namespace "st2"
+    And I connect namespace "st1" interface "st1-st2" to namespace "st2" interface "st2-st1"
+    And I start zebra-rs in namespace "st1"
+    And I start zebra-rs in namespace "st2"
+    And I apply config "st1.yaml" to namespace "st1"
+    And I apply config "st2.yaml" to namespace "st2"
+    And I wait 10 seconds
+    Then isis neighbor in namespace "st1" at level 2 on interface "st1-st2" should be up
+    And ping from "st1" to "2001:db8:61::2" should succeed
+
+  Scenario: A v6 link-local STAMP session forms and measures the link
+    Given the test topology exists
+    # No shared IPv4 pair on the link, so the session forms over the
+    # peer's IPv6 link-local — the remote shows as an fe80:: address.
+    Then show command "show stamp" in namespace "st1" should eventually contain "fe80:"
+    And show command "show stamp" in namespace "st2" should eventually contain "fe80:"
+    # Replies are coming back (sender state goes Active), so the peer's
+    # implicit reflector is answering on the [::]:862 listener.
+    And show command "show stamp" in namespace "st1" should eventually contain "Active"
+    And show command "show stamp session" in namespace "st1" should eventually contain "Min delay"
+    # Phase 1.5 rung 1: the kernel software RX timestamp (SO_TIMESTAMPING)
+    # feeds T4 on the v6 path too — software stamps are stack-level, so
+    # they're delivered on veth; once kernel-stamped replies flow the
+    # kernel count leaves zero.
+    And show command "show stamp statistics" in namespace "st1" should eventually not contain "T4 kernel timestamps: 0 ("
+
+  Scenario: IS-IS advertises the measured IPv6-link delay
+    Given the test topology exists
+    # RFC 8570 sub-TLV rendered from the self-originated LSP — present
+    # only once a measured export landed (no static te-metric anywhere).
+    Then show command "show isis database detail" in namespace "st1" should eventually contain "Min/Max Unidirectional Link Delay"
+    And show command "show isis database detail" in namespace "st2" should eventually contain "Min/Max Unidirectional Link Delay"
+
+  # Pure P2P topology (no bridge): deleting each namespace destroys the
+  # veth pair ends it holds, so only the daemons and namespaces need
+  # teardown.
+  Scenario: Teardown topology
+    Given the test topology exists
+    When I stop zebra-rs in namespace "st1"
+    And I stop zebra-rs in namespace "st2"
+    And I delete namespace "st1"
+    And I delete namespace "st2"
+    Then the test environment should be clean

--- a/docs/design/stamp-ipv6-plan.md
+++ b/docs/design/stamp-ipv6-plan.md
@@ -1,0 +1,151 @@
+# STAMP IPv6 sessions — implementation plan
+
+> **Status:** plan, awaiting review (2026-06-13)
+> **Parent docs:** [stamp-phase1-implementation-plan.md](./stamp-phase1-implementation-plan.md)
+> (the shipped IPv4 measurement plane — this extends it to IPv6),
+> [stamp-sr-mpls-te-plan.md](./stamp-sr-mpls-te-plan.md) §6 (IPv6 sessions = a Phase-1
+> deferred item).
+> **Branch:** `stamp-ipv6`
+
+---
+
+## 1. Why / scope
+
+STAMP today is IPv4-only (Phase 1 decision D13). Every other routing feature here is
+dual-stack — IS-IS v6, OSPFv3, BGP v6 — so IPv4-only delay measurement is the conspicuous
+gap, and delay-TE on IPv6 fabrics is a real use case (OSPFv3 / IS-IS v6 Flex-Algo
+metric-type-1).
+
+This slice measures a link whose **IS-IS** adjacency is **IPv6 link-local**, mirroring BFD's
+single-hop v6 model exactly:
+
+- **One session per link**, address pair chosen by the existing BFD rule
+  (`isis::packet::bfd_session_addrs`): **prefer the IPv4 pair; fall back to the IPv6
+  link-local pair** when no shared v4 exists. So a dual-stack link keeps its v4 session
+  unchanged; a **v6-only IS-IS adjacency** newly gets a v6 session. No link runs two
+  sessions — link delay is AF-independent.
+- Link-local addressing throughout (like BFD v6 single-hop), so sockets are **scoped by
+  ifindex** (the scope is already in `SessionKey.ifindex`).
+- Rung-1 kernel RX `SO_TIMESTAMPING` carries over unchanged — it's an `SOL_SOCKET` option and
+  the `ScmTimestampsns` cmsg is address-family-agnostic, and software RX stamps work on v6
+  veth just as on v4.
+- Origination is AF-agnostic on IS-IS: the measured delay flows into the same TLV 22 / 222
+  sub-TLVs (RFC 8570) via `te_metric_effective()`, no new emit path.
+
+**OSPF is out of scope, and not for lack of effort — it has nowhere to publish a v6 delay:**
+OSPFv2 is IPv4-only on the wire; **OSPFv3 has no TE-metric origination at all** (no
+`te-metric` in `config_v3.rs`; `asla_sub_subs()`/`te_metric_effective()` feed only
+`ext_link_lsa_originate`, the OSPFv2 Extended-Link *Opaque* LSA — `ospf/link.rs` notes the
+measured field is "only ever populated on v2"). A v6 STAMP session on an OSPFv3 link would
+measure correctly but have no LSA to carry the result. OSPFv3 delay-TE (an RFC 8362 OSPFv3
+Extended-LSA + a v3 `te-metric` model + Flex-Algo v3 metric-type-1 consumption) is a
+**separate, larger prerequisite** — deferred until that exists. So this slice touches **no
+OSPF code**.
+
+**Also out of scope:** global-scope IPv6 addressing (link-local only, as BFD); multi-AF dual
+sessions per link; VRF (still default-VRF, separate deferred item); RFC 9503 / SR-MPLS.
+
+## 2. The one hard part: link-local scope
+
+Unlike v4, v6 link-local addressing needs the **scope id (ifindex)** on every bind/connect,
+and `fe80::…` can collide across interfaces. Two consequences:
+
+1. **Sender socket** binds `(local_ll, scope=ifindex)` and connects `(peer_ll, scope=ifindex)`;
+   the kernel's 4-tuple demux then includes scope, so replies land on the right session.
+2. **Reflector allow-list** must disambiguate by `(src, ifindex)`, not address alone — two
+   links can both present `fe80::1`. `SessionTable::reflect_allowed` grows an `ifindex`
+   argument (match it whenever the candidate session's key ifindex is non-zero).
+3. **Reflector reply** must stamp the probed link-local as source **and** pin egress to the
+   ingress ifindex (`IPV6_PKTINFO.ipi6_addr` + `ipi6_ifindex`) — exactly what BFD's
+   `write_packet_v6` does.
+
+## 3. Design decisions
+
+| # | Decision | Rationale |
+|---|----------|-----------|
+| V1 | One session/link, BFD-style v4-preferred / v6-LL-fallback selection (reuse `bfd_session_addrs` for IS-IS) | Minimal IGP-side change; consistent with BFD; delay is AF-independent so a second session adds nothing |
+| V2 | Second reflector socket `[::]:862` (`IPV6_V6ONLY`), its own read task + `reflect_tx_v6` → `reflector_write_v6` | Mirrors BFD's dual v4/v6 listeners; `on_probe_recv` routes the reply to the channel matching the probe's family |
+| V3 | Per-session sender socket is v4 or v6 by the key's family; `add_session` picks `stamp_sender_socket{,_v6}` | The connected-socket demux model is identical; only `Domain` + scope differ |
+| V4 | `reflect_allowed(src, ifindex)` — match ifindex when the session key's ifindex is non-zero | Link-local address collisions across interfaces; v4 sessions (ifindex may be 0) keep address-only match |
+| V5 | Reuse rung-1 `set_so_timestamping` on the v6 sockets; `kernel_rx_stamp` unchanged | `SO_TIMESTAMPING` / `ScmTimestampsns` are AF-agnostic |
+| V6 | Bind failure on `[::]:862` is non-fatal (warn, v6 sessions just don't form), like the v4 port and like BFD's v6 listener | Don't break v4 measurement if v6 is unavailable in the namespace/kernel |
+| V7 | Probe TTL→Hop-Limit 255 on egress; received Hop-Limit surfaced like the v4 TTL | Symmetry with v4 / BFD GTSM-style hygiene (no floor *enforced*, per Phase 1) |
+
+## 4. Step-by-step
+
+### Step 0 — branch (done: `stamp-ipv6`)
+
+### Step 1 — sockets (`stamp/socket.rs`)
+- `stamp_reflector_socket_v6(ctx, bind: SocketAddrV6)` — `Domain::IPV6`, nonblocking, reuse,
+  `IPV6_V6ONLY`, hop-limit 255, `IPV6_RECVHOPLIMIT`, `IPV6_RECVPKTINFO`, `set_so_timestamping`
+  (RX flags), bind. Copy of `bfd_socket_ipv6` + the rung-1 timestamping line.
+- `stamp_sender_socket_v6(ctx, local: SocketAddrV6, remote: SocketAddrV6)` — `Domain::IPV6`,
+  nonblocking, hop-limit 255, `set_so_timestamping(RX)`, bind `local` (carries the scope),
+  `connect(remote)`.
+
+### Step 2 — network (`stamp/network.rs`)
+- `reflector_read_v6(sock, tx)` — `recvmsg::<SockaddrIn6>` with `in6_pktinfo` +
+  `Ipv6HopLimit` + `Timestamps` cmsgs (copy of `bfd::network::read_packet_v6` + the rung-1
+  `kernel_rx_stamp` branch); emit `Message::ProbeRecv` with the v6 `src`/`dst`/`ifindex`.
+- `reflector_write_v6(sock, rx)` — `sendmsg` with `in6_pktinfo { ipi6_addr = probed LL,
+  ipi6_ifindex }` (copy of `bfd::network::write_packet_v6`); drains a `ReflectRequest`.
+- `sender_read` — make AF-agnostic: the connected socket ignores `msg.address`, so switch the
+  recvmsg address type to one that works for both (or add a `sender_read_v6` sibling if the
+  type param forces it). The cmsg/`kernel_rx_stamp`/parse logic is identical.
+
+### Step 3 — instance (`stamp/inst.rs`)
+- Second reflector socket in `new_with`: bind `[::]:862` (non-fatal), spawn `reflector_read_v6`
+  + `reflector_write_v6`, hold a `reflect_tx_v6`. (Test ctor: optional, like the v4 ephemeral
+  bind.)
+- `on_probe_recv` routes the `ReflectRequest` to `reflect_tx` or `reflect_tx_v6` by the reply
+  `dst` family.
+- `add_session`: build a v4 or v6 sender socket by `key`'s family (`SocketAddrV6` carries the
+  scope from `key.ifindex`); spawn the same `sender_read` task.
+- `reflect_allowed` call passes the ingress `ifindex`.
+
+### Step 4 — session table (`stamp/session.rs`)
+- `reflect_allowed(&self, src: IpAddr, ifindex: u32) -> Option<SessionKey>` — match
+  `remote == src` and (`key.ifindex == 0 || key.ifindex == ifindex`). Unit-test the
+  link-local-collision disambiguation (two sessions, same `fe80::` remote, different ifindex).
+
+### Step 5 — IS-IS reconcile (only IGP change)
+- `isis/inst.rs::stamp_reconcile_link`: replace the v4-only pair selection with
+  `super::packet::bfd_session_addrs(local_v4, remote_v4, local_v6ll, remote_v6ll)` — the same
+  helper BFD uses — so a v6-only adjacency yields a v6 `SessionKey`. Address snapshots:
+  `link.state.v4addr` / `v6laddr` × the Up neighbor's `addr4` / `addr6l` (exactly what
+  `bfd_reconcile_all` already gathers). No OSPF change (see §1).
+
+### Step 6 — tests
+- Unit: `reflect_allowed` ifindex disambiguation; v6 socket builds; a `::1` loopback
+  network-test that the v6 reflector socket delivers a software RX stamp (rung-1 parity).
+- Integration: a v6 sibling of the loopback integration test (`Stamp::new_with` v6 bind, a
+  `::1` session) asserting a populated `MetricUpdate`.
+- BDD: a new `@stamp_te_metric_v6` feature — two namespaces, a **v6-only** IS-IS P2P link
+  (link-locals only, no v4 on the measured interface, so the session must form over `fe80::`),
+  `te-metric measurement` on both ends. Assert `show isis database detail` carries
+  "Min/Max Unidirectional Link Delay", `show stamp` shows the `fe80::` remote, and the rung-1
+  `T4 kernel timestamps` leaves zero on the v6 path. Explicit teardown.
+
+### Step 7 — verify & deliver
+- `cargo test --workspace --exclude bdd`, `cargo fmt`, `cargo clippy --workspace
+  --all-targets -- -D warnings`.
+- Release build, md5-guarded install, `make stamp_te_metric_v6` + the existing
+  `stamp_te_metric` (v4 regression) + one IS-IS v6 feature (e.g. `isis_ipv6`). PR.
+
+## 5. Risks
+
+| Risk | Mitigation |
+|------|------------|
+| Link-local scope handling on bind/connect (the v6 footgun) | `SocketAddrV6` carries `scope_id`; set it from `key.ifindex`. Lean on BFD's working v6 path as the template; an integration test over a real v6 veth LL pair in the BDD proves it. |
+| `fe80::` collision across interfaces in the reflector allow-list | V4: `reflect_allowed` matches `(src, ifindex)` (decision V4) with a dedicated unit test. |
+| `sender_read` recvmsg address-type for a v6 connected socket | The address is ignored on the connected socket; use an AF-agnostic recvmsg or a `_v6` sibling — decided at implementation, both are trivial. |
+| Doubling reflector sockets/tasks | Mirrors BFD exactly; negligible. |
+
+## 6. Resolved: OSPFv3 is out (verified)
+
+The "is OSPFv3 in scope" question is settled by inspection: OSPFv3 has **no TE-metric
+origination** (no `te-metric` registration in `config_v3.rs`; the measured field is "only ever
+populated on v2"; emission goes solely through the v2-only `ext_link_lsa_originate` Opaque
+LSA). A v6 session there would measure but not publish, so OSPFv3 is deferred behind a separate
+"OSPFv3 delay-TE origination" effort. **This slice is IS-IS v6 only and touches no OSPF code** —
+which also keeps it small and fully testable on a v6 veth.

--- a/zebra-rs/src/isis/inst.rs
+++ b/zebra-rs/src/isis/inst.rs
@@ -2037,7 +2037,7 @@ impl Isis {
     }
 
     /// Diff the measurement session this link *should* hold (config
-    /// enabled ∧ P2P circuit ∧ an Up adjacency ∧ an IPv4 address pair)
+    /// enabled ∧ P2P circuit ∧ an Up adjacency ∧ a usable address pair)
     /// against the tracked subscription, and (un)subscribe on the
     /// edges only. Tearing a session down also clears the link's
     /// measured values — they must not survive into the next adjacency
@@ -2051,30 +2051,35 @@ impl Isis {
         };
 
         // Desired session for the current config + adjacency state.
-        // Same v4 selection as `bfd_reconcile_all`: first interface
-        // address × first address of the first Up neighbor (P2P has at
-        // most one neighbor per level).
+        // Same address selection as `bfd_reconcile_all`: v4-preferred /
+        // v6-link-local fallback, the interface's own address × the
+        // first Up neighbor's (P2P has at most one neighbor per level).
+        // A v6-only adjacency thus yields a link-local v6 session whose
+        // scope is the link's ifindex.
         let desired = if link.config.te_metric_measurement.enabled() && link.is_p2p() {
             let local_v4 = link.state.v4addr.first().map(|p| p.addr());
-            let remote_v4 = [Level::L1, Level::L2].iter().find_map(|level| {
+            let local_v6ll = link.state.v6laddr.first().map(|p| p.addr());
+            let nbr = [Level::L1, Level::L2].iter().find_map(|level| {
                 link.state
                     .nbrs
                     .get(level)
                     .values()
                     .find(|nbr| nbr.state == NfsmState::Up)
-                    .and_then(|nbr| nbr.addr4.keys().next().copied())
             });
-            match (local_v4, remote_v4) {
-                (Some(local), Some(remote)) => Some((
-                    crate::stamp::session::SessionKey {
-                        local: std::net::IpAddr::V4(local),
-                        remote: std::net::IpAddr::V4(remote),
-                        ifindex,
-                    },
-                    link.config.te_metric_measurement.resolve(),
-                )),
-                _ => None,
-            }
+            let remote_v4 = nbr.and_then(|n| n.addr4.keys().next().copied());
+            let remote_v6ll = nbr.and_then(|n| n.addr6l.first().copied());
+            super::packet::bfd_session_addrs(local_v4, remote_v4, local_v6ll, remote_v6ll).map(
+                |(local, remote)| {
+                    (
+                        crate::stamp::session::SessionKey {
+                            local,
+                            remote,
+                            ifindex,
+                        },
+                        link.config.te_metric_measurement.resolve(),
+                    )
+                },
+            )
         } else {
             None
         };

--- a/zebra-rs/src/stamp/inst.rs
+++ b/zebra-rs/src/stamp/inst.rs
@@ -6,10 +6,12 @@
 //! `stamp_client_tx` at their own spawn time — the same lifecycle as
 //! BFD. The instance owns:
 //!
-//!   * the wildcard reflector socket (`0.0.0.0:862`) with its
-//!     read/write tasks — the **implicit reflector**: a probe is
-//!     answered iff its source is the remote of a registered session
-//!     (measurement enabled on both ends of the link, plan §2);
+//!   * the wildcard reflector sockets (`0.0.0.0:862` and, when it
+//!     binds, `[::]:862`) with their read/write tasks — the **implicit
+//!     reflector**: a probe is answered iff its source is the remote of
+//!     a registered session (measurement enabled on both ends of the
+//!     link, plan §2); the reply is routed back over the write loop of
+//!     the probe's address family;
 //!   * one connected sender socket + reply-read task + prober task per
 //!     session;
 //!   * the per-session subscriber registry fanning damped
@@ -22,7 +24,7 @@
 //! step mid-probe) are discarded and counted.
 
 use std::collections::{BTreeMap, HashMap};
-use std::net::{IpAddr, Ipv4Addr, SocketAddr, SocketAddrV4};
+use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr, SocketAddrV4, SocketAddrV6};
 use std::sync::Arc;
 
 use stamp_packet::{ErrorEstimate, ReflectorPacket, SenderPacket, StampTimestamp};
@@ -35,11 +37,16 @@ use crate::config::{
 use crate::context::{ProtoContext, Task};
 
 use super::client::{ClientId, ClientReq, ClientReqChannel, StampEvent};
-use super::network::{ReflectRequest, reflector_read, reflector_write, sender_read};
+use super::network::{
+    ReflectRequest, reflector_read, reflector_read_v6, reflector_write, reflector_write_v6,
+    sender_read,
+};
 use super::reflector::build_reply;
 use super::sender::{ProberCmd, ProberHandle, session_prober};
 use super::session::{Session, SessionKey, SessionParams, SessionTable};
-use super::socket::{stamp_reflector_socket, stamp_sender_socket};
+use super::socket::{
+    stamp_reflector_socket, stamp_reflector_socket_v6, stamp_sender_socket, stamp_sender_socket_v6,
+};
 use super::timestamp::{delta_micros, now_ntp};
 
 /// `show <path>` dispatch handler — mirrors [`crate::bfd::inst::ShowCallback`].
@@ -124,6 +131,10 @@ pub struct Stamp {
     /// Local address the reflector socket was bound to — tests bind
     /// ephemeral ports and need to learn the kernel's choice.
     pub local_addr: SocketAddrV4,
+    /// Local address the IPv6 reflector socket bound to, when one was
+    /// requested and the bind succeeded (the `[::]:862` listener is
+    /// non-fatal — `None` means v6 sessions can't be reflected).
+    pub local_addr_v6: Option<SocketAddrV6>,
     /// Config-manager subscription endpoints. STAMP has no own config
     /// in Phase 1; every commit broadcast is drained (registering as a
     /// config client also lets the manager see the task is running).
@@ -137,23 +148,40 @@ pub struct Stamp {
     subscribers: HashMap<SessionKey, BTreeMap<ClientId, UnboundedSender<StampEvent>>>,
     main_tx: UnboundedSender<Message>,
     reflect_tx: UnboundedSender<ReflectRequest>,
+    /// Reply queue for the IPv6 reflector write loop; `None` when no
+    /// `[::]:862` listener bound (so v6 probes can't be answered).
+    reflect_tx_v6: Option<UnboundedSender<ReflectRequest>>,
     probers: HashMap<SessionKey, ProberHandle>,
     pub reflector_stats: ReflectorStats,
 }
 
 impl Stamp {
-    /// Production constructor — binds the reflector to `0.0.0.0:862`.
+    /// Production constructor — binds the reflectors to `0.0.0.0:862`
+    /// and `[::]:862` (the latter non-fatal).
     pub fn new(ctx: ProtoContext) -> std::io::Result<Self> {
         Self::new_with(
             ctx,
             SocketAddrV4::new(Ipv4Addr::UNSPECIFIED, stamp_packet::STAMP_UDP_PORT),
+            Some(SocketAddrV6::new(
+                Ipv6Addr::UNSPECIFIED,
+                stamp_packet::STAMP_UDP_PORT,
+                0,
+                0,
+            )),
         )
     }
 
     /// Explicit constructor letting the caller pick the reflector bind
-    /// address (the integration test runs on a loopback ephemeral
-    /// port and aims a session's `dst_port` at it).
-    pub fn new_with(ctx: ProtoContext, bind: SocketAddrV4) -> std::io::Result<Self> {
+    /// addresses (the integration test runs on loopback ephemeral
+    /// ports and aims a session's `dst_port` at one). `bind_v6` is
+    /// `None` to skip the IPv6 listener entirely (the v4-only unit
+    /// tests); when `Some`, a bind failure is logged and swallowed —
+    /// v4 measurement must not depend on v6 being available.
+    pub fn new_with(
+        ctx: ProtoContext,
+        bind: SocketAddrV4,
+        bind_v6: Option<SocketAddrV6>,
+    ) -> std::io::Result<Self> {
         let sock = stamp_reflector_socket(&ctx, bind)?;
         let local_addr = sock
             .local_addr()?
@@ -173,11 +201,26 @@ impl Stamp {
             reflector_write(sock, reflect_rx).await;
         });
 
+        // IPv6 reflector: non-fatal. Any failure (bind denied, no v6 in
+        // the namespace) just disables v6 reflection; `reflect_tx_v6`
+        // stays `None` and v4 keeps working.
+        let (reflect_tx_v6, local_addr_v6) = match bind_v6 {
+            Some(b6) => match Self::spawn_v6_reflector(&ctx, b6, &main_tx) {
+                Ok((tx6, addr6)) => (Some(tx6), Some(addr6)),
+                Err(e) => {
+                    tracing::warn!(bind = %b6, error = %e, "stamp: IPv6 reflector unavailable; v6 sessions disabled");
+                    (None, None)
+                }
+            },
+            None => (None, None),
+        };
+
         let mut stamp = Self {
             rx,
             ctx,
             sessions: SessionTable::new(),
             local_addr,
+            local_addr_v6,
             cm: ConfigChannel::new(),
             show: ShowChannel::new(),
             show_cb: HashMap::new(),
@@ -185,11 +228,40 @@ impl Stamp {
             subscribers: HashMap::new(),
             main_tx,
             reflect_tx,
+            reflect_tx_v6,
             probers: HashMap::new(),
             reflector_stats: ReflectorStats::default(),
         };
         stamp.show_build();
         Ok(stamp)
+    }
+
+    /// Build the IPv6 reflector socket, spawn its read/write loops, and
+    /// return the reply queue plus the bound address. Split out so the
+    /// whole v6 setup is one fallible unit `new_with` can treat as
+    /// non-fatal.
+    fn spawn_v6_reflector(
+        ctx: &ProtoContext,
+        bind: SocketAddrV6,
+        main_tx: &UnboundedSender<Message>,
+    ) -> std::io::Result<(UnboundedSender<ReflectRequest>, SocketAddrV6)> {
+        let sock = stamp_reflector_socket_v6(ctx, bind)?;
+        let local_addr = sock
+            .local_addr()?
+            .as_socket_ipv6()
+            .ok_or_else(|| std::io::Error::other("bound socket has no IPv6 local address"))?;
+        let sock = Arc::new(AsyncFd::new(sock)?);
+
+        let (reflect_tx, reflect_rx) = mpsc::unbounded_channel::<ReflectRequest>();
+        let read_sock = sock.clone();
+        let read_tx = main_tx.clone();
+        tokio::spawn(async move {
+            reflector_read_v6(read_sock, read_tx).await;
+        });
+        tokio::spawn(async move {
+            reflector_write_v6(sock, reflect_rx).await;
+        });
+        Ok((reflect_tx, local_addr))
     }
 
     /// Clone the inbound client-request sender for distribution to the
@@ -265,16 +337,26 @@ impl Stamp {
     /// Create the session: connected sender socket, reply-read task,
     /// prober task.
     fn add_session(&mut self, key: SessionKey, params: SessionParams) -> std::io::Result<()> {
-        let (IpAddr::V4(local), IpAddr::V4(remote)) = (key.local, key.remote) else {
-            return Err(std::io::Error::other(
-                "stamp: IPv6 sessions are not supported yet",
-            ));
+        // One connected sender socket, v4 or v6 by the key's family. For
+        // v6 the scope id (`key.ifindex`) rides on both endpoints so a
+        // link-local 4-tuple is unambiguous across interfaces.
+        let sock = match (key.local, key.remote) {
+            (IpAddr::V4(local), IpAddr::V4(remote)) => stamp_sender_socket(
+                &self.ctx,
+                SocketAddrV4::new(local, 0),
+                SocketAddrV4::new(remote, params.dst_port),
+            )?,
+            (IpAddr::V6(local), IpAddr::V6(remote)) => stamp_sender_socket_v6(
+                &self.ctx,
+                SocketAddrV6::new(local, 0, 0, key.ifindex),
+                SocketAddrV6::new(remote, params.dst_port, 0, key.ifindex),
+            )?,
+            _ => {
+                return Err(std::io::Error::other(
+                    "stamp: session key mixes IPv4 and IPv6 addresses",
+                ));
+            }
         };
-        let sock = stamp_sender_socket(
-            &self.ctx,
-            SocketAddrV4::new(local, 0),
-            SocketAddrV4::new(remote, params.dst_port),
-        )?;
         let sock = Arc::new(AsyncFd::new(sock)?);
 
         let read_sock = sock.clone();
@@ -454,18 +536,34 @@ impl Stamp {
         len: usize,
     ) {
         self.reflector_stats.rx += 1;
-        let Some(session_key) = self.sessions.reflect_allowed(src.ip()) else {
+        let Some(session_key) = self.sessions.reflect_allowed(src.ip(), ifindex) else {
             self.reflector_stats.unauthorized += 1;
             tracing::debug!(?src, "stamp: probe from unregistered source dropped");
             return;
         };
         let reply = build_reply(&probe, rx_ts, ttl, len);
-        let _ = self.reflect_tx.send(ReflectRequest {
+        let req = ReflectRequest {
             reply,
             dst: src,
             src: dst,
             ifindex: (ifindex != 0).then_some(ifindex),
-        });
+        };
+        // Route the reply to the write loop of the probe's family. A v6
+        // probe with no `[::]:862` listener (bind failed) can't be
+        // answered — drop it without counting a reflection.
+        let queued = match src {
+            SocketAddr::V4(_) => self.reflect_tx.send(req).is_ok(),
+            SocketAddr::V6(_) => match &self.reflect_tx_v6 {
+                Some(tx) => tx.send(req).is_ok(),
+                None => {
+                    tracing::debug!(?src, "stamp: v6 probe but no v6 reflector socket; dropped");
+                    false
+                }
+            },
+        };
+        if !queued {
+            return;
+        }
         self.reflector_stats.reflected += 1;
         // The T2 we just echoed is only as good as its source; track it
         // for `show stamp statistics` (helps the peer's numbers).
@@ -529,9 +627,11 @@ mod tests {
     use super::*;
 
     fn fresh_stamp() -> Stamp {
+        // v4-only: these tests don't exercise the v6 reflector.
         Stamp::new_with(
             ProtoContext::default_table_no_rib(),
             SocketAddrV4::new(Ipv4Addr::LOCALHOST, 0),
+            None,
         )
         .expect("bind loopback")
     }
@@ -752,5 +852,101 @@ mod tests {
         assert!(updates[0].is_some());
         assert!(updates[1].is_none());
         assert!(stamp.sessions.get(&key).unwrap().last_export.is_none());
+    }
+
+    /// Build a Stamp with both reflectors on loopback ephemeral ports.
+    fn fresh_stamp_dualstack() -> Stamp {
+        Stamp::new_with(
+            ProtoContext::default_table_no_rib(),
+            SocketAddrV4::new(Ipv4Addr::LOCALHOST, 0),
+            Some(SocketAddrV6::new(Ipv6Addr::LOCALHOST, 0, 0, 0)),
+        )
+        .expect("bind loopback reflectors")
+    }
+
+    // `::1` is the only loopback v6 address (unlike `127.0.0.0/8`), so a
+    // v6 self-loop key is local == remote == `::1` — mirrors how the v4
+    // integration test loops back through LOCALHOST.
+    fn v6_loopback_key() -> SessionKey {
+        SessionKey {
+            local: IpAddr::V6(Ipv6Addr::LOCALHOST),
+            remote: IpAddr::V6(Ipv6Addr::LOCALHOST),
+            ifindex: 0,
+        }
+    }
+
+    /// Step 3: with a v6 reflector bound, a v6 session key takes the
+    /// `add_session` v6 branch — a v6 connected sender socket and a
+    /// live session with a real ssid.
+    #[tokio::test]
+    async fn v6_session_creates_over_loopback() {
+        let mut stamp = fresh_stamp_dualstack();
+        assert!(stamp.local_addr_v6.is_some(), "v6 reflector bound");
+
+        let key = v6_loopback_key();
+        let (tx, _rx) = mpsc::unbounded_channel();
+        stamp.subscribe("isis".into(), key, SessionParams::default(), tx);
+        assert_eq!(stamp.sessions.len(), 1);
+        assert_ne!(stamp.sessions.get(&key).unwrap().ssid, 0);
+    }
+
+    /// Step 3: a probe from a registered v6 remote is reflected over the
+    /// v6 write loop; the same probe is dropped (no reflection counted)
+    /// when no v6 reflector bound — the family-routing in `on_probe_recv`.
+    #[tokio::test]
+    async fn v6_probe_routes_to_v6_loop_else_drops() {
+        let src = SocketAddr::V6(SocketAddrV6::new(Ipv6Addr::LOCALHOST, 5000, 0, 0));
+
+        // With a v6 reflector: the probe is reflected.
+        let mut stamp = fresh_stamp_dualstack();
+        let key = v6_loopback_key();
+        let (tx, _rx) = mpsc::unbounded_channel();
+        stamp.subscribe("isis".into(), key, SessionParams::default(), tx);
+
+        stamp.on_probe_recv(
+            SenderPacket::default(),
+            src,
+            Some(IpAddr::V6(Ipv6Addr::LOCALHOST)),
+            0,
+            255,
+            StampTimestamp::default(),
+            false,
+            stamp_packet::BASE_LEN,
+        );
+        assert_eq!(stamp.reflector_stats.reflected, 1);
+        assert_eq!(stamp.sessions.get(&key).unwrap().reflected_count, 1);
+
+        // Without a v6 reflector (`bind_v6` = None): the v6 session still
+        // creates (the sender socket is independent), but an inbound v6
+        // probe can't be answered, so it's dropped — allowed, not
+        // reflected, not unauthorized.
+        let mut stamp = fresh_stamp(); // v4-only reflector
+        let (tx, _rx) = mpsc::unbounded_channel();
+        stamp.subscribe("isis".into(), key, SessionParams::default(), tx);
+        assert_eq!(
+            stamp.sessions.len(),
+            1,
+            "v6 session creates without a v6 reflector"
+        );
+
+        stamp.on_probe_recv(
+            SenderPacket::default(),
+            src,
+            Some(IpAddr::V6(Ipv6Addr::LOCALHOST)),
+            0,
+            255,
+            StampTimestamp::default(),
+            false,
+            stamp_packet::BASE_LEN,
+        );
+        assert_eq!(stamp.reflector_stats.rx, 1);
+        assert_eq!(
+            stamp.reflector_stats.reflected, 0,
+            "no v6 reflector → dropped"
+        );
+        assert_eq!(
+            stamp.reflector_stats.unauthorized, 0,
+            "source was registered"
+        );
     }
 }

--- a/zebra-rs/src/stamp/integration.rs
+++ b/zebra-rs/src/stamp/integration.rs
@@ -7,7 +7,7 @@
 //! → connected-socket demux → T4 → D1 delay math → stats window →
 //! damping → `MetricUpdate` fan-out, end to end over real sockets.
 
-use std::net::{IpAddr, Ipv4Addr, SocketAddrV4};
+use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddrV4, SocketAddrV6};
 use std::time::Duration;
 
 use tokio::sync::mpsc;
@@ -18,6 +18,7 @@ use super::session::{SessionKey, SessionParams};
 use crate::context::ProtoContext;
 
 const LOOPBACK: Ipv4Addr = Ipv4Addr::LOCALHOST;
+const LOOPBACK6: Ipv6Addr = Ipv6Addr::LOCALHOST;
 
 /// Subscribe a fake IGP client and assert a populated `MetricUpdate`
 /// arrives within the deadline, with internally consistent fields.
@@ -26,6 +27,7 @@ async fn loopback_session_exports_metrics() {
     let stamp = Stamp::new_with(
         ProtoContext::default_table_no_rib(),
         SocketAddrV4::new(LOOPBACK, 0),
+        None,
     )
     .expect("bind loopback reflector");
     let reflector_port = stamp.local_addr.port();
@@ -72,6 +74,66 @@ async fn loopback_session_exports_metrics() {
     assert!(snap.avg <= snap.max, "avg {} <= max {}", snap.avg, snap.max);
     // Loopback round-trips are fast; anything near the 10 s outlier
     // guard would mean the timestamps are broken.
+    assert!(
+        snap.max < 1_000_000,
+        "implausible loopback delay {}",
+        snap.max
+    );
+}
+
+/// IPv6 sibling of [`loopback_session_exports_metrics`]: a `::1` session
+/// loops through the instance's own `[::]`-family reflector, exercising
+/// the v6 socket → reflector_read_v6 (allow-list with the loopback
+/// ingress ifindex, T2) → build_reply → reflector_write_v6 (source
+/// stamp + ifindex pin) → connected v6 socket → T4 → D1 math → export,
+/// end to end over real v6 sockets.
+#[tokio::test]
+async fn loopback_session_v6_exports_metrics() {
+    let stamp = Stamp::new_with(
+        ProtoContext::default_table_no_rib(),
+        SocketAddrV4::new(LOOPBACK, 0),
+        Some(SocketAddrV6::new(LOOPBACK6, 0, 0, 0)),
+    )
+    .expect("bind loopback reflectors");
+    let reflector_port = stamp.local_addr_v6.expect("v6 reflector bound").port();
+
+    let key = SessionKey {
+        local: IpAddr::V6(LOOPBACK6),
+        remote: IpAddr::V6(LOOPBACK6),
+        ifindex: 0,
+    };
+    let params = SessionParams {
+        interval_ms: 50,
+        damping_secs: 1,
+        dst_port: reflector_port,
+    };
+    let (tx, mut rx) = mpsc::unbounded_channel();
+
+    let client_req = stamp.client_req_tx();
+    let _task = serve(stamp);
+    client_req
+        .send(super::client::ClientReq::Subscribe {
+            client: "test".into(),
+            key,
+            params,
+            notifier: tx,
+        })
+        .expect("event loop alive");
+
+    let deadline = Duration::from_secs(10);
+    let update = tokio::time::timeout(deadline, rx.recv())
+        .await
+        .expect("no MetricUpdate within deadline")
+        .expect("notifier channel closed");
+
+    let StampEvent::MetricUpdate {
+        key: got_key,
+        snapshot,
+    } = update;
+    assert_eq!(got_key, key);
+    let snap = snapshot.expect("first export carries a value, not a clear");
+    assert!(snap.min <= snap.avg, "min {} <= avg {}", snap.min, snap.avg);
+    assert!(snap.avg <= snap.max, "avg {} <= max {}", snap.avg, snap.max);
     assert!(
         snap.max < 1_000_000,
         "implausible loopback delay {}",

--- a/zebra-rs/src/stamp/network.rs
+++ b/zebra-rs/src/stamp/network.rs
@@ -18,12 +18,14 @@
 //!     keyed by the session.
 
 use std::io::{ErrorKind, IoSlice, IoSliceMut};
-use std::net::{IpAddr, Ipv4Addr, SocketAddr, SocketAddrV4};
+use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr, SocketAddrV4, SocketAddrV6};
 use std::os::fd::AsRawFd;
 use std::sync::Arc;
 
 use bytes::BytesMut;
-use nix::sys::socket::{self, ControlMessageOwned, MsgFlags, SockaddrIn};
+use nix::sys::socket::{
+    self, ControlMessageOwned, MsgFlags, SockaddrIn, SockaddrIn6, SockaddrStorage,
+};
 use socket2::Socket;
 use tokio::io::Interest;
 use tokio::io::unix::AsyncFd;
@@ -128,6 +130,94 @@ pub async fn reflector_read(sock: Arc<AsyncFd<Socket>>, tx: UnboundedSender<Mess
     }
 }
 
+/// IPv6 sibling of [`reflector_read`]: `recvmsg` on the `[::]:862`
+/// reflector socket with `IPV6_PKTINFO` + `IPV6_RECVHOPLIMIT` +
+/// `SCM_TIMESTAMPING` ancillary data. The probe `src` carries its
+/// scope id (the ingress ifindex), and the probed link-local
+/// destination (`dst`) plus the ingress `ifindex` flow through so the
+/// reply can be stamped and pinned (Step 3 / [`reflector_write_v6`]).
+/// T2 comes from the kernel software stamp when present, else a
+/// userspace read — identical to the v4 path.
+pub async fn reflector_read_v6(sock: Arc<AsyncFd<Socket>>, tx: UnboundedSender<Message>) {
+    let mut buf = [0u8; 1500];
+    let mut iov = [IoSliceMut::new(&mut buf)];
+    let mut cmsgspace =
+        nix::cmsg_space!(libc::in6_pktinfo, libc::c_int, nix::sys::socket::Timestamps);
+
+    loop {
+        let _ = sock
+            .async_io(Interest::READABLE, |sock| {
+                let msg = socket::recvmsg::<SockaddrIn6>(
+                    sock.as_raw_fd(),
+                    &mut iov,
+                    Some(&mut cmsgspace),
+                    MsgFlags::empty(),
+                )?;
+
+                let Some(src6) = msg.address else {
+                    return Err(ErrorKind::AddrNotAvailable.into());
+                };
+                let src = SocketAddr::V6(SocketAddrV6::new(
+                    src6.ip(),
+                    src6.port(),
+                    src6.flowinfo(),
+                    src6.scope_id(),
+                ));
+
+                let mut dst: Option<Ipv6Addr> = None;
+                let mut ifindex: u32 = 0;
+                let mut ttl: u8 = 0;
+                let mut kernel_t2: Option<StampTimestamp> = None;
+                for cmsg in msg.cmsgs()? {
+                    match cmsg {
+                        ControlMessageOwned::Ipv6PacketInfo(pi) => {
+                            dst = Some(Ipv6Addr::from(pi.ipi6_addr.s6_addr));
+                            ifindex = pi.ipi6_ifindex;
+                        }
+                        ControlMessageOwned::Ipv6HopLimit(v) => ttl = v.clamp(0, 255) as u8,
+                        ControlMessageOwned::ScmTimestampsns(ts) => {
+                            let (secs, nanos) = (ts.system.tv_sec(), ts.system.tv_nsec());
+                            if secs != 0 || nanos != 0 {
+                                kernel_t2 = Some(unix_to_ntp(secs as u64, nanos as u32));
+                            }
+                        }
+                        _ => {}
+                    }
+                }
+                // T2: the kernel software receive stamp when available,
+                // else a userspace read (offload notes §9b R3).
+                let t2_kernel = kernel_t2.is_some();
+                let rx_ts = kernel_t2.unwrap_or_else(now_ntp);
+
+                let Some(payload) = msg.iovs().next() else {
+                    return Err(ErrorKind::UnexpectedEof.into());
+                };
+                let len = payload.len();
+
+                let probe = match stamp_packet::SenderPacket::parse(payload) {
+                    Ok(p) => p,
+                    Err(e) => {
+                        tracing::debug!(?src, error = %e, "stamp: invalid sender packet");
+                        return Ok(());
+                    }
+                };
+
+                let _ = tx.send(Message::ProbeRecv {
+                    probe,
+                    src,
+                    dst: dst.map(IpAddr::V6),
+                    ifindex,
+                    ttl,
+                    rx_ts,
+                    t2_kernel,
+                    len,
+                });
+                Ok(())
+            })
+            .await;
+    }
+}
+
 /// Reflector send loop. The source-address stamp works exactly like
 /// BFD's: `ipi_spec_dst` names the *source* of an outgoing datagram.
 pub async fn reflector_write(
@@ -176,6 +266,62 @@ pub async fn reflector_write(
     }
 }
 
+/// IPv6 sibling of [`reflector_write`], modelled on BFD's
+/// `write_packet_v6`. `ipi6_addr` forces the outgoing source to the
+/// probed link-local (the sender's connected socket only accepts a
+/// reply from exactly the address it probed), and `ipi6_ifindex` pins
+/// egress to the ingress interface — mandatory for link-local
+/// destinations.
+pub async fn reflector_write_v6(
+    sock: Arc<AsyncFd<Socket>>,
+    mut rx: UnboundedReceiver<ReflectRequest>,
+) {
+    while let Some(req) = rx.recv().await {
+        let SocketAddr::V6(dst) = req.dst else {
+            continue; // v6 channel: drop any v4 reply queued by mistake
+        };
+        let mut buf = BytesMut::new();
+        req.reply.emit(&mut buf);
+        let iov = [IoSlice::new(&buf)];
+        let sockaddr: SockaddrIn6 = dst.into();
+
+        // `ipi6_addr` sets the source on the outgoing datagram; a cmsg
+        // is emitted when either an egress ifindex or a source address
+        // is requested (ifindex is mandatory for link-local).
+        let src6 = match req.src {
+            Some(IpAddr::V6(a)) => Some(a.octets()),
+            _ => None,
+        };
+        let pktinfo = (req.ifindex.is_some() || src6.is_some()).then(|| libc::in6_pktinfo {
+            ipi6_addr: libc::in6_addr {
+                s6_addr: src6.unwrap_or([0u8; 16]),
+            },
+            ipi6_ifindex: req.ifindex.unwrap_or(0),
+        });
+        let cmsg_storage;
+        let cmsgs: &[socket::ControlMessage<'_>] = if let Some(ref pi) = pktinfo {
+            cmsg_storage = [socket::ControlMessage::Ipv6PacketInfo(pi)];
+            &cmsg_storage
+        } else {
+            &[]
+        };
+
+        let _ = sock
+            .async_io(Interest::WRITABLE, |sock| {
+                socket::sendmsg(
+                    sock.as_raw_fd(),
+                    &iov,
+                    cmsgs,
+                    MsgFlags::empty(),
+                    Some(&sockaddr),
+                )
+                .map_err(std::io::Error::from)?;
+                Ok(())
+            })
+            .await;
+    }
+}
+
 /// Extract the software receive timestamp from an `SCM_TIMESTAMPING`
 /// ancillary message, if the kernel attached one (Phase 1.5 rung 1,
 /// enabled by [`super::socket::set_so_timestamping_rx`]). The `system`
@@ -201,6 +347,10 @@ fn kernel_rx_stamp<'a>(
 /// capture point (offload notes §9b R3): the kernel software receive
 /// stamp when available (`SO_TIMESTAMPING`), else a userspace
 /// `now_ntp()`. `t4_kernel` records which, for `show stamp statistics`.
+///
+/// Family-agnostic: the connected socket never uses `msg.address`, so
+/// the recvmsg decode type is [`SockaddrStorage`] and the same loop
+/// serves both v4 and v6 sessions.
 pub async fn sender_read(
     key: SessionKey,
     sock: Arc<AsyncFd<Socket>>,
@@ -213,7 +363,7 @@ pub async fn sender_read(
     loop {
         let _ = sock
             .async_io(Interest::READABLE, |sock| {
-                let msg = socket::recvmsg::<SockaddrIn>(
+                let msg = socket::recvmsg::<SockaddrStorage>(
                     sock.as_raw_fd(),
                     &mut iov,
                     Some(&mut cmsgspace),
@@ -254,7 +404,7 @@ mod tests {
 
     use super::*;
     use crate::context::ProtoContext;
-    use crate::stamp::socket::stamp_reflector_socket;
+    use crate::stamp::socket::{stamp_reflector_socket, stamp_reflector_socket_v6};
 
     /// Phase 1.5 rung 1: a socket built with `set_so_timestamping_rx`
     /// receives a software RX timestamp in the `SCM_TIMESTAMPING`
@@ -303,6 +453,56 @@ mod tests {
         assert!(
             stamp.is_some(),
             "loopback must deliver a software RX timestamp with SO_TIMESTAMPING enabled"
+        );
+    }
+
+    /// v6 parity for the rung-1 RX stamp (Step 6): a `[::]`-bound v6
+    /// reflector socket also gets a software `SCM_TIMESTAMPING` stamp on
+    /// the `::1` loopback, decoded the same way as the v4 path. This
+    /// exercises the v6 receive cmsg set (`in6_pktinfo` + hop-limit +
+    /// timestamp) that [`reflector_read_v6`] reads.
+    #[tokio::test]
+    async fn reflector_socket_v6_delivers_kernel_rx_stamp() {
+        let ctx = ProtoContext::default_table_no_rib();
+        let sock = stamp_reflector_socket_v6(&ctx, SocketAddrV6::new(Ipv6Addr::LOCALHOST, 0, 0, 0))
+            .unwrap();
+        let port = sock.local_addr().unwrap().as_socket_ipv6().unwrap().port();
+        let sock = Arc::new(AsyncFd::new(sock).unwrap());
+
+        let sender = UdpSocket::bind((Ipv6Addr::LOCALHOST, 0)).unwrap();
+        sender
+            .send_to(&[0u8; 44], (Ipv6Addr::LOCALHOST, port))
+            .unwrap();
+
+        let mut buf = [0u8; 1500];
+        let mut iov = [IoSliceMut::new(&mut buf)];
+        let mut cmsgspace =
+            nix::cmsg_space!(libc::in6_pktinfo, libc::c_int, nix::sys::socket::Timestamps);
+
+        let stamp = tokio::time::timeout(std::time::Duration::from_secs(2), async {
+            loop {
+                let got = sock
+                    .async_io(Interest::READABLE, |sock| {
+                        let msg = socket::recvmsg::<SockaddrIn6>(
+                            sock.as_raw_fd(),
+                            &mut iov,
+                            Some(&mut cmsgspace),
+                            MsgFlags::empty(),
+                        )?;
+                        Ok(kernel_rx_stamp(msg.cmsgs()?))
+                    })
+                    .await;
+                if let Ok(stamp) = got {
+                    return stamp;
+                }
+            }
+        })
+        .await
+        .expect("recv timed out");
+
+        assert!(
+            stamp.is_some(),
+            "v6 loopback must deliver a software RX timestamp with SO_TIMESTAMPING enabled"
         );
     }
 }

--- a/zebra-rs/src/stamp/session.rs
+++ b/zebra-rs/src/stamp/session.rs
@@ -230,13 +230,23 @@ impl SessionTable {
     /// Returns the matching key so the per-session reflected counter
     /// can tick. Kept as plain per-session data so a future XDP
     /// offload can mirror it into a BPF map (offload notes §9b R2).
-    pub fn reflect_allowed(&self, src: IpAddr) -> Option<SessionKey> {
-        self.sessions.keys().find(|k| k.remote == src).copied()
+    ///
+    /// `ifindex` is the probe's ingress interface. A session keyed with
+    /// a non-zero ifindex (IPv6 link-local — `fe80::…` collides across
+    /// interfaces) must also match it; a zero-ifindex session (every v4
+    /// session today) matches on address alone.
+    pub fn reflect_allowed(&self, src: IpAddr, ifindex: u32) -> Option<SessionKey> {
+        self.sessions
+            .keys()
+            .find(|k| k.remote == src && (k.ifindex == 0 || k.ifindex == ifindex))
+            .copied()
     }
 }
 
 #[cfg(test)]
 mod tests {
+    use std::net::{Ipv4Addr, Ipv6Addr};
+
     use super::*;
 
     #[test]
@@ -269,5 +279,80 @@ mod tests {
         // Without intervening inserts the allocator just advances; the
         // collision scan only matters once sessions hold SSIDs.
         assert_ne!(a, b);
+    }
+
+    /// An inert session entry: `reflect_allowed` reads only the key, so
+    /// a bound-less nonblocking socket and a no-op task put a real
+    /// [`Session`] in the table without any network setup. (Link-local
+    /// keys can't go through `add_session` on a test host — there are no
+    /// interfaces with those scopes — so we build the table directly.)
+    fn dummy_session(key: SessionKey, ssid: u16) -> Session {
+        let sock = Socket::new(
+            socket2::Domain::IPV6,
+            socket2::Type::DGRAM,
+            Some(socket2::Protocol::UDP),
+        )
+        .unwrap();
+        sock.set_nonblocking(true).unwrap();
+        let sock = Arc::new(AsyncFd::new(sock).unwrap());
+        let read_task = Task::spawn(async {});
+        Session::new(key, SessionParams::default(), ssid, sock, read_task)
+    }
+
+    /// Step 4: two IPv6 link-local sessions share remote `fe80::1` but
+    /// hang off different interfaces. The allow-list disambiguates by
+    /// ingress ifindex, matching the probe to the session on its own
+    /// link — never the other that merely shares the address.
+    #[tokio::test]
+    async fn reflect_allowed_disambiguates_link_local_by_ifindex() {
+        let ll = IpAddr::V6(Ipv6Addr::new(0xfe80, 0, 0, 0, 0, 0, 0, 1));
+        let local = IpAddr::V6(Ipv6Addr::new(0xfe80, 0, 0, 0, 0, 0, 0, 2));
+        let key2 = SessionKey {
+            local,
+            remote: ll,
+            ifindex: 2,
+        };
+        let key3 = SessionKey {
+            local,
+            remote: ll,
+            ifindex: 3,
+        };
+
+        let mut table = SessionTable::new();
+        let ssid2 = table.alloc_ssid();
+        table.insert(dummy_session(key2, ssid2));
+        let ssid3 = table.alloc_ssid();
+        table.insert(dummy_session(key3, ssid3));
+
+        // A probe from fe80::1 is matched to the session on its own link.
+        assert_eq!(table.reflect_allowed(ll, 2), Some(key2));
+        assert_eq!(table.reflect_allowed(ll, 3), Some(key3));
+        // An ingress ifindex with no scoped session there: not reflected.
+        assert_eq!(table.reflect_allowed(ll, 9), None);
+        // Without an ingress ifindex (0) the scoped sessions can't be
+        // told apart, so the probe is not reflected.
+        assert_eq!(table.reflect_allowed(ll, 0), None);
+    }
+
+    /// A zero-ifindex (v4) session matches on address alone; the ingress
+    /// ifindex is ignored for it, so existing v4 behaviour is preserved.
+    #[tokio::test]
+    async fn reflect_allowed_zero_ifindex_matches_address_only() {
+        let v4 = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 2));
+        let key = SessionKey {
+            local: IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1)),
+            remote: v4,
+            ifindex: 0,
+        };
+        let mut table = SessionTable::new();
+        let ssid = table.alloc_ssid();
+        table.insert(dummy_session(key, ssid));
+
+        assert_eq!(table.reflect_allowed(v4, 0), Some(key));
+        assert_eq!(
+            table.reflect_allowed(v4, 7),
+            Some(key),
+            "ifindex ignored for a zero-ifindex session"
+        );
     }
 }

--- a/zebra-rs/src/stamp/show.rs
+++ b/zebra-rs/src/stamp/show.rs
@@ -270,6 +270,9 @@ fn show_stamp_statistics(stamp: &Stamp, _args: Args, json: bool) -> Result<Strin
     let mut buf = String::new();
     writeln!(buf, "STAMP statistics:")?;
     writeln!(buf, "    Reflector socket: {}", stamp.local_addr)?;
+    if let Some(addr6) = stamp.local_addr_v6 {
+        writeln!(buf, "    Reflector socket (v6): {}", addr6)?;
+    }
     writeln!(buf, "    Sessions: {}", stamp.sessions.len())?;
     writeln!(buf, "    Sender:")?;
     writeln!(buf, "        Probes sent: {}", tx)?;
@@ -316,6 +319,7 @@ mod tests {
         Stamp::new_with(
             ProtoContext::default_table_no_rib(),
             SocketAddrV4::new(Ipv4Addr::LOCALHOST, 0),
+            None,
         )
         .expect("bind loopback")
     }

--- a/zebra-rs/src/stamp/socket.rs
+++ b/zebra-rs/src/stamp/socket.rs
@@ -1,27 +1,30 @@
 //! STAMP UDP socket construction.
 //!
-//! Two socket shapes, both IPv4 (Phase 1):
+//! Two socket shapes, each with an IPv4 and an IPv6 variant:
 //!
-//!   * one wildcard **reflector** socket per instance, normally bound
-//!     to `0.0.0.0:862`, with `IP_RECVTTL` + `IP_PKTINFO` so replies
-//!     can be stamped with the probed address as source and pinned to
-//!     the ingress interface — a copy of `bfd_socket_ipv4`;
+//!   * one wildcard **reflector** socket per instance per family,
+//!     normally bound to `0.0.0.0:862` / `[::]:862`, with the receive
+//!     TTL/Hop-Limit and `PKTINFO` options so replies can be stamped
+//!     with the probed address as source and pinned to the ingress
+//!     interface — copies of `bfd_socket_ipv4` / `bfd_socket_ipv6`;
 //!   * one **connected sender** socket per session, bound to the link
 //!     address with an ephemeral port and `connect()`ed to the
 //!     reflector — the kernel then does reply demux per 4-tuple, so no
-//!     SSID-based global demux is needed.
+//!     SSID-based global demux is needed. For IPv6 link-local the
+//!     `SocketAddrV6` scope id (ifindex) makes the 4-tuple unambiguous
+//!     across interfaces that share an `fe80::` address.
 //!
-//! Both also enable software RX `SO_TIMESTAMPING` (Phase 1.5 rung 1) so
-//! the receive timestamps (T2 / T4) come from the kernel network stack
-//! rather than a post-wakeup userspace read — see
+//! All of them enable software RX `SO_TIMESTAMPING` (Phase 1.5 rung 1)
+//! so the receive timestamps (T2 / T4) come from the kernel network
+//! stack rather than a post-wakeup userspace read — see
 //! [`set_so_timestamping_rx`].
 //!
-//! Egress TTL is 255 on both: probes between direct IGP neighbors
-//! should arrive with TTL 255, and the received TTL is surfaced for
-//! `show stamp` (a GTSM-style floor is *not* enforced in Phase 1 — the
-//! reflector allow-list is the admission gate).
+//! Egress TTL / Hop Limit is 255 on every socket: probes between direct
+//! IGP neighbors should arrive with TTL 255, and the received value is
+//! surfaced for `show stamp` (a GTSM-style floor is *not* enforced in
+//! Phase 1 — the reflector allow-list is the admission gate).
 
-use std::net::SocketAddrV4;
+use std::net::{SocketAddrV4, SocketAddrV6};
 use std::os::fd::AsRawFd;
 use std::os::raw::c_int;
 
@@ -66,6 +69,55 @@ pub fn stamp_sender_socket(
     // Phase 1.5 rung 1: kernel-stamp the reply receive (T4) so our own
     // delay math excludes the daemon RX scheduling tail (the `d` term
     // in the offload-notes §9b.1 error budget). Non-fatal.
+    set_so_timestamping_rx(&socket);
+
+    socket.bind(&local.into())?;
+    socket.connect(&remote.into())?;
+    Ok(socket)
+}
+
+/// IPv6 reflector socket. The v6 twin of [`stamp_reflector_socket`],
+/// modelled on [`crate::bfd::socket::bfd_socket_ipv6`]: bound
+/// `IPV6_V6ONLY` so it does not shadow the v4 reflector on the same
+/// port, with `IPV6_RECVHOPLIMIT` + `IPV6_RECVPKTINFO` so a reply can
+/// be stamped with the probed link-local as source and pinned to the
+/// ingress interface (`IPV6_PKTINFO`). Production callers pass
+/// `([::], 862)`; tests an ephemeral loopback port.
+pub fn stamp_reflector_socket_v6(
+    ctx: &ProtoContext,
+    bind: SocketAddrV6,
+) -> std::io::Result<Socket> {
+    let socket = ctx.udp_socket_unbound(Domain::IPV6)?;
+
+    socket.set_nonblocking(true)?;
+    socket.set_reuse_address(true)?;
+    socket.set_only_v6(true)?;
+    socket.set_unicast_hops_v6(255)?;
+    set_ipv6_recvhoplimit(&socket)?;
+    set_ipv6_recvpktinfo(&socket)?;
+    // Phase 1.5 rung 1: kernel-stamp the probe receive (T2). Non-fatal.
+    set_so_timestamping_rx(&socket);
+
+    socket.bind(&bind.into())?;
+    Ok(socket)
+}
+
+/// IPv6 connected sender socket. The v6 twin of
+/// [`stamp_sender_socket`]. For link-local sessions both `local` and
+/// `remote` must carry the interface scope id (ifindex) in their
+/// `SocketAddrV6` — the scope rides through `bind`/`connect` into the
+/// kernel's 4-tuple demux, so replies on overlapping `fe80::`
+/// addresses land on the right session.
+pub fn stamp_sender_socket_v6(
+    ctx: &ProtoContext,
+    local: SocketAddrV6,
+    remote: SocketAddrV6,
+) -> std::io::Result<Socket> {
+    let socket = ctx.udp_socket_unbound(Domain::IPV6)?;
+
+    socket.set_nonblocking(true)?;
+    socket.set_unicast_hops_v6(255)?;
+    // Phase 1.5 rung 1: kernel-stamp the reply receive (T4). Non-fatal.
     set_so_timestamping_rx(&socket);
 
     socket.bind(&local.into())?;
@@ -135,4 +187,74 @@ fn set_ipv4_pktinfo(socket: &Socket) -> std::io::Result<()> {
         return Err(std::io::Error::last_os_error());
     }
     Ok(())
+}
+
+fn set_ipv6_recvhoplimit(socket: &Socket) -> std::io::Result<()> {
+    let on: c_int = 1;
+    let rc = unsafe {
+        libc::setsockopt(
+            socket.as_raw_fd(),
+            libc::IPPROTO_IPV6,
+            libc::IPV6_RECVHOPLIMIT,
+            &on as *const _ as *const libc::c_void,
+            std::mem::size_of::<c_int>() as libc::socklen_t,
+        )
+    };
+    if rc < 0 {
+        return Err(std::io::Error::last_os_error());
+    }
+    Ok(())
+}
+
+fn set_ipv6_recvpktinfo(socket: &Socket) -> std::io::Result<()> {
+    let on: c_int = 1;
+    let rc = unsafe {
+        libc::setsockopt(
+            socket.as_raw_fd(),
+            libc::IPPROTO_IPV6,
+            libc::IPV6_RECVPKTINFO,
+            &on as *const _ as *const libc::c_void,
+            std::mem::size_of::<c_int>() as libc::socklen_t,
+        )
+    };
+    if rc < 0 {
+        return Err(std::io::Error::last_os_error());
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use std::net::{Ipv6Addr, SocketAddrV6};
+
+    use super::*;
+    use crate::context::ProtoContext;
+
+    /// Step 1 of the STAMP IPv6 slice: both v6 socket builders succeed
+    /// on the `::1` loopback. This pins the option set the kernel must
+    /// accept — `IPV6_V6ONLY`, hop-limit 255, `IPV6_RECVHOPLIMIT` /
+    /// `IPV6_RECVPKTINFO`, and software RX `SO_TIMESTAMPING` — and that
+    /// a connected sender can be `bind`/`connect`ed to the reflector's
+    /// ephemeral port. The v6 read/write/stamp paths are exercised in
+    /// the `network` module (Step 2).
+    #[tokio::test]
+    async fn ipv6_sockets_build() {
+        let ctx = ProtoContext::default_table_no_rib();
+
+        let reflector =
+            stamp_reflector_socket_v6(&ctx, SocketAddrV6::new(Ipv6Addr::LOCALHOST, 0, 0, 0))
+                .expect("v6 reflector socket builds");
+        let port = reflector
+            .local_addr()
+            .unwrap()
+            .as_socket_ipv6()
+            .unwrap()
+            .port();
+
+        // Loopback has no link scope, so scope id 0 is correct here; the
+        // ifindex-scoped link-local path is covered by the BDD (Step 6).
+        let local = SocketAddrV6::new(Ipv6Addr::LOCALHOST, 0, 0, 0);
+        let remote = SocketAddrV6::new(Ipv6Addr::LOCALHOST, port, 0, 0);
+        let _sender = stamp_sender_socket_v6(&ctx, local, remote).expect("v6 sender socket builds");
+    }
 }


### PR DESCRIPTION
## Summary

Extends the STAMP (RFC 8762) measurement plane to IPv6 so a link whose IS-IS adjacency is **IPv6 link-local** is measured the same way as a v4 or dual-stack link. Plan: `docs/design/stamp-ipv6-plan.md`.

**One session per link, unchanged.** The address pair is chosen by the existing BFD rule (`isis::packet::bfd_session_addrs`): prefer the v4 pair, fall back to the v6 link-local pair. So a dual-stack link keeps its v4 session; a **v6-only IS-IS adjacency** newly gets a v6 link-local session scoped by the link's ifindex. Delay is AF-independent and flows into the same RFC 8570 TLV 22/222 sub-TLVs — no new origination path.

**OSPF is untouched and out of scope** — OSPFv2 is IPv4-only on the wire and OSPFv3 has no TE-metric origination, so there is nowhere on the OSPF side to publish a v6 delay (plan §1).

## Changes

- **socket**: `stamp_reflector_socket_v6` / `stamp_sender_socket_v6` — `Domain::IPV6`, `IPV6_V6ONLY`, hop-limit 255, `IPV6_RECVHOPLIMIT`/`RECVPKTINFO`, rung-1 RX `SO_TIMESTAMPING`; the `SocketAddrV6` scope id carries the link ifindex.
- **network**: `reflector_read_v6` / `reflector_write_v6` (`in6_pktinfo` source-stamp + ifindex pin); `sender_read` made family-agnostic via `SockaddrStorage`.
- **inst**: a non-fatal `[::]:862` reflector (`spawn_v6_reflector`); `add_session` builds a v4-or-v6 sender by the key's family with the scope id; `on_probe_recv` routes the reply to the write loop of the probe's family.
- **session**: `reflect_allowed(src, ifindex)` — a non-zero-ifindex (link-local) session must also match the ingress interface; v4 (ifindex 0) matches on address alone.
- **isis**: `stamp_reconcile_link` uses `bfd_session_addrs` so a v6-only adjacency yields a link-local v6 `SessionKey`.

## Testing

- **Unit/integration** (loopback): v6 socket-build, v6 RX-stamp parity, v6 `add_session`/reflect routing, `reflect_allowed` link-local disambiguation, and a `::1` loopback end-to-end integration test. Full workspace `cargo test` + `clippy --workspace --all-targets -D warnings` + `fmt` clean.
- **BDD** (real veth, run locally — CI excludes BDD):
  - `@stamp_v6_te_metric` (new) — v6-only IS-IS P2P link, session forms over `fe80::`, reflector answers, delay measured (rung-1 T4 kernel stamps non-zero), IS-IS advertises "Min/Max Unidirectional Link Delay" on both ends. **4 scenarios / 26 steps pass.**
  - `@stamp_te_metric` (v4 regression) — 5/28 pass.
  - `@isis_ipv6` (IS-IS v6 regression) — 4/29 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)