### PR TITLE
isis: originate per-algorithm SRv6 End.X (adjacency) SIDs

### DIFF
--- a/docs/design/isis-flexalgo-srv6-plan.md
+++ b/docs/design/isis-flexalgo-srv6-plan.md
@@ -85,13 +85,35 @@ Per-algo fast-reroute for the SRv6 dataplane:
   per-algo locator route; ECMP routes are self-protecting; a repair
   whose segments can't all resolve is dropped (no partial install).
 
-Deferred follow-ups: per-algo End.X SID origination (emit
-`Srv6EndXSid`/`Srv6LanEndXSid` with Algorithm=N, so adj segments use
-algo-N End.X too — a refinement, not a correctness fix); SRv6 L3VPN
-colour steering; and a TI-LFA BDD (the PR-6 `isis_flex_srv6` topology
-has no intra-algo redundancy to exercise a repair). The PR-6 BDD
-feature was authored but not executed here (needs root/netns; CI runs
-the bdd suite).
+**Per-algo End.X SID origination: implemented** (branch
+`isis-flexalgo-srv6-endx`, build/fmt/clippy/non-bdd tests green) — the
+refinement deferred from PR 8 so adjacency repair segments use algo-N
+End.X rather than reusing algo-0:
+
+- Each adjacency now derives a per-algo End.X SID from the *same* ELIB
+  function as the algo-0 End.X, placed under each per-algo locator's
+  prefix (`Neighbor::algo_endx_sids`, reconciled in
+  `reconcile_algo_endx_sids`) — no extra function allocation. Registered
+  in the FIB like algo-0 (main seg6local End.X + uSID LIB twin), released
+  with the algo-0 End.X.
+- Emitted as `Srv6EndXSid`/`Srv6LanEndXSid` with Algorithm=N at both the
+  main and MT2 IS-Reach emit sites (`srv6_algo_endx_subs`; behavior from
+  the per-algo locator via the refactored `srv6_{end,endx,sid}_structure`
+  helpers).
+- `srv6_endx_sid_for_link` now selects by algo (prefer Algorithm=N, fall
+  back to algo-0 `Spf`) — required once multiple End.X sub-TLVs are
+  advertised per adjacency; `build_repair_path_srv6` passes the repair's
+  algo through.
+- `LinkTop` carries the per-algo locator snapshots so the per-Hello
+  reconcile can derive the SIDs. Limitation: per-algo End.X requires a
+  base (algo-0) locator (the shared function source); without one, repair
+  adj segments fall back to nothing (node-segment repairs only).
+
+Remaining deferred follow-ups: SRv6 L3VPN colour steering (prepend the
+End SID before the End.DT4/DT6 service SID); and a TI-LFA BDD (the PR-6
+`isis_flex_srv6` topology has no intra-algo redundancy to exercise a
+repair). The PR-6 BDD feature was authored but not executed here (needs
+root/netns; CI runs the bdd suite).
 
 ## Decisions (locked 2026-06-16)
 

--- a/zebra-rs/src/isis/inst.rs
+++ b/zebra-rs/src/isis/inst.rs
@@ -2902,6 +2902,8 @@ impl Isis {
             rib_client: &self.ctx.rib,
             sr_locator: &self.sr_locator,
             watched_locator: &self.watched_locator,
+            sr_flex_algo_locators: &self.sr_flex_algo_locators,
+            watched_flex_algo_locators: &self.watched_flex_algo_locators,
             elib: &mut self.elib,
             key_chains: &self.key_chains,
         })

--- a/zebra-rs/src/isis/link.rs
+++ b/zebra-rs/src/isis/link.rs
@@ -179,6 +179,11 @@ pub struct LinkTop<'a> {
     pub rib_client: &'a crate::rib::client::RibClient,
     pub sr_locator: &'a Option<crate::rib::Locator>,
     pub watched_locator: &'a Option<String>,
+    /// Per-Flex-Algorithm locator snapshots + watched names (mirrors
+    /// `IsisTop`). The End.X reconcile derives a per-algo End.X SID from
+    /// the algo-0 ELIB function under each of these locators' prefixes.
+    pub sr_flex_algo_locators: &'a std::collections::BTreeMap<u8, crate::rib::Locator>,
+    pub watched_flex_algo_locators: &'a std::collections::BTreeMap<u8, String>,
     pub elib: &'a mut crate::isis::srv6::ElibPool,
     /// Read-only snapshot of the policy-driven key-chain registry
     /// (mirrors `IsisTop::key_chains`). Hello / CSNP / PSNP sign +

