### PR TITLE
bgp-evpn: RFC 9251 Type 7/8 IGMP/MLD Join/Leave Synch codec + stub

### DIFF
--- a/crates/bgp-packet/src/attrs/ext_com.rs
+++ b/crates/bgp-packet/src/attrs/ext_com.rs
@@ -158,6 +158,104 @@ impl ExtCommunityValue {
             bitmap: u16::from_be_bytes([self.val[1], self.val[2]]),
         })
     }
+
+    /// Build an ES-Import Route Target (RFC 7432 §7.6): EVPN high-type
+    /// (0x06) + Route Target sub-type (0x02), value auto-derived from the
+    /// **high-order 6 octets of the ESI value** (ESI octets 1..7 — the
+    /// 1-octet ESI Type is skipped). Carried on EVPN Ethernet Segment
+    /// (Type-4) and IGMP/MLD Synch (Type-7/8, RFC 9251) routes to scope
+    /// their distribution to the PEs attached to that Ethernet Segment.
+    pub fn es_import_rt(esi: &[u8; 10]) -> Self {
+        let mut es_import = [0u8; 6];
+        es_import.copy_from_slice(&esi[1..7]);
+        Self::es_import_rt_raw(es_import)
+    }
+
+    /// Build an ES-Import Route Target from an already-derived 6-octet
+    /// ES-Import value.
+    pub fn es_import_rt_raw(es_import: [u8; 6]) -> Self {
+        ExtCommunityValue {
+            high_type: ExtCommunityType::Evpn as u8,
+            low_type: EVPN_ES_IMPORT_RT_SUB_TYPE,
+            val: es_import,
+        }
+    }
+
+    /// True iff this entry is an EVPN ES-Import Route Target (RFC 7432
+    /// §7.6): EVPN high-type (0x06) + Route Target sub-type (0x02).
+    pub fn is_es_import_rt(&self) -> bool {
+        self.high_type == ExtCommunityType::Evpn as u8
+            && self.low_type == EVPN_ES_IMPORT_RT_SUB_TYPE
+    }
+
+    /// Decode the 6-octet ES-Import value if this entry is an ES-Import RT.
+    pub fn as_es_import_rt(&self) -> Option<[u8; 6]> {
+        if self.is_es_import_rt() {
+            Some(self.val)
+        } else {
+            None
+        }
+    }
+
+    /// Build an EVI-RT Extended Community (RFC 9251 §9.5) from the EVI's
+    /// (BD's) Route Target. The EVI-RT carries the same 6-octet RT value
+    /// under the EVPN high-type (0x06), with the sub-type selecting the RT
+    /// format: 2-octet-AS RT (`0x00/0x02`) → Type 0 (`0x0A`), IPv4-address
+    /// RT (`0x01/0x02`) → Type 1 (`0x0B`), 4-octet-AS RT (`0x02/0x02`) →
+    /// Type 2 (`0x0C`). Returns `None` for a non-RT EC or an
+    /// IPv6-address-specific RT (EVI-RT Type 3 / `0x0D` needs a 20-octet
+    /// IPv6 EC that `ExtCommunityValue` cannot hold). Each Type-7/8 route
+    /// carries exactly one EVI-RT EC matching its BD's RT.
+    pub fn evi_rt_from_rt(rt: &ExtCommunityValue) -> Option<Self> {
+        if rt.low_type != ExtCommunitySubType::RouteTarget as u8 {
+            return None;
+        }
+        let sub_type = match rt.high_type {
+            0x00 => EVI_RT_TYPE0_SUB_TYPE,
+            0x01 => EVI_RT_TYPE1_SUB_TYPE,
+            0x02 => EVI_RT_TYPE2_SUB_TYPE,
+            _ => return None,
+        };
+        Some(ExtCommunityValue {
+            high_type: ExtCommunityType::Evpn as u8,
+            low_type: sub_type,
+            val: rt.val,
+        })
+    }
+
+    /// True iff this entry is an EVI-RT Extended Community (RFC 9251 §9.5):
+    /// EVPN high-type (0x06) + a Type-0..3 EVI-RT sub-type (0x0A–0x0D).
+    pub fn is_evi_rt(&self) -> bool {
+        self.high_type == ExtCommunityType::Evpn as u8
+            && matches!(
+                self.low_type,
+                EVI_RT_TYPE0_SUB_TYPE
+                    | EVI_RT_TYPE1_SUB_TYPE
+                    | EVI_RT_TYPE2_SUB_TYPE
+                    | EVI_RT_TYPE3_SUB_TYPE
+            )
+    }
+
+    /// Reconstruct the underlying Route Target EC carried by an EVI-RT EC
+    /// (RFC 9251 §9.5), the inverse of [`evi_rt_from_rt`](Self::evi_rt_from_rt).
+    /// Returns `None` for a non-EVI-RT EC or the IPv6 form (`0x0D`), which
+    /// has no 8-octet RT representation.
+    pub fn as_evi_rt(&self) -> Option<ExtCommunityValue> {
+        if self.high_type != ExtCommunityType::Evpn as u8 {
+            return None;
+        }
+        let high_type = match self.low_type {
+            EVI_RT_TYPE0_SUB_TYPE => 0x00,
+            EVI_RT_TYPE1_SUB_TYPE => 0x01,
+            EVI_RT_TYPE2_SUB_TYPE => 0x02,
+            _ => return None,
+        };
+        Some(ExtCommunityValue {
+            high_type,
+            low_type: ExtCommunitySubType::RouteTarget as u8,
+            val: self.val,
+        })
+    }
 }
 
 /// EVPN Multicast Flags Extended Community sub-type (RFC 9251 §6),
@@ -167,6 +265,19 @@ const EVPN_MCAST_FLAGS_SUB_TYPE: u8 = 0x09;
 /// DF Election Extended Community sub-type (RFC 8584 §2.2), carried under
 /// the EVPN high-type (0x06).
 const EVPN_DF_ELECTION_SUB_TYPE: u8 = 0x06;
+
+/// ES-Import Route Target sub-type (RFC 7432 §7.6), carried under the EVPN
+/// high-type (0x06). Shares the Route Target sub-type value (0x02) but is
+/// disambiguated by the EVPN high-type.
+const EVPN_ES_IMPORT_RT_SUB_TYPE: u8 = 0x02;
+
+/// EVI-RT Extended Community sub-types (RFC 9251 §9.5), carried under the
+/// EVPN high-type (0x06). The sub-type selects which Route Target format the
+/// 6-octet value encodes.
+const EVI_RT_TYPE0_SUB_TYPE: u8 = 0x0A; // 2-octet-AS RT
+const EVI_RT_TYPE1_SUB_TYPE: u8 = 0x0B; // IPv4-address RT
+const EVI_RT_TYPE2_SUB_TYPE: u8 = 0x0C; // 4-octet-AS RT
+const EVI_RT_TYPE3_SUB_TYPE: u8 = 0x0D; // IPv6-address RT (decode-only marker)
 
 /// Decoded EVPN Multicast Flags Extended Community (RFC 9251 §6, extended
 /// by RFC 9572 §8). A PE attaches this to its Inclusive Multicast (Type-3)
@@ -403,6 +514,26 @@ impl fmt::Display for ExtCommunityValue {
                 write!(f, "+ac-df")?;
             }
             Ok(())
+        } else if let Some(es) = self.as_es_import_rt() {
+            // ES-Import RT (RFC 7432 §7.6): render the 6-octet ES-Import as
+            // a colon-joined hex string, MAC-like.
+            write!(
+                f,
+                "es-import:{:02x}:{:02x}:{:02x}:{:02x}:{:02x}:{:02x}",
+                es[0], es[1], es[2], es[3], es[4], es[5]
+            )
+        } else if self.is_evi_rt() {
+            // EVI-RT EC (RFC 9251 §9.5): render `evi-rt:` then the underlying
+            // Route Target. The IPv6 form (0x0D) has no 8-octet RT, so fall
+            // back to a hex dump of the value.
+            match self.as_evi_rt() {
+                Some(rt) => write!(f, "evi-rt:{rt}"),
+                None => write!(
+                    f,
+                    "evi-rt:{:02x}{:02x}{:02x}{:02x}{:02x}{:02x}",
+                    self.val[0], self.val[1], self.val[2], self.val[3], self.val[4], self.val[5]
+                ),
+            }
         } else {
             let ip = Ipv4Addr::new(self.val[0], self.val[1], self.val[2], self.val[3]);
             let val = u16::from_be_bytes([self.val[4], self.val[5]]);
@@ -935,5 +1066,79 @@ mod tests {
         assert_eq!(parsed, original);
         let m = parsed.as_mup().unwrap();
         assert_eq!(m.sub_type, MupExtComSubType::Sub03);
+    }
+
+    #[test]
+    fn es_import_rt_derives_from_esi() {
+        // ESI: Type byte (0x00) then the 9-octet value; the ES-Import RT is
+        // the high-order 6 octets of that value (ESI octets 1..7).
+        let esi = [0x00, 0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff, 0x01, 0x02, 0x03];
+        let ec = ExtCommunityValue::es_import_rt(&esi);
+        assert_eq!(ec.high_type, ExtCommunityType::Evpn as u8);
+        assert_eq!(ec.low_type, 0x02);
+        assert_eq!(ec.val, [0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff]);
+        assert!(ec.is_es_import_rt());
+        assert_eq!(
+            ec.as_es_import_rt(),
+            Some([0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff])
+        );
+        assert_eq!(ec.to_string(), "es-import:aa:bb:cc:dd:ee:ff");
+        // A standard 2-octet-AS RT is not an ES-Import RT despite sharing
+        // the 0x02 sub-type — the high-type differs.
+        let rt = ExtCommunityValue {
+            high_type: 0x00,
+            low_type: 0x02,
+            val: [0xfd, 0xe9, 0, 0, 0, 100],
+        };
+        assert!(!rt.is_es_import_rt());
+    }
+
+    #[test]
+    fn evi_rt_round_trips_two_octet_as_rt() {
+        // EVI RT value for AS 65001, VNI 100 (Local Admin) — the same 6-octet
+        // value evpn_route_target builds.
+        let rt = ExtCommunityValue {
+            high_type: 0x00, // Two-Octet AS-specific
+            low_type: 0x02,  // Route Target
+            val: [0xfd, 0xe9, 0, 0, 0, 100],
+        };
+        let evi = ExtCommunityValue::evi_rt_from_rt(&rt).expect("2-octet-AS RT → EVI-RT Type 0");
+        assert_eq!(evi.high_type, ExtCommunityType::Evpn as u8);
+        assert_eq!(evi.low_type, 0x0A);
+        assert_eq!(evi.val, rt.val);
+        assert!(evi.is_evi_rt());
+        // Reconstructing the RT yields the original.
+        assert_eq!(evi.as_evi_rt(), Some(rt));
+        assert_eq!(evi.to_string(), "evi-rt:rt:65001:100");
+    }
+
+    #[test]
+    fn evi_rt_sub_type_per_rt_format() {
+        // IPv4-address RT → Type 1 (0x0B); 4-octet-AS RT → Type 2 (0x0C).
+        let v4 = ExtCommunityValue {
+            high_type: 0x01,
+            low_type: 0x02,
+            val: [192, 0, 2, 1, 0, 7],
+        };
+        assert_eq!(
+            ExtCommunityValue::evi_rt_from_rt(&v4).unwrap().low_type,
+            0x0B
+        );
+        let as4 = ExtCommunityValue {
+            high_type: 0x02,
+            low_type: 0x02,
+            val: [0, 1, 0, 0, 0, 9],
+        };
+        assert_eq!(
+            ExtCommunityValue::evi_rt_from_rt(&as4).unwrap().low_type,
+            0x0C
+        );
+        // A non-RT EC (Route Origin sub-type 0x03) yields no EVI-RT.
+        let soo = ExtCommunityValue {
+            high_type: 0x00,
+            low_type: 0x03,
+            val: [0; 6],
+        };
+        assert!(ExtCommunityValue::evi_rt_from_rt(&soo).is_none());
     }
 }

