### PR TITLE
Add `system tracing fib link` category for bridge enslavement traces

### DIFF
--- a/zebra-rs/src/rib/inst.rs
+++ b/zebra-rs/src/rib/inst.rs
@@ -2054,10 +2054,12 @@ impl Rib {
                 {
                     Some(link) => (link.index, link.master.unwrap_or(0)),
                     None => {
-                        tracing::info!(
-                            "link_bridge_bind: interface {} not present yet — pending",
-                            ifname
-                        );
+                        if crate::rib::tracing::fib_link() {
+                            tracing::info!(
+                                "link_bridge_bind: interface {} not present yet — pending",
+                                ifname
+                            );
+                        }
                         return;
                     }
                 };
@@ -2082,19 +2084,23 @@ impl Rib {
                 let master_ifindex = match &bridge {
                     Some(bridge) => {
                         if !self.bridges.contains_key(bridge) {
-                            tracing::info!(
-                                "link_bridge_bind: bridge {} not configured — pending",
-                                bridge
-                            );
+                            if crate::rib::tracing::fib_link() {
+                                tracing::info!(
+                                    "link_bridge_bind: bridge {} not configured — pending",
+                                    bridge
+                                );
+                            }
                             return;
                         }
                         match self.links.values().find(|l| l.name == *bridge) {
                             Some(l) => l.index,
                             None => {
-                                tracing::info!(
-                                    "link_bridge_bind: bridge {} not present yet — pending",
-                                    bridge
-                                );
+                                if crate::rib::tracing::fib_link() {
+                                    tracing::info!(
+                                        "link_bridge_bind: bridge {} not present yet — pending",
+                                        bridge
+                                    );
+                                }
                                 return;
                             }
                         }
@@ -2115,13 +2121,15 @@ impl Rib {
                 self.fib_handle
                     .link_set_master(ifindex, master_ifindex)
                     .await;
-                tracing::info!(
-                    "link_bridge_bind: ifname={} ifindex={} master={} bridge={:?}",
-                    ifname,
-                    ifindex,
-                    master_ifindex,
-                    bridge
-                );
+                if crate::rib::tracing::fib_link() {
+                    tracing::info!(
+                        "link_bridge_bind: ifname={} ifindex={} master={} bridge={:?}",
+                        ifname,
+                        ifindex,
+                        master_ifindex,
+                        bridge
+                    );
+                }
             }
             Message::BlockAdd { name, config } => {
                 let block = config.to_block();

--- a/zebra-rs/src/rib/tracing.rs
+++ b/zebra-rs/src/rib/tracing.rs
@@ -57,6 +57,7 @@ struct State {
     fib_neighbor: AtomicBool,
     fib_interface: AtomicBool,
     fib_interface_detail: AtomicBool,
+    fib_link: AtomicBool,
     fib_vrf: AtomicBool,
     fib_srv6: AtomicBool,
     fib_srv6_detail: AtomicBool,
@@ -93,6 +94,7 @@ impl State {
             fib_neighbor: AtomicBool::new(false),
             fib_interface: AtomicBool::new(false),
             fib_interface_detail: AtomicBool::new(false),
+            fib_link: AtomicBool::new(false),
             fib_vrf: AtomicBool::new(false),
             fib_srv6: AtomicBool::new(false),
             fib_srv6_detail: AtomicBool::new(false),
@@ -145,6 +147,7 @@ impl State {
             "/fib/neighbor" => self.fib_neighbor.store(set, Relaxed),
             "/fib/interface" => toggle(&self.fib_interface, &self.fib_interface_detail, op),
             "/fib/interface/detail" => detail(&self.fib_interface, &self.fib_interface_detail, op),
+            "/fib/link" => self.fib_link.store(set, Relaxed),
             "/fib/vrf" => self.fib_vrf.store(set, Relaxed),
             "/fib/srv6" => toggle(&self.fib_srv6, &self.fib_srv6_detail, op),
             "/fib/srv6/detail" => detail(&self.fib_srv6, &self.fib_srv6_detail, op),
@@ -228,6 +231,9 @@ pub fn fib_nexthop() -> bool {
 pub fn fib_srv6() -> bool {
     STATE.on(&STATE.fib_srv6)
 }
+pub fn fib_link() -> bool {
+    STATE.on(&STATE.fib_link)
+}
 pub fn fib_l2_vxlan() -> bool {
     STATE.on(&STATE.fib_l2_vxlan)
 }
@@ -274,12 +280,22 @@ mod tests {
     }
 
     #[test]
+    fn fib_link_toggle_set_delete() {
+        let s = State::new();
+        s.apply("/fib/link", &mut args(&[]), ConfigOp::Set);
+        assert!(s.on(&s.fib_link));
+        s.apply("/fib/link", &mut args(&[]), ConfigOp::Delete);
+        assert!(!s.on(&s.fib_link));
+    }
+
+    #[test]
     fn all_master_switch_lights_every_category() {
         let s = State::new();
         s.apply("/all", &mut args(&[]), ConfigOp::Set);
         assert!(s.on(&s.rib_route));
         assert!(s.on(&s.fib_l2_fdb));
         assert!(s.on(&s.fib_srv6));
+        assert!(s.on(&s.fib_link));
         // `all` is summary-level only — never implies detail.
         assert!(!s.fib_route_detail.load(Relaxed));
         s.apply("/all", &mut args(&[]), ConfigOp::Delete);

--- a/zebra-rs/yang/zebra-rib-tracing.yang
+++ b/zebra-rs/yang/zebra-rib-tracing.yang
@@ -47,8 +47,9 @@ module zebra-rib-tracing {
          into the kernel over netlink (routes, nexthop groups, the
          raw southbound messages in either direction, the MPLS LFIB,
          the ARP / ND neighbor table, interface / address programming,
-         VRF devices, SRv6 `seg6local` SIDs, and L2 / EVPN objects
-         (bridge, VXLAN, FDB, MDB)).
+         link master-binding (bridge enslavement), VRF devices, SRv6
+         `seg6local` SIDs, and L2 / EVPN objects (bridge, VXLAN, FDB,
+         MDB)).
 
      The category set was derived by cataloguing every existing
      `tracing::` site in `src/rib` and `src/fib` and giving each a
@@ -86,6 +87,14 @@ module zebra-rib-tracing {
      presence (rather than a `true` value) matches the IS-IS / OSPF /
      BGP `tracing` blocks: the config callbacks key off set vs delete
      and never read a value, so `type empty` is the honest type.";
+
+  revision 2026-06-19 {
+    description
+      "Add the `fib link` category — gates the link master-binding
+       traces (bridge enslavement / `link_set_master` and the
+       deferred-bind bookkeeping) that previously logged
+       unconditionally.";
+  }
 
   revision 2026-06-05 {
     description
@@ -227,8 +236,9 @@ module zebra-rib-tracing {
           "Dataplane categories: what is programmed into the kernel
            over netlink — routes, nexthop groups, the raw southbound
            messages, the MPLS LFIB, the ARP / ND table, interface /
-           address programming, VRF devices, SRv6 `seg6local` SIDs,
-           and L2 / EVPN objects (bridge, VXLAN, FDB, MDB).";
+           address programming, link master-binding (bridge
+           enslavement), VRF devices, SRv6 `seg6local` SIDs, and L2 /
+           EVPN objects (bridge, VXLAN, FDB, MDB).";
 
         container route {
           ext:help "Trace route programming to the kernel";
@@ -295,6 +305,15 @@ module zebra-rib-tracing {
              kernel: link admin up, MTU set, dummy-device create /
              delete, and address add / delete over netlink.";
           uses rib-tracing-detail-option;
+        }
+        leaf link {
+          ext:help "Trace link enslavement / master binding to the kernel";
+          type empty;
+          description
+            "Log link master-binding programming: enslaving an interface
+             to a bridge master over netlink (`link_set_master`), plus the
+             deferred-bind bookkeeping that holds the bind pending until
+             both the slave interface and the bridge device appear.";
         }
         leaf vrf {
           ext:help "Trace VRF device programming to the kernel";


### PR DESCRIPTION
## Summary

The four `link_bridge_bind` traces in the RIB's `LinkBridgeBind` handler (`rib/inst.rs`) logged at `info!` **unconditionally**, so they flooded the default log on every bridge enslavement and on every deferred-bind replay (each `RTM_NEWLINK` re-fires the pending bind). This adds a new `fib link` runtime tracing category that gates them, matching how every other category in the `system tracing` block behaves.

Enable at runtime (no rebuild) with `set system tracing fib link`, or via the `all` master switch.

## Changes

- **`zebra-rib-tracing.yang`** — add the `fib link` leaf (`type empty`, presence-style) next to `vrf`, since both concern enslaving an interface to a kernel master. New `2026-06-19` revision entry; refreshed the two module-prose category lists.
- **`rib/tracing.rs`** — add the `fib_link` atomic (struct + `new()`), the `"/fib/link"` dispatch arm, the `fib_link()` reader, plus a `fib_link_toggle_set_delete` unit test and an assertion under the `all` master switch.
- **`rib/inst.rs`** — wrap all four `link_bridge_bind` `info!` sites in `if crate::rib::tracing::fib_link()`.

This is a runtime trace toggle, not a behavioral change; the only default-behavior delta is that these four info lines are now off by default instead of always-on.

## Test plan

- `cargo build -p zebra-rs` — clean
- `cargo clippy --workspace --all-targets` — clean (forced re-lint via `touch`)
- `cargo test -p zebra-rs rib::tracing` — 6/6 pass (incl. new `fib_link_toggle_set_delete`)
- `cargo test -p zebra-rs yang_load` — 32/32 pass (confirms the new YANG leaf parses; cargo/clippy don't validate YANG)

Generated with [Claude Code](https://claude.com/claude-code)