### PR TITLE
BGP Mobile User Plane (MUP, SAFI 85 / RFC 9833) control plane

### DIFF
--- a/bdd/docs/bgp_mup_runtime_enable.md
+++ b/bdd/docs/bgp_mup_runtime_enable.md
@@ -1,0 +1,28 @@
+# BGP MUP capability (re)negotiates when enabled on a live session
+
+## Overview
+
+An AFI/SAFI is a BGP Multiprotocol *capability*, advertised once in the
+OPEN — the negotiated set is fixed for the life of the session. So
+enabling `afi-safi mobile-uplane` (RFC 9833, which turns on BOTH IPv4-MUP
+and IPv6-MUP) on an already-Established neighbor has no effect until the
+session renegotiates. zebra-rs therefore bounces the session on the
+change — the same teardown `clear bgp ... hard` uses — so the new MUP
+capability is advertised and received without an operator clear.
+This regressed silently before: the config was recorded but the live
+session was never bounced, so `show bgp neighbor` kept showing the old
+capability set (no MUP).
+
+## Test Topology
+
+```
+   z1 (AS65001, 192.168.0.1) ── br0 ── z2 (AS65001, 192.168.0.2)
+   both start IPv4-unicast only; mobile-uplane is enabled at runtime.
+```
+
+## Test Scenarios
+
+| Scenario | Result |
+|----------|--------|
+| Enabling mobile-uplane at runtime renegotiates the MUP capability | |
+| Teardown topology | |

--- a/bdd/tests/configs/bgp_mup_capability/z1-1.yaml
+++ b/bdd/tests/configs/bgp_mup_capability/z1-1.yaml
@@ -1,0 +1,14 @@
+router:
+  bgp:
+    global:
+      as: 65001
+      router-id: 192.168.0.1
+    neighbor:
+    - remote-address: 192.168.0.2
+      enabled: true
+      remote-as: 65001
+      afi-safi:
+      - name: ipv4
+        enabled: true
+      - name: mobile-uplane
+        enabled: true

--- a/bdd/tests/configs/bgp_mup_capability/z2-1.yaml
+++ b/bdd/tests/configs/bgp_mup_capability/z2-1.yaml
@@ -1,0 +1,14 @@
+router:
+  bgp:
+    global:
+      as: 65001
+      router-id: 192.168.0.2
+    neighbor:
+    - remote-address: 192.168.0.1
+      enabled: true
+      remote-as: 65001
+      afi-safi:
+      - name: ipv4
+        enabled: true
+      - name: mobile-uplane
+        enabled: true

--- a/bdd/tests/configs/bgp_mup_runtime_enable/z1-1.yaml
+++ b/bdd/tests/configs/bgp_mup_runtime_enable/z1-1.yaml
@@ -1,0 +1,18 @@
+## tests/configs/bgp_mup_runtime_enable/z1-1.yaml
+# iBGP, IPv4 unicast only — NO mobile-uplane at startup. The scenario
+# enables `afi-safi mobile-uplane` on the LIVE session at runtime; because
+# an AFI/SAFI is a Multiprotocol capability fixed at OPEN time, that change
+# bounces the session (like `clear bgp ... hard`) so the MUP capability is
+# renegotiated and shows up in `show bgp neighbor`.
+router:
+  bgp:
+    global:
+      as: 65001
+      router-id: 192.168.0.1
+    neighbor:
+    - remote-address: 192.168.0.2
+      enabled: true
+      remote-as: 65001
+      afi-safi:
+      - name: ipv4
+        enabled: true

--- a/bdd/tests/configs/bgp_mup_runtime_enable/z2-1.yaml
+++ b/bdd/tests/configs/bgp_mup_runtime_enable/z2-1.yaml
@@ -1,0 +1,15 @@
+## tests/configs/bgp_mup_runtime_enable/z2-1.yaml
+# Mirror of z1-1.yaml: iBGP, IPv4 unicast only, no mobile-uplane at
+# startup. mobile-uplane is enabled at runtime by the scenario.
+router:
+  bgp:
+    global:
+      as: 65001
+      router-id: 192.168.0.2
+    neighbor:
+    - remote-address: 192.168.0.1
+      enabled: true
+      remote-as: 65001
+      afi-safi:
+      - name: ipv4
+        enabled: true

--- a/bdd/tests/features/bgp_mup_capability.feature
+++ b/bdd/tests/features/bgp_mup_capability.feature
@@ -1,0 +1,72 @@
+@serial
+@bgp_mup_capability
+Feature: BGP Mobile User Plane (MUP) capability negotiation
+  As a network operator
+  I want two zebra-rs instances to negotiate the BGP MUP multiprotocol
+  capability (SAFI 85, RFC 9833) for BOTH IPv4-MUP (AFI 1) and IPv6-MUP
+  (AFI 2) from a single `afi-safi mobile-uplane enabled true` knob, and
+  bring an iBGP session to Established, so the foundation for MUP route
+  exchange (ISD / DSD / ST1 / ST2) is validated before origination is
+  implemented.
+
+  No MUP routes flow in this scenario — capability negotiation is the unit
+  under test. zebra-rs cannot originate MUP routes yet (controller phase),
+  so route exchange is exercised in a later feature once a peer can emit
+  them.
+
+  Test Topology:
+  ```
+  ┌─────────────────────────────────────────┐
+  │                   br0                    │
+  └─────────────┬───────────────┬───────────┘
+                │               │
+           ┌────┴────┐     ┌────┴────┐
+           │   z1    │     │   z2    │
+           │ AS65001 │     │ AS65001 │
+           │192.168. │     │192.168. │
+           │  0.1/24 │     │  0.2/24 │
+           └─────────┘     └─────────┘
+  ```
+
+  Both peers enable two AFI/SAFIs:
+    - ipv4 (so the session has a fallback AF and matches the
+      established BDD pattern)
+    - mobile-uplane (the single knob this scenario validates; it
+      negotiates IPv4-MUP and IPv6-MUP)
+
+  Config files:
+  - z1-1.yaml: AS 65001, peer to 192.168.0.2, mobile-uplane enabled
+  - z2-1.yaml: AS 65001, peer to 192.168.0.1, mobile-uplane enabled
+
+  Scenario: Setup topology and establish iBGP session with MUP capability
+    Given a clean test environment
+    When I create bridge "br0"
+    And I create namespace "z1" with IP "192.168.0.1/24" on bridge "br0"
+    And I create namespace "z2" with IP "192.168.0.2/24" on bridge "br0"
+    And I start zebra-rs in namespace "z1"
+    And I start zebra-rs in namespace "z2"
+    And I apply config "z1-1.yaml" to namespace "z1"
+    And I apply config "z2-1.yaml" to namespace "z2"
+    And I wait 5 seconds for BGP to operate
+    Then BGP session in "z1" to "192.168.0.2" should be "Established"
+    And BGP session in "z2" to "192.168.0.1" should be "Established"
+
+  Scenario: IPv4 and IPv6 MUP capabilities are advertised and received on both sides
+    Given the test topology exists
+    Then show command "show bgp neighbor 192.168.0.2" in namespace "z1" should contain "IPv4 MUP: advertised and received"
+    And show command "show bgp neighbor 192.168.0.2" in namespace "z1" should contain "IPv6 MUP: advertised and received"
+    And show command "show bgp neighbor 192.168.0.1" in namespace "z2" should contain "IPv4 MUP: advertised and received"
+    And show command "show bgp neighbor 192.168.0.1" in namespace "z2" should contain "IPv6 MUP: advertised and received"
+
+  Scenario: show bgp mobile-uplane renders the (empty) MUP RIB header
+    Given the test topology exists
+    Then show command "show bgp mobile-uplane" in namespace "z1" should contain "Network (MUP NLRI)"
+
+  Scenario: Teardown topology
+    Given the test topology exists
+    When I stop zebra-rs in namespace "z1"
+    And I stop zebra-rs in namespace "z2"
+    And I delete namespace "z1"
+    And I delete namespace "z2"
+    And I delete bridge "br0"
+    Then the test environment should be clean

--- a/bdd/tests/features/bgp_mup_runtime_enable.feature
+++ b/bdd/tests/features/bgp_mup_runtime_enable.feature
@@ -1,0 +1,56 @@
+@serial
+@bgp_mup_runtime_enable
+Feature: BGP MUP capability (re)negotiates when enabled on a live session
+  An AFI/SAFI is a BGP Multiprotocol *capability*, advertised once in the
+  OPEN — the negotiated set is fixed for the life of the session. So
+  enabling `afi-safi mobile-uplane` (RFC 9833, which turns on BOTH IPv4-MUP
+  and IPv6-MUP) on an already-Established neighbor has no effect until the
+  session renegotiates. zebra-rs therefore bounces the session on the
+  change — the same teardown `clear bgp ... hard` uses — so the new MUP
+  capability is advertised and received without an operator clear.
+
+  This regressed silently before: the config was recorded but the live
+  session was never bounced, so `show bgp neighbor` kept showing the old
+  capability set (no MUP).
+
+  Test Topology:
+  ```
+   z1 (AS65001, 192.168.0.1) ── br0 ── z2 (AS65001, 192.168.0.2)
+   both start IPv4-unicast only; mobile-uplane is enabled at runtime.
+  ```
+
+  Scenario: Enabling mobile-uplane at runtime renegotiates the MUP capability
+    Given a clean test environment
+    When I create bridge "br0"
+    And I create namespace "z1" with IP "192.168.0.1/24" on bridge "br0"
+    And I create namespace "z2" with IP "192.168.0.2/24" on bridge "br0"
+    And I start zebra-rs in namespace "z1"
+    And I start zebra-rs in namespace "z2"
+    And I apply config "z1-1.yaml" to namespace "z1"
+    And I apply config "z2-1.yaml" to namespace "z2"
+    And I wait 5 seconds for BGP to operate
+    Then BGP session in "z1" to "192.168.0.2" should be "Established"
+    # Not configured yet: the OPEN carried no MUP capability.
+    And show command "show bgp neighbor 192.168.0.2" in namespace "z1" should not contain "IPv4 MUP"
+    # Enable mobile-uplane on BOTH live sessions; each change bounces its
+    # session so the capability is renegotiated on reconnect.
+    When I apply command "set router bgp neighbor 192.168.0.2 afi-safi mobile-uplane enabled true" in namespace "z1"
+    And I apply command "set router bgp neighbor 192.168.0.1 afi-safi mobile-uplane enabled true" in namespace "z2"
+    And I wait 15 seconds for BGP to operate
+    Then BGP session in "z1" to "192.168.0.2" should be "Established"
+    And show command "show bgp neighbor 192.168.0.2" in namespace "z1" should contain "IPv4 MUP: advertised and received"
+    And show command "show bgp neighbor 192.168.0.2" in namespace "z1" should contain "IPv6 MUP: advertised and received"
+    And show command "show bgp neighbor 192.168.0.1" in namespace "z2" should contain "IPv4 MUP: advertised and received"
+    And show command "show bgp neighbor 192.168.0.1" in namespace "z2" should contain "IPv6 MUP: advertised and received"
+    # The new `show bgp mobile-uplane summary` lists the MUP-capable neighbor.
+    And show command "show bgp mobile-uplane summary" in namespace "z1" should contain "IPv4 MUP Summary"
+    And show command "show bgp mobile-uplane summary" in namespace "z1" should contain "192.168.0.2"
+
+  Scenario: Teardown topology
+    Given the test topology exists
+    When I stop zebra-rs in namespace "z1"
+    And I stop zebra-rs in namespace "z2"
+    And I delete namespace "z1"
+    And I delete namespace "z2"
+    And I delete bridge "br0"
+    Then the test environment should be clean

--- a/crates/bgp-packet/src/attrs/mp_reach.rs
+++ b/crates/bgp-packet/src/attrs/mp_reach.rs
@@ -1251,14 +1251,18 @@ mod tests {
         vec![0u8; 8 + 4]
     }
 
-    /// Minimal T1ST body (AFI-agnostic at plen=0 and ep_len=0):
-    /// 8 RD + 1 plen=0 + 0 prefix + 4 TEID + 1 QFI + 1 ep_len=0 + 0 endpoint.
+    /// Minimal T1ST body for the IPv6 outer AFI (its only caller): RD(8),
+    /// plen=0 (no prefix), TEID(4), QFI(1), ep_len=128, endpoint(16),
+    /// src_len=0. The endpoint length must equal the AFI host width and
+    /// the source-address-length octet is mandatory (RFC 9833 §3.2.1).
     fn min_t1st_body() -> Vec<u8> {
         let mut v = vec![0u8; 8]; // RD
         v.push(0); // plen
         v.extend_from_slice(&[0; 4]); // TEID
         v.push(0); // QFI
-        v.push(0); // ep_len
+        v.push(128); // ep_len (IPv6 host width)
+        v.extend_from_slice(&[0; 16]); // endpoint
+        v.push(0); // src_len = 0 (no source)
         v
     }
 
@@ -1354,7 +1358,9 @@ mod tests {
                 id: 0,
                 arch: crate::MupArchitectureType::Gpp5g,
                 rd: crate::RouteDistinguisher::from_str("65000:2").unwrap(),
-                endpoint: "192.0.2.50/32".parse().unwrap(),
+                endpoint: "192.0.2.50".parse().unwrap(),
+                endpoint_len: 64,
+                teid: 50,
             },
         ];
         let mut buf = BytesMut::new();

--- a/crates/bgp-packet/src/attrs/mp_unreach.rs
+++ b/crates/bgp-packet/src/attrs/mp_unreach.rs
@@ -757,11 +757,13 @@ mod tests {
         v
     }
 
-    /// Minimal T2ST body (AFI-agnostic at endpoint_len=0):
-    /// 8 RD + 1 ep_len=0 + 0 endpoint bytes.
+    /// Minimal T2ST body for the IPv4 outer AFI (its only caller): RD(8),
+    /// ep_len=32, endpoint(4) (no TEID bits). The endpoint length covers
+    /// the full-width address per RFC 9833 §3.2.2.
     fn min_t2st_body() -> Vec<u8> {
         let mut v = vec![0u8; 8];
-        v.push(0);
+        v.push(32); // endpoint_len = IPv4 address width
+        v.extend_from_slice(&[0; 4]); // endpoint
         v
     }
 
@@ -848,6 +850,7 @@ mod tests {
                 teid: 7,
                 qfi: 4,
                 endpoint: "2001:db8::5".parse().unwrap(),
+                source: None,
             },
         ];
         let mut buf = BytesMut::new();

--- a/crates/bgp-packet/src/attrs/nlri_mup.rs
+++ b/crates/bgp-packet/src/attrs/nlri_mup.rs
@@ -140,11 +140,12 @@ pub enum MupRoute {
     ///
     /// Wire body: 8-octet RD + 1-octet prefix length (bits) + prefix
     /// bytes + 4-octet TEID + 1-octet QFI + 1-octet endpoint address
-    /// length (bits) + endpoint address bytes. Both prefix and
-    /// endpoint follow the outer AFI's address family. The optional
-    /// Source Address suffix from earlier draft revisions is not
-    /// emitted here; trailing bytes inside the NLRI length window
-    /// would surface as a parse failure.
+    /// length (bits, 32 or 128) + endpoint address bytes + 1-octet
+    /// source address length (bits, 0/32/128) + optional source
+    /// address bytes. The source-address-length octet is always
+    /// present on the wire (zero when no source is carried), matching
+    /// GoBGP and RFC 9833 §3.2.1. Prefix, endpoint, and source all
+    /// follow the outer AFI's address family.
     T1st {
         id: u32,
         arch: MupArchitectureType,
@@ -153,20 +154,27 @@ pub enum MupRoute {
         teid: u32,
         qfi: u8,
         endpoint: IpAddr,
+        /// Optional GTP source address (§3.2.1). `None` encodes a
+        /// source-address-length of 0 on the wire.
+        source: Option<IpAddr>,
     },
     /// Type 2 Session Transformed Route (RFC 9833 §3.2.2).
     ///
-    /// Wire body: 8-octet RD + 1-octet endpoint address length in
-    /// bits + endpoint address bytes (ceil(len/8) octets). The TEID
-    /// is encoded in the lower bits of the endpoint address per
-    /// §3.2.2; this layer surfaces the address + bit-length pair as
-    /// an `IpNet`, leaving any TEID-bits extraction to upper layers.
-    /// The outer AFI selects the address family.
+    /// Wire body: 8-octet RD + 1-octet endpoint address length (bits,
+    /// up to 64 for IPv4 / 160 for IPv6) + full-width endpoint address
+    /// (4 or 16 octets, selected by the outer AFI) + TEID bytes. The
+    /// endpoint-address-length covers both the address and the trailing
+    /// TEID bits, so the TEID occupies ceil((len - addr_bits)/8) octets
+    /// stored high-aligned in a 32-bit value (GoBGP-compatible).
     T2st {
         id: u32,
         arch: MupArchitectureType,
         rd: RouteDistinguisher,
-        endpoint: IpNet,
+        endpoint: IpAddr,
+        /// Endpoint Address Length in bits (address bits + TEID bits).
+        endpoint_len: u8,
+        /// GTP TEID, high-aligned into 32 bits per §3.2.2.
+        teid: u32,
     },
     Unknown {
         id: u32,
@@ -219,15 +227,40 @@ impl MupRoute {
                 }
             }
             MupRoute::T1st {
-                prefix, endpoint, ..
+                prefix,
+                endpoint,
+                source,
+                ..
             } => {
                 let ep_bits = match endpoint {
                     IpAddr::V4(_) => 32u8,
                     IpAddr::V6(_) => 128u8,
                 };
-                8 + 1 + nlri_psize(prefix.prefix_len()) + 4 + 1 + 1 + nlri_psize(ep_bits)
+                // RD(8) + plen(1) + prefix + TEID(4) + QFI(1)
+                // + ep_len(1) + endpoint + src_len(1) + optional source.
+                let mut len =
+                    8 + 1 + nlri_psize(prefix.prefix_len()) + 4 + 1 + 1 + nlri_psize(ep_bits) + 1;
+                if let Some(src) = source {
+                    let src_bits = match src {
+                        IpAddr::V4(_) => 32u8,
+                        IpAddr::V6(_) => 128u8,
+                    };
+                    len += nlri_psize(src_bits);
+                }
+                len
             }
-            MupRoute::T2st { endpoint, .. } => 8 + 1 + nlri_psize(endpoint.prefix_len()),
+            MupRoute::T2st {
+                endpoint,
+                endpoint_len,
+                ..
+            } => {
+                let (addr_bytes, addr_bits) = match endpoint {
+                    IpAddr::V4(_) => (4usize, 32u8),
+                    IpAddr::V6(_) => (16usize, 128u8),
+                };
+                let teid_bits = endpoint_len.saturating_sub(addr_bits);
+                8 + 1 + addr_bytes + nlri_psize(teid_bits)
+            }
             MupRoute::Unknown { body, .. } => body.len(),
         }
     }
