### PR TITLE
config: reject key-only isis afi-safi list entries (ext:non-empty)

### DIFF
--- a/proto/vty.proto
+++ b/proto/vty.proto
@@ -210,6 +210,11 @@ message CommandPath {
   YangMatch ymatch = 3;
   repeated string mandatory = 4;
   int32 sort_priority = 5;
+  // When non-empty, this list node forbids key-only entries: every list
+  // entry must carry at least one child node. The string is the human-
+  // readable requirement (e.g. "network or redistribute") surfaced in the
+  // commit-time error. Driven by the `ext:non-empty` YANG extension.
+  string non_empty = 6;
 }
 
 // Show service.

--- a/vtyctl/src/mcp/client.rs
+++ b/vtyctl/src/mcp/client.rs
@@ -45,6 +45,7 @@ impl ZebraClient {
                 ymatch: ymatch.into(),
                 mandatory: vec![],
                 sort_priority: 0,
+                non_empty: String::new(),
             };
             paths.push(path);
         }

--- a/zebra-rs/src/config/configs.rs
+++ b/zebra-rs/src/config/configs.rs
@@ -176,6 +176,10 @@ pub struct Config {
     pub parent: Option<Rc<Config>>,
     pub mandatory: Vec<String>,
     pub sort_priority: RefCell<i32>,
+    /// `ext:non-empty` requirement text (empty = unset). When set on a
+    /// list node, every key entry must carry at least one child; a bare
+    /// `... <key>` fails `validate` with this string as the hint.
+    pub non_empty: String,
 }
 
 impl Config {
@@ -519,6 +523,22 @@ impl Config {
                 errors.push(format!("'{}' missing mandatory node '{}'", parents, m));
             }
         }
+        // `ext:non-empty`: a list node that forbids key-only entries. Each
+        // entry must carry at least one child (`configs`/`keys`) or a
+        // leaf-list value (`list`); a bare `... <key>` is rejected.
+        if !self.non_empty.is_empty() {
+            for key in self.keys.borrow().iter() {
+                if !key.has_dir() && key.list.borrow().is_empty() {
+                    let mut parents = VecDeque::<String>::new();
+                    self.parents(&mut parents);
+                    parents.push_back(self.name.clone());
+                    parents.push_back(key.name.clone());
+                    let parents = Vec::from(parents);
+                    let parents = parents.join(" ");
+                    errors.push(format!("'{}' requires {}", parents, self.non_empty));
+                }
+            }
+        }
         for key in self.keys.borrow().iter() {
             key.validate(errors);
         }
@@ -537,6 +557,7 @@ pub fn carbon_copy(conf: &Rc<Config>, parent: Option<Rc<Config>>) -> Rc<Config> 
         presence: conf.presence,
         mandatory: conf.mandatory.clone(),
         sort_priority: conf.sort_priority.clone(),
+        non_empty: conf.non_empty.clone(),
         parent,
         ..Default::default()
     });
@@ -569,6 +590,7 @@ fn config_set_dir(config: &Rc<Config>, cpath: &CommandPath) -> Rc<Config> {
                 presence: (ymatch_enum(cpath.ymatch) == YangMatch::DirMatched),
                 mandatory: cpath.mandatory.clone(),
                 sort_priority: cpath.sort_priority.into(),
+                non_empty: cpath.non_empty.clone(),
                 ..Default::default()
             });
             config.configs.borrow_mut().push(n.clone());
@@ -782,6 +804,71 @@ mod tests {
         assert_eq!(
             args.afi_safi(),
             Some(AfiSafi::new(Afi::Ip6, Safi::Flowspec))
+        );
+    }
+
+    // `ext:non-empty` on a list node (carried as `CommandPath.non_empty`)
+    // must reject a key-only entry at validate time, mirroring the IS-IS
+    // `router isis afi-safi <ipv4|ipv6>` case where a bare entry is dead
+    // config. An entry that gains a child validates clean.
+    #[test]
+    fn non_empty_rejects_bare_list_entry() {
+        let dir = |name: &str| CommandPath {
+            name: name.to_string(),
+            ymatch: YangMatch::Dir as i32,
+            ..Default::default()
+        };
+        let list = |name: &str| CommandPath {
+            name: name.to_string(),
+            ymatch: YangMatch::Key as i32,
+            non_empty: "network or redistribute".to_string(),
+            ..Default::default()
+        };
+        let key = |name: &str| CommandPath {
+            name: name.to_string(),
+            ymatch: YangMatch::KeyMatched as i32,
+            ..Default::default()
+        };
+
+        let root = Rc::new(Config::new("".to_string(), None));
+
+        // `set router isis afi-safi ipv4` — bare entry.
+        set(
+            vec![dir("router"), dir("isis"), list("afi-safi"), key("ipv4")],
+            root.clone(),
+        );
+        let mut errors = Vec::new();
+        root.validate(&mut errors);
+        assert!(
+            errors
+                .iter()
+                .any(|e| e.contains("afi-safi ipv4") && e.contains("network or redistribute")),
+            "bare list entry should be rejected, got: {:?}",
+            errors
+        );
+
+        // `... afi-safi ipv4 network 10.0.0.0/24` — entry now has a child.
+        set(
+            vec![
+                dir("router"),
+                dir("isis"),
+                list("afi-safi"),
+                key("ipv4"),
+                CommandPath {
+                    name: "network".to_string(),
+                    ymatch: YangMatch::Key as i32,
+                    ..Default::default()
+                },
+                key("10.0.0.0/24"),
+            ],
+            root.clone(),
+        );
+        let mut errors = Vec::new();
+        root.validate(&mut errors);
+        assert!(
+            errors.is_empty(),
+            "entry carrying a child must validate clean, got: {:?}",
+            errors
         );
     }
 

