### PR TITLE
bgp-packet: clamp CapVersion & CapUnknown encoder lengths

### DIFF
--- a/crates/bgp-packet/SECURITY_AUDIT.md
+++ b/crates/bgp-packet/SECURITY_AUDIT.md
@@ -13,7 +13,8 @@ current source. All four are now fully fixed and covered by regression tests:
 both High-severity panic paths, the Medium-severity trailing-garbage class, and
 the Medium-severity substructure-length cases (MP_REACH `nhop_len`, EVPN
 per-route `length`, and EVPN multicast `addr_len`). The only remaining items
-are the residual encoder-side `u8` truncation issues, which are unchanged.
+are the residual encoder-side `u8` truncation issues; `CapFqdn` is now fixed,
+and the other capability encoders are still open.
 
 Status of the four previously reported issues:
 
@@ -28,8 +29,9 @@ Status of the four previously reported issues:
    `addr_len`.
 
 The residual encoder-side `u8` truncation issues for oversized capabilities are
-unchanged. They are local packet-construction problems rather than
-network-triggered parser bugs.
+local packet-construction problems rather than network-triggered parser bugs.
+`CapFqdn` is now fixed (clamped wire lengths derived from a single helper); the
+other capability encoders remain.
 
 Earlier hardening that remains in place (carried over from the prior revision):
 the OPEN optional-parameter, capability, and IPv4 NLRI block parsers use
@@ -152,30 +154,45 @@ rather than being read as a 16-octet IPv6 address.
 Regression tests: `inclusive_multicast_rejects_bad_addr_len` and
 `parse_nlri_rejects_trailing_body_bytes` (`nlri_evpn.rs`).
 
-## Residual Hardening Issues — unchanged
+## Residual Hardening Issues — CapFqdn fixed, others open
 
-These remain lower severity because they affect local packet construction
-rather than parsing untrusted network data. All still present:
+These are lower severity because they affect local packet construction rather
+than parsing untrusted network data.
 
-- capability encoders compute wire lengths with unchecked `as u8` casts:
-  - `CapAddPath::len()` (`caps/addpath.rs:101`)
-  - `CapRestart::len()` (`caps/graceful.rs:59`)
-  - `CapLlgr::len()` (`caps/llgr.rs:68`)
-  - `CapPathLimit::len()` (`caps/path_limit.rs:39`)
-  - `CapFqdn::len()` (`caps/fqdn.rs:48`)
-  - `CapVersion::len()` (`caps/version.rs:35`)
-  - `CapUnknown::len()` (`caps/unknown.rs:29`)
-- `CapFqdn::emit_value()` (`caps/fqdn.rs:52,54`) casts `hostname.len()` and
-  `domain.len()` to `u8` independently, so oversized values can produce
-  internally inconsistent encodings.
+**Fixed — `CapFqdn`.** `CapFqdn::len()` and `emit_value()` now derive both the
+declared length and the emitted bytes from a single `wire_lengths()` helper
+(`caps/fqdn.rs`). The hostname and domain share a 251-octet budget (the
+capability value is at most 253 octets — the optional-parameter length octet is
+`len() + 2` — minus the two name-length octets); the hostname is given priority
+and the domain takes the remainder. Both length octets are always emitted, the
+clamped counts are `<= 251` so the `as u8` casts can no longer truncate, and the
+length octets always match the bytes written. Regression tests cover the normal,
+both-empty, oversized-hostname, oversized-domain, and hostname-priority cases.
+
+**Still present — the other capability encoders** compute wire lengths with
+unchecked `as u8` casts:
+
+- `CapAddPath::len()` (`caps/addpath.rs:101`)
+- `CapRestart::len()` (`caps/graceful.rs:59`)
+- `CapLlgr::len()` (`caps/llgr.rs:68`)
+- `CapPathLimit::len()` (`caps/path_limit.rs:39`)
+- `CapVersion::len()` (`caps/version.rs:35`)
+- `CapUnknown::len()` (`caps/unknown.rs:29`)
+
+A related latent issue affects all capabilities: the shared `CapEmit::emit()`
+(`caps/emit.rs:23`) writes the optional-parameter length as
+`put_u8(self.len() + 2)`, which overflows a `u8` if any capability's `len()`
+reaches 254–255. The `CapFqdn` fix bounds its value at 253 so it never triggers
+this; the remaining encoders should adopt the same bound (or `emit()` should
+saturate / reject).
 
 Recommended follow-up:
 
