### PR TITLE
docs(book): update BGP show commands to `show bgp` spelling

### DIFF
--- a/book/src/ch-02-01-dynamic-neighbors.md
+++ b/book/src/ch-02-01-dynamic-neighbors.md
@@ -84,8 +84,8 @@ group (and its `remote-as`) lands.
 ## Verification
 
 A spoke that has connected shows up like any other peer —
-`show bgp summary`, `show ip bgp neighbors` — identified by its source
-address, and `show ip bgp neighbors <addr>` reports the binding:
+`show bgp summary`, `show bgp neighbors` — identified by its source
+address, and `show bgp neighbors <addr>` reports the binding:
 
 ```
   Neighbor-group: SPOKES (remote-as inherited)
@@ -95,7 +95,7 @@ The group detail view counts the spokes that are currently
 materialized:
 
 ```
-show ip bgp neighbor-group SPOKES
+show bgp neighbor-group SPOKES
 BGP neighbor-group: SPOKES
   Remote-AS: 65002
   Afi-Safi:  ipv4 enabled, ipv6 enabled

--- a/book/src/ch-02-07-bgp-rtc.md
+++ b/book/src/ch-02-07-bgp-rtc.md
@@ -84,11 +84,11 @@ everything, exactly as it would be without RTC.
 
 ## Verification
 
-`show ip bgp neighbors <addr> rtcv4` prints the route-target constraint
+`show bgp neighbors <addr> rtcv4` prints the route-target constraint
 sets received from a neighbor, split by family:
 
 ```
-$ show ip bgp neighbors 10.0.0.1 rtcv4
+$ show bgp neighbors 10.0.0.1 rtcv4
 IPv4 Route Target Constraints for 10.0.0.1
  65000:1
  65000:2

--- a/book/src/ch-02-11-bgp-ttl-security.md
+++ b/book/src/ch-02-11-bgp-ttl-security.md
@@ -159,7 +159,7 @@ for the next unrelated flap.
 
 ### Verification
 
-`show ip bgp neighbor <addr>` reports the active policy:
+`show bgp neighbors <addr>` reports the active policy:
 
 ```
   TTL security (GTSM) enabled, minimum received TTL 255

--- a/book/src/ch-02-12-bgp-as-override.md
+++ b/book/src/ch-02-12-bgp-as-override.md
@@ -102,7 +102,7 @@ every member; a statement on the neighbor itself wins.
 
 ## Verification
 
-`show ip bgp neighbor <addr>` reports whether the knob is active:
+`show bgp neighbors <addr>` reports whether the knob is active:
 
 ```
   AS-Override enabled (outbound AS_PATH replacement)
@@ -113,7 +113,7 @@ should now hold `10.0.0.1/32` with an AS_PATH of `65002 65002` rather
 than the rejected `65002 65001`:
 
 ```
-show ip bgp 10.0.0.1/32
+show bgp 10.0.0.1/32
 ```
 
 ### Interaction with update-groups

--- a/book/src/ch-02-13-bgp-allowas-in.md
+++ b/book/src/ch-02-13-bgp-allowas-in.md
@@ -131,7 +131,7 @@ every member; a statement on the neighbor itself wins.
 
 ## Verification
 
-`show ip bgp neighbors` reports the active setting for the session:
+`show bgp neighbors` reports the active setting for the session:
 
 ```
   Allowas-in: 3 occurrence(s)
@@ -147,7 +147,7 @@ Then confirm the previously-rejected prefix is now installed. `z3` should
 hold `10.0.0.1/32` with an AS_PATH of `65002 65001`:
 
 ```
-show ip bgp 10.0.0.1/32
+show bgp 10.0.0.1/32
 ```
 
 ## Troubleshooting

--- a/book/src/ch-02-14-bgp-remove-private-as.md
+++ b/book/src/ch-02-14-bgp-remove-private-as.md
@@ -143,7 +143,7 @@ every member; a statement on the neighbor itself wins.
 
 ## Verification
 
