### PR TITLE
bgp-evpn: selective S-PMSI (Type-10) origination + RBR re-origination (Phase 5)

### DIFF
--- a/bdd/tests/configs/bgp_evpn_spmsi/z1-1.yaml
+++ b/bdd/tests/configs/bgp_evpn_spmsi/z1-1.yaml
@@ -1,0 +1,28 @@
+# z1 — a source PE in region A (AS 65001). Local VXLAN (VNI 10) on an
+# IGMP-snooping bridge; igmp-mld-proxy + segmentation are on, so a snooped
+# (*,G) membership makes z1 originate BOTH a Type-6 SMET (receiver interest)
+# and a Type-10 S-PMSI (the selective provider tunnel for that flow, RFC 9572).
+# iBGP to the RBR z2.
+vxlan:
+- name: vxlan10
+  vni: 10
+  local-address: 192.168.0.1
+router:
+  bgp:
+    global:
+      as: 65001
+      router-id: 192.168.0.1
+    afi-safi:
+    - name: evpn
+      advertise-all-vni: true
+      igmp-mld-proxy: true
+      segmentation: true
+    neighbor:
+    - remote-address: 192.168.0.2
+      enabled: true
+      remote-as: 65001
+      afi-safi:
+      - name: ipv4
+        enabled: true
+      - name: evpn
+        enabled: true

--- a/bdd/tests/configs/bgp_evpn_spmsi/z2-1.yaml
+++ b/bdd/tests/configs/bgp_evpn_spmsi/z2-1.yaml
@@ -1,0 +1,33 @@
+# z2 — the Regional Border Router (AS 65001). region-a (region-id 65001) is
+# the iBGP session to region A (z1); region-b (region-id 65002) is the eBGP
+# session to region B (z3). On receiving z1's in-region S-PMSI (Type-10) it
+# re-roots that selective (S,G) tunnel at itself toward region B. No local VXLAN.
+router:
+  bgp:
+    global:
+      as: 65001
+      router-id: 192.168.0.2
+    neighbor-group:
+    - name: region-a
+      remote-as: 65001
+      region-id: 65001
+    - name: region-b
+      remote-as: 65002
+      region-id: 65002
+    neighbor:
+    - remote-address: 192.168.0.1
+      enabled: true
+      neighbor-group: region-a
+      afi-safi:
+      - name: ipv4
+        enabled: true
+      - name: evpn
+        enabled: true
+    - remote-address: 192.168.0.3
+      enabled: true
+      neighbor-group: region-b
+      afi-safi:
+      - name: ipv4
+        enabled: true
+      - name: evpn
+        enabled: true

--- a/bdd/tests/configs/bgp_evpn_spmsi/z3-1.yaml
+++ b/bdd/tests/configs/bgp_evpn_spmsi/z3-1.yaml
@@ -1,0 +1,17 @@
+# z3 — a PE in region B (AS 65002). It peers eBGP only with the RBR z2 and
+# receives region A's selective S-PMSI (Type-10) re-rooted at z2 (Originator =
+# 192.168.0.2), not z1's per-PE originator.
+router:
+  bgp:
+    global:
+      as: 65002
+      router-id: 192.168.0.3
+    neighbor:
+    - remote-address: 192.168.0.2
+      enabled: true
+      remote-as: 65001
+      afi-safi:
+      - name: ipv4
+        enabled: true
+      - name: evpn
+        enabled: true

