### PR TITLE
offload: tc-evpn-replicate leaf End.DT2M decap + bridge flood (DP3c)

### DIFF
--- a/book/src/ch-02-33-bgp-evpn-assisted-replication.md
+++ b/book/src/ch-02-33-bgp-evpn-assisted-replication.md
@@ -128,13 +128,19 @@ VXLAN flood list — BUM rides the tree, not a zero-MAC FDB row.
 The stock kernel cannot forward an SR replication tree (next section), so
 SR P2MP is programmed through a dedicated **eBPF TC/clsact** dataplane
 (`offload/tc-evpn-replicate`). The BGP **control plane is complete**
-(signalling, import, and the replication-segment computation), and the SRv6
-**`End.Replicate`** datapath is **implemented** — a clsact-ingress classifier
-clones each BUM frame once per leaf, rewriting the outer IPv6 destination to
-that leaf's SID (the per-copy header rewrite the kernel cannot do natively),
-validated end-to-end on a veth pair. The remaining gap is the leaf-side
-`End.DT2M` decap (strip the outer IPv6+SRH and hand the inner frame to the
-bridge for native flooding).
+(signalling, import, and the replication-segment computation), and **both**
+SRv6 datapath halves are **implemented and lab-validated** on veth topologies:
+
+- **`End.Replicate`** (root/bud): a clsact-ingress classifier clones each BUM
+  frame once per leaf, rewriting the outer IPv6 destination to that leaf's SID —
+  the per-copy header rewrite the kernel cannot do natively;
+- **`End.DT2M`** (leaf): the classifier strips the outer encapsulation off a
+  frame addressed to its local `End.DT2M` SID and redirects the inner Ethernet
+  frame into a bridge port, so the bridge floods it to the local attachment
+  circuits — the L2 flood the kernel has no SID behavior for.
+
+The remaining gaps are the root `H.Encaps`-from-bare-frame path and the
+SRH-present (non-reduced) encapsulation.
 
 ## What the Linux kernel can and cannot do
 

--- a/docs/design/bgp-evpn-sr-p2mp-replication-plan.md
+++ b/docs/design/bgp-evpn-sr-p2mp-replication-plan.md
@@ -98,9 +98,11 @@ SR P2MP policy at the Root.
 ## Phasing & status (updated 2026-06-18)
 
 Branch `bgp-evpn-tunnel-replication`. The **control plane is complete and
-merged**, and the SRv6 **`End.Replicate`** datapath (clone + per-branch outer-DA
-rewrite) is **implemented and lab-validated**. The remaining gap is the leaf
-`End.DT2M` decap (strip outer IPv6+SRH, redirect inner to the bridge).
+merged**, and **both** SRv6 datapath halves are **implemented and lab-validated**:
+`End.Replicate` (clone + per-branch outer-DA rewrite) at the root/bud, and the
+leaf `End.DT2M` (decap the outer encap, flood the inner frame into the bridge).
+The remaining gaps are the root H.Encaps-from-bare-frame path and SRH-present
+(non-reduced) decap.
 
 | Slice | What landed / planned | Status |
 | --- | --- | --- |
@@ -113,8 +115,8 @@ rewrite) is **implemented and lab-validated**. The remaining gap is the leaf
 | DP1 — ReplSeg handoff | `Message::ReplSegAdd/ReplSegDel` + producer (`set_local_root`/`replication_action`) + FIB stub consumer; mode-change reconcile | ✅ merged #1508 |
 | DP2 — supervisor | spawn/refcount the `tc-evpn-replicate` loader child (pattern: `bfd/reflector.rs`), feed it over stdin line-IPC from the `ReplSeg` consumer | ✅ merged #1518 |
 | DP3a — BPF map + loader | `REPL_SEG` map + loader `repl-add`/`repl-del` population (clone+rewrite logic still a no-op) | ✅ merged #1520 |
-| DP3b — `End.Replicate` | clsact-ingress clone loop: match outer DA against `REPL_LOCAL_SID`, decrement Hop Limit (guard ≤1), `clone_redirect` one copy per leaf with outer DA rewritten, drop original. Lab-validated (`scripts/veth-replicate-test.sh`) | ✅ this slice |
-| DP3c — leaf `End.DT2M` | match the local `End.DT2M` SID → strip outer IPv6+SRH, redirect inner frame to the bridge master for native BUM flooding | ⬜ planned |
+| DP3b — `End.Replicate` | clsact-ingress clone loop: match outer DA against `REPL_LOCAL_SID`, decrement Hop Limit (guard ≤1), `clone_redirect` one copy per leaf with outer DA rewritten, drop original. Lab-validated (`scripts/veth-replicate-test.sh`) | ✅ merged #1563 |
+| DP3c — leaf `End.DT2M` | match the local `End.DT2M` SID (`DT2M_SID` map) → slide the inner frame to the front (`adjust_room` can't strip a full L3), `change_tail`-trim, `bpf_redirect` into a bridge port's ingress → native flood. Lab-validated (`scripts/veth-dt2m-test.sh`) | ✅ this slice |
 
 ## Where the pieces live
 
@@ -140,31 +142,45 @@ rewrite) is **implemented and lab-validated**. The remaining gap is the leaf
 ## eBPF dataplane design (DP2/DP3)
 
 - New `offload/tc-evpn-replicate/` crate mirrors `offload/xdp-bfd-echo/` but a
-  TC/clsact `#[classifier]`. Roles, all clsact-attached: **root/bud** (ingress)
-  match the Replication-SID → clone + per-branch outer-DA rewrite
-  (`End.Replicate`, **implemented**); **leaf** (ingress) match the `End.DT2M`
-  SID → strip outer IPv6+SRH, redirect inner frame to the bridge master for
-  native BUM flooding (DP3c). A root that must `H.Encaps` a bare BUM frame
-  (rather than re-replicate an already-encapsulated one) is a later refinement.
+  TC/clsact `#[classifier]`. One ingress classifier serves both roles, keyed by
+  which map the outer IPv6 DA hits: **root/bud** match the Replication-SID →
+  clone + per-branch outer-DA rewrite (`End.Replicate`); **leaf** match the
+  `End.DT2M` SID → decap + bridge flood. A root that must `H.Encaps` a bare BUM
+  frame (rather than re-replicate an already-encapsulated one) is a later
+  refinement.
 - **Maps** (loader-filled): `REPL_SEG` (per-VNI segment: tree-id, leaf SIDs);
