### PR TITLE
offload: tc-evpn-replicate End.Replicate clone/rewrite datapath (DP3b)

### DIFF
--- a/book/src/ch-02-33-bgp-evpn-assisted-replication.md
+++ b/book/src/ch-02-33-bgp-evpn-assisted-replication.md
@@ -128,9 +128,13 @@ VXLAN flood list — BUM rides the tree, not a zero-MAC FDB row.
 The stock kernel cannot forward an SR replication tree (next section), so
 SR P2MP is programmed through a dedicated **eBPF TC/clsact** dataplane
 (`offload/tc-evpn-replicate`). The BGP **control plane is complete**
-(signalling, import, and the replication-segment computation); the eBPF
-forwarder is under construction — selecting an SR P2MP mode today signals
-the tree and suppresses the VXLAN flood, but does not yet forward BUM.
+(signalling, import, and the replication-segment computation), and the SRv6
+**`End.Replicate`** datapath is **implemented** — a clsact-ingress classifier
+clones each BUM frame once per leaf, rewriting the outer IPv6 destination to
+that leaf's SID (the per-copy header rewrite the kernel cannot do natively),
+validated end-to-end on a veth pair. The remaining gap is the leaf-side
+`End.DT2M` decap (strip the outer IPv6+SRH and hand the inner frame to the
+bridge for native flooding).
 
 ## What the Linux kernel can and cannot do
 

--- a/docs/design/bgp-evpn-sr-p2mp-replication-plan.md
+++ b/docs/design/bgp-evpn-sr-p2mp-replication-plan.md
@@ -98,8 +98,9 @@ SR P2MP policy at the Root.
 ## Phasing & status (updated 2026-06-18)
 
 Branch `bgp-evpn-tunnel-replication`. The **control plane is complete and
-merged**; the dataplane is a skeleton + the control→dataplane handoff, with the
-eBPF forwarder under construction.
+merged**, and the SRv6 **`End.Replicate`** datapath (clone + per-branch outer-DA
+rewrite) is **implemented and lab-validated**. The remaining gap is the leaf
+`End.DT2M` decap (strip outer IPv6+SRH, redirect inner to the bridge).
 
 | Slice | What landed / planned | Status |
 | --- | --- | --- |
@@ -110,8 +111,10 @@ eBPF forwarder under construction.
 | CP3 — flood suppression + leaf model | `desired()` empty in SR mode (withdraws stale VXLAN IR); `replication_leaves()` | ✅ merged #1500 |
 | DP1 — eBPF skeleton | `offload/tc-evpn-replicate/` (loader+ebpf, TC/clsact `#[classifier]`, no-op); build-verified | ✅ merged #1505 |
 | DP1 — ReplSeg handoff | `Message::ReplSegAdd/ReplSegDel` + producer (`set_local_root`/`replication_action`) + FIB stub consumer; mode-change reconcile | ✅ merged #1508 |
-| DP2 — supervisor | spawn/refcount the `tc-evpn-replicate` loader child (pattern: `bfd/reflector.rs`), feed a BPF replication map over stdin line-IPC from the `ReplSeg` consumer | ⬜ planned |
-| DP3 — eBPF forwarding | `End.Replicate` (TC egress clone loop + per-branch DA/SRH rewrite + hop-limit guard) at root/bud; `End.DT2M`-equiv (strip outer, redirect inner to bridge master) at leaf | ⬜ planned |
+| DP2 — supervisor | spawn/refcount the `tc-evpn-replicate` loader child (pattern: `bfd/reflector.rs`), feed it over stdin line-IPC from the `ReplSeg` consumer | ✅ merged #1518 |
+| DP3a — BPF map + loader | `REPL_SEG` map + loader `repl-add`/`repl-del` population (clone+rewrite logic still a no-op) | ✅ merged #1520 |
+| DP3b — `End.Replicate` | clsact-ingress clone loop: match outer DA against `REPL_LOCAL_SID`, decrement Hop Limit (guard ≤1), `clone_redirect` one copy per leaf with outer DA rewritten, drop original. Lab-validated (`scripts/veth-replicate-test.sh`) | ✅ this slice |
+| DP3c — leaf `End.DT2M` | match the local `End.DT2M` SID → strip outer IPv6+SRH, redirect inner frame to the bridge master for native BUM flooding | ⬜ planned |
 
 ## Where the pieces live
 
@@ -137,17 +140,31 @@ eBPF forwarder under construction.
 ## eBPF dataplane design (DP2/DP3)
 
 - New `offload/tc-evpn-replicate/` crate mirrors `offload/xdp-bfd-echo/` but a
