### PR TITLE
bgp-mup: route st1/st2 CLI + mixed-AFI T1ST + no-SID origination

### DIFF
--- a/bdd/Makefile
+++ b/bdd/Makefile
@@ -26,6 +26,13 @@ bgp_mup_e2e:
 	mkdir -p allure-results
 	cargo test --test cucumber -- --concurrency=1 --tags "@bgp_mup_e2e"
 
+# MUP mixed-AFI: IPv6 UE with an IPv4 GTP endpoint, originated by the MUP-C
+# with no SRv6 locator and parsed by the peer. Needs `pfcp-inject` on the
+# host PATH (cargo build --release -p pfcp-inject; copy to /usr/bin).
+bgp_mup_mixed_afi:
+	mkdir -p allure-results
+	cargo test --test cucumber -- --concurrency=1 --tags "@bgp_mup_mixed_afi"
+
 rib_static_ipv6:
 	mkdir -p allure-results
 	cargo test --test cucumber -- --concurrency=1 --tags "@rib_static_ipv6"

--- a/bdd/tests/configs/bgp_mup_e2e/z1.yaml
+++ b/bdd/tests/configs/bgp_mup_e2e/z1.yaml
@@ -35,10 +35,11 @@ router:
         route-target:
           export:
           - "65000:200"
-        srv6-mobile:
-          encapsulation:
-            network-instance:
-              exact: access
+        route:
+          st1:
+            dest-network-instance:
+              access:
+                exact: access
     afi-safi:
     - name: mobile-uplane
       mup-c:

--- a/bdd/tests/configs/bgp_mup_mixed_afi/z1.yaml
+++ b/bdd/tests/configs/bgp_mup_mixed_afi/z1.yaml
@@ -1,0 +1,49 @@
+# z1 — MUP Controller (MUP-C). AS 65001, iBGP to z2 (192.168.0.2) with the
+# mobile-uplane afi-safi negotiated (both IPv4-MUP and IPv6-MUP). Runs the
+# PFCP/N4 listener on 192.168.0.1:8805 and, when pfcp-inject programs a
+# session whose Network Instance is `access`, originates a Type-1 Session-
+# Transformed route into the `mobile-up` VRF (rd 65000:100, RT export
+# 65000:200) with the controller-address as next hop.
+#
+# Two behaviours under test here, on purpose:
+#   1. NO SRv6 locator is configured anywhere — neither `segment-routing`
+#      nor `mup-c srv6`. Origination must still succeed, because per
+#      draft-ietf-bess-mup-safi the MUP-C does not allocate a service SID;
+#      the receiving PE derives forwarding from its own ISD/DSD routes.
+#   2. The injected session carries an IPv6 UE with an IPv4 GTP endpoint
+#      (mixed-AFI), so the ST1 route is advertised under the IPv6-MUP AFI
+#      while carrying an IPv4 endpoint.
+router:
+  bgp:
+    global:
+      as: 65001
+      router-id: 192.168.0.1
+    neighbor:
+    - remote-address: 192.168.0.2
+      remote-as: 65001
+      enabled: true
+      afi-safi:
+      - name: ipv4
+        enabled: true
+      - name: mobile-uplane
+        enabled: true
+    vrf:
+    - name: mobile-up
+      rd: "65000:100"
+      mobile-uplane:
+        route-target:
+          export:
+          - "65000:200"
+        route:
+          st1:
+            dest-network-instance:
+              access:
+                exact: access
+    afi-safi:
+    - name: mobile-uplane
+      mup-c:
+        enable: true
+        controller-address: fcbb:bb01::1
+        pfcp:
+          listen-address: 192.168.0.1
+          port: 8805

--- a/bdd/tests/configs/bgp_mup_mixed_afi/z2.yaml
+++ b/bdd/tests/configs/bgp_mup_mixed_afi/z2.yaml
@@ -1,0 +1,20 @@
+# z2 — MUP route receiver. AS 65001, iBGP to z1 (192.168.0.1) with the
+# mobile-uplane afi-safi negotiated (both IPv4-MUP and IPv6-MUP). Plain BGP
+# speaker: no controller, originates nothing. It receives the Type-1 ST
+# route z1 originates — an IPv6 UE route carrying an IPv4 endpoint — and
+# must parse and show it. A receiver that forced the endpoint family to
+# match the outer (IPv6) AFI would reject the UPDATE and never show it.
+router:
+  bgp:
+    global:
+      as: 65001
+      router-id: 192.168.0.2
+    neighbor:
+    - remote-address: 192.168.0.1
+      remote-as: 65001
+      enabled: true
+      afi-safi:
+      - name: ipv4
+        enabled: true
+      - name: mobile-uplane
+        enabled: true

