### PR TITLE
bgp: gather show-summary prefix counts from the off-main owners

### DIFF
--- a/bdd/tests/features/bgp_peer_egress_v4.feature
+++ b/bdd/tests/features/bgp_peer_egress_v4.feature
@@ -41,6 +41,13 @@ Feature: BGP IPv4-unicast read paths at N>1 (show / session-up sync read the emp
   scatter-gathers it from every shard (A2 ⑤, `ShardMsg::DumpAdjInV4`). The
   received-routes scenario below guards that.
 
+  A FOURTH — `show bgp ipv4 summary`'s per-neighbor PfxRcd/Snt — reads BOTH
+  off-main owners: PfxRcd from the pool shards' Adj-RIB-In (N>1), PfxSnt
+  from the PET's Adj-RIB-Out (peer-task). The synchronous row read finds
+  both main-side copies empty, so it gathers the COUNTS (count-only
+  messages — no prefixes/attributes) before rendering. The summary scenario
+  below guards that.
+
   Test Topology:
   ```
                          ┌── z3 (AS65003)  early peer  → event-driven (control)
@@ -106,6 +113,21 @@ Feature: BGP IPv4-unicast read paths at N>1 (show / session-up sync read the emp
     # (.10 and .11 hash to possibly-different shards).
     Then show command "show bgp neighbors 10.0.0.1 received-routes" in namespace "z2" should contain "10.10.10.0/24"
     And show command "show bgp neighbors 10.0.0.1 received-routes" in namespace "z2" should contain "10.10.11.0/24"
+
+  Scenario: z2's `show bgp ipv4 summary` per-neighbor counts come from the off-main owners
+    Given the test topology exists
+    # The FOURTH N>1 read path: the summary's PfxRcd/Snt column. At N>1 +
+    # peer-task both counts live off the main task — PfxRcd in the pool
+    # shards' Adj-RIB-In, PfxSnt in the PET's Adj-RIB-Out — so the row's
+    # main-side reads come back empty and every neighbor printed "0/0".
+    # The count-gather fixes it: z2 received z1's two routes (PfxRcd 2) and
+    # advertised both to z3 and z4 (PfxSnt 2), never back to their source z1
+    # (split-horizon, PfxSnt 0). So z1's row is "2/0" (proves the shard
+    # PfxRcd gather) and z3's / z4's are "0/2" (proves the PET PfxSnt query).
+    # The slash makes each substring specific to the PfxRcd/Snt column, and
+    # under the bug every row is "0/0", so neither appears.
+    Then show command "show bgp ipv4 summary" in namespace "z2" should contain "2/0"
+    And show command "show bgp ipv4 summary" in namespace "z2" should contain "0/2"
 
   Scenario: z1 withdraws one route; the sharded reduce removes it from z2's mirror
     Given the test topology exists

--- a/zebra-rs/src/bgp/inst.rs
+++ b/zebra-rs/src/bgp/inst.rs
@@ -2086,6 +2086,32 @@ impl Bgp {
             let _ = msg.resp.send(output).await;
             return;
         }
+        // `show [ipv4] summary` at gate-on / N>1: the v4 PfxRcd/PfxSnt live
+        // off-main — Adj-RIB-In in the pool shards (N>1), Adj-RIB-Out in the
+        // PET (peer-task) — so the synchronous renderer reads the empty main
+        // copies and prints 0/0. Gather the v4 counts first, then render. The
+        // other AFI sections stay main-owned and read correctly. (`show bgp
+        // ipv4 summary` arrives as `/show/bgp/ipv4` + a "summary" token, peeked
+        // non-destructively so a non-summary command falls through untouched.)
+        // The egress-group-task egress model is not covered here yet — its
+        // adj_out is the group task's, and its split-horizon per-peer count is
+        // a follow-up; it is gate-off by default so the summary is unaffected.
+        let v4_summary: Option<Option<bgp_packet::AfiSafi>> = match path.as_str() {
+            "/show/bgp/summary" | "/show/ip/bgp/summary" => Some(None),
+            "/show/bgp/ipv4" if args.0.front().is_some_and(|t| t == "summary") => Some(Some(
+                bgp_packet::AfiSafi::new(bgp_packet::Afi::Ip, bgp_packet::Safi::Unicast),
+            )),
+            _ => None,
+        };
+        if let Some(afi_safi_opt) = v4_summary
+            && (self.shards.is_some() || super::peer_egress::peer_egress_task_enabled())
+        {
+            let counts = self.gather_v4_summary_counts().await;
+            let output =
+                super::show::render_summary_with_counts(self, afi_safi_opt, msg.json, &counts);
+            let _ = msg.resp.send(output).await;
+            return;
+        }
         if let Some(f) = self.show_cb.get(&path) {
             let output = match f(self, args, msg.json) {
                 Ok(result) => result,
@@ -2218,6 +2244,76 @@ impl Bgp {
             }
         }
         merged
+    }
+
+    /// Gather per-peer v4-unicast summary prefix counts — `(PfxRcd, PfxSnt)` —
+    /// from their off-main owners for `show … summary` at gate-on: PfxRcd from
+    /// the pool shards' Adj-RIB-In (N>1), PfxSnt from the PET's Adj-RIB-Out
+    /// (peer-task). **Counts only** — no prefixes or attributes cross the
+    /// channel (lighter than the received/advertised dumps, which the summary
+    /// row doesn't need). Keyed by peer ident, Established v4 peers only; each
+    /// value is the COMPLETE count, falling back to the main-side read for the
+    /// half that is not off-main (N=1 PfxRcd, gate-off PfxSnt), so the render
+    /// uses it verbatim.
+    async fn gather_v4_summary_counts(&self) -> std::collections::BTreeMap<usize, (u64, u64)> {
+        use bgp_packet::{Afi, Safi};
+        let v4 = bgp_packet::AfiSafi::new(Afi::Ip, Safi::Unicast);
+
+        // PfxRcd: one count scatter per shard, summed per peer (N>1 only).
+        let mut rcvd: std::collections::BTreeMap<usize, u64> = std::collections::BTreeMap::new();
+        if let Some(pool) = self.shards.as_ref() {
+            let mut rxs = Vec::with_capacity(pool.n());
+            for idx in 0..pool.n() {
+                let (tx, rx) = tokio::sync::oneshot::channel();
+                pool.dispatch(idx, super::shard::ShardMsg::CountAdjInV4All { reply: tx });
+                rxs.push(rx);
+            }
+            for rx in rxs {
+                if let Ok(map) = rx.await {
+                    for (ident, n) in map {
+                        *rcvd.entry(ident).or_default() += n as u64;
+                    }
+                }
+            }
+        }
+
+        // Per-peer (rcvd, sent); query the PET for sent when present. Collect
+        // the PET reply receivers first so no peer borrow is held across await.
+        let mut out: std::collections::BTreeMap<usize, (u64, u64)> =
+            std::collections::BTreeMap::new();
+        let mut sent_rxs: Vec<(usize, tokio::sync::oneshot::Receiver<usize>)> = Vec::new();
+        for (_, peer) in self.peers.iter_all() {
+            if peer.state != super::peer::State::Established || !peer.config.mp.has(&v4) {
+                continue;
+            }
+            let rcvd_count = if self.shards.is_some() {
+                rcvd.get(&peer.ident).copied().unwrap_or(0)
+            } else {
+                (self.shard.adj_in_count(peer.ident, Afi::Ip, Safi::Unicast)
+                    + peer.adj_in.count(Afi::Ip, Safi::Unicast)) as u64
+            };
+            match peer.pet.as_ref() {
+                Some(pet) => {
+                    let (tx, rx) = tokio::sync::oneshot::channel();
+                    let _ = pet
+                        .delta_tx
+                        .send(super::peer_egress::EgressDeltaV4::CountAdjOut { reply: tx });
+                    sent_rxs.push((peer.ident, rx));
+                    out.insert(peer.ident, (rcvd_count, 0));
+                }
+                None => {
+                    let sent = peer.adj_out.count(Afi::Ip, Safi::Unicast) as u64;
+                    out.insert(peer.ident, (rcvd_count, sent));
+                }
+            }
+        }
+        for (ident, rx) in sent_rxs {
+            let sent = rx.await.unwrap_or(0) as u64;
+            if let Some(slot) = out.get_mut(&ident) {
+                slot.1 = sent;
+            }
+        }
+        out
     }
 
     pub async fn listen(&mut self) -> anyhow::Result<()> {

--- a/zebra-rs/src/bgp/peer_egress.rs
+++ b/zebra-rs/src/bgp/peer_egress.rs
@@ -116,6 +116,12 @@ pub enum EgressDeltaV4 {
     DumpAdjOut {
         reply: tokio::sync::oneshot::Sender<Vec<(Ipv4Net, Vec<BgpRib>)>>,
     },
+    /// A `show … summary` PfxSnt request at gate-on: reply with the PET's v4
+    /// Adj-RIB-Out prefix count. Counts only — the summary row prints the
+    /// number, not the routes (unlike [`Self::DumpAdjOut`]).
+    CountAdjOut {
+        reply: tokio::sync::oneshot::Sender<usize>,
+    },
 }
 
 /// Handle main keeps for a peer's egress task: the delta channel plus the
@@ -186,6 +192,12 @@ impl Engine {
                     .map(|(prefix, ribs)| (*prefix, ribs.clone()))
                     .collect();
                 let _ = reply.send(entries);
+            }
+            EgressDeltaV4::CountAdjOut { reply } => {
+                // Count-only twin of `DumpAdjOut`: the v4 Adj-RIB-Out prefix
+                // count for the summary's PfxSnt. `adj_out.0` is keyed by
+                // prefix, so `len` matches `peer.adj_out.count` semantics.
+                let _ = reply.send(self.adj_out.0.len());
             }
         }
     }

