### PR TITLE
bgp: EVPN RFC 9574 selective AR (Leaf A-D) + book chapter

### DIFF
--- a/bdd/tests/configs/bgp_evpn_ar/z1-1.yaml
+++ b/bdd/tests/configs/bgp_evpn_ar/z1-1.yaml
@@ -15,6 +15,7 @@ router:
       assisted-replication:
         role: replicator
         replicator-ip: 192.168.0.101
+        selective: true
     neighbor:
     - remote-address: 192.168.0.2
       enabled: true

--- a/bdd/tests/features/bgp_evpn_ar.feature
+++ b/bdd/tests/features/bgp_evpn_ar.feature
@@ -83,6 +83,14 @@ Feature: BGP EVPN Assisted Replication (RFC 9574) control plane
     Then bridge fdb "vxlan10" in namespace "z1" should eventually contain "192.168.0.2"
     And bridge fdb "vxlan10" in namespace "z1" should not contain "192.168.0.3"
 
+  Scenario: Selective AR — the AR-LEAF originates a Leaf A-D toward the replicator
+    Given the test topology exists
+    # z1 is a selective replicator (L flag set); z2 (leaf) responds with a
+    # Leaf A-D (EVPN Route Type 11) keyed on z1's Replicator-AR route, which
+    # z1 imports — observable as a [11]: route originated by z2.
+    Then show command "show bgp evpn" in namespace "z1" should eventually contain "[11]:"
+    And show command "show bgp evpn" in namespace "z1" should eventually contain "[11]:[rt3/19B]:[192.168.0.2]"
+
   Scenario: Teardown topology
     Given the test topology exists
     When I stop zebra-rs in namespace "z1"

--- a/book/src/SUMMARY.md
+++ b/book/src/SUMMARY.md
@@ -38,6 +38,7 @@
   - [L3VPN over an SRv6 Underlay](ch-02-05-bgp-l3vpn-srv6.md)
   - [EVPN Type-5 (IP Prefix Routes)](ch-02-06-bgp-evpn-type5.md)
   - [EVPN IGMP/MLD Proxy (Selective Multicast)](ch-02-32-bgp-evpn-igmp-mld-proxy.md)
+  - [EVPN BUM & Assisted Replication](ch-02-33-bgp-evpn-assisted-replication.md)
   - [Route Target Constraint (RTC)](ch-02-07-bgp-rtc.md)
   - [Inter-AS L3VPN](ch-02-18-bgp-interas.md)
     - [Option A (back-to-back VRFs)](ch-02-20-bgp-interas-option-a.md)

