### PR TITLE
rib: add EVPN SR P2MP encap child + unify dataplane config

### DIFF
--- a/zebra-rs/src/rib/evpn_replicate.rs
+++ b/zebra-rs/src/rib/evpn_replicate.rs
@@ -8,23 +8,26 @@
 //! process — this module is its supervisor, mirroring the BFD echo reflector
 //! (`bfd::reflector::EchoReflectors`).
 //!
-//! A single clsact-ingress child carries every VNI's maps; it is spawned on the
-//! first replication segment OR leaf SID and SIGTERM'd (clean TC detach) when
-//! both are withdrawn. State is pushed over a stdin line protocol:
+//! Two children carry every VNI's state — an **ingress** child (clsact ingress
+//! on the underlay: `End.Replicate` for a root/bud, `End.DT2M` decap for a leaf)
+//! and an **encap** child (root `H.Encaps`, clsact egress on the overlay port).
+//! Each is spawned lazily on the first segment/leaf SID and SIGTERM'd (clean TC
+//! detach) when no role needs it. State is pushed over a stdin line protocol:
 //!
 //! ```text
-//!   repl-add <vni> <tree-id> <srv6:0|1> <root-ip> <leaf-ip>...   # root/bud
-//!   repl-del <vni>
-//!   leaf-add <vni> <dt2m-sid>                                    # End.DT2M leaf
-//!   leaf-del <vni>
+//!   repl-add  <vni> <tree-id> <srv6:0|1> <root> <leaf-sid>...  # ingress + encap
+//!   repl-del  <vni>
+//!   leaf-add  <vni> <local-end-dt2m-sid>                       # ingress (decap)
+//!   leaf-del  <vni>
+//!   encap-cfg <vni> <underlay> <root> <eth-dst> <eth-src>      # encap (root)
 //! ```
 //!
-//! The underlay interface the classifier attaches to comes from
-//! `$ZEBRA_TC_EVPN_REPLICATE_IFACE`; with it unset the dataplane is disabled
-//! (the control plane still signals, nothing forwards) — honest on a host
-//! without the offload installed. A leaf also needs the bridge port it floods
-//! decapped frames into, from `$ZEBRA_TC_EVPN_REPLICATE_BRIDGE`. The egress
-//! root `H.Encaps` role is a separate `--encap` child (a follow-up).
+//! The attach interfaces + next hop come from BGP's `sr-p2mp-dataplane` config
+//! ([`ReplicationHelper::set_topology`]), with `$ZEBRA_TC_EVPN_REPLICATE_IFACE`
+//! / `_BRIDGE` as fallbacks for the underlay / leaf-flood bridge. Until the
+//! needed interfaces are configured the dataplane is disabled (the control
+//! plane still signals, nothing forwards) — honest on a host without the
+//! offload installed.
 
 use std::collections::BTreeSet;
 use std::net::{IpAddr, Ipv6Addr};
@@ -73,31 +76,55 @@ impl DataplaneTopology {
     }
 }
 
