### PR TITLE
bgp-mup: nest mup-ext-comm under segment, explicit route st1/st2

### DIFF
--- a/bdd/tests/configs/bgp_mup_e2e/z1.yaml
+++ b/bdd/tests/configs/bgp_mup_e2e/z1.yaml
@@ -31,12 +31,11 @@ router:
     vrf:
     - name: mobile-up
       rd: "65000:100"
-      mup:
-        route:
-          st1:
-            dest-network-instance:
-              access:
-                exact: access
+      afi-safi:
+        mup:
+          route:
+          - type: st1
+            network-instance: access
     mup-c:
       enable: true
       controller-address: fcbb:bb01::1

--- a/bdd/tests/configs/bgp_mup_interwork/z1.yaml
+++ b/bdd/tests/configs/bgp_mup_interwork/z1.yaml
@@ -3,8 +3,8 @@
 #     segment direct`, `encapsulation srv6`) carrying the per-VRF End.DT46
 #     SID and the Direct-segment id (MUP Ext-Comm `1:2`), and
 #   * a Type-2 Session-Transformed (ST2) route from a PFCP session whose
-#     Network Instance is `core` (`afi-safi mup network-instance core`),
-#     carrying the same Direct-segment id `1:2`.
+#     Network Instance is `core` (`afi-safi mup route st2 network-instance
+#     core mup-ext-comm 1:2`), carrying the same Direct-segment id `1:2`.
 # IS-IS L2 SRv6 underlay + iBGP (mup afi-safi) to z2 (the interwork SRGW)
 # over loopbacks. z2 resolves the ST2 to this End.DT46 Direct segment.
 vrf:
@@ -66,9 +66,13 @@ router:
       encapsulation: srv6
       afi-safi:
         mup:
-          segment: direct
-          mup-ext-comm: "1:2"
-          network-instance: core
+          segment:
+          - type: direct
+            mup-ext-comm: "1:2"
+          route:
+          - type: st2
+            network-instance: core
+            mup-ext-comm: "1:2"
     mup-c:
       enable: true
       controller-address: 2001:db8::1

--- a/bdd/tests/configs/bgp_mup_mixed_afi/z1.yaml
+++ b/bdd/tests/configs/bgp_mup_mixed_afi/z1.yaml
@@ -30,12 +30,11 @@ router:
     vrf:
     - name: mobile-up
       rd: "65000:100"
-      mup:
-        route:
-          st1:
-            dest-network-instance:
-              access:
-                exact: access
+      afi-safi:
+        mup:
+          route:
+          - type: st1
+            network-instance: access
     mup-c:
       enable: true
       controller-address: fcbb:bb01::1

--- a/bdd/tests/configs/bgp_mup_segment_dsd/z1.yaml
+++ b/bdd/tests/configs/bgp_mup_segment_dsd/z1.yaml
@@ -64,5 +64,6 @@ router:
       encapsulation: srv6
       afi-safi:
         mup:
-          segment: direct
-          mup-ext-comm: "1:2"
+          segment:
+          - type: direct
+            mup-ext-comm: "1:2"

--- a/bdd/tests/configs/bgp_mup_st2/z1.yaml
+++ b/bdd/tests/configs/bgp_mup_st2/z1.yaml
@@ -3,8 +3,8 @@
 # decapsulation session. AS 65001, iBGP to z2 (192.168.0.2) with the mup
 # afi-safi negotiated; PFCP/N4 listener on 192.168.0.1:8805. When
 # pfcp-inject programs a session whose Network Instance is `core`, the VRF
-# `mobile-up` binds it to a Type-2 ST route (`mup route st2
-# dest-network-instance core`), so z1 originates the ST2 carrying the core
+# `mobile-up` binds it to a Type-2 ST route (`afi-safi mup route st2
+# network-instance core`), so z1 originates the ST2 carrying the core
 # endpoint + GTP TEID, the controller-address next hop, the export
 # route-target (65000:200) and the BGP MUP Extended Community (Direct
 # segment id `1:2`, type 0x0c / sub-type 0x00). The route is advertised to
@@ -39,9 +39,13 @@ router:
       rd: "65000:100"
       afi-safi:
         mup:
-          segment: direct
-          mup-ext-comm: "1:2"
-          network-instance: core
+          segment:
+          - type: direct
+            mup-ext-comm: "1:2"
+          route:
+          - type: st2
+            network-instance: core
+            mup-ext-comm: "1:2"
     mup-c:
       enable: true
       controller-address: fcbb:bb01::1

