### PR TITLE
bgp-mup: move mup-c under router bgp; rt:/mup: ecom display

### DIFF
--- a/bdd/tests/configs/bgp_mup_e2e/z1.yaml
+++ b/bdd/tests/configs/bgp_mup_e2e/z1.yaml
@@ -37,16 +37,14 @@ router:
             dest-network-instance:
               access:
                 exact: access
-    afi-safi:
-    - name: mup
-      mup-c:
-        enable: true
-        controller-address: fcbb:bb01::1
-        pfcp:
-          listen-address: 192.168.0.1
-          port: 8805
-        srv6:
-          locator: LOC1
+    mup-c:
+      enable: true
+      controller-address: fcbb:bb01::1
+      pfcp:
+        listen-address: 192.168.0.1
+        port: 8805
+      srv6:
+        locator: LOC1
 # Top-level VRF: the MUP export route-targets live here now (same
 # `route-target {import|export}` framework as ipv4 / ipv6), not under
 # `router bgp vrf`.

--- a/bdd/tests/configs/bgp_mup_interwork/z1.yaml
+++ b/bdd/tests/configs/bgp_mup_interwork/z1.yaml
@@ -69,12 +69,10 @@ router:
           segment: direct
           mup-ext-comm: "1:2"
           network-instance: core
-    afi-safi:
-    - name: mup
-      mup-c:
-        enable: true
-        controller-address: 2001:db8::1
-        pfcp:
-          listen-address: 127.0.0.1
-        srv6:
-          locator: S
+    mup-c:
+      enable: true
+      controller-address: 2001:db8::1
+      pfcp:
+        listen-address: 127.0.0.1
+      srv6:
+        locator: S

--- a/bdd/tests/configs/bgp_mup_mixed_afi/z1.yaml
+++ b/bdd/tests/configs/bgp_mup_mixed_afi/z1.yaml
@@ -36,14 +36,12 @@ router:
             dest-network-instance:
               access:
                 exact: access
-    afi-safi:
-    - name: mup
-      mup-c:
-        enable: true
-        controller-address: fcbb:bb01::1
-        pfcp:
-          listen-address: 192.168.0.1
-          port: 8805
+    mup-c:
+      enable: true
+      controller-address: fcbb:bb01::1
+      pfcp:
+        listen-address: 192.168.0.1
+        port: 8805
 # Top-level VRF: MUP export route-targets (same `route-target` framework
 # as ipv4 / ipv6). Note there is still NO SRv6 locator anywhere.
 vrf:

--- a/bdd/tests/configs/bgp_mup_st2/z1.yaml
+++ b/bdd/tests/configs/bgp_mup_st2/z1.yaml
@@ -42,16 +42,14 @@ router:
           segment: direct
           mup-ext-comm: "1:2"
           network-instance: core
-    afi-safi:
-    - name: mup
-      mup-c:
-        enable: true
-        controller-address: fcbb:bb01::1
-        pfcp:
-          listen-address: 192.168.0.1
-          port: 8805
-        srv6:
-          locator: LOC1
+    mup-c:
+      enable: true
+      controller-address: fcbb:bb01::1
+      pfcp:
+        listen-address: 192.168.0.1
+        port: 8805
+      srv6:
+        locator: LOC1
 # Top-level VRF: the MUP export route-targets live here (same
 # `route-target {import|export}` framework as ipv4 / ipv6).
 vrf:

--- a/bdd/tests/features/bgp_mup_interwork.feature
+++ b/bdd/tests/features/bgp_mup_interwork.feature
@@ -50,14 +50,14 @@ Feature: BGP MUP interwork node resolves ST2 to the Direct segment
     Then show command "show bgp mup" in namespace "z1" should eventually contain "[DSD][65501:10][10.0.0.1]"
     And show command "show bgp mup" in namespace "z1" should eventually contain "[ST2][65501:10][ep=10.0.0.1][teid=305419896]"
     # z1 is a `segment direct` node, not interwork, so it shows no resolution.
