### PR TITLE
bgp: dynamic completion of update-group IDs for show bgp update-group

### DIFF
--- a/zebra-rs/src/bgp/inst.rs
+++ b/zebra-rs/src/bgp/inst.rs
@@ -1843,6 +1843,15 @@ impl Bgp {
             .collect()
     }
 
+    /// Candidates for the `bgp:update-group` dynamic completion (`show
+    /// bgp update-group <id>`): the stable IOS-XR-style identifier
+    /// ("ipv4-unicast.0", "ipv6-unicast.0", …) of every live
+    /// update-group across all AFI/SAFIs — the same IDs the summary
+    /// table lists in `show bgp update-group`.
+    pub fn update_group_comps(&self) -> Vec<String> {
+        super::update_group::id_comps(&self.update_groups)
+    }
+
     /// Reconcile [`Self::vrfs`] (desired set, populated by per-VRF
     /// config callbacks) against [`Self::vrf_registry`] (running
     /// set): spawn the additions, despawn the removals. Called from
@@ -2050,7 +2059,15 @@ impl Bgp {
                 self.apply_vrf_commit_diff();
             }
             ConfigOp::Completion => {
-                msg.resp.unwrap().send(self.peer_comps()).unwrap();
+                // `comps_dynamic` carries the dynamic handler name
+                // (`bgp:<handler>`) as the first path segment, so dispatch
+                // on it: `update-group` wants the group IDs, everything
+                // else (`neighbor`, `neighbor-group`) wants peer names.
+                let comps = match msg.paths.first().map(|p| p.name.as_str()) {
+                    Some("update-group") => self.update_group_comps(),
+                    _ => self.peer_comps(),
+                };
+                msg.resp.unwrap().send(comps).unwrap();
             }
             ConfigOp::Clear => {
                 // FRR-style `clear bgp [<afi>] <peer-or-all> [soft [in|out]]`

--- a/zebra-rs/src/bgp/update_group.rs
+++ b/zebra-rs/src/bgp/update_group.rs
@@ -290,6 +290,19 @@ pub fn empty_map() -> UpdateGroupMap {
     BTreeMap::new()
 }
 
+/// IOS-XR-style IDs ("ipv4-unicast.0", "ipv6-unicast.0", …) of every
+/// live update-group across all AFI/SAFIs. Backs the `bgp:update-group`
+/// dynamic completion (`show bgp update-group <id>`) and matches the IDs
+/// `show bgp update-group` renders. Iteration order follows the
+/// `BTreeMap` keys: AFI/SAFI, then signature.
+pub fn id_comps(update_groups: &UpdateGroupMap) -> Vec<String> {
+    update_groups
+        .values()
+        .flat_map(|af| af.groups.values())
+        .map(|group| group.id.to_string())
+        .collect()
+}
+
 /// Compute the signature for `peer` in `(afi, safi)`. Returns `None`
 /// if the peer is not active in this AFI/SAFI (capability not
 /// negotiated by both sides). Established-state is **not** checked
@@ -1423,6 +1436,40 @@ mod tests {
         assert_eq!(id.to_string(), "vpnv4.7");
         let id = UpdateGroupId::new(Afi::L2vpn, Safi::Evpn, 2);
         assert_eq!(id.to_string(), "evpn.2");
+    }
+
+    /// `id_comps` lists every live group's IOS-XR ID across all
+    /// AFI/SAFIs — the candidate set behind the `bgp:update-group`
+    /// dynamic completion, matching what `show bgp update-group`
+    /// renders (e.g. "ipv4-unicast.0", "ipv6-unicast.0").
+    #[test]
+    fn id_comps_lists_all_group_ids() {
+        let mut groups = empty_map();
+
+        let (_, g4) = test_group(0);
+        groups
+            .entry(AfiSafi::new(Afi::Ip, Safi::Unicast))
+            .or_default()
+            .groups
+            .insert(g4.sig.clone(), g4);
+
+        // Same base signature, but a distinct AFI/SAFI bucket and an
+        // IPv6-tagged ID.
+        let (_, mut g6) = test_group(0);
+        g6.id = UpdateGroupId::new(Afi::Ip6, Safi::Unicast, 0);
+        groups
+            .entry(AfiSafi::new(Afi::Ip6, Safi::Unicast))
+            .or_default()
+            .groups
+            .insert(g6.sig.clone(), g6);
+
+        let mut got = id_comps(&groups);
+        got.sort();
+        assert_eq!(got, vec!["ipv4-unicast.0", "ipv6-unicast.0"]);
+
+        // No groups ⇒ no candidates (the dynamic key contributes
+        // nothing rather than a placeholder).
+        assert!(id_comps(&empty_map()).is_empty());
     }
 
     fn attach_test_peer(addr: std::net::IpAddr) -> Peer {


### PR DESCRIPTION
## Summary

`show bgp update-group <id>` declares its argument with `ext:dynamic "bgp:update-group"` (exec.yang), but tab-completion offered **BGP neighbor addresses** instead of update-group IDs. The YANG was already correct — the bug was on the Rust side: the BGP `ConfigOp::Completion` handler ignored the dynamic handler name and unconditionally returned `peer_comps()`.

This PR dispatches the completion op on the handler name carried as the first path segment (mirroring the RIB `rib:vrf` / `rib:interface` pattern):

- `update-group` → IOS-XR-style group IDs (`ipv4-unicast.0`, `ipv6-unicast.0`, …)
- `neighbor` / `neighbor-group` → peer names (unchanged)

The ID list is produced by a new `update_group::id_comps()` free function that walks the same `update_groups` map `show bgp update-group` renders, so completion and the summary table stay in lock-step.

No YANG change was needed — `exec.yang` already carries `ext:dynamic "bgp:update-group"`.

## Test plan

- New unit test `id_comps_lists_all_group_ids` locks the candidate set (two AFI/SAFIs → `ipv4-unicast.0`, `ipv6-unicast.0`) and the empty-map case.
- `cargo test -p zebra-rs update_group` — 18 passed.
- `cargo build -p zebra-rs` — clean.
- `cargo clippy --workspace --all-targets -- -D warnings` — clean.
- `cargo fmt --check` — clean.

Generated with [Claude Code](https://claude.com/claude-code)