### PR TITLE
bgp-lua: enable lua by default + ship example, book, docs

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -59,15 +59,15 @@ jobs:
         # exclude them here. They are intended to be run locally.
         run: cargo test --workspace --exclude bdd
 
-  lua:
-    name: cargo test (lua)
+  no-lua:
+    name: cargo clippy (no-lua)
     runs-on: ubuntu-22.04
-    # The `lua` feature is off by default, so the default clippy / test
-    # jobs never compile the embedded scripting engine (src/script's
-    # `#[cfg(feature = "lua")]` code) nor run its unit tests. This lane
-    # closes that gap: it clippy-checks and tests zebra-rs with the
-    # feature on. `mlua`'s vendored Lua 5.4 builds from C source, so the
-    # runner's preinstalled cc is enough (no extra apt deps).
+    # The `lua` feature is ON by default, so the fmt / clippy / test jobs
+    # already build and test the embedded scripting engine. This lane
+    # guards the OTHER direction: that the feature-off build still
+    # compiles cleanly (the hooks' `#[cfg(not(feature = "lua"))]` no-op
+    # stubs and the feature-gated wiring), so `lua` stays genuinely
+    # optional.
     steps:
       - name: Checkout code
         uses: actions/checkout@v5
@@ -79,7 +79,5 @@ jobs:
         uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
           components: clippy
-      - name: Clippy (lua)
-        run: cargo clippy -p zebra-rs --features lua --all-targets -- -D warnings
-      - name: Test (lua)
-        run: cargo test -p zebra-rs --features lua
+      - name: Clippy (no default features)
+        run: cargo clippy -p zebra-rs --no-default-features --all-targets -- -D warnings

--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,10 @@
 .PHONY: zebra
 
 zebra:
-	RUSTFLAGS="--cfg tokio_unstable" cargo build --release
+	RUSTFLAGS="--cfg tokio_unstable" cargo build --release --features lua
 
 all:
-	cargo build --release
+	cargo build --release --features lua
 	$(MAKE) -C vty
 
 console:
@@ -20,7 +20,7 @@ xdp-bfd-echo:
 	@echo '[built offload/xdp-bfd-echo/target/release/xdp-bfd-echo]'
 
 install:
-	cargo build --release
+	cargo build --release --features lua
 	sudo cp target/release/zebra-rs /usr/bin/zebra-rs
 	sudo cp target/release/vtyctl /usr/bin/vtyctl
 	sudo cp target/release/vtyhelper /usr/bin/vtyhelper
@@ -76,7 +76,7 @@ run:
 	@mkdir -p /tmp/ipc/sync
 	@sudo rm -f /tmp/ipc/pair/config-ng_isisd
 	@sudo rm -f /tmp/ipc/pair/config-ng_bgpd
-	@RUSTFLAGS="--cfg tokio_unstable" cargo build --bin zebra-rs --release
+	@RUSTFLAGS="--cfg tokio_unstable" cargo build --bin zebra-rs --release --features lua
 	@sudo setcap 'cap_net_bind_service=ep cap_net_admin=ep cap_net_bind_service=ep cap_net_broadcast=ep cap_net_raw=ep' target/release/zebra-rs
 	@ZEBRA_VTY_SERVICE_ACCOUNTS=$$(id -u) target/release/zebra-rs
 	#@target/release/zebra-rs

--- a/book/src/SUMMARY.md
+++ b/book/src/SUMMARY.md
@@ -90,6 +90,7 @@
   - [Control Flow](ch-05-01-policy-control-flow.md)
   - [Match](ch-05-02-policy-match.md)
   - [Set](ch-05-03-policy-set.md)
+  - [Lua Scripting](ch-05-04-lua-scripting.md)
 
 ## Management Interface
 