--- a/bdd/tests/features/bgp_mup_mixed_afi.feature
+++ b/bdd/tests/features/bgp_mup_mixed_afi.feature
@@ -1,0 +1,72 @@
+@serial
+@bgp_mup_mixed_afi
+Feature: BGP MUP mixed-AFI Session-Transformed route (IPv6 UE, IPv4 endpoint)
+  As a network operator running 5G backhaul where the UE address family and
+  the N3 transport differ, I want the zebra-rs BGP MUP Controller to
+  originate a Type-1 Session-Transformed route (SAFI 85, RFC 9833 /
+  draft-ietf-bess-mup-safi) for an IPv6 UE whose GTP endpoint (gNB) is IPv4,
+  and a peer zebra-rs to receive and show it. This validates two behaviours:
+
+    1. Mixed-AFI: the endpoint/source address family is decided by its own
+       length octet (32 = IPv4, 128 = IPv6), independent of the outer AFI.
+       The route is advertised under the IPv6-MUP AFI (the UE prefix family)
+       yet carries an IPv4 endpoint; the receiver must parse it rather than
+       reject it for an endpoint-length that differs from the outer AFI.
+
+    2. No SID allocation by the MUP-C: z1 has NO SRv6 locator configured
+       (neither `segment-routing` nor `mup-c srv6`). Origination must still
+       succeed — the PE derives forwarding from its own ISD/DSD routes, so
+       the controller neither allocates nor advertises a service SID.
+
+  Test Topology:
+  ```
+           ┌─────────┐     ┌─────────┐
+           │   z1    │ iBGP│   z2    │
+           │ MUP-C   │◄───►│ receiver│
+           │192.168. │     │192.168. │
+           │  0.1/24 │     │  0.2/24 │
+           └────┬────┘     └─────────┘
+                │ PFCP/N4 (UDP 8805)
+           ┌────┴───────┐
+           │ pfcp-inject │  (SMF simulator, run in z1)
+           └────────────┘
+  ```
+
+  NOTE: this feature runs `pfcp-inject` inside z1, so the `pfcp-inject`
+  binary (the test-only SMF simulator, `tools/pfcp-inject`) must be on the
+  BDD host PATH — build with `cargo build --release -p pfcp-inject` and copy
+  `target/release/pfcp-inject` to /usr/bin, the same way the zebra-rs /
+  vtyctl binaries are staged for BDD.
+
+  Scenario: Setup topology and establish iBGP session with MUP capability
+    Given a clean test environment
+    When I create bridge "brmx0"
+    And I create namespace "z1" with IP "192.168.0.1/24" on bridge "brmx0"
+    And I create namespace "z2" with IP "192.168.0.2/24" on bridge "brmx0"
+    And I start zebra-rs in namespace "z1"
+    And I start zebra-rs in namespace "z2"
+    And I apply config "z1.yaml" to namespace "z1"
+    And I apply config "z2.yaml" to namespace "z2"
+    And I wait 5 seconds for BGP to operate
+    Then BGP session in "z1" to "192.168.0.2" should be "Established"
+    And BGP session in "z2" to "192.168.0.1" should be "Established"
+    And show command "show bgp neighbor 192.168.0.2" in namespace "z1" should contain "IPv6 MUP: advertised and received"
+    And show command "show bgp mobile-uplane mup-c" in namespace "z1" should contain "PFCP listen : 192.168.0.1:8805"
+
+  Scenario: IPv6 UE with IPv4 endpoint originates an ST1 route the peer parses
+    Given the test topology exists
+    When I execute "pfcp-inject --target 192.168.0.1 --port 8805 --ue-ipv6 2001:db8::5 --teid 0x12345678 --endpoint 10.0.0.1 --network-instance access" in namespace "z1"
+    Then show command "show bgp mobile-uplane mup-c session" in namespace "z1" should eventually contain "2001:db8::5"
+    And show command "show bgp mobile-uplane" in namespace "z1" should contain "ue=2001:db8::5/128"
+    And show command "show bgp mobile-uplane" in namespace "z1" should contain "ep=10.0.0.1"
+    And show command "show bgp mobile-uplane" in namespace "z2" should eventually contain "ue=2001:db8::5/128"
+    And show command "show bgp mobile-uplane" in namespace "z2" should contain "ep=10.0.0.1"
+
+  Scenario: Teardown topology
+    Given the test topology exists
+    When I stop zebra-rs in namespace "z1"
+    And I stop zebra-rs in namespace "z2"
+    And I delete namespace "z1"
+    And I delete namespace "z2"
+    And I delete bridge "brmx0"
+    Then the test environment should be clean

--- a/book/src/ch-02-35-bgp-mup.md
+++ b/book/src/ch-02-35-bgp-mup.md
@@ -94,8 +94,10 @@ router bgp {
       route-target {
         export 65000:200;
       }
-      srv6-mobile encapsulation {
-        network-instance exact access;
+      route st1 {
+        dest-network-instance access {
+          exact access;
+        }
       }
     }
   }
