### PR TITLE
bgp: RFC 4271 §9 unrecognized path attribute handling

### DIFF
--- a/bdd/Makefile
+++ b/bdd/Makefile
@@ -310,6 +310,10 @@ bgp_local_as:
 	mkdir -p allure-results
 	cargo test --test cucumber -- --concurrency=1 --tags "@bgp_local_as"
 
+bgp_unknown_attr_transitive:
+	mkdir -p allure-results
+	cargo test --test cucumber -- --concurrency=1 --tags "@bgp_unknown_attr_transitive"
+
 generate:
 	rm -rf allure-report
 	allure generate
@@ -329,4 +333,4 @@ docs/%.md: tests/features/%.feature docs/feature2md.sh FORCE
 
 FORCE:
 
-.PHONY: ecmp_bfd_evict ospfv2_bfd_frr ospfv3_bfd_frr tilfa_bfd all run ibgp ebgp rr rib_static_ipv6 isis_ipv6 isis_srv6 isis_fragmentation_ipv6 isis_fragmentation_ipv4 isis_l1p2p isis_tilfa isis_l1l2 isis_redist isis_hello_auth_keychain isis_passive isis_afi_enable isis_endx_ipv6 isis_bfd_ipv6_p2p isis_bfd_ipv6_p2p_echo isis_bfd_ipv6_lan isis_bfd_ipv6_lan_echo isis_bfd_ipv4_p2p isis_bfd_ipv4_p2p_echo isis_bfd_ipv4_lan isis_bfd_ipv4_lan_echo ospf_clear_neighbor ospfv2_nssa ospfv2_stub ospfv2_tilfa ospfv3_nssa ospfv3_tilfa stamp_te_metric stamp_v6_te_metric bgp_peer_down_cleanup bgp_ipv6_over_v4_session bgp_evpn_capability bgp_vrf_evpn_type5 bgp_evpn_outpolicy_undef bgp_route_map_match bgp_policy_dynamic_update bgp_table_map bgp_v6_table_map bgp_community bgp_neighbor_group bgp_unnumbered_neighbor nd_show bgp_interas_option_c bgp_interas_option_a bgp_interas_option_b bgp_interas_option_ab bgp_port bgp_ip_transparent bgp_local_as generate open docs FORCE
+.PHONY: ecmp_bfd_evict ospfv2_bfd_frr ospfv3_bfd_frr tilfa_bfd all run ibgp ebgp rr rib_static_ipv6 isis_ipv6 isis_srv6 isis_fragmentation_ipv6 isis_fragmentation_ipv4 isis_l1p2p isis_tilfa isis_l1l2 isis_redist isis_hello_auth_keychain isis_passive isis_afi_enable isis_endx_ipv6 isis_bfd_ipv6_p2p isis_bfd_ipv6_p2p_echo isis_bfd_ipv6_lan isis_bfd_ipv6_lan_echo isis_bfd_ipv4_p2p isis_bfd_ipv4_p2p_echo isis_bfd_ipv4_lan isis_bfd_ipv4_lan_echo ospf_clear_neighbor ospfv2_nssa ospfv2_stub ospfv2_tilfa ospfv3_nssa ospfv3_tilfa stamp_te_metric stamp_v6_te_metric bgp_peer_down_cleanup bgp_ipv6_over_v4_session bgp_evpn_capability bgp_vrf_evpn_type5 bgp_evpn_outpolicy_undef bgp_route_map_match bgp_policy_dynamic_update bgp_table_map bgp_v6_table_map bgp_community bgp_neighbor_group bgp_unnumbered_neighbor nd_show bgp_interas_option_c bgp_interas_option_a bgp_interas_option_b bgp_interas_option_ab bgp_port bgp_ip_transparent bgp_local_as bgp_unknown_attr_transitive generate open docs FORCE

--- a/bdd/tests/configs/bgp_unknown_attr_transitive/z1-base.yaml
+++ b/bdd/tests/configs/bgp_unknown_attr_transitive/z1-base.yaml
@@ -1,0 +1,26 @@
+interface:
+- if-name: i1
+  ipv4:
+    address: 192.168.0.1/24
+router:
+  bgp:
+    global:
+      as: 65001
+      router-id: 192.168.0.1
+    timer:
+      adv-interval:
+        ibgp: 1
+        ebgp: 1
+    neighbor:
+    - remote-address: 192.168.0.2
+      afi-safi:
+      - name: ipv4
+        enabled: true
+      enabled: true
+      remote-as: 65002
+      timers:
+        connect-retry-time: 3
+    afi-safi:
+    - name: ipv4
+      network:
+      - prefix: 10.0.0.1/32

--- a/bdd/tests/configs/bgp_unknown_attr_transitive/z1-nontransitive.yaml
+++ b/bdd/tests/configs/bgp_unknown_attr_transitive/z1-nontransitive.yaml
@@ -1,0 +1,29 @@
+interface:
+- if-name: i1
+  ipv4:
+    address: 192.168.0.1/24
+router:
+  bgp:
+    global:
+      as: 65001
+      router-id: 192.168.0.1
+    timer:
+      adv-interval:
+        ibgp: 1
+        ebgp: 1
+    neighbor:
+    - remote-address: 192.168.0.2
+      afi-safi:
+      - name: ipv4
+        enabled: true
+      enabled: true
+      remote-as: 65002
+      # Debug knob: attach an Optional, non-Transitive (flags 0x80 = 128)
+      # unknown attribute, Type Code 251, value 0x1234.
+      attach-unknown-attribute: "251:128:1234"
+      timers:
+        connect-retry-time: 3
+    afi-safi:
+    - name: ipv4
+      network:
+      - prefix: 10.0.0.1/32

--- a/bdd/tests/configs/bgp_unknown_attr_transitive/z1-transitive.yaml
+++ b/bdd/tests/configs/bgp_unknown_attr_transitive/z1-transitive.yaml
@@ -1,0 +1,29 @@
+interface:
+- if-name: i1
+  ipv4:
+    address: 192.168.0.1/24
+router:
+  bgp:
+    global:
+      as: 65001
+      router-id: 192.168.0.1
+    timer:
+      adv-interval:
+        ibgp: 1
+        ebgp: 1
+    neighbor:
+    - remote-address: 192.168.0.2
+      afi-safi:
+      - name: ipv4
+        enabled: true
+      enabled: true
+      remote-as: 65002
+      # Debug knob: attach an Optional|Transitive (flags 0xC0 = 192)
+      # unknown attribute, Type Code 250, value 0xDEADBEEF.
+      attach-unknown-attribute: "250:192:deadbeef"
+      timers:
+        connect-retry-time: 3
+    afi-safi:
+    - name: ipv4
+      network:
+      - prefix: 10.0.0.1/32

--- a/bdd/tests/configs/bgp_unknown_attr_transitive/z2.yaml
+++ b/bdd/tests/configs/bgp_unknown_attr_transitive/z2.yaml
@@ -1,0 +1,33 @@
+interface:
+- if-name: i1
+  ipv4:
+    address: 192.168.0.2/24
+- if-name: i2
+  ipv4:
+    address: 192.168.1.2/24
+router:
+  bgp:
+    global:
+      as: 65002
+      router-id: 192.168.0.2
+    timer:
+      adv-interval:
+        ibgp: 1
+        ebgp: 1
+    neighbor:
+    - remote-address: 192.168.0.1
+      afi-safi:
+      - name: ipv4
+        enabled: true
+      enabled: true
+      remote-as: 65001
+      timers:
+        connect-retry-time: 3
+    - remote-address: 192.168.1.3
+      afi-safi:
+      - name: ipv4
+        enabled: true
+      enabled: true
+      remote-as: 65003
+      timers:
+        connect-retry-time: 3

