### PR TITLE
bgp-evpn: inter-AS DF election + legacy coexistence (Phase 4c)

### DIFF
--- a/bdd/tests/configs/bgp_evpn_df_election/z1-1.yaml
+++ b/bdd/tests/configs/bgp_evpn_df_election/z1-1.yaml
@@ -1,0 +1,33 @@
+# z1 — a PE in region A (AS 65001). Local VXLAN (VNI 10) so it originates a
+# Type-3 IMET (auto-RT 65001:10). It is a plain (non-segmentation) PE — its
+# IMET carries no Multicast Flags segmentation bit — so the ASBRs see it as a
+# legacy PE. iBGP to both ASBRs z2 and z4.
+vxlan:
+- name: vxlan10
+  vni: 10
+  local-address: 192.168.0.1
+router:
+  bgp:
+    global:
+      as: 65001
+      router-id: 192.168.0.1
+    afi-safi:
+    - name: evpn
+      advertise-all-vni: true
+    neighbor:
+    - remote-address: 192.168.0.2
+      enabled: true
+      remote-as: 65001
+      afi-safi:
+      - name: ipv4
+        enabled: true
+      - name: evpn
+        enabled: true
+    - remote-address: 192.168.0.4
+      enabled: true
+      remote-as: 65001
+      afi-safi:
+      - name: ipv4
+        enabled: true
+      - name: evpn
+        enabled: true

--- a/bdd/tests/configs/bgp_evpn_df_election/z2-1.yaml
+++ b/bdd/tests/configs/bgp_evpn_df_election/z2-1.yaml
@@ -1,0 +1,34 @@
+# z2 — ASBR #1 (AS 65001, router-id .0.2, the lower of the two ASBRs so it is
+# the elected DF). region-a (region-id 65001) is the iBGP session to the local
+# region (z1); region-b (region-id 65002) is the eBGP session to AS 65002 (z3).
+# It re-originates region A's per-PE IMET as a Per-Region I-PMSI (Type-9) toward
+# z3, attaching a DF Election EC (AC-DF cleared).
+router:
+  bgp:
+    global:
+      as: 65001
+      router-id: 192.168.0.2
+    neighbor-group:
+    - name: region-a
+      remote-as: 65001
+      region-id: 65001
+    - name: region-b
+      remote-as: 65002
+      region-id: 65002
+    neighbor:
+    - remote-address: 192.168.0.1
+      enabled: true
+      neighbor-group: region-a
+      afi-safi:
+      - name: ipv4
+        enabled: true
+      - name: evpn
+        enabled: true
+    - remote-address: 192.168.0.3
+      enabled: true
+      neighbor-group: region-b
+      afi-safi:
+      - name: ipv4
+        enabled: true
+      - name: evpn
+        enabled: true

--- a/bdd/tests/configs/bgp_evpn_df_election/z3-1.yaml
+++ b/bdd/tests/configs/bgp_evpn_df_election/z3-1.yaml
@@ -1,0 +1,27 @@
+# z3 — the downstream AS 65002. It peers eBGP with BOTH ASBRs (z2 and z4) and
+# receives region A's aggregated Per-Region I-PMSI (Type-9) from each, under
+# each ASBR's own RD. With two candidate ASBRs it runs the RFC 9572 Section
+# 5.3.1 DF election (modulus DF Alg) and elects the lower-address ASBR
+# (192.168.0.2) as Designated Forwarder.
+router:
+  bgp:
+    global:
+      as: 65002
+      router-id: 192.168.0.3
+    neighbor:
+    - remote-address: 192.168.0.2
+      enabled: true
+      remote-as: 65001
+      afi-safi:
+      - name: ipv4
+        enabled: true
+      - name: evpn
+        enabled: true
+    - remote-address: 192.168.0.4
+      enabled: true
+      remote-as: 65001
+      afi-safi:
+      - name: ipv4
+        enabled: true
+      - name: evpn
+        enabled: true

--- a/bdd/tests/configs/bgp_evpn_df_election/z4-1.yaml
+++ b/bdd/tests/configs/bgp_evpn_df_election/z4-1.yaml
@@ -1,0 +1,33 @@
+# z4 — ASBR #2 (AS 65001, router-id .0.4, the higher of the two ASBRs). Same
+# role as z2: region-a (region-id 65001) iBGP to z1, region-b (region-id 65002)
+# eBGP to z3. It also re-originates region A's Type-9 toward z3, so z3 sees two
+# candidate ASBRs and runs the RFC 9572 Section 5.3.1 DF election.
+router:
+  bgp:
+    global:
+      as: 65001
+      router-id: 192.168.0.4
+    neighbor-group:
+    - name: region-a
+      remote-as: 65001
+      region-id: 65001
+    - name: region-b
+      remote-as: 65002
+      region-id: 65002
+    neighbor:
+    - remote-address: 192.168.0.1
+      enabled: true
+      neighbor-group: region-a
+      afi-safi:
+      - name: ipv4
+        enabled: true
+      - name: evpn
+        enabled: true
+    - remote-address: 192.168.0.3
+      enabled: true
+      neighbor-group: region-b
+      afi-safi:
+      - name: ipv4
+        enabled: true
+      - name: evpn
+        enabled: true

