### PR TITLE
bgp: disable default single-shard / egress-task info logging

### DIFF
--- a/zebra-rs/src/bgp/inst.rs
+++ b/zebra-rs/src/bgp/inst.rs
@@ -429,7 +429,8 @@ pub fn init_shard_count(config_shards: Option<usize>) -> usize {
     if n > 1 {
         tracing::info!("BGP RIB sharding: {n} shards (from {source})");
     } else {
-        tracing::info!("BGP RIB sharding: 1 shard, synchronous (from {source})");
+        // Disable default logging.
+        // tracing::info!("BGP RIB sharding: 1 shard, synchronous (from {source})");
     }
     n
 }

--- a/zebra-rs/src/bgp/peer_egress.rs
+++ b/zebra-rs/src/bgp/peer_egress.rs
@@ -69,7 +69,8 @@ pub fn init_peer_task(config: Option<bool>) -> bool {
     if on {
         tracing::info!("BGP per-peer egress task: enabled (from {source})");
     } else {
-        tracing::info!("BGP per-peer egress task: disabled (from {source})");
+        // Disable default logging.
+        // tracing::info!("BGP per-peer egress task: disabled (from {source})");
     }
     on
 }


### PR DESCRIPTION
## Summary
- Comment out the `info!` log lines that fire on the **default** BGP configuration:
  - `inst.rs`: single-shard / synchronous RIB message
  - `peer_egress.rs`: per-peer egress task *disabled* message
- These no longer emit at the default log level; the non-default branches (multi-shard, egress task enabled) still log as before.

## Test plan
- `cargo fmt --all` clean (comment-only diff)
- CI: `cargo fmt`, `cargo clippy`, `cargo test`

Generated with [Claude Code](https://claude.com/claude-code)