### PR TITLE
ospf: withdraw stale identity on Router-ID set/change (v2+v3)

### DIFF
--- a/bdd/tests/configs/ospf_router_id_change/r1.yaml
+++ b/bdd/tests/configs/ospf_router_id_change/r1.yaml
@@ -1,0 +1,18 @@
+interface:
+- if-name: lo
+  ipv4:
+    address: 192.168.11.1/32
+- if-name: eth1
+  ipv4:
+    address: 10.0.12.1/30
+router:
+  ospf:
+    router-id: 1.1.1.1
+    area:
+    - area-id: 0.0.0.0
+      interface:
+      - if-name: lo
+        enable: true
+      - if-name: eth1
+        enable: true
+        network-type: point-to-point

--- a/bdd/tests/configs/ospf_router_id_change/r2.yaml
+++ b/bdd/tests/configs/ospf_router_id_change/r2.yaml
@@ -1,0 +1,18 @@
+interface:
+- if-name: lo
+  ipv4:
+    address: 192.168.22.1/32
+- if-name: eth2
+  ipv4:
+    address: 10.0.12.2/30
+router:
+  ospf:
+    router-id: 2.2.2.2
+    area:
+    - area-id: 0.0.0.0
+      interface:
+      - if-name: lo
+        enable: true
+      - if-name: eth2
+        enable: true
+        network-type: point-to-point

--- a/bdd/tests/configs/ospfv3_router_id_change/o1.yaml
+++ b/bdd/tests/configs/ospfv3_router_id_change/o1.yaml
@@ -1,0 +1,18 @@
+interface:
+- if-name: lo
+  ipv6:
+    address: 2001:db8::1/128
+- if-name: eth1
+  ipv6:
+    address: 2001:db8:12::1/64
+router:
+  ospfv3:
+    router-id: 1.1.1.1
+    area:
+    - area-id: 0.0.0.0
+      interface:
+      - if-name: lo
+        enable: true
+      - if-name: eth1
+        enable: true
+        network-type: point-to-point

--- a/bdd/tests/configs/ospfv3_router_id_change/o2.yaml
+++ b/bdd/tests/configs/ospfv3_router_id_change/o2.yaml
@@ -1,0 +1,18 @@
+interface:
+- if-name: lo
+  ipv6:
+    address: 2001:db8::2/128
+- if-name: eth2
+  ipv6:
+    address: 2001:db8:12::2/64
+router:
+  ospfv3:
+    router-id: 2.2.2.2
+    area:
+    - area-id: 0.0.0.0
+      interface:
+      - if-name: lo
+        enable: true
+      - if-name: eth2
+        enable: true
+        network-type: point-to-point