--- a/book/src/ch-05-04-lua-scripting.md
+++ b/book/src/ch-05-04-lua-scripting.md
@@ -1,0 +1,108 @@
+# Lua Scripting
+
+Beyond the declarative [policy](ch-05-00-policy.md) engine, zebra-rs can
+run **Lua scripts** at well-defined points in the BGP route lifecycle.
+A script sees the route's prefix, its full path attributes (including
+extended communities), and the peer, and may observe, deny, or rewrite
+the route — or trigger a non-blocking side effect such as programming
+nftables. This is zebra-rs's analogue of FRR's `route-map match script`,
+redesigned around that feature's limitations.
+
+The embedded Lua 5.4 engine is **on by default**. Builds without it
+(`cargo build --no-default-features`) compile every hook to a no-op.
+
+## Hook points
+
+A script is bound to a hook on the **Adj-RIB-In → Loc-RIB** boundary
+(receive) or the **Adj-RIB-Out** boundary (advertise), per address
+family (IPv4-unicast and L2VPN-EVPN today):
+
+| Hook | Fires | Sees | May |
+|------|-------|------|-----|
+| `import`   | a received route enters the Loc-RIB | prefix, attributes, peer | observe / **deny** / **rewrite** attributes |
+| `withdraw` | a route leaves the Loc-RIB | prefix, the **stored** attributes, peer | observe only (tables are **read-only**) |
+| `export`   | a route is advertised to a peer | prefix, attributes, peer | observe / **suppress** / **rewrite** attributes |
+
+The `withdraw` hook is the half FRR cannot do: a wire withdrawal carries
+only the NLRI, but because zebra-rs is a single process the hook reads
+the **stored Loc-RIB attributes of the path being removed** — so a script
+can recover, say, a tag and tear down what the `import` hook set up.
+
+## The script contract
+
+A hook is a Lua function named for the hook (`loc_rib_import`,
+`loc_rib_withdraw`, or `adj_rib_out`). It receives the route context and
+the four result constants, and returns an action:
+
+```lua
+function loc_rib_import(prefix, attributes, peer,
+                        RM_FAILURE, RM_NOMATCH, RM_MATCH, RM_MATCH_AND_CHANGE)
+    -- ... inspect prefix / attributes / peer ...
+    return { action = RM_NOMATCH }   -- admit unchanged
+    -- or { action = RM_FAILURE }                                  -- deny
+    -- or { action = RM_MATCH_AND_CHANGE, attributes = attributes } -- rewrite
+end
+```
+
+- `prefix` — `prefix.network`, `prefix.afi` (`"ipv4"`/`"evpn"`), and for
+  EVPN a structured `prefix.evpn` (`route_type`, `mac`, `vni`, `rd`, …).
+- `attributes` — `med`, `local_pref`, `origin`, `as_path`, `next_hop`,
+  `community`, and `ext_community` (a list of 8-octet values, so
+  `string.unpack(">BBHHH", ec)` works). On `import`/`export`, mutate the
+  table and return `RM_MATCH_AND_CHANGE` to have the change land.
+- `peer` — `remote_as`, `local_as`, `remote_id`, `local_id`,
+  `remote_address`, `is_ibgp`, `state`.
+
+Scripts are **sandboxed**: `os`, `io`, `package`, `require`, `load*`, and
+`debug` are absent. Any script error fails safe (logged, treated as
+admit-unchanged), so a broken script never blackholes traffic.
+
+### Host helpers
+
+| Helper | Purpose |
+|--------|---------|
+| `ecom.gpi(tag)` / `ecom.parse_gpi(value)` | build / decode a Group-Policy-ID ext-community (type `0x03`, sub-type `0x17`) |
+| `map.get(ns, key)` | non-blocking read of a config-seeded lookup table |
+| `zlog.info/warn/error(msg)` | write to the daemon log |
+| `sideeffect.nft{ op=, table=, set=, elem= }` | enqueue an `nft add/delete element` onto a background drainer (never blocks the route path) |
+
+## Configuration
+
+Define named scripts (and optional lookup tables), then bind them:
+
+```
+router bgp 65000 {
+  lua-script GBP { source-path /etc/zebra-rs/lua/gbp-example.lua; }
+  lua-map sgt    { source-path /etc/zebra-rs/lua/sgt.json; }      // MAC -> tag JSON
+
+  loc-rib-hook {
+    ipv4-unicast { import GBP; withdraw GBP; }
+    l2vpn-evpn   { import GBP; withdraw GBP; }
+  }
+  adj-rib-out-hook {
+    ipv4-unicast { export GBP; }
+    l2vpn-evpn   { export GBP; }
+  }
+}
+```
+
+`lua-script … source-path` loads the script from a file at config time;
+`lua-map … source-path` loads a flat JSON object (`{"aa:bb:..": "100"}`)
+into a `map.get` namespace.
+
+> **Egress and update groups.** zebra-rs coalesces identical advertised
+> UPDATEs into *update groups* and encodes each once. Because an egress
+> script is an arbitrary transform, binding `adj-rib-out-hook … export`
+> places each affected peer in its **own** update group, so the script
+> runs per-peer with full peer context. Expect reduced advertise
+> coalescing for peers with an egress script bound.
+
+## Example: GBP over EVPN
+
+The package ships a complete example at
+`/etc/zebra-rs/lua/gbp-example.lua` implementing Group-Based Policy over
+EVPN: the `export` hook stamps the EVPN Type-2 (MAC) route with the
+endpoint's group tag (looked up MAC → tag via `map.get`) as a GPI
+extended community; the `import` hook recovers the tag and programs an
+nftables set member; the `withdraw` hook removes it. The receive → enforce
+→ teardown loop runs without any blocking I/O on the route path.

