### PR TITLE
bgp-mup: mirror peer-learned MUP routes into per-VRF view

### DIFF
--- a/bdd/tests/configs/bgp_mup_e2e/z2.yaml
+++ b/bdd/tests/configs/bgp_mup_e2e/z2.yaml
@@ -2,6 +2,19 @@
 # mup afi-safi negotiated. Plain BGP speaker: it has no
 # controller and originates nothing, but receives the Type-1 ST route the
 # controller (z1) originates and shows it under `show bgp mup`.
+#
+# `vrf mobile-up` imports the route's MUP route-target (65000:200, z1's
+# `mobile-up` export). The global MUP Loc-RIB stays authoritative; the
+# receive path mirrors the best-path into the per-VRF task (display only)
+# so `show bgp vrf mobile-up mup` reflects the peer-learned route. The
+# `router bgp vrf` block spawns that per-VRF task and routes the
+# `show bgp vrf <name> mup` redirect to it.
+vrf:
+- name: mobile-up
+  mup:
+    route-target:
+      import:
+      - "65000:200"
 router:
   bgp:
     global:
@@ -16,3 +29,6 @@ router:
         enabled: true
       - name: mup
         enabled: true
+    vrf:
+    - name: mobile-up
+      rd: "65000:100"

--- a/bdd/tests/features/bgp_mup_e2e.feature
+++ b/bdd/tests/features/bgp_mup_e2e.feature
@@ -59,6 +59,9 @@ Feature: BGP MUP Controller originates Session-Transformed routes from PFCP
     Then show command "show bgp mup mup-c session" in namespace "z1" should eventually contain "192.0.2.5"
     And show command "show bgp mup" in namespace "z1" should contain "ue=192.0.2.5/32"
     And show command "show bgp mup" in namespace "z2" should eventually contain "ue=192.0.2.5/32"
+    # The peer-learned route is mirrored into z2's `mobile-up` VRF (it
+    # imports the route's RT 65000:200), so the per-VRF view reflects it.
+    And show command "show bgp vrf mobile-up mup" in namespace "z2" should eventually contain "ue=192.0.2.5/32"
 
   # Session deletion / route withdrawal is covered by the `pfcp.rs`
   # `session_deletion_removes_session` unit test and manual validation; a

--- a/zebra-rs/src/bgp/inst.rs
+++ b/zebra-rs/src/bgp/inst.rs
@@ -299,6 +299,26 @@ pub(crate) fn matching_import_vrfs_v6(
         .collect()
 }
 
+/// MUP (SAFI 85) counterpart of [`matching_import_vrfs`] — intersects
+/// against each VRF's `mup_import_rts` (the top-level `vrf <name> mup
+/// route-target import` set). Drives the display-only mirror of
+/// peer-learned MUP best-paths into per-VRF tasks for
+/// `show bgp vrf <name> mup`.
+pub(crate) fn matching_import_vrfs_mup(
+    vrf_index: &BTreeMap<String, RibKnownVrf>,
+    ecom: &Option<bgp_packet::ExtCommunity>,
+) -> Vec<String> {
+    let route_rts = route_rts_from_ecom(ecom);
+    if route_rts.is_empty() {
+        return Vec::new();
+    }
+    vrf_index
+        .iter()
+        .filter(|(_, info)| !info.mup_import_rts.is_disjoint(&route_rts))
+        .map(|(name, _)| name.clone())
+        .collect()
+}
+
 /// Extract the route-target set a route carries: every extended
 /// community with RT sub-type (`low_type == 0x02`), reinterpreted as a
 /// `RouteDistinguisher` (RT and RD share the on-wire 6-octet shape).
