### PR TITLE
bgp-evpn: inter-AS ASBR re-origination + BDD (Phase 4b)

### DIFF
--- a/bdd/tests/configs/bgp_evpn_interas_segmentation/z1-1.yaml
+++ b/bdd/tests/configs/bgp_evpn_interas_segmentation/z1-1.yaml
@@ -1,0 +1,24 @@
+# z1 — a PE in AS 65001. Plain EVPN speaker with a local VXLAN (VNI 10),
+# so it originates a Type-3 IMET (auto-RT 65001:10). Peers iBGP only with
+# the AS 65001 ASBR z2.
+vxlan:
+- name: vxlan10
+  vni: 10
+  local-address: 192.168.0.1
+router:
+  bgp:
+    global:
+      as: 65001
+      router-id: 192.168.0.1
+    afi-safi:
+    - name: evpn
+      advertise-all-vni: true
+    neighbor:
+    - remote-address: 192.168.0.2
+      enabled: true
+      remote-as: 65001
+      afi-safi:
+      - name: ipv4
+        enabled: true
+      - name: evpn
+        enabled: true

--- a/bdd/tests/configs/bgp_evpn_interas_segmentation/z2-1.yaml
+++ b/bdd/tests/configs/bgp_evpn_interas_segmentation/z2-1.yaml
@@ -1,0 +1,38 @@
+# z2 — the AS 65001 ASBR / segmentation gateway (RFC 9572 Section 5). It
+# borders two ASes, each modelled as a neighbor-group carrying a region-id
+# equal to that AS:
+#   region-a (region-id 65001) is the iBGP session to the local AS 65001 (z1),
+#   region-b (region-id 65002) is the eBGP session to AS 65002 (z3).
+# z2 has no local VXLAN: it aggregates AS 65001's per-PE IMET into a single
+# Per-Region I-PMSI (Type-9) re-originated across the AS boundary toward AS
+# 65002 with next-hop-self (and an AS_PATH of [65001]), and does not propagate
+# the per-AS per-PE IMET across the boundary.
+router:
+  bgp:
+    global:
+      as: 65001
+      router-id: 192.168.0.2
+    neighbor-group:
+    - name: region-a
+      remote-as: 65001
+      region-id: 65001
+    - name: region-b
+      remote-as: 65002
+      region-id: 65002
+    neighbor:
+    - remote-address: 192.168.0.1
+      enabled: true
+      neighbor-group: region-a
+      afi-safi:
+      - name: ipv4
+        enabled: true
+      - name: evpn
+        enabled: true
+    - remote-address: 192.168.0.3
+      enabled: true
+      neighbor-group: region-b
+      afi-safi:
+      - name: ipv4
+        enabled: true
+      - name: evpn
+        enabled: true

--- a/bdd/tests/configs/bgp_evpn_interas_segmentation/z3-1.yaml
+++ b/bdd/tests/configs/bgp_evpn_interas_segmentation/z3-1.yaml
@@ -1,0 +1,18 @@
+# z3 — a PE / ASBR in AS 65002. It peers eBGP only with the AS 65001 ASBR
+# z2 and receives AS 65001's aggregated Per-Region I-PMSI (Type-9) route, with
+# z2 as the next hop and an AS_PATH of [65001]; it does NOT receive AS 65001's
+# per-PE IMET (held at the AS boundary).
+router:
+  bgp:
+    global:
+      as: 65002
+      router-id: 192.168.0.3
+    neighbor:
+    - remote-address: 192.168.0.2
+      enabled: true
+      remote-as: 65001
+      afi-safi:
+      - name: ipv4
+        enabled: true
+      - name: evpn
+        enabled: true

