### PR TITLE
config: make vty 'show version' honor -j (route via Show RPC)

### DIFF
--- a/zebra-rs/src/config/commands.rs
+++ b/zebra-rs/src/config/commands.rs
@@ -1,7 +1,6 @@
 use super::ExecCode;
 use super::manager::ConfigManager;
 use super::util::trim_first_line;
-use crate::version::VersionInfo;
 use libyang::Entry;
 use similar::TextDiff;
 use std::collections::HashMap;
@@ -31,7 +30,6 @@ impl Mode {
 pub fn exec_mode_create(entry: Rc<Entry>) -> Mode {
     let mut mode = Mode::new(entry);
     mode.install_func(String::from("/help"), help);
-    mode.install_func(String::from("/show/version"), show_version);
     install_show_config_handlers(&mut mode);
     mode.install_func(String::from("/configure"), configure);
     mode.install_func(String::from("/enable"), enable);
@@ -46,11 +44,6 @@ pub fn configure_mode_create(entry: Rc<Entry>) -> Mode {
     mode.install_func(String::from("/help"), help);
     mode.install_func(String::from("/exit"), exit);
     mode.install_func(String::from("/show"), show);
-    // Same operator command as exec mode. Without this, `show version`
-    // in configure mode falls through to the RedirectShow path, where
-    // no protocol-show handler claims it and the output is silently
-    // empty.
-    mode.install_func(String::from("/show/version"), show_version);
     install_show_config_handlers(&mut mode);
     mode.install_func(String::from("/commit"), commit);
     mode.install_func(String::from("/discard"), discard);
@@ -103,11 +96,6 @@ save output to files (e.g. `show running-config | grep bgp',
 `show version > /tmp/ver.txt').
 "#;
     (ExecCode::Show, output.to_string())
-}
-
-fn show_version(_config: &ConfigManager) -> (ExecCode, String) {
-    let version_info = VersionInfo::current();
-    (ExecCode::Show, version_info.format_version())
 }
 
 // const CLI_CONFIGURE_MODE_PROMPT: &str = "(config)";


### PR DESCRIPTION
## Summary

In the interactive `vty` shell, `show version` always printed **text**,
even with `cli format json` / `-j`, while `vtyctl show -j 'show version'`
correctly returned JSON.

Cause: `show version` had a leftover exec-path `install_func` that
returned the text banner inline (`ExecCode::Show`) and ignored `-j`. That
was a pre-#1662 workaround — back then `show version` over the
`RedirectShow` path was claimed by no handler and rendered empty. PR
#1662 added the manager `DisplayTx` interceptor that now answers
`show version` and honors `-j`, so the workaround is obsolete and was
actively shadowing the JSON path in the exec/configure dispatch.

Fix: remove the `install_func("/show/version", …)` registrations (exec +
configure mode), the now-dead `show_version` fn, and its unused
`VersionInfo` import. `show version` now falls through to `RedirectShow`
→ Show RPC → the manager interceptor, exactly like every other show
command — so it honors `-j` from the vty shell in both modes.

## Test plan

- `cargo fmt --check`, `cargo clippy --workspace --all-targets -- -D warnings`: clean
- `cargo test -p zebra-rs`: 1475 passed
- Live-verified via `vtyhelper -m {exec,configure} [-j] show version`
  (the exact path the interactive `vty` shell drives): text renders the
  banner; `-j` renders the full structured JSON record in both exec and
  configure mode. `vtyctl show -j 'show version'` unchanged.

Generated with [Claude Code](https://claude.com/claude-code)