### PR TITLE
bgp: YANG config for EVPN SR P2MP replication dataplane

### DIFF
--- a/zebra-rs/src/bgp/config.rs
+++ b/zebra-rs/src/bgp/config.rs
@@ -1657,6 +1657,93 @@ fn config_evpn_bum_tunnel_type(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> O
     Some(())
 }
 
+/// Push the current `sr-p2mp-dataplane` topology to the RIB replication
+/// supervisor (it stores it for use when the eBPF children are spawned).
+fn send_evpn_sr_dataplane(bgp: &Bgp) {
+    let c = &bgp.evpn_sr_dataplane;
+    let _ = bgp.ctx.rib.send(crate::rib::Message::ReplDataplaneCfg {
+        overlay: c.overlay_iface.clone(),
+        underlay: c.underlay_iface.clone(),
+        bridge: c.bridge_iface.clone(),
+        next_hop_mac: c.next_hop_mac.clone(),
+    });
+}
+
+/// `router bgp afi-safi evpn sr-p2mp-dataplane <leaf> <value>` — the SRv6 P2MP
+/// BUM-replication dataplane interfaces + outer next hop. Each leaf updates one
+/// field and re-pushes the whole topology to the RIB supervisor.
+fn config_evpn_sr_dp_overlay(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Option<()> {
+    let afi_safi: AfiSafi = args.afi_safi()?;
+    if afi_safi.afi != Afi::L2vpn || afi_safi.safi != Safi::Evpn {
+        return None;
+    }
+    let val = if op.is_set() {
+        Some(args.string()?)
+    } else {
+        None
+    };
+    if bgp.evpn_sr_dataplane.overlay_iface == val {
+        return Some(());
+    }
+    bgp.evpn_sr_dataplane.overlay_iface = val;
+    send_evpn_sr_dataplane(bgp);
+    Some(())
+}
+
+fn config_evpn_sr_dp_underlay(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Option<()> {
+    let afi_safi: AfiSafi = args.afi_safi()?;
+    if afi_safi.afi != Afi::L2vpn || afi_safi.safi != Safi::Evpn {
+        return None;
+    }
+    let val = if op.is_set() {
+        Some(args.string()?)
+    } else {
+        None
+    };
+    if bgp.evpn_sr_dataplane.underlay_iface == val {
+        return Some(());
+    }
+    bgp.evpn_sr_dataplane.underlay_iface = val;
+    send_evpn_sr_dataplane(bgp);
+    Some(())
+}
+
+fn config_evpn_sr_dp_bridge(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Option<()> {
+    let afi_safi: AfiSafi = args.afi_safi()?;
+    if afi_safi.afi != Afi::L2vpn || afi_safi.safi != Safi::Evpn {
+        return None;
+    }
+    let val = if op.is_set() {
+        Some(args.string()?)
+    } else {
+        None
+    };
+    if bgp.evpn_sr_dataplane.bridge_iface == val {
+        return Some(());
+    }
+    bgp.evpn_sr_dataplane.bridge_iface = val;
+    send_evpn_sr_dataplane(bgp);
+    Some(())
+}
+
+fn config_evpn_sr_dp_nexthop_mac(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Option<()> {
+    let afi_safi: AfiSafi = args.afi_safi()?;
+    if afi_safi.afi != Afi::L2vpn || afi_safi.safi != Safi::Evpn {
+        return None;
+    }
+    let val = if op.is_set() {
+        Some(args.string()?)
+    } else {
+        None
+    };
+    if bgp.evpn_sr_dataplane.next_hop_mac == val {
+        return Some(());
+    }
+    bgp.evpn_sr_dataplane.next_hop_mac = val;
+    send_evpn_sr_dataplane(bgp);
+    Some(())
+}
+
 // ---- redistribute -----------------------------------------------------
 //
 // Per-AFI redistribution sources (zebra-bgp-redistribute.yang). Each
@@ -3819,6 +3906,25 @@ impl Bgp {
         self.callback_add(
             "/router/bgp/afi-safi/bum-tunnel-type",
             config_evpn_bum_tunnel_type,
+        );
+        // EVPN SRv6 P2MP BUM-replication dataplane topology, under `router bgp
+        // afi-safi evpn sr-p2mp-dataplane`. Augmented in by zebra-bgp-evpn.yang;
+        // pushed to the RIB replication supervisor.
+        self.callback_add(
+            "/router/bgp/afi-safi/sr-p2mp-dataplane/overlay-interface",
+            config_evpn_sr_dp_overlay,
+        );
+        self.callback_add(
+            "/router/bgp/afi-safi/sr-p2mp-dataplane/underlay-interface",
+            config_evpn_sr_dp_underlay,
+        );
+        self.callback_add(
+            "/router/bgp/afi-safi/sr-p2mp-dataplane/bridge-interface",
+            config_evpn_sr_dp_bridge,
+        );
+        self.callback_add(
+            "/router/bgp/afi-safi/sr-p2mp-dataplane/next-hop-mac",
+            config_evpn_sr_dp_nexthop_mac,
         );
 
         // Per-AFI redistribution (zebra-bgp-redistribute.yang).

--- a/zebra-rs/src/bgp/inst.rs
+++ b/zebra-rs/src/bgp/inst.rs
@@ -572,6 +572,17 @@ pub enum EvpnBumTunnel {
     SrV6P2mp,
 }
 
+/// `router bgp afi-safi evpn sr-p2mp-dataplane` config: the interfaces +
+/// next hop the SRv6 P2MP BUM-replication eBPF dataplane attaches to. Pushed
+/// to the RIB replication supervisor via [`rib::Message::ReplDataplaneCfg`].
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct EvpnSrDataplaneCfg {
+    pub overlay_iface: Option<String>,
+    pub underlay_iface: Option<String>,
+    pub bridge_iface: Option<String>,
+    pub next_hop_mac: Option<String>,
+}
+
 pub struct Bgp {
     pub asn: u32,
     /// Effective BGP Identifier — what OPENs, EVPN RDs and the show
@@ -874,6 +885,9 @@ pub struct Bgp {
     /// [`Self::srv6_sid_pool`] (same band as a per-VRF SID) and freed when
     /// the VNI stops originating.
     pub evpn_dt2m_sids: BTreeMap<u32, (std::net::Ipv6Addr, u16)>,
+    /// `sr-p2mp-dataplane` config (interfaces + next hop for the SRv6 P2MP BUM
+    /// replication eBPF dataplane), pushed to the RIB supervisor on change.
+    pub evpn_sr_dataplane: EvpnSrDataplaneCfg,
     /// Precomputed advertise-time data derived from
     /// [`Self::srv6_ipv6_sid`] and the locator, borrowed into
     /// [`super::peer::BgpTop`] so the egress path stamps
@@ -1100,6 +1114,7 @@ impl Bgp {
             srv6_ipv6_unicast: false,
             srv6_ipv6_sid: None,
             evpn_dt2m_sids: BTreeMap::new(),
+            evpn_sr_dataplane: EvpnSrDataplaneCfg::default(),
             srv6_ipv6_export: None,
             networks_v6: std::collections::BTreeSet::new(),
             peer_index: BTreeMap::new(),

--- a/zebra-rs/src/config/manager.rs
+++ b/zebra-rs/src/config/manager.rs
@@ -2533,4 +2533,31 @@ mod yang_load_tests {
             assert_eq!(code, ExecCode::Success, "`{path}` must be a settable path");
         }
     }
+
+    #[test]
+    fn bgp_evpn_sr_p2mp_dataplane_is_settable() {
+        use crate::config::ExecCode;
+        use crate::config::parse::{State, parse};
+        use libyang::to_entry;
+
+        let mut yang = YangStore::new();
+        yang.add_path(concat!(env!("CARGO_MANIFEST_DIR"), "/yang"));
+        yang.read_with_resolve("configure")
+            .expect("configure mode loads");
+        yang.identity_resolve();
+        let module = yang
+            .find_module("configure")
+            .expect("configure module present");
+        let entry = to_entry(&yang, module);
+
+        for path in [
+            "set router bgp afi-safi evpn sr-p2mp-dataplane overlay-interface br-evpn0",
+            "set router bgp afi-safi evpn sr-p2mp-dataplane underlay-interface eth1",
+            "set router bgp afi-safi evpn sr-p2mp-dataplane bridge-interface br-evpn0",
+            "set router bgp afi-safi evpn sr-p2mp-dataplane next-hop-mac aa:bb:cc:dd:ee:ff",
+        ] {
+            let (code, _comps, _state) = parse(path, entry.clone(), None, State::new());
+            assert_eq!(code, ExecCode::Success, "`{path}` must be a settable path");
+        }
+    }
 }

--- a/zebra-rs/src/rib/evpn_replicate.rs
+++ b/zebra-rs/src/rib/evpn_replicate.rs
@@ -39,6 +39,33 @@ const BIN_ENV: &str = "ZEBRA_TC_EVPN_REPLICATE_BIN";
 /// Underlay interface the TC replicator attaches to. Unset ⇒ dataplane off.
 const IFACE_ENV: &str = "ZEBRA_TC_EVPN_REPLICATE_IFACE";
 
+/// Interfaces + next hop the SR P2MP BUM-replication eBPF children attach to,
+/// from BGP's `sr-p2mp-dataplane` config (`rib::Message::ReplDataplaneCfg`).
+/// Consumed when the children are (re)spawned.
+#[derive(Debug, Clone, Default)]
+pub struct DataplaneTopology {
+    /// Overlay bridge port the root `H.Encaps` classifier attaches to (egress).
+    pub overlay: Option<String>,
+    /// SR underlay NIC: replicated copies leave here; the leaf `End.DT2M`
+    /// decap classifier attaches to its ingress.
+    pub underlay: Option<String>,
+    /// Bridge port a leaf floods decapped BUM frames into.
+    pub bridge: Option<String>,
+    /// Outer Ethernet next-hop MAC for the encapsulated copies.
+    pub next_hop_mac: Option<String>,
+}
+
+impl DataplaneTopology {
+    /// True when every interface + next hop the eBPF children need is set, so
+    /// the supervisor can spawn the full send+receive dataplane.
+    pub fn is_complete(&self) -> bool {
+        self.overlay.is_some()
+            && self.underlay.is_some()
+            && self.bridge.is_some()
+            && self.next_hop_mac.is_some()
+    }
+}
+
 /// Supervises the single `tc-evpn-replicate` child that forwards EVPN BUM over
 /// SR P2MP replication trees. Lifecycle is reference-counted by the set of
 /// VNIs that currently have a replication segment.
@@ -57,6 +84,10 @@ pub struct ReplicationHelper {
     /// Underlay interface to attach to; `None` ($ZEBRA_..._IFACE unset)
     /// disables the dataplane.
     iface: Option<String>,
+    /// Dataplane topology from BGP `sr-p2mp-dataplane` config. Consumed when
+    /// the eBPF children are (re)spawned (a follow-up); stored here so the
+    /// supervisor has it before the first replication segment arrives.
+    topology: DataplaneTopology,
 }
 
 impl Default for ReplicationHelper {
@@ -74,7 +105,31 @@ impl ReplicationHelper {
             _io: None,
             bin: resolve_bin(),
             iface: std::env::var(IFACE_ENV).ok().filter(|s| !s.is_empty()),
+            topology: DataplaneTopology::default(),
         }
+    }
+
+    /// Update the SR P2MP dataplane topology from BGP `sr-p2mp-dataplane`
+    /// config. Stored for use when the eBPF children are (re)spawned; logged so
+    /// operators can see what the dataplane will attach to.
+    pub fn set_topology(
+        &mut self,
+        overlay: Option<String>,
+        underlay: Option<String>,
+        bridge: Option<String>,
+        next_hop_mac: Option<String>,
+    ) {
+        self.topology = DataplaneTopology {
+            overlay,
+            underlay,
+            bridge,
+            next_hop_mac,
+        };
+        tracing::info!(
+            "evpn replication: dataplane topology updated: {:?} (complete={})",
+            self.topology,
+            self.topology.is_complete()
+        );
     }
 
     /// Install or refresh the SR P2MP replication segment for `vni`, spawning

--- a/zebra-rs/src/rib/inst.rs
+++ b/zebra-rs/src/rib/inst.rs
@@ -364,6 +364,17 @@ pub enum Message {
     ReplSegDel {
         vni: u32,
     },
+    /// Topology for the SR P2MP BUM-replication dataplane, from BGP's
+    /// `sr-p2mp-dataplane` config: the overlay bridge port the root encap
+    /// attaches to, the SR underlay NIC, the bridge port a leaf floods into,
+    /// and the outer next-hop MAC. Stored by the replication supervisor and
+    /// used when it (re)spawns the eBPF children. Any field may be `None`.
+    ReplDataplaneCfg {
+        overlay: Option<String>,
+        underlay: Option<String>,
+        bridge: Option<String>,
+        next_hop_mac: Option<String>,
+    },
     Shutdown {
         tx: oneshot::Sender<()>,
     },
@@ -2863,6 +2874,15 @@ impl Rib {
             Message::ReplSegDel { vni } => {
                 tracing::info!("EVPN ReplSeg del: VNI {vni}");
                 self.evpn_repl.del(vni);
+            }
+            Message::ReplDataplaneCfg {
+                overlay,
+                underlay,
+                bridge,
+                next_hop_mac,
+            } => {
+                self.evpn_repl
+                    .set_topology(overlay, underlay, bridge, next_hop_mac);
             }
             Message::RedistAdd {
                 proto,

--- a/zebra-rs/yang/zebra-bgp-evpn.yang
+++ b/zebra-rs/yang/zebra-bgp-evpn.yang
@@ -198,6 +198,38 @@ module zebra-bgp-evpn {
            replicates to every node in the broadcast domain.";
       }
     }
+    container sr-p2mp-dataplane {
+      description
+        "Interfaces + next hop the SRv6 P2MP (RFC 9524) BUM-replication eBPF
+         dataplane (offload/tc-evpn-replicate) attaches to. Consulted only
+         when bum-tunnel-type is srv6-p2mp; with the offload absent the
+         control plane still signals and nothing forwards.";
+      leaf overlay-interface {
+        type string;
+        description
+          "Bridge port the root H.Encaps classifier attaches to (egress):
+           a bare BUM frame egressing it is encapsulated + fanned out per
+           leaf End.DT2M SID.";
+      }
+      leaf underlay-interface {
+        type string;
+        description
+          "SR underlay NIC: replicated copies leave here, and the leaf
+           End.DT2M decap classifier attaches to its ingress.";
+      }
+      leaf bridge-interface {
+        type string;
+        description
+          "Bridge port a leaf floods decapped BUM frames into for native
+           delivery to the local attachment circuits.";
+      }
+      leaf next-hop-mac {
+        type string;
+        description
+          "Outer Ethernet next-hop MAC (aa:bb:cc:dd:ee:ff) the encapsulated
+           copies are sent to on the underlay.";
+      }
+    }
   }
 
   /* =========================================================


### PR DESCRIPTION
## Summary

Fifth control-plane slice of the EVPN SR P2MP (RFC 9524) replication **control→dataplane integration**: a config path for the interfaces + next hop the SRv6 BUM-replication eBPF dataplane attaches to, replacing the `ZEBRA_TC_EVPN_REPLICATE_IFACE` env-var stopgap.

### YANG (`zebra-bgp-evpn.yang`)
- New `router bgp afi-safi evpn sr-p2mp-dataplane` container: `overlay-interface`, `underlay-interface`, `bridge-interface`, `next-hop-mac`.

### bgp
- `EvpnSrDataplaneCfg` on the `Bgp` instance + four config handlers; each updates one field and re-pushes the whole topology to the RIB replication supervisor via a new `rib::Message::ReplDataplaneCfg`.

### rib
- The supervisor's `ReplicationHelper::set_topology` stores the topology in a `DataplaneTopology` and logs whether it `is_complete()` (every interface + next hop set). **Storage only** — spawning the eBPF children from it is the next slice.

## Test plan

- `cargo test -p zebra-rs --bin zebra-rs sr_p2mp_dataplane` — the new `bgp_evpn_sr_p2mp_dataplane_is_settable` YANG settability guard passes.
- `cargo clippy --workspace --all-targets -- -D warnings` — clean (all topology fields are consumed by `is_complete()`, so no dead code / no `#[allow]`).

Next: the supervisor consumes this topology to spawn both eBPF children (root `H.Encaps` egress + leaf `End.DT2M` ingress) and emit `encap-cfg`/`leaf-add` with the local + per-leaf SIDs.

Generated with [Claude Code](https://claude.com/claude-code)