### PR TITLE
offload: tc-evpn-replicate root H.Encaps from a bare frame (DP4)

### DIFF
--- a/book/src/ch-02-33-bgp-evpn-assisted-replication.md
+++ b/book/src/ch-02-33-bgp-evpn-assisted-replication.md
@@ -128,8 +128,8 @@ VXLAN flood list — BUM rides the tree, not a zero-MAC FDB row.
 The stock kernel cannot forward an SR replication tree (next section), so
 SR P2MP is programmed through a dedicated **eBPF TC/clsact** dataplane
 (`offload/tc-evpn-replicate`). The BGP **control plane is complete**
-(signalling, import, and the replication-segment computation), and **both**
-SRv6 datapath halves are **implemented and lab-validated** on veth topologies:
+(signalling, import, and the replication-segment computation), and the **whole
+SRv6 datapath is implemented and lab-validated** on veth topologies:
 
 - **`End.Replicate`** (root/bud): a clsact-ingress classifier clones each BUM
   frame once per leaf, rewriting the outer IPv6 destination to that leaf's SID —
@@ -137,10 +137,13 @@ SRv6 datapath halves are **implemented and lab-validated** on veth topologies:
 - **`End.DT2M`** (leaf): the classifier strips the outer encapsulation off a
   frame addressed to its local `End.DT2M` SID and redirects the inner Ethernet
   frame into a bridge port, so the bridge floods it to the local attachment
-  circuits — the L2 flood the kernel has no SID behavior for.
+  circuits — the L2 flood the kernel has no SID behavior for;
+- **root `H.Encaps`** (ingress PE): a clsact-egress classifier on the overlay
+  port wraps a *bare* BUM frame in the SRv6 encapsulation (outer IPv6, src = the
+  root SID) and fans it out, one copy per leaf — the header push + per-copy
+  rewrite for an L2 payload that the kernel cannot express.
 
-The remaining gaps are the root `H.Encaps`-from-bare-frame path and the
-SRH-present (non-reduced) encapsulation.
+The remaining gap is SRH-present (non-reduced) encapsulation.
 
 ## What the Linux kernel can and cannot do
 

--- a/docs/design/bgp-evpn-sr-p2mp-replication-plan.md
+++ b/docs/design/bgp-evpn-sr-p2mp-replication-plan.md
@@ -98,11 +98,11 @@ SR P2MP policy at the Root.
 ## Phasing & status (updated 2026-06-18)
 
 Branch `bgp-evpn-tunnel-replication`. The **control plane is complete and
-merged**, and **both** SRv6 datapath halves are **implemented and lab-validated**:
-`End.Replicate` (clone + per-branch outer-DA rewrite) at the root/bud, and the
-leaf `End.DT2M` (decap the outer encap, flood the inner frame into the bridge).
-The remaining gaps are the root H.Encaps-from-bare-frame path and SRH-present
-(non-reduced) decap.
+merged**, and the **whole SRv6 datapath is implemented and lab-validated**:
+`End.Replicate` (clone + per-branch outer-DA rewrite) at the root/bud, the leaf
+`End.DT2M` (decap the outer encap, flood the inner frame into the bridge), and
+the root `H.Encaps` (wrap a bare BUM frame + fan out per leaf). The only
+remaining gap is SRH-present (non-reduced) encap/decap.
 
 | Slice | What landed / planned | Status |
 | --- | --- | --- |
@@ -116,7 +116,8 @@ The remaining gaps are the root H.Encaps-from-bare-frame path and SRH-present
 | DP2 — supervisor | spawn/refcount the `tc-evpn-replicate` loader child (pattern: `bfd/reflector.rs`), feed it over stdin line-IPC from the `ReplSeg` consumer | ✅ merged #1518 |
 | DP3a — BPF map + loader | `REPL_SEG` map + loader `repl-add`/`repl-del` population (clone+rewrite logic still a no-op) | ✅ merged #1520 |
 | DP3b — `End.Replicate` | clsact-ingress clone loop: match outer DA against `REPL_LOCAL_SID`, decrement Hop Limit (guard ≤1), `clone_redirect` one copy per leaf with outer DA rewritten, drop original. Lab-validated (`scripts/veth-replicate-test.sh`) | ✅ merged #1563 |
