### PR TITLE
bgp: group egress task pre-flip gaps (advertised-routes + N>1 DumpV4)

### DIFF
--- a/bdd/tests/configs/bgp_egress_group_sharded/z1-base.yaml
+++ b/bdd/tests/configs/bgp_egress_group_sharded/z1-base.yaml
@@ -1,0 +1,15 @@
+router:
+  bgp:
+    global:
+      as: 65001
+      router-id: 10.0.0.1
+    timer:
+      adv-interval:
+        ebgp: 1
+    neighbor:
+    - remote-address: 10.0.0.2
+      afi-safi:
+      - name: ipv4
+        enabled: true
+      enabled: true
+      remote-as: 65002

--- a/bdd/tests/configs/bgp_egress_group_sharded/z1-routes.yaml
+++ b/bdd/tests/configs/bgp_egress_group_sharded/z1-routes.yaml
@@ -1,0 +1,20 @@
+router:
+  bgp:
+    global:
+      as: 65001
+      router-id: 10.0.0.1
+    timer:
+      adv-interval:
+        ebgp: 1
+    neighbor:
+    - remote-address: 10.0.0.2
+      afi-safi:
+      - name: ipv4
+        enabled: true
+      enabled: true
+      remote-as: 65002
+    afi-safi:
+    - name: ipv4
+      network:
+      - prefix: 10.10.10.0/24
+      - prefix: 10.10.11.0/24

--- a/bdd/tests/configs/bgp_egress_group_sharded/z1-withdraw.yaml
+++ b/bdd/tests/configs/bgp_egress_group_sharded/z1-withdraw.yaml
@@ -1,0 +1,19 @@
+router:
+  bgp:
+    global:
+      as: 65001
+      router-id: 10.0.0.1
+    timer:
+      adv-interval:
+        ebgp: 1
+    neighbor:
+    - remote-address: 10.0.0.2
+      afi-safi:
+      - name: ipv4
+        enabled: true
+      enabled: true
+      remote-as: 65002
+    afi-safi:
+    - name: ipv4
+      network:
+      - prefix: 10.10.11.0/24

--- a/bdd/tests/configs/bgp_egress_group_sharded/z2.yaml
+++ b/bdd/tests/configs/bgp_egress_group_sharded/z2.yaml
@@ -1,0 +1,27 @@
+router:
+  bgp:
+    global:
+      as: 65002
+      router-id: 10.0.0.2
+    timer:
+      adv-interval:
+        ebgp: 1
+    neighbor:
+    - remote-address: 10.0.0.1
+      afi-safi:
+      - name: ipv4
+        enabled: true
+      enabled: true
+      remote-as: 65001
+    - remote-address: 10.0.0.3
+      afi-safi:
+      - name: ipv4
+        enabled: true
+      enabled: true
+      remote-as: 65003
+    - remote-address: 10.0.0.4
+      afi-safi:
+      - name: ipv4
+        enabled: true
+      enabled: true
+      remote-as: 65004

--- a/bdd/tests/configs/bgp_egress_group_sharded/z3.yaml
+++ b/bdd/tests/configs/bgp_egress_group_sharded/z3.yaml
@@ -1,0 +1,15 @@
+router:
+  bgp:
+    global:
+      as: 65003
+      router-id: 10.0.0.3
+    timer:
+      adv-interval:
+        ebgp: 1
+    neighbor:
+    - remote-address: 10.0.0.2
+      afi-safi:
+      - name: ipv4
+        enabled: true
+      enabled: true
+      remote-as: 65002

--- a/bdd/tests/configs/bgp_egress_group_sharded/z4.yaml
+++ b/bdd/tests/configs/bgp_egress_group_sharded/z4.yaml
@@ -1,0 +1,15 @@
+router:
+  bgp:
+    global:
+      as: 65004
+      router-id: 10.0.0.4
+    timer:
+      adv-interval:
+        ebgp: 1
+    neighbor:
+    - remote-address: 10.0.0.2
+      afi-safi:
+      - name: ipv4
+        enabled: true
+      enabled: true
+      remote-as: 65002

