### PR TITLE
rib: render JSON for show nexthop/vrf/hostname/l2 neighbor

### DIFF
--- a/docs/design/show-commands-json-output.md
+++ b/docs/design/show-commands-json-output.md
@@ -1,0 +1,268 @@
+# `show` Commands — Catalog and JSON Output Support
+
+This document catalogs every `show` CLI command in zebra-rs and records
+whether its handler renders structured **JSON** output in addition to the
+default human-readable text.
+
+> Goal: all `show` commands should support JSON output. This catalog is the
+> tracking sheet — it lists every command and flags the ones whose handler
+> still renders text only, so the remaining gap is explicit.
+
+Source of truth: the `show` grammar in `zebra-rs/yang/exec.yang` and the
+`ShowCallback` registrations across `zebra-rs/src/**/show*.rs`.
+
+## How JSON output is requested
+
+There are two independent mechanisms:
+
+1. **The `-j` / `--json` flag (universal).** `zctl show -j '<command>'`
+   (or `--json`) sets `ShowRequest.json = true`. The flag is plumbed
+   through `DisplayRequest` to **every** `ShowCallback`, whose signature
+   is `fn(&Proto, Args, json: bool) -> String`. The flag is therefore
+   accepted on *any* show command; whether a distinct JSON document comes
+   back depends on the handler:
+   - Handlers that **honor** it branch on `json` and emit
+     `serde_json::to_string_pretty(...)`.
+   - Handlers that **ignore** it take the parameter as `_json` and always
+     render text (the flag is silently a no-op).
+
+   ```
+   zctl show -j 'show ip route'        # JSON RIB
+   zctl show 'show ip route'           # text RIB
+   ```
+
+   Plumbing: `vtyctl/src/main.rs` (`-j`) → `vtyctl/src/show.rs`
+   (`ShowRequest.json`) → `zebra-rs/src/config/serve.rs:461`
+   (`json: request.json`) → each module's `ShowCallback`.
+
+2. **Config-tree sub-keyword (`running-config` / `candidate-config`).**
+   These are dispatched by `install_func` in
+   `zebra-rs/src/config/commands.rs`, not by the `ShowCallback` builder,
+   and carry their **own** output-format keyword rather than reading `-j`:
+
+   ```
+   show running-config            # native flat config
+   show running-config formal     # set-style flat statements
+   show running-config json       # pretty-printed JSON
+   show running-config yaml       # YAML
+   ```
+
+   (`show candidate-config` mirrors this for the uncommitted edit buffer.)
+
+A separate session knob, `cli format json` (`/cli/format/json`), sets the
+default output format for an interactive vty session.
+
+## Per-VRF forms
+
+`show <proto> vrf <name> …` for OSPFv2 / OSPFv3 / IS-IS / BGP is **not** a
+separate handler set. The config manager strips the `vrf <name>` selector
+(`vrf_redirect_split`) and replays the remaining command against the
+per-VRF task's show channel, so each per-VRF form's JSON support **mirrors
+its non-VRF sibling** in the tables below.
+
+---
+
+## RIB / interface / forwarding (`zebra-rs/src/rib/show.rs`)
+
+| Command | Description | JSON |
+|---|---|---|
+| `show version` | Daemon version (config-tree handler) | text only |
+| `show router-id` | Effective global router ID | ✅ |
+| `show hostname` | System hostname | ✅ |
+| `show vrf` | VRF table | ✅ |
+| `show task` | Spawned protocol tasks and their VRF (manager handler) | text only |
+| `show interface [<name>] [detail]` | Interface state | ✅ |
+| `show ip route` | IPv4 routing table | ✅ |
+| `show ip route detail` | IPv4 RIB, IOS-XR detail blocks | ✅ |
+| `show ip route prefix <A.B.C.D/M> [detail]` | One IPv4 prefix | ✅ |
+| `show ip route vrf [<name>] [detail]` | IPv4 RIB per VRF | ✅ |
+| `show ipv6 route` | IPv6 routing table | ✅ |
+| `show ipv6 route detail` | IPv6 RIB, IOS-XR detail blocks | ✅ |
+| `show ipv6 route prefix <X::Y/M> [detail]` | One IPv6 prefix | ✅ |
+| `show ipv6 route vrf [<name>] [detail]` | IPv6 RIB per VRF | ✅ |
+| `show nexthop` | Nexthop groups | ✅ |
+| `show mpls ilm` | MPLS incoming-label map | ✅ |
+| `show l2 mac table` | Bridge MAC table | ✅ |
+| `show l2 neighbor` | Bridge FDB entries | ✅ |
+| `show segment-routing srv6 sid` | Allocated SRv6 SIDs | ✅ |
+| `show evpn vni all` | EVPN VNI information | text only |
+| `show running-config [formal\|json\|yaml]` | Committed config | ✅ (sub-keyword) |
+| `show candidate-config [formal\|json\|yaml]` | Uncommitted config | ✅ (sub-keyword) |
+
+## BGP (`zebra-rs/src/bgp/show.rs`)
+
+| Command | Description | JSON |
+|---|---|---|
+| `show bgp [<addr>\|<prefix>]` | IPv4 unicast RIB (default family) | ✅ |
+| `show bgp summary` | Neighbor status per AFI/SAFI | ✅ |
+| `show bgp ipv4 [<addr>\|<prefix>\|summary]` | IPv4 unicast RIB | ✅ |
+| `show bgp ipv4 <prefix> longer-prefix` | IPv4 equal-or-more-specific | text only |
+| `show bgp ipv6 [<addr>\|<prefix>\|summary]` | IPv6 unicast RIB | ✅ |
+| `show bgp ipv6 <prefix> longer-prefix` | IPv6 equal-or-more-specific | text only |
+| `show bgp vpnv4 [<addr>\|<prefix>\|summary]` | VPNv4 RIB (all RDs) | ✅ |
+| `show bgp vpnv6 [<addr>\|<prefix>\|summary]` | VPNv6 RIB (all RDs) | ✅ |
+| `show bgp evpn [route-type <type>]` | EVPN RIB | ✅ ◐ |
+| `show bgp evpn summary` | EVPN-enabled neighbors | ✅ |
+| `show bgp evpn ethernet-segment` | Local Ethernet Segments (RFC 7432) | text only |
+| `show bgp labeled-unicast` | Labeled-Unicast (SAFI 4) RIB | ✅ ◐ |
+| `show bgp flowspec [ipv6]` | Flowspec RIB (SAFI 133) | ✅ ◐ |
+| `show bgp sr-policy [ipv6]` | SR Policy RIB (SAFI 73) | ✅ ◐ |
+| `show bgp link-state` | Link-State RIB (SAFI 71) | ✅ ◐ |
+| `show bgp attributes` | Attribute-store statistics | text only |
+| `show bgp neighbor [<addr>\|<name>]` | Neighbor information | ✅ |
+| `show bgp neighbor <addr> advertised-routes [ipv6\|vpnv4\|evpn]` | Adj-RIB-Out | ✅ (evpn ◐) |
+| `show bgp neighbor <addr> received-routes [ipv6\|vpnv4\|evpn]` | Adj-RIB-In | ✅ (evpn ◐) |
+| `show bgp neighbor <addr> rtcv4` | IPv4 Route Target Constraints | text only |
+| `show bgp neighbor-group [<name>]` | Neighbor-group inheritance state | ✅ |
+| `show bgp update-group [<id>]` | Update-groups (IOS-XR style) | ✅ |
+| `show bgp mup [summary]` | Mobile User Plane RIB (SAFI 85) | ✅ ◐ |
+| `show bgp mup mup-c [session\|association]` | MUP Controller status | ✅ ◐ |
+| `show bgp vrf [<name>] [summary\|neighbor\|ipv4\|ipv6\|mup]` | Per-VRF BGP (redirected) | ✅ |
+
+◐ = honors `-j` but currently emits an empty array/object placeholder
+pending a finalized JSON schema.
+
+## OSPFv2 (`zebra-rs/src/ospf/show.rs`)
+
+| Command | Description | JSON |
+|---|---|---|
+| `show ospf` | Instance summary | text only |
+| `show ospf interface` | Interface status | ✅ |
+| `show ospf neighbor [detail]` | Neighbors | ✅ |
+| `show ospf database [detail]` | LSDB | ✅ |
+| `show ospf route` | OSPF routing table | text only |
+| `show ospf spf` | SPF tree | text only |
+| `show ospf graph` | Topology graph | ✅ |
+| `show ospf ti-lfa` | TI-LFA per-destination repair paths | ✅ |
+| `show ospf repair-list [detail]` | TI-LFA repair-list | ✅ |
+| `show ospf flex-algo` | Flexible Algorithm (RFC 9350) state | text only |
+| `show ospf segment-routing` | SR database | text only |
+| `show ospf graceful-restart` | GR helper status | text only |
+| `show ospf checkpoint` | GR on-disk checkpoint | text only |
+| `show ospf vrf <name> …` | Per-VRF (redirected; mirrors above) | per sibling |
+
+## OSPFv3 (`zebra-rs/src/ospf/show_v3.rs`)
+
+| Command | Description | JSON |
+|---|---|---|
+| `show ospfv3` | Instance summary | ✅ |
+| `show ospfv3 interface` | Interface status | ✅ |
+| `show ospfv3 neighbor [detail]` | Neighbors | ✅ |
+| `show ospfv3 database [detail]` | LSDB | ✅ |
+| `show ospfv3 route` | OSPFv3 routing table | ✅ |
+| `show ospfv3 spf` | SPF tree | ✅ |
+| `show ospfv3 graph` | Topology graph | ✅ |
+| `show ospfv3 ti-lfa` | TI-LFA per-destination repair paths | ✅ |
+| `show ospfv3 repair-list [detail]` | TI-LFA repair-list | ✅ |
+| `show ospfv3 segment-routing` | SR state | ✅ |
+| `show ospfv3 srv6` | SRv6 state (locator, End/End.X SIDs) | ✅ |
+| `show ospfv3 flex-algo` | Flexible Algorithm (RFC 9350) state | text only |
+| `show ospfv3 vrf <name> …` | Per-VRF (redirected; mirrors above) | per sibling |
+
+## IS-IS (`zebra-rs/src/isis/show.rs`)
+
+| Command | Description | JSON |
+|---|---|---|
+| `show isis` | Basic IS-IS information | text only |
+| `show isis summary` | Summary | text only |
+| `show isis route [detail]` | Route table (TI-LFA/SR-MPLS/SRv6) | ✅ |
+| `show isis topology` | SPF tree (per-AFI) | ✅ |
+| `show isis database [detail]` | LSDB | ✅ |
+| `show isis neighbor [detail]` | Neighbors | ✅ |
+| `show isis interface [detail]` | Interfaces | ✅ |
+| `show isis dis statistics` | DIS election statistics | ✅ |
+| `show isis dis history` | DIS election history | ✅ |
+| `show isis hostname` | Dynamic hostnames | ✅ |
+| `show isis spf [detail]` | SPF computation results | ✅ |
+| `show isis graph` | Topology graph | ✅ |
+| `show isis graceful-restart` | GR per-adjacency state (RFC 5306) | ✅ |
+| `show isis checkpoint` | GR on-disk checkpoint | ✅ |
+| `show isis ti-lfa` | TI-LFA repair paths (graph view) | ✅ |
+| `show isis repair-list [detail]` | TI-LFA repair-list | ✅ |
+| `show isis egress-protection` | Mirror SID egress-protection entries | text only |
+| `show isis fast-reroute summary` | Per-level TI-LFA counters | text only |
+| `show isis fast-reroute prefix <A.B.C.D/M> detail` | Per-prefix TI-LFA repair | text only |
+| `show isis flex-algo` | Flexible Algorithm (RFC 9350) state | text only |
+| `show isis flex-algo route [algorithm <id>]` | Per-algorithm IPv4 routes | text only |
+| `show isis vrf <name> …` | Per-VRF (redirected; mirrors above) | per sibling |
+
+## IPv6 ND (`zebra-rs/src/nd/show.rs`)
+
+| Command | Description | JSON |
+|---|---|---|
+| `show ipv6 nd` | ND per-interface summary | ✅ |
+| `show ipv6 nd interface [<ifname>]` | ND detail per interface | ✅ |
+
+## BFD (`zebra-rs/src/bfd/show.rs`)
+
+| Command | Description | JSON |
+|---|---|---|
+| `show bfd` | Session summary | ✅ |
+| `show bfd peers [<addr>]` | Per-peer detail (FRR-style) | ✅ |
+| `show bfd counters` | Per-session control-packet counters | ✅ |
+
+## STAMP (`zebra-rs/src/stamp/show.rs`)
+
+| Command | Description | JSON |
+|---|---|---|
+| `show stamp` | Session summary | ✅ |
+| `show stamp session` | Per-session detail | ✅ |
+| `show stamp statistics` | Sender/reflector packet counters | ✅ |
+
+## Policy / route-policy objects (`zebra-rs/src/policy/show.rs`)
+
+| Command | Description | JSON |
+|---|---|---|
+| `show policy` | Route policies | text only |
+| `show prefix-set [name <name>]` | Prefix sets | text only |
+| `show community-set [name <name>]` | Community sets | text only |
+| `show ext-community-set [name <name>]` | Extended-community sets | text only |
+| `show large-community-set [name <name>]` | Large-community sets | text only |
+| `show as-path-set [name <name>]` | AS-path sets | text only |
+| `show key-chains [name <name>]` | Key chains | text only |
+
+---
+
+## Coverage summary
+
+| Module | Commands | JSON (incl. ◐ placeholder) | Text only |
+|---|---:|---:|---:|
+| RIB / forwarding / config | 22 | 19 | 3 |
+| BGP | 25 | 20 | 5 |
+| OSPFv2 | 13 | 6 | 7 |
+| OSPFv3 | 12 | 11 | 1 |
+| IS-IS | 21 | 14 | 7 |
+| IPv6 ND | 2 | 2 | 0 |
+| BFD | 3 | 3 | 0 |
+| STAMP | 3 | 3 | 0 |
+| Policy objects | 7 | 0 | 7 |
+
+(Counts exclude the `vrf <name>` redirect forms, which inherit their
+sibling's status. Some BGP "JSON" entries are ◐ placeholders that honor
+the flag but still emit an empty array/object.)
+
+### Remaining gaps (still text only)
+
+These are the commands to convert to reach "all `show` commands support
+JSON":
+
+- **RIB:** `show task`, `show version` (both use the config-tree /
+  manager dispatch that does not carry the `-j` flag — needs plumbing),
+  and `show evpn vni all` (lives in the BGP/EVPN module)
+- **BGP:** `show bgp <afi> <prefix> longer-prefix`,
+  `show bgp evpn ethernet-segment`, `show bgp attributes`,
+  `show bgp neighbor <addr> rtcv4`
+- **OSPFv2:** `show ospf` (summary), `route`, `spf`, `flex-algo`,
+  `segment-routing`, `graceful-restart`, `checkpoint`
+- **OSPFv3:** `show ospfv3 flex-algo`
+- **IS-IS:** `show isis` (root), `summary`, `egress-protection`,
+  `fast-reroute …`, `flex-algo [route …]`
+- **Policy objects:** every `show … -set` / `show policy` /
+  `show key-chains` command
+
+### Placeholder JSON (BGP ◐ — honors `-j`, emits empty array/object)
+
+`show bgp evpn`, `labeled-unicast`, `flowspec [ipv6]`,
+`sr-policy [ipv6]`, `link-state`, `mup [mup-c …]`, and the
+`advertised-routes evpn` / `received-routes evpn` neighbor views. The
+flag is wired but the per-AFI serialization schema is not yet filled in.

