### PR TITLE
feat(bgp): per-VRF redistribute connected/static to VPNv4/v6

### DIFF
--- a/bdd/Makefile
+++ b/bdd/Makefile
@@ -156,6 +156,10 @@ vrf_connected_route:
 	mkdir -p allure-results
 	cargo test --test cucumber -- --concurrency=1 --tags "@vrf_connected_route"
 
+bgp_vrf_redistribute:
+	mkdir -p allure-results
+	cargo test --test cucumber -- --concurrency=1 --tags "@bgp_vrf_redistribute"
+
 isis_afi_enable:
 	mkdir -p allure-results
 	cargo test --test cucumber -- --concurrency=1 --tags "@isis_afi_enable"

--- a/bdd/tests/configs/bgp_vrf_redistribute/z1-1.yaml
+++ b/bdd/tests/configs/bgp_vrf_redistribute/z1-1.yaml
@@ -1,0 +1,47 @@
+# z1 — PE originating a VRF's connected + static routes as VPNv4 via
+# `redistribute`. vrf-blue (RD 65001:100, RT 65001:100 imp/exp) holds
+# interface vc1 (10.1.0.1/24 → connected 10.1.0.0/24 in the VRF table)
+# and a static route 10.2.0.0/24 via the on-link host 10.1.0.2. Both
+# are pulled into the per-VRF BGP table by `afi-safi ipv4 redistribute
+# {connected,static}` and exported to VPNv4 over the iBGP session to z2.
+vrf:
+- name: vrf-blue
+  ipv4:
+    route-target:
+      import:
+      - 65001:100
+      export:
+      - 65001:100
+interface:
+- if-name: vc1
+  vrf: vrf-blue
+  ipv4:
+    address: 10.1.0.1/24
+router:
+  bgp:
+    global:
+      as: 65001
+      router-id: 192.168.0.1
+    neighbor:
+    - remote-address: 192.168.0.2
+      afi-safi:
+      - name: vpnv4
+        enabled: true
+      enabled: true
+      remote-as: 65001
+    vrf:
+    - name: vrf-blue
+      rd: 65001:100
+      afi-safi:
+        ipv4:
+          redistribute:
+            connected: {}
+            static: {}
+  static:
+    vrf:
+    - name: vrf-blue
+      ipv4:
+        route:
+        - prefix: 10.2.0.0/24
+          nexthop:
+          - address: 10.1.0.2

--- a/bdd/tests/configs/bgp_vrf_redistribute/z2-1.yaml
+++ b/bdd/tests/configs/bgp_vrf_redistribute/z2-1.yaml
@@ -1,0 +1,26 @@
+# z2 — remote PE. vrf-blue (RD 65001:200) imports RT 65001:100, so the
+# VPNv4 routes z1 redistributes from its vrf-blue land in z2's vrf-blue.
+# No local origination; z2 only receives over the VPNv4 iBGP session.
+vrf:
+- name: vrf-blue
+  ipv4:
+    route-target:
+      import:
+      - 65001:100
+      export:
+      - 65001:100
+router:
+  bgp:
+    global:
+      as: 65001
+      router-id: 192.168.0.2
+    neighbor:
+    - remote-address: 192.168.0.1
+      afi-safi:
+      - name: vpnv4
+        enabled: true
+      enabled: true
+      remote-as: 65001
+    vrf:
+    - name: vrf-blue
+      rd: 65001:200

--- a/bdd/tests/features/bgp_vrf_redistribute.feature
+++ b/bdd/tests/features/bgp_vrf_redistribute.feature
@@ -1,0 +1,69 @@
+@serial
+@bgp_vrf_redistribute
+Feature: BGP per-VRF redistribute connected/static to VPNv4
+  As a network operator
+  I want `router bgp vrf X afi-safi ipv4 redistribute {connected,static}`
+  to pull a VRF's connected and static routes into the per-VRF BGP table
+  and export them to VPNv4 toward a remote PE — the IOS-XR L3VPN model,
+  without a CE-facing routing protocol.
+
+  Test Topology:
+  ```
+   h1(10.1.0.2) ── z1[vrf-blue]  ── VPNv4 iBGP ──  z2[vrf-blue]
+                   vc1 10.1.0.1/24                  RD 65001:200
+                   static 10.2.0.0/24               RT 65001:100 import
+                   RD 65001:100, RT 65001:100
+                   redistribute connected + static
+   192.168.0.1 ───────────── br0 ───────────── 192.168.0.2
+  ```
+
+  Config files:
+  - z1-1.yaml: AS 65001, vrf-blue (RD 65001:100, RT 65001:100), vc1 in
+    the VRF with 10.1.0.1/24 (connected 10.1.0.0/24), a VRF static route
+    10.2.0.0/24 via 10.1.0.2, and `afi-safi ipv4 redistribute
+    {connected,static}`. VPNv4 iBGP to z2.
+  - z2-1.yaml: AS 65001, vrf-blue (RD 65001:200, RT 65001:100 import).
+    VPNv4 iBGP to z1.
+
+  Scenario: Setup topology
+    Given a clean test environment
+    When I create bridge "br0"
+    And I create namespace "z1" with IP "192.168.0.1/24" on bridge "br0"
+    And I create namespace "z2" with IP "192.168.0.2/24" on bridge "br0"
+    And I create namespace "h1"
+    And I connect namespace "z1" interface "vc1" to namespace "h1" interface "eth0"
+    And I add address "10.1.0.2/24" to interface "eth0" in namespace "h1"
+    And I start zebra-rs in namespace "z1"
+    And I start zebra-rs in namespace "z2"
+    And I apply config "z1-1.yaml" to namespace "z1"
+    And I apply config "z2-1.yaml" to namespace "z2"
+    And I wait 10 seconds for BGP to operate
+    Then BGP session in "z1" to "192.168.0.2" should be "Established"
+    And BGP session in "z2" to "192.168.0.1" should be "Established"
+
+  Scenario: The VRF connected route lands in the VRF table (Phase 0 prereq)
+    Given the test topology exists
+    Then show command "show ip route vrf vrf-blue" in namespace "z1" should contain "10.1.0.0/24"
+    And show command "show ip route vrf vrf-blue" in namespace "z1" should contain "10.2.0.0/24"
+
+  Scenario: z1 redistributes the VRF connected + static routes as VPNv4
+    Given the test topology exists
+    Then show command "show bgp vpnv4" in namespace "z1" should contain "10.1.0.0/24"
+    And show command "show bgp vpnv4" in namespace "z1" should contain "10.2.0.0/24"
+    And show command "show bgp vpnv4" in namespace "z1" should contain "65001:100"
+
+  Scenario: z2 receives the redistributed VRF prefixes as VPNv4 under z1's RD
+    Given the test topology exists
+    Then show command "show bgp vpnv4" in namespace "z2" should contain "10.1.0.0/24"
+    And show command "show bgp vpnv4" in namespace "z2" should contain "10.2.0.0/24"
+    And show command "show bgp vpnv4 10.1.0.0/24" in namespace "z2" should contain "Route Distinguisher: 65001:100"
+
+  Scenario: Teardown topology
+    Given the test topology exists
+    When I stop zebra-rs in namespace "z1"
+    And I stop zebra-rs in namespace "z2"
+    And I delete namespace "z1"
+    And I delete namespace "z2"
+    And I delete namespace "h1"
+    And I delete bridge "br0"
+    Then the test environment should be clean