@@ -130,12 +132,11 @@ router bgp {
   (the same pool an `encapsulation srv6` VRF draws its End.DT46 SID
   from).
 
-The **`srv6-mobile`** direction in the VRF selects the route type:
-`encapsulation` (the N6 / downlink VRF) originates a **Type-1 ST** route
-carrying the UE prefix; `decapsulation` (the N3 / uplink VRF) originates
-a **Type-2 ST** route carrying the core endpoint and TEID. The
-`network-instance exact` value is matched against the PFCP session's
-Network Instance.
+The **`route`** type in the VRF selects what is originated: `st1` (the
+N6 / downlink VRF) originates a **Type-1 ST** route carrying the UE
+prefix; `st2` (the N3 / uplink VRF) originates a **Type-2 ST** route
+carrying the core endpoint and TEID. The `dest-network-instance ... exact`
+value is matched against the PFCP session's Network Instance.
 
 ## From PFCP session to ST route
 

--- a/crates/bgp-packet/src/attrs/nlri_mup.rs
+++ b/crates/bgp-packet/src/attrs/nlri_mup.rs
@@ -144,8 +144,10 @@ pub enum MupRoute {
     /// source address length (bits, 0/32/128) + optional source
     /// address bytes. The source-address-length octet is always
     /// present on the wire (zero when no source is carried), matching
-    /// GoBGP and RFC 9833 §3.2.1. Prefix, endpoint, and source all
-    /// follow the outer AFI's address family.
+    /// GoBGP and RFC 9833 §3.2.1. Only the UE `prefix` follows the outer
+    /// AFI; the `endpoint` (gNB) and `source` (UPF) families are decided
+    /// by their own length octets (32 = IPv4, 128 = IPv6), so an IPv6 UE
+    /// route may carry an IPv4 endpoint/source (the mixed-AFI 5G case).
     T1st {
         id: u32,
         arch: MupArchitectureType,
@@ -380,55 +382,57 @@ impl MupRoute {
                 let rest = &rest[psize..];
                 let (rest, teid) = be_u32(rest)?;
                 let (rest, qfi) = be_u8(rest)?;
-                // Endpoint address length must be exactly the AFI's host
-                // width (32 or 128) per RFC 9833 §3.2.1.
+                // The endpoint-address-length octet selects the endpoint's
+                // address family on its own (32 = IPv4 gNB, 128 = IPv6
+                // gNB), independent of the outer AFI: draft-ietf-bess-mup-
+                // safi / RFC 9833 §3.2.1 deliberately permits an IPv6 UE
+                // prefix to carry an IPv4 endpoint/source — the real 5G
+                // case where the N3 transport is IPv4. (GoBGP infers the
+                // family from this octet the same way; only the UE prefix
+                // is tied to the outer AFI.)
                 let (rest, ep_len) = be_u8(rest)?;
-                if ep_len != max_addr_bits {
-                    return Err(nom::Err::Error(make_error(input, ErrorKind::Verify)));
-                }
-                let ep_size = nlri_psize(ep_len);
-                if rest.len() < ep_size {
-                    return Err(nom::Err::Error(make_error(input, ErrorKind::Eof)));
-                }
-                let endpoint = match afi {
-                    Afi::Ip => {
+                let (endpoint, rest) = match ep_len {
+                    32 => {
+                        if rest.len() < 4 {
+                            return Err(nom::Err::Error(make_error(input, ErrorKind::Eof)));
+                        }
                         let mut octets = [0u8; 4];
-                        octets[..ep_size].copy_from_slice(&rest[..ep_size]);
-                        IpAddr::V4(Ipv4Addr::from(octets))
+                        octets.copy_from_slice(&rest[..4]);
+                        (IpAddr::V4(Ipv4Addr::from(octets)), &rest[4..])
                     }
-                    Afi::Ip6 => {
+                    128 => {
+                        if rest.len() < 16 {
+                            return Err(nom::Err::Error(make_error(input, ErrorKind::Eof)));
+                        }
                         let mut octets = [0u8; 16];
-                        octets[..ep_size].copy_from_slice(&rest[..ep_size]);
-                        IpAddr::V6(Ipv6Addr::from(octets))
+                        octets.copy_from_slice(&rest[..16]);
+                        (IpAddr::V6(Ipv6Addr::from(octets)), &rest[16..])
                     }
-                    _ => unreachable!(),
+                    _ => return Err(nom::Err::Error(make_error(input, ErrorKind::Verify))),
                 };
-                let rest = &rest[ep_size..];
-                // Mandatory source-address-length octet; 0 means no
-                // source, otherwise it must match the AFI host width.
+                // Mandatory source-address-length octet: 0 = no source,
+                // else 32 (IPv4) or 128 (IPv6) — also family-by-length,
+                // independent of the outer AFI.
                 let (rest, src_len) = be_u8(rest)?;
-                let source = if src_len == 0 {
-                    None
-                } else if src_len == max_addr_bits {
-                    let src_size = nlri_psize(src_len);
-                    if rest.len() < src_size {
-                        return Err(nom::Err::Error(make_error(input, ErrorKind::Eof)));
-                    }
-                    match afi {
-                        Afi::Ip => {
-                            let mut octets = [0u8; 4];
-                            octets[..src_size].copy_from_slice(&rest[..src_size]);
-                            Some(IpAddr::V4(Ipv4Addr::from(octets)))
+                let source = match src_len {
+                    0 => None,
+                    32 => {
+                        if rest.len() < 4 {
+                            return Err(nom::Err::Error(make_error(input, ErrorKind::Eof)));
                         }
-                        Afi::Ip6 => {
-                            let mut octets = [0u8; 16];
-                            octets[..src_size].copy_from_slice(&rest[..src_size]);
-                            Some(IpAddr::V6(Ipv6Addr::from(octets)))
-                        }
-                        _ => unreachable!(),
+                        let mut octets = [0u8; 4];
+                        octets.copy_from_slice(&rest[..4]);
+                        Some(IpAddr::V4(Ipv4Addr::from(octets)))
                     }
-                } else {
-                    return Err(nom::Err::Error(make_error(input, ErrorKind::Verify)));
+                    128 => {
+                        if rest.len() < 16 {
+                            return Err(nom::Err::Error(make_error(input, ErrorKind::Eof)));
+                        }
+                        let mut octets = [0u8; 16];
+                        octets.copy_from_slice(&rest[..16]);
+                        Some(IpAddr::V6(Ipv6Addr::from(octets)))
+                    }
+                    _ => return Err(nom::Err::Error(make_error(input, ErrorKind::Verify))),
                 };
                 MupRoute::T1st {
                     id,
@@ -730,10 +734,12 @@ impl MupPrefix {
         }
     }
 
-    /// Outer AFI implied by the route's address family. RFC 9833 §3 ties
-    /// every address a MUP route carries to the MP_REACH AFI, so the
-    /// prefix / address / endpoint family is authoritative. `Unknown`
-    /// has no decoded address, so it defaults to IPv4.
+    /// Outer AFI implied by the route's keyed address. The MP_REACH AFI
+    /// tracks the prefix/address that names the route — the UE prefix for
+    /// ISD/T1ST, the segment address for DSD, the endpoint for T2ST — so
+    /// that field is authoritative. (A T1ST endpoint/source may be a
+    /// different family; see `MupRoute::T1st`.) `Unknown` has no decoded
+    /// address, so it defaults to IPv4.
     pub fn afi(&self) -> Afi {
         let v6 = match self {
             MupPrefix::Isd { prefix, .. } | MupPrefix::T1st { prefix, .. } => {
@@ -1123,17 +1129,94 @@ mod tests {
     }
 
     #[test]
-    fn t1st_rejects_endpoint_len_over_afi_max() {
+    fn t1st_rejects_invalid_endpoint_len() {
         // arch=1, route_type=3, length=20, RD(8) + plen=0 + TEID(4) + QFI(1)
-        // + ep_len=33 (> 32 for v4) + filler
+        // + ep_len=33 (not 32 or 128 → invalid host width) + filler.
         let mut v = vec![0x01, 0x00, 0x03, 20];
         v.extend_from_slice(&[0; 8]); // RD
         v.push(0); // plen=0 → no prefix bytes
         v.extend_from_slice(&[0; 4]); // TEID
         v.push(0); // QFI
-        v.push(33); // ep_len > 32
+        v.push(33); // ep_len neither 32 nor 128
         v.extend_from_slice(&[0; 6]); // pad to length=20
         assert!(MupRoute::parse(&v, false, Afi::Ip).is_err());
+    }
+
+    #[test]
+    fn t1st_mixed_afi_v6_ue_v4_endpoint_round_trip() {
+        // The real 5G case: an IPv6 UE prefix (outer AFI = IPv6) carrying
+        // an IPv4 gNB endpoint and IPv4 UPF source (IPv4 N3 transport).
+        // The endpoint/source families come from their own length octets,
+        // so this must round-trip under the IPv6 outer AFI.
+        round_trip(
+            MupRoute::T1st {
+                id: 0,
+                arch: MupArchitectureType::Gpp5g,
+                rd: sample_rd(),
+                prefix: "2001:db8::5/128".parse().unwrap(),
+                teid: 0x1234_5678,
+                qfi: 9,
+                endpoint: "10.0.0.1".parse().unwrap(),
+                source: Some("198.51.100.7".parse().unwrap()),
+            },
+            false,
+            Afi::Ip6,
+        );
+    }
+
+    #[test]
+    fn t1st_mixed_afi_v4_ue_v6_endpoint_round_trip() {
+        // The mirror case: an IPv4 UE prefix (outer AFI = IPv4) carrying an
+        // IPv6 endpoint/source (IPv6 N3 transport).
+        round_trip(
+            MupRoute::T1st {
+                id: 0,
+                arch: MupArchitectureType::Gpp5g,
+                rd: sample_rd(),
+                prefix: "192.0.2.5/32".parse().unwrap(),
+                teid: 7,
+                qfi: 1,
+                endpoint: "2001:db8::1".parse().unwrap(),
+                source: Some("2001:db8::abcd".parse().unwrap()),
+            },
+            false,
+            Afi::Ip,
+        );
+    }
+
+    #[test]
+    fn t1st_parses_v6_ue_with_v4_endpoint_bytes() {
+        // Hand-rolled wire bytes: outer AFI = IPv6, UE prefix /128, then a
+        // 32-bit endpoint and a 32-bit source. A parser that forced the
+        // endpoint/source to match the outer AFI (128) would reject this.
+        // arch=1, route_type=3 (T1ST).
+        // body = RD(8) + plen(1)=128 + ue(16) + TEID(4) + QFI(1)
+        //        + ep_len(1)=32 + ep(4) + src_len(1)=32 + src(4) = 40
+        let ue = std::net::Ipv6Addr::new(0x2001, 0xdb8, 0, 0, 0, 0, 0, 5);
+        let mut v = vec![0x01, 0x00, 0x03, 40];
+        v.extend_from_slice(&[0; 8]); // RD = 0:0
+        v.push(128); // prefix length
+        v.extend_from_slice(&ue.octets()); // UE prefix (16)
+        v.extend_from_slice(&0x1234_5678u32.to_be_bytes()); // TEID
+        v.push(9); // QFI
+        v.push(32); // endpoint length → IPv4
+        v.extend_from_slice(&[10, 0, 0, 1]); // endpoint
+        v.push(32); // source length → IPv4
+        v.extend_from_slice(&[198, 51, 100, 7]); // source
+        let (_, route) = MupRoute::parse(&v, false, Afi::Ip6).expect("mixed-AFI T1ST parses");
+        match route {
+            MupRoute::T1st {
+                prefix,
+                endpoint,
+                source,
+                ..
+            } => {
+                assert_eq!(prefix, "2001:db8::5/128".parse::<IpNet>().unwrap());
+                assert_eq!(endpoint, "10.0.0.1".parse::<IpAddr>().unwrap());
+                assert_eq!(source, Some("198.51.100.7".parse::<IpAddr>().unwrap()));
+            }
+            other => panic!("expected T1st, got {other:?}"),
+        }
     }
 
     #[test]

--- a/docs/design/bgp-mup-followups.md
+++ b/docs/design/bgp-mup-followups.md
@@ -18,8 +18,8 @@ phases, committed and pushed (rebased onto `origin/main`):
   the `MpReachAttr::Mup` / `MpUnreachAttr::Mup` receive arms; `adj_in.mup`;
   `route_clean` peer-down; `show bgp mobile-uplane` route table.
 - **P3 per-VRF config** — `router bgp vrf <name> mobile-uplane`:
-  `route-target export` + `srv6-mobile {decapsulation|encapsulation}
-  network-instance exact <ni>`; the config-driven `MUP VRFs:` block in
+  `route-target export` + `route {st1|st2} dest-network-instance
+  {access|core} exact <ni>`; the config-driven `MUP VRFs:` block in
   `show bgp mobile-uplane`.
 - **P4 advertise / re-originate** — `MupPrefix::afi()`/`to_route()`,
   `adj_out.mup`, AFI-aware `route_advertise_mup_to_peers` /

--- a/zebra-rs/src/bgp/config.rs
+++ b/zebra-rs/src/bgp/config.rs
@@ -4086,12 +4086,12 @@ impl Bgp {
             super::vrf_config::config_vrf_mup_rt_export,
         );
         self.callback_add(
-            "/router/bgp/vrf/mobile-uplane/srv6-mobile/decapsulation/network-instance/exact",
-            super::vrf_config::config_vrf_mup_srv6_decap,
+            "/router/bgp/vrf/mobile-uplane/route/st2/dest-network-instance/core/exact",
+            super::vrf_config::config_vrf_mup_route_st2,
         );
         self.callback_add(
-            "/router/bgp/vrf/mobile-uplane/srv6-mobile/encapsulation/network-instance/exact",
-            super::vrf_config::config_vrf_mup_srv6_encap,
+            "/router/bgp/vrf/mobile-uplane/route/st1/dest-network-instance/access/exact",
+            super::vrf_config::config_vrf_mup_route_st1,
         );
 
         // `set router bgp interface-neighbor <name> [...]`.

--- a/zebra-rs/src/bgp/inst.rs
+++ b/zebra-rs/src/bgp/inst.rs
@@ -650,10 +650,11 @@ pub struct Bgp {
     /// reconfigure a running controller.
     pub mup_c_dirty: bool,
     /// MUP routes the controller has originated, keyed by session SEID →
-    /// (originated NLRI, allocated SRv6 SID function). Tracked so a
-    /// Session Deletion / Modification withdraws the exact prior route and
-    /// returns its SID function to the pool.
-    pub mup_c_originated: BTreeMap<u64, (bgp_packet::MupPrefix, u16)>,
+    /// the originated NLRI. Tracked so a Session Deletion / Modification
+    /// withdraws the exact prior route. No SRv6 SID is allocated for these
+    /// (the PE derives forwarding from its ISD/DSD routes), so only the
+    /// prefix is retained.
+    pub mup_c_originated: BTreeMap<u64, bgp_packet::MupPrefix>,
     /// Local bridge FDB shadow keyed by `(vni, mac)`. Populated from
     /// every `RibRx::FdbAdd`, removed on `RibRx::FdbDel`. We need
     /// durable state (not just one-shot event handling) because the

--- a/zebra-rs/src/bgp/route.rs
+++ b/zebra-rs/src/bgp/route.rs
@@ -7605,24 +7605,15 @@ fn mup_ue_prefix(session: &crate::mup_c::session::MupSession) -> Option<IpNet> {
     }
 }
 
-/// End.DT4 / End.DT6 / End.DT46 SRv6 behaviour for a session's UE address
-/// family.
-fn mup_sid_behavior(session: &crate::mup_c::session::MupSession) -> u16 {
-    match (session.ue_ipv4.is_some(), session.ue_ipv6.is_some()) {
-        (true, false) => bgp_packet::SRV6_BEHAVIOR_END_DT4,
-        (false, true) => bgp_packet::SRV6_BEHAVIOR_END_DT6,
-        _ => bgp_packet::SRV6_BEHAVIOR_END_DT46,
-    }
-}
-
 /// Build the attributes for a controller-originated MUP ST route: the
-/// controller next-hop (carried in MP_REACH), the VRF's route-target
-/// exports, and the SRv6 L3 Service SID (RFC 9252 Prefix-SID).
+/// controller next-hop (carried in MP_REACH) and the VRF's route-target
+/// exports. No SID is attached — per draft-ietf-bess-mup-safi the default
+/// is for the receiving PE to derive the forwarding SID from its own
+/// ISD/DSD routes (matched by endpoint/prefix) and program the FIB itself,
+/// so the MUP-C neither allocates nor advertises one.
 fn build_mup_attr(
     controller: Option<std::net::Ipv6Addr>,
     rts: &std::collections::BTreeSet<RouteDistinguisher>,
-    sid: std::net::Ipv6Addr,
-    behavior: u16,
 ) -> BgpAttr {
     let mut attr = BgpAttr::new();
     if let Some(addr) = controller {
@@ -7635,14 +7626,6 @@ fn build_mup_attr(
         }
         attr.ecom = Some(ecom);
     }
-    attr.prefix_sid = Some(bgp_packet::PrefixSid {
-        tlvs: vec![bgp_packet::PrefixSidTlv::Srv6L3Service(
-            bgp_packet::Srv6ServiceTlv {
-                sids: vec![bgp_packet::Srv6SidInfo::new(sid, 0, behavior, None)],
-                ..Default::default()
-            },
-        )],
-    });
     attr
 }
 
@@ -12401,17 +12384,18 @@ pub fn route_sync(peer: &mut Peer, bgp: &mut BgpTop, v4_via_pool: bool) {
 impl Bgp {
     /// Originate (or re-originate) a MUP Session-Transformed route for one
     /// controller-learned session. Correlates the session's Network
-    /// Instance to a `router bgp vrf <name> mobile-uplane` config,
-    /// allocates an SRv6 service SID from the locator, builds the ST route
-    /// with its attributes, installs into the MUP Loc-RIB as `Originated`,
-    /// and advertises. A prior route for the same session is withdrawn
-    /// first, so a Session Modification cleanly replaces it. No-op when no
-    /// VRF matches the NI, the VRF has no RD, or no SRv6 SID is available.
+    /// Instance to a `router bgp vrf <name> mobile-uplane` config, builds
+    /// the ST route with its attributes, installs into the MUP Loc-RIB as
+    /// `Originated`, and advertises. A prior route for the same session is
+    /// withdrawn first, so a Session Modification cleanly replaces it.
+    /// No-op when no VRF matches the NI or the VRF has no RD. No SRv6 SID
+    /// is allocated — the receiving PE derives forwarding from its own
+    /// ISD/DSD routes (draft-ietf-bess-mup-safi default).
     pub fn originate_mup_route(&mut self, session: &crate::mup_c::session::MupSession) {
         // Replace any prior route for this session (Modification path).
         self.withdraw_mup_route(session.seid);
 
-        let Some((prefix, function, attr)) = self.build_mup_origination(session) else {
+        let Some((prefix, attr)) = self.build_mup_origination(session) else {
             return;
         };
         let mut rib = BgpRib::new(
@@ -12428,35 +12412,32 @@ impl Bgp {
         rib.attr = self.attr_store.intern(attr);
         let _ = self.local_rib.update_mup(prefix.clone(), rib);
         let selected = self.local_rib.select_best_path_mup(&prefix);
-        self.mup_c_originated
-            .insert(session.seid, (prefix.clone(), function));
+        self.mup_c_originated.insert(session.seid, prefix.clone());
         self.mup_apply_selected(prefix, selected);
     }
 
     /// Withdraw the MUP route originated for `seid` (Session Deletion or
-    /// the replace step of a Modification), returning its SRv6 SID
-    /// function to the pool. No-op when nothing was originated.
+    /// the replace step of a Modification). No-op when nothing was
+    /// originated.
     pub fn withdraw_mup_route(&mut self, seid: u64) {
-        let Some((prefix, function)) = self.mup_c_originated.remove(&seid) else {
+        let Some(prefix) = self.mup_c_originated.remove(&seid) else {
             return;
         };
-        self.srv6_sid_pool.release(function);
         self.local_rib.remove_mup(&prefix, 0, ORIGINATED_PEER);
         let selected = self.local_rib.select_best_path_mup(&prefix);
         self.mup_apply_selected(prefix, selected);
     }
 
     /// Correlate a session to a VRF `mobile-uplane` config and build the
-    /// ST prefix + attributes + allocated SID function. Returns `None`
-    /// (releasing any SID it took) when the session can't be originated.
+    /// ST prefix + attributes. Returns `None` when no VRF matches the
+    /// session's Network Instance, the VRF has no RD, or the session lacks
+    /// the addresses the chosen ST route type needs.
     fn build_mup_origination(
         &mut self,
         session: &crate::mup_c::session::MupSession,
-    ) -> Option<(bgp_packet::MupPrefix, u16, BgpAttr)> {
+    ) -> Option<(bgp_packet::MupPrefix, BgpAttr)> {
         use super::vrf_config::MupSrv6Direction;
         let ni = session.network_instance.as_deref()?;
-        // Owned copies so the immutable `vrfs` borrow ends before the
-        // mutable SID allocation below.
         let (rd, rts, direction) = self.vrfs.values().find_map(|cfg| {
             let sm = cfg.mobile_uplane.srv6_mobile.as_ref()?;
             (sm.network_instance.as_deref() == Some(ni)).then(|| {
@@ -12468,10 +12449,10 @@ impl Bgp {
             })
         })?;
         let rd = rd?;
-        let (sid, function) = self.alloc_mup_sid()?;
         let prefix = match direction {
             // Encapsulation (N6 / downlink): Type-1 ST carries the UE
-            // prefix + access tunnel.
+            // prefix + access tunnel. The endpoint (gNB) family may differ
+            // from the UE prefix family (mixed-AFI 5G).
             MupSrv6Direction::Encapsulation => match (mup_ue_prefix(session), session.endpoint) {
                 (Some(prefix), Some(endpoint)) => bgp_packet::MupPrefix::T1st {
                     rd,
@@ -12481,10 +12462,7 @@ impl Bgp {
                     endpoint,
                     source: None,
                 },
-                _ => {
-                    self.srv6_sid_pool.release(function);
-                    return None;
-                }
+                _ => return None,
             },
             // Decapsulation (N3 / uplink): Type-2 ST carries the core
             // endpoint + TEID.
@@ -12495,35 +12473,11 @@ impl Bgp {
                     endpoint_len: if endpoint.is_ipv4() { 32 } else { 128 },
                     teid: session.teid,
                 },
-                None => {
-                    self.srv6_sid_pool.release(function);
-                    return None;
-                }
+                None => return None,
             },
         };
-        let attr = build_mup_attr(
-            self.mup_c_config.controller_address,
-            &rts,
-            sid,
-            mup_sid_behavior(session),
-        );
-        Some((prefix, function, attr))
-    }
-
-    /// Allocate an SRv6 service SID from the resolved BGP locator (the
-    /// same source `encapsulation srv6` VRFs draw End.DT46 from). Returns
-    /// the full SID address and its function, or `None` when no locator
-    /// has resolved or the function band is exhausted.
-    fn alloc_mup_sid(&mut self) -> Option<(std::net::Ipv6Addr, u16)> {
-        let prefix = self.srv6_locator.as_ref().and_then(|l| l.prefix)?;
-        let function = self.srv6_sid_pool.allocate()?;
-        match crate::isis::srv6::function_addr(prefix, function) {
-            Some(addr) => Some((addr, function)),
-            None => {
-                self.srv6_sid_pool.release(function);
-                None
-            }
-        }
+        let attr = build_mup_attr(self.mup_c_config.controller_address, &rts);
+        Some((prefix, attr))
     }
 
     /// Apply the post-update best path of one MUP prefix to peers:
@@ -16988,20 +16942,6 @@ mod tests {
         );
         assert_eq!(super::mup_ue_prefix(&session(None, None)), None);
 
-        // End.DT4 / DT6 / DT46 by UE family.
-        assert_eq!(
-            super::mup_sid_behavior(&session(Some(v4), None)),
-            bgp_packet::SRV6_BEHAVIOR_END_DT4
-        );
-        assert_eq!(
-            super::mup_sid_behavior(&session(None, Some(v6))),
-            bgp_packet::SRV6_BEHAVIOR_END_DT6
-        );
-        assert_eq!(
-            super::mup_sid_behavior(&session(Some(v4), Some(v6))),
-            bgp_packet::SRV6_BEHAVIOR_END_DT46
-        );
-
         // RT shares the RD wire format (low type 0x02, value preserved).
         let rd = RouteDistinguisher::from_str("65000:100").unwrap();
         let rt = super::rd_route_target(&rd);
@@ -17009,18 +16949,14 @@ mod tests {
         assert_eq!(rt.high_type, rd.typ as u8);
         assert_eq!(rt.val, rd.val);
 
-        // The built attr carries the controller next-hop, the RT export
-        // and the SRv6 L3 Service SID.
+        // The built attr carries the controller next-hop and the RT export
+        // — and NO Prefix-SID: per draft-ietf-bess-mup-safi the receiving
+        // PE derives the forwarding SID from its own ISD/DSD routes, so the
+        // MUP-C neither allocates nor advertises one.
         let controller: Ipv6Addr = "2001:db8::1".parse().unwrap();
-        let sid: Ipv6Addr = "2001:db8:1:40::".parse().unwrap();
         let mut rts = BTreeSet::new();
         rts.insert(rd);
-        let attr = super::build_mup_attr(
-            Some(controller),
-            &rts,
-            sid,
-            bgp_packet::SRV6_BEHAVIOR_END_DT4,
-        );
+        let attr = super::build_mup_attr(Some(controller), &rts);
         assert!(
             matches!(attr.nexthop, Some(BgpNexthop::Ipv6(a)) if a == controller),
             "controller next-hop in MP_REACH"
@@ -17034,13 +16970,10 @@ mod tests {
                 .any(|v| v.low_type == 0x02),
             "RT export present"
         );
-        match &attr.prefix_sid.as_ref().unwrap().tlvs[0] {
-            bgp_packet::PrefixSidTlv::Srv6L3Service(tlv) => {
-                assert_eq!(tlv.sids[0].sid, sid);
-                assert_eq!(tlv.sids[0].behavior, bgp_packet::SRV6_BEHAVIOR_END_DT4);
-            }
-            other => panic!("expected Srv6L3Service, got {other:?}"),
-        }
+        assert!(
+            attr.prefix_sid.is_none(),
+            "MUP-C must not attach a Prefix-SID; the PE derives the SID from ISD/DSD"
+        );
     }
 
     fn bgp_rib_with_nexthop(nh: Option<BgpNexthop>, typ: super::BgpRibType) -> super::BgpRib {

--- a/zebra-rs/src/bgp/vrf_config.rs
+++ b/zebra-rs/src/bgp/vrf_config.rs
@@ -123,21 +123,21 @@ impl<N: Ord> Default for BgpVrfAfConfig<N> {
 }
 
 /// SRv6 mobile user-plane direction for a per-VRF MUP service
-/// (zebra-bgp-vrf.yang `mobile-uplane srv6-mobile`). `Decapsulation`
-/// is the egress/uplink (Type-2 ST, the N3 VRF); `Encapsulation` is
-/// the ingress/downlink (Type-1 ST, the N6 VRF).
+/// (zebra-bgp-vrf.yang `mobile-uplane route {st1|st2}`). `Decapsulation`
+/// is the `st2` egress/uplink (Type-2 ST, the N3 VRF); `Encapsulation`
+/// is the `st1` ingress/downlink (Type-1 ST, the N6 VRF).
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum MupSrv6Direction {
     Decapsulation,
     Encapsulation,
 }
 
-/// `mobile-uplane srv6-mobile {decapsulation|encapsulation}
-/// network-instance exact <ni>` for one VRF: the direction plus the
+/// `mobile-uplane route {st1|st2} dest-network-instance {access|core}
+/// exact <ni>` for one VRF: the ST route type (as a direction) plus the
 /// session network-instance matched exactly. Surfaced in
 /// `show bgp mobile-uplane` (the `MUP VRFs:` block) and consumed by the
-/// P5 MUP controller when it originates ST routes (decapsulation →
-/// Type-2 ST, the N3 VRF; encapsulation → Type-1 ST, the N6 VRF).
+/// P5 MUP controller when it originates ST routes (st2/Decapsulation →
+/// Type-2 ST, the N3 VRF; st1/Encapsulation → Type-1 ST, the N6 VRF).
 #[derive(Debug, Clone)]
 pub struct MupSrv6Mobile {
     pub direction: MupSrv6Direction,
@@ -309,10 +309,11 @@ pub fn config_vrf_mup_rt_export(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> 
     Some(())
 }
 
-/// `set router bgp vrf <NAME> mobile-uplane srv6-mobile decapsulation
-/// network-instance exact <NI>` — egress GTP decapsulation for the
-/// uplink Type-2 ST service (the N3 VRF).
-pub fn config_vrf_mup_srv6_decap(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Option<()> {
+/// `set router bgp vrf <NAME> mobile-uplane route st2 dest-network-instance
+/// core exact <NI>` — Type-2 ST (uplink) origination: egress GTP
+/// decapsulation for the N3 VRF, matched against the session's core
+/// network-instance.
+pub fn config_vrf_mup_route_st2(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Option<()> {
     let name = args.string()?;
     let cfg = vrf_entry(bgp, name);
     match op {
@@ -329,10 +330,11 @@ pub fn config_vrf_mup_srv6_decap(bgp: &mut Bgp, mut args: Args, op: ConfigOp) ->
     Some(())
 }
 
-/// `set router bgp vrf <NAME> mobile-uplane srv6-mobile encapsulation
-/// network-instance exact <NI>` — ingress GTP encapsulation for the
-/// downlink Type-1 ST service (the N6 VRF).
-pub fn config_vrf_mup_srv6_encap(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Option<()> {
+/// `set router bgp vrf <NAME> mobile-uplane route st1 dest-network-instance
+/// access exact <NI>` — Type-1 ST (downlink) origination: ingress GTP
+/// encapsulation for the N6 VRF, matched against the session's access
+/// network-instance.
+pub fn config_vrf_mup_route_st1(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Option<()> {
     let name = args.string()?;
     let cfg = vrf_entry(bgp, name);
     match op {

--- a/zebra-rs/yang/zebra-bgp-vrf.yang
+++ b/zebra-rs/yang/zebra-bgp-vrf.yang
@@ -343,10 +343,10 @@ module zebra-bgp-vrf {
       container mobile-uplane {
         description
           "BGP MUP (RFC 9833) per-VRF service. route-target/export tags
-           the ST routes the controller originates from this VRF;
-           srv6-mobile selects the direction (decapsulation = Type-2 ST
-           / uplink = N3, encapsulation = Type-1 ST / downlink = N6) and
-           the session network-instance matched exactly.";
+           the ST routes the controller originates from this VRF; route
+           selects the Session-Transformed route type (st1 = Type-1 ST
+           / downlink = N6, st2 = Type-2 ST / uplink = N3) and the
+           destination session network-instance matched exactly.";
         container route-target {
           leaf-list export {
             type route-distinguisher;
@@ -355,25 +355,34 @@ module zebra-bgp-vrf {
                this VRF (RT shares the RD wire format).";
           }
         }
-        container srv6-mobile {
-          description "SRv6 mobile user-plane behaviour for this VRF.";
-          container decapsulation {
+        container route {
+          description
+            "Session-Transformed route origination for this VRF, keyed by
+             ST route type. Each route type binds the destination
+             network-instance whose PFCP sessions it originates from.";
+          container st1 {
             description
-              "Egress GTP decapsulation (Type-2 ST / uplink); the N3 VRF.";
-            container network-instance {
-              leaf exact {
-                type string;
-                description "Session core network-instance matched exactly.";
+              "Type-1 ST (downlink); ingress GTP encapsulation, the N6 VRF.";
+            container dest-network-instance {
+              container access {
+                leaf exact {
+                  type string;
+                  description
+                    "Session access network-instance matched exactly.";
+                }
               }
             }
           }
-          container encapsulation {
+          container st2 {
             description
-              "Ingress GTP encapsulation (Type-1 ST / downlink); the N6 VRF.";
-            container network-instance {
-              leaf exact {
-                type string;
-                description "Session access network-instance matched exactly.";
+              "Type-2 ST (uplink); egress GTP decapsulation, the N3 VRF.";
+            container dest-network-instance {
+              container core {
+                leaf exact {
+                  type string;
+                  description
+                    "Session core network-instance matched exactly.";
+                }
               }
             }
           }


### PR DESCRIPTION
## Summary

Refines the already-merged BGP MUP (SAFI 85, RFC 9833 / draft-ietf-bess-mup-safi) feature on two fronts.

**1. Per-VRF route CLI rename.** Replaces `mobile-uplane srv6-mobile {encapsulation|decapsulation} network-instance exact <ni>` with:

```
set router bgp vrf N6 mobile-uplane route st1 dest-network-instance access exact access-ni
set router bgp vrf N3 mobile-uplane route st2 dest-network-instance core  exact core-ni
```

(st1 = N6/access, st2 = N3/core). YANG grammar, callback paths, handler names, and the BDD/book/docs configs are updated; the internal model (`srv6_mobile`/`MupSrv6Direction`) is unchanged.

**2. Mixed-AFI T1ST + no-SID origination (draft-compliant).**
- A Type-1 ST endpoint (gNB) / source (UPF) address family is now decided by its **own length octet** (32 = IPv4, 128 = IPv6), independent of the outer AFI. Only the UE prefix follows the outer AFI, so an **IPv6 UE route may carry an IPv4 gNB/UPF** (the real 5G case with IPv4 N3 transport). T2ST keeps its single endpoint AFI-tied. Cross-checked against GoBGP `mup.go`.
- The **MUP-C no longer allocates or advertises an SRv6 service SID** — per the draft default, the receiving PE derives forwarding from its own ISD/DSD routes. `build_mup_attr` keeps only the controller next-hop + RT export; `alloc_mup_sid`/`mup_sid_behavior` removed.

## Test plan

- `cargo test -p bgp-packet` (340; +3 mixed-AFI codec tests) and `cargo test -p zebra-rs` (1450) green.
- `cargo fmt --all --check` + `cargo clippy --workspace --all-targets -- -D warnings` clean.
- New BDD `@bgp_mup_mixed_afi` (IPv6 UE + IPv4 endpoint, **no SRv6 locator configured**) passes end-to-end — z2 receives and parses the route under IPv6-MUP, proving both fixes. Existing `@bgp_mup_e2e` still passes.
- Live single-node check: with no locator anywhere, the controller still originates `[ST1][65000:100][ue=2001:db8::5/128][...][ep=10.0.0.1]`.

Generated with [Claude Code](https://claude.com/claude-code)