--- a/crates/bgp-packet/src/attrs/mp_reach.rs
+++ b/crates/bgp-packet/src/attrs/mp_reach.rs
@@ -12,7 +12,7 @@ use bytes::BufMut;
 use crate::{
     Afi, AttrFlags, AttrType, BgpLsNlri, EvpnRoute, FlowspecNlri, Ipv4Nlri, Ipv6Nlri, Labelv4Nlri,
     Labelv6Nlri, MupRoute, ParseBe, ParseNlri, ParseOption, Rtcv4, Rtcv6, Safi, SrPolicyNlri,
-    Vpnv4Nexthop, Vpnv4Nlri, Vpnv6Nexthop, Vpnv6Nlri, many0_complete,
+    Vpnv4Nexthop, Vpnv4Nlri, Vpnv6Nexthop, Vpnv6Nlri, esi_display, many0_complete,
 };
 
 use super::{AttrEmitter, RouteDistinguisher, Rtcv4Reach, Rtcv6Reach, Vpnv4Reach, Vpnv6Reach};
@@ -670,6 +670,30 @@ impl fmt::Display for MpReachAttr {
                         EvpnRoute::Smet(v) => {
                             let src = v.src.map_or_else(|| "*".to_string(), |s| s.to_string());
                             writeln!(f, " [{}] SMET ({},{}) orig:{}", v.rd, src, v.grp, v.orig)?;
+                        }
+                        EvpnRoute::IgmpJoinSync(v) => {
+                            let src = v.src.map_or_else(|| "*".to_string(), |s| s.to_string());
+                            writeln!(
+                                f,
+                                " [{}] igmp-join-sync ({},{}) esi:{} orig:{}",
+                                v.rd,
+                                src,
+                                v.grp,
+                                esi_display(&v.esi),
+                                v.orig
+                            )?;
+                        }
+                        EvpnRoute::IgmpLeaveSync(v) => {
+                            let src = v.src.map_or_else(|| "*".to_string(), |s| s.to_string());
+                            writeln!(
+                                f,
+                                " [{}] igmp-leave-sync ({},{}) esi:{} orig:{}",
+                                v.rd,
+                                src,
+                                v.grp,
+                                esi_display(&v.esi),
+                                v.orig
+                            )?;
                         }
                         EvpnRoute::PerRegionImet(v) => {
                             writeln!(f, " [{}] per-region-imet tag:{}", v.rd, v.ether_tag)?;

--- a/crates/bgp-packet/src/attrs/mp_unreach.rs
+++ b/crates/bgp-packet/src/attrs/mp_unreach.rs
@@ -632,6 +632,14 @@ impl fmt::Display for MpUnreachAttr {
                             let src = v.src.map_or_else(|| "*".to_string(), |s| s.to_string());
                             writeln!(f, " [{}] SMET ({},{})", v.rd, src, v.grp)?;
                         }
+                        EvpnRoute::IgmpJoinSync(v) => {
+                            let src = v.src.map_or_else(|| "*".to_string(), |s| s.to_string());
+                            writeln!(f, " [{}] igmp-join-sync ({},{})", v.rd, src, v.grp)?;
+                        }
+                        EvpnRoute::IgmpLeaveSync(v) => {
+                            let src = v.src.map_or_else(|| "*".to_string(), |s| s.to_string());
+                            writeln!(f, " [{}] igmp-leave-sync ({},{})", v.rd, src, v.grp)?;
+                        }
                         EvpnRoute::PerRegionImet(v) => {
                             writeln!(f, " [{}] per-region-imet:{}", v.rd, v.ether_tag)?;
                         }

--- a/crates/bgp-packet/src/attrs/nlri_evpn.rs
+++ b/crates/bgp-packet/src/attrs/nlri_evpn.rs
@@ -19,6 +19,8 @@ pub enum EvpnRouteType {
     EthernetSr,    // 4
     IpPrefix,      // 5
     SmetRoute,     // 6 — Selective Multicast Ethernet Tag (RFC 9251)
+    IgmpJoinSync,  // 7 — IGMP/MLD Join Synch (RFC 9251 §9.2)
+    IgmpLeaveSync, // 8 — IGMP/MLD Leave Synch (RFC 9251 §9.3)
     PerRegionImet, // 9  — Per-Region I-PMSI A-D (RFC 9572 §3.1)
     SPmsiAd,       // 10 — S-PMSI A-D (RFC 9572 §3.2)
     LeafAd,        // 11 — Leaf A-D (RFC 9572 §3.3)
@@ -35,6 +37,8 @@ impl From<EvpnRouteType> for u8 {
             EthernetSr => 4,
             IpPrefix => 5,
             SmetRoute => 6,
+            IgmpJoinSync => 7,
+            IgmpLeaveSync => 8,
             PerRegionImet => 9,
             SPmsiAd => 10,
             LeafAd => 11,
@@ -53,6 +57,8 @@ impl From<u8> for EvpnRouteType {
             4 => EthernetSr,
             5 => IpPrefix,
             6 => SmetRoute,
+            7 => IgmpJoinSync,
+            8 => IgmpLeaveSync,
             9 => PerRegionImet,
             10 => SPmsiAd,
             11 => LeafAd,
@@ -74,6 +80,8 @@ pub enum EvpnRoute {
     Multicast(EvpnMulticast),
     Prefix(EvpnIpPrefix),
     Smet(EvpnSmet),
+    IgmpJoinSync(EvpnIgmpJoinSync),
+    IgmpLeaveSync(EvpnIgmpLeaveSync),
     PerRegionImet(EvpnPerRegionImet),
     SPmsi(EvpnSPmsi),
     LeafAd(EvpnLeafAd),
@@ -142,6 +150,66 @@ pub struct EvpnSmet {
     pub grp: IpAddr,
     /// Originating router's IP address.
     pub orig: IpAddr,
+    /// IGMP/MLD version + include/exclude flags (RFC 9251 §9.1).
+    /// Not part of the route key.
+    pub flags: u8,
+}
+
+/// Route Type 7 — IGMP/MLD Join Synch Route (RFC 9251 §9.2). On an
+/// all-active Ethernet Segment, a PE that receives an IGMP/MLD membership
+/// report originates this so the other PE(s) on the same ES synchronise the
+/// `(*,G)` / `(S,G)` Join state (the DF then advertises the combined SMET).
+///
+/// Wire layout (RFC 9251 §9.2): RD(8) ESI(10) EthTag(4) McastSrcLen(1)
+/// McastSrc(0|4|16) McastGrpLen(1) McastGrp(4|16) OrigLen(1) Orig(4|16)
+/// Flags(1). It is Type-6 SMET with a 10-octet ESI inserted after the RD.
+/// Source length 0 means `(*,G)`. The 1-octet Flags field (IGMP/MLD version
+/// and include/exclude mode) rides on the path, so — like SMET — it is
+/// **not** part of the BGP route key (`EvpnPrefix::IgmpJoinSync`).
+/// Distribution is scoped by an ES-Import RT; the route also carries one
+/// EVI-RT EC.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct EvpnIgmpJoinSync {
+    pub id: u32,
+    pub rd: RouteDistinguisher,
+    /// Ethernet Segment Identifier (10 octets) of the multihomed ES.
+    pub esi: [u8; 10],
+    pub ether_tag: u32,
+    /// Multicast source. `None` is the `(*,G)` wildcard (source length 0
+    /// on the wire); `Some` is a specific `(S,G)` source.
+    pub src: Option<IpAddr>,
+    /// Multicast group address (always present).
+    pub grp: IpAddr,
+    /// Originating router's IP address.
+    pub orig: IpAddr,
+    /// IGMP/MLD version + include/exclude flags (RFC 9251 §9.1).
+    /// Not part of the route key.
+    pub flags: u8,
+}
+
+/// Route Type 8 — IGMP/MLD Leave Synch Route (RFC 9251 §9.3). The companion
+/// to Type 7: a PE on an all-active ES originates this on a membership Leave
+/// so the peer PE(s) run the last-member-query synchronisation.
+///
+/// Wire layout (RFC 9251 §9.3): identical to the Join Synch route up to the
+/// Originator, then `Reserved(4)` + `MaximumResponseTime(1)` + `Flags(1)`:
+/// RD(8) ESI(10) EthTag(4) McastSrcLen(1) McastSrc(0|4|16) McastGrpLen(1)
+/// McastGrp(4|16) OrigLen(1) Orig(4|16) Reserved(4) MaxRespTime(1) Flags(1).
+/// The Reserved field is sent as zero. The Reserved, MaximumResponseTime and
+/// Flags fields all ride on the path and are **not** part of the BGP route
+/// key (`EvpnPrefix::IgmpLeaveSync`).
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct EvpnIgmpLeaveSync {
+    pub id: u32,
+    pub rd: RouteDistinguisher,
+    pub esi: [u8; 10],
+    pub ether_tag: u32,
+    pub src: Option<IpAddr>,
+    pub grp: IpAddr,
+    pub orig: IpAddr,
+    /// Maximum Response Time (RFC 2236) for the last-member query, in the
+    /// same units IGMP uses. Not part of the route key.
+    pub max_resp_time: u8,
     /// IGMP/MLD version + include/exclude flags (RFC 9251 §9.1).
     /// Not part of the route key.
     pub flags: u8,
@@ -289,6 +357,35 @@ pub enum EvpnPrefix {
         grp: IpAddr,
         orig: IpAddr,
     },
+    /// Route Type 7 — IGMP/MLD Join Synch Route (RFC 9251 §9.2).
+    ///
+    /// Wire format:
+    /// `[7]:[ESI]:[EthTag]:[SrcLen]:[Src]:[GrpLen]:[Grp]:[OrigLen]:[Orig]`.
+    /// `src = None` is the `(*,G)` wildcard. The ESI is part of the route
+    /// key (it scopes the route to the Ethernet Segment); the 1-octet Flags
+    /// field is a per-path property and is omitted here. Declared after
+    /// `Smet` (6) and before `PerRegionImet` (9) so the derived `Ord` keeps
+    /// numeric route-type ordering.
+    IgmpJoinSync {
+        esi: [u8; 10],
+        eth_tag: u32,
+        src: Option<IpAddr>,
+        grp: IpAddr,
+        orig: IpAddr,
+    },
+    /// Route Type 8 — IGMP/MLD Leave Synch Route (RFC 9251 §9.3).
+    ///
+    /// Wire format:
+    /// `[8]:[ESI]:[EthTag]:[SrcLen]:[Src]:[GrpLen]:[Grp]:[OrigLen]:[Orig]`.
+    /// Same key shape as the Join Synch route; the Reserved, Maximum
+    /// Response Time and Flags octets are per-path properties, omitted here.
+    IgmpLeaveSync {
+        esi: [u8; 10],
+        eth_tag: u32,
+        src: Option<IpAddr>,
+        grp: IpAddr,
+        orig: IpAddr,
+    },
     /// Route Type 9 — Per-Region I-PMSI A-D Route (RFC 9572 §3.1).
     PerRegionImet { eth_tag: u32, region_id: [u8; 8] },
     /// Route Type 10 — S-PMSI A-D Route (RFC 9572 §3.2). `src`/`grp` are
@@ -313,6 +410,8 @@ impl EvpnPrefix {
             EvpnPrefix::InclusiveMulticast { .. } => 3,
             EvpnPrefix::IpPrefix { .. } => 5,
             EvpnPrefix::Smet { .. } => 6,
+            EvpnPrefix::IgmpJoinSync { .. } => 7,
+            EvpnPrefix::IgmpLeaveSync { .. } => 8,
             EvpnPrefix::PerRegionImet { .. } => 9,
             EvpnPrefix::SPmsi { .. } => 10,
             EvpnPrefix::LeafAd { .. } => 11,
@@ -355,6 +454,26 @@ impl EvpnPrefix {
                     src: s.src,
                     grp: s.grp,
                     orig: s.orig,
+                },
+            ),
+            EvpnRoute::IgmpJoinSync(j) => (
+                j.rd,
+                EvpnPrefix::IgmpJoinSync {
+                    esi: j.esi,
+                    eth_tag: j.ether_tag,
+                    src: j.src,
+                    grp: j.grp,
+                    orig: j.orig,
+                },
+            ),
+            EvpnRoute::IgmpLeaveSync(l) => (
+                l.rd,
+                EvpnPrefix::IgmpLeaveSync {
+                    esi: l.esi,
+                    eth_tag: l.ether_tag,
+                    src: l.src,
+                    grp: l.grp,
+                    orig: l.orig,
                 },
             ),
             EvpnRoute::PerRegionImet(r) => (
@@ -449,6 +568,20 @@ impl fmt::Display for EvpnPrefix {
                     ip_bits(orig)
                 )
             }
+            EvpnPrefix::IgmpJoinSync {
+                esi,
+                eth_tag,
+                src,
+                grp,
+                orig,
+            } => fmt_sync_prefix(f, 7, esi, *eth_tag, src, grp, orig),
+            EvpnPrefix::IgmpLeaveSync {
+                esi,
+                eth_tag,
+                src,
+                grp,
+                orig,
+            } => fmt_sync_prefix(f, 8, esi, *eth_tag, src, grp, orig),
             EvpnPrefix::PerRegionImet { eth_tag, region_id } => {
                 // Render the Region ID via its EC-encoding (`AS:<n>` /
                 // `area:<ip>`), falling back to a hex dump for unrecognised
@@ -482,6 +615,41 @@ fn ip_bits(ip: &IpAddr) -> u8 {
         IpAddr::V4(_) => 32,
         IpAddr::V6(_) => 128,
     }
+}
+
+/// Render a 10-octet Ethernet Segment Identifier as a colon-separated hex
+/// string (`00:11:22:…`), the canonical EVPN ESI notation.
+pub fn esi_display(esi: &[u8; 10]) -> String {
+    esi.iter()
+        .map(|b| format!("{b:02x}"))
+        .collect::<Vec<_>>()
+        .join(":")
+}
+
+/// Shared `Display` body for the IGMP/MLD Join (Type 7) and Leave (Type 8)
+/// Synch route keys, which differ only in the leading route-type number:
+/// `[<rt>]:[<ESI>]:[EthTag]:[SrcLen]:[Src]:[GrpLen]:[Grp]:[OrigLen]:[Orig]`.
+/// A `(*,G)` route renders the source as `[0]:[*]`.
+fn fmt_sync_prefix(
+    f: &mut fmt::Formatter<'_>,
+    rt: u8,
+    esi: &[u8; 10],
+    eth_tag: u32,
+    src: &Option<IpAddr>,
+    grp: &IpAddr,
+    orig: &IpAddr,
+) -> fmt::Result {
+    write!(f, "[{rt}]:[{}]:[{eth_tag}]", esi_display(esi))?;
+    match src {
+        Some(s) => write!(f, ":[{}]:[{s}]", ip_bits(s))?,
+        None => write!(f, ":[0]:[*]")?,
+    }
+    write!(
+        f,
+        ":[{}]:[{grp}]:[{}]:[{orig}]",
+        ip_bits(grp),
+        ip_bits(orig)
+    )
 }
 
 impl ParseNlri<EvpnRoute> for EvpnRoute {
@@ -624,6 +792,66 @@ impl ParseNlri<EvpnRoute> for EvpnRoute {
                     flags,
                 };
                 Ok((input, EvpnRoute::Smet(evpn)))
+            }
+            IgmpJoinSync => {
+                // RFC 9251 §9.2: RD(8) ESI(10) EthTag(4) SrcLen(1) Src(0|4|16)
+                // GrpLen(1) Grp(4|16) OrigLen(1) Orig(4|16) Flags(1).
+                let (input, rd) = RouteDistinguisher::parse_be(input)?;
+                let (input, esi_raw) = take(10usize).parse(input)?;
+                let mut esi = [0u8; 10];
+                esi.copy_from_slice(esi_raw);
+                let (input, ether_tag) = be_u32(input)?;
+                let (input, src) = parse_len_prefixed_ip(input)?;
+                let (input, grp) = parse_len_prefixed_ip(input)?;
+                let grp =
+                    grp.ok_or_else(|| nom::Err::Error(make_error(input, ErrorKind::LengthValue)))?;
+                let (input, orig) = parse_len_prefixed_ip(input)?;
+                let orig =
+                    orig.ok_or_else(|| nom::Err::Error(make_error(input, ErrorKind::LengthValue)))?;
+                let (input, flags) = be_u8(input)?;
+                let evpn = EvpnIgmpJoinSync {
+                    id,
+                    rd,
+                    esi,
+                    ether_tag,
+                    src,
+                    grp,
+                    orig,
+                    flags,
+                };
+                Ok((input, EvpnRoute::IgmpJoinSync(evpn)))
+            }
+            IgmpLeaveSync => {
+                // RFC 9251 §9.3: like the Join Synch route, then Reserved(4)
+                // MaxRespTime(1) Flags(1) in place of the lone Flags octet.
+                let (input, rd) = RouteDistinguisher::parse_be(input)?;
+                let (input, esi_raw) = take(10usize).parse(input)?;
+                let mut esi = [0u8; 10];
+                esi.copy_from_slice(esi_raw);
+                let (input, ether_tag) = be_u32(input)?;
+                let (input, src) = parse_len_prefixed_ip(input)?;
+                let (input, grp) = parse_len_prefixed_ip(input)?;
+                let grp =
+                    grp.ok_or_else(|| nom::Err::Error(make_error(input, ErrorKind::LengthValue)))?;
+                let (input, orig) = parse_len_prefixed_ip(input)?;
+                let orig =
+                    orig.ok_or_else(|| nom::Err::Error(make_error(input, ErrorKind::LengthValue)))?;
+                // Reserved (4 octets, sent as zero) — read and discard.
+                let (input, _reserved) = take(4usize).parse(input)?;
+                let (input, max_resp_time) = be_u8(input)?;
+                let (input, flags) = be_u8(input)?;
+                let evpn = EvpnIgmpLeaveSync {
+                    id,
+                    rd,
+                    esi,
+                    ether_tag,
+                    src,
+                    grp,
+                    orig,
+                    max_resp_time,
+                    flags,
+                };
+                Ok((input, EvpnRoute::IgmpLeaveSync(evpn)))
             }
             PerRegionImet => {
                 // RFC 9572 §3.1: RD(8) EthTag(4) RegionID(8).
@@ -856,6 +1084,52 @@ impl EvpnRoute {
                 buf.put_u8(payload.len() as u8);
                 buf.put(&payload[..]);
             }
+            EvpnRoute::IgmpJoinSync(j) => {
+                if j.id != 0 {
+                    buf.put_u32(j.id);
+                }
+                let mut payload = BytesMut::new();
+                // RD (8 octets).
+                payload.put_u16(j.rd.typ as u16);
+                payload.put(&j.rd.val[..]);
+                // ESI (10 octets) — RFC 9251 §9.2.
+                payload.put(&j.esi[..]);
+                // Ethernet Tag (4 octets).
+                payload.put_u32(j.ether_tag);
+                // Multicast Source / Group / Originator, each <len><addr>.
+                emit_len_prefixed_ip(&mut payload, j.src);
+                emit_len_prefixed_ip(&mut payload, Some(j.grp));
+                emit_len_prefixed_ip(&mut payload, Some(j.orig));
+                // Flags (1 octet).
+                payload.put_u8(j.flags);
+                buf.put_u8(7); // Route Type 7 — IGMP/MLD Join Synch.
+                buf.put_u8(payload.len() as u8);
+                buf.put(&payload[..]);
+            }
+            EvpnRoute::IgmpLeaveSync(l) => {
+                if l.id != 0 {
+                    buf.put_u32(l.id);
+                }
+                let mut payload = BytesMut::new();
+                // RD (8 octets).
+                payload.put_u16(l.rd.typ as u16);
+                payload.put(&l.rd.val[..]);
+                // ESI (10 octets) — RFC 9251 §9.3.
+                payload.put(&l.esi[..]);
+                // Ethernet Tag (4 octets).
+                payload.put_u32(l.ether_tag);
+                // Multicast Source / Group / Originator, each <len><addr>.
+                emit_len_prefixed_ip(&mut payload, l.src);
+                emit_len_prefixed_ip(&mut payload, Some(l.grp));
+                emit_len_prefixed_ip(&mut payload, Some(l.orig));
+                // Reserved (4 octets, zero), Maximum Response Time (1), Flags (1).
+                payload.put_u32(0);
+                payload.put_u8(l.max_resp_time);
+                payload.put_u8(l.flags);
+                buf.put_u8(8); // Route Type 8 — IGMP/MLD Leave Synch.
+                buf.put_u8(payload.len() as u8);
+                buf.put(&payload[..]);
+            }
             EvpnRoute::PerRegionImet(r) => {
                 if r.id != 0 {
                     buf.put_u32(r.id);
@@ -1047,6 +1321,71 @@ mod evpn_prefix_tests {
         assert_eq!(s.route_type(), 6);
         // Variant order keeps Type 5 < Type 6.
         assert!(p < s);
+    }
+
+    #[test]
+    fn display_igmp_join_sync_star_g_v4() {
+        let p = EvpnPrefix::IgmpJoinSync {
+            esi: [0x00, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88, 0x99],
+            eth_tag: 0,
+            src: None,
+            grp: IpAddr::V4(Ipv4Addr::new(239, 1, 1, 1)),
+            orig: IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1)),
+        };
+        assert_eq!(
+            p.to_string(),
+            "[7]:[00:11:22:33:44:55:66:77:88:99]:[0]:[0]:[*]:[32]:[239.1.1.1]:[32]:[10.0.0.1]"
+        );
+        assert_eq!(p.route_type(), 7);
+    }
+
+    #[test]
+    fn display_igmp_leave_sync_s_g_v4() {
+        let p = EvpnPrefix::IgmpLeaveSync {
+            esi: [0; 10],
+            eth_tag: 20,
+            src: Some(IpAddr::V4(Ipv4Addr::new(192, 0, 2, 9))),
+            grp: IpAddr::V4(Ipv4Addr::new(232, 1, 1, 1)),
+            orig: IpAddr::V4(Ipv4Addr::new(10, 0, 0, 2)),
+        };
+        assert_eq!(
+            p.to_string(),
+            "[8]:[00:00:00:00:00:00:00:00:00:00]:[20]:[32]:[192.0.2.9]:[32]:[232.1.1.1]:[32]:[10.0.0.2]"
+        );
+        assert_eq!(p.route_type(), 8);
+    }
+
+    #[test]
+    fn sync_route_type_ordering() {
+        // The derived `Ord` must keep Type 6 < 7 < 8 < 9 so `show bgp evpn`
+        // lists the route types numerically.
+        let t6 = EvpnPrefix::Smet {
+            eth_tag: 0,
+            src: None,
+            grp: IpAddr::V4(Ipv4Addr::UNSPECIFIED),
+            orig: IpAddr::V4(Ipv4Addr::UNSPECIFIED),
+        };
+        let t7 = EvpnPrefix::IgmpJoinSync {
+            esi: [0; 10],
+            eth_tag: 0,
+            src: None,
+            grp: IpAddr::V4(Ipv4Addr::UNSPECIFIED),
+            orig: IpAddr::V4(Ipv4Addr::UNSPECIFIED),
+        };
+        let t8 = EvpnPrefix::IgmpLeaveSync {
+            esi: [0; 10],
+            eth_tag: 0,
+            src: None,
+            grp: IpAddr::V4(Ipv4Addr::UNSPECIFIED),
+            orig: IpAddr::V4(Ipv4Addr::UNSPECIFIED),
+        };
+        let t9 = EvpnPrefix::PerRegionImet {
+            eth_tag: 0,
+            region_id: [0; 8],
+        };
+        assert!(t6 < t7);
+        assert!(t7 < t8);
+        assert!(t8 < t9);
     }
 
     #[test]
@@ -1640,5 +1979,130 @@ mod evpn_emit_tests {
         EvpnRoute::PerRegionImet(r).nlri_emit(&mut buf);
         assert_eq!(&buf[0..4], &[0, 0, 0, 11], "path id prepended");
         assert_eq!(buf[4], 9, "route type follows id");
+    }
+
+    fn esi_sample() -> [u8; 10] {
+        [0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09]
+    }
+
+    /// Type-7 Join Synch `(*,G)` IPv4. Payload = 8 (RD) + 10 (ESI) + 4
+    /// (eth-tag) + 1 (src-len=0) + 1 (grp-len=32) + 4 (grp) + 1
+    /// (orig-len=32) + 4 (orig) + 1 (flags) = 34.
+    #[test]
+    fn igmp_join_sync_nlri_emit_star_g_v4() {
+        let j = EvpnIgmpJoinSync {
+            id: 0,
+            rd: rd_type1_ip(Ipv4Addr::new(10, 0, 0, 1), 100),
+            esi: esi_sample(),
+            ether_tag: 0,
+            src: None,
+            grp: IpAddr::V4(Ipv4Addr::new(239, 1, 1, 1)),
+            orig: IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1)),
+            flags: 0x04, // IGMPv3 include
+        };
+        let mut buf = BytesMut::new();
+        EvpnRoute::IgmpJoinSync(j).nlri_emit(&mut buf);
+        assert_eq!(buf[0], 7, "route type 7");
+        assert_eq!(buf[1], 34, "length");
+        assert_eq!(&buf[2..4], &[0x00, 0x01], "RD type 1");
+        assert_eq!(&buf[10..20], &esi_sample(), "ESI after RD");
+        assert_eq!(&buf[20..24], &[0, 0, 0, 0], "eth-tag = 0");
+        assert_eq!(buf[24], 0, "src len 0 — (*,G)");
+        assert_eq!(buf[25], 32, "grp len = 32");
+        assert_eq!(&buf[26..30], &[239, 1, 1, 1], "group");
+        assert_eq!(buf[30], 32, "orig len = 32");
+        assert_eq!(&buf[31..35], &[10, 0, 0, 1], "originator");
+        assert_eq!(buf[35], 0x04, "flags");
+        assert_eq!(buf.len(), 36, "1 + 1 + 34");
+    }
+
+    /// Round-trip an `(S,G)` IPv4 Join Synch route.
+    #[test]
+    fn igmp_join_sync_roundtrip_s_g_v4() {
+        let original = EvpnIgmpJoinSync {
+            id: 0,
+            rd: rd_type1_ip(Ipv4Addr::new(192, 168, 0, 1), 200),
+            esi: esi_sample(),
+            ether_tag: 5,
+            src: Some(IpAddr::V4(Ipv4Addr::new(192, 0, 2, 9))),
+            grp: IpAddr::V4(Ipv4Addr::new(232, 1, 1, 1)),
+            orig: IpAddr::V4(Ipv4Addr::new(10, 0, 0, 2)),
+            flags: 0x0c, // v3 + exclude (IE)
+        };
+        let mut buf = BytesMut::new();
+        EvpnRoute::IgmpJoinSync(original.clone()).nlri_emit(&mut buf);
+        let (_, parsed) =
+            EvpnRoute::parse_nlri(&buf, false).expect("parse_nlri must accept what we emit");
+        assert_eq!(parsed, EvpnRoute::IgmpJoinSync(original));
+    }
+
+    /// Add-Path: a non-zero `id` prepends the 4-byte path identifier.
+    #[test]
+    fn igmp_join_sync_nlri_emit_addpath() {
+        let j = EvpnIgmpJoinSync {
+            id: 13,
+            rd: rd_type1_ip(Ipv4Addr::new(10, 0, 0, 1), 100),
+            esi: esi_sample(),
+            ether_tag: 0,
+            src: None,
+            grp: IpAddr::V4(Ipv4Addr::new(239, 1, 1, 1)),
+            orig: IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1)),
+            flags: 0,
+        };
+        let mut buf = BytesMut::new();
+        EvpnRoute::IgmpJoinSync(j).nlri_emit(&mut buf);
+        assert_eq!(&buf[0..4], &[0, 0, 0, 13], "path id prepended");
+        assert_eq!(buf[4], 7, "route type follows id");
+    }
+
+    /// Type-8 Leave Synch `(*,G)` IPv4. Payload = Join Synch (34) without
+    /// the trailing flags, then Reserved(4) + MaxRespTime(1) + Flags(1)
+    /// = 33 + 4 + 1 + 1 = 39.
+    #[test]
+    fn igmp_leave_sync_nlri_emit_star_g_v4() {
+        let l = EvpnIgmpLeaveSync {
+            id: 0,
+            rd: rd_type1_ip(Ipv4Addr::new(10, 0, 0, 1), 100),
+            esi: esi_sample(),
+            ether_tag: 0,
+            src: None,
+            grp: IpAddr::V4(Ipv4Addr::new(239, 1, 1, 1)),
+            orig: IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1)),
+            max_resp_time: 100,
+            flags: 0x04,
+        };
+        let mut buf = BytesMut::new();
+        EvpnRoute::IgmpLeaveSync(l).nlri_emit(&mut buf);
+        assert_eq!(buf[0], 8, "route type 8");
+        assert_eq!(buf[1], 39, "length");
+        assert_eq!(&buf[10..20], &esi_sample(), "ESI after RD");
+        assert_eq!(buf[30], 32, "orig len = 32");
+        assert_eq!(&buf[31..35], &[10, 0, 0, 1], "originator");
+        assert_eq!(&buf[35..39], &[0, 0, 0, 0], "Reserved = 0");
+        assert_eq!(buf[39], 100, "Maximum Response Time");
+        assert_eq!(buf[40], 0x04, "flags");
+        assert_eq!(buf.len(), 41, "1 + 1 + 39");
+    }
+
+    /// Round-trip a `(*,G)` IPv6/MLD Leave Synch route (source absent,
+    /// 16-octet group + originator).
+    #[test]
+    fn igmp_leave_sync_roundtrip_star_g_v6() {
+        let original = EvpnIgmpLeaveSync {
+            id: 0,
+            rd: rd_type1_ip(Ipv4Addr::new(192, 168, 0, 1), 300),
+            esi: esi_sample(),
+            ether_tag: 0,
+            src: None,
+            grp: "ff05::1:3".parse::<IpAddr>().unwrap(),
+            orig: "2001:db8::2".parse::<IpAddr>().unwrap(),
+            max_resp_time: 50,
+            flags: 0x02, // MLDv2
+        };
+        let mut buf = BytesMut::new();
+        EvpnRoute::IgmpLeaveSync(original.clone()).nlri_emit(&mut buf);
+        let (_, parsed) =
+            EvpnRoute::parse_nlri(&buf, false).expect("parse_nlri must accept what we emit");
+        assert_eq!(parsed, EvpnRoute::IgmpLeaveSync(original));
     }
 }

