### PR TITLE
bgp-evpn: per-VTEP SMET delivery via VXLAN MDB dst (P4)

### DIFF
--- a/bdd/tests/features/bgp_evpn_smet.feature
+++ b/bdd/tests/features/bgp_evpn_smet.feature
@@ -63,20 +63,26 @@ Feature: BGP EVPN IGMP/MLD Proxy — Selective Multicast (RFC 9251)
     # positive assert above so z1 already has EVPN routes (non-vacuous).
     And show command "show bgp evpn" in namespace "z1" should not contain "ff02"
 
-  Scenario: z1 programs the received SMET into its kernel bridge MDB
+  Scenario: z1 programs the received SMET into its kernel MDB (per-VTEP dst)
     Given the test topology exists
-    # The received SMET drives `bridge mdb add dev br10 port vxlan10
-    # grp 239.1.1.1` on z1. z1 has no local member, so the group can only
-    # appear in its MDB via the SMET install. (Per-VTEP `dst` selectivity
-    # needs a vnifilter VXLAN MDB — see the design doc; a plain VXLAN
-    # registers the group on the port but the kernel drops the `dst`.)
+    # The received SMET drives two installs on z1: the bridge MDB
+    # (`dev br10 port vxlan10 grp 239.1.1.1`, local membership so the
+    # bridge forwards the group into the overlay) and the VXLAN MDB on the
+    # `external vnifilter` device (`dev vxlan10 grp 239.1.1.1 src_vni 10
+    # dst 192.168.0.2`), which delivers the group selectively to z2's VTEP
+    # instead of BUM-flooding every peer (RFC 9251). z1 has no local
+    # member, so the group can only appear via the SMET install.
     Then bridge mdb "br10" in namespace "z1" should eventually contain "239.1.1.1"
+    And bridge mdb "vxlan10" in namespace "z1" should eventually contain "239.1.1.1"
+    # The per-VTEP `dst` — the whole point: G is targeted at z2 (192.168.0.2).
+    And bridge mdb "vxlan10" in namespace "z1" should eventually contain "192.168.0.2"
 
   Scenario: A leave withdraws the SMET and removes the MDB entry on z1
     Given the test topology exists
     When I execute "bridge mdb del dev br10 port host0 grp 239.1.1.1 permanent" in namespace "z2"
     Then show command "show bgp evpn" in namespace "z1" should eventually not contain "[6]:[0]:[0]:[*]:[32]:[239.1.1.1]"
     And bridge mdb "br10" in namespace "z1" should not contain "239.1.1.1"
+    And bridge mdb "vxlan10" in namespace "z1" should not contain "239.1.1.1"
 
   Scenario: An (S,G) join originates a source-specific SMET with the right source
     Given the test topology exists
@@ -85,6 +91,10 @@ Feature: BGP EVPN IGMP/MLD Proxy — Selective Multicast (RFC 9251)
     # key, not a (*,G) wildcard.
     When I execute "bridge mdb add dev br10 port host0 src 192.0.2.9 grp 232.1.1.1 permanent" in namespace "z2"
     Then show command "show bgp evpn" in namespace "z1" should eventually contain "[6]:[0]:[32]:[192.0.2.9]:[32]:[232.1.1.1]:[32]:[192.168.0.2]"
+    # (S,G) per-VTEP VXLAN MDB on z1: the source-specific entry carries
+    # the group and z2's dst (the source rides in the MDB SET nest).
+    And bridge mdb "vxlan10" in namespace "z1" should eventually contain "232.1.1.1"
+    And bridge mdb "vxlan10" in namespace "z1" should eventually contain "192.168.0.2"
 
   Scenario: Teardown topology
     Given the test topology exists

--- a/docs/design/bgp-evpn-smet-pervtep-dst-plan.md
+++ b/docs/design/bgp-evpn-smet-pervtep-dst-plan.md
@@ -186,3 +186,39 @@ the open questions, with one tooling blocker:
    landing the Type-2/3 `src_vni` FDB rework in the same PR, since the
    plain-model FDB stops working under `external`).
 3. P2–P4 as before; P4 gated on the validation tooling above.