--- a/bdd/tests/cucumber.rs
+++ b/bdd/tests/cucumber.rs
@@ -504,6 +504,47 @@ async fn start_zebra_rs_egress_group_task(world: &mut World, namespace: String) 
     );
 }
 
+#[when(expr = "I start zebra-rs in namespace {string} with {int} shards and egress group task")]
+async fn start_zebra_rs_sharded_egress_group_task(
+    world: &mut World,
+    namespace: String,
+    shards: usize,
+) {
+    let scoped = world.ns(&namespace);
+    let log_file = format!("logs/{}.log", scoped);
+    let pid_file = world.pid_file(&namespace);
+    let shards = shards.to_string();
+
+    let _child = netns::spawn_in_netns_env(
+        &scoped,
+        // The group-task migration's N>1 axis: sharded ingest
+        // (ZEBRA_BGP_SHARDS) feeds the per-update-group egress tasks
+        // (ZEBRA_BGP_EGRESS_GROUP_TASK), exercising the DumpV4 session-up
+        // sync recording into the group adj_out (Phase 5b / N>1 DumpV4 ③).
+        &[
+            ("ZEBRA_XDP_BFD_ECHO_MODE", "skb"),
+            ("ZEBRA_BGP_SHARDS", shards.as_str()),
+            ("ZEBRA_BGP_EGRESS_GROUP_TASK", "1"),
+        ],
+        "zebra-rs",
+        &[
+            "--daemon",
+            "--log-output=file",
+            &format!("--log-file={}", log_file),
+            &format!("--pid-file={}", pid_file),
+        ],
+    )
+    .await
+    .expect("Failed to start zebra-rs");
+
+    tokio::time::sleep(tokio::time::Duration::from_secs(1)).await;
+
+    println!(
+        "✓ zebra-rs started in namespace {} with {} shards + egress group task (pid file {})",
+        scoped, shards, pid_file
+    );
+}
+
 #[when(expr = "I start zebra-rs in namespace {string} with sync chunk {int}")]
 async fn start_zebra_rs_sync_chunk(world: &mut World, namespace: String, chunk: usize) {
     let scoped = world.ns(&namespace);

--- a/bdd/tests/features/bgp_egress_group_sharded.feature
+++ b/bdd/tests/features/bgp_egress_group_sharded.feature
@@ -1,0 +1,148 @@
+@serial
+@bgp_egress_group_sharded
+Feature: BGP IPv4-unicast read paths at N>1 (show / session-up sync read the empty main shard)
+
+  Regression test for a correctness gap in BGP RIB sharding. At
+  ZEBRA_BGP_SHARDS>1, plain IPv4-unicast routes are dispatched to the
+  worker-shard pool (RouteBatchV4) and live ONLY in the pool shards; the
+  reduce (`route_apply_bestpath_v4_batch`) used to do FIB-install +
+  advertise but never mirror the best-path back into the synchronous
+  `bgp.shard`, so every read path that consults `bgp.shard.v4` was empty
+  at N>1:
+
+    * `show bgp ipv4` — the operator can't see the v4 Loc-RIB;
+    * `route_sync_ipv4` — a peer that establishes AFTER routes exist gets
+      only the End-of-RIB marker (no routes).
+
+  Forwarding itself is unaffected: the event-driven advertise runs off the
+  best-path delta, not `bgp.shard`. This is IPv4-unicast-specific (the only
+  pooled family); v6 / VPNv4 / VPNv6 / labeled-unicast are sync-ingested,
+  so their `bgp.shard` tables stay populated and read correctly at N>1.
+
+  z2 is the sharded device under test (4 shards) and the transit between
+  z1 (origin) and two downstream peers:
+    * z3 establishes BEFORE the routes exist → learns them via the
+      EVENT-DRIVEN advertise (off the delta) — the positive control, PASSES.
+    * z4 establishes AFTER the routes exist → can only learn them via z2's
+      session-up `route_sync_ipv4` — the path that was broken at N>1.
+
+  FIXED by the read-replica mirror: the pool reduce
+  (`route_apply_bestpath_v4_batch` → `BgpShard::mirror_v4`) now keeps the
+  main shard's `bgp.shard.v4` in step with the pool-owned table, so both
+  read paths — `route_sync_ipv4` (for the late peer z4) and `show bgp
+  ipv4` (z2's own RIB) — see the routes at N>1. This feature now guards
+  against regressing that. (The sync build still runs serially on the
+  main task; parallelizing its egress is a separate optimization, see
+  docs/design/bgp-rib-sharding-plan.md §B.4.)
+
+  A THIRD read path — `show bgp neighbors <peer> received-routes` (the
+  peer's Adj-RIB-In) — is NOT covered by the Loc-RIB mirror: the
+  authoritative adj_in lives in the pool shards, so at N>1 this read
+  scatter-gathers it from every shard (A2 ⑤, `ShardMsg::DumpAdjInV4`). The
+  received-routes scenario below guards that.
+
+  Test Topology:
+  ```
+                         ┌── z3 (AS65003)  early peer  → event-driven (control)
+  z1 (AS65001) ── z2 (AS65002, 4 shards) ──┤
+   10.0.0.1/24    10.0.0.2/24              └── z4 (AS65004)  late peer   → sync (bug)
+   origin         sharded transit
+  ```
+  All four on bridge br0. z1 originates 10.10.10.0/24 + 10.10.11.0/24.
+
+  Scenario: z1, the sharded z2, and the early peer z3 come up (no routes yet)
+    Given a clean test environment
+    When I create bridge "br0"
+    And I create namespace "z1" with IP "10.0.0.1/24" on bridge "br0"
+    And I create namespace "z2" with IP "10.0.0.2/24" on bridge "br0"
+    And I create namespace "z3" with IP "10.0.0.3/24" on bridge "br0"
+    And I create namespace "z4" with IP "10.0.0.4/24" on bridge "br0"
+    And I start zebra-rs in namespace "z1"
+    And I start zebra-rs in namespace "z2" with 4 shards and egress group task
+    And I start zebra-rs in namespace "z3"
+    And I apply config "z1-base.yaml" to namespace "z1"
+    And I apply config "z2.yaml" to namespace "z2"
+    And I apply config "z3.yaml" to namespace "z3"
+    And I wait 10 seconds for BGP to operate
+    Then BGP session in "z2" to "10.0.0.1" should be "Established"
+    And BGP session in "z2" to "10.0.0.3" should be "Established"
+
+  Scenario: control — z1 originates while z3 is up; the event-driven advertise reaches z3
+    Given the test topology exists
+    # z3 was Established before the routes existed, so it learns them via
+    # the event-driven advertise (which runs off the best-path delta, not
+    # bgp.shard). This MUST pass at N>1 — it proves the sharded z2 ingests
+    # and forwards correctly, so the z4 failure below is the read path, not
+    # ingest/forwarding.
+    When I apply config "z1-routes.yaml" to namespace "z1"
+    And I wait 10 seconds for BGP to operate
+    Then show command "show bgp ipv4" in namespace "z3" should contain "10.10.10.0/24"
+    And show command "show bgp ipv4" in namespace "z3" should contain "10.10.11.0/24"
+
+  Scenario: the late peer z4 gets the routes on sync, and z2 can show its own RIB
+    Given the test topology exists
+    # z4's daemon starts now — AFTER z2 already holds z1's routes — so z4 can
+    # obtain them only via z2's `route_sync_ipv4` initial dump. And z2's own
+    # `show bgp ipv4` reads the same `bgp.shard.v4`. Both read the main shard,
+    # which the pool reduce now mirrors, so both see the routes at N>1 (these
+    # FAILED before the read-replica mirror).
+    When I start zebra-rs in namespace "z4"
+    And I apply config "z4.yaml" to namespace "z4"
+    And I wait 15 seconds for BGP to operate
+    Then BGP session in "z2" to "10.0.0.4" should be "Established"
+    And show command "show bgp ipv4" in namespace "z4" should contain "10.10.10.0/24"
+    And show command "show bgp ipv4" in namespace "z4" should contain "10.10.11.0/24"
+    And show command "show bgp ipv4" in namespace "z2" should contain "10.10.10.0/24"
+    And show command "show bgp ipv4" in namespace "z2" should contain "10.10.11.0/24"
+
+  Scenario: z2's received-routes from z1 are gathered from the pool shards (N>1 Adj-RIB-In)
+    Given the test topology exists
+    # The v4-unicast Adj-RIB-In lives ONLY in the pool shards at N>1 (the
+    # mirror replicates the Loc-RIB, not adj_in), so `show bgp neighbors
+    # <z1> received-routes` must scatter-gather it from every shard (A2 ⑤,
+    # ShardMsg::DumpAdjInV4). Before the gather this read hit the empty
+    # main-side adj_in copy and showed nothing — a silent N>1 gap, untested
+    # until now. Both prefixes present ⇒ the merge across shards is complete
+    # (.10 and .11 hash to possibly-different shards).
+    Then show command "show bgp neighbors 10.0.0.1 received-routes" in namespace "z2" should contain "10.10.10.0/24"
+    And show command "show bgp neighbors 10.0.0.1 received-routes" in namespace "z2" should contain "10.10.11.0/24"
+
+  Scenario: z1 withdraws one route; the sharded reduce removes it from z2's mirror
+    Given the test topology exists
+    # z1 re-originates only 10.10.11.0/24 (dropping .10). At N=4, z2's pool
+    # ingests the withdraw and the reduce's mirror must DROP .10 from
+    # bgp.shard.v4 — exercising mirror_v4's remove (`replaced`) path — so
+    # `show bgp ipv4` (which reads the cands mirror) no longer lists it. .11
+    # staying is the positive control, so the negative assertion isn't
+    # vacuous. z4 losing .10 confirms the withdraw also propagates downstream.
+    When I apply config "z1-withdraw.yaml" to namespace "z1"
+    And I wait 10 seconds for BGP to operate
+    Then show command "show bgp ipv4" in namespace "z2" should not contain "10.10.10.0/24"
+    And show command "show bgp ipv4" in namespace "z2" should contain "10.10.11.0/24"
+    And show command "show bgp ipv4" in namespace "z4" should not contain "10.10.10.0/24"
+    And show command "show bgp ipv4" in namespace "z4" should contain "10.10.11.0/24"
+
+  Scenario: z1's session drops; the sharded peer-down sweep clears z2's mirror
+    Given the test topology exists
+    # z2 still holds .11 (positive control). Stop z1 — z2's route_clean sweeps
+    # z1's v4 slice on the pool, and the reduce's mirror must drop .11 from
+    # bgp.shard.v4 (the peer-down remove path) so `show` no longer lists it.
+    Then show command "show bgp ipv4" in namespace "z2" should contain "10.10.11.0/24"
+    When I stop zebra-rs in namespace "z1"
+    And I wait 20 seconds for BGP to operate
+    Then BGP session in "z2" to "10.0.0.1" should not be "Established"
+    And show command "show bgp ipv4" in namespace "z2" should not contain "10.10.11.0/24"
+    And show command "show bgp ipv4" in namespace "z4" should not contain "10.10.11.0/24"
+
+  Scenario: Teardown topology
+    Given the test topology exists
+    When I stop zebra-rs in namespace "z1"
+    And I stop zebra-rs in namespace "z2"
+    And I stop zebra-rs in namespace "z3"
+    And I stop zebra-rs in namespace "z4"
+    And I delete namespace "z1"
+    And I delete namespace "z2"
+    And I delete namespace "z3"
+    And I delete namespace "z4"
+    And I delete bridge "br0"
+    Then the test environment should be clean

--- a/bdd/tests/features/bgp_egress_group_task.feature
+++ b/bdd/tests/features/bgp_egress_group_task.feature
@@ -58,6 +58,16 @@ Feature: BGP per-update-group egress task (migration Phases 0-3)
     And show command "show bgp ipv4" in namespace "z3" should contain "10.10.10.0/24"
     And show command "show bgp ipv4" in namespace "z3" should contain "10.10.11.0/24"
 
+  Scenario: advertised-routes reads the group adj_out, split-horizon filtered (Phase 5)
+    Given the test topology exists
+    # z2's v4 Adj-RIB-Out to a peer lives in its update group's task at gate-on,
+    # not on the peer. `show ... advertised-routes` must request it from the
+    # group task: z3 was advertised .10/.11, and — split-horizon — z1 (the
+    # source) was advertised neither.
+    Then show command "show bgp neighbors 10.0.0.3 advertised-routes" in namespace "z2" should contain "10.10.10.0/24"
+    And show command "show bgp neighbors 10.0.0.3 advertised-routes" in namespace "z2" should contain "10.10.11.0/24"
+    And show command "show bgp neighbors 10.0.0.1 advertised-routes" in namespace "z2" should not contain "10.10.10.0/24"
+
   Scenario: a late peer z4 gets the routes on session-up sync (Phase 3)
     Given the test topology exists
     # z4's daemon starts now — AFTER z2 already holds z1's routes — so z4

--- a/zebra-rs/src/bgp/group_egress.rs
+++ b/zebra-rs/src/bgp/group_egress.rs
@@ -137,6 +137,12 @@ impl GroupEgressTask {
         self.send(GroupEgressDeltaV4::DumpAdjOut { reply });
         rx
     }
+
+    /// Clone of the delta channel — lets a caller hand the sender off (e.g.
+    /// record DumpV4 ③ rows in a loop) without holding a borrow of the task.
+    pub fn delta_tx(&self) -> UnboundedSender<GroupEgressDeltaV4> {
+        self.delta_tx.clone()
+    }
 }
 
 /// A group's owned v4-unicast egress state + per-delta logic, run inside the

--- a/zebra-rs/src/bgp/group_egress.rs
+++ b/zebra-rs/src/bgp/group_egress.rs
@@ -84,6 +84,12 @@ pub enum GroupEgressDeltaV4 {
         id: u32,
         source_ident: usize,
     },
+    /// A `show … advertised-routes` request at gate-on: reply with the group's
+    /// whole `adj_out` (the caller filters split-horizon per queried peer and
+    /// renders). The group adj-out lives here, not on the peer.
+    DumpAdjOut {
+        reply: tokio::sync::oneshot::Sender<Vec<(Ipv4Net, Vec<BgpRib>)>>,
+    },
 }
 
 /// Handle main keeps on each [`UpdateGroup`](super::update_group::UpdateGroup)
@@ -121,6 +127,15 @@ impl GroupEgressTask {
     /// gone (the group is tearing down), which is harmless here.
     pub fn send(&self, delta: GroupEgressDeltaV4) {
         let _ = self.delta_tx.send(delta);
+    }
+
+    /// Request the group's adj-out over a oneshot (for `show advertised-routes`
+    /// at gate-on). Returns the receiver so the caller can drop any borrow of
+    /// the task before awaiting.
+    pub fn request_adj_out(&self) -> tokio::sync::oneshot::Receiver<Vec<(Ipv4Net, Vec<BgpRib>)>> {
+        let (reply, rx) = tokio::sync::oneshot::channel();
+        self.send(GroupEgressDeltaV4::DumpAdjOut { reply });
+        rx
     }
 }
 
@@ -161,6 +176,15 @@ impl Engine {
                 id,
                 source_ident,
             } => self.withdraw(prefix, id, source_ident),
+            GroupEgressDeltaV4::DumpAdjOut { reply } => {
+                let entries = self
+                    .adj_out
+                    .0
+                    .iter()
+                    .map(|(prefix, ribs)| (*prefix, ribs.clone()))
+                    .collect();
+                let _ = reply.send(entries);
+            }
         }
     }
 

