### PR TITLE
bgp: originate IPv4 networks through the pool at N>1

### DIFF
--- a/bdd/tests/configs/bgp_network_origin_shard_pet/z1-withdraw.yaml
+++ b/bdd/tests/configs/bgp_network_origin_shard_pet/z1-withdraw.yaml
@@ -1,0 +1,22 @@
+router:
+  bgp:
+    global:
+      as: 65501
+      router-id: 10.0.0.1
+    peer-task: true
+    shards: 4
+    timer:
+      adv-interval:
+        ebgp: 1
+    neighbor:
+    - remote-address: 2001:db8::8
+      afi-safi:
+      - name: ipv6
+        enabled: true
+      enabled: true
+      remote-as: 65501
+      update-source: 2001:db8::1
+    afi-safi:
+    - name: ipv4
+      network:
+      - prefix: 0.0.0.0/0

--- a/bdd/tests/configs/bgp_network_origin_shard_pet/z1.yaml
+++ b/bdd/tests/configs/bgp_network_origin_shard_pet/z1.yaml
@@ -1,0 +1,23 @@
+router:
+  bgp:
+    global:
+      as: 65501
+      router-id: 10.0.0.1
+    peer-task: true
+    shards: 4
+    timer:
+      adv-interval:
+        ebgp: 1
+    neighbor:
+    - remote-address: 2001:db8::8
+      afi-safi:
+      - name: ipv6
+        enabled: true
+      enabled: true
+      remote-as: 65501
+      update-source: 2001:db8::1
+    afi-safi:
+    - name: ipv4
+      network:
+      - prefix: 0.0.0.0/0
+      - prefix: 5.5.5.0/24

--- a/bdd/tests/configs/bgp_network_origin_shard_pet/z2.yaml
+++ b/bdd/tests/configs/bgp_network_origin_shard_pet/z2.yaml
@@ -1,0 +1,16 @@
+router:
+  bgp:
+    global:
+      as: 65501
+      router-id: 10.0.0.2
+    timer:
+      adv-interval:
+        ebgp: 1
+    neighbor:
+    - remote-address: 2001:db8::1
+      afi-safi:
+      - name: ipv6
+        enabled: true
+      enabled: true
+      remote-as: 65501
+      update-source: 2001:db8::8