--- a/bdd/tests/features/bgp_evpn_interas_segmentation.feature
+++ b/bdd/tests/features/bgp_evpn_interas_segmentation.feature
@@ -1,0 +1,79 @@
+@serial
+@bgp_evpn_interas_segmentation
+Feature: BGP EVPN BUM tunnel segmentation — inter-AS ASBR (RFC 9572 Section 5)
+  As a network operator
+  I want an Autonomous System Border Router to aggregate its AS's per-PE
+  Inclusive Multicast (Type-3) routes into a single Per-Region I-PMSI (Type-9)
+  route, re-originated across the AS boundary (eBGP) with next-hop-self, while
+  not leaking the per-AS per-PE IMET across that boundary.
+
+  This reuses the region-id segmentation machinery with "region = AS": the
+  ASBR's neighbor-groups carry a region-id equal to each bordered AS, so the
+  inter-AS (Section 5) case is the inter-region (Section 6) case applied across
+  an eBGP session. It exercises the eBGP egress path the all-iBGP Section 6
+  test never touched — AS_PATH prepend and next-hop-self at the AS boundary.
+
+  Test Topology — z1 (AS 65001 PE) and z2 (AS 65001 ASBR) are iBGP; z2 and z3
+  (AS 65002 ASBR) are eBGP across the AS boundary.
+  ```
+  ┌──────────────────────────────────────────────────────────┐
+  │                            br0                            │
+  └─────────┬─────────────────┬─────────────────┬─────────────┘
+            │                 │                 │
+       ┌────┴────┐       ┌────┴────┐       ┌────┴────┐
+       │   z1    │ iBGP  │   z2    │ eBGP  │   z3    │
+       │ AS65001 │───────│  ASBR   │───────│ AS65002 │
+       │ .0.1/24 │       │ .0.2/24 │       │ .0.3/24 │
+       │ VNI 10  │       │a:65001  │       │         │
+       │         │       │b:65002  │       │         │
+       └─────────┘       └─────────┘       └─────────┘
+  ```
+
+  Scenario: Setup topology and establish the EVPN sessions
+    Given a clean test environment
+    When I create bridge "br0"
+    And I create namespace "z1" with IP "192.168.0.1/24" on bridge "br0"
+    And I create namespace "z2" with IP "192.168.0.2/24" on bridge "br0"
+    And I create namespace "z3" with IP "192.168.0.3/24" on bridge "br0"
+    And I start zebra-rs in namespace "z1"
+    And I start zebra-rs in namespace "z2"
+    And I start zebra-rs in namespace "z3"
+    And I apply config "z1-1.yaml" to namespace "z1"
+    And I apply config "z2-1.yaml" to namespace "z2"
+    And I apply config "z3-1.yaml" to namespace "z3"
+    And I wait 10 seconds for BGP to operate
+    Then BGP session in "z1" to "192.168.0.2" should be "Established"
+    # The z2-z3 session is eBGP (AS 65001 <-> AS 65002).
+    And BGP session in "z2" to "192.168.0.3" should be "Established"
+
+  Scenario: The ASBR aggregates AS 65001's IMET into a Per-Region I-PMSI route
+    Given the test topology exists
+    # z2 receives z1's per-PE IMET (AS 65001) ...
+    Then show command "show bgp evpn" in namespace "z2" should eventually contain "[3]:[0]:[32]:[192.168.0.1]"
+    # ... and re-originates a single Type-9 carrying AS 65001's Region ID
+    # (AS:65001, the Source-AS encoding of region-id 65001).
+    And show command "show bgp evpn route-type per-region-imet" in namespace "z2" should eventually contain "[9]:[0]:[AS:65001]"
+
+  Scenario: AS 65002 receives the Per-Region I-PMSI across the eBGP boundary
+    Given the test topology exists
+    # z3 learns AS 65001 only through the aggregated Type-9 route, whose BGP
+    # next hop is the ASBR z2 (192.168.0.2, next-hop-self at the AS boundary).
+    Then show command "show bgp evpn route-type per-region-imet" in namespace "z3" should eventually contain "[9]:[0]:[AS:65001]"
+    And show command "show bgp evpn" in namespace "z3" should eventually contain "192.168.0.2"
+
+  Scenario: Per-AS per-PE IMET is not propagated across the AS boundary
+    Given the test topology exists
+    # The ASBR holds AS 65001's per-PE IMET at the boundary; z3 sees the
+    # aggregated Type-9 instead, never z1's individual Type-3.
+    Then show command "show bgp evpn" in namespace "z3" should not contain "[3]:[0]:[32]:[192.168.0.1]"
+
+  Scenario: Teardown topology
+    Given the test topology exists
+    When I stop zebra-rs in namespace "z1"
+    And I stop zebra-rs in namespace "z2"
+    And I stop zebra-rs in namespace "z3"
+    And I delete namespace "z1"
+    And I delete namespace "z2"
+    And I delete namespace "z3"
+    And I delete bridge "br0"
+    Then the test environment should be clean

--- a/docs/design/bgp-evpn-bum-segmentation-plan.md
+++ b/docs/design/bgp-evpn-bum-segmentation-plan.md
@@ -336,10 +336,21 @@ codec — and any RIB/Adj-RIB/show/origination wiring.
     reserved. `is_evpn_df_election`/`as_df_election`, `From<DfElectionEc>`,
     `ac_df()`/`with_ac_df()`, `df-election:alg<N>[+ac-df]` Display, round-trip
     unit tests. No behavior change.
