### PR TITLE
packaging: set GH_REPO in publish-apt (fix release create without checkout)

### DIFF
--- a/.github/workflows/publish-apt.yaml
+++ b/.github/workflows/publish-apt.yaml
@@ -33,6 +33,9 @@ jobs:
         codename: [jammy, noble, resolute]
     env:
       GH_TOKEN: ${{ github.token }}
+      # This job has no checkout (it works from downloaded artifacts), so gh can't
+      # infer the repo from a git remote. Tell it explicitly.
+      GH_REPO: ${{ github.repository }}
     steps:
       - name: Install apt tooling
         run: sudo apt-get update && sudo apt-get install -y dpkg-dev apt-utils gnupg


### PR DESCRIPTION
The `publish-apt` job (in `publish-apt.yaml`) has no `actions/checkout` — it works purely from downloaded artifacts — so `gh release view/create/upload` had no git remote to infer the repository from and failed with:

```
failed to run git: fatal: not a git repository (or any of the parent directories): .git
```

Fix: set `GH_REPO: ${{ github.repository }}` at the job level so every `gh` call targets the repo explicitly (cleaner than adding a checkout just for repo context).

Validated by run [27884923062](https://github.com/zebra-rs/zebra-rs/actions/runs/27884923062): all 6 builds ✓, nightly release ✓, signing ✓ (key import + sign succeeded) — only the `gh release create` step failed, which this fixes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)