### PR TITLE
bgp: EVPN RFC 9574 assisted-replication role + IMET origination

### DIFF
--- a/docs/design/bgp-evpn-assisted-replication-plan.md
+++ b/docs/design/bgp-evpn-assisted-replication-plan.md
@@ -25,8 +25,9 @@ Branch `bgp-evpn-bum`. **Phase 0 (codec) landed on the branch**; Phases 1–3
 
 | Slice            | What landed / planned                                                                                  | Status |
 | ---------------- | ----------------------------------------------------------------------------------------------------- | ------ |
-| 0 — PMSI codec   | tunnel type `0x0A`, `AssistedReplicationType` (T), BM/U/L flag accessors on `PmsiTunnel`, 7 pin tests  | ✅ on branch |
-| 1 — role + non-selective AR | YANG `assisted-replication` role config; Replicator-AR / Regular-IR IMET origination + reception; AR-LEAF flood-list collapse to `{AR-IP}` | ⬜ planned |
+| 0 — PMSI codec   | tunnel type `0x0A`, `AssistedReplicationType` (T), BM/U/L flag accessors on `PmsiTunnel`, 7 pin tests  | ✅ merged #1476 |
+| 1a — role + origination | YANG `assisted-replication` role/AR-IP config; role-aware Type-3 IMET origination (Replicator-AR tunnel `0x0A` / AR-LEAF-flagged Regular-IR); pin tests | ✅ on branch |
+| 1b — reception + flood model | parse received role/AR-IP; per-VNI role-aware flood model; AR-LEAF flood-list collapse to `{AR-IP}` | ⬜ planned |
 | 2 — Pruned-Flood-Lists | originate BM/U prune flags; honor received prune at whole-VTEP flood-list membership | ⬜ planned |
 | 3 — selective AR | Replicator `L=1`; AR-LEAF Leaf A-D (Type-1) origination with `AR-IP:0` RT; per-replicator leaf-set | ⬜ planned |
 | 4 — AR-REPLICATOR dataplane | decap-on-AR-IP → re-flood to other VTEPs with split-horizon | ⛔ deferred (needs eBPF/XDP or VPP — see feasibility) |
