### PR TITLE
bgp: EVPN SMET selective MDB dataplane install (RFC 9251)

### DIFF
--- a/docs/design/bgp-evpn-igmp-mld-proxy.md
+++ b/docs/design/bgp-evpn-igmp-mld-proxy.md
@@ -31,7 +31,7 @@ before citing.
 | 2     | Multicast Flags Extended Community      | **done** |
 | 3     | IMET (Type 3) capability signaling      | **done** |
 | 4     | SMET origination from kernel MDB snoop  | **done** |
-| 5     | SMET reception → selective dataplane    | planned  |
+| 5     | SMET reception → selective dataplane    | **done** |
 | 6     | Show + BDD + docs                       | planned  |
 | —     | Type 7/8 multihoming synch              | deferred |
 
@@ -269,15 +269,31 @@ overload; the rename is cosmetic and can come with Phase 5. SMET flags
 are a per-family approximation, not derived from the kernel MDB
 group-mode (follow-up). No selective dataplane yet (Phase 5).
 
-### Phase 5 — SMET reception → selective dataplane
-- **5a (fib):** real `bridge mdb add/del dev <vxlan> grp G [src S]
-  dst <remote-VTEP> permanent` via `RTM_NEWMDB/DELMDB` *send* (proper
-  `br_mdb_entry` + MDBE attrs) — distinct from the zero-MAC FDB flood row.
-- **5b (bgp):** on a best-path Type-6 whose EVI RT matches a local VNI,
-  install selective MDB toward the originator's VTEP; withdraw removes it.
-  Reconcile with the Type-3 flood list: replicate `(x,G)` selectively only
-  to VTEPs that advertised **both** the Multicast Flags EC **and** a
-  matching SMET; others still flood (RFC 9251 IR filtering).
+### Phase 5 — SMET reception → selective dataplane — **done**
+- **5a (fib `handle.rs`):** `mdb_install(bridge, port, vid, group, source,
+  dst, add)` emits `RTM_{NEW,DEL}MDB` with the `MDBA_SET_ENTRY`
+  (`br_mdb_entry`) + `MDBA_SET_ENTRY_ATTRS` (`MDBE_ATTR_SOURCE` +
+  `MDBE_ATTR_DST`) layout, via the fork's `MdbMessage` +
+  `MdbAttribute::Other` (no fork change needed). Byte-layout unit tests
+  (`br_mdb_entry_v4_layout`, `…_v6_proto`, `mdb_nla_bytes_*`). Needed the
+  one-line `netlink-packet-utils = "0.5.2"` dep (unifies with the fork's)
+  to name `DefaultNla`.
+- **5b (rib):** `rib::Message::SmetInstall/SmetRemove`; `smet_install`
+  resolves the VNI to its local `(bridge, vxlan-port)` via
+  `vni_to_bridge_vxlan` and calls `mdb_install` (vid 0; per-VLAN is a
+  follow-up).
+- **5c (bgp `route_evpn_export_selected`):** the Smet arms now send
+  `SmetInstall` (best-path, non-Originated, dst = SMET `orig`) /
+  `SmetRemove` (withdraw), VNI from the EVI RT.
+
+**No explicit flood reconciliation needed:** a snooping bridge forwards
+*registered* groups (those with an MDB entry) only to the MDB dsts and
+floods only *unregistered* groups over the Type-3 zero-MAC FDB list — so
+installing received SMET as MDB entries yields selective delivery, and a
+non-proxy PE (which never sends SMET) keeps getting the flood. The
+Multicast Flags EC gate (skip sending selective toward non-proxy PEs) is
+therefore an optimization, deferred. **Live forwarding is validated in
+Phase 6's BDD** (byte layout is unit-tested here).
 
 ### Phase 6 — Show + BDD + docs
 - `show bgp evpn` rendering for Type-6 (src/grp/orig/flags); extend

--- a/zebra-rs/Cargo.toml
+++ b/zebra-rs/Cargo.toml
@@ -82,6 +82,9 @@ rtnetlink = { git = "https://github.com/zebra-rs/rtnetlink", rev = "2d7b1830e9bd
 netlink-sys = "0.8"
 netlink-packet-route = { git = "https://github.com/zebra-rs/netlink-packet-route", branch = "seg6" }
 netlink-packet-core = "0.7"
+# Matches the version netlink-packet-route (seg6) pins, so DefaultNla
+# unifies — used to emit kernel bridge MDB SET entries (EVPN SMET).
+netlink-packet-utils = "0.5.2"
 futures = "0.3"
 scan_fmt = "0.2"
 procfs = "0.18"

--- a/zebra-rs/src/bgp/route.rs
+++ b/zebra-rs/src/bgp/route.rs
@@ -6014,11 +6014,18 @@ fn route_evpn_export_selected(
                     }
                 }
             }