-1. replace `as u8` conversions on wire lengths with `u8::try_from(...)` where
-   oversize data should be rejected.
-2. compute aggregate lengths in `usize`, then convert once at the wire
-   boundary.
-3. add regression tests for oversized local constructors.
+1. clamp or `u8::try_from(...)` the remaining capability wire-length casts the
+   same way (compute aggregate lengths in `usize`, convert once at the wire
+   boundary), and bound or saturate the shared `emit()` optional-parameter
+   length.
+2. add regression tests for oversized local constructors.
 
 ## Recommended Priority
 
@@ -192,9 +209,13 @@ Recommended follow-up:
 4. ~~Enforce the EVPN per-route `length` and multicast `addr_len` (the remaining
    half of Finding 4).~~ Fixed. MP_REACH `nhop_len` was already done.
 
-### Priority 3 — open
+### Priority 3 — partially open
 
-5. Convert remaining encoder-side `u8` length arithmetic to checked arithmetic.
+5. Convert the remaining encoder-side `u8` length arithmetic to clamped/checked
+   arithmetic (`CapAddPath`, `CapRestart`, `CapLlgr`, `CapPathLimit`,
+   `CapVersion`, `CapUnknown`), and bound or saturate the shared
+   `CapEmit::emit()` optional-parameter length (`emit.rs:23`). `CapFqdn` is
+   done.
 
 ## Verification
 

--- a/crates/bgp-packet/SECURITY_AUDIT.md
+++ b/crates/bgp-packet/SECURITY_AUDIT.md
@@ -13,8 +13,8 @@ current source. All four are now fully fixed and covered by regression tests:
 both High-severity panic paths, the Medium-severity trailing-garbage class, and
 the Medium-severity substructure-length cases (MP_REACH `nhop_len`, EVPN
 per-route `length`, and EVPN multicast `addr_len`). The only remaining items
-are the residual encoder-side `u8` truncation issues; `CapFqdn` and `CapVersion`
-are now fixed, and the other capability encoders are still open.
+are the residual encoder-side `u8` truncation issues; `CapFqdn`, `CapVersion`,
+and `CapUnknown` are now fixed, and the other capability encoders are still open.
 
 Status of the four previously reported issues:
 
@@ -30,8 +30,8 @@ Status of the four previously reported issues:
 
 The residual encoder-side `u8` truncation issues for oversized capabilities are
 local packet-construction problems rather than network-triggered parser bugs.
-`CapFqdn` and `CapVersion` are now fixed (clamped wire lengths derived from a
-single helper each); the other capability encoders remain.
+`CapFqdn`, `CapVersion`, and `CapUnknown` are now fixed (clamped wire lengths
+derived from a single helper each); the other capability encoders remain.
 
 Earlier hardening that remains in place (carried over from the prior revision):
 the OPEN optional-parameter, capability, and IPv4 NLRI block parsers use
@@ -154,7 +154,7 @@ rather than being read as a 16-octet IPv6 address.
 Regression tests: `inclusive_multicast_rejects_bad_addr_len` and
 `parse_nlri_rejects_trailing_body_bytes` (`nlri_evpn.rs`).
 
-## Residual Hardening Issues — CapFqdn & CapVersion fixed, others open
+## Residual Hardening Issues — CapFqdn, CapVersion & CapUnknown fixed, others open
 
 These are lower severity because they affect local packet construction rather
 than parsing untrusted network data.
