### PR TITLE
bgp-lua: ship the ENOG90 talk's scripts as zebra-rs examples

### DIFF
--- a/etc/zebra-rs/lua/gbp-export.lua
+++ b/etc/zebra-rs/lua/gbp-export.lua
@@ -1,0 +1,38 @@
+-- gbp-export.lua — zebra-rs port of the FRR "route advertise" GBP script
+-- (ENOG90 "FRR Scripting は何ができるのか", slides 21–25).
+--
+-- On EVPN Type-2 (MAC) advertisement, look the MAC up in a MAC→tag map and
+-- stamp the route with a Group-Policy-ID (GPI) extended community, so the
+-- receiver can enforce group-based policy.
+--
+-- Bind:
+--   router bgp 65000 {
+--     lua-script gbp { source-path /etc/zebra-rs/lua/gbp-export.lua; }
+--     lua-map sgt    { source-path /etc/zebra-rs/lua/sgt.json; }   // {"aa:bb:..":"100"}
+--     adj-rib-out-hook l2vpn-evpn { export gbp; }
+--   }
+--
+-- FRR → zebra-rs port notes:
+--   * `route_match` → `adj_rib_out` (the advertise / Adj-RIB-Out hook).
+--   * Regex on `tostring(prefix.network)` → structured `prefix.evpn.mac`.
+--   * Blocking `http.request(...)` + `json.decode(...)` → non-blocking
+--     `map.get("sgt", mac)` (a config-seeded lookup table).
+--   * `string.pack(">BBHHH", 0x03, 0x17, 0, 0, tag)` → `ecom.gpi(tag)`.
+--     (The raw `string.pack` form also works — ext_community entries are
+--     8-byte values — `ecom.gpi` is just the tidy spelling.)
+
+function adj_rib_out(prefix, attributes, peer,
+                     RM_FAILURE, RM_NOMATCH, RM_MATCH, RM_MATCH_AND_CHANGE)
+    local mac = prefix.evpn and prefix.evpn.mac
+    if not mac then
+        return { action = RM_NOMATCH }
+    end
+
+    local tag = map.get("sgt", mac)
+    if not tag then
+        return { action = RM_NOMATCH }
+    end
+
+    table.insert(attributes.ext_community, ecom.gpi(tonumber(tag)))
+    return { action = RM_MATCH_AND_CHANGE, attributes = attributes }
+end