--- a/book/src/ch-02-33-bgp-evpn-assisted-replication.md
+++ b/book/src/ch-02-33-bgp-evpn-assisted-replication.md
@@ -1,0 +1,125 @@
+# BGP EVPN BUM & Assisted Replication
+
+zebra-rs forwards EVPN **BUM** traffic (Broadcast, Unknown-unicast,
+Multicast) over VXLAN using **ingress replication** (RFC 7432 / RFC 8365),
+and optimizes it with **Assisted Replication** and **Pruned-Flood-Lists**
+from RFC 9574 ("Optimized Ingress Replication Solution for EVPN").
+
+Where [Type-5](ch-02-06-bgp-evpn-type5.md) is the L3 service, this chapter
+covers the L2 broadcast domain: how a VNI's flood list is built from
+Type-3 (Inclusive Multicast Ethernet Tag, IMET) routes and programmed into
+the Linux VXLAN dataplane.
+
+## Ingress replication (the baseline)
+
+For every locally-configured VXLAN VNI, an `advertise-all-vni` speaker
+originates a **Type-3 IMET** route carrying a **PMSI Tunnel attribute**
+(tunnel type 6, *Ingress Replication*) whose tunnel endpoint is the local
+VTEP. Each remote PE that imports the route is added to the VNI's **flood
+list**: the daemon programs a zero-MAC (`00:00:00:00:00:00`) FDB row on the
+VXLAN device, one `dst` per remote VTEP:
+
+```
+bridge fdb append 00:00:00:00:00:00 dev vxlan10 dst <remote-VTEP> self
+```
+
+The kernel then head-end-replicates each BUM frame to every listed `dst`.
+With *N* PEs the ingress PE sends *N−1* copies — the cost Assisted
+Replication reduces.
+
+```
+set vxlan vxlan10 vni 10
+set vxlan vxlan10 local-address 10.0.0.1
+set router bgp afi-safi evpn advertise-all-vni true
+```
+
+## Assisted Replication (RFC 9574)
+
+Assisted Replication offloads the *N*-way fan-out to a dedicated
+**AR-REPLICATOR**. RFC 9574 defines three roles, signalled in the Type-3
+IMET PMSI Tunnel attribute's *Assisted Replication Type* (T) field:
+
+| Role | T | Behaviour |
+| ---- | - | --------- |
+| **RNVE** (none) | 0 | Regular NVE — plain ingress replication to every PE. The default. |
+| **AR-REPLICATOR** | 1 | Advertises a **Replicator-AR** IMET (PMSI tunnel type `0x0A`) whose next hop is a distinct **AR-IP**; replicates BUM on behalf of leaves. |
+| **AR-LEAF** | 2 | Sends one BUM copy to a replicator's AR-IP instead of replicating to every PE. |
+
+The role is configured per speaker under the `evpn` address family:
+
+```
+# An AR-REPLICATOR offering its AR-IP 10.0.0.254
+set router bgp afi-safi evpn assisted-replication role replicator
+set router bgp afi-safi evpn assisted-replication replicator-ip 10.0.0.254
+
+# An AR-LEAF (offloads BUM to a replicator)
+set router bgp afi-safi evpn assisted-replication role leaf
+```
+
+On the **receive** side the daemon classifies each remote's Type-3 route
+(Regular-IR vs Replicator-AR) and builds the flood list according to the
+*local* role:
+
+* an **AR-LEAF** collapses its flood list to a **single** zero-MAC FDB row
+  toward the chosen replicator's AR-IP (falling back to full ingress
+  replication if no replicator is available);
+* an **RNVE** / **AR-REPLICATOR** floods to every remote PE's IR-IP.
+
+The collapse is observable in the kernel FDB — an AR-LEAF shows one `dst`
+(the AR-IP); an RNVE shows one per remote VTEP.
+
+## Pruned-Flood-Lists
+
+A node that does not want to receive a flood category can ask peers to
+prune it, by setting the **BM** (Broadcast/Multicast) and/or **U**
+(Unknown-unicast) flags in its own Type-3 IMET:
+
+```
+set router bgp afi-safi evpn pruned-flood-list broadcast-multicast true
+set router bgp afi-safi evpn pruned-flood-list unknown-unicast true
+```
+
+A peer drops the node from the VNI's flood list (omits its FDB row) when it
+requests pruning from **both** categories. A single Linux flood list per
+VNI cannot express a per-category prune, so a partial (BM-only / U-only)
+request is not honored — the node stays in the flood list.
+
+## Selective Assisted Replication
+
+In **selective** mode an AR-REPLICATOR replicates only to the leaves that
+explicitly joined its set, rather than to the whole broadcast domain. The
+replicator sets the **L** (Leaf Information Required) flag in its
+Replicator-AR route; each AR-LEAF responds with a **Leaf A-D** route (EVPN
+Route Type 11, RFC 9572) keyed on the replicator's route and scoped to it
+with an **IPv4-address-specific Route Target** (`<replicator-NH>:0`):
+
+```
+set router bgp afi-safi evpn assisted-replication role replicator
+set router bgp afi-safi evpn assisted-replication replicator-ip 10.0.0.254
+set router bgp afi-safi evpn assisted-replication selective true
+```
+
+The replicator then learns its AR-LEAF set from the imported Leaf A-D
+routes (visible as `[11]:` routes in `show bgp evpn`).
+
+## What the Linux kernel can and cannot do
+
+Assisted Replication targets the VXLAN ingress-replication dataplane, where
+the kernel imposes hard limits — one flood list per VNI, shared by all BUM
+categories, with a fixed outer source IP. The roles map onto a stock kernel
+as follows:
+
+| Capability | Stock Linux | Why |
+| ---------- | ----------- | --- |
+| **RNVE** ingress replication | ✅ | The zero-MAC FDB fan-out. |
+| **AR-LEAF** (BUM → one AR-IP) | ⚠️ with unknown-unicast flooding disabled | The single flood list can't split "broadcast → AR-IP, unknown-unicast → IR"; collapsing it to the AR-IP is correct only when unknown-unicast flooding is off (the usual EVPN posture). |
+| **Whole-VTEP P-FL prune** | ✅ | Just omit the remote's FDB row. |
+| **Per-category P-FL prune** | ⛔ | One flood list per VNI can't keep a remote for broadcast but drop it for unknown-unicast. |
+| **AR-REPLICATOR forwarding** | ⛔ | The kernel never re-floods a decapsulated BUM frame back out to other VTEPs, can't branch on the AR-IP vs IR-IP outer destination, and can't rewrite the per-copy source IP — so it cannot act as a replicator. Needs eBPF/XDP or VPP. |
+
+zebra-rs therefore implements the full RFC 9574 **control plane** (role
+signalling, P-FL, selective Leaf A-D) and the kernel-supported dataplane
+subset (**RNVE**, **AR-LEAF**, whole-VTEP prune). Acting as the
+**AR-REPLICATOR** forwarder is out of stock-kernel scope and is deferred to
+a programmable dataplane (eBPF/XDP or VPP) — the control plane is the
+producer that drives it.

