### PR TITLE
feat(bgp): per-VRF redistribute OSPF/IS-IS to VPNv4/v6

### DIFF
--- a/bdd/Makefile
+++ b/bdd/Makefile
@@ -160,6 +160,10 @@ bgp_vrf_redistribute:
 	mkdir -p allure-results
 	cargo test --test cucumber -- --concurrency=1 --tags "@bgp_vrf_redistribute"
 
+bgp_vrf_ospf_redist:
+	mkdir -p allure-results
+	cargo test --test cucumber -- --concurrency=1 --tags "@bgp_vrf_ospf_redist"
+
 isis_afi_enable:
 	mkdir -p allure-results
 	cargo test --test cucumber -- --concurrency=1 --tags "@isis_afi_enable"

--- a/bdd/tests/configs/bgp_vrf_ospf_redist/ce.yaml
+++ b/bdd/tests/configs/bgp_vrf_ospf_redist/ce.yaml
@@ -1,0 +1,22 @@
+# ce — CE router speaking OSPF to z1 (in the default table; the PE side
+# runs OSPF inside vrf-blue). Advertises its loopback 10.9.9.9/32 into
+# area 0 so z1 learns it as an OSPF route in the VRF table, which z1 then
+# redistributes into VPNv4.
+interface:
+- if-name: lo
+  ipv4:
+    address: 10.9.9.9/32
+- if-name: eth0
+  ipv4:
+    address: 10.0.0.2/30
+router:
+  ospf:
+    router-id: 10.9.9.9
+    area:
+    - area-id: 0.0.0.0
+      interface:
+      - if-name: lo
+        enable: true
+      - if-name: eth0
+        enable: true
+        network-type: point-to-point

--- a/bdd/tests/configs/bgp_vrf_ospf_redist/z1-1.yaml
+++ b/bdd/tests/configs/bgp_vrf_ospf_redist/z1-1.yaml
@@ -1,0 +1,48 @@
+# z1 — PE running OSPF inside vrf-blue toward the CE and redistributing
+# the CE-learned OSPF route into VPNv4. Interface oc1 is enslaved to
+# vrf-blue; `router ospf vrf vrf-blue` forms an adjacency with the CE on
+# it and installs 10.9.9.9/32 into the VRF table as an OSPF route.
+# `afi-safi ipv4 redistribute ospf` pulls that (but NOT the connected
+# link 10.0.0.0/30) into the per-VRF BGP table for VPNv4 export to z2.
+vrf:
+- name: vrf-blue
+  ipv4:
+    route-target:
+      import:
+      - 65001:100
+      export:
+      - 65001:100
+interface:
+- if-name: oc1
+  vrf: vrf-blue
+  ipv4:
+    address: 10.0.0.1/30
+router:
+  ospf:
+    vrf:
+    - name: vrf-blue
+      router-id: 10.0.0.1
+      area:
+      - area-id: 0.0.0.0
+        interface:
+        - if-name: oc1
+          enable: true
+          network-type: point-to-point
+  bgp:
+    global:
+      as: 65001
+      router-id: 192.168.0.1
+    neighbor:
+    - remote-address: 192.168.0.2
+      afi-safi:
+      - name: vpnv4
+        enabled: true
+      enabled: true
+      remote-as: 65001
+    vrf:
+    - name: vrf-blue
+      rd: 65001:100
+      afi-safi:
+        ipv4:
+          redistribute:
+            ospf: {}

--- a/bdd/tests/configs/bgp_vrf_ospf_redist/z2-1.yaml
+++ b/bdd/tests/configs/bgp_vrf_ospf_redist/z2-1.yaml
@@ -1,0 +1,26 @@
+# z2 — remote PE. vrf-blue (RD 65001:200) imports RT 65001:100, so the
+# OSPF route z1 redistributes from its vrf-blue lands in z2's vrf-blue
+# over the VPNv4 iBGP session. No local origination.
+vrf:
+- name: vrf-blue
+  ipv4:
+    route-target:
+      import:
+      - 65001:100
+      export:
+      - 65001:100
+router:
+  bgp:
+    global:
+      as: 65001
+      router-id: 192.168.0.2
+    neighbor:
+    - remote-address: 192.168.0.1
+      afi-safi:
+      - name: vpnv4
+        enabled: true
+      enabled: true
+      remote-as: 65001
+    vrf:
+    - name: vrf-blue
+      rd: 65001:200