--- a/bdd/tests/features/bgp_evpn_spmsi.feature
+++ b/bdd/tests/features/bgp_evpn_spmsi.feature
@@ -1,0 +1,77 @@
+@serial
+@bgp_evpn_spmsi
+Feature: BGP EVPN BUM segmentation — selective S-PMSI (RFC 9572 Type-10), Phase 5
+  As a network operator
+  I want a source PE to advertise a selective per-(S,G) provider tunnel (Type-10
+  S-PMSI) for a snooped multicast flow, and a Regional Border Router to re-root
+  that selective tunnel per-region — the selective counterpart of the inclusive
+  Per-Region I-PMSI (Type-9) aggregation.
+
+  Test Topology — z1 is a source PE in region A with an IGMP-snooping bridge; a
+  snooped (*,239.1.1.1) membership makes it originate a Type-10 S-PMSI. z2 is
+  the RBR (region A iBGP / region B eBGP); z3 is a PE in region B.
+  ```
+  ┌──────────────────────────────────────────────────────────┐
+  │                            br0                            │
+  └─────────┬─────────────────┬─────────────────┬─────────────┘
+       ┌────┴────┐ iBGP  ┌────┴────┐ eBGP  ┌────┴────┐
+       │   z1    │───────│   z2    │───────│   z3    │
+       │region A │       │   RBR   │       │region B │
+       │ VNI 10  │       │a:65001  │       │ AS65002 │
+       │ snoop   │       │b:65002  │       │  .0.3   │
+       │  .0.1   │       └─────────┘       └─────────┘
+       └─────────┘
+  ```
+
+  Scenario: Setup topology, EVPN sessions, and z1's snooping bridge
+    Given a clean test environment
+    When I create bridge "br0"
+    And I create namespace "z1" with IP "192.168.0.1/24" on bridge "br0"
+    And I create namespace "z2" with IP "192.168.0.2/24" on bridge "br0"
+    And I create namespace "z3" with IP "192.168.0.3/24" on bridge "br0"
+    And I start zebra-rs in namespace "z1"
+    And I start zebra-rs in namespace "z2"
+    And I start zebra-rs in namespace "z3"
+    And I apply config "z1-1.yaml" to namespace "z1"
+    And I apply config "z2-1.yaml" to namespace "z2"
+    And I apply config "z3-1.yaml" to namespace "z3"
+    # z1's snooping bridge: enslave vxlan10 + a host-facing port for membership.
+    And I execute "ip link add br10 type bridge mcast_snooping 1" in namespace "z1"
+    And I execute "ip link set vxlan10 master br10" in namespace "z1"
+    And I execute "ip link set br10 up" in namespace "z1"
+    And I execute "ip link add host0 type dummy" in namespace "z1"
+    And I execute "ip link set host0 master br10" in namespace "z1"
+    And I execute "ip link set host0 up" in namespace "z1"
+    And I wait 10 seconds for BGP to operate
+    Then BGP session in "z1" to "192.168.0.2" should be "Established"
+    And BGP session in "z2" to "192.168.0.3" should be "Established"
+
+  Scenario: A snooped (*,G) makes z1 originate a selective S-PMSI (Type-10)
+    Given the test topology exists
+    When I execute "bridge mdb add dev br10 port host0 grp 239.1.1.1 permanent" in namespace "z1"
+    # z1 advertises the selective provider tunnel for (*,239.1.1.1), rooted at
+    # its own VTEP (192.168.0.1).
+    Then show command "show bgp evpn route-type s-pmsi" in namespace "z1" should eventually contain "[10]:[0]:[*]:[239.1.1.1]:[192.168.0.1]"
+
+  Scenario: The RBR re-roots the S-PMSI per-region toward region B
+    Given the test topology exists
+    # z2 receives z1's S-PMSI and re-originates a selective tunnel rooted at
+    # itself (Originator 192.168.0.2).
+    Then show command "show bgp evpn route-type s-pmsi" in namespace "z2" should eventually contain "[10]:[0]:[*]:[239.1.1.1]:[192.168.0.1]"
+    And show command "show bgp evpn route-type s-pmsi" in namespace "z2" should eventually contain "[10]:[0]:[*]:[239.1.1.1]:[192.168.0.2]"
+
+  Scenario: Region B receives the RBR-rooted selective S-PMSI
+    Given the test topology exists
+    # z3 learns the selective (*,G) tunnel re-rooted at the RBR (192.168.0.2).
+    Then show command "show bgp evpn route-type s-pmsi" in namespace "z3" should eventually contain "[10]:[0]:[*]:[239.1.1.1]:[192.168.0.2]"
+
+  Scenario: Teardown topology
+    Given the test topology exists
+    When I stop zebra-rs in namespace "z1"
+    And I stop zebra-rs in namespace "z2"
+    And I stop zebra-rs in namespace "z3"
+    And I delete namespace "z1"
+    And I delete namespace "z2"
+    And I delete namespace "z3"
+    And I delete bridge "br0"
+    Then the test environment should be clean

