### PR TITLE
bgp: EVPN RFC 9574 Pruned-Flood-Lists (BM/U)

### DIFF
--- a/bdd/tests/configs/bgp_evpn_ar/z3-1.yaml
+++ b/bdd/tests/configs/bgp_evpn_ar/z3-1.yaml
@@ -1,5 +1,7 @@
 # z3 — RNVE (regular NVE, no Assisted Replication). Does plain ingress
-# replication: floods to every remote PE's IR-IP, ignoring the AR-IP.
+# replication: floods to every remote PE's IR-IP, ignoring the AR-IP. Also
+# requests RFC 9574 whole-VTEP Pruned-Flood-List (BM + U), so peers drop z3
+# from their flood lists (z3 still floods outbound to z1/z2).
 vxlan:
 - name: vxlan10
   vni: 10
@@ -12,6 +14,9 @@ router:
     afi-safi:
     - name: evpn
       advertise-all-vni: true
+      pruned-flood-list:
+        broadcast-multicast: true
+        unknown-unicast: true
     neighbor:
     - remote-address: 192.168.0.1
       enabled: true

--- a/bdd/tests/features/bgp_evpn_ar.feature
+++ b/bdd/tests/features/bgp_evpn_ar.feature
@@ -26,7 +26,8 @@ Feature: BGP EVPN Assisted Replication (RFC 9574) control plane
   Roles (router bgp afi-safi evpn assisted-replication):
   - z1: role replicator, replicator-ip 192.168.0.101 (the AR-IP)
   - z2: role leaf
-  - z3: role none (default RNVE)
+  - z3: role none (default RNVE); also requests whole-VTEP P-FL pruning
+    (pruned-flood-list broadcast-multicast + unknown-unicast)
 
   The flood list is observed via the kernel VXLAN FDB: the daemon programs
   zero-MAC (00:00:00:00:00:00) rows, one `dst` per flood target. There is
@@ -69,10 +70,18 @@ Feature: BGP EVPN Assisted Replication (RFC 9574) control plane
 
   Scenario: RNVE floods to every remote VTEP (plain ingress replication)
     Given the test topology exists
-    # z3 (RNVE) floods to z1's and z2's IR-IPs, ignoring the AR-IP.
+    # z3 (RNVE) floods to z1's and z2's IR-IPs, ignoring the AR-IP. z3's own
+    # Pruned-Flood-List request is outbound-independent — it still floods.
     Then bridge fdb "vxlan10" in namespace "z3" should eventually contain "192.168.0.2"
     And bridge fdb "vxlan10" in namespace "z3" should eventually contain "192.168.0.1"
     And bridge fdb "vxlan10" in namespace "z3" should not contain "192.168.0.101"
+
+  Scenario: A whole-VTEP Pruned-Flood-List request drops the node from peers' flood lists
+    Given the test topology exists
+    # z3 set both prune flags (BM + U), so z1 — which floods to every remote
+    # IR-IP — drops z3 while keeping z2. (Inbound prune; z3 still floods out.)
+    Then bridge fdb "vxlan10" in namespace "z1" should eventually contain "192.168.0.2"
+    And bridge fdb "vxlan10" in namespace "z1" should not contain "192.168.0.3"
 
   Scenario: Teardown topology
     Given the test topology exists

--- a/docs/design/bgp-evpn-assisted-replication-plan.md
+++ b/docs/design/bgp-evpn-assisted-replication-plan.md
@@ -28,7 +28,7 @@ Branch `bgp-evpn-bum`. **Phase 0 (codec) landed on the branch**; Phases 1–3
 | 0 — PMSI codec   | tunnel type `0x0A`, `AssistedReplicationType` (T), BM/U/L flag accessors on `PmsiTunnel`, 7 pin tests  | ✅ merged #1476 |
 | 1a — role + origination | YANG `assisted-replication` role/AR-IP config; role-aware Type-3 IMET origination (Replicator-AR tunnel `0x0A` / AR-LEAF-flagged Regular-IR); pin tests | ✅ merged #1483 |
 | 1b — reception + flood model | per-VNI `EvpnFloodState` on `LocalRib`; classify received IMET (Regular-IR vs Replicator-AR); AR-LEAF flood-list collapse to a single `{AR-IP}` with full-IR fallback | ✅ on branch |
