### PR TITLE
bgp: move neighbor policy/prefix-set under afi-safi (per-AFI)

### DIFF
--- a/bdd/tests/configs/bgp_afi_safi_policy/z1.yaml
+++ b/bdd/tests/configs/bgp_afi_safi_policy/z1.yaml
@@ -1,28 +1,18 @@
-prefix-set:
-- name: out-test
-  prefixes:
-  - prefix: 10.0.0.1/32
-policy:
-- name: out-test
-  entry:
-  - number: 10
-    action: permit
-    match:
-      prefix-set: out-test
 router:
   bgp:
     global:
       as: 65001
       router-id: 192.168.0.1
+    timer:
+      adv-interval:
+        ebgp: 1
     neighbor:
     - remote-address: 192.168.0.2
       afi-safi:
       - name: ipv4
         enabled: true
-      policy:
-        out: out-test
       enabled: true
-      remote-as: 65001
+      remote-as: 65002
     afi-safi:
     - name: ipv4
       network:

--- a/bdd/tests/configs/bgp_afi_safi_policy/z2-base.yaml
+++ b/bdd/tests/configs/bgp_afi_safi_policy/z2-base.yaml
@@ -1,14 +1,3 @@
-prefix-set:
-- name: HOGE
-  prefixes:
-  - prefix: 1.1.1.1/32
-policy:
-- name: HOGE
-  entry:
-  - number: 10
-    action: permit
-    match:
-      prefix-set: HOGE
 router:
   bgp:
     global:
@@ -19,7 +8,7 @@ router:
       afi-safi:
       - name: ipv4
         enabled: true
-      policy:
-        in: HOGE
+      soft-reconfiguration:
+        inbound: true
       enabled: true
       remote-as: 65001

--- a/bdd/tests/configs/bgp_afi_safi_policy/z2-legacy-deny.yaml
+++ b/bdd/tests/configs/bgp_afi_safi_policy/z2-legacy-deny.yaml
@@ -1,0 +1,24 @@
+# Legacy peer-wide (top-level) inbound policy that denies everything.
+# Kept for backward compatibility (Task B); applies to every family that
+# has no per-AFI override of its own.
+policy:
+- name: DENY-ALL
+  entry:
+  - number: 10
+    action: deny
+router:
+  bgp:
+    global:
+      as: 65002
+      router-id: 192.168.0.2
+    neighbor:
+    - remote-address: 192.168.0.1
+      afi-safi:
+      - name: ipv4
+        enabled: true
+      soft-reconfiguration:
+        inbound: true
+      policy:
+        in: DENY-ALL
+      enabled: true
+      remote-as: 65001

--- a/bdd/tests/configs/bgp_afi_safi_policy/z2-perafi-permit.yaml
+++ b/bdd/tests/configs/bgp_afi_safi_policy/z2-perafi-permit.yaml
@@ -1,0 +1,31 @@
+# Per-AFI ipv4 inbound policy that permits everything, layered on top of
+# the still-present legacy DENY-ALL. The per-AFI binding wins for ipv4
+# (Task B/C priority), so the routes the legacy policy denied are
+# accepted again.
+policy:
+- name: DENY-ALL
+  entry:
+  - number: 10
+    action: deny
+- name: PERMIT-ALL
+  entry:
+  - number: 10
+    action: permit
+router:
+  bgp:
+    global:
+      as: 65002
+      router-id: 192.168.0.2
+    neighbor:
+    - remote-address: 192.168.0.1
+      afi-safi:
+      - name: ipv4
+        enabled: true
+        policy:
+          in: PERMIT-ALL
+      soft-reconfiguration:
+        inbound: true
+      policy:
+        in: DENY-ALL
+      enabled: true
+      remote-as: 65001

--- a/bdd/tests/configs/bgp_basic_ebgp/z1-5.yaml
+++ b/bdd/tests/configs/bgp_basic_ebgp/z1-5.yaml
@@ -8,7 +8,7 @@ policy:
   - number: 10
     action: permit
     match:
-      prefix: out-test
+      prefix-set: out-test
 router:
   bgp:
     global:
@@ -19,8 +19,8 @@ router:
       afi-safi:
       - name: ipv4
         enabled: true
-      policy:
-        out: out-test
+        policy:
+          out: out-test
       enabled: true
       remote-as: 65002
     afi-safi:

--- a/bdd/tests/configs/bgp_community/z1-3.yaml
+++ b/bdd/tests/configs/bgp_community/z1-3.yaml
@@ -12,7 +12,7 @@ policy:
   - number: 10
     action: permit
     match:
-      prefix: adv-1111
+      prefix-set: adv-1111
     set:
       community:
         name: comm-no-export

--- a/bdd/tests/configs/bgp_community/z1-4.yaml
+++ b/bdd/tests/configs/bgp_community/z1-4.yaml
@@ -12,7 +12,7 @@ policy:
   - number: 10
     action: permit
     match:
-      prefix: adv-1111
+      prefix-set: adv-1111
     set:
       community:
         name: comm-no-advertise

--- a/bdd/tests/configs/bgp_enforce_first_as/z1.yaml
+++ b/bdd/tests/configs/bgp_enforce_first_as/z1.yaml
@@ -19,7 +19,7 @@ policy:
   - number: 10
     action: permit
     match:
-      prefix: ALL-V4
+      prefix-set: ALL-V4
     set:
       as-path-prepend:
         asn: 65099

--- a/bdd/tests/configs/bgp_lu_route_map/z1-out.yaml
+++ b/bdd/tests/configs/bgp_lu_route_map/z1-out.yaml
@@ -12,7 +12,7 @@ policy:
   - number: 10
     action: deny
     match:
-      prefix: OUT-DENY-LU
+      prefix-set: OUT-DENY-LU
   - number: 20
     action: permit
 router:

--- a/bdd/tests/configs/bgp_lu_route_map/z2-in.yaml
+++ b/bdd/tests/configs/bgp_lu_route_map/z2-in.yaml
@@ -12,7 +12,7 @@ policy:
   - number: 10
     action: deny
     match:
-      prefix: IN-DENY-LU
+      prefix-set: IN-DENY-LU
   - number: 20
     action: permit
 router:
@@ -27,5 +27,5 @@ router:
       afi-safi:
       - name: label-v4
         enabled: true
-      policy:
-        in: IN-LU
+        policy:
+          in: IN-LU

--- a/bdd/tests/configs/bgp_policy_dynamic_update/z2-both.yaml
+++ b/bdd/tests/configs/bgp_policy_dynamic_update/z2-both.yaml
@@ -9,7 +9,7 @@ policy:
   - number: 10
     action: permit
     match:
-      prefix: HOGE
+      prefix-set: HOGE
 router:
   bgp:
     global:

--- a/bdd/tests/configs/bgp_policy_dynamic_update/z2-other.yaml
+++ b/bdd/tests/configs/bgp_policy_dynamic_update/z2-other.yaml
@@ -8,7 +8,7 @@ policy:
   - number: 10
     action: permit
     match:
-      prefix: HOGE
+      prefix-set: HOGE
 router:
   bgp:
     global:

--- a/bdd/tests/configs/bgp_route_map_match/z1.yaml
+++ b/bdd/tests/configs/bgp_route_map_match/z1.yaml
@@ -9,7 +9,7 @@ policy:
   - number: 10
     action: permit
     match:
-      prefix: ALL-V4
+      prefix-set: ALL-V4
     set:
       med:
         set: 100

--- a/bdd/tests/configs/bgp_shard_policy/z2-permit2.yaml
+++ b/bdd/tests/configs/bgp_shard_policy/z2-permit2.yaml
@@ -11,11 +11,11 @@ policy:
   - number: 10
     action: permit
     match:
-      prefix: ALLOW-1
+      prefix-set: ALLOW-1
   - number: 20
     action: permit
     match:
-      prefix: ALLOW-2
+      prefix-set: ALLOW-2
 router:
   bgp:
     global:

--- a/bdd/tests/configs/bgp_shard_policy/z2.yaml
+++ b/bdd/tests/configs/bgp_shard_policy/z2.yaml
@@ -8,7 +8,7 @@ policy:
   - number: 10
     action: permit
     match:
-      prefix: ALLOW-1
+      prefix-set: ALLOW-1
 router:
   bgp:
     global:

--- a/bdd/tests/configs/bgp_table_map/z2-deny-more.yaml
+++ b/bdd/tests/configs/bgp_table_map/z2-deny-more.yaml
@@ -12,11 +12,11 @@ policy:
   - number: 10
     action: deny
     match:
-      prefix: DENY
+      prefix-set: DENY
   - number: 20
     action: permit
     match:
-      prefix: MED
+      prefix-set: MED
     set:
       med:
         set: 50

--- a/bdd/tests/configs/bgp_table_map/z2.yaml
+++ b/bdd/tests/configs/bgp_table_map/z2.yaml
@@ -11,11 +11,11 @@ policy:
   - number: 10
     action: deny
     match:
-      prefix: DENY
+      prefix-set: DENY
   - number: 20
     action: permit
     match:
-      prefix: MED
+      prefix-set: MED
     set:
       med:
         set: 50

