### PR TITLE
bridge: apply addrgenmode none + up defaults on creation

### DIFF
--- a/book/src/SUMMARY.md
+++ b/book/src/SUMMARY.md
@@ -5,6 +5,7 @@
 - [Router ID Selection](ch-00-02-router-id.md)
 - [Interface Configuration](ch-00-03-interface-configuration.md)
 - [VXLAN Configuration](ch-00-04-vxlan-configuration.md)
+- [Bridge Configuration](ch-00-05-bridge-configuration.md)
 
 ## Static Route
 

--- a/book/src/ch-00-04-vxlan-configuration.md
+++ b/book/src/ch-00-04-vxlan-configuration.md
@@ -8,7 +8,8 @@ equivalent of `ip link add <name> type vxlan ...`) and tears it down
 when the entry is removed.
 
 A VXLAN device is the data-plane endpoint (VTEP) for an EVPN overlay:
-once it is enslaved to a Linux bridge it carries the L2 service, and the
+once it is enslaved to a Linux [bridge](ch-00-05-bridge-configuration.md)
+it carries the L2 service, and the
 control plane (BGP [EVPN Type-5](ch-02-06-bgp-evpn-type5.md) and the L2
 Type-2 / Type-3 routes) populates the forwarding database. Because the
 overlay relies on a BGP control plane rather than data-plane

--- a/book/src/ch-00-05-bridge-configuration.md
+++ b/book/src/ch-00-05-bridge-configuration.md
@@ -1,0 +1,78 @@
+# Bridge Configuration
+
+zebra-rs can create a **Linux bridge device** from configuration. Like
+the [`vxlan`](ch-00-04-vxlan-configuration.md) block — and unlike
+[`interface`](ch-00-03-interface-configuration.md), which only attaches
+attributes to an existing device — the top-level `bridge` list
+**creates** the kernel bridge netdevice (`ip link add <name> type
+bridge`) and tears it down when the entry is removed.
+
+A bridge is the L2 forwarding domain an EVPN deployment binds a
+[VXLAN](ch-00-04-vxlan-configuration.md) device into: the VXLAN tunnel
+and the local access ports are enslaved to the same bridge, and the
+control plane drives the forwarding database.
+
+## Configuration
+
+The `bridge` list is keyed by the device name:
+
+```
+bridge br550 {
+  address-gen-mode none;
+}
+```
+
+or, in command form:
+
+```
+set bridge br550
+set bridge br550 address-gen-mode none
+```
+
+| YANG leaf | Type | Required | Notes |
+|---|---|---|---|
+| `/bridge/<name>/name` | `string` | — | List key — the kernel device name (e.g. `br550`). |
+| `/bridge/<name>/address-gen-mode` | `enum {none, eui64, random, stable-secret}` | no | IPv6 link-local address generation mode. Defaults to `none`. |
+
+## Defaults applied automatically
+
+When zebra-rs creates the bridge it applies the same device-bring-up
+defaults as for a VXLAN. Neither has a config knob beyond the
+`address-gen-mode` leaf — they are fixed for every bridge this daemon
+creates.
+
+| Default | Netlink | `ip link` equivalent | Why |
+|---|---|---|---|
+| **Brought up** | `IFF_UP` set on create | `ip link add ... up` | The bridge is operational immediately, without a separate `ip link set <dev> up`. |
+| **`address-gen-mode none`** | `IFLA_INET6_ADDR_GEN_MODE = 1` | `ip link set <dev> addrgenmode none` | Suppresses the kernel's automatic link-local on the bridge. Applied as a follow-up `RTM_NEWLINK` after creation. |
+
+> The kernel's own default for address-gen-mode is `eui64` (it would
+> derive a link-local from the MAC). zebra-rs overrides this to `none`
+> unless the operator sets `address-gen-mode` explicitly — an explicit
+> value always wins.
+
+Together these reproduce the canonical bridge bring-up:
+
+```
+ip link add br550 type bridge
+ip link set br550 addrgenmode none
+ip link set br550 up
+```
+
+## Deleting the configuration
+
+Removing the list entry deletes the kernel device (`RTM_DELLINK`, the
+equivalent of `ip link del br550`):
+
+```
+no bridge br550
+```
+
+## Cross-reference — iproute2
+
+| zebra-rs | iproute2 |
+|---|---|
+| `bridge <n>` | `ip link add <n> type bridge` |
+| `bridge <n> address-gen-mode <m>` | `ip link set <n> addrgenmode <m>` |
+| *(automatic)* device up | `ip link set <n> up` |
+| `no bridge <n>` | `ip link del <n>` |

--- a/zebra-rs/src/fib/netlink/handle.rs
+++ b/zebra-rs/src/fib/netlink/handle.rs
@@ -1541,8 +1541,12 @@ impl FibHandle {
     }
 
     pub async fn bridge_add(&self, bridge: &Bridge) {
-        // First create the bridge interface
+        // First create the bridge interface. Bring it up at creation
+        // (`ip link add ... up`) so the device is operational without a
+        // separate operator step.
         let mut msg = LinkMessage::default();
+        msg.header.flags = LinkFlags::Up;
+        msg.header.change_mask = LinkFlags::Up;
 
         let name = LinkAttribute::IfName(bridge.name.clone());
         msg.attributes.push(name);
@@ -1564,11 +1568,12 @@ impl FibHandle {
             }
         }
 
-        // If we have addr_gen_mode, set it as a second operation
-        if let Some(addr_gen_mode) = &bridge.addr_gen_mode {
-            self.bridge_set_addr_gen_mode(&bridge.name, addr_gen_mode)
-                .await;
-        }
+        // Set the IPv6 address generation mode as a second operation.
+        // Defaults to `none` (no kernel-generated link-local on the
+        // bridge) when the operator hasn't configured one.
+        let addr_gen_mode = bridge.addr_gen_mode.clone().unwrap_or(AddrGenMode::None);
+        self.bridge_set_addr_gen_mode(&bridge.name, &addr_gen_mode)
+            .await;
     }
 
     pub async fn bridge_set_addr_gen_mode(&self, name: &str, addr_gen_mode: &AddrGenMode) {


### PR DESCRIPTION
## Summary

When zebra-rs creates a bridge device (`bridge <name>` config) it now applies the same device-bring-up defaults as a VXLAN, so the operator does not have to spell them out:

- device brought **up** at creation (`IFF_UP` in the `RTM_NEWLINK`) — no separate `ip link set <dev> up`.
- `address-gen-mode` defaults to **none** (no kernel-generated link-local on the bridge) when unset; an explicit value still wins. Previously it was skipped entirely, leaving the kernel's `eui64` default.

This reproduces the canonical bring-up:

```
ip link add br550 type bridge
ip link set br550 addrgenmode none
ip link set br550 up
```

Mirrors the VXLAN defaults landed in #1479.

## Docs

New `book/src/ch-00-05-bridge-configuration.md` (linked in `SUMMARY.md`, cross-referenced from the VXLAN chapter) documents the bridge CLI (`name`, `address-gen-mode`) and both defaults, with an iproute2 cross-reference.

## Test plan

- `cargo fmt` — no changes
- `cargo clippy --workspace --all-targets -- -D warnings` — clean
- `cargo test -p zebra-rs --bins` — 1296 passed, 0 failed
- `mdbook build book` — clean, no broken links

Generated with [Claude Code](https://claude.com/claude-code)