### PR TITLE
bdd: verify iBGP-only attrs stripped on eBGP egress (IPv6)

### DIFF
--- a/bdd/tests/configs/bgp_ebgp_strip_v6/z1.yaml
+++ b/bdd/tests/configs/bgp_ebgp_strip_v6/z1.yaml
@@ -1,0 +1,25 @@
+router:
+  bgp:
+    global:
+      as: 65001
+      router-id: 10.0.0.1
+    timer:
+      adv-interval:
+        ebgp: 3
+    neighbor:
+    - remote-address: 2001:db8::2
+      afi-safi:
+      - name: ipv6
+        enabled: true
+      enabled: true
+      remote-as: 65001
+      route-reflector:
+        client: true
+    - remote-address: 2001:db8::3
+      afi-safi:
+      - name: ipv6
+        enabled: true
+      enabled: true
+      remote-as: 65001
+      route-reflector:
+        client: true

--- a/bdd/tests/configs/bgp_ebgp_strip_v6/z2.yaml
+++ b/bdd/tests/configs/bgp_ebgp_strip_v6/z2.yaml
@@ -1,0 +1,16 @@
+router:
+  bgp:
+    global:
+      as: 65001
+      router-id: 10.0.0.2
+    neighbor:
+    - remote-address: 2001:db8::1
+      afi-safi:
+      - name: ipv6
+        enabled: true
+      enabled: true
+      remote-as: 65001
+    afi-safi:
+    - name: ipv6
+      network:
+      - prefix: 2001:db8:beef::/64

--- a/bdd/tests/configs/bgp_ebgp_strip_v6/z3.yaml
+++ b/bdd/tests/configs/bgp_ebgp_strip_v6/z3.yaml
@@ -1,0 +1,21 @@
+router:
+  bgp:
+    global:
+      as: 65001
+      router-id: 10.0.0.3
+    timer:
+      adv-interval:
+        ebgp: 3
+    neighbor:
+    - remote-address: 2001:db8::1
+      afi-safi:
+      - name: ipv6
+        enabled: true
+      enabled: true
+      remote-as: 65001
+    - remote-address: 2001:db8::4
+      afi-safi:
+      - name: ipv6
+        enabled: true
+      enabled: true
+      remote-as: 65002

--- a/bdd/tests/configs/bgp_ebgp_strip_v6/z4.yaml
+++ b/bdd/tests/configs/bgp_ebgp_strip_v6/z4.yaml
@@ -1,0 +1,15 @@
+router:
+  bgp:
+    global:
+      as: 65002
+      router-id: 10.0.0.4
+    timer:
+      adv-interval:
+        ebgp: 3
+    neighbor:
+    - remote-address: 2001:db8::3
+      afi-safi:
+      - name: ipv6
+        enabled: true
+      enabled: true
+      remote-as: 65001

