### PR TITLE
feat: add --config-file/-c daemon option (CLI/JSON/YAML/set-delete)

### DIFF
--- a/book/src/SUMMARY.md
+++ b/book/src/SUMMARY.md
@@ -6,6 +6,7 @@
 - [Interface Configuration](ch-00-03-interface-configuration.md)
 - [VXLAN Configuration](ch-00-04-vxlan-configuration.md)
 - [Bridge Configuration](ch-00-05-bridge-configuration.md)
+- [Command Line Options](ch-00-06-command-line-options.md)
 
 ## Static Route
 

--- a/book/src/ch-00-06-command-line-options.md
+++ b/book/src/ch-00-06-command-line-options.md
@@ -1,0 +1,137 @@
+# Command Line Options
+
+The `zebra-rs` daemon is configured at startup by a small set of command
+line options. Running `zebra-rs --help` prints the authoritative list;
+this chapter explains what each option does and how they interact.
+
+## Quick reference
+
+| Option | Short | Argument | Default | Purpose |
+|---|---|---|---|---|
+| `--yang-path` | `-y` | `PATH` | search order (below) | Directory the YANG schema is loaded from |
+| `--config-file` | `-c` | `FILENAME` | `zebra-rs.conf` next to the YANG tree | Configuration file loaded at startup |
+| `--daemon` | `-d` | — | foreground | Detach and run in the background |
+| `--log-output` | | `stdout \| syslog \| file` | `stdout` | Where log records are written |
+| `--log-file` | | `PATH` | `./zebra-rs.log` | Log file path when `--log-output=file` |
+| `--log-format` | | `terminal \| json \| elasticsearch` | `terminal` | Log record serialization |
+| `--no-nhid` | | — | off | Embed nexthops in routes instead of using nexthop IDs (kernels < 5.3) |
+| `--pid-file` | | `PATH` | `/var/run/zebra-rs.pid` (daemon mode) | Write the process ID to this file |
+| `--vty-socket` | | `unix:NAME \| tcp:HOST:PORT` | `unix:zebra-rs/vty` | Management (VTY gRPC) listen address |
+
+## `-c`, `--config-file FILENAME`
+
+Loads a configuration file at startup and commits it as the running
+configuration. When omitted, the daemon falls back to a file named
+`zebra-rs.conf` located next to the resolved YANG directory (that is,
+`<yang-path>/../zebra-rs.conf`). Passing `--config-file` overrides both
+the *load* and *save* target, so the `load` and `save` commands in the
+`configure` mode also operate on the file you named.
+
+The file format is detected automatically from its first meaningful
+line, mirroring the `vtyctl apply -f FILENAME` handler. Any of the four
+configuration representations is accepted:
+
+- **CLI** — the Cisco-style indented block format (`show running-config`).
+- **JSON** — a JSON document of the configuration tree.
+- **YAML** — a YAML document of the configuration tree.
+- **set/delete** — a flat list of `set …` / `delete …` statements (the
+  `formal` format that `load` and `save` consume).
+
+The four formats are interchangeable; see
+[Show Config Commands](ch-06-02-show-config-commands.md) for examples of
+each. The same configuration expressed in every format:
+
+```
+# CLI
+system {
+  hostname r1;
+  router-id 10.0.0.1;
+}
+```
+
+```yaml
+# YAML
+system:
+  hostname: r1
+  router-id: 10.0.0.1
+```
+
+```json
+{ "system": { "hostname": "r1", "router-id": "10.0.0.1" } }
+```
+
+```
+# set/delete
+set system hostname r1
+set system router-id 10.0.0.1
+```
+
+```sh
+zebra-rs --config-file /etc/zebra-rs/zebra-rs.conf
+zebra-rs -c /etc/zebra-rs/startup.yaml
+```
+
+An empty (or comment-only) file is loaded as an empty configuration. If
+the document references a key the YANG schema does not recognize, the
+file is rejected as a whole — no partial configuration is applied — and
+the offending key is reported on the error log so a typo cannot silently
+leave a half-applied configuration.
+
+## `-y`, `--yang-path PATH`
+
+Sets the directory the YANG schema is loaded from. The schema defines
+every available configuration and show command, so the daemon cannot
+start without it. When `--yang-path` is not given (or the path does not
+exist), the following locations are tried in order:
+
+1. `--yang-path` argument, if the path exists
+2. `~/.zebra-rs/yang`
+3. `/etc/zebra-rs/yang`
+
+Startup aborts if none resolve.
+
+## `-d`, `--daemon`
+
+Detaches from the controlling terminal and runs in the background. The
+current working directory is preserved across the fork, so relative
+paths passed to `--yang-path`, `--config-file`, or `--pid-file` resolve
+the same way they would in the foreground. In daemon mode the process ID
+is written to `/var/run/zebra-rs.pid` unless `--pid-file` overrides it.
+
+## `--pid-file PATH`
+
+Writes the process ID to `PATH` on startup. This is useful for service
+managers and for the test harness to locate and stop the daemon. In
+`--daemon` mode it replaces the default `/var/run/zebra-rs.pid`.
+
+## `--vty-socket ADDRESS`
+
+Sets the address the management interface (the VTY gRPC server that
+`vtyctl` connects to) listens on. Two forms are accepted:
+
+- `unix:NAME` — a Linux abstract unix-domain socket (the default,
+  `unix:zebra-rs/vty`).
+- `tcp:HOST:PORT` — a TCP endpoint.
+
+Running several daemons on one host — for example in test namespaces —
+requires giving each a distinct `--vty-socket`.
+
+## `--no-nhid`
+
+Disables the use of kernel nexthop IDs and instead embeds the nexthop
+directly in each route. Nexthop ID objects require Linux kernel 5.3 or
+newer; set this flag on older kernels.
+
+## Logging options
+
+`--log-output`, `--log-file`, and `--log-format` control where log
+records go and how they are serialized. These are covered in detail in
+[Logging Configuration](ch-03-00-logging-overview.md); the quick summary
+is:
+
+- `--log-output stdout|syslog|file` selects the destination
+  (default `stdout`).
+- `--log-file PATH` names the file when `--log-output=file`
+  (default `./zebra-rs.log`).
+- `--log-format terminal|json|elasticsearch` selects the record format
+  (default `terminal`).

