### PR TITLE
bgp-evpn: gateway re-flood primitive (Phase 6.1, control plane)

### DIFF
--- a/bdd/tests/configs/bgp_evpn_gateway_reflood/z1-1.yaml
+++ b/bdd/tests/configs/bgp_evpn_gateway_reflood/z1-1.yaml
@@ -1,0 +1,23 @@
+# z1 — a PE in region A (AS 65001) with a local VXLAN (VNI 10), so it
+# originates a Type-3 IMET (a region-A VTEP). iBGP to the gateway z2.
+vxlan:
+- name: vxlan10
+  vni: 10
+  local-address: 192.168.0.1
+router:
+  bgp:
+    global:
+      as: 65001
+      router-id: 192.168.0.1
+    afi-safi:
+    - name: evpn
+      advertise-all-vni: true
+    neighbor:
+    - remote-address: 192.168.0.2
+      enabled: true
+      remote-as: 65001
+      afi-safi:
+      - name: ipv4
+        enabled: true
+      - name: evpn
+        enabled: true

--- a/bdd/tests/configs/bgp_evpn_gateway_reflood/z2-1.yaml
+++ b/bdd/tests/configs/bgp_evpn_gateway_reflood/z2-1.yaml
@@ -1,0 +1,34 @@
+# z2 — the segmentation gateway (AS 65001). region-a (region-id 65001) is the
+# iBGP session to region A (z1); region-b (region-id 65002) is the eBGP session
+# to region B / AS 65002 (z3). It learns a VTEP in each region and computes the
+# split-horizon gateway re-flood set per region (the control-plane primitive
+# the eBPF dataplane will consume). No local VXLAN of its own.
+router:
+  bgp:
+    global:
+      as: 65001
+      router-id: 192.168.0.2
+    neighbor-group:
+    - name: region-a
+      remote-as: 65001
+      region-id: 65001
+    - name: region-b
+      remote-as: 65002
+      region-id: 65002
+    neighbor:
+    - remote-address: 192.168.0.1
+      enabled: true
+      neighbor-group: region-a
+      afi-safi:
+      - name: ipv4
+        enabled: true
+      - name: evpn
+        enabled: true
+    - remote-address: 192.168.0.3
+      enabled: true
+      neighbor-group: region-b
+      afi-safi:
+      - name: ipv4
+        enabled: true
+      - name: evpn
+        enabled: true

--- a/bdd/tests/configs/bgp_evpn_gateway_reflood/z3-1.yaml
+++ b/bdd/tests/configs/bgp_evpn_gateway_reflood/z3-1.yaml
@@ -1,0 +1,23 @@
+# z3 — a PE in region B (AS 65002) with a local VXLAN (VNI 10), so it
+# originates a Type-3 IMET (a region-B VTEP). eBGP to the gateway z2.
+vxlan:
+- name: vxlan10
+  vni: 10
+  local-address: 192.168.0.3
+router:
+  bgp:
+    global:
+      as: 65002
+      router-id: 192.168.0.3
+    afi-safi:
+    - name: evpn
+      advertise-all-vni: true
+    neighbor:
+    - remote-address: 192.168.0.2
+      enabled: true
+      remote-as: 65001
+      afi-safi:
+      - name: ipv4
+        enabled: true
+      - name: evpn
+        enabled: true

