### PR TITLE
bgp-evpn: Type-4 ES route discovery + membership

### DIFF
--- a/bdd/tests/configs/bgp_evpn_es/z1-1.yaml
+++ b/bdd/tests/configs/bgp_evpn_es/z1-1.yaml
@@ -1,0 +1,24 @@
+# z1 — EVPN multihoming (RFC 7432). Configures Ethernet Segment es1 with a
+# shared ESI; originates a Type-4 ES route and discovers z2 (the other PE on
+# the same ES) from z2's Type-4. Control-plane only — no VXLAN dataplane is
+# needed for ES discovery.
+router:
+  bgp:
+    global:
+      as: 65001
+      router-id: 192.168.0.1
+    afi-safi:
+    - name: evpn
+      ethernet-segment:
+      - name: es1
+        esi: "00:11:22:33:44:55:66:77:88:99"
+        redundancy-mode: all-active
+    neighbor:
+    - remote-address: 192.168.0.2
+      enabled: true
+      remote-as: 65001
+      afi-safi:
+      - name: ipv4
+        enabled: true
+      - name: evpn
+        enabled: true

--- a/bdd/tests/configs/bgp_evpn_es/z2-1.yaml
+++ b/bdd/tests/configs/bgp_evpn_es/z2-1.yaml
@@ -1,0 +1,23 @@
+# z2 — EVPN multihoming (RFC 7432). The second PE on Ethernet Segment es1,
+# sharing the SAME ESI as z1 (the defining property of an ES). Originates its
+# own Type-4 and discovers z1.
+router:
+  bgp:
+    global:
+      as: 65001
+      router-id: 192.168.0.2
+    afi-safi:
+    - name: evpn
+      ethernet-segment:
+      - name: es1
+        esi: "00:11:22:33:44:55:66:77:88:99"
+        redundancy-mode: all-active
+    neighbor:
+    - remote-address: 192.168.0.1
+      enabled: true
+      remote-as: 65001
+      afi-safi:
+      - name: ipv4
+        enabled: true
+      - name: evpn
+        enabled: true

--- a/bdd/tests/configs/bgp_evpn_es/z2-noes.yaml
+++ b/bdd/tests/configs/bgp_evpn_es/z2-noes.yaml
@@ -1,0 +1,18 @@
+# z2 — same as z2-1.yaml but with the ethernet-segment removed. Applying this
+# diffs out es1, so z2 withdraws its Type-4 ES route from z1.
+router:
+  bgp:
+    global:
+      as: 65001
+      router-id: 192.168.0.2
+    afi-safi:
+    - name: evpn
+    neighbor:
+    - remote-address: 192.168.0.1
+      enabled: true
+      remote-as: 65001
+      afi-safi:
+      - name: ipv4
+        enabled: true
+      - name: evpn
+        enabled: true

