### PR TITLE
rib/offload: EVPN SR P2MP replication supervisor (DP2)

### DIFF
--- a/offload/tc-evpn-replicate/loader/src/main.rs
+++ b/offload/tc-evpn-replicate/loader/src/main.rs
@@ -10,7 +10,8 @@
 use anyhow::Context as _;
 use aya::programs::{SchedClassifier, TcAttachType, tc};
 use clap::Parser;
-use log::{debug, info};
+use log::{debug, info, warn};
+use tokio::io::AsyncBufReadExt as _;
 use tokio::signal;
 
 #[derive(Debug, Parser)]
@@ -65,8 +66,60 @@ async fn main() -> anyhow::Result<()> {
     program.load()?;
     program.attach(&iface, attach)?;
 
-    info!("tc_evpn_replicate attached to {iface} ({direction}); waiting for Ctrl-C");
-    signal::ctrl_c().await?;
+    info!("tc_evpn_replicate attached to {iface} ({direction}); reading commands on stdin");
+
+    // Replication segments are fed by the zebra-rs supervisor over a stdin
+    // line protocol (one command per line):
+    //   repl-add <vni> <tree-id> <srv6:0|1> <root-ip> <leaf-ip>...
+    //   repl-del <vni>
+    // Today each command is parsed and logged; populating the BPF replication
+    // map and the End.Replicate / End.DT2M forwarding are follow-up slices.
+    let mut lines = tokio::io::BufReader::new(tokio::io::stdin()).lines();
+    loop {
+        tokio::select! {
+            line = lines.next_line() => match line {
+                Ok(Some(l)) => handle_command(&l),
+                // EOF (supervisor closed our stdin) or read error: exit so the
+                // TC program detaches cleanly.
+                _ => break,
+            },
+            _ = signal::ctrl_c() => break,
+        }
+    }
     info!("Exiting");
     Ok(())
+}
+
+/// Handle one control line from the supervisor. Unknown / malformed lines are
+/// warned and ignored so a protocol mismatch never kills the dataplane.
+fn handle_command(line: &str) {
+    let line = line.trim();
+    if line.is_empty() {
+        return;
+    }
+    let mut it = line.split_whitespace();
+    match it.next() {
+        Some("repl-add") => {
+            let vni = it.next();
+            let tree_id = it.next();
+            let srv6 = it.next();
+            let root = it.next();
+            let leaves: Vec<&str> = it.collect();
+            match (vni, tree_id, srv6, root) {
+                (Some(vni), Some(tree_id), Some(srv6), Some(root)) if !leaves.is_empty() => {
+                    info!(
+                        "repl-add vni={vni} tree={tree_id} srv6={srv6} root={root} \
+                         leaves={leaves:?} (BPF map population pending)"
+                    );
+                }
+                _ => warn!("malformed repl-add: {line:?}"),
+            }
+        }
+        Some("repl-del") => match it.next() {
+            Some(vni) => info!("repl-del vni={vni}"),
+            None => warn!("malformed repl-del: {line:?}"),
+        },
+        Some(other) => warn!("unknown command: {other:?}"),
+        None => {}
+    }
 }

