### PR TITLE
bgp-packet: saturate CapEmit::emit() optional-parameter length

### DIFF
--- a/crates/bgp-packet/SECURITY_AUDIT.md
+++ b/crates/bgp-packet/SECURITY_AUDIT.md
@@ -12,11 +12,12 @@ This revision re-verifies the four findings from the previous audit against the
 current source. All four are now fully fixed and covered by regression tests:
 both High-severity panic paths, the Medium-severity trailing-garbage class, and
 the Medium-severity substructure-length cases (MP_REACH `nhop_len`, EVPN
-per-route `length`, and EVPN multicast `addr_len`). The only remaining items
-were the residual encoder-side `u8` truncation issues; all seven capability
-encoders (`CapFqdn`, `CapVersion`, `CapUnknown`, `CapAddPath`, `CapRestart`,
-`CapLlgr`, `CapPathLimit`) now clamp to their wire budgets, leaving only the
-shared `CapEmit::emit()` `len() + 2` optional-parameter framing.
+per-route `length`, and EVPN multicast `addr_len`). The residual encoder-side
+`u8` truncation issues are now resolved as well: all seven capability encoders
+(`CapFqdn`, `CapVersion`, `CapUnknown`, `CapAddPath`, `CapRestart`, `CapLlgr`,
+`CapPathLimit`) clamp to their wire budgets, and the shared `CapEmit::emit()`
+`len() + 2` optional-parameter framing now `saturating_add`s. Every item in this
+audit is fixed.
 
 Status of the four previously reported issues:
 
@@ -32,10 +33,10 @@ Status of the four previously reported issues:
 
 The residual encoder-side `u8` truncation issues for oversized capabilities are
 local packet-construction problems rather than network-triggered parser bugs.
-all seven capability encoders (`CapFqdn`, `CapVersion`, `CapUnknown`,
-`CapAddPath`, `CapRestart`, `CapLlgr`, `CapPathLimit`) are now fixed (clamped
-wire lengths derived from a single helper each); only the shared `emit()`
-`len() + 2` framing remains.
+All seven capability encoders (`CapFqdn`, `CapVersion`, `CapUnknown`,
+`CapAddPath`, `CapRestart`, `CapLlgr`, `CapPathLimit`) clamp their wire lengths
+via a single helper each, and the shared `CapEmit::emit()` `len() + 2` framing
+`saturating_add`s — all fixed.
 
 Earlier hardening that remains in place (carried over from the prior revision):
 the OPEN optional-parameter, capability, and IPv4 NLRI block parsers use
@@ -158,7 +159,7 @@ rather than being read as a 16-octet IPv6 address.
 Regression tests: `inclusive_multicast_rejects_bad_addr_len` and
 `parse_nlri_rejects_trailing_body_bytes` (`nlri_evpn.rs`).
 
-## Residual Hardening Issues — all capability encoder casts fixed; only the shared emit() framing remains
+## Residual Hardening Issues — all fixed
 
 These are lower severity because they affect local packet construction rather
 than parsing untrusted network data.
@@ -213,19 +214,18 @@ that clamps the emitted entry count to 50 (250 octets). The `as u8` cast can no
 longer wrap. Regression tests cover the normal, empty, and too-many-entries
 cases.
 
-**Still present — the shared optional-parameter framing.** `CapEmit::emit()`
-(`caps/emit.rs:23`) writes the optional-parameter length as
-`put_u8(self.len() + 2)`, which overflows a `u8` if any capability's `len()`
-reaches 254–255. All seven per-capability encoders now bound their values at
-253/252 so they never trigger this in practice, but the shared `emit()` itself
-is still unguarded — it should clamp/saturate or `u8::try_from(...)` the
-`len() + 2` (or move to RFC 9072 extended optional parameters) so a future
-capability can't reintroduce the overflow.
+**Fixed — the shared optional-parameter framing.** `CapEmit::emit()`
+(`caps/emit.rs`) wrote the optional-parameter length as `put_u8(self.len() + 2)`,
+which overflowed a `u8` if any capability's `len()` reached 254–255. It now uses
+`self.len().saturating_add(2)`, so the length octet can never overflow
+regardless of a capability's `len()`. All seven per-capability encoders already
+bound their values at 253/252, so the add is exact in practice; the saturating
+guard is a final backstop against a future capability that forgets to clamp.
+Regression tests in `caps/emit.rs` cover the max-value boundary (`len() = 253` →
+parameter length 255), the oversized saturating case, and the grouped
+(`opt = true`) path that skips the parameter framing.
 
-Recommended follow-up:
-
-1. bound or saturate the shared `emit()` optional-parameter length (`len() + 2`)
-   so it cannot overflow regardless of a capability's `len()`.
+With this, every residual encoder-side hardening item is resolved.
 
 ## Recommended Priority
 
@@ -242,13 +242,14 @@ Recommended follow-up:
 4. ~~Enforce the EVPN per-route `length` and multicast `addr_len` (the remaining
    half of Finding 4).~~ Fixed. MP_REACH `nhop_len` was already done.
 
-### Priority 3 — partially open
+### Priority 3 — DONE
 
 5. ~~Convert the encoder-side `u8` length arithmetic for each capability to