-/// Supervises the single `tc-evpn-replicate` child that forwards EVPN BUM over
-/// SR P2MP replication trees. Lifecycle is reference-counted by the set of
-/// VNIs that currently have a replication segment.
+/// One managed `tc-evpn-replicate` child process + its stdin IPC task.
+struct ReplChild {
+    child: Child,
+    cmd_tx: UnboundedSender<String>,
+    _io: Task<()>,
+}
+
+impl ReplChild {
+    /// Queue one command line to the child's stdin.
+    fn send(&self, line: String) {
+        let _ = self.cmd_tx.send(line);
+    }
+
+    /// SIGTERM the child so the loader detaches its TC program cleanly.
+    /// `kill_on_drop(true)` reaps it (SIGKILL) if it ignores us.
+    fn stop(&self) {
+        if let Some(pid) = self.child.id() {
+            unsafe {
+                libc::kill(pid as libc::pid_t, libc::SIGTERM);
+            }
+        }
+    }
+}
+
+/// Supervises the `tc-evpn-replicate` eBPF children that forward EVPN BUM over
+/// SR P2MP replication trees: an **ingress** child (clsact ingress on the
+/// underlay — `End.Replicate` for a root/bud, `End.DT2M` decap for a leaf) and
+/// an **encap** child (root `H.Encaps`, clsact egress on the overlay port).
+/// Each is spawned lazily and SIGTERM'd when no role needs it; lifecycle is
+/// reference-counted by the replication-segment + leaf-SID VNI sets.
 pub struct ReplicationHelper {
     /// VNIs with an active replication segment (`repl-add`) — root/bud role.
     vnis: BTreeSet<u32>,
     /// VNIs with a local `End.DT2M` leaf SID (`leaf-add`) — leaf role. Tracked
-    /// separately from `vnis` so the child lives while EITHER role is active.
+    /// separately from `vnis` so the children live while EITHER role is active.
     leaf_vnis: BTreeSet<u32>,
-    /// The child process, if it spawned. `None` when the dataplane is disabled
-    /// (no interface) or the spawn failed.
-    child: Option<Child>,
-    /// Queue for stdin command lines to the child's IPC task.
-    cmd_tx: Option<UnboundedSender<String>>,
-    /// IPC task: writes commands to the child's stdin. Aborts when dropped.
-    _io: Option<Task<()>>,
+    /// Ingress child: `End.Replicate` (root/bud) + `End.DT2M` (leaf), clsact
+    /// ingress on the underlay.
+    ingress: Option<ReplChild>,
+    /// Encap child: root `H.Encaps`, clsact egress on the overlay port.
+    encap: Option<ReplChild>,
     bin: PathBuf,
-    /// Underlay interface to attach to; `None` ($ZEBRA_..._IFACE unset)
-    /// disables the dataplane.
+    /// Underlay interface env fallback ($ZEBRA_..._IFACE) when the YANG topology
+    /// has no `underlay-interface`.
     iface: Option<String>,
-    /// Bridge port a leaf floods decapped frames into ($ZEBRA_..._BRIDGE).
+    /// Leaf flood bridge-port env fallback ($ZEBRA_..._BRIDGE).
     bridge: Option<String>,
-    /// Dataplane topology from BGP `sr-p2mp-dataplane` config. Consumed when
-    /// the eBPF children are (re)spawned (a follow-up); stored here so the
-    /// supervisor has it before the first replication segment arrives.
+    /// Dataplane topology from BGP `sr-p2mp-dataplane` config — the primary
+    /// source for the attach interfaces + next hop (the env vars are fallback).
     topology: DataplaneTopology,
 }
 