--- a/docs/design/bgp-evpn-igmp-mld-proxy-followups.md
+++ b/docs/design/bgp-evpn-igmp-mld-proxy-followups.md
@@ -92,15 +92,50 @@ vlan-tunnel config and pass it to `mdb_install`.
 
 ## 6. Type 7 / Type 8 multihoming synch routes
 
-All-active multihoming only; large. Prerequisites absent today:
+**Codec + control-plane stub: DONE.** Type 7 (IGMP/MLD Join Synch) and
+Type 8 (IGMP/MLD Leave Synch) are now first-class in the BGP-packet
+codec and the EVPN RIB:
+
+- **NLRI codec** (`crates/bgp-packet/src/attrs/nlri_evpn.rs`):
+  `EvpnIgmpJoinSync` / `EvpnIgmpLeaveSync` structs, `EvpnRoute` +
+  `EvpnPrefix` variants (route types 7/8, ESI in the key), parse/emit,
+  `Display` (with an `esi_display` helper), round-trip unit tests. The
+  Type-8 `Reserved(4)` + `MaximumResponseTime(1)` + `Flags(1)` tail is
+  handled; the Flags / Max-Response-Time ride off the route key.
+- **Ext-comms** (`ext_com.rs`): **ES-Import RT** (`0x06`/`0x02`,
+  auto-derived from the ESI) and **EVI-RT EC** (`0x06`/`0x0A`–`0x0C`,
+  via `evi_rt_from_rt`), with predicates, accessors, `Display`, tests.
+  EVI-RT Type 3 (IPv6, `0x0D`, 20-octet EC) is still out — the
+  `ExtCommunityValue` is fixed 8-octet and zebra RTs are 2-octet-AS.
+- **RIB stub** (`bgp/route.rs`): received Type-7/8 routes are stored,
+  best-path-selected, and **re-advertised / route-reflected** through
+  the generic EVPN path; the per-path Flags / Max-Response-Time are
+  stamped on the `BgpRib` (`smet_flags` / `igmp_max_resp_time`) so a
+  reflected route stays faithful. `route_evpn_export_selected` treats
+  them as **kernel no-ops**. Origination helpers
+  `evpn_originate_igmp_join_sync` / `…_leave_sync` (+ withdraws) attach
+  the ES-Import RT + EVI-RT EC; they are `#[allow(dead_code)]` until an
+  ES-snoop trigger calls them (see below).
+- **CLI**: `show bgp evpn igmp-join-sync` / `igmp-leave-sync` filters +
+  legends + `exec.yang` enums.
+
+**Still deferred (the actual multihoming data plane):**
 - **Ethernet-Segment** support: Type 1 (Ethernet A-D) + Type 4
   (Ethernet Segment) routes, **DF election**.
