### PR TITLE
bgp-lua: wire the v4 egress hook into the advertise path (E3)

### DIFF
--- a/docs/design/lua-egress-hook.md
+++ b/docs/design/lua-egress-hook.md
@@ -1,6 +1,6 @@
 # Lua Egress (Adj-RIB-Out) Hook — design note
 
-Status: **in progress** — E1+E2 landed; E3 (wiring) next.
+Status: **in progress** — E1+E2+E3 (v4 wired) landed; E4 (EVPN advertise) next.
 Builds on the merged Lua scripting series (engine, import/withdraw hooks, marshalling,
 host helpers) — see `docs/design/lua-scripting-policy.md`.
 
@@ -17,8 +17,13 @@ host helpers) — see `docs/design/lua-scripting-policy.md`.
 - **Status:** E1 (engine `adj_rib_out` / `adj_rib_out_evpn` entries + egress bindings +
   `generation()`) and E2 (`UpdateGroupSig.egress_script` = [`EgressScriptKey`] {name,
   generation, peer} + `SIGNATURE_VERSION = 4` + `signature_of`) are implemented and
-  unit-tested. E3 (wire into `route_apply_policy_out` + `adj-rib-out-hook` config/YANG +
-  regroup-on-bind) and E4 (EVPN advertise) are next. Under Model B the egress hook **does**
+  unit-tested. **E3 is done**: the v4 egress hook is wired into
+  `route_apply_policy_out` (via `SyncCtx::apply_egress_v4`, with `remote_id`/
+  `remote_address` added to `SyncCtx` so the egress `peer` table is complete), bound by
+  `adj-rib-out-hook ipv4-unicast export`, and a binding change reassigns every
+  established peer's update-group (`reassign_all_update_groups`) so the singletons form
+  before the transform runs. E4 (EVPN advertise via `route_apply_policy_out_evpn`) is
+  next. Under Model B the egress hook **does**
   receive the full `peer` table (it runs per-peer), unlike the no-peer-table design A
   sketched in §3.
 

--- a/zebra-rs/src/bgp/config.rs
+++ b/zebra-rs/src/bgp/config.rs
@@ -158,6 +158,40 @@ fn config_loc_rib_hook_withdraw_evpn(_bgp: &mut Bgp, mut args: Args, op: ConfigO
     Some(())
 }
 
