### PR TITLE
isis: add SRv6 dataplane support for Flexible Algorithm

### DIFF
--- a/bdd/docs/isis_flex_srv6.md
+++ b/bdd/docs/isis_flex_srv6.md
@@ -1,0 +1,39 @@
+# IS-IS Flexible Algorithm over the SRv6 dataplane
+
+## Overview
+
+SRv6 sibling of `isis_flexalgo`. The same five-node, two-region backbone
+(se, ch, va, ln, fr) with the same affinity-constrained algorithms, but
+the Flex-Algo dataplane is SRv6 (RFC 9352 §7.1) instead of SR-MPLS.
+
+Every node advertises a distinct per-algorithm SRv6 locator, so reaching
+a node "in algo N" is plain longest-prefix IPv6 to that node's algo-N
+locator computed over the algo-N constrained topology — no per-prefix SID
+is pushed for transit. The algorithm is encoded by *which locator you
+target*.
+
+  - Algo 128 (US-only): exclude-any [eu, transatlantic]
+  - Algo 129 (EU-only): exclude-any [transatlantic, us]
+
+ch originates the FAD for both algorithms; the others participate without
+advertising a FAD.
+
+Per-node SRv6 locators (/48): `2001:db8:<n>000::` (base / algo-0),
+`2001:db8:<n>128::` (algo-128), `2001:db8:<n>129::` (algo-129), where
+`<n>` is a..e for se, ch, va, ln, fr.
+
+## Config Files
+
+se.yaml  ch.yaml  va.yaml  ln.yaml  fr.yaml
+
+## Test Scenarios
+
+| Scenario | Result |
+|----------|--------|
+| Build the SRv6 Flex-Algo topology and confirm IS-IS adjacencies | |
+| Local per-algo SRv6 locators are visible on the originator | |
+| Per-algo SRv6 locators flood to non-originating routers | |
+| Algo 128 (US-only) SRv6 routes confine to the US sub-topology | |
+| Algo 129 (EU-only) SRv6 routes confine to the EU sub-topology | |
+| Per-algo SRv6 locator routes install into the IPv6 FIB | |
+| Teardown SRv6 Flex-Algo topology | |

--- a/bdd/tests/configs/isis_flex_srv6/ch.yaml
+++ b/bdd/tests/configs/isis_flex_srv6/ch.yaml
@@ -1,0 +1,100 @@
+# ch — backbone hub, FAD originator (advertise-definition: true for both
+# algos). SRv6 sibling of configs/isis_flexalgo/ch.yaml.
+affinity-map:
+  affinity:
+  - name: us
+    bit-position: 0
+  - name: transatlantic
+    bit-position: 1
+  - name: eu
+    bit-position: 2
+
+segment-routing:
+  locator:
+  - name: BASE
+    prefix: 2001:db8:b000::/48
+  - name: A128
+    prefix: 2001:db8:b128::/48
+  - name: A129
+    prefix: 2001:db8:b129::/48
+
+interface:
+- if-name: lo
+  ipv4:
+    address: 10.0.0.2/32
+  ipv6:
+    address: 2001:db8:f::2/128
+- if-name: ch-se
+  ipv4:
+    address: 192.168.1.2/30
+  ipv6:
+    address: 2001:db8:11::2/64
+- if-name: ch-va
+  ipv4:
+    address: 192.168.1.5/30
+  ipv6:
+    address: 2001:db8:12::1/64
+- if-name: ch-ln
+  ipv4:
+    address: 192.168.1.9/30
+  ipv6:
+    address: 2001:db8:13::1/64
+
+router:
+  isis:
+    net: 49.0001.0000.0000.0002.00
+    hostname: ch
+    is-type: level-2-only
+    te-router-id: 10.0.0.2
+    segment-routing:
+      srv6:
+        locator: BASE
+        flex-algo-locator:
+        - algo: 128
+          locator: A128
+        - algo: 129
+          locator: A129
+    interface:
+    - if-name: lo
+      ipv4:
+        enable: true
+      ipv6:
+        enable: true
+    - if-name: ch-se
+      ipv4:
+        enable: true
+      ipv6:
+        enable: true
+      affinity:
+      - us
+    - if-name: ch-va
+      ipv4:
+        enable: true
+      ipv6:
+        enable: true
+      affinity:
+      - us
+    - if-name: ch-ln
+      ipv4:
+        enable: true
+      ipv6:
+        enable: true
+      affinity:
+      - transatlantic
+    flex-algo:
+    - algo: 128
+      advertise-definition: true
+      dataplane:
+        srv6: true
+      affinity:
+        exclude-any:
+        - eu
+        - transatlantic
+    - algo: 129
+      advertise-definition: true
+      dataplane:
+        srv6: true
+      affinity:
+        exclude-any:
+        - transatlantic
+        - us

--- a/bdd/tests/configs/isis_flex_srv6/fr.yaml
+++ b/bdd/tests/configs/isis_flex_srv6/fr.yaml
@@ -1,0 +1,88 @@
+# fr — EU-region node, peer of ln over the eu link and va over the
+# transatlantic link. SRv6 sibling of configs/isis_flexalgo/fr.yaml.
+affinity-map:
+  affinity:
+  - name: us
+    bit-position: 0
+  - name: transatlantic
+    bit-position: 1
+  - name: eu
+    bit-position: 2
+
+segment-routing:
+  locator:
+  - name: BASE
+    prefix: 2001:db8:e000::/48
+  - name: A128
+    prefix: 2001:db8:e128::/48
+  - name: A129
+    prefix: 2001:db8:e129::/48
+
+interface:
+- if-name: lo
+  ipv4:
+    address: 10.0.0.5/32
+  ipv6:
+    address: 2001:db8:f::5/128
+- if-name: fr-va
+  ipv4:
+    address: 192.168.1.14/30
+  ipv6:
+    address: 2001:db8:14::2/64
+- if-name: fr-ln
+  ipv4:
+    address: 192.168.1.18/30
+  ipv6:
+    address: 2001:db8:15::2/64
+
+router:
+  isis:
+    net: 49.0001.0000.0000.0005.00
+    hostname: fr
+    is-type: level-2-only
+    te-router-id: 10.0.0.5
+    segment-routing:
+      srv6:
+        locator: BASE
+        flex-algo-locator:
+        - algo: 128
+          locator: A128
+        - algo: 129
+          locator: A129
+    interface:
+    - if-name: lo
+      ipv4:
+        enable: true
+      ipv6:
+        enable: true
+    - if-name: fr-va
+      ipv4:
+        enable: true
+      ipv6:
+        enable: true
+      affinity:
+      - transatlantic
+    - if-name: fr-ln
+      ipv4:
+        enable: true
+      ipv6:
+        enable: true
+      affinity:
+      - eu
+    flex-algo:
+    - algo: 128
+      advertise-definition: false
+      dataplane:
+        srv6: true
+      affinity:
+        exclude-any:
+        - eu
+        - transatlantic
+    - algo: 129
+      advertise-definition: false
+      dataplane:
+        srv6: true
+      affinity:
+        exclude-any:
+        - transatlantic
+        - us

--- a/bdd/tests/configs/isis_flex_srv6/ln.yaml
+++ b/bdd/tests/configs/isis_flex_srv6/ln.yaml
@@ -1,0 +1,88 @@
+# ln — EU-region node reachable from ch only over the transatlantic
+# link. SRv6 sibling of configs/isis_flexalgo/ln.yaml.
+affinity-map:
+  affinity:
+  - name: us
+    bit-position: 0
+  - name: transatlantic
+    bit-position: 1
+  - name: eu
+    bit-position: 2
+
+segment-routing:
+  locator:
+  - name: BASE
+    prefix: 2001:db8:d000::/48
+  - name: A128
+    prefix: 2001:db8:d128::/48
+  - name: A129
+    prefix: 2001:db8:d129::/48
+
+interface:
+- if-name: lo
+  ipv4:
+    address: 10.0.0.4/32
+  ipv6:
+    address: 2001:db8:f::4/128
+- if-name: ln-ch
+  ipv4:
+    address: 192.168.1.10/30
+  ipv6:
+    address: 2001:db8:13::2/64
+- if-name: ln-fr
+  ipv4:
+    address: 192.168.1.17/30
+  ipv6:
+    address: 2001:db8:15::1/64
+
+router:
+  isis:
+    net: 49.0001.0000.0000.0004.00
+    hostname: ln
+    is-type: level-2-only
+    te-router-id: 10.0.0.4
+    segment-routing:
+      srv6:
+        locator: BASE
+        flex-algo-locator:
+        - algo: 128
+          locator: A128
+        - algo: 129
+          locator: A129
+    interface:
+    - if-name: lo
+      ipv4:
+        enable: true
+      ipv6:
+        enable: true
+    - if-name: ln-ch
+      ipv4:
+        enable: true
+      ipv6:
+        enable: true
+      affinity:
+      - transatlantic
+    - if-name: ln-fr
+      ipv4:
+        enable: true
+      ipv6:
+        enable: true
+      affinity:
+      - eu
+    flex-algo:
+    - algo: 128
+      advertise-definition: false
+      dataplane:
+        srv6: true
+      affinity:
+        exclude-any:
+        - eu
+        - transatlantic
+    - algo: 129
+      advertise-definition: false
+      dataplane:
+        srv6: true
+      affinity:
+        exclude-any:
+        - transatlantic
+        - us

--- a/bdd/tests/configs/isis_flex_srv6/se.yaml
+++ b/bdd/tests/configs/isis_flex_srv6/se.yaml
@@ -1,0 +1,78 @@
+# se — US-region edge. SRv6 sibling of configs/isis_flexalgo/se.yaml:
+# the Flex-Algo dataplane is SRv6 (per-algo Locator TLVs) instead of
+# SR-MPLS prefix-SIDs. Each algo binds its own /48 locator so reaching a
+# node "in algo N" is plain IPv6 to that node's algo-N locator.
+affinity-map:
+  affinity:
+  - name: us
+    bit-position: 0
+  - name: transatlantic
+    bit-position: 1
+  - name: eu
+    bit-position: 2
+
+segment-routing:
+  locator:
+  - name: BASE
+    prefix: 2001:db8:a000::/48
+  - name: A128
+    prefix: 2001:db8:a128::/48
+  - name: A129
+    prefix: 2001:db8:a129::/48
+
+interface:
+- if-name: lo
+  ipv4:
+    address: 10.0.0.1/32
+  ipv6:
+    address: 2001:db8:f::1/128
+- if-name: se-ch
+  ipv4:
+    address: 192.168.1.1/30
+  ipv6:
+    address: 2001:db8:11::1/64
+
+router:
+  isis:
+    net: 49.0001.0000.0000.0001.00
+    hostname: se
+    is-type: level-2-only
+    te-router-id: 10.0.0.1
+    segment-routing:
+      srv6:
+        locator: BASE
+        flex-algo-locator:
+        - algo: 128
+          locator: A128
+        - algo: 129
+          locator: A129
+    interface:
+    - if-name: lo
+      ipv4:
+        enable: true
+      ipv6:
+        enable: true
+    - if-name: se-ch
+      ipv4:
+        enable: true
+      ipv6:
+        enable: true
+      affinity:
+      - us
+    flex-algo:
+    - algo: 128
+      advertise-definition: false
+      dataplane:
+        srv6: true
+      affinity:
+        exclude-any:
+        - eu
+        - transatlantic
+    - algo: 129
+      advertise-definition: false
+      dataplane:
+        srv6: true
+      affinity:
+        exclude-any:
+        - transatlantic
+        - us

--- a/bdd/tests/configs/isis_flex_srv6/va.yaml
+++ b/bdd/tests/configs/isis_flex_srv6/va.yaml
@@ -1,0 +1,88 @@
+# va — US-region node also touching the transatlantic link to fr.
+# SRv6 sibling of configs/isis_flexalgo/va.yaml.
+affinity-map:
+  affinity:
+  - name: us
+    bit-position: 0
+  - name: transatlantic
+    bit-position: 1
+  - name: eu
+    bit-position: 2
+
+segment-routing:
+  locator:
+  - name: BASE
+    prefix: 2001:db8:c000::/48
+  - name: A128
+    prefix: 2001:db8:c128::/48
+  - name: A129
+    prefix: 2001:db8:c129::/48
+
+interface:
+- if-name: lo
+  ipv4:
+    address: 10.0.0.3/32
+  ipv6:
+    address: 2001:db8:f::3/128
+- if-name: va-ch
+  ipv4:
+    address: 192.168.1.6/30
+  ipv6:
+    address: 2001:db8:12::2/64
+- if-name: va-fr
+  ipv4:
+    address: 192.168.1.13/30
+  ipv6:
+    address: 2001:db8:14::1/64
+
+router:
+  isis:
+    net: 49.0001.0000.0000.0003.00
+    hostname: va
+    is-type: level-2-only
+    te-router-id: 10.0.0.3
+    segment-routing:
+      srv6:
+        locator: BASE
+        flex-algo-locator:
+        - algo: 128
+          locator: A128
+        - algo: 129
+          locator: A129
+    interface:
+    - if-name: lo
+      ipv4:
+        enable: true
+      ipv6:
+        enable: true
+    - if-name: va-ch
+      ipv4:
+        enable: true
+      ipv6:
+        enable: true
+      affinity:
+      - us
+    - if-name: va-fr
+      ipv4:
+        enable: true
+      ipv6:
+        enable: true
+      affinity:
+      - transatlantic
+    flex-algo:
+    - algo: 128
+      advertise-definition: false
+      dataplane:
+        srv6: true
+      affinity:
+        exclude-any:
+        - eu
+        - transatlantic
+    - algo: 129
+      advertise-definition: false
+      dataplane:
+        srv6: true
+      affinity:
+        exclude-any:
+        - transatlantic
+        - us

