### PR TITLE
Add `interface <name> bridge <bridge>` deferred enslavement

### DIFF
--- a/bdd/tests/cucumber.rs
+++ b/bdd/tests/cucumber.rs
@@ -1366,6 +1366,120 @@ async fn show_command_not_contains(
     );
 }
 
+/// Kernel-state sibling of `show_command_eventually_contains`: run an
+/// arbitrary command (argv split on whitespace) inside a namespace and
+/// poll until its stdout contains the needle, or fail after the budget.
+/// Unlike `show command …` (which targets the vtyctl show surface) this
+/// reaches the real `ip`/`bridge` tools — used to assert async netlink
+/// effects, e.g. a port being enslaved to a bridge (`ip -o link show
+/// <if>` gaining `master <bridge>`).
+#[then(expr = "command {string} in namespace {string} should eventually contain {string}")]
+async fn command_eventually_contains(
+    world: &mut World,
+    command: String,
+    namespace: String,
+    needle: String,
+) {
+    let scoped = world.ns(&namespace);
+    let parts: Vec<&str> = command.split_whitespace().collect();
+    let (cmd, args) = parts
+        .split_first()
+        .unwrap_or_else(|| panic!("empty command in 'command …' for {}", scoped));
+    const ATTEMPTS: u32 = 30;
+    let mut last_output = String::new();
+    for i in 0..ATTEMPTS {
+        last_output = netns::exec_in_netns(&scoped, cmd, args)
+            .await
+            .unwrap_or_else(|e| panic!("Failed to run '{}' in {}: {}", command, scoped, e));
+        if last_output.contains(&needle) {
+            println!(
+                "✓ '{}' in namespace {} contains '{}'",
+                command, scoped, needle
+            );
+            return;
+        }
+        if i + 1 < ATTEMPTS {
+            tokio::time::sleep(tokio::time::Duration::from_secs(1)).await;
+        }
+    }
+    panic!(
+        "'{}' in namespace {} did not contain '{}' after {} attempts\nlast output:\n{}",
+        command, scoped, needle, ATTEMPTS, last_output
+    );
+}
+
+/// Negative polling sibling: run the command and poll until its stdout no
+/// longer contains the needle (e.g. a port losing `master <bridge>` after
+/// the bridge is deleted and the kernel releases it).
+#[then(expr = "command {string} in namespace {string} should eventually not contain {string}")]
+async fn command_eventually_not_contains(
+    world: &mut World,
+    command: String,
+    namespace: String,
+    needle: String,
+) {
+    let scoped = world.ns(&namespace);
+    let parts: Vec<&str> = command.split_whitespace().collect();
+    let (cmd, args) = parts
+        .split_first()
+        .unwrap_or_else(|| panic!("empty command in 'command …' for {}", scoped));
+    const ATTEMPTS: u32 = 30;
+    let mut last_output = String::new();
+    for i in 0..ATTEMPTS {
+        last_output = netns::exec_in_netns(&scoped, cmd, args)
+            .await
+            .unwrap_or_else(|e| panic!("Failed to run '{}' in {}: {}", command, scoped, e));
+        if !last_output.contains(&needle) {
+            println!(
+                "✓ '{}' in namespace {} no longer contains '{}'",
+                command, scoped, needle
+            );
+            return;
+        }
+        if i + 1 < ATTEMPTS {
+            tokio::time::sleep(tokio::time::Duration::from_secs(1)).await;
+        }
+    }
+    panic!(
+        "'{}' in namespace {} still contained '{}' after {} attempts\nlast output:\n{}",
+        command, scoped, needle, ATTEMPTS, last_output
+    );
+}
+
+/// Immediate (non-polling) negative assertion: run the command once and
+/// require its stdout does NOT contain the needle. Pair with a preceding
+/// `I wait N seconds` to give any erroneous async effect time to manifest
+/// before asserting absence (e.g. a binding that must stay pending must
+/// NOT have enslaved the port).
+#[then(expr = "command {string} in namespace {string} should not contain {string}")]
+async fn command_not_contains(
+    world: &mut World,
+    command: String,
+    namespace: String,
+    needle: String,
+) {
+    let scoped = world.ns(&namespace);
+    let parts: Vec<&str> = command.split_whitespace().collect();
+    let (cmd, args) = parts
+        .split_first()
+        .unwrap_or_else(|| panic!("empty command in 'command …' for {}", scoped));
+    let output = netns::exec_in_netns(&scoped, cmd, args)
+        .await
+        .unwrap_or_else(|e| panic!("Failed to run '{}' in {}: {}", command, scoped, e));
+    assert!(
+        !output.contains(&needle),
+        "'{}' in namespace {} unexpectedly contained '{}'\nfull output:\n{}",
+        command,
+        scoped,
+        needle,
+        output,
+    );
+    println!(
+        "✓ '{}' in namespace {} does not contain '{}'",
+        command, scoped, needle
+    );
+}
+
 /// Assert the IS-IS LSDB at the given level (`L1` or `L2`) in a namespace
 /// holds at least one self-originated LSP. Reads
 /// `vtyctl show -j "show isis database"`, whose JSON is

