### PR TITLE
docs(bdd): regenerate feature docs from .feature sources

### DIFF
--- a/bdd/docs/bgp_addpath_group.md
+++ b/bdd/docs/bgp_addpath_group.md
@@ -1,0 +1,42 @@
+# BGP AddPath Send for IPv4 unicast (RFC 7911)
+
+## Overview
+
+As a network operator
+I want a BGP speaker with two paths for one prefix to advertise BOTH
+of them — each carrying its own path identifier — to a neighbor that
+negotiated AddPath, instead of the single best path.
+This is the first end-to-end AddPath wire test in the suite: it
+exercises the per-candidate advertise twin
+(`route_advertise_to_addpath`), the AddPath-Send membership split,
+and the path-id stamping. The same shape validates the VPNv6 / EVPN /
+labeled-unicast twins as those land.
+
+## Test Topology
+
+```
+        10.10.10.0/24          10.10.10.0/24
+       (origin AS65001)       (origin AS65002)
+            z1 ──┐               ┌── z2
+       192.168.   │   192.168.   │   192.168.
+        0.1/24    └──→  0.3/24  ←─┘    0.2/24
+                       z3 (AS65003)
+                        │  add-path send-receive
+                        ↓
+                       z4 (AS65004)  192.168.0.4/24
+```
+
+## Notes
+
+z3 learns 10.10.10.0/24 over eBGP from BOTH z1 (AS_PATH 65001) and
+z2 (AS_PATH 65002), so its Loc-RIB holds two candidate paths. With
+AddPath Send negotiated toward z4, z3 advertises both — so z4 sees
+TWO available paths for the prefix, not just the best one.
+
+## Test Scenarios
+
+| Scenario | Result |
+|----------|--------|
+| Setup topology and establish sessions | |
+| The AddPath receiver sees both paths for the prefix | |
+| Teardown topology | |

