### PR TITLE
bgp-evpn: Type 1 + Type 4 NLRI codec + ESI Label EC

### DIFF
--- a/crates/bgp-packet/src/attrs/ext_com.rs
+++ b/crates/bgp-packet/src/attrs/ext_com.rs
@@ -197,6 +197,45 @@ impl ExtCommunityValue {
         }
     }
 
+    /// Build an ESI Label Extended Community (RFC 7432 §7.5): EVPN high-type
+    /// (0x06) + ESI Label sub-type (0x01). Carried on the **per-ES** Ethernet
+    /// A-D (Type-1) route. The Flags octet's low bit is the redundancy mode
+    /// (`single_active`); the 3-octet `label` (low 20 bits) is the MPLS ESI
+    /// label for split-horizon (unused/0 for VXLAN, where local-bias does the
+    /// filtering — RFC 8365 §8.3.1 — but the mode flag still matters).
+    pub fn esi_label(single_active: bool, label: u32) -> Self {
+        let mut val = [0u8; 6];
+        if single_active {
+            val[0] = EsiLabelEc::SINGLE_ACTIVE;
+        }
+        // val[1..3] reserved (zero). Label in the low 20 bits of val[3..6].
+        let lbl = label.to_be_bytes();
+        val[3..6].copy_from_slice(&lbl[1..4]);
+        ExtCommunityValue {
+            high_type: ExtCommunityType::Evpn as u8,
+            low_type: EVPN_ESI_LABEL_SUB_TYPE,
+            val,
+        }
+    }
+
+    /// True iff this entry is an EVPN ESI Label EC (RFC 7432 §7.5):
+    /// EVPN high-type (0x06) + ESI Label sub-type (0x01).
+    pub fn is_esi_label(&self) -> bool {
+        self.high_type == ExtCommunityType::Evpn as u8 && self.low_type == EVPN_ESI_LABEL_SUB_TYPE
+    }
+
+    /// Decode the ESI Label EC (RFC 7432 §7.5): the redundancy-mode flag and
+    /// the 3-octet ESI label. `None` for any non-matching EC.
+    pub fn as_esi_label(&self) -> Option<EsiLabelEc> {
+        if !self.is_esi_label() {
+            return None;
+        }
+        Some(EsiLabelEc {
+            single_active: self.val[0] & EsiLabelEc::SINGLE_ACTIVE != 0,
+            label: u32::from_be_bytes([0, self.val[3], self.val[4], self.val[5]]),
+        })
+    }
+
     /// Build an EVI-RT Extended Community (RFC 9251 §9.5) from the EVI's
     /// (BD's) Route Target. The EVI-RT carries the same 6-octet RT value
     /// under the EVPN high-type (0x06), with the sub-type selecting the RT
@@ -270,6 +309,33 @@ const EVPN_DF_ELECTION_SUB_TYPE: u8 = 0x06;
 /// high-type (0x06). Shares the Route Target sub-type value (0x02) but is
 /// disambiguated by the EVPN high-type.
 const EVPN_ES_IMPORT_RT_SUB_TYPE: u8 = 0x02;
+
+/// ESI Label Extended Community sub-type (RFC 7432 §7.5), carried under the
+/// EVPN high-type (0x06).
+const EVPN_ESI_LABEL_SUB_TYPE: u8 = 0x01;
+
+/// Decoded EVPN ESI Label Extended Community (RFC 7432 §7.5). Carried on the
+/// per-ES Ethernet A-D (Type-1) route to signal the redundancy mode and the
+/// split-horizon ESI label.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct EsiLabelEc {
+    /// Redundancy mode: `true` = Single-Active, `false` = All-Active
+    /// (Flags octet low bit).
+    pub single_active: bool,
+    /// 3-octet ESI label (low 20 bits). 0 / unused for VXLAN (local-bias).
+    pub label: u32,
+}
+
+impl EsiLabelEc {
+    /// Flags octet bit 0 (LSB): set = Single-Active redundancy mode.
+    const SINGLE_ACTIVE: u8 = 0x01;
+}
+
+impl From<EsiLabelEc> for ExtCommunityValue {
+    fn from(e: EsiLabelEc) -> Self {
+        ExtCommunityValue::esi_label(e.single_active, e.label)
+    }
+}
 
 /// EVI-RT Extended Community sub-types (RFC 9251 §9.5), carried under the
 /// EVPN high-type (0x06). The sub-type selects which Route Target format the
@@ -522,6 +588,14 @@ impl fmt::Display for ExtCommunityValue {
                 "es-import:{:02x}:{:02x}:{:02x}:{:02x}:{:02x}:{:02x}",
                 es[0], es[1], es[2], es[3], es[4], es[5]
             )
