### PR TITLE
bgp: EVPN IGMP/MLD proxy capability on Type-3 IMET (RFC 9251)

### DIFF
--- a/docs/design/bgp-evpn-igmp-mld-proxy.md
+++ b/docs/design/bgp-evpn-igmp-mld-proxy.md
@@ -29,7 +29,7 @@ before citing.
 | 0     | Design doc (this file)                  | **done** |
 | 1     | Codec — Type 6 SMET NLRI                | **done** |
 | 2     | Multicast Flags Extended Community      | **done** |
-| 3     | IMET (Type 3) capability signaling      | planned  |
+| 3     | IMET (Type 3) capability signaling      | **done** |
 | 4     | SMET origination from kernel MDB snoop  | planned  |
 | 5     | SMET reception → selective dataplane    | planned  |
 | 6     | Show + BDD + docs                       | planned  |
@@ -220,14 +220,24 @@ dataplane action happens yet.
 - 6 unit tests: wire layout, IGMP-only round-trip, both-zero ignored,
   `Display`, not-matching-for-RT, emit→parse round-trip.
 
-### Phase 3 — IMET (Type 3) capability signaling
-`zebra-rs/src/bgp/route.rs` (`evpn_originate_imet` + IMET import),
-`zebra-rs/yang/zebra-bgp-evpn.yang`
-- Attach the Multicast Flags EC (IGMP+MLD = 1) to originated IMET, gated
-  on a config knob (new YANG leaf; default on when snooping is active).
-- Parse + store the EC on **received** IMET into a per-(RD/VTEP)
-  capability table — consumed by Phase 5 to pick selective-vs-flood per
-  egress PE.
+### Phase 3 — IMET (Type 3) capability signaling — **done**
+`zebra-rs/src/bgp/inst.rs`, `route.rs`, `config.rs`,
+`zebra-rs/yang/zebra-bgp-evpn.yang`, `config/manager.rs`
+- New config knob `router bgp afi-safi evpn igmp-mld-proxy <bool>`
+  (`zebra-bgp-evpn.yang` leaf → `Bgp::igmp_mld_proxy`,
+  `config_igmp_mld_proxy`). Toggling re-originates all IMET via
+  `reoriginate_all_imet`.
+- `evpn_originate_imet` attaches the Multicast Flags EC
+  (`EvpnMcastFlags { igmp_proxy: true, mld_proxy: true }`) to the IMET
+  route's extended communities when the knob is on.
+- YANG-load `*_is_settable` test for the new leaf.
+- **Consumer read folded into Phase 5:** the capability rides the IMET
+  path attr and is already in the Loc-RIB; Phase 5 reads it on demand
+  via the Phase-2 `ExtCommunityValue::as_evpn_mcast_flags` accessor when
+  deciding selective-vs-flood. A receiving PE already renders
+  `mcast-flags:IM` in `show bgp evpn` (Phase-2 `Display`), so the signal
+  is observable end-to-end today. Per-protocol (IGMP-only / MLD-only)
+  granularity is a follow-up.
 
 ### Phase 4 — SMET origination from kernel MDB snoop
 - **4a (fork `../netlink-packet-route`):** finish `br_mdb_entry` +

--- a/zebra-rs/src/bgp/config.rs
+++ b/zebra-rs/src/bgp/config.rs
@@ -1464,6 +1464,25 @@ fn config_advertise_all_vni(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Opti
     Some(())
 }
 