@@ -347,8 +380,10 @@ impl MupRoute {
                 let rest = &rest[psize..];
                 let (rest, teid) = be_u32(rest)?;
                 let (rest, qfi) = be_u8(rest)?;
+                // Endpoint address length must be exactly the AFI's host
+                // width (32 or 128) per RFC 9833 §3.2.1.
                 let (rest, ep_len) = be_u8(rest)?;
-                if ep_len > max_addr_bits {
+                if ep_len != max_addr_bits {
                     return Err(nom::Err::Error(make_error(input, ErrorKind::Verify)));
                 }
                 let ep_size = nlri_psize(ep_len);
@@ -368,6 +403,33 @@ impl MupRoute {
                     }
                     _ => unreachable!(),
                 };
+                let rest = &rest[ep_size..];
+                // Mandatory source-address-length octet; 0 means no
+                // source, otherwise it must match the AFI host width.
+                let (rest, src_len) = be_u8(rest)?;
+                let source = if src_len == 0 {
+                    None
+                } else if src_len == max_addr_bits {
+                    let src_size = nlri_psize(src_len);
+                    if rest.len() < src_size {
+                        return Err(nom::Err::Error(make_error(input, ErrorKind::Eof)));
+                    }
+                    match afi {
+                        Afi::Ip => {
+                            let mut octets = [0u8; 4];
+                            octets[..src_size].copy_from_slice(&rest[..src_size]);
+                            Some(IpAddr::V4(Ipv4Addr::from(octets)))
+                        }
+                        Afi::Ip6 => {
+                            let mut octets = [0u8; 16];
+                            octets[..src_size].copy_from_slice(&rest[..src_size]);
+                            Some(IpAddr::V6(Ipv6Addr::from(octets)))
+                        }
+                        _ => unreachable!(),
+                    }
+                } else {
+                    return Err(nom::Err::Error(make_error(input, ErrorKind::Verify)));
+                };
                 MupRoute::T1st {
                     id,
                     arch,
@@ -376,41 +438,59 @@ impl MupRoute {
                     teid,
                     qfi,
                     endpoint,
+                    source,
                 }
             }
             MupRouteType::T2st => {
                 let (rest, rd) = RouteDistinguisher::parse_be(body_slice)?;
-                let (rest, ep_len) = be_u8(rest)?;
-                let max_addr_bits = match afi {
-                    Afi::Ip => 32u8,
-                    Afi::Ip6 => 128u8,
+                let (rest, endpoint_len) = be_u8(rest)?;
+                let (max_ep_len, addr_size, addr_bits) = match afi {
+                    Afi::Ip => (64u8, 4usize, 32u8),
+                    Afi::Ip6 => (160u8, 16usize, 128u8),
                     _ => return Err(nom::Err::Error(make_error(input, ErrorKind::Verify))),
                 };
-                if ep_len > max_addr_bits {
+                if endpoint_len > max_ep_len {
                     return Err(nom::Err::Error(make_error(input, ErrorKind::Verify)));
                 }
-                let ep_size = nlri_psize(ep_len);
-                if rest.len() < ep_size {
+                if rest.len() < addr_size {
                     return Err(nom::Err::Error(make_error(input, ErrorKind::Eof)));
                 }
                 let endpoint = match afi {
                     Afi::Ip => {
                         let mut octets = [0u8; 4];
-                        octets[..ep_size].copy_from_slice(&rest[..ep_size]);
-                        IpNet::V4(Ipv4Net::new(Ipv4Addr::from(octets), ep_len).unwrap())
+                        octets.copy_from_slice(&rest[..4]);
+                        IpAddr::V4(Ipv4Addr::from(octets))
                     }
                     Afi::Ip6 => {
                         let mut octets = [0u8; 16];
-                        octets[..ep_size].copy_from_slice(&rest[..ep_size]);
-                        IpNet::V6(Ipv6Net::new(Ipv6Addr::from(octets), ep_len).unwrap())
+                        octets.copy_from_slice(&rest[..16]);
+                        IpAddr::V6(Ipv6Addr::from(octets))
                     }
                     _ => unreachable!(),
+                };
+                let rest = &rest[addr_size..];
+                // The endpoint-address-length covers the address plus the
+                // trailing TEID bits; the TEID is high-aligned in 32 bits
+                // (GoBGP-compatible).
+                let teid_bits = endpoint_len.saturating_sub(addr_bits);
+                let teid = if teid_bits > 0 {
+                    let tsize = nlri_psize(teid_bits);
+                    if rest.len() < tsize {
+                        return Err(nom::Err::Error(make_error(input, ErrorKind::Eof)));
+                    }
+                    let mut octets = [0u8; 4];
+                    octets[..tsize].copy_from_slice(&rest[..tsize]);
+                    u32::from_be_bytes(octets)
+                } else {
+                    0
                 };
                 MupRoute::T2st {
                     id,
                     arch,
                     rd,
                     endpoint,
+                    endpoint_len,
+                    teid,
                 }
             }
             MupRouteType::Unknown(rt) => MupRoute::Unknown {
@@ -463,6 +543,7 @@ impl MupRoute {
                 teid,
                 qfi,
                 endpoint,
+                source,
                 ..
             } => {
                 payload.put_u16(rd.typ as u16);
@@ -485,16 +566,43 @@ impl MupRoute {
                     IpAddr::V4(v4) => payload.put(&v4.octets()[..]),
                     IpAddr::V6(v6) => payload.put(&v6.octets()[..]),
                 }
+                // Source-address-length octet is mandatory (0 = absent).
+                match source {
+                    Some(IpAddr::V4(v4)) => {
+                        payload.put_u8(32);
+                        payload.put(&v4.octets()[..]);
+                    }
+                    Some(IpAddr::V6(v6)) => {
+                        payload.put_u8(128);
+                        payload.put(&v6.octets()[..]);
+                    }
+                    None => payload.put_u8(0),
+                }
             }
-            MupRoute::T2st { rd, endpoint, .. } => {
+            MupRoute::T2st {
+                rd,
+                endpoint,
+                endpoint_len,
+                teid,
+                ..
+            } => {
                 payload.put_u16(rd.typ as u16);
                 payload.put(&rd.val[..]);
-                let plen = endpoint.prefix_len();
-                payload.put_u8(plen);
-                let psize = nlri_psize(plen);
+                payload.put_u8(*endpoint_len);
+                let addr_bits = match endpoint {
+                    IpAddr::V4(_) => 32u8,
+                    IpAddr::V6(_) => 128u8,
+                };
                 match endpoint {
-                    IpNet::V4(p) => payload.put(&p.addr().octets()[..psize]),
-                    IpNet::V6(p) => payload.put(&p.addr().octets()[..psize]),
+                    IpAddr::V4(v4) => payload.put(&v4.octets()[..]),
+                    IpAddr::V6(v6) => payload.put(&v6.octets()[..]),
+                }
+                // TEID occupies the bits beyond the address, high-aligned.
+                let teid_bits = endpoint_len.saturating_sub(addr_bits);
+                if teid_bits > 0 {
+                    let tsize = nlri_psize(teid_bits);
+                    let tb = teid.to_be_bytes();
+                    payload.put(&tb[..tsize]);
                 }
             }
             MupRoute::Unknown { body, .. } => {
@@ -503,6 +611,123 @@ impl MupRoute {
         }
         buf.put_u8(payload.len() as u8);
         buf.put(&payload[..]);
+    }
+}
+
+/// MUP NLRI key with the add-path Path Identifier (and the constant
+/// architecture type) stripped off, used to index the MUP RIB tables.
+///
+/// This is a *full-NLRI* key: every wire field except the add-path `id`
+/// (which lives on `BgpRib.remote_id`) is part of the key, so two routes
+/// that differ only in TEID/QFI/endpoint/source coexist, and replacement
+/// is by explicit withdraw. Variant declaration order (`Dsd, Isd, T1st,
+/// T2st`) drives the derived `Ord`, so a RIB walk lists routes grouped by
+/// type (DSD then ISD then ST1 then ST2).
+#[derive(Debug, Clone, Eq, PartialEq, Ord, PartialOrd, Hash)]
+pub enum MupPrefix {
+    /// Direct Segment Discovery Route key (RFC 9833 §3.1.2).
+    Dsd {
+        rd: RouteDistinguisher,
+        address: IpAddr,
+    },
+    /// Interwork Segment Discovery Route key (§3.1.1).
+    Isd {
+        rd: RouteDistinguisher,
+        prefix: IpNet,
+    },
+    /// Type 1 Session Transformed Route (ST1) key (§3.2.1).
+    T1st {
+        rd: RouteDistinguisher,
+        prefix: IpNet,
+        teid: u32,
+        qfi: u8,
+        endpoint: IpAddr,
+        source: Option<IpAddr>,
+    },
+    /// Type 2 Session Transformed Route (ST2) key (§3.2.2).
+    T2st {
+        rd: RouteDistinguisher,
+        endpoint: IpAddr,
+        endpoint_len: u8,
+        teid: u32,
+    },
+    /// Unrecognized route type — keyed by its raw type and opaque body so
+    /// the RIB never coalesces distinct unknown routes.
+    Unknown { route_type: u16, body: Vec<u8> },
+}
+
+impl MupPrefix {
+    /// MUP route type number (1=ISD, 2=DSD, 3=T1ST, 4=T2ST).
+    pub fn route_type(&self) -> u16 {
+        match self {
+            MupPrefix::Isd { .. } => 1,
+            MupPrefix::Dsd { .. } => 2,
+            MupPrefix::T1st { .. } => 3,
+            MupPrefix::T2st { .. } => 4,
+            MupPrefix::Unknown { route_type, .. } => *route_type,
+        }
+    }
+
+    /// The Route Distinguisher carried by every defined MUP route type
+    /// (`None` only for the opaque `Unknown` variant).
+    pub fn rd(&self) -> Option<RouteDistinguisher> {
+        match self {
+            MupPrefix::Dsd { rd, .. }
+            | MupPrefix::Isd { rd, .. }
+            | MupPrefix::T1st { rd, .. }
+            | MupPrefix::T2st { rd, .. } => Some(*rd),
+            MupPrefix::Unknown { .. } => None,
+        }
+    }
+
+    /// Split a parsed `MupRoute` into the RD-and-id-stripped key used to
+    /// index the MUP RIB. The add-path `id` and the (constant) arch type
+    /// are dropped; the `id` lives on `BgpRib.remote_id`.
+    pub fn from_route(route: &MupRoute) -> MupPrefix {
+        match route {
+            MupRoute::Isd { rd, prefix, .. } => MupPrefix::Isd {
+                rd: *rd,
+                prefix: *prefix,
+            },
+            MupRoute::Dsd { rd, address, .. } => MupPrefix::Dsd {
+                rd: *rd,
+                address: *address,
+            },
+            MupRoute::T1st {
+                rd,
+                prefix,
+                teid,
+                qfi,
+                endpoint,
+                source,
+                ..
+            } => MupPrefix::T1st {
+                rd: *rd,
+                prefix: *prefix,
+                teid: *teid,
+                qfi: *qfi,
+                endpoint: *endpoint,
+                source: *source,
+            },
+            MupRoute::T2st {
+                rd,
+                endpoint,
+                endpoint_len,
+                teid,
+                ..
+            } => MupPrefix::T2st {
+                rd: *rd,
+                endpoint: *endpoint,
+                endpoint_len: *endpoint_len,
+                teid: *teid,
+            },
+            MupRoute::Unknown {
+                route_type, body, ..
+            } => MupPrefix::Unknown {
+                route_type: *route_type,
+                body: body.clone(),
+            },
+        }
     }
 }
 
@@ -753,6 +978,7 @@ mod tests {
                 teid: 0x1234_5678,
                 qfi: 9,
                 endpoint: "192.0.2.1".parse().unwrap(),
+                source: Some("198.51.100.7".parse().unwrap()),
             },
             false,
             Afi::Ip,
@@ -770,6 +996,7 @@ mod tests {
                 teid: 0xAAAA_BBBB,
                 qfi: 5,
                 endpoint: "2001:db8::1".parse().unwrap(),
+                source: Some("2001:db8::abcd".parse().unwrap()),
             },
             false,
             Afi::Ip6,
@@ -787,6 +1014,7 @@ mod tests {
                 teid: 0,
                 qfi: 0,
                 endpoint: "203.0.113.99".parse().unwrap(),
+                source: None,
             },
             true,
             Afi::Ip,
@@ -804,6 +1032,7 @@ mod tests {
                 teid: 42,
                 qfi: 1,
                 endpoint: "192.0.2.250".parse().unwrap(),
+                source: None,
             },
             false,
             Afi::Ip,
@@ -844,6 +1073,7 @@ mod tests {
             teid: 1,
             qfi: 2,
             endpoint: "192.0.2.1".parse().unwrap(),
+            source: Some("203.0.113.1".parse().unwrap()),
         };
         let mut buf = BytesMut::new();
         route.nlri_emit(&mut buf);
@@ -857,7 +1087,9 @@ mod tests {
                 id: 0,
                 arch: MupArchitectureType::Gpp5g,
                 rd: sample_rd(),
-                endpoint: "10.0.0.1/32".parse().unwrap(),
+                endpoint: "10.0.0.1".parse().unwrap(),
+                endpoint_len: 64,
+                teid: 600,
             },
             false,
             Afi::Ip,
@@ -871,7 +1103,9 @@ mod tests {
                 id: 0,
                 arch: MupArchitectureType::Gpp5g,
                 rd: sample_rd(),
-                endpoint: "2001:db8::1/128".parse().unwrap(),
+                endpoint: "2001:db8::1".parse().unwrap(),
+                endpoint_len: 160,
+                teid: 0xAABB_CCDD,
             },
             false,
             Afi::Ip6,
@@ -879,19 +1113,21 @@ mod tests {
     }
 
     #[test]
-    fn t2st_v6_partial_bit_length_round_trip() {
-        // TEID-encoded endpoint where only the upper 80 bits are
-        // semantically meaningful. The encoding stores ceil(80/8)=10
-        // octets and reconstructs them on parse.
+    fn t2st_v4_partial_teid_round_trip() {
+        // endpoint_len = 48 → 32 address bits + 16 TEID bits. The TEID is
+        // stored high-aligned, so only its upper 16 bits survive the
+        // 2-octet on-wire field.
         round_trip(
             MupRoute::T2st {
                 id: 0,
                 arch: MupArchitectureType::Gpp5g,
                 rd: sample_rd(),
-                endpoint: "2001:db8:1:2:3::/80".parse().unwrap(),
+                endpoint: "10.0.0.1".parse().unwrap(),
+                endpoint_len: 48,
+                teid: 0x0258_0000,
             },
             false,
-            Afi::Ip6,
+            Afi::Ip,
         );
     }
 
@@ -902,7 +1138,9 @@ mod tests {
                 id: 0xC0FFEE00,
                 arch: MupArchitectureType::Gpp5g,
                 rd: sample_rd(),
-                endpoint: "192.0.2.99/32".parse().unwrap(),
+                endpoint: "192.0.2.99".parse().unwrap(),
+                endpoint_len: 64,
+                teid: 0x0000_3039,
             },
             true,
             Afi::Ip,
@@ -911,11 +1149,10 @@ mod tests {
 
     #[test]
     fn t2st_rejects_endpoint_len_over_afi_max() {
-        // arch=1, route_type=4, length=14, RD(8) + ep_len=33 (> 32 for v4) + filler
-        let mut v = vec![0x01, 0x00, 0x04, 14];
+        // arch=1, route_type=4, length=9: RD(8) + ep_len=65 (> 64 for v4).
+        let mut v = vec![0x01, 0x00, 0x04, 9];
         v.extend_from_slice(&[0; 8]);
-        v.push(33);
-        v.extend_from_slice(&[0; 5]);
+        v.push(65);
         assert!(MupRoute::parse(&v, false, Afi::Ip).is_err());
     }
 
@@ -925,11 +1162,129 @@ mod tests {
             id: 0,
             arch: MupArchitectureType::Gpp5g,
             rd: sample_rd(),
-            endpoint: "2001:db8::1/128".parse().unwrap(),
+            endpoint: "2001:db8::1".parse().unwrap(),
+            endpoint_len: 160,
+            teid: 42,
         };
         let mut buf = BytesMut::new();
         route.nlri_emit(&mut buf);
         assert_eq!(buf.len(), 4 + route.body_len());
+    }
+
+    // --- GoBGP byte-exact interop vectors ---------------------------------
+    // These pin the on-wire layout against GoBGP's mup.go encoders. A
+    // zero Route Distinguisher (8 zero octets) keeps the vectors free of
+    // any dependence on RD string parsing.
+
+    #[test]
+    fn t1st_parses_gobgp_v4_bytes_with_source() {
+        // RD(8) + plen=24 + prefix(3) + TEID(4)=601 + QFI=9
+        // + ep_len=32 + endpoint(4) + src_len=32 + source(4).
+        let mut body = vec![0u8; 8];
+        body.push(24);
+        body.extend_from_slice(&[10, 0, 3]); // 10.0.3.0/24
+        body.extend_from_slice(&[0x00, 0x00, 0x02, 0x59]); // TEID 601
+        body.push(9); // QFI
+        body.push(32); // endpoint address length
+        body.extend_from_slice(&[20, 0, 3, 99]); // 20.0.3.99
+        body.push(32); // source address length
+        body.extend_from_slice(&[20, 0, 1, 1]); // 20.0.1.1
+        let mut v = vec![0x01, 0x00, 0x03, body.len() as u8];
+        v.extend_from_slice(&body);
+
+        let (rest, route) = MupRoute::parse(&v, false, Afi::Ip).unwrap();
+        assert!(rest.is_empty());
+        match route {
+            MupRoute::T1st {
+                prefix,
+                teid,
+                qfi,
+                endpoint,
+                source,
+                ..
+            } => {
+                assert_eq!(prefix.to_string(), "10.0.3.0/24");
+                assert_eq!(teid, 601);
+                assert_eq!(qfi, 9);
+                assert_eq!(endpoint, "20.0.3.99".parse::<IpAddr>().unwrap());
+                assert_eq!(source, Some("20.0.1.1".parse::<IpAddr>().unwrap()));
+            }
+            other => panic!("expected T1st, got {other:?}"),
+        }
+
+        // Re-emit must reproduce the exact same wire bytes.
+        let mut buf = BytesMut::new();
+        route.nlri_emit(&mut buf);
+        assert_eq!(&buf[..], &v[..]);
+    }
+
+    #[test]
+    fn t1st_parses_gobgp_v4_bytes_without_source() {
+        // Same as above but the mandatory source-address-length octet is
+        // zero and no source bytes follow.
+        let mut body = vec![0u8; 8];
+        body.push(24);
+        body.extend_from_slice(&[10, 0, 3]);
+        body.extend_from_slice(&[0x00, 0x00, 0x02, 0x59]);
+        body.push(9);
+        body.push(32);
+        body.extend_from_slice(&[20, 0, 3, 99]);
+        body.push(0); // source address length = 0
+        let mut v = vec![0x01, 0x00, 0x03, body.len() as u8];
+        v.extend_from_slice(&body);
+
+        let (rest, route) = MupRoute::parse(&v, false, Afi::Ip).unwrap();
+        assert!(rest.is_empty());
+        assert!(matches!(route, MupRoute::T1st { source: None, .. }));
+        let mut buf = BytesMut::new();
+        route.nlri_emit(&mut buf);
+        assert_eq!(&buf[..], &v[..]);
+    }
+
+    #[test]
+    fn t1st_rejects_non_host_endpoint_len() {
+        // ep_len = 24 is neither 32 nor 128 → malformed (RFC 9833 §3.2.1).
+        let mut body = vec![0u8; 8];
+        body.push(0); // plen=0
+        body.extend_from_slice(&[0; 4]); // TEID
+        body.push(0); // QFI
+        body.push(24); // ep_len not a host width
+        body.extend_from_slice(&[0; 3]);
+        let mut v = vec![0x01, 0x00, 0x03, body.len() as u8];
+        v.extend_from_slice(&body);
+        assert!(MupRoute::parse(&v, false, Afi::Ip).is_err());
+    }
+
+    #[test]
+    fn t2st_parses_gobgp_v4_bytes_with_teid() {
+        // RD(8) + ep_len=64 + endpoint(4) + TEID(4)=600. The endpoint
+        // address length covers the 32 address bits plus 32 TEID bits.
+        let mut body = vec![0u8; 8];
+        body.push(64);
+        body.extend_from_slice(&[20, 0, 1, 1]); // 20.0.1.1
+        body.extend_from_slice(&[0x00, 0x00, 0x02, 0x58]); // TEID 600
+        let mut v = vec![0x01, 0x00, 0x04, body.len() as u8];
+        v.extend_from_slice(&body);
+
+        let (rest, route) = MupRoute::parse(&v, false, Afi::Ip).unwrap();
+        assert!(rest.is_empty());
+        match route {
+            MupRoute::T2st {
+                endpoint,
+                endpoint_len,
+                teid,
+                ..
+            } => {
+                assert_eq!(endpoint, "20.0.1.1".parse::<IpAddr>().unwrap());
+                assert_eq!(endpoint_len, 64);
+                assert_eq!(teid, 600);
+            }
+            other => panic!("expected T2st, got {other:?}"),
+        }
+
+        let mut buf = BytesMut::new();
+        route.nlri_emit(&mut buf);
+        assert_eq!(&buf[..], &v[..]);
     }
 
     #[test]
@@ -979,5 +1334,53 @@ mod tests {
         route.nlri_emit(&mut buf);
         // 1 arch + 2 rt + 1 len + body
         assert_eq!(buf.len(), 4 + route.body_len());
+    }
+
+    #[test]
+    fn mup_prefix_strips_add_path_id() {
+        // Two routes identical but for the add-path id map to one key.
+        let a = MupRoute::Isd {
+            id: 1,
+            arch: MupArchitectureType::Gpp5g,
+            rd: sample_rd(),
+            prefix: "10.0.0.0/24".parse().unwrap(),
+        };
+        let b = MupRoute::Isd {
+            id: 999,
+            arch: MupArchitectureType::Gpp5g,
+            rd: sample_rd(),
+            prefix: "10.0.0.0/24".parse().unwrap(),
+        };
+        assert_eq!(MupPrefix::from_route(&a), MupPrefix::from_route(&b));
+    }
+
+    #[test]
+    fn mup_prefix_orders_dsd_before_isd_before_st() {
+        let dsd = MupPrefix::from_route(&MupRoute::Dsd {
+            id: 0,
+            arch: MupArchitectureType::Gpp5g,
+            rd: sample_rd(),
+            address: "1.1.1.1".parse().unwrap(),
+        });
+        let isd = MupPrefix::from_route(&MupRoute::Isd {
+            id: 0,
+            arch: MupArchitectureType::Gpp5g,
+            rd: sample_rd(),
+            prefix: "10.0.0.0/24".parse().unwrap(),
+        });
+        let st2 = MupPrefix::from_route(&MupRoute::T2st {
+            id: 0,
+            arch: MupArchitectureType::Gpp5g,
+            rd: sample_rd(),
+            endpoint: "20.0.1.1".parse().unwrap(),
+            endpoint_len: 64,
+            teid: 600,
+        });
+        assert!(dsd < isd, "Dsd sorts before Isd");
+        assert!(isd < st2, "Isd sorts before T2st");
+        assert_eq!(dsd.route_type(), 2);
+        assert_eq!(isd.route_type(), 1);
+        assert_eq!(st2.route_type(), 4);
+        assert_eq!(isd.rd(), Some(sample_rd()));
     }
 }

--- a/crates/bgp-packet/src/attrs/nlri_mup.rs
+++ b/crates/bgp-packet/src/attrs/nlri_mup.rs
@@ -729,6 +729,79 @@ impl MupPrefix {
             },
         }
     }
+
+    /// Outer AFI implied by the route's address family. RFC 9833 §3 ties
+    /// every address a MUP route carries to the MP_REACH AFI, so the
+    /// prefix / address / endpoint family is authoritative. `Unknown`
+    /// has no decoded address, so it defaults to IPv4.
+    pub fn afi(&self) -> Afi {
+        let v6 = match self {
+            MupPrefix::Isd { prefix, .. } | MupPrefix::T1st { prefix, .. } => {
+                matches!(prefix, IpNet::V6(_))
+            }
+            MupPrefix::Dsd { address, .. } => address.is_ipv6(),
+            MupPrefix::T2st { endpoint, .. } => endpoint.is_ipv6(),
+            MupPrefix::Unknown { .. } => false,
+        };
+        if v6 { Afi::Ip6 } else { Afi::Ip }
+    }
+
+    /// Reconstruct a wire `MupRoute` from the key for re-advertisement.
+    /// The full-NLRI key carries every field, so the only synthesized
+    /// values are the 3GPP-5G architecture type and a zero add-path id.
+    pub fn to_route(&self) -> MupRoute {
+        let arch = MupArchitectureType::Gpp5g;
+        match self {
+            MupPrefix::Isd { rd, prefix } => MupRoute::Isd {
+                id: 0,
+                arch,
+                rd: *rd,
+                prefix: *prefix,
+            },
+            MupPrefix::Dsd { rd, address } => MupRoute::Dsd {
+                id: 0,
+                arch,
+                rd: *rd,
+                address: *address,
+            },
+            MupPrefix::T1st {
+                rd,
+                prefix,
+                teid,
+                qfi,
+                endpoint,
+                source,
+            } => MupRoute::T1st {
+                id: 0,
+                arch,
+                rd: *rd,
+                prefix: *prefix,
+                teid: *teid,
+                qfi: *qfi,
+                endpoint: *endpoint,
+                source: *source,
+            },
+            MupPrefix::T2st {
+                rd,
+                endpoint,
+                endpoint_len,
+                teid,
+            } => MupRoute::T2st {
+                id: 0,
+                arch,
+                rd: *rd,
+                endpoint: *endpoint,
+                endpoint_len: *endpoint_len,
+                teid: *teid,
+            },
+            MupPrefix::Unknown { route_type, body } => MupRoute::Unknown {
+                id: 0,
+                arch,
+                route_type: *route_type,
+                body: body.clone(),
+            },
+        }
+    }
 }
 
 #[cfg(test)]
@@ -1352,6 +1425,51 @@ mod tests {
             prefix: "10.0.0.0/24".parse().unwrap(),
         };
         assert_eq!(MupPrefix::from_route(&a), MupPrefix::from_route(&b));
+    }
+
+    #[test]
+    fn mup_prefix_afi_and_to_route_round_trip() {
+        // afi() reflects the route-key address family; to_route() inverts
+        // from_route for the full-NLRI key (arch=Gpp5g, id=0).
+        let cases = [
+            MupRoute::Isd {
+                id: 7,
+                arch: MupArchitectureType::Gpp5g,
+                rd: sample_rd(),
+                prefix: "10.0.3.0/24".parse().unwrap(),
+            },
+            MupRoute::Dsd {
+                id: 7,
+                arch: MupArchitectureType::Gpp5g,
+                rd: sample_rd(),
+                address: "1.1.1.99".parse().unwrap(),
+            },
+            MupRoute::T1st {
+                id: 7,
+                arch: MupArchitectureType::Gpp5g,
+                rd: sample_rd(),
+                prefix: "2001:db8:cafe::5/128".parse().unwrap(),
+                teid: 601,
+                qfi: 9,
+                endpoint: "2001:db8::99".parse().unwrap(),
+                source: Some("2001:db8::1".parse().unwrap()),
+            },
+            MupRoute::T2st {
+                id: 7,
+                arch: MupArchitectureType::Gpp5g,
+                rd: sample_rd(),
+                endpoint: "20.0.1.1".parse().unwrap(),
+                endpoint_len: 64,
+                teid: 600,
+            },
+        ];
+        let expect_afi = [Afi::Ip, Afi::Ip, Afi::Ip6, Afi::Ip];
+        for (route, afi) in cases.iter().zip(expect_afi) {
+            let prefix = MupPrefix::from_route(route);
+            assert_eq!(prefix.afi(), afi);
+            // to_route() round-trips back to the same key.
+            assert_eq!(MupPrefix::from_route(&prefix.to_route()), prefix);
+        }
     }
 
     #[test]

--- a/docs/design/bgp-mup-followups.md
+++ b/docs/design/bgp-mup-followups.md
@@ -1,0 +1,346 @@
+# BGP MUP (Mobile User Plane) — deferred follow-ups
+
+Status as of 2026-06-21. The MUP **control plane** (RFC 9833 /
+draft-mpmz-bess-mup-safi, SAFI 85) landed on branch `bgp-mup` over four
+phases, committed and pushed (rebased onto `origin/main`):
+
+- **P0 codec** — completed the `MupRoute` codec to be GoBGP byte-exact:
+  T1ST now emits the mandatory source-address-length octet + optional
+  `source`; T2ST remodeled `IpNet` → `{endpoint, endpoint_len, teid}`
+  (length up to 64/160, high-aligned TEID). GoBGP byte-exact interop
+  vectors added. The MUP Extended Community (`0x0c`) and SAFI 85 were
+  already present.
+- **P1 negotiation** — `mobile-uplane` afi-safi knob that expands to
+  *both* `(Ip, Mup)` and `(Ip6, Mup)` capabilities (`mp_family_expand`),
+  per-neighbor and per-group.
+- **P2 Loc-RIB + receive + show** — full-NLRI `MupPrefix` key + flat
+  `LocalRibMupTable`; `route_mup_update`/`route_mup_withdraw` wired into
+  the `MpReachAttr::Mup` / `MpUnreachAttr::Mup` receive arms; `adj_in.mup`;
+  `route_clean` peer-down; `show bgp mobile-uplane` route table.
+- **P3 per-VRF config** — `router bgp vrf <name> mobile-uplane`:
+  `route-target export` + `srv6-mobile {decapsulation|encapsulation}
+  network-instance exact <ni>`; the config-driven `MUP VRFs:` block in
+  `show bgp mobile-uplane`.
+- **P4 advertise / re-originate** — `MupPrefix::afi()`/`to_route()`,
+  `adj_out.mup`, AFI-aware `route_advertise_mup_to_peers` /
+  `route_withdraw_mup_to_peers` (EVPN suppression + eBGP-next-hop-self /
+  iBGP-preserve + LLGR gate; next-hop in MP_REACH), and the
+  establish-time `route_sync_mup` replay + per-AFI EoR.
+
+Tests on the rebased base: 342 `bgp-packet` + 1378 `zebra-rs`, fmt +
+workspace clippy clean.
+
+The items below were consciously left out so each phase could ship as a
+small PR. None block the control-plane path for the common case
+(receive / store / show / re-advertise MUP routes between speakers).
+Each entry: **what / why deferred / where / suggested PR size**. The
+two large remaining phases (P5 controller, P6 dataplane) are at the end
+with their open design questions.
+
+Standing guidance still applies: smallest meaningful slice first, let
+the user redirect, one branch / one PR at a time.
+
+## Receive / Loc-RIB
+
+### 1. Inbound route-policy for MUP
+
+**What:** Received MUP routes are stored unfiltered — no per-AFI inbound
+`policy`/`prefix-set` is applied in `route_mup_update`.
+
+**Why deferred:** No per-AFI MUP policy binding exists (the `afi-safi
+<name> policy {in,out}` / `prefix-set` knobs don't yet accept
+`mobile-uplane`). Parity with EVPN, which also applies no inbound policy.
+
+**Where:** `route_mup_update` in `zebra-rs/src/bgp/route.rs`; the per-AFI
+policy plumbing in `zebra-rs/src/bgp/config.rs` (`config_afi_safi_policy_*`)
++ `Peer::policy_list_at`. See [the per-AFI policy work](bgp-multiprotocol-receive-followups.md).
+
+**Size:** medium (~250 lines: policy binding + apply + tests).
+
+### 2. Next-Hop Tracking (NHT) for MUP next-hops
+
+**What:** The MUP next-hop (PE/controller IPv6 address) is not registered
+with NHT, so reachability/recursive-resolution gating isn't applied to
+MUP routes.
+
+**Why deferred:** P2/P4 are control-plane only; the NHT gate matters once
+MUP routes drive forwarding (P6) or feed the controller's resolution.
+
+**Where:** `route_mup_update` + the NHT register/gate path
+(`zebra-rs/src/bgp/nht*`), mirroring how VPNv4/VPNv6 next-hops register.
+
+**Size:** medium (~200 lines).
+
+### 3. VRF import (route-target → VRF) for received MUP routes
+
+**What:** The per-VRF `mobile-uplane route-target export` set (P3) is
+stored but there is no import dispatch that pulls received MUP routes
+into a VRF by RT (unlike VPNv4/EVPN's `VrfImportDispatcher`).
+
+**Why deferred:** MUP "import" semantics are session-shaped (ST routes
+map to GTP tunnels), not L3VPN-prefix-shaped; the consumer is the P5
+controller / P6 dataplane, which don't exist yet.
+
+**Where:** mirror `dispatch_import_*` in `zebra-rs/src/bgp/route.rs` once
+the controller defines what importing an ST route *means*.
+
+**Size:** medium-large (design-dependent; sequence after P5).
+
+### 4. RFC 7606 treat-as-withdraw coverage for MUP
+
+**What:** The NLRI decoder already treat-as-withdraws malformed MUP NLRI
+fields (bad prefix/endpoint length, zero TEID, etc.). Confirm the
+*attribute*-level path — `withdraw_mp_reach` / the `treat_as_withdraw`
+branch in `route_from_peer` — has a MUP arm, so a malformed-attribute
+UPDATE that rides alongside a MUP NLRI withdraws the reachable NLRI
+rather than leaving an installed copy.
+
+**Why deferred:** Same gap flagged generally for all newly-surfaced
+families in [`bgp-multiprotocol-receive-followups.md`](bgp-multiprotocol-receive-followups.md) §"RFC 7606".
+
+**Where:** `withdraw_mp_reach` in `zebra-rs/src/bgp/route.rs`.
+
+**Size:** small (~80 lines + test).
+
+### 5. LLGR stale-retention on peer-down
+
+**What:** `route_clean`'s MUP block is a simple non-LLGR withdrawal. The
+advertise side already honours LLGR (`llgr_blocks_advertisement` gates
+`mup_advertise_one` / `route_sync_mup`), but on peer-down MUP routes are
+withdrawn outright rather than stale-marked + retained for the LLGR
+stale time.
+
+**Why deferred:** LLGR for MUP is niche; the two-branch
+stale-mark/retain path (EVPN/VPNv4 have it) is extra surface for a
+control-plane-first phase.
+
+**Where:** the MUP block in `route_clean` (`zebra-rs/src/bgp/route.rs`);
+mirror the EVPN LLGR two-branch.
+
+**Size:** medium (~200 lines).
+
+## Show
+
+### 6. Full `MUP controller:` show block
+
+**What:** `show bgp mobile-uplane` renders the config-driven `MUP VRFs:`
+block (P3) + the route table (P2). The mockup's full wrapper — header
+`MUP controller: enabled`, the `zenoh source:` line, `ingested sessions`
+count, and the `vpnv6 ue-routes:` list — needs P5 controller state.
+
+**Why deferred:** Those lines describe controller runtime that doesn't
+exist until P5.
+
+**Where:** `show_bgp_mup` / `render_mup_vrfs` in `zebra-rs/src/bgp/show.rs`.
+
+**Size:** small once P5 state exists (~150 lines).
+
+### 7. `show bgp mobile-uplane` JSON output
+
+**What:** The JSON branch returns the `"[]"` placeholder; only text is
+implemented.
+
+**Why deferred:** Text sufficed on landing.
+
+**Where:** `show_bgp_mup` in `zebra-rs/src/bgp/show.rs`.
+
+**Size:** small (~120 lines).
+
+## Advertise (P4)
+
+### 8. Egress coalescing / update-groups for MUP
+
+**What:** `route_advertise_mup_to_peers` sends one MP_REACH per route per
+peer via direct `send_packet` (the flowspec shape) — no update-group
+batching or `UpdateGroupSig` membership.
+
+**Why deferred:** Correct on the wire; coalescing is a scale
+optimization, and building a MUP egress-cache layer is its own work.
+
+**Where:** `mup_send_one` / `route_advertise_mup_to_peers` in
+`zebra-rs/src/bgp/route.rs`. See [`bgp-update-groups.md`](bgp-update-groups.md).
+
+**Size:** medium (~300 lines).
+
+### 9. Per-AFI MUP outbound route-policy
+
+**What:** Egress passes unfiltered — no `policy_list_apply` on the MUP
+advertise path.
+
+**Why deferred:** No MUP policy binding exists (see #1); parity with EVPN
+when no Output policy is configured.
+
+**Where:** `mup_advertise_one` in `zebra-rs/src/bgp/route.rs`.
+
+**Size:** medium (pairs with #1).
+
+### 10. MUP AddPath TX
+
+**What:** Fan-out uses `established_plain_idents` (best path only); no
+Add-Path send, and withdraw is the id-less whole-prefix MP_UNREACH.
+
+**Why deferred:** Add-Path TX isn't implemented for MUP; plain best-path
+covers the controller→PE and RR cases.
+
+**Where:** `route_advertise_mup_to_peers` + `adj_out.mup` (give the table
+an Add-Path id dimension like the v4 path).
+
+**Size:** medium (~250 lines).
+
+### 11. eBGP next-hop-self next-hop family
+
+**What:** For eBGP / originated routes, `route_update_mup` sets the
+next-hop to `peer.param.local_addr.ip()`, which may be IPv4. RFC 9833
+next-hops are IPv6 (PE/controller address).
+
+**Why deferred:** iBGP / route-reflector — the common controller→PE path
+— *preserves* the received IPv6 next-hop, so this only affects eBGP MUP
+peering, which is unusual.
+
+**Where:** the next-hop branch in `route_update_mup`
+(`zebra-rs/src/bgp/route.rs`); force a v6 next-hop-self for MUP.
+
+**Size:** small (~60 lines).
+
+## Codec / model
+
+### 12. BGP-IP-VPN architecture type (arch 2)
+
+**What:** Only architecture type 1 (`3gpp-5g`) is decoded into typed
+fields; any other architecture type falls through to `MupRoute::Unknown`
+(opaque body, round-trip preserved).
+
+**Why deferred:** 3GPP-5G is the only architecture the draft fully
+specifies and the only one deployed.
+
+**Where:** `crates/bgp-packet/src/attrs/nlri_mup.rs`
+(`MupArchitectureType` + the per-route-type bodies).
+
+**Size:** medium (only if a non-3GPP architecture is ever needed).
+
+### 13. Strict draft route-key (vs the chosen full-NLRI key)
+
+**What:** The RIB keys on the *whole* NLRI (minus the Add-Path id). The
+draft's route-key for BGP best-path is narrower — `RD + Prefix` for
+T1ST, `RD + Endpoint + TEID` for T2ST — i.e. a newer T1ST for the same
+UE prefix would *replace* an older one even if the TEID differs.
+
+**Why deferred:** Full-NLRI key is simpler, makes `show` complete
+directly, and relies on explicit withdraws (normal BGP). The strict
+route-key needs per-path TEID/QFI/endpoint/source stored off-key on
+`BgpRib` for display. Chosen deliberately; revisit only if
+implicit-replace semantics are required.
+
+**Where:** `MupPrefix` in `crates/bgp-packet/src/attrs/nlri_mup.rs`.
+
+**Size:** medium (~300 lines: off-key path fields + show plumbing).
+
+## Testing
+
+### 14. End-to-end receive-from-peer / RR BDD
+
+**What:** A multi-node BDD (originate on one speaker, receive +
+re-advertise + show on another) that exercises the full control plane on
+the wire.
+
+**Why deferred:** The BDD harness is zebra-rs↔zebra-rs (no GoBGP/ExaBGP
+injector), so an *originator* is required — and MUP origination is P5.
+`bdd/tests/features/bgp_mup_capability.feature` (session-up + capability
+negotiation) is authored but **not run** (needs root netns; BDD is
+excluded from CI gates per
+[`zebra-rs-ci-and-merge-rules`](../../zebra-rs-ci-and-merge-rules.md)).
+
+**Where:** `bdd/tests/`.
+
+**Size:** medium (lands with P5).
+
+### 15. zebra-rs-level advertise integration test
+
+**What:** No test drives `route_mup_update` → `adj_out.mup` + emitted
+MP_REACH through a full `Bgp` + Established peer.
+
+**Why deferred:** Standing up a full `Bgp` + peer + membership is
+impractical as a unit test (EVPN's advertise isn't unit-tested either).
+Coverage today is compile + clippy-wiring + the `bgp-packet`
+`afi()`/`to_route()` and `MupPrefix` tests + the `render_mup_*` tests.
+
+**Where:** `zebra-rs/src/bgp/route.rs` test module (or a harness).
+
+**Size:** medium.
+
+## The two remaining phases
+
+### P5 — MUP Controller (zenoh / PFCP)
+
+**What:** Subscribe to PFCP sessions over zenoh and originate, per
+session: an ST1 route (the `encapsulation` / N6 VRF), an ST2 route (the
+`decapsulation` / N3 VRF), and a VPNv6 UE route — each tagged with the
+VRF's `route-target export` and an SRv6 SID — plus the full
+`MUP controller:` show block (zenoh source, ingested-session count,
+originated-route count, `vpnv6 ue-routes`).
+
+**Open design questions (need operator input before building):**
+1. **Session schema** on the zenoh `pfcp/**` keys — encoding (JSON /
+   protobuf / custom) and fields (UE prefix, TEID, QFI, gNodeB endpoint,
+   source, network-instance, …). This is the blocker for the
+   session→route mapping.
+2. **`zenoh` crate** dependency + the `zenoh source tcp/<addr>:<port>` /
+   `prefix pfcp/**` config knobs (and a pinned version).
+3. **SID source** — where ST / VPNv6 SIDs come from (the mockup shows
+   `sid=fcbb:bb00:30:19::`, i.e. carved from a global `srv6 locator`
+   like the L3VPN End.DT46 path).
+
+**Recommended seam:** a `SessionSource` trait (zenoh is one impl) so the
+session→ST origination logic is unit-testable without standing up a
+zenoh bus. This also unblocks the end-to-end BDD (#14) using a synthetic
+source.
+
+**Where:** new module under `zebra-rs/src/bgp/`; origination reuses the
+P4 advertise path + the VPNv6 origination path.
+
+**Size:** large (multi-PR).
+
+### P6 — SRv6-mobile dataplane
+
+**What:** Install the FIB state for MUP-derived routes. Per the chosen
+"install what the kernel supports" scope: program `End.DT4/6` + the
+route-level SIDs we already do for L3VPN/SRv6, and flag the GTP
+behaviours (`End.M.GTP4.E` / `End.M.GTP6.E` / `GTP4.E` / `GTP6.E`) as
+needing VPP or eBPF — mainline Linux `seg6local` has no `End.M.GTP*`
+actions. See the kernel-support note in
+[`bgp-prefix-sid-rfc9252.md`](bgp-prefix-sid-rfc9252.md) and
+[`srv6-l3vpn` forwarding notes](../../zebra-rs-srv6-l3vpn-forwarding-bugs.md).
+
+**Where:** the FIB install path + `seg6local` programming.
+
+**Size:** large.
+
+## Quick-pick recommendations
+
+By value-per-line, if picking one up independently of P5/P6:
+
+1. **#7 (`show bgp mobile-uplane` JSON)** — cheap, mechanical, zero risk.
+2. **#11 (eBGP v6 next-hop-self)** — small RFC-correctness fix.
+3. **#4 (RFC 7606 attr-level treat-as-withdraw for MUP)** — closes a
+   small correctness/robustness gap on malformed UPDATEs.
+4. **#1 + #9 (per-AFI MUP inbound + outbound policy)** — do together;
+   first thing a real deployment with filtering will need.
+
+Larger items (#3 VRF import, #8 update-groups, #10 AddPath TX, #13
+strict route-key) should each gate on a concrete consumer — most of them
+naturally sequence after **P5**, which is the next real milestone (and
+needs the operator design input above before it can start).
+
+## Cross-references
+
+- [`bgp-multiprotocol-receive-followups.md`](bgp-multiprotocol-receive-followups.md)
+  — the parse-layer enabler that first surfaced MUP on receive; its
+  RFC 7606 and `route_sync_*` notes apply here too.
+- [`bgp-prefix-sid-rfc9252.md`](bgp-prefix-sid-rfc9252.md) — SRv6 SID /
+  Prefix-SID codec and the kernel `seg6local` support boundary relevant
+  to P6.
+- [`bgp-flowspec-plan.md`](bgp-flowspec-plan.md) — the exact-match,
+  control-plane-first, per-route-`send_packet` AFI the MUP advertise path
+  mirrors.
+- EVPN was the structural template throughout (exact-match Loc-RIB,
+  receive dispatch, advertise, establish-sync) — see the EVPN plan docs.

--- a/zebra-rs/src/bgp/adj_rib.rs
+++ b/zebra-rs/src/bgp/adj_rib.rs
@@ -312,6 +312,8 @@ pub struct AdjRib<D: RibDirection> {
     pub v6vpn: BTreeMap<RouteDistinguisher, AdjRibTable<D, Ipv6Net>>,
     // EVPN, per Route Distinguisher
     pub evpn: BTreeMap<RouteDistinguisher, AdjRibEvpnTable<D>>,
+    // MUP (SAFI 85), flat by MupPrefix
+    pub mup: AdjRibMupTable<D>,
     // IPv4 Flow Specification (AFI 1, SAFI 133)
     pub flowspec_v4: AdjRibFlowspecTable<D>,
     // IPv6 Flow Specification (AFI 2, SAFI 133)
@@ -330,6 +332,7 @@ impl<D: RibDirection> AdjRib<D> {
             v4vpn: BTreeMap::new(),
             v6vpn: BTreeMap::new(),
             evpn: BTreeMap::new(),
+            mup: AdjRibMupTable::new(),
             flowspec_v4: AdjRibFlowspecTable::new(),
             flowspec_v6: AdjRibFlowspecTable::new(),
             bgp_ls: AdjRibBgpLsTable::new(),
@@ -587,6 +590,8 @@ impl AdjRib<Out> {
             (Afi::Ip, Safi::MplsVpn) => self.v4vpn.values().map(|table| table.0.len()).sum(),
             (Afi::Ip6, Safi::MplsVpn) => self.v6vpn.values().map(|table| table.0.len()).sum(),
             (Afi::L2vpn, Safi::Evpn) => self.evpn.values().map(|table| table.0.len()).sum(),
+            // Flat MUP table; counted under IPv4-MUP to avoid double-count.
+            (Afi::Ip, Safi::Mup) => self.mup.0.len(),
             (Afi::Ip, Safi::Flowspec) => self.flowspec_v4.0.len(),
             (Afi::Ip6, Safi::Flowspec) => self.flowspec_v6.0.len(),
             (Afi::LinkState, Safi::LinkState) => self.bgp_ls.0.len(),
@@ -618,6 +623,14 @@ impl AdjRib<Out> {
         id: u32,
     ) -> Option<BgpRib> {
         self.evpn.entry(rd).or_default().remove(prefix, id)
+    }
+
+    pub fn add_mup(&mut self, prefix: MupPrefix, route: BgpRib) -> Option<BgpRib> {
+        self.mup.add(prefix, route)
+    }
+
+    pub fn remove_mup(&mut self, prefix: &MupPrefix, id: u32) -> Option<BgpRib> {
+        self.mup.remove(prefix, id)
     }
 
     pub fn add_flowspec(&mut self, afi: Afi, nlri: FlowspecNlri, route: BgpRib) -> Option<BgpRib> {

--- a/zebra-rs/src/bgp/adj_rib.rs
+++ b/zebra-rs/src/bgp/adj_rib.rs
@@ -136,6 +136,57 @@ impl<D: RibDirection> Default for AdjRibEvpnTable<D> {
     }
 }
 
+/// Flat Adj-RIB table for MUP (SAFI 85) routes, keyed on `MupPrefix`
+/// (exact match; the RD is part of the key). Mirrors `AdjRibEvpnTable<D>`;
+/// the `D` marker selects the path-id field for AddPath disambiguation.
+#[derive(Debug)]
+pub struct AdjRibMupTable<D: RibDirection>(pub BTreeMap<MupPrefix, Vec<BgpRib>>, PhantomData<D>);
+
+impl<D: RibDirection> AdjRibMupTable<D> {
+    pub fn new() -> Self {
+        Self(BTreeMap::new(), PhantomData)
+    }
+
+    pub fn add(&mut self, prefix: MupPrefix, route: BgpRib) -> Option<BgpRib> {
+        let candidates = self.0.entry(prefix).or_default();
+
+        let route_id = D::get_id(&route);
+        if let Some(pos) = candidates.iter().position(|r| D::get_id(r) == route_id) {
+            let old_route = candidates[pos].clone();
+            candidates[pos] = route;
+            Some(old_route)
+        } else {
+            candidates.push(route);
+            None
+        }
+    }
+
+    pub fn remove(&mut self, prefix: &MupPrefix, id: u32) -> Option<BgpRib> {
+        let candidates = self.0.get_mut(prefix)?;
+
+        if let Some(pos) = candidates.iter().position(|r| D::get_id(r) == id) {
+            let removed_route = candidates.remove(pos);
+
+            if candidates.is_empty() {
+                self.0.remove(prefix);
+            }
+
+            Some(removed_route)
+        } else if id == 0 {
+            self.0.remove(prefix);
+            None
+        } else {
+            None
+        }
+    }
+}
+
+impl<D: RibDirection> Default for AdjRibMupTable<D> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 /// Adj-RIB-In/Out table for Flow Specification routes, keyed on
 /// `FlowspecNlri` (exact match — overlapping flow specs coexist, so no
 /// prefix trie). Mirrors `AdjRibEvpnTable<D>`; the `D` marker selects
@@ -413,6 +464,8 @@ impl ShardAdjIn {
 pub struct MainAdjIn {
     // EVPN, per Route Distinguisher
     pub evpn: BTreeMap<RouteDistinguisher, AdjRibEvpnTable<In>>,
+    // MUP (SAFI 85), flat by MupPrefix
+    pub mup: AdjRibMupTable<In>,
     // IPv4 Flow Specification (AFI 1, SAFI 133)
     pub flowspec_v4: AdjRibFlowspecTable<In>,
     // IPv6 Flow Specification (AFI 2, SAFI 133)
@@ -446,6 +499,16 @@ impl MainAdjIn {
         self.evpn.entry(rd).or_default().remove(prefix, id)
     }
 
+    // MUP add/remove ---------------------------------------------------------
+
+    pub fn add_mup(&mut self, prefix: MupPrefix, route: BgpRib) -> Option<BgpRib> {
+        self.mup.add(prefix, route)
+    }
+
+    pub fn remove_mup(&mut self, prefix: &MupPrefix, id: u32) -> Option<BgpRib> {
+        self.mup.remove(prefix, id)
+    }
+
     // Flow Specification add/remove ------------------------------------------
 
     pub fn add_flowspec(&mut self, afi: Afi, nlri: FlowspecNlri, route: BgpRib) -> Option<BgpRib> {
@@ -477,6 +540,9 @@ impl MainAdjIn {
     pub fn count(&self, afi: Afi, safi: Safi) -> usize {
         match (afi, safi) {
             (Afi::L2vpn, Safi::Evpn) => self.evpn.values().map(|table| table.0.len()).sum(),
+            // Flat MUP table; counted under IPv4-MUP to avoid double-count
+            // in a combined v4+v6 summary.
+            (Afi::Ip, Safi::Mup) => self.mup.0.len(),
             (Afi::Ip, Safi::Flowspec) => self.flowspec_v4.0.len(),
             (Afi::Ip6, Safi::Flowspec) => self.flowspec_v6.0.len(),
             (Afi::LinkState, Safi::LinkState) => self.bgp_ls.0.len(),

--- a/zebra-rs/src/bgp/cap.rs
+++ b/zebra-rs/src/bgp/cap.rs
@@ -42,6 +42,8 @@ impl CapAfiMap {
         let mp4srp = CapMultiProtocol::new(&Afi::Ip, &Safi::SrTePolicy);
         let mp6srp = CapMultiProtocol::new(&Afi::Ip6, &Safi::SrTePolicy);
         let mp_ls = CapMultiProtocol::new(&Afi::LinkState, &Safi::LinkState);
+        let mp4mup = CapMultiProtocol::new(&Afi::Ip, &Safi::Mup);
+        let mp6mup = CapMultiProtocol::new(&Afi::Ip6, &Safi::Mup);
 
         let mut cmap = Self::default();
         cmap.entries.insert(mp4uni, SendRecv::default());
@@ -58,6 +60,8 @@ impl CapAfiMap {
         cmap.entries.insert(mp4srp, SendRecv::default());
         cmap.entries.insert(mp6srp, SendRecv::default());
         cmap.entries.insert(mp_ls, SendRecv::default());
+        cmap.entries.insert(mp4mup, SendRecv::default());
+        cmap.entries.insert(mp6mup, SendRecv::default());
         cmap
     }
 

--- a/zebra-rs/src/bgp/config.rs
+++ b/zebra-rs/src/bgp/config.rs
@@ -1331,26 +1331,50 @@ fn config_afi_safi(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Option<()> {
         && op.is_set()
         && enabled.unwrap_or(false);
 
-    let peer = bgp.peers.get_mut(&addr)?;
+    let (ident, bounce) = {
+        let peer = bgp.peers.get_mut(&addr)?;
 
-    // Record the verbatim statement, then re-resolve the effective MP
-    // set through the default < group < explicit precedence. A Delete
-    // simply forgets the statement: IPv4 unicast falls back to the
-    // built-in default (or the group's opinion), other families to
-    // off (or the group's opinion). The `mobile-uplane` name expands to
-    // both the IPv4 and IPv6 MUP families (RFC 9833).
-    if op.is_set() {
-        let enabled = enabled?;
-        for fam in super::neighbor_group::mp_family_expand(key) {
-            peer.config.mp_explicit.insert(fam, enabled);
+        // Snapshot the effective MP family set so we can tell whether this
+        // statement actually changes it (a redundant set must not bounce).
+        let before: std::collections::BTreeSet<AfiSafi> =
+            peer.config.mp.0.keys().copied().collect();
+
+        // Record the verbatim statement, then re-resolve the effective MP
+        // set through the default < group < explicit precedence. A Delete
+        // simply forgets the statement: IPv4 unicast falls back to the
+        // built-in default (or the group's opinion), other families to
+        // off (or the group's opinion). The `mobile-uplane` name expands to
+        // both the IPv4 and IPv6 MUP families (RFC 9833).
+        if op.is_set() {
+            let enabled = enabled?;
+            for fam in super::neighbor_group::mp_family_expand(key) {
+                peer.config.mp_explicit.insert(fam, enabled);
+            }
+        } else {
+            for fam in super::neighbor_group::mp_family_expand(key) {
+                peer.config.mp_explicit.remove(&fam);
+            }
         }
-    } else {
-        for fam in super::neighbor_group::mp_family_expand(key) {
-            peer.config.mp_explicit.remove(&fam);
-        }
+        super::neighbor_group::recompute_peer_mp(&bgp.neighbor_groups, &mut peer.config);
+
+        // An AFI/SAFI is a Multiprotocol *capability*, advertised once in
+        // the OPEN — the negotiated set is fixed for the life of the
+        // session. So changing the family set on an already-Established
+        // peer has no effect until the session renegotiates: bounce it with
+        // `Event::Stop` (the `clear bgp ... hard` teardown) to force a
+        // reconnect that carries the new capability set. A peer still coming
+        // up includes the new family in its first OPEN, so startup config —
+        // applied before the session establishes — never bounces.
+        let after: std::collections::BTreeSet<AfiSafi> = peer.config.mp.0.keys().copied().collect();
+        let bounce = before != after && matches!(peer.state, super::peer::State::Established);
+        (peer.ident, bounce)
+    };
+
+    if bounce {
+        let _ = bgp
+            .tx
+            .try_send(super::inst::Message::Event(ident, super::peer::Event::Stop));
     }
-    super::neighbor_group::recompute_peer_mp(&bgp.neighbor_groups, &mut peer.config);
-
     if label_block_needed {
         bgp.request_label_block();
     }
@@ -5694,9 +5718,10 @@ mod neighbor_group_wiring_tests {
     }
 
     /// Group `afi-safi ipv6 enabled true` flows to a member peer's
-    /// effective MP set reactively (no session bounce — the change is
-    /// advertised at the next capability negotiation), and `enabled
-    /// false` on ipv4 overrides the built-in default.
+    /// effective MP set, and `enabled false` on ipv4 overrides the built-in
+    /// default. The member here is not Established, so it does not bounce —
+    /// its first OPEN carries the change (the Established case bounces; see
+    /// `group_afi_safi_change_bounces_established_member`).
     #[tokio::test]
     async fn group_afi_safi_propagates_to_member() {
         let mut bgp = fresh_bgp();
@@ -5723,7 +5748,61 @@ mod neighbor_group_wiring_tests {
         assert_eq!(peer_mp_families(&bgp), vec![v6()]);
         assert!(
             drain_stop_events(&mut bgp).is_empty(),
-            "afi-safi changes must not bounce the session",
+            "a not-yet-Established member must not bounce",
+        );
+    }
+
+    /// Changing a group's afi-safi opinion is a capability change, so an
+    /// Established member renegotiates: its MP set changes and it is sent
+    /// `Event::Stop` (the `clear bgp ... hard` teardown). Mirrors the
+    /// per-peer `config_afi_safi` bounce, on the group path.
+    #[tokio::test]
+    async fn group_afi_safi_change_bounces_established_member() {
+        let mut bgp = fresh_bgp();
+        config_neighbor_group_remote_as(&mut bgp, arg_words(&["G", "65000"]), ConfigOp::Set)
+            .unwrap();
+        config_peer(&mut bgp, arg_words(&["10.0.0.1"]), ConfigOp::Set).unwrap();
+        config_peer_neighbor_group(&mut bgp, arg_words(&["10.0.0.1", "G"]), ConfigOp::Set).unwrap();
+        let peer_ident = bgp.peers.get(&peer_addr()).unwrap().ident;
+        // Bring the member up, then drain the setup events.
+        bgp.peers.get_mut(&peer_addr()).unwrap().state = crate::bgp::peer::State::Established;
+        let _ = drain_stop_events(&mut bgp);
+
+        // Enabling a new family on the group bounces the Established member.
+        config_neighbor_group_afi_safi_enabled(
+            &mut bgp,
+            arg_words(&["G", "mobile-uplane", "true"]),
+            ConfigOp::Set,
+        )
+        .unwrap();
+        assert_eq!(peer_mp_families(&bgp).len(), 3, "v4 + IPv4/IPv6 MUP");
+        assert!(
+            drain_stop_events(&mut bgp).contains(&peer_ident),
+            "enabling a group afi-safi must bounce an Established member",
+        );
+
+        // A redundant set (no family-set change) must not bounce.
+        config_neighbor_group_afi_safi_enabled(
+            &mut bgp,
+            arg_words(&["G", "mobile-uplane", "true"]),
+            ConfigOp::Set,
+        )
+        .unwrap();
+        assert!(
+            drain_stop_events(&mut bgp).is_empty(),
+            "a redundant group afi-safi set must not bounce",
+        );
+
+        // Disabling the family again also bounces (capability withdrawn).
+        config_neighbor_group_afi_safi_enabled(
+            &mut bgp,
+            arg_words(&["G", "mobile-uplane", "true"]),
+            ConfigOp::Delete,
+        )
+        .unwrap();
+        assert!(
+            drain_stop_events(&mut bgp).contains(&peer_ident),
+            "disabling a group afi-safi must bounce an Established member",
         );
     }
 
@@ -5762,6 +5841,75 @@ mod neighbor_group_wiring_tests {
         )
         .unwrap();
         assert_eq!(peer_mp_families(&bgp), Vec::<AfiSafi>::new());
+    }
+
+    /// An AFI/SAFI is a Multiprotocol *capability*: enabling or disabling
+    /// one on an Established neighbor changes the negotiated set, which is
+    /// fixed at OPEN time, so the session must bounce (`Event::Stop`, the
+    /// `clear bgp ... hard` teardown) to renegotiate. This is NOT
+    /// MUP-specific — pinned across IPv6 unicast, EVPN, VPNv4 and
+    /// mobile-uplane. A peer that has not Established yet carries the change
+    /// in its first OPEN (no bounce); a redundant set leaves the family set
+    /// unchanged (no bounce).
+    #[tokio::test]
+    async fn afi_safi_change_bounces_established_peer() {
+        for fam in ["ipv6", "evpn", "vpnv4", "mobile-uplane"] {
+            let mut bgp = fresh_bgp();
+            config_peer(&mut bgp, arg_words(&["10.0.0.1"]), ConfigOp::Set).unwrap();
+            let peer_ident = bgp.peers.get(&peer_addr()).unwrap().ident;
+
+            // Not Established yet → the upcoming OPEN carries it → no bounce.
+            config_afi_safi(
+                &mut bgp,
+                arg_words(&["10.0.0.1", fam, "true"]),
+                ConfigOp::Set,
+            )
+            .unwrap();
+            assert!(
+                drain_stop_events(&mut bgp).is_empty(),
+                "{fam}: a not-yet-Established peer must not bounce",
+            );
+
+            // Bring the session up.
+            bgp.peers.get_mut(&peer_addr()).unwrap().state = crate::bgp::peer::State::Established;
+            let _ = drain_stop_events(&mut bgp);
+
+            // Redundant set (already enabled) → family set unchanged → no bounce.
+            config_afi_safi(
+                &mut bgp,
+                arg_words(&["10.0.0.1", fam, "true"]),
+                ConfigOp::Set,
+            )
+            .unwrap();
+            assert!(
+                drain_stop_events(&mut bgp).is_empty(),
+                "{fam}: a redundant set must not bounce",
+            );
+
+            // Disabling on the live session withdraws the capability → bounce.
+            config_afi_safi(
+                &mut bgp,
+                arg_words(&["10.0.0.1", fam, "true"]),
+                ConfigOp::Delete,
+            )
+            .unwrap();
+            assert!(
+                drain_stop_events(&mut bgp).contains(&peer_ident),
+                "{fam}: disabling on an Established peer must bounce",
+            );
+
+            // Re-enabling changes the set back → bounce again.
+            config_afi_safi(
+                &mut bgp,
+                arg_words(&["10.0.0.1", fam, "true"]),
+                ConfigOp::Set,
+            )
+            .unwrap();
+            assert!(
+                drain_stop_events(&mut bgp).contains(&peer_ident),
+                "{fam}: re-enabling on an Established peer must bounce",
+            );
+        }
     }
 
     /// Deleting one group afi-safi entry (or the whole group) drops

--- a/zebra-rs/src/bgp/config.rs
+++ b/zebra-rs/src/bgp/config.rs
@@ -3736,6 +3736,18 @@ impl Bgp {
             "/router/bgp/vrf/evpn/advertise-ipv6",
             super::vrf_config::config_vrf_evpn_advertise_ipv6,
         );
+        self.callback_add(
+            "/router/bgp/vrf/mobile-uplane/route-target/export",
+            super::vrf_config::config_vrf_mup_rt_export,
+        );
+        self.callback_add(
+            "/router/bgp/vrf/mobile-uplane/srv6-mobile/decapsulation/network-instance/exact",
+            super::vrf_config::config_vrf_mup_srv6_decap,
+        );
+        self.callback_add(
+            "/router/bgp/vrf/mobile-uplane/srv6-mobile/encapsulation/network-instance/exact",
+            super::vrf_config::config_vrf_mup_srv6_encap,
+        );
 
         // `set router bgp interface-neighbor <name> [...]`.
         self.callback_add(

--- a/zebra-rs/src/bgp/config.rs
+++ b/zebra-rs/src/bgp/config.rs
@@ -1337,11 +1337,17 @@ fn config_afi_safi(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Option<()> {
     // set through the default < group < explicit precedence. A Delete
     // simply forgets the statement: IPv4 unicast falls back to the
     // built-in default (or the group's opinion), other families to
-    // off (or the group's opinion).
+    // off (or the group's opinion). The `mobile-uplane` name expands to
+    // both the IPv4 and IPv6 MUP families (RFC 9833).
     if op.is_set() {
-        peer.config.mp_explicit.insert(key, enabled?);
+        let enabled = enabled?;
+        for fam in super::neighbor_group::mp_family_expand(key) {
+            peer.config.mp_explicit.insert(fam, enabled);
+        }
     } else {
-        peer.config.mp_explicit.remove(&key);
+        for fam in super::neighbor_group::mp_family_expand(key) {
+            peer.config.mp_explicit.remove(&fam);
+        }
     }
     super::neighbor_group::recompute_peer_mp(&bgp.neighbor_groups, &mut peer.config);
 

--- a/zebra-rs/src/bgp/neighbor_group.rs
+++ b/zebra-rs/src/bgp/neighbor_group.rs
@@ -16,9 +16,11 @@
 //!   (the FSM must renegotiate with the new ASN) — see
 //!   [`config_neighbor_group_remote_as`].
 //! - `afi-safi` changes recompute the peers' effective MP set
-//!   ([`effective_mp`]) without touching the FSM: like the per-neighbor
-//!   `afi-safi <name> enabled` knob, the new set is advertised when
-//!   capabilities are next negotiated (`clear bgp …`).
+//!   ([`effective_mp`]) and bounce any Established member — an AFI/SAFI is
+//!   a Multiprotocol capability fixed at OPEN time, so the FSM must
+//!   renegotiate (the same `Event::Stop` `clear bgp … hard` uses). Like
+//!   the per-neighbor `afi-safi <name> enabled` knob; a member still
+//!   coming up carries the change in its first OPEN.
 //!
 //! Naming-wise this sits alongside the existing
 //! `peer-groups/peer-group` schema, not on top of it: a peer can
@@ -931,9 +933,18 @@ pub fn recompute_peer_mp(groups: &BTreeMap<String, NeighborGroup>, config: &mut 
 /// lookup misses and members fall back to default + explicit).
 fn sweep_group_afi_safi(bgp: &mut Bgp, name: &str) {
     sweep_members(bgp, name, |groups, peer| {
+        // An AFI/SAFI is a Multiprotocol capability fixed at OPEN time, so a
+        // change to a member's effective family set only takes effect on a
+        // session that renegotiates. Bounce an Established member whose set
+        // actually changed (mirrors the per-peer `config_afi_safi`); a member
+        // still coming up carries the new family in its first OPEN, and an
+        // unchanged set never bounces.
+        let before: std::collections::BTreeSet<AfiSafi> =
+            peer.config.mp.0.keys().copied().collect();
         recompute_peer_mp(groups, &mut peer.config);
         recompute_peer_nhs(groups, peer);
-        false
+        let after: std::collections::BTreeSet<AfiSafi> = peer.config.mp.0.keys().copied().collect();
+        before != after && matches!(peer.state, State::Established)
     });
 }
 

--- a/zebra-rs/src/bgp/neighbor_group.rs
+++ b/zebra-rs/src/bgp/neighbor_group.rs
@@ -221,14 +221,19 @@ pub fn config_neighbor_group_afi_safi_enabled(
     match op {
         ConfigOp::Set => {
             let enabled = args.boolean()?;
-            group.afi_safi.entry(family).or_default().enabled = enabled;
+            // `mobile-uplane` toggles both MUP families at once (RFC 9833).
+            for fam in mp_family_expand(family) {
+                group.afi_safi.entry(fam).or_default().enabled = enabled;
+            }
         }
         ConfigOp::Delete => {
             // `enabled` is the entry's mandatory core: dropping it
             // drops the family opinion. A surviving `next-hop-self`
             // opinion would be unreachable config (the schema requires
             // `enabled` on the entry), so remove the whole entry.
-            group.afi_safi.remove(&family);
+            for fam in mp_family_expand(family) {
+                group.afi_safi.remove(&fam);
+            }
         }
         _ => return Some(()),
     }
@@ -855,6 +860,23 @@ pub(super) fn sweep_members(
     }
 }
 
+/// MUP (RFC 9833) is exposed through a single `mobile-uplane` config
+/// name that enables *both* the IPv4 (AFI 1) and IPv6 (AFI 2) MUP
+/// families at once. Every other family is one config name → one
+/// `(AFI, SAFI)`. Expand a parsed family into the concrete set of
+/// `(AFI, SAFI)` tuples it toggles, so the `enabled` handlers, the MP
+/// capability set, and the resolver all see ordinary per-family entries.
+pub fn mp_family_expand(key: AfiSafi) -> Vec<AfiSafi> {
+    if key.safi == Safi::Mup {
+        vec![
+            AfiSafi::new(Afi::Ip, Safi::Mup),
+            AfiSafi::new(Afi::Ip6, Safi::Mup),
+        ]
+    } else {
+        vec![key]
+    }
+}
+
 /// Compute a peer's effective MP (multiprotocol) family set from the
 /// three layers, lowest precedence first:
 ///
@@ -1383,6 +1405,21 @@ mod tests {
         // Peer was never inherited and never got an explicit asn —
         // Delete on the group is a no-op from the sweep's perspective.
         assert_eq!(sweep_action(0, false, false, None), SweepAction::Ignore);
+    }
+
+    #[test]
+    fn mp_family_expand_fans_out_mup_to_both_afis() {
+        // `mobile-uplane` enables both IPv4-MUP and IPv6-MUP (RFC 9833).
+        assert_eq!(
+            mp_family_expand(AfiSafi::new(Afi::Ip, Safi::Mup)),
+            vec![
+                AfiSafi::new(Afi::Ip, Safi::Mup),
+                AfiSafi::new(Afi::Ip6, Safi::Mup),
+            ]
+        );
+        // Every other family passes through unchanged.
+        let v4 = AfiSafi::new(Afi::Ip, Safi::Unicast);
+        assert_eq!(mp_family_expand(v4), vec![v4]);
     }
 
     // [`effective_mp`] precedence matrix: built-in default (IPv4

--- a/zebra-rs/src/bgp/route.rs
+++ b/zebra-rs/src/bgp/route.rs
@@ -1685,6 +1685,111 @@ impl LocalRibEvpnTable {
     }
 }
 
+/// Flat Loc-RIB table for MUP (SAFI 85) routes — exact-match keyed by
+/// `MupPrefix`. The RD is part of the key, so one flat map holds every RD
+/// and `show bgp mobile-uplane` walks it grouped by route type. Mirrors
+/// `LocalRibEvpnTable`; best-path reuses the NLRI-agnostic `BgpRib`
+/// comparator.
+#[derive(Debug, Default)]
+pub struct LocalRibMupTable {
+    /// Candidate paths per prefix.
+    pub cands: BTreeMap<MupPrefix, Vec<BgpRib>>,
+    /// Selected best path per prefix.
+    pub selected: BTreeMap<MupPrefix, BgpRib>,
+}
+
+impl LocalRibMupTable {
+    pub fn update(&mut self, prefix: MupPrefix, rib: BgpRib) -> (Vec<BgpRib>, Vec<BgpRib>, u32) {
+        let cands = self.cands.entry(prefix.clone()).or_default();
+
+        let existing_local_id = cands
+            .iter()
+            .find(|r| r.ident == rib.ident && r.remote_id == rib.remote_id)
+            .map(|r| r.local_id);
+
+        let replaced: Vec<BgpRib> = cands
+            .extract_if(.., |r| r.ident == rib.ident && r.remote_id == rib.remote_id)
+            .collect();
+
+        let mut next_id = 1u32;
+        let mut new_rib = rib.clone();
+        if let Some(local_id) = existing_local_id {
+            new_rib.local_id = local_id;
+        } else {
+            let used_ids: std::collections::HashSet<u32> =
+                cands.iter().map(|r| r.local_id).collect();
+            while used_ids.contains(&next_id) {
+                next_id += 1;
+            }
+            new_rib.local_id = next_id;
+        }
+
+        next_id = new_rib.local_id;
+
+        cands.push(new_rib);
+
+        let selected = self.select_best_path(&prefix);
+
+        (replaced, selected, next_id)
+    }
+
+    pub fn remove(&mut self, prefix: &MupPrefix, id: u32, ident: usize) -> Vec<BgpRib> {
+        let cands = self.cands.entry(prefix.clone()).or_default();
+        cands
+            .extract_if(.., |r| r.ident == ident && r.remote_id == id)
+            .collect()
+    }
+
+    pub fn select_best_path(&mut self, prefix: &MupPrefix) -> Vec<BgpRib> {
+        let mut selected = Vec::new();
+
+        if !self.cands.contains_key(prefix) {
+            self.selected.remove(prefix);
+            return selected;
+        }
+
+        let is_empty = self
+            .cands
+            .get(prefix)
+            .map(|cands| cands.is_empty())
+            .unwrap_or(true);
+
+        if is_empty {
+            self.cands.remove(prefix);
+            self.selected.remove(prefix);
+            return selected;
+        }
+
+        let best = {
+            let cands = self.cands.get_mut(prefix).expect("prefix checked above");
+
+            let mut best_index = 0usize;
+            let mut best_reason = Reason::Default;
+            for index in 1..cands.len() {
+                let (better, reason) =
+                    LocalRibTable::<Ipv4Net>::is_better(&cands[index], &cands[best_index]);
+                if better {
+                    best_index = index;
+                }
+                best_reason = reason;
+            }
+
+            for rib in cands.iter_mut() {
+                rib.best_path = false;
+                rib.best_reason = Reason::NotSelected;
+            }
+            cands[best_index].best_path = true;
+            cands[best_index].best_reason = best_reason;
+            cands[best_index].clone()
+        };
+
+        self.selected.insert(prefix.clone(), best.clone());
+        selected.push(best);
+
+        selected
+    }
+}
+
 /// Loc-RIB table for Flow Specification routes — candidate paths and the
 /// selected best path per `FlowspecNlri`, exact-match (overlapping flow
 /// specs coexist, so no prefix trie). Mirrors `LocalRibEvpnTable`;
@@ -2399,6 +2504,9 @@ pub struct LocalRib {
     /// Per-RD EVPN Loc-RIB tables.
     pub evpn: BTreeMap<RouteDistinguisher, LocalRibEvpnTable>,
 
+    /// Flat MUP (SAFI 85, RFC 9833) Loc-RIB table.
+    pub mup: LocalRibMupTable,
+
     /// IPv4 / IPv6 Flow Specification Loc-RIB (SAFI 133).
     pub flowspec_v4: LocalRibFlowspecTable,
     pub flowspec_v6: LocalRibFlowspecTable,
@@ -2460,6 +2568,24 @@ impl LocalRib {
         prefix: &EvpnPrefix,
     ) -> Vec<BgpRib> {
         self.evpn.entry(*rd).or_default().select_best_path(prefix)
+    }
+
+    // MUP dispatch -----------------------------------------------------------
+
+    pub fn update_mup(
+        &mut self,
+        prefix: MupPrefix,
+        rib: BgpRib,
+    ) -> (Vec<BgpRib>, Vec<BgpRib>, u32) {
+        self.mup.update(prefix, rib)
+    }
+
+    pub fn remove_mup(&mut self, prefix: &MupPrefix, id: u32, ident: usize) -> Vec<BgpRib> {
+        self.mup.remove(prefix, id, ident)
+    }
+
+    pub fn select_best_path_mup(&mut self, prefix: &MupPrefix) -> Vec<BgpRib> {
+        self.mup.select_best_path(prefix)
     }
 
     // Flow Specification dispatch --------------------------------------------
@@ -7039,6 +7165,92 @@ pub fn route_evpn_withdraw(ident: usize, route: &EvpnRoute, bgp: &mut BgpTop, pe
     }
 }
 
+/// Store one received MUP NLRI (RFC 9833, SAFI 85) in the peer's
+/// Adj-RIB-In and the MUP Loc-RIB, then re-run best-path.
+///
+/// Phase 2 is receive + show only: there is no inbound route-policy, no
+/// VRF import, no re-advertise, and no FIB install yet (those land in
+/// P3/P4/P6). The caller stamps the MP_REACH next-hop into `attr` so
+/// `show bgp mobile-uplane` can render it. Loop detection mirrors
+/// `route_evpn_update` — a route carrying our own AS / ORIGINATOR_ID /
+/// CLUSTER_LIST is dropped silently.
+pub fn route_mup_update(
+    ident: usize,
+    route: &MupRoute,
+    attr: &BgpAttr,
+    bgp: &mut BgpTop,
+    peers: &mut PeerMap,
+    stale: bool,
+) {
+    let prefix = MupPrefix::from_route(route);
+    let id = route.add_path_id();
+
+    let (peer_ident, peer_router_id, typ) = {
+        let peer = peers.get_mut_by_idx(ident).expect("peer must exist");
+
+        if let Some(ref aspath) = attr.aspath
+            && aspath_own_as_loop(peer, aspath)
+        {
+            return;
+        }
+        if aspath_enforce_first_as_violation(peer, attr.aspath.as_ref()) {
+            return;
+        }
+        if let Some(ref originator_id) = attr.originator_id
+            && originator_id.id == *bgp.router_id
+        {
+            return;
+        }
+        if let Some(ref cluster_list) = attr.cluster_list
+            && cluster_list.list.contains(bgp.router_id)
+        {
+            return;
+        }
+
+        let typ = if peer.is_ibgp() {
+            BgpRibType::IBGP
+        } else {
+            BgpRibType::EBGP
+        };
+        (peer.ident, peer.remote_id, typ)
+    };
+
+    let stale = stale || attr_has_llgr_stale(attr);
+    let mut rib = BgpRib::new(
+        peer_ident,
+        peer_router_id,
+        typ,
+        id,
+        0,    // weight
+        attr, // next-hop is carried inside attr for show
+        None, // label
+        None, // nexthop (VpnNexthop) — not used by MUP at this layer
+        stale,
+    );
+
+    {
+        let peer = peers.get_mut_by_idx(ident).expect("peer must exist");
+        peer.adj_in.add_mup(prefix.clone(), rib.clone());
+    }
+
+    rib.attr = bgp.attr_store.intern(attr.clone());
+    let _ = bgp.local_rib.update_mup(prefix.clone(), rib);
+    let _ = bgp.local_rib.select_best_path_mup(&prefix);
+}
+
+/// Withdraw one MUP route advertised in an MP_UNREACH_NLRI from
+/// Adj-RIB-In and the Loc-RIB, then re-run best-path.
+pub fn route_mup_withdraw(ident: usize, route: &MupRoute, bgp: &mut BgpTop, peers: &mut PeerMap) {
+    let prefix = MupPrefix::from_route(route);
+    let id = route.add_path_id();
+    {
+        let peer = peers.get_mut_by_idx(ident).expect("peer must exist");
+        peer.adj_in.remove_mup(&prefix, id);
+    }
+    let _ = bgp.local_rib.remove_mup(&prefix, id, ident);
+    let _ = bgp.local_rib.select_best_path_mup(&prefix);
+}
+
 /// Store one received Flow Specification NLRI in the peer's Adj-RIB-In.
 ///
 /// Phase 1 (receive/reflect) is control-plane only: the flow spec is
@@ -8064,6 +8276,24 @@ pub fn route_from_peer(
                         route_evpn_update(peer_id, route, nhop, bgp_attr, bgp, peers, false);
                     }
                 }
+                MpReachAttr::Mup {
+                    afi: _,
+                    snpa: _,
+                    nhop,
+                    updates,
+                } => {
+                    // MUP carries its next-hop in MP_REACH (no usable
+                    // NEXT_HOP attr). Stamp it into the path attr so the
+                    // Loc-RIB and `show bgp mobile-uplane` render it.
+                    let mut attr_mup = bgp_attr.clone();
+                    attr_mup.nexthop = Some(match nhop {
+                        IpAddr::V4(a) => BgpNexthop::Ipv4(a),
+                        IpAddr::V6(a) => BgpNexthop::Ipv6(a),
+                    });
+                    for route in updates.iter() {
+                        route_mup_update(peer_id, route, &attr_mup, bgp, peers, false);
+                    }
+                }
                 MpReachAttr::Ipv4 {
                     snpa: _,
                     nhop,
@@ -8189,9 +8419,6 @@ pub fn route_from_peer(
                         route_labelv6_update(peer_id, update, nhop, bgp_attr, bgp, peers, false);
                     }
                 }
-                _ => {
-                    //
-                }
             }
         }
     }
@@ -8238,6 +8465,13 @@ pub fn route_from_peer(
                 let _ = bgp
                     .tx
                     .send(Message::Event(peer_id, Event::StaleTimerExipires(afi_safi)));
+            }
+            MpUnreachAttr::Mup { afi: _, withdraws } => {
+                // An empty `withdraws` list is the MUP End-of-RIB marker
+                // (no separate Eor variant); the loop is then a no-op.
+                for route in withdraws.iter() {
+                    route_mup_withdraw(peer_id, route, bgp, peers);
+                }
             }
             MpUnreachAttr::Ipv6Nlri(withdrawals) => {
                 for withdraw in withdrawals.iter() {
@@ -8842,6 +9076,27 @@ pub fn route_clean(
         let peer = peers.get_mut_by_idx(peer_id).expect("peer must exist");
         peer.adj_in.evpn.clear();
     }
+
+    // MUP (RFC 9833). Phase 2 is receive-only with no LLGR retention, so
+    // peer-down simply drops every MUP route the peer gave us from the
+    // Loc-RIB and clears its Adj-RIB-In. (LLGR stale retention for MUP is
+    // a later phase, mirroring the EVPN/VPN two-branch logic above.)
+    let mup_keys: Vec<(MupPrefix, u32)> = {
+        let peer = peers.get_mut_by_idx(peer_id).expect("peer must exist");
+        let mut out = Vec::new();
+        for (prefix, ribs) in peer.adj_in.mup.0.iter() {
+            for rib in ribs.iter() {
+                out.push((prefix.clone(), rib.remote_id));
+            }
+        }
+        out
+    };
+    for (prefix, id) in mup_keys.iter() {
+        let _ = bgp.local_rib.remove_mup(prefix, *id, peer_id);
+        let _ = bgp.local_rib.select_best_path_mup(prefix);
+    }
+    let peer = peers.get_mut_by_idx(peer_id).expect("peer must exist");
+    peer.adj_in.mup.0.clear();
 
     let peer = peers.get_mut_by_idx(peer_id).expect("peer must exist");
     peer.adj_out.evpn.clear();

--- a/zebra-rs/src/bgp/route.rs
+++ b/zebra-rs/src/bgp/route.rs
@@ -7235,7 +7235,10 @@ pub fn route_mup_update(
 
     rib.attr = bgp.attr_store.intern(attr.clone());
     let _ = bgp.local_rib.update_mup(prefix.clone(), rib);
-    let _ = bgp.local_rib.select_best_path_mup(&prefix);
+    let selected = bgp.local_rib.select_best_path_mup(&prefix);
+    if !selected.is_empty() {
+        route_advertise_mup_to_peers(prefix, &selected, bgp, peers);
+    }
 }
 
 /// Withdraw one MUP route advertised in an MP_UNREACH_NLRI from
@@ -7248,7 +7251,201 @@ pub fn route_mup_withdraw(ident: usize, route: &MupRoute, bgp: &mut BgpTop, peer
         peer.adj_in.remove_mup(&prefix, id);
     }
     let _ = bgp.local_rib.remove_mup(&prefix, id, ident);
-    let _ = bgp.local_rib.select_best_path_mup(&prefix);
+    let selected = bgp.local_rib.select_best_path_mup(&prefix);
+    if selected.is_empty() {
+        route_withdraw_mup_to_peers(prefix, peers);
+    } else {
+        // Another path remains best for this key — re-advertise it.
+        route_advertise_mup_to_peers(prefix, &selected, bgp, peers);
+    }
+}
+
+/// Extract the forwarding `IpAddr` from a stored BGP next-hop. MUP
+/// next-hops are stamped as `Ipv4`/`Ipv6` (the MP_REACH address);
+/// `Evpn` is accepted defensively, the VPN forms never occur here.
+fn bgp_nexthop_ip(nh: &BgpNexthop) -> Option<IpAddr> {
+    match nh {
+        BgpNexthop::Ipv4(a) => Some(IpAddr::V4(*a)),
+        BgpNexthop::Ipv6(a) => Some(IpAddr::V6(*a)),
+        BgpNexthop::Evpn(a) => Some(*a),
+        _ => None,
+    }
+}
+
+/// Build the (route, egress attrs, MP_REACH next-hop) to advertise one
+/// selected MUP path to `peer`, or `None` to suppress it. Mirrors
+/// `route_update_evpn`: split-horizon (never back to the source peer),
+/// iBGP-to-iBGP suppression unless the peer is a route-reflector client,
+/// RFC 1997 NO_ADVERTISE/NO_EXPORT, eBGP AS_PATH prepend + next-hop-self,
+/// iBGP default LOCAL_PREF, and stripping iBGP-only attrs on eBGP. The
+/// next-hop rides in MP_REACH (RFC 9833), so the path-attr NEXT_HOP is
+/// cleared.
+fn route_update_mup(
+    peer: &mut Peer,
+    prefix: &MupPrefix,
+    rib: &BgpRib,
+    bgp: &BgpTop,
+) -> Option<(MupRoute, BgpAttr, IpAddr)> {
+    if rib.ident == peer.ident {
+        return None;
+    }
+    if peer.peer_type == PeerType::IBGP
+        && rib.typ == BgpRibType::IBGP
+        && !peer.is_reflector_client()
+    {
+        return None;
+    }
+    if community_suppresses_advertisement(&rib.attr, peer.peer_type) {
+        return None;
+    }
+
+    let route = prefix.to_route();
+    let mut attrs = (*rib.attr).clone();
+    ebgp_egress_aspath(&peer.egress_as(), &mut attrs);
+
+    // MP_REACH next-hop: next-hop-self toward eBGP and for our own
+    // originations; otherwise preserve the received next-hop (RFC 9833 —
+    // the PE/controller address the ingress PE resolves).
+    let nhop: IpAddr = if peer.is_ebgp() || rib.is_originated() {
+        if let Some(ref local_addr) = peer.param.local_addr {
+            local_addr.ip()
+        } else {
+            IpAddr::V4(*bgp.router_id)
+        }
+    } else {
+        bgp_nexthop_ip(attrs.nexthop.as_ref()?)?
+    };
+
+    if peer.is_ibgp() && attrs.local_pref.is_none() {
+        attrs.local_pref = Some(LocalPref::default());
+    }
+    if peer.is_ebgp() {
+        strip_ibgp_only_attrs(&mut attrs);
+    }
+    // The next-hop rides in MP_REACH, not the legacy NEXT_HOP path attr.
+    attrs.nexthop = None;
+
+    Some((route, attrs, nhop))
+}
+
+/// Emit one MUP route to a peer as a single-NLRI MP_REACH UPDATE.
+fn mup_send_one(peer: &mut Peer, afi: Afi, route: MupRoute, attr: &Arc<BgpAttr>, nhop: IpAddr) {
+    let mut update = UpdatePacket::with_max_packet_size(peer.max_packet_size());
+    update.mp_update = Some(MpReachAttr::Mup {
+        afi,
+        snpa: 0,
+        nhop,
+        updates: vec![route],
+    });
+    update.bgp_attr = Some(attr.as_ref().clone());
+    peer.send_packet(update.into());
+}
+
+/// Advertise one selected MUP path to a single peer: apply egress
+/// transforms, record the Adj-RIB-Out entry, and emit the UPDATE.
+fn mup_advertise_one(peer: &mut Peer, prefix: &MupPrefix, rib: &BgpRib, bgp: &mut BgpTop) -> bool {
+    // RFC 9494 §4.3: stale routes only go to LLGR peers.
+    if llgr_blocks_advertisement(rib.stale, &peer.cap_recv, prefix.afi(), Safi::Mup) {
+        return false;
+    }
+    let Some((route, attrs, nhop)) = route_update_mup(peer, prefix, rib, bgp) else {
+        return false;
+    };
+    // No per-AFI MUP outbound route-policy binding exists yet, so the
+    // egress passes through unfiltered (parity with EVPN when no Output
+    // policy is configured).
+    let attr = bgp.attr_store.intern(attrs);
+    let mut adj = rib.clone();
+    adj.attr = attr.clone();
+    peer.adj_out.add_mup(prefix.clone(), adj);
+    mup_send_one(peer, prefix.afi(), route, &attr, nhop);
+    true
+}
+
+/// Fan out a MUP selection to every Established peer that negotiated the
+/// route's `(afi, Mup)` family. MUP AddPath TX is not implemented, so
+/// only the best path is sent (plain members). Pairs with
+/// [`route_withdraw_mup_to_peers`].
+pub fn route_advertise_mup_to_peers(
+    prefix: MupPrefix,
+    selected: &[BgpRib],
+    bgp: &mut BgpTop,
+    peers: &mut PeerMap,
+) {
+    let Some(new_best) = selected.last() else {
+        return;
+    };
+    let afi = prefix.afi();
+    for ident in peers.established_plain_idents(afi, Safi::Mup) {
+        let peer = peers.get_mut_by_idx(ident).expect("peer exists");
+        mup_advertise_one(peer, &prefix, new_best, bgp);
+    }
+}
+
+/// Send one id-less MUP MP_UNREACH to a peer and drop the Adj-RIB-Out
+/// entry so a later policy diff doesn't re-withdraw it.
+fn mup_withdraw_one(peer: &mut Peer, prefix: &MupPrefix) {
+    peer.adj_out.remove_mup(prefix, 0);
+    let mut update = UpdatePacket::with_max_packet_size(peer.max_packet_size());
+    update.mp_withdraw = Some(MpUnreachAttr::Mup {
+        afi: prefix.afi(),
+        withdraws: vec![prefix.to_route()],
+    });
+    peer.send_packet(update.into());
+}
+
+/// Withdraw a MUP prefix from every Established `(afi, Mup)` peer. The
+/// id-less MP_UNREACH clears the whole prefix; a peer that never held it
+/// ignores the withdraw.
+pub fn route_withdraw_mup_to_peers(prefix: MupPrefix, peers: &mut PeerMap) {
+    let afi = prefix.afi();
+    for ident in peers.established_plain_idents(afi, Safi::Mup) {
+        let peer = peers.get_mut_by_idx(ident).expect("peer exists");
+        mup_withdraw_one(peer, &prefix);
+    }
+}
+
+/// Replay every selected MUP route from the Loc-RIB to a peer that just
+/// reached Established, for whichever MUP AFI(s) it negotiated, then send
+/// the MUP End-of-RIB per negotiated AFI. Without this a route learned
+/// before the peer came up would never be sent. Called from `route_sync`
+/// only when the peer negotiated `(Ip, Mup)` or `(Ip6, Mup)`.
+pub fn route_sync_mup(peer: &mut Peer, bgp: &mut BgpTop) {
+    let snapshot: Vec<(MupPrefix, BgpRib)> = bgp
+        .local_rib
+        .mup
+        .selected
+        .iter()
+        .map(|(prefix, rib)| (prefix.clone(), rib.clone()))
+        .collect();
+    for (prefix, rib) in snapshot {
+        let afi = prefix.afi();
+        if !peer.is_afi_safi(afi, Safi::Mup) {
+            continue;
+        }
+        if llgr_blocks_advertisement(rib.stale, &peer.cap_recv, afi, Safi::Mup) {
+            continue;
+        }
+        let Some((route, attrs, nhop)) = route_update_mup(peer, &prefix, &rib, bgp) else {
+            continue;
+        };
+        let attr = bgp.attr_store.intern(attrs);
+        let mut adj = rib.clone();
+        adj.attr = attr.clone();
+        peer.adj_out.add_mup(prefix.clone(), adj);
+        mup_send_one(peer, afi, route, &attr, nhop);
+    }
+    // RFC 4724 / RFC 7606 §3 EoR: empty MP_UNREACH per negotiated MUP AFI.
+    for afi in [Afi::Ip, Afi::Ip6] {
+        if peer.is_afi_safi(afi, Safi::Mup) {
+            let mut update = UpdatePacket::with_max_packet_size(peer.max_packet_size());
+            update.mp_withdraw = Some(MpUnreachAttr::Mup {
+                afi,
+                withdraws: vec![],
+            });
+            peer.send_packet(update.into());
+        }
+    }
 }
 
 /// Store one received Flow Specification NLRI in the peer's Adj-RIB-In.
@@ -11937,6 +12134,12 @@ pub fn route_sync(peer: &mut Peer, bgp: &mut BgpTop, v4_via_pool: bool) {
     }
     if peer.is_afi_safi(Afi::L2vpn, Safi::Evpn) {
         route_sync_evpn(peer, bgp);
+    }
+    // SAFI 85 (RFC 9833): dump the MUP Loc-RIB. Like EVPN/label, MUP is
+    // advertised event-driven, so a route learned before this peer came
+    // up would otherwise never be sent.
+    if peer.is_afi_safi(Afi::Ip, Safi::Mup) || peer.is_afi_safi(Afi::Ip6, Safi::Mup) {
+        route_sync_mup(peer, bgp);
     }
     // SAFI 4 (RFC 3107 / 8277): dump the Labeled-Unicast Loc-RIBs. Needed
     // because label-v4/v6 are advertised event-driven only — a route that

--- a/zebra-rs/src/bgp/show.rs
+++ b/zebra-rs/src/bgp/show.rs
@@ -105,6 +105,8 @@ fn afi_safi_summary_label(afi: Afi, safi: Safi) -> &'static str {
         (Afi::Ip6, Safi::MplsLabel) => "IPv6 Labeled Unicast",
         (Afi::Ip6, Safi::MplsVpn) => "VPNv6 Unicast",
         (Afi::L2vpn, Safi::Evpn) => "L2VPN EVPN",
+        (Afi::Ip, Safi::Mup) => "IPv4 MUP",
+        (Afi::Ip6, Safi::Mup) => "IPv6 MUP",
         (Afi::Ip, Safi::Flowspec) => "IPv4 Flowspec",
         (Afi::Ip6, Safi::Flowspec) => "IPv6 Flowspec",
         (Afi::LinkState, Safi::LinkState) => "Link-State",
@@ -2749,6 +2751,18 @@ fn render(out: &mut String, neighbor: &Neighbor) -> std::fmt::Result {
         {
             writeln!(out, "    L2VPN EVPN: {}", cap.desc())?;
         }
+        let afi = CapMultiProtocol::new(&Afi::Ip, &Safi::Mup);
+        if let Some(cap) = neighbor.cap_map.entries.get(&afi)
+            && (cap.send || cap.recv)
+        {
+            writeln!(out, "    IPv4 MUP: {}", cap.desc())?;
+        }
+        let afi = CapMultiProtocol::new(&Afi::Ip6, &Safi::Mup);
+        if let Some(cap) = neighbor.cap_map.entries.get(&afi)
+            && (cap.send || cap.recv)
+        {
+            writeln!(out, "    IPv6 MUP: {}", cap.desc())?;
+        }
         let afi = CapMultiProtocol::new(&Afi::Ip, &Safi::Rtc);
         if let Some(cap) = neighbor.cap_map.entries.get(&afi)
             && (cap.send || cap.recv)
@@ -3324,6 +3338,107 @@ fn show_bgp_evpn(
             {
                 writeln!(buf, "                    {}", df)?;
             }
+        }
+    }
+
+    Ok(buf)
+}
+
+/// Decode a MUP path's extended communities for display: two-octet AS
+/// Route Targets render as `RT:<asn>:<u32>`; the MUP Extended Community
+/// (RFC 9833 §5, type 0x0c) and anything else fall through to a raw
+/// 8-octet hex dump (e.g. `0x0c0000010000003d`).
+fn format_mup_ecom_value(v: &ExtCommunityValue) -> String {
+    match (v.high_type, v.low_type) {
+        (0x00, 0x02) => {
+            let asn = u16::from_be_bytes([v.val[0], v.val[1]]);
+            let val = u32::from_be_bytes([v.val[2], v.val[3], v.val[4], v.val[5]]);
+            format!("RT:{asn}:{val}")
+        }
+        _ => format!(
+            "0x{:02x}{:02x}{:02x}{:02x}{:02x}{:02x}{:02x}{:02x}",
+            v.high_type, v.low_type, v.val[0], v.val[1], v.val[2], v.val[3], v.val[4], v.val[5]
+        ),
+    }
+}
+
+fn show_mup_ecom(attr: &BgpAttr) -> String {
+    let Some(ecom) = &attr.ecom else {
+        return String::new();
+    };
+    ecom.0
+        .iter()
+        .map(format_mup_ecom_value)
+        .collect::<Vec<_>>()
+        .join(" ")
+}
+
+/// Render a `MupPrefix` as the bracketed `[TYPE][rd][fields]` form used by
+/// `show bgp mobile-uplane`, following the MUP NLRI layout (RFC 9833).
+fn mup_prefix_display(prefix: &MupPrefix) -> String {
+    match prefix {
+        MupPrefix::Dsd { rd, address } => format!("[DSD][{rd}][{address}]"),
+        MupPrefix::Isd { rd, prefix } => format!("[ISD][{rd}][{prefix}]"),
+        MupPrefix::T1st {
+            rd,
+            prefix,
+            teid,
+            qfi,
+            endpoint,
+            source,
+        } => match source {
+            Some(src) => {
+                format!("[ST1][{rd}][ue={prefix}][teid={teid}][qfi={qfi}][ep={endpoint}:src={src}]")
+            }
+            None => format!("[ST1][{rd}][ue={prefix}][teid={teid}][qfi={qfi}][ep={endpoint}]"),
+        },
+        MupPrefix::T2st {
+            rd,
+            endpoint,
+            endpoint_len: _,
+            teid,
+        } => format!("[ST2][{rd}][ep={endpoint}][teid={teid}]"),
+        MupPrefix::Unknown { route_type, .. } => format!("[UNKNOWN type {route_type}]"),
+    }
+}
+
+/// `show bgp mobile-uplane` — the MUP (SAFI 85, RFC 9833) Loc-RIB. Phase 2
+/// renders the route table only; the `MUP controller:` block (zenoh +
+/// VRFs + sessions) lands with the controller phase.
+fn show_bgp_mup(
+    bgp: &Bgp,
+    _args: Args,
+    json: bool,
+) -> std::result::Result<String, std::fmt::Error> {
+    if json {
+        return Ok(String::from("[]"));
+    }
+    render_mup_table(&bgp.local_rib.mup)
+}
+
+/// Render the MUP Loc-RIB table body. Split out from `show_bgp_mup` so it
+/// can be unit-tested against a hand-built table without standing up a
+/// full `Bgp`.
+fn render_mup_table(
+    table: &super::route::LocalRibMupTable,
+) -> std::result::Result<String, std::fmt::Error> {
+    let mut buf = String::new();
+    writeln!(
+        buf,
+        "   Network (MUP NLRI)                                   Next Hop"
+    )?;
+
+    // The flat table iterates in `MupPrefix` Ord order: DSD, ISD, ST1, ST2.
+    for (prefix, rib) in table.selected.iter() {
+        let best = if rib.best_path { ">" } else { " " };
+        writeln!(buf, " *{best} {}", mup_prefix_display(prefix))?;
+
+        let nexthop = show_nexthop(&rib.attr);
+        writeln!(buf, "       next-hop {nexthop}  weight {}", rib.weight)?;
+
+        let ecom = show_mup_ecom(&rib.attr);
+        if !ecom.is_empty() {
+            writeln!(buf, "       {ecom}")?;
         }
     }
 
@@ -4216,6 +4331,139 @@ mod detail_tests {
             "Remote SID missing:\n{out}"
         );
     }
+
+    // --- MUP (SAFI 85) show rendering ------------------------------------
+
+    fn ecv(high: u8, low: u8, val: [u8; 6]) -> ExtCommunityValue {
+        ExtCommunityValue {
+            high_type: high,
+            low_type: low,
+            val,
+        }
+    }
+
+    fn mup_rib(nexthop: std::net::IpAddr, weight: u32, ecoms: &[ExtCommunityValue]) -> BgpRib {
+        let mut attr = BgpAttr::new();
+        attr.nexthop = Some(match nexthop {
+            std::net::IpAddr::V4(a) => BgpNexthop::Ipv4(a),
+            std::net::IpAddr::V6(a) => BgpNexthop::Ipv6(a),
+        });
+        if !ecoms.is_empty() {
+            attr.ecom = Some(ExtCommunity(ecoms.iter().cloned().collect()));
+        }
+        BgpRib::new(
+            0,
+            Ipv4Addr::new(10, 0, 0, 1),
+            BgpRibType::IBGP,
+            0,
+            weight,
+            &attr,
+            None,
+            None,
+            false,
+        )
+    }
+
+    /// End-to-end render of the MUP Loc-RIB table: exercises
+    /// `LocalRibMupTable::update`/best-path and the `show bgp mobile-uplane`
+    /// route-table body against the documented mockup shape.
+    #[test]
+    fn render_mup_table_matches_mockup_shape() {
+        use std::net::IpAddr;
+        let mut table = super::super::route::LocalRibMupTable::default();
+        let nh6: IpAddr = "fc00::30".parse().unwrap();
+        let nh4: IpAddr = "10.10.10.1".parse().unwrap();
+        let rt_2_3 = ecv(0x00, 0x02, [0x00, 0x02, 0x00, 0x00, 0x00, 0x03]);
+        let rt_9_9 = ecv(0x00, 0x02, [0x00, 0x09, 0x00, 0x00, 0x00, 0x09]);
+        let mup_ec = ecv(0x0c, 0x00, [0x00, 0x01, 0x00, 0x00, 0x00, 0x3d]);
+
+        let _ = table.update(
+            MupPrefix::from_route(&MupRoute::Isd {
+                id: 0,
+                arch: MupArchitectureType::Gpp5g,
+                rd: "1.1.1.30:50002".parse().unwrap(),
+                prefix: "20.0.3.0/24".parse().unwrap(),
+            }),
+            mup_rib(nh6, 0, &[rt_2_3]),
+        );
+        let _ = table.update(
+            MupPrefix::from_route(&MupRoute::Dsd {
+                id: 0,
+                arch: MupArchitectureType::Gpp5g,
+                rd: "1.1.1.30:50005".parse().unwrap(),
+                address: "1.1.1.99".parse().unwrap(),
+            }),
+            mup_rib(nh6, 0, &[mup_ec]),
+        );
+        let _ = table.update(
+            MupPrefix::from_route(&MupRoute::T1st {
+                id: 0,
+                arch: MupArchitectureType::Gpp5g,
+                rd: "65000:2".parse().unwrap(),
+                prefix: "2001:db8:cafe::5/128".parse().unwrap(),
+                teid: 601,
+                qfi: 9,
+                endpoint: "20.0.3.99".parse().unwrap(),
+                source: Some("20.0.1.1".parse().unwrap()),
+            }),
+            mup_rib(nh6, 32768, &[rt_9_9]),
+        );
+        let _ = table.update(
+            MupPrefix::from_route(&MupRoute::T2st {
+                id: 0,
+                arch: MupArchitectureType::Gpp5g,
+                rd: "65000:1".parse().unwrap(),
+                endpoint: "20.0.1.1".parse().unwrap(),
+                endpoint_len: 64,
+                teid: 600,
+            }),
+            mup_rib(nh4, 32768, &[]),
+        );
+
+        let out = render_mup_table(&table).unwrap();
+
+        // Grouped DSD -> ISD -> ST1 -> ST2 by MupPrefix Ord.
+        let dsd = out.find("[DSD]").expect("DSD line");
+        let isd = out.find("[ISD]").expect("ISD line");
+        let st1 = out.find("[ST1]").expect("ST1 line");
+        let st2 = out.find("[ST2]").expect("ST2 line");
+        assert!(
+            dsd < isd && isd < st1 && st1 < st2,
+            "route-type ordering:\n{out}"
+        );
+
+        assert!(out.contains("[ISD][1.1.1.30:50002][20.0.3.0/24]"), "{out}");
+        assert!(out.contains("[DSD][1.1.1.30:50005][1.1.1.99]"), "{out}");
+        assert!(
+            out.contains(
+                "[ST1][65000:2][ue=2001:db8:cafe::5/128][teid=601][qfi=9][ep=20.0.3.99:src=20.0.1.1]"
+            ),
+            "{out}"
+        );
+        assert!(
+            out.contains("[ST2][65000:1][ep=20.0.1.1][teid=600]"),
+            "{out}"
+        );
+
+        // Next-hop, weight, route-target and MUP ext-comm hex.
+        assert!(out.contains("next-hop fc00::30  weight 0"), "{out}");
+        assert!(out.contains("next-hop 10.10.10.1  weight 32768"), "{out}");
+        assert!(out.contains("RT:2:3"), "{out}");
+        assert!(out.contains("RT:9:9"), "{out}");
+        assert!(out.contains("0x0c0000010000003d"), "{out}");
+    }
+
+    #[test]
+    fn format_mup_ecom_value_rt_and_raw() {
+        assert_eq!(
+            format_mup_ecom_value(&ecv(0x00, 0x02, [0x00, 0x09, 0x00, 0x00, 0x00, 0x09])),
+            "RT:9:9"
+        );
+        assert_eq!(
+            format_mup_ecom_value(&ecv(0x0c, 0x00, [0x00, 0x01, 0x00, 0x00, 0x00, 0x3d])),
+            "0x0c0000010000003d"
+        );
+    }
 }
 
 fn show_evpn_vni_all(
@@ -4976,6 +5224,8 @@ impl Bgp {
             .set(show_bgp_evpn)
             .path("/show/bgp/evpn/route-type")
             .set(show_bgp_evpn)
+            .path("/show/bgp/mobile-uplane")
+            .set(show_bgp_mup)
             .path("/show/bgp/summary")
             .set(show_bgp_summary::<Bgp>)
             .path("/show/bgp/evpn/summary")

--- a/zebra-rs/src/bgp/show.rs
+++ b/zebra-rs/src/bgp/show.rs
@@ -3402,9 +3402,11 @@ fn mup_prefix_display(prefix: &MupPrefix) -> String {
     }
 }
 
-/// `show bgp mobile-uplane` — the MUP (SAFI 85, RFC 9833) Loc-RIB. Phase 2
-/// renders the route table only; the `MUP controller:` block (zenoh +
-/// VRFs + sessions) lands with the controller phase.
+/// `show bgp mobile-uplane` — the MUP (SAFI 85, RFC 9833) view: the
+/// config-driven `MUP VRFs:` block (per-VRF `mobile-uplane` services)
+/// followed by the Loc-RIB route table. The full `MUP controller:`
+/// wrapper (zenoh source + ingested sessions) lands with the controller
+/// phase.
 fn show_bgp_mup(
     bgp: &Bgp,
     _args: Args,
@@ -3413,7 +3415,12 @@ fn show_bgp_mup(
     if json {
         return Ok(String::from("[]"));
     }
-    render_mup_table(&bgp.local_rib.mup)
+    let mut out = render_mup_vrfs(&bgp.vrfs)?;
+    if !out.is_empty() {
+        out.push('\n');
+    }
+    out.push_str(&render_mup_table(&bgp.local_rib.mup)?);
+    Ok(out)
 }
 
 /// Render the MUP Loc-RIB table body. Split out from `show_bgp_mup` so it
@@ -3442,6 +3449,50 @@ fn render_mup_table(
         }
     }
 
+    Ok(buf)
+}
+
+/// Render the configured per-VRF MUP services (the `mobile-uplane`
+/// blocks) as the `MUP VRFs:` section of `show bgp mobile-uplane`.
+/// Config-driven only; returns an empty string when no VRF carries a
+/// `mobile-uplane` config. The full `MUP controller:` wrapper lands with
+/// the controller phase.
+fn render_mup_vrfs(
+    vrfs: &std::collections::BTreeMap<String, super::vrf_config::BgpVrfConfig>,
+) -> std::result::Result<String, std::fmt::Error> {
+    use super::vrf_config::MupSrv6Direction;
+    let mut buf = String::new();
+    let mut any = false;
+    for (name, cfg) in vrfs {
+        let mup = &cfg.mobile_uplane;
+        if mup.srv6_mobile.is_none() && mup.route_target_export.is_empty() {
+            continue;
+        }
+        if !any {
+            writeln!(buf, "MUP VRFs:")?;
+            any = true;
+        }
+        let rd = cfg
+            .rd
+            .as_ref()
+            .map(|r| r.to_string())
+            .unwrap_or_else(|| "-".into());
+        let rts = mup.route_target_export.len();
+        match &mup.srv6_mobile {
+            Some(sm) => {
+                let (dir, st) = match sm.direction {
+                    MupSrv6Direction::Decapsulation => ("decap", "ST2"),
+                    MupSrv6Direction::Encapsulation => ("encap", "ST1"),
+                };
+                let ni = sm.network_instance.as_deref().unwrap_or("-");
+                writeln!(
+                    buf,
+                    "  {name}: rd={rd} {dir}/{st} ni={ni} route-targets={rts}"
+                )?;
+            }
+            None => writeln!(buf, "  {name}: rd={rd} route-targets={rts}")?,
+        }
+    }
     Ok(buf)
 }
 
@@ -4362,6 +4413,52 @@ mod detail_tests {
             None,
             false,
         )
+    }
+
+    #[test]
+    fn render_mup_vrfs_lists_configured_services() {
+        use super::super::vrf_config::{
+            BgpVrfConfig, BgpVrfMobileUplane, MupSrv6Direction, MupSrv6Mobile,
+        };
+        use std::collections::{BTreeMap, BTreeSet};
+        let n3 = BgpVrfConfig {
+            rd: Some("65000:1".parse().unwrap()),
+            mobile_uplane: BgpVrfMobileUplane {
+                route_target_export: ["65000:100".parse().unwrap()]
+                    .into_iter()
+                    .collect::<BTreeSet<_>>(),
+                srv6_mobile: Some(MupSrv6Mobile {
+                    direction: MupSrv6Direction::Decapsulation,
+                    network_instance: Some("core-ni".to_string()),
+                }),
+            },
+            ..Default::default()
+        };
+        let n6 = BgpVrfConfig {
+            rd: Some("65000:2".parse().unwrap()),
+            mobile_uplane: BgpVrfMobileUplane {
+                route_target_export: ["65000:200".parse().unwrap()]
+                    .into_iter()
+                    .collect::<BTreeSet<_>>(),
+                srv6_mobile: Some(MupSrv6Mobile {
+                    direction: MupSrv6Direction::Encapsulation,
+                    network_instance: Some("access-ni".to_string()),
+                }),
+            },
+            ..Default::default()
+        };
+        let mut vrfs: BTreeMap<String, BgpVrfConfig> = BTreeMap::new();
+        vrfs.insert("N3".to_string(), n3);
+        vrfs.insert("N6".to_string(), n6);
+
+        let out = render_mup_vrfs(&vrfs).unwrap();
+        assert!(out.contains("MUP VRFs:"));
+        assert!(out.contains("N3: rd=65000:1 decap/ST2 ni=core-ni route-targets=1"));
+        assert!(out.contains("N6: rd=65000:2 encap/ST1 ni=access-ni route-targets=1"));
+
+        // No mobile-uplane config anywhere → empty section.
+        let empty: BTreeMap<String, BgpVrfConfig> = BTreeMap::new();
+        assert!(render_mup_vrfs(&empty).unwrap().is_empty());
     }
 
     /// End-to-end render of the MUP Loc-RIB table: exercises

--- a/zebra-rs/src/bgp/show.rs
+++ b/zebra-rs/src/bgp/show.rs
@@ -141,9 +141,35 @@ fn rib_entries_count<V: BgpShowView>(bgp: &V, afi_safi: &AfiSafi) -> usize {
         (Afi::Ip6, Safi::MplsLabel) => bgp.shard().v6lu.0.len(),
         (Afi::Ip, Safi::MplsVpn) => bgp.shard().v4vpn.values().map(|t| t.0.len()).sum(),
         (Afi::L2vpn, Safi::Evpn) => bgp.local_rib().evpn.values().map(|t| t.cands.len()).sum(),
+        (Afi::Ip, Safi::Mup) => mup_rib_count(&bgp.local_rib().mup, Afi::Ip),
+        (Afi::Ip6, Safi::Mup) => mup_rib_count(&bgp.local_rib().mup, Afi::Ip6),
         (Afi::LinkState, Safi::LinkState) => bgp.local_rib().bgp_ls.selected.len(),
         _ => 0,
     }
+}
+
+/// Address family a MUP Loc-RIB entry belongs to. The MUP table is a
+/// single flat map (RFC 9833 routes for both AFIs share it), so attribute
+/// each route to v4/v6 by the family of its principal address — the DSD
+/// address, the ISD / ST1 session prefix, or the ST2 endpoint. `Unknown`
+/// routes carry no decoded address and belong to neither family.
+fn mup_prefix_afi(prefix: &MupPrefix) -> Option<Afi> {
+    let addr = match prefix {
+        MupPrefix::Dsd { address, .. } => *address,
+        MupPrefix::Isd { prefix, .. } | MupPrefix::T1st { prefix, .. } => prefix.addr(),
+        MupPrefix::T2st { endpoint, .. } => *endpoint,
+        MupPrefix::Unknown { .. } => return None,
+    };
+    Some(if addr.is_ipv4() { Afi::Ip } else { Afi::Ip6 })
+}
+
+/// Count selected MUP Loc-RIB entries for one address family.
+fn mup_rib_count(table: &super::route::LocalRibMupTable, afi: Afi) -> usize {
+    table
+        .selected
+        .keys()
+        .filter(|p| mup_prefix_afi(p) == Some(afi))
+        .count()
 }
 
 /// Has this peer negotiated a given AFI/SAFI? True iff we advertised the
@@ -2023,6 +2049,41 @@ fn show_bgp_evpn_summary(
     json: bool,
 ) -> std::result::Result<String, std::fmt::Error> {
     show_bgp_summary_one(bgp, AfiSafi::new(Afi::L2vpn, Safi::Evpn), json)
+}
+
+/// `show bgp mobile-uplane summary` — the MUP (SAFI 85, RFC 9833)
+/// neighbor summary. `mobile-uplane` enables both IPv4-MUP and IPv6-MUP
+/// at once (RFC 9833), so this renders both sections — the MUP slice of
+/// `show bgp summary` — listing the neighbors that have each MUP family
+/// enabled and whether they negotiated the capability.
+fn show_bgp_mup_summary(
+    bgp: &Bgp,
+    _args: Args,
+    json: bool,
+) -> std::result::Result<String, std::fmt::Error> {
+    let families = [
+        AfiSafi::new(Afi::Ip, Safi::Mup),
+        AfiSafi::new(Afi::Ip6, Safi::Mup),
+    ];
+    if json {
+        let summary = BgpSummaryJson {
+            router_id: summary_router_id(bgp),
+            local_as: bgp.asn(),
+            afi_safis: families
+                .iter()
+                .map(|af| summary_section_json(bgp, *af, None))
+                .collect(),
+        };
+        return Ok(summary_json_render(&summary));
+    }
+    let mut buf = String::new();
+    for (i, af) in families.iter().enumerate() {
+        if i > 0 {
+            writeln!(buf)?;
+        }
+        write_summary_section(&mut buf, bgp, *af, None)?;
+    }
+    Ok(buf)
 }
 
 #[derive(Serialize, Debug)]
@@ -5323,6 +5384,8 @@ impl Bgp {
             .set(show_bgp_evpn)
             .path("/show/bgp/mobile-uplane")
             .set(show_bgp_mup)
+            .path("/show/bgp/mobile-uplane/summary")
+            .set(show_bgp_mup_summary)
             .path("/show/bgp/summary")
             .set(show_bgp_summary::<Bgp>)
             .path("/show/bgp/evpn/summary")

--- a/zebra-rs/src/bgp/vrf_config.rs
+++ b/zebra-rs/src/bgp/vrf_config.rs
@@ -122,6 +122,38 @@ impl<N: Ord> Default for BgpVrfAfConfig<N> {
     }
 }
 
+/// SRv6 mobile user-plane direction for a per-VRF MUP service
+/// (zebra-bgp-vrf.yang `mobile-uplane srv6-mobile`). `Decapsulation`
+/// is the egress/uplink (Type-2 ST, the N3 VRF); `Encapsulation` is
+/// the ingress/downlink (Type-1 ST, the N6 VRF).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MupSrv6Direction {
+    Decapsulation,
+    Encapsulation,
+}
+
+/// `mobile-uplane srv6-mobile {decapsulation|encapsulation}
+/// network-instance exact <ni>` for one VRF: the direction plus the
+/// session network-instance matched exactly. Surfaced in
+/// `show bgp mobile-uplane` (the `MUP VRFs:` block) and consumed by the
+/// P5 MUP controller when it originates ST routes (decapsulation →
+/// Type-2 ST, the N3 VRF; encapsulation → Type-1 ST, the N6 VRF).
+#[derive(Debug, Clone)]
+pub struct MupSrv6Mobile {
+    pub direction: MupSrv6Direction,
+    pub network_instance: Option<String>,
+}
+
+/// Per-VRF BGP MUP (RFC 9833) service config — the `mobile-uplane`
+/// container in zebra-bgp-vrf.yang. The route-targets tag the ST
+/// routes the controller originates from this VRF (RT shares the RD
+/// wire format, so it is stored as a `RouteDistinguisher`).
+#[derive(Default, Debug, Clone)]
+pub struct BgpVrfMobileUplane {
+    pub route_target_export: BTreeSet<RouteDistinguisher>,
+    pub srv6_mobile: Option<MupSrv6Mobile>,
+}
+
 /// Staged candidate configuration for one VRF entry. Mirrors the
 /// `list vrf` body in zebra-bgp-vrf.yang.
 #[derive(Default, Debug, Clone)]
@@ -145,6 +177,9 @@ pub struct BgpVrfConfig {
     /// its own PEs over a single MP-eBGP VPNv4 session while still
     /// forwarding per-VRF. Default `false` (ordinary L3VPN VRF).
     pub inter_as_hybrid: bool,
+    /// Per-VRF BGP MUP (RFC 9833) service config. Mirrors the
+    /// `mobile-uplane` container in zebra-bgp-vrf.yang.
+    pub mobile_uplane: BgpVrfMobileUplane,
 }
 
 /// Borrow-or-create the per-VRF entry on `Bgp::vrfs`. Used by every
@@ -235,6 +270,80 @@ pub fn config_vrf_inter_as_hybrid(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -
     match op {
         ConfigOp::Set => cfg.inter_as_hybrid = args.boolean()?,
         ConfigOp::Delete => cfg.inter_as_hybrid = false,
+        _ => {}
+    }
+    Some(())
+}
+
+/// `set router bgp vrf <NAME> mobile-uplane route-target export <RT>...`
+/// — the route-targets attached to MUP ST routes originated from this
+/// VRF. A leaf-list arrives as one callback call with every value in
+/// the args deque, so the handler loops (project convention).
+pub fn config_vrf_mup_rt_export(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Option<()> {
+    let name = args.string()?;
+    let cfg = vrf_entry(bgp, name);
+    match op {
+        ConfigOp::Set => {
+            while let Some(s) = args.string() {
+                if let Ok(rt) = RouteDistinguisher::from_str(&s) {
+                    cfg.mobile_uplane.route_target_export.insert(rt);
+                }
+            }
+        }
+        ConfigOp::Delete => {
+            let mut removed_any = false;
+            while let Some(s) = args.string() {
+                if let Ok(rt) = RouteDistinguisher::from_str(&s) {
+                    cfg.mobile_uplane.route_target_export.remove(&rt);
+                    removed_any = true;
+                }
+            }
+            // A bare `delete ... route-target export` with no value
+            // clears the whole leaf-list.
+            if !removed_any {
+                cfg.mobile_uplane.route_target_export.clear();
+            }
+        }
+        _ => {}
+    }
+    Some(())
+}
+
+/// `set router bgp vrf <NAME> mobile-uplane srv6-mobile decapsulation
+/// network-instance exact <NI>` — egress GTP decapsulation for the
+/// uplink Type-2 ST service (the N3 VRF).
+pub fn config_vrf_mup_srv6_decap(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Option<()> {
+    let name = args.string()?;
+    let cfg = vrf_entry(bgp, name);
+    match op {
+        ConfigOp::Set => {
+            let ni = args.string()?;
+            cfg.mobile_uplane.srv6_mobile = Some(MupSrv6Mobile {
+                direction: MupSrv6Direction::Decapsulation,
+                network_instance: Some(ni),
+            });
+        }
+        ConfigOp::Delete => cfg.mobile_uplane.srv6_mobile = None,
+        _ => {}
+    }
+    Some(())
+}
+
+/// `set router bgp vrf <NAME> mobile-uplane srv6-mobile encapsulation
+/// network-instance exact <NI>` — ingress GTP encapsulation for the
+/// downlink Type-1 ST service (the N6 VRF).
+pub fn config_vrf_mup_srv6_encap(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Option<()> {
+    let name = args.string()?;
+    let cfg = vrf_entry(bgp, name);
+    match op {
+        ConfigOp::Set => {
+            let ni = args.string()?;
+            cfg.mobile_uplane.srv6_mobile = Some(MupSrv6Mobile {
+                direction: MupSrv6Direction::Encapsulation,
+                network_instance: Some(ni),
+            });
+        }
+        ConfigOp::Delete => cfg.mobile_uplane.srv6_mobile = None,
         _ => {}
     }
     Some(())
@@ -551,6 +660,50 @@ mod tests {
             BgpVrfConfig::default().encapsulation,
             BgpVrfEncapsulation::Mpls
         );
+    }
+
+    #[test]
+    fn mobile_uplane_default_is_empty() {
+        let mup = BgpVrfConfig::default().mobile_uplane;
+        assert!(mup.route_target_export.is_empty());
+        assert!(mup.srv6_mobile.is_none());
+    }
+
+    #[test]
+    fn mobile_uplane_rt_export_insert_and_clear() {
+        let mut cfg = BgpVrfConfig::default();
+        let rt1 = RouteDistinguisher::from_str("65000:100").unwrap();
+        let rt2 = RouteDistinguisher::from_str("65000:200").unwrap();
+        cfg.mobile_uplane.route_target_export.insert(rt1);
+        cfg.mobile_uplane.route_target_export.insert(rt2);
+        assert_eq!(cfg.mobile_uplane.route_target_export.len(), 2);
+        assert!(cfg.mobile_uplane.route_target_export.contains(&rt1));
+        cfg.mobile_uplane.route_target_export.clear();
+        assert!(cfg.mobile_uplane.route_target_export.is_empty());
+    }
+
+    #[test]
+    fn mobile_uplane_srv6_decap_and_encap() {
+        let mut cfg = BgpVrfConfig::default();
+        cfg.mobile_uplane.srv6_mobile = Some(MupSrv6Mobile {
+            direction: MupSrv6Direction::Decapsulation,
+            network_instance: Some("core-ni".to_string()),
+        });
+        let sm = cfg.mobile_uplane.srv6_mobile.as_ref().unwrap();
+        assert_eq!(sm.direction, MupSrv6Direction::Decapsulation);
+        assert_eq!(sm.network_instance.as_deref(), Some("core-ni"));
+
+        cfg.mobile_uplane.srv6_mobile = Some(MupSrv6Mobile {
+            direction: MupSrv6Direction::Encapsulation,
+            network_instance: Some("access-ni".to_string()),
+        });
+        assert_eq!(
+            cfg.mobile_uplane.srv6_mobile.as_ref().unwrap().direction,
+            MupSrv6Direction::Encapsulation
+        );
+
+        cfg.mobile_uplane.srv6_mobile = None;
+        assert!(cfg.mobile_uplane.srv6_mobile.is_none());
     }
 
     #[test]

--- a/zebra-rs/src/config/configs.rs
+++ b/zebra-rs/src/config/configs.rs
@@ -154,6 +154,11 @@ impl Args {
             "sr-policy-v4" => Some(AfiSafi::new(Afi::Ip, Safi::SrTePolicy)),
             "sr-policy-v6" => Some(AfiSafi::new(Afi::Ip6, Safi::SrTePolicy)),
             "link-state" => Some(AfiSafi::new(Afi::LinkState, Safi::LinkState)),
+            // MUP (RFC 9833) is one config name that enables both the
+            // IPv4 and IPv6 MUP families; (Ip, Mup) is the canonical
+            // tuple returned here and `mp_family_expand` fans it out to
+            // both AFIs at the `enabled` handlers.
+            "mobile-uplane" => Some(AfiSafi::new(Afi::Ip, Safi::Mup)),
             _ => None,
         }
     }
@@ -775,6 +780,14 @@ mod tests {
             args.afi_safi(),
             Some(AfiSafi::new(Afi::Ip6, Safi::Flowspec))
         );
+    }
+
+    #[test]
+    fn afi_safi_parses_mobile_uplane_as_v4_mup() {
+        // The single `mobile-uplane` name canonicalizes to (Ip, Mup);
+        // the enabled handlers fan it out to both MUP AFIs (RFC 9833).
+        let mut args = Args(["mobile-uplane".to_string()].into_iter().collect());
+        assert_eq!(args.afi_safi(), Some(AfiSafi::new(Afi::Ip, Safi::Mup)));
     }
 
     #[test]

--- a/zebra-rs/src/config/parse.rs
+++ b/zebra-rs/src/config/parse.rs
@@ -1298,6 +1298,16 @@ mod tests {
             ("show bgp vpnv4 summary", "/show/bgp/vpnv4", vec!["summary"]),
             ("show bgp evpn summary", "/show/bgp/evpn/summary", vec![]),
             (
+                "show bgp mobile-uplane summary",
+                "/show/bgp/mobile-uplane/summary",
+                vec![],
+            ),
+            (
+                "show bgp mobile-uplane summ",
+                "/show/bgp/mobile-uplane/summary",
+                vec![],
+            ),
+            (
                 "show bgp vrf blue summary",
                 "/show/bgp/vrf/summary",
                 vec!["blue"],

--- a/zebra-rs/yang/exec.yang
+++ b/zebra-rs/yang/exec.yang
@@ -356,6 +356,10 @@ module exec {
           }
         }
       }
+      container mobile-uplane {
+        ext:help "BGP Mobile User Plane (MUP) RIB";
+        presence "BGP Mobile User Plane (MUP) RIB";
+      }
       list update-group {
         ext:help "BGP update-groups (IOS-XR style)";
         ext:presence "BGP update-group summary";

--- a/zebra-rs/yang/exec.yang
+++ b/zebra-rs/yang/exec.yang
@@ -359,6 +359,10 @@ module exec {
       container mobile-uplane {
         ext:help "BGP Mobile User Plane (MUP) RIB";
         presence "BGP Mobile User Plane (MUP) RIB";
+        leaf summary {
+          ext:help "Summary of MUP-enabled neighbors";
+          type empty;
+        }
       }
       list update-group {
         ext:help "BGP update-groups (IOS-XR style)";

--- a/zebra-rs/yang/zebra-afi-safi.yang
+++ b/zebra-rs/yang/zebra-afi-safi.yang
@@ -88,6 +88,12 @@ module zebra-afi-safi {
         enum link-state {
           description "BGP Link-State (AFI 16388, SAFI 71, RFC 9552).";
         }
+        enum mobile-uplane {
+          description
+            "BGP Mobile User Plane (MUP), SAFI 85, RFC 9833. A single
+             config name that negotiates BOTH IPv4-MUP (AFI 1) and
+             IPv6-MUP (AFI 2).";
+        }
       }
       description
         "Address family / sub-address family this list entry configures.

--- a/zebra-rs/yang/zebra-bgp-vrf.yang
+++ b/zebra-rs/yang/zebra-bgp-vrf.yang
@@ -340,6 +340,45 @@ module zebra-bgp-vrf {
              (IP Prefix) routes. Requires `rd` to be set.";
         }
       }
+      container mobile-uplane {
+        description
+          "BGP MUP (RFC 9833) per-VRF service. route-target/export tags
+           the ST routes the controller originates from this VRF;
+           srv6-mobile selects the direction (decapsulation = Type-2 ST
+           / uplink = N3, encapsulation = Type-1 ST / downlink = N6) and
+           the session network-instance matched exactly.";
+        container route-target {
+          leaf-list export {
+            type route-distinguisher;
+            description
+              "Route-targets attached to MUP ST routes originated from
+               this VRF (RT shares the RD wire format).";
+          }
+        }
+        container srv6-mobile {
+          description "SRv6 mobile user-plane behaviour for this VRF.";
+          container decapsulation {
+            description
+              "Egress GTP decapsulation (Type-2 ST / uplink); the N3 VRF.";
+            container network-instance {
+              leaf exact {
+                type string;
+                description "Session core network-instance matched exactly.";
+              }
+            }
+          }
+          container encapsulation {
+            description
+              "Ingress GTP encapsulation (Type-1 ST / downlink); the N6 VRF.";
+            container network-instance {
+              leaf exact {
+                type string;
+                description "Session access network-instance matched exactly.";
+              }
+            }
+          }
+        }
+      }
       uses bgp-vrf-neighbor;
       uses bgp-vrf-afi-safi;
     }


### PR DESCRIPTION
## Summary

Adds the BGP Mobile User Plane (MUP) control plane — SAFI 85, RFC 9833 —
end to end: codec, capability negotiation, Loc-RIB, per-VRF config,
advertisement/re-origination, and show commands. Dataplane (kernel/VPP) and
the zenoh/PFCP controller remain deferred (tracked in
`docs/design/bgp-mup-followups.md`).

### Control plane (P0–P4)
- **Codec** (`crates/bgp-packet`): MUP NLRI (ISD/DSD/ST1/ST2) parse+emit,
  MP_REACH/MP_UNREACH wiring, GoBGP-byte-exact.
- **Capability negotiation**: `mobile-uplane` enables both IPv4-MUP and
  IPv6-MUP (single knob, RFC 9833); per-peer and neighbor-group.
- **Loc-RIB**: flat MUP table with best-path selection.
- **Per-VRF config**: `mobile-uplane` service block (RD, SRv6 encap/decap
  direction, route-targets) + `show bgp mobile-uplane` VRFs block.
- **Advertise / re-originate** MUP routes.

### Added this cycle
- **`show bgp mobile-uplane summary`** — per-AFI/SAFI neighbor summary like
  the other families (renders both IPv4-MUP and IPv6-MUP sections).
- **Capability renegotiation fix**: toggling any `afi-safi` on an
  Established neighbor now bounces the session (the `clear bgp … hard`
  teardown) so the new Multiprotocol capability is renegotiated — both the
  per-neighbor and neighbor-group paths. Previously the config was recorded
  but the session never renegotiated, so e.g. enabling `mobile-uplane` at
  runtime showed no MUP capability until a manual clear.

## Test plan
- `cargo fmt --all`, `cargo clippy --workspace --all-targets -- -D warnings`,
  `cargo test --workspace --exclude bdd` — all green.
- Unit: MUP codec round-trips; `afi_safi_change_bounces_established_peer` and
  `group_afi_safi_change_bounces_established_member` (bounce across
  ipv6/evpn/vpnv4/mobile-uplane, with not-Established / redundant-set
  no-bounce guards); `show bgp mobile-uplane summary` parse pin.
- BDD (run live; CI excludes bdd): `@bgp_mup_capability` (startup cap
  negotiation, both AFIs) and `@bgp_mup_runtime_enable` (runtime enable
  renegotiates — verified head-to-head fail/pass against the pre-fix binary).

Generated with [Claude Code](https://claude.com/claude-code)