### PR TITLE
bgp: fan AddPath candidates through the group egress task

### DIFF
--- a/bdd/tests/configs/bgp_addpath_group/z1.yaml
+++ b/bdd/tests/configs/bgp_addpath_group/z1.yaml
@@ -1,0 +1,24 @@
+interface:
+- if-name: i1
+  ipv4:
+    address: 192.168.0.1/24
+router:
+  bgp:
+    global:
+      as: 65001
+      router-id: 192.168.0.1
+    timer:
+      adv-interval:
+        ibgp: 1
+        ebgp: 1
+    neighbor:
+    - remote-address: 192.168.0.3
+      afi-safi:
+      - name: ipv4
+        enabled: true
+      enabled: true
+      remote-as: 65003
+    afi-safi:
+    - name: ipv4
+      network:
+      - prefix: 10.10.10.0/24

--- a/bdd/tests/configs/bgp_addpath_group/z2.yaml
+++ b/bdd/tests/configs/bgp_addpath_group/z2.yaml
@@ -1,0 +1,24 @@
+interface:
+- if-name: i1
+  ipv4:
+    address: 192.168.0.2/24
+router:
+  bgp:
+    global:
+      as: 65002
+      router-id: 192.168.0.2
+    timer:
+      adv-interval:
+        ibgp: 1
+        ebgp: 1
+    neighbor:
+    - remote-address: 192.168.0.3
+      afi-safi:
+      - name: ipv4
+        enabled: true
+      enabled: true
+      remote-as: 65003
+    afi-safi:
+    - name: ipv4
+      network:
+      - prefix: 10.10.10.0/24

--- a/bdd/tests/configs/bgp_addpath_group/z3.yaml
+++ b/bdd/tests/configs/bgp_addpath_group/z3.yaml
@@ -1,0 +1,33 @@
+interface:
+- if-name: i1
+  ipv4:
+    address: 192.168.0.3/24
+router:
+  bgp:
+    global:
+      as: 65003
+      router-id: 192.168.0.3
+    timer:
+      adv-interval:
+        ibgp: 1
+        ebgp: 1
+    neighbor:
+    - remote-address: 192.168.0.1
+      afi-safi:
+      - name: ipv4
+        enabled: true
+      enabled: true
+      remote-as: 65001
+    - remote-address: 192.168.0.2
+      afi-safi:
+      - name: ipv4
+        enabled: true
+      enabled: true
+      remote-as: 65002
+    - remote-address: 192.168.0.4
+      afi-safi:
+      - name: ipv4
+        enabled: true
+        add-path: send-receive
+      enabled: true
+      remote-as: 65004

--- a/bdd/tests/configs/bgp_addpath_group/z4.yaml
+++ b/bdd/tests/configs/bgp_addpath_group/z4.yaml
@@ -1,0 +1,21 @@
+interface:
+- if-name: i1
+  ipv4:
+    address: 192.168.0.4/24
+router:
+  bgp:
+    global:
+      as: 65004
+      router-id: 192.168.0.4
+    timer:
+      adv-interval:
+        ibgp: 1
+        ebgp: 1
+    neighbor:
+    - remote-address: 192.168.0.3
+      afi-safi:
+      - name: ipv4
+        enabled: true
+        add-path: send-receive
+      enabled: true
+      remote-as: 65003

