### PR TITLE
bgp: router bgp peer-task YANG knob (per-peer egress model)

### DIFF
--- a/bdd/tests/configs/bgp_peer_task_config_knob/z1-base.yaml
+++ b/bdd/tests/configs/bgp_peer_task_config_knob/z1-base.yaml
@@ -1,0 +1,15 @@
+router:
+  bgp:
+    global:
+      as: 65001
+      router-id: 10.0.0.1
+    timer:
+      adv-interval:
+        ebgp: 1
+    neighbor:
+    - remote-address: 10.0.0.2
+      afi-safi:
+      - name: ipv4
+        enabled: true
+      enabled: true
+      remote-as: 65002

--- a/bdd/tests/configs/bgp_peer_task_config_knob/z1-routes.yaml
+++ b/bdd/tests/configs/bgp_peer_task_config_knob/z1-routes.yaml
@@ -1,0 +1,20 @@
+router:
+  bgp:
+    global:
+      as: 65001
+      router-id: 10.0.0.1
+    timer:
+      adv-interval:
+        ebgp: 1
+    neighbor:
+    - remote-address: 10.0.0.2
+      afi-safi:
+      - name: ipv4
+        enabled: true
+      enabled: true
+      remote-as: 65002
+    afi-safi:
+    - name: ipv4
+      network:
+      - prefix: 10.10.10.0/24
+      - prefix: 10.10.11.0/24

--- a/bdd/tests/configs/bgp_peer_task_config_knob/z2.yaml
+++ b/bdd/tests/configs/bgp_peer_task_config_knob/z2.yaml
@@ -1,0 +1,23 @@
+router:
+  bgp:
+    global:
+      as: 65002
+      router-id: 10.0.0.2
+    shards: 4
+    peer-task: true
+    timer:
+      adv-interval:
+        ebgp: 1
+    neighbor:
+    - remote-address: 10.0.0.1
+      afi-safi:
+      - name: ipv4
+        enabled: true
+      enabled: true
+      remote-as: 65001
+    - remote-address: 10.0.0.3
+      afi-safi:
+      - name: ipv4
+        enabled: true
+      enabled: true
+      remote-as: 65003

--- a/bdd/tests/configs/bgp_peer_task_config_knob/z3.yaml
+++ b/bdd/tests/configs/bgp_peer_task_config_knob/z3.yaml
@@ -1,0 +1,15 @@
+router:
+  bgp:
+    global:
+      as: 65003
+      router-id: 10.0.0.3
+    timer:
+      adv-interval:
+        ebgp: 1
+    neighbor:
+    - remote-address: 10.0.0.2
+      afi-safi:
+      - name: ipv4
+        enabled: true
+      enabled: true
+      remote-as: 65002