--- a/docs/design/lua-scripting-policy.md
+++ b/docs/design/lua-scripting-policy.md
@@ -58,8 +58,9 @@ first-class, in-process operation.
 ## 2. Scope
 
 **In scope (Phase 1–4):**
-- An embedded Lua 5.4 runtime, gated behind a Cargo feature `lua` (mirrors FRR's
-  `--enable-scripting` — off in default builds).
+- An embedded Lua 5.4 runtime behind a Cargo feature `lua`. (Originally off by
+  default — mirroring FRR's `--enable-scripting` — but now **on by default**; build
+  without it via `--no-default-features`, where the hooks compile to no-ops.)
 - Import hook on `route_ipv4_update` (and the v4 batch/shard reduce paths).
 - Withdraw hook on `route_ipv4_withdraw` (and the shard `WithdrawV4` reduce).
 - A read/write marshalling layer for `prefix`, `attributes` (incl. `ext_community`),
@@ -477,10 +478,11 @@ side (Phase 5); there it becomes `map.get("sgt", mac)` with a background refresh
 | 5d | `map.get` lookup | non-blocking `map.get(ns, key)` (config-seeded / background-refreshed table) — the non-blocking replacement for FRR's blocking HTTP GET on the origination side. | unit: seed + read. | |
 | 6 | GBP EVPN BDD | EVPN Type-2 marshalling (`prefix.evpn`); enrich the shard import peer table (remote-as/addresses); end-to-end `@bgp_lua_gbp` feature. Requires a **`--features lua` BDD binary** (see note). | BDD with explicit `Teardown topology`. | |
 
