### PR TITLE
isis/ospf: nest TI-LFA shard count under compute-mode sharding

### DIFF
--- a/bdd/tests/features/isis_tilfa.feature
+++ b/bdd/tests/features/isis_tilfa.feature
@@ -121,8 +121,9 @@ Feature: IS-IS TI-LFA fast-reroute over SR-MPLS
 
   Scenario: TI-LFA compute-mode sharding bounds parallelism and still protects
     Given the test topology exists
-    When I apply command "set router isis fast-reroute ti-lfa compute-shards 2" in namespace "s"
-    And I apply command "set router isis fast-reroute ti-lfa compute-mode sharding" in namespace "s"
+    # The shard count now nests under the `sharding` mode: one command
+    # selects sharding and bounds parallelism to 2 shards.
+    When I apply command "set router isis fast-reroute ti-lfa compute-mode sharding shards 2" in namespace "s"
     And I wait 5 seconds
     Then show command "show isis route detail" in namespace "s" should contain "Backup path: TI-LFA"
     And show command "show isis spf" in namespace "s" should contain "mode=sharding(2)"
@@ -134,12 +135,11 @@ Feature: IS-IS TI-LFA fast-reroute over SR-MPLS
     When I make namespace "s" interface "s-n1" up
     And I wait 10 seconds
     Then ping from "s" to "10.0.0.8" should succeed
-    # Surgical runtime deletes exercise the handlers' reset-to-default
-    # path; the next full-file apply would wipe these leaves anyway
-    # (file applies are whole-config replaces). Leaf deletes carry the
-    # current value, like `delete … bfd echo-mode transmit`.
+    # A surgical runtime delete of the `sharding` presence container
+    # exercises the handler's reset-to-default path (mode → serial,
+    # shards → 8); the next full-file apply would wipe these leaves
+    # anyway (file applies are whole-config replaces).
     When I apply command "delete router isis fast-reroute ti-lfa compute-mode sharding" in namespace "s"
-    And I apply command "delete router isis fast-reroute ti-lfa compute-shards 2" in namespace "s"
     And I wait 5 seconds
     Then show command "show isis spf" in namespace "s" should contain "mode=serial"
 

--- a/bdd/tests/features/ospfv2_tilfa.feature
+++ b/bdd/tests/features/ospfv2_tilfa.feature
@@ -162,8 +162,9 @@ Feature: OSPFv2 TI-LFA fast-reroute over SR-MPLS
 
   Scenario: TI-LFA compute-mode sharding bounds parallelism and still protects
     Given the test topology exists
-    When I apply command "set router ospf fast-reroute ti-lfa compute-shards 2" in namespace "s"
-    And I apply command "set router ospf fast-reroute ti-lfa compute-mode sharding" in namespace "s"
+    # The shard count now nests under the `sharding` mode: one command
+    # selects sharding and bounds parallelism to 2 shards.
+    When I apply command "set router ospf fast-reroute ti-lfa compute-mode sharding shards 2" in namespace "s"
     And I wait 5 seconds
     Then show command "show ospf ti-lfa" in namespace "s" should contain "Node-SID"
     And show command "show ospf" in namespace "s" should contain "mode=sharding(2)"
@@ -175,10 +176,10 @@ Feature: OSPFv2 TI-LFA fast-reroute over SR-MPLS
     When I make namespace "s" interface "s-n1" up
     And I wait 30 seconds
     Then ping from "s" to "10.0.0.8" should succeed
-    # Runtime leaf deletes (value-carrying) reset the scheduler to the
-    # stock serial mode for the remaining scenarios.
+    # Deleting the `sharding` presence container resets the scheduler to
+    # the stock serial mode (mode → serial, shards → 8) for the
+    # remaining scenarios.
     When I apply command "delete router ospf fast-reroute ti-lfa compute-mode sharding" in namespace "s"
-    And I apply command "delete router ospf fast-reroute ti-lfa compute-shards 2" in namespace "s"
     And I wait 5 seconds
     Then show command "show ospf" in namespace "s" should contain "mode=serial"
 

--- a/bdd/tests/features/ospfv3_tilfa.feature
+++ b/bdd/tests/features/ospfv3_tilfa.feature
@@ -170,8 +170,9 @@ Feature: OSPFv3 TI-LFA fast-reroute over SR-MPLS
 
   Scenario: TI-LFA compute-mode sharding bounds parallelism and still protects
     Given the test topology exists
-    When I apply command "set router ospfv3 fast-reroute ti-lfa compute-shards 2" in namespace "s"
-    And I apply command "set router ospfv3 fast-reroute ti-lfa compute-mode sharding" in namespace "s"
+    # The shard count now nests under the `sharding` mode: one command
+    # selects sharding and bounds parallelism to 2 shards.
+    When I apply command "set router ospfv3 fast-reroute ti-lfa compute-mode sharding shards 2" in namespace "s"
     And I wait 5 seconds
     Then show command "show ospfv3 ti-lfa" in namespace "s" should contain "Node-SID"
     And show command "show ospfv3" in namespace "s" should contain "mode=sharding(2)"
@@ -183,10 +184,10 @@ Feature: OSPFv3 TI-LFA fast-reroute over SR-MPLS
     When I make namespace "s" interface "s-n1" up
     And I wait 30 seconds
     Then ping from "s" to "2001:db8::8" should succeed
-    # Runtime leaf deletes (value-carrying) reset the scheduler to the
-    # stock serial mode for the remaining scenarios.
+    # Deleting the `sharding` presence container resets the scheduler to
+    # the stock serial mode (mode → serial, shards → 8) for the
+    # remaining scenarios.
     When I apply command "delete router ospfv3 fast-reroute ti-lfa compute-mode sharding" in namespace "s"
-    And I apply command "delete router ospfv3 fast-reroute ti-lfa compute-shards 2" in namespace "s"
     And I wait 5 seconds
     Then show command "show ospfv3" in namespace "s" should contain "mode=serial"
 

--- a/book/src/ch-12-00-nexthop-protect.md
+++ b/book/src/ch-12-00-nexthop-protect.md
@@ -117,14 +117,38 @@ every mode** — the same repairs install bit-for-bit; only CPU usage and
 wall-clock time differ:
 
 ```
-router isis {                       // same under router ospf / ospfv3
+router isis {
   fast-reroute {
     ti-lfa {
-      compute-mode aggressive;      // serial | conservative | aggressive | sharding
-      compute-shards 4;             // sharding mode only, 1..256 (default 8)
+      // serial | conservative | aggressive | sharding
+      compute-mode sharding shards 4;   // shard count nests under sharding,
+                                        // 1..256 (default 8); bare `sharding` = 8
     }
   }
 }
+```
+
+OSPFv2 (OSPFv3 is identical under `router ospfv3`):
+
+```
+router ospf {
+  fast-reroute {
+    ti-lfa {
+      compute-mode aggressive;          // serial | conservative | aggressive | sharding
+      // or bound the parallelism explicitly:
+      // compute-mode sharding shards 4;
+    }
+  }
+}
+```
+
+The shard count nests under the `sharding` mode
+(`compute-mode sharding [shards <1..256>]`) — identical syntax for
+IS-IS, OSPFv2 and OSPFv3. Equivalent flat CLI:
+
+```
+set router ospf    fast-reroute ti-lfa compute-mode sharding shards 4
+set router ospfv3  fast-reroute ti-lfa compute-mode sharding shards 4
 ```
 
 | mode | scheduling | when to use |
