### PR TITLE
bgp-mup: originate both ST1 and ST2 from one PFCP session

### DIFF
--- a/bdd/Makefile
+++ b/bdd/Makefile
@@ -59,6 +59,14 @@ bgp_mup_interwork:
 	mkdir -p allure-results
 	cargo test --test cucumber -- --concurrency=1 --tags "@bgp_mup_interwork"
 
+# MUP dual-ST: two VRFs (st1 downlink + st2 uplink) bind the same Network
+# Instance, so one PFCP session originates BOTH Session-Transformed routes
+# (Type-1 + Type-2), received by the peer. Needs `pfcp-inject` on the host
+# PATH (cargo build --release -p pfcp-inject; copy to /usr/bin).
+bgp_mup_dual_st:
+	mkdir -p allure-results
+	cargo test --test cucumber -- --concurrency=1 --tags "@bgp_mup_dual_st"
+
 rib_static_ipv6:
 	mkdir -p allure-results
 	cargo test --test cucumber -- --concurrency=1 --tags "@rib_static_ipv6"

--- a/bdd/tests/configs/bgp_mup_dual_st/z1.yaml
+++ b/bdd/tests/configs/bgp_mup_dual_st/z1.yaml
@@ -1,0 +1,74 @@
+# z1 — MUP Controller (MUP-C) originating BOTH Session-Transformed routes
+# from a SINGLE PFCP session. AS 65001, iBGP to z2 (192.168.0.2) with the
+# mup afi-safi negotiated; PFCP/N4 listener on 192.168.0.1:8805.
+#
+# Two VRFs bind the *same* Network Instance `internet`:
+#   * `mobile-dl` (rd 65000:101) — `afi-safi mup route st1` (downlink / N6),
+#     so a session originates a Type-1 ST (UE prefix + access tunnel).
+#   * `mobile-ul` (rd 65000:100) — `afi-safi mup route st2` (uplink / N3)
+#     with the Direct segment id `1:2`, so the same session also originates
+#     a Type-2 ST (core endpoint + GTP TEID).
+#
+# When pfcp-inject programs one session whose Network Instance is
+# `internet`, z1 originates BOTH the ST1 and the ST2 (previously only the
+# first matching VRF fired) and advertises them to z2.
+segment-routing:
+  locator:
+  - name: LOC1
+    prefix: fcbb:bb01::/48
+    behavior: usid
+router:
+  bgp:
+    global:
+      as: 65001
+      router-id: 192.168.0.1
+    segment-routing:
+      srv6:
+        locator: LOC1
+        ipv6-unicast: {}
+    neighbor:
+    - remote-address: 192.168.0.2
+      remote-as: 65001
+      enabled: true
+      afi-safi:
+      - name: ipv4
+        enabled: true
+      - name: mup
+        enabled: true
+    vrf:
+    - name: mobile-dl
+      rd: "65000:101"
+      afi-safi:
+        mup:
+          route:
+          - type: st1
+            network-instance: internet
+    - name: mobile-ul
+      rd: "65000:100"
+      afi-safi:
+        mup:
+          route:
+          - type: st2
+            network-instance: internet
+            mup-ext-comm: "1:2"
+    mup-c:
+      enable: true
+      controller-address: fcbb:bb01::1
+      pfcp:
+        listen-address: 192.168.0.1
+        port: 8805
+      srv6:
+        locator: LOC1
+# Top-level VRFs: the MUP export route-targets live here (same
+# `route-target {import|export}` framework as ipv4 / ipv6).
+vrf:
+- name: mobile-dl
+  mup:
+    route-target:
+      export:
+      - "65000:201"
+- name: mobile-ul
+  mup:
+    route-target:
+      export:
+      - "65000:200"

