### PR TITLE
packaging: publish apt repo to zebra-rs.github.io (declutter main /releases)

### DIFF
--- a/.github/workflows/publish-apt.yaml
+++ b/.github/workflows/publish-apt.yaml
@@ -32,10 +32,12 @@ jobs:
       matrix:
         codename: [jammy, noble, resolute]
     env:
-      GH_TOKEN: ${{ github.token }}
-      # This job has no checkout (it works from downloaded artifacts), so gh can't
-      # infer the repo from a git remote. Tell it explicitly.
-      GH_REPO: ${{ github.repository }}
+      # The apt repo is published to a SEPARATE repo so the main repo's /releases
+      # page stays clean (only v* and nightly). That needs a PAT with contents:write
+      # on the target repo -- the default GITHUB_TOKEN can't reach across repos.
+      # GH_REPO also tells gh which repo to act on (this job has no checkout).
+      GH_TOKEN: ${{ secrets.APT_REPO_TOKEN }}
+      GH_REPO: zebra-rs/zebra-rs.github.io
     steps:
       - name: Install apt tooling
         run: sudo apt-get update && sudo apt-get install -y dpkg-dev apt-utils gnupg

--- a/docs/apt-repository.md
+++ b/docs/apt-repository.md
@@ -3,9 +3,11 @@
 How users `apt install zebra-rs` on Ubuntu. Two pieces:
 
 - **Binaries + signed metadata** live as assets on per-codename GitHub Releases
-  in *this* repo (`zebra-rs/zebra-rs`), built by `build-debs.yaml` and published
-  by `publish-apt.yaml` (both reusable `workflow_call` workflows), driven by
-  `nightly.yaml` and `release.yaml`.
+  in the **`zebra-rs/zebra-rs.github.io`** repo (deliberately *not* the main repo,
+  so `zebra-rs/zebra-rs`'s `/releases` page shows only `v*` + `nightly`). They are
+  built by `build-debs.yaml` and published by `publish-apt.yaml` (reusable
+  `workflow_call` workflows in `zebra-rs/zebra-rs`), driven by `nightly.yaml` and
+  `release.yaml`. Cross-repo publishing uses the `APT_REPO_TOKEN` PAT (Step 2).
 - **The public signing key + a landing page** live in the separate Pages repo
   `zebra-rs/zebra-rs.github.io`, served on the custom domain **`https://zebra.rs/`**:
 
@@ -85,6 +87,8 @@ Settings → Secrets and variables → Actions:
 - **Secrets** tab:
   - `APT_GPG_PRIVATE_KEY` = contents of `/tmp/apt-private.b64` (then delete the file)
   - `APT_GPG_PASSPHRASE` = the passphrase from the keyspec
+  - `APT_REPO_TOKEN` = a fine-grained PAT with **Contents: read & write** scoped to
+    `zebra-rs/zebra-rs.github.io` (the repo where apt releases are published)
 - **Variables** tab:
   - `APT_PUBLISH_ENABLED` = `true`   ← the on-switch; set this *last*
 


### PR DESCRIPTION
Moves the `apt-*` / `nightly-*` **infrastructure** releases out of `zebra-rs/zebra-rs` so its [/releases](https://github.com/zebra-rs/zebra-rs/releases) page shows only real downloads (`v*`, `nightly`). GitHub has no "published-but-unlisted" release (only draft, whose assets aren't at the public download URL apt needs), so the only way to hide them is to host them in a different repo.

**Change:** `publish-apt.yaml` now creates the per-codename releases in `zebra-rs/zebra-rs.github.io` instead of the current repo:
```yaml
GH_TOKEN: ${{ secrets.APT_REPO_TOKEN }}   # PAT — default token can't cross repos
GH_REPO: zebra-rs/zebra-rs.github.io
```

**Before merging**, add the secret (see `docs/apt-repository.md`):
- `APT_REPO_TOKEN` — fine-grained PAT, **Contents: read & write** on `zebra-rs/zebra-rs.github.io` only.

After merge: re-run nightly + the `v26.6.2` release to create the apt releases in the new repo, flip `install.sh` + `apt/index.html` to the new download base, then delete the 6 old releases from this repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)