### PR TITLE
offload: tc-evpn-replicate BPF replication map + loader population (DP3a)

### DIFF
--- a/offload/tc-evpn-replicate/ebpf/src/main.rs
+++ b/offload/tc-evpn-replicate/ebpf/src/main.rs
@@ -22,14 +22,54 @@
 //! The branch/leaf state comes from a BPF map the loader fills from the BGP
 //! control plane (`ReplSeg`, fed by `EvpnFloodState::replication_leaves`).
 //!
-//! For now every frame is passed through untouched (`TC_ACT_PIPE`); the
-//! replication logic and maps land in follow-up slices.
+//! The per-VNI replication state lives in the `REPL_SEG` BPF map, populated by
+//! the loader from the BGP control plane (`ReplSeg`, fed by
+//! `EvpnFloodState::replication_leaves`). For now every frame is still passed
+//! through untouched (`TC_ACT_PIPE`); the classifier reading the map to clone +
+//! rewrite (`End.Replicate`) and decap (`End.DT2M`) lands in a follow-up slice.
 
-use aya_ebpf::{bindings::TC_ACT_PIPE, macros::classifier, programs::TcContext};
+use aya_ebpf::{
+    bindings::TC_ACT_PIPE,
+    macros::{classifier, map},
+    maps::HashMap,
+    programs::TcContext,
+};
+
+/// Maximum replication leaves per VNI stored in the map. Beyond this the
+/// loader truncates and warns (an EVPN BD with this many PEs is already
+/// extreme for any ingress-style replication).
+pub const MAX_LEAVES: usize = 32;
+
+/// `ReplSeg` flag bits.
+pub const REPL_FLAG_SRV6: u32 = 1 << 0; // SRv6 (vs SR-MPLS) encapsulation
+pub const REPL_FLAG_ROOT_V4: u32 = 1 << 1; // `root` is an IPv4 address (first 4 bytes)
+
+/// One VNI's SR P2MP replication segment (RFC 9524), keyed by VNI in
+/// [`REPL_SEG`]. Addresses are stored as 16 bytes — IPv6 verbatim, or IPv4 in
+/// the first 4 bytes with the corresponding family flag set. `#[repr(C)]` with
+/// the 4-byte fields first so the layout is padding-free and matches the
+/// loader's `aya::Pod` mirror byte-for-byte.
+#[repr(C)]
+#[derive(Clone, Copy)]
+pub struct ReplSeg {
+    pub tree_id: u32,
+    pub n_leaves: u32,
+    pub flags: u32,
+    pub root: [u8; 16],
+    pub leaves: [[u8; 16]; MAX_LEAVES],
+    /// Per-leaf family flag: 1 = `leaves[i]` is IPv4 (first 4 bytes).
+    pub leaf_v4: [u8; MAX_LEAVES],
+}
+
+/// Per-VNI replication segments the loader programs from the control plane.
+/// Read by the (forthcoming) replication datapath to clone + rewrite copies.
+#[map]
+static REPL_SEG: HashMap<u32, ReplSeg> = HashMap::with_max_entries(256, 0);
 
 #[classifier]
 pub fn tc_evpn_replicate(_ctx: TcContext) -> i32 {
-    // No-op skeleton: hand every frame back to the stack unchanged.
+    // No-op skeleton: hand every frame back to the stack unchanged. The
+    // replication datapath that reads REPL_SEG lands in a follow-up slice.
     TC_ACT_PIPE
 }
 

--- a/offload/tc-evpn-replicate/loader/src/main.rs
+++ b/offload/tc-evpn-replicate/loader/src/main.rs
@@ -1,18 +1,48 @@
 //! Userspace loader for the EVPN BUM replication TC/clsact dataplane
-//! (RFC 9524 SR replication segment) — skeleton.
+//! (RFC 9524 SR replication segment).
 //!
-//! Loads the eBPF object (embedded at build time) and attaches the
-//! `tc_evpn_replicate` classifier to an interface's `clsact` qdisc. The
-//! root/bud `End.Replicate` and leaf `End.DT2M` paths — and the replication
-//! map the BGP control plane (`ReplSeg`) fills — land in follow-up slices.
+//! Loads the eBPF object (embedded at build time), attaches the
+//! `tc_evpn_replicate` classifier to an interface's `clsact` qdisc, and
+//! populates the `REPL_SEG` BPF map from a stdin line protocol fed by the
+//! zebra-rs supervisor. The classifier reading that map to clone + rewrite
+//! (`End.Replicate`) and decap (`End.DT2M`) is a follow-up slice.
 //! Runs until Ctrl-C / SIGTERM.
 
+use std::net::IpAddr;
+
 use anyhow::Context as _;