--- a/bdd/tests/features/bgp_evpn_df_election.feature
+++ b/bdd/tests/features/bgp_evpn_df_election.feature
@@ -1,0 +1,78 @@
+@serial
+@bgp_evpn_df_election
+Feature: BGP EVPN BUM segmentation — inter-AS DF election (RFC 9572 Section 5.3.1)
+  As a network operator
+  I want the ASBRs that border a downstream AS to attach a DF Election Extended
+  Community (RFC 8584, AC-DF cleared) to their re-originated Per-Region I-PMSI
+  (Type-9) routes and elect a single Designated Forwarder, so a downstream AS
+  containing legacy PEs receives no duplicated BUM traffic.
+
+  Test Topology — region A (AS 65001) is bordered by TWO ASBRs, z2 (.0.2) and
+  z4 (.0.4), both re-originating region A's Type-9 toward the downstream AS
+  65002 (z3). z1 is a plain (legacy, non-segmentation) PE in region A.
+  ```
+  ┌──────────────────────────────────────────────────────────────────┐
+  │                               br0                                 │
+  └───────┬───────────────┬───────────────┬───────────────┬──────────┘
+          │               │               │               │
+     ┌────┴────┐     ┌────┴────┐     ┌────┴────┐     ┌────┴────┐
+     │   z1    │iBGP │   z2    │eBGP │   z3    │eBGP │   z4    │
+     │ AS65001 │─────│ ASBR #1 │─────│ AS65002 │─────│ ASBR #2 │
+     │ PE,VNI10│     │  .0.2   │     │  .0.3   │     │  .0.4   │
+     │  .0.1   │     │ (DF)    │     │         │     │         │
+     └─────────┘     └─────────┘     └─────────┘     └─────────┘
+        └────────────────iBGP──────────────────────────┘
+  ```
+
+  Scenario: Setup topology and establish the EVPN sessions
+    Given a clean test environment
+    When I create bridge "br0"
+    And I create namespace "z1" with IP "192.168.0.1/24" on bridge "br0"
+    And I create namespace "z2" with IP "192.168.0.2/24" on bridge "br0"
+    And I create namespace "z3" with IP "192.168.0.3/24" on bridge "br0"
+    And I create namespace "z4" with IP "192.168.0.4/24" on bridge "br0"
+    And I start zebra-rs in namespace "z1"
+    And I start zebra-rs in namespace "z2"
+    And I start zebra-rs in namespace "z3"
+    And I start zebra-rs in namespace "z4"
+    And I apply config "z1-1.yaml" to namespace "z1"
+    And I apply config "z2-1.yaml" to namespace "z2"
+    And I apply config "z3-1.yaml" to namespace "z3"
+    And I apply config "z4-1.yaml" to namespace "z4"
+    And I wait 10 seconds for BGP to operate
+    Then BGP session in "z1" to "192.168.0.2" should be "Established"
+    And BGP session in "z3" to "192.168.0.2" should be "Established"
+    And BGP session in "z3" to "192.168.0.4" should be "Established"
+
+  Scenario: Both ASBRs attach a DF Election EC to their Per-Region I-PMSI
+    Given the test topology exists
+    # z3 receives region A's Type-9 from both ASBRs, each carrying the DF
+    # Election EC (RFC 8584) with the default modulus algorithm.
+    Then show command "show bgp evpn route-type per-region-imet" in namespace "z3" should eventually contain "[9]:[0]:[AS:65001]"
+    And show command "show bgp evpn" in namespace "z3" should eventually contain "df-election:alg0"
+
+  Scenario: The downstream AS elects the lowest-address ASBR as DF
+    Given the test topology exists
+    # Modulus DF election over the two candidate ASBRs (.0.2 and .0.4) with
+    # Ethernet Tag 0 elects the numerically lowest, 192.168.0.2.
+    Then show command "show bgp evpn" in namespace "z3" should eventually contain "DF=192.168.0.2"
+    And show command "show bgp evpn" in namespace "z3" should eventually contain "candidates: 192.168.0.2 192.168.0.4"
+
+  Scenario: An ASBR flags the legacy (non-segmentation) PE in its region
+    Given the test topology exists
+    # z2 receives z1's IMET, which carries no segmentation-support bit, so the
+    # ASBR marks the region's VNI as having a legacy PE present.
+    Then show command "show bgp evpn" in namespace "z2" should eventually contain "legacy PEs present"
+
+  Scenario: Teardown topology
+    Given the test topology exists
+    When I stop zebra-rs in namespace "z1"
+    And I stop zebra-rs in namespace "z2"
+    And I stop zebra-rs in namespace "z3"
+    And I stop zebra-rs in namespace "z4"
+    And I delete namespace "z1"
+    And I delete namespace "z2"
+    And I delete namespace "z3"
+    And I delete namespace "z4"
+    And I delete bridge "br0"
+    Then the test environment should be clean

