### PR TITLE
bdd: give @ospfv3_tilfa reverse path more convergence headroom

### DIFF
--- a/bdd/tests/cucumber.rs
+++ b/bdd/tests/cucumber.rs
@@ -307,7 +307,12 @@ async fn ping_should_succeed(world: &mut World, namespace: String, target: Strin
 #[then(expr = "ping from {string} to {string} should eventually succeed")]
 async fn ping_eventually_succeeds(world: &mut World, namespace: String, target: String) {
     let scoped = world.ns(&namespace);
-    const ATTEMPTS: u32 = 30;
+    // 60 ≈ the `show … should eventually` budget. The shorter 30s here let a
+    // load-sensitive convergence flake through (`@ospfv3_tilfa`: d's route to
+    // the source loopback /128 lands just past 30s under full-suite CPU load —
+    // it polls to success in isolation). A longer budget only delays the
+    // failure of a genuinely-broken path; it never turns a fail into a pass.
+    const ATTEMPTS: u32 = 60;
     for i in 0..ATTEMPTS {
         let ok = if target.contains(':') {
             netns::ping6(&scoped, &target, 1, 1).await

--- a/bdd/tests/features/ospfv3_tilfa.feature
+++ b/bdd/tests/features/ospfv3_tilfa.feature
@@ -136,8 +136,10 @@ Feature: OSPFv3 TI-LFA fast-reroute over SR-MPLS
     # route to s flips from the expensive r3 path to the n1 path only
     # once every E-LSA has flooded and n1's ILM for s's node-SID
     # (16100, kept end-to-end by the v3 NP flag) settles — observed
-    # ~40s after config, right at this scenario's runtime. Poll
-    # instead of single-shot.
+    # ~40s after config, and slower still under full-suite CPU load.
+    # Give it explicit settle time, then poll (60-attempt budget) rather
+    # than single-shot.
+    And I wait 20 seconds
     And ping from "d" to "2001:db8::1" should eventually succeed
 
   Scenario: Fast-reroute survives the primary link failure (s-n1)


### PR DESCRIPTION
## Summary

Fixes a load-sensitive flake at `@ospfv3_tilfa` (the last feature in the suite). The "source reaches destination over the primary path" scenario polls `ping from "d" to "2001:db8::1" should eventually succeed` — d's route to the source loopback /128 only settles once every E-LSA has flooded and n1's ILM for s's node-SID converges (~40s after config, per the feature's own comment). Under full-suite CPU load that lands just past the step's 30-attempt (~30s) budget, so the full run flaked here while isolation passes 10/10.

Two test-only changes:
- Raise the `ping … should eventually succeed` budget **30 → 60** attempts, matching the existing `show … should eventually` budget. A longer budget only delays a genuinely-broken path's failure; it never masks one.
- Add a **20s settle wait** before the reverse ping in `@ospfv3_tilfa`, where this slow-reverse-convergence race is already documented.

## Test plan

- `@ospfv3_tilfa` passes 10/10 scenarios in isolation; the daemon binary is unchanged (no rebuild).

Generated with [Claude Code](https://claude.com/claude-code)