### PR TITLE
bgp: return after ConnFail on socket read error in peer_read

### DIFF
--- a/zebra-rs/src/bgp/peer.rs
+++ b/zebra-rs/src/bgp/peer.rs
@@ -2294,7 +2294,7 @@ pub async fn peer_read(
                 }
 
                 while let Some(length) = peek_bgp_length(&buf) {
-                    if length < BGP_HEADER_LEN as usize || length > opt.max_message_len() {
+                    if length < BGP_HEADER_LEN.into() || length > opt.max_message_len() {
                         event_conn_fail(ident, conn).await;
                         return;
                     }
@@ -2317,6 +2317,7 @@ pub async fn peer_read(
             }
             Err(_err) => {
                 event_conn_fail(ident, conn).await;
+                return;
             }
         }
     }


### PR DESCRIPTION
## Summary

The read-error arm of `peer_read` (`Err(_err)` from `read_half.read_buf`) signalled `ConnFail` but did not `return`, so it fell through to the bottom of `loop` and re-called `read_buf` on the already-failed socket. On a persistently failing read (connection reset / broken pipe) that is an infinite spin that re-sends `ConnFail` on every iteration; with the now-awaited `send`, it can also block the task pumping duplicate teardown events into the FSM channel.

A socket read error is terminal (tokio handles `WouldBlock`/`EINTR` internally), exactly like EOF. This change returns after notifying, mirroring the `read_len == 0` arm directly above.

## Test plan

- `cargo build -p zebra-rs` — clean, no warnings (notably no `unreachable_code`)
- `cargo fmt --all --check` — clean
- `cargo clippy --workspace --all-targets` — clean

Generated with [Claude Code](https://claude.com/claude-code)