@@ -112,9 +139,8 @@ impl ReplicationHelper {
         Self {
             vnis: BTreeSet::new(),
             leaf_vnis: BTreeSet::new(),
-            child: None,
-            cmd_tx: None,
-            _io: None,
+            ingress: None,
+            encap: None,
             bin: resolve_bin(),
             iface: std::env::var(IFACE_ENV).ok().filter(|s| !s.is_empty()),
             bridge: std::env::var(BRIDGE_ENV).ok().filter(|s| !s.is_empty()),
@@ -145,35 +171,80 @@ impl ReplicationHelper {
         );
     }
 
-    /// Install or refresh the SR P2MP replication segment for `vni`, spawning
-    /// the child on the first segment.
-    pub fn add(&mut self, vni: u32, tree_id: u32, root: IpAddr, srv6: bool, leaves: &[IpAddr]) {
-        self.ensure_child();
-        self.vnis.insert(vni);
-        let mut line = format!("repl-add {vni} {tree_id} {} {root}", u8::from(srv6));
-        for leaf in leaves {
-            line.push(' ');
-            line.push_str(&leaf.to_string());
-        }
-        self.send(line);
+    /// Underlay interface: YANG `underlay-interface`, else the env fallback.
+    fn underlay(&self) -> Option<String> {
+        self.topology
+            .underlay
+            .clone()
+            .or_else(|| self.iface.clone())
     }
 
-    /// Withdraw the replication segment for `vni`, stopping the child when no
-    /// role (segment or leaf) needs it any more.
+    /// Leaf flood bridge port: YANG `bridge-interface`, else the env fallback.
+    fn bridge_port(&self) -> Option<String> {
+        self.topology.bridge.clone().or_else(|| self.bridge.clone())
+    }
+
+    /// Install or refresh the SR P2MP replication segment for `vni`: program the
+    /// ingress child's `End.Replicate` fan-out and, when the SRv6 encap topology
+    /// is configured, the egress encap child's root `H.Encaps` fan-out.
+    pub fn add(&mut self, vni: u32, tree_id: u32, root: IpAddr, srv6: bool, leaves: &[IpAddr]) {
+        self.vnis.insert(vni);
+        let mut repl = format!("repl-add {vni} {tree_id} {} {root}", u8::from(srv6));
+        for leaf in leaves {
+            repl.push(' ');
+            repl.push_str(&leaf.to_string());
+        }
+        // Ingress child: a bud replicates packets addressed to its local
+        // replication SID (inert at a pure root/leaf, but harmless).
+        self.ensure_ingress();
+        if let Some(c) = &self.ingress {
+            c.send(repl.clone());
+        }
+        // Encap child (root H.Encaps): wrap a bare BUM frame and fan it out, one
+        // copy per leaf End.DT2M SID. SRv6-only, and needs the full encap
+        // topology (overlay + underlay + next hop).
+        if srv6 {
+            self.ensure_encap();
+            if let (Some(c), Some(underlay), Some(eth_dst)) = (
+                self.encap.as_ref(),
+                self.topology.underlay.as_ref(),
+                self.topology.next_hop_mac.as_ref(),
+            ) {
+                // Outer Ethernet source = the underlay NIC's own MAC.
+                let eth_src =
+                    iface_mac(underlay).unwrap_or_else(|| "00:00:00:00:00:00".to_string());
+                c.send(format!(
+                    "encap-cfg {vni} {underlay} {root} {eth_dst} {eth_src}"
+                ));
+                c.send(repl);
+            }
+        }
+    }
+
+    /// Withdraw the replication segment for `vni`, stopping the children when no
+    /// role (segment or leaf) needs them any more.
     pub fn del(&mut self, vni: u32) {
         if !self.vnis.remove(&vni) {
             return;
         }
-        self.send(format!("repl-del {vni}"));
+        let line = format!("repl-del {vni}");
+        if let Some(c) = &self.ingress {
+            c.send(line.clone());
+        }
+        if let Some(c) = &self.encap {
+            c.send(line);
+        }
         self.stop_if_idle();
     }
 
     /// Program this node's local `End.DT2M` leaf SID for `vni`, so a replicated
     /// copy addressed to it is decapsulated and flooded into the bridge.
     pub fn leaf_add(&mut self, vni: u32, sid: Ipv6Addr) {
-        self.ensure_child();
+        self.ensure_ingress();
         self.leaf_vnis.insert(vni);
-        self.send(format!("leaf-add {vni} {sid}"));
+        if let Some(c) = &self.ingress {
+            c.send(format!("leaf-add {vni} {sid}"));
+        }
     }
 
     /// Withdraw this node's `End.DT2M` leaf SID for `vni`.
@@ -181,79 +252,104 @@ impl ReplicationHelper {
         if !self.leaf_vnis.remove(&vni) {
             return;
         }
-        self.send(format!("leaf-del {vni}"));
+        if let Some(c) = &self.ingress {
+            c.send(format!("leaf-del {vni}"));
+        }
         self.stop_if_idle();
     }
 
-    /// Stop the child once neither role (replication segment nor leaf SID) is
-    /// active, so the loader detaches its TC program cleanly.
+    /// Stop both children once neither role (replication segment nor leaf SID)
+    /// is active, so the loaders detach their TC programs cleanly.
     fn stop_if_idle(&mut self) {
         if self.vnis.is_empty() && self.leaf_vnis.is_empty() {
             self.stop();
         }
     }
 
-    fn send(&self, line: String) {
-        if let Some(tx) = &self.cmd_tx {
-            let _ = tx.send(line);
-        }
-    }
-
-    fn ensure_child(&mut self) {
-        if self.child.is_some() {
+    /// Spawn the ingress child (`--direction ingress` on the underlay, with the
+    /// leaf flood `--bridge-iface`) if not already running.
+    fn ensure_ingress(&mut self) {
+        if self.ingress.is_some() {
             return;
         }
-        let Some(iface) = self.iface.clone() else {
-            tracing::debug!("evpn replication: {IFACE_ENV} unset; SR P2MP dataplane disabled");
+        let Some(iface) = self.underlay() else {
+            tracing::debug!("evpn replication: no underlay interface; SR P2MP dataplane disabled");
             return;
         };
-        // `tc_evpn_replicate` is the clsact-*ingress* classifier: it demuxes the
-        // inbound outer DA to End.Replicate (root/bud) or End.DT2M (leaf) by the
-        // REPL_LOCAL_SID / DT2M_SID maps. A leaf also needs the bridge port it
-        // floods decapped frames into (`--bridge-iface`). The egress H.Encaps
-        // role is a separate `--encap` child (PR-C2).
-        let mut cmd = Command::new(&self.bin);
-        cmd.arg("--iface")
-            .arg(&iface)
-            .arg("--direction")
-            .arg("ingress");
-        if let Some(bridge) = &self.bridge {
-            cmd.arg("--bridge-iface").arg(bridge);
+        let mut args: Vec<String> = vec![
+            "--iface".into(),
+            iface,
+            "--direction".into(),
+            "ingress".into(),
+        ];
+        if let Some(bridge) = self.bridge_port() {
+            args.push("--bridge-iface".into());
+            args.push(bridge);
         }
-        match cmd.stdin(Stdio::piped()).kill_on_drop(true).spawn() {
+        let argv: Vec<&str> = args.iter().map(String::as_str).collect();
+        self.ingress = self.spawn_child("ingress", &argv);
+    }
+
+    /// Spawn the encap child (`--encap` on the overlay port) if not already
+    /// running. Needs the full encap topology — overlay + underlay + next hop
+    /// (no env fallback for overlay / next-hop MAC).
+    fn ensure_encap(&mut self) {
+        if self.encap.is_some() {
+            return;
+        }
+        // Needs the full encap topology; overlay + next-hop MAC have no env
+        // fallback, so the encap child only runs once they are configured.
+        let Some(overlay) = self.topology.overlay.as_deref() else {
+            return;
+        };
+        if self.topology.underlay.is_none() || self.topology.next_hop_mac.is_none() {
+            return;
+        }
+        self.encap = self.spawn_child("encap", &["--iface", overlay, "--encap"]);
+    }
+
+    /// Spawn one `tc-evpn-replicate` child with `args`, wiring its stdin IPC.
+    fn spawn_child(&self, role: &str, args: &[&str]) -> Option<ReplChild> {
+        match Command::new(&self.bin)
+            .args(args)
+            .stdin(Stdio::piped())
+            .kill_on_drop(true)
+            .spawn()
+        {
             Ok(mut child) => {
                 tracing::info!(
-                    "evpn replication: spawned {} on {iface}",
-                    self.bin.display()
+                    "evpn replication: spawned {} {role} child ({})",
+                    self.bin.display(),
+                    args.join(" ")
                 );
-                if let Some(stdin) = child.stdin.take() {
-                    let (tx, rx) = mpsc::unbounded_channel::<String>();
-                    self._io = Some(Task::spawn(child_io(stdin, rx)));
-                    self.cmd_tx = Some(tx);
-                }
-                self.child = Some(child);
+                let stdin = child.stdin.take()?;
+                let (tx, rx) = mpsc::unbounded_channel::<String>();
+                let io = Task::spawn(child_io(stdin, rx));
+                Some(ReplChild {
+                    child,
+                    cmd_tx: tx,
+                    _io: io,
+                })
             }
             Err(e) => {
                 tracing::warn!(
-                    "evpn replication: failed to spawn {} on {iface}: {e}",
+                    "evpn replication: failed to spawn {} {role} child: {e}",
                     self.bin.display()
                 );
+                None
             }
         }
     }
 
-    /// SIGTERM the child so the loader detaches its TC program cleanly.
-    /// `kill_on_drop(true)` reaps it (SIGKILL) if it ignores us.
+    /// SIGTERM both children (last role withdrawn) so the loaders detach cleanly.
     fn stop(&mut self) {
-        if let Some(pid) = self.child.as_ref().and_then(Child::id) {
-            unsafe {
-                libc::kill(pid as libc::pid_t, libc::SIGTERM);
-            }
-            tracing::info!("evpn replication: stopping replicator (last segment withdrawn)");
+        if let Some(c) = self.ingress.take() {
+            c.stop();
         }
-        self.child = None;
-        self.cmd_tx = None;
-        self._io = None;
+        if let Some(c) = self.encap.take() {
+            c.stop();
+        }
+        tracing::info!("evpn replication: stopped (no active role)");
     }
 }
 
@@ -286,6 +382,15 @@ fn resolve_bin() -> PathBuf {
     PathBuf::from("/usr/sbin/tc-evpn-replicate")
 }
 
+/// Read an interface's MAC address from sysfs (`/sys/class/net/<name>/address`)
+/// — the outer Ethernet source of the encapsulated copies.
+fn iface_mac(name: &str) -> Option<String> {
+    std::fs::read_to_string(format!("/sys/class/net/{name}/address"))
+        .ok()
+        .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -303,7 +408,10 @@ mod tests {
         h.add(10, 10, ip("10.0.0.1"), false, &[ip("10.0.0.2")]);
         h.add(20, 20, ip("10.0.0.1"), true, &[ip("10.0.0.3")]);
         assert_eq!(h.vnis, BTreeSet::from([10, 20]));
-        assert!(h.child.is_none(), "no iface → no child spawned");
+        assert!(
+            h.ingress.is_none() && h.encap.is_none(),
+            "no interfaces → no children spawned"
+        );
 
         h.del(10);
         assert_eq!(h.vnis, BTreeSet::from([20]));


### PR DESCRIPTION
## Summary

Reconciles the two parallel SR P2MP supervisor efforts into one coherent design.

- **#1575** ("seg 6.3 PR-C1") wired the **leaf** `End.DT2M` role (ingress child, `leaf-add` via `ReplLeafAdd`) and explicitly **deferred** the egress root `H.Encaps` child.
- **#1574** added the YANG `sr-p2mp-dataplane` topology but left it unused for spawning.

This adds the missing **send side** and unifies the config path:

- `ReplicationHelper` now manages **two** children via a `ReplChild` struct: the existing **ingress** child (`End.Replicate` + `End.DT2M`, on the underlay) and a new **encap** child (root `H.Encaps`, `--encap` on the overlay port).
- On a segment, the encap child is fed `encap-cfg <vni> <underlay> <root> <eth-dst> <eth-src>` (outer source MAC read from the underlay NIC's sysfs) + `repl-add` with the per-leaf `End.DT2M` SIDs. SRv6-only; needs the full encap topology (overlay + underlay + next hop). Both children SIGTERM when no role (segment or leaf SID) is active.
- **Unify config**: attach interfaces + next hop come from the YANG topology (`set_topology`) first, with `$ZEBRA_TC_EVPN_REPLICATE_IFACE` / `_BRIDGE` as fallbacks.
- The leaf path (`leaf_add`/`leaf_del`/`ReplLeafAdd` from #1575) is unchanged.

This completes the EVPN SR P2MP control→dataplane wiring (advertise/learn `End.DT2M` SIDs → fan out to real SIDs → YANG topology → spawn + feed both eBPF children). Remaining: a two-PE netns lab to validate end-to-end (offload is workspace-excluded from CI).

## Test plan

- `cargo test -p zebra-rs --bin zebra-rs evpn_replicate` — dual-role lifecycle + no-interface-no-spawn pass.
- `cargo clippy --workspace --all-targets -- -D warnings` — clean.

Generated with [Claude Code](https://claude.com/claude-code)