### PR TITLE
config: reject/prune empty static route entries

### DIFF
--- a/zebra-rs/src/config/manager.rs
+++ b/zebra-rs/src/config/manager.rs
@@ -1633,6 +1633,87 @@ mod yang_load_tests {
         );
     }
 
+    /// `router static ipv4 route <prefix>` carries no forwarding info on its
+    /// own, so the route list is tagged `ext:non-empty "nexthop"`: a bare
+    /// entry is rejected at commit, and deleting its last child prunes it.
+    /// Same generic machinery as the IS-IS afi-safi case — this pins the
+    /// `config-static.yang` tags through the real schema.
+    #[test]
+    fn static_route_bare_entry_rejected_and_pruned() {
+        use crate::config::ExecCode;
+        use crate::config::configs::{delete, set};
+        use crate::config::parse::{State, parse};
+        use crate::config::{Config, paths::path_try_trim};
+        use libyang::to_entry;
+        use std::rc::Rc;
+
+        let mut yang = YangStore::new();
+        yang.add_path(concat!(env!("CARGO_MANIFEST_DIR"), "/yang"));
+        yang.read_with_resolve("configure")
+            .unwrap_or_else(|e| panic!("configure failed to load: {e:#}"));
+        yang.identity_resolve();
+        let module = yang.find_module("configure").unwrap();
+        let entry = to_entry(&yang, module);
+        let set_entry = entry
+            .dir
+            .borrow()
+            .iter()
+            .find(|e| e.name == "set")
+            .cloned()
+            .expect("configure mode has a `set` entry");
+        let paths = |cmd: &str| {
+            let (code, _comps, state) = parse(cmd, set_entry.clone(), None, State::new());
+            assert_eq!(code, ExecCode::Success, "should parse: {cmd}");
+            path_try_trim("set", state.paths)
+        };
+        let validate_errors = |line: &[crate::config::CommandPath]| -> Vec<String> {
+            let root = Rc::new(Config::new("".to_string(), None));
+            set(line.to_vec(), root.clone());
+            let mut errors = Vec::new();
+            root.validate(&mut errors);
+            errors
+        };
+
+        // Bare `route 10.0.0.1/32` → rejected.
+        let errors = validate_errors(&paths("router static ipv4 route 10.0.0.1/32"));
+        assert!(
+            errors
+                .iter()
+                .any(|e| e.contains("route 10.0.0.1/32") && e.contains("nexthop")),
+            "bare static route must be rejected, got: {errors:?}"
+        );
+
+        // With a nexthop child → validates clean.
+        let errors = validate_errors(&paths(
+            "router static ipv4 route 10.0.0.1/32 nexthop 10.0.0.254",
+        ));
+        assert!(
+            errors.is_empty(),
+            "route with a nexthop must validate clean, got: {errors:?}"
+        );
+
+        // set route+nexthop, then delete the nexthop → bare route is pruned.
+        let root = Rc::new(Config::new("".to_string(), None));
+        let line = paths("router static ipv4 route 10.0.0.1/32 nexthop 10.0.0.254");
+        set(line.clone(), root.clone());
+        delete(line, root.clone());
+        let mut errors = Vec::new();
+        root.validate(&mut errors);
+        assert!(
+            errors.is_empty(),
+            "tree must validate clean after set+delete, got: {errors:?}"
+        );
+        let leftover = root
+            .lookup(&"router".to_string())
+            .and_then(|r| r.lookup(&"static".to_string()))
+            .and_then(|s| s.lookup(&"ipv4".to_string()))
+            .and_then(|v4| v4.lookup(&"route".to_string()));
+        assert!(
+            leftover.is_none(),
+            "static route node must be pruned after its last child is deleted"
+        );
+    }
+
     /// Mirror SID egress-protection config paths
     /// (`draft-ietf-rtgwg-srv6-egress-protection`, config.yang). vtyctl
     /// apply is garbage-tolerant, so an unwired list / key / leaf would

--- a/zebra-rs/yang/config-static.yang
+++ b/zebra-rs/yang/config-static.yang
@@ -52,6 +52,11 @@ module config-static {
     container ipv4 {
       ext:help "IPv4 configuration";
       list route {
+        // A bare `route <prefix>` carries no forwarding information — it
+        // needs at least a nexthop (or SRv6 / distance / metric child).
+        // Reject the key-only entry at commit, and prune it when its last
+        // child is deleted, so a meaningless route can't linger.
+        ext:non-empty "nexthop";
         key "prefix";
         leaf prefix {
           type inet:ipv4-prefix;
@@ -172,6 +177,10 @@ module config-static {
       }
 
       list route {
+        // Sibling of the IPv4 route list: a bare `route <prefix>` is dead
+        // config (no nexthop / SRv6 / metric), so reject the key-only entry
+        // at commit and prune it on last-child delete.
+        ext:non-empty "nexthop";
         key "prefix";
         leaf prefix {
           type inet:ipv6-prefix;


### PR DESCRIPTION
## Summary

Applies the `ext:non-empty` treatment (from #1604/#1605) to static routes, per the same rationale as the IS-IS afi-safi case: a bare `router static {ipv4,ipv6} route <prefix>` carries no forwarding information and is dead config.

Both the IPv4 and IPv6 static `route` lists in the shared `config-static.yang` grouping (so **global and per-VRF** both inherit it) are tagged `ext:non-empty "nexthop"`. The generic machinery then handles everything with **no Rust changes**:

- A key-only `route <prefix>` is **rejected at commit** (`'router static ipv4 route 10.0.0.1/32' requires nexthop`).
- Deleting its **last child prunes** the now-empty entry, so a bare route can't linger and trip the same rule on the next commit.

## Test plan

- New `yang_load_tests` integration test `static_route_bare_entry_rejected_and_pruned` — drives the real schema: bare route rejected, route+nexthop validates clean, set+delete leaves no leftover node.
- Live-verified via `vtyctl apply`:
  - `set router static ipv4 route 10.0.0.1/32` → `error reply: … requires nexthop`
  - `set router static ipv4 route 10.0.0.1/32 nexthop 10.0.0.254` → `applied`
  - `delete … nexthop 10.0.0.254` → `applied` (route pruned)
  - `set router static ipv6 route 2001:db8::/64` → `error reply: … requires nexthop`
- `cargo test --workspace --exclude bdd` green; `cargo fmt --check` clean; `cargo clippy --workspace --all-targets -- -D warnings` clean.

Generated with [Claude Code](https://claude.com/claude-code)