--- a/bdd/tests/features/bgp_addpath_group.feature
+++ b/bdd/tests/features/bgp_addpath_group.feature
@@ -1,0 +1,74 @@
+@serial
+@bgp_addpath_group
+Feature: BGP AddPath Send for IPv4 unicast (RFC 7911)
+  As a network operator
+  I want a BGP speaker with two paths for one prefix to advertise BOTH
+  of them — each carrying its own path identifier — to a neighbor that
+  negotiated AddPath, instead of the single best path.
+
+  This is the first end-to-end AddPath wire test in the suite: it
+  exercises the per-candidate advertise twin
+  (`route_advertise_to_addpath`), the AddPath-Send membership split,
+  and the path-id stamping. The same shape validates the VPNv6 / EVPN /
+  labeled-unicast twins as those land.
+
+  Test Topology (all on br0):
+  ```
+        10.10.10.0/24          10.10.10.0/24
+       (origin AS65001)       (origin AS65002)
+            z1 ──┐               ┌── z2
+       192.168.   │   192.168.   │   192.168.
+        0.1/24    └──→  0.3/24  ←─┘    0.2/24
+                       z3 (AS65003)
+                        │  add-path send-receive
+                        ↓
+                       z4 (AS65004)  192.168.0.4/24
+  ```
+
+  z3 learns 10.10.10.0/24 over eBGP from BOTH z1 (AS_PATH 65001) and
+  z2 (AS_PATH 65002), so its Loc-RIB holds two candidate paths. With
+  AddPath Send negotiated toward z4, z3 advertises both — so z4 sees
+  TWO available paths for the prefix, not just the best one.
+
+  Scenario: Setup topology and establish sessions
+    Given a clean test environment
+    When I create bridge "br0"
+    And I create namespace "z1" with IP "192.168.0.1/24" on bridge "br0"
+    And I create namespace "z2" with IP "192.168.0.2/24" on bridge "br0"
+    And I create namespace "z3" with IP "192.168.0.3/24" on bridge "br0"
+    And I create namespace "z4" with IP "192.168.0.4/24" on bridge "br0"
+    And I start zebra-rs in namespace "z1"
+    And I start zebra-rs in namespace "z2"
+    And I start zebra-rs in namespace "z3" with egress group task
+    And I start zebra-rs in namespace "z4"
+    And I apply config "z1.yaml" to namespace "z1"
+    And I apply config "z2.yaml" to namespace "z2"
+    And I apply config "z3.yaml" to namespace "z3"
+    And I apply config "z4.yaml" to namespace "z4"
+    And I wait 5 seconds for BGP to operate
+    Then BGP session in "z3" to "192.168.0.1" should be "Established"
+    And BGP session in "z3" to "192.168.0.2" should be "Established"
+    And BGP session in "z3" to "192.168.0.4" should be "Established"
+    And BGP session in "z4" to "192.168.0.3" should be "Established"
+
+  Scenario: The AddPath receiver sees both paths for the prefix
+    Given the test topology exists
+    # z3 holds two candidate paths and, because z4 negotiated AddPath,
+    # advertises BOTH — so z4's table shows the prefix twice, once per
+    # originating AS. Without AddPath Send z4 would hold exactly the
+    # single best path (one AS_PATH only).
+    Then show command "show ip bgp 10.10.10.0/24" in namespace "z4" should eventually contain "65003 65001"
+    And show command "show ip bgp 10.10.10.0/24" in namespace "z4" should contain "65003 65002"
+
+  Scenario: Teardown topology
+    Given the test topology exists
+    When I stop zebra-rs in namespace "z1"
+    And I stop zebra-rs in namespace "z2"
+    And I stop zebra-rs in namespace "z3"
+    And I stop zebra-rs in namespace "z4"
+    And I delete namespace "z1"
+    And I delete namespace "z2"
+    And I delete namespace "z3"
+    And I delete namespace "z4"
+    And I delete bridge "br0"
+    Then the test environment should be clean

--- a/zebra-rs/src/bgp/group_egress.rs
+++ b/zebra-rs/src/bgp/group_egress.rs
@@ -250,11 +250,18 @@ impl Engine {
         self.adj_out.add(prefix, rib);
     }
 
