### PR TITLE
bgp: per-VRF SRv6 L3VPN colour steering via shadow sync

### DIFF
--- a/docs/design/isis-flexalgo-srv6-plan.md
+++ b/docs/design/isis-flexalgo-srv6-plan.md
@@ -126,13 +126,33 @@ the "prepend" counterpart of PR 7's plain-unicast "replace":
   in scope. **No-op for per-VRF VPNv4/VPNv6-over-SRv6 routes**: those
   install in per-VRF tasks that don't hold the (dynamic) colour shadow.
 
-Remaining deferred follow-ups: **per-VRF VPN colour steering** — needs a
-live global→VRF sync of `flex_algo_srv6_routes` (+ `color_policy`) to
-each VRF task (a new `BgpVrfMsg` broadcast on every IS-IS SPF + per-VRF
-storage + use in the per-VRF `fib_install`); and a **TI-LFA BDD** (the
-PR-6 `isis_flex_srv6` topology has no intra-algo redundancy to exercise
-a repair). The PR-6 BDD feature was authored but not executed here
-(needs root/netns; CI runs the bdd suite).
+**Per-VRF VPN colour steering: implemented** (branch
+`isis-flexalgo-srv6-vrf-steer`, build/fmt/clippy/non-bdd tests green) —
+the global→VRF colour-shadow sync that unlocks steering for imported
+SRv6 L3VPN routes:
+
+- VRF tasks leak their `RibRx` half, so the shadow can't reach them by
+  subscription; the global `Bgp` instead mirrors it via a new
+  `BgpVrfMsg::ColourSteering { color_policy, srv6_shadow }`.
+- `Bgp::broadcast_colour_steering` pushes the combined snapshot to every
+  `vrf_registry` entry on: a `flex_algo_srv6_routes` change (the `RibRx`
+  handler, i.e. each IS-IS SPF that moves a per-algo End SID), `CommitEnd`
+  (covers colour-policy edits *and* VRF spawn, via `apply_vrf_commit_diff`),
+  and SRv6 VRF respawn. No-op when no VRF is spawned.
+- The `Vrf` stores `color_policy` + `flex_algo_srv6_routes` (updated on
+  the new message) and its `BgpTop` sites pass `Some(&self.…)`, so the
+  `steer_srv6_vpn` already called in the per-VRF `fib_install` resolves
+  and prepends the algo-N End SID for VPNv4/VPNv6-over-SRv6 imports.
+
+Coalescing follow-up: the shadow is broadcast per-change today; batching
+across a convergence burst would cut redundant full-snapshot clones
+(VRFs are few and churn is transient, so it's a perf nicety not a
+correctness issue).
+
+Remaining deferred: a **TI-LFA BDD** (the PR-6 `isis_flex_srv6` topology
+has no intra-algo redundancy to exercise a repair). The PR-6 BDD feature
+was authored but not executed here (needs root/netns; CI runs the bdd
+suite).
 
 ## Decisions (locked 2026-06-16)
 

--- a/zebra-rs/src/bgp/inst.rs
+++ b/zebra-rs/src/bgp/inst.rs
@@ -1375,6 +1375,8 @@ impl Bgp {
         );
         self.register_vrf_show(name, &new_handle);
         self.vrf_registry.insert(name.to_string(), new_handle);
+        // Re-seed the respawned VRF with the colour-steering snapshot.
+        self.broadcast_colour_steering();
         bgp_srv6_trace!(self.tracing, vrf = %name, "bgp: reconciled SRv6 service SID for VRF");
     }
 
@@ -1964,6 +1966,10 @@ impl Bgp {
             self.register_vrf_show(&name, &handle);
             self.vrf_registry.insert(name, handle);
         }
+        // Seed every (including newly-spawned) VRF with the current
+        // colour-steering snapshot so SRv6 L3VPN routes steer from the
+        // first install, not only after the next shadow change.
+        self.broadcast_colour_steering();
     }
 
     /// Called when `RibRx::VrfAdd` for `name` arrives. If a
@@ -2640,6 +2646,33 @@ impl Bgp {
         }
     }
 
