### PR TITLE
bgp-packet: harden length-bounded parsers (SECURITY_AUDIT Findings 3 & 4)

### DIFF
--- a/crates/bgp-packet/SECURITY_AUDIT.md
+++ b/crates/bgp-packet/SECURITY_AUDIT.md
@@ -9,11 +9,11 @@
 ## Summary
 
 This revision re-verifies the four findings from the previous audit against the
-current source. Two of them — both the High-severity panic paths — are now
-fully fixed and covered by regression tests. The two Medium-severity findings
-are partly addressed: the MP_REACH `nhop_len` case is fixed, but the
-trailing-garbage class and the EVPN substructure-length cases remain open. The
-residual encoder-side `u8` truncation issues are unchanged.
+current source. Three of them are now fully fixed and covered by regression
+tests: both High-severity panic paths and the Medium-severity trailing-garbage
+class. The remaining Medium finding is partly addressed: the MP_REACH
+`nhop_len` case is fixed, but the EVPN substructure-length cases remain open.
+The residual encoder-side `u8` truncation issues are unchanged.
 
 Status of the four previously reported issues:
 
@@ -21,8 +21,8 @@ Status of the four previously reported issues:
    `packet_utils::safe_split_at()` instead of a raw `split_at()`.
 2. **High — FIXED:** IPv4 and IPv6 NLRI parsers now reject overlong prefix
    lengths before computing the prefix byte size.
-3. **Medium — OPEN:** several length-bounded BGP subparsers still ignore inner
-   remainders and silently discard trailing garbage.
+3. **Medium — FIXED:** the length-bounded BGP subparsers now enforce full
+   consumption of their bounded slice and reject trailing garbage.
 4. **Medium — PARTIALLY FIXED:** MP_REACH now validates `nhop_len`; EVPN
    per-route `length` and multicast `addr_len` are still not enforced.
 
@@ -86,30 +86,40 @@ Regression tests: `parse_nlri_rejects_prefixlen_over_32` (IPv4),
 `parse_nlri_rejects_prefixlen_over_128` and
 `parse_ipv6net_rejects_prefixlen_over_128` (IPv6).
 
-### 3. Length-bounded payloads still accept trailing garbage — OPEN
+### 3. Length-bounded payloads accepted trailing garbage — FIXED
 
 - **Severity:** Medium
 - **Files:**
   - `src/attrs/cluster_list.rs`
-  - `src/caps/packet.rs`
   - `src/attrs/nlri_ipv4.rs`
+  - `src/caps/packet.rs`
+  - `src/open.rs`
 
-The outer parsers now bound their slice with `safe_split_at()`, but they still
-ignore the inner parser's remainder rather than rejecting a non-empty one:
+The outer parsers bounded their slice with `safe_split_at()` but then ignored
+the inner parser's remainder, so a non-empty leftover was silently discarded.
+Each bounded slice now enforces full consumption:
 
-- `ClusterList::parse_be()` (`cluster_list.rs:24`) uses
-  `many0_complete(be_u32)`, so a 5-byte payload is accepted as one cluster ID
-  plus one discarded byte.
-- `CapabilityPacket::parse_cap()` (`caps/packet.rs:66`) discards the inner
-  remainder: `let (_, cap) = CapabilityPacket::parse_be(cap, …)?;`.
-- `parse_bgp_nlri_ipv4()` (`nlri_ipv4.rs:45`) uses `many0_complete(...)` and
-  drops any trailing bytes after the last valid NLRI.
+- `ClusterList::parse_be()` (`cluster_list.rs:25`) rejects a payload whose
+  length is not a multiple of 4 up front
+  (`if !input.len().is_multiple_of(4)`), so a stray trailing octet can no longer
+  be swallowed by `many0_complete(be_u32)`.
+- `parse_bgp_nlri_ipv4()` (`nlri_ipv4.rs:38`) drains the bounded slice in an
+  explicit loop (`while !nlri.is_empty()`), so a malformed or truncated trailing
+  NLRI surfaces the real parse error from `Ipv4Nlri::parse_nlri()` instead of
+  being dropped by `many0_complete()`.
+- `CapabilityPacket::parse_cap()` (`caps/packet.rs:63`) now binds the inner
+  remainder and returns `Err(ErrorKind::LengthValue)` when it is non-empty,
+  rather than discarding it with `let (_, cap) = …`.
+- `OpenPacket::parse_packet()` and the `parse_caps()` helper (`open.rs:65,79`)
+  apply the same non-empty-remainder rejection to the OPEN optional-parameter
+  and capability-block slices.
 