--- a/bdd/tests/configs/bgp_unknown_attr_transitive/z3.yaml
+++ b/bdd/tests/configs/bgp_unknown_attr_transitive/z3.yaml
@@ -1,0 +1,22 @@
+interface:
+- if-name: i1
+  ipv4:
+    address: 192.168.1.3/24
+router:
+  bgp:
+    global:
+      as: 65003
+      router-id: 192.168.1.3
+    timer:
+      adv-interval:
+        ibgp: 1
+        ebgp: 1
+    neighbor:
+    - remote-address: 192.168.1.2
+      afi-safi:
+      - name: ipv4
+        enabled: true
+      enabled: true
+      remote-as: 65002
+      timers:
+        connect-retry-time: 3

--- a/bdd/tests/cucumber.rs
+++ b/bdd/tests/cucumber.rs
@@ -1196,6 +1196,129 @@ async fn verify_bgp_route_field(
     );
 }
 
+/// Fetch the `unknown_attributes` JSON array for a prefix from
+/// `show bgp -j`, panicking if the route itself is missing. Returns an
+/// empty Vec when the route has no unrecognized attributes (the field is
+/// `skip_serializing_if = "Vec::is_empty"`, so it is simply absent).
+async fn route_unknown_attrs(world: &World, namespace: &str, prefix: &str) -> Vec<Value> {
+    let scoped = world.ns(namespace);
+    let output = netns::exec_in_netns(&scoped, "vtyctl", &["show", "-j", "show bgp"])
+        .await
+        .expect("Failed to get BGP routes");
+    let routes: Value = serde_json::from_str(&output).expect("Failed to parse JSON output");
+    let route = routes
+        .as_array()
+        .and_then(|arr| {
+            arr.iter()
+                .find(|r| r.get("prefix").and_then(|p| p.as_str()) == Some(prefix))
+        })
+        .unwrap_or_else(|| {
+            panic!(
+                "BGP route {} not found in namespace {}, got: {}",
+                prefix, scoped, output
+            )
+        });
+    route
+        .get("unknown_attributes")
+        .and_then(|v| v.as_array())
+        .cloned()
+        .unwrap_or_default()
+}
+
+/// Assert the route carries an unrecognized attribute of the given Type
+/// Code (RFC 4271 §9 — an optional transitive unknown attribute that was
+/// accepted and retained).
+#[then(expr = "BGP route in {string} has {string} with unknown attribute type {int}")]
+async fn verify_unknown_attr_present(
+    world: &mut World,
+    namespace: String,
+    prefix: String,
+    type_code: u8,
+) {
+    let attrs = route_unknown_attrs(world, &namespace, &prefix).await;
+    let found = attrs
+        .iter()
+        .any(|a| a.get("type_code").and_then(|t| t.as_u64()) == Some(type_code as u64));
+    assert!(
+        found,
+        "route {} in {} should carry unknown attribute type {}, got: {:?}",
+        prefix,
+        world.ns(&namespace),
+        type_code,
+        attrs
+    );
+    println!(
+        "✓ route {} in {} carries unknown attribute type {}",
+        prefix,
+        world.ns(&namespace),
+        type_code
+    );
+}
+
+/// Assert the route carries an unrecognized attribute of the given Type
+/// Code AND that its Partial bit is set — proving a downstream speaker
+/// set Partial on receipt of an unrecognized transitive attribute
+/// (RFC 4271 §9).
+#[then(expr = "BGP route in {string} has {string} with partial unknown attribute type {int}")]
+async fn verify_unknown_attr_partial(
+    world: &mut World,
+    namespace: String,
+    prefix: String,
+    type_code: u8,
+) {
+    let attrs = route_unknown_attrs(world, &namespace, &prefix).await;
+    let entry = attrs
+        .iter()
+        .find(|a| a.get("type_code").and_then(|t| t.as_u64()) == Some(type_code as u64))
+        .unwrap_or_else(|| {
+            panic!(
+                "route {} in {} missing unknown attribute type {}, got: {:?}",
+                prefix,
+                world.ns(&namespace),
+                type_code,
+                attrs
+            )
+        });
+    let partial = entry
+        .get("partial")
+        .and_then(|p| p.as_bool())
+        .unwrap_or(false);
+    assert!(
+        partial,
+        "unknown attribute type {} on {} in {} must have Partial set, got: {}",
+        type_code,
+        prefix,
+        world.ns(&namespace),
+        entry
+    );
+    println!(
+        "✓ route {} in {} carries unknown attribute type {} with Partial set",
+        prefix,
+        world.ns(&namespace),
+        type_code
+    );
+}
+
+/// Assert the route carries NO unrecognized attributes — proving an
+/// optional non-transitive unknown attribute was dropped and not
+/// propagated (RFC 4271 §9).
+#[then(expr = "BGP route in {string} has {string} without unknown attributes")]
+async fn verify_no_unknown_attr(world: &mut World, namespace: String, prefix: String) {
+    let attrs = route_unknown_attrs(world, &namespace, &prefix).await;
+    assert!(
+        attrs.is_empty(),
+        "route {} in {} must carry no unknown attributes, got: {:?}",
+        prefix,
+        world.ns(&namespace),
+        attrs
+    );
+    println!(
+        "✓ route {} in {} carries no unknown attributes",
+        prefix,
+        world.ns(&namespace)
+    );
+}
+
 #[given("the test topology exists")]
 async fn test_topology_exists(world: &mut World) {
     let z1 = world.ns("z1");

--- a/bdd/tests/features/bgp_unknown_attr_transitive.feature
+++ b/bdd/tests/features/bgp_unknown_attr_transitive.feature
@@ -1,0 +1,101 @@
+@serial
+@bgp_unknown_attr_transitive
+Feature: BGP unrecognized path attribute handling (RFC 4271 §9)
+  As a network operator
+  I want zebra-rs to follow RFC 4271 §9 for unrecognized path attributes
+  So an optional transitive unknown attribute survives and propagates with
+  the Partial bit set, while an optional non-transitive one is dropped.
+
+  Test Topology (a line, all eBGP, distinct ASes):
+  ```
+   ┌─────────┐  192.168.0.0/24  ┌─────────┐  192.168.1.0/24  ┌─────────┐
+   │   z1    │ i1────────────i1 │   z2    │ i2────────────i1 │   z3    │
+   │ AS65001 │                  │ AS65002 │                  │ AS65003 │
+   │ .0.1    │                  │.0.2 .1.2│                  │ .1.3    │
+   └─────────┘                  └─────────┘                  └─────────┘
+  ```
+
+  z1 originates 10.0.0.1/32. The debug knob `attach-unknown-attribute`
+  on z1's session toward z2 stamps a synthetic unrecognized path
+  attribute onto that route. Neither z2 nor z3 recognize the Type Code,
+  so they exercise the receiver-side RFC 4271 §9 rules:
+
+    * Optional Transitive (flags 0xC0) → z2 accepts it, sets the Partial
+      bit, retains it, and re-advertises to z3 (which also keeps it,
+      Partial still set).
+    * Optional non-Transitive (flags 0x80) → z2 silently drops it; it
+      never reaches z3, and the 10.0.0.1/32 route itself is unaffected.
+
+  Config files:
+  - z1-base.yaml:          z1 originates 10.0.0.1/32, no attach.
+  - z1-transitive.yaml:    z1 attaches type 250, flags 0xC0, value deadbeef.
+  - z1-nontransitive.yaml: z1 attaches type 251, flags 0x80, value 1234.
+  - z2.yaml / z3.yaml:     plain transit / tail speakers.
+
+  Scenario: Setup line topology and establish all sessions
+    Given a clean test environment
+    When I create namespace "z1"
+    And I create namespace "z2"
+    And I create namespace "z3"
+    And I connect namespace "z1" interface "i1" to namespace "z2" interface "i1"
+    And I connect namespace "z2" interface "i2" to namespace "z3" interface "i1"
+    And I start zebra-rs in namespace "z1"
+    And I start zebra-rs in namespace "z2"
+    And I start zebra-rs in namespace "z3"
+    And I apply config "z1-base.yaml" to namespace "z1"
+    And I apply config "z2.yaml" to namespace "z2"
+    And I apply config "z3.yaml" to namespace "z3"
+    And I wait 20 seconds for BGP to operate
+    Then BGP session in "z1" to "192.168.0.2" should be "Established"
+    And BGP session in "z2" to "192.168.0.1" should be "Established"
+    And BGP session in "z2" to "192.168.1.3" should be "Established"
+    And BGP session in "z3" to "192.168.1.2" should be "Established"
+
+  Scenario: Baseline - the route propagates with no unknown attributes
+    Given the test topology exists
+    Then BGP route in "z2" has "10.0.0.1/32"
+    And BGP route in "z2" has "10.0.0.1/32" without unknown attributes
+    And BGP route in "z3" has "10.0.0.1/32"
+    And BGP route in "z3" has "10.0.0.1/32" without unknown attributes
+
+  Scenario: Optional transitive unknown attribute is retained, Partial set, and propagated
+    Given the test topology exists
+    When I apply config "z1-transitive.yaml" to namespace "z1"
+    And I run "clear bgp ipv4 neighbor 192.168.0.2" in namespace "z1"
+    And I wait 25 seconds for BGP to operate
+    Then BGP session in "z1" to "192.168.0.2" should be "Established"
+    # z2 received an unrecognized OPTIONAL TRANSITIVE attribute: it MUST
+    # accept it, set the Partial bit, and retain it for propagation.
+    And BGP route in "z2" has "10.0.0.1/32"
+    And BGP route in "z2" has "10.0.0.1/32" with unknown attribute type 250
+    And BGP route in "z2" has "10.0.0.1/32" with partial unknown attribute type 250
+    # z3 received it transitively from z2 - still present, Partial still set.
+    And BGP route in "z3" has "10.0.0.1/32"
+    And BGP route in "z3" has "10.0.0.1/32" with unknown attribute type 250
+    And BGP route in "z3" has "10.0.0.1/32" with partial unknown attribute type 250
+
+  Scenario: Optional non-transitive unknown attribute is dropped and not propagated
+    Given the test topology exists
+    When I apply config "z1-nontransitive.yaml" to namespace "z1"
+    And I run "clear bgp ipv4 neighbor 192.168.0.2" in namespace "z1"
+    And I wait 25 seconds for BGP to operate
+    Then BGP session in "z1" to "192.168.0.2" should be "Established"
+    # z2 received an unrecognized OPTIONAL NON-TRANSITIVE attribute: it
+    # MUST quietly ignore it. The route survives, the attribute does not.
+    And BGP route in "z2" has "10.0.0.1/32"
+    And BGP route in "z2" has "10.0.0.1/32" without unknown attributes
+    # ... and it never reaches z3.
+    And BGP route in "z3" has "10.0.0.1/32"
+    And BGP route in "z3" has "10.0.0.1/32" without unknown attributes
+
+  # Pure P2P topology (no bridge): deleting each namespace destroys the veth
+  # pair ends it holds, so only the daemons and namespaces need teardown.
+  Scenario: Teardown topology
+    Given the test topology exists
+    When I stop zebra-rs in namespace "z1"
+    And I stop zebra-rs in namespace "z2"
+    And I stop zebra-rs in namespace "z3"
+    And I delete namespace "z1"
+    And I delete namespace "z2"
+    And I delete namespace "z3"
+    Then the test environment should be clean

--- a/crates/bgp-packet/src/attrs/attr.rs
+++ b/crates/bgp-packet/src/attrs/attr.rs
@@ -359,7 +359,36 @@ pub fn parse_bgp_update_attribute(
     while !remaining.is_empty() {
         // Parse the framing first so a Value-parse error stays recoverable:
         // `new_remaining` already points at the next attribute.
-        let (new_remaining, attr_type, _flags, attr_payload) = Attr::parse_attr_header(remaining)?;
+        let (new_remaining, attr_type, flags, attr_payload) = Attr::parse_attr_header(remaining)?;
+
+        // Unrecognized attribute Type Code — classify by the Attribute
+        // Flags octet per RFC 4271 §6.3 / §9 (and RFC 7606):
+        //   * Optional bit clear  → unrecognized WELL-KNOWN attribute:
+        //     reset the session with a NOTIFICATION (subcode 2).
+        //   * Optional + Transitive → retain, set the Partial bit, and
+        //     re-advertise to other peers.
+        //   * Optional, non-Transitive → quietly ignore (not propagated).
+        if let AttrType::Unknown(type_code) = attr_type {
+            if !flags.contains(AttributeFlags::OPTIONAL) {
+                // Capture the full attribute TLV (flags..value) for the
+                // NOTIFICATION Data field; `new_remaining` is positioned
+                // just past this attribute.
+                let consumed = remaining.len() - new_remaining.len();
+                return Err(BgpParseError::UnrecognizedWellknownAttribute {
+                    type_code,
+                    attr: remaining[..consumed].to_vec(),
+                });
+            }
+            if flags.contains(AttributeFlags::TRANSITIVE) {
+                let mut unknown = UnknownAttr::new(flags.bits(), type_code, attr_payload.to_vec());
+                unknown.set_partial();
+                bgp_attr.unknown.push(unknown);
+            }
+            // Optional non-transitive: drop silently.
+            remaining = new_remaining;
+            continue;
+        }
+
         let attr = match Attr::parse_attr_value(attr_type, attr_payload, as4, &opt) {
             Ok(attr) => attr,
             Err(e) => {
@@ -598,5 +627,111 @@ mod tests {
             }
             other => panic!("Flowspec MP_REACH must surface as mp_update, got {other:?}"),
         }
+    }
+
+    // ---- RFC 4271 §9 unrecognized attribute handling -----------------
+
+    use crate::{AttributeFlags, UnknownAttr};
+    use bytes::BytesMut;
+
+    /// ORIGIN = IGP, used as a sentinel so we can prove the well-known
+    /// attributes survive whatever the unknown attribute does.
+    const ORIGIN_IGP: [u8; 4] = [0x40, 0x01, 0x01, 0x00];
+
+    /// Unrecognized OPTIONAL TRANSITIVE attribute → accepted, the Partial
+    /// bit is set, and it is retained for propagation (RFC 4271 §9). A
+    /// re-emit reproduces the attribute with Partial set.
+    #[test]
+    fn unknown_optional_transitive_is_retained_with_partial() {
+        let mut block = ORIGIN_IGP.to_vec();
+        // flags 0xC0 = OPTIONAL|TRANSITIVE, type 250, len 2, value DE AD
+        block.extend_from_slice(&[0xC0, 0xFA, 0x02, 0xDE, 0xAD]);
+        let len = block.len() as u16;
+
+        let (_, bgp_attr, _mp_u, _mp_w, taw) =
+            parse_bgp_update_attribute(&block, len, false, None).expect("must parse");
+        assert!(!taw, "unknown transitive must not treat-as-withdraw");
+        let bgp_attr = bgp_attr.expect("attrs parsed");
+        assert!(bgp_attr.origin.is_some(), "ORIGIN must survive");
+        assert_eq!(bgp_attr.unknown.len(), 1, "transitive unknown retained");
+
+        let u = &bgp_attr.unknown[0];
+        assert_eq!(u.type_code, 250);
+        assert_eq!(u.value, vec![0xDE, 0xAD]);
+        assert!(u.is_optional() && u.is_transitive());
+        assert!(u.is_partial(), "Partial bit must be set on receive (§9)");
+
+        // Re-emit just the unknown attribute and confirm the Partial bit
+        // is on the wire (0xE0 = OPTIONAL|TRANSITIVE|PARTIAL).
+        let mut buf = BytesMut::new();
+        u.attr_emit(&mut buf);
+        assert_eq!(&buf[..], &[0xE0, 0xFA, 0x02, 0xDE, 0xAD]);
+    }
+
+    /// Unrecognized OPTIONAL NON-TRANSITIVE attribute → quietly ignored,
+    /// never stored, never propagated (RFC 4271 §9).
+    #[test]
+    fn unknown_optional_nontransitive_is_dropped() {
+        let mut block = ORIGIN_IGP.to_vec();
+        // flags 0x80 = OPTIONAL only, type 251, len 1, value 07
+        block.extend_from_slice(&[0x80, 0xFB, 0x01, 0x07]);
+        let len = block.len() as u16;
+
+        let (_, bgp_attr, _mp_u, _mp_w, taw) =
+            parse_bgp_update_attribute(&block, len, false, None).expect("must parse");
+        assert!(!taw);
+        let bgp_attr = bgp_attr.expect("attrs parsed");
+        assert!(bgp_attr.origin.is_some(), "ORIGIN must survive");
+        assert!(
+            bgp_attr.unknown.is_empty(),
+            "non-transitive unknown must be dropped"
+        );
+    }
+
+    /// Unrecognized WELL-KNOWN attribute (Optional bit clear) → session
+    /// reset error carrying the offending attribute (RFC 4271 §6.3).
+    #[test]
+    fn unrecognized_wellknown_attribute_is_an_error() {
+        let mut block = ORIGIN_IGP.to_vec();
+        // flags 0x40 = TRANSITIVE, Optional CLEAR → well-known. type 252.
+        block.extend_from_slice(&[0x40, 0xFC, 0x01, 0x09]);
+        let len = block.len() as u16;
+
+        let err = parse_bgp_update_attribute(&block, len, false, None)
+            .expect_err("unrecognized well-known attribute must error");
+        match err {
+            BgpParseError::UnrecognizedWellknownAttribute { type_code, attr } => {
+                assert_eq!(type_code, 252);
+                // Full TLV: flags, type, length, value.
+                assert_eq!(attr, vec![0x40, 0xFC, 0x01, 0x09]);
+            }
+            other => panic!("expected UnrecognizedWellknownAttribute, got {other:?}"),
+        }
+    }
+
+    /// A whole-`BgpAttr` round-trip: an unknown transitive attribute set
+    /// on `BgpAttr` is emitted by `attr_emit` and parses back identically
+    /// (Partial already set), proving propagation is bit-faithful.
+    #[test]
+    fn bgp_attr_roundtrips_unknown_transitive() {
+        let mut attr = crate::BgpAttr::new();
+        let mut u = UnknownAttr::new(
+            (AttributeFlags::OPTIONAL | AttributeFlags::TRANSITIVE).bits(),
+            240,
+            vec![1, 2, 3, 4],
+        );
+        u.set_partial();
+        attr.unknown.push(u);
+
+        let mut buf = BytesMut::new();
+        attr.attr_emit(&mut buf);
+        let len = buf.len() as u16;
+        let (_, parsed, _, _, _) =
+            parse_bgp_update_attribute(&buf, len, true, None).expect("re-parse");
+        let parsed = parsed.unwrap();
+        assert_eq!(parsed.unknown.len(), 1);
+        assert_eq!(parsed.unknown[0].type_code, 240);
+        assert_eq!(parsed.unknown[0].value, vec![1, 2, 3, 4]);
+        assert!(parsed.unknown[0].is_partial());
     }
 }

--- a/crates/bgp-packet/src/attrs/mod.rs
+++ b/crates/bgp-packet/src/attrs/mod.rs
@@ -4,6 +4,12 @@ pub use attr::*;
 pub mod flags;
 pub use flags::*;
 
+// Non-`pub` module: the crate root globs `attrs::*`, and a `pub mod
+// unknown` here would collide with the existing `caps::unknown` module
+// name. Re-export the contents (UnknownAttr) without the module name.
+mod unknown;
+pub use unknown::*;
+
 pub mod origin;
 pub use origin::*;
 

--- a/crates/bgp-packet/src/attrs/unknown.rs
+++ b/crates/bgp-packet/src/attrs/unknown.rs
@@ -1,0 +1,103 @@
+use std::fmt;
+
+use bytes::{BufMut, BytesMut};
+
+use crate::AttributeFlags;
+
+/// An optional path attribute whose Type Code this implementation does
+/// not recognize (RFC 4271 §5, §9). The flags, type code, and raw value
+/// bytes are retained verbatim so an unrecognized **transitive** optional
+/// attribute can be re-advertised to other peers (with the Partial bit
+/// set). Unrecognized **non-transitive** optional attributes are never
+/// stored here — they are dropped at parse time per RFC 4271 §9.
+///
+/// `flags` is the original Attribute Flags octet as received, except that
+/// the Partial bit (0x20) is set when the attribute is stored, matching
+/// RFC 4271 §9: "the Partial bit ... is set to 1, and the attribute is
+/// retained for propagation to other BGP speakers." The Extended-Length
+/// bit is recomputed from `value.len()` at emit time and is therefore not
+/// authoritative in `flags`.
+#[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct UnknownAttr {
+    /// Attribute Flags octet (Optional / Transitive / Partial / Extended).
+    pub flags: u8,
+    /// Attribute Type Code.
+    pub type_code: u8,
+    /// Raw attribute Value bytes (Length octet(s) excluded).
+    pub value: Vec<u8>,
+}
+
+impl UnknownAttr {
+    pub fn new(flags: u8, type_code: u8, value: Vec<u8>) -> Self {
+        Self {
+            flags,
+            type_code,
+            value,
+        }
+    }
+
+    fn flag_set(&self) -> AttributeFlags {
+        AttributeFlags::from_bits_truncate(self.flags)
+    }
+
+    pub fn is_optional(&self) -> bool {
+        self.flag_set().contains(AttributeFlags::OPTIONAL)
+    }
+
+    pub fn is_transitive(&self) -> bool {
+        self.flag_set().contains(AttributeFlags::TRANSITIVE)
+    }
+
+    pub fn is_partial(&self) -> bool {
+        self.flag_set().contains(AttributeFlags::PARTIAL)
+    }
+
+    /// Mark the attribute Partial (RFC 4271 §9). Called when an
+    /// unrecognized transitive optional attribute is retained on receive.
+    pub fn set_partial(&mut self) {
+        self.flags |= AttributeFlags::PARTIAL.bits();
+    }
+
+    /// Emit the attribute verbatim — flags, type, length, value — for
+    /// propagation. The Extended-Length bit is (re)derived from the value
+    /// length so the on-wire length field width always matches; the other
+    /// flag bits (Optional / Transitive / Partial) are written as stored.
+    pub fn attr_emit(&self, buf: &mut BytesMut) {
+        let len = self.value.len();
+        let extended = len > 255;
+        let mut flags = self.flags;
+        if extended {
+            flags |= AttributeFlags::EXTENDED.bits();
+        } else {
+            flags &= !AttributeFlags::EXTENDED.bits();
+        }
+        buf.put_u8(flags);
+        buf.put_u8(self.type_code);
+        if extended {
+            buf.put_u16(len as u16);
+        } else {
+            buf.put_u8(len as u8);
+        }
+        buf.put_slice(&self.value);
+    }
+}
+
+impl fmt::Display for UnknownAttr {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let value: String = self.value.iter().map(|b| format!("{b:02x}")).collect();
+        write!(
+            f,
+            "type {} flags {} [{}] value 0x{}",
+            self.type_code,
+            self.flags,
+            self.flag_set(),
+            if value.is_empty() { "" } else { &value }
+        )
+    }
+}
+
+impl fmt::Debug for UnknownAttr {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "UnknownAttr {{ {} }}", self)
+    }
+}