--- a/bdd/tests/features/bgp_peer_task_config_knob.feature
+++ b/bdd/tests/features/bgp_peer_task_config_knob.feature
@@ -1,0 +1,73 @@
+@serial
+@bgp_peer_task_config_knob
+Feature: BGP per-peer egress task configured via the router bgp peer-task knob
+
+  Validates the shipping form of the per-peer egress task (PET): the egress
+  model comes from config (router bgp peer-task true, zebra-bgp-sharding.yang)
+  instead of the ZEBRA_BGP_PEER_TASK environment variable. The device z2 is
+  started with the PLAIN start step — no env vars — and reads BOTH its shard
+  count (shards: 4) and its egress model (peer-task: true) from config.
+
+  PET runs the v4-unicast egress through a per-peer task (the GoBGP per-peer
+  model) instead of the main-task update-groups, and is exercised together
+  with sharding, so z2 sets both knobs. Like sharding, the egress model is
+  behavior-transparent, so the decisive proof that the knob took effect is
+  the startup log line BGP per-peer egress task: enabled (from config),
+  emitted by init_peer_task when spawn_bgp reads the leaf. The
+  route-propagation scenario then confirms the config-driven PET egress
+  ingests and forwards end to end.
+
+  The env-driven PET matrix is covered by bgp_peer_egress_v4; this feature
+  focuses on the config-knob plumbing.
+
+  Test Topology:
+  ```
+  z1 (AS65001) ── z2 (AS65002) ── z3 (AS65003)
+   10.0.0.1/24    10.0.0.2/24     10.0.0.3/24
+   origin         shards: 4       peer
+                  peer-task: true
+                  (from config)
+  ```
+  All three on bridge br0. z1 originates 10.10.10.0/24 + 10.10.11.0/24.
+
+  Scenario: z2 reads both shards and peer-task from config and the speakers establish
+    Given a clean test environment
+    When I create bridge "br0"
+    And I create namespace "z1" with IP "10.0.0.1/24" on bridge "br0"
+    And I create namespace "z2" with IP "10.0.0.2/24" on bridge "br0"
+    And I create namespace "z3" with IP "10.0.0.3/24" on bridge "br0"
+    And I start zebra-rs in namespace "z1"
+    And I start zebra-rs in namespace "z2"
+    And I start zebra-rs in namespace "z3"
+    And I apply config "z1-base.yaml" to namespace "z1"
+    And I apply config "z2.yaml" to namespace "z2"
+    And I apply config "z3.yaml" to namespace "z3"
+    And I wait 10 seconds for BGP to operate
+    # Both knobs resolved from config (no env vars were set).
+    Then the zebra-rs log in namespace "z2" should contain "BGP RIB sharding: 4 shards (from config)"
+    And the zebra-rs log in namespace "z2" should contain "BGP per-peer egress task: enabled (from config)"
+    And BGP session in "z2" to "10.0.0.1" should be "Established"
+    And BGP session in "z2" to "10.0.0.3" should be "Established"
+
+  Scenario: routes propagate through the config-driven per-peer egress
+    Given the test topology exists
+    # z1 originates; z2 must ingest (pool) and advertise to z3 through the
+    # per-peer egress task — proving the config-driven PET egress is
+    # functional, not just spawned.
+    When I apply config "z1-routes.yaml" to namespace "z1"
+    And I wait 10 seconds for BGP to operate
+    Then show command "show bgp ipv4" in namespace "z2" should contain "10.10.10.0/24"
+    And show command "show bgp ipv4" in namespace "z2" should contain "10.10.11.0/24"
+    And show command "show bgp ipv4" in namespace "z3" should contain "10.10.10.0/24"
+    And show command "show bgp ipv4" in namespace "z3" should contain "10.10.11.0/24"
+
+  Scenario: Teardown topology
+    Given the test topology exists
+    When I stop zebra-rs in namespace "z1"
+    And I stop zebra-rs in namespace "z2"
+    And I stop zebra-rs in namespace "z3"
+    And I delete namespace "z1"
+    And I delete namespace "z2"
+    And I delete namespace "z3"
+    And I delete bridge "br0"
+    Then the test environment should be clean

--- a/book/src/ch-02-31-bgp-rib-sharding.md
+++ b/book/src/ch-02-31-bgp-rib-sharding.md
@@ -122,3 +122,56 @@ This line is the authoritative confirmation that the knob took effect —
 because sharding is behavior-transparent, the routing tables themselves look
 identical at any shard count, so the log is how you tell `shards: 4`
 actually spawned four workers rather than silently falling back to one.