--- a/bdd/tests/features/ospf_router_id_change.feature
+++ b/bdd/tests/features/ospf_router_id_change.feature
@@ -1,0 +1,104 @@
+@serial
+@ospf_router_id_change
+Feature: OSPFv2 Router-ID set / change / delete on a live adjacency
+  As a network operator
+  I want zebra-rs to react correctly when an OSPFv2 instance's Router-ID is
+  set, changed, or deleted while an adjacency is already up, so the peer
+  re-learns the new identity, the database advertised under the old identity
+  is withdrawn, and forwarding keeps working.
+
+  Two routers on a point-to-point link, each advertising a loopback that is
+  numerically distinct from any Router-ID, so a Router-ID only ever appears
+  in the database as an *advertising router* (never as a stub prefix). That
+  makes "the old Router-ID is gone" a clean, unambiguous assertion.
+
+  Test Topology:
+  ```
+    r1 --- 10.0.12.0/30 (point-to-point, area 0.0.0.0) --- r2
+       eth1                                            eth2
+    loopbacks: 192.168.11.1/32 (r1)        192.168.22.1/32 (r2)
+    Router-IDs: r1 starts 1.1.1.1, r2 fixed 2.2.2.2
+  ```
+
+  The bugs this guards against:
+  * Every daemon boots with the constructor default Router-ID (10.0.0.1) and
+    only adopts the configured value once config is applied. The LSA
+    originated under the default was never withdrawn, so it lingered (and was
+    even kept refreshed) as a phantom node — two routers booting as 10.0.0.1
+    fought a sequence-number war and SPF failed to install transit routes,
+    so even a fresh bring-up could leave loopbacks unreachable.
+  * OSPFv2 keys a neighbour by its source address and only recorded the
+    peer's Router-ID at neighbour creation. A peer that changed its Router-ID
+    kept its OLD Router-ID in our neighbour table forever — our Router-LSA
+    pointed at a node that no longer originated one, and the peer's new
+    identity never entered SPF.
+
+  Scenario: Setup point-to-point topology, reach Full and exchange loopbacks
+    Given a clean test environment
+    When I create namespace "r1"
+    And I create namespace "r2"
+    And I connect namespace "r1" interface "eth1" to namespace "r2" interface "eth2"
+    And I start zebra-rs in namespace "r1"
+    And I start zebra-rs in namespace "r2"
+    And I apply config "r1.yaml" to namespace "r1"
+    And I apply config "r2.yaml" to namespace "r2"
+    # First Hello (<=10s) + DBD/LS exchange settles well inside this.
+    And I wait 30 seconds
+
+    # Both ends are Full and see each other's starting Router-IDs.
+    Then show command "show ospf neighbor" in namespace "r1" should contain "Full"
+    And show command "show ospf neighbor" in namespace "r1" should contain "2.2.2.2"
+    And show command "show ospf neighbor" in namespace "r2" should contain "Full"
+    And show command "show ospf neighbor" in namespace "r2" should contain "1.1.1.1"
+    # Loopbacks are mutually reachable: this only works once the phantom
+    # default-Router-ID LSA has been withdrawn so SPF installs the transit
+    # routes (it was the regression that broke even a clean bring-up).
+    And ping from "r1" to "192.168.22.1" should eventually succeed
+    And ping from "r2" to "192.168.11.1" should eventually succeed
+
+  Scenario: Changing r1's Router-ID re-forms the adjacency and withdraws the old identity
+    Given the test topology exists
+    When I apply command "set router ospf router-id 9.9.9.9" in namespace "r1"
+    And I wait 15 seconds
+    # r2 re-learns r1 under the NEW Router-ID and the adjacency is Full again.
+    Then show command "show ospf neighbor" in namespace "r2" should eventually contain "9.9.9.9"
+    And show command "show ospf neighbor" in namespace "r2" should eventually contain "Full"
+    # The OLD Router-ID 1.1.1.1 is gone from BOTH the neighbour table and
+    # the link-state database (the stale self-originated LSAs were flushed,
+    # not left to age out). 1.1.1.1 is never a prefix here, so its absence
+    # is unambiguous.
+    And show command "show ospf neighbor" in namespace "r2" should eventually not contain "1.1.1.1"
+    And show command "show ospf database" in namespace "r2" should eventually not contain "1.1.1.1"
+    # Forwarding still works: r1's loopback is reachable under the new identity.
+    And ping from "r2" to "192.168.11.1" should eventually succeed
+    And ping from "r1" to "192.168.22.1" should succeed
+
+  Scenario: Deleting r1's Router-ID is handled gracefully and keeps forwarding
+    Given the test topology exists
+    When I apply command "delete router ospf router-id 9.9.9.9" in namespace "r1"
+    And I wait 15 seconds
+    # The previously-configured Router-ID is withdrawn; r2 re-forms under
+    # whatever r1 now derives and the explicit 9.9.9.9 is gone.
+    Then show command "show ospf neighbor" in namespace "r2" should eventually not contain "9.9.9.9"
+    And show command "show ospf neighbor" in namespace "r2" should eventually contain "Full"
+    And show command "show ospf database" in namespace "r2" should eventually not contain "9.9.9.9"
+    And ping from "r2" to "192.168.11.1" should eventually succeed
+
+  Scenario: Setting an explicit Router-ID again re-converges the adjacency
+    Given the test topology exists
+    When I apply command "set router ospf router-id 7.7.7.7" in namespace "r1"
+    And I wait 15 seconds
+    Then show command "show ospf neighbor" in namespace "r2" should eventually contain "7.7.7.7"
+    And show command "show ospf neighbor" in namespace "r2" should eventually contain "Full"
+    And ping from "r2" to "192.168.11.1" should eventually succeed
+    And ping from "r1" to "192.168.22.1" should eventually succeed
+
+  # Pure P2P topology (no bridge): deleting each namespace destroys the veth
+  # pair, so only the daemons and namespaces need teardown.
+  Scenario: Teardown topology
+    Given the test topology exists
+    When I stop zebra-rs in namespace "r1"
+    And I stop zebra-rs in namespace "r2"
+    And I delete namespace "r1"
+    And I delete namespace "r2"
+    Then the test environment should be clean