--- a/bdd/tests/features/bgp_ebgp_strip_v6.feature
+++ b/bdd/tests/features/bgp_ebgp_strip_v6.feature
@@ -1,0 +1,106 @@
+@serial
+@bgp_ebgp_strip_v6
+Feature: BGP iBGP-only attributes are stripped on eBGP egress (IPv6 unicast)
+  As a network operator
+  I want the iBGP-only path attributes — ORIGINATOR_ID, CLUSTER_LIST and
+  LOCAL_PREF — to stay inside the AS for IPv6 unicast routes too
+  So that an iBGP-learned IPv6 route re-advertised to an eBGP peer does not
+  leak attributes that have meaning only within the local AS.
+
+  This is the IPv6 counterpart of @bgp_rr_ebgp_strip: the egress builder
+  `route_update_ipv6` clones the route's stored attrs, so without the
+  eBGP strip an iBGP-learned v6 route would carry ORIGINATOR_ID /
+  CLUSTER_LIST (RFC 4456 §8) and LOCAL_PREF (RFC 4271 §5.1.5) across the
+  AS boundary. Sessions are IPv6-transport so next-hop-self uses the
+  session's local v6 address directly.
+
+  Test Topology (IPv6 transport, 2001:db8::/64 link):
+  ```
+  ┌────────────────────────────────────────────────────────────────────────┐
+  │                                  br0                                   │
+  └────────┬──────────────────┬──────────────────┬──────────────────┬─────┘
+           │                  │                  │                  │
+      ┌────┴────┐        ┌────┴────┐        ┌────┴────┐        ┌────┴────┐
+      │   z1    │  iBGP  │   z2    │        │   z3    │  eBGP  │   z4    │
+      │  (RR)   │◀──────▶│(client) │        │(client) │◀──────▶│ (peer)  │
+      │ AS65001 │        │ AS65001 │        │+ border │        │ AS65002 │
+      │id 10.0. │        │id 10.0. │        │ AS65001 │        │id 10.0. │
+      │   0.1   │        │   0.2   │        │id 10.0. │        │   0.4   │
+      │2001:db8 │        │2001:db8 │        │   0.3   │        │2001:db8 │
+      │   ::1   │        │   ::2   │        │2001:db8 │        │   ::4   │
+      └────┬────┘        └─────────┘        │   ::3   │        └─────────┘
+           │ iBGP (RR client)               └────┬────┘
+           └─────────────────────────────────────┘
+  ```
+  - z1 is the route reflector; z2 and z3 are its clients (same AS 65001).
+  - z2 originates 2001:db8:beef::/64 and advertises it to the RR (z1).
+  - z1 REFLECTS the route to client z3, stamping ORIGINATOR_ID (z2's
+    router-id 10.0.0.2) and CLUSTER_LIST (z1's cluster-id). z3 therefore
+    sees the route WITH the iBGP-only attributes — the positive control.
+  - z3 re-advertises the route to its eBGP peer z4 (AS 65002). z4 MUST
+    receive the route WITHOUT ORIGINATOR_ID / CLUSTER_LIST / LOCAL_PREF.
+
+  Config files:
+  - z1.yaml: RR — iBGP to z2 and z3, both route-reflector clients.
+  - z2.yaml: client — iBGP to z1; originates 2001:db8:beef::/64.
+  - z3.yaml: client + border — iBGP to z1, eBGP to z4.
+  - z4.yaml: eBGP peer — eBGP to z3 only.
+
+  Scenario: Setup topology and establish BGP sessions
+    Given a clean test environment
+    When I create bridge "br0"
+    And I create namespace "z1" with IP "2001:db8::1/64" on bridge "br0"
+    And I create namespace "z2" with IP "2001:db8::2/64" on bridge "br0"
+    And I create namespace "z3" with IP "2001:db8::3/64" on bridge "br0"
+    And I create namespace "z4" with IP "2001:db8::4/64" on bridge "br0"
+    And I start zebra-rs in namespace "z1"
+    And I start zebra-rs in namespace "z2"
+    And I start zebra-rs in namespace "z3"
+    And I start zebra-rs in namespace "z4"
+    And I apply config "z1.yaml" to namespace "z1"
+    And I apply config "z2.yaml" to namespace "z2"
+    And I apply config "z3.yaml" to namespace "z3"
+    And I apply config "z4.yaml" to namespace "z4"
+    And I wait 5 seconds for BGP to operate
+    Then BGP session in "z1" to "2001:db8::2" should be "Established"
+    And BGP session in "z1" to "2001:db8::3" should be "Established"
+    And BGP session in "z2" to "2001:db8::1" should be "Established"
+    And BGP session in "z3" to "2001:db8::1" should be "Established"
+    And BGP session in "z3" to "2001:db8::4" should be "Established"
+    And BGP session in "z4" to "2001:db8::3" should be "Established"
+
+  Scenario: RR client z3 receives the reflected route WITH the iBGP-only attributes
+    Given the test topology exists
+    When I wait 15 seconds for BGP to operate
+    Then show command "show bgp ipv6 2001:db8:beef::/64" in namespace "z3" should eventually contain "BGP routing table entry for 2001:db8:beef::/64"
+    # ORIGINATOR_ID / CLUSTER_LIST stamped by the reflector (RFC 4456), and
+    # LOCAL_PREF carried across the iBGP path (RFC 4271 §5.1.5).
+    And show command "show bgp ipv6 2001:db8:beef::/64" in namespace "z3" should eventually contain "Originator: 10.0.0.2"
+    And show command "show bgp ipv6 2001:db8:beef::/64" in namespace "z3" should contain "Cluster list:"
+    And show command "show bgp ipv6 2001:db8:beef::/64" in namespace "z3" should contain "localpref"
+
+  Scenario: eBGP peer z4 receives the route but NOT the iBGP-only attributes
+    Given the test topology exists
+    When I wait 15 seconds for BGP to operate
+    # Positive guard first: prove the route is actually present (an unmatched
+    # show command returns empty output, which would make a bare "should not
+    # contain" pass vacuously).
+    Then show command "show bgp ipv6 2001:db8:beef::/64" in namespace "z4" should eventually contain "BGP routing table entry for 2001:db8:beef::/64"
+    # The iBGP-only attributes must not cross the AS boundary: ORIGINATOR_ID /
+    # CLUSTER_LIST (RFC 4456) and LOCAL_PREF (RFC 4271 §5.1.5).
+    And show command "show bgp ipv6 2001:db8:beef::/64" in namespace "z4" should not contain "Originator:"
+    And show command "show bgp ipv6 2001:db8:beef::/64" in namespace "z4" should not contain "Cluster list:"
+    And show command "show bgp ipv6 2001:db8:beef::/64" in namespace "z4" should not contain "localpref"
+
+  Scenario: Teardown topology
+    Given the test topology exists
+    When I stop zebra-rs in namespace "z1"
+    And I stop zebra-rs in namespace "z2"
+    And I stop zebra-rs in namespace "z3"
+    And I stop zebra-rs in namespace "z4"
+    And I delete namespace "z1"
+    And I delete namespace "z2"
+    And I delete namespace "z3"
+    And I delete namespace "z4"
+    And I delete bridge "br0"
+    Then the test environment should be clean


### PR DESCRIPTION
## Summary

IPv6-unicast regression test for the iBGP-only attribute strip merged in #1445. Mirrors `@bgp_rr_ebgp_strip` on an **IPv6-transport** topology to prove the v6 egress path (`route_update_ipv6`) also strips ORIGINATOR_ID / CLUSTER_LIST (RFC 4456 §8) and LOCAL_PREF (RFC 4271 §5.1.5) before a route crosses the AS boundary.

4-node hierarchical-RR topology (2001:db8::/64 link): z2 originates `2001:db8:beef::/64` → RR z1 reflects to client z3 (stamping the attributes) → z3 re-advertises over eBGP to z4.

This is **test-only** — no Rust changes. The fix itself already landed in #1445.

## Test plan

- New BDD `bgp_ebgp_strip_v6.feature`, 4 scenarios / 44 steps, all pass.
- Non-vacuous positive control: z3 (iBGP client) shows `Originator: 10.0.0.2`, `Cluster list:` and `localpref`; z4 (eBGP peer) receives the route (`BGP routing table entry for 2001:db8:beef::/64` present) but **none** of the three.
- Explicit `Teardown topology` scenario asserts the environment is clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)