### PR TITLE
bgp-mup: originate DSD segment route + End.DT46 (P6 slice 1)

### DIFF
--- a/bdd/Makefile
+++ b/bdd/Makefile
@@ -33,6 +33,14 @@ bgp_mup_mixed_afi:
 	mkdir -p allure-results
 	cargo test --test cucumber -- --concurrency=1 --tags "@bgp_mup_mixed_afi"
 
+# MUP segment DSD: a PE with `encapsulation srv6` VRF + `afi-safi mup
+# segment direct` carves a per-VRF End.DT46 SID, installs the seg6local
+# decap, and originates a Direct Segment Discovery (DSD) route the peer
+# receives. Needs root netns (kernel VRF + seg6local).
+bgp_mup_segment_dsd:
+	mkdir -p allure-results
+	cargo test --test cucumber -- --concurrency=1 --tags "@bgp_mup_segment_dsd"
+
 rib_static_ipv6:
 	mkdir -p allure-results
 	cargo test --test cucumber -- --concurrency=1 --tags "@rib_static_ipv6"

--- a/bdd/tests/configs/bgp_mup_segment_dsd/z1.yaml
+++ b/bdd/tests/configs/bgp_mup_segment_dsd/z1.yaml
@@ -1,0 +1,67 @@
+# z1 — MUP PE originating a Direct Segment Discovery (DSD, type 2) route
+# for VRF N6 (`afi-safi mup segment direct`). IS-IS L2 SRv6 underlay +
+# iBGP (mup afi-safi) to z2 over loopbacks. VRF N6 is `encapsulation
+# srv6`, so it carves a per-VRF End.DT46 service SID from locator S and
+# installs the seg6local decap into the VRF table; `segment direct`
+# advertises that segment as a DSD route (NLRI = rd + router-id) carrying
+# the End.DT46 SID as the SRv6 L3 Service, received by z2.
+vrf:
+- name: N6
+  mup:
+    route-target:
+      export:
+      - "65501:10"
+interface:
+- if-name: lo
+  ipv6:
+    address: 2001:db8::1/128
+- if-name: z1-z2
+  ipv6:
+    address: 2001:db8:0:12::1/64
+segment-routing:
+  locator:
+  - name: S
+    prefix: fcbb:bbbb:1::/48
+    behavior: usid
+router:
+  isis:
+    net: 49.0000.0000.0000.0001.00
+    hostname: z1
+    is-type: level-2-only
+    segment-routing:
+      srv6:
+        locator: S
+    interface:
+    - if-name: lo
+      ipv6:
+        enable: true
+    - if-name: z1-z2
+      network-type: point-to-point
+      metric: 1
+      ipv6:
+        enable: true
+  bgp:
+    global:
+      as: 65501
+      router-id: 10.0.0.1
+    timer:
+      adv-interval:
+        ibgp: 1
+    segment-routing:
+      srv6:
+        locator: S
+    neighbor:
+    - remote-address: 2001:db8::2
+      remote-as: 65501
+      update-source: 2001:db8::1
+      enabled: true
+      afi-safi:
+      - name: mup
+        enabled: true
+    vrf:
+    - name: N6
+      rd: "65501:10"
+      encapsulation: srv6
+      afi-safi:
+        mup:
+          segment: direct

--- a/bdd/tests/configs/bgp_mup_segment_dsd/z2.yaml
+++ b/bdd/tests/configs/bgp_mup_segment_dsd/z2.yaml
@@ -1,0 +1,51 @@
+# z2 — MUP peer that receives z1's Direct Segment Discovery (DSD) route.
+# IS-IS L2 SRv6 underlay + iBGP (mup afi-safi) to z1 over loopbacks. No
+# VRF / segment of its own — it just stores the DSD route (RD + z1's
+# router-id) carrying z1's End.DT46 SID in its MUP Loc-RIB.
+interface:
+- if-name: lo
+  ipv6:
+    address: 2001:db8::2/128
+- if-name: z2-z1
+  ipv6:
+    address: 2001:db8:0:12::2/64
+segment-routing:
+  locator:
+  - name: LOC2
+    prefix: fcbb:bbbb:2::/48
+    behavior: usid
+router:
+  isis:
+    net: 49.0000.0000.0000.0002.00
+    hostname: z2
+    is-type: level-2-only
+    segment-routing:
+      srv6:
+        locator: LOC2
+    interface:
+    - if-name: lo
+      ipv6:
+        enable: true
+    - if-name: z2-z1
+      network-type: point-to-point
+      metric: 1
+      ipv6:
+        enable: true
+  bgp:
+    global:
+      as: 65501
+      router-id: 10.0.0.2
+    timer:
+      adv-interval:
+        ibgp: 1
+    segment-routing:
+      srv6:
+        locator: LOC2
+    neighbor:
+    - remote-address: 2001:db8::1
+      remote-as: 65501
+      update-source: 2001:db8::2
+      enabled: true
+      afi-safi:
+      - name: mup
+        enabled: true