--- a/zebra-rs/src/bgp/config.rs
+++ b/zebra-rs/src/bgp/config.rs
@@ -4178,12 +4178,36 @@ impl Bgp {
             super::vrf_config::config_vrf_afi_ipv4_network,
         );
         self.callback_add(
+            "/router/bgp/vrf/afi-safi/ipv4/redistribute",
+            super::vrf_config::config_vrf_afi_ipv4_redistribute,
+        );
+        self.callback_add(
+            "/router/bgp/vrf/afi-safi/ipv4/redistribute/connected",
+            super::vrf_config::config_vrf_afi_ipv4_redistribute_connected,
+        );
+        self.callback_add(
+            "/router/bgp/vrf/afi-safi/ipv4/redistribute/static",
+            super::vrf_config::config_vrf_afi_ipv4_redistribute_static,
+        );
+        self.callback_add(
             "/router/bgp/vrf/afi-safi/ipv6",
             super::vrf_config::config_vrf_afi_ipv6,
         );
         self.callback_add(
             "/router/bgp/vrf/afi-safi/ipv6/network",
             super::vrf_config::config_vrf_afi_ipv6_network,
+        );
+        self.callback_add(
+            "/router/bgp/vrf/afi-safi/ipv6/redistribute",
+            super::vrf_config::config_vrf_afi_ipv6_redistribute,
+        );
+        self.callback_add(
+            "/router/bgp/vrf/afi-safi/ipv6/redistribute/connected",
+            super::vrf_config::config_vrf_afi_ipv6_redistribute_connected,
+        );
+        self.callback_add(
+            "/router/bgp/vrf/afi-safi/ipv6/redistribute/static",
+            super::vrf_config::config_vrf_afi_ipv6_redistribute_static,
         );
         self.callback_add(
             "/router/bgp/vrf/evpn/advertise-ipv4",

--- a/zebra-rs/src/bgp/inst.rs
+++ b/zebra-rs/src/bgp/inst.rs
@@ -1598,7 +1598,7 @@ impl Bgp {
             return;
         };
         let preserved_label = if let Some(handle) = self.vrf_registry.remove(name) {
-            super::vrf::despawn_bgp_vrf(name, &handle);
+            super::vrf::despawn_bgp_vrf(name, &handle, &self.rib_subscriber);
             self.unregister_vrf_show(name);
             self.peer_index.retain(|_, owner| owner != name);
             // Withdraw the stale SID by its (old-prefix) address.
@@ -2194,7 +2194,7 @@ impl Bgp {
 
         for name in to_despawn {
             if let Some(handle) = self.vrf_registry.remove(&name) {
-                super::vrf::despawn_bgp_vrf(&name, &handle);
+                super::vrf::despawn_bgp_vrf(&name, &handle, &self.rib_subscriber);
                 self.unregister_vrf_show(&name);
                 // Withdraw the AF_MPLS DecapVrf ILM ahead of
                 // returning the label. The netlink delete keys off
@@ -2348,7 +2348,7 @@ impl Bgp {
         // new handle.
         let (preserved_label, preserved_sid) = if let Some(handle) = self.vrf_registry.remove(name)
         {
-            super::vrf::despawn_bgp_vrf(name, &handle);
+            super::vrf::despawn_bgp_vrf(name, &handle, &self.rib_subscriber);
             self.unregister_vrf_show(name);
             // Clear stale `peer_index` entries — the spawned task
             // is about to push fresh RegisterPeer messages.
@@ -3442,7 +3442,7 @@ impl Bgp {
         };
         let kernel = self.rib_known_vrfs.get(name).cloned();
         let preserved_sid = if let Some(handle) = self.vrf_registry.remove(name) {
-            super::vrf::despawn_bgp_vrf(name, &handle);
+            super::vrf::despawn_bgp_vrf(name, &handle, &self.rib_subscriber);
             self.unregister_vrf_show(name);
             self.peer_index.retain(|_, owner| owner != name);
             handle.srv6_sid

--- a/zebra-rs/src/bgp/vrf/inst.rs
+++ b/zebra-rs/src/bgp/vrf/inst.rs
@@ -15,9 +15,10 @@ use crate::config::{ConfigChannel, ShowChannel};
 use crate::context::{ProtoContext, Task};
 
 use super::super::Message;
+use super::super::config::BgpRedistSource;
 use super::super::interface_addrs::InterfaceAddrs;
 use super::super::peer_map::PeerMap;
-use super::super::route::LocalRib;
+use super::super::route::{LocalRib, ORIGINATED_PEER};
 use super::super::shard::BgpShard;
 use super::super::store::BgpAttrStore;
 use super::super::update_group::UpdateGroupMap;
@@ -66,6 +67,16 @@ pub struct BgpVrf {
     /// dispatcher and the import pipeline push here. `Shutdown`
     /// from `despawn_bgp_vrf` also arrives on this channel.
     pub global_rx: UnboundedReceiver<BgpVrfMsg>,
+    /// RIB redistribute stream. The receive half of the per-VRF RIB
+    /// subscription (`subscribe_for_vrf("bgp:vrf:<name>", table_id)`):
+    /// after the task sends `Message::RedistAdd`, the RIB walks
+    /// `vrf_tables[table_id]` and streams the matching connected/static
+    /// routes here as `RibRx::RouteAdd`/`RouteDel`, which the event
+    /// loop turns into per-VRF Loc-RIB originations + VPNv4/v6 exports.
+    /// A placeholder-context spawn (kernel VRF not yet known) holds a
+    /// closed channel here, so the select arm stays inert until the
+    /// kernel-ctx respawn installs a live subscription.
+    pub rib_rx: UnboundedReceiver<super::super::super::rib::api::RibRx>,
     /// FSM event channel. Per-VRF peers send `Event(ident, ...)`
     /// here when their timers expire or their TCP state changes;
     /// the per-VRF event loop drives the FSM from these. Bounded
@@ -392,6 +403,32 @@ pub fn dispatch_mup(
     }
 }
 
+/// Per-rtype `remote_id` discriminator for redistribute-originated VRF
+/// rows (matches the global `Bgp::redist_remote_id`), so connected /
+/// static / IGP sources — and a `network` row at id 0 — coexist for
+/// one prefix in the per-VRF shard without overwriting one another.
+fn redist_remote_id(rtype: crate::rib::RibType) -> u32 {
+    match rtype {
+        crate::rib::RibType::Connected => 1,
+        crate::rib::RibType::Static => 2,
+        crate::rib::RibType::Ospf => 3,
+        crate::rib::RibType::Isis => 4,
+        crate::rib::RibType::Kernel => 5,
+        _ => 0,
+    }
+}
+
+/// Map a configured redistribute source to the RIB route type the
+/// subscription filters on.
+fn redist_source_rtype(source: BgpRedistSource) -> crate::rib::RibType {
+    match source {
+        BgpRedistSource::Connected => crate::rib::RibType::Connected,
+        BgpRedistSource::Static => crate::rib::RibType::Static,
+        BgpRedistSource::Isis => crate::rib::RibType::Isis,
+        BgpRedistSource::Ospf => crate::rib::RibType::Ospf,
+    }
+}
+
 impl BgpVrf {
     /// Build a `BgpVrf` and the matching inbound sender. The
     /// caller (`spawn_bgp_vrf`) keeps the `BgpVrfInbox`, hands the
@@ -405,6 +442,7 @@ impl BgpVrf {
         asn: u32,
         label: u32,
         global_tx: UnboundedSender<BgpGlobalMsg>,
+        rib_rx: UnboundedReceiver<super::super::super::rib::api::RibRx>,
     ) -> (Self, BgpVrfInbox) {
         let (inbox_tx, global_rx) = mpsc::unbounded_channel();
         let (tx, rx) = mpsc::channel(8192);
@@ -419,6 +457,7 @@ impl BgpVrf {
             show: ShowChannel::new(),
             global_tx,
             global_rx,
+            rib_rx,
             tx,
             rx,
             asn,
@@ -467,6 +506,15 @@ impl BgpVrf {
                     // path handler. Drained but ignored when no
                     // consumer is wired yet — keeps the select!
                     // arm from livelocking.
+                }
+                Some(msg) = self.rib_rx.recv() => {
+                    // Redistributed routes streamed back from the RIB
+                    // (RibRx::RouteAdd/RouteDel for the connected/static
+                    // sources this VRF subscribed to). A placeholder-ctx
+                    // spawn holds a closed channel here, so this arm is
+                    // inert until the kernel-ctx respawn provides a live
+                    // subscription.
+                    self.process_rib_msg(msg);
                 }
                 Some(msg) = self.show.rx.recv() => {
                     // `show bgp vrf <name> …` — the manager stripped the
@@ -1112,6 +1160,166 @@ impl BgpVrf {
         }
     }
 
+    /// Tell the RIB to start redistributing `source` for `afi` into
+    /// this VRF. The RIB resolves our subscriber by proto name
+    /// (`bgp:vrf:<name>`, registered at spawn) → its `vrf_id` (this
+    /// VRF's kernel table id) → walks `vrf_tables[table_id]` and
+    /// streams the matching routes back on `rib_rx`. Empty subtype set
+    /// = wildcard (every subtype under the rtype). `pub(super)` so
+    /// `spawn_bgp_vrf` can replay the staged config at spawn time.
+    pub(super) fn redist_subscribe(&self, afi: crate::rib::RedistAfi, source: BgpRedistSource) {
+        let _ = self.ctx.rib.send(crate::rib::Message::RedistAdd {
+            proto: format!("bgp:vrf:{}", self.name),
+            afi,
+            rtype: redist_source_rtype(source),
+            subtypes: std::collections::BTreeSet::new(),
+        });
+    }
+
+    /// Inverse of [`Self::redist_subscribe`]: drop the redistribute
+    /// subscription. The RIB replays the matched prefixes as
+    /// `RouteDel`, which `process_rib_msg` turns into withdraws — so no
+    /// local sweep is needed here.
+    fn redist_unsubscribe(&self, afi: crate::rib::RedistAfi, source: BgpRedistSource) {
+        let _ = self.ctx.rib.send(crate::rib::Message::RedistDel {
+            proto: format!("bgp:vrf:{}", self.name),
+            afi,
+            rtype: redist_source_rtype(source),
+        });
+    }
+
+    /// Consume one RIB redistribute notification. Only the route
+    /// add/del stream is relevant to a per-VRF redistribute subscriber;
+    /// link / addr / router-id / EoR markers are ignored.
+    fn process_rib_msg(&mut self, msg: crate::rib::api::RibRx) {
+        use crate::rib::RouteBatch;
+        use crate::rib::api::RibRx;
+        match msg {
+            RibRx::RouteAdd { rtype, routes, .. } => match routes {
+                RouteBatch::V4(entries) => {
+                    for e in entries {
+                        self.redist_inject_v4(rtype, e.prefix, e.metric);
+                    }
+                }
+                RouteBatch::V6(entries) => {
+                    for e in entries {
+                        self.redist_inject_v6(rtype, e.prefix, e.metric);
+                    }
+                }
+            },
+            RibRx::RouteDel { rtype, routes, .. } => match routes {
+                RouteBatch::V4(entries) => {
+                    for e in entries {
+                        self.redist_withdraw_v4(rtype, e.prefix);
+                    }
+                }
+                RouteBatch::V6(entries) => {
+                    for e in entries {
+                        self.redist_withdraw_v6(rtype, e.prefix);
+                    }
+                }
+            },
+            _ => {}
+        }
+    }
+
+    /// Originate one redistributed IPv4 route into this VRF's Loc-RIB
+    /// and export the winner to the global VPNv4 table. Mirrors
+    /// [`Self::originate_self_network_v4`] but keyed by a redistribute
+    /// identity (so it coexists with a `network` row for the same
+    /// prefix) and carries the source RIB cost as MED.
+    fn redist_inject_v4(
+        &mut self,
+        rtype: crate::rib::RibType,
+        prefix: ipnet::Ipv4Net,
+        metric: u32,
+    ) {
+        use bgp_packet::{BgpAttr, BgpNexthop, Med, Origin};
+
+        let mut attr = BgpAttr::new();
+        attr.origin = Some(Origin::Incomplete);
+        attr.nexthop = Some(BgpNexthop::Ipv4(self.router_id));
+        attr.med = Some(Med::new(metric));
+        let interned = self.shard.intern(attr);
+
+        let rib = self.redist_originated_rib(interned, rtype);
+        let (_, selected, _) = self.shard.update(None, prefix, rib);
+        if let Some(winner) = selected.first() {
+            let exporter = self.exporter();
+            vrf_emit_export(&exporter, prefix, &winner.attr);
+        }
+    }
+
+    /// Inverse of [`Self::redist_inject_v4`].
+    fn redist_withdraw_v4(&mut self, rtype: crate::rib::RibType, prefix: ipnet::Ipv4Net) {
+        let removed = self
+            .shard
+            .remove(None, prefix, redist_remote_id(rtype), ORIGINATED_PEER);
+        if removed.is_empty() {
+            return;
+        }
+        let exporter = self.exporter();
+        match self.shard.select_best_path(prefix).first() {
+            Some(winner) => vrf_emit_export(&exporter, prefix, &winner.attr),
+            None => vrf_emit_withdraw(&exporter, prefix),
+        }
+    }
+
+    /// IPv6 counterpart of [`Self::redist_inject_v4`]. The next-hop is a
+    /// placeholder — the global re-advertise rewrites it to
+    /// next-hop-self in `route_update_ipv6`.
+    fn redist_inject_v6(
+        &mut self,
+        rtype: crate::rib::RibType,
+        prefix: ipnet::Ipv6Net,
+        metric: u32,
+    ) {
+        use bgp_packet::{BgpAttr, BgpNexthop, Med, Origin};
+
+        let mut attr = BgpAttr::new();
+        attr.origin = Some(Origin::Incomplete);
+        attr.nexthop = Some(BgpNexthop::Ipv6(std::net::Ipv6Addr::UNSPECIFIED));
+        attr.med = Some(Med::new(metric));
+        let interned = self.shard.intern(attr);
+
+        let rib = self.redist_originated_rib(interned, rtype);
+        let (_, selected, _) = self.shard.update_v6(prefix, rib);
+        if let Some(winner) = selected.first() {
+            let exporter = self.exporter();
+            vrf_emit_export_v6(&exporter, prefix, &winner.attr);
+        }
+    }
+
+    /// IPv6 counterpart of [`Self::redist_withdraw_v4`].
+    fn redist_withdraw_v6(&mut self, rtype: crate::rib::RibType, prefix: ipnet::Ipv6Net) {
+        let removed = self
+            .shard
+            .remove_v6(prefix, redist_remote_id(rtype), ORIGINATED_PEER);
+        if removed.is_empty() {
+            return;
+        }
+        let exporter = self.exporter();
+        match self.shard.select_best_path_v6(prefix).first() {
+            Some(winner) => vrf_emit_export_v6(&exporter, prefix, &winner.attr),
+            None => vrf_emit_withdraw_v6(&exporter, prefix),
+        }
+    }
+
+    /// A redistribute-originated [`BgpRib`]: the self-originated shape
+    /// with a redistribute identity (ident `ORIGINATED_PEER`, per-rtype
+    /// `remote_id`) so distinct sources — and a `network` row at
+    /// id 0 — coexist for the same prefix without overwriting.
+    fn redist_originated_rib(
+        &self,
+        attr: std::sync::Arc<bgp_packet::BgpAttr>,
+        rtype: crate::rib::RibType,
+    ) -> super::super::route::BgpRib {
+        let mut rib = self.self_originated_rib(attr);
+        rib.ident = ORIGINATED_PEER;
+        rib.remote_id = redist_remote_id(rtype);
+        rib
+    }
+
     /// Build a fresh [`VrfExporter`] pointing at the global task.
     fn exporter(&self) -> VrfExporter {
         VrfExporter {
@@ -1235,6 +1443,12 @@ impl BgpVrf {
             BgpVrfMsg::WithdrawNetworkV6 { prefix } => {
                 self.withdraw_self_network_v6(prefix);
             }
+            BgpVrfMsg::RedistEnable { afi, source } => {
+                self.redist_subscribe(afi, source);
+            }
+            BgpVrfMsg::RedistDisable { afi, source } => {
+                self.redist_unsubscribe(afi, source);
+            }
             // Display-only mirror of the global MUP best-path for this
             // VRF's RD, so `show bgp vrf <name> mup` (redirected here)
             // renders the VRF's ST routes. We touch only `selected`
@@ -1285,6 +1499,7 @@ mod tests {
         // down cleanly.
         let (global_tx, _global_rx) = unbounded_channel::<BgpGlobalMsg>();
         let ctx = test_ctx_for_vrf(10, "vrf-test");
+        let (_rib_tx, rib_rx) = mpsc::unbounded_channel();
         let (mut vrf, inbox) = BgpVrf::new(
             "vrf-test".to_string(),
             ctx,
@@ -1292,6 +1507,7 @@ mod tests {
             65000,
             /* label */ 16,
             global_tx,
+            rib_rx,
         );
 
         inbox.send(BgpVrfMsg::Shutdown).expect("inbound rx alive");
@@ -1312,6 +1528,7 @@ mod tests {
         // leak the task.
         let (global_tx, _global_rx) = unbounded_channel::<BgpGlobalMsg>();
         let ctx = test_ctx_for_vrf(11, "vrf-test2");
+        let (_rib_tx, rib_rx) = mpsc::unbounded_channel();
         let (mut vrf, inbox) = BgpVrf::new(
             "vrf-test2".to_string(),
             ctx,
@@ -1319,6 +1536,7 @@ mod tests {
             65000,
             /* label */ 16,
             global_tx,
+            rib_rx,
         );
 
         drop(inbox);

--- a/zebra-rs/src/bgp/vrf/msg.rs
+++ b/zebra-rs/src/bgp/vrf/msg.rs
@@ -114,6 +114,24 @@ pub enum BgpVrfMsg {
     /// IPv6 counterpart of [`Self::WithdrawNetwork`].
     WithdrawNetworkV6 { prefix: Ipv6Net },
 
+    /// A `redistribute {connected,static}` source was enabled for this
+    /// VRF/AFI on a running task. The task sends `Message::RedistAdd`
+    /// to the RIB (proto `bgp:vrf:<name>`, vrf_id = this VRF's table
+    /// id), so the RIB walks `vrf_tables[table_id]` and streams the
+    /// matching routes back on `rib_rx` for origination + VPN export.
+    RedistEnable {
+        afi: crate::rib::RedistAfi,
+        source: crate::bgp::config::BgpRedistSource,
+    },
+
+    /// Inverse of [`Self::RedistEnable`]: a redistribute source was
+    /// removed. The task sends `Message::RedistDel`; the RIB replays
+    /// the matching prefixes as `RouteDel` so the task withdraws them.
+    RedistDisable {
+        afi: crate::rib::RedistAfi,
+        source: crate::bgp::config::BgpRedistSource,
+    },
+
     /// Snapshot of the global colour-steering state (Color→Flex-Algo
     /// bindings + the per-algo SRv6 End-SID shadow) so the per-VRF FIB
     /// install can steer imported SRv6 L3VPN routes into a Flex-Algo.

--- a/zebra-rs/src/bgp/vrf/spawn.rs
+++ b/zebra-rs/src/bgp/vrf/spawn.rs
@@ -128,25 +128,31 @@ pub fn spawn_bgp_vrf(
     // later.
     let kernel_table_id = kernel.as_ref().map(|k| k.table_id);
     let kernel_ifindex = kernel.as_ref().map(|k| k.ifindex);
-    let ctx = match kernel {
+    let (ctx, rib_rx) = match kernel {
         Some(k) => {
             // Mint a fresh `RibClient` for this VRF. The
-            // subscription's `vrf_id` tells RIB to route the
-            // task's route installs into `vrf_tables[table_id]`.
-            // The `RibRx` half is leaked — per-VRF subscribers
-            // don't yet consume RIB outbound notifications; that's
-            // a follow-up.
+            // subscription's `vrf_id` tells RIB to route the task's
+            // route installs into `vrf_tables[table_id]` and (now that
+            // the `RibRx` half is consumed) to stream this VRF's
+            // redistributed routes back for VPNv4/v6 origination.
             let proto = format!("bgp:vrf:{name}");
             let (rib_client, rib_rx) = rib_subscriber.subscribe_for_vrf(&proto, k.table_id);
-            Box::leak(Box::new(rib_rx));
-            ProtoContext::for_vrf(rib_client, k.table_id, name.clone())
+            (
+                ProtoContext::for_vrf(rib_client, k.table_id, name.clone()),
+                rib_rx,
+            )
         }
         None => {
             tracing::debug!(
                 vrf = %name,
                 "bgp: spawning per-VRF task with placeholder context (kernel VRF not yet known)",
             );
-            ProtoContext::default_table_no_rib()
+            // No subscription without a kernel table; hand the task a
+            // closed channel so its redistribute select arm stays inert
+            // until `maybe_respawn_vrf_with_kernel_ctx` re-spawns with a
+            // live subscription.
+            let (_closed_tx, rib_rx) = tokio::sync::mpsc::unbounded_channel();
+            (ProtoContext::default_table_no_rib(), rib_rx)
         }
     };
     // Per-VRF override on router-id wins over the global one. An
@@ -160,6 +166,7 @@ pub fn spawn_bgp_vrf(
         asn,
         label,
         global_tx,
+        rib_rx,
     );
     // Inter-AS Option AB: re-export imported VPNv4 routes (see the field
     // doc on `BgpVrf`). Carried from the staged VRF config.
@@ -191,6 +198,14 @@ pub fn spawn_bgp_vrf(
     // promotes them to VPNv4 advertisements toward PE peers.
     let network_count = materialize_self_originated_networks(&mut vrf, cfg)
         + materialize_self_originated_networks_v6(&mut vrf, cfg);
+
+    // Replay staged `afi-safi {ipv4,ipv6} redistribute {connected,
+    // static}` by (re)sending RedistAdd to the RIB. The walk's matching
+    // routes stream back on `rib_rx` for origination + VPNv4/v6 export
+    // once the event loop runs. A placeholder-ctx spawn has no live RIB
+    // client, so the sends are dropped harmlessly; the kernel-ctx
+    // respawn (which reads the same staged config) replays them.
+    let redist_count = materialize_vrf_redistribute(&vrf, cfg);
 
     // Install the AF_MPLS DecapVrf ILM at the allocated label so a
     // remote PE's VPNv4 packet with this label pops + lands in
@@ -267,6 +282,7 @@ pub fn spawn_bgp_vrf(
         srv6_sid = ?srv6_sid.map(|(addr, _)| addr),
         peers = peer_count,
         networks = network_count,
+        redistribute = redist_count,
         "bgp: spawned per-VRF task",
     );
     BgpVrfHandle {
@@ -384,13 +400,45 @@ fn materialize_self_originated_networks_v6(vrf: &mut BgpVrf, cfg: &BgpVrfConfig)
     af.networks.len()
 }
 
+/// Replay `afi-safi {ipv4,ipv6} redistribute {connected,static}` from
+/// the staged config by (re)sending RedistAdd to the RIB for each
+/// enabled source. Spawn-time twin of the dynamic
+/// [`BgpVrfMsg::RedistEnable`] path, so initial-config and post-spawn
+/// subscription stay identical. Returns the number of (afi, source)
+/// subscriptions replayed.
+fn materialize_vrf_redistribute(vrf: &BgpVrf, cfg: &BgpVrfConfig) -> usize {
+    let mut count = 0;
+    if let Some(af) = cfg.ipv4_unicast.as_ref() {
+        for source in &af.redistribute {
+            vrf.redist_subscribe(crate::rib::RedistAfi::Ipv4, *source);
+            count += 1;
+        }
+    }
+    if let Some(af) = cfg.ipv6_unicast.as_ref() {
+        for source in &af.redistribute {
+            vrf.redist_subscribe(crate::rib::RedistAfi::Ipv6, *source);
+            count += 1;
+        }
+    }
+    count
+}
+
 /// Send `Shutdown` to the per-VRF task. Caller drops the handle
 /// from `vrf_registry` *after* this returns; dropping the handle
 /// without sending `Shutdown` first would leak a final
 /// `BgpVrfMsg` send window — the FSM might miss state it needs to
 /// flush. The handle's `Task` aborts on drop regardless, so a
 /// failure path here doesn't strand the runtime.
-pub fn despawn_bgp_vrf(name: &str, handle: &BgpVrfHandle) {
+pub fn despawn_bgp_vrf(name: &str, handle: &BgpVrfHandle, rib_subscriber: &RibSubscriber) {
+    // Drop this VRF's RIB redistribute subscription (client-registry +
+    // redist-filter rows) so a respawn under the same `bgp:vrf:<name>`
+    // proto doesn't leave a stale subscriber shadowing the live one —
+    // `subscriber_for_proto` returns the first match by name. ProtoCleanup
+    // for a per-VRF proto only drops these rows (the VRF's routes live in
+    // `vrf_tables` and are reclaimed by `VrfDel`), so it's safe to call on
+    // both teardown and respawn. Sent before `Shutdown` so it's ordered
+    // ahead of any later re-subscribe by the respawn's `spawn_bgp_vrf`.
+    rib_subscriber.send_proto_cleanup(&format!("bgp:vrf:{name}"));
     if handle.inbox.send(BgpVrfMsg::Shutdown).is_err() {
         // Receiver already gone — the task exited on its own
         // (e.g. inbox-drop path). Nothing left to do.
@@ -462,6 +510,7 @@ mod tests {
         // the rx is dropped at end of scope.
         let (global_tx, _global_rx) = unbounded_channel::<BgpGlobalMsg>();
         let ctx = ProtoContext::default_table_no_rib();
+        let (_rib_tx, rib_rx) = unbounded_channel();
         let (mut vrf, _inbox) = BgpVrf::new(
             "v1".to_string(),
             ctx,
@@ -469,6 +518,7 @@ mod tests {
             65000,
             /* label */ 16,
             global_tx,
+            rib_rx,
         );
 
         let mut cfg = BgpVrfConfig::default();
@@ -517,6 +567,7 @@ mod tests {
 
         let (global_tx, _global_rx) = unbounded_channel::<BgpGlobalMsg>();
         let ctx = ProtoContext::default_table_no_rib();
+        let (_rib_tx, rib_rx) = unbounded_channel();
         let (mut vrf, _inbox) = BgpVrf::new(
             "v0".to_string(),
             ctx,
@@ -524,6 +575,7 @@ mod tests {
             65000,
             /* label */ 16,
             global_tx,
+            rib_rx,
         );
 
         let cfg = BgpVrfConfig::default();

--- a/zebra-rs/src/bgp/vrf_config.rs
+++ b/zebra-rs/src/bgp/vrf_config.rs
@@ -33,7 +33,9 @@ use crate::bgp_vrf_trace;
 use crate::config::{Args, ConfigOp};
 
 use super::Bgp;
+use super::config::BgpRedistSource;
 use super::vrf::msg::BgpVrfMsg;
+use crate::rib::RedistAfi;
 
 /// MPLS label allocation strategy for VPN routes originated from a
 /// VRF — mirrors `label-mode` in zebra-bgp-vrf.yang. Default is
@@ -112,12 +114,19 @@ impl Default for BgpVrfNeighborConfig {
 #[derive(Debug, Clone)]
 pub struct BgpVrfAfConfig<N: Ord> {
     pub networks: BTreeSet<N>,
+    /// Redistribution sources enabled for this VRF/AFI
+    /// (`afi-safi {ipv4,ipv6} redistribute {connected,static}`). Each
+    /// pulls the VRF table's routes of that protocol into the per-VRF
+    /// Loc-RIB for VPNv4/v6 export. Bare presence today (no per-source
+    /// modifiers).
+    pub redistribute: BTreeSet<BgpRedistSource>,
 }
 
 impl<N: Ord> Default for BgpVrfAfConfig<N> {
     fn default() -> Self {
         Self {
             networks: BTreeSet::new(),
+            redistribute: BTreeSet::new(),
         }
     }
 }
@@ -714,6 +723,145 @@ pub fn config_vrf_afi_ipv6_network(bgp: &mut Bgp, mut args: Args, op: ConfigOp) 
         let _ = handle.inbox.send(msg);
     }
     Some(())
+}
+
+/// Enable/disable one redistribute source for a VRF/AFI in the staged
+/// config, and drive the change onto the running VRF task. Shared by
+/// the four `redistribute {connected,static}` callbacks. Mirrors the
+/// `network` callbacks: `compute_vrf_diff` only re-spawns on the VRF
+/// *name* set, so a redistribute-only change reaches a live task through
+/// a [`BgpVrfMsg`]; an initial-config VRF picks it up at spawn-time
+/// materialization, which reads the same `redistribute` set.
+fn vrf_redist_set(
+    bgp: &mut Bgp,
+    name: String,
+    afi: RedistAfi,
+    source: BgpRedistSource,
+    op: ConfigOp,
+) -> Option<()> {
+    let set = match op {
+        ConfigOp::Set => true,
+        ConfigOp::Delete => false,
+        _ => return Some(()),
+    };
+    {
+        let cfg = vrf_entry(bgp, name.clone());
+        let redist = match afi {
+            RedistAfi::Ipv4 => {
+                &mut cfg
+                    .ipv4_unicast
+                    .get_or_insert_with(Default::default)
+                    .redistribute
+            }
+            RedistAfi::Ipv6 => {
+                &mut cfg
+                    .ipv6_unicast
+                    .get_or_insert_with(Default::default)
+                    .redistribute
+            }
+        };
+        if set {
+            redist.insert(source);
+        } else {
+            redist.remove(&source);
+        }
+    }
+    if let Some(handle) = bgp.vrf_registry.get(&name) {
+        let msg = if set {
+            BgpVrfMsg::RedistEnable { afi, source }
+        } else {
+            BgpVrfMsg::RedistDisable { afi, source }
+        };
+        let _ = handle.inbox.send(msg);
+    }
+    Some(())
+}
+
+/// Clear every redistribute source for a VRF/AFI and withdraw them
+/// from the running task. Driven by the `redistribute` container
+/// delete, whose child source-deletes the diff does not re-emit (same
+/// rationale as `config_vrf_afi_ipv4`'s network sweep).
+fn vrf_redist_clear(bgp: &mut Bgp, name: String, afi: RedistAfi) {
+    let sources: Vec<BgpRedistSource> = {
+        let cfg = vrf_entry(bgp, name.clone());
+        let redist = match afi {
+            RedistAfi::Ipv4 => cfg.ipv4_unicast.as_mut().map(|af| &mut af.redistribute),
+            RedistAfi::Ipv6 => cfg.ipv6_unicast.as_mut().map(|af| &mut af.redistribute),
+        };
+        match redist {
+            Some(set) => {
+                let drained: Vec<_> = set.iter().copied().collect();
+                set.clear();
+                drained
+            }
+            None => Vec::new(),
+        }
+    };
+    if let Some(handle) = bgp.vrf_registry.get(&name) {
+        for source in sources {
+            let _ = handle.inbox.send(BgpVrfMsg::RedistDisable { afi, source });
+        }
+    }
+}
+
+/// `delete router bgp vrf <NAME> afi-safi ipv4 redistribute` — clear
+/// all IPv4 redistribute sources. The set callback for the bare
+/// container is a no-op (sources are enabled by their own leaves).
+pub fn config_vrf_afi_ipv4_redistribute(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Option<()> {
+    let name = args.string()?;
+    if matches!(op, ConfigOp::Delete) {
+        vrf_redist_clear(bgp, name, RedistAfi::Ipv4);
+    }
+    Some(())
+}
+
+/// `set router bgp vrf <NAME> afi-safi ipv4 redistribute connected`.
+pub fn config_vrf_afi_ipv4_redistribute_connected(
+    bgp: &mut Bgp,
+    mut args: Args,
+    op: ConfigOp,
+) -> Option<()> {
+    let name = args.string()?;
+    vrf_redist_set(bgp, name, RedistAfi::Ipv4, BgpRedistSource::Connected, op)
+}
+
+/// `set router bgp vrf <NAME> afi-safi ipv4 redistribute static`.
+pub fn config_vrf_afi_ipv4_redistribute_static(
+    bgp: &mut Bgp,
+    mut args: Args,
+    op: ConfigOp,
+) -> Option<()> {
+    let name = args.string()?;
+    vrf_redist_set(bgp, name, RedistAfi::Ipv4, BgpRedistSource::Static, op)
+}
+
+/// `delete router bgp vrf <NAME> afi-safi ipv6 redistribute`.
+pub fn config_vrf_afi_ipv6_redistribute(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Option<()> {
+    let name = args.string()?;
+    if matches!(op, ConfigOp::Delete) {
+        vrf_redist_clear(bgp, name, RedistAfi::Ipv6);
+    }
+    Some(())
+}
+
+/// `set router bgp vrf <NAME> afi-safi ipv6 redistribute connected`.
+pub fn config_vrf_afi_ipv6_redistribute_connected(
+    bgp: &mut Bgp,
+    mut args: Args,
+    op: ConfigOp,
+) -> Option<()> {
+    let name = args.string()?;
+    vrf_redist_set(bgp, name, RedistAfi::Ipv6, BgpRedistSource::Connected, op)
+}
+
+/// `set router bgp vrf <NAME> afi-safi ipv6 redistribute static`.
+pub fn config_vrf_afi_ipv6_redistribute_static(
+    bgp: &mut Bgp,
+    mut args: Args,
+    op: ConfigOp,
+) -> Option<()> {
+    let name = args.string()?;
+    vrf_redist_set(bgp, name, RedistAfi::Ipv6, BgpRedistSource::Static, op)
 }
 
 /// `set router bgp vrf <NAME> evpn advertise-ipv4 <bool>`.

--- a/zebra-rs/src/config/manager.rs
+++ b/zebra-rs/src/config/manager.rs
@@ -1623,6 +1623,40 @@ mod yang_load_tests {
         }
     }
 
+    /// Regression guard for the per-VRF redistribute grammar
+    /// (zebra-bgp-vrf.yang `afi-safi {ipv4,ipv6} redistribute
+    /// {connected,static}`). Pins the new bare-presence paths so a
+    /// broken grouping or a stale callback path is caught in the unit
+    /// suite, not only in the `@bgp_vrf_redistribute` BDD.
+    #[test]
+    fn bgp_vrf_redistribute_paths_parse() {
+        use crate::config::ExecCode;
+        use crate::config::parse::{State, parse};
+        use libyang::to_entry;
+
+        let mut yang = YangStore::new();
+        yang.add_path(concat!(env!("CARGO_MANIFEST_DIR"), "/yang"));
+        yang.read_with_resolve("configure")
+            .unwrap_or_else(|e| panic!("configure failed to load: {e:#}"));
+        yang.identity_resolve();
+        let module = yang.find_module("configure").unwrap();
+        let entry = to_entry(&yang, module);
+
+        for cmd in [
+            "set router bgp vrf N3 afi-safi ipv4 redistribute connected",
+            "set router bgp vrf N3 afi-safi ipv4 redistribute static",
+            "set router bgp vrf N3 afi-safi ipv6 redistribute connected",
+            "set router bgp vrf N3 afi-safi ipv6 redistribute static",
+        ] {
+            let (code, _comps, _state) = parse(cmd, entry.clone(), None, State::new());
+            assert_eq!(
+                code,
+                ExecCode::Success,
+                "should parse as a settable path: {cmd}"
+            );
+        }
+    }
+
     /// Regression guard for the per-VRF MUP `route` list (zebra-bgp-vrf.yang).
     /// Both ST bindings now live under `afi-safi mup route {st1|st2}`
     /// (collapsed enum-keyed list): st1 (downlink / N6) and st2 (uplink /

--- a/zebra-rs/yang/zebra-bgp-vrf.yang
+++ b/zebra-rs/yang/zebra-bgp-vrf.yang
@@ -178,6 +178,31 @@ module zebra-bgp-vrf {
     }
   }
 
+  grouping bgp-vrf-redistribute {
+    description
+      "Per-VRF, per-AFI redistribution of RIB routes into this VRF's
+       BGP table. A source's routes are taken from the VRF's own
+       routing table (`vrf_tables[table_id]`, never the default
+       table), originated into the per-VRF Loc-RIB, and exported to
+       the global VPNv4 / VPNv6 RIB with the VRF's RD and export
+       route-targets — the standard IOS-XR `router bgp … vrf …
+       address-family … redistribute …` model.
+
+       Bare presence containers (no per-source modifiers yet); the
+       redistributed route's MED follows the source RIB cost.
+       `connected` and `static` are wired today; IS-IS / OSPF land in
+       a follow-up.";
+    container redistribute {
+      presence "Enable route redistribution into this VRF's BGP table";
+      container connected {
+        presence "Redistribute this VRF's connected routes";
+      }
+      container static {
+        presence "Redistribute this VRF's static routes";
+      }
+    }
+  }
+
   grouping bgp-vrf-afi-safi {
     description
       "Per-VRF address-family configuration. Only the IPv4 and IPv6
@@ -203,6 +228,7 @@ module zebra-bgp-vrf {
             type inet:ipv4-prefix;
           }
         }
+        uses bgp-vrf-redistribute;
       }
       container ipv6 {
         presence "Enables the IPv6 unicast family for this VRF";
@@ -212,6 +238,7 @@ module zebra-bgp-vrf {
             type inet:ipv6-prefix;
           }
         }
+        uses bgp-vrf-redistribute;
       }
       container mup {
         description


### PR DESCRIPTION
## Summary

Implements `router bgp vrf X afi-safi {ipv4,ipv6} redistribute {connected,static}` — the Cisco IOS-XR L3VPN model. A VRF's **connected** and **static** routes are pulled from its own RIB table into the per-VRF BGP Loc-RIB and exported to **VPNv4/VPNv6** with the VRF's RD + export route-targets, so a PE can originate VPN routes for its directly-attached subnets and static routes toward the CE without a CE-facing routing protocol.

Builds on the per-VRF RIB redistribute plumbing (table selection + steady-state delta hook) merged in #1671.

## Changes

- **YANG** (`zebra-bgp-vrf.yang`): bare-presence `redistribute {connected,static}` grouping under the VRF `ipv4`/`ipv6` afi-safi nodes (modifiers/IGP sources deferred).
- **Config** (`vrf_config.rs`, `config.rs`): `redistribute` set on `BgpVrfAfConfig`; six callbacks (container delete + per-source, both AFIs) stage config and **live-update** the running task via `BgpVrfMsg`, mirroring the existing `network` callbacks.
- **VRF task** (`vrf/inst.rs`, `vrf/msg.rs`): the per-VRF RIB subscription's `rib_rx` (previously leaked) is now consumed by a new `select!` arm — `RibRx::RouteAdd/Del` → `redist_inject/withdraw_v4/v6` (originate with MED from the RIB cost, next-hop-self, and a redistribute identity so it coexists with a `network` row at id 0) → `vrf_emit_export` → global VPNv4/v6. `RedistEnable/Disable` send `RedistAdd/Del` to the RIB.
- **Spawn/despawn** (`vrf/spawn.rs`, `inst.rs`): spawn-time materialization replays staged redistribute; `despawn_bgp_vrf` now sends `proto_cleanup` so a respawn (relabel / kernel-ctx lift / SID realloc) can't leave a stale subscriber shadowing the live one (`subscriber_for_proto` resolves by name).

## Test plan

- New BDD **`bgp_vrf_redistribute`** (2-node PE topology, all 5 scenarios pass): z1 redistributes its VRF connected (`10.1.0.0/24`) + static (`10.2.0.0/24`) routes, exports them as VPNv4 with RD `65001:100`, and **remote PE z2 receives them** under that RD.
- Regression: `bgp_vrf_vpnv4_export`, `bgp_vrf_vpnv6_export`, `vrf_connected_route` BDDs all pass (paths I touched: VRF spawn/despawn + network export).
- New `bgp_vrf_redistribute_paths_parse` yang-load grammar guard.
- `cargo fmt` + `cargo clippy --workspace --all-targets -- -D warnings` clean; **1482 unit tests pass**.

## Follow-ups
- Per-source modifiers (policy/route-map, metric override, multipath).
- `redistribute ospf` / `redistribute isis` (the RIB plumbing + IGP VRF instances already feed `vrf_tables`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)