### PR TITLE
bgp: undefined peer policy/prefix-set name is deny-all with soft-reconfig

### DIFF
--- a/bdd/Makefile
+++ b/bdd/Makefile
@@ -186,6 +186,10 @@ bgp_vrf_evpn_type5:
 	mkdir -p allure-results
 	cargo test --test cucumber -- --concurrency=1 --tags "@bgp_vrf_evpn_type5"
 
+bgp_evpn_outpolicy_undef:
+	mkdir -p allure-results
+	cargo test --test cucumber -- --concurrency=1 --tags "@bgp_evpn_outpolicy_undef"
+
 bgp_route_map_match:
 	mkdir -p allure-results
 	cargo test --test cucumber -- --concurrency=1 --tags "@bgp_route_map_match"
@@ -265,4 +269,4 @@ docs/%.md: tests/features/%.feature docs/feature2md.sh FORCE
 
 FORCE:
 
-.PHONY: ecmp_bfd_evict ospfv2_bfd_frr ospfv3_bfd_frr tilfa_bfd all run ibgp ebgp rr rib_static_ipv6 isis_ipv6 isis_srv6 isis_fragmentation_ipv6 isis_fragmentation_ipv4 isis_l1p2p isis_tilfa isis_l1l2 isis_redist isis_hello_auth_keychain isis_passive isis_afi_enable isis_endx_ipv6 isis_bfd_ipv6_p2p isis_bfd_ipv6_p2p_echo isis_bfd_ipv6_lan isis_bfd_ipv6_lan_echo isis_bfd_ipv4_p2p isis_bfd_ipv4_p2p_echo isis_bfd_ipv4_lan isis_bfd_ipv4_lan_echo ospf_clear_neighbor ospfv2_nssa ospfv2_stub ospfv2_tilfa ospfv3_nssa ospfv3_tilfa stamp_te_metric stamp_v6_te_metric bgp_peer_down_cleanup bgp_ipv6_over_v4_session bgp_evpn_capability bgp_vrf_evpn_type5 bgp_route_map_match bgp_policy_dynamic_update bgp_table_map bgp_v6_table_map bgp_community bgp_neighbor_group bgp_unnumbered_neighbor nd_show bgp_interas_option_c bgp_interas_option_a bgp_interas_option_b bgp_interas_option_ab bgp_port bgp_ip_transparent bgp_local_as generate open docs FORCE
+.PHONY: ecmp_bfd_evict ospfv2_bfd_frr ospfv3_bfd_frr tilfa_bfd all run ibgp ebgp rr rib_static_ipv6 isis_ipv6 isis_srv6 isis_fragmentation_ipv6 isis_fragmentation_ipv4 isis_l1p2p isis_tilfa isis_l1l2 isis_redist isis_hello_auth_keychain isis_passive isis_afi_enable isis_endx_ipv6 isis_bfd_ipv6_p2p isis_bfd_ipv6_p2p_echo isis_bfd_ipv6_lan isis_bfd_ipv6_lan_echo isis_bfd_ipv4_p2p isis_bfd_ipv4_p2p_echo isis_bfd_ipv4_lan isis_bfd_ipv4_lan_echo ospf_clear_neighbor ospfv2_nssa ospfv2_stub ospfv2_tilfa ospfv3_nssa ospfv3_tilfa stamp_te_metric stamp_v6_te_metric bgp_peer_down_cleanup bgp_ipv6_over_v4_session bgp_evpn_capability bgp_vrf_evpn_type5 bgp_evpn_outpolicy_undef bgp_route_map_match bgp_policy_dynamic_update bgp_table_map bgp_v6_table_map bgp_community bgp_neighbor_group bgp_unnumbered_neighbor nd_show bgp_interas_option_c bgp_interas_option_a bgp_interas_option_b bgp_interas_option_ab bgp_port bgp_ip_transparent bgp_local_as generate open docs FORCE