--- a/docs/design/bgp-evpn-assisted-replication-plan.md
+++ b/docs/design/bgp-evpn-assisted-replication-plan.md
@@ -29,7 +29,7 @@ Branch `bgp-evpn-bum`. **Phase 0 (codec) landed on the branch**; Phases 1–3
 | 1a — role + origination | YANG `assisted-replication` role/AR-IP config; role-aware Type-3 IMET origination (Replicator-AR tunnel `0x0A` / AR-LEAF-flagged Regular-IR); pin tests | ✅ merged #1483 |
 | 1b — reception + flood model | per-VNI `EvpnFloodState` on `LocalRib`; classify received IMET (Regular-IR vs Replicator-AR); AR-LEAF flood-list collapse to a single `{AR-IP}` with full-IR fallback | ✅ on branch |
 | 2 — Pruned-Flood-Lists | YANG `pruned-flood-list` (BM/U) → set flags in our IMET; honor a received whole-VTEP prune (BM **and** U) by dropping the remote from the flood list; BDD prune scenario | ✅ on branch |
-| 3 — selective AR | Replicator `L=1`; AR-LEAF Leaf A-D (Type-1) origination with `AR-IP:0` RT; per-replicator leaf-set | ⬜ planned |
+| 3 — selective AR | Replicator `L=1` (config `selective`); AR-LEAF originates a Leaf A-D (Type-11, RFC 9572) keyed on the Replicator-AR route, scoped by an `<replicator-NH>:0` IPv4-address-specific RT; replicator imports the leaf set; BDD asserts the `[11]:` route on the replicator | ✅ on branch |
 | 4 — AR-REPLICATOR dataplane | decap-on-AR-IP → re-flood to other VTEPs with split-horizon | ⛔ deferred (needs eBPF/XDP or VPP — see feasibility) |
 
 ### Where the pieces live