--- a/bdd/tests/features/bgp_mup_segment_dsd.feature
+++ b/bdd/tests/features/bgp_mup_segment_dsd.feature
@@ -1,0 +1,66 @@
+@serial
+@bgp_mup_segment_dsd
+Feature: BGP MUP PE originates a Direct Segment Discovery (DSD) route over SRv6
+  As a network operator
+  I want a zebra-rs BGP MUP PE to originate a Direct Segment Discovery
+  (DSD, type 2, SAFI 85 / RFC 9833) route for an `encapsulation srv6` VRF
+  when `afi-safi mup segment direct` is configured, so the per-VRF End.DT46
+  service SID is carved from the locator, installed into the kernel FIB, and
+  advertised as the segment a receiving PE resolves for matching
+  Session-Transformed routes (the draft-ietf-bess-mup-safi default).
+
+  Test Topology:
+  ```
+        2001:db8::1/128            2001:db8::2/128
+       ┌──────────┐  IS-IS L2 SRv6  ┌──────────┐
+       │    z1    │═════════════════│    z2    │
+       │ MUP PE   │   iBGP (mup)    │ receiver │
+       │ vrf N6   │                 │          │
+       └──────────┘                 └──────────┘
+   z1-z2 2001:db8:0:12::1/64   2001:db8:0:12::2/64
+  ```
+
+  z1 has VRF N6 (`encapsulation srv6`, rd 65501:10) and
+  `afi-safi mup segment direct`, so it carves an End.DT46 SID from locator
+  S, installs the seg6local decap into N6's table, and originates a DSD
+  route (NLRI = rd + router-id 10.0.0.1) carrying that SID. z2 receives it.
+
+  Scenario: Build topology and establish iBGP with the MUP capability
+    Given a clean test environment
+    When I create namespace "z1"
+    And I create namespace "z2"
+    And I connect namespace "z1" interface "z1-z2" to namespace "z2" interface "z2-z1"
+    And I start zebra-rs in namespace "z1"
+    And I start zebra-rs in namespace "z2"
+    And I apply config "z1.yaml" to namespace "z1"
+    And I apply config "z2.yaml" to namespace "z2"
+    And I wait 45 seconds
+    Then BGP session in "z1" to "2001:db8::2" should be "Established"
+    And BGP session in "z2" to "2001:db8::1" should be "Established"
+    And show command "show bgp neighbor 2001:db8::2" in namespace "z1" should contain "IPv4 MUP: advertised and received"
+
+  Scenario: z1 originates the DSD route and installs the End.DT46 SID
+    Given the test topology exists
+    # The DSD NLRI is the VRF RD + router-id, riding the IPv4-MUP AFI.
+    Then show command "show bgp mup" in namespace "z1" should eventually contain "[DSD][65501:10][10.0.0.1]"
+    # The route carries the per-VRF End.DT46 SID as a local SRv6 L3 Service.
+    And show command "show bgp mup" in namespace "z1" should contain "Local SID"
+    And show command "show bgp mup" in namespace "z1" should contain "End.DT46"
+    # The per-VRF view mirrors the originated DSD (its RD matches N6's rd).
+    And show command "show bgp vrf N6 mup" in namespace "z1" should eventually contain "[DSD][65501:10][10.0.0.1]"
+    # Step 4: the End.DT46 decap is installed into the kernel FIB.
+    And command "ip -6 route show table all" in namespace "z1" should eventually contain "End.DT46"
+
+  Scenario: z2 receives the DSD route with the End.DT46 SID
+    Given the test topology exists
+    Then show command "show bgp mup" in namespace "z2" should eventually contain "[DSD][65501:10][10.0.0.1]"
+    And show command "show bgp mup" in namespace "z2" should contain "Remote SID"
+    And show command "show bgp mup" in namespace "z2" should contain "End.DT46"
+
+  Scenario: Teardown topology
+    Given the test topology exists
+    When I stop zebra-rs in namespace "z1"
+    And I stop zebra-rs in namespace "z2"
+    And I delete namespace "z1"
+    And I delete namespace "z2"
+    Then the test environment should be clean