-`show ip bgp neighbor <addr>` reports the configured form:
+`show bgp neighbors <addr>` reports the configured form:
 
 ```
   Private AS removal: remove-private-AS (outbound)
@@ -155,7 +155,7 @@ On the neighbor, confirm the stripped path arrived. `z3` should now hold
 `10.0.0.1/32` with an AS_PATH of `100` rather than `100 65001`:
 
 ```
-show ip bgp 10.0.0.1/32
+show bgp 10.0.0.1/32
 ```
 
 ### Interaction with update-groups

--- a/book/src/ch-02-14-bgp-tcp-mss.md
+++ b/book/src/ch-02-14-bgp-tcp-mss.md
@@ -68,7 +68,7 @@ your peer's `tcp-mss` shrinks the segments you send to it.
 
 ## Configured vs. synced
 
-`show ip bgp neighbor <addr>` reports two numbers:
+`show bgp neighbors <addr>` reports two numbers:
 
 ```
   Configured tcp-mss is 500, synced tcp-mss is 488
@@ -101,7 +101,7 @@ the clamp is already in place when the connection forms.
 After the session establishes, confirm the negotiated value:
 
 ```
-> show ip bgp neighbor 192.168.0.2
+> show bgp neighbors 192.168.0.2
 BGP neighbor is 192.168.0.2, remote AS 65002, local AS 65001, external link
   ...
   Configured tcp-mss is 500, synced tcp-mss is 488

--- a/book/src/ch-02-15-bgp-enforce-first-as.md
+++ b/book/src/ch-02-15-bgp-enforce-first-as.md
@@ -96,7 +96,7 @@ every member; a statement on the neighbor itself wins.
 
 ## Verification
 
-`show ip bgp neighbor <addr>` reports whether the knob is active:
+`show bgp neighbors <addr>` reports whether the knob is active:
 
 ```
   Enforce-first-AS enabled (drop inbound updates not starting with peer AS)
@@ -106,7 +106,7 @@ After enabling it (and bouncing the session), a route that fails the
 check simply will not appear in the table:
 
 ```
-show ip bgp 10.0.0.1/32
+show bgp 10.0.0.1/32
 ```
 
 ## Relationship to allowas-in and as-override

--- a/book/src/ch-02-16-bgp-disable-connected-check.md
+++ b/book/src/ch-02-16-bgp-disable-connected-check.md
@@ -117,7 +117,7 @@ by every member; a statement on the neighbor itself wins.
 
 ## Verification
 
-`show ip bgp neighbor <addr>` reports the active policy:
+`show bgp neighbors <addr>` reports the active policy:
 
 ```
   Connected-network check disabled (eBGP peer may be unconnected at TTL 1)

--- a/book/src/ch-02-17-bgp-srv6-encapsulation-type.md
+++ b/book/src/ch-02-17-bgp-srv6-encapsulation-type.md
@@ -81,7 +81,7 @@ delete router bgp neighbor 2001:db8::8 afi-safi ipv6 encapsulation-type
 
 ## Verification
 
-`show ip bgp neighbor <addr>` echoes the configured mode for the IPv6
+`show bgp neighbors <addr>` echoes the configured mode for the IPv6
 unicast family:
 
 ```

--- a/book/src/ch-02-19-bgp-interas-option-c.md
+++ b/book/src/ch-02-19-bgp-interas-option-c.md
@@ -239,7 +239,7 @@ BGP-LU swap label for `2.2.2.1`.
 **The ASBRs carry only labeled IPv4 — no VPN.** On `asbr1`:
 
 ```
-$ show ip bgp labeled-unicast
+$ show bgp labeled-unicast
     Network            Next Hop            ...  Path
  *>i 1.1.1.1/32         1.1.1.1             ...  i        # local PE, from PE1
  *>  2.2.2.1/32         172.16.0.2          ...  65001 i  # remote PE, from ASBR2
@@ -248,7 +248,7 @@ $ show ip bgp labeled-unicast
 The `label-v4` capability is negotiated on each BGP-LU session:
 
 ```