--- a/zebra-rs/src/isis/lsp.rs
+++ b/zebra-rs/src/isis/lsp.rs
@@ -460,39 +460,84 @@ pub fn dis_generate(
     fragments
 }
 
-/// SRv6 End-SID endpoint behavior + SID Structure sub-sub-TLV
-/// (RFC 9352 §9) for one locator, keyed off the locator's behavior.
-/// Classic locators advertise the `End` codepoint (LB caps at 40);
-/// uSID locators advertise `EndCSID` / uN (LB caps at 32). Mirrors the
-/// per-LSP computation done for the base locator, but as a reusable
-/// helper so each per-Flex-Algorithm locator gets its own structure.
-fn srv6_end_structure(locator: &Locator) -> (Behavior, Vec<IsisSub2Tlv>) {
-    let Some(prefix) = locator.prefix else {
-        return (Behavior::End, Vec::new());
-    };
+/// SID Structure sub-sub-TLV (RFC 9352 §9) for one locator: `Some`
+/// pair `(is_usid, [structure])` when the locator has a prefix, `None`
+/// when it doesn't (no structure to advertise). uSID locators cap LB at
+/// 32, classic at 40; function is 16 bits (what `function_addr` places),
+/// argument 0.
+fn srv6_sid_structure(locator: &Locator) -> Option<(bool, Vec<IsisSub2Tlv>)> {
+    let prefix = locator.prefix?;
     let plen = prefix.prefix_len();
-    match &locator.behavior {
-        Some(LocatorBehavior::Usid) => {
-            let lb_len = plen.min(32);
-            let structure = IsisSub2Tlv::SidStructure(IsisSub2SidStructure {
-                lb_len,
-                ln_len: plen.saturating_sub(lb_len),
-                fun_len: 16,
-                arg_len: 0,
-            });
-            (Behavior::EndCSID, vec![structure])
-        }
-        None => {
-            let lb_len = plen.min(40);
-            let structure = IsisSub2Tlv::SidStructure(IsisSub2SidStructure {
-                lb_len,
-                ln_len: plen.saturating_sub(lb_len),
-                fun_len: 16,
-                arg_len: 0,
-            });
-            (Behavior::End, vec![structure])
+    let is_usid = matches!(locator.behavior, Some(LocatorBehavior::Usid));
+    let lb_len = if is_usid { plen.min(32) } else { plen.min(40) };
+    let structure = IsisSub2Tlv::SidStructure(IsisSub2SidStructure {
+        lb_len,
+        ln_len: plen.saturating_sub(lb_len),
+        fun_len: 16,
+        arg_len: 0,
+    });
+    Some((is_usid, vec![structure]))
+}
+
+/// SRv6 End-SID endpoint behavior + SID Structure for one locator
+/// (RFC 9352 §9). Classic → `End`; uSID → `EndCSID` (uN). Per-locator so
+/// each per-Flex-Algorithm locator gets its own structure.
+fn srv6_end_structure(locator: &Locator) -> (Behavior, Vec<IsisSub2Tlv>) {
+    match srv6_sid_structure(locator) {
+        Some((true, subs)) => (Behavior::EndCSID, subs),
+        Some((false, subs)) => (Behavior::End, subs),
+        None => (Behavior::End, Vec::new()),
+    }
+}
+
+/// SRv6 End.X SID endpoint behavior + SID Structure for one locator
+/// (RFC 9352 §8/§9). Classic → `EndX`; uSID → `EndXCSID` (uA). The
+/// End.X sibling of `srv6_end_structure`.
+fn srv6_endx_structure(locator: &Locator) -> (Behavior, Vec<IsisSub2Tlv>) {
+    match srv6_sid_structure(locator) {
+        Some((true, subs)) => (Behavior::EndXCSID, subs),
+        Some((false, subs)) => (Behavior::EndX, subs),
+        None => (Behavior::EndX, Vec::new()),
+    }
+}
+
+/// Per-Flexible-Algorithm SRv6 End.X (adjacency) sub-TLVs for one
+/// neighbor (RFC 9352 §8, Algorithm = N). One per entry in
+/// `nbr.algo_endx_sids` whose per-algo locator is still resolved; the
+/// behavior / structure come from that algo's locator. P2P emits
+/// `Srv6EndXSid`, LAN emits `Srv6LanEndXSid`.
+fn srv6_algo_endx_subs(
+    nbr: &super::neigh::Neighbor,
+    flex_algo_locators: &std::collections::BTreeMap<u8, Locator>,
+) -> Vec<neigh::IsisSubTlv> {
+    let mut subs = Vec::new();
+    for (algo, endx) in nbr.algo_endx_sids.iter() {
+        let Some(locator) = flex_algo_locators.get(algo) else {
+            continue;
+        };
+        let (behavior, sub2s) = srv6_endx_structure(locator);
+        if nbr.network_type.is_p2p() {
+            subs.push(neigh::IsisSubTlv::Srv6EndXSid(IsisSubSrv6EndXSid {
+                flags: 0,
+                algo: Algo::FlexAlgo(*algo),
+                weight: 0,
+                behavior,
+                sid: endx.addr,
+                sub2s,
+            }));
+        } else {
+            subs.push(neigh::IsisSubTlv::Srv6LanEndXSid(IsisSubSrv6LanEndXSid {
+                system_id: nbr.sys_id,
+                flags: 0,
+                algo: Algo::FlexAlgo(*algo),
+                weight: 0,
+                behavior,
+                sid: endx.addr,
+                sub2s,
+            }));
         }
     }
+    subs
 }
 
 pub fn lsp_generate(top: &mut IsisTop, level: Level, seq_floor: Option<u32>) -> Vec<IsisLsp> {
@@ -942,6 +987,14 @@ pub fn lsp_generate(top: &mut IsisTop, level: Level, seq_floor: Option<u32>) -> 
                     is_reach.subs.push(neigh::IsisSubTlv::Srv6LanEndXSid(sub));
                 }
             }
+
+            // Per-Flex-Algorithm End.X (adjacency) SIDs (RFC 9352 §8,
+            // Algorithm = N) — derived from the algo-0 function under
+            // each per-algo locator; lets a peer's per-algo TI-LFA use
+            // algo-N adjacency segments.
+            is_reach
+                .subs
+                .extend(srv6_algo_endx_subs(nbr, top.sr_flex_algo_locators));
         }
 
         ext_is_reach.entries.push(is_reach);
@@ -1102,6 +1155,11 @@ pub fn lsp_generate(top: &mut IsisTop, level: Level, seq_floor: Option<u32>) -> 
                         entry.subs.push(neigh::IsisSubTlv::Srv6LanEndXSid(sub));
                     }
                 }