--- a/zebra-rs/src/bgp/inst.rs
+++ b/zebra-rs/src/bgp/inst.rs
@@ -2066,6 +2066,17 @@ impl Bgp {
             let _ = msg.resp.send(output).await;
             return;
         }
+        // Group-task: at gate-on a peer's v4 Adj-RIB-Out lives in its update
+        // group's egress task — request it for advertised-routes.
+        if super::group_egress::egress_group_task_enabled()
+            && path == "/show/bgp/neighbors/advertised-routes"
+        {
+            let output = self
+                .show_advertised_v4_from_group(&mut args, msg.json)
+                .await;
+            let _ = msg.resp.send(output).await;
+            return;
+        }
         // A2 ⑥: at gate-on a peer's v4 Adj-RIB-Out lives in its PET, not on
         // the peer — request it from the PET for advertised-routes.
         if super::peer_egress::peer_egress_task_enabled()
@@ -2109,6 +2120,51 @@ impl Bgp {
                 }
                 None => std::collections::BTreeMap::new(),
             };
+        super::show::show_adj_rib_routes(&table, self.router_id, json)
+            .unwrap_or_else(|e| format!("Error formatting output: {}", e))
+    }
+
+    /// Group-task — `show … advertised-routes` at gate-on: the peer's v4
+    /// Adj-RIB-Out is the adj-out of its update group's egress task. Request
+    /// the group adj-out over a oneshot, then filter split-horizon — a route
+    /// sourced from THIS peer (`rib.ident`) was never advertised to it — and
+    /// render. Empty when the peer is in no group (not established).
+    async fn show_advertised_v4_from_group(
+        &self,
+        args: &mut crate::config::Args,
+        json: bool,
+    ) -> String {
+        let Some(addr) = args.addr() else {
+            return "% No neighbor address specified".to_string();
+        };
+        let v4 = bgp_packet::AfiSafi::new(bgp_packet::Afi::Ip, bgp_packet::Safi::Unicast);
+        let (peer_ident, gid) = match self.peers.get(&addr) {
+            None => return format!("% No such neighbor: {}", addr),
+            Some(peer) => (peer.ident, peer.update_group_id.get(&v4).cloned()),
+        };
+        // Request the group adj-out; drop the task borrow before awaiting.
+        let rx = gid
+            .and_then(|gid| {
+                self.update_groups
+                    .get(&v4)
+                    .and_then(|af| af.group_by_id(&gid))
+            })
+            .and_then(|group| group.task.as_ref())
+            .map(|task| task.request_adj_out());
+        let table: std::collections::BTreeMap<ipnet::Ipv4Net, Vec<super::route::BgpRib>> = match rx
+        {
+            Some(rx) => rx
+                .await
+                .unwrap_or_default()
+                .into_iter()
+                .filter_map(|(prefix, ribs)| {
+                    // Split-horizon: exclude paths sourced from this peer.
+                    let kept: Vec<_> = ribs.into_iter().filter(|r| r.ident != peer_ident).collect();
+                    (!kept.is_empty()).then_some((prefix, kept))
+                })
+                .collect(),
+            None => std::collections::BTreeMap::new(),
+        };
         super::show::show_adj_rib_routes(&table, self.router_id, json)
             .unwrap_or_else(|e| format!("Error formatting output: {}", e))
     }