--- a/bdd/tests/features/isis_flex_srv6.feature
+++ b/bdd/tests/features/isis_flex_srv6.feature
@@ -1,0 +1,105 @@
+@isis_flex_srv6
+Feature: IS-IS Flexible Algorithm over the SRv6 dataplane
+  SRv6 sibling of @isis_flexalgo. Same five-node, two-region backbone and
+  the same affinity-constrained algorithms, but the Flex-Algo dataplane is
+  SRv6 (RFC 9352 §7.1): every node advertises a distinct per-algorithm
+  SRv6 locator, so reaching a node "in algo N" is plain longest-prefix
+  IPv6 to that node's algo-N locator computed over the algo-N constrained
+  topology — no per-prefix SID is pushed for transit.
+
+    Algo 128 (US-only):  exclude-any [eu, transatlantic]
+    Algo 129 (EU-only):  exclude-any [transatlantic, us]
+
+  Topology (all links point-to-point; default metric 10):
+
+    se ---[us]--- ch ---[transatlantic]--- ln
+                  |                          |
+                [us]                       [eu]
+                  |                          |
+                  va ---[transatlantic]--- fr
+
+  Per-node SRv6 locators (/48):
+    Node  base(algo0)        algo-128            algo-129
+    se    2001:db8:a000::    2001:db8:a128::     2001:db8:a129::
+    ch    2001:db8:b000::    2001:db8:b128::     2001:db8:b129::
+    va    2001:db8:c000::    2001:db8:c128::     2001:db8:c129::
+    ln    2001:db8:d000::    2001:db8:d128::     2001:db8:d129::
+    fr    2001:db8:e000::    2001:db8:e128::     2001:db8:e129::
+
+  The FAD for both algorithms is originated by ch; every other router
+  participates without advertising a FAD.
+
+  Scenario: Build the SRv6 Flex-Algo topology and confirm IS-IS adjacencies
+    Given a clean test environment
+    When I create namespace "se"
+    And I create namespace "ch"
+    And I create namespace "va"
+    And I create namespace "ln"
+    And I create namespace "fr"
+    And I connect namespace "se" interface "se-ch" to namespace "ch" interface "ch-se"
+    And I connect namespace "ch" interface "ch-va" to namespace "va" interface "va-ch"
+    And I connect namespace "ch" interface "ch-ln" to namespace "ln" interface "ln-ch"
+    And I connect namespace "va" interface "va-fr" to namespace "fr" interface "fr-va"
+    And I connect namespace "ln" interface "ln-fr" to namespace "fr" interface "fr-ln"
+    And I start zebra-rs in namespace "se"
+    And I start zebra-rs in namespace "ch"
+    And I start zebra-rs in namespace "va"
+    And I start zebra-rs in namespace "ln"
+    And I start zebra-rs in namespace "fr"
+    And I apply config "se.yaml" to namespace "se"
+    And I apply config "ch.yaml" to namespace "ch"
+    And I apply config "va.yaml" to namespace "va"
+    And I apply config "ln.yaml" to namespace "ln"
+    And I apply config "fr.yaml" to namespace "fr"
+    And I wait 15 seconds
+    # se and ch are directly adjacent over se-ch (algo-0 reachability).
+    Then ping from "se" to "192.168.1.2" should succeed
+
+  Scenario: Local per-algo SRv6 locators are visible on the originator
+    Given the test topology exists
+    # ch binds its own /48 per algorithm; both must resolve and carry a
+    # node End SID.
+    Then show command "show isis flex-algo" in namespace "ch" should contain "2001:db8:b128"
+    And show command "show isis flex-algo" in namespace "ch" should contain "2001:db8:b129"
+
+  Scenario: Per-algo SRv6 locators flood to non-originating routers
+    Given the test topology exists
+    # se learns ch's per-algo locators from ch's SRv6 Locator TLV 27.
+    Then show command "show isis flex-algo" in namespace "se" should contain "2001:db8:b128"
+
+  Scenario: Algo 128 (US-only) SRv6 routes confine to the US sub-topology
+    Given the test topology exists
+    # From se: ch (b128) and va (c128) are reachable over us-tagged links
+    # only. ln and fr need a transatlantic link, which algo 128 excludes.
+    Then show command "show isis flex-algo route algorithm 128" in namespace "se" should contain "2001:db8:b128"
+    And show command "show isis flex-algo route algorithm 128" in namespace "se" should contain "2001:db8:c128"
+    And show command "show isis flex-algo route algorithm 128" in namespace "se" should not contain "2001:db8:d128"
+    And show command "show isis flex-algo route algorithm 128" in namespace "se" should not contain "2001:db8:e128"
+
+  Scenario: Algo 129 (EU-only) SRv6 routes confine to the EU sub-topology
+    Given the test topology exists
+    # From ln: fr (e129) is reachable over the eu link only. se/ch/va all
+    # require a transatlantic link, which algo 129 excludes.
+    Then show command "show isis flex-algo route algorithm 129" in namespace "ln" should contain "2001:db8:e129"
+    And show command "show isis flex-algo route algorithm 129" in namespace "ln" should not contain "2001:db8:a129"
+    And show command "show isis flex-algo route algorithm 129" in namespace "ln" should not contain "2001:db8:b129"
+    And show command "show isis flex-algo route algorithm 129" in namespace "ln" should not contain "2001:db8:c129"
+
+  Scenario: Per-algo SRv6 locator routes install into the IPv6 FIB
+    Given the test topology exists
+    # The algo-128 locator route to ch is a real IPv6 route in se's RIB.
+    Then show command "show ipv6 route" in namespace "se" should contain "2001:db8:b128"
+
+  Scenario: Teardown SRv6 Flex-Algo topology
+    Given the test topology exists
+    When I stop zebra-rs in namespace "se"
+    And I stop zebra-rs in namespace "ch"
+    And I stop zebra-rs in namespace "va"
+    And I stop zebra-rs in namespace "ln"
+    And I stop zebra-rs in namespace "fr"
+    And I delete namespace "se"
+    And I delete namespace "ch"
+    And I delete namespace "va"
+    And I delete namespace "ln"
+    And I delete namespace "fr"
+    Then the test environment should be clean

