### PR TITLE
docs(book): per-VTEP SMET delivery — external vnifilter + VXLAN MDB dst

### DIFF
--- a/book/src/ch-00-04-vxlan-configuration.md
+++ b/book/src/ch-00-04-vxlan-configuration.md
@@ -59,6 +59,7 @@ These are part of the `RTM_NEWLINK` that creates the device:
 | Default | Netlink | `ip link` equivalent | Why |
 |---|---|---|---|
 | **MAC learning off** (`nolearning`) | `IFLA_VXLAN_LEARNING = 0` | `... type vxlan ... nolearning` | The BGP control plane owns the FDB; kernel flood-and-learn must be off so it does not fight the control plane. |
+| **VNI-aware device** (`external vnifilter`) | `IFLA_VXLAN_COLLECT_METADATA = 1` + `IFLA_VXLAN_VNIFILTER = 1`; each VNI via `RTM_NEWTUNNEL` | `... type vxlan external vnifilter` then `bridge vni add vni <id> dev <dev>` | The device carries no fixed VNI (`id 0`); configured VNIs are registered explicitly and stamped on every FDB/MDB entry as `src_vni`. This VNI-aware model is what enables per-VTEP EVPN multicast — the kernel VXLAN MDB `dst` (see [IGMP/MLD Proxy](ch-02-32-bgp-evpn-igmp-mld-proxy.md)). |
 | **`dest-port 4789`** | `IFLA_VXLAN_PORT = 4789` | `... type vxlan ... dstport 4789` | The IANA-assigned VXLAN port, used when `dest-port` is unset — Linux would otherwise fall back to the legacy 8472. An explicit value always wins. |
 | **Brought up** | `IFF_UP` set on create | `ip link add ... up` | The device is operational immediately, without a separate `ip link set <dev> up`. |
 | **`address-gen-mode none`** | `IFLA_INET6_ADDR_GEN_MODE = 1` | `ip link set <dev> addrgenmode none` | Suppresses the kernel's automatic link-local on the VTEP. Applied as a follow-up `RTM_NEWLINK` after creation. |
@@ -107,11 +108,11 @@ nothing else is affected.)
 ## The full sequence
 
 Taken together, configuring a VXLAN in zebra-rs and enslaving it to a
-bridge reproduces the canonical EVPN-VXLAN bring-up. The four manual
-commands
+bridge reproduces the canonical EVPN-VXLAN bring-up. The manual commands
 
 ```
-ip link add vni550 type vxlan local 10.0.0.1 dstport 4789 id 550 nolearning
+ip link add vni550 type vxlan local 10.0.0.1 dstport 4789 external vnifilter nolearning
+bridge vni add vni 550 dev vni550
 ip link set vni550 master br550 addrgenmode none
 ip link set vni550 type bridge_slave neigh_suppress on learning off
 ip link set vni550 up
@@ -127,8 +128,9 @@ set vxlan vni550 dest-port 4789
 set vxlan vni550 bridge br550
 ```
 