--- a/bdd/tests/features/bgp_vrf_ospf_redist.feature
+++ b/bdd/tests/features/bgp_vrf_ospf_redist.feature
@@ -1,0 +1,71 @@
+@serial
+@bgp_vrf_ospf_redist
+Feature: BGP per-VRF redistribute OSPF to VPNv4
+  As a network operator
+  I want `router bgp vrf X afi-safi ipv4 redistribute ospf` to pull a
+  VRF's OSPF-learned routes (installed by a per-VRF OSPF instance into
+  the VRF table) into the per-VRF BGP table and export them to VPNv4 —
+  so a PE advertises CE-learned IGP routes into the L3VPN.
+
+  Test Topology:
+  ```
+   ce(OSPF) ── oc1 ── z1[vrf-blue: ospf + bgp] ── VPNv4 iBGP ── z2[vrf-blue]
+   lo 10.9.9.9/32     10.0.0.1/30 (vrf-blue)                    RD 65001:200
+   area 0             router ospf vrf vrf-blue                  RT 65001:100 imp
+                      redistribute ospf, RD 65001:100
+   10.0.0.2/30 ───────────── (veth) ──────────
+   192.168.0.1 ───────────── br0 ───────────── 192.168.0.2
+  ```
+
+  Config files:
+  - ce.yaml: OSPF only; lo 10.9.9.9/32 + eth0 10.0.0.2/30 in area 0.
+  - z1-1.yaml: vrf-blue (RD 65001:100, RT 65001:100), oc1 in the VRF
+    (10.0.0.1/30), `router ospf vrf vrf-blue` on oc1, `afi-safi ipv4
+    redistribute ospf`, VPNv4 iBGP to z2.
+  - z2-1.yaml: vrf-blue (RD 65001:200, RT 65001:100 import), VPNv4 iBGP
+    to z1.
+
+  Scenario: Setup topology
+    Given a clean test environment
+    When I create bridge "br0"
+    And I create namespace "z1" with IP "192.168.0.1/24" on bridge "br0"
+    And I create namespace "z2" with IP "192.168.0.2/24" on bridge "br0"
+    And I create namespace "ce"
+    And I connect namespace "z1" interface "oc1" to namespace "ce" interface "eth0"
+    And I start zebra-rs in namespace "z1"
+    And I start zebra-rs in namespace "z2"
+    And I start zebra-rs in namespace "ce"
+    And I apply config "z1-1.yaml" to namespace "z1"
+    And I apply config "z2-1.yaml" to namespace "z2"
+    And I apply config "ce.yaml" to namespace "ce"
+    And I wait 30 seconds for BGP to operate
+    Then BGP session in "z1" to "192.168.0.2" should be "Established"
+    And BGP session in "z2" to "192.168.0.1" should be "Established"
+
+  Scenario: z1 learns the CE's OSPF route in the VRF table
+    Given the test topology exists
+    Then show command "show ip route vrf vrf-blue" in namespace "z1" should eventually contain "10.9.9.9/32"
+
+  Scenario: z1 redistributes the VRF OSPF route as VPNv4, not the connected link
+    Given the test topology exists
+    Then show command "show bgp vpnv4" in namespace "z1" should eventually contain "10.9.9.9/32"
+    And show command "show bgp vpnv4" in namespace "z1" should eventually contain "65001:100"
+    # `redistribute ospf` takes only OSPF routes — the connected /30 link
+    # is RibType::Connected, so it must NOT be exported.
+    And show command "show bgp vpnv4" in namespace "z1" should not contain "10.0.0.0/30"
+
+  Scenario: z2 receives the redistributed OSPF prefix as VPNv4 under z1's RD
+    Given the test topology exists
+    Then show command "show bgp vpnv4" in namespace "z2" should eventually contain "10.9.9.9/32"
+    And show command "show bgp vpnv4 10.9.9.9/32" in namespace "z2" should eventually contain "Route Distinguisher: 65001:100"
+
+  Scenario: Teardown topology
+    Given the test topology exists
+    When I stop zebra-rs in namespace "z1"
+    And I stop zebra-rs in namespace "z2"
+    And I stop zebra-rs in namespace "ce"
+    And I delete namespace "z1"
+    And I delete namespace "z2"
+    And I delete namespace "ce"
+    And I delete bridge "br0"
+    Then the test environment should be clean

