### PR TITLE
offload: tc-evpn-replicate eBPF TC/clsact skeleton (DP1)

### DIFF
--- a/offload/tc-evpn-replicate/.cargo/config.toml
+++ b/offload/tc-evpn-replicate/.cargo/config.toml
@@ -1,0 +1,5 @@
+# Adding the clsact qdisc and attaching/detaching a TC BPF classifier needs
+# CAP_NET_ADMIN, so `cargo run` is wrapped in sudo. `-E` preserves the
+# environment (e.g. RUST_LOG) for the binary.
+[target."cfg(all())"]
+runner = "sudo -E"

--- a/offload/tc-evpn-replicate/.gitignore
+++ b/offload/tc-evpn-replicate/.gitignore
@@ -1,0 +1,2 @@
+# The root .gitignore only anchors `/target`; ignore this nested build dir too.
+/target

--- a/offload/tc-evpn-replicate/Cargo.toml
+++ b/offload/tc-evpn-replicate/Cargo.toml
@@ -1,0 +1,35 @@
+[workspace]
+resolver = "2"
+members = ["loader", "ebpf"]
+# `cargo build` (no --workspace) builds only the userspace loader. The loader's
+# build.rs (aya-build) compiles the `ebpf` crate for the `bpfel-unknown-none`
+# target via `rustup run nightly cargo ... -Z build-std=core`, so the eBPF crate
+# must NOT be built for the host as a normal member.
+default-members = ["loader"]
+
+[workspace.package]
+license = "MIT OR Apache-2.0"
+edition = "2024"
+
+# aya is pulled from git to match the current aya-template build glue
+# (aya_build::Package / build_ebpf(.., Toolchain) API on `main`), same as the
+# sibling xdp-bfd-echo offload. Pin a rev for fully reproducible builds.
+[workspace.dependencies]
+aya = { git = "https://github.com/aya-rs/aya", default-features = false }
+aya-build = { git = "https://github.com/aya-rs/aya", default-features = false }
+aya-ebpf = { git = "https://github.com/aya-rs/aya", default-features = false }
+
+anyhow = { version = "1", default-features = false }
+cargo_metadata = { version = "0.23.0", default-features = false }
+# clap currently needs the `std` feature to build.
+clap = { version = "4.5.20", default-features = false, features = ["std"] }
+env_logger = { version = "0.11.5", default-features = false }
+libc = { version = "0.2.159", default-features = false }
+log = { version = "0.4.22", default-features = false }
+tokio = { version = "1.40.0", default-features = false }
+which = { version = "6.0.0", default-features = false }
+
+[profile.release.package.tc-evpn-replicate-ebpf]
+debug = 2
+codegen-units = 1
+strip = false

--- a/offload/tc-evpn-replicate/README.md
+++ b/offload/tc-evpn-replicate/README.md
@@ -1,0 +1,44 @@
+# tc-evpn-replicate
+
+eBPF **TC/clsact** dataplane for EVPN BUM replication over an **RFC 9524 SR
+replication segment** (the SR-MPLS / SRv6 P2MP tree signalled by EVPN Type-3
+IMET, `draft-ietf-bess-mvpn-evpn-sr-p2mp`).
+
+## Why TC, not XDP
+
+The stock Linux kernel cannot forward RFC 9524 natively — there is no
+`End.Replicate` seg6local action, no MPLS P2MP/multicast, and no `End.DT2M` for
+the L2 leaf flood. Replication means *one copy per downstream branch, each with
+a different rewritten header*. The TC layer can express that with
+`bpf_clone_redirect` in a loop (mutating the skb between clones); XDP cannot
+clone per-copy. So this is a `#[classifier]` program on `clsact`, unlike the
+sibling [`xdp-bfd-echo`](../xdp-bfd-echo) offload.
+
+Planned roles (all clsact-attached):
+- **root** (egress): `H.Encaps` each copy toward a downstream SID / leaf;
+- **bud** (ingress): match the local Replication-SID, clone+rewrite per branch
+  (`End.Replicate`);
+- **leaf** (ingress): match the local `End.DT2M` SID, strip the outer IPv6+SRH,
+  redirect the inner frame to the bridge for native BUM flooding.
+
+The branch/leaf table is a BPF map the loader fills from the BGP control plane
+(`ReplSeg`, fed by `EvpnFloodState::replication_leaves`).
+
+## Status
+
+**Skeleton only.** The classifier loads and attaches but passes every frame
+through (`TC_ACT_PIPE`); the replication logic and maps are follow-up slices.
+
+## Build / run
+
+Like `xdp-bfd-echo`, this is a self-contained workspace, **excluded** from the
+root `cargo` workspace (it needs the nightly toolchain + `bpf-linker`, which the
+stable CI gate lacks). It is not built or tested by CI.
+
+```sh
+rustup toolchain install nightly --component rust-src
+cargo install bpf-linker                 # needs LLVM
+cd offload/tc-evpn-replicate
+cargo build                              # builds loader; build.rs compiles the eBPF object
+cargo run -- --iface eth0 --direction ingress   # runs under `sudo -E` (CAP_NET_ADMIN)
+```