-$ show ip bgp neighbor 172.16.0.2
+$ show bgp neighbors 172.16.0.2
   ...
     IPv4 Labeled Unicast: advertised and received
 ```
@@ -262,7 +262,7 @@ $ show bgp vpnv4
 Route Distinguisher: 65001:1
  *>  10.2.0.0/30        2.2.2.1   ...   # rt:65000:100
 
-$ show ip bgp neighbor 2.2.2.1
+$ show bgp neighbors 2.2.2.1
   BGP state = Established
 ```
 

--- a/book/src/ch-02-20-bgp-interas-option-a.md
+++ b/book/src/ch-02-20-bgp-interas-option-a.md
@@ -153,10 +153,10 @@ IP inside the VRF. A packet from `ce1` to a host in `ce2`'s subnet:
 ## Verification
 
 The inter-AS PE-CE session is a VRF session, shown under
-`show ip bgp vrf vrf-cust summary`:
+`show bgp vrf vrf-cust summary`:
 
 ```
-asbr1$ show ip bgp vrf vrf-cust summary
+asbr1$ show bgp vrf vrf-cust summary
 Neighbor    V    AS  MsgRcvd MsgSent ... State/PfxRcd
 172.16.0.2  4 65001        3       3 ... Established 1
 ```

--- a/book/src/ch-02-23-bgp-port.md
+++ b/book/src/ch-02-23-bgp-port.md
@@ -119,12 +119,12 @@ keep their own default-port listeners.
 
 ## Verification
 
-`show ip bgp neighbors` reports the actual TCP endpoints of the live
+`show bgp neighbors` reports the actual TCP endpoints of the live
 session, FRR-style. On the router that dialed a custom port, the
 **foreign** port is the configured one:
 
 ```
-> show ip bgp neighbors
+> show bgp neighbors
 BGP neighbor is 192.168.0.2, remote AS 65002, local AS 65001, external link
   Local host: 192.168.0.1, Local port: 38766
   Foreign host: 192.168.0.2, Foreign port: 1790
@@ -136,7 +136,7 @@ On the router that accepted it, the **local** port is its listen port
 and the foreign port is the peer's ephemeral source port:
 
 ```
-> show ip bgp neighbors
+> show bgp neighbors
 BGP neighbor is 192.168.0.1, remote AS 65001, local AS 65002, external link
   Local host: 192.168.0.2, Local port: 1790
   Foreign host: 192.168.0.1, Foreign port: 38766

--- a/book/src/ch-02-26-bgp-neighbor-group.md
+++ b/book/src/ch-02-26-bgp-neighbor-group.md
@@ -162,18 +162,18 @@ until the group definition lands.
 
 ## Verification
 
-`show ip bgp neighbor-group` lists every group with a member count;
+`show bgp neighbor-group` lists every group with a member count;
 the detail form shows every configured knob and which peers reference
 it:
 
 ```
-show ip bgp neighbor-group
+show bgp neighbor-group
 Name                      Remote-AS  Members
 RR                            65001        2
 ```
 
 ```
-show ip bgp neighbor-group RR
+show bgp neighbor-group RR
 BGP neighbor-group: RR
   Remote-AS: 65001
   Afi-Safi:  ipv4 enabled nhs, ipv6 enabled
@@ -188,7 +188,7 @@ BGP neighbor-group: RR
 per-neighbor `remote-as`. Both commands also have `--json` forms; the
 JSON carries the same `afi_safi` map keyed by family name.
 
-On the member side, `show ip bgp neighbors` reports the binding:
+On the member side, `show bgp neighbors` reports the binding:
 
 ```
   Neighbor-group: RR (remote-as inherited)