@@ -176,6 +176,11 @@ capability-value budget. The `as u8` length cast can no longer truncate, the
 length octet always matches the bytes written, and `len() + 2` stays within a
 u8. Regression tests cover the normal, empty, and oversized cases.
 
+**Fixed — `CapUnknown`.** Same shape as `CapVersion`: the opaque `data` blob is
+the whole capability value, so `len()` and `emit_value()` derive from a
+`wire_len()` helper (`caps/unknown.rs`) that clamps `data` to the 253-octet
+budget. Regression tests cover the normal, empty, and oversized cases.
+
 **Still present — the other capability encoders** compute wire lengths with
 unchecked `as u8` casts:
 
@@ -183,14 +188,13 @@ unchecked `as u8` casts:
 - `CapRestart::len()` (`caps/graceful.rs:59`)
 - `CapLlgr::len()` (`caps/llgr.rs:68`)
 - `CapPathLimit::len()` (`caps/path_limit.rs:39`)
-- `CapUnknown::len()` (`caps/unknown.rs:29`)
 
 A related latent issue affects all capabilities: the shared `CapEmit::emit()`
 (`caps/emit.rs:23`) writes the optional-parameter length as
 `put_u8(self.len() + 2)`, which overflows a `u8` if any capability's `len()`
-reaches 254–255. The `CapFqdn` and `CapVersion` fixes bound their values at 253
-so they never trigger this; the remaining encoders should adopt the same bound
-(or `emit()` should saturate / reject).
+reaches 254–255. The `CapFqdn`, `CapVersion`, and `CapUnknown` fixes bound their
+values at 253 so they never trigger this; the remaining encoders should adopt
+the same bound (or `emit()` should saturate / reject).
 
 Recommended follow-up:
 
@@ -218,10 +222,9 @@ Recommended follow-up:
 ### Priority 3 — partially open
 
 5. Convert the remaining encoder-side `u8` length arithmetic to clamped/checked
-   arithmetic (`CapAddPath`, `CapRestart`, `CapLlgr`, `CapPathLimit`,
-   `CapUnknown`), and bound or saturate the shared `CapEmit::emit()`
-   optional-parameter length (`emit.rs:23`). `CapFqdn` and `CapVersion` are
-   done.
+   arithmetic (`CapAddPath`, `CapRestart`, `CapLlgr`, `CapPathLimit`), and bound
+   or saturate the shared `CapEmit::emit()` optional-parameter length
+   (`emit.rs:23`). `CapFqdn`, `CapVersion`, and `CapUnknown` are done.
 
 ## Verification
 

--- a/crates/bgp-packet/SECURITY_AUDIT.md
+++ b/crates/bgp-packet/SECURITY_AUDIT.md
@@ -13,8 +13,8 @@ current source. All four are now fully fixed and covered by regression tests:
 both High-severity panic paths, the Medium-severity trailing-garbage class, and
 the Medium-severity substructure-length cases (MP_REACH `nhop_len`, EVPN
 per-route `length`, and EVPN multicast `addr_len`). The only remaining items
-are the residual encoder-side `u8` truncation issues; `CapFqdn` is now fixed,
-and the other capability encoders are still open.
+are the residual encoder-side `u8` truncation issues; `CapFqdn` and `CapVersion`
+are now fixed, and the other capability encoders are still open.
 
 Status of the four previously reported issues:
 
@@ -30,8 +30,8 @@ Status of the four previously reported issues:
 
 The residual encoder-side `u8` truncation issues for oversized capabilities are
 local packet-construction problems rather than network-triggered parser bugs.
-`CapFqdn` is now fixed (clamped wire lengths derived from a single helper); the
-other capability encoders remain.
+`CapFqdn` and `CapVersion` are now fixed (clamped wire lengths derived from a
+single helper each); the other capability encoders remain.
 
 Earlier hardening that remains in place (carried over from the prior revision):
 the OPEN optional-parameter, capability, and IPv4 NLRI block parsers use