+
+## Status — IMPLEMENTED & BDD-validated (2026-06-21)
+
+The series shipped. The "validation tooling" blocker above is **resolved**:
+the test host was upgraded to **iproute2 7.0.0 / kernel 6.8**, whose
+`bridge mdb show dev <vxlan>` renders the VXLAN MDB `dst`/`src_vni`, so P4
+is directly observable in BDD (no daemon-side readback needed after all).
+
+- **P1a (fork)** — `netlink-packet-route` seg6 `b03a738`: `tunnel::TunnelMessage`
+  (`RTM_NEWTUNNEL` = `bridge vni add`, `VXLAN_VNIFILTER_ENTRY`), plus the
+  earlier `d2c1d85` MDB `dst`/`src_vni` readback decode.
+- **P1b (model switch)** — PR #1549: `vxlan_add` → `external vnifilter`
+  (`CollectMetadata`+`Vnifilter`, no fixed `id`); `bridge vni add` per VNI via
+  `vni_filter_add`; Type-3 BUM `mdb_add`/`del` carry `src_vni`; `link.rs`
+  sources the L2VPN VNI from config when the kernel reports `id 0`. Type-2
+  needed no change (self FDB already had `src_vni`).
+- **P4 (per-VTEP dst)** — PR #1550 (stacked on #1549): `mdb_install` keeps the
+  bridge MDB (local membership → overlay) AND adds a VXLAN MDB on `dev=vxlan`
+  with nested `MDBE_ATTR_DST` (originator VTEP) + `MDBE_ATTR_SRC_VNI`
+  (+ `MDBE_ATTR_SOURCE` for (S,G)), via a shared `mdb_send`. Replicates the
+  group only to the asking VTEP instead of BUM-flooding.
+
+**Design choice vs the sketch:** the original sketch said "retarget
+`mdb_install` to `dev = vxlan`" (replace the bridge MDB). The implementation
+keeps **both** installs — the bridge MDB registers the VXLAN port so the
+snooping bridge forwards the group into the overlay, while the VXLAN MDB
+selects the destination VTEP. This mirrors FRR and avoids dropping local
+bridge→overlay forwarding.
+
+Validation (kernel 6.8 / iproute2 7.0.0): `@bgp_evpn_smet` extended to assert
+`bridge mdb "vxlan10" … contains <dst VTEP>` for (*,G) and (S,G) + withdrawal;
+green alongside `@vxlan_bridge` and `@bgp_evpn_ar`. `cargo fmt` +
+`clippy --workspace --all-targets -- -D warnings` clean.
+
+Deferred (unchanged): SMET-flags fidelity from kernel group-mode, MF-EC
+capability gate, per-VLAN VID mapping, Type 7/8 multihoming synch.

