### PR TITLE
bgp-mup: resolve received ST2 to the Direct segment (interwork)

### DIFF
--- a/bdd/Makefile
+++ b/bdd/Makefile
@@ -50,6 +50,15 @@ bgp_mup_st2:
 	mkdir -p allure-results
 	cargo test --test cucumber -- --concurrency=1 --tags "@bgp_mup_st2"
 
+# MUP interwork: a combined UPF+controller (z1) originates a DSD (End.DT46
+# + Direct-segment id) and an ST2 (same id) from a PFCP session; the
+# interwork node (z2, `afi-safi mup segment interwork`) resolves the ST2 to
+# z1's End.DT46 Direct segment by the MUP Extended Community. Needs
+# `pfcp-inject` on the host PATH and root netns (kernel VRF + seg6local).
+bgp_mup_interwork:
+	mkdir -p allure-results
+	cargo test --test cucumber -- --concurrency=1 --tags "@bgp_mup_interwork"
+
 rib_static_ipv6:
 	mkdir -p allure-results
 	cargo test --test cucumber -- --concurrency=1 --tags "@rib_static_ipv6"

--- a/bdd/tests/configs/bgp_mup_interwork/z1.yaml
+++ b/bdd/tests/configs/bgp_mup_interwork/z1.yaml
@@ -1,0 +1,80 @@
+# z1 — combined MUP UPF + Controller. It originates BOTH:
+#   * a Direct Segment Discovery (DSD) route for VRF N6 (`afi-safi mup
+#     segment direct`, `encapsulation srv6`) carrying the per-VRF End.DT46
+#     SID and the Direct-segment id (MUP Ext-Comm `1:2`), and
+#   * a Type-2 Session-Transformed (ST2) route from a PFCP session whose
+#     Network Instance is `core` (`afi-safi mup network-instance core`),
+#     carrying the same Direct-segment id `1:2`.
+# IS-IS L2 SRv6 underlay + iBGP (mup afi-safi) to z2 (the interwork SRGW)
+# over loopbacks. z2 resolves the ST2 to this End.DT46 Direct segment.
+vrf:
+- name: N6
+  mup:
+    route-target:
+      export:
+      - "65501:10"
+interface:
+- if-name: lo
+  ipv6:
+    address: 2001:db8::1/128
+- if-name: z1-z2
+  ipv6:
+    address: 2001:db8:0:12::1/64
+segment-routing:
+  locator:
+  - name: S
+    prefix: fcbb:bbbb:1::/48
+    behavior: usid
+router:
+  isis:
+    net: 49.0000.0000.0000.0001.00
+    hostname: z1
+    is-type: level-2-only
+    segment-routing:
+      srv6:
+        locator: S
+    interface:
+    - if-name: lo
+      ipv6:
+        enable: true
+    - if-name: z1-z2
+      network-type: point-to-point
+      metric: 1
+      ipv6:
+        enable: true
+  bgp:
+    global:
+      as: 65501
+      router-id: 10.0.0.1
+    timer:
+      adv-interval:
+        ibgp: 1
+    segment-routing:
+      srv6:
+        locator: S
+    neighbor:
+    - remote-address: 2001:db8::2
+      remote-as: 65501
+      update-source: 2001:db8::1
+      enabled: true
+      afi-safi:
+      - name: mup
+        enabled: true
+    vrf:
+    - name: N6
+      rd: "65501:10"
+      encapsulation: srv6
+      afi-safi:
+        mup:
+          segment: direct
+          mup-ext-comm: "1:2"
+          network-instance: core
+    afi-safi:
+    - name: mup
+      mup-c:
+        enable: true
+        controller-address: 2001:db8::1
+        pfcp:
+          listen-address: 127.0.0.1
+        srv6:
+          locator: S