-- **Impact:** Malformed wire data is normalized into a different in-memory
-  object and the dropped bytes vanish on re-emit, creating parser-differential
-  and canonicalization problems.
-- **Recommendation:** After parsing each bounded slice, reject any non-empty
-  remainder instead of discarding it.
+- **Impact (historical):** Malformed wire data was normalized into a different
+  in-memory object and the dropped bytes vanished on re-emit, creating
+  parser-differential and canonicalization problems.
+- **Regression tests:** `parse_cluster_list_rejects_non_multiple_of_four`
+  (`cluster_list.rs`), `parse_bgp_nlri_ipv4_rejects_trailing_garbage` and
+  `parse_bgp_nlri_ipv4_consumes_whole_block` (`nlri_ipv4.rs`).
 
 ### 4. Substructure length fields not enforced — PARTIALLY FIXED
 
@@ -174,8 +184,8 @@ Recommended follow-up:
 
 ### Priority 2 — partially open
 
-3. Enforce full consumption for all length-bounded attribute, capability, and
-   NLRI slices (Finding 3).
+3. ~~Enforce full consumption for all length-bounded attribute, capability, and
+   NLRI slices (Finding 3).~~ Fixed.
 4. Enforce the EVPN per-route `length` and multicast `addr_len` (the remaining
    half of Finding 4). MP_REACH `nhop_len` is done.
 
@@ -183,8 +193,6 @@ Recommended follow-up:
 
 5. Convert remaining encoder-side `u8` length arithmetic to checked arithmetic.
 6. Add malformed-length regression tests for the still-open cases:
-   - attribute/capability/NLRI payloads with valid prefixes plus trailing
-     garbage
    - EVPN substructures with inconsistent embedded lengths and non-`32`/`128`
      `addr_len`
 

--- a/crates/bgp-packet/SECURITY_AUDIT.md
+++ b/crates/bgp-packet/SECURITY_AUDIT.md
@@ -9,11 +9,11 @@
 ## Summary
 
 This revision re-verifies the four findings from the previous audit against the
-current source. Three of them are now fully fixed and covered by regression
-tests: both High-severity panic paths and the Medium-severity trailing-garbage
-class. The remaining Medium finding is partly addressed: the MP_REACH
-`nhop_len` case is fixed, but the EVPN substructure-length cases remain open.
-The residual encoder-side `u8` truncation issues are unchanged.
+current source. All four are now fully fixed and covered by regression tests:
+both High-severity panic paths, the Medium-severity trailing-garbage class, and
+the Medium-severity substructure-length cases (MP_REACH `nhop_len`, EVPN
+per-route `length`, and EVPN multicast `addr_len`). The only remaining items
+are the residual encoder-side `u8` truncation issues, which are unchanged.
 
 Status of the four previously reported issues:
 
@@ -23,8 +23,9 @@ Status of the four previously reported issues:
    lengths before computing the prefix byte size.
 3. **Medium — FIXED:** the length-bounded BGP subparsers now enforce full
    consumption of their bounded slice and reject trailing garbage.
-4. **Medium — PARTIALLY FIXED:** MP_REACH now validates `nhop_len`; EVPN
-   per-route `length` and multicast `addr_len` are still not enforced.
+4. **Medium — FIXED:** MP_REACH validates `nhop_len`, and the EVPN parser now
+   bounds each route body to its declared `length` and validates the multicast
+   `addr_len`.
 
 The residual encoder-side `u8` truncation issues for oversized capabilities are
 unchanged. They are local packet-construction problems rather than