--- a/docs/design/bgp-mup-followups.md
+++ b/docs/design/bgp-mup-followups.md
@@ -381,6 +381,52 @@ PE-derived forwarding, see *Draft-default forwarding* above.
 
 ### P6 — SRv6-mobile dataplane
 
+#### P6 slice 1 — DSD origination + End.DT46 (2026-06-23) — **DONE**
+
+The first P6 slice landed the **PE-side Direct Segment Discovery (DSD,
+type 2) origination** that the draft-default ST routes resolve against:
+
+- **`afi-safi mup segment {direct|interwork}`** on a per-VRF BGP block
+  (zebra-bgp-vrf.yang, under the per-VRF `afi-safi` container — distinct
+  from the controller-side `mup route {st1|st2}`). `MupSegmentMode` on
+  `BgpVrfMobileUplane`; callback `/router/bgp/vrf/afi-safi/mup/segment`.
+  `interwork` (ISD, type 1) is parsed but origination is deferred.
+- **`segment direct` originates a DSD** route for the VRF: NLRI is the
+  VRF **RD + router-id** (so it rides the IPv4-MUP AFI); the attributes
+  carry the PE locator node as the **IPv6 next-hop** and the per-VRF
+  **End.DT46 SID** as the SRv6 L3 Service (`srv6_l3_service_prefix_sid`,
+  `SRV6_BEHAVIOR_END_DT46`). `build_mup_dsd_origination` /
+  `originate_mup_dsd` / `withdraw_mup_dsd` mirror the controller ST path;
+  `reconcile_mup_dsd` is the idempotent driver.
+- **SID + FIB install are pure reuse** of L3VPN-over-SRv6: a VRF with
+  `encapsulation srv6` already carves an End.DT46 SID (`alloc_vrf_sid`)
+  and installs the `seg6local End.DT46 SEG6_LOCAL_VRFTABLE(table_id)`
+  decap at spawn. The DSD path only *reads* `vrf_registry[name].srv6_sid`
+  and advertises it — no new alloc / FIB code.
+- **Gating + reconcile triggers:** the DSD originates only once the VRF
+  has `segment direct` + `encapsulation srv6` + an RD + a resolved SID +
+  a **known kernel VRF** (proxy for "End.DT46 is installed") + a non-zero
+  router-id. `reconcile_mup_dsd` runs from `apply_vrf_commit_diff`,
+  `maybe_respawn_vrf_with_kernel_ctx` (kernel-ctx / FIB install),
+  `reconcile_srv6_vrfs` (locator-driven SID change under a stable key),
+  the `VrfDel` and MUP-RT (`VrfRouteTargets`) handlers, and `set_router_id`
+  (the router-id is in the NLRI key). `route_update_mup` advertises the
+  attr IPv6 next-hop for originated routes carrying a Prefix-SID (DSD);
+  ST routes (no Prefix-SID) are unaffected.
+- **Show:** `show bgp mup` / `show bgp vrf <name> mup` now print the SRv6
+  L3 SID line (`Local/Remote SID <sid> (End.DT46)`).
+- **Test:** `@bgp_mup_segment_dsd` BDD (root) — z1 originates the DSD,
+  installs the `seg6local End.DT46` (asserted via `ip -6 route show table
+  all`), and z2 receives it with the SID. Excluded from CI; run live via
+  `make -C bdd bgp_mup_segment_dsd`.
+
+**Still open in P6:** the *receive* side — a PE consuming a peer's DSD/ISD
+route to drive forwarding (the *ISD/DSD-route → segment-SID resolution*
+step below), ISD (`segment interwork`) origination, and the GTP
+behaviours.
+
+#### Remaining
+
 **What:** Install the FIB state that actually forwards MUP traffic. With
 the draft-default model (see *Draft-default forwarding* above), the PE
 receiving an ST route resolves its forwarding SID from the matching

--- a/zebra-rs/src/bgp/config.rs
+++ b/zebra-rs/src/bgp/config.rs
@@ -4089,6 +4089,10 @@ impl Bgp {
             "/router/bgp/vrf/mup/route/st1/dest-network-instance/access/exact",
             super::vrf_config::config_vrf_mup_route_st1,
         );