-Each PR is independently revertible; the feature flag keeps `main` builds untouched
-until the engine is proven. **BDD note:** the BDD harness runs a manually-installed
-`/usr/bin/zebra-rs`; the `lua` feature is off by default, so a Lua BDD needs that
-binary built with `--features lua` (a dedicated build/CI lane). Until that lane
+Each PR is independently revertible. **BDD note:** the BDD harness runs a
+manually-installed `/usr/bin/zebra-rs`; the `lua` feature is **now on by default**, so a
+stock release binary already includes the engine and the `@bgp_lua_gbp` BDD no longer
+needs a special `--features lua` build. (Historically the lane needed that build.) Until
+that lane
 exists, Lua behaviour is covered by the `#[cfg(feature = "lua")]` unit tests.
 Later: egress/origination hook (Phase 5b — *adds* the GPI ecom on advertise;
 **must join `UpdateGroupSig`**, see §10), route-map `match script` clause (FRR

--- a/docs/design/lua-scripting-policy.md
+++ b/docs/design/lua-scripting-policy.md
@@ -1,6 +1,9 @@
 # Lua Scripting Integration for zebra-rs — Loc-RIB Policy Hooks
 
-Status: **design / proposal** (branch `lua`)
+Status: **shipped** — the engine plus the import / withdraw / egress hooks (IPv4-unicast
+and L2VPN-EVPN) are on `main`; the `lua` feature is **on by default**. User docs:
+`book/src/ch-05-04-lua-scripting.md`; egress-specific design: `lua-egress-hook.md`. This
+file is the original design + the per-PR plan (§9) that drove the work.
 Prior art: FRR Scripting (合田和也, ENOG90 2026-06-19 — "FRR Scripting は何ができるのか").
 
 This document designs an embedded-Lua scripting facility for zebra-rs, modelled

--- a/etc/zebra-rs/lua/gbp-example.lua
+++ b/etc/zebra-rs/lua/gbp-example.lua
@@ -1,0 +1,82 @@
+-- gbp-example.lua — example zebra-rs Lua policy script (GBP over EVPN).
+--
+-- zebra-rs ships the embedded Lua engine by default. A script is bound to
+-- a hook from BGP config, e.g.:
+--
+--   router bgp 65000 {
+--     lua-script GBP { source-path /etc/zebra-rs/lua/gbp-example.lua; }
+--     lua-map sgt   { source-path /etc/zebra-rs/lua/sgt.json; }   -- MAC -> tag
+--     loc-rib-hook l2vpn-evpn {
+--       import GBP;     -- on receive: program nftables from the GPI tag
+--       withdraw GBP;   -- on withdraw: tear the nftables element down
+--     }
+--     adj-rib-out-hook l2vpn-evpn { export GBP; }  -- on advertise: add the GPI tag
+--   }
+--
+-- A hook function receives (prefix, attributes, peer, RM_FAILURE,
+-- RM_NOMATCH, RM_MATCH, RM_MATCH_AND_CHANGE) and returns
+--   { action = RM_NOMATCH }                        -- admit unchanged
+--   { action = RM_FAILURE }                        -- deny / suppress
+--   { action = RM_MATCH_AND_CHANGE, attributes = attributes }  -- rewrite attrs
+-- The withdraw hook is observe-only: its tables are read-only and its
+-- return value is ignored.
+--
+-- Available to scripts: string/table/math, and the host helpers
+--   ecom.gpi(tag) / ecom.parse_gpi(value)   -- GPI ext-community (0x03/0x17)
+--   map.get(namespace, key)                 -- config-seeded lookup table
+--   zlog.info/warn/error(msg)               -- daemon log
+--   sideeffect.nft{ op=, table=, set=, elem= }  -- non-blocking nftables op
+-- (os/io/network access is intentionally absent — the engine is sandboxed.)
+
+local GBP_TABLE = "bridge gbp_filter"
+
+-- Advertise side: stamp the EVPN Type-2 (MAC) route with the GPI
+-- Extended Community for the endpoint's group, looked up MAC -> tag.
+function adj_rib_out(prefix, attributes, peer, FAIL, NOMATCH, MATCH, CHANGE)
+    local mac = prefix.evpn and prefix.evpn.mac
+    if mac then
+        local tag = map.get("sgt", mac)
+        if tag then
+            table.insert(attributes.ext_community, ecom.gpi(tonumber(tag)))
+            return { action = CHANGE, attributes = attributes }
+        end
+    end
+    return { action = NOMATCH }
+end
+
+-- Receive side: recover the group tag from the GPI ext-community and add
+-- the MAC to the matching nftables set.
+function loc_rib_import(prefix, attributes, peer, FAIL, NOMATCH, MATCH, CHANGE)
+    local mac = prefix.evpn and prefix.evpn.mac
+    if mac then
+        for _, ec in ipairs(attributes.ext_community) do
+            local tag = ecom.parse_gpi(ec)
+            if tag then
+                sideeffect.nft{ op = "add", table = GBP_TABLE,
+                                set = "tag_" .. tag, elem = mac }
+                zlog.info("gbp: " .. mac .. " -> tag " .. tag)
+                break
+            end
+        end
+    end
+    return { action = NOMATCH }
+end
+
+-- Teardown: the path is leaving the Loc-RIB. `attributes` are the STORED
+-- attributes of the withdrawn route (read-only), so the tag is still
+-- recoverable — remove the nftables element. (FRR cannot do this.)
+function loc_rib_withdraw(prefix, attributes, peer, FAIL, NOMATCH, MATCH, CHANGE)
+    local mac = prefix.evpn and prefix.evpn.mac
+    if mac then
+        for _, ec in ipairs(attributes.ext_community) do
+            local tag = ecom.parse_gpi(ec)
+            if tag then
+                sideeffect.nft{ op = "delete", table = GBP_TABLE,
+                                set = "tag_" .. tag, elem = mac }
+                zlog.info("gbp: withdraw " .. mac .. " from tag " .. tag)
+                break
+            end
+        end
+    end
+    return { action = NOMATCH }
+end

--- a/packaging/Makefile
+++ b/packaging/Makefile
@@ -1,12 +1,12 @@
 all: arm64
 
 arm64: ../vty/vty
-	cargo build --release
+	cargo build --release --features lua
 	$(MAKE) -C .. xdp-bfd-echo
 	nfpm package --packager=deb --config=nfpm-arm64.yaml
 
 amd64: ../vty/vty
-	cargo build --release
+	cargo build --release --features lua
 	$(MAKE) -C .. xdp-bfd-echo
 	nfpm package --packager=deb --config=nfpm-amd64.yaml
 

--- a/packaging/nfpm-amd64.yaml
+++ b/packaging/nfpm-amd64.yaml
@@ -47,6 +47,11 @@ contents:
       mode: 0644
   - src: ../zebra-rs/yang
     dst: /etc/zebra-rs/yang
+  # Example Lua policy scripts for the embedded scripting engine (on by
+  # default). Operators drop their own scripts here and bind them from
+  # `router bgp { lua-script <name> { source-path ... } }`.
+  - src: ../etc/zebra-rs/lua
+    dst: /etc/zebra-rs/lua
   - src: ./modules-load.d/zebra-rs.conf
     dst: /etc/modules-load.d/zebra-rs.conf
   - src: ./patch/usr/lib/systemd/system/zebra-rs.service

--- a/packaging/nfpm-arm64.yaml
+++ b/packaging/nfpm-arm64.yaml
@@ -47,6 +47,11 @@ contents:
       mode: 0644
   - src: ../zebra-rs/yang
     dst: /etc/zebra-rs/yang
+  # Example Lua policy scripts for the embedded scripting engine (on by
+  # default). Operators drop their own scripts here and bind them from
+  # `router bgp { lua-script <name> { source-path ... } }`.
+  - src: ../etc/zebra-rs/lua
+    dst: /etc/zebra-rs/lua
   - src: ./modules-load.d/zebra-rs.conf
     dst: /etc/modules-load.d/zebra-rs.conf
   - src: ./patch/usr/lib/systemd/system/zebra-rs.service

--- a/zebra-rs/Cargo.toml
+++ b/zebra-rs/Cargo.toml
@@ -77,15 +77,18 @@ sha1 = "0.11"
 sha2 = "0.11"
 hmac = "0.13"
 rs-pfcp = "0.3.1"
-# Embedded Lua scripting engine — optional, enabled by the `lua` feature.
-# `vendored` bundles the Lua 5.4 interpreter so the build stays hermetic
-# (no system liblua). Off by default, mirroring FRR's --enable-scripting.
+# Embedded Lua scripting engine, enabled by the `lua` feature (on by
+# default). `vendored` bundles the Lua 5.4 interpreter so the build stays
+# hermetic (no system liblua) — it does need a C compiler at build time.
 mlua = { version = "0.10", features = ["lua54", "vendored"], optional = true }
 
 [features]
-default = []
-# Compile the embedded Lua scripting engine (src/script). Off by default;
-# enable with `--features lua`.
+# `lua` is on by default so stock builds (and the BDD binary) ship the
+# embedded scripting engine. Build without it via
+# `--no-default-features` (the hooks compile to no-ops); that path is
+# guarded by the `no-lua` CI lane.
+default = ["lua"]
+# Compile the embedded Lua scripting engine (src/script).
 lua = ["dep:mlua"]
 
 [target.'cfg(target_os = "linux")'.dependencies]

--- a/zebra-rs/src/script/engine.rs
+++ b/zebra-rs/src/script/engine.rs
@@ -1165,4 +1165,55 @@ mod tests {
                 .any(|v| v.high_type == 0x03 && v.low_type == 0x17)
         );
     }
