### PR TITLE
bgp: extend show-summary PfxSnt to the egress-group-task model

### DIFF
--- a/bdd/tests/features/bgp_egress_group_sharded.feature
+++ b/bdd/tests/features/bgp_egress_group_sharded.feature
@@ -107,6 +107,20 @@ Feature: BGP IPv4-unicast read paths at N>1 (show / session-up sync read the emp
     Then show command "show bgp neighbors 10.0.0.1 received-routes" in namespace "z2" should contain "10.10.10.0/24"
     And show command "show bgp neighbors 10.0.0.1 received-routes" in namespace "z2" should contain "10.10.11.0/24"
 
+  Scenario: z2's `show bgp ipv4 summary` counts come from the shards (PfxRcd) and the group task (PfxSnt)
+    Given the test topology exists
+    # The summary's PfxRcd/Snt column at N>1 + egress-group-task: PfxRcd lives
+    # in the pool shards' Adj-RIB-In and PfxSnt in the per-update-group egress
+    # task's shared Adj-RIB-Out (the peer's own copies are both empty), so the
+    # row read main-side printed "0/0". The count-gather fixes it: z2 received
+    # z1's two routes (PfxRcd 2) and the group advertised both to z3 and z4
+    # (PfxSnt 2), never back to their source z1 (split-horizon, PfxSnt 0). So
+    # z1's row is "2/0" (the shard PfxRcd gather) and z3's / z4's are "0/2" (the
+    # group CountAdjOut: total minus each member's solely-sourced prefixes).
+    # Under the bug every row is "0/0", so neither substring appears.
+    Then show command "show bgp ipv4 summary" in namespace "z2" should contain "2/0"
+    And show command "show bgp ipv4 summary" in namespace "z2" should contain "0/2"
+
   Scenario: z1 withdraws one route; the sharded reduce removes it from z2's mirror
     Given the test topology exists
     # z1 re-originates only 10.10.11.0/24 (dropping .10). At N=4, z2's pool

--- a/bdd/tests/features/bgp_egress_group_task.feature
+++ b/bdd/tests/features/bgp_egress_group_task.feature
@@ -93,6 +93,20 @@ Feature: BGP per-update-group egress task (migration Phases 0-3)
     And show command "show bgp ipv4" in namespace "z3" should contain "10.10.11.0/24"
     And show command "show bgp ipv4" in namespace "z4" should contain "10.10.10.0/24"
 
+  Scenario: z2's `show bgp ipv4 summary` PfxSnt comes from the group task (N=1, group gate only)
+    Given the test topology exists
+    # At gate-on the v4 Adj-RIB-Out lives in the update group's egress task, not
+    # on the peer, so the summary's PfxSnt read main-side printed 0. N=1 here
+    # (no shards), so this exercises the group branch ALONE — the summary
+    # intercept must fire on the egress-group-task gate, query the group's
+    # CountAdjOut, and subtract each member's split-horizoned own paths. z3 and
+    # z4 were each advertised z1's two routes (PfxSnt 2 -> "0/2"); z1, the
+    # source, got none back (PfxSnt 0) while z2 received its two (PfxRcd 2 read
+    # from the main shard at N=1 -> "2/0"). Under the bug PfxSnt is 0, so "0/2"
+    # never appears.
+    Then show command "show bgp ipv4 summary" in namespace "z2" should contain "0/2"
+    And show command "show bgp ipv4 summary" in namespace "z2" should contain "2/0"
+
   Scenario: an event-driven withdraw reaches BOTH the early and the late member (Phase 3 coherence)
     Given the test topology exists
     # z1 re-originates only .11. The group task must withdraw .10 from z3 AND

--- a/zebra-rs/src/bgp/group_egress.rs
+++ b/zebra-rs/src/bgp/group_egress.rs
@@ -90,6 +90,18 @@ pub enum GroupEgressDeltaV4 {
     DumpAdjOut {
         reply: tokio::sync::oneshot::Sender<Vec<(Ipv4Net, Vec<BgpRib>)>>,
     },
+    /// A `show … summary` PfxSnt request at gate-on: the group `adj_out` is
+    /// shared and split-horizon is applied at fan time (not stored), so reply
+    /// with the COUNTS needed to derive each member's sent count —
+    /// `(total prefix count, {ident → prefixes solely-sourced-by-that-ident})`.
+    /// A member M never receives a prefix whose paths it ALL sourced, so
+    /// `PfxSnt(M) = total − sole_source[M]`; in the usual case (the path
+    /// sources are non-members) the map is empty and every member's PfxSnt is
+    /// `total`. Counts only — no prefixes or attributes cross the channel
+    /// (unlike [`Self::DumpAdjOut`]).
+    CountAdjOut {
+        reply: tokio::sync::oneshot::Sender<(usize, BTreeMap<usize, usize>)>,
+    },
 }
 
 /// Handle main keeps on each [`UpdateGroup`](super::update_group::UpdateGroup)
@@ -135,6 +147,17 @@ impl GroupEgressTask {
     pub fn request_adj_out(&self) -> tokio::sync::oneshot::Receiver<Vec<(Ipv4Net, Vec<BgpRib>)>> {
         let (reply, rx) = tokio::sync::oneshot::channel();
         self.send(GroupEgressDeltaV4::DumpAdjOut { reply });
+        rx
+    }
+
+    /// Request the group's adj-out COUNTS over a oneshot (for `show … summary`
+    /// PfxSnt at gate-on): `(total, {ident → solely-sourced prefix count})`,
+    /// from which the caller derives each member's split-horizoned sent count.
+    /// Returns the receiver so the caller can drop the task borrow before
+    /// awaiting.
+    pub fn request_count(&self) -> tokio::sync::oneshot::Receiver<(usize, BTreeMap<usize, usize>)> {
+        let (reply, rx) = tokio::sync::oneshot::channel();
+        self.send(GroupEgressDeltaV4::CountAdjOut { reply });
         rx
     }
 
@@ -190,6 +213,25 @@ impl Engine {
                     .map(|(prefix, ribs)| (*prefix, ribs.clone()))
                     .collect();
                 let _ = reply.send(entries);
+            }
+            GroupEgressDeltaV4::CountAdjOut { reply } => {
+                // Counts for the summary's PfxSnt. `adj_out.0` is keyed by
+                // prefix, so its len is the total prefix count. A prefix is
+                // excluded from member M only when EVERY path is from M (fan
+                // time drops just the member's own paths, split-horizon), so
+                // tally the single-source prefixes per ident — the caller does
+                // PfxSnt(M) = total − sole_source[M].
+                let total = self.adj_out.0.len();
+                let mut sole_source: BTreeMap<usize, usize> = BTreeMap::new();
+                for ribs in self.adj_out.0.values() {
+                    let mut idents = ribs.iter().map(|r| r.ident);
+                    if let Some(first) = idents.next()
+                        && idents.all(|id| id == first)
+                    {
+                        *sole_source.entry(first).or_default() += 1;
+                    }
+                }
+                let _ = reply.send((total, sole_source));
             }
         }
     }
