### PR TITLE
bgp/mup: key the MUP RIB per-RouteDistinguisher like VPN/EVPN

### DIFF
--- a/crates/bgp-packet/src/attrs/nlri_mup.rs
+++ b/crates/bgp-packet/src/attrs/nlri_mup.rs
@@ -630,30 +630,26 @@ impl MupRoute {
     }
 }
 
-/// MUP NLRI key with the add-path Path Identifier (and the constant
-/// architecture type) stripped off, used to index the MUP RIB tables.
+/// MUP NLRI key with the add-path Path Identifier, the constant
+/// architecture type, *and* the Route Distinguisher stripped off, used as
+/// the inner key of the per-RD MUP RIB tables.
 ///
-/// This is a *full-NLRI* key: every wire field except the add-path `id`
-/// (which lives on `BgpRib.remote_id`) is part of the key, so two routes
-/// that differ only in TEID/QFI/endpoint/source coexist, and replacement
-/// is by explicit withdraw. Variant declaration order (`Dsd, Isd, T1st,
-/// T2st`) drives the derived `Ord`, so a RIB walk lists routes grouped by
-/// type (DSD then ISD then ST1 then ST2).
+/// Like EVPN's `EvpnPrefix` (and VPN's `Ipv4Net`), the RD is **not** part
+/// of this key — it is the outer `BTreeMap<RouteDistinguisher, _>` key, so
+/// [`MupPrefix::from_route`] returns `(rd, key)`. Every other wire field
+/// except the add-path `id` (which lives on `BgpRib.remote_id`) is part of
+/// the key, so two routes that differ only in TEID/QFI/endpoint/source
+/// coexist, and replacement is by explicit withdraw. Variant declaration
+/// order (`Dsd, Isd, T1st, T2st`) drives the derived `Ord`, so a RIB walk
+/// lists routes grouped by type (DSD then ISD then ST1 then ST2).
 #[derive(Debug, Clone, Eq, PartialEq, Ord, PartialOrd, Hash)]
 pub enum MupPrefix {
     /// Direct Segment Discovery Route key (RFC 9833 §3.1.2).
-    Dsd {
-        rd: RouteDistinguisher,
-        address: IpAddr,
-    },
+    Dsd { address: IpAddr },
     /// Interwork Segment Discovery Route key (§3.1.1).
-    Isd {
-        rd: RouteDistinguisher,
-        prefix: IpNet,
-    },
+    Isd { prefix: IpNet },
     /// Type 1 Session Transformed Route (ST1) key (§3.2.1).
     T1st {
-        rd: RouteDistinguisher,
         prefix: IpNet,
         teid: u32,
         qfi: u8,
@@ -662,7 +658,6 @@ pub enum MupPrefix {
     },
     /// Type 2 Session Transformed Route (ST2) key (§3.2.2).
     T2st {
-        rd: RouteDistinguisher,
         endpoint: IpAddr,
         endpoint_len: u8,
         teid: u32,
@@ -684,31 +679,15 @@ impl MupPrefix {
         }
     }
 
-    /// The Route Distinguisher carried by every defined MUP route type
-    /// (`None` only for the opaque `Unknown` variant).
-    pub fn rd(&self) -> Option<RouteDistinguisher> {
-        match self {
-            MupPrefix::Dsd { rd, .. }
-            | MupPrefix::Isd { rd, .. }
-            | MupPrefix::T1st { rd, .. }
-            | MupPrefix::T2st { rd, .. } => Some(*rd),
-            MupPrefix::Unknown { .. } => None,
-        }
-    }
-
-    /// Split a parsed `MupRoute` into the RD-and-id-stripped key used to
-    /// index the MUP RIB. The add-path `id` and the (constant) arch type
-    /// are dropped; the `id` lives on `BgpRib.remote_id`.
-    pub fn from_route(route: &MupRoute) -> MupPrefix {
+    /// Split a parsed `MupRoute` into its Route Distinguisher and the
+    /// RD-and-id-stripped inner key used to index the per-RD MUP RIB.
+    /// The add-path `id` and the (constant) arch type are dropped; the
+    /// `id` lives on `BgpRib.remote_id`. The `Unknown` variant has no
+    /// decoded RD, so it pairs with the default (`0:0`) RD.
+    pub fn from_route(route: &MupRoute) -> (RouteDistinguisher, MupPrefix) {
         match route {
-            MupRoute::Isd { rd, prefix, .. } => MupPrefix::Isd {
-                rd: *rd,
-                prefix: *prefix,
-            },
-            MupRoute::Dsd { rd, address, .. } => MupPrefix::Dsd {
-                rd: *rd,
-                address: *address,
-            },
+            MupRoute::Isd { rd, prefix, .. } => (*rd, MupPrefix::Isd { prefix: *prefix }),
+            MupRoute::Dsd { rd, address, .. } => (*rd, MupPrefix::Dsd { address: *address }),
             MupRoute::T1st {
                 rd,
                 prefix,
@@ -717,32 +696,39 @@ impl MupPrefix {
                 endpoint,
                 source,
                 ..
-            } => MupPrefix::T1st {
-                rd: *rd,
-                prefix: *prefix,
-                teid: *teid,
-                qfi: *qfi,
-                endpoint: *endpoint,
-                source: *source,
-            },
+            } => (
+                *rd,
+                MupPrefix::T1st {
+                    prefix: *prefix,
+                    teid: *teid,
+                    qfi: *qfi,
+                    endpoint: *endpoint,
+                    source: *source,
+                },
+            ),
             MupRoute::T2st {
                 rd,
                 endpoint,
                 endpoint_len,
                 teid,
                 ..
-            } => MupPrefix::T2st {
-                rd: *rd,
-                endpoint: *endpoint,
-                endpoint_len: *endpoint_len,
-                teid: *teid,
-            },
+            } => (
+                *rd,
+                MupPrefix::T2st {
+                    endpoint: *endpoint,
+                    endpoint_len: *endpoint_len,
+                    teid: *teid,
+                },
+            ),
             MupRoute::Unknown {
                 route_type, body, ..
-            } => MupPrefix::Unknown {
-                route_type: *route_type,
-                body: body.clone(),
-            },
+            } => (
+                RouteDistinguisher::default(),
+                MupPrefix::Unknown {
+                    route_type: *route_type,
+                    body: body.clone(),
+                },
+            ),
         }
     }
 
@@ -764,26 +750,27 @@ impl MupPrefix {
         if v6 { Afi::Ip6 } else { Afi::Ip }
     }
 
-    /// Reconstruct a wire `MupRoute` from the key for re-advertisement.
-    /// The full-NLRI key carries every field, so the only synthesized
-    /// values are the 3GPP-5G architecture type and a zero add-path id.
-    pub fn to_route(&self) -> MupRoute {
+    /// Reconstruct a wire `MupRoute` from the inner key and its RD (the
+    /// outer per-RD map key) for re-advertisement. The only other
+    /// synthesized values are the 3GPP-5G architecture type and a zero
+    /// add-path id. The RD is ignored for the `Unknown` variant (its
+    /// opaque body already carries the original bytes).
+    pub fn to_route(&self, rd: RouteDistinguisher) -> MupRoute {
         let arch = MupArchitectureType::Gpp5g;
         match self {
-            MupPrefix::Isd { rd, prefix } => MupRoute::Isd {
+            MupPrefix::Isd { prefix } => MupRoute::Isd {
                 id: 0,
                 arch,
-                rd: *rd,
+                rd,
                 prefix: *prefix,
             },
-            MupPrefix::Dsd { rd, address } => MupRoute::Dsd {
+            MupPrefix::Dsd { address } => MupRoute::Dsd {
                 id: 0,
                 arch,
-                rd: *rd,
+                rd,
                 address: *address,
             },
             MupPrefix::T1st {
-                rd,
                 prefix,
                 teid,
                 qfi,
@@ -792,7 +779,7 @@ impl MupPrefix {
             } => MupRoute::T1st {
                 id: 0,
                 arch,
-                rd: *rd,
+                rd,
                 prefix: *prefix,
                 teid: *teid,
                 qfi: *qfi,
@@ -800,14 +787,13 @@ impl MupPrefix {
                 source: *source,
             },
             MupPrefix::T2st {
-                rd,
                 endpoint,
                 endpoint_len,
                 teid,
             } => MupRoute::T2st {
                 id: 0,
                 arch,
-                rd: *rd,
+                rd,
                 endpoint: *endpoint,
                 endpoint_len: *endpoint_len,
                 teid: *teid,
@@ -1580,28 +1566,28 @@ mod tests {
         ];
         let expect_afi = [Afi::Ip, Afi::Ip, Afi::Ip6, Afi::Ip];
         for (route, afi) in cases.iter().zip(expect_afi) {
-            let prefix = MupPrefix::from_route(route);
+            let (rd, prefix) = MupPrefix::from_route(route);
             assert_eq!(prefix.afi(), afi);
-            // to_route() round-trips back to the same key.
-            assert_eq!(MupPrefix::from_route(&prefix.to_route()), prefix);
+            // to_route() round-trips back to the same (rd, key).
+            assert_eq!(MupPrefix::from_route(&prefix.to_route(rd)), (rd, prefix));
         }
     }
 
     #[test]
     fn mup_prefix_orders_dsd_before_isd_before_st() {
-        let dsd = MupPrefix::from_route(&MupRoute::Dsd {
+        let (_, dsd) = MupPrefix::from_route(&MupRoute::Dsd {
             id: 0,
             arch: MupArchitectureType::Gpp5g,
             rd: sample_rd(),
             address: "1.1.1.1".parse().unwrap(),
         });
-        let isd = MupPrefix::from_route(&MupRoute::Isd {
+        let (isd_rd, isd) = MupPrefix::from_route(&MupRoute::Isd {
             id: 0,
             arch: MupArchitectureType::Gpp5g,
             rd: sample_rd(),
             prefix: "10.0.0.0/24".parse().unwrap(),
         });
-        let st2 = MupPrefix::from_route(&MupRoute::T2st {
+        let (_, st2) = MupPrefix::from_route(&MupRoute::T2st {
             id: 0,
             arch: MupArchitectureType::Gpp5g,
             rd: sample_rd(),
@@ -1614,6 +1600,7 @@ mod tests {
         assert_eq!(dsd.route_type(), 2);
         assert_eq!(isd.route_type(), 1);
         assert_eq!(st2.route_type(), 4);
-        assert_eq!(isd.rd(), Some(sample_rd()));
+        // The RD is now the outer per-RD map key, returned alongside the key.
+        assert_eq!(isd_rd, sample_rd());
     }
 }

--- a/zebra-rs/src/bgp/adj_rib.rs
+++ b/zebra-rs/src/bgp/adj_rib.rs
@@ -136,9 +136,11 @@ impl<D: RibDirection> Default for AdjRibEvpnTable<D> {
     }
 }
 
-/// Flat Adj-RIB table for MUP (SAFI 85) routes, keyed on `MupPrefix`
-/// (exact match; the RD is part of the key). Mirrors `AdjRibEvpnTable<D>`;
-/// the `D` marker selects the path-id field for AddPath disambiguation.
+/// Per-RD Adj-RIB table for MUP (SAFI 85) routes, keyed on the RD-free
+/// `MupPrefix` (exact match). The RD is the outer
+/// `BTreeMap<RouteDistinguisher, AdjRibMupTable<D>>` key, mirroring
+/// `AdjRibEvpnTable<D>`; the `D` marker selects the path-id field for
+/// AddPath disambiguation.
 #[derive(Debug)]
 pub struct AdjRibMupTable<D: RibDirection>(pub BTreeMap<MupPrefix, Vec<BgpRib>>, PhantomData<D>);
 
@@ -312,8 +314,8 @@ pub struct AdjRib<D: RibDirection> {
     pub v6vpn: BTreeMap<RouteDistinguisher, AdjRibTable<D, Ipv6Net>>,
     // EVPN, per Route Distinguisher
     pub evpn: BTreeMap<RouteDistinguisher, AdjRibEvpnTable<D>>,
-    // MUP (SAFI 85), flat by MupPrefix
-    pub mup: AdjRibMupTable<D>,
+    // MUP (SAFI 85), per Route Distinguisher
+    pub mup: BTreeMap<RouteDistinguisher, AdjRibMupTable<D>>,
     // IPv4 Flow Specification (AFI 1, SAFI 133)
     pub flowspec_v4: AdjRibFlowspecTable<D>,
     // IPv6 Flow Specification (AFI 2, SAFI 133)
@@ -332,7 +334,7 @@ impl<D: RibDirection> AdjRib<D> {
             v4vpn: BTreeMap::new(),
             v6vpn: BTreeMap::new(),
             evpn: BTreeMap::new(),
-            mup: AdjRibMupTable::new(),
+            mup: BTreeMap::new(),
             flowspec_v4: AdjRibFlowspecTable::new(),
             flowspec_v6: AdjRibFlowspecTable::new(),
             bgp_ls: AdjRibBgpLsTable::new(),
@@ -467,8 +469,8 @@ impl ShardAdjIn {
 pub struct MainAdjIn {
     // EVPN, per Route Distinguisher
     pub evpn: BTreeMap<RouteDistinguisher, AdjRibEvpnTable<In>>,
-    // MUP (SAFI 85), flat by MupPrefix
-    pub mup: AdjRibMupTable<In>,
+    // MUP (SAFI 85), per Route Distinguisher
+    pub mup: BTreeMap<RouteDistinguisher, AdjRibMupTable<In>>,
     // IPv4 Flow Specification (AFI 1, SAFI 133)
     pub flowspec_v4: AdjRibFlowspecTable<In>,
     // IPv6 Flow Specification (AFI 2, SAFI 133)
@@ -504,12 +506,22 @@ impl MainAdjIn {
 
     // MUP add/remove ---------------------------------------------------------
 
-    pub fn add_mup(&mut self, prefix: MupPrefix, route: BgpRib) -> Option<BgpRib> {
-        self.mup.add(prefix, route)
+    pub fn add_mup(
+        &mut self,
+        rd: RouteDistinguisher,
+        prefix: MupPrefix,
+        route: BgpRib,
+    ) -> Option<BgpRib> {
+        self.mup.entry(rd).or_default().add(prefix, route)
     }
 
-    pub fn remove_mup(&mut self, prefix: &MupPrefix, id: u32) -> Option<BgpRib> {
-        self.mup.remove(prefix, id)
+    pub fn remove_mup(
+        &mut self,
+        rd: RouteDistinguisher,
+        prefix: &MupPrefix,
+        id: u32,
+    ) -> Option<BgpRib> {
+        self.mup.entry(rd).or_default().remove(prefix, id)
     }
 
     // Flow Specification add/remove ------------------------------------------
@@ -543,9 +555,9 @@ impl MainAdjIn {
     pub fn count(&self, afi: Afi, safi: Safi) -> usize {
         match (afi, safi) {
             (Afi::L2vpn, Safi::Evpn) => self.evpn.values().map(|table| table.0.len()).sum(),
-            // Flat MUP table; counted under IPv4-MUP to avoid double-count
+            // Per-RD MUP tables; counted under IPv4-MUP to avoid double-count
             // in a combined v4+v6 summary.
-            (Afi::Ip, Safi::Mup) => self.mup.0.len(),
+            (Afi::Ip, Safi::Mup) => self.mup.values().map(|table| table.0.len()).sum(),
             (Afi::Ip, Safi::Flowspec) => self.flowspec_v4.0.len(),
             (Afi::Ip6, Safi::Flowspec) => self.flowspec_v6.0.len(),
             (Afi::LinkState, Safi::LinkState) => self.bgp_ls.0.len(),
@@ -590,8 +602,8 @@ impl AdjRib<Out> {
             (Afi::Ip, Safi::MplsVpn) => self.v4vpn.values().map(|table| table.0.len()).sum(),
             (Afi::Ip6, Safi::MplsVpn) => self.v6vpn.values().map(|table| table.0.len()).sum(),
             (Afi::L2vpn, Safi::Evpn) => self.evpn.values().map(|table| table.0.len()).sum(),
-            // Flat MUP table; counted under IPv4-MUP to avoid double-count.
-            (Afi::Ip, Safi::Mup) => self.mup.0.len(),
+            // Per-RD MUP tables; counted under IPv4-MUP to avoid double-count.
+            (Afi::Ip, Safi::Mup) => self.mup.values().map(|table| table.0.len()).sum(),
             (Afi::Ip, Safi::Flowspec) => self.flowspec_v4.0.len(),
             (Afi::Ip6, Safi::Flowspec) => self.flowspec_v6.0.len(),
             (Afi::LinkState, Safi::LinkState) => self.bgp_ls.0.len(),
@@ -625,12 +637,22 @@ impl AdjRib<Out> {
         self.evpn.entry(rd).or_default().remove(prefix, id)
     }
 
-    pub fn add_mup(&mut self, prefix: MupPrefix, route: BgpRib) -> Option<BgpRib> {
-        self.mup.add(prefix, route)
+    pub fn add_mup(
+        &mut self,
+        rd: RouteDistinguisher,
+        prefix: MupPrefix,
+        route: BgpRib,
+    ) -> Option<BgpRib> {
+        self.mup.entry(rd).or_default().add(prefix, route)
     }
 
-    pub fn remove_mup(&mut self, prefix: &MupPrefix, id: u32) -> Option<BgpRib> {
-        self.mup.remove(prefix, id)
+    pub fn remove_mup(
+        &mut self,
+        rd: RouteDistinguisher,
+        prefix: &MupPrefix,
+        id: u32,
+    ) -> Option<BgpRib> {
+        self.mup.entry(rd).or_default().remove(prefix, id)
     }
 
     pub fn add_flowspec(&mut self, afi: Afi, nlri: FlowspecNlri, route: BgpRib) -> Option<BgpRib> {

--- a/zebra-rs/src/bgp/config.rs
+++ b/zebra-rs/src/bgp/config.rs
@@ -7761,13 +7761,13 @@ mod mup_dual_origination_tests {
         assert!(
             routes
                 .iter()
-                .any(|(p, _)| matches!(p, MupPrefix::T1st { .. })),
+                .any(|(_, p, _)| matches!(p, MupPrefix::T1st { .. })),
             "downlink Type-1 ST originated from the st1 VRF",
         );
         assert!(
             routes
                 .iter()
-                .any(|(p, _)| matches!(p, MupPrefix::T2st { .. })),
+                .any(|(_, p, _)| matches!(p, MupPrefix::T2st { .. })),
             "uplink Type-2 ST originated from the st2 VRF",
         );
     }

--- a/zebra-rs/src/bgp/inst.rs
+++ b/zebra-rs/src/bgp/inst.rs
@@ -682,7 +682,8 @@ pub struct Bgp {
     /// the exact prior routes. No SRv6 SID is allocated for these (the PE
     /// derives forwarding from its ISD/DSD routes), so only the prefixes
     /// are retained.
-    pub mup_c_originated: BTreeMap<u64, Vec<bgp_packet::MupPrefix>>,
+    pub mup_c_originated:
+        BTreeMap<u64, Vec<(bgp_packet::RouteDistinguisher, bgp_packet::MupPrefix)>>,
     /// Config-driven MUP Segment Discovery routes originated per VRF — a DSD
     /// (Direct, type 2, `afi-safi mup segment direct`) or an ISD (Interwork,
     /// type 1, `afi-safi mup segment interwork prefix <p>`); a VRF has at
@@ -695,6 +696,7 @@ pub struct Bgp {
     pub mup_segment_originated: BTreeMap<
         String,
         (
+            bgp_packet::RouteDistinguisher,
             bgp_packet::MupPrefix,
             std::net::Ipv6Addr,
             Option<bgp_packet::ExtCommunity>,

--- a/zebra-rs/src/bgp/route.rs
+++ b/zebra-rs/src/bgp/route.rs
@@ -1748,11 +1748,12 @@ impl LocalRibEvpnTable {
     }
 }
 
-/// Flat Loc-RIB table for MUP (SAFI 85) routes — exact-match keyed by
-/// `MupPrefix`. The RD is part of the key, so one flat map holds every RD
-/// and `show bgp mup` walks it grouped by route type. Mirrors
-/// `LocalRibEvpnTable`; best-path reuses the NLRI-agnostic `BgpRib`
-/// comparator.
+/// Per-RD Loc-RIB table for MUP (SAFI 85) routes — exact-match keyed by
+/// the RD-free `MupPrefix`. The RD is the outer
+/// `BTreeMap<RouteDistinguisher, LocalRibMupTable>` key (see `LocalRib.mup`),
+/// exactly as for `LocalRibEvpnTable`; `show bgp mup` walks the outer map
+/// then this table grouped by route type. Best-path reuses the
+/// NLRI-agnostic `BgpRib` comparator.
 #[derive(Debug, Default)]
 pub struct LocalRibMupTable {
     /// Candidate paths per prefix.
@@ -2567,8 +2568,8 @@ pub struct LocalRib {
     /// Per-RD EVPN Loc-RIB tables.
     pub evpn: BTreeMap<RouteDistinguisher, LocalRibEvpnTable>,
 
-    /// Flat MUP (SAFI 85, RFC 9833) Loc-RIB table.
-    pub mup: LocalRibMupTable,
+    /// Per-RD MUP (SAFI 85, RFC 9833) Loc-RIB tables, mirroring `evpn`.
+    pub mup: BTreeMap<RouteDistinguisher, LocalRibMupTable>,
 
     /// IPv4 / IPv6 Flow Specification Loc-RIB (SAFI 133).
     pub flowspec_v4: LocalRibFlowspecTable,
@@ -2637,18 +2638,29 @@ impl LocalRib {
 
     pub fn update_mup(
         &mut self,
+        rd: RouteDistinguisher,
         prefix: MupPrefix,
         rib: BgpRib,
     ) -> (Vec<BgpRib>, Vec<BgpRib>, u32) {
-        self.mup.update(prefix, rib)
+        self.mup.entry(rd).or_default().update(prefix, rib)
     }
 
-    pub fn remove_mup(&mut self, prefix: &MupPrefix, id: u32, ident: usize) -> Vec<BgpRib> {
-        self.mup.remove(prefix, id, ident)
+    pub fn remove_mup(
+        &mut self,
+        rd: RouteDistinguisher,
+        prefix: &MupPrefix,
+        id: u32,
+        ident: usize,
+    ) -> Vec<BgpRib> {
+        self.mup.entry(rd).or_default().remove(prefix, id, ident)
     }
 
-    pub fn select_best_path_mup(&mut self, prefix: &MupPrefix) -> Vec<BgpRib> {
-        self.mup.select_best_path(prefix)
+    pub fn select_best_path_mup(
+        &mut self,
+        rd: &RouteDistinguisher,
+        prefix: &MupPrefix,
+    ) -> Vec<BgpRib> {
+        self.mup.entry(*rd).or_default().select_best_path(prefix)
     }
 
     // Flow Specification dispatch --------------------------------------------
@@ -7540,7 +7552,7 @@ pub fn route_mup_update(
     peers: &mut PeerMap,
     stale: bool,
 ) {
-    let prefix = MupPrefix::from_route(route);
+    let (rd, prefix) = MupPrefix::from_route(route);
     let id = route.add_path_id();
 
     let (peer_ident, peer_router_id, typ) = {
@@ -7588,45 +7600,45 @@ pub fn route_mup_update(
 
     {
         let peer = peers.get_mut_by_idx(ident).expect("peer must exist");
-        peer.adj_in.add_mup(prefix.clone(), rib.clone());
+        peer.adj_in.add_mup(rd, prefix.clone(), rib.clone());
     }
 
     rib.attr = bgp.attr_store.intern(attr.clone());
-    let _ = bgp.local_rib.update_mup(prefix.clone(), rib);
-    let selected = bgp.local_rib.select_best_path_mup(&prefix);
+    let _ = bgp.local_rib.update_mup(rd, prefix.clone(), rib);
+    let selected = bgp.local_rib.select_best_path_mup(&rd, &prefix);
     // Mirror the new best-path to every VRF whose `mup import` RT set
     // matches, so `show bgp vrf <name> mup` reflects peer-learned routes
     // (display only; the global Loc-RIB stays authoritative).
     if let Some(dispatcher) = bgp.vrf_import {
-        super::vrf::dispatch_mup(dispatcher, &prefix, selected.first());
+        super::vrf::dispatch_mup(dispatcher, rd, &prefix, selected.first());
     }
     if !selected.is_empty() {
-        route_advertise_mup_to_peers(prefix, &selected, bgp, peers);
+        route_advertise_mup_to_peers(rd, prefix, &selected, bgp, peers);
     }
 }
 
 /// Withdraw one MUP route advertised in an MP_UNREACH_NLRI from
 /// Adj-RIB-In and the Loc-RIB, then re-run best-path.
 pub fn route_mup_withdraw(ident: usize, route: &MupRoute, bgp: &mut BgpTop, peers: &mut PeerMap) {
-    let prefix = MupPrefix::from_route(route);
+    let (rd, prefix) = MupPrefix::from_route(route);
     let id = route.add_path_id();
     {
         let peer = peers.get_mut_by_idx(ident).expect("peer must exist");
-        peer.adj_in.remove_mup(&prefix, id);
+        peer.adj_in.remove_mup(rd, &prefix, id);
     }
-    let _ = bgp.local_rib.remove_mup(&prefix, id, ident);
-    let selected = bgp.local_rib.select_best_path_mup(&prefix);
+    let _ = bgp.local_rib.remove_mup(rd, &prefix, id, ident);
+    let selected = bgp.local_rib.select_best_path_mup(&rd, &prefix);
     // Mirror the post-withdraw state to per-VRF tasks: a remaining best
     // path is re-forwarded (matched by RT), otherwise the prefix is
     // withdrawn from every VRF's display copy.
     if let Some(dispatcher) = bgp.vrf_import {
-        super::vrf::dispatch_mup(dispatcher, &prefix, selected.first());
+        super::vrf::dispatch_mup(dispatcher, rd, &prefix, selected.first());
     }
     if selected.is_empty() {
-        route_withdraw_mup_to_peers(prefix, peers);
+        route_withdraw_mup_to_peers(rd, prefix, peers);
     } else {
         // Another path remains best for this key — re-advertise it.
-        route_advertise_mup_to_peers(prefix, &selected, bgp, peers);
+        route_advertise_mup_to_peers(rd, prefix, &selected, bgp, peers);
     }
 }
 
@@ -7642,14 +7654,14 @@ fn bgp_nexthop_ip(nh: &BgpNexthop) -> Option<IpAddr> {
     }
 }
 
-/// Select the Segment Discovery NLRI for a VRF's `segment` mode: a DSD
-/// (RD + router-id) for `Direct`, or an ISD (RD + the configured interwork
-/// prefix) for `Interwork`. Returns `None` when the route's NLRI key is not
+/// Select the Segment Discovery NLRI (the RD-free MUP key) for a VRF's
+/// `segment` mode: a DSD (router-id) for `Direct`, or an ISD (the configured
+/// interwork prefix) for `Interwork`. The RD is the outer per-RD map key and
+/// is supplied separately by the caller. Returns `None` when the key is not
 /// available yet — an all-zero router-id for Direct (cold start before the
 /// router-id resolves) or an unset `segment interwork prefix` for Interwork.
 fn mup_segment_nlri(
     mode: super::vrf_config::MupSegmentMode,
-    rd: RouteDistinguisher,
     router_id: Ipv4Addr,
     interwork_prefix: Option<ipnet::IpNet>,
 ) -> Option<MupPrefix> {
@@ -7660,12 +7672,10 @@ fn mup_segment_nlri(
                 return None;
             }
             Some(MupPrefix::Dsd {
-                rd,
                 address: IpAddr::V4(router_id),
             })
         }
         MupSegmentMode::Interwork => Some(MupPrefix::Isd {
-            rd,
             prefix: interwork_prefix?,
         }),
     }
@@ -7681,6 +7691,7 @@ fn mup_segment_nlri(
 /// cleared.
 fn route_update_mup(
     peer: &mut Peer,
+    rd: RouteDistinguisher,
     prefix: &MupPrefix,
     rib: &BgpRib,
     bgp: &BgpTop,
@@ -7698,7 +7709,7 @@ fn route_update_mup(
         return None;
     }
 
-    let route = prefix.to_route();
+    let route = prefix.to_route(rd);
     let mut attrs = (*rib.attr).clone();
     ebgp_egress_aspath(&peer.egress_as(), &mut attrs);
 
@@ -7746,12 +7757,18 @@ fn mup_send_one(peer: &mut Peer, afi: Afi, route: MupRoute, attr: &Arc<BgpAttr>,
 
 /// Advertise one selected MUP path to a single peer: apply egress
 /// transforms, record the Adj-RIB-Out entry, and emit the UPDATE.
-fn mup_advertise_one(peer: &mut Peer, prefix: &MupPrefix, rib: &BgpRib, bgp: &mut BgpTop) -> bool {
+fn mup_advertise_one(
+    peer: &mut Peer,
+    rd: RouteDistinguisher,
+    prefix: &MupPrefix,
+    rib: &BgpRib,
+    bgp: &mut BgpTop,
+) -> bool {
     // RFC 9494 §4.3: stale routes only go to LLGR peers.
     if llgr_blocks_advertisement(rib.stale, &peer.cap_recv, prefix.afi(), Safi::Mup) {
         return false;
     }
-    let Some((route, attrs, nhop)) = route_update_mup(peer, prefix, rib, bgp) else {
+    let Some((route, attrs, nhop)) = route_update_mup(peer, rd, prefix, rib, bgp) else {
         return false;
     };
     // No per-AFI MUP outbound route-policy binding exists yet, so the
@@ -7760,7 +7777,7 @@ fn mup_advertise_one(peer: &mut Peer, prefix: &MupPrefix, rib: &BgpRib, bgp: &mu
     let attr = bgp.attr_store.intern(attrs);
     let mut adj = rib.clone();
     adj.attr = attr.clone();
-    peer.adj_out.add_mup(prefix.clone(), adj);
+    peer.adj_out.add_mup(rd, prefix.clone(), adj);
     mup_send_one(peer, prefix.afi(), route, &attr, nhop);
     true
 }
@@ -7770,6 +7787,7 @@ fn mup_advertise_one(peer: &mut Peer, prefix: &MupPrefix, rib: &BgpRib, bgp: &mu
 /// only the best path is sent (plain members). Pairs with
 /// [`route_withdraw_mup_to_peers`].
 pub fn route_advertise_mup_to_peers(
+    rd: RouteDistinguisher,
     prefix: MupPrefix,
     selected: &[BgpRib],
     bgp: &mut BgpTop,
@@ -7781,18 +7799,18 @@ pub fn route_advertise_mup_to_peers(
     let afi = prefix.afi();
     for ident in peers.established_plain_idents(afi, Safi::Mup) {
         let peer = peers.get_mut_by_idx(ident).expect("peer exists");
-        mup_advertise_one(peer, &prefix, new_best, bgp);
+        mup_advertise_one(peer, rd, &prefix, new_best, bgp);
     }
 }
 
 /// Send one id-less MUP MP_UNREACH to a peer and drop the Adj-RIB-Out
 /// entry so a later policy diff doesn't re-withdraw it.
-fn mup_withdraw_one(peer: &mut Peer, prefix: &MupPrefix) {
-    peer.adj_out.remove_mup(prefix, 0);
+fn mup_withdraw_one(peer: &mut Peer, rd: RouteDistinguisher, prefix: &MupPrefix) {
+    peer.adj_out.remove_mup(rd, prefix, 0);
     let mut update = UpdatePacket::with_max_packet_size(peer.max_packet_size());
     update.mp_withdraw = Some(MpUnreachAttr::Mup {
         afi: prefix.afi(),
-        withdraws: vec![prefix.to_route()],
+        withdraws: vec![prefix.to_route(rd)],
     });
     peer.send_packet(update.into());
 }
@@ -7800,11 +7818,11 @@ fn mup_withdraw_one(peer: &mut Peer, prefix: &MupPrefix) {
 /// Withdraw a MUP prefix from every Established `(afi, Mup)` peer. The
 /// id-less MP_UNREACH clears the whole prefix; a peer that never held it
 /// ignores the withdraw.
-pub fn route_withdraw_mup_to_peers(prefix: MupPrefix, peers: &mut PeerMap) {
+pub fn route_withdraw_mup_to_peers(rd: RouteDistinguisher, prefix: MupPrefix, peers: &mut PeerMap) {
     let afi = prefix.afi();
     for ident in peers.established_plain_idents(afi, Safi::Mup) {
         let peer = peers.get_mut_by_idx(ident).expect("peer exists");
-        mup_withdraw_one(peer, &prefix);
+        mup_withdraw_one(peer, rd, &prefix);
     }
 }
 
@@ -7881,14 +7899,19 @@ fn build_mup_attr(
 /// before the peer came up would never be sent. Called from `route_sync`
 /// only when the peer negotiated `(Ip, Mup)` or `(Ip6, Mup)`.
 pub fn route_sync_mup(peer: &mut Peer, bgp: &mut BgpTop) {
-    let snapshot: Vec<(MupPrefix, BgpRib)> = bgp
+    // Per-RD walk over `LocalRib::mup[rd].selected`, mirroring `route_sync_evpn`.
+    let snapshot: Vec<(RouteDistinguisher, MupPrefix, BgpRib)> = bgp
         .local_rib
         .mup
-        .selected
         .iter()
-        .map(|(prefix, rib)| (prefix.clone(), rib.clone()))
+        .flat_map(|(rd, table)| {
+            table
+                .selected
+                .iter()
+                .map(move |(prefix, rib)| (*rd, prefix.clone(), rib.clone()))
+        })
         .collect();
-    for (prefix, rib) in snapshot {
+    for (rd, prefix, rib) in snapshot {
         let afi = prefix.afi();
         if !peer.is_afi_safi(afi, Safi::Mup) {
             continue;
@@ -7896,13 +7919,13 @@ pub fn route_sync_mup(peer: &mut Peer, bgp: &mut BgpTop) {
         if llgr_blocks_advertisement(rib.stale, &peer.cap_recv, afi, Safi::Mup) {
             continue;
         }
-        let Some((route, attrs, nhop)) = route_update_mup(peer, &prefix, &rib, bgp) else {
+        let Some((route, attrs, nhop)) = route_update_mup(peer, rd, &prefix, &rib, bgp) else {
             continue;
         };
         let attr = bgp.attr_store.intern(attrs);
         let mut adj = rib.clone();
         adj.attr = attr.clone();
-        peer.adj_out.add_mup(prefix.clone(), adj);
+        peer.adj_out.add_mup(rd, prefix.clone(), adj);
         mup_send_one(peer, afi, route, &attr, nhop);
     }
     // RFC 4724 / RFC 7606 §3 EoR: empty MP_UNREACH per negotiated MUP AFI.
@@ -9748,22 +9771,24 @@ pub fn route_clean(
     // peer-down simply drops every MUP route the peer gave us from the
     // Loc-RIB and clears its Adj-RIB-In. (LLGR stale retention for MUP is
     // a later phase, mirroring the EVPN/VPN two-branch logic above.)
-    let mup_keys: Vec<(MupPrefix, u32)> = {
+    let mup_keys: Vec<(RouteDistinguisher, MupPrefix, u32)> = {
         let peer = peers.get_mut_by_idx(peer_id).expect("peer must exist");
         let mut out = Vec::new();
-        for (prefix, ribs) in peer.adj_in.mup.0.iter() {
-            for rib in ribs.iter() {
-                out.push((prefix.clone(), rib.remote_id));
+        for (rd, table) in peer.adj_in.mup.iter() {
+            for (prefix, ribs) in table.0.iter() {
+                for rib in ribs.iter() {
+                    out.push((*rd, prefix.clone(), rib.remote_id));
+                }
             }
         }
         out
     };
-    for (prefix, id) in mup_keys.iter() {
-        let _ = bgp.local_rib.remove_mup(prefix, *id, peer_id);
-        let _ = bgp.local_rib.select_best_path_mup(prefix);
+    for (rd, prefix, id) in mup_keys.iter() {
+        let _ = bgp.local_rib.remove_mup(*rd, prefix, *id, peer_id);
+        let _ = bgp.local_rib.select_best_path_mup(rd, prefix);
     }
     let peer = peers.get_mut_by_idx(peer_id).expect("peer must exist");
-    peer.adj_in.mup.0.clear();
+    peer.adj_in.mup.clear();
 
     let peer = peers.get_mut_by_idx(peer_id).expect("peer must exist");
     peer.adj_out.evpn.clear();
@@ -12711,7 +12736,7 @@ impl Bgp {
         // sharing the NI). Install + advertise each, recording every prefix
         // so the deletion / next modification withdraws all of them.
         let mut prefixes = Vec::with_capacity(originations.len());
-        for (prefix, attr) in originations {
+        for (rd, prefix, attr) in originations {
             let mut rib = BgpRib::new(
                 ORIGINATED_PEER,
                 Ipv4Addr::UNSPECIFIED,
@@ -12724,10 +12749,10 @@ impl Bgp {
                 false,
             );
             rib.attr = self.attr_store.intern(attr);
-            let _ = self.local_rib.update_mup(prefix.clone(), rib);
-            let selected = self.local_rib.select_best_path_mup(&prefix);
-            self.mup_apply_selected(prefix.clone(), selected);
-            prefixes.push(prefix);
+            let _ = self.local_rib.update_mup(rd, prefix.clone(), rib);
+            let selected = self.local_rib.select_best_path_mup(&rd, &prefix);
+            self.mup_apply_selected(rd, prefix.clone(), selected);
+            prefixes.push((rd, prefix));
         }
         self.mup_c_originated.insert(session.seid, prefixes);
     }
@@ -12739,10 +12764,10 @@ impl Bgp {
         let Some(prefixes) = self.mup_c_originated.remove(&seid) else {
             return;
         };
-        for prefix in prefixes {
-            self.local_rib.remove_mup(&prefix, 0, ORIGINATED_PEER);
-            let selected = self.local_rib.select_best_path_mup(&prefix);
-            self.mup_apply_selected(prefix, selected);
+        for (rd, prefix) in prefixes {
+            self.local_rib.remove_mup(rd, &prefix, 0, ORIGINATED_PEER);
+            let selected = self.local_rib.select_best_path_mup(&rd, &prefix);
+            self.mup_apply_selected(rd, prefix, selected);
         }
     }
 
@@ -12757,7 +12782,11 @@ impl Bgp {
     pub(super) fn build_mup_origination(
         &self,
         session: &crate::mup_c::session::MupSession,
-    ) -> Vec<(bgp_packet::MupPrefix, BgpAttr)> {
+    ) -> Vec<(
+        bgp_packet::RouteDistinguisher,
+        bgp_packet::MupPrefix,
+        BgpAttr,
+    )> {
         use super::vrf_config::MupSrv6Direction;
         let Some(ni) = session.network_instance.as_deref() else {
             return Vec::new();
@@ -12789,7 +12818,6 @@ impl Bgp {
                     MupSrv6Direction::Encapsulation => {
                         match (mup_ue_prefix(session), session.endpoint) {
                             (Some(prefix), Some(endpoint)) => bgp_packet::MupPrefix::T1st {
-                                rd,
                                 prefix,
                                 teid: session.teid,
                                 qfi: session.qfi.unwrap_or(0),
@@ -12807,7 +12835,6 @@ impl Bgp {
                     // TEID of 0 is a malformed NLRI per the draft).
                     MupSrv6Direction::Decapsulation => match session.endpoint {
                         Some(endpoint) => bgp_packet::MupPrefix::T2st {
-                            rd,
                             endpoint,
                             endpoint_len: if endpoint.is_ipv4() { 64 } else { 160 },
                             teid: session.teid,
@@ -12825,19 +12852,24 @@ impl Bgp {
                 {
                     attr_add_ecom(&mut attr, mup_direct_segment_ecom(&seg));
                 }
-                Some((prefix, attr))
+                Some((rd, prefix, attr))
             })
             .collect()
     }
 
     /// Apply the post-update best path of one MUP prefix to peers:
     /// advertise the new best, or withdraw when no path remains.
-    fn mup_apply_selected(&mut self, prefix: bgp_packet::MupPrefix, selected: Vec<BgpRib>) {
+    fn mup_apply_selected(
+        &mut self,
+        rd: RouteDistinguisher,
+        prefix: bgp_packet::MupPrefix,
+        selected: Vec<BgpRib>,
+    ) {
         // Mirror the best-path to the per-VRF task whose `rd` matches this
         // route's RD (display-only, for `show bgp vrf <name> mup`).
-        self.forward_mup_to_vrf(&prefix, selected.first());
+        self.forward_mup_to_vrf(rd, &prefix, selected.first());
         if selected.is_empty() {
-            route_withdraw_mup_to_peers(prefix, &mut self.peers);
+            route_withdraw_mup_to_peers(rd, prefix, &mut self.peers);
             return;
         }
         let mut bgp_ref = BgpTop {
@@ -12860,7 +12892,7 @@ impl Bgp {
             vrf_transport_v6: None,
             central_label_alloc: None,
         };
-        route_advertise_mup_to_peers(prefix, &selected, &mut bgp_ref, &mut self.peers);
+        route_advertise_mup_to_peers(rd, prefix, &selected, &mut bgp_ref, &mut self.peers);
     }
 
     /// Forward a MUP best-path (or its withdrawal) to the per-VRF task
@@ -12868,10 +12900,12 @@ impl Bgp {
     /// `show bgp vrf <name> mup`. No-op when no VRF owns the RD or that
     /// VRF has no running per-VRF task. Display-only: the global instance
     /// stays the authoritative MUP RIB and advertiser.
-    fn forward_mup_to_vrf(&self, prefix: &bgp_packet::MupPrefix, best: Option<&BgpRib>) {
-        let Some(rd) = prefix.rd() else {
-            return;
-        };
+    fn forward_mup_to_vrf(
+        &self,
+        rd: RouteDistinguisher,
+        prefix: &bgp_packet::MupPrefix,
+        best: Option<&BgpRib>,
+    ) {
         let Some(name) = self
             .vrfs
             .iter()
@@ -12884,10 +12918,12 @@ impl Bgp {
         };
         let msg = match best {
             Some(rib) => super::vrf::msg::BgpVrfMsg::MupUpdate {
+                rd,
                 prefix: prefix.clone(),
                 rib: rib.clone(),
             },
             None => super::vrf::msg::BgpVrfMsg::MupWithdraw {
+                rd,
                 prefix: prefix.clone(),
             },
         };
@@ -12907,7 +12943,12 @@ impl Bgp {
         let names: Vec<String> = self.vrfs.keys().cloned().collect();
         let mut desired: std::collections::BTreeMap<
             String,
-            (bgp_packet::MupPrefix, std::net::Ipv6Addr, BgpAttr),
+            (
+                RouteDistinguisher,
+                bgp_packet::MupPrefix,
+                std::net::Ipv6Addr,
+                BgpAttr,
+            ),
         > = std::collections::BTreeMap::new();
         for name in &names {
             if let Some(d) = self.build_mup_segment_origination(name) {
@@ -12918,34 +12959,34 @@ impl Bgp {
         // changed (a changed RD/router-id/prefix, or a direct↔interwork
         // switch, needs an explicit withdraw of the OLD prefix before the new
         // one is originated under a different key).
-        let prev: Vec<(String, bgp_packet::MupPrefix)> = self
+        let prev: Vec<(String, RouteDistinguisher, bgp_packet::MupPrefix)> = self
             .mup_segment_originated
             .iter()
-            .map(|(n, (p, _, _))| (n.clone(), p.clone()))
+            .map(|(n, (rd, p, _, _))| (n.clone(), *rd, p.clone()))
             .collect();
-        for (name, prev_prefix) in prev {
+        for (name, prev_rd, prev_prefix) in prev {
             let keep = desired
                 .get(&name)
-                .map(|(p, _, _)| *p == prev_prefix)
+                .map(|(rd, p, _, _)| *rd == prev_rd && *p == prev_prefix)
                 .unwrap_or(false);
             if !keep {
                 self.withdraw_mup_segment(&name);
             }
         }
-        // Originate or refresh. Skip only when the NLRI key, the SID *and*
-        // the ext-communities (export RTs + the Direct-segment MUP
+        // Originate or refresh. Skip only when the RD, the NLRI key, the SID
+        // *and* the ext-communities (export RTs + the Direct-segment MUP
         // ext-comm) are all unchanged, so an unrelated commit doesn't
         // re-advertise but a later RT / `mup-ext-comm` arrival does.
-        for (name, (prefix, sid, attr)) in desired {
+        for (name, (rd, prefix, sid, attr)) in desired {
             let unchanged = self
                 .mup_segment_originated
                 .get(&name)
-                .map(|(p, s, e)| *p == prefix && *s == sid && *e == attr.ecom)
+                .map(|(r, p, s, e)| *r == rd && *p == prefix && *s == sid && *e == attr.ecom)
                 .unwrap_or(false);
             if unchanged {
                 continue;
             }
-            self.originate_mup_segment(name, prefix, sid, attr);
+            self.originate_mup_segment(name, rd, prefix, sid, attr);
         }
     }
 
@@ -12971,11 +13012,16 @@ impl Bgp {
     ///   the AFI). Needs the prefix to be set; no MUP Extended Community (a
     ///   receiving PE resolves it by endpoint-address lookup, §3.1.1).
     ///
-    /// Returns `(prefix, sid_addr, attr)`.
+    /// Returns `(rd, prefix, sid_addr, attr)`.
     fn build_mup_segment_origination(
         &self,
         name: &str,
-    ) -> Option<(bgp_packet::MupPrefix, std::net::Ipv6Addr, BgpAttr)> {
+    ) -> Option<(
+        RouteDistinguisher,
+        bgp_packet::MupPrefix,
+        std::net::Ipv6Addr,
+        BgpAttr,
+    )> {
         use super::vrf_config::{BgpVrfEncapsulation, MupSegmentMode};
         let cfg = self.vrfs.get(name)?;
         let mode = cfg.mobile_uplane.segment?;
@@ -12995,7 +13041,7 @@ impl Bgp {
         // The NLRI differs by segment type (DSD = RD + router-id, ISD = RD +
         // interwork prefix); both ride the same End.DT46 SID.
         let router_id = cfg.router_id.unwrap_or(self.router_id);
-        let prefix = mup_segment_nlri(mode, rd, router_id, cfg.mobile_uplane.interwork_prefix)?;
+        let prefix = mup_segment_nlri(mode, router_id, cfg.mobile_uplane.interwork_prefix)?;
         let rts = self
             .rib_known_vrfs
             .get(name)
@@ -13017,7 +13063,7 @@ impl Bgp {
         {
             attr_add_ecom(&mut attr, mup_direct_segment_ecom(&seg));
         }
-        Some((prefix, sid, attr))
+        Some((rd, prefix, sid, attr))
     }
 
     /// Install one VRF's Segment Discovery route (DSD or ISD) into the MUP
@@ -13028,6 +13074,7 @@ impl Bgp {
     fn originate_mup_segment(
         &mut self,
         name: String,
+        rd: RouteDistinguisher,
         prefix: bgp_packet::MupPrefix,
         sid: std::net::Ipv6Addr,
         attr: BgpAttr,
@@ -13045,23 +13092,23 @@ impl Bgp {
         );
         let ecom = attr.ecom.clone();
         rib.attr = self.attr_store.intern(attr);
-        let _ = self.local_rib.update_mup(prefix.clone(), rib);
-        let selected = self.local_rib.select_best_path_mup(&prefix);
+        let _ = self.local_rib.update_mup(rd, prefix.clone(), rib);
+        let selected = self.local_rib.select_best_path_mup(&rd, &prefix);
         self.mup_segment_originated
-            .insert(name, (prefix.clone(), sid, ecom));
-        self.mup_apply_selected(prefix, selected);
+            .insert(name, (rd, prefix.clone(), sid, ecom));
+        self.mup_apply_selected(rd, prefix, selected);
     }
 
     /// Withdraw the Segment Discovery route (DSD or ISD) originated for
     /// `name` (a config / SID / kernel-VRF precondition dropped, or the
     /// `segment` type changed). No-op when nothing was originated.
     fn withdraw_mup_segment(&mut self, name: &str) {
-        let Some((prefix, _sid, _ecom)) = self.mup_segment_originated.remove(name) else {
+        let Some((rd, prefix, _sid, _ecom)) = self.mup_segment_originated.remove(name) else {
             return;
         };
-        self.local_rib.remove_mup(&prefix, 0, ORIGINATED_PEER);
-        let selected = self.local_rib.select_best_path_mup(&prefix);
-        self.mup_apply_selected(prefix, selected);
+        self.local_rib.remove_mup(rd, &prefix, 0, ORIGINATED_PEER);
+        let selected = self.local_rib.select_best_path_mup(&rd, &prefix);
+        self.mup_apply_selected(rd, prefix, selected);
     }
 
     pub fn route_add(&mut self, prefix: Ipv4Net) {
@@ -17937,21 +17984,18 @@ mod tests {
     #[test]
     fn mup_segment_nlri_selects_dsd_or_isd() {
         use std::net::{IpAddr, Ipv4Addr};
-        use std::str::FromStr;
 
-        use bgp_packet::{MupPrefix, RouteDistinguisher};
+        use bgp_packet::MupPrefix;
 
         use super::super::vrf_config::MupSegmentMode;
 
-        let rd = RouteDistinguisher::from_str("65501:10").unwrap();
         let router_id: Ipv4Addr = "192.168.0.1".parse().unwrap();
         let isd_prefix: ipnet::IpNet = "10.60.0.0/16".parse().unwrap();
 
-        // Direct -> DSD keyed by RD + router-id (the interwork prefix is
-        // irrelevant for Direct and is ignored).
-        match super::mup_segment_nlri(MupSegmentMode::Direct, rd, router_id, Some(isd_prefix)) {
-            Some(MupPrefix::Dsd { rd: r, address }) => {
-                assert_eq!(r, rd);
+        // Direct -> DSD keyed by router-id (the RD is the outer per-RD map
+        // key, supplied separately; the interwork prefix is ignored).
+        match super::mup_segment_nlri(MupSegmentMode::Direct, router_id, Some(isd_prefix)) {
+            Some(MupPrefix::Dsd { address }) => {
                 assert_eq!(address, IpAddr::V4(router_id));
             }
             other => panic!("expected Dsd, got {other:?}"),
@@ -17959,21 +18003,19 @@ mod tests {
         // Direct with an all-zero router-id -> nothing (cold start before the
         // router-id resolves).
         assert!(
-            super::mup_segment_nlri(MupSegmentMode::Direct, rd, Ipv4Addr::UNSPECIFIED, None)
-                .is_none()
+            super::mup_segment_nlri(MupSegmentMode::Direct, Ipv4Addr::UNSPECIFIED, None).is_none()
         );
 
-        // Interwork -> ISD keyed by RD + the configured prefix.
-        match super::mup_segment_nlri(MupSegmentMode::Interwork, rd, router_id, Some(isd_prefix)) {
-            Some(MupPrefix::Isd { rd: r, prefix }) => {
-                assert_eq!(r, rd);
+        // Interwork -> ISD keyed by the configured prefix.
+        match super::mup_segment_nlri(MupSegmentMode::Interwork, router_id, Some(isd_prefix)) {
+            Some(MupPrefix::Isd { prefix }) => {
                 assert_eq!(prefix, isd_prefix);
             }
             other => panic!("expected Isd, got {other:?}"),
         }
         // Interwork without a configured prefix -> nothing (the ISD does not
         // originate until `segment interwork prefix <p>` is set).
-        assert!(super::mup_segment_nlri(MupSegmentMode::Interwork, rd, router_id, None).is_none());
+        assert!(super::mup_segment_nlri(MupSegmentMode::Interwork, router_id, None).is_none());
     }
 
     fn bgp_rib_with_nexthop(nh: Option<BgpNexthop>, typ: super::BgpRibType) -> super::BgpRib {

--- a/zebra-rs/src/bgp/show.rs
+++ b/zebra-rs/src/bgp/show.rs
@@ -167,11 +167,14 @@ fn mup_prefix_afi(prefix: &MupPrefix) -> Option<Afi> {
     Some(if addr.is_ipv4() { Afi::Ip } else { Afi::Ip6 })
 }
 
-/// Count selected MUP Loc-RIB entries for one address family.
-fn mup_rib_count(table: &super::route::LocalRibMupTable, afi: Afi) -> usize {
-    table
-        .selected
-        .keys()
+/// Count selected MUP Loc-RIB entries for one address family across every RD.
+fn mup_rib_count(
+    tables: &std::collections::BTreeMap<RouteDistinguisher, super::route::LocalRibMupTable>,
+    afi: Afi,
+) -> usize {
+    tables
+        .values()
+        .flat_map(|table| table.selected.keys())
         .filter(|p| mup_prefix_afi(p) == Some(afi))
         .count()
 }
@@ -716,17 +719,20 @@ struct MupCAssociationJson {
 
 /// JSON rendering of a MUP Loc-RIB table — shared by the global
 /// `show bgp mup` and the per-VRF `show bgp vrf <name> mup`.
-fn mup_routes_json(table: &super::route::LocalRibMupTable) -> String {
-    let routes: Vec<MupRouteJson> = table
-        .selected
+fn mup_routes_json(
+    tables: &std::collections::BTreeMap<RouteDistinguisher, super::route::LocalRibMupTable>,
+) -> String {
+    let routes: Vec<MupRouteJson> = tables
         .iter()
-        .map(|(prefix, rib)| {
-            let ecom = show_mup_ecom(&rib.attr);
-            MupRouteJson {
-                prefix: mup_prefix_display(prefix),
-                attrs: common_route_attrs(rib),
-                extended_communities: (!ecom.is_empty()).then_some(ecom),
-            }
+        .flat_map(|(rd, table)| {
+            table.selected.iter().map(move |(prefix, rib)| {
+                let ecom = show_mup_ecom(&rib.attr);
+                MupRouteJson {
+                    prefix: mup_prefix_display(rd, prefix),
+                    attrs: common_route_attrs(rib),
+                    extended_communities: (!ecom.is_empty()).then_some(ecom),
+                }
+            })
         })
         .collect();
     serde_json::to_string_pretty(&routes).unwrap_or_else(|e| format!("{{\"error\": \"{e}\"}}"))
@@ -4029,14 +4035,14 @@ fn show_mup_ecom(attr: &BgpAttr) -> String {
         .join(" ")
 }
 
-/// Render a `MupPrefix` as the bracketed `[TYPE][rd][fields]` form used by
-/// `show bgp mup`, following the MUP NLRI layout (RFC 9833).
-fn mup_prefix_display(prefix: &MupPrefix) -> String {
+/// Render a `MupPrefix` (plus its outer-map RD) as the bracketed
+/// `[TYPE][rd][fields]` form used by `show bgp mup`, following the MUP NLRI
+/// layout (RFC 9833).
+fn mup_prefix_display(rd: &RouteDistinguisher, prefix: &MupPrefix) -> String {
     match prefix {
-        MupPrefix::Dsd { rd, address } => format!("[DSD][{rd}][{address}]"),
-        MupPrefix::Isd { rd, prefix } => format!("[ISD][{rd}][{prefix}]"),
+        MupPrefix::Dsd { address } => format!("[DSD][{rd}][{address}]"),
+        MupPrefix::Isd { prefix } => format!("[ISD][{rd}][{prefix}]"),
         MupPrefix::T1st {
-            rd,
             prefix,
             teid,
             qfi,
@@ -4049,7 +4055,6 @@ fn mup_prefix_display(prefix: &MupPrefix) -> String {
             None => format!("[ST1][{rd}][ue={prefix}][teid={teid}][qfi={qfi}][ep={endpoint}]"),
         },
         MupPrefix::T2st {
-            rd,
             endpoint,
             endpoint_len: _,
             teid,
@@ -4267,7 +4272,7 @@ fn fmt_direct_segment_id(val: &[u8; 6]) -> String {
 }
 
 fn render_mup_table(
-    table: &super::route::LocalRibMupTable,
+    tables: &std::collections::BTreeMap<RouteDistinguisher, super::route::LocalRibMupTable>,
     resolve_segments: bool,
 ) -> std::result::Result<String, std::fmt::Error> {
     // On an interwork (SRGW) node, index the selected DSD routes by their
@@ -4275,23 +4280,30 @@ fn render_mup_table(
     // can be resolved to the End.DT46 Direct segment its uplink GTP tunnel
     // forwards into (draft-mpmz-bess-mup-safi §3.3.12). The forwarding FIB
     // (H.M.GTP4.D GTP decap) is VPP/eBPF — this is the control-plane bind.
-    let dsd_index: std::collections::BTreeMap<[u8; 6], (MupPrefix, std::net::Ipv6Addr, u16)> =
-        if resolve_segments {
-            table
-                .selected
-                .iter()
-                .filter_map(|(prefix, rib)| {
-                    if !matches!(prefix, MupPrefix::Dsd { .. }) {
-                        return None;
-                    }
-                    let seg = mup_direct_segment_id(&rib.attr)?;
-                    let (sid, behavior) = rib.attr.srv6_l3_sid()?;
-                    Some((seg, (prefix.clone(), sid, behavior)))
-                })
-                .collect()
-        } else {
-            std::collections::BTreeMap::new()
-        };
+    let dsd_index: std::collections::BTreeMap<
+        [u8; 6],
+        (RouteDistinguisher, MupPrefix, std::net::Ipv6Addr, u16),
+    > = if resolve_segments {
+        tables
+            .iter()
+            .flat_map(|(rd, table)| {
+                table
+                    .selected
+                    .iter()
+                    .map(move |(prefix, rib)| (rd, prefix, rib))
+            })
+            .filter_map(|(rd, prefix, rib)| {
+                if !matches!(prefix, MupPrefix::Dsd { .. }) {
+                    return None;
+                }
+                let seg = mup_direct_segment_id(&rib.attr)?;
+                let (sid, behavior) = rib.attr.srv6_l3_sid()?;
+                Some((seg, (*rd, prefix.clone(), sid, behavior)))
+            })
+            .collect()
+    } else {
+        std::collections::BTreeMap::new()
+    };
 
     let mut buf = String::new();
     writeln!(
@@ -4299,51 +4311,54 @@ fn render_mup_table(
         "   Network (MUP NLRI)                                   Next Hop"
     )?;
 
-    // The flat table iterates in `MupPrefix` Ord order: DSD, ISD, ST1, ST2.
-    for (prefix, rib) in table.selected.iter() {
-        let best = if rib.best_path { ">" } else { " " };
-        writeln!(buf, " *{best} {}", mup_prefix_display(prefix))?;
+    // Walk per-RD tables (BTree order), each in `MupPrefix` Ord order:
+    // DSD, ISD, ST1, ST2.
+    for (rd, table) in tables.iter() {
+        for (prefix, rib) in table.selected.iter() {
+            let best = if rib.best_path { ">" } else { " " };
+            writeln!(buf, " *{best} {}", mup_prefix_display(rd, prefix))?;
 
-        let nexthop = show_nexthop(&rib.attr);
-        writeln!(buf, "       next-hop {nexthop}  weight {}", rib.weight)?;
+            let nexthop = show_nexthop(&rib.attr);
+            writeln!(buf, "       next-hop {nexthop}  weight {}", rib.weight)?;
 
-        // SRv6 L3 Service SID (the segment a DSD/ISD route advertises, or
-        // an explicitly-pushed ST-route SID). "Local" when we originated it.
-        if let Some((sid, behavior)) = rib.attr.srv6_l3_sid() {
-            let kind = if rib.is_originated() {
-                "Local SID"
-            } else {
-                "Remote SID"
-            };
-            writeln!(
-                buf,
-                "       {kind} {sid} ({})",
-                srv6_behavior_name(behavior)
-            )?;
-        }
+            // SRv6 L3 Service SID (the segment a DSD/ISD route advertises, or
+            // an explicitly-pushed ST-route SID). "Local" when we originated it.
+            if let Some((sid, behavior)) = rib.attr.srv6_l3_sid() {
+                let kind = if rib.is_originated() {
+                    "Local SID"
+                } else {
+                    "Remote SID"
+                };
+                writeln!(
+                    buf,
+                    "       {kind} {sid} ({})",
+                    srv6_behavior_name(behavior)
+                )?;
+            }
 
-        let ecom = show_mup_ecom(&rib.attr);
-        if !ecom.is_empty() {
-            writeln!(buf, "       {ecom}")?;
-        }
+            let ecom = show_mup_ecom(&rib.attr);
+            if !ecom.is_empty() {
+                writeln!(buf, "       {ecom}")?;
+            }
 
-        // ST2 -> Direct-segment resolution on an interwork (SRGW) node:
-        // the received ST2's Direct-segment id (MUP Extended Community) is
-        // matched against a received DSD to find the End.DT46 segment the
-        // uplink (endpoint, TEID) tunnel forwards into.
-        if resolve_segments
-            && matches!(prefix, MupPrefix::T2st { .. })
-            && let Some(seg) = mup_direct_segment_id(&rib.attr)
-            && let Some((dsd, sid, behavior)) = dsd_index.get(&seg)
-        {
-            writeln!(
-                buf,
-                "       resolved {} -> {} {} (via {})",
-                fmt_direct_segment_id(&seg),
-                srv6_behavior_name(*behavior),
-                sid,
-                mup_prefix_display(dsd)
-            )?;
+            // ST2 -> Direct-segment resolution on an interwork (SRGW) node:
+            // the received ST2's Direct-segment id (MUP Extended Community) is
+            // matched against a received DSD to find the End.DT46 segment the
+            // uplink (endpoint, TEID) tunnel forwards into.
+            if resolve_segments
+                && matches!(prefix, MupPrefix::T2st { .. })
+                && let Some(seg) = mup_direct_segment_id(&rib.attr)
+                && let Some((dsd_rd, dsd, sid, behavior)) = dsd_index.get(&seg)
+            {
+                writeln!(
+                    buf,
+                    "       resolved {} -> {} {} (via {})",
+                    fmt_direct_segment_id(&seg),
+                    srv6_behavior_name(*behavior),
+                    sid,
+                    mup_prefix_display(dsd_rd, dsd)
+                )?;
+            }
         }
     }
 
@@ -5575,57 +5590,71 @@ mod detail_tests {
     #[test]
     fn render_mup_table_matches_mockup_shape() {
         use std::net::IpAddr;
-        let mut table = super::super::route::LocalRibMupTable::default();
+        let mut tables: std::collections::BTreeMap<
+            RouteDistinguisher,
+            super::super::route::LocalRibMupTable,
+        > = std::collections::BTreeMap::new();
         let nh6: IpAddr = "fc00::30".parse().unwrap();
         let nh4: IpAddr = "10.10.10.1".parse().unwrap();
         let rt_2_3 = ecv(0x00, 0x02, [0x00, 0x02, 0x00, 0x00, 0x00, 0x03]);
         let rt_9_9 = ecv(0x00, 0x02, [0x00, 0x09, 0x00, 0x00, 0x00, 0x09]);
         let mup_ec = ecv(0x0c, 0x00, [0x00, 0x01, 0x00, 0x00, 0x00, 0x3d]);
 
-        let _ = table.update(
-            MupPrefix::from_route(&MupRoute::Isd {
-                id: 0,
-                arch: MupArchitectureType::Gpp5g,
-                rd: "1.1.1.30:50002".parse().unwrap(),
-                prefix: "20.0.3.0/24".parse().unwrap(),
-            }),
-            mup_rib(nh6, 0, &[rt_2_3]),
-        );
-        let _ = table.update(
-            MupPrefix::from_route(&MupRoute::Dsd {
-                id: 0,
-                arch: MupArchitectureType::Gpp5g,
-                rd: "1.1.1.30:50005".parse().unwrap(),
-                address: "1.1.1.99".parse().unwrap(),
-            }),
-            mup_rib(nh6, 0, &[mup_ec]),
-        );
-        let _ = table.update(
-            MupPrefix::from_route(&MupRoute::T1st {
-                id: 0,
-                arch: MupArchitectureType::Gpp5g,
-                rd: "65000:2".parse().unwrap(),
-                prefix: "2001:db8:cafe::5/128".parse().unwrap(),
-                teid: 601,
-                qfi: 9,
-                endpoint: "20.0.3.99".parse().unwrap(),
-                source: Some("20.0.1.1".parse().unwrap()),
-            }),
-            mup_rib(nh6, 32768, &[rt_9_9]),
-        );
-        let _ = table.update(
-            MupPrefix::from_route(&MupRoute::T2st {
-                id: 0,
-                arch: MupArchitectureType::Gpp5g,
-                rd: "65000:1".parse().unwrap(),
-                endpoint: "20.0.1.1".parse().unwrap(),
-                endpoint_len: 64,
-                teid: 600,
-            }),
-            mup_rib(nh4, 32768, &[]),
-        );
+        // All four route types share one RD, so they land in a single per-RD
+        // inner table and the display order is driven purely by `MupPrefix`
+        // Ord (DSD -> ISD -> ST1 -> ST2). (Across *different* RDs the table is
+        // RD-major, like `show bgp evpn`; that is covered by the resolve test.)
+        let rd = "65000:1";
+        {
+            let mut insert = |route: &MupRoute, rib| {
+                let (rd, prefix) = MupPrefix::from_route(route);
+                let _ = tables.entry(rd).or_default().update(prefix, rib);
+            };
+            insert(
+                &MupRoute::Isd {
+                    id: 0,
+                    arch: MupArchitectureType::Gpp5g,
+                    rd: rd.parse().unwrap(),
+                    prefix: "20.0.3.0/24".parse().unwrap(),
+                },
+                mup_rib(nh6, 0, &[rt_2_3]),
+            );
+            insert(
+                &MupRoute::Dsd {
+                    id: 0,
+                    arch: MupArchitectureType::Gpp5g,
+                    rd: rd.parse().unwrap(),
+                    address: "1.1.1.99".parse().unwrap(),
+                },
+                mup_rib(nh6, 0, &[mup_ec]),
+            );
+            insert(
+                &MupRoute::T1st {
+                    id: 0,
+                    arch: MupArchitectureType::Gpp5g,
+                    rd: rd.parse().unwrap(),
+                    prefix: "2001:db8:cafe::5/128".parse().unwrap(),
+                    teid: 601,
+                    qfi: 9,
+                    endpoint: "20.0.3.99".parse().unwrap(),
+                    source: Some("20.0.1.1".parse().unwrap()),
+                },
+                mup_rib(nh6, 32768, &[rt_9_9]),
+            );
+            insert(
+                &MupRoute::T2st {
+                    id: 0,
+                    arch: MupArchitectureType::Gpp5g,
+                    rd: rd.parse().unwrap(),
+                    endpoint: "20.0.1.1".parse().unwrap(),
+                    endpoint_len: 64,
+                    teid: 600,
+                },
+                mup_rib(nh4, 32768, &[]),
+            );
+        }
 
-        let out = render_mup_table(&table, false).unwrap();
+        let out = render_mup_table(&tables, false).unwrap();
 
         // Grouped DSD -> ISD -> ST1 -> ST2 by MupPrefix Ord.
         let dsd = out.find("[DSD]").expect("DSD line");
@@ -5637,11 +5666,11 @@ mod detail_tests {
             "route-type ordering:\n{out}"
         );
 
-        assert!(out.contains("[ISD][1.1.1.30:50002][20.0.3.0/24]"), "{out}");
-        assert!(out.contains("[DSD][1.1.1.30:50005][1.1.1.99]"), "{out}");
+        assert!(out.contains("[ISD][65000:1][20.0.3.0/24]"), "{out}");
+        assert!(out.contains("[DSD][65000:1][1.1.1.99]"), "{out}");
         assert!(
             out.contains(
-                "[ST1][65000:2][ue=2001:db8:cafe::5/128][teid=601][qfi=9][ep=20.0.3.99:src=20.0.1.1]"
+                "[ST1][65000:1][ue=2001:db8:cafe::5/128][teid=601][qfi=9][ep=20.0.3.99:src=20.0.1.1]"
             ),
             "{out}"
         );
@@ -5668,7 +5697,10 @@ mod detail_tests {
     #[test]
     fn render_mup_table_resolves_st2_to_direct_segment() {
         use std::net::{IpAddr, Ipv4Addr};
-        let mut table = super::super::route::LocalRibMupTable::default();
+        let mut tables: std::collections::BTreeMap<
+            RouteDistinguisher,
+            super::super::route::LocalRibMupTable,
+        > = std::collections::BTreeMap::new();
         // Direct-segment id 1:2 (MUP Ext-Comm 0x0c/0x00), shared DSD<->ST2.
         let seg = ecv(0x0c, 0x00, [0x00, 0x01, 0x00, 0x00, 0x00, 0x02]);
 
@@ -5692,36 +5724,38 @@ mod detail_tests {
             None,
             false,
         );
-        let _ = table.update(
-            MupPrefix::from_route(&MupRoute::Dsd {
-                id: 0,
-                arch: MupArchitectureType::Gpp5g,
-                rd: "65001:1".parse().unwrap(),
-                address: "10.0.0.1".parse().unwrap(),
-            }),
-            dsd_rib,
-        );
+        let (dsd_rd, dsd_prefix) = MupPrefix::from_route(&MupRoute::Dsd {
+            id: 0,
+            arch: MupArchitectureType::Gpp5g,
+            rd: "65001:1".parse().unwrap(),
+            address: "10.0.0.1".parse().unwrap(),
+        });
+        let _ = tables
+            .entry(dsd_rd)
+            .or_default()
+            .update(dsd_prefix, dsd_rib);
 
         // A received ST2 carrying the same segment id 1:2 (no SID of its own).
         let st2_rib = mup_rib("fc00::2".parse::<IpAddr>().unwrap(), 0, &[seg]);
-        let _ = table.update(
-            MupPrefix::from_route(&MupRoute::T2st {
-                id: 0,
-                arch: MupArchitectureType::Gpp5g,
-                rd: "65001:2".parse().unwrap(),
-                endpoint: "127.0.0.8".parse().unwrap(),
-                endpoint_len: 64,
-                teid: 2,
-            }),
-            st2_rib,
-        );
+        let (st2_rd, st2_prefix) = MupPrefix::from_route(&MupRoute::T2st {
+            id: 0,
+            arch: MupArchitectureType::Gpp5g,
+            rd: "65001:2".parse().unwrap(),
+            endpoint: "127.0.0.8".parse().unwrap(),
+            endpoint_len: 64,
+            teid: 2,
+        });
+        let _ = tables
+            .entry(st2_rd)
+            .or_default()
+            .update(st2_prefix, st2_rib);
 
         // Not an interwork node: no resolution shown.
-        let plain = render_mup_table(&table, false).unwrap();
+        let plain = render_mup_table(&tables, false).unwrap();
         assert!(!plain.contains("resolved"), "{plain}");
 
         // Interwork node: the ST2 resolves to the DSD's End.DT46 segment.
-        let out = render_mup_table(&table, true).unwrap();
+        let out = render_mup_table(&tables, true).unwrap();
         assert!(
             out.contains(
                 "resolved mup:1:2 -> End.DT46 fcbb:bbbb:1:40:: (via [DSD][65001:1][10.0.0.1])"

--- a/zebra-rs/src/bgp/vrf/inst.rs
+++ b/zebra-rs/src/bgp/vrf/inst.rs
@@ -374,6 +374,7 @@ pub fn dispatch_withdraw_import_v6(
 /// prefix simply ignores it.
 pub fn dispatch_mup(
     dispatcher: &VrfImportDispatcher<'_>,
+    rd: bgp_packet::RouteDistinguisher,
     prefix: &bgp_packet::MupPrefix,
     best: Option<&super::super::route::BgpRib>,
 ) {
@@ -388,6 +389,7 @@ pub fn dispatch_mup(
                     continue;
                 };
                 let _ = handle.inbox.send(BgpVrfMsg::MupUpdate {
+                    rd,
                     prefix: prefix.clone(),
                     rib: rib.clone(),
                 });
@@ -396,6 +398,7 @@ pub fn dispatch_mup(
         None => {
             for handle in dispatcher.vrf_registry.values() {
                 let _ = handle.inbox.send(BgpVrfMsg::MupWithdraw {
+                    rd,
                     prefix: prefix.clone(),
                 });
             }
@@ -1452,13 +1455,20 @@ impl BgpVrf {
             // Display-only mirror of the global MUP best-path for this
             // VRF's RD, so `show bgp vrf <name> mup` (redirected here)
             // renders the VRF's ST routes. We touch only `selected`
-            // (what `render_mup_table` reads); the per-VRF task never
-            // re-advertises or best-paths MUP.
-            BgpVrfMsg::MupUpdate { prefix, rib } => {
-                self.local_rib.mup.selected.insert(prefix, rib);
+            // (what `render_mup_table` reads) in the per-RD table; the
+            // per-VRF task never re-advertises or best-paths MUP.
+            BgpVrfMsg::MupUpdate { rd, prefix, rib } => {
+                self.local_rib
+                    .mup
+                    .entry(rd)
+                    .or_default()
+                    .selected
+                    .insert(prefix, rib);
             }
-            BgpVrfMsg::MupWithdraw { prefix } => {
-                self.local_rib.mup.selected.remove(&prefix);
+            BgpVrfMsg::MupWithdraw { rd, prefix } => {
+                if let Some(table) = self.local_rib.mup.get_mut(&rd) {
+                    table.selected.remove(&prefix);
+                }
             }
             BgpVrfMsg::Shutdown => unreachable!("handled in event_loop"),
         }

--- a/zebra-rs/src/bgp/vrf/msg.rs
+++ b/zebra-rs/src/bgp/vrf/msg.rs
@@ -66,12 +66,16 @@ pub enum BgpVrfMsg {
     /// task) renders the VRF's Session-Transformed routes. The global
     /// `Bgp` instance remains the authoritative MUP RIB / advertiser.
     MupUpdate {
+        rd: RouteDistinguisher,
         prefix: bgp_packet::MupPrefix,
         rib: crate::bgp::route::BgpRib,
     },
     /// Withdraw a previously-forwarded MUP best-path (the global RIB no
     /// longer has a selected path for it).
-    MupWithdraw { prefix: bgp_packet::MupPrefix },
+    MupWithdraw {
+        rd: RouteDistinguisher,
+        prefix: bgp_packet::MupPrefix,
+    },
 
     /// VPNv6 counterpart of [`Self::ImportV4`] — a VPNv6 route whose
     /// RT list intersects this VRF's `import_rts_v6`; inserted into


### PR DESCRIPTION
## Summary

The MUP (SAFI 85, RFC 9833) Loc-RIB and Adj-RIBs were a single **flat** table keyed by the full-NLRI `MupPrefix` (the RD embedded in every variant). This moves MUP to **per-RouteDistinguisher** tables — `BTreeMap<RouteDistinguisher, …>` — mirroring exactly how VPNv4/v6 and EVPN store routes. It's the structural enabler for real per-VRF MUP instance handling.

### bgp-packet
- `MupPrefix` is now the **RD-free inner key** (like `EvpnPrefix`): dropped `rd` from `Dsd`/`Isd`/`T1st`/`T2st`.
- `from_route(&MupRoute) -> (RouteDistinguisher, MupPrefix)` (was `-> MupPrefix`); `to_route(&self, rd)` takes the RD; removed `MupPrefix::rd()`.
- The opaque `Unknown` variant (no decoded RD) pairs with `RouteDistinguisher::default()` (`0:0`).

### zebra-rs
- `LocalRib.mup`, `AdjRib<D>.mup`, `MainAdjIn.mup` → `BTreeMap<RouteDistinguisher, …Table>`.
- Every accessor gained an `rd` arg via `.entry(rd).or_default()` (copied from the EVPN `update_evpn`/`add_evpn` template); `count()` sums across RDs.
- RD threaded through receive, advertise, establish-time sync (per-RD `flat_map` snapshot like `route_sync_evpn`), peer-down clean (nested walk), and the originate path; the `mup_c_originated` / `mup_segment_originated` tracking maps and the `BgpVrfMsg::Mup{Update,Withdraw}` per-VRF mirror now carry the RD.
- `show bgp mup` iterates **RD-major** (outer RD → inner selected), exactly like `show bgp evpn`. All bracket forms (`[DSD][rd][addr]`, `[ST2][rd][…]`, `ue=…`, `rt:… mup:…`, `resolved mup:1:2`) are unchanged.

This is the storage re-key only; per-VRF authoritative slices / FIB resolution are a follow-on.

## Test plan
- `cargo test -p bgp-packet` — 393 pass
- `cargo test -p zebra-rs --bins` — 1482 pass
- `cargo fmt --all --check` clean; `cargo clippy --workspace --all-targets -- -D warnings` clean
- `cargo build --release` clean
- Isolated MUP config pre-flight (`bgp_mup_dual_st/z1.yaml`) parses with no grammar rejection
- MUP BDD assertions are order-independent `should contain` of preserved output forms (left to CI — root netns)

Generated with [Claude Code](https://claude.com/claude-code)