### PR TITLE
fix(rib): file VRF interface connected routes in the VRF table

### DIFF
--- a/bdd/Makefile
+++ b/bdd/Makefile
@@ -152,6 +152,10 @@ vrf_phantom_instance:
 	mkdir -p allure-results
 	cargo test --test cucumber -- --concurrency=1 --tags "@vrf_phantom_instance"
 
+vrf_connected_route:
+	mkdir -p allure-results
+	cargo test --test cucumber -- --concurrency=1 --tags "@vrf_connected_route"
+
 isis_afi_enable:
 	mkdir -p allure-results
 	cargo test --test cucumber -- --concurrency=1 --tags "@isis_afi_enable"

--- a/bdd/tests/configs/vrf_connected_route/z1.yaml
+++ b/bdd/tests/configs/vrf_connected_route/z1.yaml
@@ -1,0 +1,26 @@
+# z1 — one router with VRF N3. Interface vc1 is enslaved to N3 and
+# carries an IPv4 address; its connected route (172.16.10.0/24) must be
+# installed into the VRF table, not the default one. A static route
+# inside the VRF reaches 172.16.20.0/24 via an on-link gateway on vc1,
+# exercising the on-link resolution that depends on the connected route
+# sitting in the VRF table.
+vrf:
+- name: N3
+  ipv4:
+    route-target:
+      export:
+      - 10:20
+interface:
+- if-name: vc1
+  vrf: N3
+  ipv4:
+    address: 172.16.10.1/24
+router:
+  static:
+    vrf:
+    - name: N3
+      ipv4:
+        route:
+        - prefix: 172.16.20.0/24
+          nexthop:
+          - address: 172.16.10.2

--- a/bdd/tests/features/vrf_connected_route.feature
+++ b/bdd/tests/features/vrf_connected_route.feature
@@ -1,0 +1,37 @@
+@vrf_connected_route
+Feature: A VRF interface's connected route lands in the VRF table
+  When an interface is enslaved to a VRF and carries an IPv4 address,
+  the connected route derived from that address must be installed into
+  the VRF's routing table — not the default table. The interface is
+  enslaved asynchronously (the kernel acknowledges `master` via a later
+  RTM_NEWLINK), so the connected route is often first filed in the
+  default table and must be re-homed onto the VRF table once the enslave
+  is observed. Regression test for: connected route shown in
+  `show ip route` but missing from `show ip route vrf <name>`.
+
+  ```
+   host(172.16.10.2) ── z1[vrf N3] (172.16.10.1, static 172.16.20.0/24)
+  ```
+
+  Scenario: Connected route of a VRF interface is in the VRF table only
+    Given a clean test environment
+    When I create namespace "z1"
+    And I create namespace "host"
+    And I connect namespace "z1" interface "vc1" to namespace "host" interface "eth0"
+    And I add address "172.16.10.2/24" to interface "eth0" in namespace "host"
+    And I start zebra-rs in namespace "z1"
+    And I apply config "z1.yaml" to namespace "z1"
+    And I wait 5 seconds
+    # The fix: the connected prefix is present in the VRF table…
+    Then show command "show ip route vrf N3" in namespace "z1" should contain "172.16.10.0/24"
+    # …and the on-link VRF static route resolves against it.
+    And show command "show ip route vrf N3" in namespace "z1" should contain "172.16.20.0/24"
+    # The default table must NOT carry the VRF interface's connected route.
+    And show command "show ip route" in namespace "z1" should not contain "172.16.10.0/24"
+
+  Scenario: Teardown topology
+    Given the test topology exists
+    When I stop zebra-rs in namespace "z1"
+    And I delete namespace "z1"
+    And I delete namespace "host"
+    Then the test environment should be clean