--- a/crates/bgp-packet/src/bgp_attr.rs
+++ b/crates/bgp-packet/src/bgp_attr.rs
@@ -5,7 +5,7 @@ use bytes::BytesMut;
 use crate::{
     Aggregator, Aigp, As4Path, AtomicAggregate, AttrEmitter, BgpLsAttr, BgpNexthop, ClusterList,
     Color, Community, ExtCommunity, LargeCommunity, LocalPref, Med, NexthopAttr, Origin,
-    OriginatorId, PmsiTunnel, PrefixSid, PrefixSidTlv, TunnelEncap,
+    OriginatorId, PmsiTunnel, PrefixSid, PrefixSidTlv, TunnelEncap, UnknownAttr,
 };
 
 // BGP Attribute for quick access to each attribute. This would be used for
@@ -52,7 +52,11 @@ pub struct BgpAttr {
     pub tunnel_encap: Option<TunnelEncap>,
     /// BGP-LS Attribute (path attribute type 29, RFC 9552).
     pub bgp_ls: Option<BgpLsAttr>,
-    // TODO: Unknown Attributes.
+    /// Unrecognized **optional transitive** path attributes (RFC 4271
+    /// §9). Retained verbatim so they can be re-advertised to other peers
+    /// with the Partial bit set. Unrecognized optional non-transitive
+    /// attributes are dropped at parse time and never land here.
+    pub unknown: Vec<UnknownAttr>,
 }
 
 impl BgpAttr {
@@ -115,6 +119,11 @@ impl BgpAttr {
             v.attr_emit(buf);
         }
         if let Some(v) = &self.tunnel_encap {
+            v.attr_emit(buf);
+        }
+        // Unrecognized optional transitive attributes (RFC 4271 §9):
+        // re-advertised verbatim with the Partial bit (set when stored).
+        for v in &self.unknown {
             v.attr_emit(buf);
         }
     }
