### PR TITLE
vty: tab-complete names with uppercase initials

### DIFF
--- a/vty/additions/vty.sh
+++ b/vty/additions/vty.sh
@@ -171,7 +171,15 @@ _cli_set_completions ()
     else
       IFS=$'\t' col=(${line})
       completions=(${completions[@]} ${col[0]})
-      if [[ ${col[0]}  =~ ^[a-zEH0-9/] ]];then
+      # Everything except a type-hint placeholder is a literal,
+      # TAB-completable word. Placeholders (`<name:string>`,
+      # `<A.B.C.D>`, `<cr>`, ...) all start with '<' and must be kept
+      # out of the compgen word list. A previous initial-character
+      # whitelist (`[a-zEH0-9/]`) wrongly dropped any candidate whose
+      # first character was an uppercase letter other than E/H, so a
+      # VRF/interface/neighbour name like `N6` showed under `?` but
+      # never expanded on TAB.
+      if [[ ${col[0]} != "<"* ]];then
         completions2=(${completions2[@]} ${col[0]})
         _cli_array_completions=(${_cli_array_completions[@]} ${col[0]})
       fi


### PR DESCRIPTION
## Summary

`set vrf N<tab>` did not expand to an existing VRF named `N6`, even though `set vrf N?` listed it. The cause is client-side in the vty shell completion handler.

`_cli_set_completions` (`vty/additions/vty.sh`) splits the daemon's candidates into two lists:
- `completions` — everything → used by `?` (so `N6` shows up), and
- `_cli_array_completions` — gated by a regex → used by TAB (`compgen`).

The gate was an initial-character whitelist `[a-zEH0-9/]`, which only allows a lowercase letter, `E`, `H`, a digit, or `/` as the first character. Any candidate starting with another uppercase letter — including `N` — failed the regex and was dropped from the TAB list, so `compgen` had nothing to expand. (`E`/`H` were ad-hoc additions; every other uppercase initial broke the same way.)

The daemon was already returning `N6` correctly in both cases — its case-sensitive matching is correct for config values and is left untouched.

## Fix

Replace the initial-character whitelist with a blacklist that excludes only the `<...>` type-hint placeholders (`<name:string>`, `<A.B.C.D>`, `<cr>`, ...) — the actual distinction between a hint and a literal completable word.

## Test plan

- Verified the new glob in isolation: `<name:string>`, `<cr>`, `<A.B.C.D>` stay hidden from TAB; `N6`, `Host-A`, `Ethernet0`, lowercase keywords, digits, and `/` remain completable.
- `vty.sh` is embedded into the `vty` binary at build (`xxd -i vty.sh`), so this is picked up by `make -C vty`.

Generated with [Claude Code](https://claude.com/claude-code)