--- a/bdd/tests/configs/bgp_v6_route_map/z1-out.yaml
+++ b/bdd/tests/configs/bgp_v6_route_map/z1-out.yaml
@@ -14,7 +14,7 @@ policy:
   - number: 10
     action: deny
     match:
-      prefix: OUT-DENY6
+      prefix-set: OUT-DENY6
   - number: 20
     action: permit
 router:

--- a/bdd/tests/configs/bgp_v6_route_map/z2-in.yaml
+++ b/bdd/tests/configs/bgp_v6_route_map/z2-in.yaml
@@ -17,11 +17,11 @@ policy:
   - number: 10
     action: deny
     match:
-      prefix: IN-DENY6
+      prefix-set: IN-DENY6
   - number: 20
     action: permit
     match:
-      prefix: IN-MED6
+      prefix-set: IN-MED6
     set:
       med:
         set: 50
@@ -41,8 +41,8 @@ router:
         enabled: true
       - name: ipv6
         enabled: true
-      policy:
-        in: IN6
+        policy:
+          in: IN6
     afi-safi:
     - name: ipv6
       redistribute:

--- a/bdd/tests/configs/bgp_v6_table_map/z2-deny-more.yaml
+++ b/bdd/tests/configs/bgp_v6_table_map/z2-deny-more.yaml
@@ -18,11 +18,11 @@ policy:
   - number: 10
     action: deny
     match:
-      prefix: DENY6
+      prefix-set: DENY6
   - number: 20
     action: permit
     match:
-      prefix: MED6
+      prefix-set: MED6
     set:
       med:
         set: 50

--- a/bdd/tests/configs/bgp_v6_table_map/z2.yaml
+++ b/bdd/tests/configs/bgp_v6_table_map/z2.yaml
@@ -17,11 +17,11 @@ policy:
   - number: 10
     action: deny
     match:
-      prefix: DENY6
+      prefix-set: DENY6
   - number: 20
     action: permit
     match:
-      prefix: MED6
+      prefix-set: MED6
     set:
       med:
         set: 50

--- a/bdd/tests/features/bgp_afi_safi_policy.feature
+++ b/bdd/tests/features/bgp_afi_safi_policy.feature
@@ -1,0 +1,69 @@
+@serial
+@bgp_afi_safi_policy
+Feature: BGP per-AFI neighbor policy under afi-safi (with legacy fallback)
+
+  As a network operator I want to bind a route-policy per address family
+  under `neighbor X afi-safi <name> policy {in,out}`, while the old
+  peer-wide `neighbor X policy {in,out}` is kept as a backward-compatible
+  fallback. A per-AFI binding MUST take priority over the legacy one for
+  routes of that family.
+
+  This is observed inbound on z2: z1 originates two /32s; z2's inbound
+  policy decides which survive in z2's BGP table. Policy edits are picked
+  up live (soft-reconfiguration inbound), no session reset.
+
+  Test Topology:
+  ```
+  z1 (AS65001) ──eBGP── z2 (AS65002)
+  192.168.0.1/24        192.168.0.2/24
+  ```
+  Both on bridge br0.
+
+  Config files:
+  - z1.yaml: AS65001, peers z2, originates 10.0.0.1/32 + 10.0.0.2/32.
+  - z2-base.yaml: AS65002, peers z1, soft-reconfiguration inbound, no
+    policy (both routes accepted).
+  - z2-legacy-deny.yaml: adds the legacy peer-wide `policy in DENY-ALL`
+    (deny everything) — both routes disappear.
+  - z2-perafi-permit.yaml: adds `afi-safi ipv4 policy in PERMIT-ALL`
+    while DENY-ALL stays bound — the per-AFI policy wins, routes return.
+
+  Scenario: Setup sessions; with no policy both routes are accepted
+    Given a clean test environment
+    When I create bridge "br0"
+    And I create namespace "z1" with IP "192.168.0.1/24" on bridge "br0"
+    And I create namespace "z2" with IP "192.168.0.2/24" on bridge "br0"
+    And I start zebra-rs in namespace "z1"
+    And I start zebra-rs in namespace "z2"
+    And I apply config "z1.yaml" to namespace "z1"
+    And I apply config "z2-base.yaml" to namespace "z2"
+    And I wait 10 seconds for BGP to operate
+    Then BGP session in "z1" to "192.168.0.2" should be "Established"
+    And BGP session in "z2" to "192.168.0.1" should be "Established"
+    And BGP route in "z2" has "10.0.0.1/32"
+    And BGP route in "z2" has "10.0.0.2/32"
+
+  Scenario: Legacy peer-wide policy denies every inbound route
+    Given the test topology exists
+    When I apply config "z2-legacy-deny.yaml" to namespace "z2"
+    And I wait 5 seconds for BGP to operate
+    Then BGP route in "z2" does not have "10.0.0.1/32"
+    And BGP route in "z2" does not have "10.0.0.2/32"
+
+  Scenario: A per-AFI ipv4 policy overrides the legacy deny — routes return
+    Given the test topology exists
+    When I apply config "z2-perafi-permit.yaml" to namespace "z2"
+    And I wait 5 seconds for BGP to operate
+    Then BGP route in "z2" has "10.0.0.1/32"
+    And BGP route in "z2" has "10.0.0.2/32"
+    And show command "show bgp neighbors 192.168.0.1" in namespace "z2" should contain "ipv4: policy in PERMIT-ALL"
+    And show command "show bgp neighbors 192.168.0.1" in namespace "z2" should contain "(peer-wide): policy in DENY-ALL"
+
+  Scenario: Teardown topology
+    Given the test topology exists
+    When I stop zebra-rs in namespace "z1"
+    And I stop zebra-rs in namespace "z2"
+    And I delete namespace "z1"
+    And I delete namespace "z2"
+    And I delete bridge "br0"
+    Then the test environment should be clean

--- a/book/src/ch-02-28-bgp-table-map.md
+++ b/book/src/ch-02-28-bgp-table-map.md
@@ -54,11 +54,11 @@ policy:
   - number: 10
     action: deny
     match:
-      prefix: DENY
+      prefix-set: DENY
   - number: 20
     action: permit
     match:
-      prefix: MED
+      prefix-set: MED
     set:
       med:
         set: 50
@@ -118,7 +118,7 @@ policy:
   - number: 10
     action: deny
     match:
-      prefix: DENY6
+      prefix-set: DENY6
   - number: 20
     action: permit
 router:

--- a/book/src/ch-05-00-policy.md
+++ b/book/src/ch-05-00-policy.md
@@ -22,7 +22,7 @@ Most policy clauses reference a *set* — a separately-named
 collection of values. The defined set types are:
 
 - `prefix-set` — IP prefixes, optionally with `le`/`ge` length
-  bounds. Used by `match prefix`.
+  bounds. Used by `match prefix-set`.
 - `community-set` — standard or extended community values, with
   optional regex. Used by `match community`.
 - `ext-community-set` — extended communities only (`rt:`/`soo:`),