--- a/bdd/tests/configs/bgp_mup_interwork/z2.yaml
+++ b/bdd/tests/configs/bgp_mup_interwork/z2.yaml
@@ -1,0 +1,60 @@
+# z2 — MUP interwork node (SRGW). IS-IS L2 SRv6 underlay + iBGP (mup
+# afi-safi) to z1 over loopbacks. VRF N6 is `afi-safi mup segment
+# interwork`, which marks this node as an interwork (SRGW) node: it
+# receives z1's DSD (Direct segment, End.DT46 + id `1:2`) and the ST2
+# (id `1:2`) into its global MUP Loc-RIB and resolves each received ST2 to
+# the matching Direct segment by that id — `show bgp mup` prints the
+# End.DT46 segment the uplink tunnel forwards into. (The GTP-decap FIB
+# itself, H.M.GTP4.D, is VPP/eBPF and out of scope here.)
+interface:
+- if-name: lo
+  ipv6:
+    address: 2001:db8::2/128
+- if-name: z2-z1
+  ipv6:
+    address: 2001:db8:0:12::2/64
+segment-routing:
+  locator:
+  - name: LOC2
+    prefix: fcbb:bbbb:2::/48
+    behavior: usid
+router:
+  isis:
+    net: 49.0000.0000.0000.0002.00
+    hostname: z2
+    is-type: level-2-only
+    segment-routing:
+      srv6:
+        locator: LOC2
+    interface:
+    - if-name: lo
+      ipv6:
+        enable: true
+    - if-name: z2-z1
+      network-type: point-to-point
+      metric: 1
+      ipv6:
+        enable: true
+  bgp:
+    global:
+      as: 65501
+      router-id: 10.0.0.2
+    timer:
+      adv-interval:
+        ibgp: 1
+    segment-routing:
+      srv6:
+        locator: LOC2
+    neighbor:
+    - remote-address: 2001:db8::1
+      remote-as: 65501
+      update-source: 2001:db8::2
+      enabled: true
+      afi-safi:
+      - name: mup
+        enabled: true
+    vrf:
+    - name: N6
+      afi-safi:
+        mup:
+          segment: interwork

