### PR TITLE
vxlan: apply EVPN-correct defaults on tunnel creation

### DIFF
--- a/book/src/SUMMARY.md
+++ b/book/src/SUMMARY.md
@@ -4,6 +4,7 @@
 - [Separation of Reachability Information and Forwarding Decision](ch-00-01-reachability-information.md)
 - [Router ID Selection](ch-00-02-router-id.md)
 - [Interface Configuration](ch-00-03-interface-configuration.md)
+- [VXLAN Configuration](ch-00-04-vxlan-configuration.md)
 
 ## Static Route
 

--- a/book/src/ch-00-04-vxlan-configuration.md
+++ b/book/src/ch-00-04-vxlan-configuration.md
@@ -1,0 +1,144 @@
+# VXLAN Configuration
+
+zebra-rs can create a **VXLAN tunnel device** from configuration. Unlike
+the [`interface`](ch-00-03-interface-configuration.md) block — which
+only attaches attributes to a device that already exists — the
+top-level `vxlan` list **creates** the kernel VXLAN netdevice (the
+equivalent of `ip link add <name> type vxlan ...`) and tears it down
+when the entry is removed.
+
+A VXLAN device is the data-plane endpoint (VTEP) for an EVPN overlay:
+once it is enslaved to a Linux bridge it carries the L2 service, and the
+control plane (BGP [EVPN Type-5](ch-02-06-bgp-evpn-type5.md) and the L2
+Type-2 / Type-3 routes) populates the forwarding database. Because the
+overlay relies on a BGP control plane rather than data-plane
+flood-and-learn, zebra-rs applies a set of EVPN-appropriate **defaults**
+automatically so the operator does not have to spell each one out.
+
+## Configuration
+
+The `vxlan` list is keyed by the device name:
+
+```
+vxlan vni550 {
+  vni 550;
+  local-address 10.0.0.1;
+  dest-port 4789;
+}
+```
+
+or, in command form:
+
+```
+set vxlan vni550 vni 550
+set vxlan vni550 local-address 10.0.0.1
+set vxlan vni550 dest-port 4789
+```
+
+| YANG leaf | Type | Required | Notes |
+|---|---|---|---|
+| `/vxlan/<name>/name` | `string` | — | List key — the kernel device name (e.g. `vni550`). |
+| `/vxlan/<name>/vni` | `uint32` | **yes** | VXLAN Network Identifier → `IFLA_VXLAN_ID`. |
+| `/vxlan/<name>/local-address` | `inet:ipv4-address` \| `inet:ipv6-address` | no | Source VTEP address → `IFLA_VXLAN_LOCAL` / `IFLA_VXLAN_LOCAL6`. |
+| `/vxlan/<name>/dest-port` | `uint16` | no | UDP destination port → `IFLA_VXLAN_PORT`. Defaults to `4789`. |
+| `/vxlan/<name>/address-gen-mode` | `enum {none, eui64, random, stable-secret}` | no | IPv6 link-local address generation mode. Defaults to `none`. |
+
+## Defaults applied automatically
+
+When zebra-rs creates the VXLAN device it bakes in the settings that an
+EVPN deployment would otherwise have to configure by hand. None of these
+have a config knob — they are the fixed default for every VXLAN this
+daemon creates.
+
+### At device creation
+
+These are part of the `RTM_NEWLINK` that creates the device:
+
+| Default | Netlink | `ip link` equivalent | Why |
+|---|---|---|---|
+| **MAC learning off** (`nolearning`) | `IFLA_VXLAN_LEARNING = 0` | `... type vxlan ... nolearning` | The BGP control plane owns the FDB; kernel flood-and-learn must be off so it does not fight the control plane. |
+| **`dest-port 4789`** | `IFLA_VXLAN_PORT = 4789` | `... type vxlan ... dstport 4789` | The IANA-assigned VXLAN port, used when `dest-port` is unset — Linux would otherwise fall back to the legacy 8472. An explicit value always wins. |
+| **Brought up** | `IFF_UP` set on create | `ip link add ... up` | The device is operational immediately, without a separate `ip link set <dev> up`. |
+| **`address-gen-mode none`** | `IFLA_INET6_ADDR_GEN_MODE = 1` | `ip link set <dev> addrgenmode none` | Suppresses the kernel's automatic link-local on the VTEP. Applied as a follow-up `RTM_NEWLINK` after creation. |
+
+> The kernel's own default for address-gen-mode is `eui64` (it would
+> derive a link-local from the MAC). zebra-rs overrides this to `none`
+> unless the operator sets `address-gen-mode` explicitly — an explicit
+> value always wins.
+
+### When the device joins a bridge
+
+A VXLAN device only carries an L2 service once it is enslaved to a Linux
+bridge. zebra-rs does **not** assign the bridge master itself — that is
+done externally (`ip link set vni550 master <bridge>`, or by your
+bridge-management tooling) and zebra-rs **observes** it over netlink.
+The moment it sees a VXLAN device gain a bridge master, it applies the
+bridge-slave defaults to the port:
+
+| Default | Netlink | `ip link` equivalent | Why |
+|---|---|---|---|
+| **Neighbour suppression on** | `IFLA_BRPORT_NEIGH_SUPPRESS = 1` | `ip link set <dev> type bridge_slave neigh_suppress on` | ARP / ND requests are answered locally from the FDB instead of being flooded across the overlay. |
+| **Bridge-port learning off** | `IFLA_BRPORT_LEARNING = 0` | `ip link set <dev> type bridge_slave learning off` | The bridge must not learn MACs from the data plane on this port — the control plane installs them. |
+
+(If the master a VXLAN gains is not actually a bridge, the kernel
+rejects the bridge-port attributes and the attempt is logged at `info`;
+nothing else is affected.)
+
+## The full sequence
+
+Taken together, configuring a VXLAN in zebra-rs and enslaving it to a
+bridge reproduces the canonical EVPN-VXLAN bring-up. The four manual
+commands
+
+```
+ip link add vni550 type vxlan local 10.0.0.1 dstport 4789 id 550 nolearning
+ip link set vni550 master br550 addrgenmode none
+ip link set vni550 type bridge_slave neigh_suppress on learning off
+ip link set vni550 up
+```
+
+map onto zebra-rs as:
+
+* `set vxlan vni550 vni 550 / local-address 10.0.0.1 / dest-port 4789`
+  — the device, with `nolearning`, `addrgenmode none`, and `up` applied
+  automatically (the first command plus the `addrgenmode`/`up` parts).
+* `ip link set vni550 master br550` — **still external**; zebra-rs
+  observes it.
+* on observing that master, zebra-rs applies `neigh_suppress on` and
+  `learning off` automatically (the third command).
+
+So the operator supplies the VNI / VTEP / port and the bridge
+enslavement; zebra-rs fills in every EVPN-correct default.
+
+## Deleting the configuration
+
+Removing the list entry deletes the kernel device (`RTM_DELLINK`, the
+equivalent of `ip link del vni550`):
+
+```
+no vxlan vni550
+```
+
+## `dest-port` default
+
+`dest-port` is optional. When it is unset, zebra-rs sends
+`IFLA_VXLAN_PORT = 4789` — the **IANA-assigned** VXLAN port. This is a
+deliberate override of the kernel's own fallback, which is the
+pre-standardisation Linux port **8472**; defaulting to 4789 keeps the
+device interoperable with other EVPN/VXLAN implementations out of the
+box. An explicit `dest-port` always takes precedence.
+
+## Cross-reference — iproute2
+
+| zebra-rs | iproute2 |
+|---|---|
+| `vxlan <n> vni <id>` | `ip link add <n> type vxlan id <id>` |
+| `vxlan <n> local-address <ip>` | `... type vxlan local <ip>` |
+| `vxlan <n> dest-port <p>` | `... type vxlan dstport <p>` |
+| `vxlan <n> address-gen-mode <m>` | `ip link set <n> addrgenmode <m>` |
+| *(automatic)* `nolearning` | `... type vxlan ... nolearning` |
+| *(automatic)* device up | `ip link set <n> up` |
+| *(automatic on bridge-join)* `neigh_suppress on` | `ip link set <n> type bridge_slave neigh_suppress on` |
+| *(automatic on bridge-join)* `learning off` | `ip link set <n> type bridge_slave learning off` |
+| `no vxlan <n>` | `ip link del <n>` |
+| *(external)* bridge enslavement | `ip link set <n> master <bridge>` |