--- a/zebra-rs/src/bgp/shard/dispatch.rs
+++ b/zebra-rs/src/bgp/shard/dispatch.rs
@@ -106,6 +106,24 @@ impl BgpShard {
                 let _ = reply.send(slice);
                 Vec::new()
             }
+            ShardMsg::CountAdjInV4All { reply } => {
+                // Count-only twin of `DumpAdjInV4`: reply with this shard's
+                // per-peer IPv4-unicast Adj-RIB-In prefix counts (the prefixes
+                // that hash here); main sums across shards for `show … summary`
+                // PfxRcd. `v4.0` is the per-prefix candidate map, so its `len`
+                // is the prefix count — matching `MainAdjIn::count`. Skip empties
+                // so the reply stays small.
+                let counts = self
+                    .adj_in
+                    .iter()
+                    .filter_map(|(ident, a)| {
+                        let n = a.v4.0.len();
+                        (n > 0).then_some((*ident, n))
+                    })
+                    .collect();
+                let _ = reply.send(counts);
+                Vec::new()
+            }
             ShardMsg::Show(_) | ShardMsg::Shutdown => Vec::new(),
         }
     }

--- a/zebra-rs/src/bgp/shard/msg.rs
+++ b/zebra-rs/src/bgp/shard/msg.rs
@@ -190,6 +190,16 @@ pub enum ShardMsg {
         reply: tokio::sync::oneshot::Sender<Vec<(ipnet::Ipv4Net, Vec<BgpRib>)>>,
     },
 
