### PR TITLE
fib: tee route installs into the cradle eBPF data plane

### DIFF
--- a/proto/cradle.proto
+++ b/proto/cradle.proto
@@ -1,0 +1,91 @@
+syntax = "proto3";
+
+// cradle-rs data-plane control API.
+//
+// This is the seam between a routing control plane (ultimately zebra-rs's
+// FibHandle backend) and the eBPF data plane. Interface references are by name;
+// the server resolves them to ifindex and attaches the datapath to ports on
+// demand.
+package cradle.v1;
+
+message Empty {}
+
+message Port {
+  string name = 1;  // interface name
+  string mac = 2;   // empty => read from the interface
+  bool l3 = 3;      // routed port; false => L2 bridge member in `vlan`
+  uint32 vlan = 4;
+}
+
+message L2Domain {
+  uint32 vlan = 1;
+  repeated string members = 2;  // interface names flooded within the domain
+}
+
+message Nexthop {
+  uint32 id = 1;
+  string gateway = 2;     // empty => on-link / connected
+  string oif = 3;         // output interface name (used when oif_index == 0)
+  uint32 oif_index = 4;   // output ifindex; preferred when non-zero
+  bool v6 = 5;            // IPv6 nexthop (gateway parsed as IPv6)
+}
+
+// A nexthop group for ECMP: ordered member nexthop ids. A route whose flags
+// include FIB_F_ECMP and whose nexthop_id is this group's id load-balances over
+// the members.
+message NexthopGroup {
+  uint32 id = 1;
+  repeated uint32 members = 2;
+}
+
+message Route4 {
+  string prefix = 1;   // "a.b.c.d/len"
+  uint32 nexthop_id = 2;
+  uint32 flags = 3;
+}
+
+message Route4Del {
+  string prefix = 1;
+}
+
+message Route6 {
+  string prefix = 1;   // "addr/len"
+  uint32 nexthop_id = 2;
+  uint32 flags = 3;
+}
+
+message Route6Del {
+  string prefix = 1;
+}
+
+message Neighbor4 {
+  string oif = 1;
+  string ip = 2;
+  string mac = 3;
+}
+
+message Backend {
+  string ip = 1;
+  uint32 port = 2;
+}
+
+message Service {
+  uint32 svc_id = 1;
+  string vip = 2;
+  uint32 port = 3;
+  string proto = 4;  // tcp | udp
+  repeated Backend backends = 5;
+}
+
+service Cradle {
+  rpc SetPort(Port) returns (Empty);
+  rpc SetL2Domain(L2Domain) returns (Empty);
+  rpc SetNexthop(Nexthop) returns (Empty);
+  rpc SetNexthopGroup(NexthopGroup) returns (Empty);
+  rpc AddRoute4(Route4) returns (Empty);
+  rpc DelRoute4(Route4Del) returns (Empty);
+  rpc AddRoute6(Route6) returns (Empty);
+  rpc DelRoute6(Route6Del) returns (Empty);
+  rpc SetNeighbor4(Neighbor4) returns (Empty);
+  rpc AddService(Service) returns (Empty);
+}

--- a/zebra-rs/build.rs
+++ b/zebra-rs/build.rs
@@ -2,6 +2,8 @@ use std::process::Command;
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     tonic_prost_build::compile_protos("../proto/vty.proto")?;
+    // cradle eBPF data-plane control API (FibHandle tee target).
+    tonic_prost_build::compile_protos("../proto/cradle.proto")?;
 
     // Capture git information at build time
     set_git_info();

