### PR TITLE
Add `vxlan <name> bridge <bridge>` enslavement

### DIFF
--- a/bdd/tests/features/vxlan_bridge.feature
+++ b/bdd/tests/features/vxlan_bridge.feature
@@ -1,0 +1,70 @@
+@serial
+@vxlan_bridge
+Feature: VXLAN-to-bridge enslavement (`vxlan <name> bridge <bridge>`)
+  As a network operator
+  I want `vxlan <name> bridge <bridge>` to enslave a VXLAN device to a bridge
+  So that an EVPN-style bridge port is set up in one step, with the VXLAN
+  bridge-slave defaults applied automatically.
+
+  This reuses the same staged bridge-bind as `interface <name> bridge
+  <bridge>` (a VXLAN is an ordinary kernel link), so config order is free.
+  In addition, binding a VXLAN to a bridge must yield the defaults from the
+  iproute2 recipe:
+    ip link set <vni> master <BR> addrgenmode none
+    ip link set <vni> type bridge_slave neigh_suppress on learning off
+  - `addrgenmode none` is the VXLAN creation default.
+  - `neigh_suppress on` + `learning off` are applied by
+    `vxlan_bridge_port_defaults` when the VXLAN gains a bridge master.
+
+  We assert kernel state via `ip -d link show <vni>` (the `-d` detail view
+  exposes addrgenmode and the bridge_slave port options).
+
+  Scenario: Setup namespace with a VXLAN device
+    Given a clean test environment
+    When I create namespace "z1"
+    And I execute "ip link add dum0 type dummy" in namespace "z1"
+    And I execute "ip addr add 10.0.0.1/24 dev dum0" in namespace "z1"
+    And I execute "ip link set dum0 up" in namespace "z1"
+    And I start zebra-rs in namespace "z1"
+    And I apply command "set vxlan vni550 vni 550" in namespace "z1"
+    And I apply command "set vxlan vni550 local-address 10.0.0.1" in namespace "z1"
+    And I wait 2 seconds
+    # The VXLAN device exists with addrgenmode none even before any bridge.
+    Then command "ip -d link show vni550" in namespace "z1" should eventually contain "addrgenmode none"
+
+  # Scenario A: binding applies master + all bridge-slave defaults.
+  Scenario: A - binding applies master and the VXLAN bridge-slave defaults
+    Given the test topology exists
+    When I apply command "set bridge br0" in namespace "z1"
+    And I apply command "set vxlan vni550 bridge br0" in namespace "z1"
+    Then command "ip -d link show vni550" in namespace "z1" should eventually contain "master br0"
+    And command "ip -d link show vni550" in namespace "z1" should eventually contain "neigh_suppress on"
+    And command "ip -d link show vni550" in namespace "z1" should eventually contain "learning off"
+    And command "ip -d link show vni550" in namespace "z1" should eventually contain "addrgenmode none"
+    # reset
+    When I apply command "delete vxlan vni550 bridge br0" in namespace "z1"
+    And I apply command "delete bridge br0" in namespace "z1"
+    Then command "ip -d link show vni550" in namespace "z1" should eventually not contain "master"
+
+  # Scenario B: binding set before the bridge exists is applied on create,
+  # with the same defaults (config order is free).
+  Scenario: B - deferred bind applies the defaults once the bridge is created
+    Given the test topology exists
+    When I apply command "set vxlan vni550 bridge br1" in namespace "z1"
+    And I wait 2 seconds
+    Then command "ip -d link show vni550" in namespace "z1" should not contain "master"
+    When I apply command "set bridge br1" in namespace "z1"
+    Then command "ip -d link show vni550" in namespace "z1" should eventually contain "master br1"
+    And command "ip -d link show vni550" in namespace "z1" should eventually contain "neigh_suppress on"
+    And command "ip -d link show vni550" in namespace "z1" should eventually contain "learning off"
+    And command "ip -d link show vni550" in namespace "z1" should eventually contain "addrgenmode none"
+    # reset
+    When I apply command "delete vxlan vni550 bridge br1" in namespace "z1"
+    And I apply command "delete bridge br1" in namespace "z1"
+    Then command "ip -d link show vni550" in namespace "z1" should eventually not contain "master"
+
+  Scenario: Teardown topology
+    Given the test topology exists
+    When I stop zebra-rs in namespace "z1"
+    And I delete namespace "z1"
+    Then the test environment should be clean