@@ -203,7 +203,7 @@ On the member side, `show ip bgp neighbors` reports the binding:
 - **An afi-safi flip "did nothing".** Capability changes wait for the
   next OPEN exchange by design. `clear bgp ipv4 neighbor <X>` the
   member and re-check the `Neighbor Capabilities:` section of
-  `show ip bgp neighbors`.
+  `show bgp neighbors`.
 - **One member ignores the group's family setting.** That member has
   its own `afi-safi <family> enabled` statement, which outranks the
   group. Delete the per-neighbor leaf to fall back to inheritance.

--- a/book/src/ch-02-27-bgp-unnumbered.md
+++ b/book/src/ch-02-27-bgp-unnumbered.md
@@ -37,7 +37,7 @@ How a session comes up:
 
 The discovered link-local is not something an operator can type, so
 the interface name is the peer's CLI identity throughout:
-`show ip bgp neighbors i1`, `clear bgp ipv4 neighbor i1`, and the
+`show bgp neighbors i1`, `clear bgp ipv4 neighbor i1`, and the
 `Neighbor` column of `show bgp summary` all use it.
 
 ## remote-as forms
@@ -119,7 +119,7 @@ their own schedule, so allow up to ~16 seconds for first discovery.
 Once both ends have applied the configuration:
 
 ```
-show ip bgp neighbors i1
+show bgp neighbors i1
 BGP neighbor on i1: fe80::8080:9fff:fef9:3fa, remote AS 65001, local AS 65001, internal link
   Local host: fe80::c49d:fbff:fe08:b421, Local port: 35086
   Foreign host: fe80::8080:9fff:fef9:3fa, Foreign port: 179
@@ -136,10 +136,10 @@ BGP neighbor on i1: fe80::8080:9fff:fef9:3fa, remote AS 65001, local AS 65001, i
 ```
 
 Both families negotiated, and both tables carry the neighbor's