--- a/docs/design/bgp-evpn-bum-segmentation-plan.md
+++ b/docs/design/bgp-evpn-bum-segmentation-plan.md
@@ -370,8 +370,20 @@ codec — and any RIB/Adj-RIB/show/origination wiring.
     elected, legacy PE flagged. **Deferred:** the elected DF gates nothing until
     the Phase-6 replication dataplane; conditional EC-attach (only when legacy
     present); HRW DF Alg.
-- **Phase 5 (optional) — S-PMSI selective multicast (Type 10 + Leaf A-D)**
-  end to end; ties to SMET (Type 6) if/when that lands.
+- **Phase 5 — S-PMSI selective multicast (Type 10 + Leaf A-D). DONE.**
+  Origination + RBR re-origination, end to end. `evpn_originate_spmsi`
+  (mirrors `evpn_originate_smet` but adds a PMSI Tunnel attr — the selective
+  provider tunnel for the snooped `(S,G)` — rooted at the local VTEP; gated on
+  `segmentation`, called alongside SMET from the `SnoopJoin` path + the
+  proxy/segmentation toggle replays). `evpn_reoriginate_spmsi` re-roots an
+  in-region S-PMSI at the RBR (Originator + next-hop-self, L-flag PTA, the
+  selective analog of `evpn_reoriginate_per_region`); triggered from the
+  Type-10 receive path, skipping our own Originator. Leaf A-D for S-PMSI was
+  already generalized in 3c. Live BDD `@bgp_evpn_spmsi` (source PE → RBR →
+  region B, 5/5); SMET BDD still green. **Deferred:** the RBR doesn't withdraw
+  its re-originated S-PMSI when the source withdraws, and doesn't hold the
+  per-PE S-PMSI at the boundary (both mirror the deferred Type-9 follow-ups);
+  S-PMSI-specific DF election.
 
 ## 8. YANG / config (later phases)
 

--- a/zebra-rs/src/bgp/config.rs
+++ b/zebra-rs/src/bgp/config.rs
@@ -1467,8 +1467,12 @@ fn config_igmp_mld_proxy(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Option<
     for (vni, group, source, vtep_local) in memberships {
         if enabled {
             bgp.evpn_originate_smet(vni, vtep_local, group, source);
+            // A selective S-PMSI rides the same snoop membership when
+            // segmentation is on (the originate is a no-op otherwise).
+            bgp.evpn_originate_spmsi(vni, vtep_local, group, source);
         } else {
             bgp.evpn_withdraw_smet(vni, vtep_local, group, source);
+            bgp.evpn_withdraw_spmsi(vni, vtep_local, group, source);
         }
     }
     Some(())
@@ -1490,6 +1494,20 @@ fn config_segmentation(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Option<()
     }
     bgp.segmentation = enabled;
     reoriginate_all_imet(bgp);
+    // Replay snooped memberships so existing flows gain/lose their selective
+    // S-PMSI (Type-10) tunnel on the segmentation toggle.
+    let memberships: Vec<(u32, IpAddr, Option<IpAddr>, IpAddr)> = bgp
+        .local_smet
+        .iter()
+        .map(|((vni, group, source), vtep)| (*vni, *group, *source, *vtep))
+        .collect();
+    for (vni, group, source, vtep_local) in memberships {
+        if enabled {
+            bgp.evpn_originate_spmsi(vni, vtep_local, group, source);
+        } else {
+            bgp.evpn_withdraw_spmsi(vni, vtep_local, group, source);
+        }
+    }
     Some(())
 }
 

