### PR TITLE
ci(nightly): keep only the latest .deb set on the nightly release

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -44,6 +44,21 @@ jobs:
           git tag -f nightly
           git push -f origin nightly
 
+      # The nightly release accumulates one dated set of six .debs per run: the
+      # build date is baked into each filename (zebra-rs_26.6.2~nightlyYYYYMMDD-...),
+      # so old names are never overwritten by the publish step below and pile up
+      # 6-per-day. Delete every existing asset first so only the freshly-built six
+      # remain. Tolerate the first run, when no nightly release exists yet.
+      - name: Remove stale .deb assets from nightly release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh release view nightly --json assets --jq '.assets[].name' 2>/dev/null \
+            | while read -r asset; do
+                echo "Deleting stale asset: $asset"
+                gh release delete-asset nightly "$asset" --yes
+              done || echo "No existing nightly release yet; nothing to clean."
+
       - name: Publish to GitHub Releases
         uses: softprops/action-gh-release@v2
         with:


### PR DESCRIPTION
## Summary

The `nightly` GitHub release accumulates one dated set of six `.deb` files
per run (3 Ubuntu codenames × 2 architectures). Because the build date is
baked into each filename (`zebra-rs_26.6.2~nightlyYYYYMMDD-<dist>_<arch>.deb`),
`softprops/action-gh-release` never overwrites the previous day's assets —
it only matches identical names — so files pile up 6-per-day, wasting space
and forcing users to hunt for the newest date.

This adds a step to the `release` job that deletes every existing asset on
the `nightly` release before the publish step runs, so only the freshly-built
six remain. The `|| echo …` tolerates the first run, when no `nightly`
release exists yet.

Scope is limited to the main repo's `nightly` direct-download release; the
apt channel (`publish-apt.yaml` → `zebra-rs.github.io`) is regenerated
separately and is unaffected.

## Test plan

- `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/nightly.yaml'))"` — parses cleanly; new step sits after the tag move and before publish.
- Cannot be exercised locally (workflow-only); will prune on the next nightly cron run or a manual `workflow_dispatch`.
- No untrusted input in the new step (asset names come from `gh release view` on our own release, read via stdin and quoted), so no Actions injection surface.

Generated with [Claude Code](https://claude.com/claude-code)