+use aya::maps::{HashMap as AyaHashMap, MapData};
 use aya::programs::{SchedClassifier, TcAttachType, tc};
 use clap::Parser;
 use log::{debug, info, warn};
 use tokio::io::AsyncBufReadExt as _;
 use tokio::signal;
+
+/// Must match `tc-evpn-replicate-ebpf`'s `MAX_LEAVES`.
+const MAX_LEAVES: usize = 32;
+const REPL_FLAG_SRV6: u32 = 1 << 0;
+const REPL_FLAG_ROOT_V4: u32 = 1 << 1;
+
+/// Userspace mirror of the eBPF `ReplSeg` map value — identical `#[repr(C)]`
+/// layout (4-byte fields first, then the padding-free byte arrays) so it is a
+/// valid `aya::Pod`.
+#[repr(C)]
+#[derive(Clone, Copy)]
+struct ReplSeg {
+    tree_id: u32,
+    n_leaves: u32,
+    flags: u32,
+    root: [u8; 16],
+    leaves: [[u8; 16]; MAX_LEAVES],
+    leaf_v4: [u8; MAX_LEAVES],
+}
+
+// SAFETY: `ReplSeg` is `#[repr(C)]`, contains only integer/byte-array fields
+// (valid for any bit pattern) and has no padding (the three `u32`s lead, then
+// 1-aligned arrays totalling a multiple of 4), so every byte is initialized.
+unsafe impl aya::Pod for ReplSeg {}
+
+type ReplMap = AyaHashMap<MapData, u32, ReplSeg>;
 
 #[derive(Debug, Parser)]
 #[command(about = "EVPN BUM replication (RFC 9524 SR P2MP) TC/clsact dataplane")]