-- New ext-comms: **EVI-RT EC** (`0x06` / sub-types `0x0A`–`0x0D`) and
-  **ES-Import RT**.
 - Synch state machine + timers (last-member-query, Maximum Response
   Time); the DF advertises/withdraws the SMET from the combined
   `(x,G)` state across the ES.
-The Type 7/8 NLRI wire layouts are recorded in the main design doc.
+- The **organic origination trigger**: a snoop on a multihomed ES that
+  calls the `evpn_originate_igmp_*_sync` helpers (today nothing does).
+- **Kernel MDB synch** between the PEs on the ES.
+- EVPN **import-RT filtering** so the ES-Import RT actually scopes
+  distribution (today Type-7/8 reflect to all EVPN peers; the RTs are
+  carried but not yet consulted on import). Note `route_rts_from_ecom`
+  filters `low_type == 0x02` regardless of high-type and is VPNv4/v6
+  only, so the ES-Import RT (`0x06/0x02`) causes no collision today.
+- **Live validation** (BDD): needs an injection path (a debug exec
+  command driving the origination helpers, or real ES multihoming) to
+  observe reflection end-to-end.
 
 ## 7. Minor / cosmetic
 

--- a/docs/design/bgp-evpn-igmp-mld-proxy.md
+++ b/docs/design/bgp-evpn-igmp-mld-proxy.md
@@ -36,7 +36,8 @@ true per-VTEP `dst` selectivity are deferred (see **Deferred**).
 | 4     | SMET origination from kernel MDB snoop  | **done** | #1502 |
 | 5     | SMET reception → selective dataplane    | **done** | #1506 |
 | 6     | Show + BDD + docs                       | **done** | #1510 |