-  TC/clsact `#[classifier]`. Roles, all clsact-attached: **root** (egress)
-  `H.Encaps` per copy; **bud** (ingress) match the Replication-SID → clone +
-  per-branch DA/SRH rewrite (`End.Replicate`); **leaf** (ingress) match the
-  `End.DT2M` SID → strip outer IPv6+SRH, redirect inner frame to the bridge
-  master for native BUM flooding.
-- The branch/leaf table is a BPF map the loader fills from `ReplSeg` over a
-  stdin line protocol; a supervisor spawns/refcounts the loader per ifindex.
-- **Caveats:** `bpf_clone_redirect` is TC-only; per-copy IPv6/SRH checksum;
-  `H.Encaps.Red` MTU (eBPF can't fragment → jumbo/large underlay); RFC 9524
-  hop-limit threshold (ICMPv6-storm guard); veth needs `-m skb` TC mode; aya is
-  pulled from git unpinned.
+  TC/clsact `#[classifier]`. Roles, all clsact-attached: **root/bud** (ingress)
+  match the Replication-SID → clone + per-branch outer-DA rewrite
+  (`End.Replicate`, **implemented**); **leaf** (ingress) match the `End.DT2M`
+  SID → strip outer IPv6+SRH, redirect inner frame to the bridge master for
+  native BUM flooding (DP3c). A root that must `H.Encaps` a bare BUM frame
+  (rather than re-replicate an already-encapsulated one) is a later refinement.
+- **Maps** (loader-filled): `REPL_SEG` (per-VNI segment: tree-id, leaf SIDs);
+  `REPL_LOCAL_SID` (local replication SID → VNI, so the datapath demuxes an
+  inbound packet to its segment by outer IPv6 DA — derived here from each
+  segment's root SID); `CONFIG[0]` (egress ifindex the copies leave on,
+  `--redirect-iface`). Fed from `ReplSeg` over a stdin line protocol; a
+  supervisor spawns/refcounts the loader per ifindex.
+- **`End.Replicate` datapath:** on an inbound IPv6 frame whose outer DA hits
+  `REPL_LOCAL_SID`, decrement the outer Hop Limit (drop if ≤1), then for each
+  leaf rewrite the outer DA and `clone_redirect` a copy out `CONFIG[0]`; drop
+  the original (`TC_ACT_SHOT`). Writes use `bpf_skb_store_bytes`/`load_bytes`
+  (not raw `data` pointers), so nothing is held across the `clone_redirect`s
+  that invalidate packet pointers. No outer checksum fix-up is needed (IPv6 has
+  no header checksum; the outer DA is not in any inner L4 pseudo-header).
+  Validated end-to-end on a veth pair by `scripts/veth-replicate-test.sh` (one
+  frame to a replication SID → a copy at each leaf SID).
+- **Caveats:** `bpf_clone_redirect` is TC-only; the leaf decap (DP3c) and any
+  SRH segment-list rewrite are still to come; `H.Encaps.Red` MTU (eBPF can't
+  fragment → jumbo/large underlay); veth needs the clsact path (no native XDP);
+  aya is pulled from git unpinned.
 
 ## Gotchas / build notes
 

--- a/offload/tc-evpn-replicate/README.md
+++ b/offload/tc-evpn-replicate/README.md
@@ -14,20 +14,40 @@ a different rewritten header*. The TC layer can express that with
 clone per-copy. So this is a `#[classifier]` program on `clsact`, unlike the
 sibling [`xdp-bfd-echo`](../xdp-bfd-echo) offload.
 
-Planned roles (all clsact-attached):
-- **root** (egress): `H.Encaps` each copy toward a downstream SID / leaf;
-- **bud** (ingress): match the local Replication-SID, clone+rewrite per branch
-  (`End.Replicate`);
-- **leaf** (ingress): match the local `End.DT2M` SID, strip the outer IPv6+SRH,
-  redirect the inner frame to the bridge for native BUM flooding.
+Roles (all clsact-attached):
+- **root / bud** (ingress) — **implemented**: match the local Replication-SID
+  (the outer IPv6 DA), then for each downstream leaf clone the packet and
+  rewrite the outer DA to that leaf's SID (`End.Replicate`);
+- **leaf** (ingress) — *follow-up (DP3c)*: match the local `End.DT2M` SID, strip
+  the outer IPv6+SRH, redirect the inner frame to the bridge for native BUM
+  flooding.
 
 The branch/leaf table is a BPF map the loader fills from the BGP control plane
 (`ReplSeg`, fed by `EvpnFloodState::replication_leaves`).
 
 ## Status
 
-**Skeleton only.** The classifier loads and attaches but passes every frame
-through (`TC_ACT_PIPE`); the replication logic and maps are follow-up slices.
+**`End.Replicate` works.** The classifier reads three maps the loader fills:
+
+- `REPL_SEG` — per-VNI replication segment (tree + leaf SIDs);
+- `REPL_LOCAL_SID` — local replication SID → VNI, for demuxing an inbound packet
+  to its segment by outer IPv6 DA (derived from each segment's root SID);
+- `CONFIG` — index 0 = egress ifindex the copies are `clone_redirect`'d out of.
+
+On an inbound IPv6 frame whose DA is a known replication SID it decrements the
+outer Hop Limit (dropping anything that arrives with Hop Limit ≤ 1) and emits
+one clone per leaf with the outer DA rewritten, then drops the original.
+
+Validated end-to-end on a veth pair —
+[`scripts/veth-replicate-test.sh`](scripts/veth-replicate-test.sh) sends one
+frame to a replication SID and asserts a copy arrives at *each* leaf SID:
+
+```sh
+sudo bash offload/tc-evpn-replicate/scripts/veth-replicate-test.sh
+```
+
+The **leaf `End.DT2M` decap** (strip outer IPv6+SRH, redirect inner to the
+bridge) and the **root H.Encaps-from-bare-frame** path are follow-up slices.
 
 ## Build / run
 

--- a/offload/tc-evpn-replicate/ebpf/src/main.rs
+++ b/offload/tc-evpn-replicate/ebpf/src/main.rs
@@ -2,36 +2,42 @@
 #![no_main]
 
 //! EVPN BUM replication dataplane (RFC 9524 SR replication segment) — eBPF
-//! TC/clsact skeleton.
+//! TC/clsact `End.Replicate`.
 //!
-//! This is the load-and-attach skeleton for the SR P2MP / RFC 9524 replication
-//! forwarder that the stock Linux kernel cannot do natively: there is no
-//! `End.Replicate` seg6local action, no MPLS P2MP, and no `End.DT2M` for the L2
-//! leaf flood. Replication needs a *copy per downstream branch, each with a
-//! different rewritten header* — which only the TC layer can express
-//! (`bpf_clone_redirect` in a loop, mutating the skb between clones). XDP has no
-//! per-copy clone, so this is a `#[classifier]` (clsact) program, unlike the
-//! sibling `xdp-bfd-echo` offload.
+//! This is the SR P2MP / RFC 9524 replication forwarder the stock Linux kernel
+//! cannot do natively: there is no `End.Replicate` seg6local action, no MPLS
+//! P2MP, and no `End.DT2M` for the L2 leaf flood. Replication needs a *copy per
+//! downstream branch, each with a different rewritten header* — which only the
+//! TC layer can express (`bpf_clone_redirect` in a loop, mutating the skb
+//! between clones). XDP has no per-copy clone, so this is a `#[classifier]`
+//! (clsact) program, unlike the sibling `xdp-bfd-echo` offload.
 //!
-//! Planned roles, all attached here via clsact:
-//!   * root (egress)  — H.Encaps each copy toward a downstream SID / leaf;
-//!   * bud  (ingress) — match the local Replication-SID, clone+rewrite per
-//!                      branch (`End.Replicate`);
-//!   * leaf (ingress) — match the local End.DT2M SID, strip the outer
-//!                      IPv6+SRH, redirect the inner frame to the bridge.
-//! The branch/leaf state comes from a BPF map the loader fills from the BGP
-//! control plane (`ReplSeg`, fed by `EvpnFloodState::replication_leaves`).
+//! ## `End.Replicate` (this slice — root/bud, clsact ingress)
 //!
-//! The per-VNI replication state lives in the `REPL_SEG` BPF map, populated by
-//! the loader from the BGP control plane (`ReplSeg`, fed by
-//! `EvpnFloodState::replication_leaves`). For now every frame is still passed
-//! through untouched (`TC_ACT_PIPE`); the classifier reading the map to clone +
-//! rewrite (`End.Replicate`) and decap (`End.DT2M`) lands in a follow-up slice.
+//! A BUM packet arrives already SRv6-encapsulated, its outer IPv6 Destination
+//! Address equal to the local replication SID for the tree (the loader indexes
+//! that SID -> VNI in [`REPL_LOCAL_SID`]). For each downstream leaf the program:
+//!   1. rewrites the outer IPv6 DA to the leaf's SID (no checksum fix-up — IPv6
+//!      has no header checksum and the *outer* DA is not in any inner L4
+//!      pseudo-header), and
+//!   2. `bpf_clone_redirect`s the copy out the egress ifindex in [`CONFIG`].
+//! The outer Hop Limit is decremented once up front (a replication node is a
+//! forwarding hop); a packet that arrives with Hop Limit <= 1 is dropped rather
+//! than replicated, so a misrouted copy can't storm. The original (which still
+//! carries the replication SID, not a deliverable destination) is dropped with
+//! `TC_ACT_SHOT` after the fan-out.
+//!
+//! Writes go through `bpf_skb_store_bytes` / `bpf_skb_load_bytes`
+//! (`TcContext::store` / `::load`), never a raw `data` pointer, so nothing is
+//! held across the `clone_redirect` calls that invalidate packet pointers.
+//!
+//! The leaf side — match the local `End.DT2M` SID, strip the outer IPv6+SRH and
+//! redirect the inner frame to the bridge master — is the next slice (DP3c).
 
 use aya_ebpf::{
-    bindings::TC_ACT_PIPE,
+    bindings::{TC_ACT_PIPE, TC_ACT_SHOT},
     macros::{classifier, map},
-    maps::HashMap,
+    maps::{Array, HashMap},
     programs::TcContext,
 };
 
@@ -43,6 +49,21 @@ pub const MAX_LEAVES: usize = 32;
 /// `ReplSeg` flag bits.
 pub const REPL_FLAG_SRV6: u32 = 1 << 0; // SRv6 (vs SR-MPLS) encapsulation
 pub const REPL_FLAG_ROOT_V4: u32 = 1 << 1; // `root` is an IPv4 address (first 4 bytes)
+
+// `aya_ebpf::bindings::TC_ACT_*` are `u32`; a `#[classifier]` returns `i32`.
+const ACT_PIPE: i32 = TC_ACT_PIPE as i32;
+const ACT_SHOT: i32 = TC_ACT_SHOT as i32;
+
+/// Ethernet II + IPv6 fixed-header offsets (from the start of the frame). Only
+/// a base IPv6 header is parsed; the replication match is purely on the outer
+/// Destination Address, so extension headers between it and any inner payload
+/// are irrelevant here.
+const ETH_HLEN: usize = 14;
+const ETH_TYPE_OFF: usize = 12; // u16 (big-endian) EtherType
+const ETHERTYPE_IPV6: u16 = 0x86DD;
+const IP6_OFF: usize = ETH_HLEN;
+const IP6_HOPLIMIT_OFF: usize = IP6_OFF + 7; // u8 Hop Limit
+const IP6_DST_OFF: usize = IP6_OFF + 24; // [u8; 16] destination address
 
 /// One VNI's SR P2MP replication segment (RFC 9524), keyed by VNI in
 /// [`REPL_SEG`]. Addresses are stored as 16 bytes — IPv6 verbatim, or IPv4 in
@@ -62,15 +83,95 @@ pub struct ReplSeg {
 }
 
 /// Per-VNI replication segments the loader programs from the control plane.
-/// Read by the (forthcoming) replication datapath to clone + rewrite copies.
 #[map]
 static REPL_SEG: HashMap<u32, ReplSeg> = HashMap::with_max_entries(256, 0);
 
+/// Local replication SID -> VNI index, so the datapath can demux an inbound
+/// packet to its replication segment by the outer IPv6 Destination Address.
+/// The loader fills this from each segment's root SID on `repl-add`.
+#[map]
+static REPL_LOCAL_SID: HashMap<[u8; 16], u32> = HashMap::with_max_entries(256, 0);
+
+/// Single-entry config: index 0 holds the egress ifindex the replicated copies
+/// are `bpf_clone_redirect`ed out of (the SR underlay-facing NIC). The loader
+/// sets it from `--redirect-iface`.
+#[map]
+static CONFIG: Array<u32> = Array::with_max_entries(1, 0);
+
 #[classifier]
-pub fn tc_evpn_replicate(_ctx: TcContext) -> i32 {
-    // No-op skeleton: hand every frame back to the stack unchanged. The
-    // replication datapath that reads REPL_SEG lands in a follow-up slice.
-    TC_ACT_PIPE
+pub fn tc_evpn_replicate(ctx: TcContext) -> i32 {
+    match try_replicate(&ctx) {
+        Ok(action) => action,
+        // A truncated/short frame or a transient map/helper failure: hand the
+        // packet back to the stack untouched rather than dropping it.
+        Err(()) => ACT_PIPE,
+    }
+}
+
+fn try_replicate(ctx: &TcContext) -> Result<i32, ()> {
+    // Only IPv6-framed packets carry an SRv6 replication SID. Anything else is
+    // not ours; pass it on.
+    let ethertype = u16::from_be(ctx.load::<u16>(ETH_TYPE_OFF).map_err(|_| ())?);
+    if ethertype != ETHERTYPE_IPV6 {
+        return Ok(ACT_PIPE);
+    }
+
+    // Demux by the outer Destination Address: is it one of our local
+    // replication SIDs? If not, leave the frame for the stack.
+    let da: [u8; 16] = ctx.load(IP6_DST_OFF).map_err(|_| ())?;
+    let Some(vni) = (unsafe { REPL_LOCAL_SID.get(&da) }) else {
+        return Ok(ACT_PIPE);
+    };
+    let Some(seg) = (unsafe { REPL_SEG.get(vni) }) else {
+        // Indexed SID with no segment (racing withdraw): drop the original, it
+        // carries a replication SID that isn't locally deliverable anyway.
+        return Ok(ACT_SHOT);
+    };
+
+    // Egress device for the replicated copies. Unset (0) means the loader hasn't
+    // configured one yet — don't replicate into the void; pass the frame on.
+    let ifindex = match CONFIG.get(0) {
+        Some(&v) if v != 0 => v,
+        _ => return Ok(ACT_PIPE),
+    };
+
+    // A replication node is a forwarding hop: decrement the outer Hop Limit
+    // once (shared by every copy). Hop Limit <= 1 can't be forwarded — drop
+    // rather than replicate, so a misrouted packet can't loop/storm.
+    let hop_limit = ctx.load::<u8>(IP6_HOPLIMIT_OFF).map_err(|_| ())?;
+    if hop_limit <= 1 {
+        return Ok(ACT_SHOT);
+    }
+    let next_hop_limit = hop_limit - 1;
+    ctx.store(IP6_HOPLIMIT_OFF, &next_hop_limit, 0)
+        .map_err(|_| ())?;
+
+    // Fan out: one clone per leaf, each with the outer DA rewritten to that
+    // leaf's SID. `n_leaves` is bounded by MAX_LEAVES at insert time; the
+    // constant loop bound keeps the verifier happy.
+    let n_leaves = seg.n_leaves;
+    for i in 0..MAX_LEAVES {
+        if i as u32 >= n_leaves {
+            break;
+        }
+        let leaf = seg.leaves[i];
+        // Rewrite the outer IPv6 Destination Address to this leaf's SID. No
+        // checksum fix-up: IPv6 has no header checksum, and the outer DA is not
+        // part of any inner L4 pseudo-header.
+        if ctx.store(IP6_DST_OFF, &leaf, 0).is_err() {
+            // Couldn't rewrite — abandon the fan-out; the original is dropped
+            // below regardless (it still holds the replication SID).
+            break;
+        }
+        // Clone the current skb (DA = leaf[i], Hop Limit decremented) and
+        // transmit the copy out the egress device. Ignore per-copy errors so
+        // one bad leaf doesn't sink the rest.
+        let _ = ctx.clone_redirect(ifindex, 0);
+    }
+
+    // The original carries the replication SID, not a deliverable address —
+    // consume it now that every branch copy has been emitted.
+    Ok(ACT_SHOT)
 }
 
 #[cfg(not(test))]
@@ -79,8 +180,8 @@ fn panic(_info: &core::panic::PanicInfo) -> ! {
     loop {}
 }
 
-// Replication will use GPL-only helpers (bpf_clone_redirect, bpf_redirect),
-// so declare a GPL-compatible license up front.
+// `bpf_clone_redirect` is a GPL-only helper, so declare a GPL-compatible
+// license.
 #[unsafe(link_section = "license")]
 #[unsafe(no_mangle)]
 static LICENSE: [u8; 13] = *b"Dual MIT/GPL\0";

--- a/offload/tc-evpn-replicate/loader/src/main.rs
+++ b/offload/tc-evpn-replicate/loader/src/main.rs
@@ -3,15 +3,22 @@
 //!
 //! Loads the eBPF object (embedded at build time), attaches the
 //! `tc_evpn_replicate` classifier to an interface's `clsact` qdisc, and
-//! populates the `REPL_SEG` BPF map from a stdin line protocol fed by the
-//! zebra-rs supervisor. The classifier reading that map to clone + rewrite
-//! (`End.Replicate`) and decap (`End.DT2M`) is a follow-up slice.
+//! populates the BPF maps from a stdin line protocol fed by the zebra-rs
+//! supervisor. The classifier reads those maps to clone + rewrite each copy's
+//! outer IPv6 Destination Address (`End.Replicate`). Three maps back it:
+//!   * `REPL_SEG`       — per-VNI replication segment (tree + leaf SIDs);
+//!   * `REPL_LOCAL_SID` — local replication SID -> VNI, so the datapath can
+//!     demux an inbound packet to its segment by outer DA (derived from each
+//!     segment's root SID here);
+//!   * `CONFIG`         — index 0 = egress ifindex the copies are redirected
+//!     out of (`--redirect-iface`).
 //! Runs until Ctrl-C / SIGTERM.
 
+use std::ffi::CString;
 use std::net::IpAddr;
 
 use anyhow::Context as _;
-use aya::maps::{HashMap as AyaHashMap, MapData};
+use aya::maps::{Array as AyaArray, HashMap as AyaHashMap, MapData};
 use aya::programs::{SchedClassifier, TcAttachType, tc};
 use clap::Parser;
 use log::{debug, info, warn};
@@ -43,6 +50,15 @@ struct ReplSeg {
 unsafe impl aya::Pod for ReplSeg {}
 
 type ReplMap = AyaHashMap<MapData, u32, ReplSeg>;
+type SidIndex = AyaHashMap<MapData, [u8; 16], u32>;
+
+/// The maps the stdin line protocol programs, threaded together so an `repl-add`
+/// keeps the per-VNI segment ([`ReplMap`]) and the SID demux index
+/// ([`SidIndex`]) in lockstep.
+struct Maps {
+    repl: ReplMap,
+    sid_index: SidIndex,
+}
 
 #[derive(Debug, Parser)]
 #[command(about = "EVPN BUM replication (RFC 9524 SR P2MP) TC/clsact dataplane")]
@@ -53,11 +69,20 @@ struct Opt {
     /// clsact direction: `ingress` (bud/leaf decap) or `egress` (root encap).
     #[clap(short, long, default_value = "ingress")]
     direction: String,
+    /// Interface the replicated copies are transmitted out of. Defaults to
+    /// `--iface` (the all-on-one-underlay case, where copies leave the same NIC
+    /// they arrived on, each toward a different leaf SID).
+    #[clap(short, long)]
+    redirect_iface: Option<String>,
 }
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
-    let Opt { iface, direction } = Opt::parse();
+    let Opt {
+        iface,
+        direction,
+        redirect_iface,
+    } = Opt::parse();
     env_logger::init();
 
     // Bump the memlock rlimit. Needed on older kernels that don't use the
@@ -70,6 +95,12 @@ async fn main() -> anyhow::Result<()> {
     if ret != 0 {
         debug!("remove limit on locked memory failed, ret is: {ret}");
     }
+
+    // The device replicated copies are clone_redirect'd out of. Resolve to an
+    // ifindex now (0 = lookup failure) so the datapath has it before any frame.
+    let redirect = redirect_iface.unwrap_or_else(|| iface.clone());
+    let redirect_ifindex = if_nametoindex(&redirect)
+        .with_context(|| format!("redirect interface {redirect:?} not found"))?;
 
     // Embed the eBPF object built by build.rs and load it (the object's name is
     // the eBPF crate's `[[bin]]` name, `tc-evpn-replicate`).
@@ -96,13 +127,31 @@ async fn main() -> anyhow::Result<()> {
     program.load()?;
     program.attach(&iface, attach)?;
 
-    // Userspace handle to the per-VNI replication map the classifier reads.
-    let mut repl: ReplMap = AyaHashMap::try_from(
-        ebpf.take_map("REPL_SEG")
-            .context("map 'REPL_SEG' not found in object")?,
+    // Egress ifindex for the replicated copies (CONFIG[0]).
+    let mut config: AyaArray<MapData, u32> = AyaArray::try_from(
+        ebpf.take_map("CONFIG")
+            .context("map 'CONFIG' not found in object")?,
     )?;
+    config
+        .set(0, redirect_ifindex, 0)
+        .context("CONFIG[0] = redirect ifindex")?;
 
-    info!("tc_evpn_replicate attached to {iface} ({direction}); reading commands on stdin");
+    // Userspace handles to the maps the classifier reads.
+    let mut maps = Maps {
+        repl: AyaHashMap::try_from(
+            ebpf.take_map("REPL_SEG")
+                .context("map 'REPL_SEG' not found in object")?,
+        )?,
+        sid_index: AyaHashMap::try_from(
+            ebpf.take_map("REPL_LOCAL_SID")
+                .context("map 'REPL_LOCAL_SID' not found in object")?,
+        )?,
+    };
+
+    info!(
+        "tc_evpn_replicate attached to {iface} ({direction}); copies -> {redirect} \
+         (ifindex {redirect_ifindex}); reading commands on stdin"
+    );
 
     // Replication segments are fed by the zebra-rs supervisor over a stdin
     // line protocol (one command per line):
@@ -112,7 +161,7 @@ async fn main() -> anyhow::Result<()> {
     loop {
         tokio::select! {
             line = lines.next_line() => match line {
-                Ok(Some(l)) => handle_command(&l, &mut repl),
+                Ok(Some(l)) => handle_command(&l, &mut maps),
                 // EOF (supervisor closed our stdin) or read error: exit so the
                 // TC program detaches cleanly.
                 _ => break,
@@ -122,6 +171,17 @@ async fn main() -> anyhow::Result<()> {
     }
     info!("Exiting");
     Ok(())
+}
+
+/// Resolve an interface name to its ifindex via `if_nametoindex(3)`. Returns an
+/// error (rather than 0) if the interface does not exist.
+fn if_nametoindex(name: &str) -> anyhow::Result<u32> {
+    let cname = CString::new(name).context("interface name has an interior NUL")?;
+    let idx = unsafe { libc::if_nametoindex(cname.as_ptr()) };
+    if idx == 0 {
+        anyhow::bail!("if_nametoindex({name:?}) failed");
+    }
+    Ok(idx)
 }
 
 /// Encode an IP into the map's 16-byte slot: IPv6 verbatim, or IPv4 in the
@@ -137,10 +197,10 @@ fn encode_addr(ip: IpAddr) -> ([u8; 16], bool) {
     }
 }
 
-/// Handle one control line from the supervisor, programming the `REPL_SEG`
-/// map. Unknown / malformed lines are warned and ignored so a protocol
-/// mismatch never kills the dataplane.
-fn handle_command(line: &str, repl: &mut ReplMap) {
+/// Handle one control line from the supervisor, programming the maps. Unknown /
+/// malformed lines are warned and ignored so a protocol mismatch never kills the
+/// dataplane.
+fn handle_command(line: &str, maps: &mut Maps) {
     let line = line.trim();
     if line.is_empty() {
         return;
@@ -149,19 +209,30 @@ fn handle_command(line: &str, repl: &mut ReplMap) {
     match it.next() {
         Some("repl-add") => match parse_add(&mut it) {
             Some((vni, seg)) => {
-                if let Err(e) = repl.insert(vni, seg, 0) {
+                if let Err(e) = maps.repl.insert(vni, seg, 0) {
                     warn!("REPL_SEG insert vni={vni} failed: {e}");
-                } else {
-                    info!("repl-add vni={vni} ({} leaf PE(s))", seg.n_leaves);
+                    return;
                 }
+                // Index the segment's root SID -> VNI so the datapath can match
+                // an inbound packet's outer DA. The root is our local
+                // replication SID for the tree at this node.
+                if let Err(e) = maps.sid_index.insert(seg.root, vni, 0) {
+                    warn!("REPL_LOCAL_SID insert vni={vni} failed: {e}");
+                }
+                info!("repl-add vni={vni} ({} leaf PE(s))", seg.n_leaves);
             }
             None => warn!("malformed repl-add: {line:?}"),
         },
         Some("repl-del") => match it.next().and_then(|v| v.parse::<u32>().ok()) {
             Some(vni) => {
+                // Evict the SID index first, while we can still read the
+                // segment's root SID (the index's key).
+                if let Ok(seg) = maps.repl.get(&vni, 0) {
+                    let _ = maps.sid_index.remove(&seg.root);
+                }
                 // `remove` errors if the key was never present — fine on a
-                // duplicate/late withdraw, so only warn on other failures.
-                if let Err(e) = repl.remove(&vni) {
+                // duplicate/late withdraw, so only debug-log other failures.
+                if let Err(e) = maps.repl.remove(&vni) {
                     debug!("REPL_SEG remove vni={vni}: {e}");
                 }
                 info!("repl-del vni={vni}");

--- a/offload/tc-evpn-replicate/scripts/veth-replicate-test.sh
+++ b/offload/tc-evpn-replicate/scripts/veth-replicate-test.sh
@@ -1,0 +1,145 @@
+#!/usr/bin/env bash
+#
+# End-to-end load test for the EVPN BUM replication TC/clsact `End.Replicate`
+# datapath (RFC 9524 SR replication segment).
+#
+# What it proves: the stock kernel cannot replicate one packet into N copies
+# each with a different rewritten header. This datapath can. We send ONE
+# SRv6-style frame addressed to a tree's replication SID and observe N copies
+# come back out, each with its outer IPv6 Destination Address rewritten to a
+# different leaf SID.
+#
+# Topology (one veth pair; the namespace end is both sender and collector):
+#
+#   ns evpnrepl-ns                      root ns
+#   ┌───────────────┐                   ┌──────────────────────────────────┐
+#   │ evpnr1        │── veth pair ──────│ evpnr0  [clsact ingress:          │
+#   │ (send 1 frame │                   │          tc_evpn_replicate]       │
+#   │  dst = SID_R) │◄── N clones ──────│  clone_redirect each copy out     │
+#   │  capture in   │                   │  evpnr0 egress, DA = leaf_i       │
+#   └───────────────┘                   └──────────────────────────────────┘
+#
+# Putting the sender in its own namespace forces the frame across the veth so
+# the clsact ingress hook on evpnr0 actually fires (a same-netns destination
+# would be delivered locally and never hit the wire). The replicated copies are
+# clone_redirect'd back out evpnr0's egress, arriving *inbound* on evpnr1 where
+# tcpdump -Q in observes them.
+#
+# Run as root:
+#   sudo bash offload/tc-evpn-replicate/scripts/veth-replicate-test.sh
+set -u
+
+NS=evpnrepl-ns
+V0=evpnr0           # root-ns end — classifier attaches here (clsact ingress)
+V1=evpnr1          # namespace end — sender + collector
+
+VNI=100
+TREE=100
+SID_R="2001:db8:cafe::1"      # the tree's replication SID (outer DA we send to)
+L1="2001:db8:0:1::100"        # leaf 1 End.DT2M SID
+L2="2001:db8:0:2::100"        # leaf 2 End.DT2M SID
+SRC="2001:db8:0:fe::1"        # arbitrary ingress source
+
+RUNTIME=12        # seconds the loader stays attached (stdin held open)
+CAP_SECS=7        # tcpdump capture window
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+BIN="$SCRIPT_DIR/../target/release/tc-evpn-replicate"
+LOG=/tmp/evpnrepl_loader.log
+CAPOUT=/tmp/evpnrepl_tcpdump.out
+CAPERR=/tmp/evpnrepl_tcpdump.err
+
+LOADER_PID=""
+cleanup() {
+    [ -n "$LOADER_PID" ] && kill "$LOADER_PID" 2>/dev/null
+    sleep 0.3
+    ip netns del "$NS" 2>/dev/null
+    ip link del "$V0" 2>/dev/null   # also removes the clsact qdisc + program
+}
+trap cleanup EXIT
+
+if [ "$(id -u)" -ne 0 ]; then echo "ERROR: run as root (sudo)"; exit 1; fi
+if [ ! -x "$BIN" ]; then
+    echo "ERROR: binary not found: $BIN"
+    echo "       build it first:  (cd $SCRIPT_DIR/.. && cargo build --release)"
+    exit 1
+fi
+
+echo "== 1. fresh veth pair + namespace =="
+ip netns del "$NS" 2>/dev/null; ip link del "$V0" 2>/dev/null   # clean slate
+ip netns add "$NS"
+ip link add "$V0" type veth peer name "$V1"
+ip link set "$V1" netns "$NS"
+ip link set "$V0" up
+ip netns exec "$NS" ip link set "$V1" up
+ip netns exec "$NS" ip link set lo up
+MAC_DST=$(cat "/sys/class/net/$V0/address")
+MAC_SRC=$(ip netns exec "$NS" cat "/sys/class/net/$V1/address")
+echo "   root ns: $V0 ($MAC_DST)   |   $NS: $V1 ($MAC_SRC)"
+
+echo "== 2. attach replicator on $V0 (clsact ingress), copies -> $V0 egress =="
+# Feed the replication segment on stdin, then hold stdin open with a sleep so
+# the loader stays attached for the capture window; EOF makes it detach.
+( printf 'repl-add %s %s 1 %s %s %s\n' "$VNI" "$TREE" "$SID_R" "$L1" "$L2"; sleep "$RUNTIME" ) \
+    | RUST_LOG=info "$BIN" -i "$V0" -d ingress >"$LOG" 2>&1 &
+LOADER_PID=$!
+sleep 2
+if ! kill -0 "$LOADER_PID" 2>/dev/null; then
+    echo "ERROR: loader exited early:"; cat "$LOG"; exit 1
+fi
+grep -iE 'attached|repl-add' "$LOG" | sed 's/^/   /'
+
+echo "== 3. capture inbound ip6 on $V1, then send 3 trigger frames (dst $SID_R) =="
+ip netns exec "$NS" timeout "$CAP_SECS" tcpdump -lnei "$V1" -Q in 'ip6' \
+    >"$CAPOUT" 2>"$CAPERR" &
+TCPDUMP_PID=$!
+sleep 1
+MAC_DST="$MAC_DST" MAC_SRC="$MAC_SRC" SRC="$SRC" DST="$SID_R" IFACE="$V1" \
+    ip netns exec "$NS" python3 - <<'PY'
+import os, socket, time
+
+def mac(s): return bytes(int(b, 16) for b in s.split(":"))
+def ip6(s): return socket.inet_pton(socket.AF_INET6, s)
+
+iface = os.environ["IFACE"]
+eth   = mac(os.environ["MAC_DST"]) + mac(os.environ["MAC_SRC"]) + b"\x86\xdd"
+# IPv6: ver/tc/flow=0x60000000, payload_len, next_header=59 (No Next Header),
+# hop_limit=64, src, dst. Outer-only frame: the datapath touches the DA + hop
+# limit, nothing inner, so a header-only payload is enough to be observable.
+payload = b"BUMFLOOD"
+ipv6 = (b"\x60\x00\x00\x00"
+        + len(payload).to_bytes(2, "big")
+        + b"\x3b" + b"\x40"
+        + ip6(os.environ["SRC"]) + ip6(os.environ["DST"]))
+frame = eth + ipv6 + payload
+
+s = socket.socket(socket.AF_PACKET, socket.SOCK_RAW)
+s.bind((iface, 0))
+for _ in range(3):
+    s.send(frame); time.sleep(0.2)
+print("   sent 3x  %s -> %s (replication SID)" % (os.environ["SRC"], os.environ["DST"]))
+PY
+wait "$TCPDUMP_PID" 2>/dev/null
+
+echo "== 4. result =="
+echo "-- loader log --"; grep -iE 'attached|repl-add|exiting' "$LOG" | sed 's/^/   /' || true
+echo "-- tcpdump (inbound ip6 on $V1) --"; sed 's/^/   /' "$CAPOUT"
+
+n1=$(grep -c "> $L1" "$CAPOUT" 2>/dev/null) || true
+n2=$(grep -c "> $L2" "$CAPOUT" 2>/dev/null) || true
+n1=${n1:-0}; n2=${n2:-0}
+echo
+echo "   copies to leaf 1 ($L1): $n1"
+echo "   copies to leaf 2 ($L2): $n2"
+if [ "$n1" -ge 1 ] && [ "$n2" -ge 1 ]; then
+    echo
+    echo "PASS: one frame to the replication SID was replicated to BOTH leaf SIDs"
+    echo "      (End.Replicate: clone + per-branch outer-DA rewrite via TC clsact)"
+    exit 0
+else
+    echo
+    echo "FAIL: expected >=1 copy to each leaf SID"
+    echo "-- tcpdump stderr --"; sed 's/^/   /' "$CAPERR"
+    echo "-- full loader log --"; sed 's/^/   /' "$LOG"
+    exit 2
+fi


### PR DESCRIPTION
## Summary

Implements the SRv6 **`End.Replicate`** forwarder for EVPN BUM replication over an RFC 9524 SR replication segment — the per-copy header rewrite the stock Linux kernel cannot do natively (no `End.Replicate` seg6local action, no MPLS P2MP).

The `tc_evpn_replicate` clsact-ingress classifier (previously a `TC_ACT_PIPE` no-op) now reads the replication maps and fans a BUM frame out one copy per leaf, each with its outer IPv6 Destination Address rewritten to that leaf's SID.

### eBPF (`offload/tc-evpn-replicate/ebpf`)
- Match an inbound IPv6 frame's outer DA against a new **`REPL_LOCAL_SID`** map (local replication SID → VNI), fetch `REPL_SEG[vni]`, decrement the outer Hop Limit (drop if ≤ 1 — storm guard), then for each leaf rewrite the outer DA and `bpf_clone_redirect` a copy out `CONFIG[0]`; drop the original with `TC_ACT_SHOT` (it carries the replication SID, not a deliverable address).
- All packet access goes through `bpf_skb_store_bytes`/`load_bytes`, never a raw `data` pointer, so nothing is held across the `clone_redirect` calls that invalidate packet pointers. No checksum fix-up needed (IPv6 has no header checksum; the outer DA is not in any inner L4 pseudo-header).

### loader
- New `REPL_LOCAL_SID` index (derived from each segment's root SID, evicted on `repl-del`) and a `CONFIG` array holding the egress ifindex from the new `--redirect-iface` (defaults to `--iface`).

### docs
- README status, design-doc phase table (DP2 #1518 / DP3a #1520 merged, **DP3b done**, DP3c next), and the SR P2MP section of book `ch-02-33`.

## Test plan

`offload/` is workspace-excluded and **not built by CI** (needs nightly + bpf-linker). Verified locally:

- `cd offload/tc-evpn-replicate && cargo build --release` — eBPF object + loader both compile clean.
- `sudo bash offload/tc-evpn-replicate/scripts/veth-replicate-test.sh` — **PASS**: one frame sent to a replication SID is replicated to *both* leaf SIDs (3 trigger frames → 3 copies to each of 2 leaves, emitted in the same microsecond; the original carrying the replication SID is consumed, never observed inbound).

Remaining for a follow-up (DP3c): leaf `End.DT2M` decap (strip outer IPv6+SRH, redirect inner to the bridge master).

Generated with [Claude Code](https://claude.com/claude-code)