### PR TITLE
config: detect CLI brace format when first line ends with ';'

### DIFF
--- a/zebra-rs/src/config/manager.rs
+++ b/zebra-rs/src/config/manager.rs
@@ -1347,12 +1347,68 @@ pub fn config_format_type(config_str: &str) -> ConfigFormat {
         .unwrap_or("");
     if first_line.starts_with('{') {
         ConfigFormat::Json
-    } else if first_line.ends_with('{') {
+    } else if first_line.ends_with('{') || first_line.ends_with(';') {
+        // CLI brace format. A block opens with `… {`, but a top-level
+        // leaf or a bare keyed list entry is a `;`-terminated statement
+        // with no block — e.g. a config that starts with `vrf N3;`. Both
+        // are CLI; only `{` was matched before, so such a config fell
+        // through to the YAML default and was silently dropped. YAML and
+        // `set`/`delete` lines never end with `;`, so this is unambiguous.
         ConfigFormat::Cli
     } else if first_line.starts_with("set ") || first_line.starts_with("delete ") {
         ConfigFormat::SetDelete
     } else {
         ConfigFormat::Yaml
+    }
+}
+
+#[cfg(test)]
+mod config_format_tests {
+    use super::*;
+
+    #[test]
+    fn cli_brace_block() {
+        assert_eq!(
+            config_format_type("system {\n  hostname r1;\n}\n"),
+            ConfigFormat::Cli
+        );
+    }
+
+    /// Regression: a CLI config that opens with a `;`-terminated leaf or a
+    /// bare keyed list entry (no block) — e.g. `vrf N3;` — used to be
+    /// sniffed as YAML and silently dropped at load.
+    #[test]
+    fn cli_leading_semicolon_statement() {
+        assert_eq!(config_format_type("vrf N3;\nvrf N6;\n"), ConfigFormat::Cli);
+        assert_eq!(config_format_type("hostname r1;\n"), ConfigFormat::Cli);
+        // Leading blank lines / comments are skipped before sniffing.
+        assert_eq!(
+            config_format_type("\n# a comment\nvrf N3;\n"),
+            ConfigFormat::Cli
+        );
+    }
+
+    #[test]
+    fn json_object() {
+        assert_eq!(
+            config_format_type("{\n  \"system\": {}\n}"),
+            ConfigFormat::Json
+        );
+    }
+
+    #[test]
+    fn set_delete_lines() {
+        assert_eq!(config_format_type("set vrf N3\n"), ConfigFormat::SetDelete);
+        assert_eq!(
+            config_format_type("delete vrf N3\n"),
+            ConfigFormat::SetDelete
+        );
+    }
+
+    #[test]
+    fn yaml_mapping() {
+        assert_eq!(config_format_type("vrf:\n- name: N3\n"), ConfigFormat::Yaml);
+        assert_eq!(config_format_type("router:\n  bgp:\n"), ConfigFormat::Yaml);
     }
 }
 


### PR DESCRIPTION
## Summary

Fixes a config-file format-detection bug: `config_format_type` sniffed the
CLI brace format only when the first meaningful line ended with `{`. A CLI
config can legitimately start with a `;`-terminated statement that opens no
block — a top-level leaf or a bare keyed list entry, e.g.:

```
vrf N3;
vrf N6;
```

Such a config fell through to the YAML default, was parsed as YAML (garbage),
and silently dropped — at startup the whole file produced an empty candidate,
so the VRFs (and anything after them) were never created. A config that
started with a block (`system {`, `interface X {`) was detected as CLI and
worked, which masked the bug and made it look VRF-specific.

Treat a first line ending in `;` as CLI too. YAML mappings/sequences and
`set`/`delete` lines never end with `;`, so the sniff stays unambiguous.

Pre-existing since the format sniffer landed (2026-01-17); not related to the
recent per-VRF config dispatch change.

## Test plan
- New `config_format_tests`: brace block, leading-`;` statement (incl. blank
  / comment lines first), JSON, set/delete, YAML mapping.
- `cargo fmt --all`, `cargo clippy --workspace --all-targets -- -D warnings`,
  `cargo test --workspace --exclude bdd` — all green.
- Verified live in an isolated netns: a `vrf N3; vrf N6;` startup config now
  fires `vrf_add`, creates the kernel VRF devices, and `show ip route vrf
  N3/N6` resolve (broken before the fix).

Generated with [Claude Code](https://claude.com/claude-code)