### PR TITLE
bgp: EVPN Multicast Flags Extended Community (RFC 9251)

### DIFF
--- a/crates/bgp-packet/src/attrs/ext_com.rs
+++ b/crates/bgp-packet/src/attrs/ext_com.rs
@@ -108,6 +108,73 @@ impl ExtCommunityValue {
             value: self.val,
         })
     }
+
+    /// True iff this entry is the EVPN Multicast Flags Extended
+    /// Community (RFC 9251 §6): EVPN high-type (0x06) + Multicast
+    /// Flags sub-type (0x09).
+    pub fn is_evpn_mcast_flags(&self) -> bool {
+        self.high_type == ExtCommunityType::Evpn as u8 && self.low_type == EVPN_MCAST_FLAGS_SUB_TYPE
+    }
+
+    /// Decode the EVPN Multicast Flags EC (RFC 9251 §6). Returns the
+    /// IGMP / MLD proxy-support bits. Per §6 an EC with **both** bits
+    /// clear is malformed and MUST be ignored by the receiver, so this
+    /// returns `None` in that case (and for any non-matching EC).
+    pub fn as_evpn_mcast_flags(&self) -> Option<EvpnMcastFlags> {
+        if !self.is_evpn_mcast_flags() {
+            return None;
+        }
+        let flags = u16::from_be_bytes([self.val[0], self.val[1]]);
+        let mcast = EvpnMcastFlags {
+            igmp_proxy: flags & EvpnMcastFlags::IGMP_PROXY != 0,
+            mld_proxy: flags & EvpnMcastFlags::MLD_PROXY != 0,
+        };
+        if !mcast.igmp_proxy && !mcast.mld_proxy {
+            return None;
+        }
+        Some(mcast)
+    }
+}
+
+/// EVPN Multicast Flags Extended Community sub-type (RFC 9251 §6),
+/// carried under the EVPN high-type (0x06).
+const EVPN_MCAST_FLAGS_SUB_TYPE: u8 = 0x09;
+
+/// Decoded EVPN Multicast Flags Extended Community (RFC 9251 §6). A
+/// PE attaches this to its Inclusive Multicast (Type-3) route to
+/// advertise IGMP / MLD proxy capability. The 2-octet Flags field
+/// carries the two capability bits; the remaining 4 octets are
+/// reserved (zero).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct EvpnMcastFlags {
+    pub igmp_proxy: bool,
+    pub mld_proxy: bool,
+}
+
+impl EvpnMcastFlags {
+    /// Bit 15 of the Flags field (RFC 9251 §6): IGMP Proxy Support.
+    const IGMP_PROXY: u16 = 0x0001;
+    /// Bit 14 of the Flags field: MLD Proxy Support.
+    const MLD_PROXY: u16 = 0x0002;
+}
+
+impl From<EvpnMcastFlags> for ExtCommunityValue {
+    fn from(m: EvpnMcastFlags) -> Self {
+        let mut flags: u16 = 0;
+        if m.igmp_proxy {
+            flags |= EvpnMcastFlags::IGMP_PROXY;
+        }
+        if m.mld_proxy {
+            flags |= EvpnMcastFlags::MLD_PROXY;
+        }
+        let mut val = [0u8; 6];
+        val[0..2].copy_from_slice(&flags.to_be_bytes());
+        ExtCommunityValue {
+            high_type: ExtCommunityType::Evpn as u8,
+            low_type: EVPN_MCAST_FLAGS_SUB_TYPE,
+            val,
+        }
+    }
 }
 
 /// Decoded MUP Extended Community (RFC 9833 §5). The `value` field
@@ -209,6 +276,19 @@ impl fmt::Display for ExtCommunityValue {
                     ExtCommunitySubType::display(self.low_type)
                 )
             }
