### PR TITLE
bgp: render JSON for the text-only show commands

### DIFF
--- a/docs/design/show-commands-json-output.md
+++ b/docs/design/show-commands-json-output.md
@@ -96,23 +96,23 @@ its non-VRF sibling** in the tables below.
 | `show bgp [<addr>\|<prefix>]` | IPv4 unicast RIB (default family) | ✅ |
 | `show bgp summary` | Neighbor status per AFI/SAFI | ✅ |
 | `show bgp ipv4 [<addr>\|<prefix>\|summary]` | IPv4 unicast RIB | ✅ |
-| `show bgp ipv4 <prefix> longer-prefix` | IPv4 equal-or-more-specific | text only |
+| `show bgp ipv4 <prefix> longer-prefix` | IPv4 equal-or-more-specific | ✅ |
 | `show bgp ipv6 [<addr>\|<prefix>\|summary]` | IPv6 unicast RIB | ✅ |
-| `show bgp ipv6 <prefix> longer-prefix` | IPv6 equal-or-more-specific | text only |
+| `show bgp ipv6 <prefix> longer-prefix` | IPv6 equal-or-more-specific | ✅ |
 | `show bgp vpnv4 [<addr>\|<prefix>\|summary]` | VPNv4 RIB (all RDs) | ✅ |
 | `show bgp vpnv6 [<addr>\|<prefix>\|summary]` | VPNv6 RIB (all RDs) | ✅ |
 | `show bgp evpn [route-type <type>]` | EVPN RIB | ✅ ◐ |
 | `show bgp evpn summary` | EVPN-enabled neighbors | ✅ |
-| `show bgp evpn ethernet-segment` | Local Ethernet Segments (RFC 7432) | text only |
+| `show bgp evpn ethernet-segment` | Local Ethernet Segments (RFC 7432) | ✅ |
 | `show bgp labeled-unicast` | Labeled-Unicast (SAFI 4) RIB | ✅ ◐ |
 | `show bgp flowspec [ipv6]` | Flowspec RIB (SAFI 133) | ✅ ◐ |
 | `show bgp sr-policy [ipv6]` | SR Policy RIB (SAFI 73) | ✅ ◐ |
 | `show bgp link-state` | Link-State RIB (SAFI 71) | ✅ ◐ |
-| `show bgp attributes` | Attribute-store statistics | text only |
+| `show bgp attributes` | Attribute-store statistics | ✅ |
 | `show bgp neighbor [<addr>\|<name>]` | Neighbor information | ✅ |
 | `show bgp neighbor <addr> advertised-routes [ipv6\|vpnv4\|evpn]` | Adj-RIB-Out | ✅ (evpn ◐) |
 | `show bgp neighbor <addr> received-routes [ipv6\|vpnv4\|evpn]` | Adj-RIB-In | ✅ (evpn ◐) |
-| `show bgp neighbor <addr> rtcv4` | IPv4 Route Target Constraints | text only |
+| `show bgp neighbor <addr> rtcv4` | IPv4 Route Target Constraints | ✅ |
 | `show bgp neighbor-group [<name>]` | Neighbor-group inheritance state | ✅ |
 | `show bgp update-group [<id>]` | Update-groups (IOS-XR style) | ✅ |
 | `show bgp mup [summary]` | Mobile User Plane RIB (SAFI 85) | ✅ ◐ |
@@ -237,7 +237,7 @@ pending a finalized JSON schema.
 | Module | Commands | JSON (incl. ◐ placeholder) | Text only |
 |---|---:|---:|---:|
 | RIB / forwarding / config | 22 | 19 | 3 |
-| BGP | 25 | 20 | 5 |
+| BGP | 25 | 25 | 0 |
 | OSPFv2 | 13 | 13 | 0 |
 | OSPFv3 | 12 | 12 | 0 |
 | IS-IS | 21 | 21 | 0 |
@@ -258,9 +258,11 @@ JSON":
 - **RIB:** `show task`, `show version` (both use the config-tree /
   manager dispatch that does not carry the `-j` flag — needs plumbing),
   and `show evpn vni all` (lives in the BGP/EVPN module)
-- **BGP:** `show bgp <afi> <prefix> longer-prefix`,
-  `show bgp evpn ethernet-segment`, `show bgp attributes`,
-  `show bgp neighbor <addr> rtcv4`
+
+Every per-protocol `ShowCallback` (RIB, BGP, all IGPs, BFD, STAMP, ND,
+policy) now honors `-j`. What's left is the handful of commands routed
+through a different dispatch path (above) plus the BGP `◐` placeholders
+below.
 
 ### Placeholder JSON (BGP ◐ — honors `-j`, emits empty array/object)
 

