### PR TITLE
bgp-evpn: re-apply region-id to bound neighbors (RFC 9572 RBR fix)

### DIFF
--- a/zebra-rs/src/bgp/neighbor_group.rs
+++ b/zebra-rs/src/bgp/neighbor_group.rs
@@ -675,7 +675,17 @@ pub fn config_neighbor_group_region_id(bgp: &mut Bgp, mut args: Args, op: Config
         ConfigOp::Delete => None,
         _ => return Some(()),
     };
-    bgp.neighbor_groups.entry(name).or_default().knobs.region_id = value;
+    bgp.neighbor_groups
+        .entry(name.clone())
+        .or_default()
+        .knobs
+        .region_id = value;
+    // Re-resolve members already bound to this group so the region-id
+    // (RFC 9572 §6.1 RBR gate) reaches an existing neighbor regardless of
+    // config order. Without this, a neighbor bound before the region-id
+    // leaf is applied keeps `region_id = None` and never re-originates the
+    // Type-9 Per-Region I-PMSI — every other neighbor-group knob sweeps.
+    sweep_members_inherit(bgp, &name);
     Some(())
 }
 


### PR DESCRIPTION
## Bug

`@bgp_evpn_segmentation` was **red on `main`** (Phase 3b, #1522): a Regional Border Router never re-originated the Type-9 Per-Region I-PMSI from a received Type-3 IMET, so neither the RBR nor the downstream region saw `[9]:[0]:[AS:65001]`. BDD isn't in CI, so it landed broken.

## Root cause

`route_evpn_update` gates Type-9 re-origination on the ingress peer carrying a `region_id`. But `config_neighbor_group_region_id` only set the group knob — unlike **every other** neighbor-group knob handler, it never called `sweep_members` / `sweep_members_inherit` to push the change to peers already bound to the group. So a neighbor bound to the group before the `region-id` leaf was applied kept `region_id = None` and the gate never fired.

Root-caused with a temporary trace at the gate:
```
RBR-DEBUG Type-3 recv: peer_idx=0 region_id=None vni=Some(10)
```
VNI extracted fine; `region_id` was `None`.

## Fix

Add the missing `sweep_members_inherit(bgp, &name)` so bound neighbors re-resolve the region-id regardless of config order — matching the pattern of `update-source`, `tcp-mss`, `password`, etc.

## Validation

`@bgp_evpn_segmentation` now **passes** (5 scenarios): z2 re-originates `[9]:[0]:[AS:65001]`, z3 receives it with z2 as next hop, and the per-PE IMET is correctly held at the boundary. `cargo fmt` + `clippy --workspace --all-targets -- -D warnings` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)