--- a/bdd/tests/features/bgp_mup_interwork.feature
+++ b/bdd/tests/features/bgp_mup_interwork.feature
@@ -21,10 +21,11 @@ Feature: BGP MUP interwork node resolves ST2 to the Direct segment
   ```
 
   z1 is a combined UPF + controller: VRF N6 (`encapsulation srv6`, rd
-  65501:10) with `afi-safi mup segment direct mup-ext-comm 1:2
-  network-instance core` originates a DSD (End.DT46 SID + Direct-segment id
-  1:2) and — when `pfcp-inject` programs a session on Network Instance
-  `core` — an ST2 (same id 1:2). z2 has `afi-safi mup segment interwork`,
+  65501:10) with `afi-safi mup segment direct mup-ext-comm 1:2` plus
+  `route st2 network-instance core mup-ext-comm 1:2` originates a DSD
+  (End.DT46 SID + Direct-segment id 1:2) and — when `pfcp-inject` programs
+  a session on Network Instance `core` — an ST2 (same id 1:2). z2 has
+  `afi-safi mup segment interwork`,
   receives both, and resolves the ST2 to z1's End.DT46 Direct segment.
 
   NOTE: needs `pfcp-inject` on the BDD host PATH (cargo build --release -p

--- a/bdd/tests/features/bgp_mup_st2.feature
+++ b/bdd/tests/features/bgp_mup_st2.feature
@@ -28,9 +28,10 @@ Feature: BGP MUP Controller originates a Type-2 ST route from a PFCP session
   ```
 
   z1 runs the controller (PFCP listener on 192.168.0.1:8805, locator LOC1,
-  VRF `mobile-up` with `afi-safi mup segment direct network-instance core`
-  binding Network Instance `core` to its Type-2 ST / Direct segment, and
-  carrying the Direct segment id `1:2`). `pfcp-inject` plays the SMF: it
+  VRF `mobile-up` with `afi-safi mup segment direct` plus `route st2
+  network-instance core` binding Network Instance `core` to its Type-2 ST /
+  Direct segment, and carrying the Direct segment id `1:2` on both the
+  segment and the st2 route). `pfcp-inject` plays the SMF: it
   sends an Association Setup + Session Establishment for endpoint 10.0.0.1 /
   TEID 0x12345678 (Network Instance `core`), so z1 originates the ST2 route
   and advertises it to z2.

--- a/docs/design/bgp-mup-followups.md
+++ b/docs/design/bgp-mup-followups.md
@@ -440,15 +440,23 @@ MUP Extended Community:
   the GoBGP byte-exact vectors. `build_mup_origination`
   (`zebra-rs/src/bgp/route.rs`).
 - **BGP MUP Extended Community** (transitive type `0x0c`, sub-type `0x00`
-  = Direct-Type Segment Identifier, §3.2). New per-VRF knob `router bgp
-  vrf <name> afi-safi mup segment direct mup-ext-comm <2:4>` (YANG leaf
-  `mup-ext-comm`, type `route-distinguisher`; `BgpVrfMobileUplane
-  .mup_ext_comm`). The 6-octet value reuses the RD/RT 2:4 wire layout. It
-  is attached to the **ST2** route the controller originates (§3.3.10 —
-  the Direct segment a receiving PE resolves against, §3.3.12) and to the
-  VRF's **DSD** route (it *is* that Direct segment). End.DT46 is the
-  forwarding behaviour both directions (RFC 9433), so no SID is carried —
-  the ext-comm is the correlation handle.
+  = Direct-Type Segment Identifier, §3.2). The 6-octet value reuses the
+  RD/RT 2:4 wire layout. It is declared independently on each side of the
+  service, so a split controller/PE can point an ST2 at a remote PE's
+  segment:
+  - **DSD side** — `router bgp vrf <name> afi-safi mup segment direct
+    mup-ext-comm <2:4>` (YANG leaf `mup-ext-comm` on the `segment` list
+    entry; `BgpVrfMobileUplane.mup_ext_comm`). The DSD route *is* that
+    Direct segment, so it advertises this as its own identifier.
+  - **ST2 side** — `router bgp vrf <name> afi-safi mup route st2
+    mup-ext-comm <2:4>` (YANG leaf `mup-ext-comm` on the `route` list
+    entry; `MupSrv6Mobile.mup_ext_comm`). Attached to the ST2 route the
+    controller originates (§3.3.10 — the Direct segment a receiving PE
+    resolves against, §3.3.12). In a collocated UPF+controller both carry
+    the same value.
+
+  End.DT46 is the forwarding behaviour both directions (RFC 9433), so no
+  SID is carried — the ext-comm is the correlation handle.
 - **Show.** `show bgp mup` / `show bgp vrf <name> mup` render the Direct
   segment id bare in the RD/RT 2:4 form on the ext-community line (e.g.
   `RT:65000:200 1:2`).
@@ -458,17 +466,20 @@ MUP Extended Community:
   `VrfRouteTargets`) never carried the RT — and would likewise miss a
   later `mup-ext-comm`. The skip now also compares the ext-community set,
   so an RT / segment-id change re-advertises under the stable key.