--- a/zebra-rs/src/fib/cradle.rs
+++ b/zebra-rs/src/fib/cradle.rs
@@ -1,0 +1,253 @@
+//! Optional tee of FIB route installs into the **cradle** eBPF data plane.
+//!
+//! Enabled by setting `CRADLE_GRPC=<host:port>`. When set, the protocol routes
+//! the RIB installs are also pushed to a running `cradle` via its gRPC control
+//! API, so zebra-rs-computed routes (static, BGP, OSPF, IS-IS, …) program the
+//! eBPF FIB in addition to the kernel. This is the zebra-rs side of the
+//! cradle-rs integration.
+
+use std::collections::HashMap;
+use std::net::{Ipv4Addr, Ipv6Addr};
+use std::sync::Arc;
+use std::sync::atomic::{AtomicU32, Ordering};
+
+use ipnet::{Ipv4Net, Ipv6Net};
+use tokio::sync::Mutex;
+use tonic::transport::Channel;
+
+pub mod pb {
+    tonic::include_proto!("cradle.v1");
+}
+use pb::cradle_client::CradleClient;
+
+/// Mirrors `cradle_common::FIB_F_ECMP` (data-plane ABI; kept local so this file
+/// has no dependency on the cradle crates).
+const FIB_F_ECMP: u32 = 1 << 3;
+
+#[derive(Clone)]
+pub struct CradleFib {
+    endpoint: String,
+    client: Arc<Mutex<Option<CradleClient<Channel>>>>,
+    /// Dedup `(gateway, oif) -> nexthop id` so we `SetNexthop` once per nexthop.
+    nh_ids: Arc<Mutex<HashMap<(u32, u32), u32>>>,
+    nh_ids6: Arc<Mutex<HashMap<([u8; 16], u32), u32>>>,
+    next_id: Arc<AtomicU32>,
+}
+
+impl CradleFib {
+    /// Construct from `CRADLE_GRPC` (e.g. `127.0.0.1:50151`). Returns `None`
+    /// when the variable is unset (tee disabled).
+    pub fn from_env() -> Option<Self> {
+        let ep = std::env::var("CRADLE_GRPC").ok()?;
+        // `unix:/path` (UDS) and `http://...` pass through; a bare host:port is
+        // treated as TCP.
+        let endpoint = if ep.starts_with("unix:") || ep.starts_with("http") {
+            ep
+        } else {
+            format!("http://{ep}")
+        };
+        tracing::info!("fib: cradle eBPF tee enabled -> {endpoint}");
+        Some(Self {
+            endpoint,
+            client: Arc::new(Mutex::new(None)),
+            nh_ids: Arc::new(Mutex::new(HashMap::new())),
+            nh_ids6: Arc::new(Mutex::new(HashMap::new())),
+            next_id: Arc::new(AtomicU32::new(1)),
+        })
+    }
+
+    /// Lazily connect (and cache) the gRPC client.
+    async fn client(&self) -> anyhow::Result<CradleClient<Channel>> {
+        let mut guard = self.client.lock().await;
+        if guard.is_none() {
+            *guard = Some(CradleClient::connect(self.endpoint.clone()).await?);
+        }
+        Ok(guard.as_ref().unwrap().clone())
+    }
+
+    /// Resolve (creating if needed) the cradle nexthop id for `(gw, oif)`.
+    async fn nexthop_id(&self, gw: Option<Ipv4Addr>, oif: u32) -> anyhow::Result<u32> {
+        let key = (gw.map(u32::from).unwrap_or(0), oif);
+        {
+            let ids = self.nh_ids.lock().await;
+            if let Some(id) = ids.get(&key) {
+                return Ok(*id);
+            }
+        }
+        let id = self.next_id.fetch_add(1, Ordering::Relaxed);
+        let mut client = self.client().await?;
+        client
+            .set_nexthop(pb::Nexthop {
+                id,
+                gateway: gw.map(|a| a.to_string()).unwrap_or_default(),
+                oif: String::new(),
+                oif_index: oif,
+                v6: false,
+            })
+            .await?;
+        self.nh_ids.lock().await.insert(key, id);
+        Ok(id)
+    }
+
+    /// Install an IPv4 route with one or more nexthops. A single member becomes
+    /// a plain route; multiple members become an ECMP nexthop group.
+    pub async fn route_install(&self, prefix: Ipv4Net, members: Vec<(Option<Ipv4Addr>, u32)>) {
+        if let Err(e) = self.try_route_install(prefix, members).await {
+            tracing::warn!("fib: cradle route_install {prefix} failed: {e}");
+        }
+    }
+
+    async fn try_route_install(
+        &self,
+        prefix: Ipv4Net,
+        members: Vec<(Option<Ipv4Addr>, u32)>,
+    ) -> anyhow::Result<()> {
+        if members.is_empty() {
+            return Ok(());
+        }
+        if members.len() == 1 {
+            let (gw, oif) = members[0];
+            let id = self.nexthop_id(gw, oif).await?;
+            self.client()
+                .await?
+                .add_route4(pb::Route4 {
+                    prefix: prefix.to_string(),
+                    nexthop_id: id,
+                    flags: 0,
+                })
+                .await?;
+            return Ok(());
+        }
+        // ECMP: one nexthop per member, then a group the route points at.
+        let mut ids = Vec::with_capacity(members.len());
+        for (gw, oif) in &members {
+            ids.push(self.nexthop_id(*gw, *oif).await?);
+        }
+        let gid = self.next_id.fetch_add(1, Ordering::Relaxed);
+        let mut client = self.client().await?;
+        client
+            .set_nexthop_group(pb::NexthopGroup {
+                id: gid,
+                members: ids,
+            })
+            .await?;
+        client
+            .add_route4(pb::Route4 {
+                prefix: prefix.to_string(),
+                nexthop_id: gid,
+                flags: FIB_F_ECMP,
+            })
+            .await?;
+        tracing::debug!(
+            "fib: cradle route_install {prefix} ECMP group {gid} ({} members)",
+            members.len()
+        );
+        Ok(())
+    }
+
+    pub async fn route_del(&self, prefix: Ipv4Net) {
+        let result = async {
+            self.client()
+                .await?
+                .del_route4(pb::Route4Del {
+                    prefix: prefix.to_string(),
+                })
+                .await?;
+            anyhow::Ok(())
+        }
+        .await;
+        if let Err(e) = result {
+            tracing::warn!("fib: cradle route_del {prefix} failed: {e}");
+        }
+    }
+
+    async fn nexthop_id6(&self, gw: Option<Ipv6Addr>, oif: u32) -> anyhow::Result<u32> {
+        let key = (gw.map(|a| a.octets()).unwrap_or([0; 16]), oif);
+        {
+            let ids = self.nh_ids6.lock().await;
+            if let Some(id) = ids.get(&key) {
+                return Ok(*id);
+            }
+        }
+        let id = self.next_id.fetch_add(1, Ordering::Relaxed);
+        let mut client = self.client().await?;
+        client
+            .set_nexthop(pb::Nexthop {
+                id,
+                gateway: gw.map(|a| a.to_string()).unwrap_or_default(),
+                oif: String::new(),
+                oif_index: oif,
+                v6: true,
+            })
+            .await?;
+        self.nh_ids6.lock().await.insert(key, id);
+        Ok(id)
+    }
+
+    /// Install an IPv6 route with one or more nexthops (single = plain route,
+    /// multiple = ECMP nexthop group).
+    pub async fn route_install6(&self, prefix: Ipv6Net, members: Vec<(Option<Ipv6Addr>, u32)>) {
+        if let Err(e) = self.try_route_install6(prefix, members).await {
+            tracing::warn!("fib: cradle route_install6 {prefix} failed: {e}");
+        }
+    }
+
+    async fn try_route_install6(
+        &self,
+        prefix: Ipv6Net,
+        members: Vec<(Option<Ipv6Addr>, u32)>,
+    ) -> anyhow::Result<()> {
+        if members.is_empty() {
+            return Ok(());
+        }
+        if members.len() == 1 {
+            let (gw, oif) = members[0];
+            let id = self.nexthop_id6(gw, oif).await?;
+            self.client()
+                .await?
+                .add_route6(pb::Route6 {
+                    prefix: prefix.to_string(),
+                    nexthop_id: id,
+                    flags: 0,
+                })
+                .await?;
+            return Ok(());
+        }
+        let mut ids = Vec::with_capacity(members.len());
+        for (gw, oif) in &members {
+            ids.push(self.nexthop_id6(*gw, *oif).await?);
+        }
+        let gid = self.next_id.fetch_add(1, Ordering::Relaxed);
+        let mut client = self.client().await?;
+        client
+            .set_nexthop_group(pb::NexthopGroup {
+                id: gid,
+                members: ids,
+            })
+            .await?;
+        client
+            .add_route6(pb::Route6 {
+                prefix: prefix.to_string(),
+                nexthop_id: gid,
+                flags: FIB_F_ECMP,
+            })
+            .await?;
+        Ok(())
+    }
+
+    pub async fn route_del6(&self, prefix: Ipv6Net) {
+        let result = async {
+            self.client()
+                .await?
+                .del_route6(pb::Route6Del {
+                    prefix: prefix.to_string(),
+                })
+                .await?;
+            anyhow::Ok(())
+        }
+        .await;
+        if let Err(e) = result {
+            tracing::warn!("fib: cradle route_del6 {prefix} failed: {e}");
+        }
+    }
+}