+        self.callback_add(
+            "/router/bgp/vrf/afi-safi/mup/segment",
+            super::vrf_config::config_vrf_mup_segment,
+        );
 
         // `set router bgp interface-neighbor <name> [...]`.
         self.callback_add(

--- a/zebra-rs/src/bgp/inst.rs
+++ b/zebra-rs/src/bgp/inst.rs
@@ -210,7 +210,7 @@ pub struct Srv6Ipv6Export {
     pub nexthop: std::net::Ipv6Addr,
 }
 
-fn srv6_l3_service_prefix_sid(
+pub(super) fn srv6_l3_service_prefix_sid(
     sid: std::net::Ipv6Addr,
     structure: Option<crate::rib::SidStructure>,
     behavior: u16,
@@ -681,6 +681,13 @@ pub struct Bgp {
     /// (the PE derives forwarding from its ISD/DSD routes), so only the
     /// prefix is retained.
     pub mup_c_originated: BTreeMap<u64, bgp_packet::MupPrefix>,
+    /// Config-driven MUP DSD (Direct Segment Discovery, type 2) routes
+    /// originated per VRF (`afi-safi mup segment direct`), keyed by VRF
+    /// name → `(originated NLRI, End.DT46 SID)`. The SID is tracked
+    /// alongside the prefix so a locator-driven SID change re-advertises
+    /// even though the RD+router-id NLRI key is stable. See
+    /// [`Bgp::reconcile_mup_dsd`].
+    pub mup_dsd_originated: BTreeMap<String, (bgp_packet::MupPrefix, std::net::Ipv6Addr)>,
     /// Local bridge FDB shadow keyed by `(vni, mac)`. Populated from
     /// every `RibRx::FdbAdd`, removed on `RibRx::FdbDel`. We need
     /// durable state (not just one-shot event handling) because the
@@ -1121,6 +1128,7 @@ impl Bgp {
             mup_c_view: crate::mup_c::inst::MupCView::default(),
             mup_c_dirty: false,
             mup_c_originated: BTreeMap::new(),
+            mup_dsd_originated: BTreeMap::new(),
             local_fdb: BTreeMap::new(),
             local_vxlans: BTreeMap::new(),
             local_smet: BTreeMap::new(),
@@ -1430,6 +1438,9 @@ impl Bgp {
         for name in srv6_vrfs {
             self.resid_vrf(&name);
         }
+        // The SIDs just changed under stable RD+router-id keys — re-advertise
+        // any `segment direct` DSD route with the new End.DT46 SID.
+        self.reconcile_mup_dsd();
     }
 
     /// `segment-routing srv6 ipv6-unicast` toggle. Enables or disables
@@ -1677,6 +1688,11 @@ impl Bgp {
                 }
             }
         }
+
+        // MUP DSD NLRIs embed the router-id (RD + router-id); a router-id
+        // change rebinds the key, so withdraw the old-keyed DSD and
+        // re-originate under the new — `reconcile_mup_dsd` does both.
+        self.reconcile_mup_dsd();
     }
 
     /// Recompute the effective BGP Identifier from its two sources —
@@ -2217,6 +2233,9 @@ impl Bgp {
         // colour-steering snapshot so SRv6 L3VPN routes steer from the
         // first install, not only after the next shadow change.
         self.broadcast_colour_steering();
+        // Originate / withdraw config-driven MUP DSD segment routes now the
+        // VRF set (and its SIDs / kernel context) may have changed.
+        self.reconcile_mup_dsd();
     }
 
     /// Reconcile the MUP controller against `mup_c_config` at every
@@ -2316,6 +2335,9 @@ impl Bgp {
             table_id,
             "bgp: respawned per-VRF task with real ProtoContext::for_vrf",
         );
+        // The respawn with real kernel context is what actually installs the
+        // End.DT46 decap; a `segment direct` VRF can now originate its DSD.
+        self.reconcile_mup_dsd();
     }
 
     pub fn process_cm_msg(&mut self, msg: ConfigRequest) {
@@ -3175,6 +3197,9 @@ impl Bgp {
                 // per-VRF task carries the YANG intent. If the
                 // operator subsequently deletes the BGP VRF block,
                 // `apply_vrf_commit_diff` handles teardown.
+                // The kernel VRF (and its End.DT46 decap) is gone, so
+                // withdraw any DSD segment route that depended on it.
+                self.reconcile_mup_dsd();
             }
             RibRx::VrfRouteTargets {
                 name,
@@ -3201,6 +3226,7 @@ impl Bgp {
                 let entry = self.rib_known_vrfs.entry(name.clone()).or_default();
                 let export_v4_changed = entry.export_rts_v4 != ipv4_export_rts;
                 let export_v6_changed = entry.export_rts_v6 != ipv6_export_rts;
+                let export_mup_changed = entry.mup_export_rts != mup_export_rts;
                 entry.import_rts_v4 = ipv4_import_rts;
                 entry.export_rts_v4 = ipv4_export_rts;
                 entry.import_rts_v6 = ipv6_import_rts;
@@ -3219,6 +3245,11 @@ impl Bgp {
                 }
                 if export_v6_changed {
                     self.retag_vrf_exports_v6(&name);
+                }
+                // Re-stamp the VRF's DSD segment route with the new MUP
+                // export RTs (same race the v4/v6 retag above closes).
+                if export_mup_changed {
+                    self.reconcile_mup_dsd();
                 }
             }
             // Redistribute deliveries from RIB — initial walk

--- a/zebra-rs/src/bgp/route.rs
+++ b/zebra-rs/src/bgp/route.rs
@@ -7506,10 +7506,14 @@ fn route_update_mup(
     let mut attrs = (*rib.attr).clone();
     ebgp_egress_aspath(&peer.egress_as(), &mut attrs);
 
-    // MP_REACH next-hop: next-hop-self toward eBGP and for our own
-    // originations; otherwise preserve the received next-hop (RFC 9833 —
-    // the PE/controller address the ingress PE resolves).
-    let nhop: IpAddr = if peer.is_ebgp() || rib.is_originated() {
+    // MP_REACH next-hop: an SRv6 segment route we originate (a DSD carrying
+    // an End.DT46 Prefix-SID) advertises the PE locator node carried in the
+    // attr, so a receiving PE H.Encaps to it; next-hop-self toward eBGP and
+    // for our other originations; otherwise preserve the received next-hop
+    // (RFC 9833 — the PE/controller address the ingress PE resolves).
+    let nhop: IpAddr = if rib.is_originated() && attrs.prefix_sid.is_some() {
+        bgp_nexthop_ip(attrs.nexthop.as_ref()?)?
+    } else if peer.is_ebgp() || rib.is_originated() {
         if let Some(ref local_addr) = peer.param.local_addr {
             local_addr.ip()
         } else {
@@ -12576,6 +12580,154 @@ impl Bgp {
             },
         };
         let _ = handle.inbox.send(msg);
+    }
+
+    /// Reconcile config-driven MUP DSD (Direct Segment Discovery, type 2)
+    /// origination across every VRF. Idempotent — safe to call after VRF
+    /// spawn / kernel-ctx respawn, locator (SID) change, and MUP RT update.
+    /// Originates a DSD for each VRF that now qualifies (see
+    /// [`Self::build_mup_dsd_origination`]), withdraws those that no longer
+    /// do, and re-advertises when the SID changed under a stable NLRI key.
+    pub(super) fn reconcile_mup_dsd(&mut self) {
+        let names: Vec<String> = self.vrfs.keys().cloned().collect();
+        let mut desired: std::collections::BTreeMap<
+            String,
+            (bgp_packet::MupPrefix, std::net::Ipv6Addr, BgpAttr),
+        > = std::collections::BTreeMap::new();
+        for name in &names {
+            if let Some(d) = self.build_mup_dsd_origination(name) {
+                desired.insert(name.clone(), d);
+            }
+        }
+        // Withdraw DSDs no longer desired, or whose NLRI key changed (a
+        // changed RD/router-id needs an explicit withdraw of the OLD prefix
+        // before the new one is originated under a different key).
+        let prev: Vec<(String, bgp_packet::MupPrefix)> = self
+            .mup_dsd_originated
+            .iter()
+            .map(|(n, (p, _))| (n.clone(), p.clone()))
+            .collect();
+        for (name, prev_prefix) in prev {
+            let keep = desired
+                .get(&name)
+                .map(|(p, _, _)| *p == prev_prefix)
+                .unwrap_or(false);
+            if !keep {
+                self.withdraw_mup_dsd(&name);
+            }
+        }
+        // Originate or refresh. Skip when both the NLRI key and the SID are
+        // unchanged so an unrelated commit doesn't re-advertise.
+        for (name, (prefix, sid, attr)) in desired {
+            let unchanged = self
+                .mup_dsd_originated
+                .get(&name)
+                .map(|(p, s)| *p == prefix && *s == sid)
+                .unwrap_or(false);
+            if unchanged {
+                continue;
+            }
+            self.originate_mup_dsd(name, prefix, sid, attr);
+        }
+    }
+
+    /// Build a VRF's DSD origination, or `None` when it shouldn't originate
+    /// one right now. Gates: `afi-safi mup segment direct`, `encapsulation
+    /// srv6`, a configured RD, a resolved per-VRF End.DT46 SID, a resolved
+    /// locator, and a known kernel VRF — the last so the local End.DT46
+    /// decap is already installed before the segment is advertised (the SID
+    /// install rides the same `VrfAdd`/spawn path).
+    ///
+    /// The NLRI is the VRF RD + router-id (so the route rides the IPv4-MUP
+    /// AFI); the attributes carry the PE locator node as the IPv6 next-hop
+    /// and the End.DT46 SID as the SRv6 L3 Service — the segment a receiving
+    /// PE resolves for matching Session-Transformed routes. Returns
+    /// `(prefix, sid_addr, attr)`.
+    fn build_mup_dsd_origination(
+        &self,
+        name: &str,
+    ) -> Option<(bgp_packet::MupPrefix, std::net::Ipv6Addr, BgpAttr)> {
+        use super::vrf_config::{BgpVrfEncapsulation, MupSegmentMode};
+        let cfg = self.vrfs.get(name)?;
+        if cfg.mobile_uplane.segment != Some(MupSegmentMode::Direct) {
+            return None;
+        }
+        if cfg.encapsulation != BgpVrfEncapsulation::Srv6 {
+            return None;
+        }
+        let rd = cfg.rd?;
+        // The End.DT46 decap must already be installed in the kernel before
+        // we advertise the segment — a known kernel VRF (the SID install
+        // path) is the proxy for "installed".
+        if !self.rib_known_vrfs.contains_key(name) {
+            return None;
+        }
+        let (sid, _function) = self.vrf_registry.get(name)?.srv6_sid?;
+        let locator = self.srv6_locator.as_ref()?;
+        let node = locator.node_sid_addr()?;
+        let router_id = cfg.router_id.unwrap_or(self.router_id);
+        // The DSD NLRI embeds the router-id; never originate one under the
+        // all-zero identity (cold start before the router-id resolves —
+        // `reconcile_mup_dsd` re-runs from `set_router_id`).
+        if router_id.is_unspecified() {
+            return None;
+        }
+        let prefix = bgp_packet::MupPrefix::Dsd {
+            rd,
+            address: IpAddr::V4(router_id),
+        };
+        let rts = self
+            .rib_known_vrfs
+            .get(name)
+            .map(|k| k.mup_export_rts.clone())
+            .unwrap_or_default();
+        let mut attr = build_mup_attr(Some(node), &rts);
+        attr.prefix_sid = Some(super::inst::srv6_l3_service_prefix_sid(
+            sid,
+            locator.sid_structure(),
+            bgp_packet::SRV6_BEHAVIOR_END_DT46,
+        ));
+        Some((prefix, sid, attr))
+    }
+
+    /// Install one VRF's DSD route into the MUP Loc-RIB as `Originated` and
+    /// advertise it (mirrors [`Self::originate_mup_route`]). Tracks
+    /// `(prefix, sid)` so [`Self::reconcile_mup_dsd`] can detect a SID
+    /// change under a stable RD+router-id key.
+    fn originate_mup_dsd(
+        &mut self,
+        name: String,
+        prefix: bgp_packet::MupPrefix,
+        sid: std::net::Ipv6Addr,
+        attr: BgpAttr,
+    ) {
+        let mut rib = BgpRib::new(
+            ORIGINATED_PEER,
+            Ipv4Addr::UNSPECIFIED,
+            BgpRibType::Originated,
+            0,
+            32768,
+            &attr,
+            None,
+            None,
+            false,
+        );
+        rib.attr = self.attr_store.intern(attr);
+        let _ = self.local_rib.update_mup(prefix.clone(), rib);
+        let selected = self.local_rib.select_best_path_mup(&prefix);
+        self.mup_dsd_originated.insert(name, (prefix.clone(), sid));
+        self.mup_apply_selected(prefix, selected);
+    }
+
+    /// Withdraw the DSD route originated for `name` (a config / SID /
+    /// kernel-VRF precondition dropped). No-op when nothing was originated.
+    fn withdraw_mup_dsd(&mut self, name: &str) {
+        let Some((prefix, _sid)) = self.mup_dsd_originated.remove(name) else {
+            return;
+        };
+        self.local_rib.remove_mup(&prefix, 0, ORIGINATED_PEER);
+        let selected = self.local_rib.select_best_path_mup(&prefix);
+        self.mup_apply_selected(prefix, selected);
     }
 
     pub fn route_add(&mut self, prefix: Ipv4Net) {

--- a/zebra-rs/src/bgp/show.rs
+++ b/zebra-rs/src/bgp/show.rs
@@ -3690,6 +3690,21 @@ fn render_mup_table(
         let nexthop = show_nexthop(&rib.attr);
         writeln!(buf, "       next-hop {nexthop}  weight {}", rib.weight)?;
 
+        // SRv6 L3 Service SID (the segment a DSD/ISD route advertises, or
+        // an explicitly-pushed ST-route SID). "Local" when we originated it.
+        if let Some((sid, behavior)) = rib.attr.srv6_l3_sid() {
+            let kind = if rib.is_originated() {
+                "Local SID"
+            } else {
+                "Remote SID"
+            };
+            writeln!(
+                buf,
+                "       {kind} {sid} ({})",
+                srv6_behavior_name(behavior)
+            )?;
+        }
+
         let ecom = show_mup_ecom(&rib.attr);
         if !ecom.is_empty() {
             writeln!(buf, "       {ecom}")?;
@@ -4794,6 +4809,7 @@ mod detail_tests {
                     direction: MupSrv6Direction::Decapsulation,
                     network_instance: Some("core-ni".to_string()),
                 }),
+                segment: None,
             },
             ..Default::default()
         };
@@ -4804,6 +4820,7 @@ mod detail_tests {
                     direction: MupSrv6Direction::Encapsulation,
                     network_instance: Some("access-ni".to_string()),
                 }),
+                segment: None,
             },
             ..Default::default()
         };

--- a/zebra-rs/src/bgp/vrf_config.rs
+++ b/zebra-rs/src/bgp/vrf_config.rs
@@ -132,6 +132,28 @@ pub enum MupSrv6Direction {
     Encapsulation,
 }
 
+/// MUP Segment Discovery route type for a per-VRF service — the PE side
+/// (zebra-bgp-vrf.yang `afi-safi mup segment {direct|interwork}`).
+/// `Direct` originates a Direct Segment Discovery (DSD, type 2) route
+/// carrying the VRF's End.DT46 SID; `Interwork` an Interwork Segment
+/// Discovery (ISD, type 1) route. Independent of [`MupSrv6Mobile`], which
+/// is the controller-side Session-Transformed origination binding.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MupSegmentMode {
+    Direct,
+    Interwork,
+}
+
+impl MupSegmentMode {
+    fn parse(s: &str) -> Option<Self> {
+        match s {
+            "direct" => Some(Self::Direct),
+            "interwork" => Some(Self::Interwork),
+            _ => None,
+        }
+    }
+}
+
 /// `mup route {st1|st2} dest-network-instance {access|core}
 /// exact <ni>` for one VRF: the ST route type (as a direction) plus the
 /// session network-instance matched exactly. Surfaced in
@@ -153,6 +175,11 @@ pub struct MupSrv6Mobile {
 #[derive(Default, Debug, Clone)]
 pub struct BgpVrfMobileUplane {
     pub srv6_mobile: Option<MupSrv6Mobile>,
+    /// `afi-safi mup segment {direct|interwork}` — PE-side Segment
+    /// Discovery origination for this VRF. `Direct` → DSD (type 2,
+    /// carrying the VRF's End.DT46 SID); `Interwork` → ISD (type 1,
+    /// origination deferred). Independent of `srv6_mobile`.
+    pub segment: Option<MupSegmentMode>,
 }
 
 /// Staged candidate configuration for one VRF entry. Mirrors the
@@ -313,6 +340,24 @@ pub fn config_vrf_mup_route_st1(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> 
             });
         }
         ConfigOp::Delete => cfg.mobile_uplane.srv6_mobile = None,