--- a/zebra-rs/src/rib/evpn_replicate.rs
+++ b/zebra-rs/src/rib/evpn_replicate.rs
@@ -1,0 +1,230 @@
+//! EVPN SR P2MP replication dataplane supervisor (RFC 9524).
+//!
+//! The BGP control plane computes a replication segment per VNI and sends
+//! `rib::Message::ReplSegAdd` / `ReplSegDel`. The stock Linux kernel cannot
+//! forward an SR replication tree (no `End.Replicate`, no MPLS P2MP, no
+//! `End.DT2M`), so forwarding is offloaded to the `tc-evpn-replicate` eBPF
+//! TC/clsact program (`offload/tc-evpn-replicate/`), run as a managed child
+//! process — this module is its supervisor, mirroring the BFD echo reflector
+//! (`bfd::reflector::EchoReflectors`).
+//!
+//! A single child carries every VNI's replication map; it is spawned on the
+//! first replication segment and SIGTERM'd (clean TC detach) when the last is
+//! withdrawn. Segments are pushed over a stdin line protocol:
+//!
+//! ```text
+//!   repl-add <vni> <tree-id> <srv6:0|1> <root-ip> <leaf-ip>...
+//!   repl-del <vni>
+//! ```
+//!
+//! The underlay interface the replicator attaches to comes from
+//! `$ZEBRA_TC_EVPN_REPLICATE_IFACE`; with it unset the dataplane is disabled
+//! (the control plane still signals, nothing forwards) — honest on a host
+//! without the offload installed.
+
+use std::collections::BTreeSet;
+use std::net::IpAddr;
+use std::path::PathBuf;
+use std::process::Stdio;
+
+use tokio::io::AsyncWriteExt;
+use tokio::process::{Child, ChildStdin, Command};
+use tokio::sync::mpsc::{self, UnboundedReceiver, UnboundedSender};
+
+use crate::context::Task;
+
+/// Env override for the replicator binary path (mirrors the BFD reflector's
+/// `ZEBRA_XDP_BFD_ECHO_BIN`).
+const BIN_ENV: &str = "ZEBRA_TC_EVPN_REPLICATE_BIN";
+/// Underlay interface the TC replicator attaches to. Unset ⇒ dataplane off.
+const IFACE_ENV: &str = "ZEBRA_TC_EVPN_REPLICATE_IFACE";
+
+/// Supervises the single `tc-evpn-replicate` child that forwards EVPN BUM over
+/// SR P2MP replication trees. Lifecycle is reference-counted by the set of
+/// VNIs that currently have a replication segment.
+pub struct ReplicationHelper {
+    /// VNIs with an active replication segment — spawn on the first, stop on
+    /// the last.
+    vnis: BTreeSet<u32>,
+    /// The child process, if it spawned. `None` when the dataplane is disabled
+    /// (no interface) or the spawn failed.
+    child: Option<Child>,
+    /// Queue for stdin command lines to the child's IPC task.
+    cmd_tx: Option<UnboundedSender<String>>,
+    /// IPC task: writes commands to the child's stdin. Aborts when dropped.
+    _io: Option<Task<()>>,
+    bin: PathBuf,
+    /// Underlay interface to attach to; `None` ($ZEBRA_..._IFACE unset)
+    /// disables the dataplane.
+    iface: Option<String>,
+}
+
+impl Default for ReplicationHelper {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl ReplicationHelper {
+    pub fn new() -> Self {
+        Self {
+            vnis: BTreeSet::new(),
+            child: None,
+            cmd_tx: None,
+            _io: None,
+            bin: resolve_bin(),
+            iface: std::env::var(IFACE_ENV).ok().filter(|s| !s.is_empty()),
+        }
+    }
+
+    /// Install or refresh the SR P2MP replication segment for `vni`, spawning
+    /// the child on the first segment.
+    pub fn add(&mut self, vni: u32, tree_id: u32, root: IpAddr, srv6: bool, leaves: &[IpAddr]) {
+        self.ensure_child();
+        self.vnis.insert(vni);
+        let mut line = format!("repl-add {vni} {tree_id} {} {root}", u8::from(srv6));
+        for leaf in leaves {
+            line.push(' ');
+            line.push_str(&leaf.to_string());
+        }
+        self.send(line);
+    }
+
+    /// Withdraw the replication segment for `vni`, stopping the child when the
+    /// last segment is gone.
+    pub fn del(&mut self, vni: u32) {
+        if !self.vnis.remove(&vni) {
+            return;
+        }
+        self.send(format!("repl-del {vni}"));
+        if self.vnis.is_empty() {
+            self.stop();
+        }
+    }
+
+    fn send(&self, line: String) {
+        if let Some(tx) = &self.cmd_tx {
+            let _ = tx.send(line);
+        }
+    }
+
+    fn ensure_child(&mut self) {
+        if self.child.is_some() {
+            return;
+        }
+        let Some(iface) = self.iface.clone() else {
+            tracing::debug!("evpn replication: {IFACE_ENV} unset; SR P2MP dataplane disabled");
+            return;
+        };
+        // The replicator encaps + clones at egress (the root); ingress
+        // bud/leaf attach is a follow-up once those roles are wired.
+        match Command::new(&self.bin)
+            .arg("--iface")
+            .arg(&iface)
+            .arg("--direction")
+            .arg("egress")
+            .stdin(Stdio::piped())
+            .kill_on_drop(true)
+            .spawn()
+        {
+            Ok(mut child) => {
+                tracing::info!(
+                    "evpn replication: spawned {} on {iface}",
+                    self.bin.display()
+                );
+                if let Some(stdin) = child.stdin.take() {
+                    let (tx, rx) = mpsc::unbounded_channel::<String>();
+                    self._io = Some(Task::spawn(child_io(stdin, rx)));
+                    self.cmd_tx = Some(tx);
+                }
+                self.child = Some(child);
+            }
+            Err(e) => {
+                tracing::warn!(
+                    "evpn replication: failed to spawn {} on {iface}: {e}",
+                    self.bin.display()
+                );
+            }
+        }
+    }
+
+    /// SIGTERM the child so the loader detaches its TC program cleanly.
+    /// `kill_on_drop(true)` reaps it (SIGKILL) if it ignores us.
+    fn stop(&mut self) {
+        if let Some(pid) = self.child.as_ref().and_then(Child::id) {
+            unsafe {
+                libc::kill(pid as libc::pid_t, libc::SIGTERM);
+            }
+            tracing::info!("evpn replication: stopping replicator (last segment withdrawn)");
+        }
+        self.child = None;
+        self.cmd_tx = None;
+        self._io = None;
+    }
+}
+
+/// Per-child IPC task: drains queued command lines to the child's stdin. Ends
+/// when the command sender is dropped (helper stopped) or a write fails (child
+/// gone).
+async fn child_io(mut stdin: ChildStdin, mut cmd_rx: UnboundedReceiver<String>) {
+    while let Some(c) = cmd_rx.recv().await {
+        if stdin.write_all(c.as_bytes()).await.is_err()
+            || stdin.write_all(b"\n").await.is_err()
+            || stdin.flush().await.is_err()
+        {
+            break;
+        }
+    }
+}
+
+/// Resolve the replicator binary: `$ZEBRA_TC_EVPN_REPLICATE_BIN`, else the dev
+/// install (`~/.zebra/bin`), else the packaged location.
+fn resolve_bin() -> PathBuf {
+    if let Some(p) = std::env::var_os(BIN_ENV) {
+        return PathBuf::from(p);
+    }
+    if let Some(home) = std::env::var_os("HOME") {
+        let dev = PathBuf::from(home).join(".zebra/bin/tc-evpn-replicate");
+        if dev.exists() {
+            return dev;
+        }
+    }
+    PathBuf::from("/usr/sbin/tc-evpn-replicate")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn ip(s: &str) -> IpAddr {
+        s.parse().unwrap()
+    }
+
+    #[test]
+    fn add_del_tracks_vnis() {
+        let mut h = ReplicationHelper::new();
+        // Force the dataplane off so the test never spawns a child regardless
+        // of the environment — we exercise the segment bookkeeping only.
+        h.iface = None;
+        h.add(10, 10, ip("10.0.0.1"), false, &[ip("10.0.0.2")]);
+        h.add(20, 20, ip("10.0.0.1"), true, &[ip("10.0.0.3")]);
+        assert_eq!(h.vnis, BTreeSet::from([10, 20]));
+        assert!(h.child.is_none(), "no iface → no child spawned");
+
+        h.del(10);
+        assert_eq!(h.vnis, BTreeSet::from([20]));
+        h.del(99); // unknown VNI: no-op, no underflow
+        assert_eq!(h.vnis, BTreeSet::from([20]));
+        h.del(20);
+        assert!(h.vnis.is_empty());
+    }
+
+    #[test]
+    fn bin_env_override_is_honoured() {
+        // SAFETY: single-threaded test; set then read immediately.
+        unsafe { std::env::set_var(BIN_ENV, "/opt/custom/tc-evpn-replicate") };
+        let h = ReplicationHelper::new();
+        unsafe { std::env::remove_var(BIN_ENV) };
+        assert_eq!(h.bin, PathBuf::from("/opt/custom/tc-evpn-replicate"));
+    }
+}

--- a/zebra-rs/src/rib/inst.rs
+++ b/zebra-rs/src/rib/inst.rs
@@ -662,6 +662,11 @@ pub struct Rib {
     /// `crate::rib::route::RECOVERY_*` if an external actor keeps
     /// fighting us.
     pub addr_recovery: BTreeMap<(u32, IpNet), AddrRecoveryState>,
+
+    /// Supervisor for the EVPN SR P2MP replication dataplane (RFC 9524).
+    /// Driven by `Message::ReplSegAdd` / `ReplSegDel`; spawns/feeds the
+    /// `tc-evpn-replicate` offload child.
+    pub evpn_repl: super::evpn_replicate::ReplicationHelper,
 }
 
 /// Name of the dummy interface that hosts End-style seg6local routes
@@ -742,6 +747,7 @@ impl Rib {
             rib_sync_interval: DEFAULT_RIB_SYNC_INTERVAL_SEC,
             sr0_owned: false,
             addr_recovery: BTreeMap::new(),
+            evpn_repl: super::evpn_replicate::ReplicationHelper::new(),
         };
         rib.show_build();
         Ok(rib)
@@ -2242,17 +2248,20 @@ impl Rib {
                 srv6,
                 leaves,
             } => {
-                // The SR replication dataplane (eBPF TC/clsact, offload crate
-                // `tc-evpn-replicate`) is wired in a follow-up; record the
-                // intent for now so the control plane is observable end to end.
+                // Hand the replication segment to the SR P2MP dataplane
+                // supervisor (the `tc-evpn-replicate` offload child). With no
+                // offload interface configured this is a logged no-op — the
+                // control plane still signals, nothing forwards.
                 tracing::info!(
-                    "EVPN ReplSeg add: VNI {vni} tree {tree_id} root {root} {} -> {} leaf PE(s): {leaves:?} (SR dataplane pending)",
+                    "EVPN ReplSeg add: VNI {vni} tree {tree_id} root {root} {} -> {} leaf PE(s)",
                     if srv6 { "SRv6" } else { "SR-MPLS" },
                     leaves.len()
                 );
+                self.evpn_repl.add(vni, tree_id, root, srv6, &leaves);
             }
             Message::ReplSegDel { vni } => {
-                tracing::info!("EVPN ReplSeg del: VNI {vni} (SR dataplane pending)");
+                tracing::info!("EVPN ReplSeg del: VNI {vni}");
+                self.evpn_repl.del(vni);
             }
             Message::RedistAdd {
                 proto,

--- a/zebra-rs/src/rib/mod.rs
+++ b/zebra-rs/src/rib/mod.rs
@@ -80,3 +80,5 @@ pub use addr_gen_mode::*;
 
 pub mod segment_routing;
 pub use segment_routing::*;
+
+pub mod evpn_replicate;


### PR DESCRIPTION
## Summary

DP slice (2) of the RFC 9524 EVPN BUM replication plan — the **supervisor** that drives the `tc-evpn-replicate` eBPF dataplane from the `ReplSeg` control→dataplane handoff (#1508). Mirrors the BFD echo reflector (`bfd::reflector::EchoReflectors`).

- **offload `tc-evpn-replicate` loader**: reads a stdin line protocol and parse+logs each segment:
  ```
  repl-add <vni> <tree-id> <srv6:0|1> <root-ip> <leaf-ip>...
  repl-del <vni>
  ```
  (BPF map population + `End.Replicate` / `End.DT2M` forwarding are DP slice 3.)
- **`zebra-rs` `rib::evpn_replicate::ReplicationHelper`**: supervises a single replicator child — spawns it on the first replication segment, SIGTERMs it (clean TC detach) on the last, and feeds segments over the child's stdin via an IPC task. Attaches to `$ZEBRA_TC_EVPN_REPLICATE_IFACE`; **unset ⇒ dataplane disabled** (the control plane still signals, nothing forwards — honest on a host without the offload).
- **`rib` `process_msg`** `ReplSegAdd`/`ReplSegDel` now drive the supervisor instead of just logging.

**Scope:** process supervision + IPC plumbing. No BPF map / forwarding yet (DP3); the loader parses and logs.

## Test

- 2 unit tests: segment refcount/lifecycle bookkeeping (add/del/unknown-vni, no spawn without an interface) + bin-env override.
- The offload crate is **workspace-excluded** (built + verified locally with `cargo build`, not by CI).
- `cargo fmt --all` clean · `cargo clippy --workspace --all-targets -- -D warnings` clean · zebra-rs unit tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)