--- a/zebra-rs/src/config/manager.rs
+++ b/zebra-rs/src/config/manager.rs
@@ -776,7 +776,18 @@ impl ConfigManager {
                 }
             }
         }
-        let _ = self.commit_config();
+        // A schema-validation failure (mandatory / `ext:non-empty`) rejects
+        // the whole startup commit — nothing is dispatched. Log it loudly so
+        // a config file the operator hand-edited into an invalid state (e.g.
+        // a bare `router isis afi-safi ipv4`) is diagnosable, rather than the
+        // daemon silently coming up with no config.
+        if let Err(e) = self.commit_config() {
+            tracing::error!(
+                "startup config {} rejected by schema validation: {}",
+                self.config_path.display(),
+                e
+            );
+        }
     }
 
     pub fn save_config(&self) {
@@ -959,7 +970,21 @@ impl ConfigManager {
                         return;
                     }
                 }
-                let _ = self.commit_config();
+                // Schema validation (mandatory / `ext:non-empty`) runs
+                // inside `commit_config` and returns Err *before* any
+                // dispatch. Surface it instead of swallowing it, and revert
+                // the candidate so the rejected lines don't linger into the
+                // next apply.
+                if let Err(e) = self.commit_config() {
+                    self.store.discard();
+                    let resp = DeployResponse {
+                        apply_code: ApplyCode::MissingMandatory,
+                        exec_code: ExecCode::Success,
+                        cmd: e.to_string(),
+                    };
+                    let _ = req.resp.send(resp);
+                    return;
+                }
 
                 let resp = DeployResponse {
                     apply_code: ApplyCode::Applied,
@@ -1480,6 +1505,71 @@ mod yang_load_tests {
                 code,
                 ExecCode::Success,
                 "should parse as a settable path: {cmd}"
+            );
+        }
+    }
+
+    /// `router isis afi-safi <ipv4|ipv6>` is dead config unless it carries
+    /// a `network` or `redistribute` child — IS-IS does per-AFI enable
+    /// per-interface, the list only holds those. The list is tagged
+    /// `ext:non-empty` so a key-only entry is rejected at commit. This
+    /// drives the real schema end to end (proving the extension flows
+    /// YANG -> Entry -> CommandPath -> Config) and checks that a bare entry
+    /// fails `validate` while a child-bearing entry passes.
+    #[test]
+    fn isis_afi_safi_bare_entry_is_rejected() {
+        use crate::config::ExecCode;
+        use crate::config::configs::set;
+        use crate::config::parse::{State, parse};
+        use crate::config::{Config, paths::path_try_trim};
+        use libyang::to_entry;
+        use std::rc::Rc;
+
+        let mut yang = YangStore::new();
+        yang.add_path(concat!(env!("CARGO_MANIFEST_DIR"), "/yang"));
+        yang.read_with_resolve("configure")
+            .unwrap_or_else(|e| panic!("configure failed to load: {e:#}"));
+        yang.identity_resolve();
+        let module = yang.find_module("configure").unwrap();
+        let entry = to_entry(&yang, module);
+        // The diff/apply layer parses config lines against the `set`
+        // subtree (no leading `set` keyword), so do the same here.
+        let set_entry = entry
+            .dir
+            .borrow()
+            .iter()
+            .find(|e| e.name == "set")
+            .cloned()
+            .expect("configure mode has a `set` entry");
+
+        let validate_errors = |cmd: &str| -> Vec<String> {
+            let (code, _comps, state) = parse(cmd, set_entry.clone(), None, State::new());
+            assert_eq!(code, ExecCode::Success, "should parse: {cmd}");
+            let root = Rc::new(Config::new("".to_string(), None));
+            set(path_try_trim("set", state.paths), root.clone());
+            let mut errors = Vec::new();
+            root.validate(&mut errors);
+            errors
+        };
+
+        // Bare entry → rejected.
+        let errors = validate_errors("router isis afi-safi ipv4");
+        assert!(
+            errors
+                .iter()
+                .any(|e| e.contains("afi-safi ipv4") && e.contains("network or redistribute")),
+            "bare `afi-safi ipv4` must be rejected, got: {errors:?}"
+        );
+
+        // network / redistribute children → validate clean.
+        for cmd in [
+            "router isis afi-safi ipv4 network 10.0.0.0/24",
+            "router isis afi-safi ipv6 redistribute connected",
+        ] {
+            let errors = validate_errors(cmd);
+            assert!(
+                errors.is_empty(),
+                "should validate clean: {cmd}, got: {errors:?}"
             );
         }
     }

