### PR TITLE
bgp-evpn: debug command to originate RFC 9251 Type 7/8 + BDD

### DIFF
--- a/bdd/tests/configs/bgp_evpn_igmp_sync/z1-1.yaml
+++ b/bdd/tests/configs/bgp_evpn_igmp_sync/z1-1.yaml
@@ -1,0 +1,21 @@
+# z1 — EVPN IGMP/MLD proxy (RFC 9251). Acts as the receiver/route
+# reflector for the Type-7/8 Join/Leave Synch routes z2 originates via the
+# `clear bgp debug igmp-*-sync-*` test command. Control-plane only — no
+# VXLAN dataplane is needed for the synch routes in this phase.
+router:
+  bgp:
+    global:
+      as: 65001
+      router-id: 192.168.0.1
+    afi-safi:
+    - name: evpn
+      igmp-mld-proxy: true
+    neighbor:
+    - remote-address: 192.168.0.2
+      enabled: true
+      remote-as: 65001
+      afi-safi:
+      - name: ipv4
+        enabled: true
+      - name: evpn
+        enabled: true

--- a/bdd/tests/configs/bgp_evpn_igmp_sync/z2-1.yaml
+++ b/bdd/tests/configs/bgp_evpn_igmp_sync/z2-1.yaml
@@ -1,0 +1,22 @@
+# z2 — EVPN IGMP/MLD proxy (RFC 9251). Originates the Type-7 (Join Synch)
+# and Type-8 (Leave Synch) routes via the `clear bgp debug igmp-*-sync-*`
+# test command. `igmp-mld-proxy: true` is the gate the origination helpers
+# require; router-id 192.168.0.2 is the VTEP stamped as the route's
+# Originator address.
+router:
+  bgp:
+    global:
+      as: 65001
+      router-id: 192.168.0.2
+    afi-safi:
+    - name: evpn
+      igmp-mld-proxy: true
+    neighbor:
+    - remote-address: 192.168.0.1
+      enabled: true
+      remote-as: 65001
+      afi-safi:
+      - name: ipv4
+        enabled: true
+      - name: evpn
+        enabled: true