--- a/bdd/tests/features/bgp_mup_interwork.feature
+++ b/bdd/tests/features/bgp_mup_interwork.feature
@@ -1,0 +1,69 @@
+@serial
+@bgp_mup_interwork
+Feature: BGP MUP interwork node resolves ST2 to the Direct segment
+  As a network operator
+  I want a zebra-rs BGP MUP interwork (SRGW) node — `afi-safi mup segment
+  interwork` — to resolve each received Type-2 Session-Transformed (ST2)
+  route to the matching Direct Segment Discovery (DSD) route by their BGP
+  MUP Extended Community (Direct-segment id), so it knows the End.DT46
+  segment a session's uplink GTP tunnel forwards into
+  (draft-mpmz-bess-mup-safi §3.3.12, RFC 9433 End.DT46).
+
+  Test Topology:
+  ```
+        2001:db8::1/128            2001:db8::2/128
+       ┌──────────┐  IS-IS L2 SRv6  ┌──────────┐
+       │    z1    │═════════════════│    z2    │
+       │ UPF +    │   iBGP (mup)    │ interwork│
+       │ MUP-C    │                 │  (SRGW)  │
+       └──────────┘                 └──────────┘
+   z1-z2 2001:db8:0:12::1/64   2001:db8:0:12::2/64
+  ```
+
+  z1 is a combined UPF + controller: VRF N6 (`encapsulation srv6`, rd
+  65501:10) with `afi-safi mup segment direct mup-ext-comm 1:2
+  network-instance core` originates a DSD (End.DT46 SID + Direct-segment id
+  1:2) and — when `pfcp-inject` programs a session on Network Instance
+  `core` — an ST2 (same id 1:2). z2 has `afi-safi mup segment interwork`,
+  receives both, and resolves the ST2 to z1's End.DT46 Direct segment.
+
+  NOTE: needs `pfcp-inject` on the BDD host PATH (cargo build --release -p
+  pfcp-inject; copy to /usr/bin) and root netns (kernel VRF + seg6local).
+
+  Scenario: Build topology and establish iBGP with the MUP capability
+    Given a clean test environment
+    When I create namespace "z1"
+    And I create namespace "z2"
+    And I connect namespace "z1" interface "z1-z2" to namespace "z2" interface "z2-z1"
+    And I start zebra-rs in namespace "z1"
+    And I start zebra-rs in namespace "z2"
+    And I apply config "z1.yaml" to namespace "z1"
+    And I apply config "z2.yaml" to namespace "z2"
+    And I wait 45 seconds
+    Then BGP session in "z1" to "2001:db8::2" should be "Established"
+    And BGP session in "z2" to "2001:db8::1" should be "Established"
+    And show command "show bgp neighbor 2001:db8::2" in namespace "z1" should contain "IPv4 MUP: advertised and received"
+
+  Scenario: z1 originates the DSD and (from PFCP) the ST2, both with id 1:2
+    Given the test topology exists
+    When I execute "pfcp-inject --target 127.0.0.1 --port 8805 --ue-ipv4 192.0.2.5 --teid 0x12345678 --endpoint 10.0.0.1 --network-instance core" in namespace "z1"
+    Then show command "show bgp mup" in namespace "z1" should eventually contain "[DSD][65501:10][10.0.0.1]"
+    And show command "show bgp mup" in namespace "z1" should eventually contain "[ST2][65501:10][ep=10.0.0.1][teid=305419896]"
+    # z1 is a `segment direct` node, not interwork, so it shows no resolution.
+    And show command "show bgp mup" in namespace "z1" should not contain "resolved 1:2"
+
+  Scenario: z2 (interwork) resolves the ST2 to z1's End.DT46 Direct segment
+    Given the test topology exists
+    Then show command "show bgp mup" in namespace "z2" should eventually contain "[ST2][65501:10][ep=10.0.0.1][teid=305419896]"
+    And show command "show bgp mup" in namespace "z2" should contain "[DSD][65501:10][10.0.0.1]"
+    # The ST2's Direct-segment id (1:2) resolves to the DSD's End.DT46 SID.
+    And show command "show bgp mup" in namespace "z2" should eventually contain "resolved 1:2 -> End.DT46"
+    And show command "show bgp mup" in namespace "z2" should contain "(via [DSD][65501:10][10.0.0.1])"
+
+  Scenario: Teardown topology
+    Given the test topology exists
+    When I stop zebra-rs in namespace "z1"
+    And I stop zebra-rs in namespace "z2"
+    And I delete namespace "z1"
+    And I delete namespace "z2"
+    Then the test environment should be clean

--- a/docs/design/bgp-mup-followups.md
+++ b/docs/design/bgp-mup-followups.md
@@ -477,6 +477,36 @@ MUP Extended Community:
 resolution → FIB), ISD (`segment interwork`) origination, and the GTP
 behaviours.
 