--- a/zebra-rs/src/bgp/show.rs
+++ b/zebra-rs/src/bgp/show.rs
@@ -503,6 +503,31 @@ struct BgpRouteJson {
     origin: Option<String>,
 }
 
+/// Convert one Loc-RIB entry to its `BgpRouteJson` row. Shared by the
+/// `longer-prefix` filters; mirrors the inline construction in
+/// `render_unicast_table` but reports the entry's real `best_path`.
+fn bgp_route_json(prefix: String, rib: &BgpRib) -> BgpRouteJson {
+    let aspath_str = show_aspath(&rib.attr);
+    let origin_str = show_origin(&rib.attr);
+    BgpRouteJson {
+        prefix,
+        valid: true,
+        best: rib.best_path,
+        internal: rib.typ == BgpRibType::IBGP,
+        route_type: if rib.typ == BgpRibType::IBGP {
+            "iBGP".to_string()
+        } else {
+            "eBGP".to_string()
+        },
+        next_hop: show_nexthop(&rib.attr),
+        metric: show_med2(&rib.attr),
+        local_pref: show_local_pref2(&rib.attr),
+        weight: rib.weight,
+        as_path: (!aspath_str.is_empty()).then_some(aspath_str),
+        origin: (!origin_str.is_empty()).then_some(origin_str),
+    }
+}
+
 #[derive(Serialize)]
 struct BgpVpnv4RouteJson {
     route_distinguisher: String,
@@ -1565,10 +1590,13 @@ fn show_bgp_ipv4<V: BgpShowView>(
 fn show_bgp_ipv4_longer<V: BgpShowView>(
     bgp: &V,
     mut args: Args,
-    _json: bool,
+    json: bool,
 ) -> std::result::Result<String, std::fmt::Error> {
     let mut out = String::new();
     let Some(tok) = args.string() else {
+        if json {
+            return Ok("[]".to_string());
+        }
         return Ok(String::from("% Specify an IPv4 prefix\n"));
     };
     let net = if tok.contains('/') {
@@ -1577,9 +1605,22 @@ fn show_bgp_ipv4_longer<V: BgpShowView>(
         tok.parse::<Ipv4Addr>().ok().map(|a| a.to_host_prefix())
     };
     let Some(net) = net else {
+        if json {
+            return Ok("[]".to_string());
+        }
         writeln!(out, "% Malformed IPv4 prefix: {tok}")?;
         return Ok(out);
     };
+    if json {
+        let mut routes: Vec<BgpRouteJson> = Vec::new();
+        for (prefix, ribs) in bgp.shard().v4.0.children(&net) {
+            for rib in ribs.iter() {
+                routes.push(bgp_route_json(prefix.to_string(), rib));
+            }
+        }
+        return Ok(serde_json::to_string_pretty(&routes)
+            .unwrap_or_else(|e| format!("{{\"error\": \"Failed to serialize routes: {}\"}}", e)));
+    }
     out.push_str(SHOW_BGP_HEADER);
     for (prefix, ribs) in bgp.shard().v4.0.children(&net) {
         for rib in ribs.iter() {
@@ -1630,10 +1671,13 @@ fn show_bgp_ipv6<V: BgpShowView>(
 fn show_bgp_ipv6_longer<V: BgpShowView>(
     bgp: &V,
     mut args: Args,
-    _json: bool,
+    json: bool,
 ) -> std::result::Result<String, std::fmt::Error> {
     let mut out = String::new();
     let Some(tok) = args.string() else {
+        if json {
+            return Ok("[]".to_string());
+        }
         return Ok(String::from("% Specify an IPv6 prefix\n"));
     };
     let net = if tok.contains('/') {
@@ -1642,9 +1686,22 @@ fn show_bgp_ipv6_longer<V: BgpShowView>(
         tok.parse::<Ipv6Addr>().ok().map(|a| a.to_host_prefix())
     };
     let Some(net) = net else {
+        if json {
+            return Ok("[]".to_string());
+        }
         writeln!(out, "% Malformed IPv6 prefix: {tok}")?;
         return Ok(out);
     };
+    if json {
+        let mut routes: Vec<BgpRouteJson> = Vec::new();
+        for (prefix, ribs) in bgp.shard().v6.0.children(&net) {
+            for rib in ribs.iter() {
+                routes.push(bgp_route_json(prefix.to_string(), rib));
+            }
+        }
+        return Ok(serde_json::to_string_pretty(&routes)
+            .unwrap_or_else(|e| format!("{{\"error\": \"Failed to serialize routes: {}\"}}", e)));
+    }
     out.push_str(SHOW_BGP_HEADER);
     for (prefix, ribs) in bgp.shard().v6.0.children(&net) {
         for rib in ribs.iter() {
@@ -2053,12 +2110,77 @@ pub(super) fn render_summary_with_counts<V: BgpShowView>(
 /// Segments (RFC 7432): name, ESI, redundancy mode, access interface, and the
 /// auto-derived ES-Import RT. Config + state only in this phase (DF state and
 /// the per-ES PE membership set arrive with Type-4 discovery / DF election).
+#[derive(Serialize)]
+struct EsMemberVtepJson {
+    ordinal: usize,
+    vtep: String,
+    local: bool,
+}
+
+#[derive(Serialize)]
+struct EthernetSegmentJson {
+    name: String,
+    esi: Option<String>,
+    redundancy_mode: String,
+    interface: Option<String>,
+    es_import_rt: Option<String>,
+    member_vteps: Vec<EsMemberVtepJson>,
+    df_algorithm: Option<String>,
+    designated_forwarder: Option<String>,
+}
+
 fn show_bgp_evpn_ethernet_segment(
     bgp: &Bgp,
     _args: Args,
-    _json: bool,
+    json: bool,
 ) -> std::result::Result<String, std::fmt::Error> {
     use std::fmt::Write;
+
+    if json {
+        let local = std::net::IpAddr::V4(bgp.router_id);
+        let mut list = Vec::new();
+        for (name, es) in bgp.ethernet_segments.iter() {
+            let mut member_vteps = Vec::new();
+            let mut df_algorithm = None;
+            let mut designated_forwarder = None;
+            if let Some(esi) = es.esi {
+                let cands = bgp.es_df_candidates(&esi);
+                let vteps: Vec<std::net::IpAddr> = cands.iter().map(|(ip, _)| *ip).collect();
+                for (ordinal, (vtep, _)) in cands.iter().enumerate() {
+                    member_vteps.push(EsMemberVtepJson {
+                        ordinal,
+                        vtep: vtep.to_string(),
+                        local: *vtep == local,
+                    });
+                }
+                let algs: Vec<u8> = cands.iter().map(|(_, a)| *a).collect();
+                let alg = super::ethernet_segment::negotiate_df_alg(&algs);
+                df_algorithm = Some(
+                    if alg == bgp_packet::DfElectionEc::ALG_DEFAULT {
+                        "service-carving (default)"
+                    } else {
+                        "negotiated (non-default; carving fallback)"
+                    }
+                    .to_string(),
+                );
+                designated_forwarder = super::ethernet_segment::designated_forwarder(&vteps, 0)
+                    .map(|df| df.to_string());
+            }
+            list.push(EthernetSegmentJson {
+                name: name.clone(),
+                esi: es.esi.map(|esi| bgp_packet::esi_display(&esi)),
+                redundancy_mode: es.redundancy_mode.as_str().to_string(),
+                interface: es.interface.clone(),
+                es_import_rt: es.es_import_rt().map(|rt| format_evpn_ecom_value(&rt)),
+                member_vteps,
+                df_algorithm,
+                designated_forwarder,
+            });
+        }
+        return Ok(serde_json::to_string_pretty(&list)
+            .unwrap_or_else(|e| format!("{{\"error\": \"{e}\"}}")));
+    }
+
     let mut buf = String::new();
     if bgp.ethernet_segments.is_empty() {
         writeln!(buf, "No EVPN Ethernet Segments configured")?;
@@ -5283,19 +5405,39 @@ fn show_evpn_vni_all(
 fn show_bgp_rtcv4(
     bgp: &Bgp,
     mut args: Args,
-    _json: bool,
+    json: bool,
 ) -> std::result::Result<String, std::fmt::Error> {
     let mut buf = String::new();
 
     let addr = match args.addr() {
         Some(addr) => addr,
-        None => return Ok(String::from("% No neighbor address specified")),
+        None => {
+            if json {
+                return Ok("{\"error\": \"no neighbor address specified\"}".to_string());
+            }
+            return Ok(String::from("% No neighbor address specified"));
+        }
     };
 
     let peer = match bgp.peers.get(&addr) {
         Some(peer) => peer,
-        None => return Ok(format!("% No such neighbor: {}", addr)),
+        None => {
+            if json {
+                return Ok(format!("{{\"error\": \"no such neighbor: {}\"}}", addr));
+            }
+            return Ok(format!("% No such neighbor: {}", addr));
+        }
     };
+
+    if json {
+        let view = RtcJson {
+            neighbor: addr.to_string(),
+            ipv4: peer.rtcv4.iter().map(|rt| rt.to_string()).collect(),
+            ipv6: peer.rtcv6.iter().map(|rt| rt.to_string()).collect(),
+        };
+        return Ok(serde_json::to_string_pretty(&view)
+            .unwrap_or_else(|e| format!("{{\"error\": \"{e}\"}}")));
+    }
 
     if !peer.rtcv4.is_empty() {
         writeln!(buf, "IPv4 Route Target Constraints for {}", addr)?;
@@ -5313,11 +5455,60 @@ fn show_bgp_rtcv4(
     Ok(buf)
 }
 
+#[derive(Serialize)]
+struct RtcJson {
+    neighbor: String,
+    ipv4: Vec<String>,
+    ipv6: Vec<String>,
+}
+
+#[derive(Serialize)]
+struct BgpAttrEntryJson {
+    refcnt: usize,
+    store: String,
+    /// The attribute set's text rendering (multi-line `Display`).
+    attr: String,
+}
+
+#[derive(Serialize)]
+struct BgpAttributesJson {
+    total_entries: usize,
+    active_entries: usize,
+    main_entries: usize,
+    shard_entries: usize,
+    attributes: Vec<BgpAttrEntryJson>,
+}
+
 fn show_bgp_attributes(
     bgp: &Bgp,
     _args: Args,
-    _json: bool,
+    json: bool,
 ) -> std::result::Result<String, std::fmt::Error> {
+    if json {
+        let mut attributes = Vec::new();
+        for (label, store) in [("main", &bgp.attr_store), ("shard", &bgp.shard.attr_store)] {
+            for (attr, weak) in store.iter() {
+                let refcnt = weak.strong_count();
+                if refcnt > 0 {
+                    attributes.push(BgpAttrEntryJson {
+                        refcnt,
+                        store: label.to_string(),
+                        attr: format!("{}", attr),
+                    });
+                }
+            }
+        }
+        let view = BgpAttributesJson {
+            total_entries: bgp.attr_store.len() + bgp.shard.attr_store.len(),
+            active_entries: bgp.attr_store.refcnt_all() + bgp.shard.attr_store.refcnt_all(),
+            main_entries: bgp.attr_store.len(),
+            shard_entries: bgp.shard.attr_store.len(),
+            attributes,
+        };
+        return Ok(serde_json::to_string_pretty(&view)
+            .unwrap_or_else(|e| format!("{{\"error\": \"{e}\"}}")));
+    }
+
     let mut buf = String::new();
     // Two stores since RIB sharding B.1: the main store (egress
     // encode + EVPN/flowspec/BGP-LS/VRF re-tag) and the shard store


### PR DESCRIPTION
## Summary

Adds `-j` / `--json` rendering to the remaining text-only BGP `show`
handlers. Each gains an `if json { … serde_json::to_string_pretty }`
branch; text output is unchanged.

| Command | JSON shape |
|---|---|
| `show bgp {ipv4,ipv6} <prefix> longer-prefix` | `[ BgpRouteJson ]` over the equal-or-more-specific subtree |
| `show bgp evpn ethernet-segment` | `[ { name, esi, redundancy_mode, interface, es_import_rt, member_vteps[{ordinal, vtep, local}], df_algorithm, designated_forwarder } ]` |
| `show bgp neighbor <addr> rtcv4` | `{ neighbor, ipv4[], ipv6[] }` |
| `show bgp attributes` | `{ total_entries, active_entries, main_entries, shard_entries, attributes[{refcnt, store, attr}] }` |

A shared `bgp_route_json(prefix, rib)` helper backs the longer-prefix
views (reports the entry's real `best_path`). Argument/lookup error
paths return JSON `[]` / `{"error": …}` under `-j` instead of a `%` text
line.

## Test plan

- `cargo fmt --check`, `cargo clippy --workspace --all-targets -- -D warnings`: clean
- `cargo test -p zebra-rs`: 1475 passed
- Live-verified via `vtyctl show -j`: the ethernet-segment view rendered
  the full ES (ESI, ES-Import RT, member VTEPs, DF election); rtcv4 /
  attributes / longer-prefix emitted valid structured JSON; text paths
  unchanged.

BGP is now 25/25 JSON. The remaining `◐` per-AFI placeholders (EVPN /
labeled-unicast / flowspec / sr-policy / link-state / mup route dumps)
already accept `-j` but emit empty arrays pending dedicated schemas —
tracked separately in the design doc.

Generated with [Claude Code](https://claude.com/claude-code)