--- a/bdd/tests/configs/bgp_mup_dual_st/z2.yaml
+++ b/bdd/tests/configs/bgp_mup_dual_st/z2.yaml
@@ -1,0 +1,41 @@
+# z2 — MUP dual-ST route receiver. AS 65001, iBGP to z1 (192.168.0.1) with
+# the mup afi-safi negotiated. Plain BGP speaker: no controller, originates
+# nothing, but receives BOTH the Type-1 (ST1) and Type-2 (ST2)
+# Session-Transformed routes z1 originates from one PFCP session and shows
+# them under `show bgp mup`.
+#
+# Two `vrf` blocks import the routes' MUP route-targets (65000:201 for the
+# downlink/ST1, 65000:200 for the uplink/ST2 — z1's `mobile-dl` /
+# `mobile-ul` exports); the global MUP Loc-RIB stays authoritative and each
+# best-path is mirrored into its per-VRF task for `show bgp vrf <name> mup`
+# (display only). The `router bgp vrf` blocks spawn those per-VRF tasks.
+vrf:
+- name: mobile-dl
+  mup:
+    route-target:
+      import:
+      - "65000:201"
+- name: mobile-ul
+  mup:
+    route-target:
+      import:
+      - "65000:200"
+router:
+  bgp:
+    global:
+      as: 65001
+      router-id: 192.168.0.2
+    neighbor:
+    - remote-address: 192.168.0.1
+      remote-as: 65001
+      enabled: true
+      afi-safi:
+      - name: ipv4
+        enabled: true
+      - name: mup
+        enabled: true
+    vrf:
+    - name: mobile-dl
+      rd: "65000:101"
+    - name: mobile-ul
+      rd: "65000:100"

--- a/bdd/tests/features/bgp_mup_dual_st.feature
+++ b/bdd/tests/features/bgp_mup_dual_st.feature
@@ -1,0 +1,81 @@
+@serial
+@bgp_mup_dual_st
+Feature: BGP MUP Controller originates both ST1 and ST2 from one PFCP session
+  As a network operator
+  I want the zebra-rs BGP MUP Controller (MUP-C) to originate every
+  Session-Transformed route whose VRF binds a session's Network Instance —
+  so when a downlink (st1) VRF and an uplink (st2) VRF both bind the same
+  Network Instance, a single PFCP/N4 session originates BOTH the Type-1 ST
+  (UE prefix + access tunnel) and the Type-2 ST (core endpoint + GTP TEID),
+  not just the first matching VRF.
+
+  Test Topology:
+  ```
+  ┌─────────────────────────────────────────┐
+  │                   br0                    │
+  └─────────────┬───────────────┬───────────┘
+                │               │
+           ┌────┴────┐     ┌────┴────┐
+           │   z1    │     │   z2    │
+           │ MUP-C   │ iBGP│ receiver│
+           │192.168. │◄───►│192.168. │
+           │  0.1/24 │     │  0.2/24 │
+           └────┬────┘     └─────────┘
+                │ PFCP/N4 (UDP 8805)
+           ┌────┴──────┐
+           │ pfcp-inject│  (SMF simulator, run in z1)
+           └───────────┘
+  ```
+
+  z1 runs the controller (PFCP listener on 192.168.0.1:8805, locator LOC1)
+  with two VRFs binding Network Instance `internet`: `mobile-dl`
+  (rd 65000:101, `afi-safi mup route st1`) for the downlink Type-1 ST, and
+  `mobile-ul` (rd 65000:100, `afi-safi mup route st2` carrying Direct
+  segment id `1:2`) for the uplink Type-2 ST. `pfcp-inject` plays the SMF:
+  it sends an Association Setup + Session Establishment for UE 192.0.2.5 /
+  endpoint 10.0.0.1 / TEID 0x12345678 (Network Instance `internet`), so z1
+  originates BOTH ST routes and advertises them to z2.
+
+  NOTE: this feature runs `pfcp-inject` inside z1, so the `pfcp-inject`
+  binary (`tools/pfcp-inject`) must be on the BDD host PATH — build with
+  `cargo build --release -p pfcp-inject` and copy `target/release/pfcp-inject`
+  to /usr/bin, the same way the zebra-rs / vtyctl binaries are staged.
+
+  Scenario: Setup topology and establish iBGP session with MUP capability
+    Given a clean test environment
+    When I create bridge "br0"
+    And I create namespace "z1" with IP "192.168.0.1/24" on bridge "br0"
+    And I create namespace "z2" with IP "192.168.0.2/24" on bridge "br0"
+    And I start zebra-rs in namespace "z1"
+    And I start zebra-rs in namespace "z2"
+    And I apply config "z1.yaml" to namespace "z1"
+    And I apply config "z2.yaml" to namespace "z2"
+    And I wait 5 seconds for BGP to operate
+    Then BGP session in "z1" to "192.168.0.2" should be "Established"
+    And BGP session in "z2" to "192.168.0.1" should be "Established"
+    And show command "show bgp neighbor 192.168.0.2" in namespace "z1" should contain "IPv4 MUP: advertised and received"
+    And show command "show bgp mup mup-c" in namespace "z1" should contain "PFCP listen : 192.168.0.1:8805"
+
+  Scenario: One PFCP session originates both an ST1 and an ST2 route received by the peer
+    Given the test topology exists
+    When I execute "pfcp-inject --target 192.168.0.1 --port 8805 --ue-ipv4 192.0.2.5 --teid 0x12345678 --endpoint 10.0.0.1 --network-instance internet" in namespace "z1"
+    # PFCP ingest learned the single session.
+    Then show command "show bgp mup mup-c session" in namespace "z1" should eventually contain "192.0.2.5"
+    # The downlink VRF (st1) originates a Type-1 ST: UE prefix + access tunnel.
+    And show command "show bgp mup" in namespace "z1" should contain "[ST1][65000:101][ue=192.0.2.5/32][teid=305419896]"
+    # The uplink VRF (st2) originates a Type-2 ST from the SAME session:
+    # core endpoint + the full 32-bit GTP TEID, plus the Direct segment id.
+    And show command "show bgp mup" in namespace "z1" should contain "[ST2][65000:100][ep=10.0.0.1][teid=305419896]"
+    And show command "show bgp mup" in namespace "z1" should contain "rt:65000:200 mup:1:2"
+    # The peer receives both Session-Transformed routes.
+    And show command "show bgp mup" in namespace "z2" should eventually contain "[ST1][65000:101][ue=192.0.2.5/32][teid=305419896]"
+    And show command "show bgp mup" in namespace "z2" should contain "[ST2][65000:100][ep=10.0.0.1][teid=305419896]"
+
+  Scenario: Teardown topology
+    Given the test topology exists
+    When I stop zebra-rs in namespace "z1"
+    And I stop zebra-rs in namespace "z2"
+    And I delete namespace "z1"
+    And I delete namespace "z2"
+    And I delete bridge "br0"
+    Then the test environment should be clean

