### PR TITLE
bgp-lua: wire the EVPN egress hook into the advertise path (E4)

### DIFF
--- a/docs/design/lua-egress-hook.md
+++ b/docs/design/lua-egress-hook.md
@@ -1,6 +1,7 @@
 # Lua Egress (Adj-RIB-Out) Hook — design note
 
-Status: **in progress** — E1+E2+E3 (v4 wired) landed; E4 (EVPN advertise) next.
+Status: **E1–E4 complete** — egress hook wired and config-bindable for IPv4-unicast and
+L2VPN-EVPN. (E5, the Model-B opt-in / restricted-identity table, remains deferred.)
 Builds on the merged Lua scripting series (engine, import/withdraw hooks, marshalling,
 host helpers) — see `docs/design/lua-scripting-policy.md`.
 

--- a/zebra-rs/src/bgp/config.rs
+++ b/zebra-rs/src/bgp/config.rs
@@ -192,6 +192,20 @@ fn config_adj_rib_out_hook_export_v4(bgp: &mut Bgp, mut args: Args, op: ConfigOp
     Some(())
 }
 
+/// `set router bgp adj-rib-out-hook l2vpn-evpn export <name>` — bind a
+/// script to the EVPN egress hook; delete unbinds. Re-forms the
+/// update-groups (the EVPN sig branch already keys on the egress script).
+fn config_adj_rib_out_hook_export_evpn(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Option<()> {
+    if op.is_set() {
+        let name = args.string()?;
+        crate::script::set_egress_binding_evpn(Some(name));
+    } else {
+        crate::script::set_egress_binding_evpn(None);
+    }
+    reassign_all_update_groups(bgp);
+    Some(())
+}
+
 /// Parse a flat JSON object (`{"key": "value", ...}`) into a string→string
 /// map for `map.get`. Non-string JSON values (numbers, bools) are taken as
 /// their JSON text (so `{"aa:..": 100}` yields `"100"`); a parse failure
@@ -3802,6 +3816,10 @@ impl Bgp {
         self.callback_add(
             "/router/bgp/adj-rib-out-hook/ipv4-unicast/export",
             config_adj_rib_out_hook_export_v4,
+        );
+        self.callback_add(
+            "/router/bgp/adj-rib-out-hook/l2vpn-evpn/export",
+            config_adj_rib_out_hook_export_evpn,
         );
         self.callback_add("/router/bgp/lua-map", config_lua_map);
         self.callback_add(

--- a/zebra-rs/src/bgp/route.rs
+++ b/zebra-rs/src/bgp/route.rs
@@ -2823,17 +2823,52 @@ pub fn route_apply_policy_out_evpn(
     weight: u32,
 ) -> Option<PolicyDecision> {
     let evpn = AfiSafi::new(Afi::L2vpn, Safi::Evpn);
-    let config = peer.policy_list_at(evpn, InOut::Output);
-    if config.name.is_some() {
-        let Some(policy_list) = &config.policy_list else {
-            return None;
-        };
-        return policy_list_apply_evpn(policy_list, route, bgp_attr, weight, peer.router_id);
+    let decision = {
+        let config = peer.policy_list_at(evpn, InOut::Output);
+        if config.name.is_some() {
+            match &config.policy_list {
+                Some(policy_list) => {
+                    policy_list_apply_evpn(policy_list, route, bgp_attr, weight, peer.router_id)
+                }
+                None => None,
+            }
+        } else {
+            Some(PolicyDecision {
+                attr: bgp_attr,
+                weight,
+            })
+        }
+    };
+    // EVPN egress (Adj-RIB-Out) Lua hook after native out-policy. EVPN
+    // advertise has a full `&Peer`, so the hook runs with the complete
+    // peer table. Failure suppresses the advertisement; MatchAndChange
+    // folds the rewritten attributes in (e.g. add the GBP GPI ecom).
+    #[cfg(feature = "lua")]
+    let decision = apply_egress_evpn(route, decision, peer);
+    decision
+}
+
+/// Apply the bound EVPN egress (Adj-RIB-Out) Lua hook to a native
+/// out-policy decision. No-op when no egress script is bound.
+#[cfg(feature = "lua")]
+fn apply_egress_evpn(
+    route: &EvpnRoute,
+    decision: Option<PolicyDecision>,
+    peer: &Peer,
+) -> Option<PolicyDecision> {
+    let mut decision = decision?;
+    let view = lua_peer_view(peer);
+    let outcome = crate::script::adj_rib_out_evpn(route, &decision.attr, &view);
+    match outcome.action {
+        crate::script::Action::Failure => None,
+        crate::script::Action::MatchAndChange => {
+            if let Some(attr) = outcome.attr {
+                decision.attr = attr;
+            }
+            Some(decision)
+        }
+        _ => Some(decision),
     }
-    Some(PolicyDecision {
-        attr: bgp_attr,
-        weight,
-    })
 }
 
 /// Outbound-policy evaluation for an IPv4 NLRI: the v4 / Output

--- a/zebra-rs/yang/zebra-bgp-lua.yang
+++ b/zebra-rs/yang/zebra-bgp-lua.yang
@@ -95,6 +95,13 @@ module zebra-bgp-lua {
           type string;
         }
       }
+      container l2vpn-evpn {
+        ext:help "L2VPN-EVPN egress hooks";
+        leaf export {
+          ext:help "Script run as an EVPN route is advertised (sees prefix.evpn); may rewrite attributes, or deny to suppress";
+          type string;
+        }
+      }
     }
 
     container loc-rib-hook {


### PR DESCRIPTION
Symmetric EVPN counterpart of #1595 (E3), completing the egress (Adj-RIB-Out) Lua hook for both families. Behind the `lua` feature.

## What's here

- **`route_apply_policy_out_evpn`** restructured to compute the native out-policy decision, then apply `apply_egress_evpn`. EVPN advertise has a full `&Peer` (unlike v4's peer-free `SyncCtx`), so the hook runs with the **complete peer table** via `lua_peer_view`. `Failure` suppresses the advertisement; `MatchAndChange` folds the rewritten attributes in (e.g. add the GBP GPI ext-community on the originated Type-2 route).
- **config**: `router bgp adj-rib-out-hook l2vpn-evpn export <name>` (`zebra-bgp-lua.yang` + handler), reusing `reassign_all_update_groups`. The EVPN egress binding (`set_egress_binding_evpn`) and the EVPN `signature_of` branch already existed from E1/E2.

The GBP **advertise** side now works for v4 **and** EVPN; with the merged import/withdraw hooks the **originate → receive → teardown** loop from the talk is complete at the engine/wiring level.

## Test plan

- `cargo test -p zebra-rs --features lua script::` — 24 (the EVPN egress transform is engine-unit-tested: `adj_rib_out_evpn_appends_gpi`). The advertise-path wiring is mechanical + `--features lua` clippy.
- `cargo test -p zebra-rs configure_mode_loads` — the `l2vpn-evpn export` leaf loads.
- default + `--features lua` clippy clean; fmt clean.

Deferred (E5): the Model-B opt-in / restricted-identity variant, if ever needed.

Generated with [Claude Code](https://claude.com/claude-code)