### PR TITLE
bdd: validate EVPN (S,G) SMET source decode

### DIFF
--- a/bdd/tests/features/bgp_evpn_smet.feature
+++ b/bdd/tests/features/bgp_evpn_smet.feature
@@ -78,6 +78,14 @@ Feature: BGP EVPN IGMP/MLD Proxy — Selective Multicast (RFC 9251)
     Then show command "show bgp evpn" in namespace "z1" should eventually not contain "[6]:[0]:[0]:[*]:[32]:[239.1.1.1]"
     And bridge mdb "br10" in namespace "z1" should not contain "239.1.1.1"
 
+  Scenario: An (S,G) join originates a source-specific SMET with the right source
+    Given the test topology exists
+    # Source-specific (IGMPv3) membership. Validates the kernel MDB
+    # EATTR_SOURCE decode — z1 must see the source 192.0.2.9 in the SMET
+    # key, not a (*,G) wildcard.
+    When I execute "bridge mdb add dev br10 port host0 src 192.0.2.9 grp 232.1.1.1 permanent" in namespace "z2"
+    Then show command "show bgp evpn" in namespace "z1" should eventually contain "[6]:[0]:[32]:[192.0.2.9]:[32]:[232.1.1.1]:[32]:[192.168.0.2]"
+
   Scenario: Teardown topology
     Given the test topology exists
     When I stop zebra-rs in namespace "z1"


### PR DESCRIPTION
Adds an `(S,G)` scenario to `@bgp_evpn_smet` validating that a
source-specific (IGMPv3) join originates a SMET with the **correct
source** in the key (`[6]:[0]:[32]:[192.0.2.9]:[32]:[232.1.1.1]:…`),
not a `(*,G)` wildcard.

This exercises the kernel MDB `EATTR_SOURCE` decode fix in the
`netlink-packet-route` `seg6` fork (commit `d2c1d85`): the dump-side
`MDBA_MDB_EATTR_SOURCE` eattr is **4**, not 2 (2 is `SRC_LIST`) — the
previous value mis-decoded the `(S)` of an `(S,G)` entry. The fork
commit also adds `dst`/`vni` decode (`RTM_GETMDB` readback) for the
upcoming per-VTEP `dst` work. Tracked via the `branch = "seg6"` dep.

## Test plan
- `@bgp_evpn_smet` ran live (sudo netns): **6/6 scenarios pass**,
  including the new `(S,G)` case.
- `cargo clippy -p bdd --tests -- -D warnings` + `cargo fmt --all --check` — clean.

Generated with [Claude Code](https://claude.com/claude-code)