@@ -241,7 +241,7 @@ Closest end-to-end template: the **EVPN Type-3/IMET** path itself (originate
 | 1a | YANG `assisted-replication` role/AR-IP; role-aware Type-3 IMET origination (Replicator-AR `0x0A` / AR-LEAF-flagged Regular-IR) | ✅ merged #1483 |
 | 1b | `EvpnFloodState` per-VNI flood model on `LocalRib`; classify received IMET; AR-LEAF flood-list → single `{AR-IP}`, full-IR fallback (U-flood off) | ✅ on branch |
 | 2 | Pruned-Flood-Lists: `pruned-flood-list` config → BM/U flags in our IMET; honor a received whole-VTEP prune (BM **and** U) by dropping the remote; partial (BM-only/U-only) not honored (one kernel flood list/VNI) | ✅ on branch |
-| 3 | Selective AR (control plane): Leaf A-D (Type-1) origination + `AR-IP:0` IP-specific RT; replicator `L=1`; per-replicator leaf-set | ⬜ planned |
+| 3 | Selective AR (control plane): `selective` config → `L=1`; route-triggered Leaf A-D (Type-11) origination from the AR-LEAF + `<NH>:0` IPv4-address-specific RT; replicator imports the leaf set (reuses the RFC 9251 Leaf A-D codec) | ✅ on branch |
 | 4 | **AR-REPLICATOR forwarding dataplane** (eBPF/XDP or VPP) | ⛔ deferred — out of stock-kernel scope |
 
 Phases 0–3 deliver a standards-compliant, interoperable AR/P-FL **control
@@ -266,6 +266,9 @@ kernel state:
 - **Phase 2 P-FL** — z3 also requests whole-VTEP prune (`pruned-flood-list`
   BM + U); **z1**'s FDB drops z3 (`not contain 192.168.0.3`) while keeping z2,
   proving a received whole-VTEP prune is honored.
+- **Phase 3 selective AR** — z1 is a `selective` replicator (L flag); z2
+  (leaf) originates a Leaf A-D (Type-11) that z1 imports, asserted as a
+  `[11]:[rt3/19B]:[192.168.0.2]` route in z1's `show bgp evpn`.
 
 This verifies the whole 1a→1b chain end-to-end: z1 originates Replicator-AR
 (AR-IP in the PMSI tunnel endpoint), z2 classifies it and collapses its flood
@@ -278,10 +281,18 @@ not faked. Run: `cd bdd && cargo test --test cucumber -- --concurrency=1 --tags
 
 ## Leftover / deferred
 
+- **Selective AR joins *all* replicators, not one chosen.** The AR-LEAF
+  originates a Leaf A-D toward every selective replicator it sees, where
+  RFC 9574 has it join a single chosen replicator's set. Harmless with no
+  replicator dataplane (Phase 4); chosen-replicator selection + a
+  config-change reconcile (the origination is route-triggered today, so a
+  role/`selective` flip after routes arrive isn't retro-applied) are
+  follow-ups.
 - **Replicator-AR BGP next-hop = AR-IP (RFC 9574 §4).** Found via the
-  `@bgp_evpn_ar` BDD: the EVPN advertise path overrides the route's BGP
-  next-hop to the local VTEP, so a Replicator-AR route carries next-hop =
-  VTEP, not the AR-IP. zebra-rs is self-consistent (it reads the AR-IP from
+  `@bgp_evpn_ar` BDD (confirmed again in Phase 3: the leaf builds the
+  `<NH>:0` selective RT from the *received* next-hop, which is the VTEP):
+  the EVPN advertise path overrides the route's BGP next-hop to the local
+  VTEP, so a Replicator-AR route carries next-hop = VTEP, not the AR-IP. zebra-rs is self-consistent (it reads the AR-IP from
   the PMSI tunnel endpoint, which *is* set correctly), so the flood collapse
   works — but for strict interop with implementations that read the AR-IP
   from the BGP next-hop, the next-hop should be the AR-IP. Fix is in the EVPN

--- a/zebra-rs/src/bgp/config.rs
+++ b/zebra-rs/src/bgp/config.rs
@@ -1579,6 +1579,27 @@ fn config_assisted_replication_ip(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -
     Some(())
 }
 
+/// `router bgp afi-safi evpn assisted-replication selective <bool>` (RFC
+/// 9574). Toggles the L flag in our Replicator-AR route (selective mode);
+/// re-originates the IMET so the flag change reaches peers.
+fn config_assisted_replication_selective(
+    bgp: &mut Bgp,
+    mut args: Args,
+    op: ConfigOp,
+) -> Option<()> {
+    let afi_safi: AfiSafi = args.afi_safi()?;
+    if afi_safi.afi != Afi::L2vpn || afi_safi.safi != Safi::Evpn {
+        return None;
+    }
+    let on = if op.is_set() { args.boolean()? } else { false };
+    if bgp.local_rib.evpn_flood.selective == on {
+        return Some(());
+    }
+    bgp.local_rib.evpn_flood.selective = on;
+    reoriginate_all_imet(bgp);
+    Some(())
+}
+
 /// `router bgp afi-safi evpn pruned-flood-list broadcast-multicast <bool>`
 /// (RFC 9574). Sets the BM flag in this node's own Type-3 IMET to ask peers
 /// to prune it from the broadcast/multicast flood list.
@@ -3779,6 +3800,10 @@ impl Bgp {
         self.callback_add(
             "/router/bgp/afi-safi/assisted-replication/replicator-ip",
             config_assisted_replication_ip,
+        );
+        self.callback_add(
+            "/router/bgp/afi-safi/assisted-replication/selective",
+            config_assisted_replication_selective,
         );
         // EVPN Pruned-Flood-List (RFC 9574), under `router bgp afi-safi evpn
         // pruned-flood-list`. Augmented in by zebra-bgp-evpn.yang.

--- a/zebra-rs/src/bgp/route.rs
+++ b/zebra-rs/src/bgp/route.rs
@@ -1929,6 +1929,12 @@ pub struct EvpnFloodState {
     /// unknown-unicast (`prune_unknown`) flood lists.
     pub prune_bm: bool,
     pub prune_unknown: bool,
+    /// RFC 9574 selective Assisted Replication (`... assisted-replication
+    /// selective`). When set on an AR-REPLICATOR, its Replicator-AR IMET
+    /// carries the L (Leaf Information Required) flag, soliciting Leaf A-D
+    /// routes; an AR-LEAF then originates a Leaf A-D toward each selective
+    /// replicator it sees.
+    pub selective: bool,
     /// Per-VNI flood model.
     vnis: BTreeMap<u32, VniFlood>,
 }
@@ -6363,6 +6369,10 @@ pub fn route_evpn_update(
     if !selected.is_empty() {
         route_advertise_evpn_to_peers(rd, prefix, &selected, bgp, peers);
     }
+
+    // RFC 9574 selective AR: an AR-LEAF responds to a selective Replicator-AR
+    // route (L flag set) by originating a Leaf A-D toward it.
+    evpn_selective_ar_on_receive(route, attr, bgp, peers);
 }
 
 /// Withdraw one EVPN route advertised in an MP_UNREACH_NLRI from Adj-RIB-In
@@ -6394,6 +6404,16 @@ pub fn route_evpn_withdraw(ident: usize, route: &EvpnRoute, bgp: &mut BgpTop, pe
     let selected = bgp.local_rib.select_best_path_evpn(&rd, &prefix);
 
     route_evpn_export_selected(&rd, &prefix, &selected, removed.first(), bgp);
+
+    // RFC 9574 selective AR: a withdrawn Replicator-AR route pulls the Leaf
+    // A-D we may have originated toward it (no-op if we originated none).
+    if bgp.local_rib.evpn_flood.role == AssistedReplicationRole::Leaf
+        && let EvpnRoute::Multicast(m) = route
+    {
+        let route_key = evpn_leaf_ad_route_key(m);
+        let originator = IpAddr::V4(*bgp.router_id);
+        evpn_withdraw_leaf_ad(route_key, originator, bgp, peers);
+    }
 }
 
 /// Store one received Flow Specification NLRI in the peer's Adj-RIB-In.
@@ -12174,11 +12194,17 @@ impl Bgp {
         let ar_ip = self.local_rib.evpn_flood.ar_ip;
         let prune_bm = self.local_rib.evpn_flood.prune_bm;
         let prune_unknown = self.local_rib.evpn_flood.prune_unknown;
+        let selective = self.local_rib.evpn_flood.selective;
         let (mut pmsi, nexthop) = imet_pmsi_tunnel(bum, role, ar_ip, vtep_local, vni);
         // RFC 9574 Pruned-Flood-List: advertise our prune preferences so
         // remote PEs can drop us from the BM / unknown-unicast flood lists.
         pmsi.set_prune_bm(prune_bm);
         pmsi.set_prune_unknown(prune_unknown);
+        // RFC 9574 selective AR: a selective AR-REPLICATOR sets the L flag in
+        // its Replicator-AR route to solicit Leaf A-D routes from the leaves.
+        if role == AssistedReplicationRole::Replicator && selective {
+            pmsi.set_leaf_info_required(true);
+        }
         attr.pmsi_tunnel = Some(pmsi);
         attr.nexthop = Some(BgpNexthop::Evpn(nexthop));
 
@@ -12487,6 +12513,148 @@ fn imet_pmsi_tunnel(
 /// four (24-bit VNI naturally encoded big-endian into the low 3 of
 /// 4 bytes; 32-bit values would clobber the high byte but VNIs are
 /// 24-bit per RFC 7348).
+/// Build an IPv4-address-specific Route Target extended community (type 0x01
+/// / sub 0x02, RFC 4360): `<IPv4>:<local-admin>`. RFC 9574 selective AR
+/// scopes a Leaf A-D route to one AR-REPLICATOR with `<replicator-NH>:0`.
+fn evpn_ipv4_route_target(addr: Ipv4Addr, local_admin: u16) -> ExtCommunityValue {
+    let mut rt = ExtCommunityValue {
+        high_type: 0x01,
+        low_type: 0x02,
+        val: [0; 6],
+    };
+    rt.val[0..4].copy_from_slice(&addr.octets());
+    rt.val[4..6].copy_from_slice(&local_admin.to_be_bytes());
+    rt
+}
+
+/// The Leaf A-D `route_key` (RFC 9572 §3.3) for a Replicator-AR Type-3 IMET:
+/// its Route Type Specific NLRI (route-type + length + body), Add-Path id
+/// stripped, so leaf and replicator agree on the key.
+fn evpn_leaf_ad_route_key(m: &EvpnMulticast) -> Vec<u8> {
+    let mut buf = BytesMut::new();
+    EvpnRoute::Multicast(EvpnMulticast { id: 0, ..m.clone() }).nlri_emit(&mut buf);
+    buf.to_vec()
+}
+
+/// RFC 9574 selective AR: originate (or refresh) a Leaf A-D route (EVPN Route
+/// Type 11) toward a selective AR-REPLICATOR. `route_key` is the
+/// Replicator-AR route's NLRI; `replicator_nh` its next hop (→ the `<NH>:0`
+/// IP-specific RT scoping the route to that replicator); `originator` is our
+/// (AR-LEAF) VTEP IP; `vni` the BUM domain.
+fn evpn_originate_leaf_ad(
+    route_key: Vec<u8>,
+    originator: IpAddr,
+    replicator_nh: Ipv4Addr,
+    vni: u32,
+    bgp: &mut BgpTop,
+    peers: &mut PeerMap,
+) {
+    let route = EvpnRoute::LeafAd(EvpnLeafAd {
+        id: 0,
+        route_key,
+        originator,
+    });
+    let (rd, prefix) = EvpnPrefix::from_route(&route);
+
+    let mut attr = BgpAttr::new();
+    attr.ecom = Some(ExtCommunity::from([
+        evpn_ipv4_route_target(replicator_nh, 0),
+        evpn_encap_vxlan(),
+    ]));
+    attr.pmsi_tunnel = Some(
+        PmsiTunnel {
+            flags: 0,
+            tunnel_type: PmsiTunnel::TUNNEL_ASSISTED_REPLICATION,
+            vni,
+            endpoint: originator,
+            tree_id: None,
+        }
+        .with_ar_type(AssistedReplicationType::Leaf),
+    );
+    attr.nexthop = Some(BgpNexthop::Evpn(originator));
+
+    let rib = BgpRib::new(
+        ORIGINATED_PEER,
+        Ipv4Addr::UNSPECIFIED,
+        BgpRibType::Originated,
+        0,
+        32768,
+        &attr,
+        None,
+        None,
+        false,
+    );
+    let (_replaced, selected, _next_id) = bgp.local_rib.update_evpn(rd, prefix.clone(), rib);
+    if !selected.is_empty() {
+        route_advertise_evpn_to_peers(rd, prefix, &selected, bgp, peers);
+    }
+}
+
+/// Withdraw the Leaf A-D route we originated toward the replicator identified
+/// by `route_key` (its Replicator-AR route was withdrawn). No-op if we never
+/// originated one.
+fn evpn_withdraw_leaf_ad(
+    route_key: Vec<u8>,
+    originator: IpAddr,
+    bgp: &mut BgpTop,
+    peers: &mut PeerMap,
+) {
+    let route = EvpnRoute::LeafAd(EvpnLeafAd {
+        id: 0,
+        route_key,
+        originator,
+    });
+    let (rd, prefix) = EvpnPrefix::from_route(&route);
+    let removed = bgp.local_rib.remove_evpn(rd, &prefix, 0, ORIGINATED_PEER);
+    if removed.is_empty() {
+        return;
+    }
+    let _ = bgp.local_rib.select_best_path_evpn(&rd, &prefix);
+    route_withdraw_evpn_to_peers(rd, prefix, peers);
+}
+
+/// RFC 9574 selective AR receive hook (per received EVPN route). An AR-LEAF
+/// originates a Leaf A-D toward every selective AR-REPLICATOR it sees (a
+/// Replicator-AR route carrying the L flag).
+///
+/// Note: RFC 9574 has the leaf join a *single* chosen replicator's set; we
+/// currently join every selective replicator. Harmless with no replicator
+/// dataplane (Phase 4); chosen-replicator selection is a follow-up.
+fn evpn_selective_ar_on_receive(
+    route: &EvpnRoute,
+    attr: &BgpAttr,
+    bgp: &mut BgpTop,
+    peers: &mut PeerMap,
+) {
+    if bgp.local_rib.evpn_flood.role != AssistedReplicationRole::Leaf {
+        return;
+    }
+    let EvpnRoute::Multicast(m) = route else {
+        return;
+    };
+    let Some(pmsi) = attr.pmsi_tunnel.as_ref() else {
+        return;
+    };
+    if !(pmsi.is_assisted_replication()
+        && pmsi.ar_type() == AssistedReplicationType::Replicator
+        && pmsi.leaf_info_required())
+    {
+        return;
+    }
+    // The IP-specific RT scopes the Leaf A-D to this replicator's next hop;
+    // IPv4 only (VXLAN VTEPs are IPv4 here).
+    let nh = match attr.nexthop.as_ref() {
+        Some(BgpNexthop::Evpn(IpAddr::V4(nh))) => *nh,
+        _ => return,
+    };
+    let Some(vni) = extract_vni_from_attr(attr) else {
+        return;
+    };
+    let originator = IpAddr::V4(*bgp.router_id);
+    let route_key = evpn_leaf_ad_route_key(m);
+    evpn_originate_leaf_ad(route_key, originator, nh, vni, bgp, peers);
+}
+
 fn evpn_route_target(asn: u32, vni: u32) -> ExtCommunityValue {
     let mut rt = ExtCommunityValue {
         high_type: 0x00,
@@ -12781,6 +12949,50 @@ mod evpn_flood_tests {
             imet_whole_vtep_prune(Some(&pmsi(true, true))),
             "BM and U → whole-VTEP prune"
         );
+    }
+}
+
+#[cfg(test)]
+mod evpn_selective_ar_tests {
+    use super::*;
+
+    /// IPv4-address-specific RT wire format: type 0x01 / sub 0x02, value =
+    /// 4-octet IPv4 + 2-octet local-administrator.
+    #[test]
+    fn ipv4_route_target_wire_format() {
+        let rt = evpn_ipv4_route_target(Ipv4Addr::new(192, 0, 2, 1), 0);
+        assert_eq!(rt.high_type, 0x01, "IPv4-address-specific");
+        assert_eq!(rt.low_type, 0x02, "Route Target");
+        assert_eq!(rt.val, [192, 0, 2, 1, 0, 0]);
+
+        let rt = evpn_ipv4_route_target(Ipv4Addr::new(10, 0, 0, 254), 7);
+        assert_eq!(rt.val, [10, 0, 0, 254, 0, 7]);
+    }
+
+    /// The Leaf A-D route_key is the Replicator-AR's Type-3 NLRI with the
+    /// Add-Path id stripped, so it parses back as a Type-3 IMET with id 0.
+    #[test]
+    fn leaf_ad_route_key_is_replicator_ar_nlri() {
+        let m = EvpnMulticast {
+            id: 5, // Add-Path id must NOT leak into the route_key
+            rd: RouteDistinguisher::default(),
+            ether_tag: 0,
+            addr: IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1)),
+        };
+        let key = evpn_leaf_ad_route_key(&m);
+        assert_eq!(
+            key[0], 3,
+            "route_key starts with the Type-3 route-type byte"
+        );
+        let (_, parsed) =
+            EvpnRoute::parse_nlri(&key, false).expect("route_key parses as a Type-3 NLRI");
+        match parsed {
+            EvpnRoute::Multicast(p) => {
+                assert_eq!(p.id, 0, "Add-Path id stripped");
+                assert_eq!(p.addr, m.addr);
+            }
+            other => panic!("expected Multicast, got {other:?}"),
+        }
     }
 }
 

--- a/zebra-rs/src/config/manager.rs
+++ b/zebra-rs/src/config/manager.rs
@@ -2288,6 +2288,7 @@ mod yang_load_tests {
             "set router bgp afi-safi evpn assisted-replication role replicator",
             "set router bgp afi-safi evpn assisted-replication role leaf",
             "set router bgp afi-safi evpn assisted-replication replicator-ip 10.0.0.254",
+            "set router bgp afi-safi evpn assisted-replication selective true",
         ] {
             let (code, _comps, _state) = parse(path, entry.clone(), None, State::new());
             assert_eq!(code, ExecCode::Success, "`{path}` must be a settable path");

--- a/zebra-rs/yang/zebra-bgp-evpn.yang
+++ b/zebra-rs/yang/zebra-bgp-evpn.yang
@@ -185,6 +185,18 @@ module zebra-bgp-evpn {
            destination by AR-LEAF nodes. Required when `role` is
            `replicator`; ignored otherwise.";
       }
+      leaf selective {
+        type boolean;
+        default false;
+        description
+          "Selective Assisted Replication (RFC 9574). When true on an
+           AR-REPLICATOR, its Replicator-AR route carries the L (Leaf
+           Information Required) flag, soliciting Leaf A-D routes (EVPN
+           Route Type 11) so the replicator learns exactly which AR-LEAFs
+           to replicate to. An AR-LEAF originates a Leaf A-D toward each
+           selective replicator it sees. Non-selective (the default)
+           replicates to every node in the broadcast domain.";
+      }
     }
   }
 


