### PR TITLE
deps: use libyang 1.0 from crates.io

### DIFF
--- a/zebra-rs/Cargo.toml
+++ b/zebra-rs/Cargo.toml
@@ -22,7 +22,8 @@ tokio-stream.workspace = true
 tonic.workspace = true
 tonic-prost.workspace = true
 console-subscriber = "0.5"
-libyang = { git = "https://github.com/zebra-rs/libyang", rev = "103b60c2d560a91d37fa26502eb3d495db1cdb99" }
+libyang = "1"
+#libyang = { git = "https://github.com/zebra-rs/libyang", rev = "103b60c2d560a91d37fa26502eb3d495db1cdb99" }
 #libyang = { path = "../../libyang" }
 regex = "1.10"
 similar = "3"


### PR DESCRIPTION
## Summary

`libyang` is now published to crates.io, so depend on the released `"1"` version instead of the pinned git rev. The git and path lines are kept commented out for easy local fallback, matching the convention used for the other forked dependencies.

## Test plan

- `cargo check -p zebra-rs` compiles cleanly against `libyang v1.0.0` — the API is compatible with the previous git rev (0.8.2).

Generated with [Claude Code](https://claude.com/claude-code)