--- a/docs/design/bgp-evpn-bum-segmentation-plan.md
+++ b/docs/design/bgp-evpn-bum-segmentation-plan.md
@@ -351,10 +351,25 @@ codec — and any RIB/Adj-RIB/show/origination wiring.
     live in namespaces (5/5 scenarios). **Deferred:** transit re-root of a
     *received* Type-9 (re-rooting the PMSI endpoint at each ASBR for 3+ AS
     chains) — only matters with the replication dataplane (Phase 6).
-  - **4c — DF election among ASBRs + legacy coexistence.** Attach the DF
-    Election EC with AC-DF cleared to the re-advertised Type-9 so exactly one
-    ASBR forwards into a downstream AS with legacy PEs; gate legacy behavior on
-    the Multicast-Flags segmentation bit. End-to-end BDD.
+  - **4c — DF election among ASBRs + legacy coexistence. DONE.** Full
+    control-plane DF election (decision with Kunihiro). `evpn_reoriginate_per_region`
+    attaches a DF Election EC (`DfElectionEc`, RFC 8584) with **AC-DF cleared**
+    to the re-originated Type-9. `evpn_df_election` implements the RFC 7432 §8.5
+    modulus (Default) algorithm: the candidate ASBRs (every node advertising the
+    region's Type-9, gathered across RDs by `evpn_per_region_asbrs` — each ASBR
+    re-originates under its own RD) are ordered by address and DF =
+    ordinal `eth_tag mod N`; for the I-PMSI (eth-tag 0) that is the lowest
+    address. `show bgp evpn` renders the elected DF + candidate list per region
+    (`evpn_df_election_show`) and the DF Election EC (`df-election:alg0`).
+    Legacy-PE detection: the IMET receive path records each remote's
+    Multicast-Flags segmentation bit (`RemoteImet.segmentation_capable`), and
+    `EvpnFloodState::has_legacy_remote(vni)` surfaces a `(legacy PEs present)`
+    note in the per-region show — an ASBR flags a non-segmentation PE in its
+    region. Validated by a new 4-namespace BDD (`@bgp_evpn_df_election`: PE +
+    two ASBRs .0.2/.0.4 + downstream AS) run live (5/5): EC present, DF=.0.2
+    elected, legacy PE flagged. **Deferred:** the elected DF gates nothing until
+    the Phase-6 replication dataplane; conditional EC-attach (only when legacy
+    present); HRW DF Alg.
 - **Phase 5 (optional) — S-PMSI selective multicast (Type 10 + Leaf A-D)**
   end to end; ties to SMET (Type 6) if/when that lands.
 
@@ -399,11 +414,17 @@ on push, not targeted filters).
 - **PR4a — Phase 4a: DF Election EC codec (RFC 8584). DONE (this PR).**
   `DfElectionEc` in `ext_com.rs` + AC-DF accessors + Display + round-trip
   tests. No behavior change.
-- **PR4b — Phase 4b: inter-AS ASBR re-origination. DONE (this PR).** Reuse
+- **PR4b — Phase 4b: inter-AS ASBR re-origination. DONE.** Reuse
   `region-id` on eBGP groups ("region = AS"); the 3b/3c machinery already
   re-originates the per-AS Type-9 across eBGP with next-hop-self + AS_PATH and
   holds per-AS IMET AS-local. No production code change; new 2-AS
   `@bgp_evpn_interas_segmentation` BDD (run live, 5/5).
+- **PR4c — Phase 4c: inter-AS DF election + legacy coexistence. DONE (this
+  PR).** DF Election EC (AC-DF cleared) on the re-originated Type-9; modulus DF
+  election over the region's ASBRs (`evpn_df_election` / `evpn_per_region_asbrs`)
+  with elected-DF + candidate show; legacy-PE detection via the Multicast-Flags
+  segmentation bit (`RemoteImet.segmentation_capable` / `has_legacy_remote`).
+  4-namespace `@bgp_evpn_df_election` BDD (run live, 5/5). Completes Phase 4.
 - **PR4c — Phase 4c: DF election among ASBRs (AC-DF cleared) + legacy
   coexistence gating + BDD.**
 - **PR5 (optional) — Phase 5: S-PMSI selective multicast + BDD.**

--- a/zebra-rs/src/bgp/route.rs
+++ b/zebra-rs/src/bgp/route.rs
@@ -1957,6 +1957,11 @@ struct RemoteImet {
     /// honored — the single kernel flood list per VNI can't express a
     /// per-category prune — so such a remote stays in the flood list.
     prune: bool,
+    /// RFC 9572 §8: the remote PE advertised BUM tunnel-segmentation support
+    /// (the Multicast Flags EC segmentation bit) on its IMET. A remote without
+    /// it is a *legacy* (non-segmentation) PE, which an ASBR must account for
+    /// in the §5.3.1 DF election when bordering a downstream AS.
+    segmentation_capable: bool,
 }
 
 /// Per-VNI flood state: which remotes advertised a Type-3 IMET, and what