-  `REPL_LOCAL_SID` (local replication SID → VNI, so the datapath demuxes an
-  inbound packet to its segment by outer IPv6 DA — derived here from each
-  segment's root SID); `CONFIG[0]` (egress ifindex the copies leave on,
-  `--redirect-iface`). Fed from `ReplSeg` over a stdin line protocol; a
+  `REPL_LOCAL_SID` (local replication SID → VNI, demuxes a packet to its segment
+  by outer IPv6 DA — derived here from each segment's root SID); `DT2M_SID`
+  (local `End.DT2M` SID → VNI, leaf role); `CONFIG[0]` (clone egress ifindex,
+  `--redirect-iface`), `CONFIG[1]` (bridge port the leaf floods into,
+  `--bridge-iface`). Fed from `ReplSeg`/`leaf-add` over a stdin line protocol; a
   supervisor spawns/refcounts the loader per ifindex.
 - **`End.Replicate` datapath:** on an inbound IPv6 frame whose outer DA hits
   `REPL_LOCAL_SID`, decrement the outer Hop Limit (drop if ≤1), then for each
   leaf rewrite the outer DA and `clone_redirect` a copy out `CONFIG[0]`; drop
-  the original (`TC_ACT_SHOT`). Writes use `bpf_skb_store_bytes`/`load_bytes`
-  (not raw `data` pointers), so nothing is held across the `clone_redirect`s
-  that invalidate packet pointers. No outer checksum fix-up is needed (IPv6 has
-  no header checksum; the outer DA is not in any inner L4 pseudo-header).
-  Validated end-to-end on a veth pair by `scripts/veth-replicate-test.sh` (one
-  frame to a replication SID → a copy at each leaf SID).
-- **Caveats:** `bpf_clone_redirect` is TC-only; the leaf decap (DP3c) and any
-  SRH segment-list rewrite are still to come; `H.Encaps.Red` MTU (eBPF can't
-  fragment → jumbo/large underlay); veth needs the clsact path (no native XDP);
-  aya is pulled from git unpinned.
+  the original (`TC_ACT_SHOT`). No outer checksum fix-up (IPv6 has no header
+  checksum; the outer DA is not in any inner L4 pseudo-header). Validated by
+  `scripts/veth-replicate-test.sh`.
+- **Leaf `End.DT2M` datapath:** on an inbound IPv6 frame whose outer DA hits
+  `DT2M_SID` (reduced encap, Next Header = Ethernet/143), slide the inner
+  Ethernet frame to the front of the skb and `bpf_skb_change_tail`-trim the tail,
+  then `bpf_redirect(BPF_F_INGRESS)` into a bridge **port** so the bridge floods
+  to the other ports. `bpf_skb_adjust_room` can't do this (it preserves the L3
+  header and refuses to shrink past it — confirmed: a small MAC-mode shrink
+  succeeds but a full-header shrink returns `-ENOTSUPP`); the slide+trim is the
+  head-removal workaround. Redirecting to the bridge *master* would only send
+  the frame up the host stack, so a dedicated bridge port is the inject point.
+  Validated by `scripts/veth-dt2m-test.sh`.
+- Both use `bpf_skb_store_bytes`/`load_bytes` (`TcContext::store`/`load`), never
+  a raw `data` pointer, so nothing is held across the `clone_redirect` /
+  `change_tail` calls that invalidate packet pointers.
+- **Caveats:** `bpf_clone_redirect`/`bpf_redirect` are TC-only; the root
+  H.Encaps-from-bare-frame path and SRH-present (non-reduced) decap + any SRH
+  segment-list rewrite are still to come; `change_tail`'s minimum length is the
+  stale transport offset, so a sub-`DT2M_STRIP`-byte (runt) inner frame can't be
+  trimmed and is dropped — real ≥60-byte Ethernet frames trim fine; veth needs
+  GRO off (a GRO'd skb presents as GSO and blocks shrink helpers); aya is pulled
+  from git unpinned.
 
 ## Gotchas / build notes
 
@@ -182,5 +198,10 @@ rewrite) is **implemented and lab-validated**. The remaining gap is the leaf
   SRv6 Function transposition) — label field left 0.
 - Controller-instantiated replication SIDs (PCEP / BGP SR-P2MP policy) — only
   the locally-computed degenerate tree is built.
-- Multi-tier (bud-node) replication forwarding depends on the eBPF dataplane
-  (DP3); the signaling/state model already supports it.
+- Multi-tier (bud-node) replication forwarding: the `End.Replicate` datapath
+  already clones + rewrites per branch, so a bud is forwarding-capable; the
+  remaining piece is the control plane computing a multi-tier tree (only the
+  degenerate root→leaves tree is built today).
+- Root `H.Encaps`-from-bare-frame (encapsulate a BUM frame arriving bare from
+  the local bridge, vs. re-replicating an already-encapsulated one) and
+  SRH-present (non-reduced) `End.DT2M` decap + SRH segment-list rewrite.

--- a/offload/tc-evpn-replicate/README.md
+++ b/offload/tc-evpn-replicate/README.md
@@ -14,40 +14,48 @@ a different rewritten header*. The TC layer can express that with
 clone per-copy. So this is a `#[classifier]` program on `clsact`, unlike the
 sibling [`xdp-bfd-echo`](../xdp-bfd-echo) offload.
 
-Roles (all clsact-attached):
-- **root / bud** (ingress) — **implemented**: match the local Replication-SID
-  (the outer IPv6 DA), then for each downstream leaf clone the packet and
-  rewrite the outer DA to that leaf's SID (`End.Replicate`);
-- **leaf** (ingress) — *follow-up (DP3c)*: match the local `End.DT2M` SID, strip
-  the outer IPv6+SRH, redirect the inner frame to the bridge for native BUM
-  flooding.
+Roles (all clsact-ingress, dispatched by which map the outer IPv6 DA hits):
+- **root / bud** — **implemented**: match the local Replication-SID, then for
+  each downstream leaf clone the packet and rewrite the outer DA to that leaf's
+  SID (`End.Replicate`);
+- **leaf** — **implemented**: match the local `End.DT2M` SID, strip the outer
+  encap (link Ethernet + outer IPv6), and redirect the inner frame to a bridge
+  port for native BUM flooding.
 
 The branch/leaf table is a BPF map the loader fills from the BGP control plane
 (`ReplSeg`, fed by `EvpnFloodState::replication_leaves`).
 
 ## Status
 
