### PR TITLE
bgp: per-update-group egress task (migration Phases 0-4, env-gated)

### DIFF
--- a/bdd/tests/configs/bgp_egress_group_task/z1-base.yaml
+++ b/bdd/tests/configs/bgp_egress_group_task/z1-base.yaml
@@ -1,0 +1,15 @@
+router:
+  bgp:
+    global:
+      as: 65001
+      router-id: 10.0.0.1
+    timer:
+      adv-interval:
+        ebgp: 1
+    neighbor:
+    - remote-address: 10.0.0.2
+      afi-safi:
+      - name: ipv4
+        enabled: true
+      enabled: true
+      remote-as: 65002

--- a/bdd/tests/configs/bgp_egress_group_task/z1-routes.yaml
+++ b/bdd/tests/configs/bgp_egress_group_task/z1-routes.yaml
@@ -1,0 +1,20 @@
+router:
+  bgp:
+    global:
+      as: 65001
+      router-id: 10.0.0.1
+    timer:
+      adv-interval:
+        ebgp: 1
+    neighbor:
+    - remote-address: 10.0.0.2
+      afi-safi:
+      - name: ipv4
+        enabled: true
+      enabled: true
+      remote-as: 65002
+    afi-safi:
+    - name: ipv4
+      network:
+      - prefix: 10.10.10.0/24
+      - prefix: 10.10.11.0/24

--- a/bdd/tests/configs/bgp_egress_group_task/z1-withdraw.yaml
+++ b/bdd/tests/configs/bgp_egress_group_task/z1-withdraw.yaml
@@ -1,0 +1,19 @@
+router:
+  bgp:
+    global:
+      as: 65001
+      router-id: 10.0.0.1
+    timer:
+      adv-interval:
+        ebgp: 1
+    neighbor:
+    - remote-address: 10.0.0.2
+      afi-safi:
+      - name: ipv4
+        enabled: true
+      enabled: true
+      remote-as: 65002
+    afi-safi:
+    - name: ipv4
+      network:
+      - prefix: 10.10.11.0/24

--- a/bdd/tests/configs/bgp_egress_group_task/z2.yaml
+++ b/bdd/tests/configs/bgp_egress_group_task/z2.yaml
@@ -1,0 +1,21 @@
+router:
+  bgp:
+    global:
+      as: 65002
+      router-id: 10.0.0.2
+    timer:
+      adv-interval:
+        ebgp: 1
+    neighbor:
+    - remote-address: 10.0.0.1
+      afi-safi:
+      - name: ipv4
+        enabled: true
+      enabled: true
+      remote-as: 65001
+    - remote-address: 10.0.0.3
+      afi-safi:
+      - name: ipv4
+        enabled: true
+      enabled: true
+      remote-as: 65003

--- a/bdd/tests/configs/bgp_egress_group_task/z2.yaml
+++ b/bdd/tests/configs/bgp_egress_group_task/z2.yaml
@@ -19,3 +19,9 @@ router:
         enabled: true
       enabled: true
       remote-as: 65003
+    - remote-address: 10.0.0.4
+      afi-safi:
+      - name: ipv4
+        enabled: true
+      enabled: true
+      remote-as: 65004

--- a/bdd/tests/configs/bgp_egress_group_task/z3.yaml
+++ b/bdd/tests/configs/bgp_egress_group_task/z3.yaml
@@ -1,0 +1,15 @@
+router:
+  bgp:
+    global:
+      as: 65003
+      router-id: 10.0.0.3
+    timer:
+      adv-interval:
+        ebgp: 1
+    neighbor:
+    - remote-address: 10.0.0.2
+      afi-safi:
+      - name: ipv4
+        enabled: true
+      enabled: true
+      remote-as: 65002

--- a/bdd/tests/configs/bgp_egress_group_task/z4.yaml
+++ b/bdd/tests/configs/bgp_egress_group_task/z4.yaml
@@ -1,0 +1,15 @@
+router:
+  bgp:
+    global:
+      as: 65004
+      router-id: 10.0.0.4
+    timer:
+      adv-interval:
+        ebgp: 1
+    neighbor:
+    - remote-address: 10.0.0.2
+      afi-safi:
+      - name: ipv4
+        enabled: true
+      enabled: true
+      remote-as: 65002

--- a/bdd/tests/cucumber.rs
+++ b/bdd/tests/cucumber.rs
@@ -469,6 +469,41 @@ async fn start_zebra_rs_sharded_peer_task(world: &mut World, namespace: String, 
     );
 }
 
