### PR TITLE
config: prune empty ext:non-empty list entry on last-child delete

### DIFF
--- a/zebra-rs/src/config/configs.rs
+++ b/zebra-rs/src/config/configs.rs
@@ -737,7 +737,23 @@ pub fn delete(paths: Vec<CommandPath>, mut config: Rc<Config>) {
         config_delete(parent.clone(), &config.name);
         config = parent.clone();
         if config.has_dir() || config.has_prefix() || config.presence {
-            break;
+            // Exception: an empty entry of an `ext:non-empty` list is dead
+            // config — a bare `... <key>` (e.g. `router isis afi-safi ipv4`)
+            // that the same `ext:non-empty` rule rejects at commit. So when
+            // deleting its last child empties a list-key entry, keep
+            // cascading to prune the entry (and the list node, if it too
+            // becomes empty) instead of leaving the bare key behind. Gated on
+            // the parent list carrying the marker, so ordinary key entries
+            // still stop the cascade as before.
+            let prunable_empty_entry = !config.has_dir()
+                && config.list.borrow().is_empty()
+                && config
+                    .parent
+                    .as_ref()
+                    .is_some_and(|p| !p.non_empty.is_empty());
+            if !prunable_empty_entry {
+                break;
+            }
         }
     }
 }
@@ -869,6 +885,82 @@ mod tests {
             errors.is_empty(),
             "entry carrying a child must validate clean, got: {:?}",
             errors
+        );
+    }
+
+    // Deleting the last child of an `ext:non-empty` list entry must prune
+    // the now-empty entry rather than leave a bare `... <key>` behind (which
+    // would then fail commit validation). A sibling entry that still has a
+    // child is left untouched.
+    #[test]
+    fn delete_last_child_prunes_non_empty_list_entry() {
+        let dir = |name: &str| CommandPath {
+            name: name.to_string(),
+            ymatch: YangMatch::Dir as i32,
+            ..Default::default()
+        };
+        let list = |name: &str| CommandPath {
+            name: name.to_string(),
+            ymatch: YangMatch::Key as i32,
+            non_empty: "network or redistribute".to_string(),
+            ..Default::default()
+        };
+        let plain = |name: &str| CommandPath {
+            name: name.to_string(),
+            ymatch: YangMatch::Key as i32,
+            ..Default::default()
+        };
+        let key = |name: &str| CommandPath {
+            name: name.to_string(),
+            ymatch: YangMatch::KeyMatched as i32,
+            ..Default::default()
+        };
+        let net = |afi: &str, prefix: &str| {
+            vec![
+                dir("router"),
+                dir("isis"),
+                list("afi-safi"),
+                key(afi),
+                plain("network"),
+                key(prefix),
+            ]
+        };
+
+        let root = Rc::new(Config::new("".to_string(), None));
+        set(net("ipv4", "10.0.0.0/24"), root.clone());
+        set(net("ipv6", "2001:db8::/64"), root.clone());
+
+        // Drop ipv4's only network. ipv4 becomes empty and must be pruned;
+        // ipv6 (still carrying a network) and the afi-safi node survive.
+        delete(net("ipv4", "10.0.0.0/24"), root.clone());
+
+        let afi_safi = root
+            .lookup(&"router".to_string())
+            .and_then(|r| r.lookup(&"isis".to_string()))
+            .and_then(|i| i.lookup(&"afi-safi".to_string()))
+            .expect("afi-safi node should survive (ipv6 still present)");
+        assert!(
+            afi_safi.lookup_key(&"ipv4".to_string()).is_none(),
+            "empty ipv4 entry must be pruned"
+        );
+        assert!(
+            afi_safi.lookup_key(&"ipv6".to_string()).is_some(),
+            "ipv6 entry with a child must be untouched"
+        );
+
+        // Dropping ipv6's network too empties the whole afi-safi subtree,
+        // which cascades away (no bare entry, no empty afi-safi node left).
+        delete(net("ipv6", "2001:db8::/64"), root.clone());
+        let afi_safi_gone = match root
+            .lookup(&"router".to_string())
+            .and_then(|r| r.lookup(&"isis".to_string()))
+        {
+            None => true,
+            Some(isis) => isis.lookup(&"afi-safi".to_string()).is_none(),
+        };
+        assert!(
+            afi_safi_gone,
+            "afi-safi node must be gone once its last entry is pruned"
         );
     }
 