+
+## Egress model: per-peer task (experimental)
+
+Where `shards` parallelises the **ingress** side (which thread elects the
+best path), a second, independent knob — `peer-task` — chooses how the
+**egress** side is structured.
+
+By default zebra-rs coalesces outbound work into **update groups**: peers
+that share an outbound identity (same out-policy, next-hop treatment, AS,
+capabilities) are served by one group, so a prefix is policy-processed and
+encoded **once** and the resulting bytes are fanned to every member. This is
+the FRR model and is the right default — especially for a **route
+reflector**, where hundreds of clients often share one policy and would
+otherwise each repeat the same encode.
+
+`router bgp peer-task true` switches plain IPv4-unicast egress to a
+**per-peer egress task** instead: one task per established peer builds and
+encodes that peer's stream independently (the GoBGP per-peer model). This
+trades coalescing away for per-peer parallelism — it can help when peers
+have *divergent* policies (so update groups wouldn't coalesce much anyway)
+and there are spare cores, but for the shared-policy reflector case it
+multiplies encode work and is a net loss. It is therefore **experimental and
+off by default**; leave it off unless you are specifically measuring the
+per-peer model.
+
+```yaml
+router:
+  bgp:
+    global:
+      as: 65001
+      router-id: 10.0.0.1
+    shards: 4
+    peer-task: true
+```
+
+```
+set router bgp peer-task true
+```
+
+Like `shards`, `peer-task` is **startup-only** — the two egress models are
+alternatives that are never interleaved, so the choice is frozen when the
+instance starts. Changing it on a live instance is ignored with a warning;
+clear `router bgp` or restart to switch. It supersedes the
+`ZEBRA_BGP_PEER_TASK` environment variable (the fallback when the leaf is
+unset), and the resolved model is logged at startup:
+
+```
+BGP per-peer egress task: enabled (from config)
+```
+
+(or `disabled (from default)` for the update-group default). As with the
+shard count, this log line is the authoritative confirmation the knob took
+effect.

--- a/zebra-rs/src/bgp/peer_egress.rs
+++ b/zebra-rs/src/bgp/peer_egress.rs
@@ -28,18 +28,63 @@ use super::adj_rib::{AdjRibTable, Out};
 use super::route::{BgpRib, SyncCtx};
 use super::store::BgpAttrStore;
 
-/// `ZEBRA_BGP_PEER_TASK=1` opts peers into the per-peer egress task at
-/// Established. Default off: the v4 egress stays on the main task
-/// (update-groups), exactly as today. Read once (the pool is sized at
-/// startup), like `ZEBRA_BGP_SHARDS` / `ZEBRA_BGP_SYNC_CHUNK`.
+/// Process-global per-peer-egress-task flag, frozen once at BGP instance
+/// spawn by [`init_peer_task`]. A `OnceLock` (not a per-call env read) so the
+/// egress model chosen at startup is consistent across the ~8 gate sites for
+/// the instance's lifetime — the PET and update-group models are
+/// alternatives, never interleaved.
+static PEER_TASK: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
+
+/// The `ZEBRA_BGP_PEER_TASK` environment variable (the pre-knob form, now the
+/// fallback when the YANG `peer-task` leaf is unset). `None` if unset;
+/// `Some(true)` for `1` / `true` (case-insensitive), `Some(false)` otherwise.
+fn peer_task_env() -> Option<bool> {
+    std::env::var("ZEBRA_BGP_PEER_TASK")
+        .ok()
+        .map(|v| v == "1" || v.eq_ignore_ascii_case("true"))
+}
+
+/// Pure resolution policy (unit-tested): the YANG `router bgp peer-task` leaf
+/// wins over the env var, which wins over the default `false` (update-group
+/// egress, unchanged).
+fn resolve_peer_task(config: Option<bool>, env: Option<bool>) -> bool {
+    config.or(env).unwrap_or(false)
+}
+
+/// Freeze the per-peer-egress-task model at instance spawn from the YANG
+/// `peer-task` leaf (else `ZEBRA_BGP_PEER_TASK`, else off). Called once from
+/// `spawn_bgp` before the instance processes any peer; the result is stored
+/// process-globally so [`peer_egress_task_enabled`] returns it at every gate
+/// site. Idempotent — `spawn_bgp` short-circuits a re-spawn, first value wins.
+pub fn init_peer_task(config: Option<bool>) -> bool {
+    let _ = PEER_TASK.set(resolve_peer_task(config, peer_task_env()));
+    let on = peer_egress_task_enabled();
+    let source = if config.is_some() {
+        "config"
+    } else if peer_task_env().is_some() {
+        "ZEBRA_BGP_PEER_TASK"
+    } else {
+        "default"
+    };
+    if on {
+        tracing::info!("BGP per-peer egress task: enabled (from {source})");
+    } else {
+        tracing::info!("BGP per-peer egress task: disabled (from {source})");
+    }
+    on
+}
+
+/// `true` opts peers into the per-peer egress task (the GoBGP per-peer model)
+/// at Established; `false` (default) keeps the v4 egress on the main task
+/// (update-groups). Returns the value frozen at spawn by [`init_peer_task`]
+/// (YANG `peer-task` leaf or `ZEBRA_BGP_PEER_TASK`); before any instance
+/// spawns (unit tests) it falls back to the env var, then `false`. The two
+/// egress models are alternatives, fixed for the instance lifetime.
 pub fn peer_egress_task_enabled() -> bool {
-    use std::sync::OnceLock;
-    static ON: OnceLock<bool> = OnceLock::new();
-    *ON.get_or_init(|| {
-        std::env::var("ZEBRA_BGP_PEER_TASK")
-            .ok()
-            .is_some_and(|v| v == "1" || v.eq_ignore_ascii_case("true"))
-    })
+    PEER_TASK
+        .get()
+        .copied()
+        .unwrap_or_else(|| resolve_peer_task(None, peer_task_env()))
 }
 
 /// One v4-unicast egress operation main forwards to a peer's task — the
@@ -222,6 +267,19 @@ mod tests {
             None,
             false,
         )
+    }
+
+    #[test]
+    fn peer_task_resolution_policy() {
+        use super::resolve_peer_task;
+        // The YANG `peer-task` leaf wins over the env var...
+        assert!(resolve_peer_task(Some(true), Some(false)));
+        assert!(!resolve_peer_task(Some(false), Some(true)));
+        // ...the env var is the fallback when the leaf is unset...
+        assert!(resolve_peer_task(None, Some(true)));
+        assert!(!resolve_peer_task(None, Some(false)));
+        // ...and off (update-group egress) is the default when neither is set.
+        assert!(!resolve_peer_task(None, None));
     }
 
     /// Drive the engine synchronously (it is a plain `&mut self` method —

