### PR TITLE
bgp-lua: egress hook engine + UpdateGroupSig keystone (E1+E2)

### DIFF
--- a/docs/design/lua-egress-hook.md
+++ b/docs/design/lua-egress-hook.md
@@ -1,0 +1,226 @@
+# Lua Egress (Adj-RIB-Out) Hook — design note
+
+Status: **in progress** — E1+E2 landed; E3 (wiring) next.
+Builds on the merged Lua scripting series (engine, import/withdraw hooks, marshalling,
+host helpers) — see `docs/design/lua-scripting-policy.md`.
+
+## Decision (confirmed 2026-06-22)
+
+- **Correctness model: B — singleton group per scripted peer.** Folding the bound
+  script identity *plus a peer-unique key* into `UpdateGroupSig` makes any peer with an
+  egress script its own update-group; the black-box transform then runs **per-peer with
+  the full `peer` table**, never replicating one peer's bytes to another. This trades
+  update-group coalescing (for scripted peers) for unconditional correctness and full
+  peer context — chosen over Model A. The §3 analysis below is kept for the rationale.
+- **Config surface: a new `adj-rib-out-hook` container** (separate from `loc-rib-hook`,
+  since Adj-RIB-Out is a different RIB boundary).
+- **Status:** E1 (engine `adj_rib_out` / `adj_rib_out_evpn` entries + egress bindings +
+  `generation()`) and E2 (`UpdateGroupSig.egress_script` = [`EgressScriptKey`] {name,
+  generation, peer} + `SIGNATURE_VERSION = 4` + `signature_of`) are implemented and
+  unit-tested. E3 (wire into `route_apply_policy_out` + `adj-rib-out-hook` config/YANG +
+  regroup-on-bind) and E4 (EVPN advertise) are next. Under Model B the egress hook **does**
+  receive the full `peer` table (it runs per-peer), unlike the no-peer-table design A
+  sketched in §3.
+
+## 1. Goal
+
+The merged hooks cover the **receive** side. This adds the **advertise** side: a hook
+that runs as a route is built into a peer's Adj-RIB-Out, after native outbound policy,
+and may **transform the attributes** before they are encoded. The motivating use case
+is the GBP-over-EVPN talk's *origination* half — attach the GPI Extended Community
+(`0x03/0x17`, the group tag) to the EVPN Type-2 route on the way out:
+
+```lua
+function adj_rib_out(prefix, attributes, RM_FAILURE, RM_NOMATCH, RM_MATCH, RM_MATCH_AND_CHANGE)
+    local mac = prefix.evpn and prefix.evpn.mac
+    if mac then
+        local tag = map.get("sgt", mac)              -- non-blocking lookup
+        if tag then
+            table.insert(attributes.ext_community, ecom.gpi(tonumber(tag)))
+            return { action = RM_MATCH_AND_CHANGE, attributes = attributes }
+        end
+    end
+    return { action = RM_NOMATCH }
+end
+```
+
+Reuses the engine, marshalling, write-back (`read_attr`), and `ecom.gpi`/`map.get`
+host helpers already on `main`. **The hard part is not the hook — it is update-group
+coalescing.**
+
+## 2. The hard problem: update-group coalescing
+
+zebra-rs does not encode an UPDATE per peer. Peers that would receive **byte-identical**
+UPDATEs are grouped (`UpdateGroupSig`, `update_group.rs:120`); one *canonical member*
+runs the egress transform + encodes once, and the bytes are replicated to every member
+(`docs/design/bgp-egress-*`). This is a large convergence win and the default path.
+
+The grouping is sound **only because the canonical-member transform output is assumed
+to depend solely on the signature fields.** Every native per-peer egress transform that
+*could* differ between peers is folded into `UpdateGroupSig` so peers that would diverge
+land in different groups:
+
+- `policy_out_name`, `prefix_set_out_name` — the bound out-policy.
+- `as_override_target = remote_as` — as-override rewrites the peer's AS, so the output
+  depends on `remote_as`; two peers may only share if they override the *same* AS.
+- `remove_private_as` (mode + kept AS), `local_as_substitute` — same reasoning.
+- `local_as`, `peer_type`, `reflector_client`, `local_addr`, negotiated caps.
+
+`signature_of` (`update_group.rs:310`) builds this; `SIGNATURE_VERSION` (currently **3**)
+is bumped whenever a field is added (surfaced in `show bgp update-group`).
+
+**A Lua egress script is a black box.** The engine cannot know which inputs it reads.
+If a script branches on `peer.remote_as` (or any non-signature peer field), two peers in
+the same group but with different `remote_as` would both get the **canonical member's**
+output — silently wrong, and a BDD would not catch it (the bytes look fine; only the
+*wrong* peer's bytes). This is the exact trap the memory note
+`zebra-rs-bgp-update-group-signature-trap` warns about, generalized to an arbitrary
+transform.
+
+## 3. Two correctness models
+
+### Model A — purity contract + sig-keyed sharing (recommended)
+
+Treat the egress hook the way native transforms are treated: **it must be a pure
+function of `(prefix, attributes)` and the signature-invariant identity** — nothing
+peer-specific outside the signature.
+
+Enforce it structurally rather than by documentation:
+
+- The egress hook is passed **`prefix` and `attributes` only — no `peer` table** (v1).
+  Within a group, all members share the same pre-transform `attributes` for a given
+  route, and the same prefix, so the transform output is identical for the whole group.
+  Any group-invariant identity the script legitimately needs (local-AS, iBGP/eBGP,
+  reflector-client) is *already* a signature field; if a real need appears, expose a
+  **restricted** `egress` table carrying only those signature-invariant fields (still
+  safe), never arbitrary peer state.
+- Add the bound script identity to `UpdateGroupSig` so enabling / disabling / reloading
+  the script forces a regroup + recompute (§4).
+
+Result: coalescing is preserved (the GBP origination transform is a pure function of the
+route, so all members of a group get the correct, identical bytes), and the canonical-
+member assumption still holds.
+
+The remaining soft spot is **non-determinism inside the script** — e.g. `map.get`
+returning a different value on two calls within the same flush, or `Math.random`-style
+sources (already removed by the sandbox). `map.get` is the realistic one: the canonical
+member runs the transform once per route per flush, so a mid-flush map change can only
+make *the next* flush differ, never split one group's members — the map is read once per
+canonical encode and replicated. That is acceptable (eventual consistency on the next
+advertise), and is called out in §7.
+
+### Model B — singleton group per egress-scripted peer (fallback)
+
+If we are unwilling to rely on the purity contract, make any peer with an egress script
+its **own** update-group (fold the peer's identity into the signature when a script is
+bound), so the script runs per-peer with full peer context. Correct unconditionally, but
+loses coalescing for scripted peers (N encodes instead of 1). Keep this as an opt-in
+(`adj-rib-out-hook … per-peer`) or a fallback if a future hook needs real peer state.
+
+**Recommendation: ship Model A** (no `peer` table → purity is structural), with Model B
+noted as the escape hatch. v1 binding is **global per-AFI** (one egress script for the
+family), which does not shard groups at all — it only needs to ride the signature so a
+reload invalidates cached encodings.
+
+## 4. UpdateGroupSig integration
+
+```rust
+pub struct UpdateGroupSig {
+    // … existing fields …
+    /// Bound egress (Adj-RIB-Out) Lua script for this family: `(name,
+    /// generation)`. `None` when unbound. The generation makes a hot
+    /// reload bump the signature, so every group re-forms and the
+    /// canonical member re-encodes with the new script. With a global
+    /// per-AFI binding every peer carries the same value, so this does
+    /// not shard groups — it gates cache validity. (Per-peer bindings,
+    /// if added later, would shard here, which is exactly correct.)
+    pub egress_script: Option<(String, u64)>,
+}
+```
+
+- Bump `SIGNATURE_VERSION` 3 → **4**.
+- `signature_of`: `egress_script: script::egress_binding(afi, safi)` (the bound name +
+  `script::generation()`), `None` when unbound or the `lua` feature is off.
+- Add a column to `show bgp update-group` (the sig is already rendered there).
+
+The script `generation` is the registry counter already used for lazy VM recompile;
+expose a `script::generation()` getter (read of the existing `Scripts.generation`).
+
+## 5. Firing point
+
+Native outbound policy is `route_apply_policy_out` (v4, `route.rs:2790`) /
+`route_apply_policy_out_evpn` (`route.rs:2767`), both returning `Option<PolicyDecision>`
+and both consulted by the canonical-member encode (`route.rs:3817`, `4304`, `4951`).
+Hook **after** the native decision, mutating `decision.attr`:
+
+```rust
+let decision = route_apply_policy_out(&ctx, &nlri, attr, weight)?;
+#[cfg(feature = "lua")]
+let decision = script::adj_rib_out_v4(IpNet::V4(nlri.prefix), decision); // Failure→None, Change→new attr
+```
+
+Because this is the canonical member's single encode, the script runs **once per group
+per route**, and the bytes replicate — correct under Model A. The egress engine entry is
+the existing `run_import_prefix` machinery renamed conceptually (`adj_rib_out`), reusing
+`MATCH_AND_CHANGE` write-back; `Failure` means "don't advertise this route to the group".
+
+EVPN advertise hooks at `route_apply_policy_out_evpn` the same way (`prefix.evpn`).
+
+## 6. Config / YANG
+
+A new container (the egress boundary is Adj-RIB-Out, distinct from `loc-rib-hook`):
+
+```
+router bgp 65000
+  adj-rib-out-hook {
+    ipv4-unicast { export GBP_OUT; }
+    l2vpn-evpn   { export GBP_OUT; }
+  }
+```
+
+`zebra-bgp-lua.yang`: an `adj-rib-out-hook` container mirroring `loc-rib-hook`, leaf
+`export`. Handler → `script::set_egress_binding(afi_safi, Some(name))`; the binding lives
+in the global script registry (like the import binding) so `signature_of` and the encode
+path both read it without threading new fields through `BgpTop`/`SyncCtx`. Setting/
+clearing the binding must **trigger a regroup** (the sig changed) — reuse the existing
+update-group rebuild that a policy-out change already triggers.
+
+## 7. Risks & mitigations
+
+- **Canonical-member correctness** — addressed by Model A (no `peer` table → pure
+  transform). The sig unit test (below) is the gate, not BDD.
+- **`map.get` non-determinism within a flush** — read once per canonical encode and
+  replicated; a mid-flush change shows up on the next advertise. Acceptable; documented.
+  (A future "snapshot map at flush start" is possible if strict consistency is needed.)
+- **Reload churn** — a generation bump re-forms every group with an egress script and
+  re-encodes. Rare (config event); same cost as changing an out-route-map. The generation
+  is per *script set*, so editing an unrelated script also bumps it — acceptable, or
+  refine to per-script generations later.
+- **Performance** — one extra script call per group per route on the canonical member
+  (not per peer). Bounded; the egress task already fans encodes across a worker pool.
+- **`UpdateGroupSig` version bump** — `show bgp update-group` surfaces v4; any external
+  parser of that output must tolerate the new column. Internal only today.
+
+## 8. Phased PRs
+
+| PR | Content | Test |
+|----|---------|------|
+| E1 | `script::set_egress_binding` / `egress_binding` / `generation`; engine `adj_rib_out` entry (reuse `run_import_prefix` + write-back); **no** wiring yet. | unit: egress transform adds GPI ecom; Failure drops. |
+| E2 | `UpdateGroupSig.egress_script` + `SIGNATURE_VERSION = 4` + `signature_of` + `show` column. | **sig unit test**: two peers, different egress bindings → different sigs; same binding+gen → same sig; reload (gen bump) → sig changes. |
+| E3 | wire the hook into `route_apply_policy_out` (v4) + config/YANG (`adj-rib-out-hook ipv4-unicast export`) + regroup-on-bind. | unit: bound egress script transforms the advertised attr via the canonical encode. |
+| E4 | EVPN: `route_apply_policy_out_evpn` + `l2vpn-evpn export`. | unit: EVPN advertise adds GPI ecom. |
+| E5 | (deferred) Model B opt-in (`per-peer`) + restricted `egress` identity table, if a need appears. | |
+
+E2 is the keystone — landing the `UpdateGroupSig` field with its unit test *before* the
+wiring (E3) makes the coalescing-correctness contract explicit and regression-proof.
+
+## 9. Open questions for review
+
+1. **Binding name/shape** — `adj-rib-out-hook … export` vs folding `export` into the
+   existing `loc-rib-hook` container. (Proposed: separate container, since it is a
+   different RIB boundary.)
+2. **`peer` table on egress** — v1 omits it (purity). Confirm we don't need a restricted
+   identity table on day one.
+3. **Model A vs B default** — proposed A (purity contract). Confirm before E2.
+4. **Per-script vs per-set generation** — v1 uses the existing per-set generation in the
+   sig (a coarse but correct reload signal). Refine later only if churn matters.

--- a/zebra-rs/src/bgp/update_group.rs
+++ b/zebra-rs/src/bgp/update_group.rs
@@ -40,7 +40,7 @@ use crate::context::Timer;
 
 /// Bumped whenever a new field is added to `UpdateGroupSig`. Surfaced
 /// in `show bgp update-group` so a stale view is detectable.
-pub const SIGNATURE_VERSION: u32 = 3;
+pub const SIGNATURE_VERSION: u32 = 4;
 
 /// Address families the grouping logic considers — every family whose
 /// advertise pipeline consults `peer.update_group_id`. IPv6 unicast
@@ -154,7 +154,29 @@ pub struct UpdateGroupSig {
     pub addpath_send: bool,
     pub extended_next_hop: bool,
     pub multiple_labels: bool,
+    /// Bound egress (Adj-RIB-Out) Lua script identity for this family, or
+    /// `None`. A bound egress script is an arbitrary black-box attribute
+    /// transform, so it cannot ride the canonical-member "encode once,
+    /// replicate" path safely. [`EgressScriptKey`] includes a peer-unique
+    /// key, so a scripted peer lands in its OWN singleton update-group and
+    /// the transform runs per-peer with full peer context (the egress
+    /// design note's Model B). The `generation` makes a script hot-reload
+    /// bump the signature → regroup + re-encode.
+    pub egress_script: Option<EgressScriptKey>,
     pub signature_version: u32,
+}
+
+/// Identity of a per-peer egress Lua script in [`UpdateGroupSig`].
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct EgressScriptKey {
+    /// Bound script name.
+    pub name: String,
+    /// Script-registry generation (a hot-reload bumps it).
+    pub generation: u64,
+    /// Peer address — makes the signature unique per peer (singleton
+    /// group), so the black-box transform never replicates one peer's
+    /// bytes to another.
+    pub peer: IpAddr,
 }
 
 #[derive(Debug, Default, Clone)]
@@ -373,7 +395,26 @@ pub fn signature_of(peer: &Peer, afi: Afi, safi: Safi) -> Option<UpdateGroupSig>
         // RFC 8277 multiple-labels is still not negotiated by zebra-rs;
         // the field is forward-compatible for the day it lands.
         multiple_labels: false,
+        egress_script: egress_script_key(peer, afi, safi),
         signature_version: SIGNATURE_VERSION,
+    })
+}
+
+/// The bound egress Lua script for `(afi, safi)`, keyed per peer so a
+/// scripted peer becomes its own singleton update-group (Model B). `None`
+/// when no egress script is bound for the family (the common case — no
+/// effect on grouping). Always compiled; the bindings are empty without
+/// the `lua` feature.
+fn egress_script_key(peer: &Peer, afi: Afi, safi: Safi) -> Option<EgressScriptKey> {
+    let name = match (afi, safi) {
+        (Afi::Ip, Safi::Unicast) => crate::script::egress_binding_v4(),
+        (Afi::L2vpn, Safi::Evpn) => crate::script::egress_binding_evpn(),
+        _ => None,
+    }?;
+    Some(EgressScriptKey {
+        name,
+        generation: crate::script::generation(),
+        peer: peer.address,
     })
 }
 
@@ -1326,8 +1367,44 @@ mod tests {
             addpath_send: false,
             extended_next_hop: false,
             multiple_labels: false,
+            egress_script: None,
             signature_version: SIGNATURE_VERSION,
         }
+    }
+
+    /// A bound egress Lua script must shard the update-group per peer
+    /// (Model B): two peers under the same script land in DIFFERENT groups
+    /// (distinct signatures), so the black-box transform never replicates
+    /// one peer's bytes to another. A reload (generation bump) also
+    /// re-shards. Without an egress script, grouping is unchanged.
+    #[test]
+    fn egress_script_shards_group_per_peer() {
+        use std::net::{IpAddr, Ipv4Addr};
+
+        let a = base_sig();
+        let b = base_sig();
+        assert_eq!(a, b, "no egress script ⇒ identical sigs share a group");
+
+        let key = |peer: [u8; 4], generation: u64| EgressScriptKey {
+            name: "gbp".into(),
+            generation,
+            peer: IpAddr::V4(Ipv4Addr::from(peer)),
+        };
+
+        // Same script + generation, different peers ⇒ singleton groups.
+        let mut p1 = base_sig();
+        p1.egress_script = Some(key([10, 0, 0, 1], 1));
+        let mut p2 = base_sig();
+        p2.egress_script = Some(key([10, 0, 0, 2], 1));
+        assert_ne!(p1, p2, "scripted peers get their own groups");
+
+        // Same peer, a reload (generation bump) ⇒ new sig (regroup).
+        let mut p1_reloaded = base_sig();
+        p1_reloaded.egress_script = Some(key([10, 0, 0, 1], 2));
+        assert_ne!(p1, p1_reloaded, "a script reload re-forms the group");
+
+        // Binding vs unbound also differ.
+        assert_ne!(a, p1, "binding an egress script changes the sig");
     }
 
     /// Two structurally identical signatures must hash and compare equal.

--- a/zebra-rs/src/script/engine.rs
+++ b/zebra-rs/src/script/engine.rs
@@ -139,13 +139,47 @@ impl Engine {
         self.run_import_prefix(name, prefix_t, attr, peer)
     }
 
-    /// Prefix-agnostic core of the import hook: given the already-built
-    /// `prefix` table (v4 or EVPN), build `attributes` / `peer`, call the
-    /// script's `loc_rib_import`, and fold a mutated `attributes` table
-    /// back on `MATCH_AND_CHANGE`.
     fn run_import_prefix(
         &self,
         name: &str,
+        prefix_t: Table,
+        attr: &BgpAttr,
+        peer: &PeerView,
+    ) -> mlua::Result<ImportOutcome> {
+        self.run_hook(name, "loc_rib_import", prefix_t, attr, peer)
+    }
+
+    fn run_adj_rib_out(
+        &self,
+        name: &str,
+        prefix: IpNet,
+        attr: &BgpAttr,
+        peer: &PeerView,
+    ) -> mlua::Result<ImportOutcome> {
+        let prefix_t = marshal::prefix_table(&self.lua, prefix)?;
+        self.run_hook(name, "adj_rib_out", prefix_t, attr, peer)
+    }
+
+    fn run_adj_rib_out_evpn(
+        &self,
+        name: &str,
+        route: &EvpnRoute,
+        attr: &BgpAttr,
+        peer: &PeerView,
+    ) -> mlua::Result<ImportOutcome> {
+        let prefix_t = marshal::evpn_prefix_table(&self.lua, route)?;
+        self.run_hook(name, "adj_rib_out", prefix_t, attr, peer)
+    }
+
+    /// Prefix- and direction-agnostic core of a transforming hook: given
+    /// the already-built `prefix` table (v4 or EVPN) and the script
+    /// function name (`loc_rib_import` or `adj_rib_out`), build
+    /// `attributes` / `peer`, call the function, and fold a mutated
+    /// `attributes` table back on `MATCH_AND_CHANGE`.
+    fn run_hook(
+        &self,
+        name: &str,
+        func_name: &str,
         prefix_t: Table,
         attr: &BgpAttr,
         peer: &PeerView,
@@ -154,7 +188,7 @@ impl Engine {
             .envs
             .get(name)
             .ok_or_else(|| mlua::Error::RuntimeError(format!("no loaded script '{name}'")))?;
-        let func: Function = env.get("loc_rib_import")?;
+        let func: Function = env.get(func_name)?;
         let attr_t = marshal::attr_table(&self.lua, attr)?;
         let peer_t = marshal::peer_table(&self.lua, peer)?;
         let ret: Value = func.call((
@@ -445,6 +479,25 @@ pub fn loc_rib_import_evpn(
 ) -> ImportOutcome {
     with_engine(name, |engine| {
         engine.run_import_evpn(name, route, attr, peer)
+    })
+}
+
+/// Thread-local entry point used by [`super::adj_rib_out_v4`].
+pub fn adj_rib_out(name: &str, prefix: IpNet, attr: &BgpAttr, peer: &PeerView) -> ImportOutcome {
+    with_engine(name, |engine| {
+        engine.run_adj_rib_out(name, prefix, attr, peer)
+    })
+}
+
+/// Thread-local entry point used by [`super::adj_rib_out_evpn`].
+pub fn adj_rib_out_evpn(
+    name: &str,
+    route: &EvpnRoute,
+    attr: &BgpAttr,
+    peer: &PeerView,
+) -> ImportOutcome {
+    with_engine(name, |engine| {
+        engine.run_adj_rib_out_evpn(name, route, attr, peer)
     })
 }
 
@@ -1043,5 +1096,73 @@ mod tests {
         assert!(run_withdraw_evpn_test("evpnw", &mac, &attr, &peer()).is_err());
         // No GPI ext-community on the removed path → no-op.
         assert!(run_withdraw_evpn_test("evpnw", &mac, &BgpAttr::default(), &peer()).is_ok());
+    }
+
+    #[test]
+    fn adj_rib_out_appends_gpi() {
+        // The GBP origination move (advertise side): the egress hook adds
+        // a GPI ext-community to the outbound attributes. Model B gives it
+        // the full `peer` table.
+        let _g = install_one(
+            "eg",
+            r#"
+            function adj_rib_out(prefix, attributes, peer, FAIL, NOMATCH, MATCH, CHANGE)
+                if peer.remote_as == 65001 then
+                    table.insert(attributes.ext_community, ecom.gpi(300))
+                    return { action = CHANGE, attributes = attributes }
+                end
+                return { action = NOMATCH }
+            end
+        "#,
+        );
+        let out = adj_rib_out("eg", net("10.0.0.0/24"), &BgpAttr::default(), &peer());
+        assert_eq!(out.action, Action::MatchAndChange);
+        let ecom = out
+            .attr
+            .expect("attributes present")
+            .ecom
+            .expect("ext-community installed");
+        let gpi = ecom
+            .0
+            .iter()
+            .find(|v| v.high_type == 0x03 && v.low_type == 0x17)
+            .expect("GPI ext-community present");
+        assert_eq!(u16::from_be_bytes([gpi.val[4], gpi.val[5]]), 300);
+    }
+
+    #[test]
+    fn adj_rib_out_evpn_appends_gpi() {
+        use bgp_packet::{EvpnMac, EvpnRoute, RouteDistinguisher};
+        let _g = install_one(
+            "ege",
+            r#"
+            function adj_rib_out(prefix, attributes, peer, FAIL, NOMATCH, MATCH, CHANGE)
+                if prefix.evpn and prefix.evpn.mac == "aa:bb:cc:dd:ee:01" then
+                    table.insert(attributes.ext_community, ecom.gpi(300))
+                    return { action = CHANGE, attributes = attributes }
+                end
+                return { action = NOMATCH }
+            end
+        "#,
+        );
+        let mac = EvpnRoute::Mac(EvpnMac {
+            id: 0,
+            rd: "65000:1".parse::<RouteDistinguisher>().unwrap(),
+            esi: [0; 10],
+            ether_tag: 0,
+            mac: [0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0x01],
+            vni: 100,
+        });
+        let out = adj_rib_out_evpn("ege", &mac, &BgpAttr::default(), &peer());
+        assert_eq!(out.action, Action::MatchAndChange);
+        assert!(
+            out.attr
+                .unwrap()
+                .ecom
+                .unwrap()
+                .0
+                .iter()
+                .any(|v| v.high_type == 0x03 && v.low_type == 0x17)
+        );
     }
 }

--- a/zebra-rs/src/script/mod.rs
+++ b/zebra-rs/src/script/mod.rs
@@ -156,6 +156,13 @@ pub fn current() -> Arc<Scripts> {
     registry().read().unwrap().clone()
 }
 
+/// Current registry generation. Folded into `UpdateGroupSig` for the
+/// egress hook so a script hot-reload re-forms the update-groups and
+/// re-encodes (the canonical member must run the new transform).
+pub fn generation() -> u64 {
+    registry().read().unwrap().generation
+}
+
 /// The script name bound to the IPv4-unicast Adj-RIB-In → Loc-RIB import
 /// hook, or `None` when unbound. Kept separate from [`Scripts`] so
 /// changing the binding does not force every VM to recompile.
@@ -215,6 +222,81 @@ pub fn loc_rib_import_evpn(route: &EvpnRoute, attr: &BgpAttr, peer: &PeerView) -
 /// Feature-off no-op.
 #[cfg(not(feature = "lua"))]
 pub fn loc_rib_import_evpn(_route: &EvpnRoute, _attr: &BgpAttr, _peer: &PeerView) -> ImportOutcome {
+    ImportOutcome::nomatch()
+}
+
+// ---------------------------------------------------------------------------
+// Egress (Adj-RIB-Out) hook — the GBP advertise side. A bound egress script
+// is a black-box per-peer transform, so (per the egress design note, Model B)
+// `UpdateGroupSig` folds the script identity + the peer key in, making a
+// scripted peer its own singleton update-group — the transform then runs
+// per-peer with the full peer table. These bindings are read by
+// `signature_of` and (later) the advertise path; they are always compiled so
+// `signature_of` links regardless of the `lua` feature.
+// ---------------------------------------------------------------------------
+
+static EGRESS_BINDING_V4: OnceLock<RwLock<Option<String>>> = OnceLock::new();
+static EGRESS_BINDING_EVPN: OnceLock<RwLock<Option<String>>> = OnceLock::new();
+
+fn egress_slot_v4() -> &'static RwLock<Option<String>> {
+    EGRESS_BINDING_V4.get_or_init(|| RwLock::new(None))
+}
+
+fn egress_slot_evpn() -> &'static RwLock<Option<String>> {
+    EGRESS_BINDING_EVPN.get_or_init(|| RwLock::new(None))
+}
+
+/// Bind (or, with `None`, unbind) the IPv4-unicast egress hook.
+pub fn set_egress_binding_v4(name: Option<String>) {
+    *egress_slot_v4().write().unwrap() = name;
+}
+
+/// Bind (or, with `None`, unbind) the EVPN egress hook.
+pub fn set_egress_binding_evpn(name: Option<String>) {
+    *egress_slot_evpn().write().unwrap() = name;
+}
+
+/// The script bound to the IPv4-unicast egress hook, or `None`.
+pub fn egress_binding_v4() -> Option<String> {
+    egress_slot_v4().read().unwrap().clone()
+}
+
+/// The script bound to the EVPN egress hook, or `None`.
+pub fn egress_binding_evpn() -> Option<String> {
+    egress_slot_evpn().read().unwrap().clone()
+}
+
+/// Run the IPv4-unicast egress hook against the currently-bound script,
+/// transforming the advertised attributes (e.g. add a GPI ext-community).
+/// `Failure` means "do not advertise this route"; `MatchAndChange` carries
+/// the rewritten attributes. No-op when unbound / off.
+#[cfg(feature = "lua")]
+pub fn adj_rib_out_v4(prefix: IpNet, attr: &BgpAttr, peer: &PeerView) -> ImportOutcome {
+    match egress_binding_v4() {
+        Some(name) => engine::adj_rib_out(&name, prefix, attr, peer),
+        None => ImportOutcome::nomatch(),
+    }
+}
+
+/// Feature-off no-op.
+#[cfg(not(feature = "lua"))]
+pub fn adj_rib_out_v4(_prefix: IpNet, _attr: &BgpAttr, _peer: &PeerView) -> ImportOutcome {
+    ImportOutcome::nomatch()
+}
+
+/// Run the EVPN egress hook against the currently-bound script (sees
+/// `prefix.evpn`). Same contract as [`adj_rib_out_v4`].
+#[cfg(feature = "lua")]
+pub fn adj_rib_out_evpn(route: &EvpnRoute, attr: &BgpAttr, peer: &PeerView) -> ImportOutcome {
+    match egress_binding_evpn() {
+        Some(name) => engine::adj_rib_out_evpn(&name, route, attr, peer),
+        None => ImportOutcome::nomatch(),
+    }
+}
+
+/// Feature-off no-op.
+#[cfg(not(feature = "lua"))]
+pub fn adj_rib_out_evpn(_route: &EvpnRoute, _attr: &BgpAttr, _peer: &PeerView) -> ImportOutcome {
     ImportOutcome::nomatch()
 }
 


### PR DESCRIPTION
Starts the **egress (Adj-RIB-Out) hook** — the GBP *advertise* side that adds the GPI ext-community on outbound. This PR lands the two pieces that must come **before** any advertise-path wiring: the engine entry, and the update-group coalescing-correctness key. Design note: `docs/design/lua-egress-hook.md`.

## The problem this guards against
zebra-rs encodes one UPDATE per *update-group* (a canonical member transforms + encodes once, bytes replicate). That's correct only because the transform output depends solely on `UpdateGroupSig` fields. A Lua egress script is a **black box** — if it branched on peer state, two peers sharing a group would get the wrong bytes, and a BDD would not catch it. **Model B** (chosen): fold the script identity *plus a peer-unique key* into the signature, so a scripted peer becomes its **own singleton update-group** and the transform runs per-peer with full peer context.

## E1 — engine
- Generalize the import core to `run_hook(name, func_name, …)`; add `run_adj_rib_out` / `run_adj_rib_out_evpn` calling the script's `adj_rib_out` function, reusing the `attributes`/`peer` marshalling and the `MATCH_AND_CHANGE` write-back (the egress hook's purpose is to rewrite attributes).
- `script::set_egress_binding_v4/evpn`, `egress_binding_v4/evpn`, `generation()`.

## E2 — UpdateGroupSig keystone
- Add `egress_script: Option<EgressScriptKey>` (`{name, generation, peer}`); bump `SIGNATURE_VERSION` 3→4; populate in `signature_of`. The peer-unique key gives Model B; the generation makes a hot-reload re-shard + re-encode.

No `route.rs` wiring or config yet (E3) — there is no config surface to set the egress binding, so the sig field is `None` in production until E3.

## Test plan
- `cargo test -p zebra-rs --features lua script::` — 27 (3 new: `adj_rib_out_appends_gpi` v4 + EVPN add a GPI ext-community via the egress transform).
- `cargo test -p zebra-rs egress_script_shards_group_per_peer` — the sig keystone: two peers under one egress script get **distinct** signatures (singleton groups); a generation bump re-shards; unbound is unchanged.
- default + `--features lua` clippy clean; fmt clean.

Generated with [Claude Code](https://claude.com/claude-code)