--- a/etc/zebra-rs/lua/gbp-import.lua
+++ b/etc/zebra-rs/lua/gbp-import.lua
@@ -1,0 +1,63 @@
+-- gbp-import.lua — zebra-rs port of the FRR "route receive" GBP script
+-- (ENOG90 "FRR Scripting は何ができるのか", slides 27–30), plus the withdraw
+-- teardown the talk wished for but FRR could not do (slide 32, #1).
+--
+-- On receiving an EVPN Type-2 (MAC) route, recover the group tag from its
+-- GPI extended community and add the MAC to the matching nftables set; on
+-- withdrawal, remove it.
+--
+-- Bind:
+--   router bgp 65000 {
+--     lua-script gbp { source-path /etc/zebra-rs/lua/gbp-import.lua; }
+--     loc-rib-hook l2vpn-evpn { import gbp; withdraw gbp; }
+--   }
+--
+-- FRR → zebra-rs port notes:
+--   * `route_match` → `loc_rib_import` (the receive / Adj-RIB-In→Loc-RIB hook).
+--   * Regex on `tostring(prefix.network)` → structured `prefix.evpn.mac`.
+--   * The `ec:byte(1)/ec:byte(2)` loop + `string.unpack(">BBHHH", ec)` →
+--     `ecom.parse_gpi(ec)` (returns the tag, or nil if `ec` is not a GPI
+--     community). The raw byte/unpack form also works in zebra-rs.
+--   * Blocking, unsandboxed `os.execute("nft ...")` → non-blocking
+--     `sideeffect.nft{...}`, which enqueues onto a background drainer.
+--     (`os` is intentionally absent from the sandbox.)
+
+local GBP_TABLE = "bridge gbp_filter"
+
+-- Receive: program the nftables set from the GPI tag.
+function loc_rib_import(prefix, attributes, peer,
+                        RM_FAILURE, RM_NOMATCH, RM_MATCH, RM_MATCH_AND_CHANGE)
+    local mac = prefix.evpn and prefix.evpn.mac
+    if mac then
+        for _, ec in ipairs(attributes.ext_community) do
+            local tag = ecom.parse_gpi(ec)
+            if tag then
+                sideeffect.nft{ op = "add", table = GBP_TABLE,
+                                set = "tag_" .. tag, elem = mac }
+                break
+            end
+        end
+    end
+    return { action = RM_NOMATCH }
+end
+
+-- Withdraw: the route is leaving the Loc-RIB. `attributes` are the STORED
+-- attributes of the withdrawn path (read-only), so the tag is still
+-- recoverable — remove the nftables element. FRR has no hook here: its
+-- route-map is not run on withdrawal, and the zebra dataplane hook lacks
+-- the BGP ext-communities. zebra-rs is one process, so it just works.
+function loc_rib_withdraw(prefix, attributes, peer,
+                          RM_FAILURE, RM_NOMATCH, RM_MATCH, RM_MATCH_AND_CHANGE)
+    local mac = prefix.evpn and prefix.evpn.mac
+    if mac then
+        for _, ec in ipairs(attributes.ext_community) do
+            local tag = ecom.parse_gpi(ec)
+            if tag then
+                sideeffect.nft{ op = "delete", table = GBP_TABLE,
+                                set = "tag_" .. tag, elem = mac }
+                break
+            end
+        end
+    end
+    return { action = RM_NOMATCH }
+end

--- a/etc/zebra-rs/lua/metric.lua
+++ b/etc/zebra-rs/lua/metric.lua
@@ -1,0 +1,28 @@
+-- metric.lua — zebra-rs port of the basic FRR Scripting example
+-- (ENOG90 "FRR Scripting は何ができるのか", slide 7).
+--
+-- FRR original (route-map `match script`):
+--   function route_match(prefix, attributes, peer, ...)
+--     if prefix.network == "172.16.10.4/24" then
+--       return { action = RM_NOMATCH }
+--     else
+--       attributes["metric"] = attributes["metric"] + 7
+--       return { action = RM_MATCH_AND_CHANGE, attributes = attributes }
+--     end
+--   end
+--
+-- Port notes:
+--   * `route_match` → a named hook. Bind this file's `loc_rib_import` to
+--       router bgp { loc-rib-hook ipv4-unicast { import metric } }
+--     (rename the function to `adj_rib_out` to run it on advertise instead).
+--   * FRR's `attributes["metric"]` is the MED; in zebra-rs it is
+--     `attributes.med`. Guarded with `or 0` since MED may be unset.
+
+function loc_rib_import(prefix, attributes, peer,
+                        RM_FAILURE, RM_NOMATCH, RM_MATCH, RM_MATCH_AND_CHANGE)
+    if prefix.network == "172.16.10.4/24" then
+        return { action = RM_NOMATCH }
+    end
+    attributes.med = (attributes.med or 0) + 7
+    return { action = RM_MATCH_AND_CHANGE, attributes = attributes }
+end

--- a/zebra-rs/src/script/engine.rs
+++ b/zebra-rs/src/script/engine.rs
@@ -1216,4 +1216,83 @@ mod tests {
 
         crate::script::map_clear_namespace("sgt");
     }
+
+    #[test]
+    fn packaged_lua_scripts_load() {
+        // The other example scripts shipped to /etc/zebra-rs/lua must stay
+        // valid (they are packaged): `include_str!` pins each path at
+        // compile time, and the positive transforms below prove each one
+        // actually loaded and ran.
+        use bgp_packet::{EvpnMac, EvpnRoute, RouteDistinguisher};
+        const METRIC: &str = include_str!(concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/../etc/zebra-rs/lua/metric.lua"
+        ));
+        const EXPORT: &str = include_str!(concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/../etc/zebra-rs/lua/gbp-export.lua"
+        ));
+        const IMPORT: &str = include_str!(concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/../etc/zebra-rs/lua/gbp-import.lua"
+        ));
+
+        // metric.lua — non-matching prefix bumps MED by 7 (proves it loaded).
+        {
+            let _g = install_one("metric_port", METRIC);
+            let out = loc_rib_import(
+                "metric_port",
+                net("10.0.0.0/24"),
+                &BgpAttr::default(),
+                &peer(),
+            );
+            assert_eq!(out.action, Action::MatchAndChange);
+            assert_eq!(out.attr.unwrap().med.map(|m| m.med), Some(7));
+            assert_eq!(
+                import("metric_port", "172.16.10.4/24", &BgpAttr::default()),
+                Action::NoMatch
+            );
+        }
+
+        let mac = EvpnRoute::Mac(EvpnMac {
+            id: 0,
+            rd: "65000:1".parse::<RouteDistinguisher>().unwrap(),
+            esi: [0; 10],
+            ether_tag: 0,
+            mac: [0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0x01],
+            vni: 100,
+        });
+
+        // gbp-export.lua — map.get → ecom.gpi → MATCH_AND_CHANGE (proves it loaded).
+        {
+            let _g = install_one("gbp_export", EXPORT);
+            let mut sgt = BTreeMap::new();
+            sgt.insert("aa:bb:cc:dd:ee:01".to_string(), "100".to_string());
+            crate::script::map_set_namespace("sgt", sgt);
+            let out = adj_rib_out_evpn("gbp_export", &mac, &BgpAttr::default(), &peer());
+            assert_eq!(out.action, Action::MatchAndChange);
+            assert!(
+                out.attr
+                    .unwrap()
+                    .ecom
+                    .unwrap()
+                    .0
+                    .iter()
+                    .any(|v| v.high_type == 0x03 && v.low_type == 0x17)
+            );
+            crate::script::map_clear_namespace("sgt");
+        }
+
+        // gbp-import.lua — loads + import/withdraw run without error.
+        {
+            let _g = install_one("gbp_import", IMPORT);
+            assert_eq!(
+                loc_rib_import_evpn("gbp_import", &mac, &BgpAttr::default(), &peer()).action,
+                Action::NoMatch
+            );
+            assert!(
+                run_withdraw_evpn_test("gbp_import", &mac, &BgpAttr::default(), &peer()).is_ok()
+            );
+        }
+    }
 }