-    /// Drop `prefix` from `adj_out` and, if it had been advertised, fan one
-    /// MP_UNREACH to every member except `source_ident`. Matches by prefix
-    /// (not exact `id`), as the PET withdraw does.
+    /// Drop a path from `adj_out` and, if it had been advertised, fan one
+    /// MP_UNREACH to every member except `source_ident`. `id == 0` is the
+    /// non-AddPath / whole-prefix withdraw (the wire carries id 0); `id != 0`
+    /// is an AddPath per-path withdraw — remove just that path (`adj_out` keys
+    /// by the Out local-id), leaving the prefix's other paths advertised.
     fn withdraw(&mut self, prefix: Ipv4Net, id: u32, source_ident: usize) {
-        if self.adj_out.0.remove(&prefix).is_some() {
+        let removed = if id == 0 {
+            self.adj_out.0.remove(&prefix).is_some()
+        } else {
+            self.adj_out.remove(prefix, id).is_some()
+        };
+        if removed {
             let max = self
                 .members
                 .values()

--- a/zebra-rs/src/bgp/route.rs
+++ b/zebra-rs/src/bgp/route.rs
@@ -2715,6 +2715,14 @@ fn apply_ipv4_advertise_job(
     // (`rd = Some`) stays on the update-group path.
     if rd.is_none() && super::group_egress::egress_group_task_enabled() {
         fan_advertise_to_groups(prefix, &selected, source_ident, bgp.update_groups, peers);
+        fan_addpath_to_groups(
+            prefix,
+            &added,
+            &replaced,
+            source_ident,
+            bgp.update_groups,
+            peers,
+        );
         return;
     }
     // A2 ⑥ (gate-on): the v4-unicast event-driven advertise runs in the
@@ -3130,6 +3138,77 @@ fn fan_advertise_to_groups(
                 id: 0,
                 source_ident,
             }),
+        }
+    }
+}
+
+/// Group-task migration — fan the AddPath per-candidate stream to the
+/// per-update-group egress tasks, in step with `route_advertise_to_addpath` /
+/// `route_withdraw_from_addpath`. AddPath peers receive *every* path (RFC 7911),
+/// not the best, so for an AddPath group this — not `fan_advertise_to_groups`,
+/// which serves only the plain (best-path) groups — carries the routes: each
+/// received path arrives as an `added` candidate (the current best included),
+/// each gone path as a `replaced` one. The engine keys `adj_out` by the Out
+/// local-id, so an added candidate accumulates as a distinct path and a removed
+/// one withdraws by its `local_id`. The `sig.addpath_send` check is a defensive
+/// redundancy: the `established_addpath_idents` audience is already AddPath-only.
+fn fan_addpath_to_groups(
+    prefix: Ipv4Net,
+    added: &Option<BgpRib>,
+    replaced: &[BgpRib],
+    source_ident: usize,
+    update_groups: &super::update_group::UpdateGroupMap,
+    peers: &PeerMap,
+) {
+    if added.is_none() && replaced.is_empty() {
+        return;
+    }
+    let afi_safi = AfiSafi::new(Afi::Ip, Safi::Unicast);
+    let mut seen: std::collections::BTreeSet<super::update_group::UpdateGroupId> =
+        std::collections::BTreeSet::new();
+    // AddPath peers are the per-candidate audience: `plain` and `addpath_tx`
+    // are disjoint partitions (a peer that negotiated AddPath Send is only in
+    // `addpath_tx`), so iterating `plain` here — as `fan_advertise_to_groups`
+    // correctly does for the best path — would reach zero AddPath groups. This
+    // is the group twin of `route_advertise_to_addpath`'s
+    // `established_addpath_idents` audience.
+    for ident in peers.established_addpath_idents(Afi::Ip, Safi::Unicast) {
+        let Some(peer) = peers.get_by_idx(ident) else {
+            continue;
+        };
+        let Some(gid) = peer.update_group_id.get(&afi_safi).cloned() else {
+            continue;
+        };
+        if !seen.insert(gid.clone()) {
+            continue;
+        }
+        let Some(group) = update_groups
+            .get(&afi_safi)
+            .and_then(|af| af.group_by_id(&gid))
+        else {
+            continue;
+        };
+        // Extra paths only matter to AddPath groups.
+        if !group.sig.addpath_send {
+            continue;
+        }
+        let Some(task) = group.task.as_ref() else {
+            continue;
+        };
+        match added {
+            Some(added) => task.send(super::group_egress::GroupEgressDeltaV4::Advertise {
+                prefix,
+                rib: added.clone(),
+            }),
+            None => {
+                for removed in replaced {
+                    task.send(super::group_egress::GroupEgressDeltaV4::Withdraw {
+                        prefix,
+                        id: removed.local_id,
+                        source_ident,
+                    });
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary

At `ZEBRA_BGP_EGRESS_GROUP_TASK=1` the v4-unicast event-driven advertise runs in the per-update-group egress task. The best-path fan (`fan_advertise_to_groups`) served only the **plain** groups; the AddPath per-candidate stream had no group equivalent, so an AddPath-Send peer received only its best path (or whatever session-up sync happened to deliver), never the additional candidates.

This adds `fan_addpath_to_groups`, the group twin of `route_advertise_to_addpath`: each received path arrives as an `added` candidate, each gone path as a `replaced` one, fanned to the AddPath groups. The engine keys `adj_out` by the Out local-id, so candidates accumulate as distinct paths and a withdraw drops just the one path (`id != 0`) rather than the whole prefix.

The audience is `established_addpath_idents`, **not** `established_plain_idents`: the two sets are disjoint partitions (a peer that negotiated AddPath Send is only in `addpath_tx`), exactly as `route_advertise_to_addpath` uses — an AddPath peer is served entirely by the per-candidate stream, never by the best-path batch.

## Test plan

- `@bgp_addpath_group` ✓ — z3 (group task) learns `10.10.10.0/24` from both z1 (AS65001) and z2 (AS65002) and advertises BOTH to the AddPath receiver z4, which sees `65003 65001` and `65003 65002`.
- Regressions ✓: `@bgp_addpath_ipv4` (gate-off), `@bgp_egress_group_sharded` (N>1 group), `@bgp_egress_group_task` (plain group), `@bgp_peer_egress_v4` (PET).
- `cargo test -p zebra-rs --release --bins` ✓ (1286), `cargo clippy --workspace --all-targets -- -D warnings` ✓

Generated with [Claude Code](https://claude.com/claude-code)