@@ -221,6 +230,9 @@ impl fmt::Display for BgpAttr {
         }
         if let Some(v) = &self.tunnel_encap {
             writeln!(f, " TunnelEncap: {}", v)?;
+        }
+        for v in &self.unknown {
+            writeln!(f, " Unknown: {}", v)?;
         }
         // Nexthop
         if let Some(v) = &self.nexthop {

--- a/crates/bgp-packet/src/error.rs
+++ b/crates/bgp-packet/src/error.rs
@@ -27,6 +27,15 @@ pub enum BgpParseError {
     #[error("Unknown attribute type: {attr_type}")]
     UnknownAttributeType { attr_type: u8 },
 
+    /// RFC 4271 §6.3: an attribute whose Type Code is unrecognized AND
+    /// whose Optional bit is clear (i.e. an unrecognized *well-known*
+    /// attribute) is an error. The session must be reset with a
+    /// NOTIFICATION (Update Message Error, subcode 2). `attr` carries the
+    /// full offending attribute TLV (flags, type, length, value) for the
+    /// NOTIFICATION Data field.
+    #[error("Unrecognized well-known attribute: type {type_code}")]
+    UnrecognizedWellknownAttribute { type_code: u8, attr: Vec<u8> },
+
     #[error("Header length is smaller than expected: got {actual}, expected {expected}")]
     InvalidHeaderLength { expected: usize, actual: usize },
 }

--- a/crates/bgp-packet/src/notification.rs
+++ b/crates/bgp-packet/src/notification.rs
@@ -247,6 +247,25 @@ impl From<u8> for UpdateError {
     }
 }
 
