### PR TITLE
bdd: per-Flex-Algorithm TI-LFA over SRv6 feature

### DIFF
--- a/bdd/docs/flexalgo_tilfa_srv6.md
+++ b/bdd/docs/flexalgo_tilfa_srv6.md
@@ -1,0 +1,41 @@
+# IS-IS per-Flex-Algorithm TI-LFA over SRv6
+
+## Overview
+
+Flex-Algo sibling of `tilfa_srv6`. The same proven eight-router topology
+and metrics (IPv6-only, every circuit point-to-point), but each router
+also runs a Flexible-Algorithm 128 (RFC 9350) on the SRv6 dataplane:
+
+- a per-algo SRv6 locator `fcbb:bbbb:1X::/48` (usid) bound to algo 128 via
+  `segment-routing srv6 flex-algo-locator`, beside the base (algo-0)
+  locator `fcbb:bbbb:X::/48`;
+- algo 128 has no affinity constraints, so its topology equals algo 0's —
+  the per-algo TI-LFA repair mirrors the algo-0 one;
+- `flex-algo 128 fast-reroute ti-lfa` enables per-algo TI-LFA, so the
+  per-algo locator routes carry a repair resolved to *algo-128* End /
+  End.X SIDs (SRH-inserted), keeping the repair inside algo 128.
+
+The metrics are tuned (from `tilfa_srv6`) so a simple LFA is impossible —
+protecting `s-n1` needs an SR repair tunnel through the r-plane. This
+validates per-algo TI-LFA (#1469) + per-algo End.X SID origination
+(#1470) end-to-end on the SRv6 dataplane. Pure-IGP (no BGP/LAN): the test
+asserts the per-algo locator repair, not colour-steered service traffic.
+
+> Like every BDD here it runs under the CI-excluded bdd suite in network
+> namespaces; it was authored (reusing the proven `tilfa_srv6` topology)
+> but not executed in the authoring sandbox — a real run may need
+> assertion tuning.
+
+## Config Files
+
+s.yaml  n1.yaml  n2.yaml  n3.yaml  r1.yaml  r2.yaml  r3.yaml  d.yaml
+
+## Test Scenarios
+
+| Scenario | Result |
+|----------|--------|
+| Build the per-Flex-Algo SRv6 TI-LFA topology and confirm IS-IS | |
+| Per-algo SRv6 SIDs exist and algo-128 locators are reachable | |
+| Algo-0 fast-reroute survives the primary link failure (s-n1) | |
+| Promoted per-algo backup forwards over the algo-128 SRv6 repair | |
+| Teardown topology | |

--- a/bdd/tests/configs/flexalgo_tilfa_srv6/d.yaml
+++ b/bdd/tests/configs/flexalgo_tilfa_srv6/d.yaml
@@ -1,0 +1,54 @@
+# d — TI-LFA destination. Mirror of s: IS-IS L2 + LOC8 (+ algo-128
+# locator LOC8_A128). Pure-IGP variant (no BGP/LAN).
+interface:
+- if-name: lo
+  ipv6:
+    address: 2001:db8::8/128
+- if-name: d-n1
+  ipv6:
+    address: 2001:db8:0:10::2/64
+- if-name: d-r3
+  ipv6:
+    address: 2001:db8:0:11::2/64
+segment-routing:
+  locator:
+  - name: LOC8
+    prefix: fcbb:bbbb:8::/48
+    behavior: usid
+  - name: LOC8_A128
+    prefix: fcbb:bbbb:18::/48
+    behavior: usid
+router:
+  isis:
+    net: 49.0000.0000.0000.0008.00
+    hostname: d
+    is-type: level-2-only
+    segment-routing:
+      srv6:
+        locator: LOC8
+        flex-algo-locator:
+        - algo: 128
+          locator: LOC8_A128
+    fast-reroute:
+      ti-lfa: {}
+    flex-algo:
+    - algo: 128
+      advertise-definition: true
+      dataplane:
+        srv6: true
+      fast-reroute:
+        ti-lfa: {}
+    interface:
+    - if-name: lo
+      ipv6:
+        enable: true
+    - if-name: d-n1
+      network-type: point-to-point
+      metric: 1
+      ipv6:
+        enable: true
+    - if-name: d-r3
+      network-type: point-to-point
+      metric: 1
+      ipv6:
+        enable: true

--- a/bdd/tests/configs/flexalgo_tilfa_srv6/n1.yaml
+++ b/bdd/tests/configs/flexalgo_tilfa_srv6/n1.yaml
@@ -1,0 +1,69 @@
+# n1 — the primary-path midpoint s protects against (s-n1 link / n1 node).
+interface:
+- if-name: lo
+  ipv6:
+    address: 2001:db8::2/128
+- if-name: n1-s
+  ipv6:
+    address: 2001:db8:0:1::2/64
+- if-name: n1-r1
+  ipv6:
+    address: 2001:db8:0:4::1/64
+- if-name: n1-r2
+  ipv6:
+    address: 2001:db8:0:7::1/64
+- if-name: n1-d
+  ipv6:
+    address: 2001:db8:0:10::1/64
+segment-routing:
+  locator:
+  - name: LOC2
+    prefix: fcbb:bbbb:2::/48
+    behavior: usid
+  - name: LOC2_A128
+    prefix: fcbb:bbbb:12::/48
+    behavior: usid
+router:
+  isis:
+    net: 49.0000.0000.0000.0002.00
+    hostname: n1
+    is-type: level-2-only
+    segment-routing:
+      srv6:
+        locator: LOC2
+        flex-algo-locator:
+        - algo: 128
+          locator: LOC2_A128
+    fast-reroute:
+      ti-lfa: {}
+    flex-algo:
+    - algo: 128
+      advertise-definition: true
+      dataplane:
+        srv6: true
+      fast-reroute:
+        ti-lfa: {}
+    interface:
+    - if-name: lo
+      ipv6:
+        enable: true
+    - if-name: n1-s
+      network-type: point-to-point
+      metric: 1
+      ipv6:
+        enable: true
+    - if-name: n1-r1
+      network-type: point-to-point
+      metric: 1
+      ipv6:
+        enable: true
+    - if-name: n1-r2
+      network-type: point-to-point
+      metric: 1
+      ipv6:
+        enable: true
+    - if-name: n1-d
+      network-type: point-to-point
+      metric: 1
+      ipv6:
+        enable: true

--- a/bdd/tests/configs/flexalgo_tilfa_srv6/n2.yaml
+++ b/bdd/tests/configs/flexalgo_tilfa_srv6/n2.yaml
@@ -1,0 +1,53 @@
+# n2 — the post-convergence first hop when s-n1 fails (P-node side).
+interface:
+- if-name: lo
+  ipv6:
+    address: 2001:db8::3/128
+- if-name: n2-s
+  ipv6:
+    address: 2001:db8:0:2::2/64
+- if-name: n2-r1
+  ipv6:
+    address: 2001:db8:0:5::1/64
+segment-routing:
+  locator:
+  - name: LOC3
+    prefix: fcbb:bbbb:3::/48
+    behavior: usid
+  - name: LOC3_A128
+    prefix: fcbb:bbbb:13::/48
+    behavior: usid
+router:
+  isis:
+    net: 49.0000.0000.0000.0003.00
+    hostname: n2
+    is-type: level-2-only
+    segment-routing:
+      srv6:
+        locator: LOC3
+        flex-algo-locator:
+        - algo: 128
+          locator: LOC3_A128
+    fast-reroute:
+      ti-lfa: {}
+    flex-algo:
+    - algo: 128
+      advertise-definition: true
+      dataplane:
+        srv6: true
+      fast-reroute:
+        ti-lfa: {}
+    interface:
+    - if-name: lo
+      ipv6:
+        enable: true
+    - if-name: n2-s
+      network-type: point-to-point
+      metric: 1
+      ipv6:
+        enable: true
+    - if-name: n2-r1
+      network-type: point-to-point
+      metric: 1
+      ipv6:
+        enable: true

--- a/bdd/tests/configs/flexalgo_tilfa_srv6/n3.yaml
+++ b/bdd/tests/configs/flexalgo_tilfa_srv6/n3.yaml
@@ -1,0 +1,53 @@
+# n3 — expensive third neighbour of s; makes a plain LFA impossible.
+interface:
+- if-name: lo
+  ipv6:
+    address: 2001:db8::4/128
+- if-name: n3-s
+  ipv6:
+    address: 2001:db8:0:3::2/64
+- if-name: n3-r1
+  ipv6:
+    address: 2001:db8:0:6::1/64
+segment-routing:
+  locator:
+  - name: LOC4
+    prefix: fcbb:bbbb:4::/48
+    behavior: usid
+  - name: LOC4_A128
+    prefix: fcbb:bbbb:14::/48
+    behavior: usid
+router:
+  isis:
+    net: 49.0000.0000.0000.0004.00
+    hostname: n3
+    is-type: level-2-only
+    segment-routing:
+      srv6:
+        locator: LOC4
+        flex-algo-locator:
+        - algo: 128
+          locator: LOC4_A128
+    fast-reroute:
+      ti-lfa: {}
+    flex-algo:
+    - algo: 128
+      advertise-definition: true
+      dataplane:
+        srv6: true
+      fast-reroute:
+        ti-lfa: {}
+    interface:
+    - if-name: lo
+      ipv6:
+        enable: true
+    - if-name: n3-s
+      network-type: point-to-point
+      metric: 1000
+      ipv6:
+        enable: true
+    - if-name: n3-r1
+      network-type: point-to-point
+      metric: 1000
+      ipv6:
+        enable: true

--- a/bdd/tests/configs/flexalgo_tilfa_srv6/r1.yaml
+++ b/bdd/tests/configs/flexalgo_tilfa_srv6/r1.yaml
@@ -1,0 +1,69 @@
+# r1 — hub of the r-plane the repair tunnel traverses.
+interface:
+- if-name: lo
+  ipv6:
+    address: 2001:db8::5/128
+- if-name: r1-n1
+  ipv6:
+    address: 2001:db8:0:4::2/64
+- if-name: r1-n2
+  ipv6:
+    address: 2001:db8:0:5::2/64
+- if-name: r1-n3
+  ipv6:
+    address: 2001:db8:0:6::2/64
+- if-name: r1-r2
+  ipv6:
+    address: 2001:db8:0:8::1/64
+segment-routing:
+  locator:
+  - name: LOC5
+    prefix: fcbb:bbbb:5::/48
+    behavior: usid
+  - name: LOC5_A128
+    prefix: fcbb:bbbb:15::/48
+    behavior: usid
+router:
+  isis:
+    net: 49.0000.0000.0000.0005.00
+    hostname: r1
+    is-type: level-2-only
+    segment-routing:
+      srv6:
+        locator: LOC5
+        flex-algo-locator:
+        - algo: 128
+          locator: LOC5_A128
+    fast-reroute:
+      ti-lfa: {}
+    flex-algo:
+    - algo: 128
+      advertise-definition: true
+      dataplane:
+        srv6: true
+      fast-reroute:
+        ti-lfa: {}
+    interface:
+    - if-name: lo
+      ipv6:
+        enable: true
+    - if-name: r1-n1
+      network-type: point-to-point
+      metric: 1
+      ipv6:
+        enable: true
+    - if-name: r1-n2
+      network-type: point-to-point
+      metric: 1
+      ipv6:
+        enable: true
+    - if-name: r1-n3
+      network-type: point-to-point
+      metric: 1000
+      ipv6:
+        enable: true
+    - if-name: r1-r2
+      network-type: point-to-point
+      metric: 1000
+      ipv6:
+        enable: true

--- a/bdd/tests/configs/flexalgo_tilfa_srv6/r2.yaml
+++ b/bdd/tests/configs/flexalgo_tilfa_srv6/r2.yaml
@@ -1,0 +1,61 @@
+# r2 — r-plane transit between r1 and r3.
+interface:
+- if-name: lo
+  ipv6:
+    address: 2001:db8::6/128
+- if-name: r2-n1
+  ipv6:
+    address: 2001:db8:0:7::2/64
+- if-name: r2-r1
+  ipv6:
+    address: 2001:db8:0:8::2/64
+- if-name: r2-r3
+  ipv6:
+    address: 2001:db8:0:9::1/64
+segment-routing:
+  locator:
+  - name: LOC6
+    prefix: fcbb:bbbb:6::/48
+    behavior: usid
+  - name: LOC6_A128
+    prefix: fcbb:bbbb:16::/48
+    behavior: usid
+router:
+  isis:
+    net: 49.0000.0000.0000.0006.00
+    hostname: r2
+    is-type: level-2-only
+    segment-routing:
+      srv6:
+        locator: LOC6
+        flex-algo-locator:
+        - algo: 128
+          locator: LOC6_A128
+    fast-reroute:
+      ti-lfa: {}
+    flex-algo:
+    - algo: 128
+      advertise-definition: true
+      dataplane:
+        srv6: true
+      fast-reroute:
+        ti-lfa: {}
+    interface:
+    - if-name: lo
+      ipv6:
+        enable: true
+    - if-name: r2-n1
+      network-type: point-to-point
+      metric: 1
+      ipv6:
+        enable: true
+    - if-name: r2-r1
+      network-type: point-to-point
+      metric: 1000
+      ipv6:
+        enable: true
+    - if-name: r2-r3
+      network-type: point-to-point
+      metric: 1000
+      ipv6:
+        enable: true

--- a/bdd/tests/configs/flexalgo_tilfa_srv6/r3.yaml
+++ b/bdd/tests/configs/flexalgo_tilfa_srv6/r3.yaml
@@ -1,0 +1,53 @@
+# r3 — last r-plane hop before d (Q-node side).
+interface:
+- if-name: lo
+  ipv6:
+    address: 2001:db8::7/128
+- if-name: r3-r2
+  ipv6:
+    address: 2001:db8:0:9::2/64
+- if-name: r3-d
+  ipv6:
+    address: 2001:db8:0:11::1/64
+segment-routing:
+  locator:
+  - name: LOC7
+    prefix: fcbb:bbbb:7::/48
+    behavior: usid
+  - name: LOC7_A128
+    prefix: fcbb:bbbb:17::/48
+    behavior: usid
+router:
+  isis:
+    net: 49.0000.0000.0000.0007.00
+    hostname: r3
+    is-type: level-2-only
+    segment-routing:
+      srv6:
+        locator: LOC7
+        flex-algo-locator:
+        - algo: 128
+          locator: LOC7_A128
+    fast-reroute:
+      ti-lfa: {}
+    flex-algo:
+    - algo: 128
+      advertise-definition: true
+      dataplane:
+        srv6: true
+      fast-reroute:
+        ti-lfa: {}
+    interface:
+    - if-name: lo
+      ipv6:
+        enable: true
+    - if-name: r3-r2
+      network-type: point-to-point
+      metric: 1000
+      ipv6:
+        enable: true
+    - if-name: r3-d
+      network-type: point-to-point
+      metric: 1
+      ipv6:
+        enable: true

--- a/bdd/tests/configs/flexalgo_tilfa_srv6/s.yaml
+++ b/bdd/tests/configs/flexalgo_tilfa_srv6/s.yaml
@@ -1,0 +1,67 @@
+# s — TI-LFA source. Flex-Algo sibling of configs/tilfa_srv6/s.yaml:
+# the SAME proven 8-node topology + metrics, plus a Flex-Algorithm 128
+# that participates over every link (no affinity constraints, so algo
+# 128's topology == algo 0's) with its own per-algo SRv6 locator and
+# per-algo TI-LFA. The algo-128 repair therefore mirrors the algo-0 one.
+# Pure-IGP variant (no BGP/LAN): the test exercises the per-algo SRv6
+# TI-LFA repair on the per-algo locator routes, not service traffic.
+interface:
+- if-name: lo
+  ipv6:
+    address: 2001:db8::1/128
+- if-name: s-n1
+  ipv6:
+    address: 2001:db8:0:1::1/64
+- if-name: s-n2
+  ipv6:
+    address: 2001:db8:0:2::1/64
+- if-name: s-n3
+  ipv6:
+    address: 2001:db8:0:3::1/64
+segment-routing:
+  locator:
+  - name: LOC1
+    prefix: fcbb:bbbb:1::/48
+    behavior: usid
+  - name: LOC1_A128
+    prefix: fcbb:bbbb:11::/48
+    behavior: usid
+router:
+  isis:
+    net: 49.0000.0000.0000.0001.00
+    hostname: s
+    is-type: level-2-only
+    segment-routing:
+      srv6:
+        locator: LOC1
+        flex-algo-locator:
+        - algo: 128
+          locator: LOC1_A128
+    fast-reroute:
+      ti-lfa: {}
+    flex-algo:
+    - algo: 128
+      advertise-definition: true
+      dataplane:
+        srv6: true
+      fast-reroute:
+        ti-lfa: {}
+    interface:
+    - if-name: lo
+      ipv6:
+        enable: true
+    - if-name: s-n1
+      network-type: point-to-point
+      metric: 1
+      ipv6:
+        enable: true
+    - if-name: s-n2
+      network-type: point-to-point
+      metric: 1
+      ipv6:
+        enable: true
+    - if-name: s-n3
+      network-type: point-to-point
+      metric: 1000
+      ipv6:
+        enable: true

--- a/bdd/tests/features/flexalgo_tilfa_srv6.feature
+++ b/bdd/tests/features/flexalgo_tilfa_srv6.feature
@@ -1,0 +1,138 @@
+@flexalgo_tilfa_srv6
+Feature: IS-IS per-Flex-Algorithm TI-LFA over SRv6
+  Flex-Algo sibling of @tilfa_srv6. Same proven eight-router topology and
+  metrics (IPv6-only, every circuit point-to-point), but each router also
+  runs a Flexible-Algorithm 128 (RFC 9350) on the SRv6 dataplane:
+
+  - each router owns a per-algo SRv6 locator fcbb:bbbb:1X::/48 (behavior
+    usid) bound to algo 128 via `segment-routing srv6 flex-algo-locator`,
+    alongside its base (algo-0) locator fcbb:bbbb:X::/48;
+  - algo 128 has no affinity constraints, so its topology equals algo 0's
+    — the per-algo TI-LFA repair therefore mirrors the algo-0 one;
+  - `flex-algo 128 fast-reroute ti-lfa` enables per-algo TI-LFA, so the
+    per-algo locator routes carry a repair resolved to *algo-128* End /
+    End.X SIDs (the repair stays inside algo 128's topology), SRH-inserted
+    like the algo-0 repair.
+
+  The metrics are tuned (from @tilfa_srv6) so a simple LFA is impossible:
+  s reaches d via s-n1 (cost 2); protecting s-n1 needs an SR repair tunnel
+  through the r-plane. This validates per-algo TI-LFA + per-algo End.X SID
+  origination end-to-end on the SRv6 dataplane.
+
+  NOTE: like every BDD here this runs under the (CI-excluded) bdd suite in
+  network namespaces; it has not been executed in the authoring sandbox.
+
+  Scenario: Build the per-Flex-Algo SRv6 TI-LFA topology and confirm IS-IS
+    Given a clean test environment
+    When I create namespace "s"
+    And I create namespace "n1"
+    And I create namespace "n2"
+    And I create namespace "n3"
+    And I create namespace "r1"
+    And I create namespace "r2"
+    And I create namespace "r3"
+    And I create namespace "d"
+    And I connect namespace "s" interface "s-n1" to namespace "n1" interface "n1-s"
+    And I connect namespace "s" interface "s-n2" to namespace "n2" interface "n2-s"
+    And I connect namespace "s" interface "s-n3" to namespace "n3" interface "n3-s"
+    And I connect namespace "n1" interface "n1-r1" to namespace "r1" interface "r1-n1"
+    And I connect namespace "n2" interface "n2-r1" to namespace "r1" interface "r1-n2"
+    And I connect namespace "n3" interface "n3-r1" to namespace "r1" interface "r1-n3"
+    And I connect namespace "n1" interface "n1-r2" to namespace "r2" interface "r2-n1"
+    And I connect namespace "r1" interface "r1-r2" to namespace "r2" interface "r2-r1"
+    And I connect namespace "r2" interface "r2-r3" to namespace "r3" interface "r3-r2"
+    And I connect namespace "n1" interface "n1-d" to namespace "d" interface "d-n1"
+    And I connect namespace "r3" interface "r3-d" to namespace "d" interface "d-r3"
+    And I start zebra-rs in namespace "s"
+    And I start zebra-rs in namespace "n1"
+    And I start zebra-rs in namespace "n2"
+    And I start zebra-rs in namespace "n3"
+    And I start zebra-rs in namespace "r1"
+    And I start zebra-rs in namespace "r2"
+    And I start zebra-rs in namespace "r3"
+    And I start zebra-rs in namespace "d"
+    And I apply config "s.yaml" to namespace "s"
+    And I apply config "n1.yaml" to namespace "n1"
+    And I apply config "n2.yaml" to namespace "n2"
+    And I apply config "n3.yaml" to namespace "n3"
+    And I apply config "r1.yaml" to namespace "r1"
+    And I apply config "r2.yaml" to namespace "r2"
+    And I apply config "r3.yaml" to namespace "r3"
+    And I apply config "d.yaml" to namespace "d"
+    And I wait 20 seconds
+    # Directly-connected adjacency over s-n1, then loopbacks across the
+    # IS-IS IPv6 (algo-0) domain.
+    Then ping from "s" to "2001:db8:0:1::2" should succeed
+    And ping from "s" to "2001:db8::8" should succeed
+    And ping from "d" to "2001:db8::1" should succeed
+
+  Scenario: Per-algo SRv6 SIDs exist and algo-128 locators are reachable
+    Given the test topology exists
+    # s owns its base + algo-128 End (uN) SIDs and carved End.X (uA) SIDs
+    # per adjacency for both algorithms; each uA also installs its LIB
+    # twin for NEXT-C-SID carrier resolution.
+    Then show command "show segment-routing srv6 sid" in namespace "s" should contain "uN"
+    And show command "show segment-routing srv6 sid" in namespace "s" should contain "uA"
+    And show command "show segment-routing srv6 sid" in namespace "s" should contain "uA(LIB)"
+    # s reaches every other node's algo-128 locator over the algo-128
+    # topology (= algo-0 here): d (fcbb:bbbb:18::), n1 (fcbb:bbbb:12::),
+    # r3 (fcbb:bbbb:17::).
+    And show command "show isis flex-algo route algorithm 128" in namespace "s" should contain "fcbb:bbbb:18::"
+    And show command "show isis flex-algo route algorithm 128" in namespace "s" should contain "fcbb:bbbb:12::"
+    And show command "show isis flex-algo route algorithm 128" in namespace "s" should contain "fcbb:bbbb:17::"
+
+  Scenario: Algo-0 fast-reroute survives the primary link failure (s-n1)
+    Given the test topology exists
+    Then ping from "s" to "2001:db8::8" should succeed
+    When I make namespace "s" interface "s-n1" down
+    And I wait 5 seconds
+    # Reachability restored over the SRv6 repair / post-convergence path
+    # (out a different interface than the failed s-n1). The algo-128
+    # locator route to d also reconverges and stays installed.
+    Then ping from "s" to "2001:db8::8" should succeed
+    And kernel route "fcbb:bbbb:18::/48" in namespace "s" should eventually contain "proto isis"
+    When I make namespace "s" interface "s-n1" up
+    And I wait 10 seconds
+    Then ping from "s" to "2001:db8::8" should succeed
+
+  Scenario: Promoted per-algo backup forwards over the algo-128 SRv6 repair
+    Given the test topology exists
+    # `backup-as-primary` swaps the metric-sort offset so each TI-LFA
+    # repair (algo-0 and per-algo) installs as the active route; `clear
+    # isis spf` recomputes and reinstalls with the flag applied. This
+    # pins the algo-128 locator route onto its SRv6 repair while every
+    # link stays up — proving the algo-128 uN/uA SID list genuinely
+    # installs in the dataplane.
+    When I apply command "set router isis fast-reroute backup-as-primary" in namespace "s"
+    And I run "clear isis spf" in namespace "s"
+    # d's algo-128 locator route now has the SRH-insert repair as its best
+    # kernel entry: out the repair egress s-n2, an IS-IS route.
+    Then kernel route "fcbb:bbbb:18::/48" in namespace "s" should eventually contain "mode inline"
+    And kernel route "fcbb:bbbb:18::/48" in namespace "s" should eventually contain "proto isis"
+    And kernel route "fcbb:bbbb:18::/48" in namespace "s" should eventually contain "dev s-n2"
+    # NEXT-C-SID compression: the algo-128 repair uSIDs (uN of the P node
+    # plus the uAs) ride one 128-bit carrier, so the inserted SRH is
+    # carrier + original destination — 2 segments.
+    And kernel route "fcbb:bbbb:18::/48" in namespace "s" should eventually contain "segs 2 ["
+    # Algo-0 forwarding stays intact (same topology, separate locator).
+    And ping from "s" to "2001:db8::8" should succeed
+
+  Scenario: Teardown topology
+    Given the test topology exists
+    When I stop zebra-rs in namespace "s"
+    And I stop zebra-rs in namespace "n1"
+    And I stop zebra-rs in namespace "n2"
+    And I stop zebra-rs in namespace "n3"
+    And I stop zebra-rs in namespace "r1"
+    And I stop zebra-rs in namespace "r2"
+    And I stop zebra-rs in namespace "r3"
+    And I stop zebra-rs in namespace "d"
+    And I delete namespace "s"
+    And I delete namespace "n1"
+    And I delete namespace "n2"
+    And I delete namespace "n3"
+    And I delete namespace "r1"
+    And I delete namespace "r2"
+    And I delete namespace "r3"
+    And I delete namespace "d"
+    Then the test environment should be clean

--- a/docs/design/isis-flexalgo-srv6-plan.md
+++ b/docs/design/isis-flexalgo-srv6-plan.md
@@ -149,10 +149,23 @@ across a convergence burst would cut redundant full-snapshot clones
 (VRFs are few and churn is transient, so it's a perf nicety not a
 correctness issue).
 
-Remaining deferred: a **TI-LFA BDD** (the PR-6 `isis_flex_srv6` topology
-has no intra-algo redundancy to exercise a repair). The PR-6 BDD feature
-was authored but not executed here (needs root/netns; CI runs the bdd
-suite).
+**TI-LFA BDD: authored** (`@flexalgo_tilfa_srv6`) — clones the proven
+8-node `tilfa_srv6` topology + metrics (so the repair is guaranteed to
+exist) and adds a per-algo locator + `flex-algo 128` (`dataplane srv6` +
+per-algo `ti-lfa`, no affinity constraints → algo-128 topology == algo-0)
+to each node. Pure-IGP; 5 scenarios assert per-algo SID + algo-128
+locator reachability, algo-0 FRR survival on `s-n1` down, and — under
+`backup-as-primary` — the promoted per-algo SRv6 repair on d's algo-128
+locator kernel route (`mode inline` / `proto isis` / `dev s-n2` /
+`segs 2 [`). All 8 configs YAML-validated. Like every BDD here it runs
+under the CI-excluded bdd suite (root/netns) and was *not* executed in
+the authoring sandbox — a real run may need assertion tuning.
+
+The SRv6 Flex-Algo plan is now complete end-to-end: IGP reachability
+(#1461), colour steering — global unicast (#1462), service-route (#1471),
+per-VRF VPN (#1472) — per-algo TI-LFA (#1469), per-algo End.X (#1470),
+and this BDD. Remaining nicety: coalescing the per-VRF colour-shadow
+broadcast across a convergence burst.
 
 ## Decisions (locked 2026-06-16)
 


### PR DESCRIPTION
## Summary

Add `@flexalgo_tilfa_srv6`, the Flex-Algo sibling of `@tilfa_srv6` — the BDD that exercises per-algorithm TI-LFA (#1469) and per-algo End.X SID origination (#1470) end-to-end on the SRv6 dataplane.

It **clones the proven 8-node `tilfa_srv6` topology + metrics** (so a TI-LFA repair is guaranteed to exist) and adds to each node a per-algo SRv6 locator (`fcbb:bbbb:1X::/48`) bound to algo 128, plus a `flex-algo 128` with `dataplane srv6` + per-algo `fast-reroute ti-lfa`. Algo 128 carries no affinity constraints, so its topology equals algo 0's and the per-algo repair mirrors the algo-0 one.

## Scenarios (pure-IGP, no BGP/LAN)

1. Build the topology + confirm IS-IS adjacency.
2. Per-algo SRv6 SIDs (uN/uA/uA(LIB)) + algo-128 locator reachability (`show isis flex-algo route algorithm 128`).
3. Algo-0 fast-reroute survives `s-n1` down; the algo-128 locator route stays installed.
4. Under `backup-as-primary`, the promoted per-algo SRv6 repair on d's algo-128 locator kernel route: `mode inline` / `proto isis` / `dev s-n2` / `segs 2 [`.
5. Teardown.

## Test plan

- All 8 node configs YAML-validated; design-doc updated.
- No Rust changed (BDD data + docs only) — `fmt`/`clippy`/`test` unaffected.
- **Caveat:** like every BDD here it runs under the CI-excluded bdd suite in network namespaces and was **not** executed in the authoring sandbox (no root/netns). A real run may need assertion tuning.

Generated with [Claude Code](https://claude.com/claude-code)