--- a/bdd/tests/features/bgp_evpn_es.feature
+++ b/bdd/tests/features/bgp_evpn_es.feature
@@ -1,0 +1,69 @@
+@serial
+@bgp_evpn_es
+Feature: BGP EVPN Ethernet Segment discovery (RFC 7432 Type-4)
+  As a network operator
+  I want each PE attached to a multihomed Ethernet Segment to advertise a
+  Type-4 Ethernet Segment route (carrying the auto-derived ES-Import RT and a
+  DF Election EC) and to discover the other PEs on the same ES, so the
+  control-plane foundation for DF election and all-active multihoming is in
+  place. (DF election itself and the data plane are later phases.)
+
+  Test Topology — two iBGP (AS 65001) EVPN speakers on a shared transport
+  bridge br0, both configured with the SAME Ethernet Segment es1 / ESI (the
+  defining property of an ES — the shared CE looks identical to both PEs):
+  ```
+  ┌─────────────────────────────────┐
+  │               br0               │
+  └───────┬─────────────────┬───────┘
+     ┌────┴────┐       ┌────┴────┐
+     │   z1    │       │   z2    │   both: ethernet-segment es1
+     │ .0.1/24 │       │ .0.2/24 │   esi 00:11:..:99
+     └─────────┘       └─────────┘
+  ```
+
+  Scenario: Setup topology and EVPN iBGP with a shared Ethernet Segment
+    Given a clean test environment
+    When I create bridge "br0"
+    And I create namespace "z1" with IP "192.168.0.1/24" on bridge "br0"
+    And I create namespace "z2" with IP "192.168.0.2/24" on bridge "br0"
+    And I start zebra-rs in namespace "z1"
+    And I start zebra-rs in namespace "z2"
+    And I apply config "z1-1.yaml" to namespace "z1"
+    And I apply config "z2-1.yaml" to namespace "z2"
+    And I wait 10 seconds for BGP to operate
+    Then BGP session in "z1" to "192.168.0.2" should be "Established"
+
+  Scenario: Each PE originates a Type-4 ES route the other imports
+    Given the test topology exists
+    # z1 sees z2's Type-4 in the EVPN RIB: [4]:[ESI]:[IPlen]:[OrigIP=z2].
+    Then show command "show bgp evpn" in namespace "z1" should eventually contain "[4]:[00:11:22:33:44:55:66:77:88:99]:[32]:[192.168.0.2]"
+    # The Type-4 carries the auto-derived ES-Import RT (from ESI octets 1..7).
+    And show command "show bgp evpn" in namespace "z1" should eventually contain "es-import:11:22:33:44:55:66"
+    # ... and a default-algorithm DF Election EC (RFC 8584).
+    And show command "show bgp evpn" in namespace "z1" should eventually contain "df-election:alg0"
+    # z2 symmetrically sees z1's Type-4.
+    And show command "show bgp evpn" in namespace "z2" should eventually contain "[4]:[00:11:22:33:44:55:66:77:88:99]:[32]:[192.168.0.1]"
+
+  Scenario: ES membership shows both PEs on z1
+    Given the test topology exists
+    # z1's ethernet-segment view lists both VTEPs (its own + z2's), keyed by
+    # the shared ESI, with the local one tagged.
+    Then show command "show bgp evpn ethernet-segment" in namespace "z1" should eventually contain "ESI: 00:11:22:33:44:55:66:77:88:99"
+    And show command "show bgp evpn ethernet-segment" in namespace "z1" should eventually contain "Member VTEPs (2)"
+    And show command "show bgp evpn ethernet-segment" in namespace "z1" should contain "192.168.0.1 (local)"
+    And show command "show bgp evpn ethernet-segment" in namespace "z1" should contain "192.168.0.2"
+
+  Scenario: Removing the ES on z2 withdraws its Type-4 from z1
+    Given the test topology exists
+    When I apply config "z2-noes.yaml" to namespace "z2"
+    Then show command "show bgp evpn" in namespace "z1" should eventually not contain "[4]:[00:11:22:33:44:55:66:77:88:99]:[32]:[192.168.0.2]"
+    And show command "show bgp evpn ethernet-segment" in namespace "z1" should eventually contain "Member VTEPs (1)"
+
+  Scenario: Teardown topology
+    Given the test topology exists
+    When I stop zebra-rs in namespace "z1"
+    And I stop zebra-rs in namespace "z2"
+    And I delete namespace "z1"
+    And I delete namespace "z2"
+    And I delete bridge "br0"
+    Then the test environment should be clean

--- a/zebra-rs/src/bgp/config.rs
+++ b/zebra-rs/src/bgp/config.rs
@@ -1686,8 +1686,8 @@ fn config_igmp_mld_proxy(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Option<
 }
 
 /// `router bgp afi-safi evpn ethernet-segment <name>` (RFC 7432) — create or