@@ -419,5 +461,56 @@ mod tests {
             rx1.try_recv().is_ok(),
             "the withdraw reaches the sync-recorded member"
         );
+    }
+
+    #[test]
+    fn count_adj_out_tallies_total_and_solely_sourced_prefixes() {
+        // The summary's PfxSnt at group-gate-on: the engine reports the total
+        // prefix count and, per ident, how many prefixes that ident SOLELY
+        // sources — the ones split-horizon drops from that member's fan. The
+        // caller derives PfxSnt(member) = total − sole_source[member].
+        let mut engine = Engine::default();
+        // Two prefixes solely from peer 5, one solely from peer 7.
+        for p in ["10.0.0.0/24", "10.0.1.0/24"] {
+            engine.handle(GroupEgressDeltaV4::RecordAdjOut {
+                prefix: p.parse().unwrap(),
+                rib: rib(5, "192.0.2.1"),
+            });
+        }
+        engine.handle(GroupEgressDeltaV4::RecordAdjOut {
+            prefix: "10.0.2.0/24".parse().unwrap(),
+            rib: rib(7, "192.0.2.1"),
+        });
+        // A fourth prefix with paths from BOTH 5 and 7 (distinct local-ids so
+        // they accumulate) — mixed-source, so it is NOT solely-sourced by
+        // either: both members still receive the other's path.
+        let mut a = rib(5, "192.0.2.1");
+        a.local_id = 1;
+        let mut b = rib(7, "192.0.2.1");
+        b.local_id = 2;
+        for r in [a, b] {
+            engine.handle(GroupEgressDeltaV4::RecordAdjOut {
+                prefix: "10.0.3.0/24".parse().unwrap(),
+                rib: r,
+            });
+        }
+
+        let (reply, mut reply_rx) = tokio::sync::oneshot::channel();
+        engine.handle(GroupEgressDeltaV4::CountAdjOut { reply });
+        let (total, sole) = reply_rx.try_recv().expect("CountAdjOut replied");
+
+        assert_eq!(total, 4, "four prefixes in the group adj_out");
+        assert_eq!(sole.get(&5), Some(&2), "peer 5 solely sources two prefixes");
+        assert_eq!(
+            sole.get(&7),
+            Some(&1),
+            "peer 7 solely sources one — the mixed prefix is excluded"
+        );
+        // Derived PfxSnt: source-5 member gets 4−2=2, source-7 gets 4−1=3, a
+        // non-sourcing member gets all 4.
+        let pfx_snt = |ident: usize| total - sole.get(&ident).copied().unwrap_or(0);
+        assert_eq!(pfx_snt(5), 2);
+        assert_eq!(pfx_snt(7), 3);
+        assert_eq!(pfx_snt(9), 4);
     }
 }