--- a/zebra-rs/src/rib/nexthop/show.rs
+++ b/zebra-rs/src/rib/nexthop/show.rs
@@ -1,9 +1,148 @@
 use std::fmt::Write;
 
+use serde::Serialize;
+
 use crate::rib::nexthop::group::{GroupTrait, GroupUni};
 use crate::{config::Args, rib::Rib};
 
 use super::Group;
+
+#[derive(Serialize)]
+pub struct NexthopGroupJson {
+    pub id: usize,
+    pub refcnt: usize,
+    pub valid: bool,
+    pub installed: bool,
+    /// Group flavour: `uni`, `multi`, or `protect`.
+    #[serde(rename = "type")]
+    pub kind: String,
+    // --- Uni groups only ---
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub via: Option<String>,
+    /// SRv6 segment list (mutually exclusive with `via`).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub seg6: Option<Vec<String>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub interface: Option<String>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub labels: Vec<u32>,
+    // --- Multi / Protect groups ---
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub members: Vec<NexthopGroupMemberJson>,
+}
+
+#[derive(Serialize)]
+pub struct NexthopGroupMemberJson {
+    pub id: usize,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub via: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub seg6: Option<Vec<String>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub interface: Option<String>,
+    /// Relative weight of a `multi` (ECMP) member.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub weight: Option<u8>,
+    /// `primary` or `backup` for a `protect` member.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub role: Option<String>,
+    /// True for the `protect` member the kernel group currently holds.
+    #[serde(skip_serializing_if = "std::ops::Not::not")]
+    pub active: bool,
+}
+
+/// Split a `GroupUni` into its JSON `(via, seg6)` pair, mirroring
+/// `write_via`: an SRv6 nexthop surfaces as a `seg6` segment list, a
+/// plain nexthop as a bare `via` address.
+fn group_uni_via_json(uni: &GroupUni) -> (Option<String>, Option<Vec<String>>) {
+    if uni.segs.is_empty() {
+        (Some(uni.addr.to_string()), None)
+    } else {
+        (None, Some(uni.segs.iter().map(|s| s.to_string()).collect()))
+    }
+}
+
+fn nexthop_show_json(rib: &Rib) -> String {
+    let mut groups = Vec::new();
+    for grp in rib.nmap.groups.iter().flatten() {
+        let mut entry = NexthopGroupJson {
+            id: grp.gid(),
+            refcnt: grp.refcnt(),
+            valid: grp.is_valid(),
+            installed: grp.is_installed(),
+            kind: String::new(),
+            via: None,
+            seg6: None,
+            interface: None,
+            labels: Vec::new(),
+            members: Vec::new(),
+        };
+        match grp {
+            Group::Uni(uni) => {
+                let (via, seg6) = group_uni_via_json(uni);
+                entry.kind = "uni".to_string();
+                entry.via = via;
+                entry.seg6 = seg6;
+                entry.interface = Some(rib.link_name(uni.ifindex().unwrap_or(0)));
+                entry.labels = uni.labels.clone();
+            }
+            Group::Multi(multi) => {
+                entry.kind = "multi".to_string();
+                entry.members = multi
+                    .set
+                    .iter()
+                    .filter_map(|(gid, weight)| {
+                        let Some(Group::Uni(uni)) = rib.nmap.get(*gid) else {
+                            return None;
+                        };
+                        let (via, seg6) = group_uni_via_json(uni);
+                        Some(NexthopGroupMemberJson {
+                            id: *gid,
+                            via,
+                            seg6,
+                            interface: Some(rib.link_name(uni.ifindex().unwrap_or(0))),
+                            weight: Some(*weight),
+                            role: None,
+                            active: false,
+                        })
+                    })
+                    .collect();
+            }
+            Group::Protect(pro) => {
+                let active = pro.active_gid();
+                entry.kind = "protect".to_string();
+                entry.members = [("primary", pro.primary_gid), ("backup", pro.backup_gid)]
+                    .into_iter()
+                    .map(|(role, gid)| {
+                        let (via, seg6, interface) = match rib.nmap.get(gid) {
+                            Some(Group::Uni(uni)) => {
+                                let (via, seg6) = group_uni_via_json(uni);
+                                (via, seg6, Some(rib.link_name(uni.ifindex().unwrap_or(0))))
+                            }
+                            _ => (None, None, None),
+                        };
+                        NexthopGroupMemberJson {
+                            id: gid,
+                            via,
+                            seg6,
+                            interface,
+                            weight: None,
+                            role: Some(role.to_string()),
+                            active: gid == active,
+                        }
+                    })
+                    .collect();
+            }
+        }
+        groups.push(entry);
+    }
+    serde_json::to_string_pretty(&groups).unwrap_or_else(|e| {
+        format!(
+            "{{\"error\": \"Failed to serialize nexthop groups: {}\"}}",
+            e
+        )
+    })
+}
 
 fn write_group_detail(buf: &mut String, grp: &Group) {
     writeln!(
@@ -29,7 +168,10 @@ fn write_via(buf: &mut String, uni: &GroupUni) {
     }
 }
 
-pub fn nexthop_show(rib: &Rib, _args: Args, _json: bool) -> String {
+pub fn nexthop_show(rib: &Rib, _args: Args, json: bool) -> String {
+    if json {
+        return nexthop_show_json(rib);
+    }
     let mut buf = String::new();
 
     for grp in rib.nmap.groups.iter().flatten() {
@@ -132,5 +274,38 @@ mod tests {
         let mut buf = String::new();
         write_via(&mut buf, &g);
         assert_eq!(buf, "via seg6 [fcbb:bbbb:2:3:2::, fcbb:bbbb:2:3:3::]");
+    }
+
+    #[test]
+    fn via_json_plain_is_via_not_seg6() {
+        let uni = NexthopUni {
+            addr: IpAddr::V4("10.0.0.1".parse().unwrap()),
+            ..Default::default()
+        };
+        let (via, seg6) = group_uni_via_json(&mk_group(uni));
+        assert_eq!(via.as_deref(), Some("10.0.0.1"));
+        assert!(seg6.is_none());
+    }
+
+    #[test]
+    fn via_json_srv6_is_seg6_not_via() {
+        let uni = NexthopUni {
+            addr: IpAddr::V6("fcbb:bbbb:2:3:2::".parse().unwrap()),
+            segs: vec![
+                "fcbb:bbbb:2:3:2::".parse().unwrap(),
+                "fcbb:bbbb:2:3:3::".parse().unwrap(),
+            ],
+            encap_type: Some(EncapType::HEncap),
+            ..Default::default()
+        };
+        let (via, seg6) = group_uni_via_json(&mk_group(uni));
+        assert!(via.is_none());
+        assert_eq!(
+            seg6,
+            Some(vec![
+                "fcbb:bbbb:2:3:2::".to_string(),
+                "fcbb:bbbb:2:3:3::".to_string(),
+            ])
+        );
     }
 }

--- a/zebra-rs/src/rib/show.rs
+++ b/zebra-rs/src/rib/show.rs
@@ -1823,16 +1823,55 @@ pub fn router_id_show(rib: &Rib, _args: Args, json: bool) -> String {
     format!("Router ID: {} ({})\n", rib.router_id, source)
 }
 
-pub fn hostname_show(_rib: &Rib, _args: Args, _json: bool) -> String {
-    hostname::get()
+pub fn hostname_show(_rib: &Rib, _args: Args, json: bool) -> String {
+    let name = hostname::get()
         .ok()
         .and_then(|s| s.into_string().ok())
-        .filter(|s| !s.is_empty())
-        .map(|s| format!("{s}\n"))
+        .filter(|s| !s.is_empty());
+    if json {
+        // `name` is `Option<String>`: a resolved hostname or JSON `null`.
+        return serde_json::to_string_pretty(&serde_json::json!({ "hostname": name }))
+            .unwrap_or_else(|e| format!("{{\"error\": \"Failed to serialize hostname: {}\"}}", e));
+    }
+    name.map(|s| format!("{s}\n"))
         .unwrap_or_else(|| "unknown\n".to_string())
 }
 
-pub fn vrf_show(rib: &Rib, _args: Args, _json: bool) -> String {
+#[derive(Serialize)]
+pub struct VrfJson {
+    pub name: String,
+    pub table_id: u32,
+    /// `None` (JSON `null`) when this VRF has no Router ID selected yet.
+    pub router_id: Option<String>,
+    pub members: Vec<String>,
+}
+
+#[derive(Serialize)]
+pub struct VrfTable {
+    pub vrfs: Vec<VrfJson>,
+}
+
+pub fn vrf_show(rib: &Rib, _args: Args, json: bool) -> String {
+    if json {
+        let mut vrfs = Vec::new();
+        for vrf in rib.vrfs.values() {
+            let members: Vec<String> = rib
+                .links
+                .values()
+                .filter(|l| l.master == Some(vrf.ifindex))
+                .map(|l| l.name.clone())
+                .collect();
+            vrfs.push(VrfJson {
+                name: vrf.name.clone(),
+                table_id: vrf.table_id,
+                router_id: (!vrf.router_id.is_unspecified()).then(|| vrf.router_id.to_string()),
+                members,
+            });
+        }
+        let vrf_table = VrfTable { vrfs };
+        return serde_json::to_string_pretty(&vrf_table)
+            .unwrap_or_else(|e| format!("{{\"error\": \"Failed to serialize VRFs: {}\"}}", e));
+    }
     let mut buf = String::new();
     writeln!(
         buf,
@@ -1872,8 +1911,51 @@ pub fn vrf_show(rib: &Rib, _args: Args, _json: bool) -> String {
 /// attributes (VLAN, VNI, remote VTEP IP) the kernel supplied. ARP/NDP
 /// (AF_INET / AF_INET6) lives in the same map but isn't shown here —
 /// `show ip arp` / `show ipv6 neighbor` will surface those separately.
-pub fn l2_neighbor_show(rib: &Rib, _args: Args, _json: bool) -> String {
+#[derive(Serialize)]
+pub struct L2NeighborJson {
+    pub mac: String,
+    pub interface: String,
+    pub vlan: Option<u16>,
+    pub vni: Option<u32>,
+    pub dst: Option<String>,
+    pub state: String,
+    /// `NTF_*` flags as a raw bitmask (mirrors the `0x..` text column).
+    pub flags: u8,
+}
+
+#[derive(Serialize)]
+pub struct L2NeighborTable {
+    pub entries: Vec<L2NeighborJson>,
+}
+
+pub fn l2_neighbor_show(rib: &Rib, _args: Args, json: bool) -> String {
     use super::inst::NeighborKey;
+    if json {
+        let mut entries = Vec::new();
+        for (key, nbr) in rib.neighbors.iter() {
+            let NeighborKey::Bridge { ifindex, mac, vlan } = key else {
+                continue;
+            };
+            let interface = rib
+                .links
+                .get(ifindex)
+                .map(|l| l.name.clone())
+                .unwrap_or_else(|| format!("if#{ifindex}"));
+            entries.push(L2NeighborJson {
+                mac: mac.to_string(),
+                interface,
+                vlan: *vlan,
+                vni: nbr.vni,
+                dst: nbr.dst.map(|d| d.to_string()),
+                state: format!("{:?}", nbr.state),
+                flags: nbr.flags.bits(),
+            });
+        }
+        let table = L2NeighborTable { entries };
+        return serde_json::to_string_pretty(&table).unwrap_or_else(|e| {
+            format!("{{\"error\": \"Failed to serialize L2 neighbors: {}\"}}", e)
+        });
+    }
     let mut buf = String::new();
     writeln!(
         buf,


### PR DESCRIPTION
## Summary

Adds JSON rendering to the four RIB/forwarding `show` commands that
accepted the `-j` / `--json` flag but always rendered text. Each handler
gains an `if json { … serde_json::to_string_pretty }` branch following
the existing `ilm_show` / `mac_show` pattern, so the text output is
byte-for-byte unchanged.

| Command | JSON shape |
|---|---|
| `show hostname` | `{ "hostname": <name>\|null }` |
| `show vrf` | `{ "vrfs": [ { name, table_id, router_id, members[] } ] }` |
| `show l2 neighbor` | `{ "entries": [ { mac, interface, vlan, vni, dst, state, flags } ] }` |
| `show nexthop` | `[ { id, refcnt, valid, installed, type, via\|seg6, interface, labels, members[] } ]` (Uni / Multi / Protect variants) |

A `group_uni_via_json` helper mirrors the text-side `write_via` (SRv6
`seg6` segment list vs. plain `via` address).

Also lands a design doc (`docs/design/show-commands-json-output.md`)
cataloging every `show` command and its JSON-output status; the RIB row
is now 19/22 JSON.

## Test plan

- `cargo fmt --check`: clean
- `cargo clippy --workspace --all-targets -- -D warnings`: clean
- `cargo test -p zebra-rs`: 1475 passed, 0 failed (incl. 2 new unit
  tests for `group_uni_via_json`)
- Live daemon smoke test on a throwaway vty socket: all four emit valid
  JSON; `show l2 neighbor -j` serialized real kernel bridge-FDB entries,
  empty cases returned `[]` / `{"vrfs":[]}` confirming `-j` reaches the
  handlers. Text paths unchanged.

Generated with [Claude Code](https://claude.com/claude-code)