+impl From<UpdateError> for u8 {
+    fn from(sub_code: UpdateError) -> Self {
+        use UpdateError::*;
+        match sub_code {
+            MalformedAttributeList => 1,
+            UnrecognizedWellknownAttribute => 2,
+            MissingWellknownAttribute => 3,
+            AttributeFlagsError => 4,
+            AttributeLengthError => 5,
+            InvalidOriginAttribute => 6,
+            InvalidNexthopAttribute => 8,
+            OptionalAttributeError => 9,
+            InvalidNetworkField => 10,
+            MalformedAspath => 11,
+            Unknown(v) => v,
+        }
+    }
+}
+
 fn sub_update_error_str(sub_code: UpdateError) -> String {
     use UpdateError::*;
     match sub_code {

--- a/zebra-rs/src/bgp/config.rs
+++ b/zebra-rs/src/bgp/config.rs
@@ -1037,6 +1037,52 @@ pub(super) fn apply_enforce_first_as(peer: &mut Peer, want: bool) -> bool {
     false
 }
 
+/// Parse the compact `attach-unknown-attribute` spec
+/// `<type>:<flags>:<value-hex>` into a [`UnknownAttr`].
+///
+/// * `<type>`  — Attribute Type Code, decimal 0–255.
+/// * `<flags>` — Attribute Flags octet, decimal 0–255 (e.g. 192 =
+///   Optional|Transitive, 128 = Optional only). The Extended-Length bit
+///   is ignored here and re-derived from the value length at emit time.
+/// * `<value-hex>` — attribute Value as an even-length hex string; may be
+///   empty for a zero-length attribute (`250:192:`).
+///
+/// Returns `None` on any malformed field so the config callback rejects
+/// the statement rather than attaching a half-built attribute.
+fn parse_attach_unknown_attr(spec: &str) -> Option<UnknownAttr> {
+    let mut parts = spec.splitn(3, ':');
+    let type_code: u8 = parts.next()?.trim().parse().ok()?;
+    let flags: u8 = parts.next()?.trim().parse().ok()?;
+    let value_hex = parts.next()?.trim();
+    if value_hex.len() % 2 != 0 {
+        return None;
+    }
+    let mut value = Vec::with_capacity(value_hex.len() / 2);
+    for i in (0..value_hex.len()).step_by(2) {
+        value.push(u8::from_str_radix(&value_hex[i..i + 2], 16).ok()?);
+    }
+    Some(UnknownAttr::new(flags, type_code, value))
+}
+
+/// `set router bgp neighbor X attach-unknown-attribute "<type>:<flags>:<hex>"`
+/// (zebra-bgp-unknown-attr.yang). Debug/test knob: stamp a synthetic
+/// unrecognized path attribute onto every IPv4-unicast route advertised
+/// to this neighbor so a downstream speaker's RFC 4271 §9 handling can be
+/// driven from config. `delete` clears it.
+fn config_attach_unknown_attribute(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Option<()> {
+    let addr = args.addr()?;
+    if op.is_set() {
+        let spec = args.string()?;
+        let attr = parse_attach_unknown_attr(&spec)?;
+        let peer = bgp.peers.get_mut(&addr)?;
+        peer.config.attach_unknown_attr = Some(attr);
+    } else {
+        let peer = bgp.peers.get_mut(&addr)?;
+        peer.config.attach_unknown_attr = None;
+    }
+    Some(())
+}
+
 /// Resolve the `local-as` entry the callbacks below may write to,
 /// enforcing the two commit-time rules from zebra-bgp-local-as.yang:
 /// the substitute must differ from the router's global AS (FRR's
@@ -4540,6 +4586,11 @@ impl Bgp {
         self.callback_peer("/enforce-first-as", config_enforce_first_as);
         self.callback_peer("/pic-retention", config_pic_retention);
 
+        // Debug/test knob (zebra-bgp-unknown-attr.yang): attach a synthetic
+        // unrecognized path attribute to routes advertised to this
+        // neighbor — exercises RFC 4271 §9 receiver handling end to end.
+        self.callback_peer("/attach-unknown-attribute", config_attach_unknown_attribute);
+
         // Per-neighbor local-as (zebra-bgp-local-as.yang): a
         // single-entry list keyed by the substitute AS number, with
         // three independent boolean modifier leaves.
@@ -5248,6 +5299,67 @@ mod bfd_wiring_tests {
         config_enforce_first_as(&mut bgp, arg_words(&["10.0.0.2"]), ConfigOp::Set).unwrap();
         config_enforce_first_as(&mut bgp, arg_words(&["10.0.0.2"]), ConfigOp::Delete).unwrap();
         assert!(!peer_enforce_first_as(&bgp, "10.0.0.2"));
+    }
+
+    fn peer_attach_unknown(bgp: &Bgp, addr: &str) -> Option<UnknownAttr> {
+        bgp.peers
+            .get(&addr.parse().unwrap())
+            .unwrap()
+            .config
+            .attach_unknown_attr
+            .clone()
+    }
+
+    /// The `attach-unknown-attribute` debug knob parses the compact
+    /// `<type>:<flags>:<value-hex>` spec onto the peer; delete clears it.
+    #[tokio::test]
+    async fn attach_unknown_attr_set_and_delete() {
+        let (mut bgp, _rx) = fresh_bgp_with_bfd();
+        config_peer(&mut bgp, arg_words(&["10.0.0.2"]), ConfigOp::Set).unwrap();
+        assert!(peer_attach_unknown(&bgp, "10.0.0.2").is_none());
+
+        config_attach_unknown_attribute(
+            &mut bgp,
+            arg_words(&["10.0.0.2", "250:192:deadbeef"]),
+            ConfigOp::Set,
+        )
+        .unwrap();
+        let u = peer_attach_unknown(&bgp, "10.0.0.2").expect("attr set");
+        assert_eq!(u.type_code, 250);
+        assert_eq!(u.flags, 192);
+        assert!(u.is_optional() && u.is_transitive());
+        assert_eq!(u.value, vec![0xde, 0xad, 0xbe, 0xef]);
+
+        config_attach_unknown_attribute(&mut bgp, arg_words(&["10.0.0.2"]), ConfigOp::Delete)
+            .unwrap();
+        assert!(peer_attach_unknown(&bgp, "10.0.0.2").is_none());
+    }
+
+    /// Spec parsing: empty value is a zero-length attribute; odd-length
+    /// hex and non-numeric fields are rejected.
+    #[test]
+    fn attach_unknown_attr_spec_parsing() {
+        let z = parse_attach_unknown_attr("251:128:").expect("empty value ok");
+        assert_eq!(z.type_code, 251);
+        assert_eq!(z.flags, 128);
+        assert!(z.value.is_empty());
+
+        assert!(
+            parse_attach_unknown_attr("250:192:dea").is_none(),
+            "odd hex"
+        );
+        assert!(
+            parse_attach_unknown_attr("999:0:00").is_none(),
+            "type > 255"
+        );
+        assert!(
+            parse_attach_unknown_attr("250:xx:00").is_none(),
+            "bad flags"
+        );
+        assert!(
+            parse_attach_unknown_attr("250:192").is_none(),
+            "missing value"
+        );
     }
 }
 

--- a/zebra-rs/src/bgp/peer.rs
+++ b/zebra-rs/src/bgp/peer.rs
@@ -141,6 +141,12 @@ pub enum Event {
     NotifMsg(ConnId, NotificationPacket), // 25
     KeepAliveMsg(ConnId),                 // 26
     UpdateMsg(UpdatePacket),              // 27
+    /// A received UPDATE failed validation with an error that RFC 4271
+    /// §6.3 maps to a NOTIFICATION + session reset (today: an
+    /// unrecognized well-known attribute). Carries the NOTIFICATION code,
+    /// subcode, and Data field. The reader emits it before the
+    /// connection drops; the FSM sends the NOTIFICATION and goes Idle.
+    UpdateError(NotifyCode, u8, Vec<u8>),
     // RFC 2918 Route Refresh receive. Carries the AFI/SAFI from the
     // wire (raw u16/u8) so unknown-AF refreshes still dispatch
     // through the FSM rather than tearing the session down.
@@ -531,6 +537,13 @@ pub struct PeerConfig {
     /// the session under the router's global AS; `Some` presents the
     /// substitute AS to this neighbor (see [`LocalAs`]).
     pub local_as: Option<LocalAs>,
+    /// Debug/test knob (zebra-bgp-unknown-attr.yang): attach a synthetic
+    /// unrecognized path attribute to every IPv4-unicast route advertised
+    /// to this neighbor. Lets a test originate an unknown attribute with a
+    /// chosen Type Code and Attribute Flags so the receiver's RFC 4271 §9
+    /// handling (transitive-retain + Partial / non-transitive-drop /
+    /// well-known NOTIFICATION) can be exercised end to end. `None` = off.
+    pub attach_unknown_attr: Option<UnknownAttr>,
 }
 
 impl Default for PeerConfig {
@@ -560,6 +573,7 @@ impl Default for PeerConfig {
             remove_private_as: None,
             enforce_first_as: false,
             local_as: None,
+            attach_unknown_attr: None,
         }
     }
 }
@@ -1324,6 +1338,7 @@ impl Peer {
             packet_tx: self.packet_tx.clone(),
             egress_depth: self.egress_depth.clone(),
             extended_message: self.opt.extended_message,
+            attach_unknown_attr: self.config.attach_unknown_attr.clone(),
         }
     }
 
@@ -1571,6 +1586,10 @@ pub fn fsm_next_state(peer: &mut Peer, event: Event) -> (State, FsmEffect) {
             timer::refresh_hold_timer(peer);
             (State::Established, FsmEffect::RouteUpdate(packet))
         }
+        Event::UpdateError(code, sub_code, data) => (
+            fsm_update_error(peer, code, sub_code, data),
+            FsmEffect::None,
+        ),
         Event::RouteRefreshMsg(afi, safi) => {
             peer.counter[BgpType::RouteRefresh as usize].rcvd += 1;
             timer::refresh_hold_timer(peer);
@@ -2129,6 +2148,16 @@ pub fn fsm_holdtimer_expires(peer: &mut Peer) -> State {
     State::Idle
 }
 
+/// RFC 4271 §6.3: a fatal UPDATE error (today, an unrecognized
+/// well-known attribute) resets the session with a NOTIFICATION. Mirrors
+/// [`fsm_holdtimer_expires`]: queue the NOTIFICATION on the writer, then
+/// go Idle so the Established→Idle teardown drains it onto the wire (the
+/// writer is detached, not aborted) and cleans the Adj-RIBs.
+pub fn fsm_update_error(peer: &mut Peer, code: NotifyCode, sub_code: u8, data: Vec<u8>) -> State {
+    peer_send_notification(peer, code, sub_code, data);
+    State::Idle
+}
+
 pub fn fsm_idle_hold_timer_expires(peer: &mut Peer) -> State {
     peer.timer.idle_hold_timer = None;
     peer.task.connect = Some(peer_start_connection(peer));
@@ -2268,7 +2297,26 @@ pub async fn peer_packet_parse(
             }
             Ok(())
         }
-        Err(e) => Err(e.to_string()),
+        Err(e) => {
+            // RFC 4271 §6.3: an unrecognized well-known attribute must be
+            // answered with a NOTIFICATION (Update Message Error, subcode
+            // 2) before the session drops. The reader has no `&mut Peer`,
+            // so hand the FSM the code/subcode/Data via an event; the
+            // subsequent ConnFail is a no-op once the FSM has gone Idle.
+            if let BgpParseError::UnrecognizedWellknownAttribute { attr, .. } = &e {
+                let _ = tx
+                    .send(Message::Event(
+                        ident,
+                        Event::UpdateError(
+                            NotifyCode::UpdateMsgError,
+                            UpdateError::UnrecognizedWellknownAttribute.into(),
+                            attr.clone(),
+                        ),
+                    ))
+                    .await;
+            }
+            Err(e.to_string())
+        }
     }
 }
 

--- a/zebra-rs/src/bgp/route.rs
+++ b/zebra-rs/src/bgp/route.rs
@@ -194,6 +194,11 @@ pub struct SyncCtx {
     pub packet_tx: Option<tokio::sync::mpsc::UnboundedSender<BytesMut>>,
     pub egress_depth: Arc<std::sync::atomic::AtomicUsize>,
     pub extended_message: bool,
+    /// Debug/test knob: a synthetic unrecognized path attribute to attach
+    /// to every IPv4-unicast route advertised on this session (RFC 4271
+    /// §9 origination test). `None` = off. See
+    /// [`super::peer::PeerConfig::attach_unknown_attr`].
+    pub attach_unknown_attr: Option<bgp_packet::UnknownAttr>,
 }
 
 impl SyncCtx {
@@ -283,6 +288,7 @@ impl SyncCtx {
             packet_tx: None,
             egress_depth: Arc::new(std::sync::atomic::AtomicUsize::new(0)),
             extended_message: false,
+            attach_unknown_attr: None,
         }
     }
 }
