### PR TITLE
docs: design plan for EVPN SMET per-VTEP dst (VXLAN MDB)

### DIFF
--- a/docs/design/bgp-evpn-igmp-mld-proxy-followups.md
+++ b/docs/design/bgp-evpn-igmp-mld-proxy-followups.md
@@ -15,6 +15,10 @@ the group is delivered out the VXLAN and head-end-replicated to every
 remote VTEP on the Type-3 zero-MAC FDB list. True
 `(x,G)`-to-only-the-asking-VTEP delivery needs the kernel **VXLAN MDB**.
 
+> Scoped in its own design doc: **`bgp-evpn-smet-pervtep-dst-plan.md`**
+> (the `external vnifilter` VXLAN model, the wholesale-vs-per-VNI
+> decision, phasing, and the iproute2-6.1.0 / kernel-6.8 tooling note).
+
 Why deferred: it is not a localized SMET change. The kernel rejects
 `MDBE_ATTR_DST` on a plain VXLAN with `EINVAL` (verified; `iproute2`
 drops it too — see the `mdb_install` comment). The per-VTEP form needs a

--- a/docs/design/bgp-evpn-smet-pervtep-dst-plan.md
+++ b/docs/design/bgp-evpn-smet-pervtep-dst-plan.md
@@ -1,0 +1,143 @@
+# EVPN SMET per-VTEP `dst` selectivity (VXLAN MDB) — design / scoping
+
+Status: **proposed** (2026-06-19). Follow-up #1 from
+`bgp-evpn-igmp-mld-proxy-followups.md`. Turns the shipped RFC 9251 SMET
+control plane into a *truly* per-VTEP-selective data plane.
+
+## Problem
+
+The shipped Phase-5 dataplane (`fib::mdb_install`, PR #1506) installs a
+received SMET as a **bridge** MDB entry:
+
+```
+bridge mdb add dev <bridge> port <vxlan> grp G [src S]
+```
+
+That registers the group on the VXLAN bridge port, so the snooping
+bridge stops *flooding* it to local non-member ports — but it carries
+**no per-entry destination**. When the group egresses the VXLAN it is
+head-end-replicated to **every** remote VTEP on the Type-3 zero-MAC FDB
+list. So across the overlay it is not selective: a `(*,G)` joined only
+behind PE-B is still sent to PE-C, PE-D, … This was confirmed in
+testing — the kernel **silently drops `MDBE_ATTR_DST` on a plain
+VXLAN** (returns `EINVAL` if you force it), which is why Phase 5
+deliberately omits the `dst` (the `dst` is plumbed end-to-end through
+`rib::Message::SmetInstall { … dst }` → `smet_install` → `mdb_install`
+but currently only logged).
+
+Goal: deliver `(x,G)` only to the VTEPs whose SMET asked for it.
+
+## Mechanism: the VXLAN MDB (kernel ≥ 6.3)
+
+The kernel models per-VTEP multicast forwarding with a **VXLAN MDB** on
+a **VNI-aware (`vnifilter`), externally-controlled** VXLAN device. The
+MDB entry lives on the *VXLAN device itself* (not the bridge) and
+carries the remote destination:
+
+```
+ip link add vtep type vxlan external vnifilter local <ip> dstport 4789
+bridge vni add vni <N> dev vtep
+# per (S,G) → remote VTEP:
+bridge mdb add dev vtep port vtep src_vni <N> grp G [src S] permanent dst <VTEP-IP>
+```
+
+The netlink message is `RTM_NEWMDB` with `family=AF_BRIDGE`,
+`ifindex=<vxlan>`, an `MDBA_SET_ENTRY` (`struct br_mdb_entry`), and —
+**mandatory for a VXLAN device** — a NESTED `MDBA_SET_ENTRY_ATTRS`
+carrying `MDBE_ATTR_SOURCE` (S), `MDBE_ATTR_DST` (remote VTEP), and
+`MDBE_ATTR_SRC_VNI` (the VNI). (On a *plain* bridge MDB the
+`SET_ENTRY_ATTRS` is optional and `MDBE_ATTR_DST` is rejected — the
+opposite of the VXLAN MDB, which requires it.)
+
+### Tooling note
+
+zebra-rs emits netlink **directly**, so it is *not* limited by the host
+`iproute2` (the test box ships 6.1.0, whose `bridge mdb` predates the
+`dst`/`src_vni`/VXLAN-MDB options — that is why manual `bridge mdb add …
+dst` probes fail with "Missing MDBA_SET_ENTRY_ATTRS"). The kernel
+itself (6.8 here) supports it; we encode the attributes ourselves
+(exactly as we already do for the Phase-5 `MDBE_ATTR_SOURCE` nest). The
+`MDBE_ATTR_*` enum values come from `linux/if_bridge.h`
+(`SOURCE=1`, `DST=5`, `DST_PORT=6`, `SRC_VNI=9`) — pin them against the
+header during implementation.
+
+## The architectural decision
+
+`external vnifilter` is a **different VXLAN model** from the plain
+fixed-VNI device zebra-rs creates today (`vxlan_add` in
+`fib/netlink/handle.rs`: `InfoVxlan::Id(vni)` + `Local` +
+`Learning(false)`). An `external` VXLAN delegates BUM/forwarding
+decisions to the control plane rather than the device's own FDB. This
+interacts with the **already-shipped** L2 EVPN paths:
+
+- **Type-2 (MAC/IP)** — `mac_add`/`mac_del` program the bridge FDB with
+  the remote VTEP as `dst`; under `external` the addressing/VNI
+  plumbing differs (per-VNI `bridge fdb … src_vni`).
+- **Type-3 (BUM)** — the misnamed `mdb_add`/`mdb_del` (a zero-MAC FDB
+  *flood* row per remote VTEP) is the ingress-replication list; the
+  `external vnifilter` model expresses BUM via the VXLAN MDB too
+  (a `grp 0.0.0.0`/all-zeros catch-all per VTEP) rather than zero-MAC
+  FDB.
+
+So this is **not a localized SMET patch** — it changes the L2
+dataplane model. Two scoping options:
+
+| Option | What | Pros | Cons |
+| ------ | ---- | ---- | ---- |
+| **A. Wholesale** | Every EVPN VXLAN becomes `external vnifilter`; rework Type-2 FDB + Type-3 BUM onto the VNI-aware model | One consistent model; unlocks per-VTEP SMET cleanly; aligns with how FRR/modern kernels do EVPN multicast | Touches shipped, working Type-2/3 paths — regression surface; bigger BDD matrix |
+| **B. Per-VNI opt-in** | Only VNIs with `igmp-mld-proxy` use `external vnifilter`; others stay plain | Smaller blast radius on existing deployments | Two VXLAN models in one daemon; Type-2/3 must work both ways; more conditional code |
+
+**Recommendation:** Option A, as its own phased series with FRR/IOS-XR
+interop validation — the per-VNI split (B) doubles the L2 matrix for
+little durable benefit, since the `external vnifilter` model is where
+EVPN multicast is going anyway. **This is the decision to confirm
+before any code.**
+
+## Implementation sketch (Option A)
+
+1. **Fork (`netlink-packet-route` seg6):** ensure `InfoVxlan` exposes
+   `CollectMetadata`/external + the `vnifilter` flag, and add the
+   `MDBE_ATTR_DST`/`SRC_VNI` encoders if we want typed helpers (today
+   Phase 5 hand-rolls the nested attrs via `MdbAttribute::Other` —
+   that path extends fine without a fork change).
+2. **VXLAN creation (`vxlan_add`):** create `external vnifilter`; drive
+   `bridge vni add` per VNI (RTM_NEWTUNNEL / `VNI`-filter netlink) as
+   VNIs are learned.
+3. **Type-2 / Type-3 rework** onto the VNI-aware model (the bulk of the
+   work and the regression risk).
+4. **`mdb_install`:** retarget to `dev = <vxlan>`, add
+   `MDBA_SET_ENTRY_ATTRS { MDBE_ATTR_SOURCE?, MDBE_ATTR_DST=orig,
+   MDBE_ATTR_SRC_VNI=vni }`. `dst`/`vni` are already plumbed; drop the
+   bridge-vs-vxlan ifindex distinction in `smet_install`.
+5. **Show / introspection:** `show bgp evpn` is unaffected; a
+   `show evpn mdb`-style command could surface the programmed
+   per-VTEP state (the host `bridge mdb show` is too old to render it).
+
+## Phasing
+
+- **P0** — this doc + the Option A/B decision.
+- **P1** — fork/`vxlan_add`: create `external vnifilter` VXLANs + VNI
+  filter; keep behavior otherwise identical (Type-2/3 still work).
+- **P2** — port Type-3 BUM to the VXLAN-MDB catch-all; verify the
+  existing `@bgp_evpn_ar` / Type-3 BDDs stay green.
+- **P3** — port Type-2 MAC to `src_vni` FDB; verify Type-2 BDDs.
+- **P4** — retarget `mdb_install` to the VXLAN MDB with `dst`; extend
+  `@bgp_evpn_smet` to assert per-VTEP delivery.
+
+## Risks / open questions
+
+- **Regression surface.** Type-2/3 are shipped and BDD-covered; the
+  model change must keep them green. This is the main risk.
+- **Test harness.** The box's `iproute2` 6.1.0 can't render the VXLAN
+  MDB (`bridge mdb show` won't show `dst`/`src_vni`), so the P4 BDD
+  needs either a newer `bridge` or a daemon-side `show` + netlink dump
+  assertion. (zebra-rs *programming* it is unaffected — only the test
+  *observation* is.)
+- **Interop.** Validate the on-wire VXLAN encapsulation + MDB-driven
+  replication against FRR / a second stack, not just self-consistency.
+- **Exact `br_mdb_entry` + `MDBE_ATTR_*` layout** for the VXLAN-MDB
+  SET — pin against `linux/if_bridge.h` and a real kernel ACK (can't
+  strace the old iproute2 for a reference; read kernel source or upgrade
+  the host tool).
+- **`bridge vni add` netlink** — confirm the exact message
+  (`RTM_NEWTUNNEL` + `VXLAN_VNIFILTER_*`) the fork must emit.


### PR DESCRIPTION
Docs-only. Scoping/design doc for follow-up #1 of the EVPN IGMP/MLD
proxy work — making the SMET dataplane *truly* per-VTEP selective via
the kernel **VXLAN MDB** on an `external vnifilter` device.

Covers the gap (plain-VXLAN bridge MDB drops the per-entry `dst`), the
kernel mechanism + exact netlink shape, the key architectural decision
(adopt `external vnifilter` wholesale vs per-VNI — recommend wholesale)
and its interaction with the shipped Type-2/Type-3 paths, phasing,
risks, and open questions. Includes the tooling note that zebra-rs emits
netlink directly and so isn't limited by the host's old `iproute2`.

No code — the implementation decision (Option A vs B) is the next gate.

Generated with [Claude Code](https://claude.com/claude-code)