--- a/zebra-rs/src/fib/netlink/handle.rs
+++ b/zebra-rs/src/fib/netlink/handle.rs
@@ -11,8 +11,8 @@ use netlink_packet_route::address::{
     AddressAttribute, AddressHeaderFlags, AddressMessage, AddressScope,
 };
 use netlink_packet_route::link::{
-    AfSpecInet6, AfSpecUnspec, InfoData, InfoKind, InfoVrf, InfoVxlan, LinkAttribute, LinkFlags,
-    LinkInfo, LinkLayerType, LinkMessage,
+    AfSpecInet6, AfSpecUnspec, InfoBridgePort, InfoData, InfoKind, InfoPortData, InfoPortKind,
+    InfoVrf, InfoVxlan, LinkAttribute, LinkFlags, LinkInfo, LinkLayerType, LinkMessage,
 };
 use netlink_packet_route::neighbour::{NeighbourAddress, NeighbourAttribute, NeighbourMessage};
 use netlink_packet_route::nexthop::{NexthopAttribute, NexthopFlags, NexthopGroup, NexthopMessage};
@@ -1623,8 +1623,12 @@ impl FibHandle {
             return;
         };
 
-        // First create the vxlan interface
+        // First create the vxlan interface. Bring it up at creation
+        // (`ip link add ... up`) so the device is operational without a
+        // separate operator step.
         let mut msg = LinkMessage::default();
