### PR TITLE
feat(rib): per-VRF redistribute plumbing (table selection + delta hook)

### DIFF
--- a/zebra-rs/src/rib/inst.rs
+++ b/zebra-rs/src/rib/inst.rs
@@ -2022,6 +2022,11 @@ impl Rib {
         }
     }
 
+    /// Walk the table the subscriber is bound to. A subscriber's
+    /// `vrf_id` (recorded at `Subscribe` time) selects the table:
+    /// `0` walks the default `self.table` / `self.table_v6`; any other
+    /// value is the kernel table id keying `vrf_tables`. A VRF whose
+    /// table has since been torn down walks nothing.
     fn redist_walk(
         &self,
         proto: &str,
@@ -2031,12 +2036,33 @@ impl Rib {
         op: super::redist::WalkOp,
         tx: &UnboundedSender<RibRx>,
     ) {
+        let vrf_id = self
+            .client_registry
+            .subscriber_for_proto(proto)
+            .map(|s| s.vrf_id)
+            .unwrap_or(0);
         match afi {
             super::RedistAfi::Ipv4 => {
-                super::redist::walk_v4(&self.table, proto, rtype, subtypes, op, tx);
+                let table = if vrf_id == 0 {
+                    &self.table
+                } else {
+                    match self.vrf_tables.get(&vrf_id) {
+                        Some(t) => &t.table,
+                        None => return,
+                    }
+                };
+                super::redist::walk_v4(table, proto, rtype, subtypes, op, tx);
             }
             super::RedistAfi::Ipv6 => {
-                super::redist::walk_v6(&self.table_v6, proto, rtype, subtypes, op, tx);
+                let table = if vrf_id == 0 {
+                    &self.table_v6
+                } else {
+                    match self.vrf_tables.get(&vrf_id) {
+                        Some(t) => &t.table_v6,
+                        None => return,
+                    }
+                };
+                super::redist::walk_v6(table, proto, rtype, subtypes, op, tx);
             }
         }
     }

--- a/zebra-rs/src/rib/redist.rs
+++ b/zebra-rs/src/rib/redist.rs
@@ -17,9 +17,13 @@
 //!     after its nexthop became (un)resolvable via the debounced
 //!     resolve / link up-down / address add-del paths.
 //!
-//! Still default-table only: `notify_v{4,6}_delta` delivers to
-//! `vrf_id == 0` subscribers, so VRF-table selection changes need a
-//! separate per-VRF hook (see `notify_v4_delta`).
+//! Both the default table and per-VRF tables feed the hook:
+//! `notify_v{4,6}_delta` takes a `target_vrf_id` and delivers only to
+//! subscribers bound to that VRF. The default-VRF route paths pass
+//! `0`; the per-VRF paths (`ipv{4,6}_route_{add,del}_vrf` /
+//! `ipv{4,6}_vrf_sync` on `vrf_tables[table_id]`) pass that table id.
+//! The initial walk-and-replay (`redist_walk`) likewise selects the
+//! subscriber's table from its recorded `vrf_id`.
 
 use std::collections::{BTreeMap, BTreeSet, HashMap};
 
@@ -382,23 +386,27 @@ pub(super) fn selected_changed_v6(
     key(prefix, before) != key(prefix, after)
 }
 
-/// Notify every default-VRF subscriber whose filter matches the
-/// before/after transition of the selected entry at `prefix`. Single-
-/// entry batches, `bulk: More`. EoR is reserved for initial walk /
-/// `Redist{Add,Update,Del}` replays — steady-state never emits Eor.
+/// Notify every subscriber bound to `target_vrf_id` whose filter
+/// matches the before/after transition of the selected entry at
+/// `prefix`. Single-entry batches, `bulk: More`. EoR is reserved for
+/// initial walk / `Redist{Add,Update,Del}` replays — steady-state
+/// never emits Eor.
 ///
-/// VRF-attached subscribers (`vrf_id != 0`) are skipped here because
-/// `notify_v*_delta` is called from the default-VRF route paths
-/// (`Rib::ipv*_route_{add,del}` on `self.table` / `self.table_v6`).
-/// A per-VRF resolve + select pipeline can install a sibling hook
-/// that walks `vrf_tables[vrf_id]` and pushes to subscribers bound
-/// to that VRF.
+/// `target_vrf_id` scopes delivery to the table the transition came
+/// from: the default-VRF route paths (`Rib::ipv*_route_{add,del}` /
+/// `ipv*_default_sync` on `self.table` / `self.table_v6`) pass `0`,
+/// and the per-VRF paths (`ipv*_route_{add,del}_vrf` /
+/// `ipv*_vrf_sync` on `vrf_tables[table_id]`) pass that VRF's kernel
+/// table id. A subscriber whose `vrf_id` doesn't match is skipped so
+/// a default-table change never leaks to a VRF subscriber and vice
+/// versa.
 pub fn notify_v4_delta(
     filters: &HashMap<String, FilterMap>,
     registry: &ClientRegistry,
     prefix: &Ipv4Net,
     before: Option<&RibEntry>,
     after: Option<&RibEntry>,
+    target_vrf_id: u32,
 ) {
     if before.is_none() && after.is_none() {
         return;
@@ -407,7 +415,7 @@ pub fn notify_v4_delta(
         let Some(sub) = registry.subscriber_for_proto(proto) else {
             continue;
         };
-        if sub.vrf_id != 0 {
+        if sub.vrf_id != target_vrf_id {
             continue;
         }
         let tx = &sub.rib_rx_tx;
@@ -425,12 +433,15 @@ pub fn notify_v4_delta(
     }
 }
 
+/// IPv6 sibling of [`notify_v4_delta`]; see its docstring for the
+/// `target_vrf_id` scoping rules.
 pub fn notify_v6_delta(
     filters: &HashMap<String, FilterMap>,
     registry: &ClientRegistry,
     prefix: &Ipv6Net,
     before: Option<&RibEntry>,
     after: Option<&RibEntry>,
+    target_vrf_id: u32,
 ) {
     if before.is_none() && after.is_none() {
         return;
@@ -439,7 +450,7 @@ pub fn notify_v6_delta(
         let Some(sub) = registry.subscriber_for_proto(proto) else {
             continue;
         };
-        if sub.vrf_id != 0 {
+        if sub.vrf_id != target_vrf_id {
             continue;
         }
         let tx = &sub.rib_rx_tx;
@@ -570,8 +581,10 @@ fn send_v6_one(tx: &UnboundedSender<RibRx>, rtype: RibType, op: WalkOp, entry: R
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::rib::client::ProtoId;
     use crate::rib::nexthop::NexthopUni;
     use std::net::IpAddr;
+    use tokio::sync::mpsc::unbounded_channel;
 
     fn static_uni(addr: &str, metric: u32) -> RibEntry {
         let mut e = RibEntry::new(RibType::Static);
@@ -688,5 +701,86 @@ mod tests {
         assert!(!redistributable_v6(&"::1/128".parse().unwrap()));
         assert!(!redistributable_v6(&"fe80::/64".parse().unwrap()));
         assert!(redistributable_v6(&"2001:db8::/64".parse().unwrap()));
+    }
+
+    /// Build a `(filters, registry)` pair with one default-VRF
+    /// subscriber (`vrf_id 0`) and one VRF subscriber (`vrf_id 100`),
+    /// each carrying a wildcard Connected/IPv4 filter row, returning
+    /// their receivers so a test can assert who heard a delta.
+    fn two_subscribers() -> (
+        HashMap<String, FilterMap>,
+        ClientRegistry,
+        tokio::sync::mpsc::UnboundedReceiver<RibRx>,
+        tokio::sync::mpsc::UnboundedReceiver<RibRx>,
+    ) {
+        let mut reg = ClientRegistry::new();
+        let (tx_def, rx_def) = unbounded_channel();
+        let (tx_vrf, rx_vrf) = unbounded_channel();
+        reg.register_with_id(ProtoId::from_raw(0), "bgp", tx_def, 0);
+        reg.register_with_id(ProtoId::from_raw(1), "bgp:vrf:N3", tx_vrf, 100);
+
+        let mut filters: HashMap<String, FilterMap> = HashMap::new();
+        for proto in ["bgp", "bgp:vrf:N3"] {
+            let mut fm = FilterMap::new();
+            fm.insert((RedistAfi::Ipv4, RibType::Connected), BTreeSet::new());
+            filters.insert(proto.to_string(), fm);
+        }
+        (filters, reg, rx_def, rx_vrf)
+    }
+
+    fn connected_link(ifindex: u32) -> RibEntry {
+        let mut e = RibEntry::new(RibType::Connected);
+        e.nexthop = Nexthop::Link(ifindex);
+        e.ifindex = ifindex;
+        e
+    }
+
+    #[test]
+    fn notify_v4_delta_scopes_to_target_vrf() {
+        // The crux of per-VRF redistribution: a selection change in a
+        // VRF table must reach only the subscriber bound to that VRF,
+        // and a default-table change must reach only the default
+        // subscriber. Cross-delivery would advertise a VRF's CE prefix
+        // into the global table (and vice versa).
+        let (filters, reg, mut rx_def, mut rx_vrf) = two_subscribers();
+        let prefix: Ipv4Net = "203.0.113.0/24".parse().unwrap();
+        let conn = connected_link(7);
+
+        // Connected route appears in VRF 100 → only the VRF subscriber.
+        notify_v4_delta(&filters, &reg, &prefix, None, Some(&conn), 100);
+        assert!(
+            matches!(rx_vrf.try_recv(), Ok(RibRx::RouteAdd { .. })),
+            "VRF subscriber must hear the VRF-100 add"
+        );
+        assert!(
+            rx_def.try_recv().is_err(),
+            "default subscriber must not hear a VRF-100 change"
+        );
+
+        // Same prefix appears in the default table → only the default
+        // subscriber.
+        notify_v4_delta(&filters, &reg, &prefix, None, Some(&conn), 0);
+        assert!(
+            matches!(rx_def.try_recv(), Ok(RibRx::RouteAdd { .. })),
+            "default subscriber must hear the default-table add"
+        );
+        assert!(
+            rx_vrf.try_recv().is_err(),
+            "VRF subscriber must not hear a default-table change"
+        );
+    }
+
+    #[test]
+    fn notify_v4_delta_unknown_vrf_reaches_nobody() {
+        // A transition tagged with a table id no subscriber is bound to
+        // is silently dropped — no spurious delivery to the default or
+        // any other VRF.
+        let (filters, reg, mut rx_def, mut rx_vrf) = two_subscribers();
+        let prefix: Ipv4Net = "203.0.113.0/24".parse().unwrap();
+        let conn = connected_link(7);
+
+        notify_v4_delta(&filters, &reg, &prefix, None, Some(&conn), 777);
+        assert!(rx_def.try_recv().is_err());
+        assert!(rx_vrf.try_recv().is_err());
     }
 }

--- a/zebra-rs/src/rib/route.rs
+++ b/zebra-rs/src/rib/route.rs
@@ -558,6 +558,11 @@ impl Rib {
         prefix: &Ipv4Net,
         mut entry: RibEntry,
     ) {
+        let before = self
+            .vrf_tables
+            .get(&table_id)
+            .and_then(|t| selected_v4(&t.table, prefix))
+            .cloned();
         let replace = {
             let Some(t) = self.vrf_tables.get_mut(&table_id) else {
                 tracing::warn!(
@@ -578,9 +583,27 @@ impl Rib {
             }
         };
         self.vrf_rib_selection(table_id, prefix, replace).await;
+        let after = self
+            .vrf_tables
+            .get(&table_id)
+            .and_then(|t| selected_v4(&t.table, prefix))
+            .cloned();
+        super::redist::notify_v4_delta(
+            &self.redist_filters,
+            &self.client_registry,
+            prefix,
+            before.as_ref(),
+            after.as_ref(),
+            table_id,
+        );
     }
 
     pub async fn ipv4_route_del_vrf(&mut self, table_id: u32, prefix: &Ipv4Net, entry: RibEntry) {
+        let before = self
+            .vrf_tables
+            .get(&table_id)
+            .and_then(|t| selected_v4(&t.table, prefix))
+            .cloned();
         let replace = {
             let Some(t) = self.vrf_tables.get_mut(&table_id) else {
                 return;
@@ -592,6 +615,19 @@ impl Rib {
             }
         };
         self.vrf_rib_selection(table_id, prefix, replace).await;
+        let after = self
+            .vrf_tables
+            .get(&table_id)
+            .and_then(|t| selected_v4(&t.table, prefix))
+            .cloned();
+        super::redist::notify_v4_delta(
+            &self.redist_filters,
+            &self.client_registry,
+            prefix,
+            before.as_ref(),
+            after.as_ref(),
+            table_id,
+        );
     }
 
     pub async fn ipv6_route_add_vrf(
@@ -600,6 +636,11 @@ impl Rib {
         prefix: &Ipv6Net,
         mut entry: RibEntry,
     ) {
+        let before = self
+            .vrf_tables
+            .get(&table_id)
+            .and_then(|t| selected_v6(&t.table_v6, prefix))
+            .cloned();
         let replace = {
             let Some(t) = self.vrf_tables.get_mut(&table_id) else {
                 tracing::warn!(
@@ -620,9 +661,27 @@ impl Rib {
             }
         };
         self.vrf_rib_selection_v6(table_id, prefix, replace).await;
+        let after = self
+            .vrf_tables
+            .get(&table_id)
+            .and_then(|t| selected_v6(&t.table_v6, prefix))
+            .cloned();
+        super::redist::notify_v6_delta(
+            &self.redist_filters,
+            &self.client_registry,
+            prefix,
+            before.as_ref(),
+            after.as_ref(),
+            table_id,
+        );
     }
 
     pub async fn ipv6_route_del_vrf(&mut self, table_id: u32, prefix: &Ipv6Net, entry: RibEntry) {
+        let before = self
+            .vrf_tables
+            .get(&table_id)
+            .and_then(|t| selected_v6(&t.table_v6, prefix))
+            .cloned();
         let replace = {
             let Some(t) = self.vrf_tables.get_mut(&table_id) else {
                 return;
@@ -634,6 +693,19 @@ impl Rib {
             }
         };
         self.vrf_rib_selection_v6(table_id, prefix, replace).await;
+        let after = self
+            .vrf_tables
+            .get(&table_id)
+            .and_then(|t| selected_v6(&t.table_v6, prefix))
+            .cloned();
+        super::redist::notify_v6_delta(
+            &self.redist_filters,
+            &self.client_registry,
+            prefix,
+            before.as_ref(),
+            after.as_ref(),
+            table_id,
+        );
     }
 
     /// Best-path selection + FIB reconcile for one VRF prefix. Mirrors
@@ -717,6 +789,7 @@ impl Rib {
             prefix,
             before.as_ref(),
             after.as_ref(),
+            0,
         );
 
         // Any RIB add can shift the FIB — debounced resolve catches static /
@@ -742,6 +815,7 @@ impl Rib {
             prefix,
             before.as_ref(),
             after.as_ref(),
+            0,
         );
 
         self.schedule_rib_sync();
@@ -863,6 +937,7 @@ impl Rib {
             prefix,
             before.as_ref(),
             after.as_ref(),
+            0,
         );
 
         // Any RIB add can shift the FIB — debounced resolve catches static /
@@ -888,6 +963,7 @@ impl Rib {
             prefix,
             before.as_ref(),
             after.as_ref(),
+            0,
         );
 
         self.schedule_rib_sync();
@@ -926,6 +1002,7 @@ impl Rib {
                 &prefix,
                 before.as_ref(),
                 after.as_ref(),
+                0,
             );
         }
         retry
@@ -956,6 +1033,73 @@ impl Rib {
                 &prefix,
                 before.as_ref(),
                 after.as_ref(),
+                0,
+            );
+        }
+        retry
+    }
+
+    /// Per-VRF sibling of [`Self::ipv4_default_sync`]: re-resolve the
+    /// VRF table at `table_id` and, when redistribute subscribers are
+    /// registered, push the resulting selected-entry deltas to those
+    /// bound to this VRF (`target_vrf_id = table_id`). With no
+    /// subscribers it falls back to the plain sync with zero snapshot
+    /// overhead, matching the default path.
+    pub(super) async fn ipv4_vrf_sync(&mut self, table_id: u32, ifdown: bool) -> bool {
+        let Some(t) = self.vrf_tables.get_mut(&table_id) else {
+            return false;
+        };
+        if self.redist_filters.is_empty() {
+            return ipv4_route_sync(
+                &mut t.table,
+                &mut self.nmap,
+                &self.fib_handle,
+                table_id,
+                ifdown,
+            )
+            .await;
+        }
+        let (retry, deltas) = ipv4_route_sync_collect(
+            &mut t.table,
+            &mut self.nmap,
+            &self.fib_handle,
+            table_id,
+            ifdown,
+        )
+        .await;
+        for (prefix, before, after) in deltas {
+            super::redist::notify_v4_delta(
+                &self.redist_filters,
+                &self.client_registry,
+                &prefix,
+                before.as_ref(),
+                after.as_ref(),
+                table_id,
+            );
+        }
+        retry
+    }
+
+    /// IPv6 sibling of [`Self::ipv4_vrf_sync`].
+    pub(super) async fn ipv6_vrf_sync(&mut self, table_id: u32) -> bool {
+        let Some(t) = self.vrf_tables.get_mut(&table_id) else {
+            return false;
+        };
+        if self.redist_filters.is_empty() {
+            return ipv6_route_sync(&mut t.table_v6, &mut self.nmap, &self.fib_handle, table_id)
+                .await;
+        }
+        let (retry, deltas) =
+            ipv6_route_sync_collect(&mut t.table_v6, &mut self.nmap, &self.fib_handle, table_id)
+                .await;
+        for (prefix, before, after) in deltas {
+            super::redist::notify_v6_delta(
+                &self.redist_filters,
+                &self.client_registry,
+                &prefix,
+                before.as_ref(),
+                after.as_ref(),
+                table_id,
             );
         }
         retry
@@ -973,11 +1117,7 @@ impl Rib {
         let mut retry = self.ipv6_default_sync().await;
         let table_ids: Vec<u32> = self.vrf_tables.keys().copied().collect();
         for table_id in table_ids {
-            if let Some(t) = self.vrf_tables.get_mut(&table_id) {
-                retry |=
-                    ipv6_route_sync(&mut t.table_v6, &mut self.nmap, &self.fib_handle, table_id)
-                        .await;
-            }
+            retry |= self.ipv6_vrf_sync(table_id).await;
         }
         if retry {
             self.schedule_rib_sync();
@@ -1003,16 +1143,7 @@ impl Rib {
         // installed.
         let table_ids: Vec<u32> = self.vrf_tables.keys().copied().collect();
         for table_id in table_ids {
-            if let Some(t) = self.vrf_tables.get_mut(&table_id) {
-                retry |= ipv4_route_sync(
-                    &mut t.table,
-                    &mut self.nmap,
-                    &self.fib_handle,
-                    table_id,
-                    false,
-                )
-                .await;
-            }
+            retry |= self.ipv4_vrf_sync(table_id, false).await;
         }
         // A failed install forced a nexthop recreation; arm another
         // pass so the recreated nexthop and the pending route both land.
@@ -1249,9 +1380,11 @@ pub async fn ipv4_route_sync(
 
 /// Like `ipv4_route_sync` but also returns the per-prefix selected-entry
 /// transitions (so the caller can notify redistribute subscribers about
-/// resolution/topology-driven selection changes). Only the default
-/// table should collect: `notify_v4_delta` delivers to `vrf_id == 0`
-/// subscribers, so VRF-table deltas must not flow through it.
+/// resolution/topology-driven selection changes). The default table
+/// (`ipv4_default_sync`) and each VRF table (`ipv4_vrf_sync`) both
+/// collect; the caller scopes delivery by passing the matching
+/// `target_vrf_id` to `notify_v4_delta` (0 for the default table, the
+/// kernel table id for a VRF).
 pub async fn ipv4_route_sync_collect(
     table: &mut PrefixMap<Ipv4Net, RibEntries>,
     nmap: &mut NexthopMap,


### PR DESCRIPTION
## Summary

First phase (RIB-only) of supporting `redistribute {connected|static|...}` under `router bgp vrf <VRF> afi-safi {ipv4|ipv6}` (Cisco IOS-XR-style VRF redistribution into VPNv4/VPNv6). This lands the RIB foundation: the redistribute walk and the steady-state delta hook become **VRF-aware**, so a future per-VRF subscriber receives only its own VRF table's routes.

**No behavior change today.** The only registered redistribute subscriber is the global BGP instance (`vrf_id 0`), which still sees exactly the default table. The new VRF hooks deliver to nobody until a per-VRF BGP subscriber registers (Phase 2).

## Changes

- **`redist_walk` (inst.rs):** select the walked table from the subscriber's recorded `vrf_id` — `0` walks the default `self.table`/`table_v6`, otherwise `vrf_tables[vrf_id]`; a torn-down VRF walks nothing.
- **`notify_v4_delta`/`notify_v6_delta` (redist.rs):** take a `target_vrf_id` and deliver only to subscribers bound to that VRF, so a default-table change never leaks to a VRF subscriber and vice-versa. All default callers pass `0`.
- **`route.rs`:** `ipv{4,6}_route_{add,del}_vrf` capture before/after selected entries and notify with `target_vrf_id = table_id` (mirroring the default `ipv4_route_add`). New `ipv{4,6}_vrf_sync` helpers emit resolution/topology-driven deltas for VRF tables and are wired into both `ipv*_route_resolve` loops, keeping the zero-overhead fast path when no redistribute subscriber is registered.
- Stale "default-table only" docs updated.

## Test plan

- New unit tests `notify_v4_delta_scopes_to_target_vrf` and `notify_v4_delta_unknown_vrf_reaches_nobody` prove the VRF scoping (right VRF hears it; default and unknown VRFs don't).
- `cargo fmt --all` clean; `cargo clippy --workspace --all-targets -- -D warnings` clean.
- **1481 zebra-rs tests pass**, 0 failed.

## Follow-ups

- Phase 2: BGP VRF config (`redistribute` under `bgp-vrf-afi-safi`) + the per-VRF BGP task as a RIB redistribute subscriber, feeding the VRF Loc-RIB → existing VPNv4/v6 export.
- Phase 3: extend to `redistribute ospf`/`isis`.

Generated with [Claude Code](https://claude.com/claude-code)