### PR TITLE
bgp-mup: MUP Controller (MUP-C) — PFCP ingest to ST route origination

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ members = [
   "crates/fixedbuf",
   "bdd",
   "tools/bgp-bench",
+  "tools/pfcp-inject",
 ]
 # The offload/ tree holds XDP/eBPF PoCs built with aya. It is intentionally NOT
 # a member of this workspace: building it needs a nightly `bpfel` toolchain +

--- a/bdd/Makefile
+++ b/bdd/Makefile
@@ -20,6 +20,13 @@ bgp_srv6_redistribute:
 	mkdir -p allure-results
 	cargo test --test cucumber -- --concurrency=1 --tags "@bgp_srv6_redistribute"
 
+# MUP controller end-to-end: PFCP session -> ST route origination ->
+# peer receive. Needs the `pfcp-inject` binary on the host PATH
+# (cargo build --release -p pfcp-inject; copy to /usr/bin).
+bgp_mup_e2e:
+	mkdir -p allure-results
+	cargo test --test cucumber -- --concurrency=1 --tags "@bgp_mup_e2e"
+
 rib_static_ipv6:
 	mkdir -p allure-results
 	cargo test --test cucumber -- --concurrency=1 --tags "@rib_static_ipv6"

--- a/bdd/docs/bgp_mup_e2e.md
+++ b/bdd/docs/bgp_mup_e2e.md
@@ -1,0 +1,50 @@
+# BGP MUP Controller originates Session-Transformed routes from PFCP
+
+## Overview
+
+As a network operator
+I want the zebra-rs BGP MUP Controller (MUP-C) to learn a mobile session
+over PFCP/N4 and originate a Type-1 Session-Transformed route (SAFI 85,
+RFC 9833) that a peer zebra-rs receives, so the end-to-end control plane
+— PFCP ingest, NI -> VRF correlation, SRv6 SID allocation, ST route
+origination, and iBGP advertisement — is validated.
+
+## Test Topology
+
+```
+  ┌─────────────────────────────────────────┐
+  │                   br0                    │
+  └─────────────┬───────────────┬───────────┘
+                │               │
+           ┌────┴────┐     ┌────┴────┐
+           │   z1    │     │   z2    │
+           │ MUP-C   │ iBGP│ receiver│
+           │192.168. │◄───►│192.168. │
+           │  0.1/24 │     │  0.2/24 │
+           └────┬────┘     └─────────┘
+                │ PFCP/N4 (UDP 8805)
+           ┌────┴──────┐
+           │ pfcp-inject│  (SMF simulator, run in z1)
+           └───────────┘
+```
+
+## Notes
+
+z1 runs the controller (PFCP listener on 192.168.0.1:8805, locator LOC1,
+VRF `mobile-up` matching Network Instance `access`). `pfcp-inject` plays
+the SMF: it sends an Association Setup + Session Establishment for UE
+192.0.2.5 (Network Instance `access`), so z1 originates the ST1 route and
+advertises it to z2.
+NOTE: this feature runs `pfcp-inject` inside z1, so the `pfcp-inject`
+binary (the test-only SMF simulator, `tools/pfcp-inject`) must be on the
+BDD host PATH — build with `cargo build --release -p pfcp-inject` and
+copy `target/release/pfcp-inject` to /usr/bin, the same way the
+zebra-rs / vtyctl binaries are staged for BDD.
+
+## Test Scenarios
+
+| Scenario | Result |
+|----------|--------|
+| Setup topology and establish iBGP session with MUP capability | |
+| PFCP session establishment originates an ST1 route received by the peer | |
+| Teardown topology | |

--- a/bdd/tests/configs/bgp_mup_e2e/z1.yaml
+++ b/bdd/tests/configs/bgp_mup_e2e/z1.yaml
@@ -1,0 +1,51 @@
+# z1 — MUP Controller (MUP-C). AS 65001, iBGP to z2 (192.168.0.2) with the
+# mobile-uplane afi-safi negotiated. Runs the PFCP/N4 listener on
+# 192.168.0.1:8805 and, when pfcp-inject programs a session whose Network
+# Instance is `access`, originates a Type-1 Session-Transformed route into
+# the `mobile-up` VRF (rd 65000:100, RT export 65000:200) with an End.DT4
+# SID carved from locator LOC1 and the controller-address as next hop. The
+# route is advertised to z2 over the mobile-uplane session.
+segment-routing:
+  locator:
+  - name: LOC1
+    prefix: fcbb:bb01::/48
+    behavior: usid
+router:
+  bgp:
+    global:
+      as: 65001
+      router-id: 192.168.0.1
+    segment-routing:
+      srv6:
+        locator: LOC1
+        ipv6-unicast: {}
+    neighbor:
+    - remote-address: 192.168.0.2
+      remote-as: 65001
+      enabled: true
+      afi-safi:
+      - name: ipv4
+        enabled: true
+      - name: mobile-uplane
+        enabled: true
+    vrf:
+    - name: mobile-up
+      rd: "65000:100"
+      mobile-uplane:
+        route-target:
+          export:
+          - "65000:200"
+        srv6-mobile:
+          encapsulation:
+            network-instance:
+              exact: access
+    afi-safi:
+    - name: mobile-uplane
+      mup-c:
+        enable: true
+        controller-address: fcbb:bb01::1
+        pfcp:
+          listen-address: 192.168.0.1
+          port: 8805
+        srv6:
+          locator: LOC1

--- a/bdd/tests/configs/bgp_mup_e2e/z2.yaml
+++ b/bdd/tests/configs/bgp_mup_e2e/z2.yaml
@@ -1,0 +1,18 @@
+# z2 — MUP route receiver. AS 65001, iBGP to z1 (192.168.0.1) with the
+# mobile-uplane afi-safi negotiated. Plain BGP speaker: it has no
+# controller and originates nothing, but receives the Type-1 ST route the
+# controller (z1) originates and shows it under `show bgp mobile-uplane`.
+router:
+  bgp:
+    global:
+      as: 65001
+      router-id: 192.168.0.2
+    neighbor:
+    - remote-address: 192.168.0.1
+      remote-as: 65001
+      enabled: true
+      afi-safi:
+      - name: ipv4
+        enabled: true
+      - name: mobile-uplane
+        enabled: true

--- a/bdd/tests/features/bgp_mup_e2e.feature
+++ b/bdd/tests/features/bgp_mup_e2e.feature
@@ -1,0 +1,77 @@
+@serial
+@bgp_mup_e2e
+Feature: BGP MUP Controller originates Session-Transformed routes from PFCP
+  As a network operator
+  I want the zebra-rs BGP MUP Controller (MUP-C) to learn a mobile session
+  over PFCP/N4 and originate a Type-1 Session-Transformed route (SAFI 85,
+  RFC 9833) that a peer zebra-rs receives, so the end-to-end control plane
+  — PFCP ingest, NI -> VRF correlation, SRv6 SID allocation, ST route
+  origination, and iBGP advertisement — is validated.
+
+  Test Topology:
+  ```
+  ┌─────────────────────────────────────────┐
+  │                   br0                    │
+  └─────────────┬───────────────┬───────────┘
+                │               │
+           ┌────┴────┐     ┌────┴────┐
+           │   z1    │     │   z2    │
+           │ MUP-C   │ iBGP│ receiver│
+           │192.168. │◄───►│192.168. │
+           │  0.1/24 │     │  0.2/24 │
+           └────┬────┘     └─────────┘
+                │ PFCP/N4 (UDP 8805)
+           ┌────┴──────┐
+           │ pfcp-inject│  (SMF simulator, run in z1)
+           └───────────┘
+  ```
+
+  z1 runs the controller (PFCP listener on 192.168.0.1:8805, locator LOC1,
+  VRF `mobile-up` matching Network Instance `access`). `pfcp-inject` plays
+  the SMF: it sends an Association Setup + Session Establishment for UE
+  192.0.2.5 (Network Instance `access`), so z1 originates the ST1 route and
+  advertises it to z2.
+
+  NOTE: this feature runs `pfcp-inject` inside z1, so the `pfcp-inject`
+  binary (the test-only SMF simulator, `tools/pfcp-inject`) must be on the
+  BDD host PATH — build with `cargo build --release -p pfcp-inject` and
+  copy `target/release/pfcp-inject` to /usr/bin, the same way the
+  zebra-rs / vtyctl binaries are staged for BDD.
+
+  Scenario: Setup topology and establish iBGP session with MUP capability
+    Given a clean test environment
+    When I create bridge "br0"
+    And I create namespace "z1" with IP "192.168.0.1/24" on bridge "br0"
+    And I create namespace "z2" with IP "192.168.0.2/24" on bridge "br0"
+    And I start zebra-rs in namespace "z1"
+    And I start zebra-rs in namespace "z2"
+    And I apply config "z1.yaml" to namespace "z1"
+    And I apply config "z2.yaml" to namespace "z2"
+    And I wait 5 seconds for BGP to operate
+    Then BGP session in "z1" to "192.168.0.2" should be "Established"
+    And BGP session in "z2" to "192.168.0.1" should be "Established"
+    And show command "show bgp neighbor 192.168.0.2" in namespace "z1" should contain "IPv4 MUP: advertised and received"
+    And show command "show bgp mobile-uplane mup-c" in namespace "z1" should contain "PFCP listen : 192.168.0.1:8805"
+
+  Scenario: PFCP session establishment originates an ST1 route received by the peer
+    Given the test topology exists
+    When I execute "pfcp-inject --target 192.168.0.1 --port 8805 --ue-ipv4 192.0.2.5 --teid 0x12345678 --endpoint 10.0.0.1 --network-instance access" in namespace "z1"
+    Then show command "show bgp mobile-uplane mup-c session" in namespace "z1" should eventually contain "192.0.2.5"
+    And show command "show bgp mobile-uplane" in namespace "z1" should contain "ue=192.0.2.5/32"
+    And show command "show bgp mobile-uplane" in namespace "z2" should eventually contain "ue=192.0.2.5/32"
+
+  # Session deletion / route withdrawal is covered by the `pfcp.rs`
+  # `session_deletion_removes_session` unit test and manual validation; a
+  # BDD assertion on it is omitted here because `pfcp-inject` is one-shot
+  # (establish+delete in a single run) and the controller allocates a fresh
+  # SEID per establish, so a back-to-back establish/delete can't be
+  # deterministically observed on the receiver across propagation delay.
+
+  Scenario: Teardown topology
+    Given the test topology exists
+    When I stop zebra-rs in namespace "z1"
+    And I stop zebra-rs in namespace "z2"
+    And I delete namespace "z1"
+    And I delete namespace "z2"
+    And I delete bridge "br0"
+    Then the test environment should be clean

--- a/book/src/SUMMARY.md
+++ b/book/src/SUMMARY.md
@@ -41,6 +41,7 @@
   - [EVPN IGMP/MLD Proxy (Selective Multicast)](ch-02-32-bgp-evpn-igmp-mld-proxy.md)
   - [EVPN BUM & Assisted Replication](ch-02-33-bgp-evpn-assisted-replication.md)
   - [EVPN BUM Tunnel Segmentation (RFC 9572)](ch-02-34-bgp-evpn-segmentation.md)
+  - [Mobile User Plane (MUP) & the MUP Controller](ch-02-35-bgp-mup.md)
   - [Route Target Constraint (RTC)](ch-02-07-bgp-rtc.md)
   - [Inter-AS L3VPN](ch-02-18-bgp-interas.md)
     - [Option A (back-to-back VRFs)](ch-02-20-bgp-interas-option-a.md)

