### PR TITLE
bgp-bench: peer-task vs update-group egress A/B benchmark

### DIFF
--- a/docs/design/bgp-peer-task-bench.md
+++ b/docs/design/bgp-peer-task-bench.md
@@ -1,0 +1,129 @@
+# BGP peer-task vs update-group egress benchmark
+
+Status: **measured (2026-06-20)**, branch `bgp-egress-group-bench`. Harness:
+`tools/bgp-bench/compare-peer-task.sh` over the `bgp-bench` load generator.
+Cross-refs: `bgp-peer-egress-task.md` (the PET design + the "OFF wins for RR"
+prediction this run refines), `bgp-egress-group-task-migration.md` (the group
+task that subsumes both models), `bgp-rib-sharding-plan.md` §9, and
+`bgp-sharding-prior-art.md` (the two-axis model: ingress shard vs egress
+coalescing).
+
+## 1. Question
+
+For a **large incoming table re-advertised ("reflected") to many peers**, with
+**N=4 incoming RIB shards**, which egress model converges faster?
+
+| | gate | egress model |
+|---|---|---|
+| peer-task **OFF** (default) | `ZEBRA_BGP_PEER_TASK` unset | update-group flush — FRR coalesce-once, replicate bytes to all members |
+| peer-task **ON** | `ZEBRA_BGP_PEER_TASK=1` | per-peer egress task (PET) — GoBGP per-goroutine, parallel re-encode per peer |
+
+Both runs set `ZEBRA_BGP_SHARDS=4` so the **ingress** side is identical and only
+the egress model differs.
+
+## 2. Method
+
+`compare-peer-task.sh` is a thin A/B orchestrator over `bgp-bench` (the existing
+synthetic load generator). For each config it: emits the matching daemon config,
+starts `zebra-rs` with the two env gates, runs **one `bgp-bench` measurement**,
+captures the single-line JSON (convergence = blast-start → last UPDATE at the
+slowest receiver), tears the daemon down, and repeats interleaved over `--reps`.
+`bgp-bench` validates correctness itself — a receiver that never sees the full
+prefix set reports "DID NOT CONVERGE", so a broken egress model cannot look fast.
+
+**Topology measured:** 4 senders × 200 000 /32s (RIB-FIB ratio 4) → **16 receiver
+peers** (the fan-out we "reflect to" and measure), N=4 shards, 3 reps.
+
+**Out-policy** (`emit-config --out-policy`): a permit-all policy doing real work
+(`set med` + `as-path-prepend` ×2) is attached to **each receiver**, so the
+out-policy *build* — the per-peer egress work the design memo puts at ~75 % of
+egress CPU — is on the measured path. Two shapes:
+
+- **shared** — one policy on all 16 receivers ⇒ they share **one** update-group
+  (coalescing-favorable; the route-reflector shape the PET memo predicts OFF wins).
+- **distinct** — a distinct policy per receiver ⇒ **one update-group each** ⇒
+  neither model can coalesce.
+
+**Machine:** 12 cores, 31 GiB RAM, Linux 6.8, release build, `no-fib-install`
+(control-plane only; daemon on host loopback — unprivileged userns was disabled).
+
+## 3. Results
+
+```
+out-policy = shared  (4 senders × 200k → 16 receivers, N=4 shards, 3 reps)
+ config                     converged   conv secs min/med/mean    pfx/s med
+ peer-task OFF (upd-group)  3/3         6.504 / 6.515 / 6.950     30 700
+ peer-task ON  (per-peer)   3/3         1.915 / 2.106 / 2.149     94 953
+ → peer-task ON ~3.1× faster (median 2.106s vs 6.515s)
+
+out-policy = distinct
+ config                     converged   conv secs min/med/mean    pfx/s med
+ peer-task OFF (upd-group)  3/3        12.362 / 12.708 / 12.659   15 738
+ peer-task ON  (per-peer)   3/3         1.853 / 2.123 / 2.102     94 215
+ → peer-task ON ~6.0× faster (median 2.123s vs 12.708s)
+```
+
+All 16 receivers received the full table in every run (per-receiver `announced`
+290k–534k; the surplus over 200k is documented transient best-path flips as the
+4 senders' paths arrive during the concurrent blast).
+
+## 4. Analysis
+
+**peer-task ON wins decisively for fan-out convergence, in both shapes.**
+
+At N=4 the v4 Loc-RIB lives in the shard pool and best-path deltas return to the
+**main** task. From there:
+
+- **OFF (update-group):** main does the per-prefix attribute **bucketing** and the
+  out-policy build/encode runs through a single update-group **flush job** (a
+  transient `spawn_blocking` per flush). The encode is coalesced (once per group,
+  replicated to members) but the work is gated on main + one flush — it does not
+  parallelize across the 16-peer fan-out.
+- **ON (PET):** main just fans the best-path delta to 16 **per-peer tasks**, each
+  of which runs the out-policy build (`set med` + `as-path-prepend`) and encode
+  **in parallel** across the 12 cores.
+
+So the convergence/throughput metric favors parallel-per-peer even in the
+**shared** (identical-peer / route-reflector) case — which **refines** the
+`bgp-peer-egress-task.md` prediction that OFF wins there. That prediction is
+about **CPU/bytes**: OFF coalesces (one encode, fewer UPDATEs), ON re-encodes per
+peer and streams more uncoalesced UPDATEs. For one-shot **convergence latency**
+on a multi-core box, parallelism beats coalescing-on-main. In **distinct** the gap
+widens (OFF degrades to 16 serial flushes, 12.7s; ON is flat at ~2.1s because it
+never coalesced anyway).
+
+## 5. Caveats
+
+- **Run large.** The update-group path carries a ~1 s flush/settle floor
+  (independent of `adv-interval` — confirmed: `adv-interval 0` keeps it and also
+  inflates announce counts by sending transient flips uncoalesced). At 200k it is
+  ~15 % of OFF's 6.5 s, not the cause of the 3× gap; at <10k it dominates and the
+  comparison is meaningless.
+- **Metric is convergence latency / throughput**, not CPU or bytes. A churny
+  steady-state route-reflector core with hundreds of *identical* clients may still
+  favor OFF on CPU/bytes via coalescing; this is a one-shot bulk-convergence test.
+- **Scales with cores.** ON's win is core-bound (16 PETs over 12 cores here).
+- The **group egress task** (`bgp-egress-group-task-migration.md`) is the intended
+  end-state that gets *both* — coalesce *and* parallelize, at M tasks not N — and
+  should beat both models in the shared case; this bench is the baseline to judge
+  it against once it lands.
+
+## 6. Reproduce
+
+```sh
+cargo build --release -p bgp-bench -p zebra-rs
+
+# shared (coalescing-favorable) — the headline run
+tools/bgp-bench/compare-peer-task.sh \
+    --senders 4 --receivers 16 --prefixes 200000 --shards 4 \
+    --out-policy shared --reps 3
+
+# distinct (diversity-favorable)
+tools/bgp-bench/compare-peer-task.sh ... --out-policy distinct
+```
+
+Per-run daemon logs and `result.json` are kept under the printed results dir. The
+harness emits `transport passive-mode true` on every neighbor (else the daemon's
+own outbound dialing collides with the bench's inbound sessions per BGP §6.8 and
+resets them once more than ~4 receivers are configured) and runs in a rootless
+user+net namespace when available, else on host loopback.

--- a/tools/bgp-bench/README.md
+++ b/tools/bgp-bench/README.md
@@ -58,12 +58,67 @@ flip between two senders' paths mid-ingest re-advertises the prefix.
 
 - `emit-config` sets `router bgp timer adv-interval {ibgp,ebgp}: 1`
   so MRAI debounce quantization (defaults 5s/30s) stays out of the
-  measurement.
-- The daemon actively dials each configured neighbor's address on
-  port 179; nothing listens there, so those dials fail and retry
-  harmlessly while the bench drives the inbound sessions.
+  measurement. (A separate ~1s flush/settle floor remains on the
+  update-group path, so keep the prefix count large enough that real
+  work dominates it — see the comparison below.)
+- `emit-config` marks every neighbor `transport passive-mode true`: the
+  daemon then only **accepts**, and the bench is always the dialer.
+  Without this the daemon *also* dials each neighbor on port 179, and
+  that outbound attempt collides with the bench's inbound session (BGP
+  §6.8 collision resolution), resetting sessions once more than a
+  handful of receivers are configured.
 - Senders drain and discard everything the daemon re-advertises to
   them, so daemon-side writers never stall on a full TCP window.