--- a/bdd/tests/configs/bgp_evpn_outpolicy_undef/z1-permit.yaml
+++ b/bdd/tests/configs/bgp_evpn_outpolicy_undef/z1-permit.yaml
@@ -1,0 +1,40 @@
+# z1 originates 10.1.0.0/24 from vrf-blue as an EVPN Type-5 route and
+# advertises it to z2 over the L2VPN/EVPN address family. The EVPN
+# outbound policy is bound to PERMIT-ALL, which exists and permits
+# everything, so z2 receives the route.
+policy:
+- name: PERMIT-ALL
+  entry:
+  - number: 10
+    action: permit
+vrf:
+- name: vrf-blue
+  ipv4:
+    route-target:
+      import:
+      - 65001:100
+      export:
+      - 65001:100
+router:
+  bgp:
+    global:
+      as: 65001
+      router-id: 192.168.0.1
+    neighbor:
+    - remote-address: 192.168.0.2
+      afi-safi:
+      - name: evpn
+        enabled: true
+        policy:
+          out: PERMIT-ALL
+      enabled: true
+      remote-as: 65001
+    vrf:
+    - name: vrf-blue
+      rd: 65001:100
+      evpn:
+        advertise-ipv4: true
+      afi-safi:
+        ipv4:
+          network:
+          - prefix: 10.1.0.0/24

--- a/bdd/tests/configs/bgp_evpn_outpolicy_undef/z1-recover.yaml
+++ b/bdd/tests/configs/bgp_evpn_outpolicy_undef/z1-recover.yaml
@@ -1,0 +1,44 @@
+# The neighbor stays bound to NOPE, but NOPE is now defined as a
+# permit-all policy. Defining a previously-undefined referenced policy
+# must replay through the watch and re-advertise the EVPN Type-5 route to
+# z2 — again without a session reset.
+policy:
+- name: PERMIT-ALL
+  entry:
+  - number: 10
+    action: permit
+- name: NOPE
+  entry:
+  - number: 10
+    action: permit
+vrf:
+- name: vrf-blue
+  ipv4:
+    route-target:
+      import:
+      - 65001:100
+      export:
+      - 65001:100
+router:
+  bgp:
+    global:
+      as: 65001
+      router-id: 192.168.0.1
+    neighbor:
+    - remote-address: 192.168.0.2
+      afi-safi:
+      - name: evpn
+        enabled: true
+        policy:
+          out: NOPE
+      enabled: true
+      remote-as: 65001
+    vrf:
+    - name: vrf-blue
+      rd: 65001:100
+      evpn:
+        advertise-ipv4: true
+      afi-safi:
+        ipv4:
+          network:
+          - prefix: 10.1.0.0/24

--- a/bdd/tests/configs/bgp_evpn_outpolicy_undef/z1-undef.yaml
+++ b/bdd/tests/configs/bgp_evpn_outpolicy_undef/z1-undef.yaml
@@ -1,0 +1,42 @@
+# Same as z1-permit.yaml but the EVPN outbound policy is rebound from
+# PERMIT-ALL to NOPE, a policy name that is NOT defined. A bound-but-
+# unresolved peer policy is deny-all, so the EVPN Type-5 route must be
+# withdrawn from z2 immediately, without a session reset. (PERMIT-ALL is
+# left defined but unreferenced so the only diff is the neighbor's
+# out-policy name.)
+policy:
+- name: PERMIT-ALL
+  entry:
+  - number: 10
+    action: permit
+vrf:
+- name: vrf-blue
+  ipv4:
+    route-target:
+      import:
+      - 65001:100
+      export:
+      - 65001:100
+router:
+  bgp:
+    global:
+      as: 65001
+      router-id: 192.168.0.1
+    neighbor:
+    - remote-address: 192.168.0.2
+      afi-safi:
+      - name: evpn
+        enabled: true
+        policy:
+          out: NOPE
+      enabled: true
+      remote-as: 65001
+    vrf:
+    - name: vrf-blue
+      rd: 65001:100
+      evpn:
+        advertise-ipv4: true
+      afi-safi:
+        ipv4:
+          network:
+          - prefix: 10.1.0.0/24