@@ -121,12 +122,12 @@ Each bounded slice now enforces full consumption:
   (`cluster_list.rs`), `parse_bgp_nlri_ipv4_rejects_trailing_garbage` and
   `parse_bgp_nlri_ipv4_consumes_whole_block` (`nlri_ipv4.rs`).
 
-### 4. Substructure length fields not enforced — PARTIALLY FIXED
+### 4. Substructure length fields not enforced — FIXED
 
 - **Severity:** Medium
 - **Files:**
-  - `src/attrs/mp_reach.rs` (fixed)
-  - `src/attrs/nlri_evpn.rs` (open)
+  - `src/attrs/mp_reach.rs`
+  - `src/attrs/nlri_evpn.rs`
 
 **Fixed — MP_REACH `nhop_len`.** `parse_nlri_opt()` now matches on
 `header.nhop_len` for every AFI/SAFI and rejects unexpected lengths instead of
@@ -134,20 +135,22 @@ assuming a fixed nexthop width. VPNv4 accepts only 12/24/48 (`mp_reach.rs:200`),
 VPNv6 only 24/48 (`mp_reach.rs:254`), and any other value returns
 `Err(ErrorKind::LengthValue)`.
 
-**Open — EVPN per-route `length`.** `EvpnRoute::parse_nlri()`
-(`nlri_evpn.rs:752`) reads the per-route `length` octet but only uses it for the
-`IpPrefix` family-width selection (`nlri_evpn.rs:853`). The other route types
-(EthernetAd, EthernetSr, MacIpAdvRoute, IncMulticast) decode their fields
-without splitting the payload to `length` first. There is no
-`safe_split_at()`/`split_at()` anywhere in the file.
+**Fixed — EVPN per-route `length`.** `EvpnRoute::parse_nlri()`
+(`nlri_evpn.rs:748`) now bounds the route body to its declared `length` octet
+with `packet_utils::safe_split_at()` (`nlri_evpn.rs:758`) before dispatching on
+the route type, so no field can read past the NLRI into the next one. After the
+per-type parse it rejects any non-empty remainder inside the bounded body
+(`nlri_evpn.rs:1057`) with `Err(ErrorKind::LengthValue)`, so a field shorter
+than the declared length — or a padded length — fails the parse instead of
+silently dropping the extra octets.
 
-**Open — EVPN multicast `addr_len`.** `nlri_evpn.rs:828` treats any `addr_len`
-other than `32` as a 16-byte IPv6 address (`else { take(16) }`) without
-validating that the value is `128`.
+**Fixed — EVPN multicast `addr_len`.** The Inclusive Multicast (Type-3) arm
+now matches `addr_len` against `32` (IPv4) and `128` (IPv6) explicitly
+(`nlri_evpn.rs:834`); any other value returns `Err(ErrorKind::LengthValue)`
+rather than being read as a 16-octet IPv6 address.
 
-- **Recommendation:** Bound each EVPN route body to its declared `length`,
-  parse within that slice, reject a non-empty remainder, and validate
-  `addr_len` against the expected `32`/`128` before decoding.
+Regression tests: `inclusive_multicast_rejects_bad_addr_len` and
+`parse_nlri_rejects_trailing_body_bytes` (`nlri_evpn.rs`).
 
 ## Residual Hardening Issues — unchanged
 
@@ -182,19 +185,16 @@ Recommended follow-up:
 2. ~~Add explicit IPv4/IPv6 prefix-length validation before `nlri_psize()`.~~
    Fixed.
 
-### Priority 2 — partially open
+### Priority 2 — DONE
 
 3. ~~Enforce full consumption for all length-bounded attribute, capability, and
    NLRI slices (Finding 3).~~ Fixed.
-4. Enforce the EVPN per-route `length` and multicast `addr_len` (the remaining
-   half of Finding 4). MP_REACH `nhop_len` is done.
+4. ~~Enforce the EVPN per-route `length` and multicast `addr_len` (the remaining
+   half of Finding 4).~~ Fixed. MP_REACH `nhop_len` was already done.
 
 ### Priority 3 — open
 
 5. Convert remaining encoder-side `u8` length arithmetic to checked arithmetic.