+
+    #[test]
+    fn shipped_gbp_example_loads_and_runs() {
+        // The example script packaged at /etc/zebra-rs/lua/gbp-example.lua
+        // must stay valid: `include_str!` pins the path at compile time,
+        // and exercising the egress path (map.get → ecom.gpi →
+        // MATCH_AND_CHANGE) proves it actually loaded and ran (a syntax
+        // error would fail-safe to a *loaded-script-missing* NoMatch, so
+        // we assert the positive transform).
+        use bgp_packet::{EvpnMac, EvpnRoute, RouteDistinguisher};
+        const EXAMPLE: &str = include_str!(concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/../etc/zebra-rs/lua/gbp-example.lua"
+        ));
+        let _g = install_one("gbp_example", EXAMPLE);
+
+        let mac = EvpnRoute::Mac(EvpnMac {
+            id: 0,
+            rd: "65000:1".parse::<RouteDistinguisher>().unwrap(),
+            esi: [0; 10],
+            ether_tag: 0,
+            mac: [0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0x01],
+            vni: 100,
+        });
+        let mut sgt = std::collections::BTreeMap::new();
+        sgt.insert("aa:bb:cc:dd:ee:01".to_string(), "300".to_string());
+        crate::script::map_set_namespace("sgt", sgt);
+
+        // Egress: stamps the GPI ext-community looked up MAC → tag.
+        let out = adj_rib_out_evpn("gbp_example", &mac, &BgpAttr::default(), &peer());
+        assert_eq!(out.action, Action::MatchAndChange);
+        let ecom = out.attr.unwrap().ecom.unwrap();
+        assert!(
+            ecom.0
+                .iter()
+                .any(|v| v.high_type == 0x03 && v.low_type == 0x17)
+        );
+
+        // Import + withdraw run on the stamped route without error.
+        let stamped = BgpAttr {
+            ecom: Some(ecom),
+            ..Default::default()
+        };
+        assert_eq!(
+            loc_rib_import_evpn("gbp_example", &mac, &stamped, &peer()).action,
+            Action::NoMatch
+        );
+        assert!(run_withdraw_evpn_test("gbp_example", &mac, &stamped, &peer()).is_ok());
+
+        crate::script::map_clear_namespace("sgt");
+    }
 }


