### PR TITLE
ci: bump Node-20 actions to Node-24 majors

### DIFF
--- a/.github/workflows/build-amd64.yaml
+++ b/.github/workflows/build-amd64.yaml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Rust
         uses: actions-rust-lang/setup-rust-toolchain@v1
 
@@ -41,7 +41,7 @@ jobs:
           make -C packaging amd64
 
       - name: Upload basefs artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: zebra-rs-amd64
           path: |

--- a/.github/workflows/build-arm64.yaml
+++ b/.github/workflows/build-arm64.yaml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-22.04-arm
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Rust
         uses: actions-rust-lang/setup-rust-toolchain@v1
 
@@ -41,7 +41,7 @@ jobs:
           make -C packaging arm64
 
       - name: Upload basefs artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: zebra-rs-arm64
           path: |

--- a/.github/workflows/build-debs.yaml
+++ b/.github/workflows/build-debs.yaml
@@ -31,7 +31,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Rust
         uses: actions-rust-lang/setup-rust-toolchain@v1
@@ -93,7 +93,7 @@ jobs:
           ls -la *.deb
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: deb-${{ matrix.dist }}-${{ matrix.arch }}
           path: ./packaging/*.deb
@@ -122,7 +122,7 @@ jobs:
           apt-get install -y curl git ca-certificates sudo build-essential pkg-config xxd
 
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Rust
         uses: actions-rust-lang/setup-rust-toolchain@v1
@@ -183,7 +183,7 @@ jobs:
           ls -la *.deb
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: deb-resolute-${{ matrix.arch }}
           path: ./packaging/*.deb

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Rust
         uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
@@ -29,7 +29,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Install build deps
         run: |
           sudo apt-get update
@@ -46,7 +46,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Install build deps
         run: |
           sudo apt-get update

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -23,12 +23,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0    # Needed to move tags
 
       - name: Download all build artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           path: artifacts
           pattern: deb-*

--- a/.github/workflows/publish-apt.yaml
+++ b/.github/workflows/publish-apt.yaml
@@ -41,7 +41,7 @@ jobs:
         run: sudo apt-get update && sudo apt-get install -y dpkg-dev apt-utils gnupg
 
       - name: Download this codename's freshly built .debs
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           path: incoming
           pattern: deb-${{ matrix.codename }}-*

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -22,7 +22,7 @@ jobs:
     name: Verify tag matches version file
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Tag vs version file
         run: |
           tag="${GITHUB_REF_NAME#v}"
@@ -48,7 +48,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Download all build artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           path: artifacts
           pattern: deb-*


### PR DESCRIPTION
GitHub [deprecated Node 20 on runners](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/); `actions/checkout@v4`, `actions/upload-artifact@v4`, and `actions/download-artifact@v4` were being force-run on Node 24 with a deprecation warning.

Bumped repo-wide to Node-24 majors:
- `actions/checkout@v4` → **`@v5`**
- `actions/upload-artifact@v4` → **`@v7`**
- `actions/download-artifact@v4` → **`@v8`**

Verified before bumping: all three are `using: node24`; `download-artifact@v8` still exposes `pattern` + `merge-multiple` (used by the apt publish + release jobs) and `upload-artifact@v7` still exposes `name`/`path`. `actions-rust-lang/setup-rust-toolchain@v1` and `softprops/action-gh-release@v2` aren't affected by the deprecation and are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)