### PR TITLE
bgp: export eBGP-learned VRF routes into VPNv4 (Inter-AS Option A)

### DIFF
--- a/bdd/tests/features/bgp_interas_option_a.feature
+++ b/bdd/tests/features/bgp_interas_option_a.feature
@@ -61,7 +61,11 @@ Feature: Inter-AS MPLS/VPN Option A over SR-MPLS (RFC 4364 §10a)
     And I apply config "p2.yaml" to namespace "p2"
     And I apply config "pe2.yaml" to namespace "pe2"
     And I apply config "ce2.yaml" to namespace "ce2"
-    And I wait 35 seconds for BGP to operate
+    # 75s, not the 35s the sibling option features use: the customer
+    # prefix crosses the longest chain here — CE2 → PE2 (VPNv4) → ASBR2
+    # → (PE-CE eBGP) → ASBR1 → re-export to VPNv4 → PE1 → import — so end-
+    # to-end convergence (measured ~55-60s) needs the extra headroom.
+    And I wait 75 seconds for BGP to operate
     # IS-IS SR adjacencies form the intra-AS transport.
     Then isis neighbor in namespace "pe1" at level 2 on interface "p1" should be up
     And isis neighbor in namespace "asbr1" at level 2 on interface "p1" should be up

--- a/zebra-rs/src/bgp/route.rs
+++ b/zebra-rs/src/bgp/route.rs
@@ -3755,7 +3755,7 @@ fn reduce_bestpath_v4_nht_fib(
 ) -> Option<(usize, Ipv4AdvertiseJob)> {
     let ShardOut::BestPathV4 {
         ident,
-        rd: _,
+        rd,
         prefix,
         selected,
         replaced,
@@ -3774,6 +3774,22 @@ fn reduce_bestpath_v4_nht_fib(
         );
     }
     fib_install_v4(bgp, prefix.prefix, &selected);
+    // Per-VRF VPNv4 export (rd == None, inside a VRF task) — mirror the
+    // same hook in `route_ipv4_update_decided`. This batch reduce is the
+    // ONLY path for received v4-unicast NLRI, so without firing the export
+    // here a route a VRF learns from a peer (e.g. an Inter-AS Option A
+    // PE-CE eBGP session) never crosses into VPNv4 — only spawn-time
+    // `network`-originated prefixes did, which is why the remote-AS
+    // customer prefix never reached the far PE.
+    if rd.is_none()
+        && let Some(exporter) = bgp.vrf_export
+    {
+        if let Some(winner) = selected.first() {
+            super::vrf::vrf_emit_export(exporter, prefix.prefix, &winner.attr);
+        } else {
+            super::vrf::vrf_emit_withdraw(exporter, prefix.prefix);
+        }
+    }
     Some((
         ident,
         Ipv4AdvertiseJob {

--- a/zebra-rs/src/bgp/vrf/spawn.rs
+++ b/zebra-rs/src/bgp/vrf/spawn.rs
@@ -284,7 +284,7 @@ pub fn spawn_bgp_vrf(
 /// idle-hold timer; once it fires the FSM event lands on
 /// `vrf.tx`.
 fn materialize_peers(vrf: &mut BgpVrf, cfg: &BgpVrfConfig) -> usize {
-    use super::super::peer::Peer;
+    use super::super::peer::{Peer, PeerType};
     use super::super::peer_key::PeerKey;
 
     let mut count = 0usize;
@@ -315,6 +315,19 @@ fn materialize_peers(vrf: &mut BgpVrf, cfg: &BgpVrfConfig) -> usize {
             vrf.tx.clone(),
             vrf.ctx.clone(),
         );
+        // `Peer::new` defaults `peer_type` to IBGP and, unlike the global
+        // `config_remote_as` path, nothing else recomputes it for a VRF
+        // peer — so derive it here from the AS comparison. Without this a
+        // per-VRF PE-CE *eBGP* session (remote-as != the VRF's AS) is
+        // treated as iBGP: its routes are marked internal, carry no
+        // AS-path prepend, and (the symptom) are never re-advertised to
+        // the iBGP VPNv4 core, so an Inter-AS Option A remote-AS customer
+        // prefix never reaches the far PE.
+        peer.peer_type = if remote_as == vrf.asn {
+            PeerType::IBGP
+        } else {
+            PeerType::EBGP
+        };
         peer.start();
         vrf.peers.insert_with_key(PeerKey::Addr(*addr), peer);
         count += 1;
@@ -477,9 +490,18 @@ mod tests {
         // a dormant entry would clutter `show bgp vrf v1 summary`
         // output until the operator filled the leaf in.
         assert_eq!(count, 1);
-        assert!(
-            vrf.peers.get(&with_as).is_some(),
-            "peer with remote-as inserted"
+        let peer = vrf
+            .peers
+            .get(&with_as)
+            .expect("peer with remote-as inserted");
+        // remote-as 65001 != the VRF's AS 65000 → eBGP. `Peer::new`
+        // defaults to IBGP, so `materialize_peers` must derive this — else
+        // a per-VRF PE-CE eBGP session is treated as iBGP and its routes
+        // never re-advertise into the VPNv4 core (Inter-AS Option A).
+        assert_eq!(
+            peer.peer_type,
+            crate::bgp::peer::PeerType::EBGP,
+            "remote-as != VRF AS must be classified eBGP"
         );
         assert!(
             vrf.peers.get(&no_as).is_none(),


### PR DESCRIPTION
## Summary

Fixes Inter-AS MPLS/VPN **Option A** (per-VRF PE-CE eBGP with routes re-exported to VPNv4). An ASBR learned the remote-AS customer prefix in its VRF but never advertised it into the VPNv4 core, so the far PE never imported it and end-to-end forwarding failed. Two pre-existing daemon bugs (the feature never actually passed; CI excludes BDD):

1. **`materialize_peers` (per-VRF spawn) never set `peer_type`.** `Peer::new` defaults to `IBGP`, so a VRF PE-CE **eBGP** session (remote-as ≠ the VRF's AS) was treated as iBGP: its routes were marked internal, carried no AS-path prepend, and — the symptom — weren't re-advertised to the iBGP VPNv4 core (iBGP→iBGP split-horizon). Now derives `peer_type` from the AS comparison, like the global `config_remote_as` path.

2. **`reduce_bestpath_v4_nht_fib` never fired the per-VRF VPNv4 export hook.** This is the best-path reduce on the v4-unicast **batch** ingest path — the ONLY path for *received* NLRI. It installed the FIB and built the advertise job but skipped `vrf_emit_export` (which `route_ipv4_update_decided` fires). So a VRF route *received* from a peer never crossed into VPNv4; only spawn-time `network`-originated prefixes did. Now fires the export there too.

With both fixes the prefix flows CE2 → PE2 → ASBR2 → (PE-CE eBGP) → ASBR1 → VPNv4 → PE1 → import, and ce1↔ce2 ping works.

The `@bgp_interas_option_a` setup wait is bumped 35s→75s: this is the longest inter-AS chain, full convergence measures ~55-60s, and the 35s was never validated (the feature was broken).

## Test plan

- `@bgp_interas_option_a` passes 6/6 scenarios (was: 2 failing — VRF route import + end-to-end ping).
- Added a `materialize_peers` unit-test assertion that remote-as ≠ VRF AS classifies eBGP.
- 1450 zebra-rs unit tests pass; `cargo fmt` + `cargo clippy --workspace --all-targets -- -D warnings` clean.

Generated with [Claude Code](https://claude.com/claude-code)