### PR TITLE
bdd: connect-retry-time on bgp_allowas_in z3 to avoid 120s reconnect park

### DIFF
--- a/bdd/tests/configs/bgp_allowas_in/z3-allowas.yaml
+++ b/bdd/tests/configs/bgp_allowas_in/z3-allowas.yaml
@@ -18,6 +18,12 @@ router:
         enabled: true
       enabled: true
       remote-as: 65002
+      # Short connect-retry so a hard-clear reconnect that collides
+      # (both sides land in Active) re-dials in seconds instead of
+      # parking on the 120s default — keeps the fixed 30s settle waits
+      # in this feature reliable under full-suite load.
+      timers:
+        connect-retry-time: 3
       # Bare presence container → default occurrence budget of 3.
       # (`allowas-in: {}` — a childless presence container — lowers to `set ... allowas-in`.)
       allowas-in: {}

--- a/bdd/tests/configs/bgp_allowas_in/z3-base.yaml
+++ b/bdd/tests/configs/bgp_allowas_in/z3-base.yaml
@@ -18,3 +18,9 @@ router:
         enabled: true
       enabled: true
       remote-as: 65002
+      # Short connect-retry so a hard-clear reconnect that collides
+      # (both sides land in Active) re-dials in seconds instead of
+      # parking on the 120s default — keeps the fixed 30s settle waits
+      # in this feature reliable under full-suite load.
+      timers:
+        connect-retry-time: 3

--- a/bdd/tests/configs/bgp_allowas_in/z3-origin.yaml
+++ b/bdd/tests/configs/bgp_allowas_in/z3-origin.yaml
@@ -18,6 +18,12 @@ router:
         enabled: true
       enabled: true
       remote-as: 65002
+      # Short connect-retry so a hard-clear reconnect that collides
+      # (both sides land in Active) re-dials in seconds instead of
+      # parking on the 120s default — keeps the fixed 30s settle waits
+      # in this feature reliable under full-suite load.
+      timers:
+        connect-retry-time: 3
       # origin mode → accept only when our AS is the route's origin.
       # (`origin:` is a `type empty` leaf → `set ... allowas-in origin`.)
       allowas-in:


### PR DESCRIPTION
## Summary

Fixes a flaky `@bgp_allowas_in` BDD failure. The *"allowas-in lets z3 accept the looped route"* and *"origin mode"* scenarios hard-clear z3's eBGP session, then assert `Established` after a fixed 30s wait.

After a hard clear both ends detect the drop at the same instant and re-dial; the dials **collide and both connections tear down**, leaving **both peers in `Active`** waiting their **120s connect-retry timer** — they recover together at ~127s, well past the 30s check. The race is rare in isolation (reconnect is normally ~6s) but reliably reproducible with back-to-back double-clears and far more likely under full-suite load. `verify_bgp_session` is single-shot (no polling), so the daemon must converge inside the wait.

The fix sets `timers: { connect-retry-time: 3 }` on z3's neighbor (the hard-cleared side) so a collided reconnect re-dials within seconds. Same mitigation pattern already used by `bgp_interas_option_c`. No daemon code change — `connect-retry-time` is an existing per-neighbor knob.

## Test plan

- Reproduced the wedge deterministically with back-to-back double-clears: z3 (and z2) stuck in `Active` ~120-127s.
- With `connect-retry-time: 3`, a 12-trial double-clear stress test recovered in **≤9s** worst-case (no parks).
- `@bgp_allowas_in` passes 2/2 fresh harness runs.

Generated with [Claude Code](https://claude.com/claude-code)