@@ -10331,6 +10337,19 @@ pub fn route_update_ipv4(
     // the iBGP stamping/local-pref-default above; see `strip_ibgp_only_attrs`.
     if ctx.peer_type.is_ebgp() {
         strip_ibgp_only_attrs(&mut attrs);
+    }
+
+    // Debug/test knob: attach a synthetic unrecognized path attribute on
+    // egress (RFC 4271 §9 origination test). Done last so the configured
+    // Type Code / Flags reach the wire verbatim — the originator decides
+    // the Partial bit, downstream speakers that don't recognize it set
+    // Partial themselves on receive. Skip if the route already carries an
+    // unknown attribute of the same Type Code (a received one being
+    // re-advertised) so we never emit a duplicate.
+    if let Some(extra) = &ctx.attach_unknown_attr
+        && !attrs.unknown.iter().any(|u| u.type_code == extra.type_code)
+    {
+        attrs.unknown.push(extra.clone());
     }
 
     Some((nlri, attrs))

--- a/zebra-rs/src/bgp/show.rs
+++ b/zebra-rs/src/bgp/show.rs
@@ -501,6 +501,40 @@ struct BgpRouteJson {
     as_path: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     origin: Option<String>,
+    /// Unrecognized optional transitive path attributes (RFC 4271 §9)
+    /// carried verbatim on this route. Empty for routes without any.
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    unknown_attributes: Vec<UnknownAttrJson>,
+}
+
+/// One unrecognized path attribute (RFC 4271 §9) as rendered for
+/// `show bgp -j`. The boolean flags decode the Attribute Flags octet so
+/// tests/operators can see the Optional / Transitive / Partial state
+/// directly; `value` is the attribute Value bytes in lowercase hex.
+#[derive(Serialize)]
+struct UnknownAttrJson {
+    type_code: u8,
+    flags: u8,
+    optional: bool,
+    transitive: bool,
+    partial: bool,
+    value: String,
+}
+
+/// Render the unrecognized optional transitive attributes retained on a
+/// route into their JSON rows.
+fn show_unknown_attrs(attr: &BgpAttr) -> Vec<UnknownAttrJson> {
+    attr.unknown
+        .iter()
+        .map(|u| UnknownAttrJson {
+            type_code: u.type_code,
+            flags: u.flags,
+            optional: u.is_optional(),
+            transitive: u.is_transitive(),
+            partial: u.is_partial(),
+            value: u.value.iter().map(|b| format!("{b:02x}")).collect(),
+        })
+        .collect()
 }
 
 /// Convert one Loc-RIB entry to its `BgpRouteJson` row. Shared by the
@@ -525,6 +559,7 @@ fn bgp_route_json(prefix: String, rib: &BgpRib) -> BgpRouteJson {
         weight: rib.weight,
         as_path: (!aspath_str.is_empty()).then_some(aspath_str),
         origin: (!origin_str.is_empty()).then_some(origin_str),
+        unknown_attributes: show_unknown_attrs(&rib.attr),
     }
 }
 