-| —     | Type 7/8 multihoming synch              | deferred | —     |
+| —     | Type 7/8 codec + control-plane stub     | **done** | —     |
+| —     | Type 7/8 multihoming data plane (DF/ES) | deferred | —     |
 
 (Phase 4 also pushed `netlink-packet-route` `seg6` commit `d912564`, which
 adds the MDB-entry decode; tracked via the `branch = "seg6"` dependency.)
@@ -112,7 +113,7 @@ Flags (2 octets): **bit 15 = IGMP Proxy Support**, **bit 14 = MLD Proxy
 Support**, bits 0-13 reserved. Both-zero ⇒ malformed, ignore the EC.
 Rides on the Type-3 IMET route to advertise proxy capability.
 
-### Route Types 7 / 8 (deferred — recorded for completeness)
+### Route Types 7 / 8 (codec + control-plane stub implemented)
 
 Type 7 (Join Synch) = SMET fields **plus a 10-octet ESI** (after RD,
 before Ethernet Tag). Type 8 (Leave Synch) = Type 7 fields **plus**
@@ -121,6 +122,14 @@ Reserved(4) + Maximum Response Time(1) before Flags. Both MUST carry an
 `0x0A`–`0x0D` for the 2-octet-AS / IPv4 / 4-octet-AS / IPv6 RT shapes).
 Distribution is scoped by the ES-Import RT only; the EVI-RT EC carries the
 EVI's RT value but does not control propagation.
+
+The NLRI codec, the ES-Import RT / EVI-RT extended communities, the EVPN
+RIB store + reflect path, the `show bgp evpn igmp-join-sync` /
+`igmp-leave-sync` filters, and the origination helpers are now in tree;
+the multihoming data plane (DF election, Ethernet-Segment Type 1/4, the
+synch state machine, and the ES-snoop origination trigger) remains
+deferred. See `bgp-evpn-igmp-mld-proxy-followups.md` §6 for the full
+breakdown.
 
 ## Operational model (how SMET fits with Type 3)
 

--- a/zebra-rs/src/bgp/inst.rs
+++ b/zebra-rs/src/bgp/inst.rs
@@ -4590,6 +4590,7 @@ impl Bgp {
                     esi: None,
                     vrf_transit_only: false,
                     smet_flags: 0,
+                    igmp_max_resp_time: 0,
                     ingress_region: None,
                 };
 
@@ -4873,6 +4874,7 @@ impl Bgp {
                     esi: None,
                     vrf_transit_only: false,
                     smet_flags: 0,
+                    igmp_max_resp_time: 0,
                     ingress_region: None,
                 };
 