--- a/bdd/tests/features/bgp_evpn_gateway_reflood.feature
+++ b/bdd/tests/features/bgp_evpn_gateway_reflood.feature
@@ -1,0 +1,73 @@
+@serial
+@bgp_evpn_gateway_reflood
+Feature: BGP EVPN BUM segmentation — gateway re-flood primitive (RFC 9572 §6, Phase 6 control plane)
+  As a network operator
+  I want a segmentation gateway to partition its learned VTEPs by region and
+  compute the split-horizon re-flood set per region — the control-plane
+  primitive the (eBPF) BUM-replication dataplane consumes — so that BUM
+  ingressing from one region is replicated only to VTEPs in the other regions,
+  never back into the region it came from.
+
+  This is the control-plane foundation for the Phase 6 eBPF gateway dataplane;
+  no packet forwarding happens yet (the replication offload is a follow-up).
+
+  Test Topology — region A (AS 65001) PE z1 and region B (AS 65002) PE z3 each
+  own a VXLAN (VNI 10); the gateway z2 borders both and learns one VTEP per
+  region.
+  ```
+  ┌──────────────────────────────────────────────────────────┐
+  │                            br0                            │
+  └─────────┬─────────────────┬─────────────────┬─────────────┘
+            │                 │                 │
+       ┌────┴────┐ iBGP  ┌────┴────┐ eBGP  ┌────┴────┐
+       │   z1    │───────│   z2    │───────│   z3    │
+       │region A │       │ gateway │       │region B │
+       │ VNI 10  │       │a:65001  │       │ VNI 10  │
+       │  .0.1   │       │b:65002  │       │  .0.3   │
+       └─────────┘       └─────────┘       └─────────┘
+  ```
+
+  Scenario: Setup topology and establish the EVPN sessions
+    Given a clean test environment
+    When I create bridge "br0"
+    And I create namespace "z1" with IP "192.168.0.1/24" on bridge "br0"
+    And I create namespace "z2" with IP "192.168.0.2/24" on bridge "br0"
+    And I create namespace "z3" with IP "192.168.0.3/24" on bridge "br0"
+    And I start zebra-rs in namespace "z1"
+    And I start zebra-rs in namespace "z2"
+    And I start zebra-rs in namespace "z3"
+    And I apply config "z1-1.yaml" to namespace "z1"
+    And I apply config "z2-1.yaml" to namespace "z2"
+    And I apply config "z3-1.yaml" to namespace "z3"
+    And I wait 10 seconds for BGP to operate
+    Then BGP session in "z1" to "192.168.0.2" should be "Established"
+    And BGP session in "z2" to "192.168.0.3" should be "Established"
+
+  Scenario: The gateway computes a split-horizon re-flood set per region
+    Given the test topology exists
+    # z2 learns region A's VTEP (192.168.0.1) and region B's VTEP (192.168.0.3).
+    # BUM from region A re-floods to region B's VTEP only, and vice versa.
+    Then show command "show bgp evpn route-type per-region-imet" in namespace "z2" should eventually contain "gateway re-flood [192.168.0.3]"
+    And show command "show bgp evpn route-type per-region-imet" in namespace "z2" should eventually contain "gateway re-flood [192.168.0.1]"
+
+  Scenario: The gateway is the elected DF and forwards
+    Given the test topology exists
+    # A single gateway per boundary is trivially the DF, so it forwards.
+    Then show command "show bgp evpn route-type per-region-imet" in namespace "z2" should eventually contain "this node is DF, forwards"
+
+  Scenario: Per-PE IMET is not propagated across the boundary (still segmented)
+    Given the test topology exists
+    # The gateway holds each region's per-PE IMET at the boundary; z3 never
+    # sees region A's VTEP directly.
+    Then show command "show bgp evpn" in namespace "z3" should not contain "[3]:[0]:[32]:[192.168.0.1]"
+
+  Scenario: Teardown topology
+    Given the test topology exists
+    When I stop zebra-rs in namespace "z1"
+    And I stop zebra-rs in namespace "z2"
+    And I stop zebra-rs in namespace "z3"
+    And I delete namespace "z1"
+    And I delete namespace "z2"
+    And I delete namespace "z3"
+    And I delete bridge "br0"
+    Then the test environment should be clean

--- a/docs/design/bgp-evpn-bum-segmentation-plan.md
+++ b/docs/design/bgp-evpn-bum-segmentation-plan.md
@@ -425,11 +425,27 @@ on push, not targeted filters).
   with elected-DF + candidate show; legacy-PE detection via the Multicast-Flags
   segmentation bit (`RemoteImet.segmentation_capable` / `has_legacy_remote`).
   4-namespace `@bgp_evpn_df_election` BDD (run live, 5/5). Completes Phase 4.