--- a/zebra-rs/src/config/parse.rs
+++ b/zebra-rs/src/config/parse.rs
@@ -713,6 +713,15 @@ pub fn parse(
         .extension
         .get("ext:sort")
         .map_or_else(|| 0, |v| v.parse::<i32>().unwrap_or(0));
+    // `ext:non-empty` on a list node: forbids key-only entries. Carried
+    // on every CommandPath for the list so `config_set_dir` can stamp it
+    // onto the list's Config node, where `validate` enforces it.
+    let non_empty = mx
+        .matched_entry
+        .extension
+        .get("ext:non-empty")
+        .cloned()
+        .unwrap_or_default();
 
     let path = if ymatch_complete(s.ymatch, mx.matched_entry.presence, s.delete) {
         // KeyMatched / LeafMatched / LeafListMatched carry the user-
@@ -734,6 +743,7 @@ pub fn parse(
             key: mx.matched_entry.name.to_owned(),
             mandatory,
             sort_priority,
+            non_empty,
         }
     } else {
         CommandPath {
@@ -742,6 +752,7 @@ pub fn parse(
             key: "".to_string(),
             mandatory,
             sort_priority,
+            non_empty,
         }
     };
 

--- a/zebra-rs/yang/config.yang
+++ b/zebra-rs/yang/config.yang
@@ -1878,6 +1878,12 @@ module config {
           // every self-originated LSP as an IP-reach TLV (135 / 236 /
           // 237 depending on MT). Prefix family must match the
           // afi-safi name; the callback rejects mismatches.
+          //
+          // A bare `afi-safi <ipv4|ipv6>` carries no state — IS-IS does
+          // per-AFI enable per-interface, and this list exists only to
+          // hold `network` + `redistribute`. Reject the empty entry so a
+          // meaningless line can't be committed.
+          ext:non-empty "network or redistribute";
           key "name";
           uses zas:afi-safi-unicast;
           list network {
@@ -2593,6 +2599,7 @@ module config {
             // (mirrors the default instance, reusing the same
             // groupings). Forwarded `/router/isis/afi-safi/...` paths
             // match the existing v2 callbacks.
+            ext:non-empty "network or redistribute";
             key "name";
             uses zas:afi-safi-unicast;
             list network {

--- a/zebra-rs/yang/extension.yang
+++ b/zebra-rs/yang/extension.yang
@@ -41,4 +41,15 @@ module extension {
        `show bgp ipv4 A.B.C.D`). The argument is the child node name.";
     argument "default-child";
   }
+
+  extension non-empty {
+    description
+      "Forbids key-only entries on this `list`: every entry must carry at
+       least one child node, so a bare `... <key>` is rejected at commit.
+       (YANG has no clean `must`-style 'at least one child' constraint and
+       this config tree does not evaluate `must`.) The argument is the
+       human-readable requirement echoed in the error, e.g.
+       'network or redistribute'.";
+    argument "non-empty";
+  }
 }


### PR DESCRIPTION
## Summary

A bare `router isis afi-safi <ipv4|ipv6>` carries no state — IS-IS does per-AFI enable per-interface, and the `afi-safi` list exists only to hold `network` + `redistribute`. Today it is silently accepted as dead config (no callback, no effect). This rejects it at commit.

A new generic `ext:non-empty` YANG extension tags a `list` as forbidding key-only entries. The requirement string flows YANG → `Entry.extension` → `CommandPath` → `Config`, and the config tree's `validate()` (the same pass that enforces `mandatory`) rejects any entry that carries no child. Both the global and per-VRF isis `afi-safi` lists are tagged `ext:non-empty "network or redistribute"`.

The validation error is now surfaced on the two commit paths that were swallowing it (`let _ = self.commit_config()`):
- **`Deploy` (vtyctl apply)** reverts the candidate and returns the error.
- **startup `load_config`** logs it (instead of booting silently with no config).

## Behavior change

A config **file** containing a bare `afi-safi <ipv4|ipv6>` now fails the whole startup commit (logged as `ERROR … rejected by schema validation`). This is consistent with how existing `mandatory` violations already behave. Remove the bare line (or give it a `network`/`redistribute` child) before deploying.

## Test plan

- New unit test (`non_empty_rejects_bare_list_entry`) covers the `validate()` logic.
- New integration test (`isis_afi_safi_bare_entry_is_rejected` in `yang_load_tests`) drives the **real** schema end to end, proving the extension flows from YANG.
- Live-verified against a debug daemon: `set router isis afi-safi ipv4` → `error reply: 'router isis afi-safi ipv4' requires network or redistribute`; `… ipv4 network 10.0.0.0/24` and `… ipv6 redistribute connected` → `applied`. Startup file with a bare entry is rejected + logged.
- `cargo test --workspace --exclude bdd` green; `cargo fmt --check` clean; `cargo clippy --workspace --all-targets -- -D warnings` clean.

Generated with [Claude Code](https://claude.com/claude-code)