### PR DESCRIPTION
## Summary

RFC 9574 (Optimized Ingress Replication for EVPN) **Phase 3** — selective Assisted Replication — plus a book chapter documenting the whole EVPN BUM / AR feature. Builds on #1476 / #1483 / #1488 / #1496 / #1504.

### Selective AR — `zebra-bgp-evpn.yang` + `bgp/config.rs` + `bgp/route.rs`
- New `... evpn assisted-replication selective <bool>`: a selective AR-REPLICATOR sets the **L** (Leaf Information Required) flag in its Replicator-AR route.
- An **AR-LEAF** that receives a Replicator-AR with L=1 originates a **Leaf A-D** route (EVPN Type-11, RFC 9572 — reuses the merged RFC 9251 codec) keyed on the replicator's route and scoped with an `<replicator-NH>:0` **IPv4-address-specific RT**. The replicator imports the leaf set (visible as `[11]:` routes in `show bgp evpn`).
- New helpers: `evpn_ipv4_route_target`, `evpn_leaf_ad_route_key`, `evpn_originate_leaf_ad` / `evpn_withdraw_leaf_ad`, and the receive hook `evpn_selective_ar_on_receive` (wired into `route_evpn_update` / `route_evpn_withdraw`).

Documented follow-ups: the leaf joins every selective replicator (RFC says one chosen); origination is route-triggered (no config-change reconcile yet).

### book/ — new chapter
`ch-02-33-bgp-evpn-assisted-replication.md` ("EVPN BUM & Assisted Replication"): ingress replication, the three AR roles + config, Pruned-Flood-Lists, selective AR, and the Linux kernel-feasibility matrix. Linked in `SUMMARY.md`.

## Test plan
- 2 codec helper tests + a `yang_load` path. `cargo test -p zebra-rs --bins` — 1336 passed.
- `cargo clippy --workspace --all-targets -- -D warnings` clean; `cargo fmt` clean; `mdbook build` succeeds.
- **BDD `@bgp_evpn_ar`** extended: z1 `selective`, z2 (leaf) originates a Leaf A-D that z1 imports, asserted as `[11]:[rt3/19B]:[192.168.0.2]` in z1's `show bgp evpn`. All 7 scenarios pass locally (CI excludes BDD).

Rebased onto current `main` (resolved a clean SUMMARY merge with the concurrently-landed RFC 9251 IGMP/MLD chapter; my chapter renumbered to ch-02-33).

Generated with [Claude Code](https://claude.com/claude-code)