### PR TITLE
bgp-evpn: DF-gated gateway re-flood (Phase 6.2, control plane)

### DIFF
--- a/bdd/tests/configs/bgp_evpn_gateway_df/z1-1.yaml
+++ b/bdd/tests/configs/bgp_evpn_gateway_df/z1-1.yaml
@@ -1,0 +1,31 @@
+# z1 — a PE in region A (AS 65001) with a local VXLAN (VNI 10), so it
+# originates a Type-3 IMET (a region-A VTEP). iBGP to BOTH gateways z2 and z4.
+vxlan:
+- name: vxlan10
+  vni: 10
+  local-address: 192.168.0.1
+router:
+  bgp:
+    global:
+      as: 65001
+      router-id: 192.168.0.1
+    afi-safi:
+    - name: evpn
+      advertise-all-vni: true
+    neighbor:
+    - remote-address: 192.168.0.2
+      enabled: true
+      remote-as: 65001
+      afi-safi:
+      - name: ipv4
+        enabled: true
+      - name: evpn
+        enabled: true
+    - remote-address: 192.168.0.4
+      enabled: true
+      remote-as: 65001
+      afi-safi:
+      - name: ipv4
+        enabled: true
+      - name: evpn
+        enabled: true

--- a/bdd/tests/configs/bgp_evpn_gateway_df/z2-1.yaml
+++ b/bdd/tests/configs/bgp_evpn_gateway_df/z2-1.yaml
@@ -1,0 +1,45 @@
+# z2 — gateway #1 (AS 65001, router-id .0.2, the lower of the two, so the
+# elected DF). It borders region A (region-id 65001, iBGP to z1) and region B
+# (region-id 65002, eBGP to z3), and peers iBGP with the other gateway z4
+# (no region-id) so the two exchange their originated Per-Region I-PMSI
+# (Type-9) routes and run the §5.3.1 DF election. As DF it owns delivery into
+# both regions and re-floods BUM across the boundary.
+router:
+  bgp:
+    global:
+      as: 65001
+      router-id: 192.168.0.2
+    neighbor-group:
+    - name: region-a
+      remote-as: 65001
+      region-id: 65001
+    - name: region-b
+      remote-as: 65002
+      region-id: 65002
+    neighbor:
+    - remote-address: 192.168.0.1
+      enabled: true
+      neighbor-group: region-a
+      afi-safi:
+      - name: ipv4
+        enabled: true
+      - name: evpn
+        enabled: true
+    - remote-address: 192.168.0.3
+      enabled: true
+      neighbor-group: region-b
+      afi-safi:
+      - name: ipv4
+        enabled: true
+      - name: evpn
+        enabled: true
+    # Gateway-to-gateway iBGP (no region-id) — exchanges the Type-9 routes the
+    # DF election runs over.
+    - remote-address: 192.168.0.4
+      enabled: true
+      remote-as: 65001
+      afi-safi:
+      - name: ipv4
+        enabled: true
+      - name: evpn
+        enabled: true

--- a/bdd/tests/configs/bgp_evpn_gateway_df/z3-1.yaml
+++ b/bdd/tests/configs/bgp_evpn_gateway_df/z3-1.yaml
@@ -1,0 +1,31 @@
+# z3 — a PE in region B (AS 65002) with a local VXLAN (VNI 10), so it
+# originates a Type-3 IMET (a region-B VTEP). eBGP to BOTH gateways z2 and z4.
+vxlan:
+- name: vxlan10
+  vni: 10
+  local-address: 192.168.0.3
+router:
+  bgp:
+    global:
+      as: 65002
+      router-id: 192.168.0.3
+    afi-safi:
+    - name: evpn
+      advertise-all-vni: true
+    neighbor:
+    - remote-address: 192.168.0.2
+      enabled: true
+      remote-as: 65001
+      afi-safi:
+      - name: ipv4
+        enabled: true
+      - name: evpn
+        enabled: true
+    - remote-address: 192.168.0.4
+      enabled: true
+      remote-as: 65001
+      afi-safi:
+      - name: ipv4
+        enabled: true
+      - name: evpn
+        enabled: true