--- a/bdd/tests/features/interface_bridge.feature
+++ b/bdd/tests/features/interface_bridge.feature
@@ -1,0 +1,78 @@
+@serial
+@interface_bridge
+Feature: Interface-to-bridge enslavement (`interface <if-name> bridge <bridge>`)
+  As a network operator
+  I want `interface <if-name> bridge <bridge>` to enslave a port to a bridge
+  So that the binding is staged and applied once both the interface and the
+  bridge exist — config order is free (equivalent to
+  `ip link set <if-name> master <bridge>`).
+
+  The binding is durable desired-state, mirroring `interface <if-name> vrf
+  <vrf>`: it survives the bridge being created AFTER the interface config, an
+  explicit unbind clears it, and the bridge being deleted then re-created
+  re-applies it. We drive config with `apply command` (surgical set/delete)
+  and assert the kernel state via `ip -o link show <if>` — `show interface`
+  does not expose the master.
+
+  Topology: one namespace `z1` with a single `dummy` port `dum0`. The bridge
+  is created by the daemon from config (a namespace-internal kernel device),
+  so no host-side bridge/veth scoping is needed.
+
+  Scenario: Setup namespace with a dummy port
+    Given a clean test environment
+    When I create namespace "z1"
+    And I execute "ip link add dum0 type dummy" in namespace "z1"
+    And I execute "ip link set dum0 up" in namespace "z1"
+    And I start zebra-rs in namespace "z1"
+
+  # Scenario A: bind staged before the bridge exists, applied on bridge create.
+  Scenario: A - binding set before the bridge exists is applied once it is created
+    Given the test topology exists
+    When I apply command "set interface dum0 bridge br0" in namespace "z1"
+    And I wait 2 seconds
+    # The bridge does not exist yet, so the bind stays pending: no master.
+    Then command "ip -o link show dum0" in namespace "z1" should not contain "master"
+    When I apply command "set bridge br0" in namespace "z1"
+    # Bridge created -> the pending bind fires and enslaves dum0.
+    Then command "ip -o link show dum0" in namespace "z1" should eventually contain "master br0"
+    # reset
+    When I apply command "delete interface dum0 bridge br0" in namespace "z1"
+    And I apply command "delete bridge br0" in namespace "z1"
+    Then command "ip -o link show dum0" in namespace "z1" should eventually not contain "master"
+
+  # Scenario B: an unbind clears the pending intent so a later bridge does NOT enslave.
+  Scenario: B - unbind clears the pending binding before the bridge appears
+    Given the test topology exists
+    When I apply command "set interface dum0 bridge br1" in namespace "z1"
+    And I wait 2 seconds
+    Then command "ip -o link show dum0" in namespace "z1" should not contain "master"
+    When I apply command "delete interface dum0 bridge br1" in namespace "z1"
+    And I apply command "set bridge br1" in namespace "z1"
+    And I wait 3 seconds
+    # Pending was cleared, so creating br1 must NOT enslave dum0.
+    Then command "ip -o link show dum0" in namespace "z1" should not contain "master"
+    # reset
+    When I apply command "delete bridge br1" in namespace "z1"
+
+  # Scenario C: the binding is durable across a bridge delete + re-create.
+  Scenario: C - binding survives the bridge being deleted and re-binds on re-create
+    Given the test topology exists
+    When I apply command "set interface dum0 bridge br2" in namespace "z1"
+    And I apply command "set bridge br2" in namespace "z1"
+    Then command "ip -o link show dum0" in namespace "z1" should eventually contain "master br2"
+    When I apply command "delete bridge br2" in namespace "z1"
+    # Bridge gone -> kernel releases the port; the intent stays pending.
+    Then command "ip -o link show dum0" in namespace "z1" should eventually not contain "master"
+    When I apply command "set bridge br2" in namespace "z1"
+    # Re-created -> the retained pending bind re-applies.
+    Then command "ip -o link show dum0" in namespace "z1" should eventually contain "master br2"
+    # reset
+    When I apply command "delete interface dum0 bridge br2" in namespace "z1"
+    And I apply command "delete bridge br2" in namespace "z1"
+    Then command "ip -o link show dum0" in namespace "z1" should eventually not contain "master"
+
+  Scenario: Teardown topology
+    Given the test topology exists
+    When I stop zebra-rs in namespace "z1"
+    And I delete namespace "z1"
+    Then the test environment should be clean

