### PR TITLE
bgp-evpn: Designated Forwarder election (ES foundation P4)

### DIFF
--- a/bdd/tests/features/bgp_evpn_es.feature
+++ b/bdd/tests/features/bgp_evpn_es.feature
@@ -53,6 +53,17 @@ Feature: BGP EVPN Ethernet Segment discovery (RFC 7432 Type-4)
     And show command "show bgp evpn ethernet-segment" in namespace "z1" should contain "192.168.0.1 (local)"
     And show command "show bgp evpn ethernet-segment" in namespace "z1" should contain "192.168.0.2"
 
+  Scenario: DF election carves the segment (default service-carving)
+    Given the test topology exists
+    # Both PEs advertise Alg 0, so the negotiated algorithm is the default.
+    Then show command "show bgp evpn ethernet-segment" in namespace "z1" should eventually contain "DF algorithm: service-carving (default)"
+    # 2 PEs sorted by IP: ordinal 0 = z1 (192.168.0.1) is DF for tag 0; both
+    # PEs agree on the same elected DF.
+    And show command "show bgp evpn ethernet-segment" in namespace "z1" should contain "Designated Forwarder (tag 0): 192.168.0.1 (this node)"
+    And show command "show bgp evpn ethernet-segment" in namespace "z2" should eventually contain "Designated Forwarder (tag 0): 192.168.0.1"
+    # z2 (ordinal 1) is NOT the DF for tag 0.
+    And show command "show bgp evpn ethernet-segment" in namespace "z2" should not contain "Designated Forwarder (tag 0): 192.168.0.2"
+
   Scenario: Removing the ES on z2 withdraws its Type-4 from z1
     Given the test topology exists
     When I apply config "z2-noes.yaml" to namespace "z2"

--- a/zebra-rs/src/bgp/ethernet_segment.rs
+++ b/zebra-rs/src/bgp/ethernet_segment.rs
@@ -6,7 +6,9 @@
 //! those are later phases. The config handlers live in `config.rs` alongside
 //! the other EVPN afi-safi knobs; this module owns the state types.
 
-use bgp_packet::ExtCommunityValue;
+use std::net::IpAddr;
+
+use bgp_packet::{DfElectionEc, ExtCommunityValue};
 
 /// All-active vs single-active multihoming redundancy mode (RFC 7432 §14.1).
 /// Carried in the ESI Label EC's flag on the per-ES A-D route.
@@ -62,6 +64,32 @@ impl EthernetSegment {
     }
 }
 