-            EvpnPrefix::Smet { .. } => {
-                // TODO(phase5): withdraw the selective kernel MDB entry
-                // (`bridge mdb del grp G dst <originator-VTEP>`). The
-                // selective-forwarding dataplane is not wired yet, so a
-                // received SMET withdraw is a no-op beyond Loc-RIB removal.
+            EvpnPrefix::Smet { src, grp, orig, .. } => {
+                // Remove the selective kernel MDB entry toward the
+                // originator's VTEP (the SMET `orig`). VNI comes from the
+                // withdrawn path's EVI RT.
+                if let Some(vni) = extract_vni_from_attr(&wd.attr) {
+                    let _ = bgp.rib_client.send(rib::Message::SmetRemove {
+                        vni,
+                        group: *grp,
+                        source: *src,
+                        dst: *orig,
+                    });
+                }
             }
             // RFC 9572 A-D routes have no VXLAN dataplane action — withdraw
             // is a control-plane no-op.
@@ -6115,12 +6122,22 @@ fn route_evpn_export_selected(
                 }
             }
         }
-        EvpnPrefix::Smet { .. } => {
-            // TODO(phase5): install the selective kernel MDB entry
-            // (`bridge mdb add grp G [src S] dst <originator-VTEP>`) so
-            // the ingress PE replicates (x,G) only toward PEs that asked.
-            // The received SMET is already in the Loc-RIB and `show bgp
-            // evpn`; the selective-forwarding dataplane lands in Phase 5.
+        EvpnPrefix::Smet { src, grp, orig, .. } => {
+            // Install a selective kernel MDB entry toward the originator's
+            // VTEP (the SMET `orig`) so this PE delivers (x,G) only to the
+            // asking PE — the snooping bridge forwards the registered
+            // group selectively instead of flooding. Skip our own
+            // originated SMET; VNI comes from the EVI RT.
+            if best.typ != BgpRibType::Originated
+                && let Some(vni) = extract_vni_from_attr(&best.attr)
+            {
+                let _ = bgp.rib_client.send(rib::Message::SmetInstall {
+                    vni,
+                    group: *grp,
+                    source: *src,
+                    dst: *orig,
+                });
+            }
         }
         // RFC 9572 Per-Region I-PMSI / S-PMSI / Leaf A-D have no VXLAN
         // dataplane action in the current codec-only phase — install is a

--- a/zebra-rs/src/fib/netlink/handle.rs
+++ b/zebra-rs/src/fib/netlink/handle.rs
@@ -2569,6 +2569,86 @@ impl FibHandle {
         }
     }
 
