### PR TITLE
bgp-mup: originate ISD route from segment interwork

### DIFF
--- a/bdd/Makefile
+++ b/bdd/Makefile
@@ -41,6 +41,15 @@ bgp_mup_segment_dsd:
 	mkdir -p allure-results
 	cargo test --test cucumber -- --concurrency=1 --tags "@bgp_mup_segment_dsd"
 
+# MUP segment ISD: a PE with `encapsulation srv6` VRF + `afi-safi mup
+# segment interwork prefix <p>` carves a per-VRF End.DT46 SID, installs the
+# seg6local decap, and originates an Interwork Segment Discovery (ISD) route
+# under the configured prefix, received by the peer. Needs root netns
+# (kernel VRF + seg6local).
+bgp_mup_isd:
+	mkdir -p allure-results
+	cargo test --test cucumber -- --concurrency=1 --tags "@bgp_mup_isd"
+
 # MUP ST2: the MUP-C learns a PFCP decapsulation session (Network Instance
 # `core`) and originates a Type-2 Session-Transformed route carrying the
 # core endpoint + GTP TEID and the Direct segment id (MUP Extended

--- a/bdd/tests/configs/bgp_mup_isd/z1.yaml
+++ b/bdd/tests/configs/bgp_mup_isd/z1.yaml
@@ -1,0 +1,71 @@
+# z1 — MUP PE originating an Interwork Segment Discovery (ISD, type 1)
+# route for VRF N6 (`afi-safi mup segment interwork prefix 10.60.0.0/16`).
+# IS-IS L2 SRv6 underlay + iBGP (mup afi-safi) to z2 over loopbacks. VRF N6
+# is `encapsulation srv6`, so it carves a per-VRF End.DT46 service SID from
+# locator S and installs the seg6local decap into the VRF table; `segment
+# interwork` advertises that segment as an ISD route (NLRI = rd + the
+# configured interwork prefix) carrying the End.DT46 SID as the SRv6 L3
+# Service, received by z2. (zebra-rs uses End.DT46 for the interwork segment
+# too; the draft's GTP4.E/GTP6.E behaviours are VPP/eBPF, deferred.)
+vrf:
+- name: N6
+  mup:
+    route-target:
+      export:
+      - "65501:10"
+interface:
+- if-name: lo
+  ipv6:
+    address: 2001:db8::1/128
+- if-name: z1-z2
+  ipv6:
+    address: 2001:db8:0:12::1/64
+segment-routing:
+  locator:
+  - name: S
+    prefix: fcbb:bbbb:1::/48
+    behavior: usid
+router:
+  isis:
+    net: 49.0000.0000.0000.0001.00
+    hostname: z1
+    is-type: level-2-only
+    segment-routing:
+      srv6:
+        locator: S
+    interface:
+    - if-name: lo
+      ipv6:
+        enable: true
+    - if-name: z1-z2
+      network-type: point-to-point
+      metric: 1
+      ipv6:
+        enable: true
+  bgp:
+    global:
+      as: 65501
+      router-id: 10.0.0.1
+    timer:
+      adv-interval:
+        ibgp: 1
+    segment-routing:
+      srv6:
+        locator: S
+    neighbor:
+    - remote-address: 2001:db8::2
+      remote-as: 65501
+      update-source: 2001:db8::1
+      enabled: true
+      afi-safi:
+      - name: mup
+        enabled: true
+    vrf:
+    - name: N6
+      rd: "65501:10"
+      encapsulation: srv6
+      afi-safi:
+        mup:
+          segment:
+          - type: interwork
+            prefix: 10.60.0.0/16

--- a/bdd/tests/configs/bgp_mup_isd/z2.yaml
+++ b/bdd/tests/configs/bgp_mup_isd/z2.yaml
@@ -1,0 +1,52 @@
+# z2 — MUP peer that receives z1's Interwork Segment Discovery (ISD) route.
+# IS-IS L2 SRv6 underlay + iBGP (mup afi-safi) to z1 over loopbacks. No
+# VRF / segment of its own — it just stores the ISD route (RD + z1's
+# interwork prefix 10.60.0.0/16) carrying z1's End.DT46 SID in its MUP
+# Loc-RIB.
+interface:
+- if-name: lo
+  ipv6:
+    address: 2001:db8::2/128
+- if-name: z2-z1
+  ipv6:
+    address: 2001:db8:0:12::2/64
+segment-routing:
+  locator:
+  - name: LOC2
+    prefix: fcbb:bbbb:2::/48
+    behavior: usid
+router:
+  isis:
+    net: 49.0000.0000.0000.0002.00
+    hostname: z2
+    is-type: level-2-only
+    segment-routing:
+      srv6:
+        locator: LOC2
+    interface:
+    - if-name: lo
+      ipv6:
+        enable: true
+    - if-name: z2-z1
+      network-type: point-to-point
+      metric: 1
+      ipv6:
+        enable: true
+  bgp:
+    global:
+      as: 65501
+      router-id: 10.0.0.2
+    timer:
+      adv-interval:
+        ibgp: 1
+    segment-routing:
+      srv6:
+        locator: LOC2
+    neighbor:
+    - remote-address: 2001:db8::1
+      remote-as: 65501
+      update-source: 2001:db8::2
+      enabled: true
+      afi-safi:
+      - name: mup
+        enabled: true

