### PR TITLE
config: order bridge and vxlan first in config output

### DIFF
--- a/zebra-rs/yang/config.yang
+++ b/zebra-rs/yang/config.yang
@@ -292,7 +292,7 @@ module config {
     }
 
     list bridge {
-      ext:sort "10";
+      ext:sort "100";
       key "name";
       leaf name {
         type string;
@@ -308,7 +308,7 @@ module config {
     }
 
     list vxlan {
-      ext:sort "15";
+      ext:sort "90";
       key "name";
       leaf name {
         type string;


### PR DESCRIPTION
## Summary
Adjusts the `ext:sort` priorities of the top-level `bridge` and `vxlan` lists in `config.yang` so they render first in configuration output.

Config siblings are sorted **descending** by `ext:sort` priority (`compare_configs` in `src/config/configs.rs`), then alphabetically. The previous top-level maximum was `vrf=30`, so `bridge`/`vxlan` were buried mid-list. The new values pin them to the top:

- `bridge`: `10` → `100`
- `vxlan`: `15` → `90`

Resulting top-level order: **bridge**, **vxlan**, then `vrf` (30), `interface` (20), and the remaining nodes in their existing order.

## Test plan
- `cargo test -p zebra-rs --bin zebra-rs yang_load` → 33 passed, 0 failed (modules still load and validate).
- No test pins the bridge/vxlan ordering, so no test updates were required.

Generated with [Claude Code](https://claude.com/claude-code)