+/// RFC 8584 DF Election algorithm negotiation across the PEs on an Ethernet
+/// Segment: if every PE advertised the same algorithm (in its Type-4 DF
+/// Election EC), that algorithm is used; otherwise the Default algorithm
+/// (Alg 0, service-carving / modulus) is used as the fallback. An empty set
+/// yields the default.
+pub fn negotiate_df_alg(algs: &[u8]) -> u8 {
+    match algs.split_first() {
+        Some((first, rest)) if rest.iter().all(|a| a == first) => *first,
+        _ => DfElectionEc::ALG_DEFAULT,
+    }
+}
+
+/// Designated-Forwarder election via service carving (RFC 7432 §8.5 /
+/// RFC 8584 Alg 0): the candidate VTEPs are ordered by ascending IP, given
+/// ordinals 0..N, and the DF for a given Ethernet Tag / VLAN `tag` is the
+/// candidate at ordinal `tag mod N`. `candidates` MUST already be sorted
+/// ascending. `None` for an empty candidate set. (HRW, Alg 1, is a follow-up;
+/// callers fall back to this carving for any non-zero negotiated algorithm.)
+pub fn designated_forwarder(candidates: &[IpAddr], tag: u32) -> Option<IpAddr> {
+    if candidates.is_empty() {
+        return None;
+    }
+    let idx = (tag as usize) % candidates.len();
+    Some(candidates[idx])
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -102,5 +130,36 @@ mod tests {
             rt.as_es_import_rt(),
             Some([0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff])
         );
+    }
+
+    #[test]
+    fn df_alg_negotiation() {
+        // All agree → that algorithm.
+        assert_eq!(negotiate_df_alg(&[0, 0, 0]), 0);
+        assert_eq!(negotiate_df_alg(&[1, 1]), 1);
+        // Disagreement → Default (0).
+        assert_eq!(negotiate_df_alg(&[0, 1]), 0);
+        assert_eq!(negotiate_df_alg(&[1, 1, 0]), 0);
+        // Empty → Default.
+        assert_eq!(negotiate_df_alg(&[]), 0);
+        // Single PE → its own algorithm.
+        assert_eq!(negotiate_df_alg(&[1]), 1);
+    }
+
+    #[test]
+    fn service_carving_df() {
+        use std::net::Ipv4Addr;
+        let a = IpAddr::V4(Ipv4Addr::new(192, 168, 0, 1));
+        let b = IpAddr::V4(Ipv4Addr::new(192, 168, 0, 2));
+        let cands = [a, b]; // sorted ascending
+        // tag 0 -> ordinal 0 (a); tag 1 -> ordinal 1 (b); tag 2 -> 0 (a).
+        assert_eq!(designated_forwarder(&cands, 0), Some(a));
+        assert_eq!(designated_forwarder(&cands, 1), Some(b));
+        assert_eq!(designated_forwarder(&cands, 2), Some(a));
+        assert_eq!(designated_forwarder(&cands, 3), Some(b));
+        // Single candidate is DF for every tag.
+        assert_eq!(designated_forwarder(&[a], 7), Some(a));
+        // Empty → none.
+        assert_eq!(designated_forwarder(&[], 0), None);
     }
 }

--- a/zebra-rs/src/bgp/route.rs
+++ b/zebra-rs/src/bgp/route.rs
@@ -14431,23 +14431,33 @@ impl Bgp {
         route_withdraw_evpn_to_peers(rd, prefix, &mut self.peers);
     }
 