--- a/book/src/ch-02-35-bgp-mup.md
+++ b/book/src/ch-02-35-bgp-mup.md
@@ -1,0 +1,223 @@
+# BGP Mobile User Plane (MUP) and the MUP Controller
+
+zebra-rs implements **BGP Mobile User Plane** (BGP-MUP, SAFI 85) as
+specified in RFC 9833 / `draft-mpmz-bess-mup-safi`. BGP-MUP carries 5G
+mobile-backhaul session state in BGP so that a GTP-U tunnel between a
+mobile gateway and the radio access network can be stitched into an
+**SRv6** transport network — the GTP encap/decap happens at the SRv6
+edge instead of on a dedicated mobile gateway.
+
+There are four MUP route types:
+
+| Type | Name | Originated by |
+|---|---|---|
+| 1 | Interwork Segment Discovery (ISD) | MUP-GW / PE |
+| 2 | Direct Segment Discovery (DSD) | MUP-GW / PE |
+| 3 | Type-1 Session Transformed (T1ST) | **MUP Controller** |
+| 4 | Type-2 Session Transformed (T2ST) | **MUP Controller** |
+
+The **MUP Controller (MUP-C)** is the node that learns per-session
+mobile state — the UE address, the GTP-U TEID, the tunnel endpoint, the
+QoS flow — and turns each session into a **Session-Transformed** route
+(T1ST for the access/downlink side, T2ST for the core/uplink side). The
+draft leaves the controller's session source as an out-of-scope
+"northbound API"; zebra-rs uses **PFCP / N4** (3GPP TS 29.244) as that
+northbound and terminates it as a UP-node — an external SMF programs the
+controller exactly as it would a UPF.
+
+```
+   SMF ──PFCP/N4──▶ zebra-rs MUP-C ──BGP MUP (SAFI 85)──▶ SRv6 PEs
+ (sessions)          │ learns UE/TEID/NI                 (install
+                     │ originates T1ST/T2ST               forwarding)
+                     ▼
+             SRv6 End.DT4/DT6 SID  (from a locator)
+```
+
+The MUP control plane (capability negotiation, Loc-RIB, receive, and
+re-advertisement) is always present once the `mobile-uplane` AFI/SAFI is
+negotiated. The **controller** — the PFCP listener and route origination
+— is what the `mup-c` block below turns on.
+
+## Enabling the MUP capability
+
+`mobile-uplane` is a single AFI/SAFI knob that negotiates **both**
+IPv4-MUP (AFI 1) and IPv6-MUP (AFI 2). Enable it per neighbor like any
+other family:
+
+```
+router bgp {
+  global {
+    as 65001;
+    router-id 192.168.0.1;
+  }
+  neighbor 192.168.0.2 {
+    remote-as 65001;
+    afi-safi ipv4 {
+      enabled true;
+    }
+    afi-safi mobile-uplane {
+      enabled true;
+    }
+  }
+}
+```
+
+## Configuring the controller
+
+The controller lives under the **global** `mobile-uplane` AFI/SAFI. It
+needs three things: an SRv6 locator to carve per-session SIDs from, a
+per-VRF `mobile-uplane` service that maps a PFCP Network Instance to a
+Route Distinguisher / route-targets, and the `mup-c` block itself.
+
+```
+segment-routing {
+  locator LOC1 {
+    prefix fcbb:bb01::/48;
+  }
+}
+router bgp {
+  global {
+    as 65001;
+    router-id 192.168.0.1;
+  }
+  segment-routing {
+    srv6 {
+      locator LOC1;
+    }
+  }
+
+  # Map the PFCP Network Instance "access" to a VPN service: the RD
+  # stamped on the ST route and the route-targets it carries.
+  vrf mobile-up {
+    rd 65000:100;
+    mobile-uplane {
+      route-target {
+        export 65000:200;
+      }
+      srv6-mobile encapsulation {
+        network-instance exact access;
+      }
+    }
+  }
+
+  # Turn on the controller: the PFCP/N4 listener + route origination.
+  afi-safi mobile-uplane {
+    mup-c {
+      enable true;
+      controller-address fcbb:bb01::1;
+      pfcp {
+        listen-address 192.168.0.1;
+        port 8805;
+      }
+      srv6 {
+        locator LOC1;
+      }
+    }
+  }
+}
+```
+
+* **`enable true`** spawns the in-process controller. It is configured
+  under the BGP instance (not as a separate daemon) so that it is handed
+  the BGP instance's own channel, the same way a per-VRF BGP instance is
+  — route origination is a direct in-process call, not a cross-process
+  hop.
+* **`controller-address`** is the IPv6 address advertised as the next
+  hop on every originated ST route.
+* **`pfcp`** sets the N4 listener bind address and port (default
+  `[::]:8805`).
+* **`srv6 locator`** names the locator per-session SIDs are carved from
+  (the same pool an `encapsulation srv6` VRF draws its End.DT46 SID
+  from).
+
+The **`srv6-mobile`** direction in the VRF selects the route type:
+`encapsulation` (the N6 / downlink VRF) originates a **Type-1 ST** route
+carrying the UE prefix; `decapsulation` (the N3 / uplink VRF) originates
+a **Type-2 ST** route carrying the core endpoint and TEID. The
+`network-instance exact` value is matched against the PFCP session's
+Network Instance.
+
+## From PFCP session to ST route
+
+When an SMF establishes a session, the controller:
+
+1. extracts the UE IP address, the access-side F-TEID (TEID + GTP
+   endpoint), and the Network Instance from the PFCP Session
+   Establishment Request;
+2. correlates the Network Instance against the per-VRF `mobile-uplane`
+   config to find the RD, the route-targets, and the direction;
+3. allocates an **SRv6 service SID** (End.DT4 for an IPv4 UE, End.DT6
+   for IPv6) from the configured locator;
+4. originates the ST route into the MUP Loc-RIB with the
+   controller-address as next hop, the VRF's route-targets, and the SID
+   carried in the SRv6 L3 Service Prefix-SID attribute;
+5. advertises it to every `mobile-uplane` peer.
+
+A Session Deletion withdraws the route and returns the SID to the pool.
+
+## Showing MUP state
+
+`show bgp mobile-uplane` renders the configured per-VRF services and the
+MUP Loc-RIB:
+
+```
+# show bgp mobile-uplane
+MUP VRFs:
+  mobile-up: rd=65000:100 encap/ST1 ni=access route-targets=1
+
+   Network (MUP NLRI)                                   Next Hop
+ *> [ST1][65000:100][ue=192.0.2.5/32][teid=305419896][qfi=0][ep=10.0.0.1]
+       next-hop fcbb:bb01::1  weight 32768
+       RT:65000:200
+```
+
+`show bgp mobile-uplane mup-c` shows the controller status, and the
+`session` / `association` sub-commands show the learned PFCP state:
+
+```
+# show bgp mobile-uplane mup-c
+MUP controller (MUP-C)
+  Admin state : enabled
+  PFCP listen : 192.168.0.1:8805
+  Associations: 1
+  Sessions    : 1
+
+# show bgp mobile-uplane mup-c session
+SEID       UE address     TEID         Endpoint     QFI   Network-Instance
+1          192.0.2.5      0x12345678   10.0.0.1     -     access
+```
+
+`show bgp neighbor <addr>` reports the negotiated MUP capability:
+
+```
+  IPv4 MUP: advertised and received
+  IPv6 MUP: advertised and received
+```
+
+## Testing with `pfcp-inject`
+
+`tools/pfcp-inject` is a tiny PFCP/N4 SMF simulator used by the
+`@bgp_mup_e2e` BDD feature and for manual validation. It sends an
+Association Setup followed by a Session Establishment (and, with
+`--delete`, a Session Deletion) describing one mobile session:
+
+```
+pfcp-inject --target 192.168.0.1 --port 8805 \
+            --ue-ipv4 192.0.2.5 --teid 0x12345678 \
+            --endpoint 10.0.0.1 --network-instance access
+```
+
+After it runs, the session appears under `show bgp mobile-uplane mup-c
+session` and the controller's ST route appears in `show bgp
+mobile-uplane` on both the controller and its peers.
+
+## Scope and limitations
+
+The control plane — capability negotiation, ISD/DSD/T1ST/T2ST codec,
+Loc-RIB receive/store/show, and controller origination + advertisement —
+is complete. The forwarding plane (programming GTP4.E / GTP6.E
+behaviours into the kernel) is **not** implemented: stock Linux has no
+GTP-U SRv6 endpoint behaviour, so the data plane is left to a
+VPP/eBPF-based forwarder. The controller's PFCP northbound currently
+handles Association and Session lifecycle messages; heartbeat-driven
+eviction of idle associations is a follow-up.

--- a/docs/design/bgp-mup-followups.md
+++ b/docs/design/bgp-mup-followups.md
@@ -30,12 +30,15 @@ phases, committed and pushed (rebased onto `origin/main`):
 Tests on the rebased base: 342 `bgp-packet` + 1378 `zebra-rs`, fmt +
 workspace clippy clean.
 
+**P5 (the MUP Controller) is now built** over PR-A/B/C using a **PFCP/N4**
+northbound (not zenoh) — see the P5 section below. **P6 (the
+SRv6-mobile dataplane) remains the one large deferred phase.**
+
 The items below were consciously left out so each phase could ship as a
 small PR. None block the control-plane path for the common case
-(receive / store / show / re-advertise MUP routes between speakers).
-Each entry: **what / why deferred / where / suggested PR size**. The
-two large remaining phases (P5 controller, P6 dataplane) are at the end
-with their open design questions.
+(receive / store / show / re-advertise MUP routes between speakers, and
+controller origination). Each entry: **what / why deferred / where /
+suggested PR size**; several are now marked **DONE** by P5.
 
 Standing guidance still applies: smallest meaningful slice first, let
 the user redirect, one branch / one PR at a time.
@@ -121,19 +124,18 @@ mirror the EVPN LLGR two-branch.
 
 ## Show
 
-### 6. Full `MUP controller:` show block
+### 6. Full `MUP controller:` show block — **DONE (P5)**
 
-**What:** `show bgp mobile-uplane` renders the config-driven `MUP VRFs:`
-block (P3) + the route table (P2). The mockup's full wrapper — header
-`MUP controller: enabled`, the `zenoh source:` line, `ingested sessions`
-count, and the `vpnv6 ue-routes:` list — needs P5 controller state.
+`show bgp mobile-uplane mup-c [session|association]` now renders the
+controller runtime (admin state, PFCP listen address, association /
+session counts, and the per-session table) from the BGP-held
+`mup_c_view` the controller feeds over `Message::MupC`. The
+`zenoh source:` line is moot (the northbound is PFCP, not zenoh); the
+`vpnv6 ue-routes:` list was dropped (the ST routes carry the SRv6
+service directly). `show bgp mobile-uplane` still renders the `MUP VRFs:`
+block (P3) + the route table (P2), now populated by originated ST routes.
 
-**Why deferred:** Those lines describe controller runtime that doesn't
-exist until P5.
-
-**Where:** `show_bgp_mup` / `render_mup_vrfs` in `zebra-rs/src/bgp/show.rs`.
-
-**Size:** small once P5 state exists (~150 lines).
+**Where:** `show_bgp_mup_c*` / `render_mup_vrfs` in `zebra-rs/src/bgp/show.rs`.
 
 ### 7. `show bgp mobile-uplane` JSON output
 
@@ -237,22 +239,20 @@ implicit-replace semantics are required.
 
 ## Testing
 
-### 14. End-to-end receive-from-peer / RR BDD
+### 14. End-to-end originate → receive BDD — **DONE (P5/PR-C)**
 
-**What:** A multi-node BDD (originate on one speaker, receive +
-re-advertise + show on another) that exercises the full control plane on
-the wire.
+`bdd/tests/features/bgp_mup_e2e.feature` (`@bgp_mup_e2e`): the controller
+node (z1) is driven by `tools/pfcp-inject` (a PFCP SMF simulator that
+supplies the originator the harness otherwise lacks), originates the ST1
+route, and the peer (z2) receives it. The earlier
+`bgp_mup_capability.feature` covers session-up + capability negotiation.
+Both need root netns and are excluded from CI gates per
+[`zebra-rs-ci-and-merge-rules`](../../zebra-rs-ci-and-merge-rules.md) —
+run live (`make -C bdd bgp_mup_e2e`, with `pfcp-inject` staged on PATH).
+Remaining: a receive-from-peer / RR variant (a third node reflecting the
+ST route) is still worth adding.
 
-**Why deferred:** The BDD harness is zebra-rs↔zebra-rs (no GoBGP/ExaBGP
-injector), so an *originator* is required — and MUP origination is P5.
-`bdd/tests/features/bgp_mup_capability.feature` (session-up + capability
-negotiation) is authored but **not run** (needs root netns; BDD is
-excluded from CI gates per
-[`zebra-rs-ci-and-merge-rules`](../../zebra-rs-ci-and-merge-rules.md)).
-
-**Where:** `bdd/tests/`.
-
-**Size:** medium (lands with P5).
+**Where:** `bdd/tests/features/bgp_mup_e2e.feature`, `tools/pfcp-inject/`.
 
 ### 15. zebra-rs-level advertise integration test
 
@@ -270,35 +270,42 @@ Coverage today is compile + clippy-wiring + the `bgp-packet`
 
 ## The two remaining phases
 
-### P5 — MUP Controller (zenoh / PFCP)
+### P5 — MUP Controller (PFCP) — **BUILT**
 
-**What:** Subscribe to PFCP sessions over zenoh and originate, per
-session: an ST1 route (the `encapsulation` / N6 VRF), an ST2 route (the
-`decapsulation` / N3 VRF), and a VPNv6 UE route — each tagged with the
-VRF's `route-target export` and an SRv6 SID — plus the full
-`MUP controller:` show block (zenoh source, ingested-session count,
-originated-route count, `vpnv6 ue-routes`).
+Built over PR-A/B/C. The northbound is **PFCP / N4** (3GPP TS 29.244, via
+the `rs-pfcp` crate), not zenoh — the controller terminates N4 as a
+UP-node, so an external SMF programs it exactly as it would a UPF. The
+session schema question is therefore answered by PFCP itself (no custom
+zenoh encoding to design).
 
-**Open design questions (need operator input before building):**
-1. **Session schema** on the zenoh `pfcp/**` keys — encoding (JSON /
-   protobuf / custom) and fields (UE prefix, TEID, QFI, gNodeB endpoint,
-   source, network-instance, …). This is the blocker for the
-   session→route mapping.
-2. **`zenoh` crate** dependency + the `zenoh source tcp/<addr>:<port>` /
-   `prefix pfcp/**` config knobs (and a pinned version).
-3. **SID source** — where ST / VPNv6 SIDs come from (the mockup shows
-   `sid=fcbb:bb00:30:19::`, i.e. carved from a global `srv6 locator`
-   like the L3VPN End.DT46 path).
+* **Config home:** under the BGP instance at `router bgp afi-safi
+  mobile-uplane mup-c { enable; controller-address; pfcp {…}; srv6 {…} }`
+  — so the controller is spawned by the BGP task and handed its `Message`
+  channel, the way a per-VRF BGP instance is. Module: `zebra-rs/src/mup-c/`
+  (`inst` task, `pfcp` socket/handlers, `session`/`assoc` tables); spawn /
+  reconfigure / teardown in `Bgp::apply_mup_c_commit_diff`.
+* **PR-A (ingest):** PFCP listener (own tokio UDP socket); Association
+  Setup/Release, Heartbeat, Session Establishment/Modification/Deletion;
+  per-session table; `show bgp mobile-uplane mup-c [session|association]`.
+  Hardened (commit security review): session-ownership check on
+  Modify/Delete, association precondition on Establish, bounded tables.
+* **PR-B (origination):** `Bgp::originate_mup_route` correlates the
+  session's Network Instance → a per-VRF `mobile-uplane` config (RD /
+  route-targets / direction), allocates an SRv6 SID (`alloc_mup_sid`,
+  same pool as the L3VPN End.DT46 path), builds the ST NLRI
+  (`encapsulation`→T1ST UE prefix; `decapsulation`→T2ST endpoint+TEID)
+  and attributes (controller-address next hop, RT exports, SRv6 L3
+  Service Prefix-SID End.DT4/DT6), and originates via the P4 advertise
+  path. Tracked per session SEID for stable withdraw.
+* **PR-C (e2e):** `tools/pfcp-inject` (PFCP SMF simulator) + the
+  `@bgp_mup_e2e` BDD feature (#14). Live-validated end-to-end.
 
-**Recommended seam:** a `SessionSource` trait (zenoh is one impl) so the
-session→ST origination logic is unit-testable without standing up a
-zenoh bus. This also unblocks the end-to-end BDD (#14) using a synthetic
-source.
-
-**Where:** new module under `zebra-rs/src/bgp/`; origination reuses the
-P4 advertise path + the VPNv6 origination path.
-
-**Size:** large (multi-PR).
+**Deferred from P5:** the VPNv6 UE host route originally listed here was
+dropped — the ST routes carry the per-session SRv6 service directly.
+Heartbeat-driven eviction of idle PFCP associations and per-source rate
+limiting are follow-ups (the tables are bounded by hard caps today). The
+controller draws SIDs from the **global** resolved locator; honouring a
+distinct `mup-c srv6 locator` override is a small follow-up.
 
 ### P6 — SRv6-mobile dataplane
 
@@ -327,9 +334,10 @@ By value-per-line, if picking one up independently of P5/P6:
    first thing a real deployment with filtering will need.
 
 Larger items (#3 VRF import, #8 update-groups, #10 AddPath TX, #13
-strict route-key) should each gate on a concrete consumer — most of them
-naturally sequence after **P5**, which is the next real milestone (and
-needs the operator design input above before it can start).
+strict route-key) should each gate on a concrete consumer. With **P5
+built**, the next real milestone is **P6 (the SRv6-mobile dataplane)**;
+most of the larger items above now have a concrete consumer in the
+controller and can be picked up as deployments demand them.
 
 ## Cross-references
 

--- a/tools/pfcp-inject/Cargo.toml
+++ b/tools/pfcp-inject/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "pfcp-inject"
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+license.workspace = true
+description = "Minimal PFCP/N4 SMF simulator for driving the zebra-rs MUP controller in tests"
+
+[dependencies]
+anyhow.workspace = true
+clap.workspace = true
+rs-pfcp = "0.3.1"
+
+[lints]
+workspace = true

--- a/tools/pfcp-inject/src/main.rs
+++ b/tools/pfcp-inject/src/main.rs
@@ -1,0 +1,207 @@
+//! `pfcp-inject` — a minimal PFCP/N4 SMF simulator.
+//!
+//! Drives the zebra-rs BGP MUP controller (`router bgp afi-safi
+//! mobile-uplane mup-c`) in tests: it sends a PFCP Association Setup
+//! Request followed by a Session Establishment Request describing one
+//! mobile session (UE IP, access-side F-TEID, Network Instance), so the
+//! controller learns the session and originates a MUP Session-Transformed
+//! route. With `--delete` it also tears the session down again.
+//!
+//! It is intentionally tiny and synchronous — the `rs-pfcp` crate is a
+//! pure codec, and the only transport we need is a single blocking UDP
+//! socket. Used from the `@bgp_mup_e2e` BDD feature via
+//! `I execute "pfcp-inject …" in namespace "…"`, and runnable by hand
+//! against a locally-spawned controller.
+
+use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr, UdpSocket};
+use std::time::{Duration, SystemTime};
+
+use anyhow::{Context, Result, bail};
+use clap::Parser;
+
+use rs_pfcp::ie::IeType;
+use rs_pfcp::ie::create_far::CreateFar;
+use rs_pfcp::ie::create_pdr::CreatePdrBuilder;
+use rs_pfcp::ie::destination_interface::Interface;
+use rs_pfcp::ie::f_teid::FteidBuilder;
+use rs_pfcp::ie::far_id::FarId;
+use rs_pfcp::ie::fseid::Fseid;
+use rs_pfcp::ie::network_instance::NetworkInstance;
+use rs_pfcp::ie::pdi::PdiBuilder;
+use rs_pfcp::ie::pdr_id::PdrId;
+use rs_pfcp::ie::precedence::Precedence;
+use rs_pfcp::ie::source_interface::{SourceInterface, SourceInterfaceValue};
+use rs_pfcp::ie::ue_ip_address::UeIpAddress;
+use rs_pfcp::message::association_setup_request::AssociationSetupRequestBuilder;
+use rs_pfcp::message::session_deletion_request::SessionDeletionRequestBuilder;
+use rs_pfcp::message::session_establishment_request::SessionEstablishmentRequestBuilder;
+use rs_pfcp::message::{self, Message, MsgType};
+
+#[derive(Parser, Debug)]
+#[command(
+    author,
+    version,
+    about = "Minimal PFCP/N4 SMF simulator for the zebra-rs MUP controller"
+)]
+struct Args {
+    /// Controller PFCP listener address.
+    #[arg(long)]
+    target: IpAddr,
+
+    /// Controller PFCP listener port.
+    #[arg(long, default_value_t = 8805)]
+    port: u16,
+
+    /// Our (the SMF's) PFCP Node ID.
+    #[arg(long, default_value = "10.0.0.99")]
+    node_id: IpAddr,
+
+    /// UE IPv4 address assigned to the session.
+    #[arg(long)]
+    ue_ipv4: Option<Ipv4Addr>,
+
+    /// UE IPv6 address assigned to the session.
+    #[arg(long)]
+    ue_ipv6: Option<Ipv6Addr>,
+
+    /// Access-side GTP-U TEID (decimal, or `0x`-prefixed hex).
+    #[arg(long, default_value_t = 0x1234_5678, value_parser = parse_u32)]
+    teid: u32,
+
+    /// Access-side GTP-U endpoint (F-TEID) address.
+    #[arg(long, default_value = "10.0.0.1")]
+    endpoint: IpAddr,
+
+    /// Network Instance (APN/DNN) — matched against a VRF `mobile-uplane`
+    /// config on the controller.
+    #[arg(long, default_value = "access")]
+    network_instance: String,
+
+    /// CP-side F-SEID we advertise in the Session Establishment Request.
+    #[arg(long, default_value_t = 1)]
+    seid: u64,
+
+    /// Also delete the session after establishing it.
+    #[arg(long, default_value_t = false)]
+    delete: bool,
+
+    /// Per-exchange receive timeout (seconds).
+    #[arg(long, default_value_t = 3)]
+    timeout: u64,
+}
+
+/// Parse a `u32` accepting either decimal or a `0x`-prefixed hex string.
+fn parse_u32(s: &str) -> std::result::Result<u32, String> {
+    let s = s.trim();
+    let parsed = match s.strip_prefix("0x").or_else(|| s.strip_prefix("0X")) {
+        Some(hex) => u32::from_str_radix(hex, 16),
+        None => s.parse::<u32>(),
+    };
+    parsed.map_err(|e| format!("invalid u32 `{s}`: {e}"))
+}
+
+fn main() -> Result<()> {
+    let args = Args::parse();
+    if args.ue_ipv4.is_none() && args.ue_ipv6.is_none() {
+        bail!("at least one of --ue-ipv4 / --ue-ipv6 is required");
+    }
+
+    let dst = SocketAddr::new(args.target, args.port);
+    let bind: SocketAddr = match args.target {
+        IpAddr::V4(_) => "0.0.0.0:0".parse().unwrap(),
+        IpAddr::V6(_) => "[::]:0".parse().unwrap(),
+    };
+    let sock = UdpSocket::bind(bind).context("bind UDP socket")?;
+    sock.set_read_timeout(Some(Duration::from_secs(args.timeout)))?;
+    sock.connect(dst)
+        .with_context(|| format!("connect {dst}"))?;
+
+    // 1. Association Setup.
+    let assoc = AssociationSetupRequestBuilder::new(1u32)
+        .node_id(args.node_id)
+        .recovery_time_stamp(SystemTime::now())
+        .build();
+    let resp = exchange(&sock, &assoc.marshal(), "Association Setup")?;
+    expect_type(&resp, MsgType::AssociationSetupResponse)?;
+    println!("pfcp-inject: association established with {dst}");
+
+    // 2. Session Establishment.
+    let fteid = {
+        let b = FteidBuilder::new().teid(args.teid);
+        match args.endpoint {
+            IpAddr::V4(v4) => b.ipv4(v4),
+            IpAddr::V6(v6) => b.ipv6(v6),
+        }
+        .build()
+        .context("build F-TEID")?
+    };
+    let pdi = PdiBuilder::new(SourceInterface::new(SourceInterfaceValue::Access))
+        .f_teid(fteid)
+        .ue_ip_address(UeIpAddress::new(args.ue_ipv4, args.ue_ipv6))
+        .network_instance(NetworkInstance::new(&args.network_instance))
+        .build()
+        .context("build PDI")?;
+    let pdr = CreatePdrBuilder::new(PdrId::new(1))
+        .precedence(Precedence::new(100))
+        .pdi(pdi)
+        .far_id(FarId::new(1))
+        .build()
+        .context("build Create PDR")?;
+    let far = CreateFar::builder(FarId::new(1))
+        .forward_to(Interface::Core)
+        .build()
+        .context("build Create FAR")?;
+    let establish = SessionEstablishmentRequestBuilder::new(args.seid, 2u32)
+        .node_id(args.node_id)
+        .fseid(args.seid, args.node_id)
+        .create_pdrs(vec![pdr.to_ie()])
+        .create_fars(vec![far.to_ie()])
+        .build()
+        .context("build Session Establishment Request")?;
+    let resp = exchange(&sock, &establish.marshal(), "Session Establishment")?;
+    expect_type(&resp, MsgType::SessionEstablishmentResponse)?;
+    // The controller returns its local SEID in the F-SEID; the CP must
+    // use it as the message SEID when addressing this session later.
+    let up_seid = fseid_of(&resp).unwrap_or(args.seid);
+    println!(
+        "pfcp-inject: session established (UP F-SEID 0x{up_seid:016x}) ni={} teid=0x{:08x}",
+        args.network_instance, args.teid
+    );
+
+    // 3. Optional Session Deletion.
+    if args.delete {
+        let del = SessionDeletionRequestBuilder::new(up_seid, 3u32).build();
+        let resp = exchange(&sock, &del.marshal(), "Session Deletion")?;
+        expect_type(&resp, MsgType::SessionDeletionResponse)?;
+        println!("pfcp-inject: session 0x{up_seid:016x} deleted");
+    }
+
+    Ok(())
+}
+
+/// Send one request and read the matching response.
+fn exchange(sock: &UdpSocket, req: &[u8], what: &str) -> Result<Vec<u8>> {
+    sock.send(req).with_context(|| format!("send {what}"))?;
+    let mut buf = vec![0u8; 65535];
+    let n = sock
+        .recv(&mut buf)
+        .with_context(|| format!("no {what} response (timeout?)"))?;
+    buf.truncate(n);
+    Ok(buf)
+}
+
+/// Parse a response and assert its message type.
+fn expect_type(bytes: &[u8], want: MsgType) -> Result<()> {
+    let msg = message::parse(bytes).context("parse PFCP response")?;
+    if msg.msg_type() != want {
+        bail!("expected {want:?}, got {:?}", msg.msg_type());
+    }
+    Ok(())
+}
+
+/// Extract the F-SEID (the controller's UP SEID) from a response.
+fn fseid_of(bytes: &[u8]) -> Option<u64> {
+    let msg = message::parse(bytes).ok()?;
+    let ie = msg.ies(IeType::Fseid).next()?;
+    Some(Fseid::unmarshal(&ie.payload).ok()?.seid.value())
+}

--- a/zebra-rs/Cargo.toml
+++ b/zebra-rs/Cargo.toml
@@ -76,6 +76,7 @@ md-5 = "0.11"
 sha1 = "0.11"
 sha2 = "0.11"
 hmac = "0.13"
+rs-pfcp = "0.3.1"
 
 [target.'cfg(target_os = "linux")'.dependencies]
 rtnetlink = { git = "https://github.com/zebra-rs/rtnetlink", rev = "2d7b1830e9bd9a049a757f0a79ccd16216450bf2" }

--- a/zebra-rs/src/bgp/config.rs
+++ b/zebra-rs/src/bgp/config.rs
@@ -1541,6 +1541,114 @@ fn config_segmentation(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Option<()
     Some(())
 }
 
+// --- MUP controller config (afi-safi mobile-uplane mup-c) -------------
+//
+// `router bgp afi-safi mobile-uplane mup-c { enable; controller-address;
+// pfcp { node-id; listen-address; port }; srv6 { locator }; architecture }`
+// (augmented in by zebra-bgp-mup-controller.yang). Every callback gates on
+// the list entry's afi-safi being `mobile-uplane` (Safi::Mup) and mutates
+// the staged `mup_c_config`, marking it dirty. The spawn / teardown /
+// reconfigure of the controller task happens at CommitEnd in
+// `Bgp::apply_mup_c_commit_diff` — these only stage config.
+
+/// `… mup-c enable <bool>` — the controller master switch.
+fn config_mup_c_enable(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Option<()> {
+    let afi_safi: AfiSafi = args.afi_safi()?;
+    if afi_safi.safi != Safi::Mup {
+        return None;
+    }
+    let enabled = if op.is_set() { args.boolean()? } else { false };
+    bgp.mup_c_config.enable = enabled;
+    bgp.mup_c_dirty = true;
+    Some(())
+}
+
+/// `… mup-c controller-address <ipv6>` — next-hop on originated ST routes.
+fn config_mup_c_controller_address(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Option<()> {
+    let afi_safi: AfiSafi = args.afi_safi()?;
+    if afi_safi.safi != Safi::Mup {
+        return None;
+    }
+    bgp.mup_c_config.controller_address = if op.is_set() {
+        Some(args.v6addr()?)
+    } else {
+        None
+    };
+    bgp.mup_c_dirty = true;
+    Some(())
+}
+
+/// `… mup-c pfcp node-id <ip>` — our PFCP Node ID for responses.
+fn config_mup_c_pfcp_node_id(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Option<()> {
+    let afi_safi: AfiSafi = args.afi_safi()?;
+    if afi_safi.safi != Safi::Mup {
+        return None;
+    }
+    bgp.mup_c_config.node_id = if op.is_set() {
+        Some(args.addr()?)
+    } else {
+        None
+    };
+    bgp.mup_c_dirty = true;
+    Some(())
+}
+
+/// `… mup-c pfcp listen-address <ip>` — PFCP bind address (default `::`).
+fn config_mup_c_pfcp_listen_address(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Option<()> {
+    let afi_safi: AfiSafi = args.afi_safi()?;
+    if afi_safi.safi != Safi::Mup {
+        return None;
+    }
+    bgp.mup_c_config.listen_address = if op.is_set() {
+        Some(args.addr()?)
+    } else {
+        None
+    };
+    bgp.mup_c_dirty = true;
+    Some(())
+}
+
+/// `… mup-c pfcp port <0-65535>` — PFCP bind port (default 8805).
+fn config_mup_c_pfcp_port(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Option<()> {
+    let afi_safi: AfiSafi = args.afi_safi()?;
+    if afi_safi.safi != Safi::Mup {
+        return None;
+    }
+    bgp.mup_c_config.port = if op.is_set() { Some(args.u16()?) } else { None };
+    bgp.mup_c_dirty = true;
+    Some(())
+}
+
+/// `… mup-c srv6 locator <name>` — locator SIDs are drawn from (route phase).
+fn config_mup_c_srv6_locator(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Option<()> {
+    let afi_safi: AfiSafi = args.afi_safi()?;
+    if afi_safi.safi != Safi::Mup {
+        return None;
+    }
+    bgp.mup_c_config.locator = if op.is_set() {
+        Some(args.string()?)
+    } else {
+        None
+    };
+    bgp.mup_c_dirty = true;
+    Some(())
+}
+
+/// `… mup-c architecture <enum>` — mobile architecture (informational).
+fn config_mup_c_architecture(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Option<()> {
+    let afi_safi: AfiSafi = args.afi_safi()?;
+    if afi_safi.safi != Safi::Mup {
+        return None;
+    }
+    bgp.mup_c_config.architecture = if op.is_set() {
+        Some(args.string()?)
+    } else {
+        None
+    };
+    bgp.mup_c_dirty = true;
+    Some(())
+}
+
 /// Re-originate every per-VNI Type-3 IMET route so a changed Assisted
 /// Replication role / AR-IP is reflected in the PMSI Tunnel attribute and
 /// next hop. `evpn_originate_imet` replaces the existing Originated path
@@ -3916,6 +4024,35 @@ impl Bgp {
         // `router bgp afi-safi evpn segmentation`. When set, the Multicast
         // Flags EC's segmentation bit rides the originated Type-3 IMET route.
         self.callback_add("/router/bgp/afi-safi/segmentation", config_segmentation);
+
+        // MUP controller (`afi-safi mobile-uplane mup-c …`, RFC 9833).
+        // Augmented in by zebra-bgp-mup-controller.yang; the controller
+        // task is spawned/torn down at CommitEnd by `apply_mup_c_commit_diff`.
+        self.callback_add("/router/bgp/afi-safi/mup-c/enable", config_mup_c_enable);
+        self.callback_add(
+            "/router/bgp/afi-safi/mup-c/controller-address",
+            config_mup_c_controller_address,
+        );
+        self.callback_add(
+            "/router/bgp/afi-safi/mup-c/pfcp/node-id",
+            config_mup_c_pfcp_node_id,
+        );
+        self.callback_add(
+            "/router/bgp/afi-safi/mup-c/pfcp/listen-address",
+            config_mup_c_pfcp_listen_address,
+        );
+        self.callback_add(
+            "/router/bgp/afi-safi/mup-c/pfcp/port",
+            config_mup_c_pfcp_port,
+        );
+        self.callback_add(
+            "/router/bgp/afi-safi/mup-c/srv6/locator",
+            config_mup_c_srv6_locator,
+        );
+        self.callback_add(
+            "/router/bgp/afi-safi/mup-c/architecture",
+            config_mup_c_architecture,
+        );
 
         // EVPN Assisted Replication role + AR-IP (RFC 9574), under
         // `router bgp afi-safi evpn assisted-replication`. Augmented in by

--- a/zebra-rs/src/bgp/inst.rs
+++ b/zebra-rs/src/bgp/inst.rs
@@ -649,6 +649,11 @@ pub struct Bgp {
     /// commit; consumed (and cleared) at `CommitEnd` to decide whether to
     /// reconfigure a running controller.
     pub mup_c_dirty: bool,
+    /// MUP routes the controller has originated, keyed by session SEID →
+    /// (originated NLRI, allocated SRv6 SID function). Tracked so a
+    /// Session Deletion / Modification withdraws the exact prior route and
+    /// returns its SID function to the pool.
+    pub mup_c_originated: BTreeMap<u64, (bgp_packet::MupPrefix, u16)>,
     /// Local bridge FDB shadow keyed by `(vni, mac)`. Populated from
     /// every `RibRx::FdbAdd`, removed on `RibRx::FdbDel`. We need
     /// durable state (not just one-shot event handling) because the
@@ -1088,6 +1093,7 @@ impl Bgp {
             mup_c: None,
             mup_c_view: crate::mup_c::inst::MupCView::default(),
             mup_c_dirty: false,
+            mup_c_originated: BTreeMap::new(),
             local_fdb: BTreeMap::new(),
             local_vxlans: BTreeMap::new(),
             local_smet: BTreeMap::new(),
@@ -1966,9 +1972,29 @@ impl Bgp {
             }
             Message::MupC(ev) => {
                 // A session/association change from the in-process MUP
-                // controller. Record it in the read-only view that
-                // `show bgp mobile-uplane mup-c` renders. MUP route
-                // origination from these events lands in a follow-up.
+                // controller. Drive MUP route origination, then record it
+                // in the read-only view `show bgp mobile-uplane mup-c`
+                // renders.
+                use crate::mup_c::inst::MupCEvent;
+                match &ev {
+                    MupCEvent::SessionUp(session) => self.originate_mup_route(session),
+                    MupCEvent::SessionDown { seid } => self.withdraw_mup_route(*seid),
+                    MupCEvent::AssocDown { peer } => {
+                        // The peer's sessions are about to drop from the
+                        // view; withdraw their routes first.
+                        let seids: Vec<u64> = self
+                            .mup_c_view
+                            .sessions
+                            .iter()
+                            .filter(|(_, s)| s.peer == *peer)
+                            .map(|(seid, _)| *seid)
+                            .collect();
+                        for seid in seids {
+                            self.withdraw_mup_route(seid);
+                        }
+                    }
+                    MupCEvent::Listener { .. } | MupCEvent::AssocUp { .. } => {}
+                }
                 self.mup_c_view.apply(ev);
             }
             Message::Relisten => {

--- a/zebra-rs/src/bgp/inst.rs
+++ b/zebra-rs/src/bgp/inst.rs
@@ -117,6 +117,13 @@ pub enum Message {
         add: Vec<(bgp_packet::BgpLsNlri, bgp_packet::BgpLsAttr)>,
         withdraw: Vec<bgp_packet::BgpLsNlri>,
     },
+    /// A session/association change reported by the in-process MUP
+    /// controller (`src/mup-c/`), which the BGP task spawns when
+    /// `afi-safi mobile-uplane mup-c enable true` is committed and hands
+    /// `self.tx`. Recorded in [`Bgp::mup_c_view`] for `show bgp
+    /// mobile-uplane mup-c`; MUP route origination from these lands in a
+    /// follow-up. Mirrors the IS-IS `BgpLs` producer seam.
+    MupC(crate::mup_c::inst::MupCEvent),
     /// `router bgp port <0-65535>` changed: close the BGP listen
     /// sockets and reopen them on the (new) configured port — or leave
     /// them closed when the port is 0. Sent by the config callback
@@ -627,6 +634,21 @@ pub struct Bgp {
     /// `evpn_originate_imet`; toggling it re-originates all IMET routes via
     /// `reoriginate_all_imet`.
     pub segmentation: bool,
+    /// MUP controller (`afi-safi mobile-uplane mup-c`) config, staged by
+    /// the config callbacks and applied at `CommitEnd` by
+    /// [`Self::apply_mup_c_commit_diff`].
+    pub mup_c_config: crate::mup_c::inst::MupCConfig,
+    /// Running MUP controller handle, or `None` when disabled. Dropping it
+    /// aborts the controller task (the VRF-handle idiom).
+    pub mup_c: Option<crate::mup_c::inst::MupCHandle>,
+    /// Read-only snapshot of the controller's sessions / associations,
+    /// fed by `Message::MupC` and rendered by `show bgp mobile-uplane
+    /// mup-c`.
+    pub mup_c_view: crate::mup_c::inst::MupCView,
+    /// Set by the MUP-C config callbacks when a `mup-c` leaf changed this
+    /// commit; consumed (and cleared) at `CommitEnd` to decide whether to
+    /// reconfigure a running controller.
+    pub mup_c_dirty: bool,
     /// Local bridge FDB shadow keyed by `(vni, mac)`. Populated from
     /// every `RibRx::FdbAdd`, removed on `RibRx::FdbDel`. We need
     /// durable state (not just one-shot event handling) because the
@@ -1062,6 +1084,10 @@ impl Bgp {
             advertise_all_vni: false,
             igmp_mld_proxy: false,
             segmentation: false,
+            mup_c_config: crate::mup_c::inst::MupCConfig::default(),
+            mup_c: None,
+            mup_c_view: crate::mup_c::inst::MupCView::default(),
+            mup_c_dirty: false,
             local_fdb: BTreeMap::new(),
             local_vxlans: BTreeMap::new(),
             local_smet: BTreeMap::new(),
@@ -1938,6 +1964,13 @@ impl Bgp {
                     );
                 }
             }
+            Message::MupC(ev) => {
+                // A session/association change from the in-process MUP
+                // controller. Record it in the read-only view that
+                // `show bgp mobile-uplane mup-c` renders. MUP route
+                // origination from these events lands in a follow-up.
+                self.mup_c_view.apply(ev);
+            }
             Message::Relisten => {
                 // Intercepted in `event_loop` before this dispatcher
                 // (the rebind is async, this method is not). Nothing to
@@ -2133,6 +2166,41 @@ impl Bgp {
         self.broadcast_colour_steering();
     }
 
+    /// Reconcile the MUP controller against `mup_c_config` at every
+    /// `CommitEnd`. Spawn on enable, tear down on disable (dropping the
+    /// handle aborts the task), and push a reconfigure when a `mup-c`
+    /// leaf changed while it stays enabled. The controller is handed
+    /// `self.tx` — the BGP Message channel — exactly the way a per-VRF
+    /// instance receives the global channel from `spawn_bgp_vrf`.
+    fn apply_mup_c_commit_diff(&mut self) {
+        let want = self.mup_c_config.enable;
+        let running = self.mup_c.is_some();
+        let dirty = std::mem::take(&mut self.mup_c_dirty);
+        match (want, running) {
+            (true, false) => {
+                let handle = crate::mup_c::inst::spawn(
+                    self.mup_c_config.clone(),
+                    self.tx.clone(),
+                    self.ctx.clone(),
+                );
+                self.mup_c = Some(handle);
+            }
+            (false, true) => {
+                // Drop the handle → abort the controller task. Reset the
+                // view so `show` reflects the teardown. (Route withdrawal
+                // for originated MUP routes lands with the route phase.)
+                self.mup_c = None;
+                self.mup_c_view = crate::mup_c::inst::MupCView::default();
+            }
+            (true, true) if dirty => {
+                if let Some(handle) = &self.mup_c {
+                    handle.reconfig(self.mup_c_config.clone());
+                }
+            }
+            _ => {}
+        }
+    }
+
     /// Called when `RibRx::VrfAdd` for `name` arrives. If a
     /// placeholder per-VRF task is already running for this name,
     /// tear it down and respawn it with the real
@@ -2224,6 +2292,7 @@ impl Bgp {
                 // cfg-hash comparison on top.
                 super::vrf_config::log_commit_diff(self);
                 self.apply_vrf_commit_diff();
+                self.apply_mup_c_commit_diff();
             }
             ConfigOp::Completion => {
                 // `comps_dynamic` carries the dynamic handler name

--- a/zebra-rs/src/bgp/route.rs
+++ b/zebra-rs/src/bgp/route.rs
@@ -7405,6 +7405,72 @@ pub fn route_withdraw_mup_to_peers(prefix: MupPrefix, peers: &mut PeerMap) {
     }
 }
 
+/// Build a Route-Target extended community from a stored Route
+/// Distinguisher. An RT shares the RD's 8-octet wire format — the RD
+/// type becomes the EC high-order type and the low-order type is `0x02`
+/// (Route Target) — so the per-VRF `mobile-uplane route-target export`
+/// set (stored as `RouteDistinguisher`s) maps straight through.
+fn rd_route_target(rd: &RouteDistinguisher) -> ExtCommunityValue {
+    ExtCommunityValue {
+        high_type: rd.typ as u8,
+        low_type: 0x02,
+        val: rd.val,
+    }
+}
+
+/// UE host prefix (/32 or /128) for a session, preferring IPv4 — the
+/// prefix carried in a Type-1 Session-Transformed route.
+fn mup_ue_prefix(session: &crate::mup_c::session::MupSession) -> Option<IpNet> {
+    if let Some(v4) = session.ue_ipv4 {
+        Ipv4Net::new(v4, 32).ok().map(IpNet::V4)
+    } else if let Some(v6) = session.ue_ipv6 {
+        Ipv6Net::new(v6, 128).ok().map(IpNet::V6)
+    } else {
+        None
+    }
+}
+
+/// End.DT4 / End.DT6 / End.DT46 SRv6 behaviour for a session's UE address
+/// family.
+fn mup_sid_behavior(session: &crate::mup_c::session::MupSession) -> u16 {
+    match (session.ue_ipv4.is_some(), session.ue_ipv6.is_some()) {
+        (true, false) => bgp_packet::SRV6_BEHAVIOR_END_DT4,
+        (false, true) => bgp_packet::SRV6_BEHAVIOR_END_DT6,
+        _ => bgp_packet::SRV6_BEHAVIOR_END_DT46,
+    }
+}
+
+/// Build the attributes for a controller-originated MUP ST route: the
+/// controller next-hop (carried in MP_REACH), the VRF's route-target
+/// exports, and the SRv6 L3 Service SID (RFC 9252 Prefix-SID).
+fn build_mup_attr(
+    controller: Option<std::net::Ipv6Addr>,
+    rts: &std::collections::BTreeSet<RouteDistinguisher>,
+    sid: std::net::Ipv6Addr,
+    behavior: u16,
+) -> BgpAttr {
+    let mut attr = BgpAttr::new();
+    if let Some(addr) = controller {
+        attr.nexthop = Some(BgpNexthop::Ipv6(addr));
+    }
+    if !rts.is_empty() {
+        let mut ecom = ExtCommunity(std::collections::BTreeSet::new());
+        for rd in rts {
+            ecom.0.insert(rd_route_target(rd));
+        }
+        attr.ecom = Some(ecom);
+    }
+    attr.prefix_sid = Some(bgp_packet::PrefixSid {
+        tlvs: vec![bgp_packet::PrefixSidTlv::Srv6L3Service(
+            bgp_packet::Srv6ServiceTlv {
+                sids: vec![bgp_packet::Srv6SidInfo::new(sid, 0, behavior, None)],
+                ..Default::default()
+            },
+        )],
+    });
+    attr
+}
+
 /// Replay every selected MUP route from the Loc-RIB to a peer that just
 /// reached Established, for whichever MUP AFI(s) it negotiated, then send
 /// the MUP End-of-RIB per negotiated AFI. Without this a route learned
@@ -12158,6 +12224,163 @@ pub fn route_sync(peer: &mut Peer, bgp: &mut BgpTop, v4_via_pool: bool) {
 }
 
 impl Bgp {
+    /// Originate (or re-originate) a MUP Session-Transformed route for one
+    /// controller-learned session. Correlates the session's Network
+    /// Instance to a `router bgp vrf <name> mobile-uplane` config,
+    /// allocates an SRv6 service SID from the locator, builds the ST route
+    /// with its attributes, installs into the MUP Loc-RIB as `Originated`,
+    /// and advertises. A prior route for the same session is withdrawn
+    /// first, so a Session Modification cleanly replaces it. No-op when no
+    /// VRF matches the NI, the VRF has no RD, or no SRv6 SID is available.
+    pub fn originate_mup_route(&mut self, session: &crate::mup_c::session::MupSession) {
+        // Replace any prior route for this session (Modification path).
+        self.withdraw_mup_route(session.seid);
+
+        let Some((prefix, function, attr)) = self.build_mup_origination(session) else {
+            return;
+        };
+        let mut rib = BgpRib::new(
+            ORIGINATED_PEER,
+            Ipv4Addr::UNSPECIFIED,
+            BgpRibType::Originated,
+            0,
+            32768,
+            &attr,
+            None,
+            None,
+            false,
+        );
+        rib.attr = self.attr_store.intern(attr);
+        let _ = self.local_rib.update_mup(prefix.clone(), rib);
+        let selected = self.local_rib.select_best_path_mup(&prefix);
+        self.mup_c_originated
+            .insert(session.seid, (prefix.clone(), function));
+        self.mup_apply_selected(prefix, selected);
+    }
+
+    /// Withdraw the MUP route originated for `seid` (Session Deletion or
+    /// the replace step of a Modification), returning its SRv6 SID
+    /// function to the pool. No-op when nothing was originated.
+    pub fn withdraw_mup_route(&mut self, seid: u64) {
+        let Some((prefix, function)) = self.mup_c_originated.remove(&seid) else {
+            return;
+        };
+        self.srv6_sid_pool.release(function);
+        self.local_rib.remove_mup(&prefix, 0, ORIGINATED_PEER);
+        let selected = self.local_rib.select_best_path_mup(&prefix);
+        self.mup_apply_selected(prefix, selected);
+    }
+
+    /// Correlate a session to a VRF `mobile-uplane` config and build the
+    /// ST prefix + attributes + allocated SID function. Returns `None`
+    /// (releasing any SID it took) when the session can't be originated.
+    fn build_mup_origination(
+        &mut self,
+        session: &crate::mup_c::session::MupSession,
+    ) -> Option<(bgp_packet::MupPrefix, u16, BgpAttr)> {
+        use super::vrf_config::MupSrv6Direction;
+        let ni = session.network_instance.as_deref()?;
+        // Owned copies so the immutable `vrfs` borrow ends before the
+        // mutable SID allocation below.
+        let (rd, rts, direction) = self.vrfs.values().find_map(|cfg| {
+            let sm = cfg.mobile_uplane.srv6_mobile.as_ref()?;
+            (sm.network_instance.as_deref() == Some(ni)).then(|| {
+                (
+                    cfg.rd,
+                    cfg.mobile_uplane.route_target_export.clone(),
+                    sm.direction,
+                )
+            })
+        })?;
+        let rd = rd?;
+        let (sid, function) = self.alloc_mup_sid()?;
+        let prefix = match direction {
+            // Encapsulation (N6 / downlink): Type-1 ST carries the UE
+            // prefix + access tunnel.
+            MupSrv6Direction::Encapsulation => match (mup_ue_prefix(session), session.endpoint) {
+                (Some(prefix), Some(endpoint)) => bgp_packet::MupPrefix::T1st {
+                    rd,
+                    prefix,
+                    teid: session.teid,
+                    qfi: session.qfi.unwrap_or(0),
+                    endpoint,
+                    source: None,
+                },
+                _ => {
+                    self.srv6_sid_pool.release(function);
+                    return None;
+                }
+            },
+            // Decapsulation (N3 / uplink): Type-2 ST carries the core
+            // endpoint + TEID.
+            MupSrv6Direction::Decapsulation => match session.endpoint {
+                Some(endpoint) => bgp_packet::MupPrefix::T2st {
+                    rd,
+                    endpoint,
+                    endpoint_len: if endpoint.is_ipv4() { 32 } else { 128 },
+                    teid: session.teid,
+                },
+                None => {
+                    self.srv6_sid_pool.release(function);
+                    return None;
+                }
+            },
+        };
+        let attr = build_mup_attr(
+            self.mup_c_config.controller_address,
+            &rts,
+            sid,
+            mup_sid_behavior(session),
+        );
+        Some((prefix, function, attr))
+    }
+
+    /// Allocate an SRv6 service SID from the resolved BGP locator (the
+    /// same source `encapsulation srv6` VRFs draw End.DT46 from). Returns
+    /// the full SID address and its function, or `None` when no locator
+    /// has resolved or the function band is exhausted.
+    fn alloc_mup_sid(&mut self) -> Option<(std::net::Ipv6Addr, u16)> {
+        let prefix = self.srv6_locator.as_ref().and_then(|l| l.prefix)?;
+        let function = self.srv6_sid_pool.allocate()?;
+        match crate::isis::srv6::function_addr(prefix, function) {
+            Some(addr) => Some((addr, function)),
+            None => {
+                self.srv6_sid_pool.release(function);
+                None
+            }
+        }
+    }
+
+    /// Apply the post-update best path of one MUP prefix to peers:
+    /// advertise the new best, or withdraw when no path remains.
+    fn mup_apply_selected(&mut self, prefix: bgp_packet::MupPrefix, selected: Vec<BgpRib>) {
+        if selected.is_empty() {
+            route_withdraw_mup_to_peers(prefix, &mut self.peers);
+            return;
+        }
+        let mut bgp_ref = BgpTop {
+            router_id: &self.router_id,
+            srv6_ipv6_export: self.srv6_ipv6_export.as_ref(),
+            local_rib: &mut self.local_rib,
+            shard: &mut self.shard,
+            tx: &self.tx,
+            rib_client: &self.ctx.rib,
+            attr_store: &mut self.attr_store,
+            update_groups: &mut self.update_groups,
+            interface_addrs: &self.interface_addrs,
+            vrf_export: None,
+            color_policy: Some(&self.color_policy),
+            flex_algo_routes: Some(&self.flex_algo_routes),
+            flex_algo_srv6_routes: Some(&self.flex_algo_srv6_routes),
+            vrf_import: None,
+            nexthop_cache: None,
+            vrf_transport_v4: None,
+            vrf_transport_v6: None,
+            central_label_alloc: None,
+        };
+        route_advertise_mup_to_peers(prefix, &selected, &mut bgp_ref, &mut self.peers);
+    }
+
     pub fn route_add(&mut self, prefix: Ipv4Net) {
         // N>1: originate through the pool so the pool owns the row — its
         // session-up `DumpV4` sync, the reduce's event-driven advertise, and
@@ -16549,6 +16772,100 @@ mod tests {
     // FIB install translation: `make_bgp_rib_entry_v4` produces an
     // installable RibEntry only when the BGP best-path has a usable
     // IPv4 next-hop. The four cases below cover the decision matrix.
+
+    // --- MUP controller origination helpers ------------------------------
+
+    #[test]
+    fn mup_origination_helpers_build_st_prefix_and_attrs() {
+        use std::collections::BTreeSet;
+        use std::net::Ipv6Addr;
+
+        use bgp_packet::RouteDistinguisher;
+
+        fn session(
+            v4: Option<Ipv4Addr>,
+            v6: Option<Ipv6Addr>,
+        ) -> crate::mup_c::session::MupSession {
+            crate::mup_c::session::MupSession {
+                seid: 1,
+                peer: "10.0.0.2:8805".parse().unwrap(),
+                ue_ipv4: v4,
+                ue_ipv6: v6,
+                teid: 0x1234,
+                endpoint: Some("10.0.0.1".parse().unwrap()),
+                network_instance: Some("internet.apn".to_string()),
+                qfi: Some(9),
+            }
+        }
+
+        let v4: Ipv4Addr = "192.0.2.5".parse().unwrap();
+        let v6: Ipv6Addr = "2001:db8::5".parse().unwrap();
+
+        // UE host prefix: /32 for v4, /128 for v6, prefer v4, None when absent.
+        assert_eq!(
+            super::mup_ue_prefix(&session(Some(v4), None)),
+            "192.0.2.5/32".parse::<ipnet::IpNet>().ok()
+        );
+        assert_eq!(
+            super::mup_ue_prefix(&session(None, Some(v6))),
+            "2001:db8::5/128".parse::<ipnet::IpNet>().ok()
+        );
+        assert_eq!(super::mup_ue_prefix(&session(None, None)), None);
+
+        // End.DT4 / DT6 / DT46 by UE family.
+        assert_eq!(
+            super::mup_sid_behavior(&session(Some(v4), None)),
+            bgp_packet::SRV6_BEHAVIOR_END_DT4
+        );
+        assert_eq!(
+            super::mup_sid_behavior(&session(None, Some(v6))),
+            bgp_packet::SRV6_BEHAVIOR_END_DT6
+        );
+        assert_eq!(
+            super::mup_sid_behavior(&session(Some(v4), Some(v6))),
+            bgp_packet::SRV6_BEHAVIOR_END_DT46
+        );
+
+        // RT shares the RD wire format (low type 0x02, value preserved).
+        let rd = RouteDistinguisher::from_str("65000:100").unwrap();
+        let rt = super::rd_route_target(&rd);
+        assert_eq!(rt.low_type, 0x02);
+        assert_eq!(rt.high_type, rd.typ as u8);
+        assert_eq!(rt.val, rd.val);
+
+        // The built attr carries the controller next-hop, the RT export
+        // and the SRv6 L3 Service SID.
+        let controller: Ipv6Addr = "2001:db8::1".parse().unwrap();
+        let sid: Ipv6Addr = "2001:db8:1:40::".parse().unwrap();
+        let mut rts = BTreeSet::new();
+        rts.insert(rd);
+        let attr = super::build_mup_attr(
+            Some(controller),
+            &rts,
+            sid,
+            bgp_packet::SRV6_BEHAVIOR_END_DT4,
+        );
+        assert!(
+            matches!(attr.nexthop, Some(BgpNexthop::Ipv6(a)) if a == controller),
+            "controller next-hop in MP_REACH"
+        );
+        assert!(
+            attr.ecom
+                .as_ref()
+                .unwrap()
+                .0
+                .iter()
+                .any(|v| v.low_type == 0x02),
+            "RT export present"
+        );
+        match &attr.prefix_sid.as_ref().unwrap().tlvs[0] {
+            bgp_packet::PrefixSidTlv::Srv6L3Service(tlv) => {
+                assert_eq!(tlv.sids[0].sid, sid);
+                assert_eq!(tlv.sids[0].behavior, bgp_packet::SRV6_BEHAVIOR_END_DT4);
+            }
+            other => panic!("expected Srv6L3Service, got {other:?}"),
+        }
+    }
 
     fn bgp_rib_with_nexthop(nh: Option<BgpNexthop>, typ: super::BgpRibType) -> super::BgpRib {
         let attr = BgpAttr {

--- a/zebra-rs/src/bgp/show.rs
+++ b/zebra-rs/src/bgp/show.rs
@@ -3463,6 +3463,102 @@ fn mup_prefix_display(prefix: &MupPrefix) -> String {
     }
 }
 
+/// `show bgp mobile-uplane mup-c` — MUP controller (MUP-C) status: admin
+/// state, the PFCP listener, and association / session counts. Rendered
+/// from the read-only [`crate::mup_c::inst::MupCView`] the controller
+/// feeds over `Message::MupC`.
+fn show_bgp_mup_c(
+    bgp: &Bgp,
+    _args: Args,
+    json: bool,
+) -> std::result::Result<String, std::fmt::Error> {
+    if json {
+        return Ok(String::from("{}"));
+    }
+    let view = &bgp.mup_c_view;
+    let mut buf = String::new();
+    writeln!(buf, "MUP controller (MUP-C)")?;
+    writeln!(
+        buf,
+        "  Admin state : {}",
+        if bgp.mup_c.is_some() {
+            "enabled"
+        } else {
+            "disabled"
+        }
+    )?;
+    match view.listen {
+        Some(addr) => writeln!(buf, "  PFCP listen : {addr}")?,
+        None => writeln!(buf, "  PFCP listen : down")?,
+    }
+    writeln!(buf, "  Associations: {}", view.associations.len())?;
+    writeln!(buf, "  Sessions    : {}", view.sessions.len())?;
+    Ok(buf)
+}
+
+/// `show bgp mobile-uplane mup-c session` — the PFCP sessions the
+/// controller has learned (one row each).
+fn show_bgp_mup_c_session(
+    bgp: &Bgp,
+    _args: Args,
+    json: bool,
+) -> std::result::Result<String, std::fmt::Error> {
+    if json {
+        return Ok(String::from("[]"));
+    }
+    let mut buf = String::new();
+    writeln!(
+        buf,
+        "{:<10} {:<40} {:<12} {:<40} {:<5} Network-Instance",
+        "SEID", "UE address", "TEID", "Endpoint", "QFI"
+    )?;
+    for s in bgp.mup_c_view.sessions.values() {
+        let ue = match (s.ue_ipv4, s.ue_ipv6) {
+            (Some(v4), _) => v4.to_string(),
+            (None, Some(v6)) => v6.to_string(),
+            (None, None) => "-".to_string(),
+        };
+        let teid = format!("0x{:08x}", s.teid);
+        let endpoint = s
+            .endpoint
+            .map(|e| e.to_string())
+            .unwrap_or_else(|| "-".to_string());
+        let qfi = s
+            .qfi
+            .map(|q| q.to_string())
+            .unwrap_or_else(|| "-".to_string());
+        writeln!(
+            buf,
+            "{:<10} {:<40} {:<12} {:<40} {:<5} {}",
+            s.seid,
+            ue,
+            teid,
+            endpoint,
+            qfi,
+            s.network_instance.as_deref().unwrap_or("-")
+        )?;
+    }
+    Ok(buf)
+}
+
+/// `show bgp mobile-uplane mup-c association` — the PFCP associations
+/// (control-plane peers) the controller currently holds.
+fn show_bgp_mup_c_association(
+    bgp: &Bgp,
+    _args: Args,
+    json: bool,
+) -> std::result::Result<String, std::fmt::Error> {
+    if json {
+        return Ok(String::from("[]"));
+    }
+    let mut buf = String::new();
+    writeln!(buf, "{:<36} Node-ID", "Peer")?;
+    for (peer, info) in bgp.mup_c_view.associations.iter() {
+        writeln!(buf, "{:<36} {}", peer.to_string(), info.node_id)?;
+    }
+    Ok(buf)
+}
+
 /// `show bgp mobile-uplane` — the MUP (SAFI 85, RFC 9833) view: the
 /// config-driven `MUP VRFs:` block (per-VRF `mobile-uplane` services)
 /// followed by the Loc-RIB route table. The full `MUP controller:`
@@ -5386,6 +5482,12 @@ impl Bgp {
             .set(show_bgp_mup)
             .path("/show/bgp/mobile-uplane/summary")
             .set(show_bgp_mup_summary)
+            .path("/show/bgp/mobile-uplane/mup-c")
+            .set(show_bgp_mup_c)
+            .path("/show/bgp/mobile-uplane/mup-c/session")
+            .set(show_bgp_mup_c_session)
+            .path("/show/bgp/mobile-uplane/mup-c/association")
+            .set(show_bgp_mup_c_association)
             .path("/show/bgp/summary")
             .set(show_bgp_summary::<Bgp>)
             .path("/show/bgp/evpn/summary")

--- a/zebra-rs/src/bgp/vrf/inst.rs
+++ b/zebra-rs/src/bgp/vrf/inst.rs
@@ -538,6 +538,11 @@ impl BgpVrf {
                 // BGP-LS (RFC 9552) is produced and stored only by the
                 // global BGP instance — per-VRF tasks never see it.
             }
+            Message::MupC(_) => {
+                // The MUP controller reports only to the global BGP
+                // instance (it is handed the global `tx`); per-VRF tasks
+                // never see `MupC`.
+            }
             Message::Relisten => {
                 // `router bgp port` is a global-instance knob; only the
                 // global event loop queues (and handles) Relisten.

--- a/zebra-rs/src/main.rs
+++ b/zebra-rs/src/main.rs
@@ -24,6 +24,10 @@ mod fib;
 mod flex_algo;
 mod fmt;
 mod isis;
+// The MUP controller lives in `src/mup-c/` (hyphenated dir, per the
+// feature's home); `#[path]` maps it to the `mup_c` module name.
+#[path = "mup-c/mod.rs"]
+mod mup_c;
 mod nd;
 mod policy;
 use policy::Policy;

--- a/zebra-rs/src/mup-c/assoc.rs
+++ b/zebra-rs/src/mup-c/assoc.rs
@@ -1,0 +1,38 @@
+//! PFCP node-association table for the MUP controller.
+//!
+//! Tracks the N4 associations (one per control-plane peer / SMF) the
+//! controller has accepted. PFCP requires an established association
+//! before any session message is valid; the controller answers
+//! Association Setup / Release and Heartbeat to keep it alive.
+
+use std::collections::BTreeMap;
+use std::net::SocketAddr;
+
+/// One PFCP association (N4) with a control-plane peer (SMF).
+#[derive(Debug, Clone)]
+pub struct MupAssocInfo {
+    /// Human form of the peer's PFCP Node ID (IP or FQDN).
+    pub node_id: String,
+}
+
+/// Associations keyed by PFCP peer transport address.
+#[derive(Debug, Default)]
+pub struct AssocTable {
+    peers: BTreeMap<SocketAddr, MupAssocInfo>,
+}
+
+impl AssocTable {
+    pub fn new() -> Self {
+        Self {
+            peers: BTreeMap::new(),
+        }
+    }
+
+    pub fn upsert(&mut self, peer: SocketAddr, info: MupAssocInfo) {
+        self.peers.insert(peer, info);
+    }
+
+    pub fn remove(&mut self, peer: &SocketAddr) -> Option<MupAssocInfo> {
+        self.peers.remove(peer)
+    }
+}

--- a/zebra-rs/src/mup-c/assoc.rs
+++ b/zebra-rs/src/mup-c/assoc.rs
@@ -35,4 +35,15 @@ impl AssocTable {
     pub fn remove(&mut self, peer: &SocketAddr) -> Option<MupAssocInfo> {
         self.peers.remove(peer)
     }
+
+    /// Whether `peer` has an established association — the precondition
+    /// for accepting its session messages (3GPP TS 29.244 §6.2.6.2).
+    pub fn contains(&self, peer: &SocketAddr) -> bool {
+        self.peers.contains_key(peer)
+    }
+
+    /// Number of associations held (used to bound state).
+    pub fn count(&self) -> usize {
+        self.peers.len()
+    }
 }

--- a/zebra-rs/src/mup-c/inst.rs
+++ b/zebra-rs/src/mup-c/inst.rs
@@ -1,0 +1,266 @@
+//! MUP controller task: state, BGP-facing types, spawn + event loop.
+//!
+//! See the [module docs](super) for the architecture. This file owns the
+//! [`MupC`] task struct, the config staged from BGP ([`MupCConfig`]), the
+//! neutral events reported back to BGP ([`MupCEvent`]) and the read-only
+//! snapshot BGP renders from ([`MupCView`]). The PFCP socket and message
+//! handling live in [`super::pfcp`].
+
+use std::collections::BTreeMap;
+use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr};
+use std::sync::Arc;
+
+use tokio::net::UdpSocket;
+use tokio::sync::mpsc::{self, UnboundedReceiver, UnboundedSender};
+
+use crate::context::{ProtoContext, Task};
+
+use super::assoc::{AssocTable, MupAssocInfo};
+use super::session::{MupSession, SessionTable};
+
+/// PFCP default port (3GPP TS 29.244 §4.2.2).
+pub const PFCP_PORT: u16 = 8805;
+
+/// Controller config, staged from `router bgp afi-safi mobile-uplane
+/// mup-c { … }` by the BGP config callbacks and applied at `CommitEnd`.
+#[derive(Debug, Clone, Default)]
+pub struct MupCConfig {
+    /// Master switch: spawns / tears down the controller task.
+    pub enable: bool,
+    /// IPv6 next-hop stamped on originated ST routes (route phase).
+    pub controller_address: Option<Ipv6Addr>,
+    /// Our PFCP Node ID, used in responses. Falls back to the bind
+    /// address / `controller_address` when unset.
+    pub node_id: Option<IpAddr>,
+    /// PFCP listen address (default `::`).
+    pub listen_address: Option<IpAddr>,
+    /// PFCP listen port (default 8805).
+    pub port: Option<u16>,
+    /// SRv6 locator name SIDs are drawn from (route phase).
+    pub locator: Option<String>,
+    /// Mobile architecture (e.g. `3gpp-5g`); informational for now.
+    pub architecture: Option<String>,
+}
+
+impl MupCConfig {
+    /// The effective PFCP bind address (defaults `[::]:8805`).
+    pub fn listen_socket_addr(&self) -> SocketAddr {
+        let ip = self
+            .listen_address
+            .unwrap_or(IpAddr::V6(Ipv6Addr::UNSPECIFIED));
+        SocketAddr::new(ip, self.port.unwrap_or(PFCP_PORT))
+    }
+}
+
+/// Neutral session/association events the controller reports to BGP over
+/// the handed-in channel. BGP records them in [`MupCView`] (this slice)
+/// and originates / withdraws MUP routes from them (route phase).
+#[derive(Debug, Clone)]
+pub enum MupCEvent {
+    /// PFCP listener (re)bound (`Some`) or down (`None`).
+    Listener { bound: Option<SocketAddr> },
+    /// Association established with a CP peer.
+    AssocUp { peer: SocketAddr, node_id: String },
+    /// Association released / lost; its sessions are withdrawn too.
+    AssocDown { peer: SocketAddr },
+    /// Session created or modified.
+    SessionUp(MupSession),
+    /// Session deleted.
+    SessionDown { seid: u64 },
+}
+
+/// Read-only controller snapshot held by the BGP task, fed by
+/// [`MupCEvent`]. Renders `show bgp mobile-uplane mup-c [session |
+/// association]`.
+#[derive(Debug, Default)]
+pub struct MupCView {
+    /// The bound PFCP listener address, or `None` while down.
+    pub listen: Option<SocketAddr>,
+    /// Active associations keyed by CP peer transport address.
+    pub associations: BTreeMap<SocketAddr, MupAssocInfo>,
+    /// Learned sessions keyed by local SEID.
+    pub sessions: BTreeMap<u64, MupSession>,
+}
+
+impl MupCView {
+    /// Fold one reported event into the snapshot.
+    pub fn apply(&mut self, ev: MupCEvent) {
+        match ev {
+            MupCEvent::Listener { bound } => self.listen = bound,
+            MupCEvent::AssocUp { peer, node_id } => {
+                self.associations.insert(peer, MupAssocInfo { node_id });
+            }
+            MupCEvent::AssocDown { peer } => {
+                self.associations.remove(&peer);
+                self.sessions.retain(|_, s| s.peer != peer);
+            }
+            MupCEvent::SessionUp(session) => {
+                self.sessions.insert(session.seid, session);
+            }
+            MupCEvent::SessionDown { seid } => {
+                self.sessions.remove(&seid);
+            }
+        }
+    }
+}
+
+/// BGP → controller control messages. Teardown is by dropping the
+/// [`MupCHandle`] (which aborts the task), so the only control message is
+/// reconfigure.
+#[derive(Debug)]
+pub enum MupCCtl {
+    /// Config changed while the controller is running: rebind the
+    /// listener to the new address/port.
+    Reconfig(MupCConfig),
+}
+
+/// Handle the BGP task holds for a running controller. Dropping `task`
+/// aborts the controller (the VRF-handle idiom); `ctl_tx` pushes
+/// reconfigure / shutdown.
+#[derive(Debug)]
+pub struct MupCHandle {
+    pub ctl_tx: UnboundedSender<MupCCtl>,
+    // Held only for its `Drop` (aborts the spawned task on teardown);
+    // never read. Mirrors how `BgpVrfHandle` keeps its `Task`.
+    #[allow(dead_code)]
+    task: Task<()>,
+}
+
+impl MupCHandle {
+    /// Push a new config to the running controller.
+    pub fn reconfig(&self, config: MupCConfig) {
+        let _ = self.ctl_tx.send(MupCCtl::Reconfig(config));
+    }
+}
+
+/// Internal controller events (fed by the PFCP recv task).
+#[derive(Debug)]
+pub enum Message {
+    /// A datagram arrived on the PFCP socket.
+    PfcpRecv { data: Vec<u8>, src: SocketAddr },
+}
+
+/// The controller task state.
+pub struct MupC {
+    pub(super) config: MupCConfig,
+    /// Channel into the BGP task — the same `tx` BGP feeds its own loop.
+    pub(super) bgp_tx: mpsc::Sender<crate::bgp::inst::Message>,
+    /// Spawn-time runtime context (socket factory + VRF binding).
+    pub(super) ctx: ProtoContext,
+    /// BGP → controller control channel.
+    ctl_rx: UnboundedReceiver<MupCCtl>,
+    /// Self events from the PFCP recv task.
+    rx: UnboundedReceiver<Message>,
+    /// Cloned for each (re)spawned recv task.
+    pub(super) main_tx: UnboundedSender<Message>,
+    pub(super) sessions: SessionTable,
+    pub(super) assoc: AssocTable,
+    /// Bound PFCP socket; `None` until the first successful bind.
+    pub(super) sock: Option<Arc<UdpSocket>>,
+    /// Recv task; replaced (aborting the old) on every rebind.
+    pub(super) recv_task: Option<Task<()>>,
+    /// Last successfully bound local address.
+    pub(super) listen_addr: Option<SocketAddr>,
+}
+
+/// Spawn the controller. Mirrors `spawn_bgp_vrf`: takes the global BGP
+/// channel by value. The socket bind happens inside the task (it is
+/// async; the BGP-side caller is sync).
+pub fn spawn(
+    config: MupCConfig,
+    bgp_tx: mpsc::Sender<crate::bgp::inst::Message>,
+    ctx: ProtoContext,
+) -> MupCHandle {
+    let (ctl_tx, ctl_rx) = mpsc::unbounded_channel();
+    let task = Task::spawn(async move {
+        let mut mupc = MupC::new(config, bgp_tx, ctx, ctl_rx);
+        mupc.bind().await;
+        mupc.event_loop().await;
+    });
+    MupCHandle { ctl_tx, task }
+}
+
+impl MupC {
+    fn new(
+        config: MupCConfig,
+        bgp_tx: mpsc::Sender<crate::bgp::inst::Message>,
+        ctx: ProtoContext,
+        ctl_rx: UnboundedReceiver<MupCCtl>,
+    ) -> Self {
+        let (main_tx, rx) = mpsc::unbounded_channel();
+        Self {
+            config,
+            bgp_tx,
+            ctx,
+            ctl_rx,
+            rx,
+            main_tx,
+            sessions: SessionTable::new(),
+            assoc: AssocTable::new(),
+            sock: None,
+            recv_task: None,
+            listen_addr: None,
+        }
+    }
+
+    /// Test-only constructor: builds a controller with a dummy BGP
+    /// channel and a parked RIB context, so the synchronous PFCP handlers
+    /// can be exercised without spawning the task or binding a socket.
+    /// Returns the BGP receiver too (kept alive by the caller so a stray
+    /// `report` doesn't see a closed channel).
+    #[cfg(test)]
+    pub(super) fn new_for_test(
+        config: MupCConfig,
+    ) -> (Self, mpsc::Receiver<crate::bgp::inst::Message>) {
+        let (bgp_tx, bgp_rx) = mpsc::channel(64);
+        let (_ctl_tx, ctl_rx) = mpsc::unbounded_channel();
+        let ctx = ProtoContext::default_table_no_rib();
+        (Self::new(config, bgp_tx, ctx, ctl_rx), bgp_rx)
+    }
+
+    /// Report an event to the BGP task. Best-effort: if BGP's bounded
+    /// channel is gone the controller is about to be torn down anyway.
+    pub(super) async fn report(&self, ev: MupCEvent) {
+        if self
+            .bgp_tx
+            .send(crate::bgp::inst::Message::MupC(ev))
+            .await
+            .is_err()
+        {
+            tracing::warn!("mup-c: BGP channel closed; dropping event");
+        }
+    }
+
+    /// Our local address, used for the F-SEID / Node ID in responses:
+    /// configured `node-id`, else `controller-address`, else the bound
+    /// (non-unspecified) listen IP, else loopback.
+    pub(super) fn local_ip(&self) -> IpAddr {
+        self.config
+            .node_id
+            .or(self.config.controller_address.map(IpAddr::V6))
+            .or_else(|| {
+                self.listen_addr
+                    .map(|a| a.ip())
+                    .filter(|ip| !ip.is_unspecified())
+            })
+            .unwrap_or(IpAddr::V4(Ipv4Addr::LOCALHOST))
+    }
+
+    async fn event_loop(&mut self) {
+        loop {
+            tokio::select! {
+                Some(msg) = self.rx.recv() => match msg {
+                    Message::PfcpRecv { data, src } => self.handle_pfcp(&data, src).await,
+                },
+                Some(MupCCtl::Reconfig(cfg)) = self.ctl_rx.recv() => {
+                    let rebind = cfg.listen_socket_addr() != self.config.listen_socket_addr();
+                    self.config = cfg;
+                    if rebind {
+                        self.bind().await;
+                    }
+                }
+                else => break,
+            }
+        }
+    }
+}

--- a/zebra-rs/src/mup-c/mod.rs
+++ b/zebra-rs/src/mup-c/mod.rs
@@ -1,0 +1,30 @@
+//! BGP MUP Controller (MUP-C) — Mobile User Plane controller.
+//!
+//! Implements the controller half of BGP MUP (RFC 9833 /
+//! `draft-mpmz-bess-mup-safi`, SAFI 85). Per the draft §3.3.7/§3.3.10 a
+//! MUP Controller learns per-session mobile state through a "northbound
+//! API" (left out of scope by the draft) and originates Type-1 / Type-2
+//! Session-Transformed routes from it. zebra-rs uses **PFCP / N4** (3GPP
+//! TS 29.244, via the `rs-pfcp` codec) as that northbound, terminating it
+//! as a **UP-node (UPF role)**: an external SMF/CP programs the controller
+//! with Association Setup + Session Establishment/Modification/Deletion +
+//! Heartbeat.
+//!
+//! The controller is **configured under the BGP instance** at
+//! `router bgp ... afi-safi mobile-uplane mup-c { enable; pfcp … }` and is
+//! spawned by the BGP task, which hands it the BGP instance's own
+//! `mpsc::Sender<crate::bgp::inst::Message>` — exactly the way a BGP VRF
+//! instance receives the global BGP channel. The controller reports
+//! neutral session/association events back over that channel
+//! ([`inst::MupCEvent`]); the BGP task records them for
+//! `show bgp mobile-uplane mup-c` (this slice) and originates MUP routes
+//! from them (follow-up).
+//!
+//! Module layout: [`inst`] owns the task + the BGP-facing types,
+//! [`pfcp`] the PFCP socket + message handling, [`session`] / [`assoc`]
+//! the per-session and per-association tables.
+
+pub mod assoc;
+pub mod inst;
+pub mod pfcp;
+pub mod session;

--- a/zebra-rs/src/mup-c/pfcp.rs
+++ b/zebra-rs/src/mup-c/pfcp.rs
@@ -15,6 +15,7 @@ use tokio::net::UdpSocket;
 use tokio::sync::mpsc::UnboundedSender;
 
 use rs_pfcp::ie::IeType;
+use rs_pfcp::ie::cause::CauseValue;
 use rs_pfcp::ie::create_pdr::CreatePdr;
 use rs_pfcp::ie::node_id::NodeId;
 use rs_pfcp::message::association_release_response::AssociationReleaseResponseBuilder;
@@ -24,6 +25,7 @@ use rs_pfcp::message::session_deletion_response::SessionDeletionResponseBuilder;
 use rs_pfcp::message::session_establishment_response::SessionEstablishmentResponseBuilder;
 use rs_pfcp::message::session_modification_response::SessionModificationResponseBuilder;
 use rs_pfcp::message::{self, Message as PfcpMessage, MsgType};
+use rs_pfcp::types::SequenceNumber;
 
 use crate::context::Task;
 
@@ -34,6 +36,14 @@ use super::session::MupSession;
 /// Outcome of handling one PFCP request: an optional reply to send back
 /// to the peer, plus the events to report to BGP.
 type Handled = (Option<Vec<u8>>, Vec<MupCEvent>);
+
+/// Upper bound on concurrent PFCP associations. The controller faces an
+/// external SMF/CP, so the association and session tables are bounded to
+/// keep a misbehaving or hostile peer from exhausting memory. Idle/dead
+/// association eviction (driven by Heartbeat liveness) is a follow-up.
+const MAX_ASSOCS: usize = 256;
+/// Upper bound on concurrently learned sessions across all peers.
+const MAX_SESSIONS: usize = 1 << 20;
 
 impl MupC {
     /// (Re)bind the PFCP listener to the configured address/port and
@@ -112,9 +122,9 @@ impl MupC {
                     self.handle_session_establishment(msg.as_ref(), src)
                 }
                 MsgType::SessionModificationRequest => {
-                    self.handle_session_modification(msg.as_ref())
+                    self.handle_session_modification(msg.as_ref(), src)
                 }
-                MsgType::SessionDeletionRequest => self.handle_session_deletion(msg.as_ref()),
+                MsgType::SessionDeletionRequest => self.handle_session_deletion(msg.as_ref(), src),
                 other => {
                     tracing::debug!("mup-c: unhandled PFCP {other:?} from {src}");
                     (None, Vec::new())
@@ -139,6 +149,17 @@ impl MupC {
     }
 
     fn handle_association_setup(&mut self, msg: &dyn PfcpMessage, src: SocketAddr) -> Handled {
+        // Bound the association table against a flood of distinct peers.
+        // A re-setup from an already-known peer is always allowed.
+        if !self.assoc.contains(&src) && self.assoc.count() >= MAX_ASSOCS {
+            tracing::warn!("mup-c: association table full ({MAX_ASSOCS}); rejecting {src}");
+            let resp = AssociationSetupResponseBuilder::new(msg.sequence())
+                .cause(CauseValue::NoResourcesAvailable)
+                .node_id(self.local_ip())
+                .recovery_time_stamp(std::time::SystemTime::now())
+                .build();
+            return (Some(resp.marshal()), Vec::new());
+        }
         let node_id = msg
             .ies(IeType::NodeId)
             .next()
@@ -180,6 +201,23 @@ impl MupC {
 
     fn handle_session_establishment(&mut self, msg: &dyn PfcpMessage, src: SocketAddr) -> Handled {
         let seq = msg.sequence();
+
+        // A session is only valid inside an established association
+        // (3GPP TS 29.244 §6.2.6.2).
+        if !self.assoc.contains(&src) {
+            return (
+                self.reject_session_establishment(seq, CauseValue::NoEstablishedPfcpAssociation),
+                Vec::new(),
+            );
+        }
+        // Bound the session table against a hostile / runaway peer.
+        if self.sessions.count() >= MAX_SESSIONS {
+            tracing::warn!("mup-c: session table full ({MAX_SESSIONS}); rejecting from {src}");
+            return (
+                self.reject_session_establishment(seq, CauseValue::NoResourcesAvailable),
+                Vec::new(),
+            );
+        }
 
         // Walk the Create PDRs for the access-side F-TEID, UE IP and NI.
         let mut ue_ipv4 = None;
@@ -246,9 +284,40 @@ impl MupC {
         (reply, vec![MupCEvent::SessionUp(session)])
     }
 
-    fn handle_session_modification(&mut self, msg: &dyn PfcpMessage) -> Handled {
+    /// Build a rejected Session Establishment Response carrying `cause`
+    /// (SEID 0 — no session was created). An F-SEID is set even on
+    /// rejection because the codec requires it; its value is irrelevant
+    /// when the cause is not "accepted".
+    fn reject_session_establishment(
+        &self,
+        seq: SequenceNumber,
+        cause: CauseValue,
+    ) -> Option<Vec<u8>> {
+        let local_ip = self.local_ip();
+        match SessionEstablishmentResponseBuilder::new(0u64, seq, cause)
+            .node_id(local_ip)
+            .fseid(0u64, local_ip)
+            .build()
+        {
+            Ok(resp) => Some(resp.marshal()),
+            Err(e) => {
+                tracing::warn!("mup-c: build rejected SessionEstablishmentResponse failed: {e}");
+                None
+            }
+        }
+    }
+
+    fn handle_session_modification(&mut self, msg: &dyn PfcpMessage, src: SocketAddr) -> Handled {
         let seq = msg.sequence();
         let seid = msg.seid().map(|s| s.value()).unwrap_or(0);
+        // Only the peer that owns the session may modify it; a mismatch
+        // (or unknown SEID) is rejected without touching state.
+        if self.sessions.get(seid).map(|s| s.peer) != Some(src) {
+            let resp = SessionModificationResponseBuilder::new(seid, seq)
+                .cause(CauseValue::SessionContextNotFound)
+                .build();
+            return (Some(resp.marshal()), Vec::new());
+        }
         // PR-A re-reports the existing session unchanged (field-level
         // re-extraction from Update/Create PDRs is a follow-up).
         let events = match self.sessions.get(seid).cloned() {
@@ -261,9 +330,16 @@ impl MupC {
         (Some(resp.marshal()), events)
     }
 
-    fn handle_session_deletion(&mut self, msg: &dyn PfcpMessage) -> Handled {
+    fn handle_session_deletion(&mut self, msg: &dyn PfcpMessage, src: SocketAddr) -> Handled {
         let seq = msg.sequence();
         let seid = msg.seid().map(|s| s.value()).unwrap_or(0);
+        // Only the peer that owns the session may delete it.
+        if self.sessions.get(seid).map(|s| s.peer) != Some(src) {
+            let resp = SessionDeletionResponseBuilder::new(seid, seq)
+                .cause(CauseValue::SessionContextNotFound)
+                .build();
+            return (Some(resp.marshal()), Vec::new());
+        }
         let removed = self.sessions.remove(seid).is_some();
         let resp = SessionDeletionResponseBuilder::new(seid, seq)
             .cause_accepted()
@@ -348,6 +424,18 @@ mod tests {
         "10.0.0.2:8805".parse().unwrap()
     }
 
+    /// Establish the association that `peer()` must hold before the
+    /// controller will accept its session messages.
+    fn associate(mupc: &mut MupC) {
+        let asr = AssociationSetupRequestBuilder::new(1u32)
+            .node_id(Ipv4Addr::new(10, 0, 0, 2))
+            .recovery_time_stamp(std::time::SystemTime::now())
+            .build()
+            .marshal();
+        let msg = message::parse(&asr).unwrap();
+        let _ = mupc.handle_association_setup(msg.as_ref(), peer());
+    }
+
     /// A Session Establishment Request whose uplink/access PDR carries an
     /// F-TEID (teid + GTP endpoint), a UE IPv4 address and a Network
     /// Instance — the three things the controller extracts.
@@ -386,6 +474,7 @@ mod tests {
     #[test]
     fn session_establishment_extracts_and_acks() {
         let (mut mupc, _bgp_rx) = MupC::new_for_test(MupCConfig::default());
+        associate(&mut mupc);
         let bytes = establishment_bytes();
         let msg = message::parse(&bytes).unwrap();
         let (reply, events) = mupc.handle_session_establishment(msg.as_ref(), peer());
@@ -412,6 +501,7 @@ mod tests {
     #[test]
     fn session_deletion_removes_session() {
         let (mut mupc, _bgp_rx) = MupC::new_for_test(MupCConfig::default());
+        associate(&mut mupc);
         let est = message::parse(&establishment_bytes()).unwrap();
         let (_, events) = mupc.handle_session_establishment(est.as_ref(), peer());
         let MupCEvent::SessionUp(session) = &events[0] else {
@@ -423,7 +513,7 @@ mod tests {
             .build()
             .marshal();
         let msg = message::parse(&del).unwrap();
-        let (reply, events) = mupc.handle_session_deletion(msg.as_ref());
+        let (reply, events) = mupc.handle_session_deletion(msg.as_ref(), peer());
 
         assert!(mupc.sessions.get(seid).is_none());
         assert!(
@@ -432,6 +522,49 @@ mod tests {
         );
         let resp = message::parse(&reply.unwrap()).unwrap();
         assert_eq!(resp.msg_type(), MsgType::SessionDeletionResponse);
+    }
+
+    #[test]
+    fn session_without_association_is_rejected() {
+        let (mut mupc, _bgp_rx) = MupC::new_for_test(MupCConfig::default());
+        // No association established for peer().
+        let msg = message::parse(&establishment_bytes()).unwrap();
+        let (reply, events) = mupc.handle_session_establishment(msg.as_ref(), peer());
+
+        assert!(
+            events.is_empty(),
+            "no session learned without an association"
+        );
+        assert!(mupc.sessions.get(1).is_none(), "no session inserted");
+        let resp = message::parse(&reply.unwrap()).unwrap();
+        assert_eq!(resp.msg_type(), MsgType::SessionEstablishmentResponse);
+    }
+
+    #[test]
+    fn foreign_peer_cannot_delete_session() {
+        let (mut mupc, _bgp_rx) = MupC::new_for_test(MupCConfig::default());
+        associate(&mut mupc);
+        let est = message::parse(&establishment_bytes()).unwrap();
+        let (_, events) = mupc.handle_session_establishment(est.as_ref(), peer());
+        let MupCEvent::SessionUp(session) = &events[0] else {
+            panic!("expected SessionUp");
+        };
+        let seid = session.seid;
+
+        // A different peer tries to delete the session by SEID.
+        let other: SocketAddr = "10.9.9.9:8805".parse().unwrap();
+        let del = SessionDeletionRequestBuilder::new(seid, 9u32)
+            .build()
+            .marshal();
+        let msg = message::parse(&del).unwrap();
+        let (reply, events) = mupc.handle_session_deletion(msg.as_ref(), other);
+
+        assert!(events.is_empty(), "foreign delete emits no event");
+        assert!(
+            mupc.sessions.get(seid).is_some(),
+            "session survives a foreign delete"
+        );
+        let _ = reply.expect("a (rejected) response is still sent");
     }
 
     #[test]

--- a/zebra-rs/src/mup-c/pfcp.rs
+++ b/zebra-rs/src/mup-c/pfcp.rs
@@ -1,0 +1,470 @@
+//! PFCP/N4 socket and message handling for the MUP controller.
+//!
+//! The controller terminates PFCP as a UP-node (UPF role): it binds a UDP
+//! socket (default `[::]:8805`), answers the node-management messages
+//! (Heartbeat, Association Setup/Release) and the session messages
+//! (Establishment / Modification / Deletion), and reports each
+//! session/association change to the BGP task as a [`MupCEvent`]. Wire
+//! encode/decode is the `rs-pfcp` codec; the socket is ours.
+
+use std::net::{IpAddr, SocketAddr};
+use std::sync::Arc;
+
+use socket2::Domain;
+use tokio::net::UdpSocket;
+use tokio::sync::mpsc::UnboundedSender;
+
+use rs_pfcp::ie::IeType;
+use rs_pfcp::ie::create_pdr::CreatePdr;
+use rs_pfcp::ie::node_id::NodeId;
+use rs_pfcp::message::association_release_response::AssociationReleaseResponseBuilder;
+use rs_pfcp::message::association_setup_response::AssociationSetupResponseBuilder;
+use rs_pfcp::message::heartbeat_response::HeartbeatResponseBuilder;
+use rs_pfcp::message::session_deletion_response::SessionDeletionResponseBuilder;
+use rs_pfcp::message::session_establishment_response::SessionEstablishmentResponseBuilder;
+use rs_pfcp::message::session_modification_response::SessionModificationResponseBuilder;
+use rs_pfcp::message::{self, Message as PfcpMessage, MsgType};
+
+use crate::context::Task;
+
+use super::assoc::MupAssocInfo;
+use super::inst::{Message, MupC, MupCEvent};
+use super::session::MupSession;
+
+/// Outcome of handling one PFCP request: an optional reply to send back
+/// to the peer, plus the events to report to BGP.
+type Handled = (Option<Vec<u8>>, Vec<MupCEvent>);
+
+impl MupC {
+    /// (Re)bind the PFCP listener to the configured address/port and
+    /// (re)start the recv task. Idempotent — replacing `recv_task`
+    /// aborts the previous one. Failures are non-fatal: the controller
+    /// stays up and reports the listener as down.
+    pub(super) async fn bind(&mut self) {
+        let addr = self.config.listen_socket_addr();
+        let domain = match addr.ip() {
+            IpAddr::V4(_) => Domain::IPV4,
+            IpAddr::V6(_) => Domain::IPV6,
+        };
+        let sock = match self.ctx.udp_socket_unbound(domain) {
+            Ok(sock) => sock,
+            Err(e) => {
+                tracing::warn!("mup-c: PFCP socket({addr}) failed: {e}");
+                return self.set_listener(None).await;
+            }
+        };
+        let _ = sock.set_reuse_address(true);
+        if let Err(e) = sock.bind(&addr.into()) {
+            tracing::warn!("mup-c: PFCP bind {addr} failed: {e}");
+            return self.set_listener(None).await;
+        }
+        if let Err(e) = sock.set_nonblocking(true) {
+            tracing::warn!("mup-c: PFCP set_nonblocking failed: {e}");
+        }
+        let std_sock: std::net::UdpSocket = sock.into();
+        let tokio_sock = match UdpSocket::from_std(std_sock) {
+            Ok(sock) => sock,
+            Err(e) => {
+                tracing::warn!("mup-c: PFCP from_std failed: {e}");
+                return self.set_listener(None).await;
+            }
+        };
+        let sock = Arc::new(tokio_sock);
+        let local = sock.local_addr().ok();
+        self.listen_addr = local;
+        self.sock = Some(sock.clone());
+        // Replace the recv task; dropping the old handle aborts it.
+        let tx = self.main_tx.clone();
+        self.recv_task = Some(Task::spawn(async move {
+            recv_loop(sock, tx).await;
+        }));
+        tracing::info!("mup-c: PFCP listening on {local:?}");
+        self.set_listener(local).await;
+    }
+
+    async fn set_listener(&self, bound: Option<SocketAddr>) {
+        self.report(MupCEvent::Listener { bound }).await;
+    }
+
+    /// Decode one datagram, dispatch by message type, send the reply, and
+    /// report the resulting events to BGP.
+    pub(super) async fn handle_pfcp(&mut self, data: &[u8], src: SocketAddr) {
+        // Decode + dispatch in a block so the parsed `Box<dyn Message>`
+        // (not `Send`) is dropped before the `.await`s below; otherwise
+        // the controller future would not be `Send`-spawnable.
+        let (reply, events) = {
+            let msg = match message::parse(data) {
+                Ok(msg) => msg,
+                Err(e) => {
+                    tracing::warn!("mup-c: PFCP parse error from {src}: {e}");
+                    return;
+                }
+            };
+            match msg.msg_type() {
+                MsgType::HeartbeatRequest => self.handle_heartbeat(msg.as_ref()),
+                MsgType::AssociationSetupRequest => {
+                    self.handle_association_setup(msg.as_ref(), src)
+                }
+                MsgType::AssociationReleaseRequest => {
+                    self.handle_association_release(msg.as_ref(), src)
+                }
+                MsgType::SessionEstablishmentRequest => {
+                    self.handle_session_establishment(msg.as_ref(), src)
+                }
+                MsgType::SessionModificationRequest => {
+                    self.handle_session_modification(msg.as_ref())
+                }
+                MsgType::SessionDeletionRequest => self.handle_session_deletion(msg.as_ref()),
+                other => {
+                    tracing::debug!("mup-c: unhandled PFCP {other:?} from {src}");
+                    (None, Vec::new())
+                }
+            }
+        };
+        if let (Some(bytes), Some(sock)) = (reply, self.sock.as_ref())
+            && let Err(e) = sock.send_to(&bytes, src).await
+        {
+            tracing::warn!("mup-c: PFCP send to {src} failed: {e}");
+        }
+        for ev in events {
+            self.report(ev).await;
+        }
+    }
+
+    fn handle_heartbeat(&mut self, msg: &dyn PfcpMessage) -> Handled {
+        let resp = HeartbeatResponseBuilder::new(msg.sequence())
+            .recovery_time_stamp(std::time::SystemTime::now())
+            .build();
+        (Some(resp.marshal()), Vec::new())
+    }
+
+    fn handle_association_setup(&mut self, msg: &dyn PfcpMessage, src: SocketAddr) -> Handled {
+        let node_id = msg
+            .ies(IeType::NodeId)
+            .next()
+            .and_then(|ie| NodeId::unmarshal(&ie.payload).ok())
+            .map(|n| node_id_string(&n))
+            .unwrap_or_else(|| src.ip().to_string());
+        self.assoc.upsert(
+            src,
+            MupAssocInfo {
+                node_id: node_id.clone(),
+            },
+        );
+        let resp = AssociationSetupResponseBuilder::new(msg.sequence())
+            .cause_accepted()
+            .node_id(self.local_ip())
+            .recovery_time_stamp(std::time::SystemTime::now())
+            .build();
+        (
+            Some(resp.marshal()),
+            vec![MupCEvent::AssocUp { peer: src, node_id }],
+        )
+    }
+
+    fn handle_association_release(&mut self, msg: &dyn PfcpMessage, src: SocketAddr) -> Handled {
+        self.assoc.remove(&src);
+        // The view's `AssocDown` drops this peer's sessions, so one event
+        // covers them; the controller drops them locally here.
+        let _ = self.sessions.remove_peer(src);
+        let node_ie = node_from_ip(self.local_ip()).to_ie();
+        let resp = AssociationReleaseResponseBuilder::new(msg.sequence())
+            .cause_accepted()
+            .node_id(node_ie)
+            .build();
+        (
+            Some(resp.marshal()),
+            vec![MupCEvent::AssocDown { peer: src }],
+        )
+    }
+
+    fn handle_session_establishment(&mut self, msg: &dyn PfcpMessage, src: SocketAddr) -> Handled {
+        let seq = msg.sequence();
+
+        // Walk the Create PDRs for the access-side F-TEID, UE IP and NI.
+        let mut ue_ipv4 = None;
+        let mut ue_ipv6 = None;
+        let mut teid = 0u32;
+        let mut endpoint = None;
+        let mut network_instance = None;
+        for ie in msg.ies(IeType::CreatePdr) {
+            let Ok(pdr) = CreatePdr::unmarshal(&ie.payload) else {
+                continue;
+            };
+            let pdi = &pdr.pdi;
+            if let Some(f) = &pdi.f_teid {
+                if teid == 0 {
+                    teid = f.teid.value();
+                }
+                if endpoint.is_none() {
+                    endpoint = f
+                        .ipv4_address
+                        .map(IpAddr::V4)
+                        .or(f.ipv6_address.map(IpAddr::V6));
+                }
+            }
+            if let Some(ue) = &pdi.ue_ip_address {
+                if ue.ipv4_address.is_some() {
+                    ue_ipv4 = ue.ipv4_address;
+                }
+                if ue.ipv6_address.is_some() {
+                    ue_ipv6 = ue.ipv6_address;
+                }
+            }
+            if network_instance.is_none()
+                && let Some(ni) = &pdi.network_instance
+            {
+                network_instance = Some(ni.instance.clone());
+            }
+        }
+
+        let seid = self.sessions.alloc_seid();
+        let session = MupSession {
+            seid,
+            peer: src,
+            ue_ipv4,
+            ue_ipv6,
+            teid,
+            endpoint,
+            network_instance,
+            qfi: None,
+        };
+        self.sessions.insert(session.clone());
+
+        let local_ip = self.local_ip();
+        let reply = match SessionEstablishmentResponseBuilder::accepted(seid, seq)
+            .node_id(local_ip)
+            .fseid(seid, local_ip)
+            .build()
+        {
+            Ok(resp) => Some(resp.marshal()),
+            Err(e) => {
+                tracing::warn!("mup-c: build SessionEstablishmentResponse failed: {e}");
+                None
+            }
+        };
+        (reply, vec![MupCEvent::SessionUp(session)])
+    }
+
+    fn handle_session_modification(&mut self, msg: &dyn PfcpMessage) -> Handled {
+        let seq = msg.sequence();
+        let seid = msg.seid().map(|s| s.value()).unwrap_or(0);
+        // PR-A re-reports the existing session unchanged (field-level
+        // re-extraction from Update/Create PDRs is a follow-up).
+        let events = match self.sessions.get(seid).cloned() {
+            Some(session) => vec![MupCEvent::SessionUp(session)],
+            None => Vec::new(),
+        };
+        let resp = SessionModificationResponseBuilder::new(seid, seq)
+            .cause_accepted()
+            .build();
+        (Some(resp.marshal()), events)
+    }
+
+    fn handle_session_deletion(&mut self, msg: &dyn PfcpMessage) -> Handled {
+        let seq = msg.sequence();
+        let seid = msg.seid().map(|s| s.value()).unwrap_or(0);
+        let removed = self.sessions.remove(seid).is_some();
+        let resp = SessionDeletionResponseBuilder::new(seid, seq)
+            .cause_accepted()
+            .build();
+        let events = if removed {
+            vec![MupCEvent::SessionDown { seid }]
+        } else {
+            Vec::new()
+        };
+        (Some(resp.marshal()), events)
+    }
+}
+
+/// Receive datagrams forever, forwarding each to the controller event
+/// loop. Exits when the controller is gone (send fails).
+async fn recv_loop(sock: Arc<UdpSocket>, tx: UnboundedSender<Message>) {
+    let mut buf = vec![0u8; 65535];
+    loop {
+        match sock.recv_from(&mut buf).await {
+            Ok((n, src)) => {
+                if tx
+                    .send(Message::PfcpRecv {
+                        data: buf[..n].to_vec(),
+                        src,
+                    })
+                    .is_err()
+                {
+                    break;
+                }
+            }
+            Err(e) => {
+                // Transient (e.g. an ICMP port-unreachable surfaced on a
+                // prior send). Log and keep listening.
+                tracing::warn!("mup-c: PFCP recv error: {e}");
+            }
+        }
+    }
+}
+
+/// Build a PFCP `NodeId` from an IP address.
+fn node_from_ip(ip: IpAddr) -> NodeId {
+    match ip {
+        IpAddr::V4(v4) => NodeId::new_ipv4(v4),
+        IpAddr::V6(v6) => NodeId::new_ipv6(v6),
+    }
+}
+
+/// Human-readable form of a PFCP `NodeId`.
+fn node_id_string(node_id: &NodeId) -> String {
+    match node_id {
+        NodeId::IPv4(addr) => addr.to_string(),
+        NodeId::IPv6(addr) => addr.to_string(),
+        NodeId::FQDN(fqdn) => fqdn.clone(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::net::Ipv4Addr;
+
+    use rs_pfcp::ie::create_far::CreateFar;
+    use rs_pfcp::ie::create_pdr::CreatePdrBuilder;
+    use rs_pfcp::ie::destination_interface::Interface;
+    use rs_pfcp::ie::f_teid::FteidBuilder;
+    use rs_pfcp::ie::far_id::FarId;
+    use rs_pfcp::ie::network_instance::NetworkInstance;
+    use rs_pfcp::ie::pdi::PdiBuilder;
+    use rs_pfcp::ie::pdr_id::PdrId;
+    use rs_pfcp::ie::precedence::Precedence;
+    use rs_pfcp::ie::source_interface::{SourceInterface, SourceInterfaceValue};
+    use rs_pfcp::ie::ue_ip_address::UeIpAddress;
+    use rs_pfcp::message::association_setup_request::AssociationSetupRequestBuilder;
+    use rs_pfcp::message::heartbeat_request::HeartbeatRequestBuilder;
+    use rs_pfcp::message::session_deletion_request::SessionDeletionRequestBuilder;
+    use rs_pfcp::message::session_establishment_request::SessionEstablishmentRequestBuilder;
+    use rs_pfcp::message::{self, Message as PfcpMessage, MsgType};
+
+    use super::super::inst::{MupC, MupCConfig, MupCEvent};
+    use std::net::{IpAddr, SocketAddr};
+
+    fn peer() -> SocketAddr {
+        "10.0.0.2:8805".parse().unwrap()
+    }
+
+    /// A Session Establishment Request whose uplink/access PDR carries an
+    /// F-TEID (teid + GTP endpoint), a UE IPv4 address and a Network
+    /// Instance — the three things the controller extracts.
+    fn establishment_bytes() -> Vec<u8> {
+        let fteid = FteidBuilder::new()
+            .teid(0x1234_5678u32)
+            .ipv4(Ipv4Addr::new(10, 0, 0, 1))
+            .build()
+            .unwrap();
+        let pdi = PdiBuilder::new(SourceInterface::new(SourceInterfaceValue::Access))
+            .f_teid(fteid)
+            .ue_ip_address(UeIpAddress::new(Some(Ipv4Addr::new(192, 0, 2, 5)), None))
+            .network_instance(NetworkInstance::new("internet.apn"))
+            .build()
+            .unwrap();
+        let pdr = CreatePdrBuilder::new(PdrId::new(1))
+            .precedence(Precedence::new(100))
+            .pdi(pdi)
+            .far_id(FarId::new(1))
+            .build()
+            .unwrap();
+        let far = CreateFar::builder(FarId::new(1))
+            .forward_to(Interface::Core)
+            .build()
+            .unwrap();
+        SessionEstablishmentRequestBuilder::new(0u64, 1u32)
+            .node_id(Ipv4Addr::new(10, 0, 0, 2))
+            .fseid(0x1111u64, Ipv4Addr::new(10, 0, 0, 2))
+            .create_pdrs(vec![pdr.to_ie()])
+            .create_fars(vec![far.to_ie()])
+            .build()
+            .unwrap()
+            .marshal()
+    }
+
+    #[test]
+    fn session_establishment_extracts_and_acks() {
+        let (mut mupc, _bgp_rx) = MupC::new_for_test(MupCConfig::default());
+        let bytes = establishment_bytes();
+        let msg = message::parse(&bytes).unwrap();
+        let (reply, events) = mupc.handle_session_establishment(msg.as_ref(), peer());
+
+        assert_eq!(events.len(), 1);
+        let MupCEvent::SessionUp(session) = &events[0] else {
+            panic!("expected SessionUp, got {:?}", events[0]);
+        };
+        assert_eq!(session.ue_ipv4, Some(Ipv4Addr::new(192, 0, 2, 5)));
+        assert_eq!(session.teid, 0x1234_5678);
+        assert_eq!(
+            session.endpoint,
+            Some(IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1)))
+        );
+        assert_eq!(session.network_instance.as_deref(), Some("internet.apn"));
+        assert_eq!(session.peer, peer());
+        assert!(mupc.sessions.get(session.seid).is_some());
+
+        let reply = reply.expect("a Session Establishment Response");
+        let resp = message::parse(&reply).unwrap();
+        assert_eq!(resp.msg_type(), MsgType::SessionEstablishmentResponse);
+    }
+
+    #[test]
+    fn session_deletion_removes_session() {
+        let (mut mupc, _bgp_rx) = MupC::new_for_test(MupCConfig::default());
+        let est = message::parse(&establishment_bytes()).unwrap();
+        let (_, events) = mupc.handle_session_establishment(est.as_ref(), peer());
+        let MupCEvent::SessionUp(session) = &events[0] else {
+            panic!("expected SessionUp");
+        };
+        let seid = session.seid;
+
+        let del = SessionDeletionRequestBuilder::new(seid, 2u32)
+            .build()
+            .marshal();
+        let msg = message::parse(&del).unwrap();
+        let (reply, events) = mupc.handle_session_deletion(msg.as_ref());
+
+        assert!(mupc.sessions.get(seid).is_none());
+        assert!(
+            matches!(events.as_slice(), [MupCEvent::SessionDown { seid: s }] if *s == seid),
+            "expected SessionDown {{ {seid} }}, got {events:?}"
+        );
+        let resp = message::parse(&reply.unwrap()).unwrap();
+        assert_eq!(resp.msg_type(), MsgType::SessionDeletionResponse);
+    }
+
+    #[test]
+    fn heartbeat_is_answered() {
+        let (mut mupc, _bgp_rx) = MupC::new_for_test(MupCConfig::default());
+        let hb = HeartbeatRequestBuilder::new(7u32)
+            .recovery_time_stamp(std::time::SystemTime::now())
+            .build()
+            .marshal();
+        let msg = message::parse(&hb).unwrap();
+        let (reply, events) = mupc.handle_heartbeat(msg.as_ref());
+
+        assert!(events.is_empty());
+        let resp = message::parse(&reply.unwrap()).unwrap();
+        assert_eq!(resp.msg_type(), MsgType::HeartbeatResponse);
+    }
+
+    #[test]
+    fn association_setup_records_peer_and_acks() {
+        let (mut mupc, _bgp_rx) = MupC::new_for_test(MupCConfig::default());
+        let asr = AssociationSetupRequestBuilder::new(3u32)
+            .node_id(Ipv4Addr::new(10, 0, 0, 2))
+            .recovery_time_stamp(std::time::SystemTime::now())
+            .build()
+            .marshal();
+        let msg = message::parse(&asr).unwrap();
+        let (reply, events) = mupc.handle_association_setup(msg.as_ref(), peer());
+
+        assert!(
+            matches!(events.as_slice(), [MupCEvent::AssocUp { peer: p, .. }] if *p == peer()),
+            "expected AssocUp, got {events:?}"
+        );
+        let resp = message::parse(&reply.unwrap()).unwrap();
+        assert_eq!(resp.msg_type(), MsgType::AssociationSetupResponse);
+    }
+}

--- a/zebra-rs/src/mup-c/session.rs
+++ b/zebra-rs/src/mup-c/session.rs
@@ -67,6 +67,12 @@ impl SessionTable {
         self.sessions.remove(&seid)
     }
 
+    /// Number of sessions held (used to bound state — see the
+    /// per-listener cap in [`super::pfcp`]).
+    pub fn count(&self) -> usize {
+        self.sessions.len()
+    }
+
     /// Drop every session owned by `peer` (PFCP association release).
     /// Returns the removed SEIDs so the caller can emit withdrawals.
     pub fn remove_peer(&mut self, peer: SocketAddr) -> Vec<u64> {

--- a/zebra-rs/src/mup-c/session.rs
+++ b/zebra-rs/src/mup-c/session.rs
@@ -1,0 +1,84 @@
+//! PFCP session table for the MUP controller.
+//!
+//! Each PFCP session learned over N4 is normalized into a [`MupSession`]
+//! — the neutral record the BGP task needs to (in a follow-up) originate
+//! Type-1 / Type-2 Session-Transformed routes. The controller is the
+//! authoritative holder; a clone rides each
+//! [`super::inst::MupCEvent::SessionUp`] into the BGP task.
+
+use std::collections::BTreeMap;
+use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr};
+
+/// A mobile session learned from PFCP, normalized for BGP MUP.
+#[derive(Debug, Clone)]
+pub struct MupSession {
+    /// Local SEID we allocated for this session. Returned to the CP in
+    /// our F-SEID; the CP then addresses Session Modification / Deletion
+    /// with this value as the message SEID, so it is the table key.
+    pub seid: u64,
+    /// The PFCP peer (SMF) transport address that owns this session.
+    pub peer: SocketAddr,
+    /// UE IPv4 address/prefix, if assigned.
+    pub ue_ipv4: Option<Ipv4Addr>,
+    /// UE IPv6 address/prefix, if assigned.
+    pub ue_ipv6: Option<Ipv6Addr>,
+    /// Access-side GTP-U TEID (from the uplink PDR's F-TEID).
+    pub teid: u32,
+    /// Access-side GTP-U endpoint (the F-TEID address).
+    pub endpoint: Option<IpAddr>,
+    /// Network Instance (APN/DNN). Correlated to a BGP VRF `mobile-uplane`
+    /// config when routes are originated.
+    pub network_instance: Option<String>,
+    /// QoS Flow Identifier, if present.
+    pub qfi: Option<u8>,
+}
+
+/// Session store keyed by local SEID, plus the local-SEID allocator.
+#[derive(Debug, Default)]
+pub struct SessionTable {
+    sessions: BTreeMap<u64, MupSession>,
+    next_seid: u64,
+}
+
+impl SessionTable {
+    pub fn new() -> Self {
+        Self {
+            sessions: BTreeMap::new(),
+            next_seid: 1,
+        }
+    }
+
+    /// Allocate a fresh non-zero local SEID (SEID 0 is invalid in PFCP).
+    pub fn alloc_seid(&mut self) -> u64 {
+        let seid = self.next_seid.max(1);
+        self.next_seid = seid.wrapping_add(1).max(1);
+        seid
+    }
+
+    pub fn insert(&mut self, session: MupSession) {
+        self.sessions.insert(session.seid, session);
+    }
+
+    pub fn get(&self, seid: u64) -> Option<&MupSession> {
+        self.sessions.get(&seid)
+    }
+
+    pub fn remove(&mut self, seid: u64) -> Option<MupSession> {
+        self.sessions.remove(&seid)
+    }
+
+    /// Drop every session owned by `peer` (PFCP association release).
+    /// Returns the removed SEIDs so the caller can emit withdrawals.
+    pub fn remove_peer(&mut self, peer: SocketAddr) -> Vec<u64> {
+        let victims: Vec<u64> = self
+            .sessions
+            .iter()
+            .filter(|(_, s)| s.peer == peer)
+            .map(|(seid, _)| *seid)
+            .collect();
+        for seid in &victims {
+            self.sessions.remove(seid);
+        }
+        victims
+    }
+}

--- a/zebra-rs/yang/config.yang
+++ b/zebra-rs/yang/config.yang
@@ -44,6 +44,10 @@ module config {
     prefix zbe;
   }
 
+  import zebra-bgp-mup-controller {
+    prefix zbmupc;
+  }
+
   import zebra-bgp-redistribute {
     prefix zbr;
   }

--- a/zebra-rs/yang/exec.yang
+++ b/zebra-rs/yang/exec.yang
@@ -363,6 +363,18 @@ module exec {
           ext:help "Summary of MUP-enabled neighbors";
           type empty;
         }
+        container mup-c {
+          ext:help "MUP Controller (MUP-C) status";
+          presence "MUP Controller (MUP-C) status";
+          leaf session {
+            ext:help "Learned PFCP sessions";
+            type empty;
+          }
+          leaf association {
+            ext:help "PFCP associations";
+            type empty;
+          }
+        }
       }
       list update-group {
         ext:help "BGP update-groups (IOS-XR style)";

--- a/zebra-rs/yang/zebra-bgp-mup-controller.yang
+++ b/zebra-rs/yang/zebra-bgp-mup-controller.yang
@@ -1,0 +1,140 @@
+module zebra-bgp-mup-controller {
+  yang-version "1";
+
+  namespace "urn:ietf:params:xml:ns:yang:zebra-bgp-mup-controller";
+  prefix "zbmupc";
+
+  import ietf-bgp {
+    prefix bgp;
+  }
+
+  import config {
+    prefix config;
+  }
+
+  import configure {
+    prefix configure;
+  }
+
+  import ietf-inet-types {
+    prefix inet;
+  }
+
+  organization
+    "zebra-rs";
+
+  contact
+    "https://github.com/zebra-rs";
+
+  description
+    "BGP MUP Controller (MUP-C) extensions to the BGP candidate-config
+     tree. Adds a `mup-c` container under the BGP global AFI/SAFI list,
+     only meaningful when the entry's name is `mobile-uplane` (SAFI 85,
+     RFC 9833). When enabled, the BGP task spawns an in-process MUP
+     controller that terminates PFCP/N4 (3GPP TS 29.244) as a UP-node,
+     learns mobile sessions and (in a follow-up) originates Type-1 /
+     Type-2 Session-Transformed routes.
+
+     Resulting CLI / config shape:
+
+       router bgp {
+         afi-safi {
+           name mobile-uplane;
+           mup-c {
+             enable true;
+             controller-address 2001:db8::1;
+             pfcp {
+               node-id 10.0.0.1;
+               listen-address ::;
+               port 8805;
+             }
+             srv6 { locator LOC1; }
+           }
+         }
+       }";
+
+  reference
+    "RFC 9833: A YANG ... (BGP MUP, draft-mpmz-bess-mup-safi)
+     3GPP TS 29.244: Interface between the Control Plane and the User
+     Plane Nodes (PFCP)";
+
+  grouping bgp-afi-safi-mup-c-extension {
+    description
+      "MUP controller config on the global afi-safi list. Only
+       meaningful when the list entry's name is `mobile-uplane` —
+       harmless and ignored on other AFI/SAFIs.";
+
+    container mup-c {
+      description
+        "BGP MUP Controller (MUP-C). Terminates PFCP/N4 as a UP-node and
+         originates MUP Session-Transformed routes from learned sessions.";
+
+      leaf enable {
+        type boolean;
+        default false;
+        description
+          "Master switch. When true, the BGP task spawns the in-process
+           MUP controller (PFCP listener); when false it is torn down.";
+      }
+
+      leaf controller-address {
+        type inet:ipv6-address;
+        description
+          "Controller IPv6 address advertised as the next hop on
+           originated Type-1 / Type-2 Session-Transformed routes.";
+      }
+
+      container pfcp {
+        description
+          "PFCP / N4 listener parameters (3GPP TS 29.244).";
+
+        leaf node-id {
+          type inet:ip-address;
+          description
+            "Our PFCP Node ID, returned in responses. Falls back to the
+             bind address / controller-address when unset.";
+        }
+        leaf listen-address {
+          type inet:ip-address;
+          description
+            "PFCP listen address. Defaults to `::` (all addresses) when
+             unset.";
+        }
+        leaf port {
+          type inet:port-number;
+          description
+            "PFCP listen port. Defaults to 8805 when unset.";
+        }
+      }
+
+      container srv6 {
+        description
+          "SRv6 parameters for originated routes (route phase).";
+        leaf locator {
+          type string;
+          description
+            "Name of the SRv6 locator per-session SIDs are drawn from.";
+        }
+      }
+
+      leaf architecture {
+        type enumeration {
+          enum "3gpp-5g";
+        }
+        default "3gpp-5g";
+        description
+          "Mobile architecture the controller serves. Informational.";
+      }
+    }
+  }
+
+  augment "/configure:set/config:router/bgp:bgp/bgp:afi-safi" {
+    description "MUP controller config under the global afi-safi list (set).";
+    uses bgp-afi-safi-mup-c-extension;
+  }
+
+  augment "/configure:delete/config:router/bgp:bgp/bgp:afi-safi" {
+    description "MUP controller config under the global afi-safi list (delete).";
+    uses bgp-afi-safi-mup-c-extension;
+  }
+}


### PR DESCRIPTION
## Summary

Implements the **BGP MUP Controller (MUP-C)** — the deferred P5 of the BGP MUP plan (RFC 9833 / `draft-mpmz-bess-mup-safi`, SAFI 85). The controller terminates **PFCP / N4** (3GPP TS 29.244, via the `rs-pfcp` crate) as a UP-node, learns mobile sessions, and originates MUP Session-Transformed routes.

Configured under the BGP instance at `router bgp afi-safi mobile-uplane mup-c { enable; controller-address; pfcp {…}; srv6 {…} }`, so the controller is spawned by the BGP task and handed its `Message` channel — the way a per-VRF BGP instance is.

### Commits
- **PR-A — ingest**: `src/mup-c/` controller task (own tokio UDP socket); Association/Heartbeat/Session Establishment/Modification/Deletion; session + association tables; `show bgp mobile-uplane mup-c [session|association]`.
- **Hardening** (from the automated commit security review): session-ownership check on Modify/Delete (closes an IDOR), association precondition on Establish, bounded association/session tables.
- **PR-B — origination**: `Bgp::originate_mup_route` correlates the session's Network Instance → a per-VRF `mobile-uplane` config (RD / route-targets / direction), allocates an SRv6 SID from the locator, builds the ST NLRI (encapsulation→T1ST UE prefix; decapsulation→T2ST endpoint+TEID) + attributes (controller-address next hop, RT exports, SRv6 L3 Service Prefix-SID), and advertises. Withdraw on Session Deletion / peer down.
- **PR-C — e2e**: `tools/pfcp-inject` (PFCP SMF simulator) + the `@bgp_mup_e2e` BDD feature/configs/doc.
- **docs**: book chapter `ch-02-35-bgp-mup.md` + `docs/design/bgp-mup-followups.md` (P5 marked built).

The forwarding plane (GTP4.E/GTP6.E) is intentionally out of scope — stock Linux has no GTP-U SRv6 behaviour (VPP/eBPF, the deferred P6).

## Test plan
- `cargo fmt`, `cargo clippy --workspace --all-targets -- -D warnings` (clean), `cargo test -p zebra-rs` (1406 pass) — incl. new `mup-c` PFCP-handler unit tests, the authorization-check tests, and the PR-B origination-helper test.
- `yang_load_tests` validate the new `zebra-bgp-mup-controller.yang` augment + `exec.yang`.
- **Live-validated end-to-end** (debug daemon + `pfcp-inject`): a PFCP session for UE 192.0.2.5 (NI `access`) produces `[ST1][65000:100][ue=192.0.2.5/32][teid=…]` in `show bgp mobile-uplane` with the controller-address next hop and RT export; Session Deletion withdraws it.
- `@bgp_mup_e2e` BDD feature added (run live with `make -C bdd bgp_mup_e2e`; CI excludes BDD).

🤖 Generated with [Claude Code](https://claude.com/claude-code)