--- a/zebra-rs/src/bgp/config.rs
+++ b/zebra-rs/src/bgp/config.rs
@@ -4190,6 +4190,14 @@ impl Bgp {
             super::vrf_config::config_vrf_afi_ipv4_redistribute_static,
         );
         self.callback_add(
+            "/router/bgp/vrf/afi-safi/ipv4/redistribute/ospf",
+            super::vrf_config::config_vrf_afi_ipv4_redistribute_ospf,
+        );
+        self.callback_add(
+            "/router/bgp/vrf/afi-safi/ipv4/redistribute/isis",
+            super::vrf_config::config_vrf_afi_ipv4_redistribute_isis,
+        );
+        self.callback_add(
             "/router/bgp/vrf/afi-safi/ipv6",
             super::vrf_config::config_vrf_afi_ipv6,
         );
@@ -4208,6 +4216,14 @@ impl Bgp {
         self.callback_add(
             "/router/bgp/vrf/afi-safi/ipv6/redistribute/static",
             super::vrf_config::config_vrf_afi_ipv6_redistribute_static,
+        );
+        self.callback_add(
+            "/router/bgp/vrf/afi-safi/ipv6/redistribute/ospf",
+            super::vrf_config::config_vrf_afi_ipv6_redistribute_ospf,
+        );
+        self.callback_add(
+            "/router/bgp/vrf/afi-safi/ipv6/redistribute/isis",
+            super::vrf_config::config_vrf_afi_ipv6_redistribute_isis,
         );
         self.callback_add(
             "/router/bgp/vrf/evpn/advertise-ipv4",

--- a/zebra-rs/src/bgp/vrf/inst.rs
+++ b/zebra-rs/src/bgp/vrf/inst.rs
@@ -420,7 +420,7 @@ fn redist_remote_id(rtype: crate::rib::RibType) -> u32 {
 
 /// Map a configured redistribute source to the RIB route type the
 /// subscription filters on.
-fn redist_source_rtype(source: BgpRedistSource) -> crate::rib::RibType {
+pub(super) fn redist_source_rtype(source: BgpRedistSource) -> crate::rib::RibType {
     match source {
         BgpRedistSource::Connected => crate::rib::RibType::Connected,
         BgpRedistSource::Static => crate::rib::RibType::Static,

--- a/zebra-rs/src/bgp/vrf/spawn.rs
+++ b/zebra-rs/src/bgp/vrf/spawn.rs
@@ -205,7 +205,7 @@ pub fn spawn_bgp_vrf(
     // once the event loop runs. A placeholder-ctx spawn has no live RIB
     // client, so the sends are dropped harmlessly; the kernel-ctx
     // respawn (which reads the same staged config) replays them.
-    let redist_count = materialize_vrf_redistribute(&vrf, cfg);
+    let redist_count = materialize_vrf_redistribute(&name, cfg, rib_subscriber);
 
     // Install the AF_MPLS DecapVrf ILM at the allocated label so a
     // remote PE's VPNv4 packet with this label pops + lands in
@@ -406,17 +406,39 @@ fn materialize_self_originated_networks_v6(vrf: &mut BgpVrf, cfg: &BgpVrfConfig)
 /// [`BgpVrfMsg::RedistEnable`] path, so initial-config and post-spawn
 /// subscription stay identical. Returns the number of (afi, source)
 /// subscriptions replayed.
-fn materialize_vrf_redistribute(vrf: &BgpVrf, cfg: &BgpVrfConfig) -> usize {
+fn materialize_vrf_redistribute(
+    name: &str,
+    cfg: &BgpVrfConfig,
+    rib_subscriber: &RibSubscriber,
+) -> usize {
+    // Issue the RedistAdds on the main RIB channel (`rib_tx`) so they
+    // stay FIFO-ordered after this spawn's `Subscribe` (and a respawn's
+    // `ProtoCleanup`). Going through the per-task `RibClient` (`ctx.rib`,
+    // a separate channel) races the `Subscribe` and can lose the filter —
+    // see `RibSubscriber::send_redist_add`. The live reconfig path
+    // (`BgpVrfMsg::RedistEnable`) keeps using `ctx.rib`: by then the
+    // subscriber is long registered, so there is no ordering hazard.
+    let proto = format!("bgp:vrf:{name}");
     let mut count = 0;
     if let Some(af) = cfg.ipv4_unicast.as_ref() {
         for source in &af.redistribute {
-            vrf.redist_subscribe(crate::rib::RedistAfi::Ipv4, *source);
+            rib_subscriber.send_redist_add(
+                &proto,
+                crate::rib::RedistAfi::Ipv4,
+                super::inst::redist_source_rtype(*source),
+                Default::default(),
+            );
             count += 1;
         }
     }
     if let Some(af) = cfg.ipv6_unicast.as_ref() {
         for source in &af.redistribute {
-            vrf.redist_subscribe(crate::rib::RedistAfi::Ipv6, *source);
+            rib_subscriber.send_redist_add(
+                &proto,
+                crate::rib::RedistAfi::Ipv6,
+                super::inst::redist_source_rtype(*source),
+                Default::default(),
+            );
             count += 1;
         }
     }

--- a/zebra-rs/src/bgp/vrf_config.rs
+++ b/zebra-rs/src/bgp/vrf_config.rs
@@ -835,6 +835,26 @@ pub fn config_vrf_afi_ipv4_redistribute_static(
     vrf_redist_set(bgp, name, RedistAfi::Ipv4, BgpRedistSource::Static, op)
 }
 
+/// `set router bgp vrf <NAME> afi-safi ipv4 redistribute ospf`.
+pub fn config_vrf_afi_ipv4_redistribute_ospf(
+    bgp: &mut Bgp,
+    mut args: Args,
+    op: ConfigOp,
+) -> Option<()> {
+    let name = args.string()?;
+    vrf_redist_set(bgp, name, RedistAfi::Ipv4, BgpRedistSource::Ospf, op)
+}
+
+/// `set router bgp vrf <NAME> afi-safi ipv4 redistribute isis`.
+pub fn config_vrf_afi_ipv4_redistribute_isis(
+    bgp: &mut Bgp,
+    mut args: Args,
+    op: ConfigOp,
+) -> Option<()> {
+    let name = args.string()?;
+    vrf_redist_set(bgp, name, RedistAfi::Ipv4, BgpRedistSource::Isis, op)
+}
+
 /// `delete router bgp vrf <NAME> afi-safi ipv6 redistribute`.
 pub fn config_vrf_afi_ipv6_redistribute(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Option<()> {
     let name = args.string()?;
@@ -862,6 +882,26 @@ pub fn config_vrf_afi_ipv6_redistribute_static(
 ) -> Option<()> {
     let name = args.string()?;
     vrf_redist_set(bgp, name, RedistAfi::Ipv6, BgpRedistSource::Static, op)
+}
+
+/// `set router bgp vrf <NAME> afi-safi ipv6 redistribute ospf`.
+pub fn config_vrf_afi_ipv6_redistribute_ospf(
+    bgp: &mut Bgp,
+    mut args: Args,
+    op: ConfigOp,
+) -> Option<()> {
+    let name = args.string()?;
+    vrf_redist_set(bgp, name, RedistAfi::Ipv6, BgpRedistSource::Ospf, op)
+}
+
+/// `set router bgp vrf <NAME> afi-safi ipv6 redistribute isis`.
+pub fn config_vrf_afi_ipv6_redistribute_isis(
+    bgp: &mut Bgp,
+    mut args: Args,
+    op: ConfigOp,
+) -> Option<()> {
+    let name = args.string()?;
+    vrf_redist_set(bgp, name, RedistAfi::Ipv6, BgpRedistSource::Isis, op)
 }
 
 /// `set router bgp vrf <NAME> evpn advertise-ipv4 <bool>`.

--- a/zebra-rs/src/config/manager.rs
+++ b/zebra-rs/src/config/manager.rs
@@ -156,6 +156,33 @@ impl RibSubscriber {
         });
     }
 
+    /// Register a redistribute subscription on the **main** RIB channel
+    /// (`rib_tx`), the same channel `Subscribe` and `ProtoCleanup` use.
+    ///
+    /// Spawn-time per-VRF redistribution must use this rather than the
+    /// per-task `RibClient` (`ctx.rib`, which rides the separate
+    /// `inbound` channel): the `Subscribe` that registers the VRF's
+    /// subscriber and this `RedistAdd` are issued back-to-back at spawn,
+    /// and `redist_register` drops the filter if the subscriber isn't
+    /// recorded yet. Cross-channel ordering is undefined, so a `RibClient`
+    /// `RedistAdd` can race ahead of the `Subscribe` and silently lose
+    /// the filter. Routing it through `rib_tx` keeps it FIFO-ordered
+    /// after the `Subscribe` (and after a respawn's `ProtoCleanup`).
+    pub fn send_redist_add(
+        &self,
+        proto: &str,
+        afi: crate::rib::RedistAfi,
+        rtype: crate::rib::RibType,
+        subtypes: std::collections::BTreeSet<crate::rib::RibSubType>,
+    ) {
+        let _ = self.rib_tx.send(crate::rib::Message::RedistAdd {
+            proto: proto.to_string(),
+            afi,
+            rtype,
+            subtypes,
+        });
+    }
+
     /// Request a dynamic MPLS label block of `size` labels for `proto`
     /// from the RIB label manager. The RIB replies asynchronously with
     /// a `RibRx::LabelBlock` on `proto`'s subscriber channel.
@@ -1645,8 +1672,12 @@ mod yang_load_tests {
         for cmd in [
             "set router bgp vrf N3 afi-safi ipv4 redistribute connected",
             "set router bgp vrf N3 afi-safi ipv4 redistribute static",
+            "set router bgp vrf N3 afi-safi ipv4 redistribute ospf",
+            "set router bgp vrf N3 afi-safi ipv4 redistribute isis",
             "set router bgp vrf N3 afi-safi ipv6 redistribute connected",
             "set router bgp vrf N3 afi-safi ipv6 redistribute static",
+            "set router bgp vrf N3 afi-safi ipv6 redistribute ospf",
+            "set router bgp vrf N3 afi-safi ipv6 redistribute isis",
         ] {
             let (code, _comps, _state) = parse(cmd, entry.clone(), None, State::new());
             assert_eq!(

--- a/zebra-rs/yang/zebra-bgp-vrf.yang
+++ b/zebra-rs/yang/zebra-bgp-vrf.yang
@@ -189,9 +189,12 @@ module zebra-bgp-vrf {
        address-family … redistribute …` model.
 
        Bare presence containers (no per-source modifiers yet); the
-       redistributed route's MED follows the source RIB cost.
-       `connected` and `static` are wired today; IS-IS / OSPF land in
-       a follow-up.";
+       redistributed route's MED follows the source RIB cost. The IGP
+       sources pull this VRF's OSPF / IS-IS routes — which a per-VRF
+       OSPF / IS-IS instance installs into `vrf_tables[table_id]` — so
+       a PE can advertise CE-learned IGP routes into the VPN without a
+       per-source level / match filter (deferred with the other
+       modifiers).";
     container redistribute {
       presence "Enable route redistribution into this VRF's BGP table";
       container connected {
@@ -199,6 +202,12 @@ module zebra-bgp-vrf {
       }
       container static {
         presence "Redistribute this VRF's static routes";
+      }
+      container ospf {
+        presence "Redistribute this VRF's OSPF routes";
+      }
+      container isis {
+        presence "Redistribute this VRF's IS-IS routes";
       }
     }
   }


### PR DESCRIPTION
## Summary
Completes the per-VRF `redistribute` set for BGP L3VPN by adding the **OSPF** and **IS-IS** sources to `router bgp vrf X afi-safi {ipv4|ipv6} redistribute …` (Phase 1 RIB plumbing #1671; Phase 2 connected/static #1672). A per-VRF OSPF/IS-IS instance installs into the VRF table; BGP pulls those routes into the per-VRF table and exports them to VPNv4/v6, so a PE advertises CE-learned IGP routes into the L3VPN.

- YANG: `ospf`/`isis` presence containers under each afi-safi `redistribute`
- 4 config callbacks → `BgpRedistSource::{Ospf,Isis}`
- **Spawn-time cross-channel race fix**: per-VRF redistribute registrations now ride the main RIB channel (`rib_tx`) via `RibSubscriber::send_redist_add`, FIFO-ordered after the VRF's `Subscribe` (and a respawn's `ProtoCleanup`), instead of the per-task `RibClient` whose `RedistAdd` could race ahead of the `Subscribe` and silently lose the filter. The live-reconfig path keeps using `ctx.rib` (subscriber already registered, no hazard).

## Test plan
- New `@bgp_vrf_ospf_redist` BDD feature: z1 PE (vrf-blue OSPF + `redistribute ospf`, VPNv4 iBGP) ─ ce CE (OSPF, lo `10.9.9.9/32`) ─ z2 PE (VPNv4 import). Asserts z1 learns `10.9.9.9/32` via OSPF in the VRF table, exports it as VPNv4 under RD 65001:100 (**not** the connected `/30`), and z2 receives it under z1's RD. Verified locally: `5 scenarios (5 passed)` reliably across piped/redirected runs.
- `parse()` `yang_load_tests` extended with the 4 new redistribute commands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