+        _ => {}
+    }
+    Some(())
+}
+
+/// `set router bgp vrf <NAME> afi-safi mup segment {direct|interwork}` —
+/// PE-side Segment Discovery origination. `direct` originates a Direct
+/// Segment Discovery (DSD, type 2) route carrying the VRF's End.DT46 SID;
+/// `interwork` an Interwork Segment Discovery (ISD, type 1) route.
+pub fn config_vrf_mup_segment(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Option<()> {
+    let name = args.string()?;
+    let cfg = vrf_entry(bgp, name);
+    match op {
+        ConfigOp::Set => {
+            let raw = args.string()?;
+            cfg.mobile_uplane.segment = Some(MupSegmentMode::parse(&raw)?);
+        }
+        ConfigOp::Delete => cfg.mobile_uplane.segment = None,
         _ => {}
     }
     Some(())

--- a/zebra-rs/yang/zebra-bgp-vrf.yang
+++ b/zebra-rs/yang/zebra-bgp-vrf.yang
@@ -213,6 +213,35 @@ module zebra-bgp-vrf {
           }
         }
       }
+      container mup {
+        description
+          "Per-VRF MUP (RFC 9833) Segment Discovery origination — the PE
+           side. `segment direct` originates a Direct Segment Discovery
+           (DSD, type 2) route for this VRF carrying the VRF's End.DT46
+           SID (carved from `encapsulation srv6`); `interwork` originates
+           an Interwork Segment Discovery (ISD, type 1) route. A receiving
+           PE derives forwarding for matching Session-Transformed routes
+           from these segment routes (draft-ietf-bess-mup-safi default).
+           Distinct from the controller-side `mup route {st1|st2}` block.";
+        leaf segment {
+          type enumeration {
+            enum direct {
+              description
+                "Originate a Direct Segment Discovery (DSD, type 2)
+                 route: the NLRI is the VRF RD + router-id and the SRv6
+                 L3 Service carries the per-VRF End.DT46 SID.";
+            }
+            enum interwork {
+              description
+                "Originate an Interwork Segment Discovery (ISD, type 1)
+                 route. (Origination deferred — parsed but not yet acted
+                 on.)";
+            }
+          }
+          description
+            "MUP Segment Discovery route type originated for this VRF.";
+        }
+      }
     }
   }
 


