### PR TITLE
ci: add --features lua clippy/test lane

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -58,3 +58,28 @@ jobs:
         # namespaces and are not runnable in the GitHub Actions sandbox;
         # exclude them here. They are intended to be run locally.
         run: cargo test --workspace --exclude bdd
+
+  lua:
+    name: cargo test (lua)
+    runs-on: ubuntu-22.04
+    # The `lua` feature is off by default, so the default clippy / test
+    # jobs never compile the embedded scripting engine (src/script's
+    # `#[cfg(feature = "lua")]` code) nor run its unit tests. This lane
+    # closes that gap: it clippy-checks and tests zebra-rs with the
+    # feature on. `mlua`'s vendored Lua 5.4 builds from C source, so the
+    # runner's preinstalled cc is enough (no extra apt deps).
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v5
+      - name: Install build deps
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y protobuf-compiler libpam0g-dev
+      - name: Rust
+        uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          components: clippy
+      - name: Clippy (lua)
+        run: cargo clippy -p zebra-rs --features lua --all-targets -- -D warnings
+      - name: Test (lua)
+        run: cargo test -p zebra-rs --features lua


### PR DESCRIPTION
The `lua` feature (the embedded scripting engine, #1585/#1586/#1587) is off by default, so the existing `cargo clippy` / `cargo test` jobs never compile `src/script`'s `#[cfg(feature = "lua")]` code nor run its unit tests — they've been verified only locally. This adds a `lua` CI job that gates the feature:

- `cargo clippy -p zebra-rs --features lua --all-targets -- -D warnings`
- `cargo test -p zebra-rs --features lua`

so the engine, marshalling, import/withdraw hooks, and the sideeffect channel are covered by CI from here on. `mlua`'s vendored Lua 5.4 builds from C with the runner's preinstalled `cc` (no extra apt deps beyond the existing protobuf/pam).

## Test plan

- Validated locally on the merged `main`: the lane's exact commands pass — clippy clean; `cargo test -p zebra-rs --features lua` runs the full crate suite (1426 tests incl. the 17 `script::` tests), all green.
- This PR only touches `.github/workflows/ci.yaml`; since `pull_request` runs the head branch's workflow, the new `lua` job runs on this PR and validates itself.

Generated with [Claude Code](https://claude.com/claude-code)