@@ -132,7 +156,7 @@ router isis {                       // same under router ospf / ospfv3
 | `serial` (default) | sequential on the SPF worker thread | small topologies; the conservative default |
 | `conservative` | one parallel task per destination, no shared state between tasks | simple parallelism without shared SPF trees |
 | `aggressive` | shares each first-hop's excluded-graph SPF across its destinations, all jobs fanned out | fastest wall clock and lowest total CPU |
-| `sharding` | the same shared-SPF work, packed into at most `compute-shards` parallel shards | hard cap on TI-LFA's core usage — reserve CPU for other daemons on a shared box |
+| `sharding` | the same shared-SPF work, packed into at most `shards` parallel shards (`compute-mode sharding shards N`) | hard cap on TI-LFA's core usage — reserve CPU for other daemons on a shared box |
 
 Parallel modes run on a process-wide worker pool sized to the machine's
 core count, so concurrent SPF runs (L1+L2, multiple areas, VRF

--- a/docs/design/isis-tilfa-parallel-spf.md
+++ b/docs/design/isis-tilfa-parallel-spf.md
@@ -291,18 +291,25 @@ YANG (`zebra-rs/yang/config.yang`, inside the existing
 ```yang
 container ti-lfa {
   presence "Enable Topology-Independent LFA (TI-LFA)";
-  leaf compute-mode {
-    type enumeration {
-      enum serial;        // current behavior (default)
-      enum conservative;  // task per destination
-      enum aggressive;    // SPF-granularity map-reduce, full dedup
-      enum sharding;      // bounded by compute-shards
+  container compute-mode {
+    // One keyword per mode under a `choice`; the shard count nests
+    // under `sharding`, the only mode it applies to. Mutually
+    // exclusive cases; the default mode (serial) is applied by the
+    // handler (a choice/case carries no YANG default).
+    choice mode {
+      case serial       { leaf serial       { type empty; } }  // current behavior (default)
+      case conservative { leaf conservative { type empty; } }  // task per destination
+      case aggressive   { leaf aggressive   { type empty; } }  // SPF-granularity map-reduce, full dedup
+      case sharding {
+        container sharding {
+          presence "Shard the aggressive computation (default 8 shards)";
+          leaf shards {
+            type uint16 { range "1..256"; }
+            default 8;   // bare `sharding` => 8 (applied by the handler)
+          }
+        }
+      }
     }
-    default serial;
-  }
-  leaf compute-shards {
-    type uint16 { range "1..256"; }
-    default 8;            // consulted only when compute-mode = sharding
   }
 }
 ```
@@ -311,9 +318,12 @@ CLI:
 
 ```
 set router isis fast-reroute ti-lfa compute-mode aggressive
-set router isis fast-reroute ti-lfa compute-mode sharding
-set router isis fast-reroute ti-lfa compute-shards 4
+set router isis fast-reroute ti-lfa compute-mode sharding              # 8 shards
+set router isis fast-reroute ti-lfa compute-mode sharding shards 4
 ```
+
+(OSPFv2 / OSPFv3 carry the same nested shape — `compute-mode <mode>`
+with the shard count under `compute-mode sharding shards <1..256>`.)
 
 Handlers mirror `config_fast_reroute_backup_as_primary`
 (config.rs:1345): store on `IsisConfig`
@@ -359,7 +369,7 @@ Tests:
 - Planner unit: grouping, LPT balance, `K >` group count, single group.
 - BDD: extend `bdd/tests/features/isis_tilfa.feature` (or a sibling
   `@isis_tilfa_parallel` feature reusing its topology) with scenarios
-  that set `compute-mode aggressive` / `sharding` + `compute-shards 2`
+  that set `compute-mode aggressive` / `compute-mode sharding shards 2`
   and assert the same repair output as the serial scenario; mandatory
   `Scenario: Teardown topology` per repo BDD rules.
 - Perf harness: `#[ignore]`d test generating a ~24×24 grid graph and

--- a/docs/design/tilfa-parallel-spf-followups.md
+++ b/docs/design/tilfa-parallel-spf-followups.md
@@ -78,7 +78,7 @@ IS-IS and OSPF.
 - `Sharding(K)` with `K >` (distinct first-hop count) silently runs at
   group-count width (groups are never split; `width` reports the
   effective value). A debug log on the clamp could help operators
-  tuning `compute-shards`.
+  tuning the `compute-mode sharding shards` count.
 - Conservative mode has no BDD scenario (aggressive + sharding are
   exercised live; conservative is pinned by the unit equivalence
   suite). Add one if a regression ever slips through that gap.

--- a/zebra-rs/src/config/manager.rs
+++ b/zebra-rs/src/config/manager.rs
@@ -1454,10 +1454,11 @@ mod yang_load_tests {
     }
 
     /// TI-LFA parallel-computation knobs: `fast-reroute ti-lfa
-    /// compute-mode <serial|conservative|aggressive|sharding>` plus
-    /// `compute-shards <1..256>`. Pinned because vtyctl apply is
-    /// garbage-tolerant — an unwired grammar silently no-ops instead
-    /// of erroring.
+    /// compute-mode <serial|conservative|aggressive|sharding>`. IS-IS,
+    /// OSPFv2 and OSPFv3 all nest the shard count as `compute-mode
+    /// sharding shards <1..256>`. Pinned because vtyctl apply is
+    /// garbage-tolerant — an unwired grammar silently no-ops instead of
+    /// erroring.
     #[test]
     fn isis_tilfa_compute_grammar() {
         use crate::config::ExecCode;
@@ -1474,37 +1475,46 @@ mod yang_load_tests {
             .expect("configure module present");
         let entry = to_entry(&yang, module);
 
-        for cmd in [
-            "set router isis fast-reroute ti-lfa compute-mode serial",
-            "set router isis fast-reroute ti-lfa compute-mode conservative",
-            "set router isis fast-reroute ti-lfa compute-mode aggressive",
-            "set router isis fast-reroute ti-lfa compute-mode sharding",
-            "set router isis fast-reroute ti-lfa compute-shards 4",
-            "set router ospf fast-reroute ti-lfa compute-mode aggressive",
-            "set router ospf fast-reroute ti-lfa compute-shards 4",
-            "set router ospfv3 fast-reroute ti-lfa compute-mode sharding",
-            "set router ospfv3 fast-reroute ti-lfa compute-shards 2",
-        ] {
-            let (code, _comps, _state) = parse(cmd, entry.clone(), None, State::new());
-            assert_eq!(
+        // IS-IS, OSPFv2 and OSPFv3 all nest the shard count under the
+        // `sharding` mode: the bare presence form and the explicit
+        // count must both settle for each protocol.
+        for proto in ["isis", "ospf", "ospfv3"] {
+            for tail in [
+                "compute-mode serial",
+                "compute-mode conservative",
+                "compute-mode aggressive",
+                "compute-mode sharding",
+                "compute-mode sharding shards 4",
+            ] {
+                let cmd = format!("set router {proto} fast-reroute ti-lfa {tail}");
+                let (code, _comps, _state) = parse(&cmd, entry.clone(), None, State::new());
+                assert_eq!(
+                    code,
+                    ExecCode::Success,
+                    "should parse as a settable path: {cmd}"
+                );
+            }
+
+            // An unknown mode keyword must not resolve to a settable path.
+            let cmd = format!("set router {proto} fast-reroute ti-lfa compute-mode turbo");
+            let (code, _comps, _state) = parse(&cmd, entry.clone(), None, State::new());
+            assert_ne!(
                 code,
                 ExecCode::Success,
-                "should parse as a settable path: {cmd}"
+                "`compute-mode turbo` must not parse"
+            );
+
+            // The flat `compute-shards` leaf moved under `sharding`; the
+            // old spelling must no longer resolve (vtyctl apply is
+            // garbage-tolerant, so an unwired path silently no-ops).
+            let cmd = format!("set router {proto} fast-reroute ti-lfa compute-shards 4");
+            let (code, _comps, _state) = parse(&cmd, entry.clone(), None, State::new());
+            assert_ne!(
+                code,
+                ExecCode::Success,
+                "flat `{proto}` `compute-shards` must not parse after the move"
             );
         }
-
-        // An unknown mode keyword must not resolve to a settable path.
-        let (code, _comps, _state) = parse(
-            "set router isis fast-reroute ti-lfa compute-mode turbo",
-            entry.clone(),
-            None,
-            State::new(),
-        );
-        assert_ne!(
-            code,
-            ExecCode::Success,
-            "`compute-mode turbo` must not parse"
-        );
     }
 
     /// STAMP Phase 1 grammar: the `te-metric measurement` block on

--- a/zebra-rs/src/isis/config.rs
+++ b/zebra-rs/src/isis/config.rs
@@ -141,11 +141,23 @@ impl Isis {
         );
         self.callback_add("/router/isis/fast-reroute/ti-lfa", config_ti_lfa);
         self.callback_add(
-            "/router/isis/fast-reroute/ti-lfa/compute-mode",
-            config_ti_lfa_compute_mode,
+            "/router/isis/fast-reroute/ti-lfa/compute-mode/serial",
+            config_ti_lfa_compute_mode_serial,
         );
         self.callback_add(
-            "/router/isis/fast-reroute/ti-lfa/compute-shards",
+            "/router/isis/fast-reroute/ti-lfa/compute-mode/conservative",
+            config_ti_lfa_compute_mode_conservative,
+        );
+        self.callback_add(
+            "/router/isis/fast-reroute/ti-lfa/compute-mode/aggressive",
+            config_ti_lfa_compute_mode_aggressive,
+        );
+        self.callback_add(
+            "/router/isis/fast-reroute/ti-lfa/compute-mode/sharding",
+            config_ti_lfa_compute_mode_sharding,
+        );
+        self.callback_add(
+            "/router/isis/fast-reroute/ti-lfa/compute-mode/sharding/shards",
             config_ti_lfa_compute_shards,
         );
         self.callback_add(
@@ -510,14 +522,14 @@ pub struct IsisConfig {
     /// /router/isis/fast-reroute/ti-lfa/compute-mode — how the
     /// per-destination TI-LFA computation is scheduled (serial
     /// default; conservative/aggressive/sharding fan out on the rayon
-    /// pool). Kept as the payload-free YANG mirror; the
-    /// `compute-shards` count joins in [`Self::tilfa_compute_mode`].
-    /// Results are identical across modes — only CPU scheduling
-    /// differs.
+    /// pool). Selected by one keyword per mode under the `mode` choice.
+    /// Kept as the payload-free YANG mirror; the shard count joins in
+    /// [`Self::tilfa_compute_mode`]. Results are identical across modes
+    /// — only CPU scheduling differs.
     pub ti_lfa_compute_mode: TilfaComputeModeConfig,
 
-    /// /router/isis/fast-reroute/ti-lfa/compute-shards — the
-    /// operator's hard upper bound on TI-LFA parallelism, consulted
+    /// /router/isis/fast-reroute/ti-lfa/compute-mode/sharding/shards —
+    /// the operator's hard upper bound on TI-LFA parallelism, consulted
     /// only when `compute-mode sharding` is set. Default 8, matching
     /// the YANG default.
     pub ti_lfa_compute_shards: u16,
@@ -767,7 +779,7 @@ impl Default for IsisConfig {
             ti_lfa_enabled: Default::default(),
             fast_reroute_backup_as_primary: Default::default(),
             ti_lfa_compute_mode: Default::default(),
-            // Matches the YANG `default 8` on compute-shards.
+            // Matches the YANG `default 8` on the sharding `shards` leaf.
             ti_lfa_compute_shards: 8,
             mt_enabled: Default::default(),
             mt_topologies: Default::default(),
@@ -811,9 +823,10 @@ impl IsisConfig {
         self.is_type.unwrap_or(IsLevel::L1L2)
     }
 
-    /// Combine the `compute-mode` and `compute-shards` leaves into the
+    /// Combine the selected `compute-mode` and the shard count into the
     /// scheduler-facing [`spf::TilfaComputeMode`], snapshotted into
-    /// `SpfInput` at graph-build time.
+    /// `SpfInput` at graph-build time (the count only matters for
+    /// sharding).
     pub fn tilfa_compute_mode(&self) -> spf::TilfaComputeMode {
         self.ti_lfa_compute_mode
             .with_shards(self.ti_lfa_compute_shards)
@@ -1402,38 +1415,97 @@ fn config_ti_lfa(isis: &mut Isis, _args: Args, op: ConfigOp) -> Option<()> {
     Some(())
 }
 
-/// `/router/isis/fast-reroute/ti-lfa/compute-mode`. Picks how the
-/// TI-LFA computation is scheduled across cores (see
-/// `spf::TilfaComputeMode`). Results are identical across modes, so
-/// nothing advertised changes — no LSP re-origination. The SPF re-run
-/// makes the change observable immediately in `show isis spf` stats.
-fn config_ti_lfa_compute_mode(isis: &mut Isis, mut args: Args, op: ConfigOp) -> Option<()> {
-    let prev = isis.config.tilfa_compute_mode();
-    isis.config.ti_lfa_compute_mode = if op.is_set() {
-        args.string()?.parse().ok()?
-    } else {
-        TilfaComputeModeConfig::default()
-    };
+/// Re-run SPF on both levels iff the *effective* TI-LFA scheduling
+/// mode (mode + shard count, [`IsisConfig::tilfa_compute_mode`])
+/// changed from `prev`. Results are identical across modes, so nothing
+/// advertised changes — no LSP re-origination; the SPF re-run only
+/// makes the new schedule observable in `show isis spf` stats.
+fn ti_lfa_recompute_if_changed(isis: &mut Isis, prev: spf::TilfaComputeMode) {
     if isis.config.tilfa_compute_mode() == prev {
-        return Some(());
+        return;
     }
     let _ = isis.tx.send(Message::SpfCalc(Level::L1));
     let _ = isis.tx.send(Message::SpfCalc(Level::L2));
+}
+
+/// Set the payload-free `compute-mode` selector and re-run SPF on an
+/// effective-mode change. Shared by the per-case callbacks below.
+fn apply_ti_lfa_compute_mode(isis: &mut Isis, mode: TilfaComputeModeConfig) {
+    let prev = isis.config.tilfa_compute_mode();
+    isis.config.ti_lfa_compute_mode = mode;
+    ti_lfa_recompute_if_changed(isis, prev);
+}
+
+/// Body shared by the `serial` / `conservative` / `aggressive`
+/// `compute-mode` cases (each an empty leaf under the `mode` choice).
+/// Setting the case selects `mode`; deleting it reverts to the default
+/// mode — but only when *this* case is the active one, so a stale
+/// delete of a non-active case node (the candidate store does not
+/// auto-clear sibling choice cases) is a no-op rather than clobbering a
+/// newer selection.
+fn config_ti_lfa_compute_mode_case(
+    isis: &mut Isis,
+    op: ConfigOp,
+    mode: TilfaComputeModeConfig,
+) -> Option<()> {
+    if op.is_set() {
+        apply_ti_lfa_compute_mode(isis, mode);
+    } else if isis.config.ti_lfa_compute_mode == mode {
+        apply_ti_lfa_compute_mode(isis, TilfaComputeModeConfig::default());
+    }
     Some(())
 }
 
-/// `/router/isis/fast-reroute/ti-lfa/compute-shards`. Upper bound on
-/// TI-LFA parallelism; consulted only when `compute-mode sharding`
-/// is configured (the effective-mode comparison below keeps the SPF
-/// re-run suppressed otherwise).
+/// `/router/isis/fast-reroute/ti-lfa/compute-mode/serial`.
+fn config_ti_lfa_compute_mode_serial(isis: &mut Isis, _args: Args, op: ConfigOp) -> Option<()> {
+    config_ti_lfa_compute_mode_case(isis, op, TilfaComputeModeConfig::Serial)
+}
+
+/// `/router/isis/fast-reroute/ti-lfa/compute-mode/conservative`.
+fn config_ti_lfa_compute_mode_conservative(
+    isis: &mut Isis,
+    _args: Args,
+    op: ConfigOp,
+) -> Option<()> {
+    config_ti_lfa_compute_mode_case(isis, op, TilfaComputeModeConfig::Conservative)
+}
+
+/// `/router/isis/fast-reroute/ti-lfa/compute-mode/aggressive`.
+fn config_ti_lfa_compute_mode_aggressive(isis: &mut Isis, _args: Args, op: ConfigOp) -> Option<()> {
+    config_ti_lfa_compute_mode_case(isis, op, TilfaComputeModeConfig::Aggressive)
+}
+
+/// `/router/isis/fast-reroute/ti-lfa/compute-mode/sharding` — the
+/// presence container for the sharding case. Bare `sharding` selects
+/// the mode with the default shard count; the `shards` child overrides
+/// the count. Deleting the container drops the whole sharding subtree,
+/// so reset the count here too (regardless of whether the child
+/// `shards` delete also fires) and revert the mode when sharding is the
+/// active case.
+fn config_ti_lfa_compute_mode_sharding(isis: &mut Isis, _args: Args, op: ConfigOp) -> Option<()> {
+    if op.is_set() {
+        apply_ti_lfa_compute_mode(isis, TilfaComputeModeConfig::Sharding);
+    } else {
+        let prev = isis.config.tilfa_compute_mode();
+        // Matches the YANG `default 8` on the `shards` leaf.
+        isis.config.ti_lfa_compute_shards = 8;
+        if isis.config.ti_lfa_compute_mode == TilfaComputeModeConfig::Sharding {
+            isis.config.ti_lfa_compute_mode = TilfaComputeModeConfig::default();
+        }
+        ti_lfa_recompute_if_changed(isis, prev);
+    }
+    Some(())
+}
+
+/// `/router/isis/fast-reroute/ti-lfa/compute-mode/sharding/shards`.
+/// Upper bound on TI-LFA parallelism; consulted only when sharding is
+/// the active mode (the effective-mode comparison keeps the SPF re-run
+/// suppressed otherwise). A bare-`sharding` reset of the count lands on
+/// the YANG default 8.
 fn config_ti_lfa_compute_shards(isis: &mut Isis, mut args: Args, op: ConfigOp) -> Option<()> {
     let prev = isis.config.tilfa_compute_mode();
     isis.config.ti_lfa_compute_shards = if op.is_set() { args.u16()? } else { 8 };
-    if isis.config.tilfa_compute_mode() == prev {
-        return Some(());
-    }
-    let _ = isis.tx.send(Message::SpfCalc(Level::L1));
-    let _ = isis.tx.send(Message::SpfCalc(Level::L2));
+    ti_lfa_recompute_if_changed(isis, prev);
     Some(())
 }
 

--- a/zebra-rs/src/isis/rib.rs
+++ b/zebra-rs/src/isis/rib.rs
@@ -1113,7 +1113,7 @@ pub(super) struct SpfInput {
     lsp_map: LspMap,
     ti_lfa_enabled: bool,
     /// How the TI-LFA computation is scheduled
-    /// (`fast-reroute ti-lfa compute-mode` / `compute-shards`),
+    /// (`fast-reroute ti-lfa compute-mode [sharding shards <N>]`),
     /// snapshotted from config at build time so a mid-run change
     /// cleanly applies to the next run.
     tilfa_mode: spf::TilfaComputeMode,

--- a/zebra-rs/src/ospf/config.rs
+++ b/zebra-rs/src/ospf/config.rs
@@ -215,11 +215,23 @@ impl Ospf {
         self.ospf_add("/segment-routing/mpls", config_ospf_sr_mpls);
         self.ospf_add("/fast-reroute/ti-lfa", config_ospf_ti_lfa);
         self.ospf_add(
-            "/fast-reroute/ti-lfa/compute-mode",
-            config_ospf_ti_lfa_compute_mode,
+            "/fast-reroute/ti-lfa/compute-mode/serial",
+            config_ospf_ti_lfa_compute_mode_serial,
         );
         self.ospf_add(
-            "/fast-reroute/ti-lfa/compute-shards",
+            "/fast-reroute/ti-lfa/compute-mode/conservative",
+            config_ospf_ti_lfa_compute_mode_conservative,
+        );
+        self.ospf_add(
+            "/fast-reroute/ti-lfa/compute-mode/aggressive",
+            config_ospf_ti_lfa_compute_mode_aggressive,
+        );
+        self.ospf_add(
+            "/fast-reroute/ti-lfa/compute-mode/sharding",
+            config_ospf_ti_lfa_compute_mode_sharding,
+        );
+        self.ospf_add(
+            "/fast-reroute/ti-lfa/compute-mode/sharding/shards",
             config_ospf_ti_lfa_compute_shards,
         );
         self.ospf_add(
@@ -1496,48 +1508,120 @@ fn config_ospf_ti_lfa(ospf: &mut Ospf, _args: Args, op: ConfigOp) -> Option<()> 
     Some(())
 }
 
-/// `/router/ospf/fast-reroute/ti-lfa/compute-mode`. Picks how the
-/// TI-LFA computation is scheduled across cores (see
-/// `spf::TilfaComputeMode`). Results are identical across modes —
-/// nothing advertised changes, no LSA re-origination. The SPF re-run
-/// makes the change observable immediately in the telemetry.
-fn config_ospf_ti_lfa_compute_mode(ospf: &mut Ospf, mut args: Args, op: ConfigOp) -> Option<()> {
-    let prev = ospf.ti_lfa_compute_mode;
-    ospf.ti_lfa_compute_mode = if op.is_set() {
-        args.string()?.parse().ok()?
-    } else {
-        crate::spf::TilfaComputeModeConfig::default()
-    };
-    if ospf.ti_lfa_compute_mode == prev {
-        return Some(());
-    }
-    let area_ids: Vec<Ipv4Addr> = ospf.areas.iter().map(|(id, _)| *id).collect();
-    for id in area_ids {
-        let _ = ospf.tx.send(Message::SpfCalc(id));
-    }
-    Some(())
-}
-
-/// `/router/ospf/fast-reroute/ti-lfa/compute-shards`. Upper bound on
-/// TI-LFA parallelism; consulted only when `compute-mode sharding` is
-/// configured (the effective-mode comparison keeps the SPF re-run
-/// suppressed otherwise).
-fn config_ospf_ti_lfa_compute_shards(ospf: &mut Ospf, mut args: Args, op: ConfigOp) -> Option<()> {
-    let prev = ospf
-        .ti_lfa_compute_mode
-        .with_shards(ospf.ti_lfa_compute_shards);
-    ospf.ti_lfa_compute_shards = if op.is_set() { args.u16()? } else { 8 };
+/// Re-run SPF on every area iff the *effective* TI-LFA scheduling mode
+/// (mode + shard count) changed from `prev`. Results are identical
+/// across modes — nothing advertised changes, no LSA re-origination;
+/// the SPF re-run only makes the new schedule observable in telemetry.
+fn ospf_ti_lfa_recompute_if_changed(ospf: &mut Ospf, prev: crate::spf::TilfaComputeMode) {
     if ospf
         .ti_lfa_compute_mode
         .with_shards(ospf.ti_lfa_compute_shards)
         == prev
     {
-        return Some(());
+        return;
     }
     let area_ids: Vec<Ipv4Addr> = ospf.areas.iter().map(|(id, _)| *id).collect();
     for id in area_ids {
         let _ = ospf.tx.send(Message::SpfCalc(id));
     }
+}
+
+/// Set the payload-free `compute-mode` selector and re-run SPF on an
+/// effective-mode change. Shared by the per-case callbacks below.
+fn apply_ospf_ti_lfa_compute_mode(ospf: &mut Ospf, mode: crate::spf::TilfaComputeModeConfig) {
+    let prev = ospf
+        .ti_lfa_compute_mode
+        .with_shards(ospf.ti_lfa_compute_shards);
+    ospf.ti_lfa_compute_mode = mode;
+    ospf_ti_lfa_recompute_if_changed(ospf, prev);
+}
+
+/// Body shared by the `serial` / `conservative` / `aggressive`
+/// `compute-mode` cases (each an empty leaf under the `mode` choice).
+/// Setting the case selects `mode`; deleting it reverts to the default
+/// mode — but only when *this* case is the active one, so a stale
+/// delete of a non-active case node (the candidate store does not
+/// auto-clear sibling choice cases) is a no-op rather than clobbering a
+/// newer selection.
+fn config_ospf_ti_lfa_compute_mode_case(
+    ospf: &mut Ospf,
+    op: ConfigOp,
+    mode: crate::spf::TilfaComputeModeConfig,
+) -> Option<()> {
+    if op.is_set() {
+        apply_ospf_ti_lfa_compute_mode(ospf, mode);
+    } else if ospf.ti_lfa_compute_mode == mode {
+        apply_ospf_ti_lfa_compute_mode(ospf, crate::spf::TilfaComputeModeConfig::default());
+    }
+    Some(())
+}
+
+/// `/router/ospf/fast-reroute/ti-lfa/compute-mode/serial`.
+fn config_ospf_ti_lfa_compute_mode_serial(
+    ospf: &mut Ospf,
+    _args: Args,
+    op: ConfigOp,
+) -> Option<()> {
+    config_ospf_ti_lfa_compute_mode_case(ospf, op, crate::spf::TilfaComputeModeConfig::Serial)
+}
+
+/// `/router/ospf/fast-reroute/ti-lfa/compute-mode/conservative`.
+fn config_ospf_ti_lfa_compute_mode_conservative(
+    ospf: &mut Ospf,
+    _args: Args,
+    op: ConfigOp,
+) -> Option<()> {
+    config_ospf_ti_lfa_compute_mode_case(ospf, op, crate::spf::TilfaComputeModeConfig::Conservative)
+}
+
+/// `/router/ospf/fast-reroute/ti-lfa/compute-mode/aggressive`.
+fn config_ospf_ti_lfa_compute_mode_aggressive(
+    ospf: &mut Ospf,
+    _args: Args,
+    op: ConfigOp,
+) -> Option<()> {
+    config_ospf_ti_lfa_compute_mode_case(ospf, op, crate::spf::TilfaComputeModeConfig::Aggressive)
+}
+
+/// `/router/ospf/fast-reroute/ti-lfa/compute-mode/sharding` — the
+/// presence container for the sharding case. Bare `sharding` selects
+/// the mode with the default shard count; the `shards` child overrides
+/// the count. Deleting the container drops the whole sharding subtree,
+/// so reset the count here too (regardless of whether the child
+/// `shards` delete also fires) and revert the mode when sharding is the
+/// active case.
+fn config_ospf_ti_lfa_compute_mode_sharding(
+    ospf: &mut Ospf,
+    _args: Args,
+    op: ConfigOp,
+) -> Option<()> {
+    if op.is_set() {
+        apply_ospf_ti_lfa_compute_mode(ospf, crate::spf::TilfaComputeModeConfig::Sharding);
+    } else {
+        let prev = ospf
+            .ti_lfa_compute_mode
+            .with_shards(ospf.ti_lfa_compute_shards);
+        // Matches the YANG `default 8` on the `shards` leaf.
+        ospf.ti_lfa_compute_shards = 8;
+        if ospf.ti_lfa_compute_mode == crate::spf::TilfaComputeModeConfig::Sharding {
+            ospf.ti_lfa_compute_mode = crate::spf::TilfaComputeModeConfig::default();
+        }
+        ospf_ti_lfa_recompute_if_changed(ospf, prev);
+    }
+    Some(())
+}
+
+/// `/router/ospf/fast-reroute/ti-lfa/compute-mode/sharding/shards`.
+/// Upper bound on TI-LFA parallelism; consulted only when sharding is
+/// the active mode (the effective-mode comparison keeps the SPF re-run
+/// suppressed otherwise). A bare-`sharding` reset of the count lands on
+/// the YANG default 8.
+fn config_ospf_ti_lfa_compute_shards(ospf: &mut Ospf, mut args: Args, op: ConfigOp) -> Option<()> {
+    let prev = ospf
+        .ti_lfa_compute_mode
+        .with_shards(ospf.ti_lfa_compute_shards);
+    ospf.ti_lfa_compute_shards = if op.is_set() { args.u16()? } else { 8 };
+    ospf_ti_lfa_recompute_if_changed(ospf, prev);
     Some(())
 }
 

--- a/zebra-rs/src/ospf/config_v3.rs
+++ b/zebra-rs/src/ospf/config_v3.rs
@@ -158,11 +158,23 @@ impl Ospf<Ospfv3> {
             ("/segment-routing/srv6/locator", config_ospfv3_srv6_locator),
             ("/fast-reroute/ti-lfa", config_ospfv3_ti_lfa),
             (
-                "/fast-reroute/ti-lfa/compute-mode",
-                config_ospfv3_ti_lfa_compute_mode,
+                "/fast-reroute/ti-lfa/compute-mode/serial",
+                config_ospfv3_ti_lfa_compute_mode_serial,
             ),
             (
-                "/fast-reroute/ti-lfa/compute-shards",
+                "/fast-reroute/ti-lfa/compute-mode/conservative",
+                config_ospfv3_ti_lfa_compute_mode_conservative,
+            ),
+            (
+                "/fast-reroute/ti-lfa/compute-mode/aggressive",
+                config_ospfv3_ti_lfa_compute_mode_aggressive,
+            ),
+            (
+                "/fast-reroute/ti-lfa/compute-mode/sharding",
+                config_ospfv3_ti_lfa_compute_mode_sharding,
+            ),
+            (
+                "/fast-reroute/ti-lfa/compute-mode/sharding/shards",
                 config_ospfv3_ti_lfa_compute_shards,
             ),
             (
@@ -194,32 +206,114 @@ fn config_ospfv3_ti_lfa(ospf: &mut Ospf<Ospfv3>, _args: Args, op: ConfigOp) -> O
     Some(())
 }
 
-/// `/router/ospfv3/fast-reroute/ti-lfa/compute-mode` — v3 sibling of
-/// the v2 callback. Results are identical across modes; the SPF
-/// re-run makes the change observable in the telemetry.
-fn config_ospfv3_ti_lfa_compute_mode(
-    ospf: &mut Ospf<Ospfv3>,
-    mut args: Args,
-    op: ConfigOp,
-) -> Option<()> {
-    let prev = ospf.ti_lfa_compute_mode;
-    ospf.ti_lfa_compute_mode = if op.is_set() {
-        args.string()?.parse().ok()?
-    } else {
-        crate::spf::TilfaComputeModeConfig::default()
-    };
-    if ospf.ti_lfa_compute_mode == prev {
-        return Some(());
+/// Re-run SPF on every area iff the *effective* v3 TI-LFA scheduling
+/// mode (mode + shard count) changed from `prev`. v3 sibling of the v2
+/// `ospf_ti_lfa_recompute_if_changed`.
+fn ospfv3_ti_lfa_recompute_if_changed(ospf: &mut Ospf<Ospfv3>, prev: crate::spf::TilfaComputeMode) {
+    if ospf
+        .ti_lfa_compute_mode
+        .with_shards(ospf.ti_lfa_compute_shards)
+        == prev
+    {
+        return;
     }
     let area_ids: Vec<std::net::Ipv4Addr> = ospf.areas.iter().map(|(id, _)| *id).collect();
     for id in area_ids {
         let _ = ospf.tx.send(Message::SpfCalc(id));
     }
+}
+
+/// Set the payload-free v3 `compute-mode` selector and re-run SPF on an
+/// effective-mode change. Shared by the per-case callbacks below.
+fn apply_ospfv3_ti_lfa_compute_mode(
+    ospf: &mut Ospf<Ospfv3>,
+    mode: crate::spf::TilfaComputeModeConfig,
+) {
+    let prev = ospf
+        .ti_lfa_compute_mode
+        .with_shards(ospf.ti_lfa_compute_shards);
+    ospf.ti_lfa_compute_mode = mode;
+    ospfv3_ti_lfa_recompute_if_changed(ospf, prev);
+}
+
+/// Body shared by the v3 `serial` / `conservative` / `aggressive`
+/// `compute-mode` cases. Setting selects `mode`; deleting reverts to
+/// the default mode only when *this* case is the active one (the
+/// candidate store does not auto-clear sibling choice cases, so a stale
+/// delete of an inactive case is a no-op).
+fn config_ospfv3_ti_lfa_compute_mode_case(
+    ospf: &mut Ospf<Ospfv3>,
+    op: ConfigOp,
+    mode: crate::spf::TilfaComputeModeConfig,
+) -> Option<()> {
+    if op.is_set() {
+        apply_ospfv3_ti_lfa_compute_mode(ospf, mode);
+    } else if ospf.ti_lfa_compute_mode == mode {
+        apply_ospfv3_ti_lfa_compute_mode(ospf, crate::spf::TilfaComputeModeConfig::default());
+    }
     Some(())
 }
 
-/// `/router/ospfv3/fast-reroute/ti-lfa/compute-shards` — v3 sibling of
-/// the v2 callback. Consulted only in sharding mode.
+/// `/router/ospfv3/fast-reroute/ti-lfa/compute-mode/serial`.
+fn config_ospfv3_ti_lfa_compute_mode_serial(
+    ospf: &mut Ospf<Ospfv3>,
+    _args: Args,
+    op: ConfigOp,
+) -> Option<()> {
+    config_ospfv3_ti_lfa_compute_mode_case(ospf, op, crate::spf::TilfaComputeModeConfig::Serial)
+}
+
+/// `/router/ospfv3/fast-reroute/ti-lfa/compute-mode/conservative`.
+fn config_ospfv3_ti_lfa_compute_mode_conservative(
+    ospf: &mut Ospf<Ospfv3>,
+    _args: Args,
+    op: ConfigOp,
+) -> Option<()> {
+    config_ospfv3_ti_lfa_compute_mode_case(
+        ospf,
+        op,
+        crate::spf::TilfaComputeModeConfig::Conservative,
+    )
+}
+
+/// `/router/ospfv3/fast-reroute/ti-lfa/compute-mode/aggressive`.
+fn config_ospfv3_ti_lfa_compute_mode_aggressive(
+    ospf: &mut Ospf<Ospfv3>,
+    _args: Args,
+    op: ConfigOp,
+) -> Option<()> {
+    config_ospfv3_ti_lfa_compute_mode_case(ospf, op, crate::spf::TilfaComputeModeConfig::Aggressive)
+}
+
+/// `/router/ospfv3/fast-reroute/ti-lfa/compute-mode/sharding` — the
+/// presence container for the sharding case. Bare `sharding` selects
+/// the mode with the default shard count; the `shards` child overrides
+/// it. Deleting the container drops the whole sharding subtree, so
+/// reset the count here too and revert the mode when sharding is the
+/// active case.
+fn config_ospfv3_ti_lfa_compute_mode_sharding(
+    ospf: &mut Ospf<Ospfv3>,
+    _args: Args,
+    op: ConfigOp,
+) -> Option<()> {
+    if op.is_set() {
+        apply_ospfv3_ti_lfa_compute_mode(ospf, crate::spf::TilfaComputeModeConfig::Sharding);
+    } else {
+        let prev = ospf
+            .ti_lfa_compute_mode
+            .with_shards(ospf.ti_lfa_compute_shards);
+        // Matches the YANG `default 8` on the `shards` leaf.
+        ospf.ti_lfa_compute_shards = 8;
+        if ospf.ti_lfa_compute_mode == crate::spf::TilfaComputeModeConfig::Sharding {
+            ospf.ti_lfa_compute_mode = crate::spf::TilfaComputeModeConfig::default();
+        }
+        ospfv3_ti_lfa_recompute_if_changed(ospf, prev);
+    }
+    Some(())
+}
+
+/// `/router/ospfv3/fast-reroute/ti-lfa/compute-mode/sharding/shards` —
+/// v3 sibling of the v2 callback. Consulted only in sharding mode.
 fn config_ospfv3_ti_lfa_compute_shards(
     ospf: &mut Ospf<Ospfv3>,
     mut args: Args,
@@ -229,17 +323,7 @@ fn config_ospfv3_ti_lfa_compute_shards(
         .ti_lfa_compute_mode
         .with_shards(ospf.ti_lfa_compute_shards);
     ospf.ti_lfa_compute_shards = if op.is_set() { args.u16()? } else { 8 };
-    if ospf
-        .ti_lfa_compute_mode
-        .with_shards(ospf.ti_lfa_compute_shards)
-        == prev
-    {
-        return Some(());
-    }
-    let area_ids: Vec<std::net::Ipv4Addr> = ospf.areas.iter().map(|(id, _)| *id).collect();
-    for id in area_ids {
-        let _ = ospf.tx.send(Message::SpfCalc(id));
-    }
+    ospfv3_ti_lfa_recompute_if_changed(ospf, prev);
     Some(())
 }
 

--- a/zebra-rs/src/ospf/inst.rs
+++ b/zebra-rs/src/ospf/inst.rs
@@ -117,15 +117,16 @@ pub struct Ospf<V: OspfVersion = Ospfv2> {
     /// primary. A protection-testing knob; no effect when
     /// `ti_lfa_enabled` is off (there is no repair to promote).
     pub fast_reroute_backup_as_primary: bool,
-    /// `/router/ospf/fast-reroute/ti-lfa/compute-mode` — how the
-    /// per-destination TI-LFA computation is scheduled (serial
-    /// default; conservative/aggressive/sharding fan out on the rayon
-    /// pool). Joined with `ti_lfa_compute_shards` at SPF-input build
-    /// time. Results are identical across modes.
+    /// `/router/ospf{,v3}/fast-reroute/ti-lfa/compute-mode` — how the
+    /// per-destination TI-LFA computation is scheduled (serial default;
+    /// conservative/aggressive/sharding fan out on the rayon pool),
+    /// selected by one keyword per mode under the `mode` choice. Joined
+    /// with `ti_lfa_compute_shards` at SPF-input build time. Results are
+    /// identical across modes.
     pub ti_lfa_compute_mode: spf::TilfaComputeModeConfig,
-    /// `/router/ospf/fast-reroute/ti-lfa/compute-shards` — hard upper
-    /// bound on TI-LFA parallelism, consulted only in sharding mode.
-    /// Default 8, matching the YANG default.
+    /// `/router/ospf{,v3}/fast-reroute/ti-lfa/compute-mode/sharding/shards`
+    /// — hard upper bound on TI-LFA parallelism, consulted only in
+    /// sharding mode. Default 8, matching the YANG default.
     pub ti_lfa_compute_shards: u16,
     /// TI-LFA compute telemetry for the most recent SPF run, stamped
     /// by `apply_spf_result` like `spf_duration` (last-area-wins).
@@ -1182,7 +1183,7 @@ impl Ospf<Ospfv2> {
             graph: None,
             ti_lfa_enabled: false,
             ti_lfa_compute_mode: spf::TilfaComputeModeConfig::default(),
-            // Matches the YANG `default 8` on compute-shards.
+            // Matches the YANG `default 8` on the sharding `shards` leaf.
             ti_lfa_compute_shards: 8,
             tilfa_stats: None,
             fast_reroute_backup_as_primary: false,
@@ -5232,7 +5233,7 @@ impl Ospf<Ospfv3> {
             graph: None,
             ti_lfa_enabled: false,
             ti_lfa_compute_mode: spf::TilfaComputeModeConfig::default(),
-            // Matches the YANG `default 8` on compute-shards.
+            // Matches the YANG `default 8` on the sharding `shards` leaf.
             ti_lfa_compute_shards: 8,
             tilfa_stats: None,
             fast_reroute_backup_as_primary: false,
@@ -11781,9 +11782,9 @@ struct SpfInput {
     /// `/router/ospf/fast-reroute/ti-lfa` snapshot. Gates the
     /// graph-only TI-LFA repair computation on the worker.
     ti_lfa_enabled: bool,
-    /// TI-LFA compute scheduling (`compute-mode` + `compute-shards`
-    /// joined), snapshotted from config at build time so a mid-run
-    /// change cleanly applies to the next run.
+    /// TI-LFA compute scheduling (`compute-mode` + the nested sharding
+    /// `shards` count joined), snapshotted from config at build time so
+    /// a mid-run change cleanly applies to the next run.
     tilfa_mode: spf::TilfaComputeMode,
     /// One per configured Flex-Algorithm: its FAD-filtered graph and
     /// source vertex (None if the algo's graph had no source).

--- a/zebra-rs/src/spf/tilfa_par.rs
+++ b/zebra-rs/src/spf/tilfa_par.rs
@@ -30,8 +30,9 @@ use super::calc::{
 };
 
 /// How the per-destination TI-LFA computation is executed.
-/// Operator-facing via `fast-reroute ti-lfa compute-mode` (plus
-/// `compute-shards` for [`Self::Sharding`]).
+/// Operator-facing via `fast-reroute ti-lfa compute-mode` (plus the
+/// nested `compute-mode sharding shards <N>` count for
+/// [`Self::Sharding`]).
 #[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
 pub enum TilfaComputeMode {
     /// Sequential loop on the SPF worker thread; rayon is never
@@ -64,11 +65,12 @@ impl std::fmt::Display for TilfaComputeMode {
     }
 }
 
-/// YANG mirror of the `fast-reroute/ti-lfa/compute-mode` leaf
-/// (payload-free — the sharding count lives in the sibling
-/// `compute-shards` leaf; [`Self::with_shards`] joins them into the
-/// scheduler-facing [`TilfaComputeMode`]). Shared by the IS-IS and
-/// OSPF config layers, which carry the same two leaves.
+/// YANG mirror of the `fast-reroute/ti-lfa/compute-mode` selector
+/// (payload-free — the sharding count lives in the nested
+/// `compute-mode/sharding/shards` leaf; [`Self::with_shards`] joins
+/// them into the scheduler-facing [`TilfaComputeMode`]). Shared by the
+/// IS-IS and OSPF config layers, which carry the same `compute-mode`
+/// choice.
 #[derive(
     Debug, Default, Clone, Copy, PartialEq, Eq, strum_macros::EnumString, strum_macros::Display,
 )]

--- a/zebra-rs/yang/config.yang
+++ b/zebra-rs/yang/config.yang
@@ -850,30 +850,51 @@ module config {
             // dataplane.
             presence "Enable Topology-Independent LFA (TI-LFA)";
 
-            leaf compute-mode {
+            container compute-mode {
               ext:help "How the TI-LFA computation is scheduled";
               // Execution scheduling for the per-destination TI-LFA
               // computation; same modes and semantics as
               // `router isis fast-reroute ti-lfa compute-mode` (see
               // docs/design/isis-tilfa-parallel-spf.md, §13 for the
-              // OSPF specifics).
-              type enumeration {
-                enum serial;
-                enum conservative;
-                enum aggressive;
-                enum sharding;
+              // OSPF specifics). One keyword per mode under a `choice`;
+              // the shard count nests under `sharding`. The default
+              // mode (serial) is applied by the Rust handler.
+              choice mode {
+                case serial {
+                  leaf serial {
+                    ext:help "Run on the SPF worker thread";
+                    type empty;
+                  }
+                }
+                case conservative {
+                  leaf conservative {
+                    ext:help "Fan out one task per destination";
+                    type empty;
+                  }
+                }
+                case aggressive {
+                  leaf aggressive {
+                    ext:help "Also share the PC-path SPF per protected node";
+                    type empty;
+                  }
+                }
+                case sharding {
+                  container sharding {
+                    ext:help "Aggressive work split into parallel shards";
+                    presence "Shard the aggressive computation (default 8 shards)";
+                    // Hard upper bound on TI-LFA parallelism, consulted
+                    // only in this mode. Bare `sharding` uses 8
+                    // (applied by the handler).
+                    leaf shards {
+                      ext:help "Max parallel TI-LFA shards";
+                      type uint16 {
+                        range "1..256";
+                      }
+                      default "8";
+                    }
+                  }
+                }
               }
-              default "serial";
-            }
-
-            leaf compute-shards {
-              ext:help "Max parallel TI-LFA shards (sharding mode)";
-              // Hard upper bound on TI-LFA parallelism, consulted
-              // only when `compute-mode sharding` is set.
-              type uint16 {
-                range "1..256";
-              }
-              default "8";
             }
           }
           container backup-as-primary {
@@ -1296,27 +1317,49 @@ module config {
             // RFC 9490). Post-convergence repair over the v3 LSDB.
             presence "Enable Topology-Independent LFA (TI-LFA)";
 
-            leaf compute-mode {
+            container compute-mode {
               ext:help "How the TI-LFA computation is scheduled";
               // Same modes and semantics as `router ospf
-              // fast-reroute ti-lfa compute-mode`.
-              type enumeration {
-                enum serial;
-                enum conservative;
-                enum aggressive;
-                enum sharding;
+              // fast-reroute ti-lfa compute-mode`. One keyword per
+              // mode under a `choice`; the shard count nests under
+              // `sharding`. The default mode (serial) is applied by
+              // the Rust handler.
+              choice mode {
+                case serial {
+                  leaf serial {
+                    ext:help "Run on the SPF worker thread";
+                    type empty;
+                  }
+                }
+                case conservative {
+                  leaf conservative {
+                    ext:help "Fan out one task per destination";
+                    type empty;
+                  }
+                }
+                case aggressive {
+                  leaf aggressive {
+                    ext:help "Also share the PC-path SPF per protected node";
+                    type empty;
+                  }
+                }
+                case sharding {
+                  container sharding {
+                    ext:help "Aggressive work split into parallel shards";
+                    presence "Shard the aggressive computation (default 8 shards)";
+                    // Hard upper bound on TI-LFA parallelism, consulted
+                    // only in this mode. Bare `sharding` uses 8
+                    // (applied by the handler).
+                    leaf shards {
+                      ext:help "Max parallel TI-LFA shards";
+                      type uint16 {
+                        range "1..256";
+                      }
+                      default "8";
+                    }
+                  }
+                }
               }
-              default "serial";
-            }
-
-            leaf compute-shards {
-              ext:help "Max parallel TI-LFA shards (sharding mode)";
-              // Hard upper bound on TI-LFA parallelism, consulted
-              // only when `compute-mode sharding` is set.
-              type uint16 {
-                range "1..256";
-              }
-              default "8";
             }
           }
           container backup-as-primary {
@@ -1614,36 +1657,64 @@ module config {
             // enabled for the repair to install in the dataplane.
             presence "Enable Topology-Independent LFA (TI-LFA)";
 
-            leaf compute-mode {
+            container compute-mode {
               ext:help "How the TI-LFA computation is scheduled";
               // Execution scheduling for the per-destination TI-LFA
               // computation (design: docs/design/isis-tilfa-parallel-
-              // spf.md). Results are identical across modes — only
-              // CPU usage and wall-clock differ. `serial` runs on the
-              // SPF worker thread; `conservative` fans out one task
-              // per destination; `aggressive` additionally shares the
+              // spf.md). Results are identical across modes — only CPU
+              // usage and wall-clock differ. `serial` runs on the SPF
+              // worker thread; `conservative` fans out one task per
+              // destination; `aggressive` additionally shares the
               // PC-path SPF across destinations behind the same
               // protected node; `sharding` is the aggressive work
-              // split into at most `compute-shards` parallel shards.
-              type enumeration {
-                enum serial;
-                enum conservative;
-                enum aggressive;
-                enum sharding;
+              // split into at most `shards` parallel shards.
+              //
+              // Modelled as a `choice` of one keyword per mode (the
+              // shard count nests under `sharding`, the only mode it
+              // applies to). The cases are mutually exclusive. The
+              // default mode (serial) is applied by the Rust handler —
+              // a choice/case carries no YANG default, and switching
+              // cases does not auto-clear the previous case node from
+              // the candidate store (same cosmetic as
+              // `allowas-in {count|origin}`).
+              choice mode {
+                case serial {
+                  leaf serial {
+                    ext:help "Run on the SPF worker thread";
+                    type empty;
+                  }
+                }
+                case conservative {
+                  leaf conservative {
+                    ext:help "Fan out one task per destination";
+                    type empty;
+                  }
+                }
+                case aggressive {
+                  leaf aggressive {
+                    ext:help "Also share the PC-path SPF per protected node";
+                    type empty;
+                  }
+                }
+                case sharding {
+                  container sharding {
+                    ext:help "Aggressive work split into parallel shards";
+                    presence "Shard the aggressive computation (default 8 shards)";
+                    // Hard upper bound on TI-LFA parallelism — lets an
+                    // operator reserve cores for other daemons on a
+                    // shared box. Bare `sharding` uses 8 (applied by
+                    // the handler; libyang does not carry the leaf
+                    // `default` into the entry tree).
+                    leaf shards {
+                      ext:help "Max parallel TI-LFA shards";
+                      type uint16 {
+                        range "1..256";
+                      }
+                      default "8";
+                    }
+                  }
+                }
               }
-              default "serial";
-            }
-
-            leaf compute-shards {
-              ext:help "Max parallel TI-LFA shards (sharding mode)";
-              // Hard upper bound on TI-LFA parallelism, consulted
-              // only when `compute-mode sharding` is set. Lets an
-              // operator reserve cores for other daemons on a shared
-              // box.
-              type uint16 {
-                range "1..256";
-              }
-              default "8";
             }
           }
           container backup-as-primary {


### PR DESCRIPTION
## Summary

The `compute-shards <1..256>` leaf only made sense alongside `compute-mode sharding`, so this moves it under that mode. `compute-mode` becomes a `container` with a `choice` of one keyword per mode — `serial`/`conservative`/`aggressive` as empty leaves, `sharding` as a presence container carrying a `shards` leaf:

```
set router isis   fast-reroute ti-lfa compute-mode sharding shards 16
set router ospf   fast-reroute ti-lfa compute-mode sharding shards 16
set router ospfv3 fast-reroute ti-lfa compute-mode sharding shards 16
```

Bare `compute-mode sharding` uses the default 8 shards (applied by the handler, since libyang carries no leaf default into the entry tree). Applied to **IS-IS, OSPFv2 and OSPFv3** — all three already share the `spf::tilfa_par` scheduler, so this is a config-surface change only.

Per-mode callbacks replace the two flat handlers. Delete of the `sharding` container resets mode→serial and shards→8; sibling-case deletes guard on the active case (the candidate store does not auto-clear `choice` cases — same known cosmetic as `allowas-in {count|origin}`).

## Test plan

- `cargo test -p zebra-rs` (1296 unit tests) — green; the `isis_tilfa_compute_grammar` parse test is parameterized over isis/ospf/ospfv3 (nested form settles, unknown mode rejected, flat `compute-shards` no longer parses).
- `cargo clippy --workspace --all-targets -- -D warnings` — clean; `cargo fmt` applied.
- BDD on a freshly built+installed `/usr/bin/zebra-rs` + `/etc/zebra-rs/yang`:
  - `@isis_tilfa` — 1 passed (127 steps)
  - `@ospfv2_tilfa` — 1 passed (123 steps)
  - `@ospfv3_tilfa` — 1 passed (125 steps)
  - All confirm `mode=sharding(2)` telemetry, repair install, traffic survives primary-link failure, and `delete compute-mode sharding` → `mode=serial`. Clean teardown (no leaked namespaces/daemons).
- Docs + book updated to the nested syntax (`mdbook build` succeeds).

Generated with [Claude Code](https://claude.com/claude-code)