--- a/bdd/tests/features/bgp_evpn_igmp_sync.feature
+++ b/bdd/tests/features/bgp_evpn_igmp_sync.feature
@@ -1,0 +1,82 @@
+@serial
+@bgp_evpn_igmp_sync
+Feature: BGP EVPN IGMP/MLD Join/Leave Synch routes (RFC 9251 Type 7/8)
+  As a network operator
+  I want zebra-rs to originate, store, and route-reflect the RFC 9251
+  multihoming synch routes — Type 7 (IGMP/MLD Join Synch) and Type 8
+  (IGMP/MLD Leave Synch) — carrying their ES-Import RT and EVI-RT
+  extended communities, so the control-plane foundation for all-active
+  multihoming is exercised end to end. (DF election and the kernel-MDB
+  synch dataplane are still deferred — there is no organic ES-snoop
+  trigger yet, so origination is driven by the `clear bgp debug
+  igmp-*-sync-*` test command.)
+
+  Test Topology — two iBGP (AS 65001) EVPN speakers on a shared transport
+  bridge br0:
+  ```
+  ┌─────────────────────────────────┐
+  │               br0               │
+  └───────┬─────────────────┬───────┘
+          │                 │
+     ┌────┴────┐       ┌────┴────┐
+     │   z1    │       │   z2    │
+     │ .0.1/24 │       │ .0.2/24 │   <- originates Type-7/8 via debug cmd
+     └─────────┘       └─────────┘
+  ```
+
+  z2 originates a Type-7/8 synch route via
+  `clear bgp debug igmp-{join,leave}-sync-{originate,withdraw} <spec>`
+  (spec = `vni,esi,group[,source]`); z1 imports it into its EVPN RIB and
+  renders it under `show bgp evpn`, with the ES-Import RT and EVI-RT
+  extended communities preserved.
+
+  Scenario: Setup topology and EVPN iBGP
+    Given a clean test environment
+    When I create bridge "br0"
+    And I create namespace "z1" with IP "192.168.0.1/24" on bridge "br0"
+    And I create namespace "z2" with IP "192.168.0.2/24" on bridge "br0"
+    And I start zebra-rs in namespace "z1"
+    And I start zebra-rs in namespace "z2"
+    And I apply config "z1-1.yaml" to namespace "z1"
+    And I apply config "z2-1.yaml" to namespace "z2"
+    And I wait 10 seconds for BGP to operate
+    Then BGP session in "z1" to "192.168.0.2" should be "Established"
+
+  Scenario: z2 originates a (*,G) Type-7 Join Synch route that z1 imports
+    Given the test topology exists
+    When I run "clear bgp debug igmp-join-sync-originate 10,00:01:02:03:04:05:06:07:08:09,239.1.1.1" in namespace "z2"
+    # The (*,G) Join Synch NLRI: ESI in the key, source wildcard, group +
+    # z2's VTEP (192.168.0.2) as the Originator.
+    Then show command "show bgp evpn" in namespace "z1" should eventually contain "[7]:[00:01:02:03:04:05:06:07:08:09]:[0]:[0]:[*]:[32]:[239.1.1.1]:[32]:[192.168.0.2]"
+    # RFC 9251 §9.5 mandates an ES-Import RT (auto-derived from the ESI's
+    # high-order 6 octets) and exactly one EVI-RT EC (carrying the EVI RT).
+    And show command "show bgp evpn" in namespace "z1" should eventually contain "es-import:01:02:03:04:05:06"
+    And show command "show bgp evpn" in namespace "z1" should eventually contain "evi-rt:rt:65001:10"
+    # The route-type filter (RFC 9251 Type 7) selects only the Join Synch route.
+    And show command "show bgp evpn route-type igmp-join-sync" in namespace "z1" should eventually contain "[7]:[00:01:02:03:04:05:06:07:08:09]"
+
+  Scenario: Withdrawing the Type-7 route removes it from z1
+    Given the test topology exists
+    When I run "clear bgp debug igmp-join-sync-withdraw 10,00:01:02:03:04:05:06:07:08:09,239.1.1.1" in namespace "z2"
+    Then show command "show bgp evpn" in namespace "z1" should eventually not contain "[7]:[00:01:02:03:04:05:06:07:08:09]"
+
+  Scenario: z2 originates a source-specific (S,G) Type-8 Leave Synch route
+    Given the test topology exists
+    # (S,G) Leave Synch: source 192.0.2.9 present in the key, group 232.1.1.1.
+    When I run "clear bgp debug igmp-leave-sync-originate 10,00:01:02:03:04:05:06:07:08:09,232.1.1.1,192.0.2.9" in namespace "z2"
+    Then show command "show bgp evpn" in namespace "z1" should eventually contain "[8]:[00:01:02:03:04:05:06:07:08:09]:[0]:[32]:[192.0.2.9]:[32]:[232.1.1.1]:[32]:[192.168.0.2]"
+    And show command "show bgp evpn route-type igmp-leave-sync" in namespace "z1" should eventually contain "[8]:[00:01:02:03:04:05:06:07:08:09]"
+
+  Scenario: Withdrawing the Type-8 route removes it from z1
+    Given the test topology exists
+    When I run "clear bgp debug igmp-leave-sync-withdraw 10,00:01:02:03:04:05:06:07:08:09,232.1.1.1,192.0.2.9" in namespace "z2"
+    Then show command "show bgp evpn" in namespace "z1" should eventually not contain "[8]:[00:01:02:03:04:05:06:07:08:09]"
+
+  Scenario: Teardown topology
+    Given the test topology exists
+    When I stop zebra-rs in namespace "z1"
+    And I stop zebra-rs in namespace "z2"
+    And I delete namespace "z1"
+    And I delete namespace "z2"
+    And I delete bridge "br0"
+    Then the test environment should be clean