+#### P6 slice 3 — receive-side ST2 → Direct-segment resolution — **DONE**
+
+The interwork (SRGW) node — any VRF with `afi-safi mup segment
+interwork` — now resolves each received Type-2 ST route to the Direct
+segment it forwards into, the control-plane half of
+draft-mpmz-bess-mup-safi §3.3.12:
+
+- **Resolution.** `show bgp mup` indexes the selected DSD routes by their
+  BGP MUP Extended Community (Direct-segment id, type 0x0c / sub-type
+  0x00) and, for each received ST2 carrying the same id, prints the
+  End.DT46 segment and the DSD it resolves to:
+  `resolved 1:2 -> End.DT46 <sid> (via [DSD][rd][addr])`. Gated on the
+  node being an interwork node (a `segment interwork` VRF) — a
+  `segment direct` PE or a controller shows nothing. Pure control plane,
+  computed over the global MUP Loc-RIB (`render_mup_table` in
+  `zebra-rs/src/bgp/show.rs`); no new RIB state.
+- **FIB still deferred.** Actually forwarding the uplink — GTP-U decap
+  (`H.M.GTP4.D`) then SRv6 H.Encaps toward the resolved End.DT46 SID —
+  needs VPP / eBPF (mainline Linux `seg6local` has no `End.M.GTP*` /
+  `H.M.GTP4.D`), so this slice binds the segment but does not install the
+  decap.
+- **Test.** `@bgp_mup_interwork` BDD: z1 (combined UPF + controller)
+  originates a DSD (End.DT46 + id 1:2) and an ST2 (id 1:2) from a PFCP
+  session; z2 (`segment interwork`) resolves the ST2 to z1's End.DT46
+  Direct segment. Plus a `render_mup_table` unit test. Run live via
+  `make -C bdd bgp_mup_interwork`.
+
+**Still open in P6 (unchanged):** the receive-side *FIB* write (above),
+ISD (`segment interwork`) route origination, and the GTP behaviours.
+
 #### Remaining
 
 **What:** Install the FIB state that actually forwards MUP traffic. With

--- a/zebra-rs/src/bgp/show.rs
+++ b/zebra-rs/src/bgp/show.rs
@@ -3658,7 +3658,14 @@ fn show_bgp_mup(
     if !out.is_empty() {
         out.push('\n');
     }
-    out.push_str(&render_mup_table(&bgp.local_rib.mup)?);
+    // An interwork (SRGW) node — any VRF with `afi-safi mup segment
+    // interwork` — resolves received ST2 routes against received DSD
+    // (Direct segment) routes by their MUP Extended Community.
+    let is_interwork = bgp
+        .vrfs
+        .values()
+        .any(|c| c.mobile_uplane.segment == Some(super::vrf_config::MupSegmentMode::Interwork));
+    out.push_str(&render_mup_table(&bgp.local_rib.mup, is_interwork)?);
     Ok(out)
 }
 
@@ -3675,15 +3682,62 @@ fn show_bgp_vrf_mup<V: BgpShowView>(
     if json {
         return Ok(String::from("[]"));
     }
-    render_mup_table(&bgp.local_rib().mup)
+    // The per-VRF task holds only the best-paths mirrored to it (by RD) and
+    // none of the config, so ST2 -> Direct-segment resolution (which spans
+    // the whole MUP Loc-RIB on an interwork node) is rendered only by the
+    // global `show bgp mup`.
+    render_mup_table(&bgp.local_rib().mup, false)
 }
 
 /// Render the MUP Loc-RIB table body. Split out from `show_bgp_mup` so it
 /// can be unit-tested against a hand-built table without standing up a
 /// full `Bgp`.