--- a/zebra-rs/src/bgp/config.rs
+++ b/zebra-rs/src/bgp/config.rs
@@ -7503,3 +7503,130 @@ mod afi_safi_next_hop_self_tests {
         );
     }
 }
+
+#[cfg(test)]
+mod mup_dual_origination_tests {
+    //! `build_mup_origination` fans one PFCP session out to *every* VRF
+    //! whose `afi-safi mup route {st1|st2}` binding matches the session's
+    //! Network Instance — so a single session under `internet` originates
+    //! both the downlink (st1 / Type-1 ST, the N6 VRF) and the uplink
+    //! (st2 / Type-2 ST, the N3 VRF) routes. The earlier `find_map`
+    //! returned only the first match. Independent test module with its own
+    //! mock channels, mirroring `afi_safi_next_hop_self_tests`.
+
+    use std::str::FromStr;
+
+    use bgp_packet::{MupPrefix, RouteDistinguisher};
+    use tokio::sync::mpsc;
+
+    use super::super::vrf_config::{BgpVrfConfig, MupSrv6Direction, MupSrv6Mobile};
+    use super::*;
+
+    fn fresh_bgp() -> Bgp {
+        let (inbound_tx, _inbound_rx) = mpsc::unbounded_channel();
+        let (_rib_rx_tx, rib_rx) = mpsc::unbounded_channel();
+        let client = crate::rib::client::RibClient::new(
+            inbound_tx,
+            crate::rib::client::ProtoId::from_raw(0),
+        );
+        Box::leak(Box::new(_inbound_rx));
+        let ctx = crate::context::ProtoContext::default_table(client);
+
+        let (rib_tx, _rib_rx) = mpsc::unbounded_channel();
+        let (rib_inbound_tx, _sub_inbound_rx) = mpsc::unbounded_channel();
+        Box::leak(Box::new(_rib_rx));
+        Box::leak(Box::new(_sub_inbound_rx));
+        let next_proto_id = std::sync::Arc::new(std::sync::atomic::AtomicU32::new(1));
+        let subscriber =
+            crate::config::RibSubscriber::for_test(rib_tx, rib_inbound_tx, next_proto_id);
+
+        let (policy_tx, _policy_rx) = mpsc::unbounded_channel();
+        Box::leak(Box::new(_policy_rx));
+        Bgp::new(
+            ctx,
+            rib_rx,
+            subscriber,
+            policy_tx,
+            None,
+            None,
+            tokio::sync::mpsc::channel(1).0,
+        )
+    }
+
+    fn mup_vrf(rd: &str, direction: MupSrv6Direction, ni: &str, ext: Option<&str>) -> BgpVrfConfig {
+        let mut cfg = BgpVrfConfig {
+            rd: Some(RouteDistinguisher::from_str(rd).unwrap()),
+            ..BgpVrfConfig::default()
+        };
+        cfg.mobile_uplane.srv6_mobile = Some(MupSrv6Mobile {
+            direction,
+            network_instance: Some(ni.to_string()),
+            mup_ext_comm: ext.map(|e| RouteDistinguisher::from_str(e).unwrap()),
+        });
+        cfg
+    }
+
+    fn session(ni: &str) -> crate::mup_c::session::MupSession {
+        crate::mup_c::session::MupSession {
+            seid: 1,
+            cp_seid: 0x1111,
+            peer: "10.0.0.2:8805".parse().unwrap(),
+            ue_ipv4: Some("192.0.2.5".parse().unwrap()),
+            ue_ipv6: None,
+            teid: 0x1234,
+            endpoint: Some("10.0.0.1".parse().unwrap()),
+            network_instance: Some(ni.to_string()),
+            qfi: Some(9),
+        }
+    }
+
+    /// One NI bound by both an st1 (N6 / downlink) VRF and an st2 (N3 /
+    /// uplink) VRF originates BOTH Session-Transformed routes from a single
+    /// session.
+    #[test]
+    fn one_session_originates_both_st1_and_st2() {
+        let mut bgp = fresh_bgp();
+        bgp.vrfs.insert(
+            "N6".to_string(),
+            mup_vrf("65501:1", MupSrv6Direction::Encapsulation, "internet", None),
+        );
+        bgp.vrfs.insert(
+            "N3".to_string(),
+            mup_vrf(
+                "65501:2",
+                MupSrv6Direction::Decapsulation,
+                "internet",
+                Some("100:1"),
+            ),
+        );
+
+        let routes = bgp.build_mup_origination(&session("internet"));
+        assert_eq!(routes.len(), 2, "one session → both st1 and st2 routes");
+        assert!(
+            routes
+                .iter()
+                .any(|(p, _)| matches!(p, MupPrefix::T1st { .. })),
+            "downlink Type-1 ST originated from the st1 VRF",
+        );
+        assert!(
+            routes
+                .iter()
+                .any(|(p, _)| matches!(p, MupPrefix::T2st { .. })),
+            "uplink Type-2 ST originated from the st2 VRF",
+        );
+    }
+
+    /// A session whose NI matches no VRF binding originates nothing.
+    #[test]
+    fn unmatched_ni_originates_nothing() {
+        let mut bgp = fresh_bgp();
+        bgp.vrfs.insert(
+            "N3".to_string(),
+            mup_vrf("65501:2", MupSrv6Direction::Decapsulation, "internet", None),
+        );
+        assert!(
+            bgp.build_mup_origination(&session("ims")).is_empty(),
+            "no VRF binds NI `ims`",
+        );
+    }
+}