-prefixes — `show ip bgp` holds `10.0.1.2/32` (learned via ENHE with a
+prefixes — `show bgp` holds `10.0.1.2/32` (learned via ENHE with a
 link-local next hop) and `show bgp ipv6` holds `2001:db8:1::2/128`.
 The unnumbered peer appears as `i1` in `show bgp summary`, and as a
-member in `show ip bgp neighbor-group dynamic`.
+member in `show bgp neighbor-group dynamic`.
 
 ## Changing the family set at runtime
 
@@ -161,12 +161,12 @@ clear bgp ipv4 neighbor i1
 
 The re-established session advertises only IPv6 unicast — the
 `IPv4 Unicast:` capability line is gone from
-`show ip bgp neighbors i1`, the IPv4 routes learned from the peer were
+`show bgp neighbors i1`, the IPv4 routes learned from the peer were
 withdrawn with the old session and do not return, and the IPv6 routes
 re-sync immediately:
 
 ```
-show ip bgp neighbor-group dynamic
+show bgp neighbor-group dynamic
 BGP neighbor-group: dynamic
   Remote-AS: (unset)
   Afi-Safi:  ipv4 disabled, ipv6 enabled

--- a/book/src/ch-02-28-bgp-table-map.md
+++ b/book/src/ch-02-28-bgp-table-map.md
@@ -17,7 +17,7 @@ installed. `table-map` inserts a policy at exactly that boundary:
 
 A **deny** keeps the route out of the kernel; permit-side **set**
 clauses rewrite the installed entry. Either way the Loc-RIB and what
-peers receive are completely untouched — `show ip bgp` still shows the
+peers receive are completely untouched — `show bgp` still shows the
 route as best, and downstream neighbors still learn it. This is the
 same separation of reachability information from forwarding decision
 described in
@@ -149,7 +149,7 @@ $ ip -6 route show 2001:db8:200::/48
 
 **Install-time only.** The policy runs on a transient copy of the best
 path each time it is (re)installed. The Loc-RIB original is never
-modified, so best-path selection, `show ip bgp` output, and
+modified, so best-path selection, `show bgp` output, and
 advertisements to peers are identical with and without the table-map.
 
 **Useful set clauses.** At the install boundary only attributes that
@@ -186,7 +186,7 @@ The signature of a working table-map is the *disagreement* between the
 BGP table and the kernel:
 
 ```
-show ip bgp
+show bgp
 ```
 
 still lists `1.1.1.1/32` as a valid best path (`*>`), while the kernel

--- a/book/src/ch-02-29-bgp-ip-transparent.md
+++ b/book/src/ch-02-29-bgp-ip-transparent.md
@@ -103,7 +103,7 @@ Semantics worth knowing:
 
 ## Verification
 
-`show ip bgp neighbor <addr>` reports the active policy:
+`show bgp neighbors <addr>` reports the active policy:
 
 ```
   IP transparent enabled (session may use a non-local update-source address)

--- a/book/src/ch-02-30-bgp-local-as.md
+++ b/book/src/ch-02-30-bgp-local-as.md
@@ -150,12 +150,12 @@ The fastest check is the peer's view. On an FRR neighbor configured
 with `remote-as 64999`:
 
 ```
-show bgp neighbor 192.168.1.3   # remote AS shows 64999, session Established
-show ip bgp 10.0.0.0/24         # AS_PATH begins 64999 …
+show bgp neighbors 192.168.1.3   # remote AS shows 64999, session Established
+show bgp 10.0.0.0/24         # AS_PATH begins 64999 …
 ```
 
-On the local router, `show ip bgp neighbor <addr>` reports the
-substitute AS for the session, and `show ip bgp <prefix>` on a route
+On the local router, `show bgp neighbors <addr>` reports the
+substitute AS for the session, and `show bgp <prefix>` on a route
 learned from the neighbor shows whether the ingress prepend is active
 (`64999` leading the path, unless `no-prepend true`).
 

--- a/book/src/ch-06-00-vty-access.md
+++ b/book/src/ch-06-00-vty-access.md
@@ -120,7 +120,7 @@ vtyctl show 'show ip route'
 ip netns exec vrf-red vtyctl show 'show ip route'
 
 # Remote TCP
-vtyctl show --host tcp://router.example.com:2666 'show ip bgp'
+vtyctl show --host tcp://router.example.com:2666 'show bgp'
 
 # Legacy bare hostname (back-compat)
 vtyctl show --host 127.0.0.1 'show ip route'


### PR DESCRIPTION
## Summary

Follow-up to #1466, which dropped the `ip` prefix from the `show ip bgp …` command tree. This updates the mdBook BGP chapters to match the merged grammar.

- Renamed `show ip bgp …` → `show bgp …` across **19 BGP chapters** (45 references).
- **Pluralized the singular neighbor form**: `show bgp neighbor <addr>` → `show bgp neighbors <addr>`. This is a correctness fix, not cosmetic — #1466 placed the `neighbors` and `neighbor-group` lists in the same `show bgp` subtree, so the singular abbreviation `show bgp neighbor <addr>` now parses as **`Ambiguous`** (verified against the parser); only the canonical plural list name resolves.
- Left untouched: `neighbor-group` forms, and the unrelated `clear bgp ipv4 neighbor` config command (separate grammar).
- One FRR-side example was pluralized too, for chapter consistency (FRR accepts the plural form).

All documented command forms parse under the current grammar, including the newly-real `show bgp labeled-unicast` (its YANG node was added in #1466).

## Test plan

- `mdbook build` — clean
- Verified via the parser that singular `show bgp neighbor <addr>` is `Ambiguous` and plural `show bgp neighbors <addr>` resolves to `/show/bgp/neighbors`
- Docs-only change; no code touched

Generated with [Claude Code](https://claude.com/claude-code)