### PR TITLE
bgp-packet: clamp CapAddPath encoder length (no truncating u8 cast)

### DIFF
--- a/crates/bgp-packet/SECURITY_AUDIT.md
+++ b/crates/bgp-packet/SECURITY_AUDIT.md
@@ -14,7 +14,8 @@ both High-severity panic paths, the Medium-severity trailing-garbage class, and
 the Medium-severity substructure-length cases (MP_REACH `nhop_len`, EVPN
 per-route `length`, and EVPN multicast `addr_len`). The only remaining items
 are the residual encoder-side `u8` truncation issues; `CapFqdn`, `CapVersion`,
-and `CapUnknown` are now fixed, and the other capability encoders are still open.
+`CapUnknown`, and `CapAddPath` are now fixed, and the other capability encoders
+are still open.
 
 Status of the four previously reported issues:
 
@@ -30,8 +31,9 @@ Status of the four previously reported issues:
 
 The residual encoder-side `u8` truncation issues for oversized capabilities are
 local packet-construction problems rather than network-triggered parser bugs.
-`CapFqdn`, `CapVersion`, and `CapUnknown` are now fixed (clamped wire lengths
-derived from a single helper each); the other capability encoders remain.
+`CapFqdn`, `CapVersion`, `CapUnknown`, and `CapAddPath` are now fixed (clamped
+wire lengths derived from a single helper each); the other capability encoders
+remain.
 
 Earlier hardening that remains in place (carried over from the prior revision):
 the OPEN optional-parameter, capability, and IPv4 NLRI block parsers use
@@ -154,7 +156,7 @@ rather than being read as a 16-octet IPv6 address.
 Regression tests: `inclusive_multicast_rejects_bad_addr_len` and
 `parse_nlri_rejects_trailing_body_bytes` (`nlri_evpn.rs`).
 
-## Residual Hardening Issues — CapFqdn, CapVersion & CapUnknown fixed, others open
+## Residual Hardening Issues — CapFqdn, CapVersion, CapUnknown & CapAddPath fixed, others open
 
 These are lower severity because they affect local packet construction rather
 than parsing untrusted network data.
@@ -181,10 +183,17 @@ the whole capability value, so `len()` and `emit_value()` derive from a
 `wire_len()` helper (`caps/unknown.rs`) that clamps `data` to the 253-octet
 budget. Regression tests cover the normal, empty, and oversized cases.
 
+**Fixed — `CapAddPath`.** Each AddPath entry is a fixed 4 octets, so `len()`
+(`values.len() * 4`) and `emit_value()` now derive from a `wire_count()` helper
+(`caps/addpath.rs`) that clamps the emitted entry count to 63 (252 octets) — the
+most that fits the 253-octet capability-value budget. The `as u8` cast can no
+longer wrap (entries beyond the budget are dropped, not silently truncated into
+a bogus length octet). Regression tests cover the normal, empty, and
+too-many-entries cases.
+
 **Still present — the other capability encoders** compute wire lengths with
 unchecked `as u8` casts:
 
-- `CapAddPath::len()` (`caps/addpath.rs:101`)
 - `CapRestart::len()` (`caps/graceful.rs:59`)
 - `CapLlgr::len()` (`caps/llgr.rs:68`)
 - `CapPathLimit::len()` (`caps/path_limit.rs:39`)
@@ -192,9 +201,9 @@ unchecked `as u8` casts:
 A related latent issue affects all capabilities: the shared `CapEmit::emit()`
 (`caps/emit.rs:23`) writes the optional-parameter length as
 `put_u8(self.len() + 2)`, which overflows a `u8` if any capability's `len()`
-reaches 254–255. The `CapFqdn`, `CapVersion`, and `CapUnknown` fixes bound their
-values at 253 so they never trigger this; the remaining encoders should adopt
-the same bound (or `emit()` should saturate / reject).
+reaches 254–255. The `CapFqdn`, `CapVersion`, `CapUnknown`, and `CapAddPath`
+fixes bound their values at 253/252 so they never trigger this; the remaining
+encoders should adopt the same bound (or `emit()` should saturate / reject).
 
 Recommended follow-up:
 
@@ -222,9 +231,9 @@ Recommended follow-up:
 ### Priority 3 — partially open
 
 5. Convert the remaining encoder-side `u8` length arithmetic to clamped/checked
-   arithmetic (`CapAddPath`, `CapRestart`, `CapLlgr`, `CapPathLimit`), and bound
-   or saturate the shared `CapEmit::emit()` optional-parameter length
-   (`emit.rs:23`). `CapFqdn`, `CapVersion`, and `CapUnknown` are done.
+   arithmetic (`CapRestart`, `CapLlgr`, `CapPathLimit`), and bound or saturate
+   the shared `CapEmit::emit()` optional-parameter length (`emit.rs:23`).
+   `CapFqdn`, `CapVersion`, `CapUnknown`, and `CapAddPath` are done.
 
 ## Verification
 