--- a/bdd/tests/features/ospfv3_router_id_change.feature
+++ b/bdd/tests/features/ospfv3_router_id_change.feature
@@ -1,0 +1,62 @@
+@serial
+@ospfv3_router_id_change
+Feature: OSPFv3 Router-ID change on a live adjacency
+  As a network operator
+  I want zebra-rs to withdraw the LSAs advertised under an OSPFv3 instance's
+  old Router-ID when that Router-ID changes on a running adjacency, so a
+  stale identity does not linger in every router's database until MaxAge.
+
+  Two OSPFv3 routers on a point-to-point link. OSPFv3 keys a neighbour by
+  Router-ID (RFC 5340 §10), so when o1's Router-ID changes o2 naturally
+  forms a fresh neighbour and the old one ages out on its dead timer. The
+  part that needs a fix is the database: the LSAs o1 originated under the
+  old Router-ID would otherwise survive as a phantom node. A Router-ID is
+  numerically distinct from any IPv6 prefix here, so "the old Router-ID is
+  gone from the database" is an unambiguous assertion.
+
+  Test Topology:
+  ```
+    o1 --- 2001:db8:12::/64 (point-to-point, area 0.0.0.0) --- o2
+       eth1                                                eth2
+    loopbacks: 2001:db8::1/128 (o1)            2001:db8::2/128 (o2)
+    Router-IDs: o1 starts 1.1.1.1, o2 fixed 2.2.2.2
+  ```
+
+  Scenario: Setup point-to-point topology and reach Full
+    Given a clean test environment
+    When I create namespace "o1"
+    And I create namespace "o2"
+    And I connect namespace "o1" interface "eth1" to namespace "o2" interface "eth2"
+    And I start zebra-rs in namespace "o1"
+    And I start zebra-rs in namespace "o2"
+    And I apply config "o1.yaml" to namespace "o1"
+    And I apply config "o2.yaml" to namespace "o2"
+    And I wait 30 seconds
+
+    Then show command "show ospfv3 neighbor" in namespace "o1" should contain "Full"
+    And show command "show ospfv3 neighbor" in namespace "o1" should contain "2.2.2.2"
+    And show command "show ospfv3 neighbor" in namespace "o2" should contain "Full"
+    And show command "show ospfv3 neighbor" in namespace "o2" should contain "1.1.1.1"
+    And show command "show ospfv3 database" in namespace "o2" should contain "1.1.1.1"
+
+  Scenario: Changing o1's Router-ID re-forms the adjacency and withdraws the old identity
+    Given the test topology exists
+    When I apply command "set router ospfv3 router-id 9.9.9.9" in namespace "o1"
+    # New neighbour forms under the new Router-ID; the old neighbour ages
+    # out on its dead timer (~40s), so poll generously.
+    And I wait 15 seconds
+    Then show command "show ospfv3 neighbor" in namespace "o2" should eventually contain "9.9.9.9"
+    And show command "show ospfv3 neighbor" in namespace "o2" should eventually contain "Full"
+    # The old Router-ID disappears from the neighbour table (dead timer) and
+    # from the database (its self-originated LSAs were flushed, not left to
+    # age out for ~1 h).
+    And show command "show ospfv3 neighbor" in namespace "o2" should eventually not contain "1.1.1.1"
+    And show command "show ospfv3 database" in namespace "o2" should eventually not contain "1.1.1.1"
+
+  Scenario: Teardown topology
+    Given the test topology exists
+    When I stop zebra-rs in namespace "o1"
+    And I stop zebra-rs in namespace "o2"
+    And I delete namespace "o1"
+    And I delete namespace "o2"
+    Then the test environment should be clean

