### PR TITLE
bgp: advertise EVPN End.DT2M SID on Type-3 IMET over SRv6

### DIFF
--- a/crates/bgp-packet/src/attrs/prefix_sid.rs
+++ b/crates/bgp-packet/src/attrs/prefix_sid.rs
@@ -10,10 +10,12 @@ use crate::{AttrType, ParseBe};
 use super::{AttrEmitter, AttrFlags};
 
 /// SRv6 Endpoint Behavior codepoints (IANA "SRv6 Endpoint Behaviors",
-/// RFC 8986). Only the L3VPN-relevant decap behaviors are named here.
+/// RFC 8986). The L3VPN decap behaviors plus the L2 multicast/BUM decap
+/// (`End.DT2M`) used by EVPN-over-SRv6 (RFC 9252 §6.4).
 pub const SRV6_BEHAVIOR_END_DT6: u16 = 0x0012;
 pub const SRV6_BEHAVIOR_END_DT4: u16 = 0x0013;
 pub const SRV6_BEHAVIOR_END_DT46: u16 = 0x0014;
+pub const SRV6_BEHAVIOR_END_DT2M: u16 = 0x0016;
 
 /// BGP Prefix-SID TLV Types (IANA "BGP Prefix-SID TLV Types", RFC 8669 /
 /// RFC 9252 §8.1).
@@ -637,6 +639,42 @@ mod tests {
                 );
             }
             _ => panic!("expected SRv6 L3 Service TLV"),
+        }
+    }
+
+    #[test]
+    fn srv6_l2_service_end_dt2m_round_trips() {
+        // One End.DT2M SID in an SRv6 L2 Service TLV (sub-TLV type 6) — the
+        // EVPN-over-SRv6 BUM-replication advertise shape on a Type-3 IMET.
+        let sid = PrefixSid {
+            tlvs: vec![PrefixSidTlv::Srv6L2Service(Srv6ServiceTlv {
+                sids: vec![Srv6SidInfo::new(
+                    "2001:db8:1:2::".parse().unwrap(),
+                    0,
+                    SRV6_BEHAVIOR_END_DT2M,
+                    Some(Srv6SidStructure {
+                        locator_block_len: 32,
+                        locator_node_len: 16,
+                        function_len: 16,
+                        argument_len: 0,
+                        transposition_len: 0,
+                        transposition_offset: 0,
+                    }),
+                )],
+                ..Default::default()
+            })],
+        };
+        let rt = round_trip(sid.clone());
+        assert_eq!(rt, sid);
+        match &rt.tlvs[0] {
+            PrefixSidTlv::Srv6L2Service(svc) => {
+                assert_eq!(svc.sids[0].behavior, SRV6_BEHAVIOR_END_DT2M);
+                assert_eq!(
+                    svc.sids[0].sid,
+                    "2001:db8:1:2::".parse::<Ipv6Addr>().unwrap()
+                );
+            }
+            _ => panic!("expected SRv6 L2 Service TLV"),
         }
     }
 

--- a/crates/bgp-packet/src/bgp_attr.rs
+++ b/crates/bgp-packet/src/bgp_attr.rs
@@ -148,6 +148,17 @@ impl BgpAttr {
         })
     }
 
+    /// The first SRv6 L2 Service SID (value + endpoint behavior) carried
+    /// in the Prefix-SID attribute — RFC 9252 EVPN-over-SRv6 (e.g. an
+    /// `End.DT2M` SID on a Type-3 IMET route). `None` when the attribute
+    /// is absent or carries no SRv6 L2 Service TLV.
+    pub fn srv6_l2_sid(&self) -> Option<(std::net::Ipv6Addr, u16)> {
+        self.prefix_sid.as_ref()?.tlvs.iter().find_map(|t| match t {
+            PrefixSidTlv::Srv6L2Service(svc) => svc.sids.first().map(|s| (s.sid, s.behavior)),
+            _ => None,
+        })
+    }
+
     /// Iterate every Color extended community (RFC 9012 §4.3, type
     /// 0x03 0x0b) attached to the route. Returns an empty iterator
     /// when the route has no EXT_COMMUNITIES or the attribute carries

--- a/zebra-rs/src/bgp/inst.rs
+++ b/zebra-rs/src/bgp/inst.rs
@@ -226,6 +226,32 @@ fn srv6_l3_service_prefix_sid(
     }
 }
 
+/// Build an SRv6 **L2** Service Prefix-SID (RFC 9252 §6) carrying a single
+/// service SID — used for the EVPN `End.DT2M` SID on a Type-3 IMET route.
+/// Mirrors [`srv6_l3_service_prefix_sid`] but emits the L2 Service TLV.
+pub(super) fn srv6_l2_service_prefix_sid(
+    sid: std::net::Ipv6Addr,
+    structure: Option<crate::rib::SidStructure>,
+    behavior: u16,
+) -> bgp_packet::PrefixSid {
+    let structure = structure.map(|s| bgp_packet::Srv6SidStructure {
+        locator_block_len: s.lb_bits,
+        locator_node_len: s.ln_bits,
+        function_len: s.fun_bits,
+        argument_len: s.arg_bits,
+        transposition_len: 0,
+        transposition_offset: 0,
+    });
+    bgp_packet::PrefixSid {
+        tlvs: vec![bgp_packet::PrefixSidTlv::Srv6L2Service(
+            bgp_packet::Srv6ServiceTlv {
+                sids: vec![bgp_packet::Srv6SidInfo::new(sid, 0, behavior, structure)],
+                ..Default::default()
+            },
+        )],
+    }
+}
+
 /// Walk `vrf_index` and return every VRF name whose
 /// `import_rts_v4` intersects the route's Route-Target extended
 /// communities in `ecom`. RTs on the wire are distinguished from