+        } else if self.is_evpn_mcast_flags() {
+            // EVPN Multicast Flags EC (RFC 9251 §6). Render the raw
+            // capability bits as `mcast-flags:` plus `I` (IGMP) / `M`
+            // (MLD); a both-clear value renders as a bare `mcast-flags:`.
+            let flags = u16::from_be_bytes([self.val[0], self.val[1]]);
+            let mut s = String::new();
+            if flags & EvpnMcastFlags::IGMP_PROXY != 0 {
+                s.push('I');
+            }
+            if flags & EvpnMcastFlags::MLD_PROXY != 0 {
+                s.push('M');
+            }
+            write!(f, "mcast-flags:{s}")
         } else {
             let ip = Ipv4Addr::new(self.val[0], self.val[1], self.val[2], self.val[3]);
             let val = u16::from_be_bytes([self.val[4], self.val[5]]);
@@ -397,6 +477,90 @@ mod tests {
     fn color_renders_in_display() {
         let c = ExtCommunityValue::from_color(0b01, 4242);
         assert_eq!(c.to_string(), "color:1:4242");
+    }
+
+    #[test]
+    fn evpn_mcast_flags_wire_layout() {
+        // Both IGMP + MLD proxy: high 0x06, sub 0x09, Flags=0x0003,
+        // reserved 4 octets zero.
+        let ec: ExtCommunityValue = EvpnMcastFlags {
+            igmp_proxy: true,
+            mld_proxy: true,
+        }
+        .into();
+        assert_eq!(ec.high_type, 0x06);
+        assert_eq!(ec.low_type, 0x09);
+        assert_eq!(ec.val, [0x00, 0x03, 0, 0, 0, 0]);
+        let mut buf = BytesMut::new();
+        ec.encode(&mut buf);
+        assert_eq!(&buf[..], &[0x06, 0x09, 0x00, 0x03, 0, 0, 0, 0]);
+    }
+
+    #[test]
+    fn evpn_mcast_flags_igmp_only_round_trips() {
+        let ec: ExtCommunityValue = EvpnMcastFlags {
+            igmp_proxy: true,
+            mld_proxy: false,
+        }
+        .into();
+        assert_eq!(ec.val[0..2], [0x00, 0x01], "Flags bit 15 (IGMP) set only");
+        assert!(ec.is_evpn_mcast_flags());
+        let decoded = ec.as_evpn_mcast_flags().expect("decode");
+        assert!(decoded.igmp_proxy);
+        assert!(!decoded.mld_proxy);
+    }
+
+    #[test]
+    fn evpn_mcast_flags_both_zero_is_ignored() {
+        // RFC 9251 §6: an EVPN Multicast Flags EC with both bits clear
+        // is malformed; `as_evpn_mcast_flags` returns None so callers
+        // ignore it (but `is_` still recognises the type for Display).
+        let ec = ExtCommunityValue {
+            high_type: 0x06,
+            low_type: 0x09,
+            val: [0; 6],
+        };
+        assert!(ec.is_evpn_mcast_flags());
+        assert!(ec.as_evpn_mcast_flags().is_none());
+        assert_eq!(ec.to_string(), "mcast-flags:");
+    }
+
+    #[test]
+    fn evpn_mcast_flags_renders_in_display() {
+        let both: ExtCommunityValue = EvpnMcastFlags {
+            igmp_proxy: true,
+            mld_proxy: true,
+        }
+        .into();
+        assert_eq!(both.to_string(), "mcast-flags:IM");
+        let mld: ExtCommunityValue = EvpnMcastFlags {
+            igmp_proxy: false,
+            mld_proxy: true,
+        }
+        .into();
+        assert_eq!(mld.to_string(), "mcast-flags:M");
+    }
+
+    #[test]
+    fn evpn_mcast_flags_false_for_rt() {
+        let rt: ExtCommunity = ExtCommunity::from_str("rt:100:200").unwrap();
+        let rt = rt.0.first().unwrap();
+        assert!(!rt.is_evpn_mcast_flags());
+        assert!(rt.as_evpn_mcast_flags().is_none());
+    }
+
+    #[test]
+    fn evpn_mcast_flags_round_trips_through_parse() {
+        let original: ExtCommunityValue = EvpnMcastFlags {
+            igmp_proxy: true,
+            mld_proxy: true,
+        }
+        .into();
+        let mut buf = BytesMut::new();
+        original.encode(&mut buf);
+        let (_, parsed) = ExtCommunityValue::parse_be(&buf).expect("parse 8-octet EC");
+        assert_eq!(parsed, original);
+        assert_eq!(parsed.as_evpn_mcast_flags(), original.as_evpn_mcast_flags());
     }
 
     #[test]

--- a/crates/bgp-packet/src/attrs/ext_com_type.rs
+++ b/crates/bgp-packet/src/attrs/ext_com_type.rs
@@ -7,6 +7,10 @@ pub enum ExtCommunityType {
     // TransIpv4Addr = 0x01,
     // TransFourOctetAS = 0x03,
     TransOpaque = 0x03,
+    /// RFC 7153 / RFC 9251 — EVPN Extended Community high-type byte.
+    /// Sub-type 0x09 is the Multicast Flags EC (IGMP/MLD proxy
+    /// capability); see `ExtCommunityValue::as_evpn_mcast_flags`.
+    Evpn = 0x06,
     /// RFC 9833 — BGP MUP Extended Community high-type byte. Sub-type
     /// decode is deferred to a later phase; raw 8-byte value passes
     /// through the generic ExtCommunity path for now.

--- a/docs/design/bgp-evpn-igmp-mld-proxy.md
+++ b/docs/design/bgp-evpn-igmp-mld-proxy.md
@@ -28,7 +28,7 @@ before citing.
 | ----- | --------------------------------------- | -------- |
 | 0     | Design doc (this file)                  | **done** |
 | 1     | Codec — Type 6 SMET NLRI                | **done** |
-| 2     | Multicast Flags Extended Community      | planned  |
+| 2     | Multicast Flags Extended Community      | **done** |
 | 3     | IMET (Type 3) capability signaling      | planned  |
 | 4     | SMET origination from kernel MDB snoop  | planned  |
 | 5     | SMET reception → selective dataplane    | planned  |
@@ -207,13 +207,18 @@ RIB key, and `BgpRib` does not yet carry them, so a *re-advertised*
 parsed, stored in the Loc-RIB, and renderable; no SMET origination or
 dataplane action happens yet.
 
-### Phase 2 — Multicast Flags Extended Community
+### Phase 2 — Multicast Flags Extended Community — **done**
 `crates/bgp-packet/src/attrs/ext_com_type.rs`, `ext_com.rs`
-- Add `ExtCommunityType::Evpn = 0x06` and sub-type `0x09`.
-- `EvpnMcastFlags { igmp_proxy: bool, mld_proxy: bool }` ↔
-  `ExtCommunityValue` (2-octet flags: bit15=IGMP, bit14=MLD; 4-octet
-  reserved). Parse / emit / `Display`; both-zero ⇒ ignore. Wire-layout
-  unit test.
+- Added `ExtCommunityType::Evpn = 0x06`; the Multicast Flags sub-type
+  is the module const `EVPN_MCAST_FLAGS_SUB_TYPE = 0x09`.
+- `EvpnMcastFlags { igmp_proxy, mld_proxy }` with `From<…> for
+  ExtCommunityValue` (2-octet flags: bit15=IGMP `0x0001`, bit14=MLD
+  `0x0002`; 4-octet reserved), `ExtCommunityValue::is_evpn_mcast_flags`
+  / `as_evpn_mcast_flags` (the latter returns `None` when both bits
+  clear, per §6 "ignore"), and a `Display` branch rendering
+  `mcast-flags:IM`. Both types re-exported via `pub use ext_com::*`.
+- 6 unit tests: wire layout, IGMP-only round-trip, both-zero ignored,
+  `Display`, not-matching-for-RT, emit→parse round-trip.
 
 ### Phase 3 — IMET (Type 3) capability signaling
 `zebra-rs/src/bgp/route.rs` (`evpn_originate_imet` + IMET import),


### PR DESCRIPTION
## Summary

Phase 2 of EVPN IGMP/MLD proxy support (RFC 9251): the **Multicast Flags
Extended Community** used to advertise IGMP/MLD proxy capability on the
Type-3 (IMET) route. Codec only — producer/consumer wiring is Phase 3.

- `ext_com_type.rs`: `ExtCommunityType::Evpn` (0x06) high-type.
- `ext_com.rs`: `EvpnMcastFlags { igmp_proxy, mld_proxy }` with
  `From<EvpnMcastFlags> for ExtCommunityValue` (wire: `[0x06][0x09][Flags(2)][Reserved(4)]`,
  Flags **bit15=IGMP** `0x0001`, **bit14=MLD** `0x0002`),
  `is_evpn_mcast_flags` / `as_evpn_mcast_flags` (the latter returns `None`
  when **both** bits are clear, per §6 "malformed → ignore"), and a
  `Display` branch rendering `mcast-flags:IM`. Both types re-export via the
  crate glob so Phase 3 can use `bgp_packet::EvpnMcastFlags`.

## Test plan

- `cargo test -p bgp-packet` — 307 pass, incl. 6 new EC tests (wire layout,
  IGMP-only round-trip, both-zero-ignored, Display, not-RT, emit→parse).
- `cargo clippy --workspace --all-targets -- -D warnings` — clean.
- `cargo fmt --all --check` — clean.

Generated with [Claude Code](https://claude.com/claude-code)