--- a/zebra-rs/src/fib/cradle.rs
+++ b/zebra-rs/src/fib/cradle.rs
@@ -1,10 +1,11 @@
 //! Optional tee of FIB route installs into the **cradle** eBPF data plane.
 //!
-//! Enabled by setting `CRADLE_GRPC=<host:port>`. When set, the protocol routes
-//! the RIB installs are also pushed to a running `cradle` via its gRPC control
-//! API, so zebra-rs-computed routes (static, BGP, OSPF, IS-IS, …) program the
-//! eBPF FIB in addition to the kernel. This is the zebra-rs side of the
-//! cradle-rs integration.
+//! Enabled by the `system cradle-grpc <endpoint>` config leaf (or the
+//! `CRADLE_GRPC` env var as a fallback). When set, the protocol routes the RIB
+//! installs are also pushed to a running `cradle` via its gRPC control API, so
+//! zebra-rs-computed routes (static, BGP, OSPF, IS-IS, …) program the eBPF FIB
+//! in addition to the kernel. This is the zebra-rs side of the cradle-rs
+//! integration.
 
 use std::collections::HashMap;
 use std::net::{Ipv4Addr, Ipv6Addr};
@@ -35,25 +36,28 @@ pub struct CradleFib {
 }
 
 impl CradleFib {
-    /// Construct from `CRADLE_GRPC` (e.g. `127.0.0.1:50151`). Returns `None`
-    /// when the variable is unset (tee disabled).
-    pub fn from_env() -> Option<Self> {
-        let ep = std::env::var("CRADLE_GRPC").ok()?;
-        // `unix:/path` (UDS) and `http://...` pass through; a bare host:port is
-        // treated as TCP.
+    /// Build a tee to the cradle gRPC endpoint `ep`. `unix:/path` (UDS) and
+    /// `http://...` pass through; a bare `host:port` is treated as TCP.
+    pub fn new(ep: &str) -> Self {
         let endpoint = if ep.starts_with("unix:") || ep.starts_with("http") {
-            ep
+            ep.to_string()
         } else {
             format!("http://{ep}")
         };
         tracing::info!("fib: cradle eBPF tee enabled -> {endpoint}");
-        Some(Self {
+        Self {
             endpoint,
             client: Arc::new(Mutex::new(None)),
             nh_ids: Arc::new(Mutex::new(HashMap::new())),
             nh_ids6: Arc::new(Mutex::new(HashMap::new())),
             next_id: Arc::new(AtomicU32::new(1)),
-        })
+        }
+    }
+
+    /// Construct from `CRADLE_GRPC` if set (env fallback; the primary control is
+    /// the `system cradle-grpc` config leaf). Returns `None` when unset.
+    pub fn from_env() -> Option<Self> {
+        std::env::var("CRADLE_GRPC").ok().map(|ep| Self::new(&ep))
     }
 
     /// Lazily connect (and cache) the gRPC client.

--- a/zebra-rs/src/fib/mod.rs
+++ b/zebra-rs/src/fib/mod.rs
@@ -3,6 +3,10 @@ pub mod netlink;
 #[cfg(target_os = "linux")]
 pub use netlink::*;
 
+// Optional tee of FIB route installs into the cradle eBPF data plane.
+#[cfg(target_os = "linux")]
+pub mod cradle;
+
 #[cfg(target_os = "macos")]
 pub mod macos;
 #[cfg(target_os = "macos")]

--- a/zebra-rs/src/fib/netlink/handle.rs
+++ b/zebra-rs/src/fib/netlink/handle.rs
@@ -32,6 +32,7 @@ use rtnetlink::{
 };
 use tokio::sync::mpsc::UnboundedSender;
 
+use crate::fib::cradle::CradleFib;
 use crate::fib::sysctl::sysctl_enable;
 use crate::fib::{FibAddr, FibLink, FibMdbEntry, FibMessage, FibNeighbor, FibRoute};
 use crate::rib::entry::RibEntry;
@@ -320,6 +321,61 @@ pub struct FibHandle {
     /// VNI to VXLAN interface index mapping
     /// Used to resolve VNI to the correct VXLAN device for FDB operations
     pub vni_ifindex_map: BTreeMap<u32, u32>,
+    /// Optional tee of route installs into the cradle eBPF data plane
+    /// (`CRADLE_GRPC`).
+    pub cradle: Option<CradleFib>,
+}
+
+/// Extract all IPv4 `(gateway, oif)` members of a nexthop for the cradle tee.
+/// A single member installs a plain route; multiple members install an ECMP
+/// group. (Protect/backup nexthops are not teed.)
+fn cradle_members_v4(nexthop: &Nexthop) -> Vec<(Option<Ipv4Addr>, u32)> {
+    fn member(u: &NexthopUni) -> (Option<Ipv4Addr>, u32) {
+        let oif = u.ifindex().unwrap_or(0);
+        let gw = match u.addr {
+            IpAddr::V4(a) if !a.is_unspecified() => Some(a),
+            _ => None,
+        };
+        (gw, oif)
+    }
+    match nexthop {
+        Nexthop::Uni(u) => vec![member(u)],
+        Nexthop::Multi(m) => m.nexthops.iter().map(member).collect(),
+        Nexthop::List(l) => l
+            .nexthops
+            .iter()
+            .filter_map(|m| match m {
+                NexthopMember::Uni(u) => Some(member(u)),
+                _ => None,
+            })
+            .collect(),
+        _ => vec![],
+    }
+}
+
+/// IPv6 counterpart of [`cradle_members_v4`].
+fn cradle_members_v6(nexthop: &Nexthop) -> Vec<(Option<Ipv6Addr>, u32)> {
+    fn member(u: &NexthopUni) -> (Option<Ipv6Addr>, u32) {
+        let oif = u.ifindex().unwrap_or(0);
+        let gw = match u.addr {
+            IpAddr::V6(a) if !a.is_unspecified() => Some(a),
+            _ => None,
+        };
+        (gw, oif)
+    }
+    match nexthop {
+        Nexthop::Uni(u) => vec![member(u)],
+        Nexthop::Multi(m) => m.nexthops.iter().map(member).collect(),
+        Nexthop::List(l) => l
+            .nexthops
+            .iter()
+            .filter_map(|m| match m {
+                NexthopMember::Uni(u) => Some(member(u)),
+                _ => None,
+            })
+            .collect(),
+        _ => vec![],
+    }
 }
 
 /// Op selector for `fdb_neigh_send`. The kernel netlink flag set
@@ -419,6 +475,7 @@ impl FibHandle {
             handle,
             use_nhid,
             vni_ifindex_map: BTreeMap::new(),
+            cradle: CradleFib::from_env(),
         })
     }
 