-| 2 — Pruned-Flood-Lists | originate BM/U prune flags; honor received prune at whole-VTEP flood-list membership | ⬜ planned |
+| 2 — Pruned-Flood-Lists | YANG `pruned-flood-list` (BM/U) → set flags in our IMET; honor a received whole-VTEP prune (BM **and** U) by dropping the remote from the flood list; BDD prune scenario | ✅ on branch |
 | 3 — selective AR | Replicator `L=1`; AR-LEAF Leaf A-D (Type-1) origination with `AR-IP:0` RT; per-replicator leaf-set | ⬜ planned |
 | 4 — AR-REPLICATOR dataplane | decap-on-AR-IP → re-flood to other VTEPs with split-horizon | ⛔ deferred (needs eBPF/XDP or VPP — see feasibility) |
 
@@ -240,7 +240,7 @@ Closest end-to-end template: the **EVPN Type-3/IMET** path itself (originate
 | 0 | Codec: PMSI tunnel 0x0A + `AssistedReplicationType` (T) + BM/U/L accessors + pin tests | ✅ merged #1476 |
 | 1a | YANG `assisted-replication` role/AR-IP; role-aware Type-3 IMET origination (Replicator-AR `0x0A` / AR-LEAF-flagged Regular-IR) | ✅ merged #1483 |
 | 1b | `EvpnFloodState` per-VNI flood model on `LocalRib`; classify received IMET; AR-LEAF flood-list → single `{AR-IP}`, full-IR fallback (U-flood off) | ✅ on branch |
-| 2 | Pruned-Flood-Lists: originate BM/U flags; honor received prune at whole-VTEP membership | ⬜ planned |
+| 2 | Pruned-Flood-Lists: `pruned-flood-list` config → BM/U flags in our IMET; honor a received whole-VTEP prune (BM **and** U) by dropping the remote; partial (BM-only/U-only) not honored (one kernel flood list/VNI) | ✅ on branch |
 | 3 | Selective AR (control plane): Leaf A-D (Type-1) origination + `AR-IP:0` IP-specific RT; replicator `L=1`; per-replicator leaf-set | ⬜ planned |
 | 4 | **AR-REPLICATOR forwarding dataplane** (eBPF/XDP or VPP) | ⛔ deferred — out of stock-kernel scope |
 
@@ -263,6 +263,9 @@ kernel state:
   single zero-MAC `dst 192.168.0.101` (the AR-IP) and **not** z3's VTEP,
   proving the AR-LEAF collapse; on **z3** it contains both remote IR-IPs
   (`.1`, `.2`) and **not** the AR-IP, proving RNVE full ingress replication.
+- **Phase 2 P-FL** — z3 also requests whole-VTEP prune (`pruned-flood-list`
+  BM + U); **z1**'s FDB drops z3 (`not contain 192.168.0.3`) while keeping z2,
+  proving a received whole-VTEP prune is honored.
 
 This verifies the whole 1a→1b chain end-to-end: z1 originates Replicator-AR
 (AR-IP in the PMSI tunnel endpoint), z2 classifies it and collapses its flood

--- a/zebra-rs/src/bgp/config.rs
+++ b/zebra-rs/src/bgp/config.rs
@@ -1560,6 +1560,39 @@ fn config_assisted_replication_ip(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -
     Some(())
 }
 
+/// `router bgp afi-safi evpn pruned-flood-list broadcast-multicast <bool>`
+/// (RFC 9574). Sets the BM flag in this node's own Type-3 IMET to ask peers
+/// to prune it from the broadcast/multicast flood list.
+fn config_pruned_flood_bm(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Option<()> {
+    let afi_safi: AfiSafi = args.afi_safi()?;
+    if afi_safi.afi != Afi::L2vpn || afi_safi.safi != Safi::Evpn {
+        return None;
+    }
+    let on = if op.is_set() { args.boolean()? } else { false };
+    if bgp.local_rib.evpn_flood.prune_bm == on {
+        return Some(());
+    }
+    bgp.local_rib.evpn_flood.prune_bm = on;
+    reoriginate_all_imet(bgp);
+    Some(())
+}
+
+/// `router bgp afi-safi evpn pruned-flood-list unknown-unicast <bool>`
+/// (RFC 9574). Sets the U flag in this node's own Type-3 IMET.
+fn config_pruned_flood_unknown(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Option<()> {
+    let afi_safi: AfiSafi = args.afi_safi()?;
+    if afi_safi.afi != Afi::L2vpn || afi_safi.safi != Safi::Evpn {
+        return None;
+    }
+    let on = if op.is_set() { args.boolean()? } else { false };
+    if bgp.local_rib.evpn_flood.prune_unknown == on {
+        return Some(());
+    }
+    bgp.local_rib.evpn_flood.prune_unknown = on;
+    reoriginate_all_imet(bgp);
+    Some(())
+}
+
 /// `router bgp afi-safi evpn bum-tunnel-type <ingress-replication|
 /// sr-mpls-p2mp|srv6-p2mp>` — the inclusive BUM P-tunnel advertised in the
 /// Type-3 IMET PMSI. The SR P2MP modes bind BUM delivery to an RFC 9524
@@ -3717,6 +3750,16 @@ impl Bgp {
         self.callback_add(
             "/router/bgp/afi-safi/assisted-replication/replicator-ip",
             config_assisted_replication_ip,
+        );
+        // EVPN Pruned-Flood-List (RFC 9574), under `router bgp afi-safi evpn
+        // pruned-flood-list`. Augmented in by zebra-bgp-evpn.yang.
+        self.callback_add(
+            "/router/bgp/afi-safi/pruned-flood-list/broadcast-multicast",
+            config_pruned_flood_bm,
+        );
+        self.callback_add(
+            "/router/bgp/afi-safi/pruned-flood-list/unknown-unicast",
+            config_pruned_flood_unknown,
         );
         // EVPN inclusive BUM P-tunnel selection (RFC 9524 SR P2MP trees vs.
         // ingress replication), under `router bgp afi-safi evpn

--- a/zebra-rs/src/bgp/route.rs
+++ b/zebra-rs/src/bgp/route.rs
@@ -1923,8 +1923,28 @@ pub struct EvpnFloodState {
     /// (`... evpn bum-tunnel-type`). Default Ingress Replication; the SR
     /// P2MP modes advertise an RFC 9524 replication tree rooted here.
     pub bum_tunnel: EvpnBumTunnel,
+    /// RFC 9574 Pruned-Flood-List request flags set in this node's *own*
+    /// Type-3 IMET (`... evpn pruned-flood-list`): ask remote PEs to prune
+    /// this node from the broadcast/multicast (`prune_bm`) and/or
+    /// unknown-unicast (`prune_unknown`) flood lists.
+    pub prune_bm: bool,
+    pub prune_unknown: bool,
     /// Per-VNI flood model.
     vnis: BTreeMap<u32, VniFlood>,
+}
+
+/// One remote PE's Type-3 IMET state for a VNI.
+#[derive(Debug, Default)]
+struct RemoteImet {
+    /// The remote's AR-IP when it advertised a Replicator-AR route (PMSI
+    /// tunnel type 0x0A), else `None` for a Regular-IR route.
+    ar_ip: Option<IpAddr>,
+    /// RFC 9574 Pruned-Flood-List: the remote asked to be pruned from BOTH
+    /// the BM and the unknown-unicast flood lists, so we drop it from our
+    /// flood list entirely. A partial (BM-only / U-only) request is not
+    /// honored — the single kernel flood list per VNI can't express a
+    /// per-category prune — so such a remote stays in the flood list.
+    prune: bool,
 }
 
 /// Per-VNI flood state: which remotes advertised a Type-3 IMET, and what
@@ -1933,10 +1953,11 @@ pub struct EvpnFloodState {
 struct VniFlood {
     /// Remote PEs that advertised an Ingress/Assisted Replication Type-3
     /// IMET for this VNI, keyed by the NLRI Originating Router IP (the
-    /// remote's IR-IP). The value is the remote's AR-IP when it advertised
-    /// a Replicator-AR route (PMSI tunnel type 0x0A), else `None` for a
-    /// Regular-IR route. These are the VXLAN head-end flood candidates.
-    remotes: BTreeMap<IpAddr, Option<IpAddr>>,
+    /// remote's IR-IP). The value ([`RemoteImet`]) carries the remote's
+    /// AR-IP (when it advertised a Replicator-AR route, PMSI tunnel type
+    /// 0x0A) and its RFC 9574 prune request. These are the VXLAN head-end
+    /// flood candidates.
+    remotes: BTreeMap<IpAddr, RemoteImet>,
     /// Remote PEs that advertised an SR P2MP tree Type-3 IMET (PMSI tunnel
     /// type 0x0C/0x0D, RFC 9524), keyed by Originating Router IP (the tree
     /// Root), valued by the tree's Tree-ID. Recorded for the SR replication
@@ -1951,12 +1972,13 @@ struct VniFlood {
 impl EvpnFloodState {
     /// Record an Ingress/Assisted Replication remote's Type-3 IMET for
     /// `vni`. `ar_ip` is `Some` when the remote is an AR-REPLICATOR
-    /// (Replicator-AR route). Clears any stale SR P2MP record for the same
-    /// originator (a remote that flipped tunnel type).
-    pub fn update_remote(&mut self, vni: u32, orig: IpAddr, ar_ip: Option<IpAddr>) {
+    /// (Replicator-AR route); `prune` is true when it requested whole-VTEP
+    /// pruning (RFC 9574 BM and U both set). Clears any stale SR P2MP record
+    /// for the same originator (a remote that flipped tunnel type).
+    pub fn update_remote(&mut self, vni: u32, orig: IpAddr, ar_ip: Option<IpAddr>, prune: bool) {
         let v = self.vnis.entry(vni).or_default();
         v.sr_remotes.remove(&orig);
-        v.remotes.insert(orig, ar_ip);
+        v.remotes.insert(orig, RemoteImet { ar_ip, prune });
     }
 
     /// Record an SR P2MP tree remote's Type-3 IMET for `vni` (RFC 9524):
@@ -2038,12 +2060,18 @@ impl EvpnFloodState {
         let Some(v) = self.vnis.get(&vni) else {
             return BTreeSet::new();
         };
+        // RFC 9574 Pruned-Flood-List: drop any remote that asked to be pruned
+        // from both flood categories before computing flood targets.
+        let active: Vec<(&IpAddr, &RemoteImet)> =
+            v.remotes.iter().filter(|(_, r)| !r.prune).collect();
         match self.role {
-            AssistedReplicationRole::Leaf => match v.remotes.values().flatten().min().copied() {
-                Some(ar_ip) => BTreeSet::from([ar_ip]),
-                None => v.remotes.keys().copied().collect(),
-            },
-            _ => v.remotes.keys().copied().collect(),
+            AssistedReplicationRole::Leaf => {
+                match active.iter().filter_map(|(_, r)| r.ar_ip).min() {
+                    Some(ar_ip) => BTreeSet::from([ar_ip]),
+                    None => active.iter().map(|(orig, _)| **orig).collect(),
+                }
+            }
+            _ => active.iter().map(|(orig, _)| **orig).collect(),
         }
     }
 
@@ -6054,7 +6082,10 @@ fn route_evpn_export_selected(
                     let ar_ip = pmsi
                         .filter(|p| p.is_assisted_replication())
                         .map(|p| p.endpoint);
-                    bgp.local_rib.evpn_flood.update_remote(vni, *orig, ar_ip);
+                    let prune = imet_whole_vtep_prune(pmsi);
+                    bgp.local_rib
+                        .evpn_flood
+                        .update_remote(vni, *orig, ar_ip, prune);
                 }
                 bgp.local_rib.evpn_flood.reconcile(vni, bgp.rib_client);
             } else {
@@ -12037,7 +12068,13 @@ impl Bgp {
         let bum = self.local_rib.evpn_flood.bum_tunnel;
         let role = self.local_rib.evpn_flood.role;
         let ar_ip = self.local_rib.evpn_flood.ar_ip;
-        let (pmsi, nexthop) = imet_pmsi_tunnel(bum, role, ar_ip, vtep_local, vni);
+        let prune_bm = self.local_rib.evpn_flood.prune_bm;
+        let prune_unknown = self.local_rib.evpn_flood.prune_unknown;
+        let (mut pmsi, nexthop) = imet_pmsi_tunnel(bum, role, ar_ip, vtep_local, vni);
+        // RFC 9574 Pruned-Flood-List: advertise our prune preferences so
+        // remote PEs can drop us from the BM / unknown-unicast flood lists.
+        pmsi.set_prune_bm(prune_bm);
+        pmsi.set_prune_unknown(prune_unknown);
         attr.pmsi_tunnel = Some(pmsi);
         attr.nexthop = Some(BgpNexthop::Evpn(nexthop));
 
@@ -12268,6 +12305,17 @@ fn rd_from_router_id_vni(router_id: Ipv4Addr, vni: u32) -> Option<RouteDistingui
 /// When `bum` selects an SR P2MP tree (RFC 9524) the AR role is bypassed:
 /// the local node is the tree Root, the Tree-ID is derived from the VNI,
 /// and the tunnel endpoint / next hop is the local VTEP.
+/// RFC 9574 Pruned-Flood-List: decide whether a received Type-3 IMET prunes
+/// its originator from OUR flood list. We honor the request only when the
+/// remote asks to be pruned from BOTH the BM and the unknown-unicast lists —
+/// a single kernel flood list per VNI can't express a per-category
+/// (BM-only / U-only) prune, so a partial request is not honored and the
+/// remote stays in the flood list.
+fn imet_whole_vtep_prune(pmsi: Option<&PmsiTunnel>) -> bool {
+    pmsi.map(|p| p.prune_bm() && p.prune_unknown())
+        .unwrap_or(false)
+}
+
 fn imet_pmsi_tunnel(
     bum: EvpnBumTunnel,
     role: AssistedReplicationRole,
@@ -12369,14 +12417,28 @@ mod evpn_flood_tests {
         s.parse().unwrap()
     }
 
+    /// An Ingress Replication PMSI with the given BM / U prune flags set.
+    fn pmsi(bm: bool, unknown: bool) -> PmsiTunnel {
+        let mut p = PmsiTunnel {
+            flags: 0,
+            tunnel_type: PmsiTunnel::TUNNEL_INGRESS_REPLICATION,
+            vni: 10,
+            endpoint: ip("10.0.0.1"),
+            tree_id: None,
+        };
+        p.set_prune_bm(bm);
+        p.set_prune_unknown(unknown);
+        p
+    }
+
     /// RNVE floods to every remote PE's IR-IP (originating IP), ignoring any
     /// AR-IP a replicator advertised.
     #[test]
     fn rnve_floods_all_remote_ir_ips() {
         let mut f = EvpnFloodState::default();
-        f.update_remote(100, ip("10.0.0.1"), None);
-        f.update_remote(100, ip("10.0.0.2"), None);
-        f.update_remote(100, ip("10.0.0.3"), Some(ip("10.0.0.254")));
+        f.update_remote(100, ip("10.0.0.1"), None, false);
+        f.update_remote(100, ip("10.0.0.2"), None, false);
+        f.update_remote(100, ip("10.0.0.3"), Some(ip("10.0.0.254")), false);
         assert_eq!(
             f.desired(100),
             BTreeSet::from([ip("10.0.0.1"), ip("10.0.0.2"), ip("10.0.0.3")])
@@ -12391,9 +12453,9 @@ mod evpn_flood_tests {
             role: AssistedReplicationRole::Leaf,
             ..Default::default()
         };
-        f.update_remote(100, ip("10.0.0.1"), None); // another leaf
-        f.update_remote(100, ip("10.0.0.10"), Some(ip("10.0.0.254"))); // replicator A
-        f.update_remote(100, ip("10.0.0.20"), Some(ip("10.0.0.253"))); // replicator B
+        f.update_remote(100, ip("10.0.0.1"), None, false); // another leaf
+        f.update_remote(100, ip("10.0.0.10"), Some(ip("10.0.0.254")), false); // replicator A
+        f.update_remote(100, ip("10.0.0.20"), Some(ip("10.0.0.253")), false); // replicator B
         assert_eq!(f.desired(100), BTreeSet::from([ip("10.0.0.253")]));
     }
 
@@ -12405,8 +12467,8 @@ mod evpn_flood_tests {
             role: AssistedReplicationRole::Leaf,
             ..Default::default()
         };
-        f.update_remote(100, ip("10.0.0.1"), None);
-        f.update_remote(100, ip("10.0.0.2"), None);
+        f.update_remote(100, ip("10.0.0.1"), None, false);
+        f.update_remote(100, ip("10.0.0.2"), None, false);
         assert_eq!(
             f.desired(100),
             BTreeSet::from([ip("10.0.0.1"), ip("10.0.0.2")])
@@ -12421,8 +12483,8 @@ mod evpn_flood_tests {
             role: AssistedReplicationRole::Leaf,
             ..Default::default()
         };
-        f.update_remote(100, ip("10.0.0.1"), None);
-        f.update_remote(100, ip("10.0.0.10"), Some(ip("10.0.0.254")));
+        f.update_remote(100, ip("10.0.0.1"), None, false);
+        f.update_remote(100, ip("10.0.0.10"), Some(ip("10.0.0.254")), false);
         assert_eq!(f.desired(100), BTreeSet::from([ip("10.0.0.254")]));
         f.remove_remote(100, ip("10.0.0.10"));
         assert_eq!(f.desired(100), BTreeSet::from([ip("10.0.0.1")]));
@@ -12432,8 +12494,8 @@ mod evpn_flood_tests {
     #[test]
     fn flood_state_is_per_vni() {
         let mut f = EvpnFloodState::default();
-        f.update_remote(100, ip("10.0.0.1"), None);
-        f.update_remote(200, ip("10.0.0.2"), None);
+        f.update_remote(100, ip("10.0.0.1"), None, false);
+        f.update_remote(200, ip("10.0.0.2"), None, false);
         assert_eq!(f.desired(100), BTreeSet::from([ip("10.0.0.1")]));
         assert_eq!(f.desired(200), BTreeSet::from([ip("10.0.0.2")]));
         assert!(f.desired(300).is_empty());
@@ -12444,7 +12506,7 @@ mod evpn_flood_tests {
     #[test]
     fn sr_p2mp_remotes_recorded_and_excluded_from_flood() {
         let mut f = EvpnFloodState::default();
-        f.update_remote(100, ip("10.0.0.1"), None); // plain IR remote
+        f.update_remote(100, ip("10.0.0.1"), None, false); // plain IR remote
         f.update_sr_remote(100, ip("10.0.0.7"), 4242); // SR P2MP tree remote
         // Only the IR remote floods via VXLAN; the SR P2MP Root does not.
         assert_eq!(f.desired(100), BTreeSet::from([ip("10.0.0.1")]));
@@ -12459,7 +12521,7 @@ mod evpn_flood_tests {
             bum_tunnel: EvpnBumTunnel::SrMplsP2mp,
             ..Default::default()
         };
-        f.update_remote(100, ip("10.0.0.1"), None);
+        f.update_remote(100, ip("10.0.0.1"), None, false);
         f.update_sr_remote(100, ip("10.0.0.2"), 100);
         // No VXLAN head-end FDB targets in SR P2MP mode.
         assert!(f.desired(100).is_empty());
@@ -12475,7 +12537,7 @@ mod evpn_flood_tests {
     #[test]
     fn replication_leaves_unions_ir_and_sr_remotes() {
         let mut f = EvpnFloodState::default();
-        f.update_remote(100, ip("10.0.0.1"), None);
+        f.update_remote(100, ip("10.0.0.1"), None, false);
         f.update_sr_remote(100, ip("10.0.0.7"), 9);
         assert_eq!(
             f.replication_leaves(100),
@@ -12490,7 +12552,7 @@ mod evpn_flood_tests {
     #[test]
     fn remote_tunnel_type_flip_is_exclusive() {
         let mut f = EvpnFloodState::default();
-        f.update_remote(100, ip("10.0.0.5"), None);
+        f.update_remote(100, ip("10.0.0.5"), None, false);
         assert_eq!(f.desired(100), BTreeSet::from([ip("10.0.0.5")]));
         assert!(f.sr_p2mp_remotes(100).is_empty());
 
@@ -12500,7 +12562,7 @@ mod evpn_flood_tests {
         assert_eq!(f.sr_p2mp_remotes(100), vec![(ip("10.0.0.5"), 7)]);
 
         // Flip back SR P2MP -> IR.
-        f.update_remote(100, ip("10.0.0.5"), None);
+        f.update_remote(100, ip("10.0.0.5"), None, false);
         assert_eq!(f.desired(100), BTreeSet::from([ip("10.0.0.5")]));
         assert!(f.sr_p2mp_remotes(100).is_empty());
 
@@ -12509,6 +12571,49 @@ mod evpn_flood_tests {
         f.remove_remote(100, ip("10.0.0.5"));
         assert!(f.desired(100).is_empty());
         assert!(f.sr_p2mp_remotes(100).is_empty());
+    }
+
+    /// RFC 9574 P-FL: a remote requesting whole-VTEP prune is dropped from
+    /// an RNVE's flood list.
+    #[test]
+    fn pruned_remote_excluded_from_rnve_flood() {
+        let mut f = EvpnFloodState::default();
+        f.update_remote(100, ip("10.0.0.1"), None, false);
+        f.update_remote(100, ip("10.0.0.2"), None, true);
+        assert_eq!(f.desired(100), BTreeSet::from([ip("10.0.0.1")]));
+    }
+
+    /// A pruned remote is also dropped from an AR-LEAF's full-IR fallback.
+    #[test]
+    fn pruned_remote_excluded_from_leaf_fallback() {
+        let mut f = EvpnFloodState {
+            role: AssistedReplicationRole::Leaf,
+            ..Default::default()
+        };
+        f.update_remote(100, ip("10.0.0.1"), None, false);
+        f.update_remote(100, ip("10.0.0.2"), None, true);
+        assert_eq!(f.desired(100), BTreeSet::from([ip("10.0.0.1")]));
+    }
+
+    /// Whole-VTEP prune is honored only when BOTH BM and U are set — a
+    /// per-category (BM-only / U-only) request is not expressible with one
+    /// kernel flood list per VNI, so it is not honored.
+    #[test]
+    fn whole_vtep_prune_requires_both_flags() {
+        assert!(!imet_whole_vtep_prune(None));
+        assert!(!imet_whole_vtep_prune(Some(&pmsi(false, false))));
+        assert!(
+            !imet_whole_vtep_prune(Some(&pmsi(true, false))),
+            "BM-only is not honored"
+        );
+        assert!(
+            !imet_whole_vtep_prune(Some(&pmsi(false, true))),
+            "U-only is not honored"
+        );
+        assert!(
+            imet_whole_vtep_prune(Some(&pmsi(true, true))),
+            "BM and U → whole-VTEP prune"
+        );
     }
 }
 

--- a/zebra-rs/src/config/manager.rs
+++ b/zebra-rs/src/config/manager.rs
@@ -2295,6 +2295,31 @@ mod yang_load_tests {
     }
 
     #[test]
+    fn bgp_evpn_pruned_flood_list_is_settable() {
+        use crate::config::ExecCode;
+        use crate::config::parse::{State, parse};
+        use libyang::to_entry;
+
+        let mut yang = YangStore::new();
+        yang.add_path(concat!(env!("CARGO_MANIFEST_DIR"), "/yang"));
+        yang.read_with_resolve("configure")
+            .expect("configure mode loads");
+        yang.identity_resolve();
+        let module = yang
+            .find_module("configure")
+            .expect("configure module present");
+        let entry = to_entry(&yang, module);
+
+        for path in [
+            "set router bgp afi-safi evpn pruned-flood-list broadcast-multicast true",
+            "set router bgp afi-safi evpn pruned-flood-list unknown-unicast true",
+        ] {
+            let (code, _comps, _state) = parse(path, entry.clone(), None, State::new());
+            assert_eq!(code, ExecCode::Success, "`{path}` must be a settable path");
+        }
+    }
+
+    #[test]
     fn bgp_evpn_igmp_mld_proxy_is_settable() {
         use crate::config::ExecCode;
         use crate::config::parse::{State, parse};

--- a/zebra-rs/yang/zebra-bgp-evpn.yang
+++ b/zebra-rs/yang/zebra-bgp-evpn.yang
@@ -116,6 +116,29 @@ module zebra-bgp-evpn {
          advertise a Tree-ID + Root identifier with the local node as the
          tree Root; they bypass Assisted Replication.";
     }
+    container pruned-flood-list {
+      description
+        "RFC 9574 Pruned-Flood-List: request that remote PEs prune this
+         node from the named BUM flood categories by setting the matching
+         flag in this node's Type-3 IMET PMSI Tunnel attribute. Honoring a
+         received request is whole-VTEP only on a Linux VXLAN dataplane
+         (one flood list per VNI), so a remote is dropped from the flood
+         list only when it prunes BOTH categories.";
+      leaf broadcast-multicast {
+        type boolean;
+        default false;
+        description
+          "Ask peers to prune this node from the broadcast/multicast flood
+           list (RFC 9574 BM flag).";
+      }
+      leaf unknown-unicast {
+        type boolean;
+        default false;
+        description
+          "Ask peers to prune this node from the unknown-unicast flood
+           list (RFC 9574 U flag).";
+      }
+    }
     container assisted-replication {
       description
         "RFC 9574 Optimized Ingress Replication (Assisted Replication)


### PR DESCRIPTION
## Summary

RFC 9574 (Optimized Ingress Replication for EVPN) **Phase 2** — Pruned-Flood-Lists. Originate the BM/U prune flags in our own Type-3 IMET, and honor a received whole-VTEP prune by dropping the remote from the flood list. Builds on #1476 / #1483 / #1488 / #1496.

### Config — `zebra-bgp-evpn.yang` + `bgp/config.rs`
- New `router bgp afi-safi evpn pruned-flood-list { broadcast-multicast; unknown-unicast }` container. Handlers write `prune_bm`/`prune_unknown` to `local_rib.evpn_flood` and re-originate our IMET.

### Origination — `bgp/route.rs`
- `evpn_originate_imet` applies the configured BM/U flags to the IMET PMSI (after `imet_pmsi_tunnel`, so it works for both ingress-replication and SR-P2MP tunnels).

### Reception — `bgp/route.rs`
- `RemoteImet { ar_ip, prune }` per remote; `imet_whole_vtep_prune()` honors a prune only when **both** BM and U are set — the single kernel flood list per VNI can't express a per-category (BM-only / U-only) prune, so a partial request is not honored. `desired()` drops pruned remotes.

## Test plan
- 8 flood-model tests (prune exclusion for RNVE + AR-LEAF fallback, BM-only/U-only-not-honored helper) + a `yang_load` test. `cargo test -p zebra-rs --bins`: **1334 passed, 0 failed**.
- `cargo clippy --workspace --all-targets -- -D warnings` clean; `cargo fmt` clean.
- **BDD `@bgp_evpn_ar`** extended with a whole-VTEP-prune scenario (z3 sets both flags → z1 drops z3 from its flood list, keeps z2). Re-run locally on the rebased tree: **1 feature, 1 passed, 0 failed** (CI excludes BDD).

Rebased onto current `main` (resolved a clean merge with the concurrently-landed SR-P2MP / `RemoteImet` evolution).

Generated with [Claude Code](https://claude.com/claude-code)