### PR TITLE
bgp-evpn: ethernet-segment config + per-ES state

### DIFF
--- a/crates/bgp-packet/src/attrs/nlri_evpn.rs
+++ b/crates/bgp-packet/src/attrs/nlri_evpn.rs
@@ -703,6 +703,21 @@ pub fn esi_display(esi: &[u8; 10]) -> String {
         .join(":")
 }
 
+/// Parse a 10-octet Ethernet Segment Identifier from colon-hex
+/// (`00:11:…:99`) or 20 bare hex digits. Returns `None` on any other length
+/// or a non-hex digit. The inverse of [`esi_display`].
+pub fn esi_from_str(s: &str) -> Option<[u8; 10]> {
+    let hex: String = s.chars().filter(|c| *c != ':').collect();
+    if hex.len() != 20 {
+        return None;
+    }
+    let mut esi = [0u8; 10];
+    for (i, byte) in esi.iter_mut().enumerate() {
+        *byte = u8::from_str_radix(&hex[i * 2..i * 2 + 2], 16).ok()?;
+    }
+    Some(esi)
+}
+
 /// Shared `Display` body for the IGMP/MLD Join (Type 7) and Leave (Type 8)
 /// Synch route keys, which differ only in the leading route-type number:
 /// `[<rt>]:[<ESI>]:[EthTag]:[SrcLen]:[Src]:[GrpLen]:[Grp]:[OrigLen]:[Orig]`.
@@ -1381,6 +1396,18 @@ mod evpn_prefix_tests {
             "[4]:[00:11:22:33:44:55:66:77:88:99]:[32]:[10.0.0.1]"
         );
         assert_eq!(es.route_type(), 4);
+    }
+
+    #[test]
+    fn esi_from_str_parses_and_round_trips() {
+        let want = [0x00, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88, 0x99];
+        assert_eq!(esi_from_str("00:11:22:33:44:55:66:77:88:99"), Some(want));
+        assert_eq!(esi_from_str("00112233445566778899"), Some(want));
+        // Round-trips with esi_display.
+        assert_eq!(esi_from_str(&esi_display(&want)), Some(want));
+        // Wrong length / non-hex rejected.
+        assert_eq!(esi_from_str("00:11:22"), None);
+        assert_eq!(esi_from_str("zz112233445566778899"), None);
     }
 
     #[test]

--- a/zebra-rs/src/bgp/config.rs
+++ b/zebra-rs/src/bgp/config.rs
@@ -1685,6 +1685,85 @@ fn config_igmp_mld_proxy(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Option<
     Some(())
 }
 