--- a/zebra-rs/src/bgp/inst.rs
+++ b/zebra-rs/src/bgp/inst.rs
@@ -676,11 +676,13 @@ pub struct Bgp {
     /// reconfigure a running controller.
     pub mup_c_dirty: bool,
     /// MUP routes the controller has originated, keyed by session SEID →
-    /// the originated NLRI. Tracked so a Session Deletion / Modification
-    /// withdraws the exact prior route. No SRv6 SID is allocated for these
-    /// (the PE derives forwarding from its ISD/DSD routes), so only the
-    /// prefix is retained.
-    pub mup_c_originated: BTreeMap<u64, bgp_packet::MupPrefix>,
+    /// the originated NLRIs. One session can map to several ST routes (an
+    /// st1 and an st2 VRF binding the same Network Instance), so a Vec of
+    /// prefixes is retained — a Session Deletion / Modification withdraws
+    /// the exact prior routes. No SRv6 SID is allocated for these (the PE
+    /// derives forwarding from its ISD/DSD routes), so only the prefixes
+    /// are retained.
+    pub mup_c_originated: BTreeMap<u64, Vec<bgp_packet::MupPrefix>>,
     /// Config-driven MUP DSD (Direct Segment Discovery, type 2) routes
     /// originated per VRF (`afi-safi mup segment direct`), keyed by VRF
     /// name → `(originated NLRI, End.DT46 SID, ext-communities)`. The SID

--- a/zebra-rs/src/bgp/route.rs
+++ b/zebra-rs/src/bgp/route.rs
@@ -12652,110 +12652,134 @@ impl Bgp {
     /// is allocated — the receiving PE derives forwarding from its own
     /// ISD/DSD routes (draft-ietf-bess-mup-safi default).
     pub fn originate_mup_route(&mut self, session: &crate::mup_c::session::MupSession) {
-        // Replace any prior route for this session (Modification path).
+        // Replace any prior routes for this session (Modification path).
         self.withdraw_mup_route(session.seid);
 
-        let Some((prefix, attr)) = self.build_mup_origination(session) else {
+        let originations = self.build_mup_origination(session);
+        if originations.is_empty() {
             return;
-        };
-        let mut rib = BgpRib::new(
-            ORIGINATED_PEER,
-            Ipv4Addr::UNSPECIFIED,
-            BgpRibType::Originated,
-            0,
-            32768,
-            &attr,
-            None,
-            None,
-            false,
-        );
-        rib.attr = self.attr_store.intern(attr);
-        let _ = self.local_rib.update_mup(prefix.clone(), rib);
-        let selected = self.local_rib.select_best_path_mup(&prefix);
-        self.mup_c_originated.insert(session.seid, prefix.clone());
-        self.mup_apply_selected(prefix, selected);
+        }
+        // One session can map to several ST routes (an st1 and an st2 VRF
+        // sharing the NI). Install + advertise each, recording every prefix
+        // so the deletion / next modification withdraws all of them.
+        let mut prefixes = Vec::with_capacity(originations.len());
+        for (prefix, attr) in originations {
+            let mut rib = BgpRib::new(
+                ORIGINATED_PEER,
+                Ipv4Addr::UNSPECIFIED,
+                BgpRibType::Originated,
+                0,
+                32768,
+                &attr,
+                None,
+                None,
+                false,
+            );
+            rib.attr = self.attr_store.intern(attr);
+            let _ = self.local_rib.update_mup(prefix.clone(), rib);
+            let selected = self.local_rib.select_best_path_mup(&prefix);
+            self.mup_apply_selected(prefix.clone(), selected);
+            prefixes.push(prefix);
+        }
+        self.mup_c_originated.insert(session.seid, prefixes);
     }
 
-    /// Withdraw the MUP route originated for `seid` (Session Deletion or
+    /// Withdraw the MUP route(s) originated for `seid` (Session Deletion or
     /// the replace step of a Modification). No-op when nothing was
     /// originated.
     pub fn withdraw_mup_route(&mut self, seid: u64) {
-        let Some(prefix) = self.mup_c_originated.remove(&seid) else {
+        let Some(prefixes) = self.mup_c_originated.remove(&seid) else {
             return;
         };
-        self.local_rib.remove_mup(&prefix, 0, ORIGINATED_PEER);
-        let selected = self.local_rib.select_best_path_mup(&prefix);
-        self.mup_apply_selected(prefix, selected);
+        for prefix in prefixes {
+            self.local_rib.remove_mup(&prefix, 0, ORIGINATED_PEER);
+            let selected = self.local_rib.select_best_path_mup(&prefix);
+            self.mup_apply_selected(prefix, selected);
+        }
     }
 
-    /// Correlate a session to a VRF `mup` config and build the
-    /// ST prefix + attributes. Returns `None` when no VRF matches the
-    /// session's Network Instance, the VRF has no RD, or the session lacks
-    /// the addresses the chosen ST route type needs.
-    fn build_mup_origination(
-        &mut self,
+    /// Correlate a session to the VRF `mup` configs and build one ST prefix +
+    /// attributes per matching VRF. A single Network Instance can be bound by
+    /// more than one VRF — e.g. an N3 VRF binds `route st1` and an N6 VRF
+    /// binds `route st2` to the same `internet` NI — so one PFCP session
+    /// originates *both* Session-Transformed routes, one per matching VRF.
+    /// Returns an empty Vec when no VRF matches the session's Network
+    /// Instance. A matching VRF is skipped (no entry) when it has no RD or
+    /// the session lacks the addresses that ST route type needs.
+    pub(super) fn build_mup_origination(
+        &self,
         session: &crate::mup_c::session::MupSession,
-    ) -> Option<(bgp_packet::MupPrefix, BgpAttr)> {
+    ) -> Vec<(bgp_packet::MupPrefix, BgpAttr)> {
         use super::vrf_config::MupSrv6Direction;
-        let ni = session.network_instance.as_deref()?;
-        // Correlate the session NI to a `router bgp vrf <name> afi-safi mup
-        // route {st1|st2}` config for the RD + direction + (st2) ext-comm.
-        let (name, rd, direction, seg_ec) = self.vrfs.iter().find_map(|(name, cfg)| {
-            let sm = cfg.mobile_uplane.srv6_mobile.as_ref()?;
-            (sm.network_instance.as_deref() == Some(ni))
-                .then(|| (name.clone(), cfg.rd, sm.direction, sm.mup_ext_comm))
-        })?;
-        let rd = rd?;
-        // The export route-targets now live on the top-level
-        // `vrf <name> mup route-target export` (RIB-owned,
-        // pushed to `rib_known_vrfs` via `VrfRouteTargets`), the same
-        // framework as ipv4 / ipv6.
-        let rts = self
-            .rib_known_vrfs
-            .get(&name)
-            .map(|k| k.mup_export_rts.clone())
-            .unwrap_or_default();
-        let prefix = match direction {
-            // Encapsulation (N6 / downlink): Type-1 ST carries the UE
-            // prefix + access tunnel. The endpoint (gNB) family may differ
-            // from the UE prefix family (mixed-AFI 5G).
-            MupSrv6Direction::Encapsulation => match (mup_ue_prefix(session), session.endpoint) {
-                (Some(prefix), Some(endpoint)) => bgp_packet::MupPrefix::T1st {
-                    rd,
-                    prefix,
-                    teid: session.teid,
-                    qfi: session.qfi.unwrap_or(0),
-                    endpoint,
-                    source: None,
-                },
-                _ => return None,
-            },
-            // Decapsulation (N3 / uplink): Type-2 ST carries the core
-            // endpoint + TEID. The Endpoint Length (draft §3.1.4.1) spans
-            // the address *and* the trailing 32-bit GTP TEID, so it is
-            // 64 (IPv4) / 160 (IPv6) — using the bare address width (32 /
-            // 128) would drop the TEID from the wire (a TEID of 0 is a
-            // malformed NLRI per the draft).
-            MupSrv6Direction::Decapsulation => match session.endpoint {
-                Some(endpoint) => bgp_packet::MupPrefix::T2st {
-                    rd,
-                    endpoint,
-                    endpoint_len: if endpoint.is_ipv4() { 64 } else { 160 },
-                    teid: session.teid,
-                },
-                None => return None,
-            },
+        let Some(ni) = session.network_instance.as_deref() else {
+            return Vec::new();
         };
-        let mut attr = build_mup_attr(self.mup_c_config.controller_address, &rts);
-        // §3.3.10: a Type-2 ST route SHOULD carry the BGP MUP Extended
-        // Community of the Direct segment it resolves to, so a receiving PE
-        // maps the (endpoint, TEID) tunnel onto the End.DT46 segment.
-        if matches!(direction, MupSrv6Direction::Decapsulation)
-            && let Some(seg) = seg_ec
-        {
-            attr_add_ecom(&mut attr, mup_direct_segment_ecom(&seg));
-        }
-        Some((prefix, attr))
+        // Correlate the session NI to *every* `router bgp vrf <name> afi-safi
+        // mup route {st1|st2}` binding that matches it, building one ST route
+        // per match (RD + direction + the st2 ext-comm come from each VRF).
+        self.vrfs
+            .iter()
+            .filter_map(|(name, cfg)| {
+                let sm = cfg.mobile_uplane.srv6_mobile.as_ref()?;
+                if sm.network_instance.as_deref() != Some(ni) {
+                    return None;
+                }
+                let rd = cfg.rd?;
+                // The export route-targets now live on the top-level
+                // `vrf <name> mup route-target export` (RIB-owned, pushed to
+                // `rib_known_vrfs` via `VrfRouteTargets`), the same framework
+                // as ipv4 / ipv6.
+                let rts = self
+                    .rib_known_vrfs
+                    .get(name)
+                    .map(|k| k.mup_export_rts.clone())
+                    .unwrap_or_default();
+                let prefix = match sm.direction {
+                    // Encapsulation (N6 / downlink): Type-1 ST carries the UE
+                    // prefix + access tunnel. The endpoint (gNB) family may
+                    // differ from the UE prefix family (mixed-AFI 5G).
+                    MupSrv6Direction::Encapsulation => {
+                        match (mup_ue_prefix(session), session.endpoint) {
+                            (Some(prefix), Some(endpoint)) => bgp_packet::MupPrefix::T1st {
+                                rd,
+                                prefix,
+                                teid: session.teid,
+                                qfi: session.qfi.unwrap_or(0),
+                                endpoint,
+                                source: None,
+                            },
+                            _ => return None,
+                        }
+                    }
+                    // Decapsulation (N3 / uplink): Type-2 ST carries the core
+                    // endpoint + TEID. The Endpoint Length (draft §3.1.4.1)
+                    // spans the address *and* the trailing 32-bit GTP TEID, so
+                    // it is 64 (IPv4) / 160 (IPv6) — using the bare address
+                    // width (32 / 128) would drop the TEID from the wire (a
+                    // TEID of 0 is a malformed NLRI per the draft).
+                    MupSrv6Direction::Decapsulation => match session.endpoint {
+                        Some(endpoint) => bgp_packet::MupPrefix::T2st {
+                            rd,
+                            endpoint,
+                            endpoint_len: if endpoint.is_ipv4() { 64 } else { 160 },
+                            teid: session.teid,
+                        },
+                        None => return None,
+                    },
+                };
+                let mut attr = build_mup_attr(self.mup_c_config.controller_address, &rts);
+                // §3.3.10: a Type-2 ST route SHOULD carry the BGP MUP Extended
+                // Community of the Direct segment it resolves to, so a
+                // receiving PE maps the (endpoint, TEID) tunnel onto the
+                // End.DT46 segment.
+                if matches!(sm.direction, MupSrv6Direction::Decapsulation)
+                    && let Some(seg) = sm.mup_ext_comm
+                {
+                    attr_add_ecom(&mut attr, mup_direct_segment_ecom(&seg));
+                }
+                Some((prefix, attr))
+            })
+            .collect()
     }
 
     /// Apply the post-update best path of one MUP prefix to peers:


### PR DESCRIPTION
## Summary

A MUP controller session whose Network Instance is bound by more than one VRF should originate **all** matching Session-Transformed routes. `build_mup_origination` used `find_map` over the VRFs, so it picked the **first** match and emitted a single route. With an N3 VRF binding `afi-safi mup route st1` and an N6 VRF binding `route st2` to the same NI, only one ST route fired.

This change iterates **every** VRF whose `srv6_mobile.network_instance` matches the session NI and builds one ST route per match:

- `build_mup_origination` now returns `Vec<(MupPrefix, BgpAttr)>`. One session under `internet` originates both the downlink **Type-1 ST** (UE prefix + access tunnel) and the uplink **Type-2 ST** (core endpoint + GTP TEID). Each match still skips cleanly when it has no RD or lacks the addresses its route type needs.
- `mup_c_originated` becomes `BTreeMap<u64, Vec<MupPrefix>>`, so a Session Deletion / Modification withdraws all of a session's routes. `originate_mup_route` installs + advertises each; `withdraw_mup_route` withdraws them all.

Grammar is unchanged — the symmetric `route st1{}/route st2{}/segment direct{}` shape from #1637 already supports this; only the origination behavior changes.

## Test plan

- `cargo fmt`, `cargo clippy --workspace --all-targets -- -D warnings` — clean.
- Full zebra-rs unit suite **1472 passed** + **42 yang_load** — green.
- New unit tests `config::mup_dual_origination_tests`: one session → both a `T1st` and a `T2st`; unmatched NI → nothing.
- New BDD feature `bgp_mup_dual_st`: two VRFs bind NI `internet`, one `pfcp-inject` session, asserts both `[ST1][65000:101][ue=192.0.2.5/32]…` and `[ST2][65000:100][ep=10.0.0.1]…` (`rt:65000:200 mup:1:2`) on z1 and on z2.
- BDD config grammar validated via an isolated `--yang-path` + `--config-file` daemon load (both VRFs + `mup-c` parsed). The BDD run itself is left to CI — a parallel session holds the shared `/usr/bin/zebra-rs`.

Generated with [Claude Code](https://claude.com/claude-code)