-    /// The set of Originating Router IPs (VTEPs) that have advertised a Type-4
-    /// Ethernet Segment route for `esi` — the PE membership of the segment,
-    /// computed from the EVPN Loc-RIB (includes our own originated Type-4).
-    /// The ESI is in the Type-4 NLRI key, so membership matches on it directly
-    /// rather than on the ES-Import RT.
-    pub fn es_member_vteps(&self, esi: &[u8; 10]) -> std::collections::BTreeSet<IpAddr> {
-        let mut members = std::collections::BTreeSet::new();
+    /// The DF-election candidates for an ES, computed from the EVPN Loc-RIB:
+    /// the `(VTEP, advertised DF algorithm)` of every Type-4 route with this
+    /// ESI (our own originated one included), **sorted by ascending VTEP** so
+    /// the index is the RFC 7432 §8.5 service-carving ordinal. The algorithm
+    /// is read from each Type-4's DF Election EC (RFC 8584), defaulting to
+    /// service-carving (Alg 0) when absent. The ESI is in the Type-4 NLRI key,
+    /// so candidates match on it directly rather than on the ES-Import RT.
+    pub fn es_df_candidates(&self, esi: &[u8; 10]) -> Vec<(IpAddr, u8)> {
+        let mut cands: Vec<(IpAddr, u8)> = Vec::new();
         for table in self.local_rib.evpn.values() {
-            for prefix in table.selected.keys() {
+            for (prefix, rib) in table.selected.iter() {
                 if let EvpnPrefix::EthernetSeg { esi: e, orig } = prefix
                     && e == esi
                 {
-                    members.insert(*orig);
+                    let alg = rib
+                        .attr
+                        .ecom
+                        .as_ref()
+                        .and_then(|ec| ec.0.iter().find_map(|v| v.as_df_election()))
+                        .map(|df| df.df_alg)
+                        .unwrap_or(bgp_packet::DfElectionEc::ALG_DEFAULT);
+                    cands.push((*orig, alg));
                 }
             }
         }
-        members
+        cands.sort_by_key(|(ip, _)| *ip);
+        cands
     }
 
     /// Originate a Type-7 IGMP/MLD Join Synch route (RFC 9251 §9.2) for a

--- a/zebra-rs/src/bgp/show.rs
+++ b/zebra-rs/src/bgp/show.rs
@@ -2078,13 +2078,29 @@ fn show_bgp_evpn_ethernet_segment(
         if let Some(rt) = es.es_import_rt() {
             writeln!(buf, "  ES-Import RT: {}", format_evpn_ecom_value(&rt))?;
         }
-        // PE membership discovered from received (and our own) Type-4 routes.
+        // PE membership + DF election, from the received (and our own) Type-4
+        // routes. Candidates are sorted by VTEP — the index is the RFC 7432
+        // §8.5 service-carving ordinal.
         if let Some(esi) = es.esi {
-            let members = bgp.es_member_vteps(&esi);
-            writeln!(buf, "  Member VTEPs ({}):", members.len())?;
-            for vtep in &members {
+            let cands = bgp.es_df_candidates(&esi);
+            let vteps: Vec<std::net::IpAddr> = cands.iter().map(|(ip, _)| *ip).collect();
+            writeln!(buf, "  Member VTEPs ({}):", vteps.len())?;
+            for (ordinal, (vtep, _)) in cands.iter().enumerate() {
                 let tag = if *vtep == local { " (local)" } else { "" };
-                writeln!(buf, "    {vtep}{tag}")?;
+                writeln!(buf, "    [{ordinal}] {vtep}{tag}")?;
+            }
+            // RFC 8584 algorithm negotiation, then RFC 7432 §8.5 carving.
+            let algs: Vec<u8> = cands.iter().map(|(_, a)| *a).collect();
+            let alg = super::ethernet_segment::negotiate_df_alg(&algs);
+            let alg_name = if alg == bgp_packet::DfElectionEc::ALG_DEFAULT {
+                "service-carving (default)"
+            } else {
+                "negotiated (non-default; carving fallback)"
+            };
+            writeln!(buf, "  DF algorithm: {alg_name}")?;
+            if let Some(df) = super::ethernet_segment::designated_forwarder(&vteps, 0) {
+                let tag = if df == local { " (this node)" } else { "" };
+                writeln!(buf, "  Designated Forwarder (tag 0): {df}{tag}")?;
             }
         }
     }


### PR DESCRIPTION
## Summary

**Phase 4** of the EVPN Ethernet Segment foundation (RFC 7432 / RFC 8584; design: `docs/design/bgp-evpn-ethernet-segment.md`, #1633). Computes the **Designated Forwarder** per Ethernet Segment from the Type-4 membership. **Control-plane only** — the DF is computed and shown, not yet enforced in the data plane (Phase 6); HRW (Alg 1) and the 3s hold timer are follow-ups.

### DF election logic (`ethernet_segment.rs`)
- `negotiate_df_alg` — RFC 8584: if all PEs on the ES advertised the same DF algorithm use it, else fall back to the Default (Alg 0).
- `designated_forwarder` — RFC 7432 §8.5 service-carving: DF = `candidates[tag mod N]` over the ascending-IP-sorted member VTEPs.

### Candidate collection (`route.rs`)
- `es_df_candidates` collects `(VTEP, advertised DF algorithm)` from each Type-4's DF Election EC, sorted by VTEP (the index is the carving ordinal); `es_member_vteps` folded into it.

### Show (`show.rs`)
- `show bgp evpn ethernet-segment` now lists candidate **ordinals**, the **negotiated algorithm**, and the **elected DF for tag 0** (this-node tagged).

## Test plan
- `cargo fmt`, build, `cargo clippy --workspace --all-targets -- -D warnings`: clean
- `cargo test`: bgp-packet 365, zebra-rs 1468 pass (incl. `df_alg_negotiation`, `service_carving_df`)
- **`@bgp_evpn_es` BDD: 6/6 scenarios pass** — the new DF scenario confirms both PEs negotiate `service-carving (default)` and agree that z1 (ordinal 0, lowest IP) is the Designated Forwarder for tag 0, while z2 is not.

Generated with [Claude Code](https://claude.com/claude-code)