+
+                // Per-Flex-Algorithm End.X (adjacency) SIDs (Algorithm = N).
+                entry
+                    .subs
+                    .extend(srv6_algo_endx_subs(nbr, top.sr_flex_algo_locators));
             }
             mt2_entries.push(entry);
         }

--- a/zebra-rs/src/isis/neigh.rs
+++ b/zebra-rs/src/isis/neigh.rs
@@ -19,6 +19,15 @@ use super::link::NetworkType;
 use super::nfsm::NfsmState;
 use super::{Isis, Level, Message, NeighborAddr4};
 
+/// One per-Flexible-Algorithm End.X SID held against an adjacency: the
+/// full SID address (under the algo's locator) plus the optional uSID
+/// LIB-twin address. Both are FIB-registered and withdrawn in lockstep.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AlgoEndxSid {
+    pub addr: Ipv6Addr,
+    pub lib_addr: Option<Ipv6Addr>,
+}
+
 // IS-IS Neighbor
 #[derive(Debug)]
 pub struct Neighbor {
@@ -67,6 +76,17 @@ pub struct Neighbor {
     /// when [`Neighbor::endx_nh6`] stops matching this.
     pub endx_installed_nh6: Option<Ipv6Addr>,
 
+    /// Per-Flexible-Algorithm End.X (adjacency) SIDs, keyed by algo
+    /// (128..=255). Each is derived from the *same* ELIB function as
+    /// `endx_sid` but placed under that algo's own locator prefix, so no
+    /// extra function allocation is needed — a different locator gives a
+    /// different SID address for the same function. Emitted with
+    /// Algorithm=N (RFC 9352 §8) so a peer's per-algo TI-LFA can use
+    /// algo-N adjacency segments, and registered in the FIB exactly like
+    /// the algo-0 End.X. `lib_addr` is the uSID LIB twin (carrier
+    /// resolution), `None` for classic locators.
+    pub algo_endx_sids: BTreeMap<u8, AlgoEndxSid>,
+
     /// Graceful Restart observation (RFC 5306). Records the peer's
     /// most recent Restart TLV and drives helper-side behavior
     /// (refresh hold once, send RA, suppress teardown).
@@ -105,6 +125,7 @@ impl Neighbor {
             endx_sid: None,
             endx_lib_sid: None,
             endx_installed_nh6: None,
+            algo_endx_sids: BTreeMap::new(),
             gr: AdjGrState::default(),
             created: true,
         }
@@ -190,19 +211,23 @@ impl Neighbor {
     /// neighbor's protocols / addresses), so a change in the neighbor's
     /// IPv6 capability is picked up at the next Hello and, if the
     /// adjacency is Up, the LSP re-originated immediately.
+    #[allow(clippy::too_many_arguments)]
     pub fn reconcile_endx_sid(
         &mut self,
         ifname: &str,
         sr_locator: &Option<Locator>,
         watched_locator: &Option<String>,
+        flex_algo_locators: &BTreeMap<u8, Locator>,
+        watched_flex_algo_locators: &BTreeMap<u8, String>,
         elib: &mut ElibPool,
         rib_client: &crate::rib::client::RibClient,
     ) {
         if !self.endx_eligible() {
             // No IPv6 forwarding path to this neighbor (no IPv6 in its
             // Protocols Supported TLV, or no IPv6 link-local in its
-            // Hello). Drop any SID we previously allocated.
-            if self.endx_sid.is_some() {
+            // Hello). Drop any SID we previously allocated — algo-0 and
+            // every per-algo derivative.
+            if self.endx_sid.is_some() || !self.algo_endx_sids.is_empty() {
                 self.release_endx_sid(elib, rib_client);
                 self.reoriginate_endx_if_up();
             }
@@ -222,43 +247,221 @@ impl Neighbor {
         // nexthop is always present here. See `endx_nh6` for why a
         // global is preferred over the link-local.
         let nh6 = self.endx_nh6();
+        // Whether the preferred nexthop drifted since the last install;
+        // drives a del-then-add of the algo-0 *and* per-algo End.X.
+        let nh6_changed = self.endx_installed_nh6 != nh6;
 
-        if let Some((function, addr)) = self.endx_sid {
+        let mut reoriginate = false;
+
+        // --- algo-0 (base) End.X — unchanged behavior, but we keep the
+        // allocated function to derive the per-algo SIDs below.
+        let function = if let Some((function, addr)) = self.endx_sid {
             // SID already allocated. The SID address never changes for
             // the life of the adjacency, but the preferred nexthop can
             // (the neighbor's first Hello often carries only the
             // link-local; a global learned later must upgrade the FIB
             // entry). Delete-then-add rather than a bare re-add so the
             // RIB walks back the old nexthop-group reference.
-            if self.endx_installed_nh6 == nh6 {
-                return;
+            if nh6_changed {
+                let sid = self.endx_sid_entry(ifname, locator, loc_name.clone(), addr, nh6);
+                let _ = rib_client.send(rib::Message::SidDel { addr });
+                let _ = rib_client.send(rib::Message::SidAdd { sid });
+                self.reconcile_endx_lib_sid(
+                    ifname,
+                    locator,
+                    loc_name.clone(),
+                    prefix,
+                    function,
+                    nh6,
+                    rib_client,
+                );
+                self.endx_installed_nh6 = nh6;
             }
+            function
+        } else {
+            let Some(function) = elib.allocate() else {
+                return;
+            };
+            let Some(addr) = function_addr(prefix, function) else {
+                // Prefix too long for a 16-bit function — release the
+                // function so we don't pin it forever.
+                elib.release(function);
+                return;
+            };
             let sid = self.endx_sid_entry(ifname, locator, loc_name.clone(), addr, nh6);
-            let _ = rib_client.send(rib::Message::SidDel { addr });
             let _ = rib_client.send(rib::Message::SidAdd { sid });
             self.reconcile_endx_lib_sid(
-                ifname, locator, loc_name, prefix, function, nh6, rib_client,
+                ifname,
+                locator,
+                loc_name.clone(),
+                prefix,
+                function,
+                nh6,
+                rib_client,
             );
+            self.endx_sid = Some((function, addr));
             self.endx_installed_nh6 = nh6;
-            // The advertised SID is unchanged — no LSP re-origination.
-            return;
+            reoriginate = true;
+            function
+        };
+
+        // --- per-Flex-Algorithm End.X, sharing the algo-0 `function`
+        // under each per-algo locator's prefix.
+        if self.reconcile_algo_endx_sids(
+            ifname,
+            function,
+            nh6,
+            nh6_changed,
+            flex_algo_locators,
+            watched_flex_algo_locators,
+            rib_client,
+        ) {
+            reoriginate = true;
         }
 
-        let Some(function) = elib.allocate() else {
-            return;
-        };
-        let Some(addr) = function_addr(prefix, function) else {
-            // Prefix too long for a 16-bit function — release the
-            // function so we don't pin it forever.
-            elib.release(function);
-            return;
-        };
-        let sid = self.endx_sid_entry(ifname, locator, loc_name.clone(), addr, nh6);
-        let _ = rib_client.send(rib::Message::SidAdd { sid });
-        self.reconcile_endx_lib_sid(ifname, locator, loc_name, prefix, function, nh6, rib_client);
-        self.endx_sid = Some((function, addr));
-        self.endx_installed_nh6 = nh6;
-        self.reoriginate_endx_if_up();
+        if reoriginate {
+            self.reoriginate_endx_if_up();
+        }
+    }
+
+    /// Reconcile the per-Flex-Algorithm End.X SIDs to the set of
+    /// resolved per-algo locators, all sharing the algo-0 `function`.
+    /// Returns `true` when the *advertised* set changed (an algo SID was
+    /// added/removed or its address moved) so the caller re-originates;
+    /// a nexthop-only re-install returns `false` (the advertised SID is
+    /// unchanged). Mirrors `reconcile_endx_sid` / `reconcile_endx_lib_sid`
+    /// for each per-algo locator.
+    #[allow(clippy::too_many_arguments)]
+    fn reconcile_algo_endx_sids(
+        &mut self,
+        ifname: &str,
+        function: u16,
+        nh6: Option<Ipv6Addr>,
+        nh6_changed: bool,
+        flex_algo_locators: &BTreeMap<u8, Locator>,
+        watched_flex_algo_locators: &BTreeMap<u8, String>,
+        rib_client: &crate::rib::client::RibClient,
+    ) -> bool {
+        let mut changed = false;
+
+        // Release per-algo SIDs whose locator is no longer resolved
+        // (algo removed from config, or its locator lost its prefix).
+        let resolvable: BTreeSet<u8> = flex_algo_locators
+            .iter()
+            .filter(|(algo, loc)| {
+                loc.prefix.is_some() && watched_flex_algo_locators.contains_key(algo)
+            })
+            .map(|(algo, _)| *algo)
+            .collect();
+        let stale: Vec<u8> = self
+            .algo_endx_sids
+            .keys()
+            .filter(|algo| !resolvable.contains(algo))
+            .copied()
+            .collect();
+        for algo in stale {
+            if let Some(s) = self.algo_endx_sids.remove(&algo) {
+                let _ = rib_client.send(rib::Message::SidDel { addr: s.addr });
+                if let Some(lib) = s.lib_addr {
+                    let _ = rib_client.send(rib::Message::SidDel { addr: lib });
+                }
+                changed = true;
+            }
+        }
+
+        for (algo, locator) in flex_algo_locators {
+            let Some(prefix) = locator.prefix else {
+                continue;
+            };
+            let Some(loc_name) = watched_flex_algo_locators.get(algo).cloned() else {
+                continue;
+            };
+            let Some(addr) = function_addr(prefix, function) else {
+                continue;
+            };
+
+            let addr_changed = self
+                .algo_endx_sids
+                .get(algo)
+                .map(|s| s.addr != addr)
+                .unwrap_or(true);
+            if !addr_changed && !nh6_changed {
+                continue;
+            }
+
+            // Withdraw the previous SID + LIB twin before re-adding.
+            if let Some(s) = self.algo_endx_sids.remove(algo) {
+                let _ = rib_client.send(rib::Message::SidDel { addr: s.addr });
+                if let Some(lib) = s.lib_addr {
+                    let _ = rib_client.send(rib::Message::SidDel { addr: lib });
+                }
+            }
+
+            // Main End.X registration; behavior from the per-algo
+            // locator (uA for uSID, End.X for classic).
+            let (behavior, structure) = match locator.behavior {
+                Some(crate::rib::LocatorBehavior::Usid) => {
+                    (SidBehavior::UA, locator.sid_structure())
+                }
+                None => (SidBehavior::EndX, None),
+            };
+            let sid = Sid {
+                addr,
+                behavior,
+                context: SidContext::Interface(ifname.to_string()),
+                owner: SidOwner::new("isis", 0),
+                locator: loc_name.clone(),
+                allocation_type: SidAllocationType::Dynamic,
+                ifindex: self.ifindex,
+                nh6,
+                structure,
+                table_id: 0,
+                segs: Vec::new(),
+            };
+            let _ = rib_client.send(rib::Message::SidAdd { sid });
+
+            // uSID LIB twin (carrier resolution), mirroring
+            // `reconcile_endx_lib_sid`. Classic locators have none.
+            let lib_twin = if matches!(locator.behavior, Some(crate::rib::LocatorBehavior::Usid)) {
+                locator
+                    .sid_structure()
+                    .and_then(|st| lib_addr(prefix, st.lb_bits, function).map(|la| (la, st)))
+                    .map(|(la, st)| {
+                        let lib_sid = Sid {
+                            addr: la,
+                            behavior: SidBehavior::UALib,
+                            context: SidContext::Interface(ifname.to_string()),
+                            owner: SidOwner::new("isis", 0),
+                            locator: loc_name.clone(),
+                            allocation_type: SidAllocationType::Dynamic,
+                            ifindex: self.ifindex,
+                            nh6,
+                            structure: Some(st),
+                            table_id: 0,
+                            segs: Vec::new(),
+                        };
+                        let _ = rib_client.send(rib::Message::SidAdd { sid: lib_sid });
+                        la
+                    })
+            } else {
+                None
+            };
+
+            // A newly-added algo or a moved address changes the
+            // advertised set; a nexthop-only re-install does not.
+            if addr_changed {
+                changed = true;
+            }
+            self.algo_endx_sids.insert(
+                *algo,
+                AlgoEndxSid {
+                    addr,
+                    lib_addr: lib_twin,
+                },
+            );
+        }
+
+        changed
     }
 
     /// (Re-)install the LIB twin of this neighbor's uA — the
@@ -351,6 +554,14 @@ impl Neighbor {
         }
         if let Some(addr) = self.endx_lib_sid.take() {
             let _ = rib_client.send(rib::Message::SidDel { addr });
+        }
+        // Per-algo End.X SIDs share the algo-0 function (freed above);
+        // just withdraw their FIB entries + LIB twins.
+        for (_, s) in std::mem::take(&mut self.algo_endx_sids) {
+            let _ = rib_client.send(rib::Message::SidDel { addr: s.addr });
+            if let Some(lib) = s.lib_addr {
+                let _ = rib_client.send(rib::Message::SidDel { addr: lib });
+            }
         }
     }
 }

--- a/zebra-rs/src/isis/packet.rs
+++ b/zebra-rs/src/isis/packet.rs
@@ -452,6 +452,8 @@ pub fn hello_recv(link: &mut LinkTop, level: Level, pdu: IsisHello, mac: Option<
         &ifname,
         link.sr_locator,
         link.watched_locator,
+        link.sr_flex_algo_locators,
+        link.watched_flex_algo_locators,
         link.elib,
         link.rib_client,
     );
@@ -710,6 +712,8 @@ pub fn hello_p2p_recv(link: &mut LinkTop, pdu: IsisP2pHello, mac: Option<MacAddr
             &ifname,
             link.sr_locator,
             link.watched_locator,
+            link.sr_flex_algo_locators,
+            link.watched_flex_algo_locators,
             link.elib,
             link.rib_client,
         );

--- a/zebra-rs/src/isis/rib.rs
+++ b/zebra-rs/src/isis/rib.rs
@@ -1702,11 +1702,10 @@ fn build_rib6_from_flex_algo(
         // Per-algo TI-LFA backup. Single-nexthop only (an ECMP route is
         // already self-protecting), mirroring `build_rib_from_spf`. Node
         // segments resolve to algo-N End SIDs so the repair stays in the
-        // algo-N topology; adjacency segments reuse the algo-0 End.X
-        // (the final single hop into the repair link). A repair whose
-        // segments can't all resolve (e.g. the origin hasn't advertised
-        // an algo-N End SID for a node hop) is dropped rather than
-        // installed partial.
+        // algo-N topology; adjacency segments prefer the peer's algo-N
+        // End.X (falling back to algo-0). A repair whose segments can't
+        // all resolve (e.g. the origin hasn't advertised an algo-N End
+        // SID for a node hop) is dropped rather than installed partial.
         if route.nhops.len() == 1
             && let Some(repair) = tilfa.get(node).and_then(|paths| paths.first())
             && let Some(backup) = build_repair_path_srv6(top, level, Some(algo), repair)

--- a/zebra-rs/src/isis/tilfa.rs
+++ b/zebra-rs/src/isis/tilfa.rs
@@ -3,7 +3,7 @@ use std::net::{Ipv4Addr, Ipv6Addr};
 
 use isis_packet::neigh;
 use isis_packet::srv6::EncapType;
-use isis_packet::{IsisNeighborId, IsisSysId, IsisTlv, SidLabelValue};
+use isis_packet::{Algo, IsisNeighborId, IsisSysId, IsisTlv, SidLabelValue};
 
 use crate::rib;
 use crate::spf;
@@ -139,7 +139,7 @@ pub(super) fn build_repair_path_srv6(
                 })
             }
             spf::SrSegment::AdjSid(from, to, via) => {
-                srv6_endx_sid_for_link(top, level, *from, *to, *via).map(|endx| RepairSeg {
+                srv6_endx_sid_for_link(top, level, *from, *to, *via, algo).map(|endx| RepairSeg {
                     sid: endx.sid,
                     landing: *to,
                     csid: csid_bits_endx(&endx, *from),
@@ -196,9 +196,9 @@ pub(super) fn build_repair_path_srv6(
 /// inside the algo-N topology: each node-SID hop routes to that node's
 /// algo-N locator (installed by the per-algo IPv6 RIB build), so the
 /// repair traffic follows the algo-N constrained paths rather than the
-/// unconstrained algo-0 ones. Adjacency (End.X) segments stay algo-0:
-/// they are the final single-hop into the repair link, processed at the
-/// node the prior algo-N node-SID already delivered the packet to.
+/// unconstrained algo-0 ones. Adjacency (End.X) segments prefer the
+/// peer's algo-N End.X (see `srv6_endx_sid_for_link`) and fall back to
+/// the algo-0 End.X — the final single hop into the repair link.
 fn node_sid_info(
     top: &IsisTop,
     level: Level,
@@ -243,12 +243,20 @@ fn endx_structure(sub2s: &[isis_packet::IsisSub2Tlv]) -> Option<isis_packet::Isi
 /// `system_id` field identifies the LAN member; for P2P adjacencies
 /// the neighbor_id is `(to_sys, 0)` and any End.X sub-TLV under it
 /// qualifies (RFC 9352 §8.1 / §8.2).
+///
+/// `want` selects the algorithm: `None` (or no per-algo match found)
+/// returns the algo-0 (`Spf`) End.X; `Some(n)` prefers the
+/// Algorithm-`n` End.X and falls back to algo-0 when the advertiser
+/// hasn't originated a per-algo End.X (older peer). The advertiser now
+/// emits one End.X per algo, so this must filter by algo rather than
+/// taking the first.
 fn srv6_endx_sid_for_link(
     top: &IsisTop,
     level: Level,
     from_vertex: usize,
     to_vertex: usize,
     via_pseudonode: Option<usize>,
+    want: Option<u8>,
 ) -> Option<Srv6EndXInfo> {
     let from_sys = *top.lsp_map.get(&level).resolve(from_vertex)?;
     let target_neighbor_id = if let Some(via_v) = via_pseudonode {
@@ -257,6 +265,13 @@ fn srv6_endx_sid_for_link(
         let to_sys = *top.lsp_map.get(&level).resolve(to_vertex)?;
         IsisNeighborId::from_sys_id(&to_sys, 0)
     };
+    let to_sys = top.lsp_map.get(&level).resolve(to_vertex).copied();
+
+    // Preferred (algo-N) and fallback (algo-0) matches, collected over
+    // the whole walk so the order of End.X sub-TLVs doesn't matter.
+    let mut algo_n: Option<Srv6EndXInfo> = None;
+    let mut algo_0: Option<Srv6EndXInfo> = None;
+    let want = want.map(Algo::FlexAlgo);
 
     // Walk every non-pseudonode fragment originated by `from_sys` at
     // this level — with send-side LSP fragmentation the IS-reach
@@ -275,33 +290,41 @@ fn srv6_endx_sid_for_link(
                     continue;
                 }
                 for sub in &entry.subs {
-                    match sub {
-                        neigh::IsisSubTlv::Srv6EndXSid(endx) => {
-                            return Some(Srv6EndXInfo {
+                    let (algo, info) = match sub {
+                        neigh::IsisSubTlv::Srv6EndXSid(endx) => (
+                            endx.algo,
+                            Srv6EndXInfo {
                                 sid: endx.sid,
                                 behavior: endx.behavior,
                                 structure: endx_structure(&endx.sub2s),
-                            });
-                        }
+                            },
+                        ),
                         neigh::IsisSubTlv::Srv6LanEndXSid(lan_endx) => {
-                            let Some(to_sys) = top.lsp_map.get(&level).resolve(to_vertex) else {
+                            // LAN End.X identifies its member by system_id.
+                            if to_sys.as_ref() != Some(&lan_endx.system_id) {
                                 continue;
-                            };
-                            if &lan_endx.system_id == to_sys {
-                                return Some(Srv6EndXInfo {
+                            }
+                            (
+                                lan_endx.algo,
+                                Srv6EndXInfo {
                                     sid: lan_endx.sid,
                                     behavior: lan_endx.behavior,
                                     structure: endx_structure(&lan_endx.sub2s),
-                                });
-                            }
+                                },
+                            )
                         }
-                        _ => {}
+                        _ => continue,
+                    };
+                    if Some(algo) == want && algo_n.is_none() {
+                        algo_n = Some(info);
+                    } else if algo == Algo::Spf && algo_0.is_none() {
+                        algo_0 = Some(info);
                     }
                 }
             }
         }
     }
-    None
+    algo_n.or(algo_0)
 }
 
 /// Resolve a peer-advertised SID to an absolute MPLS label, using


### PR DESCRIPTION
## Summary

Originate per-Flexible-Algorithm SRv6 End.X (adjacency) SIDs so a peer's per-algo TI-LFA can use **algo-N adjacency segments** rather than falling back to the algo-0 End.X. The refinement deferred from the per-algo TI-LFA PR (#1469).

Each adjacency derives a per-algo End.X SID from the **same** ELIB function as its algo-0 End.X, placed under each per-algo locator's prefix — a different locator yields a different SID address for the same function, so no extra allocation is needed.

## What's in this PR

- `Neighbor::algo_endx_sids` + `reconcile_algo_endx_sids`: derive, FIB-register (main seg6local End.X + uSID LIB twin), del-then-add on nexthop drift, and release in lockstep with the algo-0 End.X. Driven every Hello off the resolved per-algo locators (`LinkTop` now carries the per-algo locator snapshots + names; `reconcile_endx_sid` gained the params; both `packet.rs` call sites updated).
- `lsp.rs`: emit `Srv6EndXSid` / `Srv6LanEndXSid` with Algorithm=N at the main and MT2 IS-Reach sites (`srv6_algo_endx_subs`); behavior/structure from the per-algo locator via the refactored `srv6_{sid,end,endx}_structure` helpers (classic → End.X, uSID → EndX.CSID/uA).
- `tilfa.rs`: `srv6_endx_sid_for_link` selects by algo (prefer Algorithm=N, fall back to algo-0 `Spf`) — required now that multiple End.X sub-TLVs are advertised per adjacency; `build_repair_path_srv6` threads the repair's algo through.

**Limitation:** per-algo End.X requires a base (algo-0) locator as the shared ELIB function source.

## Test plan

- `cargo build` / `cargo fmt --check` / `cargo clippy --workspace --all-targets -- -D warnings` — all clean.
- Full non-bdd suite green (1293 zebra-rs + 286 isis-packet tests, 0 failures). The End.X codec carries the Algorithm field (existing isis-packet coverage); the per-algo origination + algo-aware repair resolution are integration-validated like the rest of the SRv6 Flex-Algo work.

Generated with [Claude Code](https://claude.com/claude-code)