+        msg.header.flags = LinkFlags::Up;
+        msg.header.change_mask = LinkFlags::Up;
 
         let name = LinkAttribute::IfName(vxlan.name.clone());
         msg.attributes.push(name);
@@ -1637,11 +1641,11 @@ impl FibHandle {
         let vni = InfoVxlan::Id(vni);
         let mut vxlan_info = vec![vni];
 
-        // Destination port.
-        if let Some(dport) = vxlan.dport {
-            let port = InfoVxlan::Port(dport);
-            vxlan_info.push(port);
-        }
+        // Destination port. Defaults to the IANA-assigned VXLAN port
+        // (4789) when the operator hasn't configured one — Linux would
+        // otherwise fall back to the legacy 8472.
+        let dport = vxlan.dport.unwrap_or(4789);
+        vxlan_info.push(InfoVxlan::Port(dport));
 
         // Local address.
         if let Some(local_addr) = vxlan.local_addr {
@@ -1651,6 +1655,12 @@ impl FibHandle {
             };
             vxlan_info.push(info);
         }
+
+        // Disable data-plane MAC learning by default (`nolearning`).
+        // EVPN populates the FDB from the BGP control plane, so kernel
+        // flood-and-learn must be off.
+        vxlan_info.push(InfoVxlan::Learning(false));
+
         let link_info = LinkInfo::Data(InfoData::Vxlan(vxlan_info));
 
         let attr = LinkAttribute::LinkInfo(vec![link_kind, link_info]);
@@ -1667,11 +1677,12 @@ impl FibHandle {
             }
         }
 