+    /// Count-only scatter for `show bgp [ipv4] summary` at N>1: each shard
+    /// replies with `{peer ident → its IPv4-unicast Adj-RIB-In prefix count}`
+    /// over the prefixes it owns; main sums across shards for each peer's
+    /// PfxRcd column. Counts only — no prefixes or attributes cross the
+    /// channel (unlike [`Self::DumpAdjInV4`]), since the summary prints just
+    /// the number. Read-only, returns no [`ShardOut`].
+    CountAdjInV4All {
+        reply: tokio::sync::oneshot::Sender<std::collections::BTreeMap<usize, usize>>,
+    },
+
     /// Tear the shard task down; its event loop exits on the next
     /// iteration. Used at daemon shutdown.
     Shutdown,

--- a/zebra-rs/src/bgp/show.rs
+++ b/zebra-rs/src/bgp/show.rs
@@ -155,6 +155,34 @@ fn peer_has_negotiated(peer: &Peer, afi: Afi, safi: Safi) -> bool {
         .unwrap_or(false)
 }
 
+/// Externally-gathered per-peer v4-unicast summary prefix counts (peer ident
+/// → (PfxRcd, PfxSnt)). At gate-on / N>1 the v4 Adj-RIB-In lives in the pool
+/// shards and the v4 Adj-RIB-Out in the PET, so the main-side reads below come
+/// back empty; the async show path gathers the real counts first
+/// ([`super::inst`]) and passes them here. Only the v4-unicast section ever
+/// receives a `Some` — every other family is main-owned and reads correctly.
+type SummaryCounts = std::collections::BTreeMap<usize, (u64, u64)>;
+
+/// The (PfxRcd, PfxSnt) for one peer's summary row: the gathered counts when
+/// present (gate-on / N>1), else the main-side Adj-RIB read. Sharded and
+/// main-owned family counts are disjoint, so the sum is the received count for
+/// any AFI/SAFI.
+fn summary_pfx_counts(
+    shard: &super::shard::BgpShard,
+    peer: &Peer,
+    afi: Afi,
+    safi: Safi,
+    counts: Option<&SummaryCounts>,
+) -> (u64, u64) {
+    match counts.and_then(|m| m.get(&peer.ident)) {
+        Some(&(pr, ps)) => (pr, ps),
+        None => (
+            (shard.adj_in_count(peer.ident, afi, safi) + peer.adj_in.count(afi, safi)) as u64,
+            peer.adj_out.count(afi, safi) as u64,
+        ),
+    }
+}
+
 fn write_summary_header_row(buf: &mut String) -> std::fmt::Result {
     writeln!(
         buf,
@@ -179,6 +207,7 @@ fn write_summary_peer_row(
     peer: &Peer,
     afi: Afi,
     safi: Safi,
+    counts: Option<&SummaryCounts>,
 ) -> std::fmt::Result {
     let mut msg_sent: u64 = 0;
     let mut msg_rcvd: u64 = 0;
@@ -196,10 +225,7 @@ fn write_summary_peer_row(
     } else if !negotiated {
         "NoNeg".to_string()
     } else {
-        // Sharded and main-owned family counts are disjoint, so the
-        // sum is the peer's received count for any AFI/SAFI.
-        let pr = shard.adj_in_count(peer.ident, afi, safi) + peer.adj_in.count(afi, safi);
-        let ps = peer.adj_out.count(afi, safi);
+        let (pr, ps) = summary_pfx_counts(shard, peer, afi, safi, counts);
         format!("{}/{}", pr, ps)
     };
 
@@ -234,7 +260,11 @@ fn write_summary_section<V: BgpShowView>(
     buf: &mut String,
     bgp: &V,
     afi_safi: AfiSafi,
+    counts: Option<&SummaryCounts>,
 ) -> std::fmt::Result {
+    // The gathered counts are v4-unicast only; every other section reads its
+    // main-owned Adj-RIBs directly.
+    let section_counts = counts.filter(|_| afi_safi == AfiSafi::new(Afi::Ip, Safi::Unicast));
     let label = afi_safi_summary_label(afi_safi.afi, afi_safi.safi);
     let router_id = summary_router_id(bgp);
     let asn = if bgp.asn() == 0 {
@@ -272,7 +302,14 @@ fn write_summary_section<V: BgpShowView>(
 
     write_summary_header_row(buf)?;
     for peer in peers.iter() {
-        write_summary_peer_row(buf, bgp.shard(), peer, afi_safi.afi, afi_safi.safi)?;
+        write_summary_peer_row(
+            buf,
+            bgp.shard(),
+            peer,
+            afi_safi.afi,
+            afi_safi.safi,
+            section_counts,
+        )?;
     }
 
     writeln!(buf)?;
@@ -1824,6 +1861,7 @@ fn summary_peer_row_json(
     peer: &Peer,
     afi: Afi,
     safi: Safi,
+    counts: Option<&SummaryCounts>,
 ) -> BgpPeerSummaryJson {
     let mut msg_sent: u64 = 0;
     let mut msg_rcvd: u64 = 0;
@@ -1832,9 +1870,7 @@ fn summary_peer_row_json(
         msg_rcvd += counter.rcvd;
     }
 
-    let pfx_rcvd =
-        (shard.adj_in_count(peer.ident, afi, safi) + peer.adj_in.count(afi, safi)) as u64;
-    let pfx_sent = peer.adj_out.count(afi, safi) as u64;
+    let (pfx_rcvd, pfx_sent) = summary_pfx_counts(shard, peer, afi, safi, counts);
 
     // FRR-style State/PfxRcd column: an Established session shows its
     // received-prefix count in place of the state word.
@@ -1857,7 +1893,13 @@ fn summary_peer_row_json(
     }
 }
 
-fn summary_section_json<V: BgpShowView>(bgp: &V, afi_safi: AfiSafi) -> BgpAfiSafiSummaryJson {
+fn summary_section_json<V: BgpShowView>(
+    bgp: &V,
+    afi_safi: AfiSafi,
+    counts: Option<&SummaryCounts>,
+) -> BgpAfiSafiSummaryJson {
+    // v4-unicast only; see `write_summary_section`.
+    let section_counts = counts.filter(|_| afi_safi == AfiSafi::new(Afi::Ip, Safi::Unicast));
     BgpAfiSafiSummaryJson {
         afi_safi: afi_safi_summary_label(afi_safi.afi, afi_safi.safi).to_string(),
         // `iter_all` for the same reason as the text renderer:
@@ -1866,7 +1908,15 @@ fn summary_section_json<V: BgpShowView>(bgp: &V, afi_safi: AfiSafi) -> BgpAfiSaf
             .peers()
             .iter_all()
             .filter(|(_, peer)| peer.config.mp.has(&afi_safi))
-            .map(|(_, peer)| summary_peer_row_json(bgp.shard(), peer, afi_safi.afi, afi_safi.safi))
+            .map(|(_, peer)| {
+                summary_peer_row_json(
+                    bgp.shard(),
+                    peer,
+                    afi_safi.afi,
+                    afi_safi.safi,
+                    section_counts,
+                )
+            })
             .collect(),
     }
 }
@@ -1881,13 +1931,25 @@ fn show_bgp_summary<V: BgpShowView>(
     _args: Args,
     json: bool,
 ) -> std::result::Result<String, std::fmt::Error> {
+    summary_all(bgp, json, None)
+}
+
+/// Body of `show bgp summary` (every configured AFI/SAFI), parameterised on the
+/// optional gathered v4 counts. `None` is the synchronous path (the row reads
+/// its main-side Adj-RIBs); `Some` is the async gate-on / N>1 path via
+/// [`render_summary_with_counts`].
+fn summary_all<V: BgpShowView>(
+    bgp: &V,
+    json: bool,
+    counts: Option<&SummaryCounts>,
+) -> std::result::Result<String, std::fmt::Error> {
     if json {
         let summary = BgpSummaryJson {
             router_id: summary_router_id(bgp),
             local_as: bgp.asn(),
             afi_safis: configured_afi_safis(bgp)
                 .into_iter()
-                .map(|afi_safi| summary_section_json(bgp, afi_safi))
+                .map(|afi_safi| summary_section_json(bgp, afi_safi, counts))
                 .collect(),
         };
         return Ok(summary_json_render(&summary));
@@ -1919,7 +1981,7 @@ fn show_bgp_summary<V: BgpShowView>(
         if i > 0 {
             writeln!(buf)?;
         }
-        write_summary_section(&mut buf, bgp, afi_safi)?;
+        write_summary_section(&mut buf, bgp, afi_safi, counts)?;
     }
 
     Ok(buf)
@@ -1933,17 +1995,47 @@ fn show_bgp_summary_one<V: BgpShowView>(
     afi_safi: AfiSafi,
     json: bool,
 ) -> std::result::Result<String, std::fmt::Error> {
+    summary_one(bgp, afi_safi, json, None)
+}
+
+/// Body of `show bgp <afi> summary`, parameterised on the optional gathered v4
+/// counts (see [`summary_all`]).
+fn summary_one<V: BgpShowView>(
+    bgp: &V,
+    afi_safi: AfiSafi,
+    json: bool,
+    counts: Option<&SummaryCounts>,
+) -> std::result::Result<String, std::fmt::Error> {
     if json {
         let summary = BgpSummaryJson {
             router_id: summary_router_id(bgp),
             local_as: bgp.asn(),
-            afi_safis: vec![summary_section_json(bgp, afi_safi)],
+            afi_safis: vec![summary_section_json(bgp, afi_safi, counts)],
         };
         return Ok(summary_json_render(&summary));
     }
     let mut buf = String::new();
-    write_summary_section(&mut buf, bgp, afi_safi)?;
+    write_summary_section(&mut buf, bgp, afi_safi, counts)?;
     Ok(buf)
+}
+
+/// Render `show … summary` with externally-gathered v4-unicast prefix counts —
+/// the async path for gate-on / N>1, where the v4 PfxRcd/PfxSnt live off-main
+/// (pool shards / PET) and must be gathered before this (synchronous) render
+/// (see [`super::inst::Bgp::gather_v4_summary_counts`]). `afi_safi` `None`
+/// renders every configured section (`show bgp summary`); `Some` renders that
+/// one (`show bgp ipv4 summary`). The counts apply only to the v4 section.
+pub(super) fn render_summary_with_counts<V: BgpShowView>(
+    bgp: &V,
+    afi_safi: Option<AfiSafi>,
+    json: bool,
+    counts: &SummaryCounts,
+) -> String {
+    let rendered = match afi_safi {
+        Some(one) => summary_one(bgp, one, json, Some(counts)),
+        None => summary_all(bgp, json, Some(counts)),
+    };
+    rendered.unwrap_or_else(|e| format!("Error formatting output: {}", e))
 }
 
 /// `show bgp evpn summary` — the L2VPN/EVPN section only.


### PR DESCRIPTION
## Summary

`show bgp [ipv4] summary` prints each neighbor's **PfxRcd/PfxSnt** from the peer's main-side Adj-RIBs. At `ZEBRA_BGP_SHARDS>1` the v4-unicast Adj-RIB-In lives in the **pool shards**, and at `ZEBRA_BGP_PEER_TASK=1` the v4 Adj-RIB-Out lives in the **PET** — so both main-side copies are empty and every row printed `0/0`. That is the reported bug at **sharding + peer-task**: the summary shows neither received nor sent counts.

The summary render is synchronous, so it cannot reach the off-main owners. This intercepts the summary command in `process_show_msg` (async, like the received-routes / advertised-routes gathers), gathers the per-neighbor counts, then renders with them. **Counts only** — no prefixes or attributes cross the channel, since the summary prints just the number:

- **PfxRcd**: `ShardMsg::CountAdjInV4All` scatters to every shard, each replies with `{peer ident → v4 Adj-RIB-In prefix count}`; main sums across shards.
- **PfxSnt**: `EgressDeltaV4::CountAdjOut` asks each PET for its v4 adj_out prefix count.

Each gathered value is the COMPLETE count: the gather falls back to the main-side read for the half that is not off-main (N=1 PfxRcd, gate-off PfxSnt). The override threads only into the v4-unicast summary section (text + JSON) — every other AFI is main-owned and reads correctly. **Gate-off + N=1 pass `None`, so the synchronous render is byte-identical.**

The egress-group-task egress model is not covered here yet (its adj_out is the group task's, needing a split-horizon per-peer count) — a follow-up; it is gate-off by default, so its summary is unaffected today.

## Test plan

- `@bgp_peer_egress_v4` ✓ (8 scenarios) — new summary scenario on the existing 4-shard + peer-task topology: z2 received z1's two routes (z1 row `2/0`, proving the shard PfxRcd gather) and advertised both to z3/z4 (their rows `0/2`, proving the PET PfxSnt query). Under the bug every row is `0/0`, so neither substring appears.
- `@bgp_unnumbered_summary` ✓ — gate-off summary unchanged.
- `cargo test -p zebra-rs --release --bins` ✓ (1286 passed)
- `cargo clippy --workspace --all-targets -- -D warnings` ✓

Generated with [Claude Code](https://claude.com/claude-code)