-| DP3c — leaf `End.DT2M` | match the local `End.DT2M` SID (`DT2M_SID` map) → slide the inner frame to the front (`adjust_room` can't strip a full L3), `change_tail`-trim, `bpf_redirect` into a bridge port's ingress → native flood. Lab-validated (`scripts/veth-dt2m-test.sh`) | ✅ this slice |
+| DP3c — leaf `End.DT2M` | match the local `End.DT2M` SID (`DT2M_SID` map) → slide the inner frame to the front (`adjust_room` can't strip a full L3), `change_tail`-trim, `bpf_redirect` into a bridge port's ingress → native flood. Lab-validated (`scripts/veth-dt2m-test.sh`) | ✅ merged #1567 |
+| DP4 — root `H.Encaps` | `tc_evpn_encap` (clsact egress on the overlay port): grow + slide a bare BUM frame to open headroom, write the outer link Ethernet + IPv6 (NH=Ethernet, src=root SID, from `ENCAP_CFG`), `clone_redirect` one copy per leaf out the underlay. Lab-validated (`scripts/veth-encap-test.sh`) | ✅ this slice |
 
 ## Where the pieces live
 
@@ -139,22 +140,24 @@ The remaining gaps are the root H.Encaps-from-bare-frame path and SRH-present
   AR-REPLICATOR eBPF/VPP dataplane effort is tracked in
   `bgp-evpn-ar-replicator-dataplane-plan.md` (same offload approach).
 
-## eBPF dataplane design (DP2/DP3)
+## eBPF dataplane design (DP2/DP3/DP4)
 
 - New `offload/tc-evpn-replicate/` crate mirrors `offload/xdp-bfd-echo/` but a
-  TC/clsact `#[classifier]`. One ingress classifier serves both roles, keyed by
-  which map the outer IPv6 DA hits: **root/bud** match the Replication-SID →
-  clone + per-branch outer-DA rewrite (`End.Replicate`); **leaf** match the
-  `End.DT2M` SID → decap + bridge flood. A root that must `H.Encaps` a bare BUM
-  frame (rather than re-replicate an already-encapsulated one) is a later
-  refinement.
+  TC/clsact `#[classifier]`. Two classifiers: `tc_evpn_replicate` (clsact
+  **ingress**) serves the SID-matched roles — **root/bud** match the
+  Replication-SID → clone + per-branch outer-DA rewrite (`End.Replicate`),
+  **leaf** match the `End.DT2M` SID → decap + bridge flood; `tc_evpn_encap`
+  (clsact **egress** on the overlay port) wraps a bare BUM frame and fans it out
+  (root `H.Encaps`).
 - **Maps** (loader-filled): `REPL_SEG` (per-VNI segment: tree-id, leaf SIDs);
   `REPL_LOCAL_SID` (local replication SID → VNI, demuxes a packet to its segment
   by outer IPv6 DA — derived here from each segment's root SID); `DT2M_SID`
   (local `End.DT2M` SID → VNI, leaf role); `CONFIG[0]` (clone egress ifindex,
   `--redirect-iface`), `CONFIG[1]` (bridge port the leaf floods into,
-  `--bridge-iface`). Fed from `ReplSeg`/`leaf-add` over a stdin line protocol; a
-  supervisor spawns/refcounts the loader per ifindex.
+  `--bridge-iface`); `ENCAP_CFG` (root `H.Encaps`: VNI, underlay ifindex, root
+  SID, outer MAC header — `--encap`). Fed from `ReplSeg`/`leaf-add`/`encap-cfg`
+  over a stdin line protocol; a supervisor spawns/refcounts the loader per
+  ifindex.
 - **`End.Replicate` datapath:** on an inbound IPv6 frame whose outer DA hits
   `REPL_LOCAL_SID`, decrement the outer Hop Limit (drop if ≤1), then for each
   leaf rewrite the outer DA and `clone_redirect` a copy out `CONFIG[0]`; drop
@@ -171,16 +174,24 @@ The remaining gaps are the root H.Encaps-from-bare-frame path and SRH-present
   head-removal workaround. Redirecting to the bridge *master* would only send
   the frame up the host stack, so a dedicated bridge port is the inject point.
   Validated by `scripts/veth-dt2m-test.sh`.
-- Both use `bpf_skb_store_bytes`/`load_bytes` (`TcContext::store`/`load`), never
-  a raw `data` pointer, so nothing is held across the `clone_redirect` /
+- **Root `H.Encaps` datapath:** on a bare BUM frame egressing the overlay port,
+  grow the buffer (`bpf_skb_change_tail`) and slide the frame right to open
+  `ENCAP_OVERHEAD` (54) bytes of headroom, write the outer link Ethernet + IPv6
+  (NH = Ethernet/143, src = root SID from `ENCAP_CFG`), then per leaf set the
+  outer DA and `clone_redirect` a copy out the underlay; drop the bare original.
+  Validated by `scripts/veth-encap-test.sh`.
+- All use `bpf_skb_store_bytes`/`load_bytes` (`TcContext::store`/`load`), never a
+  raw `data` pointer, so nothing is held across the `clone_redirect` /
   `change_tail` calls that invalidate packet pointers.
-- **Caveats:** `bpf_clone_redirect`/`bpf_redirect` are TC-only; the root
-  H.Encaps-from-bare-frame path and SRH-present (non-reduced) decap + any SRH
-  segment-list rewrite are still to come; `change_tail`'s minimum length is the
-  stale transport offset, so a sub-`DT2M_STRIP`-byte (runt) inner frame can't be
-  trimmed and is dropped — real ≥60-byte Ethernet frames trim fine; veth needs
-  GRO off (a GRO'd skb presents as GSO and blocks shrink helpers); aya is pulled
-  from git unpinned.
+- **Caveats:** `bpf_clone_redirect`/`bpf_redirect` are TC-only; SRH-present
+  (non-reduced) encap/decap + any SRH segment-list rewrite are still to come;
+  `change_tail`'s minimum length is the stale transport offset, so a
+  sub-`DT2M_STRIP`-byte (runt) inner frame can't be trimmed and is dropped — real
+  ≥60-byte Ethernet frames trim fine; the `H.Encaps` lab must keep the overlay
+  port off the qdisc-bypass path (`PACKET_QDISC_BYPASS` skips egress clsact) and
+  tolerate spurious `ENOBUFS` (the frame still egresses); veth needs GRO off (a
+  GRO'd skb presents as GSO and blocks shrink helpers); aya is pulled from git
+  unpinned.
 
 ## Gotchas / build notes
 
@@ -202,6 +213,6 @@ The remaining gaps are the root H.Encaps-from-bare-frame path and SRH-present
   already clones + rewrites per branch, so a bud is forwarding-capable; the
   remaining piece is the control plane computing a multi-tier tree (only the
   degenerate root→leaves tree is built today).
-- Root `H.Encaps`-from-bare-frame (encapsulate a BUM frame arriving bare from
-  the local bridge, vs. re-replicating an already-encapsulated one) and
-  SRH-present (non-reduced) `End.DT2M` decap + SRH segment-list rewrite.
+- SRH-present (non-reduced) encap/decap: today only the reduced SRv6 encap
+  (single SID in the DA, no SRH) is handled; an SRH-present frame needs the
+  variable SRH length parsed and the active segment-list entry rewritten.

--- a/offload/tc-evpn-replicate/README.md
+++ b/offload/tc-evpn-replicate/README.md
@@ -14,28 +14,36 @@ a different rewritten header*. The TC layer can express that with
 clone per-copy. So this is a `#[classifier]` program on `clsact`, unlike the
 sibling [`xdp-bfd-echo`](../xdp-bfd-echo) offload.
 
-Roles (all clsact-ingress, dispatched by which map the outer IPv6 DA hits):
-- **root / bud** — **implemented**: match the local Replication-SID, then for
-  each downstream leaf clone the packet and rewrite the outer DA to that leaf's
-  SID (`End.Replicate`);
-- **leaf** — **implemented**: match the local `End.DT2M` SID, strip the outer
-  encap (link Ethernet + outer IPv6), and redirect the inner frame to a bridge
-  port for native BUM flooding.
+Roles:
+- **root / bud** (clsact ingress) — **implemented**: match the local
+  Replication-SID, then for each downstream leaf clone the packet and rewrite
+  the outer DA to that leaf's SID (`End.Replicate`);
+- **leaf** (clsact ingress) — **implemented**: match the local `End.DT2M` SID,
+  strip the outer encap (link Ethernet + outer IPv6), and redirect the inner
+  frame to a bridge port for native BUM flooding;
+- **root ingress** (clsact egress on the overlay port) — **implemented**: wrap a
+  *bare* BUM frame in a reduced SRv6 encap (root `H.Encaps`) and fan it out, one
+  copy per leaf.
 
-The branch/leaf table is a BPF map the loader fills from the BGP control plane
-(`ReplSeg`, fed by `EvpnFloodState::replication_leaves`).
+The ingress classifier (`tc_evpn_replicate`) dispatches `End.Replicate` vs
+`End.DT2M` by which map the inbound outer IPv6 DA hits; the egress classifier
+(`tc_evpn_encap`) handles the bare-frame `H.Encaps`. The leaf set is a BPF map
+the loader fills from the BGP control plane (`ReplSeg`, fed by
+`EvpnFloodState::replication_leaves`).
 
 ## Status
 
-**`End.Replicate` + leaf `End.DT2M` both work.** The classifier reads four maps
-the loader fills:
+**`End.Replicate`, leaf `End.DT2M`, and root `H.Encaps` all work.** The loader
+fills these maps:
 
 - `REPL_SEG` — per-VNI replication segment (tree + leaf SIDs);
 - `REPL_LOCAL_SID` — local replication SID → VNI, for demuxing an inbound packet
   to its segment by outer IPv6 DA (derived from each segment's root SID);
 - `DT2M_SID` — local `End.DT2M` SID → VNI for the leaf role;
 - `CONFIG` — index 0 = `End.Replicate` clone egress ifindex; index 1 = the
-  bridge port a leaf floods decapped frames into.
+  bridge port a leaf floods decapped frames into;
+- `ENCAP_CFG` — root `H.Encaps` config: VNI, underlay ifindex, root SID, outer
+  MAC header (`--encap` mode).
 
 `End.Replicate`: on an inbound IPv6 frame whose DA is a known replication SID,
 decrement the outer Hop Limit (drop anything ≤ 1) and emit one clone per leaf
@@ -47,15 +55,20 @@ the skb (`bpf_skb_adjust_room` can't strip a full outer L3), trim the tail with
 `bpf_skb_change_tail`, and `bpf_redirect` it into a bridge port's ingress so the
 bridge floods it to the local ACs.
 
-Both validated end-to-end on veth pairs:
+`H.Encaps`: on a bare BUM frame egressing the overlay port, grow the buffer
+(`bpf_skb_change_tail`) and slide the frame right to open headroom, write the
+outer link Ethernet + IPv6 (Next Header = Ethernet, src = root SID), then
+`clone_redirect` one copy per leaf with the outer DA set, out the underlay.
+
+All three validated end-to-end on veth topologies:
 
 ```sh
 sudo bash offload/tc-evpn-replicate/scripts/veth-replicate-test.sh   # End.Replicate
 sudo bash offload/tc-evpn-replicate/scripts/veth-dt2m-test.sh        # leaf End.DT2M
+sudo bash offload/tc-evpn-replicate/scripts/veth-encap-test.sh       # root H.Encaps
 ```
 
-The **root H.Encaps-from-bare-frame** path and **SRH-present** decap (non-reduced
-encap) are follow-up slices.
+**SRH-present** (non-reduced) encap/decap is the remaining follow-up.
 
 ## Build / run
 

--- a/offload/tc-evpn-replicate/ebpf/src/main.rs
+++ b/offload/tc-evpn-replicate/ebpf/src/main.rs
@@ -40,6 +40,20 @@
 //! the reduced encap, no SRH, is handled here; the SRH-present form is a
 //! follow-up.)
 //!
+//! ## Root `H.Encaps` from a bare frame — `tc_evpn_encap` (clsact egress)
+//!
+//! At the ingress PE a BUM frame arrives *bare* (just `[inner Ethernet][...]`)
+//! from the local bridge — there is no outer SID to match on, so this is a
+//! separate classifier attached at the overlay bridge-port's **egress**. For
+//! every bare frame it prepends a reduced SRv6 encap (link Ethernet + outer
+//! IPv6, Next Header = Ethernet/143, src = the root SID), then fans out exactly
+//! like `End.Replicate`: one `clone_redirect` per leaf with the outer DA set to
+//! that leaf's SID, out the underlay. `bpf_skb_adjust_room` can't prepend a full
+//! outer L2+L3 in front of the frame, so — mirroring the leaf decap — the buffer
+//! is grown at the tail (`bpf_skb_change_tail`) and the bare frame slid right to
+//! open 54 bytes of headroom. Config (root SID, VNI, underlay ifindex, outer MAC
+//! header) comes from [`ENCAP_CFG`]; the leaf set is `REPL_SEG[vni]`.
+//!
 //! Packet access goes through `bpf_skb_store_bytes` / `bpf_skb_load_bytes`
 //! (`TcContext::store` / `::load`), never a raw `data` pointer, so nothing is
 //! held across the `clone_redirect` / `change_tail` calls that invalidate
@@ -93,9 +107,12 @@ const NH_ETHERNET: u8 = 143;
 /// Ethernet header + the outer IPv6 header. What follows is the inner Ethernet
 /// BUM frame, which becomes the new link frame.
 const DT2M_STRIP: usize = ETH_HLEN + IP6_HLEN; // 54
-/// Upper bound on the inner frame length copied to the front during decap (a
-/// jumbo-free Ethernet payload fits well under this). The verifier needs a
-/// constant loop bound; a frame longer than this is left for the stack.
+/// Bytes of reduced SRv6 encap the root prepends to a bare BUM frame: a new link
+/// Ethernet header + the outer IPv6 header (mirror of [`DT2M_STRIP`]).
+const ENCAP_OVERHEAD: usize = ETH_HLEN + IP6_HLEN; // 54
+/// Upper bound on the inner frame length copied during decap/encap (a jumbo-free
+/// Ethernet payload fits well under this). The verifier needs a constant loop
+/// bound; a frame longer than this is left for the stack.
 const MAX_INNER: usize = 2048;
 
 /// One VNI's SR P2MP replication segment (RFC 9524), keyed by VNI in
@@ -135,6 +152,28 @@ static DT2M_SID: HashMap<[u8; 16], u32> = HashMap::with_max_entries(256, 0);
 /// `[1]` = leaf `End.DT2M` bridge-flood target. 0 = unset (role disabled).
 #[map]
 static CONFIG: Array<u32> = Array::with_max_entries(2, 0);
+
+/// Root `H.Encaps` config (single entry), filled by the loader for the
+/// `tc_evpn_encap` role. `#[repr(C)]` with the `u32`s first so it is padding-free
+/// and matches the loader's `aya::Pod` mirror byte-for-byte.
+#[repr(C)]
+#[derive(Clone, Copy)]
+pub struct EncapCfg {
+    /// VNI whose leaf set (`REPL_SEG[vni]`) the bare frame fans out to.
+    pub vni: u32,
+    /// Underlay ifindex the encapsulated copies are `clone_redirect`ed out of.
+    /// 0 = the encap role is not configured.
+    pub underlay_ifindex: u32,
+    /// Outer IPv6 source address (this PE's root SID).
+    pub root_sid: [u8; 16],
+    /// Prebuilt outer link Ethernet header (dst MAC | src MAC | 0x86DD).
+    pub link_eth: [u8; ETH_HLEN],
+    pub _pad: [u8; 2],
+}
+
+/// Single-entry root `H.Encaps` config the loader fills from `encap-cfg`.
+#[map]
+static ENCAP_CFG: Array<EncapCfg> = Array::with_max_entries(1, 0);
 
 #[classifier]
 pub fn tc_evpn_replicate(ctx: TcContext) -> i32 {
@@ -280,6 +319,87 @@ fn end_dt2m(ctx: &TcContext) -> Result<i32, ()> {
     // Flood into the bridge (ingress on a bridge port): the bridge replicates
     // the inner BUM frame to the other local attachment circuits.
     Ok(unsafe { bpf_redirect(bridge, BPF_F_INGRESS) } as i32)
+}
+
+#[classifier]
+pub fn tc_evpn_encap(ctx: TcContext) -> i32 {
+    match try_encap(&ctx) {
+        Ok(action) => action,
+        Err(()) => ACT_PIPE,
+    }
+}
+
+/// Root `H.Encaps`: wrap a bare BUM Ethernet frame in a reduced SRv6 encap and
+/// fan it out, one `clone_redirect` per leaf with the outer DA set to that
+/// leaf's SID.
+fn try_encap(ctx: &TcContext) -> Result<i32, ()> {
+    let Some(cfg) = ENCAP_CFG.get(0) else {
+        return Ok(ACT_PIPE);
+    };
+    if cfg.underlay_ifindex == 0 {
+        return Ok(ACT_PIPE); // encap role not configured
+    }
+    let Some(seg) = (unsafe { REPL_SEG.get(&cfg.vni) }) else {
+        return Ok(ACT_PIPE); // no leaf set yet
+    };
+    let n_leaves = seg.n_leaves;
+    if n_leaves == 0 {
+        return Ok(ACT_PIPE);
+    }
+
+    // The bare BUM frame currently being transmitted out the overlay port.
+    let inner_total = ctx.len() as usize;
+    if inner_total < ETH_HLEN || inner_total > MAX_INNER {
+        return Ok(ACT_PIPE);
+    }
+
+    // Open ENCAP_OVERHEAD bytes of headroom at the front: grow the buffer at the
+    // tail, then slide the bare frame right. (`bpf_skb_adjust_room` can't prepend
+    // a full outer L2+L3.) Descending copy so a not-yet-read lower byte is never
+    // clobbered by an earlier (higher) write.
+    let new_total = inner_total + ENCAP_OVERHEAD;
+    if unsafe { bpf_skb_change_tail(ctx.skb.skb, new_total as u32, 0) } != 0 {
+        return Ok(ACT_PIPE); // can't grow (MTU) — leave the frame for the stack
+    }
+    let mut k = 0usize;
+    while k < inner_total && k < MAX_INNER {
+        let src = inner_total - 1 - k;
+        let b: u8 = ctx.load(src).map_err(|_| ())?;
+        ctx.store(ENCAP_OVERHEAD + src, &b, 0).map_err(|_| ())?;
+        k += 1;
+    }
+    if k < inner_total {
+        return Ok(ACT_SHOT); // unreachable (inner_total <= MAX_INNER) — be safe
+    }
+
+    // Outer link Ethernet header (dst | src | 0x86DD), prebuilt by the loader.
+    ctx.store(0, &cfg.link_eth, 0).map_err(|_| ())?;
+
+    // Outer IPv6 header: version 6, payload length = the inner frame, Next Header
+    // = Ethernet(143), Hop Limit 64, src = root SID. The DA is set per leaf below.
+    let mut ip6 = [0u8; IP6_HLEN];
+    ip6[0] = 0x60;
+    ip6[4] = (inner_total >> 8) as u8;
+    ip6[5] = inner_total as u8;
+    ip6[6] = NH_ETHERNET;
+    ip6[7] = 64;
+    ip6[8..24].copy_from_slice(&cfg.root_sid);
+    ctx.store(IP6_OFF, &ip6, 0).map_err(|_| ())?;
+
+    // Fan out: per leaf, set the outer DA and clone a copy out the underlay.
+    for i in 0..MAX_LEAVES {
+        if i as u32 >= n_leaves {
+            break;
+        }
+        let leaf = seg.leaves[i];
+        if ctx.store(IP6_DST_OFF, &leaf, 0).is_err() {
+            break;
+        }
+        let _ = ctx.clone_redirect(cfg.underlay_ifindex, 0);
+    }
+
+    // Drop the bare original — the encapsulated copies carry it onward.
+    Ok(ACT_SHOT)
 }
 
 #[cfg(not(test))]

--- a/offload/tc-evpn-replicate/loader/src/main.rs
+++ b/offload/tc-evpn-replicate/loader/src/main.rs
@@ -14,7 +14,9 @@
 //!   * `DT2M_SID`       — local `End.DT2M` SID -> VNI for the leaf role;
 //!   * `CONFIG`         — index 0 = egress ifindex the replicated copies leave
 //!     on (`--redirect-iface`); index 1 = bridge ifindex a leaf floods decapped
-//!     frames into (`--bridge-iface`).
+//!     frames into (`--bridge-iface`);
+//!   * `ENCAP_CFG`      — root `H.Encaps` config (`--encap` mode): VNI, underlay
+//!     ifindex, root SID, outer MAC header.
 //! Runs until Ctrl-C / SIGTERM.
 
 use std::collections::HashMap as StdHashMap;
@@ -31,6 +33,7 @@ use tokio::signal;
 
 /// Must match `tc-evpn-replicate-ebpf`'s `MAX_LEAVES`.
 const MAX_LEAVES: usize = 32;
+const ETH_HLEN: usize = 14;
 const REPL_FLAG_SRV6: u32 = 1 << 0;
 const REPL_FLAG_ROOT_V4: u32 = 1 << 1;
 
@@ -53,8 +56,25 @@ struct ReplSeg {
 // 1-aligned arrays totalling a multiple of 4), so every byte is initialized.
 unsafe impl aya::Pod for ReplSeg {}
 
+/// Userspace mirror of the eBPF `EncapCfg` map value (root `H.Encaps` role).
+/// Same padding-free `#[repr(C)]` layout (`u32`s first, then byte arrays).
+#[repr(C)]
+#[derive(Clone, Copy)]
+struct EncapCfg {
+    vni: u32,
+    underlay_ifindex: u32,
+    root_sid: [u8; 16],
+    link_eth: [u8; ETH_HLEN],
+    _pad: [u8; 2],
+}
+
+// SAFETY: `#[repr(C)]`, integer/byte-array fields only, no padding (two `u32`s
+// then 1-aligned arrays totalling a multiple of 4) — every byte is initialized.
+unsafe impl aya::Pod for EncapCfg {}
+
 type ReplMap = AyaHashMap<MapData, u32, ReplSeg>;
 type SidIndex = AyaHashMap<MapData, [u8; 16], u32>;
+type EncapMap = AyaArray<MapData, EncapCfg>;
 
 /// The maps the stdin line protocol programs, threaded together so a `repl-add`
 /// keeps the per-VNI segment ([`ReplMap`]) and the SID demux index
@@ -67,6 +87,8 @@ struct Maps {
     /// VNI -> its `End.DT2M` SID, so `leaf-del <vni>` can evict the SID-keyed
     /// `dt2m` map (which has no VNI to look the key up by).
     leaf_sids: StdHashMap<u32, [u8; 16]>,
+    /// Single-entry root `H.Encaps` config (`encap-cfg`).
+    encap: EncapMap,
 }
 
 #[derive(Debug, Parser)]
@@ -87,6 +109,11 @@ struct Opt {
     /// disables the leaf role (the datapath passes such frames to the stack).
     #[clap(short, long)]
     bridge_iface: Option<String>,
+    /// Root `H.Encaps` mode: attach the `tc_evpn_encap` classifier at `--iface`
+    /// *egress* (the overlay bridge port) instead of the ingress replicator, so
+    /// every bare BUM frame is encapsulated + fanned out per `encap-cfg`.
+    #[clap(short, long)]
+    encap: bool,
 }
 
 #[tokio::main]
@@ -96,6 +123,7 @@ async fn main() -> anyhow::Result<()> {
         direction,
         redirect_iface,
         bridge_iface,
+        encap,
     } = Opt::parse();
     env_logger::init();
 
@@ -138,14 +166,21 @@ async fn main() -> anyhow::Result<()> {
         debug!("qdisc_add_clsact({iface}): {e} (already present?)");
     }
 
-    let attach = match direction.as_str() {
-        "egress" => TcAttachType::Egress,
-        _ => TcAttachType::Ingress,
+    // Encap mode attaches the root H.Encaps classifier at egress; otherwise the
+    // ingress replicate/decap classifier at the requested direction.
+    let (prog_name, attach) = if encap {
+        ("tc_evpn_encap", TcAttachType::Egress)
+    } else {
+        let dir = match direction.as_str() {
+            "egress" => TcAttachType::Egress,
+            _ => TcAttachType::Ingress,
+        };
+        ("tc_evpn_replicate", dir)
     };
 
     let program: &mut SchedClassifier = ebpf
-        .program_mut("tc_evpn_replicate")
-        .context("classifier 'tc_evpn_replicate' not found in object")?
+        .program_mut(prog_name)
+        .with_context(|| format!("classifier {prog_name:?} not found in object"))?
         .try_into()?;
     program.load()?;
     program.attach(&iface, attach)?;
@@ -177,23 +212,32 @@ async fn main() -> anyhow::Result<()> {
                 .context("map 'DT2M_SID' not found in object")?,
         )?,
         leaf_sids: StdHashMap::new(),
+        encap: AyaArray::try_from(
+            ebpf.take_map("ENCAP_CFG")
+                .context("map 'ENCAP_CFG' not found in object")?,
+        )?,
     };
 
-    let bridge_desc = match bridge_iface.as_deref() {
-        Some(name) => format!("{name} (ifindex {bridge_ifindex})"),
-        None => "disabled".to_string(),
-    };
-    info!(
-        "tc_evpn_replicate attached to {iface} ({direction}); copies -> {redirect} \
-         (ifindex {redirect_ifindex}); leaf flood -> {bridge_desc}; reading commands on stdin"
-    );
+    if encap {
+        info!("{prog_name} attached to {iface} (egress); awaiting encap-cfg + repl-add on stdin");
+    } else {
+        let bridge_desc = match bridge_iface.as_deref() {
+            Some(name) => format!("{name} (ifindex {bridge_ifindex})"),
+            None => "disabled".to_string(),
+        };
+        info!(
+            "{prog_name} attached to {iface} ({direction}); copies -> {redirect} \
+             (ifindex {redirect_ifindex}); leaf flood -> {bridge_desc}; reading commands on stdin"
+        );
+    }
 
-    // Replication segments are fed by the zebra-rs supervisor over a stdin
-    // line protocol (one command per line):
+    // The control plane feeds map updates over a stdin line protocol (one
+    // command per line):
     //   repl-add <vni> <tree-id> <srv6:0|1> <root-ip> <leaf-ip>...
     //   repl-del <vni>
     //   leaf-add <vni> <dt2m-sid>        (this node's End.DT2M SID for the VNI)
     //   leaf-del <vni>
+    //   encap-cfg <vni> <underlay-ifname> <root-sid> <eth-dst-mac> <eth-src-mac>
     let mut lines = tokio::io::BufReader::new(tokio::io::stdin()).lines();
     loop {
         tokio::select! {
@@ -296,9 +340,62 @@ fn handle_command(line: &str, maps: &mut Maps) {
             }
             None => warn!("malformed leaf-del: {line:?}"),
         },
+        Some("encap-cfg") => match parse_encap(&mut it) {
+            Some(cfg) => {
+                if let Err(e) = maps.encap.set(0, cfg, 0) {
+                    warn!("ENCAP_CFG set failed: {e}");
+                } else {
+                    info!(
+                        "encap-cfg vni={} underlay-ifindex={}",
+                        cfg.vni, cfg.underlay_ifindex
+                    );
+                }
+            }
+            None => warn!("malformed encap-cfg: {line:?}"),
+        },
         Some(other) => warn!("unknown command: {other:?}"),
         None => {}
     }
+}
+
+/// Parse a MAC address `aa:bb:cc:dd:ee:ff` into 6 bytes.
+fn parse_mac(s: &str) -> Option<[u8; 6]> {
+    let mut out = [0u8; 6];
+    let mut n = 0usize;
+    for part in s.split(':') {
+        if n >= 6 {
+            return None;
+        }
+        out[n] = u8::from_str_radix(part, 16).ok()?;
+        n += 1;
+    }
+    (n == 6).then_some(out)
+}
+
+/// Parse an `encap-cfg <vni> <underlay-ifname> <root-sid> <eth-dst> <eth-src>`
+/// body (the verb already consumed) into the root `H.Encaps` config: the root
+/// SID must be IPv6; the underlay must resolve to an ifindex.
+fn parse_encap<'a>(it: &mut impl Iterator<Item = &'a str>) -> Option<EncapCfg> {
+    let vni: u32 = it.next()?.parse().ok()?;
+    let underlay_ifindex = if_nametoindex(it.next()?).ok()?;
+    let root_sid = match it.next()?.parse::<IpAddr>().ok()? {
+        IpAddr::V6(a) => a.octets(),
+        IpAddr::V4(_) => return None,
+    };
+    let dst = parse_mac(it.next()?)?;
+    let src = parse_mac(it.next()?)?;
+    let mut link_eth = [0u8; ETH_HLEN];
+    link_eth[..6].copy_from_slice(&dst);
+    link_eth[6..12].copy_from_slice(&src);
+    link_eth[12] = 0x86; // EtherType IPv6 (0x86DD)
+    link_eth[13] = 0xdd;
+    Some(EncapCfg {
+        vni,
+        underlay_ifindex,
+        root_sid,
+        link_eth,
+        _pad: [0; 2],
+    })
 }
 
 /// Parse a `leaf-add <vni> <dt2m-sid>` body (the verb already consumed) into the

--- a/offload/tc-evpn-replicate/scripts/veth-encap-test.sh
+++ b/offload/tc-evpn-replicate/scripts/veth-encap-test.sh
@@ -1,0 +1,166 @@
+#!/usr/bin/env bash
+#
+# End-to-end load test for the root H.Encaps-from-bare-frame datapath
+# (RFC 9524 SR replication segment, ingress PE).
+#
+# What it proves: a BUM frame arriving *bare* (just an inner Ethernet frame)
+# from the local bridge is wrapped in a reduced SRv6 encapsulation (link
+# Ethernet + outer IPv6, Next Header = Ethernet, src = the root SID) and fanned
+# out — one copy per leaf, each with the outer IPv6 destination set to that
+# leaf's SID. The stock kernel has no way to do this header push + per-copy
+# rewrite for an L2 payload.
+#
+# Topology — the overlay port + underlay egress live in their own namespace so
+# the host's own multicast (mDNS, etc.) can't leak onto the overlay port and get
+# encapsulated too; only the injected BUM frame egresses enc0:
+#
+#   ns evpnencap-ns                                    root ns
+#   ┌────────────────────────────────────────────┐
+#   │ enc1 ── veth ── enc0 [clsact egress:         │
+#   │ (carrier)        |   tc_evpn_encap]          │
+#   │                  |  AF_PACKET send bare ARP  │
+#   │                  v  encap + clone per leaf   │
+#   │           ul0 ───────────── veth ───────────────── ul1 [capture inbound]
+#   └────────────────────────────────────────────┘
+#
+# Run as root:
+#   sudo bash offload/tc-evpn-replicate/scripts/veth-encap-test.sh
+set -u
+
+NS=evpnencap-ns
+E0=evpnenc0          # overlay-port end (in ns) — tc_evpn_encap attaches (egress)
+E1=evpnenc1         # its peer (in ns, carrier only)
+U0=evpnul0           # underlay end (in ns) — encapsulated copies leave here
+U1=evpnul1          # underlay peer (root ns) — copies captured here
+
+VNI=100
+ROOT_SID="2001:db8:aaaa::1"   # this PE's root SID (outer IPv6 source)
+L1="2001:db8:0:1::100"        # leaf 1 SID
+L2="2001:db8:0:2::100"        # leaf 2 SID
+INNER_SRC_MAC=02:00:00:00:0b:01
+
+RUNTIME=12
+CAP_SECS=7
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+BIN="$SCRIPT_DIR/../target/release/tc-evpn-replicate"
+LOG=/tmp/evpnencap_loader.log
+CAPOUT=/tmp/evpnencap_tcpdump.out
+CAPERR=/tmp/evpnencap_tcpdump.err
+
+LOADER_PID=""
+cleanup() {
+    [ -n "$LOADER_PID" ] && kill "$LOADER_PID" 2>/dev/null
+    sleep 0.3
+    ip netns del "$NS" 2>/dev/null
+    ip link del "$U1" 2>/dev/null   # root-ns end (also removes ul0 if still here)
+    ip link del "$E0" 2>/dev/null
+}
+trap cleanup EXIT
+
+if [ "$(id -u)" -ne 0 ]; then echo "ERROR: run as root (sudo)"; exit 1; fi
+if [ ! -x "$BIN" ]; then
+    echo "ERROR: binary not found: $BIN"
+    echo "       build it first:  (cd $SCRIPT_DIR/.. && cargo build --release)"
+    exit 1
+fi
+
+echo "== 1. fresh namespace + veth pairs =="
+cleanup 2>/dev/null
+ip netns add "$NS"
+ip link add "$E0" type veth peer name "$E1"
+ip link add "$U0" type veth peer name "$U1"
+ip link set "$E0" netns "$NS"; ip link set "$E1" netns "$NS"
+ip link set "$U0" netns "$NS"   # U1 stays in the root ns for capture
+ip netns exec "$NS" ip link set lo up
+for d in "$E0" "$E1" "$U0"; do
+    # Disable IPv6 autoconf so the veths don't emit their own MLD/RS frames
+    # (which would egress the overlay port and get encapsulated as noise); the
+    # AF_PACKET inject + clone_redirect datapath is unaffected.
+    ip netns exec "$NS" sysctl -qw "net.ipv6.conf.$d.disable_ipv6=1" 2>/dev/null || true
+    ip netns exec "$NS" ip link set "$d" up
+    ip netns exec "$NS" ethtool -K "$d" gro off gso off tso off lro off 2>/dev/null || true
+done
+ip link set "$U1" up
+ethtool -K "$U1" gro off gso off tso off lro off 2>/dev/null || true
+MAC_U0=$(ip netns exec "$NS" cat "/sys/class/net/$U0/address")
+MAC_U1=$(cat "/sys/class/net/$U1/address")
+echo "   ns $NS: overlay port $E0, underlay $U0 ($MAC_U0)  ->  root ns: $U1 ($MAC_U1)"
+
+echo "== 2. attach root encap on $E0 (clsact egress), copies -> $U0 =="
+# encap-cfg sets the outer src=root SID + underlay + outer MACs; repl-add fills
+# the leaf set (REPL_SEG[vni]) the encap fans out to.
+( printf 'encap-cfg %s %s %s %s %s\n' "$VNI" "$U0" "$ROOT_SID" "$MAC_U1" "$MAC_U0"
+  printf 'repl-add %s %s 1 %s %s %s\n'  "$VNI" "$VNI" "$ROOT_SID" "$L1" "$L2"
+  sleep "$RUNTIME" ) \
+    | ip netns exec "$NS" env RUST_LOG=info "$BIN" -i "$E0" --encap >"$LOG" 2>&1 &
+LOADER_PID=$!
+sleep 2
+if ! kill -0 "$LOADER_PID" 2>/dev/null; then
+    echo "ERROR: loader exited early:"; cat "$LOG"; exit 1
+fi
+grep -iE 'attached|encap-cfg|repl-add' "$LOG" | sed 's/^/   /'
+
+echo "== 3. capture inbound on $U1, then send 3 bare BUM frames out $E0 =="
+timeout "$CAP_SECS" tcpdump -lnei "$U1" -Q in 'ip6' >"$CAPOUT" 2>"$CAPERR" &
+TCPDUMP_PID=$!
+sleep 1
+INNER_SRC_MAC="$INNER_SRC_MAC" IFACE="$E0" \
+    ip netns exec "$NS" python3 - <<'PY'
+import errno, os, socket, time
+
+def mac(s): return bytes(int(b, 16) for b in s.split(":"))
+
+iface = os.environ["IFACE"]
+smac = mac(os.environ["INNER_SRC_MAC"])
+# Bare inner BUM frame: broadcast ARP request, padded to the 60-byte minimum.
+eth = b"\xff\xff\xff\xff\xff\xff" + smac + b"\x08\x06"
+arp = (b"\x00\x01\x08\x00\x06\x04\x00\x01"
+       + smac + socket.inet_aton("10.0.0.1")
+       + b"\x00\x00\x00\x00\x00\x00" + socket.inet_aton("10.0.0.2"))
+frame = (eth + arp).ljust(60, b"\x00")
+
+s = socket.socket(socket.AF_PACKET, socket.SOCK_RAW)
+s.bind((iface, 0))
+# A raw send through the qdisc on a veth can return ENOBUFS even though the frame
+# was queued + transmitted (so the egress clsact hook — the encap classifier —
+# still runs). Treat ENOBUFS as sent and do NOT retry (retrying double-sends);
+# PACKET_QDISC_BYPASS is not an option here because it would skip egress clsact.
+sent = 0
+for _ in range(3):
+    try:
+        s.send(frame)
+    except OSError as e:
+        if e.errno != errno.ENOBUFS:
+            raise
+    sent += 1
+    time.sleep(0.2)
+print("   sent %d/3 bare BUM (broadcast ARP) out %s" % (sent, iface))
+PY
+wait "$TCPDUMP_PID" 2>/dev/null
+
+echo "== 4. result =="
+echo "-- loader log --"; grep -iE 'attached|encap-cfg|repl-add|exiting' "$LOG" | sed 's/^/   /' || true
+echo "-- tcpdump (inbound ip6 on $U1) --"; sed 's/^/   /' "$CAPOUT"
+
+# Assert on the full encap: outer src = root SID, outer dst = each leaf SID, and
+# the decoded inner ARP (tcpdump understands Next Header = Ethernet/143), so the
+# match can only be our injected BUM frame.
+n1=$(grep -c "$ROOT_SID > $L1:.*Request who-has 10.0.0.2" "$CAPOUT" 2>/dev/null) || true
+n2=$(grep -c "$ROOT_SID > $L2:.*Request who-has 10.0.0.2" "$CAPOUT" 2>/dev/null) || true
+n1=${n1:-0}; n2=${n2:-0}
+echo
+echo "   encapped ARP $ROOT_SID > $L1 : $n1"
+echo "   encapped ARP $ROOT_SID > $L2 : $n2"
+if [ "$n1" -ge 1 ] && [ "$n2" -ge 1 ]; then
+    echo
+    echo "PASS: a bare BUM frame was H.Encaps'd (outer IPv6 src = root SID, inner"
+    echo "      frame intact) and fanned out to BOTH leaf SIDs via TC clsact egress"
+    exit 0
+else
+    echo
+    echo "FAIL: expected an encapsulated copy of the inner ARP to each leaf SID"
+    echo "-- tcpdump stderr --"; sed 's/^/   /' "$CAPERR"
+    echo "-- full loader log --"; sed 's/^/   /' "$LOG"
+    exit 2
+fi


### PR DESCRIPTION
## Summary

Completes the RFC 9524 SRv6 datapath: the **ingress PE** encapsulating a BUM frame that arrives *bare* (just an inner Ethernet frame) from the local bridge. With this, all three datapath roles — `End.Replicate` (#1563), leaf `End.DT2M` (#1567), and root `H.Encaps` — are implemented and lab-validated.

A bare frame has no outer SID to match on, so this is a **separate classifier** `tc_evpn_encap` attached at the overlay bridge-port's **clsact egress** (the ingress `tc_evpn_replicate` dispatcher is unchanged).

### eBPF (`offload/tc-evpn-replicate/ebpf`)
- `tc_evpn_encap`: for every bare frame egressing the overlay port, prepend a reduced SRv6 encap (link Ethernet + outer IPv6, Next Header = Ethernet/143, src = root SID) then fan out like `End.Replicate` — one `clone_redirect` per leaf with the outer DA set, out the underlay; drop the bare original.
- `bpf_skb_adjust_room` can't prepend a full outer L2+L3, so (mirroring the leaf decap) the buffer is grown at the tail with `bpf_skb_change_tail` and the bare frame slid right to open 54 bytes of headroom.
- Config (root SID, VNI, underlay ifindex, outer MAC header) comes from a new `ENCAP_CFG` map; the leaf set is `REPL_SEG[vni]`.

### loader
- New `--encap` mode attaches `tc_evpn_encap` at egress (else the ingress replicate/decap classifier); new `encap-cfg <vni> <underlay-ifname> <root-sid> <eth-dst> <eth-src>` line command + `ENCAP_CFG` map + MAC parsing.

## Test plan

`offload/` is workspace-excluded and **not built by CI** (needs nightly + bpf-linker). Verified locally:

- `cd offload/tc-evpn-replicate && cargo build --release` — eBPF object + loader build clean, fmt'd.
- `sudo bash scripts/veth-encap-test.sh` — **PASS** (4/4 deterministic runs): a bare broadcast ARP injected at the overlay port's egress is H.Encaps'd (outer src = root SID, inner frame intact) and fanned out to both leaf SIDs on the underlay (3 sends → 3 copies per leaf).
- `sudo bash scripts/veth-replicate-test.sh` and `sudo bash scripts/veth-dt2m-test.sh` — **PASS** (regression: `End.Replicate` and `End.DT2M` still work).

Lab notes captured in the design doc: the overlay port must be isolated in a netns (else host multicast gets encapped); `PACKET_QDISC_BYPASS` skips egress clsact (can't use it); a raw send may return spurious `ENOBUFS` while still transmitting (tolerate, don't retry — retrying double-sends).

Remaining: SRH-present (non-reduced) encap/decap.

Generated with [Claude Code](https://claude.com/claude-code)