+/// Re-evaluate every established peer's update-group membership
+/// (detach + attach, which recompute `signature_of`). Needed after an
+/// egress-script binding change: a bound egress script must move each
+/// scripted peer into its own singleton group (Model B) *before* the
+/// transform runs, or the canonical-member encode would replicate one
+/// peer's rewritten bytes to another.
+fn reassign_all_update_groups(bgp: &mut Bgp) {
+    let router_id = bgp.router_id;
+    let idents: Vec<usize> = bgp
+        .peers
+        .iter_all()
+        .filter(|(_, peer)| peer.state.is_established())
+        .map(|(_, peer)| peer.ident)
+        .collect();
+    for ident in idents {
+        super::update_group::detach(&mut bgp.update_groups, &mut bgp.peers, ident);
+        super::update_group::attach(&mut bgp.update_groups, &mut bgp.peers, ident, router_id);
+    }
+}
+
+/// `set router bgp adj-rib-out-hook ipv4-unicast export <name>` — bind a
+/// script to the IPv4-unicast egress (Adj-RIB-Out) hook; delete unbinds.
+/// A change re-forms the update-groups (see [`reassign_all_update_groups`]).
+fn config_adj_rib_out_hook_export_v4(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Option<()> {
+    if op.is_set() {
+        let name = args.string()?;
+        crate::script::set_egress_binding_v4(Some(name));
+    } else {
+        crate::script::set_egress_binding_v4(None);
+    }
+    reassign_all_update_groups(bgp);
+    Some(())
+}
+
 /// Parse a flat JSON object (`{"key": "value", ...}`) into a string→string
 /// map for `map.get`. Non-string JSON values (numbers, bools) are taken as
 /// their JSON text (so `{"aa:..": 100}` yields `"100"`); a parse failure
@@ -3764,6 +3798,10 @@ impl Bgp {
         self.callback_add(
             "/router/bgp/loc-rib-hook/l2vpn-evpn/withdraw",
             config_loc_rib_hook_withdraw_evpn,
+        );
+        self.callback_add(
+            "/router/bgp/adj-rib-out-hook/ipv4-unicast/export",
+            config_adj_rib_out_hook_export_v4,
         );
         self.callback_add("/router/bgp/lua-map", config_lua_map);
         self.callback_add(

--- a/zebra-rs/src/bgp/peer.rs
+++ b/zebra-rs/src/bgp/peer.rs
@@ -1316,6 +1316,8 @@ impl Peer {
                 _ => None,
             }),
             router_id,
+            remote_id: self.remote_id,
+            remote_address: self.address,
             vpnv4_next_hop_self: self.next_hop_self(Afi::Ip, Safi::MplsVpn),
             egress_as: self.egress_as(),
             out_policy: self.out_policy.clone(),

--- a/zebra-rs/src/bgp/route.rs
+++ b/zebra-rs/src/bgp/route.rs
@@ -175,6 +175,14 @@ pub struct SyncCtx {
     pub reflector_client: bool,
     pub local_addr_v4: Option<Ipv4Addr>,
     pub router_id: Ipv4Addr,
+    /// The peer's BGP Identifier and address — carried so the egress Lua
+    /// hook (which runs without a `&Peer`) can present a full `peer` table.
+    /// Under Model B a scripted peer is its own singleton group, so these
+    /// are that one peer's values. Read only by the `lua` egress hook.
+    #[cfg_attr(not(feature = "lua"), allow(dead_code))]
+    pub remote_id: Ipv4Addr,
+    #[cfg_attr(not(feature = "lua"), allow(dead_code))]
+    pub remote_address: IpAddr,
     pub vpnv4_next_hop_self: bool,
     pub egress_as: EgressAs,
     pub out_policy: Arc<super::policy::OutPolicy>,
@@ -205,6 +213,48 @@ impl SyncCtx {
     }
 }
 
+#[cfg(feature = "lua")]
+impl SyncCtx {
+    /// Build the `peer` table for the egress hook. Under Model B the
+    /// canonical member of a scripted peer's singleton group *is* that
+    /// peer, so these snapshot fields are its values.
+    fn lua_peer_view(&self) -> crate::script::PeerView {
+        crate::script::PeerView {
+            remote_as: self.egress_as.remote_as,
+            local_as: self.egress_as.local_as,
+            remote_id: self.remote_id,
+            local_id: self.router_id,
+            remote_address: self.remote_address,
+            state: "Established".to_string(),
+            is_ibgp: matches!(self.peer_type, PeerType::IBGP),
+        }
+    }
+
+    /// Apply the bound IPv4-unicast egress (Adj-RIB-Out) Lua hook to a
+    /// native out-policy decision: `Failure` drops the advertisement,
+    /// `MatchAndChange` folds the script's rewritten attributes in, else
+    /// pass through. No-op when no egress script is bound.
+    fn apply_egress_v4(
+        &self,
+        prefix: IpNet,
+        decision: Option<PolicyDecision>,
+    ) -> Option<PolicyDecision> {
+        let mut decision = decision?;
+        let peer = self.lua_peer_view();
+        let outcome = crate::script::adj_rib_out_v4(prefix, &decision.attr, &peer);
+        match outcome.action {
+            crate::script::Action::Failure => None,
+            crate::script::Action::MatchAndChange => {
+                if let Some(attr) = outcome.attr {
+                    decision.attr = attr;
+                }
+                Some(decision)
+            }
+            _ => Some(decision),
+        }
+    }
+}
+
 #[cfg(test)]
 impl SyncCtx {
     /// Minimal `SyncCtx` for shard-dispatch tests — no peer, no writer
@@ -217,6 +267,8 @@ impl SyncCtx {
             reflector_client: false,
             local_addr_v4: None,
             router_id: Ipv4Addr::UNSPECIFIED,
+            remote_id: Ipv4Addr::UNSPECIFIED,
+            remote_address: IpAddr::V4(Ipv4Addr::UNSPECIFIED),
             vpnv4_next_hop_self: false,
             egress_as: EgressAs {
                 is_ebgp: true,
@@ -2793,14 +2845,20 @@ pub fn route_apply_policy_out(
     bgp_attr: BgpAttr,
     weight: u32,
 ) -> Option<PolicyDecision> {
-    apply_policy_net(
+    let decision = apply_policy_net(
         &ctx.out_policy.prefix_set,
         &ctx.out_policy.policy_list,
         ctx.router_id,
         IpNet::V4(nlri.prefix),
         bgp_attr,
         weight,
-    )
+    );
+    // Egress (Adj-RIB-Out) Lua hook after native out-policy. Runs on the
+    // canonical member's encode; under Model B a scripted peer is a
+    // singleton group, so it runs per-peer.
+    #[cfg(feature = "lua")]
+    let decision = ctx.apply_egress_v4(IpNet::V4(nlri.prefix), decision);
+    decision
 }
 
 /// Per-AFI v4-family outbound policy: the v4 twin of

--- a/zebra-rs/yang/zebra-bgp-lua.yang
+++ b/zebra-rs/yang/zebra-bgp-lua.yang
@@ -86,6 +86,17 @@ module zebra-bgp-lua {
       }
     }
 
+    container adj-rib-out-hook {
+      ext:help "Bind Lua scripts to Adj-RIB-Out (advertise) hooks";
+      container ipv4-unicast {
+        ext:help "IPv4-unicast egress hooks";
+        leaf export {
+          ext:help "Script run as a route is advertised; may rewrite attributes, or deny to suppress";
+          type string;
+        }
+      }
+    }
+
     container loc-rib-hook {
       ext:help "Bind Lua scripts to Loc-RIB lifecycle hooks";
       container ipv4-unicast {


### PR DESCRIPTION
Makes the IPv4-unicast egress (Adj-RIB-Out) Lua hook actually run on the wire, on top of the E1 engine + E2 `UpdateGroupSig` keystone (#1594). Behind the `lua` feature.

## What's here

- **`SyncCtx`** (the peer-free egress snapshot) gains `remote_id` + `remote_address` so the egress hook can present a **full `peer` table**; populated in `Peer::sync_ctx`. Under Model B a scripted peer is a singleton group, so these are that one peer's values. (`cfg_attr(allow(dead_code))` when the feature is off, where the fields are write-only.)
- **`route_apply_policy_out`** fires `SyncCtx::apply_egress_v4` after native out-policy: `Failure` suppresses the advertisement, `MatchAndChange` folds the script's rewritten attributes in (e.g. the GBP GPI ext-community).
- **config**: `router bgp adj-rib-out-hook ipv4-unicast export <name>` (`zebra-bgp-lua.yang` + handler). A binding change calls **`reassign_all_update_groups`** (detach + attach every established peer) so each scripted peer moves into its own singleton group **before** the transform runs — otherwise the canonical-member encode would replicate one peer's rewritten bytes to another.

## Test plan

- `cargo test -p zebra-rs --features lua script::` — 24 green (the egress transform itself is unit-tested at the engine layer in #1594: `adj_rib_out_appends_gpi` v4 + EVPN). The advertise-path wiring is mechanical + `--features lua` clippy, matching how the import/withdraw wiring was validated (a route.rs integration test would race on the process-global script registry across test modules).
- `cargo test -p zebra-rs configure_mode_loads` — the `adj-rib-out-hook` container loads.
- default workspace clippy (incl. the dead-code gate) + `--features lua` clippy clean; fmt clean.

E4 (EVPN advertise via `route_apply_policy_out_evpn`) is next.

Generated with [Claude Code](https://claude.com/claude-code)