### PR TITLE
policy: JSON for policy-object show suite (+ dispatch/grammar fix)

### DIFF
--- a/docs/design/show-commands-json-output.md
+++ b/docs/design/show-commands-json-output.md
@@ -213,13 +213,22 @@ pending a finalized JSON schema.
 
 | Command | Description | JSON |
 |---|---|---|
-| `show policy` | Route policies | text only |
-| `show prefix-set [name <name>]` | Prefix sets | text only |
-| `show community-set [name <name>]` | Community sets | text only |
-| `show ext-community-set [name <name>]` | Extended-community sets | text only |
-| `show large-community-set [name <name>]` | Large-community sets | text only |
-| `show as-path-set [name <name>]` | AS-path sets | text only |
-| `show key-chains [name <name>]` | Key chains | text only |
+| `show policy` | Route policies | ✅ |
+| `show prefix-set [name <name>]` | Prefix sets | ✅ |
+| `show community-set [name <name>]` | Community sets | ✅ |
+| `show ext-community-set [name <name>]` | Extended-community sets | ✅ |
+| `show large-community-set [name <name>]` | Large-community sets | ✅ |
+| `show as-path-set [name <name>]` | AS-path sets | ✅ |
+| `show key-chains [name <name>]` | Key chains | ✅ |
+
+> Wiring fix shipped alongside the JSON: `show as-path-set`,
+> `show ext-community-set`, `show large-community-set`, and
+> `show key-chains` were unreachable before — `is_policy()` in the show
+> dispatcher didn't list them (so they fell through to the `rib`
+> channel), and the latter three plus `community-set name <name>` had no
+> grammar node in `exec.yang`. The dispatcher now recognizes every
+> policy-object root, and `exec.yang` defines all of them as containers
+> with a `name` selector.
 
 ---
 
@@ -235,7 +244,7 @@ pending a finalized JSON schema.
 | IPv6 ND | 2 | 2 | 0 |
 | BFD | 3 | 3 | 0 |
 | STAMP | 3 | 3 | 0 |