@@ -52,7 +52,7 @@ policy IN-CUSTOMER-A {
     entry 10 {
         action permit;
         match {
-            prefix CUSTOMER-A;
+            prefix-set CUSTOMER-A;
         }
         set {
             local-preference {

--- a/book/src/ch-05-01-policy-control-flow.md
+++ b/book/src/ch-05-01-policy-control-flow.md
@@ -40,7 +40,7 @@ policy ACCEPT-CUSTOMER-A {
     entry 10 {
         action permit;
         match {
-            prefix CUSTOMER-A;
+            prefix-set CUSTOMER-A;
         }
         set {
             local-preference {
@@ -66,7 +66,7 @@ policy LAYERED {
     entry 10 {
         action next;
         match {
-            prefix CUSTOMER-A;
+            prefix-set CUSTOMER-A;
         }
         set {
             community {
@@ -106,7 +106,7 @@ policy BLOCK-MARTIANS {
     entry 10 {
         action deny;
         match {
-            prefix MARTIANS;
+            prefix-set MARTIANS;
         }
     }
     entry 20 {
@@ -129,7 +129,7 @@ policy ENDS-ON-NEXT {
     entry 10 {
         action next;
         match {
-            prefix CUSTOMER-A;
+            prefix-set CUSTOMER-A;
         }
         set {
             community {
@@ -151,7 +151,7 @@ policy CORRECT {
     entry 10 {
         action next;
         match {
-            prefix CUSTOMER-A;
+            prefix-set CUSTOMER-A;
         }
         set {
             community {
@@ -179,7 +179,7 @@ policy DEFAULT-PERMIT {
     entry 10 {
         action permit;
         match {
-            prefix CUSTOMER-A;
+            prefix-set CUSTOMER-A;
         }
         set {
             local-preference {
@@ -190,7 +190,7 @@ policy DEFAULT-PERMIT {
     entry 20 {
         action deny;
         match {
-            prefix MARTIANS;
+            prefix-set MARTIANS;
         }
     }
     entry 99 {
@@ -210,13 +210,13 @@ policy ORDER-DEMO {
     entry 10 {
         action deny;
         match {
-            prefix BLOCKLIST;
+            prefix-set BLOCKLIST;
         }
     }
     entry 20 {
         action permit;
         match {
-            prefix VIPS;
+            prefix-set VIPS;
         }
         set {
             local-preference {

--- a/book/src/ch-05-02-policy-match.md
+++ b/book/src/ch-05-02-policy-match.md
@@ -7,7 +7,7 @@ clause must succeed for the entry to fire. An empty `match` block
 
 This chapter covers all match clauses grouped by shape:
 
-1. **Set references** — `prefix`, `community`, `ext-community`,
+1. **Set references** — `prefix-set`, `community`, `ext-community`,
    `large-community`, `as-path` — name a separately-defined set.
 2. **Direct address** — `next-hop` — exact equality against the
    route's NEXT_HOP attribute.
@@ -18,7 +18,7 @@ This chapter covers all match clauses grouped by shape:
 
 ## Set references
 
-### `match prefix`
+### `match prefix-set`
 
 References a `prefix-set`. The route's prefix is checked against
 each entry of the set; if any matches (with optional `le` / `ge`
@@ -39,7 +39,7 @@ policy IN-CUSTOMER {
     entry 10 {
         action permit;
         match {
-            prefix CUSTOMER-NETS;
+            prefix-set CUSTOMER-NETS;
         }
     }
 }
@@ -164,7 +164,7 @@ matching `650030` or `650031`.
 Takes an IPv4 *or* IPv6 address — not a prefix-set name — and
 compares it for **exact equality** against the route's BGP
 NEXT_HOP attribute. To match a *range* of addresses, use a
-prefix-set with `match prefix` against the route prefix, or
+prefix-set with `match prefix-set` against the route prefix, or
 write multiple entries.
 
 ```console
@@ -343,7 +343,7 @@ policy STRICT {
     entry 10 {
         action permit;
         match {
-            prefix CUSTOMER-NETS;
+            prefix-set CUSTOMER-NETS;
             as-path FROM-65003;
             med {
                 le 100;

--- a/book/src/ch-05-03-policy-set.md
+++ b/book/src/ch-05-03-policy-set.md
@@ -223,7 +223,7 @@ policy ADD-INTERNAL-TAG {
     entry 10 {
         action permit;
         match {
-            prefix INTERNAL-NETS;
+            prefix-set INTERNAL-NETS;
         }
         set {
             community {
@@ -347,7 +347,7 @@ policy IN-CUSTOMER-A {
     entry 10 {
         action permit;
         match {
-            prefix CUSTOMER-A;
+            prefix-set CUSTOMER-A;
         }
         set {
             local-preference {
@@ -379,5 +379,5 @@ For a route 10.10.5.0/24 from this peer with `LOCAL_PREF=100`,
 
 For a route 192.168.0.0/24 (not in `CUSTOMER-A`):
 
-1. Entry 10's `match prefix` fails. Entry skipped.
+1. Entry 10's `match prefix-set` fails. Entry skipped.
 2. Entry 20: unconditional `permit`. Accepted unchanged.

--- a/zebra-rs/src/bgp/config.rs
+++ b/zebra-rs/src/bgp/config.rs
@@ -419,15 +419,51 @@ pub(super) fn apply_peer_policy_ref(
     policy_type: policy::PolicyType,
     want: Option<String>,
 ) {
-    let ident = peer.ident;
+    // The legacy peer-wide binding registers with a family-less ident.
+    let ident = peer_policy_ident(peer.ident, None);
     let slot = match policy_type {
-        policy::PolicyType::PolicyListIn => &mut peer.policy_list.get_mut(&InOut::Input).name,
-        policy::PolicyType::PolicyListOut => &mut peer.policy_list.get_mut(&InOut::Output).name,
-        policy::PolicyType::PrefixSetIn => &mut peer.prefix_set.get_mut(&InOut::Input).name,
-        policy::PolicyType::PrefixSetOut => &mut peer.prefix_set.get_mut(&InOut::Output).name,
+        policy::PolicyType::PolicyListIn => {
+            &mut peer.policy_list_legacy.get_mut(&InOut::Input).name
+        }
+        policy::PolicyType::PolicyListOut => {
+            &mut peer.policy_list_legacy.get_mut(&InOut::Output).name
+        }
+        policy::PolicyType::PrefixSetIn => &mut peer.prefix_set_legacy.get_mut(&InOut::Input).name,
+        policy::PolicyType::PrefixSetOut => {
+            &mut peer.prefix_set_legacy.get_mut(&InOut::Output).name
+        }
         // Key-chain subscriptions ride a different registry, and
         // table-map subscriptions are AFI-scoped rather than
         // peer-scoped; neither reaches this helper.
+        policy::PolicyType::KeyChain(_) | policy::PolicyType::TableMap => return,
+    };
+    let prior = match &want {
+        Some(n) => slot.replace(n.clone()),
+        None => slot.take(),
+    };
+    policy_attach_msgs(policy_tx, ident, policy_type, prior, want);
+}
+
+/// Per-AFI sibling of [`apply_peer_policy_ref`]: bind a resolved policy
+/// / prefix-set name to one direction slot of one address family and
+/// (un)register it with the policy actor under a family-tagged ident so
+/// the resolve reply lands back on the same per-AFI slot. Used by the
+/// `neighbor X afi-safi <name> {policy,prefix-set} {in,out}` callbacks.
+pub(super) fn apply_peer_afi_policy_ref(
+    policy_tx: &tokio::sync::mpsc::UnboundedSender<policy::Message>,
+    peer: &mut Peer,
+    afi_safi: AfiSafi,
+    policy_type: policy::PolicyType,
+    want: Option<String>,
+) {
+    let ident = peer_policy_ident(peer.ident, Some(afi_safi));
+    let slot = match policy_type {
+        policy::PolicyType::PolicyListIn => &mut peer.policy_list_slot(afi_safi, InOut::Input).name,
+        policy::PolicyType::PolicyListOut => {
+            &mut peer.policy_list_slot(afi_safi, InOut::Output).name
+        }
+        policy::PolicyType::PrefixSetIn => &mut peer.prefix_set_slot(afi_safi, InOut::Input).name,
+        policy::PolicyType::PrefixSetOut => &mut peer.prefix_set_slot(afi_safi, InOut::Output).name,
         policy::PolicyType::KeyChain(_) | policy::PolicyType::TableMap => return,
     };
     let prior = match &want {
@@ -474,35 +510,88 @@ fn config_policy_out(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Option<()> 
     Some(())
 }
 
-fn config_prefix_in(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Option<()> {
+/// `neighbor X afi-safi <name> policy {in,out} <ref>` — the per-family
+/// route-policy binding. Wins over the legacy top-level `policy {in,out}`
+/// for routes of this family ([`Peer::policy_list_at`]). No neighbor-group
+/// inheritance layer (the group has no per-AFI policy knob), so the
+/// explicit name is bound directly.
+fn config_afi_safi_policy_in(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Option<()> {
     let addr = args.addr()?;
+    let afi_safi: AfiSafi = args.afi_safi()?;
     let new_name = if op.is_set() {
         Some(args.string()?)
     } else {
         None
     };
     let peer = bgp.peers.get_mut(&addr)?;
-    peer.config.knobs_explicit.prefix_set_in = new_name;
-    let want = super::neighbor_group::resolve_knob(&bgp.neighbor_groups, &peer.config, |k| {
-        k.prefix_set_in.clone()
-    });
-    apply_peer_policy_ref(&bgp.policy_tx, peer, policy::PolicyType::PrefixSetIn, want);
+    apply_peer_afi_policy_ref(
+        &bgp.policy_tx,
+        peer,
+        afi_safi,
+        policy::PolicyType::PolicyListIn,
+        new_name,
+    );
     Some(())
 }
 
-fn config_prefix_out(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Option<()> {
+fn config_afi_safi_policy_out(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Option<()> {
     let addr = args.addr()?;
+    let afi_safi: AfiSafi = args.afi_safi()?;
     let new_name = if op.is_set() {
         Some(args.string()?)
     } else {
         None
     };
     let peer = bgp.peers.get_mut(&addr)?;
-    peer.config.knobs_explicit.prefix_set_out = new_name;
-    let want = super::neighbor_group::resolve_knob(&bgp.neighbor_groups, &peer.config, |k| {
-        k.prefix_set_out.clone()
-    });
-    apply_peer_policy_ref(&bgp.policy_tx, peer, policy::PolicyType::PrefixSetOut, want);
+    apply_peer_afi_policy_ref(
+        &bgp.policy_tx,
+        peer,
+        afi_safi,
+        policy::PolicyType::PolicyListOut,
+        new_name,
+    );
+    Some(())
+}
+
+/// `neighbor X afi-safi <name> prefix-set {in,out} <ref>` — the per-family
+/// prefix-set binding. There is no legacy top-level neighbor `prefix-set`
+/// (it was removed when this moved under afi-safi); inheritance through a
+/// neighbor-group still feeds the per-family fallback.
+fn config_afi_safi_prefix_in(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Option<()> {
+    let addr = args.addr()?;
+    let afi_safi: AfiSafi = args.afi_safi()?;
+    let new_name = if op.is_set() {
+        Some(args.string()?)
+    } else {
+        None
+    };
+    let peer = bgp.peers.get_mut(&addr)?;
+    apply_peer_afi_policy_ref(
+        &bgp.policy_tx,
+        peer,
+        afi_safi,
+        policy::PolicyType::PrefixSetIn,
+        new_name,
+    );
+    Some(())
+}
+
+fn config_afi_safi_prefix_out(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Option<()> {
+    let addr = args.addr()?;
+    let afi_safi: AfiSafi = args.afi_safi()?;
+    let new_name = if op.is_set() {
+        Some(args.string()?)
+    } else {
+        None
+    };
+    let peer = bgp.peers.get_mut(&addr)?;
+    apply_peer_afi_policy_ref(
+        &bgp.policy_tx,
+        peer,
+        afi_safi,
+        policy::PolicyType::PrefixSetOut,
+        new_name,
+    );
     Some(())
 }
 
@@ -1855,6 +1944,44 @@ pub(super) fn table_map_ident_decode(ident: usize) -> Option<AfiSafi> {
         1 => Some(AfiSafi::new(Afi::Ip6, Safi::Unicast)),
         _ => None,
     }
+}
+
+/// Low bits of a per-neighbor policy `ident` carry the AFI/SAFI the
+/// binding belongs to; the high bits carry the peer index. The policy
+/// watch registry treats `ident` as an opaque token and echoes it back
+/// on resolve, so [`process_policy_msg`](super::Bgp::process_policy_msg)
+/// recovers both halves. Tag `0` means the legacy peer-wide binding
+/// (top-level `policy {in,out}` / neighbor-group inheritance), which has
+/// no family of its own. A real family's code is `(afi << 8) | safi`,
+/// always ≥ 257, so it never collides with the legacy tag.
+const POLICY_AFI_BITS: u32 = 24;
+const POLICY_AFI_MASK: usize = (1 << POLICY_AFI_BITS) - 1;
+
+fn policy_afi_code(afi_safi: AfiSafi) -> usize {
+    ((u16::from(afi_safi.afi) as usize) << 8) | (u8::from(afi_safi.safi) as usize)
+}
+
+/// Encode `(peer_idx, family)` into a policy-watch `ident`. `family ==
+/// None` ⇒ the legacy peer-wide slot.
+pub(super) fn peer_policy_ident(peer_idx: usize, afi_safi: Option<AfiSafi>) -> usize {
+    debug_assert!(peer_idx < (1 << (usize::BITS - POLICY_AFI_BITS)));
+    (peer_idx << POLICY_AFI_BITS) | afi_safi.map(policy_afi_code).unwrap_or(0)
+}
+
+/// Inverse of [`peer_policy_ident`]. Returns the peer index and the
+/// family the binding targets (`None` ⇒ the legacy peer-wide slot).
+pub(super) fn peer_policy_ident_decode(ident: usize) -> (usize, Option<AfiSafi>) {
+    let code = ident & POLICY_AFI_MASK;
+    let peer_idx = ident >> POLICY_AFI_BITS;
+    let afi_safi = if code == 0 {
+        None
+    } else {
+        Some(AfiSafi::new(
+            Afi::from((code >> 8) as u16),
+            Safi::from((code & 0xff) as u8),
+        ))
+    };
+    (peer_idx, afi_safi)
 }
 
 /// `router bgp afi-safi <af> table-map <policy>`
@@ -3535,10 +3662,16 @@ impl Bgp {
         self.callback_add("/router/bgp/afi-safi/table-map", config_table_map);
 
         // Applying policy.
+        // Legacy peer-wide policy (kept for backward compatibility): a
+        // per-family `afi-safi <name> policy …` binding overrides it.
         self.callback_peer("/policy/in", config_policy_in);
         self.callback_peer("/policy/out", config_policy_out);
-        self.callback_peer("/prefix-set/in", config_prefix_in);
-        self.callback_peer("/prefix-set/out", config_prefix_out);
+        // Per-AFI policy / prefix-set (the canonical location). The old
+        // top-level `prefix-set` node was removed; only these remain.
+        self.callback_peer("/afi-safi/policy/in", config_afi_safi_policy_in);
+        self.callback_peer("/afi-safi/policy/out", config_afi_safi_policy_out);
+        self.callback_peer("/afi-safi/prefix-set/in", config_afi_safi_prefix_in);
+        self.callback_peer("/afi-safi/prefix-set/out", config_afi_safi_prefix_out);
 
         // Route Reflector.
         self.callback_peer("/route-reflector/client", config_route_reflector);
@@ -6199,11 +6332,13 @@ mod neighbor_group_wiring_tests {
         config_peer(&mut bgp, arg_words(&["10.0.0.1"]), ConfigOp::Set).unwrap();
         config_peer_neighbor_group(&mut bgp, arg_words(&["10.0.0.1", "G"]), ConfigOp::Set).unwrap();
 
+        // The group/top-level (legacy) bindings land in the peer-wide
+        // fallback slots, not the per-AFI map.
         let pol_out = |bgp: &Bgp| {
             bgp.peers
                 .get(&peer_addr())
                 .unwrap()
-                .policy_list
+                .policy_list_legacy
                 .get(&InOut::Output)
                 .name
                 .clone()
@@ -6212,7 +6347,7 @@ mod neighbor_group_wiring_tests {
             bgp.peers
                 .get(&peer_addr())
                 .unwrap()
-                .prefix_set
+                .prefix_set_legacy
                 .get(&InOut::Input)
                 .name
                 .clone()
@@ -6241,6 +6376,83 @@ mod neighbor_group_wiring_tests {
         config_neighbor_group_policy_out(&mut bgp, arg_words(&["G", "EGRESS"]), ConfigOp::Delete)
             .unwrap();
         assert_eq!(pol_out(&bgp), None, "group delete unbinds");
+    }
+
+    /// A per-AFI `afi-safi <name> policy/prefix-set` binding wins for its
+    /// own family; other families fall back to the legacy peer-wide
+    /// `policy {in,out}` (Task B/C priority). Deleting the per-AFI binding
+    /// restores the fallback.
+    #[tokio::test]
+    async fn afi_safi_policy_overrides_legacy_per_family() {
+        use crate::bgp::InOut;
+        use bgp_packet::{Afi, AfiSafi, Safi};
+
+        let mut bgp = fresh_bgp();
+        config_peer(&mut bgp, arg_words(&["10.0.0.1"]), ConfigOp::Set).unwrap();
+
+        let v4 = AfiSafi::new(Afi::Ip, Safi::Unicast);
+        let evpn = AfiSafi::new(Afi::L2vpn, Safi::Evpn);
+        let pol_in = |bgp: &Bgp, af: AfiSafi| {
+            bgp.peers
+                .get(&peer_addr())
+                .unwrap()
+                .policy_list_at(af, InOut::Input)
+                .name
+                .clone()
+        };
+        let pfx_in = |bgp: &Bgp, af: AfiSafi| {
+            bgp.peers
+                .get(&peer_addr())
+                .unwrap()
+                .prefix_set_at(af, InOut::Input)
+                .name
+                .clone()
+        };
+
+        // Legacy top-level policy (kept for backward compatibility)
+        // applies to every family as the fallback.
+        config_policy_in(&mut bgp, arg_words(&["10.0.0.1", "LEGACY"]), ConfigOp::Set).unwrap();
+        assert_eq!(pol_in(&bgp, v4).as_deref(), Some("LEGACY"));
+        assert_eq!(pol_in(&bgp, evpn).as_deref(), Some("LEGACY"));
+
+        // A per-AFI ipv4 binding overrides the legacy one — but only for
+        // ipv4; evpn still sees the legacy fallback.
+        super::config_afi_safi_policy_in(
+            &mut bgp,
+            arg_words(&["10.0.0.1", "ipv4", "PERAFI"]),
+            ConfigOp::Set,
+        )
+        .unwrap();
+        assert_eq!(pol_in(&bgp, v4).as_deref(), Some("PERAFI"), "per-AFI wins");
+        assert_eq!(
+            pol_in(&bgp, evpn).as_deref(),
+            Some("LEGACY"),
+            "other family keeps the legacy fallback",
+        );
+
+        // prefix-set has no legacy peer-wide slot (Task C removed it), so
+        // it is per-AFI only.
+        super::config_afi_safi_prefix_in(
+            &mut bgp,
+            arg_words(&["10.0.0.1", "ipv4", "PFX4"]),
+            ConfigOp::Set,
+        )
+        .unwrap();
+        assert_eq!(pfx_in(&bgp, v4).as_deref(), Some("PFX4"));
+        assert_eq!(pfx_in(&bgp, evpn), None, "no prefix-set fallback");
+
+        // Deleting the per-AFI policy restores the legacy fallback for ipv4.
+        super::config_afi_safi_policy_in(
+            &mut bgp,
+            arg_words(&["10.0.0.1", "ipv4"]),
+            ConfigOp::Delete,
+        )
+        .unwrap();
+        assert_eq!(
+            pol_in(&bgp, v4).as_deref(),
+            Some("LEGACY"),
+            "per-AFI delete falls back to legacy",
+        );
     }
 }
 

--- a/zebra-rs/src/bgp/inst.rs
+++ b/zebra-rs/src/bgp/inst.rs
@@ -3540,9 +3540,13 @@ impl Bgp {
         let Some(peer) = self.peers.get_by_idx(ident) else {
             return;
         };
+        // The shard only policy-filters IPv4 unicast ingress
+        // (`compute_policy`), so it carries that family's effective
+        // inbound policy (per-AFI binding, else the legacy fallback).
+        let v4u = bgp_packet::AfiSafi::new(bgp_packet::Afi::Ip, bgp_packet::Safi::Unicast);
         let snap = std::sync::Arc::new(super::shard::InPolicy {
-            prefix_set: peer.prefix_set.input.clone(),
-            policy_list: peer.policy_list.input.clone(),
+            prefix_set: peer.prefix_set_at(v4u, InOut::Input).clone(),
+            policy_list: peer.policy_list_at(v4u, InOut::Input).clone(),
         });
         if let Some(pool) = self.shards.as_ref() {
             pool.broadcast(|| super::shard::ShardMsg::PolicyReplace {
@@ -3568,7 +3572,10 @@ impl Bgp {
                 policy_type,
                 prefix_set,
             } => {
-                let Some(peer) = self.peers.get_mut_by_idx(ident) else {
+                // The low bits of `ident` carry the family (or the
+                // legacy peer-wide slot); the high bits the peer index.
+                let (peer_idx, afi_opt) = super::config::peer_policy_ident_decode(ident);
+                let Some(peer) = self.peers.get_mut_by_idx(peer_idx) else {
                     return;
                 };
                 let direction = match policy_type {
@@ -3576,7 +3583,10 @@ impl Bgp {
                     policy::PolicyType::PrefixSetOut => InOut::Output,
                     _ => return,
                 };
-                let config = peer.prefix_set.get_mut(&direction);
+                let config = match afi_opt {
+                    Some(afi) => peer.prefix_set_slot(afi, direction),
+                    None => peer.prefix_set_legacy.get_mut(&direction),
+                };
                 config.prefix_set = prefix_set;
                 // Keep the cached outbound-policy snapshot (carried by
                 // every `SyncCtx`) current before the soft-out re-advertise
@@ -3591,10 +3601,10 @@ impl Bgp {
                         // before replaying Adj-RIB-In, so the replay
                         // re-evaluates against it (single-relay FIFO keeps
                         // PolicyReplace ahead of the replayed routes).
-                        self.shard_replace_in_policy(ident);
-                        super::peer::apply_soft_in_peer(self, ident);
+                        self.shard_replace_in_policy(peer_idx);
+                        super::peer::apply_soft_in_peer(self, peer_idx);
                     }
-                    InOut::Output => super::peer::apply_soft_out_peer(self, ident),
+                    InOut::Output => super::peer::apply_soft_out_peer(self, peer_idx),
                 }
             }
             policy::PolicyRx::PolicyList {
@@ -3624,7 +3634,8 @@ impl Bgp {
                     self.table_map_resync(afi_safi);
                     return;
                 }
-                let Some(peer) = self.peers.get_mut_by_idx(ident) else {
+                let (peer_idx, afi_opt) = super::config::peer_policy_ident_decode(ident);
+                let Some(peer) = self.peers.get_mut_by_idx(peer_idx) else {
                     return;
                 };
                 let direction = match policy_type {
@@ -3632,7 +3643,10 @@ impl Bgp {
                     policy::PolicyType::PolicyListOut => InOut::Output,
                     _ => return,
                 };
-                let config = peer.policy_list.get_mut(&direction);
+                let config = match afi_opt {
+                    Some(afi) => peer.policy_list_slot(afi, direction),
+                    None => peer.policy_list_legacy.get_mut(&direction),
+                };
                 config.policy_list = policy_list;
                 // Keep the cached outbound-policy snapshot current before
                 // the soft-out re-advertise reads it (see the prefix-set
@@ -3647,10 +3661,10 @@ impl Bgp {
                         // before replaying Adj-RIB-In, so the replay
                         // re-evaluates against it (single-relay FIFO keeps
                         // PolicyReplace ahead of the replayed routes).
-                        self.shard_replace_in_policy(ident);
-                        super::peer::apply_soft_in_peer(self, ident);
+                        self.shard_replace_in_policy(peer_idx);
+                        super::peer::apply_soft_in_peer(self, peer_idx);
                     }
-                    InOut::Output => super::peer::apply_soft_out_peer(self, ident),
+                    InOut::Output => super::peer::apply_soft_out_peer(self, peer_idx),
                 }
             }
             policy::PolicyRx::KeyChain {

--- a/zebra-rs/src/bgp/peer.rs
+++ b/zebra-rs/src/bgp/peer.rs
@@ -836,12 +836,25 @@ pub struct Peer {
     /// (the writer holds a clone).
     pub egress_depth: Arc<AtomicUsize>,
     pub opt: ParseOption,
-    pub policy_list: InOuts<PolicyListValue>,
-    pub prefix_set: InOuts<PrefixSetValue>,
-    /// Cached owned snapshot of the *outbound* policy (Output direction of
-    /// `prefix_set` / `policy_list`), rebuilt by `rebuild_out_policy` only
-    /// when that policy resolves (`process_policy_msg`). `sync_ctx` clones
-    /// the `Arc` into every `SyncCtx`, so the per-route egress evaluation
+    /// Per-AFI/SAFI inbound/outbound route-policy + prefix-set, bound via
+    /// `neighbor X afi-safi <name> {policy,prefix-set} {in,out} <ref>`.
+    /// An explicit entry for a family (name set) wins for that family;
+    /// otherwise the family falls back to [`policy_list_legacy`] /
+    /// [`prefix_set_legacy`]. Read through [`Peer::policy_list_at`] /
+    /// [`Peer::prefix_set_at`], never indexed directly, so the fallback
+    /// stays consistent across every apply site.
+    pub policy_list: BTreeMap<AfiSafi, InOuts<PolicyListValue>>,
+    pub prefix_set: BTreeMap<AfiSafi, InOuts<PrefixSetValue>>,
+    /// Peer-wide fallback policy / prefix-set. Fed by the legacy
+    /// top-level `neighbor X policy {in,out}` (kept for backward
+    /// compatibility) and by `neighbor-group` inheritance, and used by
+    /// any family without its own per-AFI binding.
+    pub policy_list_legacy: InOuts<PolicyListValue>,
+    pub prefix_set_legacy: InOuts<PrefixSetValue>,
+    /// Cached owned snapshot of the effective IPv4-unicast *outbound*
+    /// policy, rebuilt by `rebuild_out_policy` only when that policy
+    /// resolves (`process_policy_msg`). `sync_ctx` clones the `Arc` into
+    /// every (v4-unicast) `SyncCtx`, so the per-route egress evaluation
     /// (and later a shard worker) reads the policy without a deep clone.
     pub out_policy: Arc<super::policy::OutPolicy>,
     pub rtcv4: BTreeSet<ExtCommunityValue>,
@@ -996,8 +1009,10 @@ impl Peer {
             pet: None,
             egress_depth: Arc::new(AtomicUsize::new(0)),
             opt: ParseOption::default(),
-            policy_list: InOuts::<PolicyListValue>::default(),
-            prefix_set: InOuts::<PrefixSetValue>::default(),
+            policy_list: BTreeMap::new(),
+            prefix_set: BTreeMap::new(),
+            policy_list_legacy: InOuts::<PolicyListValue>::default(),
+            prefix_set_legacy: InOuts::<PrefixSetValue>::default(),
             out_policy: Arc::new(super::policy::OutPolicy::default()),
             rtcv4: BTreeSet::default(),
             rtcv6: BTreeSet::default(),
@@ -1211,10 +1226,64 @@ impl Peer {
     /// clones stays current; the deep clone of the route-map / prefix-list
     /// happens here — once per resolve, never per advertised route.
     pub fn rebuild_out_policy(&mut self) {
+        // The cached snapshot drives only the IPv4-unicast egress (the
+        // `SyncCtx` family); other families read the peer directly.
+        let v4u = AfiSafi::new(Afi::Ip, Safi::Unicast);
         self.out_policy = Arc::new(super::policy::OutPolicy {
-            prefix_set: self.prefix_set.get(&super::policy::InOut::Output).clone(),
-            policy_list: self.policy_list.get(&super::policy::InOut::Output).clone(),
+            prefix_set: self
+                .prefix_set_at(v4u, super::policy::InOut::Output)
+                .clone(),
+            policy_list: self
+                .policy_list_at(v4u, super::policy::InOut::Output)
+                .clone(),
         });
+    }
+
+    /// The effective inbound/outbound prefix-set for `afi_safi`: the
+    /// family's explicit per-AFI binding if it names one, else the
+    /// peer-wide [`prefix_set_legacy`] fallback (top-level / inherited).
+    pub fn prefix_set_at(
+        &self,
+        afi_safi: AfiSafi,
+        dir: super::policy::InOut,
+    ) -> &super::policy::PrefixSetValue {
+        match self.prefix_set.get(&afi_safi).map(|io| io.get(&dir)) {
+            Some(v) if v.name.is_some() => v,
+            _ => self.prefix_set_legacy.get(&dir),
+        }
+    }
+
+    /// The effective inbound/outbound policy-list for `afi_safi`. Same
+    /// per-AFI-wins-else-legacy rule as [`prefix_set_at`].
+    pub fn policy_list_at(
+        &self,
+        afi_safi: AfiSafi,
+        dir: super::policy::InOut,
+    ) -> &super::policy::PolicyListValue {
+        match self.policy_list.get(&afi_safi).map(|io| io.get(&dir)) {
+            Some(v) if v.name.is_some() => v,
+            _ => self.policy_list_legacy.get(&dir),
+        }
+    }
+
+    /// Mutable per-AFI prefix-set slot, creating the family entry on
+    /// demand. Used by the config + resolve paths to bind a name and to
+    /// fill the resolved object.
+    pub fn prefix_set_slot(
+        &mut self,
+        afi_safi: AfiSafi,
+        dir: super::policy::InOut,
+    ) -> &mut super::policy::PrefixSetValue {
+        self.prefix_set.entry(afi_safi).or_default().get_mut(&dir)
+    }
+
+    /// Mutable per-AFI policy-list slot (see [`prefix_set_slot`]).
+    pub fn policy_list_slot(
+        &mut self,
+        afi_safi: AfiSafi,
+        dir: super::policy::InOut,
+    ) -> &mut super::policy::PolicyListValue {
+        self.policy_list.entry(afi_safi).or_default().get_mut(&dir)
     }
 
     /// Snapshot this peer's IPv4-unicast egress context (A2). `router_id`

--- a/zebra-rs/src/bgp/route.rs
+++ b/zebra-rs/src/bgp/route.rs
@@ -1950,13 +1950,14 @@ impl LocalRib {
 // RIB update from peer.
 pub fn route_apply_policy_in(
     peer: &Peer,
+    afi_safi: AfiSafi,
     nlri: &Ipv4Nlri,
     bgp_attr: BgpAttr,
     weight: u32,
 ) -> Option<PolicyDecision> {
     apply_policy_in_pure(
-        peer.prefix_set.get(&InOut::Input),
-        peer.policy_list.get(&InOut::Input),
+        peer.prefix_set_at(afi_safi, InOut::Input),
+        peer.policy_list_at(afi_safi, InOut::Input),
         peer.router_id,
         nlri,
         bgp_attr,
@@ -2033,7 +2034,8 @@ pub fn route_apply_policy_in_evpn(
     bgp_attr: BgpAttr,
     weight: u32,
 ) -> Option<PolicyDecision> {
-    let config = peer.policy_list.get(&InOut::Input);
+    let evpn = AfiSafi::new(Afi::L2vpn, Safi::Evpn);
+    let config = peer.policy_list_at(evpn, InOut::Input);
     if config.name.is_some() {
         let Some(policy_list) = &config.policy_list else {
             return None;
@@ -2057,7 +2059,8 @@ pub fn route_apply_policy_out_evpn(
     bgp_attr: BgpAttr,
     weight: u32,
 ) -> Option<PolicyDecision> {
-    let config = peer.policy_list.get(&InOut::Output);
+    let evpn = AfiSafi::new(Afi::L2vpn, Safi::Evpn);
+    let config = peer.policy_list_at(evpn, InOut::Output);
     if config.name.is_some() {
         let Some(policy_list) = &config.policy_list else {
             return None;
@@ -2095,13 +2098,14 @@ pub fn route_apply_policy_out(
 /// silently ignored.
 pub fn route_apply_policy_in_v6(
     peer: &Peer,
+    afi_safi: AfiSafi,
     nlri: &Ipv6Nlri,
     bgp_attr: BgpAttr,
     weight: u32,
 ) -> Option<PolicyDecision> {
     apply_policy_net(
-        peer.prefix_set.get(&InOut::Input),
-        peer.policy_list.get(&InOut::Input),
+        peer.prefix_set_at(afi_safi, InOut::Input),
+        peer.policy_list_at(afi_safi, InOut::Input),
         peer.router_id,
         IpNet::V6(nlri.prefix),
         bgp_attr,
@@ -2113,13 +2117,14 @@ pub fn route_apply_policy_in_v6(
 /// projection of [`apply_policy_net`].
 pub fn route_apply_policy_out_v6(
     peer: &Peer,
+    afi_safi: AfiSafi,
     nlri: &Ipv6Nlri,
     bgp_attr: BgpAttr,
     weight: u32,
 ) -> Option<PolicyDecision> {
     apply_policy_net(
-        peer.prefix_set.get(&InOut::Output),
-        peer.policy_list.get(&InOut::Output),
+        peer.prefix_set_at(afi_safi, InOut::Output),
+        peer.policy_list_at(afi_safi, InOut::Output),
         peer.router_id,
         IpNet::V6(nlri.prefix),
         bgp_attr,
@@ -2263,7 +2268,13 @@ pub fn route_ipv4_update(
     let stale = stale || attr_has_llgr_stale(attr);
     let decision = {
         let peer = peers.get_mut_by_idx(ident).expect("peer must exist");
-        route_apply_policy_in(peer, nlri, attr.clone(), 0)
+        route_apply_policy_in(
+            peer,
+            AfiSafi::new(Afi::Ip, Safi::Unicast),
+            nlri,
+            attr.clone(),
+            0,
+        )
     };
     let jobs = route_ipv4_update_decided(
         peer_ident,
@@ -2449,8 +2460,9 @@ fn any_established_out_policy_v4(peers: &PeerMap) -> bool {
         .into_iter()
         .filter_map(|id| peers.get_by_idx(id))
         .any(|p| {
-            p.policy_list.get(&InOut::Output).name.is_some()
-                || p.prefix_set.get(&InOut::Output).name.is_some()
+            let v4u = AfiSafi::new(Afi::Ip, Safi::Unicast);
+            p.policy_list_at(v4u, InOut::Output).name.is_some()
+                || p.prefix_set_at(v4u, InOut::Output).name.is_some()
         })
 }
 
@@ -3579,7 +3591,13 @@ fn compute_advertise_outcome_v6(
     add_path: bool,
 ) -> AdvertiseOutcome<Ipv6Nlri> {
     if let Some((nlri, attr)) = route_update_ipv6(peer, prefix, best, bgp, add_path) {
-        if let Some(decision) = route_apply_policy_out_v6(peer, &nlri, attr, best.weight) {
+        if let Some(decision) = route_apply_policy_out_v6(
+            peer,
+            AfiSafi::new(Afi::Ip6, Safi::Unicast),
+            &nlri,
+            attr,
+            best.weight,
+        ) {
             AdvertiseOutcome::Advertise(nlri, decision.attr)
         } else {
             AdvertiseOutcome::Withdraw
@@ -4539,7 +4557,13 @@ fn route_soft_in_peer_table(
             let pre_weight = stored.weight;
             let post_attr_opt = {
                 let peer = peers.get_mut_by_idx(peer_idx).expect("peer exists");
-                route_apply_policy_in(peer, &nlri, pre_attr, pre_weight)
+                route_apply_policy_in(
+                    peer,
+                    AfiSafi::new(Afi::Ip, Safi::Unicast),
+                    &nlri,
+                    pre_attr,
+                    pre_weight,
+                )
             };
 
             match post_attr_opt {
@@ -4781,7 +4805,13 @@ pub fn route_ipv6_update(
     // inbound policy.)
     let decision = {
         let peer = peers.get_by_idx(ident).expect("peer must exist");
-        route_apply_policy_in_v6(peer, nlri, attr.clone(), 0)
+        route_apply_policy_in_v6(
+            peer,
+            AfiSafi::new(Afi::Ip6, Safi::Unicast),
+            nlri,
+            attr.clone(),
+            0,
+        )
     };
 
     let dep = match rd {
@@ -5073,7 +5103,13 @@ pub fn route_labelv4_update(
     // unicast ingest — LU previously applied no per-neighbor policy.
     let decision = {
         let peer = peers.get_by_idx(ident).expect("peer must exist");
-        route_apply_policy_in(peer, &lu.nlri, attr.clone(), 0)
+        route_apply_policy_in(
+            peer,
+            AfiSafi::new(Afi::Ip, Safi::MplsLabel),
+            &lu.nlri,
+            attr.clone(),
+            0,
+        )
     };
 
     // Adj-RIB-In keeps the pre-policy attribute (soft-reconfig replay).
@@ -5191,7 +5227,13 @@ pub fn route_labelv6_update(
     // `route_labelv4_update`). `None` drops the route.
     let decision = {
         let peer = peers.get_by_idx(ident).expect("peer must exist");
-        route_apply_policy_in_v6(peer, &lu.nlri, attr.clone(), 0)
+        route_apply_policy_in_v6(
+            peer,
+            AfiSafi::new(Afi::Ip6, Safi::MplsLabel),
+            &lu.nlri,
+            attr.clone(),
+            0,
+        )
     };
 
     // Adj-RIB-In keeps the pre-policy attribute (soft-reconfig replay).
@@ -8743,7 +8785,13 @@ impl LabeledAfi for LabeledV6 {
         attr: BgpAttr,
         weight: u32,
     ) -> Option<PolicyDecision> {
-        route_apply_policy_out_v6(peer, nlri, attr, weight)
+        route_apply_policy_out_v6(
+            peer,
+            AfiSafi::new(Afi::Ip6, Safi::MplsLabel),
+            nlri,
+            attr,
+            weight,
+        )
     }
     fn reach(nhop: IpAddr, label: Label, nlri: Ipv6Nlri) -> MpReachAttr {
         MpReachAttr::Labelv6 {
@@ -9817,7 +9865,13 @@ pub fn route_sync_ipv6(peer: &mut Peer, bgp: &mut BgpTop) {
         // event-driven advertise does, mirroring the v4 sync path —
         // otherwise an out-policy-denied prefix leaks on the initial
         // sync and is only suppressed on a later update.
-        let Some(decision) = route_apply_policy_out_v6(peer, &nlri, attr, rib.weight) else {
+        let Some(decision) = route_apply_policy_out_v6(
+            peer,
+            AfiSafi::new(Afi::Ip6, Safi::Unicast),
+            &nlri,
+            attr,
+            rib.weight,
+        ) else {
             continue;
         };
         rib.attr = bgp.attr_store.intern(decision.attr);
@@ -9949,7 +10003,13 @@ pub fn route_sync_vpnv6(peer: &mut Peer, bgp: &mut BgpTop) {
             let Some((nlri, attr)) = route_update_ipv6(peer, &prefix, &rib, bgp, add_path) else {
                 continue;
             };
-            let Some(decision) = route_apply_policy_out_v6(peer, &nlri, attr, rib.weight) else {
+            let Some(decision) = route_apply_policy_out_v6(
+                peer,
+                AfiSafi::new(Afi::Ip6, Safi::MplsVpn),
+                &nlri,
+                attr,
+                rib.weight,
+            ) else {
                 continue;
             };
             let attr = decision.attr;
@@ -10238,7 +10298,13 @@ pub fn route_sync_labelv6(peer: &mut Peer, bgp: &mut BgpTop) {
             continue;
         };
         // Outbound policy on the establish-time dump (see route_sync_labelv4).
-        let Some(decision) = route_apply_policy_out_v6(peer, &nlri, attr, best.weight) else {
+        let Some(decision) = route_apply_policy_out_v6(
+            peer,
+            AfiSafi::new(Afi::Ip6, Safi::MplsLabel),
+            &nlri,
+            attr,
+            best.weight,
+        ) else {
             continue;
         };
         let mut update = UpdatePacket::with_max_packet_size(peer.max_packet_size());

--- a/zebra-rs/src/bgp/show.rs
+++ b/zebra-rs/src/bgp/show.rs
@@ -2148,6 +2148,75 @@ struct Neighbor<'a> {
     /// the same cases as `nd_discovered_secs_ago`.
     #[serde(skip_serializing_if = "Option::is_none")]
     nd_refreshed_secs_ago: Option<u64>,
+
+    /// Configured route-policy / prefix-set bindings: one entry per
+    /// address family that names something, plus a `(peer-wide)` entry
+    /// for the legacy top-level `policy` / inherited fallback. Empty
+    /// when nothing is bound.
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    policy_bindings: Vec<PolicyBindingView>,
+}
+
+/// One row of a neighbor's configured policy/prefix-set, scoped either
+/// to an address family (`ipv4`, `evpn`, …) or to the `(peer-wide)`
+/// legacy fallback. Only the bound directions are `Some`.
+#[derive(Debug, Serialize)]
+struct PolicyBindingView {
+    scope: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    policy_in: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    policy_out: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    prefix_set_in: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    prefix_set_out: Option<String>,
+}
+
+impl PolicyBindingView {
+    fn is_empty(&self) -> bool {
+        self.policy_in.is_none()
+            && self.policy_out.is_none()
+            && self.prefix_set_in.is_none()
+            && self.prefix_set_out.is_none()
+    }
+}
+
+/// Collect a neighbor's per-AFI bindings (sorted by family) followed by
+/// the peer-wide legacy fallback, dropping rows that name nothing.
+fn collect_policy_bindings(peer: &Peer) -> Vec<PolicyBindingView> {
+    use super::policy::InOut;
+    let mut families: std::collections::BTreeSet<AfiSafi> = std::collections::BTreeSet::new();
+    families.extend(peer.policy_list.keys().copied());
+    families.extend(peer.prefix_set.keys().copied());
+
+    let mut out: Vec<PolicyBindingView> = Vec::new();
+    for af in families {
+        let pl = peer.policy_list.get(&af);
+        let ps = peer.prefix_set.get(&af);
+        let row = PolicyBindingView {
+            scope: afi_safi_config_name(&af).to_string(),
+            policy_in: pl.and_then(|io| io.get(&InOut::Input).name.clone()),
+            policy_out: pl.and_then(|io| io.get(&InOut::Output).name.clone()),
+            prefix_set_in: ps.and_then(|io| io.get(&InOut::Input).name.clone()),
+            prefix_set_out: ps.and_then(|io| io.get(&InOut::Output).name.clone()),
+        };
+        if !row.is_empty() {
+            out.push(row);
+        }
+    }
+
+    let legacy = PolicyBindingView {
+        scope: "(peer-wide)".to_string(),
+        policy_in: peer.policy_list_legacy.get(&InOut::Input).name.clone(),
+        policy_out: peer.policy_list_legacy.get(&InOut::Output).name.clone(),
+        prefix_set_in: peer.prefix_set_legacy.get(&InOut::Input).name.clone(),
+        prefix_set_out: peer.prefix_set_legacy.get(&InOut::Output).name.clone(),
+    };
+    if !legacy.is_empty() {
+        out.push(legacy);
+    }
+    out
 }
 
 const ONE_DAY_SECOND: u64 = 60 * 60 * 24;
@@ -2328,6 +2397,7 @@ fn fetch(peer: &Peer) -> Neighbor<'_> {
         nd_discovered_secs_ago,
         nd_refresh_count,
         nd_refreshed_secs_ago,
+        policy_bindings: collect_policy_bindings(peer),
     };
 
     // Timers.
@@ -2591,6 +2661,29 @@ fn render(out: &mut String, neighbor: &Neighbor) -> std::fmt::Result {
             ""
         };
         writeln!(out, "  Neighbor-group: {group}{suffix}")?;
+    }
+
+    // Configured route-policy / prefix-set, per address family, with the
+    // legacy peer-wide fallback last. A family-scoped binding takes
+    // priority over `(peer-wide)` for routes of that family.
+    if !neighbor.policy_bindings.is_empty() {
+        writeln!(out, "  Policy:")?;
+        for b in &neighbor.policy_bindings {
+            let mut parts: Vec<String> = Vec::new();
+            if let Some(ref n) = b.policy_in {
+                parts.push(format!("policy in {n}"));
+            }
+            if let Some(ref n) = b.policy_out {
+                parts.push(format!("policy out {n}"));
+            }
+            if let Some(ref n) = b.prefix_set_in {
+                parts.push(format!("prefix-set in {n}"));
+            }
+            if let Some(ref n) = b.prefix_set_out {
+                parts.push(format!("prefix-set out {n}"));
+            }
+            writeln!(out, "    {}: {}", b.scope, parts.join(", "))?;
+        }
     }
 
     writeln!(out)?;
@@ -3818,6 +3911,40 @@ Neighbor        V         AS   MsgRcvd   MsgSent   TblVer  InQ OutQ  Up/Down Sta
         );
     }
 
+    /// `show bgp neighbor` lists per-AFI policy/prefix-set bindings and
+    /// the legacy peer-wide fallback, family-scoped rows first.
+    #[test]
+    fn policy_block_lists_per_afi_and_legacy() {
+        let mut out = String::new();
+        let mut n = minimal_neighbor(None);
+        n.policy_bindings = vec![
+            PolicyBindingView {
+                scope: "ipv4".to_string(),
+                policy_in: Some("IN4".to_string()),
+                policy_out: None,
+                prefix_set_in: Some("PFX4".to_string()),
+                prefix_set_out: None,
+            },
+            PolicyBindingView {
+                scope: "(peer-wide)".to_string(),
+                policy_in: Some("LEGACY".to_string()),
+                policy_out: None,
+                prefix_set_in: None,
+                prefix_set_out: None,
+            },
+        ];
+        render(&mut out, &n).unwrap();
+        assert!(out.contains("  Policy:"), "missing Policy header:\n{out}");
+        assert!(
+            out.contains("    ipv4: policy in IN4, prefix-set in PFX4"),
+            "missing per-AFI row:\n{out}"
+        );
+        assert!(
+            out.contains("    (peer-wide): policy in LEGACY"),
+            "missing legacy row:\n{out}"
+        );
+    }
+
     /// JSON output for an interface-keyed peer carries the three ND
     /// fields; an address-keyed peer must not carry them.
     #[test]
@@ -3897,6 +4024,7 @@ Neighbor        V         AS   MsgRcvd   MsgSent   TblVer  InQ OutQ  Up/Down Sta
             nd_discovered_secs_ago: None,
             nd_refresh_count: None,
             nd_refreshed_secs_ago: None,
+            policy_bindings: Vec::new(),
         }
     }
 }

--- a/zebra-rs/src/bgp/update_group.rs
+++ b/zebra-rs/src/bgp/update_group.rs
@@ -312,8 +312,12 @@ pub fn signature_of(peer: &Peer, afi: Afi, safi: Safi) -> Option<UpdateGroupSig>
         return None;
     }
 
-    let policy_out_name = peer.policy_list.get(&InOut::Output).name.clone();
-    let prefix_set_out_name = peer.prefix_set.get(&InOut::Output).name.clone();
+    // The update-group is per-(afi,safi), so its egress policy is that
+    // family's effective outbound binding (per-AFI override, else the
+    // legacy peer-wide fallback).
+    let afi_safi = AfiSafi::new(afi, safi);
+    let policy_out_name = peer.policy_list_at(afi_safi, InOut::Output).name.clone();
+    let prefix_set_out_name = peer.prefix_set_at(afi_safi, InOut::Output).name.clone();
 
     Some(UpdateGroupSig {
         peer_type: match peer.peer_type {

--- a/zebra-rs/src/config/manager.rs
+++ b/zebra-rs/src/config/manager.rs
@@ -2027,6 +2027,56 @@ mod yang_load_tests {
         }
     }
 
+    /// Per-AFI neighbor `policy` / `prefix-set` live under `afi-safi
+    /// <name>` (Tasks B & C). The legacy peer-wide `policy {in,out}` is
+    /// kept for backward compatibility; the peer-wide `prefix-set
+    /// {in,out}` is removed (no back-compat). The policy `match`
+    /// reference is `prefix-set`, not `prefix` (Task A). vtyctl apply is
+    /// garbage-tolerant, so these grammar moves are pinned here.
+    #[test]
+    fn bgp_neighbor_afi_safi_policy_and_prefix_set_paths() {
+        use crate::config::ExecCode;
+        use crate::config::parse::{State, parse};
+        use libyang::to_entry;
+
+        let mut yang = YangStore::new();
+        yang.add_path(concat!(env!("CARGO_MANIFEST_DIR"), "/yang"));
+        yang.read_with_resolve("configure")
+            .expect("configure mode loads");
+        yang.identity_resolve();
+        let module = yang
+            .find_module("configure")
+            .expect("configure module present");
+        let entry = to_entry(&yang, module);
+
+        // Settable: per-AFI policy + prefix-set, the kept legacy
+        // peer-wide policy, and `match prefix-set`.
+        for cmd in [
+            "set router bgp neighbor 10.0.0.2 afi-safi ipv4 policy in IN",
+            "set router bgp neighbor 10.0.0.2 afi-safi ipv4 policy out OUT",
+            "set router bgp neighbor 10.0.0.2 afi-safi ipv4 prefix-set in PIN",
+            "set router bgp neighbor 10.0.0.2 afi-safi evpn policy out EOUT",
+            "set router bgp neighbor 10.0.0.2 afi-safi label-v4 prefix-set out POUT",
+            "set router bgp neighbor 10.0.0.2 policy in LEGACY-IN",
+            "set router bgp neighbor 10.0.0.2 policy out LEGACY-OUT",
+            "set policy P entry 10 match prefix-set PS",
+        ] {
+            let (code, _comps, _state) = parse(cmd, entry.clone(), None, State::new());
+            assert_eq!(code, ExecCode::Success, "`{cmd}` must be a settable path");
+        }
+
+        // No longer settable: the removed peer-wide `prefix-set` node.
+        // (The neighbor still has `prefix-limit`, so `prefix-set` is not
+        // an abbreviation of any surviving node and must fail outright.)
+        for cmd in [
+            "set router bgp neighbor 10.0.0.2 prefix-set in PIN",
+            "set router bgp neighbor 10.0.0.2 prefix-set out POUT",
+        ] {
+            let (code, _comps, _state) = parse(cmd, entry.clone(), None, State::new());
+            assert_ne!(code, ExecCode::Success, "`{cmd}` must NOT be settable");
+        }
+    }
+
     /// The IS-IS per-interface `passive` leaf must be a settable path.
     /// It is hand-added to `config.yang` (no YANG generator), so a typo in
     /// the leaf or its placement would otherwise only surface at runtime —

--- a/zebra-rs/src/policy/policy_list.rs
+++ b/zebra-rs/src/policy/policy_list.rs
@@ -455,7 +455,7 @@ impl ConfigBuilder {
                 list.entry.remove(&seq).context(ARG_ERR)?;
                 Ok(())
             })
-            .path("/entry/match/prefix")
+            .path("/entry/match/prefix-set")
             .set(|policy, cache, name, seq, args| {
                 let list = cache_get(policy, cache, &name).context(ARG_ERR)?;
                 let entry = list.entry(seq);

--- a/zebra-rs/yang/config.yang
+++ b/zebra-rs/yang/config.yang
@@ -2834,7 +2834,7 @@ module config {
         }
         container "match" {
           ext:sort "7";
-          leaf "prefix" {
+          leaf "prefix-set" {
             type string;
             description
               "Reference to a `prefix-set` by name.";

--- a/zebra-rs/yang/ietf-bgp-neighbor@2023-07-05.yang
+++ b/zebra-rs/yang/ietf-bgp-neighbor@2023-07-05.yang
@@ -238,6 +238,35 @@ submodule ietf-bgp-neighbor {
            next-hop carried across the inter-AS eBGP link. Honored on the
            Labeled-Unicast (SAFI 4) and VPNv4 (SAFI 128) advertise paths.";
       }
+      container policy {
+        ext:sort "40";
+        ext:help "Per-family route-policy references";
+        description
+          "Per-direction route-policy references applied to routes of
+           THIS address family. Takes priority over the legacy
+           peer-wide `neighbor X policy {in,out}`; when a family has no
+           per-family binding it falls back to that peer-wide policy.";
+        leaf in {
+          type string;
+        }
+        leaf out {
+          type string;
+        }
+      }
+      container prefix-set {
+        ext:sort "50";
+        ext:help "Per-family prefix-set references";
+        description
+          "Per-direction prefix-set references applied to routes of THIS
+           address family. The per-family successor of the (removed)
+           peer-wide `neighbor X prefix-set {in,out}`.";
+        leaf in {
+          type string;
+        }
+        leaf out {
+          type string;
+        }
+      }
     }
   }
 }

--- a/zebra-rs/yang/ietf-bgp@2023-07-05.yang
+++ b/zebra-rs/yang/ietf-bgp@2023-07-05.yang
@@ -665,14 +665,9 @@ module ietf-bgp {
                  graceful restart with the peer";
           }
         }
-        container prefix-set {
-          leaf in {
-            type string;
-          }
-          leaf out {
-            type string;
-          }
-        }
+        // The per-neighbor `prefix-set {in,out}` moved under
+        // `afi-safi <name> prefix-set {in,out}` (per-family). No
+        // backward-compatibility alias is kept (unlike `policy`).
 
         container prefix-limit {
           description


### PR DESCRIPTION
## Summary

Per-neighbor BGP route-policy and prefix-set are now **per-AFI/SAFI**, with the legacy peer-wide form kept (policy) or removed (prefix-set).

- **Task A** — policy `match prefix` → `match prefix-set` (`config.yang` leaf + `policy_list.rs` path); swept all `bdd/` configs and the book. The CLI still accepts `prefix` as an abbreviation; the YAML loader needs the exact key.
- **Task B** — `neighbor X afi-safi <name> policy {in,out}` added. The top-level `neighbor X policy {in,out}` is kept as a backward-compatible **fallback**.
- **Task C** — `neighbor X afi-safi <name> prefix-set {in,out}` added; the top-level `neighbor X prefix-set {in,out}` YANG node + callbacks removed (no back-compat).

**Priority:** a per-AFI binding wins for its family; otherwise the family falls back to the legacy peer-wide policy. All reads go through `Peer::policy_list_at` / `prefix_set_at`.

### Implementation notes
- `peer.policy_list` / `prefix_set` are now `BTreeMap<AfiSafi, InOuts<…>>` + single `*_legacy` slots.
- The policy-watch `ident` packs `(peer_idx<<24 | afisafi_code)` (tag 0 = legacy); `process_policy_msg` decodes it to the right slot.
- `out_policy` and the shard `InPolicy` stay v4-unicast-effective (the only family they serve); the apply fns and `signature_of` pass the route's AFI.
- neighbor-group inheritance feeds the legacy slots (unchanged).
- `show bgp neighbors` now prints a `Policy:` block — one row per family, then a `(peer-wide):` legacy row.

## Test plan
- `cargo test -p zebra-rs` — 1296 passed (incl. new `afi_safi_policy_overrides_legacy_per_family`, `policy_block_lists_per_afi_and_legacy`, and YANG parse pins `bgp_neighbor_afi_safi_policy_and_prefix_set_paths`).
- `cargo clippy --workspace --all-targets -- -D warnings` — clean.
- `cargo fmt --all --check` — clean.
- BDD: 3 configs migrated to the per-AFI form (v4-out / v6-in / label-v4-in) for end-to-end coverage; the rest stay on the legacy form as back-compat coverage. New `@bgp_afi_safi_policy` feature exercises legacy-deny → per-AFI-permit override end-to-end (runs out-of-band; BDD needs root/namespaces).

Generated with [Claude Code](https://claude.com/claude-code)