--- a/bdd/tests/features/bgp_mup_isd.feature
+++ b/bdd/tests/features/bgp_mup_isd.feature
@@ -1,0 +1,71 @@
+@serial
+@bgp_mup_isd
+Feature: BGP MUP PE originates an Interwork Segment Discovery (ISD) route over SRv6
+  As a network operator
+  I want a zebra-rs BGP MUP PE to originate an Interwork Segment Discovery
+  (ISD, type 1, SAFI 85 / RFC 9833) route for an `encapsulation srv6` VRF
+  when `afi-safi mup segment interwork prefix <p>` is configured, so the
+  per-VRF End.DT46 service SID is carved from the locator, installed into the
+  kernel FIB, and advertised under the configured interwork prefix as the
+  segment a receiving PE resolves for matching Session-Transformed routes.
+
+  Test Topology:
+  ```
+        2001:db8::1/128            2001:db8::2/128
+       ┌──────────┐  IS-IS L2 SRv6  ┌──────────┐
+       │    z1    │═════════════════│    z2    │
+       │ MUP PE   │   iBGP (mup)    │ receiver │
+       │ vrf N6   │                 │          │
+       └──────────┘                 └──────────┘
+   z1-z2 2001:db8:0:12::1/64   2001:db8:0:12::2/64
+  ```
+
+  z1 has VRF N6 (`encapsulation srv6`, rd 65501:10) and `afi-safi mup
+  segment interwork prefix 10.60.0.0/16`, so it carves an End.DT46 SID from
+  locator S, installs the seg6local decap into N6's table, and originates an
+  ISD route (NLRI = rd + the interwork prefix 10.60.0.0/16) carrying that
+  SID. z2 receives it.
+
+  Scenario: Build topology and establish iBGP with the MUP capability
+    Given a clean test environment
+    When I create namespace "z1"
+    And I create namespace "z2"
+    And I connect namespace "z1" interface "z1-z2" to namespace "z2" interface "z2-z1"
+    And I start zebra-rs in namespace "z1"
+    And I start zebra-rs in namespace "z2"
+    And I apply config "z1.yaml" to namespace "z1"
+    And I apply config "z2.yaml" to namespace "z2"
+    And I wait 45 seconds
+    Then BGP session in "z1" to "2001:db8::2" should be "Established"
+    And BGP session in "z2" to "2001:db8::1" should be "Established"
+    And show command "show bgp neighbor 2001:db8::2" in namespace "z1" should contain "IPv4 MUP: advertised and received"
+
+  Scenario: z1 originates the ISD route and installs the End.DT46 SID
+    Given the test topology exists
+    # The ISD NLRI is the VRF RD + the configured interwork prefix; an IPv4
+    # prefix rides the IPv4-MUP AFI.
+    Then show command "show bgp mup" in namespace "z1" should eventually contain "[ISD][65501:10][10.60.0.0/16]"
+    # The route carries the per-VRF End.DT46 SID as a local SRv6 L3 Service.
+    And show command "show bgp mup" in namespace "z1" should contain "Local SID"
+    And show command "show bgp mup" in namespace "z1" should contain "End.DT46"
+    # The ISD carries the VRF's export route-target (no MUP Extended Community
+    # — the interwork route is resolved by endpoint-address lookup, §3.1.1).
+    And show command "show bgp mup" in namespace "z1" should contain "rt:65501:10"
+    # The per-VRF view mirrors the originated ISD (its RD matches N6's rd).
+    And show command "show bgp vrf N6 mup" in namespace "z1" should eventually contain "[ISD][65501:10][10.60.0.0/16]"
+    # The End.DT46 decap is installed into the kernel FIB.
+    And command "ip -6 route show table all" in namespace "z1" should eventually contain "End.DT46"
+
+  Scenario: z2 receives the ISD route with the End.DT46 SID
+    Given the test topology exists
+    Then show command "show bgp mup" in namespace "z2" should eventually contain "[ISD][65501:10][10.60.0.0/16]"
+    And show command "show bgp mup" in namespace "z2" should contain "Remote SID"
+    And show command "show bgp mup" in namespace "z2" should contain "End.DT46"
+
+  Scenario: Teardown topology
+    Given the test topology exists
+    When I stop zebra-rs in namespace "z1"
+    And I stop zebra-rs in namespace "z2"
+    And I delete namespace "z1"
+    And I delete namespace "z2"
+    Then the test environment should be clean

--- a/docs/design/bgp-mup-followups.md
+++ b/docs/design/bgp-mup-followups.md
@@ -391,7 +391,7 @@ type 2) origination** that the draft-default ST routes resolve against:
   (zebra-bgp-vrf.yang, under the per-VRF `afi-safi` container — distinct
   from the controller-side `mup route {st1|st2}`). `MupSegmentMode` on
   `BgpVrfMobileUplane`; callback `/router/bgp/vrf/afi-safi/mup/segment`.
-  `interwork` (ISD, type 1) is parsed but origination is deferred.
+  (`interwork` (ISD, type 1) origination landed later — see P6 slice 4.)
 - **`segment direct` originates a DSD** route for the VRF: NLRI is the
   VRF **RD + router-id** (so it rides the IPv4-MUP AFI); the attributes
   carry the PE locator node as the **IPv6 next-hop** and the per-VRF