--- a/zebra-rs/src/rib/inst.rs
+++ b/zebra-rs/src/rib/inst.rs
@@ -2376,6 +2376,41 @@ impl Rib {
                 // per-`ProtoId` dispatcher writes routes here when a
                 // VRF-attached protocol installs.
                 self.vrf_tables.insert(table_id, VrfRibTables::new());
+                // Adopting a pre-existing kernel VRF can surface members
+                // that were already enslaved before we knew this VRF, so
+                // their connected routes were filed in the default table
+                // (`route_table_for` saw `master_vrf_id` == 0 because the
+                // VRF wasn't in `self.vrfs` yet). Now that the VRF and its
+                // table exist, re-home each member's connected routes out
+                // of the default table and into this one — mirroring the
+                // per-interface reconcile in `link_add`. The common
+                // fresh-create path has no members yet, so this is a
+                // no-op there.
+                let members: Vec<u32> = self
+                    .links
+                    .values()
+                    .filter(|l| l.master == Some(ifindex) && l.is_up())
+                    .map(|l| l.index)
+                    .collect();
+                for member in members {
+                    let addrs: Vec<IpNet> = self
+                        .links
+                        .get(&member)
+                        .map(|l| {
+                            l.addr4
+                                .iter()
+                                .chain(l.addr6.iter())
+                                .map(|a| a.addr)
+                                .collect()
+                        })
+                        .unwrap_or_default();
+                    for addr in addrs {
+                        // Old table is the default (0): the member was
+                        // enslaved in the kernel but this VRF was unknown.
+                        self.connected_route_del(member, addr, 0).await;
+                        self.connected_route_add(member, addr).await;
+                    }
+                }
                 // Re-emit any static routes configured for this VRF now
                 // that its kernel table exists — the initial commit's
                 // install was dropped if it raced ahead of the VRF.

--- a/zebra-rs/src/rib/link.rs
+++ b/zebra-rs/src/rib/link.rs
@@ -643,6 +643,28 @@ impl Rib {
                 for addr in link.addr4.iter().chain(link.addr6.iter()) {
                     self.api_addr_add_vrf(addr, now_vrf_id);
                 }
+                // Re-home this interface's own connected-route shadows
+                // between the two VRF tables. Each address's connected
+                // route was filed in the *old* table — `route_table_for`
+                // picked it from the master in effect when the address
+                // was learned, which (during a config-driven enslave)
+                // is the default table because the kernel's enslaving
+                // RTM_NEWLINK hadn't landed yet. Enslaving doesn't move
+                // those entries on its own, so without this the connected
+                // prefix is missing from `show ip route vrf <N>` and
+                // wrongly present in `show ip route`. Pull each one out of
+                // the old table (named by `prev_vrf_id`) and re-add it
+                // into the new one (derived from the now-updated
+                // `link.master`). Connected routes are non-protocol, so
+                // this never touches the kernel FIB. Only meaningful while
+                // the link is up — a down link has no connected shadow.
+                if link.is_up() {
+                    for addr in link.addr4.iter().chain(link.addr6.iter()) {
+                        self.connected_route_del(ifindex, addr.addr, prev_vrf_id)
+                            .await;
+                        self.connected_route_add(ifindex, addr.addr).await;
+                    }
+                }
                 // Replay this VRF's static routes now that the interface
                 // is enslaved: a route whose gateway sits on this link was
                 // unresolvable while the link was still in the default VRF,

--- a/zebra-rs/src/rib/route.rs
+++ b/zebra-rs/src/rib/route.rs
@@ -13,8 +13,8 @@ use super::inst::{IlmEntry, RT_TABLE_MAIN, Rib};
 use super::nexthop::NexthopUni;
 use super::tracing::{rib_interface, rib_nexthop, rib_route};
 use super::{
-    Group, GroupTrait, Message, NexthopList, NexthopMap, NexthopMember, NexthopMulti,
-    NexthopProtect, ProtectActive, RibEntries, RibType,
+    Group, GroupTrait, NexthopList, NexthopMap, NexthopMember, NexthopMulti, NexthopProtect,
+    ProtectActive, RibEntries, RibType,
 };
 use std::net::IpAddr;
 
@@ -250,32 +250,21 @@ impl Rib {
     }
 
     pub async fn link_down(&mut self, ifindex: u32) {
-        let Some(link) = self.links.get(&ifindex) else {
+        // Own a snapshot — `connected_route_del` borrows `&mut self`.
+        let Some(link) = self.links.get(&ifindex).cloned() else {
             return;
         };
 
         // Notify protocol daemons.
         self.api_link_down(ifindex);
 
-        // Remove connected route.
-        for addr4 in link.addr4.iter() {
-            if let IpNet::V4(addr) = addr4.addr {
-                let prefix = addr.apply_mask();
-                let mut rib = RibEntry::new(RibType::Connected);
-                rib.ifindex = ifindex;
-                let _ = rib_replace_system(&mut self.table, &prefix, rib);
-            }
-        }
-        // Remove connected IPv6 route.
-        for addr6 in link.addr6.iter() {
-            if let IpNet::V6(addr) = addr6.addr {
-                let prefix = addr.apply_mask();
-                // println!("Connected IPv6: {:?} down - removing from RIB", prefix);
-                let mut rib = RibEntry::new(RibType::Connected);
-                rib.ifindex = ifindex;
-                let msg = Message::Ipv6Del { prefix, rib };
-                let _ = self.tx.send(msg);
-            }
+        // Remove the interface's connected routes from the table of the
+        // VRF it belongs to (default table when not enslaved). The route
+        // currently sits in the interface's *current* VRF, so derive the
+        // table id from `link.master` via `ifindex_vrf_id`.
+        let vrf_id = self.ifindex_vrf_id(ifindex);
+        for addr in link.addr4.iter().chain(link.addr6.iter()) {
+            self.connected_route_del(ifindex, addr.addr, vrf_id).await;
         }
         // Remove DHCP and Kernel routes.
         #[cfg(any())]
@@ -365,8 +354,84 @@ impl Rib {
         self.schedule_rib_sync();
     }
 
+    /// Install the connected route for an interface address into the
+    /// routing table of the VRF the interface currently belongs to —
+    /// the default table (`RT_TABLE_MAIN`) when it isn't enslaved.
+    ///
+    /// Every connected-route producer (link up, VRF re-home) funnels
+    /// through here so table placement honours VRF membership exactly
+    /// the way `route_table_for` does for the internal message path.
+    /// The VRF is derived from `link.master`, so callers must invoke
+    /// this only once that reflects the interface's *current* VRF.
+    /// Connected routes are non-protocol, so the FIB layer treats the
+    /// resulting add as a no-op (the kernel owns connected routes) —
+    /// this is pure RIB-table bookkeeping plus redistribution notify.
+    pub(crate) async fn connected_route_add(&mut self, ifindex: u32, addr: IpNet) {
+        let vrf_id = self.ifindex_vrf_id(ifindex);
+        match addr {
+            IpNet::V4(net) => {
+                let prefix = net.apply_mask();
+                let mut entry = RibEntry::new(RibType::Connected);
+                entry.ifindex = ifindex;
+                entry.set_valid(true);
+                if vrf_id == 0 {
+                    self.ipv4_route_add(&prefix, entry, RT_TABLE_MAIN).await;
+                } else {
+                    self.ipv4_route_add_vrf(vrf_id, &prefix, entry).await;
+                }
+            }
+            IpNet::V6(net) => {
+                let prefix = net.apply_mask();
+                let mut entry = RibEntry::new(RibType::Connected);
+                entry.ifindex = ifindex;
+                entry.set_valid(true);
+                if vrf_id == 0 {
+                    self.ipv6_route_add(&prefix, entry, RT_TABLE_MAIN).await;
+                } else {
+                    self.ipv6_route_add_vrf(vrf_id, &prefix, entry).await;
+                }
+            }
+        }
+    }
+
+    /// Withdraw the connected route for an interface address from the
+    /// table identified by `vrf_id` (0 == default / `RT_TABLE_MAIN`).
+    ///
+    /// `vrf_id` is passed explicitly rather than re-derived from
+    /// `link.master`: on a VRF boundary cross the route must be pulled
+    /// from the table it sat in *before* the master changed, which the
+    /// caller alone knows. As with the add side this is a no-op at the
+    /// FIB layer for connected (non-protocol) routes.
+    pub(crate) async fn connected_route_del(&mut self, ifindex: u32, addr: IpNet, vrf_id: u32) {
+        match addr {
+            IpNet::V4(net) => {
+                let prefix = net.apply_mask();
+                let mut entry = RibEntry::new(RibType::Connected);
+                entry.ifindex = ifindex;
+                if vrf_id == 0 {
+                    self.ipv4_route_del(&prefix, entry, RT_TABLE_MAIN).await;
+                } else {
+                    self.ipv4_route_del_vrf(vrf_id, &prefix, entry).await;
+                }
+            }
+            IpNet::V6(net) => {
+                let prefix = net.apply_mask();
+                let mut entry = RibEntry::new(RibType::Connected);
+                entry.ifindex = ifindex;
+                if vrf_id == 0 {
+                    self.ipv6_route_del(&prefix, entry, RT_TABLE_MAIN).await;
+                } else {
+                    self.ipv6_route_del_vrf(vrf_id, &prefix, entry).await;
+                }
+            }
+        }
+    }
+
     pub async fn link_up(&mut self, ifindex: u32) {
-        let Some(link) = self.links.get(&ifindex) else {
+        // Own a snapshot of the link: the connected-route recovery below
+        // calls `&mut self` helpers, so we can't keep an immutable borrow
+        // of `self.links` alive across them.
+        let Some(link) = self.links.get(&ifindex).cloned() else {
             if rib_interface() {
                 tracing::info!(
                     "link_up: ifindex {} not found in link table; skipping connected route recovery",
@@ -390,62 +455,20 @@ impl Rib {
         // Notify protocol daemons.
         self.api_link_up(ifindex);
 
-        // Add connected IPv4 routes when link comes up
-        for addr4 in link.addr4.iter() {
-            if let IpNet::V4(addr) = addr4.addr {
-                let prefix = addr.apply_mask();
-                let mut entry = RibEntry::new(RibType::Connected);
-                entry.ifindex = ifindex;
-                entry.set_valid(true);
-
-                if rib_interface() {
-                    tracing::info!(
-                        "link_up: {} re-adding IPv4 connected prefix {}",
-                        link_name,
-                        prefix
-                    );
-                }
-
-                rib_add_system(&mut self.table, &prefix, entry);
-                rib_selection_ipv4(
-                    &mut self.table,
-                    &prefix,
-                    None,
-                    &mut self.nmap,
-                    &self.fib_handle,
-                    RT_TABLE_MAIN,
-                )
-                .await;
+        // Re-add connected routes when the link comes up, into the
+        // table of the VRF the interface belongs to (default table when
+        // not enslaved) — `connected_route_add` derives that from
+        // `link.master`, so a VRF interface's connected prefix lands in
+        // its VRF table rather than polluting the default one.
+        for addr in link.addr4.iter().chain(link.addr6.iter()) {
+            if rib_interface() {
+                tracing::info!(
+                    "link_up: {} re-adding connected prefix {}",
+                    link_name,
+                    addr.addr
+                );
             }
-        }
-
-        // Add connected IPv6 routes when link comes up
-        for addr6 in link.addr6.iter() {
-            if let IpNet::V6(addr) = addr6.addr {
-                let prefix = addr.apply_mask();
-                let mut entry = RibEntry::new(RibType::Connected);
-                entry.ifindex = ifindex;
-                entry.set_valid(true);
-
-                if rib_interface() {
-                    tracing::info!(
-                        "link_up: {} re-adding IPv6 connected prefix {}",
-                        link_name,
-                        prefix
-                    );
-                }
-
-                rib_add_system_v6(&mut self.table_v6, &prefix, entry);
-                rib_selection_ipv6(
-                    &mut self.table_v6,
-                    &prefix,
-                    None,
-                    &mut self.nmap,
-                    &self.fib_handle,
-                    RT_TABLE_MAIN,
-                )
-                .await;
-            }
+            self.connected_route_add(ifindex, addr.addr).await;
         }
 
         // Re-install configured addresses that the kernel removed while the
@@ -1044,34 +1067,6 @@ impl Rib {
             self.schedule_rib_sync();
         }
     }
-}
-
-pub async fn rib_selection_ipv4(
-    table: &mut PrefixMap<Ipv4Net, RibEntries>,
-    prefix: &Ipv4Net,
-    replace: Option<RibEntry>,
-    nmap: &mut NexthopMap,
-    fib: &FibHandle,
-    table_id: u32,
-) -> bool {
-    let Some(entries) = table.get_mut(prefix) else {
-        return false;
-    };
-    ipv4_entry_selection(prefix, entries, replace, nmap, fib, table_id, true).await
-}
-
-pub async fn rib_selection_ipv6(
-    table: &mut PrefixMap<Ipv6Net, RibEntries>,
-    prefix: &Ipv6Net,
-    replace: Option<RibEntry>,
-    nmap: &mut NexthopMap,
-    fib: &FibHandle,
-    table_id: u32,
-) -> bool {
-    let Some(entries) = table.get_mut(prefix) else {
-        return false;
-    };
-    ipv6_entry_selection(prefix, entries, replace, nmap, fib, table_id).await
 }
 
 pub async fn ipv4_nexthop_sync(


### PR DESCRIPTION
## Summary

A connected route derived from a VRF-enslaved interface's address was installed in the **default** routing table instead of the interface's **VRF** table. As a result it wrongly appeared in `show ip route` and was missing from `show ip route vrf <name>`, even though the kernel had it correctly in the VRF table.

### Root cause

During a config-driven enslave, the interface address (and its connected route) is learned **before** the kernel's enslaving `RTM_NEWLINK` lands, so `link.master` is still unset and `route_table_for` files the route in the default table. Nothing then re-homed it:

- `link_add`'s VRF-boundary reconciliation re-notified subscribers and reinstalled static routes, but left the RIB's own connected entry in the default table.
- The kernel flushes a VRF interface's IPv4 addresses on enslave; the re-add comes back as a merge (`was_addr_added=false`), so `addr_add` never re-creates the connected route.
- `link_up`/`link_down` hard-coded the default table, so a flap re-polluted it.

### Changes

- **route.rs**: add `connected_route_add`/`connected_route_del` helpers that dispatch to the default vs per-VRF route table based on the interface's VRF (mirroring `route_table_for`); rewrite `link_up`/`link_down` to use them so connected routes land in the correct table across interface flaps.
- **link.rs**: on a VRF-boundary crossing in `link_add`, re-home each address's connected route out of the old table and into the new one.
- **inst.rs**: same re-home in `VrfAdd` when adopting a pre-existing kernel VRF with already-enslaved members.

Connected routes are non-protocol, so the FIB layer no-ops — this is pure RIB bookkeeping with no kernel route flapping.

## Test plan

- `cargo fmt --check`, `clippy -D warnings`, 236 rib unit tests: clean.
- New BDD feature `vrf_connected_route` covers the exact scenario — **fails without the fix** (route wrongly in `show ip route`), **passes with it**.
- Regression: `static_vrf` (v6 VRF + forwarding), `vrf_phantom_instance`, `bgp_basic_ibgp` (default-table connected routes) all pass.

Generated with [Claude Code](https://claude.com/claude-code)