@@ -154,7 +154,7 @@ rather than being read as a 16-octet IPv6 address.
 Regression tests: `inclusive_multicast_rejects_bad_addr_len` and
 `parse_nlri_rejects_trailing_body_bytes` (`nlri_evpn.rs`).
 
-## Residual Hardening Issues — CapFqdn fixed, others open
+## Residual Hardening Issues — CapFqdn & CapVersion fixed, others open
 
 These are lower severity because they affect local packet construction rather
 than parsing untrusted network data.
@@ -169,6 +169,13 @@ clamped counts are `<= 251` so the `as u8` casts can no longer truncate, and the
 length octets always match the bytes written. Regression tests cover the normal,
 both-empty, oversized-hostname, oversized-domain, and hostname-priority cases.
 
+**Fixed — `CapVersion`.** The version string is the whole capability value (no
+internal length octet), so `len()` and `emit_value()` now derive from a single
+`wire_len()` helper (`caps/version.rs`) that clamps the version to the 253-octet
+capability-value budget. The `as u8` length cast can no longer truncate, the
+length octet always matches the bytes written, and `len() + 2` stays within a
+u8. Regression tests cover the normal, empty, and oversized cases.
+
 **Still present — the other capability encoders** compute wire lengths with
 unchecked `as u8` casts:
 
@@ -176,15 +183,14 @@ unchecked `as u8` casts:
 - `CapRestart::len()` (`caps/graceful.rs:59`)
 - `CapLlgr::len()` (`caps/llgr.rs:68`)
 - `CapPathLimit::len()` (`caps/path_limit.rs:39`)
-- `CapVersion::len()` (`caps/version.rs:35`)
 - `CapUnknown::len()` (`caps/unknown.rs:29`)
 
 A related latent issue affects all capabilities: the shared `CapEmit::emit()`
 (`caps/emit.rs:23`) writes the optional-parameter length as
 `put_u8(self.len() + 2)`, which overflows a `u8` if any capability's `len()`
-reaches 254–255. The `CapFqdn` fix bounds its value at 253 so it never triggers
-this; the remaining encoders should adopt the same bound (or `emit()` should
-saturate / reject).
+reaches 254–255. The `CapFqdn` and `CapVersion` fixes bound their values at 253
+so they never trigger this; the remaining encoders should adopt the same bound
+(or `emit()` should saturate / reject).
 
 Recommended follow-up:
 
@@ -213,8 +219,8 @@ Recommended follow-up:
 
 5. Convert the remaining encoder-side `u8` length arithmetic to clamped/checked
    arithmetic (`CapAddPath`, `CapRestart`, `CapLlgr`, `CapPathLimit`,
-   `CapVersion`, `CapUnknown`), and bound or saturate the shared
-   `CapEmit::emit()` optional-parameter length (`emit.rs:23`). `CapFqdn` is
+   `CapUnknown`), and bound or saturate the shared `CapEmit::emit()`
+   optional-parameter length (`emit.rs:23`). `CapFqdn` and `CapVersion` are
    done.
 
 ## Verification

--- a/crates/bgp-packet/src/caps/unknown.rs
+++ b/crates/bgp-packet/src/caps/unknown.rs
@@ -20,22 +20,90 @@ impl Default for CapUnknown {
     }
 }
 