@@ -793,6 +828,7 @@ where
                     } else {
                         Some(origin_str)
                     },
+                    unknown_attributes: show_unknown_attrs(&rib.attr),
                 });
             }
         }
@@ -1949,6 +1985,7 @@ pub(super) fn show_adj_rib_routes<P: std::fmt::Display>(
                     } else {
                         Some(origin_str)
                     },
+                    unknown_attributes: show_unknown_attrs(&rib.attr),
                 });
             }
         }

--- a/zebra-rs/src/bgp/update_group.rs
+++ b/zebra-rs/src/bgp/update_group.rs
@@ -27,7 +27,7 @@ use std::time::Instant;
 
 use bgp_packet::{
     Afi, AfiSafi, BgpAttr, BgpNexthop, CapExtendedNextHop, Ipv4MpReachNextHop, Ipv4Nlri, Ipv6Nlri,
-    MpReachAttr, Safi, UpdatePacket,
+    MpReachAttr, Safi, UnknownAttr, UpdatePacket,
 };
 use tokio::sync::mpsc;
 
@@ -40,7 +40,7 @@ use crate::context::Timer;
 
 /// Bumped whenever a new field is added to `UpdateGroupSig`. Surfaced
 /// in `show bgp update-group` so a stale view is detectable.
-pub const SIGNATURE_VERSION: u32 = 4;
+pub const SIGNATURE_VERSION: u32 = 5;
 
 /// Address families the grouping logic considers — every family whose
 /// advertise pipeline consults `peer.update_group_id`. IPv6 unicast
@@ -163,6 +163,12 @@ pub struct UpdateGroupSig {
     /// design note's Model B). The `generation` makes a script hot-reload
     /// bump the signature → regroup + re-encode.
     pub egress_script: Option<EgressScriptKey>,
+    /// Debug/test knob: a synthetic unrecognized attribute attached on
+    /// egress (zebra-bgp-unknown-attr.yang). It changes the encoded
+    /// UPDATE bytes for this peer, so two peers attaching different
+    /// attributes (or only one attaching) must not share canonical
+    /// bytes — fold it into the key. `None` when off (the common case).
+    pub attach_unknown_attr: Option<UnknownAttr>,
     pub signature_version: u32,
 }
 
@@ -396,6 +402,10 @@ pub fn signature_of(peer: &Peer, afi: Afi, safi: Safi) -> Option<UpdateGroupSig>
         // the field is forward-compatible for the day it lands.
         multiple_labels: false,
         egress_script: egress_script_key(peer, afi, safi),
+        // The egress attach knob (debug/test) stamps an extra attribute
+        // onto every advertised route, so peers with different attach
+        // specs encode different bytes and must shard the group.
+        attach_unknown_attr: peer.config.attach_unknown_attr.clone(),
         signature_version: SIGNATURE_VERSION,
     })
 }
@@ -1368,6 +1378,7 @@ mod tests {
             extended_next_hop: false,
             multiple_labels: false,
             egress_script: None,
+            attach_unknown_attr: None,
             signature_version: SIGNATURE_VERSION,
         }
     }
@@ -1505,6 +1516,16 @@ mod tests {
         let mut a = base.clone();
         a.multiple_labels = true;
         assert_ne!(base, a);
+
+        // The egress attach knob (debug/test) appends an attribute to the
+        // encoded UPDATE, so two peers attaching different attributes —
+        // or only one attaching — must shard the group.
+        let mut a = base.clone();
+        a.attach_unknown_attr = Some(UnknownAttr::new(0xC0, 250, vec![0xde, 0xad]));
+        assert_ne!(base, a);
+        let mut b = a.clone();
+        b.attach_unknown_attr = Some(UnknownAttr::new(0xC0, 251, vec![0xde, 0xad]));
+        assert_ne!(a, b);
     }
 
     #[test]

--- a/zebra-rs/src/config/manager.rs
+++ b/zebra-rs/src/config/manager.rs
@@ -1555,6 +1555,37 @@ mod yang_load_tests {
         }
     }
 
