### PR TITLE
static: install router-static-vrf routes into the VRF table

### DIFF
--- a/bdd/tests/configs/static_vrf/z1.yaml
+++ b/bdd/tests/configs/static_vrf/z1.yaml
@@ -1,0 +1,33 @@
+# z1 — a single router with VRF cust holding two CE links. Two
+# static routes *inside the VRF* reach each host's loopback via its
+# CE link; forwarding between the hosts therefore rides entirely on
+# `router static vrf cust` routes installed into the VRF kernel table.
+vrf:
+- name: cust
+  ipv6:
+    route-target:
+      import:
+      - 65000:100
+      export:
+      - 65000:100
+interface:
+- if-name: ce1
+  vrf: cust
+  ipv6:
+    address: 2001:db8:a::1/64
+- if-name: ce2
+  vrf: cust
+  ipv6:
+    address: 2001:db8:b::1/64
+router:
+  static:
+    vrf:
+    - name: cust
+      ipv6:
+        route:
+        - prefix: 2001:db8:aa::1/128
+          nexthop:
+          - address: 2001:db8:a::2
+        - prefix: 2001:db8:bb::1/128
+          nexthop:
+          - address: 2001:db8:b::2

--- a/bdd/tests/features/static_vrf.feature
+++ b/bdd/tests/features/static_vrf.feature
@@ -1,0 +1,50 @@
+@static_vrf
+Feature: Static routes inside a VRF (router static vrf NAME)
+  A static route configured under `router static vrf <name>` installs
+  into that VRF's kernel routing table and forwards traffic. Two hosts
+  hang off one router's VRF, each reached by a per-VRF static route to
+  its loopback; a ping between the host loopbacks proves the VRF static
+  routes are installed and resolving on-link (the gateway sits on a VRF
+  interface, whose connected route the kernel flushes on enslave — so
+  this exercises the on-link `ifindex_origin` resolution path).
+
+  ```
+   hostA ── z1[vrf cust] ── hostB
+   aa::1     (static vrf)    bb::1
+  ```
+
+  Scenario: Build topology and confirm the VRF static routes install
+    Given a clean test environment
+    When I create namespace "z1"
+    And I create namespace "hostA"
+    And I create namespace "hostB"
+    And I connect namespace "z1" interface "ce1" to namespace "hostA" interface "eth0"
+    And I connect namespace "z1" interface "ce2" to namespace "hostB" interface "eth0"
+    And I make namespace "hostA" interface "lo" up
+    And I make namespace "hostB" interface "lo" up
+    And I add address "2001:db8:a::2/64" to interface "eth0" in namespace "hostA"
+    And I add address "2001:db8:aa::1/128" to interface "lo" in namespace "hostA"
+    And I add address "2001:db8:b::2/64" to interface "eth0" in namespace "hostB"
+    And I add address "2001:db8:bb::1/128" to interface "lo" in namespace "hostB"
+    And I add route "2001:db8:bb::1/128" via "2001:db8:a::1" in namespace "hostA"
+    And I add route "2001:db8:b::/64" via "2001:db8:a::1" in namespace "hostA"
+    And I add route "2001:db8:aa::1/128" via "2001:db8:b::1" in namespace "hostB"
+    And I add route "2001:db8:a::/64" via "2001:db8:b::1" in namespace "hostB"
+    And I start zebra-rs in namespace "z1"
+    And I apply config "z1.yaml" to namespace "z1"
+    And I wait 5 seconds
+    Then show command "show ipv6 route vrf cust" in namespace "z1" should contain "2001:db8:aa::1/128"
+    And show command "show ipv6 route vrf cust" in namespace "z1" should contain "2001:db8:bb::1/128"
+
+  Scenario: Traffic forwards between the hosts via the VRF static routes
+    Given the test topology exists
+    Then ping from "hostA" to "2001:db8:bb::1" should eventually succeed
+    And ping from "hostB" to "2001:db8:aa::1" should eventually succeed
+
+  Scenario: Teardown topology
+    Given the test topology exists
+    When I stop zebra-rs in namespace "z1"
+    And I delete namespace "z1"
+    And I delete namespace "hostA"
+    And I delete namespace "hostB"
+    Then the test environment should be clean