-| Policy objects | 7 | 0 | 7 |
+| Policy objects | 7 | 7 | 0 |
 
 (Counts exclude the `vrf <name>` redirect forms, which inherit their
 sibling's status. Some BGP "JSON" entries are ◐ placeholders that honor
@@ -254,8 +263,6 @@ JSON":
   `show bgp neighbor <addr> rtcv4`
 - **IS-IS:** `show isis` (root), `summary`, `egress-protection`,
   `fast-reroute …`, `flex-algo [route …]`
-- **Policy objects:** every `show … -set` / `show policy` /
-  `show key-chains` command
 
 ### Placeholder JSON (BGP ◐ — honors `-j`, emits empty array/object)
 

--- a/zebra-rs/src/config/manager.rs
+++ b/zebra-rs/src/config/manager.rs
@@ -1217,9 +1217,23 @@ fn is_nd(paths: &[CommandPath]) -> bool {
 }
 
 fn is_policy(paths: &[CommandPath]) -> bool {
-    paths
-        .iter()
-        .any(|x| x.name == "prefix-set" || x.name == "community-set" || x.name == "policy")
+    // Every policy-object root the policy module registers a show
+    // handler for. Missing roots fall through to the `"rib"` fallback
+    // in `show_proto`, which has no handler for them — so the command
+    // silently returns empty (this dropped `as-path-set`, `key-chains`,
+    // and both extended/large community sets before being listed here).
+    paths.iter().any(|x| {
+        matches!(
+            x.name.as_str(),
+            "prefix-set"
+                | "community-set"
+                | "ext-community-set"
+                | "large-community-set"
+                | "as-path-set"
+                | "key-chains"
+                | "policy"
+        )
+    })
 }
 
 /// Map a show command to the protocol name used as its `show_clients`

--- a/zebra-rs/src/policy/aspath/show.rs
+++ b/zebra-rs/src/policy/aspath/show.rs
@@ -1,11 +1,35 @@
 use anyhow::{Context, Error};
+use serde::Serialize;
 use std::fmt::Write;
 
+use super::AsPathSet;
 use crate::{config::Args, policy::Policy};
 
-pub fn as_path_set(policy: &Policy, _args: Args, _json: bool) -> Result<String, Error> {
-    let mut buf = String::new();
+#[derive(Serialize)]
+struct AsPathSetJson {
+    name: String,
+    members: Vec<String>,
+}
 
+fn to_json(name: &str, set: &AsPathSet) -> AsPathSetJson {
+    AsPathSetJson {
+        name: name.to_string(),
+        members: set.vals.iter().map(|m| m.pattern().to_string()).collect(),
+    }
+}
+
+pub fn as_path_set(policy: &Policy, _args: Args, json: bool) -> Result<String, Error> {
+    if json {
+        let list: Vec<_> = policy
+            .as_path_config
+            .config
+            .iter()
+            .map(|(name, set)| to_json(name, set))
+            .collect();
+        return Ok(serde_json::to_string_pretty(&list)?);
+    }
+
+    let mut buf = String::new();
     for (name, set) in policy.as_path_config.config.iter() {
         writeln!(buf, "as-path-set: {} len: {}", name, set.vals.len())?;
         for matcher in &set.vals {
@@ -16,9 +40,7 @@ pub fn as_path_set(policy: &Policy, _args: Args, _json: bool) -> Result<String, 
     Ok(buf)
 }
 
-pub fn as_path_set_name(policy: &Policy, mut args: Args, _json: bool) -> Result<String, Error> {
-    let mut buf = String::new();
-
+pub fn as_path_set_name(policy: &Policy, mut args: Args, json: bool) -> Result<String, Error> {
     let name = args.string().context("missing as-path-set name")?;
     let set = policy
         .as_path_config
@@ -26,6 +48,11 @@ pub fn as_path_set_name(policy: &Policy, mut args: Args, _json: bool) -> Result<
         .get(&name)
         .context(format!("as-path-set '{}' not found", name))?;
 
+    if json {
+        return Ok(serde_json::to_string_pretty(&to_json(&name, set))?);
+    }
+
+    let mut buf = String::new();
     writeln!(buf, "as-path-set: {}", name)?;
     for matcher in &set.vals {
         writeln!(buf, "  {}", matcher.pattern())?;

--- a/zebra-rs/src/policy/community/show.rs
+++ b/zebra-rs/src/policy/community/show.rs
@@ -1,12 +1,35 @@
 use anyhow::{Context, Error};
+use serde::Serialize;
 use std::fmt::Write;
 
-use super::{CommunityMatcher, ExtendedMatcher, StandardMatcher};
+use super::{CommunityMatcher, CommunitySet, ExtendedMatcher, StandardMatcher};
 use crate::{config::Args, policy::Policy};
 
-pub fn community_set(policy: &Policy, _args: Args, _json: bool) -> Result<String, Error> {
-    let mut buf = String::new();
+#[derive(Serialize)]
+struct CommunitySetJson {
+    name: String,
+    members: Vec<String>,
+}
 
+fn to_json(name: &str, set: &CommunitySet) -> CommunitySetJson {
+    CommunitySetJson {
+        name: name.to_string(),
+        members: set.vals.iter().map(format_community_matcher).collect(),
+    }
+}
+
+pub fn community_set(policy: &Policy, _args: Args, json: bool) -> Result<String, Error> {
+    if json {
+        let list: Vec<_> = policy
+            .community_config
+            .config
+            .iter()
+            .map(|(name, set)| to_json(name, set))
+            .collect();
+        return Ok(serde_json::to_string_pretty(&list)?);
+    }
+
+    let mut buf = String::new();
     for (name, set) in policy.community_config.config.iter() {
         writeln!(buf, "community-set: {} len: {}", name, set.vals.len())?;
         for matcher in &set.vals {
@@ -17,9 +40,7 @@ pub fn community_set(policy: &Policy, _args: Args, _json: bool) -> Result<String
     Ok(buf)
 }
 
-pub fn community_set_name(policy: &Policy, mut args: Args, _json: bool) -> Result<String, Error> {
-    let mut buf = String::new();
-
+pub fn community_set_name(policy: &Policy, mut args: Args, json: bool) -> Result<String, Error> {
     // get the community-set name from arguments
     let name = args.string().context("missing community-set name")?;
 
@@ -30,6 +51,11 @@ pub fn community_set_name(policy: &Policy, mut args: Args, _json: bool) -> Resul
         .get(&name)
         .context(format!("community-set '{}' not found", name))?;
 
+    if json {
+        return Ok(serde_json::to_string_pretty(&to_json(&name, set))?);
+    }
+
+    let mut buf = String::new();
     writeln!(buf, "community-set: {}", name)?;
 
     // Show all community matchers in this set

--- a/zebra-rs/src/policy/ext_community/show.rs
+++ b/zebra-rs/src/policy/ext_community/show.rs
@@ -1,11 +1,34 @@
 use std::fmt::Write;
 
 use anyhow::{Context, Error};
+use serde::Serialize;
 
-use super::ExtCommunityMatcher;
+use super::{ExtCommunityMatcher, ExtCommunitySet};
 use crate::{config::Args, policy::Policy};
 
-pub fn ext_community_set(policy: &Policy, _args: Args, _json: bool) -> Result<String, Error> {
+#[derive(Serialize)]
+struct ExtCommunitySetJson {
+    name: String,
+    members: Vec<String>,
+}
+
+fn to_json(name: &str, set: &ExtCommunitySet) -> ExtCommunitySetJson {
+    ExtCommunitySetJson {
+        name: name.to_string(),
+        members: set.vals.iter().map(format_matcher).collect(),
+    }
+}
+
+pub fn ext_community_set(policy: &Policy, _args: Args, json: bool) -> Result<String, Error> {
+    if json {
+        let list: Vec<_> = policy
+            .ext_community_config
+            .config
+            .iter()
+            .map(|(name, set)| to_json(name, set))
+            .collect();
+        return Ok(serde_json::to_string_pretty(&list)?);
+    }
     let mut buf = String::new();
     for (name, set) in policy.ext_community_config.config.iter() {
         writeln!(buf, "ext-community-set: {} len: {}", name, set.vals.len())?;
@@ -19,15 +42,18 @@ pub fn ext_community_set(policy: &Policy, _args: Args, _json: bool) -> Result<St
 pub fn ext_community_set_name(
     policy: &Policy,
     mut args: Args,
-    _json: bool,
+    json: bool,
 ) -> Result<String, Error> {
-    let mut buf = String::new();
     let name = args.string().context("missing ext-community-set name")?;
     let set = policy
         .ext_community_config
         .config
         .get(&name)
         .context(format!("ext-community-set '{}' not found", name))?;
+    if json {
+        return Ok(serde_json::to_string_pretty(&to_json(&name, set))?);
+    }
+    let mut buf = String::new();
     writeln!(buf, "ext-community-set: {}", name)?;
     for matcher in &set.vals {
         writeln!(buf, "  {}", format_matcher(matcher))?;

--- a/zebra-rs/src/policy/keychain/show.rs
+++ b/zebra-rs/src/policy/keychain/show.rs
@@ -1,13 +1,63 @@
 use std::fmt::Write;
 
 use anyhow::{Context, Error};
+use serde::Serialize;
 
 use crate::config::Args;
 use crate::policy::Policy;
 
 use super::{CryptoAlgorithm, Lifetime, LifetimeEnd};
 
-pub fn key_chains(policy: &Policy, _args: Args, _json: bool) -> Result<String, Error> {
+#[derive(Serialize)]
+struct KeyJson {
+    id: u64,
+    algo: Option<String>,
+    /// Length of the raw key material in bytes (the secret itself is
+    /// never serialized).
+    key_bytes: usize,
+    send_id: Option<u8>,
+    recv_id: Option<u8>,
+    send_lifetime: String,
+    accept_lifetime: String,
+}
+
+#[derive(Serialize)]
+struct KeyChainJson {
+    name: String,
+    description: Option<String>,
+    keys: Vec<KeyJson>,
+}
+
+fn to_json(name: &str, kc: &super::KeyChain) -> KeyChainJson {
+    KeyChainJson {
+        name: name.to_string(),
+        description: kc.description.clone(),
+        keys: kc
+            .keys
+            .iter()
+            .map(|(id, key)| KeyJson {
+                id: *id,
+                algo: key.algo.map(|a| algo_name(a).to_string()),
+                key_bytes: key.key_material.len(),
+                send_id: key.send_id,
+                recv_id: key.recv_id,
+                send_lifetime: fmt_lifetime(&key.send_lifetime),
+                accept_lifetime: fmt_lifetime(&key.accept_lifetime),
+            })
+            .collect(),
+    }
+}
+
+pub fn key_chains(policy: &Policy, _args: Args, json: bool) -> Result<String, Error> {
+    if json {
+        let list: Vec<_> = policy
+            .key_chain_config
+            .config
+            .iter()
+            .map(|(name, kc)| to_json(name, kc))
+            .collect();
+        return Ok(serde_json::to_string_pretty(&list)?);
+    }
     let mut buf = String::new();
     for (name, kc) in policy.key_chain_config.config.iter() {
         write_chain(&mut buf, name, kc)?;
@@ -15,13 +65,16 @@ pub fn key_chains(policy: &Policy, _args: Args, _json: bool) -> Result<String, E
     Ok(buf)
 }
 
-pub fn key_chain_name(policy: &Policy, mut args: Args, _json: bool) -> Result<String, Error> {
+pub fn key_chain_name(policy: &Policy, mut args: Args, json: bool) -> Result<String, Error> {
     let name = args.string().context("missing key-chain name")?;
     let kc = policy
         .key_chain_config
         .config
         .get(&name)
         .context(format!("key-chain '{}' not found", name))?;
+    if json {
+        return Ok(serde_json::to_string_pretty(&to_json(&name, kc))?);
+    }
     let mut buf = String::new();
     write_chain(&mut buf, &name, kc)?;
     Ok(buf)

--- a/zebra-rs/src/policy/large_community/show.rs
+++ b/zebra-rs/src/policy/large_community/show.rs
@@ -1,11 +1,34 @@
 use std::fmt::Write;
 
 use anyhow::{Context, Error};
+use serde::Serialize;
 
-use super::LargeCommunityMatcher;
+use super::{LargeCommunityMatcher, LargeCommunitySet};
 use crate::{config::Args, policy::Policy};
 
-pub fn large_community_set(policy: &Policy, _args: Args, _json: bool) -> Result<String, Error> {
+#[derive(Serialize)]
+struct LargeCommunitySetJson {
+    name: String,
+    members: Vec<String>,
+}
+
+fn to_json(name: &str, set: &LargeCommunitySet) -> LargeCommunitySetJson {
+    LargeCommunitySetJson {
+        name: name.to_string(),
+        members: set.vals.iter().map(format_matcher).collect(),
+    }
+}
+
+pub fn large_community_set(policy: &Policy, _args: Args, json: bool) -> Result<String, Error> {
+    if json {
+        let list: Vec<_> = policy
+            .large_community_config
+            .config
+            .iter()
+            .map(|(name, set)| to_json(name, set))
+            .collect();
+        return Ok(serde_json::to_string_pretty(&list)?);
+    }
     let mut buf = String::new();
     for (name, set) in policy.large_community_config.config.iter() {
         writeln!(buf, "large-community-set: {} len: {}", name, set.vals.len())?;
@@ -19,15 +42,18 @@ pub fn large_community_set(policy: &Policy, _args: Args, _json: bool) -> Result<
 pub fn large_community_set_name(
     policy: &Policy,
     mut args: Args,
-    _json: bool,
+    json: bool,
 ) -> Result<String, Error> {
-    let mut buf = String::new();
     let name = args.string().context("missing large-community-set name")?;
     let set = policy
         .large_community_config
         .config
         .get(&name)
         .context(format!("large-community-set '{}' not found", name))?;
+    if json {
+        return Ok(serde_json::to_string_pretty(&to_json(&name, set))?);
+    }
+    let mut buf = String::new();
     writeln!(buf, "large-community-set: {}", name)?;
     for matcher in &set.vals {
         writeln!(buf, "  {}", format_matcher(matcher))?;

--- a/zebra-rs/src/policy/policy_list.rs
+++ b/zebra-rs/src/policy/policy_list.rs
@@ -1250,7 +1250,122 @@ impl ConfigBuilder {
     }
 }
 
-pub fn show(policy: &Policy, _args: Args, _json: bool) -> Result<String, Error> {
+/// Build the JSON object for one policy entry: `seq`, `action`, and the
+/// present-only `match` / `set` sub-objects. Mirrors the text renderer
+/// below field-for-field (plus `action`, which the text omits).
+fn entry_to_json(seq: u32, entry: &PolicyEntry) -> serde_json::Value {
+    use serde_json::{Map, Value, json};
+
+    let op_val = |op: &str, value: u32| json!({ "op": op, "value": value });
+
+    let mut m = Map::new();
+    if let Some(x) = &entry.prefix_set_name {
+        m.insert("prefix_set".into(), json!(x));
+    }
+    if let Some(x) = &entry.community_set_name {
+        m.insert("community_set".into(), json!(x));
+    }
+    if let Some(x) = &entry.ext_community_set_name {
+        m.insert("ext_community_set".into(), json!(x));
+    }
+    if let Some(x) = &entry.large_community_set_name {
+        m.insert("large_community_set".into(), json!(x));
+    }
+    if let Some(x) = &entry.as_path_set_name {
+        m.insert("as_path_set".into(), json!(x));
+    }
+    if let Some(x) = &entry.match_next_hop {
+        m.insert("next_hop".into(), json!(x.to_string()));
+    }
+    if let Some(x) = &entry.match_med {
+        m.insert("med".into(), op_val(x.op_str(), x.value()));
+    }
+    if let Some(x) = &entry.match_as_path_len {
+        m.insert("as_path_len".into(), op_val(x.op_str(), x.value()));
+    }
+    if let Some(x) = &entry.match_as_path_len_uniq {
+        m.insert("as_path_len_uniq".into(), op_val(x.op_str(), x.value()));
+    }
+    if let Some(x) = &entry.match_local_pref {
+        m.insert("local_preference".into(), op_val(x.op_str(), x.value()));
+    }
+    if let Some(x) = &entry.match_weight {
+        m.insert("weight".into(), op_val(x.op_str(), x.value()));
+    }
+    if let Some(x) = &entry.match_origin {
+        m.insert("origin".into(), json!(format!("{:?}", x)));
+    }
+    if let Some(x) = &entry.match_evpn_route_type {
+        m.insert("evpn_route_type".into(), json!(x.to_string()));
+    }
+    if let Some(x) = &entry.match_evpn_vni {
+        m.insert("evpn_vni".into(), json!(x));
+    }
+
+    let mut s = Map::new();
+    if let Some(x) = &entry.local_pref {
+        s.insert("local_preference".into(), op_val(x.op_str(), x.value()));
+    }
+    if let Some(x) = &entry.med {
+        s.insert("med".into(), op_val(x.op_str(), x.value()));
+    }
+    if let Some(x) = &entry.weight {
+        s.insert("weight".into(), json!(x));
+    }
+    if let Some(cfg) = &entry.set_community {
+        let mode = match cfg.mode {
+            SetCommunityMode::Replace => "replace",
+            SetCommunityMode::Additive => "additive",
+            SetCommunityMode::Delete => "delete",
+        };
+        s.insert(
+            "community".into(),
+            json!({ "name": cfg.name, "mode": mode }),
+        );
+    }
+    if let Some(p) = &entry.set_as_path_prepend {
+        s.insert(
+            "as_path_prepend".into(),
+            json!({ "asn": p.asn, "repeat": p.repeat }),
+        );
+    }
+    if let Some(nh) = &entry.set_next_hop {
+        let v = match nh {
+            SetNextHop::Address(a) => a.to_string(),
+            SetNextHop::SelfAddr => "self".to_string(),
+        };
+        s.insert("next_hop".into(), json!(v));
+    }
+    if let Some(o) = &entry.set_origin {
+        s.insert("origin".into(), json!(format!("{:?}", o)));
+    }
+
+    json!({
+        "seq": seq,
+        "action": entry.action.to_string(),
+        "match": Value::Object(m),
+        "set": Value::Object(s),
+    })
+}
+
+pub fn show(policy: &Policy, _args: Args, json: bool) -> Result<String, Error> {
+    if json {
+        let list: Vec<serde_json::Value> = policy
+            .policy_config
+            .config
+            .iter()
+            .map(|(name, plist)| {
+                let entries: Vec<serde_json::Value> = plist
+                    .entry
+                    .iter()
+                    .map(|(seq, entry)| entry_to_json(*seq, entry))
+                    .collect();
+                serde_json::json!({ "name": name, "entries": entries })
+            })
+            .collect();
+        return Ok(serde_json::to_string_pretty(&list)?);
+    }
+
     let mut buf = String::new();
     for (name, policy) in policy.policy_config.config.iter() {
         let _ = writeln!(buf, "policy-list: {}", name);

--- a/zebra-rs/src/policy/prefix/show.rs
+++ b/zebra-rs/src/policy/prefix/show.rs
@@ -1,50 +1,45 @@
 use anyhow::{Context, Error};
+use serde::Serialize;
 use std::fmt::Write;
 
+use super::PrefixSet;
 use crate::{config::Args, policy::Policy};
 
-// List all of prefix-set.
-pub fn prefix_set(policy: &Policy, _args: Args, _json: bool) -> Result<String, Error> {
-    let mut buf = String::new();
-
-    // Iterate through all prefix-sets
-    for (name, set) in policy.prefix_config.config.iter() {
-        writeln!(buf, "prefix-set: {}", name)?;
-        for (prefix, entry) in set.iter() {
-            write!(buf, "  {}", prefix)?;
-            if let Some(le) = entry.le {
-                write!(buf, " le {}", le)?;
-            }
-            if let Some(eq) = entry.eq {
-                write!(buf, " eq {}", eq)?;
-            }
-            if let Some(ge) = entry.ge {
-                write!(buf, " ge {}", ge)?;
-            }
-            writeln!(buf)?;
-        }
-    }
-
-    Ok(buf)
+#[derive(Serialize)]
+struct PrefixEntryJson {
+    prefix: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    le: Option<u8>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    eq: Option<u8>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    ge: Option<u8>,
 }
 
-// Show prefix-set of the name.
-pub fn prefix_set_name(policy: &Policy, mut args: Args, _json: bool) -> Result<String, Error> {
-    let mut buf = String::new();
+#[derive(Serialize)]
+struct PrefixSetJson {
+    name: String,
+    prefixes: Vec<PrefixEntryJson>,
+}
 
-    // get the prefix-set name from arguments
-    let name = args.string().context("missing prefix-set name")?;
+fn to_json(name: &str, set: &PrefixSet) -> PrefixSetJson {
+    PrefixSetJson {
+        name: name.to_string(),
+        prefixes: set
+            .iter()
+            .map(|(prefix, entry)| PrefixEntryJson {
+                prefix: prefix.to_string(),
+                le: entry.le,
+                eq: entry.eq,
+                ge: entry.ge,
+            })
+            .collect(),
+    }
+}
 
-    // Look up the prefix-set by name
-    let set = policy
-        .prefix_config
-        .config
-        .get(&name)
-        .context(format!("prefix-set '{}' not found", name))?;
-
+// Render one prefix-set the FRR-ish way (`  P/M le L eq E ge G`).
+fn write_set(buf: &mut String, name: &str, set: &PrefixSet) -> Result<(), std::fmt::Error> {
     writeln!(buf, "prefix-set: {}", name)?;
-
-    // Show all prefixes in this set
     for (prefix, entry) in set.iter() {
         write!(buf, "  {}", prefix)?;
         if let Some(le) = entry.le {
@@ -58,6 +53,47 @@ pub fn prefix_set_name(policy: &Policy, mut args: Args, _json: bool) -> Result<S
         }
         writeln!(buf)?;
     }
+    Ok(())
+}
+
+// List all of prefix-set.
+pub fn prefix_set(policy: &Policy, _args: Args, json: bool) -> Result<String, Error> {
+    if json {
+        let list: Vec<_> = policy
+            .prefix_config
+            .config
+            .iter()
+            .map(|(name, set)| to_json(name, set))
+            .collect();
+        return Ok(serde_json::to_string_pretty(&list)?);
+    }
+
+    let mut buf = String::new();
+    for (name, set) in policy.prefix_config.config.iter() {
+        write_set(&mut buf, name, set)?;
+    }
+
+    Ok(buf)
+}
+
+// Show prefix-set of the name.
+pub fn prefix_set_name(policy: &Policy, mut args: Args, json: bool) -> Result<String, Error> {
+    // get the prefix-set name from arguments
+    let name = args.string().context("missing prefix-set name")?;
+
+    // Look up the prefix-set by name
+    let set = policy
+        .prefix_config
+        .config
+        .get(&name)
+        .context(format!("prefix-set '{}' not found", name))?;
+
+    if json {
+        return Ok(serde_json::to_string_pretty(&to_json(&name, set))?);
+    }
+
+    let mut buf = String::new();
+    write_set(&mut buf, &name, set)?;
 
     Ok(buf)
 }

--- a/zebra-rs/yang/exec.yang
+++ b/zebra-rs/yang/exec.yang
@@ -159,13 +159,49 @@ module exec {
         type empty;
       }
     }
-    leaf community-set {
+    container "community-set" {
       ext:help "Show community-set";
-      type empty;
+      presence "Show community-set";
+      list name {
+        key name;
+        leaf name {
+          type string;
+        }
+      }
+    }
+    container "ext-community-set" {
+      ext:help "Show ext-community-set";
+      presence "Show ext-community-set";
+      list name {
+        key name;
+        leaf name {
+          type string;
+        }
+      }
+    }
+    container "large-community-set" {
+      ext:help "Show large-community-set";
+      presence "Show large-community-set";
+      list name {
+        key name;
+        leaf name {
+          type string;
+        }
+      }
     }
     container "as-path-set" {
       ext:help "Show as-path-set";
       presence "Show as-path-set";
+      list name {
+        key name;
+        leaf name {
+          type string;
+        }
+      }
+    }
+    container "key-chains" {
+      ext:help "Show key-chains";
+      presence "Show key-chains";
       list name {
         key name;
         leaf name {


### PR DESCRIPTION
## Summary

Adds `-j` / `--json` rendering to all seven policy-object `show`
commands — `show policy`, `prefix-set`, `community-set`,
`ext-community-set`, `large-community-set`, `as-path-set`, `key-chains`
(including the `name <name>` variants). Each handler gains an
`if json { … serde_json::to_string_pretty }` branch via a shared
per-object `to_json` helper; text output is unchanged.

JSON shapes:

| Command | Shape |
|---|---|
| `show prefix-set` | `[ { name, prefixes[{prefix, le, eq, ge}] } ]` |
| `show {,ext-,large-}community-set` | `[ { name, members[] } ]` |
| `show as-path-set` | `[ { name, members[] } ]` |
| `show key-chains` | `[ { name, description, keys[{id, algo, key_bytes, send_id, recv_id, send_lifetime, accept_lifetime}] } ]` |
| `show policy` | `[ { name, entries[{seq, action, match{}, set{}}] } ]` |

The key material itself is never serialized — only its byte length.

## Pre-existing bugs found and fixed

While verifying, four of these commands turned out to be **dead** — text
*or* JSON — for two reasons, both fixed here:

1. **Dispatch:** `is_policy()` (`config/manager.rs`) only matched
   `prefix-set` / `community-set` / `policy`, so `as-path-set`,
   `ext-community-set`, `large-community-set`, and `key-chains` fell
   through to the `rib` show channel (no handler → silent empty output).
   It now recognizes every policy-object root.
2. **Grammar:** `exec.yang` had no node for `ext-community-set`,
   `large-community-set`, or `key-chains`, and `community-set` was a bare
   leaf (so `community-set name <name>` couldn't parse). All are now
   containers with a `name` selector, mirroring `as-path-set`.

## Test plan

- `cargo fmt --check`, `cargo clippy --workspace --all-targets -- -D warnings`: clean
- `cargo test -p zebra-rs`: 1475 passed (incl. the `yang_load_tests` guard, which validates the `exec.yang` change)
- Live-verified on a throwaway daemon via `vtyctl show -j` for every command (list + by-name) and the text paths: prefix-set/community-set/large-community-set/as-path-set/key-chains/policy all emit valid JSON; unconfigured objects return `[]`; text output unchanged.

Generated with [Claude Code](https://claude.com/claude-code)