### PR TITLE
config/bgp: JSON for manager-answered show commands

### DIFF
--- a/docs/design/show-commands-json-output.md
+++ b/docs/design/show-commands-json-output.md
@@ -66,11 +66,11 @@ its non-VRF sibling** in the tables below.
 
 | Command | Description | JSON |
 |---|---|---|
-| `show version` | Daemon version (config-tree handler) | text only |
+| `show version` | Daemon version (manager-answered global) | ✅ |
 | `show router-id` | Effective global router ID | ✅ |
 | `show hostname` | System hostname | ✅ |
 | `show vrf` | VRF table | ✅ |
-| `show task` | Spawned protocol tasks and their VRF (manager handler) | text only |
+| `show task` | Spawned protocol tasks and their VRF (manager handler) | ✅ |
 | `show interface [<name>] [detail]` | Interface state | ✅ |
 | `show ip route` | IPv4 routing table | ✅ |
 | `show ip route detail` | IPv4 RIB, IOS-XR detail blocks | ✅ |
@@ -85,7 +85,7 @@ its non-VRF sibling** in the tables below.
 | `show l2 mac table` | Bridge MAC table | ✅ |
 | `show l2 neighbor` | Bridge FDB entries | ✅ |
 | `show segment-routing srv6 sid` | Allocated SRv6 SIDs | ✅ |
-| `show evpn vni all` | EVPN VNI information | text only |
+| `show evpn vni all` | EVPN VNI information (stub; `-j` → `[]`) | ✅ |
 | `show running-config [formal\|json\|yaml]` | Committed config | ✅ (sub-keyword) |
 | `show candidate-config [formal\|json\|yaml]` | Uncommitted config | ✅ (sub-keyword) |
 
@@ -236,7 +236,7 @@ pending a finalized JSON schema.
 
 | Module | Commands | JSON (incl. ◐ placeholder) | Text only |
 |---|---:|---:|---:|
-| RIB / forwarding / config | 22 | 19 | 3 |
+| RIB / forwarding / config | 22 | 22 | 0 |
 | BGP | 25 | 25 | 0 |
 | OSPFv2 | 13 | 13 | 0 |
 | OSPFv3 | 12 | 12 | 0 |
@@ -252,17 +252,22 @@ the flag but still emit an empty array/object.)
 
 ### Remaining gaps (still text only)
 
-These are the commands to convert to reach "all `show` commands support
-JSON":
+None. Every concrete `show` command now honors `-j`:
 
-- **RIB:** `show task`, `show version` (both use the config-tree /
-  manager dispatch that does not carry the `-j` flag — needs plumbing),
-  and `show evpn vni all` (lives in the BGP/EVPN module)
+- Every per-protocol `ShowCallback` (RIB, BGP, all IGPs, BFD, STAMP, ND,
+  policy) branches on the flag.
+- `show version` and `show task` — owned by no protocol daemon — are
+  answered by the manager's `DisplayTx` interceptor, which now picks
+  text vs. JSON from the second-phase `DisplayRequest.json`
+  (`reply_static_show`). `show version` previously returned **nothing**
+  over the Show RPC (it was only wired to the interactive exec path);
+  it now works in both renderings.
+- `show evpn vni all` is still a content stub, but honors `-j` (`[]`)
+  rather than emitting the text placeholder.
 
-Every per-protocol `ShowCallback` (RIB, BGP, all IGPs, BFD, STAMP, ND,
-policy) now honors `-j`. What's left is the handful of commands routed
-through a different dispatch path (above) plus the BGP `◐` placeholders
-below.
+The only entries left short of a full document are the BGP `◐`
+placeholders below — they already accept `-j` but emit an empty
+array/object pending dedicated per-AFI route schemas.
 
 ### Placeholder JSON (BGP ◐ — honors `-j`, emits empty array/object)
 

