### PR TITLE
fib: gate netlink route/nexthop info logs behind system tracing flags

### DIFF
--- a/zebra-rs/src/fib/netlink/handle.rs
+++ b/zebra-rs/src/fib/netlink/handle.rs
@@ -506,13 +506,15 @@ impl FibHandle {
                     continue;
                 }
                 ok = false;
-                tracing::info!(
-                    "NewRoute error: {prefix} {e} table={table_id} rtype={:?} metric={} use_nhid={} nh={}",
-                    entry.rtype,
-                    entry.metric,
-                    self.use_nhid,
-                    fmt_nexthop_for_trace(nexthop),
-                );
+                if fib_route() {
+                    tracing::info!(
+                        "NewRoute error: {prefix} {e} table={table_id} rtype={:?} metric={} use_nhid={} nh={}",
+                        entry.rtype,
+                        entry.metric,
+                        self.use_nhid,
+                        fmt_nexthop_for_trace(nexthop),
+                    );
+                }
             }
         }
         ok
@@ -653,7 +655,9 @@ impl FibHandle {
 
         let mut response = self.handle.clone().request(req).unwrap();
         while let Some(msg) = response.next().await {
-            if let NetlinkPayload::Error(e) = msg.payload {
+            if let NetlinkPayload::Error(e) = msg.payload
+                && fib_route()
+            {
                 tracing::info!(
                     "DelRoute error: {prefix} {e} table={table_id} rtype={:?} metric={} use_nhid={} nh={}",
                     entry.rtype,
@@ -903,11 +907,13 @@ impl FibHandle {
                     continue;
                 }
                 ok = false;
-                tracing::info!(
-                    "NewRoute IPv6 error: {prefix} {e} use_nhid={} nh={}",
-                    self.use_nhid,
-                    fmt_nexthop_for_trace(nexthop),
-                );
+                if fib_route() {
+                    tracing::info!(
+                        "NewRoute IPv6 error: {prefix} {e} use_nhid={} nh={}",
+                        self.use_nhid,
+                        fmt_nexthop_for_trace(nexthop),
+                    );
+                }
             }
         }
         ok
@@ -1316,10 +1322,12 @@ impl FibHandle {
         while let Some(msg) = response.next().await {
             match msg.payload {
                 NetlinkPayload::Error(e) => {
-                    tracing::info!(
-                        "NewNexthop error: {e} gid: {gid} refcnt: {refcnt} {}",
-                        group_summary,
-                    );
+                    if fib_nexthop() {
+                        tracing::info!(
+                            "NewNexthop error: {e} gid: {gid} refcnt: {refcnt} {}",
+                            group_summary,
+                        );
+                    }
                 }
                 // Non-error payloads here are mostly the RTNLGRP_NEXTHOP
                 // multicast echoes the kernel delivers on the shared
@@ -1373,7 +1381,9 @@ impl FibHandle {
 
         let mut response = self.handle.clone().request(req).unwrap();
         while let Some(msg) = response.next().await {
-            if let NetlinkPayload::Error(e) = msg.payload {
+            if let NetlinkPayload::Error(e) = msg.payload
+                && fib_nexthop()
+            {
                 tracing::info!(
                     "DelNexthop error: {e} gid: {gid} refcnt: {refcnt} nhop: {nexthop:?}",
                     gid = nexthop.gid(),


### PR DESCRIPTION
## Summary

The NewRoute/DelRoute (IPv4 + IPv6) and NewNexthop/DelNexthop netlink-error logs in `fib/netlink/handle.rs` were emitted unconditionally at `info` level, spamming production logs on every install/delete failure.

This gates those five sites behind the existing `system tracing fib { route | nexthop }` toggles:

| Site | Function | Flag |
|------|----------|------|
| `NewRoute error` | `route_ipv4_add_uni` | `fib_route()` |
| `DelRoute error` | `route_ipv4_del_uni` | `fib_route()` |
| `NewRoute IPv6 error` | `route_ipv6_add_uni` | `fib_route()` |
| `NewNexthop error` | `nexthop_add` | `fib_nexthop()` |
| `DelNexthop error` | `nexthop_del` | `fib_nexthop()` |

For the `add` paths only the `tracing::info!` is wrapped (the `ok = false` control flow stays outside the gate); for the `del` paths the toggle is folded into the existing `if let` let-chain, matching the pattern the v6-del path (`route_ipv6_del_uni`) already uses. `fib_route`/`fib_nexthop` were already imported.

Other unconditional `info!` logs in this file (SID-uninstall/srv6, MPLS ilm/label, fdb/l2, address/link) are intentionally left out of scope.

## Test plan

- `cargo check -p zebra-rs` — clean
- `cargo clippy -p zebra-rs --all-targets -- -D warnings` — clean
- `cargo fmt -p zebra-rs` — no diff

Generated with [Claude Code](https://claude.com/claude-code)