### PR TITLE
bgp-evpn: external vnifilter VXLAN model — per-VTEP SMET groundwork (P1b)

### DIFF
--- a/zebra-rs/src/fib/netlink/handle.rs
+++ b/zebra-rs/src/fib/netlink/handle.rs
@@ -1817,9 +1817,13 @@ impl FibHandle {
         let kind = InfoKind::Vxlan;
         let link_kind = LinkInfo::Kind(kind);
 
-        // VNI encode.
-        let vni = InfoVxlan::Id(vni);
-        let mut vxlan_info = vec![vni];
+        // EVPN VXLAN device model: `external vnifilter`. The device
+        // carries no fixed VNI (`IFLA_VXLAN_ID` = 0); each VNI it serves
+        // is registered separately with `bridge vni add` and stamped on
+        // every FDB/MDB entry as `src_vni`. This VNI-aware model is what
+        // unlocks the kernel VXLAN MDB (per-VTEP `dst` for RFC 9251
+        // SMET) — a plain fixed-`id` device cannot carry an MDB `dst`.
+        let mut vxlan_info = vec![InfoVxlan::CollectMetadata(true), InfoVxlan::Vnifilter(true)];
 
         // Destination port. Defaults to the IANA-assigned VXLAN port
         // (4789) when the operator hasn't configured one — Linux would
@@ -1855,6 +1859,13 @@ impl FibHandle {
                 tracing::info!("NewLink vxlan error: {e}");
                 return;
             }
+        }
+
+        // Register the VNI on the vnifilter device so the kernel accepts
+        // and encapsulates traffic for it (`bridge vni add vni N dev X`).
+        // The device must exist first, so resolve its ifindex now.
+        if let Some(ifindex) = self.link_index_by_name(&vxlan.name).await {
+            self.vni_filter_add(ifindex, vni).await;
         }
 
         // Set the IPv6 address generation mode as a second operation.
@@ -1939,6 +1950,36 @@ impl FibHandle {
         while let Some(msg) = response.next().await {
             if let NetlinkPayload::Error(e) = msg.payload {
                 tracing::info!("DelLink error: {}", e);
+            }
+        }
+    }
+
+    /// Register a VNI on a `vnifilter` VXLAN device — the netlink
+    /// equivalent of `bridge vni add vni <vni> dev <ifindex>`. Required
+    /// before an `external vnifilter` device will accept or originate
+    /// traffic for that VNI (and before VXLAN-MDB / FDB entries can bind
+    /// to it via `src_vni`). Emits `RTM_NEWTUNNEL` carrying one
+    /// `VXLAN_VNIFILTER_ENTRY`. (Removal rides on device deletion, which
+    /// the kernel cascades, so there is no explicit del counterpart.)
+    pub async fn vni_filter_add(&self, ifindex: u32, vni: u32) {
+        use netlink_packet_route::RouteNetlinkMessage;
+        use netlink_packet_route::tunnel::TunnelMessage;
+
+        let msg = TunnelMessage::vni(ifindex, vni);
+        let mut req = NetlinkMessage::from(RouteNetlinkMessage::NewTunnel(msg));
+        req.header.flags = NLM_F_REQUEST | NLM_F_ACK | NLM_F_CREATE;
+
+        let mut response = self.handle.clone().request(req).unwrap();
+        while let Some(rsp) = response.next().await {
+            if let NetlinkPayload::Error(e) = rsp.payload
+                && e.code.is_some()
+            {
+                tracing::info!(
+                    "vni_filter_add: netlink error vni {} ifindex {}: {}",
+                    vni,
+                    ifindex,
+                    e
+                );
             }
         }
     }