--- a/zebra-rs/src/bgp/route.rs
+++ b/zebra-rs/src/bgp/route.rs
@@ -1215,11 +1215,15 @@ pub struct BgpRib {
     /// (`route_ipv4_update` / `route_ipv6_update`); `route_update_ipv4` /
     /// `…ipv6` suppress the advertise. Default `false` (ordinary route).
     pub vrf_transit_only: bool,
-    /// EVPN Type-6 SMET Flags octet (IGMP/MLD version + include/exclude
-    /// mode, RFC 9251 §9.1). The Flags field is NOT part of the SMET
-    /// route key, so it rides here on the path; the advertise/rebuild
-    /// helpers re-emit it. `0` for every non-SMET row.
+    /// EVPN RFC 9251 §9.1 Flags octet (IGMP/MLD version + include/exclude
+    /// mode). The Flags field is NOT part of the SMET (Type-6) or Join/Leave
+    /// Synch (Type-7/8) route key, so it rides here on the path; the
+    /// advertise/rebuild helpers re-emit it. `0` for every non-RFC-9251 row.
     pub smet_flags: u8,
+    /// EVPN Type-8 Leave Synch Maximum Response Time (RFC 9251 §9.3), a
+    /// per-path field carried off the route key like `smet_flags`. `0` for
+    /// every non-Leave-Synch row.
+    pub igmp_max_resp_time: u8,
     /// RFC 9572 §6.1 region of the peer this route was received from
     /// (the resolved `Peer.region_id`), stamped at receive. The EVPN
     /// advertise gate uses it to suppress per-PE IMET (Type-3) across region
@@ -1322,6 +1326,7 @@ impl BgpRib {
             esi: None,
             vrf_transit_only: false,
             smet_flags: 0,
+            igmp_max_resp_time: 0,
             ingress_region: None,
         }
     }
@@ -4846,6 +4851,42 @@ pub fn route_update_evpn(
             // its IGMP/MLD version + IE mode.
             flags: rib.smet_flags,
         }),
+        // Type-7/8 Synch routes (RFC 9251): the ESI/src/grp/orig come from
+        // the RIB key; the per-path Flags (and Type-8 Maximum Response Time)
+        // ride on the `BgpRib`, preserved so a reflected route stays faithful.
+        EvpnPrefix::IgmpJoinSync {
+            esi,
+            eth_tag,
+            src,
+            grp,
+            orig,
+        } => EvpnRoute::IgmpJoinSync(EvpnIgmpJoinSync {
+            id,
+            rd: *rd,
+            esi: *esi,
+            ether_tag: *eth_tag,
+            src: *src,
+            grp: *grp,
+            orig: *orig,
+            flags: rib.smet_flags,
+        }),
+        EvpnPrefix::IgmpLeaveSync {
+            esi,
+            eth_tag,
+            src,
+            grp,
+            orig,
+        } => EvpnRoute::IgmpLeaveSync(EvpnIgmpLeaveSync {
+            id,
+            rd: *rd,
+            esi: *esi,
+            ether_tag: *eth_tag,
+            src: *src,
+            grp: *grp,
+            orig: *orig,
+            max_resp_time: rib.igmp_max_resp_time,
+            flags: rib.smet_flags,
+        }),
     };
 
     let mut attrs = (*rib.attr).clone();
@@ -5031,6 +5072,42 @@ fn evpn_route_from_prefix(rd: &RouteDistinguisher, prefix: &EvpnPrefix, id: u32)
             orig: *orig,
             // Withdraw is matched on the NLRI key (flags are not part of
             // it), so flags = 0 here is correct. See TODO(phase4).
+            flags: 0,
+        }),
+        // Type-7/8 Synch routes: ESI comes from the key; the per-path Flags
+        // and Maximum Response Time are not part of the key, so 0 is correct
+        // for a withdraw matched on the NLRI key.
+        EvpnPrefix::IgmpJoinSync {
+            esi,
+            eth_tag,
+            src,
+            grp,
+            orig,
+        } => EvpnRoute::IgmpJoinSync(EvpnIgmpJoinSync {
+            id,
+            rd: *rd,
+            esi: *esi,
+            ether_tag: *eth_tag,
+            src: *src,
+            grp: *grp,
+            orig: *orig,
+            flags: 0,
+        }),
+        EvpnPrefix::IgmpLeaveSync {
+            esi,
+            eth_tag,
+            src,
+            grp,
+            orig,
+        } => EvpnRoute::IgmpLeaveSync(EvpnIgmpLeaveSync {
+            id,
+            rd: *rd,
+            esi: *esi,
+            ether_tag: *eth_tag,
+            src: *src,
+            grp: *grp,
+            orig: *orig,
+            max_resp_time: 0,
             flags: 0,
         }),
     }
@@ -6506,6 +6583,9 @@ fn evpn_route_type_of(route: &EvpnRoute) -> crate::policy::EvpnRouteType {
         EvpnRoute::Multicast(_) => EvpnRouteType::Multicast,
         EvpnRoute::Prefix(_) => EvpnRouteType::Prefix,
         EvpnRoute::Smet(_) => EvpnRouteType::Smet,
+        // RFC 9251 Type-7/8 Join/Leave Synch are multicast membership routes;
+        // the closest existing policy discriminator is Multicast.
+        EvpnRoute::IgmpJoinSync(_) | EvpnRoute::IgmpLeaveSync(_) => EvpnRouteType::Multicast,
         // RFC 9572 Per-Region I-PMSI / S-PMSI / Leaf A-D are BUM tunnel A-D
         // routes; the closest existing policy discriminator is Multicast.
         // (They are dropped before policy in the current codec-only phase.)
@@ -6531,6 +6611,9 @@ fn evpn_vni_of(route: &EvpnRoute, attr: &BgpAttr) -> Option<u32> {
         // Type-6 (SMET) carries the EVI Route Target like Type-3; the
         // VNI comes from the RT extended community (RFC 8365 §5.1.2.4).
         EvpnRoute::Smet(_) => extract_vni_from_attr(attr),
+        // RFC 9251 Type-7/8 Synch routes are control-plane only here (no
+        // kernel MDB action); they carry no bridge VNI we act on.
+        EvpnRoute::IgmpJoinSync(_) | EvpnRoute::IgmpLeaveSync(_) => None,
         // RFC 9572 A-D routes carry no bridge VNI in the NLRI (any VNI rides
         // the PMSI Tunnel attribute, consumed in a later phase).
         EvpnRoute::PerRegionImet(_) | EvpnRoute::SPmsi(_) | EvpnRoute::LeafAd(_) => None,
@@ -6680,9 +6763,11 @@ fn route_evpn_export_selected(
                     });
                 }
             }
-            // RFC 9572 A-D routes have no VXLAN dataplane action — withdraw
-            // is a control-plane no-op.
-            EvpnPrefix::PerRegionImet { .. }
+            // RFC 9251 Type-7/8 Synch and RFC 9572 A-D routes have no VXLAN
+            // dataplane action here — withdraw is a control-plane no-op.
+            EvpnPrefix::IgmpJoinSync { .. }
+            | EvpnPrefix::IgmpLeaveSync { .. }
+            | EvpnPrefix::PerRegionImet { .. }
             | EvpnPrefix::SPmsi { .. }
             | EvpnPrefix::LeafAd { .. } => {}
         }
@@ -6815,11 +6900,15 @@ fn route_evpn_export_selected(
                 });
             }
         }
-        // RFC 9572 Per-Region I-PMSI / S-PMSI / Leaf A-D have no VXLAN
-        // dataplane action in the current codec-only phase — install is a
-        // control-plane no-op.
-        EvpnPrefix::PerRegionImet { .. } | EvpnPrefix::SPmsi { .. } | EvpnPrefix::LeafAd { .. } => {
-        }
+        // RFC 9251 Type-7/8 Synch and RFC 9572 Per-Region I-PMSI / S-PMSI /
+        // Leaf A-D have no VXLAN dataplane action in the current control-plane
+        // phase — install is a no-op (the routes are still stored and
+        // re-advertised; only kernel programming is skipped).
+        EvpnPrefix::IgmpJoinSync { .. }
+        | EvpnPrefix::IgmpLeaveSync { .. }
+        | EvpnPrefix::PerRegionImet { .. }
+        | EvpnPrefix::SPmsi { .. }
+        | EvpnPrefix::LeafAd { .. } => {}
     }
 }
 
@@ -7129,6 +7218,8 @@ pub fn route_evpn_update(
         EvpnRoute::Multicast(m) => m.id,
         EvpnRoute::Prefix(p) => p.id,
         EvpnRoute::Smet(s) => s.id,
+        EvpnRoute::IgmpJoinSync(j) => j.id,
+        EvpnRoute::IgmpLeaveSync(l) => l.id,
         EvpnRoute::PerRegionImet(r) => r.id,
         EvpnRoute::SPmsi(r) => r.id,
         EvpnRoute::LeafAd(r) => r.id,
@@ -7203,6 +7294,18 @@ pub fn route_evpn_update(
             exp: 0,
             bos: true,
         });
+    }
+    // RFC 9251 Type-7/8 Synch: the Flags (and the Type-8 Maximum Response
+    // Time) ride off the route key, so capture them onto the BgpRib path so a
+    // reflected route re-emits them faithfully. The ESI is part of the key,
+    // so it travels in the `EvpnPrefix` rather than here.
+    match route {
+        EvpnRoute::IgmpJoinSync(j) => rib.smet_flags = j.flags,
+        EvpnRoute::IgmpLeaveSync(l) => {
+            rib.smet_flags = l.flags;
+            rib.igmp_max_resp_time = l.max_resp_time;
+        }
+        _ => {}
     }
 
     // Apply input policy *after* the route is registered in