+impl CapUnknown {
+    /// The capability value is the opaque `data` blob, at most 253 octets on
+    /// the wire: the BGP optional-parameter that carries it has a single length
+    /// octet covering `code(1) + length(1) + value` (`emit.rs` writes
+    /// `put_u8(len() + 2)`), so `value <= 255 - 2`.
+    const VALUE_MAX: usize = 253;
+
+    /// Number of data octets actually written on the wire. Clamped to the
+    /// capability-value budget so the `as u8` length cast cannot truncate and
+    /// the length octet always matches the bytes emitted. `len()` and
+    /// `emit_value()` both derive from this.
+    fn wire_len(&self) -> usize {
+        self.data.len().min(Self::VALUE_MAX)
+    }
+}
+
 impl CapEmit for CapUnknown {
     fn code(&self) -> CapCode {
         CapCode::Unknown(100)
     }
 
     fn len(&self) -> u8 {
-        self.data.len() as u8
+        // wire_len() <= 253, so the cast cannot truncate and `len() + 2` stays
+        // within a u8 for the optional-parameter framing.
+        self.wire_len() as u8
     }
 
     fn emit_value(&self, buf: &mut BytesMut) {
-        buf.put(&self.data[..]);
+        let n = self.wire_len();
+        buf.put(&self.data[..n]);
     }
 }
 
 impl fmt::Display for CapUnknown {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "Unknown: Code {}", self.header.code)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn cap_with_data(n: usize) -> CapUnknown {
+        CapUnknown {
+            header: CapabilityHeader::new(CapCode::Unknown(100), 0),
+            data: vec![0xab; n],
+        }
+    }
+
+    #[test]
+    fn len_matches_emitted_bytes() {
+        let cap = cap_with_data(10);
+        let mut buf = BytesMut::new();
+        cap.emit_value(&mut buf);
+        assert_eq!(
+            cap.len() as usize,
+            buf.len(),
+            "len() must equal emitted bytes"
+        );
+        assert_eq!(cap.len(), 10);
+    }
+
+    #[test]
+    fn empty_data() {
+        let cap = cap_with_data(0);
+        let mut buf = BytesMut::new();
+        cap.emit_value(&mut buf);
+        assert!(buf.is_empty());
+        assert_eq!(cap.len(), 0);
+    }
+
+    #[test]
+    fn oversized_data_clamped_to_budget() {
+        // 300-octet blob clamps to 253; len() + 2 stays within a u8.
+        let cap = cap_with_data(300);
+        let mut buf = BytesMut::new();
+        cap.emit_value(&mut buf);
+        assert_eq!(cap.len(), 253);
+        assert_eq!(buf.len(), 253, "emitted bytes match len()");
+        assert_eq!(
+            cap.len() + 2,
+            255,
+            "optional-parameter length stays within a u8"
+        );
     }
 }

--- a/crates/bgp-packet/src/caps/version.rs
+++ b/crates/bgp-packet/src/caps/version.rs
@@ -24,6 +24,20 @@ impl CapVersion {
             String::from_utf8_lossy(&self.version)
         }
     }
+
+    /// The capability value is the version string itself, at most 253 octets
+    /// on the wire: the BGP optional-parameter that carries it has a single
+    /// length octet covering `code(1) + length(1) + value` (`emit.rs` writes
+    /// `put_u8(len() + 2)`), so `value <= 255 - 2`.
+    const VALUE_MAX: usize = 253;
+
+    /// Number of version octets actually written on the wire. Clamped to the
+    /// capability-value budget so the `as u8` length cast cannot truncate and
+    /// the length octet always matches the bytes emitted. `len()` and
+    /// `emit_value()` both derive from this.
+    fn wire_len(&self) -> usize {
+        self.version.len().min(Self::VALUE_MAX)
+    }
 }
 
 impl CapEmit for CapVersion {
@@ -32,11 +46,14 @@ impl CapEmit for CapVersion {
     }
 
     fn len(&self) -> u8 {
-        self.version.len() as u8
+        // wire_len() <= 253, so the cast cannot truncate and `len() + 2` stays
+        // within a u8 for the optional-parameter framing.
+        self.wire_len() as u8
     }
 
     fn emit_value(&self, buf: &mut BytesMut) {
-        buf.put(&self.version[..]);
+        let n = self.wire_len();
+        buf.put(&self.version[..n]);
     }
 }
 
