### PR TITLE
bgp-lua: EVPN withdraw hook + read-only withdraw tables

### DIFF
--- a/zebra-rs/src/bgp/config.rs
+++ b/zebra-rs/src/bgp/config.rs
@@ -146,6 +146,18 @@ fn config_loc_rib_hook_import_evpn(_bgp: &mut Bgp, mut args: Args, op: ConfigOp)
     Some(())
 }
 
+/// `set router bgp loc-rib-hook l2vpn-evpn withdraw <name>` — bind a
+/// script to the EVPN Loc-RIB withdraw hook; delete unbinds.
+fn config_loc_rib_hook_withdraw_evpn(_bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Option<()> {
+    if op.is_set() {
+        let name = args.string()?;
+        crate::script::set_withdraw_binding_evpn(Some(name));
+    } else {
+        crate::script::set_withdraw_binding_evpn(None);
+    }
+    Some(())
+}
+
 /// Parse a flat JSON object (`{"key": "value", ...}`) into a string→string
 /// map for `map.get`. Non-string JSON values (numbers, bools) are taken as
 /// their JSON text (so `{"aa:..": 100}` yields `"100"`); a parse failure
@@ -3748,6 +3760,10 @@ impl Bgp {
         self.callback_add(
             "/router/bgp/loc-rib-hook/l2vpn-evpn/import",
             config_loc_rib_hook_import_evpn,
+        );
+        self.callback_add(
+            "/router/bgp/loc-rib-hook/l2vpn-evpn/withdraw",
+            config_loc_rib_hook_withdraw_evpn,
         );
         self.callback_add("/router/bgp/lua-map", config_lua_map);
         self.callback_add(

--- a/zebra-rs/src/bgp/route.rs
+++ b/zebra-rs/src/bgp/route.rs
@@ -7195,6 +7195,18 @@ pub fn route_evpn_withdraw(ident: usize, route: &EvpnRoute, bgp: &mut BgpTop, pe
     // and `.first()` is fine. If the prefix wasn't in the RIB the
     // vec is empty and the export becomes a no-op.
     let removed = bgp.local_rib.remove_evpn(rd, &prefix, id, ident);
+
+    // Lua EVPN withdraw hook (Loc-RIB → gone): hand the script the stored
+    // attributes of the EVPN path that just left the Loc-RIB (the GBP
+    // teardown move — recover the tag from `prefix.evpn` + the ext-comm).
+    #[cfg(feature = "lua")]
+    if let Some(gone) = removed.first()
+        && let Some(peer) = peers.get_by_idx(ident)
+    {
+        let view = lua_peer_view(peer);
+        crate::script::loc_rib_withdraw_evpn(route, &gone.attr, &view);
+    }
+
     let selected = bgp.local_rib.select_best_path_evpn(&rd, &prefix);
 
     route_evpn_export_selected(&rd, &prefix, &selected, removed.first(), bgp);

--- a/zebra-rs/src/script/engine.rs
+++ b/zebra-rs/src/script/engine.rs
@@ -191,15 +191,36 @@ impl Engine {
         })
     }
 
-    /// Run the script's `loc_rib_withdraw(prefix, attributes, peer, RM_*)`.
-    /// Observe-only: the return value is ignored (the route is already
-    /// gone), so there is no attribute write-back. A script that defines
-    /// no `loc_rib_withdraw` is a silent no-op (a script may bind only the
-    /// import hook).
     fn run_withdraw(
         &self,
         name: &str,
         prefix: IpNet,
+        attr: &BgpAttr,
+        peer: &PeerView,
+    ) -> mlua::Result<()> {
+        let prefix_t = marshal::prefix_table(&self.lua, prefix)?;
+        self.run_withdraw_prefix(name, prefix_t, attr, peer)
+    }
+
+    fn run_withdraw_evpn(
+        &self,
+        name: &str,
+        route: &EvpnRoute,
+        attr: &BgpAttr,
+        peer: &PeerView,
+    ) -> mlua::Result<()> {
+        let prefix_t = marshal::evpn_prefix_table(&self.lua, route)?;
+        self.run_withdraw_prefix(name, prefix_t, attr, peer)
+    }
+
+    /// Prefix-agnostic core of the withdraw hook. Observe-only: the return
+    /// value is ignored (the route is already gone), so there is no
+    /// attribute write-back. A script that defines no `loc_rib_withdraw`
+    /// is a silent no-op (a script may bind only the import hook).
+    fn run_withdraw_prefix(
+        &self,
+        name: &str,
+        prefix_t: Table,
         attr: &BgpAttr,
         peer: &PeerView,
     ) -> mlua::Result<()> {
@@ -210,9 +231,14 @@ impl Engine {
         let Some(func) = env.get::<Option<Function>>("loc_rib_withdraw")? else {
             return Ok(());
         };
-        let prefix_t = marshal::prefix_table(&self.lua, prefix)?;
         let attr_t = marshal::attr_table(&self.lua, attr)?;
         let peer_t = marshal::peer_table(&self.lua, peer)?;
+        // The withdraw hook is strictly observe-only: pass the tables
+        // deeply read-only so a script cannot even appear to mutate route
+        // state (the route is already gone — there is nothing to change).
+        let prefix_t = freeze(&self.lua, &prefix_t)?;
+        let attr_t = freeze(&self.lua, &attr_t)?;
+        let peer_t = freeze(&self.lua, &peer_t)?;
         let _: Value = func.call((
             prefix_t,
             attr_t,
@@ -224,6 +250,52 @@ impl Engine {
         ))?;
         Ok(())
     }
+}
+
+/// Recursively wrap `table` (and its nested table values) in a read-only
+/// proxy: an empty table whose metatable indexes the backing for reads and
+/// errors on every write. Existing keys are blocked too (the proxy is
+/// empty, so all access goes through `__index` / `__newindex`), and
+/// `__metatable = false` hides the metatable so a script can't unwrap it.
+/// `ipairs` and field reads work through `__index`; the withdraw hook uses
+/// this so it cannot mutate the route values it observes.
+fn freeze(lua: &Lua, table: &Table) -> mlua::Result<Table> {
+    // Freeze nested tables in the backing first (collect, then replace —
+    // no mutation during iteration).
+    let mut nested: Vec<(Value, Table)> = Vec::new();
+    table.for_each::<Value, Value>(|key, value| {
+        if let Value::Table(child) = value {
+            nested.push((key, child));
+        }
+        Ok(())
+    })?;
+    for (key, child) in nested {
+        let frozen = freeze(lua, &child)?;
+        table.raw_set(key, frozen)?;
+    }
+
+    let proxy = lua.create_table()?;
+    let meta = lua.create_table()?;
+    meta.set("__index", table.clone())?;
+    let backing = table.clone();
+    meta.set(
+        "__len",
+        lua.create_function(move |_, _: Table| Ok(backing.raw_len()))?,
+    )?;
+    meta.set(
+        "__newindex",
+        lua.create_function(
+            |_, (_t, _k, _v): (Table, Value, Value)| -> mlua::Result<()> {
+                Err(mlua::Error::RuntimeError(
+                    "read-only: the withdraw hook cannot modify route values".into(),
+                ))
+            },
+        )?,
+    )?;
+    // Hide the metatable so a script cannot reach `__newindex` to disable it.
+    meta.set("__metatable", false)?;
+    proxy.set_metatable(Some(meta));
+    Ok(proxy)
 }
 
 /// Load one script source into its own sandboxed environment table and
@@ -376,21 +448,34 @@ pub fn loc_rib_import_evpn(
     })
 }
 
-/// Thread-local entry point used by [`super::loc_rib_withdraw_v4`].
-/// Observe-only; fail-safe (errors are logged, nothing else happens).
-pub fn loc_rib_withdraw(name: &str, prefix: IpNet, attr: &BgpAttr, peer: &PeerView) {
+/// Sync the thread-local VM and run an observe-only `op` against it,
+/// logging (and otherwise swallowing) any error — the fail-safe used by
+/// both withdraw entry points.
+fn with_engine_unit(name: &str, op: impl FnOnce(&Engine) -> mlua::Result<()>) {
     let scripts = current();
     ENGINE.with(|cell| {
         let mut engine = cell.borrow_mut();
         engine.sync(&scripts);
-        if let Err(err) = engine.run_withdraw(name, prefix, attr, peer) {
+        if let Err(err) = op(&engine) {
             tracing::warn!("lua: withdraw hook '{name}' error: {err}");
         }
     });
 }
 
-/// Test-only: run the withdraw hook and surface the `Result` (the public
-/// entry swallows errors by design), so a test can assert the script ran
+/// Thread-local entry point used by [`super::loc_rib_withdraw_v4`].
+pub fn loc_rib_withdraw(name: &str, prefix: IpNet, attr: &BgpAttr, peer: &PeerView) {
+    with_engine_unit(name, |engine| engine.run_withdraw(name, prefix, attr, peer));
+}
+
+/// Thread-local entry point used by [`super::loc_rib_withdraw_evpn`].
+pub fn loc_rib_withdraw_evpn(name: &str, route: &EvpnRoute, attr: &BgpAttr, peer: &PeerView) {
+    with_engine_unit(name, |engine| {
+        engine.run_withdraw_evpn(name, route, attr, peer)
+    });
+}
+
+/// Test-only: run a withdraw hook and surface the `Result` (the public
+/// entries swallow errors by design), so a test can assert the script ran
 /// and saw the stored attributes.
 #[cfg(test)]
 fn run_withdraw_test(
@@ -404,6 +489,22 @@ fn run_withdraw_test(
         let mut engine = cell.borrow_mut();
         engine.sync(&scripts);
         engine.run_withdraw(name, prefix, attr, peer)
+    })
+}
+
+/// Test-only EVPN twin of [`run_withdraw_test`].
+#[cfg(test)]
+fn run_withdraw_evpn_test(
+    name: &str,
+    route: &EvpnRoute,
+    attr: &BgpAttr,
+    peer: &PeerView,
+) -> mlua::Result<()> {
+    let scripts = current();
+    ENGINE.with(|cell| {
+        let mut engine = cell.borrow_mut();
+        engine.sync(&scripts);
+        engine.run_withdraw_evpn(name, route, attr, peer)
     })
 }
 
@@ -735,6 +836,57 @@ mod tests {
     }
 
     #[test]
+    fn withdraw_tables_are_read_only() {
+        // The withdraw hook is observe-only: any write to prefix /
+        // attributes / peer (top-level or nested) must raise an error.
+        for body in [
+            "attributes.med = 5",                  // overwrite a scalar attribute
+            "attributes.foo = 1",                  // add a new key
+            "prefix.network = \"x\"",              // mutate prefix
+            "peer.remote_as = 0",                  // mutate peer
+            "attributes.ext_community[1] = \"x\"", // mutate a nested list
+        ] {
+            let src = format!(
+                "function loc_rib_withdraw(prefix, attributes, peer, F, N, M, C)\n{body}\nend"
+            );
+            let _g = install_one("ro", &src);
+            // A write attempt raises a Lua error, surfaced here as Err
+            // (the public entry would fail-safe and log it).
+            assert!(
+                run_withdraw_test("ro", net("10.0.0.0/24"), &BgpAttr::default(), &peer()).is_err(),
+                "write `{body}` should be rejected by the read-only table",
+            );
+        }
+    }
+
+    #[test]
+    fn withdraw_reads_still_work_under_freeze() {
+        // Freezing must not break reads: field access + ipairs over a
+        // nested list still work.
+        let _g = install_one(
+            "rd",
+            r#"
+            function loc_rib_withdraw(prefix, attributes, peer, F, N, M, C)
+                local _ = prefix.network
+                local n = 0
+                for _, ec in ipairs(attributes.ext_community) do n = n + 1 end
+                if peer.remote_as ~= 65001 or n ~= 1 then error("unexpected") end
+            end
+        "#,
+        );
+        let ecom = ExtCommunity::from([ExtCommunityValue {
+            high_type: 0x03,
+            low_type: 0x17,
+            val: [0x00, 0x00, 0x00, 0x00, 0x01, 0x2c],
+        }]);
+        let attr = BgpAttr {
+            ecom: Some(ecom),
+            ..Default::default()
+        };
+        assert!(run_withdraw_test("rd", net("10.0.0.0/24"), &attr, &peer()).is_ok());
+    }
+
+    #[test]
     fn withdraw_v4_binding_smoke() {
         // Exercise the public dispatch: unbound → no-op, bound → runs.
         let _g = install_one("wb", "function loc_rib_withdraw(p, a, pe, F, N, M, C) end");
@@ -848,5 +1000,48 @@ mod tests {
             loc_rib_import_evpn("evpn", &mac, &BgpAttr::default(), &peer()).action,
             Action::NoMatch
         );
+    }
+
+    #[test]
+    fn evpn_withdraw_sees_stored_attrs() {
+        // The GBP teardown move: on EVPN withdraw the script recovers the
+        // MAC (prefix.evpn.mac) and the GPI tag from the *stored* attrs of
+        // the path leaving the Loc-RIB. The script `error()`s on tag 300,
+        // which the test surfaces as Err.
+        use bgp_packet::{EvpnMac, EvpnRoute, RouteDistinguisher};
+        let _g = install_one(
+            "evpnw",
+            r#"
+            function loc_rib_withdraw(prefix, attributes, peer, FAIL, NOMATCH, MATCH, CHANGE)
+                if prefix.evpn.mac == "aa:bb:cc:dd:ee:01" then
+                    for _, ec in ipairs(attributes.ext_community) do
+                        if ecom.parse_gpi(ec) == 300 then
+                            error("teardown mac 300")
+                        end
+                    end
+                end
+            end
+        "#,
+        );
+        let mac = EvpnRoute::Mac(EvpnMac {
+            id: 0,
+            rd: "65000:1".parse::<RouteDistinguisher>().unwrap(),
+            esi: [0; 10],
+            ether_tag: 0,
+            mac: [0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0x01],
+            vni: 100,
+        });
+        let ecom = ExtCommunity::from([ExtCommunityValue {
+            high_type: 0x03,
+            low_type: 0x17,
+            val: [0x00, 0x00, 0x00, 0x00, 0x01, 0x2c],
+        }]);
+        let attr = BgpAttr {
+            ecom: Some(ecom),
+            ..Default::default()
+        };
+        assert!(run_withdraw_evpn_test("evpnw", &mac, &attr, &peer()).is_err());
+        // No GPI ext-community on the removed path → no-op.
+        assert!(run_withdraw_evpn_test("evpnw", &mac, &BgpAttr::default(), &peer()).is_ok());
     }
 }

--- a/zebra-rs/src/script/mod.rs
+++ b/zebra-rs/src/script/mod.rs
@@ -249,6 +249,32 @@ pub fn loc_rib_withdraw_v4(prefix: IpNet, attr: &BgpAttr, peer: &PeerView) {
 #[cfg(not(feature = "lua"))]
 pub fn loc_rib_withdraw_v4(_prefix: IpNet, _attr: &BgpAttr, _peer: &PeerView) {}
 
+/// The script name bound to the L2VPN-EVPN withdraw hook, or `None`.
+static WITHDRAW_BINDING_EVPN: OnceLock<RwLock<Option<String>>> = OnceLock::new();
+
+fn withdraw_binding_evpn() -> &'static RwLock<Option<String>> {
+    WITHDRAW_BINDING_EVPN.get_or_init(|| RwLock::new(None))
+}
+
+/// Bind (or, with `None`, unbind) the EVPN withdraw hook.
+pub fn set_withdraw_binding_evpn(name: Option<String>) {
+    *withdraw_binding_evpn().write().unwrap() = name;
+}
+
+/// Run the EVPN withdraw hook against the currently-bound script with the
+/// stored attributes of the EVPN path leaving the Loc-RIB (the teardown
+/// half of the GBP-over-EVPN demo). Observe-only; no-op when unbound/off.
+#[cfg(feature = "lua")]
+pub fn loc_rib_withdraw_evpn(route: &EvpnRoute, attr: &BgpAttr, peer: &PeerView) {
+    if let Some(name) = withdraw_binding_evpn().read().unwrap().clone() {
+        engine::loc_rib_withdraw_evpn(&name, route, attr, peer);
+    }
+}
+
+/// Feature-off no-op.
+#[cfg(not(feature = "lua"))]
+pub fn loc_rib_withdraw_evpn(_route: &EvpnRoute, _attr: &BgpAttr, _peer: &PeerView) {}
+
 /// Config-seeded lookup tables exposed to scripts as `map.get(ns, key)`.
 /// This is the non-blocking replacement for FRR's blocking HTTP GET: a
 /// background process can refresh a namespace out of band while the hook

--- a/zebra-rs/yang/zebra-bgp-lua.yang
+++ b/zebra-rs/yang/zebra-bgp-lua.yang
@@ -105,6 +105,10 @@ module zebra-bgp-lua {
           ext:help "Script run when an EVPN route is admitted into the Loc-RIB (sees prefix.evpn)";
           type string;
         }
+        leaf withdraw {
+          ext:help "Script run when an EVPN route is removed from the Loc-RIB (sees the stored attributes)";
+          type string;
+        }
       }
     }
   }