--- a/bdd/tests/configs/bgp_evpn_outpolicy_undef/z2-1.yaml
+++ b/bdd/tests/configs/bgp_evpn_outpolicy_undef/z2-1.yaml
@@ -1,0 +1,25 @@
+# z2 peers with z1 over L2VPN/EVPN and imports Type-5 routes carrying
+# RT 65001:100 into vrf-blue. Mirrors the bgp_vrf_evpn_type5 receiver.
+vrf:
+- name: vrf-blue
+  ipv4:
+    route-target:
+      import:
+      - 65001:100
+      export:
+      - 65001:100
+router:
+  bgp:
+    global:
+      as: 65001
+      router-id: 192.168.0.2
+    neighbor:
+    - remote-address: 192.168.0.1
+      afi-safi:
+      - name: evpn
+        enabled: true
+      enabled: true
+      remote-as: 65001
+    vrf:
+    - name: vrf-blue
+      rd: 65001:200

--- a/bdd/tests/features/bgp_evpn_outpolicy_undef.feature
+++ b/bdd/tests/features/bgp_evpn_outpolicy_undef.feature
@@ -1,0 +1,79 @@
+@serial
+@bgp_evpn_outpolicy_undef
+Feature: EVPN outbound policy rebound to an undefined name is deny-all
+  As a network operator
+  I want a BGP neighbor whose EVPN outbound policy is rebound to a
+  policy name that does not exist to immediately withdraw the routes it
+  was advertising, rather than keep leaking them with the previously
+  resolved policy still applied.
+
+  A bound-but-unresolved peer policy is deny-all. Previously the policy
+  actor stayed silent when a peer registered an undefined policy name, so
+  no soft-reconfiguration fired and the stale resolved policy lingered:
+  the neighbor kept advertising. The actor now answers even with a `None`
+  policy, which clears the stale resolve and drives a soft-out that
+  withdraws the now-denied routes — all without a session reset.
+
+  The exercise: z1 originates 10.1.0.0/24 in vrf-blue and advertises it to
+  z2 as an EVPN Type-5 route. z1's EVPN outbound policy starts bound to an
+  existing PERMIT-ALL policy (z2 sees the route), is then rebound to the
+  undefined NOPE (z2 must lose the route), and finally NOPE is defined as
+  permit (z2 must see the route again).
+
+  Test Topology:
+  ```
+  ┌─────────────────────────────────────────┐
+  │                   br0                   │
+  └─────────────┬───────────────┬───────────┘
+                │               │
+           ┌────┴────┐     ┌────┴────┐
+           │   z1    │     │   z2    │
+           │ AS65001 │     │ AS65001 │
+           │192.168. │     │192.168. │
+           │  0.1/24 │     │  0.2/24 │
+           └─────────┘     └─────────┘
+  ```
+
+  Config files:
+  - z1-permit.yaml: vrf-blue originates 10.1.0.0/24, EVPN out-policy bound
+    to the existing PERMIT-ALL.
+  - z1-undef.yaml: EVPN out-policy rebound to the undefined NOPE.
+  - z1-recover.yaml: NOPE defined as a permit policy.
+  - z2-1.yaml: EVPN receiver importing RT 65001:100 into vrf-blue.
+
+  Scenario: Setup topology and verify the route is advertised under PERMIT-ALL
+    Given a clean test environment
+    When I create bridge "br0"
+    And I create namespace "z1" with IP "192.168.0.1/24" on bridge "br0"
+    And I create namespace "z2" with IP "192.168.0.2/24" on bridge "br0"
+    And I start zebra-rs in namespace "z1"
+    And I start zebra-rs in namespace "z2"
+    And I apply config "z1-permit.yaml" to namespace "z1"
+    And I apply config "z2-1.yaml" to namespace "z2"
+    And I wait 10 seconds for BGP to operate
+    Then BGP session in "z1" to "192.168.0.2" should be "Established"
+    And BGP session in "z2" to "192.168.0.1" should be "Established"
+    And show command "show bgp evpn" in namespace "z2" should contain "10.1.0.0"
+
+  Scenario: Rebinding the EVPN out-policy to an undefined name withdraws the route
+    Given the test topology exists
+    When I apply config "z1-undef.yaml" to namespace "z1"
+    And I wait 5 seconds for BGP to operate
+    Then BGP session in "z2" to "192.168.0.1" should be "Established"
+    And show command "show bgp evpn" in namespace "z2" should not contain "10.1.0.0"
+
+  Scenario: Defining the previously-undefined policy re-advertises the route
+    Given the test topology exists
+    When I apply config "z1-recover.yaml" to namespace "z1"
+    And I wait 5 seconds for BGP to operate
+    Then BGP session in "z2" to "192.168.0.1" should be "Established"
+    And show command "show bgp evpn" in namespace "z2" should contain "10.1.0.0"
+
+  Scenario: Teardown topology
+    Given the test topology exists
+    When I stop zebra-rs in namespace "z1"
+    And I stop zebra-rs in namespace "z2"
+    And I delete namespace "z1"
+    And I delete namespace "z2"
+    And I delete bridge "br0"
+    Then the test environment should be clean