--- a/offload/tc-evpn-replicate/ebpf/Cargo.toml
+++ b/offload/tc-evpn-replicate/ebpf/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "tc-evpn-replicate-ebpf"
+version = "0.1.0"
+edition.workspace = true
+license.workspace = true
+
+[dependencies]
+aya-ebpf = { workspace = true }
+
+[build-dependencies]
+# Build fails fast with a clear error if bpf-linker is not on $PATH.
+which = { workspace = true }
+
+[[bin]]
+name = "tc-evpn-replicate"
+path = "src/main.rs"
+
+# No `[profile]` here: the eBPF object is built by the loader's build.rs via
+# aya-build, which applies the `[profile.release.package.*]` settings declared in
+# the workspace root manifest.

--- a/offload/tc-evpn-replicate/ebpf/build.rs
+++ b/offload/tc-evpn-replicate/ebpf/build.rs
@@ -1,0 +1,13 @@
+use which::which;
+
+/// Building this crate has an undeclared dependency on the `bpf-linker` binary.
+/// This build script makes the failure mode obvious (a clear "not found" error
+/// instead of a confusing link failure) and asks cargo to rebuild when the
+/// resolved `bpf-linker` path changes.
+fn main() {
+    let bpf_linker = which("bpf-linker").expect(
+        "bpf-linker not found on $PATH — install it with `cargo install bpf-linker` \
+         (needs LLVM; see this crate's README)",
+    );
+    println!("cargo:rerun-if-changed={}", bpf_linker.to_str().unwrap());
+}

--- a/offload/tc-evpn-replicate/ebpf/src/lib.rs
+++ b/offload/tc-evpn-replicate/ebpf/src/lib.rs
@@ -1,0 +1,5 @@
+#![no_std]
+
+// This file exists only to provide a library target. Cargo builds it for the
+// host as a (cache-tracking) build-dependency of the loader, while aya-build
+// compiles the binary target (`src/main.rs`) for `bpfel-unknown-none`.

--- a/offload/tc-evpn-replicate/ebpf/src/main.rs
+++ b/offload/tc-evpn-replicate/ebpf/src/main.rs
@@ -1,0 +1,46 @@
+#![no_std]
+#![no_main]
+
+//! EVPN BUM replication dataplane (RFC 9524 SR replication segment) — eBPF
+//! TC/clsact skeleton.
+//!
+//! This is the load-and-attach skeleton for the SR P2MP / RFC 9524 replication
+//! forwarder that the stock Linux kernel cannot do natively: there is no
+//! `End.Replicate` seg6local action, no MPLS P2MP, and no `End.DT2M` for the L2
+//! leaf flood. Replication needs a *copy per downstream branch, each with a
+//! different rewritten header* — which only the TC layer can express
+//! (`bpf_clone_redirect` in a loop, mutating the skb between clones). XDP has no
+//! per-copy clone, so this is a `#[classifier]` (clsact) program, unlike the
+//! sibling `xdp-bfd-echo` offload.
+//!
+//! Planned roles, all attached here via clsact:
+//!   * root (egress)  — H.Encaps each copy toward a downstream SID / leaf;
+//!   * bud  (ingress) — match the local Replication-SID, clone+rewrite per
+//!                      branch (`End.Replicate`);
+//!   * leaf (ingress) — match the local End.DT2M SID, strip the outer
+//!                      IPv6+SRH, redirect the inner frame to the bridge.
+//! The branch/leaf state comes from a BPF map the loader fills from the BGP
+//! control plane (`ReplSeg`, fed by `EvpnFloodState::replication_leaves`).
+//!
+//! For now every frame is passed through untouched (`TC_ACT_PIPE`); the
+//! replication logic and maps land in follow-up slices.
+
+use aya_ebpf::{bindings::TC_ACT_PIPE, macros::classifier, programs::TcContext};
+
+#[classifier]
+pub fn tc_evpn_replicate(_ctx: TcContext) -> i32 {
+    // No-op skeleton: hand every frame back to the stack unchanged.
+    TC_ACT_PIPE
+}
+
+#[cfg(not(test))]
+#[panic_handler]
+fn panic(_info: &core::panic::PanicInfo) -> ! {
+    loop {}
+}
+
+// Replication will use GPL-only helpers (bpf_clone_redirect, bpf_redirect),
+// so declare a GPL-compatible license up front.
+#[unsafe(link_section = "license")]
+#[unsafe(no_mangle)]
+static LICENSE: [u8; 13] = *b"Dual MIT/GPL\0";

