### PR TITLE
isis-packet: SID/Label Binding TLV (149) codec — Phase 1b

### DIFF
--- a/crates/isis-packet/src/disp.rs
+++ b/crates/isis-packet/src/disp.rs
@@ -193,6 +193,7 @@ impl Display for IsisTlv {
             Ipv4IfAddr(v) => write!(f, "{}", v),
             TeRouterId(v) => write!(f, "{}", v),
             ExtIpReach(v) => write!(f, "{}", v),
+            SidLabelBinding(v) => write!(f, "{}", v),
             Hostname(v) => write!(f, "{}", v),
             Srlg(v) => write!(f, "{:?}", v),
             Ipv6Srlg(v) => write!(f, "{:?}", v),

--- a/crates/isis-packet/src/flags_serde.rs
+++ b/crates/isis-packet/src/flags_serde.rs
@@ -24,7 +24,7 @@ use crate::parser::IsisLspTypes;
 use crate::sub::cap::{RouterCapFlags, SegmentRoutingCapFlags, Srv6Flags};
 use crate::sub::neigh::AdjSidFlags;
 use crate::sub::prefix::{
-    Ipv4ControlInfo, Ipv6ControlInfo, MultiTopologyId, PrefixSidFlags, Srv6TlvFlags,
+    BindingFlags, Ipv4ControlInfo, Ipv6ControlInfo, MultiTopologyId, PrefixSidFlags, Srv6TlvFlags,
 };
 
 /// Generate field-decoded `Serialize` + `Deserialize` for a
@@ -83,6 +83,14 @@ bitfield_serde!(Ipv4ControlInfo {
 });
 
 bitfield_serde!(MultiTopologyId { id: u16 } reserved { resvd: u8 });
+
+bitfield_serde!(BindingFlags {
+    a_flag: bool,
+    d_flag: bool,
+    s_flag: bool,
+    m_flag: bool,
+    f_flag: bool,
+} reserved { resvd: u8 });
 
 bitfield_serde!(Ipv6ControlInfo {
     sub_tlv: bool,

--- a/crates/isis-packet/src/parser.rs
+++ b/crates/isis-packet/src/parser.rs
@@ -16,7 +16,7 @@ use super::util::{ParseBe, TlvEmitter, u32_u8_3};
 use super::{
     IsisTlvExtIpReach, IsisTlvExtIsReach, IsisTlvIpv6Reach, IsisTlvIpv6Srlg, IsisTlvMtIpReach,
     IsisTlvMtIpv6Reach, IsisTlvMtIsReach, IsisTlvMultiTopology, IsisTlvRestart, IsisTlvRouterCap,
-    IsisTlvSrlg, IsisTlvSrv6, IsisTlvType, IsisType, many0_complete,
+    IsisTlvSidLabelBinding, IsisTlvSrlg, IsisTlvSrv6, IsisTlvType, IsisType, many0_complete,
 };
 
 // IS-IS discriminator.
@@ -538,6 +538,8 @@ pub enum IsisTlv {
     TeRouterId(IsisTlvTeRouterId),
     #[nom(Selector = "IsisTlvType::ExtIpReach")]
     ExtIpReach(IsisTlvExtIpReach),
+    #[nom(Selector = "IsisTlvType::SidLabelBinding")]
+    SidLabelBinding(IsisTlvSidLabelBinding),
     #[nom(Selector = "IsisTlvType::DynamicHostname")]
     Hostname(IsisTlvHostname),
     #[nom(Selector = "IsisTlvType::Srlg")]
@@ -603,6 +605,7 @@ impl IsisTlv {
             Ipv4IfAddr(v) => v.tlv_emit(buf),
             TeRouterId(v) => v.tlv_emit(buf),
             ExtIpReach(v) => v.tlv_emit(buf),
+            SidLabelBinding(v) => v.tlv_emit(buf),
             Hostname(v) => v.tlv_emit(buf),
             Srlg(v) => v.tlv_emit(buf),
             Ipv6Srlg(v) => v.tlv_emit(buf),

--- a/crates/isis-packet/src/sub/mod.rs
+++ b/crates/isis-packet/src/sub/mod.rs
@@ -33,11 +33,12 @@ pub mod neigh_disp;
 
 pub mod prefix;
 pub use prefix::{
-    IsisMirrorSub2Tlv, IsisSub2ProtectedLocators, IsisSub2SidStructure, IsisSub2Tlv,
-    IsisSubIpv4SourceRouterId, IsisSubIpv6SourceRouterId, IsisSubPrefixSid, IsisSubSrv6EndSid,
-    IsisSubSrv6MirrorSid, IsisTlvExtIpReach, IsisTlvExtIpReachEntry, IsisTlvIpv6Reach,
-    IsisTlvIpv6ReachEntry, IsisTlvMtIpReach, IsisTlvMtIpv6Reach, IsisTlvMultiTopology, IsisTlvSrv6,
-    MultiTopologyId, PrefixSidFlags, Srv6Locator,
+    BindingFlags, BindingPrefix, IsisBindingSubTlv, IsisMirrorSub2Tlv, IsisSub2ProtectedLocators,
+    IsisSub2SidStructure, IsisSub2Tlv, IsisSubIpv4SourceRouterId, IsisSubIpv6SourceRouterId,
+    IsisSubPrefixSid, IsisSubSrv6EndSid, IsisSubSrv6MirrorSid, IsisTlvExtIpReach,
+    IsisTlvExtIpReachEntry, IsisTlvIpv6Reach, IsisTlvIpv6ReachEntry, IsisTlvMtIpReach,
+    IsisTlvMtIpv6Reach, IsisTlvMultiTopology, IsisTlvSidLabelBinding, IsisTlvSrv6, MultiTopologyId,
+    PrefixSidFlags, Srv6Locator,
 };
 pub mod prefix_code;
 pub use prefix_code::{IsisPrefixCode, IsisSrv6MirrorSub2Code, IsisSrv6SidSub2Code};

--- a/crates/isis-packet/src/sub/prefix.rs
+++ b/crates/isis-packet/src/sub/prefix.rs
@@ -775,6 +775,207 @@ impl IsisTlvIpv6ReachEntry {
     }
 }
 
+/// SID/Label Binding TLV (type 149) flags — RFC 8667 §2.4. Wire order
+/// is MSB-first (F at bit 7); the `bitfield` macro lays fields LSB-first,
+/// so the *last*-declared field lands at the MSB. The **M-flag (Mirror
+/// Context)** is what egress protection's SR-MPLS path (RFC 8679 context
+/// label) keys on: M-set means the binding advertises a *context label*
+/// (in a SID/Label sub-TLV) for the prefix's mirroring context rather
+/// than a normal Prefix-SID mapping.
+#[bitfield(u8, debug = true)]
+#[derive(PartialEq)]
+pub struct BindingFlags {
+    #[bits(3)]
+    pub resvd: u8,
+    /// A-flag — Attached.
+    pub a_flag: bool,
+    /// D-flag — leaked Down from L2 to L1.
+    pub d_flag: bool,
+    /// S-flag — leak into another level.
+    pub s_flag: bool,
+    /// M-flag — Mirror Context (RFC 8679 egress protection).
+    pub m_flag: bool,
+    /// F-flag — Address Family of the prefix: 0 = IPv4, 1 = IPv6.
+    pub f_flag: bool,
+}
+
+impl ParseBe<BindingFlags> for BindingFlags {
+    fn parse_be(input: &[u8]) -> IResult<&[u8], Self> {
+        let (input, flags) = be_u8(input)?;
+        Ok((input, flags.into()))
+    }
+}
+
+/// FEC prefix carried by the Binding TLV; family is selected by the
+/// TLV's F-flag (kept here as a typed enum so consumers don't re-derive
+/// it).
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub enum BindingPrefix {
+    V4(Ipv4Net),
+    V6(Ipv6Net),
+}
+
+impl BindingPrefix {
+    fn prefix_len(&self) -> u8 {
+        match self {
+            BindingPrefix::V4(p) => p.prefix_len(),
+            BindingPrefix::V6(p) => p.prefix_len(),
+        }
+    }
+
+    fn emit(&self, buf: &mut BytesMut) {
+        let plen = psize(self.prefix_len());
+        buf.put_u8(self.prefix_len());
+        match self {
+            BindingPrefix::V4(p) => buf.put(&p.addr().octets()[..plen]),
+            BindingPrefix::V6(p) => buf.put(&p.addr().octets()[..plen]),
+        }
+    }
+}
+
+/// One sub-TLV of a Binding TLV. The codec is permissive: it understands
+/// the SID/Label sub-TLV (type 1, RFC 8667 §2.3 — the context label for a
+/// Mirror Context binding) and round-trips everything else as raw bytes.
+/// Validation (M-set ⇒ exactly one SID/Label sub-TLV, no Prefix-SID) lives
+/// in the IS-IS layer, not here.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub enum IsisBindingSubTlv {
+    /// SID/Label sub-TLV (type 1) — a 20-bit label (len 3) or 32-bit
+    /// index (len 4).
+    SidLabel(SidLabelValue),
+    Unknown {
+        typ: u8,
+        value: Vec<u8>,
+    },
+}
+
+impl IsisBindingSubTlv {
+    fn parse_be(input: &[u8]) -> IResult<&[u8], Self> {
+        let (input, typ) = be_u8(input)?;
+        let (input, len) = be_u8(input)?;
+        let (input, value) = safe_split_at(input, len as usize)?;
+        match typ {
+            1 => {
+                let (_, sid) = SidLabelValue::parse_be(value)?;
+                Ok((input, Self::SidLabel(sid)))
+            }
+            other => Ok((
+                input,
+                Self::Unknown {
+                    typ: other,
+                    value: value.to_vec(),
+                },
+            )),
+        }
+    }
+
+    /// Value length (excludes the 2-byte type+length header).
+    fn value_len(&self) -> u8 {
+        match self {
+            Self::SidLabel(sid) => sid.len(),
+            Self::Unknown { value, .. } => value.len() as u8,
+        }
+    }
+
+    fn emit(&self, buf: &mut BytesMut) {
+        match self {
+            Self::SidLabel(sid) => {
+                buf.put_u8(1);
+                buf.put_u8(sid.len());
+                sid.emit(buf);
+            }
+            Self::Unknown { typ, value } => {
+                buf.put_u8(*typ);
+                buf.put_u8(value.len() as u8);
+                buf.put(&value[..]);
+            }
+        }
+    }
+}
+
+/// SID/Label Binding TLV (type 149) — RFC 8667 §2.4. Advertises a
+/// mapping from a FEC prefix (range of prefixes) to a SID/Label, plus
+/// sub-TLVs. With the **M-flag** set it is a Mirror Context binding
+/// (RFC 8679): the SID/Label sub-TLV carries the context label a PLR
+/// pushes to steer protected traffic to the protector. The codec is
+/// permissive — the M-set ⇒ SID/Label-present / Prefix-SID-absent
+/// invariant is enforced at origination in the IS-IS layer.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct IsisTlvSidLabelBinding {
+    pub flags: BindingFlags,
+    pub weight: u8,
+    pub range: u16,
+    pub prefix: BindingPrefix,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub subs: Vec<IsisBindingSubTlv>,
+}
+
+impl ParseBe<IsisTlvSidLabelBinding> for IsisTlvSidLabelBinding {
+    fn parse_be(input: &[u8]) -> IResult<&[u8], Self> {
+        let (input, flags) = BindingFlags::parse_be(input)?;
+        let (input, weight) = be_u8(input)?;
+        let (input, range) = be_u16(input)?;
+        let (input, prefixlen) = be_u8(input)?;
+        let (input, prefix) = if flags.f_flag() {
+            let (input, p) = ptakev6(input, prefixlen)?;
+            (input, BindingPrefix::V6(p))
+        } else {
+            let (input, p) = ptake(input, prefixlen)?;
+            (input, BindingPrefix::V4(p))
+        };
+        // The remainder of the TLV value is sub-TLVs (no separate
+        // sub-TLV-length field — the TLV length bounds them).
+        let (input, subs) = many0_complete(IsisBindingSubTlv::parse_be).parse(input)?;
+        Ok((
+            input,
+            Self {
+                flags,
+                weight,
+                range,
+                prefix,
+                subs,
+            },
+        ))
+    }
+}
+
+impl TlvEmitter for IsisTlvSidLabelBinding {
+    fn typ(&self) -> u8 {
+        IsisTlvType::SidLabelBinding.into()
+    }
+
+    fn len(&self) -> u8 {
+        // Flags(1)+Weight(1)+Range(2)+PrefixLen(1)+Prefix+Sub-TLVs.
+        let prefix = psize(self.prefix.prefix_len()) as u8;
+        let subs: u8 = self
+            .subs
+            .iter()
+            .map(|sub| sub.value_len() + 2)
+            .fold(0u8, u8::saturating_add);
+        1u8.saturating_add(1)
+            .saturating_add(2)
+            .saturating_add(1)
+            .saturating_add(prefix)
+            .saturating_add(subs)
+    }
+
+    fn emit(&self, buf: &mut BytesMut) {
+        buf.put_u8(self.flags.into());
+        buf.put_u8(self.weight);
+        buf.put_u16(self.range);
+        self.prefix.emit(buf);
+        for sub in &self.subs {
+            sub.emit(buf);
+        }
+    }
+}
+
+impl From<IsisTlvSidLabelBinding> for IsisTlv {
+    fn from(tlv: IsisTlvSidLabelBinding) -> Self {
+        IsisTlv::SidLabelBinding(tlv)
+    }
+}
+
 pub fn psize(plen: u8) -> usize {
     // From Rust 1.73 we can use .dev_ceil()
     // ((plen + 7) / 8) as usize

--- a/crates/isis-packet/src/sub/prefix_disp.rs
+++ b/crates/isis-packet/src/sub/prefix_disp.rs
@@ -6,10 +6,39 @@ use super::prefix::{
     IsisSubTlv, PrefixSidFlags,
 };
 use super::{
-    IsisSubPrefixSid, IsisTlvExtIpReach, IsisTlvExtIpReachEntry, IsisTlvIpv6Reach,
-    IsisTlvIpv6ReachEntry, IsisTlvMtIpReach, IsisTlvMtIpv6Reach, IsisTlvMultiTopology,
-    MultiTopologyId,
+    BindingPrefix, IsisBindingSubTlv, IsisSubPrefixSid, IsisTlvExtIpReach, IsisTlvExtIpReachEntry,
+    IsisTlvIpv6Reach, IsisTlvIpv6ReachEntry, IsisTlvMtIpReach, IsisTlvMtIpv6Reach,
+    IsisTlvMultiTopology, IsisTlvSidLabelBinding, MultiTopologyId,
 };
+
+impl Display for BindingPrefix {
+    fn fmt(&self, f: &mut Formatter<'_>) -> Result {
+        match self {
+            BindingPrefix::V4(p) => write!(f, "{}", p),
+            BindingPrefix::V6(p) => write!(f, "{}", p),
+        }
+    }
+}
+
+impl Display for IsisTlvSidLabelBinding {
+    fn fmt(&self, f: &mut Formatter<'_>) -> Result {
+        write!(f, "  SID/Label Binding")?;
+        if self.flags.m_flag() {
+            write!(f, " (Mirror Context)")?;
+        }
+        write!(f, ": {}", self.prefix)?;
+        if self.range > 1 {
+            write!(f, " range {}", self.range)?;
+        }
+        for sub in &self.subs {
+            match sub {
+                IsisBindingSubTlv::SidLabel(sid) => write!(f, " label/index {}", sid.value())?,
+                IsisBindingSubTlv::Unknown { typ, .. } => write!(f, " sub-tlv {}", typ)?,
+            }
+        }
+        Ok(())
+    }
+}
 
 impl Display for IsisTlvExtIpReach {
     fn fmt(&self, f: &mut Formatter<'_>) -> Result {

--- a/crates/isis-packet/src/tlv_type.rs
+++ b/crates/isis-packet/src/tlv_type.rs
@@ -38,6 +38,10 @@ pub enum IsisTlvType {
     /// IPv6 Shared Risk Link Group (RFC 6119).
     Ipv6Srlg = 139,
     Ipv6TeRouterId = 140,
+    /// SID/Label Binding TLV (RFC 8667 §2.4). Carries SR mapping-server
+    /// bindings and, with the M-flag, RFC 8679 Mirror Context (egress
+    /// protection) context-label bindings.
+    SidLabelBinding = 149,
     Ipv6IfAddr = 232,
     Ipv6GlobalIfAddr = 233,
     MultiTopology = 229,
@@ -84,6 +88,7 @@ impl IsisTlvType {
                 | Srlg
                 | Ipv6Srlg
                 | Ipv6TeRouterId
+                | SidLabelBinding
                 | Ipv6IfAddr
                 | Ipv6GlobalIfAddr
                 | MultiTopology
@@ -119,6 +124,7 @@ impl From<IsisTlvType> for u8 {
             Srlg => 138,
             Ipv6Srlg => 139,
             Ipv6TeRouterId => 140,
+            SidLabelBinding => 149,
             Ipv6IfAddr => 232,
             Ipv6GlobalIfAddr => 233,
             MultiTopology => 229,
@@ -155,6 +161,7 @@ impl From<u8> for IsisTlvType {
             138 => Srlg,
             139 => Ipv6Srlg,
             140 => Ipv6TeRouterId,
+            149 => SidLabelBinding,
             232 => Ipv6IfAddr,
             233 => Ipv6GlobalIfAddr,
             229 => MultiTopology,

--- a/crates/isis-packet/tests/parser.rs
+++ b/crates/isis-packet/tests/parser.rs
@@ -394,6 +394,79 @@ fn srv6_mirror_sid_round_trips_through_isis_tlv() {
 }
 
 #[test]
+fn sid_label_binding_mirror_context_round_trips() {
+    use ipnet::Ipv4Net;
+
+    // SID/Label Binding TLV (149) with the M-flag set: a Mirror Context
+    // binding (RFC 8679 egress protection) for the protected egress's
+    // loopback 10.0.0.3/32, carrying the context label 16003 in a
+    // SID/Label sub-TLV (type 1).
+    let original = IsisTlv::SidLabelBinding(IsisTlvSidLabelBinding {
+        flags: BindingFlags::new().with_m_flag(true),
+        weight: 0,
+        range: 1,
+        prefix: BindingPrefix::V4("10.0.0.3/32".parse::<Ipv4Net>().unwrap()),
+        subs: vec![IsisBindingSubTlv::SidLabel(SidLabelValue::Label(16003))],
+    });
+
+    let mut buf = BytesMut::new();
+    original.emit(&mut buf);
+
+    let (rest, tlvs) = IsisTlv::parse_tlvs(&buf).expect("parse must succeed");
+    assert!(rest.is_empty());
+    assert_eq!(tlvs.len(), 1);
+    assert_eq!(tlvs[0], original, "round-trip must preserve the TLV");
+
+    let IsisTlv::SidLabelBinding(b) = &tlvs[0] else {
+        panic!("expected SidLabelBinding TLV, got {:?}", tlvs[0]);
+    };
+    assert!(b.flags.m_flag(), "M-flag must survive the round-trip");
+    assert!(!b.flags.f_flag(), "IPv4 binding ⇒ F-flag clear");
+    assert_eq!(b.prefix, BindingPrefix::V4("10.0.0.3/32".parse().unwrap()));
+    assert_eq!(b.subs.len(), 1);
+    let IsisBindingSubTlv::SidLabel(SidLabelValue::Label(label)) = &b.subs[0] else {
+        panic!(
+            "expected SID/Label sub-TLV with a label, got {:?}",
+            b.subs[0]
+        );
+    };
+    assert_eq!(*label, 16003);
+}
+
+#[test]
+fn sid_label_binding_ipv6_index_round_trips() {
+    use ipnet::Ipv6Net;
+
+    // IPv6 prefix (F-flag set) + a 32-bit SID index sub-TLV (len 4).
+    let original = IsisTlv::SidLabelBinding(IsisTlvSidLabelBinding {
+        flags: BindingFlags::new().with_f_flag(true),
+        weight: 5,
+        range: 4,
+        prefix: BindingPrefix::V6("2001:db8::3/128".parse::<Ipv6Net>().unwrap()),
+        subs: vec![IsisBindingSubTlv::SidLabel(SidLabelValue::Index(42))],
+    });
+
+    let mut buf = BytesMut::new();
+    original.emit(&mut buf);
+
+    let (rest, tlvs) = IsisTlv::parse_tlvs(&buf).expect("parse must succeed");
+    assert!(rest.is_empty());
+    assert_eq!(tlvs[0], original, "round-trip must preserve the TLV");
+
+    let IsisTlv::SidLabelBinding(b) = &tlvs[0] else {
+        panic!("expected SidLabelBinding TLV");
+    };
+    assert!(b.flags.f_flag());
+    assert!(!b.flags.m_flag());
+    assert_eq!(b.weight, 5);
+    assert_eq!(b.range, 4);
+    assert!(matches!(
+        b.subs[0],
+        IsisBindingSubTlv::SidLabel(SidLabelValue::Index(42))
+    ));
+}
+
+#[test]
 pub fn parse_p2p_hello() {
     const PACKET: &[u8] = &hex!(
         "


### PR DESCRIPTION
## Summary

First slice of the **SR-MPLS** variant of IS-IS Mirror SID egress protection (Phase 1b): the RFC 8667 §2.4 **SID/Label Binding TLV (149)** codec, with the **M-flag** (Mirror Context, RFC 8679) that the egress-protection control plane keys on. Pure codec — no behavioral change anywhere else; mirrors the SRv6 codec (Phase 1a).

- `IsisTlvType::SidLabelBinding = 149` + the `IsisTlv::SidLabelBinding` variant + emit/dispatch wiring.
- `IsisTlvSidLabelBinding { flags: BindingFlags, weight, range, prefix: BindingPrefix, subs }`.
  - `BindingFlags` — bitfield with F (address family), M (Mirror Context), S, D, A; serde via the existing `bitfield_serde!` macro.
  - `BindingPrefix` — typed V4/V6 enum selected by the F-flag.
- `IsisBindingSubTlv` — permissive: understands the SID/Label sub-TLV (type 1: the context label, 20-bit label or 32-bit index) and round-trips everything else as raw bytes. The "M-set ⇒ SID/Label-present, Prefix-SID-absent" invariant is enforced at origination in the IS-IS layer (a later phase), not in the codec.
- `Display` surfaces `SID/Label Binding (Mirror Context): <prefix> ...` so `show isis database detail` reads cleanly.

## Test plan

- Two round-trip tests in `crates/isis-packet/tests/parser.rs` (IPv4 + Mirror-Context label; IPv6 + SID index) — build → emit → re-parse → assert field equality.
- `cargo test -p isis-packet` (53 tests), `cargo fmt`, `cargo clippy --workspace --all-targets -- -D warnings`, and `cargo test --workspace --exclude bdd` (1355) all clean.

Generated with [Claude Code](https://claude.com/claude-code)