--- a/zebra-rs/src/policy/inst.rs
+++ b/zebra-rs/src/policy/inst.rs
@@ -24,10 +24,11 @@ pub enum PolicyType {
     /// A BGP per-AFI `table-map` binding (zebra-bgp-table-map.yang).
     /// Rides the same policy-list watch registry as
     /// `PolicyListIn`/`Out`, but `ident` encodes the AFI/SAFI rather
-    /// than a peer index, and `Register` always answers — even with
-    /// `policy_list: None` — because an unresolved table-map is
-    /// deny-all (FRR parity) and the subscriber needs the definitive
-    /// answer to resync its FIB installs exactly once.
+    /// than a peer index. Like the policy-lists it shares the registry
+    /// with, `Register` always answers — even with `policy_list: None`
+    /// — because an unresolved table-map is deny-all (FRR parity) and
+    /// the subscriber needs the definitive answer to resync its FIB
+    /// installs exactly once.
     TableMap,
     /// Subscription to a named `/key-chains/key-chain <name>`. The
     /// inner `KeyChainScope` lets the subscribed protocol
@@ -300,17 +301,22 @@ impl Policy {
             } => {
                 match policy_type {
                     PolicyType::PrefixSetIn | PolicyType::PrefixSetOut => {
-                        if let Some(prefix_set) = self.prefix_config.config.get(&name) {
-                            // Advertise.
-                            if let Some(tx) = self.clients.get(&proto) {
-                                let msg = PolicyRx::PrefixSet {
-                                    name: name.clone(),
-                                    ident,
-                                    policy_type,
-                                    prefix_set: Some(prefix_set.clone()),
-                                };
-                                let _ = tx.send(msg);
-                            }
+                        // Always answer, even when the named set is
+                        // absent (`prefix_set: None`): like a policy-list
+                        // a bound-but-unresolved prefix-set is deny-all,
+                        // so the subscriber must hear the `None` to clear
+                        // a stale resolved set (e.g. after a rebind to an
+                        // undefined name) and soft-reconfigure. Definition
+                        // later replays via the `watch_prefix` entry below.
+                        let prefix_set = self.prefix_config.config.get(&name).cloned();
+                        if let Some(tx) = self.clients.get(&proto) {
+                            let msg = PolicyRx::PrefixSet {
+                                name: name.clone(),
+                                ident,
+                                policy_type,
+                                prefix_set,
+                            };
+                            let _ = tx.send(msg);
                         }
                         let watch = PolicyWatch {
                             proto,
@@ -320,15 +326,20 @@ impl Policy {
                         self.watch_prefix.entry(name).or_default().push(watch);
                     }
                     PolicyType::PolicyListIn | PolicyType::PolicyListOut | PolicyType::TableMap => {
-                        // Peer policies only answer when the list
-                        // exists (absent = permit-all, nothing to
-                        // replay). A table-map answers even with
-                        // `None`: unresolved is deny-all, and the
-                        // subscriber resyncs on the reply.
+                        // Always answer, even when the named list is
+                        // absent (`policy_list: None`). For a peer
+                        // policy a bound-but-unresolved name is
+                        // deny-all, so the subscriber must hear the
+                        // `None` to clear any stale resolved policy
+                        // (e.g. after a rebind from an existing name to
+                        // an undefined one) and run a soft-reconfig that
+                        // withdraws routes the now-missing policy no
+                        // longer permits. A table-map likewise resyncs
+                        // on `None`. Re-resolution once the name is
+                        // later defined arrives via the `watch_policy`
+                        // notification registered below.
                         let policy_list = self.policy_config.config.get(&name).cloned();
-                        if (policy_list.is_some() || policy_type == PolicyType::TableMap)
-                            && let Some(tx) = self.clients.get(&proto)
-                        {
+                        if let Some(tx) = self.clients.get(&proto) {
                             let msg = PolicyRx::PolicyList {
                                 name: name.clone(),
                                 ident,


### PR DESCRIPTION
## Summary

A BGP neighbor whose per-AFI outbound (or inbound) policy-list or prefix-set was rebound to a **name that does not exist** kept advertising its routes instead of withdrawing them. Two compounding defects:

- The policy actor's `Register` handler stayed silent when the named policy/prefix-set did not resolve (only existing names, or table-maps, got a reply). So no `PolicyRx` reached BGP, `process_policy_msg` never ran, and `apply_soft_out_peer` / `apply_soft_in_peer` never fired.
- Changing the bound name never cleared the previously-resolved policy object, so the apply path (`route_apply_policy_out_evpn`, `apply_policy_net`) saw `name = Some`, `policy_list = Some(<stale>)` and kept applying the **old** policy.

An unresolved peer policy/prefix-set is deny-all (matching the existing `name.is_some() && resolved.is_none()` arms). The fix makes the actor's `Register` **always answer** for `PolicyListIn/Out` and `PrefixSetIn/Out`, even with a `None` payload. The existing `process_policy_msg` path then assigns the `None` (clearing the stale resolve), rebuilds the cached out-policy, and runs a soft-reconfiguration, so the now-denied routes are withdrawn **without a session reset**. Re-resolution once the name is later defined still replays via the `watch_policy` / `watch_prefix` notification.

Blast radius is BGP-only: ISIS registers only `KeyChain`, and OSPF/ISIS ignore `PolicyRx::PolicyList`/`PrefixSet`.

## Test plan

Adds `@bgp_evpn_outpolicy_undef` BDD: z1 advertises an EVPN Type-5 route to z2 under `PERMIT-ALL`, rebinds the EVPN out-policy to an undefined name (z2 must **withdraw** the route), then defines that name as permit (z2 must see it again) — all without a session reset.

- `cargo fmt --all` — clean
- `cargo clippy --workspace --all-targets -- -D warnings` — clean
- `cargo test -p zebra-rs` — 1352 passed, 0 failed
- BDD `@bgp_evpn_outpolicy_undef` — 4/4 scenarios pass
- **Negative control:** the same BDD **fails** scenario 2 on the pre-fix binary (route not withdrawn), confirming the test catches the regression.

Generated with [Claude Code](https://claude.com/claude-code)