@@ -7304,6 +7407,8 @@ pub fn route_evpn_withdraw(ident: usize, route: &EvpnRoute, bgp: &mut BgpTop, pe
         EvpnRoute::Multicast(m) => m.id,
         EvpnRoute::Prefix(p) => p.id,
         EvpnRoute::Smet(s) => s.id,
+        EvpnRoute::IgmpJoinSync(j) => j.id,
+        EvpnRoute::IgmpLeaveSync(l) => l.id,
         EvpnRoute::PerRegionImet(r) => r.id,
         EvpnRoute::SPmsi(r) => r.id,
         EvpnRoute::LeafAd(r) => r.id,
@@ -9768,6 +9873,41 @@ fn build_evpn_route(
             // Flags ride on the path; preserve them from the stored row
             // (a peer-down withdraw is key-matched, but keeping the real
             // flags is harmless and consistent with the advertise path).
+            flags: rib.smet_flags,
+        })),
+        // RFC 9251 Type-7/8 Synch: ESI is in the key; flags / Max Response
+        // Time ride on the stored path, preserved for a faithful withdraw.
+        EvpnPrefix::IgmpJoinSync {
+            esi,
+            eth_tag,
+            src,
+            grp,
+            orig,
+        } => Some(EvpnRoute::IgmpJoinSync(EvpnIgmpJoinSync {
+            id: rib.remote_id,
+            rd: *rd,
+            esi: *esi,
+            ether_tag: *eth_tag,
+            src: *src,
+            grp: *grp,
+            orig: *orig,
+            flags: rib.smet_flags,
+        })),
+        EvpnPrefix::IgmpLeaveSync {
+            esi,
+            eth_tag,
+            src,
+            grp,
+            orig,
+        } => Some(EvpnRoute::IgmpLeaveSync(EvpnIgmpLeaveSync {
+            id: rib.remote_id,
+            rd: *rd,
+            esi: *esi,
+            ether_tag: *eth_tag,
+            src: *src,
+            grp: *grp,
+            orig: *orig,
+            max_resp_time: rib.igmp_max_resp_time,
             flags: rib.smet_flags,
         })),
         // RFC 9572 A-D routes are not stored in the Loc-RIB in the current
@@ -14164,6 +14304,214 @@ impl Bgp {
         route_withdraw_evpn_to_peers(rd, prefix, &mut self.peers);
     }
 
+    /// Originate a Type-7 IGMP/MLD Join Synch route (RFC 9251 §9.2) for a
+    /// membership snooped on the multihomed Ethernet Segment `esi`. Mirrors
+    /// `evpn_originate_smet`, but the route is scoped to the ES: it carries an
+    /// **ES-Import RT** (controls distribution to the PEs on that ES) plus a
+    /// single **EVI-RT EC** (identifies the EVI), and the NLRI key embeds the
+    /// ESI. The Flags octet rides on the path (`BgpRib::smet_flags`).
+    ///
+    /// Control-plane stub: this builds and advertises the route with the
+    /// mandated RTs attached so a route reflector relays it; DF election and
+    /// the kernel-MDB synch state machine are follow-ups, so nothing calls
+    /// this from an ES-snoop trigger yet — hence `allow(dead_code)` on the
+    /// Type-7/8 origination API below.
+    #[allow(dead_code)]
+    pub fn evpn_originate_igmp_join_sync(
+        &mut self,
+        vni: u32,
+        esi: [u8; 10],
+        vtep_local: IpAddr,
+        group: IpAddr,
+        source: Option<IpAddr>,
+        flags: u8,
+    ) {
+        if !self.igmp_mld_proxy || self.router_id.is_unspecified() {
+            return;
+        }
+        if !smet_advertisable_group(group) {
+            return;
+        }
+        let Some(rd) = rd_from_router_id_vni(self.router_id, vni) else {
+            return;
+        };
+        let prefix = EvpnPrefix::IgmpJoinSync {
+            esi,
+            eth_tag: 0,
+            src: source,
+            grp: group,
+            orig: vtep_local,
+        };
+        let mut rib = self.igmp_sync_rib(vni, esi, vtep_local);
+        rib.smet_flags = flags;
+        self.evpn_originate_synch(rd, prefix, rib);
+    }
+
+    /// Inverse of `evpn_originate_igmp_join_sync`. Not gated on
+    /// `igmp_mld_proxy` so a leave (or the feature being disabled) always
+    /// clears the originated route.
+    #[allow(dead_code)]
+    pub fn evpn_withdraw_igmp_join_sync(
+        &mut self,
+        vni: u32,
+        esi: [u8; 10],
+        vtep_local: IpAddr,
+        group: IpAddr,
+        source: Option<IpAddr>,
+    ) {
+        if !smet_advertisable_group(group) {
+            return;
+        }
+        let Some(rd) = rd_from_router_id_vni(self.router_id, vni) else {
+            return;
+        };
+        let prefix = EvpnPrefix::IgmpJoinSync {
+            esi,
+            eth_tag: 0,
+            src: source,
+            grp: group,
+            orig: vtep_local,
+        };
+        let _ = self.local_rib.remove_evpn(rd, &prefix, 0, ORIGINATED_PEER);
+        let _ = self.local_rib.select_best_path_evpn(&rd, &prefix);
+        route_withdraw_evpn_to_peers(rd, prefix, &mut self.peers);
+    }
+
+    /// Originate a Type-8 IGMP/MLD Leave Synch route (RFC 9251 §9.3). As the
+    /// Join Synch route, plus the per-path Maximum Response Time used to drive
+    /// the last-member-query synchronisation on the peer PE(s).
+    #[allow(dead_code)]
+    pub fn evpn_originate_igmp_leave_sync(
+        &mut self,
+        vni: u32,
+        esi: [u8; 10],
+        vtep_local: IpAddr,
+        group: IpAddr,
+        source: Option<IpAddr>,
+        max_resp_time: u8,
+        flags: u8,
+    ) {
+        if !self.igmp_mld_proxy || self.router_id.is_unspecified() {
+            return;
+        }
+        if !smet_advertisable_group(group) {
+            return;
+        }
+        let Some(rd) = rd_from_router_id_vni(self.router_id, vni) else {
+            return;
+        };
+        let prefix = EvpnPrefix::IgmpLeaveSync {
+            esi,
+            eth_tag: 0,
+            src: source,
+            grp: group,
+            orig: vtep_local,
+        };
+        let mut rib = self.igmp_sync_rib(vni, esi, vtep_local);
+        rib.smet_flags = flags;
+        rib.igmp_max_resp_time = max_resp_time;
+        self.evpn_originate_synch(rd, prefix, rib);
+    }
+
+    /// Inverse of `evpn_originate_igmp_leave_sync`.
+    #[allow(dead_code)]
+    pub fn evpn_withdraw_igmp_leave_sync(
+        &mut self,
+        vni: u32,
+        esi: [u8; 10],
+        vtep_local: IpAddr,
+        group: IpAddr,
+        source: Option<IpAddr>,
+    ) {
+        if !smet_advertisable_group(group) {
+            return;
+        }
+        let Some(rd) = rd_from_router_id_vni(self.router_id, vni) else {
+            return;
+        };
+        let prefix = EvpnPrefix::IgmpLeaveSync {
+            esi,
+            eth_tag: 0,
+            src: source,
+            grp: group,
+            orig: vtep_local,
+        };
+        let _ = self.local_rib.remove_evpn(rd, &prefix, 0, ORIGINATED_PEER);
+        let _ = self.local_rib.select_best_path_evpn(&rd, &prefix);
+        route_withdraw_evpn_to_peers(rd, prefix, &mut self.peers);
+    }
+
+    /// Build the originated `BgpRib` shared by the Type-7/8 Synch helpers:
+    /// next hop = local VTEP, extended communities = the ES-Import RT (derived
+    /// from `esi`, scopes distribution to the ES) plus the EVI-RT EC (carries
+    /// the EVI's RT). Caller stamps `smet_flags` / `igmp_max_resp_time`.
+    #[allow(dead_code)]
+    fn igmp_sync_rib(&self, vni: u32, esi: [u8; 10], vtep_local: IpAddr) -> BgpRib {
+        let mut attr = BgpAttr::new();
+        // RFC 9251 §9.5: the EVI-RT EC carries the EVI's Route Target. A
+        // 2-octet-AS RT always converts; the fallback keeps a usable RT.
+        let evi_rt = evpn_route_target(self.asn, vni);
+        let evi_rt_ec = ExtCommunityValue::evi_rt_from_rt(&evi_rt).unwrap_or(evi_rt);
+        attr.ecom = Some(ExtCommunity::from([
+            ExtCommunityValue::es_import_rt(&esi),
+            evi_rt_ec,
+        ]));
+        attr.nexthop = Some(BgpNexthop::Evpn(vtep_local));
+        let mut rib = BgpRib::new(
+            ORIGINATED_PEER,
+            Ipv4Addr::UNSPECIFIED,
+            BgpRibType::Originated,
+            0,
+            32768,
+            &attr,
+            None,
+            None,
+            false,
+        );
+        rib.esi = Some(esi);
+        rib
+    }
+
+    /// Shared tail of the Type-7/8 Synch originators: insert into the Loc-RIB,
+    /// run best-path, and fan the selected route out to peers (route reflection
+    /// included). Mirrors the advertise tail of `evpn_originate_smet`.
+    #[allow(dead_code)]
+    fn evpn_originate_synch(
+        &mut self,
+        rd: RouteDistinguisher,
+        prefix: EvpnPrefix,
+        mut rib: BgpRib,
+    ) {
+        let (_replaced, selected, next_id) =
+            self.local_rib.update_evpn(rd, prefix.clone(), rib.clone());
+        rib.local_id = next_id;
+
+        let mut bgp_ref = BgpTop {
+            router_id: &self.router_id,
+            srv6_ipv6_export: self.srv6_ipv6_export.as_ref(),
+            local_rib: &mut self.local_rib,
+            shard: &mut self.shard,
+            tx: &self.tx,
+            rib_client: &self.ctx.rib,
+            attr_store: &mut self.attr_store,
+            update_groups: &mut self.update_groups,
+            interface_addrs: &self.interface_addrs,
+            vrf_export: None,
+            color_policy: Some(&self.color_policy),
+            flex_algo_routes: Some(&self.flex_algo_routes),
+            flex_algo_srv6_routes: Some(&self.flex_algo_srv6_routes),
+            vrf_import: None,
+            nexthop_cache: None,
+            vrf_transport_v4: None,
+            vrf_transport_v6: None,
+            central_label_alloc: None,
+        };
+
+        if !selected.is_empty() {
+            route_advertise_evpn_to_peers(rd, prefix, &selected, &mut bgp_ref, &mut self.peers);
+        }
+    }
+
     /// RFC 9572 §3.2: originate a Type-10 S-PMSI A-D route for a locally-snooped
     /// `(S,G)` / `(*,G)`, declaring a *selective* provider tunnel for that flow
     /// — the per-(S,G) analog of the inclusive Type-3 IMET. Unlike the Type-6