### PR DESCRIPTION
Two related changes that complete the EVPN receive+teardown half of the GBP-over-EVPN demo and make the withdraw contract *enforced*. Behind the `lua` feature.

## EVPN withdraw hook

Fires `loc_rib_withdraw` in `route_evpn_withdraw` with the **stored attributes of the EVPN path leaving the Loc-RIB** (`bgp.local_rib.remove_evpn` already returns the removed rows) and the full peer view. The script sees the route as `prefix.evpn` — the GBP teardown move (recover the tag, remove the nft element). Config: `router bgp loc-rib-hook l2vpn-evpn withdraw <name>`. Engine: factored `run_withdraw_prefix`; added the EVPN twin.

## Strictly read-only withdraw tables (consistency)

The withdraw hook is observe-only (the route is already gone — there is nothing to change), so the `prefix` / `attributes` / `peer` tables, **and their nested tables**, are now passed **deeply read-only**: an empty proxy whose metatable reads the backing via `__index` and **errors on every write** via `__newindex` (this blocks existing-key overwrites too, which a plain `__newindex` would miss), with `__metatable = false` so a script can't unwrap it. A withdraw script can no longer even appear to mutate route state. `ipairs` and field reads still work through `__index`, so existing withdraw scripts are unaffected. The import hook is unchanged (its `attributes` stays mutable for write-back).

## Test plan

- `cargo test -p zebra-rs --features lua script::` — 22 tests (4 new):
  - `evpn_withdraw_sees_stored_attrs` — recovers `prefix.evpn.mac` + GPI tag from the removed `EvpnRoute::Mac`'s stored attrs.
  - `withdraw_tables_are_read_only` — 5 write attempts (scalar overwrite, new key, prefix, peer, nested list element) all rejected.
  - `withdraw_reads_still_work_under_freeze` — field reads + `ipairs` over `ext_community` still work.
- `cargo test -p zebra-rs configure_mode_loads` — the new `l2vpn-evpn withdraw` leaf loads.
- default + `--features lua` clippy clean; fmt clean.

Generated with [Claude Code](https://claude.com/claude-code)