### PR TITLE
docs: EVPN IGMP/MLD proxy completion summary + book accuracy

### DIFF
--- a/book/src/ch-02-32-bgp-evpn-igmp-mld-proxy.md
+++ b/book/src/ch-02-32-bgp-evpn-igmp-mld-proxy.md
@@ -5,9 +5,12 @@ which add *selective* multicast delivery to an EVPN. Without it, an
 ingress PE floods every BUM (broadcast / unknown-unicast / multicast)
 frame to **all** remote VTEPs over the Type-3 (Inclusive Multicast)
 tree. With it, a PE learns which groups its locally-attached hosts have
-joined (via the kernel bridge's IGMP/MLD snooping), advertises that
-interest in BGP, and ingress PEs replicate each `(*,G)` / `(S,G)` flow
-**only** to the PEs that asked.
+joined (via the kernel bridge's IGMP/MLD snooping) and advertises that
+interest in BGP (a **Type-6 SMET** route), so other PEs can constrain
+multicast to the groups that were actually asked for. The control plane
+(snoop → SMET → import → kernel bridge MDB) is implemented and
+validated; per-VTEP `dst` pruning of the overlay replication is a
+documented follow-up (see [Limitations](#limitations)).
 
 Three new EVPN route types and one extended community carry this:
 

--- a/docs/design/bgp-evpn-igmp-mld-proxy.md
+++ b/docs/design/bgp-evpn-igmp-mld-proxy.md
@@ -17,23 +17,44 @@ the `rib::Message::Mdb*` / `fib/netlink/handle.rs` MDB code, or
 
 Branch: `bgp-evpn-igmp-mld-proxy` (already created).
 
-## Status (updated 2026-06-20)
+## Status (updated 2026-06-20) — COMPLETE
 
-**Phase 0 (this design doc) complete. No code landed yet.** The plan below
-is the agreed slice. Numbers (PR counts, byte offsets, line numbers) are
-estimates to guide the work, not commitments — verify against the tree
-before citing.
+**All six phases are merged to `main` and validated live** (the
+`@bgp_evpn_smet` BDD passes 5/5 against real kernel namespaces). Type-6
+SMET works end to end for single-homed PEs: a kernel-bridge IGMP/MLD
+snoop drives SMET origination, a received SMET imports into the Loc-RIB
+and programs the kernel bridge MDB, and the Multicast Flags EC signals
+proxy capability on the Type-3 IMET. Type 7/8 (multihoming synch) and
+true per-VTEP `dst` selectivity are deferred (see **Deferred**).
 
-| Phase | Slice                                   | State    |
-| ----- | --------------------------------------- | -------- |
-| 0     | Design doc (this file)                  | **done** |
-| 1     | Codec — Type 6 SMET NLRI                | **done** |
-| 2     | Multicast Flags Extended Community      | **done** |
-| 3     | IMET (Type 3) capability signaling      | **done** |
-| 4     | SMET origination from kernel MDB snoop  | **done** |
-| 5     | SMET reception → selective dataplane    | **done** |
-| 6     | Show + BDD + docs                       | **done** |
-| —     | Type 7/8 multihoming synch              | deferred |
+| Phase | Slice                                   | State    | PR    |
+| ----- | --------------------------------------- | -------- | ----- |
+| 0     | Design doc (this file)                  | **done** | #1477 |
+| 1     | Codec — Type 6 SMET NLRI                | **done** | #1486 |
+| 2     | Multicast Flags Extended Community      | **done** | #1489 |
+| 3     | IMET (Type 3) capability signaling      | **done** | #1493 |
+| 4     | SMET origination from kernel MDB snoop  | **done** | #1502 |
+| 5     | SMET reception → selective dataplane    | **done** | #1506 |
+| 6     | Show + BDD + docs                       | **done** | #1510 |
+| —     | Type 7/8 multihoming synch              | deferred | —     |
+
+(Phase 4 also pushed `netlink-packet-route` `seg6` commit `d912564`, which
+adds the MDB-entry decode; tracked via the `branch = "seg6"` dependency.)
+
+### One-paragraph recap
+
+Wire types live in `crates/bgp-packet`: `EvpnSmet` / `EvpnRoute::Smet` /
+`EvpnPrefix::Smet` (`nlri_evpn.rs`) and `EvpnMcastFlags` (`ext_com.rs`,
+type 0x06 / sub 0x09). The data path is fib → rib → bgp: kernel
+`RTM_NEWMDB` (joined group `RTNLGRP_MDB`, plus an `RTM_GETMDB` startup
+dump) → `FibMessage::NewMdb` → rib maps bridge→VNI (`mdb_vni_vtep`) →
+`RibRx::SnoopJoin` → `bgp::route::evpn_originate_smet` (RD `router-id:VNI`,
+RT `AS:VNI`, next hop = local VTEP, Flags via `smet_flags()`). On receive,
+`route_evpn_export_selected` → `rib::Message::SmetInstall` →
+`fib::mdb_install` (an `MDBA_SET_ENTRY`; NESTED `MDBE_ATTR_SOURCE` for
+`(S,G)`). The `igmp-mld-proxy` knob (`zebra-bgp-evpn.yang`) gates
+origination and the IMET capability EC. User docs:
+`book/src/ch-02-32-bgp-evpn-igmp-mld-proxy.md`.
 
 ## Locked decisions (2026-06-20, with Kunihiro)
 


### PR DESCRIPTION
## Summary

Docs-only wrap-up for the now-complete EVPN IGMP/MLD proxy (RFC 9251)
feature (6 phases merged, live `@bgp_evpn_smet` BDD).

- `docs/design/bgp-evpn-igmp-mld-proxy.md`: the Status section said
  "Phase 0 done, no code landed yet" — replaced with a **COMPLETE**
  summary: per-phase → PR mapping, the `netlink-packet-route` `seg6`
  fork note, and a one-paragraph recap of the fib→rib→bgp data path and
  key symbols.
- `book/src/ch-02-32-bgp-evpn-igmp-mld-proxy.md`: the intro implied
  per-VTEP overlay pruning; softened to state the implemented + validated
  control plane and point at the Limitations follow-up.

## Test plan

- Docs only. `mdbook build` succeeds.

Generated with [Claude Code](https://claude.com/claude-code)