### PR TITLE
bgp-packet: clamp CapPathLimit encoder length (last encoder cast)

### DIFF
--- a/crates/bgp-packet/SECURITY_AUDIT.md
+++ b/crates/bgp-packet/SECURITY_AUDIT.md
@@ -13,9 +13,10 @@ current source. All four are now fully fixed and covered by regression tests:
 both High-severity panic paths, the Medium-severity trailing-garbage class, and
 the Medium-severity substructure-length cases (MP_REACH `nhop_len`, EVPN
 per-route `length`, and EVPN multicast `addr_len`). The only remaining items
-are the residual encoder-side `u8` truncation issues; `CapFqdn`, `CapVersion`,
-`CapUnknown`, `CapAddPath`, `CapRestart`, and `CapLlgr` are now fixed, leaving
-only `CapPathLimit` (and the shared `emit()` framing).
+were the residual encoder-side `u8` truncation issues; all seven capability
+encoders (`CapFqdn`, `CapVersion`, `CapUnknown`, `CapAddPath`, `CapRestart`,
+`CapLlgr`, `CapPathLimit`) now clamp to their wire budgets, leaving only the
+shared `CapEmit::emit()` `len() + 2` optional-parameter framing.
 
 Status of the four previously reported issues:
 
@@ -31,9 +32,10 @@ Status of the four previously reported issues:
 
 The residual encoder-side `u8` truncation issues for oversized capabilities are
 local packet-construction problems rather than network-triggered parser bugs.
-`CapFqdn`, `CapVersion`, `CapUnknown`, `CapAddPath`, `CapRestart`, and `CapLlgr`
-are now fixed (clamped wire lengths derived from a single helper each); only
-`CapPathLimit` remains.
+all seven capability encoders (`CapFqdn`, `CapVersion`, `CapUnknown`,
+`CapAddPath`, `CapRestart`, `CapLlgr`, `CapPathLimit`) are now fixed (clamped
+wire lengths derived from a single helper each); only the shared `emit()`
+`len() + 2` framing remains.
 
 Earlier hardening that remains in place (carried over from the prior revision):
 the OPEN optional-parameter, capability, and IPv4 NLRI block parsers use
@@ -156,7 +158,7 @@ rather than being read as a 16-octet IPv6 address.
 Regression tests: `inclusive_multicast_rejects_bad_addr_len` and
 `parse_nlri_rejects_trailing_body_bytes` (`nlri_evpn.rs`).
 
-## Residual Hardening Issues — only CapPathLimit + shared emit() framing open
+## Residual Hardening Issues — all capability encoder casts fixed; only the shared emit() framing remains
 
 These are lower severity because they affect local packet construction rather
 than parsing untrusted network data.
@@ -204,26 +206,26 @@ clamps the emitted entry count to 36 (252 octets). The `as u8` cast can no
 longer wrap. Regression tests cover the normal, empty, and too-many-entries
 cases.
 
-**Still present — one capability encoder** computes its wire length with an
-unchecked `as u8` cast:
+**Fixed — `CapPathLimit`.** Same shape: each Path-Limit entry is a fixed 5
+octets (AFI + SAFI + Path Limit u16), so `len()` (`values.len() * 5`) and
+`emit_value()` now derive from a `wire_count()` helper (`caps/path_limit.rs`)
+that clamps the emitted entry count to 50 (250 octets). The `as u8` cast can no
+longer wrap. Regression tests cover the normal, empty, and too-many-entries
+cases.
 
-- `CapPathLimit::len()` (`caps/path_limit.rs:39`)
-
-A related latent issue affects all capabilities: the shared `CapEmit::emit()`
+**Still present — the shared optional-parameter framing.** `CapEmit::emit()`
 (`caps/emit.rs:23`) writes the optional-parameter length as
 `put_u8(self.len() + 2)`, which overflows a `u8` if any capability's `len()`