@@ -14461,6 +14809,8 @@ fn evpn_leaf_ad_route_key(route: &EvpnRoute) -> Vec<u8> {
         EvpnRoute::Multicast(m) => EvpnRoute::Multicast(EvpnMulticast { id: 0, ..m }),
         EvpnRoute::Prefix(p) => EvpnRoute::Prefix(EvpnIpPrefix { id: 0, ..p }),
         EvpnRoute::Smet(s) => EvpnRoute::Smet(EvpnSmet { id: 0, ..s }),
+        EvpnRoute::IgmpJoinSync(j) => EvpnRoute::IgmpJoinSync(EvpnIgmpJoinSync { id: 0, ..j }),
+        EvpnRoute::IgmpLeaveSync(l) => EvpnRoute::IgmpLeaveSync(EvpnIgmpLeaveSync { id: 0, ..l }),
         EvpnRoute::PerRegionImet(r) => EvpnRoute::PerRegionImet(EvpnPerRegionImet { id: 0, ..r }),
         EvpnRoute::SPmsi(r) => EvpnRoute::SPmsi(EvpnSPmsi { id: 0, ..r }),
         EvpnRoute::LeafAd(r) => EvpnRoute::LeafAd(EvpnLeafAd { id: 0, ..r }),

--- a/zebra-rs/src/bgp/show.rs
+++ b/zebra-rs/src/bgp/show.rs
@@ -1089,6 +1089,14 @@ fn show_adj_rib_routes_evpn<D: RibDirection>(
         buf,
         "EVPN type-6 prefix: [6]:[EthTag]:[SrcLen]:[Src]:[GrpLen]:[Grp]:[OrigLen]:[Orig]"
     )?;
+    writeln!(
+        buf,
+        "EVPN type-7 prefix: [7]:[ESI]:[EthTag]:[SrcLen]:[Src]:[GrpLen]:[Grp]:[OrigLen]:[Orig]"
+    )?;
+    writeln!(
+        buf,
+        "EVPN type-8 prefix: [8]:[ESI]:[EthTag]:[SrcLen]:[Src]:[GrpLen]:[Grp]:[OrigLen]:[Orig]"
+    )?;
     writeln!(buf, "EVPN type-9 prefix: [9]:[EthTag]:[RegionID]")?;
     writeln!(buf, "EVPN type-10 prefix: [10]:[EthTag]:[Src]:[Grp]:[Orig]")?;
     writeln!(buf, "EVPN type-11 prefix: [11]:[RouteKey]:[Orig]")?;
@@ -3359,6 +3367,8 @@ fn evpn_route_type_filter(token: String) -> Option<u8> {
         "multicast" => Some(3),
         "prefix" => Some(5),
         "smet" => Some(6),
+        "igmp-join-sync" => Some(7),
+        "igmp-leave-sync" => Some(8),
         "per-region-imet" => Some(9),
         "s-pmsi" => Some(10),
         "leaf" => Some(11),
@@ -3400,6 +3410,14 @@ fn show_bgp_evpn(
     writeln!(
         buf,
         "EVPN type-6 prefix: [6]:[EthTag]:[SrcLen]:[Src]:[GrpLen]:[Grp]:[OrigLen]:[Orig]"
+    )?;
+    writeln!(
+        buf,
+        "EVPN type-7 prefix: [7]:[ESI]:[EthTag]:[SrcLen]:[Src]:[GrpLen]:[Grp]:[OrigLen]:[Orig]"
+    )?;
+    writeln!(
+        buf,
+        "EVPN type-8 prefix: [8]:[ESI]:[EthTag]:[SrcLen]:[Src]:[GrpLen]:[Grp]:[OrigLen]:[Orig]"
     )?;
     writeln!(buf, "EVPN type-9 prefix: [9]:[EthTag]:[RegionID]")?;
     writeln!(buf, "EVPN type-10 prefix: [10]:[EthTag]:[Src]:[Grp]:[Orig]")?;

--- a/zebra-rs/src/bgp/vrf/inst.rs
+++ b/zebra-rs/src/bgp/vrf/inst.rs
@@ -666,6 +666,7 @@ impl BgpVrf {
             esi: None,
             vrf_transit_only: false,
             smet_flags: 0,
+            igmp_max_resp_time: 0,
             ingress_region: None,
         };
 
@@ -890,6 +891,7 @@ impl BgpVrf {
             esi: None,
             vrf_transit_only: false,
             smet_flags: 0,
+            igmp_max_resp_time: 0,
             ingress_region: None,
         };
 
@@ -1145,6 +1147,7 @@ impl BgpVrf {
             esi: None,
             vrf_transit_only: false,
             smet_flags: 0,
+            igmp_max_resp_time: 0,
             ingress_region: None,
         }
     }

--- a/zebra-rs/src/script/marshal.rs
+++ b/zebra-rs/src/script/marshal.rs
@@ -64,6 +64,24 @@ pub fn evpn_prefix_table(lua: &Lua, route: &EvpnRoute) -> mlua::Result<Table> {
             evpn.set("rd", s.rd.to_string())?;
             "[6]".to_string()
         }
+        EvpnRoute::IgmpJoinSync(j) => {
+            evpn.set("route_type", 7)?;
+            evpn.set("rd", j.rd.to_string())?;
+            evpn.set("group", j.grp.to_string())?;
+            if let Some(src) = j.src {
+                evpn.set("source", src.to_string())?;
+            }
+            "[7]".to_string()
+        }
+        EvpnRoute::IgmpLeaveSync(l) => {
+            evpn.set("route_type", 8)?;
+            evpn.set("rd", l.rd.to_string())?;
+            evpn.set("group", l.grp.to_string())?;
+            if let Some(src) = l.src {
+                evpn.set("source", src.to_string())?;
+            }
+            "[8]".to_string()
+        }
         EvpnRoute::PerRegionImet(r) => {
             evpn.set("route_type", 9)?;
             evpn.set("rd", r.rd.to_string())?;

--- a/zebra-rs/yang/exec.yang
+++ b/zebra-rs/yang/exec.yang
@@ -343,13 +343,16 @@ module exec {
         }
         leaf route-type {
           ext:help "Filter the EVPN RIB by route type";
-          // macip=2, multicast=3, prefix=5 (RFC 7432/9136); smet=6
-          // (RFC 9251); per-region-imet=9, s-pmsi=10, leaf=11 (RFC 9572).
+          // macip=2, multicast=3, prefix=5 (RFC 7432/9136); smet=6,
+          // igmp-join-sync=7, igmp-leave-sync=8 (RFC 9251);
+          // per-region-imet=9, s-pmsi=10, leaf=11 (RFC 9572).
           type enumeration {
             enum macip;
             enum multicast;
             enum prefix;
             enum smet;
+            enum igmp-join-sync;
+            enum igmp-leave-sync;
             enum per-region-imet;
             enum s-pmsi;
             enum leaf;


### PR DESCRIPTION
## Summary

Adds EVPN Route Types **7 (IGMP/MLD Join Synch)** and **8 (IGMP/MLD Leave Synch)** per RFC 9251 as a **wire codec + control-plane stub**. zebra-rs can now parse, store, best-path-select, **re-advertise/route-reflect**, and display Type 7/8, with the mandated **ES-Import RT** and **EVI-RT** extended communities. Mirrors how Types 9/10/11 were added (codec-first, RIB-generic, no data plane).

### bgp-packet codec (`nlri_evpn.rs`)
- `EvpnRouteType` 7/8; `EvpnIgmpJoinSync` / `EvpnIgmpLeaveSync` structs; `EvpnRoute` + `EvpnPrefix` variants (ESI in the route key, ordered between Type 6 and Type 9 to keep numeric `Ord`); `route_type()`, `from_route()`, `Display` + `esi_display()`; parse/emit (Type 8 handles the `Reserved(4)` + `MaxRespTime(1)` + `Flags(1)` tail). Covered the EVPN matches in `mp_reach.rs` / `mp_unreach.rs`.

### Extended communities (`ext_com.rs`)
- **ES-Import RT** (`0x06`/`0x02`, auto-derived from the ESI) and **EVI-RT EC** (`0x06`/`0x0A`–`0x0C` via `evi_rt_from_rt`) with predicates, accessors, and `Display`. IPv6 EVI-RT (`0x0D`, 20-octet) is out of scope — `ExtCommunityValue` is fixed 8-octet.

### Control-plane stub (`route.rs`, `inst.rs`, `vrf/inst.rs`, `script/marshal.rs`)
- New `BgpRib.igmp_max_resp_time` field; received Type 7/8 Flags / Max Response Time are stamped on the path so reflected routes stay faithful. All exhaustive `EvpnRoute`/`EvpnPrefix` matches updated; export is a **kernel no-op**. Origination helpers `evpn_originate_igmp_join_sync` / `_leave_sync` (+ withdraws) attach the ES-Import RT + EVI-RT EC; `#[allow(dead_code)]` until an ES-snoop trigger calls them.

### CLI
- `show bgp evpn igmp-join-sync` / `igmp-leave-sync` filters + legends + `exec.yang` enums. Design docs updated.

## Deferred (multihoming data plane)
DF election; Ethernet-Segment Type 1/4; synch state machine + timers; kernel MDB synch; EVPN import-RT filtering (RTs are carried but not yet consulted on import); the organic ES-snoop origination trigger; live BDD validation. See `docs/design/bgp-evpn-igmp-mld-proxy-followups.md` §6.

## Test plan
- `cargo fmt --check`: clean
- `cargo build` (bgp-packet + zebra-rs): clean, no warnings
- `cargo test -p bgp-packet`: 357 pass (incl. 12 new codec/EC tests)
- `cargo test -p zebra-rs`: 1454 pass (incl. yang_load_tests)
- `cargo clippy --workspace --all-targets -- -D warnings`: clean

Generated with [Claude Code](https://claude.com/claude-code)