### PR DESCRIPTION
## Summary

First slice of P6 (the SRv6-mobile dataplane) for BGP MUP: PE-side **Direct Segment Discovery (DSD, type 2)** origination, the segment that draft-default Session-Transformed routes resolve against.

- New per-VRF knob **`afi-safi mup segment {direct|interwork}`** (under the per-VRF `afi-safi` container, distinct from the controller-side `mup route {st1|st2}`).
- **`segment direct` originates a DSD route**: NLRI = VRF **RD + router-id** (rides the IPv4-MUP AFI); attributes carry the PE locator node as the **IPv6 next-hop** and the per-VRF **End.DT46 SID** as the SRv6 L3 Service (`SRV6_BEHAVIOR_END_DT46`).
- **SID + kernel FIB install are pure reuse** of the L3VPN-over-SRv6 path: a VRF with `encapsulation srv6` already carves the End.DT46 SID (`alloc_vrf_sid`) and installs the `seg6local End.DT46 SEG6_LOCAL_VRFTABLE(table_id)` decap at spawn — the DSD path only reads `vrf_registry[name].srv6_sid` and advertises it.
- `reconcile_mup_dsd` is the idempotent driver, called from `apply_vrf_commit_diff`, `maybe_respawn_vrf_with_kernel_ctx`, `reconcile_srv6_vrfs`, the `VrfDel` / `VrfRouteTargets` handlers, and `set_router_id`. It gates on the kernel VRF being known (so a segment is never advertised before its decap is installed) and a non-zero router-id.
- `route_update_mup` advertises the attr IPv6 next-hop for originated routes carrying a Prefix-SID (DSD-scoped; ST routes have none → unaffected).
- `show bgp mup` / `show bgp vrf <name> mup` now print `Local/Remote SID <sid> (End.DT46)`.

**Deferred:** `segment interwork` (ISD, type 1) origination, and the receive side (a peer consuming a DSD/ISD to drive forwarding).

## Test plan

- New BDD `@bgp_mup_segment_dsd` (root netns) — **all 4 scenarios pass**: z1 originates `[DSD][65501:10][10.0.0.1]`, installs the `seg6local End.DT46` (asserted via `ip -6 route show table all`), mirrors it into `show bgp vrf N6 mup`, and z2 receives it with the SID. Excluded from CI; run live via `make -C bdd bgp_mup_segment_dsd`.
- `cargo test`: 1453 zebra-rs + 337 bgp-packet + 38 yang_load green.
- `cargo clippy --workspace --all-targets -- -D warnings` and `cargo fmt --check` clean.

Generated with [Claude Code](https://claude.com/claude-code)