@@ -551,6 +608,12 @@ impl FibHandle {
     pub async fn route_ipv4_add(&self, prefix: &Ipv4Net, entry: &RibEntry, table_id: u32) -> bool {
         if !entry.is_protocol() {
             return true;
+        }
+        if let Some(cradle) = &self.cradle {
+            let members = cradle_members_v4(&entry.nexthop);
+            if !members.is_empty() {
+                cradle.route_install(*prefix, members).await;
+            }
         }
         match &entry.nexthop {
             Nexthop::Uni(_) | Nexthop::Multi(_) => {
@@ -693,6 +756,9 @@ impl FibHandle {
     pub async fn route_ipv4_del(&self, prefix: &Ipv4Net, entry: &RibEntry, table_id: u32) {
         if !entry.is_protocol() {
             return;
+        }
+        if let Some(cradle) = &self.cradle {
+            cradle.route_del(*prefix).await;
         }
 
         match &entry.nexthop {
@@ -946,6 +1012,12 @@ impl FibHandle {
         if !entry.is_protocol() {
             return true;
         }
+        if let Some(cradle) = &self.cradle {
+            let members = cradle_members_v6(&entry.nexthop);
+            if !members.is_empty() {
+                cradle.route_install6(*prefix, members).await;
+            }
+        }
         match &entry.nexthop {
             Nexthop::Uni(_) | Nexthop::Multi(_) => {
                 self.route_ipv6_add_uni(prefix, entry, &entry.nexthop, table_id)
@@ -1105,6 +1177,9 @@ impl FibHandle {
     pub async fn route_ipv6_del(&self, prefix: &Ipv6Net, entry: &RibEntry, table_id: u32) {
         if !entry.is_protocol() {
             return;
+        }
+        if let Some(cradle) = &self.cradle {
+            cradle.route_del6(*prefix).await;
         }
 
         match &entry.nexthop {

--- a/zebra-rs/src/fib/netlink/handle.rs
+++ b/zebra-rs/src/fib/netlink/handle.rs
@@ -321,8 +321,10 @@ pub struct FibHandle {
     /// VNI to VXLAN interface index mapping
     /// Used to resolve VNI to the correct VXLAN device for FDB operations
     pub vni_ifindex_map: BTreeMap<u32, u32>,
-    /// Optional tee of route installs into the cradle eBPF data plane
-    /// (`CRADLE_GRPC`).
+    /// Optional tee of route installs into the cradle eBPF data plane. Driven by
+    /// the `system cradle-grpc <endpoint>` config leaf (`set_cradle`, dispatched
+    /// from `Rib::cradle_grpc_config_exec`), with `CRADLE_GRPC` as an env
+    /// fallback.
     pub cradle: Option<CradleFib>,
 }
 
@@ -477,6 +479,15 @@ impl FibHandle {
             vni_ifindex_map: BTreeMap::new(),
             cradle: CradleFib::from_env(),
         })
+    }
+
+    /// Enable/re-point (`Some`) or disable (`None`) the cradle eBPF tee at
+    /// runtime. Driven by the `system cradle-grpc` config leaf.
+    pub fn set_cradle(&mut self, endpoint: Option<&str>) {
+        self.cradle = endpoint.map(CradleFib::new);
+        if self.cradle.is_none() {
+            tracing::info!("fib: cradle eBPF tee disabled");
+        }
     }
 
     pub async fn route_ipv4_add_uni(

--- a/zebra-rs/src/rib/inst.rs
+++ b/zebra-rs/src/rib/inst.rs
@@ -3175,6 +3175,25 @@ impl Rib {
         Some((vni, vtep_local))
     }
 
+    /// `set system cradle-grpc <endpoint>` enables (or re-points) the cradle
+    /// eBPF data-plane tee; deleting it disables the tee. Mirrors
+    /// `router_id_config_exec`. The endpoint is `unix:/path`, `http://host:port`
+    /// or a bare `host:port` (treated as TCP).
+    #[cfg(target_os = "linux")]
+    pub(crate) fn cradle_grpc_config_exec(
+        &mut self,
+        mut args: crate::config::Args,
+        op: ConfigOp,
+    ) -> Option<()> {
+        if op.is_set() {
+            let endpoint = args.string()?;
+            self.fib_handle.set_cradle(Some(&endpoint));
+        } else {
+            self.fib_handle.set_cradle(None);
+        }
+        Some(())
+    }
+
     async fn process_cm_msg(&mut self, msg: ConfigRequest) {
         match msg.op {
             ConfigOp::CommitStart => {
@@ -3184,6 +3203,9 @@ impl Rib {
                 let (path, mut args) = path_from_command(&msg.paths);
                 if path.as_str() == "/system/router-id" {
                     let _ = self.router_id_config_exec(args, msg.op);
+                } else if path.as_str() == "/system/cradle-grpc" {
+                    #[cfg(target_os = "linux")]
+                    let _ = self.cradle_grpc_config_exec(args, msg.op);
                 } else if path.as_str().starts_with("/router/static/vrf/ipv4/route") {
                     let _ = self.static_vrf_v4.exec(path, args, msg.op);
                 } else if path.as_str().starts_with("/router/static/vrf/ipv6/route") {

--- a/zebra-rs/yang/config.yang
+++ b/zebra-rs/yang/config.yang
@@ -380,6 +380,16 @@ module config {
         ext:help "Global router identifier";
         type inet:ipv4-address;
       }
+      // gRPC endpoint of a cradle eBPF data plane to tee FIB route
+      // installs to (e.g. `unix:/run/cradle.sock` or `127.0.0.1:50151`).
+      // When set, every route zebra-rs installs is pushed to cradle in
+      // addition to the kernel (see `rib/inst.rs cradle_grpc_config_exec`);
+      // unset disables the tee. The zebra-rs side of the cradle-rs eBPF
+      // data-plane integration.
+      leaf cradle-grpc {
+        ext:help "cradle eBPF data-plane gRPC endpoint";
+        type string;
+      }
       container dhcp {
         uses "dhcp:dhcp";
       }


### PR DESCRIPTION
## Summary
Optional tee of FIB route installs into the **cradle** eBPF data plane (the
zebra-rs side of the cradle-rs integration). Purely additive; no behavior change
when disabled.

- `src/fib/cradle.rs` — `CradleFib`: lazy tonic gRPC client, dedups nexthops,
  installs IPv4/IPv6 routes (single → plain route, multiple → ECMP nexthop group
  + `FIB_F_ECMP`).
- `src/fib/netlink/handle.rs` — `FibHandle` holds an optional `CradleFib`;
  `route_ipv4/6_add/del` tee all unicast members.
- Gated by a YANG config leaf **`system cradle-grpc <endpoint>`** (`rib/inst.rs`
  `cradle_grpc_config_exec`, mirroring `router_id_config_exec`); `CRADLE_GRPC`
  env kept as a fallback. Endpoint is `unix:/path`, `http://host:port`, or a
  bare `host:port`.
- `proto/cradle.proto` + `build.rs` compile the `cradle.v1` control API.

## Test plan
- `cargo build -p zebra-rs` clean.
- cradle-rs cucumber BDD: 10 features / 20 scenarios pass, including
  static-route, BGP, and ECMP (v4+v6) routes teed into the eBPF FIB and
  forwarding live traffic with kernel forwarding off; zebra logs confirm the tee
  was enabled by the `system cradle-grpc` leaf (no env set).
- No tee / no change when the leaf and `CRADLE_GRPC` are both unset.

Generated with [Claude Code](https://claude.com/claude-code)