+
+## Egress out-policy (`--out-policy`)
+
+`emit-config --out-policy {none|shared|distinct}` attaches an outbound
+policy (permit-all, `set med` + `as-path-prepend`) to every **receiver**,
+so the egress out-policy *build* — the per-peer attribute work the egress
+models differ on — is on the measured path (default `none`).
+
+- `shared` — one policy on all receivers ⇒ they fall in **one**
+  update-group. Coalescing-favorable (the route-reflector shape).
+- `distinct` — a distinct policy per receiver ⇒ **one update-group each**.
+  Neither model can coalesce, so per-peer parallel build is free to win.
+
+## peer-task vs update-group comparison
+
+`compare-peer-task.sh` is an A/B harness over this tool. It runs one
+measurement per egress model — both with `ZEBRA_BGP_SHARDS=4` so only the
+egress side differs — and prints a side-by-side verdict:
+
+| | gate | egress model |
+|---|---|---|
+| peer-task **OFF** (default) | `ZEBRA_BGP_PEER_TASK` unset | update-group flush — FRR coalesce-once-replicate |
+| peer-task **ON** | `ZEBRA_BGP_PEER_TASK=1` | per-peer egress task — GoBGP per-goroutine, parallel re-encode |
+
+```sh
+# Large incoming table (4 senders × 200k prefixes) reflected to 16
+# receiver peers, N=4 incoming shards, shared out-policy, 3 reps:
+tools/bgp-bench/compare-peer-task.sh \
+    --senders 4 --receivers 16 --prefixes 200000 --shards 4 \
+    --out-policy shared --reps 3
+
+# The diversity case (each receiver its own update-group):
+tools/bgp-bench/compare-peer-task.sh ... --out-policy distinct
+```
+
+It spins the daemon up in a rootless user+net namespace when
+unprivileged userns is available, else straight on the host loopback
+(the `no-fib-install` daemon needs no `CAP_NET_ADMIN`). `bgp-bench`
+itself validates correctness: a receiver that never sees the full prefix
+set makes the run report "DID NOT CONVERGE", so a broken egress model
+cannot masquerade as a fast one. Per-run daemon logs and `result.json`
+are kept under the printed results dir.
+
+Run it large: at small prefix counts the update-group path's ~1s flush
+floor dominates and the comparison is meaningless. Keep the work-time
+well above ~1s (≥ ~100k prefixes) so the numbers reflect real egress
+work, not the timer.
+
+Measured results and analysis live in
+`docs/design/bgp-peer-task-bench.md`.
 
 ## Flamegraph recipe
 