### PR DESCRIPTION
Makes the embedded Lua scripting engine **on by default** and follows that through the build, packaging, and docs. The whole Lua scripting series (engine, import/withdraw/egress hooks for v4 + EVPN, host helpers) is already on `main`; this flips it from opt-in to shipped-by-default.

## Commit 1 — enable the feature by default
- `zebra-rs/Cargo.toml`: `default = ["lua"]`. Build without it via `--no-default-features` (every hook compiles to a no-op).
- `.github/workflows/ci.yaml`: the old `lua` lane is now redundant (the default `fmt`/`clippy`/`test` jobs cover the lua code); repurpose it to a **`no-lua`** lane that guards the `--no-default-features` build so the feature stays genuinely optional.

## Commit 2 — build, package, document
- `Makefile` + `packaging/Makefile`: pass `--features lua` explicitly on the release builds (redundant with the default, but documents intent / robust if the default changes).
- `etc/zebra-rs/lua/gbp-example.lua`: a complete, commented GBP-over-EVPN template (import / withdraw / export), shipped to `/etc/zebra-rs/lua` via both nfpm configs — operators get a place + a working example.
- `book/src/ch-05-04-lua-scripting.md`: user-facing chapter under **Policy** (hooks, the script contract, host helpers, config, the GBP example); linked from `SUMMARY.md`.
- `docs/design/lua-scripting-policy.md`: marked shipped.

## Test plan
- default `cargo clippy --workspace --all-targets -- -D warnings` (now lua-on) — clean.
- default `cargo test -p zebra-rs` runs the 25 `script::` tests, including `shipped_gbp_example_loads_and_runs` which `include_str!`s the packaged example and exercises the egress → import path (so a broken example fails CI).
- `cargo clippy -p zebra-rs --no-default-features --all-targets -- -D warnings` (the new lane) — clean.
- `mdbook build` — the new chapter + SUMMARY render; nfpm YAML validates; fmt clean.

`mlua`'s vendored Lua 5.4 builds from C; every build/release workflow already has a C compiler.

Generated with [Claude Code](https://claude.com/claude-code)