-  - **4b — inter-AS ASBR re-origination.** ASBR re-originates the per-region
-    I-PMSI across the AS boundary (eBGP) with next-hop-self; per-AS IMET held
-    AS-local. Extends `evpn_reoriginate_per_region`; needs an AS-boundary
-    config model decision (reuse `region-id` neighbor-group vs a new toggle).
+  - **4b — inter-AS ASBR re-origination. DONE.** Config-model decision (with
+    Kunihiro): **reuse `region-id` on eBGP neighbor-groups** ("region = AS"),
+    no new config surface. The 3b/3c re-origination trigger
+    (`evpn_reoriginate_per_region`, fired from the Type-3 receive path) is
+    **not** iBGP-gated, and the cross-region advertise gates + eBGP egress
+    (`ebgp_egress_aspath` prepends the local AS — `BgpAttr::new()` seeds an
+    empty `As4Path` and an ORIGIN, so the originated Type-9 is well-formed —
+    plus next-hop-self for `is_ebgp() || is_originated()`) are all AS-agnostic.
+    So an ASBR already re-originates the per-AS Type-9 across an eBGP boundary
+    with next-hop-self + AS_PATH `[local-as]`, and holds the per-AS per-PE IMET
+    AS-local. No production code change; validated by a new 2-AS BDD
+    (`@bgp_evpn_interas_segmentation`, AS 65001 iBGP→ASBR eBGP→AS 65002) run
+    live in namespaces (5/5 scenarios). **Deferred:** transit re-root of a
+    *received* Type-9 (re-rooting the PMSI endpoint at each ASBR for 3+ AS
+    chains) — only matters with the replication dataplane (Phase 6).
   - **4c — DF election among ASBRs + legacy coexistence.** Attach the DF
     Election EC with AC-DF cleared to the re-advertised Type-9 so exactly one
     ASBR forwards into a downstream AS with legacy PEs; gate legacy behavior on
@@ -388,8 +399,11 @@ on push, not targeted filters).
 - **PR4a — Phase 4a: DF Election EC codec (RFC 8584). DONE (this PR).**
   `DfElectionEc` in `ext_com.rs` + AC-DF accessors + Display + round-trip
   tests. No behavior change.
-- **PR4b — Phase 4b: inter-AS ASBR re-origination** (per-region I-PMSI across
-  the AS boundary, next-hop-self; per-AS IMET AS-local).
+- **PR4b — Phase 4b: inter-AS ASBR re-origination. DONE (this PR).** Reuse
+  `region-id` on eBGP groups ("region = AS"); the 3b/3c machinery already
+  re-originates the per-AS Type-9 across eBGP with next-hop-self + AS_PATH and
+  holds per-AS IMET AS-local. No production code change; new 2-AS
+  `@bgp_evpn_interas_segmentation` BDD (run live, 5/5).
 - **PR4c — Phase 4c: DF election among ASBRs (AC-DF cleared) + legacy
   coexistence gating + BDD.**
 - **PR5 (optional) — Phase 5: S-PMSI selective multicast + BDD.**


### PR DESCRIPTION
## Summary

Phase 4b of RFC 9572 EVPN BUM tunnel segmentation: **inter-AS ASBR re-origination (RFC 9572 §5)**.

The inter-AS (§5) case reuses the §6 region-id machinery with **"region = AS"**: set `region-id <asn>` on the eBGP neighbor-groups so the ASBR aggregates its AS's per-PE Inclusive Multicast (Type-3) routes into a single Per-Region I-PMSI (Type-9) route, re-originated across the AS boundary with next-hop-self, while holding the per-AS per-PE IMET AS-local.

**No production code change was required.** The 3b/3c re-origination trigger (`evpn_reoriginate_per_region`, fired from the Type-3 receive path) is **not** iBGP-gated, and the cross-region advertise gates + eBGP egress are AS-agnostic:
- `ebgp_egress_aspath` prepends the local AS — and `BgpAttr::new()` seeds an empty `As4Path` + ORIGIN, so the originated Type-9 is a well-formed eBGP UPDATE.
- next-hop-self applies for `is_ebgp() || is_originated()`.

So an ASBR already re-originates the per-AS Type-9 across an eBGP boundary with next-hop-self + AS_PATH `[local-as]`, and the existing "per-PE IMET held when ingress region ≠ egress region" gate keeps the per-AS IMET AS-local.

(Config-model decision made with the maintainer: reuse `region-id` on eBGP groups, no new config surface.)

## Test plan

New 2-AS BDD `@bgp_evpn_interas_segmentation`: AS 65001 PE z1 →iBGP→ ASBR z2 →**eBGP**→ AS 65002 z3. It exercises the eBGP egress path (AS_PATH prepend, next-hop-self at the AS boundary) that the all-iBGP §6 test never touched.

CI excludes BDD (it needs root + netns), so this was **run live in network namespaces** against a freshly-installed release binary:

```
✓ bgp_evpn_interas_segmentation (5 scenario(s))
1 feature(s) ran, 1 passed, 0 failed
```

Scenarios: eBGP session established (AS 65001↔65002), Type-9 aggregated on z2, z3 receives `[9]:[0]:[AS:65001]` with next-hop 192.168.0.2, per-AS per-PE IMET not propagated across the boundary, clean teardown (no leaked namespaces/daemons). `cargo fmt --check` + `cargo clippy --workspace --all-targets` clean.

**Deferred:** transit re-root of a *received* Type-9 (re-rooting the PMSI endpoint at each ASBR for 3+ AS chains) — only matters with the replication dataplane (Phase 6).

Generated with [Claude Code](https://claude.com/claude-code)