--- a/bdd/docs/bgp_afi_safi_policy.md
+++ b/bdd/docs/bgp_afi_safi_policy.md
@@ -1,0 +1,41 @@
+# BGP per-AFI neighbor policy under afi-safi (peer-wide fallback)
+
+## Overview
+
+As a network operator I want to bind a route-policy per address family
+under `neighbor X afi-safi <name> policy {in,out}`. The per-neighbor
+peer-wide `neighbor X policy {in,out}` form has been retired; the only
+way to bind a peer-wide route-policy is now through a `neighbor-group`,
+which a neighbor inherits as a fallback across families. A per-AFI
+binding MUST take priority over the inherited peer-wide one for routes
+of that family.
+This is observed inbound on z2: z1 originates two /32s; z2's inbound
+policy decides which survive in z2's BGP table. Policy edits are picked
+up live (soft-reconfiguration inbound), no session reset.
+
+## Test Topology
+
+```
+  z1 (AS65001) ──eBGP── z2 (AS65002)
+  192.168.0.1/24        192.168.0.2/24
+```
+
+## Notes
+
+Both on bridge br0.
+
+## Config Files
+
+- z1.yaml: AS65001, peers z2, originates 10.0.0.1/32 + 10.0.0.2/32.
+- z2-base.yaml: AS65002, peers z1, soft-reconfiguration inbound, no
+- z2-peerwide-deny.yaml: binds a peer-wide `policy in DENY-ALL` (deny
+- z2-perafi-permit.yaml: adds `afi-safi ipv4 policy in PERMIT-ALL`
+
+## Test Scenarios
+
+| Scenario | Result |
+|----------|--------|
+| Setup sessions; with no policy both routes are accepted | |
+| Peer-wide policy inherited from a neighbor-group denies every inbound route | |
+| A per-AFI ipv4 policy overrides the inherited peer-wide deny — routes return | |
+| Teardown topology | |

--- a/bdd/docs/bgp_community.md
+++ b/bdd/docs/bgp_community.md
@@ -43,10 +43,9 @@ route from A exercises both re-advertisement edges:
 - z2-1.yaml: B — eBGP to A, iBGP to C, eBGP to D.
 - z3-1.yaml: C — iBGP to B only.
 - z4-1.yaml: D — eBGP to B only.
-- eBGP MinRouteAdvertisementInterval = 30 s
-- iBGP MinRouteAdvertisementInterval =  5 s
-- End-to-end A → B → C propagation: up to 30 + 5 = 35 s.
-- End-to-end A → B → D propagation: up to 30 + 30 = 60 s.
+- Every router sets `timer adv-interval ebgp: 3`, overriding the
+- End-to-end A → B → C propagation: up to 3 + 5 =  8 s.
+- End-to-end A → B → D propagation: up to 3 + 3 =  6 s.
 - Each scenario that triggers a fresh advertisement on A waits
 
 Convergence wait-time rationale:

--- a/bdd/docs/bgp_ebgp_strip_v6.md
+++ b/bdd/docs/bgp_ebgp_strip_v6.md
@@ -1,0 +1,61 @@
+# BGP iBGP-only attributes are stripped on eBGP egress (IPv6 unicast)
+
+## Overview
+
+As a network operator
+I want the iBGP-only path attributes — ORIGINATOR_ID, CLUSTER_LIST and
+LOCAL_PREF — to stay inside the AS for IPv6 unicast routes too
+So that an iBGP-learned IPv6 route re-advertised to an eBGP peer does not
+leak attributes that have meaning only within the local AS.
+This is the IPv6 counterpart of @bgp_rr_ebgp_strip: the egress builder
+`route_update_ipv6` clones the route's stored attrs, so without the
+eBGP strip an iBGP-learned v6 route would carry ORIGINATOR_ID /
+CLUSTER_LIST (RFC 4456 §8) and LOCAL_PREF (RFC 4271 §5.1.5) across the
+AS boundary. Sessions are IPv6-transport so next-hop-self uses the
+session's local v6 address directly.
+
+## Test Topology
+
+```
+  ┌────────────────────────────────────────────────────────────────────────┐
+  │                                  br0                                   │
+  └────────┬──────────────────┬──────────────────┬──────────────────┬─────┘
+           │                  │                  │                  │
+      ┌────┴────┐        ┌────┴────┐        ┌────┴────┐        ┌────┴────┐
+      │   z1    │  iBGP  │   z2    │        │   z3    │  eBGP  │   z4    │
+      │  (RR)   │◀──────▶│(client) │        │(client) │◀──────▶│ (peer)  │
+      │ AS65001 │        │ AS65001 │        │+ border │        │ AS65002 │
+      │id 10.0. │        │id 10.0. │        │ AS65001 │        │id 10.0. │
+      │   0.1   │        │   0.2   │        │id 10.0. │        │   0.4   │
+      │2001:db8 │        │2001:db8 │        │   0.3   │        │2001:db8 │
+      │   ::1   │        │   ::2   │        │2001:db8 │        │   ::4   │
+      └────┬────┘        └─────────┘        │   ::3   │        └─────────┘
+           │ iBGP (RR client)               └────┬────┘
+           └─────────────────────────────────────┘
+```
+
+## Notes
+
+- z1 is the route reflector; z2 and z3 are its clients (same AS 65001).
+- z2 originates 2001:db8:beef::/64 and advertises it to the RR (z1).
+- z1 REFLECTS the route to client z3, stamping ORIGINATOR_ID (z2's
+  router-id 10.0.0.2) and CLUSTER_LIST (z1's cluster-id). z3 therefore
+  sees the route WITH the iBGP-only attributes — the positive control.
+- z3 re-advertises the route to its eBGP peer z4 (AS 65002). z4 MUST
+  receive the route WITHOUT ORIGINATOR_ID / CLUSTER_LIST / LOCAL_PREF.
+
+## Config Files
+
+- z1.yaml: RR — iBGP to z2 and z3, both route-reflector clients.
+- z2.yaml: client — iBGP to z1; originates 2001:db8:beef::/64.
+- z3.yaml: client + border — iBGP to z1, eBGP to z4.
+- z4.yaml: eBGP peer — eBGP to z3 only.
+
+## Test Scenarios
+
+| Scenario | Result |
+|----------|--------|
+| Setup topology and establish BGP sessions | |
+| RR client z3 receives the reflected route WITH the iBGP-only attributes | |
+| eBGP peer z4 receives the route but NOT the iBGP-only attributes | |
+| Teardown topology | |

--- a/bdd/docs/bgp_egress_group_sharded.md
+++ b/bdd/docs/bgp_egress_group_sharded.md
@@ -1,0 +1,56 @@
+# BGP IPv4-unicast read paths at N>1 (show / session-up sync read the empty main shard)
+
+## Overview
+
+Regression test for a correctness gap in BGP RIB sharding. At
+ZEBRA_BGP_SHARDS>1, plain IPv4-unicast routes are dispatched to the
+worker-shard pool (RouteBatchV4) and live ONLY in the pool shards; the
+reduce (`route_apply_bestpath_v4_batch`) used to do FIB-install +
+advertise but never mirror the best-path back into the synchronous
+`bgp.shard`, so every read path that consults `bgp.shard.v4` was empty
+at N>1:
+Forwarding itself is unaffected: the event-driven advertise runs off the
+best-path delta, not `bgp.shard`. This is IPv4-unicast-specific (the only
+pooled family); v6 / VPNv4 / VPNv6 / labeled-unicast are sync-ingested,
+so their `bgp.shard` tables stay populated and read correctly at N>1.
+z2 is the sharded device under test (4 shards) and the transit between
+z1 (origin) and two downstream peers:
+FIXED by the read-replica mirror: the pool reduce
+(`route_apply_bestpath_v4_batch` → `BgpShard::mirror_v4`) now keeps the
+main shard's `bgp.shard.v4` in step with the pool-owned table, so both
+read paths — `route_sync_ipv4` (for the late peer z4) and `show bgp
+ipv4` (z2's own RIB) — see the routes at N>1. This feature now guards
+against regressing that. (The sync build still runs serially on the
+main task; parallelizing its egress is a separate optimization, see
+docs/design/bgp-rib-sharding-plan.md §B.4.)
+A THIRD read path — `show bgp neighbor <peer> received-routes` (the
+peer's Adj-RIB-In) — is NOT covered by the Loc-RIB mirror: the
+authoritative adj_in lives in the pool shards, so at N>1 this read
+scatter-gathers it from every shard (A2 ⑤, `ShardMsg::DumpAdjInV4`). The
+received-routes scenario below guards that.
+
+## Test Topology
+
+```
+                         ┌── z3 (AS65003)  early peer  → event-driven (control)
+  z1 (AS65001) ── z2 (AS65002, 4 shards) ──┤
+   10.0.0.1/24    10.0.0.2/24              └── z4 (AS65004)  late peer   → sync (bug)
+   origin         sharded transit
+```
+
+## Notes
+
+All four on bridge br0. z1 originates 10.10.10.0/24 + 10.10.11.0/24.
+
+## Test Scenarios
+
+| Scenario | Result |
+|----------|--------|
+| z1, the sharded z2, and the early peer z3 come up (no routes yet) | |
+| control — z1 originates while z3 is up; the event-driven advertise reaches z3 | |
+| the late peer z4 gets the routes on sync, and z2 can show its own RIB | |
+| z2's received-routes from z1 are gathered from the pool shards (N>1 Adj-RIB-In) | |
+| z2's `show bgp ipv4 summary` counts come from the shards (PfxRcd) and the group task (PfxSnt) | |
+| z1 withdraws one route; the sharded reduce removes it from z2's mirror | |
+| z1's session drops; the sharded peer-down sweep clears z2's mirror | |
+| Teardown topology | |

--- a/bdd/docs/bgp_egress_group_task.md
+++ b/bdd/docs/bgp_egress_group_task.md
@@ -1,0 +1,41 @@
+# BGP per-update-group egress task (migration Phases 0-3)
+
+## Overview
+
+Per-update-group egress-task migration
+(docs/design/bgp-egress-group-task-migration.md). At
+ZEBRA_BGP_EGRESS_GROUP_TASK=1 the v4-unicast egress runs in one task per
+update group (M tasks, not N peers): the task owns the group adj_out,
+encodes each best path once, and fans the bytes to its member peers,
+excluding the path's source (split-horizon).
+This feature exercises the gate-on egress matrix through the group task:
+z3 and z4 share one update group (same eBGP egress identity; remote-AS is
+not part of the signature). z2 is the device under test, started with the
+egress group task.
+
+## Test Topology
+
+```
+                        ┌── z3 (AS65003)  early peer
+  z1 (AS65001) ── z2 (AS65002) ──┤
+                  egress group   └── z4 (AS65004)  late peer (Phase 3)
+                  task (gate-on)
+```
+
+## Notes
+
+All four on bridge br0. z1 originates 10.10.10.0/24 + 10.10.11.0/24.
+
+## Test Scenarios
+
+| Scenario | Result |
+|----------|--------|
+| a group forming spawns its egress task; early speakers establish | |
+| routes propagate through the group task (Phase 1b event-driven advertise) | |
+| advertised-routes reads the group adj_out, split-horizon filtered (Phase 5) | |
+| a late peer z4 gets the routes on session-up sync (Phase 3) | |
+| a clear soft-out re-fans the group through the task (Phase 4) | |
+| z2's `show bgp ipv4 summary` PfxSnt comes from the group task (N=1, group gate only) | |
+| an event-driven withdraw reaches BOTH the early and the late member (Phase 3 coherence) | |
+| peer-down withdraws through the group task to both members (Phase 2/3) | |
+| Teardown topology | |

--- a/bdd/docs/bgp_evpn_ar.md
+++ b/bdd/docs/bgp_evpn_ar.md
@@ -1,0 +1,48 @@
+# BGP EVPN Assisted Replication (RFC 9574) control plane
+
+## Overview
+
+As a network operator
+I want zebra-rs to signal RFC 9574 Assisted Replication roles in the
+Type-3 (Inclusive Multicast) IMET route and build the BUM flood list
+accordingly, so that an AR-LEAF offloads BUM replication to an
+AR-REPLICATOR while an RNVE keeps plain ingress replication.
+Test Topology — three iBGP (AS 65001) EVPN speakers on a shared bridge,
+each with a local VXLAN (VNI 10) so every node originates a Type-3 IMET:
+```
+┌──────────────────────────────────────────────────────────┐
+│                            br0                            │
+└─────────┬─────────────────┬─────────────────┬─────────────┘
+```
+Roles (router bgp afi-safi evpn assisted-replication):
+- z1: role replicator, replicator-ip 192.168.0.101 (the AR-IP)
+- z2: role leaf
+- z3: role none (default RNVE); also requests whole-VTEP P-FL pruning
+The flood list is observed via the kernel VXLAN FDB: the daemon programs
+zero-MAC (00:00:00:00:00:00) rows, one `dst` per flood target. There is
+no actual BUM forwarding here — the FDB *decisions* are the unit under
+test, so the AR-IP need not be a reachable interface.
+
+## Notes
+
+Roles (router bgp afi-safi evpn assisted-replication):
+- z1: role replicator, replicator-ip 192.168.0.101 (the AR-IP)
+- z2: role leaf
+- z3: role none (default RNVE); also requests whole-VTEP P-FL pruning
+  (pruned-flood-list broadcast-multicast + unknown-unicast)
+The flood list is observed via the kernel VXLAN FDB: the daemon programs
+zero-MAC (00:00:00:00:00:00) rows, one `dst` per flood target. There is
+no actual BUM forwarding here — the FDB *decisions* are the unit under
+test, so the AR-IP need not be a reachable interface.
+
+## Test Scenarios
+
+| Scenario | Result |
+|----------|--------|
+| Setup topology and establish the EVPN iBGP full mesh | |
+| Type-3 IMET routes are exchanged across the EVPN mesh | |
+| AR-LEAF collapses its BUM flood list to the replicator's AR-IP | |
+| RNVE floods to every remote VTEP (plain ingress replication) | |
+| A whole-VTEP Pruned-Flood-List request drops the node from peers' flood lists | |
+| Selective AR — the AR-LEAF originates a Leaf A-D toward the replicator | |
+| Teardown topology | |

--- a/bdd/docs/bgp_evpn_df_election.md
+++ b/bdd/docs/bgp_evpn_df_election.md
@@ -1,0 +1,27 @@
+# BGP EVPN BUM segmentation — inter-AS DF election (RFC 9572 Section 5.3.1)
+
+## Overview
+
+As a network operator
+I want the ASBRs that border a downstream AS to attach a DF Election Extended
+Community (RFC 8584, AC-DF cleared) to their re-originated Per-Region I-PMSI
+(Type-9) routes and elect a single Designated Forwarder, so a downstream AS
+containing legacy PEs receives no duplicated BUM traffic.
+Test Topology — region A (AS 65001) is bordered by TWO ASBRs, z2 (.0.2) and
+z4 (.0.4), both re-originating region A's Type-9 toward the downstream AS
+65002 (z3). z1 is a plain (legacy, non-segmentation) PE in region A.
+```
+┌──────────────────────────────────────────────────────────────────┐
+│                               br0                                 │
+└───────┬───────────────┬───────────────┬───────────────┬──────────┘
+```
+
+## Test Scenarios
+
+| Scenario | Result |
+|----------|--------|
+| Setup topology and establish the EVPN sessions | |
+| Both ASBRs attach a DF Election EC to their Per-Region I-PMSI | |
+| The downstream AS elects the lowest-address ASBR as DF | |
+| An ASBR flags the legacy (non-segmentation) PE in its region | |
+| Teardown topology | |

--- a/bdd/docs/bgp_evpn_gateway_df.md
+++ b/bdd/docs/bgp_evpn_gateway_df.md
@@ -1,0 +1,26 @@
+# BGP EVPN BUM segmentation — DF-gated gateway re-flood (RFC 9572 §5.3.1, Phase 6.2)
+
+## Overview
+
+As a network operator
+I want only the elected Designated Forwarder among the gateways bordering a
+region to deliver BUM into it, so that with multiple redundant gateways no
+duplicate BUM is produced — the standby gateway drops the region from its
+re-flood set.
+Control-plane only (the eBPF replication is a follow-up). Two gateways z2 and
+z4 border both region A (z1) and region B (z3); z2 (lower address) wins the
+modulus DF election for both regions, so z2 re-floods and z4 stays standby.
+```
+┌──────────────────────────────────────────────────────────┐
+│                            br0                            │
+└────┬────────────┬────────────┬────────────┬───────────────┘
+```
+
+## Test Scenarios
+
+| Scenario | Result |
+|----------|--------|
+| Setup topology and establish the EVPN sessions | |
+| The DF gateway owns both regions and re-floods across the boundary | |
+| The standby gateway re-floods nothing (no duplicate BUM) | |
+| Teardown topology | |

--- a/bdd/docs/bgp_evpn_gateway_reflood.md
+++ b/bdd/docs/bgp_evpn_gateway_reflood.md
@@ -1,0 +1,30 @@
+# BGP EVPN BUM segmentation — gateway re-flood primitive (RFC 9572 §6, Phase 6 control plane)
+
+## Overview
+
+As a network operator
+I want a segmentation gateway to partition its learned VTEPs by region and
+compute the split-horizon re-flood set per region — the control-plane
+primitive the (eBPF) BUM-replication dataplane consumes — so that BUM
+ingressing from one region is replicated only to VTEPs in the other regions,
+never back into the region it came from.
+This is the control-plane foundation for the Phase 6 eBPF gateway dataplane;
+no packet forwarding happens yet (the replication offload is a follow-up).
+Test Topology — region A (AS 65001) PE z1 and region B (AS 65002) PE z3 each
+own a VXLAN (VNI 10); the gateway z2 borders both and learns one VTEP per
+region.
+```
+┌──────────────────────────────────────────────────────────┐
+│                            br0                            │
+└─────────┬─────────────────┬─────────────────┬─────────────┘
+```
+
+## Test Scenarios
+
+| Scenario | Result |
+|----------|--------|
+| Setup topology and establish the EVPN sessions | |
+| The gateway computes a split-horizon re-flood set per region | |
+| The gateway is the elected DF and forwards | |
+| Per-PE IMET is not propagated across the boundary (still segmented) | |
+| Teardown topology | |

--- a/bdd/docs/bgp_evpn_interas_segmentation.md
+++ b/bdd/docs/bgp_evpn_interas_segmentation.md
@@ -1,0 +1,31 @@
+# BGP EVPN BUM tunnel segmentation — inter-AS ASBR (RFC 9572 Section 5)
+
+## Overview
+
+As a network operator
+I want an Autonomous System Border Router to aggregate its AS's per-PE
+Inclusive Multicast (Type-3) routes into a single Per-Region I-PMSI (Type-9)
+route, re-originated across the AS boundary (eBGP) with next-hop-self, while
+not leaking the per-AS per-PE IMET across that boundary.
+This reuses the region-id segmentation machinery with "region = AS": the
+ASBR's neighbor-groups carry a region-id equal to each bordered AS, so the
+inter-AS (Section 5) case is the inter-region (Section 6) case applied across
+an eBGP session. It exercises the eBGP egress path the all-iBGP Section 6
+test never touched — AS_PATH prepend and next-hop-self at the AS boundary.
+Test Topology — z1 (AS 65001 PE) and z2 (AS 65001 ASBR) are iBGP; z2 and z3
+(AS 65002 ASBR) are eBGP across the AS boundary.
+```
+┌──────────────────────────────────────────────────────────┐
+│                            br0                            │
+└─────────┬─────────────────┬─────────────────┬─────────────┘
+```
+
+## Test Scenarios
+
+| Scenario | Result |
+|----------|--------|
+| Setup topology and establish the EVPN sessions | |
+| The ASBR aggregates AS 65001's IMET into a Per-Region I-PMSI route | |
+| AS 65002 receives the Per-Region I-PMSI across the eBGP boundary | |
+| Per-AS per-PE IMET is not propagated across the AS boundary | |
+| Teardown topology | |

--- a/bdd/docs/bgp_evpn_outpolicy_undef.md
+++ b/bdd/docs/bgp_evpn_outpolicy_undef.md
@@ -1,0 +1,51 @@
+# EVPN outbound policy rebound to an undefined name is deny-all
+
+## Overview
+
+As a network operator
+I want a BGP neighbor whose EVPN outbound policy is rebound to a
+policy name that does not exist to immediately withdraw the routes it
+was advertising, rather than keep leaking them with the previously
+resolved policy still applied.
+A bound-but-unresolved peer policy is deny-all. Previously the policy
+actor stayed silent when a peer registered an undefined policy name, so
+no soft-reconfiguration fired and the stale resolved policy lingered:
+the neighbor kept advertising. The actor now answers even with a `None`
+policy, which clears the stale resolve and drives a soft-out that
+withdraws the now-denied routes — all without a session reset.
+The exercise: z1 originates 10.1.0.0/24 in vrf-blue and advertises it to
+z2 as an EVPN Type-5 route. z1's EVPN outbound policy starts bound to an
+existing PERMIT-ALL policy (z2 sees the route), is then rebound to the
+undefined NOPE (z2 must lose the route), and finally NOPE is defined as
+permit (z2 must see the route again).
+
+## Test Topology
+
+```
+  ┌─────────────────────────────────────────┐
+  │                   br0                   │
+  └─────────────┬───────────────┬───────────┘
+                │               │
+           ┌────┴────┐     ┌────┴────┐
+           │   z1    │     │   z2    │
+           │ AS65001 │     │ AS65001 │
+           │192.168. │     │192.168. │
+           │  0.1/24 │     │  0.2/24 │
+           └─────────┘     └─────────┘
+```
+
+## Config Files
+
+- z1-permit.yaml: vrf-blue originates 10.1.0.0/24, EVPN out-policy bound
+- z1-undef.yaml: EVPN out-policy rebound to the undefined NOPE.
+- z1-recover.yaml: NOPE defined as a permit policy.
+- z2-1.yaml: EVPN receiver importing RT 65001:100 into vrf-blue.
+
+## Test Scenarios
+
+| Scenario | Result |
+|----------|--------|
+| Setup topology and verify the route is advertised under PERMIT-ALL | |
+| Rebinding the EVPN out-policy to an undefined name withdraws the route | |
+| Defining the previously-undefined policy re-advertises the route | |
+| Teardown topology | |

--- a/bdd/docs/bgp_evpn_segmentation.md
+++ b/bdd/docs/bgp_evpn_segmentation.md
@@ -1,0 +1,30 @@
+# BGP EVPN BUM tunnel segmentation — inter-region RBR (RFC 9572 Section 6)
+
+## Overview
+
+As a network operator
+I want a Regional Border Router to aggregate a region's per-PE Inclusive
+Multicast (Type-3) routes into a single Per-Region I-PMSI (Type-9) route,
+re-originated into the other region with next-hop-self, while not leaking
+the per-PE IMET across the region boundary.
+Test Topology — three iBGP (AS 65001) speakers on a shared bridge. z2 is the
+Regional Border Router; its neighbor-groups carry the region-id of each
+bordered region. z1 (region A) originates a Type-3 IMET; z3 (region B) only
+peers with z2.
+```
+┌──────────────────────────────────────────────────────────┐
+│                            br0                            │
+└─────────┬─────────────────┬─────────────────┬─────────────┘
+```
+
+## Test Scenarios
+
+| Scenario | Result |
+|----------|--------|
+| Setup topology and establish the EVPN sessions | |
+| The RBR aggregates region A's IMET into a Per-Region I-PMSI route | |
+| Region B receives the Per-Region I-PMSI with the RBR as next hop | |
+| Per-PE IMET is not propagated across the region boundary | |
+| Region B leaf answers the Per-Region I-PMSI with a Leaf A-D | |
+| The RBR collects the region's Leaf A-D route | |
+| Teardown topology | |

--- a/bdd/docs/bgp_evpn_smet.md
+++ b/bdd/docs/bgp_evpn_smet.md
@@ -1,0 +1,39 @@
+# BGP EVPN IGMP/MLD Proxy — Selective Multicast (RFC 9251)
+
+## Overview
+
+As a network operator
+I want zebra-rs to originate a Type-6 SMET route from locally-snooped
+IGMP/MLD membership and install received SMET routes as selective
+kernel bridge MDB entries, so multicast is delivered only to PEs that
+asked for it instead of flooded over the Type-3 BUM tree.
+Test Topology — two iBGP (AS 65001) EVPN speakers on a shared transport
+bridge br0, each with a local VXLAN (VNI 10) enslaved to a per-node
+IGMP-snooping bridge br10:
+```
+┌───────────────────────────────────────────┐
+│                    br0                     │
+└───────────┬───────────────────┬───────────┘
+```
+z2 carries a local (*,G)=239.1.1.1 membership (injected via
+`bridge mdb add`); the kernel emits RTM_NEWMDB, zebra-rs maps br10 to
+VNI 10 and originates a Type-6 SMET. z1 imports it and programs a
+selective kernel bridge MDB entry on br10 with `dst` = z2's VTEP.
+
+## Notes
+
+z2 carries a local (*,G)=239.1.1.1 membership (injected via
+`bridge mdb add`); the kernel emits RTM_NEWMDB, zebra-rs maps br10 to
+VNI 10 and originates a Type-6 SMET. z1 imports it and programs a
+selective kernel bridge MDB entry on br10 with `dst` = z2's VTEP.
+
+## Test Scenarios
+
+| Scenario | Result |
+|----------|--------|
+| Setup topology, EVPN iBGP, and per-node snooping bridges | |
+| A snooped (*,G) join makes z2 originate a Type-6 SMET that z1 imports | |
+| z1 programs the received SMET into its kernel MDB (per-VTEP dst) | |
+| A leave withdraws the SMET and removes the MDB entry on z1 | |
+| An (S,G) join originates a source-specific SMET with the right source | |
+| Teardown topology | |

--- a/bdd/docs/bgp_evpn_spmsi.md
+++ b/bdd/docs/bgp_evpn_spmsi.md
@@ -1,0 +1,27 @@
+# BGP EVPN BUM segmentation — selective S-PMSI (RFC 9572 Type-10), Phase 5
+
+## Overview
+
+As a network operator
+I want a source PE to advertise a selective per-(S,G) provider tunnel (Type-10
+S-PMSI) for a snooped multicast flow, and a Regional Border Router to re-root
+that selective tunnel per-region — the selective counterpart of the inclusive
+Per-Region I-PMSI (Type-9) aggregation.
+Test Topology — z1 is a source PE in region A with an IGMP-snooping bridge; a
+snooped (*,239.1.1.1) membership makes it originate a Type-10 S-PMSI. z2 is
+the RBR (region A iBGP / region B eBGP); z3 is a PE in region B.
+```
+┌──────────────────────────────────────────────────────────┐
+│                            br0                            │
+└─────────┬─────────────────┬─────────────────┬─────────────┘
+```
+
+## Test Scenarios
+
+| Scenario | Result |
+|----------|--------|
+| Setup topology, EVPN sessions, and z1's snooping bridge | |
+| A snooped (*,G) makes z1 originate a selective S-PMSI (Type-10) | |
+| The RBR re-roots the S-PMSI per-region toward region B | |
+| Region B receives the RBR-rooted selective S-PMSI | |
+| Teardown topology | |

--- a/bdd/docs/bgp_evpn_srv6_p2mp.md
+++ b/bdd/docs/bgp_evpn_srv6_p2mp.md
@@ -1,0 +1,27 @@
+# BGP EVPN BUM over SRv6 P2MP replication (RFC 9524) — daemon-driven offload
+
+## Overview
+
+As a network operator
+I want the BGP control plane to drive the tc-evpn-replicate eBPF offload: two
+SRv6 EVPN PEs exchange their End.DT2M SIDs over an SR P2MP IMET, the root
+forms a replication segment, and the daemon spawns + feeds the ingress
+(End.Replicate / End.DT2M) and encap (root H.Encaps) children that move BUM.
+This proves the control-plane -> supervisor -> loader integration end to end
+(session, SID exchange, ReplSeg, child spawn). Each datapath's actual packet
+forwarding is proven standalone by offload/tc-evpn-replicate/scripts/veth-*.sh
+(End.Replicate, End.DT2M, H.Encaps); wiring the netns packet capture through
+all three is a follow-up.
+Test Topology — z1 and z2 are SRv6 EVPN PEs on a direct underlay link, each a
+root + leaf for VNI 10. z1 sources a BUM frame on its access port; the offload
+encaps it toward z2's End.DT2M SID; z2 decaps it onto its bridge.
+```
+```
+
+## Test Scenarios
+
+| Scenario | Result |
+|----------|--------|
+| Build the SRv6 EVPN topology and confirm the SR P2MP exchange | |
+| The daemon spawns the offload children and programs the tree | |
+| Teardown topology | |

--- a/bdd/docs/bgp_lu_route_map.md
+++ b/bdd/docs/bgp_lu_route_map.md
@@ -1,0 +1,39 @@
+# BGP per-peer route-map for IPv4 labeled-unicast (inbound + outbound)
+
+## Overview
+
+As a network operator
+I want `neighbor X afi-safi label-v4 policy in/out <policy>` to filter
+IPv4 labeled-unicast (SAFI 4) routes per neighbor, the same per-peer
+per-family route-map the IPv4
+unicast path already has. Before this, the labeled-unicast ingest and
+advertise applied no per-neighbor policy, so BGP-LU route-maps were
+silently ignored.
+Policies are configured before the session establishes, so this
+exercises the ingest / advertise / establish-sync policy hooks
+directly.
+
+## Test Topology
+
+```
+  ┌─────────────────┐  192.168.0.0/30  ┌─────────────────┐
+  │       z1        │                  │       z2        │
+  │     AS65001     ├──────────────────┤     AS65002     │
+  │ label-v4 origin │   eBGP label-v4  │ label-v4 recv   │
+  └─────────────────┘                  └─────────────────┘
+```
+
+## Notes
+
+z1 originates 1.1.1.1/32, 2.2.2.2/32, 3.3.3.3/32 into BGP-LU and binds
+an OUTBOUND policy OUT-LU that denies 3.3.3.3/32. z2 binds an INBOUND
+policy IN-LU that denies 1.1.1.1/32.
+Expected at z2: only 2.2.2.2/32 survives — 1.1.1.1/32 dropped by z2's
+inbound deny, 3.3.3.3/32 never advertised by z1's outbound deny.
+
+## Test Scenarios
+
+| Scenario | Result |
+|----------|--------|
+| Setup and verify inbound + outbound labeled-unicast route-map | |
+| Teardown topology | |

--- a/bdd/docs/bgp_neighbor_adj_rib_v6.md
+++ b/bdd/docs/bgp_neighbor_adj_rib_v6.md
@@ -1,0 +1,26 @@
+# show bgp neighbor <X> advertised-routes / received-routes ipv6
+
+## Overview
+
+As a network operator
+I want to inspect a single neighbor's IPv6-unicast Adj-RIB-Out and
+Adj-RIB-In, so I can see exactly what was advertised to, and received
+from, that peer for the v6 address family.
+These are the v6-unicast twins of the existing (bare) v4 forms:
+`advertised-routes ipv6` reads the peer's `adj_out.v6`, and
+`received-routes ipv6` reads its `adj_in.v6`. The IPv6 Adj-RIB-Out
+always lives on the peer (the per-peer egress task is v4-only) and the
+IPv6 Adj-RIB-In lives in main's shard (v6 ingest never moves to the
+pool), so both reads are correct at any shard count.
+Topology: one dual-stack point-to-point link, eBGP over the IPv4
+transport with both ipv4 and ipv6 afi-safi negotiated, both sides
+redistributing connected. The session is keyed by the IPv4 transport
+address; the `ipv6` keyword selects the v6 Adj-RIB on that peer.
+
+## Test Scenarios
+
+| Scenario | Result |
+|----------|--------|
+| A neighbor's v6 Adj-RIB-Out and Adj-RIB-In are visible per peer | |
+| A post-establishment v6 prefix appears, then withdraws, from the Adj-RIBs | |
+| Teardown topology | |

--- a/bdd/docs/bgp_network_origin_shard_pet.md
+++ b/bdd/docs/bgp_network_origin_shard_pet.md
@@ -1,0 +1,40 @@
+# BGP IPv4 network origination is advertised under shards + peer-task
+
+## Overview
+
+Repro for a reported bug: a speaker with the RIB sharded
+(router bgp shards 4) AND per-peer egress tasks (router bgp peer-task true)
+configured with IPv4 network statements never advertises those networks to
+its neighbor.
+Key fact: IPv4-unicast AFI/SAFI is enabled by DEFAULT on every neighbor,
+even one whose transport address is IPv6 (it is only off when explicitly
+set "afi-safi ipv4 enabled false"). So the iBGP neighbor below — peered over
+an IPv6 transport with the ipv6 family also enabled — negotiates
+IPv4-unicast too and MUST receive the originated IPv4 networks (IPv4 NLRI
+with an IPv4 next-hop carried over the IPv6 session).
+z1 is the device under test, configured exactly like the report: AS 65501,
+shards 4 + peer-task true, originating 0.0.0.0/0 and 5.5.5.0/24, with one
+iBGP neighbor z2 over IPv6.
+
+## Test Topology
+
+```
+  z1 (AS65501)  ---- iBGP over IPv6 ----  z2 (AS65501)
+  2001:db8::1/64                          2001:db8::8/64
+  shards 4 + peer-task
+  originates 0.0.0.0/0, 5.5.5.0/24
+```
+
+## Notes
+
+Both on bridge br0.
+
+## Test Scenarios
+
+| Scenario | Result |
+|----------|--------|
+| the speaker and its iBGP neighbor establish over IPv6 | |
+| z1 originates the IPv4 networks into its own Loc-RIB | |
+| z2 receives the originated IPv4 networks (the reported bug) | |
+| dropping a network statement withdraws it from the neighbor (route_del at N>1) | |
+| Teardown topology | |

--- a/bdd/docs/bgp_peer_egress_v4.md
+++ b/bdd/docs/bgp_peer_egress_v4.md
@@ -1,0 +1,62 @@
+# BGP IPv4-unicast read paths at N>1 (show / session-up sync read the empty main shard)
+
+## Overview
+
+Regression test for a correctness gap in BGP RIB sharding. At
+ZEBRA_BGP_SHARDS>1, plain IPv4-unicast routes are dispatched to the
+worker-shard pool (RouteBatchV4) and live ONLY in the pool shards; the
+reduce (`route_apply_bestpath_v4_batch`) used to do FIB-install +
+advertise but never mirror the best-path back into the synchronous
+`bgp.shard`, so every read path that consults `bgp.shard.v4` was empty
+at N>1:
+Forwarding itself is unaffected: the event-driven advertise runs off the
+best-path delta, not `bgp.shard`. This is IPv4-unicast-specific (the only
+pooled family); v6 / VPNv4 / VPNv6 / labeled-unicast are sync-ingested,
+so their `bgp.shard` tables stay populated and read correctly at N>1.
+z2 is the sharded device under test (4 shards) and the transit between
+z1 (origin) and two downstream peers:
+FIXED by the read-replica mirror: the pool reduce
+(`route_apply_bestpath_v4_batch` → `BgpShard::mirror_v4`) now keeps the
+main shard's `bgp.shard.v4` in step with the pool-owned table, so both
+read paths — `route_sync_ipv4` (for the late peer z4) and `show bgp
+ipv4` (z2's own RIB) — see the routes at N>1. This feature now guards
+against regressing that. (The sync build still runs serially on the
+main task; parallelizing its egress is a separate optimization, see
+docs/design/bgp-rib-sharding-plan.md §B.4.)
+A THIRD read path — `show bgp neighbor <peer> received-routes` (the
+peer's Adj-RIB-In) — is NOT covered by the Loc-RIB mirror: the
+authoritative adj_in lives in the pool shards, so at N>1 this read
+scatter-gathers it from every shard (A2 ⑤, `ShardMsg::DumpAdjInV4`). The
+received-routes scenario below guards that.
+A FOURTH — `show bgp ipv4 summary`'s per-neighbor PfxRcd/Snt — reads BOTH
+off-main owners: PfxRcd from the pool shards' Adj-RIB-In (N>1), PfxSnt
+from the PET's Adj-RIB-Out (peer-task). The synchronous row read finds
+both main-side copies empty, so it gathers the COUNTS (count-only
+messages — no prefixes/attributes) before rendering. The summary scenario
+below guards that.
+
+## Test Topology
+
+```
+                         ┌── z3 (AS65003)  early peer  → event-driven (control)
+  z1 (AS65001) ── z2 (AS65002, 4 shards) ──┤
+   10.0.0.1/24    10.0.0.2/24              └── z4 (AS65004)  late peer   → sync (bug)
+   origin         sharded transit
+```
+
+## Notes
+
+All four on bridge br0. z1 originates 10.10.10.0/24 + 10.10.11.0/24.
+
+## Test Scenarios
+
+| Scenario | Result |
+|----------|--------|
+| z1, the sharded z2, and the early peer z3 come up (no routes yet) | |
+| control — z1 originates while z3 is up; the event-driven advertise reaches z3 | |
+| the late peer z4 gets the routes on sync, and z2 can show its own RIB | |
+| z2's received-routes from z1 are gathered from the pool shards (N>1 Adj-RIB-In) | |
+| z2's `show bgp ipv4 summary` per-neighbor counts come from the off-main owners | |
+| z1 withdraws one route; the sharded reduce removes it from z2's mirror | |
+| z1's session drops; the sharded peer-down sweep clears z2's mirror | |
+| Teardown topology | |

--- a/bdd/docs/bgp_peer_task_config_knob.md
+++ b/bdd/docs/bgp_peer_task_config_knob.md
@@ -1,0 +1,41 @@
+# BGP per-peer egress task configured via the router bgp peer-task knob
+
+## Overview
+
+Validates the shipping form of the per-peer egress task (PET): the egress
+model comes from config (router bgp peer-task true, zebra-bgp-sharding.yang)
+instead of the ZEBRA_BGP_PEER_TASK environment variable. The device z2 is
+started with the PLAIN start step — no env vars — and reads BOTH its shard
+count (shards: 4) and its egress model (peer-task: true) from config.
+PET runs the v4-unicast egress through a per-peer task (the GoBGP per-peer
+model) instead of the main-task update-groups, and is exercised together
+with sharding, so z2 sets both knobs. Like sharding, the egress model is
+behavior-transparent, so the decisive proof that the knob took effect is
+the startup log line BGP per-peer egress task: enabled (from config),
+emitted by init_peer_task when spawn_bgp reads the leaf. The
+route-propagation scenario then confirms the config-driven PET egress
+ingests and forwards end to end.
+The env-driven PET matrix is covered by bgp_peer_egress_v4; this feature
+focuses on the config-knob plumbing.
+
+## Test Topology
+
+```
+  z1 (AS65001) ── z2 (AS65002) ── z3 (AS65003)
+   10.0.0.1/24    10.0.0.2/24     10.0.0.3/24
+   origin         shards: 4       peer
+                  peer-task: true
+                  (from config)
+```
+
+## Notes
+
+All three on bridge br0. z1 originates 10.10.10.0/24 + 10.10.11.0/24.
+
+## Test Scenarios
+
+| Scenario | Result |
+|----------|--------|
+| z2 reads both shards and peer-task from config and the speakers establish | |
+| routes propagate through the config-driven per-peer egress | |
+| Teardown topology | |

--- a/bdd/docs/bgp_policy_dynamic_update.md
+++ b/bdd/docs/bgp_policy_dynamic_update.md
@@ -6,7 +6,7 @@ As a network operator
 I want zebra-rs to re-evaluate Adj-RIB-In when a referenced prefix-set
 or policy-list is edited, so that operational changes propagate
 immediately without me having to clear the BGP session.
-The exercise: z2 attaches `apply-policy in HOGE`, where policy HOGE
+The exercise: z2 attaches `afi-safi ipv4 policy in HOGE`, where policy HOGE
 matches `prefix-set HOGE`. Because the prefix-set is referenced
 *indirectly* via the policy's match clause, the harness must follow
 the cascade prefix-set HOGE -> policy HOGE -> peer's Adj-RIB-In

--- a/bdd/docs/bgp_rr_ebgp_strip.md
+++ b/bdd/docs/bgp_rr_ebgp_strip.md
@@ -1,0 +1,62 @@
+# BGP iBGP-only attributes are stripped on eBGP egress
+
+## Overview
+
+As a network operator
+I want the iBGP-only path attributes — ORIGINATOR_ID, CLUSTER_LIST and
+LOCAL_PREF — to stay inside the AS
+So that an iBGP-learned route re-advertised to an eBGP peer does not leak
+attributes that have meaning only within the local AS.
+RFC 4456 §8 defines ORIGINATOR_ID (type 9) and CLUSTER_LIST (type 10) as
+optional NON-TRANSITIVE attributes that carry meaning only within the
+local AS (the originating router-id and the intra-AS reflection path).
+They MUST NOT cross an AS boundary: leaking them risks spurious loop
+drops at a remote AS that happens to share a router-id / cluster-id.
+RFC 4271 §5.1.5 likewise forbids sending LOCAL_PREF to external peers.
+
+## Test Topology
+
+```
+  ┌────────────────────────────────────────────────────────────────────────┐
+  │                                  br0                                   │
+  └────────┬──────────────────┬──────────────────┬──────────────────┬─────┘
+           │                  │                  │                  │
+      ┌────┴────┐        ┌────┴────┐        ┌────┴────┐        ┌────┴────┐
+      │   z1    │  iBGP  │   z2    │        │   z3    │  eBGP  │   z4    │
+      │  (RR)   │◀──────▶│(client) │        │(client) │◀──────▶│ (peer)  │
+      │ AS65001 │        │ AS65001 │        │+ border │        │ AS65002 │
+      │id 10.0. │        │id 10.0. │        │ AS65001 │        │id 10.0. │
+      │   0.1   │        │   0.2   │        │id 10.0. │        │   0.4   │
+      │192.168. │        │192.168. │        │   0.3   │        │192.168. │
+      │  0.1/24 │        │  0.2/24 │        │192.168. │        │  0.4/24 │
+      └────┬────┘        └─────────┘        │  0.3/24 │        └─────────┘
+           │ iBGP (RR client)               └────┬────┘
+           └─────────────────────────────────────┘
+```
+
+## Notes
+
+- z1 is the route reflector; z2 and z3 are its clients (same AS 65001).
+- z2 originates 10.10.10.0/24 and advertises it to the RR (z1).
+- z1 REFLECTS the route to client z3, stamping ORIGINATOR_ID (z2's
+  router-id 10.0.0.2) and CLUSTER_LIST (z1's cluster-id). z3 therefore
+  sees the route WITH the route-reflection attributes — the positive
+  control proving the route really traversed a reflector.
+- z3 re-advertises the route to its eBGP peer z4 (AS 65002). z4 MUST
+  receive the route WITHOUT ORIGINATOR_ID / CLUSTER_LIST.
+
+## Config Files
+
+- z1.yaml: RR — iBGP to z2 and z3, both route-reflector clients.
+- z2.yaml: client — iBGP to z1; originates 10.10.10.0/24.
+- z3.yaml: client + border — iBGP to z1, eBGP to z4.
+- z4.yaml: eBGP peer — eBGP to z3 only.
+
+## Test Scenarios
+
+| Scenario | Result |
+|----------|--------|
+| Setup topology and establish BGP sessions | |
+| RR client z3 receives the reflected route WITH the iBGP-only attributes | |
+| eBGP peer z4 receives the route but NOT the iBGP-only attributes | |
+| Teardown topology | |

--- a/bdd/docs/bgp_shard_addpath_lu4.md
+++ b/bdd/docs/bgp_shard_addpath_lu4.md
@@ -1,0 +1,33 @@
+# BGP labeled-unicast (v4) AddPath session-up sync at N>1 (all paths sync; per-path withdraw + peer-down)
+
+## Overview
+
+AddPath variant of @bgp_shard_sync_lu. Two origins (z1, z2) advertise the
+same LU-v4 prefix, so the sharded z3 holds two candidates and AddPath-Sends
+both to the late peer z4. Pins that `route_sync_labelv4` dumps every
+candidate from `bgp.shard.v4lu.0` and registers each path-id in
+`adj_out.v4lu`, so a per-path withdraw + peer-down remove only the right
+path-id from a synced AddPath LU peer. `show bgp labeled-unicast`
+carries the AS_PATH column.
+
+## Test Topology
+
+```
+  z1 (AS65001) ┐                        z1 path: "65003 65001"
+               ├─ z3 (AS65003, 4 shards) ── z4 (AS65004) AddPath-recv (late)
+  z2 (AS65002) ┘  AddPath-send to z4      z2 path: "65003 65002"
+```
+
+## Notes
+
+z1 and z2 each originate LU 10.10.10.0/24. All four on bridge br0.
+
+## Test Scenarios
+
+| Scenario | Result |
+|----------|--------|
+| z1, z2 and the sharded z3 come up; z3 holds two candidates | |
+| the late AddPath peer z4 gets BOTH paths on sync | |
+| z1 withdraws; only z1's path-id is withdrawn from the synced z4 | |
+| z2's session drops; the surviving path is withdrawn from z4 too | |
+| Teardown topology | |

--- a/bdd/docs/bgp_shard_addpath_lu6.md
+++ b/bdd/docs/bgp_shard_addpath_lu6.md
@@ -1,0 +1,33 @@
+# BGP labeled-unicast (v6) AddPath session-up sync at N>1 (all paths sync; per-path withdraw + peer-down)
+
+## Overview
+
+AddPath variant of @bgp_shard_sync_labelv6. Two origins (z1, z2) advertise the
+same LU-v6 prefix, so the sharded z3 holds two candidates and AddPath-Sends
+both to the late peer z4. Pins that `route_sync_labelv6` dumps every
+candidate from `bgp.shard.v6lu.0` and registers each path-id in
+`adj_out.v6lu`, so a per-path withdraw + peer-down remove only the right
+path-id from a synced AddPath LU peer. `show bgp labeled-unicast`
+carries the AS_PATH column.
+
+## Test Topology
+
+```
+  z1 (AS65001) ┐                        z1 path: "65003 65001"
+               ├─ z3 (AS65003, 4 shards) ── z4 (AS65004) AddPath-recv (late)
+  z2 (AS65002) ┘  AddPath-send to z4      z2 path: "65003 65002"
+```
+
+## Notes
+
+z1 and z2 each originate LU 2001:db8:beef::/64. All four on bridge br0.
+
+## Test Scenarios
+
+| Scenario | Result |
+|----------|--------|
+| z1, z2 and the sharded z3 come up; z3 holds two candidates | |
+| the late AddPath peer z4 gets BOTH paths on sync | |
+| z1 withdraws; only z1's path-id is withdrawn from the synced z4 | |
+| z2's session drops; the surviving path is withdrawn from z4 too | |
+| Teardown topology | |

--- a/bdd/docs/bgp_shard_addpath_v4.md
+++ b/bdd/docs/bgp_shard_addpath_v4.md
@@ -1,0 +1,33 @@
+# BGP IPv4-unicast AddPath session-up sync at N>1 (all paths sync; per-path withdraw + peer-down)
+
+## Overview
+
+AddPath variant of @bgp_shard_v4_sync. Two origins (z1, z2) advertise the
+same prefix, so the sharded z3 holds two candidates; z3 AddPath-Sends both
+to the late peer z4. This exercises the AddPath dimension of the N>1 sync
+fixes: the read-replica mirror must carry the candidate table (`v4.0`,
+not just best), and `route_sync_ipv4` must dump every candidate and
+register each in `adj_out` so a later per-path withdraw / peer-down
+removes only that path-id from z4.
+
+## Test Topology
+
+```
+  z1 (AS65001) ┐                        z1 path: "65003 65001"
+               ├─ z3 (AS65003, 4 shards) ── z4 (AS65004) AddPath-recv (late)
+  z2 (AS65002) ┘  AddPath-send to z4      z2 path: "65003 65002"
+```
+
+## Notes
+
+z1 and z2 each originate 10.10.10.0/24. All four on bridge br0 (192.168.0.x).
+
+## Test Scenarios
+
+| Scenario | Result |
+|----------|--------|
+| z1, z2 and the sharded z3 come up; z3 holds two candidates | |
+| the late AddPath peer z4 gets BOTH paths on sync | |
+| z1 withdraws; only z1's path-id is withdrawn from the synced z4 | |
+| z2's session drops; the surviving path is withdrawn from z4 too | |
+| Teardown topology | |

--- a/bdd/docs/bgp_shard_addpath_v6.md
+++ b/bdd/docs/bgp_shard_addpath_v6.md
@@ -1,0 +1,32 @@
+# BGP IPv6-unicast AddPath session-up sync at N>1 (all paths sync; per-path withdraw + peer-down)
+
+## Overview
+
+AddPath variant of @bgp_shard_sync_v6. Two origins (z1, z2) advertise the
+same v6 prefix, so the sharded z3 holds two candidates and AddPath-Sends
+both to the late peer z4. v6 is sync-ingested (not pooled), so this pins
+that `route_sync_ipv6` dumps every candidate from `bgp.shard.v6.0` and
+registers each path-id in `adj_out.v6`, so a per-path withdraw + peer-down
+remove only the right path-id from a synced AddPath peer.
+
+## Test Topology
+
+```
+  z1 (AS65001) ┐                        z1 path: "65003 65001"
+               ├─ z3 (AS65003, 4 shards) ── z4 (AS65004) AddPath-recv (late)
+  z2 (AS65002) ┘  AddPath-send to z4      z2 path: "65003 65002"
+```
+
+## Notes
+
+z1 and z2 each originate 2001:db8:beef::/64. All four on bridge br0.
+
+## Test Scenarios
+
+| Scenario | Result |
+|----------|--------|
+| z1, z2 and the sharded z3 come up; z3 holds two candidates | |
+| the late AddPath peer z4 gets BOTH paths on sync | |
+| z1 withdraws; only z1's path-id is withdrawn from the synced z4 | |
+| z2's session drops; the surviving path is withdrawn from z4 too | |
+| Teardown topology | |

--- a/bdd/docs/bgp_shard_addpath_vpnv4.md
+++ b/bdd/docs/bgp_shard_addpath_vpnv4.md
@@ -1,0 +1,34 @@
+# BGP VPNv4 AddPath session-up sync at N>1 (all paths sync; per-path withdraw + peer-down)
+
+## Overview
+
+AddPath variant of @bgp_shard_sync_vpnv4. Two PEs (z1, z2) export the
+SAME VPNv4 NLRI (RD 65001:100, 10.9.0.0/24) with different AS_PATHs,
+so the sharded relay z3 holds two candidates and AddPath-Sends both to
+the late peer z4. Pins that `route_sync_vpnv4` dumps every candidate
+and registers each path-id in `adj_out`, so a per-path withdraw (a
+config removal on z1, driven through the VRF self-network withdraw
+path) and a peer-down (z2) remove only the right path-id from a synced
+AddPath VPNv4 peer.
+
+## Test Topology
+
+```
+  z1 (AS65001) PE ┐                            z1 path: "65003 65001"
+                  ├─ z3 (AS65003, 4 shards) ── z4 (AS65004) AddPath-recv (late)
+  z2 (AS65002) PE ┘  VPNv4 relay, no VRF       z2 path: "65003 65002"
+```
+
+## Notes
+
+z1 and z2 each export RD 65001:100 / 10.9.0.0/24. All four on bridge br0.
+
+## Test Scenarios
+
+| Scenario | Result |
+|----------|--------|
+| z1, z2 (PEs) and the sharded relay z3 come up; z3 holds two candidates | |
+| the late AddPath peer z4 gets BOTH paths on sync | |
+| z1 withdraws; only z1's path-id is withdrawn from the synced z4 | |
+| z2's session drops; the surviving path is withdrawn from z4 too | |
+| Teardown topology | |

--- a/bdd/docs/bgp_shard_addpath_vpnv6.md
+++ b/bdd/docs/bgp_shard_addpath_vpnv6.md
@@ -1,0 +1,35 @@
+# BGP VPNv6 AddPath session-up sync at N>1 (all paths sync; per-path withdraw + peer-down)
+
+## Overview
+
+AddPath variant of @bgp_shard_sync_vpnv6, and the VPNv6 twin of the
+vpnv4 AddPath test. Two PEs (z1, z2) export the SAME VPNv6 NLRI
+(RD 65001:100, 2001:db8:9::/64) with different AS_PATHs (export-only
+RT, so neither re-imports the other), so the sharded relay z3 holds
+two candidates and AddPath-Sends both to the late peer z4. Pins that
+`route_sync_vpnv6` dumps every candidate and registers each path-id in
+`adj_out`, so a per-path config-withdraw on z1 (driven through the VRF
+self-network withdraw path) and a peer-down (z2) remove only the right
+path-id from a synced AddPath VPNv6 peer.
+
+## Test Topology
+
+```
+  z1 (AS65001) PE ┐                            z1 path: "65003 65001"
+                  ├─ z3 (AS65003, 4 shards) ── z4 (AS65004) AddPath-recv (late)
+  z2 (AS65002) PE ┘  VPNv6 relay, no VRF       z2 path: "65003 65002"
+```
+
+## Notes
+
+z1 and z2 each export RD 65001:100 / 2001:db8:9::/64. All four on bridge br0.
+
+## Test Scenarios
+
+| Scenario | Result |
+|----------|--------|
+| z1, z2 (PEs) and the sharded relay z3 come up; z3 holds two candidates | |
+| the late AddPath peer z4 gets BOTH paths on sync | |
+| z1 withdraws; only z1's path-id is withdrawn from the synced z4 | |
+| z2's session drops; the surviving path is withdrawn from z4 too | |
+| Teardown topology | |

--- a/bdd/docs/bgp_shard_config_knob.md
+++ b/bdd/docs/bgp_shard_config_knob.md
@@ -1,0 +1,41 @@
+# BGP RIB sharding configured via the router bgp shards YANG knob
+
+## Overview
+
+Validates the C.4 shipping form of RIB sharding: the shard count comes
+from config (`router bgp shards <1-64>`, zebra-bgp-sharding.yang) instead
+of the `ZEBRA_BGP_SHARDS` environment variable. The sharded device z2 is
+started with the PLAIN `start zebra-rs` step — no env var — and gets its
+shard count purely from `shards: 4` in its applied config.
+Sharding is behavior-transparent (the same correct result at N=1 and
+N>1), so a correctness matrix alone cannot prove the knob actually
+activated N=4 — it would pass even if the daemon silently fell back to
+N=1. The decisive assertion is therefore the startup log line
+`BGP RIB sharding: 4 shards (from config)`, emitted by `init_shard_count`
+when `spawn_bgp` reads the leaf — which is true only if the knob resolved
+to 4 from config. The route-propagation scenario then confirms the
+config-sharded daemon ingests and forwards correctly end to end.
+The env-driven N>1 read-path matrix (mirror, late-peer sync,
+received-routes gather, withdraw, peer-down) is covered by the
+bgp_shard_v4_sync feature; this one focuses on the config-knob plumbing.
+
+## Test Topology
+
+```
+  z1 (AS65001) ── z2 (AS65002) ── z3 (AS65003)
+   10.0.0.1/24    10.0.0.2/24     10.0.0.3/24
+   origin         shards: 4       peer
+                  (from config)
+```
+
+## Notes
+
+All three on bridge br0. z1 originates 10.10.10.0/24 + 10.10.11.0/24.
+
+## Test Scenarios
+
+| Scenario | Result |
+|----------|--------|
+| z2 is sharded by config (not env) and the speakers establish | |
+| routes propagate through the config-sharded z2 | |
+| Teardown topology | |

--- a/bdd/docs/bgp_shard_lu.md
+++ b/bdd/docs/bgp_shard_lu.md
@@ -1,0 +1,38 @@
+# BGP IPv4 Labeled-Unicast (SAFI 4) withdraw/peer-down through a sharded daemon
+
+## Overview
+
+Companion to @bgp_shard_v6 for the SAFI-4 (labeled-unicast) Loc-RIB.
+Like v6-unicast, LU has no Adj-RIB-Out, so `route_labelv4_withdraw` must
+drop a no-op withdraw (one that removed nothing) before re-advertising —
+otherwise two speakers that both lack the prefix bounce MP_UNREACH
+forever, the same ping-pong fixed for v6-unicast. z2 runs with 4 shards
+(LU runs in-process at every N; the shards exercise the exact daemon
+configuration that first surfaced the v6 withdraw storm).
+A two-node z1—z2 topology is enough: z1 originates two LU prefixes after
+the session is Established (z2 ingests them live), and the withdraw of
+one of them floods back to z1 (the source), which is where the ping-pong
+starts. The withdraw and a peer-down (z1 killed) must each remove exactly
+the right routes from z2's LU Loc-RIB.
+
+## Test Topology
+
+```
+  z1 (AS65001) ── z2 (AS65002, 4 shards)
+  192.168.0.1/24   192.168.0.2/24
+```
+
+## Notes
+
+Both on bridge br0. z2's LU Loc-RIB is read directly (LU is in-process,
+so the N>1 pooled-`show` gap does not apply here).
+
+## Test Scenarios
+
+| Scenario | Result |
+|----------|--------|
+| Setup session with z2 sharded, before any routes exist | |
+| z1 originates LU routes; the sharded z2 ingests them | |
+| z1 withdraws one LU route; the sharded withdraw drops only it | |
+| z1's session drops; sharded peer-down sweeps its LU routes | |
+| Teardown topology | |

--- a/bdd/docs/bgp_shard_policy.md
+++ b/bdd/docs/bgp_shard_policy.md
@@ -1,0 +1,58 @@
+# BGP inbound policy through the RIB shards (ZEBRA_BGP_SHARDS>1)
+
+## Overview
+
+As a network operator running BGP with the RIB partitioned across
+worker shards (ZEBRA_BGP_SHARDS>1), I want per-neighbor inbound policy
+to be applied by the shard workers exactly as on the synchronous N=1
+path, so that sharding stays transparent to policy.
+This exercises RIB sharding Phase C + PolicyReplace + the dropped N=1
+par_iter: z2 runs with 4 shards, so its inbound policy is replicated to
+every shard (a peer's prefixes hash across all of them) and applied in
+`compute_policy` on the shard worker — not on the main task.
+Correctness is observed DOWNSTREAM on z3 on the N>1 advertise,
+withdraw, peer-down, and soft-reconfig paths (the N>1 `show` and
+new-peer sync are still gaps): policy is set at startup, z3 is brought
+up FIRST, and z1's routes are originated only AFTER every session is
+Established, so z2 processes them live (ingest → shard → reduce →
+advertise to the already-up z3). One inbound policy permits 10.0.0.1/32
+and implicit-denies 10.0.0.2/32 — a positive and a negative control in
+one shot: z3 must see .1 (sharded permit + advertise works) but never
+.2 (sharded deny works; before PolicyReplace the shard default-permitted
+and .2 would have leaked).
+Follow-on scenarios exercise churn at N=4: a soft-reconfig replay (z2's
+prefix-set widens to also permit .2 → SoftInV4 to every pool shard
+replays the stored Adj-RIB-In, no UPDATE from z1), an explicit withdraw
+(z1 deletes its `network` statements → z2 runs WithdrawV4 to the owning
+pool shard), and a session drop (z1 killed → z2's route_clean dispatches
+PeerDown to every pool shard) — verified by z3 gaining .2, then losing
+10.0.0.1/32.
+
+## Test Topology
+
+```
+  z1 (AS65001) ── z2 (AS65002, 4 shards) ── z3 (AS65003)
+  192.168.0.1/24   192.168.0.2/24           192.168.0.3/24
+```
+
+## Notes
+
+All three on bridge br0.
+
+## Config Files
+
+- z1-base.yaml: AS 65001, peers z2, originates nothing yet.
+- z1-routes.yaml: adds network 10.0.0.1/32 + 10.0.0.2/32 (originated
+- z2.yaml: AS 65002, peers z1 (inbound policy IN-POL permitting only
+- z3.yaml: AS 65003, peers z2 — the downstream observer (N=1, `show`
+
+## Test Scenarios
+
+| Scenario | Result |
+|----------|--------|
+| Setup sessions with z2 sharded, before any routes exist | |
+| z1 originates routes; sharded inbound policy permits .1, denies .2 | |
+| z2's inbound prefix-set widens; soft-reconfiguration replays the sharded Adj-RIB-In | |
+| z1 withdraws its routes; the sharded withdraw reaches z3 | |
+| z1's session drops; sharded peer-down withdraws its routes from z3 | |
+| Teardown topology | |

--- a/bdd/docs/bgp_shard_sync_labelv6.md
+++ b/bdd/docs/bgp_shard_sync_labelv6.md
@@ -1,0 +1,41 @@
+# BGP labeled-unicast (v6) session-up sync at N>1 (sync + withdraw reach a late peer)
+
+## Overview
+
+The IPv6 labeled-unicast counterpart of @bgp_shard_sync_lu, exercising
+`route_sync_labelv6`. At ZEBRA_BGP_SHARDS>1 labeled-unicast is
+sync-ingested to the main `bgp.shard` (not pooled), so `bgp.shard.v6lu`
+stays populated and the read paths work. The risk this pins is the
+Adj-RIB-Out one v6/LU-v4 exposed: `route_sync_labelv6` dumps the LU-v6
+Loc-RIB to a newly-established peer and must register each prefix in
+`adj_out.v6lu`, otherwise the event-driven LU withdraw's gate skips that
+peer and the route gets stuck. (This is native LU-v6 over an IPv6
+session; the next-hop-self is the v6 session local address.)
+z2 is the sharded device under test (4 shards) and transit between
+z1 (origin) and two downstream peers:
+`show bgp labeled-unicast` renders both the v4lu and v6lu Loc-RIBs, so
+the v6 LU prefixes appear there.
+
+## Test Topology
+
+```
+                            ┌── z3 (AS65003)  early peer  → event-driven (control)
+  z1 (AS65001) ── z2 (AS65002, 4 shards) ──┤
+   2001:db8::1/64  2001:db8::2/64          └── z4 (AS65004)  late peer  → sync
+   origin          sharded transit
+```
+
+## Notes
+
+All four on bridge br0. z1 originates LU-v6 2001:db8:a::1/128 + ::2/128.
+
+## Test Scenarios
+
+| Scenario | Result |
+|----------|--------|
+| z1, the sharded z2, and the early peer z3 come up (no routes yet) | |
+| control — z1 originates while z3 is up; the event-driven advertise reaches z3 | |
+| the late peer z4 gets the routes on sync, and z2 can show its own RIB | |
+| z1 withdraws one route; the withdraw reaches the synced peer z4 | |
+| z1's session drops; the peer-down sweep clears its routes from z4 | |
+| Teardown topology | |

--- a/bdd/docs/bgp_shard_sync_lu.md
+++ b/bdd/docs/bgp_shard_sync_lu.md
@@ -1,0 +1,38 @@
+# BGP labeled-unicast (v4) session-up sync at N>1 (sync + withdraw reach a late peer)
+
+## Overview
+
+The labeled-unicast counterpart of @bgp_shard_v4_sync / @bgp_shard_sync_v6.
+At ZEBRA_BGP_SHARDS>1, labeled-unicast is sync-ingested to the main
+`bgp.shard` (not pooled), so `bgp.shard.v4lu` stays populated and the
+read paths work. The risk this pins is the Adj-RIB-Out one v6 exposed:
+`route_sync_labelv4` dumps the LU Loc-RIB to a newly-established peer and
+must register each prefix in `adj_out.v4lu`, otherwise the event-driven
+LU withdraw's `adj_out.v4lu` gate skips that peer and the route gets
+stuck. (route_sync_labelv6 carries the byte-identical fix.)
+z2 is the sharded device under test (4 shards) and transit between
+z1 (origin) and two downstream peers:
+
+## Test Topology
+
+```
+                            ┌── z3 (AS65003)  early peer  → event-driven (control)
+  z1 (AS65001) ── z2 (AS65002, 4 shards) ──┤
+   192.168.0.1/24  192.168.0.2/24          └── z4 (AS65004)  late peer  → sync
+   origin          sharded transit
+```
+
+## Notes
+
+All four on bridge br0. z1 originates LU 10.10.10.1/32 + 10.10.10.2/32.
+
+## Test Scenarios
+
+| Scenario | Result |
+|----------|--------|
+| z1, the sharded z2, and the early peer z3 come up (no routes yet) | |
+| control — z1 originates while z3 is up; the event-driven advertise reaches z3 | |
+| the late peer z4 gets the routes on sync, and z2 can show its own RIB | |
+| z1 withdraws one route; the withdraw reaches the synced peer z4 | |
+| z1's session drops; the peer-down sweep clears its routes from z4 | |
+| Teardown topology | |

--- a/bdd/docs/bgp_shard_sync_v6.md
+++ b/bdd/docs/bgp_shard_sync_v6.md
@@ -1,0 +1,40 @@
+# BGP IPv6-unicast read paths at N>1 (sync / show stay correct — v6 is not pooled)
+
+## Overview
+
+The IPv6 counterpart of @bgp_shard_v4_sync, asserting the *absence* of
+the read-path bug for v6. At ZEBRA_BGP_SHARDS>1 only plain v4-unicast is
+dispatched to the worker pool; IPv6-unicast is sync-ingested straight to
+the main `bgp.shard` (no `RouteBatchV6`). So `bgp.shard.v6` stays
+populated at N>1, and the synchronous main-task read paths —
+`route_sync_ipv6` (session-up dump) and `show bgp ipv6` — see the routes
+with no mirror needed. This feature pins that: a late-establishing v6
+peer must still get the full table on sync, and the sharded node must
+show its own v6 RIB. (v4 needed `BgpShard::mirror_v4` for this; v6 does
+not, and this guards against v6 ever regressing into the same hole.)
+z2 is the sharded device under test (4 shards) and the transit between
+z1 (origin) and two downstream peers:
+
+## Test Topology
+
+```
+                            ┌── z3 (AS65003)  early peer  → event-driven (control)
+  z1 (AS65001) ── z2 (AS65002, 4 shards) ──┤
+   2001:db8::1/64  2001:db8::2/64          └── z4 (AS65004)  late peer   → sync
+   origin          sharded transit
+```
+
+## Notes
+
+All four on bridge br0. z1 originates 2001:db8:a::1/128 + 2001:db8:a::2/128.
+
+## Test Scenarios
+
+| Scenario | Result |
+|----------|--------|
+| z1, the sharded z2, and the early peer z3 come up (no routes yet) | |
+| control — z1 originates while z3 is up; the event-driven advertise reaches z3 | |
+| the late peer z4 gets the routes on sync, and z2 can show its own RIB | |
+| z1 withdraws one route; z2's sync shard drops it | |
+| z1's session drops; the peer-down sweep clears its routes | |
+| Teardown topology | |

--- a/bdd/docs/bgp_shard_sync_vpnv4.md
+++ b/bdd/docs/bgp_shard_sync_vpnv4.md
@@ -1,0 +1,35 @@
+# BGP VPNv4 session-up sync at N>1 (sync + withdraw + peer-down reach a late peer)
+
+## Overview
+
+VPNv4 counterpart of @bgp_shard_v4_sync. VPNv4 is sync-ingested to the
+main `bgp.shard` (not pooled), so `bgp.shard.v4vpn` stays populated at
+N>1. This pins that `route_sync_vpnv4` dumps the VPNv4 Loc-RIB to a late
+peer AND registers each route in `adj_out` (it already does), so a later
+withdraw + peer-down reach the synced peer.
+z1 is a PE: a route in vrf-blue (RD 65001:100, RT 65001:100) exported to
+VPNv4. z2 (4 shards) is an eBGP VPNv4 relay (no VRF — holds the VPNv4
+routes and re-advertises, Inter-AS Option-B style). z3 establishes early
+(event-driven control); z4 establishes late (session-up route_sync_vpnv4).
+
+## Test Topology
+
+```
+                            ┌── z3 (AS65003)  early peer  → event-driven (control)
+  z1 (AS65001) ── z2 (AS65002, 4 shards) ──┤
+   PE, vrf-blue    VPNv4 relay (no VRF)    └── z4 (AS65004)  late peer  → sync
+```
+
+## Notes
+
+All four on bridge br0 (192.168.0.x). z1 exports 10.1.0.0/24 + 10.2.0.0/24.
+
+## Test Scenarios
+
+| Scenario | Result |
+|----------|--------|
+| z1 (PE) and the sharded VPNv4 relay z2 come up; z2 holds the routes | |
+| the late peer z4 gets the VPNv4 routes on sync | |
+| z1 withdraws one route; the withdraw reaches the synced peer z4 | |
+| z1's session drops; the peer-down sweep clears its routes from z4 | |
+| Teardown topology | |

--- a/bdd/docs/bgp_shard_sync_vpnv6.md
+++ b/bdd/docs/bgp_shard_sync_vpnv6.md
@@ -1,0 +1,36 @@
+# BGP VPNv6 session-up sync at N>1 (sync + withdraw + peer-down reach a late peer)
+
+## Overview
+
+VPNv6 counterpart of @bgp_shard_sync_vpnv4. VPNv6 is sync-ingested to
+the main `bgp.shard` (not pooled), so its Loc-RIB stays populated at
+N>1. This pins that `route_sync_vpnv6` dumps the VPNv6 Loc-RIB to a
+late peer AND registers each route in `adj_out` (it already does), so
+a later config-withdraw + peer-down reach the synced peer.
+z1 is a PE: a route in vrf-blue (RD 65001:100, RT 65001:100) exported
+to VPNv6. z2 (4 shards) is an eBGP VPNv6 relay (no VRF — holds the
+VPNv6 routes and re-advertises, Inter-AS Option-B style). z3
+establishes early (event-driven control); z4 establishes late
+(session-up route_sync_vpnv6). All sessions ride IPv6 transport.
+
+## Test Topology
+
+```
+                            ┌── z3 (AS65003)  early peer  → event-driven (control)
+  z1 (AS65001) ── z2 (AS65002, 4 shards) ──┤
+   PE, vrf-blue    VPNv6 relay (no VRF)    └── z4 (AS65004)  late peer  → sync
+```
+
+## Notes
+
+All four on bridge br0 (2001:db8::x). z1 exports 2001:db8:1::/64 + 2001:db8:2::/64.
+
+## Test Scenarios
+
+| Scenario | Result |
+|----------|--------|
+| z1 (PE) and the sharded VPNv6 relay z2 come up; z2 holds the routes | |
+| the late peer z4 gets the VPNv6 routes on sync | |
+| z1 withdraws one route; the withdraw reaches the synced peer z4 | |
+| z1's session drops; the peer-down sweep clears its routes from z4 | |
+| Teardown topology | |

--- a/bdd/docs/bgp_shard_v4_sync.md
+++ b/bdd/docs/bgp_shard_v4_sync.md
@@ -1,0 +1,55 @@
+# BGP IPv4-unicast read paths at N>1 (show / session-up sync read the empty main shard)
+
+## Overview
+
+Regression test for a correctness gap in BGP RIB sharding. At
+ZEBRA_BGP_SHARDS>1, plain IPv4-unicast routes are dispatched to the
+worker-shard pool (RouteBatchV4) and live ONLY in the pool shards; the
+reduce (`route_apply_bestpath_v4_batch`) used to do FIB-install +
+advertise but never mirror the best-path back into the synchronous
+`bgp.shard`, so every read path that consults `bgp.shard.v4` was empty
+at N>1:
+Forwarding itself is unaffected: the event-driven advertise runs off the
+best-path delta, not `bgp.shard`. This is IPv4-unicast-specific (the only
+pooled family); v6 / VPNv4 / VPNv6 / labeled-unicast are sync-ingested,
+so their `bgp.shard` tables stay populated and read correctly at N>1.
+z2 is the sharded device under test (4 shards) and the transit between
+z1 (origin) and two downstream peers:
+FIXED by the read-replica mirror: the pool reduce
+(`route_apply_bestpath_v4_batch` → `BgpShard::mirror_v4`) now keeps the
+main shard's `bgp.shard.v4` in step with the pool-owned table, so both
+read paths — `route_sync_ipv4` (for the late peer z4) and `show bgp
+ipv4` (z2's own RIB) — see the routes at N>1. This feature now guards
+against regressing that. (The sync build still runs serially on the
+main task; parallelizing its egress is a separate optimization, see
+docs/design/bgp-rib-sharding-plan.md §B.4.)
+A THIRD read path — `show bgp neighbor <peer> received-routes` (the
+peer's Adj-RIB-In) — is NOT covered by the Loc-RIB mirror: the
+authoritative adj_in lives in the pool shards, so at N>1 this read
+scatter-gathers it from every shard (A2 ⑤, `ShardMsg::DumpAdjInV4`). The
+received-routes scenario below guards that.
+
+## Test Topology
+
+```
+                         ┌── z3 (AS65003)  early peer  → event-driven (control)
+  z1 (AS65001) ── z2 (AS65002, 4 shards) ──┤
+   10.0.0.1/24    10.0.0.2/24              └── z4 (AS65004)  late peer   → sync (bug)
+   origin         sharded transit
+```
+
+## Notes
+
+All four on bridge br0. z1 originates 10.10.10.0/24 + 10.10.11.0/24.
+
+## Test Scenarios
+
+| Scenario | Result |
+|----------|--------|
+| z1, the sharded z2, and the early peer z3 come up (no routes yet) | |
+| control — z1 originates while z3 is up; the event-driven advertise reaches z3 | |
+| the late peer z4 gets the routes on sync, and z2 can show its own RIB | |
+| z2's received-routes from z1 are gathered from the pool shards (N>1 Adj-RIB-In) | |
+| z1 withdraws one route; the sharded reduce removes it from z2's mirror | |
+| z1's session drops; the sharded peer-down sweep clears z2's mirror | |
+| Teardown topology | |

--- a/bdd/docs/bgp_shard_v6.md
+++ b/bdd/docs/bgp_shard_v6.md
@@ -1,0 +1,37 @@
+# BGP IPv6-unicast Loc-RIB through the RIB shards (ZEBRA_BGP_SHARDS>1)
+
+## Overview
+
+The IPv6 mirror of @bgp_shard_policy. With the RIB partitioned across
+worker shards (ZEBRA_BGP_SHARDS>1), IPv6-unicast routes must flow
+through the pool exactly as IPv4-unicast does — ingest → owning shard →
+reduce → advertise — and the churn paths (withdraw, peer-down) must hit
+the pool too, not the now-empty synchronous shard.
+z2 runs with 4 shards. Correctness is observed DOWNSTREAM on z3 (N=1,
+so its `show` reads a whole table): z1 originates a v6 prefix only after
+every session is Established, so z2 processes it live on the N>1 path.
+IPv6 inbound policy still runs in main (the post-policy decision is sent
+to the shard), so this first cut does not exercise sharded policy /
+soft-reconfig — those land with full v4/v6 parity (compute-policy +
+SoftInV6) as a follow-up, mirrored from @bgp_shard_policy.
+
+## Test Topology
+
+```
+  z1 (AS65001) ── z2 (AS65002, 4 shards) ── z3 (AS65003)
+  2001:db8::1/64   2001:db8::2/64           2001:db8::3/64
+```
+
+## Notes
+
+All three on bridge br0.
+
+## Test Scenarios
+
+| Scenario | Result |
+|----------|--------|
+| Setup sessions with z2 sharded, before any routes exist | |
+| z1 originates v6 routes; the sharded z2 advertises them to z3 | |
+| z1 withdraws one v6 route; the sharded withdraw reaches z3 | |
+| z1's session drops; sharded peer-down withdraws its v6 routes from z3 | |
+| Teardown topology | |

--- a/bdd/docs/bgp_sync_backpressure.md
+++ b/bdd/docs/bgp_sync_backpressure.md
@@ -1,0 +1,27 @@
+# BGP IPv4 sync cursor egress backpressure — park + resume (Tier 1b)
+
+## Overview
+
+z2 originates 16384 IPv4-unicast routes and runs the resumable cursor
+with a low egress watermark and a slowed egress writer
+(ZEBRA_BGP_WRITER_DELAY_MS — a slow peer simulated at the app layer).
+When the late peer z3 establishes, z2's session-up dump outruns the
+slow writer: the pending-UPDATE queue grows past the watermark and the
+cursor PARKS, then resumes as the writer drains. Pins that the park
+engages (log) and the slowed dump still converges (z3 gets the routes)
+— the proof Tier 1b works.
+
+## Test Topology
+
+```
+  z2 (AS65002, cursor, slow egress writer) ── z3 (AS65003) late peer
+   16384 routes, sync chunk 500, egress high 4, writer delay 20ms
+```
+
+## Test Scenarios
+
+| Scenario | Result |
+|----------|--------|
+| z2 comes up with the large RIB and a slowed egress writer | |
+| late peer z3 triggers a slowed dump; the cursor parks then converges | |
+| Teardown topology | |

--- a/bdd/docs/bgp_sync_cursor_v4.md
+++ b/bdd/docs/bgp_sync_cursor_v4.md
@@ -1,0 +1,32 @@
+# BGP IPv4-unicast resumable session-up sync cursor (Tier 1a)
+
+## Overview
+
+Exercises the ZEBRA_BGP_SYNC_CHUNK resumable cursor: the device under
+test z2 runs with sync chunk 1, so its session-up IPv4-unicast dump to
+a late peer runs one prefix per main-loop tick instead of one
+uninterruptible pass. Pins that the chunked dump still delivers every
+route, sends EoR, registers each route in adj_out (so a later withdraw
++ peer-down reach the synced peer), and matches the legacy one-shot
+result.
+
+## Test Topology
+
+```
+  z1 (AS65001) ── z2 (AS65002, sync chunk 1) ── z3 (AS65003)  late peer → cursor sync
+   origin          device under test            recv
+```
+
+## Notes
+
+z1 originates 10.1.0.0/24, 10.2.0.0/24, 10.3.0.0/24. All on bridge br0.
+
+## Test Scenarios
+
+| Scenario | Result |
+|----------|--------|
+| z1 and the cursor device z2 come up; z2 holds the routes | |
+| the late peer z3 gets every route via the chunked cursor | |
+| z1 withdraws one route; the withdraw reaches the cursor-synced peer z3 | |
+| z1's session drops; the peer-down sweep clears its routes from z3 | |
+| Teardown topology | |

--- a/bdd/docs/bgp_v6_route_map.md
+++ b/bdd/docs/bgp_v6_route_map.md
@@ -1,0 +1,44 @@
+# BGP per-peer route-map for IPv6 unicast (inbound + outbound)
+
+## Overview
+
+As a network operator
+I want `neighbor X afi-safi ipv6 policy in/out <policy>` to filter and
+rewrite IPv6 unicast routes per neighbor — the same per-peer per-family
+route-map semantics
+the IPv4 unicast path already has. Before this, the v6 ingest and the
+v6 advertise applied no per-neighbor policy, so v6 route-maps were
+silently ignored (the global `table-map` was the only v6 policy hook).
+Unlike `table-map` (which gates only the kernel install and keeps a
+denied route visible in `show bgp ipv6`), an inbound route-map deny
+drops the route from the receiver's RIB entirely, and an outbound deny
+suppresses the advertisement at the originator.
+Policies are configured before the session establishes, so the test
+exercises the ingest / advertise policy hooks directly (no inbound
+soft-reconfiguration is assumed).
+
+## Test Topology
+
+```
+  ┌─────────────────┐   192.168.0.0/30    ┌─────────────────┐
+  │       z1        │   2001:db8:12::/64   │       z2        │
+  │     AS65001     ├─────────────────────┤     AS65002     │
+  │ .1 / 12::1      │                     │ .2 / 12::2      │
+  └─────────────────┘                     └─────────────────┘
+```
+
+## Notes
+
+z1 originates 2001:db8:100::/48, :200::/48, :300::/48 and binds an
+OUTBOUND policy OUT6 that denies :300::/48. z2 binds an INBOUND policy
+IN6 that denies :100::/48 and stamps `set med 50` on :200::/48.
+Expected at z2: only :200::/48 survives — :100::/48 is dropped by z2's
+inbound deny, :300::/48 is never advertised by z1's outbound deny —
+and :200::/48 carries the inbound-stamped MED into the FIB.
+
+## Test Scenarios
+
+| Scenario | Result |
+|----------|--------|
+| Setup topology and verify inbound + outbound IPv6 route-map | |
+| Teardown topology | |

--- a/bdd/docs/bgp_vrf_show.md
+++ b/bdd/docs/bgp_vrf_show.md
@@ -30,6 +30,6 @@ redirect into the spawned per-VRF task.
 |----------|--------|
 | Setup topology | |
 | Configure vrf-blue and observe via show | |
-| Inspect vrf-blue via the `show bgp vrf` tree | |
+| Inspect vrf-blue via the `show bgp vrf` AFI forms | |
 | Remove the BGP VRF block and observe the RD clear | |
 | Teardown topology | |

--- a/bdd/docs/bgp_vrf_vpnv6_export.md
+++ b/bdd/docs/bgp_vrf_vpnv6_export.md
@@ -1,0 +1,21 @@
+# BGP per-VRF VPNv6 origination (network) + receive on a remote PE
+
+## Overview
+
+Regression guard for VPNv6 VRF-`network` origination — the v6 sibling of
+`materialize_self_originated_networks` in vrf/spawn.rs that was missing —
+and the VPNv6 advertise path (V6Batch). z1 originates two v6 networks
+inside vrf-blue at VRF spawn; they are exported as VPNv6 NLRIs and
+received by z2. Killing z1 withdraws them from z2.
+Topology: z1 (RD 65001:100) <-VPNv6 iBGP-> z2 (RD 65001:200), both AS
+65001, vrf-blue importing/exporting RT 65001:100, over a native IPv6 link
+(so VPNv6 next-hop-self is a valid v6 address).
+
+## Test Scenarios
+
+| Scenario | Result |
+|----------|--------|
+| Setup topology (z1 originates its vrf-blue v6 networks at spawn) | |
+| z1 originates the vrf-blue v6 networks; z2 receives them as VPNv6 | |
+| z1 dies; z2 withdraws the VPNv6 routes it learned from it | |
+| Teardown topology | |

--- a/bdd/docs/flexalgo_tilfa_srv6.md
+++ b/bdd/docs/flexalgo_tilfa_srv6.md
@@ -2,33 +2,18 @@
 
 ## Overview
 
-Flex-Algo sibling of `tilfa_srv6`. The same proven eight-router topology
-and metrics (IPv6-only, every circuit point-to-point), but each router
-also runs a Flexible-Algorithm 128 (RFC 9350) on the SRv6 dataplane:
-
-- a per-algo SRv6 locator `fcbb:bbbb:1X::/48` (usid) bound to algo 128 via
-  `segment-routing srv6 flex-algo-locator`, beside the base (algo-0)
-  locator `fcbb:bbbb:X::/48`;
-- algo 128 has no affinity constraints, so its topology equals algo 0's —
-  the per-algo TI-LFA repair mirrors the algo-0 one;
+Flex-Algo sibling of @tilfa_srv6. Same proven eight-router topology and
+metrics (IPv6-only, every circuit point-to-point), but each router also
+runs a Flexible-Algorithm 128 (RFC 9350) on the SRv6 dataplane:
+- each router owns a per-algo SRv6 locator fcbb:bbbb:1X::/48 (behavior
+- algo 128 has no affinity constraints, so its topology equals algo 0's
 - `flex-algo 128 fast-reroute ti-lfa` enables per-algo TI-LFA, so the
-  per-algo locator routes carry a repair resolved to *algo-128* End /
-  End.X SIDs (SRH-inserted), keeping the repair inside algo 128.
-
-The metrics are tuned (from `tilfa_srv6`) so a simple LFA is impossible —
-protecting `s-n1` needs an SR repair tunnel through the r-plane. This
-validates per-algo TI-LFA (#1469) + per-algo End.X SID origination
-(#1470) end-to-end on the SRv6 dataplane. Pure-IGP (no BGP/LAN): the test
-asserts the per-algo locator repair, not colour-steered service traffic.
-
-> Like every BDD here it runs under the CI-excluded bdd suite in network
-> namespaces; it was authored (reusing the proven `tilfa_srv6` topology)
-> but not executed in the authoring sandbox — a real run may need
-> assertion tuning.
-
-## Config Files
-
-s.yaml  n1.yaml  n2.yaml  n3.yaml  r1.yaml  r2.yaml  r3.yaml  d.yaml
+The metrics are tuned (from @tilfa_srv6) so a simple LFA is impossible:
+s reaches d via s-n1 (cost 2); protecting s-n1 needs an SR repair tunnel
+through the r-plane. This validates per-algo TI-LFA + per-algo End.X SID
+origination end-to-end on the SRv6 dataplane.
+NOTE: like every BDD here this runs under the (CI-excluded) bdd suite in
+network namespaces; it has not been executed in the authoring sandbox.
 
 ## Test Scenarios
 

--- a/bdd/docs/interface_bridge.md
+++ b/bdd/docs/interface_bridge.md
@@ -1,0 +1,28 @@
+# Interface-to-bridge enslavement (`interface <if-name> bridge <bridge>`)
+
+## Overview
+
+As a network operator
+I want `interface <if-name> bridge <bridge>` to enslave a port to a bridge
+So that the binding is staged and applied once both the interface and the
+bridge exist — config order is free (equivalent to
+`ip link set <if-name> master <bridge>`).
+The binding is durable desired-state, mirroring `interface <if-name> vrf
+<vrf>`: it survives the bridge being created AFTER the interface config, an
+explicit unbind clears it, and the bridge being deleted then re-created
+re-applies it. We drive config with `apply command` (surgical set/delete)
+and assert the kernel state via `ip -o link show <if>` — `show interface`
+does not expose the master.
+Topology: one namespace `z1` with a single `dummy` port `dum0`. The bridge
+is created by the daemon from config (a namespace-internal kernel device),
+so no host-side bridge/veth scoping is needed.
+
+## Test Scenarios
+
+| Scenario | Result |
+|----------|--------|
+| Setup namespace with a dummy port | |
+| A - binding set before the bridge exists is applied once it is created | |
+| B - unbind clears the pending binding before the bridge appears | |
+| C - binding survives the bridge being deleted and re-binds on re-create | |
+| Teardown topology | |

--- a/bdd/docs/isis_flex_srv6.md
+++ b/bdd/docs/isis_flex_srv6.md
@@ -2,29 +2,16 @@
 
 ## Overview
 
-SRv6 sibling of `isis_flexalgo`. The same five-node, two-region backbone
-(se, ch, va, ln, fr) with the same affinity-constrained algorithms, but
-the Flex-Algo dataplane is SRv6 (RFC 9352 §7.1) instead of SR-MPLS.
-
-Every node advertises a distinct per-algorithm SRv6 locator, so reaching
-a node "in algo N" is plain longest-prefix IPv6 to that node's algo-N
-locator computed over the algo-N constrained topology — no per-prefix SID
-is pushed for transit. The algorithm is encoded by *which locator you
-target*.
-
-  - Algo 128 (US-only): exclude-any [eu, transatlantic]
-  - Algo 129 (EU-only): exclude-any [transatlantic, us]
-
-ch originates the FAD for both algorithms; the others participate without
-advertising a FAD.
-
-Per-node SRv6 locators (/48): `2001:db8:<n>000::` (base / algo-0),
-`2001:db8:<n>128::` (algo-128), `2001:db8:<n>129::` (algo-129), where
-`<n>` is a..e for se, ch, va, ln, fr.
-
-## Config Files
-
-se.yaml  ch.yaml  va.yaml  ln.yaml  fr.yaml
+SRv6 sibling of @isis_flexalgo. Same five-node, two-region backbone and
+the same affinity-constrained algorithms, but the Flex-Algo dataplane is
+SRv6 (RFC 9352 §7.1): every node advertises a distinct per-algorithm
+SRv6 locator, so reaching a node "in algo N" is plain longest-prefix
+IPv6 to that node's algo-N locator computed over the algo-N constrained
+topology — no per-prefix SID is pushed for transit.
+Topology (all links point-to-point; default metric 10):
+Per-node SRv6 locators (/48):
+The FAD for both algorithms is originated by ch; every other router
+participates without advertising a FAD.
 
 ## Test Scenarios
 

--- a/bdd/docs/isis_mirror_sid_srv6.md
+++ b/bdd/docs/isis_mirror_sid_srv6.md
@@ -1,0 +1,41 @@
+# IS-IS SRv6 Mirror SID egress protection — control plane + install
+
+## Overview
+
+As a network operator
+I want a protector PE to advertise a Mirror SID (SRv6 End.M) for a
+primary egress's locator, and a PLR to install an H.Encaps-to-the-
+Mirror-SID backup, so that on egress failure traffic can be redirected
+to the protector (draft-ietf-rtgwg-srv6-egress-protection).
+This feature validates the control + install path that needs no BGP
+L3VPN service: advertisement, reception, the protector's End.M localsid
+install, and the PLR backup install. The mirror-context table
+population (via-vrf) and live traffic failover need a VRF/VPN service
+and are covered separately.
+
+## Test Topology
+
+```
+    pe1 ──── p1 ──── pea
+   (::1)   (::2,PLR)  (::3, protected, fcbb:bbbb:3::/48)
+                \    /
+                 peb           (::4, protector, fcbb:bbbb:4::/48)
+                              Mirror SID fcbb:bbbb:4:1:: protects
+                              fcbb:bbbb:3::/48
+```
+
+## Notes
+
+All circuits are IS-IS Level-2, point-to-point, SRv6 uSID. p1 reaches
+both pea and peb directly, so the backup to peb is valid when pea fails.
+
+## Test Scenarios
+
+| Scenario | Result |
+|----------|--------|
+| Build the topology and confirm IS-IS + SRv6 convergence | |
+| peb advertises the Mirror SID and p1 receives it | |
+| peb installs the End.M localsid | |
+| p1 installs the PLR Mirror SID backup | |
+| peb withdraws the Mirror SID and the PLR backup clears | |
+| Teardown topology | |

--- a/bdd/docs/mirror_sid_egress_link.md
+++ b/bdd/docs/mirror_sid_egress_link.md
@@ -1,0 +1,36 @@
+# IS-IS SRv6 Mirror SID egress link protection — steady-state baseline
+
+## Overview
+
+A dual-homed CE (ce2) hangs off both the primary egress pea and the
+protector peb. pea carries the BGP L3VPN service for ce2 over SRv6
+(per-VRF End.DT46), and peb advertises a Mirror SID (End.M) protecting
+pea's locator with via-vrf vrf-cust, so on a pea PE-CE link failure pea
+can redirect its own service SID to peb's Mirror SID. This feature
+validates the steady state that the failover test builds on: the VPN
+forwards via pea, the Mirror SID is advertised and the End.M localsid +
+mirror-context route install on peb, and pea's End.DT46 service SID is
+in place. The live link-failure redirect is exercised separately.
+Topology (loopback 2001:db8::X, SRv6 locator fcbb:bbbb:X::/48):
+```
+```
+ce2 returns to ce1 via peb in both states (peb imports ce1), so the
+forward path is the only thing that changes on failover. peb does not
+originate ce2 into BGP — pe1 always forwards ce2-bound traffic via pea.
+
+## Notes
+
+ce2 returns to ce1 via peb in both states (peb imports ce1), so the
+forward path is the only thing that changes on failover. peb does not
+originate ce2 into BGP — pe1 always forwards ce2-bound traffic via pea.
+
+## Test Scenarios
+
+| Scenario | Result |
+|----------|--------|
+| Build topology and confirm IS-IS + BGP VPNv6 convergence | |
+| The VPN service forwards ce1 to ce2 via pea (primary egress) | |
+| peb advertises the Mirror SID and installs End.M + mirror-context | |
+| pea installs its per-VRF End.DT46 service SID | |
+| PE-CE link failure redirects via the Mirror SID | |
+| Teardown topology | |

--- a/bdd/docs/mirror_sid_mpls.md
+++ b/bdd/docs/mirror_sid_mpls.md
@@ -1,0 +1,38 @@
+# IS-IS SR-MPLS Mirror SID egress link protection — steady-state baseline
+
+## Overview
+
+A dual-homed CE (ce2) hangs off both the primary egress pea and the
+protector peb. pea carries the BGP L3VPN service for ce2 over SR-MPLS
+(IS-IS Prefix-SID transport + per-VRF VPN label), and peb advertises a
+Mirror Context binding (SID/Label Binding TLV 149, M-flag, RFC 8679) for
+pea's loopback with via-vrf vrf-cust, installing a context-label ILM
+that decaps into the VRF. On a pea PE-CE link failure pea can redirect
+its VPN traffic to peb's context label. This feature validates the
+steady state the failover builds on: VPNv4 forwards via pea over the
+SR-MPLS transport, the context binding is advertised and its ILM
+installs on peb, and pea's per-VRF VPN-label ILM is in place. The live
+link-failure redirect is exercised separately.
+Topology (loopback 1.1.1.X/32, Prefix-SID index X -> label 1600X):
+```
+```
+ce2 returns to ce1 via peb in both states (peb imports ce1), so the
+forward path is the only thing that changes on failover. peb does not
+originate ce2 into BGP — pe1 always forwards ce2-bound traffic via pea.
+
+## Notes
+
+ce2 returns to ce1 via peb in both states (peb imports ce1), so the
+forward path is the only thing that changes on failover. peb does not
+originate ce2 into BGP — pe1 always forwards ce2-bound traffic via pea.
+
+## Test Scenarios
+
+| Scenario | Result |
+|----------|--------|
+| Build topology and confirm IS-IS SR-MPLS + BGP VPNv4 | |
+| The VPN service forwards ce1 to ce2 via pea (primary egress) | |
+| peb advertises the Mirror Context binding and installs its ILM | |
+| pea installs its per-VRF VPN-label ILM | |
+| PE-CE link failure redirects via the Mirror Context label | |
+| Teardown topology | |

--- a/bdd/docs/mirror_sid_node.md
+++ b/bdd/docs/mirror_sid_node.md
@@ -1,0 +1,43 @@
+# IS-IS SRv6 Mirror SID egress NODE protection — stale-route retention
+
+## Overview
+
+TI-LFA and the egress-link redirect both need the protected egress to
+stay alive. This feature covers the other failure: the protected
+egress's whole NODE goes down. pea is a stub egress reachable only via
+the PLR pe1; peb (the protector) is reached directly over pe1-peb and
+advertises a Mirror SID (End.M) for pea's locator fcbb:bbbb:3::/48.
+While pea is up, pe1 routes to its locator over the pe1-pea adjacency
+and carries peb's Mirror SID as the egress-protection backup. When pea's
+node fails, that adjacency drops and pea's locator leaves the SPF — the
+diff would normally withdraw it, taking the repair with it. Mirror SID
+node-protection **stale-route retention** instead keeps the locator
+alive as a seg6 H.Encaps route to peb's Mirror SID, so traffic into the
+failed egress's locator is carried to the protector and the failover
+survives SPF reconvergence (not just the sub-second BFD window). When
+pea returns, its real locator route supersedes the retained one.
+```
+```
+The seg6 H.Encaps forwarding the retained route points at is exercised
+with live traffic by @mirror_sid_egress_link; here we validate that the
+locator route itself survives the node failure and is withdrawn on
+recovery.
+
+## Notes
+
+The seg6 H.Encaps forwarding the retained route points at is exercised
+with live traffic by @mirror_sid_egress_link; here we validate that the
+locator route itself survives the node failure and is withdrawn on
+recovery.
+
+## Test Scenarios
+
+| Scenario | Result |
+|----------|--------|
+| Build topology and confirm IS-IS SRv6 + Mirror SID exchange | |
+| Steady state — pe1 routes to pea's locator over the direct adjacency | |
+| Node failure — retention keeps the locator via the Mirror SID | |
+| Recovery — pea returns and its real locator route supersedes | |
+| Hold-down bounds the retention and withdraws the backup | |
+| After the hold-down, a returning egress re-installs the backup | |
+| Teardown topology | |

--- a/bdd/docs/mirror_sid_node_vpn.md
+++ b/bdd/docs/mirror_sid_node_vpn.md
@@ -1,0 +1,34 @@
+# IS-IS SRv6 Mirror SID egress NODE protection — live L3VPN service failover
+
+## Overview
+
+A real BGP L3VPN service survives the death of its egress PE node. The
+dual-homed CE ce2 hangs off the primary egress pea (a stub off pe1) and
+the protector peb (reached from pe1 over a direct bypass). pea carries
+the SRv6 L3VPN service for ce2 (per-VRF End.DT46) and peb advertises a
+Mirror SID (End.M) protecting pea's locator.
+When pea's node is killed, two opt-in mechanisms compose to keep the
+service forwarding end to end:
+NHT tracks pea's End.DT46 service SID (not pea's loopback), so it
+resolves the retained route *through* the locator, accumulating the
+Mirror SID — pe1 then double-encaps [Mirror SID, pea-SID] to peb, whose
+End.M re-resolves pea's SID in its mirror context and delivers to ce2.
+Topology (loopback 2001:db8::X, SRv6 locator fcbb:bbbb:X::/48):
+```
+```
+ce2 returns to ce1 via peb in both states (peb imports ce1), so only the
+forward path changes when pea dies.
+
+## Notes
+
+ce2 returns to ce1 via peb in both states (peb imports ce1), so only the
+forward path changes when pea dies.
+
+## Test Scenarios
+
+| Scenario | Result |
+|----------|--------|
+| Build topology and confirm IS-IS + BGP VPNv6 convergence | |
+| Baseline — the VPN service forwards ce1 to ce2 via pea | |
+| pea node death — pic-retention keeps the route and the service survives | |
+| Teardown topology | |

--- a/bdd/docs/mirror_sid_vpnsrv6_base.md
+++ b/bdd/docs/mirror_sid_vpnsrv6_base.md
@@ -1,0 +1,22 @@
+# VRF L3VPN over SRv6 (End.DT46) dataplane forwarding — v4 + v6
+
+## Overview
+
+Foundation for the Mirror SID live-traffic test, and the VPNv4-over-SRv6
+support check: two PEs (z1, z2) run IS-IS L2 SRv6 + iBGP VPNv4/VPNv6,
+each with a dual-stack VRF vrf-cust whose v4 and v6 CE prefixes are
+carried with the per-VRF End.DT46 service SID (one dual-family SID for
+both AFIs). Hosts behind z2 must reach hosts behind z1 over both v4 and
+v6 — z2 H.Encaps CE traffic toward z1's End.DT46 SID, z1 decapsulates
+into the VRF.
+```
+```
+
+## Test Scenarios
+
+| Scenario | Result |
+|----------|--------|
+| Build topology and confirm IS-IS + BGP VPNv4/VPNv6 | |
+| VPNv4 and VPNv6 routes carry SRv6 End.DT46 SIDs | |
+| CE-to-CE traffic forwards over the VPNv4/VPNv6 SRv6 dataplane | |
+| Teardown topology | |

--- a/bdd/docs/stamp_v6_te_metric.md
+++ b/bdd/docs/stamp_v6_te_metric.md
@@ -1,0 +1,34 @@
+# STAMP link-delay measurement over an IPv6-only IS-IS link
+
+## Overview
+
+As a network operator running delay-based traffic engineering on an
+IPv6 fabric, I want each P2P link's delay measured actively (STAMP,
+RFC 8762) and advertised by IS-IS (RFC 8570 link-delay sub-TLVs) even
+when the link carries no IPv4 — so dual-stack and v6-only links are
+measured the same way.
+Two zebra-rs instances share one IPv6-only P2P link (global addresses
+for routing, link-locals for the adjacency — no IPv4 anywhere on the
+measured interface). Both run IS-IS with `te-metric measurement`
+enabled (probe interval 100 ms, damping period 2 s). Because no shared
+IPv4 pair exists, the one STAMP session per link falls back to the
+IPv6 link-local pair (the same v4-preferred / v6-LL-fallback rule BFD
+uses), scoped by the link's ifindex. After the first damping period
+the measured values appear as "Min/Max Unidirectional Link Delay" in
+both LSDBs.
+OSPF is intentionally absent: OSPFv2 is IPv4-only on the wire and
+OSPFv3 has no TE-metric origination, so there is nowhere on the OSPF
+side to publish an IPv6 delay (see docs/design/stamp-ipv6-plan.md §1).
+Topology:
+
+## Config Files
+
+
+## Test Scenarios
+
+| Scenario | Result |
+|----------|--------|
+| Build the IPv6-only measured topology | |
+| A v6 link-local STAMP session forms and measures the link | |
+| IS-IS advertises the measured IPv6-link delay | |
+| Teardown topology | |

--- a/bdd/docs/static_vrf.md
+++ b/bdd/docs/static_vrf.md
@@ -1,0 +1,21 @@
+# Static routes inside a VRF (router static vrf NAME)
+
+## Overview
+
+A static route configured under `router static vrf <name>` installs
+into that VRF's kernel routing table and forwards traffic. Two hosts
+hang off one router's VRF, each reached by a per-VRF static route to
+its loopback; a ping between the host loopbacks proves the VRF static
+routes are installed and resolving on-link (the gateway sits on a VRF
+interface, whose connected route the kernel flushes on enslave — so
+this exercises the on-link `ifindex_origin` resolution path).
+```
+```
+
+## Test Scenarios
+
+| Scenario | Result |
+|----------|--------|
+| Build topology and confirm the VRF static routes install | |
+| Traffic forwards between the hosts via the VRF static routes | |
+| Teardown topology | |

--- a/bdd/docs/vxlan_bridge.md
+++ b/bdd/docs/vxlan_bridge.md
@@ -1,0 +1,25 @@
+# VXLAN-to-bridge enslavement (`vxlan <name> bridge <bridge>`)
+
+## Overview
+
+As a network operator
+I want `vxlan <name> bridge <bridge>` to enslave a VXLAN device to a bridge
+So that an EVPN-style bridge port is set up in one step, with the VXLAN
+bridge-slave defaults applied automatically.
+This reuses the same staged bridge-bind as `interface <name> bridge
+<bridge>` (a VXLAN is an ordinary kernel link), so config order is free.
+In addition, binding a VXLAN to a bridge must yield the defaults from the
+iproute2 recipe:
+- `addrgenmode none` is the VXLAN creation default.
+- `neigh_suppress on` + `learning off` are applied by
+We assert kernel state via `ip -d link show <vni>` (the `-d` detail view
+exposes addrgenmode and the bridge_slave port options).
+
+## Test Scenarios
+
+| Scenario | Result |
+|----------|--------|
+| Setup namespace with a VXLAN device | |
+| A - binding applies master and the VXLAN bridge-slave defaults | |
+| B - deferred bind applies the defaults once the bridge is created | |
+| Teardown topology | |


### PR DESCRIPTION
## Summary

Runs `make docs` in `bdd/` to regenerate the per-feature Markdown under
`bdd/docs/` from the cucumber `.feature` files.

- 54 new docs for feature files added since docs were last regenerated
  (BGP EVPN segmentation/AR/SMET/S-PMSI/SRv6-P2MP, BGP RIB sharding suite,
  mirror-SID failover variants, VXLAN/bridge, static VRF, STAMP v6, …).
- 5 refreshed docs whose scenarios changed (bgp_community,
  bgp_policy_dynamic_update, bgp_vrf_show, flexalgo_tilfa_srv6,
  isis_flex_srv6).

## Test plan

- Generated output only (`docs/feature2md.sh` over each `.feature`); no code
  changes. `git diff` confirms every change is under `bdd/docs/`.

Generated with [Claude Code](https://claude.com/claude-code)