### PR TITLE
bdd: poll the second AddPath AS_PATH check (@bgp_addpath_ipv4)

### DIFF
--- a/bdd/tests/features/bgp_addpath_ipv4.feature
+++ b/bdd/tests/features/bgp_addpath_ipv4.feature
@@ -57,8 +57,11 @@ Feature: BGP AddPath Send for IPv4 unicast (RFC 7911)
     # advertises BOTH — so z4's table shows the prefix twice, once per
     # originating AS. Without AddPath Send z4 would hold exactly the
     # single best path (one AS_PATH only).
+    # Both checks poll: z3 advertises the two AddPaths asynchronously, so
+    # the second AS_PATH can land a beat after the first — a single-shot
+    # check on it races that arrival under full-suite load.
     Then show command "show bgp 10.10.10.0/24" in namespace "z4" should eventually contain "65003 65001"
-    And show command "show bgp 10.10.10.0/24" in namespace "z4" should contain "65003 65002"
+    And show command "show bgp 10.10.10.0/24" in namespace "z4" should eventually contain "65003 65002"
 
   Scenario: Teardown topology
     Given the test topology exists


### PR DESCRIPTION
## Summary

Fixes a flaky `@bgp_addpath_ipv4` failure. The "receiver sees both paths" scenario polled for the first AddPath AS_PATH (`should eventually contain "65003 65001"`) but asserted the second (`65003 65002`) with a single-shot `should contain`. z3 advertises the two AddPaths asynchronously, so the second AS_PATH can land a beat after the first — the single check raced that arrival and failed under full-suite load (passes in isolation; z4 ends with both paths, 2 available).

Make the second check `should eventually contain` too, matching the already-correct `@bgp_addpath_ipv6` sibling (both of its checks poll). Test-only.

## Test plan

- `@bgp_addpath_ipv4` passes 2/2 fresh runs; isolation shows z4 with both paths.

Generated with [Claude Code](https://claude.com/claude-code)