@@ -47,5 +64,59 @@ impl fmt::Display for CapVersion {
             "Software Version: {}",
             String::from_utf8_lossy(&self.version)
         )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Emit the value, assert `len()` matches the bytes written and `len() + 2`
+    /// fits a u8 (the optional-parameter framing), then parse it back.
+    fn emit_and_parse(cap: &CapVersion) -> (u8, CapVersion) {
+        let mut buf = BytesMut::new();
+        cap.emit_value(&mut buf);
+        assert_eq!(
+            cap.len() as usize,
+            buf.len(),
+            "len() must equal the emitted byte count"
+        );
+        // emit.rs writes the optional-parameter length as `put_u8(len() + 2)`.
+        assert!(
+            cap.len().checked_add(2).is_some(),
+            "len() + 2 must fit a u8"
+        );
+        let (rest, parsed) = CapVersion::parse_be(&buf).expect("parse emitted value");
+        assert!(
+            rest.is_empty(),
+            "emit_value must be fully consumed by parse"
+        );
+        (cap.len(), parsed)
+    }
+
+    #[test]
+    fn normal_round_trip() {
+        let cap = CapVersion::new("zebra-rs 1.0");
+        let (len, parsed) = emit_and_parse(&cap);
+        assert_eq!(len as usize, "zebra-rs 1.0".len());
+        assert_eq!(parsed, cap);
+    }
+
+    #[test]
+    fn empty_version_round_trips() {
+        let cap = CapVersion::default();
+        let (len, parsed) = emit_and_parse(&cap);
+        assert_eq!(len, 0);
+        assert_eq!(parsed, cap);
+    }
+
+    #[test]
+    fn oversized_version_clamped_to_budget() {
+        // 300-octet version clamps to 253; len() + 2 stays within a u8.
+        let cap = CapVersion::new(&"v".repeat(300));
+        let (len, parsed) = emit_and_parse(&cap);
+        assert_eq!(parsed.version.len(), 253);
+        assert_eq!(len, 253);
+        assert_eq!(len + 2, 255, "optional-parameter length stays within a u8");
     }
 }


### PR DESCRIPTION
## Summary

Continues the Priority-3 residual encoder-side `u8`-truncation cleanup in
`crates/bgp-packet/SECURITY_AUDIT.md`, covering the **`CapVersion`** and
**`CapUnknown`** capability encoders (and folding in the `CapFqdn` audit-doc
update from the prior fix).

Both `CapVersion::len()` and `CapUnknown::len()` cast their value length
(`version.len()` / `data.len()`) to `u8` directly, so an over-long value
produced a length octet that disagreed with the bytes emitted (and could wrap
to a bogus value). In both, the variable field *is* the whole capability value
(no internal length octet), so:

- `len()` and `emit_value()` now derive from a single `wire_len()` helper that
  clamps the value to the **253-octet** capability-value budget (the
  optional-parameter length octet is `len() + 2`, a single `u8`, so
  `value <= 255 - 2`).
- The clamped length is `<= 253`, so the `as u8` cast can no longer truncate,
  the length octet always matches the emitted bytes, and `len() + 2` stays
  within a `u8`.

This matches the approach already merged for `CapFqdn` (#1647).

## Test plan

- `cargo test -p bgp-packet` — 373 pass, incl. 6 new tests (CapVersion: normal
  round-trip, empty, oversized→253; CapUnknown: emit/len consistency, empty,
  oversized→253).
- `cargo clippy -p bgp-packet --all-targets -- -D warnings` — clean.
- `cargo fmt --check` — clean.

## Audit status

Residual encoder casts: `CapFqdn`, `CapVersion`, `CapUnknown` are now fixed.
Still open: `CapAddPath`, `CapRestart`, `CapLlgr`, `CapPathLimit`, plus the
shared `CapEmit::emit()` `len() + 2` optional-parameter framing.

Generated with [Claude Code](https://claude.com/claude-code)