@@ -236,8 +237,9 @@ Closest end-to-end template: the **EVPN Type-3/IMET** path itself (originate
 
 | Phase | Scope | Status |
 | ----- | ----- | ------ |
-| 0 | Codec: PMSI tunnel 0x0A + `AssistedReplicationType` (T) + BM/U/L accessors + pin tests | ✅ on branch |
-| 1 | YANG `assisted-replication` role; Replicator-AR / Regular-IR IMET originate + receive; per-VNI role-aware flood model; AR-LEAF flood-list → `{AR-IP}` (U-flood off) | ⬜ planned |
+| 0 | Codec: PMSI tunnel 0x0A + `AssistedReplicationType` (T) + BM/U/L accessors + pin tests | ✅ merged #1476 |
+| 1a | YANG `assisted-replication` role/AR-IP; role-aware Type-3 IMET origination (Replicator-AR `0x0A` / AR-LEAF-flagged Regular-IR) | ✅ on branch |
+| 1b | Parse received role/AR-IP; per-VNI role-aware flood model; AR-LEAF flood-list → `{AR-IP}` (U-flood off) | ⬜ planned |
 | 2 | Pruned-Flood-Lists: originate BM/U flags; honor received prune at whole-VTEP membership | ⬜ planned |
 | 3 | Selective AR (control plane): Leaf A-D (Type-1) origination + `AR-IP:0` IP-specific RT; replicator `L=1`; per-replicator leaf-set | ⬜ planned |
 | 4 | **AR-REPLICATOR forwarding dataplane** (eBPF/XDP or VPP) | ⛔ deferred — out of stock-kernel scope |

--- a/zebra-rs/src/bgp/config.rs
+++ b/zebra-rs/src/bgp/config.rs
@@ -16,7 +16,7 @@ use super::auth::AoConfig;
 use super::peer::{AfiSafiEncapType, BgpTop};
 use super::route_clean;
 use super::{
-    BGP_PORT, Bgp,
+    AssistedReplicationRole, BGP_PORT, Bgp,
     inst::Callback,
     peer::{
         ALLOWAS_IN_DEFAULT_COUNT, AllowAsIn, LocalAs, PasswordEncoding, Peer, PeerType,
@@ -1372,6 +1372,65 @@ fn config_advertise_all_vni(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Opti
             bgp.evpn_withdraw_imet(vni, vtep_local);
         }
     }
+    Some(())
+}
+
+/// Re-originate every per-VNI Type-3 IMET route so a changed Assisted
+/// Replication role / AR-IP is reflected in the PMSI Tunnel attribute and
+/// next hop. `evpn_originate_imet` replaces the existing Originated path
+/// in place (the prefix key is the local VTEP, which does not change) and
+/// re-advertises to peers. No-op unless `advertise-all-vni` is on.
+fn reoriginate_all_imet(bgp: &mut Bgp) {
+    if !bgp.advertise_all_vni {
+        return;
+    }
+    let vxlans: Vec<(u32, IpAddr)> = bgp.local_vxlans.iter().map(|(k, v)| (*k, *v)).collect();
+    for (vni, vtep_local) in vxlans {
+        bgp.evpn_originate_imet(vni, vtep_local);
+    }
+}
+
+/// `router bgp afi-safi evpn assisted-replication role {none|replicator|leaf}`
+/// (RFC 9574). Stored on `Bgp` and consumed by `evpn_originate_imet`.
+fn config_assisted_replication_role(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Option<()> {
+    let afi_safi: AfiSafi = args.afi_safi()?;
+    if afi_safi.afi != Afi::L2vpn || afi_safi.safi != Safi::Evpn {
+        return None;
+    }
+    let role = if op.is_set() {
+        match args.string()?.as_str() {
+            "replicator" => AssistedReplicationRole::Replicator,
+            "leaf" => AssistedReplicationRole::Leaf,
+            _ => AssistedReplicationRole::None,
+        }
+    } else {
+        AssistedReplicationRole::None
+    };
+    if bgp.assisted_replication_role == role {
+        return Some(());
+    }
+    bgp.assisted_replication_role = role;
+    reoriginate_all_imet(bgp);
+    Some(())
+}
+
+/// `router bgp afi-safi evpn assisted-replication replicator-ip <ip>` —
+/// the AR-IP advertised in the Replicator-AR route's next hop (RFC 9574).
+fn config_assisted_replication_ip(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Option<()> {
+    let afi_safi: AfiSafi = args.afi_safi()?;
+    if afi_safi.afi != Afi::L2vpn || afi_safi.safi != Safi::Evpn {
+        return None;
+    }
+    let ip = if op.is_set() {
+        Some(args.addr()?)
+    } else {
+        None
+    };
+    if bgp.assisted_replication_ip == ip {
+        return Some(());
+    }
+    bgp.assisted_replication_ip = ip;
+    reoriginate_all_imet(bgp);
     Some(())
 }
 
@@ -3451,6 +3510,18 @@ impl Bgp {
         self.callback_add(
             "/router/bgp/afi-safi/advertise-all-vni",
             config_advertise_all_vni,
+        );
+
+        // EVPN Assisted Replication role + AR-IP (RFC 9574), under
+        // `router bgp afi-safi evpn assisted-replication`. Augmented in by
+        // zebra-bgp-evpn.yang.
+        self.callback_add(
+            "/router/bgp/afi-safi/assisted-replication/role",
+            config_assisted_replication_role,
+        );
+        self.callback_add(
+            "/router/bgp/afi-safi/assisted-replication/replicator-ip",
+            config_assisted_replication_ip,
         );
 
         // Per-AFI redistribution (zebra-bgp-redistribute.yang).

--- a/zebra-rs/src/bgp/inst.rs
+++ b/zebra-rs/src/bgp/inst.rs
@@ -510,6 +510,23 @@ impl DumpBarrierV4 {
     }
 }
 
+/// RFC 9574 Optimized Ingress Replication role for the local speaker,
+/// configured under `router bgp afi-safi evpn assisted-replication`.
+/// Distinct from the on-wire [`bgp_packet::AssistedReplicationType`] the
+/// codec uses: this is the operator-facing config knob and has no
+/// `Reserved` value.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum AssistedReplicationRole {
+    /// Regular NVE — plain ingress replication (RFC 7432). The default.
+    #[default]
+    None,
+    /// AR-REPLICATOR — advertise a Replicator-AR IMET (tunnel type 0x0A,
+    /// next hop = the configured AR-IP).
+    Replicator,
+    /// AR-LEAF — advertise a Regular-IR IMET flagged as AR-LEAF.
+    Leaf,
+}
+
 pub struct Bgp {
     pub asn: u32,
     /// Effective BGP Identifier — what OPENs, EVPN RDs and the show
@@ -560,6 +577,16 @@ pub struct Bgp {
     /// — and replays on `advertise_all_vni` / `router_id` transitions
     /// just like `local_fdb`.
     pub local_vxlans: BTreeMap<u32, std::net::IpAddr>,
+    /// RFC 9574 Assisted Replication role for the local speaker
+    /// (`router bgp afi-safi evpn assisted-replication role`). Drives the
+    /// Type-3 IMET PMSI Tunnel encoding in `evpn_originate_imet`.
+    pub assisted_replication_role: AssistedReplicationRole,
+    /// The AR-IP advertised in the Replicator-AR route's next hop when
+    /// `assisted_replication_role` is `Replicator` (`... assisted-replication
+    /// replicator-ip`). A distinct routable IP that AR-LEAF nodes send BUM
+    /// to; required for the Replicator role, otherwise IMET origination
+    /// falls back to plain ingress replication.
+    pub assisted_replication_ip: Option<std::net::IpAddr>,
     /// Configured hostname for the local BGP speaker. Advertised in
     /// the FQDN capability (capability code 73). When None, falls back
     /// to the OS hostname; if that also fails, no FQDN capability is
@@ -959,6 +986,8 @@ impl Bgp {
             advertise_all_vni: false,
             local_fdb: BTreeMap::new(),
             local_vxlans: BTreeMap::new(),
+            assisted_replication_role: AssistedReplicationRole::None,
+            assisted_replication_ip: None,
             hostname: None,
             no_fib_install: false,
             peers: PeerMap::new(),

--- a/zebra-rs/src/bgp/mod.rs
+++ b/zebra-rs/src/bgp/mod.rs
@@ -1,5 +1,5 @@
 pub mod inst;
-pub use inst::{Bgp, Message};
+pub use inst::{AssistedReplicationRole, Bgp, Message};
 
 pub mod constant;
 pub use constant::*;

--- a/zebra-rs/src/bgp/route.rs
+++ b/zebra-rs/src/bgp/route.rs
@@ -19,7 +19,7 @@ use super::peer_map::PeerMap;
 use super::shard::msg::{ShardUpdateV4, ShardUpdateV6};
 use super::shard::{ShardMsg, ShardOut};
 use super::timer::{start_adv_timer_vpnv4, start_adv_timer_vpnv6};
-use super::{Bgp, InOut, Message};
+use super::{AssistedReplicationRole, Bgp, InOut, Message};
 
 pub const ORIGINATED_PEER: usize = usize::MAX;
 
@@ -11559,15 +11559,19 @@ impl Bgp {
             evpn_route_target(self.asn, vni),
             evpn_encap_vxlan(),
         ]));
-        attr.pmsi_tunnel = Some(PmsiTunnel {
-            // Flags = 0 (no leaf info required, per RFC 6514 §5).
-            flags: 0,
-            // Tunnel Type 6 = Ingress Replication.
-            tunnel_type: 6,
+        // RFC 9574: the PMSI Tunnel attribute and next hop depend on the
+        // local Assisted Replication role. RNVE keeps the plain Ingress
+        // Replication encoding (tunnel type 6); a Replicator emits a
+        // Replicator-AR route (tunnel type 0x0A, next hop = AR-IP); a Leaf
+        // tags its Regular-IR route as AR-LEAF.
+        let (pmsi, nexthop) = imet_pmsi_tunnel(
+            self.assisted_replication_role,
+            self.assisted_replication_ip,
+            vtep_local,
             vni,
-            endpoint: vtep_local,
-        });
-        attr.nexthop = Some(BgpNexthop::Evpn(vtep_local));
+        );
+        attr.pmsi_tunnel = Some(pmsi);
+        attr.nexthop = Some(BgpNexthop::Evpn(nexthop));
 
         let mut rib = BgpRib::new(
             ORIGINATED_PEER,
@@ -11649,6 +11653,56 @@ fn rd_from_router_id_vni(router_id: Ipv4Addr, vni: u32) -> Option<RouteDistingui
     Some(rd)
 }
 
+/// RFC 9574 role-aware PMSI Tunnel attribute + BGP next hop for a Type-3
+/// IMET origination. Returns the `(PmsiTunnel, next-hop)` pair the
+/// configured Assisted Replication role dictates:
+///
+/// - **Replicator** (with an AR-IP configured): the Replicator-AR route —
+///   tunnel type `0x0A`, T = AR-REPLICATOR, next hop and tunnel endpoint =
+///   the AR-IP, so AR-LEAF nodes send BUM there.
+/// - **Leaf**: the Regular-IR route flagged T = AR-LEAF — tunnel type 6,
+///   next hop = local VTEP (IR-IP).
+/// - **None**, or Replicator without an AR-IP: plain Ingress Replication
+///   (tunnel type 6, T = RNVE) — byte-for-byte the pre-RFC-9574 encoding.
+fn imet_pmsi_tunnel(
+    role: AssistedReplicationRole,
+    ar_ip: Option<IpAddr>,
+    vtep_local: IpAddr,
+    vni: u32,
+) -> (PmsiTunnel, IpAddr) {
+    match (role, ar_ip) {
+        (AssistedReplicationRole::Replicator, Some(ar)) => (
+            PmsiTunnel {
+                flags: 0,
+                tunnel_type: PmsiTunnel::TUNNEL_ASSISTED_REPLICATION,
+                vni,
+                endpoint: ar,
+            }
+            .with_ar_type(AssistedReplicationType::Replicator),
+            ar,
+        ),
+        (AssistedReplicationRole::Leaf, _) => (
+            PmsiTunnel {
+                flags: 0,
+                tunnel_type: PmsiTunnel::TUNNEL_INGRESS_REPLICATION,
+                vni,
+                endpoint: vtep_local,
+            }
+            .with_ar_type(AssistedReplicationType::Leaf),
+            vtep_local,
+        ),
+        _ => (
+            PmsiTunnel {
+                flags: 0,
+                tunnel_type: PmsiTunnel::TUNNEL_INGRESS_REPLICATION,
+                vni,
+                endpoint: vtep_local,
+            },
+            vtep_local,
+        ),
+    }
+}
+
 /// Build the auto-derived Route Target extended community for an EVPN
 /// route per RFC 8365 §5.1.2.4: type 0x00 / sub 0x02 (Two-Octet AS
 /// Specific Route Target) carrying `<local-AS>:<VNI>`. The 2-byte
@@ -11683,6 +11737,70 @@ fn evpn_encap_vxlan() -> ExtCommunityValue {
     // Encapsulation type 8 = VXLAN, occupies the trailing 2 octets.
     encap.val[5] = 8;
     encap
+}
+
+#[cfg(test)]
+mod evpn_imet_ar_tests {
+    use super::*;
+
+    fn ir_ip() -> IpAddr {
+        IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1))
+    }
+    fn ar_ip() -> IpAddr {
+        IpAddr::V4(Ipv4Addr::new(10, 0, 0, 254))
+    }
+
+    /// RNVE (default role) must produce byte-for-byte the pre-RFC-9574
+    /// Ingress Replication encoding: tunnel type 6, flags 0, endpoint and
+    /// next hop = the local VTEP, regardless of any stray AR-IP.
+    #[test]
+    fn rnve_is_plain_ingress_replication() {
+        let (pmsi, nh) =
+            imet_pmsi_tunnel(AssistedReplicationRole::None, Some(ar_ip()), ir_ip(), 100);
+        assert_eq!(pmsi.tunnel_type, PmsiTunnel::TUNNEL_INGRESS_REPLICATION);
+        assert_eq!(pmsi.ar_type(), AssistedReplicationType::Rnve);
+        assert_eq!(pmsi.flags, 0, "byte-for-byte the legacy encoding");
+        assert_eq!(pmsi.endpoint, ir_ip());
+        assert_eq!(nh, ir_ip());
+    }
+
+    /// Replicator role → Replicator-AR route: tunnel type 0x0A,
+    /// T = AR-REPLICATOR, tunnel endpoint and next hop = the AR-IP.
+    #[test]
+    fn replicator_emits_replicator_ar_route() {
+        let (pmsi, nh) = imet_pmsi_tunnel(
+            AssistedReplicationRole::Replicator,
+            Some(ar_ip()),
+            ir_ip(),
+            100,
+        );
+        assert_eq!(pmsi.tunnel_type, PmsiTunnel::TUNNEL_ASSISTED_REPLICATION);
+        assert_eq!(pmsi.ar_type(), AssistedReplicationType::Replicator);
+        assert_eq!(pmsi.endpoint, ar_ip(), "tunnel endpoint = AR-IP");
+        assert_eq!(nh, ar_ip(), "next hop = AR-IP");
+    }
+
+    /// Leaf role → Regular-IR route flagged T = AR-LEAF, still tunnel type
+    /// 6 with the next hop = local VTEP (IR-IP).
+    #[test]
+    fn leaf_flags_regular_ir_as_ar_leaf() {
+        let (pmsi, nh) = imet_pmsi_tunnel(AssistedReplicationRole::Leaf, None, ir_ip(), 100);
+        assert_eq!(pmsi.tunnel_type, PmsiTunnel::TUNNEL_INGRESS_REPLICATION);
+        assert_eq!(pmsi.ar_type(), AssistedReplicationType::Leaf);
+        assert_eq!(pmsi.endpoint, ir_ip());
+        assert_eq!(nh, ir_ip());
+    }
+
+    /// A Replicator misconfigured without an AR-IP degrades safely to plain
+    /// Ingress Replication rather than advertising an AR route with no
+    /// usable tunnel destination.
+    #[test]
+    fn replicator_without_ar_ip_falls_back_to_ir() {
+        let (pmsi, nh) = imet_pmsi_tunnel(AssistedReplicationRole::Replicator, None, ir_ip(), 100);
+        assert_eq!(pmsi.tunnel_type, PmsiTunnel::TUNNEL_INGRESS_REPLICATION);
+        assert_eq!(pmsi.ar_type(), AssistedReplicationType::Rnve);
+        assert_eq!(nh, ir_ip());
+    }
 }
 
 #[cfg(test)]

--- a/zebra-rs/src/config/manager.rs
+++ b/zebra-rs/src/config/manager.rs
@@ -2171,4 +2171,30 @@ mod yang_load_tests {
             "`set router bgp segment-routing srv6 ipv6-unicast` must be a valid settable path",
         );
     }