+/// `router bgp afi-safi evpn igmp-mld-proxy <bool>` (RFC 9251 §6).
+/// When enabled, the Multicast Flags Extended Community (IGMP + MLD
+/// proxy capability) is attached to every originated Type-3 IMET
+/// route. Toggling re-originates all IMET so the EC is added/removed;
+/// `evpn_originate_imet` replaces the Originated path in place.
+fn config_igmp_mld_proxy(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Option<()> {
+    let afi_safi: AfiSafi = args.afi_safi()?;
+    if afi_safi.afi != Afi::L2vpn || afi_safi.safi != Safi::Evpn {
+        return None;
+    }
+    let enabled = if op.is_set() { args.boolean()? } else { false };
+    if bgp.igmp_mld_proxy == enabled {
+        return Some(());
+    }
+    bgp.igmp_mld_proxy = enabled;
+    reoriginate_all_imet(bgp);
+    Some(())
+}
+
 /// Re-originate every per-VNI Type-3 IMET route so a changed Assisted
 /// Replication role / AR-IP is reflected in the PMSI Tunnel attribute and
 /// next hop. `evpn_originate_imet` replaces the existing Originated path
@@ -3640,6 +3659,11 @@ impl Bgp {
             "/router/bgp/afi-safi/advertise-all-vni",
             config_advertise_all_vni,
         );
+
+        // EVPN IGMP/MLD proxy capability (RFC 9251 §6) under
+        // `router bgp afi-safi evpn igmp-mld-proxy`. When set, the
+        // Multicast Flags EC rides the originated Type-3 IMET route.
+        self.callback_add("/router/bgp/afi-safi/igmp-mld-proxy", config_igmp_mld_proxy);
 
         // EVPN Assisted Replication role + AR-IP (RFC 9574), under
         // `router bgp afi-safi evpn assisted-replication`. Augmented in by

--- a/zebra-rs/src/bgp/inst.rs
+++ b/zebra-rs/src/bgp/inst.rs
@@ -557,6 +557,13 @@ pub struct Bgp {
     /// The Rib::neighbors -> EvpnPrefix::MacIp pipeline that reads
     /// this lands separately.
     pub advertise_all_vni: bool,
+    /// When true, attach the EVPN Multicast Flags Extended Community
+    /// (RFC 9251 §6, IGMP + MLD proxy capability) to every locally
+    /// originated Type-3 (IMET) route. Signals to peers that this PE
+    /// performs IGMP/MLD proxying, so they may send selective (SMET)
+    /// multicast toward it. Drives `evpn_originate_imet`; toggling it
+    /// re-originates all IMET routes via `reoriginate_all_imet`.
+    pub igmp_mld_proxy: bool,
     /// Local bridge FDB shadow keyed by `(vni, mac)`. Populated from
     /// every `RibRx::FdbAdd`, removed on `RibRx::FdbDel`. We need
     /// durable state (not just one-shot event handling) because the
@@ -974,6 +981,7 @@ impl Bgp {
             router_id_config: None,
             rib_router_id: None,
             advertise_all_vni: false,
+            igmp_mld_proxy: false,
             local_fdb: BTreeMap::new(),
             local_vxlans: BTreeMap::new(),
             hostname: None,

--- a/zebra-rs/src/bgp/route.rs
+++ b/zebra-rs/src/bgp/route.rs
@@ -11802,10 +11802,20 @@ impl Bgp {
             orig: vtep_local,
         };
         let mut attr = BgpAttr::new();
-        attr.ecom = Some(ExtCommunity::from([
-            evpn_route_target(self.asn, vni),
-            evpn_encap_vxlan(),
-        ]));
+        let mut ecom = ExtCommunity::from([evpn_route_target(self.asn, vni), evpn_encap_vxlan()]);
+        // RFC 9251 §6: advertise IGMP/MLD proxy capability on the IMET
+        // route via the Multicast Flags EC, so peers know they may send
+        // selective (SMET) multicast toward this PE instead of flooding.
+        if self.igmp_mld_proxy {
+            ecom.0.insert(
+                EvpnMcastFlags {
+                    igmp_proxy: true,
+                    mld_proxy: true,
+                }
+                .into(),
+            );
+        }
+        attr.ecom = Some(ecom);
         // RFC 9574: the PMSI Tunnel attribute and next hop depend on the
         // local Assisted Replication role. RNVE keeps the plain Ingress
         // Replication encoding (tunnel type 6); a Replicator emits a

--- a/zebra-rs/src/config/manager.rs
+++ b/zebra-rs/src/config/manager.rs
@@ -2293,4 +2293,29 @@ mod yang_load_tests {
             assert_eq!(code, ExecCode::Success, "`{path}` must be a settable path");
         }
     }
+
+    #[test]
+    fn bgp_evpn_igmp_mld_proxy_is_settable() {
+        use crate::config::ExecCode;
+        use crate::config::parse::{State, parse};
+        use libyang::to_entry;
+
+        let mut yang = YangStore::new();
+        yang.add_path(concat!(env!("CARGO_MANIFEST_DIR"), "/yang"));
+        yang.read_with_resolve("configure")
+            .expect("configure mode loads");
+        yang.identity_resolve();
+        let module = yang
+            .find_module("configure")
+            .expect("configure module present");
+        let entry = to_entry(&yang, module);
+
+        for path in [
+            "set router bgp afi-safi evpn igmp-mld-proxy true",
+            "set router bgp afi-safi evpn igmp-mld-proxy false",
+        ] {
+            let (code, _comps, _state) = parse(path, entry.clone(), None, State::new());
+            assert_eq!(code, ExecCode::Success, "`{path}` must be a settable path");
+        }
+    }
 }

--- a/zebra-rs/yang/zebra-bgp-evpn.yang
+++ b/zebra-rs/yang/zebra-bgp-evpn.yang
@@ -78,6 +78,18 @@ module zebra-bgp-evpn {
          Equivalent to FRR's `advertise-all-vni` under
          `address-family l2vpn evpn`.";
     }
+    leaf igmp-mld-proxy {
+      type boolean;
+      default false;
+      description
+        "When true, advertise IGMP/MLD proxy capability (RFC 9251 §6)
+         by attaching the Multicast Flags Extended Community (both the
+         IGMP and MLD proxy bits) to every locally originated Type-3
+         (Inclusive Multicast) route. This tells remote PEs they may
+         send selective multicast (Type-6 SMET) toward this PE instead
+         of flooding BUM for snooped groups. Per-protocol granularity
+         (IGMP-only / MLD-only) is a follow-up.";
+    }
     container assisted-replication {
       description
         "RFC 9574 Optimized Ingress Replication (Assisted Replication)


### PR DESCRIPTION
## Summary

Phase 3 of EVPN IGMP/MLD proxy support (RFC 9251): advertise IGMP/MLD proxy
capability by attaching the **Multicast Flags Extended Community** (added in
Phase 2) to the locally originated Type-3 (IMET) route.

- New config knob `router bgp afi-safi evpn igmp-mld-proxy <bool>`
  (`zebra-bgp-evpn.yang` leaf → `Bgp::igmp_mld_proxy`, `config_igmp_mld_proxy`).
  Toggling re-originates all IMET via `reoriginate_all_imet`.
- `evpn_originate_imet` attaches the Multicast Flags EC (IGMP + MLD bits)
  to the IMET route's ext-communities when the knob is on.
- YANG-load `is-settable` test for the new leaf.

The **consumer read is folded into Phase 5**: the capability rides the IMET
path attribute (already in the Loc-RIB) and is read on demand via the Phase-2
`ExtCommunityValue::as_evpn_mcast_flags` accessor when deciding
selective-vs-flood. A receiving PE already renders `mcast-flags:IM` in
`show bgp evpn` (Phase-2 `Display`), so the signal is observable end-to-end.
Per-protocol (IGMP-only / MLD-only) granularity is a follow-up.

## Test plan

- `cargo test -p zebra-rs yang` — 31 pass incl. new `bgp_evpn_igmp_mld_proxy_is_settable`.
- `cargo test -p bgp-packet evpn` — 30 pass.
- `cargo clippy --workspace --all-targets -- -D warnings` — clean.
- `cargo fmt --all --check` — clean.

Generated with [Claude Code](https://claude.com/claude-code)