--- a/book/src/ch-00-03-interface-configuration.md
+++ b/book/src/ch-00-03-interface-configuration.md
@@ -18,6 +18,7 @@ interface enp0s6 {
 | `/interface/<name>/if-name` | `string` | List key — the kernel interface name. |
 | `/interface/<name>/mtu` | `uint32` (68..65535) | Maximum transmission unit in bytes. See below. |
 | `/interface/<name>/vrf` | leafref `/vrf/name` | Enslave the interface to a VRF master device. |
+| `/interface/<name>/bridge` | leafref `/bridge/name` | Enslave the interface to a bridge master device. See below. |
 | `/interface/<name>/ipv4/address` | `inet:ipv4-prefix` | IPv4 address (with prefix length). |
 | `/interface/<name>/ipv6/address` | `inet:ipv6-prefix` | IPv6 address (with prefix length). |
 
@@ -25,6 +26,40 @@ The list entry itself is not a separate "create interface" operation —
 it just attaches configuration to a kernel device that already exists
 (or appears later). zebra-rs does not create physical or virtual links
 from this block.
+
+## Bridge and VRF enslavement
+
+The `bridge` and `vrf` leaves enslave the interface to a master device —
+the equivalent of `ip link set <name> master <master>`:
+
+```
+interface enp0s6 {
+  bridge br0;     # make enp0s6 a port of the Linux bridge br0
+}
+interface enp0s7 {
+  vrf CUST-A;     # move enp0s7 into the VRF CUST-A
+}
+```
+
+Both write the kernel `IFLA_MASTER`, so they are mutually exclusive — an
+interface has exactly one master. `bridge` is a leafref to
+`/bridge/name` and `vrf` a leafref to `/vrf/name`; the referenced device
+is the one zebra-rs creates from its own
+[`bridge`](ch-00-05-bridge-configuration.md) / `vrf` block.
+
+The bind is **staged**, the same way the configured MTU is: it is held
+as durable desired-state and applied once *both* the interface and the
+master device exist in the kernel, so the order of configuration and
+device creation is irrelevant. If the bridge is configured after the
+interface, the enslavement fires when the bridge appears; if the bridge
+is later deleted, the kernel releases the port and zebra-rs re-applies
+the bind automatically when the bridge is re-created.
+
+Remove the binding with the master name as the argument:
+
+```
+no interface enp0s6 bridge br0
+```
 
 ## MTU
 
@@ -126,7 +161,8 @@ they are sourced from one RIB-driven update, not independent reads.
 | `interface <n> mtu <v>` | `mtu <v>` (interface) / `ip link set <n> mtu <v>` |
 | `no interface <n> mtu` | restore original — no direct FRR equivalent (FRR leaves the last value) |
 | `interface <n> ipv4 address <p>` | `ip address <p>` (interface) |
-| `interface <n> vrf <name>` | `ip link set <n> master <name>` |
+| `interface <n> vrf <name>` | `ip link set <n> master <name>` (VRF master) |
+| `interface <n> bridge <name>` | `ip link set <n> master <name>` (bridge master) |
 
 Note the delete semantics differ: zebra-rs restores the
 originally-observed MTU, whereas iproute2/FRR simply leave whatever was

--- a/book/src/ch-00-04-vxlan-configuration.md
+++ b/book/src/ch-00-04-vxlan-configuration.md
@@ -43,6 +43,7 @@ set vxlan vni550 dest-port 4789
 | `/vxlan/<name>/local-address` | `inet:ipv4-address` \| `inet:ipv6-address` | no | Source VTEP address → `IFLA_VXLAN_LOCAL` / `IFLA_VXLAN_LOCAL6`. |
 | `/vxlan/<name>/dest-port` | `uint16` | no | UDP destination port → `IFLA_VXLAN_PORT`. Defaults to `4789`. |
 | `/vxlan/<name>/address-gen-mode` | `enum {none, eui64, random, stable-secret}` | no | IPv6 link-local address generation mode. Defaults to `none`. |
+| `/vxlan/<name>/bridge` | leafref `/bridge/name` | no | Enslave the VXLAN to a bridge master → `IFLA_MASTER`. Triggers the bridge-slave defaults below. |
 
 ## Defaults applied automatically
 
@@ -70,11 +71,29 @@ These are part of the `RTM_NEWLINK` that creates the device:
 ### When the device joins a bridge
 
 A VXLAN device only carries an L2 service once it is enslaved to a Linux
-bridge. zebra-rs does **not** assign the bridge master itself — that is
-done externally (`ip link set vni550 master <bridge>`, or by your
-bridge-management tooling) and zebra-rs **observes** it over netlink.
-The moment it sees a VXLAN device gain a bridge master, it applies the
-bridge-slave defaults to the port:
+bridge. Enslave it with the `bridge` leaf — the equivalent of
+`ip link set vni550 master <bridge>`:
+
+```
+vxlan vni550 {
+  vni 550;
+  local-address 10.0.0.1;
+  bridge br550;
+}
+```
+
+`bridge` is a leafref to `/bridge/name`, and the bind is **staged** — it
+is applied once both the VXLAN and the bridge exist in the kernel, so
+the order of configuration is irrelevant. This is the same deferred
+mechanism as [`interface <name>
+bridge`](ch-00-03-interface-configuration.md#bridge-and-vrf-enslavement),
+which the VXLAN binding reuses directly. zebra-rs also still
+**observes** enslavement performed externally
+(`ip link set vni550 master <bridge>`), so either path works.
+
+The moment a VXLAN device gains a bridge master — by config or by an
+external action — zebra-rs applies the bridge-slave defaults to the
+port:
 
 | Default | Netlink | `ip link` equivalent | Why |
 |---|---|---|---|
@@ -100,16 +119,25 @@ ip link set vni550 up
 
 map onto zebra-rs as:
 
-* `set vxlan vni550 vni 550 / local-address 10.0.0.1 / dest-port 4789`
-  — the device, with `nolearning`, `addrgenmode none`, and `up` applied
-  automatically (the first command plus the `addrgenmode`/`up` parts).
-* `ip link set vni550 master br550` — **still external**; zebra-rs
-  observes it.
-* on observing that master, zebra-rs applies `neigh_suppress on` and
+```
+set bridge br550
+set vxlan vni550 vni 550
+set vxlan vni550 local-address 10.0.0.1
+set vxlan vni550 dest-port 4789
+set vxlan vni550 bridge br550
+```
+
+* the `vxlan` leaves create the device, with `nolearning`,
+  `addrgenmode none`, and `up` applied automatically (the first command
+  plus the `addrgenmode`/`up` parts);
+* `set vxlan vni550 bridge br550` enslaves it — the equivalent of
+  `ip link set vni550 master br550` (the second command);
+* on gaining that master, zebra-rs applies `neigh_suppress on` and
   `learning off` automatically (the third command).
 
-So the operator supplies the VNI / VTEP / port and the bridge
-enslavement; zebra-rs fills in every EVPN-correct default.
+So the operator supplies the VNI / VTEP / port and names the bridge;
+zebra-rs creates the devices, performs the enslavement, and fills in
+every EVPN-correct default.
 
 ## Deleting the configuration
 
@@ -137,9 +165,9 @@ box. An explicit `dest-port` always takes precedence.
 | `vxlan <n> local-address <ip>` | `... type vxlan local <ip>` |
 | `vxlan <n> dest-port <p>` | `... type vxlan dstport <p>` |
 | `vxlan <n> address-gen-mode <m>` | `ip link set <n> addrgenmode <m>` |
+| `vxlan <n> bridge <name>` | `ip link set <n> master <name>` |
 | *(automatic)* `nolearning` | `... type vxlan ... nolearning` |
 | *(automatic)* device up | `ip link set <n> up` |
 | *(automatic on bridge-join)* `neigh_suppress on` | `ip link set <n> type bridge_slave neigh_suppress on` |
 | *(automatic on bridge-join)* `learning off` | `ip link set <n> type bridge_slave learning off` |
 | `no vxlan <n>` | `ip link del <n>` |
-| *(external)* bridge enslavement | `ip link set <n> master <bridge>` |

--- a/book/src/ch-00-05-bridge-configuration.md
+++ b/book/src/ch-00-05-bridge-configuration.md
@@ -59,6 +59,33 @@ ip link set br550 addrgenmode none
 ip link set br550 up
 ```
 
+## Enslaving ports to the bridge
+
+Ports are enslaved from *their own* config block — not the bridge's —
+each with a `bridge` leafref to `/bridge/name` (the equivalent of
+`ip link set <port> master <bridge>`):
+
+```
+interface enp0s6 {
+  bridge br550;        # a local access port
+}
+vxlan vni550 {
+  vni 550;
+  bridge br550;        # the EVPN VXLAN tunnel
+}
+```
+
+The bind is staged the same way for both: it is applied once the port
+*and* the bridge exist in the kernel, so the bridge may be configured
+before or after its members, and a deleted-and-recreated bridge
+re-acquires them automatically. Enslaving a VXLAN additionally triggers
+the EVPN bridge-slave defaults (`neigh_suppress on`, `learning off`) on
+the port.
+
+See [Interface Configuration](ch-00-03-interface-configuration.md#bridge-and-vrf-enslavement)
+and [VXLAN Configuration](ch-00-04-vxlan-configuration.md#when-the-device-joins-a-bridge)
+for the full details.
+
 ## Deleting the configuration
 
 Removing the list entry deletes the kernel device (`RTM_DELLINK`, the
@@ -75,4 +102,6 @@ no bridge br550
 | `bridge <n>` | `ip link add <n> type bridge` |
 | `bridge <n> address-gen-mode <m>` | `ip link set <n> addrgenmode <m>` |
 | *(automatic)* device up | `ip link set <n> up` |
+| `interface <p> bridge <n>` | `ip link set <p> master <n>` (enslave a port) |
+| `vxlan <p> bridge <n>` | `ip link set <p> master <n>` (enslave a VXLAN) |
 | `no bridge <n>` | `ip link del <n>` |

--- a/zebra-rs/src/config/manager.rs
+++ b/zebra-rs/src/config/manager.rs
@@ -2046,6 +2046,36 @@ mod yang_load_tests {
         );
     }
 
+    /// `vxlan <name> bridge <bridge>` enslaves a VXLAN device to a bridge,
+    /// reusing the same `bridge` leafref (to `/bridge/name`) as the
+    /// interface case. Pin that the `set` path parses so a future YANG
+    /// edit dropping/renaming the leaf is caught here rather than silently
+    /// turning the `/vxlan/bridge` dispatch into a no-op.
+    #[test]
+    fn vxlan_bridge_is_settable() {
+        use crate::config::ExecCode;
+        use crate::config::parse::{State, parse};
+        use libyang::to_entry;
+
+        let mut yang = YangStore::new();
+        yang.add_path(concat!(env!("CARGO_MANIFEST_DIR"), "/yang"));
+        yang.read_with_resolve("configure")
+            .expect("configure mode loads");
+        yang.identity_resolve();
+        let module = yang
+            .find_module("configure")
+            .expect("configure module present");
+        let entry = to_entry(&yang, module);
+
+        let (code, _comps, _state) =
+            parse("set vxlan vni550 bridge br0", entry, None, State::new());
+        assert_eq!(
+            code,
+            ExecCode::Success,
+            "`set vxlan vni550 bridge br0` must parse as a settable path",
+        );
+    }
+
     /// The per-neighbor `afi-safi ipv6 encapsulation-type` knob is a
     /// hand-added leaf on the vendored `ietf-bgp-neighbor` afi-safi list.
     /// `load_mode` proves the module loads but not that the concrete path

--- a/zebra-rs/src/rib/inst.rs
+++ b/zebra-rs/src/rib/inst.rs
@@ -1803,6 +1803,13 @@ impl Rib {
                 self.fib_handle.vxlan_add(&vxlan).await;
             }
             Message::VxlanDel { name } => {
+                // Deleting the VXLAN device removes its kernel master
+                // implicitly. Drop any staged bridge-bind for it so a
+                // later same-named VXLAN isn't silently re-enslaved by a
+                // stale intent (belt-and-braces: a `delete vxlan X bridge
+                // BR` line, when present, already clears it via the
+                // `/vxlan/bridge` dispatch above).
+                self.pending_bridge_bind.remove(&name);
                 let vxlan = Vxlan {
                     name: name.clone(),
                     ..Default::default()
@@ -2572,7 +2579,7 @@ impl Rib {
                 //
             }
             ConfigOp::Set | ConfigOp::Delete => {
-                let (path, args) = path_from_command(&msg.paths);
+                let (path, mut args) = path_from_command(&msg.paths);
                 if path.as_str() == "/system/router-id" {
                     let _ = self.router_id_config_exec(args, msg.op);
                 } else if path.as_str().starts_with("/router/static/ipv4/route") {
@@ -2586,6 +2593,34 @@ impl Rib {
                     let _ = link_config_exec(self, path, args, msg.op).await;
                 } else if path.as_str().starts_with("/bridge") {
                     let _ = self.bridge_config.exec(path, args, msg.op);
+                } else if path.as_str() == "/vxlan/bridge" {
+                    // `set vxlan X bridge BR` enslaves the VXLAN device X
+                    // to bridge BR, reusing the SAME deferred bridge-bind
+                    // as `interface X bridge BR` (a VXLAN is an ordinary
+                    // kernel link in `self.links`, keyed by name). The
+                    // VXLAN-specific bridge-slave defaults are applied
+                    // automatically: `neigh_suppress on` + `learning off`
+                    // by `vxlan_bridge_port_defaults` (fired from
+                    // `link_add` when a VXLAN gains a master), and
+                    // addrgenmode none is the VXLAN creation default. We
+                    // intercept here rather than routing through the
+                    // VxlanBuilder so a bridge-only change doesn't re-emit
+                    // VxlanAdd (which would re-create the device). The
+                    // leaf still lands in the running-config tree like the
+                    // interface case. `delete … bridge BR` carries the
+                    // value, which we drain and treat as detach.
+                    if let Some(name) = args.string() {
+                        let bridge = if msg.op.is_set() {
+                            args.string()
+                        } else {
+                            let _ = args.string();
+                            None
+                        };
+                        let _ = self.tx.send(Message::LinkBridgeBind {
+                            ifname: name,
+                            bridge,
+                        });
+                    }
                 } else if path.as_str().starts_with("/vxlan") {
                     let _ = self.vxlan_config.exec(path, args, msg.op);
                 } else if path.as_str().starts_with("/vrf") {

--- a/zebra-rs/yang/config.yang
+++ b/zebra-rs/yang/config.yang
@@ -324,6 +324,23 @@ module config {
           enum stable-secret;
         }
       }
+      leaf bridge {
+        ext:dynamic "rib:bridge";
+        type leafref {
+          path "/bridge/name";
+        }
+        description
+          "Enslave this VXLAN device to the named bridge master,
+           equivalent to `ip link set <name> master <bridge>`. Reuses
+           the same staged bridge-bind as `interface <name> bridge
+           <bridge>` (applied once both the VXLAN and the bridge exist,
+           so config order is free), and the VXLAN bridge-slave defaults
+           are applied automatically: addrgenmode none (the VXLAN
+           creation default) plus `neigh_suppress on` and `learning off`
+           on the bridge port (set by `vxlan_bridge_port_defaults` when
+           the VXLAN gains a master). Omitted means the VXLAN is not a
+           bridge port.";
+      }
     }
 
     container system {


### PR DESCRIPTION
## Summary

Adds a `bridge` leaf to the `vxlan` list — `set vxlan <name> bridge <bridge>` — that enslaves a VXLAN device to a bridge master. It **reuses the same deferred bridge-bind** introduced for `interface <name> bridge <bridge>` (#1525): a VXLAN is an ordinary kernel link keyed by name in `self.links`, so `LinkBridgeBind` works on it unchanged.

The VXLAN-specific bridge-slave defaults come for free, reproducing the canonical EVPN bring-up:
- `neigh_suppress on` + `learning off` — applied by the existing `vxlan_bridge_port_defaults`, which `link_add` fires when a VXLAN gains a bridge master;
- `addrgenmode none` — the VXLAN creation default.

### Changes
- **`config.yang`**: `bridge` leafref leaf (to `/bridge/name`, `rib:bridge` completion) on the `vxlan` list.
- **`inst.rs`**: dispatch `/vxlan/bridge` → `LinkBridgeBind`, intercepted *before* the `VxlanBuilder` so a bridge-only change doesn't re-create the device; `VxlanDel` clears any stale pending bind.
- **Unit test**: pins `set vxlan <name> bridge <bridge>` as a settable path.
- **BDD**: `vxlan_bridge.feature` asserts `master`, `addrgenmode none`, `neigh_suppress on`, `learning off` in both immediate and deferred (bridge-created-after) orderings.
- **Docs** (`book/`): document the command in the interface / vxlan / bridge chapters; the VXLAN bridge enslavement is no longer "external", so the VXLAN chapter is updated accordingly.

## Test plan
- `cargo fmt --all --check` clean; `cargo clippy --workspace --all-targets -- -D warnings` clean.
- All 1350 `zebra-rs` bin unit tests pass (incl. the new `vxlan_bridge_is_settable`).
- **Live** (namespace + VXLAN device): `ip -d link show vni550` shows `master <br>`, `addrgenmode none`, `neigh_suppress on`, `learning off` — in both immediate and deferred order, no EINVAL.
- **BDD** `@vxlan_bridge`: 36/36 steps pass, clean teardown.
- `mdbook build` succeeds.

Generated with [Claude Code](https://claude.com/claude-code)