### PR TITLE
bgp-mup: move ST2 NI binding to afi-safi mup network-instance

### DIFF
--- a/bdd/tests/configs/bgp_mup_st2/z1.yaml
+++ b/bdd/tests/configs/bgp_mup_st2/z1.yaml
@@ -37,16 +37,11 @@ router:
     vrf:
     - name: mobile-up
       rd: "65000:100"
-      mup:
-        route:
-          st2:
-            dest-network-instance:
-              core:
-                exact: core
       afi-safi:
         mup:
           segment: direct
           mup-ext-comm: "1:2"
+          network-instance: core
     afi-safi:
     - name: mup
       mup-c:

--- a/bdd/tests/features/bgp_mup_st2.feature
+++ b/bdd/tests/features/bgp_mup_st2.feature
@@ -28,7 +28,8 @@ Feature: BGP MUP Controller originates a Type-2 ST route from a PFCP session
   ```
 
   z1 runs the controller (PFCP listener on 192.168.0.1:8805, locator LOC1,
-  VRF `mobile-up` matching Network Instance `core` to a Type-2 ST route and
+  VRF `mobile-up` with `afi-safi mup segment direct network-instance core`
+  binding Network Instance `core` to its Type-2 ST / Direct segment, and
   carrying the Direct segment id `1:2`). `pfcp-inject` plays the SMF: it
   sends an Association Setup + Session Establishment for endpoint 10.0.0.1 /
   TEID 0x12345678 (Network Instance `core`), so z1 originates the ST2 route

--- a/book/src/ch-02-35-bgp-mup.md
+++ b/book/src/ch-02-35-bgp-mup.md
@@ -141,14 +141,37 @@ vrf mobile-up {
   **without** a service SID — the receiving PE derives forwarding from
   its own ISD/DSD routes — so no per-session SID is allocated.
 
-The **`route`** type in the VRF selects what is originated: `st1` (the
-N6 / downlink VRF) originates a **Type-1 ST** route carrying the UE
-prefix; `st2` (the N3 / uplink VRF) originates a **Type-2 ST** route
-carrying the core endpoint and TEID. The `dest-network-instance ... exact`
-value is matched against the PFCP session's Network Instance. The export
-route-targets the ST route carries come from the top-level
-`vrf <name> mup route-target export` — the same `route-target` framework
-as `ipv4` / `ipv6`.
+The VRF binds each direction to a PFCP Network Instance:
+
+* **Downlink (Type-1 ST).** `mup route st1 dest-network-instance access
+  exact <ni>` — the N6 VRF originates a **Type-1 ST** route carrying the
+  UE prefix (ingress GTP encapsulation).
+* **Uplink (Type-2 ST).** `afi-safi mup segment direct network-instance
+  <ni>` — the N3 VRF originates a **Type-2 ST** route carrying the core
+  endpoint and the GTP TEID (egress GTP decapsulation into the VRF's
+  End.DT46 Direct segment). The ST2 NI binding lives next to `segment
+  direct` because the ST2 resolves to that Direct segment; the route also
+  carries the segment's BGP MUP Extended Community (`mup-ext-comm`, a
+  Direct-segment id in RD/RT 2:4 form, e.g. `1:2`).
+
+In both cases the configured network-instance is matched exactly against
+the PFCP session's Network Instance. The export route-targets the ST route
+carries come from the top-level `vrf <name> mup route-target export` — the
+same `route-target` framework as `ipv4` / `ipv6`.
+
+For example, an uplink VRF:
+
+```
+vrf N3 {
+  rd 65000:100;
+  encapsulation srv6;
+  afi-safi mup {
+    segment direct;          # originate the End.DT46 Direct Segment Discovery route
+    mup-ext-comm 1:2;        # the Direct segment id (BGP MUP Ext-Comm 0x0c/0x00)
+    network-instance core;   # originate an ST2 for PFCP sessions on NI "core"
+  }
+}
+```
 
 ## From PFCP session to ST route
 

--- a/docs/design/bgp-mup-followups.md
+++ b/docs/design/bgp-mup-followups.md
@@ -457,11 +457,21 @@ MUP Extended Community:
   `VrfRouteTargets`) never carried the RT — and would likewise miss a
   later `mup-ext-comm`. The skip now also compares the ext-community set,
   so an RT / segment-id change re-advertises under the stable key.
-- **Tests.** `@bgp_mup_st2` BDD (controller drives `pfcp-inject` with a
-  `core` Network Instance → ST2 with endpoint + TEID + Direct segment id,
-  received by the peer); `@bgp_mup_segment_dsd` extended to assert the
-  DSD carries `RT:65501:10 1:2`. Run live via `make -C bdd bgp_mup_st2`
-  / `bgp_mup_segment_dsd`.
+- **Grammar simplification.** The ST2 (uplink) Network-Instance binding
+  moved off the nested `router bgp vrf <name> mup route st2
+  dest-network-instance core exact <ni>` onto a single
+  `router bgp vrf <name> afi-safi mup network-instance <ni>` leaf, next to
+  `segment direct` (the Direct segment the ST2 resolves to). It still maps
+  to the Decapsulation direction on `srv6_mobile`, so `build_mup_origination`
+  / `render_mup_vrfs` are unchanged. The downlink `mup route st1
+  dest-network-instance access exact <ni>` is unchanged; the `route st2`
+  sub-container was removed.
+- **Tests.** `@bgp_mup_st2` BDD (controller, `afi-safi mup segment direct
+  network-instance core`, drives `pfcp-inject` with a `core` Network
+  Instance → ST2 with endpoint + TEID + Direct segment id, received by the
+  peer); `@bgp_mup_segment_dsd` extended to assert the DSD carries
+  `RT:65501:10 1:2`. Run live via `make -C bdd bgp_mup_st2` /
+  `bgp_mup_segment_dsd`.
 
 **Still open in P6 (unchanged):** the *receive* side (ST2 → Direct-segment
 resolution → FIB), ISD (`segment interwork`) origination, and the GTP

--- a/zebra-rs/src/bgp/config.rs
+++ b/zebra-rs/src/bgp/config.rs
@@ -4082,10 +4082,6 @@ impl Bgp {
             super::vrf_config::config_vrf_evpn_advertise_ipv6,
         );
         self.callback_add(
-            "/router/bgp/vrf/mup/route/st2/dest-network-instance/core/exact",
-            super::vrf_config::config_vrf_mup_route_st2,
-        );
-        self.callback_add(
             "/router/bgp/vrf/mup/route/st1/dest-network-instance/access/exact",
             super::vrf_config::config_vrf_mup_route_st1,
         );
@@ -4096,6 +4092,10 @@ impl Bgp {
         self.callback_add(
             "/router/bgp/vrf/afi-safi/mup/mup-ext-comm",
             super::vrf_config::config_vrf_mup_ext_comm,
+        );
+        self.callback_add(
+            "/router/bgp/vrf/afi-safi/mup/network-instance",
+            super::vrf_config::config_vrf_mup_network_instance,
         );
 
         // `set router bgp interface-neighbor <name> [...]`.

--- a/zebra-rs/src/bgp/vrf_config.rs
+++ b/zebra-rs/src/bgp/vrf_config.rs
@@ -311,11 +311,13 @@ pub fn config_vrf_inter_as_hybrid(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -
     Some(())
 }
 
-/// `set router bgp vrf <NAME> mup route st2 dest-network-instance
-/// core exact <NI>` — Type-2 ST (uplink) origination: egress GTP
-/// decapsulation for the N3 VRF, matched against the session's core
-/// network-instance.
-pub fn config_vrf_mup_route_st2(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Option<()> {
+/// `set router bgp vrf <NAME> afi-safi mup network-instance <NI>` — the
+/// Type-2 ST (uplink) NI binding, alongside `segment direct` (the Direct
+/// segment the ST2 resolves to). When the MUP controller learns a session
+/// whose Network Instance matches `<NI>`, it originates an ST2 (endpoint +
+/// GTP TEID, egress GTP decapsulation into this VRF's End.DT46 Direct
+/// segment). Stored as the Decapsulation direction on `srv6_mobile`.
+pub fn config_vrf_mup_network_instance(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Option<()> {
     let name = args.string()?;
     let cfg = vrf_entry(bgp, name);
     match op {

--- a/zebra-rs/yang/zebra-bgp-vrf.yang
+++ b/zebra-rs/yang/zebra-bgp-vrf.yang
@@ -252,6 +252,18 @@ module zebra-bgp-vrf {
              (ST2) routes that resolve to this Direct segment (§3.3.10 /
              §3.3.12). The 6-octet value reuses the RD/RT 2:4 wire format.";
         }
+        leaf network-instance {
+          type string;
+          description
+            "PFCP session Network Instance whose uplink sessions this
+             Direct segment originates Type-2 Session-Transformed (ST2)
+             routes for. When the MUP controller learns a session whose
+             Network Instance matches this value, it originates an ST2
+             (endpoint + GTP TEID) for this VRF — egress GTP decapsulation
+             into the VRF's End.DT46 Direct segment. This is the ST2 NI
+             binding; the downlink (ST1) binding stays on
+             `mup route st1 dest-network-instance access exact`.";
+        }
       }
     }
   }
@@ -382,18 +394,19 @@ module zebra-bgp-vrf {
       }
       container mup {
         description
-          "BGP MUP (RFC 9833) per-VRF service. `route` selects the
-           Session-Transformed route type (st1 = Type-1 ST / downlink =
-           N6, st2 = Type-2 ST / uplink = N3) and the destination session
-           network-instance matched exactly. The export/import route-
-           targets live on the top-level `vrf <name> mup
+          "BGP MUP (RFC 9833) per-VRF service. `route st1` binds the
+           Type-1 ST (downlink / N6) destination session network-instance
+           matched exactly. The uplink Type-2 ST (N3) binding lives on the
+           `afi-safi mup network-instance` leaf, alongside `segment direct`
+           (the Direct segment the ST2 resolves to). The export/import
+           route-targets live on the top-level `vrf <name> mup
            route-target {export|import}` (config.yang), the same place as
            the ipv4 / ipv6 RT policy.";
         container route {
           description
-            "Session-Transformed route origination for this VRF, keyed by
-             ST route type. Each route type binds the destination
-             network-instance whose PFCP sessions it originates from.";
+            "Session-Transformed route origination for this VRF. Only the
+             downlink (st1) binding lives here; the uplink (st2) binding
+             moved to `afi-safi mup network-instance`.";
           container st1 {
             description
               "Type-1 ST (downlink); ingress GTP encapsulation, the N6 VRF.";
@@ -403,19 +416,6 @@ module zebra-bgp-vrf {
                   type string;
                   description
                     "Session access network-instance matched exactly.";
-                }
-              }
-            }
-          }
-          container st2 {
-            description
-              "Type-2 ST (uplink); egress GTP decapsulation, the N3 VRF.";
-            container dest-network-instance {
-              container core {
-                leaf exact {
-                  type string;
-                  description
-                    "Session core network-instance matched exactly.";
                 }
               }
             }


### PR DESCRIPTION
## Summary

Simplify the per-VRF MUP grammar: the **Type-2 ST (uplink) Network-Instance binding** moves off the nested `mup route st2 dest-network-instance core exact <ni>` onto a single leaf next to `segment direct`:

```
afi-safi mup {
  segment direct;
  mup-ext-comm 1:2;
  network-instance internet;   # ← ST2 NI binding (was: mup route st2 dest-network-instance core exact)
}
```

The ST2 resolves to the VRF's End.DT46 **Direct segment**, so the NI binding belongs next to `segment direct`. Internally it still sets `srv6_mobile = {Decapsulation, ni}`, so `build_mup_origination` / `render_mup_vrfs` are unchanged and the `Decapsulation` variant is still constructed (no dead code). The downlink `mup route st1 dest-network-instance access exact <ni>` is **unchanged**; the `route st2` sub-container is removed.

## Test plan

- `cargo test -p zebra-rs` (1453) + `yang_load` guard (the new `network-instance` callback path and the removed `st2` path match the YANG) — green.
- `cargo fmt` + `cargo clippy --workspace --all-targets -- -D warnings` — clean.
- Live BDD (root netns): `@bgp_mup_st2` (new grammar), `@bgp_mup_e2e` (ST1, unchanged), `@bgp_mup_segment_dsd` — all pass. BDD is excluded from CI gates.
- Book (`ch-02-35`) and design doc updated.

Generated with [Claude Code](https://claude.com/claude-code)