### PR TITLE
bdd: connect-retry-time on bgp_as_override eBGP neighbors

### DIFF
--- a/bdd/tests/configs/bgp_as_override/z1.yaml
+++ b/bdd/tests/configs/bgp_as_override/z1.yaml
@@ -18,6 +18,12 @@ router:
         enabled: true
       enabled: true
       remote-as: 65002
+      # Short connect-retry so a synchronized startup dial that
+      # collides (both eBGP ends dial at once) recovers in seconds
+      # instead of parking on the 120s default — keeps the fixed
+      # setup waits reliable under full-suite load.
+      timers:
+        connect-retry-time: 3
     afi-safi:
     - name: ipv4
       network:

--- a/bdd/tests/configs/bgp_as_override/z2-base.yaml
+++ b/bdd/tests/configs/bgp_as_override/z2-base.yaml
@@ -21,9 +21,21 @@ router:
         enabled: true
       enabled: true
       remote-as: 65001
+      # Short connect-retry so a synchronized startup dial that
+      # collides (both eBGP ends dial at once) recovers in seconds
+      # instead of parking on the 120s default — keeps the fixed
+      # setup waits reliable under full-suite load.
+      timers:
+        connect-retry-time: 3
     - remote-address: 192.168.1.3
       afi-safi:
       - name: ipv4
         enabled: true
       enabled: true
       remote-as: 65001
+      # Short connect-retry so a synchronized startup dial that
+      # collides (both eBGP ends dial at once) recovers in seconds
+      # instead of parking on the 120s default — keeps the fixed
+      # setup waits reliable under full-suite load.
+      timers:
+        connect-retry-time: 3

--- a/bdd/tests/configs/bgp_as_override/z2-override.yaml
+++ b/bdd/tests/configs/bgp_as_override/z2-override.yaml
@@ -21,12 +21,24 @@ router:
         enabled: true
       enabled: true
       remote-as: 65001
+      # Short connect-retry so a synchronized startup dial that
+      # collides (both eBGP ends dial at once) recovers in seconds
+      # instead of parking on the 120s default — keeps the fixed
+      # setup waits reliable under full-suite load.
+      timers:
+        connect-retry-time: 3
     - remote-address: 192.168.1.3
       afi-safi:
       - name: ipv4
         enabled: true
       enabled: true
       remote-as: 65001
+      # Short connect-retry so a synchronized startup dial that
+      # collides (both eBGP ends dial at once) recovers in seconds
+      # instead of parking on the 120s default — keeps the fixed
+      # setup waits reliable under full-suite load.
+      timers:
+        connect-retry-time: 3
       # Presence container → bare `set ... as-override`. On egress toward
       # z3, replaces z3's AS (65001) in the AS_PATH with z2's AS (65002)
       # before the local-AS prepend, so z3's RFC 4271 loop check accepts

--- a/bdd/tests/configs/bgp_as_override/z3.yaml
+++ b/bdd/tests/configs/bgp_as_override/z3.yaml
@@ -18,3 +18,9 @@ router:
         enabled: true
       enabled: true
       remote-as: 65002
+      # Short connect-retry so a synchronized startup dial that
+      # collides (both eBGP ends dial at once) recovers in seconds
+      # instead of parking on the 120s default — keeps the fixed
+      # setup waits reliable under full-suite load.
+      timers:
+        connect-retry-time: 3


### PR DESCRIPTION
## Summary

Fixes a flaky `@bgp_as_override` setup failure. The scenario establishes two directly-connected eBGP sessions (z1-z2, z2-z3) and asserts both Established after a fixed 20s wait. When both ends of a session dial at the same instant (synchronized startup timers) the connects collide and both peers park on the 120s default connect-retry until the timers drift — so the z2-z3 session came up only at ~52s and the single-shot Established check failed under full-suite load (passes in isolation).

Set `timers: connect-retry-time 3` on every eBGP neighbor so a collided dial re-fires within seconds. Same mitigation pattern as `bgp_allowas_in` / `bgp_interas_option_c`. Test-config-only.

## Test plan

- `@bgp_as_override` passes 2/2 fresh runs.

Generated with [Claude Code](https://claude.com/claude-code)