--- a/docs/design/isis-flexalgo-srv6-plan.md
+++ b/docs/design/isis-flexalgo-srv6-plan.md
@@ -1,0 +1,298 @@
+# IS-IS Flex-Algorithm over SRv6 — implementation plan
+
+Status as of 2026-06-16. Tracks the work to extend IS-IS Flexible
+Algorithm (RFC 9350) from the SR-MPLS dataplane (complete) to the
+SRv6 dataplane (RFC 9352 §7–8). Companion to
+`docs/design/flex-algo-roadmap.md`, which covered the SR-MPLS path
+and pre-scoped the SRv6 work as its §5; this document supersedes that
+§5 with the current code state and an agreed scope.
+
+## Implementation status (2026-06-16)
+
+PRs 1–6 are **implemented** on branch `isis-flexalgo-srv6` (build / fmt /
+workspace-clippy / full non-bdd test suite all green; 1 new lsdb parse
+unit test). Summary of what landed:
+
+- **PR 1** — per-algo locator watch + End SID alloc: `Isis::{watched_flex_algo_locators,
+  sr_flex_algo_locators, sr_flex_algo_end_sid}`, `reconcile_locator_watch`
+  now diffs the union of base + per-algo names, `update_flex_algo_end_sid`,
+  `process_sr_rx` applies snapshots to every subscriber, config handler
+  wired (`inst.rs`, `config.rs`).
+- **PR 2** — emit per-algo SRv6 Locator TLV 27 (Algorithm = N) in
+  `lsp_generate`, `srv6_end_structure` helper; per-algo locators are *not*
+  added to the IPv6-reach advert (separation rule) (`lsp.rs`).
+- **PR 3** — `srv6::Srv6AlgoLoc`, `Isis::peer_algo_srv6` threaded through
+  IsisTop/LinkTop/SysStateRefs (all sites), parsed in
+  `lsdb::rebuild_sys_state` (base `Algo::Spf` → `srv6_end_map`,
+  `FlexAlgo(N)` → `peer_algo_srv6`) + clear-on-purge + unit test
+  (`srv6.rs`, `inst.rs`, `link.rs`, `lsdb.rs`).
+- **PR 4** — `Isis::rib6_flex_algo`, `build_rib6_from_flex_algo` (routes
+  each participating node's per-algo locator over the algo-N SPF with a
+  plain IPv6 nexthop), `diff_apply_flex_algo6` installs them as real
+  `Ipv6Add`/`Ipv6Del` FIB routes (`rib.rs`, `inst.rs`). End SID stays
+  cached for the future colour consumer (PR 7).
+- **PR 5** — orchestration reads `dataplane_sr_mpls`/`dataplane_srv6` to
+  pick which RIB build runs (backward-compatible default: no flag → SR-MPLS)
+  (`rib.rs`).
+- **PR 6** — `show isis flex-algo` shows local + peer per-algo locators;
+  `show isis flex-algo route [algorithm N]` renders the SRv6 per-algo RIB
+  alongside the SR-MPLS one (no new exec.yang grammar) (`show.rs`); BDD
+  `@isis_flex_srv6` feature + 5 node configs + doc. Also broadened the
+  SRv6 capability/SR-Algorithm advertisement gate in `lsp.rs` so an
+  SRv6-only Flex-Algo config (no base locator) still advertises
+  participation.
+
+Not done (deferred per scope): PR 7 (BGP colour → SRv6 steering) and
+PR 8 (per-algo TI-LFA over SRv6). The BDD feature was authored but not
+executed here (needs root/netns; CI runs the bdd suite).
+
+## Decisions (locked 2026-06-16)
+
+- **Install model:** per-algo locator prefixes are installed as **real
+  IPv6 FIB routes** computed over the algo-N topology (operator can
+  ping/traceroute a per-algo locator), *and* the per-algo End SID is
+  cached for a later BGP colour-aware steering consumer. Per-algo SRv6
+  reachability is plain longest-prefix IPv6 — the algorithm is encoded
+  by *which locator you target*, not by a pushed SID.
+- **Scope (this effort):** IGP reachability first — PRs 1–6
+  (originate → parse → per-algo IPv6 RIB → dataplane gate → show →
+  BDD). BGP colour→SRv6 steering (PR 7) and per-algo TI-LFA (PR 8)
+  are deferred.
+
+## Why SRv6 flex-algo ≠ SR-MPLS flex-algo
+
+SR-MPLS routes a destination *prefix* by pushing that prefix's
+**per-algo Prefix-SID label** (`peer_algo_sid[(algo, prefix)]` →
+origin SRGB → label). SRv6 is structurally different:
+
+- Each node advertises a **distinct per-algo locator** (a different
+  IPv6 prefix per algorithm) in SRv6 Locator TLV 27 with
+  `algo = FlexAlgo(N)`.
+- Reaching a node "in algo N" = routing to its **algo-N locator
+  prefix**, computed over the algo-N constrained topology. Transit is
+  plain IPv6 — no per-prefix SID lookup.
+- The per-algo **End SID** (function 0 of the per-algo locator) is what
+  a headend/colour-resolver encapsulates toward (H.Encap) to steer a
+  service into algo N.
+
+**Separation rule (critical):** per-algo locators must be advertised
+**only** in TLV 27 (algo=N), **never** as plain IPv6 Reachability TLVs.
+Otherwise algo-0 SPF would also install a route to them over the
+unconstrained path and defeat the constraint. The algo-N IPv6 RIB build
+sources its destinations from the parsed per-(peer, algo) locator
+cache, not from generic IPv6 reachability.
+
+## Current state (verified 2026-06-16)
+
+### SR-MPLS flex-algo — complete, the template to mirror
+
+- FAD codec `IsisSubFlexAlgoDef` — `crates/isis-packet/src/sub/cap.rs`
+  (no dataplane field on the wire; RFC 9350 defines none — dataplane is
+  config-only).
+- Per-algo constrained SPF — `graph_flex_algo()`
+  (`zebra-rs/src/isis/graph.rs:548`): peer participation filter
+  (`peer_algos`), affinity gate (`flex_algo::constraint::link_passes_fad`),
+  IGP + min-delay metric. Result in `spf_flex_algo`. **AF-agnostic — the
+  SRv6 RIB build reuses this result as-is.**
+- Per-algo IPv4 RIB — `build_rib_from_flex_algo()`
+  (`zebra-rs/src/isis/rib.rs:1504`) →
+  `rib_flex_algo: Levels<BTreeMap<u8, PrefixMap<Ipv4Net, SpfRoute<V4>>>>`.
+- Export — `make_flex_algo_route` → `rib::api::FlexAlgoRoute`
+  (`Ipv4Net` + `label: u32`) → `Message::FlexAlgoRouteAdd/Del` →
+  consumed by the BGP colour-aware resolver (`Rib::flex_algo_routes`),
+  *not* installed as plain FIB routes.
+
+### SRv6 (algo-0) machinery — reusable
+
+- TLV 27 codec `Srv6Locator { algo: Algo, locator: Ipv6Net, subs }`
+  (`crates/isis-packet/src/sub/prefix.rs:761`) **already carries the
+  Algorithm field**. End.X codec `IsisSubSrv6EndXSid { algo: Algo, … }`
+  (`neigh.rs:925`) too.
+- Single-locator watch — `reconcile_locator_watch()` + `watched_locator`
+  / `sr_locator: Option<Locator>` / `sr_end_sid: Option<Ipv6Addr>` /
+  `elib: ElibPool` (`zebra-rs/src/isis/inst.rs`). SID math in
+  `zebra-rs/src/isis/srv6.rs` (`function_addr`, `ElibPool`).
+- Origination — `lsp.rs:742` emits one `Srv6Locator { algo: Algo::Spf }`
+  (**hardcoded algo-0**) + End SID; `lsp.rs:1154` advertises the algo-0
+  locator as a plain IPv6 Reachability TLV.
+- Consume — `lsdb.rs` parses peer TLV 27 →
+  `srv6_end_map: Levels<BTreeMap<IsisSysId, Srv6EndSidInfo>>` (sys-id
+  only, algo-0 implicit).
+- Primary IPv6 forwarding is plain IPv6 (`resolve_sid` for V6 returns
+  `None`, `rib.rs:245`); SRv6 segment lists only feed TI-LFA backup
+  (`RepairPathSrv6`, `tilfa::build_repair_path_srv6`, shared
+  `spf::srv6::pack_carriers`).
+
+### SRv6 flex-algo scaffolding already on the branch (config/model only)
+
+- YANG: `router isis/segment-routing/srv6/flex-algo-locator[algo]/locator`
+  + `flex-algo/dataplane/{sr-mpls,srv6,ip}` (`zebra-rs/yang/config.yang`).
+- Storage: `IsisConfig::sr_srv6_flex_algo_locators: BTreeMap<u8,String>`
+  (`config.rs:492`); `FlexAlgoEntry::dataplane_srv6`
+  (`flex_algo/entry.rs`).
+- **Both parsed and stored but read by zero logic.** The config handler
+  comment defers emit + locator-watch to "the PR that consumes the map"
+  (`config.rs:1366`).
+
+## Gap summary
+
+| Layer | SR-MPLS (done) | SRv6 (gap) |
+|---|---|---|
+| Locator watch | n/a | single-locator only — watch N per-algo locators, resolve, alloc per-algo End SID |
+| Origination | FAD/SID emit done | TLV 27 hardcodes algo-0 — emit per-algo sub-locators |
+| Consume | `peer_algo_sid` | `srv6_end_map` sys-id-only — need per-(peer, algo) locator + End-SID cache |
+| SPF | `graph_flex_algo` ✅ | reuse as-is (graph is AF-agnostic) |
+| RIB install | `build_rib_from_flex_algo` (IPv4 + label) | IPv6 twin: routes to per-algo locators over algo-N path |
+| Export / API | `FlexAlgoRoute` (Ipv4Net + label) | IPv6/SRv6 variant + msg; install as FIB routes |
+| dataplane gate | flags ignored | read `dataplane_srv6`/`sr_mpls` to pick which RIB build runs |
+| TI-LFA | per-algo n/a | per-algo End.X + repair (deferred, PR 8) |
+| show / BDD | present | extend |
+
+## Plan — ordered PRs
+
+Repo conventions apply to every PR: `cargo fmt` before commit, workspace
+clippy (`cargo clippy --workspace --all-targets -- -D warnings`), and any
+BDD feature ends with an explicit teardown scenario.
+
+### PR 1 — Per-algo locator watch + End SID allocation
+
+**Size:** medium. **Scope:** generalize the single-locator watch to a set.
+
+- Add `Isis::sr_flex_algo_locators: BTreeMap<u8, Locator>` (resolved
+  snapshots) and `Isis::sr_flex_algo_end_sid: BTreeMap<u8, Ipv6Addr>`
+  (function-0 node SID per algo).
+- `reconcile_locator_watch()` subscribes to the **union** of the algo-0
+  locator name and every name in `sr_srv6_flex_algo_locators`; on `SrRx`
+  resolve each and compute its End SID (locator network address).
+- Wire `config_sr_srv6_flex_algo_locator` to call
+  `reconcile_locator_watch()` and re-originate the self LSP (today it is
+  storage-only).
+- On a per-algo locator prefix change, drop its stale End SID.
+
+**Files:** `inst.rs`, `config.rs`, `lsp.rs` (`target_locator_name` →
+locator-name set), `srv6.rs` (helpers if needed).
+**Tests:** watch-set computation (union, add/remove); resolve → End SID
+(function 0 == network addr); prefix change clears stale SID.
+
+### PR 2 — Emit per-algo SRv6 Locator TLV 27 (algo = N)
+
+**Size:** small. **Scope:** origination only.
+
+- At `lsp.rs:742`, in addition to the algo-0 sub-locator, push one
+  `Srv6Locator { algo: Algo::FlexAlgo(N), locator: prefix_N,
+  subs: [Srv6EndSid] }` per entry in `sr_flex_algo_locators` that has a
+  resolved snapshot and an End SID.
+- **Do not** add per-algo locators to the IPv6 Reachability advert
+  (separation rule).
+
+**Files:** `lsp.rs`.
+**Tests:** LSP build with one flex-algo locator → TLV 27 carries a
+second sub-locator with `algo=128` + End SID; codec round-trip.
+
+### PR 3 — Parse + cache peer per-(algo) SRv6 locators
+
+**Size:** medium (mirrors the `peer_algo_sid` cache end-to-end).
+
+- New cache
+  `Isis::peer_algo_srv6: Levels<BTreeMap<IsisSysId, BTreeMap<u8, Srv6AlgoLoc>>>`
+  where `Srv6AlgoLoc { locator: Ipv6Net, end: Srv6EndSidInfo }`.
+- Populate in `lsdb::rebuild_sys_state`: walk peer TLV 27 sub-locators;
+  `algo == FlexAlgo(N)` → cache; `algo == Spf` → existing `srv6_end_map`
+  path. Clear on fragment/peer drop.
+- Thread the new field through `IsisTop` / `LinkTop` / `SysStateRefs`
+  (the ~10 construction sites flagged in the roadmap's cross-cutting
+  note — grep `peer_algo_sid` and add next to it everywhere).
+
+**Files:** `inst.rs`, `lsdb.rs`, `srv6.rs`.
+**Tests:** ingest a peer LSP with an algo-128 locator → cache
+populated; fragment drop clears.
+
+### PR 4 — Per-algo IPv6 RIB build → install per-algo locator routes (FIB)
+
+**Size:** medium-large. **Scope:** the actual SRv6 dataplane.
+
+- Add `Isis::rib6_flex_algo: Levels<BTreeMap<u8, PrefixMap<Ipv6Net, SpfRoute<V6>>>>`
+  (mirrors OSPFv3's `rib6_flex_algo`).
+- New `build_rib6_from_flex_algo(top, level, algo, source, spf_result)`:
+  reuse the existing per-algo `spf_flex_algo` path result (no new SPF);
+  for each participating node with `peer_algo_srv6[sys_id][algo]`,
+  install a route to that locator prefix with the algo-N IPv6 nexthop(s)
+  (`SpfNexthop<V6>`, plain link nexthop, `segs: []`, no encap for
+  transit).
+- Diff/apply: `diff_apply_flex_algo6` → new `rib::api` IPv6 route type
+  (`FlexAlgoRoute6 { algo, prefix: Ipv6Net, metric, nexthops }`) and
+  `Message::FlexAlgoRoute6Add/Del`. Per the install decision, the
+  RIB-side handler installs these as **real IPv6 FIB routes** (distinct
+  per-algo locator prefixes are safe to install).
+- Keep the per-algo End SID (`sr_flex_algo_end_sid` local +
+  `peer_algo_srv6[..].end` remote) available for the later colour
+  consumer (PR 7), but do not wire that consumer here.
+
+**Files:** `inst.rs`, `rib.rs`, `rib/api.rs`, plus the `rib/` install
+handler for the new message.
+**Tests:** synth LSDB with per-algo locators across a constrained
+topology; assert algo-128 IPv6 routes are computed over the constrained
+graph (excluded link skipped) with the correct nexthop; metric =
+path-cost + locator metric.
+
+### PR 5 — Gate on the `dataplane_*` flags
+
+**Size:** small-medium. **Scope:** pick the right RIB build per algo.
+
+- In the `spf_calc` orchestration (`rib.rs:1199–1461`), read each FAD's
+  `dataplane_sr_mpls` / `dataplane_srv6` to decide which build runs:
+  SR-MPLS → IPv4 label RIB (existing), SRv6 → IPv6 locator RIB (PR 4).
+  Today the V4 build runs unconditionally for every configured algo.
+- Confirm the separation rule holds end-to-end: per-algo locators never
+  appear in the algo-0 IPv6 RIB.
+
+**Files:** `rib.rs`.
+**Tests:** algo with only `srv6` → no IPv4 flex RIB entry; algo with
+only `sr-mpls` → no IPv6 flex RIB entry; both → both.
+
+### PR 6 — Operator visibility
+
+**Size:** small-medium.
+
+- Extend `show isis flex-algo`: per-algo SRv6 locators (configured +
+  resolved + End SID) and per-peer received per-algo locators.
+- Add `show isis ipv6 route algorithm N` reading `rib6_flex_algo`.
+
+**Files:** `show.rs`, `exec.yang`. (Heed the show-grammar/bdd sweep
+note: grep old spellings, add `parse()` tests.)
+
+### PR 7 — (deferred) BGP colour → SRv6 service steering
+
+SRv6 twin of `flex_algo_routes`: expose per-algo End SID per node so
+colour policy encapsulates coloured service routes (H.Encap) toward the
+destination's algo-N End SID. *Files:* `rib/api.rs`,
+`bgp/color_policy.rs`, `bgp/inst.rs`.
+
+### PR 8 — (deferred) Per-algo TI-LFA over SRv6
+
+Per-algo End.X SID emit (codec `algo` field already exists) + algo-N
+`build_repair_path_srv6` over the algo-N graph and algo-N End/End.X
+SIDs. Heavy; defer until base SRv6 flex-algo is validated.
+
+### PR 9 — BDD `isis_flexalgo_srv6`
+
+Mirror the `isis_flexalgo` topology (`bdd/docs/isis_flexalgo.md`) with a
+per-algo SRv6 locator per algorithm; assert per-algo IPv6 routes confine
+to the constrained sub-topology and that seg6 entries appear in each
+namespace's FIB. End with an explicit `Teardown topology` scenario
+(stop zebra-rs, delete namespaces, assert the environment is clean).
+
+## Cross-cutting notes
+
+- **Per-peer cache shape:** `peer_algo_srv6` follows the same
+  `Levels<BTreeMap<IsisSysId, <inner>>>` shape as `peer_algo_sid` /
+  `peer_fad`; update the field on `Isis`/`IsisTop`/`LinkTop`/
+  `SysStateRefs` and all `SysStateRefs` construction sites.
+- **MT:** the minimal plan runs the algo-N SPF over the default graph
+  (single-topology, the common SRv6 case). If an MT2 (IPv6 MT)
+  constrained SPF is needed, parameterize `graph_flex_algo` by topology
+  as a follow-up — out of scope here.
+- **Style references:** new per-peer cache → mirror `peer_algo_sid`
+  (PR #619); per-algo locator emit → mirror the algo-0 TLV 27 emit at
+  `lsp.rs:742`; IPv6 per-algo RIB → mirror `build_rib_from_flex_algo`
+  for control flow and OSPFv3 `rib6_flex_algo` for the storage shape.

--- a/zebra-rs/src/isis/config.rs
+++ b/zebra-rs/src/isis/config.rs
@@ -1358,12 +1358,11 @@ fn config_sr_srv6_locator(isis: &mut Isis, mut args: Args, op: ConfigOp) -> Opti
 
 // `/router/isis/segment-routing/srv6/flex-algo-locator[algo=N]/locator`
 // — bind a /segment-routing/locator name to algorithm N for SRv6
-// origination. Storage-only here; the LSP emit follow-up will turn
-// each entry into an SRv6 Locator TLV 27 with Algorithm=N (RFC 9352
-// §7.1). The locator-watch reconciliation that fires for the algo-0
-// `sr_srv6_locator` is not invoked here — per-algo locators live in
-// the same /segment-routing/locator namespace and will be folded into
-// the watch set in the same PR that consumes the map.
+// origination. `reconcile_locator_watch` folds the per-algo names into
+// the SR-watch set (alongside the algo-0 `sr_srv6_locator`) and
+// allocates the per-algo node (End) SID; the LSP emit turns each
+// resolved entry into an SRv6 Locator TLV 27 with Algorithm=N
+// (RFC 9352 §7.1).
 fn config_sr_srv6_flex_algo_locator(isis: &mut Isis, mut args: Args, op: ConfigOp) -> Option<()> {
     let algo = args.u8()?;
     if !(128..=255).contains(&algo) {
@@ -1375,6 +1374,11 @@ fn config_sr_srv6_flex_algo_locator(isis: &mut Isis, mut args: Args, op: ConfigO
     } else {
         isis.config.sr_srv6_flex_algo_locators.remove(&algo);
     }
+    // Subscribe to / drop the per-algo locator on the RIB SR channel and
+    // (de)allocate its node SID. The resolved snapshot arrives on
+    // `sr_rx` and re-originates the LSP carrying the per-algo Locator
+    // TLV with Algorithm=N.
+    isis.reconcile_locator_watch();
     Some(())
 }
 

--- a/zebra-rs/src/isis/inst.rs
+++ b/zebra-rs/src/isis/inst.rs
@@ -238,6 +238,15 @@ pub struct Isis {
     /// not contain the algo being computed (RFC 9350 §5.2
     /// participation requirement). Cleared on peer purge.
     pub peer_algos: Levels<BTreeMap<IsisSysId, BTreeSet<u8>>>,
+
+    /// Per-peer per-Flexible-Algorithm SRv6 locators. Outer key is peer
+    /// sys-id; inner key is the algorithm (128..=255). Populated from
+    /// SRv6 Locator TLV 27 sub-locators whose Algorithm field is a
+    /// Flex-Algo id (RFC 9352 §7.1). Each value is the per-algo locator
+    /// prefix plus its node End SID; the per-algo IPv6 RIB build routes
+    /// the prefix over the algo-N constrained topology. Cleared on peer
+    /// purge.
+    pub peer_algo_srv6: Levels<BTreeMap<IsisSysId, BTreeMap<u8, super::srv6::Srv6AlgoLoc>>>,
     pub rib: Levels<PrefixMap<Ipv4Net, SpfRoute<V4>>>,
     pub rib_v6: Levels<PrefixMap<Ipv6Net, SpfRoute<V6>>>,
     pub ilm: Levels<BTreeMap<u32, SpfIlm>>,
@@ -317,6 +326,13 @@ pub struct Isis {
     /// alongside the algo-0 entries).
     pub rib_flex_algo: Levels<BTreeMap<u8, PrefixMap<Ipv4Net, SpfRoute<V4>>>>,
 
+    /// Per-algorithm IPv6 RIB (SRv6 dataplane). Outer key is the
+    /// algorithm (128..=255); each value routes that algo's per-node
+    /// SRv6 locator prefixes over the algo-N constrained topology. Held
+    /// in-memory for `show isis ipv6 route algorithm N`; the routes are
+    /// also installed into the kernel FIB as plain IPv6 routes.
+    pub rib6_flex_algo: Levels<BTreeMap<u8, PrefixMap<Ipv6Net, SpfRoute<V6>>>>,
+
     /// SR-update return channel from the RIB. Carries the current value of
     /// the watched block / locator and any subsequent updates.
     pub sr_rx: UnboundedReceiver<RibSrRx>,
@@ -342,6 +358,19 @@ pub struct Isis {
     /// Reset whenever the watched locator changes so stale function
     /// reservations don't leak across prefix swaps.
     pub elib: super::srv6::ElibPool,
+
+    /// Per-Flexible-Algorithm SRv6 locator subscriptions. Mirrors the
+    /// single-locator `watched_locator` / `sr_locator` / `sr_end_sid`
+    /// trio but keyed by algorithm (128..=255). Populated from
+    /// `IsisConfig::sr_srv6_flex_algo_locators` via
+    /// `reconcile_locator_watch`; the resolved snapshot and node (End)
+    /// SID arrive on the same `sr_rx` channel as the base locator and
+    /// land here in `process_sr_rx`. Each algorithm advertises its own
+    /// locator (RFC 9352 §7.1, Algorithm field = N) so reaching a node
+    /// "in algo N" is plain longest-prefix IPv6 to its algo-N locator.
+    pub watched_flex_algo_locators: BTreeMap<u8, String>,
+    pub sr_flex_algo_locators: BTreeMap<u8, Locator>,
+    pub sr_flex_algo_end_sid: BTreeMap<u8, std::net::Ipv6Addr>,
 
     /// Per-fragment seq-number-wrap wait. Keyed by fragment id
     /// (LSPID byte 7). Armed when a fragment's next emission would
@@ -531,6 +560,12 @@ pub struct IsisTop<'a> {
     /// rebuild path can populate it from peer Router Capability
     /// SR-Algorithms sub-TLVs.
     pub peer_algos: &'a mut Levels<BTreeMap<IsisSysId, BTreeSet<u8>>>,
+
+    /// Per-peer per-algo SRv6 locators (see `Isis::peer_algo_srv6`).
+    /// Threaded through IsisTop so the LSDB rebuild path can populate it
+    /// from peer SRv6 Locator TLVs and the per-algo IPv6 RIB build can
+    /// read it.
+    pub peer_algo_srv6: &'a mut Levels<BTreeMap<IsisSysId, BTreeMap<u8, super::srv6::Srv6AlgoLoc>>>,
     pub rib: &'a mut Levels<PrefixMap<Ipv4Net, SpfRoute<V4>>>,
     pub rib_v6: &'a mut Levels<PrefixMap<Ipv6Net, SpfRoute<V6>>>,
     pub ilm: &'a mut Levels<BTreeMap<u32, SpfIlm>>,
@@ -566,12 +601,25 @@ pub struct IsisTop<'a> {
     /// after each SPF cycle.
     pub rib_flex_algo: &'a mut Levels<BTreeMap<u8, PrefixMap<Ipv4Net, SpfRoute<V4>>>>,
 
+    /// Per-algorithm IPv6 RIB (see `Isis::rib6_flex_algo`). Threaded so
+    /// `apply_spf_result` can install + snapshot the per-algo SRv6
+    /// locator routes after each SPF cycle.
+    pub rib6_flex_algo: &'a mut Levels<BTreeMap<u8, PrefixMap<Ipv6Net, SpfRoute<V6>>>>,
+
     /// Read-only access to the SR snapshot the IS-IS instance is caching
     /// from RIB::SrSubscribe. lsp_generate uses these to populate the SR
     /// Capability / SRv6 sub-TLVs.
     pub sr_block: &'a Option<Block>,
     pub sr_locator: &'a Option<Locator>,
     pub sr_end_sid: &'a Option<std::net::Ipv6Addr>,
+
+    /// Per-Flex-Algorithm SRv6 locator snapshots + node (End) SIDs
+    /// (see `Isis::sr_flex_algo_locators` / `sr_flex_algo_end_sid`).
+    /// `lsp_generate` emits one SRv6 Locator TLV sub-locator per
+    /// resolved entry with Algorithm=N; the per-algo IPv6 RIB build
+    /// exports the local End SID for colour steering.
+    pub sr_flex_algo_locators: &'a BTreeMap<u8, Locator>,
+    pub sr_flex_algo_end_sid: &'a BTreeMap<u8, std::net::Ipv6Addr>,
 
     /// Read-only access to the cached SRLG table (see
     /// `Isis::srlg_groups`). lsp_generate resolves per-link SRLG group
@@ -681,6 +729,8 @@ impl Isis {
                     BTreeMap<IsisSysId, BTreeMap<(u8, Ipv4Net), isis_packet::SidLabelValue>>,
                 >::default(),
                 peer_algos: Levels::<BTreeMap<IsisSysId, BTreeSet<u8>>>::default(),
+                peer_algo_srv6:
+                    Levels::<BTreeMap<IsisSysId, BTreeMap<u8, super::srv6::Srv6AlgoLoc>>>::default(),
                 rib: Levels::<PrefixMap<Ipv4Net, SpfRoute<V4>>>::default(),
                 rib_v6: Levels::<PrefixMap<Ipv6Net, SpfRoute<V6>>>::default(),
                 ilm: Levels::<BTreeMap<u32, SpfIlm>>::default(),
@@ -711,9 +761,13 @@ impl Isis {
                 spf_flex_algo: Levels::<BTreeMap<u8, Option<BTreeMap<usize, spf::Path>>>>::default(
                 ),
                 rib_flex_algo: Levels::<BTreeMap<u8, PrefixMap<Ipv4Net, SpfRoute<V4>>>>::default(),
+                rib6_flex_algo: Levels::<BTreeMap<u8, PrefixMap<Ipv6Net, SpfRoute<V6>>>>::default(),
                 sr_rx,
                 watched_block: None,
                 watched_locator: None,
+                watched_flex_algo_locators: BTreeMap::new(),
+                sr_flex_algo_locators: BTreeMap::new(),
+                sr_flex_algo_end_sid: BTreeMap::new(),
                 sr_block: None,
                 sr_locator: None,
                 sr_end_sid: None,
@@ -2762,6 +2816,7 @@ impl Isis {
             peer_link_affinity: &mut self.peer_link_affinity,
             peer_algo_sid: &mut self.peer_algo_sid,
             peer_algos: &mut self.peer_algos,
+            peer_algo_srv6: &mut self.peer_algo_srv6,
             rib: &mut self.rib,
             rib_v6: &mut self.rib_v6,
             ilm: &mut self.ilm,
@@ -2782,9 +2837,12 @@ impl Isis {
             graph_flex_algo: &mut self.graph_flex_algo,
             spf_flex_algo: &mut self.spf_flex_algo,
             rib_flex_algo: &mut self.rib_flex_algo,
+            rib6_flex_algo: &mut self.rib6_flex_algo,
             sr_block: &self.sr_block,
             sr_locator: &self.sr_locator,
             sr_end_sid: &self.sr_end_sid,
+            sr_flex_algo_locators: &self.sr_flex_algo_locators,
+            sr_flex_algo_end_sid: &self.sr_flex_algo_end_sid,
             srlg_groups: &self.srlg_groups,
             flex_algo: &self.flex_algo,
             affinity_map: &self.affinity_map,
@@ -2821,6 +2879,7 @@ impl Isis {
             peer_link_affinity: &mut self.peer_link_affinity,
             peer_algo_sid: &mut self.peer_algo_sid,
             peer_algos: &mut self.peer_algos,
+            peer_algo_srv6: &mut self.peer_algo_srv6,
             spf_timer: &mut self.spf_timer,
             spf_throttle: &mut self.spf_throttle,
             rib_client: &self.ctx.rib,
@@ -2900,30 +2959,107 @@ impl Isis {
         }
     }
 
-    /// Mirror of `reconcile_block_watch` for the SRv6 locator name.
+    /// Mirror of `reconcile_block_watch` for the SRv6 locator name(s).
+    ///
+    /// Reconciles BOTH the base (algorithm 0) locator and every
+    /// per-Flex-Algorithm locator binding
+    /// (`IsisConfig::sr_srv6_flex_algo_locators`, gated on SRv6 being
+    /// enabled). Watch / Unwatch is computed against the *union* of all
+    /// subscribed names so a name shared by the base and a flex-algo (or
+    /// by two flex-algos) is never double-unwatched while another algo
+    /// still needs it.
     pub fn reconcile_locator_watch(&mut self) {
-        let desired = target_locator_name(&self.config);
-        if desired == self.watched_locator {
-            return;
-        }
-        if let Some(prev) = self.watched_locator.take() {
+        let desired_base = target_locator_name(&self.config);
+        let desired_flex: BTreeMap<u8, String> = if self.config.sr_srv6_enabled {
+            self.config.sr_srv6_flex_algo_locators.clone()
+        } else {
+            BTreeMap::new()
+        };
+
+        // Union of names we currently watch vs. the union we want.
+        let mut current_names: BTreeSet<String> = BTreeSet::new();
+        current_names.extend(self.watched_locator.clone());
+        current_names.extend(self.watched_flex_algo_locators.values().cloned());
+        let mut desired_names: BTreeSet<String> = BTreeSet::new();
+        desired_names.extend(desired_base.clone());
+        desired_names.extend(desired_flex.values().cloned());
+
+        for name in current_names.difference(&desired_names) {
             let _ = self.ctx.rib.send(rib::Message::SrLocatorUnwatch {
                 proto: "isis".into(),
-                name: prev,
+                name: name.clone(),
             });
-            self.sr_locator = None;
-            // Locator gone -> Node SID has nothing to attach to. Drop
-            // the registration before we leave the helper so the show
-            // table doesn't keep advertising a SID with no locator.
-            self.update_end_sid();
-            self.clear_all_endx_sids();
         }
-        if let Some(next) = desired {
+        for name in desired_names.difference(&current_names) {
             let _ = self.ctx.rib.send(rib::Message::SrLocatorWatch {
                 proto: "isis".into(),
-                name: next.clone(),
+                name: name.clone(),
             });
-            self.watched_locator = Some(next);
+        }
+
+        // Base (algo-0) snapshot / Node SID / End.X reconcile, unchanged
+        // in spirit from the single-locator version.
+        if desired_base != self.watched_locator {
+            if self.watched_locator.is_some() {
+                self.sr_locator = None;
+                self.update_end_sid();
+                self.clear_all_endx_sids();
+            }
+            self.watched_locator = desired_base;
+        }
+
+        // Per-algo: drop snapshots + Node SIDs for algos that were
+        // removed or repointed at a different locator name. The fresh
+        // snapshot for any (re)added name arrives on `sr_rx` and is
+        // applied in `process_sr_rx`.
+        let stale: Vec<u8> = self
+            .watched_flex_algo_locators
+            .iter()
+            .filter(|(algo, name)| desired_flex.get(algo) != Some(name))
+            .map(|(algo, _)| *algo)
+            .collect();
+        for algo in stale {
+            self.sr_flex_algo_locators.remove(&algo);
+            self.update_flex_algo_end_sid(algo);
+            self.watched_flex_algo_locators.remove(&algo);
+        }
+        for (algo, name) in desired_flex {
+            self.watched_flex_algo_locators.insert(algo, name);
+        }
+    }
+
+    /// Per-algo twin of `update_end_sid`: reconcile the algorithm-N
+    /// node (End / uN) SID registration against the current per-algo
+    /// locator snapshot. Distinct per-algo locator prefixes mean each
+    /// SID has a distinct address, so the RIB registry (keyed by addr)
+    /// never collides across algorithms.
+    fn update_flex_algo_end_sid(&mut self, algo: u8) {
+        if let Some(prev) = self.sr_flex_algo_end_sid.remove(&algo) {
+            let _ = self.ctx.rib.send(rib::Message::SidDel { addr: prev });
+        }
+        if let Some(locator) = self.sr_flex_algo_locators.get(&algo)
+            && let Some(addr) = locator.node_sid_addr()
+            && let Some(loc_name) = self.watched_flex_algo_locators.get(&algo).cloned()
+        {
+            let (behavior, structure) = match locator.behavior {
+                Some(LocatorBehavior::Usid) => (SidBehavior::UN, locator.sid_structure()),
+                None => (SidBehavior::End, None),
+            };
+            let sid = Sid {
+                addr,
+                behavior,
+                context: SidContext::None,
+                owner: SidOwner::new("isis", 0),
+                locator: loc_name,
+                allocation_type: SidAllocationType::Dynamic,
+                ifindex: 0,
+                nh6: None,
+                structure,
+                table_id: 0,
+                segs: Vec::new(),
+            };
+            let _ = self.ctx.rib.send(rib::Message::SidAdd { sid });
+            self.sr_flex_algo_end_sid.insert(algo, addr);
         }
     }
 
@@ -3026,19 +3162,44 @@ impl Isis {
                 self.reconcile_local_pool();
             }
             RibSrRx::Locator { name, locator } => {
-                if self.watched_locator.as_deref() != Some(name.as_str()) {
+                // A single locator name may back the base (algo-0)
+                // subscription and/or one or more flex-algo bindings.
+                // Apply the snapshot to every subscriber of this name.
+                let mut touched = false;
+                if self.watched_locator.as_deref() == Some(name.as_str()) {
+                    self.sr_locator = locator.clone();
+                    // Locator snapshot churned — every End.X address
+                    // computed against the previous prefix is now stale.
+                    // Drop them all and let the next Hellos re-allocate
+                    // from a fresh ELIB pool.
+                    self.clear_all_endx_sids();
+                    // Allocate / withdraw the Node SID against the new
+                    // snapshot before flooding so the LSP carries the
+                    // correct value on the very first emission.
+                    self.update_end_sid();
+                    touched = true;
+                }
+                let algos: Vec<u8> = self
+                    .watched_flex_algo_locators
+                    .iter()
+                    .filter(|(_, n)| n.as_str() == name.as_str())
+                    .map(|(algo, _)| *algo)
+                    .collect();
+                for algo in algos {
+                    match &locator {
+                        Some(l) => {
+                            self.sr_flex_algo_locators.insert(algo, l.clone());
+                        }
+                        None => {
+                            self.sr_flex_algo_locators.remove(&algo);
+                        }
+                    }
+                    self.update_flex_algo_end_sid(algo);
+                    touched = true;
+                }
+                if !touched {
                     return;
                 }
-                self.sr_locator = locator;
-                // Locator snapshot churned — every End.X address
-                // computed against the previous prefix is now stale.
-                // Drop them all and let the next Hellos re-allocate
-                // from a fresh ELIB pool.
-                self.clear_all_endx_sids();
-                // Allocate / withdraw the Node SID against the new
-                // snapshot before flooding so the LSP carries the
-                // correct value on the very first emission.
-                self.update_end_sid();
             }
         }
         // Re-originate both levels so the new SR snapshot is reflected in

--- a/zebra-rs/src/isis/link.rs
+++ b/zebra-rs/src/isis/link.rs
@@ -163,6 +163,12 @@ pub struct LinkTop<'a> {
     >,
     pub peer_algos:
         &'a mut Levels<std::collections::BTreeMap<IsisSysId, std::collections::BTreeSet<u8>>>,
+    pub peer_algo_srv6: &'a mut Levels<
+        std::collections::BTreeMap<
+            IsisSysId,
+            std::collections::BTreeMap<u8, super::srv6::Srv6AlgoLoc>,
+        >,
+    >,
     pub spf_timer: &'a mut Levels<Option<Timer>>,
     pub spf_throttle: &'a mut Levels<super::throttle::Throttle>,
 

--- a/zebra-rs/src/isis/lsdb.rs
+++ b/zebra-rs/src/isis/lsdb.rs
@@ -209,6 +209,12 @@ pub(super) struct SysStateRefs<'a> {
     /// this instead of re-walking the LSDB; missing entry means the
     /// peer is not a candidate for any non-default algo.
     pub peer_algos: &'a mut BTreeMap<IsisSysId, BTreeSet<u8>>,
+
+    /// Per-peer per-Flexible-Algorithm SRv6 locators keyed by algo
+    /// (128..=255). Populated from SRv6 Locator TLV 27 sub-locators
+    /// whose Algorithm field is a Flex-Algo id (RFC 9352 §7.1). Union
+    /// across fragments.
+    pub peer_algo_srv6: &'a mut BTreeMap<IsisSysId, BTreeMap<u8, super::srv6::Srv6AlgoLoc>>,
 }
 
 /// Recompute the per-sys-id consumer maps from the union of every
@@ -269,6 +275,7 @@ pub(super) fn rebuild_sys_state(
         s.peer_link_affinity.remove(sys_id);
         s.peer_algo_sid.remove(sys_id);
         s.peer_algos.remove(sys_id);
+        s.peer_algo_srv6.remove(sys_id);
         return;
     }
 
@@ -436,6 +443,7 @@ pub(super) fn rebuild_sys_state(
     let mut v6_entries: Vec<IsisTlvIpv6ReachEntry> = Vec::new();
     let mut mt2_v6_entries: Vec<IsisTlvIpv6ReachEntry> = Vec::new();
     let mut end_sid: Option<super::srv6::Srv6EndSidInfo> = None;
+    let mut algo_srv6: BTreeMap<u8, super::srv6::Srv6AlgoLoc> = BTreeMap::new();
 
     for f in &frags {
         for tlv in &f.tlvs {
@@ -445,27 +453,51 @@ pub(super) fn rebuild_sys_state(
                 IsisTlv::MtIpv6Reach(t) if t.mt.id() == 2 => {
                     mt2_v6_entries.extend(t.entries.iter().cloned());
                 }
-                IsisTlv::Srv6(t) if end_sid.is_none() => {
-                    'outer: for locator in &t.locators {
-                        for sub in &locator.subs {
-                            if let prefix::IsisSubTlv::Srv6EndSid(es) = sub {
-                                // Keep behavior + SID structure alongside the
-                                // address: the TI-LFA encoder needs them to
-                                // decide NEXT-C-SID carrier membership.
-                                let structure = es.sub2s.iter().find_map(|s2| {
-                                    if let isis_packet::IsisSub2Tlv::SidStructure(st) = s2 {
-                                        Some(st.clone())
-                                    } else {
-                                        None
-                                    }
-                                });
-                                end_sid = Some(super::srv6::Srv6EndSidInfo {
-                                    sid: es.sid,
-                                    behavior: es.behavior,
-                                    structure,
-                                });
-                                break 'outer;
+                IsisTlv::Srv6(t) => {
+                    for locator in &t.locators {
+                        // First End SID sub-TLV under this sub-locator,
+                        // keeping behavior + SID structure (the TI-LFA /
+                        // NEXT-C-SID encoder needs them to decide carrier
+                        // membership).
+                        let Some(end) = locator.subs.iter().find_map(|sub| {
+                            let prefix::IsisSubTlv::Srv6EndSid(es) = sub else {
+                                return None;
+                            };
+                            let structure = es.sub2s.iter().find_map(|s2| {
+                                if let isis_packet::IsisSub2Tlv::SidStructure(st) = s2 {
+                                    Some(st.clone())
+                                } else {
+                                    None
+                                }
+                            });
+                            Some(super::srv6::Srv6EndSidInfo {
+                                sid: es.sid,
+                                behavior: es.behavior,
+                                structure,
+                            })
+                        }) else {
+                            continue;
+                        };
+                        match locator.algo {
+                            // Base (algo-0) Node SID — first wins, matching
+                            // the historical single-locator behavior.
+                            Algo::Spf => {
+                                if end_sid.is_none() {
+                                    end_sid = Some(end);
+                                }
                             }
+                            // Per-Flexible-Algorithm locator (RFC 9352
+                            // §7.1, Algorithm = N). Last fragment wins.
+                            Algo::FlexAlgo(n) => {
+                                algo_srv6.insert(
+                                    n,
+                                    super::srv6::Srv6AlgoLoc {
+                                        locator: locator.locator,
+                                        end,
+                                    },
+                                );
+                            }
+                            _ => {}
                         }
                     }
                 }
@@ -493,6 +525,11 @@ pub(super) fn rebuild_sys_state(
         s.srv6_end_map.insert(*sys_id, sid);
     } else {
         s.srv6_end_map.remove(sys_id);
+    }
+    if algo_srv6.is_empty() {
+        s.peer_algo_srv6.remove(sys_id);
+    } else {
+        s.peer_algo_srv6.insert(*sys_id, algo_srv6);
     }
 }
 
@@ -582,6 +619,7 @@ pub fn insert_lsp(top: &mut LinkTop, level: Level, lsp: IsisLsp, bytes: Vec<u8>)
                 peer_link_affinity: top.peer_link_affinity.get_mut(&level),
                 peer_algo_sid: top.peer_algo_sid.get_mut(&level),
                 peer_algos: top.peer_algos.get_mut(&level),
+                peer_algo_srv6: top.peer_algo_srv6.get_mut(&level),
             },
         );
     }
@@ -678,6 +716,7 @@ pub fn remove_lsp(top: &mut IsisTop, level: Level, key: IsisLspId) {
             peer_link_affinity: top.peer_link_affinity.get_mut(&level),
             peer_algo_sid: top.peer_algo_sid.get_mut(&level),
             peer_algos: top.peer_algos.get_mut(&level),
+            peer_algo_srv6: top.peer_algo_srv6.get_mut(&level),
         },
     );
 }
@@ -824,6 +863,8 @@ mod tests {
         let mut peer_algo_sid: BTreeMap<IsisSysId, BTreeMap<(u8, Ipv4Net), SidLabelValue>> =
             BTreeMap::new();
         let mut peer_algos: BTreeMap<IsisSysId, BTreeSet<u8>> = BTreeMap::new();
+        let mut peer_algo_srv6: BTreeMap<IsisSysId, BTreeMap<u8, crate::isis::srv6::Srv6AlgoLoc>> =
+            BTreeMap::new();
 
         rebuild_sys_state(
             &lsdb,
@@ -841,6 +882,7 @@ mod tests {
                 peer_link_affinity: &mut peer_link_affinity,
                 peer_algo_sid: &mut peer_algo_sid,
                 peer_algos: &mut peer_algos,
+                peer_algo_srv6: &mut peer_algo_srv6,
             },
         );
 
@@ -872,6 +914,7 @@ mod tests {
                 peer_link_affinity: &mut peer_link_affinity,
                 peer_algo_sid: &mut peer_algo_sid,
                 peer_algos: &mut peer_algos,
+                peer_algo_srv6: &mut peer_algo_srv6,
             },
         );
         assert!(
@@ -900,6 +943,7 @@ mod tests {
                 peer_link_affinity: &mut peer_link_affinity,
                 peer_algo_sid: &mut peer_algo_sid,
                 peer_algos: &mut peer_algos,
+                peer_algo_srv6: &mut peer_algo_srv6,
             },
         );
         assert!(reach_v4.get(&peer).is_none());
@@ -939,6 +983,8 @@ mod tests {
         let mut peer_algo_sid: BTreeMap<IsisSysId, BTreeMap<(u8, Ipv4Net), SidLabelValue>> =
             BTreeMap::new();
         let mut peer_algos: BTreeMap<IsisSysId, BTreeSet<u8>> = BTreeMap::new();
+        let mut peer_algo_srv6: BTreeMap<IsisSysId, BTreeMap<u8, crate::isis::srv6::Srv6AlgoLoc>> =
+            BTreeMap::new();
 
         rebuild_sys_state(
             &lsdb,
@@ -956,6 +1002,7 @@ mod tests {
                 peer_link_affinity: &mut peer_link_affinity,
                 peer_algo_sid: &mut peer_algo_sid,
                 peer_algos: &mut peer_algos,
+                peer_algo_srv6: &mut peer_algo_srv6,
             },
         );
 
@@ -1014,6 +1061,8 @@ mod tests {
         let mut peer_algo_sid: BTreeMap<IsisSysId, BTreeMap<(u8, Ipv4Net), SidLabelValue>> =
             BTreeMap::new();
         let mut peer_algos: BTreeMap<IsisSysId, BTreeSet<u8>> = BTreeMap::new();
+        let mut peer_algo_srv6: BTreeMap<IsisSysId, BTreeMap<u8, crate::isis::srv6::Srv6AlgoLoc>> =
+            BTreeMap::new();
 
         rebuild_sys_state(
             &lsdb,
@@ -1031,6 +1080,7 @@ mod tests {
                 peer_link_affinity: &mut peer_link_affinity,
                 peer_algo_sid: &mut peer_algo_sid,
                 peer_algos: &mut peer_algos,
+                peer_algo_srv6: &mut peer_algo_srv6,
             },
         );
 
@@ -1059,6 +1109,7 @@ mod tests {
                 peer_link_affinity: &mut peer_link_affinity,
                 peer_algo_sid: &mut peer_algo_sid,
                 peer_algos: &mut peer_algos,
+                peer_algo_srv6: &mut peer_algo_srv6,
             },
         );
         assert!(
@@ -1132,6 +1183,8 @@ mod tests {
         let mut peer_algo_sid: BTreeMap<IsisSysId, BTreeMap<(u8, Ipv4Net), SidLabelValue>> =
             BTreeMap::new();
         let mut peer_algos: BTreeMap<IsisSysId, BTreeSet<u8>> = BTreeMap::new();
+        let mut peer_algo_srv6: BTreeMap<IsisSysId, BTreeMap<u8, crate::isis::srv6::Srv6AlgoLoc>> =
+            BTreeMap::new();
 
         rebuild_sys_state(
             &lsdb,
@@ -1149,6 +1202,7 @@ mod tests {
                 peer_link_affinity: &mut peer_link_affinity,
                 peer_algo_sid: &mut peer_algo_sid,
                 peer_algos: &mut peer_algos,
+                peer_algo_srv6: &mut peer_algo_srv6,
             },
         );
 
@@ -1178,6 +1232,7 @@ mod tests {
                 peer_link_affinity: &mut peer_link_affinity,
                 peer_algo_sid: &mut peer_algo_sid,
                 peer_algos: &mut peer_algos,
+                peer_algo_srv6: &mut peer_algo_srv6,
             },
         );
         assert!(!peer_link_affinity.contains_key(&peer));
@@ -1232,6 +1287,8 @@ mod tests {
         let mut peer_algo_sid: BTreeMap<IsisSysId, BTreeMap<(u8, Ipv4Net), SidLabelValue>> =
             BTreeMap::new();
         let mut peer_algos: BTreeMap<IsisSysId, BTreeSet<u8>> = BTreeMap::new();
+        let mut peer_algo_srv6: BTreeMap<IsisSysId, BTreeMap<u8, crate::isis::srv6::Srv6AlgoLoc>> =
+            BTreeMap::new();
 
         rebuild_sys_state(
             &lsdb,
@@ -1249,6 +1306,7 @@ mod tests {
                 peer_link_affinity: &mut peer_link_affinity,
                 peer_algo_sid: &mut peer_algo_sid,
                 peer_algos: &mut peer_algos,
+                peer_algo_srv6: &mut peer_algo_srv6,
             },
         );
 
@@ -1279,9 +1337,130 @@ mod tests {
                 peer_link_affinity: &mut peer_link_affinity,
                 peer_algo_sid: &mut peer_algo_sid,
                 peer_algos: &mut peer_algos,
+                peer_algo_srv6: &mut peer_algo_srv6,
             },
         );
         assert!(!peer_algo_sid.contains_key(&peer));
+    }
+
+    /// A peer LSP carrying an SRv6 Locator TLV (RFC 9352 §7.1) with one
+    /// algo-0 sub-locator and one Flex-Algo (128) sub-locator must route
+    /// the algo-0 End SID into `srv6_end_map` and the per-algo locator +
+    /// End SID into `peer_algo_srv6[peer][128]`. Dropping the fragment
+    /// must clear both.
+    #[test]
+    fn rebuild_populates_and_clears_peer_algo_srv6() {
+        use isis_packet::prefix::IsisSubTlv as PrefixSubTlv;
+        use isis_packet::{Behavior, IsisSubSrv6EndSid, IsisTlvSrv6, Srv6Locator};
+        use std::net::Ipv6Addr;
+
+        let mut lsdb = Lsdb::default();
+        let peer = sys(12);
+
+        let base_loc: ipnet::Ipv6Net = "2001:db8:0::/48".parse().unwrap();
+        let algo_loc: ipnet::Ipv6Net = "2001:db8:128::/48".parse().unwrap();
+        let base_sid: Ipv6Addr = "2001:db8:0::".parse().unwrap();
+        let algo_end: Ipv6Addr = "2001:db8:128::".parse().unwrap();
+
+        let end_sub = |sid| {
+            PrefixSubTlv::Srv6EndSid(IsisSubSrv6EndSid {
+                flags: 0,
+                behavior: Behavior::End,
+                sid,
+                sub2s: vec![],
+            })
+        };
+        let srv6 = IsisTlvSrv6 {
+            flags: Default::default(),
+            locators: vec![
+                Srv6Locator {
+                    metric: 0,
+                    flags: 0,
+                    algo: Algo::Spf,
+                    locator: base_loc,
+                    subs: vec![end_sub(base_sid)],
+                },
+                Srv6Locator {
+                    metric: 0,
+                    flags: 0,
+                    algo: Algo::FlexAlgo(128),
+                    locator: algo_loc,
+                    subs: vec![end_sub(algo_end)],
+                },
+            ],
+        };
+        let mut f0 = frag(peer, 0);
+        f0.tlvs.push(IsisTlv::Srv6(srv6));
+        lsdb.map.insert(f0.lsp_id, Lsa::new(f0));
+
+        let mut hostname = Hostname::default();
+        let mut label_map = IsisLabelMap::default();
+        let mut reach_v4 = ReachMapV4::default();
+        let mut reach_v6 = ReachMapV6::default();
+        let mut mt_membership: BTreeMap<IsisSysId, BTreeSet<MtId>> = BTreeMap::new();
+        let mut mt2_reach_v6 = ReachMapV6::default();
+        let mut srv6_end_map: BTreeMap<IsisSysId, crate::isis::srv6::Srv6EndSidInfo> =
+            BTreeMap::new();
+        let mut peer_fad: BTreeMap<IsisSysId, BTreeMap<u8, IsisSubFlexAlgoDef>> = BTreeMap::new();
+        let mut peer_link_affinity: BTreeMap<IsisSysId, BTreeMap<IsisNeighborId, ExtAdminGroup>> =
+            BTreeMap::new();
+        let mut peer_algo_sid: BTreeMap<IsisSysId, BTreeMap<(u8, Ipv4Net), SidLabelValue>> =
+            BTreeMap::new();
+        let mut peer_algos: BTreeMap<IsisSysId, BTreeSet<u8>> = BTreeMap::new();
+        let mut peer_algo_srv6: BTreeMap<IsisSysId, BTreeMap<u8, crate::isis::srv6::Srv6AlgoLoc>> =
+            BTreeMap::new();
+
+        rebuild_sys_state(
+            &lsdb,
+            &sys(0xFF),
+            &peer,
+            SysStateRefs {
+                hostname: &mut hostname,
+                label_map: &mut label_map,
+                reach_v4: &mut reach_v4,
+                reach_v6: &mut reach_v6,
+                mt_membership: &mut mt_membership,
+                mt2_reach_v6: &mut mt2_reach_v6,
+                srv6_end_map: &mut srv6_end_map,
+                peer_fad: &mut peer_fad,
+                peer_link_affinity: &mut peer_link_affinity,
+                peer_algo_sid: &mut peer_algo_sid,
+                peer_algos: &mut peer_algos,
+                peer_algo_srv6: &mut peer_algo_srv6,
+            },
+        );
+
+        assert_eq!(srv6_end_map.get(&peer).map(|e| e.sid), Some(base_sid));
+        let locs = peer_algo_srv6
+            .get(&peer)
+            .expect("peer_algo_srv6 must populate");
+        assert_eq!(locs.len(), 1, "only the flex-algo locator is cached");
+        let l = locs.get(&128).expect("algo 128 locator");
+        assert_eq!(l.locator, algo_loc);
+        assert_eq!(l.end.sid, algo_end);
+
+        lsdb.map.remove(&IsisLspId::new(peer, 0, 0));
+        rebuild_sys_state(
+            &lsdb,
+            &sys(0xFF),
+            &peer,
+            SysStateRefs {
+                hostname: &mut hostname,
+                label_map: &mut label_map,
+                reach_v4: &mut reach_v4,
+                reach_v6: &mut reach_v6,
+                mt_membership: &mut mt_membership,
+                mt2_reach_v6: &mut mt2_reach_v6,
+                srv6_end_map: &mut srv6_end_map,
+                peer_fad: &mut peer_fad,
+                peer_link_affinity: &mut peer_link_affinity,
+                peer_algo_sid: &mut peer_algo_sid,
+                peer_algos: &mut peer_algos,
+                peer_algo_srv6: &mut peer_algo_srv6,
+            },
+        );
+        assert!(!peer_algo_srv6.contains_key(&peer));
+        assert!(!srv6_end_map.contains_key(&peer));
     }
 
     /// A peer LSP fragment 0 carrying a Router Capability TLV with an
@@ -1321,6 +1500,8 @@ mod tests {
         let mut peer_algo_sid: BTreeMap<IsisSysId, BTreeMap<(u8, Ipv4Net), SidLabelValue>> =
             BTreeMap::new();
         let mut peer_algos: BTreeMap<IsisSysId, BTreeSet<u8>> = BTreeMap::new();
+        let mut peer_algo_srv6: BTreeMap<IsisSysId, BTreeMap<u8, crate::isis::srv6::Srv6AlgoLoc>> =
+            BTreeMap::new();
 
         rebuild_sys_state(
             &lsdb,
@@ -1338,6 +1519,7 @@ mod tests {
                 peer_link_affinity: &mut peer_link_affinity,
                 peer_algo_sid: &mut peer_algo_sid,
                 peer_algos: &mut peer_algos,
+                peer_algo_srv6: &mut peer_algo_srv6,
             },
         );
 
@@ -1369,6 +1551,7 @@ mod tests {
                 peer_link_affinity: &mut peer_link_affinity,
                 peer_algo_sid: &mut peer_algo_sid,
                 peer_algos: &mut peer_algos,
+                peer_algo_srv6: &mut peer_algo_srv6,
             },
         );
         assert!(!peer_algos.contains_key(&peer));

--- a/zebra-rs/src/isis/lsp.rs
+++ b/zebra-rs/src/isis/lsp.rs
@@ -13,7 +13,7 @@ use crate::isis::config::{
 };
 use crate::isis_event_trace;
 use crate::rib::util::IpNetExt;
-use crate::rib::{DEFAULT_BLOCK_NAME, LocatorBehavior, MacAddr};
+use crate::rib::{DEFAULT_BLOCK_NAME, Locator, LocatorBehavior, MacAddr};
 
 /// Per ISO 10589 §7.3.16.4, the additional grace beyond MaxAge a
 /// purged LSP needs before any surviving copy is fully evicted from
@@ -460,6 +460,41 @@ pub fn dis_generate(
     fragments
 }
 
+/// SRv6 End-SID endpoint behavior + SID Structure sub-sub-TLV
+/// (RFC 9352 §9) for one locator, keyed off the locator's behavior.
+/// Classic locators advertise the `End` codepoint (LB caps at 40);
+/// uSID locators advertise `EndCSID` / uN (LB caps at 32). Mirrors the
+/// per-LSP computation done for the base locator, but as a reusable
+/// helper so each per-Flex-Algorithm locator gets its own structure.
+fn srv6_end_structure(locator: &Locator) -> (Behavior, Vec<IsisSub2Tlv>) {
+    let Some(prefix) = locator.prefix else {
+        return (Behavior::End, Vec::new());
+    };
+    let plen = prefix.prefix_len();
+    match &locator.behavior {
+        Some(LocatorBehavior::Usid) => {
+            let lb_len = plen.min(32);
+            let structure = IsisSub2Tlv::SidStructure(IsisSub2SidStructure {
+                lb_len,
+                ln_len: plen.saturating_sub(lb_len),
+                fun_len: 16,
+                arg_len: 0,
+            });
+            (Behavior::EndCSID, vec![structure])
+        }
+        None => {
+            let lb_len = plen.min(40);
+            let structure = IsisSub2Tlv::SidStructure(IsisSub2SidStructure {
+                lb_len,
+                ln_len: plen.saturating_sub(lb_len),
+                fun_len: 16,
+                arg_len: 0,
+            });
+            (Behavior::End, vec![structure])
+        }
+    }
+}
+
 pub fn lsp_generate(top: &mut IsisTop, level: Level, seq_floor: Option<u32>) -> Vec<IsisLsp> {
     // Fragment 0 is the anchor for the originator's per-node attributes
     // (hostname, area, capability, OL/ATT) and the only LSP whose seq is
@@ -656,11 +691,16 @@ pub fn lsp_generate(top: &mut IsisTop, level: Level, seq_floor: Option<u32>) -> 
             }
         }
 
-        // SRv6 Capability sub-TLV. Only advertise when the configured
-        // locator actually resolved in the RIB; an `srv6` container with
-        // no usable locator means we have nothing to derive a SID from,
-        // so we don't claim SRv6 capability.
-        if top.config.sr_srv6_enabled && top.sr_locator.is_some() {
+        // SRv6 Capability sub-TLV. Only advertise when at least one
+        // locator (the algo-0 base or any per-Flex-Algorithm locator)
+        // actually resolved in the RIB; an `srv6` container with no
+        // usable locator means we have nothing to derive a SID from, so
+        // we don't claim SRv6 capability. Including the per-algo
+        // locators here lets an SRv6-only Flex-Algo config advertise its
+        // SR-Algorithm participation even without a base locator.
+        if top.config.sr_srv6_enabled
+            && (top.sr_locator.is_some() || !top.sr_flex_algo_locators.is_empty())
+        {
             let srv6 = IsisSubSrv6::default();
             cap.subs.push(srv6.into());
 
@@ -733,34 +773,57 @@ pub fn lsp_generate(top: &mut IsisTop, level: Level, seq_floor: Option<u32>) -> 
         None => (Behavior::End, Behavior::EndX, Vec::new()),
     };
 
-    // SRv6 Locators TLV (RFC 9352 §7.1, type 27). One sub-locator per
-    // active locator; today we only carry one. The contained End SID
-    // sub-TLV (RFC 9352 §7.2) advertises the Node SID we registered
-    // with the RIB. Both `sr_locator` and `sr_end_sid` must be set —
-    // sr_end_sid is only populated when the locator's prefix produced
-    // a usable address.
+    // SRv6 Locators TLV (RFC 9352 §7.1, type 27). One sub-locator for
+    // the base (algo-0) locator plus one per Flexible-Algorithm locator
+    // binding, each carrying its node End SID (RFC 9352 §7.2). Per-algo
+    // locators are advertised ONLY here (Algorithm field = N) — never as
+    // plain IPv6 Reachability TLVs — so receivers route each one in its
+    // own algorithm's constrained topology rather than over the
+    // unconstrained algo-0 SPF.
+    let mut srv6_locators: Vec<Srv6Locator> = Vec::new();
     if let Some(locator) = top.sr_locator.as_ref()
         && let Some(end_sid) = *top.sr_end_sid
         && let Some(prefix) = locator.prefix
     {
-        let end_sub = IsisSubSrv6EndSid {
-            flags: 0,
-            behavior: end_behavior,
-            sid: end_sid,
-            sub2s: sid_structure_subs.clone(),
-        };
-        let sub_locator = Srv6Locator {
+        srv6_locators.push(Srv6Locator {
             metric: 0,
             flags: 0,
             algo: Algo::Spf,
             locator: prefix,
-            subs: vec![prefix::IsisSubTlv::Srv6EndSid(end_sub)],
+            subs: vec![prefix::IsisSubTlv::Srv6EndSid(IsisSubSrv6EndSid {
+                flags: 0,
+                behavior: end_behavior,
+                sid: end_sid,
+                sub2s: sid_structure_subs.clone(),
+            })],
+        });
+    }
+    for (&algo, locator) in top.sr_flex_algo_locators.iter() {
+        let Some(end_sid) = top.sr_flex_algo_end_sid.get(&algo).copied() else {
+            continue;
         };
-        let srv6_tlv = IsisTlvSrv6 {
+        let Some(prefix) = locator.prefix else {
+            continue;
+        };
+        let (behavior, sub2s) = srv6_end_structure(locator);
+        srv6_locators.push(Srv6Locator {
+            metric: 0,
+            flags: 0,
+            algo: Algo::FlexAlgo(algo),
+            locator: prefix,
+            subs: vec![prefix::IsisSubTlv::Srv6EndSid(IsisSubSrv6EndSid {
+                flags: 0,
+                behavior,
+                sid: end_sid,
+                sub2s,
+            })],
+        });
+    }
+    if !srv6_locators.is_empty() {
+        distributable.push(IsisTlv::Srv6(IsisTlvSrv6 {
             flags: Default::default(),
-            locators: vec![sub_locator],
-        };
-        distributable.push(IsisTlv::Srv6(srv6_tlv));
+            locators: srv6_locators,
+        }));
     }
 
     // Multi-Topology TLV (229) — RFC 5120 §7.1. Lists the MT IDs

--- a/zebra-rs/src/isis/rib.rs
+++ b/zebra-rs/src/isis/rib.rs
@@ -599,6 +599,31 @@ fn make_flex_algo_route(
 /// different / only_next` split the IPv4 and IPv6 diff helpers use,
 /// so the semantics of "route changed under the hood but same
 /// prefix" match what RIB already sees from algo-0.
+/// Diff per-algo IPv6 RIB snapshots (SRv6 dataplane) and install the
+/// per-algo locator routes into the kernel FIB as real IPv6 routes.
+///
+/// Unlike `diff_apply_flex_algo` (SR-MPLS), which feeds the colour-aware
+/// nexthop resolver an outer-label-per-(algo, prefix) shadow, SRv6
+/// per-algo reachability is plain longest-prefix IPv6 to each node's
+/// distinct per-algo locator. So we reuse the ordinary IPv6 install path
+/// (`diff_apply::<V6>` → `Ipv6Add` / `Ipv6Del`) per algorithm; the
+/// per-algo locator prefixes never collide with algo-0 reachability.
+fn diff_apply_flex_algo6(
+    rib_client: &crate::rib::client::RibClient,
+    level: Level,
+    prev: &BTreeMap<u8, PrefixMap<Ipv6Net, SpfRoute<V6>>>,
+    next: &BTreeMap<u8, PrefixMap<Ipv6Net, SpfRoute<V6>>>,
+) {
+    let all_algos: BTreeSet<u8> = prev.keys().chain(next.keys()).copied().collect();
+    let empty: PrefixMap<Ipv6Net, SpfRoute<V6>> = PrefixMap::new();
+    for algo in all_algos {
+        let prev_table = prev.get(&algo).unwrap_or(&empty);
+        let next_table = next.get(&algo).unwrap_or(&empty);
+        let diff = spf::table_diff(prev_table.iter(), next_table.iter());
+        diff_apply::<V6>(rib_client, &diff, level);
+    }
+}
+
 pub fn diff_apply_flex_algo(
     rib_client: &crate::rib::client::RibClient,
     prev: &BTreeMap<u8, PrefixMap<Ipv4Net, SpfRoute<V4>>>,
@@ -1427,6 +1452,7 @@ pub(super) fn apply_spf_result(top: &mut IsisTop, output: SpfOutput) {
     let mut new_flex_algo_graphs: BTreeMap<u8, Option<spf::Graph>> = BTreeMap::new();
     let mut new_flex_algo_spfs: BTreeMap<u8, Option<BTreeMap<usize, spf::Path>>> = BTreeMap::new();
     let mut new_flex_algo_rib: BTreeMap<u8, PrefixMap<Ipv4Net, SpfRoute<V4>>> = BTreeMap::new();
+    let mut new_flex_algo_rib6: BTreeMap<u8, PrefixMap<Ipv6Net, SpfRoute<V6>>> = BTreeMap::new();
     for FlexAlgoOutput {
         algo,
         graph: algo_graph,
@@ -1434,41 +1460,75 @@ pub(super) fn apply_spf_result(top: &mut IsisTop, output: SpfOutput) {
         spf: algo_spf,
     } in flex_algos
     {
-        // Build the per-algo IPv4 RIB iff we have both a source and
-        // an SPF result. Empty PrefixMap for the algo otherwise so
-        // the show command and downstream consumers still see a
-        // well-formed (if empty) snapshot.
-        let algo_rib = match (algo_source, algo_spf.as_ref()) {
-            (Some(src), Some(spf_res)) => {
+        // Per-algo dataplane participation (RFC 9350 §6). Build the
+        // SR-MPLS IPv4 RIB when the algo enables sr-mpls, and the SRv6
+        // IPv6 RIB when it enables srv6. The flag block is scoped so the
+        // immutable `top.flex_algo` borrow ends before the `&mut top`
+        // RIB builders run. Default (no dataplane flag, or only `ip`)
+        // keeps the historical SR-MPLS behavior; an algo that enables
+        // *only* srv6 skips the SR-MPLS build.
+        let (mpls_on, srv6_on) = {
+            let entry = top.flex_algo.config.get(&algo);
+            let srv6_on = entry
+                .map(|e| e.dataplane_srv6 == Some(true))
+                .unwrap_or(false);
+            let mpls_on = entry
+                .map(|e| e.dataplane_sr_mpls == Some(true) || e.dataplane_srv6 != Some(true))
+                .unwrap_or(true);
+            (mpls_on, srv6_on)
+        };
+
+        // The per-algo SPF graph is address-family-independent, so both
+        // dataplanes reuse the same `spf_res`. Empty PrefixMaps when the
+        // algo lacks a source/SPF or doesn't enable that dataplane, so
+        // the show command and the route diff still see a well-formed
+        // (if empty) snapshot.
+        let algo_rib = match (mpls_on, algo_source, algo_spf.as_ref()) {
+            (true, Some(src), Some(spf_res)) => {
                 let r = build_rib_from_flex_algo(top, level, algo, src, spf_res);
                 mpls_route(&r, &mut ilm, srgb);
                 r
             }
             _ => PrefixMap::<Ipv4Net, SpfRoute<V4>>::new(),
         };
+        let algo_rib6 = match (srv6_on, algo_source, algo_spf.as_ref()) {
+            (true, Some(src), Some(spf_res)) => {
+                build_rib6_from_flex_algo(top, level, algo, src, spf_res)
+            }
+            _ => PrefixMap::<Ipv6Net, SpfRoute<V6>>::new(),
+        };
 
         new_flex_algo_graphs.insert(algo, Some(algo_graph));
         new_flex_algo_spfs.insert(algo, algo_spf);
         new_flex_algo_rib.insert(algo, algo_rib);
+        new_flex_algo_rib6.insert(algo, algo_rib6);
     }
-    // Per-algo route diff → RIB publish. The shadow on
-    // `Rib::flex_algo_routes` is the colour-aware nexthop resolver's
-    // source of truth for the outer MPLS label per (algo, prefix).
+    // Per-algo route diff → RIB publish. SR-MPLS feeds the colour-aware
+    // nexthop resolver (shadow on `Rib::flex_algo_routes`, outer MPLS
+    // label per (algo, prefix)); SRv6 installs per-algo locator routes
+    // straight into the kernel FIB as plain IPv6 routes.
     if top.config.distribute.rib {
         diff_apply_flex_algo(
             top.rib_client,
             top.rib_flex_algo.get(&level),
             &new_flex_algo_rib,
         );
+        diff_apply_flex_algo6(
+            top.rib_client,
+            level,
+            top.rib6_flex_algo.get(&level),
+            &new_flex_algo_rib6,
+        );
     }
 
     // Swap the new state in. The retain that used to live above is
     // implicit: any algo present in the old map but absent from the
-    // new one yielded `FlexAlgoRouteDel` messages above; the swap
-    // drops the old entry entirely.
+    // new one yielded route Del messages above; the swap drops the old
+    // entry entirely.
     *top.graph_flex_algo.get_mut(&level) = new_flex_algo_graphs;
     *top.spf_flex_algo.get_mut(&level) = new_flex_algo_spfs;
     *top.rib_flex_algo.get_mut(&level) = new_flex_algo_rib;
+    *top.rib6_flex_algo.get_mut(&level) = new_flex_algo_rib6;
 
     *top.spf_result.get_mut(&level) = Some(spf_result);
     *top.tilfa_result.get_mut(&level) = Some(tilfa_result);
@@ -1501,6 +1561,103 @@ pub(super) fn apply_spf_result(top: &mut IsisTop, output: SpfOutput) {
 /// are silently skipped — algo-N SR-MPLS forwarding requires a label
 /// at every step. The algo-0 (legacy) RIB still installs the prefix
 /// via `build_rib_from_spf`, so reachability is not lost.
+/// Build the per-algorithm IPv6 RIB (SRv6 dataplane) from a Flex-Algo
+/// SPF result. Unlike the SR-MPLS path, SRv6 Flex-Algo does not push a
+/// per-prefix SID: each node advertises a *distinct* per-algo SRv6
+/// locator (RFC 9352 §7.1, Algorithm = N), so reaching that node "in
+/// algo N" is plain longest-prefix IPv6 to its locator over the algo-N
+/// constrained topology. This routes each participating origin's
+/// per-algo locator prefix (`peer_algo_srv6[origin][algo]`) with the
+/// algo-N SPF nexthop(s) — no SID push for transit, no TI-LFA backup
+/// (per-algo fast-reroute over SRv6 is deferred).
+///
+/// Nodes that did not advertise a per-algo locator are skipped: they do
+/// not participate in algo-N SRv6 forwarding. The algo-0 IPv6 RIB still
+/// covers ordinary reachability, so nothing is lost.
+fn build_rib6_from_flex_algo(
+    top: &mut IsisTop,
+    level: Level,
+    algo: u8,
+    source: usize,
+    spf_result: &BTreeMap<usize, spf::Path>,
+) -> PrefixMap<Ipv6Net, SpfRoute<V6>> {
+    let mut rib = PrefixMap::<Ipv6Net, SpfRoute<V6>>::new();
+
+    for (node, nhops) in spf_result {
+        if *node == source {
+            continue;
+        }
+        if top.lsp_map.get(&level).is_pseudo(*node) {
+            continue;
+        }
+        let Some(sys_id) = top.lsp_map.get(&level).resolve(*node).copied() else {
+            continue;
+        };
+        // The per-algo SRv6 locator this origin advertised. Absent → the
+        // node doesn't participate in algo-N SRv6; skip it.
+        let Some(locator) = top
+            .peer_algo_srv6
+            .get(&level)
+            .get(&sys_id)
+            .and_then(|m| m.get(&algo))
+            .map(|l| l.locator)
+        else {
+            continue;
+        };
+
+        // First-router-hop walk, identical to the IPv4 builder, but the
+        // nexthop addresses are the neighbor's link-local IPv6 (SRv6
+        // transit is plain IPv6 forwarding over the egress link).
+        let mut spf_nhops = BTreeMap::new();
+        for p in &nhops.paths {
+            let Some(nhop_id) = first_router_hop_id(top.lsp_map.get(&level), p) else {
+                continue;
+            };
+            let Some(nhop_sys_id) = top.lsp_map.get(&level).resolve(nhop_id).copied() else {
+                continue;
+            };
+            for (_, link_id) in nhops.first_hop_links.iter().filter(|(v, _)| *v == p[0]) {
+                if *link_id == 0 {
+                    continue;
+                }
+                let Some(link) = top.links.get(link_id) else {
+                    continue;
+                };
+                let Some(nbr) = link.state.nbrs.get(&level).get(&nhop_sys_id) else {
+                    continue;
+                };
+                for addr in nbr.addr6l.iter() {
+                    spf_nhops.insert(
+                        *addr,
+                        SpfNexthop::<V6> {
+                            ifindex: *link_id,
+                            adjacency: *node == nhop_id,
+                            sys_id: Some(nhop_sys_id),
+                            backup: None,
+                        },
+                    );
+                }
+            }
+        }
+        if spf_nhops.is_empty() {
+            continue;
+        }
+
+        let route = SpfRoute::<V6> {
+            metric: nhops.cost,
+            nhops: spf_nhops,
+            sid: None,
+            prefix_sid: None,
+            no_php: false,
+            dest_vertex: Some(*node),
+            backup_as_primary: top.config.fast_reroute_backup_as_primary,
+        };
+        rib.insert(locator.trunc(), route);
+    }
+
+    rib
+}
+
 fn build_rib_from_flex_algo(
     top: &mut IsisTop,
     level: Level,

--- a/zebra-rs/src/isis/show.rs
+++ b/zebra-rs/src/isis/show.rs
@@ -3018,11 +3018,39 @@ fn show_isis_flex_algo(
         }
     }
 
+    // Local per-algo SRv6 locator bindings (RFC 9352 §7.1). Shows the
+    // configured locator name, whether it resolved against the global
+    // /segment-routing/locator table, and the allocated node (End) SID.
+    if !isis.config.sr_srv6_flex_algo_locators.is_empty() {
+        writeln!(buf)?;
+        writeln!(buf, "Local SRv6 Flex-Algo Locators:")?;
+        writeln!(
+            buf,
+            "  {:<5} {:<16} {:<24} End-SID",
+            "Algo", "Locator", "Prefix"
+        )?;
+        for (algo, name) in &isis.config.sr_srv6_flex_algo_locators {
+            let prefix = isis
+                .sr_flex_algo_locators
+                .get(algo)
+                .and_then(|l| l.prefix)
+                .map(|p| p.to_string())
+                .unwrap_or_else(|| "(unresolved)".to_string());
+            let end = isis
+                .sr_flex_algo_end_sid
+                .get(algo)
+                .map(|s| s.to_string())
+                .unwrap_or_else(|| "-".to_string());
+            writeln!(buf, "  {algo:<5} {name:<16} {prefix:<24} {end}")?;
+        }
+    }
+
     // Per-level peer state.
     for level in &[Level::L1, Level::L2] {
         let peer_fad = isis.peer_fad.get(level);
         let peer_algos = isis.peer_algos.get(level);
-        if peer_fad.is_empty() && peer_algos.is_empty() {
+        let peer_algo_srv6 = isis.peer_algo_srv6.get(level);
+        if peer_fad.is_empty() && peer_algos.is_empty() && peer_algo_srv6.is_empty() {
             continue;
         }
         let level_long = match level {
@@ -3058,6 +3086,20 @@ fn show_isis_flex_algo(
                     .collect::<Vec<_>>()
                     .join(", ");
                 writeln!(buf, "    {name} ({sys_id}): [{list}]")?;
+            }
+        }
+
+        if !peer_algo_srv6.is_empty() {
+            writeln!(buf, "  Peer SRv6 Flex-Algo Locators:")?;
+            for (sys_id, locs) in peer_algo_srv6.iter() {
+                let name = hostname_for(isis, level, sys_id);
+                for (algo, loc) in locs {
+                    writeln!(
+                        buf,
+                        "    {name} ({sys_id}): algo {algo} locator {} end-sid {}",
+                        loc.locator, loc.end.sid,
+                    )?;
+                }
             }
         }
     }
@@ -3156,6 +3198,61 @@ fn write_flex_algo_routes(
                         addr.to_string(),
                         ifname,
                         label
+                    )?;
+                }
+            }
+        }
+    }
+
+    // SRv6 dataplane: per-algo locator routes (IPv6). No per-prefix
+    // label — the destination is the per-algo locator and transit is
+    // plain IPv6, so the SID column is omitted.
+    for level in &[Level::L1, Level::L2] {
+        let per_algo = isis.rib6_flex_algo.get(level);
+        if per_algo.is_empty() {
+            continue;
+        }
+        let level_long = match level {
+            Level::L1 => "Level-1",
+            Level::L2 => "Level-2",
+        };
+        for (algo, rib) in per_algo {
+            if let Some(f) = filter
+                && *algo != f
+            {
+                continue;
+            }
+            if rib.iter().next().is_none() {
+                continue;
+            }
+            wrote_any = true;
+            writeln!(buf)?;
+            writeln!(buf, "{level_long} Algorithm {algo} (SRv6):")?;
+            writeln!(
+                buf,
+                "  {:<40} {:<8} {:<28} Interface",
+                "Locator", "Metric", "Nexthop"
+            )?;
+            for (prefix, route) in rib.iter() {
+                if route.nhops.is_empty() {
+                    writeln!(
+                        buf,
+                        "  {:<40} {:<8} {:<28} -",
+                        prefix.to_string(),
+                        route.metric,
+                        "(unreachable)",
+                    )?;
+                    continue;
+                }
+                for (addr, nhop) in route.nhops.iter() {
+                    let ifname = isis.ifname(nhop.ifindex);
+                    writeln!(
+                        buf,
+                        "  {:<40} {:<8} {:<28} {}",
+                        prefix.to_string(),
+                        route.metric,
+                        addr.to_string(),
+                        ifname,
                     )?;
                 }
             }

--- a/zebra-rs/src/isis/srv6.rs
+++ b/zebra-rs/src/isis/srv6.rs
@@ -121,6 +121,17 @@ pub struct Srv6EndSidInfo {
     pub structure: Option<isis_packet::IsisSub2SidStructure>,
 }
 
+/// A peer's per-Flexible-Algorithm SRv6 locator as learned from its
+/// SRv6 Locator TLV (RFC 9352 §7.1) with Algorithm in 128..=255: the
+/// locator prefix (the destination the per-algo IPv6 RIB routes to over
+/// the algo-N constrained topology) plus the node End SID under it (for
+/// colour / SR-policy headend encapsulation).
+#[derive(Debug, Clone, PartialEq)]
+pub struct Srv6AlgoLoc {
+    pub locator: Ipv6Net,
+    pub end: Srv6EndSidInfo,
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;


### PR DESCRIPTION
## Summary

Extends IS-IS Flexible Algorithm (RFC 9350) from the SR-MPLS-only dataplane to **SRv6** (RFC 9352 §7.1).

The key architectural difference from SR-MPLS: each node advertises a **distinct per-algorithm SRv6 locator**, so reaching a node "in algo N" is plain longest-prefix IPv6 to its algo-N locator computed over the algo-N constrained topology — no per-prefix SID is pushed for transit. The algorithm is encoded by *which locator you target*.

**Separation rule:** per-algo locators are advertised only in SRv6 Locator TLV 27 (Algorithm=N), never as plain IPv6 reachability, so algo-0 SPF cannot reach them over the unconstrained path.

## What's in this PR (plan PRs 1–6)

1. **Per-algo locator watch + End SID alloc** — `reconcile_locator_watch` diffs the union of base + per-algo locator names; per-algo node End SID allocated/withdrawn on snapshot churn (`inst.rs`, `config.rs`).
2. **Emit per-algo SRv6 Locator TLV 27** with `Algorithm=N` (`lsp.rs`).
3. **Parse + cache** peer per-(peer, algo) locators in `peer_algo_srv6` (`srv6.rs`, `inst.rs`, `link.rs`, `lsdb.rs`) + unit test.
4. **Per-algo IPv6 RIB build** (`rib6_flex_algo`) installed as real `Ipv6Add`/`Del` FIB routes (`rib.rs`, `inst.rs`).
5. **Dataplane gate** — `dataplane sr-mpls` → IPv4 label RIB, `dataplane srv6` → IPv6 locator RIB; no-flag default keeps historical SR-MPLS behavior (`rib.rs`).
6. **show** extended (`show isis flex-algo` + `show isis flex-algo route [algorithm N]`) and BDD `@isis_flex_srv6` feature + 5 node configs (`show.rs`, `bdd/...`).

Also broadens the SRv6 capability / SR-Algorithm advertise gate so an SRv6-only Flex-Algo config advertises participation without a base locator.

Deferred (out of scope): BGP colour → SRv6 steering (PR 7) and per-algo TI-LFA over SRv6 (PR 8). Design doc: `docs/design/isis-flexalgo-srv6-plan.md`.

## Test plan

- `cargo build` / `cargo fmt --check` / `cargo clippy --workspace --all-targets -- -D warnings` — all clean.
- Full non-bdd test suite green (1288 zebra-rs + 286 isis-packet, 0 failures), including a new `rebuild_populates_and_clears_peer_algo_srv6` lsdb parse test.
- BDD `@isis_flex_srv6` feature authored (mirrors `@isis_flexalgo` with SRv6 locators); runs under CI's bdd suite (needs root/netns).

Generated with [Claude Code](https://claude.com/claude-code)