### PR TITLE
book: enable mdBook sidebar section folding

### DIFF
--- a/book/book.toml
+++ b/book/book.toml
@@ -3,3 +3,6 @@ title = "zebra-rs"
 authors = ["Kunihiro Ishiguro"]
 language = "en"
 src = "src"
+[output.html.fold]
+enable = true
+level = 0 


### PR DESCRIPTION
## Summary

Add `[output.html.fold]` to `book/book.toml` so the generated documentation sidebar collapses chapter sections by default (`enable = true`, `level = 0`).

## Test plan

- `mdbook build book` renders the sidebar with foldable sections.
- Docs-only change; no code paths affected.

Generated with [Claude Code](https://claude.com/claude-code)