-        // If we have addr_gen_mode, set it as a second operation
-        if let Some(addr_gen_mode) = &vxlan.addr_gen_mode {
-            self.vxlan_set_addr_gen_mode(&vxlan.name, addr_gen_mode)
-                .await;
-        }
+        // Set the IPv6 address generation mode as a second operation.
+        // Defaults to `none` (no kernel-generated link-local on the
+        // VXLAN device) when the operator hasn't configured one.
+        let addr_gen_mode = vxlan.addr_gen_mode.clone().unwrap_or(AddrGenMode::None);
+        self.vxlan_set_addr_gen_mode(&vxlan.name, &addr_gen_mode)
+            .await;
     }
 
     pub async fn vxlan_set_addr_gen_mode(&self, name: &str, addr_gen_mode: &AddrGenMode) {
@@ -1693,6 +1704,38 @@ impl FibHandle {
         while let Some(msg) = response.next().await {
             if let NetlinkPayload::Error(e) = msg.payload {
                 tracing::info!("SetLink addr-gen-mode error: {e}");
+            }
+        }
+    }
+
+    /// Apply the VXLAN bridge-slave defaults to the port at `ifindex`:
+    /// neighbour suppression on (ARP/ND answered locally from the FDB
+    /// instead of flooded) and bridge-port MAC learning off (EVPN's BGP
+    /// control plane owns the FDB). Equivalent to:
+    ///   ip link set <dev> type bridge_slave neigh_suppress on learning off
+    /// Called when the RIB observes a VXLAN device gaining a bridge
+    /// master; a no-op error is logged if the master is not a bridge.
+    pub async fn vxlan_bridge_port_defaults(&self, ifindex: u32) {
+        let mut msg = LinkMessage::default();
+        msg.header.index = ifindex;
+
+        let port_data = InfoPortData::BridgePort(vec![
+            InfoBridgePort::NeighSupress(true),
+            InfoBridgePort::Learning(false),
+        ]);
+        let link_info = LinkAttribute::LinkInfo(vec![
+            LinkInfo::PortKind(InfoPortKind::Bridge),
+            LinkInfo::PortData(port_data),
+        ]);
+        msg.attributes.push(link_info);
+
+        let mut req = NetlinkMessage::from(RouteNetlinkMessage::NewLink(msg));
+        req.header.flags = NLM_F_REQUEST | NLM_F_ACK;
+
+        let mut response = self.handle.clone().request(req).unwrap();
+        while let Some(msg) = response.next().await {
+            if let NetlinkPayload::Error(e) = msg.payload {
+                tracing::info!("SetLink bridge-port defaults error: {e}");
             }
         }
     }

--- a/zebra-rs/src/rib/link.rs
+++ b/zebra-rs/src/rib/link.rs
@@ -675,6 +675,9 @@ impl Rib {
         if let Some(bridge) = now_evpn_bridge
             && prev_evpn_bridge != Some(bridge)
         {
+            // The VXLAN just joined a bridge: apply the EVPN bridge-slave
+            // defaults on its port (`neigh_suppress on`, `learning off`).
+            self.fib_handle.vxlan_bridge_port_defaults(ifindex).await;
             self.rescan_fdb_for_bridge(bridge);
         }
 


### PR DESCRIPTION
## Summary

When zebra-rs creates a VXLAN tunnel device it now bakes in the settings an EVPN deployment needs, so the operator only supplies VNI / VTEP / port and the bridge enslavement — no per-knob configuration required.

**At device creation** (`vxlan_add`):
- `nolearning` (`IFLA_VXLAN_LEARNING=0`) — the BGP control plane owns the FDB, so kernel flood-and-learn must be off.
- `dest-port` defaults to **4789** (IANA) when unset, instead of the kernel's legacy 8472.
- `address-gen-mode` defaults to **none** (no auto link-local on the VTEP) when unset; an explicit value still wins.
- device brought **up** at creation (`IFF_UP`).

**On bridge-join** (observed via netlink in `link.rs`):
- `neigh_suppress on` (`IFLA_BRPORT_NEIGH_SUPPRESS=1`) and bridge-port `learning off` (`IFLA_BRPORT_LEARNING=0`) applied to the port. The bridge master assignment itself stays external; zebra-rs only observes it.

All defaults are hard (no new YANG knobs), matching the canonical `ip link add ... type vxlan ... nolearning` + `bridge_slave neigh_suppress on learning off` + `up` recipe.

## Docs

New `book/src/ch-00-04-vxlan-configuration.md` (linked in `SUMMARY.md`) documents every VXLAN CLI leaf and each default, with an iproute2 cross-reference.

## Test plan

- `cargo fmt` — no changes
- `cargo clippy --workspace --all-targets -- -D warnings` — clean
- `cargo test -p zebra-rs --bins` — 1296 passed, 0 failed
- `mdbook build book` — clean, no broken links

Generated with [Claude Code](https://claude.com/claude-code)