-    And show command "show bgp mup" in namespace "z1" should not contain "resolved 1:2"
+    And show command "show bgp mup" in namespace "z1" should not contain "resolved mup:1:2"
 
   Scenario: z2 (interwork) resolves the ST2 to z1's End.DT46 Direct segment
     Given the test topology exists
     Then show command "show bgp mup" in namespace "z2" should eventually contain "[ST2][65501:10][ep=10.0.0.1][teid=305419896]"
     And show command "show bgp mup" in namespace "z2" should contain "[DSD][65501:10][10.0.0.1]"
     # The ST2's Direct-segment id (1:2) resolves to the DSD's End.DT46 SID.
-    And show command "show bgp mup" in namespace "z2" should eventually contain "resolved 1:2 -> End.DT46"
+    And show command "show bgp mup" in namespace "z2" should eventually contain "resolved mup:1:2 -> End.DT46"
     And show command "show bgp mup" in namespace "z2" should contain "(via [DSD][65501:10][10.0.0.1])"
 
   Scenario: Teardown topology

--- a/bdd/tests/features/bgp_mup_mixed_afi.feature
+++ b/bdd/tests/features/bgp_mup_mixed_afi.feature
@@ -62,7 +62,7 @@ Feature: BGP MUP mixed-AFI Session-Transformed route (IPv6 UE, IPv4 endpoint)
     # The export route-target comes from the top-level `vrf mobile-up mup
     # route-target export` (the ipv4/ipv6 framework), proving it reaches
     # origination via the RIB -> rib_known_vrfs path.
-    And show command "show bgp mup" in namespace "z1" should contain "RT:65000:200"
+    And show command "show bgp mup" in namespace "z1" should contain "rt:65000:200"
     # Per-VRF MUP view: the global best-path is mirrored into the
     # mobile-up per-VRF task, so `show bgp vrf mobile-up mup` renders it.
     And show command "show bgp vrf mobile-up mup" in namespace "z1" should contain "ue=2001:db8::5/128"

--- a/bdd/tests/features/bgp_mup_segment_dsd.feature
+++ b/bdd/tests/features/bgp_mup_segment_dsd.feature
@@ -49,7 +49,7 @@ Feature: BGP MUP PE originates a Direct Segment Discovery (DSD) route over SRv6
     # The DSD advertises its BGP MUP Extended Community (Direct segment ID,
     # `mup-ext-comm 1:2`), rendered bare in the RD/RT 2:4 form alongside the
     # export route-target.
-    And show command "show bgp mup" in namespace "z1" should contain "RT:65501:10 1:2"
+    And show command "show bgp mup" in namespace "z1" should contain "rt:65501:10 mup:1:2"
     # The per-VRF view mirrors the originated DSD (its RD matches N6's rd).
     And show command "show bgp vrf N6 mup" in namespace "z1" should eventually contain "[DSD][65501:10][10.0.0.1]"
     # Step 4: the End.DT46 decap is installed into the kernel FIB.
@@ -61,7 +61,7 @@ Feature: BGP MUP PE originates a Direct Segment Discovery (DSD) route over SRv6
     And show command "show bgp mup" in namespace "z2" should contain "Remote SID"
     And show command "show bgp mup" in namespace "z2" should contain "End.DT46"
     # The Direct segment ID (MUP Extended Community) rides through to the peer.
-    And show command "show bgp mup" in namespace "z2" should contain "RT:65501:10 1:2"
+    And show command "show bgp mup" in namespace "z2" should contain "rt:65501:10 mup:1:2"
 
   Scenario: Teardown topology
     Given the test topology exists

--- a/bdd/tests/features/bgp_mup_st2.feature
+++ b/bdd/tests/features/bgp_mup_st2.feature
@@ -66,10 +66,10 @@ Feature: BGP MUP Controller originates a Type-2 ST route from a PFCP session
     And show command "show bgp mup" in namespace "z1" should contain "[ST2][65000:100][ep=10.0.0.1][teid=305419896]"
     # The ST2 carries the export route-target and the Direct segment id
     # (MUP Extended Community 1:2), both rendered in the RD/RT 2:4 form.
-    And show command "show bgp mup" in namespace "z1" should contain "RT:65000:200 1:2"
+    And show command "show bgp mup" in namespace "z1" should contain "rt:65000:200 mup:1:2"
     # The peer receives the ST2 with the TEID and the Direct segment id.
     And show command "show bgp mup" in namespace "z2" should eventually contain "[ST2][65000:100][ep=10.0.0.1][teid=305419896]"
