### PR TITLE
docs: EVPN AR implementation summary + replicator dataplane plan

### DIFF
--- a/docs/design/bgp-evpn-ar-replicator-dataplane-plan.md
+++ b/docs/design/bgp-evpn-ar-replicator-dataplane-plan.md
@@ -1,0 +1,139 @@
+# EVPN AR-REPLICATOR Forwarding Dataplane (RFC 9574 Phase 4) — Deferred Design
+
+The RFC 9574 **control plane** (roles, Pruned-Flood-Lists, selective AR) is
+built and merged — see
+[`bgp-evpn-assisted-replication-plan.md`](bgp-evpn-assisted-replication-plan.md).
+This document is the design for the one piece that is **out of stock-kernel
+scope and therefore deferred**: making a zebra-rs node act as an
+**AR-REPLICATOR forwarder** — receive a BUM packet on its AR-IP, and re-flood
+it to the other VTEPs in the broadcast domain.
+
+It is written as a handoff: the control plane is the *producer*; this is the
+*consumer* a future programmable dataplane (eBPF/XDP or VPP) would implement.
+
+## Why the stock Linux kernel cannot do this
+
+The Linux VXLAN/bridge datapath gives one flood list per VNI (the zero-MAC
+FDB), shared by all BUM categories, with a fixed outer source IP. An
+AR-REPLICATOR needs three things the kernel does not provide:
+
+1. **VTEP → VTEP re-flood.** A BUM packet received from a VTEP is decapsulated
+   into the bridge, which floods only to *other bridge ports* — never back out
+   the ingress port. The VXLAN netdev is both the ingress port and the sole
+   overlay egress port, so received BUM reaches local ACs only and is never
+   re-encapsulated toward other VTEPs. There is no "replicator" data path.
+2. **Per-outer-destination branch.** The driver decapsulates identically
+   whether the outer destination was the **AR-IP** (→ replicate to tunnels) or
+   the **IR-IP** (→ local delivery only). There is no hook to branch on it.
+   (The single-IP / VNI-discriminated RFC variant does not help — the kernel
+   will not branch on VNI to re-flood either.)
+3. **Per-copy source-IP rewrite.** VXLAN egress source is the device's fixed
+   `local` address, so the replicator cannot set the outer source to the
+   originating leaf's IP (needed for multihomed-ES split-horizon, RFC 9574
+   §6), nor re-originate at all.
+
+This is the same class of gap already documented for the deferred EVPN-SRv6-L2
+producer (kernel `seg6local` has no `End.DT2M` "L2 multicast → replicate").
+
+## What the AR-REPLICATOR forwarder must do (RFC 9574 §5–6)
+
+On a packet arriving on the **AR-IP** (VXLAN UDP, VNI `V`):
+
+- decapsulate, deliver to local ACs for VNI `V`;
+- replicate to **every other** PE in `V`'s flood domain:
+  - to other **AR-REPLICATORs**: outer dst = their **IR-IP** (stops further
+    replication);
+  - to **AR-LEAF / RNVE**: outer dst = their IR-IP; outer src = own IR-IP
+    (MAY preserve the originating leaf's src for ES split-horizon);
+- **split-horizon:** never send back toward the source VTEP;
+- skip a tunnel flagged `BM=1` for broadcast/multicast and `U=1` for
+  unknown-unicast (per-category P-FL);
+- **selective mode:** replicate only to the AR-LEAFs in this replicator's
+  leaf-set (the Leaf A-D originators), plus RNVEs.
+
+A packet arriving on the **IR-IP** is delivered to local ACs only (normal
+ingress replication) — no re-flood.
+
+## The control plane already produces everything this needs
+
+The future dataplane consumes state the merged control plane maintains in
+`EvpnFloodState` (on `LocalRib`) per VNI:
+
+| Dataplane input | Control-plane source |
+| --------------- | -------------------- |
+| The replicator's own **AR-IP** | `assisted-replication replicator-ip` config |
+| The **IR-IP list** of every remote PE | `VniFlood.remotes` keys |
+| Per-remote **BM/U prune** flags | `RemoteImet.prune` (today coarse; per-category is a refinement) |
+| **Selective leaf-set** (which AR-LEAFs joined) | received Leaf A-D (Type-11) routes carrying `<own-NH>:0` RT |
+| Which remotes are other **AR-REPLICATORs** vs leaves | `RemoteImet.ar_ip.is_some()` |
+
+So Phase 4 is purely a **southbound** build: a new FIB program that turns this
+table into per-VNI replication state, plus the packet-path that executes it.
+
+## Option A — eBPF/XDP/tc (in-kernel programmable)
+
+zebra-rs already ships XDP/aya infrastructure (BFD/STAMP offload), so this
+reuses the build toolchain.
+
+- **Attach point:** XDP (or tc-ingress) on the underlay interface that
+  receives VXLAN UDP. Match `udp.dport == 4789 && outer.dst == AR-IP`.
+- **Replicate:** for each target IR-IP in the per-VNI map, `bpf_clone_redirect`
+  (tc) or build N copies (XDP `bpf_xdp_adjust_*` + redirect), rewriting the
+  outer IP/UDP header (dst = target, src = own IR-IP or preserved leaf src) and
+  recomputing checksums. Source-VTEP match drops the copy toward the ingress
+  VTEP (split-horizon).
+- **AR-IP/IR-IP branch:** two maps (or a per-dst-IP lookup) select
+  replicate-to-tunnels vs local-only.
+- **Maps populated from the control plane:** a new `rib::Message` (e.g.
+  `ArReplicatorProgram { vni, ar_ip, targets: [{ir_ip, is_replicator, bm, u}], leaf_set }`)
+  → a `fib/xdp` handle writes the BPF maps; mirrors how `mdb_add` writes the
+  FDB today.
+- **Caveats (from the XDP offload notes):** veth needs SKB mode; clone/redirect
+  fan-out and per-copy checksum fix-ups are the hard part; `bpf_timer` not
+  needed here.
+
+## Option B — VPP (userspace dataplane)
+
+VPP has native L2 flood/replication (`interface_rx_dpo`, `l2-input` flooding —
+see the VPP L2-over-MPLS note), which maps directly onto AR replication and
+also unblocks the EVPN-SRv6-L2 `End.DT2M` gap.
+
+- **Southbound:** the same per-VNI replication table is pushed to VPP via its
+  binary API / a vpp-agent, programming a replication list keyed on the AR-IP
+  bridge-domain.
+- **Pros:** real per-copy header rewrite + source preservation are first-class;
+  highest performance; one dataplane covers AR-REPLICATOR *and* SRv6 L2 BUM.
+- **Cons:** a separate dataplane process and packaging; the largest build.
+
+## Suggested phasing (when Phase 4 is picked up)
+
+1. **FIB interface** — the `ArReplicatorProgram` RIB message + a stub
+   `fib` handle that logs the desired replication table (no packet path yet).
+   Wire it from `EvpnFloodState` on role/leaf-set/flood changes. (Control-plane
+   testable in isolation, like the Flowspec Phase-4 stub.)
+2. **Dataplane MVP** — non-selective, single-replicator, IPv4 VTEPs, own-IR-IP
+   source, split-horizon by source VTEP. eBPF/XDP on veth (lab) or VPP.
+3. **Selective + P-FL** — restrict the target set to the leaf-set; honor
+   per-category BM/U (this also unblocks per-category P-FL on the *leaf* side,
+   currently whole-VTEP only).
+4. **Multihomed-ES** — optional source-IP preservation + local-bias.
+
+## Verification
+
+Cannot be a stock-kernel BDD (the whole point). Options: an eBPF/veth lab that
+counts replicated copies and checks split-horizon; a VPP lab; or interop
+against a hardware/vendor AR-REPLICATOR. The control-plane producer
+(`ArReplicatorProgram` emission) *is* unit/BDD-testable independent of the
+packet path.
+
+## Related follow-ups (control-plane, not Phase 4)
+
+These were left open by Phases 0–3 and are cheaper than the dataplane:
+
+- **Replicator-AR BGP next-hop = AR-IP (RFC 9574 §4).** Today the EVPN advertise
+  path overrides the next-hop to the local VTEP; the AR-IP rides in the PMSI
+  endpoint instead. Self-consistent in zebra-rs, but an interop gap.
+- **Render the PMSI / AR role in `show bgp evpn`** (currently only the FDB
+  reveals AR behavior).
+- **Selective AR: join one chosen replicator** (today joins all) + a
+  config-change reconcile for the route-triggered Leaf A-D origination.

--- a/docs/design/bgp-evpn-assisted-replication-plan.md
+++ b/docs/design/bgp-evpn-assisted-replication-plan.md
@@ -17,20 +17,24 @@ flood-list netlink path in `zebra-rs/src/fib/netlink/handle.rs`
 (`mdb_add`/`mdb_del`), `rib::Message::MdbAdd/MdbDel`, or
 `zebra-rs/yang/zebra-bgp-evpn.yang`.
 
-## Status (updated 2026-06-20)
+## Status (updated 2026-06-18)
 
-Branch `bgp-evpn-bum`. **Phase 0 (codec) landed on the branch**; Phases 1–3
-(control plane + the kernel-supported dataplane subset) are planned; Phase 4
-(AR-REPLICATOR forwarding) is an explicit out-of-stock-kernel deferral.
+Branch `bgp-evpn-bum`. **The RFC 9574 control plane (Phases 0–3) is complete
+and merged**, together with the kernel-supported dataplane subset (RNVE,
+AR-LEAF flood-collapse, whole-VTEP P-FL prune). Phase 4 (AR-REPLICATOR
+*forwarding*) is an explicit out-of-stock-kernel deferral — its design lives
+in [`bgp-evpn-ar-replicator-dataplane-plan.md`](bgp-evpn-ar-replicator-dataplane-plan.md).
+A consolidated recap of what was built is in **Implementation summary** below.
 
-| Slice            | What landed / planned                                                                                  | Status |
+| Slice            | What landed                                                                                            | Status |
 | ---------------- | ----------------------------------------------------------------------------------------------------- | ------ |
 | 0 — PMSI codec   | tunnel type `0x0A`, `AssistedReplicationType` (T), BM/U/L flag accessors on `PmsiTunnel`, 7 pin tests  | ✅ merged #1476 |
 | 1a — role + origination | YANG `assisted-replication` role/AR-IP config; role-aware Type-3 IMET origination (Replicator-AR tunnel `0x0A` / AR-LEAF-flagged Regular-IR); pin tests | ✅ merged #1483 |
-| 1b — reception + flood model | per-VNI `EvpnFloodState` on `LocalRib`; classify received IMET (Regular-IR vs Replicator-AR); AR-LEAF flood-list collapse to a single `{AR-IP}` with full-IR fallback | ✅ on branch |
-| 2 — Pruned-Flood-Lists | YANG `pruned-flood-list` (BM/U) → set flags in our IMET; honor a received whole-VTEP prune (BM **and** U) by dropping the remote from the flood list; BDD prune scenario | ✅ on branch |
-| 3 — selective AR | Replicator `L=1` (config `selective`); AR-LEAF originates a Leaf A-D (Type-11, RFC 9572) keyed on the Replicator-AR route, scoped by an `<replicator-NH>:0` IPv4-address-specific RT; replicator imports the leaf set; BDD asserts the `[11]:` route on the replicator | ✅ on branch |
-| 4 — AR-REPLICATOR dataplane | decap-on-AR-IP → re-flood to other VTEPs with split-horizon | ⛔ deferred (needs eBPF/XDP or VPP — see feasibility) |
+| 1b — reception + flood model | per-VNI `EvpnFloodState` on `LocalRib`; classify received IMET (Regular-IR vs Replicator-AR); AR-LEAF flood-list collapse to a single `{AR-IP}` with full-IR fallback | ✅ merged #1488 |
+| BDD              | first VXLAN-dataplane BDD (`@bgp_evpn_ar`) — RNVE/AR-LEAF/replicator FDB assertions + `bridge fdb` step | ✅ merged #1496 |
+| 2 — Pruned-Flood-Lists | YANG `pruned-flood-list` (BM/U) → set flags in our IMET; honor a received whole-VTEP prune (BM **and** U) by dropping the remote from the flood list; BDD prune scenario | ✅ merged #1504 |
+| 3 — selective AR | Replicator `L=1` (config `selective`); AR-LEAF originates a Leaf A-D (Type-11, RFC 9572) keyed on the Replicator-AR route, scoped by an `<replicator-NH>:0` IPv4-address-specific RT; replicator imports the leaf set; BDD asserts the `[11]:` route; book chapter | ✅ merged #1512 |
+| 4 — AR-REPLICATOR dataplane | decap-on-AR-IP → re-flood to other VTEPs with split-horizon | ⛔ deferred — eBPF/XDP or VPP ([dedicated plan](bgp-evpn-ar-replicator-dataplane-plan.md)) |
 
 ### Where the pieces live
 
@@ -58,6 +62,76 @@ Branch `bgp-evpn-bum`. **Phase 0 (codec) landed on the branch**; Phases 1–3
   `local_vxlans: BTreeMap<u32, IpAddr>` / `local_fdb` (~`:544–562`).
 - **Config / YANG:** `zebra-rs/yang/zebra-bgp-evpn.yang` (`advertise-all-vni`
   at ~`:62–75`).
+
+## Implementation summary (as merged, Phases 0–3)
+
+What the merged control plane does, end to end.
+
+### Config surface (`zebra-bgp-evpn.yang`, global `router bgp afi-safi evpn`)
+
+```
+advertise-all-vni true
+assisted-replication { role none|replicator|leaf; replicator-ip <AR-IP>; selective <bool> }
+pruned-flood-list   { broadcast-multicast <bool>; unknown-unicast <bool> }
+bum-tunnel-type     ingress-replication|sr-mpls-p2mp|srv6-p2mp   # (SR P2MP from the RFC 9251/9524 series)
+```
+
+Each leaf has a `config_*` handler in `bgp/config.rs` that writes to
+`LocalRib.evpn_flood` and re-originates the per-VNI IMET (`reoriginate_all_imet`);
+a role change additionally reconciles the flood lists (`evpn_reconcile_all_flood`).
+
+### Runtime data model — `EvpnFloodState` on `LocalRib` (`bgp/route.rs`)
+
+Lives on `LocalRib` (not `Bgp`) so both the config callbacks (`&mut Bgp`) and
+the receive path (`BgpTop`, 38 build sites) reach it — the same pattern as
+`sr_policy_local` / `table_map`.
+
+- **Local config:** `role`, `ar_ip`, `selective`, `prune_bm`, `prune_unknown`,
+  `bum_tunnel`.
+- **Per-VNI (`VniFlood`):** `remotes: BTreeMap<orig, RemoteImet { ar_ip, prune }>`
+  (Regular-IR vs Replicator-AR, plus the whole-VTEP prune bit) ·
+  `sr_remotes: BTreeMap<orig, tree_id>` (SR P2MP roots, kept out of the flood
+  set) · `installed: BTreeSet<IpAddr>` (the zero-MAC FDB targets currently
+  programmed, for delta computation).
+
+### Origination — `evpn_originate_imet` (per local VXLAN VNI)
+
+`imet_pmsi_tunnel(bum, role, ar_ip, vtep, vni)` builds the PMSI: Replicator →
+tunnel `0x0A`, T=REPLICATOR, next-hop/endpoint = AR-IP; Leaf → Regular-IR
+flagged T=LEAF; None → legacy IR. The caller then stamps the P-FL **BM/U**
+flags (`set_prune_bm`/`set_prune_unknown`) and, for a selective Replicator,
+the **L** flag (`set_leaf_info_required`).
+
+### Reception — two hooks on the received-route path
+
+1. **Flood reconcile** — `route_evpn_export_selected` (Type-3 arm) classifies
+   the remote (`is_assisted_replication()` → AR-IP from the PMSI endpoint;
+   `prune_bm() && prune_unknown()` → whole-VTEP prune), updates `RemoteImet`,
+   and calls `EvpnFloodState::reconcile(vni)`. `desired(vni)` is the heart:
+   SR-P2MP mode → empty; AR-LEAF → the single lowest replicator AR-IP (full-IR
+   fallback); RNVE/Replicator → every remote IR-IP; pruned remotes excluded.
+   The delta vs `installed` emits `rib::Message::MdbAdd/MdbDel`.
+2. **Selective AR** — `evpn_selective_ar_on_receive` (called from
+   `route_evpn_update`/`route_evpn_withdraw`): when an AR-LEAF sees a
+   Replicator-AR with L=1, it originates a Leaf A-D (Type-11) via
+   `evpn_originate_leaf_ad` — `route_key` = the Replicator-AR NLRI
+   (`evpn_leaf_ad_route_key`), RT = `<replicator-NH>:0`
+   (`evpn_ipv4_route_target`, type 0x01).
+
+### Dataplane (Linux VXLAN kernel FDB)
+
+`MdbAdd/MdbDel { vni, group, .. }` → `fib/netlink/handle.rs::mdb_add/mdb_del`
+→ `bridge fdb {add,del} 00:00:00:00:00:00 dev <vxlan> dst <group> self`. The
+`group` is the flood target: a remote IR-IP (RNVE), or the chosen AR-IP
+(AR-LEAF). Whole-VTEP prune = the remote is simply omitted from `desired`.
+
+### Verified by
+
+Codec/flag/route-key unit tests in `pmsi_tunnel.rs` and `route.rs`
+(`evpn_flood_tests`, `evpn_imet_ar_tests`, `evpn_selective_ar_tests`),
+`yang_load` path tests, and the `@bgp_evpn_ar` BDD (7 scenarios: IMET
+exchange, AR-LEAF flood-collapse, RNVE full-IR, whole-VTEP prune, selective
+Leaf A-D). CI excludes BDD, so it is verified locally.
 
 ## Can the Linux kernel do it? — feasibility (the crux)
 
@@ -239,17 +313,17 @@ Closest end-to-end template: the **EVPN Type-3/IMET** path itself (originate
 | ----- | ----- | ------ |
 | 0 | Codec: PMSI tunnel 0x0A + `AssistedReplicationType` (T) + BM/U/L accessors + pin tests | ✅ merged #1476 |
 | 1a | YANG `assisted-replication` role/AR-IP; role-aware Type-3 IMET origination (Replicator-AR `0x0A` / AR-LEAF-flagged Regular-IR) | ✅ merged #1483 |
-| 1b | `EvpnFloodState` per-VNI flood model on `LocalRib`; classify received IMET; AR-LEAF flood-list → single `{AR-IP}`, full-IR fallback (U-flood off) | ✅ on branch |
-| 2 | Pruned-Flood-Lists: `pruned-flood-list` config → BM/U flags in our IMET; honor a received whole-VTEP prune (BM **and** U) by dropping the remote; partial (BM-only/U-only) not honored (one kernel flood list/VNI) | ✅ on branch |
-| 3 | Selective AR (control plane): `selective` config → `L=1`; route-triggered Leaf A-D (Type-11) origination from the AR-LEAF + `<NH>:0` IPv4-address-specific RT; replicator imports the leaf set (reuses the RFC 9251 Leaf A-D codec) | ✅ on branch |
-| 4 | **AR-REPLICATOR forwarding dataplane** (eBPF/XDP or VPP) | ⛔ deferred — out of stock-kernel scope |
+| 1b | `EvpnFloodState` per-VNI flood model on `LocalRib`; classify received IMET; AR-LEAF flood-list → single `{AR-IP}`, full-IR fallback (U-flood off) | ✅ merged #1488 |
+| 2 | Pruned-Flood-Lists: `pruned-flood-list` config → BM/U flags in our IMET; honor a received whole-VTEP prune (BM **and** U) by dropping the remote; partial (BM-only/U-only) not honored (one kernel flood list/VNI) | ✅ merged #1504 |
+| 3 | Selective AR (control plane): `selective` config → `L=1`; route-triggered Leaf A-D (Type-11) origination from the AR-LEAF + `<NH>:0` IPv4-address-specific RT; replicator imports the leaf set (reuses the RFC 9251 Leaf A-D codec) | ✅ merged #1512 |
+| 4 | **AR-REPLICATOR forwarding dataplane** (eBPF/XDP or VPP) — [dedicated plan](bgp-evpn-ar-replicator-dataplane-plan.md) | ⛔ deferred — out of stock-kernel scope |
 
 Phases 0–3 deliver a standards-compliant, interoperable AR/P-FL **control
 plane** plus the genuinely-useful Linux dataplane subset (RNVE, AR-LEAF,
 whole-VTEP prune), mirroring how the v6 BGP stack and the Flowspec series
 shipped control-plane-first. Phase 4 carries the dataplane risk.
 
-### BDD (`@bgp_evpn_ar`) — ✅ on branch
+### BDD (`@bgp_evpn_ar`) — ✅ merged (#1496, + prune #1504, + selective #1512)
 
 The repo's first VXLAN-dataplane BDD. Three iBGP (AS 65001) EVPN nodes on a
 shared bridge, each with a config-driven local VXLAN (VNI 10) so every node
@@ -302,10 +376,14 @@ not faked. Run: `cd bdd && cargo test --test cucumber -- --concurrency=1 --tags
   evpn` prints prefix + next-hop + ext-comms but not the PMSI tunnel
   type/flags, so the AR role isn't observable via `show` (only via the FDB).
   Adding a PMSI line would make AR role / tunnel-type 0x0A operator-visible.
-- **Phase 4 — AR-REPLICATOR forwarding.** The decap-on-AR-IP → re-flood
-  datapath with source-VTEP split-horizon and (optional) source-IP
+- **Phase 4 — AR-REPLICATOR forwarding (deferred).** The decap-on-AR-IP →
+  re-flood datapath with source-VTEP split-horizon and (optional) source-IP
   preservation. Needs eBPF/XDP/tc clone+redirect+header-rewrite or a VPP
-  southbound; not expressible on the stock kernel VXLAN/bridge datapath.
+  southbound; not expressible on the stock kernel VXLAN/bridge datapath. The
+  control plane already produces the per-VNI replication table this needs —
+  full design (kernel blockers, eBPF vs VPP options, FIB interface, phasing,
+  verification) in
+  [`bgp-evpn-ar-replicator-dataplane-plan.md`](bgp-evpn-ar-replicator-dataplane-plan.md).
 - **Per-category (BM-only / U-only) P-FL pruning.** Kernel has one flood
   list per VNI; per-remote per-category pruning needs the Phase 4 dataplane.
 - **AR-LEAF with unknown-unicast flooding *enabled*.** The RFC's separate


### PR DESCRIPTION
## Summary

Documentation-only. Consolidates the RFC 9574 EVPN Assisted Replication work now that the **control plane (Phases 0–3) is complete and merged** (#1476/#1483/#1488/#1496/#1504/#1512).

- **`bgp-evpn-assisted-replication-plan.md`** — status/phasing tables updated to "merged" with PR numbers; new **Implementation summary (as merged, Phases 0–3)** section: the config surface, the `EvpnFloodState` runtime data model on `LocalRib`, the origination (`evpn_originate_imet` + `imet_pmsi_tunnel`) and reception (flood reconcile + the selective-AR Leaf A-D hook) paths, the kernel zero-MAC FDB dataplane, and what's verified (unit tests + `@bgp_evpn_ar` BDD).
- **`bgp-evpn-ar-replicator-dataplane-plan.md`** (new) — the deferred **Phase 4** AR-REPLICATOR forwarding dataplane design: the three stock-kernel blockers (no VTEP→VTEP re-flood, no AR-IP/IR-IP branch, no per-copy source rewrite), what the forwarder must do (RFC 9574 §5–6), the per-VNI replication table the control plane already produces, **eBPF/XDP vs VPP** options, a FIB-interface-first phasing, and the verification approach.

## Test plan
Docs only — no code change. Cross-links between the two design docs resolve. CI (fmt/clippy/test) is a no-op for the routing code.

Generated with [Claude Code](https://claude.com/claude-code)