+    /// Push the current colour-steering snapshot (Color→Flex-Algo
+    /// bindings + the per-algo SRv6 End-SID shadow) to every per-VRF
+    /// task, so a per-VRF SRv6 L3VPN route whose Color binds to a
+    /// Flex-Algo gets the algo-N End SID prepended at FIB install. The
+    /// per-VRF tasks leak their `RibRx` half, so the shadow can't reach
+    /// them by subscription — the global task mirrors it via
+    /// `BgpVrfMsg::ColourSteering` instead.
+    ///
+    /// Called on shadow change (each IS-IS SPF that moves a per-algo
+    /// End SID), colour-policy commit, and VRF spawn. No-op when no VRF
+    /// is spawned. Sent per-change today; coalescing across a
+    /// convergence burst is a follow-up (VRFs are few and shadow churn
+    /// is transient).
+    pub fn broadcast_colour_steering(&self) {
+        if self.vrf_registry.is_empty() {
+            return;
+        }
+        for handle in self.vrf_registry.values() {
+            let _ = handle
+                .inbox
+                .send(super::vrf::msg::BgpVrfMsg::ColourSteering {
+                    color_policy: self.color_policy.clone(),
+                    srv6_shadow: self.flex_algo_srv6_routes.clone(),
+                });
+        }
+    }
+
     pub fn process_rib_msg(&mut self, msg: RibRx) {
         // println!("RIB Message {:?}", msg);
         match msg {
@@ -2833,9 +2866,13 @@ impl Bgp {
             RibRx::FlexAlgoSrv6RouteAdd { route } => {
                 self.flex_algo_srv6_routes
                     .insert(route.algo, route.prefix, route.end_sid);
+                // Mirror the updated shadow to per-VRF tasks for L3VPN
+                // colour steering.
+                self.broadcast_colour_steering();
             }
             RibRx::FlexAlgoSrv6RouteDel { algo, prefix } => {
                 self.flex_algo_srv6_routes.remove(algo, prefix);
+                self.broadcast_colour_steering();
             }
             RibRx::NexthopUpdate { nh, resolution } => {
                 self.nht_handle_update(nh, &resolution);

--- a/zebra-rs/src/bgp/vrf/inst.rs
+++ b/zebra-rs/src/bgp/vrf/inst.rs
@@ -121,6 +121,14 @@ pub struct BgpVrf {
         std::collections::BTreeMap<ipnet::Ipv4Net, Vec<crate::rib::nht::ResolvedNexthop>>,
     pub transport_v6:
         std::collections::BTreeMap<ipnet::Ipv6Net, Vec<crate::rib::nht::ResolvedNexthop>>,
+    /// Colour-steering state mirrored from the global task via
+    /// `BgpVrfMsg::ColourSteering`: the Color→Flex-Algo bindings and the
+    /// per-algo SRv6 End-SID shadow. Read by `fib_install_v4`/`v6` (via
+    /// `BgpTop`) so an imported SRv6 L3VPN route whose Color binds to a
+    /// Flex-Algo gets the algo-N End SID prepended before its service
+    /// SID. Empty until the first snapshot arrives.
+    pub color_policy: super::super::color_policy::ColorPolicy,
+    pub flex_algo_srv6_routes: super::super::color_policy::FlexAlgoSrv6Shadow,
 }
 
 /// Sender side of the per-VRF inbound channel — handed back to
@@ -376,6 +384,8 @@ impl BgpVrf {
             interface_addrs: InterfaceAddrs::new(),
             transport_v4: std::collections::BTreeMap::new(),
             transport_v6: std::collections::BTreeMap::new(),
+            color_policy: Default::default(),
+            flex_algo_srv6_routes: Default::default(),
         };
         (vrf, inbox_tx)
     }
@@ -459,9 +469,9 @@ impl BgpVrf {
                     vrf_export: Some(&exporter),
                     // Color → Flex-Algo binding is a default-VRF
                     // concept today; per-VRF support is a follow-up.
-                    color_policy: None,
+                    color_policy: Some(&self.color_policy),
                     flex_algo_routes: None,
-                    flex_algo_srv6_routes: None,
+                    flex_algo_srv6_routes: Some(&self.flex_algo_srv6_routes),
                     // Per-VRF tasks never receive VPNv4 NLRI directly,
                     // so no import dispatcher to thread through.
                     vrf_import: None,
@@ -632,9 +642,9 @@ impl BgpVrf {
             // No re-export of imported routes: a VPNv4-from-RD
             // re-emitted as a VPNv4-with-same-RD would loop.
             vrf_export: None,
-            color_policy: None,
+            color_policy: Some(&self.color_policy),
             flex_algo_routes: None,
-            flex_algo_srv6_routes: None,
+            flex_algo_srv6_routes: Some(&self.flex_algo_srv6_routes),
             vrf_import: None,
             nexthop_cache: None,
             vrf_transport_v4: Some(&self.transport_v4),
@@ -719,9 +729,9 @@ impl BgpVrf {
             update_groups: &mut self.update_groups,
             interface_addrs: &self.interface_addrs,
             vrf_export: None,
-            color_policy: None,
+            color_policy: Some(&self.color_policy),
             flex_algo_routes: None,
-            flex_algo_srv6_routes: None,
+            flex_algo_srv6_routes: Some(&self.flex_algo_srv6_routes),
             vrf_import: None,
             nexthop_cache: None,
             vrf_transport_v4: Some(&self.transport_v4),
@@ -849,9 +859,9 @@ impl BgpVrf {
             update_groups: &mut self.update_groups,
             interface_addrs: &self.interface_addrs,
             vrf_export: None,
-            color_policy: None,
+            color_policy: Some(&self.color_policy),
             flex_algo_routes: None,
-            flex_algo_srv6_routes: None,
+            flex_algo_srv6_routes: Some(&self.flex_algo_srv6_routes),
             vrf_import: None,
             nexthop_cache: None,
             vrf_transport_v4: Some(&self.transport_v4),
@@ -920,9 +930,9 @@ impl BgpVrf {
             update_groups: &mut self.update_groups,
             interface_addrs: &self.interface_addrs,
             vrf_export: None,
-            color_policy: None,
+            color_policy: Some(&self.color_policy),
             flex_algo_routes: None,
-            flex_algo_srv6_routes: None,
+            flex_algo_srv6_routes: Some(&self.flex_algo_srv6_routes),
             vrf_import: None,
             nexthop_cache: None,
             vrf_transport_v4: Some(&self.transport_v4),
@@ -1086,6 +1096,18 @@ impl BgpVrf {
     /// `Shutdown`.
     fn process_global_msg(&mut self, msg: BgpVrfMsg) {
         match msg {
+            BgpVrfMsg::ColourSteering {
+                color_policy,
+                srv6_shadow,
+            } => {
+                // Mirror the global colour-steering state so this VRF's
+                // FIB install can steer imported SRv6 L3VPN routes. No
+                // re-install of existing routes here — the next best-path
+                // / NHT churn re-runs `fib_install`; steady-state VPN
+                // routes refresh on the SPF that changed the shadow.
+                self.color_policy = color_policy;
+                self.flex_algo_srv6_routes = srv6_shadow;
+            }
             BgpVrfMsg::Accept(stream, sockaddr) => {
                 // Passive accept for the per-VRF PE-CE session. The global
                 // accept dispatcher routed this inbound connection here by

--- a/zebra-rs/src/bgp/vrf/msg.rs
+++ b/zebra-rs/src/bgp/vrf/msg.rs
@@ -100,6 +100,17 @@ pub enum BgpVrfMsg {
     /// IPv6 counterpart of [`Self::WithdrawNetwork`].
     WithdrawNetworkV6 { prefix: Ipv6Net },
 
+    /// Snapshot of the global colour-steering state (Color→Flex-Algo
+    /// bindings + the per-algo SRv6 End-SID shadow) so the per-VRF FIB
+    /// install can steer imported SRv6 L3VPN routes into a Flex-Algo.
+    /// The shadow is rebuilt on every IS-IS SPF; the global task
+    /// re-sends this on change (and once at VRF spawn). Both travel by
+    /// value so the VRF task owns its copy without locking the global.
+    ColourSteering {
+        color_policy: crate::bgp::color_policy::ColorPolicy,
+        srv6_shadow: crate::bgp::color_policy::FlexAlgoSrv6Shadow,
+    },
+
     /// Tear the VRF task down cleanly. The event loop exits on the
     /// next select iteration after receiving this. Used by
     /// `despawn_bgp_vrf` and during daemon shutdown.


### PR DESCRIPTION
## Summary

Extend colour-aware SRv6 Flex-Algo steering to imported **VPNv4/VPNv6-over-SRv6** routes. These install in per-VRF tasks that don't hold the (dynamic) colour shadow — and those tasks leak their `RibRx` half, so the shadow can't reach them by subscription. The global task mirrors it via a new message instead.

Builds on #1471 (the `steer_srv6_vpn` prepend logic, already called in the per-VRF `fib_install` but previously a no-op there for lack of the shadow).

## What's in this PR

- New `BgpVrfMsg::ColourSteering { color_policy, srv6_shadow }` (global → VRF).
- `Bgp::broadcast_colour_steering` pushes the combined snapshot to every `vrf_registry` entry on:
  - a `flex_algo_srv6_routes` change (the `RibRx` handler — each IS-IS SPF that moves a per-algo End SID),
  - `CommitEnd` (via `apply_vrf_commit_diff`, covering colour-policy edits **and** VRF spawn),
  - SRv6 VRF respawn.
  No-op when no VRF is spawned.
- `Vrf` stores `color_policy` + `flex_algo_srv6_routes` (updated on the new message); its `BgpTop` sites now pass `Some(&self.…)`, so `steer_srv6_vpn` resolves and prepends the algo-N End SID before the End.DT4/DT6 service SID for VPN imports.

**Effect:** an imported SRv6 L3VPN route whose Color binds to a Flex-Algo gets `segs = [algoN-End-SID, service-SID]` in the per-VRF FIB — the VPN traffic rides the algo-N constrained path to the egress PE, then decaps.

**Follow-up:** the shadow is broadcast per-change today; coalescing across a convergence burst is a perf nicety (VRFs are few, churn transient) — not a correctness issue.

## Test plan

- `cargo build` / `cargo fmt --check` / `cargo clippy --workspace --all-targets -- -D warnings` — all clean.
- Full non-bdd suite green (1296 zebra-rs tests, 0 failures). The steering logic itself is covered by the `steer_srv6_vpn_inner` unit tests from #1471; this PR is the global→VRF plumbing that feeds it.

Generated with [Claude Code](https://claude.com/claude-code)