--- a/zebra-rs/src/bgp/inst.rs
+++ b/zebra-rs/src/bgp/inst.rs
@@ -2088,14 +2088,12 @@ impl Bgp {
         }
         // `show [ipv4] summary` at gate-on / N>1: the v4 PfxRcd/PfxSnt live
         // off-main — Adj-RIB-In in the pool shards (N>1), Adj-RIB-Out in the
-        // PET (peer-task) — so the synchronous renderer reads the empty main
-        // copies and prints 0/0. Gather the v4 counts first, then render. The
-        // other AFI sections stay main-owned and read correctly. (`show bgp
-        // ipv4 summary` arrives as `/show/bgp/ipv4` + a "summary" token, peeked
-        // non-destructively so a non-summary command falls through untouched.)
-        // The egress-group-task egress model is not covered here yet — its
-        // adj_out is the group task's, and its split-horizon per-peer count is
-        // a follow-up; it is gate-off by default so the summary is unaffected.
+        // PET (peer-task) or the per-update-group egress task (group-task) — so
+        // the synchronous renderer reads the empty main copies and prints 0/0.
+        // Gather the v4 counts first, then render. The other AFI sections stay
+        // main-owned and read correctly. (`show bgp ipv4 summary` arrives as
+        // `/show/bgp/ipv4` + a "summary" token, peeked non-destructively so a
+        // non-summary command falls through untouched.)
         let v4_summary: Option<Option<bgp_packet::AfiSafi>> = match path.as_str() {
             "/show/bgp/summary" | "/show/ip/bgp/summary" => Some(None),
             "/show/bgp/ipv4" if args.0.front().is_some_and(|t| t == "summary") => Some(Some(
@@ -2104,7 +2102,9 @@ impl Bgp {
             _ => None,
         };
         if let Some(afi_safi_opt) = v4_summary
-            && (self.shards.is_some() || super::peer_egress::peer_egress_task_enabled())
+            && (self.shards.is_some()
+                || super::peer_egress::peer_egress_task_enabled()
+                || super::group_egress::egress_group_task_enabled())
         {
             let counts = self.gather_v4_summary_counts().await;
             let output =
@@ -2249,12 +2249,13 @@ impl Bgp {
     /// Gather per-peer v4-unicast summary prefix counts — `(PfxRcd, PfxSnt)` —
     /// from their off-main owners for `show … summary` at gate-on: PfxRcd from
     /// the pool shards' Adj-RIB-In (N>1), PfxSnt from the PET's Adj-RIB-Out
-    /// (peer-task). **Counts only** — no prefixes or attributes cross the
-    /// channel (lighter than the received/advertised dumps, which the summary
-    /// row doesn't need). Keyed by peer ident, Established v4 peers only; each
-    /// value is the COMPLETE count, falling back to the main-side read for the
-    /// half that is not off-main (N=1 PfxRcd, gate-off PfxSnt), so the render
-    /// uses it verbatim.
+    /// (peer-task) or the per-update-group egress task's shared Adj-RIB-Out
+    /// (group-task, minus the member's split-horizoned own paths). **Counts
+    /// only** — no prefixes or attributes cross the channel (lighter than the
+    /// received/advertised dumps, which the summary row doesn't need). Keyed by
+    /// peer ident, Established v4 peers only; each value is the COMPLETE count,
+    /// falling back to the main-side read for the half that is not off-main
+    /// (N=1 PfxRcd, gate-off PfxSnt), so the render uses it verbatim.
     async fn gather_v4_summary_counts(&self) -> std::collections::BTreeMap<usize, (u64, u64)> {
         use bgp_packet::{Afi, Safi};
         let v4 = bgp_packet::AfiSafi::new(Afi::Ip, Safi::Unicast);
@@ -2277,6 +2278,47 @@ impl Bgp {
             }
         }
 
+        // PfxSnt at group-gate-on: the v4 Adj-RIB-Out lives in each update
+        // group's egress task (shared across members), so query each group's
+        // counts ONCE — `(total, {ident → solely-sourced prefixes})` — and
+        // derive every member's split-horizoned sent count below. Collect the
+        // group reply receivers first so no borrow is held across await.
+        let group_on = super::group_egress::egress_group_task_enabled();
+        let mut group_counts: std::collections::BTreeMap<
+            super::update_group::UpdateGroupId,
+            (u64, std::collections::BTreeMap<usize, u64>),
+        > = std::collections::BTreeMap::new();
+        if group_on {
+            let mut seen = std::collections::BTreeSet::new();
+            let mut rxs = Vec::new();
+            for (_, peer) in self.peers.iter_all() {
+                if peer.state != super::peer::State::Established || !peer.config.mp.has(&v4) {
+                    continue;
+                }
+                let Some(gid) = peer.update_group_id.get(&v4).cloned() else {
+                    continue;
+                };
+                if !seen.insert(gid.clone()) {
+                    continue;
+                }
+                if let Some(rx) = self
+                    .update_groups
+                    .get(&v4)
+                    .and_then(|af| af.group_by_id(&gid))
+                    .and_then(|g| g.task.as_ref())
+                    .map(|t| t.request_count())
+                {
+                    rxs.push((gid, rx));
+                }
+            }
+            for (gid, rx) in rxs {
+                if let Ok((total, sole)) = rx.await {
+                    let sole = sole.into_iter().map(|(k, v)| (k, v as u64)).collect();
+                    group_counts.insert(gid, (total as u64, sole));
+                }
+            }
+        }
+
         // Per-peer (rcvd, sent); query the PET for sent when present. Collect
         // the PET reply receivers first so no peer borrow is held across await.
         let mut out: std::collections::BTreeMap<usize, (u64, u64)> =
@@ -2292,19 +2334,29 @@ impl Bgp {
                 (self.shard.adj_in_count(peer.ident, Afi::Ip, Safi::Unicast)
                     + peer.adj_in.count(Afi::Ip, Safi::Unicast)) as u64
             };
-            match peer.pet.as_ref() {
-                Some(pet) => {
-                    let (tx, rx) = tokio::sync::oneshot::channel();
-                    let _ = pet
-                        .delta_tx
-                        .send(super::peer_egress::EgressDeltaV4::CountAdjOut { reply: tx });
-                    sent_rxs.push((peer.ident, rx));
-                    out.insert(peer.ident, (rcvd_count, 0));
-                }
-                None => {
-                    let sent = peer.adj_out.count(Afi::Ip, Safi::Unicast) as u64;
-                    out.insert(peer.ident, (rcvd_count, sent));
-                }
+            // Sent precedence mirrors the egress gate (group → PET → flush).
+            if group_on {
+                // PfxSnt(member) = group total − the member's solely-sourced
+                // prefixes (the ones split-horizon drops from its fan).
+                let sent = peer
+                    .update_group_id
+                    .get(&v4)
+                    .and_then(|gid| group_counts.get(gid))
+                    .map(|(total, sole)| {
+                        total.saturating_sub(sole.get(&peer.ident).copied().unwrap_or(0))
+                    })
+                    .unwrap_or(0);
+                out.insert(peer.ident, (rcvd_count, sent));
+            } else if let Some(pet) = peer.pet.as_ref() {
+                let (tx, rx) = tokio::sync::oneshot::channel();
+                let _ = pet
+                    .delta_tx
+                    .send(super::peer_egress::EgressDeltaV4::CountAdjOut { reply: tx });
+                sent_rxs.push((peer.ident, rx));
+                out.insert(peer.ident, (rcvd_count, 0));
+            } else {
+                let sent = peer.adj_out.count(Afi::Ip, Safi::Unicast) as u64;
+                out.insert(peer.ident, (rcvd_count, sent));
             }
         }
         for (ident, rx) in sent_rxs {


### PR DESCRIPTION
## Summary

Follow-up to #1455 (the summary count gather), which covered **PfxRcd** (pool shards) and **PfxSnt** (PET) but left the per-update-group egress task uncovered. At `ZEBRA_BGP_EGRESS_GROUP_TASK=1` the peer's `adj_out` is empty (the group task owns it, shared across members), so the summary's **PfxSnt** printed `0`.

The group `adj_out` is shared and split-horizon is applied at fan time (not stored), so a member M's sent count is the group's total prefixes minus the prefixes M **solely** sources (M never receives a prefix whose paths it ALL sourced).

- `GroupEgressDeltaV4::CountAdjOut` replies with `(total, {ident → solely-sourced prefix count})` — **counts only**, no prefixes/attributes — plus a `request_count()` helper.
- The summary gather queries each v4 update group's task **once** and derives every member's `PfxSnt = total − sole_source[member]`. Sent precedence is **group → PET → main flush**, mirroring the egress gate.
- The summary intercept now also fires on the egress-group-task gate.

## Test plan

- `@bgp_egress_group_task` ✓ (N=1) — the group branch ALONE: the intercept fires on the group gate (no shards), z3/z4 rows `0/2` (group PfxSnt), z1 `2/0` (PfxRcd from the main shard at N=1).
- `@bgp_egress_group_sharded` ✓ (N>1) — both gathers: z1 `2/0` (shard PfxRcd) and z3/z4 `0/2` (group PfxSnt).
- Unit test `count_adj_out_tallies_total_and_solely_sourced_prefixes` ✓ (incl. a mixed-source prefix that is excluded).
- `@bgp_peer_egress_v4` ✓ (PET summary unchanged), `@bgp_unnumbered_summary` ✓ (gate-off summary unchanged).
- `cargo test -p zebra-rs --release --bins` ✓ (1287), `cargo clippy --workspace --all-targets -- -D warnings` ✓

Generated with [Claude Code](https://claude.com/claude-code)