--- a/zebra-rs/src/config/manager.rs
+++ b/zebra-rs/src/config/manager.rs
@@ -2013,6 +2013,39 @@ mod yang_load_tests {
         );
     }
 
+    /// `interface <name> bridge <bridge>` enslaves the interface to a
+    /// bridge master device (equivalent to `ip link set <name> master
+    /// <bridge>`). The `bridge` leaf is a leafref to `/bridge/name`; pin
+    /// that the `set` path parses so a future YANG edit that drops or
+    /// renames the leaf is caught here rather than silently turning the
+    /// runtime handler into a no-op. (`delete` of a leaf is not a
+    /// `parse()`-settable path — like every other leaf, it flows through
+    /// a separate dispatch — so only the `set` form is pinned here.)
+    #[test]
+    fn interface_bridge_is_settable() {
+        use crate::config::ExecCode;
+        use crate::config::parse::{State, parse};
+        use libyang::to_entry;
+
+        let mut yang = YangStore::new();
+        yang.add_path(concat!(env!("CARGO_MANIFEST_DIR"), "/yang"));
+        yang.read_with_resolve("configure")
+            .expect("configure mode loads");
+        yang.identity_resolve();
+        let module = yang
+            .find_module("configure")
+            .expect("configure module present");
+        let entry = to_entry(&yang, module);
+
+        let (code, _comps, _state) =
+            parse("set interface eth0 bridge br0", entry, None, State::new());
+        assert_eq!(
+            code,
+            ExecCode::Success,
+            "`set interface eth0 bridge br0` must parse as a settable path",
+        );
+    }
+
     /// The per-neighbor `afi-safi ipv6 encapsulation-type` knob is a
     /// hand-added leaf on the vendored `ietf-bgp-neighbor` afi-safi list.
     /// `load_mode` proves the module loads but not that the concrete path

--- a/zebra-rs/src/rib/inst.rs
+++ b/zebra-rs/src/rib/inst.rs
@@ -248,6 +248,17 @@ pub enum Message {
         ifname: String,
         vrf: Option<String>,
     },