@@ -5396,7 +5416,7 @@ mod tests {
 
         use super::super::{
             RibKnownVrf, import_targets, import_targets_v6, matching_import_vrfs,
-            matching_import_vrfs_v6,
+            matching_import_vrfs_mup, matching_import_vrfs_v6,
         };
 
         fn rt(s: &str) -> RouteDistinguisher {
@@ -5518,6 +5538,56 @@ mod tests {
             let mut got = import_targets(&index, &ecom, None);
             got.sort();
             assert_eq!(got, vec!["v1".to_string(), "v2".to_string()]);
+        }
+
+        fn vrf_with_mup_imports(rts: &[&str]) -> RibKnownVrf {
+            let mut mup_import_rts = BTreeSet::new();
+            for s in rts {
+                mup_import_rts.insert(rt(s));
+            }
+            RibKnownVrf {
+                table_id: 100,
+                ifindex: 1,
+                import_rts_v4: BTreeSet::new(),
+                export_rts_v4: BTreeSet::new(),
+                import_rts_v6: BTreeSet::new(),
+                export_rts_v6: BTreeSet::new(),
+                mup_import_rts,
+                mup_export_rts: BTreeSet::new(),
+                inter_as_hybrid: false,
+            }
+        }
+
+        #[test]
+        fn mup_rt_matches_mup_importing_vrf() {
+            // A peer-learned MUP route carrying RT 65501:10 is mirrored
+            // into the VRF whose `mup import` set contains it.
+            let mut index = BTreeMap::new();
+            index.insert("N3".to_string(), vrf_with_mup_imports(&["65501:10"]));
+            index.insert("N4".to_string(), vrf_with_mup_imports(&["65501:20"]));
+            let ecom = Some(ExtCommunity::from([rt_extcom("65501:10")]));
+            assert_eq!(
+                matching_import_vrfs_mup(&index, &ecom),
+                vec!["N3".to_string()]
+            );
+        }
+
+        #[test]
+        fn mup_ignores_v4_import_rts() {
+            // The MUP fan-out keys on `mup_import_rts` only: a VRF that
+            // imports the same RT for VPNv4 unicast (but not MUP) must
+            // not receive the MUP route.
+            let mut index = BTreeMap::new();
+            index.insert("v1".to_string(), vrf_with_imports(&["65501:10"]));
+            let ecom = Some(ExtCommunity::from([rt_extcom("65501:10")]));
+            assert!(matching_import_vrfs_mup(&index, &ecom).is_empty());
+        }
+
+        #[test]
+        fn mup_no_ecom_matches_no_vrf() {
+            let mut index = BTreeMap::new();
+            index.insert("N3".to_string(), vrf_with_mup_imports(&["65501:10"]));
+            assert!(matching_import_vrfs_mup(&index, &None).is_empty());
         }
 
         #[test]

--- a/zebra-rs/src/bgp/route.rs
+++ b/zebra-rs/src/bgp/route.rs
@@ -7427,6 +7427,12 @@ pub fn route_mup_update(
     rib.attr = bgp.attr_store.intern(attr.clone());
     let _ = bgp.local_rib.update_mup(prefix.clone(), rib);
     let selected = bgp.local_rib.select_best_path_mup(&prefix);
+    // Mirror the new best-path to every VRF whose `mup import` RT set
+    // matches, so `show bgp vrf <name> mup` reflects peer-learned routes
+    // (display only; the global Loc-RIB stays authoritative).
+    if let Some(dispatcher) = bgp.vrf_import {
+        super::vrf::dispatch_mup(dispatcher, &prefix, selected.first());
+    }
     if !selected.is_empty() {
         route_advertise_mup_to_peers(prefix, &selected, bgp, peers);
     }
@@ -7443,6 +7449,12 @@ pub fn route_mup_withdraw(ident: usize, route: &MupRoute, bgp: &mut BgpTop, peer
     }
     let _ = bgp.local_rib.remove_mup(&prefix, id, ident);
     let selected = bgp.local_rib.select_best_path_mup(&prefix);
+    // Mirror the post-withdraw state to per-VRF tasks: a remaining best
+    // path is re-forwarded (matched by RT), otherwise the prefix is
+    // withdrawn from every VRF's display copy.
+    if let Some(dispatcher) = bgp.vrf_import {
+        super::vrf::dispatch_mup(dispatcher, &prefix, selected.first());
+    }
     if selected.is_empty() {
         route_withdraw_mup_to_peers(prefix, peers);
     } else {

--- a/zebra-rs/src/bgp/vrf/inst.rs
+++ b/zebra-rs/src/bgp/vrf/inst.rs
@@ -346,6 +346,52 @@ pub fn dispatch_withdraw_import_v6(
     }
 }
 
+/// Mirror a peer-learned MUP (SAFI 85) best-path — or its withdrawal —
+/// to every VRF whose `mup_import_rts` intersects the route's RT
+/// extcomms, so `show bgp vrf <name> mup` reflects routes received from
+/// peers (not just locally-originated Session-Transformed routes). This
+/// is **display only**: the global `Bgp` Loc-RIB stays the authoritative
+/// MUP RIB and advertiser. It mirrors the originate-side
+/// [`super::super::route::Bgp::forward_mup_to_vrf`], which keys on `rd`
+/// because it already knows the originating VRF; the receive path has no
+/// such context, so it keys on the route's RTs like the VPNv4/v6 import
+/// fan-out.
+///
+/// On withdrawal (`best` is `None`) the route's RTs are no longer
+/// available, so `BgpVrfMsg::MupWithdraw` is flooded to every VRF — the
+/// per-VRF `selected.remove` is idempotent, so a VRF that never held the
+/// prefix simply ignores it.
+pub fn dispatch_mup(
+    dispatcher: &VrfImportDispatcher<'_>,
+    prefix: &bgp_packet::MupPrefix,
+    best: Option<&super::super::route::BgpRib>,
+) {
+    match best {
+        Some(rib) => {
+            let matches = super::super::inst::matching_import_vrfs_mup(
+                dispatcher.rib_known_vrfs,
+                &rib.attr.ecom,
+            );
+            for vrf_name in matches {
+                let Some(handle) = dispatcher.vrf_registry.get(&vrf_name) else {
+                    continue;
+                };
+                let _ = handle.inbox.send(BgpVrfMsg::MupUpdate {
+                    prefix: prefix.clone(),
+                    rib: rib.clone(),
+                });
+            }
+        }
+        None => {
+            for handle in dispatcher.vrf_registry.values() {
+                let _ = handle.inbox.send(BgpVrfMsg::MupWithdraw {
+                    prefix: prefix.clone(),
+                });
+            }
+        }
+    }
+}
+
 impl BgpVrf {
     /// Build a `BgpVrf` and the matching inbound sender. The
     /// caller (`spawn_bgp_vrf`) keeps the `BgpVrfInbox`, hands the

--- a/zebra-rs/src/bgp/vrf/mod.rs
+++ b/zebra-rs/src/bgp/vrf/mod.rs
@@ -25,7 +25,7 @@ pub use sid::{BgpSidPool, Srv6VrfSid};
 // `msg::BgpVrfMsg` stay internal — they're constructed / consumed
 // inside `vrf::spawn` only.
 pub use inst::{
-    VrfExporter, VrfImportDispatcher, dispatch_import_v4, dispatch_import_v6,
+    VrfExporter, VrfImportDispatcher, dispatch_import_v4, dispatch_import_v6, dispatch_mup,
     dispatch_withdraw_import_v4, dispatch_withdraw_import_v6, vrf_emit_export, vrf_emit_export_v6,
     vrf_emit_withdraw, vrf_emit_withdraw_v6,
 };


### PR DESCRIPTION
## Summary

`show bgp vrf <name> mup` reads a per-VRF mirror of the global MUP Loc-RIB. That mirror was populated only on the **locally-originated** path (`originate_mup_route` → `forward_mup_to_vrf`); the **peer-received** path (`route_mup_update`/`route_mup_withdraw`) updated the global Loc-RIB and re-advertised but never mirrored to the VRF. So a route learned from a neighbor appeared in `show bgp mup` but never in `show bgp vrf <name> mup`.

This finishes the staged "MUP import dispatch follow-up" (the reserved `RibKnownVrf::mup_import_rts`): each peer-learned MUP best-path is fanned out to every VRF whose `mup import` route-target set intersects the route's RTs, reusing the `VrfImportDispatcher` already carried on the receive-path `BgpTop`.

- `bgp/inst.rs`: `matching_import_vrfs_mup()` (mirrors `matching_import_vrfs[_v6]`) + 3 unit tests.
- `bgp/vrf/inst.rs`: `dispatch_mup()` sends `BgpVrfMsg::Mup{Update,Withdraw}`; on withdraw with no remaining path it floods (the per-VRF remove is idempotent).
- `bgp/vrf/mod.rs`: re-export `dispatch_mup`.
- `bgp/route.rs`: `route_mup_update`/`route_mup_withdraw` invoke it via `bgp.vrf_import`.

The originate path stays RD-keyed (it knows its originating VRF); the receive path is RT-keyed (no originating-VRF context), matching the VPNv4/v6 import fan-out. Display-only — the global instance remains the authoritative MUP RIB and advertiser.

## Test plan

- `cargo build`, `cargo fmt --all`, `cargo clippy --workspace --all-targets --exclude bdd -- -D warnings` — clean.
- Full `zebra-rs` test suite: 1453 passed (incl. 3 new `matching_import_vrfs_mup` tests).
- BDD: `bgp_mup_e2e` extended — z2 imports the route's RT (`65000:200`) into a `mobile-up` VRF and asserts `show bgp vrf mobile-up mup` shows the peer-learned route. Not yet run locally (a full BDD suite was occupying `/usr/bin/zebra-rs`); to be validated by CI / a later run.

Generated with [Claude Code](https://claude.com/claude-code)