--- a/zebra-rs/src/ospf/inst.rs
+++ b/zebra-rs/src/ospf/inst.rs
@@ -4544,11 +4544,100 @@ impl Ospf<Ospfv2> {
     }
 
     pub(super) fn router_id_update(&mut self, router_id: Ipv4Addr) {
+        // Flush everything we originated under the PREVIOUS Router-ID
+        // before adopting the new one. Self-originated LSAs are keyed by
+        // advertising router, so once our Router-ID changes the old
+        // instances are no longer "self" — nothing refreshes them and
+        // they would linger as phantom nodes in every router's LSDB
+        // until they age out at MaxAge (~1 h). Pre-aging + re-flooding
+        // them now withdraws the stale identity immediately.
+        let old_router_id = self.router_id;
+        if old_router_id != router_id {
+            self.flush_self_originated_under(old_router_id);
+        }
+
         self.router_id = router_id;
         for (_, link) in self.links.iter_mut() {
             link.ident.router_id = router_id;
         }
         self.router_lsa_originate();
+    }
+
+    /// Flush (pre-age to MaxAge + re-flood) every LSA we originated
+    /// under `old_router_id` — the per-area Router/Network/Summary/
+    /// Opaque LSAs plus AS-External LSAs. Called from
+    /// [`Self::router_id_update`] when the effective Router-ID moves so
+    /// the database advertised under our former identity is withdrawn
+    /// instead of lingering until MaxAge.
+    fn flush_self_originated_under(&mut self, old_router_id: Ipv4Addr) {
+        if self.in_restart() {
+            return;
+        }
+        // Per-area LSDBs.
+        let area_ids: Vec<Ipv4Addr> = self.areas.iter().map(|(id, _)| *id).collect();
+        for area_id in area_ids {
+            let keys: Vec<OspfLsaKey> = match self.areas.get(area_id) {
+                Some(area) => area
+                    .lsdb
+                    .tables
+                    .keys()
+                    .filter(|(_, _, adv)| *adv == old_router_id)
+                    .copied()
+                    .collect(),
+                None => continue,
+            };
+            for key in keys {
+                let flushed = if let Some(area) = self.areas.get_mut(area_id) {
+                    area.lsdb.flush_lsa_by_raw_key(key, &self.tx, Some(area_id))
+                } else {
+                    None
+                };
+                if let Some(lsa) = flushed {
+                    self.flood_self_originated_lsa(area_id, &lsa);
+                }
+            }
+        }
+        // AS-External LSDB (Type-5), flooded AS-wide.
+        let as_keys: Vec<OspfLsaKey> = self
+            .lsdb_as
+            .tables
+            .keys()
+            .filter(|(_, _, adv)| *adv == old_router_id)
+            .copied()
+            .collect();
+        for key in as_keys {
+            if let Some(lsa) = self.lsdb_as.flush_lsa_by_raw_key(key, &self.tx, None) {
+                self.flood_lsa_through_as(&lsa, None);
+            }
+        }
+
+        // Per-link LSDBs: link-scope Opaque LSAs (e.g. the Extended-Link
+        // LSA that carries an Adj-SID) live in `link.lsdb`, not the area
+        // LSDB. Flush + re-flood them on their link so a peer's
+        // link-scope database doesn't keep the old identity around.
+        let ifindices: Vec<u32> = self.links.keys().copied().collect();
+        for ifindex in ifindices {
+            let keys: Vec<OspfLsaKey> = match self.links.get(&ifindex) {
+                Some(link) => link
+                    .lsdb
+                    .tables
+                    .keys()
+                    .filter(|(_, _, adv)| *adv == old_router_id)
+                    .copied()
+                    .collect(),
+                None => continue,
+            };
+            for key in keys {
+                let flushed = if let Some(link) = self.links.get_mut(&ifindex) {
+                    link.lsdb.flush_lsa_by_raw_key(key, &self.tx, None)
+                } else {
+                    None
+                };
+                if let Some(lsa) = flushed {
+                    self.flood_link_scope_lsa_v2(ifindex, &lsa);
+                }
+            }
+        }
     }
 
     /// Recompute the effective Router ID from its sources —