--- a/zebra-rs/src/config/manager.rs
+++ b/zebra-rs/src/config/manager.rs
@@ -1574,6 +1574,65 @@ mod yang_load_tests {
         }
     }
 
+    /// Companion to `isis_afi_safi_bare_entry_is_rejected`: deleting the
+    /// last child of an afi-safi entry must prune the now-empty entry, so
+    /// the bare `afi-safi <name>` doesn't linger and trip `ext:non-empty`
+    /// at the next commit. Drives the real schema (set then delete) and
+    /// checks the tree is clean and the node is gone.
+    #[test]
+    fn isis_afi_safi_delete_last_child_prunes_entry() {
+        use crate::config::ExecCode;
+        use crate::config::configs::{delete, set};
+        use crate::config::parse::{State, parse};
+        use crate::config::{Config, paths::path_try_trim};
+        use libyang::to_entry;
+        use std::rc::Rc;
+
+        let mut yang = YangStore::new();
+        yang.add_path(concat!(env!("CARGO_MANIFEST_DIR"), "/yang"));
+        yang.read_with_resolve("configure")
+            .unwrap_or_else(|e| panic!("configure failed to load: {e:#}"));
+        yang.identity_resolve();
+        let module = yang.find_module("configure").unwrap();
+        let entry = to_entry(&yang, module);
+        let set_entry = entry
+            .dir
+            .borrow()
+            .iter()
+            .find(|e| e.name == "set")
+            .cloned()
+            .expect("configure mode has a `set` entry");
+
+        let paths = |cmd: &str| {
+            let (code, _comps, state) = parse(cmd, set_entry.clone(), None, State::new());
+            assert_eq!(code, ExecCode::Success, "should parse: {cmd}");
+            path_try_trim("set", state.paths)
+        };
+
+        let root = Rc::new(Config::new("".to_string(), None));
+        let line = "router isis afi-safi ipv4 network 10.0.0.1/32";
+        set(paths(line), root.clone());
+        delete(paths(line), root.clone());
+
+        // No bare afi-safi entry left → validates clean.
+        let mut errors = Vec::new();
+        root.validate(&mut errors);
+        assert!(
+            errors.is_empty(),
+            "tree must validate clean after set+delete, got: {errors:?}"
+        );
+
+        // And the afi-safi node itself is gone (not a key-only leftover).
+        let leftover = root
+            .lookup(&"router".to_string())
+            .and_then(|r| r.lookup(&"isis".to_string()))
+            .and_then(|i| i.lookup(&"afi-safi".to_string()));
+        assert!(
+            leftover.is_none(),
+            "afi-safi node must be pruned after its last child is deleted"
+        );
+    }
+
     /// Mirror SID egress-protection config paths
     /// (`draft-ietf-rtgwg-srv6-egress-protection`, config.yang). vtyctl
     /// apply is garbage-tolerant, so an unwired list / key / leaf would


### PR DESCRIPTION
## Summary

Follow-up to #1604. `ext:non-empty` rejects a key-only `afi-safi <ipv4|ipv6>` entry at commit, but the delete cascade stopped at a list-key node (its key gives `has_prefix() == true`), so:

```
set router isis afi-safi ipv4 network 10.0.0.1/32
delete router isis afi-safi ipv4 network 10.0.0.1/32
```

left a **bare `router isis afi-safi ipv4`** behind — dead config that the same `ext:non-empty` rule then rejects at the *next* commit, wedging the candidate.

This lets the cascade continue past an empty list entry whose parent list carries the `ext:non-empty` marker: the bare key (and the list node, if it too becomes empty) is pruned rather than left behind. Gated on the marker, so ordinary key entries still stop the cascade exactly as before.

## Test plan

- New `configs.rs` unit test `delete_last_child_prunes_non_empty_list_entry` — covers the prune **and** that a sibling entry still carrying a child is untouched.
- New `yang_load_tests` integration test `isis_afi_safi_delete_last_child_prunes_entry` — drives the **real** schema (set then delete → validates clean, afi-safi node gone).
- Live-verified: `set … network X` then `delete … network X` via `vtyctl apply` now both return `applied` (previously the second would fail commit validation on the leftover bare entry).
- `cargo test --workspace --exclude bdd` green (1447 in the main suite); `cargo fmt --check` clean; `cargo clippy --workspace --all-targets -- -D warnings` clean.

Generated with [Claude Code](https://claude.com/claude-code)