+/// The 6-octet Direct-segment id carried by a MUP Extended Community
+/// (transitive type 0x0c, sub-type 0x00 = Direct-Type Segment Identifier),
+/// if the attributes carry one.
+fn mup_direct_segment_id(attr: &BgpAttr) -> Option<[u8; 6]> {
+    attr.ecom
+        .as_ref()?
+        .0
+        .iter()
+        .find(|v| v.high_type == 0x0c && v.low_type == 0x00)
+        .map(|v| v.val)
+}
+
+/// Render a 6-octet Direct-segment id in the RD/RT 2:4 form.
+fn fmt_direct_segment_id(val: &[u8; 6]) -> String {
+    let asn = u16::from_be_bytes([val[0], val[1]]);
+    let v = u32::from_be_bytes([val[2], val[3], val[4], val[5]]);
+    format!("{asn}:{v}")
+}
+
 fn render_mup_table(
     table: &super::route::LocalRibMupTable,
+    resolve_segments: bool,
 ) -> std::result::Result<String, std::fmt::Error> {
+    // On an interwork (SRGW) node, index the selected DSD routes by their
+    // Direct-segment id (the MUP Extended Community) so each received ST2
+    // can be resolved to the End.DT46 Direct segment its uplink GTP tunnel
+    // forwards into (draft-mpmz-bess-mup-safi §3.3.12). The forwarding FIB
+    // (H.M.GTP4.D GTP decap) is VPP/eBPF — this is the control-plane bind.
+    let dsd_index: std::collections::BTreeMap<[u8; 6], (MupPrefix, std::net::Ipv6Addr, u16)> =
+        if resolve_segments {
+            table
+                .selected
+                .iter()
+                .filter_map(|(prefix, rib)| {
+                    if !matches!(prefix, MupPrefix::Dsd { .. }) {
+                        return None;
+                    }
+                    let seg = mup_direct_segment_id(&rib.attr)?;
+                    let (sid, behavior) = rib.attr.srv6_l3_sid()?;
+                    Some((seg, (prefix.clone(), sid, behavior)))
+                })
+                .collect()
+        } else {
+            std::collections::BTreeMap::new()
+        };
+
     let mut buf = String::new();
     writeln!(
         buf,
@@ -3716,6 +3770,25 @@ fn render_mup_table(
         let ecom = show_mup_ecom(&rib.attr);
         if !ecom.is_empty() {
             writeln!(buf, "       {ecom}")?;
+        }
+
+        // ST2 -> Direct-segment resolution on an interwork (SRGW) node:
+        // the received ST2's Direct-segment id (MUP Extended Community) is
+        // matched against a received DSD to find the End.DT46 segment the
+        // uplink (endpoint, TEID) tunnel forwards into.
+        if resolve_segments
+            && matches!(prefix, MupPrefix::T2st { .. })
+            && let Some(seg) = mup_direct_segment_id(&rib.attr)
+            && let Some((dsd, sid, behavior)) = dsd_index.get(&seg)
+        {
+            writeln!(
+                buf,
+                "       resolved {} -> {} {} (via {})",
+                fmt_direct_segment_id(&seg),
+                srv6_behavior_name(*behavior),
+                sid,
+                mup_prefix_display(dsd)
+            )?;
         }
     }
 
@@ -4923,7 +4996,7 @@ mod detail_tests {
             mup_rib(nh4, 32768, &[]),
         );
 
-        let out = render_mup_table(&table).unwrap();
+        let out = render_mup_table(&table, false).unwrap();
 
         // Grouped DSD -> ISD -> ST1 -> ST2 by MupPrefix Ord.
         let dsd = out.find("[DSD]").expect("DSD line");
@@ -4956,6 +5029,76 @@ mod detail_tests {
         // MUP Extended Community sub-type 0x00 (Direct segment ID) renders
         // bare in the RD/RT 2:4 form: 0x0001:0x0000003d = 1:61.
         assert!(out.contains("1:61"), "{out}");
+    }
+
+    /// On an interwork (SRGW) node, a received ST2 resolves to a received
+    /// DSD (Direct segment) sharing the same MUP Extended Community
+    /// (Direct-segment id), and `show bgp mup` prints the End.DT46 segment
+    /// the uplink tunnel forwards into. Without the interwork gate, no
+    /// resolution line is shown.
+    #[test]
+    fn render_mup_table_resolves_st2_to_direct_segment() {
+        use std::net::{IpAddr, Ipv4Addr};
+        let mut table = super::super::route::LocalRibMupTable::default();
+        // Direct-segment id 1:2 (MUP Ext-Comm 0x0c/0x00), shared DSD<->ST2.
+        let seg = ecv(0x0c, 0x00, [0x00, 0x01, 0x00, 0x00, 0x00, 0x02]);
+
+        // A received DSD carrying segment id 1:2 + an End.DT46 SID.
+        let mut dsd_attr = BgpAttr::new();
+        dsd_attr.nexthop = Some(BgpNexthop::Ipv6("fc00::1".parse().unwrap()));
+        dsd_attr.ecom = Some(ExtCommunity([seg.clone()].into_iter().collect()));
+        dsd_attr.prefix_sid = Some(super::super::inst::srv6_l3_service_prefix_sid(
+            "fcbb:bbbb:1:40::".parse().unwrap(),
+            None,
+            bgp_packet::SRV6_BEHAVIOR_END_DT46,
+        ));
+        let dsd_rib = BgpRib::new(
+            0,
+            Ipv4Addr::new(10, 0, 0, 1),
+            BgpRibType::IBGP,
+            0,
+            0,
+            &dsd_attr,
+            None,
+            None,
+            false,
+        );
+        let _ = table.update(
+            MupPrefix::from_route(&MupRoute::Dsd {
+                id: 0,
+                arch: MupArchitectureType::Gpp5g,
+                rd: "65001:1".parse().unwrap(),
+                address: "10.0.0.1".parse().unwrap(),
+            }),
+            dsd_rib,
+        );
+
+        // A received ST2 carrying the same segment id 1:2 (no SID of its own).
+        let st2_rib = mup_rib("fc00::2".parse::<IpAddr>().unwrap(), 0, &[seg]);
+        let _ = table.update(
+            MupPrefix::from_route(&MupRoute::T2st {
+                id: 0,
+                arch: MupArchitectureType::Gpp5g,
+                rd: "65001:2".parse().unwrap(),
+                endpoint: "127.0.0.8".parse().unwrap(),
+                endpoint_len: 64,
+                teid: 2,
+            }),
+            st2_rib,
+        );
+
+        // Not an interwork node: no resolution shown.
+        let plain = render_mup_table(&table, false).unwrap();
+        assert!(!plain.contains("resolved"), "{plain}");
+
+        // Interwork node: the ST2 resolves to the DSD's End.DT46 segment.
+        let out = render_mup_table(&table, true).unwrap();
+        assert!(
+            out.contains(
+                "resolved 1:2 -> End.DT46 fcbb:bbbb:1:40:: (via [DSD][65001:1][10.0.0.1])"
+            ),
+            "{out}"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Receive-side **ST2 → Direct-segment resolution** at the interwork (SRGW) node — the control-plane half of draft-mpmz-bess-mup-safi §3.3.12.

A node with `afi-safi mup segment interwork` on any VRF now resolves each **received ST2** to the matching **DSD (Direct segment)** by their shared BGP MUP Extended Community (Direct-segment id, type `0x0c` / sub-type `0x00`). `show bgp mup` prints, under each ST2:

```
resolved 1:2 -> End.DT46 fcbb:bbbb:1:40:: (via [DSD][65501:10][10.0.0.1])
```

- Computed over the global MUP Loc-RIB in `render_mup_table` (`show.rs`), gated on the node being an interwork node — a `segment direct` PE or a controller shows nothing. No new RIB state.
- The forwarding FIB (`H.M.GTP4.D` GTP-decap → SRv6 H.Encaps toward the resolved End.DT46 SID) needs VPP / eBPF and stays **deferred**; this binds the segment in the control plane.

## Test plan

- `cargo test -p zebra-rs` (1454, incl. new `render_mup_table_resolves_st2_to_direct_segment`) + `yang_load` — green.
- `cargo fmt` + `cargo clippy --workspace --all-targets -- -D warnings` — clean.
- Live BDD (root netns): new `@bgp_mup_interwork` — z1 (combined UPF + controller) originates a DSD (End.DT46 + id 1:2) and an ST2 (same id) from a PFCP session; z2 (`segment interwork`) resolves the ST2 to z1's End.DT46 Direct segment, while z1 (not interwork) shows no resolution. Passes. BDD is excluded from CI gates.
- Design doc (P6 slice 3) updated.

Generated with [Claude Code](https://claude.com/claude-code)