### PR TITLE
bdd: sweep stray host-loopback addresses in clean step

### DIFF
--- a/bdd/src/netns.rs
+++ b/bdd/src/netns.rs
@@ -125,6 +125,55 @@ pub async fn delete_bridge(bridge_name: &str) -> Result<()> {
     .await
 }
 
+/// Remove stray global-scope addresses left on the HOST loopback.
+///
+/// A router config that puts a `/32` on `interface lo` adds it to the
+/// loopback of whatever namespace the daemon runs in. When such a daemon
+/// leaks into — or is run by hand in — the host namespace, its loopback
+/// address persists on the host `lo` after teardown (deleting a netns
+/// can't reclaim an address that was added to the host's own `lo`). That
+/// stray address then poisons every later feature that peers over
+/// loopbacks across a bridge: the bridge lives in the host namespace, so
+/// when a namespace ARPs for its bridge-subnet next-hop the host answers
+/// for the leaked address with the bridge's MAC and silently black-holes
+/// one direction of the session — the peer wedges in Connect until the
+/// ~120s ConnectRetryTimer, far past any scenario wait. (Diagnosed on
+/// `@bgp_disable_connected_check`, whose z2→z1 loopback path died exactly
+/// this way against a stale `10.0.0.1/32` on the host `lo`.)
+///
+/// `scope global` excludes real loopback (127.0.0.0/8 and ::1 are scope
+/// host), so this only ever deletes leaked test addresses — there is no
+/// legitimate global address on a BDD host's `lo`.
+pub async fn sweep_host_loopback_addrs() -> Result<()> {
+    let output = Command::new("ip")
+        .args(["-o", "addr", "show", "dev", "lo", "scope", "global"])
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .output()
+        .await
+        .context("Failed to list host loopback addresses")?;
+
+    let text = String::from_utf8_lossy(&output.stdout);
+    for line in text.lines() {
+        // `N: lo    inet 10.0.0.1/32 scope global lo \ ...` — pull the
+        // CIDR token right after `inet` / `inet6`.
+        let mut tokens = line.split_whitespace();
+        while let Some(tok) = tokens.next() {
+            if tok == "inet" || tok == "inet6" {
+                if let Some(addr) = tokens.next() {
+                    let _ = run_cmd(
+                        &["ip", "addr", "del", addr, "dev", "lo"],
+                        &format!("Failed to delete stray host lo address {}", addr),
+                    )
+                    .await;
+                }
+                break;
+            }
+        }
+    }
+    Ok(())
+}
+
 /// Create a veth pair and connect a namespace to a bridge.
 ///
 /// `veth_host` must be unique in the host's default namespace.

--- a/bdd/tests/cucumber.rs
+++ b/bdd/tests/cucumber.rs
@@ -116,6 +116,15 @@ async fn clean_test_environment(world: &mut World) {
         }
     }
 
+    // 5. Sweep stray global-scope addresses off the HOST loopback. Unlike
+    // the per-feature resources above this is host-global, but it is only
+    // ever leaked test addresses (a router `interface lo` /32 whose daemon
+    // ran in the host namespace) — never anything a live feature needs —
+    // so an unconditional sweep is safe and self-healing. A leaked address
+    // here makes the host answer ARP for a bridge subnet and black-holes
+    // loopback-peered sessions (see `sweep_host_loopback_addrs`).
+    let _ = netns::sweep_host_loopback_addrs().await;
+
     println!(
         "✓ Test environment cleaned for feature {}",
         world.feature_tag


### PR DESCRIPTION
## Summary

Fixes a flaky/wedged `@bgp_disable_connected_check` BDD failure whose root cause is an environmental leak, not a daemon bug.

A router config that puts a `/32` on `interface lo` adds it to the loopback of the namespace its daemon runs in. When such a daemon leaks into — or is run by hand in — the host namespace, that address persists on the host `lo` after teardown (`ip netns del` can't reclaim an address added to the host's own `lo`). The BDD bridge also lives in the host namespace, so the stray address makes the **host answer ARP for the test's bridge subnet with the bridge MAC**, silently black-holing one direction of any loopback-peered session — the peer wedges in `Connect` until the ~120s ConnectRetryTimer, far past any scenario wait.

That is exactly how `@bgp_disable_connected_check` failed: a stale `10.0.0.1/32` on the host `lo` (z1's static-route next-hop to z2's loopback peer) meant z2→z1 packets went to the host/bridge instead of z1. z1→z2 was fine (no `10.0.0.2` leak), so the session half-opened and never converged.

The fix sweeps global-scope addresses off the host `lo` in `Given a clean test environment`. `scope global` excludes real loopback (127.0.0.0/8 and ::1 are scope *host*), so only leaked test addresses are removed — a BDD host has no legitimate global `lo` address. The sweep is host-global but self-healing and safe under feature parallelism (no live feature owns a host `lo` address).

## Diagnosis

- Per-veth tcpdump: z2's SYN-ACK left z2's veth but never reached z1's veth (z1 saw only its own TTL-1 SYNs).
- `ip neigh` on z2: the next-hop `10.0.0.1` resolved to the **bridge's** MAC (host ns), not z1's veth.
- Deleting `10.0.0.1/32` from host `lo` made the session establish instantly.

## Test plan

- With the leak re-introduced before each run, `@bgp_disable_connected_check` passes 3/3 against an unmodified daemon binary.
- `@bgp_basic_ebgp` regression-clean.
- `cargo fmt` clean; `cargo clippy --workspace --all-targets -- -D warnings` clean.

Generated with [Claude Code](https://claude.com/claude-code)