### PR TITLE
bgp-lua: embedded Lua scripting engine + Loc-RIB import hook

### DIFF
--- a/docs/design/lua-scripting-policy.md
+++ b/docs/design/lua-scripting-policy.md
@@ -1,0 +1,544 @@
+# Lua Scripting Integration for zebra-rs — Loc-RIB Policy Hooks
+
+Status: **design / proposal** (branch `lua`)
+Prior art: FRR Scripting (合田和也, ENOG90 2026-06-19 — "FRR Scripting は何ができるのか").
+
+This document designs an embedded-Lua scripting facility for zebra-rs, modelled
+on FRR's `route-map match script` hook but **redesigned around the gaps that talk
+surfaced**. The agreed first step (per Kunihiro) is two hooks on the **Adj-RIB-In →
+Loc-RIB** boundary of BGP:
+
+1. **import hook** — fires when a received path is admitted from Adj-RIB-In into
+   the Loc-RIB (the inbound-policy decision point). The script sees the prefix,
+   the full path attributes, and the sending peer, and may *observe*, *deny*, or
+   *modify* attributes.
+2. **withdraw hook** — fires when a path is removed from the Loc-RIB. A withdraw
+   on the wire carries **only the NLRI**, so the hook reads the **stored Loc-RIB
+   attributes of the path being removed** and hands them to the script. This is
+   the half FRR structurally cannot do.
+
+Egress / Adj-RIB-Out origination hooks and the route-map `match script` clause are
+explicitly **later phases**, layered on the same engine.
+
+**Decisions locked (2026-06-21):**
+- The import hook includes **attribute write-back** in step 1 — `RM_MATCH_AND_CHANGE`
+  is in scope from the start, not deferred. The script can mutate `med`,
+  `local_pref`, `community`, `ext_community`, etc. and have the change land in the
+  Loc-RIB.
+- **IPv4-unicast first; EVPN Type-2 is Phase 2.** The policy engine is IPv4-typed
+  today, so step 1 wires the v4 ingest/withdraw paths; EVPN marshalling
+  (`prefix.evpn`) and the full GBP demo follow in Phase 2.
+
+---
+
+## 1. Why — what FRR proved, and what it could not do
+
+FRR exposes Lua at two points only (`on_rib_process_dplane_results` in zebra, and
+`route-map match script` in any daemon). The talk's worked example is **GBP
+(Group-Based Policy) over EVPN**: a Group-Policy-ID (GPI) BGP Extended Community
+(`draft-wlin-bess-group-policy-id-extended-community`, type `0x03` sub-type `0x17`,
+carrying a 16-bit tag) is attached to EVPN Type-2 (MAC) routes; receivers extract
+the tag and program nftables sets (`tag_100`, `tag_200`, …) to enforce
+group-to-group accept/deny.
+
+The talk hits three walls — all of which zebra-rs is positioned to avoid:
+
+| # | FRR limitation | zebra-rs answer |
+|---|----------------|-----------------|
+| L1 | Stock FRR Lua exposes only `metric` / `ifindex` / `aspath` / `localpref`; **Extended-Communities are invisible** — the presenter had to patch `bgpd` to expose `attributes.ext_community`. | `BgpAttr` already carries `ecom: Option<ExtCommunity>` and `lcom` natively (`crates/bgp-packet/src/bgp_attr.rs`). We expose the **whole** attribute set from day one. |
+| L2 | **No withdraw hook.** route-map is not invoked on withdraw, so nftables elements leak on EVPN withdraw. The `on_rib_process_dplane_results` hook *could* fire on delete, but it runs in **zebra** and has no access to **bgpd's** ext-comm → cannot recover the tag. | zebra-rs is a **single multi-threaded process**. The withdraw hook runs in the BGP module with the **removed Loc-RIB row's `attr` in hand** (`route_ipv4_withdraw` already returns `removed[].attr`). The tag is right there. |
+| L3 | Cross-daemon "cookie" problem — FRR wants a way to carry the MAC↔TAG binding across the bgpd/zebra boundary. | No boundary. Loc-RIB *is* the shared state; the withdraw hook reads it directly. |
+
+So the first step is deliberately the two Loc-RIB hooks: they (a) give Lua the full
+attribute set including ext-communities, and (b) make teardown-on-withdraw a
+first-class, in-process operation.
+
+---
+
+## 2. Scope
+
+**In scope (Phase 1–4):**
+- An embedded Lua 5.4 runtime, gated behind a Cargo feature `lua` (mirrors FRR's
+  `--enable-scripting` — off in default builds).
+- Import hook on `route_ipv4_update` (and the v4 batch/shard reduce paths).
+- Withdraw hook on `route_ipv4_withdraw` (and the shard `WithdrawV4` reduce).
+- A read/write marshalling layer for `prefix`, `attributes` (incl. `ext_community`),
+  and `peer`.
+- A safe host-helper surface (logging, a key/value map service, a fire-and-forget
+  side-effect channel for nftables/exec — *not* inline blocking I/O).
+- Config + YANG to bind a named script to the import/withdraw hooks, per-AFI.
+
+**Out of scope for step 1 (later phases, §11):**
+- EVPN Type-2 import/withdraw hooks (same mechanism, EVPN marshalling).
+- Egress / Adj-RIB-Out origination hook (the GBP *advertise* side that *adds* the GPI ecom).
+- route-map `match script` / `set script` clause (FRR parity, per-sequence).
+- IPv6/VPN families (the policy engine is IPv4-typed today; v6 follows the same shape).
+
+**Non-goals:** replacing the native route-map; a general plugin/FFI system; running
+untrusted scripts (scripts run with daemon privileges — operator-trusted, like FRR).
+
+---
+
+## 3. Architecture
+
+### 3.1 Crate / module layout
+
+```
+zebra-rs/src/script/            <- new module, behind feature = "lua"
+  mod.rs            ScriptEngine, ScriptRegistry, generation counter
+  marshal.rs        BgpAttr/Peer/prefix  <->  Lua tables & UserData
+  ecom.rs           ExtCommunity <-> Lua (raw 8-byte list + typed gpi() helper)
+  host.rs           sandboxed host API: zlog, map, sideeffect
+  hooks.rs          loc_rib_import() / loc_rib_withdraw() entry points
+```
+
+The BGP module calls `script::hooks::loc_rib_import(...)` / `loc_rib_withdraw(...)`.
+When the feature is off, these are `#[inline] fn …() {}` no-ops, so the ingest path
+compiles unchanged and pays nothing.
+
+### 3.2 Runtime choice: `mlua`
+
+- `mlua` with features `lua54`, `vendored` (bundles the interpreter — no system
+  dep), and `serde` (table ⇄ Rust via `serde`).
+- Rationale: actively maintained, Lua 5.4 (the version FRR moved to), `UserData`
+  for zero-copy mutable wrappers, `vendored` keeps CI hermetic. `rlua` is now a thin
+  shim over `mlua`.
+
+### 3.3 Threading model — the hard part FRR doesn't have
+
+zebra-rs runs BGP ingest across an async runtime and, at `N>1`, a **sharded
+lock-free Loc-RIB** (v4-unicast lives on the shard pool, not `main`; see
+`docs/design/` RIB-sharding notes and the `ShardMsg::WithdrawV4` reduce in
+`route_ipv4_withdraw`). An `mlua::Lua` is `!Sync` and cannot be shared mutably
+across threads. `policy_list_apply_net` is a **synchronous** function returning
+`Option<PolicyDecision>`, called from both the async peer task and the shard
+reduce — so the hook must be callable synchronously from whatever thread owns the
+route.
+
+**Decision: thread-local VM + global script registry + generation counter.**
+
+```
+ScriptRegistry (global, Arc<ArcSwap<Scripts>>):   compiled-source + generation:u64
+thread_local! ENGINE: RefCell<Engine>             one mlua::Lua per worker thread
+```
+
+- On the hot path, the hook borrows the thread-local `Engine`. If
+  `Engine.generation != registry.generation`, it recompiles the scripts into *this
+  thread's* VM (cheap, lazy, once per thread per reload) and bumps its local gen.
+- No cross-thread VM sharing, no global lock on the hot path. Each shard worker and
+  each peer task gets its own VM. Pure match/transform is embarrassingly parallel —
+  exactly how `route_ipv4_update_batch` already fans the policy walk across cores
+  with rayon.
+- Script *state* is therefore **per-thread** and must not be relied on for
+  cross-route memory. Shared state lives in Rust (the host `map` service, §3.5),
+  not in Lua globals.
+
+### 3.4 Pure vs side-effecting — no inline blocking I/O
+
+FRR's GBP scripts call `http.request(...)` and `os.execute("nft …")`
+**synchronously inside the route path**. FRR tolerates the stall because bgpd is
+single-threaded per peer. In zebra-rs that would block an async worker or a shard
+reduce — unacceptable.
+
+Two tiers:
+
+- **Pure tier (default):** the script may read/modify `prefix`/`attributes`/`peer`
+  and call non-blocking host helpers (`zlog`, `map.get`). Runs **inline** on the
+  thread-local VM. Deterministic, bounded.
+- **Side-effect tier (opt-in):** anything external (program nftables, HTTP) is
+  expressed as a **message**, not a blocking call. The script calls
+  `sideeffect.nft{op="add", set="tag_100", elem=mac}` which enqueues onto an
+  `mpsc` drained by a dedicated `tokio` task (or `spawn_blocking` for `nft`/exec).
+  The route path never blocks; ordering per (set) is preserved by the single
+  drainer. The MAC→tag lookup that FRR did over HTTP becomes `map.get("sgt", mac)`
+  against an in-memory table that a background task refreshes — a synchronous map
+  read on the hot path, async refresh off it.
+
+This is strictly better than FRR's model and leans on zebra-rs being one process
+with shared memory + an async runtime.
+
+### 3.5 The host `map` service
+
+A small `Arc<RwLock<HashMap<String, HashMap<String,String>>>>` (namespace → key →
+value), seeded from config and/or refreshed by a background fetcher task. Exposed to
+Lua as `map.get(ns, key)`. This replaces FRR's blocking `http.request` with a
+non-blocking lookup, while a Rust task does the HTTP refresh out of band.
+
+---
+
+## 4. The Lua contract
+
+### 4.1 Entry points
+
+Mirror FRR's `route_match` shape so scripts stay familiar/portable. Two functions,
+selected by hook:
+
+```lua
+-- import: Adj-RIB-In -> Loc-RIB. May observe / deny / modify.
+-- Returns an action; on MATCH_AND_CHANGE the (mutated) attributes are read back.
+function loc_rib_import(prefix, attributes, peer,
+                        RM_FAILURE, RM_NOMATCH, RM_MATCH, RM_MATCH_AND_CHANGE)
+    ...
+    return { action = RM_MATCH_AND_CHANGE, attributes = attributes }
+    -- or { action = RM_NOMATCH }  (admit unchanged; convention: "no opinion")
+    -- or { action = RM_FAILURE }  (deny — drop before Loc-RIB)
+end
+
+-- withdraw: path leaving the Loc-RIB. attributes are the STORED Loc-RIB attrs
+-- of the path being removed (read-only). Return value is ignored for routing;
+-- the hook is for side-effects (teardown). action=RM_FAILURE is logged only.
+function loc_rib_withdraw(prefix, attributes, peer,
+                          RM_FAILURE, RM_NOMATCH, RM_MATCH, RM_MATCH_AND_CHANGE)
+    ...
+    return { action = RM_NOMATCH }
+end
+```
+
+Action semantics for the **import** hook (maps onto the existing
+`Option<PolicyDecision>` contract of `policy_list_apply_net`):
+
+| Lua `action` | Effect on import |
+|---|---|
+| `RM_FAILURE` | Deny — route is dropped (returns `None`, like a route-map `deny`). |
+| `RM_NOMATCH` | Admit the route **unchanged** (script had no opinion). |
+| `RM_MATCH` | Admit unchanged (explicit match, no attr edits). |
+| `RM_MATCH_AND_CHANGE` | Admit with the script's mutated `attributes`. |
+
+Errors / a missing function / a non-table return are **fail-safe**: logged, treated
+as `RM_NOMATCH` (admit unchanged) so a broken script never silently blackholes
+traffic. (Configurable to `RM_FAILURE`=deny for fail-closed deployments.)
+
+### 4.2 `prefix`
+
+```lua
+prefix.network   -- "10.0.0.0/24"  (string, FRR-compatible)
+prefix.afi       -- "ipv4" | "ipv6" | "evpn"
+prefix.addr      -- "10.0.0.0"
+prefix.len       -- 24
+-- EVPN (phase 2):  prefix.evpn = { route_type=2, mac="aa:bb:cc:dd:ee:00",
+--                                  ip=..., vni=..., rd=... }
+```
+
+For EVPN, zebra-rs parses the route natively, so the script gets a **structured**
+`prefix.evpn.mac` instead of FRR's brittle `tostring(prefix.network):match(...)`
+regex on `[2]:[0]:[48]:[aa:bb:cc:dd:ee:00]`.
+
+### 4.3 `attributes` — the full set (fixes L1)
+
+Exposed as `UserData` so reads are lazy and writes mutate a working `BgpAttr` the
+host reads back. Field map (R = readable, W = writable in import hook):
+
+| Lua field | `BgpAttr` source | R | W |
+|---|---|---|---|
+| `attributes.med` | `med: Option<Med>` | ✓ | ✓ |
+| `attributes.local_pref` | `local_pref: Option<LocalPref>` | ✓ | ✓ |
+| `attributes.weight` | local weight (PolicyDecision) | ✓ | ✓ |
+| `attributes.origin` | `origin: Option<Origin>` ("igp"/"egp"/"incomplete") | ✓ | ✓ |
+| `attributes.as_path` | `aspath: Option<As4Path>` (list of ASNs) | ✓ | ✓ |
+| `attributes.next_hop` | `nexthop: Option<BgpNexthop>` | ✓ | ✓ |
+| `attributes.community` | `com: Option<Community>` (list "ASN:val") | ✓ | ✓ |
+| `attributes.large_community` | `lcom: Option<LargeCommunity>` | ✓ | ✓ |
+| `attributes.ext_community` | `ecom: Option<ExtCommunity>` (list of 8-byte values) | ✓ | ✓ |
+
+`ext_community` is the headline. It is a list of opaque 8-octet values so the
+FRR-style `string.pack(">BBHHH", …)` / `string.unpack` idiom works **verbatim**,
+plus a typed convenience (§4.5).
+
+### 4.4 `peer`
+
+Read-only, populated from `Peer`:
+
+```lua
+peer.remote_as, peer.local_as,
+peer.remote_id, peer.local_id,            -- router-ids
+peer.remote_address, peer.local_address,
+peer.state,                               -- "Established" etc.
+peer.is_ibgp,
+peer.description
+-- stats/timers can be added incrementally (FRR exposes a large table; we add on demand)
+```
+
+### 4.5 Host helpers (sandboxed)
+
+The base sandbox **removes** `os`, `io`, `package`, `require`, `dofile`,
+`loadfile`. In their place:
+
+```lua
+zlog.info(msg) / zlog.warn(msg) / zlog.error(msg)   -- into the daemon log
+map.get(ns, key)            -- non-blocking lookup (e.g. map.get("sgt", mac))
+ecom.gpi(tag)               -- build a GPI ext-community value (type 0x03, sub 0x17)
+ecom.parse_gpi(value)       -- -> tag or nil   (typed decode; avoids manual unpack)
+sideeffect.nft{op=, table=, set=, elem=}            -- enqueue nft mutation (tier 2)
+```
+
+`string.pack`/`string.unpack`/`string`/`table`/`math` remain available (pure).
+
+---
+
+## 5. Marshalling (Rust ⇄ Lua)
+
+- `prefix` and `peer`: built as plain Lua tables once per hook call (small, cheap).
+- `attributes`: an `mlua::UserData` wrapper around `&mut BgpAttr` (+ working weight)
+  with `__index`/`__newindex` metamethods. Reads pull from the live `BgpAttr`;
+  writes set an "dirty" flag and the field. After the call, if `action ==
+  MATCH_AND_CHANGE`, the host keeps the mutated `BgpAttr`; otherwise it discards it.
+- `ExtCommunity` ⇄ Lua: `marshal::ecom` converts to/from a Lua sequence of 8-byte
+  binary strings (matching FRR). `ecom.gpi`/`ecom.parse_gpi` are Rust closures that
+  encode/decode the GPI layout so scripts don't hand-roll byte math.
+- Lifetime: the `UserData` borrows for the duration of the synchronous call only;
+  nothing escapes the VM (we never store Lua refs to Rust data across calls).
+
+---
+
+## 6. Config & YANG
+
+A defined-set holding script source/path, plus per-AFI binding of the two hooks.
+New YANG `zebra-lua-policy.yang` augmenting the routing-policy tree:
+
+```
+policy
+  lua-script <NAME>
+    source-path <FILE>        # or inline `source <heredoc>` for tests
+    fail-action permit|deny   # default permit (fail-safe)
+bgp <ASN>
+  loc-rib-hook ipv4-unicast
+    import  <NAME>            # bind script NAME's loc_rib_import
+    withdraw <NAME>           # bind script NAME's loc_rib_withdraw
+```
+
+Config example:
+
+```
+policy lua-script GBP
+  source-path /etc/zebra-rs/lua/gbp.lua
+bgp 65000
+  loc-rib-hook ipv4-unicast import GBP withdraw GBP
+```
+
+Parsing follows the existing `PolicyConfig::exec()` dispatch; the binding lands in
+new `Bgp`/per-AFI fields, and a `ScriptRegistry` reload bumps the generation counter
+so thread-local VMs lazily recompile (§3.3). EVPN binds under
+`loc-rib-hook l2vpn-evpn` in phase 2.
+
+---
+
+## 7. Integration points — step by step
+
+### 7.1 Import hook (Adj-RIB-In → Loc-RIB)
+
+`route_ipv4_update` (`zebra-rs/src/bgp/route.rs:2965`) today:
+
+```rust
+let decision = {
+    let peer = peers.get_mut_by_idx(ident).expect("peer must exist");
+    route_apply_policy_in(peer, afi_safi, nlri, attr.clone(), 0)   // :2996
+};
+```
+
+Insert the hook **after** native inbound policy, before
+`route_ipv4_update_decided` writes the Loc-RIB:
+
+```rust
+let decision = route_apply_policy_in(peer, afi_safi, nlri, attr.clone(), 0);
+#[cfg(feature = "lua")]
+let decision = script::hooks::loc_rib_import(   // no-op when feature off
+    bgp.script.as_ref(),                        // bound script for this AFI, or None
+    IpNet::V4(nlri.prefix),
+    decision,                                   // Option<PolicyDecision> threads through
+    peer,
+);
+```
+
+`loc_rib_import` is a thin wrapper: if no script is bound, or `decision` is already
+`None` (native policy denied), return as-is; else build `prefix`/`attributes`(from
+`decision.attr`)/`peer`, run `loc_rib_import`, and fold the action back into
+`Option<PolicyDecision>`. The same call is added to the batch path
+(`route_ipv4_update_batch`, :3058) and the shard ingest reduce so `N>1` is covered.
+
+### 7.2 Withdraw hook (→ Loc-RIB removal) — reads stored attrs
+
+`route_ipv4_withdraw` (`zebra-rs/src/bgp/route.rs:5466`) removes from Loc-RIB and
+**returns the removed rows with their attributes**:
+
+```rust
+let mut removed = bgp.shard.remove(rd, nlri.prefix, nlri.id, ident);   // :5508
+```
+
+`removed[].attr` is the stored Loc-RIB attribute set of the path that just left —
+already used downstream at :5585 (`gone.attr`). Fire the hook here:
+
+```rust
+let mut removed = bgp.shard.remove(rd, nlri.prefix, nlri.id, ident);
+#[cfg(feature = "lua")]
+if let Some(gone) = removed.first() {
+    script::hooks::loc_rib_withdraw(
+        bgp.script.as_ref(),
+        IpNet::V4(nlri.prefix),
+        &gone.attr,                 // <-- the attrs a wire-withdraw doesn't carry
+        peers.get_by_idx(ident),
+    );
+}
+```
+
+**Sharding caveat (N>1):** v4-unicast withdraws are dispatched as
+`ShardMsg::WithdrawV4` and reduced in `route_apply_bestpath_v4_batch`. The hook must
+fire where `removed`/`gone.attr` is actually known — i.e. in the **shard reduce**,
+not before dispatch. Phase 1 wires both the synchronous (VPNv4 / `N==1`) site shown
+above **and** the reduce site; a unit test asserts the hook fires exactly once per
+withdrawn path in both modes. (This mirrors the show/originate read-path lesson:
+at `N>1` the v4 RIB is on the pool, so RIB-touching logic must run on the shard.)
+
+### 7.3 Engine entry (`script/hooks.rs`, sketch)
+
+```rust
+pub fn loc_rib_import(
+    script: Option<&BoundScript>, prefix: IpNet,
+    decision: Option<PolicyDecision>, peer: &Peer,
+) -> Option<PolicyDecision> {
+    let (Some(script), Some(mut d)) = (script, decision) else { return decision; };
+    ENGINE.with(|e| {
+        let mut e = e.borrow_mut();
+        e.sync(&SCRIPTS.load());                  // lazy recompile if generation changed
+        match e.run_import(script, prefix, &mut d, peer) {
+            Ok(Action::Failure)        => None,                  // deny
+            Ok(Action::Change)         => Some(d),               // d.attr mutated in place
+            Ok(_) /* NoMatch|Match */  => Some(d),               // admit unchanged
+            Err(err) => { zlog_warn!(err); Some(d) }             // fail-safe: admit
+        }
+    })
+}
+```
+
+---
+
+## 8. Worked example — GBP over EVPN (receiver + teardown)
+
+The two Phase-1 hooks implement the **consumer** half of the talk's demo (the
+*advertise* half is the egress hook, Phase 5). With EVPN marshalling (phase 2) the
+same hooks run for Type-2 routes. Single script, both functions:
+
+```lua
+-- /etc/zebra-rs/lua/gbp.lua
+
+local function mac_of(prefix)
+    return prefix.evpn and prefix.evpn.mac            -- native EVPN parse (no regex)
+end
+
+-- Receive: extract GPI tag from ext-community, program nftables.
+function loc_rib_import(prefix, attributes, peer, FAIL, NOMATCH, MATCH, CHANGE)
+    local mac = mac_of(prefix)
+    if not mac then return { action = NOMATCH } end
+    for _, ec in ipairs(attributes.ext_community) do
+        local tag = ecom.parse_gpi(ec)                -- typed decode of 0x03/0x17
+        if tag then
+            sideeffect.nft{ op="add", table="bridge gbp_filter",
+                            set="tag_" .. tag, elem=mac }  -- non-blocking enqueue
+            zlog.info("gbp: " .. mac .. " -> tag " .. tag)
+            break
+        end
+    end
+    return { action = NOMATCH }                       -- observe only; route unchanged
+end
+
+-- Withdraw: the path is leaving the Loc-RIB. `attributes` are the STORED attrs,
+-- so we still see the GPI tag and can remove the nft element. FRR cannot do this.
+function loc_rib_withdraw(prefix, attributes, peer, FAIL, NOMATCH, MATCH, CHANGE)
+    local mac = mac_of(prefix)
+    if not mac then return { action = NOMATCH } end
+    for _, ec in ipairs(attributes.ext_community) do
+        local tag = ecom.parse_gpi(ec)
+        if tag then
+            sideeffect.nft{ op="delete", table="bridge gbp_filter",
+                            set="tag_" .. tag, elem=mac }
+            zlog.info("gbp: withdraw " .. mac .. " from tag " .. tag)
+            break
+        end
+    end
+    return { action = NOMATCH }
+end
+```
+
+The MAC→tag map server (FRR's blocking HTTP GET) is only needed on the *advertise*
+side (Phase 5); there it becomes `map.get("sgt", mac)` with a background refresher.
+
+---
+
+## 9. Phased PR plan (small PRs, branch `lua`)
+
+| PR | Title | Content | Test | Status |
+|----|-------|---------|------|--------|
+| 1 | engine skeleton | `mlua` dep behind `lua` feature; thread-local VM + registry generation; `Action`/RM_* contract; sandbox (`os`/`io`/`package` stripped, per-script `_ENV`); no-op hooks when feature off. | unit: load source, call `loc_rib_import` → NOMATCH; sandbox + fail-safe. | **done** |
+| 2 | marshalling / data model | `prefix` / read-only `attributes` (incl. `ext_community` as 8-byte values) / `peer` (`PeerView`) tables; `loc_rib_import(name, prefix, attr, peer) -> Action`. | unit: GPI `ext_community` `string.unpack`; prefix/peer marshalling; fail-safe. | **done** |
+| 3 | config surface + ingest wiring | `zebra-bgp-lua.yang` augment (`lua-script source-path`, `loc-rib-hook ipv4-unicast import`); BGP config handlers → registry (`set_source` / `set_import_binding_v4`); hook at the shard chokepoint `handle_update_v4` (covers N=1 **and** N>1, plain v4-unicast; VPNv4 skipped). | unit: binding dispatch (Failure→deny); `configure_mode_loads` YANG test. | **done** |
+| 4 | attribute write-back | `ImportOutcome { action, attr }`; read the script-mutated `attributes` table back onto the original `BgpAttr` on `MATCH_AND_CHANGE` (writable: `med`/`local_pref`/`origin`/`community`/`ext_community`; other attrs preserved); shard hook applies it; `ecom.gpi`/`parse_gpi` host helpers; `community`/`ext_community` always-present lists for append. | unit: set med/local-pref, append GPI ecom, clear-on-nil, NOMATCH-no-change. | **done** |
+| 5 | withdraw hook + side-effects | `loc_rib_withdraw` at `route_ipv4_withdraw` **and** the `WithdrawV4` shard reduce (fires once, both modes, reads `removed.attr`); `zlog`, `map.get`, `sideeffect.nft` drainer task. | unit: fires once per withdrawn path at N=1/N>1. | |
+| 6 | GBP EVPN BDD | EVPN Type-2 marshalling (`prefix.evpn`); enrich the shard peer table (remote-as/addresses); end-to-end `@bgp_lua_gbp` feature. Requires a **`--features lua` BDD binary** (see note). | BDD with explicit `Teardown topology`. | |
+
+Each PR is independently revertible; the feature flag keeps `main` builds untouched
+until the engine is proven. **BDD note:** the BDD harness runs a manually-installed
+`/usr/bin/zebra-rs`; the `lua` feature is off by default, so a Lua BDD needs that
+binary built with `--features lua` (a dedicated build/CI lane). Until that lane
+exists, Lua behaviour is covered by the `#[cfg(feature = "lua")]` unit tests.
+Later: egress/origination hook (Phase 5b — *adds* the GPI ecom on advertise;
+**must join `UpdateGroupSig`**, see §10), route-map `match script` clause (FRR
+parity), IPv6/VPN. The shard peer table is partial today (router-id + IBGP/EBGP);
+enriching it needs extra fields on `ShardUpdateV4` (PR6).
+
+---
+
+## 10. Risks & gotchas
+
+- **`UpdateGroupSig` (for the later egress hook).** Any Lua transform on the
+  *outbound* path changes per-neighbor egress attributes. Two peers with different
+  bound scripts (or a different script generation) must **not** share an
+  update-group. The bound-script identity + generation must be folded into
+  `UpdateGroupSig`, or egress members silently leak each other's attrs. BDD won't
+  catch this; the signature unit test will. (Not a Phase-1 concern — import/withdraw
+  hooks are ingress — but called out so the egress phase doesn't repeat the
+  as-override / outbound-knob trap.)
+- **Sharding (N>1).** Both hooks must fire on the thread that owns the route (shard
+  reduce), not before dispatch, or the withdraw hook sees no `removed.attr`. Tested
+  explicitly in PR4.
+- **No inline blocking I/O.** Enforced by the sandbox (no `os`/`io`) + the
+  side-effect channel. A script that busy-loops still stalls its worker — Phase 1
+  is pure/bounded; if scripts grow, add an instruction-count hook
+  (`Lua::set_hook`) to cap runtime.
+- **Fail-safe default.** Script error / missing function / bad return ⇒ log +
+  `RM_NOMATCH` (admit unchanged). `fail-action deny` opt-in for fail-closed sites.
+- **Hot reload races.** Generation counter + lazy per-thread recompile; a reload
+  mid-batch is fine — each route uses whatever generation its thread last synced,
+  and the next route picks up the new one. No partial-script visibility (compile is
+  all-or-nothing into the VM).
+- **Privilege.** Scripts run as the daemon. Gate behind the `lua` build feature
+  *and* explicit config; document that `loc-rib-hook` grants code execution.
+- **Determinism / ordering.** `sideeffect.nft` ops are serialized per-set by the
+  single drainer, so add-before-delete ordering across an import→withdraw of the
+  same MAC is preserved.
+
+---
+
+## 11. Later phases (sketch)
+
+- **EVPN hooks (Phase 2):** same engine; `route_*_evpn` ingest/withdraw
+  (`route_apply_policy_in_evpn` :2723, `route_withdraw_evpn` :4756) + `prefix.evpn`
+  marshalling. Unlocks the full GBP demo.
+- **Egress / origination hook (Phase 5b):** a hook on the Adj-RIB-Out build path
+  that lets a script *add* attributes (the GBP advertise side: `map.get` the tag,
+  `ecom.gpi(tag)`, append). **Joins `UpdateGroupSig`** (§10).
+- **route-map `match script` / `set script` (Phase 6):** FRR-parity per-sequence
+  clause. Reuses §4–5 wholesale; adds `PolicyEntry.match_script: Option<String>`
+  and a call in `entry_matches` (`route.rs:11059`) + the `Permit|Next` set block
+  (`route.rs:11000`). This is the closest analogue to FRR's actual hook, layered on
+  top of the Loc-RIB hooks rather than instead of them.
+- **IPv6 / VPN families:** once the policy engine is family-generic on the v6 side.
+
+---
+
+## 12. Summary
+
+The first step — **import and withdraw hooks on the Adj-RIB-In → Loc-RIB
+boundary** — is the highest-leverage slice: it hands Lua the full native attribute
+set (including ext-communities, fixing FRR's L1), and makes **withdraw-time teardown
+a first-class operation reading the stored Loc-RIB attrs** (fixing L2/L3, which
+FRR's cross-daemon architecture cannot). Everything else (egress origination,
+route-map `match script`, EVPN/v6) layers on the same engine and marshalling.

--- a/zebra-rs/Cargo.toml
+++ b/zebra-rs/Cargo.toml
@@ -77,6 +77,16 @@ sha1 = "0.11"
 sha2 = "0.11"
 hmac = "0.13"
 rs-pfcp = "0.3.1"
+# Embedded Lua scripting engine — optional, enabled by the `lua` feature.
+# `vendored` bundles the Lua 5.4 interpreter so the build stays hermetic
+# (no system liblua). Off by default, mirroring FRR's --enable-scripting.
+mlua = { version = "0.10", features = ["lua54", "vendored"], optional = true }
+
+[features]
+default = []
+# Compile the embedded Lua scripting engine (src/script). Off by default;
+# enable with `--features lua`.
+lua = ["dep:mlua"]
 
 [target.'cfg(target_os = "linux")'.dependencies]
 rtnetlink = { git = "https://github.com/zebra-rs/rtnetlink", rev = "2d7b1830e9bd9a049a757f0a79ccd16216450bf2" }

--- a/zebra-rs/src/bgp/config.rs
+++ b/zebra-rs/src/bgp/config.rs
@@ -76,6 +76,52 @@ fn config_global_no_fib_install(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> 
     Some(())
 }
 
+/// `set router bgp lua-script <name> source-path <path>` — load a named
+/// Lua script from a file into the global script registry. With the `lua`
+/// build feature off the registry is still populated (so a config
+/// round-trips) but never executed. A read error logs and clears that
+/// script rather than failing the commit.
+fn config_lua_script_source_path(_bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Option<()> {
+    let name = args.string()?;
+    if op.is_set() {
+        let path = args.string()?;
+        match std::fs::read_to_string(&path) {
+            Ok(src) => crate::script::set_source(&name, Some(src)),
+            Err(e) => {
+                tracing::warn!("lua: cannot read script '{name}' from '{path}': {e}");
+                crate::script::set_source(&name, None);
+            }
+        }
+    } else {
+        crate::script::set_source(&name, None);
+    }
+    Some(())
+}
+
+/// `delete router bgp lua-script <name>` — drop the named script. The
+/// `set` of the list node itself carries no data (the `source-path` leaf
+/// installs it), so only delete acts here.
+fn config_lua_script(_bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Option<()> {
+    if op == ConfigOp::Delete {
+        let name = args.string()?;
+        crate::script::set_source(&name, None);
+    }
+    Some(())
+}
+
+/// `set router bgp loc-rib-hook ipv4-unicast import <name>` — bind a
+/// script to the IPv4-unicast Adj-RIB-In → Loc-RIB import hook; delete
+/// unbinds.
+fn config_loc_rib_hook_import_v4(_bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Option<()> {
+    if op.is_set() {
+        let name = args.string()?;
+        crate::script::set_import_binding_v4(Some(name));
+    } else {
+        crate::script::set_import_binding_v4(None);
+    }
+    Some(())
+}
+
 /// `set router bgp segment-routing srv6 locator <name>` — names the
 /// SRv6 locator BGP carves per-VRF End.DT46 service SIDs from for
 /// L3VPN over SRv6 (RFC 9252). Mirrors `router isis / segment-routing
@@ -3612,6 +3658,17 @@ impl Bgp {
         self.callback_add(
             "/router/bgp/segment-routing/srv6/ipv6-unicast",
             config_srv6_ipv6_unicast,
+        );
+        // Embedded Lua scripting (zebra-bgp-lua.yang): define scripts and
+        // bind the IPv4-unicast Adj-RIB-In → Loc-RIB import hook.
+        self.callback_add("/router/bgp/lua-script", config_lua_script);
+        self.callback_add(
+            "/router/bgp/lua-script/source-path",
+            config_lua_script_source_path,
+        );
+        self.callback_add(
+            "/router/bgp/loc-rib-hook/ipv4-unicast/import",
+            config_loc_rib_hook_import_v4,
         );
         self.callback_peer("", config_peer);
         self.callback_peer("/remote-as", config_remote_as);

--- a/zebra-rs/src/bgp/shard/dispatch.rs
+++ b/zebra-rs/src/bgp/shard/dispatch.rs
@@ -360,6 +360,40 @@ impl BgpShard {
             decision
         };
 
+        // Lua import hook (Adj-RIB-In → Loc-RIB), run on the shard worker
+        // thread (thread-local VM) right after native inbound policy.
+        // Plain IPv4-unicast only (`rd == None`); VPNv4 is skipped. The
+        // shard carries only router-id + IBGP/EBGP for the peer table —
+        // remote-as / addresses are enriched in a later PR. A `Failure`
+        // verdict denies the route (same drop path as a policy deny).
+        #[cfg(feature = "lua")]
+        let decision = decision.and_then(|mut d| {
+            if rd.is_some() {
+                return Some(d);
+            }
+            let peer = crate::script::PeerView {
+                remote_as: 0,
+                local_as: 0,
+                remote_id: peer_router_id,
+                local_id: std::net::Ipv4Addr::UNSPECIFIED,
+                remote_address: std::net::IpAddr::V4(std::net::Ipv4Addr::UNSPECIFIED),
+                state: String::new(),
+                is_ibgp: matches!(typ, super::super::route::BgpRibType::IBGP),
+            };
+            let outcome =
+                crate::script::loc_rib_import_v4(ipnet::IpNet::V4(nlri.prefix), &d.attr, &peer);
+            match outcome.action {
+                crate::script::Action::Failure => None,
+                crate::script::Action::MatchAndChange => {
+                    if let Some(attr) = outcome.attr {
+                        d.attr = attr;
+                    }
+                    Some(d)
+                }
+                _ => Some(d),
+            }
+        });
+
         let Some(decision) = decision else {
             // Inbound policy denied: drop any Loc-RIB row from this peer.
             let removed = self.remove(rd, nlri.prefix, nlri.id, ident);

--- a/zebra-rs/src/config/configs.rs
+++ b/zebra-rs/src/config/configs.rs
@@ -679,7 +679,10 @@ pub fn delete(paths: Vec<CommandPath>, mut config: Rc<Config>) {
                 }
             }
             YangMatch::LeafMatched => {
-                if config.value.borrow().as_ref() != path.name {
+                // `as_str()` (not `as_ref()`): the `lua` feature pulls in
+                // `bstr`, whose `PartialEq<String> for &BStr` makes a bare
+                // `as_ref()` here ambiguous. `as_str()` pins it to `&str`.
+                if config.value.borrow().as_str() != path.name {
                     break;
                 }
             }

--- a/zebra-rs/src/main.rs
+++ b/zebra-rs/src/main.rs
@@ -34,6 +34,11 @@ use policy::Policy;
 mod rib;
 use rib::{LogFormatType, LogOutputType, Rib, logging_config, tracing_set};
 mod ospf;
+// Embedded Lua scripting engine, behind the `lua` feature. PR1 is the
+// engine skeleton only; the route.rs Loc-RIB hooks that call it land in a
+// later PR, so nothing references it yet — drop the allow once wired.
+#[allow(dead_code)]
+mod script;
 mod spf;
 mod srv6;
 mod stamp;

--- a/zebra-rs/src/script/engine.rs
+++ b/zebra-rs/src/script/engine.rs
@@ -1,0 +1,530 @@
+//! Per-thread Lua VM, sandbox, and script loading (feature = "lua").
+//!
+//! Each worker thread owns one [`Engine`] (a sandboxed `mlua::Lua` plus
+//! the per-script environment tables). The Loc-RIB hooks call
+//! synchronously from whatever thread owns the route — the sharded
+//! Loc-RIB means that can be any shard worker — so a thread-local VM
+//! avoids cross-thread sharing of the `!Sync` `Lua` and keeps the hot
+//! path lock-free. A reload is picked up lazily: the first call on each
+//! thread after a generation bump rebuilds that thread's VM.
+
+use std::cell::RefCell;
+use std::collections::BTreeMap;
+
+use bgp_packet::BgpAttr;
+use ipnet::IpNet;
+use mlua::{Function, Lua, Table, Value};
+
+use super::{Action, ImportOutcome, PeerView, Scripts, current, marshal};
+
+thread_local! {
+    static ENGINE: RefCell<Engine> = RefCell::new(Engine::new());
+}
+
+/// Per-thread compiled state: one sandboxed VM plus the per-script
+/// environment tables that hold each script's hook functions.
+/// `generation` records which registry snapshot this VM was built from;
+/// a mismatch triggers a lazy rebuild in [`Engine::sync`].
+struct Engine {
+    lua: Lua,
+    generation: u64,
+    envs: BTreeMap<String, Table>,
+}
+
+/// Safe standard-library symbols copied into each script's environment.
+/// Everything else — `os`, `io`, `package`, `require`, `load*`,
+/// `dofile`, `debug`, `print` — is intentionally absent (sandbox). The
+/// non-blocking host helpers (`zlog`, `map`, `sideeffect`) arrive in a
+/// later PR.
+const SAFE_GLOBALS: &[&str] = &[
+    "string",
+    "table",
+    "math",
+    "tostring",
+    "tonumber",
+    "type",
+    "pairs",
+    "ipairs",
+    "next",
+    "select",
+    "pcall",
+    "xpcall",
+    "error",
+    "assert",
+    "rawget",
+    "rawset",
+    "rawequal",
+    "rawlen",
+    "setmetatable",
+    "getmetatable",
+];
+
+/// Dangerous globals stripped from the VM itself, as defence-in-depth on
+/// top of the per-script environment (a script's `_ENV` already excludes
+/// these, but dropping them from the VM closes any leak path).
+const STRIPPED_GLOBALS: &[&str] = &[
+    "os",
+    "io",
+    "package",
+    "require",
+    "dofile",
+    "loadfile",
+    "load",
+    "loadstring",
+    "debug",
+    "collectgarbage",
+    "print",
+];
+
+impl Engine {
+    fn new() -> Self {
+        // Start at u64::MAX so the first call on this thread always syncs
+        // against the registry (whose initial generation is 0).
+        Engine {
+            lua: Lua::new(),
+            generation: u64::MAX,
+            envs: BTreeMap::new(),
+        }
+    }
+
+    /// Recompile against `scripts` if our generation is stale. A fresh VM
+    /// is built so old script state and functions are fully dropped. A
+    /// script that fails to load is logged and skipped (its hooks then
+    /// fail-safe to `NoMatch`); the generation still advances so we do
+    /// not retry-compile on every call.
+    fn sync(&mut self, scripts: &Scripts) {
+        if self.generation == scripts.generation {
+            return;
+        }
+        let lua = Lua::new();
+        let globals = lua.globals();
+        for &sym in STRIPPED_GLOBALS {
+            let _ = globals.set(sym, Value::Nil);
+        }
+        let mut envs = BTreeMap::new();
+        for (name, src) in &scripts.sources {
+            match load_script(&lua, name, src) {
+                Ok(env) => {
+                    envs.insert(name.clone(), env);
+                }
+                Err(err) => {
+                    tracing::warn!("lua: script '{name}' failed to load: {err}");
+                }
+            }
+        }
+        self.lua = lua;
+        self.envs = envs;
+        self.generation = scripts.generation;
+    }
+
+    fn run_import(
+        &self,
+        name: &str,
+        prefix: IpNet,
+        attr: &BgpAttr,
+        peer: &PeerView,
+    ) -> mlua::Result<ImportOutcome> {
+        let env = self
+            .envs
+            .get(name)
+            .ok_or_else(|| mlua::Error::RuntimeError(format!("no loaded script '{name}'")))?;
+        let func: Function = env.get("loc_rib_import")?;
+        let prefix_t = marshal::prefix_table(&self.lua, prefix)?;
+        let attr_t = marshal::attr_table(&self.lua, attr)?;
+        let peer_t = marshal::peer_table(&self.lua, peer)?;
+        let ret: Value = func.call((
+            prefix_t,
+            attr_t,
+            peer_t,
+            Action::Failure as i64,
+            Action::NoMatch as i64,
+            Action::Match as i64,
+            Action::MatchAndChange as i64,
+        ))?;
+        let Value::Table(table) = ret else {
+            return Err(mlua::Error::RuntimeError(
+                "script must return a table { action = ... }".into(),
+            ));
+        };
+        let action_i: i64 = table.get("action")?;
+        let action = Action::from_i64(action_i)
+            .ok_or_else(|| mlua::Error::RuntimeError(format!("unknown action {action_i}")))?;
+        // Fold a mutated `attributes` table back onto the input attr only
+        // on MATCH_AND_CHANGE; a missing `attributes` field means "no
+        // change" (admit with the original).
+        let new_attr = if action == Action::MatchAndChange {
+            match table.get::<Option<Table>>("attributes")? {
+                Some(attrs) => Some(marshal::read_attr(&attrs, attr)?),
+                None => None,
+            }
+        } else {
+            None
+        };
+        Ok(ImportOutcome {
+            action,
+            attr: new_attr,
+        })
+    }
+}
+
+/// Load one script source into its own sandboxed environment table and
+/// return that table. The chunk's `_ENV` is the env table, so the script
+/// sees only [`SAFE_GLOBALS`] and its own definitions — no cross-script
+/// global collisions. After `exec`, the env holds the script's
+/// `loc_rib_import` / `loc_rib_withdraw` functions.
+fn load_script(lua: &Lua, name: &str, src: &str) -> mlua::Result<Table> {
+    let env = lua.create_table()?;
+    let globals = lua.globals();
+    for &sym in SAFE_GLOBALS {
+        let value: Value = globals.get(sym)?;
+        if value != Value::Nil {
+            env.set(sym, value)?;
+        }
+    }
+    install_host_helpers(lua, &env)?;
+    lua.load(src)
+        .set_name(name)
+        .set_environment(env.clone())
+        .exec()?;
+    Ok(env)
+}
+
+/// Register the non-blocking host helpers exposed to scripts. PR4 adds the
+/// `ecom` typed Group-Policy-ID helpers (draft-wlin-bess, type 0x03,
+/// sub-type 0x17); `zlog` / `map` / `sideeffect` follow in a later PR.
+fn install_host_helpers(lua: &Lua, env: &Table) -> mlua::Result<()> {
+    let ecom = lua.create_table()?;
+    // ecom.gpi(tag) -> 8-octet GPI extended-community value.
+    ecom.set(
+        "gpi",
+        lua.create_function(|lua, tag: u16| {
+            let mut bytes = [0u8; 8];
+            bytes[0] = 0x03;
+            bytes[1] = 0x17;
+            bytes[6] = (tag >> 8) as u8;
+            bytes[7] = (tag & 0xff) as u8;
+            lua.create_string(&bytes[..])
+        })?,
+    )?;
+    // ecom.parse_gpi(value) -> tag, or nil if not a GPI ext-community.
+    ecom.set(
+        "parse_gpi",
+        lua.create_function(|_, value: mlua::String| {
+            let bytes = value.as_bytes();
+            Ok(
+                if bytes.len() == 8 && bytes[0] == 0x03 && bytes[1] == 0x17 {
+                    Some(u16::from_be_bytes([bytes[6], bytes[7]]))
+                } else {
+                    None
+                },
+            )
+        })?,
+    )?;
+    env.set("ecom", ecom)?;
+    Ok(())
+}
+
+/// Thread-local entry point used by [`super::loc_rib_import`]. Fail-safe:
+/// sync/run errors are logged and mapped to [`ImportOutcome::nomatch`].
+pub fn loc_rib_import(name: &str, prefix: IpNet, attr: &BgpAttr, peer: &PeerView) -> ImportOutcome {
+    let scripts = current();
+    ENGINE.with(|cell| {
+        let mut engine = cell.borrow_mut();
+        engine.sync(&scripts);
+        match engine.run_import(name, prefix, attr, peer) {
+            Ok(outcome) => outcome,
+            Err(err) => {
+                tracing::warn!("lua: import hook '{name}' error: {err}");
+                ImportOutcome::nomatch()
+            }
+        }
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use bgp_packet::{ExtCommunity, ExtCommunityValue};
+    use std::collections::BTreeMap;
+    use std::sync::{Mutex, MutexGuard};
+
+    // The registry and per-thread VMs are process-global, so tests must
+    // not install concurrently. Each test holds this lock for its whole
+    // body; `into_inner` ignores poisoning so one panicking test does not
+    // cascade-fail the rest.
+    static TEST_LOCK: Mutex<()> = Mutex::new(());
+
+    fn install_one(name: &str, src: &str) -> MutexGuard<'static, ()> {
+        let guard = TEST_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let mut map = BTreeMap::new();
+        map.insert(name.to_string(), src.to_string());
+        crate::script::install(map);
+        guard
+    }
+
+    fn net(s: &str) -> IpNet {
+        s.parse().unwrap()
+    }
+
+    fn peer() -> PeerView {
+        PeerView {
+            remote_as: 65001,
+            local_as: 65000,
+            remote_id: "2.2.2.2".parse().unwrap(),
+            local_id: "1.1.1.1".parse().unwrap(),
+            remote_address: "10.0.0.2".parse().unwrap(),
+            state: "Established".into(),
+            is_ibgp: false,
+        }
+    }
+
+    fn import(name: &str, prefix: &str, attr: &BgpAttr) -> Action {
+        loc_rib_import(name, net(prefix), attr, &peer()).action
+    }
+
+    #[test]
+    fn import_returns_nomatch() {
+        let _g = install_one(
+            "t",
+            r#"
+            function loc_rib_import(prefix, attributes, peer,
+                                    RM_FAILURE, RM_NOMATCH, RM_MATCH, RM_MATCH_AND_CHANGE)
+                return { action = RM_NOMATCH }
+            end
+        "#,
+        );
+        assert_eq!(
+            import("t", "10.0.0.0/24", &BgpAttr::default()),
+            Action::NoMatch
+        );
+    }
+
+    #[test]
+    fn prefix_and_peer_are_marshalled() {
+        let _g = install_one(
+            "t2",
+            r#"
+            function loc_rib_import(prefix, attributes, peer, FAIL, NOMATCH, MATCH, CHANGE)
+                if prefix.network == "1.1.1.0/24"
+                   and prefix.afi == "ipv4"
+                   and peer.remote_as == 65001 then
+                    return { action = FAIL }
+                end
+                return { action = NOMATCH }
+            end
+        "#,
+        );
+        assert_eq!(
+            import("t2", "1.1.1.0/24", &BgpAttr::default()),
+            Action::Failure
+        );
+        assert_eq!(
+            import("t2", "2.2.2.0/24", &BgpAttr::default()),
+            Action::NoMatch
+        );
+    }
+
+    #[test]
+    fn reads_gpi_ext_community() {
+        // GPI ext-community (draft-wlin-bess): type 0x03, sub-type 0x17,
+        // scope=0, reserved=0, tag=300 (0x012c). The script extracts the
+        // tag with FRR's `string.unpack(">BBHHH", ...)` idiom.
+        let ecom = ExtCommunity::from([ExtCommunityValue {
+            high_type: 0x03,
+            low_type: 0x17,
+            val: [0x00, 0x00, 0x00, 0x00, 0x01, 0x2c],
+        }]);
+        let attr = BgpAttr {
+            ecom: Some(ecom),
+            ..Default::default()
+        };
+        let _g = install_one(
+            "gbp",
+            r#"
+            function loc_rib_import(prefix, attributes, peer, FAIL, NOMATCH, MATCH, CHANGE)
+                for _, ec in ipairs(attributes.ext_community) do
+                    local ht, lt, scope, resv, tag = string.unpack(">BBHHH", ec)
+                    if ht == 0x03 and lt == 0x17 and tag == 300 then
+                        return { action = FAIL }
+                    end
+                end
+                return { action = NOMATCH }
+            end
+        "#,
+        );
+        assert_eq!(import("gbp", "10.0.0.0/24", &attr), Action::Failure);
+        // No ext-community → loop is empty → NoMatch.
+        assert_eq!(
+            import("gbp", "10.0.0.0/24", &BgpAttr::default()),
+            Action::NoMatch
+        );
+    }
+
+    #[test]
+    fn sandbox_blocks_os() {
+        // `os` is absent from the script env, so referencing it raises a
+        // runtime error, which fail-safes to NoMatch.
+        let _g = install_one(
+            "t3",
+            r#"
+            function loc_rib_import(prefix, a, p, FAIL, NOMATCH, MATCH, CHANGE)
+                local _ = os.time()
+                return { action = MATCH }
+            end
+        "#,
+        );
+        assert_eq!(
+            import("t3", "10.0.0.0/24", &BgpAttr::default()),
+            Action::NoMatch
+        );
+    }
+
+    #[test]
+    fn missing_function_failsafe() {
+        let _g = install_one("t4", "x = 1\n");
+        assert_eq!(
+            import("t4", "10.0.0.0/24", &BgpAttr::default()),
+            Action::NoMatch
+        );
+    }
+
+    #[test]
+    fn unknown_script_failsafe() {
+        let _g = install_one("t5", "function loc_rib_import() return { action = 1 } end");
+        assert_eq!(
+            import("nope", "10.0.0.0/24", &BgpAttr::default()),
+            Action::NoMatch
+        );
+    }
+
+    #[test]
+    fn bad_return_failsafe() {
+        let _g = install_one(
+            "t6",
+            "function loc_rib_import(prefix, a, p, F, N, M, C) return 42 end",
+        );
+        assert_eq!(
+            import("t6", "10.0.0.0/24", &BgpAttr::default()),
+            Action::NoMatch
+        );
+    }
+
+    #[test]
+    fn import_v4_binding_dispatch() {
+        let _g = install_one(
+            "bind",
+            r#"
+            function loc_rib_import(prefix, a, p, FAIL, NOMATCH, MATCH, CHANGE)
+                if prefix.network == "9.9.9.0/24" then return { action = FAIL } end
+                return { action = NOMATCH }
+            end
+        "#,
+        );
+        // Unbound → NoMatch regardless of the route.
+        assert_eq!(
+            crate::script::loc_rib_import_v4(net("9.9.9.0/24"), &BgpAttr::default(), &peer())
+                .action,
+            Action::NoMatch
+        );
+        // Bound → the script decides.
+        crate::script::set_import_binding_v4(Some("bind".to_string()));
+        assert_eq!(
+            crate::script::loc_rib_import_v4(net("9.9.9.0/24"), &BgpAttr::default(), &peer())
+                .action,
+            Action::Failure
+        );
+        assert_eq!(
+            crate::script::loc_rib_import_v4(net("8.8.8.0/24"), &BgpAttr::default(), &peer())
+                .action,
+            Action::NoMatch
+        );
+        // Unbind → NoMatch again (clean up the global for other tests).
+        crate::script::set_import_binding_v4(None);
+        assert_eq!(
+            crate::script::loc_rib_import_v4(net("9.9.9.0/24"), &BgpAttr::default(), &peer())
+                .action,
+            Action::NoMatch
+        );
+    }
+
+    #[test]
+    fn write_back_med_and_local_pref() {
+        let _g = install_one(
+            "wb",
+            r#"
+            function loc_rib_import(prefix, attributes, peer, FAIL, NOMATCH, MATCH, CHANGE)
+                attributes.med = 222
+                attributes.local_pref = 333
+                return { action = CHANGE, attributes = attributes }
+            end
+        "#,
+        );
+        let out = loc_rib_import("wb", net("10.0.0.0/24"), &BgpAttr::default(), &peer());
+        assert_eq!(out.action, Action::MatchAndChange);
+        let attr = out.attr.expect("MATCH_AND_CHANGE carries attributes");
+        assert_eq!(attr.med.map(|m| m.med), Some(222));
+        assert_eq!(attr.local_pref.map(|l| l.local_pref), Some(333));
+    }
+
+    #[test]
+    fn write_back_appends_gpi_ext_community() {
+        // The GBP origination move: append a GPI ext-community via the
+        // typed `ecom.gpi` helper, then read it back on the Rust side.
+        let _g = install_one(
+            "gpi",
+            r#"
+            function loc_rib_import(prefix, attributes, peer, FAIL, NOMATCH, MATCH, CHANGE)
+                table.insert(attributes.ext_community, ecom.gpi(300))
+                return { action = CHANGE, attributes = attributes }
+            end
+        "#,
+        );
+        let out = loc_rib_import("gpi", net("10.0.0.0/24"), &BgpAttr::default(), &peer());
+        assert_eq!(out.action, Action::MatchAndChange);
+        let attr = out.attr.expect("attributes present");
+        let ecom = attr.ecom.expect("ext-community installed");
+        let gpi = ecom
+            .0
+            .iter()
+            .find(|v| v.high_type == 0x03 && v.low_type == 0x17)
+            .expect("GPI ext-community present");
+        assert_eq!(u16::from_be_bytes([gpi.val[4], gpi.val[5]]), 300);
+    }
+
+    #[test]
+    fn write_back_clears_med_on_nil() {
+        let _g = install_one(
+            "clr",
+            r#"
+            function loc_rib_import(prefix, attributes, peer, FAIL, NOMATCH, MATCH, CHANGE)
+                attributes.med = nil
+                return { action = CHANGE, attributes = attributes }
+            end
+        "#,
+        );
+        let base = BgpAttr {
+            med: Some(bgp_packet::Med::new(100)),
+            ..Default::default()
+        };
+        let out = loc_rib_import("clr", net("10.0.0.0/24"), &base, &peer());
+        assert_eq!(out.action, Action::MatchAndChange);
+        assert_eq!(out.attr.expect("attributes present").med, None);
+    }
+
+    #[test]
+    fn nomatch_does_not_change_attrs() {
+        // Mutating then returning NOMATCH must not fold anything back.
+        let _g = install_one(
+            "nm",
+            r#"
+            function loc_rib_import(prefix, attributes, peer, FAIL, NOMATCH, MATCH, CHANGE)
+                attributes.med = 999
+                return { action = NOMATCH }
+            end
+        "#,
+        );
+        let out = loc_rib_import("nm", net("10.0.0.0/24"), &BgpAttr::default(), &peer());
+        assert_eq!(out.action, Action::NoMatch);
+        assert!(out.attr.is_none());
+    }
+}

--- a/zebra-rs/src/script/marshal.rs
+++ b/zebra-rs/src/script/marshal.rs
@@ -1,0 +1,181 @@
+//! Marshalling of route context into Lua tables (feature = "lua").
+//!
+//! Each hook call builds fresh `prefix`, `attributes` and `peer` tables
+//! snapshotting the route. Tables are plain Lua values (not `UserData`),
+//! matching FRR's model: a script mutates the `attributes` table and, on
+//! `MATCH_AND_CHANGE`, [`read_attr`] folds the writable fields back onto
+//! the original `BgpAttr` (preserving every attribute the script never
+//! saw).
+
+use std::collections::BTreeSet;
+
+use bgp_packet::{
+    BgpAttr, BgpNexthop, Community, ExtCommunity, ExtCommunityValue, LocalPref, Med, Origin,
+};
+use ipnet::IpNet;
+use mlua::{Lua, Table};
+
+use super::PeerView;
+
+/// Build the `prefix` table: `network` (FRR-compatible "addr/len"
+/// string) plus structured `afi` / `addr` / `len`.
+pub fn prefix_table(lua: &Lua, prefix: IpNet) -> mlua::Result<Table> {
+    let table = lua.create_table()?;
+    table.set("network", prefix.to_string())?;
+    let (afi, addr, len) = match prefix {
+        IpNet::V4(net) => ("ipv4", net.addr().to_string(), net.prefix_len()),
+        IpNet::V6(net) => ("ipv6", net.addr().to_string(), net.prefix_len()),
+    };
+    table.set("afi", afi)?;
+    table.set("addr", addr)?;
+    table.set("len", len)?;
+    Ok(table)
+}
+
+/// Build the read-only `peer` table from a [`PeerView`].
+pub fn peer_table(lua: &Lua, peer: &PeerView) -> mlua::Result<Table> {
+    let table = lua.create_table()?;
+    table.set("remote_as", peer.remote_as)?;
+    table.set("local_as", peer.local_as)?;
+    table.set("remote_id", peer.remote_id.to_string())?;
+    table.set("local_id", peer.local_id.to_string())?;
+    table.set("remote_address", peer.remote_address.to_string())?;
+    table.set("state", peer.state.clone())?;
+    table.set("is_ibgp", peer.is_ibgp)?;
+    Ok(table)
+}
+
+/// Build the `attributes` table. Present attributes are set; absent ones
+/// are simply omitted (the script reads `nil`). `ext_community` is a list
+/// of 8-octet binary strings so FRR's `string.pack`/`string.unpack(
+/// ">BBHHH", ...)` idiom works verbatim.
+pub fn attr_table(lua: &Lua, attr: &BgpAttr) -> mlua::Result<Table> {
+    let table = lua.create_table()?;
+    if let Some(med) = &attr.med {
+        table.set("med", med.med)?;
+    }
+    if let Some(local_pref) = &attr.local_pref {
+        table.set("local_pref", local_pref.local_pref)?;
+    }
+    if let Some(origin) = &attr.origin {
+        let s = match origin {
+            Origin::Igp => "igp",
+            Origin::Egp => "egp",
+            Origin::Incomplete => "incomplete",
+        };
+        table.set("origin", s)?;
+    }
+    if let Some(aspath) = &attr.aspath {
+        table.set("as_path", aspath.as_path_display())?;
+    }
+    if let Some(nexthop) = &attr.nexthop {
+        let s = match nexthop {
+            BgpNexthop::Ipv4(addr) => Some(addr.to_string()),
+            BgpNexthop::Ipv6(addr) => Some(addr.to_string()),
+            BgpNexthop::Evpn(addr) => Some(addr.to_string()),
+            _ => None,
+        };
+        if let Some(s) = s {
+            table.set("next_hop", s)?;
+        }
+    }
+    // `community` / `ext_community` are always created (even empty) so a
+    // script can `table.insert(...)` without a nil guard. On `MATCH_AND_CHANGE`
+    // the lists are read back by [`read_attr`].
+    let community = lua.create_table()?;
+    if let Some(com) = &attr.com {
+        for (i, value) in com.0.iter().enumerate() {
+            let value = *value;
+            community.set(i + 1, format!("{}:{}", value >> 16, value & 0xffff))?;
+        }
+    }
+    table.set("community", community)?;
+    let ext_community = lua.create_table()?;
+    if let Some(ecom) = &attr.ecom {
+        for (i, value) in ecom.0.iter().enumerate() {
+            ext_community.set(i + 1, lua.create_string(&ecom_bytes(value)[..])?)?;
+        }
+    }
+    table.set("ext_community", ext_community)?;
+    Ok(table)
+}
+
+/// 8-octet wire encoding of an extended-community value (`BBHHH`-shaped:
+/// type, sub-type, then the 6-octet value), the form scripts see/build.
+fn ecom_bytes(value: &ExtCommunityValue) -> [u8; 8] {
+    let mut bytes = [0u8; 8];
+    bytes[0] = value.high_type;
+    bytes[1] = value.low_type;
+    bytes[2..8].copy_from_slice(&value.val);
+    bytes
+}
+
+/// Fold a script-mutated `attributes` table back onto `base`, returning a
+/// new `BgpAttr`. Only the writable fields are read from the table —
+/// `med`, `local_pref`, `origin`, `community`, `ext_community` — and they
+/// are authoritative (absent ⇒ cleared, since [`attr_table`] marshalled
+/// them in). Every other attribute (aggregator, originator-id, prefix-sid,
+/// …) is carried over from `base` untouched, so the script cannot
+/// accidentally drop an attribute it never saw.
+pub fn read_attr(table: &Table, base: &BgpAttr) -> mlua::Result<BgpAttr> {
+    let mut attr = base.clone();
+    attr.med = table.get::<Option<u32>>("med")?.map(Med::new);
+    attr.local_pref = table.get::<Option<u32>>("local_pref")?.map(LocalPref::new);
+    attr.origin = match table.get::<Option<String>>("origin")? {
+        // Unknown spelling keeps the original rather than clearing it.
+        Some(s) => parse_origin(&s).or(attr.origin),
+        None => None,
+    };
+    attr.com = read_community(table)?;
+    attr.ecom = read_ext_community(table)?;
+    Ok(attr)
+}
+
+fn parse_origin(s: &str) -> Option<Origin> {
+    match s {
+        "igp" => Some(Origin::Igp),
+        "egp" => Some(Origin::Egp),
+        "incomplete" => Some(Origin::Incomplete),
+        _ => None,
+    }
+}
+
+/// Parse `"asn:value"` into the packed 32-bit community.
+fn parse_community(s: &str) -> Option<u32> {
+    let (hi, lo) = s.split_once(':')?;
+    let hi: u16 = hi.trim().parse().ok()?;
+    let lo: u16 = lo.trim().parse().ok()?;
+    Some(((hi as u32) << 16) | lo as u32)
+}
+
+fn read_community(table: &Table) -> mlua::Result<Option<Community>> {
+    let Some(list) = table.get::<Option<Table>>("community")? else {
+        return Ok(None);
+    };
+    let mut set = BTreeSet::new();
+    for value in list.sequence_values::<String>() {
+        if let Some(v) = parse_community(&value?) {
+            set.insert(v);
+        }
+    }
+    Ok((!set.is_empty()).then(|| set.into_iter().collect()))
+}
+
+fn read_ext_community(table: &Table) -> mlua::Result<Option<ExtCommunity>> {
+    let Some(list) = table.get::<Option<Table>>("ext_community")? else {
+        return Ok(None);
+    };
+    let mut set = BTreeSet::new();
+    for value in list.sequence_values::<mlua::String>() {
+        let bytes = value?;
+        let bytes = bytes.as_bytes();
+        if bytes.len() == 8 {
+            set.insert(ExtCommunityValue {
+                high_type: bytes[0],
+                low_type: bytes[1],
+                val: [bytes[2], bytes[3], bytes[4], bytes[5], bytes[6], bytes[7]],
+            });
+        }
+    }
+    Ok((!set.is_empty()).then(|| set.into_iter().collect()))
+}

--- a/zebra-rs/src/script/mod.rs
+++ b/zebra-rs/src/script/mod.rs
@@ -1,0 +1,217 @@
+//! Embedded Lua scripting engine.
+//!
+//! Gated behind the `lua` Cargo feature. Provides a per-thread sandboxed
+//! Lua VM, a global script registry with a generation counter for lazy
+//! hot-reload, and the `RM_*` / [`Action`] return contract — plus a
+//! feature-off no-op path so default builds compile and pay nothing.
+//!
+//! PR2 marshals `prefix` / `attributes` / `peer` into the script (read
+//! only) and exposes the [`loc_rib_import`] entry the BGP ingest path
+//! calls after inbound policy. Attribute write-back and the withdraw
+//! hook land in later PRs; see `docs/design/lua-scripting-policy.md`.
+
+use std::collections::BTreeMap;
+use std::net::{IpAddr, Ipv4Addr};
+use std::sync::{Arc, OnceLock, RwLock};
+
+use bgp_packet::BgpAttr;
+use ipnet::IpNet;
+
+#[cfg(feature = "lua")]
+mod engine;
+#[cfg(feature = "lua")]
+mod marshal;
+
+/// Outcome of a script hook, mirroring FRR's route-map result constants.
+///
+/// The four variants are passed *into* a script as the `RM_FAILURE`,
+/// `RM_NOMATCH`, `RM_MATCH` and `RM_MATCH_AND_CHANGE` arguments, and read
+/// back from the `{ action = ... }` table the script returns. The integer
+/// discriminants are the wire values shared with Lua.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum Action {
+    /// Deny — drop the route before it reaches the Loc-RIB.
+    Failure = 0,
+    /// No opinion — admit the route unchanged.
+    NoMatch = 1,
+    /// Explicit match, no attribute edits — admit unchanged.
+    Match = 2,
+    /// Admit with the script's mutated attributes (write-back: later PR).
+    MatchAndChange = 3,
+}
+
+impl Action {
+    /// Map a Lua-supplied integer back to an [`Action`]; `None` for an
+    /// out-of-range value (treated as a script error by callers).
+    pub fn from_i64(v: i64) -> Option<Action> {
+        match v {
+            0 => Some(Action::Failure),
+            1 => Some(Action::NoMatch),
+            2 => Some(Action::Match),
+            3 => Some(Action::MatchAndChange),
+            _ => None,
+        }
+    }
+}
+
+/// Result of an import hook: the [`Action`] plus, for
+/// [`Action::MatchAndChange`], the attributes the script mutated (already
+/// folded onto the original `BgpAttr`, so unmarshalled fields are
+/// preserved). `attr` is `None` for every other action.
+#[derive(Debug, Clone)]
+pub struct ImportOutcome {
+    pub action: Action,
+    pub attr: Option<BgpAttr>,
+}
+
+impl ImportOutcome {
+    /// Admit unchanged — the fail-safe / unbound / feature-off result.
+    pub fn nomatch() -> Self {
+        ImportOutcome {
+            action: Action::NoMatch,
+            attr: None,
+        }
+    }
+}
+
+/// A flattened, read-only view of the sending `Peer`, marshalled into the
+/// Lua `peer` table. The BGP module fills this from its `Peer` before
+/// invoking a hook, which keeps this module decoupled from BGP internals.
+#[derive(Debug, Clone)]
+pub struct PeerView {
+    pub remote_as: u32,
+    pub local_as: u32,
+    pub remote_id: Ipv4Addr,
+    pub local_id: Ipv4Addr,
+    pub remote_address: IpAddr,
+    pub state: String,
+    pub is_ibgp: bool,
+}
+
+/// Immutable snapshot of the bound script sources, tagged with a
+/// monotonic `generation`. A reload installs a fresh `Scripts` with
+/// `generation + 1`; per-thread VMs compare generations and lazily
+/// recompile (see [`engine`]). Snapshots are shared by `Arc`, so a
+/// reload never disturbs a hook mid-evaluation.
+#[derive(Debug)]
+pub struct Scripts {
+    pub generation: u64,
+    pub sources: BTreeMap<String, String>,
+}
+
+impl Scripts {
+    fn empty() -> Self {
+        Scripts {
+            generation: 0,
+            sources: BTreeMap::new(),
+        }
+    }
+}
+
+static REGISTRY: OnceLock<RwLock<Arc<Scripts>>> = OnceLock::new();
+
+fn registry() -> &'static RwLock<Arc<Scripts>> {
+    REGISTRY.get_or_init(|| RwLock::new(Arc::new(Scripts::empty())))
+}
+
+/// Install a new set of script sources (name → Lua source), bumping the
+/// generation so live per-thread VMs recompile on their next call.
+/// Called by config wiring in a later PR; exercised directly by tests.
+pub fn install(sources: BTreeMap<String, String>) {
+    let mut guard = registry().write().unwrap();
+    let generation = guard.generation + 1;
+    *guard = Arc::new(Scripts {
+        generation,
+        sources,
+    });
+}
+
+/// Insert or remove a single named script source, bumping the
+/// generation so live per-thread VMs recompile on their next call.
+/// `Some(src)` installs/replaces; `None` removes. This is the
+/// incremental form used by config (one `lua-script` at a time);
+/// [`install`] replaces the whole set at once.
+pub fn set_source(name: &str, source: Option<String>) {
+    let mut guard = registry().write().unwrap();
+    let mut sources = guard.sources.clone();
+    match source {
+        Some(src) => {
+            sources.insert(name.to_string(), src);
+        }
+        None => {
+            sources.remove(name);
+        }
+    }
+    let generation = guard.generation + 1;
+    *guard = Arc::new(Scripts {
+        generation,
+        sources,
+    });
+}
+
+/// Current script snapshot (cheap `Arc` clone of the registry contents).
+pub fn current() -> Arc<Scripts> {
+    registry().read().unwrap().clone()
+}
+
+/// The script name bound to the IPv4-unicast Adj-RIB-In → Loc-RIB import
+/// hook, or `None` when unbound. Kept separate from [`Scripts`] so
+/// changing the binding does not force every VM to recompile.
+static BINDING_V4: OnceLock<RwLock<Option<String>>> = OnceLock::new();
+
+fn binding_v4() -> &'static RwLock<Option<String>> {
+    BINDING_V4.get_or_init(|| RwLock::new(None))
+}
+
+/// Bind (or, with `None`, unbind) the IPv4-unicast import hook to a named
+/// script. Called by BGP config.
+pub fn set_import_binding_v4(name: Option<String>) {
+    *binding_v4().write().unwrap() = name;
+}
+
+/// Run the IPv4-unicast import hook against the currently-bound script.
+/// Returns an [`ImportOutcome::nomatch`] (admit unchanged) when nothing
+/// is bound or the feature is off — so the BGP ingest path can call this
+/// unconditionally and act on the returned [`Action`].
+#[cfg(feature = "lua")]
+pub fn loc_rib_import_v4(prefix: IpNet, attr: &BgpAttr, peer: &PeerView) -> ImportOutcome {
+    match binding_v4().read().unwrap().clone() {
+        Some(name) => engine::loc_rib_import(&name, prefix, attr, peer),
+        None => ImportOutcome::nomatch(),
+    }
+}
+
+/// Feature-off no-op.
+#[cfg(not(feature = "lua"))]
+pub fn loc_rib_import_v4(_prefix: IpNet, _attr: &BgpAttr, _peer: &PeerView) -> ImportOutcome {
+    ImportOutcome::nomatch()
+}
+
+/// Run the bound script's
+/// `loc_rib_import(prefix, attributes, peer, RM_*)` and return its
+/// [`Action`].
+///
+/// **Fail-safe:** any error — no such script, missing function, runtime
+/// error, or a malformed return — is logged and mapped to
+/// [`Action::NoMatch`] (admit unchanged) so a broken script can never
+/// silently blackhole routes.
+///
+/// On [`Action::MatchAndChange`] the script's mutated `attributes` table
+/// is read back and folded onto `attr` (see [`ImportOutcome`]). The
+/// caller treats `Failure` as deny, `MatchAndChange` as
+/// admit-with-new-attrs, and everything else as admit-unchanged.
+#[cfg(feature = "lua")]
+pub fn loc_rib_import(name: &str, prefix: IpNet, attr: &BgpAttr, peer: &PeerView) -> ImportOutcome {
+    engine::loc_rib_import(name, prefix, attr, peer)
+}
+
+/// Feature-off no-op: always admit unchanged.
+#[cfg(not(feature = "lua"))]
+pub fn loc_rib_import(
+    _name: &str,
+    _prefix: IpNet,
+    _attr: &BgpAttr,
+    _peer: &PeerView,
+) -> ImportOutcome {
+    ImportOutcome::nomatch()
+}

--- a/zebra-rs/yang/config.yang
+++ b/zebra-rs/yang/config.yang
@@ -60,6 +60,10 @@ module config {
     prefix zbt;
   }
 
+  import zebra-bgp-lua {
+    prefix zbl;
+  }
+
   import zebra-bgp-password {
     prefix zbp;
   }

--- a/zebra-rs/yang/zebra-bgp-lua.yang
+++ b/zebra-rs/yang/zebra-bgp-lua.yang
@@ -1,0 +1,104 @@
+module zebra-bgp-lua {
+  yang-version "1";
+
+  namespace "urn:ietf:params:xml:ns:yang:zebra-bgp-lua";
+  prefix "zbl";
+
+  import ietf-bgp {
+    prefix bgp;
+  }
+
+  import config {
+    prefix config;
+  }
+
+  import configure {
+    prefix configure;
+  }
+
+  import extension {
+    prefix ext;
+  }
+
+  organization
+    "zebra-rs";
+
+  contact
+    "https://github.com/zebra-rs";
+
+  description
+    "Embedded Lua scripting hooks on the BGP instance (gated behind the
+     `lua` build feature; the config tree is always present so a config
+     loads identically with or without the feature).
+
+     Two surfaces:
+
+       router bgp {
+         lua-script GBP {
+           source-path /etc/zebra-rs/lua/gbp.lua;
+         }
+         loc-rib-hook {
+           ipv4-unicast {
+             import GBP;
+           }
+         }
+       }
+
+     `lua-script` defines a named script from a file; `loc-rib-hook
+     ipv4-unicast import` binds a script to the Adj-RIB-In -> Loc-RIB
+     import hook, run after native inbound policy on every received
+     IPv4-unicast path. See docs/design/lua-scripting-policy.md.";
+
+  revision 2026-06-21 {
+    description
+      "Initial revision: `lua-script` defined-set (source-path) plus the
+       per-AFI Loc-RIB import hook binding for ipv4-unicast.";
+  }
+
+  grouping bgp-lua-extension {
+    description
+      "Lua script definitions and Loc-RIB hook bindings on the BGP
+       instance.";
+
+    list lua-script {
+      ext:help "Define a named Lua script";
+      key "name";
+      leaf name {
+        ext:help "Script name (referenced by loc-rib-hook bindings)";
+        type string;
+      }
+      leaf source-path {
+        ext:help "Filesystem path to the Lua script source loaded at config time";
+        type string;
+      }
+    }
+
+    container loc-rib-hook {
+      ext:help "Bind Lua scripts to Loc-RIB lifecycle hooks";
+      container ipv4-unicast {
+        ext:help "IPv4-unicast Loc-RIB hooks";
+        leaf import {
+          ext:help "Script run when a route is admitted from Adj-RIB-In into the Loc-RIB";
+          type string;
+        }
+      }
+    }
+  }
+
+  augment "/configure:set/config:router"
+        + "/bgp:bgp" {
+    description
+      "Attach the Lua scripting surface to the BGP instance in the
+       candidate-set subtree.";
+    uses bgp-lua-extension;
+  }
+
+  augment "/configure:delete/config:router"
+        + "/bgp:bgp" {
+    description
+      "Same attachment for the delete subtree so
+       `delete router bgp lua-script X` / `delete router bgp loc-rib-hook
+       ipv4-unicast import` are path-valid.";
+    uses bgp-lua-extension;
+  }
+}


### PR DESCRIPTION
Embeds a Lua scripting engine in zebra-rs, modelled on FRR's `route-map match script` but redesigned around the gaps that talk surfaced (no native ext-community access; no withdraw hook because of the bgpd/zebra split). zebra-rs is one process, so it can do better. This PR lands the **import** half (Adj-RIB-In → Loc-RIB); the withdraw hook and EVPN/GBP BDD are follow-ups.

Behind the `lua` Cargo feature (off by default, like FRR's `--enable-scripting`), so default builds are unchanged.

## What's here (PR1–PR4 of the plan in `docs/design/lua-scripting-policy.md`)

- **Engine** (`src/script`): per-thread sandboxed `mlua` (Lua 5.4, vendored) VM + a global script registry with a generation counter for lazy hot-reload; `RM_FAILURE/NOMATCH/MATCH/MATCH_AND_CHANGE` contract; `os`/`io`/`package`/… stripped, each script in its own `_ENV`. Fail-safe: any script error → admit unchanged.
- **Marshalling**: `prefix` / `attributes` / `peer` Lua tables. `ext_community` is a list of 8-octet values so FRR's `string.unpack(">BBHHH", ec)` works verbatim; typed `ecom.gpi`/`ecom.parse_gpi` helpers for the GBP Group-Policy-ID community.
- **Config** (`zebra-bgp-lua.yang`): `router bgp { lua-script NAME { source-path … } loc-rib-hook { ipv4-unicast { import NAME } } }`. Handlers load the source into the registry and bind the hook.
- **Hook**: placed at the shard `compute_policy` chokepoint (`handle_update_v4`), so it covers plain IPv4-unicast at N=1 **and** N>1. `Failure` → deny; `MatchAndChange` folds the script-mutated `attributes` back onto the route's `BgpAttr` (writable: med/local_pref/origin/community/ext_community; all other attributes preserved).
- `config/configs.rs`: pin a now-ambiguous `as_ref()` → `as_str()` (the `lua` feature pulls in `bstr`).

## Test plan

- `cargo test -p zebra-rs --features lua script::` — 12 unit tests: marshalling, GPI `ext_community` read, fail-safe paths, registry binding→dispatch→deny, and attribute write-back (set med/local-pref, append GPI ecom, clear-on-nil, NOMATCH-no-change).
- `cargo test -p zebra-rs configure_mode_loads` — YANG augment loads.
- `cargo clippy --workspace --all-targets -- -D warnings` (default, matches CI) and `--features lua` — clean.
- `cargo fmt --all --check` — clean.

End-to-end BDD is deferred: the BDD harness runs a manually-installed `/usr/bin/zebra-rs` and `lua` is off by default, so it needs a `--features lua` build lane. Until then the `#[cfg(feature = "lua")]` unit tests cover behaviour.

Generated with [Claude Code](https://claude.com/claude-code)