+    /// Install (`add`) or remove (`!add`) a selective EVPN multicast
+    /// forwarding entry in the kernel bridge MDB: forward `group`
+    /// (optionally `source`-filtered) out the VXLAN `port_ifindex`
+    /// toward the remote VTEP `dst`. Built from a received Type-6 SMET
+    /// route — the kernel snooping bridge then delivers that registered
+    /// group selectively to `dst` instead of flooding (RFC 9251).
+    /// `bridge_ifindex` is the bridge (`dev`); `port_ifindex` its VXLAN
+    /// slave (`port`). Emits `RTM_{NEW,DEL}MDB` with the
+    /// `MDBA_SET_ENTRY` / `MDBA_SET_ENTRY_ATTRS` layout
+    /// (linux/if_bridge.h).
+    pub async fn mdb_install(
+        &self,
+        bridge_ifindex: u32,
+        port_ifindex: u32,
+        vid: u16,
+        group: IpAddr,
+        source: Option<IpAddr>,
+        dst: IpAddr,
+        add: bool,
+    ) {
+        use netlink_packet_route::RouteNetlinkMessage;
+        use netlink_packet_route::mdb::{MdbAttribute, MdbHeader, MdbMessage};
+        use netlink_packet_utils::nla::DefaultNla;
+
+        let entry = br_mdb_entry_bytes(port_ifindex, vid, group);
+        let mut nested = Vec::new();
+        if let Some(src) = source {
+            nested.extend_from_slice(&mdb_nla_bytes(MDBE_ATTR_SOURCE, &ip_octets(src)));
+        }
+        nested.extend_from_slice(&mdb_nla_bytes(MDBE_ATTR_DST, &ip_octets(dst)));
+
+        let msg = MdbMessage {
+            header: MdbHeader {
+                family: AddressFamily::Bridge,
+                index: bridge_ifindex,
+            },
+            attributes: vec![
+                MdbAttribute::Other(DefaultNla::new(MDBA_SET_ENTRY, entry.to_vec())),
+                MdbAttribute::Other(DefaultNla::new(MDBA_SET_ENTRY_ATTRS, nested)),
+            ],
+        };
+
+        let req = if add {
+            let mut r = NetlinkMessage::from(RouteNetlinkMessage::NewMdb(msg));
+            r.header.flags = NLM_F_REQUEST | NLM_F_ACK | NLM_F_CREATE | NLM_F_REPLACE;
+            r
+        } else {
+            let mut r = NetlinkMessage::from(RouteNetlinkMessage::DelMdb(msg));
+            r.header.flags = NLM_F_REQUEST | NLM_F_ACK;
+            r
+        };
+
+        if fib_l2_mdb() {
+            tracing::info!(
+                "mdb_install(add={}): br {} port {} grp {} src {:?} dst {}",
+                add,
+                bridge_ifindex,
+                port_ifindex,
+                group,
+                source,
+                dst
+            );
+        }
+
+        let mut response = self.handle.clone().request(req).unwrap();
+        while let Some(rsp) = response.next().await {
+            if let NetlinkPayload::Error(e) = rsp.payload
+                && e.code.is_some()
+            {
+                tracing::info!(
+                    "mdb_install: netlink error grp {} dst {} (add={}): {}",
+                    group,
+                    dst,
+                    add,
+                    e
+                );
+            }
+        }
+    }
+
     /// Delete EVPN MAC entry from bridge FDB
     pub async fn mac_del(&self, vni: u32, mac: &MacAddr) {
         // Mirror `mac_add` — skip when no local VXLAN registered for
@@ -3106,6 +3186,59 @@ fn process_msg(msg: NetlinkMessage<RouteNetlinkMessage>, tx: UnboundedSender<Fib
 /// statically-added L2 MAC groups carry no IGMP/MLD membership and are
 /// skipped. The bridge ifindex (`header.index`) is mapped to a VNI by
 /// the RIB.
+// MDB SET request attribute kinds (linux/if_bridge.h). The top-level
+// container is MDBA_SET_ENTRY (the br_mdb_entry struct) + the nested
+// MDBA_SET_ENTRY_ATTRS holding per-entry MDBE_ATTR_* attributes.
+const MDBA_SET_ENTRY: u16 = 1;
+const MDBA_SET_ENTRY_ATTRS: u16 = 2;
+const MDBE_ATTR_SOURCE: u16 = 1;
+const MDBE_ATTR_DST: u16 = 5;
+const MDB_PERMANENT: u8 = 1;
+const ETH_P_IP_BE: u16 = 0x0800;
+const ETH_P_IPV6_BE: u16 = 0x86dd;
+
+/// Build a `struct br_mdb_entry` (28 octets) for an MDB SET request.
+/// Integer fields (`ifindex`, `vid`) are host byte order; the address
+/// union and `proto` are network byte order.
+fn br_mdb_entry_bytes(port_ifindex: u32, vid: u16, group: IpAddr) -> [u8; 28] {
+    let mut b = [0u8; 28];
+    b[0..4].copy_from_slice(&port_ifindex.to_ne_bytes());
+    b[4] = MDB_PERMANENT;
+    b[6..8].copy_from_slice(&vid.to_ne_bytes());
+    match group {
+        IpAddr::V4(g) => {
+            b[8..12].copy_from_slice(&g.octets());
+            b[24..26].copy_from_slice(&ETH_P_IP_BE.to_be_bytes());
+        }
+        IpAddr::V6(g) => {
+            b[8..24].copy_from_slice(&g.octets());
+            b[24..26].copy_from_slice(&ETH_P_IPV6_BE.to_be_bytes());
+        }
+    }
+    b
+}
+
+/// Encode one netlink attribute (host-endian header) with 4-byte tail
+/// padding: `[len u16][kind u16][value][pad]`.
+fn mdb_nla_bytes(kind: u16, value: &[u8]) -> Vec<u8> {
+    let len = 4 + value.len();
+    let mut out = Vec::with_capacity((len + 3) & !3);
+    out.extend_from_slice(&(len as u16).to_ne_bytes());
+    out.extend_from_slice(&kind.to_ne_bytes());
+    out.extend_from_slice(value);
+    while out.len() % 4 != 0 {
+        out.push(0);
+    }
+    out
+}
+
+fn ip_octets(ip: IpAddr) -> Vec<u8> {
+    match ip {
+        IpAddr::V4(v) => v.octets().to_vec(),
+        IpAddr::V6(v) => v.octets().to_vec(),
+    }
+}
+
 pub(crate) fn mdb_entries_from_msg(
     msg: &netlink_packet_route::mdb::MdbMessage,
 ) -> Vec<FibMdbEntry> {
@@ -3154,6 +3287,40 @@ mod tests {
             "RTM_NEWNEXTHOP decode regressed: {:?}",
             parsed.err()
         );
+    }
+
+    #[test]
+    fn br_mdb_entry_v4_layout() {
+        use std::net::Ipv4Addr;
+        let b = br_mdb_entry_bytes(7, 0, IpAddr::V4(Ipv4Addr::new(239, 1, 1, 1)));
+        assert_eq!(b.len(), 28);
+        assert_eq!(&b[0..4], &7u32.to_ne_bytes(), "port ifindex (host order)");
+        assert_eq!(b[4], 1, "MDB_PERMANENT");
+        assert_eq!(&b[6..8], &0u16.to_ne_bytes(), "vid");
+        assert_eq!(&b[8..12], &[239, 1, 1, 1], "group v4");
+        assert_eq!(&b[24..26], &[0x08, 0x00], "proto ETH_P_IP (big-endian)");
+    }
+
+    #[test]
+    fn br_mdb_entry_v6_proto() {
+        use std::net::Ipv6Addr;
+        let g: Ipv6Addr = "ff05::1:3".parse().unwrap();
+        let b = br_mdb_entry_bytes(3, 10, IpAddr::V6(g));
+        assert_eq!(&b[6..8], &10u16.to_ne_bytes(), "vid 10");
+        assert_eq!(&b[8..24], &g.octets(), "group v6");
+        assert_eq!(&b[24..26], &[0x86, 0xdd], "proto ETH_P_IPV6");
+    }
+
+    #[test]
+    fn mdb_nla_bytes_header_and_pad() {
+        // IPv4 value: [len=8][kind][4 bytes] — already 4-aligned.
+        let n = mdb_nla_bytes(MDBE_ATTR_SOURCE, &[192, 0, 2, 1]);
+        assert_eq!(n.len(), 8);
+        assert_eq!(&n[0..2], &8u16.to_ne_bytes(), "nla len");
+        assert_eq!(&n[2..4], &MDBE_ATTR_SOURCE.to_ne_bytes(), "nla kind");
+        assert_eq!(&n[4..8], &[192, 0, 2, 1], "value");
+        // IPv6 value: 4 + 16 = 20, aligned.
+        assert_eq!(mdb_nla_bytes(MDBE_ATTR_DST, &[0u8; 16]).len(), 20);
     }
 
     #[test]

--- a/zebra-rs/src/rib/inst.rs
+++ b/zebra-rs/src/rib/inst.rs
@@ -273,6 +273,23 @@ pub enum Message {
         source: Option<IpAddr>,
         ifindex: u32,
     },
+    /// Install (`SmetInstall`) or remove (`SmetRemove`) a selective EVPN
+    /// multicast forwarding entry from a received Type-6 SMET route:
+    /// deliver `(source, group)` in `vni` toward the remote VTEP `dst`
+    /// (the SMET originator). The RIB resolves `vni` to its local
+    /// `(bridge, vxlan-port)` and programs the kernel bridge MDB.
+    SmetInstall {
+        vni: u32,
+        group: IpAddr,
+        source: Option<IpAddr>,
+        dst: IpAddr,
+    },
+    SmetRemove {
+        vni: u32,
+        group: IpAddr,
+        source: Option<IpAddr>,
+        dst: IpAddr,
+    },
     Shutdown {
         tx: oneshot::Sender<()>,
     },
@@ -2182,6 +2199,22 @@ impl Rib {
             } => {
                 self.mdb_del(vni, group, source, ifindex).await;
             }
+            Message::SmetInstall {
+                vni,
+                group,
+                source,
+                dst,
+            } => {
+                self.smet_install(vni, group, source, dst, true).await;
+            }
+            Message::SmetRemove {
+                vni,
+                group,
+                source,
+                dst,
+            } => {
+                self.smet_install(vni, group, source, dst, false).await;
+            }
             Message::RedistAdd {
                 proto,
                 afi,
@@ -2504,6 +2537,40 @@ impl Rib {
     async fn mdb_del(&mut self, vni: u32, group: IpAddr, source: Option<IpAddr>, ifindex: u32) {
         self.vtep_table.remove(&(vni, group));
         self.fib_handle.mdb_del(vni, group, source, ifindex).await;
+    }
+
+    /// Resolve a VNI to its local `(bridge ifindex, VXLAN-port ifindex)`
+    /// — the VXLAN link carrying `vni` is the bridge port, and its
+    /// `master` is the bridge. `None` when the VNI has no local VXLAN
+    /// enslaved to a bridge.
+    fn vni_to_bridge_vxlan(&self, vni: u32) -> Option<(u32, u32)> {
+        self.links.iter().find_map(|(ifindex, link)| {
+            if link.vni == Some(vni) {
+                link.master.map(|bridge| (bridge, *ifindex))
+            } else {
+                None
+            }
+        })
+    }
+
+    /// Program (or remove) a selective EVPN multicast forwarding entry
+    /// in the kernel bridge MDB from a received Type-6 SMET route.
+    /// vid 0 (non-VLAN-aware bridge) for now — per-VLAN mapping is a
+    /// follow-up. No-op when the VNI has no local VXLAN bridge.
+    async fn smet_install(
+        &self,
+        vni: u32,
+        group: IpAddr,
+        source: Option<IpAddr>,
+        dst: IpAddr,
+        add: bool,
+    ) {
+        let Some((bridge_ifindex, vxlan_ifindex)) = self.vni_to_bridge_vxlan(vni) else {
+            return;
+        };
+        self.fib_handle
+            .mdb_install(bridge_ifindex, vxlan_ifindex, 0, group, source, dst, add)
+            .await;
     }
 
     pub async fn event_loop(&mut self) {


### PR DESCRIPTION
## Summary

Phase 5 of EVPN IGMP/MLD proxy support (RFC 9251): program received Type-6
SMET routes into the **kernel bridge MDB** so the snooping bridge delivers
registered multicast groups selectively to the asking VTEP — and still
floods *unregistered* groups over the Type-3 zero-MAC FDB list, so **no
explicit flood reconciliation is needed** (the kernel does it).

- **fib**: `mdb_install(bridge, port, vid, group, source, dst, add)` emits
  `RTM_{NEW,DEL}MDB` with the `MDBA_SET_ENTRY` (`br_mdb_entry`) +
  `MDBA_SET_ENTRY_ATTRS` (`MDBE_ATTR_SOURCE` + `MDBE_ATTR_DST`) layout,
  built on the fork's existing `MdbMessage` + `MdbAttribute::Other` (**no
  fork change**). Byte-layout unit tests. Adds `netlink-packet-utils =
  "0.5.2"` (unifies with the fork) to name `DefaultNla`.
- **rib**: `Message::SmetInstall/SmetRemove`; `smet_install` resolves the
  VNI → local `(bridge, vxlan-port)` via `vni_to_bridge_vxlan` (vid 0;
  per-VLAN is a follow-up).
- **bgp**: `route_evpn_export_selected` Smet arms send `SmetInstall`
  (best-path, non-Originated, dst = SMET `orig`) / `SmetRemove` (withdraw);
  VNI from the EVI RT.

The Multicast Flags EC gate (skip selective toward non-proxy PEs) is an
optimization, deferred. Live forwarding is validated in Phase 6's BDD;
byte layout is unit-tested here.

## Test plan

- `cargo test -p zebra-rs` — **1331 passed**, 0 failed (incl. new MDB
  byte-layout tests).
- `cargo clippy --workspace --all-targets -- -D warnings` — clean.
- `cargo fmt --all --check` — clean.

Generated with [Claude Code](https://claude.com/claude-code)