-/// delete a locally-configured Ethernet Segment. Config + state only in this
-/// phase; Type-4 discovery and DF election land later.
+/// delete a locally-configured Ethernet Segment. Deleting an ES that had an
+/// ESI withdraws its Type-4 route.
 fn config_ethernet_segment(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Option<()> {
     let afi_safi: AfiSafi = args.afi_safi()?;
     if afi_safi.afi != Afi::L2vpn || afi_safi.safi != Safi::Evpn {
@@ -1699,6 +1699,10 @@ fn config_ethernet_segment(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Optio
             bgp.ethernet_segments.entry(name).or_default();
         }
         ConfigOp::Delete => {
+            let vtep = IpAddr::V4(bgp.router_id);
+            if let Some(esi) = bgp.ethernet_segments.get(&name).and_then(|es| es.esi) {
+                bgp.evpn_withdraw_ethernet_seg(esi, vtep);
+            }
             bgp.ethernet_segments.remove(&name);
         }
         _ => {}
@@ -1708,18 +1712,29 @@ fn config_ethernet_segment(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Optio
 
 /// `router bgp afi-safi evpn ethernet-segment <name> esi <value>` — the
 /// 10-octet ESI (colon-hex or 20 hex digits). A malformed value is rejected.
+/// Setting the ESI originates the Type-4 ES route (RFC 7432 §7.4); changing or
+/// clearing it withdraws the previous one first.
 fn config_ethernet_segment_esi(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Option<()> {
     let afi_safi: AfiSafi = args.afi_safi()?;
     if afi_safi.afi != Afi::L2vpn || afi_safi.safi != Safi::Evpn {
         return None;
     }
     let name = args.string()?;
-    let esi = if op.is_set() {
+    let new_esi = if op.is_set() {
         Some(bgp_packet::esi_from_str(&args.string()?)?)
     } else {
         None
     };
-    bgp.ethernet_segments.entry(name).or_default().esi = esi;
+    let vtep = IpAddr::V4(bgp.router_id);
+    // Withdraw the Type-4 for the previously-configured ESI (if any), then set
+    // the new one and originate.
+    if let Some(old) = bgp.ethernet_segments.get(&name).and_then(|es| es.esi) {
+        bgp.evpn_withdraw_ethernet_seg(old, vtep);
+    }
+    bgp.ethernet_segments.entry(name).or_default().esi = new_esi;
+    if let Some(esi) = new_esi {
+        bgp.evpn_originate_ethernet_seg(esi, vtep);
+    }
     Some(())
 }
 

--- a/zebra-rs/src/bgp/inst.rs
+++ b/zebra-rs/src/bgp/inst.rs
@@ -1678,6 +1678,21 @@ impl Bgp {
             }
         }
 
+        // RFC 7432 Type-4 ES routes are keyed by the <router-id>:0 RD and the
+        // router-id Originator; a router-id change rebinds both. Withdraw the
+        // old-keyed Type-4 for every configured ES — independent of
+        // advertise-all-vni (ES origination gates only on the router-id).
+        if !old_router_id.is_unspecified() {
+            let esis: Vec<[u8; 10]> = self
+                .ethernet_segments
+                .values()
+                .filter_map(|es| es.esi)
+                .collect();
+            for esi in esis {
+                self.evpn_withdraw_ethernet_seg(esi, std::net::IpAddr::V4(old_router_id));
+            }
+        }
+
         self.router_id = router_id;
         for (_, peer) in self.peers.iter_mut_all() {
             peer.router_id = router_id;
@@ -1701,6 +1716,19 @@ impl Bgp {
                 for (vni, vtep_local) in vxlans {
                     self.evpn_originate_imet(vni, vtep_local);
                 }
+            }
+        }
+
+        // Re-originate the Type-4 ES routes under the new router-id (the
+        // inverse of the withdraw above; gated only on a valid router-id).
+        if !router_id.is_unspecified() {
+            let esis: Vec<[u8; 10]> = self
+                .ethernet_segments
+                .values()
+                .filter_map(|es| es.esi)
+                .collect();
+            for esi in esis {
+                self.evpn_originate_ethernet_seg(esi, std::net::IpAddr::V4(router_id));
             }
         }
 

--- a/zebra-rs/src/bgp/route.rs
+++ b/zebra-rs/src/bgp/route.rs
@@ -14374,6 +14374,82 @@ impl Bgp {
         route_withdraw_evpn_to_peers(rd, prefix, &mut self.peers);
     }
 
+    /// Originate a Type-4 Ethernet Segment route (RFC 7432 §7.4) for a
+    /// locally-configured ES, so the PEs on the same segment discover one
+    /// another. Carries the auto-derived **ES-Import RT** (scopes distribution
+    /// to that ES) and a default-algorithm **DF Election EC** (RFC 8584).
+    /// Gated on a set router-id (the originating VTEP); RD is `<router-id>:0`,
+    /// the Originator is `vtep_local`. DF election itself is a later phase.
+    pub fn evpn_originate_ethernet_seg(&mut self, esi: [u8; 10], vtep_local: IpAddr) {
+        if self.router_id.is_unspecified() {
+            return;
+        }
+        let Some(rd) = rd_from_router_id_vni(self.router_id, 0) else {
+            return;
+        };
+        let prefix = EvpnPrefix::EthernetSeg {
+            esi,
+            orig: vtep_local,
+        };
+        let mut attr = BgpAttr::new();
+        let df = bgp_packet::DfElectionEc {
+            df_alg: bgp_packet::DfElectionEc::ALG_DEFAULT,
+            bitmap: 0,
+        };
+        attr.ecom = Some(ExtCommunity::from([
+            ExtCommunityValue::es_import_rt(&esi),
+            df.into(),
+        ]));
+        attr.nexthop = Some(BgpNexthop::Evpn(vtep_local));
+        let mut rib = BgpRib::new(
+            ORIGINATED_PEER,
+            Ipv4Addr::UNSPECIFIED,
+            BgpRibType::Originated,
+            0,
+            32768,
+            &attr,
+            None,
+            None,
+            false,
+        );
+        rib.esi = Some(esi);
+        self.evpn_originate_synch(rd, prefix, rib);
+    }
+
+    /// Inverse of `evpn_originate_ethernet_seg`. Not gated on the router-id so
+    /// a teardown always clears the route.
+    pub fn evpn_withdraw_ethernet_seg(&mut self, esi: [u8; 10], vtep_local: IpAddr) {
+        let Some(rd) = rd_from_router_id_vni(self.router_id, 0) else {
+            return;
+        };
+        let prefix = EvpnPrefix::EthernetSeg {
+            esi,
+            orig: vtep_local,
+        };
+        let _ = self.local_rib.remove_evpn(rd, &prefix, 0, ORIGINATED_PEER);
+        let _ = self.local_rib.select_best_path_evpn(&rd, &prefix);
+        route_withdraw_evpn_to_peers(rd, prefix, &mut self.peers);
+    }
+
+    /// The set of Originating Router IPs (VTEPs) that have advertised a Type-4
+    /// Ethernet Segment route for `esi` — the PE membership of the segment,
+    /// computed from the EVPN Loc-RIB (includes our own originated Type-4).
+    /// The ESI is in the Type-4 NLRI key, so membership matches on it directly
+    /// rather than on the ES-Import RT.
+    pub fn es_member_vteps(&self, esi: &[u8; 10]) -> std::collections::BTreeSet<IpAddr> {
+        let mut members = std::collections::BTreeSet::new();
+        for table in self.local_rib.evpn.values() {
+            for prefix in table.selected.keys() {
+                if let EvpnPrefix::EthernetSeg { esi: e, orig } = prefix
+                    && e == esi
+                {
+                    members.insert(*orig);
+                }
+            }
+        }
+        members
+    }
+
     /// Originate a Type-7 IGMP/MLD Join Synch route (RFC 9251 §9.2) for a
     /// membership snooped on the multihomed Ethernet Segment `esi`. Mirrors
     /// `evpn_originate_smet`, but the route is scoped to the ES: it carries an

--- a/zebra-rs/src/bgp/show.rs
+++ b/zebra-rs/src/bgp/show.rs
@@ -2064,6 +2064,7 @@ fn show_bgp_evpn_ethernet_segment(
         writeln!(buf, "No EVPN Ethernet Segments configured")?;
         return Ok(buf);
     }
+    let local = std::net::IpAddr::V4(bgp.router_id);
     for (name, es) in bgp.ethernet_segments.iter() {
         writeln!(buf, "Ethernet Segment: {name}")?;
         match es.esi {
@@ -2076,6 +2077,15 @@ fn show_bgp_evpn_ethernet_segment(
         }
         if let Some(rt) = es.es_import_rt() {
             writeln!(buf, "  ES-Import RT: {}", format_evpn_ecom_value(&rt))?;
+        }
+        // PE membership discovered from received (and our own) Type-4 routes.
+        if let Some(esi) = es.esi {
+            let members = bgp.es_member_vteps(&esi);
+            writeln!(buf, "  Member VTEPs ({}):", members.len())?;
+            for vtep in &members {
+                let tag = if *vtep == local { " (local)" } else { "" };
+                writeln!(buf, "    {vtep}{tag}")?;
+            }
         }
     }
     Ok(buf)


### PR DESCRIPTION
## Summary

**Phase 3** of the EVPN Ethernet Segment foundation (RFC 7432; design: `docs/design/bgp-evpn-ethernet-segment.md`, #1633). Each PE on a multihomed ES advertises a **Type-4 Ethernet Segment route** and **discovers the other PEs** on the same segment. DF election itself and the data plane are later phases.

### Origination (`route.rs`)
- `evpn_originate_ethernet_seg` / `evpn_withdraw_ethernet_seg` build the Type-4 (RD `<router-id>:0`, Originator = VTEP) with the auto-derived **ES-Import RT** (§7.6) + a default-algorithm **DF Election EC** (RFC 8584), reusing the generic advertise helper.
- `es_member_vteps` computes the per-ES PE membership from the EVPN Loc-RIB by matching the ESI in the Type-4 NLRI key (the ESI is authoritative for membership; the ES-Import RT is for distribution control).

### Config triggers + replay (`config.rs`, `inst.rs`)
- Setting/changing/clearing the ESI originates/withdraws the Type-4; deleting an ES withdraws it; `set_router_id` replays all ES Type-4s (the `<router-id>:0` RD rebinds on a router-id change, like the IMET replay).

### Show (`show.rs`)
- `show bgp evpn ethernet-segment` lists the discovered **Member VTEPs**, the local one tagged.

## Test plan
- `cargo fmt`, build, `cargo clippy --workspace --all-targets -- -D warnings`: clean
- `cargo test`: bgp-packet 365, zebra-rs 1466 pass
- **`@bgp_evpn_es` BDD: 5/5 scenarios pass** on live kernel namespaces — two PEs sharing an ESI each originate a Type-4, discover the other (`[4]:[ESI]:[32]:[peer]`, `es-import:11:22:33:44:55:66`, `df-election:alg0`), show `Member VTEPs (2)`, and drop to `(1)` when one PE removes its ES.

Generated with [Claude Code](https://claude.com/claude-code)