@@ -2014,10 +2019,34 @@ impl EvpnFloodState {
     /// (Replicator-AR route); `prune` is true when it requested whole-VTEP
     /// pruning (RFC 9574 BM and U both set). Clears any stale SR P2MP record
     /// for the same originator (a remote that flipped tunnel type).
-    pub fn update_remote(&mut self, vni: u32, orig: IpAddr, ar_ip: Option<IpAddr>, prune: bool) {
+    pub fn update_remote(
+        &mut self,
+        vni: u32,
+        orig: IpAddr,
+        ar_ip: Option<IpAddr>,
+        prune: bool,
+        segmentation_capable: bool,
+    ) {
         let v = self.vnis.entry(vni).or_default();
         v.sr_remotes.remove(&orig);
-        v.remotes.insert(orig, RemoteImet { ar_ip, prune });
+        v.remotes.insert(
+            orig,
+            RemoteImet {
+                ar_ip,
+                prune,
+                segmentation_capable,
+            },
+        );
+    }
+
+    /// RFC 9572 §5.3.1: does any remote PE in `vni`'s flood set lack
+    /// segmentation support (a legacy PE)? An ASBR uses this to decide whether
+    /// a DF election is needed toward a downstream AS. `false` for an unknown
+    /// VNI (no remotes recorded).
+    pub fn has_legacy_remote(&self, vni: u32) -> bool {
+        self.vnis
+            .get(&vni)
+            .is_some_and(|v| v.remotes.values().any(|r| !r.segmentation_capable))
     }
 
     /// Record an SR P2MP tree remote's Type-3 IMET for `vni` (RFC 9524):
@@ -6288,9 +6317,10 @@ fn route_evpn_export_selected(
                         .filter(|p| p.is_assisted_replication())
                         .map(|p| p.endpoint);
                     let prune = imet_whole_vtep_prune(pmsi);
+                    let seg_capable = attr_segmentation_support(&best.attr);
                     bgp.local_rib
                         .evpn_flood
-                        .update_remote(vni, *orig, ar_ip, prune);
+                        .update_remote(vni, *orig, ar_ip, prune, seg_capable);
                 }
                 bgp.local_rib.evpn_flood.reconcile(vni, bgp.rib_client);
             } else {
@@ -6367,6 +6397,84 @@ fn route_evpn_export_selected(
 /// encapsulation ECs are reused verbatim from the received IMET's attribute
 /// (that RT is what egress PEs import); §6.3's PTA rewrite roots the Ingress
 /// Replication tunnel at this RBR's address.
+/// True when `attr` carries a Multicast Flags Extended Community (RFC 9251 §6 /
+/// RFC 9572 §8) advertising BUM tunnel-segmentation support. Used to classify a
+/// remote IMET's originator as a segmentation-capable vs legacy PE.
+fn attr_segmentation_support(attr: &BgpAttr) -> bool {
+    attr.ecom.as_ref().is_some_and(|ec| {
+        ec.0.iter().any(|v| {
+            v.as_evpn_mcast_flags()
+                .is_some_and(|m| m.segmentation_support)
+        })
+    })
+}
+
+/// RFC 8584 §3 / RFC 7432 §8.5 modulus ("Default") DF election. The candidate
+/// ASBRs are ordered by their addresses (ascending = ordinal numbers) and the
+/// Designated Forwarder is ordinal `eth_tag mod N`. For the Per-Region I-PMSI
+/// the Ethernet Tag is 0, so this selects the numerically lowest ASBR address.
+/// Returns `None` for an empty candidate set.
+fn evpn_df_election(candidates: &[Ipv4Addr], eth_tag: u32) -> Option<Ipv4Addr> {
+    let mut sorted: Vec<Ipv4Addr> = candidates.to_vec();
+    sorted.sort_unstable();
+    sorted.dedup();
+    if sorted.is_empty() {
+        return None;
+    }
+    let idx = (eth_tag as usize) % sorted.len();
+    Some(sorted[idx])
+}
+
+/// Collect the ASBR addresses advertising the Per-Region I-PMSI (Type-9) for
+/// `region_id` — the DF-election candidates for the region (RFC 9572 §5.3.1).
+/// Each ASBR re-originates the region's Type-9 under its own RD, so they appear
+/// as separate `(RD, PerRegionImet{region_id})` selected entries; the BGP
+/// next-hop of each is that ASBR's address. IPv4 next-hops only (VXLAN VTEPs).
+fn evpn_per_region_asbrs(local_rib: &LocalRib, region_id: [u8; 8]) -> Vec<Ipv4Addr> {
+    let mut asbrs = Vec::new();
+    for table in local_rib.evpn.values() {
+        for (prefix, rib) in table.selected.iter() {
+            if let EvpnPrefix::PerRegionImet { region_id: r, .. } = prefix
+                && *r == region_id
+                && let Some(BgpNexthop::Evpn(IpAddr::V4(nh))) = rib.attr.nexthop
+            {
+                asbrs.push(nh);
+            }
+        }
+    }
+    asbrs
+}
+
+/// Render the RFC 9572 §5.3.1 inter-AS DF-election summary for one region's
+/// Per-Region I-PMSI (Type-9), as appended by `show bgp evpn`: the candidate
+/// ASBRs (those advertising the region's Type-9), the elected Designated
+/// Forwarder (modulus DF Alg), and — from the route's VNI — whether any
+/// downstream legacy (non-segmentation) PE is present. `None` when there are no
+/// candidates (nothing to elect).
+pub(super) fn evpn_df_election_show(
+    local_rib: &LocalRib,
+    region_id: [u8; 8],
+    eth_tag: u32,
+    attr: &BgpAttr,
+) -> Option<String> {
+    let mut asbrs = evpn_per_region_asbrs(local_rib, region_id);
+    let df = evpn_df_election(&asbrs, eth_tag)?;
+    asbrs.sort_unstable();
+    asbrs.dedup();
+    let cands = asbrs
+        .iter()
+        .map(|a| a.to_string())
+        .collect::<Vec<_>>()
+        .join(" ");
+    let legacy = extract_vni_from_attr(attr)
+        .map(|vni| local_rib.evpn_flood.has_legacy_remote(vni))
+        .unwrap_or(false);
+    let legacy_note = if legacy { " (legacy PEs present)" } else { "" };
+    Some(format!(
+        "DF-election (modulus): DF={df} [candidates: {cands}]{legacy_note}"
+    ))
+}
+
 fn evpn_reoriginate_per_region(
     bgp: &mut BgpTop,
     peers: &mut PeerMap,
@@ -6386,6 +6494,21 @@ fn evpn_reoriginate_per_region(
     };
     let mut attr = BgpAttr::new();
     attr.ecom = src_attr.ecom.clone();
+    // RFC 9572 §5.3.1: advertise this ASBR's participation in the inter-AS DF
+    // election by attaching a DF Election EC (RFC 8584) with the AC-DF bit
+    // cleared. The ASBRs advertising this region's Type-9 then elect a single
+    // Designated Forwarder (default modulus DF Alg, see `evpn_df_election`), so
+    // a downstream AS containing legacy PEs receives no duplicated BUM. The
+    // forwarding gate itself rides the (deferred) replication dataplane.
+    let df_ec: ExtCommunityValue = DfElectionEc {
+        df_alg: DfElectionEc::ALG_DEFAULT,
+        bitmap: 0,
+    }
+    .into();
+    attr.ecom
+        .get_or_insert_with(ExtCommunity::default)
+        .0
+        .insert(df_ec);
     // Build the Per-Region I-PMSI's PMSI Tunnel attribute from this RBR's
     // configured BUM tunnel type, rooted at the RBR (next-hop-self). For SR
     // P2MP modes this advertises an RFC 9524 replication tree; otherwise plain
@@ -13044,9 +13167,9 @@ mod evpn_flood_tests {
     #[test]
     fn rnve_floods_all_remote_ir_ips() {
         let mut f = EvpnFloodState::default();
-        f.update_remote(100, ip("10.0.0.1"), None, false);
-        f.update_remote(100, ip("10.0.0.2"), None, false);
-        f.update_remote(100, ip("10.0.0.3"), Some(ip("10.0.0.254")), false);
+        f.update_remote(100, ip("10.0.0.1"), None, false, false);
+        f.update_remote(100, ip("10.0.0.2"), None, false, false);
+        f.update_remote(100, ip("10.0.0.3"), Some(ip("10.0.0.254")), false, false);
         assert_eq!(
             f.desired(100),
             BTreeSet::from([ip("10.0.0.1"), ip("10.0.0.2"), ip("10.0.0.3")])
@@ -13061,9 +13184,9 @@ mod evpn_flood_tests {
             role: AssistedReplicationRole::Leaf,
             ..Default::default()
         };
-        f.update_remote(100, ip("10.0.0.1"), None, false); // another leaf
-        f.update_remote(100, ip("10.0.0.10"), Some(ip("10.0.0.254")), false); // replicator A
-        f.update_remote(100, ip("10.0.0.20"), Some(ip("10.0.0.253")), false); // replicator B
+        f.update_remote(100, ip("10.0.0.1"), None, false, false); // another leaf
+        f.update_remote(100, ip("10.0.0.10"), Some(ip("10.0.0.254")), false, false); // replicator A
+        f.update_remote(100, ip("10.0.0.20"), Some(ip("10.0.0.253")), false, false); // replicator B
         assert_eq!(f.desired(100), BTreeSet::from([ip("10.0.0.253")]));
     }
 
@@ -13075,8 +13198,8 @@ mod evpn_flood_tests {
             role: AssistedReplicationRole::Leaf,
             ..Default::default()
         };
-        f.update_remote(100, ip("10.0.0.1"), None, false);
-        f.update_remote(100, ip("10.0.0.2"), None, false);
+        f.update_remote(100, ip("10.0.0.1"), None, false, false);
+        f.update_remote(100, ip("10.0.0.2"), None, false, false);
         assert_eq!(
             f.desired(100),
             BTreeSet::from([ip("10.0.0.1"), ip("10.0.0.2")])
@@ -13091,8 +13214,8 @@ mod evpn_flood_tests {
             role: AssistedReplicationRole::Leaf,
             ..Default::default()
         };
-        f.update_remote(100, ip("10.0.0.1"), None, false);
-        f.update_remote(100, ip("10.0.0.10"), Some(ip("10.0.0.254")), false);
+        f.update_remote(100, ip("10.0.0.1"), None, false, false);
+        f.update_remote(100, ip("10.0.0.10"), Some(ip("10.0.0.254")), false, false);
         assert_eq!(f.desired(100), BTreeSet::from([ip("10.0.0.254")]));
         f.remove_remote(100, ip("10.0.0.10"));
         assert_eq!(f.desired(100), BTreeSet::from([ip("10.0.0.1")]));
@@ -13102,8 +13225,8 @@ mod evpn_flood_tests {
     #[test]
     fn flood_state_is_per_vni() {
         let mut f = EvpnFloodState::default();
-        f.update_remote(100, ip("10.0.0.1"), None, false);
-        f.update_remote(200, ip("10.0.0.2"), None, false);
+        f.update_remote(100, ip("10.0.0.1"), None, false, false);
+        f.update_remote(200, ip("10.0.0.2"), None, false, false);
         assert_eq!(f.desired(100), BTreeSet::from([ip("10.0.0.1")]));
         assert_eq!(f.desired(200), BTreeSet::from([ip("10.0.0.2")]));
         assert!(f.desired(300).is_empty());
@@ -13114,7 +13237,7 @@ mod evpn_flood_tests {
     #[test]
     fn sr_p2mp_remotes_recorded_and_excluded_from_flood() {
         let mut f = EvpnFloodState::default();
-        f.update_remote(100, ip("10.0.0.1"), None, false); // plain IR remote
+        f.update_remote(100, ip("10.0.0.1"), None, false, false); // plain IR remote
         f.update_sr_remote(100, ip("10.0.0.7"), 4242); // SR P2MP tree remote
         // Only the IR remote floods via VXLAN; the SR P2MP Root does not.
         assert_eq!(f.desired(100), BTreeSet::from([ip("10.0.0.1")]));
@@ -13129,7 +13252,7 @@ mod evpn_flood_tests {
             bum_tunnel: EvpnBumTunnel::SrMplsP2mp,
             ..Default::default()
         };
-        f.update_remote(100, ip("10.0.0.1"), None, false);
+        f.update_remote(100, ip("10.0.0.1"), None, false, false);
         f.update_sr_remote(100, ip("10.0.0.2"), 100);
         // No VXLAN head-end FDB targets in SR P2MP mode.
         assert!(f.desired(100).is_empty());
@@ -13145,7 +13268,7 @@ mod evpn_flood_tests {
     #[test]
     fn replication_leaves_unions_ir_and_sr_remotes() {
         let mut f = EvpnFloodState::default();
-        f.update_remote(100, ip("10.0.0.1"), None, false);
+        f.update_remote(100, ip("10.0.0.1"), None, false, false);
         f.update_sr_remote(100, ip("10.0.0.7"), 9);
         assert_eq!(
             f.replication_leaves(100),
@@ -13164,7 +13287,7 @@ mod evpn_flood_tests {
             ..Default::default()
         };
         f.set_local_root(100, ip("10.0.0.9"));
-        f.update_remote(100, ip("10.0.0.3"), None, false);
+        f.update_remote(100, ip("10.0.0.3"), None, false, false);
         f.update_sr_remote(100, ip("10.0.0.2"), 100);
         assert_eq!(
             f.replication_action(100),
@@ -13190,7 +13313,7 @@ mod evpn_flood_tests {
         // IR mode with a root → None.
         let mut g = EvpnFloodState::default();
         g.set_local_root(100, ip("10.0.0.9"));
-        g.update_remote(100, ip("10.0.0.3"), None, false);
+        g.update_remote(100, ip("10.0.0.3"), None, false, false);
         assert_eq!(g.replication_action(100), ReplAction::None);
     }
 
@@ -13220,7 +13343,7 @@ mod evpn_flood_tests {
     #[test]
     fn remote_tunnel_type_flip_is_exclusive() {
         let mut f = EvpnFloodState::default();
-        f.update_remote(100, ip("10.0.0.5"), None, false);
+        f.update_remote(100, ip("10.0.0.5"), None, false, false);
         assert_eq!(f.desired(100), BTreeSet::from([ip("10.0.0.5")]));
         assert!(f.sr_p2mp_remotes(100).is_empty());
 
@@ -13230,7 +13353,7 @@ mod evpn_flood_tests {
         assert_eq!(f.sr_p2mp_remotes(100), vec![(ip("10.0.0.5"), 7)]);
 
         // Flip back SR P2MP -> IR.
-        f.update_remote(100, ip("10.0.0.5"), None, false);
+        f.update_remote(100, ip("10.0.0.5"), None, false, false);
         assert_eq!(f.desired(100), BTreeSet::from([ip("10.0.0.5")]));
         assert!(f.sr_p2mp_remotes(100).is_empty());
 
@@ -13246,8 +13369,8 @@ mod evpn_flood_tests {
     #[test]
     fn pruned_remote_excluded_from_rnve_flood() {
         let mut f = EvpnFloodState::default();
-        f.update_remote(100, ip("10.0.0.1"), None, false);
-        f.update_remote(100, ip("10.0.0.2"), None, true);
+        f.update_remote(100, ip("10.0.0.1"), None, false, false);
+        f.update_remote(100, ip("10.0.0.2"), None, true, false);
         assert_eq!(f.desired(100), BTreeSet::from([ip("10.0.0.1")]));
     }
 
@@ -13258,8 +13381,8 @@ mod evpn_flood_tests {
             role: AssistedReplicationRole::Leaf,
             ..Default::default()
         };
-        f.update_remote(100, ip("10.0.0.1"), None, false);
-        f.update_remote(100, ip("10.0.0.2"), None, true);
+        f.update_remote(100, ip("10.0.0.1"), None, false, false);
+        f.update_remote(100, ip("10.0.0.2"), None, true, false);
         assert_eq!(f.desired(100), BTreeSet::from([ip("10.0.0.1")]));
     }
 
@@ -13282,6 +13405,62 @@ mod evpn_flood_tests {
             imet_whole_vtep_prune(Some(&pmsi(true, true))),
             "BM and U → whole-VTEP prune"
         );
+    }
+
+    fn v4(s: &str) -> Ipv4Addr {
+        s.parse().unwrap()
+    }
+
+    /// Modulus DF election with the Per-Region I-PMSI Ethernet Tag (0) picks
+    /// the numerically lowest ASBR (ordinal 0), regardless of input order.
+    #[test]
+    fn df_election_eth_tag_zero_is_lowest_asbr() {
+        let cands = [v4("192.168.0.4"), v4("192.168.0.2"), v4("192.168.0.9")];
+        assert_eq!(evpn_df_election(&cands, 0), Some(v4("192.168.0.2")));
+        // Reordering the input does not change the elected DF.
+        let rev = [v4("192.168.0.9"), v4("192.168.0.2"), v4("192.168.0.4")];
+        assert_eq!(evpn_df_election(&rev, 0), Some(v4("192.168.0.2")));
+    }
+
+    /// A non-zero Ethernet Tag rotates the ordinal modulo the candidate count.
+    #[test]
+    fn df_election_rotates_with_eth_tag() {
+        let cands = [v4("10.0.0.1"), v4("10.0.0.2"), v4("10.0.0.3")];
+        assert_eq!(evpn_df_election(&cands, 0), Some(v4("10.0.0.1")));
+        assert_eq!(evpn_df_election(&cands, 1), Some(v4("10.0.0.2")));
+        assert_eq!(evpn_df_election(&cands, 2), Some(v4("10.0.0.3")));
+        // Wraps: ordinal 3 mod 3 == 0.
+        assert_eq!(evpn_df_election(&cands, 3), Some(v4("10.0.0.1")));
+    }
+
+    /// Duplicate candidate addresses collapse so they don't skew the modulus.
+    #[test]
+    fn df_election_dedups_candidates() {
+        let cands = [v4("10.0.0.2"), v4("10.0.0.1"), v4("10.0.0.2")];
+        // Two distinct ASBRs → eth_tag 1 selects the higher of the two.
+        assert_eq!(evpn_df_election(&cands, 1), Some(v4("10.0.0.2")));
+    }
+
+    /// No candidates → no DF.
+    #[test]
+    fn df_election_empty_is_none() {
+        assert_eq!(evpn_df_election(&[], 0), None);
+    }
+
+    /// `has_legacy_remote` is true iff some remote in the VNI lacks the
+    /// segmentation-support bit; isolated per VNI.
+    #[test]
+    fn has_legacy_remote_tracks_segmentation_capability() {
+        let mut f = EvpnFloodState::default();
+        // Two segmentation-capable remotes on VNI 100 → no legacy.
+        f.update_remote(100, ip("10.0.0.1"), None, false, true);
+        f.update_remote(100, ip("10.0.0.2"), None, false, true);
+        assert!(!f.has_legacy_remote(100));
+        // A legacy (non-segmentation) remote joins VNI 100 → legacy present.
+        f.update_remote(100, ip("10.0.0.3"), None, false, false);
+        assert!(f.has_legacy_remote(100));
+        // VNI 200 is unaffected (and unknown VNIs report no legacy).
+        assert!(!f.has_legacy_remote(200));
     }
 }
 

--- a/zebra-rs/src/bgp/show.rs
+++ b/zebra-rs/src/bgp/show.rs
@@ -3181,6 +3181,9 @@ fn format_evpn_ecom_value(v: &ExtCommunityValue) -> String {
         // proxy + segmentation-support bits). Reuse the codec's Display,
         // which renders `mcast-flags:` + I / M / S.
         (0x06, 0x09) => v.to_string(),
+        // DF Election EC — RFC 8584 §2.2 (RFC 9572 §5.3.1 inter-AS DF
+        // election). Reuse the codec's Display: `df-election:alg<N>[+ac-df]`.
+        (0x06, 0x06) => v.to_string(),
         _ => format!(
             "0x{:02x}{:02x}{:02x}{:02x}{:02x}{:02x}{:02x}{:02x}",
             v.high_type, v.low_type, v.val[0], v.val[1], v.val[2], v.val[3], v.val[4], v.val[5]
@@ -3306,6 +3309,19 @@ fn show_bgp_evpn(
             let ecom = show_evpn_ecom(&rib.attr);
             if !ecom.is_empty() {
                 writeln!(buf, "                    {}", ecom)?;
+            }
+
+            // Line 4 (Type-9 only): RFC 9572 §5.3.1 inter-AS DF election among
+            // the ASBRs advertising this region's Per-Region I-PMSI.
+            if let EvpnPrefix::PerRegionImet { eth_tag, region_id } = prefix
+                && let Some(df) = super::route::evpn_df_election_show(
+                    &bgp.local_rib,
+                    *region_id,
+                    *eth_tag,
+                    &rib.attr,
+                )
+            {
+                writeln!(buf, "                    {}", df)?;
             }
         }
     }


### PR DESCRIPTION
## Summary

Phase 4c of RFC 9572 EVPN BUM tunnel segmentation: **inter-AS DF election (RFC 9572 §5.3.1) + legacy-PE coexistence**. Completes Phase 4 (inter-AS ASBR segmentation).

When multiple ASBRs border a downstream AS, they attach a DF Election Extended Community and elect a single Designated Forwarder so a downstream AS containing legacy PEs sees no duplicated BUM.

- **DF Election EC attach** — `evpn_reoriginate_per_region` adds a `DfElectionEc` (RFC 8584, from Phase 4a) with **AC-DF cleared** to the re-originated Per-Region I-PMSI (Type-9).
- **`evpn_df_election`** — RFC 7432 §8.5 modulus (Default) algorithm: candidate ASBRs ordered by address, DF = ordinal `eth_tag mod N`; for the I-PMSI (eth-tag 0) that's the lowest address.
- **`evpn_per_region_asbrs`** — gathers candidates across RDs (each ASBR re-originates the region's Type-9 under its own RD, so they appear as separate `(RD, PerRegionImet)` entries).
- **Legacy-PE detection** — record each remote IMET's Multicast-Flags segmentation bit (`RemoteImet.segmentation_capable`); `EvpnFloodState::has_legacy_remote(vni)` surfaces it.
- **show** — `show bgp evpn` renders the DF Election EC (`df-election:alg0`), the elected DF + candidate list per region, and a `(legacy PEs present)` note.

The elected DF gates no forwarding yet — the BUM replication dataplane is Phase 6. (Scope chosen with the maintainer: full control-plane DF election.)

## Test plan

- Unit tests: modulus election (lowest-for-tag-0, rotation, dedup, empty) + `has_legacy_remote` segmentation tracking.
- New 4-namespace BDD `@bgp_evpn_df_election`: PE z1 + two ASBRs z2 (.0.2) / z4 (.0.4) + downstream AS 65002 (z3). CI excludes BDD (needs root + netns), so **run live in network namespaces** against a freshly-installed release binary:

```
✓ bgp_evpn_df_election (5 scenario(s))  —  1 passed, 0 failed
```

Scenarios: both ASBRs attach the EC (`df-election:alg0` on z3), z3 elects **DF=192.168.0.2** of candidates `192.168.0.2 192.168.0.4`, z2 flags the legacy PE (`legacy PEs present`), clean teardown (no leaked namespaces/daemons). `cargo fmt --check` + `cargo clippy --workspace --all-targets` clean; full `cargo test --workspace --exclude bdd` green (326 bgp-packet + 1366 bin, 0 failed).

**Deferred:** elected DF gates nothing until the Phase-6 dataplane; conditional EC-attach (only when legacy present); HRW DF Alg.

Generated with [Claude Code](https://claude.com/claude-code)