### PR TITLE
bgp-mup: rename to mup, RT on top-level VRF, show bgp vrf <name> mup

### DIFF
--- a/bdd/docs/bgp_mup_runtime_enable.md
+++ b/bdd/docs/bgp_mup_runtime_enable.md
@@ -4,7 +4,7 @@
 
 An AFI/SAFI is a BGP Multiprotocol *capability*, advertised once in the
 OPEN — the negotiated set is fixed for the life of the session. So
-enabling `afi-safi mobile-uplane` (RFC 9833, which turns on BOTH IPv4-MUP
+enabling `afi-safi mup` (RFC 9833, which turns on BOTH IPv4-MUP
 and IPv6-MUP) on an already-Established neighbor has no effect until the
 session renegotiates. zebra-rs therefore bounces the session on the
 change — the same teardown `clear bgp ... hard` uses — so the new MUP
@@ -17,12 +17,12 @@ capability set (no MUP).
 
 ```
    z1 (AS65001, 192.168.0.1) ── br0 ── z2 (AS65001, 192.168.0.2)
-   both start IPv4-unicast only; mobile-uplane is enabled at runtime.
+   both start IPv4-unicast only; mup is enabled at runtime.
 ```
 
 ## Test Scenarios
 
 | Scenario | Result |
 |----------|--------|
-| Enabling mobile-uplane at runtime renegotiates the MUP capability | |
+| Enabling mup at runtime renegotiates the MUP capability | |
 | Teardown topology | |

--- a/bdd/tests/configs/bgp_mup_capability/z1-1.yaml
+++ b/bdd/tests/configs/bgp_mup_capability/z1-1.yaml
@@ -10,5 +10,5 @@ router:
       afi-safi:
       - name: ipv4
         enabled: true
-      - name: mobile-uplane
+      - name: mup
         enabled: true

--- a/bdd/tests/configs/bgp_mup_capability/z2-1.yaml
+++ b/bdd/tests/configs/bgp_mup_capability/z2-1.yaml
@@ -10,5 +10,5 @@ router:
       afi-safi:
       - name: ipv4
         enabled: true
-      - name: mobile-uplane
+      - name: mup
         enabled: true

--- a/bdd/tests/configs/bgp_mup_e2e/z1.yaml
+++ b/bdd/tests/configs/bgp_mup_e2e/z1.yaml
@@ -1,10 +1,10 @@
 # z1 — MUP Controller (MUP-C). AS 65001, iBGP to z2 (192.168.0.2) with the
-# mobile-uplane afi-safi negotiated. Runs the PFCP/N4 listener on
+# mup afi-safi negotiated. Runs the PFCP/N4 listener on
 # 192.168.0.1:8805 and, when pfcp-inject programs a session whose Network
 # Instance is `access`, originates a Type-1 Session-Transformed route into
 # the `mobile-up` VRF (rd 65000:100, RT export 65000:200) with an End.DT4
 # SID carved from locator LOC1 and the controller-address as next hop. The
-# route is advertised to z2 over the mobile-uplane session.
+# route is advertised to z2 over the mup session.
 segment-routing:
   locator:
   - name: LOC1
@@ -26,22 +26,19 @@ router:
       afi-safi:
       - name: ipv4
         enabled: true
-      - name: mobile-uplane
+      - name: mup
         enabled: true
     vrf:
     - name: mobile-up
       rd: "65000:100"
-      mobile-uplane:
-        route-target:
-          export:
-          - "65000:200"
+      mup:
         route:
           st1:
             dest-network-instance:
               access:
                 exact: access
     afi-safi:
-    - name: mobile-uplane
+    - name: mup
       mup-c:
         enable: true
         controller-address: fcbb:bb01::1
@@ -50,3 +47,12 @@ router:
           port: 8805
         srv6:
           locator: LOC1
+# Top-level VRF: the MUP export route-targets live here now (same
+# `route-target {import|export}` framework as ipv4 / ipv6), not under
+# `router bgp vrf`.
+vrf:
+- name: mobile-up
+  mup:
+    route-target:
+      export:
+      - "65000:200"

--- a/bdd/tests/configs/bgp_mup_e2e/z2.yaml
+++ b/bdd/tests/configs/bgp_mup_e2e/z2.yaml
@@ -1,7 +1,7 @@
 # z2 — MUP route receiver. AS 65001, iBGP to z1 (192.168.0.1) with the
-# mobile-uplane afi-safi negotiated. Plain BGP speaker: it has no
+# mup afi-safi negotiated. Plain BGP speaker: it has no
 # controller and originates nothing, but receives the Type-1 ST route the
-# controller (z1) originates and shows it under `show bgp mobile-uplane`.
+# controller (z1) originates and shows it under `show bgp mup`.
 router:
   bgp:
     global:
@@ -14,5 +14,5 @@ router:
       afi-safi:
       - name: ipv4
         enabled: true
-      - name: mobile-uplane
+      - name: mup
         enabled: true

--- a/bdd/tests/configs/bgp_mup_mixed_afi/z1.yaml
+++ b/bdd/tests/configs/bgp_mup_mixed_afi/z1.yaml
@@ -1,5 +1,5 @@
 # z1 — MUP Controller (MUP-C). AS 65001, iBGP to z2 (192.168.0.2) with the
-# mobile-uplane afi-safi negotiated (both IPv4-MUP and IPv6-MUP). Runs the
+# mup afi-safi negotiated (both IPv4-MUP and IPv6-MUP). Runs the
 # PFCP/N4 listener on 192.168.0.1:8805 and, when pfcp-inject programs a
 # session whose Network Instance is `access`, originates a Type-1 Session-
 # Transformed route into the `mobile-up` VRF (rd 65000:100, RT export
@@ -25,25 +25,30 @@ router:
       afi-safi:
       - name: ipv4
         enabled: true
-      - name: mobile-uplane
+      - name: mup
         enabled: true
     vrf:
     - name: mobile-up
       rd: "65000:100"
-      mobile-uplane:
-        route-target:
-          export:
-          - "65000:200"
+      mup:
         route:
           st1:
             dest-network-instance:
               access:
                 exact: access
     afi-safi:
-    - name: mobile-uplane
+    - name: mup
       mup-c:
         enable: true
         controller-address: fcbb:bb01::1
         pfcp:
           listen-address: 192.168.0.1
           port: 8805
+# Top-level VRF: MUP export route-targets (same `route-target` framework
+# as ipv4 / ipv6). Note there is still NO SRv6 locator anywhere.
+vrf:
+- name: mobile-up
+  mup:
+    route-target:
+      export:
+      - "65000:200"

--- a/bdd/tests/configs/bgp_mup_mixed_afi/z2.yaml
+++ b/bdd/tests/configs/bgp_mup_mixed_afi/z2.yaml
@@ -1,5 +1,5 @@
 # z2 — MUP route receiver. AS 65001, iBGP to z1 (192.168.0.1) with the
-# mobile-uplane afi-safi negotiated (both IPv4-MUP and IPv6-MUP). Plain BGP
+# mup afi-safi negotiated (both IPv4-MUP and IPv6-MUP). Plain BGP
 # speaker: no controller, originates nothing. It receives the Type-1 ST
 # route z1 originates — an IPv6 UE route carrying an IPv4 endpoint — and
 # must parse and show it. A receiver that forced the endpoint family to
@@ -16,5 +16,5 @@ router:
       afi-safi:
       - name: ipv4
         enabled: true
-      - name: mobile-uplane
+      - name: mup
         enabled: true

--- a/bdd/tests/configs/bgp_mup_runtime_enable/z1-1.yaml
+++ b/bdd/tests/configs/bgp_mup_runtime_enable/z1-1.yaml
@@ -1,6 +1,6 @@
 ## tests/configs/bgp_mup_runtime_enable/z1-1.yaml
-# iBGP, IPv4 unicast only — NO mobile-uplane at startup. The scenario
-# enables `afi-safi mobile-uplane` on the LIVE session at runtime; because
+# iBGP, IPv4 unicast only — NO mup at startup. The scenario
+# enables `afi-safi mup` on the LIVE session at runtime; because
 # an AFI/SAFI is a Multiprotocol capability fixed at OPEN time, that change
 # bounces the session (like `clear bgp ... hard`) so the MUP capability is
 # renegotiated and shows up in `show bgp neighbor`.

--- a/bdd/tests/configs/bgp_mup_runtime_enable/z2-1.yaml
+++ b/bdd/tests/configs/bgp_mup_runtime_enable/z2-1.yaml
@@ -1,6 +1,6 @@
 ## tests/configs/bgp_mup_runtime_enable/z2-1.yaml
-# Mirror of z1-1.yaml: iBGP, IPv4 unicast only, no mobile-uplane at
-# startup. mobile-uplane is enabled at runtime by the scenario.
+# Mirror of z1-1.yaml: iBGP, IPv4 unicast only, no mup at
+# startup. mup is enabled at runtime by the scenario.
 router:
   bgp:
     global:

--- a/bdd/tests/features/bgp_mup_capability.feature
+++ b/bdd/tests/features/bgp_mup_capability.feature
@@ -4,7 +4,7 @@ Feature: BGP Mobile User Plane (MUP) capability negotiation
   As a network operator
   I want two zebra-rs instances to negotiate the BGP MUP multiprotocol
   capability (SAFI 85, RFC 9833) for BOTH IPv4-MUP (AFI 1) and IPv6-MUP
-  (AFI 2) from a single `afi-safi mobile-uplane enabled true` knob, and
+  (AFI 2) from a single `afi-safi mup enabled true` knob, and
   bring an iBGP session to Established, so the foundation for MUP route
   exchange (ISD / DSD / ST1 / ST2) is validated before origination is
   implemented.
@@ -31,12 +31,12 @@ Feature: BGP Mobile User Plane (MUP) capability negotiation
   Both peers enable two AFI/SAFIs:
     - ipv4 (so the session has a fallback AF and matches the
       established BDD pattern)
-    - mobile-uplane (the single knob this scenario validates; it
+    - mup (the single knob this scenario validates; it
       negotiates IPv4-MUP and IPv6-MUP)
 
   Config files:
-  - z1-1.yaml: AS 65001, peer to 192.168.0.2, mobile-uplane enabled
-  - z2-1.yaml: AS 65001, peer to 192.168.0.1, mobile-uplane enabled
+  - z1-1.yaml: AS 65001, peer to 192.168.0.2, mup enabled
+  - z2-1.yaml: AS 65001, peer to 192.168.0.1, mup enabled
 
   Scenario: Setup topology and establish iBGP session with MUP capability
     Given a clean test environment
@@ -58,9 +58,9 @@ Feature: BGP Mobile User Plane (MUP) capability negotiation
     And show command "show bgp neighbor 192.168.0.1" in namespace "z2" should contain "IPv4 MUP: advertised and received"
     And show command "show bgp neighbor 192.168.0.1" in namespace "z2" should contain "IPv6 MUP: advertised and received"
 
-  Scenario: show bgp mobile-uplane renders the (empty) MUP RIB header
+  Scenario: show bgp mup renders the (empty) MUP RIB header
     Given the test topology exists
-    Then show command "show bgp mobile-uplane" in namespace "z1" should contain "Network (MUP NLRI)"
+    Then show command "show bgp mup" in namespace "z1" should contain "Network (MUP NLRI)"
 
   Scenario: Teardown topology
     Given the test topology exists

--- a/bdd/tests/features/bgp_mup_e2e.feature
+++ b/bdd/tests/features/bgp_mup_e2e.feature
@@ -51,14 +51,14 @@ Feature: BGP MUP Controller originates Session-Transformed routes from PFCP
     Then BGP session in "z1" to "192.168.0.2" should be "Established"
     And BGP session in "z2" to "192.168.0.1" should be "Established"
     And show command "show bgp neighbor 192.168.0.2" in namespace "z1" should contain "IPv4 MUP: advertised and received"
-    And show command "show bgp mobile-uplane mup-c" in namespace "z1" should contain "PFCP listen : 192.168.0.1:8805"
+    And show command "show bgp mup mup-c" in namespace "z1" should contain "PFCP listen : 192.168.0.1:8805"
 
   Scenario: PFCP session establishment originates an ST1 route received by the peer
     Given the test topology exists
     When I execute "pfcp-inject --target 192.168.0.1 --port 8805 --ue-ipv4 192.0.2.5 --teid 0x12345678 --endpoint 10.0.0.1 --network-instance access" in namespace "z1"
-    Then show command "show bgp mobile-uplane mup-c session" in namespace "z1" should eventually contain "192.0.2.5"
-    And show command "show bgp mobile-uplane" in namespace "z1" should contain "ue=192.0.2.5/32"
-    And show command "show bgp mobile-uplane" in namespace "z2" should eventually contain "ue=192.0.2.5/32"
+    Then show command "show bgp mup mup-c session" in namespace "z1" should eventually contain "192.0.2.5"
+    And show command "show bgp mup" in namespace "z1" should contain "ue=192.0.2.5/32"
+    And show command "show bgp mup" in namespace "z2" should eventually contain "ue=192.0.2.5/32"
 
   # Session deletion / route withdrawal is covered by the `pfcp.rs`
   # `session_deletion_removes_session` unit test and manual validation; a

--- a/bdd/tests/features/bgp_mup_mixed_afi.feature
+++ b/bdd/tests/features/bgp_mup_mixed_afi.feature
@@ -51,16 +51,23 @@ Feature: BGP MUP mixed-AFI Session-Transformed route (IPv6 UE, IPv4 endpoint)
     Then BGP session in "z1" to "192.168.0.2" should be "Established"
     And BGP session in "z2" to "192.168.0.1" should be "Established"
     And show command "show bgp neighbor 192.168.0.2" in namespace "z1" should contain "IPv6 MUP: advertised and received"
-    And show command "show bgp mobile-uplane mup-c" in namespace "z1" should contain "PFCP listen : 192.168.0.1:8805"
+    And show command "show bgp mup mup-c" in namespace "z1" should contain "PFCP listen : 192.168.0.1:8805"
 
   Scenario: IPv6 UE with IPv4 endpoint originates an ST1 route the peer parses
     Given the test topology exists
     When I execute "pfcp-inject --target 192.168.0.1 --port 8805 --ue-ipv6 2001:db8::5 --teid 0x12345678 --endpoint 10.0.0.1 --network-instance access" in namespace "z1"
-    Then show command "show bgp mobile-uplane mup-c session" in namespace "z1" should eventually contain "2001:db8::5"
-    And show command "show bgp mobile-uplane" in namespace "z1" should contain "ue=2001:db8::5/128"
-    And show command "show bgp mobile-uplane" in namespace "z1" should contain "ep=10.0.0.1"
-    And show command "show bgp mobile-uplane" in namespace "z2" should eventually contain "ue=2001:db8::5/128"
-    And show command "show bgp mobile-uplane" in namespace "z2" should contain "ep=10.0.0.1"
+    Then show command "show bgp mup mup-c session" in namespace "z1" should eventually contain "2001:db8::5"
+    And show command "show bgp mup" in namespace "z1" should contain "ue=2001:db8::5/128"
+    And show command "show bgp mup" in namespace "z1" should contain "ep=10.0.0.1"
+    # The export route-target comes from the top-level `vrf mobile-up mup
+    # route-target export` (the ipv4/ipv6 framework), proving it reaches
+    # origination via the RIB -> rib_known_vrfs path.
+    And show command "show bgp mup" in namespace "z1" should contain "RT:65000:200"
+    # Per-VRF MUP view: the global best-path is mirrored into the
+    # mobile-up per-VRF task, so `show bgp vrf mobile-up mup` renders it.
+    And show command "show bgp vrf mobile-up mup" in namespace "z1" should contain "ue=2001:db8::5/128"
+    And show command "show bgp mup" in namespace "z2" should eventually contain "ue=2001:db8::5/128"
+    And show command "show bgp mup" in namespace "z2" should contain "ep=10.0.0.1"
 
   Scenario: Teardown topology
     Given the test topology exists

--- a/bdd/tests/features/bgp_mup_runtime_enable.feature
+++ b/bdd/tests/features/bgp_mup_runtime_enable.feature
@@ -3,7 +3,7 @@
 Feature: BGP MUP capability (re)negotiates when enabled on a live session
   An AFI/SAFI is a BGP Multiprotocol *capability*, advertised once in the
   OPEN — the negotiated set is fixed for the life of the session. So
-  enabling `afi-safi mobile-uplane` (RFC 9833, which turns on BOTH IPv4-MUP
+  enabling `afi-safi mup` (RFC 9833, which turns on BOTH IPv4-MUP
   and IPv6-MUP) on an already-Established neighbor has no effect until the
   session renegotiates. zebra-rs therefore bounces the session on the
   change — the same teardown `clear bgp ... hard` uses — so the new MUP
@@ -16,10 +16,10 @@ Feature: BGP MUP capability (re)negotiates when enabled on a live session
   Test Topology:
   ```
    z1 (AS65001, 192.168.0.1) ── br0 ── z2 (AS65001, 192.168.0.2)
-   both start IPv4-unicast only; mobile-uplane is enabled at runtime.
+   both start IPv4-unicast only; mup is enabled at runtime.
   ```
 
-  Scenario: Enabling mobile-uplane at runtime renegotiates the MUP capability
+  Scenario: Enabling mup at runtime renegotiates the MUP capability
     Given a clean test environment
     When I create bridge "br0"
     And I create namespace "z1" with IP "192.168.0.1/24" on bridge "br0"
@@ -32,19 +32,19 @@ Feature: BGP MUP capability (re)negotiates when enabled on a live session
     Then BGP session in "z1" to "192.168.0.2" should be "Established"
     # Not configured yet: the OPEN carried no MUP capability.
     And show command "show bgp neighbor 192.168.0.2" in namespace "z1" should not contain "IPv4 MUP"
-    # Enable mobile-uplane on BOTH live sessions; each change bounces its
+    # Enable mup on BOTH live sessions; each change bounces its
     # session so the capability is renegotiated on reconnect.
-    When I apply command "set router bgp neighbor 192.168.0.2 afi-safi mobile-uplane enabled true" in namespace "z1"
-    And I apply command "set router bgp neighbor 192.168.0.1 afi-safi mobile-uplane enabled true" in namespace "z2"
+    When I apply command "set router bgp neighbor 192.168.0.2 afi-safi mup enabled true" in namespace "z1"
+    And I apply command "set router bgp neighbor 192.168.0.1 afi-safi mup enabled true" in namespace "z2"
     And I wait 15 seconds for BGP to operate
     Then BGP session in "z1" to "192.168.0.2" should be "Established"
     And show command "show bgp neighbor 192.168.0.2" in namespace "z1" should contain "IPv4 MUP: advertised and received"
     And show command "show bgp neighbor 192.168.0.2" in namespace "z1" should contain "IPv6 MUP: advertised and received"
     And show command "show bgp neighbor 192.168.0.1" in namespace "z2" should contain "IPv4 MUP: advertised and received"
     And show command "show bgp neighbor 192.168.0.1" in namespace "z2" should contain "IPv6 MUP: advertised and received"
-    # The new `show bgp mobile-uplane summary` lists the MUP-capable neighbor.
-    And show command "show bgp mobile-uplane summary" in namespace "z1" should contain "IPv4 MUP Summary"
-    And show command "show bgp mobile-uplane summary" in namespace "z1" should contain "192.168.0.2"
+    # The new `show bgp mup summary` lists the MUP-capable neighbor.
+    And show command "show bgp mup summary" in namespace "z1" should contain "IPv4 MUP Summary"
+    And show command "show bgp mup summary" in namespace "z1" should contain "192.168.0.2"
 
   Scenario: Teardown topology
     Given the test topology exists

--- a/book/src/ch-02-35-bgp-mup.md
+++ b/book/src/ch-02-35-bgp-mup.md
@@ -34,13 +34,13 @@ controller exactly as it would a UPF.
 ```
 
 The MUP control plane (capability negotiation, Loc-RIB, receive, and
-re-advertisement) is always present once the `mobile-uplane` AFI/SAFI is
+re-advertisement) is always present once the `mup` AFI/SAFI is
 negotiated. The **controller** — the PFCP listener and route origination
 — is what the `mup-c` block below turns on.
 
 ## Enabling the MUP capability
 
-`mobile-uplane` is a single AFI/SAFI knob that negotiates **both**
+`mup` is a single AFI/SAFI knob that negotiates **both**
 IPv4-MUP (AFI 1) and IPv6-MUP (AFI 2). Enable it per neighbor like any
 other family:
 
@@ -55,7 +55,7 @@ router bgp {
     afi-safi ipv4 {
       enabled true;
     }
-    afi-safi mobile-uplane {
+    afi-safi mup {
       enabled true;
     }
   }
@@ -64,9 +64,9 @@ router bgp {
 
 ## Configuring the controller
 
-The controller lives under the **global** `mobile-uplane` AFI/SAFI. It
+The controller lives under the **global** `mup` AFI/SAFI. It
 needs three things: an SRv6 locator to carve per-session SIDs from, a
-per-VRF `mobile-uplane` service that maps a PFCP Network Instance to a
+per-VRF `mup` service that maps a PFCP Network Instance to a
 Route Distinguisher / route-targets, and the `mup-c` block itself.
 
 ```
@@ -87,13 +87,10 @@ router bgp {
   }
 
   # Map the PFCP Network Instance "access" to a VPN service: the RD
-  # stamped on the ST route and the route-targets it carries.
+  # stamped on the ST route and the ST route type it originates.
   vrf mobile-up {
     rd 65000:100;
-    mobile-uplane {
-      route-target {
-        export 65000:200;
-      }
+    mup {
       route st1 {
         dest-network-instance access {
           exact access;
@@ -103,7 +100,7 @@ router bgp {
   }
 
   # Turn on the controller: the PFCP/N4 listener + route origination.
-  afi-safi mobile-uplane {
+  afi-safi mup {
     mup-c {
       enable true;
       controller-address fcbb:bb01::1;
@@ -114,6 +111,16 @@ router bgp {
       srv6 {
         locator LOC1;
       }
+    }
+  }
+}
+
+# The export route-targets the ST routes carry live on the top-level VRF,
+# the same `route-target {import|export}` framework as ipv4 / ipv6.
+vrf mobile-up {
+  mup {
+    route-target {
+      export 65000:200;
     }
   }
 }
@@ -128,15 +135,20 @@ router bgp {
   hop on every originated ST route.
 * **`pfcp`** sets the N4 listener bind address and port (default
   `[::]:8805`).
-* **`srv6 locator`** names the locator per-session SIDs are carved from
-  (the same pool an `encapsulation srv6` VRF draws its End.DT46 SID
-  from).
+* **`srv6 locator`** is **reserved** for the non-default mode where the
+  controller pushes an explicit SID; in the default mode it is unused.
+  Per draft-ietf-bess-mup-safi the controller originates ST routes
+  **without** a service SID — the receiving PE derives forwarding from
+  its own ISD/DSD routes — so no per-session SID is allocated.
 
 The **`route`** type in the VRF selects what is originated: `st1` (the
 N6 / downlink VRF) originates a **Type-1 ST** route carrying the UE
 prefix; `st2` (the N3 / uplink VRF) originates a **Type-2 ST** route
 carrying the core endpoint and TEID. The `dest-network-instance ... exact`
-value is matched against the PFCP session's Network Instance.
+value is matched against the PFCP session's Network Instance. The export
+route-targets the ST route carries come from the top-level
+`vrf <name> mup route-target export` — the same `route-target` framework
+as `ipv4` / `ipv6`.
 
 ## From PFCP session to ST route
 
@@ -145,24 +157,26 @@ When an SMF establishes a session, the controller:
 1. extracts the UE IP address, the access-side F-TEID (TEID + GTP
    endpoint), and the Network Instance from the PFCP Session
    Establishment Request;
-2. correlates the Network Instance against the per-VRF `mobile-uplane`
-   config to find the RD, the route-targets, and the direction;
-3. allocates an **SRv6 service SID** (End.DT4 for an IPv4 UE, End.DT6
-   for IPv6) from the configured locator;
-4. originates the ST route into the MUP Loc-RIB with the
-   controller-address as next hop, the VRF's route-targets, and the SID
-   carried in the SRv6 L3 Service Prefix-SID attribute;
-5. advertises it to every `mobile-uplane` peer.
+2. correlates the Network Instance against the per-VRF `mup` config to
+   find the RD and the ST route type (`st1` / `st2`), and the VRF's
+   export route-targets from the top-level VRF;
+3. originates the ST route into the MUP Loc-RIB with the
+   controller-address as next hop and the VRF's export route-targets —
+   and **no** service SID (PE-derived forwarding, the draft default);
+4. advertises it to every `mup` peer.
 
-A Session Deletion withdraws the route and returns the SID to the pool.
+A Session Deletion withdraws the route. For an IPv6 UE whose GTP
+endpoint is IPv4 (IPv4 N3 transport), the endpoint/source address family
+is taken from its own length octet, so the route rides the IPv6-MUP AFI
+while carrying the IPv4 endpoint.
 
 ## Showing MUP state
 
-`show bgp mobile-uplane` renders the configured per-VRF services and the
+`show bgp mup` renders the configured per-VRF services and the
 MUP Loc-RIB:
 
 ```
-# show bgp mobile-uplane
+# show bgp mup
 MUP VRFs:
   mobile-up: rd=65000:100 encap/ST1 ni=access route-targets=1
 
@@ -172,18 +186,31 @@ MUP VRFs:
        RT:65000:200
 ```
 
-`show bgp mobile-uplane mup-c` shows the controller status, and the
+`show bgp vrf <name> mup` renders just the ST routes belonging to one
+VRF (those whose RD matches that VRF's `rd`). The authoritative MUP
+Loc-RIB stays on the global instance; the matching best-paths are
+mirrored into the per-VRF task so the per-VRF view renders them:
+
+```
+# show bgp vrf mobile-up mup
+   Network (MUP NLRI)                                   Next Hop
+ *> [ST1][65000:100][ue=192.0.2.5/32][teid=305419896][qfi=0][ep=10.0.0.1]
+       next-hop fcbb:bb01::1  weight 32768
+       RT:65000:200
+```
+
+`show bgp mup mup-c` shows the controller status, and the
 `session` / `association` sub-commands show the learned PFCP state:
 
 ```
-# show bgp mobile-uplane mup-c
+# show bgp mup mup-c
 MUP controller (MUP-C)
   Admin state : enabled
   PFCP listen : 192.168.0.1:8805
   Associations: 1
   Sessions    : 1
 
-# show bgp mobile-uplane mup-c session
+# show bgp mup mup-c session
 SEID       UE address     TEID         Endpoint     QFI   Network-Instance
 1          192.0.2.5      0x12345678   10.0.0.1     -     access
 ```
@@ -208,9 +235,9 @@ pfcp-inject --target 192.168.0.1 --port 8805 \
             --endpoint 10.0.0.1 --network-instance access
 ```
 
-After it runs, the session appears under `show bgp mobile-uplane mup-c
+After it runs, the session appears under `show bgp mup mup-c
 session` and the controller's ST route appears in `show bgp
-mobile-uplane` on both the controller and its peers.
+mup` on both the controller and its peers.
 
 ## Scope and limitations
 

--- a/docs/design/bgp-mup-followups.md
+++ b/docs/design/bgp-mup-followups.md
@@ -10,17 +10,19 @@ phases, committed and pushed (rebased onto `origin/main`):
   (length up to 64/160, high-aligned TEID). GoBGP byte-exact interop
   vectors added. The MUP Extended Community (`0x0c`) and SAFI 85 were
   already present.
-- **P1 negotiation** — `mobile-uplane` afi-safi knob that expands to
+- **P1 negotiation** — `mup` afi-safi knob that expands to
   *both* `(Ip, Mup)` and `(Ip6, Mup)` capabilities (`mp_family_expand`),
   per-neighbor and per-group.
 - **P2 Loc-RIB + receive + show** — full-NLRI `MupPrefix` key + flat
   `LocalRibMupTable`; `route_mup_update`/`route_mup_withdraw` wired into
   the `MpReachAttr::Mup` / `MpUnreachAttr::Mup` receive arms; `adj_in.mup`;
-  `route_clean` peer-down; `show bgp mobile-uplane` route table.
-- **P3 per-VRF config** — `router bgp vrf <name> mobile-uplane`:
-  `route-target export` + `route {st1|st2} dest-network-instance
-  {access|core} exact <ni>`; the config-driven `MUP VRFs:` block in
-  `show bgp mobile-uplane`.
+  `route_clean` peer-down; `show bgp mup` route table.
+- **P3 per-VRF config** — `router bgp vrf <name> mup route {st1|st2}
+  dest-network-instance {access|core} exact <ni>` (the ST origination
+  binding), plus the export/import route-targets on the top-level
+  `vrf <name> mup route-target {export|import}` (RIB-owned, the same
+  framework as ipv4 / ipv6, surfaced to BGP via `rib_known_vrfs`); the
+  config-driven `MUP VRFs:` block in `show bgp mup`.
 - **P4 advertise / re-originate** — `MupPrefix::afi()`/`to_route()`,
   `adj_out.mup`, AFI-aware `route_advertise_mup_to_peers` /
   `route_withdraw_mup_to_peers` (EVPN suppression + eBGP-next-hop-self /
@@ -43,6 +45,71 @@ suggested PR size**; several are now marked **DONE** by P5.
 Standing guidance still applies: smallest meaningful slice first, let
 the user redirect, one branch / one PR at a time.
 
+## Draft-default forwarding & mixed-AFI (2026-06-23)
+
+Two post-P5 corrections aligned the controller and codec with
+draft-ietf-bess-mup-safi (merged as PR #1614):
+
+**No SID allocation by the controller — draft-default forwarding.** The
+MUP-C no longer allocates or advertises an SRv6 service SID on the ST
+routes it originates. Per the draft the **default** is that the receiving
+PE derives the forwarding SID from its *own* ISD / DSD routes: it matches
+an ST route against the segment a co-located ISD (GTP4.E / GTP6.E) or DSD
+(End.DT4/6) route advertises and programs the FIB itself. So an
+originated ST route now carries only the controller-address next hop and
+the VRF's route-target exports — `alloc_mup_sid` / `mup_sid_behavior` and
+the per-session SID-function bookkeeping were removed, and
+`build_mup_attr` no longer attaches the SRv6 L3 Service Prefix-SID.
+Carrying an *explicit* SID (via Prefix-SID or the `0x0c` MUP Direct-SID
+extended community) is the **non-default, controller-pushed** mode; it
+can be reintroduced behind a knob if a deployment needs it, and the
+now-unused `mup-c srv6 locator` config is retained as the natural home
+for that mode.
+
+**Mixed-AFI T1ST endpoint/source.** A Type-1 ST route's endpoint (gNB)
+and source (UPF) address family is now decided by its own length octet
+(32 = IPv4, 128 = IPv6), **independent of the outer AFI**; only the UE
+prefix follows the outer AFI. This lets an IPv6 UE route carry an IPv4
+gNB/UPF — the real 5G case where the N3 transport is IPv4 — matching
+GoBGP. (T2ST keeps its single endpoint AFI-tied; it has no second address
+that could differ.) Covered end-to-end by the `@bgp_mup_mixed_afi` BDD
+feature (#14): an IPv6 UE + IPv4 endpoint session, with no SRv6 locator
+configured anywhere, originated by z1 and received/parsed by z2.
+
+## CLI rename, RT framework, per-VRF show (2026-06-23)
+
+Three follow-on changes (post-PR #1614, not yet merged):
+
+**`mobile-uplane` → `mup` rename.** The CLI / YANG keyword is now `mup`
+everywhere: the afi-safi enum (`neighbor X afi-safi mup`,
+`router bgp afi-safi mup mup-c`), `show bgp mup`, `router bgp vrf <name>
+mup`, and every matching callback-path string + YANG node name (renamed
+in lockstep). Internal Rust identifiers (`mobile_uplane`,
+`BgpVrfMobileUplane`, `MupSrv6*`) are unchanged — not user-facing.
+
+**Export RT moved to the top-level VRF framework.** The MUP export (and
+import) route-targets now live on `vrf <name> mup route-target
+{export|import}` — the same `vrf-route-target-policy` grouping as
+`ipv4` / `ipv6`, owned by the RIB. They flow RIB → BGP via
+`Message::VrfRouteTargets` / `RibRx::VrfRouteTargets`
+(`mup_{import,export}_rts`) into `RibKnownVrf`, and `build_mup_origination`
+reads the export set from `rib_known_vrfs`. **Consequence:** the MUP RT
+now requires the VRF's kernel device to exist (it rides the RIB `Vrf`
+row), exactly like the ipv4/ipv6 RT — the old `router bgp vrf <name> mup
+route-target export` is gone. The import set is parsed and carried but
+not yet consumed (reserved for the MUP import dispatch, §3 below).
+
+**`show bgp vrf <name> mup`.** The MUP Loc-RIB is global, but the
+command renders per-VRF: the global `mup_apply_selected` mirrors each
+best-path to the per-VRF `BgpVrf` task whose `rd` matches the route's RD
+(`BgpVrfMsg::Mup{Update,Withdraw}`, display-only — it touches just
+`local_rib.mup.selected`). The manager's existing `vrf_redirect_split`
+routes `show bgp vrf <name> mup` into that task, which renders it via the
+new `/show/bgp/mup` arm in `process_vrf_show` (`show_bgp_vrf_mup`). The
+per-VRF task spawns from `router bgp vrf <name>` config (placeholder
+context when the kernel VRF isn't up yet), so the redirect target exists.
+A `/show/bgp/vrf/mup` global handler is the not-running fallback.
+
 ## Receive / Loc-RIB
 
 ### 1. Inbound route-policy for MUP
@@ -52,7 +119,7 @@ the user redirect, one branch / one PR at a time.
 
 **Why deferred:** No per-AFI MUP policy binding exists (the `afi-safi
 <name> policy {in,out}` / `prefix-set` knobs don't yet accept
-`mobile-uplane`). Parity with EVPN, which also applies no inbound policy.
+`mup`). Parity with EVPN, which also applies no inbound policy.
 
 **Where:** `route_mup_update` in `zebra-rs/src/bgp/route.rs`; the per-AFI
 policy plumbing in `zebra-rs/src/bgp/config.rs` (`config_afi_safi_policy_*`)
@@ -76,7 +143,7 @@ MUP routes drive forwarding (P6) or feed the controller's resolution.
 
 ### 3. VRF import (route-target → VRF) for received MUP routes
 
-**What:** The per-VRF `mobile-uplane route-target export` set (P3) is
+**What:** The per-VRF `mup route-target export` set (P3) is
 stored but there is no import dispatch that pulls received MUP routes
 into a VRF by RT (unlike VPNv4/EVPN's `VrfImportDispatcher`).
 
@@ -126,18 +193,18 @@ mirror the EVPN LLGR two-branch.
 
 ### 6. Full `MUP controller:` show block — **DONE (P5)**
 
-`show bgp mobile-uplane mup-c [session|association]` now renders the
+`show bgp mup mup-c [session|association]` now renders the
 controller runtime (admin state, PFCP listen address, association /
 session counts, and the per-session table) from the BGP-held
 `mup_c_view` the controller feeds over `Message::MupC`. The
 `zenoh source:` line is moot (the northbound is PFCP, not zenoh); the
 `vpnv6 ue-routes:` list was dropped (the ST routes carry the SRv6
-service directly). `show bgp mobile-uplane` still renders the `MUP VRFs:`
+service directly). `show bgp mup` still renders the `MUP VRFs:`
 block (P3) + the route table (P2), now populated by originated ST routes.
 
 **Where:** `show_bgp_mup_c*` / `render_mup_vrfs` in `zebra-rs/src/bgp/show.rs`.
 
-### 7. `show bgp mobile-uplane` JSON output
+### 7. `show bgp mup` JSON output
 
 **What:** The JSON branch returns the `"[]"` placeholder; only text is
 implemented.
@@ -246,11 +313,15 @@ node (z1) is driven by `tools/pfcp-inject` (a PFCP SMF simulator that
 supplies the originator the harness otherwise lacks), originates the ST1
 route, and the peer (z2) receives it. The earlier
 `bgp_mup_capability.feature` covers session-up + capability negotiation.
-Both need root netns and are excluded from CI gates per
+`bgp_mup_mixed_afi.feature` (`@bgp_mup_mixed_afi`) is a variant covering
+the *Draft-default forwarding & mixed-AFI* corrections above — an IPv6 UE
+with an IPv4 endpoint, originated with no SRv6 locator configured, and
+parsed by the peer under the IPv6-MUP AFI. All need root netns and are
+excluded from CI gates per
 [`zebra-rs-ci-and-merge-rules`](../../zebra-rs-ci-and-merge-rules.md) —
-run live (`make -C bdd bgp_mup_e2e`, with `pfcp-inject` staged on PATH).
-Remaining: a receive-from-peer / RR variant (a third node reflecting the
-ST route) is still worth adding.
+run live (`make -C bdd bgp_mup_e2e` / `make -C bdd bgp_mup_mixed_afi`,
+with `pfcp-inject` staged on PATH). Remaining: a receive-from-peer / RR
+variant (a third node reflecting the ST route) is still worth adding.
 
 **Where:** `bdd/tests/features/bgp_mup_e2e.feature`, `tools/pfcp-inject/`.
 
@@ -279,42 +350,47 @@ session schema question is therefore answered by PFCP itself (no custom
 zenoh encoding to design).
 
 * **Config home:** under the BGP instance at `router bgp afi-safi
-  mobile-uplane mup-c { enable; controller-address; pfcp {…}; srv6 {…} }`
+  mup mup-c { enable; controller-address; pfcp {…}; srv6 {…} }`
   — so the controller is spawned by the BGP task and handed its `Message`
   channel, the way a per-VRF BGP instance is. Module: `zebra-rs/src/mup-c/`
   (`inst` task, `pfcp` socket/handlers, `session`/`assoc` tables); spawn /
   reconfigure / teardown in `Bgp::apply_mup_c_commit_diff`.
 * **PR-A (ingest):** PFCP listener (own tokio UDP socket); Association
   Setup/Release, Heartbeat, Session Establishment/Modification/Deletion;
-  per-session table; `show bgp mobile-uplane mup-c [session|association]`.
+  per-session table; `show bgp mup mup-c [session|association]`.
   Hardened (commit security review): session-ownership check on
   Modify/Delete, association precondition on Establish, bounded tables.
 * **PR-B (origination):** `Bgp::originate_mup_route` correlates the
-  session's Network Instance → a per-VRF `mobile-uplane` config (RD /
-  route-targets / direction), allocates an SRv6 SID (`alloc_mup_sid`,
-  same pool as the L3VPN End.DT46 path), builds the ST NLRI
-  (`encapsulation`→T1ST UE prefix; `decapsulation`→T2ST endpoint+TEID)
-  and attributes (controller-address next hop, RT exports, SRv6 L3
-  Service Prefix-SID End.DT4/DT6), and originates via the P4 advertise
-  path. Tracked per session SEID for stable withdraw.
+  session's Network Instance → a per-VRF `mup` config (RD /
+  route-targets / `route {st1|st2}` direction), builds the ST NLRI
+  (`st1`→T1ST UE prefix; `st2`→T2ST endpoint+TEID) and attributes
+  (controller-address next hop, RT exports), and originates via the P4
+  advertise path. Tracked per session SEID for stable withdraw. As of
+  2026-06-23 it allocates **no** SRv6 SID — see *Draft-default
+  forwarding* above. (PR-B as originally landed did allocate an
+  End.DT4/6 Prefix-SID; that was removed to match the draft default.)
 * **PR-C (e2e):** `tools/pfcp-inject` (PFCP SMF simulator) + the
   `@bgp_mup_e2e` BDD feature (#14). Live-validated end-to-end.
 
 **Deferred from P5:** the VPNv6 UE host route originally listed here was
-dropped — the ST routes carry the per-session SRv6 service directly.
-Heartbeat-driven eviction of idle PFCP associations and per-source rate
-limiting are follow-ups (the tables are bounded by hard caps today). The
-controller draws SIDs from the **global** resolved locator; honouring a
-distinct `mup-c srv6 locator` override is a small follow-up.
+dropped. Heartbeat-driven eviction of idle PFCP associations and
+per-source rate limiting are follow-ups (the tables are bounded by hard
+caps today). The controller-pushed *explicit*-SID origination mode (and
+its `mup-c srv6 locator` source) is a follow-up — the default is now
+PE-derived forwarding, see *Draft-default forwarding* above.
 
 ### P6 — SRv6-mobile dataplane
 
-**What:** Install the FIB state for MUP-derived routes. Per the chosen
-"install what the kernel supports" scope: program `End.DT4/6` + the
-route-level SIDs we already do for L3VPN/SRv6, and flag the GTP
-behaviours (`End.M.GTP4.E` / `End.M.GTP6.E` / `GTP4.E` / `GTP6.E`) as
-needing VPP or eBPF — mainline Linux `seg6local` has no `End.M.GTP*`
-actions. See the kernel-support note in
+**What:** Install the FIB state that actually forwards MUP traffic. With
+the draft-default model (see *Draft-default forwarding* above), the PE
+receiving an ST route resolves its forwarding SID from the matching
+ISD / DSD route rather than from a SID carried on the ST route — so P6
+gains an *ISD/DSD-route → segment-SID resolution* step ahead of the FIB
+write. Per the chosen "install what the kernel supports" scope: program
+`End.DT4/6` + the route-level SIDs we already do for L3VPN/SRv6, and flag
+the GTP behaviours (`End.M.GTP4.E` / `End.M.GTP6.E` / `GTP4.E` /
+`GTP6.E`) as needing VPP or eBPF — mainline Linux `seg6local` has no
+`End.M.GTP*` actions. See the kernel-support note in
 [`bgp-prefix-sid-rfc9252.md`](bgp-prefix-sid-rfc9252.md) and
 [`srv6-l3vpn` forwarding notes](../../zebra-rs-srv6-l3vpn-forwarding-bugs.md).
 
@@ -326,7 +402,7 @@ actions. See the kernel-support note in
 
 By value-per-line, if picking one up independently of P5/P6:
 
-1. **#7 (`show bgp mobile-uplane` JSON)** — cheap, mechanical, zero risk.
+1. **#7 (`show bgp mup` JSON)** — cheap, mechanical, zero risk.
 2. **#11 (eBGP v6 next-hop-self)** — small RFC-correctness fix.
 3. **#4 (RFC 7606 attr-level treat-as-withdraw for MUP)** — closes a
    small correctness/robustness gap on malformed UPDATEs.

--- a/tools/pfcp-inject/src/main.rs
+++ b/tools/pfcp-inject/src/main.rs
@@ -1,7 +1,7 @@
 //! `pfcp-inject` — a minimal PFCP/N4 SMF simulator.
 //!
 //! Drives the zebra-rs BGP MUP controller (`router bgp afi-safi
-//! mobile-uplane mup-c`) in tests: it sends a PFCP Association Setup
+//! mup mup-c`) in tests: it sends a PFCP Association Setup
 //! Request followed by a Session Establishment Request describing one
 //! mobile session (UE IP, access-side F-TEID, Network Instance), so the
 //! controller learns the session and originates a MUP Session-Transformed
@@ -72,7 +72,7 @@ struct Args {
     #[arg(long, default_value = "10.0.0.1")]
     endpoint: IpAddr,
 
-    /// Network Instance (APN/DNN) — matched against a VRF `mobile-uplane`
+    /// Network Instance (APN/DNN) — matched against a VRF `mup`
     /// config on the controller.
     #[arg(long, default_value = "access")]
     network_instance: String,

--- a/zebra-rs/src/bgp/config.rs
+++ b/zebra-rs/src/bgp/config.rs
@@ -1520,7 +1520,7 @@ fn config_afi_safi(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Option<()> {
         // set through the default < group < explicit precedence. A Delete
         // simply forgets the statement: IPv4 unicast falls back to the
         // built-in default (or the group's opinion), other families to
-        // off (or the group's opinion). The `mobile-uplane` name expands to
+        // off (or the group's opinion). The `mup` name expands to
         // both the IPv4 and IPv6 MUP families (RFC 9833).
         if op.is_set() {
             let enabled = enabled?;
@@ -1718,12 +1718,12 @@ fn config_segmentation(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Option<()
     Some(())
 }
 
-// --- MUP controller config (afi-safi mobile-uplane mup-c) -------------
+// --- MUP controller config (afi-safi mup mup-c) -------------
 //
-// `router bgp afi-safi mobile-uplane mup-c { enable; controller-address;
+// `router bgp afi-safi mup mup-c { enable; controller-address;
 // pfcp { node-id; listen-address; port }; srv6 { locator }; architecture }`
 // (augmented in by zebra-bgp-mup-controller.yang). Every callback gates on
-// the list entry's afi-safi being `mobile-uplane` (Safi::Mup) and mutates
+// the list entry's afi-safi being `mup` (Safi::Mup) and mutates
 // the staged `mup_c_config`, marking it dirty. The spawn / teardown /
 // reconfigure of the controller task happens at CommitEnd in
 // `Bgp::apply_mup_c_commit_diff` — these only stage config.
@@ -4082,15 +4082,11 @@ impl Bgp {
             super::vrf_config::config_vrf_evpn_advertise_ipv6,
         );
         self.callback_add(
-            "/router/bgp/vrf/mobile-uplane/route-target/export",
-            super::vrf_config::config_vrf_mup_rt_export,
-        );
-        self.callback_add(
-            "/router/bgp/vrf/mobile-uplane/route/st2/dest-network-instance/core/exact",
+            "/router/bgp/vrf/mup/route/st2/dest-network-instance/core/exact",
             super::vrf_config::config_vrf_mup_route_st2,
         );
         self.callback_add(
-            "/router/bgp/vrf/mobile-uplane/route/st1/dest-network-instance/access/exact",
+            "/router/bgp/vrf/mup/route/st1/dest-network-instance/access/exact",
             super::vrf_config::config_vrf_mup_route_st1,
         );
 
@@ -4238,7 +4234,7 @@ impl Bgp {
         // Flags EC's segmentation bit rides the originated Type-3 IMET route.
         self.callback_add("/router/bgp/afi-safi/segmentation", config_segmentation);
 
-        // MUP controller (`afi-safi mobile-uplane mup-c …`, RFC 9833).
+        // MUP controller (`afi-safi mup mup-c …`, RFC 9833).
         // Augmented in by zebra-bgp-mup-controller.yang; the controller
         // task is spawned/torn down at CommitEnd by `apply_mup_c_commit_diff`.
         self.callback_add("/router/bgp/afi-safi/mup-c/enable", config_mup_c_enable);
@@ -6121,7 +6117,7 @@ mod neighbor_group_wiring_tests {
         // Enabling a new family on the group bounces the Established member.
         config_neighbor_group_afi_safi_enabled(
             &mut bgp,
-            arg_words(&["G", "mobile-uplane", "true"]),
+            arg_words(&["G", "mup", "true"]),
             ConfigOp::Set,
         )
         .unwrap();
@@ -6134,7 +6130,7 @@ mod neighbor_group_wiring_tests {
         // A redundant set (no family-set change) must not bounce.
         config_neighbor_group_afi_safi_enabled(
             &mut bgp,
-            arg_words(&["G", "mobile-uplane", "true"]),
+            arg_words(&["G", "mup", "true"]),
             ConfigOp::Set,
         )
         .unwrap();
@@ -6146,7 +6142,7 @@ mod neighbor_group_wiring_tests {
         // Disabling the family again also bounces (capability withdrawn).
         config_neighbor_group_afi_safi_enabled(
             &mut bgp,
-            arg_words(&["G", "mobile-uplane", "true"]),
+            arg_words(&["G", "mup", "true"]),
             ConfigOp::Delete,
         )
         .unwrap();
@@ -6198,12 +6194,12 @@ mod neighbor_group_wiring_tests {
     /// fixed at OPEN time, so the session must bounce (`Event::Stop`, the
     /// `clear bgp ... hard` teardown) to renegotiate. This is NOT
     /// MUP-specific — pinned across IPv6 unicast, EVPN, VPNv4 and
-    /// mobile-uplane. A peer that has not Established yet carries the change
+    /// mup. A peer that has not Established yet carries the change
     /// in its first OPEN (no bounce); a redundant set leaves the family set
     /// unchanged (no bounce).
     #[tokio::test]
     async fn afi_safi_change_bounces_established_peer() {
-        for fam in ["ipv6", "evpn", "vpnv4", "mobile-uplane"] {
+        for fam in ["ipv6", "evpn", "vpnv4", "mup"] {
             let mut bgp = fresh_bgp();
             config_peer(&mut bgp, arg_words(&["10.0.0.1"]), ConfigOp::Set).unwrap();
             let peer_ident = bgp.peers.get(&peer_addr()).unwrap().ident;

--- a/zebra-rs/src/bgp/inst.rs
+++ b/zebra-rs/src/bgp/inst.rs
@@ -119,9 +119,9 @@ pub enum Message {
     },
     /// A session/association change reported by the in-process MUP
     /// controller (`src/mup-c/`), which the BGP task spawns when
-    /// `afi-safi mobile-uplane mup-c enable true` is committed and hands
+    /// `afi-safi mup mup-c enable true` is committed and hands
     /// `self.tx`. Recorded in [`Bgp::mup_c_view`] for `show bgp
-    /// mobile-uplane mup-c`; MUP route origination from these lands in a
+    /// mup mup-c`; MUP route origination from these lands in a
     /// follow-up. Mirrors the IS-IS `BgpLs` producer seam.
     MupC(crate::mup_c::inst::MupCEvent),
     /// `router bgp port <0-65535>` changed: close the BGP listen
@@ -407,6 +407,12 @@ pub struct RibKnownVrf {
     pub export_rts_v4: std::collections::BTreeSet<bgp_packet::RouteDistinguisher>,
     pub import_rts_v6: std::collections::BTreeSet<bgp_packet::RouteDistinguisher>,
     pub export_rts_v6: std::collections::BTreeSet<bgp_packet::RouteDistinguisher>,
+    /// MUP (mup / SAFI 85) RT sets from the top-level
+    /// `vrf <name> mup route-target {import,export}`. The
+    /// export set tags the controller-originated ST routes; the import
+    /// set is reserved for the MUP import dispatch follow-up.
+    pub mup_import_rts: std::collections::BTreeSet<bgp_packet::RouteDistinguisher>,
+    pub mup_export_rts: std::collections::BTreeSet<bgp_packet::RouteDistinguisher>,
     /// Inter-AS Option AB: copied from the VRF's BGP config
     /// (`inter_as_hybrid`). Lets the shared VPNv4/VPNv6 receive path
     /// (which only borrows `rib_known_vrfs`, not the config map) tell
@@ -634,7 +640,7 @@ pub struct Bgp {
     /// `evpn_originate_imet`; toggling it re-originates all IMET routes via
     /// `reoriginate_all_imet`.
     pub segmentation: bool,
-    /// MUP controller (`afi-safi mobile-uplane mup-c`) config, staged by
+    /// MUP controller (`afi-safi mup mup-c`) config, staged by
     /// the config callbacks and applied at `CommitEnd` by
     /// [`Self::apply_mup_c_commit_diff`].
     pub mup_c_config: crate::mup_c::inst::MupCConfig,
@@ -642,7 +648,7 @@ pub struct Bgp {
     /// aborts the controller task (the VRF-handle idiom).
     pub mup_c: Option<crate::mup_c::inst::MupCHandle>,
     /// Read-only snapshot of the controller's sessions / associations,
-    /// fed by `Message::MupC` and rendered by `show bgp mobile-uplane
+    /// fed by `Message::MupC` and rendered by `show bgp mup
     /// mup-c`.
     pub mup_c_view: crate::mup_c::inst::MupCView,
     /// Set by the MUP-C config callbacks when a `mup-c` leaf changed this
@@ -1974,7 +1980,7 @@ impl Bgp {
             Message::MupC(ev) => {
                 // A session/association change from the in-process MUP
                 // controller. Drive MUP route origination, then record it
-                // in the read-only view `show bgp mobile-uplane mup-c`
+                // in the read-only view `show bgp mup mup-c`
                 // renders.
                 use crate::mup_c::inst::MupCEvent;
                 match &ev {
@@ -3119,6 +3125,14 @@ impl Bgp {
                         .as_ref()
                         .map(|p| p.export_rts_v6.clone())
                         .unwrap_or_default(),
+                    mup_import_rts: prev_rts
+                        .as_ref()
+                        .map(|p| p.mup_import_rts.clone())
+                        .unwrap_or_default(),
+                    mup_export_rts: prev_rts
+                        .as_ref()
+                        .map(|p| p.mup_export_rts.clone())
+                        .unwrap_or_default(),
                     inter_as_hybrid: self
                         .vrfs
                         .get(&name)
@@ -3148,6 +3162,8 @@ impl Bgp {
                 ipv4_export_rts,
                 ipv6_import_rts,
                 ipv6_export_rts,
+                mup_import_rts,
+                mup_export_rts,
             } => {
                 // Mutate-in-place if a `VrfAdd` already populated
                 // the row; otherwise stage the RT cache so a later
@@ -3169,6 +3185,8 @@ impl Bgp {
                 entry.export_rts_v4 = ipv4_export_rts;
                 entry.import_rts_v6 = ipv6_import_rts;
                 entry.export_rts_v6 = ipv6_export_rts;
+                entry.mup_import_rts = mup_import_rts;
+                entry.mup_export_rts = mup_export_rts;
                 entry.inter_as_hybrid = hybrid;
                 // Close the export / RT-learning race: a per-VRF route can
                 // be exported into `v4vpn`/`v6vpn` before this RT policy
@@ -5403,6 +5421,8 @@ mod tests {
                 export_rts_v4: BTreeSet::new(),
                 import_rts_v6: BTreeSet::new(),
                 export_rts_v6: BTreeSet::new(),
+                mup_import_rts: BTreeSet::new(),
+                mup_export_rts: BTreeSet::new(),
                 inter_as_hybrid: false,
             }
         }
@@ -5419,6 +5439,8 @@ mod tests {
                 export_rts_v4: BTreeSet::new(),
                 import_rts_v6,
                 export_rts_v6: BTreeSet::new(),
+                mup_import_rts: BTreeSet::new(),
+                mup_export_rts: BTreeSet::new(),
                 inter_as_hybrid: false,
             }
         }

--- a/zebra-rs/src/bgp/neighbor_group.rs
+++ b/zebra-rs/src/bgp/neighbor_group.rs
@@ -223,7 +223,7 @@ pub fn config_neighbor_group_afi_safi_enabled(
     match op {
         ConfigOp::Set => {
             let enabled = args.boolean()?;
-            // `mobile-uplane` toggles both MUP families at once (RFC 9833).
+            // `mup` toggles both MUP families at once (RFC 9833).
             for fam in mp_family_expand(family) {
                 group.afi_safi.entry(fam).or_default().enabled = enabled;
             }
@@ -862,7 +862,7 @@ pub(super) fn sweep_members(
     }
 }
 
-/// MUP (RFC 9833) is exposed through a single `mobile-uplane` config
+/// MUP (RFC 9833) is exposed through a single `mup` config
 /// name that enables *both* the IPv4 (AFI 1) and IPv6 (AFI 2) MUP
 /// families at once. Every other family is one config name → one
 /// `(AFI, SAFI)`. Expand a parsed family into the concrete set of
@@ -1420,7 +1420,7 @@ mod tests {
 
     #[test]
     fn mp_family_expand_fans_out_mup_to_both_afis() {
-        // `mobile-uplane` enables both IPv4-MUP and IPv6-MUP (RFC 9833).
+        // `mup` enables both IPv4-MUP and IPv6-MUP (RFC 9833).
         assert_eq!(
             mp_family_expand(AfiSafi::new(Afi::Ip, Safi::Mup)),
             vec![

--- a/zebra-rs/src/bgp/route.rs
+++ b/zebra-rs/src/bgp/route.rs
@@ -1739,7 +1739,7 @@ impl LocalRibEvpnTable {
 
 /// Flat Loc-RIB table for MUP (SAFI 85) routes — exact-match keyed by
 /// `MupPrefix`. The RD is part of the key, so one flat map holds every RD
-/// and `show bgp mobile-uplane` walks it grouped by route type. Mirrors
+/// and `show bgp mup` walks it grouped by route type. Mirrors
 /// `LocalRibEvpnTable`; best-path reuses the NLRI-agnostic `BgpRib`
 /// comparator.
 #[derive(Debug, Default)]
@@ -7346,7 +7346,7 @@ pub fn route_evpn_withdraw(ident: usize, route: &EvpnRoute, bgp: &mut BgpTop, pe
 /// Phase 2 is receive + show only: there is no inbound route-policy, no
 /// VRF import, no re-advertise, and no FIB install yet (those land in
 /// P3/P4/P6). The caller stamps the MP_REACH next-hop into `attr` so
-/// `show bgp mobile-uplane` can render it. Loop detection mirrors
+/// `show bgp mup` can render it. Loop detection mirrors
 /// `route_evpn_update` — a route carrying our own AS / ORIGINATOR_ID /
 /// CLUSTER_LIST is dropped silently.
 pub fn route_mup_update(
@@ -7583,7 +7583,7 @@ pub fn route_withdraw_mup_to_peers(prefix: MupPrefix, peers: &mut PeerMap) {
 /// Build a Route-Target extended community from a stored Route
 /// Distinguisher. An RT shares the RD's 8-octet wire format — the RD
 /// type becomes the EC high-order type and the low-order type is `0x02`
-/// (Route Target) — so the per-VRF `mobile-uplane route-target export`
+/// (Route Target) — so the per-VRF `mup route-target export`
 /// set (stored as `RouteDistinguisher`s) maps straight through.
 fn rd_route_target(rd: &RouteDistinguisher) -> ExtCommunityValue {
     ExtCommunityValue {
@@ -8705,7 +8705,7 @@ pub fn route_from_peer(
                 } => {
                     // MUP carries its next-hop in MP_REACH (no usable
                     // NEXT_HOP attr). Stamp it into the path attr so the
-                    // Loc-RIB and `show bgp mobile-uplane` render it.
+                    // Loc-RIB and `show bgp mup` render it.
                     let mut attr_mup = bgp_attr.clone();
                     attr_mup.nexthop = Some(match nhop {
                         IpAddr::V4(a) => BgpNexthop::Ipv4(a),
@@ -12384,7 +12384,7 @@ pub fn route_sync(peer: &mut Peer, bgp: &mut BgpTop, v4_via_pool: bool) {
 impl Bgp {
     /// Originate (or re-originate) a MUP Session-Transformed route for one
     /// controller-learned session. Correlates the session's Network
-    /// Instance to a `router bgp vrf <name> mobile-uplane` config, builds
+    /// Instance to a `router bgp vrf <name> mup` config, builds
     /// the ST route with its attributes, installs into the MUP Loc-RIB as
     /// `Originated`, and advertises. A prior route for the same session is
     /// withdrawn first, so a Session Modification cleanly replaces it.
@@ -12428,7 +12428,7 @@ impl Bgp {
         self.mup_apply_selected(prefix, selected);
     }
 
-    /// Correlate a session to a VRF `mobile-uplane` config and build the
+    /// Correlate a session to a VRF `mup` config and build the
     /// ST prefix + attributes. Returns `None` when no VRF matches the
     /// session's Network Instance, the VRF has no RD, or the session lacks
     /// the addresses the chosen ST route type needs.
@@ -12438,17 +12438,23 @@ impl Bgp {
     ) -> Option<(bgp_packet::MupPrefix, BgpAttr)> {
         use super::vrf_config::MupSrv6Direction;
         let ni = session.network_instance.as_deref()?;
-        let (rd, rts, direction) = self.vrfs.values().find_map(|cfg| {
+        // Correlate the session NI to a `router bgp vrf <name> mup
+        // route {st1|st2}` config for the RD + direction.
+        let (name, rd, direction) = self.vrfs.iter().find_map(|(name, cfg)| {
             let sm = cfg.mobile_uplane.srv6_mobile.as_ref()?;
-            (sm.network_instance.as_deref() == Some(ni)).then(|| {
-                (
-                    cfg.rd,
-                    cfg.mobile_uplane.route_target_export.clone(),
-                    sm.direction,
-                )
-            })
+            (sm.network_instance.as_deref() == Some(ni))
+                .then(|| (name.clone(), cfg.rd, sm.direction))
         })?;
         let rd = rd?;
+        // The export route-targets now live on the top-level
+        // `vrf <name> mup route-target export` (RIB-owned,
+        // pushed to `rib_known_vrfs` via `VrfRouteTargets`), the same
+        // framework as ipv4 / ipv6.
+        let rts = self
+            .rib_known_vrfs
+            .get(&name)
+            .map(|k| k.mup_export_rts.clone())
+            .unwrap_or_default();
         let prefix = match direction {
             // Encapsulation (N6 / downlink): Type-1 ST carries the UE
             // prefix + access tunnel. The endpoint (gNB) family may differ
@@ -12483,6 +12489,9 @@ impl Bgp {
     /// Apply the post-update best path of one MUP prefix to peers:
     /// advertise the new best, or withdraw when no path remains.
     fn mup_apply_selected(&mut self, prefix: bgp_packet::MupPrefix, selected: Vec<BgpRib>) {
+        // Mirror the best-path to the per-VRF task whose `rd` matches this
+        // route's RD (display-only, for `show bgp vrf <name> mup`).
+        self.forward_mup_to_vrf(&prefix, selected.first());
         if selected.is_empty() {
             route_withdraw_mup_to_peers(prefix, &mut self.peers);
             return;
@@ -12508,6 +12517,37 @@ impl Bgp {
             central_label_alloc: None,
         };
         route_advertise_mup_to_peers(prefix, &selected, &mut bgp_ref, &mut self.peers);
+    }
+
+    /// Forward a MUP best-path (or its withdrawal) to the per-VRF task
+    /// whose configured `rd` matches the route's RD, for display under
+    /// `show bgp vrf <name> mup`. No-op when no VRF owns the RD or that
+    /// VRF has no running per-VRF task. Display-only: the global instance
+    /// stays the authoritative MUP RIB and advertiser.
+    fn forward_mup_to_vrf(&self, prefix: &bgp_packet::MupPrefix, best: Option<&BgpRib>) {
+        let Some(rd) = prefix.rd() else {
+            return;
+        };
+        let Some(name) = self
+            .vrfs
+            .iter()
+            .find_map(|(n, c)| (c.rd == Some(rd)).then_some(n))
+        else {
+            return;
+        };
+        let Some(handle) = self.vrf_registry.get(name) else {
+            return;
+        };
+        let msg = match best {
+            Some(rib) => super::vrf::msg::BgpVrfMsg::MupUpdate {
+                prefix: prefix.clone(),
+                rib: rib.clone(),
+            },
+            None => super::vrf::msg::BgpVrfMsg::MupWithdraw {
+                prefix: prefix.clone(),
+            },
+        };
+        let _ = handle.inbox.send(msg);
     }
 
     pub fn route_add(&mut self, prefix: Ipv4Net) {

--- a/zebra-rs/src/bgp/show.rs
+++ b/zebra-rs/src/bgp/show.rs
@@ -86,6 +86,10 @@ pub async fn process_vrf_show(vrf: &BgpVrf, msg: DisplayRequest) {
         "/show/bgp/ipv4/longer-prefix" => show_bgp_ipv4_longer(vrf, args, msg.json),
         "/show/bgp/ipv6" => show_bgp_ipv6(vrf, args, msg.json),
         "/show/bgp/ipv6/longer-prefix" => show_bgp_ipv6_longer(vrf, args, msg.json),
+        // `show bgp vrf <name> mup` — the manager strips `vrf <name>`, so
+        // the per-VRF task sees `/show/bgp/mup` and renders the MUP routes
+        // the global instance mirrored to it (by matching RD).
+        "/show/bgp/mup" => show_bgp_vrf_mup(vrf, args, msg.json),
         other => Ok(format!("% Unsupported per-VRF show command: {other}\n")),
     };
     let out = out.unwrap_or_else(|e| format!("Error formatting output: {e}"));
@@ -2048,8 +2052,8 @@ fn show_bgp_evpn_summary(
     show_bgp_summary_one(bgp, AfiSafi::new(Afi::L2vpn, Safi::Evpn), json)
 }
 
-/// `show bgp mobile-uplane summary` — the MUP (SAFI 85, RFC 9833)
-/// neighbor summary. `mobile-uplane` enables both IPv4-MUP and IPv6-MUP
+/// `show bgp mup summary` — the MUP (SAFI 85, RFC 9833)
+/// neighbor summary. `mup` enables both IPv4-MUP and IPv6-MUP
 /// at once (RFC 9833), so this renders both sections — the MUP slice of
 /// `show bgp summary` — listing the neighbors that have each MUP family
 /// enabled and whether they negotiated the capability.
@@ -3505,7 +3509,7 @@ fn show_mup_ecom(attr: &BgpAttr) -> String {
 }
 
 /// Render a `MupPrefix` as the bracketed `[TYPE][rd][fields]` form used by
-/// `show bgp mobile-uplane`, following the MUP NLRI layout (RFC 9833).
+/// `show bgp mup`, following the MUP NLRI layout (RFC 9833).
 fn mup_prefix_display(prefix: &MupPrefix) -> String {
     match prefix {
         MupPrefix::Dsd { rd, address } => format!("[DSD][{rd}][{address}]"),
@@ -3533,7 +3537,7 @@ fn mup_prefix_display(prefix: &MupPrefix) -> String {
     }
 }
 
-/// `show bgp mobile-uplane mup-c` — MUP controller (MUP-C) status: admin
+/// `show bgp mup mup-c` — MUP controller (MUP-C) status: admin
 /// state, the PFCP listener, and association / session counts. Rendered
 /// from the read-only [`crate::mup_c::inst::MupCView`] the controller
 /// feeds over `Message::MupC`.
@@ -3566,7 +3570,7 @@ fn show_bgp_mup_c(
     Ok(buf)
 }
 
-/// `show bgp mobile-uplane mup-c session` — the PFCP sessions the
+/// `show bgp mup mup-c session` — the PFCP sessions the
 /// controller has learned (one row each).
 fn show_bgp_mup_c_session(
     bgp: &Bgp,
@@ -3611,7 +3615,7 @@ fn show_bgp_mup_c_session(
     Ok(buf)
 }
 
-/// `show bgp mobile-uplane mup-c association` — the PFCP associations
+/// `show bgp mup mup-c association` — the PFCP associations
 /// (control-plane peers) the controller currently holds.
 fn show_bgp_mup_c_association(
     bgp: &Bgp,
@@ -3629,8 +3633,8 @@ fn show_bgp_mup_c_association(
     Ok(buf)
 }
 
-/// `show bgp mobile-uplane` — the MUP (SAFI 85, RFC 9833) view: the
-/// config-driven `MUP VRFs:` block (per-VRF `mobile-uplane` services)
+/// `show bgp mup` — the MUP (SAFI 85, RFC 9833) view: the
+/// config-driven `MUP VRFs:` block (per-VRF `mup` services)
 /// followed by the Loc-RIB route table. The full `MUP controller:`
 /// wrapper (zenoh source + ingested sessions) lands with the controller
 /// phase.
@@ -3642,12 +3646,28 @@ fn show_bgp_mup(
     if json {
         return Ok(String::from("[]"));
     }
-    let mut out = render_mup_vrfs(&bgp.vrfs)?;
+    let mut out = render_mup_vrfs(&bgp.vrfs, &bgp.rib_known_vrfs)?;
     if !out.is_empty() {
         out.push('\n');
     }
     out.push_str(&render_mup_table(&bgp.local_rib.mup)?);
     Ok(out)
+}
+
+/// `show bgp vrf <name> mup` — the per-VRF MUP view. The manager
+/// redirects this into the VRF's task, which holds the MUP best-paths the
+/// global instance mirrored to it (those whose RD matches this VRF's
+/// `rd`); renders just the route table. Generic over [`BgpShowView`] so it
+/// runs against either the per-VRF task or (in tests) any view.
+fn show_bgp_vrf_mup<V: BgpShowView>(
+    bgp: &V,
+    _args: Args,
+    json: bool,
+) -> std::result::Result<String, std::fmt::Error> {
+    if json {
+        return Ok(String::from("[]"));
+    }
+    render_mup_table(&bgp.local_rib().mup)
 }
 
 /// Render the MUP Loc-RIB table body. Split out from `show_bgp_mup` so it
@@ -3679,20 +3699,27 @@ fn render_mup_table(
     Ok(buf)
 }
 
-/// Render the configured per-VRF MUP services (the `mobile-uplane`
-/// blocks) as the `MUP VRFs:` section of `show bgp mobile-uplane`.
+/// Render the configured per-VRF MUP services (the `mup`
+/// blocks) as the `MUP VRFs:` section of `show bgp mup`.
 /// Config-driven only; returns an empty string when no VRF carries a
-/// `mobile-uplane` config. The full `MUP controller:` wrapper lands with
+/// `mup` config. The full `MUP controller:` wrapper lands with
 /// the controller phase.
 fn render_mup_vrfs(
     vrfs: &std::collections::BTreeMap<String, super::vrf_config::BgpVrfConfig>,
+    rib_known_vrfs: &std::collections::BTreeMap<String, super::inst::RibKnownVrf>,
 ) -> std::result::Result<String, std::fmt::Error> {
     use super::vrf_config::MupSrv6Direction;
     let mut buf = String::new();
     let mut any = false;
     for (name, cfg) in vrfs {
         let mup = &cfg.mobile_uplane;
-        if mup.srv6_mobile.is_none() && mup.route_target_export.is_empty() {
+        // The export RTs live on the top-level `vrf <name> mup
+        // route-target export`, surfaced to BGP via `rib_known_vrfs`.
+        let rts = rib_known_vrfs
+            .get(name)
+            .map(|k| k.mup_export_rts.len())
+            .unwrap_or(0);
+        if mup.srv6_mobile.is_none() && rts == 0 {
             continue;
         }
         if !any {
@@ -3704,7 +3731,6 @@ fn render_mup_vrfs(
             .as_ref()
             .map(|r| r.to_string())
             .unwrap_or_else(|| "-".into());
-        let rts = mup.route_target_export.len();
         match &mup.srv6_mobile {
             Some(sm) => {
                 let (dir, st) = match sm.direction {
@@ -4756,16 +4782,14 @@ mod detail_tests {
 
     #[test]
     fn render_mup_vrfs_lists_configured_services() {
+        use super::super::inst::RibKnownVrf;
         use super::super::vrf_config::{
             BgpVrfConfig, BgpVrfMobileUplane, MupSrv6Direction, MupSrv6Mobile,
         };
-        use std::collections::{BTreeMap, BTreeSet};
+        use std::collections::BTreeMap;
         let n3 = BgpVrfConfig {
             rd: Some("65000:1".parse().unwrap()),
             mobile_uplane: BgpVrfMobileUplane {
-                route_target_export: ["65000:100".parse().unwrap()]
-                    .into_iter()
-                    .collect::<BTreeSet<_>>(),
                 srv6_mobile: Some(MupSrv6Mobile {
                     direction: MupSrv6Direction::Decapsulation,
                     network_instance: Some("core-ni".to_string()),
@@ -4776,9 +4800,6 @@ mod detail_tests {
         let n6 = BgpVrfConfig {
             rd: Some("65000:2".parse().unwrap()),
             mobile_uplane: BgpVrfMobileUplane {
-                route_target_export: ["65000:200".parse().unwrap()]
-                    .into_iter()
-                    .collect::<BTreeSet<_>>(),
                 srv6_mobile: Some(MupSrv6Mobile {
                     direction: MupSrv6Direction::Encapsulation,
                     network_instance: Some("access-ni".to_string()),
@@ -4790,18 +4811,37 @@ mod detail_tests {
         vrfs.insert("N3".to_string(), n3);
         vrfs.insert("N6".to_string(), n6);
 
-        let out = render_mup_vrfs(&vrfs).unwrap();
+        // The export RTs now come from `rib_known_vrfs` (the top-level
+        // `vrf <name> mup route-target export`).
+        let mut rib_known_vrfs: BTreeMap<String, RibKnownVrf> = BTreeMap::new();
+        rib_known_vrfs.insert(
+            "N3".to_string(),
+            RibKnownVrf {
+                mup_export_rts: ["65000:100".parse().unwrap()].into_iter().collect(),
+                ..Default::default()
+            },
+        );
+        rib_known_vrfs.insert(
+            "N6".to_string(),
+            RibKnownVrf {
+                mup_export_rts: ["65000:200".parse().unwrap()].into_iter().collect(),
+                ..Default::default()
+            },
+        );
+
+        let out = render_mup_vrfs(&vrfs, &rib_known_vrfs).unwrap();
         assert!(out.contains("MUP VRFs:"));
         assert!(out.contains("N3: rd=65000:1 decap/ST2 ni=core-ni route-targets=1"));
         assert!(out.contains("N6: rd=65000:2 encap/ST1 ni=access-ni route-targets=1"));
 
-        // No mobile-uplane config anywhere → empty section.
+        // No mup config anywhere → empty section.
         let empty: BTreeMap<String, BgpVrfConfig> = BTreeMap::new();
-        assert!(render_mup_vrfs(&empty).unwrap().is_empty());
+        let empty_rib: BTreeMap<String, RibKnownVrf> = BTreeMap::new();
+        assert!(render_mup_vrfs(&empty, &empty_rib).unwrap().is_empty());
     }
 
     /// End-to-end render of the MUP Loc-RIB table: exercises
-    /// `LocalRibMupTable::update`/best-path and the `show bgp mobile-uplane`
+    /// `LocalRibMupTable::update`/best-path and the `show bgp mup`
     /// route-table body against the documented mockup shape.
     #[test]
     fn render_mup_table_matches_mockup_shape() {
@@ -5660,15 +5700,15 @@ impl Bgp {
             .set(show_bgp_evpn)
             .path("/show/bgp/evpn/route-type")
             .set(show_bgp_evpn)
-            .path("/show/bgp/mobile-uplane")
+            .path("/show/bgp/mup")
             .set(show_bgp_mup)
-            .path("/show/bgp/mobile-uplane/summary")
+            .path("/show/bgp/mup/summary")
             .set(show_bgp_mup_summary)
-            .path("/show/bgp/mobile-uplane/mup-c")
+            .path("/show/bgp/mup/mup-c")
             .set(show_bgp_mup_c)
-            .path("/show/bgp/mobile-uplane/mup-c/session")
+            .path("/show/bgp/mup/mup-c/session")
             .set(show_bgp_mup_c_session)
-            .path("/show/bgp/mobile-uplane/mup-c/association")
+            .path("/show/bgp/mup/mup-c/association")
             .set(show_bgp_mup_c_association)
             .path("/show/bgp/summary")
             .set(show_bgp_summary::<Bgp>)
@@ -5687,6 +5727,8 @@ impl Bgp {
             .path("/show/bgp/vrf/ipv6")
             .set(show_bgp_vrf_not_running)
             .path("/show/bgp/vrf/ipv6/longer-prefix")
+            .set(show_bgp_vrf_not_running)
+            .path("/show/bgp/vrf/mup")
             .set(show_bgp_vrf_not_running)
             .map();
     }

--- a/zebra-rs/src/bgp/vrf/inst.rs
+++ b/zebra-rs/src/bgp/vrf/inst.rs
@@ -1186,6 +1186,17 @@ impl BgpVrf {
             BgpVrfMsg::WithdrawNetworkV6 { prefix } => {
                 self.withdraw_self_network_v6(prefix);
             }
+            // Display-only mirror of the global MUP best-path for this
+            // VRF's RD, so `show bgp vrf <name> mup` (redirected here)
+            // renders the VRF's ST routes. We touch only `selected`
+            // (what `render_mup_table` reads); the per-VRF task never
+            // re-advertises or best-paths MUP.
+            BgpVrfMsg::MupUpdate { prefix, rib } => {
+                self.local_rib.mup.selected.insert(prefix, rib);
+            }
+            BgpVrfMsg::MupWithdraw { prefix } => {
+                self.local_rib.mup.selected.remove(&prefix);
+            }
             BgpVrfMsg::Shutdown => unreachable!("handled in event_loop"),
         }
     }

--- a/zebra-rs/src/bgp/vrf/msg.rs
+++ b/zebra-rs/src/bgp/vrf/msg.rs
@@ -59,6 +59,20 @@ pub enum BgpVrfMsg {
         prefix: ipnet::Ipv4Net,
     },
 
+    /// A MUP (SAFI 85) best-path the global Loc-RIB selected whose RD
+    /// matches this VRF's `rd`. Forwarded for **display only**: the
+    /// per-VRF task mirrors it into `local_rib.mup.selected` so a
+    /// `show bgp vrf <name> mup` (which the manager redirects into this
+    /// task) renders the VRF's Session-Transformed routes. The global
+    /// `Bgp` instance remains the authoritative MUP RIB / advertiser.
+    MupUpdate {
+        prefix: bgp_packet::MupPrefix,
+        rib: crate::bgp::route::BgpRib,
+    },
+    /// Withdraw a previously-forwarded MUP best-path (the global RIB no
+    /// longer has a selected path for it).
+    MupWithdraw { prefix: bgp_packet::MupPrefix },
+
     /// VPNv6 counterpart of [`Self::ImportV4`] — a VPNv6 route whose
     /// RT list intersects this VRF's `import_rts_v6`; inserted into
     /// the VRF's IPv6 unicast Loc-RIB and advertised to CE peers.

--- a/zebra-rs/src/bgp/vrf_config.rs
+++ b/zebra-rs/src/bgp/vrf_config.rs
@@ -123,7 +123,7 @@ impl<N: Ord> Default for BgpVrfAfConfig<N> {
 }
 
 /// SRv6 mobile user-plane direction for a per-VRF MUP service
-/// (zebra-bgp-vrf.yang `mobile-uplane route {st1|st2}`). `Decapsulation`
+/// (zebra-bgp-vrf.yang `mup route {st1|st2}`). `Decapsulation`
 /// is the `st2` egress/uplink (Type-2 ST, the N3 VRF); `Encapsulation`
 /// is the `st1` ingress/downlink (Type-1 ST, the N6 VRF).
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -132,10 +132,10 @@ pub enum MupSrv6Direction {
     Encapsulation,
 }
 
-/// `mobile-uplane route {st1|st2} dest-network-instance {access|core}
+/// `mup route {st1|st2} dest-network-instance {access|core}
 /// exact <ni>` for one VRF: the ST route type (as a direction) plus the
 /// session network-instance matched exactly. Surfaced in
-/// `show bgp mobile-uplane` (the `MUP VRFs:` block) and consumed by the
+/// `show bgp mup` (the `MUP VRFs:` block) and consumed by the
 /// P5 MUP controller when it originates ST routes (st2/Decapsulation →
 /// Type-2 ST, the N3 VRF; st1/Encapsulation → Type-1 ST, the N6 VRF).
 #[derive(Debug, Clone)]
@@ -144,13 +144,14 @@ pub struct MupSrv6Mobile {
     pub network_instance: Option<String>,
 }
 
-/// Per-VRF BGP MUP (RFC 9833) service config — the `mobile-uplane`
-/// container in zebra-bgp-vrf.yang. The route-targets tag the ST
-/// routes the controller originates from this VRF (RT shares the RD
-/// wire format, so it is stored as a `RouteDistinguisher`).
+/// Per-VRF BGP MUP (RFC 9833) service config — the `mup`
+/// container under `router bgp vrf <name>` in zebra-bgp-vrf.yang. Holds
+/// only the `route {st1|st2}` origination binding; the export/import
+/// route-targets live on the top-level `vrf <name> mup
+/// route-target {export|import}` (RIB-owned, surfaced to BGP via
+/// `rib_known_vrfs`), the same framework as ipv4 / ipv6.
 #[derive(Default, Debug, Clone)]
 pub struct BgpVrfMobileUplane {
-    pub route_target_export: BTreeSet<RouteDistinguisher>,
     pub srv6_mobile: Option<MupSrv6Mobile>,
 }
 
@@ -178,7 +179,7 @@ pub struct BgpVrfConfig {
     /// forwarding per-VRF. Default `false` (ordinary L3VPN VRF).
     pub inter_as_hybrid: bool,
     /// Per-VRF BGP MUP (RFC 9833) service config. Mirrors the
-    /// `mobile-uplane` container in zebra-bgp-vrf.yang.
+    /// `mup` container in zebra-bgp-vrf.yang.
     pub mobile_uplane: BgpVrfMobileUplane,
 }
 
@@ -275,41 +276,7 @@ pub fn config_vrf_inter_as_hybrid(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -
     Some(())
 }
 
-/// `set router bgp vrf <NAME> mobile-uplane route-target export <RT>...`
-/// — the route-targets attached to MUP ST routes originated from this
-/// VRF. A leaf-list arrives as one callback call with every value in
-/// the args deque, so the handler loops (project convention).
-pub fn config_vrf_mup_rt_export(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Option<()> {
-    let name = args.string()?;
-    let cfg = vrf_entry(bgp, name);
-    match op {
-        ConfigOp::Set => {
-            while let Some(s) = args.string() {
-                if let Ok(rt) = RouteDistinguisher::from_str(&s) {
-                    cfg.mobile_uplane.route_target_export.insert(rt);
-                }
-            }
-        }
-        ConfigOp::Delete => {
-            let mut removed_any = false;
-            while let Some(s) = args.string() {
-                if let Ok(rt) = RouteDistinguisher::from_str(&s) {
-                    cfg.mobile_uplane.route_target_export.remove(&rt);
-                    removed_any = true;
-                }
-            }
-            // A bare `delete ... route-target export` with no value
-            // clears the whole leaf-list.
-            if !removed_any {
-                cfg.mobile_uplane.route_target_export.clear();
-            }
-        }
-        _ => {}
-    }
-    Some(())
-}
-
-/// `set router bgp vrf <NAME> mobile-uplane route st2 dest-network-instance
+/// `set router bgp vrf <NAME> mup route st2 dest-network-instance
 /// core exact <NI>` — Type-2 ST (uplink) origination: egress GTP
 /// decapsulation for the N3 VRF, matched against the session's core
 /// network-instance.
@@ -330,7 +297,7 @@ pub fn config_vrf_mup_route_st2(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> 
     Some(())
 }
 
-/// `set router bgp vrf <NAME> mobile-uplane route st1 dest-network-instance
+/// `set router bgp vrf <NAME> mup route st1 dest-network-instance
 /// access exact <NI>` — Type-1 ST (downlink) origination: ingress GTP
 /// encapsulation for the N6 VRF, matched against the session's access
 /// network-instance.
@@ -667,21 +634,7 @@ mod tests {
     #[test]
     fn mobile_uplane_default_is_empty() {
         let mup = BgpVrfConfig::default().mobile_uplane;
-        assert!(mup.route_target_export.is_empty());
         assert!(mup.srv6_mobile.is_none());
-    }
-
-    #[test]
-    fn mobile_uplane_rt_export_insert_and_clear() {
-        let mut cfg = BgpVrfConfig::default();
-        let rt1 = RouteDistinguisher::from_str("65000:100").unwrap();
-        let rt2 = RouteDistinguisher::from_str("65000:200").unwrap();
-        cfg.mobile_uplane.route_target_export.insert(rt1);
-        cfg.mobile_uplane.route_target_export.insert(rt2);
-        assert_eq!(cfg.mobile_uplane.route_target_export.len(), 2);
-        assert!(cfg.mobile_uplane.route_target_export.contains(&rt1));
-        cfg.mobile_uplane.route_target_export.clear();
-        assert!(cfg.mobile_uplane.route_target_export.is_empty());
     }
 
     #[test]

--- a/zebra-rs/src/config/configs.rs
+++ b/zebra-rs/src/config/configs.rs
@@ -158,7 +158,7 @@ impl Args {
             // IPv4 and IPv6 MUP families; (Ip, Mup) is the canonical
             // tuple returned here and `mp_family_expand` fans it out to
             // both AFIs at the `enabled` handlers.
-            "mobile-uplane" => Some(AfiSafi::new(Afi::Ip, Safi::Mup)),
+            "mup" => Some(AfiSafi::new(Afi::Ip, Safi::Mup)),
             _ => None,
         }
     }
@@ -966,9 +966,9 @@ mod tests {
 
     #[test]
     fn afi_safi_parses_mobile_uplane_as_v4_mup() {
-        // The single `mobile-uplane` name canonicalizes to (Ip, Mup);
+        // The single `mup` name canonicalizes to (Ip, Mup);
         // the enabled handlers fan it out to both MUP AFIs (RFC 9833).
-        let mut args = Args(["mobile-uplane".to_string()].into_iter().collect());
+        let mut args = Args(["mup".to_string()].into_iter().collect());
         assert_eq!(args.afi_safi(), Some(AfiSafi::new(Afi::Ip, Safi::Mup)));
     }
 

--- a/zebra-rs/src/config/parse.rs
+++ b/zebra-rs/src/config/parse.rs
@@ -1308,16 +1308,8 @@ mod tests {
             ("show bgp ipv6 summary", "/show/bgp/ipv6", vec!["summary"]),
             ("show bgp vpnv4 summary", "/show/bgp/vpnv4", vec!["summary"]),
             ("show bgp evpn summary", "/show/bgp/evpn/summary", vec![]),
-            (
-                "show bgp mobile-uplane summary",
-                "/show/bgp/mobile-uplane/summary",
-                vec![],
-            ),
-            (
-                "show bgp mobile-uplane summ",
-                "/show/bgp/mobile-uplane/summary",
-                vec![],
-            ),
+            ("show bgp mup summary", "/show/bgp/mup/summary", vec![]),
+            ("show bgp mup summ", "/show/bgp/mup/summary", vec![]),
             (
                 "show bgp vrf blue summary",
                 "/show/bgp/vrf/summary",

--- a/zebra-rs/src/mup-c/inst.rs
+++ b/zebra-rs/src/mup-c/inst.rs
@@ -21,7 +21,7 @@ use super::session::{MupSession, SessionTable};
 /// PFCP default port (3GPP TS 29.244 §4.2.2).
 pub const PFCP_PORT: u16 = 8805;
 
-/// Controller config, staged from `router bgp afi-safi mobile-uplane
+/// Controller config, staged from `router bgp afi-safi mup
 /// mup-c { … }` by the BGP config callbacks and applied at `CommitEnd`.
 #[derive(Debug, Clone, Default)]
 pub struct MupCConfig {
@@ -70,7 +70,7 @@ pub enum MupCEvent {
 }
 
 /// Read-only controller snapshot held by the BGP task, fed by
-/// [`MupCEvent`]. Renders `show bgp mobile-uplane mup-c [session |
+/// [`MupCEvent`]. Renders `show bgp mup mup-c [session |
 /// association]`.
 #[derive(Debug, Default)]
 pub struct MupCView {

--- a/zebra-rs/src/mup-c/mod.rs
+++ b/zebra-rs/src/mup-c/mod.rs
@@ -11,13 +11,13 @@
 //! Heartbeat.
 //!
 //! The controller is **configured under the BGP instance** at
-//! `router bgp ... afi-safi mobile-uplane mup-c { enable; pfcp … }` and is
+//! `router bgp ... afi-safi mup mup-c { enable; pfcp … }` and is
 //! spawned by the BGP task, which hands it the BGP instance's own
 //! `mpsc::Sender<crate::bgp::inst::Message>` — exactly the way a BGP VRF
 //! instance receives the global BGP channel. The controller reports
 //! neutral session/association events back over that channel
 //! ([`inst::MupCEvent`]); the BGP task records them for
-//! `show bgp mobile-uplane mup-c` (this slice) and originates MUP routes
+//! `show bgp mup mup-c` (this slice) and originates MUP routes
 //! from them (follow-up).
 //!
 //! Module layout: [`inst`] owns the task + the BGP-facing types,

--- a/zebra-rs/src/mup-c/session.rs
+++ b/zebra-rs/src/mup-c/session.rs
@@ -33,7 +33,7 @@ pub struct MupSession {
     pub teid: u32,
     /// Access-side GTP-U endpoint (the F-TEID address).
     pub endpoint: Option<IpAddr>,
-    /// Network Instance (APN/DNN). Correlated to a BGP VRF `mobile-uplane`
+    /// Network Instance (APN/DNN). Correlated to a BGP VRF `mup`
     /// config when routes are originated.
     pub network_instance: Option<String>,
     /// QoS Flow Identifier, if present.

--- a/zebra-rs/src/rib/api.rs
+++ b/zebra-rs/src/rib/api.rs
@@ -184,6 +184,8 @@ pub enum RibRx {
         ipv4_export_rts: std::collections::BTreeSet<bgp_packet::RouteDistinguisher>,
         ipv6_import_rts: std::collections::BTreeSet<bgp_packet::RouteDistinguisher>,
         ipv6_export_rts: std::collections::BTreeSet<bgp_packet::RouteDistinguisher>,
+        mup_import_rts: std::collections::BTreeSet<bgp_packet::RouteDistinguisher>,
+        mup_export_rts: std::collections::BTreeSet<bgp_packet::RouteDistinguisher>,
     },
     EoR,
 
@@ -479,6 +481,8 @@ impl Rib {
                 ipv4_export_rts: vrf.ipv4_export_rts.clone(),
                 ipv6_import_rts: vrf.ipv6_import_rts.clone(),
                 ipv6_export_rts: vrf.ipv6_export_rts.clone(),
+                mup_import_rts: vrf.mup_import_rts.clone(),
+                mup_export_rts: vrf.mup_export_rts.clone(),
             });
         }
     }

--- a/zebra-rs/src/rib/inst.rs
+++ b/zebra-rs/src/rib/inst.rs
@@ -276,6 +276,8 @@ pub enum Message {
         ipv4_export_rts: std::collections::BTreeSet<bgp_packet::RouteDistinguisher>,
         ipv6_import_rts: std::collections::BTreeSet<bgp_packet::RouteDistinguisher>,
         ipv6_export_rts: std::collections::BTreeSet<bgp_packet::RouteDistinguisher>,
+        mup_import_rts: std::collections::BTreeSet<bgp_packet::RouteDistinguisher>,
+        mup_export_rts: std::collections::BTreeSet<bgp_packet::RouteDistinguisher>,
     },
     /// Configured `vrf <name> router-id` snapshot from the VRF config
     /// builder, sent on commit after `VrfAdd` (same ordering contract
@@ -1763,6 +1765,8 @@ impl Rib {
                     ipv4_export_rts: vrf.ipv4_export_rts.clone(),
                     ipv6_import_rts: vrf.ipv6_import_rts.clone(),
                     ipv6_export_rts: vrf.ipv6_export_rts.clone(),
+                    mup_import_rts: vrf.mup_import_rts.clone(),
+                    mup_export_rts: vrf.mup_export_rts.clone(),
                 };
                 if tx.send(rt_msg).is_err() {
                     return;
@@ -2358,11 +2362,13 @@ impl Rib {
                         // RT sets arrive separately via
                         // `Message::VrfRouteTargets` once the VRF
                         // config builder has finished parsing
-                        // /vrf/<name>/{ipv4,ipv6}/route-target.
+                        // /vrf/<name>/{ipv4,ipv6,mup}/route-target.
                         ipv4_import_rts: std::collections::BTreeSet::new(),
                         ipv4_export_rts: std::collections::BTreeSet::new(),
                         ipv6_import_rts: std::collections::BTreeSet::new(),
                         ipv6_export_rts: std::collections::BTreeSet::new(),
+                        mup_import_rts: std::collections::BTreeSet::new(),
+                        mup_export_rts: std::collections::BTreeSet::new(),
                     },
                 );
                 // Park an empty per-VRF routing table set keyed by
@@ -2431,6 +2437,8 @@ impl Rib {
                 ipv4_export_rts,
                 ipv6_import_rts,
                 ipv6_export_rts,
+                mup_import_rts,
+                mup_export_rts,
             } => {
                 // Idempotent — the message carries a full snapshot
                 // of the staged RT sets, replacing whatever was on
@@ -2444,6 +2452,8 @@ impl Rib {
                     vrf.ipv4_export_rts = ipv4_export_rts;
                     vrf.ipv6_import_rts = ipv6_import_rts;
                     vrf.ipv6_export_rts = ipv6_export_rts;
+                    vrf.mup_import_rts = mup_import_rts;
+                    vrf.mup_export_rts = mup_export_rts;
                     let vrf_snapshot = vrf.clone();
                     self.api_vrf_route_targets(&vrf_snapshot);
                 } else {

--- a/zebra-rs/src/rib/vrf/builder.rs
+++ b/zebra-rs/src/rib/vrf/builder.rs
@@ -59,6 +59,8 @@ impl VrfBuilder {
                 let ipv4_export_rts = config.ipv4_export_rts.clone();
                 let ipv6_import_rts = config.ipv6_import_rts.clone();
                 let ipv6_export_rts = config.ipv6_export_rts.clone();
+                let mup_import_rts = config.mup_import_rts.clone();
+                let mup_export_rts = config.mup_export_rts.clone();
                 let router_id = config.router_id;
                 self.config.insert(name.clone(), config);
                 let _ = tx.send(Message::VrfAdd { name: name.clone() });
@@ -68,6 +70,8 @@ impl VrfBuilder {
                     ipv4_export_rts,
                     ipv6_import_rts,
                     ipv6_export_rts,
+                    mup_import_rts,
+                    mup_export_rts,
                 });
                 // Router-id snapshot follows the same VrfAdd-first
                 // ordering contract as the RT message; `None` (leaf
@@ -253,6 +257,50 @@ impl ConfigBuilder {
                     .remove(&rt);
                 Ok(())
             })
+            // /vrf/<name>/mup/route-target/{import,export} —
+            // BGP MUP (SAFI 85) RT policy, same shape as ipv4 / ipv6.
+            .path("/mup/route-target/import")
+            .set(|config, cache, name, args| {
+                let raw = args.string().context(RT_ERR)?;
+                let rt = bgp_packet::RouteDistinguisher::from_str(&raw)
+                    .map_err(|_| anyhow::anyhow!(RT_PARSE_ERR))?;
+                cache_get(config, cache, name)
+                    .context(CONFIG_ERR)?
+                    .mup_import_rts
+                    .insert(rt);
+                Ok(())
+            })
+            .del(|config, cache, name, args| {
+                let raw = args.string().context(RT_ERR)?;
+                let rt = bgp_packet::RouteDistinguisher::from_str(&raw)
+                    .map_err(|_| anyhow::anyhow!(RT_PARSE_ERR))?;
+                cache_get(config, cache, name)
+                    .context(CONFIG_ERR)?
+                    .mup_import_rts
+                    .remove(&rt);
+                Ok(())
+            })
+            .path("/mup/route-target/export")
+            .set(|config, cache, name, args| {
+                let raw = args.string().context(RT_ERR)?;
+                let rt = bgp_packet::RouteDistinguisher::from_str(&raw)
+                    .map_err(|_| anyhow::anyhow!(RT_PARSE_ERR))?;
+                cache_get(config, cache, name)
+                    .context(CONFIG_ERR)?
+                    .mup_export_rts
+                    .insert(rt);
+                Ok(())
+            })
+            .del(|config, cache, name, args| {
+                let raw = args.string().context(RT_ERR)?;
+                let rt = bgp_packet::RouteDistinguisher::from_str(&raw)
+                    .map_err(|_| anyhow::anyhow!(RT_PARSE_ERR))?;
+                cache_get(config, cache, name)
+                    .context(CONFIG_ERR)?
+                    .mup_export_rts
+                    .remove(&rt);
+                Ok(())
+            })
     }
 
     pub fn path(mut self, path: &str) -> Self {
@@ -329,6 +377,8 @@ mod tests {
             ipv4_export_rts,
             ipv6_import_rts,
             ipv6_export_rts,
+            mup_import_rts,
+            mup_export_rts,
         } = second
         else {
             panic!("second message is not VrfRouteTargets");
@@ -340,6 +390,8 @@ mod tests {
         assert!(ipv4_export_rts.contains(&exp));
         assert!(ipv6_import_rts.is_empty());
         assert!(ipv6_export_rts.is_empty());
+        assert!(mup_import_rts.is_empty());
+        assert!(mup_export_rts.is_empty());
 
         // The router-id snapshot always trails the RT message — `None`
         // here because the operator never set `vrf v1 router-id`.

--- a/zebra-rs/src/rib/vrf/config.rs
+++ b/zebra-rs/src/rib/vrf/config.rs
@@ -31,6 +31,15 @@ pub struct VrfConfig {
     /// IPv6-unicast RT export set —
     /// `set vrf X ipv6 route-target export …`.
     pub ipv6_export_rts: std::collections::BTreeSet<bgp_packet::RouteDistinguisher>,
+    /// MUP (mup / SAFI 85) RT import set —
+    /// `set vrf X mup route-target import …`. Reserved for the
+    /// MUP import dispatch follow-up; carried for framework parity.
+    pub mup_import_rts: std::collections::BTreeSet<bgp_packet::RouteDistinguisher>,
+    /// MUP (mup / SAFI 85) RT export set —
+    /// `set vrf X mup route-target export …`. Tags the
+    /// Session-Transformed routes the MUP controller originates from this
+    /// VRF.
+    pub mup_export_rts: std::collections::BTreeSet<bgp_packet::RouteDistinguisher>,
 }
 
 #[cfg(test)]

--- a/zebra-rs/src/rib/vrf/inst.rs
+++ b/zebra-rs/src/rib/vrf/inst.rs
@@ -41,6 +41,10 @@ pub struct Vrf {
     pub ipv4_export_rts: std::collections::BTreeSet<bgp_packet::RouteDistinguisher>,
     pub ipv6_import_rts: std::collections::BTreeSet<bgp_packet::RouteDistinguisher>,
     pub ipv6_export_rts: std::collections::BTreeSet<bgp_packet::RouteDistinguisher>,
+    /// MUP (mup / SAFI 85) RT sets —
+    /// `set vrf X mup route-target {import,export} …`.
+    pub mup_import_rts: std::collections::BTreeSet<bgp_packet::RouteDistinguisher>,
+    pub mup_export_rts: std::collections::BTreeSet<bgp_packet::RouteDistinguisher>,
 }
 
 /// Per-VRF routing-table set. Mirrors the `table` / `table_v6` /

--- a/zebra-rs/yang/config.yang
+++ b/zebra-rs/yang/config.yang
@@ -3010,6 +3010,16 @@ module config {
           "IPv6 unicast (VPNv6 / RFC 4659) route policy for this VRF.";
         uses vrf-route-target-policy;
       }
+      container mup {
+        description
+          "BGP MUP (RFC 9833 / draft-ietf-bess-mup-safi) route policy for
+           this VRF. The export RTs tag the Session-Transformed routes the
+           MUP controller originates from this VRF; the import RTs select
+           which received ST routes belong to it (the import side is
+           reserved for the MUP import dispatch follow-up). Same
+           `route-target {import|export}` shape as ipv4 / ipv6.";
+        uses vrf-route-target-policy;
+      }
     }
     list policy {
       ext:sort "4";

--- a/zebra-rs/yang/exec.yang
+++ b/zebra-rs/yang/exec.yang
@@ -356,7 +356,7 @@ module exec {
           }
         }
       }
-      container mobile-uplane {
+      container mup {
         ext:help "BGP Mobile User Plane (MUP) RIB";
         presence "BGP Mobile User Plane (MUP) RIB";
         leaf summary {
@@ -443,6 +443,10 @@ module exec {
         }
         leaf neighbor {
           ext:help "Detailed information on this VRF's BGP neighbors";
+          type empty;
+        }
+        leaf mup {
+          ext:help "This VRF's BGP Mobile User Plane (MUP) RIB";
           type empty;
         }
         uses bgp-show-afi-rib;

--- a/zebra-rs/yang/zebra-afi-safi.yang
+++ b/zebra-rs/yang/zebra-afi-safi.yang
@@ -88,7 +88,7 @@ module zebra-afi-safi {
         enum link-state {
           description "BGP Link-State (AFI 16388, SAFI 71, RFC 9552).";
         }
-        enum mobile-uplane {
+        enum mup {
           description
             "BGP Mobile User Plane (MUP), SAFI 85, RFC 9833. A single
              config name that negotiates BOTH IPv4-MUP (AFI 1) and

--- a/zebra-rs/yang/zebra-bgp-mup-controller.yang
+++ b/zebra-rs/yang/zebra-bgp-mup-controller.yang
@@ -29,7 +29,7 @@ module zebra-bgp-mup-controller {
   description
     "BGP MUP Controller (MUP-C) extensions to the BGP candidate-config
      tree. Adds a `mup-c` container under the BGP global AFI/SAFI list,
-     only meaningful when the entry's name is `mobile-uplane` (SAFI 85,
+     only meaningful when the entry's name is `mup` (SAFI 85,
      RFC 9833). When enabled, the BGP task spawns an in-process MUP
      controller that terminates PFCP/N4 (3GPP TS 29.244) as a UP-node,
      learns mobile sessions and (in a follow-up) originates Type-1 /
@@ -39,7 +39,7 @@ module zebra-bgp-mup-controller {
 
        router bgp {
          afi-safi {
-           name mobile-uplane;
+           name mup;
            mup-c {
              enable true;
              controller-address 2001:db8::1;
@@ -61,7 +61,7 @@ module zebra-bgp-mup-controller {
   grouping bgp-afi-safi-mup-c-extension {
     description
       "MUP controller config on the global afi-safi list. Only
-       meaningful when the list entry's name is `mobile-uplane` —
+       meaningful when the list entry's name is `mup` —
        harmless and ignored on other AFI/SAFIs.";
 
     container mup-c {

--- a/zebra-rs/yang/zebra-bgp-vrf.yang
+++ b/zebra-rs/yang/zebra-bgp-vrf.yang
@@ -340,21 +340,15 @@ module zebra-bgp-vrf {
              (IP Prefix) routes. Requires `rd` to be set.";
         }
       }
-      container mobile-uplane {
+      container mup {
         description
-          "BGP MUP (RFC 9833) per-VRF service. route-target/export tags
-           the ST routes the controller originates from this VRF; route
-           selects the Session-Transformed route type (st1 = Type-1 ST
-           / downlink = N6, st2 = Type-2 ST / uplink = N3) and the
-           destination session network-instance matched exactly.";
-        container route-target {
-          leaf-list export {
-            type route-distinguisher;
-            description
-              "Route-targets attached to MUP ST routes originated from
-               this VRF (RT shares the RD wire format).";
-          }
-        }
+          "BGP MUP (RFC 9833) per-VRF service. `route` selects the
+           Session-Transformed route type (st1 = Type-1 ST / downlink =
+           N6, st2 = Type-2 ST / uplink = N3) and the destination session
+           network-instance matched exactly. The export/import route-
+           targets live on the top-level `vrf <name> mup
+           route-target {export|import}` (config.yang), the same place as
+           the ipv4 / ipv6 RT policy.";
         container route {
           description
             "Session-Transformed route origination for this VRF, keyed by


### PR DESCRIPTION
## Summary

Three related changes to the BGP MUP (SAFI 85, RFC 9833 / draft-ietf-bess-mup-safi) CLI surface.

**1. Rename `mobile-uplane` → `mup`.** The CLI/YANG keyword is now `mup` everywhere: the afi-safi enum (`neighbor X afi-safi mup`, `router bgp afi-safi mup mup-c`), `show bgp mup`, `router bgp vrf <name> mup`, and every matching callback-path string + YANG node name (renamed in lockstep), plus the BDD configs/features, book, and design docs. Internal Rust identifiers (`mobile_uplane`, `BgpVrfMobileUplane`, `MupSrv6*`) are left unchanged.

**2. MUP route-target moved to the top-level VRF framework.**

```
- set router bgp vrf N3 mup route-target export 65501:10
+ set vrf N3 mup route-target export 65501:10
```

Reuses the same `vrf-route-target-policy` grouping as `ipv4` / `ipv6`. The RTs are RIB-owned, carried to BGP via `Message::VrfRouteTargets` / `RibRx::VrfRouteTargets` (`mup_{import,export}_rts`) into `rib_known_vrfs`, and read by `build_mup_origination`. Consequence (matching ipv4/ipv6): the export RT now rides the RIB's VRF row, so it requires the VRF's kernel device. The import side is parsed and carried but not yet consumed (reserved for the MUP import dispatch follow-up).

**3. New `show bgp vrf <name> mup`.** The MUP Loc-RIB stays global; `mup_apply_selected` mirrors each best-path to the per-VRF task whose `rd` matches the route's RD (`BgpVrfMsg::Mup{Update,Withdraw}`, display-only — touches `local_rib.mup.selected`). The manager's existing `vrf_redirect_split` routes `show bgp vrf <name> mup` into that task, rendered by `process_vrf_show` → `show_bgp_vrf_mup`. A `/show/bgp/vrf/mup` global handler is the not-running fallback.

## Test plan

- `cargo test -p zebra-rs` (1449) + `-p bgp-packet` (337) + yang_load — green.
- `cargo fmt --all --check` + `cargo clippy --workspace --all-targets -- -D warnings` — clean.
- All 4 MUP BDD features pass as root: `bgp_mup_mixed_afi` (now also asserts `RT:65000:200` from the top-level VRF and `show bgp vrf mobile-up mup`), `bgp_mup_e2e`, `bgp_mup_capability`, `bgp_mup_runtime_enable`.

Generated with [Claude Code](https://claude.com/claude-code)