+    /// Regression guard for the per-neighbor `attach-unknown-attribute`
+    /// debug knob (zebra-bgp-unknown-attr.yang). The string-valued leaf —
+    /// whose `<type>:<flags>:<value-hex>` value contains colons — must
+    /// parse as a settable path on the neighbor (the `set` subtree is what
+    /// `parse()` resolves here; the `delete` subtree, like every other
+    /// per-neighbor leaf, is exercised by the runtime diff engine, not by
+    /// this harness). Pins the augment + leaf so a broken schema is caught
+    /// in the unit suite, not only in the `@bgp_unknown_attr_transitive` BDD.
+    #[test]
+    fn bgp_neighbor_attach_unknown_attribute_paths_parse() {
+        use crate::config::ExecCode;
+        use crate::config::parse::{State, parse};
+        use libyang::to_entry;
+
+        let mut yang = YangStore::new();
+        yang.add_path(concat!(env!("CARGO_MANIFEST_DIR"), "/yang"));
+        yang.read_with_resolve("configure")
+            .unwrap_or_else(|e| panic!("configure failed to load: {e:#}"));
+        yang.identity_resolve();
+        let module = yang.find_module("configure").unwrap();
+        let entry = to_entry(&yang, module);
+
+        let cmd = "set router bgp neighbor 192.168.0.2 attach-unknown-attribute 250:192:deadbeef";
+        let (code, _comps, _state) = parse(cmd, entry.clone(), None, State::new());
+        assert_eq!(
+            code,
+            ExecCode::Success,
+            "should parse as a settable path: {cmd}"
+        );
+    }
+
     /// Regression guard for the per-VRF MUP `segment` list
     /// (zebra-bgp-vrf.yang). `mup-ext-comm` moved from a sibling leaf of
     /// `segment` to a child leaf of the `segment direct` list entry, so the

--- a/zebra-rs/yang/config.yang
+++ b/zebra-rs/yang/config.yang
@@ -111,6 +111,9 @@ module config {
   import zebra-bgp-enforce-first-as {
     prefix zbef;
   }
+  import zebra-bgp-unknown-attr {
+    prefix zbua;
+  }
   import zebra-bgp-pic-retention {
     prefix zbpic;
   }

--- a/zebra-rs/yang/zebra-bgp-unknown-attr.yang
+++ b/zebra-rs/yang/zebra-bgp-unknown-attr.yang
@@ -1,0 +1,98 @@
+module zebra-bgp-unknown-attr {
+  yang-version "1";
+
+  namespace "urn:ietf:params:xml:ns:yang:zebra-bgp-unknown-attr";
+  prefix "zbua";
+
+  import ietf-bgp {
+    prefix bgp;
+  }
+
+  import config {
+    prefix config;
+  }
+
+  import configure {
+    prefix configure;
+  }
+
+  import extension {
+    prefix ext;
+  }
+
+  organization
+    "zebra-rs";
+
+  contact
+    "https://github.com/zebra-rs";
+
+  description
+    "Debug/test per-neighbor knob: attach a synthetic *unrecognized* path
+     attribute to every IPv4-unicast route advertised to this neighbor.
+
+     This exists to drive the receiver-side RFC 4271 §9 handling of
+     unrecognized path attributes from configuration, without having to
+     hand-craft BGP packets:
+
+       * an Optional Transitive unknown attribute must be accepted, have
+         its Partial bit set, and be re-advertised;
+       * an Optional non-Transitive unknown attribute must be silently
+         dropped and never propagated;
+       * an unrecognized well-known attribute (Optional bit clear) must
+         reset the session with a NOTIFICATION (subcode 2).
+
+     The value is a compact `<type>:<flags>:<value-hex>` spec:
+
+       router bgp {
+         neighbor 10.0.0.2 {
+           remote-as 65002;
+           // type 250, flags 0xC0 (Optional|Transitive), value DE AD BE EF
+           attach-unknown-attribute 250:192:deadbeef;
+         }
+       }
+
+     `<type>` and `<flags>` are decimal 0-255; `<value-hex>` is an
+     even-length hex string (possibly empty). The Extended-Length flag bit
+     is ignored and re-derived from the value length on emit.";
+
+  revision 2026-06-27 {
+    description "Initial revision.";
+    reference "RFC 4271 §5, §9 unrecognized path attribute handling.";
+  }
+
+  grouping bgp-neighbor-attach-unknown-attr-extension {
+    description
+      "Per-neighbor `attach-unknown-attribute` leaf.";
+
+    leaf attach-unknown-attribute {
+      type string;
+      ext:help "Attach a synthetic unrecognized attribute: <type>:<flags>:<value-hex>";
+      description
+        "When set, stamp a synthetic unrecognized path attribute onto
+         every IPv4-unicast route advertised to this neighbor. Format is
+         `<type>:<flags>:<value-hex>` (decimal type/flags, even-length hex
+         value). Debug/test use only.";
+    }
+  }
+
+  /* =========================================================
+   * Augments into the zebra-rs configure tree
+   * ========================================================= */
+
+  augment "/configure:set/config:router"
+        + "/bgp:bgp/bgp:neighbor" {
+    description
+      "Attach the debug knob to BGP neighbors in the candidate-set
+       subtree.";
+    uses bgp-neighbor-attach-unknown-attr-extension;
+  }
+
+  augment "/configure:delete/config:router"
+        + "/bgp:bgp/bgp:neighbor" {
+    description
+      "Same attachment for the delete subtree so
+       `delete router bgp neighbor X attach-unknown-attribute` is
+       path-valid.";
+    uses bgp-neighbor-attach-unknown-attr-extension;
+  }
+}


### PR DESCRIPTION
## Summary

Implements RFC 4271 §9 / §6.3 handling of **unrecognized** BGP path attributes — previously absent (`AttrType::Unknown` existed but the `Attr` enum had no variant and `BgpAttr` carried a `// TODO`), so any unknown attribute failed to parse and the reader dropped the connection silently.

Receiver behavior, by the Attribute Flags octet:

| Received | Action |
|---|---|
| Optional **transitive**, unknown | accept, set the **Partial** bit, retain (new `BgpAttr.unknown` / `UnknownAttr`), re-advertise verbatim |
| Optional **non-transitive**, unknown | quietly drop, never propagate |
| **Well-known** (Optional bit clear), unknown | reset session with NOTIFICATION (Update Message Error, subcode 2) |

Also:
- **Debug originate knob** — per-neighbor `attach-unknown-attribute "<type>:<flags>:<value-hex>"` (`zebra-bgp-unknown-attr.yang`) to stamp a synthetic unknown attribute with chosen Type Code / Flags onto routes advertised to a neighbor. Folded into `UpdateGroupSig` (version 4→5) so it can't leak across coalesced peers.
- **NOTIFICATION path** — new `Event::UpdateError`; `fsm_update_error` mirrors `fsm_holdtimer_expires`. Added `From<UpdateError> for u8`.
- **Observability** — `show bgp -j` now emits `unknown_attributes: [{type_code, flags, optional, transitive, partial, value}]`.

## Test plan

- `bgp-packet`: 4 new unit tests (transitive-retain+Partial, non-transitive-drop, well-known error, whole-`BgpAttr` round-trip) — full crate suite green.
- `zebra-rs`: new config set/delete + spec-parsing tests, schema path-parse guard, and update-group signature distinguisher — full non-BDD workspace suite, **0 failed**.
- `cargo fmt --check` clean; `cargo clippy --workspace --all-targets -- -D warnings` clean.
- **BDD `@bgp_unknown_attr_transitive`** (z1→z2→z3 eBGP line) ran live end-to-end: baseline (no attrs), transitive (z2 & z3 retain type 250 with Partial set), non-transitive (dropped at z2, absent at z3), clean teardown — **5/5 scenarios pass**.

Generated with [Claude Code](https://claude.com/claude-code)