-**`End.Replicate` works.** The classifier reads three maps the loader fills:
+**`End.Replicate` + leaf `End.DT2M` both work.** The classifier reads four maps
+the loader fills:
 
 - `REPL_SEG` — per-VNI replication segment (tree + leaf SIDs);
 - `REPL_LOCAL_SID` — local replication SID → VNI, for demuxing an inbound packet
   to its segment by outer IPv6 DA (derived from each segment's root SID);
-- `CONFIG` — index 0 = egress ifindex the copies are `clone_redirect`'d out of.
+- `DT2M_SID` — local `End.DT2M` SID → VNI for the leaf role;
+- `CONFIG` — index 0 = `End.Replicate` clone egress ifindex; index 1 = the
+  bridge port a leaf floods decapped frames into.
 
-On an inbound IPv6 frame whose DA is a known replication SID it decrements the
-outer Hop Limit (dropping anything that arrives with Hop Limit ≤ 1) and emits
-one clone per leaf with the outer DA rewritten, then drops the original.
+`End.Replicate`: on an inbound IPv6 frame whose DA is a known replication SID,
+decrement the outer Hop Limit (drop anything ≤ 1) and emit one clone per leaf
+with the outer DA rewritten, then drop the original.
 
-Validated end-to-end on a veth pair —
-[`scripts/veth-replicate-test.sh`](scripts/veth-replicate-test.sh) sends one
-frame to a replication SID and asserts a copy arrives at *each* leaf SID:
+`End.DT2M`: on an inbound IPv6 frame whose DA is a local `End.DT2M` SID (reduced
+encap, Next Header = Ethernet), slide the inner Ethernet frame to the front of
+the skb (`bpf_skb_adjust_room` can't strip a full outer L3), trim the tail with
+`bpf_skb_change_tail`, and `bpf_redirect` it into a bridge port's ingress so the
+bridge floods it to the local ACs.
+
+Both validated end-to-end on veth pairs:
 
 ```sh
-sudo bash offload/tc-evpn-replicate/scripts/veth-replicate-test.sh
+sudo bash offload/tc-evpn-replicate/scripts/veth-replicate-test.sh   # End.Replicate
+sudo bash offload/tc-evpn-replicate/scripts/veth-dt2m-test.sh        # leaf End.DT2M
 ```
 
-The **leaf `End.DT2M` decap** (strip outer IPv6+SRH, redirect inner to the
-bridge) and the **root H.Encaps-from-bare-frame** path are follow-up slices.
+The **root H.Encaps-from-bare-frame** path and **SRH-present** decap (non-reduced
+encap) are follow-up slices.
 
 ## Build / run
 

--- a/offload/tc-evpn-replicate/ebpf/src/main.rs
+++ b/offload/tc-evpn-replicate/ebpf/src/main.rs
@@ -2,7 +2,7 @@
 #![no_main]
 
 //! EVPN BUM replication dataplane (RFC 9524 SR replication segment) — eBPF
-//! TC/clsact `End.Replicate`.
+//! TC/clsact `End.Replicate` + leaf `End.DT2M`.
 //!
 //! This is the SR P2MP / RFC 9524 replication forwarder the stock Linux kernel
 //! cannot do natively: there is no `End.Replicate` seg6local action, no MPLS
@@ -12,30 +12,42 @@
 //! between clones). XDP has no per-copy clone, so this is a `#[classifier]`
 //! (clsact) program, unlike the sibling `xdp-bfd-echo` offload.
 //!
-//! ## `End.Replicate` (this slice — root/bud, clsact ingress)
+//! One clsact-ingress classifier serves both replication roles, keyed by which
+//! map the inbound packet's outer IPv6 Destination Address hits:
 //!
-//! A BUM packet arrives already SRv6-encapsulated, its outer IPv6 Destination
-//! Address equal to the local replication SID for the tree (the loader indexes
-//! that SID -> VNI in [`REPL_LOCAL_SID`]). For each downstream leaf the program:
-//!   1. rewrites the outer IPv6 DA to the leaf's SID (no checksum fix-up — IPv6
-//!      has no header checksum and the *outer* DA is not in any inner L4
-//!      pseudo-header), and
-//!   2. `bpf_clone_redirect`s the copy out the egress ifindex in [`CONFIG`].
-//! The outer Hop Limit is decremented once up front (a replication node is a
-//! forwarding hop); a packet that arrives with Hop Limit <= 1 is dropped rather
+//! ## `End.Replicate` (root/bud) — DA in [`REPL_LOCAL_SID`]
+//!
+//! A BUM packet arrives already SRv6-encapsulated, its outer IPv6 DA equal to
+//! the local replication SID for the tree. For each downstream leaf the program
+//! rewrites the outer DA to the leaf's SID (no checksum fix-up — IPv6 has no
+//! header checksum and the *outer* DA is not in any inner L4 pseudo-header) and
+//! `bpf_clone_redirect`s the copy out the egress ifindex in [`CONFIG`]`[0]`. The
+//! outer Hop Limit is decremented once up front (a replication node is a
+//! forwarding hop); a packet arriving with Hop Limit <= 1 is dropped rather
 //! than replicated, so a misrouted copy can't storm. The original (which still
-//! carries the replication SID, not a deliverable destination) is dropped with
-//! `TC_ACT_SHOT` after the fan-out.
+//! carries the replication SID) is dropped with `TC_ACT_SHOT` after fan-out.
 //!
-//! Writes go through `bpf_skb_store_bytes` / `bpf_skb_load_bytes`
+//! ## Leaf `End.DT2M` — DA in [`DT2M_SID`]
+//!
+//! A replicated copy arrives at a leaf PE addressed to its local `End.DT2M`
+//! SID: outer IPv6 (reduced SRv6 encap, Next Header = Ethernet/143) wrapping the
+//! inner Ethernet BUM frame. The program removes the outer encap (link Ethernet
+//! + outer IPv6) by sliding the inner frame to the front and trimming the tail
+//! (`bpf_skb_adjust_room` can't strip a full outer L3 — it preserves the
+//! network header), then `bpf_redirect`s the inner frame to a bridge port's
+//! ingress (`CONFIG[1]`) so the bridge floods it natively to the local
+//! attachment circuits — the L2 flood the kernel has no SID behavior for. (Only
+//! the reduced encap, no SRH, is handled here; the SRH-present form is a
+//! follow-up.)
+//!
+//! Packet access goes through `bpf_skb_store_bytes` / `bpf_skb_load_bytes`
 //! (`TcContext::store` / `::load`), never a raw `data` pointer, so nothing is
-//! held across the `clone_redirect` calls that invalidate packet pointers.
-//!
-//! The leaf side — match the local `End.DT2M` SID, strip the outer IPv6+SRH and
-//! redirect the inner frame to the bridge master — is the next slice (DP3c).
+//! held across the `clone_redirect` / `change_tail` calls that invalidate
+//! packet pointers.
 
 use aya_ebpf::{
     bindings::{TC_ACT_PIPE, TC_ACT_SHOT},
+    helpers::{bpf_redirect, bpf_skb_change_tail},
     macros::{classifier, map},
     maps::{Array, HashMap},
     programs::TcContext,
@@ -54,16 +66,37 @@ pub const REPL_FLAG_ROOT_V4: u32 = 1 << 1; // `root` is an IPv4 address (first 4
 const ACT_PIPE: i32 = TC_ACT_PIPE as i32;
 const ACT_SHOT: i32 = TC_ACT_SHOT as i32;
 
-/// Ethernet II + IPv6 fixed-header offsets (from the start of the frame). Only
-/// a base IPv6 header is parsed; the replication match is purely on the outer
-/// Destination Address, so extension headers between it and any inner payload
-/// are irrelevant here.
+/// `CONFIG` slots (egress devices the loader resolves once at attach).
+const CFG_REPLICATE_IFINDEX: u32 = 0; // `End.Replicate` clone egress
+const CFG_BRIDGE_IFINDEX: u32 = 1; // leaf `End.DT2M` flood target
+
+/// `bpf_redirect` flag: deliver to the target's ingress (kernel
+/// `BPF_F_INGRESS`). Redirecting a decapped frame to a bridge *port's* ingress
+/// makes the bridge flood it to the other ports.
+const BPF_F_INGRESS: u64 = 1;
+
+/// Ethernet II + IPv6 fixed-header offsets (from the start of the frame).
 const ETH_HLEN: usize = 14;
 const ETH_TYPE_OFF: usize = 12; // u16 (big-endian) EtherType
 const ETHERTYPE_IPV6: u16 = 0x86DD;
 const IP6_OFF: usize = ETH_HLEN;
+const IP6_HLEN: usize = 40;
+const IP6_NEXTHDR_OFF: usize = IP6_OFF + 6; // u8 Next Header
 const IP6_HOPLIMIT_OFF: usize = IP6_OFF + 7; // u8 Hop Limit
 const IP6_DST_OFF: usize = IP6_OFF + 24; // [u8; 16] destination address
+
+/// IANA protocol number for "Ethernet" (RFC 8986 §6.6) — the outer IPv6 Next
+/// Header of a reduced SRv6 L2 (`End.DT2M`) encapsulation, indicating the
+/// payload is an Ethernet frame.
+const NH_ETHERNET: u8 = 143;
+/// Bytes of outer encap to remove for a reduced `End.DT2M` frame: the link
+/// Ethernet header + the outer IPv6 header. What follows is the inner Ethernet
+/// BUM frame, which becomes the new link frame.
+const DT2M_STRIP: usize = ETH_HLEN + IP6_HLEN; // 54
+/// Upper bound on the inner frame length copied to the front during decap (a
+/// jumbo-free Ethernet payload fits well under this). The verifier needs a
+/// constant loop bound; a frame longer than this is left for the stack.
+const MAX_INNER: usize = 2048;
 
 /// One VNI's SR P2MP replication segment (RFC 9524), keyed by VNI in
 /// [`REPL_SEG`]. Addresses are stored as 16 bytes — IPv6 verbatim, or IPv4 in
@@ -92,15 +125,20 @@ static REPL_SEG: HashMap<u32, ReplSeg> = HashMap::with_max_entries(256, 0);
 #[map]
 static REPL_LOCAL_SID: HashMap<[u8; 16], u32> = HashMap::with_max_entries(256, 0);
 
-/// Single-entry config: index 0 holds the egress ifindex the replicated copies
-/// are `bpf_clone_redirect`ed out of (the SR underlay-facing NIC). The loader
-/// sets it from `--redirect-iface`.
+/// Local `End.DT2M` SID -> VNI index for the leaf role: a packet whose outer DA
+/// matches is decapsulated and the inner Ethernet frame flooded into the
+/// bridge. The loader fills this on `leaf-add`.
 #[map]
-static CONFIG: Array<u32> = Array::with_max_entries(1, 0);
+static DT2M_SID: HashMap<[u8; 16], u32> = HashMap::with_max_entries(256, 0);
+
+/// Egress devices, by `CFG_*` index: `[0]` = `End.Replicate` clone egress,
+/// `[1]` = leaf `End.DT2M` bridge-flood target. 0 = unset (role disabled).
+#[map]
+static CONFIG: Array<u32> = Array::with_max_entries(2, 0);
 
 #[classifier]
 pub fn tc_evpn_replicate(ctx: TcContext) -> i32 {
-    match try_replicate(&ctx) {
+    match try_forward(&ctx) {
         Ok(action) => action,
         // A truncated/short frame or a transient map/helper failure: hand the
         // packet back to the stack untouched rather than dropping it.
@@ -108,18 +146,33 @@ pub fn tc_evpn_replicate(ctx: TcContext) -> i32 {
     }
 }
 
-fn try_replicate(ctx: &TcContext) -> Result<i32, ()> {
-    // Only IPv6-framed packets carry an SRv6 replication SID. Anything else is
-    // not ours; pass it on.
+fn try_forward(ctx: &TcContext) -> Result<i32, ()> {
+    // Only IPv6-framed packets carry an SRv6 replication / End.DT2M SID.
     let ethertype = u16::from_be(ctx.load::<u16>(ETH_TYPE_OFF).map_err(|_| ())?);
     if ethertype != ETHERTYPE_IPV6 {
         return Ok(ACT_PIPE);
     }
 
-    // Demux by the outer Destination Address: is it one of our local
-    // replication SIDs? If not, leave the frame for the stack.
+    // Demux by the outer Destination Address.
     let da: [u8; 16] = ctx.load(IP6_DST_OFF).map_err(|_| ())?;
-    let Some(vni) = (unsafe { REPL_LOCAL_SID.get(&da) }) else {
+    if unsafe { REPL_LOCAL_SID.get(&da) }.is_some() {
+        // Root/bud: a replication SID -> clone + per-branch DA rewrite.
+        return end_replicate(ctx, &da);
+    }
+    if unsafe { DT2M_SID.get(&da) }.is_some() {
+        // Leaf: our End.DT2M SID -> decap + flood into the bridge.
+        return end_dt2m(ctx);
+    }
+    // Not one of our SIDs; leave it for the stack.
+    Ok(ACT_PIPE)
+}
+
+/// `End.Replicate` (root/bud): fan the packet out, one clone per leaf, each with
+/// the outer IPv6 DA rewritten to that leaf's SID.
+fn end_replicate(ctx: &TcContext, da: &[u8; 16]) -> Result<i32, ()> {
+    // `da` already matched REPL_LOCAL_SID in the caller; re-fetch the VNI +
+    // segment here so the borrows are local to this branch.
+    let Some(vni) = (unsafe { REPL_LOCAL_SID.get(da) }) else {
         return Ok(ACT_PIPE);
     };
     let Some(seg) = (unsafe { REPL_SEG.get(vni) }) else {
@@ -130,7 +183,7 @@ fn try_replicate(ctx: &TcContext) -> Result<i32, ()> {
 
     // Egress device for the replicated copies. Unset (0) means the loader hasn't
     // configured one yet — don't replicate into the void; pass the frame on.
-    let ifindex = match CONFIG.get(0) {
+    let ifindex = match CONFIG.get(CFG_REPLICATE_IFINDEX) {
         Some(&v) if v != 0 => v,
         _ => return Ok(ACT_PIPE),
     };
@@ -174,14 +227,69 @@ fn try_replicate(ctx: &TcContext) -> Result<i32, ()> {
     Ok(ACT_SHOT)
 }
 
+/// Leaf `End.DT2M`: strip the reduced SRv6 encap and flood the inner Ethernet
+/// frame into the bridge so the kernel replicates it to the local ACs.
+fn end_dt2m(ctx: &TcContext) -> Result<i32, ()> {
+    // Only the reduced encap (single SID in the DA, no SRH) is handled here:
+    // the outer IPv6 Next Header is Ethernet(143) and the inner Ethernet frame
+    // follows the fixed header directly. An SRH-present frame (Next Header 43)
+    // is left for a follow-up; pass it on.
+    if ctx.load::<u8>(IP6_NEXTHDR_OFF).map_err(|_| ())? != NH_ETHERNET {
+        return Ok(ACT_PIPE);
+    }
+
+    // Bridge port to flood into. Unset (0) means the leaf role isn't configured.
+    let bridge = match CONFIG.get(CFG_BRIDGE_IFINDEX) {
+        Some(&v) if v != 0 => v,
+        _ => return Ok(ACT_PIPE),
+    };
+
+    // Decap = remove the outer encap (link Ethernet + outer IPv6) from the front
+    // of the frame, leaving the inner Ethernet BUM frame. `bpf_skb_adjust_room`
+    // can't do this — it preserves the L3 header and refuses to shrink past it —
+    // so shift the inner frame to the front and trim the tail. (`adjust_room`
+    // also has no "remove the L2 header" mode.)
+    let total = ctx.len() as usize;
+    if total <= DT2M_STRIP {
+        return Ok(ACT_PIPE); // no inner frame
+    }
+    let inner_len = total - DT2M_STRIP;
+
+    // Slide the inner frame left by DT2M_STRIP bytes, ascending so the (lower)
+    // destination never clobbers a not-yet-read (higher) source byte. The
+    // constant `MAX_INNER` bound keeps the loop bounded for the verifier; a
+    // frame longer than that is left for the stack.
+    let mut i = 0usize;
+    while i < inner_len && i < MAX_INNER {
+        let b: u8 = ctx.load(DT2M_STRIP + i).map_err(|_| ())?;
+        ctx.store(i, &b, 0).map_err(|_| ())?;
+        i += 1;
+    }
+    if i < inner_len {
+        return Ok(ACT_PIPE); // frame larger than MAX_INNER — don't truncate it
+    }
+
+    // Trim the now-duplicated trailing DT2M_STRIP bytes: the skb becomes exactly
+    // the inner Ethernet frame. A real BUM frame is a full (>=60-byte) Ethernet
+    // frame, so `inner_len` clears the kernel's change_tail minimum; if a runt
+    // frame can't be trimmed, drop it rather than flood stale tail bytes.
+    if unsafe { bpf_skb_change_tail(ctx.skb.skb, inner_len as u32, 0) } != 0 {
+        return Ok(ACT_SHOT);
+    }
+
+    // Flood into the bridge (ingress on a bridge port): the bridge replicates
+    // the inner BUM frame to the other local attachment circuits.
+    Ok(unsafe { bpf_redirect(bridge, BPF_F_INGRESS) } as i32)
+}
+
 #[cfg(not(test))]
 #[panic_handler]
 fn panic(_info: &core::panic::PanicInfo) -> ! {
     loop {}
 }
 
-// `bpf_clone_redirect` is a GPL-only helper, so declare a GPL-compatible
-// license.
+// `bpf_clone_redirect` / `bpf_redirect` are GPL-only helpers, so declare a
+// GPL-compatible license.
 #[unsafe(link_section = "license")]
 #[unsafe(no_mangle)]
 static LICENSE: [u8; 13] = *b"Dual MIT/GPL\0";

--- a/offload/tc-evpn-replicate/loader/src/main.rs
+++ b/offload/tc-evpn-replicate/loader/src/main.rs
@@ -5,15 +5,19 @@
 //! `tc_evpn_replicate` classifier to an interface's `clsact` qdisc, and
 //! populates the BPF maps from a stdin line protocol fed by the zebra-rs
 //! supervisor. The classifier reads those maps to clone + rewrite each copy's
-//! outer IPv6 Destination Address (`End.Replicate`). Three maps back it:
+//! outer IPv6 Destination Address (`End.Replicate`) and to decap + bridge-flood
+//! a leaf's `End.DT2M` SID. The maps:
 //!   * `REPL_SEG`       — per-VNI replication segment (tree + leaf SIDs);
 //!   * `REPL_LOCAL_SID` — local replication SID -> VNI, so the datapath can
 //!     demux an inbound packet to its segment by outer DA (derived from each
 //!     segment's root SID here);
-//!   * `CONFIG`         — index 0 = egress ifindex the copies are redirected
-//!     out of (`--redirect-iface`).
+//!   * `DT2M_SID`       — local `End.DT2M` SID -> VNI for the leaf role;
+//!   * `CONFIG`         — index 0 = egress ifindex the replicated copies leave
+//!     on (`--redirect-iface`); index 1 = bridge ifindex a leaf floods decapped
+//!     frames into (`--bridge-iface`).
 //! Runs until Ctrl-C / SIGTERM.
 
+use std::collections::HashMap as StdHashMap;
 use std::ffi::CString;
 use std::net::IpAddr;
 
@@ -52,12 +56,17 @@ unsafe impl aya::Pod for ReplSeg {}
 type ReplMap = AyaHashMap<MapData, u32, ReplSeg>;
 type SidIndex = AyaHashMap<MapData, [u8; 16], u32>;
 
-/// The maps the stdin line protocol programs, threaded together so an `repl-add`
+/// The maps the stdin line protocol programs, threaded together so a `repl-add`
 /// keeps the per-VNI segment ([`ReplMap`]) and the SID demux index
-/// ([`SidIndex`]) in lockstep.
+/// ([`SidIndex`]) in lockstep, and `leaf-add`/`leaf-del` maintain the
+/// `End.DT2M` SID index plus its reverse map (for eviction by VNI).
 struct Maps {
     repl: ReplMap,
     sid_index: SidIndex,
+    dt2m: SidIndex,
+    /// VNI -> its `End.DT2M` SID, so `leaf-del <vni>` can evict the SID-keyed
+    /// `dt2m` map (which has no VNI to look the key up by).
+    leaf_sids: StdHashMap<u32, [u8; 16]>,
 }
 
 #[derive(Debug, Parser)]
@@ -74,6 +83,10 @@ struct Opt {
     /// they arrived on, each toward a different leaf SID).
     #[clap(short, long)]
     redirect_iface: Option<String>,
+    /// Bridge interface a leaf floods decapped `End.DT2M` frames into. Unset
+    /// disables the leaf role (the datapath passes such frames to the stack).
+    #[clap(short, long)]
+    bridge_iface: Option<String>,
 }
 
 #[tokio::main]
@@ -82,6 +95,7 @@ async fn main() -> anyhow::Result<()> {
         iface,
         direction,
         redirect_iface,
+        bridge_iface,
     } = Opt::parse();
     env_logger::init();
 
@@ -101,6 +115,15 @@ async fn main() -> anyhow::Result<()> {
     let redirect = redirect_iface.unwrap_or_else(|| iface.clone());
     let redirect_ifindex = if_nametoindex(&redirect)
         .with_context(|| format!("redirect interface {redirect:?} not found"))?;
+
+    // The bridge a leaf floods decapped End.DT2M frames into. Optional: 0
+    // leaves the leaf role disabled (no bridge to flood into).
+    let bridge_ifindex = match bridge_iface.as_deref() {
+        Some(name) => {
+            if_nametoindex(name).with_context(|| format!("bridge interface {name:?} not found"))?
+        }
+        None => 0,
+    };
 
     // Embed the eBPF object built by build.rs and load it (the object's name is
     // the eBPF crate's `[[bin]]` name, `tc-evpn-replicate`).
@@ -127,7 +150,7 @@ async fn main() -> anyhow::Result<()> {
     program.load()?;
     program.attach(&iface, attach)?;
 
-    // Egress ifindex for the replicated copies (CONFIG[0]).
+    // Egress devices: CONFIG[0] = replicate copies, CONFIG[1] = leaf bridge.
     let mut config: AyaArray<MapData, u32> = AyaArray::try_from(
         ebpf.take_map("CONFIG")
             .context("map 'CONFIG' not found in object")?,
@@ -135,6 +158,9 @@ async fn main() -> anyhow::Result<()> {
     config
         .set(0, redirect_ifindex, 0)
         .context("CONFIG[0] = redirect ifindex")?;
+    config
+        .set(1, bridge_ifindex, 0)
+        .context("CONFIG[1] = bridge ifindex")?;
 
     // Userspace handles to the maps the classifier reads.
     let mut maps = Maps {
@@ -146,17 +172,28 @@ async fn main() -> anyhow::Result<()> {
             ebpf.take_map("REPL_LOCAL_SID")
                 .context("map 'REPL_LOCAL_SID' not found in object")?,
         )?,
+        dt2m: AyaHashMap::try_from(
+            ebpf.take_map("DT2M_SID")
+                .context("map 'DT2M_SID' not found in object")?,
+        )?,
+        leaf_sids: StdHashMap::new(),
     };
 
+    let bridge_desc = match bridge_iface.as_deref() {
+        Some(name) => format!("{name} (ifindex {bridge_ifindex})"),
+        None => "disabled".to_string(),
+    };
     info!(
         "tc_evpn_replicate attached to {iface} ({direction}); copies -> {redirect} \
-         (ifindex {redirect_ifindex}); reading commands on stdin"
+         (ifindex {redirect_ifindex}); leaf flood -> {bridge_desc}; reading commands on stdin"
     );
 
     // Replication segments are fed by the zebra-rs supervisor over a stdin
     // line protocol (one command per line):
     //   repl-add <vni> <tree-id> <srv6:0|1> <root-ip> <leaf-ip>...
     //   repl-del <vni>
+    //   leaf-add <vni> <dt2m-sid>        (this node's End.DT2M SID for the VNI)
+    //   leaf-del <vni>
     let mut lines = tokio::io::BufReader::new(tokio::io::stdin()).lines();
     loop {
         tokio::select! {
@@ -239,8 +276,39 @@ fn handle_command(line: &str, maps: &mut Maps) {
             }
             None => warn!("malformed repl-del: {line:?}"),
         },
+        Some("leaf-add") => match parse_leaf(&mut it) {
+            Some((vni, sid)) => {
+                if let Err(e) = maps.dt2m.insert(sid, vni, 0) {
+                    warn!("DT2M_SID insert vni={vni} failed: {e}");
+                    return;
+                }
+                maps.leaf_sids.insert(vni, sid);
+                info!("leaf-add vni={vni}");
+            }
+            None => warn!("malformed leaf-add: {line:?}"),
+        },
+        Some("leaf-del") => match it.next().and_then(|v| v.parse::<u32>().ok()) {
+            Some(vni) => {
+                if let Some(sid) = maps.leaf_sids.remove(&vni) {
+                    let _ = maps.dt2m.remove(&sid);
+                }
+                info!("leaf-del vni={vni}");
+            }
+            None => warn!("malformed leaf-del: {line:?}"),
+        },
         Some(other) => warn!("unknown command: {other:?}"),
         None => {}
+    }
+}
+
+/// Parse a `leaf-add <vni> <dt2m-sid>` body (the verb already consumed) into the
+/// VNI + the 16-byte SID key. The SID must be an IPv6 address (an SRv6
+/// `End.DT2M` SID); an IPv4 value is rejected.
+fn parse_leaf<'a>(it: &mut impl Iterator<Item = &'a str>) -> Option<(u32, [u8; 16])> {
+    let vni: u32 = it.next()?.parse().ok()?;
+    match it.next()?.parse::<IpAddr>().ok()? {
+        IpAddr::V6(sid) => Some((vni, sid.octets())),
+        IpAddr::V4(_) => None,
     }
 }
 

--- a/offload/tc-evpn-replicate/scripts/veth-dt2m-test.sh
+++ b/offload/tc-evpn-replicate/scripts/veth-dt2m-test.sh
@@ -1,0 +1,183 @@
+#!/usr/bin/env bash
+#
+# End-to-end load test for the EVPN BUM replication TC/clsact leaf `End.DT2M`
+# datapath (RFC 9524 SR replication segment): decap + native bridge flood.
+#
+# What it proves: a leaf PE receives a replicated BUM copy addressed to its
+# local End.DT2M SID — outer IPv6 (reduced SRv6 encap, Next Header = Ethernet)
+# wrapping the inner Ethernet frame. The stock kernel has no SID behavior that
+# strips that and floods the inner frame into the L2 domain. This datapath does:
+# it pops the outer IPv6, restores the inner Ethernet frame, and redirects it
+# into a bridge port's ingress so the bridge floods it to every local
+# attachment circuit.
+#
+# Topology (root ns unless noted):
+#
+#   ns evpndt2m-ns        root ns
+#   ┌──────────────┐      ┌──────────────────────────────────────────────────┐
+#   │ evpndl1      │──────│ evpndl0  [clsact ingress: tc_evpn_replicate]      │
+#   │ send 1 frame │ veth │   match DT2M SID → strip outer IPv6 → redirect    │
+#   │ dst=DT2M SID │      │   inner frame to evpninj0 ingress (a bridge port) │
+#   └──────────────┘      │                          │                        │
+#                         │   brevpn (bridge) ◄───────┘ floods to other ports  │
+#                         │     ├─ evpninj0 (injection port, redirect target)  │
+#                         │     └─ evpnap0 ──veth── evpnap1  [capture inbound] │
+#                         └──────────────────────────────────────────────────┘
+#
+# The injection port matters: redirecting a decapped frame to a bridge *port's*
+# ingress makes the bridge flood it to the other ports (split-horizon skips the
+# injection port); redirecting to the bridge *master* would just send it up the
+# host stack, not flood. The inner frame is a broadcast ARP so the bridge floods
+# it unconditionally; we capture it leaving the access port (evpnap0 → evpnap1).
+#
+# Run as root:
+#   sudo bash offload/tc-evpn-replicate/scripts/veth-dt2m-test.sh
+set -u
+
+NS=evpndt2m-ns
+DL0=evpndl0          # underlay root-ns end — classifier attaches here
+DL1=evpndl1         # underlay namespace end — the sender
+BR=brevpn            # leaf bridge
+INJ0=evpninj0        # bridge injection port (redirect target) ...
+INJ1=evpninj1        # ... and its peer (just needs carrier)
+AP0=evpnap0          # bridge access port ...
+AP1=evpnap1          # ... and its peer, where flooded BUM is captured
+
+VNI=100
+DT2M_SID="2001:db8:beef::2"   # this leaf's End.DT2M SID (outer DA we send to)
+SRC="2001:db8:0:fe::1"        # arbitrary ingress source
+ARP_SENDER_IP=10.0.0.1
+ARP_TARGET_IP=10.0.0.2
+INNER_SRC_MAC=02:00:00:00:0a:01
+
+RUNTIME=12        # seconds the loader stays attached (stdin held open)
+CAP_SECS=7        # tcpdump capture window
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+BIN="$SCRIPT_DIR/../target/release/tc-evpn-replicate"
+LOG=/tmp/evpndt2m_loader.log
+CAPOUT=/tmp/evpndt2m_tcpdump.out
+CAPERR=/tmp/evpndt2m_tcpdump.err
+
+LOADER_PID=""
+cleanup() {
+    [ -n "$LOADER_PID" ] && kill "$LOADER_PID" 2>/dev/null
+    sleep 0.3
+    ip netns del "$NS" 2>/dev/null
+    ip link del "$DL0" 2>/dev/null
+    ip link del "$INJ0" 2>/dev/null
+    ip link del "$AP0" 2>/dev/null
+    ip link del "$BR" 2>/dev/null
+}
+trap cleanup EXIT
+
+if [ "$(id -u)" -ne 0 ]; then echo "ERROR: run as root (sudo)"; exit 1; fi
+if [ ! -x "$BIN" ]; then
+    echo "ERROR: binary not found: $BIN"
+    echo "       build it first:  (cd $SCRIPT_DIR/.. && cargo build --release)"
+    exit 1
+fi
+
+echo "== 1. fresh bridge + veths + namespace =="
+cleanup 2>/dev/null   # clean slate
+ip netns add "$NS"
+# Underlay veth: namespace sender <-> root-ns classifier.
+ip link add "$DL0" type veth peer name "$DL1"
+ip link set "$DL1" netns "$NS"
+ip link set "$DL0" up
+ip netns exec "$NS" ip link set "$DL1" up
+ip netns exec "$NS" ip link set lo up
+# Disable GRO/GSO/TSO on the underlay path: GRO on the receive side can present
+# the skb as GSO, which makes bpf_skb_adjust_room shrink return -ENOTSUPP.
+ethtool -K "$DL0" gro off gso off tso off lro off 2>/dev/null || true
+ip netns exec "$NS" ethtool -K "$DL1" gro off gso off tso off lro off 2>/dev/null || true
+# Bridge with STP off (ports forward immediately).
+ip link add "$BR" type bridge
+ip link set "$BR" type bridge stp_state 0
+ip link set "$BR" up
+# Injection + access ports (both veth pairs; both ends up so the enslaved end
+# has carrier and the bridge forwards on it).
+ip link add "$INJ0" type veth peer name "$INJ1"
+ip link add "$AP0" type veth peer name "$AP1"
+ip link set "$INJ0" master "$BR"; ip link set "$INJ0" up; ip link set "$INJ1" up
+ip link set "$AP0" master "$BR";  ip link set "$AP0" up;  ip link set "$AP1" up
+MAC_DST=$(cat "/sys/class/net/$DL0/address")
+MAC_SRC=$(ip netns exec "$NS" cat "/sys/class/net/$DL1/address")
+echo "   underlay: $DL0 ($MAC_DST) <-> $NS:$DL1 ($MAC_SRC)"
+echo "   bridge $BR ports: $INJ0 (inject), $AP0 (access; capture on $AP1)"
+
+echo "== 2. attach leaf on $DL0 (clsact ingress), flood -> bridge port $INJ0 =="
+( printf 'leaf-add %s %s\n' "$VNI" "$DT2M_SID"; sleep "$RUNTIME" ) \
+    | RUST_LOG=info "$BIN" -i "$DL0" -d ingress -b "$INJ0" >"$LOG" 2>&1 &
+LOADER_PID=$!
+sleep 2
+if ! kill -0 "$LOADER_PID" 2>/dev/null; then
+    echo "ERROR: loader exited early:"; cat "$LOG"; exit 1
+fi
+grep -iE 'attached|leaf-add' "$LOG" | sed 's/^/   /'
+
+echo "== 3. capture inbound on $AP1, then send 3 encapsulated BUM frames =="
+ip netns exec "$NS" true 2>/dev/null   # noop to keep ns warm
+timeout "$CAP_SECS" tcpdump -lnei "$AP1" -Q in >"$CAPOUT" 2>"$CAPERR" &
+TCPDUMP_PID=$!
+sleep 1
+MAC_DST="$MAC_DST" MAC_SRC="$MAC_SRC" SRC="$SRC" DST="$DT2M_SID" IFACE="$DL1" \
+INNER_SRC_MAC="$INNER_SRC_MAC" ARP_SENDER_IP="$ARP_SENDER_IP" ARP_TARGET_IP="$ARP_TARGET_IP" \
+    ip netns exec "$NS" python3 - <<'PY'
+import os, socket, time
+
+def mac(s): return bytes(int(b, 16) for b in s.split(":"))
+def ip6(s): return socket.inet_pton(socket.AF_INET6, s)
+def ip4(s): return socket.inet_aton(s)
+
+iface = os.environ["IFACE"]
+# Inner Ethernet BUM frame: broadcast ARP request (floods unconditionally).
+inner_smac = mac(os.environ["INNER_SRC_MAC"])
+inner_eth = b"\xff\xff\xff\xff\xff\xff" + inner_smac + b"\x08\x06"   # dst=bcast, ARP
+arp = (b"\x00\x01\x08\x00\x06\x04\x00\x01"                          # htype/ptype/hlen/plen/op=req
+       + inner_smac + ip4(os.environ["ARP_SENDER_IP"])
+       + b"\x00\x00\x00\x00\x00\x00" + ip4(os.environ["ARP_TARGET_IP"]))
+# Pad to the 60-byte Ethernet minimum (14 header + 46 payload), as a real NIC
+# would: the inner BUM frame is a full Ethernet frame, which also keeps its
+# length above the kernel's bpf_skb_change_tail minimum so decap can trim cleanly.
+arp = arp.ljust(46, b"\x00")
+inner = inner_eth + arp
+
+# Outer: link Ethernet + IPv6 (reduced SRv6 encap, Next Header = Ethernet/143).
+link_eth = mac(os.environ["MAC_DST"]) + mac(os.environ["MAC_SRC"]) + b"\x86\xdd"
+ipv6 = (b"\x60\x00\x00\x00"
+        + len(inner).to_bytes(2, "big")
+        + b"\x8f" + b"\x40"        # next_header=143 (Ethernet), hop_limit=64
+        + ip6(os.environ["SRC"]) + ip6(os.environ["DST"]))
+frame = link_eth + ipv6 + inner
+
+s = socket.socket(socket.AF_PACKET, socket.SOCK_RAW)
+s.bind((iface, 0))
+for _ in range(3):
+    s.send(frame); time.sleep(0.2)
+print("   sent 3x encapsulated BUM (inner ARP) -> %s (End.DT2M SID)" % os.environ["DST"])
+PY
+wait "$TCPDUMP_PID" 2>/dev/null
+
+echo "== 4. result =="
+echo "-- loader log --"; grep -iE 'attached|leaf-add|exiting' "$LOG" | sed 's/^/   /' || true
+echo "-- tcpdump (inbound on $AP1) --"; sed 's/^/   /' "$CAPOUT"
+
+# A PASS is the inner ARP flooded out the access port: broadcast dst, ARP, and
+# the inner sender MAC — none of which appear in the encapsulated outer frame.
+arp_n=$(grep -c -iE "Request who-has $ARP_TARGET_IP tell $ARP_SENDER_IP" "$CAPOUT" 2>/dev/null) || true
+arp_n=${arp_n:-0}
+echo
+echo "   inner ARP frames flooded to $AP1: $arp_n"
+if [ "$arp_n" -ge 1 ]; then
+    echo
+    echo "PASS: End.DT2M decapped the outer IPv6 and the bridge flooded the inner"
+    echo "      BUM frame to the local access port (strip + redirect via TC clsact)"
+    exit 0
+else
+    echo
+    echo "FAIL: inner ARP not observed on the access port"
+    echo "-- tcpdump stderr --"; sed 's/^/   /' "$CAPERR"
+    echo "-- full loader log --"; sed 's/^/   /' "$LOG"
+    exit 2
+fi


### PR DESCRIPTION
## Summary

Implements the **leaf side** of the RFC 9524 SR replication datapath — the L2 BUM flood the stock Linux kernel has no SID behavior for (no `End.DT2M`). Completes the pair started in #1563 (`End.Replicate`).

The `tc_evpn_replicate` classifier is now a dispatcher keyed by which map the inbound outer IPv6 DA hits: `REPL_LOCAL_SID` → `End.Replicate` (root/bud), or the new `DT2M_SID` → `End.DT2M` (leaf).

### eBPF (`offload/tc-evpn-replicate/ebpf`)
- `end_dt2m`: match a frame addressed to the local `End.DT2M` SID (reduced SRv6 encap, outer IPv6 Next Header = Ethernet/143), strip the outer encap (link Ethernet + outer IPv6) by **sliding the inner Ethernet frame to the front** and trimming the tail with `bpf_skb_change_tail`, then `bpf_redirect` it into a **bridge port's** ingress (`BPF_F_INGRESS`) so the bridge floods it to the local ACs.
- `bpf_skb_adjust_room` can't do this — it preserves the L3 header and refuses to shrink past it (a full-header MAC-mode shrink returns `-ENOTSUPP`), so the slide+trim is the head-removal workaround. Redirecting to the bridge *master* would only send the frame up the host stack, hence a bridge port.
- A runt inner frame that can't clear `change_tail`'s minimum length is dropped rather than flooded with stale tail bytes; real ≥60-byte Ethernet frames trim cleanly.

### loader
- New `DT2M_SID` map + `leaf-add <vni> <dt2m-sid>` / `leaf-del <vni>` line protocol; `--bridge-iface` → `CONFIG[1]`; `CONFIG` bumped to two slots (clone egress, bridge flood).

## Test plan

`offload/` is workspace-excluded and **not built by CI** (needs nightly + bpf-linker). Verified locally:

- `cd offload/tc-evpn-replicate && cargo build --release` — eBPF object + loader build clean, fmt'd.
- `sudo bash offload/tc-evpn-replicate/scripts/veth-dt2m-test.sh` — **PASS**: an encapsulated BUM frame sent to a leaf's `End.DT2M` SID is decapped and the inner ARP flooded (clean 60 bytes) out the bridge access port (3/3 frames).
- `sudo bash offload/tc-evpn-replicate/scripts/veth-replicate-test.sh` — **PASS** (regression: the `End.Replicate` path still fans out one copy per leaf).

Kernel facts learned (now in the design doc): `adjust_room` won't shrink past the L3 base header (`-ENOTSUPP`); `change_tail`'s floor is the stale transport offset (`-EINVAL` below it); redirect-to-bridge-master doesn't flood — a bridge port does; veth needs GRO off (a GRO'd skb presents as GSO and blocks shrink helpers).

Remaining: root `H.Encaps`-from-bare-frame path and SRH-present (non-reduced) decap.

Generated with [Claude Code](https://claude.com/claude-code)