@@ -421,10 +421,10 @@ type 2) origination** that the draft-default ST routes resolve against:
   all`), and z2 receives it with the SID. Excluded from CI; run live via
   `make -C bdd bgp_mup_segment_dsd`.
 
-**Still open in P6:** the *receive* side — a PE consuming a peer's DSD/ISD
-route to drive forwarding (the *ISD/DSD-route → segment-SID resolution*
-step below), ISD (`segment interwork`) origination, and the GTP
-behaviours.
+**Still open in P6 (at the time of slice 1):** the *receive* side — a PE
+consuming a peer's DSD/ISD route to drive forwarding (the *ISD/DSD-route →
+segment-SID resolution* step below), ISD (`segment interwork`) origination
+(landed in slice 4), and the GTP behaviours.
 
 #### P6 slice 2 — ST2 origination (TEID) + MUP Extended Community — **DONE**
 
@@ -486,8 +486,8 @@ MUP Extended Community:
   `bgp_mup_segment_dsd`.
 
 **Still open in P6 (unchanged):** the *receive* side (ST2 → Direct-segment
-resolution → FIB), ISD (`segment interwork`) origination, and the GTP
-behaviours.
+resolution → FIB) and the GTP behaviours. (ISD (`segment interwork`)
+origination landed in slice 4.)
 
 #### P6 slice 3 — receive-side ST2 → Direct-segment resolution — **DONE**
 
@@ -516,8 +516,38 @@ draft-mpmz-bess-mup-safi §3.3.12:
   Direct segment. Plus a `render_mup_table` unit test. Run live via
   `make -C bdd bgp_mup_interwork`.
 
-**Still open in P6 (unchanged):** the receive-side *FIB* write (above),
-ISD (`segment interwork`) route origination, and the GTP behaviours.
+**Still open in P6 (unchanged):** the receive-side *FIB* write (above) and
+the GTP behaviours.
+
+#### P6 slice 4 — ISD origination — **DONE**
+
+The PE-side **Interwork Segment Discovery (ISD, type 1) origination**, the
+sibling of the slice-1 DSD:
+
+- **`afi-safi mup segment interwork prefix <p>`** — a new `prefix` leaf on
+  the `segment` list (zebra-bgp-vrf.yang; `BgpVrfMobileUplane.interwork_prefix`,
+  handler `config_vrf_mup_segment_prefix`, callback
+  `/router/bgp/vrf/afi-safi/mup/segment/prefix`). The CLI is
+  `router bgp vrf <name> afi-safi mup segment interwork prefix 10.60.0.0/16`
+  — typically the locally connected gNodeB N3 prefix (draft §3.1.1).
+- **`segment interwork` originates an ISD** route: NLRI = the VRF **RD + the
+  configured prefix** (its family selects the AFI), the attributes carry the
+  PE locator node as the IPv6 next-hop and the per-VRF **End.DT46** SID as
+  the SRv6 L3 Service. zebra-rs uses End.DT46 for the interwork segment too
+  (the draft's GTP4.E/GTP6.E behaviours are VPP/eBPF, deferred); no MUP
+  Extended Community (an ISD is resolved by endpoint-address lookup, §3.1.1).
+- **Shared machinery with DSD.** The DSD reconcile/originate/withdraw were
+  generalized to *segment* origination (`build_mup_segment_origination`,
+  `reconcile_mup_segment`, `mup_segment_originated`) — a VRF has at most one
+  segment route (its `segment` is direct *or* interwork), so the existing
+  per-VRF-name tracking covers both, and a direct↔interwork switch naturally
+  withdraws the old NLRI and originates the new. The SID carve + seg6local
+  decap + gating (encap srv6, RD, kernel VRF, locator) are unchanged.
+- **Test.** `@bgp_mup_isd` BDD (root): z1 originates
+  `[ISD][65501:10][10.60.0.0/16]` with a local End.DT46 SID + installs the
+  decap; z2 receives it. Plus a `mup_segment_nlri` unit test (DSD vs ISD NLRI
+  selection + the empty-prefix / zero-router-id gates). Run live via
+  `make -C bdd bgp_mup_isd`.
 
 #### Remaining
 

--- a/zebra-rs/src/bgp/config.rs
+++ b/zebra-rs/src/bgp/config.rs
@@ -4156,6 +4156,10 @@ impl Bgp {
             super::vrf_config::config_vrf_mup_ext_comm,
         );
         self.callback_add(
+            "/router/bgp/vrf/afi-safi/mup/segment/prefix",
+            super::vrf_config::config_vrf_mup_segment_prefix,
+        );
+        self.callback_add(
             "/router/bgp/vrf/afi-safi/mup/route",
             super::vrf_config::config_vrf_mup_route,
         );

--- a/zebra-rs/src/bgp/inst.rs
+++ b/zebra-rs/src/bgp/inst.rs
@@ -683,15 +683,16 @@ pub struct Bgp {
     /// derives forwarding from its ISD/DSD routes), so only the prefixes
     /// are retained.
     pub mup_c_originated: BTreeMap<u64, Vec<bgp_packet::MupPrefix>>,
-    /// Config-driven MUP DSD (Direct Segment Discovery, type 2) routes
-    /// originated per VRF (`afi-safi mup segment direct`), keyed by VRF
-    /// name → `(originated NLRI, End.DT46 SID, ext-communities)`. The SID
-    /// and the ext-community set (export RTs + the Direct-segment MUP
-    /// ext-comm) are tracked alongside the prefix so a locator-driven SID
-    /// change *or* a later RT / `mup-ext-comm` change re-advertises even
-    /// though the RD+router-id NLRI key is stable. See
-    /// [`Bgp::reconcile_mup_dsd`].
-    pub mup_dsd_originated: BTreeMap<
+    /// Config-driven MUP Segment Discovery routes originated per VRF — a DSD
+    /// (Direct, type 2, `afi-safi mup segment direct`) or an ISD (Interwork,
+    /// type 1, `afi-safi mup segment interwork prefix <p>`); a VRF has at
+    /// most one. Keyed by VRF name → `(originated NLRI, End.DT46 SID,
+    /// ext-communities)`. The SID and the ext-community set (export RTs + the
+    /// Direct-segment MUP ext-comm, DSD only) are tracked alongside the
+    /// prefix so a locator-driven SID change *or* a later RT / `mup-ext-comm`
+    /// change re-advertises even though the NLRI key is stable. See
+    /// [`Bgp::reconcile_mup_segment`].
+    pub mup_segment_originated: BTreeMap<
         String,
         (
             bgp_packet::MupPrefix,
@@ -1144,7 +1145,7 @@ impl Bgp {
             mup_c_view: crate::mup_c::inst::MupCView::default(),
             mup_c_dirty: false,
             mup_c_originated: BTreeMap::new(),
-            mup_dsd_originated: BTreeMap::new(),
+            mup_segment_originated: BTreeMap::new(),
             local_fdb: BTreeMap::new(),
             local_vxlans: BTreeMap::new(),
             local_smet: BTreeMap::new(),
@@ -1457,7 +1458,7 @@ impl Bgp {
         }
         // The SIDs just changed under stable RD+router-id keys — re-advertise
         // any `segment direct` DSD route with the new End.DT46 SID.
-        self.reconcile_mup_dsd();
+        self.reconcile_mup_segment();
     }
 
     /// `segment-routing srv6 ipv6-unicast` toggle. Enables or disables
@@ -1736,8 +1737,8 @@ impl Bgp {
 
         // MUP DSD NLRIs embed the router-id (RD + router-id); a router-id
         // change rebinds the key, so withdraw the old-keyed DSD and
-        // re-originate under the new — `reconcile_mup_dsd` does both.
-        self.reconcile_mup_dsd();
+        // re-originate under the new — `reconcile_mup_segment` does both.
+        self.reconcile_mup_segment();
     }
 
     /// Recompute the effective BGP Identifier from its two sources —
@@ -2280,7 +2281,7 @@ impl Bgp {
         self.broadcast_colour_steering();
         // Originate / withdraw config-driven MUP DSD segment routes now the
         // VRF set (and its SIDs / kernel context) may have changed.
-        self.reconcile_mup_dsd();
+        self.reconcile_mup_segment();
     }
 
     /// Reconcile the MUP controller against `mup_c_config` at every
@@ -2382,7 +2383,7 @@ impl Bgp {
         );
         // The respawn with real kernel context is what actually installs the
         // End.DT46 decap; a `segment direct` VRF can now originate its DSD.
-        self.reconcile_mup_dsd();
+        self.reconcile_mup_segment();
     }
 
     pub fn process_cm_msg(&mut self, msg: ConfigRequest) {
@@ -3249,7 +3250,7 @@ impl Bgp {
                 // `apply_vrf_commit_diff` handles teardown.
                 // The kernel VRF (and its End.DT46 decap) is gone, so
                 // withdraw any DSD segment route that depended on it.
-                self.reconcile_mup_dsd();
+                self.reconcile_mup_segment();
             }
             RibRx::VrfRouteTargets {
                 name,
@@ -3299,7 +3300,7 @@ impl Bgp {
                 // Re-stamp the VRF's DSD segment route with the new MUP
                 // export RTs (same race the v4/v6 retag above closes).
                 if export_mup_changed {
-                    self.reconcile_mup_dsd();
+                    self.reconcile_mup_segment();
                 }
             }
             // Redistribute deliveries from RIB — initial walk

--- a/zebra-rs/src/bgp/route.rs
+++ b/zebra-rs/src/bgp/route.rs
@@ -7636,6 +7636,35 @@ fn bgp_nexthop_ip(nh: &BgpNexthop) -> Option<IpAddr> {
     }
 }
 
+/// Select the Segment Discovery NLRI for a VRF's `segment` mode: a DSD
+/// (RD + router-id) for `Direct`, or an ISD (RD + the configured interwork
+/// prefix) for `Interwork`. Returns `None` when the route's NLRI key is not
+/// available yet — an all-zero router-id for Direct (cold start before the
+/// router-id resolves) or an unset `segment interwork prefix` for Interwork.
+fn mup_segment_nlri(
+    mode: super::vrf_config::MupSegmentMode,
+    rd: RouteDistinguisher,
+    router_id: Ipv4Addr,
+    interwork_prefix: Option<ipnet::IpNet>,
+) -> Option<MupPrefix> {
+    use super::vrf_config::MupSegmentMode;
+    match mode {
+        MupSegmentMode::Direct => {
+            if router_id.is_unspecified() {
+                return None;
+            }
+            Some(MupPrefix::Dsd {
+                rd,
+                address: IpAddr::V4(router_id),
+            })
+        }
+        MupSegmentMode::Interwork => Some(MupPrefix::Isd {
+            rd,
+            prefix: interwork_prefix?,
+        }),
+    }
+}
+
 /// Build the (route, egress attrs, MP_REACH next-hop) to advertise one
 /// selected MUP path to `peer`, or `None` to suppress it. Mirrors
 /// `route_update_evpn`: split-horizon (never back to the source peer),
@@ -7667,11 +7696,11 @@ fn route_update_mup(
     let mut attrs = (*rib.attr).clone();
     ebgp_egress_aspath(&peer.egress_as(), &mut attrs);
 
-    // MP_REACH next-hop: an SRv6 segment route we originate (a DSD carrying
-    // an End.DT46 Prefix-SID) advertises the PE locator node carried in the
-    // attr, so a receiving PE H.Encaps to it; next-hop-self toward eBGP and
-    // for our other originations; otherwise preserve the received next-hop
-    // (RFC 9833 — the PE/controller address the ingress PE resolves).
+    // MP_REACH next-hop: an SRv6 segment route we originate (a DSD or ISD
+    // carrying an End.DT46 Prefix-SID) advertises the PE locator node carried
+    // in the attr, so a receiving PE H.Encaps to it; next-hop-self toward
+    // eBGP and for our other originations; otherwise preserve the received
+    // next-hop (RFC 9833 — the PE/controller address the ingress PE resolves).
     let nhop: IpAddr = if rib.is_originated() && attrs.prefix_sid.is_some() {
         bgp_nexthop_ip(attrs.nexthop.as_ref()?)?
     } else if peer.is_ebgp() || rib.is_originated() {
@@ -12846,28 +12875,32 @@ impl Bgp {
         let _ = handle.inbox.send(msg);
     }
 
-    /// Reconcile config-driven MUP DSD (Direct Segment Discovery, type 2)
-    /// origination across every VRF. Idempotent — safe to call after VRF
-    /// spawn / kernel-ctx respawn, locator (SID) change, and MUP RT update.
-    /// Originates a DSD for each VRF that now qualifies (see
-    /// [`Self::build_mup_dsd_origination`]), withdraws those that no longer
-    /// do, and re-advertises when the SID changed under a stable NLRI key.
-    pub(super) fn reconcile_mup_dsd(&mut self) {
+    /// Reconcile config-driven MUP Segment Discovery origination — DSD
+    /// (Direct, type 2) and ISD (Interwork, type 1) — across every VRF.
+    /// Idempotent — safe to call after VRF spawn / kernel-ctx respawn,
+    /// locator (SID) change, and MUP RT update. Originates a segment route
+    /// for each VRF that now qualifies (see
+    /// [`Self::build_mup_segment_origination`]), withdraws those that no
+    /// longer do, and re-advertises when the SID changed under a stable
+    /// NLRI key. A VRF has at most one segment route (its `segment` is one
+    /// of direct/interwork), so the per-VRF-name tracking holds for both.
+    pub(super) fn reconcile_mup_segment(&mut self) {
         let names: Vec<String> = self.vrfs.keys().cloned().collect();
         let mut desired: std::collections::BTreeMap<
             String,
             (bgp_packet::MupPrefix, std::net::Ipv6Addr, BgpAttr),
         > = std::collections::BTreeMap::new();
         for name in &names {
-            if let Some(d) = self.build_mup_dsd_origination(name) {
+            if let Some(d) = self.build_mup_segment_origination(name) {
                 desired.insert(name.clone(), d);
             }
         }
-        // Withdraw DSDs no longer desired, or whose NLRI key changed (a
-        // changed RD/router-id needs an explicit withdraw of the OLD prefix
-        // before the new one is originated under a different key).
+        // Withdraw segment routes no longer desired, or whose NLRI key
+        // changed (a changed RD/router-id/prefix, or a direct↔interwork
+        // switch, needs an explicit withdraw of the OLD prefix before the new
+        // one is originated under a different key).
         let prev: Vec<(String, bgp_packet::MupPrefix)> = self
-            .mup_dsd_originated
+            .mup_segment_originated
             .iter()
             .map(|(n, (p, _, _))| (n.clone(), p.clone()))
             .collect();
@@ -12877,7 +12910,7 @@ impl Bgp {
                 .map(|(p, _, _)| *p == prev_prefix)
                 .unwrap_or(false);
             if !keep {
-                self.withdraw_mup_dsd(&name);
+                self.withdraw_mup_segment(&name);
             }
         }
         // Originate or refresh. Skip only when the NLRI key, the SID *and*
@@ -12886,38 +12919,47 @@ impl Bgp {
         // re-advertise but a later RT / `mup-ext-comm` arrival does.
         for (name, (prefix, sid, attr)) in desired {
             let unchanged = self
-                .mup_dsd_originated
+                .mup_segment_originated
                 .get(&name)
                 .map(|(p, s, e)| *p == prefix && *s == sid && *e == attr.ecom)
                 .unwrap_or(false);
             if unchanged {
                 continue;
             }
-            self.originate_mup_dsd(name, prefix, sid, attr);
+            self.originate_mup_segment(name, prefix, sid, attr);
         }
     }
 
-    /// Build a VRF's DSD origination, or `None` when it shouldn't originate
-    /// one right now. Gates: `afi-safi mup segment direct`, `encapsulation
-    /// srv6`, a configured RD, a resolved per-VRF End.DT46 SID, a resolved
-    /// locator, and a known kernel VRF — the last so the local End.DT46
-    /// decap is already installed before the segment is advertised (the SID
-    /// install rides the same `VrfAdd`/spawn path).
+    /// Build a VRF's Segment Discovery origination — a DSD (type 2) for
+    /// `segment direct` or an ISD (type 1) for `segment interwork` — or
+    /// `None` when it shouldn't originate one right now. Shared gates:
+    /// `encapsulation srv6`, a configured RD, a resolved per-VRF End.DT46
+    /// SID, a resolved locator, and a known kernel VRF — the last so the
+    /// local End.DT46 decap is already installed before the segment is
+    /// advertised (the SID install rides the same `VrfAdd`/spawn path).
+    /// Both carry the PE locator node as the IPv6 next-hop and the per-VRF
+    /// **End.DT46** SID as the SRv6 L3 Service — the segment a receiving PE
+    /// resolves for matching Session-Transformed routes. (zebra-rs uses
+    /// End.DT46 for both Direct and Interwork; the draft's GTP4.E/GTP6.E
+    /// interwork behaviours are VPP/eBPF and deferred.)
     ///
-    /// The NLRI is the VRF RD + router-id (so the route rides the IPv4-MUP
-    /// AFI); the attributes carry the PE locator node as the IPv6 next-hop
-    /// and the End.DT46 SID as the SRv6 L3 Service — the segment a receiving
-    /// PE resolves for matching Session-Transformed routes. Returns
-    /// `(prefix, sid_addr, attr)`.
-    fn build_mup_dsd_origination(
+    /// - **Direct (DSD):** NLRI = RD + router-id (rides the IPv4-MUP AFI);
+    ///   additionally carries the VRF's MUP Extended Community
+    ///   (Direct-segment id) so ST2 routes resolve to it. Needs a non-zero
+    ///   router-id (it is in the NLRI key).
+    /// - **Interwork (ISD):** NLRI = RD + the configured interwork `prefix`
+    ///   (`afi-safi mup segment interwork prefix <p>`; its family selects
+    ///   the AFI). Needs the prefix to be set; no MUP Extended Community (a
+    ///   receiving PE resolves it by endpoint-address lookup, §3.1.1).
+    ///
+    /// Returns `(prefix, sid_addr, attr)`.
+    fn build_mup_segment_origination(
         &self,
         name: &str,
     ) -> Option<(bgp_packet::MupPrefix, std::net::Ipv6Addr, BgpAttr)> {
         use super::vrf_config::{BgpVrfEncapsulation, MupSegmentMode};
         let cfg = self.vrfs.get(name)?;
-        if cfg.mobile_uplane.segment != Some(MupSegmentMode::Direct) {
-            return None;
-        }
+        let mode = cfg.mobile_uplane.segment?;
         if cfg.encapsulation != BgpVrfEncapsulation::Srv6 {
             return None;
         }
@@ -12931,17 +12973,10 @@ impl Bgp {
         let (sid, _function) = self.vrf_registry.get(name)?.srv6_sid?;
         let locator = self.srv6_locator.as_ref()?;
         let node = locator.node_sid_addr()?;
+        // The NLRI differs by segment type (DSD = RD + router-id, ISD = RD +
+        // interwork prefix); both ride the same End.DT46 SID.
         let router_id = cfg.router_id.unwrap_or(self.router_id);
-        // The DSD NLRI embeds the router-id; never originate one under the
-        // all-zero identity (cold start before the router-id resolves —
-        // `reconcile_mup_dsd` re-runs from `set_router_id`).
-        if router_id.is_unspecified() {
-            return None;
-        }
-        let prefix = bgp_packet::MupPrefix::Dsd {
-            rd,
-            address: IpAddr::V4(router_id),
-        };
+        let prefix = mup_segment_nlri(mode, rd, router_id, cfg.mobile_uplane.interwork_prefix)?;
         let rts = self
             .rib_known_vrfs
             .get(name)
@@ -12953,20 +12988,25 @@ impl Bgp {
             locator.sid_structure(),
             bgp_packet::SRV6_BEHAVIOR_END_DT46,
         ));
-        // The DSD route *is* the Direct segment, so it advertises its own
-        // MUP Extended Community identifier (draft §3.2 / §3.3.4); the
-        // controller's ST2 routes carry the same value to resolve here.
-        if let Some(seg) = cfg.mobile_uplane.mup_ext_comm {
+        // A Direct (DSD) route *is* the Direct segment, so it advertises its
+        // own MUP Extended Community identifier (draft §3.2 / §3.3.4); the
+        // controller's ST2 routes carry the same value to resolve here. The
+        // Interwork (ISD) route is resolved by endpoint-address lookup
+        // (§3.1.1), not by this ext-comm.
+        if matches!(mode, MupSegmentMode::Direct)
+            && let Some(seg) = cfg.mobile_uplane.mup_ext_comm
+        {
             attr_add_ecom(&mut attr, mup_direct_segment_ecom(&seg));
         }
         Some((prefix, sid, attr))
     }
 
-    /// Install one VRF's DSD route into the MUP Loc-RIB as `Originated` and
-    /// advertise it (mirrors [`Self::originate_mup_route`]). Tracks
-    /// `(prefix, sid)` so [`Self::reconcile_mup_dsd`] can detect a SID
-    /// change under a stable RD+router-id key.
-    fn originate_mup_dsd(
+    /// Install one VRF's Segment Discovery route (DSD or ISD) into the MUP
+    /// Loc-RIB as `Originated` and advertise it (mirrors
+    /// [`Self::originate_mup_route`]). Tracks `(prefix, sid, ecom)` so
+    /// [`Self::reconcile_mup_segment`] can detect a SID / ext-comm change
+    /// under a stable NLRI key.
+    fn originate_mup_segment(
         &mut self,
         name: String,
         prefix: bgp_packet::MupPrefix,
@@ -12988,15 +13028,16 @@ impl Bgp {
         rib.attr = self.attr_store.intern(attr);
         let _ = self.local_rib.update_mup(prefix.clone(), rib);
         let selected = self.local_rib.select_best_path_mup(&prefix);
-        self.mup_dsd_originated
+        self.mup_segment_originated
             .insert(name, (prefix.clone(), sid, ecom));
         self.mup_apply_selected(prefix, selected);
     }
 
-    /// Withdraw the DSD route originated for `name` (a config / SID /
-    /// kernel-VRF precondition dropped). No-op when nothing was originated.
-    fn withdraw_mup_dsd(&mut self, name: &str) {
-        let Some((prefix, _sid, _ecom)) = self.mup_dsd_originated.remove(name) else {
+    /// Withdraw the Segment Discovery route (DSD or ISD) originated for
+    /// `name` (a config / SID / kernel-VRF precondition dropped, or the
+    /// `segment` type changed). No-op when nothing was originated.
+    fn withdraw_mup_segment(&mut self, name: &str) {
+        let Some((prefix, _sid, _ecom)) = self.mup_segment_originated.remove(name) else {
             return;
         };
         self.local_rib.remove_mup(&prefix, 0, ORIGINATED_PEER);
@@ -17869,6 +17910,51 @@ mod tests {
             attr.prefix_sid.is_none(),
             "MUP-C must not attach a Prefix-SID; the PE derives the SID from ISD/DSD"
         );
+    }
+
+    // The Segment Discovery NLRI selector: `segment direct` keys a DSD off
+    // RD + router-id; `segment interwork` keys an ISD off RD + the configured
+    // interwork prefix. Each mode returns `None` until its NLRI key exists.
+    #[test]
+    fn mup_segment_nlri_selects_dsd_or_isd() {
+        use std::net::{IpAddr, Ipv4Addr};
+        use std::str::FromStr;
+
+        use bgp_packet::{MupPrefix, RouteDistinguisher};
+
+        use super::super::vrf_config::MupSegmentMode;
+
+        let rd = RouteDistinguisher::from_str("65501:10").unwrap();
+        let router_id: Ipv4Addr = "192.168.0.1".parse().unwrap();
+        let isd_prefix: ipnet::IpNet = "10.60.0.0/16".parse().unwrap();
+
+        // Direct -> DSD keyed by RD + router-id (the interwork prefix is
+        // irrelevant for Direct and is ignored).
+        match super::mup_segment_nlri(MupSegmentMode::Direct, rd, router_id, Some(isd_prefix)) {
+            Some(MupPrefix::Dsd { rd: r, address }) => {
+                assert_eq!(r, rd);
+                assert_eq!(address, IpAddr::V4(router_id));
+            }
+            other => panic!("expected Dsd, got {other:?}"),
+        }
+        // Direct with an all-zero router-id -> nothing (cold start before the
+        // router-id resolves).
+        assert!(
+            super::mup_segment_nlri(MupSegmentMode::Direct, rd, Ipv4Addr::UNSPECIFIED, None)
+                .is_none()
+        );
+
+        // Interwork -> ISD keyed by RD + the configured prefix.
+        match super::mup_segment_nlri(MupSegmentMode::Interwork, rd, router_id, Some(isd_prefix)) {
+            Some(MupPrefix::Isd { rd: r, prefix }) => {
+                assert_eq!(r, rd);
+                assert_eq!(prefix, isd_prefix);
+            }
+            other => panic!("expected Isd, got {other:?}"),
+        }
+        // Interwork without a configured prefix -> nothing (the ISD does not
+        // originate until `segment interwork prefix <p>` is set).
+        assert!(super::mup_segment_nlri(MupSegmentMode::Interwork, rd, router_id, None).is_none());
     }
 
     fn bgp_rib_with_nexthop(nh: Option<BgpNexthop>, typ: super::BgpRibType) -> super::BgpRib {

--- a/zebra-rs/src/bgp/show.rs
+++ b/zebra-rs/src/bgp/show.rs
@@ -5039,6 +5039,7 @@ mod detail_tests {
                 }),
                 segment: None,
                 mup_ext_comm: None,
+                interwork_prefix: None,
             },
             ..Default::default()
         };
@@ -5052,6 +5053,7 @@ mod detail_tests {
                 }),
                 segment: None,
                 mup_ext_comm: None,
+                interwork_prefix: None,
             },
             ..Default::default()
         };

--- a/zebra-rs/src/bgp/vrf_config.rs
+++ b/zebra-rs/src/bgp/vrf_config.rs
@@ -27,7 +27,7 @@ use std::net::{IpAddr, Ipv4Addr};
 use std::str::FromStr;
 
 use bgp_packet::RouteDistinguisher;
-use ipnet::{Ipv4Net, Ipv6Net};
+use ipnet::{IpNet, Ipv4Net, Ipv6Net};
 
 use crate::bgp_vrf_trace;
 use crate::config::{Args, ConfigOp};
@@ -184,9 +184,10 @@ pub struct MupSrv6Mobile {
 pub struct BgpVrfMobileUplane {
     pub srv6_mobile: Option<MupSrv6Mobile>,
     /// `afi-safi mup segment {direct|interwork}` — PE-side Segment
-    /// Discovery origination for this VRF. `Direct` → DSD (type 2,
-    /// carrying the VRF's End.DT46 SID); `Interwork` → ISD (type 1,
-    /// origination deferred). Independent of `srv6_mobile`.
+    /// Discovery origination for this VRF. `Direct` → DSD (type 2, NLRI =
+    /// RD + router-id); `Interwork` → ISD (type 1, NLRI = RD +
+    /// [`Self::interwork_prefix`]). Both carry the VRF's End.DT46 SID.
+    /// Independent of `srv6_mobile`.
     pub segment: Option<MupSegmentMode>,
     /// `afi-safi mup segment direct mup-ext-comm <2:4>` — the BGP MUP
     /// Extended Community (transitive type 0x0c, sub-type 0x00 =
@@ -196,6 +197,13 @@ pub struct BgpVrfMobileUplane {
     /// this Direct segment (§3.3.10 / §3.3.12). The 6-octet value reuses
     /// the RD/RT 2:4 wire layout, so it is stored as a `RouteDistinguisher`.
     pub mup_ext_comm: Option<RouteDistinguisher>,
+    /// `afi-safi mup segment interwork prefix <p>` — the interwork segment
+    /// prefix advertised in this VRF's Interwork Segment Discovery (ISD,
+    /// type 1) route NLRI (draft-mpmz-bess-mup-safi §3.1.1), typically the
+    /// locally connected gNodeB N3 prefix. Meaningful only under the
+    /// `interwork` segment; the ISD does not originate until it is set, and
+    /// its AFI follows this prefix's family.
+    pub interwork_prefix: Option<IpNet>,
 }
 
 /// Staged candidate configuration for one VRF entry. Mirrors the
@@ -471,6 +479,28 @@ pub fn config_vrf_mup_ext_comm(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> O
             cfg.mobile_uplane.mup_ext_comm = Some(RouteDistinguisher::from_str(&raw).ok()?);
         }
         ConfigOp::Delete => cfg.mobile_uplane.mup_ext_comm = None,
+        _ => {}
+    }
+    Some(())
+}
+
+/// `set router bgp vrf <NAME> afi-safi mup segment interwork prefix <p>` —
+/// the interwork segment prefix carried in this VRF's Interwork Segment
+/// Discovery (ISD, type 1) route NLRI (draft §3.1.1). Like `mup-ext-comm`,
+/// this leaf hangs off the `segment` list, so the segment list key
+/// (`direct`/`interwork`) sits between the VRF name and the value and is
+/// skipped here. The value is an IPv4 or IPv6 prefix; the ISD's AFI follows
+/// its family.
+pub fn config_vrf_mup_segment_prefix(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Option<()> {
+    let name = args.string()?;
+    let _segment = args.string()?; // segment list key (direct|interwork)
+    let cfg = vrf_entry(bgp, name);
+    match op {
+        ConfigOp::Set => {
+            let raw = args.string()?;
+            cfg.mobile_uplane.interwork_prefix = Some(IpNet::from_str(&raw).ok()?);
+        }
+        ConfigOp::Delete => cfg.mobile_uplane.interwork_prefix = None,
         _ => {}
     }
     Some(())

--- a/zebra-rs/src/config/manager.rs
+++ b/zebra-rs/src/config/manager.rs
@@ -1535,6 +1535,7 @@ mod yang_load_tests {
             "set router bgp vrf N3 afi-safi mup segment direct",
             "set router bgp vrf N3 afi-safi mup segment interwork",
             "set router bgp vrf N3 afi-safi mup segment direct mup-ext-comm 1:20",
+            "set router bgp vrf N3 afi-safi mup segment interwork prefix 10.60.0.0/16",
         ] {
             let (code, _comps, _state) = parse(cmd, entry.clone(), None, State::new());
             assert_eq!(

--- a/zebra-rs/yang/zebra-bgp-vrf.yang
+++ b/zebra-rs/yang/zebra-bgp-vrf.yang
@@ -245,8 +245,9 @@ module zebra-bgp-vrf {
               enum interwork {
                 description
                   "Originate an Interwork Segment Discovery (ISD, type 1)
-                   route. (Origination deferred — parsed but not yet acted
-                   on.)";
+                   route: the NLRI is the VRF RD + the configured `prefix`
+                   and the SRv6 L3 Service carries the per-VRF End.DT46 SID.
+                   Requires `prefix` to be set.";
               }
             }
             description
@@ -263,6 +264,18 @@ module zebra-bgp-vrf {
                (ST2) routes that resolve to this Direct segment (§3.3.10 /
                §3.3.12). The 6-octet value reuses the RD/RT 2:4 wire format.
                Meaningful only under the `direct` segment.";
+          }
+          leaf prefix {
+            type inet:ip-prefix;
+            description
+              "Interwork segment prefix advertised in the Interwork Segment
+               Discovery (ISD, type 1) route's NLRI
+               (draft-mpmz-bess-mup-safi §3.1.1) — typically the locally
+               connected gNodeB N3 interface prefix. The route's AFI follows
+               this prefix's family (IPv4 / IPv6) and the SRv6 L3 Service
+               carries the VRF's End.DT46 SID. Meaningful only under the
+               `interwork` segment; the ISD does not originate until it is
+               set.";
           }
         }
         list route {


### PR DESCRIPTION
## Summary

`afi-safi mup segment interwork` was parsed but never originated a route. This wires up **Interwork Segment Discovery (ISD, type 1)** origination — the sibling of the slice-1 DSD.

- **New knob** `router bgp vrf <V> afi-safi mup segment interwork prefix 10.60.0.0/16` — a `prefix` leaf on the `segment` list (`BgpVrfMobileUplane.interwork_prefix`, handler `config_vrf_mup_segment_prefix`, callback `/router/bgp/vrf/afi-safi/mup/segment/prefix`). The ISD does not originate until the prefix is set; it is typically the locally connected gNodeB N3 prefix (draft-mpmz-bess-mup-safi §3.1.1).
- **Generalized origination**: the DSD reconcile/build/originate/withdraw machinery becomes *segment* origination (`build_mup_segment_origination`, `reconcile_mup_segment`, `mup_segment_originated`). It emits a **DSD** (NLRI = RD + router-id, with the Direct-segment ext-comm) for `segment direct` or an **ISD** (NLRI = RD + the configured interwork prefix, no ext-comm) for `segment interwork`. A VRF has at most one segment route, so per-VRF-name tracking covers both and a direct↔interwork switch withdraws the old NLRI and originates the new. NLRI selection is factored into the pure helper `mup_segment_nlri`.
- Both segment routes carry the per-VRF **End.DT46** SID (zebra-rs uses End.DT46 for the interwork segment too; the draft's GTP4.E/GTP6.E behaviours are VPP/eBPF, deferred). The ISD's AFI follows the prefix family; `show bgp mup` already renders `[ISD][rd][prefix]` and the End.DT46 SID line generically.

## Test plan

- `cargo fmt`, `cargo clippy --workspace --all-targets -- -D warnings` — clean.
- Full zebra-rs unit suite **1473 passed** + **42 yang_load** — green.
- New unit test `mup_segment_nlri_selects_dsd_or_isd` (DSD vs ISD NLRI + empty-prefix / zero-router-id gates); extended `bgp_vrf_mup_segment_paths_parse` yang_load guard for `segment interwork prefix`.
- New BDD `@bgp_mup_isd`: z1 originates `[ISD][65501:10][10.60.0.0/16]` with a local End.DT46 SID + installs the seg6local decap, z2 receives it.
- BDD config grammar validated via an isolated `--yang-path` + `--config-file` daemon load (VRF spawned, End.DT46 SID carved, no grammar rejection). The BDD run itself is left to CI — a parallel session holds the shared `/usr/bin/zebra-rs`.

Generated with [Claude Code](https://claude.com/claude-code)