### PR TITLE
docs: clarify Quick Install ships only Ubuntu 22.04/24.04/26.04 packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,8 +17,11 @@ curl -fsSL https://zebra.rs/install.sh | bash
 The script downloads the latest package from the
 [GitHub releases](https://github.com/zebra-rs/zebra-rs/releases) and installs
 it with `apt`, so it pulls in the runtime dependencies automatically. It needs
-`sudo` for the install step and supports Ubuntu 22.04/24.04/26.04 on x86_64 and
-ARM64. Piping a remote script into `bash` runs it with your privileges — read
+`sudo` for the install step. Prebuilt `.deb` packages are currently provided
+only for Ubuntu 22.04 (jammy), 24.04 (noble), and 26.04 (resolute) on x86_64
+and ARM64 — other distributions or releases are not packaged yet and should
+build from source (below). Piping a remote script into `bash` runs it with your
+privileges — read
 it first at <https://zebra.rs/install.sh> if you'd rather review before
 running.
 


### PR DESCRIPTION
## Summary

Clarifies the **Quick Install** section of `README.md` so users know exactly
which prebuilt `.deb` packages exist and don't expect a package for an
unsupported release.

- Spell out the supported releases with code names: **22.04 (jammy)**,
  **24.04 (noble)**, **26.04 (resolute)** on x86_64 and ARM64.
- Explicitly state other distributions/releases are not packaged yet and
  point them at the build-from-source path.

## Test plan

- Docs-only change; verified the rendered Markdown reads correctly and stays
  consistent with the Nightly Packages section (same versions + code names).

Generated with [Claude Code](https://claude.com/claude-code)