--- a/bdd/tests/features/bgp_network_origin_shard_pet.feature
+++ b/bdd/tests/features/bgp_network_origin_shard_pet.feature
@@ -1,0 +1,82 @@
+@serial
+@bgp_network_origin_shard_pet
+Feature: BGP IPv4 network origination is advertised under shards + peer-task
+
+  Repro for a reported bug: a speaker with the RIB sharded
+  (router bgp shards 4) AND per-peer egress tasks (router bgp peer-task true)
+  configured with IPv4 network statements never advertises those networks to
+  its neighbor.
+
+  Key fact: IPv4-unicast AFI/SAFI is enabled by DEFAULT on every neighbor,
+  even one whose transport address is IPv6 (it is only off when explicitly
+  set "afi-safi ipv4 enabled false"). So the iBGP neighbor below — peered over
+  an IPv6 transport with the ipv6 family also enabled — negotiates
+  IPv4-unicast too and MUST receive the originated IPv4 networks (IPv4 NLRI
+  with an IPv4 next-hop carried over the IPv6 session).
+
+  z1 is the device under test, configured exactly like the report: AS 65501,
+  shards 4 + peer-task true, originating 0.0.0.0/0 and 5.5.5.0/24, with one
+  iBGP neighbor z2 over IPv6.
+
+  Test Topology:
+  ```
+  z1 (AS65501)  ---- iBGP over IPv6 ----  z2 (AS65501)
+  2001:db8::1/64                          2001:db8::8/64
+  shards 4 + peer-task
+  originates 0.0.0.0/0, 5.5.5.0/24
+  ```
+  Both on bridge br0.
+
+  Scenario: the speaker and its iBGP neighbor establish over IPv6
+    Given a clean test environment
+    When I create bridge "br0"
+    And I create namespace "z1" with IP "2001:db8::1/64" on bridge "br0"
+    And I create namespace "z2" with IP "2001:db8::8/64" on bridge "br0"
+    And I start zebra-rs in namespace "z1"
+    And I start zebra-rs in namespace "z2"
+    And I apply config "z1.yaml" to namespace "z1"
+    And I apply config "z2.yaml" to namespace "z2"
+    And I wait 15 seconds for BGP to operate
+    Then the zebra-rs log in namespace "z1" should contain "BGP RIB sharding: 4 shards (from config)"
+    And BGP session in "z1" to "2001:db8::8" should be "Established"
+    And BGP session in "z2" to "2001:db8::1" should be "Established"
+
+  Scenario: z1 originates the IPv4 networks into its own Loc-RIB
+    Given the test topology exists
+    # Isolates origination from advertisement: route_add must put the
+    # network statements into z1's v4 Loc-RIB (the main-shard mirror at N>1),
+    # so `show bgp ipv4` on z1 itself lists them. If this fails the bug is in
+    # origination; if it passes but the next scenario fails, the bug is in the
+    # egress to the peer.
+    Then show command "show bgp ipv4" in namespace "z1" should contain "5.5.5.0/24"
+    And show command "show bgp ipv4" in namespace "z1" should contain "0.0.0.0/0"
+
+  Scenario: z2 receives the originated IPv4 networks (the reported bug)
+    Given the test topology exists
+    # The neighbor negotiated IPv4-unicast by default, so z1 must advertise
+    # both originated networks to it. They land in z2's v4 Loc-RIB, so
+    # `show bgp ipv4` on z2 lists them. This is the assertion the report says
+    # fails under shards + peer-task.
+    Then show command "show bgp ipv4" in namespace "z2" should eventually contain "5.5.5.0/24"
+    And show command "show bgp ipv4" in namespace "z2" should contain "0.0.0.0/0"
+
+  Scenario: dropping a network statement withdraws it from the neighbor (route_del at N>1)
+    Given the test topology exists
+    # z1 re-applies its config without 5.5.5.0/24 (keeping 0.0.0.0/0). The
+    # config diff calls route_del, which at N>1 retracts the prefix through
+    # the pool (OriginateV4 withdraw) so the reduce withdraws it. z2 must lose
+    # 5.5.5.0/24 while keeping 0.0.0.0/0 (the positive control proving the
+    # withdraw is targeted, not a full session drop).
+    When I apply config "z1-withdraw.yaml" to namespace "z1"
+    And I wait 10 seconds for BGP to operate
+    Then show command "show bgp ipv4" in namespace "z2" should not contain "5.5.5.0/24"
+    And show command "show bgp ipv4" in namespace "z2" should contain "0.0.0.0/0"
+
+  Scenario: Teardown topology
+    Given the test topology exists
+    When I stop zebra-rs in namespace "z1"
+    And I stop zebra-rs in namespace "z2"
+    And I delete namespace "z1"
+    And I delete namespace "z2"
+    And I delete bridge "br0"
+    Then the test environment should be clean

