### PR TITLE
bdd: poll the standby-gateway re-flood negative check

### DIFF
--- a/bdd/tests/features/bgp_evpn_gateway_df.feature
+++ b/bdd/tests/features/bgp_evpn_gateway_df.feature
@@ -52,9 +52,12 @@ Feature: BGP EVPN BUM segmentation — DF-gated gateway re-flood (RFC 9572 §5.3
   Scenario: The standby gateway re-floods nothing (no duplicate BUM)
     Given the test topology exists
     # z4 (.0.4) loses the DF election for both regions, so it owns neither and
-    # drops every region from its re-flood set.
+    # drops every region from its re-flood set. Poll the negative check: until
+    # z4 has learned z2 as a candidate for *every* region it can transiently
+    # see itself as the lone (hence DF) gateway for a not-yet-converged region
+    # and re-flood it, dropping that only once z2's per-region IMET arrives.
     Then show command "show bgp evpn route-type per-region-imet" in namespace "z4" should eventually contain "(standby)"
-    And show command "show bgp evpn route-type per-region-imet" in namespace "z4" should not contain "gateway re-flood"
+    And show command "show bgp evpn route-type per-region-imet" in namespace "z4" should eventually not contain "gateway re-flood"
 
   Scenario: Teardown topology
     Given the test topology exists


### PR DESCRIPTION
## Summary

Fixes a flaky `@bgp_evpn_gateway_df` failure. The "standby gateway re-floods nothing" scenario asserted z4 (the DF-election loser) `should not contain "gateway re-flood"` with a single check.

DF election converges per-region as each gateway's per-region IMET arrives: until z4 has learned z2 as a candidate for *every* region, it can transiently see itself as the lone — hence DF — gateway for a not-yet-converged region and re-flood it, dropping that only once z2's IMET lands. The preceding `eventually contain "(standby)"` can pass while one region is still in that transient state, so the single-shot negative check raced it and failed under full-suite load (passes in isolation).

Switch it to `should eventually not contain`, which polls until z4's re-flood set has fully converged to empty — the same convergence-tolerant pattern the bridge fdb/mdb negative checks already use. Test-only change.

## Test plan

- `@bgp_evpn_gateway_df` passes 2/2 fresh runs.

Generated with [Claude Code](https://claude.com/claude-code)