### PR TITLE
bgp: EVPN SMET origination from kernel IGMP/MLD snoop (RFC 9251)

### DIFF
--- a/docs/design/bgp-evpn-igmp-mld-proxy.md
+++ b/docs/design/bgp-evpn-igmp-mld-proxy.md
@@ -30,7 +30,7 @@ before citing.
 | 1     | Codec — Type 6 SMET NLRI                | **done** |
 | 2     | Multicast Flags Extended Community      | **done** |
 | 3     | IMET (Type 3) capability signaling      | **done** |
-| 4     | SMET origination from kernel MDB snoop  | planned  |
+| 4     | SMET origination from kernel MDB snoop  | **done** |
 | 5     | SMET reception → selective dataplane    | planned  |
 | 6     | Show + BDD + docs                       | planned  |
 | —     | Type 7/8 multihoming synch              | deferred |
@@ -239,22 +239,35 @@ dataplane action happens yet.
   is observable end-to-end today. Per-protocol (IGMP-only / MLD-only)
   granularity is a follow-up.
 
-### Phase 4 — SMET origination from kernel MDB snoop
-- **4a (fork `../netlink-packet-route`):** finish `br_mdb_entry` +
-  `MDBA_MDB_ENTRY_INFO` + `MDBE_ATTR_SOURCE/GROUP` decode (currently raw
-  bytes); commit to `seg6`, **push**, bump the Cargo git rev (CI builds
-  from the pinned rev).
-- **4b (fib `handle.rs`):** startup `RTM_GETMDB` dump + subscribe to the
-  MDB rtnl multicast group; parse `NewMdb/DelMdb` (the `:2930` TODO). Map
-  (bridge, VID→VNI, grp, src) → a **new** `rib::Message::SnoopJoin /
-  SnoopLeave`. Rename the existing Type-3 `MdbAdd`/`mdb_add` (e.g.
-  `BumReplicationAdd`) to remove the overload.
-- **4c (bgp `route.rs`):** membership events → `evpn_originate_smet` /
-  `evpn_withdraw_smet`. RD auto-derived `router-id:VNI` (like macip/imet),
-  RT = EVI RT `AS:VNI`, nexthop = local VTEP, flags from the snooped
-  IGMP/MLD version + IE mode. Cache for replay on capability/gate
-  transitions. Triggers per RFC 9251 §6 (first `(*,G)`; IGMPv3 `(S,G)`;
-  version upgrade ⇒ re-advertise, not withdraw).
+### Phase 4 — SMET origination from kernel MDB snoop — **done**
+- **4a (fork `netlink-packet-route` `seg6`):** `src/mdb/entry.rs` decodes
+  the nested `MDBA_MDB → MDBA_MDB_ENTRY → MDBA_MDB_ENTRY_INFO →
+  br_mdb_entry + MDBA_MDB_EATTR_SOURCE` tree into typed
+  `MdbEntry { port_ifindex, state, flags, vid, group, source }` (+
+  `MdbGroup`, `parse_mdb_entries`, `MdbMessage::entries()`). Pushed to
+  `seg6` (commit `d912564`); Cargo.lock bumped to it.
+- **4b (fib):** join `RTNLGRP_MDB` (group 26); `process_msg` handles
+  `NewMdb/DelMdb` → `mdb_entries_from_msg` (IP groups only) →
+  `FibMessage::NewMdb/DelMdb { bridge_ifindex, vid, group, source }`;
+  `mdb_dump` issues an `RTM_GETMDB` dump at startup via
+  `Handle::request`. RIB `process_fib_msg` maps `bridge_ifindex →
+  (VNI, local VTEP)` (`mdb_vni_vtep` over `vni_for_bridge` +
+  `vxlan_local_for_bridge`) → `RibRx::SnoopJoin/SnoopLeave`.
+- **4c (bgp):** `process_rib_msg` caches membership in `local_smet` and
+  calls `evpn_originate_smet` / `evpn_withdraw_smet` (`route.rs`): RD
+  auto-derived `router-id:VNI`, RT = EVI RT `AS:VNI`, next hop = local
+  VTEP, no PMSI, Flags via `smet_flags()` (IPv4→IGMPv3, IPv6→MLDv2; IE =
+  exclude for `(*,G)`, include for `(S,G)`). The Flags octet now rides on
+  `BgpRib::smet_flags` (resolves the Phase-1 TODO), so reflected SMET
+  preserves it. Gated on the `igmp-mld-proxy` knob; `config_igmp_mld_proxy`
+  replays `local_smet` across the gate transition.
+
+**Notes / deferred:** the existing Type-3 `MdbAdd`/`mdb_add` (zero-MAC FDB
+flood list) was left as-is rather than renamed — the new SMET path uses
+distinct `SnoopJoin/SnoopLeave` messages, so there's no functional
+overload; the rename is cosmetic and can come with Phase 5. SMET flags
+are a per-family approximation, not derived from the kernel MDB
+group-mode (follow-up). No selective dataplane yet (Phase 5).
 
 ### Phase 5 — SMET reception → selective dataplane
 - **5a (fib):** real `bridge mdb add/del dev <vxlan> grp G [src S]

--- a/zebra-rs/src/bgp/config.rs
+++ b/zebra-rs/src/bgp/config.rs
@@ -1479,7 +1479,23 @@ fn config_igmp_mld_proxy(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Option<
         return Some(());
     }
     bgp.igmp_mld_proxy = enabled;
+    // Re-originate IMET (the Multicast Flags EC rides it), then replay
+    // the snooped-membership cache across the gate transition: on
+    // enable, originate a SMET per cached (*,G)/(S,G); on disable,
+    // withdraw them all.
     reoriginate_all_imet(bgp);
+    let memberships: Vec<(u32, IpAddr, Option<IpAddr>, IpAddr)> = bgp
+        .local_smet
+        .iter()
+        .map(|((vni, group, source), vtep)| (*vni, *group, *source, *vtep))
+        .collect();
+    for (vni, group, source, vtep_local) in memberships {
+        if enabled {
+            bgp.evpn_originate_smet(vni, vtep_local, group, source);
+        } else {
+            bgp.evpn_withdraw_smet(vni, vtep_local, group, source);
+        }
+    }
     Some(())
 }
 

--- a/zebra-rs/src/bgp/inst.rs
+++ b/zebra-rs/src/bgp/inst.rs
@@ -602,6 +602,12 @@ pub struct Bgp {
     /// — and replays on `advertise_all_vni` / `router_id` transitions
     /// just like `local_fdb`.
     pub local_vxlans: BTreeMap<u32, std::net::IpAddr>,
+    /// Local snooped IGMP/MLD membership shadow, keyed by
+    /// `(vni, group, source)` → local VTEP IP. Populated from
+    /// `RibRx::SnoopJoin`, removed on `RibRx::SnoopLeave`. Drives
+    /// Type-6 (SMET) origination and replays on `igmp_mld_proxy`
+    /// transitions, mirroring `local_vxlans`/`local_fdb`.
+    pub local_smet: BTreeMap<(u32, std::net::IpAddr, Option<std::net::IpAddr>), std::net::IpAddr>,
     /// Configured hostname for the local BGP speaker. Advertised in
     /// the FQDN capability (capability code 73). When None, falls back
     /// to the OS hostname; if that also fails, no FQDN capability is
@@ -1002,6 +1008,7 @@ impl Bgp {
             igmp_mld_proxy: false,
             local_fdb: BTreeMap::new(),
             local_vxlans: BTreeMap::new(),
+            local_smet: BTreeMap::new(),
             hostname: None,
             no_fib_install: false,
             peers: PeerMap::new(),
@@ -2778,6 +2785,26 @@ impl Bgp {
                     self.evpn_withdraw_imet(vni, vtep_local);
                 }
             }
+            RibRx::SnoopJoin {
+                vni,
+                vtep_local,
+                group,
+                source,
+            } => {
+                // Cache durably so we can replay on `igmp_mld_proxy`
+                // false→true transitions — see `local_smet` doc.
+                self.local_smet.insert((vni, group, source), vtep_local);
+                self.evpn_originate_smet(vni, vtep_local, group, source);
+            }
+            RibRx::SnoopLeave {
+                vni,
+                vtep_local,
+                group,
+                source,
+            } => {
+                self.local_smet.remove(&(vni, group, source));
+                self.evpn_withdraw_smet(vni, vtep_local, group, source);
+            }
             RibRx::VrfAdd {
                 name,
                 table_id,
@@ -4194,6 +4221,7 @@ impl Bgp {
                     stale: false,
                     esi: None,
                     vrf_transit_only: false,
+                    smet_flags: 0,
                 };
 
                 let (_, selected, _gen) = self.shard.update(Some(rd), prefix, rib);
@@ -4475,6 +4503,7 @@ impl Bgp {
                     stale: false,
                     esi: None,
                     vrf_transit_only: false,
+                    smet_flags: 0,
                 };
 
                 let (_, selected, _gen) = self.shard.update_v6vpn(rd, prefix, rib);

--- a/zebra-rs/src/bgp/route.rs
+++ b/zebra-rs/src/bgp/route.rs
@@ -1156,6 +1156,11 @@ pub struct BgpRib {
     /// (`route_ipv4_update` / `route_ipv6_update`); `route_update_ipv4` /
     /// `…ipv6` suppress the advertise. Default `false` (ordinary route).
     pub vrf_transit_only: bool,
+    /// EVPN Type-6 SMET Flags octet (IGMP/MLD version + include/exclude
+    /// mode, RFC 9251 §9.1). The Flags field is NOT part of the SMET
+    /// route key, so it rides here on the path; the advertise/rebuild
+    /// helpers re-emit it. `0` for every non-SMET row.
+    pub smet_flags: u8,
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -1252,6 +1257,7 @@ impl BgpRib {
             stale,
             esi: None,
             vrf_transit_only: false,
+            smet_flags: 0,
         }
     }
 
@@ -4165,11 +4171,11 @@ pub fn route_update_evpn(
             src: *src,
             grp: *grp,
             orig: *orig,
-            // TODO(phase4): SMET Flags (IGMP/MLD version + IE mode) are
-            // not part of the RIB key; carry them on `BgpRib` so a
-            // reflected SMET preserves them. Until then a re-advertised
-            // SMET emits flags = 0.
-            flags: 0,
+            // SMET Flags are not part of the RIB key; they ride on the
+            // path (`BgpRib::smet_flags`), set at origination and
+            // preserved here so a re-advertised / reflected SMET keeps
+            // its IGMP/MLD version + IE mode.
+            flags: rib.smet_flags,
         }),
     };
 
@@ -8174,10 +8180,10 @@ fn build_evpn_route(
             src: *src,
             grp: *grp,
             orig: *orig,
-            // TODO(phase4): carry SMET flags on `BgpRib` (see the
-            // advertise path). Peer-down withdraw is key-matched, so
-            // flags = 0 is correct here.
-            flags: 0,
+            // Flags ride on the path; preserve them from the stored row
+            // (a peer-down withdraw is key-matched, but keeping the real
+            // flags is harmless and consistent with the advertise path).
+            flags: rib.smet_flags,
         })),
         // RFC 9572 A-D routes are not stored in the Loc-RIB in the current
         // codec-only phase (dropped at receive), so this is unreachable in
@@ -12051,6 +12057,110 @@ impl Bgp {
         route_withdraw_evpn_to_peers(rd, prefix, &mut self.peers);
     }
 
+    /// Originate a Type-6 SMET route for a locally-snooped `(*,G)` /
+    /// `(S,G)` membership (RFC 9251 §9.1). Mirrors `evpn_originate_imet`.
+    /// Gated on `igmp_mld_proxy` — the proxy feature must be enabled.
+    /// RD is auto-derived `<router-id>:<VNI>`, the RT is the EVI RT
+    /// `<AS>:<VNI>` (so receivers map it back to the VNI), next hop is
+    /// the local VTEP, and the Flags octet carries the IGMP/MLD version
+    /// + include/exclude mode. No PMSI attribute (RFC 9251 §6).
+    pub fn evpn_originate_smet(
+        &mut self,
+        vni: u32,
+        vtep_local: IpAddr,
+        group: IpAddr,
+        source: Option<IpAddr>,
+    ) {
+        if !self.igmp_mld_proxy {
+            return;
+        }
+        if self.router_id.is_unspecified() {
+            return;
+        }
+        let Some(rd) = rd_from_router_id_vni(self.router_id, vni) else {
+            return;
+        };
+        let prefix = EvpnPrefix::Smet {
+            eth_tag: 0,
+            src: source,
+            grp: group,
+            orig: vtep_local,
+        };
+        let mut attr = BgpAttr::new();
+        attr.ecom = Some(ExtCommunity::from([
+            evpn_route_target(self.asn, vni),
+            evpn_encap_vxlan(),
+        ]));
+        attr.nexthop = Some(BgpNexthop::Evpn(vtep_local));
+
+        let mut rib = BgpRib::new(
+            ORIGINATED_PEER,
+            Ipv4Addr::UNSPECIFIED,
+            BgpRibType::Originated,
+            0,
+            32768,
+            &attr,
+            None,
+            None,
+            false,
+        );
+        // The Flags octet is not part of the route key — carry it on the
+        // path so the advertise side re-emits it.
+        rib.smet_flags = smet_flags(group, source);
+        let (_replaced, selected, next_id) =
+            self.local_rib.update_evpn(rd, prefix.clone(), rib.clone());
+        rib.local_id = next_id;
+
+        let mut bgp_ref = BgpTop {
+            router_id: &self.router_id,
+            srv6_ipv6_export: self.srv6_ipv6_export.as_ref(),
+            local_rib: &mut self.local_rib,
+            shard: &mut self.shard,
+            tx: &self.tx,
+            rib_client: &self.ctx.rib,
+            attr_store: &mut self.attr_store,
+            update_groups: &mut self.update_groups,
+            interface_addrs: &self.interface_addrs,
+            vrf_export: None,
+            color_policy: Some(&self.color_policy),
+            flex_algo_routes: Some(&self.flex_algo_routes),
+            flex_algo_srv6_routes: Some(&self.flex_algo_srv6_routes),
+            vrf_import: None,
+            nexthop_cache: None,
+            vrf_transport_v4: None,
+            vrf_transport_v6: None,
+            central_label_alloc: None,
+        };
+
+        if !selected.is_empty() {
+            route_advertise_evpn_to_peers(rd, prefix, &selected, &mut bgp_ref, &mut self.peers);
+        }
+    }
+
+    /// Inverse of `evpn_originate_smet`. Not gated on `igmp_mld_proxy`
+    /// so a membership leave (or the proxy being turned off) always
+    /// clears the originated route.
+    pub fn evpn_withdraw_smet(
+        &mut self,
+        vni: u32,
+        vtep_local: IpAddr,
+        group: IpAddr,
+        source: Option<IpAddr>,
+    ) {
+        let Some(rd) = rd_from_router_id_vni(self.router_id, vni) else {
+            return;
+        };
+        let prefix = EvpnPrefix::Smet {
+            eth_tag: 0,
+            src: source,
+            grp: group,
+            orig: vtep_local,
+        };
+        let _ = self.local_rib.remove_evpn(rd, &prefix, 0, ORIGINATED_PEER);
+        let _ = self.local_rib.select_best_path_evpn(&rd, &prefix);
+        route_withdraw_evpn_to_peers(rd, prefix, &mut self.peers);
+    }
+
     /// Reconcile the BUM flood list of every VNI against the current
     /// Assisted Replication role/AR-IP. Called from the config callbacks
     /// when `role` or `replicator-ip` changes — e.g. switching to AR-LEAF
@@ -12074,6 +12184,23 @@ const NTF_EXT_LEARNED: u8 = 0x10;
 /// when the VNI exceeds 16 bits — Type-1 only has 2 bytes for the
 /// assigned-number field; supporting VNIs above 65535 needs the
 /// Type-0 (ASN) format and is a follow-up.
+/// Derive the RFC 9251 §9.1 SMET Flags octet from the group family and
+/// source presence. IPv4 advertises IGMPv3 (v3 bit), IPv6 advertises
+/// MLDv2 (v2 bit; MLD has no v3); a `(*,G)` join sets exclude (IE)
+/// mode, an `(S,G)` join include mode. Precise per-host version/mode
+/// derivation from the kernel MDB group-mode is a follow-up.
+fn smet_flags(group: IpAddr, source: Option<IpAddr>) -> u8 {
+    const V2: u8 = 0x02;
+    const V3: u8 = 0x04;
+    const IE_EXCLUDE: u8 = 0x08;
+    let version = match group {
+        IpAddr::V4(_) => V3,
+        IpAddr::V6(_) => V2,
+    };
+    let mode = if source.is_some() { 0 } else { IE_EXCLUDE };
+    version | mode
+}
+
 fn rd_from_router_id_vni(router_id: Ipv4Addr, vni: u32) -> Option<RouteDistinguisher> {
     let vni_short: u16 = vni.try_into().ok()?;
     let mut rd = RouteDistinguisher::new(RouteDistinguisherType::IP);

--- a/zebra-rs/src/bgp/vrf/inst.rs
+++ b/zebra-rs/src/bgp/vrf/inst.rs
@@ -614,6 +614,7 @@ impl BgpVrf {
             stale: false,
             esi: None,
             vrf_transit_only: false,
+            smet_flags: 0,
         };
 
         let (_, selected, _gen) = self.shard.update(None, prefix, rib);
@@ -836,6 +837,7 @@ impl BgpVrf {
             stale: false,
             esi: None,
             vrf_transit_only: false,
+            smet_flags: 0,
         };
 
         let (_, selected, _gen) = self.shard.update_v6(prefix, rib);
@@ -1089,6 +1091,7 @@ impl BgpVrf {
             stale: false,
             esi: None,
             vrf_transit_only: false,
+            smet_flags: 0,
         }
     }
 

--- a/zebra-rs/src/fib/message.rs
+++ b/zebra-rs/src/fib/message.rs
@@ -136,4 +136,21 @@ pub enum FibMessage {
     DelNexthop(u32),
     NewNeighbor(FibNeighbor),
     DelNeighbor(FibNeighbor),
+    /// Bridge multicast database entry from kernel IGMP/MLD snooping
+    /// (`RTM_NEWMDB`). Drives EVPN SMET (Type-6) origination.
+    NewMdb(FibMdbEntry),
+    /// Inverse of `NewMdb` (`RTM_DELMDB`).
+    DelMdb(FibMdbEntry),
+}
+
+/// One kernel bridge MDB entry, reduced to the fields EVPN cares about.
+/// `group`/`source` are IP (L2 MAC groups are filtered out upstream);
+/// `bridge_ifindex` is the bridge the group was learned on (mapped to a
+/// VNI by the RIB).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct FibMdbEntry {
+    pub bridge_ifindex: u32,
+    pub vid: u16,
+    pub group: IpAddr,
+    pub source: Option<IpAddr>,
 }

--- a/zebra-rs/src/fib/netlink/dump.rs
+++ b/zebra-rs/src/fib/netlink/dump.rs
@@ -1,13 +1,17 @@
 use std::net::{Ipv4Addr, Ipv6Addr};
 
 use anyhow::Result;
-use futures::stream::TryStreamExt;
-use netlink_packet_route::AddressFamily;
+use futures::stream::{StreamExt, TryStreamExt};
+use netlink_packet_core::{NLM_F_DUMP, NLM_F_REQUEST, NetlinkPayload};
+use netlink_packet_route::mdb::{MdbHeader, MdbMessage};
+use netlink_packet_route::{AddressFamily, RouteNetlinkMessage};
 use rtnetlink::{IpVersion, RouteMessageBuilder};
 
 use crate::{fib::FibMessage, rib::Rib};
 
-use super::{addr_from_msg, link_from_msg, neighbor_from_msg, route_from_msg};
+use super::{
+    addr_from_msg, link_from_msg, mdb_entries_from_msg, neighbor_from_msg, route_from_msg,
+};
 
 pub async fn fib_dump(rib: &mut Rib) -> Result<()> {
     link_dump(rib, rib.fib_handle.handle.clone()).await?;
@@ -21,7 +25,43 @@ pub async fn fib_dump(rib: &mut Rib) -> Result<()> {
     neighbor_dump(rib, rib.fib_handle.handle.clone(), AddressFamily::Inet).await?;
     neighbor_dump(rib, rib.fib_handle.handle.clone(), AddressFamily::Inet6).await?;
     neighbor_dump(rib, rib.fib_handle.handle.clone(), AddressFamily::Bridge).await?;
+    // Bridge multicast database (IGMP/MLD snooping) — existing
+    // memberships at startup. Best-effort: hosts without a snooping
+    // bridge simply return nothing (or an error we log and ignore).
+    mdb_dump(rib, rib.fib_handle.handle.clone()).await;
     Ok(())
+}
+
+/// Dump the kernel bridge MDB (`RTM_GETMDB`) so EVPN learns memberships
+/// that existed before start-up. rtnetlink has no MDB helper, so issue
+/// the dump request by hand and feed each `RTM_NEWMDB` reply through the
+/// same converter the live notification path uses.
+async fn mdb_dump(rib: &mut Rib, mut handle: rtnetlink::Handle) {
+    let mdb = MdbMessage {
+        header: MdbHeader {
+            family: AddressFamily::Bridge,
+            index: 0,
+        },
+        ..Default::default()
+    };
+    let mut req = netlink_packet_core::NetlinkMessage::from(RouteNetlinkMessage::GetMdb(mdb));
+    req.header.flags = NLM_F_REQUEST | NLM_F_DUMP;
+    req.finalize();
+
+    let mut resp = match handle.request(req) {
+        Ok(resp) => resp,
+        Err(e) => {
+            tracing::warn!("fib: RTM_GETMDB dump request failed ({e}); skipping MDB dump");
+            return;
+        }
+    };
+    while let Some(msg) = resp.next().await {
+        if let NetlinkPayload::InnerMessage(RouteNetlinkMessage::NewMdb(m)) = msg.payload {
+            for entry in mdb_entries_from_msg(&m) {
+                rib.process_fib_msg(FibMessage::NewMdb(entry)).await;
+            }
+        }
+    }
 }
 
 async fn link_dump(rib: &mut Rib, handle: rtnetlink::Handle) -> Result<()> {

--- a/zebra-rs/src/fib/netlink/handle.rs
+++ b/zebra-rs/src/fib/netlink/handle.rs
@@ -33,7 +33,7 @@ use rtnetlink::{
 use tokio::sync::mpsc::UnboundedSender;
 
 use crate::fib::sysctl::sysctl_enable;
-use crate::fib::{FibAddr, FibLink, FibMessage, FibNeighbor, FibRoute};
+use crate::fib::{FibAddr, FibLink, FibMdbEntry, FibMessage, FibNeighbor, FibRoute};
 use crate::rib::entry::RibEntry;
 use crate::rib::inst::{IlmEntry, IlmType};
 use crate::rib::tracing::{fib_l2_fdb, fib_l2_mdb, fib_l2_vxlan, fib_nexthop, fib_route, fib_srv6};
@@ -172,6 +172,12 @@ fn protect_primary_nexthop(pro: &crate::rib::nexthop::NexthopProtect) -> Nexthop
 /// (`RTNLGRP_NEXTHOP`, linux/rtnetlink.h). Numbered past the legacy
 /// `RTMGRP_*` bind mask, so it's joined via `add_membership`.
 const RTNLGRP_NEXTHOP: u32 = 32;
+
+/// `RTNLGRP_MDB` (linux/rtnetlink.h) — bridge multicast database
+/// notifications (`RTM_{NEW,DEL}MDB`) from IGMP/MLD snooping. Past the
+/// legacy `RTMGRP_*` bind mask, so joined via `add_membership`. Drives
+/// EVPN SMET (RFC 9251) origination.
+const RTNLGRP_MDB: u32 = 26;
 
 /// Mask the lower (128 - prefix_len) bits of an IPv6 address. The
 /// kernel ignores bits past the prefix length on install, but masking
@@ -372,6 +378,20 @@ impl FibHandle {
             Err(e) => tracing::warn!(
                 "fib: could not join RTNLGRP_NEXTHOP ({e}); nexthop reconciliation disabled"
             ),
+        }
+
+        // Bridge MDB group — kernel IGMP/MLD snooping notifications that
+        // drive EVPN SMET origination. Non-fatal on join error (the host
+        // may not have a snooping bridge).
+        match connection
+            .socket_mut()
+            .socket_mut()
+            .add_membership(RTNLGRP_MDB)
+        {
+            Ok(()) => tracing::debug!("fib: joined RTNLGRP_MDB for EVPN IGMP/MLD snooping"),
+            Err(e) => {
+                tracing::warn!("fib: could not join RTNLGRP_MDB ({e}); EVPN SMET snooping disabled")
+            }
         }
 
         tokio::spawn(connection);
@@ -3066,16 +3086,47 @@ fn process_msg(msg: NetlinkMessage<RouteNetlinkMessage>, tx: UnboundedSender<Fib
                 let neighbor = neighbor_from_msg(msg);
                 let _ = tx.send(FibMessage::DelNeighbor(neighbor));
             }
-            // TODO: Add MDB message handling when netlink-packet-route supports it.
-            // RouteNetlinkMessage::NewMdb(_) => {
-            //     // Parse MDB message and send MdbAdd message
-            // }
-            // RouteNetlinkMessage::DelMdb(_) => {
-            //     // Parse MDB message and send MdbDel message
-            // }
+            RouteNetlinkMessage::NewMdb(msg) => {
+                for entry in mdb_entries_from_msg(&msg) {
+                    let _ = tx.send(FibMessage::NewMdb(entry));
+                }
+            }
+            RouteNetlinkMessage::DelMdb(msg) => {
+                for entry in mdb_entries_from_msg(&msg) {
+                    let _ = tx.send(FibMessage::DelMdb(entry));
+                }
+            }
             _ => {}
         }
     }
+}
+
+/// Convert a kernel `RTM_{NEW,DEL}MDB` message into per-group
+/// [`FibMdbEntry`] events. Only IP multicast groups are surfaced —
+/// statically-added L2 MAC groups carry no IGMP/MLD membership and are
+/// skipped. The bridge ifindex (`header.index`) is mapped to a VNI by
+/// the RIB.
+pub(crate) fn mdb_entries_from_msg(
+    msg: &netlink_packet_route::mdb::MdbMessage,
+) -> Vec<FibMdbEntry> {
+    use netlink_packet_route::mdb::MdbGroup;
+    let bridge_ifindex = msg.header.index;
+    msg.entries()
+        .into_iter()
+        .filter_map(|e| {
+            let group = match e.group {
+                MdbGroup::V4(g) => IpAddr::V4(g),
+                MdbGroup::V6(g) => IpAddr::V6(g),
+                MdbGroup::Mac(_) => return None,
+            };
+            Some(FibMdbEntry {
+                bridge_ifindex,
+                vid: e.vid,
+                group,
+                source: e.source,
+            })
+        })
+        .collect()
 }
 
 #[cfg(test)]

--- a/zebra-rs/src/rib/api.rs
+++ b/zebra-rs/src/rib/api.rs
@@ -135,6 +135,23 @@ pub enum RibRx {
     VxlanDel {
         vni: u32,
     },
+    /// Local IGMP/MLD membership snooped by the kernel bridge
+    /// (`RTM_NEWMDB`), resolved to its VNI. The EVPN advertise path
+    /// consumes this to originate a Type-6 SMET route. `source` is
+    /// `None` for a `(*,G)` join, `Some` for `(S,G)`.
+    SnoopJoin {
+        vni: u32,
+        vtep_local: IpAddr,
+        group: IpAddr,
+        source: Option<IpAddr>,
+    },
+    /// Inverse of `SnoopJoin` — emitted on `RTM_DELMDB`.
+    SnoopLeave {
+        vni: u32,
+        vtep_local: IpAddr,
+        group: IpAddr,
+        source: Option<IpAddr>,
+    },
     /// A Linux VRF master device the operator has committed. Emitted
     /// when [`crate::rib::inst::Message::VrfAdd`] has allocated a
     /// `table_id` and the netlink-side `ip link add` succeeded; also
@@ -386,6 +403,44 @@ impl Rib {
     pub fn api_vxlan_add(&self, vni: u32, vtep_local: IpAddr) {
         for (_, sub) in self.client_registry.iter() {
             let _ = sub.rib_rx_tx.send(RibRx::VxlanAdd { vni, vtep_local });
+        }
+    }
+
+    /// Announce / withdraw a snooped IGMP/MLD membership to EVPN
+    /// subscribers (BGP), resolved to its VNI + local VTEP. Like
+    /// FDB/VXLAN events, broadcast to every subscriber (single BGP
+    /// instance consumes the full view).
+    pub fn api_snoop_join(
+        &self,
+        vni: u32,
+        vtep_local: IpAddr,
+        group: IpAddr,
+        source: Option<IpAddr>,
+    ) {
+        for (_, sub) in self.client_registry.iter() {
+            let _ = sub.rib_rx_tx.send(RibRx::SnoopJoin {
+                vni,
+                vtep_local,
+                group,
+                source,
+            });
+        }
+    }
+
+    pub fn api_snoop_leave(
+        &self,
+        vni: u32,
+        vtep_local: IpAddr,
+        group: IpAddr,
+        source: Option<IpAddr>,
+    ) {
+        for (_, sub) in self.client_registry.iter() {
+            let _ = sub.rib_rx_tx.send(RibRx::SnoopLeave {
+                vni,
+                vtep_local,
+                group,
+                source,
+            });
         }
     }
 

--- a/zebra-rs/src/rib/inst.rs
+++ b/zebra-rs/src/rib/inst.rs
@@ -2351,7 +2351,28 @@ impl Rib {
                     self.api_fdb_del(&entry);
                 }
             }
+            FibMessage::NewMdb(entry) => {
+                if let Some((vni, vtep_local)) = self.mdb_vni_vtep(entry.bridge_ifindex) {
+                    self.api_snoop_join(vni, vtep_local, entry.group, entry.source);
+                }
+            }
+            FibMessage::DelMdb(entry) => {
+                if let Some((vni, vtep_local)) = self.mdb_vni_vtep(entry.bridge_ifindex) {
+                    self.api_snoop_leave(vni, vtep_local, entry.group, entry.source);
+                }
+            }
         }
+    }
+
+    /// Resolve a snooped MDB entry's bridge ifindex to `(VNI, local
+    /// VTEP IP)` via the bridge's VXLAN slave. `None` when the bridge
+    /// has no VXLAN slave with a VNI + local address (e.g. a plain L2
+    /// bridge not participating in EVPN) — such memberships are not
+    /// advertised.
+    fn mdb_vni_vtep(&self, bridge_ifindex: u32) -> Option<(u32, IpAddr)> {
+        let vni = self.vni_for_bridge(bridge_ifindex)?;
+        let vtep_local = self.vxlan_local_for_bridge(bridge_ifindex)?;
+        Some((vni, vtep_local))
     }
 
     async fn process_cm_msg(&mut self, msg: ConfigRequest) {


### PR DESCRIPTION
## Summary

Phase 4 of EVPN IGMP/MLD proxy support (RFC 9251): originate **Type-6 SMET**
routes from local kernel-bridge MDB snooping. First phase with a control
plane driven by real membership.

**Fork dependency:** relies on `netlink-packet-route` `seg6` commit `d912564`
(adds `MdbEntry` decode of the nested `br_mdb_entry` tree). Tracked via the
existing `branch = "seg6"` dependency (Cargo.lock is gitignored, so CI
resolves seg6 to that tip).

- **fib**: join `RTNLGRP_MDB`; `process_msg` handles `RTM_{NEW,DEL}MDB` →
  `mdb_entries_from_msg` (IP groups only) → `FibMessage::NewMdb/DelMdb
  { bridge_ifindex, vid, group, source }`; `mdb_dump` issues an `RTM_GETMDB`
  dump at startup (`Handle::request`) for cold-boot memberships.
- **rib**: `process_fib_msg` maps `bridge_ifindex → (VNI, local VTEP)` via
  `mdb_vni_vtep` (`vni_for_bridge` + `vxlan_local_for_bridge`) and emits
  `RibRx::SnoopJoin/SnoopLeave`.
- **bgp**: `process_rib_msg` caches membership in `local_smet` and calls
  `evpn_originate_smet` / `evpn_withdraw_smet`. RD = `router-id:VNI`, RT =
  EVI RT `AS:VNI`, next hop = local VTEP, no PMSI; Flags via `smet_flags()`
  (IPv4→IGMPv3, IPv6→MLDv2; IE exclude for `(*,G)`, include for `(S,G)`).
  Flags ride on `BgpRib::smet_flags` (resolves the Phase-1 TODO) so a
  reflected SMET preserves them. Gated on `igmp-mld-proxy`;
  `config_igmp_mld_proxy` replays `local_smet` across the transition.

No selective-forwarding dataplane yet (Phase 5). The Type-3 zero-MAC-FDB
flood path is untouched (SMET uses distinct `SnoopJoin/SnoopLeave`).

## Test plan

- `cargo test -p zebra-rs` — **1317 passed**, 0 failed.
- `cargo test -p bgp-packet evpn` — 30 passed.
- fork `cargo test` (netlink-packet-route) — 120 passed (incl. 5 new MDB decode tests).
- `cargo clippy --workspace --all-targets -- -D warnings` — clean.
- `cargo fmt --all --check` — clean.

Generated with [Claude Code](https://claude.com/claude-code)