@@ -841,6 +867,13 @@ pub struct Bgp {
     /// `None` otherwise. The `function` is borrowed from
     /// [`Self::srv6_sid_pool`], same as a per-VRF SID.
     pub srv6_ipv6_sid: Option<(std::net::Ipv6Addr, u16)>,
+    /// Per-VNI `End.DT2M` service SID `(addr, function)` for EVPN BUM
+    /// replication over SRv6 (RFC 9252 §6.4), carved from
+    /// [`Self::srv6_locator`] and advertised on the VNI's Type-3 IMET when
+    /// the BUM tunnel mode is SRv6 P2MP. The `function` is borrowed from
+    /// [`Self::srv6_sid_pool`] (same band as a per-VRF SID) and freed when
+    /// the VNI stops originating.
+    pub evpn_dt2m_sids: BTreeMap<u32, (std::net::Ipv6Addr, u16)>,
     /// Precomputed advertise-time data derived from
     /// [`Self::srv6_ipv6_sid`] and the locator, borrowed into
     /// [`super::peer::BgpTop`] so the egress path stamps
@@ -1066,6 +1099,7 @@ impl Bgp {
             srv6_sid_pool: super::vrf::BgpSidPool::new(),
             srv6_ipv6_unicast: false,
             srv6_ipv6_sid: None,
+            evpn_dt2m_sids: BTreeMap::new(),
             srv6_ipv6_export: None,
             networks_v6: std::collections::BTreeSet::new(),
             peer_index: BTreeMap::new(),
@@ -1237,6 +1271,49 @@ impl Bgp {
         }
     }
 
+    /// Allocate (or return the existing) `End.DT2M` SID for `vni`, carved from
+    /// the resolved locator. Stable per VNI for as long as it originates;
+    /// `None` when no locator has resolved or the function band is exhausted.
+    fn alloc_vni_dt2m_sid(&mut self, vni: u32) -> Option<std::net::Ipv6Addr> {
+        if let Some((addr, _function)) = self.evpn_dt2m_sids.get(&vni) {
+            return Some(*addr);
+        }
+        let prefix = self.srv6_locator.as_ref().and_then(|l| l.prefix)?;
+        let function = self.srv6_sid_pool.allocate()?;
+        match crate::isis::srv6::function_addr(prefix, function) {
+            Some(addr) => {
+                self.evpn_dt2m_sids.insert(vni, (addr, function));
+                Some(addr)
+            }
+            None => {
+                self.srv6_sid_pool.release(function);
+                None
+            }
+        }
+    }
+
+    /// Release `vni`'s `End.DT2M` SID back to the pool (it stopped
+    /// originating). No-op if it had none (e.g. no locator was resolved).
+    pub(super) fn free_vni_dt2m_sid(&mut self, vni: u32) {
+        if let Some((_addr, function)) = self.evpn_dt2m_sids.remove(&vni) {
+            self.srv6_sid_pool.release(function);
+        }
+    }
+
+    /// Build the SRv6 L2 Service Prefix-SID attribute advertised on `vni`'s
+    /// Type-3 IMET — this PE's `End.DT2M` SID for the VNI. `None` when no
+    /// locator has resolved (the IMET is advertised SID-less and reconciled
+    /// on the next locator update).
+    pub(super) fn vni_dt2m_prefix_sid(&mut self, vni: u32) -> Option<bgp_packet::PrefixSid> {
+        let sid = self.alloc_vni_dt2m_sid(vni)?;
+        let structure = self.srv6_locator.as_ref().and_then(|l| l.sid_structure());
+        Some(srv6_l2_service_prefix_sid(
+            sid,
+            structure,
+            bgp_packet::SRV6_BEHAVIOR_END_DT2M,
+        ))
+    }
+
     /// Rebuild a [`super::vrf::Srv6VrfSid`] from a handle's preserved
     /// `(addr, function)` so a relabel / kernel-ctx respawn re-installs
     /// the *same* SID rather than churning the address.
@@ -1260,6 +1337,9 @@ impl Bgp {
         // maps to a now-invalid address. Throw the pool away and
         // re-allocate from the base under the new prefix.
         self.srv6_sid_pool.reset();
+        // Per-VNI End.DT2M SIDs were carved from the same pool; drop them so
+        // the next Type-3 (re)origination re-allocates under the new prefix.
+        self.evpn_dt2m_sids.clear();
         let srv6_vrfs: Vec<String> = self
             .vrf_registry
             .keys()
@@ -4862,6 +4942,21 @@ mod tests {
 
     fn addr(s: &str) -> IpAddr {
         s.parse().unwrap()
+    }
+
+    #[test]
+    fn srv6_l2_service_prefix_sid_emits_end_dt2m() {
+        // The EVPN End.DT2M producer must emit an SRv6 *L2* Service TLV (not
+        // the L3VPN one) carrying the End.DT2M behavior + the SID value.
+        let sid: std::net::Ipv6Addr = "2001:db8:1:2::".parse().unwrap();
+        let ps = super::srv6_l2_service_prefix_sid(sid, None, bgp_packet::SRV6_BEHAVIOR_END_DT2M);
+        match &ps.tlvs[0] {
+            bgp_packet::PrefixSidTlv::Srv6L2Service(svc) => {
+                assert_eq!(svc.sids[0].sid, sid);
+                assert_eq!(svc.sids[0].behavior, bgp_packet::SRV6_BEHAVIOR_END_DT2M);
+            }
+            other => panic!("expected SRv6 L2 Service TLV, got {other:?}"),
+        }
     }
 
     #[test]

--- a/zebra-rs/src/bgp/route.rs
+++ b/zebra-rs/src/bgp/route.rs
@@ -12710,6 +12710,13 @@ impl Bgp {
         }
         attr.pmsi_tunnel = Some(pmsi);
         attr.nexthop = Some(BgpNexthop::Evpn(nexthop));
+        // RFC 9252 §6.4: in SRv6 P2MP mode, advertise this PE's End.DT2M SID
+        // for the VNI on the IMET route (SRv6 L2 Service TLV in the Prefix-SID
+        // attribute) so remote roots fan replicated BUM to it. SID-less when no
+        // locator has resolved yet (reconciled on the next locator update).
+        if matches!(bum, EvpnBumTunnel::SrV6P2mp) {
+            attr.prefix_sid = self.vni_dt2m_prefix_sid(vni);
+        }
 
         let mut rib = BgpRib::new(
             ORIGINATED_PEER,
@@ -12770,8 +12777,10 @@ impl Bgp {
         let _ = self.local_rib.select_best_path_evpn(&rd, &prefix);
         route_withdraw_evpn_to_peers(rd, prefix, &mut self.peers);
         // We no longer originate this VNI — drop its SR P2MP tree Root so a
-        // subsequent reconcile withdraws any replication segment.
+        // subsequent reconcile withdraws any replication segment, and release
+        // its End.DT2M SID back to the pool.
         self.local_rib.evpn_flood.clear_local_root(vni);
+        self.free_vni_dt2m_sid(vni);
     }
 
     /// Originate a Type-6 SMET route for a locally-snooped `(*,G)` /


### PR DESCRIPTION
## Summary

First control-plane slice of the EVPN SR P2MP (RFC 9524) replication **control→dataplane integration**: a PE now signals the per-VNI `End.DT2M` SID that the eBPF BUM-replication dataplane needs, reusing the RFC 9252 SRv6 service-TLV infrastructure already built for L3VPN.

This unblocks the previously-deferred EVPN-SRv6-L2 producer (deferred only because the stock kernel lacked `End.DT2M` — now provided by the `tc-evpn-replicate` eBPF dataplane).

### `bgp-packet`
- Add `SRV6_BEHAVIOR_END_DT2M` (`0x0016`, IANA SRv6 Endpoint Behaviors) and a `BgpAttr::srv6_l2_sid()` accessor for the SRv6 L2 Service TLV (sub-TLV type 6). The L2 service *wire codec* already existed; this names the behavior and adds the consumer-side accessor. Round-trip unit test.

### `zebra-rs`
- Allocate a per-VNI `End.DT2M` SID from the node's SRv6 Locator (`evpn_dt2m_sids`, drawing from the existing `BgpSidPool` band), and attach it to the originated Type-3 IMET as an SRv6 L2 Service Prefix-SID. **Gated on the `SrV6P2mp` BUM tunnel mode**; advertised SID-less when no locator has resolved (reconciled on the next locator update).
- Free the SID on IMET withdrawal; clear the per-VNI map on a locator-prefix change so the next origination re-allocates under the new prefix.
- `srv6_l2_service_prefix_sid` builder (mirrors the L3VPN `srv6_l3_service_prefix_sid`) + a guard test that it emits an **L2** (not L3) service TLV carrying `End.DT2M`.

## Test plan

- `cargo clippy --workspace --all-targets -- -D warnings` — clean.
- `cargo test -p bgp-packet srv6_l2` — L2 Service + End.DT2M round-trip passes.
- `cargo test -p zebra-rs --bin zebra-rs srv6_l2_service_prefix_sid` — builder guard passes.

This is the producer half (opt-in via `SrV6P2mp`). Follow-ups: remote PEs learning this SID on import (leaf VTEP → SID map), then threading the SIDs through `ReplSeg` into the eBPF supervisor + YANG dataplane topology config.

Generated with [Claude Code](https://claude.com/claude-code)