@@ -5516,11 +5605,92 @@ impl Ospf<Ospfv3> {
     /// at all and every instance kept the constructor default
     /// 10.0.0.1).
     pub(super) fn router_id_update(&mut self, router_id: Ipv4Addr) {
+        // See the v2 sibling: withdraw everything originated under the
+        // previous Router-ID so it does not linger as a phantom node in
+        // peers' LSDBs until MaxAge.
+        let old_router_id = self.router_id;
+        if old_router_id != router_id {
+            self.flush_self_originated_under(old_router_id);
+        }
+
         self.router_id = router_id;
         for (_, link) in self.links.iter_mut() {
             link.ident.router_id = router_id;
         }
         self.router_lsa_originate();
+    }
+
+    /// v3 sibling of the v2 `flush_self_originated_under`: pre-age to
+    /// MaxAge + re-flood every LSA we originated under `old_router_id`
+    /// (per-area LSAs plus AS-External LSAs) when the effective
+    /// Router-ID moves.
+    fn flush_self_originated_under(&mut self, old_router_id: Ipv4Addr) {
+        let area_ids: Vec<Ipv4Addr> = self.areas.iter().map(|(id, _)| *id).collect();
+        for area_id in area_ids {
+            let keys: Vec<OspfLsaKey> = match self.areas.get(area_id) {
+                Some(area) => area
+                    .lsdb
+                    .tables
+                    .keys()
+                    .filter(|(_, _, adv)| *adv == old_router_id)
+                    .copied()
+                    .collect(),
+                None => continue,
+            };
+            for key in keys {
+                let flushed = if let Some(area) = self.areas.get_mut(area_id) {
+                    area.lsdb.flush_lsa_by_raw_key(key, &self.tx, Some(area_id))
+                } else {
+                    None
+                };
+                if let Some(lsa) = flushed {
+                    self.flood_self_originated_lsa(area_id, &lsa);
+                }
+            }
+        }
+        let as_keys: Vec<OspfLsaKey> = self
+            .lsdb_as
+            .tables
+            .keys()
+            .filter(|(_, _, adv)| *adv == old_router_id)
+            .copied()
+            .collect();
+        for key in as_keys {
+            if let Some(lsa) = self.lsdb_as.flush_lsa_by_raw_key(key, &self.tx, None) {
+                self.flood_lsa_through_as_v3(&lsa, None);
+            }
+        }
+
+        // Per-link LSDBs: v3 Link-LSAs (RFC 5340 §A.4.9) are
+        // link-local scope and live in `link.lsdb`, not the area
+        // LSDB, so the loop above misses them. A peer keeps the
+        // Link-LSA we originated under the old Router-ID (it shows up
+        // in its `show ospfv3 database`) until it MaxAges on its own;
+        // flush + re-flood it on the link so it goes away with the
+        // rest of the old identity.
+        let ifindices: Vec<u32> = self.links.keys().copied().collect();
+        for ifindex in ifindices {
+            let keys: Vec<OspfLsaKey> = match self.links.get(&ifindex) {
+                Some(link) => link
+                    .lsdb
+                    .tables
+                    .keys()
+                    .filter(|(_, _, adv)| *adv == old_router_id)
+                    .copied()
+                    .collect(),
+                None => continue,
+            };
+            for key in keys {
+                let flushed = if let Some(link) = self.links.get_mut(&ifindex) {
+                    link.lsdb.flush_lsa_by_raw_key(key, &self.tx, None)
+                } else {
+                    None
+                };
+                if let Some(lsa) = flushed {
+                    self.flood_link_scope_lsa(ifindex, &lsa);
+                }
+            }
+        }
     }
 
     /// v3 sibling of the v2 `refresh_router_id`: configured value

--- a/zebra-rs/src/ospf/packet.rs
+++ b/zebra-rs/src/ospf/packet.rs
@@ -411,6 +411,25 @@ pub fn ospf_hello_recv(
         )
     });
 
+    // RFC 2328 §10.5 ("Receiving Hello Packets"): a Hello from a known
+    // source address but carrying a *different* Router-ID means the
+    // neighbour restarted under a new identity — typically an operator
+    // changed its `router-id`. OSPFv2 keys neighbours by source address
+    // (unlike v3, which keys by Router-ID), so without this the stale
+    // entry would keep the OLD Router-ID forever: our Router-LSA would
+    // point at a node that no longer originates one, the peer's new
+    // identity would never enter SPF, and `show ospf neighbor` would
+    // report a Router-ID that no longer exists. Tear the stale neighbour
+    // down through the same path as the dead-timer / `clear ospf
+    // neighbor`; the next Hello re-learns it cleanly under the new
+    // Router-ID.
+    if !init && nbr.ident.router_id != packet.router_id {
+        let _ = oi
+            .tx
+            .send(Message::Nfsm(oi.index, *src, NfsmEvent::InactivityTimer));
+        return;
+    }
+
     oi.tx
         .send(Message::Nfsm(oi.index, *src, NfsmEvent::HelloReceived))
         .unwrap();

