### PR TITLE
bgp: drop `ip` prefix from `show ip bgp` show commands

### DIFF
--- a/bdd/docs/bgp_vrf_show.md
+++ b/bdd/docs/bgp_vrf_show.md
@@ -5,7 +5,7 @@
 As a network operator
 I want to inspect the per-VRF state of a running zebra-rs
 Using a single-namespace topology that drives the local config
-callbacks end-to-end so `show ip bgp vrf` reports the committed
+callbacks end-to-end so `show bgp vrf` reports the committed
 Route Distinguisher / MPLS label / task state, and the named forms
 redirect into the spawned per-VRF task.
 

--- a/bdd/tests/cucumber.rs
+++ b/bdd/tests/cucumber.rs
@@ -1052,7 +1052,7 @@ async fn verify_unnumbered_session_eventually_not(
 #[then(expr = "BGP route in {string} has {string}")]
 async fn verify_bgp_route(world: &mut World, namespace: String, expected_prefix: String) {
     let scoped = world.ns(&namespace);
-    let output = netns::exec_in_netns(&scoped, "vtyctl", &["show", "-j", "show ip bgp"])
+    let output = netns::exec_in_netns(&scoped, "vtyctl", &["show", "-j", "show bgp"])
         .await
         .expect("Failed to get BGP routes");
 
@@ -1081,7 +1081,7 @@ async fn verify_bgp_route(world: &mut World, namespace: String, expected_prefix:
 #[then(expr = "BGP route in {string} does not have {string}")]
 async fn verify_bgp_route_not(world: &mut World, namespace: String, unexpected_prefix: String) {
     let scoped = world.ns(&namespace);
-    let output = netns::exec_in_netns(&scoped, "vtyctl", &["show", "-j", "show ip bgp"])
+    let output = netns::exec_in_netns(&scoped, "vtyctl", &["show", "-j", "show bgp"])
         .await
         .expect("Failed to get BGP routes");
 
@@ -1117,7 +1117,7 @@ async fn verify_bgp_route_field(
     expected_value: String,
 ) {
     let scoped = world.ns(&namespace);
-    let output = netns::exec_in_netns(&scoped, "vtyctl", &["show", "-j", "show ip bgp"])
+    let output = netns::exec_in_netns(&scoped, "vtyctl", &["show", "-j", "show bgp"])
         .await
         .expect("Failed to get BGP routes");
 

--- a/bdd/tests/features/bgp_addpath_group.feature
+++ b/bdd/tests/features/bgp_addpath_group.feature
@@ -57,8 +57,8 @@ Feature: BGP AddPath Send for IPv4 unicast (RFC 7911)
     # advertises BOTH — so z4's table shows the prefix twice, once per
     # originating AS. Without AddPath Send z4 would hold exactly the
     # single best path (one AS_PATH only).
-    Then show command "show ip bgp 10.10.10.0/24" in namespace "z4" should eventually contain "65003 65001"
-    And show command "show ip bgp 10.10.10.0/24" in namespace "z4" should contain "65003 65002"
+    Then show command "show bgp 10.10.10.0/24" in namespace "z4" should eventually contain "65003 65001"
+    And show command "show bgp 10.10.10.0/24" in namespace "z4" should contain "65003 65002"
 
   Scenario: Teardown topology
     Given the test topology exists

--- a/bdd/tests/features/bgp_addpath_ipv4.feature
+++ b/bdd/tests/features/bgp_addpath_ipv4.feature
@@ -57,8 +57,8 @@ Feature: BGP AddPath Send for IPv4 unicast (RFC 7911)
     # advertises BOTH — so z4's table shows the prefix twice, once per
     # originating AS. Without AddPath Send z4 would hold exactly the
     # single best path (one AS_PATH only).
-    Then show command "show ip bgp 10.10.10.0/24" in namespace "z4" should eventually contain "65003 65001"
-    And show command "show ip bgp 10.10.10.0/24" in namespace "z4" should contain "65003 65002"
+    Then show command "show bgp 10.10.10.0/24" in namespace "z4" should eventually contain "65003 65001"
+    And show command "show bgp 10.10.10.0/24" in namespace "z4" should contain "65003 65002"
 
   Scenario: Teardown topology
     Given the test topology exists

--- a/bdd/tests/features/bgp_interas_option_c.feature
+++ b/bdd/tests/features/bgp_interas_option_c.feature
@@ -102,15 +102,15 @@ Feature: Inter-AS MPLS/VPN Option C over SR-MPLS (RFC 4364 §10c)
     # ASBR1 originates nothing itself; it relays the local-AS PE loopback
     # (1.1.1.1/32, from PE1) and the remote-AS PE loopback (2.2.2.1/32,
     # from ASBR2) — both as labeled IPv4, no VPNv4.
-    Then show command "show ip bgp labeled-unicast" in namespace "asbr1" should contain "1.1.1.1/32"
-    And show command "show ip bgp labeled-unicast" in namespace "asbr1" should contain "2.2.2.1/32"
-    And show command "show ip bgp labeled-unicast" in namespace "asbr2" should contain "1.1.1.1/32"
-    And show command "show ip bgp labeled-unicast" in namespace "asbr2" should contain "2.2.2.1/32"
+    Then show command "show bgp labeled-unicast" in namespace "asbr1" should contain "1.1.1.1/32"
+    And show command "show bgp labeled-unicast" in namespace "asbr1" should contain "2.2.2.1/32"
+    And show command "show bgp labeled-unicast" in namespace "asbr2" should contain "1.1.1.1/32"
+    And show command "show bgp labeled-unicast" in namespace "asbr2" should contain "2.2.2.1/32"
 
   Scenario: Each PE learns the remote PE loopback through the BGP-LU chain
     Given the test topology exists
-    Then show command "show ip bgp labeled-unicast" in namespace "pe1" should contain "2.2.2.1/32"
-    And show command "show ip bgp labeled-unicast" in namespace "pe2" should contain "1.1.1.1/32"
+    Then show command "show bgp labeled-unicast" in namespace "pe1" should contain "2.2.2.1/32"
+    And show command "show bgp labeled-unicast" in namespace "pe2" should contain "1.1.1.1/32"
 
   Scenario: VPNv4 customer routes are exchanged directly between the PEs
     Given the test topology exists

--- a/bdd/tests/features/bgp_lu_route_map.feature
+++ b/bdd/tests/features/bgp_lu_route_map.feature
@@ -41,15 +41,15 @@ Feature: BGP per-peer route-map for IPv4 labeled-unicast (inbound + outbound)
     Then show command "show bgp summary" in namespace "z2" should contain "Established"
     # z1 originates all three — the outbound policy gates advertisement,
     # not origination, so 3.3.3.3/32 stays in z1's own LU RIB.
-    And show command "show ip bgp labeled-unicast" in namespace "z1" should contain "1.1.1.1/32"
-    And show command "show ip bgp labeled-unicast" in namespace "z1" should contain "3.3.3.3/32"
+    And show command "show bgp labeled-unicast" in namespace "z1" should contain "1.1.1.1/32"
+    And show command "show bgp labeled-unicast" in namespace "z1" should contain "3.3.3.3/32"
     # The permitted prefix flows end to end.
-    And show command "show ip bgp labeled-unicast" in namespace "z2" should contain "2.2.2.2/32"
+    And show command "show bgp labeled-unicast" in namespace "z2" should contain "2.2.2.2/32"
     # Inbound deny: z1 advertised 1.1.1.1/32 but z2's IN-LU drops it.
-    And show command "show ip bgp labeled-unicast" in namespace "z2" should not contain "1.1.1.1/32"
+    And show command "show bgp labeled-unicast" in namespace "z2" should not contain "1.1.1.1/32"
     # Outbound deny: z1's OUT-LU never advertises 3.3.3.3/32 (z2 has no
     # matching inbound deny, so its absence isolates the outbound hook).
-    And show command "show ip bgp labeled-unicast" in namespace "z2" should not contain "3.3.3.3/32"
+    And show command "show bgp labeled-unicast" in namespace "z2" should not contain "3.3.3.3/32"
 
   Scenario: Teardown topology
     Given the test topology exists

--- a/bdd/tests/features/bgp_shard_addpath_lu4.feature
+++ b/bdd/tests/features/bgp_shard_addpath_lu4.feature
@@ -7,7 +7,7 @@ Feature: BGP labeled-unicast (v4) AddPath session-up sync at N>1 (all paths sync
   both to the late peer z4. Pins that `route_sync_labelv4` dumps every
   candidate from `bgp.shard.v4lu.0` and registers each path-id in
   `adj_out.v4lu`, so a per-path withdraw + peer-down remove only the right
-  path-id from a synced AddPath LU peer. `show ip bgp labeled-unicast`
+  path-id from a synced AddPath LU peer. `show bgp labeled-unicast`
   carries the AS_PATH column.
 
   Test Topology (z3 is the sharded device under test, 4 shards):
@@ -41,23 +41,23 @@ Feature: BGP labeled-unicast (v4) AddPath session-up sync at N>1 (all paths sync
     And I apply config "z4.yaml" to namespace "z4"
     And I wait 15 seconds for BGP to operate
     Then BGP session in "z3" to "192.168.0.4" should be "Established"
-    And show command "show ip bgp labeled-unicast" in namespace "z4" should contain "65003 65001"
-    And show command "show ip bgp labeled-unicast" in namespace "z4" should contain "65003 65002"
+    And show command "show bgp labeled-unicast" in namespace "z4" should contain "65003 65001"
+    And show command "show bgp labeled-unicast" in namespace "z4" should contain "65003 65002"
 
   Scenario: z1 withdraws; only z1's path-id is withdrawn from the synced z4
     Given the test topology exists
     When I apply config "z1-withdraw.yaml" to namespace "z1"
     And I wait 10 seconds for BGP to operate
-    Then show command "show ip bgp labeled-unicast" in namespace "z4" should not contain "65003 65001"
-    And show command "show ip bgp labeled-unicast" in namespace "z4" should contain "65003 65002"
+    Then show command "show bgp labeled-unicast" in namespace "z4" should not contain "65003 65001"
+    And show command "show bgp labeled-unicast" in namespace "z4" should contain "65003 65002"
 
   Scenario: z2's session drops; the surviving path is withdrawn from z4 too
     Given the test topology exists
-    Then show command "show ip bgp labeled-unicast" in namespace "z4" should contain "65003 65002"
+    Then show command "show bgp labeled-unicast" in namespace "z4" should contain "65003 65002"
     When I stop zebra-rs in namespace "z2"
     And I wait 20 seconds for BGP to operate
     Then BGP session in "z3" to "192.168.0.2" should not be "Established"
-    And show command "show ip bgp labeled-unicast" in namespace "z4" should not contain "65003 65002"
+    And show command "show bgp labeled-unicast" in namespace "z4" should not contain "65003 65002"
 
   Scenario: Teardown topology
     Given the test topology exists

--- a/bdd/tests/features/bgp_shard_addpath_lu6.feature
+++ b/bdd/tests/features/bgp_shard_addpath_lu6.feature
@@ -7,7 +7,7 @@ Feature: BGP labeled-unicast (v6) AddPath session-up sync at N>1 (all paths sync
   both to the late peer z4. Pins that `route_sync_labelv6` dumps every
   candidate from `bgp.shard.v6lu.0` and registers each path-id in
   `adj_out.v6lu`, so a per-path withdraw + peer-down remove only the right
-  path-id from a synced AddPath LU peer. `show ip bgp labeled-unicast`
+  path-id from a synced AddPath LU peer. `show bgp labeled-unicast`
   carries the AS_PATH column.
 
   Test Topology (z3 is the sharded device under test, 4 shards):
@@ -41,23 +41,23 @@ Feature: BGP labeled-unicast (v6) AddPath session-up sync at N>1 (all paths sync
     And I apply config "z4.yaml" to namespace "z4"
     And I wait 15 seconds for BGP to operate
     Then BGP session in "z3" to "2001:db8::4" should be "Established"
-    And show command "show ip bgp labeled-unicast" in namespace "z4" should contain "65003 65001"
-    And show command "show ip bgp labeled-unicast" in namespace "z4" should contain "65003 65002"
+    And show command "show bgp labeled-unicast" in namespace "z4" should contain "65003 65001"
+    And show command "show bgp labeled-unicast" in namespace "z4" should contain "65003 65002"
 
   Scenario: z1 withdraws; only z1's path-id is withdrawn from the synced z4
     Given the test topology exists
     When I apply config "z1-withdraw.yaml" to namespace "z1"
     And I wait 10 seconds for BGP to operate
-    Then show command "show ip bgp labeled-unicast" in namespace "z4" should not contain "65003 65001"
-    And show command "show ip bgp labeled-unicast" in namespace "z4" should contain "65003 65002"
+    Then show command "show bgp labeled-unicast" in namespace "z4" should not contain "65003 65001"
+    And show command "show bgp labeled-unicast" in namespace "z4" should contain "65003 65002"
 
   Scenario: z2's session drops; the surviving path is withdrawn from z4 too
     Given the test topology exists
-    Then show command "show ip bgp labeled-unicast" in namespace "z4" should contain "65003 65002"
+    Then show command "show bgp labeled-unicast" in namespace "z4" should contain "65003 65002"
     When I stop zebra-rs in namespace "z2"
     And I wait 20 seconds for BGP to operate
     Then BGP session in "z3" to "2001:db8::2" should not be "Established"
-    And show command "show ip bgp labeled-unicast" in namespace "z4" should not contain "65003 65002"
+    And show command "show bgp labeled-unicast" in namespace "z4" should not contain "65003 65002"
 
   Scenario: Teardown topology
     Given the test topology exists

--- a/bdd/tests/features/bgp_shard_addpath_v4.feature
+++ b/bdd/tests/features/bgp_shard_addpath_v4.feature
@@ -43,8 +43,8 @@ Feature: BGP IPv4-unicast AddPath session-up sync at N>1 (all paths sync; per-pa
     And I apply config "z4.yaml" to namespace "z4"
     And I wait 15 seconds for BGP to operate
     Then BGP session in "z3" to "192.168.0.4" should be "Established"
-    And show command "show ip bgp 10.10.10.0/24" in namespace "z4" should contain "65003 65001"
-    And show command "show ip bgp 10.10.10.0/24" in namespace "z4" should contain "65003 65002"
+    And show command "show bgp 10.10.10.0/24" in namespace "z4" should contain "65003 65001"
+    And show command "show bgp 10.10.10.0/24" in namespace "z4" should contain "65003 65002"
 
   Scenario: z1 withdraws; only z1's path-id is withdrawn from the synced z4
     Given the test topology exists
@@ -52,18 +52,18 @@ Feature: BGP IPv4-unicast AddPath session-up sync at N>1 (all paths sync; per-pa
     # — must lose only "65003 65001"; z2's "65003 65002" survives.
     When I apply config "z1-withdraw.yaml" to namespace "z1"
     And I wait 10 seconds for BGP to operate
-    Then show command "show ip bgp 10.10.10.0/24" in namespace "z4" should not contain "65003 65001"
-    And show command "show ip bgp 10.10.10.0/24" in namespace "z4" should contain "65003 65002"
+    Then show command "show bgp 10.10.10.0/24" in namespace "z4" should not contain "65003 65001"
+    And show command "show bgp 10.10.10.0/24" in namespace "z4" should contain "65003 65002"
 
   Scenario: z2's session drops; the surviving path is withdrawn from z4 too
     Given the test topology exists
     # z2 still feeds the only path now (positive control). Kill z2 — z3's
     # peer-down sweep must withdraw "65003 65002" from the synced z4.
-    Then show command "show ip bgp 10.10.10.0/24" in namespace "z4" should contain "65003 65002"
+    Then show command "show bgp 10.10.10.0/24" in namespace "z4" should contain "65003 65002"
     When I stop zebra-rs in namespace "z2"
     And I wait 20 seconds for BGP to operate
     Then BGP session in "z3" to "192.168.0.2" should not be "Established"
-    And show command "show ip bgp 10.10.10.0/24" in namespace "z4" should not contain "65003 65002"
+    And show command "show bgp 10.10.10.0/24" in namespace "z4" should not contain "65003 65002"
 
   Scenario: Teardown topology
     Given the test topology exists

--- a/bdd/tests/features/bgp_shard_lu.feature
+++ b/bdd/tests/features/bgp_shard_lu.feature
@@ -40,8 +40,8 @@ Feature: BGP IPv4 Labeled-Unicast (SAFI 4) withdraw/peer-down through a sharded 
     Given the test topology exists
     When I apply config "z1-routes.yaml" to namespace "z1"
     And I wait 10 seconds for BGP to operate
-    Then show command "show ip bgp labeled-unicast" in namespace "z2" should contain "10.10.10.1/32"
-    And show command "show ip bgp labeled-unicast" in namespace "z2" should contain "10.10.10.2/32"
+    Then show command "show bgp labeled-unicast" in namespace "z2" should contain "10.10.10.1/32"
+    And show command "show bgp labeled-unicast" in namespace "z2" should contain "10.10.10.2/32"
 
   Scenario: z1 withdraws one LU route; the sharded withdraw drops only it
     Given the test topology exists
@@ -51,18 +51,18 @@ Feature: BGP IPv4 Labeled-Unicast (SAFI 4) withdraw/peer-down through a sharded 
     # positive control, so the negative assertion is not vacuous.
     When I apply config "z1-withdraw1.yaml" to namespace "z1"
     And I wait 10 seconds for BGP to operate
-    Then show command "show ip bgp labeled-unicast" in namespace "z2" should not contain "10.10.10.1/32"
-    And show command "show ip bgp labeled-unicast" in namespace "z2" should contain "10.10.10.2/32"
+    Then show command "show bgp labeled-unicast" in namespace "z2" should not contain "10.10.10.1/32"
+    And show command "show bgp labeled-unicast" in namespace "z2" should contain "10.10.10.2/32"
 
   Scenario: z1's session drops; sharded peer-down sweeps its LU routes
     Given the test topology exists
     # z2 still holds .2 from the previous scenario (positive control). Kill
     # z1 — z2's route_clean must withdraw 10.10.10.2/32 from its LU Loc-RIB.
-    Then show command "show ip bgp labeled-unicast" in namespace "z2" should contain "10.10.10.2/32"
+    Then show command "show bgp labeled-unicast" in namespace "z2" should contain "10.10.10.2/32"
     When I stop zebra-rs in namespace "z1"
     And I wait 20 seconds for BGP to operate
     Then BGP session in "z2" to "192.168.0.1" should not be "Established"
-    And show command "show ip bgp labeled-unicast" in namespace "z2" should not contain "10.10.10.2/32"
+    And show command "show bgp labeled-unicast" in namespace "z2" should not contain "10.10.10.2/32"
 
   Scenario: Teardown topology
     Given the test topology exists

--- a/bdd/tests/features/bgp_shard_sync_labelv6.feature
+++ b/bdd/tests/features/bgp_shard_sync_labelv6.feature
@@ -17,7 +17,7 @@ Feature: BGP labeled-unicast (v6) session-up sync at N>1 (sync + withdraw reach 
     * z3 establishes BEFORE the routes exist → event-driven (control);
     * z4 establishes AFTER the routes exist → session-up `route_sync_labelv6`.
 
-  `show ip bgp labeled-unicast` renders both the v4lu and v6lu Loc-RIBs, so
+  `show bgp labeled-unicast` renders both the v4lu and v6lu Loc-RIBs, so
   the v6 LU prefixes appear there.
 
   Test Topology:
@@ -50,8 +50,8 @@ Feature: BGP labeled-unicast (v6) session-up sync at N>1 (sync + withdraw reach 
     Given the test topology exists
     When I apply config "z1-routes.yaml" to namespace "z1"
     And I wait 10 seconds for BGP to operate
-    Then show command "show ip bgp labeled-unicast" in namespace "z3" should contain "2001:db8:a::1/128"
-    And show command "show ip bgp labeled-unicast" in namespace "z3" should contain "2001:db8:a::2/128"
+    Then show command "show bgp labeled-unicast" in namespace "z3" should contain "2001:db8:a::1/128"
+    And show command "show bgp labeled-unicast" in namespace "z3" should contain "2001:db8:a::2/128"
 
   Scenario: the late peer z4 gets the routes on sync, and z2 can show its own RIB
     Given the test topology exists
@@ -61,10 +61,10 @@ Feature: BGP labeled-unicast (v6) session-up sync at N>1 (sync + withdraw reach 
     And I apply config "z4.yaml" to namespace "z4"
     And I wait 15 seconds for BGP to operate
     Then BGP session in "z2" to "2001:db8::4" should be "Established"
-    And show command "show ip bgp labeled-unicast" in namespace "z4" should contain "2001:db8:a::1/128"
-    And show command "show ip bgp labeled-unicast" in namespace "z4" should contain "2001:db8:a::2/128"
-    And show command "show ip bgp labeled-unicast" in namespace "z2" should contain "2001:db8:a::1/128"
-    And show command "show ip bgp labeled-unicast" in namespace "z2" should contain "2001:db8:a::2/128"
+    And show command "show bgp labeled-unicast" in namespace "z4" should contain "2001:db8:a::1/128"
+    And show command "show bgp labeled-unicast" in namespace "z4" should contain "2001:db8:a::2/128"
+    And show command "show bgp labeled-unicast" in namespace "z2" should contain "2001:db8:a::1/128"
+    And show command "show bgp labeled-unicast" in namespace "z2" should contain "2001:db8:a::2/128"
 
   Scenario: z1 withdraws one route; the withdraw reaches the synced peer z4
     Given the test topology exists
@@ -74,21 +74,21 @@ Feature: BGP labeled-unicast (v6) session-up sync at N>1 (sync + withdraw reach 
     # z4 and ::1 stays stuck (the bug this feature guards).
     When I apply config "z1-withdraw.yaml" to namespace "z1"
     And I wait 10 seconds for BGP to operate
-    Then show command "show ip bgp labeled-unicast" in namespace "z2" should not contain "2001:db8:a::1/128"
-    And show command "show ip bgp labeled-unicast" in namespace "z2" should contain "2001:db8:a::2/128"
-    And show command "show ip bgp labeled-unicast" in namespace "z4" should not contain "2001:db8:a::1/128"
-    And show command "show ip bgp labeled-unicast" in namespace "z4" should contain "2001:db8:a::2/128"
+    Then show command "show bgp labeled-unicast" in namespace "z2" should not contain "2001:db8:a::1/128"
+    And show command "show bgp labeled-unicast" in namespace "z2" should contain "2001:db8:a::2/128"
+    And show command "show bgp labeled-unicast" in namespace "z4" should not contain "2001:db8:a::1/128"
+    And show command "show bgp labeled-unicast" in namespace "z4" should contain "2001:db8:a::2/128"
 
   Scenario: z1's session drops; the peer-down sweep clears its routes from z4
     Given the test topology exists
     # z4 still holds ::2 (positive control). Stop z1 — z2's route_clean sweep
     # withdraws ::2, which must also reach the synced peer z4.
-    Then show command "show ip bgp labeled-unicast" in namespace "z4" should contain "2001:db8:a::2/128"
+    Then show command "show bgp labeled-unicast" in namespace "z4" should contain "2001:db8:a::2/128"
     When I stop zebra-rs in namespace "z1"
     And I wait 20 seconds for BGP to operate
     Then BGP session in "z2" to "2001:db8::1" should not be "Established"
-    And show command "show ip bgp labeled-unicast" in namespace "z2" should not contain "2001:db8:a::2/128"
-    And show command "show ip bgp labeled-unicast" in namespace "z4" should not contain "2001:db8:a::2/128"
+    And show command "show bgp labeled-unicast" in namespace "z2" should not contain "2001:db8:a::2/128"
+    And show command "show bgp labeled-unicast" in namespace "z4" should not contain "2001:db8:a::2/128"
 
   Scenario: Teardown topology
     Given the test topology exists

--- a/bdd/tests/features/bgp_shard_sync_lu.feature
+++ b/bdd/tests/features/bgp_shard_sync_lu.feature
@@ -46,8 +46,8 @@ Feature: BGP labeled-unicast (v4) session-up sync at N>1 (sync + withdraw reach 
     Given the test topology exists
     When I apply config "z1-routes.yaml" to namespace "z1"
     And I wait 10 seconds for BGP to operate
-    Then show command "show ip bgp labeled-unicast" in namespace "z3" should contain "10.10.10.1/32"
-    And show command "show ip bgp labeled-unicast" in namespace "z3" should contain "10.10.10.2/32"
+    Then show command "show bgp labeled-unicast" in namespace "z3" should contain "10.10.10.1/32"
+    And show command "show bgp labeled-unicast" in namespace "z3" should contain "10.10.10.2/32"
 
   Scenario: the late peer z4 gets the routes on sync, and z2 can show its own RIB
     Given the test topology exists
@@ -57,10 +57,10 @@ Feature: BGP labeled-unicast (v4) session-up sync at N>1 (sync + withdraw reach 
     And I apply config "z4.yaml" to namespace "z4"
     And I wait 15 seconds for BGP to operate
     Then BGP session in "z2" to "192.168.0.4" should be "Established"
-    And show command "show ip bgp labeled-unicast" in namespace "z4" should contain "10.10.10.1/32"
-    And show command "show ip bgp labeled-unicast" in namespace "z4" should contain "10.10.10.2/32"
-    And show command "show ip bgp labeled-unicast" in namespace "z2" should contain "10.10.10.1/32"
-    And show command "show ip bgp labeled-unicast" in namespace "z2" should contain "10.10.10.2/32"
+    And show command "show bgp labeled-unicast" in namespace "z4" should contain "10.10.10.1/32"
+    And show command "show bgp labeled-unicast" in namespace "z4" should contain "10.10.10.2/32"
+    And show command "show bgp labeled-unicast" in namespace "z2" should contain "10.10.10.1/32"
+    And show command "show bgp labeled-unicast" in namespace "z2" should contain "10.10.10.2/32"
 
   Scenario: z1 withdraws one route; the withdraw reaches the synced peer z4
     Given the test topology exists
@@ -70,21 +70,21 @@ Feature: BGP labeled-unicast (v4) session-up sync at N>1 (sync + withdraw reach 
     # z4 and .1 stays stuck (the bug this feature guards).
     When I apply config "z1-withdraw.yaml" to namespace "z1"
     And I wait 10 seconds for BGP to operate
-    Then show command "show ip bgp labeled-unicast" in namespace "z2" should not contain "10.10.10.1/32"
-    And show command "show ip bgp labeled-unicast" in namespace "z2" should contain "10.10.10.2/32"
-    And show command "show ip bgp labeled-unicast" in namespace "z4" should not contain "10.10.10.1/32"
-    And show command "show ip bgp labeled-unicast" in namespace "z4" should contain "10.10.10.2/32"
+    Then show command "show bgp labeled-unicast" in namespace "z2" should not contain "10.10.10.1/32"
+    And show command "show bgp labeled-unicast" in namespace "z2" should contain "10.10.10.2/32"
+    And show command "show bgp labeled-unicast" in namespace "z4" should not contain "10.10.10.1/32"
+    And show command "show bgp labeled-unicast" in namespace "z4" should contain "10.10.10.2/32"
 
   Scenario: z1's session drops; the peer-down sweep clears its routes from z4
     Given the test topology exists
     # z4 still holds .2 (positive control). Stop z1 — z2's route_clean sweep
     # withdraws .2, which must also reach the synced peer z4.
-    Then show command "show ip bgp labeled-unicast" in namespace "z4" should contain "10.10.10.2/32"
+    Then show command "show bgp labeled-unicast" in namespace "z4" should contain "10.10.10.2/32"
     When I stop zebra-rs in namespace "z1"
     And I wait 20 seconds for BGP to operate
     Then BGP session in "z2" to "192.168.0.1" should not be "Established"
-    And show command "show ip bgp labeled-unicast" in namespace "z2" should not contain "10.10.10.2/32"
-    And show command "show ip bgp labeled-unicast" in namespace "z4" should not contain "10.10.10.2/32"
+    And show command "show bgp labeled-unicast" in namespace "z2" should not contain "10.10.10.2/32"
+    And show command "show bgp labeled-unicast" in namespace "z4" should not contain "10.10.10.2/32"
 
   Scenario: Teardown topology
     Given the test topology exists

--- a/bdd/tests/features/bgp_unnumbered_afi_safi.feature
+++ b/bdd/tests/features/bgp_unnumbered_afi_safi.feature
@@ -64,7 +64,7 @@ Feature: BGP neighbor-group afi-safi inheritance on an IPv6 unnumbered iBGP sess
     And I wait 5 seconds
     And show command "show bgp neighbors i1" in namespace "z1" should contain "IPv4 Unicast: advertised and received"
     And show command "show bgp neighbors i1" in namespace "z1" should contain "IPv6 Unicast: advertised and received"
-    And show command "show ip bgp neighbor-group dynamic" in namespace "z1" should contain "ipv4 enabled, ipv6 enabled"
+    And show command "show bgp neighbor-group dynamic" in namespace "z1" should contain "ipv4 enabled, ipv6 enabled"
     And BGP route in "z2" has "10.0.1.1/32"
     And BGP route in "z1" has "10.0.1.2/32"
     And show command "show bgp ipv6" in namespace "z2" should contain "2001:db8:1::1/128"
@@ -88,7 +88,7 @@ Feature: BGP neighbor-group afi-safi inheritance on an IPv6 unnumbered iBGP sess
     And show command "show bgp neighbors i1" in namespace "z1" should contain "IPv6 Unicast: advertised and received"
     And show command "show bgp neighbors i1" in namespace "z1" should not contain "IPv4 Unicast:"
     And show command "show bgp neighbors i1" in namespace "z2" should not contain "IPv4 Unicast:"
-    And show command "show ip bgp neighbor-group dynamic" in namespace "z1" should contain "ipv4 disabled, ipv6 enabled"
+    And show command "show bgp neighbor-group dynamic" in namespace "z1" should contain "ipv4 disabled, ipv6 enabled"
     # IPv4 routes from the old session were cleaned on the bounce and
     # must not re-sync on the IPv6-only session; IPv6 routes must.
     And BGP route in "z2" does not have "10.0.1.1/32"

--- a/bdd/tests/features/bgp_unnumbered_incremental.feature
+++ b/bdd/tests/features/bgp_unnumbered_incremental.feature
@@ -59,10 +59,10 @@ Feature: Routes appearing after establishment reach an IPv6-unnumbered peer
     Given the test topology exists
     When I apply command "delete router bgp afi-safi ipv4 network 10.99.1.0/24" in namespace "z1"
     And I wait 8 seconds
-    Then show command "show ip bgp" in namespace "z2" should not contain "10.99.1.0/24"
+    Then show command "show bgp" in namespace "z2" should not contain "10.99.1.0/24"
     # Guard against a vacuous pass of the negative assertion above: the
     # same table must still carry z1's initial network.
-    And show command "show ip bgp" in namespace "z2" should contain "10.0.0.1/32"
+    And show command "show bgp" in namespace "z2" should contain "10.0.0.1/32"
 
   Scenario: Teardown topology
     Given the test topology exists

--- a/bdd/tests/features/bgp_vrf_show.feature
+++ b/bdd/tests/features/bgp_vrf_show.feature
@@ -4,7 +4,7 @@ Feature: BGP per-VRF show command
   As a network operator
   I want to inspect the per-VRF state of a running zebra-rs
   Using a single-namespace topology that drives the local config
-  callbacks end-to-end so `show ip bgp vrf` reports the committed
+  callbacks end-to-end so `show bgp vrf` reports the committed
   Route Distinguisher / MPLS label / task state, and the named forms
   redirect into the spawned per-VRF task.
 
@@ -29,26 +29,26 @@ Feature: BGP per-VRF show command
     And I start zebra-rs in namespace "z1"
     And I apply config "z1-1.yaml" to namespace "z1"
     And I wait 2 seconds for BGP to operate
-    Then show command "show ip bgp vrf" in namespace "z1" should contain "(no VRFs configured)"
+    Then show command "show bgp vrf" in namespace "z1" should contain "(no VRFs configured)"
 
   Scenario: Configure vrf-blue and observe via show
     # The top-level vrf block spawns a per-VRF BGP task, so the bare
-    # `show ip bgp vrf` summary lists the row (name, RD, state) and the
+    # `show bgp vrf` summary lists the row (name, RD, state) and the
     # named form is redirected into the task, rendering that VRF's IPv4
-    # unicast RIB (same layout as `show ip bgp`).
+    # unicast RIB (same layout as `show bgp`).
     Given the test topology exists
     When I apply config "z1-2.yaml" to namespace "z1"
     And I wait 5 seconds for BGP to operate
-    Then show command "show ip bgp vrf" in namespace "z1" should contain "vrf-blue"
-    And show command "show ip bgp vrf" in namespace "z1" should contain "65001:100"
-    And show command "show ip bgp vrf" in namespace "z1" should contain "running"
-    And show command "show ip bgp vrf vrf-blue" in namespace "z1" should contain "Network"
+    Then show command "show bgp vrf" in namespace "z1" should contain "vrf-blue"
+    And show command "show bgp vrf" in namespace "z1" should contain "65001:100"
+    And show command "show bgp vrf" in namespace "z1" should contain "running"
+    And show command "show bgp vrf vrf-blue" in namespace "z1" should contain "Network"
 
-  Scenario: Inspect vrf-blue via the `show bgp vrf` tree
-    # The `show bgp vrf <name> [ipv4|ipv6] …` tree shares the manager
-    # redirect plumbing with the legacy `show ip bgp vrf` tree: with the
-    # per-VRF task running, the bare-name form renders the VRF's IPv4
-    # unicast RIB and the explicit AFI forms select the per-AFI tables.
+  Scenario: Inspect vrf-blue via the `show bgp vrf` AFI forms
+    # The `show bgp vrf <name> [ipv4|ipv6] …` tree drives the manager
+    # redirect plumbing: with the per-VRF task running, the bare-name
+    # form renders the VRF's IPv4 unicast RIB and the explicit AFI forms
+    # select the per-AFI tables.
     Given the test topology exists
     Then show command "show bgp vrf" in namespace "z1" should contain "vrf-blue"
     And show command "show bgp vrf vrf-blue" in namespace "z1" should contain "Network"
@@ -63,8 +63,8 @@ Feature: BGP per-VRF show command
     Given the test topology exists
     When I apply config "z1-1.yaml" to namespace "z1"
     And I wait 2 seconds for BGP to operate
-    Then show command "show ip bgp vrf" in namespace "z1" should not contain "65001:100"
-    And show command "show ip bgp vrf" in namespace "z1" should contain "vrf-blue"
+    Then show command "show bgp vrf" in namespace "z1" should not contain "65001:100"
+    And show command "show bgp vrf" in namespace "z1" should contain "vrf-blue"
 
   Scenario: Teardown topology
     Given the test topology exists

--- a/docs/design/bgp-flex-algo-deferred.md
+++ b/docs/design/bgp-flex-algo-deferred.md
@@ -287,7 +287,7 @@ which we explicitly skipped.
 ### 16. `show bgp flex-algo` command
 
 **What:** Operators can see per-route Color + Label-Index via
-`show ip bgp <prefix>` (PR #692). There's no aggregate view:
+`show bgp <prefix>` (PR #692). There's no aggregate view:
 "what colors does this router currently bind, and how many routes
 match each?"
 

--- a/docs/design/bgp-flex-algo-integration.md
+++ b/docs/design/bgp-flex-algo-integration.md
@@ -47,7 +47,7 @@ the inner label is whatever the service AFI/SAFI requires.
 | Route-map `match/set color`, `set prefix-sid label-index` | ✅ | PR #690 |
 | Color → flex-algorithm binding (`Bgp::color_policy`) | ✅ | PR #687 |
 | Color/algo-aware next-hop resolution + outer label push | ✅ | PRs #697 / #701 (`bgp_color_aware_nht_consumer`) |
-| `show ip bgp <prefix>` surfaces Prefix-SID / Color | ✅ | PR #692 |
+| `show bgp <prefix>` surfaces Prefix-SID / Color | ✅ | PR #692 |
 
 ---
 
@@ -177,7 +177,7 @@ Wires the Phase-1 codec into BGP semantics.
 2. Add an integration fixture under `tests/` that brings up a minimal 3-node
    IS-IS topology with two FADs and verifies kernel LFIB + IP-MPLS encap
    entries for a BGP route with a Color community.
-3. Per-route observability: `show ip bgp <prefix>` should expose
+3. Per-route observability: `show bgp <prefix>` should expose
    `Color: 100 -> Algo: 128 -> Outer label: 16128`.
 
 ## Phase 5 — CLI, YANG, observability
@@ -185,8 +185,8 @@ Wires the Phase-1 codec into BGP semantics.
 1. YANG additions under `/router/bgp/`:
    - `color-policy/color/flex-algorithm` (see Phase 2.4)
    - `neighbor/.../send-prefix-sid`, `send-tunnel-encap`
-2. CLI verbs: `set color`, `match color`, `show ip bgp color N`,
-   `show ip bgp policy`.
+2. CLI verbs: `set color`, `match color`, `show bgp color N`,
+   `show bgp policy`.
 3. Tracing spans (`tracing::debug_span!("bgp.nht.color")`) for resolver
    misses — Color resolution failures are otherwise silent.
 

--- a/docs/design/bgp-flowspec-plan.md
+++ b/docs/design/bgp-flowspec-plan.md
@@ -24,8 +24,8 @@ and a few validation refinements remain — see **Leftover work**.
 | Slice            | PR    | What landed                                                                                  |
 | ---------------- | ----- | -------------------------------------------------------------------------------------------- |
 | 0 — codec        | #1046 | `FlowspecNlri` (v4+v6 components), action ext-comms, §5.1 `Ord`, round-trip tests            |
-| 1a — capability  | #1048 | `flowspec-ipv4`/`flowspec-ipv6` family, MP capability negotiation, `show ip bgp summary` label |
-| 1b — receive     | #1050 | `AdjRibFlowspecTable`, `route_flowspec_update/withdraw`, `show ip bgp flowspec [ipv6]`        |
+| 1a — capability  | #1048 | `flowspec-ipv4`/`flowspec-ipv6` family, MP capability negotiation, `show bgp summary` label |
+| 1b — receive     | #1050 | `AdjRibFlowspecTable`, `route_flowspec_update/withdraw`, `show bgp flowspec [ipv6]`        |
 | 2 — validation   | #1052 | RFC 9117 `flowspec_validate` (b.1 originator-match + b.2 AS_PATH-local), surfaced in `show`   |
 | (rename)         | #1053 | `ipv4-flowspec`→`flowspec-ipv4` (+ v6) for type-first consistency with `label-v4`            |
 | 3a — Loc-RIB     | #1056 | `LocalRibFlowspecTable` (cands+selected) + best-path; `show` reads the Loc-RIB                |
@@ -48,7 +48,7 @@ and a few validation refinements remain — see **Leftover work**.
   `config/configs.rs::Args::afi_safi`,
   `bgp/config.rs::config_flowspec_validation`.
 - **Show:** `zebra-rs/src/bgp/show.rs` (`show_bgp_flowspec`),
-  `exec.yang` (`show ip bgp flowspec`).
+  `exec.yang` (`show bgp flowspec`).
 
 ## Locked decisions (2026-05-30)
 
@@ -311,7 +311,7 @@ pattern (`config.rs:1622`, `vrf_config.rs:358`) — one callback per leaf into a
 | Phase     | Scope                                                              | Status                                           |
 | --------- | ------------------------------------------------------------------ | ------------------------------------------------ |
 | 0         | Codec: `FlowspecNlri` (v4+v6) + action ext-comms + `Ord` + tests   | ✅ merged (#1046)                                |
-| 1a / 1b   | Capability + receive → Adj-RIB-In + `show ip bgp flowspec`         | ✅ merged (#1048, #1050)                         |
+| 1a / 1b   | Capability + receive → Adj-RIB-In + `show bgp flowspec`         | ✅ merged (#1048, #1050)                         |
 | 2         | RFC 9117 validation vs unicast Loc-RIB                             | ✅ merged (#1052) — computed live, see leftovers |
 | 3a/3b/3c  | Loc-RIB best-path + re-advertise + per-neighbor validation knob    | ✅ merged (#1056, #1057, #1058)                  |
 | 4         | Dataplane: `tc`-flower netlink southbound                          | ⬜ not started (the large, isolated build)       |
@@ -376,5 +376,5 @@ today, and the `netlink-packet-route` fork lacks `RTM_NEW{T,Q}FILTER` /
   action) — planned extension to `zebra-bgp-flowspec.yang`.
 - **Add-path / update-group batching** for flowspec advertise (current
   send is one NLRI per UPDATE, direct via `send_flowspec_one`).
-- **JSON** output for `show ip bgp flowspec` (returns `[]` today).
+- **JSON** output for `show bgp flowspec` (returns `[]` today).
 - VPP classifier/ACL southbound.

--- a/docs/design/bgp-labeled-unicast.md
+++ b/docs/design/bgp-labeled-unicast.md
@@ -100,7 +100,7 @@ per-prefix **received** label rides each `BgpRib.label`.
 
 `route_labelv4/v6_update` / `_withdraw` ingest received routes (mirror
 the v6-unicast path), `route_clean` sweeps the LU tables on peer-down
-(no LLGR yet), and `show ip bgp labeled-unicast` lists both Loc-RIBs
+(no LLGR yet), and `show bgp labeled-unicast` lists both Loc-RIBs
 with a Label column.
 
 ### Advertise and origination

--- a/docs/design/bgp-mpls-vpn-plan.md
+++ b/docs/design/bgp-mpls-vpn-plan.md
@@ -46,7 +46,7 @@ order:
 | 5d: import pipeline  | step 18b | Per-VRF LocRIB write + CE advertise               | Step 18 (sliced — completes import side)                      |
 | 5e: MPLS label       | step 19a | `VrfLabelAllocator` + Export uses real label     | Step 19 (sliced)                                              |
 | 5e: MPLS label       | step 19b | `IlmType::DecapVrf` + ILM install at spawn        | Step 19 (sliced — completes data plane)                       |
-| 6: observability     | step 20a | `show ip bgp vrf` (list + detail, global state)  | Step 20 (sliced)                                              |
+| 6: observability     | step 20a | `show bgp vrf` (list + detail, global state)  | Step 20 (sliced)                                              |
 | 6: observability     | step 21a | `bgp_vrf_show` BDD scenario                       | Step 21 (sliced)                                              |
 | 6: docs              | step 22 | This refresh                                      | Step 22                                                       |
 
@@ -229,7 +229,7 @@ Land in any order; none block each other.
   and BFD client hand-off live on the global `Bgp`. Per-VRF
   unnumbered peering and per-VRF BFD subscriptions would need
   the per-VRF task to hold its own ND / BFD client handles.
-- **Per-VRF snapshot mirroring (step 20b).** `show ip bgp vrf
+- **Per-VRF snapshot mirroring (step 20b).** `show bgp vrf
   NAME` currently doesn't show per-peer FSM state. A snapshot
   via `BgpGlobalMsg::VrfStatus` would unlock that.
 - **`clear bgp vrf` action.** Not yet wired. Operator currently

--- a/docs/design/bgp-table-map-followups.md
+++ b/docs/design/bgp-table-map-followups.md
@@ -93,7 +93,7 @@ section documents the limitation — update it when this lands.
 Nothing in `show` reveals whether a bound table-map's policy
 resolved. Because unresolved = deny-all, a typo in the policy name
 silently blackholes every install for the family until the operator
-diffs the kernel against `show ip bgp`. A small show surface — e.g.
+diffs the kernel against `show bgp`. A small show surface — e.g.
 a line in `show bgp ipv4 summary` or a `show bgp table-map` — could
 render `LocalRib.table_map`'s `name` vs `policy.is_some()`
 ("TMAP (resolved)" / "NOSUCH (unresolved — filtering all

--- a/docs/design/bgp-update-groups.md
+++ b/docs/design/bgp-update-groups.md
@@ -744,7 +744,7 @@ OpenConfig augment if we ever add one.
 
 ## 9. Resolved decisions
 
-1. **No `show ip bgp update-group` form.** The command stays under
+1. **No `show bgp update-group` form.** The command stays under
    `show bgp ...` only, with explicit AFI/SAFI filter args (e.g.
    `show bgp update-group ipv4 unicast`). Decided 2026-05-07.
 2. **VPNv4 / EVPN grouping is per (AFI, SAFI), not per (AFI, SAFI,

--- a/zebra-rs/src/bgp/flowspec.rs
+++ b/zebra-rs/src/bgp/flowspec.rs
@@ -10,7 +10,7 @@
 //!   * **(b.1)** the originator of the flow spec matches the originator
 //!     of the best-match unicast route for the destination prefix.
 //!
-//! Phase 2 computes this verdict on demand for `show ip bgp flowspec`;
+//! Phase 2 computes this verdict on demand for `show bgp flowspec`;
 //! nothing yet *gates* behaviour on it. Stored verdicts, event-driven
 //! re-validation when the unicast RIB changes, the more-specific-route
 //! check (RFC 8955 rule c), and the per-neighbor disable knob land with

--- a/zebra-rs/src/bgp/inst.rs
+++ b/zebra-rs/src/bgp/inst.rs
@@ -2121,7 +2121,7 @@ impl Bgp {
         // `/show/bgp/ipv4` + a "summary" token, peeked non-destructively so a
         // non-summary command falls through untouched.)
         let v4_summary: Option<Option<bgp_packet::AfiSafi>> = match path.as_str() {
-            "/show/bgp/summary" | "/show/ip/bgp/summary" => Some(None),
+            "/show/bgp/summary" => Some(None),
             "/show/bgp/ipv4" if args.0.front().is_some_and(|t| t == "summary") => Some(Some(
                 bgp_packet::AfiSafi::new(bgp_packet::Afi::Ip, bgp_packet::Safi::Unicast),
             )),

--- a/zebra-rs/src/bgp/interface_neighbor.rs
+++ b/zebra-rs/src/bgp/interface_neighbor.rs
@@ -161,7 +161,7 @@ fn materialize(
     };
     peer.origin = PeerOrigin::Interface { ifindex };
     // The operator-facing identity for show/clear output and lookups
-    // (`show bgp summary`, `show ip bgp neighbors i1`, …) — the
+    // (`show bgp summary`, `show bgp neighbors i1`, …) — the
     // link-local in `address` is not something the operator can name.
     peer.ifname = Some(name.to_string());
     // Required for the kernel connect(2) to a fe80:: target —

--- a/zebra-rs/src/bgp/peer.rs
+++ b/zebra-rs/src/bgp/peer.rs
@@ -98,7 +98,7 @@ pub struct CollisionConn {
     pub role: Role,
     /// Endpoint addresses of this collision conn, written into
     /// `peer.param` if it wins §6.8 resolution and is promoted —
-    /// `show ip bgp neighbors`' Local/Foreign host lines must
+    /// `show bgp neighbors`' Local/Foreign host lines must
     /// describe the surviving connection, not the primary it
     /// replaced.
     pub local_addr: Option<SocketAddr>,
@@ -649,7 +649,7 @@ pub struct PeerParam {
     /// refreshed if a §6.8 collision conn is promoted). For a dialed
     /// session the port is the neighbor's configured `port` (default
     /// 179); for an accepted one it is the peer's ephemeral source
-    /// port. Rendered as `Foreign host/port` by `show ip bgp neighbors`,
+    /// port. Rendered as `Foreign host/port` by `show bgp neighbors`,
     /// mirroring FRR's `su_remote`.
     pub remote_addr: Option<SocketAddr>,
 }
@@ -3369,7 +3369,7 @@ mod fsm_idle_hold_tests {
     }
 
     /// The eBGP connected-check holdoff parks in Active with the
-    /// connect-retry backstop armed (and `show ip bgp neighbors`
+    /// connect-retry backstop armed (and `show bgp neighbors`
     /// reports "Next connect retry timer fires in N seconds").
     #[tokio::test]
     async fn connected_check_holdoff_parks_active_with_connect_retry() {

--- a/zebra-rs/src/bgp/peer_map.rs
+++ b/zebra-rs/src/bgp/peer_map.rs
@@ -251,7 +251,7 @@ impl PeerMap {
     // lookups go through [`Self::get`] / [`Self::keys`].
 
     /// Iterate every peer regardless of key variant, including
-    /// `PeerKey::Interface` (IPv6 unnumbered) peers — `show ip bgp
+    /// `PeerKey::Interface` (IPv6 unnumbered) peers — `show bgp
     /// neighbors` needs them so an operator can observe an
     /// interface-keyed session whose remote link-local address isn't
     /// something they can name.

--- a/zebra-rs/src/bgp/show.rs
+++ b/zebra-rs/src/bgp/show.rs
@@ -74,9 +74,8 @@ impl BgpShowView for BgpVrf {
 pub async fn process_vrf_show(vrf: &BgpVrf, msg: DisplayRequest) {
     let (path, args) = path_from_command(&msg.paths);
     let out = match path.as_str() {
-        "/show/ip/bgp" => show_bgp(vrf, args, msg.json),
-        "/show/ip/bgp/summary" | "/show/bgp/summary" => show_bgp_summary(vrf, args, msg.json),
-        "/show/ip/bgp/neighbors" => show_bgp_neighbor(vrf, args, msg.json),
+        "/show/bgp/summary" => show_bgp_summary(vrf, args, msg.json),
+        "/show/bgp/neighbors" => show_bgp_neighbor(vrf, args, msg.json),
         // `show bgp vrf <name> [ipv4|ipv6] [<addr>|<prefix> [longer-prefix]]`
         // — the manager strips the `vrf <name>` selector, so a per-VRF
         // task sees the same `/show/bgp/…` paths as the default VRF and
@@ -586,19 +585,8 @@ where
     Ok(buf)
 }
 
-/// `show ip bgp` — IPv4 unicast Loc-RIB (legacy tree). The new
-/// `show bgp [ipv4]` tree shares the same renderer via
-/// [`render_unicast_table`].
-fn show_bgp<V: BgpShowView>(
-    bgp: &V,
-    _args: Args,
-    json: bool,
-) -> std::result::Result<String, std::fmt::Error> {
-    render_unicast_table(&bgp.shard().v4.0, json)
-}
-
-/// `show ip bgp labeled-unicast` — render the IPv4 and IPv6
-/// Labeled-Unicast (SAFI 4) Loc-RIBs. Same columns as `show ip bgp`
+/// `show bgp labeled-unicast` — render the IPv4 and IPv6
+/// Labeled-Unicast (SAFI 4) Loc-RIBs. Same columns as `show bgp`
 /// plus a Label column carrying the per-prefix MPLS label. JSON output
 /// is not yet defined (mirrors `show_bgp_evpn`); returns an empty array.
 fn show_bgp_labeled(
@@ -628,7 +616,7 @@ fn show_bgp_labeled(
     Ok(buf)
 }
 
-/// One labeled-unicast row: the unicast columns from `show ip bgp` plus
+/// One labeled-unicast row: the unicast columns from `show bgp` plus
 /// the per-prefix label (or `-` when absent).
 fn show_labeled_row(
     buf: &mut String,
@@ -1227,7 +1215,7 @@ fn show_bgp_vpnv4_entry(bgp: &Bgp, tok: &str) -> std::result::Result<String, std
 }
 
 /// One RD's detail block — header lines plus the per-path breakdown.
-/// Layout carried over from the legacy `show ip bgp vpnv4 route`.
+/// Layout carried over from the legacy `show bgp vpnv4 route`.
 fn write_vpnv4_entry_detail(
     out: &mut String,
     bgp: &Bgp,
@@ -1490,25 +1478,6 @@ fn write_bgp_entry_detail<V: BgpShowView>(
         writeln!(out)?;
     }
     Ok(())
-}
-
-/// `show ip bgp <A.B.C.D>` (legacy tree) — longest-match detail for one
-/// IPv4 address. The new `show bgp [ipv4] …` tree reuses
-/// [`write_bgp_entry_detail`] via [`show_bgp_ipv4`].
-fn show_bgp_route_entry(
-    bgp: &Bgp,
-    mut args: Args,
-    _json: bool,
-) -> std::result::Result<String, std::fmt::Error> {
-    let mut out = String::new();
-    let addr = match args.v4addr() {
-        Some(addr) => addr,
-        None => return Ok(String::from("% No BGP route exists")),
-    };
-    if let Some((prefix, ribs)) = bgp.shard.v4.0.get_lpm(&addr.to_host_prefix()) {
-        write_bgp_entry_detail(&mut out, bgp, &prefix.to_string(), ribs)?;
-    }
-    Ok(out)
 }
 
 /// `show bgp` / `show bgp ipv4 [A.B.C.D | A.B.C.D/M]` — IPv4 unicast.
@@ -2591,7 +2560,7 @@ fn render(out: &mut String, neighbor: &Neighbor) -> std::fmt::Result {
     // Configured `tcp-mss` plus the MSS the kernel actually negotiated on
     // the live socket. The two can differ — a config change only takes
     // effect on the next connect — and the synced value is 0 until the
-    // session is up. Mirrors FRR's `show ip bgp neighbor` line.
+    // session is up. Mirrors FRR's `show bgp neighbor` line.
     if let Some(mss) = neighbor.tcp_mss {
         writeln!(
             out,
@@ -3240,7 +3209,7 @@ fn show_flowspec_actions(attr: &BgpAttr) -> String {
     }
 }
 
-/// `show ip bgp flowspec [ipv6]` — list the Flow Specification rules in
+/// `show bgp flowspec [ipv6]` — list the Flow Specification rules in
 /// Adj-RIB-In across all peers for the given AFI, each with its decoded
 /// traffic-filtering actions and the advertising neighbor. Phase 1 is
 /// receive-only: there is no Loc-RIB / best-path for flow specs yet, so
@@ -3430,7 +3399,7 @@ fn show_bgp_sr_policy_v6(
     show_bgp_sr_policy(bgp, Afi::Ip6, json)
 }
 
-/// `show ip bgp link-state` — the BGP-LS Loc-RIB (RFC 9552, AFI 16388 /
+/// `show bgp link-state` — the BGP-LS Loc-RIB (RFC 9552, AFI 16388 /
 /// SAFI 71). One line per selected Node/Link/Prefix object with the
 /// advertising neighbor. BGP-LS is a single exact-match family (the v4/v6
 /// distinction is inside the NLRI), so there is no per-AFI split. The
@@ -3763,7 +3732,7 @@ Neighbor        V         AS   MsgRcvd   MsgSent   TblVer  InQ OutQ  Up/Down Sta
         assert!(addr.get("interface").is_none());
     }
 
-    /// `show ip bgp neighbors <name>` resolves an `interface-neighbor`
+    /// `show bgp neighbors <name>` resolves an `interface-neighbor`
     /// name (the completion offers them) and renders the FRR-style
     /// `BGP neighbor on <ifname>: <link-local>` identity; address
     /// lookups and the no-match error keep their existing forms.
@@ -4128,8 +4097,8 @@ fn show_bgp_attributes(
     Ok(buf)
 }
 
-/// `show ip bgp vrf` — without args lists every committed
-/// per-VRF block as a single table; with one arg (`show ip bgp
+/// `show bgp vrf` — without args lists every committed
+/// per-VRF block as a single table; with one arg (`show bgp
 /// vrf NAME`) renders the same row plus the kernel-known
 /// `table_id`, `ifindex`, RT sets, and the materialized peer
 /// addresses.
@@ -4155,7 +4124,7 @@ fn show_bgp_vrf(
     }
 }
 
-/// Handler for `show ip bgp vrf <name> {summary,neighbors}` reached
+/// Handler for `show bgp vrf <name> {summary,neighbors}` reached
 /// only when the manager did *not* redirect — i.e. no per-VRF BGP task
 /// is registered for `<name>`. Running VRFs are intercepted by the
 /// manager and dispatched into their own task; this just reports the
@@ -4361,7 +4330,7 @@ fn show_bgp_vrf_detail(
 }
 
 // ---------------------------------------------------------------------
-// `show ip bgp neighbor-group [NAME]`
+// `show bgp neighbor-group [NAME]`
 // ---------------------------------------------------------------------
 
 /// Map an [`AfiSafi`] to the zebra-rs config-layer token name used in
@@ -4386,7 +4355,7 @@ fn afi_safi_config_name(afi_safi: &AfiSafi) -> &'static str {
     }
 }
 
-/// One row of `show ip bgp neighbor-group` (list form). Captures the
+/// One row of `show bgp neighbor-group` (list form). Captures the
 /// configured fields plus a member-peer count to make the list useful
 /// at a glance.
 ///
@@ -4755,12 +4724,8 @@ fn show_bgp_neighbor_group_detail(
 impl Bgp {
     pub fn show_build(&mut self) {
         self.show_cb = Builder::<ShowCallback>::default()
-            .path("/show/ip/bgp")
-            .set(show_bgp::<Bgp>)
-            .path("/show/ip/bgp/labeled-unicast")
+            .path("/show/bgp/labeled-unicast")
             .set(show_bgp_labeled)
-            .path("/show/ip/bgp/route")
-            .set(show_bgp_route_entry)
             .path("/show/bgp/neighbors")
             .set(show_bgp_neighbor::<Bgp>)
             .path("/show/bgp/neighbors/advertised-routes")
@@ -4781,25 +4746,19 @@ impl Bgp {
             .set(show_bgp_received_evpn)
             .path("/show/bgp/neighbors/rtcv4")
             .set(show_bgp_rtcv4)
-            .path("/show/ip/bgp/flowspec")
+            .path("/show/bgp/flowspec")
             .set(show_bgp_flowspec_v4)
-            .path("/show/ip/bgp/flowspec/ipv6")
+            .path("/show/bgp/flowspec/ipv6")
             .set(show_bgp_flowspec_v6)
-            .path("/show/ip/bgp/sr-policy")
+            .path("/show/bgp/sr-policy")
             .set(show_bgp_sr_policy_v4)
-            .path("/show/ip/bgp/sr-policy/ipv6")
+            .path("/show/bgp/sr-policy/ipv6")
             .set(show_bgp_sr_policy_v6)
-            .path("/show/ip/bgp/link-state")
+            .path("/show/bgp/link-state")
             .set(show_bgp_link_state)
-            .path("/show/ip/bgp/attributes")
+            .path("/show/bgp/attributes")
             .set(show_bgp_attributes)
-            .path("/show/ip/bgp/vrf")
-            .set(show_bgp_vrf)
-            .path("/show/ip/bgp/vrf/summary")
-            .set(show_bgp_vrf_not_running)
-            .path("/show/ip/bgp/vrf/neighbors")
-            .set(show_bgp_vrf_not_running)
-            .path("/show/ip/bgp/neighbor-group")
+            .path("/show/bgp/neighbor-group")
             .set(show_bgp_neighbor_group)
             .path("/show/evpn/vni/all")
             .set(show_evpn_vni_all)
@@ -4828,6 +4787,8 @@ impl Bgp {
             .path("/show/bgp/vrf")
             .set(show_bgp_vrf)
             .path("/show/bgp/vrf/summary")
+            .set(show_bgp_vrf_not_running)
+            .path("/show/bgp/vrf/neighbors")
             .set(show_bgp_vrf_not_running)
             .path("/show/bgp/vrf/ipv4")
             .set(show_bgp_vrf_not_running)

--- a/zebra-rs/src/config/parse.rs
+++ b/zebra-rs/src/config/parse.rs
@@ -1149,19 +1149,32 @@ mod tests {
         }
     }
 
-    /// The VPNv4 / EVPN RIB views moved from the legacy `show ip bgp`
-    /// tree to `show bgp …`; the old spellings must no longer parse.
-    /// The per-neighbor views (and their `vpnv4` / `evpn` Adj-RIB
-    /// filters) moved the same way: `show bgp neighbors …`.
+    /// The BGP RIB views moved off the legacy `show ip bgp` tree onto
+    /// `show bgp …`; the whole `show ip bgp` subtree is gone, so every
+    /// old spelling must no longer parse and each `show bgp …` twin must.
+    /// Covers the earlier VPNv4/EVPN/neighbor move plus the final cutover
+    /// (labeled-unicast, flowspec, sr-policy, attributes, link-state,
+    /// neighbor-group, vrf, and the bare `show ip bgp`).
     #[test]
     fn show_ip_bgp_vpnv4_evpn_moved() {
         let entry = exec_entry();
         for cmd in [
+            "show ip bgp",
             "show ip bgp vpnv4",
             "show ip bgp vpnv4 route 10.0.0.1",
             "show ip bgp evpn",
             "show ip bgp neighbors 10.0.0.1",
             "show ip bgp neighbors 10.0.0.1 advertised-routes vpnv4",
+            "show ip bgp labeled-unicast",
+            "show ip bgp flowspec",
+            "show ip bgp flowspec ipv6",
+            "show ip bgp sr-policy",
+            "show ip bgp attributes",
+            "show ip bgp link-state",
+            "show ip bgp route 10.0.0.1",
+            "show ip bgp vrf",
+            "show ip bgp vrf blue neighbors",
+            "show ip bgp neighbor-group g1",
         ] {
             let (code, _comps, _state) = parse(cmd, entry.clone(), None, State::new());
             assert_ne!(code, ExecCode::Success, "`{cmd}` must not be a command");
@@ -1169,6 +1182,15 @@ mod tests {
         for cmd in [
             "show bgp neighbors 10.0.0.1 advertised-routes vpnv4",
             "show bgp neighbors 10.0.0.1 received-routes evpn",
+            "show bgp labeled-unicast",
+            "show bgp flowspec",
+            "show bgp flowspec ipv6",
+            "show bgp sr-policy",
+            "show bgp sr-policy ipv6",
+            "show bgp attributes",
+            "show bgp link-state",
+            "show bgp vrf blue neighbors",
+            "show bgp neighbor-group g1",
         ] {
             let (code, _comps, _state) = parse(cmd, entry.clone(), None, State::new());
             assert_eq!(code, ExecCode::Success, "`{cmd}` must parse");
@@ -1281,25 +1303,12 @@ mod tests {
             assert_eq!(&got, want_args, "args for `{cmd}`");
         }
 
-        // The legacy spelling is gone; the legacy per-VRF leaf stays.
-        let (code, _comps, _state) =
-            parse("show ip bgp summary", entry.clone(), None, State::new());
-        assert_ne!(
-            code,
-            ExecCode::Success,
-            "`show ip bgp summary` must not be a command"
-        );
-        let (code, _comps, _state) = parse(
-            "show ip bgp vrf v1 summary",
-            entry.clone(),
-            None,
-            State::new(),
-        );
-        assert_eq!(
-            code,
-            ExecCode::Success,
-            "`show ip bgp vrf v1 summary` must parse"
-        );
+        // The whole legacy `show ip bgp` subtree is gone, including the
+        // per-VRF leaf — both spellings must no longer parse.
+        for cmd in ["show ip bgp summary", "show ip bgp vrf v1 summary"] {
+            let (code, _comps, _state) = parse(cmd, entry.clone(), None, State::new());
+            assert_ne!(code, ExecCode::Success, "`{cmd}` must not be a command");
+        }
     }
 
     /// The OSPFv2 show tree moved from `show ip ospf …` to a

--- a/zebra-rs/src/config/paths.rs
+++ b/zebra-rs/src/config/paths.rs
@@ -74,12 +74,11 @@ mod tests {
         }
     }
 
-    // `show ip bgp vrf vrf1 summary` -> ("vrf1", `show ip bgp summary`).
+    // `show bgp vrf vrf1 summary` -> ("vrf1", `show bgp summary`).
     #[test]
     fn vrf_redirect_split_strips_vrf_and_name() {
         let paths = vec![
             cp("show", 0),
-            cp("ip", 0),
             cp("bgp", 0),
             cp("vrf", 2),     // Key
             cp("vrf1", 3),    // KeyMatched
@@ -88,37 +87,31 @@ mod tests {
         let (name, rewritten) = vrf_redirect_split(&paths).expect("should split");
         assert_eq!(name, "vrf1");
         let names: Vec<&str> = rewritten.iter().map(|p| p.name.as_str()).collect();
-        assert_eq!(names, ["show", "ip", "bgp", "summary"]);
+        assert_eq!(names, ["show", "bgp", "summary"]);
     }
 
-    // `show ip bgp vrf vrf1` (no trailing keyword) -> ("vrf1", `show ip bgp`).
+    // `show bgp vrf vrf1` (no trailing keyword) -> ("vrf1", `show bgp`).
     #[test]
     fn vrf_redirect_split_handles_bare_name() {
-        let paths = vec![
-            cp("show", 0),
-            cp("ip", 0),
-            cp("bgp", 0),
-            cp("vrf", 2),
-            cp("vrf1", 3),
-        ];
+        let paths = vec![cp("show", 0), cp("bgp", 0), cp("vrf", 2), cp("vrf1", 3)];
         let (name, rewritten) = vrf_redirect_split(&paths).expect("should split");
         assert_eq!(name, "vrf1");
         let names: Vec<&str> = rewritten.iter().map(|p| p.name.as_str()).collect();
-        assert_eq!(names, ["show", "ip", "bgp"]);
+        assert_eq!(names, ["show", "bgp"]);
     }
 
-    // Bare `show ip bgp vrf` (presence, no key) is the all-VRFs list, not a
+    // Bare `show bgp vrf` (presence, no key) is the all-VRFs list, not a
     // redirect.
     #[test]
     fn vrf_redirect_split_none_without_key() {
-        let paths = vec![cp("show", 0), cp("ip", 0), cp("bgp", 0), cp("vrf", 2)];
+        let paths = vec![cp("show", 0), cp("bgp", 0), cp("vrf", 2)];
         assert!(vrf_redirect_split(&paths).is_none());
     }
 
     // A command with no `vrf` segment is never a redirect.
     #[test]
     fn vrf_redirect_split_none_without_vrf() {
-        let paths = vec![cp("show", 0), cp("ip", 0), cp("bgp", 0), cp("summary", 4)];
+        let paths = vec![cp("show", 0), cp("bgp", 0), cp("summary", 4)];
         assert!(vrf_redirect_split(&paths).is_none());
     }
 }

--- a/zebra-rs/yang/exec.yang
+++ b/zebra-rs/yang/exec.yang
@@ -352,6 +352,42 @@ module exec {
           type string;
         }
       }
+      leaf labeled-unicast {
+        ext:help "BGP Labeled-Unicast (SAFI 4) RIB";
+        type empty;
+      }
+      container flowspec {
+        ext:help "BGP IPv4 Flow Specification RIB";
+        presence "BGP IPv4 Flowspec RIB";
+        leaf ipv6 {
+          ext:help "BGP IPv6 Flow Specification RIB";
+          type empty;
+        }
+      }
+      container sr-policy {
+        ext:help "BGP IPv4 SR Policy (SAFI 73) RIB";
+        presence "BGP IPv4 SR Policy RIB";
+        leaf ipv6 {
+          ext:help "BGP IPv6 SR Policy (SAFI 73) RIB";
+          type empty;
+        }
+      }
+      leaf link-state {
+        ext:help "BGP Link-State (SAFI 71) RIB";
+        type empty;
+      }
+      leaf attributes {
+        type empty;
+      }
+      list neighbor-group {
+        ext:help "BGP neighbor-group inheritance state";
+        ext:presence "Show every configured neighbor-group";
+        key name;
+        leaf name {
+          ext:dynamic "bgp:neighbor-group";
+          type string;
+        }
+      }
       list vrf {
         ext:help "Per-VRF BGP RIB";
         ext:presence "BGP per-VRF summary table";
@@ -369,6 +405,10 @@ module exec {
         }
         leaf summary {
           ext:help "Summary of this VRF's BGP neighbor status";
+          type empty;
+        }
+        leaf neighbors {
+          ext:help "Detailed information on this VRF's BGP neighbors";
           type empty;
         }
         uses bgp-show-afi-rib;
@@ -407,63 +447,6 @@ module exec {
           leaf detail {
             ext:help "Show this VRF's routes in detail format";
             type empty;
-          }
-        }
-      }
-      container bgp {
-        ext:help "BGP commands";
-        presence "BGP RIB";
-        leaf route {
-          ext:help "BGP RIB";
-          type inet:ipv4-address;
-        }
-        leaf labeled-unicast {
-          ext:help "BGP Labeled-Unicast (SAFI 4) RIB";
-          type empty;
-        }
-        container flowspec {
-          ext:help "BGP IPv4 Flow Specification RIB";
-          presence "BGP IPv4 Flowspec RIB";
-          leaf ipv6 {
-            ext:help "BGP IPv6 Flow Specification RIB";
-            type empty;
-          }
-        }
-        container sr-policy {
-          ext:help "BGP IPv4 SR Policy (SAFI 73) RIB";
-          presence "BGP IPv4 SR Policy RIB";
-          leaf ipv6 {
-            ext:help "BGP IPv6 SR Policy (SAFI 73) RIB";
-            type empty;
-          }
-        }
-        leaf attributes {
-          type empty;
-        }
-        list vrf {
-          ext:help "Per-VRF BGP runtime";
-          ext:presence "BGP per-VRF summary table";
-          key name;
-          leaf name {
-            ext:dynamic "rib:vrf";
-            type string;
-          }
-          leaf summary {
-            ext:help "Summary of this VRF's BGP neighbor status";
-            type empty;
-          }
-          leaf neighbors {
-            ext:help "Detailed information on this VRF's BGP neighbors";
-            type empty;
-          }
-        }
-        list neighbor-group {
-          ext:help "BGP neighbor-group inheritance state";
-          ext:presence "Show every configured neighbor-group";
-          key name;
-          leaf name {
-            ext:dynamic "bgp:neighbor-group";
-            type string;
           }
         }
       }


### PR DESCRIPTION
## Summary

Completes the migration of the legacy `show ip bgp …` tree onto `show bgp …`. The earlier vpnv4/vpnv6/evpn/neighbors/summary/ipv4/ipv6/update-group moves left seven subcommands under the legacy `container ip { container bgp }`; this is the hard cutover (no aliases).

- **exec.yang**: add `labeled-unicast`, `flowspec`(+`ipv6`), `sr-policy`(+`ipv6`), `link-state`, `attributes`, the `neighbor-group` list, and a `neighbors` leaf on the `vrf` list to the modern `container bgp`; delete the legacy `container ip { container bgp }`. `show ip route` is untouched. The previously-dangling `show_bgp_link_state` handler is now reachable via the new `show bgp link-state` node.
- **show.rs**: re-key all `/show/ip/bgp/*` callbacks to `/show/bgp/*`, add `/show/bgp/vrf/neighbors`, and drop two now-dead handlers (`show_bgp`, `show_bgp_route_entry`) subsumed by `show_bgp_ipv4`. `process_vrf_show` gains `/show/bgp/neighbors` (per-VRF neighbor view previously reachable only via the `ip` spelling).
- **inst.rs**: drop the legacy `/show/ip/bgp/summary` async-gather arm.
- **parse.rs / paths.rs**: extend the moved-spelling pin (old forms must-not-parse, new twins must-parse); fix `show_bgp_summary_grammar` now that the legacy per-VRF leaf is gone; update the vrf-redirect fixtures.
- **bdd + docs**: rename `show ip bgp` → `show bgp` across 13 feature files, 3 cucumber JSON helpers, and 7 design docs.

### Behavioral note
`show bgp <prefix>` now does a real exact-match lookup where the old bare `show ip bgp <prefix>` silently ignored the prefix and dumped the full table. Verified the affected addpath BDD `AS path: …` assertions still hold (and `should not contain` lines are now strictly more precise).

## Test plan

- `cargo clippy --workspace --all-targets -- -D warnings` — clean
- `cargo test -p zebra-rs --bin zebra-rs` — 1293 passed, 0 failed (incl. YANG-load, parse-grammar, vrf-redirect)
- BDD test crate compiles; `cargo fmt` applied
- BDD feature scenarios run under CI (root/namespace)

Generated with [Claude Code](https://claude.com/claude-code)