--- a/zebra-rs/src/config/manager.rs
+++ b/zebra-rs/src/config/manager.rs
@@ -251,14 +251,25 @@ pub struct ConfigManager {
 impl ConfigManager {
     pub fn new(
         yang_path: String,
+        config_file: Option<String>,
         rib_tx: UnboundedSender<crate::rib::Message>,
         rib_inbound_tx: UnboundedSender<crate::rib::client::RibInbound>,
         policy_tx: UnboundedSender<crate::policy::Message>,
         yang_service_accounts: std::sync::Arc<std::sync::RwLock<std::collections::HashSet<u32>>>,
     ) -> anyhow::Result<Self> {
-        let mut config_path = PathBuf::from(yang_path.clone());
-        config_path.pop();
-        config_path.push("zebra-rs.conf");
+        // `--config-file FILENAME` overrides the load/save target; with no
+        // override fall back to `zebra-rs.conf` next to the YANG tree. The
+        // explicit file may be in any format `load_config` understands
+        // (CLI brace, JSON, YAML, set/delete) — see `config_to_commands`.
+        let config_path = match config_file {
+            Some(path) => PathBuf::from(path),
+            None => {
+                let mut p = PathBuf::from(yang_path.clone());
+                p.pop();
+                p.push("zebra-rs.conf");
+                p
+            }
+        };
 
         let (tx, rx) = mpsc::channel(255);
         let mut cm = Self {
@@ -689,13 +700,78 @@ impl ConfigManager {
         Ok(to_entry(yang, module))
     }
 
+    /// Sniff the format of a raw config document and convert it into a
+    /// flat list of `set`/`delete` command strings. Shared by the
+    /// startup/`load` path ([`Self::load_config`]) and the
+    /// `vtyctl apply` (`Message::Deploy`) path so a config — whether on
+    /// disk or streamed in — may be CLI brace, JSON, YAML, or
+    /// `set`/`delete` form.
+    ///
+    /// On success returns the detected format plus the commands. A
+    /// document key that doesn't exist in the schema used to be dropped
+    /// silently, applying a PARTIAL config with a clean "applied" reply
+    /// (e.g. a misspelled policy match leaf that left the policy
+    /// permit-all). Reject the document instead, returning the offending
+    /// keys as `Err`, so the operator sees exactly which keys the schema
+    /// refused.
+    fn config_to_commands(&self, config: &str) -> Result<(ConfigFormat, Vec<String>), Vec<String>> {
+        let mode = self.modes.get("configure").unwrap();
+        let mut entry: Option<Rc<Entry>> = None;
+        for e in mode.entry.dir.borrow().iter() {
+            if e.name == "set" {
+                entry = Some(e.clone());
+            }
+        }
+        let entry = entry.unwrap();
+
+        let format_type = config_format_type(config);
+        let (cmds, doc_errors) = match format_type {
+            ConfigFormat::Cli => (load_config_file(config.to_string()), Vec::new()),
+            ConfigFormat::Json => json_read(entry, config),
+            ConfigFormat::Yaml => {
+                let json = yaml_parse(config);
+                json_read(entry, json.as_str())
+            }
+            ConfigFormat::SetDelete => (
+                config
+                    .lines()
+                    .filter(|l| !l.trim().is_empty())
+                    .map(str::to_string)
+                    .collect(),
+                Vec::new(),
+            ),
+        };
+        if !doc_errors.is_empty() {
+            return Err(doc_errors);
+        }
+        Ok((format_type, cmds))
+    }
+
     pub fn load_config(&self) {
-        let output = std::fs::read_to_string(&self.config_path);
-        if let Ok(output) = output {
-            let cmds = load_config_file(output);
-            if let Some(mode) = self.modes.get("configure") {
-                for cmd in cmds.iter() {
-                    let _ = self.execute(mode, cmd);
+        if let Ok(output) = std::fs::read_to_string(&self.config_path) {
+            // An empty (or comment/whitespace-only) config file carries no
+            // commands. Skip the format parsers entirely: the YAML default
+            // would otherwise `yaml_parse("")` → `null` → a bogus bare
+            // `set` line. (Done here, not in `config_to_commands`, so the
+            // `vtyctl apply` path keeps its existing empty-document
+            // behavior — an empty apply must not clear+commit the running
+            // config.)
+            if !output.trim().is_empty() {
+                match self.config_to_commands(&output) {
+                    Ok((_format, cmds)) => {
+                        if let Some(mode) = self.modes.get("configure") {
+                            for cmd in cmds.iter() {
+                                let _ = self.execute(mode, cmd);
+                            }
+                        }
+                    }
+                    Err(doc_errors) => {
+                        tracing::error!(
+                            "config file {}: rejected by schema: {}",
+                            self.config_path.display(),
+                            doc_errors.join("; ")
+                        );
+                    }
                 }
             }
         }
@@ -851,46 +927,19 @@ impl ConfigManager {
             }
             Message::Deploy(req) => {
                 let mode = self.modes.get("configure").unwrap();
-                let mut entry: Option<Rc<Entry>> = None;
-                for e in mode.entry.dir.borrow().iter() {
-                    if e.name == "set" {
-                        entry = Some(e.clone());
-                    }
-                }
-                let entry = entry.unwrap();
 
-                let format_type = config_format_type(&req.config);
-                let (cmds, doc_errors) = match format_type {
-                    ConfigFormat::Cli => (load_config_file(req.config.clone()), Vec::new()),
-                    ConfigFormat::Json => json_read(entry, req.config.as_str()),
-                    ConfigFormat::Yaml => {
-                        let config = yaml_parse(req.config.as_str());
-                        json_read(entry, config.as_str())
+                let (format_type, cmds) = match self.config_to_commands(&req.config) {
+                    Ok(parsed) => parsed,
+                    Err(doc_errors) => {
+                        let resp = DeployResponse {
+                            apply_code: ApplyCode::ParseError,
+                            exec_code: ExecCode::Nomatch,
+                            cmd: doc_errors.join("; "),
+                        };
+                        let _ = req.resp.send(resp);
+                        return;
                     }
-                    ConfigFormat::SetDelete => (
-                        req.config
-                            .lines()
-                            .filter(|l| !l.trim().is_empty())
-                            .map(str::to_string)
-                            .collect(),
-                        Vec::new(),
-                    ),
                 };
-                // A document key that doesn't exist in the schema used
-                // to be dropped silently, applying a PARTIAL config
-                // with a clean "applied" reply (e.g. a misspelled
-                // policy match leaf that left the policy permit-all).
-                // Reject the document instead so the operator sees
-                // exactly which keys the schema refused.
-                if !doc_errors.is_empty() {
-                    let resp = DeployResponse {
-                        apply_code: ApplyCode::ParseError,
-                        exec_code: ExecCode::Nomatch,
-                        cmd: doc_errors.join("; "),
-                    };
-                    let _ = req.resp.send(resp);
-                    return;
-                }
 
                 if format_type != ConfigFormat::SetDelete {
                     self.store.candidate_clear();

--- a/zebra-rs/src/main.rs
+++ b/zebra-rs/src/main.rs
@@ -41,6 +41,14 @@ struct Arg {
     #[arg(short, long, help = "YANG load path", default_value = "")]
     yang_path: String,
 
+    #[arg(
+        short = 'c',
+        long = "config-file",
+        value_name = "FILENAME",
+        help = "Configuration file to load at startup (CLI, JSON, YAML, or set/delete format); overrides the default zebra-rs.conf"
+    )]
+    config_file: Option<String>,
+
     #[arg(short, long, help = "Run as daemon in background")]
     daemon: bool,
 
@@ -184,6 +192,7 @@ async fn run(arg: Arg) -> anyhow::Result<()> {
 
     let config = ConfigManager::new(
         yang_path,
+        arg.config_file.clone(),
         rib.tx.clone(),
         rib.inbound_tx.clone(),
         policy.tx.clone(),


### PR DESCRIPTION
## Summary

Adds a `--config-file FILENAME` (short `-c`) command line option to the `zebra-rs` daemon for loading a configuration file at startup. When omitted, the daemon keeps loading the default `zebra-rs.conf` next to the YANG tree; when given, `-c` overrides both the load and save target.

The file format is auto-detected from its first meaningful line — the **same** detection used by `vtyctl apply -f FILENAME` — so the file may be:
- **CLI** (Cisco-style indented block)
- **JSON**
- **YAML**
- **set/delete** (flat `set …` / `delete …` statements)

### Implementation
- `main.rs`: new `-c, --config-file <FILENAME>` flag, passed into `ConfigManager::new()`.
- `manager.rs`: extracted the shared format-detection/parsing logic from the `vtyctl apply` (`Message::Deploy`) handler into `ConfigManager::config_to_commands()`. `Deploy` is otherwise byte-for-byte unchanged. `load_config()` now uses the helper and rejects a document with unknown schema keys (logging the offending key) instead of applying a partial config.
- The empty/comment-only-document guard lives in `load_config`, **not** the shared helper, so an empty `vtyctl apply` cannot `candidate_clear()` + commit and wipe the running config.
- `book/`: new "Command Line Options" chapter documenting every flag (focused on `--config-file`), registered in `SUMMARY.md`.

## Test plan
- `cargo check`, `cargo clippy --workspace --all-targets`, `cargo fmt --all --check` — all clean.
- Live end-to-end: started the daemon with `-c` for each format and read back `show running-config`:
  - YAML → `hostname yamlhost` ✓
  - JSON → `hostname jsonhost` ✓
  - set/delete → `hostname setdelhost` ✓
  - CLI → `hostname clihost` ✓
  - empty / comment-only file → loaded as empty config, daemon stays up, no panic ✓
  - unknown schema key → daemon stays up and logs `config file <path>: rejected by schema: system: unknown key \`hostnam\`` ✓
- `mdbook build` succeeds with the new chapter.

Generated with [Claude Code](https://claude.com/claude-code)