### PR DESCRIPTION
Ports the three Lua scripts from the FRR-scripting talk (ENOG90 90, 合田和也 — "FRR Scripting は何ができるのか") to the zebra-rs hook model and ships them under `/etc/zebra-rs/lua` alongside `gbp-example.lua`. nfpm already packages that whole directory, so the new scripts ship with the deb automatically.

## Scripts

| File | Talk slide | What it does |
|------|-----------|--------------|
| `metric.lua` | 7 | the basic `route_match` example — bump MED by 7 unless the prefix matches |
| `gbp-export.lua` | 21–25 | advertise side: `adj_rib_out` stamps the GPI ext-community; `map.get` replaces FRR's blocking HTTP GET, `ecom.gpi` replaces the raw `string.pack` |
| `gbp-import.lua` | 27–30 (+32) | receive side: `loc_rib_import` programs the nftables set via non-blocking `sideeffect.nft` (vs FRR's `os.execute`), plus `loc_rib_withdraw` to tear it down — the half the talk wished for but FRR cannot do |

Each file carries a header comment mapping the FRR original to its zebra-rs form.

## Test plan
- `packaged_lua_scripts_load` (new engine test) `include_str!`s all three and exercises the positive transform of each — `metric.lua` → MED becomes 7, `gbp-export.lua` → GPI ext-community stamped, `gbp-import.lua` → import + withdraw run — so a syntax error or broken example fails CI.
- `cargo test -p zebra-rs script::` green; workspace clippy + fmt clean.

Generated with [Claude Code](https://claude.com/claude-code)