--- a/zebra-rs/src/bgp/show.rs
+++ b/zebra-rs/src/bgp/show.rs
@@ -5396,10 +5396,15 @@ mod detail_tests {
 fn show_evpn_vni_all(
     _bgp: &Bgp,
     _args: Args,
-    _json: bool,
+    json: bool,
 ) -> std::result::Result<String, std::fmt::Error> {
-    let out = String::from("EVPN output here");
-    Ok(out)
+    // Placeholder: the EVPN VNI inventory isn't wired up here yet (the
+    // per-VNI MAC state lives in the RIB — see `show l2 mac table`).
+    // Honor `-j` with an empty array so the flag isn't a silent no-op.
+    if json {
+        return Ok("[]".to_string());
+    }
+    Ok(String::from("EVPN output here"))
 }
 
 fn show_bgp_rtcv4(

--- a/zebra-rs/src/config/manager.rs
+++ b/zebra-rs/src/config/manager.rs
@@ -1,4 +1,4 @@
-use crate::config::api::{ClearTxResponse, DeployResponse, DisplayTxResponse};
+use crate::config::api::{ClearTxResponse, DeployResponse, DisplayTxRequest, DisplayTxResponse};
 
 use super::api::{CompletionResponse, ConfigOp, ExecuteResponse, Message};
 use super::bfd::{despawn_bfd, spawn_bfd};
@@ -998,18 +998,17 @@ impl ConfigManager {
                 // the task registries (`protocol_tasks` plus the per-VRF
                 // show channels), which no single daemon can see.
                 if req.paths.iter().any(|p| p.name == "task") {
-                    let output = self.show_task();
-                    let (task_tx, task_rx) = mpsc::unbounded_channel();
-                    let _ = req.resp.send(DisplayTxResponse {
-                        tx: task_tx,
-                        paths: None,
-                    });
-                    tokio::spawn(async move {
-                        let mut task_rx = task_rx;
-                        if let Some(display_req) = task_rx.recv().await {
-                            let _ = display_req.resp.send(output).await;
-                        }
-                    });
+                    reply_static_show(req, self.show_task(), self.show_task_json());
+                    return;
+                }
+                // `show version` is a build-time global owned by no
+                // protocol daemon; the per-proto `show_proto` routing would
+                // misfile it under `rib` (which has no handler), so the
+                // manager answers it directly — honoring `-j` via the
+                // second-phase `DisplayRequest.json`.
+                if req.paths.iter().any(|p| p.name == "version") {
+                    let v = crate::version::VersionInfo::current();
+                    reply_static_show(req, v.format_version(), v.format_json());
                     return;
                 }
                 // Generic per-VRF instance redirect: `show <proto> vrf
@@ -1105,7 +1104,10 @@ impl ConfigManager {
     /// Default-VRF tasks come from `protocol_tasks` (keyed by protocol);
     /// per-VRF tasks come from the `"<proto>:vrf:<name>"` keys that
     /// VRF-spawning daemons register via `SubscribeShowVrf`.
-    fn show_task(&self) -> String {
+    /// `(protocol, vrf)` rows for `show task`: one per spawned protocol
+    /// task plus one per registered `"<proto>:vrf:<name>"` show channel.
+    /// Shared by the text and JSON renderers.
+    fn task_rows(&self) -> Vec<(String, String)> {
         let mut rows: Vec<(String, String)> = self
             .protocol_tasks
             .borrow()
@@ -1119,11 +1121,24 @@ impl ConfigManager {
             }
         }
         rows.sort();
+        rows
+    }
+
+    fn show_task(&self) -> String {
         let mut buf = format!("{:<12}  {}\n", "Protocol", "VRF");
-        for (proto, vrf) in rows {
+        for (proto, vrf) in self.task_rows() {
             buf.push_str(&format!("{proto:<12}  {vrf}\n"));
         }
         buf
+    }
+
+    fn show_task_json(&self) -> String {
+        let tasks: Vec<_> = self
+            .task_rows()
+            .into_iter()
+            .map(|(protocol, vrf)| serde_json::json!({ "protocol": protocol, "vrf": vrf }))
+            .collect();
+        serde_json::to_string_pretty(&tasks).unwrap_or_else(|e| format!("{{\"error\": \"{e}\"}}"))
     }
 
     /// Apply a `vty service-account uid N` change to the in-memory
@@ -1182,6 +1197,23 @@ impl ConfigManager {
             );
         }
     }
+}
+
+/// Answer a manager-owned show command (`show task`, `show version`)
+/// with a static `(text, json)` pair, picking the rendering from the
+/// second-phase `DisplayRequest.json`. Mirrors the channel/spawn dance
+/// the `DisplayTx` handler uses for protocol daemons, but the payload is
+/// already computed so nothing is forwarded to a daemon.
+fn reply_static_show(req: DisplayTxRequest, text: String, json: String) {
+    let (tx, rx) = mpsc::unbounded_channel();
+    let _ = req.resp.send(DisplayTxResponse { tx, paths: None });
+    tokio::spawn(async move {
+        let mut rx = rx;
+        if let Some(display_req) = rx.recv().await {
+            let output = if display_req.json { json } else { text };
+            let _ = display_req.resp.send(output).await;
+        }
+    });
 }
 
 fn is_bgp(paths: &[CommandPath]) -> bool {

--- a/zebra-rs/src/version.rs
+++ b/zebra-rs/src/version.rs
@@ -2,7 +2,10 @@
 /// Version information module containing package and git details
 use std::fmt;
 
+use serde::Serialize;
+
 /// Build-time version information
+#[derive(Serialize)]
 pub struct VersionInfo {
     pub package_version: &'static str,
     pub package_name: &'static str,
@@ -36,6 +39,12 @@ impl VersionInfo {
             "{} version {} ({})\nBuild Date: {}",
             self.package_name, self.package_version, self.git_hash, self.build_date
         )
+    }
+
+    /// Pretty-printed JSON rendering of the full version record —
+    /// every build-time field, for `show version -j`.
+    pub fn format_json(&self) -> String {
+        serde_json::to_string_pretty(self).unwrap_or_else(|e| format!("{{\"error\": \"{e}\"}}"))
     }
 
     /// Get a short version string


### PR DESCRIPTION
## Summary

Fixes the three `show` commands that bypass the per-protocol
`ShowCallback` path, so the `-j` flag never reached them.

| Command | Before | After |
|---|---|---|
| `show version` | **empty over the Show RPC** (only wired to the interactive exec path; the per-proto router misfiled it under `rib`, which has no handler) | manager-answered; text + full JSON build record |
| `show task` | text only (`-j` ignored) | `[{protocol, vrf}]` under `-j` |
| `show evpn vni all` | text stub (`-j` ignored) | honors `-j` with `[]` |

### How

- `VersionInfo` gains `#[derive(Serialize)]` + `format_json()`.
- The manager's `DisplayTx` interceptor now answers `show version`
  alongside `show task`, choosing text vs JSON from the second-phase
  `DisplayRequest.json` via a shared `reply_static_show` helper.
- `task_rows()` is factored out to feed both `show_task` (text) and the
  new `show_task_json`.
- `show_evpn_vni_all` is still a content stub (per-VNI MAC state lives in
  the RIB — see `show l2 mac table`) but no longer makes `-j` a silent
  no-op.

## Test plan

- `cargo fmt --check`, `cargo clippy --workspace --all-targets -- -D warnings`: clean
- `cargo test -p zebra-rs`: 1475 passed
- Live-verified via `vtyctl show -j`: `show version` now returns the full
  structured record (and the previously-empty text now works);
  `show task -j` returns the protocol/vrf array (bfd + bgp with a config
  loaded); `show evpn vni all -j` → `[]`. All text paths unchanged.

With this, every concrete `show` command honors `-j`. The only remaining
non-full entries are the BGP `◐` per-AFI placeholders (EVPN /
labeled-unicast / flowspec / sr-policy / link-state / MUP route dumps),
tracked in the design doc.

Generated with [Claude Code](https://claude.com/claude-code)