+        } else if let Some(es) = self.as_esi_label() {
+            // ESI Label EC (RFC 7432 §7.5): redundancy mode + ESI label.
+            let mode = if es.single_active {
+                "single-active"
+            } else {
+                "all-active"
+            };
+            write!(f, "esi-label:{mode}:{}", es.label)
         } else if self.is_evi_rt() {
             // EVI-RT EC (RFC 9251 §9.5): render `evi-rt:` then the underlying
             // Route Target. The IPv6 form (0x0D) has no 8-octet RT, so fall
@@ -1140,5 +1214,40 @@ mod tests {
             val: [0; 6],
         };
         assert!(ExtCommunityValue::evi_rt_from_rt(&soo).is_none());
+    }
+
+    #[test]
+    fn esi_label_ec_round_trips() {
+        // All-active, label 100.
+        let ec = ExtCommunityValue::esi_label(false, 100);
+        assert_eq!(ec.high_type, ExtCommunityType::Evpn as u8);
+        assert_eq!(ec.low_type, 0x01);
+        assert_eq!(ec.val, [0x00, 0, 0, 0, 0, 100], "flags 0, label in low 24");
+        assert!(ec.is_esi_label());
+        let dec = ec.as_esi_label().expect("decode");
+        assert!(!dec.single_active);
+        assert_eq!(dec.label, 100);
+        assert_eq!(ec.to_string(), "esi-label:all-active:100");
+        // Single-active, label 0x12345 (20 bits).
+        let sa = ExtCommunityValue::esi_label(true, 0x12345);
+        assert_eq!(sa.val, [0x01, 0, 0, 0x01, 0x23, 0x45]);
+        let dec = sa.as_esi_label().expect("decode");
+        assert!(dec.single_active);
+        assert_eq!(dec.label, 0x12345);
+        assert_eq!(sa.to_string(), "esi-label:single-active:74565");
+        // From-impl mirrors the constructor.
+        let from: ExtCommunityValue = EsiLabelEc {
+            single_active: true,
+            label: 7,
+        }
+        .into();
+        assert_eq!(from, ExtCommunityValue::esi_label(true, 7));
+        // A standard RT is not an ESI Label EC.
+        let rt = ExtCommunityValue {
+            high_type: 0x00,
+            low_type: 0x02,
+            val: [0; 6],
+        };
+        assert!(!rt.is_esi_label());
     }
 }