--- a/crates/bgp-packet/src/caps/addpath.rs
+++ b/crates/bgp-packet/src/caps/addpath.rs
@@ -90,6 +90,22 @@ impl CapAddPath {
     pub fn is_empty(&self) -> bool {
         self.values.is_empty()
     }
+
+    /// Each AddPath entry is 4 octets on the wire (AFI u16 + SAFI u8 +
+    /// Send/Receive u8). A capability value is at most 253 octets — the BGP
+    /// optional-parameter that carries it has a single length octet covering
+    /// `code(1) + length(1) + value` (`emit.rs` writes `put_u8(len() + 2)`),
+    /// so `value <= 255 - 2` — which fits at most 63 entries (252 octets).
+    const ENTRY_LEN: usize = 4;
+    const MAX_ENTRIES: usize = 253 / Self::ENTRY_LEN; // 63
+
+    /// Number of entries actually written on the wire. `len()` and
+    /// `emit_value()` both derive from this so the declared length always
+    /// matches the bytes emitted and the `as u8` cast cannot truncate; entries
+    /// beyond the budget are dropped rather than wrapping the length octet.
+    fn wire_count(&self) -> usize {
+        self.values.len().min(Self::MAX_ENTRIES)
+    }
 }
 
 impl CapEmit for CapAddPath {
@@ -98,11 +114,13 @@ impl CapEmit for CapAddPath {
     }
 
     fn len(&self) -> u8 {
-        (self.values.len() * 4) as u8
+        // wire_count() <= 63, so wire_count() * 4 <= 252 fits a u8 and
+        // `len() + 2` stays within a u8 for the optional-parameter framing.
+        (self.wire_count() * Self::ENTRY_LEN) as u8
     }
 
     fn emit_value(&self, buf: &mut BytesMut) {
-        for val in self.values.iter() {
+        for val in self.values.iter().take(self.wire_count()) {
             buf.put_u16(val.afi.into());
             buf.put_u8(val.safi.into());
             buf.put_u8(val.send_receive.into());
@@ -120,5 +138,72 @@ impl fmt::Display for CapAddPath {
             let _ = write!(f, "{}/{}: {}", value.afi, value.safi, value.send_receive);
         }
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn cap_with_entries(n: usize) -> CapAddPath {
+        CapAddPath {
+            values: (0..n)
+                .map(|_| AddPathValue {
+                    afi: Afi::Ip,
+                    safi: Safi::Unicast,
+                    send_receive: AddPathSendReceive::SendReceive,
+                })
+                .collect(),
+        }
+    }
+
+    /// Emit the value, assert `len()` matches the bytes written and `len() + 2`
+    /// fits a u8 (the optional-parameter framing), then parse it back.
+    fn emit_and_parse(cap: &CapAddPath) -> (u8, CapAddPath) {
+        let mut buf = BytesMut::new();
+        cap.emit_value(&mut buf);
+        assert_eq!(
+            cap.len() as usize,
+            buf.len(),
+            "len() must equal the emitted byte count"
+        );
+        assert!(
+            cap.len().checked_add(2).is_some(),
+            "len() + 2 must fit a u8"
+        );
+        let (rest, parsed) = CapAddPath::parse_be(&buf).expect("parse emitted value");
+        assert!(
+            rest.is_empty(),
+            "emit_value must be fully consumed by parse"
+        );
+        (cap.len(), parsed)
+    }
+
+    #[test]
+    fn normal_round_trip() {
+        let cap = cap_with_entries(2);
+        let (len, parsed) = emit_and_parse(&cap);
+        assert_eq!(len, 8, "2 entries * 4");
+        assert_eq!(parsed.values.len(), 2);
+        assert_eq!(parsed, cap);
+    }
+
+    #[test]
+    fn empty_round_trips() {
+        let cap = CapAddPath::default();
+        let (len, parsed) = emit_and_parse(&cap);
+        assert_eq!(len, 0);
+        assert_eq!(parsed, cap);
+    }
+
+    #[test]
+    fn too_many_entries_clamped_to_budget() {
+        // 100 entries * 4 = 400 octets would wrap the length octet; clamp to 63
+        // entries (252 octets).
+        let cap = cap_with_entries(100);
+        let (len, parsed) = emit_and_parse(&cap);
+        assert_eq!(len, 252, "63 entries * 4");
+        assert_eq!(parsed.values.len(), 63);
+        assert_eq!(len + 2, 254, "optional-parameter length stays within a u8");
     }
 }


### PR DESCRIPTION
## Summary

Continues the Priority-3 residual encoder-side `u8`-truncation cleanup in
`crates/bgp-packet/SECURITY_AUDIT.md`, covering the **`CapAddPath`** encoder.

`CapAddPath::len()` cast `(values.len() * 4)` to `u8`, so 64+ AddPath entries
(256+ octets) wrapped the length octet to a bogus value that disagreed with the
bytes `emit_value()` wrote. Each entry is a fixed 4 octets (AFI u16 + SAFI u8 +
Send/Receive u8), so:

- `len()` and `emit_value()` now derive from a single `wire_count()` helper that
  clamps the emitted entry count to **63** (252 octets) — the most that fits the
  253-octet capability-value budget (the optional-parameter length octet is
  `len() + 2`, a single `u8`).
- Entries beyond the budget are dropped rather than wrapping the length octet;
  the `as u8` cast can no longer truncate.

In practice only a handful of AFI/SAFIs are ever advertised, so the clamp is a
safety net for pathological input; the previous code produced an inconsistent
length octet for 64+ entries.

## Test plan

- `cargo test -p bgp-packet` — 376 pass, incl. 3 new tests (normal round-trip,
  empty, too-many-entries → clamped to 63).
- `cargo clippy -p bgp-packet --all-targets -- -D warnings` — clean.
- `cargo fmt --check` — clean.

## Audit status

Residual encoder casts: `CapFqdn`, `CapVersion`, `CapUnknown`, `CapAddPath` are
now fixed. Still open: `CapRestart`, `CapLlgr`, `CapPathLimit`, plus the shared
`CapEmit::emit()` `len() + 2` optional-parameter framing.

Generated with [Claude Code](https://claude.com/claude-code)