--- a/offload/tc-evpn-replicate/loader/Cargo.toml
+++ b/offload/tc-evpn-replicate/loader/Cargo.toml
@@ -1,0 +1,36 @@
+[package]
+name = "tc-evpn-replicate"
+version = "0.1.0"
+edition.workspace = true
+license.workspace = true
+
+[dependencies]
+anyhow = { workspace = true, default-features = true }
+aya = { workspace = true }
+clap = { workspace = true, features = ["derive"] }
+env_logger = { workspace = true }
+libc = { workspace = true }
+log = { workspace = true }
+tokio = { workspace = true, features = [
+    "macros",
+    "rt",
+    "rt-multi-thread",
+    "net",
+    "signal",
+    "time",
+    "io-util",
+    "io-std",
+] }
+
+[build-dependencies]
+anyhow = { workspace = true }
+aya-build = { workspace = true }
+cargo_metadata = { workspace = true }
+# Declared so cargo tracks the eBPF crate for cache invalidation. It is actually
+# compiled for `bpfel-unknown-none` by build.rs (aya-build), not as a normal
+# host build-dependency — see the aya-template for the rationale.
+tc-evpn-replicate-ebpf = { path = "../ebpf" }
+
+[[bin]]
+name = "tc-evpn-replicate"
+path = "src/main.rs"

--- a/offload/tc-evpn-replicate/loader/build.rs
+++ b/offload/tc-evpn-replicate/loader/build.rs
@@ -1,0 +1,31 @@
+use anyhow::{Context as _, anyhow};
+use aya_build::Toolchain;
+
+/// Compile the `tc-evpn-replicate-ebpf` crate for the `bpfel-unknown-none`
+/// target and emit the object into `OUT_DIR`, where `main.rs` embeds it via
+/// `include_bytes_aligned!`. `Toolchain::default()` resolves to `nightly`, and
+/// aya-build invokes it with `-Z build-std=core`.
+fn main() -> anyhow::Result<()> {
+    let cargo_metadata::Metadata { packages, .. } = cargo_metadata::MetadataCommand::new()
+        .no_deps()
+        .exec()
+        .context("MetadataCommand::exec")?;
+    let ebpf_package = packages
+        .into_iter()
+        .find(|cargo_metadata::Package { name, .. }| name.as_str() == "tc-evpn-replicate-ebpf")
+        .ok_or_else(|| anyhow!("tc-evpn-replicate-ebpf package not found"))?;
+    let cargo_metadata::Package {
+        name,
+        manifest_path,
+        ..
+    } = ebpf_package;
+    let ebpf_package = aya_build::Package {
+        name: name.as_str(),
+        root_dir: manifest_path
+            .parent()
+            .ok_or_else(|| anyhow!("no parent for {manifest_path}"))?
+            .as_str(),
+        ..Default::default()
+    };
+    aya_build::build_ebpf([ebpf_package], Toolchain::default())
+}