-reaches 254–255. The `CapFqdn`, `CapVersion`, `CapUnknown`, `CapAddPath`,
-`CapRestart`, and `CapLlgr` fixes bound their values at 253/252 so they never
-trigger this; the remaining encoder should adopt the same bound (or `emit()`
-should saturate / reject).
+reaches 254–255. All seven per-capability encoders now bound their values at
+253/252 so they never trigger this in practice, but the shared `emit()` itself
+is still unguarded — it should clamp/saturate or `u8::try_from(...)` the
+`len() + 2` (or move to RFC 9072 extended optional parameters) so a future
+capability can't reintroduce the overflow.
 
 Recommended follow-up:
 
-1. clamp or `u8::try_from(...)` the remaining capability wire-length casts the
-   same way (compute aggregate lengths in `usize`, convert once at the wire
-   boundary), and bound or saturate the shared `emit()` optional-parameter
-   length.
-2. add regression tests for oversized local constructors.
+1. bound or saturate the shared `emit()` optional-parameter length (`len() + 2`)
+   so it cannot overflow regardless of a capability's `len()`.
 
 ## Recommended Priority
 
@@ -242,11 +244,11 @@ Recommended follow-up:
 
 ### Priority 3 — partially open
 
-5. Convert the remaining encoder-side `u8` length arithmetic to clamped/checked
-   arithmetic (`CapPathLimit`), and bound or saturate the shared
-   `CapEmit::emit()` optional-parameter length (`emit.rs:23`). `CapFqdn`,
-   `CapVersion`, `CapUnknown`, `CapAddPath`, `CapRestart`, and `CapLlgr` are
-   done.
+5. ~~Convert the encoder-side `u8` length arithmetic for each capability to
+   clamped/checked arithmetic.~~ Done — all seven (`CapFqdn`, `CapVersion`,
+   `CapUnknown`, `CapAddPath`, `CapRestart`, `CapLlgr`, `CapPathLimit`) now
+   clamp to their wire budgets. The only remaining item is to bound or saturate
+   the shared `CapEmit::emit()` optional-parameter length (`emit.rs:23`).
 
 ## Verification
 

--- a/crates/bgp-packet/src/caps/path_limit.rs
+++ b/crates/bgp-packet/src/caps/path_limit.rs
@@ -28,6 +28,22 @@ impl CapPathLimit {
             }],
         }
     }
