### PR TITLE
bgp: originate Type-3 IMET over an SR P2MP P-tunnel

### DIFF
--- a/zebra-rs/src/bgp/config.rs
+++ b/zebra-rs/src/bgp/config.rs
@@ -16,7 +16,7 @@ use super::auth::AoConfig;
 use super::peer::{AfiSafiEncapType, BgpTop};
 use super::route_clean;
 use super::{
-    AssistedReplicationRole, BGP_PORT, Bgp,
+    AssistedReplicationRole, BGP_PORT, Bgp, EvpnBumTunnel,
     inst::Callback,
     peer::{
         ALLOWAS_IN_DEFAULT_COUNT, AllowAsIn, LocalAs, PasswordEncoding, Peer, PeerType,
@@ -1540,6 +1540,32 @@ fn config_assisted_replication_ip(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -
         return Some(());
     }
     bgp.local_rib.evpn_flood.ar_ip = ip;
+    reoriginate_all_imet(bgp);
+    Some(())
+}
+
+/// `router bgp afi-safi evpn bum-tunnel-type <ingress-replication|
+/// sr-mpls-p2mp|srv6-p2mp>` — the inclusive BUM P-tunnel advertised in the
+/// Type-3 IMET PMSI. The SR P2MP modes bind BUM delivery to an RFC 9524
+/// replication tree (draft-ietf-bess-mvpn-evpn-sr-p2mp).
+fn config_evpn_bum_tunnel_type(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Option<()> {
+    let afi_safi: AfiSafi = args.afi_safi()?;
+    if afi_safi.afi != Afi::L2vpn || afi_safi.safi != Safi::Evpn {
+        return None;
+    }
+    let bum = if op.is_set() {
+        match args.string()?.as_str() {
+            "sr-mpls-p2mp" => EvpnBumTunnel::SrMplsP2mp,
+            "srv6-p2mp" => EvpnBumTunnel::SrV6P2mp,
+            _ => EvpnBumTunnel::IngressReplication,
+        }
+    } else {
+        EvpnBumTunnel::IngressReplication
+    };
+    if bgp.local_rib.evpn_flood.bum_tunnel == bum {
+        return Some(());
+    }
+    bgp.local_rib.evpn_flood.bum_tunnel = bum;
     reoriginate_all_imet(bgp);
     Some(())
 }
@@ -3675,6 +3701,13 @@ impl Bgp {
         self.callback_add(
             "/router/bgp/afi-safi/assisted-replication/replicator-ip",
             config_assisted_replication_ip,
+        );
+        // EVPN inclusive BUM P-tunnel selection (RFC 9524 SR P2MP trees vs.
+        // ingress replication), under `router bgp afi-safi evpn
+        // bum-tunnel-type`. Augmented in by zebra-bgp-evpn.yang.
+        self.callback_add(
+            "/router/bgp/afi-safi/bum-tunnel-type",
+            config_evpn_bum_tunnel_type,
         );
 
         // Per-AFI redistribution (zebra-bgp-redistribute.yang).

--- a/zebra-rs/src/bgp/inst.rs
+++ b/zebra-rs/src/bgp/inst.rs
@@ -527,6 +527,24 @@ pub enum AssistedReplicationRole {
     Leaf,
 }
 
+/// Inclusive BUM P-tunnel mode advertised in the Type-3 IMET PMSI Tunnel
+/// attribute, configured under `router bgp afi-safi evpn bum-tunnel-type`.
+/// Ingress Replication (optionally optimized by Assisted Replication via
+/// [`AssistedReplicationRole`]) is the default; the SR P2MP modes bind BUM
+/// delivery to an RFC 9524 replication tree
+/// (draft-ietf-bess-mvpn-evpn-sr-p2mp), with the local node as the tree Root.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum EvpnBumTunnel {
+    /// Ingress Replication (PMSI tunnel type 0x06, or Assisted Replication
+    /// 0x0A per the AR role). The default.
+    #[default]
+    IngressReplication,
+    /// SR-MPLS P2MP tree (PMSI tunnel type 0x0C).
+    SrMplsP2mp,
+    /// SRv6 P2MP tree (PMSI tunnel type 0x0D).
+    SrV6P2mp,
+}
+
 pub struct Bgp {
     pub asn: u32,
     /// Effective BGP Identifier — what OPENs, EVPN RDs and the show

--- a/zebra-rs/src/bgp/mod.rs
+++ b/zebra-rs/src/bgp/mod.rs
@@ -1,5 +1,5 @@
 pub mod inst;
-pub use inst::{AssistedReplicationRole, Bgp, Message};
+pub use inst::{AssistedReplicationRole, Bgp, EvpnBumTunnel, Message};
 
 pub mod constant;
 pub use constant::*;

--- a/zebra-rs/src/bgp/route.rs
+++ b/zebra-rs/src/bgp/route.rs
@@ -19,7 +19,7 @@ use super::peer_map::PeerMap;
 use super::shard::msg::{ShardUpdateV4, ShardUpdateV6};
 use super::shard::{ShardMsg, ShardOut};
 use super::timer::{start_adv_timer_vpnv4, start_adv_timer_vpnv6};
-use super::{AssistedReplicationRole, Bgp, InOut, Message};
+use super::{AssistedReplicationRole, Bgp, EvpnBumTunnel, InOut, Message};
 
 pub const ORIGINATED_PEER: usize = usize::MAX;
 
@@ -1913,6 +1913,10 @@ pub struct EvpnFloodState {
     /// Local AR-IP (`... assisted-replication replicator-ip`), advertised in
     /// the Replicator-AR route's next hop when `role` is `Replicator`.
     pub ar_ip: Option<IpAddr>,
+    /// Inclusive BUM P-tunnel advertised in the Type-3 IMET PMSI
+    /// (`... evpn bum-tunnel-type`). Default Ingress Replication; the SR
+    /// P2MP modes advertise an RFC 9524 replication tree rooted here.
+    pub bum_tunnel: EvpnBumTunnel,
     /// Per-VNI flood model.
     vnis: BTreeMap<u32, VniFlood>,
 }
@@ -11821,9 +11825,10 @@ impl Bgp {
         // Replication encoding (tunnel type 6); a Replicator emits a
         // Replicator-AR route (tunnel type 0x0A, next hop = AR-IP); a Leaf
         // tags its Regular-IR route as AR-LEAF.
+        let bum = self.local_rib.evpn_flood.bum_tunnel;
         let role = self.local_rib.evpn_flood.role;
         let ar_ip = self.local_rib.evpn_flood.ar_ip;
-        let (pmsi, nexthop) = imet_pmsi_tunnel(role, ar_ip, vtep_local, vni);
+        let (pmsi, nexthop) = imet_pmsi_tunnel(bum, role, ar_ip, vtep_local, vni);
         attr.pmsi_tunnel = Some(pmsi);
         attr.nexthop = Some(BgpNexthop::Evpn(nexthop));
 
@@ -11929,12 +11934,31 @@ fn rd_from_router_id_vni(router_id: Ipv4Addr, vni: u32) -> Option<RouteDistingui
 ///   next hop = local VTEP (IR-IP).
 /// - **None**, or Replicator without an AR-IP: plain Ingress Replication
 ///   (tunnel type 6, T = RNVE) — byte-for-byte the pre-RFC-9574 encoding.
+///
+/// When `bum` selects an SR P2MP tree (RFC 9524) the AR role is bypassed:
+/// the local node is the tree Root, the Tree-ID is derived from the VNI,
+/// and the tunnel endpoint / next hop is the local VTEP.
 fn imet_pmsi_tunnel(
+    bum: EvpnBumTunnel,
     role: AssistedReplicationRole,
     ar_ip: Option<IpAddr>,
     vtep_local: IpAddr,
     vni: u32,
 ) -> (PmsiTunnel, IpAddr) {
+    // SR P2MP replication trees ignore the AR role. The MPLS Label field
+    // stays 0 (shared-tunnel upstream label / SRv6 transposition is a
+    // follow-up); the Root is the local VTEP and the Tree-ID is the VNI.
+    let sr_tunnel_type = match bum {
+        EvpnBumTunnel::SrMplsP2mp => Some(PmsiTunnel::TUNNEL_SR_MPLS_P2MP),
+        EvpnBumTunnel::SrV6P2mp => Some(PmsiTunnel::TUNNEL_SRV6_P2MP),
+        EvpnBumTunnel::IngressReplication => None,
+    };
+    if let Some(tunnel_type) = sr_tunnel_type {
+        return (
+            PmsiTunnel::sr_p2mp(tunnel_type, 0, vni, vtep_local),
+            vtep_local,
+        );
+    }
     match (role, ar_ip) {
         (AssistedReplicationRole::Replicator, Some(ar)) => (
             PmsiTunnel {
@@ -12102,8 +12126,13 @@ mod evpn_imet_ar_tests {
     /// next hop = the local VTEP, regardless of any stray AR-IP.
     #[test]
     fn rnve_is_plain_ingress_replication() {
-        let (pmsi, nh) =
-            imet_pmsi_tunnel(AssistedReplicationRole::None, Some(ar_ip()), ir_ip(), 100);
+        let (pmsi, nh) = imet_pmsi_tunnel(
+            EvpnBumTunnel::IngressReplication,
+            AssistedReplicationRole::None,
+            Some(ar_ip()),
+            ir_ip(),
+            100,
+        );
         assert_eq!(pmsi.tunnel_type, PmsiTunnel::TUNNEL_INGRESS_REPLICATION);
         assert_eq!(pmsi.ar_type(), AssistedReplicationType::Rnve);
         assert_eq!(pmsi.flags, 0, "byte-for-byte the legacy encoding");
@@ -12116,6 +12145,7 @@ mod evpn_imet_ar_tests {
     #[test]
     fn replicator_emits_replicator_ar_route() {
         let (pmsi, nh) = imet_pmsi_tunnel(
+            EvpnBumTunnel::IngressReplication,
             AssistedReplicationRole::Replicator,
             Some(ar_ip()),
             ir_ip(),
@@ -12131,7 +12161,13 @@ mod evpn_imet_ar_tests {
     /// 6 with the next hop = local VTEP (IR-IP).
     #[test]
     fn leaf_flags_regular_ir_as_ar_leaf() {
-        let (pmsi, nh) = imet_pmsi_tunnel(AssistedReplicationRole::Leaf, None, ir_ip(), 100);
+        let (pmsi, nh) = imet_pmsi_tunnel(
+            EvpnBumTunnel::IngressReplication,
+            AssistedReplicationRole::Leaf,
+            None,
+            ir_ip(),
+            100,
+        );
         assert_eq!(pmsi.tunnel_type, PmsiTunnel::TUNNEL_INGRESS_REPLICATION);
         assert_eq!(pmsi.ar_type(), AssistedReplicationType::Leaf);
         assert_eq!(pmsi.endpoint, ir_ip());
@@ -12143,9 +12179,50 @@ mod evpn_imet_ar_tests {
     /// usable tunnel destination.
     #[test]
     fn replicator_without_ar_ip_falls_back_to_ir() {
-        let (pmsi, nh) = imet_pmsi_tunnel(AssistedReplicationRole::Replicator, None, ir_ip(), 100);
+        let (pmsi, nh) = imet_pmsi_tunnel(
+            EvpnBumTunnel::IngressReplication,
+            AssistedReplicationRole::Replicator,
+            None,
+            ir_ip(),
+            100,
+        );
         assert_eq!(pmsi.tunnel_type, PmsiTunnel::TUNNEL_INGRESS_REPLICATION);
         assert_eq!(pmsi.ar_type(), AssistedReplicationType::Rnve);
+        assert_eq!(nh, ir_ip());
+    }
+
+    /// SR-MPLS P2MP mode → an SR P2MP tree IMET (RFC 9524): tunnel type
+    /// 0x0C, Root and next hop = the local VTEP, Tree-ID derived from the
+    /// VNI. The AR role is bypassed.
+    #[test]
+    fn sr_mpls_p2mp_origination() {
+        let (pmsi, nh) = imet_pmsi_tunnel(
+            EvpnBumTunnel::SrMplsP2mp,
+            AssistedReplicationRole::Replicator,
+            Some(ar_ip()),
+            ir_ip(),
+            100,
+        );
+        assert_eq!(pmsi.tunnel_type, PmsiTunnel::TUNNEL_SR_MPLS_P2MP);
+        assert!(pmsi.is_sr_p2mp());
+        assert_eq!(pmsi.tree_id, Some(100), "Tree-ID derived from VNI");
+        assert_eq!(pmsi.endpoint, ir_ip(), "Root = local VTEP");
+        assert_eq!(nh, ir_ip(), "next hop = local VTEP, not the AR-IP");
+    }
+
+    /// SRv6 P2MP mode → tunnel type 0x0D, otherwise as SR-MPLS.
+    #[test]
+    fn srv6_p2mp_origination() {
+        let (pmsi, nh) = imet_pmsi_tunnel(
+            EvpnBumTunnel::SrV6P2mp,
+            AssistedReplicationRole::None,
+            None,
+            ir_ip(),
+            4242,
+        );
+        assert_eq!(pmsi.tunnel_type, PmsiTunnel::TUNNEL_SRV6_P2MP);
+        assert_eq!(pmsi.tree_id, Some(4242));
+        assert_eq!(pmsi.endpoint, ir_ip());
         assert_eq!(nh, ir_ip());
     }
 }

--- a/zebra-rs/src/config/manager.rs
+++ b/zebra-rs/src/config/manager.rs
@@ -2318,4 +2318,30 @@ mod yang_load_tests {
             assert_eq!(code, ExecCode::Success, "`{path}` must be a settable path");
         }
     }
+
+    #[test]
+    fn bgp_evpn_bum_tunnel_type_is_settable() {
+        use crate::config::ExecCode;
+        use crate::config::parse::{State, parse};
+        use libyang::to_entry;
+
+        let mut yang = YangStore::new();
+        yang.add_path(concat!(env!("CARGO_MANIFEST_DIR"), "/yang"));
+        yang.read_with_resolve("configure")
+            .expect("configure mode loads");
+        yang.identity_resolve();
+        let module = yang
+            .find_module("configure")
+            .expect("configure module present");
+        let entry = to_entry(&yang, module);
+
+        for path in [
+            "set router bgp afi-safi evpn bum-tunnel-type ingress-replication",
+            "set router bgp afi-safi evpn bum-tunnel-type sr-mpls-p2mp",
+            "set router bgp afi-safi evpn bum-tunnel-type srv6-p2mp",
+        ] {
+            let (code, _comps, _state) = parse(path, entry.clone(), None, State::new());
+            assert_eq!(code, ExecCode::Success, "`{path}` must be a settable path");
+        }
+    }
 }

--- a/zebra-rs/yang/zebra-bgp-evpn.yang
+++ b/zebra-rs/yang/zebra-bgp-evpn.yang
@@ -90,6 +90,32 @@ module zebra-bgp-evpn {
          of flooding BUM for snooped groups. Per-protocol granularity
          (IGMP-only / MLD-only) is a follow-up.";
     }
+    leaf bum-tunnel-type {
+      type enumeration {
+        enum ingress-replication {
+          description
+            "Ingress Replication (the default) — BUM is head-end
+             replicated to each remote PE, optionally optimized by
+             Assisted Replication per the `assisted-replication` role.";
+        }
+        enum sr-mpls-p2mp {
+          description
+            "SR-MPLS P2MP tree (PMSI tunnel type 0x0C) — BUM delivery is
+             bound to an RFC 9524 replication tree rooted at this node.";
+        }
+        enum srv6-p2mp {
+          description
+            "SRv6 P2MP tree (PMSI tunnel type 0x0D) — the SRv6 form of
+             the RFC 9524 replication tree.";
+        }
+      }
+      default ingress-replication;
+      description
+        "Inclusive BUM P-tunnel advertised in the Type-3 IMET PMSI Tunnel
+         attribute. The SR P2MP modes (draft-ietf-bess-mvpn-evpn-sr-p2mp)
+         advertise a Tree-ID + Root identifier with the local node as the
+         tree Root; they bypass Assisted Replication.";
+    }
     container assisted-replication {
       description
         "RFC 9574 Optimized Ingress Replication (Assisted Replication)


### PR DESCRIPTION
## Summary

Third slice of the **RFC 9524 (Segment Routing Replication) for EVPN BUM** plan (after #1487 codepoints, #1491 identifier codec). Wires the codec into Type-3 IMET **origination**.

New config knob:
```
router bgp afi-safi evpn bum-tunnel-type {ingress-replication | sr-mpls-p2mp | srv6-p2mp}
```
The SR P2MP modes advertise the inclusive BUM P-tunnel as an RFC 9524 replication tree (`draft-ietf-bess-mvpn-evpn-sr-p2mp`):
- PMSI tunnel type `0x0C` (SR-MPLS) / `0x0D` (SRv6),
- the local node is the tree **Root** (= next hop / tunnel endpoint = local VTEP),
- **Tree-ID** derived from the VNI,
- the Assisted Replication role is bypassed in these modes.

- `EvpnBumTunnel` enum stored on `EvpnFloodState`; config handler + YANG `bum-tunnel-type` leaf + `yang_load` pin test.
- `imet_pmsi_tunnel()` takes the BUM mode and builds the SR P2MP PMSI via `PmsiTunnel::sr_p2mp()`.

**Scope:** origination only. The BUM **forwarding / import** path is unchanged — a node in SR P2MP mode still floods via kernel ingress replication, since the SR P2MP dataplane (eBPF) is a later slice. The MPLS Label field stays 0 (shared-tunnel / SRv6-transposition labels deferred).

## Test

- 2 new unit tests (`sr_mpls_p2mp_origination`, `srv6_p2mp_origination`) assert the originated PMSI: tunnel type, `is_sr_p2mp()`, Tree-ID == VNI, Root/next-hop == local VTEP, AR role bypassed. Existing AR/IR origination tests retained.
- `bgp_evpn_bum_tunnel_type_is_settable` pins the three config paths.
- `cargo fmt --all` clean · `cargo clippy --workspace --all-targets -- -D warnings` clean · zebra-rs unit + yang_load tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)