-- **PR4c — Phase 4c: DF election among ASBRs (AC-DF cleared) + legacy
-  coexistence gating + BDD.**
 - **PR5 (optional) — Phase 5: S-PMSI selective multicast + BDD.**
-- **PR6 (later, re-confirm direction) — Phase 6: VXLAN-IR aggregation
-  dataplane only;** MPLS-P2MP / BIER / clean-DF gateway → VPP/eBPF backend.
+- **Phase 6 — eBPF gateway dataplane (direction confirmed: multi-gateway
+  correct, extend `tc-evpn-replicate`).** Sliced:
+  - **PR6.1 — control-plane gateway re-flood primitive. DONE (this PR).** Tag
+    each remote VTEP with its region (`RemoteImet.region`, from the path's
+    `ingress_region`); `EvpnFloodState::gateway_replicate(vni, ingress_region)`
+    returns the split-horizon re-flood set (every remote VTEP in another
+    region — never back into the ingress region; region-less remotes always
+    included). `show bgp evpn` renders the per-region re-flood set + the DF
+    forward/standby role (`evpn_df_election_show`). Unit tests + 3-namespace
+    `@bgp_evpn_gateway_reflood` BDD (region-A PE + gateway + region-B PE, both
+    VNI 10), run live (5/5). No dataplane forwarding yet.
+  - **PR6.2 — offload signaling:** extend the `tc-evpn-replicate` loader line
+    protocol + a new BPF map + a supervisor (mirror `rib/evpn_replicate.rs`)
+    to carry the DF-gated per-region stitch.
+  - **PR6.3 — eBPF replication:** implement the clone + re-encap in the
+    `tc-evpn-replicate` skeleton (currently `TC_ACT_PIPE` passthrough), with
+    split-horizon + DF gate, and a forwarding BDD. NOTE: the offload is
+    excluded from CI (nightly + bpf-linker); validate live.
+  - MPLS-P2MP / BIER segmentation stays out of scope (no kernel/eBPF-feasible
+    path) → VPP/ASIC backend.
 
 ## 11. Validation strategy
 

--- a/zebra-rs/src/bgp/route.rs
+++ b/zebra-rs/src/bgp/route.rs
@@ -1962,6 +1962,12 @@ struct RemoteImet {
     /// it is a *legacy* (non-segmentation) PE, which an ASBR must account for
     /// in the §5.3.1 DF election when bordering a downstream AS.
     segmentation_capable: bool,
+    /// RFC 9572 §6.1: the segmentation region the remote VTEP belongs to (the
+    /// ingress peer's `region-id`), or `None` for a non-segmented neighbor. A
+    /// segmentation gateway uses this to partition its flood set by region and
+    /// re-flood BUM across the boundary with split-horizon (never back into the
+    /// ingress region). See [`EvpnFloodState::gateway_replicate`].
+    region: Option<[u8; 8]>,
 }
 
 /// Per-VNI flood state: which remotes advertised a Type-3 IMET, and what
@@ -2026,6 +2032,7 @@ impl EvpnFloodState {
         ar_ip: Option<IpAddr>,
         prune: bool,
         segmentation_capable: bool,
+        region: Option<[u8; 8]>,
     ) {
         let v = self.vnis.entry(vni).or_default();
         v.sr_remotes.remove(&orig);
@@ -2035,8 +2042,30 @@ impl EvpnFloodState {
                 ar_ip,
                 prune,
                 segmentation_capable,
+                region,
             },
         );