+
+    /// Each Path-Limit entry is 5 octets on the wire (AFI u16 + SAFI u8 +
+    /// Path Limit u16). A capability value is at most 253 octets — the BGP
+    /// optional-parameter that carries it has a single length octet covering
+    /// `code(1) + length(1) + value` (`emit.rs` writes `put_u8(len() + 2)`),
+    /// so `value <= 255 - 2` — which fits at most 50 entries (250 octets).
+    const ENTRY_LEN: usize = 5;
+    const MAX_ENTRIES: usize = 253 / Self::ENTRY_LEN; // 50
+
+    /// Number of entries actually written on the wire. `len()` and
+    /// `emit_value()` both derive from this so the declared length always
+    /// matches the bytes emitted and the `as u8` cast cannot truncate; entries
+    /// beyond the budget are dropped rather than wrapping the length octet.
+    fn wire_count(&self) -> usize {
+        self.values.len().min(Self::MAX_ENTRIES)
+    }
 }
 
 impl CapEmit for CapPathLimit {
@@ -36,11 +52,13 @@ impl CapEmit for CapPathLimit {
     }
 
     fn len(&self) -> u8 {
-        (self.values.len() * 5) as u8
+        // wire_count() <= 50, so wire_count() * 5 <= 250 fits a u8 and
+        // `len() + 2` stays within a u8 for the optional-parameter framing.
+        (self.wire_count() * Self::ENTRY_LEN) as u8
     }
 
     fn emit_value(&self, buf: &mut BytesMut) {
-        for val in self.values.iter() {
+        for val in self.values.iter().take(self.wire_count()) {
             buf.put_u16(val.afi.into());
             buf.put_u8(val.safi.into());
             buf.put_u16(val.path_limit);
@@ -58,5 +76,72 @@ impl fmt::Display for CapPathLimit {
             let _ = write!(f, "{}/{} {}", value.afi, value.safi, value.path_limit);
         }
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn cap_with_entries(n: usize) -> CapPathLimit {
+        CapPathLimit {
+            values: (0..n)
+                .map(|_| PathLimitValue {
+                    afi: Afi::Ip,
+                    safi: Safi::Unicast,
+                    path_limit: 100,
+                })
+                .collect(),
+        }
+    }
+
+    /// Emit the value, assert `len()` matches the bytes written and `len() + 2`
+    /// fits a u8 (the optional-parameter framing), then parse it back.
+    fn emit_and_parse(cap: &CapPathLimit) -> (u8, CapPathLimit) {
+        let mut buf = BytesMut::new();
+        cap.emit_value(&mut buf);
+        assert_eq!(
+            cap.len() as usize,
+            buf.len(),
+            "len() must equal the emitted byte count"
+        );
+        assert!(
+            cap.len().checked_add(2).is_some(),
+            "len() + 2 must fit a u8"
+        );
+        let (rest, parsed) = CapPathLimit::parse_be(&buf).expect("parse emitted value");
+        assert!(
+            rest.is_empty(),
+            "emit_value must be fully consumed by parse"
+        );
+        (cap.len(), parsed)
+    }
+
+    #[test]
+    fn normal_round_trip() {
+        let cap = cap_with_entries(2);
+        let (len, parsed) = emit_and_parse(&cap);
+        assert_eq!(len, 10, "2 entries * 5");
+        assert_eq!(parsed.values.len(), 2);
+        assert_eq!(parsed, cap);
+    }
+
+    #[test]
+    fn empty_round_trips() {
+        let cap = CapPathLimit::default();
+        let (len, parsed) = emit_and_parse(&cap);
+        assert_eq!(len, 0);
+        assert_eq!(parsed, cap);
+    }
+
+    #[test]
+    fn too_many_entries_clamped_to_budget() {
+        // 60 entries * 5 = 300 octets would wrap the length octet; clamp to 50
+        // entries (250 octets).
+        let cap = cap_with_entries(60);
+        let (len, parsed) = emit_and_parse(&cap);
+        assert_eq!(len, 250, "50 entries * 5");
+        assert_eq!(parsed.values.len(), 50);
+        assert_eq!(len + 2, 252, "optional-parameter length stays within a u8");
     }
 }


### PR DESCRIPTION
## Summary

Final per-capability item in the Priority-3 residual encoder-side
`u8`-truncation cleanup in `crates/bgp-packet/SECURITY_AUDIT.md`, covering the
**`CapPathLimit`** encoder.

`CapPathLimit::len()` cast `(values.len() * 5)` to `u8`, so 52+ Path-Limit
entries (260+ octets) wrapped the length octet to a bogus value that disagreed
with the bytes `emit_value()` wrote. Each entry is a fixed 5 octets (AFI u16 +
SAFI u8 + Path Limit u16), so:

- `len()` and `emit_value()` now derive from a single `wire_count()` helper that
  clamps the emitted entry count to **50** (250 octets) — the most that fits the
  253-octet capability-value budget (the optional-parameter length octet is
  `len() + 2`, a single `u8`).
- Entries beyond the budget are dropped rather than wrapping the length octet;
  the `as u8` cast can no longer truncate.

Mirrors the `CapAddPath` (#1649), `CapRestart` (#1650), and `CapLlgr` (#1651)
fixes. With this, **all seven capability encoders** clamp to their wire budgets.

## Test plan

- `cargo test -p bgp-packet` — 385 pass, incl. 3 new tests (normal round-trip,
  empty, too-many-entries → clamped to 50).
- `cargo clippy -p bgp-packet --all-targets -- -D warnings` — clean.
- `cargo fmt --check` — clean.

## Audit status

All seven per-capability encoder casts (`CapFqdn`, `CapVersion`, `CapUnknown`,
`CapAddPath`, `CapRestart`, `CapLlgr`, `CapPathLimit`) are now fixed. The only
residual item left in SECURITY_AUDIT.md is bounding the shared
`CapEmit::emit()` `len() + 2` optional-parameter framing (`emit.rs:23`).

Generated with [Claude Code](https://claude.com/claude-code)