--- a/zebra-rs/src/rib/inst.rs
+++ b/zebra-rs/src/rib/inst.rs
@@ -6,7 +6,7 @@ use super::{
     Block, BlockBuilder, BlockConfig, BridgeBuilder, BridgeConfig, DEFAULT_BLOCK_NAME, GroupTrait,
     Link, Locator, LocatorBuilder, LocatorConfig, MacAddr, MplsConfig, Nexthop, NexthopMap,
     NexthopUni, RibSrRx, RibType, Sid, SidBehavior, StaticConfig, V4, V6, Vrf, VrfBuilder,
-    VrfIdAllocator, VrfRibTables, Vxlan, VxlanBuilder, VxlanConfig,
+    VrfIdAllocator, VrfRibTables, VrfStaticConfig, Vxlan, VxlanBuilder, VxlanConfig,
 };
 
 use crate::config::{Args, path_from_command};
@@ -48,6 +48,30 @@ pub enum Message {
         rib: RibEntry,
     },
     Ipv6Del {
+        prefix: Ipv6Net,
+        rib: RibEntry,
+    },
+    /// Static-route install/withdraw into a named VRF's table. The VRF
+    /// name (not the kernel `table_id`) is carried so the message
+    /// survives a VRF whose table isn't up yet — `process_msg` resolves
+    /// it via `self.vrfs`, and the `VrfAdd` reconcile re-emits it.
+    Ipv4AddVrf {
+        vrf: String,
+        prefix: Ipv4Net,
+        rib: RibEntry,
+    },
+    Ipv4DelVrf {
+        vrf: String,
+        prefix: Ipv4Net,
+        rib: RibEntry,
+    },
+    Ipv6AddVrf {
+        vrf: String,
+        prefix: Ipv6Net,
+        rib: RibEntry,
+    },
+    Ipv6DelVrf {
+        vrf: String,
         prefix: Ipv6Net,
         rib: RibEntry,
     },
@@ -389,7 +413,11 @@ impl Message {
     pub fn is_fib_install(&self) -> bool {
         matches!(
             self,
-            Message::Ipv4Add { .. } | Message::Ipv6Add { .. } | Message::IlmAdd { .. }
+            Message::Ipv4Add { .. }
+                | Message::Ipv6Add { .. }
+                | Message::Ipv4AddVrf { .. }
+                | Message::Ipv6AddVrf { .. }
+                | Message::IlmAdd { .. }
         )
     }
 }