--- a/bdd/tests/configs/bgp_evpn_gateway_df/z4-1.yaml
+++ b/bdd/tests/configs/bgp_evpn_gateway_df/z4-1.yaml
@@ -1,0 +1,42 @@
+# z4 — gateway #2 (AS 65001, router-id .0.4, the higher of the two, so the
+# standby — NOT the DF). Same wiring as z2: region A (iBGP to z1), region B
+# (eBGP to z3), gateway-to-gateway iBGP with z2. Since z2 wins the modulus DF
+# election for both regions, z4 owns no region and re-floods nothing (no
+# duplicate BUM).
+router:
+  bgp:
+    global:
+      as: 65001
+      router-id: 192.168.0.4
+    neighbor-group:
+    - name: region-a
+      remote-as: 65001
+      region-id: 65001
+    - name: region-b
+      remote-as: 65002
+      region-id: 65002
+    neighbor:
+    - remote-address: 192.168.0.1
+      enabled: true
+      neighbor-group: region-a
+      afi-safi:
+      - name: ipv4
+        enabled: true
+      - name: evpn
+        enabled: true
+    - remote-address: 192.168.0.3
+      enabled: true
+      neighbor-group: region-b
+      afi-safi:
+      - name: ipv4
+        enabled: true
+      - name: evpn
+        enabled: true
+    - remote-address: 192.168.0.2
+      enabled: true
+      remote-as: 65001
+      afi-safi:
+      - name: ipv4
+        enabled: true
+      - name: evpn
+        enabled: true

--- a/bdd/tests/features/bgp_evpn_gateway_df.feature
+++ b/bdd/tests/features/bgp_evpn_gateway_df.feature
@@ -1,0 +1,70 @@
+@serial
+@bgp_evpn_gateway_df
+Feature: BGP EVPN BUM segmentation — DF-gated gateway re-flood (RFC 9572 §5.3.1, Phase 6.2)
+  As a network operator
+  I want only the elected Designated Forwarder among the gateways bordering a
+  region to deliver BUM into it, so that with multiple redundant gateways no
+  duplicate BUM is produced — the standby gateway drops the region from its
+  re-flood set.
+
+  Control-plane only (the eBPF replication is a follow-up). Two gateways z2 and
+  z4 border both region A (z1) and region B (z3); z2 (lower address) wins the
+  modulus DF election for both regions, so z2 re-floods and z4 stays standby.
+  ```
+  ┌──────────────────────────────────────────────────────────┐
+  │                            br0                            │
+  └────┬────────────┬────────────┬────────────┬───────────────┘
+    ┌──┴──┐      ┌──┴──┐      ┌──┴──┐      ┌──┴──┐
+    │ z1  │ iBGP │ z2  │ eBGP │ z3  │ eBGP │ z4  │
+    │regA │──────│ DF  │──────│regB │──────│stby │
+    │VNI10│      │ .0.2│      │VNI10│      │ .0.4│
+    │ .0.1│      └──┬──┘      │ .0.3│      └──┬──┘
+    └─────┘         └─────iBGP(gw-gw)─────────┘
+  ```
+
+  Scenario: Setup topology and establish the EVPN sessions
+    Given a clean test environment
+    When I create bridge "br0"
+    And I create namespace "z1" with IP "192.168.0.1/24" on bridge "br0"
+    And I create namespace "z2" with IP "192.168.0.2/24" on bridge "br0"
+    And I create namespace "z3" with IP "192.168.0.3/24" on bridge "br0"
+    And I create namespace "z4" with IP "192.168.0.4/24" on bridge "br0"
+    And I start zebra-rs in namespace "z1"
+    And I start zebra-rs in namespace "z2"
+    And I start zebra-rs in namespace "z3"
+    And I start zebra-rs in namespace "z4"
+    And I apply config "z1-1.yaml" to namespace "z1"
+    And I apply config "z2-1.yaml" to namespace "z2"
+    And I apply config "z3-1.yaml" to namespace "z3"
+    And I apply config "z4-1.yaml" to namespace "z4"
+    And I wait 10 seconds for BGP to operate
+    Then BGP session in "z2" to "192.168.0.4" should be "Established"
+    And BGP session in "z2" to "192.168.0.3" should be "Established"
+
+  Scenario: The DF gateway owns both regions and re-floods across the boundary
+    Given the test topology exists
+    # z2 (.0.2) wins the DF election, so it re-floods BUM from each region to
+    # the other region's VTEP.
+    Then show command "show bgp evpn route-type per-region-imet" in namespace "z2" should eventually contain "this node is DF, forwards"
+    And show command "show bgp evpn route-type per-region-imet" in namespace "z2" should eventually contain "gateway re-flood [192.168.0.3]"
+    And show command "show bgp evpn route-type per-region-imet" in namespace "z2" should eventually contain "gateway re-flood [192.168.0.1]"
+
+  Scenario: The standby gateway re-floods nothing (no duplicate BUM)
+    Given the test topology exists
+    # z4 (.0.4) loses the DF election for both regions, so it owns neither and
+    # drops every region from its re-flood set.
+    Then show command "show bgp evpn route-type per-region-imet" in namespace "z4" should eventually contain "(standby)"
+    And show command "show bgp evpn route-type per-region-imet" in namespace "z4" should not contain "gateway re-flood"
+
+  Scenario: Teardown topology
+    Given the test topology exists
+    When I stop zebra-rs in namespace "z1"
+    And I stop zebra-rs in namespace "z2"
+    And I stop zebra-rs in namespace "z3"
+    And I stop zebra-rs in namespace "z4"
+    And I delete namespace "z1"
+    And I delete namespace "z2"
+    And I delete namespace "z3"
+    And I delete namespace "z4"
+    And I delete bridge "br0"
+    Then the test environment should be clean