--- a/zebra-rs/src/config/bgp.rs
+++ b/zebra-rs/src/config/bgp.rs
@@ -23,6 +23,18 @@ pub fn spawn_bgp(config: &ConfigManager) {
                 );
             }
         }
+        // Same lifetime contract for the egress model: the PET and
+        // update-group models are alternatives, fixed at spawn.
+        if let Some(requested) = configured_peer_task(config) {
+            let live = crate::bgp::peer_egress::peer_egress_task_enabled();
+            if requested != live {
+                tracing::warn!(
+                    "router bgp peer-task {requested} ignored: the egress model is \
+                     fixed for the BGP instance lifetime — clear `router bgp` or \
+                     restart the daemon to switch"
+                );
+            }
+        }
         return;
     }
     // Capture BFD / ND client handles so per-neighbor `bfd { enable }`
@@ -40,6 +52,9 @@ pub fn spawn_bgp(config: &ConfigManager) {
     // C.4: freeze the shard count from the `router bgp shards <n>` leaf (else
     // `ZEBRA_BGP_SHARDS`, else 1) before `Bgp::new` spawns the pool.
     inst::init_shard_count(configured_shards(config));
+    // Freeze the per-peer egress-task model from the `router bgp peer-task`
+    // leaf (else `ZEBRA_BGP_PEER_TASK`, else off) before any peer establishes.
+    crate::bgp::peer_egress::init_peer_task(configured_peer_task(config));
     let bgp = inst::Bgp::new(
         ctx,
         rib_rx,
@@ -99,6 +114,25 @@ fn shards_from_config_text(text: &str) -> Option<usize> {
     })
 }
 