--- a/zebra-rs/src/ospf/packet_v3.rs
+++ b/zebra-rs/src/ospf/packet_v3.rs
@@ -397,6 +397,31 @@ pub fn ospfv3_hello_recv(
 
     let nbr_router_id = packet.router_id;
 
+    // RFC 5340 §10 keys neighbours by Router-ID, but a single physical
+    // neighbour is identified on the wire by its link-local source
+    // address. A Hello arriving from a source we already track under a
+    // *different* Router-ID means that neighbour restarted under a new
+    // identity (typically an operator changed its `router-id`). The old
+    // entry would otherwise linger as a phantom Full adjacency — our
+    // Router-LSA would advertise a link to a Router-ID that no longer
+    // originates an LSA, and we would retransmit to it indefinitely
+    // (its dead timer does not reap it while the underlying link stays
+    // up). Tear the stale entry down at once via the same path as the
+    // dead timer / `clear ospfv3 neighbor`; the fresh Router-ID is
+    // (re-)learned just below.
+    let stale: Vec<std::net::Ipv4Addr> = oi
+        .nbrs
+        .iter()
+        .filter_map(|(rid, nbr)| {
+            (*rid != nbr_router_id && nbr.ident.prefix.addr() == *src).then_some(*rid)
+        })
+        .collect();
+    for rid in stale {
+        let _ = oi
+            .tx
+            .send(Message::Nfsm(oi.index, rid, NfsmEvent::InactivityTimer));
+    }
+
     // Neighbor key in `oi.nbrs` is Ipv4Addr in both versions; v3
     // stores the router-id (RFC 5340 §10), which matches what
     // `V::nbr_addr` returns for v3.


### PR DESCRIPTION
## Problem

Setting or changing an OSPF Router-ID could break OSPF — including on a clean bring-up:

- Every daemon boots with the constructor default Router-ID **10.0.0.1** and only adopts the configured value once config is applied. The LSAs originated under the default (and under any previous Router-ID after a runtime change) were **never withdrawn** — they kept their refresh timers and lingered as phantom nodes in every router's LSDB. Two routers booting as 10.0.0.1 fought a sequence-number war and SPF failed to install transit routes, so even a fresh adjacency could leave loopbacks unreachable.
- **OSPFv2** keys a neighbour by its *source address* and only recorded the peer's Router-ID at neighbour creation. A peer that changed its Router-ID kept its **old** Router-ID in our neighbour table forever — our Router-LSA pointed at a node that no longer originated one and the peer's new identity never entered SPF.
- **OSPFv3** keys by Router-ID but left the stale neighbour (and its link-scope Link-LSA) behind when a peer's Router-ID changed (it never aged out while the link stayed up).

## Fix

- `router_id_update` (v2 + v3): on any effective Router-ID change, flush (pre-age to MaxAge + re-flood) every self-originated LSA under the **previous** Router-ID across **all scopes** — per-area, AS-external, and per-link LSDBs.
- v2 `ospf_hello_recv`: when a Hello's Router-ID differs from the stored neighbour identity, tear the stale neighbour down (RFC 2328 §10.5) so it re-forms under the new Router-ID.
- v3 `ospfv3_hello_recv`: when a Hello's link-local source matches an existing neighbour with a different Router-ID, tear the stale one down.

## Test plan

- New BDD features (both pass):
  - `ospf_router_id_change` (v2): setup → change → delete → set → teardown; asserts the peer re-learns the new Router-ID, the old identity is gone from neighbour table **and** database, and forwarding keeps working.
  - `ospfv3_router_id_change` (v3): setup → change → teardown; same assertions including the database flush of the old identity.
- Reproduced the failure on the pre-fix binary (loopbacks unreachable on bring-up; stale neighbour Router-ID never updated) and confirmed the fix resolves it.
- `cargo fmt`, `cargo clippy --workspace --all-targets` clean; `cargo test -p zebra-rs --bins` = 1473 passed.
- Regression: existing `ospfv2_multi_area`, `ospfv3_adjacency`, `ospf_clear_neighbor` features.

Generated with [Claude Code](https://claude.com/claude-code)