@@ -596,6 +624,8 @@ pub struct Rib {
     pub rx: UnboundedReceiver<Message>,
     pub static_v4: StaticConfig<V4>,
     pub static_v6: StaticConfig<V6>,
+    pub static_vrf_v4: VrfStaticConfig<V4>,
+    pub static_vrf_v6: VrfStaticConfig<V6>,
     pub mpls_config: MplsConfig,
     pub link_config: LinkConfig,
     pub bridge_config: BridgeBuilder,
@@ -714,6 +744,8 @@ impl Rib {
             rx,
             static_v4: StaticConfig::<V4>::new(),
             static_v6: StaticConfig::<V6>::new(),
+            static_vrf_v4: VrfStaticConfig::<V4>::new(),
+            static_vrf_v6: VrfStaticConfig::<V6>::new(),
             mpls_config: MplsConfig::new(),
             link_config: LinkConfig::new(),
             bridge_config: BridgeBuilder::new(),
@@ -1640,6 +1672,48 @@ impl Rib {
         table_id
     }
 
+    /// Pre-resolve a VRF-static route's gateway that sits directly on a
+    /// VRF interface by stamping its egress `ifindex_origin`. The kernel
+    /// flushes (and silently re-adds) an interface's addresses when it is
+    /// enslaved to a VRF, which races our connected-route shadow out of
+    /// the per-VRF table — so a table-walk resolution of an on-link
+    /// gateway intermittently fails. `ifindex_origin` makes the resolver
+    /// skip the table walk (`GroupUni::resolve_v6`) and install the route
+    /// on-link, exactly as the kernel resolves it. Only stamps a Uni/Multi
+    /// gateway the source didn't already pin to an interface.
+    fn stamp_vrf_onlink(&self, entry: &mut RibEntry, table_id: u32) {
+        let onlink_ifindex = |nh: IpAddr| -> Option<u32> {
+            self.links.values().find_map(|link| {
+                if self.ifindex_vrf_id(link.index) != table_id {
+                    return None;
+                }
+                let hit = match nh {
+                    IpAddr::V4(a) => link
+                        .addr4
+                        .iter()
+                        .any(|x| matches!(x.addr, IpNet::V4(net) if net.contains(&a))),
+                    IpAddr::V6(a) => link
+                        .addr6
+                        .iter()
+                        .any(|x| matches!(x.addr, IpNet::V6(net) if net.contains(&a))),
+                };
+                hit.then_some(link.index)
+            })
+        };
+        let stamp = |uni: &mut NexthopUni| {
+            if uni.ifindex_origin.is_none()
+                && let Some(ifindex) = onlink_ifindex(uni.addr)
+            {
+                uni.ifindex_origin = Some(ifindex);
+            }
+        };
+        match &mut entry.nexthop {
+            Nexthop::Uni(uni) => stamp(uni),
+            Nexthop::Multi(multi) => multi.nexthops.iter_mut().for_each(stamp),
+            _ => {}
+        }
+    }
+
     async fn process_msg(&mut self, msg: Message, table_id: u32) {
         match msg {
             Message::Ipv4Add { prefix, rib } => {
@@ -1675,6 +1749,42 @@ impl Rib {
                     self.ipv6_route_del(&prefix, rib, table_id).await;
                     self.nht_recompute_and_notify();
                 } else {
+                    self.ipv6_route_del_vrf(table_id, &prefix, rib).await;
+                }
+            }
+            // Static-route install/withdraw into a named VRF's table.
+            // Resolve the VRF name → kernel `table_id`; a VRF that isn't
+            // up yet drops the install (re-emitted by the `VrfAdd`
+            // reconcile once its table exists).
+            Message::Ipv4AddVrf {
+                vrf,
+                prefix,
+                mut rib,
+            } => match self.vrfs.get(&vrf).map(|v| v.table_id) {
+                Some(table_id) => {
+                    self.stamp_vrf_onlink(&mut rib, table_id);
+                    self.ipv4_route_add_vrf(table_id, &prefix, rib).await
+                }
+                None => tracing::debug!(%vrf, %prefix, "static vrf route: vrf table not up yet"),
+            },
+            Message::Ipv4DelVrf { vrf, prefix, rib } => {
+                if let Some(table_id) = self.vrfs.get(&vrf).map(|v| v.table_id) {
+                    self.ipv4_route_del_vrf(table_id, &prefix, rib).await;
+                }
+            }
+            Message::Ipv6AddVrf {
+                vrf,
+                prefix,
+                mut rib,
+            } => match self.vrfs.get(&vrf).map(|v| v.table_id) {
+                Some(table_id) => {
+                    self.stamp_vrf_onlink(&mut rib, table_id);
+                    self.ipv6_route_add_vrf(table_id, &prefix, rib).await
+                }
+                None => tracing::debug!(%vrf, %prefix, "static vrf route: vrf table not up yet"),
+            },
+            Message::Ipv6DelVrf { vrf, prefix, rib } => {
+                if let Some(table_id) = self.vrfs.get(&vrf).map(|v| v.table_id) {
                     self.ipv6_route_del_vrf(table_id, &prefix, rib).await;
                 }
             }
@@ -1855,6 +1965,11 @@ impl Rib {
                 // per-`ProtoId` dispatcher writes routes here when a
                 // VRF-attached protocol installs.
                 self.vrf_tables.insert(table_id, VrfRibTables::new());
+                // Re-emit any static routes configured for this VRF now
+                // that its kernel table exists — the initial commit's
+                // install was dropped if it raced ahead of the VRF.
+                self.static_vrf_v4.reinstall(&name, &self.tx);
+                self.static_vrf_v6.reinstall(&name, &self.tx);
                 tracing::info!(
                     "vrf_add: {} table_id={} ifindex={}",
                     name,
@@ -2463,6 +2578,10 @@ impl Rib {
                 let (path, args) = path_from_command(&msg.paths);
                 if path.as_str() == "/system/router-id" {
                     let _ = self.router_id_config_exec(args, msg.op);
+                } else if path.as_str().starts_with("/router/static/vrf/ipv4/route") {
+                    let _ = self.static_vrf_v4.exec(path, args, msg.op);
+                } else if path.as_str().starts_with("/router/static/vrf/ipv6/route") {
+                    let _ = self.static_vrf_v6.exec(path, args, msg.op);
                 } else if path.as_str().starts_with("/router/static/ipv4/route") {
                     let _ = self.static_v4.exec(path, args, msg.op);
                 } else if path.as_str().starts_with("/router/static/ipv6/route") {
@@ -2493,6 +2612,8 @@ impl Rib {
                 self.link_config.commit(self.tx.clone());
                 self.static_v4.commit(self.tx.clone());
                 self.static_v6.commit(self.tx.clone());
+                self.static_vrf_v4.commit(&self.tx);
+                self.static_vrf_v6.commit(&self.tx);
                 self.mpls_config.commit(self.tx.clone());
                 self.block_config.commit(self.tx.clone());
                 self.locator_config.commit(self.tx.clone());

--- a/zebra-rs/src/rib/link.rs
+++ b/zebra-rs/src/rib/link.rs
@@ -631,6 +631,21 @@ impl Rib {
                 for addr in link.addr4.iter().chain(link.addr6.iter()) {
                     self.api_addr_add_vrf(addr, now_vrf_id);
                 }
+                // Replay this VRF's static routes now that the interface
+                // is enslaved: a route whose gateway sits on this link was
+                // unresolvable while the link was still in the default VRF,
+                // but the on-link stamp (`Rib::stamp_vrf_onlink`) can pin
+                // its egress now that `link.master` reflects the VRF.
+                if now_vrf_id != 0
+                    && let Some(name) = self
+                        .vrfs
+                        .values()
+                        .find(|v| v.table_id == now_vrf_id)
+                        .map(|v| v.name.clone())
+                {
+                    self.static_vrf_v4.reinstall(&name, &self.tx);
+                    self.static_vrf_v6.reinstall(&name, &self.tx);
+                }
                 // The interface's addresses changed scope: both the
                 // VRF it left and the one it joined (and the global
                 // pick, which excludes VRF members) may now derive a

--- a/zebra-rs/src/rib/nexthop/map.rs
+++ b/zebra-rs/src/rib/nexthop/map.rs
@@ -94,6 +94,17 @@ impl NexthopMap {
             let entry = self.groups.get_mut(gid)?;
             if entry.is_none() {
                 *entry = Some(Group::from_nexthop_uni(uni, gid, table_id));
+            } else if let Some(Group::Uni(g)) = entry
+                && g.ifindex_origin.is_none()
+                && uni.ifindex_origin.is_some()
+            {
+                // A later install pinned an on-link egress the cached
+                // group was created without (the VRF-static on-link
+                // stamp — see `Rib::stamp_vrf_onlink`). Adopt it so the
+                // shared group resolves on-link instead of re-walking a
+                // table whose connected route the VRF enslave flushed.
+                g.ifindex_origin = uni.ifindex_origin;
+                g.set_valid(true);
             }
             return self.get_mut(gid);
         }

--- a/zebra-rs/src/rib/static/config.rs
+++ b/zebra-rs/src/rib/static/config.rs
@@ -23,6 +23,12 @@ pub trait StaticFamily: Sized + 'static {
     fn to_ip_addr(addr: Self::Addr) -> IpAddr;
     fn add_msg(prefix: Self::Prefix, rib: RibEntry) -> Message;
     fn del_msg(prefix: Self::Prefix, rib: RibEntry) -> Message;
+    /// VRF counterparts: install/withdraw into the named VRF's kernel
+    /// table instead of the global table. `process_msg` resolves the
+    /// VRF name to its `table_id` (so the message survives a VRF that
+    /// isn't up yet — the `VrfAdd` reconcile re-emits it).
+    fn add_vrf_msg(vrf: String, prefix: Self::Prefix, rib: RibEntry) -> Message;
+    fn del_vrf_msg(vrf: String, prefix: Self::Prefix, rib: RibEntry) -> Message;
 }
 
 pub struct V4;
@@ -45,6 +51,12 @@ impl StaticFamily for V4 {
     }
     fn del_msg(prefix: Self::Prefix, rib: RibEntry) -> Message {
         Message::Ipv4Del { prefix, rib }
+    }
+    fn add_vrf_msg(vrf: String, prefix: Self::Prefix, rib: RibEntry) -> Message {
+        Message::Ipv4AddVrf { vrf, prefix, rib }
+    }
+    fn del_vrf_msg(vrf: String, prefix: Self::Prefix, rib: RibEntry) -> Message {
+        Message::Ipv4DelVrf { vrf, prefix, rib }
     }
 }
 
@@ -69,6 +81,12 @@ impl StaticFamily for V6 {
     fn del_msg(prefix: Self::Prefix, rib: RibEntry) -> Message {
         Message::Ipv6Del { prefix, rib }
     }
+    fn add_vrf_msg(vrf: String, prefix: Self::Prefix, rib: RibEntry) -> Message {
+        Message::Ipv6AddVrf { vrf, prefix, rib }
+    }
+    fn del_vrf_msg(vrf: String, prefix: Self::Prefix, rib: RibEntry) -> Message {
+        Message::Ipv6DelVrf { vrf, prefix, rib }
+    }
 }
 
 pub struct StaticConfig<F: StaticFamily> {
@@ -82,7 +100,18 @@ impl<F: StaticFamily> StaticConfig<F> {
         Self {
             config: BTreeMap::new(),
             cache: BTreeMap::new(),
-            builder: config_builder::<F>(),
+            builder: config_builder::<F>("/router/static"),
+        }
+    }
+
+    /// Per-VRF instance: the same handlers, but registered under
+    /// `/router/static/vrf/<family>/...` and committed into a named
+    /// VRF's table. Held one-per-VRF by [`VrfStaticConfig`].
+    pub fn new_vrf() -> Self {
+        Self {
+            config: BTreeMap::new(),
+            cache: BTreeMap::new(),
+            builder: config_builder::<F>("/router/static/vrf"),
         }
     }
 
@@ -101,6 +130,23 @@ impl<F: StaticFamily> StaticConfig<F> {
     }
 
     pub fn commit(&mut self, tx: UnboundedSender<Message>) {
+        self.commit_inner(None, tx);
+    }
+
+    /// VRF variant: emit installs/withdrawals tagged for `vrf`'s table.
+    pub fn commit_vrf(&mut self, vrf: &str, tx: UnboundedSender<Message>) {
+        self.commit_inner(Some(vrf), tx);
+    }
+
+    fn commit_inner(&mut self, vrf: Option<&str>, tx: UnboundedSender<Message>) {
+        let add = |p, rib| match vrf {
+            Some(v) => F::add_vrf_msg(v.to_string(), p, rib),
+            None => F::add_msg(p, rib),
+        };
+        let del = |p| match vrf {
+            Some(v) => F::del_vrf_msg(v.to_string(), p, RibEntry::new(RibType::Static)),
+            None => F::del_msg(p, RibEntry::new(RibType::Static)),
+        };
         while let Some((p, s)) = self.cache.pop_first() {
             // self.config holds the last-committed snapshot, and commit() is
             // the only path that emits add/del_msg for static routes — so
@@ -115,21 +161,80 @@ impl<F: StaticFamily> StaticConfig<F> {
             if s.delete {
                 self.config.remove(&p);
                 if prev_installed {
-                    let _ = tx.send(F::del_msg(p, RibEntry::new(RibType::Static)));
+                    let _ = tx.send(del(p));
                 }
             } else {
                 let new_entry = s.to_entry();
                 self.config.insert(p, s);
                 match (prev_installed, new_entry) {
                     (_, Some(rib)) => {
-                        let _ = tx.send(F::add_msg(p, rib));
+                        let _ = tx.send(add(p, rib));
                     }
                     (true, None) => {
-                        let _ = tx.send(F::del_msg(p, RibEntry::new(RibType::Static)));
+                        let _ = tx.send(del(p));
                     }
                     (false, None) => {}
                 }
             }
+        }
+    }
+
+    /// Re-emit every currently-committed route as a VRF install. Called
+    /// when the VRF's kernel table appears (`VrfAdd`) after the routes
+    /// were committed — the initial `commit_vrf` install was dropped
+    /// because the table wasn't present yet. Idempotent (the FIB layer
+    /// replaces).
+    pub fn reinstall_vrf(&self, vrf: &str, tx: &UnboundedSender<Message>) {
+        for (p, s) in self.config.iter() {
+            if let Some(rib) = s.to_entry() {
+                let _ = tx.send(F::add_vrf_msg(vrf.to_string(), *p, rib));
+            }
+        }
+    }
+}
+
+/// Per-VRF static-route configuration: one [`StaticConfig`] per VRF
+/// name, fed by the `/router/static/vrf/<family>/...` callback tree.
+/// The VRF name is the first arg the config manager supplies (the
+/// `vrf` list key); the remaining args match the global handlers.
+pub struct VrfStaticConfig<F: StaticFamily> {
+    pub vrfs: BTreeMap<String, StaticConfig<F>>,
+}
+
+impl<F: StaticFamily> Default for VrfStaticConfig<F> {
+    fn default() -> Self {
+        Self {
+            vrfs: BTreeMap::new(),
+        }
+    }
+}
+
+impl<F: StaticFamily> VrfStaticConfig<F> {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Route a `/router/static/vrf/...` commit to the per-VRF
+    /// [`StaticConfig`]. The leading arg is the VRF name.
+    pub fn exec(&mut self, path: String, mut args: Args, op: ConfigOp) -> Result<()> {
+        let vrf = args.string().context("missing vrf name arg")?;
+        self.vrfs
+            .entry(vrf)
+            .or_insert_with(StaticConfig::<F>::new_vrf)
+            .exec(path, args, op)
+    }
+
+    /// Commit every VRF's pending cache.
+    pub fn commit(&mut self, tx: &UnboundedSender<Message>) {
+        for (vrf, cfg) in self.vrfs.iter_mut() {
+            cfg.commit_vrf(vrf, tx.clone());
+        }
+    }
+
+    /// Re-emit one VRF's committed routes (on `VrfAdd`).
+    pub fn reinstall(&self, vrf: &str, tx: &UnboundedSender<Message>) {
+        if let Some(cfg) = self.vrfs.get(vrf) {
+            cfg.reinstall_vrf(vrf, tx);
         }
     }
 }
@@ -213,7 +318,7 @@ fn cache_lookup<'a, F: StaticFamily>(
     if cache.delete { None } else { Some(cache) }
 }
 
-fn config_builder<F: StaticFamily>() -> ConfigBuilder<F> {
+fn config_builder<F: StaticFamily>(base: &str) -> ConfigBuilder<F> {
     const CONFIG_ERR: &str = "config parse error";
     const NEXTHOP_ERR: &str = "nexthop address parse error";
     const METRIC_ERR: &str = "metric arg parse error";
@@ -221,7 +326,7 @@ fn config_builder<F: StaticFamily>() -> ConfigBuilder<F> {
     const WEIGHT_ERR: &str = "weight arg parse error";
 
     ConfigBuilder::<F>::default()
-        .path(&format!("/router/static/{}/route", F::FAMILY))
+        .path(&format!("{base}/{}/route", F::FAMILY))
         .set(|config, cache, prefix, _args| {
             let _ = cache_get::<F>(config, cache, prefix).context(CONFIG_ERR)?;
             Ok(())
@@ -236,7 +341,7 @@ fn config_builder<F: StaticFamily>() -> ConfigBuilder<F> {
             }
             Ok(())
         })
-        .path(&format!("/router/static/{}/route/metric", F::FAMILY))
+        .path(&format!("{base}/{}/route/metric", F::FAMILY))
         .set(|config, cache, prefix, args| {
             let s = cache_get::<F>(config, cache, prefix).context(CONFIG_ERR)?;
             s.metric = Some(args.u32().context(METRIC_ERR)?);
@@ -247,7 +352,7 @@ fn config_builder<F: StaticFamily>() -> ConfigBuilder<F> {
             s.metric = None;
             Ok(())
         })
-        .path(&format!("/router/static/{}/route/distance", F::FAMILY))
+        .path(&format!("{base}/{}/route/distance", F::FAMILY))
         .set(|config, cache, prefix, args| {
             let s = cache_get::<F>(config, cache, prefix).context(CONFIG_ERR)?;
             s.distance = Some(args.u8().context(DISTANCE_ERR)?);
@@ -258,7 +363,7 @@ fn config_builder<F: StaticFamily>() -> ConfigBuilder<F> {
             s.distance = None;
             Ok(())
         })
-        .path(&format!("/router/static/{}/route/nexthop", F::FAMILY))
+        .path(&format!("{base}/{}/route/nexthop", F::FAMILY))
         .set(|config, cache, prefix, args| {
             let s = cache_get::<F>(config, cache, prefix).context(CONFIG_ERR)?;
             let naddr = F::parse_addr(args).context(NEXTHOP_ERR)?;
@@ -271,10 +376,7 @@ fn config_builder<F: StaticFamily>() -> ConfigBuilder<F> {
             s.nexthops.remove(&naddr).context(CONFIG_ERR)?;
             Ok(())
         })
-        .path(&format!(
-            "/router/static/{}/route/nexthop/metric",
-            F::FAMILY
-        ))
+        .path(&format!("{base}/{}/route/nexthop/metric", F::FAMILY))
         .set(|config, cache, prefix, args| {
             let s = cache_get::<F>(config, cache, prefix).context(CONFIG_ERR)?;
             let naddr = F::parse_addr(args).context(NEXTHOP_ERR)?;
@@ -289,10 +391,7 @@ fn config_builder<F: StaticFamily>() -> ConfigBuilder<F> {
             n.metric = None;
             Ok(())
         })
-        .path(&format!(
-            "/router/static/{}/route/nexthop/weight",
-            F::FAMILY
-        ))
+        .path(&format!("{base}/{}/route/nexthop/weight", F::FAMILY))
         .set(|config, cache, prefix, args| {
             let s = cache_get::<F>(config, cache, prefix).context(CONFIG_ERR)?;
             let naddr = F::parse_addr(args).context(NEXTHOP_ERR)?;
@@ -307,7 +406,7 @@ fn config_builder<F: StaticFamily>() -> ConfigBuilder<F> {
             n.weight = None;
             Ok(())
         })
-        .path(&format!("/router/static/{}/route/nexthop/label", F::FAMILY))
+        .path(&format!("{base}/{}/route/nexthop/label", F::FAMILY))
         .set(|config, cache, prefix, args| {
             let s = cache_get::<F>(config, cache, prefix).context(CONFIG_ERR)?;
             let naddr = F::parse_addr(args).context(NEXTHOP_ERR)?;
@@ -325,7 +424,7 @@ fn config_builder<F: StaticFamily>() -> ConfigBuilder<F> {
             n.labels.clear();
             Ok(())
         })
-        .path(&format!("/router/static/{}/route/segments", F::FAMILY))
+        .path(&format!("{base}/{}/route/segments", F::FAMILY))
         .set(|config, cache, prefix, args| {
             const SEG_ERR: &str = "segment address parse error";
             let s = cache_get::<F>(config, cache, prefix).context(CONFIG_ERR)?;
@@ -346,7 +445,7 @@ fn config_builder<F: StaticFamily>() -> ConfigBuilder<F> {
             s.segs.clear();
             Ok(())
         })
-        .path(&format!("/router/static/{}/route/encap-type", F::FAMILY))
+        .path(&format!("{base}/{}/route/encap-type", F::FAMILY))
         .set(|config, cache, prefix, args| {
             const ENCAP_ERR: &str = "missing encap-type arg";
             let s = cache_get::<F>(config, cache, prefix).context(CONFIG_ERR)?;
@@ -359,7 +458,7 @@ fn config_builder<F: StaticFamily>() -> ConfigBuilder<F> {
             s.encap_type = None;
             Ok(())
         })
-        .path(&format!("/router/static/{}/route/action", F::FAMILY))
+        .path(&format!("{base}/{}/route/action", F::FAMILY))
         .set(|config, cache, prefix, args| {
             const ACTION_ERR: &str = "missing seg6local action arg";
             let s = cache_get::<F>(config, cache, prefix).context(CONFIG_ERR)?;
@@ -529,5 +628,67 @@ mod tests {
             Nexthop::Uni(uni) => assert_eq!(uni.addr, IpAddr::V4(other_nexthop_addr())),
             _ => panic!("expected Nexthop::Uni"),
         }
+    }
+
+    fn assert_ipv4_add_vrf(msg: &Message, expected_vrf: &str, expected_prefix: Ipv4Net) {
+        match msg {
+            Message::Ipv4AddVrf { vrf, prefix, .. } => {
+                assert_eq!(vrf, expected_vrf);
+                assert_eq!(*prefix, expected_prefix);
+            }
+            _ => panic!("expected Ipv4AddVrf"),
+        }
+    }
+
+    #[test]
+    fn vrf_commit_emits_add_vrf_tagged_with_vrf_name() {
+        // A route committed under a named VRF must surface as
+        // Ipv4AddVrf carrying that VRF name (not the plain Ipv4Add the
+        // global table uses), so inst.rs installs it into the VRF table.
+        let (tx, mut rx) = mpsc::unbounded_channel();
+        let mut vc = VrfStaticConfig::<V4>::new();
+        let cfg = vc
+            .vrfs
+            .entry("cust".to_string())
+            .or_insert_with(StaticConfig::<V4>::new_vrf);
+        cfg.cache
+            .insert(prefix(), route_with_nexthop(nexthop_addr()));
+
+        vc.commit(&tx);
+
+        let msgs = drain(&mut rx);
+        assert_eq!(msgs.len(), 1);
+        assert_ipv4_add_vrf(&msgs[0], "cust", prefix());
+    }
+
+    #[test]
+    fn vrf_reinstall_re_emits_committed_routes() {
+        // On VrfAdd the table appears after the initial commit; reinstall
+        // must re-emit every committed route as an Ipv4AddVrf so the
+        // dropped install lands once the VRF table exists.
+        let (tx, mut rx) = mpsc::unbounded_channel();
+        let mut vc = VrfStaticConfig::<V4>::new();
+        {
+            let cfg = vc
+                .vrfs
+                .entry("cust".to_string())
+                .or_insert_with(StaticConfig::<V4>::new_vrf);
+            cfg.config
+                .insert(prefix(), route_with_nexthop(nexthop_addr()));
+        }
+
+        vc.reinstall("cust", &tx);
+
+        let msgs = drain(&mut rx);
+        assert_eq!(msgs.len(), 1);
+        assert_ipv4_add_vrf(&msgs[0], "cust", prefix());
+    }
+
+    #[test]
+    fn vrf_reinstall_unknown_vrf_is_noop() {
+        let (tx, mut rx) = mpsc::unbounded_channel();
+        let vc = VrfStaticConfig::<V4>::new();
+        vc.reinstall("nope", &tx);
+        assert!(drain(&mut rx).is_empty());
     }
 }


### PR DESCRIPTION
## Summary

Wires `router static vrf <name>` to the FIB. Previously the YANG existed but configured routes never reached the VRF kernel table.

- **Config layer** — a `VrfStaticConfig<F>` holds one per-VRF `StaticConfig` fed by the `/router/static/vrf/<family>/...` callback tree. `commit` emits new `Ipv{4,6}{Add,Del}Vrf` messages carrying the VRF name; `inst.rs` resolves the name to a `table_id` and installs via `ipv{4,6}_route_add_vrf`.
- **Late VRF table** — routes committed before the VRF table exists are re-emitted on `VrfAdd` and on the link VRF-boundary reconcile (idempotent; FIB replaces).
- **On-link resolution** — the gateway of a VRF static route usually sits on a VRF interface whose connected route the kernel *flushes* when the link is enslaved, so the nexthop never resolves via the table walk. `stamp_vrf_onlink` stamps `NexthopUni.ifindex_origin` for any nexthop on-link to a VRF interface, and `NexthopMap::fetch_uni` adopts a later install's on-link origin so a stale cached group (keyed by `table_id+addr`) doesn't pin `ifindex_origin=None`.

This is the foundation for the IS-IS Mirror-SID Phase 7b dual-homed-CE L3VPN failover BDD, which needs static CE prefixes inside a VRF.

## Test plan

- `VrfStaticConfig` unit tests (commit emits `Ipv4AddVrf` tagged with the VRF name; reinstall re-emits committed routes; unknown-VRF reinstall is a no-op).
- New `@static_vrf` BDD: install check (`show ipv6 route vrf cust` contains both /128s) + bidirectional host forwarding (ping between two host loopbacks routed entirely on per-VRF static routes) + teardown. Passes 3/3.
- `cargo fmt`, `cargo clippy --workspace --all-targets -- -D warnings`, and `cargo test --workspace --exclude bdd` all clean.

Generated with [Claude Code](https://claude.com/claude-code)