+/// Read the `router bgp peer-task <bool>` leaf from the committed candidate
+/// config, if set. Same flattened-text scan as [`configured_shards`].
+/// `None` ⇒ the caller falls back to `ZEBRA_BGP_PEER_TASK` / off.
+fn configured_peer_task(config: &ConfigManager) -> Option<bool> {
+    let mut text = String::new();
+    config.store.candidate.borrow().list(&mut text);
+    peer_task_from_config_text(&text)
+}
+
+/// Pure line-scan (unit-tested): pull the `peer-task` boolean out of the
+/// flattened config text — `router bgp peer-task <true|false>`, the form the
+/// `bgp_peer_task_grammar` parse test pins.
+fn peer_task_from_config_text(text: &str) -> Option<bool> {
+    text.lines().find_map(|line| {
+        let v = line.strip_prefix("router bgp peer-task ")?.trim();
+        Some(v == "true" || v == "1")
+    })
+}
+
 #[cfg(test)]
 mod tests {
     use super::shards_from_config_text;
@@ -123,5 +157,23 @@ mod tests {
             None
         );
         assert_eq!(shards_from_config_text(""), None);
+    }
+
+    #[test]
+    fn peer_task_line_scan() {
+        use super::peer_task_from_config_text;
+        assert_eq!(
+            peer_task_from_config_text("router bgp peer-task true\n"),
+            Some(true)
+        );
+        // Explicit false is distinguishable from absent (so config can
+        // override an env-on).
+        assert_eq!(
+            peer_task_from_config_text("router bgp peer-task false\n"),
+            Some(false)
+        );
+        // Absent ⇒ None (caller falls back to env / off).
+        assert_eq!(peer_task_from_config_text("router bgp shards 4\n"), None);
+        assert_eq!(peer_task_from_config_text(""), None);
     }
 }

--- a/zebra-rs/src/config/manager.rs
+++ b/zebra-rs/src/config/manager.rs
@@ -1417,6 +1417,42 @@ mod yang_load_tests {
         }
     }
 
+    /// `router bgp peer-task <true|false>` — the per-peer egress-task model
+    /// knob (`zebra-bgp-sharding.yang`), the shipping form of
+    /// `ZEBRA_BGP_PEER_TASK`. Pinned for the same reason as `shards`:
+    /// `configured_peer_task` reads this leaf at spawn, and a broken path
+    /// would silently fall back to the env/default.
+    #[test]
+    fn bgp_peer_task_grammar() {
+        use crate::config::ExecCode;
+        use crate::config::parse::{State, parse};
+        use libyang::to_entry;
+
+        let mut yang = YangStore::new();
+        yang.add_path(concat!(env!("CARGO_MANIFEST_DIR"), "/yang"));
+        yang.read_with_resolve("configure")
+            .expect("configure mode loads");
+        yang.identity_resolve();
+        let module = yang
+            .find_module("configure")
+            .expect("configure module present");
+        let entry = to_entry(&yang, module);
+
+        // Both boolean forms must be settable paths directly under `router
+        // bgp` — the exact text `configured_peer_task` scans for.
+        for cmd in [
+            "set router bgp peer-task true",
+            "set router bgp peer-task false",
+        ] {
+            let (code, _comps, _state) = parse(cmd, entry.clone(), None, State::new());
+            assert_eq!(
+                code,
+                ExecCode::Success,
+                "should parse as a settable path: {cmd}"
+            );
+        }
+    }
+
     /// TI-LFA parallel-computation knobs: `fast-reroute ti-lfa
     /// compute-mode <serial|conservative|aggressive|sharding>` plus
     /// `compute-shards <1..256>`. Pinned because vtyctl apply is