--- a/crates/bgp-packet/src/attrs/mp_reach.rs
+++ b/crates/bgp-packet/src/attrs/mp_reach.rs
@@ -647,6 +647,25 @@ impl fmt::Display for MpReachAttr {
             } => {
                 for update in updates.iter() {
                     match update {
+                        EvpnRoute::EthernetAd(v) => {
+                            writeln!(
+                                f,
+                                " [{}] ethernet-ad esi:{} tag:{} label:{}",
+                                v.rd,
+                                esi_display(&v.esi),
+                                v.ether_tag,
+                                v.label
+                            )?;
+                        }
+                        EvpnRoute::EthernetSeg(v) => {
+                            writeln!(
+                                f,
+                                " [{}] ethernet-segment esi:{} orig:{}",
+                                v.rd,
+                                esi_display(&v.esi),
+                                v.orig
+                            )?;
+                        }
                         EvpnRoute::Mac(v) => {
                             writeln!(
                                 f,

--- a/crates/bgp-packet/src/attrs/mp_unreach.rs
+++ b/crates/bgp-packet/src/attrs/mp_unreach.rs
@@ -608,6 +608,12 @@ impl fmt::Display for MpUnreachAttr {
             Evpn(evpn_routes) => {
                 for evpn in evpn_routes.iter() {
                     match evpn {
+                        EvpnRoute::EthernetAd(v) => {
+                            writeln!(f, " [{}] ethernet-ad tag:{}", v.rd, v.ether_tag)?;
+                        }
+                        EvpnRoute::EthernetSeg(v) => {
+                            writeln!(f, " [{}] ethernet-segment orig:{}", v.rd, v.orig)?;
+                        }
                         EvpnRoute::Mac(v) => {
                             writeln!(
                                 f,

--- a/crates/bgp-packet/src/attrs/nlri_evpn.rs
+++ b/crates/bgp-packet/src/attrs/nlri_evpn.rs
@@ -76,8 +76,10 @@ pub struct Evpn {
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum EvpnRoute {
+    EthernetAd(EvpnEthernetAd),
     Mac(EvpnMac),
     Multicast(EvpnMulticast),
+    EthernetSeg(EvpnEthernetSeg),
     Prefix(EvpnIpPrefix),
     Smet(EvpnSmet),
     IgmpJoinSync(EvpnIgmpJoinSync),
@@ -85,6 +87,44 @@ pub enum EvpnRoute {
     PerRegionImet(EvpnPerRegionImet),
     SPmsi(EvpnSPmsi),
     LeafAd(EvpnLeafAd),
+}
+
+/// Route Type 1 — Ethernet Auto-Discovery (A-D) Route (RFC 7432 §7.1). A PE
+/// advertises one per multihomed Ethernet Segment for fast convergence and
+/// split-horizon (the **per-ES** A-D, Ethernet Tag = `MAX-ET`
+/// 0xFFFFFFFF, carrying the ESI Label EC), and one per EVI for aliasing /
+/// backup-path load-balancing (the **per-EVI** A-D, Ethernet Tag = the
+/// EVI's tag).
+///
+/// Wire layout (RFC 7432 §7.1, fixed 25 octets): RD(8) ESI(10) EthTag(4)
+/// MPLSLabel(3). The route key is **ESI + Ethernet Tag**; the RD and Label
+/// are per-path properties (the Label is the VXLAN VNI or MPLS label, 0 for
+/// a per-ES A-D whose label rides the ESI Label EC instead).
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct EvpnEthernetAd {
+    pub id: u32,
+    pub rd: RouteDistinguisher,
+    pub esi: [u8; 10],
+    pub ether_tag: u32,
+    /// MPLS label / VXLAN VNI (low 24 bits). Per-path, not in the key.
+    pub label: u32,
+}
+
+/// Route Type 4 — Ethernet Segment Route (RFC 7432 §7.4). A PE advertises
+/// one per locally-attached Ethernet Segment so the PEs on the same ES
+/// discover one another (matched by the auto-derived **ES-Import RT**) and
+/// run **Designated Forwarder** election (RFC 7432 §8.5 / RFC 8584). It
+/// carries the ES-Import RT and the DF Election EC.
+///
+/// Wire layout (RFC 7432 §7.4): RD(8) ESI(10) IPAddrLen(1) OrigRouterIP(4|16).
+/// The route key is **ESI + Originating Router's IP**; the RD is per-path.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct EvpnEthernetSeg {
+    pub id: u32,
+    pub rd: RouteDistinguisher,
+    pub esi: [u8; 10],
+    /// Originating router's IP address (the PE's VTEP / loopback).
+    pub orig: IpAddr,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -323,6 +363,13 @@ impl Evpn {
 /// `show bgp evpn` output).
 #[derive(Debug, Clone, Eq, PartialEq, Ord, PartialOrd, Hash)]
 pub enum EvpnPrefix {
+    /// Route Type 1 — Ethernet Auto-Discovery (A-D) Route (RFC 7432 §7.1).
+    ///
+    /// Wire format: `[1]:[ESI]:[EthTag]`. The route key is the ESI plus the
+    /// Ethernet Tag; the MPLS label / VNI rides on the `EvpnEthernetAd`
+    /// path, not the key. Declared first so the derived `Ord` keeps numeric
+    /// route-type ordering (Type 1 < 2).
+    EthernetAd { esi: [u8; 10], eth_tag: u32 },
     /// Route Type 2 — MAC/IP Advertisement Route.
     ///
     /// Wire format: `[2]:[EthTag]:[MAClen]:[MAC]:[IPlen]:[IP]`. The IP
@@ -337,6 +384,12 @@ pub enum EvpnPrefix {
     ///
     /// Wire format: `[3]:[EthTag]:[IPlen]:[OrigIP]`.
     InclusiveMulticast { eth_tag: u32, orig: IpAddr },
+    /// Route Type 4 — Ethernet Segment Route (RFC 7432 §7.4).
+    ///
+    /// Wire format: `[4]:[ESI]:[IPlen]:[OrigIP]`. The route key is the ESI
+    /// plus the Originating Router's IP; the RD is per-path. Declared
+    /// between Type 3 and Type 5 so the derived `Ord` stays numeric.
+    EthernetSeg { esi: [u8; 10], orig: IpAddr },
     /// Route Type 5 — IP Prefix Route (RFC 9136).
     ///
     /// Wire format: `[5]:[EthTag]:[IPlen]:[IP]`. The gateway IP and label
@@ -406,8 +459,10 @@ impl EvpnPrefix {
     /// EVPN route type number (2, 3, 5, or 6).
     pub fn route_type(&self) -> u8 {
         match self {
+            EvpnPrefix::EthernetAd { .. } => 1,
             EvpnPrefix::MacIp { .. } => 2,
             EvpnPrefix::InclusiveMulticast { .. } => 3,
+            EvpnPrefix::EthernetSeg { .. } => 4,
             EvpnPrefix::IpPrefix { .. } => 5,
             EvpnPrefix::Smet { .. } => 6,
             EvpnPrefix::IgmpJoinSync { .. } => 7,
@@ -422,6 +477,20 @@ impl EvpnPrefix {
     /// RD-stripped key suitable for indexing the EVPN RIB.
     pub fn from_route(route: &EvpnRoute) -> (RouteDistinguisher, EvpnPrefix) {
         match route {
+            EvpnRoute::EthernetAd(e) => (
+                e.rd,
+                EvpnPrefix::EthernetAd {
+                    esi: e.esi,
+                    eth_tag: e.ether_tag,
+                },
+            ),
+            EvpnRoute::EthernetSeg(e) => (
+                e.rd,
+                EvpnPrefix::EthernetSeg {
+                    esi: e.esi,
+                    orig: e.orig,
+                },
+            ),
             EvpnRoute::Mac(m) => (
                 m.rd,
                 EvpnPrefix::MacIp {
@@ -518,6 +587,14 @@ impl EvpnPrefix {
 impl fmt::Display for EvpnPrefix {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
+            EvpnPrefix::EthernetAd { esi, eth_tag } => {
+                // `[1]:[ESI]:[EthTag]` — the per-ES/per-EVI A-D route key.
+                write!(f, "[1]:[{}]:[{eth_tag}]", esi_display(esi))
+            }
+            EvpnPrefix::EthernetSeg { esi, orig } => {
+                // `[4]:[ESI]:[IPlen]:[OrigIP]` — the Ethernet Segment route key.
+                write!(f, "[4]:[{}]:[{}]:[{orig}]", esi_display(esi), ip_bits(orig))
+            }
             EvpnPrefix::MacIp { eth_tag, mac, ip } => {
                 write!(
                     f,
@@ -661,6 +738,39 @@ impl ParseNlri<EvpnRoute> for EvpnRoute {
 
         use EvpnRouteType::*;
         match route_type {
+            EthernetAd => {
+                // RFC 7432 §7.1: RD(8) ESI(10) EthTag(4) MPLSLabel(3).
+                let (input, rd) = RouteDistinguisher::parse_be(input)?;
+                let (input, esi_raw) = take(10usize).parse(input)?;
+                let mut esi = [0u8; 10];
+                esi.copy_from_slice(esi_raw);
+                let (input, ether_tag) = be_u32(input)?;
+                let (input, label) = be_u24(input)?;
+                Ok((
+                    input,
+                    EvpnRoute::EthernetAd(EvpnEthernetAd {
+                        id,
+                        rd,
+                        esi,
+                        ether_tag,
+                        label,
+                    }),
+                ))
+            }
+            EthernetSr => {
+                // RFC 7432 §7.4: RD(8) ESI(10) IPAddrLen(1) OrigRouterIP(4|16).
+                let (input, rd) = RouteDistinguisher::parse_be(input)?;
+                let (input, esi_raw) = take(10usize).parse(input)?;
+                let mut esi = [0u8; 10];
+                esi.copy_from_slice(esi_raw);
+                let (input, orig) = parse_len_prefixed_ip(input)?;
+                let orig =
+                    orig.ok_or_else(|| nom::Err::Error(make_error(input, ErrorKind::LengthValue)))?;
+                Ok((
+                    input,
+                    EvpnRoute::EthernetSeg(EvpnEthernetSeg { id, rd, esi, orig }),
+                ))
+            }
             MacIpAdvRoute => {
                 let (input, rd) = RouteDistinguisher::parse_be(input)?;
 
@@ -957,6 +1067,41 @@ impl EvpnRoute {
     /// (e.g. Type-2 IP component going from absent → IPv4 → IPv6).
     pub fn nlri_emit(&self, buf: &mut BytesMut) {
         match self {
+            EvpnRoute::EthernetAd(e) => {
+                if e.id != 0 {
+                    buf.put_u32(e.id);
+                }
+                let mut payload = BytesMut::new();
+                // RD (8 octets).
+                payload.put_u16(e.rd.typ as u16);
+                payload.put(&e.rd.val[..]);
+                // ESI (10 octets) — RFC 7432 §7.1.
+                payload.put(&e.esi[..]);
+                // Ethernet Tag (4 octets).
+                payload.put_u32(e.ether_tag);
+                // MPLS Label / VNI (3 octets, low 24 bits).
+                let label_bytes = e.label.to_be_bytes();
+                payload.put(&label_bytes[1..4]);
+                buf.put_u8(1); // Route Type 1 — Ethernet Auto-Discovery.
+                buf.put_u8(payload.len() as u8);
+                buf.put(&payload[..]);
+            }
+            EvpnRoute::EthernetSeg(e) => {
+                if e.id != 0 {
+                    buf.put_u32(e.id);
+                }
+                let mut payload = BytesMut::new();
+                // RD (8 octets).
+                payload.put_u16(e.rd.typ as u16);
+                payload.put(&e.rd.val[..]);
+                // ESI (10 octets) — RFC 7432 §7.4.
+                payload.put(&e.esi[..]);
+                // Originating Router's IP (<len-in-bits><addr>).
+                emit_len_prefixed_ip(&mut payload, Some(e.orig));
+                buf.put_u8(4); // Route Type 4 — Ethernet Segment.
+                buf.put_u8(payload.len() as u8);
+                buf.put(&payload[..]);
+            }
             EvpnRoute::Mac(m) => {
                 if m.id != 0 {
                     buf.put_u32(m.id);
@@ -1213,6 +1358,56 @@ mod evpn_prefix_tests {
             ip: None,
         };
         assert_eq!(p.to_string(), "[2]:[0]:[48]:[fe:b2:14:6c:11:6c]");
+    }
+
+    #[test]
+    fn display_ethernet_ad_and_segment() {
+        let esi = [0x00, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88, 0x99];
+        let ad = EvpnPrefix::EthernetAd {
+            esi,
+            eth_tag: 0xffffffff,
+        };
+        assert_eq!(
+            ad.to_string(),
+            "[1]:[00:11:22:33:44:55:66:77:88:99]:[4294967295]"
+        );
+        assert_eq!(ad.route_type(), 1);
+        let es = EvpnPrefix::EthernetSeg {
+            esi,
+            orig: IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1)),
+        };
+        assert_eq!(
+            es.to_string(),
+            "[4]:[00:11:22:33:44:55:66:77:88:99]:[32]:[10.0.0.1]"
+        );
+        assert_eq!(es.route_type(), 4);
+    }
+
+    #[test]
+    fn es_route_type_ordering() {
+        // Derived `Ord` must keep numeric route-type order: 1 < 2 < 3 < 4 < 5.
+        let t1 = EvpnPrefix::EthernetAd {
+            esi: [0; 10],
+            eth_tag: 0,
+        };
+        let t2 = EvpnPrefix::MacIp {
+            eth_tag: 0,
+            mac: [0; 6],
+            ip: None,
+        };
+        let t3 = EvpnPrefix::InclusiveMulticast {
+            eth_tag: 0,
+            orig: IpAddr::V4(Ipv4Addr::UNSPECIFIED),
+        };
+        let t4 = EvpnPrefix::EthernetSeg {
+            esi: [0; 10],
+            orig: IpAddr::V4(Ipv4Addr::UNSPECIFIED),
+        };
+        let t5 = EvpnPrefix::IpPrefix {
+            eth_tag: 0,
+            prefix: "10.0.0.0/8".parse().unwrap(),
+        };
+        assert!(t1 < t2 && t2 < t3 && t3 < t4 && t4 < t5);
     }
 
     #[test]
@@ -2104,5 +2299,87 @@ mod evpn_emit_tests {
         let (_, parsed) =
             EvpnRoute::parse_nlri(&buf, false).expect("parse_nlri must accept what we emit");
         assert_eq!(parsed, EvpnRoute::IgmpLeaveSync(original));
+    }
+
+    fn es_esi() -> [u8; 10] {
+        [0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09]
+    }
+
+    /// Type-1 per-ES A-D: payload = 8 (RD) + 10 (ESI) + 4 (tag) + 3
+    /// (label) = 25. Per-ES form uses MAX-ET and label 0 (the real label
+    /// rides the ESI Label EC).
+    #[test]
+    fn ethernet_ad_nlri_emit_per_es() {
+        let e = EvpnEthernetAd {
+            id: 0,
+            rd: rd_type1_ip(Ipv4Addr::new(10, 0, 0, 1), 100),
+            esi: es_esi(),
+            ether_tag: 0xffffffff,
+            label: 0,
+        };
+        let mut buf = BytesMut::new();
+        EvpnRoute::EthernetAd(e.clone()).nlri_emit(&mut buf);
+        assert_eq!(buf[0], 1, "route type 1");
+        assert_eq!(buf[1], 25, "length");
+        assert_eq!(&buf[10..20], &es_esi(), "ESI after RD");
+        assert_eq!(&buf[20..24], &[0xff, 0xff, 0xff, 0xff], "MAX-ET");
+        assert_eq!(&buf[24..27], &[0, 0, 0], "label 0");
+        let (_, parsed) = EvpnRoute::parse_nlri(&buf, false).expect("round-trip");
+        assert_eq!(parsed, EvpnRoute::EthernetAd(e));
+    }
+
+    /// Type-1 per-EVI A-D round-trip with a real VNI label and Add-Path id.
+    #[test]
+    fn ethernet_ad_roundtrip_per_evi_addpath() {
+        let original = EvpnEthernetAd {
+            id: 7,
+            rd: rd_type1_ip(Ipv4Addr::new(192, 168, 0, 1), 200),
+            esi: es_esi(),
+            ether_tag: 0,
+            label: 10,
+        };
+        let mut buf = BytesMut::new();
+        EvpnRoute::EthernetAd(original.clone()).nlri_emit(&mut buf);
+        assert_eq!(&buf[0..4], &[0, 0, 0, 7], "path id prepended");
+        assert_eq!(buf[4], 1, "route type follows id");
+        let (_, parsed) = EvpnRoute::parse_nlri(&buf, true).expect("round-trip");
+        assert_eq!(parsed, EvpnRoute::EthernetAd(original));
+    }
+
+    /// Type-4 Ethernet Segment: payload = 8 (RD) + 10 (ESI) + 1 (IP-len) +
+    /// 4 (orig) = 23 for IPv4.
+    #[test]
+    fn ethernet_seg_nlri_emit_v4() {
+        let e = EvpnEthernetSeg {
+            id: 0,
+            rd: rd_type1_ip(Ipv4Addr::new(10, 0, 0, 1), 0),
+            esi: es_esi(),
+            orig: IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1)),
+        };
+        let mut buf = BytesMut::new();
+        EvpnRoute::EthernetSeg(e.clone()).nlri_emit(&mut buf);
+        assert_eq!(buf[0], 4, "route type 4");
+        assert_eq!(buf[1], 23, "length");
+        assert_eq!(&buf[10..20], &es_esi(), "ESI after RD");
+        assert_eq!(buf[20], 32, "IP len = 32");
+        assert_eq!(&buf[21..25], &[10, 0, 0, 1], "orig router IP");
+        let (_, parsed) = EvpnRoute::parse_nlri(&buf, false).expect("round-trip");
+        assert_eq!(parsed, EvpnRoute::EthernetSeg(e));
+    }
+
+    /// Type-4 Ethernet Segment round-trip with an IPv6 originating router.
+    #[test]
+    fn ethernet_seg_roundtrip_v6() {
+        let original = EvpnEthernetSeg {
+            id: 0,
+            rd: rd_type1_ip(Ipv4Addr::new(192, 168, 0, 1), 0),
+            esi: es_esi(),
+            orig: "2001:db8::2".parse::<IpAddr>().unwrap(),
+        };
+        let mut buf = BytesMut::new();
+        EvpnRoute::EthernetSeg(original.clone()).nlri_emit(&mut buf);
+        assert_eq!(buf[1], 35, "IPv6 payload length");
+        let (_, parsed) = EvpnRoute::parse_nlri(&buf, false).expect("round-trip");
+        assert_eq!(parsed, EvpnRoute::EthernetSeg(original));
     }
 }

--- a/zebra-rs/src/bgp/route.rs
+++ b/zebra-rs/src/bgp/route.rs
@@ -4771,6 +4771,21 @@ pub fn route_update_evpn(
     let id = if add_path { rib.local_id } else { 0 };
 
     let route = match prefix {
+        // Type-1/4: ESI is in the key; the per-path label (Type-1) rides the
+        // BgpRib so a reflected route stays faithful.
+        EvpnPrefix::EthernetAd { esi, eth_tag } => EvpnRoute::EthernetAd(EvpnEthernetAd {
+            id,
+            rd: *rd,
+            esi: *esi,
+            ether_tag: *eth_tag,
+            label: rib.label.as_ref().map(|l| l.label).unwrap_or(0),
+        }),
+        EvpnPrefix::EthernetSeg { esi, orig } => EvpnRoute::EthernetSeg(EvpnEthernetSeg {
+            id,
+            rd: *rd,
+            esi: *esi,
+            orig: *orig,
+        }),
         EvpnPrefix::MacIp { eth_tag, mac, .. } => {
             let vni = extract_vni_from_attr(&rib.attr).unwrap_or(0);
             EvpnRoute::Mac(EvpnMac {
@@ -4993,6 +5008,21 @@ pub fn route_withdraw_evpn_to_peers(
 /// passes through.
 fn evpn_route_from_prefix(rd: &RouteDistinguisher, prefix: &EvpnPrefix, id: u32) -> EvpnRoute {
     match prefix {
+        // Type-1/4: reconstructed from the key for a withdraw (label/RD are
+        // not part of the key, so 0/empty is correct for a key-matched pull).
+        EvpnPrefix::EthernetAd { esi, eth_tag } => EvpnRoute::EthernetAd(EvpnEthernetAd {
+            id,
+            rd: *rd,
+            esi: *esi,
+            ether_tag: *eth_tag,
+            label: 0,
+        }),
+        EvpnPrefix::EthernetSeg { esi, orig } => EvpnRoute::EthernetSeg(EvpnEthernetSeg {
+            id,
+            rd: *rd,
+            esi: *esi,
+            orig: *orig,
+        }),
         EvpnPrefix::MacIp { eth_tag, mac, .. } => {
             // RD type 1 (IPv4 + 2-byte assigned-number) is the form
             // we emit at origination — the assigned-number bytes
@@ -6573,12 +6603,14 @@ fn extract_vni_from_attr(attr: &BgpAttr) -> Option<u32> {
 }
 
 /// Map a parsed `EvpnRoute` to the policy-side `EvpnRouteType`
-/// discriminator. Type-2 (MAC-IP), Type-3 (Inclusive Multicast) and
-/// Type-5 (IP Prefix) parse into `EvpnRoute`; Type-1/4 NLRIs are
-/// dropped at parse, so they are not represented here.
+/// discriminator. The policy enum predates Type-1/4/7-11; routes without a
+/// dedicated discriminator map to the closest existing one.
 fn evpn_route_type_of(route: &EvpnRoute) -> crate::policy::EvpnRouteType {
     use crate::policy::EvpnRouteType;
     match route {
+        // RFC 7432 Type-1 (Ethernet A-D) and Type-4 (Ethernet Segment) are
+        // MAC-segment / multihoming routes; the closest discriminator is MacIp.
+        EvpnRoute::EthernetAd(_) | EvpnRoute::EthernetSeg(_) => EvpnRouteType::MacIp,
         EvpnRoute::Mac(_) => EvpnRouteType::MacIp,
         EvpnRoute::Multicast(_) => EvpnRouteType::Multicast,
         EvpnRoute::Prefix(_) => EvpnRouteType::Prefix,
@@ -6603,6 +6635,9 @@ fn evpn_route_type_of(route: &EvpnRoute) -> crate::policy::EvpnRouteType {
 /// Returns `None` when neither source yields a non-zero VNI.
 fn evpn_vni_of(route: &EvpnRoute, attr: &BgpAttr) -> Option<u32> {
     match route {
+        // Type-1 A-D carries the VNI in its label field; Type-4 ES carries none.
+        EvpnRoute::EthernetAd(e) => (e.label != 0).then_some(e.label),
+        EvpnRoute::EthernetSeg(_) => None,
         EvpnRoute::Mac(m) => (m.vni != 0).then_some(m.vni),
         EvpnRoute::Multicast(_) => extract_vni_from_attr(attr),
         // Type-5 (IP Prefix) is an L3VPN-style route: forwarding rides
@@ -6763,9 +6798,12 @@ fn route_evpn_export_selected(
                     });
                 }
             }
-            // RFC 9251 Type-7/8 Synch and RFC 9572 A-D routes have no VXLAN
-            // dataplane action here — withdraw is a control-plane no-op.
-            EvpnPrefix::IgmpJoinSync { .. }
+            // RFC 7432 Type-1/4 ES routes, RFC 9251 Type-7/8 Synch, and RFC
+            // 9572 A-D routes have no VXLAN dataplane action here — withdraw
+            // is a control-plane no-op.
+            EvpnPrefix::EthernetAd { .. }
+            | EvpnPrefix::EthernetSeg { .. }
+            | EvpnPrefix::IgmpJoinSync { .. }
             | EvpnPrefix::IgmpLeaveSync { .. }
             | EvpnPrefix::PerRegionImet { .. }
             | EvpnPrefix::SPmsi { .. }
@@ -6900,11 +6938,14 @@ fn route_evpn_export_selected(
                 });
             }
         }
-        // RFC 9251 Type-7/8 Synch and RFC 9572 Per-Region I-PMSI / S-PMSI /
-        // Leaf A-D have no VXLAN dataplane action in the current control-plane
-        // phase — install is a no-op (the routes are still stored and
-        // re-advertised; only kernel programming is skipped).
-        EvpnPrefix::IgmpJoinSync { .. }
+        // RFC 7432 Type-1/4 ES routes, RFC 9251 Type-7/8 Synch, and RFC 9572
+        // Per-Region I-PMSI / S-PMSI / Leaf A-D have no VXLAN dataplane action
+        // in the current control-plane phase — install is a no-op (the routes
+        // are still stored and re-advertised; only kernel programming is
+        // skipped).
+        EvpnPrefix::EthernetAd { .. }
+        | EvpnPrefix::EthernetSeg { .. }
+        | EvpnPrefix::IgmpJoinSync { .. }
         | EvpnPrefix::IgmpLeaveSync { .. }
         | EvpnPrefix::PerRegionImet { .. }
         | EvpnPrefix::SPmsi { .. }
@@ -7214,6 +7255,8 @@ pub fn route_evpn_update(
     // action (`route_evpn_export_selected` handles them as no-ops). Local
     // origination / segmentation re-origination lands in a later phase.
     let id = match route {
+        EvpnRoute::EthernetAd(e) => e.id,
+        EvpnRoute::EthernetSeg(e) => e.id,
         EvpnRoute::Mac(m) => m.id,
         EvpnRoute::Multicast(m) => m.id,
         EvpnRoute::Prefix(p) => p.id,
@@ -7291,6 +7334,17 @@ pub fn route_evpn_update(
     {
         rib.label = Some(bgp_packet::Label {
             label: p.label,
+            exp: 0,
+            bos: true,
+        });
+    }
+    // Type-1 Ethernet A-D: the MPLS label / VNI is per-path (not in the key);
+    // capture it so a reflected A-D re-emits it faithfully.
+    if let EvpnRoute::EthernetAd(e) = route
+        && e.label != 0
+    {
+        rib.label = Some(bgp_packet::Label {
+            label: e.label,
             exp: 0,
             bos: true,
         });
@@ -7403,6 +7457,8 @@ pub fn route_evpn_update(
 pub fn route_evpn_withdraw(ident: usize, route: &EvpnRoute, bgp: &mut BgpTop, peers: &mut PeerMap) {
     let (rd, prefix) = EvpnPrefix::from_route(route);
     let id = match route {
+        EvpnRoute::EthernetAd(e) => e.id,
+        EvpnRoute::EthernetSeg(e) => e.id,
         EvpnRoute::Mac(m) => m.id,
         EvpnRoute::Multicast(m) => m.id,
         EvpnRoute::Prefix(p) => p.id,
@@ -9824,6 +9880,20 @@ fn build_evpn_route(
     rib: &BgpRib,
 ) -> Option<EvpnRoute> {
     match prefix {
+        // Type-1/4: ESI is in the key; label (Type-1) preserved from the path.
+        EvpnPrefix::EthernetAd { esi, eth_tag } => Some(EvpnRoute::EthernetAd(EvpnEthernetAd {
+            id: rib.remote_id,
+            rd: *rd,
+            esi: *esi,
+            ether_tag: *eth_tag,
+            label: rib.label.as_ref().map(|l| l.label).unwrap_or(0),
+        })),
+        EvpnPrefix::EthernetSeg { esi, orig } => Some(EvpnRoute::EthernetSeg(EvpnEthernetSeg {
+            id: rib.remote_id,
+            rd: *rd,
+            esi: *esi,
+            orig: *orig,
+        })),
         EvpnPrefix::MacIp { eth_tag, mac, .. } => {
             let vni = extract_vni_from_attr(&rib.attr).unwrap_or(0);
             Some(EvpnRoute::Mac(EvpnMac {
@@ -14916,6 +14986,8 @@ fn evpn_ipv4_route_target(addr: Ipv4Addr, local_admin: u16) -> ExtCommunityValue
 /// routes.
 fn evpn_leaf_ad_route_key(route: &EvpnRoute) -> Vec<u8> {
     let zeroed = match route.clone() {
+        EvpnRoute::EthernetAd(e) => EvpnRoute::EthernetAd(EvpnEthernetAd { id: 0, ..e }),
+        EvpnRoute::EthernetSeg(e) => EvpnRoute::EthernetSeg(EvpnEthernetSeg { id: 0, ..e }),
         EvpnRoute::Mac(m) => EvpnRoute::Mac(EvpnMac { id: 0, ..m }),
         EvpnRoute::Multicast(m) => EvpnRoute::Multicast(EvpnMulticast { id: 0, ..m }),
         EvpnRoute::Prefix(p) => EvpnRoute::Prefix(EvpnIpPrefix { id: 0, ..p }),

--- a/zebra-rs/src/bgp/show.rs
+++ b/zebra-rs/src/bgp/show.rs
@@ -1074,10 +1074,7 @@ fn show_adj_rib_routes_evpn<D: RibDirection>(
 
     let mut buf = String::new();
 
-    writeln!(
-        buf,
-        "EVPN type-1 prefix: [1]:[EthTag]:[ESI]:[IPlen]:[VTEP-IP]:[Frag-id]"
-    )?;
+    writeln!(buf, "EVPN type-1 prefix: [1]:[ESI]:[EthTag]")?;
     writeln!(
         buf,
         "EVPN type-2 prefix: [2]:[EthTag]:[MAClen]:[MAC]:[IPlen]:[IP]"
@@ -3268,10 +3265,13 @@ fn format_evpn_ecom_value(v: &ExtCommunityValue) -> String {
         // DF Election EC — RFC 8584 §2.2 (RFC 9572 §5.3.1 inter-AS DF
         // election). Reuse the codec's Display: `df-election:alg<N>[+ac-df]`.
         (0x06, 0x06) => v.to_string(),
-        // EVPN ES-Import RT — RFC 7432 §7.6, carried on Type-7/8 IGMP/MLD
-        // Synch routes (RFC 9251). Reuse the codec's Display:
-        // `es-import:<6-octet colon-hex>`.
+        // EVPN ES-Import RT — RFC 7432 §7.6, carried on Type-4 ES routes and
+        // Type-7/8 IGMP/MLD Synch routes (RFC 9251). Reuse the codec's
+        // Display: `es-import:<6-octet colon-hex>`.
         (0x06, 0x02) => v.to_string(),
+        // EVPN ESI Label EC — RFC 7432 §7.5, carried on the per-ES Type-1
+        // A-D route. Reuse the codec's Display: `esi-label:<mode>:<label>`.
+        (0x06, 0x01) => v.to_string(),
         // EVPN EVI-RT EC — RFC 9251 §9.5 (Type 0..3 sub-types 0x0a-0x0d),
         // carried on the Type-7/8 Synch routes. Reuse the codec's Display:
         // `evi-rt:<route-target>`.
@@ -3433,8 +3433,10 @@ fn write_evpn_path_attrs(buf: &mut String, attr: &BgpAttr) -> std::fmt::Result {
 /// Keywords mirror the `route-type` enum in exec.yang.
 fn evpn_route_type_filter(token: String) -> Option<u8> {
     match token.as_str() {
+        "ethernet-ad" => Some(1),
         "macip" => Some(2),
         "multicast" => Some(3),
+        "ethernet-segment" => Some(4),
         "prefix" => Some(5),
         "smet" => Some(6),
         "igmp-join-sync" => Some(7),
@@ -3466,10 +3468,7 @@ fn show_bgp_evpn(
     let mut buf = String::new();
 
     // Legend — describes the wire-format layout of each EVPN route type.
-    writeln!(
-        buf,
-        "EVPN type-1 prefix: [1]:[EthTag]:[ESI]:[IPlen]:[VTEP-IP]:[Frag-id]"
-    )?;
+    writeln!(buf, "EVPN type-1 prefix: [1]:[ESI]:[EthTag]")?;
     writeln!(
         buf,
         "EVPN type-2 prefix: [2]:[EthTag]:[MAClen]:[MAC]:[IPlen]:[IP]"

--- a/zebra-rs/src/script/marshal.rs
+++ b/zebra-rs/src/script/marshal.rs
@@ -11,7 +11,7 @@ use std::collections::BTreeSet;
 
 use bgp_packet::{
     BgpAttr, BgpNexthop, Community, EvpnRoute, ExtCommunity, ExtCommunityValue, LocalPref, Med,
-    Origin,
+    Origin, esi_display,
 };
 use ipnet::IpNet;
 use mlua::{Lua, Table};
@@ -35,6 +35,20 @@ pub fn evpn_prefix_table(lua: &Lua, route: &EvpnRoute) -> mlua::Result<Table> {
     table.set("afi", "evpn")?;
     let evpn = lua.create_table()?;
     let network = match route {
+        EvpnRoute::EthernetAd(e) => {
+            evpn.set("route_type", 1)?;
+            evpn.set("rd", e.rd.to_string())?;
+            evpn.set("esi", esi_display(&e.esi))?;
+            evpn.set("ether_tag", e.ether_tag)?;
+            format!("[1]:[{}]:[{}]", esi_display(&e.esi), e.ether_tag)
+        }
+        EvpnRoute::EthernetSeg(e) => {
+            evpn.set("route_type", 4)?;
+            evpn.set("rd", e.rd.to_string())?;
+            evpn.set("esi", esi_display(&e.esi))?;
+            evpn.set("orig", e.orig.to_string())?;
+            format!("[4]:[{}]:[{}]", esi_display(&e.esi), e.orig)
+        }
         EvpnRoute::Mac(m) => {
             evpn.set("route_type", 2)?;
             evpn.set("rd", m.rd.to_string())?;

--- a/zebra-rs/yang/exec.yang
+++ b/zebra-rs/yang/exec.yang
@@ -343,12 +343,15 @@ module exec {
         }
         leaf route-type {
           ext:help "Filter the EVPN RIB by route type";
-          // macip=2, multicast=3, prefix=5 (RFC 7432/9136); smet=6,
-          // igmp-join-sync=7, igmp-leave-sync=8 (RFC 9251);
-          // per-region-imet=9, s-pmsi=10, leaf=11 (RFC 9572).
+          // ethernet-ad=1, macip=2, multicast=3, ethernet-segment=4,
+          // prefix=5 (RFC 7432/9136); smet=6, igmp-join-sync=7,
+          // igmp-leave-sync=8 (RFC 9251); per-region-imet=9, s-pmsi=10,
+          // leaf=11 (RFC 9572).
           type enumeration {
+            enum ethernet-ad;
             enum macip;
             enum multicast;
+            enum ethernet-segment;
             enum prefix;
             enum smet;
             enum igmp-join-sync;


### PR DESCRIPTION
## Summary

**Phase 1** of the EVPN Ethernet Segment foundation (RFC 7432; design: `docs/design/bgp-evpn-ethernet-segment.md`, #1633). Implements the two remaining base-EVPN route types — **1 (Ethernet Auto-Discovery / A-D)** and **4 (Ethernet Segment)** — as a wire codec plus RIB-generic plumbing, and adds the **ESI Label** extended community. Self-contained: no kernel work, no behaviour change beyond the routes now parsing / storing / reflecting / displaying instead of being rejected at parse. DF election, ESI config, and the data plane are later phases.

### bgp-packet codec (`nlri_evpn.rs`)
- `EvpnEthernetAd` (Type 1) + `EvpnEthernetSeg` (Type 4) structs; `EvpnRoute` + `EvpnPrefix` variants ordered to keep the derived `Ord` numeric (1 < 2 < 3 < 4 < 5 …); `route_type`/`from_route`/`Display`; parse/emit. The two enum-only stubs are now fully implemented. Round-trip + Display unit tests. Covered the EVPN Display matches in `mp_reach.rs` / `mp_unreach.rs`.

### ESI Label EC (`ext_com.rs`)
- `EsiLabelEc` (`0x06`/`0x01`): single-active flag + 3-octet ESI label; `esi_label()` constructor, `is_/as_esi_label()`, `From` impl, Display, test.

### RIB-generic plumbing (`route.rs`, `marshal.rs`)
- Type 1/4 are stored, best-path-selected, **reflected**, and displayed; the Type-1 label is stamped on receive so reflection stays faithful. All exhaustive `EvpnRoute`/`EvpnPrefix` matches updated; export is a **control-plane no-op** (like the RFC 9572 A-D routes).

### Show + YANG (`show.rs`, `exec.yang`)
- `show bgp evpn route-type ethernet-ad|ethernet-segment` filters; `esi-label:` EC rendering; **fixed the pre-existing wrong Type-1 legend** (`[1]:[EthTag]:[ESI]:…` → the correct `[1]:[ESI]:[EthTag]`); YANG enum values.

## Test plan
- `cargo fmt --check`, `cargo build`, `cargo clippy --workspace --all-targets -- -D warnings`: clean
- `cargo test -p bgp-packet`: 364 pass (incl. 7 new codec/EC tests); `cargo test -p zebra-rs`: 1463 pass

Generated with [Claude Code](https://claude.com/claude-code)