-- **Grammar simplification.** The ST2 (uplink) Network-Instance binding
-  moved off the nested `router bgp vrf <name> mup route st2
-  dest-network-instance core exact <ni>` onto a single
-  `router bgp vrf <name> afi-safi mup network-instance <ni>` leaf, next to
-  `segment direct` (the Direct segment the ST2 resolves to). It still maps
-  to the Decapsulation direction on `srv6_mobile`, so `build_mup_origination`
-  / `render_mup_vrfs` are unchanged. The downlink `mup route st1
-  dest-network-instance access exact <ni>` is unchanged; the `route st2`
-  sub-container was removed.
-- **Tests.** `@bgp_mup_st2` BDD (controller, `afi-safi mup segment direct
-  network-instance core`, drives `pfcp-inject` with a `core` Network
+- **Grammar — explicit symmetric ST routes.** Both Session-Transformed
+  bindings live under one collapsed enum-keyed list `router bgp vrf <name>
+  afi-safi mup route {st1|st2}` (YANG `list route { key type; }`), each
+  with a flat `network-instance <ni>` leaf, and `route st2` additionally a
+  `mup-ext-comm <2:4>`. st1 → Encapsulation (downlink / N6), st2 →
+  Decapsulation (uplink / N3); the list key maps to the direction on
+  `srv6_mobile`. This replaced both the bare `afi-safi mup
+  network-instance` leaf (the old st2 binding) and the nested vrf-level
+  `mup route st1 dest-network-instance access exact <ni>` container, so
+  st1 and st2 now read identically. `build_mup_origination` /
+  `render_mup_vrfs` consume the same `srv6_mobile` binding.
+- **Tests.** `@bgp_mup_st2` BDD (controller, `afi-safi mup segment direct`
+  + `route st2 network-instance core mup-ext-comm 1:2`, drives
+  `pfcp-inject` with a `core` Network
   Instance → ST2 with endpoint + TEID + Direct segment id, received by the
   peer); `@bgp_mup_segment_dsd` extended to assert the DSD carries
   `RT:65501:10 1:2`. Run live via `make -C bdd bgp_mup_st2` /

--- a/zebra-rs/src/bgp/config.rs
+++ b/zebra-rs/src/bgp/config.rs
@@ -4054,20 +4054,24 @@ impl Bgp {
             super::vrf_config::config_vrf_evpn_advertise_ipv6,
         );
         self.callback_add(
-            "/router/bgp/vrf/mup/route/st1/dest-network-instance/access/exact",
-            super::vrf_config::config_vrf_mup_route_st1,
-        );
-        self.callback_add(
             "/router/bgp/vrf/afi-safi/mup/segment",
             super::vrf_config::config_vrf_mup_segment,
         );
         self.callback_add(
-            "/router/bgp/vrf/afi-safi/mup/mup-ext-comm",
+            "/router/bgp/vrf/afi-safi/mup/segment/mup-ext-comm",
             super::vrf_config::config_vrf_mup_ext_comm,
         );
         self.callback_add(
-            "/router/bgp/vrf/afi-safi/mup/network-instance",
-            super::vrf_config::config_vrf_mup_network_instance,
+            "/router/bgp/vrf/afi-safi/mup/route",
+            super::vrf_config::config_vrf_mup_route,
+        );
+        self.callback_add(
+            "/router/bgp/vrf/afi-safi/mup/route/network-instance",
+            super::vrf_config::config_vrf_mup_route_network_instance,
+        );
+        self.callback_add(
+            "/router/bgp/vrf/afi-safi/mup/route/mup-ext-comm",
+            super::vrf_config::config_vrf_mup_route_mup_ext_comm,
         );
 
         // `set router bgp interface-neighbor <name> [...]`.

--- a/zebra-rs/src/bgp/route.rs
+++ b/zebra-rs/src/bgp/route.rs
@@ -12698,18 +12698,12 @@ impl Bgp {
     ) -> Option<(bgp_packet::MupPrefix, BgpAttr)> {
         use super::vrf_config::MupSrv6Direction;
         let ni = session.network_instance.as_deref()?;
-        // Correlate the session NI to a `router bgp vrf <name> mup
-        // route {st1|st2}` config for the RD + direction.
+        // Correlate the session NI to a `router bgp vrf <name> afi-safi mup
+        // route {st1|st2}` config for the RD + direction + (st2) ext-comm.
         let (name, rd, direction, seg_ec) = self.vrfs.iter().find_map(|(name, cfg)| {
             let sm = cfg.mobile_uplane.srv6_mobile.as_ref()?;
-            (sm.network_instance.as_deref() == Some(ni)).then(|| {
-                (
-                    name.clone(),
-                    cfg.rd,
-                    sm.direction,
-                    cfg.mobile_uplane.mup_ext_comm,
-                )
-            })
+            (sm.network_instance.as_deref() == Some(ni))
+                .then(|| (name.clone(), cfg.rd, sm.direction, sm.mup_ext_comm))
         })?;
         let rd = rd?;
         // The export route-targets now live on the top-level

--- a/zebra-rs/src/bgp/show.rs
+++ b/zebra-rs/src/bgp/show.rs
@@ -4977,6 +4977,7 @@ mod detail_tests {
                 srv6_mobile: Some(MupSrv6Mobile {
                     direction: MupSrv6Direction::Decapsulation,
                     network_instance: Some("core-ni".to_string()),
+                    mup_ext_comm: None,
                 }),
                 segment: None,
                 mup_ext_comm: None,
@@ -4989,6 +4990,7 @@ mod detail_tests {
                 srv6_mobile: Some(MupSrv6Mobile {
                     direction: MupSrv6Direction::Encapsulation,
                     network_instance: Some("access-ni".to_string()),
+                    mup_ext_comm: None,
                 }),
                 segment: None,
                 mup_ext_comm: None,

--- a/zebra-rs/src/bgp/vrf_config.rs
+++ b/zebra-rs/src/bgp/vrf_config.rs
@@ -123,7 +123,7 @@ impl<N: Ord> Default for BgpVrfAfConfig<N> {
 }
 
 /// SRv6 mobile user-plane direction for a per-VRF MUP service
-/// (zebra-bgp-vrf.yang `mup route {st1|st2}`). `Decapsulation`
+/// (zebra-bgp-vrf.yang `afi-safi mup route {st1|st2}`). `Decapsulation`
 /// is the `st2` egress/uplink (Type-2 ST, the N3 VRF); `Encapsulation`
 /// is the `st1` ingress/downlink (Type-1 ST, the N6 VRF).
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -154,16 +154,24 @@ impl MupSegmentMode {
     }
 }
 
-/// `mup route {st1|st2} dest-network-instance {access|core}
-/// exact <ni>` for one VRF: the ST route type (as a direction) plus the
-/// session network-instance matched exactly. Surfaced in
-/// `show bgp mup` (the `MUP VRFs:` block) and consumed by the
+/// `afi-safi mup route {st1|st2} { network-instance <ni>; [mup-ext-comm
+/// <2:4>;] }` for one VRF: the ST route type (as a direction) plus the
+/// session network-instance matched, and (st2 only) the Direct-segment
+/// MUP Extended Community the originated ST2 routes resolve to. Surfaced
+/// in `show bgp mup` (the `MUP VRFs:` block) and consumed by the
 /// P5 MUP controller when it originates ST routes (st2/Decapsulation →
 /// Type-2 ST, the N3 VRF; st1/Encapsulation → Type-1 ST, the N6 VRF).
 #[derive(Debug, Clone)]
 pub struct MupSrv6Mobile {
     pub direction: MupSrv6Direction,
     pub network_instance: Option<String>,
+    /// `afi-safi mup route st2 mup-ext-comm <2:4>` — the BGP MUP Extended
+    /// Community (Direct-Type Segment Identifier, draft-mpmz-bess-mup-safi
+    /// §3.2 / §3.3.10) attached to the Type-2 ST routes this VRF
+    /// originates, so a receiving PE resolves the (endpoint, TEID) tunnel
+    /// onto the matching End.DT46 Direct segment. Set only for the
+    /// Decapsulation (st2) direction; `None` for st1.
+    pub mup_ext_comm: Option<RouteDistinguisher>,
 }
 
 /// Per-VRF BGP MUP (RFC 9833) service config — the `mup`
@@ -311,63 +319,136 @@ pub fn config_vrf_inter_as_hybrid(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -
     Some(())
 }
 
-/// `set router bgp vrf <NAME> afi-safi mup network-instance <NI>` — the
-/// Type-2 ST (uplink) NI binding, alongside `segment direct` (the Direct
-/// segment the ST2 resolves to). When the MUP controller learns a session
-/// whose Network Instance matches `<NI>`, it originates an ST2 (endpoint +
-/// GTP TEID, egress GTP decapsulation into this VRF's End.DT46 Direct
-/// segment). Stored as the Decapsulation direction on `srv6_mobile`.
-pub fn config_vrf_mup_network_instance(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Option<()> {
+/// Map an `afi-safi mup route` list key (`st1`/`st2`) to the ST direction:
+/// st1 = Encapsulation (downlink / N6 / ingress GTP encap), st2 =
+/// Decapsulation (uplink / N3 / egress GTP decap).
+fn mup_route_direction(key: &str) -> Option<MupSrv6Direction> {
+    match key {
+        "st1" => Some(MupSrv6Direction::Encapsulation),
+        "st2" => Some(MupSrv6Direction::Decapsulation),
+        _ => None,
+    }
+}
+
+/// Borrow-or-create the per-VRF `srv6_mobile` binding for the given ST
+/// direction, forcing the direction (the single binding flips st1↔st2 if
+/// the VRF is reconfigured). Lets the `network-instance` / `mup-ext-comm`
+/// child-leaf handlers accumulate into the same binding regardless of the
+/// order their callbacks fire.
+fn mup_route_binding(cfg: &mut BgpVrfConfig, direction: MupSrv6Direction) -> &mut MupSrv6Mobile {
+    let sm = cfg.mobile_uplane.srv6_mobile.get_or_insert(MupSrv6Mobile {
+        direction,
+        network_instance: None,
+        mup_ext_comm: None,
+    });
+    sm.direction = direction;
+    sm
+}
+
+/// `set router bgp vrf <NAME> afi-safi mup route {st1|st2}` — list-key
+/// handler. Establishes the ST direction binding (st1 = Encapsulation /
+/// downlink, st2 = Decapsulation / uplink); the session network-instance
+/// and (st2) the Direct-segment `mup-ext-comm` hang off child leaves.
+pub fn config_vrf_mup_route(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Option<()> {
     let name = args.string()?;
+    let direction = mup_route_direction(&args.string()?)?;
     let cfg = vrf_entry(bgp, name);
     match op {
         ConfigOp::Set => {
-            let ni = args.string()?;
-            cfg.mobile_uplane.srv6_mobile = Some(MupSrv6Mobile {
-                direction: MupSrv6Direction::Decapsulation,
-                network_instance: Some(ni),
-            });
+            mup_route_binding(cfg, direction);
         }
-        ConfigOp::Delete => cfg.mobile_uplane.srv6_mobile = None,
+        ConfigOp::Delete
+            if cfg
+                .mobile_uplane
+                .srv6_mobile
+                .as_ref()
+                .map(|sm| sm.direction)
+                == Some(direction) =>
+        {
+            cfg.mobile_uplane.srv6_mobile = None;
+        }
         _ => {}
     }
     Some(())
 }
 
-/// `set router bgp vrf <NAME> mup route st1 dest-network-instance
-/// access exact <NI>` — Type-1 ST (downlink) origination: ingress GTP
-/// encapsulation for the N6 VRF, matched against the session's access
-/// network-instance.
-pub fn config_vrf_mup_route_st1(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Option<()> {
+/// `set router bgp vrf <NAME> afi-safi mup route {st1|st2} network-instance
+/// <NI>` — the PFCP session Network Instance this VRF originates ST routes
+/// for. Matched against the session's Network Instance by the MUP
+/// controller (st1 → Type-1 ST / ingress encap; st2 → Type-2 ST / egress
+/// decap).
+pub fn config_vrf_mup_route_network_instance(
+    bgp: &mut Bgp,
+    mut args: Args,
+    op: ConfigOp,
+) -> Option<()> {
     let name = args.string()?;
+    let direction = mup_route_direction(&args.string()?)?;
     let cfg = vrf_entry(bgp, name);
     match op {
         ConfigOp::Set => {
             let ni = args.string()?;
-            cfg.mobile_uplane.srv6_mobile = Some(MupSrv6Mobile {
-                direction: MupSrv6Direction::Encapsulation,
-                network_instance: Some(ni),
-            });
+            mup_route_binding(cfg, direction).network_instance = Some(ni);
         }
-        ConfigOp::Delete => cfg.mobile_uplane.srv6_mobile = None,
+        ConfigOp::Delete => {
+            if let Some(sm) = cfg.mobile_uplane.srv6_mobile.as_mut()
+                && sm.direction == direction
+            {
+                sm.network_instance = None;
+            }
+        }
+        _ => {}
+    }
+    Some(())
+}
+
+/// `set router bgp vrf <NAME> afi-safi mup route st2 mup-ext-comm <2:4>` —
+/// the BGP MUP Extended Community (Direct-Type Segment Identifier) the
+/// originated Type-2 ST routes resolve to (draft §3.3.10). Meaningful only
+/// under `route st2` (Decapsulation); stored on the `srv6_mobile` binding.
+pub fn config_vrf_mup_route_mup_ext_comm(
+    bgp: &mut Bgp,
+    mut args: Args,
+    op: ConfigOp,
+) -> Option<()> {
+    let name = args.string()?;
+    let direction = mup_route_direction(&args.string()?)?;
+    let cfg = vrf_entry(bgp, name);
+    match op {
+        ConfigOp::Set => {
+            let raw = args.string()?;
+            mup_route_binding(cfg, direction).mup_ext_comm =
+                Some(RouteDistinguisher::from_str(&raw).ok()?);
+        }
+        ConfigOp::Delete => {
+            if let Some(sm) = cfg.mobile_uplane.srv6_mobile.as_mut()
+                && sm.direction == direction
+            {
+                sm.mup_ext_comm = None;
+            }
+        }
         _ => {}
     }
     Some(())
 }
 
 /// `set router bgp vrf <NAME> afi-safi mup segment {direct|interwork}` —
+/// list-key handler for the `segment` list (keyed by the route type).
 /// PE-side Segment Discovery origination. `direct` originates a Direct
 /// Segment Discovery (DSD, type 2) route carrying the VRF's End.DT46 SID;
-/// `interwork` an Interwork Segment Discovery (ISD, type 1) route.
+/// `interwork` an Interwork Segment Discovery (ISD, type 1) route. The
+/// list key is the only token, so it is read before the op branch (the
+/// `config_vrf_neighbor` pattern) and the delete only clears a matching
+/// mode.
 pub fn config_vrf_mup_segment(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Option<()> {
     let name = args.string()?;
+    let mode = MupSegmentMode::parse(&args.string()?)?;
     let cfg = vrf_entry(bgp, name);
     match op {
-        ConfigOp::Set => {
-            let raw = args.string()?;
-            cfg.mobile_uplane.segment = Some(MupSegmentMode::parse(&raw)?);
+        ConfigOp::Set => cfg.mobile_uplane.segment = Some(mode),
+        ConfigOp::Delete if cfg.mobile_uplane.segment == Some(mode) => {
+            cfg.mobile_uplane.segment = None;
         }
-        ConfigOp::Delete => cfg.mobile_uplane.segment = None,
         _ => {}
     }
     Some(())
@@ -375,11 +456,14 @@ pub fn config_vrf_mup_segment(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Op
 
 /// `set router bgp vrf <NAME> afi-safi mup segment direct mup-ext-comm
 /// <2:4>` — the BGP MUP Extended Community (Direct-Type Segment
-/// Identifier) for this VRF's Direct segment. The value is the RD/RT 2:4
-/// notation, stored as a `RouteDistinguisher` whose 6-octet `val` maps
-/// straight onto the extended-community value.
+/// Identifier) for this VRF's Direct segment. This leaf hangs off the
+/// `segment` list, so the segment list key (`direct`/`interwork`) sits
+/// between the VRF name and the value and is skipped here. The value is
+/// the RD/RT 2:4 notation, stored as a `RouteDistinguisher` whose 6-octet
+/// `val` maps straight onto the extended-community value.
 pub fn config_vrf_mup_ext_comm(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Option<()> {
     let name = args.string()?;
+    let _segment = args.string()?; // segment list key (direct|interwork)
     let cfg = vrf_entry(bgp, name);
     match op {
         ConfigOp::Set => {
@@ -717,14 +801,17 @@ mod tests {
         cfg.mobile_uplane.srv6_mobile = Some(MupSrv6Mobile {
             direction: MupSrv6Direction::Decapsulation,
             network_instance: Some("core-ni".to_string()),
+            mup_ext_comm: Some("1:2".parse().unwrap()),
         });
         let sm = cfg.mobile_uplane.srv6_mobile.as_ref().unwrap();
         assert_eq!(sm.direction, MupSrv6Direction::Decapsulation);
         assert_eq!(sm.network_instance.as_deref(), Some("core-ni"));
+        assert_eq!(sm.mup_ext_comm, Some("1:2".parse().unwrap()));
 
         cfg.mobile_uplane.srv6_mobile = Some(MupSrv6Mobile {
             direction: MupSrv6Direction::Encapsulation,
             network_instance: Some("access-ni".to_string()),
+            mup_ext_comm: None,
         });
         assert_eq!(
             cfg.mobile_uplane.srv6_mobile.as_ref().unwrap().direction,

--- a/zebra-rs/src/config/manager.rs
+++ b/zebra-rs/src/config/manager.rs
@@ -1509,6 +1509,77 @@ mod yang_load_tests {
         }
     }
 
+    /// Regression guard for the per-VRF MUP `segment` list
+    /// (zebra-bgp-vrf.yang). `mup-ext-comm` moved from a sibling leaf of
+    /// `segment` to a child leaf of the `segment direct` list entry, so the
+    /// key-only `segment direct` / `segment interwork` entries and the
+    /// nested `mup-ext-comm` leaf must each parse as settable paths. Pins
+    /// the new shape (`segment <type> { mup-ext-comm <2:4>; }`) so a broken
+    /// list key or a stale callback path is caught in the unit suite, not
+    /// only in the `@bgp_mup_segment_dsd` / `@bgp_mup_st2` BDDs.
+    #[test]
+    fn bgp_vrf_mup_segment_paths_parse() {
+        use crate::config::ExecCode;
+        use crate::config::parse::{State, parse};
+        use libyang::to_entry;
+
+        let mut yang = YangStore::new();
+        yang.add_path(concat!(env!("CARGO_MANIFEST_DIR"), "/yang"));
+        yang.read_with_resolve("configure")
+            .unwrap_or_else(|e| panic!("configure failed to load: {e:#}"));
+        yang.identity_resolve();
+        let module = yang.find_module("configure").unwrap();
+        let entry = to_entry(&yang, module);
+
+        for cmd in [
+            "set router bgp vrf N3 afi-safi mup segment direct",
+            "set router bgp vrf N3 afi-safi mup segment interwork",
+            "set router bgp vrf N3 afi-safi mup segment direct mup-ext-comm 1:20",
+        ] {
+            let (code, _comps, _state) = parse(cmd, entry.clone(), None, State::new());
+            assert_eq!(
+                code,
+                ExecCode::Success,
+                "should parse as a settable path: {cmd}"
+            );
+        }
+    }
+
+    /// Regression guard for the per-VRF MUP `route` list (zebra-bgp-vrf.yang).
+    /// Both ST bindings now live under `afi-safi mup route {st1|st2}`
+    /// (collapsed enum-keyed list): st1 (downlink / N6) and st2 (uplink /
+    /// N3), each with a `network-instance`, and st2 additionally with a
+    /// `mup-ext-comm`. Pins the new shape so a broken list key or a stale
+    /// callback path is caught in the unit suite, not only in the
+    /// `@bgp_mup_st2` / `@bgp_mup_e2e` BDDs.
+    #[test]
+    fn bgp_vrf_mup_route_paths_parse() {
+        use crate::config::ExecCode;
+        use crate::config::parse::{State, parse};
+        use libyang::to_entry;
+
+        let mut yang = YangStore::new();
+        yang.add_path(concat!(env!("CARGO_MANIFEST_DIR"), "/yang"));
+        yang.read_with_resolve("configure")
+            .unwrap_or_else(|e| panic!("configure failed to load: {e:#}"));
+        yang.identity_resolve();
+        let module = yang.find_module("configure").unwrap();
+        let entry = to_entry(&yang, module);
+
+        for cmd in [
+            "set router bgp vrf N6 afi-safi mup route st1 network-instance access",
+            "set router bgp vrf N3 afi-safi mup route st2 network-instance core",
+            "set router bgp vrf N3 afi-safi mup route st2 mup-ext-comm 1:30",
+        ] {
+            let (code, _comps, _state) = parse(cmd, entry.clone(), None, State::new());
+            assert_eq!(
+                code,
+                ExecCode::Success,
+                "should parse as a settable path: {cmd}"
+            );
+        }
+    }
+
     /// The RFC 9251 Type-7/8 debug-origination surface
     /// (`clear bgp debug igmp-{join,leave}-sync-{originate,withdraw} <spec>`,
     /// zebra-bgp-clear.yang) must parse as a complete exec path against the

--- a/zebra-rs/yang/zebra-bgp-vrf.yang
+++ b/zebra-rs/yang/zebra-bgp-vrf.yang
@@ -215,54 +215,104 @@ module zebra-bgp-vrf {
       }
       container mup {
         description
-          "Per-VRF MUP (RFC 9833) Segment Discovery origination — the PE
-           side. `segment direct` originates a Direct Segment Discovery
+          "Per-VRF MUP (RFC 9833) service. The `segment` list is the PE
+           side: `segment direct` originates a Direct Segment Discovery
            (DSD, type 2) route for this VRF carrying the VRF's End.DT46
-           SID (carved from `encapsulation srv6`); `interwork` originates
-           an Interwork Segment Discovery (ISD, type 1) route. A receiving
-           PE derives forwarding for matching Session-Transformed routes
-           from these segment routes (draft-ietf-bess-mup-safi default).
-           Distinct from the controller-side `mup route {st1|st2}` block.";
-        leaf segment {
-          type enumeration {
-            enum direct {
-              description
-                "Originate a Direct Segment Discovery (DSD, type 2)
-                 route: the NLRI is the VRF RD + router-id and the SRv6
-                 L3 Service carries the per-VRF End.DT46 SID.";
+           SID (carved from `encapsulation srv6`); `segment interwork` an
+           Interwork Segment Discovery (ISD, type 1) route. The `route`
+           list is the controller side: `route {st1|st2}` binds a PFCP
+           session Network Instance to Session-Transformed (ST) route
+           origination. A receiving PE derives forwarding for matching ST
+           routes from the segment routes (draft-ietf-bess-mup-safi
+           default).";
+        list segment {
+          key "type";
+          description
+            "MUP Segment Discovery route type originated for this VRF.
+             `segment direct` originates a Direct Segment Discovery (DSD,
+             type 2) route carrying the VRF's End.DT46 SID; `segment
+             interwork` an Interwork Segment Discovery (ISD, type 1)
+             route. The `direct` entry additionally carries the
+             `mup-ext-comm` identifying this VRF's Direct segment.";
+          leaf type {
+            type enumeration {
+              enum direct {
+                description
+                  "Originate a Direct Segment Discovery (DSD, type 2)
+                   route: the NLRI is the VRF RD + router-id and the SRv6
+                   L3 Service carries the per-VRF End.DT46 SID.";
+              }
+              enum interwork {
+                description
+                  "Originate an Interwork Segment Discovery (ISD, type 1)
+                   route. (Origination deferred — parsed but not yet acted
+                   on.)";
+              }
             }
-            enum interwork {
-              description
-                "Originate an Interwork Segment Discovery (ISD, type 1)
-                 route. (Origination deferred — parsed but not yet acted
-                 on.)";
-            }
+            description
+              "MUP Segment Discovery route type originated for this VRF.";
           }
-          description
-            "MUP Segment Discovery route type originated for this VRF.";
+          leaf mup-ext-comm {
+            type route-distinguisher;
+            description
+              "BGP MUP Extended Community (transitive type 0x0c, sub-type
+               0x00 = Direct-Type Segment Identifier,
+               draft-mpmz-bess-mup-safi §3.2) identifying this VRF's Direct
+               segment. Attached to the VRF's Direct Segment Discovery (DSD)
+               route and to the controller's Type-2 Session-Transformed
+               (ST2) routes that resolve to this Direct segment (§3.3.10 /
+               §3.3.12). The 6-octet value reuses the RD/RT 2:4 wire format.
+               Meaningful only under the `direct` segment.";
+          }
         }
-        leaf mup-ext-comm {
-          type route-distinguisher;
+        list route {
+          key "type";
           description
-            "BGP MUP Extended Community (transitive type 0x0c, sub-type
-             0x00 = Direct-Type Segment Identifier,
-             draft-mpmz-bess-mup-safi §3.2) identifying this VRF's Direct
-             segment. Attached to the VRF's Direct Segment Discovery (DSD)
-             route and to the controller's Type-2 Session-Transformed
-             (ST2) routes that resolve to this Direct segment (§3.3.10 /
-             §3.3.12). The 6-octet value reuses the RD/RT 2:4 wire format.";
-        }
-        leaf network-instance {
-          type string;
-          description
-            "PFCP session Network Instance whose uplink sessions this
-             Direct segment originates Type-2 Session-Transformed (ST2)
-             routes for. When the MUP controller learns a session whose
-             Network Instance matches this value, it originates an ST2
-             (endpoint + GTP TEID) for this VRF — egress GTP decapsulation
-             into the VRF's End.DT46 Direct segment. This is the ST2 NI
-             binding; the downlink (ST1) binding stays on
-             `mup route st1 dest-network-instance access exact`.";
+            "Session-Transformed route origination for this VRF, keyed by
+             ST route type. `route st1` is the downlink (Type-1 ST / N6;
+             ingress GTP encapsulation); `route st2` the uplink (Type-2 ST
+             / N3; egress GTP decapsulation). Each binds the PFCP session
+             Network Instance whose sessions the MUP controller originates
+             ST routes for; `route st2` additionally carries its own
+             `mup-ext-comm` of the Direct segment those ST2 routes resolve
+             to.";
+          leaf type {
+            type enumeration {
+              enum st1 {
+                description
+                  "Type-1 ST (downlink); ingress GTP encapsulation, the
+                   N6 VRF.";
+              }
+              enum st2 {
+                description
+                  "Type-2 ST (uplink); egress GTP decapsulation, the
+                   N3 VRF.";
+              }
+            }
+            description
+              "ST route type this entry originates (st1 = downlink / N6,
+               st2 = uplink / N3).";
+          }
+          leaf network-instance {
+            type string;
+            description
+              "PFCP session Network Instance whose sessions this VRF
+               originates ST routes for. When the MUP controller learns a
+               session whose Network Instance matches this value, it
+               originates the ST route (st1 → Type-1 / ingress encap;
+               st2 → Type-2 / egress decap into the VRF's End.DT46 Direct
+               segment).";
+          }
+          leaf mup-ext-comm {
+            type route-distinguisher;
+            description
+              "BGP MUP Extended Community (Direct-Type Segment Identifier,
+               draft-mpmz-bess-mup-safi §3.2 / §3.3.10) of the Direct
+               segment the originated ST2 routes resolve to, so a receiving
+               PE maps the (endpoint, TEID) tunnel onto the matching
+               End.DT46 segment. Meaningful only under `route st2`. The
+               6-octet value reuses the RD/RT 2:4 wire format.";
+          }
         }
       }
     }
@@ -390,36 +440,6 @@ module zebra-bgp-vrf {
           description
             "Advertise this VRF's IPv6 unicast routes as EVPN Type-5
              (IP Prefix) routes. Requires `rd` to be set.";
-        }
-      }
-      container mup {
-        description
-          "BGP MUP (RFC 9833) per-VRF service. `route st1` binds the
-           Type-1 ST (downlink / N6) destination session network-instance
-           matched exactly. The uplink Type-2 ST (N3) binding lives on the
-           `afi-safi mup network-instance` leaf, alongside `segment direct`
-           (the Direct segment the ST2 resolves to). The export/import
-           route-targets live on the top-level `vrf <name> mup
-           route-target {export|import}` (config.yang), the same place as
-           the ipv4 / ipv6 RT policy.";
-        container route {
-          description
-            "Session-Transformed route origination for this VRF. Only the
-             downlink (st1) binding lives here; the uplink (st2) binding
-             moved to `afi-safi mup network-instance`.";
-          container st1 {
-            description
-              "Type-1 ST (downlink); ingress GTP encapsulation, the N6 VRF.";
-            container dest-network-instance {
-              container access {
-                leaf exact {
-                  type string;
-                  description
-                    "Session access network-instance matched exactly.";
-                }
-              }
-            }
-          }
         }
       }
       uses bgp-vrf-neighbor;


### PR DESCRIPTION
## Summary

Restructures the per-VRF MUP (RFC 9833 / draft-mpmz-bess-mup-safi) config grammar under `afi-safi mup`:

- **`segment` → enum-keyed list.** `mup-ext-comm` now nests under the Direct entry:
  ```
  segment direct { mup-ext-comm 1:20; }
  ```
  (the DSD route's own Direct-segment identifier; `segment direct;` key-only is still valid).
- **Explicit, symmetric `route {st1|st2}`.** Both Session-Transformed bindings live under one collapsed enum-keyed list, each with a flat `network-instance`, and `route st2` with its own `mup-ext-comm`:
  ```
  route st1 { network-instance internet; }
  route st2 { network-instance internet; mup-ext-comm 1:30; }
  ```
  This replaces both the bare `afi-safi mup network-instance` leaf (old st2 binding) and the nested vrf-level `mup route st1 dest-network-instance access exact` container (st1 flattened), so st1 and st2 read identically.

The DSD ext-comm (`segment direct`, `BgpVrfMobileUplane.mup_ext_comm`) and the ST2 ext-comm (`route st2`, new `MupSrv6Mobile.mup_ext_comm`) are **independent knobs**; `build_mup_origination` attaches the route-st2 value to the ST2 route. New `route` list-key handlers merge into one `srv6_mobile` binding; the old `config_vrf_mup_network_instance` / `config_vrf_mup_route_st1` handlers are removed.

## Test plan

- `cargo fmt --check` ✅
- `cargo clippy --workspace --all-targets -- -D warnings` ✅
- Full `zebra-rs` unit suite — **1465 passed**, incl. YANG load + two new path-parse guards (`bgp_vrf_mup_segment_paths_parse`, `bgp_vrf_mup_route_paths_parse`) ✅
- 5 MUP BDD configs + 2 feature docstrings + followups design doc updated. BDD suite not run locally (needs root netns) — covered by CI.

Generated with [Claude Code](https://claude.com/claude-code)