+
+    #[test]
+    fn bgp_evpn_assisted_replication_is_settable() {
+        use crate::config::ExecCode;
+        use crate::config::parse::{State, parse};
+        use libyang::to_entry;
+
+        let mut yang = YangStore::new();
+        yang.add_path(concat!(env!("CARGO_MANIFEST_DIR"), "/yang"));
+        yang.read_with_resolve("configure")
+            .expect("configure mode loads");
+        yang.identity_resolve();
+        let module = yang
+            .find_module("configure")
+            .expect("configure module present");
+        let entry = to_entry(&yang, module);
+
+        for path in [
+            "set router bgp afi-safi evpn assisted-replication role replicator",
+            "set router bgp afi-safi evpn assisted-replication role leaf",
+            "set router bgp afi-safi evpn assisted-replication replicator-ip 10.0.0.254",
+        ] {
+            let (code, _comps, _state) = parse(path, entry.clone(), None, State::new());
+            assert_eq!(code, ExecCode::Success, "`{path}` must be a settable path");
+        }
+    }
 }

--- a/zebra-rs/yang/zebra-bgp-evpn.yang
+++ b/zebra-rs/yang/zebra-bgp-evpn.yang
@@ -16,6 +16,10 @@ module zebra-bgp-evpn {
     prefix configure;
   }
 
