### PR TITLE
test(bdd): fail on steps that match no definition

### DIFF
--- a/bdd/tests/cucumber.rs
+++ b/bdd/tests/cucumber.rs
@@ -2785,6 +2785,21 @@ async fn main() {
                             .tee::<World, _>(writer::Json::for_tee(json_file))
                             .normalized(),
                     )
+                    // Treat a SKIPPED step as a FAILURE. cucumber silently
+                    // skips a step whose phrasing matches no step definition
+                    // (a typo'd `When`/`Then`, or a wait like `I wait 90
+                    // seconds for OSPF and BGP to operate` when only `I wait
+                    // {int} seconds [for BGP to operate]` is registered). A
+                    // skipped wait reads identically to "converged instantly"
+                    // and the *next* assertion then fails on an un-converged
+                    // topology — which looks like a product bug. Failing on
+                    // skip surfaces the real cause (the unmatched step) loudly
+                    // at its own line. Wraps the whole writer so the terminal
+                    // output, the summary stats, and the Allure JSON all agree.
+                    // A scenario that legitimately expects a skip can opt out
+                    // with the `@allow.skipped` tag (already excluded from
+                    // `feature_tag` selection in the `before` hook above).
+                    .fail_on_skipped()
                     // Ignore the process CLI for the per-feature runner so
                     // `--concurrency` doesn't override `max_concurrent_scenarios`;
                     // the tag / name filter is re-applied in the closure below.


### PR DESCRIPTION
## Summary
cucumber silently **skips** a step whose phrasing matches no step definition. A typo'd `When`/`Then` — or a wait like `I wait 90 seconds for OSPF and BGP to operate` when only `I wait {int} seconds [for BGP to operate]` is registered — is skipped without error. A skipped *wait* reads identically to "converged instantly", so the next single-shot assertion fails on an un-converged topology, which looks like a product bug. This exact trap recently sent a multi-session hunt chasing a non-existent "OSPF-in-VRF tokio freeze" that was really just an unmatched wait step.

This enables cucumber's `.fail_on_skipped()` on the per-feature runner, so an **unmatched step fails loudly at its own line** instead of hiding as `1 skipped`.

- Wraps the whole writer ⇒ terminal output, summary stats, and Allure JSON all agree.
- Per-scenario opt-out via the `@allow.skipped` tag — already plumbed (the `before` hook excludes it from feature-tag resource scoping).
- BDD is excluded from CI, so the blast radius is **manual runs only** — exactly where the loud signal is wanted.

## Test plan
- **Unmatched step now fails:** a throwaway feature with `Given <phrase matching nothing>` → `✘ … Step failed`, `1 scenario (1 failed)` (vs. silently skipping before).
- **No regression:** the `@bgp_vrf_ospf_redist` feature (all steps match) still passes `5 scenarios (5 passed)`.
- Distinguishing signal for maintainers: an unmatched step fails with **no captured panic output**, unlike a real assertion failure.

> Note: on the next full-suite run (`make -C bdd run`) this may surface latent unmatched steps in other features that were previously skipped silently — those are real typos to fix (or tag `@allow.skipped` if intentional).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