+#[when(expr = "I start zebra-rs in namespace {string} with egress group task")]
+async fn start_zebra_rs_egress_group_task(world: &mut World, namespace: String) {
+    let scoped = world.ns(&namespace);
+    let log_file = format!("logs/{}.log", scoped);
+    let pid_file = world.pid_file(&namespace);
+
+    let _child = netns::spawn_in_netns_env(
+        &scoped,
+        // Group-task migration Phase 0: ZEBRA_BGP_EGRESS_GROUP_TASK spawns one
+        // egress task per update-group. Phase 0 is idle (it tracks members and
+        // routes no egress yet), so this exercises the spawn/teardown lifecycle
+        // without changing egress.
+        &[
+            ("ZEBRA_XDP_BFD_ECHO_MODE", "skb"),
+            ("ZEBRA_BGP_EGRESS_GROUP_TASK", "1"),
+        ],
+        "zebra-rs",
+        &[
+            "--daemon",
+            "--log-output=file",
+            &format!("--log-file={}", log_file),
+            &format!("--pid-file={}", pid_file),
+        ],
+    )
+    .await
+    .expect("Failed to start zebra-rs");
+
+    tokio::time::sleep(tokio::time::Duration::from_secs(1)).await;
+
+    println!(
+        "✓ zebra-rs started in namespace {} with egress group task (pid file {})",
+        scoped, pid_file
+    );
+}
+
 #[when(expr = "I start zebra-rs in namespace {string} with sync chunk {int}")]
 async fn start_zebra_rs_sync_chunk(world: &mut World, namespace: String, chunk: usize) {
     let scoped = world.ns(&namespace);

--- a/bdd/tests/features/bgp_egress_group_task.feature
+++ b/bdd/tests/features/bgp_egress_group_task.feature
@@ -69,6 +69,17 @@ Feature: BGP per-update-group egress task lifecycle (migration Phase 0)
     Then show command "show bgp ipv4" in namespace "z3" should not contain "10.10.10.0/24"
     And show command "show bgp ipv4" in namespace "z3" should contain "10.10.11.0/24"
 
+  Scenario: a peer-down withdraw propagates through the group task (Phase 2)
+    Given the test topology exists
+    # z3 still holds .11 (positive control). Stopping z1 makes z2 clean z1's
+    # routes; the group task must withdraw .11 from z3. This is the peer-down
+    # path (route_clean), distinct from the event-driven withdraw above.
+    Then show command "show bgp ipv4" in namespace "z3" should contain "10.10.11.0/24"
+    When I stop zebra-rs in namespace "z1"
+    And I wait 20 seconds for BGP to operate
+    Then BGP session in "z2" to "10.0.0.1" should not be "Established"
+    And show command "show bgp ipv4" in namespace "z3" should not contain "10.10.11.0/24"
+
   Scenario: Teardown topology
     Given the test topology exists
     When I stop zebra-rs in namespace "z1"

--- a/bdd/tests/features/bgp_egress_group_task.feature
+++ b/bdd/tests/features/bgp_egress_group_task.feature
@@ -1,0 +1,55 @@
+@serial
+@bgp_egress_group_task
+Feature: BGP per-update-group egress task lifecycle (migration Phase 0)
+
+  Phase 0 of the per-update-group egress-task migration
+  (docs/design/bgp-egress-group-task-migration.md). At
+  ZEBRA_BGP_EGRESS_GROUP_TASK=1 the speaker spawns one egress task per
+  update group, tracking the group's members from the attach/detach
+  machinery. Phase 0 is IDLE — the task routes no egress yet (that is
+  Phase 1) — so the egress output is unchanged; this feature only proves the
+  task LIFECYCLE: a group forming spawns its task, and sessions/teardown are
+  undisturbed.
+
+  z2 is the device under test, started with the egress group task. When its
+  eBGP neighbors z1 and z3 establish, z2 forms at least one update group, so
+  its log must show the group-task spawn. The sessions establishing proves
+  the spawn/track wiring does not disrupt the session machinery.
+
+  Test Topology:
+  ```
+  z1 (AS65001) ── z2 (AS65002) ── z3 (AS65003)
+   10.0.0.1/24    10.0.0.2/24     10.0.0.3/24
+                  egress group
+                  task (gate-on)
+  ```
+  All three on bridge br0.
+
+  Scenario: a group forming spawns its egress task; sessions are undisturbed
+    Given a clean test environment
+    When I create bridge "br0"
+    And I create namespace "z1" with IP "10.0.0.1/24" on bridge "br0"
+    And I create namespace "z2" with IP "10.0.0.2/24" on bridge "br0"
+    And I create namespace "z3" with IP "10.0.0.3/24" on bridge "br0"
+    And I start zebra-rs in namespace "z1"
+    And I start zebra-rs in namespace "z2" with egress group task
+    And I start zebra-rs in namespace "z3"
+    And I apply config "z1-base.yaml" to namespace "z1"
+    And I apply config "z2.yaml" to namespace "z2"
+    And I apply config "z3.yaml" to namespace "z3"
+    And I wait 10 seconds for BGP to operate
+    # A group forms once a peer establishes, so the task must have spawned.
+    Then the zebra-rs log in namespace "z2" should contain "BGP egress group task: spawned"
+    And BGP session in "z2" to "10.0.0.1" should be "Established"
+    And BGP session in "z2" to "10.0.0.3" should be "Established"
+
+  Scenario: Teardown topology
+    Given the test topology exists
+    When I stop zebra-rs in namespace "z1"
+    And I stop zebra-rs in namespace "z2"
+    And I stop zebra-rs in namespace "z3"
+    And I delete namespace "z1"
+    And I delete namespace "z2"
+    And I delete namespace "z3"
+    And I delete bridge "br0"
+    Then the test environment should be clean

--- a/bdd/tests/features/bgp_egress_group_task.feature
+++ b/bdd/tests/features/bgp_egress_group_task.feature
@@ -43,6 +43,32 @@ Feature: BGP per-update-group egress task lifecycle (migration Phase 0)
     And BGP session in "z2" to "10.0.0.1" should be "Established"
     And BGP session in "z2" to "10.0.0.3" should be "Established"
 
+  Scenario: routes propagate through the group task (Phase 1b event-driven advertise)
+    Given the test topology exists
+    # All speakers are up before any route exists, so z1's origination is an
+    # event-driven advertise: z2's reduce fans one delta to the (single) update
+    # group serving z3, whose task encodes once and sends to z3 (split-horizon
+    # excludes z1, the source). z2's own `show bgp ipv4` reads its Loc-RIB.
+    When I apply config "z1-routes.yaml" to namespace "z1"
+    And I wait 10 seconds for BGP to operate
+    Then show command "show bgp ipv4" in namespace "z2" should contain "10.10.10.0/24"
+    And show command "show bgp ipv4" in namespace "z2" should contain "10.10.11.0/24"
+    And show command "show bgp ipv4" in namespace "z3" should contain "10.10.10.0/24"
+    And show command "show bgp ipv4" in namespace "z3" should contain "10.10.11.0/24"
+
+  Scenario: an event-driven withdraw propagates through the group task (Phase 1b)
+    Given the test topology exists
+    # z1 re-originates only 10.10.11.0/24 (dropping .10). The reduce's
+    # apply_ipv4_advertise_job handles BOTH the advertise and the withdraw, so
+    # the group task must withdraw .10 from z3 while .11 stays — proving the
+    # gate-on event path is coherent (advertise + withdraw both through the
+    # task, the update-group flush bypassed). .11 staying is the positive
+    # control so the negative assertion isn't vacuous.
+    When I apply config "z1-withdraw.yaml" to namespace "z1"
+    And I wait 10 seconds for BGP to operate
+    Then show command "show bgp ipv4" in namespace "z3" should not contain "10.10.10.0/24"
+    And show command "show bgp ipv4" in namespace "z3" should contain "10.10.11.0/24"
+
   Scenario: Teardown topology
     Given the test topology exists
     When I stop zebra-rs in namespace "z1"

--- a/bdd/tests/features/bgp_egress_group_task.feature
+++ b/bdd/tests/features/bgp_egress_group_task.feature
@@ -1,36 +1,44 @@
 @serial
 @bgp_egress_group_task
-Feature: BGP per-update-group egress task lifecycle (migration Phase 0)
+Feature: BGP per-update-group egress task (migration Phases 0-3)
 
-  Phase 0 of the per-update-group egress-task migration
+  Per-update-group egress-task migration
   (docs/design/bgp-egress-group-task-migration.md). At
-  ZEBRA_BGP_EGRESS_GROUP_TASK=1 the speaker spawns one egress task per
-  update group, tracking the group's members from the attach/detach
-  machinery. Phase 0 is IDLE — the task routes no egress yet (that is
-  Phase 1) — so the egress output is unchanged; this feature only proves the
-  task LIFECYCLE: a group forming spawns its task, and sessions/teardown are
-  undisturbed.
+  ZEBRA_BGP_EGRESS_GROUP_TASK=1 the v4-unicast egress runs in one task per
+  update group (M tasks, not N peers): the task owns the group adj_out,
+  encodes each best path once, and fans the bytes to its member peers,
+  excluding the path's source (split-horizon).
 
-  z2 is the device under test, started with the egress group task. When its
-  eBGP neighbors z1 and z3 establish, z2 forms at least one update group, so
-  its log must show the group-task spawn. The sessions establishing proves
-  the spawn/track wiring does not disrupt the session machinery.
+  This feature exercises the gate-on egress matrix through the group task:
+    * Phase 0/1a — a forming group spawns its task (lifecycle).
+    * Phase 1b — z1's origination is an event-driven advertise that reaches
+      z3 through the task; an event-driven withdraw drops a route.
+    * Phase 2 — peer-down (z1 stops) withdraws through the task.
+    * Phase 3 — z4 establishes AFTER the routes exist (a late peer). It must
+      receive them on session-up sync, and — the coherence check — a later
+      withdraw / peer-down must reach z4 too, which holds only if the group
+      adj_out reflects what z4 was sync'd.
+
+  z3 and z4 share one update group (same eBGP egress identity; remote-AS is
+  not part of the signature). z2 is the device under test, started with the
+  egress group task.
 
   Test Topology:
   ```
-  z1 (AS65001) ── z2 (AS65002) ── z3 (AS65003)
-   10.0.0.1/24    10.0.0.2/24     10.0.0.3/24
-                  egress group
+                        ┌── z3 (AS65003)  early peer
+  z1 (AS65001) ── z2 (AS65002) ──┤
+                  egress group   └── z4 (AS65004)  late peer (Phase 3)
                   task (gate-on)
   ```
-  All three on bridge br0.
+  All four on bridge br0. z1 originates 10.10.10.0/24 + 10.10.11.0/24.
 
-  Scenario: a group forming spawns its egress task; sessions are undisturbed
+  Scenario: a group forming spawns its egress task; early speakers establish
     Given a clean test environment
     When I create bridge "br0"
     And I create namespace "z1" with IP "10.0.0.1/24" on bridge "br0"
     And I create namespace "z2" with IP "10.0.0.2/24" on bridge "br0"
     And I create namespace "z3" with IP "10.0.0.3/24" on bridge "br0"
+    And I create namespace "z4" with IP "10.0.0.4/24" on bridge "br0"
     And I start zebra-rs in namespace "z1"
     And I start zebra-rs in namespace "z2" with egress group task
     And I start zebra-rs in namespace "z3"
@@ -38,55 +46,60 @@ Feature: BGP per-update-group egress task lifecycle (migration Phase 0)
     And I apply config "z2.yaml" to namespace "z2"
     And I apply config "z3.yaml" to namespace "z3"
     And I wait 10 seconds for BGP to operate
-    # A group forms once a peer establishes, so the task must have spawned.
     Then the zebra-rs log in namespace "z2" should contain "BGP egress group task: spawned"
     And BGP session in "z2" to "10.0.0.1" should be "Established"
     And BGP session in "z2" to "10.0.0.3" should be "Established"
 
   Scenario: routes propagate through the group task (Phase 1b event-driven advertise)
     Given the test topology exists
-    # All speakers are up before any route exists, so z1's origination is an
-    # event-driven advertise: z2's reduce fans one delta to the (single) update
-    # group serving z3, whose task encodes once and sends to z3 (split-horizon
-    # excludes z1, the source). z2's own `show bgp ipv4` reads its Loc-RIB.
     When I apply config "z1-routes.yaml" to namespace "z1"
     And I wait 10 seconds for BGP to operate
     Then show command "show bgp ipv4" in namespace "z2" should contain "10.10.10.0/24"
-    And show command "show bgp ipv4" in namespace "z2" should contain "10.10.11.0/24"
     And show command "show bgp ipv4" in namespace "z3" should contain "10.10.10.0/24"
     And show command "show bgp ipv4" in namespace "z3" should contain "10.10.11.0/24"
 
-  Scenario: an event-driven withdraw propagates through the group task (Phase 1b)
+  Scenario: a late peer z4 gets the routes on session-up sync (Phase 3)
     Given the test topology exists
-    # z1 re-originates only 10.10.11.0/24 (dropping .10). The reduce's
-    # apply_ipv4_advertise_job handles BOTH the advertise and the withdraw, so
-    # the group task must withdraw .10 from z3 while .11 stays — proving the
-    # gate-on event path is coherent (advertise + withdraw both through the
-    # task, the update-group flush bypassed). .11 staying is the positive
-    # control so the negative assertion isn't vacuous.
+    # z4's daemon starts now — AFTER z2 already holds z1's routes — so z4
+    # learns them via z2's route_sync_ipv4 dump while it joins z3's update
+    # group. z4 seeing both prefixes proves the late-join sync path.
+    When I start zebra-rs in namespace "z4"
+    And I apply config "z4.yaml" to namespace "z4"
+    And I wait 15 seconds for BGP to operate
+    Then BGP session in "z2" to "10.0.0.4" should be "Established"
+    And show command "show bgp ipv4" in namespace "z4" should contain "10.10.10.0/24"
+    And show command "show bgp ipv4" in namespace "z4" should contain "10.10.11.0/24"
+
+  Scenario: an event-driven withdraw reaches BOTH the early and the late member (Phase 3 coherence)
+    Given the test topology exists
+    # z1 re-originates only .11. The group task must withdraw .10 from z3 AND
+    # z4 — z4 too only if the group adj_out reflects what z4 was sync'd (the
+    # late-member coherence the per-peer route_sync would otherwise miss).
     When I apply config "z1-withdraw.yaml" to namespace "z1"
     And I wait 10 seconds for BGP to operate
     Then show command "show bgp ipv4" in namespace "z3" should not contain "10.10.10.0/24"
     And show command "show bgp ipv4" in namespace "z3" should contain "10.10.11.0/24"
+    And show command "show bgp ipv4" in namespace "z4" should not contain "10.10.10.0/24"
+    And show command "show bgp ipv4" in namespace "z4" should contain "10.10.11.0/24"
 
-  Scenario: a peer-down withdraw propagates through the group task (Phase 2)
+  Scenario: peer-down withdraws through the group task to both members (Phase 2/3)
     Given the test topology exists
-    # z3 still holds .11 (positive control). Stopping z1 makes z2 clean z1's
-    # routes; the group task must withdraw .11 from z3. This is the peer-down
-    # path (route_clean), distinct from the event-driven withdraw above.
-    Then show command "show bgp ipv4" in namespace "z3" should contain "10.10.11.0/24"
+    Then show command "show bgp ipv4" in namespace "z4" should contain "10.10.11.0/24"
     When I stop zebra-rs in namespace "z1"
     And I wait 20 seconds for BGP to operate
     Then BGP session in "z2" to "10.0.0.1" should not be "Established"
     And show command "show bgp ipv4" in namespace "z3" should not contain "10.10.11.0/24"
+    And show command "show bgp ipv4" in namespace "z4" should not contain "10.10.11.0/24"
 
   Scenario: Teardown topology
     Given the test topology exists
     When I stop zebra-rs in namespace "z1"
     And I stop zebra-rs in namespace "z2"
     And I stop zebra-rs in namespace "z3"
+    And I stop zebra-rs in namespace "z4"
     And I delete namespace "z1"
     And I delete namespace "z2"
     And I delete namespace "z3"
+    And I delete namespace "z4"
     And I delete bridge "br0"
     Then the test environment should be clean

--- a/bdd/tests/features/bgp_egress_group_task.feature
+++ b/bdd/tests/features/bgp_egress_group_task.feature
@@ -70,6 +70,19 @@ Feature: BGP per-update-group egress task (migration Phases 0-3)
     And show command "show bgp ipv4" in namespace "z4" should contain "10.10.10.0/24"
     And show command "show bgp ipv4" in namespace "z4" should contain "10.10.11.0/24"
 
+  Scenario: a clear soft-out re-fans the group through the task (Phase 4)
+    Given the test topology exists
+    # `clear ... soft out` on z2 for z3 triggers route_soft_out_peer, which at
+    # gate-on refreshes the group's member ctxs and re-fans the v4 Loc-RIB
+    # through the task. With no policy change the routes are unchanged, so z3
+    # (and z4, its group-mate) keep them — proving the soft-out re-fan
+    # re-advertises rather than dropping or going through the old flush.
+    When I run "clear bgp ipv4 neighbor 10.0.0.3 soft out" in namespace "z2"
+    And I wait 5 seconds for BGP to operate
+    Then show command "show bgp ipv4" in namespace "z3" should contain "10.10.10.0/24"
+    And show command "show bgp ipv4" in namespace "z3" should contain "10.10.11.0/24"
+    And show command "show bgp ipv4" in namespace "z4" should contain "10.10.10.0/24"
+
   Scenario: an event-driven withdraw reaches BOTH the early and the late member (Phase 3 coherence)
     Given the test topology exists
     # z1 re-originates only .11. The group task must withdraw .10 from z3 AND

--- a/zebra-rs/src/bgp/group_egress.rs
+++ b/zebra-rs/src/bgp/group_egress.rs
@@ -62,16 +62,14 @@ pub enum GroupEgressDeltaV4 {
     RemoveMember {
         ident: usize,
     },
-    // Advertise / Withdraw are routed by the reduce in Phase 1b; until then
-    // they are constructed only by the engine unit tests, so the bin build
-    // sees them as unconstructed.
-    #[allow(dead_code)]
+    /// The new best path for `prefix`. The split-horizon source is the path's
+    /// own origin (`rib.ident`), derived in the engine — no separate field.
     Advertise {
         prefix: Ipv4Net,
         rib: BgpRib,
-        source_ident: usize,
     },
-    #[allow(dead_code)]
+    /// `prefix` is gone; `source_ident` is the withdrawing peer (excluded from
+    /// the fan — it never received the advertisement under split-horizon).
     Withdraw {
         prefix: Ipv4Net,
         id: u32,
@@ -147,11 +145,7 @@ impl Engine {
             GroupEgressDeltaV4::RemoveMember { ident } => {
                 self.members.remove(&ident);
             }
-            GroupEgressDeltaV4::Advertise {
-                prefix,
-                rib,
-                source_ident,
-            } => self.advertise(prefix, rib, source_ident),
+            GroupEgressDeltaV4::Advertise { prefix, rib } => self.advertise(prefix, rib),
             GroupEgressDeltaV4::Withdraw {
                 prefix,
                 id,
@@ -165,11 +159,22 @@ impl Engine {
     /// once, and fan to every member except `source_ident`. A build / policy
     /// filter (split-horizon at the source, policy-deny) becomes a withdraw,
     /// exactly as the PET / gate-off `Withdraw` outcome.
-    fn advertise(&mut self, prefix: Ipv4Net, mut rib: BgpRib, source_ident: usize) {
-        // Any member's ctx yields the canonical bytes (shared transform).
-        let Some(ctx) = self.members.values().next().cloned() else {
-            // No members yet — still record the group's RIB state so a future
-            // member is caught up; nothing to send.
+    fn advertise(&mut self, prefix: Ipv4Net, mut rib: BgpRib) {
+        // Split-horizon target is the path's own source peer.
+        let source = rib.ident;
+        // Build with a NON-source member's ctx: `route_update_ipv4` drops the
+        // advertise when `ctx.ident == rib.ident`, so the source member's ctx
+        // would wrongly collapse the whole group advertise into a withdraw.
+        // The transform is otherwise group-shared, so any non-source member
+        // yields the canonical bytes.
+        let Some(ctx) = self
+            .members
+            .iter()
+            .find(|(id, _)| **id != source)
+            .map(|(_, c)| c.clone())
+        else {
+            // No non-source member to advertise to — still record the group's
+            // RIB state so a future member is caught up; nothing to send.
             let arc = self.attr_store.intern((*rib.attr).clone());
             rib.attr = arc;
             self.adj_out.add(prefix, rib);
@@ -182,7 +187,7 @@ impl Engine {
             },
         );
         let Some((nlri, decision)) = built else {
-            self.withdraw(prefix, rib.remote_id, source_ident);
+            self.withdraw(prefix, rib.remote_id, source);
             return;
         };
         let arc = self.attr_store.intern(decision.attr);
@@ -191,7 +196,7 @@ impl Engine {
         let already_sent = prev.is_some_and(|p| Arc::ptr_eq(&p.attr, &arc));
         if !already_sent {
             let bytes_list = encode_ipv4_update(&arc, &[nlri], ctx.max_packet_size(), None);
-            self.fan(&bytes_list, source_ident);
+            self.fan(&bytes_list, source);
         }
     }
 
@@ -267,11 +272,12 @@ mod tests {
         rx
     }
 
-    fn advertise(engine: &mut Engine, prefix: &str, source_ident: usize) {
+    /// `src` becomes the path's source (`rib.ident`) — the split-horizon
+    /// target the engine derives.
+    fn advertise(engine: &mut Engine, prefix: &str, src: usize) {
         engine.handle(GroupEgressDeltaV4::Advertise {
             prefix: prefix.parse().unwrap(),
-            rib: rib(5, "192.0.2.1"),
-            source_ident,
+            rib: rib(src, "192.0.2.1"),
         });
     }
 

--- a/zebra-rs/src/bgp/group_egress.rs
+++ b/zebra-rs/src/bgp/group_egress.rs
@@ -1,0 +1,112 @@
+//! Per-update-group egress task — **Phase 0 (the lifecycle shell)**.
+//!
+//! Plan: `docs/design/bgp-egress-group-task-migration.md`. The end state is
+//! one persistent task per [`UpdateGroup`](super::update_group::UpdateGroup)
+//! that owns the group's coalescing cache + the encode and fans bytes to its
+//! member peers — **M tasks (groups), not N (peers)**, coalescing *and*
+//! off-main-parallel. A per-peer egress task (PET) is the M=1 case.
+//!
+//! Phase 0 is only the lifecycle: env-gated, spawned when a group is created
+//! (`attach`) and dropped when it empties (`detach`), tracking its member set
+//! from the membership machinery. It is **idle** — no egress is routed through
+//! it yet (Phase 1). Default off; gate-off is byte-identical (no task is
+//! created and the member sends are `if let Some` no-ops).
+
+use std::collections::BTreeSet;
+use std::sync::OnceLock;
+
+use tokio::sync::mpsc::{self, UnboundedSender};
+
+use crate::context::task::Task;
+
+use super::update_group::UpdateGroupId;
+
+/// `ZEBRA_BGP_EGRESS_GROUP_TASK=1` opts into the per-update-group egress task
+/// (the group-task migration). Default off: egress stays on the update-group
+/// flush / the per-peer PET, unchanged. Read once — the egress model is fixed
+/// for the instance lifetime, like the other sharding gates.
+pub fn egress_group_task_enabled() -> bool {
+    static ON: OnceLock<bool> = OnceLock::new();
+    *ON.get_or_init(|| {
+        std::env::var("ZEBRA_BGP_EGRESS_GROUP_TASK")
+            .ok()
+            .is_some_and(|v| v == "1" || v.eq_ignore_ascii_case("true"))
+    })
+}
+
+/// A member-set change the `attach` / `detach` machinery pushes to a group's
+/// task. Phase 0 carries identity only; the member's `packet_tx` (for the
+/// fan-out) and the egress deltas arrive in Phase 1.
+#[derive(Debug)]
+pub enum GroupMemberDelta {
+    Add(usize),
+    Remove(usize),
+}
+
+/// Handle main keeps on each [`UpdateGroup`](super::update_group::UpdateGroup)
+/// for its egress task. Dropping it — when the group empties in `detach`, or
+/// when the whole map is torn down — aborts the task (abort-on-drop) and
+/// closes the channel.
+#[derive(Debug)]
+pub struct GroupEgressTask {
+    /// `attach` / `detach` push member add/remove here.
+    member_tx: UnboundedSender<GroupMemberDelta>,
+    // Held only for its abort-on-drop teardown; the task is driven entirely by
+    // the channel, so the handle is never read after spawn.
+    #[allow(dead_code)]
+    task: Task<()>,
+}
+
+impl GroupEgressTask {
+    /// Spawn a group's egress task. **Phase 0 — idle**: it maintains its
+    /// member set from [`GroupMemberDelta`]s and otherwise does nothing.
+    /// Phase 1 adds the egress delta channel and the encode/fan. Exits when
+    /// `member_tx` is dropped (the group emptied).
+    pub fn spawn(id: UpdateGroupId) -> Self {
+        let (member_tx, mut member_rx) = mpsc::unbounded_channel::<GroupMemberDelta>();
+        tracing::info!("BGP egress group task: spawned (group {id:?})");
+        let task = Task::spawn(async move {
+            let mut members: BTreeSet<usize> = BTreeSet::new();
+            while let Some(delta) = member_rx.recv().await {
+                match delta {
+                    GroupMemberDelta::Add(ident) => {
+                        members.insert(ident);
+                    }
+                    GroupMemberDelta::Remove(ident) => {
+                        members.remove(&ident);
+                    }
+                }
+                // Phase 0: membership tracked (the `members.len()` read keeps
+                // the set live for Phase 1), but no egress is routed yet.
+                tracing::debug!("BGP egress group {id:?}: {} member(s)", members.len());
+            }
+            tracing::debug!("BGP egress group task: exited (group {id:?})");
+        });
+        GroupEgressTask { member_tx, task }
+    }
+
+    /// Push a member-set change to the task. A send failure means the task has
+    /// already gone (the group is tearing down), which is harmless here.
+    pub fn member_delta(&self, delta: GroupMemberDelta) {
+        let _ = self.member_tx.send(delta);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use bgp_packet::{Afi, Safi};
+
+    #[tokio::test]
+    async fn spawn_accepts_member_deltas_and_aborts_on_drop() {
+        let task = GroupEgressTask::spawn(UpdateGroupId::new(Afi::Ip, Safi::Unicast, 0));
+        // Member add/remove are accepted without panicking (Phase 0 is idle).
+        task.member_delta(GroupMemberDelta::Add(1));
+        task.member_delta(GroupMemberDelta::Add(2));
+        task.member_delta(GroupMemberDelta::Remove(1));
+        // Dropping the handle closes the channel and aborts the task; the
+        // task observes the closed channel on the next poll and exits.
+        drop(task);
+        tokio::task::yield_now().await;
+    }
+}

--- a/zebra-rs/src/bgp/group_egress.rs
+++ b/zebra-rs/src/bgp/group_egress.rs
@@ -1,25 +1,38 @@
-//! Per-update-group egress task — **Phase 0 (the lifecycle shell)**.
+//! Per-update-group egress task — **Phase 1a (the engine; not yet reduce-wired)**.
 //!
-//! Plan: `docs/design/bgp-egress-group-task-migration.md`. The end state is
-//! one persistent task per [`UpdateGroup`](super::update_group::UpdateGroup)
-//! that owns the group's coalescing cache + the encode and fans bytes to its
-//! member peers — **M tasks (groups), not N (peers)**, coalescing *and*
+//! Plan: `docs/design/bgp-egress-group-task-migration.md`. One persistent task
+//! per [`UpdateGroup`](super::update_group::UpdateGroup) that — at the end of
+//! the migration — owns the group's adj-out + encode and fans bytes to its
+//! member peers: **M tasks (groups), not N (peers)**, coalescing *and*
 //! off-main-parallel. A per-peer egress task (PET) is the M=1 case.
 //!
-//! Phase 0 is only the lifecycle: env-gated, spawned when a group is created
-//! (`attach`) and dropped when it empties (`detach`), tracking its member set
-//! from the membership machinery. It is **idle** — no egress is routed through
-//! it yet (Phase 1). Default off; gate-off is byte-identical (no task is
-//! created and the member sends are `if let Some` no-ops).
+//! Phase 0 was the lifecycle shell (member tracking, idle). **Phase 1a** adds
+//! the [`Engine`]: it captures each member's [`SyncCtx`] and can build one
+//! best-path advertisement **once** (the shared group transform), record it in
+//! the group's `adj_out`, encode it **once**, and **fan** the bytes to every
+//! member except the path's source (split-horizon). It is the per-group twin
+//! of the PET `Engine` — `send_ipv4_direct` fanned across members.
+//!
+//! 1a is **not wired into the reduce yet**: `attach`/`detach` feed the member
+//! set live (so the engine holds real `SyncCtx`s at gate-on), but no
+//! `Advertise`/`Withdraw` delta is routed to it — those land in Phase 1b. So
+//! gate-on egress is unchanged; the engine is exercised by the unit tests.
+//! Default off; gate-off is byte-identical.
 
-use std::collections::BTreeSet;
-use std::sync::OnceLock;
+use std::collections::BTreeMap;
+use std::sync::{Arc, OnceLock};
 
+use bgp_packet::{Ipv4Nlri, UpdatePacket};
+use bytes::BytesMut;
+use ipnet::Ipv4Net;
 use tokio::sync::mpsc::{self, UnboundedSender};
 
 use crate::context::task::Task;
 
-use super::update_group::UpdateGroupId;
+use super::adj_rib::{AdjRibTable, Out};
+use super::route::{BgpRib, SyncCtx};
+use super::store::BgpAttrStore;
+use super::update_group::{UpdateGroupId, encode_ipv4_update};
 
 /// `ZEBRA_BGP_EGRESS_GROUP_TASK=1` opts into the per-update-group egress task
 /// (the group-task migration). Default off: egress stays on the update-group
@@ -34,13 +47,36 @@ pub fn egress_group_task_enabled() -> bool {
     })
 }
 
-/// A member-set change the `attach` / `detach` machinery pushes to a group's
-/// task. Phase 0 carries identity only; the member's `packet_tx` (for the
-/// fan-out) and the egress deltas arrive in Phase 1.
+/// One egress operation the `attach`/`detach` (and, from Phase 1b, the reduce)
+/// machinery forwards to a group's task. `AddMember` carries the member's
+/// `SyncCtx` (its packet sink and the shared egress identity) so the engine can
+/// build and fan, plus the group's `add_path` flag. `Advertise` and `Withdraw`
+/// carry the path's `source_ident` for split-horizon.
 #[derive(Debug)]
-pub enum GroupMemberDelta {
-    Add(usize),
-    Remove(usize),
+pub enum GroupEgressDeltaV4 {
+    AddMember {
+        ident: usize,
+        ctx: Box<SyncCtx>,
+        add_path: bool,
+    },
+    RemoveMember {
+        ident: usize,
+    },
+    // Advertise / Withdraw are routed by the reduce in Phase 1b; until then
+    // they are constructed only by the engine unit tests, so the bin build
+    // sees them as unconstructed.
+    #[allow(dead_code)]
+    Advertise {
+        prefix: Ipv4Net,
+        rib: BgpRib,
+        source_ident: usize,
+    },
+    #[allow(dead_code)]
+    Withdraw {
+        prefix: Ipv4Net,
+        id: u32,
+        source_ident: usize,
+    },
 }
 
 /// Handle main keeps on each [`UpdateGroup`](super::update_group::UpdateGroup)
@@ -49,8 +85,8 @@ pub enum GroupMemberDelta {
 /// closes the channel.
 #[derive(Debug)]
 pub struct GroupEgressTask {
-    /// `attach` / `detach` push member add/remove here.
-    member_tx: UnboundedSender<GroupMemberDelta>,
+    /// `attach` / `detach` (and, from Phase 1b, the reduce) push deltas here.
+    delta_tx: UnboundedSender<GroupEgressDeltaV4>,
     // Held only for its abort-on-drop teardown; the task is driven entirely by
     // the channel, so the handle is never read after spawn.
     #[allow(dead_code)]
@@ -58,55 +94,244 @@ pub struct GroupEgressTask {
 }
 
 impl GroupEgressTask {
-    /// Spawn a group's egress task. **Phase 0 — idle**: it maintains its
-    /// member set from [`GroupMemberDelta`]s and otherwise does nothing.
-    /// Phase 1 adds the egress delta channel and the encode/fan. Exits when
-    /// `member_tx` is dropped (the group emptied).
+    /// Spawn a group's egress task. The [`Engine`] starts empty and fills its
+    /// member set from `AddMember` deltas. Exits when `delta_tx` is dropped
+    /// (the group emptied).
     pub fn spawn(id: UpdateGroupId) -> Self {
-        let (member_tx, mut member_rx) = mpsc::unbounded_channel::<GroupMemberDelta>();
+        let (delta_tx, mut delta_rx) = mpsc::unbounded_channel::<GroupEgressDeltaV4>();
         tracing::info!("BGP egress group task: spawned (group {id:?})");
         let task = Task::spawn(async move {
-            let mut members: BTreeSet<usize> = BTreeSet::new();
-            while let Some(delta) = member_rx.recv().await {
-                match delta {
-                    GroupMemberDelta::Add(ident) => {
-                        members.insert(ident);
-                    }
-                    GroupMemberDelta::Remove(ident) => {
-                        members.remove(&ident);
-                    }
-                }
-                // Phase 0: membership tracked (the `members.len()` read keeps
-                // the set live for Phase 1), but no egress is routed yet.
-                tracing::debug!("BGP egress group {id:?}: {} member(s)", members.len());
+            let mut engine = Engine::default();
+            while let Some(delta) = delta_rx.recv().await {
+                engine.handle(delta);
             }
             tracing::debug!("BGP egress group task: exited (group {id:?})");
         });
-        GroupEgressTask { member_tx, task }
+        GroupEgressTask { delta_tx, task }
     }
 
-    /// Push a member-set change to the task. A send failure means the task has
-    /// already gone (the group is tearing down), which is harmless here.
-    pub fn member_delta(&self, delta: GroupMemberDelta) {
-        let _ = self.member_tx.send(delta);
+    /// Push a delta to the task. A send failure means the task has already
+    /// gone (the group is tearing down), which is harmless here.
+    pub fn send(&self, delta: GroupEgressDeltaV4) {
+        let _ = self.delta_tx.send(delta);
+    }
+}
+
+/// A group's owned v4-unicast egress state + per-delta logic, run inside the
+/// task. The build / out-policy / intern / `adj_out` dedup are identical to
+/// the PET `Engine`; the only difference is the **send**: it encodes one
+/// best-path advertisement once and fans the bytes to every member except the
+/// path's source (split-horizon), instead of to a single peer.
+#[derive(Default)]
+struct Engine {
+    /// Member peer → its `SyncCtx` (the packet sink; the egress-transform
+    /// fields are shared across the group, so any member's ctx builds the
+    /// canonical bytes).
+    members: BTreeMap<usize, SyncCtx>,
+    add_path: bool,
+    adj_out: AdjRibTable<Out>,
+    attr_store: BgpAttrStore,
+}
+
+impl Engine {
+    fn handle(&mut self, delta: GroupEgressDeltaV4) {
+        match delta {
+            GroupEgressDeltaV4::AddMember {
+                ident,
+                ctx,
+                add_path,
+            } => {
+                self.add_path = add_path;
+                self.members.insert(ident, *ctx);
+            }
+            GroupEgressDeltaV4::RemoveMember { ident } => {
+                self.members.remove(&ident);
+            }
+            GroupEgressDeltaV4::Advertise {
+                prefix,
+                rib,
+                source_ident,
+            } => self.advertise(prefix, rib, source_ident),
+            GroupEgressDeltaV4::Withdraw {
+                prefix,
+                id,
+                source_ident,
+            } => self.withdraw(prefix, id, source_ident),
+        }
+    }
+
+    /// Build one best path for the group's shared egress identity, record it
+    /// in `adj_out` (dedup'd by interned-attr pointer identity), encode it
+    /// once, and fan to every member except `source_ident`. A build / policy
+    /// filter (split-horizon at the source, policy-deny) becomes a withdraw,
+    /// exactly as the PET / gate-off `Withdraw` outcome.
+    fn advertise(&mut self, prefix: Ipv4Net, mut rib: BgpRib, source_ident: usize) {
+        // Any member's ctx yields the canonical bytes (shared transform).
+        let Some(ctx) = self.members.values().next().cloned() else {
+            // No members yet — still record the group's RIB state so a future
+            // member is caught up; nothing to send.
+            let arc = self.attr_store.intern((*rib.attr).clone());
+            rib.attr = arc;
+            self.adj_out.add(prefix, rib);
+            return;
+        };
+        let built = super::route::route_update_ipv4(&ctx, &prefix, &rib, self.add_path).and_then(
+            |(nlri, attr)| {
+                super::route::route_apply_policy_out(&ctx, &nlri, attr, rib.weight)
+                    .map(|d| (nlri, d))
+            },
+        );
+        let Some((nlri, decision)) = built else {
+            self.withdraw(prefix, rib.remote_id, source_ident);
+            return;
+        };
+        let arc = self.attr_store.intern(decision.attr);
+        rib.attr = arc.clone();
+        let prev = self.adj_out.add(prefix, rib);
+        let already_sent = prev.is_some_and(|p| Arc::ptr_eq(&p.attr, &arc));
+        if !already_sent {
+            let bytes_list = encode_ipv4_update(&arc, &[nlri], ctx.max_packet_size(), None);
+            self.fan(&bytes_list, source_ident);
+        }
+    }
+
+    /// Drop `prefix` from `adj_out` and, if it had been advertised, fan one
+    /// MP_UNREACH to every member except `source_ident`. Matches by prefix
+    /// (not exact `id`), as the PET withdraw does.
+    fn withdraw(&mut self, prefix: Ipv4Net, id: u32, source_ident: usize) {
+        if self.adj_out.0.remove(&prefix).is_some() {
+            let max = self
+                .members
+                .values()
+                .next()
+                .map(|c| c.max_packet_size())
+                .unwrap_or(4096);
+            let mut update = UpdatePacket::with_max_packet_size(max);
+            update.ipv4_withdraw.push(Ipv4Nlri { id, prefix });
+            self.fan(&[update.into()], source_ident);
+        }
+    }
+
+    /// Fan pre-encoded UPDATE bytes to every member except the path's source.
+    /// The encode happened once; this is a cheap per-member buffer clone +
+    /// enqueue (the per-member backpressure rides each ctx's `send_packet`).
+    fn fan(&self, bytes_list: &[BytesMut], source_ident: usize) {
+        for (ident, ctx) in &self.members {
+            if *ident == source_ident {
+                continue;
+            }
+            for buf in bytes_list {
+                ctx.send_packet(buf.clone());
+            }
+        }
     }
 }
 
 #[cfg(test)]
 mod tests {
+    use super::super::route::BgpRibType;
     use super::*;
-    use bgp_packet::{Afi, Safi};
+    use bgp_packet::{BgpAttr, BgpNexthop};
 
-    #[tokio::test]
-    async fn spawn_accepts_member_deltas_and_aborts_on_drop() {
-        let task = GroupEgressTask::spawn(UpdateGroupId::new(Afi::Ip, Safi::Unicast, 0));
-        // Member add/remove are accepted without panicking (Phase 0 is idle).
-        task.member_delta(GroupMemberDelta::Add(1));
-        task.member_delta(GroupMemberDelta::Add(2));
-        task.member_delta(GroupMemberDelta::Remove(1));
-        // Dropping the handle closes the channel and aborts the task; the
-        // task observes the closed channel on the next poll and exits.
-        drop(task);
-        tokio::task::yield_now().await;
+    /// A best-path row from peer `ident`, next-hop `nh` (mirrors the PET
+    /// test's `rib`).
+    fn rib(ident: usize, nh: &str) -> BgpRib {
+        let attr = BgpAttr {
+            nexthop: Some(BgpNexthop::Ipv4(nh.parse().unwrap())),
+            ..Default::default()
+        };
+        BgpRib::new_arc(
+            ident,
+            "10.0.0.1".parse().unwrap(),
+            BgpRibType::EBGP,
+            0,
+            100,
+            Arc::new(attr),
+            None,
+            None,
+            false,
+        )
+    }
+
+    /// Add a member with a readable packet channel via the real `AddMember`
+    /// delta (so the protocol path is exercised end to end).
+    fn member(engine: &mut Engine, ident: usize) -> mpsc::UnboundedReceiver<BytesMut> {
+        let (tx, rx) = mpsc::unbounded_channel();
+        let mut ctx = SyncCtx::for_test();
+        ctx.packet_tx = Some(tx);
+        engine.handle(GroupEgressDeltaV4::AddMember {
+            ident,
+            ctx: Box::new(ctx),
+            add_path: false,
+        });
+        rx
+    }
+
+    fn advertise(engine: &mut Engine, prefix: &str, source_ident: usize) {
+        engine.handle(GroupEgressDeltaV4::Advertise {
+            prefix: prefix.parse().unwrap(),
+            rib: rib(5, "192.0.2.1"),
+            source_ident,
+        });
+    }
+
+    #[test]
+    fn advertise_encodes_once_and_fans_to_all_members_when_source_is_external() {
+        let mut engine = Engine::default();
+        let mut rx1 = member(&mut engine, 1);
+        let mut rx2 = member(&mut engine, 2);
+        // source 99 is not a member, so both members receive the advertisement.
+        advertise(&mut engine, "10.10.10.0/24", 99);
+        assert!(rx1.try_recv().is_ok(), "member 1 receives the advertise");
+        assert!(rx2.try_recv().is_ok(), "member 2 receives the advertise");
+    }
+
+    #[test]
+    fn advertise_excludes_the_source_member_split_horizon() {
+        let mut engine = Engine::default();
+        let mut rx1 = member(&mut engine, 1);
+        let mut rx2 = member(&mut engine, 2);
+        // The path's source is member 1 — it must NOT be advertised back to it.
+        advertise(&mut engine, "10.10.10.0/24", 1);
+        assert!(rx1.try_recv().is_err(), "source member 1 is excluded");
+        assert!(rx2.try_recv().is_ok(), "member 2 still receives it");
+    }
+
+    #[test]
+    fn re_advertise_same_attr_dedups() {
+        let mut engine = Engine::default();
+        let mut rx1 = member(&mut engine, 1);
+        advertise(&mut engine, "10.10.10.0/24", 99);
+        assert!(rx1.try_recv().is_ok(), "first advertise sends");
+        // Same path again: recorded but not re-sent (interned-attr ptr_eq).
+        advertise(&mut engine, "10.10.10.0/24", 99);
+        assert!(rx1.try_recv().is_err(), "identical re-advertise dedups");
+    }
+
+    #[test]
+    fn removed_member_is_dropped_from_the_fan() {
+        let mut engine = Engine::default();
+        let mut rx1 = member(&mut engine, 1);
+        engine.handle(GroupEgressDeltaV4::RemoveMember { ident: 1 });
+        advertise(&mut engine, "10.10.10.0/24", 99);
+        assert!(rx1.try_recv().is_err(), "removed member receives nothing");
+    }
+
+    #[test]
+    fn withdraw_fans_to_non_source_members() {
+        let mut engine = Engine::default();
+        let mut rx1 = member(&mut engine, 1);
+        let mut rx2 = member(&mut engine, 2);
+        advertise(&mut engine, "10.10.10.0/24", 99);
+        let _ = rx1.try_recv();
+        let _ = rx2.try_recv();
+        // Withdraw of an advertised prefix reaches the non-source members.
+        engine.handle(GroupEgressDeltaV4::Withdraw {
+            prefix: "10.10.10.0/24".parse().unwrap(),
+            id: 0,
+            source_ident: 99,
+        });
+        assert!(rx1.try_recv().is_ok(), "member 1 receives the withdraw");
+        assert!(rx2.try_recv().is_ok(), "member 2 receives the withdraw");
     }
 }

--- a/zebra-rs/src/bgp/group_egress.rs
+++ b/zebra-rs/src/bgp/group_egress.rs
@@ -68,6 +68,15 @@ pub enum GroupEgressDeltaV4 {
         prefix: Ipv4Net,
         rib: BgpRib,
     },
+    /// A route the session-up sync (`route_sync_ipv4`) already sent to a NEW
+    /// member directly — record it in the group `adj_out` *without* re-sending,
+    /// so the group's later withdraws reach that member (a late peer that is
+    /// the first of a new group would otherwise be invisible to the group).
+    /// Mirrors the PET's DumpV4 ③ `RecordAdjOut`.
+    RecordAdjOut {
+        prefix: Ipv4Net,
+        rib: BgpRib,
+    },
     /// `prefix` is gone; `source_ident` is the withdrawing peer (excluded from
     /// the fan — it never received the advertisement under split-horizon).
     Withdraw {
@@ -146,6 +155,7 @@ impl Engine {
                 self.members.remove(&ident);
             }
             GroupEgressDeltaV4::Advertise { prefix, rib } => self.advertise(prefix, rib),
+            GroupEgressDeltaV4::RecordAdjOut { prefix, rib } => self.record_adj_out(prefix, rib),
             GroupEgressDeltaV4::Withdraw {
                 prefix,
                 id,
@@ -198,6 +208,16 @@ impl Engine {
             let bytes_list = encode_ipv4_update(&arc, &[nlri], ctx.max_packet_size(), None);
             self.fan(&bytes_list, source);
         }
+    }
+
+    /// Record a session-up-sync row in `adj_out` **without** sending — sync
+    /// already delivered the bytes to the new member directly. Re-intern the
+    /// (already post-policy) attr in the group's store so the dedup against
+    /// the event-driven path stays pointer-consistent. The PET's `record_adj_out`
+    /// twin.
+    fn record_adj_out(&mut self, prefix: Ipv4Net, mut rib: BgpRib) {
+        rib.attr = self.attr_store.intern((*rib.attr).clone());
+        self.adj_out.add(prefix, rib);
     }
 
     /// Drop `prefix` from `adj_out` and, if it had been advertised, fan one
@@ -339,5 +359,28 @@ mod tests {
         });
         assert!(rx1.try_recv().is_ok(), "member 1 receives the withdraw");
         assert!(rx2.try_recv().is_ok(), "member 2 receives the withdraw");
+    }
+
+    #[test]
+    fn record_adj_out_makes_a_synced_route_withdrawable() {
+        // The first member of a new group is sync'd directly by route_sync_ipv4
+        // (no send via the task); RecordAdjOut puts the route in the group
+        // adj_out so a later group withdraw still reaches that member.
+        let mut engine = Engine::default();
+        let mut rx1 = member(&mut engine, 1);
+        engine.handle(GroupEgressDeltaV4::RecordAdjOut {
+            prefix: "10.10.10.0/24".parse().unwrap(),
+            rib: rib(5, "192.0.2.1"),
+        });
+        assert!(rx1.try_recv().is_err(), "record_adj_out sends nothing");
+        engine.handle(GroupEgressDeltaV4::Withdraw {
+            prefix: "10.10.10.0/24".parse().unwrap(),
+            id: 0,
+            source_ident: 99,
+        });
+        assert!(
+            rx1.try_recv().is_ok(),
+            "the withdraw reaches the sync-recorded member"
+        );
     }
 }

--- a/zebra-rs/src/bgp/mod.rs
+++ b/zebra-rs/src/bgp/mod.rs
@@ -8,6 +8,7 @@ pub mod auth;
 pub mod config;
 pub mod connected;
 pub mod dynamic_neighbors;
+pub mod group_egress;
 pub mod interface_addrs;
 pub mod interface_neighbor;
 pub mod membership;

--- a/zebra-rs/src/bgp/peer.rs
+++ b/zebra-rs/src/bgp/peer.rs
@@ -1605,7 +1605,7 @@ pub fn fsm(
         if prev_state.is_established() && !now_established {
             super::update_group::detach(bgp_ref.update_groups, peer_map, id);
         } else if !prev_state.is_established() && now_established {
-            super::update_group::attach(bgp_ref.update_groups, peer_map, id);
+            super::update_group::attach(bgp_ref.update_groups, peer_map, id, *bgp_ref.router_id);
         }
         peer_map.debug_verify_membership();
     }

--- a/zebra-rs/src/bgp/route.rs
+++ b/zebra-rs/src/bgp/route.rs
@@ -2708,6 +2708,15 @@ fn apply_ipv4_advertise_job(
         added,
         replaced,
     } = job;
+    // Group-task migration Phase 1b (gate-on): the v4-unicast event-driven
+    // advertise/withdraw runs in the per-update-group egress tasks — fan one
+    // delta per group and bypass the update-group flush. Takes precedence over
+    // the per-peer PET below (they are alternative egress models). VPNv4
+    // (`rd = Some`) stays on the update-group path.
+    if rd.is_none() && super::group_egress::egress_group_task_enabled() {
+        fan_advertise_to_groups(prefix, &selected, source_ident, bgp.update_groups, peers);
+        return;
+    }
     // A2 ⑥ (gate-on): the v4-unicast event-driven advertise runs in the
     // PETs — fan the best path there and bypass the update-group path. This
     // is the reduce's advertise sink (`route_apply_bestpath_v4_batch` →
@@ -3062,6 +3071,57 @@ fn fan_advertise_to_pets(prefix: Ipv4Net, selected: &[BgpRib], peers: &PeerMap) 
             None => super::peer_egress::EgressDeltaV4::Withdraw { prefix, id: 0 },
         };
         let _ = pet.delta_tx.send(delta);
+    }
+}
+
+/// Group-task migration Phase 1b — fan the reduce's best-path delta to the
+/// per-update-group egress tasks: **one** delta per group (deduped across the
+/// established members), keyed by `peer.update_group_id`. An empty `selected`
+/// is a withdraw (the path is gone). The per-member split-horizon is the
+/// engine's job (it excludes `rib.ident` from the fan), so the source need
+/// only ride the withdraw — the advertise carries its source in `rib`.
+fn fan_advertise_to_groups(
+    prefix: Ipv4Net,
+    selected: &[BgpRib],
+    source_ident: usize,
+    update_groups: &super::update_group::UpdateGroupMap,
+    peers: &PeerMap,
+) {
+    let afi_safi = AfiSafi::new(Afi::Ip, Safi::Unicast);
+    let new_best = selected.last();
+    let mut seen: std::collections::BTreeSet<super::update_group::UpdateGroupId> =
+        std::collections::BTreeSet::new();
+    for ident in peers.established_plain_idents(Afi::Ip, Safi::Unicast) {
+        let Some(peer) = peers.get_by_idx(ident) else {
+            continue;
+        };
+        let Some(gid) = peer.update_group_id.get(&afi_safi).cloned() else {
+            continue;
+        };
+        // One delta per group, not per member.
+        if !seen.insert(gid.clone()) {
+            continue;
+        }
+        let Some(af) = update_groups.get(&afi_safi) else {
+            continue;
+        };
+        let Some(group) = af.group_by_id(&gid) else {
+            continue;
+        };
+        let Some(task) = group.task.as_ref() else {
+            continue;
+        };
+        match new_best {
+            Some(best) => task.send(super::group_egress::GroupEgressDeltaV4::Advertise {
+                prefix,
+                rib: best.clone(),
+            }),
+            None => task.send(super::group_egress::GroupEgressDeltaV4::Withdraw {
+                prefix,
+                id: 0,
+                source_ident,
+            }),
+        }
     }
 }
 

--- a/zebra-rs/src/bgp/route.rs
+++ b/zebra-rs/src/bgp/route.rs
@@ -3029,6 +3029,15 @@ pub(super) fn route_advertise_to_peers(
     bgp: &mut BgpTop,
     peers: &mut PeerMap,
 ) {
+    // Group-task migration (gate-on): the v4-unicast direct-withdraw / re-
+    // advertise egress (route_ipv4_withdraw, peer-down route_clean) runs in
+    // the per-update-group egress tasks — fan one delta per group. This is the
+    // peer-down path's sink; gating it (not only `apply_ipv4_advertise_job`)
+    // is what makes peer-down coherent at gate-on. Precedes the PET gate.
+    if rd.is_none() && super::group_egress::egress_group_task_enabled() {
+        fan_advertise_to_groups(prefix, selected, source_peer, bgp.update_groups, peers);
+        return;
+    }
     // A2 ⑥ (gate-on): the v4-unicast event-driven advertise runs in the
     // per-peer egress tasks. Fan the best path to each PET — which builds +
     // out-policy + records adj_out + sends/withdraws off the main loop —

--- a/zebra-rs/src/bgp/route.rs
+++ b/zebra-rs/src/bgp/route.rs
@@ -3177,6 +3177,63 @@ fn soft_out_v4_to_pet(peer_idx: usize, bgp: &BgpTop, peers: &PeerMap) {
     }
 }
 
+/// Group-task migration Phase 4 — soft-out for a v4-unicast peer at gate-on.
+/// Refresh every member of the peer's update group with a fresh `SyncCtx` (the
+/// out-policy snapshot changed) by re-sending `AddMember` (which overwrites the
+/// member's ctx), then re-fan the whole v4 Loc-RIB so the group re-evaluates
+/// each route against it — advertising changes, withdrawing newly-denied. The
+/// per-peer soft-out collapses to the group: members share the egress identity,
+/// so a policy-content change is the group's, and the engine's per-prefix
+/// dedup keeps the re-send cheap for the unchanged routes.
+fn soft_out_v4_to_group(peer_idx: usize, bgp: &BgpTop, peers: &PeerMap) {
+    let v4 = AfiSafi::new(Afi::Ip, Safi::Unicast);
+    let Some(peer) = peers.get_by_idx(peer_idx) else {
+        return;
+    };
+    let Some(gid) = peer.update_group_id.get(&v4).cloned() else {
+        return;
+    };
+    let Some(af) = bgp.update_groups.get(&v4) else {
+        return;
+    };
+    let Some(group) = af.group_by_id(&gid) else {
+        return;
+    };
+    let Some(task) = group.task.as_ref() else {
+        return;
+    };
+    let add_path = peer.opt.is_add_path_send(Afi::Ip, Safi::Unicast);
+    // Refresh every member's ctx so the re-fan builds against the new policy.
+    for &ident in &group.members {
+        if let Some(m) = peers.get_by_idx(ident) {
+            task.send(super::group_egress::GroupEgressDeltaV4::AddMember {
+                ident,
+                ctx: Box::new(m.sync_ctx(*bgp.router_id)),
+                add_path: m.opt.is_add_path_send(Afi::Ip, Safi::Unicast),
+            });
+        }
+    }
+    // Re-fan the v4 Loc-RIB so the group re-evaluates every route.
+    let routes: Vec<(Ipv4Net, BgpRib)> = if add_path {
+        bgp.shard
+            .v4
+            .0
+            .iter()
+            .flat_map(|(prefix, ribs)| ribs.iter().map(move |rib| (prefix, rib.clone())))
+            .collect()
+    } else {
+        bgp.shard
+            .v4
+            .1
+            .iter()
+            .map(|(prefix, rib)| (prefix, rib.clone()))
+            .collect()
+    };
+    for (prefix, rib) in routes {
+        task.send(super::group_egress::GroupEgressDeltaV4::Advertise { prefix, rib });
+    }
+}
+
 /// Per-AF hooks for the generic update-group/memo advertise path
 /// ([`route_advertise_batch`]). Phase 2 of the Adj-RIB-Out unification:
 /// v4-unicast/VPNv4 (`V4Batch`) and v6-unicast/VPNv6 (`V6Batch`) share the
@@ -4007,7 +4064,9 @@ pub fn route_soft_out_peer(peer_idx: usize, bgp: &mut BgpTop, peers: &mut PeerMa
     };
 
     if do_v4 {
-        if super::peer_egress::peer_egress_task_enabled() {
+        if super::group_egress::egress_group_task_enabled() {
+            soft_out_v4_to_group(peer_idx, bgp, peers);
+        } else if super::peer_egress::peer_egress_task_enabled() {
             soft_out_v4_to_pet(peer_idx, bgp, peers);
         } else {
             route_soft_out_peer_table(peer_idx, None, bgp, peers);

--- a/zebra-rs/src/bgp/route.rs
+++ b/zebra-rs/src/bgp/route.rs
@@ -9504,6 +9504,7 @@ pub(super) fn route_sync_v4_chunk(peer: &mut Peer, bgp: &mut BgpTop, chunk: usiz
 
 pub fn route_sync_ipv4(peer: &mut Peer, bgp: &mut BgpTop) {
     let add_path = peer.opt.is_add_path_send(Afi::Ip, Safi::Unicast);
+    let v4_afi_safi = AfiSafi::new(Afi::Ip, Safi::Unicast);
 
     // Collect all routes first to avoid borrow checker issues
     let routes: Vec<(Ipv4Net, BgpRib)> = if add_path {
@@ -9545,6 +9546,21 @@ pub fn route_sync_ipv4(peer: &mut Peer, bgp: &mut BgpTop) {
         // Register to AdjOut.
         rib.attr = bgp.attr_store.intern(decision.attr);
         let arc_attr = rib.attr.clone();
+        // Group-task migration Phase 3: also record the synced route into the
+        // group adj_out (without re-sending — the direct dump below delivers
+        // the bytes) so a late member that is the first of its group stays
+        // withdrawable by the group's later withdraws.
+        if super::group_egress::egress_group_task_enabled()
+            && let Some(gid) = peer.update_group_id.get(&v4_afi_safi).cloned()
+            && let Some(af) = bgp.update_groups.get(&v4_afi_safi)
+            && let Some(group) = af.group_by_id(&gid)
+            && let Some(task) = group.task.as_ref()
+        {
+            task.send(super::group_egress::GroupEgressDeltaV4::RecordAdjOut {
+                prefix: nlri.prefix,
+                rib: rib.clone(),
+            });
+        }
         peer.adj_out.add(None, nlri.prefix, rib);
 
         entries.push((arc_attr, nlri));

--- a/zebra-rs/src/bgp/update_group.rs
+++ b/zebra-rs/src/bgp/update_group.rs
@@ -253,6 +253,12 @@ pub struct UpdateGroup {
     pub flush_inflight_ipv6: bool,
     pub flush_pending_ipv6: bool,
     pub deferred_withdraw_ipv6: Vec<(usize, Ipv6Nlri)>,
+    /// Per-update-group egress task (migration Phase 0,
+    /// `docs/design/bgp-egress-group-task-migration.md`). `Some` only at
+    /// gate-on (`ZEBRA_BGP_EGRESS_GROUP_TASK`); spawned when the group is
+    /// created, dropped (abort-on-drop) when it empties. Phase 0 is idle —
+    /// it tracks the member set and routes no egress yet.
+    pub task: Option<super::group_egress::GroupEgressTask>,
 }
 
 /// Per-AFI/SAFI bookkeeping: the active groups plus a monotonic seq
@@ -405,6 +411,10 @@ pub fn attach(update_groups: &mut UpdateGroupMap, peers: &mut PeerMap, peer_idx:
         let entry = af.groups.entry(sig.clone()).or_insert_with(|| {
             let id = UpdateGroupId::new(afi_safi.afi, afi_safi.safi, af.next_seq);
             af.next_seq += 1;
+            // Phase 0: spawn the per-group egress task at gate-on; dropped
+            // (abort-on-drop) when this group is removed in `detach`.
+            let task = super::group_egress::egress_group_task_enabled()
+                .then(|| super::group_egress::GroupEgressTask::spawn(id.clone()));
             UpdateGroup {
                 id,
                 sig: sig.clone(),
@@ -424,9 +434,14 @@ pub fn attach(update_groups: &mut UpdateGroupMap, peers: &mut PeerMap, peer_idx:
                 flush_inflight_ipv6: false,
                 flush_pending_ipv6: false,
                 deferred_withdraw_ipv6: Vec::new(),
+                task,
             }
         });
         entry.members.insert(peer_idx);
+        // Phase 0: mirror the membership into the group's egress task (gate-on).
+        if let Some(t) = &entry.task {
+            t.member_delta(super::group_egress::GroupMemberDelta::Add(peer_idx));
+        }
 
         let id = entry.id.clone();
         if let Some(peer) = peers.get_mut_by_idx(peer_idx) {
@@ -467,6 +482,12 @@ pub fn detach(update_groups: &mut UpdateGroupMap, peers: &mut PeerMap, peer_idx:
             let drop_group = {
                 let group = af.groups.get_mut(&key).expect("just located");
                 group.members.remove(&peer_idx);
+                // Phase 0: mirror the removal into the group's egress task
+                // (the task itself is dropped + aborted below if the group
+                // becomes empty).
+                if let Some(t) = &group.task {
+                    t.member_delta(super::group_egress::GroupMemberDelta::Remove(peer_idx));
+                }
                 group.members.is_empty()
             };
             if drop_group {
@@ -1511,6 +1532,7 @@ mod tests {
                 flush_inflight_ipv6: false,
                 flush_pending_ipv6: false,
                 deferred_withdraw_ipv6: Vec::new(),
+                task: None,
             },
         );
         af.next_seq = 1;
@@ -1850,6 +1872,7 @@ mod tests {
             flush_inflight_ipv6: false,
             flush_pending_ipv6: false,
             deferred_withdraw_ipv6: Vec::new(),
+            task: None,
         };
         (id, group)
     }

--- a/zebra-rs/src/bgp/update_group.rs
+++ b/zebra-rs/src/bgp/update_group.rs
@@ -276,6 +276,11 @@ impl UpdateGroupAf {
     pub fn group_by_id_mut(&mut self, id: &UpdateGroupId) -> Option<&mut UpdateGroup> {
         self.groups.values_mut().find(|g| &g.id == id)
     }
+
+    /// Shared-reference twin of [`group_by_id_mut`](Self::group_by_id_mut).
+    pub fn group_by_id(&self, id: &UpdateGroupId) -> Option<&UpdateGroup> {
+        self.groups.values().find(|g| &g.id == id)
+    }
 }
 
 /// Top-level container on `Bgp`.

--- a/zebra-rs/src/bgp/update_group.rs
+++ b/zebra-rs/src/bgp/update_group.rs
@@ -21,7 +21,7 @@
 //! handles.
 
 use std::collections::{BTreeMap, BTreeSet, HashMap};
-use std::net::IpAddr;
+use std::net::{IpAddr, Ipv4Addr};
 use std::sync::Arc;
 use std::time::Instant;
 
@@ -389,7 +389,12 @@ fn enhe_negotiated_for(
 /// Takes split borrows on `update_groups` and `peers` so the caller
 /// can be the FSM (which holds a `BgpTop` separately from the
 /// `PeerMap`).
-pub fn attach(update_groups: &mut UpdateGroupMap, peers: &mut PeerMap, peer_idx: usize) {
+pub fn attach(
+    update_groups: &mut UpdateGroupMap,
+    peers: &mut PeerMap,
+    peer_idx: usize,
+    router_id: Ipv4Addr,
+) {
     let Some(peer) = peers.get_by_idx(peer_idx) else {
         return;
     };
@@ -411,10 +416,13 @@ pub fn attach(update_groups: &mut UpdateGroupMap, peers: &mut PeerMap, peer_idx:
         let entry = af.groups.entry(sig.clone()).or_insert_with(|| {
             let id = UpdateGroupId::new(afi_safi.afi, afi_safi.safi, af.next_seq);
             af.next_seq += 1;
-            // Phase 0: spawn the per-group egress task at gate-on; dropped
-            // (abort-on-drop) when this group is removed in `detach`.
-            let task = super::group_egress::egress_group_task_enabled()
-                .then(|| super::group_egress::GroupEgressTask::spawn(id.clone()));
+            // Phase 0/1a: spawn the per-group egress task at gate-on for
+            // v4-unicast (the family being migrated); dropped (abort-on-drop)
+            // when this group is removed in `detach`.
+            let task = (afi_safi.afi == Afi::Ip
+                && afi_safi.safi == Safi::Unicast
+                && super::group_egress::egress_group_task_enabled())
+            .then(|| super::group_egress::GroupEgressTask::spawn(id.clone()));
             UpdateGroup {
                 id,
                 sig: sig.clone(),
@@ -438,9 +446,18 @@ pub fn attach(update_groups: &mut UpdateGroupMap, peers: &mut PeerMap, peer_idx:
             }
         });
         entry.members.insert(peer_idx);
-        // Phase 0: mirror the membership into the group's egress task (gate-on).
-        if let Some(t) = &entry.task {
-            t.member_delta(super::group_egress::GroupMemberDelta::Add(peer_idx));
+        // Phase 1a: mirror the membership into the group's egress task with the
+        // member's SyncCtx (its packet sink + the shared egress identity) so the
+        // engine can build + fan once advertises are routed there (Phase 1b).
+        if let Some(t) = &entry.task
+            && let Some(peer) = peers.get_by_idx(peer_idx)
+        {
+            let add_path = peer.opt.is_add_path_send(afi_safi.afi, afi_safi.safi);
+            t.send(super::group_egress::GroupEgressDeltaV4::AddMember {
+                ident: peer_idx,
+                ctx: Box::new(peer.sync_ctx(router_id)),
+                add_path,
+            });
         }
 
         let id = entry.id.clone();
@@ -482,11 +499,12 @@ pub fn detach(update_groups: &mut UpdateGroupMap, peers: &mut PeerMap, peer_idx:
             let drop_group = {
                 let group = af.groups.get_mut(&key).expect("just located");
                 group.members.remove(&peer_idx);
-                // Phase 0: mirror the removal into the group's egress task
-                // (the task itself is dropped + aborted below if the group
-                // becomes empty).
+                // Mirror the removal into the group's egress task (the task
+                // itself is dropped + aborted below if the group empties).
                 if let Some(t) = &group.task {
-                    t.member_delta(super::group_egress::GroupMemberDelta::Remove(peer_idx));
+                    t.send(super::group_egress::GroupEgressDeltaV4::RemoveMember {
+                        ident: peer_idx,
+                    });
                 }
                 group.members.is_empty()
             };
@@ -1461,8 +1479,9 @@ mod tests {
         let v4only_idx = peers.get(&v4only).unwrap().ident;
 
         let mut groups = empty_map();
-        attach(&mut groups, &mut peers, dual_idx);
-        attach(&mut groups, &mut peers, v4only_idx);
+        let rid = "1.1.1.1".parse().unwrap();
+        attach(&mut groups, &mut peers, dual_idx, rid);
+        attach(&mut groups, &mut peers, v4only_idx, rid);
 
         let v4_key = AfiSafi::new(Afi::Ip, Safi::Unicast);
         let v6_key = AfiSafi::new(Afi::Ip6, Safi::Unicast);


### PR DESCRIPTION
## Summary

Implements the per-update-group egress task — re-keying the BGP v4-unicast
egress from **per peer** (N tasks) to **per `UpdateGroupSig`** (M tasks): one
persistent task per update group that encodes each best path once and fans the
bytes to its member peers, excluding the path's source (split-horizon). The
design and migration plan are in `docs/design/bgp-egress-group-task-migration.md`
(already on `main`); this is Phases 0–4.

**Env-gated, default off** (`ZEBRA_BGP_EGRESS_GROUP_TASK`). Gate-off is
byte-identical (the `UpdateGroup.task` field is `None`, all sends are
`if let Some` no-ops, and the new gate-on branches are skipped). Coherent at
gate-on for the full core egress matrix:

- **Phase 0** — lifecycle shell: spawn a task per v4-unicast update group,
  track members from `attach`/`detach`, abort-on-drop when the group empties.
- **Phase 1a/1b** — the engine (build once via a non-source member's ctx,
  `adj_out` dedup, encode once, fan to non-source members) wired to the reduce
  sink `apply_ipv4_advertise_job`; event-driven advertise + withdraw.
- **Phase 2** — peer-down: gate `route_advertise_to_peers` (the `route_clean`
  egress sink), so peer-down withdraws through the task, not the stale flush.
- **Phase 3** — late-peer session-up sync: `route_sync_ipv4` also sends the
  group a `RecordAdjOut` so a late member stays withdrawable.
- **Phase 4** — soft-out: gate `route_soft_out_peer` → refresh member ctxs +
  re-fan the Loc-RIB through the task.

A PET is the M=1 case; retiring the per-peer PET into the group task and
flipping the default are Phase 5 (deferred). Other deferrals: a policy-change
soft-out re-evaluation BDD, `advertised-routes` reads from the group adj_out,
the membership-move case, N>1 DumpV4 ③ (all noted in the commits).

## Test plan

- **Unit** (`cargo test --workspace --exclude bdd`, all green): the engine —
  fan to all non-source members, split-horizon excludes the source, dedup,
  removed-member drops from the fan, withdraw fans, and `record_adj_out` makes
  a synced route withdrawable.
- **BDD `@bgp_egress_group_task`** (7/7, gate-on, env=ZEBRA_BGP_EGRESS_GROUP_TASK):
  a forming group spawns its task; event-driven advertise reaches z3; a late
  peer z4 gets the routes on sync; a soft-out re-fan preserves them; an
  event-driven withdraw and a peer-down both reach z3 and z4.
- **Regressions**: gate-off `@bgp_shard_v4_sync` 7/7 and PET
  `@bgp_peer_egress_v4` 7/7 unchanged (the group gate is skipped when off).
- fmt + `cargo clippy --workspace --all-targets -- -D warnings` clean.

Note: BDD is excluded from CI; the daemon loads YANG from installed
`/etc/zebra-rs/yang`, but this PR adds no YANG, so no install step is needed
for CI.

Generated with [Claude Code](https://claude.com/claude-code)