+  import ietf-inet-types {
+    prefix inet;
+  }
+
   organization
     "zebra-rs";
 
@@ -52,7 +56,8 @@ module zebra-bgp-evpn {
 
   reference
     "RFC 7432: BGP MPLS-Based Ethernet VPN
-     RFC 8365: Network Virtualization Overlay Solution Using EVPN";
+     RFC 8365: Network Virtualization Overlay Solution Using EVPN
+     RFC 9574: Optimized Ingress Replication Solution for EVPN";
 
   grouping bgp-afi-safi-evpn-extension {
     description
@@ -72,6 +77,43 @@ module zebra-bgp-evpn {
 
          Equivalent to FRR's `advertise-all-vni` under
          `address-family l2vpn evpn`.";
+    }
+    container assisted-replication {
+      description
+        "RFC 9574 Optimized Ingress Replication (Assisted Replication)
+         role for the local speaker. Applies to every VNI advertised
+         under `advertise-all-vni`.";
+      leaf role {
+        type enumeration {
+          enum none {
+            description
+              "Regular NVE — plain ingress replication (the default).";
+          }
+          enum replicator {
+            description
+              "AR-REPLICATOR — advertise a Replicator-AR Type-3 route
+               (PMSI tunnel type 0x0A) whose next hop is `replicator-ip`,
+               so AR-LEAF nodes offload BUM replication here.";
+          }
+          enum leaf {
+            description
+              "AR-LEAF — tag the Regular-IR Type-3 route as AR-LEAF and
+               offload BUM replication to an AR-REPLICATOR.";
+          }
+        }
+        default none;
+        description
+          "Assisted Replication role advertised in the Type-3 IMET PMSI
+           Tunnel attribute (RFC 9574 §4, the T field).";
+      }
+      leaf replicator-ip {
+        type inet:ip-address;
+        description
+          "The AR-IP — a distinct routable local address advertised in
+           the Replicator-AR route's next hop and used as the BUM tunnel
+           destination by AR-LEAF nodes. Required when `role` is
+           `replicator`; ignored otherwise.";
+      }
     }
   }
 


### PR DESCRIPTION
## Summary

RFC 9574 (Optimized Ingress Replication for EVPN) **Phase 1a** — makes Type-3 IMET origination Assisted-Replication role-aware. Builds on the Phase 0 PMSI codec (#1476).

This is the **origination half** of Phase 1. Reception / flood-list behavior is intentionally unchanged — a node left at the default `none` role emits the byte-for-byte legacy Ingress Replication encoding, so this is non-regressive. The AR-IP-consuming receive path + AR-LEAF flood-list collapse land in **1b**.

### Config — `zebra-bgp-evpn.yang` + `bgp/config.rs`
- New container: `router bgp afi-safi evpn assisted-replication { role {none|replicator|leaf}; replicator-ip <ip>; }`.
- `config_assisted_replication_role` / `_ip` handlers (evpn-AFI-filtered like `advertise-all-vni`), re-originating every per-VNI IMET on change via `reoriginate_all_imet`.

### State — `bgp/inst.rs` (re-exported via `mod.rs`)
- `AssistedReplicationRole` enum (`None`/`Replicator`/`Leaf`) + `assisted_replication_role` / `assisted_replication_ip` fields on `Bgp`.

### Origination — `bgp/route.rs`
- Pure `imet_pmsi_tunnel(role, ar_ip, vtep_local, vni)` helper wired into `evpn_originate_imet`:
  - **Replicator** → Replicator-AR route: tunnel type `0x0A`, T=AR-REPLICATOR, next hop + tunnel endpoint = the AR-IP.
  - **Leaf** → Regular-IR route flagged T=AR-LEAF (tunnel type 6, next hop = local VTEP).
  - **None**, or Replicator misconfigured without an AR-IP → plain Ingress Replication (degrades safely).

## Test plan
- 4 unit tests pinning each role's PMSI/next-hop (`evpn_imet_ar_tests`).
- 1 `yang_load` test pinning the new config paths (`bgp_evpn_assisted_replication_is_settable`).
- `cargo test -p zebra-rs --bins` — 1301 passed, 0 failed (all `yang_load_tests` green).
- `cargo clippy --workspace --all-targets -- -D warnings` — no warnings.
- `cargo fmt` clean.

Generated with [Claude Code](https://claude.com/claude-code)