@@ -2835,16 +2876,18 @@ impl FibHandle {
         const NTF_EXT_LEARNED: u8 = 0x10;
         const NUD_PERMANENT: u16 = 0x80;
 
-        // Zero-MAC entry on the VXLAN device. Note we pass `vni: None`
-        // — for ingress-replication entries the kernel uses the
-        // VXLAN device's own VNI (set at link creation), and adding
-        // NDA_VNI/NDA_SRC_VNI here is incorrect.
+        // Zero-MAC entry on the VXLAN device. Under the `external
+        // vnifilter` model the device has no fixed VNI, so the BUM
+        // ingress-replication row must carry `src_vni` (NDA_SRC_VNI) to
+        // bind it to this VNI; NDA_VNI sets the VNI used when
+        // encapsulating the replicated BUM traffic to `group` (the
+        // remote VTEP).
         self.fdb_neigh_send(
             vxlan_ifindex,
             &MacAddr::from([0u8; 6]),
             NTF_SELF | NTF_EXT_LEARNED,
             NUD_PERMANENT,
-            None,
+            Some(vni),
             Some(group),
             FdbOp::Append,
             "mdb_add(zero-mac)",
@@ -2882,7 +2925,7 @@ impl FibHandle {
             &MacAddr::from([0u8; 6]),
             NTF_SELF,
             0,
-            None,
+            Some(vni),
             Some(group),
             FdbOp::Delete,
             "mdb_del(zero-mac)",

--- a/zebra-rs/src/rib/link.rs
+++ b/zebra-rs/src/rib/link.rs
@@ -452,6 +452,18 @@ pub fn link_addr_del(link: &mut Link, addr: LinkAddr) -> Option<()> {
 
 impl Rib {
     pub async fn link_add(&mut self, fib_link: FibLink) {
+        // `external vnifilter` VXLAN devices (the EVPN model) carry no
+        // fixed kernel VNI — `IFLA_VXLAN_ID` is 0. Source the real VNI
+        // from our own config (keyed by device name) so the VNI→ifindex
+        // map, EVPN VTEP discovery and `vni_for_bridge` all observe the
+        // true L2VPN VNI instead of 0.
+        let mut fib_link = fib_link;
+        if fib_link.vni == Some(0)
+            && let Some(cfg_vni) = self.vxlan.get(&fib_link.name).and_then(|v| v.vni)
+        {
+            fib_link.vni = Some(cfg_vni);
+        }
+
         if rib_interface() {
             tracing::info!(
                 "link_add: ifindex {} name {} vni {:?} master {:?}",
@@ -740,9 +752,17 @@ impl Rib {
     }
 
     pub fn link_delete(&mut self, oslink: FibLink) {
-        // Unregister via the kernel-derived VNI on the netlink
-        // message (mirrors the registration trigger in `link_add`).
-        if let Some(vni) = oslink.vni {
+        // Unregister via the VNI we resolved when the link was added
+        // (config-sourced for `external vnifilter` devices, whose kernel
+        // `IFLA_VXLAN_ID` is 0). Fall back to the netlink value for a
+        // plain fixed-`id` VXLAN.
+        let del_vni = self
+            .links
+            .get(&oslink.index)
+            .and_then(|l| l.vni)
+            .filter(|v| *v != 0)
+            .or(oslink.vni);
+        if let Some(vni) = del_vni {
             self.fib_handle.unregister_vxlan_ifindex(vni);
             self.api_vxlan_del(vni);
         }


### PR DESCRIPTION
## What

Switches the EVPN VXLAN dataplane to the VNI-aware **`external vnifilter`** device model — the prerequisite for true per-VTEP RFC 9251 SMET delivery via the kernel **VXLAN MDB** (a plain fixed-`id` VXLAN cannot carry an MDB `dst`; an `external vnifilter` device can). This is **P1b** of the per-VTEP `dst` series; the actual `mdb_install` retarget is the follow-up **P4**.

## Changes

- **`vxlan_add`**: create `external vnifilter` (`CollectMetadata` + `Vnifilter`, no fixed `IFLA_VXLAN_ID`) and register each VNI with `bridge vni add` (`RTM_NEWTUNNEL`, via the new `vni_filter_add` helper).
- **Type-3 BUM** (`mdb_add`/`mdb_del`): carry `src_vni` (`NDA_SRC_VNI`) — the device no longer has an implicit VNI, so the zero-MAC ingress-replication row must bind to the VNI explicitly.
- **`link.rs`**: source the L2VPN VNI from config when the kernel reports `id 0` (external devices) so `vni_for_bridge` / VTEP discovery / `vni_ifindex_map` observe the real VNI; unregister under the stored VNI on link delete.
- **Type-2 MAC** needs no change — its self FDB entry already carries `src_vni`.

## Dependency

Requires the seg6 fork VNI-filter primitive: `netlink-packet-route` (branch `seg6`) `b03a738` — adds `tunnel::TunnelMessage` (`RTM_NEWTUNNEL` = `bridge vni add`, `VXLAN_VNIFILTER_ENTRY`). Already pushed; `Cargo.lock` is gitignored so CI picks up the seg6 tip.

## Validation

Kernel 6.8 / iproute2 7.0.0:

- `cargo fmt`, `cargo clippy --workspace --all-targets -- -D warnings` — clean
- `cargo test -p zebra-rs` — 1358 passed
- BDD: **`@vxlan_bridge` (4)**, **`@bgp_evpn_ar` (7)**, **`@bgp_evpn_smet` (6)** — all green

Note: `@bgp_evpn_segmentation` is **pre-existing red on `main`** (verified head-to-head against the parent binary — RBR Type-9 re-origination, Phase 3b #1522); unrelated to this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)