-* the `vxlan` leaves create the device, with `nolearning`,
-  `addrgenmode none`, and `up` applied automatically (the first command
+* the `vxlan` leaves create the device as an `external vnifilter` VXLAN
+  with `nolearning`, register the configured VNI (`bridge vni add`), and
+  apply `addrgenmode none` and `up` automatically (the first two commands
   plus the `addrgenmode`/`up` parts);
 * `set vxlan vni550 bridge br550` enslaves it — the equivalent of
   `ip link set vni550 master br550` (the second command);
@@ -161,7 +163,7 @@ box. An explicit `dest-port` always takes precedence.
 
 | zebra-rs | iproute2 |
 |---|---|
-| `vxlan <n> vni <id>` | `ip link add <n> type vxlan id <id>` |
+| `vxlan <n> vni <id>` | `ip link add <n> type vxlan external vnifilter` + `bridge vni add vni <id> dev <n>` |
 | `vxlan <n> local-address <ip>` | `... type vxlan local <ip>` |
 | `vxlan <n> dest-port <p>` | `... type vxlan dstport <p>` |
 | `vxlan <n> address-gen-mode <m>` | `ip link set <n> addrgenmode <m>` |

--- a/book/src/ch-02-32-bgp-evpn-igmp-mld-proxy.md
+++ b/book/src/ch-02-32-bgp-evpn-igmp-mld-proxy.md
@@ -7,10 +7,11 @@ frame to **all** remote VTEPs over the Type-3 (Inclusive Multicast)
 tree. With it, a PE learns which groups its locally-attached hosts have
 joined (via the kernel bridge's IGMP/MLD snooping) and advertises that
 interest in BGP (a **Type-6 SMET** route), so other PEs can constrain
-multicast to the groups that were actually asked for. The control plane
-(snoop → SMET → import → kernel bridge MDB) is implemented and
-validated; per-VTEP `dst` pruning of the overlay replication is a
-documented follow-up (see [Limitations](#limitations)).
+multicast to the groups that were actually asked for. Both the control
+plane (snoop → SMET → import) and the per-VTEP data plane — a kernel
+**VXLAN MDB** entry that replicates the group only to the VTEP that
+asked for it, instead of head-end-replicating to every PE — are
+implemented and validated.
 
 Three new EVPN route types and one extended community carry this:
 
@@ -39,13 +40,25 @@ withdraws it. Existing memberships at start-up are picked up by an
 `RTM_GETMDB` dump.
 
 **Reception (ingress / source PE).** A received SMET whose RT matches a
-local VNI registers the group in the kernel bridge MDB —
-`bridge mdb add dev <bridge> port <vxlan> grp G [src S]`. With snooping
-on, the bridge forwards that **registered** group only to ports that
-asked for it, while still flooding *unregistered* groups over the
-Type-3 zero-MAC FDB list. No explicit flood-vs-selective reconciliation
-is needed — the kernel does it, and a non-proxy PE (which never sends
-SMET) simply keeps receiving the flood.
+local VNI is programmed as **two** kernel MDB entries:
+
+* a **bridge MDB** entry — `bridge mdb add dev <bridge> port <vxlan>
+  grp G [src S]` — that registers the group on the VXLAN bridge port so
+  the snooping bridge forwards it *into* the overlay rather than dropping
+  it; and
+* a **VXLAN MDB** entry on the VXLAN device itself — `bridge mdb add dev
+  <vxlan> grp G [src S] src_vni <VNI> dst <VTEP>` — carrying the
+  originating PE as `dst`, so the kernel replicates the group **only** to
+  the VTEP that asked for it instead of head-end-replicating it to every
+  VTEP on the Type-3 BUM tree.
+
+The per-VTEP `dst` requires a VNI-aware VXLAN, so zebra-rs creates its
+EVPN VXLAN devices in the kernel's **`external vnifilter`** model
+(equivalent to `ip link add … type vxlan external vnifilter`, with each
+VNI registered via `bridge vni add`); FDB and MDB entries are keyed by
+`src_vni`. Unregistered groups still flood over the Type-3 tree, so a
+non-proxy PE (which never sends SMET) keeps receiving them — no explicit
+flood-vs-selective reconciliation is needed.
 
 **Capability signalling.** A proxy-capable PE attaches the **Multicast
 Flags Extended Community** to its Type-3 IMET route so peers know it
@@ -104,13 +117,17 @@ Route Distinguisher: 192.168.0.2:10
 
 Filter by route type with `show bgp evpn route-type smet`.
 
-The registered group is visible in the kernel bridge MDB on the ingress
-PE (it has no local member, so the entry can only come from the received
-SMET):
+The registered group is visible in both MDBs on the ingress PE (it has
+no local member, so the entries can only come from the received SMET).
+The bridge MDB registers the VXLAN port; the VXLAN MDB carries the
+per-VTEP `dst`:
 
 ```
 bridge mdb show dev br10
 dev br10 port vxlan10 grp 239.1.1.1 permanent
+
+bridge mdb show dev vxlan10
+dev vxlan10 port vxlan10 grp 239.1.1.1 permanent dst 192.168.0.2 src_vni 10
 ```
 
 ## Limitations
@@ -122,14 +139,6 @@ dev br10 port vxlan10 grp 239.1.1.1 permanent
   rather than from the kernel MDB group-mode.
 * Selective entries are programmed with bridge **VLAN 0** (non
   VLAN-aware bridge); per-VLAN mapping is a follow-up.
-* **Per-VTEP `dst` selectivity is not yet programmed.** A received SMET
-  registers the group on the VXLAN bridge port (`bridge mdb add … grp G`)
-  but does *not* encode a per-entry `dst` — the kernel rejects
-  `MDBE_ATTR_DST` on a plain VXLAN (and `iproute2` drops it too). True
-  per-`(x,G)`-to-specific-VTEP delivery requires a **`vnifilter` VXLAN
-  MDB** (`bridge mdb add dev <vxlan> … src_vni N dst <VTEP>`), a separate
-  follow-up. Today the registered group is delivered out the VXLAN and
-  head-end-replicated per the Type-3 FDB list.
 * The Multicast Flags EC capability gate (skip selective replication
   toward non-proxy PEs) is an optimization that is not yet applied —
   correctness still holds because the kernel floods unregistered groups.


### PR DESCRIPTION
Updates the book for the now-shipped RFC 9251 per-VTEP SMET delivery (PRs #1549/#1550) and the `external vnifilter` VXLAN device model.

## ch-02-32 — IGMP/MLD Proxy
- Intro: per-VTEP `dst` is **implemented & validated**, no longer a follow-up.
- Reception: now describes the **two** MDB installs — bridge MDB (registers the VXLAN port) + **VXLAN MDB** carrying `dst <VTEP>` for per-VTEP delivery — and notes EVPN VXLANs use the `external vnifilter` model.
- Verification: adds `bridge mdb show dev vxlan10` output with `dst … src_vni`.
- Limitations: drops the resolved "per-VTEP `dst` not yet programmed" bullet.

## ch-00-04 — VXLAN configuration
- Device-creation table: new row for the VNI-aware `external vnifilter` model (no fixed `id`; VNIs via `bridge vni add`, FDB/MDB keyed by `src_vni`).
- Bring-up sequence + iproute2 cross-reference updated (`type vxlan external vnifilter` + `bridge vni add` instead of `id <id>`).

User-facing config is unchanged. `mdbook build` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)