+    }
+
+    /// RFC 9572 §6: a segmentation gateway re-floods a BUM frame that ingressed
+    /// from `ingress_region` to every remote VTEP in `vni`'s flood set that is
+    /// in a *different* region — split-horizon: a copy is never sent back into
+    /// the region it came from. Remotes with no region (`None`) are plain
+    /// (non-segmented) neighbours and are always included. Returns the set of
+    /// re-flood target VTEPs (empty for an unknown VNI).
+    ///
+    /// This is the per-boundary replication primitive the (eBPF) gateway
+    /// dataplane consumes; the caller gates it on being the elected DF
+    /// (`evpn_df_election`) so only one gateway forwards across the boundary.
+    pub fn gateway_replicate(&self, vni: u32, ingress_region: [u8; 8]) -> BTreeSet<IpAddr> {
+        let Some(v) = self.vnis.get(&vni) else {
+            return BTreeSet::new();
+        };
+        v.remotes
+            .iter()
+            .filter(|(_, r)| r.region != Some(ingress_region))
+            .map(|(orig, _)| *orig)
+            .collect()
     }
 
     /// RFC 9572 §5.3.1: does any remote PE in `vni`'s flood set lack
@@ -6318,9 +6347,18 @@ fn route_evpn_export_selected(
                         .map(|p| p.endpoint);
                     let prune = imet_whole_vtep_prune(pmsi);
                     let seg_capable = attr_segmentation_support(&best.attr);
-                    bgp.local_rib
-                        .evpn_flood
-                        .update_remote(vni, *orig, ar_ip, prune, seg_capable);
+                    // RFC 9572 §6.1: the remote VTEP's region (the ingress
+                    // peer's region-id, stamped on the path) lets a gateway
+                    // partition its flood set for cross-boundary re-flooding.
+                    let region = best.ingress_region;
+                    bgp.local_rib.evpn_flood.update_remote(
+                        vni,
+                        *orig,
+                        ar_ip,
+                        prune,
+                        seg_capable,
+                        region,
+                    );
                 }
                 bgp.local_rib.evpn_flood.reconcile(vni, bgp.rib_client);
             } else {
@@ -6448,14 +6486,16 @@ fn evpn_per_region_asbrs(local_rib: &LocalRib, region_id: [u8; 8]) -> Vec<Ipv4Ad
 /// Render the RFC 9572 §5.3.1 inter-AS DF-election summary for one region's
 /// Per-Region I-PMSI (Type-9), as appended by `show bgp evpn`: the candidate
 /// ASBRs (those advertising the region's Type-9), the elected Designated
-/// Forwarder (modulus DF Alg), and — from the route's VNI — whether any
-/// downstream legacy (non-segmentation) PE is present. `None` when there are no
-/// candidates (nothing to elect).
+/// Forwarder (modulus DF Alg) and whether `router_id` (this node) is it,
+/// whether a legacy PE is present, and — when this node is a gateway with
+/// remote VTEPs outside the region — the split-horizon gateway re-flood set for
+/// BUM ingressing from this region. `None` when there are no candidates.
 pub(super) fn evpn_df_election_show(
     local_rib: &LocalRib,
     region_id: [u8; 8],
     eth_tag: u32,
     attr: &BgpAttr,
+    router_id: Ipv4Addr,
 ) -> Option<String> {
     let mut asbrs = evpn_per_region_asbrs(local_rib, region_id);
     let df = evpn_df_election(&asbrs, eth_tag)?;
@@ -6466,13 +6506,30 @@ pub(super) fn evpn_df_election_show(
         .map(|a| a.to_string())
         .collect::<Vec<_>>()
         .join(" ");
-    let legacy = extract_vni_from_attr(attr)
-        .map(|vni| local_rib.evpn_flood.has_legacy_remote(vni))
-        .unwrap_or(false);
-    let legacy_note = if legacy { " (legacy PEs present)" } else { "" };
-    Some(format!(
-        "DF-election (modulus): DF={df} [candidates: {cands}]{legacy_note}"
-    ))
+    // RFC 9572 §5.3.1: only the elected DF forwards BUM across the boundary.
+    let role = if df == router_id {
+        " (this node is DF, forwards)"
+    } else {
+        " (standby)"
+    };
+    let mut out = format!("DF-election (modulus): DF={df} [candidates: {cands}]{role}");
+    if let Some(vni) = extract_vni_from_attr(attr) {
+        if local_rib.evpn_flood.has_legacy_remote(vni) {
+            out.push_str(" (legacy PEs present)");
+        }
+        // The split-horizon re-flood set for BUM that ingressed from this
+        // region: every remote VTEP in the VNI that is in another region.
+        let reflood = local_rib.evpn_flood.gateway_replicate(vni, region_id);
+        if !reflood.is_empty() {
+            let targets = reflood
+                .iter()
+                .map(|a| a.to_string())
+                .collect::<Vec<_>>()
+                .join(" ");
+            out.push_str(&format!("; gateway re-flood [{targets}]"));
+        }
+    }
+    Some(out)
 }
 
 fn evpn_reoriginate_per_region(
@@ -13167,9 +13224,16 @@ mod evpn_flood_tests {
     #[test]
     fn rnve_floods_all_remote_ir_ips() {
         let mut f = EvpnFloodState::default();
-        f.update_remote(100, ip("10.0.0.1"), None, false, false);
-        f.update_remote(100, ip("10.0.0.2"), None, false, false);
-        f.update_remote(100, ip("10.0.0.3"), Some(ip("10.0.0.254")), false, false);
+        f.update_remote(100, ip("10.0.0.1"), None, false, false, None);
+        f.update_remote(100, ip("10.0.0.2"), None, false, false, None);
+        f.update_remote(
+            100,
+            ip("10.0.0.3"),
+            Some(ip("10.0.0.254")),
+            false,
+            false,
+            None,
+        );
         assert_eq!(
             f.desired(100),
             BTreeSet::from([ip("10.0.0.1"), ip("10.0.0.2"), ip("10.0.0.3")])
@@ -13184,9 +13248,23 @@ mod evpn_flood_tests {
             role: AssistedReplicationRole::Leaf,
             ..Default::default()
         };
-        f.update_remote(100, ip("10.0.0.1"), None, false, false); // another leaf
-        f.update_remote(100, ip("10.0.0.10"), Some(ip("10.0.0.254")), false, false); // replicator A
-        f.update_remote(100, ip("10.0.0.20"), Some(ip("10.0.0.253")), false, false); // replicator B
+        f.update_remote(100, ip("10.0.0.1"), None, false, false, None); // another leaf
+        f.update_remote(
+            100,
+            ip("10.0.0.10"),
+            Some(ip("10.0.0.254")),
+            false,
+            false,
+            None,
+        ); // replicator A
+        f.update_remote(
+            100,
+            ip("10.0.0.20"),
+            Some(ip("10.0.0.253")),
+            false,
+            false,
+            None,
+        ); // replicator B
         assert_eq!(f.desired(100), BTreeSet::from([ip("10.0.0.253")]));
     }
 
@@ -13198,8 +13276,8 @@ mod evpn_flood_tests {
             role: AssistedReplicationRole::Leaf,
             ..Default::default()
         };
-        f.update_remote(100, ip("10.0.0.1"), None, false, false);
-        f.update_remote(100, ip("10.0.0.2"), None, false, false);
+        f.update_remote(100, ip("10.0.0.1"), None, false, false, None);
+        f.update_remote(100, ip("10.0.0.2"), None, false, false, None);
         assert_eq!(
             f.desired(100),
             BTreeSet::from([ip("10.0.0.1"), ip("10.0.0.2")])
@@ -13214,8 +13292,15 @@ mod evpn_flood_tests {
             role: AssistedReplicationRole::Leaf,
             ..Default::default()
         };
-        f.update_remote(100, ip("10.0.0.1"), None, false, false);
-        f.update_remote(100, ip("10.0.0.10"), Some(ip("10.0.0.254")), false, false);
+        f.update_remote(100, ip("10.0.0.1"), None, false, false, None);
+        f.update_remote(
+            100,
+            ip("10.0.0.10"),
+            Some(ip("10.0.0.254")),
+            false,
+            false,
+            None,
+        );
         assert_eq!(f.desired(100), BTreeSet::from([ip("10.0.0.254")]));
         f.remove_remote(100, ip("10.0.0.10"));
         assert_eq!(f.desired(100), BTreeSet::from([ip("10.0.0.1")]));
@@ -13225,8 +13310,8 @@ mod evpn_flood_tests {
     #[test]
     fn flood_state_is_per_vni() {
         let mut f = EvpnFloodState::default();
-        f.update_remote(100, ip("10.0.0.1"), None, false, false);
-        f.update_remote(200, ip("10.0.0.2"), None, false, false);
+        f.update_remote(100, ip("10.0.0.1"), None, false, false, None);
+        f.update_remote(200, ip("10.0.0.2"), None, false, false, None);
         assert_eq!(f.desired(100), BTreeSet::from([ip("10.0.0.1")]));
         assert_eq!(f.desired(200), BTreeSet::from([ip("10.0.0.2")]));
         assert!(f.desired(300).is_empty());
@@ -13237,7 +13322,7 @@ mod evpn_flood_tests {
     #[test]
     fn sr_p2mp_remotes_recorded_and_excluded_from_flood() {
         let mut f = EvpnFloodState::default();
-        f.update_remote(100, ip("10.0.0.1"), None, false, false); // plain IR remote
+        f.update_remote(100, ip("10.0.0.1"), None, false, false, None); // plain IR remote
         f.update_sr_remote(100, ip("10.0.0.7"), 4242); // SR P2MP tree remote
         // Only the IR remote floods via VXLAN; the SR P2MP Root does not.
         assert_eq!(f.desired(100), BTreeSet::from([ip("10.0.0.1")]));
@@ -13252,7 +13337,7 @@ mod evpn_flood_tests {
             bum_tunnel: EvpnBumTunnel::SrMplsP2mp,
             ..Default::default()
         };
-        f.update_remote(100, ip("10.0.0.1"), None, false, false);
+        f.update_remote(100, ip("10.0.0.1"), None, false, false, None);
         f.update_sr_remote(100, ip("10.0.0.2"), 100);
         // No VXLAN head-end FDB targets in SR P2MP mode.
         assert!(f.desired(100).is_empty());
@@ -13268,7 +13353,7 @@ mod evpn_flood_tests {
     #[test]
     fn replication_leaves_unions_ir_and_sr_remotes() {
         let mut f = EvpnFloodState::default();
-        f.update_remote(100, ip("10.0.0.1"), None, false, false);
+        f.update_remote(100, ip("10.0.0.1"), None, false, false, None);
         f.update_sr_remote(100, ip("10.0.0.7"), 9);
         assert_eq!(
             f.replication_leaves(100),
@@ -13287,7 +13372,7 @@ mod evpn_flood_tests {
             ..Default::default()
         };
         f.set_local_root(100, ip("10.0.0.9"));
-        f.update_remote(100, ip("10.0.0.3"), None, false, false);
+        f.update_remote(100, ip("10.0.0.3"), None, false, false, None);
         f.update_sr_remote(100, ip("10.0.0.2"), 100);
         assert_eq!(
             f.replication_action(100),
@@ -13313,7 +13398,7 @@ mod evpn_flood_tests {
         // IR mode with a root → None.
         let mut g = EvpnFloodState::default();
         g.set_local_root(100, ip("10.0.0.9"));
-        g.update_remote(100, ip("10.0.0.3"), None, false, false);
+        g.update_remote(100, ip("10.0.0.3"), None, false, false, None);
         assert_eq!(g.replication_action(100), ReplAction::None);
     }
 
@@ -13343,7 +13428,7 @@ mod evpn_flood_tests {
     #[test]
     fn remote_tunnel_type_flip_is_exclusive() {
         let mut f = EvpnFloodState::default();
-        f.update_remote(100, ip("10.0.0.5"), None, false, false);
+        f.update_remote(100, ip("10.0.0.5"), None, false, false, None);
         assert_eq!(f.desired(100), BTreeSet::from([ip("10.0.0.5")]));
         assert!(f.sr_p2mp_remotes(100).is_empty());
 
@@ -13353,7 +13438,7 @@ mod evpn_flood_tests {
         assert_eq!(f.sr_p2mp_remotes(100), vec![(ip("10.0.0.5"), 7)]);
 
         // Flip back SR P2MP -> IR.
-        f.update_remote(100, ip("10.0.0.5"), None, false, false);
+        f.update_remote(100, ip("10.0.0.5"), None, false, false, None);
         assert_eq!(f.desired(100), BTreeSet::from([ip("10.0.0.5")]));
         assert!(f.sr_p2mp_remotes(100).is_empty());
 
@@ -13369,8 +13454,8 @@ mod evpn_flood_tests {
     #[test]
     fn pruned_remote_excluded_from_rnve_flood() {
         let mut f = EvpnFloodState::default();
-        f.update_remote(100, ip("10.0.0.1"), None, false, false);
-        f.update_remote(100, ip("10.0.0.2"), None, true, false);
+        f.update_remote(100, ip("10.0.0.1"), None, false, false, None);
+        f.update_remote(100, ip("10.0.0.2"), None, true, false, None);
         assert_eq!(f.desired(100), BTreeSet::from([ip("10.0.0.1")]));
     }
 
@@ -13381,8 +13466,8 @@ mod evpn_flood_tests {
             role: AssistedReplicationRole::Leaf,
             ..Default::default()
         };
-        f.update_remote(100, ip("10.0.0.1"), None, false, false);
-        f.update_remote(100, ip("10.0.0.2"), None, true, false);
+        f.update_remote(100, ip("10.0.0.1"), None, false, false, None);
+        f.update_remote(100, ip("10.0.0.2"), None, true, false, None);
         assert_eq!(f.desired(100), BTreeSet::from([ip("10.0.0.1")]));
     }
 
@@ -13453,14 +13538,57 @@ mod evpn_flood_tests {
     fn has_legacy_remote_tracks_segmentation_capability() {
         let mut f = EvpnFloodState::default();
         // Two segmentation-capable remotes on VNI 100 → no legacy.
-        f.update_remote(100, ip("10.0.0.1"), None, false, true);
-        f.update_remote(100, ip("10.0.0.2"), None, false, true);
+        f.update_remote(100, ip("10.0.0.1"), None, false, true, None);
+        f.update_remote(100, ip("10.0.0.2"), None, false, true, None);
         assert!(!f.has_legacy_remote(100));
         // A legacy (non-segmentation) remote joins VNI 100 → legacy present.
-        f.update_remote(100, ip("10.0.0.3"), None, false, false);
+        f.update_remote(100, ip("10.0.0.3"), None, false, false, None);
         assert!(f.has_legacy_remote(100));
         // VNI 200 is unaffected (and unknown VNIs report no legacy).
         assert!(!f.has_legacy_remote(200));
+    }
+
+    const REGION_A: [u8; 8] = [0x00, 0x09, 0xfd, 0xe9, 0, 0, 0, 0]; // AS 65001
+    const REGION_B: [u8; 8] = [0x00, 0x09, 0xfd, 0xea, 0, 0, 0, 0]; // AS 65002
+
+    /// A gateway re-floods BUM from region A only to VTEPs outside region A
+    /// (split-horizon): region-B VTEPs get a copy, region-A VTEPs do not.
+    #[test]
+    fn gateway_replicate_is_split_horizon() {
+        let mut f = EvpnFloodState::default();
+        f.update_remote(10, ip("192.168.0.1"), None, false, true, Some(REGION_A));
+        f.update_remote(10, ip("192.168.0.5"), None, false, true, Some(REGION_A));
+        f.update_remote(10, ip("192.168.0.3"), None, false, true, Some(REGION_B));
+        // BUM ingressing from region A re-floods to region B only.
+        assert_eq!(
+            f.gateway_replicate(10, REGION_A),
+            BTreeSet::from([ip("192.168.0.3")])
+        );
+        // BUM ingressing from region B re-floods to both region-A VTEPs.
+        assert_eq!(
+            f.gateway_replicate(10, REGION_B),
+            BTreeSet::from([ip("192.168.0.1"), ip("192.168.0.5")])
+        );
+    }
+
+    /// Plain (non-segmented, region `None`) remotes are always a re-flood
+    /// target regardless of the ingress region.
+    #[test]
+    fn gateway_replicate_includes_regionless_remotes() {
+        let mut f = EvpnFloodState::default();
+        f.update_remote(10, ip("192.168.0.1"), None, false, true, Some(REGION_A));
+        f.update_remote(10, ip("192.168.0.9"), None, false, false, None);
+        assert_eq!(
+            f.gateway_replicate(10, REGION_A),
+            BTreeSet::from([ip("192.168.0.9")])
+        );
+    }
+
+    /// An unknown VNI re-floods nowhere.
+    #[test]
+    fn gateway_replicate_unknown_vni_is_empty() {
+        let f = EvpnFloodState::default();
+        assert!(f.gateway_replicate(999, REGION_A).is_empty());
     }
 }
 

--- a/zebra-rs/src/bgp/show.rs
+++ b/zebra-rs/src/bgp/show.rs
@@ -3319,6 +3319,7 @@ fn show_bgp_evpn(
                     *region_id,
                     *eth_tag,
                     &rib.attr,
+                    bgp.router_id,
                 )
             {
                 writeln!(buf, "                    {}", df)?;


### PR DESCRIPTION
## Summary

First slice of the RFC 9572 §6 **eBPF gateway BUM dataplane** (direction confirmed with the maintainer: multi-gateway correct, extending `offload/tc-evpn-replicate`).

The `tc-evpn-replicate` eBPF program is still a `TC_ACT_PIPE` skeleton (no replication, no maps, excluded from CI), so this PR builds the **control-plane foundation** the dataplane will consume — no packet forwarding yet.

- **`RemoteImet.region`** — tag each remote VTEP with its segmentation region (the path's `ingress_region`), threaded through `update_remote`.
- **`EvpnFloodState::gateway_replicate(vni, ingress_region)`** — the split-horizon re-flood primitive: every remote VTEP in *another* region (never back into the ingress region; region-less / non-segmented remotes always included). This is what a gateway replicates a BUM frame to, gated by the DF election from Phase 4c.
- **`show bgp evpn`** (`evpn_df_election_show`) renders the per-region gateway re-flood set and the DF forward/standby role.

## Test plan

- Unit tests: `gateway_replicate` split-horizon, region-less inclusion, unknown-VNI.
- New 3-namespace BDD `@bgp_evpn_gateway_reflood`: region-A PE (z1) + gateway (z2) + region-B PE (z3), both VNI 10. CI excludes BDD (root + netns), so **run live in network namespaces**:

```
✓ bgp_evpn_gateway_reflood (5 scenario(s))  —  1 passed, 0 failed
```

The gateway shows `gateway re-flood [192.168.0.3]` (region A→B) and `[192.168.0.1]` (region B→A), `this node is DF, forwards`, and per-PE IMET still held at the boundary. `cargo fmt --check` + `cargo clippy --workspace --all-targets` clean; full `cargo test --workspace --exclude bdd` green (326 bgp-packet + 1369 bin, 0 failed).

## Follow-up slices (not in this PR)

- **6.2** — extend the `tc-evpn-replicate` loader line protocol + a new BPF map + a supervisor (mirror `rib/evpn_replicate.rs`) to carry the DF-gated per-region stitch.
- **6.3** — implement the clone + re-encap in the eBPF skeleton with split-horizon + DF gate, and a forwarding BDD (offload excluded from CI → validated live).

Generated with [Claude Code](https://claude.com/claude-code)