### PR TITLE
bgp: soft-out must purge update-group pending cache on withdraw

### DIFF
--- a/zebra-rs/src/bgp/route.rs
+++ b/zebra-rs/src/bgp/route.rs
@@ -5326,10 +5326,27 @@ fn route_soft_out_peer_table(
         let peer = peers.get_mut_by_idx(peer_idx).expect("peer exists");
         if let Some(rd) = rd {
             peer.cache_remove_vpnv4(rd, prefix, 0);
+        } else {
+            // Drop any not-yet-flushed pending advert of this prefix
+            // from the shared update-group cache. The re-advert above
+            // goes out per-peer via `send_ipv4_direct`, but a PRIOR
+            // group-based advertise (`send_ipv4`, e.g. the origination
+            // that ran before this peer's out-policy resolved) may have
+            // parked the prefix in `cache_ipv4` behind the MRAI debounce
+            // timer (30s for eBGP). That entry outlives this soft-out:
+            // when the timer later fires, `build_flush_job_ipv4` rebuilds
+            // from the stale cache and re-sends the prefix this soft-out
+            // just withdrew — resurrecting a route the peer's `adj_out`
+            // no longer tracks, so nothing ever withdraws it again.
+            // Mirrors the group-cache cleanup in `V4Batch::withdraw`.
+            let afi_safi = AfiSafi::new(Afi::Ip, Safi::Unicast);
+            if let Some(gid) = peer.update_group_id.get(&afi_safi).cloned()
+                && let Some(af) = bgp.update_groups.get_mut(&afi_safi)
+                && let Some(group) = af.group_by_id_mut(&gid)
+            {
+                super::update_group::cache_remove_ipv4(group, prefix, 0);
+            }
         }
-        // No IPv4 cache to remove from — direct-encode means there
-        // was never a pending bucket to drop. adj_out + the on-wire
-        // withdraw still happen.
         peer.adj_out.remove(rd, prefix, 0);
         withdraw_ipv4_deferrable(bgp.update_groups, peer, rd, prefix, 0);
     }


### PR DESCRIPTION
## Summary

Fixes a BGP egress bug where a soft-out (per-peer outbound re-evaluation) left a policy-denied prefix on the wire, which the MRAI debounce timer later resurrected.

`route_soft_out_peer_table` re-advertises permitted prefixes per-peer via `send_ipv4_direct`, but in its withdraw loop it only dropped the prefix from `peer.adj_out` and sent a wire withdraw — it left the prefix in the **shared update-group pending cache** (`cache_ipv4`). A prior group-based advertise (`send_ipv4`, e.g. origination that ran before the peer's out-policy resolved) parks the prefix behind the MRAI debounce timer (30s eBGP). That stale entry outlives the soft-out: when the timer fires, `build_flush_job_ipv4` rebuilds from the cache and **re-sends the prefix the soft-out just withdrew**, resurrecting a route `adj_out` no longer tracks — so nothing ever withdraws it again.

The fix mirrors `V4Batch::withdraw`'s existing `cache_remove_ipv4` cleanup in the soft-out withdraw loop. The old comment ("No IPv4 cache to remove from — direct-encode means there was never a pending bucket to drop") was the wrong assumption: group origination put it there.

### Symptom
z1 `adj_out = {10.0.0.1/32}` (correct) but the peer's adj-rib-in `= {10.0.0.1/32, 10.0.0.2/32}` — a route on the wire the speaker no longer tracks and can never withdraw.

## Test plan

- `@bgp_basic_ebgp` scenario *"Apply output policy with prefix-set"* (`z1-5.yaml`: two networks + an out prefix-set permitting only one) failed reliably before this change (z2 received the denied `10.0.0.2/32` ~30s after apply) and now passes on **3 fresh-daemon runs**.
  - Reliable on **fresh** daemons (MRAI timer freshly armed at origination, fires ~30s later, after the soft-out); the scenario's 30s settle wait is exactly when the stale flush lands. Passes on warm daemons in manual replay (timer phase differs) — looked flaky but isn't.
- No regression in related out-policy / soft-out features: `bgp_basic_ibgp`, `bgp_policy_dynamic_update`, `bgp_route_map_match`, `bgp_community`, `bgp_table_map`, `bgp_afi_safi_policy`.
- `cargo fmt` clean; `cargo clippy --workspace --all-targets -- -D warnings` clean; 1447 zebra-rs unit tests pass.

Generated with [Claude Code](https://claude.com/claude-code)