--- a/zebra-rs/src/bgp/route.rs
+++ b/zebra-rs/src/bgp/route.rs
@@ -10277,6 +10277,22 @@ pub fn route_sync(peer: &mut Peer, bgp: &mut BgpTop, v4_via_pool: bool) {
 
 impl Bgp {
     pub fn route_add(&mut self, prefix: Ipv4Net) {
+        // N>1: originate through the pool so the pool owns the row — its
+        // session-up `DumpV4` sync, the reduce's event-driven advertise, and
+        // `mirror_v4` (into main's shard, for `show bgp ipv4`) all pick it up,
+        // exactly like a peer route. Writing to `self.shard` directly (the N=1
+        // path below) left the originated row invisible to the pool's DumpV4,
+        // so a peer establishing after origination never learned the network.
+        if let Some(pool) = self.shards.as_ref() {
+            pool.dispatch(
+                pool.shard_of(std::net::IpAddr::V4(prefix.addr())),
+                ShardMsg::OriginateV4 {
+                    prefix,
+                    withdraw: false,
+                },
+            );
+            return;
+        }
         let ident = ORIGINATED_PEER;
         let attr = BgpAttr::new();
         let mut rib = BgpRib::new(
@@ -10334,6 +10350,18 @@ impl Bgp {
     }
 
     pub fn route_del(&mut self, prefix: Ipv4Net) {
+        // N>1: retract through the pool (the owning shard re-runs best-path and
+        // the reduce withdraws + un-mirrors), matching `route_add`.
+        if let Some(pool) = self.shards.as_ref() {
+            pool.dispatch(
+                pool.shard_of(std::net::IpAddr::V4(prefix.addr())),
+                ShardMsg::OriginateV4 {
+                    prefix,
+                    withdraw: true,
+                },
+            );
+            return;
+        }
         let ident = ORIGINATED_PEER;
         let id = 0;
         let removed = self.shard.remove(None, prefix, id, ident);

--- a/zebra-rs/src/bgp/shard/dispatch.rs
+++ b/zebra-rs/src/bgp/shard/dispatch.rs
@@ -60,6 +60,9 @@ impl BgpShard {
                 }
                 vec![self.best_path_delta_v4(ident, rd, nlri, Vec::new())]
             }
+            ShardMsg::OriginateV4 { prefix, withdraw } => {
+                self.handle_originate_v4(prefix, withdraw)
+            }
             ShardMsg::UpdateV6(u) => self.handle_update_v6(u),
             ShardMsg::WithdrawV6 { ident, rd, nlri } => {
                 vec![self.best_path_delta_v6(ident, rd, nlri, Vec::new())]
@@ -392,6 +395,54 @@ impl BgpShard {
         vec![ShardOut::BestPathV4 {
             ident,
             rd,
+            prefix: nlri,
+            selected,
+            replaced,
+            added: Some(added),
+            survivor_nexthops,
+        }]
+    }
+
+    /// Originate / withdraw one locally-configured `network` prefix in this
+    /// shard — the pool half of `Bgp::route_add` / `route_del` at N>1. Builds
+    /// the canonical originated row (typ `Originated`, weight 32768, empty
+    /// attr, always reachable) and runs best-path off the Loc-RIB ONLY — no
+    /// Adj-RIB-In, since the route is not received from a peer — replying with
+    /// the best-path delta for the reduce to FIB-install, advertise, and mirror
+    /// into main's shard. The store tail mirrors `handle_update_v4`.
+    fn handle_originate_v4(&mut self, prefix: Ipv4Net, withdraw: bool) -> Vec<ShardOut> {
+        let orig = super::super::route::ORIGINATED_PEER;
+        let nlri = Ipv4Nlri { id: 0, prefix };
+        if withdraw {
+            let removed = self.remove(None, prefix, 0, orig);
+            return vec![self.best_path_delta_v4(orig, None, nlri, removed)];
+        }
+        // Identical row to the synchronous `route_add`, interned for dedup.
+        let attr = bgp_packet::BgpAttr::new();
+        let mut rib = BgpRib::new(
+            orig,
+            std::net::Ipv4Addr::UNSPECIFIED,
+            super::super::route::BgpRibType::Originated,
+            0,
+            32768,
+            &attr,
+            None,
+            None,
+            false,
+        );
+        rib.nexthop_reachable = true;
+        rib.attr = self.intern(attr);
+        let mut added = rib.clone();
+        let (replaced, selected, next_id) = self.update(None, prefix, rib);
+        added.local_id = next_id;
+        let survivor_nexthops = if replaced.is_empty() {
+            std::collections::BTreeSet::new()
+        } else {
+            self.candidate_nexthops_v4(None, prefix)
+        };
+        vec![ShardOut::BestPathV4 {
+            ident: orig,
+            rd: None,
             prefix: nlri,
             selected,
             replaced,

--- a/zebra-rs/src/bgp/shard/msg.rs
+++ b/zebra-rs/src/bgp/shard/msg.rs
@@ -83,6 +83,20 @@ pub enum ShardMsg {
         rib_in: bool,
     },
 
+    /// Originate (or, with `withdraw`, retract) a locally-configured
+    /// IPv4-unicast `network` prefix at N>1. The shard builds the canonical
+    /// originated row (typ `Originated`, weight 32768, empty attr) and runs
+    /// best-path WITHOUT touching Adj-RIB-In — an originated route is not
+    /// "received" — replying with [`ShardOut::BestPathV4`] so the reduce
+    /// installs the FIB, advertises it, and mirrors it into main's shard,
+    /// exactly like a peer route. (`route_add` wrote straight to main's shard,
+    /// which the pool's session-up `DumpV4` never sees — the origination bug.)
+    /// The N=1 path stays synchronous in `route_add` / `route_del`.
+    OriginateV4 {
+        prefix: ipnet::Ipv4Net,
+        withdraw: bool,
+    },
+
     /// A received IPv6-unicast (`rd = None`) or VPNv6 (`rd = Some`)
     /// route. Unlike v4 there is no inbound-policy stage (the v6
     /// ingest path has none today), so the carried `attr` is final:


### PR DESCRIPTION
## Summary

A speaker with the RIB sharded (`router bgp shards N>1`) and IPv4 `network` statements never advertised those networks to a neighbor that established **after** the networks were configured.

**Root cause:** `route_add` / `route_del` wrote the originated row straight into **main's** shard. At N>1 a peer's session-up v4 sync is the pool's `DumpV4` broadcast (`route_sync` skips `route_sync_ipv4` when `v4_via_pool`), and the pool never received the origination — so it's absent from the dump. The event-driven `route_advertise_to_peers` only fires at config time, before any session is up, so it reaches nobody either.

Reported with `shards 4` + `peer-task true` and an iBGP neighbor over IPv6. peer-task is incidental — it's an **N>1 (sharding)** bug; and the IPv6-transport neighbor still negotiates IPv4-unicast by default, so it must receive the IPv4 networks.

## Fix

At N>1, `route_add` / `route_del` dispatch a new `ShardMsg::OriginateV4` to the owning pool shard (prefix hash), exactly like a peer route. The shard builds the canonical originated row (typ `Originated`, weight 32768, empty attr) and runs best-path **without** an Adj-RIB-In entry (an originated route is not "received"), replying with `ShardOut::BestPathV4`. The reduce then FIB-installs, advertises (event-driven **and** via the now-populated `DumpV4`), and `mirror_v4` reflects it into main's shard so `show bgp ipv4` still shows it. Also closes a latent gap — an originated route and a peer route for the same prefix now compete in the pool's best-path (they sat in separate tables at N>1). N=1 keeps the synchronous path, unchanged.

## Test plan

- `@bgp_network_origin_shard_pet` ✓ **5 scenarios** — origination (z1's own `show bgp ipv4`), advertisement to the IPv6 iBGP neighbor (the reported bug), and withdrawal of one network (`route_del` at N>1).
- Regressions ✓ — `@bgp_peer_egress_v4`, `@bgp_egress_group_sharded`, `@bgp_egress_group_task`, `@bgp_shard_config_knob` (N>1 transit, N=1 origination, config-knob path).
- `cargo test -p zebra-rs --release --bins` ✓ (1287), `cargo clippy --workspace --all-targets -- -D warnings` ✓

Generated with [Claude Code](https://claude.com/claude-code)