--- a/docs/design/bgp-evpn-bum-segmentation-plan.md
+++ b/docs/design/bgp-evpn-bum-segmentation-plan.md
@@ -437,13 +437,25 @@ on push, not targeted filters).
     forward/standby role (`evpn_df_election_show`). Unit tests + 3-namespace
     `@bgp_evpn_gateway_reflood` BDD (region-A PE + gateway + region-B PE, both
     VNI 10), run live (5/5). No dataplane forwarding yet.
-  - **PR6.2 — offload signaling:** extend the `tc-evpn-replicate` loader line
-    protocol + a new BPF map + a supervisor (mirror `rib/evpn_replicate.rs`)
-    to carry the DF-gated per-region stitch.
-  - **PR6.3 — eBPF replication:** implement the clone + re-encap in the
-    `tc-evpn-replicate` skeleton (currently `TC_ACT_PIPE` passthrough), with
-    split-horizon + DF gate, and a forwarding BDD. NOTE: the offload is
-    excluded from CI (nightly + bpf-linker); validate live.
+  - **PR6.2 — DF-gated re-flood. DONE (this PR).** Refine the re-flood to the
+    DF gate (RFC 9572 §5.3.1): `gateway_replicate_gated(vni, ingress_region,
+    owned)` restricts the split-horizon set to remote VTEPs whose destination
+    region this gateway *owns* (is the elected DF for); `evpn_gateway_owned_regions`
+    computes the owned set (win the modulus DF election among the region's
+    ASBRs). With redundant gateways, only the DF delivers into a region → no
+    duplicate BUM; the standby drops every region it doesn't own. `show bgp
+    evpn` uses the gated set. Unit tests (incl. drops-unowned-region) + a
+    4-namespace `@bgp_evpn_gateway_df` BDD (two gateways peering iBGP so they
+    exchange Type-9s and DF-elect; DF z2 re-floods, standby z4 prunes), run
+    live (4/4); 6.1 BDD still green. Topology note: gateway↔gateway iBGP is
+    required (so they see each other's *originated* Type-9s); iBGP split-horizon
+    keeps per-PE IMET from leaking between them.
+  - **PR6.3 — offload signaling + eBPF replication:** extend `tc-evpn-replicate`
+    loader line protocol + a new BPF map + a supervisor (mirror
+    `rib/evpn_replicate.rs`); implement the clone + re-encap in the skeleton
+    (currently `TC_ACT_PIPE` passthrough) with split-horizon + DF gate, and a
+    forwarding BDD. NOTE: the offload is excluded from CI (nightly +
+    bpf-linker); validate live.
   - MPLS-P2MP / BIER segmentation stays out of scope (no kernel/eBPF-feasible
     path) → VPP/ASIC backend.
 

--- a/zebra-rs/src/bgp/route.rs
+++ b/zebra-rs/src/bgp/route.rs
@@ -1966,7 +1966,7 @@ struct RemoteImet {
     /// ingress peer's `region-id`), or `None` for a non-segmented neighbor. A
     /// segmentation gateway uses this to partition its flood set by region and
     /// re-flood BUM across the boundary with split-horizon (never back into the
-    /// ingress region). See [`EvpnFloodState::gateway_replicate`].
+    /// ingress region). See [`EvpnFloodState::gateway_replicate_gated`].
     region: Option<[u8; 8]>,
 }
 
@@ -2047,23 +2047,37 @@ impl EvpnFloodState {
         );
     }
 
-    /// RFC 9572 §6: a segmentation gateway re-floods a BUM frame that ingressed
-    /// from `ingress_region` to every remote VTEP in `vni`'s flood set that is
-    /// in a *different* region — split-horizon: a copy is never sent back into
-    /// the region it came from. Remotes with no region (`None`) are plain
-    /// (non-segmented) neighbours and are always included. Returns the set of
-    /// re-flood target VTEPs (empty for an unknown VNI).
-    ///
-    /// This is the per-boundary replication primitive the (eBPF) gateway
-    /// dataplane consumes; the caller gates it on being the elected DF
-    /// (`evpn_df_election`) so only one gateway forwards across the boundary.
-    pub fn gateway_replicate(&self, vni: u32, ingress_region: [u8; 8]) -> BTreeSet<IpAddr> {
+    /// The segmentation regions present in `vni`'s flood set (the regions a
+    /// gateway bridges). Region-less (non-segmented) remotes are ignored.
+    pub fn gateway_regions(&self, vni: u32) -> BTreeSet<[u8; 8]> {
+        self.vnis
+            .get(&vni)
+            .map(|v| v.remotes.values().filter_map(|r| r.region).collect())
+            .unwrap_or_default()
+    }
+
+    /// DF-gated split-horizon gateway re-flood set
+    /// (RFC 9572 §5.3.1): restricted to remote
+    /// VTEPs whose destination region this gateway *owns* — i.e. is the elected
+    /// DF for (`owned`). With multiple gateways bordering a region, only its DF
+    /// delivers BUM into it, so the others drop that region from their re-flood
+    /// and no duplicate is produced. Region-less remotes are always delivered.
+    pub fn gateway_replicate_gated(
+        &self,
+        vni: u32,
+        ingress_region: [u8; 8],
+        owned: &BTreeSet<[u8; 8]>,
+    ) -> BTreeSet<IpAddr> {
         let Some(v) = self.vnis.get(&vni) else {
             return BTreeSet::new();
         };
         v.remotes
             .iter()
-            .filter(|(_, r)| r.region != Some(ingress_region))
+            .filter(|(_, r)| r.region != Some(ingress_region)) // split-horizon
+            .filter(|(_, r)| match r.region {
+                Some(region) => owned.contains(&region), // DF owns this region
+                None => true,                            // non-segmented PE
+            })
             .map(|(orig, _)| *orig)
             .collect()
     }
@@ -6483,6 +6497,26 @@ fn evpn_per_region_asbrs(local_rib: &LocalRib, region_id: [u8; 8]) -> Vec<Ipv4Ad
     asbrs
 }
 
+/// The set of segmentation regions in `vni`'s flood set that `router_id` (this
+/// node) is the elected Designated Forwarder for — the destination regions a
+/// gateway owns delivery into (RFC 9572 §5.3.1). A region is owned when this
+/// node wins the modulus DF election among the ASBRs advertising that region's
+/// Per-Region I-PMSI (Type-9).
+fn evpn_gateway_owned_regions(
+    local_rib: &LocalRib,
+    router_id: Ipv4Addr,
+    vni: u32,
+) -> BTreeSet<[u8; 8]> {
+    local_rib
+        .evpn_flood
+        .gateway_regions(vni)
+        .into_iter()
+        .filter(|&region| {
+            evpn_df_election(&evpn_per_region_asbrs(local_rib, region), 0) == Some(router_id)
+        })
+        .collect()
+}
+
 /// Render the RFC 9572 §5.3.1 inter-AS DF-election summary for one region's
 /// Per-Region I-PMSI (Type-9), as appended by `show bgp evpn`: the candidate
 /// ASBRs (those advertising the region's Type-9), the elected Designated
@@ -6517,9 +6551,13 @@ pub(super) fn evpn_df_election_show(
         if local_rib.evpn_flood.has_legacy_remote(vni) {
             out.push_str(" (legacy PEs present)");
         }
-        // The split-horizon re-flood set for BUM that ingressed from this
-        // region: every remote VTEP in the VNI that is in another region.
-        let reflood = local_rib.evpn_flood.gateway_replicate(vni, region_id);
+        // The DF-gated split-horizon re-flood set for BUM that ingressed from
+        // this region: every remote VTEP in another region this gateway owns
+        // (is the DF for), so multiple gateways don't duplicate BUM.
+        let owned = evpn_gateway_owned_regions(local_rib, router_id, vni);
+        let reflood = local_rib
+            .evpn_flood
+            .gateway_replicate_gated(vni, region_id, &owned);
         if !reflood.is_empty() {
             let targets = reflood
                 .iter()
@@ -13551,35 +13589,58 @@ mod evpn_flood_tests {
     const REGION_A: [u8; 8] = [0x00, 0x09, 0xfd, 0xe9, 0, 0, 0, 0]; // AS 65001
     const REGION_B: [u8; 8] = [0x00, 0x09, 0xfd, 0xea, 0, 0, 0, 0]; // AS 65002
 
-    /// A gateway re-floods BUM from region A only to VTEPs outside region A
-    /// (split-horizon): region-B VTEPs get a copy, region-A VTEPs do not.
+    /// A gateway that owns both regions re-floods BUM from region A only to
+    /// VTEPs outside region A (split-horizon): region-B VTEPs get a copy,
+    /// region-A VTEPs do not.
     #[test]
     fn gateway_replicate_is_split_horizon() {
         let mut f = EvpnFloodState::default();
         f.update_remote(10, ip("192.168.0.1"), None, false, true, Some(REGION_A));
         f.update_remote(10, ip("192.168.0.5"), None, false, true, Some(REGION_A));
         f.update_remote(10, ip("192.168.0.3"), None, false, true, Some(REGION_B));
+        let both = BTreeSet::from([REGION_A, REGION_B]);
         // BUM ingressing from region A re-floods to region B only.
         assert_eq!(
-            f.gateway_replicate(10, REGION_A),
+            f.gateway_replicate_gated(10, REGION_A, &both),
             BTreeSet::from([ip("192.168.0.3")])
         );
         // BUM ingressing from region B re-floods to both region-A VTEPs.
         assert_eq!(
-            f.gateway_replicate(10, REGION_B),
+            f.gateway_replicate_gated(10, REGION_B, &both),
             BTreeSet::from([ip("192.168.0.1"), ip("192.168.0.5")])
         );
     }
 
+    /// The DF gate (RFC 9572 §5.3.1): a gateway that does NOT own region B
+    /// drops region-B VTEPs from its re-flood, so the region-B DF is the only
+    /// one that delivers there (no duplicate BUM).
+    #[test]
+    fn gateway_replicate_gated_drops_unowned_region() {
+        let mut f = EvpnFloodState::default();
+        f.update_remote(10, ip("192.168.0.1"), None, false, true, Some(REGION_A));
+        f.update_remote(10, ip("192.168.0.3"), None, false, true, Some(REGION_B));
+        // This gateway owns only region A → BUM from region A re-floods nowhere
+        // (the region-B VTEP belongs to region B's DF, not this node).
+        let owns_a = BTreeSet::from([REGION_A]);
+        assert!(f.gateway_replicate_gated(10, REGION_A, &owns_a).is_empty());
+        // Owning region B, BUM from region A reaches the region-B VTEP.
+        let owns_b = BTreeSet::from([REGION_B]);
+        assert_eq!(
+            f.gateway_replicate_gated(10, REGION_A, &owns_b),
+            BTreeSet::from([ip("192.168.0.3")])
+        );
+    }
+
     /// Plain (non-segmented, region `None`) remotes are always a re-flood
-    /// target regardless of the ingress region.
+    /// target regardless of ownership or ingress region.
     #[test]
     fn gateway_replicate_includes_regionless_remotes() {
         let mut f = EvpnFloodState::default();
         f.update_remote(10, ip("192.168.0.1"), None, false, true, Some(REGION_A));
         f.update_remote(10, ip("192.168.0.9"), None, false, false, None);
+        // Owns no segmentation region, yet the region-less PE still gets BUM.
         assert_eq!(
-            f.gateway_replicate(10, REGION_A),
+            f.gateway_replicate_gated(10, REGION_A, &BTreeSet::new()),
             BTreeSet::from([ip("192.168.0.9")])
         );
     }
@@ -13588,7 +13649,10 @@ mod evpn_flood_tests {
     #[test]
     fn gateway_replicate_unknown_vni_is_empty() {
         let f = EvpnFloodState::default();
-        assert!(f.gateway_replicate(999, REGION_A).is_empty());
+        assert!(
+            f.gateway_replicate_gated(999, REGION_A, &BTreeSet::from([REGION_A]))
+                .is_empty()
+        );
     }
 }
 


### PR DESCRIPTION
## Summary

Phase 6.2 of the RFC 9572 §6 eBPF gateway BUM dataplane: **DF-gate the gateway re-flood (RFC 9572 §5.3.1)**. With redundant gateways bordering a region, only the elected Designated Forwarder delivers BUM into it, so no duplicate BUM is produced — the correctness refinement 6.1's single-gateway slice deferred.

- **`EvpnFloodState::gateway_replicate_gated(vni, ingress_region, owned)`** replaces 6.1's ungated `gateway_replicate`: the split-horizon re-flood set restricted to remote VTEPs whose destination region this gateway *owns* (is the elected DF for). Region-less (non-segmented) remotes always included.
- **`evpn_gateway_owned_regions(local_rib, router_id, vni)`** — the regions this node wins the modulus DF election for (over each region's Type-9 ASBRs).
- `show bgp evpn` renders the DF-gated re-flood set.

Still control-plane only; the eBPF replication is 6.3.

## Test plan

- Unit tests including `gateway_replicate_gated_drops_unowned_region` (the standby gateway drops the region it doesn't own).
- New 4-namespace BDD `@bgp_evpn_gateway_df`: two gateways z2 (`.0.2`) / z4 (`.0.4`) bordering regions A and B, peering **iBGP** so they exchange originated Type-9s and DF-elect. CI excludes BDD (root + netns), so **run live in network namespaces**:

```
✓ bgp_evpn_gateway_df (4 scenario(s))  —  1 passed, 0 failed
```

z2 (DF) shows `this node is DF, forwards` + `gateway re-flood [192.168.0.3]`/`[192.168.0.1]`; z4 (standby) shows `(standby)` and **no** `gateway re-flood` (the dedup). The 6.1 `@bgp_evpn_gateway_reflood` BDD still passes (5/5) — gated == ungated for a single gateway. `cargo fmt --check` + `cargo clippy --workspace --all-targets` clean; full `cargo test --workspace --exclude bdd` green (326 bgp-packet + 1370 bin, 0 failed).

Topology note: gateway↔gateway iBGP is required so they see each other's *originated* Type-9s; iBGP split-horizon keeps per-PE IMET from leaking between them, so region tagging stays correct.

## Remaining

**6.3** — the actual offload: extend the `tc-evpn-replicate` loader protocol + a new BPF map + a supervisor + the clone/re-encap in the eBPF, with a forwarding BDD (offload excluded from CI → validated live).

Generated with [Claude Code](https://claude.com/claude-code)