@@ -66,19 +96,23 @@ async fn main() -> anyhow::Result<()> {
     program.load()?;
     program.attach(&iface, attach)?;
 
+    // Userspace handle to the per-VNI replication map the classifier reads.
+    let mut repl: ReplMap = AyaHashMap::try_from(
+        ebpf.take_map("REPL_SEG")
+            .context("map 'REPL_SEG' not found in object")?,
+    )?;
+
     info!("tc_evpn_replicate attached to {iface} ({direction}); reading commands on stdin");
 
     // Replication segments are fed by the zebra-rs supervisor over a stdin
     // line protocol (one command per line):
     //   repl-add <vni> <tree-id> <srv6:0|1> <root-ip> <leaf-ip>...
     //   repl-del <vni>
-    // Today each command is parsed and logged; populating the BPF replication
-    // map and the End.Replicate / End.DT2M forwarding are follow-up slices.
     let mut lines = tokio::io::BufReader::new(tokio::io::stdin()).lines();
     loop {
         tokio::select! {
             line = lines.next_line() => match line {
-                Ok(Some(l)) => handle_command(&l),
+                Ok(Some(l)) => handle_command(&l, &mut repl),
                 // EOF (supervisor closed our stdin) or read error: exit so the
                 // TC program detaches cleanly.
                 _ => break,
@@ -90,36 +124,101 @@ async fn main() -> anyhow::Result<()> {
     Ok(())
 }
 
-/// Handle one control line from the supervisor. Unknown / malformed lines are
-/// warned and ignored so a protocol mismatch never kills the dataplane.
-fn handle_command(line: &str) {
+/// Encode an IP into the map's 16-byte slot: IPv6 verbatim, or IPv4 in the
+/// first four bytes. Returns `(bytes, is_v4)`.
+fn encode_addr(ip: IpAddr) -> ([u8; 16], bool) {
+    match ip {
+        IpAddr::V4(v4) => {
+            let mut b = [0u8; 16];
+            b[..4].copy_from_slice(&v4.octets());
+            (b, true)
+        }
+        IpAddr::V6(v6) => (v6.octets(), false),
+    }
+}
+
+/// Handle one control line from the supervisor, programming the `REPL_SEG`
+/// map. Unknown / malformed lines are warned and ignored so a protocol
+/// mismatch never kills the dataplane.
+fn handle_command(line: &str, repl: &mut ReplMap) {
     let line = line.trim();
     if line.is_empty() {
         return;
     }
     let mut it = line.split_whitespace();
     match it.next() {
-        Some("repl-add") => {
-            let vni = it.next();
-            let tree_id = it.next();
-            let srv6 = it.next();
-            let root = it.next();
-            let leaves: Vec<&str> = it.collect();
-            match (vni, tree_id, srv6, root) {
-                (Some(vni), Some(tree_id), Some(srv6), Some(root)) if !leaves.is_empty() => {
-                    info!(
-                        "repl-add vni={vni} tree={tree_id} srv6={srv6} root={root} \
-                         leaves={leaves:?} (BPF map population pending)"
-                    );
+        Some("repl-add") => match parse_add(&mut it) {
+            Some((vni, seg)) => {
+                if let Err(e) = repl.insert(vni, seg, 0) {
+                    warn!("REPL_SEG insert vni={vni} failed: {e}");
+                } else {
+                    info!("repl-add vni={vni} ({} leaf PE(s))", seg.n_leaves);
                 }
-                _ => warn!("malformed repl-add: {line:?}"),
             }
-        }
-        Some("repl-del") => match it.next() {
-            Some(vni) => info!("repl-del vni={vni}"),
+            None => warn!("malformed repl-add: {line:?}"),
+        },
+        Some("repl-del") => match it.next().and_then(|v| v.parse::<u32>().ok()) {
+            Some(vni) => {
+                // `remove` errors if the key was never present — fine on a
+                // duplicate/late withdraw, so only warn on other failures.
+                if let Err(e) = repl.remove(&vni) {
+                    debug!("REPL_SEG remove vni={vni}: {e}");
+                }
+                info!("repl-del vni={vni}");
+            }
             None => warn!("malformed repl-del: {line:?}"),
         },
         Some(other) => warn!("unknown command: {other:?}"),
         None => {}
     }
+}
+
+/// Parse a `repl-add <vni> <tree-id> <srv6:0|1> <root-ip> <leaf-ip>...` body
+/// (the verb already consumed) into the map key + value.
+fn parse_add<'a>(it: &mut impl Iterator<Item = &'a str>) -> Option<(u32, ReplSeg)> {
+    let vni: u32 = it.next()?.parse().ok()?;
+    let tree_id: u32 = it.next()?.parse().ok()?;
+    let srv6 = it.next()? == "1";
+    let root: IpAddr = it.next()?.parse().ok()?;
+
+    let mut seg = ReplSeg {
+        tree_id,
+        n_leaves: 0,
+        flags: 0,
+        root: [0; 16],
+        leaves: [[0; 16]; MAX_LEAVES],
+        leaf_v4: [0; MAX_LEAVES],
+    };
+    let (root_bytes, root_v4) = encode_addr(root);
+    seg.root = root_bytes;
+    if srv6 {
+        seg.flags |= REPL_FLAG_SRV6;
+    }
+    if root_v4 {
+        seg.flags |= REPL_FLAG_ROOT_V4;
+    }
+
+    let mut n = 0usize;
+    let mut overflow = false;
+    for tok in it {
+        let Ok(leaf) = tok.parse::<IpAddr>() else {
+            return None; // a malformed leaf invalidates the whole command
+        };
+        if n >= MAX_LEAVES {
+            overflow = true;
+            continue;
+        }
+        let (b, v4) = encode_addr(leaf);
+        seg.leaves[n] = b;
+        seg.leaf_v4[n] = u8::from(v4);
+        n += 1;
+    }
+    if n == 0 {
+        return None; // a replication segment with no leaves is meaningless
+    }
+    if overflow {
+        warn!("repl-add vni={vni}: more than {MAX_LEAVES} leaves, truncated");
+    }
+    seg.n_leaves = n as u32;
+    Some((vni, seg))
 }


### PR DESCRIPTION
## Summary

DP slice (3a) of the RFC 9524 EVPN BUM replication plan — the **BPF replication map**, the kernel-side state the forwarding datapath will read. The `tc-evpn-replicate` loader now programs a per-VNI `REPL_SEG` map from the supervisor's stdin line protocol (#1518) instead of just logging.

- **ebpf**: define `ReplSeg` (tree-id, flags, root, up to `MAX_LEAVES=32` leaf addresses as 16-byte slots + a per-leaf IPv4 flag) and a `HashMap<vni, ReplSeg>` `REPL_SEG` map. The classifier still passes frames through (`TC_ACT_PIPE`).
- **loader**: an `aya::Pod` mirror of `ReplSeg` (identical, padding-free `repr(C)` layout) + parse `repl-add`/`repl-del` into `REPL_SEG` insert/remove, encoding IPv4/IPv6 roots and leaves (truncating beyond `MAX_LEAVES` with a warning).

## Scope

The kernel now **holds** each VNI's replication segment. The classifier **reading** it to clone + rewrite (`End.Replicate`) and decap (`End.DT2M`) is the next slice — and that forwarding logic is **CI-untestable** (needs root + a veth/SR lab), so it'll be verified by hand.

## Test

- `cd offload/tc-evpn-replicate && cargo build` clean — the eBPF object (with the map) and the loader (with the aya map population) both compile.
- Offload crate is **workspace-excluded** (not built by CI); no zebra-rs changes (the DP2 supervisor's line format already matches the loader's parser). Main-workspace gates unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)