--- a/offload/tc-evpn-replicate/loader/src/main.rs
+++ b/offload/tc-evpn-replicate/loader/src/main.rs
@@ -1,0 +1,72 @@
+//! Userspace loader for the EVPN BUM replication TC/clsact dataplane
+//! (RFC 9524 SR replication segment) — skeleton.
+//!
+//! Loads the eBPF object (embedded at build time) and attaches the
+//! `tc_evpn_replicate` classifier to an interface's `clsact` qdisc. The
+//! root/bud `End.Replicate` and leaf `End.DT2M` paths — and the replication
+//! map the BGP control plane (`ReplSeg`) fills — land in follow-up slices.
+//! Runs until Ctrl-C / SIGTERM.
+
+use anyhow::Context as _;
+use aya::programs::{SchedClassifier, TcAttachType, tc};
+use clap::Parser;
+use log::{debug, info};
+use tokio::signal;
+
+#[derive(Debug, Parser)]
+#[command(about = "EVPN BUM replication (RFC 9524 SR P2MP) TC/clsact dataplane")]
+struct Opt {
+    /// Interface to attach the replicator to (the SR underlay-facing NIC).
+    #[clap(short, long, default_value = "eth0")]
+    iface: String,
+    /// clsact direction: `ingress` (bud/leaf decap) or `egress` (root encap).
+    #[clap(short, long, default_value = "ingress")]
+    direction: String,
+}
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    let Opt { iface, direction } = Opt::parse();
+    env_logger::init();
+
+    // Bump the memlock rlimit. Needed on older kernels that don't use the
+    // memcg-based accounting; see https://lwn.net/Articles/837122/.
+    let rlim = libc::rlimit {
+        rlim_cur: libc::RLIM_INFINITY,
+        rlim_max: libc::RLIM_INFINITY,
+    };
+    let ret = unsafe { libc::setrlimit(libc::RLIMIT_MEMLOCK, &rlim) };
+    if ret != 0 {
+        debug!("remove limit on locked memory failed, ret is: {ret}");
+    }
+
+    // Embed the eBPF object built by build.rs and load it (the object's name is
+    // the eBPF crate's `[[bin]]` name, `tc-evpn-replicate`).
+    let mut ebpf = aya::Ebpf::load(aya::include_bytes_aligned!(concat!(
+        env!("OUT_DIR"),
+        "/tc-evpn-replicate"
+    )))?;
+
+    // clsact hosts both the ingress and egress BPF classifiers. Adding it is
+    // idempotent for our purposes: tolerate "already exists".
+    if let Err(e) = tc::qdisc_add_clsact(&iface) {
+        debug!("qdisc_add_clsact({iface}): {e} (already present?)");
+    }
+
+    let attach = match direction.as_str() {
+        "egress" => TcAttachType::Egress,
+        _ => TcAttachType::Ingress,
+    };
+
+    let program: &mut SchedClassifier = ebpf
+        .program_mut("tc_evpn_replicate")
+        .context("classifier 'tc_evpn_replicate' not found in object")?
+        .try_into()?;
+    program.load()?;
+    program.attach(&iface, attach)?;
+
+    info!("tc_evpn_replicate attached to {iface} ({direction}); waiting for Ctrl-C");
+    signal::ctrl_c().await?;
+    info!("Exiting");
+    Ok(())
+}


### PR DESCRIPTION
## Summary

First **dataplane** slice (DP1) of the RFC 9524 (Segment Routing Replication) for EVPN BUM plan — after the control plane (#1487/#1491/#1494/#1498/#1500). A new self-contained, **workspace-excluded** offload crate `offload/tc-evpn-replicate`, mirroring `offload/xdp-bfd-echo` but using a **TC/clsact `#[classifier]`** instead of XDP.

### Why TC, not XDP

The stock Linux kernel cannot forward RFC 9524 natively (no `End.Replicate` seg6local action, no MPLS P2MP, no `End.DT2M` for the L2 leaf flood). Replication means *one copy per downstream branch, each with a different rewritten header* — expressible only at the TC layer (`bpf_clone_redirect` in a loop, mutating the skb between clones). XDP has no per-copy clone. Hence a `#[classifier]` on `clsact`.

### What's here

Skeleton only: the classifier loads and attaches to a `clsact` qdisc (aya `SchedClassifier` + `TcAttachType`, `tc::qdisc_add_clsact`) and passes every frame through (`TC_ACT_PIPE`). Planned roles (all clsact-attached): root (egress) `H.Encaps`, bud (ingress) `End.Replicate`, leaf (ingress) `End.DT2M` → bridge. The branch/leaf table will be a BPF map the loader fills from the BGP control plane (`ReplSeg`, fed by `EvpnFloodState::replication_leaves`).

## Test

- **Build-verified locally**: `cd offload/tc-evpn-replicate && cargo build` compiles both the eBPF object (nightly + `bpf-linker`, `bpfel-unknown-none`) and the loader binary — confirming the novel TC/clsact build + aya attach API surface.
- **Not built by CI**: `offload/*` is excluded from the root workspace (it needs the nightly toolchain the stable gate lacks), same as `xdp-bfd-echo`. The main-workspace fmt/clippy/test gates are unaffected (no main-crate changes).
- Runtime attach needs root + a veth; deferred to the functional slices.

🤖 Generated with [Claude Code](https://claude.com/claude-code)