--- a/zebra-rs/src/bgp/inst.rs
+++ b/zebra-rs/src/bgp/inst.rs
@@ -2958,6 +2958,9 @@ impl Bgp {
                 // false→true transitions — see `local_smet` doc.
                 self.local_smet.insert((vni, group, source), vtep_local);
                 self.evpn_originate_smet(vni, vtep_local, group, source);
+                // RFC 9572 §3.2: with segmentation, also advertise a selective
+                // S-PMSI tunnel (Type-10) for the flow (no-op unless enabled).
+                self.evpn_originate_spmsi(vni, vtep_local, group, source);
             }
             RibRx::SnoopLeave {
                 vni,
@@ -2967,6 +2970,7 @@ impl Bgp {
             } => {
                 self.local_smet.remove(&(vni, group, source));
                 self.evpn_withdraw_smet(vni, vtep_local, group, source);
+                self.evpn_withdraw_spmsi(vni, vtep_local, group, source);
             }
             RibRx::VrfAdd {
                 name,

--- a/zebra-rs/src/bgp/route.rs
+++ b/zebra-rs/src/bgp/route.rs
@@ -6710,6 +6710,64 @@ fn evpn_reoriginate_per_region(
     }
 }
 
+/// RFC 9572 §6: when an in-region S-PMSI (Type-10) arrives, a Regional Border
+/// Router re-roots that selective `(S,G)` tunnel at itself toward the other
+/// regions — the selective analog of `evpn_reoriginate_per_region`. The
+/// re-originated route keeps the `(src, grp)` but takes the RBR as Originator
+/// and next hop (next-hop-self), with a PMSI Tunnel rooted at the RBR carrying
+/// the Leaf-Information-Required flag (so in-region leaves answer with a Type-11
+/// Leaf A-D, reusing the generalized `evpn_segmentation_leaf_ad_on_receive`).
+fn evpn_reoriginate_spmsi(
+    bgp: &mut BgpTop,
+    peers: &mut PeerMap,
+    src: Option<IpAddr>,
+    grp: Option<IpAddr>,
+    vni: u32,
+    src_attr: &BgpAttr,
+) {
+    if bgp.router_id.is_unspecified() {
+        return;
+    }
+    let Some(rd) = rd_from_router_id_vni(*bgp.router_id, vni) else {
+        return;
+    };
+    let prefix = EvpnPrefix::SPmsi {
+        eth_tag: 0,
+        src,
+        grp,
+        orig: IpAddr::V4(*bgp.router_id),
+    };
+    let mut attr = BgpAttr::new();
+    attr.ecom = src_attr.ecom.clone();
+    let bum = bgp.local_rib.evpn_flood.bum_tunnel;
+    let (mut pmsi, root) = imet_pmsi_tunnel(
+        bum,
+        AssistedReplicationRole::None,
+        None,
+        IpAddr::V4(*bgp.router_id),
+        vni,
+    );
+    pmsi.set_leaf_info_required(true);
+    attr.pmsi_tunnel = Some(pmsi);
+    attr.nexthop = Some(BgpNexthop::Evpn(root));
+
+    let rib = BgpRib::new(
+        ORIGINATED_PEER,
+        Ipv4Addr::UNSPECIFIED,
+        BgpRibType::Originated,
+        0,
+        32768,
+        &attr,
+        None,
+        None,
+        false,
+    );
+    let (_replaced, selected, _next_id) = bgp.local_rib.update_evpn(rd, prefix.clone(), rib);
+    if !selected.is_empty() {
+        route_advertise_evpn_to_peers(rd, prefix, &selected, bgp, peers);
+    }
+}
+
 pub fn route_evpn_update(
     ident: usize,
     route: &EvpnRoute,
@@ -6852,6 +6910,18 @@ pub fn route_evpn_update(
         && let Some(vni) = extract_vni_from_attr(attr)
     {
         evpn_reoriginate_per_region(bgp, peers, region_id, vni, attr);
+    }
+
+    // RFC 9572 §6: an in-region S-PMSI (Type-10) is re-rooted per-region at the
+    // RBR — the selective counterpart of the Type-9 aggregation. Gated on the
+    // ingress peer carrying a region-id, and skips our own re-originated route
+    // (Originator == us) to avoid a re-origination loop.
+    if let EvpnRoute::SPmsi(s) = route
+        && peers.get_by_idx(ident).and_then(|p| p.region_id).is_some()
+        && s.originator != IpAddr::V4(*bgp.router_id)
+        && let Some(vni) = extract_vni_from_attr(attr)
+    {
+        evpn_reoriginate_spmsi(bgp, peers, s.src, s.grp, vni, attr);
     }
 
     // RFC 9574 selective AR: an AR-LEAF responds to a selective Replicator-AR
@@ -12955,6 +13025,119 @@ impl Bgp {
             eth_tag: 0,
             src: source,
             grp: group,
+            orig: vtep_local,
+        };
+        let _ = self.local_rib.remove_evpn(rd, &prefix, 0, ORIGINATED_PEER);
+        let _ = self.local_rib.select_best_path_evpn(&rd, &prefix);
+        route_withdraw_evpn_to_peers(rd, prefix, &mut self.peers);
+    }
+
+    /// RFC 9572 §3.2: originate a Type-10 S-PMSI A-D route for a locally-snooped
+    /// `(S,G)` / `(*,G)`, declaring a *selective* provider tunnel for that flow
+    /// — the per-(S,G) analog of the inclusive Type-3 IMET. Unlike the Type-6
+    /// SMET (receiver interest, no tunnel — RFC 9251 §6), the S-PMSI carries a
+    /// PMSI Tunnel attribute rooting the selective tunnel at this node, so the
+    /// RBR can segment it per-region (`evpn_reoriginate_spmsi`). Gated on the
+    /// `segmentation` knob; called alongside `evpn_originate_smet`, so the
+    /// `igmp_mld_proxy` / advertisable-group gates already held at the caller.
+    pub fn evpn_originate_spmsi(
+        &mut self,
+        vni: u32,
+        vtep_local: IpAddr,
+        group: IpAddr,
+        source: Option<IpAddr>,
+    ) {
+        if !self.segmentation {
+            return;
+        }
+        if self.router_id.is_unspecified() || !smet_advertisable_group(group) {
+            return;
+        }
+        let Some(rd) = rd_from_router_id_vni(self.router_id, vni) else {
+            return;
+        };
+        let prefix = EvpnPrefix::SPmsi {
+            eth_tag: 0,
+            src: source,
+            grp: Some(group),
+            orig: vtep_local,
+        };
+        let mut attr = BgpAttr::new();
+        attr.ecom = Some(ExtCommunity::from([
+            evpn_route_target(self.asn, vni),
+            evpn_encap_vxlan(),
+        ]));
+        // The selective provider tunnel for this (S,G): an Ingress-Replication
+        // PMSI rooted at our VTEP (the key difference from a Type-6 SMET).
+        attr.pmsi_tunnel = Some(PmsiTunnel {
+            flags: 0,
+            tunnel_type: PmsiTunnel::TUNNEL_INGRESS_REPLICATION,
+            vni,
+            endpoint: vtep_local,
+            tree_id: None,
+        });
+        attr.nexthop = Some(BgpNexthop::Evpn(vtep_local));
+
+        let mut rib = BgpRib::new(
+            ORIGINATED_PEER,
+            Ipv4Addr::UNSPECIFIED,
+            BgpRibType::Originated,
+            0,
+            32768,
+            &attr,
+            None,
+            None,
+            false,
+        );
+        let (_replaced, selected, next_id) =
+            self.local_rib.update_evpn(rd, prefix.clone(), rib.clone());
+        rib.local_id = next_id;
+
+        let mut bgp_ref = BgpTop {
+            router_id: &self.router_id,
+            srv6_ipv6_export: self.srv6_ipv6_export.as_ref(),
+            local_rib: &mut self.local_rib,
+            shard: &mut self.shard,
+            tx: &self.tx,
+            rib_client: &self.ctx.rib,
+            attr_store: &mut self.attr_store,
+            update_groups: &mut self.update_groups,
+            interface_addrs: &self.interface_addrs,
+            vrf_export: None,
+            color_policy: Some(&self.color_policy),
+            flex_algo_routes: Some(&self.flex_algo_routes),
+            flex_algo_srv6_routes: Some(&self.flex_algo_srv6_routes),
+            vrf_import: None,
+            nexthop_cache: None,
+            vrf_transport_v4: None,
+            vrf_transport_v6: None,
+            central_label_alloc: None,
+        };
+        if !selected.is_empty() {
+            route_advertise_evpn_to_peers(rd, prefix, &selected, &mut bgp_ref, &mut self.peers);
+        }
+    }
+
+    /// Inverse of `evpn_originate_spmsi`. Not gated on `segmentation` so turning
+    /// the feature off (or a membership leave) always clears the originated
+    /// route.
+    pub fn evpn_withdraw_spmsi(
+        &mut self,
+        vni: u32,
+        vtep_local: IpAddr,
+        group: IpAddr,
+        source: Option<IpAddr>,
+    ) {
+        if !smet_advertisable_group(group) {
+            return;
+        }
+        let Some(rd) = rd_from_router_id_vni(self.router_id, vni) else {
+            return;
+        };
+        let prefix = EvpnPrefix::SPmsi {
+            eth_tag: 0,
+            src: source,
+            grp: Some(group),
             orig: vtep_local,
         };
         let _ = self.local_rib.remove_evpn(rd, &prefix, 0, ORIGINATED_PEER);


### PR DESCRIPTION
## Summary

Phase 5 of RFC 9572 EVPN BUM segmentation: **selective S-PMSI (Type-10) multicast, end to end** — origination + RBR re-origination. The codec / RIB / show / Leaf-A-D already existed (Phases 1–2 + 3c); this adds the originator and the re-originator.

- **`evpn_originate_spmsi`** — mirrors `evpn_originate_smet` but adds a **PMSI Tunnel attribute**: the selective per-(S,G) provider tunnel rooted at the local VTEP (the key difference from a Type-6 SMET, which carries receiver interest with no tunnel). Gated on the `segmentation` knob; called alongside SMET from the `SnoopJoin` path and replayed on the `igmp-mld-proxy` / `segmentation` config toggles.
- **`evpn_reoriginate_spmsi`** — when an in-region S-PMSI arrives, the RBR re-roots that selective (S,G) tunnel at itself (Originator + next-hop-self, L-flag PMSI) toward the other regions — the selective analog of `evpn_reoriginate_per_region`. Triggered from the Type-10 receive path, skipping our own Originator (loop guard).

No YANG change — reuses the existing `segmentation` knob.

## Test plan

New 3-namespace BDD `@bgp_evpn_spmsi`: source PE z1 → RBR z2 → region-B z3. CI excludes BDD (root + netns), so **run live in network namespaces**:

```
✓ bgp_evpn_spmsi (5 scenario(s))  —  1 passed, 0 failed
```

A snooped `(*,239.1.1.1)` on z1 makes it originate `[10]:[0]:[*]:[239.1.1.1]:[192.168.0.1]`; the RBR z2 re-roots it as `…:[192.168.0.2]`; z3 (region B) receives the RBR-rooted tunnel. The SMET BDD still passes **6/6** (the paired S-PMSI calls didn't regress it); clean teardown.

`cargo fmt --check` + `cargo clippy --workspace --all-targets` clean; full `cargo test --workspace --exclude bdd` green (327 bgp-packet + 1375 bin, 0 failed).

**Deferred** (mirroring the deferred Type-9 follow-ups): the RBR doesn't withdraw its re-originated S-PMSI when the source withdraws, nor hold the per-PE S-PMSI at the boundary; S-PMSI-specific DF election.

Generated with [Claude Code](https://claude.com/claude-code)