+    /// Bind / unbind an interface to a bridge master device
+    /// (`ip link set <ifname> master <bridge>` / `... nomaster`).
+    /// `bridge == Some(name)` enslaves to that bridge; `None` detaches
+    /// (sets IFLA_MASTER = 0). Like `LinkVrfBind`, the handler tolerates
+    /// the interface or the bridge not yet existing in our tables and
+    /// stages the intent in `pending_bridge_bind`, firing it when the
+    /// missing kernel device appears via `link_add`.
+    LinkBridgeBind {
+        ifname: String,
+        bridge: Option<String>,
+    },
     MacAdd {
         vni: u32,
         mac: MacAddr,
@@ -557,6 +568,12 @@ pub struct Rib {
     /// when a missing interface or VRF master appears later, and clears
     /// the entry once the netlink call succeeds.
     pub pending_vrf_bind: BTreeMap<String, Option<String>>,
+    /// Operator intent for per-interface bridge binding, keyed by
+    /// ifname. `Some(bridge)` = enslave; `None` = detach. Mirrors
+    /// `pending_vrf_bind`: retried when either the interface or the
+    /// bridge master appears later, kept as durable desired-state across
+    /// link flaps, and cleared on detach.
+    pub pending_bridge_bind: BTreeMap<String, Option<String>>,
     /// Operator-configured interface MTU, keyed by ifname. This is the
     /// durable desired-state for `set interface <name> mtu <n>`: it is
     /// applied to the kernel when set, replayed when a matching link
@@ -707,6 +724,7 @@ impl Rib {
             vrf_tables: BTreeMap::new(),
             vrf_id_alloc: VrfIdAllocator::new(),
             pending_vrf_bind: BTreeMap::new(),
+            pending_bridge_bind: BTreeMap::new(),
             mtu_config: BTreeMap::new(),
             table: PrefixMap::new(),
             table_v6: PrefixMap::new(),
@@ -2013,6 +2031,91 @@ impl Rib {
                     vrf
                 );
             }
+            Message::LinkBridgeBind { ifname, bridge } => {
+                // Always record operator intent so a later kernel
+                // NewLink (the slave interface appears, or the bridge
+                // master is created) can fire the bind without the
+                // operator re-issuing the command.
+                if bridge.is_none() {
+                    self.pending_bridge_bind.remove(&ifname);
+                } else {
+                    self.pending_bridge_bind
+                        .insert(ifname.clone(), bridge.clone());
+                }
+
+                let (ifindex, current_master) = match self.links.values().find(|l| l.name == ifname)
+                {
+                    Some(link) => (link.index, link.master.unwrap_or(0)),
+                    None => {
+                        tracing::info!(
+                            "link_bridge_bind: interface {} not present yet — pending",
+                            ifname
+                        );
+                        return;
+                    }
+                };
+
+                // Resolve the bridge to its kernel ifindex. `master == 0`
+                // detaches (`ip link set ... nomaster`). Gate on TWO
+                // things, mirroring how the VRF bind resolves through
+                // `self.vrfs`:
+                //   1. config presence (`self.bridges`) — `BridgeDel`
+                //      removes the entry synchronously, BEFORE the netlink
+                //      delete that releases this port. The released port's
+                //      RTM_NEWLINK (master cleared) re-fires this bind via
+                //      `link_add`; gating here means it sees the bridge
+                //      already gone and stays pending, instead of racing a
+                //      `link_set_master` against the vanishing device —
+                //      which the kernel rejects with EINVAL. The `bridge`
+                //      leaf is a leafref to `/bridge/name`, so a bound
+                //      bridge is always a configured one.
+                //   2. kernel presence (`self.links`) for the ifindex — it
+                //      lands there once `BridgeAdd`'s netlink create echoes
+                //      back as RTM_NEWLINK.
+                let master_ifindex = match &bridge {
+                    Some(bridge) => {
+                        if !self.bridges.contains_key(bridge) {
+                            tracing::info!(
+                                "link_bridge_bind: bridge {} not configured — pending",
+                                bridge
+                            );
+                            return;
+                        }
+                        match self.links.values().find(|l| l.name == *bridge) {
+                            Some(l) => l.index,
+                            None => {
+                                tracing::info!(
+                                    "link_bridge_bind: bridge {} not present yet — pending",
+                                    bridge
+                                );
+                                return;
+                            }
+                        }
+                    }
+                    None => 0,
+                };
+
+                // Only touch the kernel when the master actually changes.
+                // `pending_bridge_bind` is durable desired-state, so
+                // `link_add` replays this on every RTM_NEWLINK for the
+                // interface; without this guard the enslave burst would
+                // re-issue redundant `link_set_master` calls (see the
+                // `LinkVrfBind` guard for the same rationale).
+                if current_master == master_ifindex {
+                    return;
+                }
+
+                self.fib_handle
+                    .link_set_master(ifindex, master_ifindex)
+                    .await;
+                tracing::info!(
+                    "link_bridge_bind: ifname={} ifindex={} master={} bridge={:?}",
+                    ifname,
+                    ifindex,
+                    master_ifindex,
+                    bridge
+                );
+            }
             Message::BlockAdd { name, config } => {
                 let block = config.to_block();
                 self.blocks.insert(name.clone(), block);
@@ -2511,6 +2614,7 @@ impl Rib {
                 // (`rib:<handler>`) as the first path segment.
                 let comps = match msg.paths.first().map(|p| p.name.as_str()) {
                     Some("vrf") => self.vrf_comps(),
+                    Some("bridge") => self.bridge_comps(),
                     _ => self.link_comps(),
                 };
                 msg.resp.unwrap().send(comps).unwrap();

--- a/zebra-rs/src/rib/link.rs
+++ b/zebra-rs/src/rib/link.rs
@@ -690,7 +690,37 @@ impl Rib {
             .map(|l| l.name.clone())
             .unwrap_or_default();
         if let Some(vrf) = self.pending_vrf_bind.get(&ifname).cloned() {
-            let _ = self.tx.send(Message::LinkVrfBind { ifname, vrf });
+            let _ = self.tx.send(Message::LinkVrfBind {
+                ifname: ifname.clone(),
+                vrf,
+            });
+        }
+
+        // Replay any pending bridge binding now that a link (re)appeared.
+        // Two cases, both keyed off the just-arrived link, cover either
+        // config/creation order:
+        //   1. this link is the *slave* that was waiting to be enslaved
+        //      (operator set `bridge` before the interface appeared, or
+        //      before its bridge existed).
+        //   2. this link is the *bridge master* one or more slaves were
+        //      waiting on (BridgeAdd's netlink create just echoed back).
+        if let Some(bridge) = self.pending_bridge_bind.get(&ifname).cloned() {
+            let _ = self.tx.send(Message::LinkBridgeBind {
+                ifname: ifname.clone(),
+                bridge,
+            });
+        }
+        let waiting: Vec<(String, Option<String>)> = self
+            .pending_bridge_bind
+            .iter()
+            .filter(|(_, b)| b.as_deref() == Some(ifname.as_str()))
+            .map(|(slave, b)| (slave.clone(), b.clone()))
+            .collect();
+        for (slave, bridge) in waiting {
+            let _ = self.tx.send(Message::LinkBridgeBind {
+                ifname: slave,
+                bridge,
+            });
         }
     }
 
@@ -729,6 +759,13 @@ impl Rib {
     /// of the VRFs currently applied (one per kernel master device).
     pub fn vrf_comps(&self) -> Vec<String> {
         self.vrfs.keys().cloned().collect()
+    }
+
+    /// Completion candidates for the `rib:bridge` dynamic key — the
+    /// names of the bridges currently configured (the eligible master
+    /// devices for `interface <name> master <bridge>`).
+    pub fn bridge_comps(&self) -> Vec<String> {
+        self.bridges.keys().cloned().collect()
     }
 
     /// Add an IPv4 or IPv6 address to an interface link.
@@ -1047,6 +1084,19 @@ pub async fn link_config_exec(
             None
         };
         let _ = rib.tx.send(Message::LinkVrfBind { ifname, vrf });
+    } else if path == "/interface/bridge" {
+        // `set interface X bridge BR`   → enslave X to bridge master BR.
+        // `delete interface X bridge [BR]` → detach X from its bridge.
+        // The optional name on delete is ignored: the intent is
+        // unambiguous and we tolerate either form (mirrors `vrf`).
+        let bridge = if op.is_set() {
+            Some(args.string().context("missing bridge name")?)
+        } else {
+            // Drain any trailing token so it isn't picked up later.
+            let _ = args.string();
+            None
+        };
+        let _ = rib.tx.send(Message::LinkBridgeBind { ifname, bridge });
     } else if path == "/interface/mtu" {
         // `set interface X mtu N`    → record desired MTU and apply it.
         // `delete interface X mtu`   → drop the desired MTU and restore

--- a/zebra-rs/yang/config.yang
+++ b/zebra-rs/yang/config.yang
@@ -2883,6 +2883,23 @@ module config {
            Omitted means the interface lives in the default routing
            instance.";
       }
+      leaf bridge {
+        // Same priority as `vrf` (and mutually exclusive with it in
+        // practice — an interface has a single kernel IFLA_MASTER):
+        // apply the enslave before any address.
+        ext:sort "11";
+        ext:dynamic "rib:bridge";
+        type leafref {
+          path "/bridge/name";
+        }
+        description
+          "Enslave this interface to the named bridge master device,
+           equivalent to `ip link set <if-name> master <bridge>`. The
+           bind is staged and applied once both the interface and the
+           bridge exist in the kernel, so config order is free (the
+           bridge may be created after this leaf is set). Omitted means
+           the interface is not a bridge port.";
+      }
       leaf mtu {
         ext:help "Maximum transmission unit in bytes";
         type uint32 {


### PR DESCRIPTION
## Summary

Adds an interface-node command `interface <if-name> bridge <bridge>` that enslaves a port to a bridge master device (equivalent to `ip link set <if-name> master <bridge>`). It is modelled on the existing `interface <if-name> vrf <vrf>` deferred binding, so **config order is free**: the operator intent is staged in `pending_bridge_bind` and applied once both the interface and the bridge exist in the kernel.

### Changes
- **`config.yang`**: new `bridge` leaf (leafref to `/bridge/name`, `rib:bridge` completion) on the interface list, same sort tier as `vrf`.
- **`LinkBridgeBind` message + handler** (`rib/inst.rs`): resolves the bridge through **both** config presence (`self.bridges`) and kernel presence (`self.links`), mirroring how the VRF bind resolves through `self.vrfs`. Gating on `self.bridges` — which `BridgeDel` clears *synchronously* before the netlink delete — avoids racing a `link_set_master` against a vanishing bridge during teardown (the kernel rejects that with `EINVAL`).
- **`link_add` replay** (`rib/link.rs`): replays the pending bind when either the slave interface or the bridge master appears, covering both creation orders.
- **`bridge_comps`** dynamic completion + `/interface/bridge` config dispatch.
- **Unit test**: pins `set interface <name> bridge <bridge>` as a settable path.
- **BDD**: `interface_bridge.feature` (staged-bind, unbind-clears-pending, bridge delete+re-create re-bind) plus reusable `command … should [eventually] [not] contain` kernel-state assertion steps.

## Test plan
- `cargo fmt --all --check` clean; `cargo clippy --workspace --all-targets -- -D warnings` clean.
- All 1349 `zebra-rs` bin unit tests pass (incl. the new `interface_bridge_is_settable`).
- **Live** (namespace + dummy port): all three scenarios (A bind→create, B bind→unbind→create, C bind→create→delete→re-create) pass for **both** `bridge` and `vrf` binding, with **no EINVAL**.
- **BDD** `@interface_bridge`: 38/38 steps pass, clean teardown, no leaked namespaces/daemons.

Generated with [Claude Code](https://claude.com/claude-code)