-    And show command "show bgp mup" in namespace "z2" should contain "RT:65000:200 1:2"
+    And show command "show bgp mup" in namespace "z2" should contain "rt:65000:200 mup:1:2"
 
   Scenario: Teardown topology
     Given the test topology exists

--- a/book/src/ch-02-35-bgp-mup.md
+++ b/book/src/ch-02-35-bgp-mup.md
@@ -100,17 +100,16 @@ router bgp {
   }
 
   # Turn on the controller: the PFCP/N4 listener + route origination.
-  afi-safi mup {
-    mup-c {
-      enable true;
-      controller-address fcbb:bb01::1;
-      pfcp {
-        listen-address 192.168.0.1;
-        port 8805;
-      }
-      srv6 {
-        locator LOC1;
-      }
+  # The `mup-c` block sits directly under the BGP instance.
+  mup-c {
+    enable true;
+    controller-address fcbb:bb01::1;
+    pfcp {
+      listen-address 192.168.0.1;
+      port 8805;
+    }
+    srv6 {
+      locator LOC1;
     }
   }
 }

--- a/docs/design/bgp-mup-followups.md
+++ b/docs/design/bgp-mup-followups.md
@@ -349,10 +349,11 @@ UP-node, so an external SMF programs it exactly as it would a UPF. The
 session schema question is therefore answered by PFCP itself (no custom
 zenoh encoding to design).
 
-* **Config home:** under the BGP instance at `router bgp afi-safi
-  mup mup-c { enable; controller-address; pfcp {…}; srv6 {…} }`
-  — so the controller is spawned by the BGP task and handed its `Message`
-  channel, the way a per-VRF BGP instance is. Module: `zebra-rs/src/mup-c/`
+* **Config home:** directly under the BGP instance at `router bgp mup-c {
+  enable; controller-address; pfcp {…}; srv6 {…} }` (lifted out of the
+  former `afi-safi mup` wrapper) — so the controller is spawned by the BGP
+  task and handed its `Message` channel, the way a per-VRF BGP instance is.
+  Module: `zebra-rs/src/mup-c/`
   (`inst` task, `pfcp` socket/handlers, `session`/`assoc` tables); spawn /
   reconfigure / teardown in `Bgp::apply_mup_c_commit_diff`.
 * **PR-A (ingest):** PFCP listener (own tokio UDP socket); Association

--- a/zebra-rs/src/bgp/config.rs
+++ b/zebra-rs/src/bgp/config.rs
@@ -1718,22 +1718,18 @@ fn config_segmentation(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Option<()
     Some(())
 }
 
-// --- MUP controller config (afi-safi mup mup-c) -------------
+// --- MUP controller config (router bgp mup-c) ---------------
 //
-// `router bgp afi-safi mup mup-c { enable; controller-address;
+// `router bgp mup-c { enable; controller-address;
 // pfcp { node-id; listen-address; port }; srv6 { locator }; architecture }`
-// (augmented in by zebra-bgp-mup-controller.yang). Every callback gates on
-// the list entry's afi-safi being `mup` (Safi::Mup) and mutates
-// the staged `mup_c_config`, marking it dirty. The spawn / teardown /
-// reconfigure of the controller task happens at CommitEnd in
+// (augmented in by zebra-bgp-mup-controller.yang, directly under the BGP
+// instance — no `afi-safi` wrapper). Every callback mutates the staged
+// `mup_c_config`, marking it dirty. The spawn / teardown / reconfigure of
+// the controller task happens at CommitEnd in
 // `Bgp::apply_mup_c_commit_diff` — these only stage config.
 
 /// `… mup-c enable <bool>` — the controller master switch.
 fn config_mup_c_enable(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Option<()> {
-    let afi_safi: AfiSafi = args.afi_safi()?;
-    if afi_safi.safi != Safi::Mup {
-        return None;
-    }
     let enabled = if op.is_set() { args.boolean()? } else { false };
     bgp.mup_c_config.enable = enabled;
     bgp.mup_c_dirty = true;
@@ -1742,10 +1738,6 @@ fn config_mup_c_enable(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Option<()
 
 /// `… mup-c controller-address <ipv6>` — next-hop on originated ST routes.
 fn config_mup_c_controller_address(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Option<()> {
-    let afi_safi: AfiSafi = args.afi_safi()?;
-    if afi_safi.safi != Safi::Mup {
-        return None;
-    }
     bgp.mup_c_config.controller_address = if op.is_set() {
         Some(args.v6addr()?)
     } else {
@@ -1757,10 +1749,6 @@ fn config_mup_c_controller_address(bgp: &mut Bgp, mut args: Args, op: ConfigOp) 
 
 /// `… mup-c pfcp node-id <ip>` — our PFCP Node ID for responses.
 fn config_mup_c_pfcp_node_id(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Option<()> {
-    let afi_safi: AfiSafi = args.afi_safi()?;
-    if afi_safi.safi != Safi::Mup {
-        return None;
-    }
     bgp.mup_c_config.node_id = if op.is_set() {
         Some(args.addr()?)
     } else {
@@ -1772,10 +1760,6 @@ fn config_mup_c_pfcp_node_id(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Opt
 
 /// `… mup-c pfcp listen-address <ip>` — PFCP bind address (default `::`).
 fn config_mup_c_pfcp_listen_address(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Option<()> {
-    let afi_safi: AfiSafi = args.afi_safi()?;
-    if afi_safi.safi != Safi::Mup {
-        return None;
-    }
     bgp.mup_c_config.listen_address = if op.is_set() {
         Some(args.addr()?)
     } else {
@@ -1787,10 +1771,6 @@ fn config_mup_c_pfcp_listen_address(bgp: &mut Bgp, mut args: Args, op: ConfigOp)
 
 /// `… mup-c pfcp port <0-65535>` — PFCP bind port (default 8805).
 fn config_mup_c_pfcp_port(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Option<()> {
-    let afi_safi: AfiSafi = args.afi_safi()?;
-    if afi_safi.safi != Safi::Mup {
-        return None;
-    }
     bgp.mup_c_config.port = if op.is_set() { Some(args.u16()?) } else { None };
     bgp.mup_c_dirty = true;
     Some(())
@@ -1798,10 +1778,6 @@ fn config_mup_c_pfcp_port(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Option
 
 /// `… mup-c srv6 locator <name>` — locator SIDs are drawn from (route phase).
 fn config_mup_c_srv6_locator(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Option<()> {
-    let afi_safi: AfiSafi = args.afi_safi()?;
-    if afi_safi.safi != Safi::Mup {
-        return None;
-    }
     bgp.mup_c_config.locator = if op.is_set() {
         Some(args.string()?)
     } else {
@@ -1813,10 +1789,6 @@ fn config_mup_c_srv6_locator(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Opt
 
 /// `… mup-c architecture <enum>` — mobile architecture (informational).
 fn config_mup_c_architecture(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Option<()> {
-    let afi_safi: AfiSafi = args.afi_safi()?;
-    if afi_safi.safi != Safi::Mup {
-        return None;
-    }
     bgp.mup_c_config.architecture = if op.is_set() {
         Some(args.string()?)
     } else {
@@ -4242,34 +4214,22 @@ impl Bgp {
         // Flags EC's segmentation bit rides the originated Type-3 IMET route.
         self.callback_add("/router/bgp/afi-safi/segmentation", config_segmentation);
 
-        // MUP controller (`afi-safi mup mup-c …`, RFC 9833).
+        // MUP controller (`router bgp mup-c …`, RFC 9833).
         // Augmented in by zebra-bgp-mup-controller.yang; the controller
         // task is spawned/torn down at CommitEnd by `apply_mup_c_commit_diff`.
-        self.callback_add("/router/bgp/afi-safi/mup-c/enable", config_mup_c_enable);
+        self.callback_add("/router/bgp/mup-c/enable", config_mup_c_enable);
         self.callback_add(
-            "/router/bgp/afi-safi/mup-c/controller-address",
+            "/router/bgp/mup-c/controller-address",
             config_mup_c_controller_address,
         );
+        self.callback_add("/router/bgp/mup-c/pfcp/node-id", config_mup_c_pfcp_node_id);
         self.callback_add(
-            "/router/bgp/afi-safi/mup-c/pfcp/node-id",
-            config_mup_c_pfcp_node_id,
-        );
-        self.callback_add(
-            "/router/bgp/afi-safi/mup-c/pfcp/listen-address",
+            "/router/bgp/mup-c/pfcp/listen-address",
             config_mup_c_pfcp_listen_address,
         );
-        self.callback_add(
-            "/router/bgp/afi-safi/mup-c/pfcp/port",
-            config_mup_c_pfcp_port,
-        );
-        self.callback_add(
-            "/router/bgp/afi-safi/mup-c/srv6/locator",
-            config_mup_c_srv6_locator,
-        );
-        self.callback_add(
-            "/router/bgp/afi-safi/mup-c/architecture",
-            config_mup_c_architecture,
-        );
+        self.callback_add("/router/bgp/mup-c/pfcp/port", config_mup_c_pfcp_port);
+        self.callback_add("/router/bgp/mup-c/srv6/locator", config_mup_c_srv6_locator);
+        self.callback_add("/router/bgp/mup-c/architecture", config_mup_c_architecture);
 
         // EVPN Assisted Replication role + AR-IP (RFC 9574), under
         // `router bgp afi-safi evpn assisted-replication`. Augmented in by

--- a/zebra-rs/src/bgp/inst.rs
+++ b/zebra-rs/src/bgp/inst.rs
@@ -119,7 +119,7 @@ pub enum Message {
     },
     /// A session/association change reported by the in-process MUP
     /// controller (`src/mup-c/`), which the BGP task spawns when
-    /// `afi-safi mup mup-c enable true` is committed and hands
+    /// `router bgp mup-c enable true` is committed and hands
     /// `self.tx`. Recorded in [`Bgp::mup_c_view`] for `show bgp
     /// mup mup-c`; MUP route origination from these lands in a
     /// follow-up. Mirrors the IS-IS `BgpLs` producer seam.
@@ -660,7 +660,7 @@ pub struct Bgp {
     /// `evpn_originate_imet`; toggling it re-originates all IMET routes via
     /// `reoriginate_all_imet`.
     pub segmentation: bool,
-    /// MUP controller (`afi-safi mup mup-c`) config, staged by
+    /// MUP controller (`router bgp mup-c`) config, staged by
     /// the config callbacks and applied at `CommitEnd` by
     /// [`Self::apply_mup_c_commit_diff`].
     pub mup_c_config: crate::mup_c::inst::MupCConfig,

--- a/zebra-rs/src/bgp/show.rs
+++ b/zebra-rs/src/bgp/show.rs
@@ -3488,15 +3488,15 @@ fn format_mup_ecom_value(v: &ExtCommunityValue) -> String {
         (0x00, 0x02) => {
             let asn = u16::from_be_bytes([v.val[0], v.val[1]]);
             let val = u32::from_be_bytes([v.val[2], v.val[3], v.val[4], v.val[5]]);
-            format!("RT:{asn}:{val}")
+            format!("rt:{asn}:{val}")
         }
         // BGP MUP Extended Community, sub-type 0x00 = Direct-Type Segment
         // Identifier (draft-mpmz-bess-mup-safi §3.2). The 6-octet value
-        // reuses the RD/RT 2:4 layout, shown bare as `<asn>:<val>`.
+        // reuses the RD/RT 2:4 layout, shown as `mup:<asn>:<val>`.
         (0x0c, 0x00) => {
             let asn = u16::from_be_bytes([v.val[0], v.val[1]]);
             let val = u32::from_be_bytes([v.val[2], v.val[3], v.val[4], v.val[5]]);
-            format!("{asn}:{val}")
+            format!("mup:{asn}:{val}")
         }
         _ => format!(
             "0x{:02x}{:02x}{:02x}{:02x}{:02x}{:02x}{:02x}{:02x}",
@@ -3704,11 +3704,12 @@ fn mup_direct_segment_id(attr: &BgpAttr) -> Option<[u8; 6]> {
         .map(|v| v.val)
 }
 
-/// Render a 6-octet Direct-segment id in the RD/RT 2:4 form.
+/// Render a 6-octet Direct-segment id as the MUP Extended Community
+/// `mup:<asn>:<val>` (the RD/RT 2:4 layout with the `mup:` prefix).
 fn fmt_direct_segment_id(val: &[u8; 6]) -> String {
     let asn = u16::from_be_bytes([val[0], val[1]]);
     let v = u32::from_be_bytes([val[2], val[3], val[4], val[5]]);
-    format!("{asn}:{v}")
+    format!("mup:{asn}:{v}")
 }
 
 fn render_mup_table(
@@ -5024,11 +5025,11 @@ mod detail_tests {
         // Next-hop, weight, route-target and MUP ext-comm hex.
         assert!(out.contains("next-hop fc00::30  weight 0"), "{out}");
         assert!(out.contains("next-hop 10.10.10.1  weight 32768"), "{out}");
-        assert!(out.contains("RT:2:3"), "{out}");
-        assert!(out.contains("RT:9:9"), "{out}");
+        assert!(out.contains("rt:2:3"), "{out}");
+        assert!(out.contains("rt:9:9"), "{out}");
         // MUP Extended Community sub-type 0x00 (Direct segment ID) renders
-        // bare in the RD/RT 2:4 form: 0x0001:0x0000003d = 1:61.
-        assert!(out.contains("1:61"), "{out}");
+        // as `mup:<2:4>`: 0x0001:0x0000003d = mup:1:61.
+        assert!(out.contains("mup:1:61"), "{out}");
     }
 
     /// On an interwork (SRGW) node, a received ST2 resolves to a received
@@ -5095,7 +5096,7 @@ mod detail_tests {
         let out = render_mup_table(&table, true).unwrap();
         assert!(
             out.contains(
-                "resolved 1:2 -> End.DT46 fcbb:bbbb:1:40:: (via [DSD][65001:1][10.0.0.1])"
+                "resolved mup:1:2 -> End.DT46 fcbb:bbbb:1:40:: (via [DSD][65001:1][10.0.0.1])"
             ),
             "{out}"
         );
@@ -5105,13 +5106,13 @@ mod detail_tests {
     fn format_mup_ecom_value_rt_and_direct_segment() {
         assert_eq!(
             format_mup_ecom_value(&ecv(0x00, 0x02, [0x00, 0x09, 0x00, 0x00, 0x00, 0x09])),
-            "RT:9:9"
+            "rt:9:9"
         );
         // MUP Extended Community sub-type 0x00 = Direct segment ID, shown
-        // bare in the RD/RT 2:4 form (0x0001:0x0000003d = 1:61).
+        // as `mup:<2:4>` (0x0001:0x0000003d = mup:1:61).
         assert_eq!(
             format_mup_ecom_value(&ecv(0x0c, 0x00, [0x00, 0x01, 0x00, 0x00, 0x00, 0x3d])),
-            "1:61"
+            "mup:1:61"
         );
         // An unrecognized MUP sub-type still falls back to raw hex.
         assert_eq!(

--- a/zebra-rs/src/mup-c/mod.rs
+++ b/zebra-rs/src/mup-c/mod.rs
@@ -11,7 +11,7 @@
 //! Heartbeat.
 //!
 //! The controller is **configured under the BGP instance** at
-//! `router bgp ... afi-safi mup mup-c { enable; pfcp … }` and is
+//! `router bgp mup-c { enable; pfcp … }` and is
 //! spawned by the BGP task, which hands it the BGP instance's own
 //! `mpsc::Sender<crate::bgp::inst::Message>` — exactly the way a BGP VRF
 //! instance receives the global BGP channel. The controller reports

--- a/zebra-rs/yang/zebra-bgp-mup-controller.yang
+++ b/zebra-rs/yang/zebra-bgp-mup-controller.yang
@@ -28,28 +28,24 @@ module zebra-bgp-mup-controller {
 
   description
     "BGP MUP Controller (MUP-C) extensions to the BGP candidate-config
-     tree. Adds a `mup-c` container under the BGP global AFI/SAFI list,
-     only meaningful when the entry's name is `mup` (SAFI 85,
-     RFC 9833). When enabled, the BGP task spawns an in-process MUP
-     controller that terminates PFCP/N4 (3GPP TS 29.244) as a UP-node,
-     learns mobile sessions and (in a follow-up) originates Type-1 /
-     Type-2 Session-Transformed routes.
+     tree. Adds a `mup-c` container directly under the BGP instance
+     (SAFI 85, RFC 9833). When enabled, the BGP task spawns an in-process
+     MUP controller that terminates PFCP/N4 (3GPP TS 29.244) as a UP-node,
+     learns mobile sessions and originates Type-1 / Type-2
+     Session-Transformed routes.
 
      Resulting CLI / config shape:
 
        router bgp {
-         afi-safi {
-           name mup;
-           mup-c {
-             enable true;
-             controller-address 2001:db8::1;
-             pfcp {
-               node-id 10.0.0.1;
-               listen-address ::;
-               port 8805;
-             }
-             srv6 { locator LOC1; }
+         mup-c {
+           enable true;
+           controller-address 2001:db8::1;
+           pfcp {
+             node-id 10.0.0.1;
+             listen-address ::;
+             port 8805;
            }
+           srv6 { locator LOC1; }
          }
        }";
 
@@ -58,11 +54,9 @@ module zebra-bgp-mup-controller {
      3GPP TS 29.244: Interface between the Control Plane and the User
      Plane Nodes (PFCP)";
 
-  grouping bgp-afi-safi-mup-c-extension {
+  grouping bgp-mup-c-extension {
     description
-      "MUP controller config on the global afi-safi list. Only
-       meaningful when the list entry's name is `mup` —
-       harmless and ignored on other AFI/SAFIs.";
+      "MUP controller config, hung directly off the BGP instance.";
 
     container mup-c {
       description
@@ -128,13 +122,13 @@ module zebra-bgp-mup-controller {
     }
   }
 
-  augment "/configure:set/config:router/bgp:bgp/bgp:afi-safi" {
-    description "MUP controller config under the global afi-safi list (set).";
-    uses bgp-afi-safi-mup-c-extension;
+  augment "/configure:set/config:router/bgp:bgp" {
+    description "MUP controller config under the BGP instance (set).";
+    uses bgp-mup-c-extension;
   }
 
-  augment "/configure:delete/config:router/bgp:bgp/bgp:afi-safi" {
-    description "MUP controller config under the global afi-safi list (delete).";
-    uses bgp-afi-safi-mup-c-extension;
+  augment "/configure:delete/config:router/bgp:bgp" {
+    description "MUP controller config under the BGP instance (delete).";
+    uses bgp-mup-c-extension;
   }
 }


### PR DESCRIPTION
## Summary

Two MUP CLI/display tweaks.

**1. `mup-c` lifted out of the `afi-safi mup` wrapper** — the controller now configures directly under the BGP instance:
```
router bgp { mup-c { enable; controller-address; pfcp {…}; srv6 {…} } }
```
The YANG augment retargets from the BGP `afi-safi` list to the `bgp` container (grouping renamed `bgp-mup-c-extension`), the 7 callback paths become `/router/bgp/mup-c/*`, and the per-handler `afi-safi`/`Safi::Mup` gate is dropped (no list key in the path anymore).

**2. `show bgp mup` extended-community rendering** — the route target is lowercased to `rt:<2:4>` and the BGP MUP Extended Community (Direct-segment id) gets a `mup:` prefix:
```
       rt:65501:1 mup:1:2
```
The interwork resolution line follows: `resolved mup:1:2 -> End.DT46 …`.

Controller configs (e2e/st2/mixed_afi/interwork), the book, and the design doc are updated to match.

## Test plan

- `cargo test -p zebra-rs` (1454) + `yang_load` guard (new `/router/bgp/mup-c/*` paths match the moved augment) — green.
- `cargo fmt` + `cargo clippy --workspace --all-targets -- -D warnings` — clean.
- Live BDD (root netns): all 5 MUP features — `@bgp_mup_e2e`, `@bgp_mup_st2`, `@bgp_mup_mixed_afi`, `@bgp_mup_segment_dsd`, `@bgp_mup_interwork` — pass. BDD is excluded from CI gates.

Generated with [Claude Code](https://claude.com/claude-code)