--- a/zebra-rs/src/bgp/inst.rs
+++ b/zebra-rs/src/bgp/inst.rs
@@ -3663,28 +3663,47 @@ impl Bgp {
                     sent,
                     advertised,
                 } => {
-                    // A2 ⑥ — at gate-on `adj_out` lives in the PET, so
-                    // forward the dump rows there as record-only advertises
-                    // (`send: false`: the shard already put the bytes on the
-                    // wire). The PET rebuilds + records, keeping its adj_out
-                    // and interner consistent with its event-driven path.
-                    // Gate-off records main's adj_out as before.
-                    let to_pet = super::peer_egress::peer_egress_task_enabled()
-                        && self
-                            .peers
-                            .get_by_idx(ident)
-                            .is_some_and(|p| p.pet.is_some());
-                    if to_pet {
-                        if let Some(pet) = self.peers.get_by_idx(ident).and_then(|p| p.pet.as_ref())
-                        {
-                            for (nlri, rib) in advertised {
-                                let _ = pet.delta_tx.send(
-                                    super::peer_egress::EgressDeltaV4::RecordAdjOut {
-                                        prefix: nlri.prefix,
-                                        rib,
-                                    },
-                                );
-                            }
+                    // At gate-on `adj_out` lives in the egress task (group or
+                    // PET), so forward the dump rows there as record-only — the
+                    // shard already put the bytes on the wire. Group-task first
+                    // (the N>1 twin of route_sync_ipv4's RecordAdjOut, Phase 3),
+                    // then the per-peer PET, then main's adj_out at gate-off.
+                    let v4 =
+                        bgp_packet::AfiSafi::new(bgp_packet::Afi::Ip, bgp_packet::Safi::Unicast);
+                    let group_tx = super::group_egress::egress_group_task_enabled()
+                        .then(|| {
+                            let gid = self
+                                .peers
+                                .get_by_idx(ident)?
+                                .update_group_id
+                                .get(&v4)?
+                                .clone();
+                            self.update_groups
+                                .get(&v4)?
+                                .group_by_id(&gid)?
+                                .task
+                                .as_ref()
+                                .map(|t| t.delta_tx())
+                        })
+                        .flatten();
+                    if let Some(tx) = group_tx {
+                        for (nlri, rib) in advertised {
+                            let _ =
+                                tx.send(super::group_egress::GroupEgressDeltaV4::RecordAdjOut {
+                                    prefix: nlri.prefix,
+                                    rib,
+                                });
+                        }
+                    } else if super::peer_egress::peer_egress_task_enabled()
+                        && let Some(pet) = self.peers.get_by_idx(ident).and_then(|p| p.pet.as_ref())
+                    {
+                        for (nlri, rib) in advertised {
+                            let _ = pet.delta_tx.send(
+                                super::peer_egress::EgressDeltaV4::RecordAdjOut {
+                                    prefix: nlri.prefix,
+                                    rib,
+                                },
+                            );
                         }
                     } else if let Some(peer) = self.peers.get_mut_by_idx(ident) {
                         for (nlri, rib) in advertised {


### PR DESCRIPTION
## Summary

Closes the two pre-flip gaps for the per-update-group egress task (gate-on,
`ZEBRA_BGP_EGRESS_GROUP_TASK`, default off). With these, the group task is
coherent for the full v4-unicast egress matrix at **N=1 and N>1**.

- **5a — advertised-routes reads the group adj_out.** At gate-on a peer's v4
  Adj-RIB-Out lives in its update group's task, not `peer.adj_out`, so
  `show bgp neighbors <X> advertised-routes` read an incomplete copy. Add
  `GroupEgressDeltaV4::DumpAdjOut` (+ `request_adj_out`) and gate the show:
  `show_advertised_v4_from_group` requests the queried peer's group adj_out and
  renders it, **filtered by split-horizon** (a path sourced from that peer was
  never advertised to it). Mirrors `show_advertised_v4_from_pet`.
- **5b — N>1 DumpV4 ③ records the group adj_out.** At N>1 the session-up sync
  runs through the shard DumpV4 path; its ③ record wrote `peer.adj_out`,
  leaving the group task unaware (a late peer that is the first of a new group
  would be missed by the group's later withdraws — the N>1 twin of the N=1
  `route_sync_ipv4` gap closed in Phase 3). Gate the DumpV4 ③ record to the
  group task (RecordAdjOut, record-only — the shard already sent the bytes);
  group-task first, then PET, then main's adj_out at gate-off.

## Test plan

- **BDD** (gate-on, env): `@bgp_egress_group_task` (8/8) gains the
  advertised-routes read scenario (z3 shows .10/.11; z1, the source, shows
  neither — split-horizon). New `@bgp_egress_group_sharded` (7/7, 4 shards +
  group task, derived from `@bgp_shard_v4_sync`): event-driven advertise,
  late-peer DumpV4 sync, received-routes gather, withdraw, peer-down — the
  sharded ingest feeding the group tasks. New start step "with N shards and
  egress group task".
- **Regressions**: gate-off `@bgp_shard_v4_sync` 7/7 and PET
  `@bgp_peer_egress_v4` 7/7 unchanged (the group branches precede and are
  skipped when off).
- **Unit** (`cargo test --workspace --exclude bdd`): green; fmt + workspace
  clippy clean.

The default flip + PET retirement is deferred to a separate focused PR (it
also needs AddPath fanning in the group, gate precedence so an explicit
`ZEBRA_BGP_PEER_TASK` wins over the default, and a full BGP BDD re-validation
at the new default).

Generated with [Claude Code](https://claude.com/claude-code)