--- a/zebra-rs/src/fib/netlink/handle.rs
+++ b/zebra-rs/src/fib/netlink/handle.rs
@@ -2716,36 +2716,74 @@ impl FibHandle {
         group: IpAddr,
         source: Option<IpAddr>,
         dst: IpAddr,
+        vni: u32,
         add: bool,
     ) {
-        use netlink_packet_route::RouteNetlinkMessage;
-        use netlink_packet_route::mdb::{MdbAttribute, MdbHeader, MdbMessage};
+        use netlink_packet_route::mdb::MdbAttribute;
         use netlink_packet_utils::nla::DefaultNla;
 
+        // (1) Bridge MDB — register the group on the bridge toward the
+        // VXLAN port (`dev = bridge`, `port = vxlan`) so the snooping
+        // bridge forwards it into the overlay. (*,G) is the bare
+        // br_mdb_entry; (S,G) nests MDBE_ATTR_SOURCE. No `dst` here — the
+        // bridge MDB rejects MDBE_ATTR_DST; per-VTEP selectivity is the
+        // VXLAN MDB below.
         let entry = br_mdb_entry_bytes(port_ifindex, vid, group);
-        // MDBA_SET_ENTRY is the bare br_mdb_entry (this is all iproute2
-        // sends for a (*,G) entry). An (S,G) entry adds a NESTED
-        // MDBA_SET_ENTRY_ATTRS holding MDBE_ATTR_SOURCE. The per-VTEP
-        // `dst` is deliberately NOT encoded: the kernel rejects
-        // MDBE_ATTR_DST on a plain (non-vnifilter) VXLAN with EINVAL, and
-        // iproute2 silently drops it too. True per-VTEP selectivity needs
-        // a vnifilter VXLAN MDB — a documented follow-up.
-        let mut attributes = vec![MdbAttribute::Other(DefaultNla::new(
+        let mut bridge_attrs = vec![MdbAttribute::Other(DefaultNla::new(
             MDBA_SET_ENTRY,
             entry.to_vec(),
         ))];
         if let Some(src) = source {
-            let nested = mdb_nla_bytes(MDBE_ATTR_SOURCE, &ip_octets(src));
-            attributes.push(MdbAttribute::Other(DefaultNla::new(
+            bridge_attrs.push(MdbAttribute::Other(DefaultNla::new(
                 MDBA_SET_ENTRY_ATTRS | NLA_F_NESTED,
-                nested,
+                mdb_nla_bytes(MDBE_ATTR_SOURCE, &ip_octets(src)),
             )));
         }
+        self.mdb_send(bridge_ifindex, bridge_attrs, group, dst, add, "bridge")
+            .await;
+
+        // (2) VXLAN MDB — per-VTEP overlay selectivity (`dev = port =
+        // vxlan`). The nested MDBA_SET_ENTRY_ATTRS carries MDBE_ATTR_DST
+        // (the remote VTEP the SMET came from) + MDBE_ATTR_SRC_VNI, plus
+        // MDBE_ATTR_SOURCE for (S,G). The kernel then replicates the
+        // group only to `dst` instead of BUM-flooding to every VTEP
+        // (RFC 9251). Requires an `external vnifilter` VXLAN device (P1b).
+        let mut nested = Vec::new();
+        if let Some(src) = source {
+            nested.extend_from_slice(&mdb_nla_bytes(MDBE_ATTR_SOURCE, &ip_octets(src)));
+        }
+        nested.extend_from_slice(&mdb_nla_bytes(MDBE_ATTR_DST, &ip_octets(dst)));
+        nested.extend_from_slice(&mdb_nla_bytes(MDBE_ATTR_SRC_VNI, &vni.to_ne_bytes()));
+        let vxlan_attrs = vec![
+            MdbAttribute::Other(DefaultNla::new(
+                MDBA_SET_ENTRY,
+                br_mdb_entry_bytes(port_ifindex, vid, group).to_vec(),
+            )),
+            MdbAttribute::Other(DefaultNla::new(MDBA_SET_ENTRY_ATTRS | NLA_F_NESTED, nested)),
+        ];
+        self.mdb_send(port_ifindex, vxlan_attrs, group, dst, add, "vxlan")
+            .await;
+    }
+
+    /// Send one `RTM_{NEW,DEL}MDB` for `dev_ifindex` with the supplied
+    /// `MDBA_SET_ENTRY` (+ optional nested `MDBA_SET_ENTRY_ATTRS`).
+    /// Shared by the bridge-MDB and VXLAN-MDB installs in `mdb_install`.
+    async fn mdb_send(
+        &self,
+        dev_ifindex: u32,
+        attributes: Vec<netlink_packet_route::mdb::MdbAttribute>,
+        group: IpAddr,
+        dst: IpAddr,
+        add: bool,
+        kind: &str,
+    ) {
+        use netlink_packet_route::RouteNetlinkMessage;
+        use netlink_packet_route::mdb::{MdbHeader, MdbMessage};
 
         let msg = MdbMessage {
             header: MdbHeader {
                 family: AddressFamily::Bridge,
-                index: bridge_ifindex,
+                index: dev_ifindex,
             },
             attributes,
         };
@@ -2762,12 +2800,11 @@ impl FibHandle {
 
         if fib_l2_mdb() {
             tracing::info!(
-                "mdb_install(add={}): br {} port {} grp {} src {:?} dst {}",
+                "mdb_install[{}](add={}): dev {} grp {} dst {}",
+                kind,
                 add,
-                bridge_ifindex,
-                port_ifindex,
+                dev_ifindex,
                 group,
-                source,
                 dst
             );
         }
@@ -2778,7 +2815,8 @@ impl FibHandle {
                 && e.code.is_some()
             {
                 tracing::info!(
-                    "mdb_install: netlink error grp {} dst {} (add={}): {}",
+                    "mdb_install[{}]: netlink error grp {} dst {} (add={}): {}",
+                    kind,
                     group,
                     dst,
                     add,
@@ -3333,6 +3371,11 @@ fn process_msg(msg: NetlinkMessage<RouteNetlinkMessage>, tx: UnboundedSender<Fib
 const MDBA_SET_ENTRY: u16 = 1;
 const MDBA_SET_ENTRY_ATTRS: u16 = 2;
 const MDBE_ATTR_SOURCE: u16 = 1;
+/// VXLAN-MDB per-entry attributes (linux/if_bridge.h): the remote VTEP
+/// (`MDBE_ATTR_DST`) and the source VNI (`MDBE_ATTR_SRC_VNI`). Only
+/// accepted on a VNI-aware `external vnifilter` VXLAN device.
+const MDBE_ATTR_DST: u16 = 5;
+const MDBE_ATTR_SRC_VNI: u16 = 9;
 /// `NLA_F_NESTED` (linux/netlink.h) — the kernel expects it on the
 /// `MDBA_SET_ENTRY_ATTRS` container (matches what iproute2 sets).
 const NLA_F_NESTED: u16 = 0x8000;

--- a/zebra-rs/src/rib/inst.rs
+++ b/zebra-rs/src/rib/inst.rs
@@ -3256,7 +3256,16 @@ impl Rib {
             return;
         };
         self.fib_handle
-            .mdb_install(bridge_ifindex, vxlan_ifindex, 0, group, source, dst, add)
+            .mdb_install(
+                bridge_ifindex,
+                vxlan_ifindex,
+                0,
+                group,
+                source,
+                dst,
+                vni,
+                add,
+            )
             .await;
     }
 


### PR DESCRIPTION
## What

Completes RFC 9251 **per-VTEP** selective multicast: a received Type-6 SMET now programs the kernel **VXLAN MDB** with the originator's VTEP as `dst`, so the group is replicated only to the PE that asked for it instead of BUM-flooding every peer.

**Stacks on #1549 (P1b)** — base is `bgp-evpn-smet-pervtep-dst`. The `external vnifilter` device model from P1b is the prerequisite (a plain VXLAN rejects `MDBE_ATTR_DST`).

## Changes

- **`mdb_install`** now performs two installs (factored into a shared `mdb_send`):
  1. **Bridge MDB** (`dev=bridge, port=vxlan`) — unchanged; registers the group toward the VXLAN port so the snooping bridge forwards it into the overlay.
  2. **VXLAN MDB** (`dev=port=vxlan`) — nested `MDBA_SET_ENTRY_ATTRS` carrying `MDBE_ATTR_DST` (originator VTEP) + `MDBE_ATTR_SRC_VNI`, plus `MDBE_ATTR_SOURCE` for (S,G).
- `vni` threaded through `mdb_install` ← `smet_install` (`dst`/`vni` were already plumbed via `SmetInstall`).
- New constants `MDBE_ATTR_DST = 5`, `MDBE_ATTR_SRC_VNI = 9`.

## Validation

Kernel 6.8 / iproute2 7.0.0. `cargo fmt` + `clippy --workspace --all-targets -- -D warnings` clean.

`@bgp_evpn_smet` extended to assert the per-VTEP `dst` on the VXLAN MDB and re-run green (6 scenarios, 45 steps):
- `bridge mdb "vxlan10" … contains "192.168.0.2"` (z2's VTEP) for both (*,G) and (S,G)
- withdrawal removes the VXLAN MDB entry

No regression: `@vxlan_bridge` and `@bgp_evpn_ar` still green.

> Note: this host was upgraded to iproute2 7.0.0, which (unlike the 6.1.0 the design doc assumed) renders the VXLAN MDB — so the per-VTEP `dst` is now directly BDD-observable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)