### PR TITLE
bgp-lua: EVPN Type-2 import hook (prefix.evpn)

### DIFF
--- a/zebra-rs/src/bgp/config.rs
+++ b/zebra-rs/src/bgp/config.rs
@@ -134,6 +134,18 @@ fn config_loc_rib_hook_withdraw_v4(_bgp: &mut Bgp, mut args: Args, op: ConfigOp)
     Some(())
 }
 
+/// `set router bgp loc-rib-hook l2vpn-evpn import <name>` — bind a script
+/// to the EVPN Adj-RIB-In → Loc-RIB import hook; delete unbinds.
+fn config_loc_rib_hook_import_evpn(_bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Option<()> {
+    if op.is_set() {
+        let name = args.string()?;
+        crate::script::set_import_binding_evpn(Some(name));
+    } else {
+        crate::script::set_import_binding_evpn(None);
+    }
+    Some(())
+}
+
 /// Parse a flat JSON object (`{"key": "value", ...}`) into a string→string
 /// map for `map.get`. Non-string JSON values (numbers, bools) are taken as
 /// their JSON text (so `{"aa:..": 100}` yields `"100"`); a parse failure
@@ -3732,6 +3744,10 @@ impl Bgp {
         self.callback_add(
             "/router/bgp/loc-rib-hook/ipv4-unicast/withdraw",
             config_loc_rib_hook_withdraw_v4,
+        );
+        self.callback_add(
+            "/router/bgp/loc-rib-hook/l2vpn-evpn/import",
+            config_loc_rib_hook_import_evpn,
         );
         self.callback_add("/router/bgp/lua-map", config_lua_map);
         self.callback_add(

--- a/zebra-rs/src/bgp/route.rs
+++ b/zebra-rs/src/bgp/route.rs
@@ -7088,6 +7088,26 @@ pub fn route_evpn_update(
         peer.adj_in.add_evpn(rd, prefix.clone(), rib.clone());
         route_apply_policy_in_evpn(peer, route, attr.clone(), rib.weight)
     };
+    // Lua EVPN import hook (Adj-RIB-In → Loc-RIB), after native policy.
+    // Unlike v4 (sharded), EVPN ingest is synchronous in main, so the
+    // hook runs here with the full peer; the script sees `prefix.evpn`.
+    // Failure → deny (implicit withdraw); MatchAndChange folds the
+    // mutated attrs back onto the route.
+    #[cfg(feature = "lua")]
+    let decision = decision.and_then(|mut d| {
+        let view = lua_peer_view(peers.get_by_idx(ident)?);
+        let outcome = crate::script::loc_rib_import_evpn(route, &d.attr, &view);
+        match outcome.action {
+            crate::script::Action::Failure => None,
+            crate::script::Action::MatchAndChange => {
+                if let Some(attr) = outcome.attr {
+                    d.attr = attr;
+                }
+                Some(d)
+            }
+            _ => Some(d),
+        }
+    });
     let Some(decision) = decision else {
         route_evpn_withdraw(ident, route, bgp, peers);
         return;

--- a/zebra-rs/src/script/engine.rs
+++ b/zebra-rs/src/script/engine.rs
@@ -11,7 +11,7 @@
 use std::cell::RefCell;
 use std::collections::BTreeMap;
 
-use bgp_packet::BgpAttr;
+use bgp_packet::{BgpAttr, EvpnRoute};
 use ipnet::IpNet;
 use mlua::{Function, Lua, Table, Value};
 
@@ -124,12 +124,37 @@ impl Engine {
         attr: &BgpAttr,
         peer: &PeerView,
     ) -> mlua::Result<ImportOutcome> {
+        let prefix_t = marshal::prefix_table(&self.lua, prefix)?;
+        self.run_import_prefix(name, prefix_t, attr, peer)
+    }
+
+    fn run_import_evpn(
+        &self,
+        name: &str,
+        route: &EvpnRoute,
+        attr: &BgpAttr,
+        peer: &PeerView,
+    ) -> mlua::Result<ImportOutcome> {
+        let prefix_t = marshal::evpn_prefix_table(&self.lua, route)?;
+        self.run_import_prefix(name, prefix_t, attr, peer)
+    }
+
+    /// Prefix-agnostic core of the import hook: given the already-built
+    /// `prefix` table (v4 or EVPN), build `attributes` / `peer`, call the
+    /// script's `loc_rib_import`, and fold a mutated `attributes` table
+    /// back on `MATCH_AND_CHANGE`.
+    fn run_import_prefix(
+        &self,
+        name: &str,
+        prefix_t: Table,
+        attr: &BgpAttr,
+        peer: &PeerView,
+    ) -> mlua::Result<ImportOutcome> {
         let env = self
             .envs
             .get(name)
             .ok_or_else(|| mlua::Error::RuntimeError(format!("no loaded script '{name}'")))?;
         let func: Function = env.get("loc_rib_import")?;
-        let prefix_t = marshal::prefix_table(&self.lua, prefix)?;
         let attr_t = marshal::attr_table(&self.lua, attr)?;
         let peer_t = marshal::peer_table(&self.lua, peer)?;
         let ret: Value = func.call((
@@ -314,20 +339,40 @@ fn install_host_helpers(lua: &Lua, env: &Table) -> mlua::Result<()> {
     Ok(())
 }
 
-/// Thread-local entry point used by [`super::loc_rib_import`]. Fail-safe:
-/// sync/run errors are logged and mapped to [`ImportOutcome::nomatch`].
-pub fn loc_rib_import(name: &str, prefix: IpNet, attr: &BgpAttr, peer: &PeerView) -> ImportOutcome {
+/// Sync the thread-local VM and run `op` against it, mapping any error to
+/// the fail-safe [`ImportOutcome::nomatch`] (errors logged).
+fn with_engine(
+    name: &str,
+    op: impl FnOnce(&Engine) -> mlua::Result<ImportOutcome>,
+) -> ImportOutcome {
     let scripts = current();
     ENGINE.with(|cell| {
         let mut engine = cell.borrow_mut();
         engine.sync(&scripts);
-        match engine.run_import(name, prefix, attr, peer) {
+        match op(&engine) {
             Ok(outcome) => outcome,
             Err(err) => {
                 tracing::warn!("lua: import hook '{name}' error: {err}");
                 ImportOutcome::nomatch()
             }
         }
+    })
+}
+
+/// Thread-local entry point used by [`super::loc_rib_import_v4`].
+pub fn loc_rib_import(name: &str, prefix: IpNet, attr: &BgpAttr, peer: &PeerView) -> ImportOutcome {
+    with_engine(name, |engine| engine.run_import(name, prefix, attr, peer))
+}
+
+/// Thread-local entry point used by [`super::loc_rib_import_evpn`].
+pub fn loc_rib_import_evpn(
+    name: &str,
+    route: &EvpnRoute,
+    attr: &BgpAttr,
+    peer: &PeerView,
+) -> ImportOutcome {
+    with_engine(name, |engine| {
+        engine.run_import_evpn(name, route, attr, peer)
     })
 }
 
@@ -749,6 +794,58 @@ mod tests {
         crate::script::map_clear_namespace("sgt");
         assert_eq!(
             import("m", "10.0.0.0/24", &BgpAttr::default()),
+            Action::NoMatch
+        );
+    }
+
+    #[test]
+    fn evpn_import_reads_mac_and_gpi() {
+        // The GBP demo target: an EVPN Type-2 (MAC) route. The script
+        // reads the structured `prefix.evpn.mac` (no regex) and the GPI
+        // ext-community, exactly the talk's receive path.
+        use bgp_packet::{EvpnMac, EvpnRoute, RouteDistinguisher};
+        let _g = install_one(
+            "evpn",
+            r#"
+            function loc_rib_import(prefix, attributes, peer, FAIL, NOMATCH, MATCH, CHANGE)
+                if prefix.afi == "evpn"
+                   and prefix.evpn.route_type == 2
+                   and prefix.evpn.mac == "aa:bb:cc:dd:ee:01"
+                   and prefix.evpn.vni == 100 then
+                    for _, ec in ipairs(attributes.ext_community) do
+                        if ecom.parse_gpi(ec) == 300 then
+                            return { action = FAIL }
+                        end
+                    end
+                end
+                return { action = NOMATCH }
+            end
+        "#,
+        );
+        let mac = EvpnRoute::Mac(EvpnMac {
+            id: 0,
+            rd: "65000:1".parse::<RouteDistinguisher>().unwrap(),
+            esi: [0; 10],
+            ether_tag: 0,
+            mac: [0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0x01],
+            vni: 100,
+        });
+        let ecom = ExtCommunity::from([ExtCommunityValue {
+            high_type: 0x03,
+            low_type: 0x17,
+            val: [0x00, 0x00, 0x00, 0x00, 0x01, 0x2c],
+        }]);
+        let attr = BgpAttr {
+            ecom: Some(ecom),
+            ..Default::default()
+        };
+        assert_eq!(
+            loc_rib_import_evpn("evpn", &mac, &attr, &peer()).action,
+            Action::Failure
+        );
+        // Same MAC but no GPI ext-community → no match.
+        assert_eq!(
+            loc_rib_import_evpn("evpn", &mac, &BgpAttr::default(), &peer()).action,
             Action::NoMatch
         );
     }

--- a/zebra-rs/src/script/marshal.rs
+++ b/zebra-rs/src/script/marshal.rs
@@ -10,12 +10,79 @@
 use std::collections::BTreeSet;
 
 use bgp_packet::{
-    BgpAttr, BgpNexthop, Community, ExtCommunity, ExtCommunityValue, LocalPref, Med, Origin,
+    BgpAttr, BgpNexthop, Community, EvpnRoute, ExtCommunity, ExtCommunityValue, LocalPref, Med,
+    Origin,
 };
 use ipnet::IpNet;
 use mlua::{Lua, Table};
 
 use super::PeerView;
+
+/// Format a 6-octet MAC as `aa:bb:cc:dd:ee:ff`.
+fn mac_str(mac: &[u8; 6]) -> String {
+    mac.iter()
+        .map(|b| format!("{b:02x}"))
+        .collect::<Vec<_>>()
+        .join(":")
+}
+
+/// Build the `prefix` table for an EVPN route: `afi = "evpn"`, a
+/// human-readable `network`, and a structured `evpn` sub-table. For a
+/// Type-2 (MAC) route the script gets `prefix.evpn.mac` / `.vni` directly
+/// (no brittle `tostring(network):match(...)` regex, unlike FRR).
+pub fn evpn_prefix_table(lua: &Lua, route: &EvpnRoute) -> mlua::Result<Table> {
+    let table = lua.create_table()?;
+    table.set("afi", "evpn")?;
+    let evpn = lua.create_table()?;
+    let network = match route {
+        EvpnRoute::Mac(m) => {
+            evpn.set("route_type", 2)?;
+            evpn.set("rd", m.rd.to_string())?;
+            evpn.set("ether_tag", m.ether_tag)?;
+            evpn.set("mac", mac_str(&m.mac))?;
+            evpn.set("vni", m.vni)?;
+            format!("[2]:[{}]:[{}]", m.ether_tag, mac_str(&m.mac))
+        }
+        EvpnRoute::Multicast(m) => {
+            evpn.set("route_type", 3)?;
+            evpn.set("rd", m.rd.to_string())?;
+            evpn.set("ether_tag", m.ether_tag)?;
+            evpn.set("ip", m.addr.to_string())?;
+            format!("[3]:[{}]:[{}]", m.ether_tag, m.addr)
+        }
+        EvpnRoute::Prefix(p) => {
+            evpn.set("route_type", 5)?;
+            evpn.set("rd", p.rd.to_string())?;
+            evpn.set("ether_tag", p.ether_tag)?;
+            evpn.set("network", p.prefix.to_string())?;
+            evpn.set("gw", p.gw.to_string())?;
+            evpn.set("label", p.label)?;
+            format!("[5]:[{}]", p.prefix)
+        }
+        EvpnRoute::Smet(s) => {
+            evpn.set("route_type", 6)?;
+            evpn.set("rd", s.rd.to_string())?;
+            "[6]".to_string()
+        }
+        EvpnRoute::PerRegionImet(r) => {
+            evpn.set("route_type", 9)?;
+            evpn.set("rd", r.rd.to_string())?;
+            "[9]".to_string()
+        }
+        EvpnRoute::SPmsi(r) => {
+            evpn.set("route_type", 10)?;
+            evpn.set("rd", r.rd.to_string())?;
+            "[10]".to_string()
+        }
+        EvpnRoute::LeafAd(_) => {
+            evpn.set("route_type", 11)?;
+            "[11]".to_string()
+        }
+    };
+    table.set("network", network)?;
+    table.set("evpn", evpn)?;
+    Ok(table)
+}
 
 /// Build the `prefix` table: `network` (FRR-compatible "addr/len"
 /// string) plus structured `afi` / `addr` / `len`.

--- a/zebra-rs/src/script/mod.rs
+++ b/zebra-rs/src/script/mod.rs
@@ -14,7 +14,7 @@ use std::collections::BTreeMap;
 use std::net::{IpAddr, Ipv4Addr};
 use std::sync::{Arc, OnceLock, RwLock};
 
-use bgp_packet::BgpAttr;
+use bgp_packet::{BgpAttr, EvpnRoute};
 use ipnet::IpNet;
 
 #[cfg(feature = "lua")]
@@ -186,6 +186,35 @@ pub fn loc_rib_import_v4(prefix: IpNet, attr: &BgpAttr, peer: &PeerView) -> Impo
 /// Feature-off no-op.
 #[cfg(not(feature = "lua"))]
 pub fn loc_rib_import_v4(_prefix: IpNet, _attr: &BgpAttr, _peer: &PeerView) -> ImportOutcome {
+    ImportOutcome::nomatch()
+}
+
+/// The script name bound to the L2VPN-EVPN import hook, or `None`.
+static BINDING_EVPN: OnceLock<RwLock<Option<String>>> = OnceLock::new();
+
+fn binding_evpn() -> &'static RwLock<Option<String>> {
+    BINDING_EVPN.get_or_init(|| RwLock::new(None))
+}
+
+/// Bind (or, with `None`, unbind) the EVPN import hook.
+pub fn set_import_binding_evpn(name: Option<String>) {
+    *binding_evpn().write().unwrap() = name;
+}
+
+/// Run the EVPN import hook against the currently-bound script. The script
+/// sees the route as `prefix.evpn` (route_type / mac / vni / rd / …). Same
+/// `ImportOutcome` contract as the v4 hook; no-op when unbound / off.
+#[cfg(feature = "lua")]
+pub fn loc_rib_import_evpn(route: &EvpnRoute, attr: &BgpAttr, peer: &PeerView) -> ImportOutcome {
+    match binding_evpn().read().unwrap().clone() {
+        Some(name) => engine::loc_rib_import_evpn(&name, route, attr, peer),
+        None => ImportOutcome::nomatch(),
+    }
+}
+
+/// Feature-off no-op.
+#[cfg(not(feature = "lua"))]
+pub fn loc_rib_import_evpn(_route: &EvpnRoute, _attr: &BgpAttr, _peer: &PeerView) -> ImportOutcome {
     ImportOutcome::nomatch()
 }
 

--- a/zebra-rs/yang/zebra-bgp-lua.yang
+++ b/zebra-rs/yang/zebra-bgp-lua.yang
@@ -99,6 +99,13 @@ module zebra-bgp-lua {
           type string;
         }
       }
+      container l2vpn-evpn {
+        ext:help "L2VPN-EVPN Loc-RIB hooks";
+        leaf import {
+          ext:help "Script run when an EVPN route is admitted into the Loc-RIB (sees prefix.evpn)";
+          type string;
+        }
+      }
     }
   }
 


### PR DESCRIPTION
Wires the Loc-RIB import hook into the **EVPN** ingest path — the actual GBP-over-EVPN demo target from the talk (the demo is EVPN Type-2 MAC routes, not v4-unicast). Behind the `lua` feature.

A Type-2 route now reaches a script as a **structured** `prefix.evpn` table — `prefix.evpn.mac` / `.vni` / `.rd` / `.route_type` — so the GBP receive script extracts the MAC directly, with none of FRR's brittle `tostring(prefix.network):match("...")` regex on `[2]:[0]:[48]:[aa:bb:..]`.

## What's here

- **marshal**: `evpn_prefix_table` → `prefix.afi = "evpn"`, a human-readable `network`, and a structured `prefix.evpn` sub-table per route type (Type-2 MAC gets `mac`/`vni`/`ether_tag`/`rd`).
- **engine**: factored the prefix-agnostic core (`run_import_prefix`); `run_import_evpn` / `loc_rib_import_evpn` reuse the `attributes`/`peer` marshalling, the `Action` contract, and `MATCH_AND_CHANGE` write-back.
- **config** (`zebra-bgp-lua.yang`): `router bgp loc-rib-hook l2vpn-evpn import <name>`.
- **hook**: fires in `route_evpn_update` after `route_apply_policy_in_evpn`. Unlike v4 (sharded), EVPN ingest is synchronous in main, so the hook runs with the **full peer** (`lua_peer_view`). `Failure` → deny (implicit withdraw); `MatchAndChange` folds mutated attrs back.

## Test plan

- `cargo test -p zebra-rs --features lua script::` — 19 tests (1 new: `evpn_import_reads_mac_and_gpi` — reads `prefix.evpn.mac`/`vni` and the GPI ext-community on a real `EvpnRoute::Mac`, denies on a hit; same MAC without the GPI ecom → no match).
- `cargo test -p zebra-rs configure_mode_loads` — the new `l2vpn-evpn` container loads.
- `cargo clippy --workspace --all-targets -- -D warnings` (default) and `--features lua` — clean; fmt clean.

EVPN **withdraw** hook (teardown) is the next slice.

Generated with [Claude Code](https://claude.com/claude-code)