--- a/zebra-rs/src/bgp/inst.rs
+++ b/zebra-rs/src/bgp/inst.rs
@@ -2397,6 +2397,11 @@ impl Bgp {
                 let (path, mut args) = path_from_command(&msg.paths);
                 if let Some((afi_safi, op)) = parse_clear_bgp_path(&path) {
                     let _ = peer::clear_bgp_action(self, &mut args, afi_safi, op);
+                } else if let Some(action) = path.strip_prefix("/clear/bgp/debug/")
+                    && let Some(spec) = args.string()
+                {
+                    // RFC 9251 Type-7/8 debug origination (zebra-bgp-clear.yang).
+                    self.debug_igmp_sync_action(action, &spec);
                 }
             }
         }

--- a/zebra-rs/src/bgp/route.rs
+++ b/zebra-rs/src/bgp/route.rs
@@ -14312,11 +14312,10 @@ impl Bgp {
     /// ESI. The Flags octet rides on the path (`BgpRib::smet_flags`).
     ///
     /// Control-plane stub: this builds and advertises the route with the
-    /// mandated RTs attached so a route reflector relays it; DF election and
-    /// the kernel-MDB synch state machine are follow-ups, so nothing calls
-    /// this from an ES-snoop trigger yet — hence `allow(dead_code)` on the
-    /// Type-7/8 origination API below.
-    #[allow(dead_code)]
+    /// mandated RTs attached so a route reflector relays it. DF election and
+    /// the kernel-MDB synch state machine are follow-ups, so the only caller
+    /// today is the `clear bgp debug igmp-join-sync-*` test command
+    /// (`debug_igmp_sync_action`), not an organic ES-snoop trigger.
     pub fn evpn_originate_igmp_join_sync(
         &mut self,
         vni: u32,
@@ -14350,7 +14349,6 @@ impl Bgp {
     /// Inverse of `evpn_originate_igmp_join_sync`. Not gated on
     /// `igmp_mld_proxy` so a leave (or the feature being disabled) always
     /// clears the originated route.
-    #[allow(dead_code)]
     pub fn evpn_withdraw_igmp_join_sync(
         &mut self,
         vni: u32,
@@ -14380,7 +14378,6 @@ impl Bgp {
     /// Originate a Type-8 IGMP/MLD Leave Synch route (RFC 9251 §9.3). As the
     /// Join Synch route, plus the per-path Maximum Response Time used to drive
     /// the last-member-query synchronisation on the peer PE(s).
-    #[allow(dead_code)]
     pub fn evpn_originate_igmp_leave_sync(
         &mut self,
         vni: u32,
@@ -14414,7 +14411,6 @@ impl Bgp {
     }
 
     /// Inverse of `evpn_originate_igmp_leave_sync`.
-    #[allow(dead_code)]
     pub fn evpn_withdraw_igmp_leave_sync(
         &mut self,
         vni: u32,
@@ -14445,7 +14441,6 @@ impl Bgp {
     /// next hop = local VTEP, extended communities = the ES-Import RT (derived
     /// from `esi`, scopes distribution to the ES) plus the EVI-RT EC (carries
     /// the EVI's RT). Caller stamps `smet_flags` / `igmp_max_resp_time`.
-    #[allow(dead_code)]
     fn igmp_sync_rib(&self, vni: u32, esi: [u8; 10], vtep_local: IpAddr) -> BgpRib {
         let mut attr = BgpAttr::new();
         // RFC 9251 §9.5: the EVI-RT EC carries the EVI's Route Target. A
@@ -14475,7 +14470,6 @@ impl Bgp {
     /// Shared tail of the Type-7/8 Synch originators: insert into the Loc-RIB,
     /// run best-path, and fan the selected route out to peers (route reflection
     /// included). Mirrors the advertise tail of `evpn_originate_smet`.
-    #[allow(dead_code)]
     fn evpn_originate_synch(
         &mut self,
         rd: RouteDistinguisher,
@@ -14509,6 +14503,44 @@ impl Bgp {
 
         if !selected.is_empty() {
             route_advertise_evpn_to_peers(rd, prefix, &selected, &mut bgp_ref, &mut self.peers);
+        }
+    }
+
+    /// Debug / test-injection entry point for the EVPN Type-7/8 Synch routes
+    /// (`clear bgp debug igmp-{join,leave}-sync-{originate,withdraw} <spec>`,
+    /// zebra-bgp-clear.yang). `action` is the path tail after
+    /// `/clear/bgp/debug/`; `spec` is `vni,esi,group[,source]`. The VTEP is
+    /// this node's router-id, the Flags are derived from the group family
+    /// (IGMPv3 / MLDv2 + IE), and the Type-8 Maximum Response Time uses a
+    /// fixed debug default. This exists so a route reflector can be exercised
+    /// end-to-end without the deferred ES/DF dataplane.
+    pub fn debug_igmp_sync_action(&mut self, action: &str, spec: &str) {
+        let Some((vni, esi, group, source)) = parse_igmp_sync_spec(spec) else {
+            eprintln!("[debug] igmp-sync: bad spec '{spec}' — want vni,esi,group[,source]");
+            return;
+        };
+        let vtep = IpAddr::V4(self.router_id);
+        let flags = smet_flags(group, source);
+        match action {
+            "igmp-join-sync-originate" => {
+                self.evpn_originate_igmp_join_sync(vni, esi, vtep, group, source, flags)
+            }
+            "igmp-join-sync-withdraw" => {
+                self.evpn_withdraw_igmp_join_sync(vni, esi, vtep, group, source)
+            }
+            "igmp-leave-sync-originate" => self.evpn_originate_igmp_leave_sync(
+                vni,
+                esi,
+                vtep,
+                group,
+                source,
+                IGMP_DEBUG_MAX_RESP_TIME,
+                flags,
+            ),
+            "igmp-leave-sync-withdraw" => {
+                self.evpn_withdraw_igmp_leave_sync(vni, esi, vtep, group, source)
+            }
+            other => eprintln!("[debug] igmp-sync: unknown action '{other}'"),
         }
     }
 
@@ -14642,6 +14674,85 @@ impl Bgp {
 /// speaker that installed via netlink). Must be filtered out of
 /// origination to avoid advertise loops.
 const NTF_EXT_LEARNED: u8 = 0x10;
+
+/// Fixed Maximum Response Time stamped on a Type-8 Leave Synch route
+/// originated by the `clear bgp debug igmp-leave-sync-*` test command
+/// (RFC 9251 §9.3; IGMP units, ~10s). The real value would come from the
+/// last-member-query timer, which is part of the deferred synch machinery.
+const IGMP_DEBUG_MAX_RESP_TIME: u8 = 100;
+
+/// Parse the `vni,esi,group[,source]` spec of the `clear bgp debug
+/// igmp-*-sync-*` test commands into the origination-helper arguments.
+/// `esi` is colon-hex (`00:01:…:09`) or 20 plain hex digits; an empty or
+/// absent `source` field yields the `(*,G)` wildcard. Returns `None` on any
+/// malformed field (the caller logs and ignores).
+fn parse_igmp_sync_spec(spec: &str) -> Option<(u32, [u8; 10], IpAddr, Option<IpAddr>)> {
+    let mut parts = spec.split(',');
+    let vni: u32 = parts.next()?.trim().parse().ok()?;
+    let esi = parse_esi(parts.next()?.trim())?;
+    let group: IpAddr = parts.next()?.trim().parse().ok()?;
+    let source = match parts.next().map(str::trim) {
+        Some(s) if !s.is_empty() => Some(s.parse().ok()?),
+        _ => None,
+    };
+    Some((vni, esi, group, source))
+}
+
+/// Decode a 10-octet ESI from colon-hex (`00:01:…:09`) or 20 bare hex
+/// digits. Colons are stripped; any other length or non-hex digit fails.
+fn parse_esi(s: &str) -> Option<[u8; 10]> {
+    let hex: String = s.chars().filter(|c| *c != ':').collect();
+    if hex.len() != 20 {
+        return None;
+    }
+    let mut esi = [0u8; 10];
+    for (i, byte) in esi.iter_mut().enumerate() {
+        *byte = u8::from_str_radix(&hex[i * 2..i * 2 + 2], 16).ok()?;
+    }
+    Some(esi)
+}
+
+#[cfg(test)]
+mod igmp_sync_spec_tests {
+    use super::{parse_esi, parse_igmp_sync_spec};
+    use std::net::{IpAddr, Ipv4Addr};
+
+    #[test]
+    fn esi_colon_hex_and_plain() {
+        let want = [0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09];
+        assert_eq!(parse_esi("00:01:02:03:04:05:06:07:08:09"), Some(want));
+        assert_eq!(parse_esi("00010203040506070809"), Some(want));
+        // Wrong length / non-hex are rejected.
+        assert_eq!(parse_esi("00:01:02"), None);
+        assert_eq!(parse_esi("zz010203040506070809"), None);
+    }
+
+    #[test]
+    fn spec_star_g_and_s_g() {
+        // (*,G): no source field.
+        let (vni, esi, grp, src) =
+            parse_igmp_sync_spec("10,00:01:02:03:04:05:06:07:08:09,239.1.1.1").unwrap();
+        assert_eq!(vni, 10);
+        assert_eq!(esi[1], 0x01);
+        assert_eq!(grp, IpAddr::V4(Ipv4Addr::new(239, 1, 1, 1)));
+        assert_eq!(src, None);
+        // (S,G): trailing source.
+        let (_, _, _, src) =
+            parse_igmp_sync_spec("10,00010203040506070809,232.1.1.1,192.0.2.9").unwrap();
+        assert_eq!(src, Some(IpAddr::V4(Ipv4Addr::new(192, 0, 2, 9))));
+        // Empty trailing source field is the (*,G) wildcard.
+        let (_, _, _, src) = parse_igmp_sync_spec("10,00010203040506070809,239.1.1.1,").unwrap();
+        assert_eq!(src, None);
+    }
+
+    #[test]
+    fn spec_rejects_malformed() {
+        assert!(parse_igmp_sync_spec("notanum,00010203040506070809,239.1.1.1").is_none());
+        assert!(parse_igmp_sync_spec("10,00010203040506070809,notanip").is_none());
+        assert!(parse_igmp_sync_spec("10,badesi,239.1.1.1").is_none());
+        assert!(parse_igmp_sync_spec("10").is_none());
+    }
+}
 
 /// Derive the RFC 9251 §9.1 SMET Flags octet from the group family and
 /// source presence. IPv4 advertises IGMPv3 (v3 bit), IPv6 advertises

--- a/zebra-rs/src/bgp/show.rs
+++ b/zebra-rs/src/bgp/show.rs
@@ -3268,6 +3268,14 @@ fn format_evpn_ecom_value(v: &ExtCommunityValue) -> String {
         // DF Election EC — RFC 8584 §2.2 (RFC 9572 §5.3.1 inter-AS DF
         // election). Reuse the codec's Display: `df-election:alg<N>[+ac-df]`.
         (0x06, 0x06) => v.to_string(),
+        // EVPN ES-Import RT — RFC 7432 §7.6, carried on Type-7/8 IGMP/MLD
+        // Synch routes (RFC 9251). Reuse the codec's Display:
+        // `es-import:<6-octet colon-hex>`.
+        (0x06, 0x02) => v.to_string(),
+        // EVPN EVI-RT EC — RFC 9251 §9.5 (Type 0..3 sub-types 0x0a-0x0d),
+        // carried on the Type-7/8 Synch routes. Reuse the codec's Display:
+        // `evi-rt:<route-target>`.
+        (0x06, 0x0a) | (0x06, 0x0b) | (0x06, 0x0c) | (0x06, 0x0d) => v.to_string(),
         _ => format!(
             "0x{:02x}{:02x}{:02x}{:02x}{:02x}{:02x}{:02x}{:02x}",
             v.high_type, v.low_type, v.val[0], v.val[1], v.val[2], v.val[3], v.val[4], v.val[5]

--- a/zebra-rs/src/config/manager.rs
+++ b/zebra-rs/src/config/manager.rs
@@ -1509,6 +1509,51 @@ mod yang_load_tests {
         }
     }
 
+    /// The RFC 9251 Type-7/8 debug-origination surface
+    /// (`clear bgp debug igmp-{join,leave}-sync-{originate,withdraw} <spec>`,
+    /// zebra-bgp-clear.yang) must parse as a complete exec path against the
+    /// configure tree — the `clear` augment lives there. Guards the
+    /// hand-written grammar (the `debug` container + the single comma-spec
+    /// list key) so a regression is caught in the unit suite, not only the
+    /// `@bgp_evpn_igmp_sync` BDD.
+    #[test]
+    fn bgp_clear_debug_igmp_sync_paths_parse() {
+        use crate::config::ExecCode;
+        use crate::config::parse::{State, parse};
+        use libyang::to_entry;
+
+        let mut yang = YangStore::new();
+        yang.add_path(concat!(env!("CARGO_MANIFEST_DIR"), "/yang"));
+        yang.read_with_resolve("configure")
+            .unwrap_or_else(|e| panic!("configure failed to load: {e:#}"));
+        yang.identity_resolve();
+        let module = yang.find_module("configure").unwrap();
+        let entry = to_entry(&yang, module);
+
+        for (cmd, want_path, want_arg0) in [
+            (
+                "clear bgp debug igmp-join-sync-originate 10,00:01:02:03:04:05:06:07:08:09,239.1.1.1",
+                "/clear/bgp/debug/igmp-join-sync-originate",
+                "10,00:01:02:03:04:05:06:07:08:09,239.1.1.1",
+            ),
+            (
+                "clear bgp debug igmp-leave-sync-originate 10,00:01:02:03:04:05:06:07:08:09,232.1.1.1,192.0.2.9",
+                "/clear/bgp/debug/igmp-leave-sync-originate",
+                "10,00:01:02:03:04:05:06:07:08:09,232.1.1.1,192.0.2.9",
+            ),
+        ] {
+            let (code, _comps, state) = parse(cmd, entry.clone(), None, State::new());
+            assert_eq!(code, ExecCode::Success, "should parse: {cmd}");
+            let (path, mut args) = crate::config::path_from_command(&state.paths);
+            assert_eq!(path, want_path, "path for: {cmd}");
+            assert_eq!(
+                args.string().as_deref(),
+                Some(want_arg0),
+                "spec arg for: {cmd}"
+            );
+        }
+    }
+
     /// `router isis afi-safi <ipv4|ipv6>` is dead config unless it carries
     /// a `network` or `redistribute` child — IS-IS does per-AFI enable
     /// per-interface, the list only holds those. The list is tagged

--- a/zebra-rs/yang/zebra-bgp-clear.yang
+++ b/zebra-rs/yang/zebra-bgp-clear.yang
@@ -157,6 +157,56 @@ module zebra-bgp-clear {
         ext:default-child "neighbor";
         uses bgp-clear-neighbor-actions;
       }
+      // Debug / test-injection surface for the RFC 9251 EVPN Type-7
+      // (IGMP/MLD Join Synch) and Type-8 (Leave Synch) routes. Each action
+      // takes one comma-separated spec token `vni,esi,group[,source]`:
+      //   - vni    L2VPN VNI (selects RD <router-id>:VNI and the EVI RT)
+      //   - esi    10-octet ESI, colon-hex (00:01:..:09) or 20 hex digits
+      //   - group  multicast group address
+      //   - source multicast source for (S,G); omit for (*,G)
+      // It drives `evpn_originate_igmp_*_sync` directly so a route reflector
+      // can be exercised end-to-end (BDD) without the ES/DF dataplane, which
+      // is still deferred. Flags are derived from the group family
+      // (IGMPv3 / MLDv2) and the Type-8 Maximum Response Time defaults.
+      container debug {
+        ext:help "BGP debug / test-injection actions";
+        list igmp-join-sync-originate {
+          ext:presence "Originate an EVPN Type-7 IGMP/MLD Join Synch route";
+          ext:help "Originate a Type-7 Join Synch route (RFC 9251, debug)";
+          key spec;
+          leaf spec {
+            ext:help "vni,esi,group[,source]";
+            type string;
+          }
+        }
+        list igmp-join-sync-withdraw {
+          ext:presence "Withdraw an EVPN Type-7 IGMP/MLD Join Synch route";
+          ext:help "Withdraw a Type-7 Join Synch route (RFC 9251, debug)";
+          key spec;
+          leaf spec {
+            ext:help "vni,esi,group[,source]";
+            type string;
+          }
+        }
+        list igmp-leave-sync-originate {
+          ext:presence "Originate an EVPN Type-8 IGMP/MLD Leave Synch route";
+          ext:help "Originate a Type-8 Leave Synch route (RFC 9251, debug)";
+          key spec;
+          leaf spec {
+            ext:help "vni,esi,group[,source]";
+            type string;
+          }
+        }
+        list igmp-leave-sync-withdraw {
+          ext:presence "Withdraw an EVPN Type-8 IGMP/MLD Leave Synch route";
+          ext:help "Withdraw a Type-8 Leave Synch route (RFC 9251, debug)";
+          key spec;
+          leaf spec {
+            ext:help "vni,esi,group[,source]";
+            type string;
+          }
+        }
+      }
     }
   }
 }


### PR DESCRIPTION
## Summary

Adds a **test-injection command** that drives the (previously dead-code) RFC 9251 Type-7/8 origination helpers, plus a **BDD feature** validating end-to-end route-reflection of the IGMP/MLD Join/Leave Synch routes. Follows up #1631 (the Type-7/8 codec + control-plane stub). The multihoming dataplane (DF election, Ethernet-Segment, kernel-MDB synch, organic ES-snoop trigger) remains deferred — this command is the validation hook for the control-plane stub.

Command: `clear bgp debug igmp-{join,leave}-sync-{originate,withdraw} <vni,esi,group[,source]>`

### Grammar (`zebra-bgp-clear.yang`)
A `debug` container under `/clear/bgp` with four list actions, each taking one comma-separated spec token (`esi` as colon-hex or 20 hex digits; omit `source` for `(*,G)`).

### Dispatch + handler (`inst.rs`, `route.rs`)
`process_cm_msg`'s `ConfigOp::Clear` arm routes `/clear/bgp/debug/*` to `Bgp::debug_igmp_sync_action`, which parses the spec (`parse_igmp_sync_spec` / `parse_esi`), derives the RFC 9251 §9.1 flags from the group family, uses the router-id as the VTEP, and calls `evpn_originate_igmp_*_sync` (+ withdraw). The `#[allow(dead_code)]` markers come off the six origination methods now that they have a caller.

### Show (`show.rs`)
`format_evpn_ecom_value` renders the **ES-Import RT** (`es-import:…`) and **EVI-RT EC** (`evi-rt:rt:…`) via the codec `Display` instead of raw hex.

### Tests
- **Grammar parse test** (`manager.rs`): deterministically asserts the exact `/clear/bgp/debug/…` path + spec arg (not just `ExecCode::Success`).
- **Spec-parser unit tests** (`route.rs`): colon-hex/plain ESI, `(*,G)`/`(S,G)`, malformed rejection.
- **BDD** `bgp_evpn_igmp_sync.feature` (6 scenarios): z2 originates Type-7/8 via the debug command; z1 imports and renders them under `show bgp evpn` with the correct prefixes, ES-Import RT, EVI-RT EC, and `route-type` filter; withdrawals remove them.

## Test plan
- `cargo fmt --check`, `cargo build`, `cargo clippy --workspace --all-targets -- -D warnings`: clean
- `cargo test -p zebra-rs`: 1463 pass (incl. new grammar + spec tests); `cargo test -p bgp-packet`: 357 pass
- **`@bgp_evpn_igmp_sync` BDD: 6/6 scenarios pass** on the release binary (validated locally against live kernel namespaces)

Generated with [Claude Code](https://claude.com/claude-code)