--- a/tools/bgp-bench/compare-peer-task.sh
+++ b/tools/bgp-bench/compare-peer-task.sh
@@ -1,0 +1,313 @@
+#!/usr/bin/env bash
+#
+# compare-peer-task.sh — A/B convergence benchmark for the two BGP egress
+# models, with N=4 incoming RIB shards on both sides.
+#
+#   peer-task OFF  (default)  →  update-group flush  (FRR coalesce-once-
+#                                replicate; one encode fanned to all members)
+#   peer-task ON   (gate-on)  →  per-peer egress task (GoBGP per-goroutine;
+#                                each peer re-encodes its own egress in parallel)
+#
+# Scenario (what the user asked for): a large incoming route set blasted by
+# several senders is re-advertised ("reflected") to MANY receiver peers — i.e.
+# the egress fan-out is the bottleneck under test. Both runs use
+# ZEBRA_BGP_SHARDS=4 so the ingress side is identical and only the egress model
+# differs.
+#
+# This is a thin orchestrator over the existing `bgp-bench` load generator
+# (tools/bgp-bench): it spins the daemon up in a rootless user+net namespace
+# (the README recipe), runs one measurement per config, captures the JSON
+# convergence number, and prints a side-by-side verdict. `bgp-bench` itself
+# validates correctness — a receiver that never sees the full prefix set makes
+# the run exit non-zero ("DID NOT CONVERGE"), so a broken egress model can't
+# masquerade as a fast one.
+#
+# Usage:
+#   tools/bgp-bench/compare-peer-task.sh [flags]
+#
+# Common flags (see --help for the full list):
+#   --senders N        injecting eBGP sessions          (default 4)
+#   --receivers R      fan-out eBGP sessions ("peers")   (default 16, max 55)
+#   --prefixes M       unique /32s per sender            (default 100000)
+#   --shards S         incoming RIB shards, both configs (default 4)
+#   --reps K           repetitions per config            (default 3)
+#   --no-build         use the binaries already in target/release
+#
+set -euo pipefail
+
+# Absolute path to this script — re-exec'd inside the namespace as `__inner`.
+SELF="$(readlink -f "$0")"
+
+# ──────────────────────────────────────────────────────────────────────────
+# Inner mode: runs INSIDE the per-run user+net namespace created by `unshare`.
+# Everything it needs arrives via BB_* environment variables (unshare keeps the
+# parent environment). It starts the daemon, runs one bgp-bench measurement,
+# prints the bench's single-line JSON to stdout, and tears the daemon down.
+# ──────────────────────────────────────────────────────────────────────────
+if [ "${1:-}" = "__inner" ]; then
+    set +e # capture the bench's exit code rather than aborting on non-zero
+    # Only in netns mode do we own (and need to raise) loopback. On the host
+    # lo is already up and we lack CAP_NET_ADMIN to touch it.
+    [ "${BB_NETNS:-0}" = 1 ] && ip link set lo up
+
+    ZEBRA_BGP_SHARDS="$BB_SHARDS" ZEBRA_BGP_PEER_TASK="$BB_PEER_TASK" \
+        "$BB_ZEBRA" --yang-path "$BB_DIR/yang" \
+        --vty-socket "unix:$BB_DIR/vty" \
+        >"$BB_DIR/daemon.log" 2>&1 &
+    dpid=$!
+
+    # The daemon needs a moment to commit the config and open its listener;
+    # bgp-bench's establish_retry (20×500ms) absorbs any remaining lag.
+    sleep "$BB_WARMUP"
+
+    "$BB_BENCH" run \
+        --target "127.0.0.1:$BB_PORT" \
+        --senders "$BB_SENDERS" \
+        --receivers "$BB_RECEIVERS" \
+        --prefixes "$BB_PREFIXES" \
+        --attr-buckets "$BB_ATTR_BUCKETS" \
+        --quiet-ms "$BB_QUIET_MS" \
+        --timeout-secs "$BB_TIMEOUT" \
+        --json
+    rc=$?
+
+    # Teardown: SIGTERM, brief grace, then SIGKILL so a slow/large daemon
+    # shutdown can never wedge the run between configs.
+    kill "$dpid" 2>/dev/null
+    for _ in 1 2 3 4 5 6 7 8 9 10; do
+        kill -0 "$dpid" 2>/dev/null || break
+        sleep 0.5
+    done
+    kill -9 "$dpid" 2>/dev/null
+    wait "$dpid" 2>/dev/null
+    exit "$rc"
+fi
+
+# ──────────────────────────────────────────────────────────────────────────
+# Outer mode
+# ──────────────────────────────────────────────────────────────────────────
+
+REPO="$(cd "$(dirname "$SELF")/../.." && pwd)"
+
+# Defaults.
+SENDERS=4
+RECEIVERS=16
+PREFIXES=100000
+SHARDS=4
+ATTR_BUCKETS=16
+QUIET_MS=3000
+TIMEOUT=600
+PORT=1179
+REPS=3
+WARMUP=3
+OUT_POLICY=shared
+BUILD=1
+BUILD_JOBS=""
+
+usage() {
+    cat <<EOF
+compare-peer-task.sh — A/B convergence benchmark: BGP peer-task OFF vs ON,
+with N=$SHARDS incoming RIB shards on both sides.
+
+Flags:
+  --senders N        injecting eBGP sessions (RIB-FIB ratio = N)   [default $SENDERS]
+  --receivers R      fan-out eBGP sessions, the "all peers" set     [default $RECEIVERS, max 55]
+  --prefixes M       unique /32s each sender advertises            [default $PREFIXES, max 2^24]
+  --shards S         ZEBRA_BGP_SHARDS for BOTH configs             [default $SHARDS]
+  --attr-buckets B   distinct attribute sets per sender            [default $ATTR_BUCKETS]
+  --quiet-ms Q       receiver convergence quiet window             [default $QUIET_MS]
+  --timeout-secs T   hard cap per measurement                      [default $TIMEOUT]
+  --port P           daemon BGP listen port                        [default $PORT]
+  --reps K           repetitions per config (interleaved)          [default $REPS]
+  --warmup W         seconds to wait after daemon start            [default $WARMUP]
+  --out-policy MODE  egress out-policy on receivers: none|shared|distinct
+                       shared   = all receivers in ONE update-group (coalesce)
+                       distinct = one update-group per receiver (diverse)
+                                                                    [default $OUT_POLICY]
+  --build-jobs J     cargo -j J for the release build              [default: cargo default]
+  --no-build         skip the build; use target/release as-is
+  -h, --help         this message
+
+Output is a side-by-side table (min/median/mean convergence per config) and a
+verdict naming the faster egress model. Per-run daemon logs are kept under a
+temp results dir whose path is printed at the end.
+EOF
+}
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+    --senders) SENDERS="$2"; shift 2 ;;
+    --receivers) RECEIVERS="$2"; shift 2 ;;
+    --prefixes) PREFIXES="$2"; shift 2 ;;
+    --shards) SHARDS="$2"; shift 2 ;;
+    --attr-buckets) ATTR_BUCKETS="$2"; shift 2 ;;
+    --quiet-ms) QUIET_MS="$2"; shift 2 ;;
+    --timeout-secs) TIMEOUT="$2"; shift 2 ;;
+    --port) PORT="$2"; shift 2 ;;
+    --reps) REPS="$2"; shift 2 ;;
+    --warmup) WARMUP="$2"; shift 2 ;;
+    --out-policy) OUT_POLICY="$2"; shift 2 ;;
+    --build-jobs) BUILD_JOBS="$2"; shift 2 ;;
+    --no-build) BUILD=0; shift ;;
+    -h | --help) usage; exit 0 ;;
+    *) echo "unknown flag: $1" >&2; usage >&2; exit 1 ;;
+    esac
+done
+
+ZEBRA="$REPO/target/release/zebra-rs"
+BENCH="$REPO/target/release/bgp-bench"
+
+# Preflight.
+if [ "$RECEIVERS" -gt 55 ]; then
+    echo "error: --receivers must be <= 55 (the 127.0.0.200+ address plan)" >&2
+    exit 1
+fi
+case "$OUT_POLICY" in
+none | shared | distinct) ;;
+*) echo "error: --out-policy must be none|shared|distinct (got '$OUT_POLICY')" >&2; exit 1 ;;
+esac
+
+# Isolation mode. A rootless user+net namespace (the README recipe) is tidiest,
+# but it needs unprivileged userns, which many hosts disable. We don't actually
+# require it: emit-config sets `no-fib-install`, so the daemon never writes the
+# kernel FIB, and every 127.0.0.0/8 source the bench binds is local anyway. So
+# probe once and fall back to running the daemon straight on the host loopback.
+NETNS=0
+if command -v unshare >/dev/null 2>&1 && unshare -rn true >/dev/null 2>&1; then
+    NETNS=1
+fi
+
+if [ "$BUILD" = 1 ]; then
+    echo ">> building release binaries (zebra-rs + bgp-bench)…" >&2
+    if [ -n "$BUILD_JOBS" ]; then
+        cargo build --release -p bgp-bench -p zebra-rs -j "$BUILD_JOBS"
+    else
+        cargo build --release -p bgp-bench -p zebra-rs
+    fi
+fi
+[ -x "$ZEBRA" ] || { echo "error: $ZEBRA missing (drop --no-build, or build it)" >&2; exit 1; }
+[ -x "$BENCH" ] || { echo "error: $BENCH missing (drop --no-build, or build it)" >&2; exit 1; }
+
+RESULTS_DIR="$(mktemp -d "${TMPDIR:-/tmp}/bgp-bench-compare-XXXXXX")"
+
+# run_one <peer_task 0|1> <run-tag> → echoes the bench JSON; returns bench rc.
+run_one() {
+    local peer_task="$1" tag="$2"
+    local dir="$RESULTS_DIR/$tag"
+    mkdir -p "$dir"
+    ln -sfn "$REPO/zebra-rs/yang" "$dir/yang"
+    "$BENCH" emit-config \
+        --senders "$SENDERS" --receivers "$RECEIVERS" --port "$PORT" \
+        --out-policy "$OUT_POLICY" \
+        >"$dir/zebra-rs.conf"
+
+    local json rc
+    # In netns mode re-exec under unshare; on the host run __inner directly.
+    local runner=("$SELF" __inner)
+    [ "$NETNS" = 1 ] && runner=(unshare -rn "$SELF" __inner)
+    if json=$(
+        BB_SHARDS="$SHARDS" BB_PEER_TASK="$peer_task" BB_NETNS="$NETNS" \
+            BB_ZEBRA="$ZEBRA" BB_BENCH="$BENCH" BB_DIR="$dir" BB_PORT="$PORT" \
+            BB_SENDERS="$SENDERS" BB_RECEIVERS="$RECEIVERS" \
+            BB_PREFIXES="$PREFIXES" BB_ATTR_BUCKETS="$ATTR_BUCKETS" \
+            BB_QUIET_MS="$QUIET_MS" BB_TIMEOUT="$TIMEOUT" BB_WARMUP="$WARMUP" \
+            "${runner[@]}"
+    ); then
+        rc=0
+    else
+        rc=$?
+    fi
+    printf '%s\n' "$json" >"$dir/result.json"
+    printf '%s' "$json"
+    # Host mode reuses port $PORT across runs; let the listener fully close
+    # before the next daemon binds it.
+    [ "$NETNS" = 1 ] || sleep 1
+    return "$rc"
+}
+
+# field <json> <key> → numeric value, or empty.
+field() {
+    printf '%s' "$1" | sed -n "s/.*\"$2\":\([0-9.]*\).*/\1/p"
+}
+flag() {
+    printf '%s' "$1" | sed -n "s/.*\"$2\":\(true\|false\).*/\1/p"
+}
+
+echo ">> topology: $SENDERS senders × $PREFIXES prefixes → $RECEIVERS receivers (fan-out), N=$SHARDS shards, $REPS reps" >&2
+echo ">> out-policy: $OUT_POLICY (set MED + AS-path-prepend on each receiver)" >&2
+echo ">> isolation: $([ "$NETNS" = 1 ] && echo 'rootless user+net namespace' || echo 'host loopback (no userns; no-fib-install daemon)')" >&2
+echo ">> results dir: $RESULTS_DIR" >&2
+
+declare -a CONV_OFF=() CONV_ON=() RATE_OFF=() RATE_ON=()
+OK_OFF=0 OK_ON=0
+
+for rep in $(seq 1 "$REPS"); do
+    for variant in off on; do
+        if [ "$variant" = off ]; then pt=0; label="peer-task OFF"; else pt=1; label="peer-task ON "; fi
+        echo ">> [rep $rep] $label …" >&2
+        json="$(run_one "$pt" "${variant}.rep${rep}")" && rc=0 || rc=$?
+
+        converged="$(flag "$json" converged)"
+        conv="$(field "$json" convergence_secs)"
+        rate="$(field "$json" unique_prefixes_per_sec)"
+
+        if [ "$rc" = 0 ] && [ "$converged" = true ] && [ -n "$conv" ]; then
+            echo "   converged in ${conv}s (${rate} pfx/s)" >&2
+            if [ "$variant" = off ]; then
+                CONV_OFF+=("$conv"); RATE_OFF+=("$rate"); OK_OFF=$((OK_OFF + 1))
+            else
+                CONV_ON+=("$conv"); RATE_ON+=("$rate"); OK_ON=$((OK_ON + 1))
+            fi
+        else
+            echo "   DID NOT CONVERGE (rc=$rc) — see $RESULTS_DIR/${variant}.rep${rep}/daemon.log" >&2
+        fi
+    done
+done
+
+# stats <samples…> → "min median mean" (3 decimals), or "- - -" if none.
+stats() {
+    [ $# -eq 0 ] && { echo "- - -"; return; }
+    printf '%s\n' "$@" | sort -g | awk '
+        {a[NR]=$1}
+        END{
+            n=NR; min=a[1];
+            med=(n%2)?a[(n+1)/2]:(a[n/2]+a[n/2+1])/2;
+            s=0; for(i=1;i<=n;i++)s+=a[i];
+            printf "%.3f %.3f %.3f", min, med, s/n;
+        }'
+}
+median() {
+    [ $# -eq 0 ] && { echo ""; return; }
+    printf '%s\n' "$@" | sort -g | awk '{a[NR]=$1} END{n=NR; print (n%2)?a[(n+1)/2]:(a[n/2]+a[n/2+1])/2}'
+}
+
+read -r OFF_MIN OFF_MED OFF_MEAN <<<"$(stats "${CONV_OFF[@]}")"
+read -r ON_MIN ON_MED ON_MEAN <<<"$(stats "${CONV_ON[@]}")"
+OFF_RATE_MED="$(median "${RATE_OFF[@]}")"
+ON_RATE_MED="$(median "${RATE_ON[@]}")"
+
+printf '\n'
+printf '════════════════════════════════════════════════════════════════════════\n'
+printf ' BGP peer-task A/B benchmark   (N=%s incoming shards, out-policy=%s)\n' "$SHARDS" "$OUT_POLICY"
+printf ' topology: %s senders × %s prefixes → %s receivers (fan-out), %s reps\n' \
+    "$SENDERS" "$PREFIXES" "$RECEIVERS" "$REPS"
+printf '════════════════════════════════════════════════════════════════════════\n'
+printf ' %-26s %-10s %-26s %-12s\n' "config" "converged" "conv secs min/med/mean" "pfx/s med"
+printf ' %-26s %-10s %-26s %-12s\n' \
+    "peer-task OFF (upd-group)" "$OK_OFF/$REPS" "$OFF_MIN / $OFF_MED / $OFF_MEAN" "${OFF_RATE_MED:-–}"
+printf ' %-26s %-10s %-26s %-12s\n' \
+    "peer-task ON  (per-peer)" "$OK_ON/$REPS" "$ON_MIN / $ON_MED / $ON_MEAN" "${ON_RATE_MED:-–}"
+printf '════════════════════════════════════════════════════════════════════════\n'
+
+# Verdict by median convergence (lower = faster).
+if [ "$OK_OFF" -gt 0 ] && [ "$OK_ON" -gt 0 ]; then
+    awk -v off="$OFF_MED" -v on="$ON_MED" 'BEGIN{
+        if (off < on)      { d=(on-off)/on*100;  printf " verdict: peer-task OFF (update-group) is faster — median %.3fs vs %.3fs (%.1f%% quicker)\n", off, on, d }
+        else if (on < off) { d=(off-on)/off*100; printf " verdict: peer-task ON  (per-peer)    is faster — median %.3fs vs %.3fs (%.1f%% quicker)\n", on, off, d }
+        else               { printf " verdict: tie — median %.3fs both\n", off }
+    }'
+else
+    printf ' verdict: inconclusive — a config failed to converge (see logs)\n'
+fi
+printf '════════════════════════════════════════════════════════════════════════\n'
+printf ' logs: %s\n' "$RESULTS_DIR"

--- a/tools/bgp-bench/src/main.rs
+++ b/tools/bgp-bench/src/main.rs
@@ -54,6 +54,24 @@ enum Cmd {
     Run(RunArgs),
 }
 
+/// Outbound policy attached to each receiver, to exercise the egress
+/// out-policy build — the per-peer work the peer-task vs update-group
+/// comparison turns on (the design memo puts it at ~75% of egress CPU).
+#[derive(Clone, Copy, PartialEq, Eq, clap::ValueEnum)]
+enum OutPolicy {
+    /// No out-policy; egress is a trivial copy of the Loc-RIB attr.
+    None,
+    /// One shared policy on every receiver → all receivers fall in ONE
+    /// update-group. Coalescing-favorable (the route-reflector case):
+    /// peer-task OFF builds+encodes once and replicates; ON re-does it
+    /// per peer.
+    Shared,
+    /// A distinct policy per receiver → one update-group EACH. Diversity-
+    /// favorable: neither model can coalesce, so the per-peer parallel
+    /// build (peer-task ON) is free to win on many cores.
+    Distinct,
+}
+
 #[derive(Args)]
 struct EmitArgs {
     /// Daemon's AS number.
@@ -81,7 +99,17 @@ struct EmitArgs {
     /// plane. Enable for a with-FIB run under root.
     #[arg(long)]
     fib_install: bool,
+    /// Outbound policy applied to every receiver (set MED + AS-path-
+    /// prepend, permit-all). `shared` puts all receivers in one update-
+    /// group (coalescing case); `distinct` gives each its own (diversity
+    /// case). `none` is a trivial-egress baseline.
+    #[arg(long, value_enum, default_value = "none")]
+    out_policy: OutPolicy,
 }
+
+/// eBGP AS prepended by the bench out-policy (distinct mode offsets per
+/// receiver). Kept clear of the sender/receiver AS ranges.
+const PREPEND_AS_BASE: u32 = 64600;
 
 #[derive(Args)]
 struct RunArgs {
@@ -147,20 +175,77 @@ fn emit_config(args: &EmitArgs) -> Result<()> {
     if !args.fib_install {
         out.push_str("router bgp global no-fib-install true;\n");
     }
-    let mut neighbor = |addr: Ipv4Addr, asn: u32| {
-        out.push_str(&format!(
-            "router bgp neighbor {addr} remote-as {asn};\n\
-             router bgp neighbor {addr} afi-safi ipv4 enabled true;\n",
-        ));
-    };
-    for i in 0..args.senders {
-        neighbor(sender_addr(i), SENDER_AS_BASE + i as u32);
+
+    // Out-policy definitions (before the neighbors that reference them).
+    match args.out_policy {
+        OutPolicy::None => {}
+        OutPolicy::Shared => push_policy(&mut out, "bench-out", 100, PREPEND_AS_BASE, 2),
+        OutPolicy::Distinct => {
+            for j in 0..args.receivers {
+                push_policy(
+                    &mut out,
+                    &format!("bench-out-{j}"),
+                    100 + j as u32,
+                    PREPEND_AS_BASE + j as u32,
+                    2,
+                );
+            }
+        }
     }
+
+    // Senders inject only; no out-policy on them (they drain-and-discard).
+    for i in 0..args.senders {
+        push_neighbor(&mut out, sender_addr(i), SENDER_AS_BASE + i as u32, None);
+    }
+    // Receivers are the fan-out set we "reflect to" and measure; the
+    // out-policy lives here so its build cost is on the measured path.
     for j in 0..args.receivers {
-        neighbor(receiver_addr(j), RECEIVER_AS_BASE + j as u32);
+        let policy = match args.out_policy {
+            OutPolicy::None => None,
+            OutPolicy::Shared => Some("bench-out".to_string()),
+            OutPolicy::Distinct => Some(format!("bench-out-{j}")),
+        };
+        push_neighbor(
+            &mut out,
+            receiver_addr(j),
+            RECEIVER_AS_BASE + j as u32,
+            policy.as_deref(),
+        );
     }
     print!("{out}");
     Ok(())
+}
+
+/// Emit one neighbor: remote-as, ipv4-unicast enabled, and `passive-mode`.
+/// Passive is essential at scale — without it the daemon *also* dials each
+/// neighbor's address on port 179, and that outbound attempt collides with
+/// the bench's inbound session (BGP §6.8 collision resolution), resetting
+/// sessions once more than a handful of receivers are configured. Passive =
+/// the daemon only accepts; the bench is always the dialer.
+fn push_neighbor(out: &mut String, addr: Ipv4Addr, asn: u32, out_policy: Option<&str>) {
+    out.push_str(&format!(
+        "router bgp neighbor {addr} remote-as {asn};\n\
+         router bgp neighbor {addr} afi-safi ipv4 enabled true;\n\
+         router bgp neighbor {addr} transport passive-mode true;\n",
+    ));
+    if let Some(name) = out_policy {
+        out.push_str(&format!("router bgp neighbor {addr} policy out {name};\n"));
+    }
+}
+
+/// Emit a permit-all out-policy that sets MED and prepends `prepend_as`
+/// `repeat` times. The prepend forces an AS_PATH rebuild per prefix per
+/// advertisement, so the out-policy application is real work on the egress
+/// path — exactly the per-peer cost the peer-task vs update-group benchmark
+/// is comparing. A single permit entry with no match clause passes every
+/// prefix (verified: a deny-all twin zeroes the receiver's routes).
+fn push_policy(out: &mut String, name: &str, med: u32, prepend_as: u32, repeat: u8) {
+    out.push_str(&format!(
+        "policy {name} entry 10 action permit;\n\
+         policy {name} entry 10 set med set {med};\n\
+         policy {name} entry 10 set as-path-prepend asn {prepend_as};\n\
+         policy {name} entry 10 set as-path-prepend repeat {repeat};\n",
+    ));
 }
 
 fn assert_addr_capacity(senders: u8, receivers: u8) -> Result<()> {


### PR DESCRIPTION
## Summary

Adds an A/B benchmark for the two BGP egress models, answering: for a large
incoming table reflected to many peers, with **N=4 incoming RIB shards**, which
model converges faster?

- **`tools/bgp-bench/compare-peer-task.sh`** — orchestrator over the existing
  `bgp-bench` load generator. Runs one measurement per egress model
  (`ZEBRA_BGP_PEER_TASK` off = update-group coalesce; on = per-peer egress task),
  both with `ZEBRA_BGP_SHARDS=4`, and prints a side-by-side verdict. Auto-detects
  rootless user+net namespace, falls back to host loopback (the `no-fib-install`
  daemon needs no `CAP_NET_ADMIN`).
- **`tools/bgp-bench/src/main.rs`** — `emit-config` now:
  - takes `--out-policy {none|shared|distinct}` so the egress out-policy build
    (`set med` + `as-path-prepend`, the per-peer work the models differ on) is on
    the measured path;
  - always emits `transport passive-mode true` per neighbor — fixes a real
    collision bug where the daemon's own outbound dialing reset the bench's
    inbound sessions (BGP §6.8) at >~4 receivers.
- **`docs/design/bgp-peer-task-bench.md`** + README — methodology, results, caveats.

## Result

4 senders × 200k prefixes → 16 receivers, N=4 shards, 12 cores, 3 reps:

| out-policy | peer-task OFF (update-group) | peer-task ON (per-peer) |
|---|---|---|
| shared (1 update-group) | 6.5s median · 30.7k pfx/s | **2.1s · 95k pfx/s** (~3×) |
| distinct (16 groups) | 12.7s median · 15.7k pfx/s | **2.1s · 94k pfx/s** (~6×) |

All runs converged 3/3 with every receiver receiving the full table. peer-task ON
wins fan-out convergence in both shapes (parallel per-peer build/encode across
cores beats coalesce-on-main); analysis in the design doc refines the
`bgp-peer-egress-task.md` "OFF wins for RR clients" prediction (latency/throughput
vs CPU/bytes).

## Test plan

- `cargo fmt -p bgp-bench --check` — clean
- `cargo clippy -p bgp-bench --all-targets -- -D warnings` — clean
- Benchmark executed end-to-end (results above); harness self-validates
  correctness (non-convergence reported as failure, not a fast number).

Generated with [Claude Code](https://claude.com/claude-code)