+/// `router bgp afi-safi evpn ethernet-segment <name>` (RFC 7432) — create or
+/// delete a locally-configured Ethernet Segment. Config + state only in this
+/// phase; Type-4 discovery and DF election land later.
+fn config_ethernet_segment(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Option<()> {
+    let afi_safi: AfiSafi = args.afi_safi()?;
+    if afi_safi.afi != Afi::L2vpn || afi_safi.safi != Safi::Evpn {
+        return None;
+    }
+    let name = args.string()?;
+    match op {
+        ConfigOp::Set => {
+            bgp.ethernet_segments.entry(name).or_default();
+        }
+        ConfigOp::Delete => {
+            bgp.ethernet_segments.remove(&name);
+        }
+        _ => {}
+    }
+    Some(())
+}
+
+/// `router bgp afi-safi evpn ethernet-segment <name> esi <value>` — the
+/// 10-octet ESI (colon-hex or 20 hex digits). A malformed value is rejected.
+fn config_ethernet_segment_esi(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Option<()> {
+    let afi_safi: AfiSafi = args.afi_safi()?;
+    if afi_safi.afi != Afi::L2vpn || afi_safi.safi != Safi::Evpn {
+        return None;
+    }
+    let name = args.string()?;
+    let esi = if op.is_set() {
+        Some(bgp_packet::esi_from_str(&args.string()?)?)
+    } else {
+        None
+    };
+    bgp.ethernet_segments.entry(name).or_default().esi = esi;
+    Some(())
+}
+
+/// `router bgp afi-safi evpn ethernet-segment <name> redundancy-mode
+/// <all-active|single-active>` (default all-active).
+fn config_ethernet_segment_redundancy_mode(
+    bgp: &mut Bgp,
+    mut args: Args,
+    op: ConfigOp,
+) -> Option<()> {
+    let afi_safi: AfiSafi = args.afi_safi()?;
+    if afi_safi.afi != Afi::L2vpn || afi_safi.safi != Safi::Evpn {
+        return None;
+    }
+    let name = args.string()?;
+    let mode = if op.is_set() {
+        super::ethernet_segment::EsRedundancyMode::from_keyword(&args.string()?)
+    } else {
+        super::ethernet_segment::EsRedundancyMode::default()
+    };
+    bgp.ethernet_segments
+        .entry(name)
+        .or_default()
+        .redundancy_mode = mode;
+    Some(())
+}
+
+/// `router bgp afi-safi evpn ethernet-segment <name> interface <name>` — the
+/// CE-facing access port bound to this ES.
+fn config_ethernet_segment_interface(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Option<()> {
+    let afi_safi: AfiSafi = args.afi_safi()?;
+    if afi_safi.afi != Afi::L2vpn || afi_safi.safi != Safi::Evpn {
+        return None;
+    }
+    let name = args.string()?;
+    let interface = if op.is_set() {
+        Some(args.string()?)
+    } else {
+        None
+    };
+    bgp.ethernet_segments.entry(name).or_default().interface = interface;
+    Some(())
+}
+
 /// `router bgp afi-safi evpn segmentation <bool>` (RFC 9572 §8). When
 /// enabled, the Multicast Flags Extended Community's segmentation-support
 /// bit (bit 8) is attached to every originated Type-3 IMET route, telling
@@ -4213,6 +4292,26 @@ impl Bgp {
         // `router bgp afi-safi evpn segmentation`. When set, the Multicast
         // Flags EC's segmentation bit rides the originated Type-3 IMET route.
         self.callback_add("/router/bgp/afi-safi/segmentation", config_segmentation);
+
+        // EVPN Ethernet Segment (RFC 7432), under
+        // `router bgp afi-safi evpn ethernet-segment <name> …`. Augmented in
+        // by zebra-bgp-evpn.yang. Config + state only in this phase.
+        self.callback_add(
+            "/router/bgp/afi-safi/ethernet-segment",
+            config_ethernet_segment,
+        );
+        self.callback_add(
+            "/router/bgp/afi-safi/ethernet-segment/esi",
+            config_ethernet_segment_esi,
+        );
+        self.callback_add(
+            "/router/bgp/afi-safi/ethernet-segment/redundancy-mode",
+            config_ethernet_segment_redundancy_mode,
+        );
+        self.callback_add(
+            "/router/bgp/afi-safi/ethernet-segment/interface",
+            config_ethernet_segment_interface,
+        );
 
         // MUP controller (`router bgp mup-c …`, RFC 9833).
         // Augmented in by zebra-bgp-mup-controller.yang; the controller

--- a/zebra-rs/src/bgp/ethernet_segment.rs
+++ b/zebra-rs/src/bgp/ethernet_segment.rs
@@ -1,0 +1,106 @@
+//! EVPN Ethernet Segment (RFC 7432) configuration state.
+//!
+//! Phase 2 of the ES foundation (see `docs/design/bgp-evpn-ethernet-segment.md`):
+//! the `router bgp afi-safi evpn ethernet-segment <name>` config surface and
+//! the per-ES state it populates. No routes / DF election / data plane yet —
+//! those are later phases. The config handlers live in `config.rs` alongside
+//! the other EVPN afi-safi knobs; this module owns the state types.
+
+use bgp_packet::ExtCommunityValue;
+
+/// All-active vs single-active multihoming redundancy mode (RFC 7432 §14.1).
+/// Carried in the ESI Label EC's flag on the per-ES A-D route.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub enum EsRedundancyMode {
+    /// All PEs on the ES forward to/from the CE (load-balanced, RFC 7432).
+    /// The default and the common data-center case.
+    #[default]
+    AllActive,
+    /// Exactly one PE (the DF) forwards per service; the rest are backup.
+    SingleActive,
+}
+
+impl EsRedundancyMode {
+    /// Parse the YANG `redundancy-mode` enum keyword (defaults to all-active).
+    pub fn from_keyword(s: &str) -> Self {
+        match s {
+            "single-active" => EsRedundancyMode::SingleActive,
+            _ => EsRedundancyMode::AllActive,
+        }
+    }
+
+    /// The YANG keyword for this mode.
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            EsRedundancyMode::AllActive => "all-active",
+            EsRedundancyMode::SingleActive => "single-active",
+        }
+    }
+}
+
+/// A locally-configured Ethernet Segment: an ESI, a redundancy mode, and the
+/// access interface it is bound to. Keyed by an operator-chosen name in
+/// `Bgp::ethernet_segments`. DF state and the per-ES PE membership set are
+/// added in later phases (Type-4 discovery + DF election).
+#[derive(Debug, Clone, Default)]
+pub struct EthernetSegment {
+    /// 10-octet ESI (manual Type-0 in this phase). `None` until configured.
+    pub esi: Option<[u8; 10]>,
+    /// All-active (default) or single-active.
+    pub redundancy_mode: EsRedundancyMode,
+    /// Access interface bound to this ES (the multihomed CE-facing port).
+    pub interface: Option<String>,
+}
+
+impl EthernetSegment {
+    /// Auto-derive the ES-Import Route Target (RFC 7432 §7.6) from the ESI —
+    /// the high-order 6 octets of the ESI value. `None` until the ESI is set.
+    /// Used (in a later phase) to scope the Type-4 ES route to the PEs on this
+    /// segment.
+    pub fn es_import_rt(&self) -> Option<ExtCommunityValue> {
+        self.esi.map(|esi| ExtCommunityValue::es_import_rt(&esi))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn redundancy_mode_keyword_round_trip() {
+        assert_eq!(
+            EsRedundancyMode::from_keyword("single-active"),
+            EsRedundancyMode::SingleActive
+        );
+        assert_eq!(
+            EsRedundancyMode::from_keyword("all-active"),
+            EsRedundancyMode::AllActive
+        );
+        // Default / unknown keyword falls back to all-active.
+        assert_eq!(
+            EsRedundancyMode::from_keyword("bogus"),
+            EsRedundancyMode::AllActive
+        );
+        assert_eq!(EsRedundancyMode::default(), EsRedundancyMode::AllActive);
+        assert_eq!(EsRedundancyMode::SingleActive.as_str(), "single-active");
+    }
+
+    #[test]
+    fn es_import_rt_derives_from_esi() {
+        // No ESI yet → no RT.
+        let es = EthernetSegment::default();
+        assert!(es.es_import_rt().is_none());
+        // ESI set → ES-Import RT auto-derived from the high-order 6 octets of
+        // the ESI value (esi[1..7]).
+        let es = EthernetSegment {
+            esi: Some([0x00, 0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff, 0x01, 0x02, 0x03]),
+            ..Default::default()
+        };
+        let rt = es.es_import_rt().expect("RT derived");
+        assert!(rt.is_es_import_rt());
+        assert_eq!(
+            rt.as_es_import_rt(),
+            Some([0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff])
+        );
+    }
+}

--- a/zebra-rs/src/bgp/inst.rs
+++ b/zebra-rs/src/bgp/inst.rs
@@ -723,6 +723,11 @@ pub struct Bgp {
     /// Type-6 (SMET) origination and replays on `igmp_mld_proxy`
     /// transitions, mirroring `local_vxlans`/`local_fdb`.
     pub local_smet: BTreeMap<(u32, std::net::IpAddr, Option<std::net::IpAddr>), std::net::IpAddr>,
+    /// Locally-configured EVPN Ethernet Segments (RFC 7432) keyed by the
+    /// operator-chosen name, from `router bgp afi-safi evpn ethernet-segment`.
+    /// Config + state only in this phase — Type-4 discovery and DF election
+    /// are later phases.
+    pub ethernet_segments: BTreeMap<String, super::ethernet_segment::EthernetSegment>,
     /// Configured hostname for the local BGP speaker. Advertised in
     /// the FQDN capability (capability code 73). When None, falls back
     /// to the OS hostname; if that also fails, no FQDN capability is
@@ -1141,6 +1146,7 @@ impl Bgp {
             local_fdb: BTreeMap::new(),
             local_vxlans: BTreeMap::new(),
             local_smet: BTreeMap::new(),
+            ethernet_segments: BTreeMap::new(),
             hostname: None,
             no_fib_install: false,
             peers: PeerMap::new(),

--- a/zebra-rs/src/bgp/mod.rs
+++ b/zebra-rs/src/bgp/mod.rs
@@ -8,6 +8,7 @@ pub mod auth;
 pub mod config;
 pub mod connected;
 pub mod dynamic_neighbors;
+pub mod ethernet_segment;
 pub mod group_egress;
 pub mod interface_addrs;
 pub mod interface_neighbor;

--- a/zebra-rs/src/bgp/route.rs
+++ b/zebra-rs/src/bgp/route.rs
@@ -14769,17 +14769,9 @@ fn parse_igmp_sync_spec(spec: &str) -> Option<(u32, [u8; 10], IpAddr, Option<IpA
 }
 
 /// Decode a 10-octet ESI from colon-hex (`00:01:…:09`) or 20 bare hex
-/// digits. Colons are stripped; any other length or non-hex digit fails.
+/// digits — delegates to the shared `bgp_packet::esi_from_str`.
 fn parse_esi(s: &str) -> Option<[u8; 10]> {
-    let hex: String = s.chars().filter(|c| *c != ':').collect();
-    if hex.len() != 20 {
-        return None;
-    }
-    let mut esi = [0u8; 10];
-    for (i, byte) in esi.iter_mut().enumerate() {
-        *byte = u8::from_str_radix(&hex[i * 2..i * 2 + 2], 16).ok()?;
-    }
-    Some(esi)
+    bgp_packet::esi_from_str(s)
 }
 
 #[cfg(test)]

--- a/zebra-rs/src/bgp/show.rs
+++ b/zebra-rs/src/bgp/show.rs
@@ -2049,6 +2049,38 @@ pub(super) fn render_summary_with_counts<V: BgpShowView>(
 }
 
 /// `show bgp evpn summary` — the L2VPN/EVPN section only.
+/// `show bgp evpn ethernet-segment` — the locally-configured EVPN Ethernet
+/// Segments (RFC 7432): name, ESI, redundancy mode, access interface, and the
+/// auto-derived ES-Import RT. Config + state only in this phase (DF state and
+/// the per-ES PE membership set arrive with Type-4 discovery / DF election).
+fn show_bgp_evpn_ethernet_segment(
+    bgp: &Bgp,
+    _args: Args,
+    _json: bool,
+) -> std::result::Result<String, std::fmt::Error> {
+    use std::fmt::Write;
+    let mut buf = String::new();
+    if bgp.ethernet_segments.is_empty() {
+        writeln!(buf, "No EVPN Ethernet Segments configured")?;
+        return Ok(buf);
+    }
+    for (name, es) in bgp.ethernet_segments.iter() {
+        writeln!(buf, "Ethernet Segment: {name}")?;
+        match es.esi {
+            Some(esi) => writeln!(buf, "  ESI: {}", bgp_packet::esi_display(&esi))?,
+            None => writeln!(buf, "  ESI: (unset)")?,
+        }
+        writeln!(buf, "  Redundancy mode: {}", es.redundancy_mode.as_str())?;
+        if let Some(ifname) = &es.interface {
+            writeln!(buf, "  Interface: {ifname}")?;
+        }
+        if let Some(rt) = es.es_import_rt() {
+            writeln!(buf, "  ES-Import RT: {}", format_evpn_ecom_value(&rt))?;
+        }
+    }
+    Ok(buf)
+}
+
 fn show_bgp_evpn_summary(
     bgp: &Bgp,
     _args: Args,
@@ -5967,6 +5999,8 @@ impl Bgp {
             .set(show_bgp_evpn)
             .path("/show/bgp/evpn/route-type")
             .set(show_bgp_evpn)
+            .path("/show/bgp/evpn/ethernet-segment")
+            .set(show_bgp_evpn_ethernet_segment)
             .path("/show/bgp/mup")
             .set(show_bgp_mup)
             .path("/show/bgp/mup/summary")

--- a/zebra-rs/src/config/manager.rs
+++ b/zebra-rs/src/config/manager.rs
@@ -2984,6 +2984,41 @@ mod yang_load_tests {
         }
     }
 
+    /// The RFC 7432 Ethernet Segment config surface
+    /// (`router bgp afi-safi evpn ethernet-segment <name> …`,
+    /// zebra-bgp-evpn.yang). Guards the hand-written list-under-afi-safi
+    /// grammar so a regression is caught in the unit suite.
+    #[test]
+    fn bgp_evpn_ethernet_segment_is_settable() {
+        use crate::config::ExecCode;
+        use crate::config::parse::{State, parse};
+        use libyang::to_entry;
+
+        let mut yang = YangStore::new();
+        yang.add_path(concat!(env!("CARGO_MANIFEST_DIR"), "/yang"));
+        yang.read_with_resolve("configure")
+            .expect("configure mode loads");
+        yang.identity_resolve();
+        let module = yang
+            .find_module("configure")
+            .expect("configure module present");
+        let entry = to_entry(&yang, module);
+
+        // Only `set` paths are schema-validated here: delete-mode parsing
+        // matches against the live config (empty in this test), so deleting a
+        // non-existent entry is correctly Nomatch.
+        for path in [
+            "set router bgp afi-safi evpn ethernet-segment es1",
+            "set router bgp afi-safi evpn ethernet-segment es1 esi 00:11:22:33:44:55:66:77:88:99",
+            "set router bgp afi-safi evpn ethernet-segment es1 redundancy-mode all-active",
+            "set router bgp afi-safi evpn ethernet-segment es1 redundancy-mode single-active",
+            "set router bgp afi-safi evpn ethernet-segment es1 interface eth0",
+        ] {
+            let (code, _comps, _state) = parse(path, entry.clone(), None, State::new());
+            assert_eq!(code, ExecCode::Success, "`{path}` must be a settable path");
+        }
+    }
+
     #[test]
     fn bgp_evpn_segmentation_is_settable() {
         use crate::config::ExecCode;

--- a/zebra-rs/yang/exec.yang
+++ b/zebra-rs/yang/exec.yang
@@ -341,6 +341,10 @@ module exec {
           ext:help "Summary of EVPN-enabled neighbors";
           type empty;
         }
+        leaf ethernet-segment {
+          ext:help "Locally-configured EVPN Ethernet Segments (RFC 7432)";
+          type empty;
+        }
         leaf route-type {
           ext:help "Filter the EVPN RIB by route type";
           // ethernet-ad=1, macip=2, multicast=3, ethernet-segment=4,

--- a/zebra-rs/yang/zebra-bgp-evpn.yang
+++ b/zebra-rs/yang/zebra-bgp-evpn.yang
@@ -100,6 +100,44 @@ module zebra-bgp-evpn {
          route. Tells peers and Regional Border Routers that this PE
          supports the RFC 9572 segmentation procedures.";
     }
+    list ethernet-segment {
+      key "name";
+      description
+        "EVPN Ethernet Segment (RFC 7432) — a CE multihomed to two or more
+         PEs. Identified to the overlay by a 10-octet ESI; the PEs on the
+         same ES discover one another (Type-4 route + ES-Import RT) and run
+         Designated-Forwarder election. Config + state only in this phase;
+         Type-1/4 origination and DF election are later phases.";
+      leaf name {
+        type string;
+        description "Operator-chosen Ethernet Segment name (the list key).";
+      }
+      leaf esi {
+        type string;
+        description
+          "10-octet Ethernet Segment Identifier, colon-hex (00:11:..:99) or
+           20 bare hex digits. Manual Type-0 ESI in this phase.";
+      }
+      leaf redundancy-mode {
+        type enumeration {
+          enum all-active {
+            description
+              "All PEs on the ES forward to/from the CE (load-balanced).";
+          }
+          enum single-active {
+            description
+              "Only the Designated Forwarder forwards per service; the rest
+               are backup.";
+          }
+        }
+        default all-active;
+        description "All-active (default) or single-active multihoming.";
+      }
+      leaf interface {
+        type string;
+        description "Access interface (CE-facing port) bound to this ES.";
+      }
+    }
     leaf bum-tunnel-type {
       type enumeration {
         enum ingress-replication {


### PR DESCRIPTION
## Summary

**Phase 2** of the EVPN Ethernet Segment foundation (RFC 7432; design: `docs/design/bgp-evpn-ethernet-segment.md`, #1633). The `router bgp afi-safi evpn ethernet-segment <name>` config surface and the per-ES state it populates. **Config + state only** — no routes, DF election, or data plane yet (Phases 3–6).

### YANG + config (`zebra-bgp-evpn.yang`, `config.rs`)
- `list ethernet-segment { key name; leaf esi; leaf redundancy-mode (all-active|single-active, default all-active); leaf interface }` — the first nested list under the afi-safi grouping.
- Four config handlers (gated on afi-safi evpn) populating/removing the per-ES map; a malformed ESI string is rejected.

### State (new `bgp/ethernet_segment.rs`, `inst.rs`)
- `EthernetSegment { esi, redundancy_mode, interface }` + `EsRedundancyMode` enum + `es_import_rt()` auto-derivation (RFC 7432 §7.6); `Bgp.ethernet_segments`.

### Show (`show.rs`, `exec.yang`)
- `show bgp evpn ethernet-segment` renders name, ESI, redundancy mode, interface, and the derived ES-Import RT.

### Shared ESI parser (`nlri_evpn.rs`)
- Added `bgp_packet::esi_from_str` (next to `esi_display`) and deduped route.rs's private `parse_esi` to delegate.

## Test plan
- `cargo fmt`, build, `cargo clippy --workspace --all-targets -- -D warnings`: clean
- `cargo test -p bgp-packet`: 365 pass; `cargo test -p zebra-rs`: 1466 pass — incl. a deterministic `ethernet-segment` settable grammar test, `esi_from_str` round-trip, and ES-state tests (`es_import_rt` derivation, redundancy-mode parsing)

Generated with [Claude Code](https://claude.com/claude-code)