--- a/zebra-rs/yang/zebra-bgp-sharding.yang
+++ b/zebra-rs/yang/zebra-bgp-sharding.yang
@@ -63,6 +63,21 @@ module zebra-bgp-sharding {
          No YANG default is declared on purpose: an unset leaf must stay
          absent so it does not shadow the ZEBRA_BGP_SHARDS fallback.";
     }
+    leaf peer-task {
+      ext:help "Per-peer egress task model (GoBGP-style; default false)";
+      type boolean;
+      description
+        "Egress model for plain IPv4-unicast. false (default) keeps the
+         FRR-style update-group egress on the main task; true runs the
+         GoBGP-style per-peer egress task, spawned per peer at Established.
+         The two models are alternatives, never interleaved, so this is read
+         once at instance spawn and immutable thereafter — changing it on a
+         live instance is ignored with a warning. Supersedes the
+         ZEBRA_BGP_PEER_TASK environment variable (the fallback when unset);
+         no YANG default is declared so an unset leaf stays absent and does
+         not shadow that fallback. Experimental — the update-group model
+         remains the supported default, especially for route reflectors.";
+    }
   }
 
   /* =========================================================


### PR DESCRIPTION
## Summary

Adds `router bgp peer-task <true|false>` — the shipping form of the
`ZEBRA_BGP_PEER_TASK` environment variable, selecting the per-peer egress
task (PET, GoBGP per-peer model) vs the default update-group (FRR) egress.
A new `peer-task` boolean leaf in `zebra-bgp-sharding.yang`, sibling of
`shards` (both are `router bgp` parallelism knobs).

Mirrors the `shards` (C.4) plumbing exactly:

- `configured_peer_task` scans the committed candidate config for
  `router bgp peer-task <bool>` (same flattened-text read as `shards`);
- `init_peer_task` freezes the resolved value (**leaf → `ZEBRA_BGP_PEER_TASK`
  → false**) into a process-global `OnceLock` at `spawn_bgp`, before any peer
  establishes, so `peer_egress_task_enabled()` returns it at all ~8 gate
  sites;
- **startup-only**: the PET and update-group models are alternatives, never
  interleaved, so a live `peer-task` change is ignored with a warning (clear
  `router bgp` or restart);
- the env var stays the fallback (the env-based BDD is unchanged);
- a startup INFO line reports the resolved model + source.

No YANG default on the leaf, so an unset knob stays absent and doesn't shadow
the env fallback. Experimental — the update-group model remains the supported
default, especially for route reflectors.

## Test plan

- **Unit** (`cargo test --workspace --exclude bdd`, all green): `resolve_peer_task`
  precedence; `peer_task_from_config_text` line scan (explicit `false`
  distinguishable from absent); `bgp_peer_task_grammar` pins
  `set router bgp peer-task <true|false>`; `configure_mode_loads` validates
  the updated module.
- **BDD `@bgp_peer_task_config_knob`** (3/3): device started with the plain
  step (no env vars), reads both `shards: 4` and `peer-task: true` from
  config; asserts both startup log lines (`BGP RIB sharding: 4 shards (from
  config)` and `BGP per-peer egress task: enabled (from config)`) plus
  end-to-end route propagation through the config-driven PET egress.
- **Regression**: `@bgp_peer_egress_v4` (env path) stays 7/7;
  `@bgp_shard_config_knob` stays 3/3.
- Book: `ch-02-31-bgp-rib-sharding.md` extended with a per-peer egress task
  section. fmt + `cargo clippy --workspace --all-targets -- -D warnings` clean.

Note: BDD is excluded from CI; the daemon loads YANG from installed
`/etc/zebra-rs/yang`, so running the BDD locally needs the updated module
synced there (`make` install / `sudo cp zebra-rs/yang/*.yang /etc/zebra-rs/yang/`).

Generated with [Claude Code](https://claude.com/claude-code)