-6. Add malformed-length regression tests for the still-open cases:
-   - EVPN substructures with inconsistent embedded lengths and non-`32`/`128`
-     `addr_len`
 
 ## Verification
 

--- a/crates/bgp-packet/src/attrs/cluster_list.rs
+++ b/crates/bgp-packet/src/attrs/cluster_list.rs
@@ -5,6 +5,7 @@ use bytes::{BufMut, BytesMut};
 use itertools::Itertools;
 use nom::IResult;
 use nom::Parser;
+use nom::error::{ErrorKind, make_error};
 use nom::number::complete::be_u32;
 
 use crate::{AttrEmitter, AttrFlags, AttrType, ParseBe, many0_complete};
@@ -22,6 +23,11 @@ impl ClusterList {
 
 impl ParseBe<ClusterList> for ClusterList {
     fn parse_be(input: &[u8]) -> IResult<&[u8], Self> {
+        // CLUSTER_LIST is a sequence of 4-octet cluster IDs (RFC 4456); a
+        // payload whose length is not a multiple of 4 is malformed.
+        if !input.len().is_multiple_of(4) {
+            return Err(nom::Err::Error(make_error(input, ErrorKind::LengthValue)));
+        }
         let (input, ids) = many0_complete(be_u32).parse(input)?;
         let list = ids.into_iter().map(Ipv4Addr::from).collect();
         Ok((input, ClusterList { list }))
@@ -57,5 +63,28 @@ impl fmt::Display for ClusterList {
 impl fmt::Debug for ClusterList {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "Cluster List: {}", self)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_cluster_list_accepts_multiple_of_four() {
+        let input = [192, 0, 2, 1, 198, 51, 100, 2];
+        let (rest, cl) = ClusterList::parse_be(&input).unwrap();
+        assert!(rest.is_empty());
+        assert_eq!(
+            cl.list,
+            vec![Ipv4Addr::new(192, 0, 2, 1), Ipv4Addr::new(198, 51, 100, 2),]
+        );
+    }
+
+    #[test]
+    fn parse_cluster_list_rejects_non_multiple_of_four() {
+        // 5 bytes: one cluster ID plus a stray trailing octet.
+        let input = [192, 0, 2, 1, 0];
+        assert!(ClusterList::parse_be(&input).is_err());
     }
 }

--- a/crates/bgp-packet/src/attrs/nlri_evpn.rs
+++ b/crates/bgp-packet/src/attrs/nlri_evpn.rs
@@ -751,8 +751,14 @@ impl ParseNlri<EvpnRoute> for EvpnRoute {
         let route_type: EvpnRouteType = typ.into();
         let (input, length) = be_u8(input)?;
 
+        // Bound the route body to its declared length (the EVPN NLRI length
+        // octet, RFC 7432 §5). No field may read past this NLRI into the next
+        // one, and any octet left unparsed inside the body fails the parse
+        // (RFC 7606 treat-as-withdraw at the caller).
+        let (rest, input) = packet_utils::safe_split_at(input, length as usize)?;
+
         use EvpnRouteType::*;
-        match route_type {
+        let result: IResult<&[u8], EvpnRoute> = match route_type {
             EthernetAd => {
                 // RFC 7432 §7.1: RD(8) ESI(10) EthTag(4) MPLSLabel(3).
                 let (input, rd) = RouteDistinguisher::parse_be(input)?;
@@ -825,17 +831,22 @@ impl ParseNlri<EvpnRoute> for EvpnRoute {
                 let (input, rd) = RouteDistinguisher::parse_be(input)?;
                 let (input, ether_tag) = be_u32(input)?;
                 let (input, addr_len) = be_u8(input)?;
-                let (input, addr) = if addr_len == 32 {
-                    let (input, val) = be_u32(input)?;
-                    let nhop = IpAddr::V4(Ipv4Addr::from(val));
-                    (input, nhop)
-                } else {
-                    let (input, val) = take(16usize).parse(input)?;
-                    let mut octets = [0u8; 16];
-                    octets.copy_from_slice(val);
-                    let addr = Ipv6Addr::from(octets);
-                    let nhop = IpAddr::V6(addr);
-                    (input, nhop)
+                // RFC 7432 §7.3: the Originating Router's IP Address length is
+                // 32 (IPv4) or 128 (IPv6). Reject any other value instead of
+                // treating it as a 16-octet IPv6 read (RFC 7606
+                // treat-as-withdraw at the caller).
+                let (input, addr) = match addr_len {
+                    32 => {
+                        let (input, val) = be_u32(input)?;
+                        (input, IpAddr::V4(Ipv4Addr::from(val)))
+                    }
+                    128 => {
+                        let (input, val) = take(16usize).parse(input)?;
+                        let mut octets = [0u8; 16];
+                        octets.copy_from_slice(val);
+                        (input, IpAddr::V6(Ipv6Addr::from(octets)))
+                    }
+                    _ => return Err(nom::Err::Error(make_error(input, ErrorKind::LengthValue))),
                 };
                 let evpn = EvpnMulticast {
                     id,
@@ -1041,7 +1052,18 @@ impl ParseNlri<EvpnRoute> for EvpnRoute {
                 ))
             }
             _ => Err(nom::Err::Error(make_error(input, ErrorKind::NoneOf))),
+        };
+
+        let (remainder, route) = result?;
+        if !remainder.is_empty() {
+            // A field was shorter than the declared length, or the length was
+            // padded — reject rather than silently dropping the extra octets.
+            return Err(nom::Err::Error(make_error(
+                remainder,
+                ErrorKind::LengthValue,
+            )));
         }
+        Ok((rest, route))
     }
 }
 
@@ -2408,5 +2430,46 @@ mod evpn_emit_tests {
         assert_eq!(buf[1], 35, "IPv6 payload length");
         let (_, parsed) = EvpnRoute::parse_nlri(&buf, false).expect("round-trip");
         assert_eq!(parsed, EvpnRoute::EthernetSeg(original));
+    }
+
+    /// RFC 7432 §7.3: an Inclusive Multicast (Type-3) Originating Router IP
+    /// length other than 32/128 must be rejected, not read as 16 IPv6 octets.
+    #[test]
+    fn inclusive_multicast_rejects_bad_addr_len() {
+        let mut body = BytesMut::new();
+        body.put_u16(0x0001); // RD type 1 ...
+        body.put_slice(&[10, 0, 0, 1, 0x00, 0x64]); // ... value (RD = 8 octets)
+        body.put_u32(0); // Ethernet Tag
+        body.put_u8(64); // IP address length — illegal (not 32/128)
+        body.put_slice(&[0u8; 16]);
+        let mut nlri = BytesMut::new();
+        nlri.put_u8(3); // Route Type 3 — Inclusive Multicast
+        nlri.put_u8(body.len() as u8);
+        nlri.put_slice(&body);
+        assert!(EvpnRoute::parse_nlri(&nlri, false).is_err());
+    }
+
+    /// The declared NLRI length bounds the route body: a length octet that
+    /// claims one extra byte the route does not use must be rejected, not
+    /// parsed with the stray octet silently dropped.
+    #[test]
+    fn parse_nlri_rejects_trailing_body_bytes() {
+        let original = EvpnEthernetAd {
+            id: 0,
+            rd: rd_type1_ip(Ipv4Addr::new(192, 0, 2, 1), 100),
+            esi: [0; 10],
+            ether_tag: 7,
+            label: 42,
+        };
+        let mut buf = BytesMut::new();
+        EvpnRoute::EthernetAd(original).nlri_emit(&mut buf);
+        // buf = [type=1, len=25, <25 body octets>]. Bump the declared length
+        // and append a stray octet inside the now-26-octet body.
+        let mut nlri = BytesMut::new();
+        nlri.put_u8(buf[0]); // Route Type 1
+        nlri.put_u8(buf[1] + 1); // declared length + 1
+        nlri.put_slice(&buf[2..]); // 25 real body octets
+        nlri.put_u8(0xff); // stray trailing octet
+        assert!(EvpnRoute::parse_nlri(&nlri, false).is_err());
     }
 }

--- a/crates/bgp-packet/src/attrs/nlri_ipv4.rs
+++ b/crates/bgp-packet/src/attrs/nlri_ipv4.rs
@@ -7,7 +7,7 @@ use nom::error::{ErrorKind, make_error};
 use nom::number::complete::{be_u8, be_u32};
 use nom_derive::*;
 
-use crate::{ParseNlri, many0_complete, nlri_psize};
+use crate::{ParseNlri, nlri_psize};
 
 #[derive(Debug, Clone, Hash, Eq, PartialEq)]
 pub struct Ipv4Nlri {
@@ -41,19 +41,46 @@ pub fn parse_bgp_nlri_ipv4(
     add_path: bool,
 ) -> IResult<&[u8], Vec<Ipv4Nlri>> {
     let len = length as usize;
-    let (input, nlri) = packet_utils::safe_split_at(input, len)?;
-    let (_, nlris) = many0_complete(|i| Ipv4Nlri::parse_nlri(i, add_path)).parse(nlri)?;
+    let (input, mut nlri) = packet_utils::safe_split_at(input, len)?;
+    // Drain the whole bounded slice: every byte must belong to a complete
+    // NLRI. A leftover (malformed/truncated trailing entry) surfaces the
+    // real parse error instead of being silently discarded.
+    let mut nlris = Vec::new();
+    while !nlri.is_empty() {
+        let (rest, entry) = Ipv4Nlri::parse_nlri(nlri, add_path)?;
+        nlris.push(entry);
+        nlri = rest;
+    }
     Ok((input, nlris))
 }
 
 #[cfg(test)]
 mod tests {
-    use super::Ipv4Nlri;
+    use super::{Ipv4Nlri, parse_bgp_nlri_ipv4};
     use crate::ParseNlri;
 
     #[test]
     fn parse_nlri_rejects_prefixlen_over_32() {
         let input = [33, 192, 0, 2, 1, 0];
         assert!(Ipv4Nlri::parse_nlri(&input, false).is_err());
+    }
+
+    #[test]
+    fn parse_bgp_nlri_ipv4_consumes_whole_block() {
+        // Two NLRIs: 192.0.2.0/24 (4 bytes) then the default route /0 (1 byte).
+        let input = [24, 192, 0, 2, 0];
+        let (rest, nlris) = parse_bgp_nlri_ipv4(&input, 5, false).unwrap();
+        assert!(rest.is_empty());
+        assert_eq!(nlris.len(), 2);
+        assert_eq!(nlris[0].prefix, "192.0.2.0/24".parse().unwrap());
+        assert_eq!(nlris[1].prefix, "0.0.0.0/0".parse().unwrap());
+    }
+
+    #[test]
+    fn parse_bgp_nlri_ipv4_rejects_trailing_garbage() {
+        // One /24 NLRI (4 bytes) plus a stray length octet that cannot form a
+        // complete NLRI; previously many0_complete dropped it silently.
+        let input = [24, 192, 0, 2, 8];
+        assert!(parse_bgp_nlri_ipv4(&input, 5, false).is_err());
     }
 }

--- a/crates/bgp-packet/src/caps/packet.rs
+++ b/crates/bgp-packet/src/caps/packet.rs
@@ -2,6 +2,7 @@ use std::fmt;
 
 use bytes::BytesMut;
 use nom::IResult;
+use nom::error::{ErrorKind, make_error};
 use nom_derive::*;
 
 use super::*;
@@ -63,7 +64,10 @@ impl CapabilityPacket {
         let (input, cap_header) = CapabilityHeader::parse_be(input)?;
         let len = cap_header.length as usize;
         let (input, cap) = packet_utils::safe_split_at(input, len)?;
-        let (_, cap) = CapabilityPacket::parse_be(cap, cap_header.code.into())?;
+        let (remaining, cap) = CapabilityPacket::parse_be(cap, cap_header.code.into())?;
+        if !remaining.is_empty() {
+            return Err(nom::Err::Error(make_error(input, ErrorKind::LengthValue)));
+        }
         Ok((input, cap))
     }
 

--- a/crates/bgp-packet/src/open.rs
+++ b/crates/bgp-packet/src/open.rs
@@ -62,7 +62,10 @@ impl OpenPacket {
             return Err(nom::Err::Error(make_error(input, ErrorKind::LengthValue)));
         }
         let (input, opts) = packet_utils::safe_split_at(input, len as usize)?;
-        let (_, caps) = many0_complete(parse_caps).parse(opts)?;
+        let (remaining, caps) = many0_complete(parse_caps).parse(opts)?;
+        if !remaining.is_empty() {
+            return Err(nom::Err::Error(make_error(input, ErrorKind::LengthValue)));
+        }
         let bgp_cap = BgpCap::from(caps);
         packet.bgp_cap = bgp_cap;
         Ok((input, packet))
@@ -73,7 +76,10 @@ fn parse_caps(input: &[u8]) -> IResult<&[u8], Vec<CapabilityPacket>> {
     let (input, header) = CapabilityHeader::parse_be(input)?;
     let len = header.length as usize;
     let (input, opts) = packet_utils::safe_split_at(input, len)?;
-    let (_, caps) = many0_complete(CapabilityPacket::parse_cap).parse(opts)?;
+    let (remaining, caps) = many0_complete(CapabilityPacket::parse_cap).parse(opts)?;
+    if !remaining.is_empty() {
+        return Err(nom::Err::Error(make_error(input, ErrorKind::LengthValue)));
+    }
     Ok((input, caps))
 }
 


### PR DESCRIPTION
## Summary

Closes the remaining open parser-hardening items in
`crates/bgp-packet/SECURITY_AUDIT.md` — **Finding 3** (length-bounded
payloads accepted trailing garbage) and **Finding 4** (EVPN substructure
length fields not enforced). After this change all four audit findings are
**FIXED**; only the Priority-3 encoder-side `u8` casts remain.

### Finding 3 — reject trailing bytes in length-bounded parsers
Several subparsers bounded their slice with `safe_split_at()` but then
discarded whatever their inner parser left over, normalizing malformed wire
data into a different in-memory object that vanished on re-emit. Enforce full
consumption of each bounded slice:

- `ClusterList::parse_be` — reject a payload whose length is not a multiple of 4.
- `parse_bgp_nlri_ipv4` — drain the whole bounded slice in an explicit loop so a
  malformed/truncated trailing NLRI surfaces the real parse error instead of
  being dropped by `many0_complete`.
- `CapabilityPacket::parse_cap` and the OPEN optional-parameter / capability-block
  parsers (`open.rs`) — reject a non-empty remainder after parsing.

### Finding 4 — enforce EVPN NLRI length and multicast addr_len
`EvpnRoute::parse_nlri` read the per-route `length` octet but only used it to
pick the Type-5 family width; every other route type decoded from the unbounded
buffer, and the Type-3 multicast arm read any non-32 `addr_len` as 16 IPv6
octets.

- Bound the route body to its declared `length` with `safe_split_at()` before
  dispatching on the route type, and reject a non-empty remainder after the
  per-type parse (RFC 7606 treat-as-withdraw at the caller).
- Validate the Type-3 Originating Router IP length against 32/128.

## Test plan

- `cargo test -p bgp-packet` — all pass, incl. 6 new regression tests
  (cluster-list multiple-of-4, IPv4 NLRI full-consumption + trailing-garbage,
  EVPN bad multicast addr_len, EVPN trailing-body bytes).
- `cargo clippy -p bgp-packet --all-targets -- -D warnings` — clean.
- `cargo fmt --check` — clean.

Behavior is unchanged for well-formed input (the emitters always set
`length == body`); only malformed wire data is now rejected rather than
silently canonicalized.

Generated with [Claude Code](https://claude.com/claude-code)