-   clamped/checked arithmetic.~~ Done — all seven (`CapFqdn`, `CapVersion`,
-   `CapUnknown`, `CapAddPath`, `CapRestart`, `CapLlgr`, `CapPathLimit`) now
-   clamp to their wire budgets. The only remaining item is to bound or saturate
-   the shared `CapEmit::emit()` optional-parameter length (`emit.rs:23`).
+   clamped/checked arithmetic, and bound the shared `CapEmit::emit()`
+   optional-parameter length.~~ Done — all seven capability encoders (`CapFqdn`,
+   `CapVersion`, `CapUnknown`, `CapAddPath`, `CapRestart`, `CapLlgr`,
+   `CapPathLimit`) clamp to their wire budgets, and `CapEmit::emit()` now
+   `saturating_add`s the `len() + 2` parameter length.
 
 ## Verification
 

--- a/crates/bgp-packet/src/caps/emit.rs
+++ b/crates/bgp-packet/src/caps/emit.rs
@@ -20,10 +20,75 @@ pub trait CapEmit {
     fn emit(&self, buf: &mut BytesMut, opt: bool) {
         if !opt {
             buf.put_u8(CAPABILITY_CODE);
-            buf.put_u8(self.len() + 2);
+            // Optional-parameter length = code(1) + length(1) + value, so a
+            // single classic optional parameter can only carry a value up to
+            // 253 octets. Every `CapEmit` impl clamps its own `len()` to that
+            // budget, so this add is exact in practice; `saturating_add` is a
+            // final guard so a future capability whose `len()` reached 254–255
+            // (unencodable here) can never overflow the u8 length octet.
+            buf.put_u8(self.len().saturating_add(2));
         }
         buf.put_u8(self.code().into());
         buf.put_u8(self.len());
         self.emit_value(buf);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Minimal `CapEmit` whose value length is whatever we pass in, so we can
+    /// exercise the shared framing at the budget boundary.
+    struct DummyCap(u8);
+
+    impl CapEmit for DummyCap {
+        fn code(&self) -> CapCode {
+            CapCode::Unknown(99)
+        }
+        fn len(&self) -> u8 {
+            self.0
+        }
+        fn emit_value(&self, buf: &mut BytesMut) {
+            buf.put_bytes(0, self.0 as usize);
+        }
+    }
+
+    #[test]
+    fn emit_max_value_param_length_is_exact() {
+        // len() = 253 is the largest value a single classic optional parameter
+        // can carry: the parameter length is 255, exactly filling the u8.
+        let cap = DummyCap(253);
+        let mut buf = BytesMut::new();
+        cap.emit(&mut buf, false);
+        let code: u8 = cap.code().into();
+        assert_eq!(buf[0], CAPABILITY_CODE, "optional parameter type");
+        assert_eq!(buf[1], 255, "optional-parameter length = len() + 2");
+        assert_eq!(buf[2], code, "capability code");
+        assert_eq!(buf[3], 253, "capability length");
+        assert_eq!(buf.len(), 2 + 2 + 253);
+    }
+
+    #[test]
+    fn emit_oversized_value_saturates_without_panic() {
+        // No capability produces len() > 253 (each clamps its own value), but
+        // emit() must not overflow the u8 length octet if one ever did.
+        let cap = DummyCap(255);
+        let mut buf = BytesMut::new();
+        cap.emit(&mut buf, false); // must not panic
+        assert_eq!(buf[1], 255, "parameter length saturates at u8::MAX");
+    }
+
+    #[test]
+    fn emit_grouped_skips_param_framing() {
+        // opt = true: the caller writes the optional-parameter framing, so
+        // emit() writes only code + length + value.
+        let cap = DummyCap(4);
+        let mut buf = BytesMut::new();
+        cap.emit(&mut buf, true);
+        let code: u8 = cap.code().into();
+        assert_eq!(buf[0], code, "capability code (no parameter framing)");
+        assert_eq!(buf[1], 4, "capability length");
+        assert_eq!(buf.len(), 2 + 4);
     }
 }


### PR DESCRIPTION
## Summary

Final residual item in `crates/bgp-packet/SECURITY_AUDIT.md` — the shared
capability-emit framing.

`CapEmit::emit()` wrote the BGP optional-parameter length as
`put_u8(self.len() + 2)`, which overflows a `u8` (panic in debug, wrap in
release) if a capability's `len()` reaches 254–255. A single classic optional
parameter can only carry a 253-octet value (`code + length + value <= 255`), and
all seven capability encoders now clamp their `len()` to that budget — so the
add is exact in practice. This replaces it with `self.len().saturating_add(2)`
as a final backstop so a future capability that forgets to clamp can never
overflow the length octet.

## Test plan

- `cargo test -p bgp-packet` — 388 pass, incl. 3 new tests via a minimal
  `CapEmit` impl: max-value boundary (`len() = 253` → parameter length 255), the
  oversized saturating case (no panic), and the grouped (`opt = true`) path that
  skips the parameter framing.
- `cargo clippy -p bgp-packet --all-targets -- -D warnings` — clean.
- `cargo fmt --check` — clean.

## Audit status

**Every finding and residual item in SECURITY_AUDIT.md is now resolved.** The
four original findings (2 High panic paths, 2 Medium substructure/trailing-byte
classes) plus all seven per-capability encoder casts and this shared `emit()`
framing are fixed and regression-tested.

Generated with [Claude Code](https://claude.com/claude-code)