### PR TITLE
bgp/mup: make per-VRF MUP RIB authoritative via RT-import

### DIFF
--- a/bdd/tests/configs/bgp_mup_e2e/z2.yaml
+++ b/bdd/tests/configs/bgp_mup_e2e/z2.yaml
@@ -4,11 +4,11 @@
 # controller (z1) originates and shows it under `show bgp mup`.
 #
 # `vrf mobile-up` imports the route's MUP route-target (65000:200, z1's
-# `mobile-up` export). The global MUP Loc-RIB stays authoritative; the
-# receive path mirrors the best-path into the per-VRF task (display only)
-# so `show bgp vrf mobile-up mup` reflects the peer-learned route. The
-# `router bgp vrf` block spawns that per-VRF task and routes the
-# `show bgp vrf <name> mup` redirect to it.
+# `mobile-up` export). The global MUP Loc-RIB stays the BGP-peer advertiser;
+# the receive path imports the best-path (RT-matched) into the per-VRF task,
+# which best-paths it into its own MUP Loc-RIB so `show bgp vrf mobile-up
+# mup` reflects the peer-learned route. The `router bgp vrf` block spawns
+# that per-VRF task and routes the `show bgp vrf <name> mup` redirect to it.
 vrf:
 - name: mobile-up
   mup:

--- a/bdd/tests/configs/bgp_mup_isd/z1.yaml
+++ b/bdd/tests/configs/bgp_mup_isd/z1.yaml
@@ -13,6 +13,8 @@ vrf:
     route-target:
       export:
       - "65501:10"
+      import:
+      - "65501:10"
 interface:
 - if-name: lo
   ipv6:

--- a/bdd/tests/configs/bgp_mup_mixed_afi/z1.yaml
+++ b/bdd/tests/configs/bgp_mup_mixed_afi/z1.yaml
@@ -49,3 +49,5 @@ vrf:
     route-target:
       export:
       - "65000:200"
+      import:
+      - "65000:200"

--- a/bdd/tests/configs/bgp_mup_segment_dsd/z1.yaml
+++ b/bdd/tests/configs/bgp_mup_segment_dsd/z1.yaml
@@ -11,6 +11,8 @@ vrf:
     route-target:
       export:
       - "65501:10"
+      import:
+      - "65501:10"
 interface:
 - if-name: lo
   ipv6:

--- a/zebra-rs/src/bgp/route.rs
+++ b/zebra-rs/src/bgp/route.rs
@@ -12865,9 +12865,18 @@ impl Bgp {
         prefix: bgp_packet::MupPrefix,
         selected: Vec<BgpRib>,
     ) {
-        // Mirror the best-path to the per-VRF task whose `rd` matches this
-        // route's RD (display-only, for `show bgp vrf <name> mup`).
-        self.forward_mup_to_vrf(rd, &prefix, selected.first());
+        // Import the best-path into every VRF whose `mup_import_rts` match
+        // the route's RTs — the same RT-matched dispatch the receive path
+        // uses, so locally-originated and peer-learned MUP routes reach the
+        // per-VRF tasks by one consistent rule. (Originated routes carry the
+        // VRF's export RTs; a VRF self-imports when it also imports them.)
+        {
+            let dispatcher = super::vrf::VrfImportDispatcher {
+                rib_known_vrfs: &self.rib_known_vrfs,
+                vrf_registry: &self.vrf_registry,
+            };
+            super::vrf::dispatch_mup(&dispatcher, rd, &prefix, selected.first());
+        }
         if selected.is_empty() {
             route_withdraw_mup_to_peers(rd, prefix, &mut self.peers);
             return;
@@ -12893,41 +12902,6 @@ impl Bgp {
             central_label_alloc: None,
         };
         route_advertise_mup_to_peers(rd, prefix, &selected, &mut bgp_ref, &mut self.peers);
-    }
-
-    /// Forward a MUP best-path (or its withdrawal) to the per-VRF task
-    /// whose configured `rd` matches the route's RD, for display under
-    /// `show bgp vrf <name> mup`. No-op when no VRF owns the RD or that
-    /// VRF has no running per-VRF task. Display-only: the global instance
-    /// stays the authoritative MUP RIB and advertiser.
-    fn forward_mup_to_vrf(
-        &self,
-        rd: RouteDistinguisher,
-        prefix: &bgp_packet::MupPrefix,
-        best: Option<&BgpRib>,
-    ) {
-        let Some(name) = self
-            .vrfs
-            .iter()
-            .find_map(|(n, c)| (c.rd == Some(rd)).then_some(n))
-        else {
-            return;
-        };
-        let Some(handle) = self.vrf_registry.get(name) else {
-            return;
-        };
-        let msg = match best {
-            Some(rib) => super::vrf::msg::BgpVrfMsg::MupUpdate {
-                rd,
-                prefix: prefix.clone(),
-                rib: rib.clone(),
-            },
-            None => super::vrf::msg::BgpVrfMsg::MupWithdraw {
-                rd,
-                prefix: prefix.clone(),
-            },
-        };
-        let _ = handle.inbox.send(msg);
     }
 
     /// Reconcile config-driven MUP Segment Discovery origination — DSD
@@ -18071,6 +18045,63 @@ mod tests {
         // the prefix is withdrawn.
         let (_, selected, _) = t.update(prefix, mk(2, 10, false));
         assert!(selected.is_empty(), "all-unreachable → withdraw");
+    }
+
+    /// The per-VRF `BgpVrfMsg::MupUpdate` / `MupWithdraw` handler is
+    /// authoritative, not a display mirror: an RT-matched import inserts the
+    /// route as a candidate and best-paths it (populating `selected` with
+    /// `best_path` set), and a withdraw removes the prefix and prunes the
+    /// now-empty per-RD table so an empty RD never renders. This exercises
+    /// the exact RIB operations the handler performs (see
+    /// `bgp::vrf::inst` `BgpVrfMsg::MupUpdate`).
+    #[test]
+    fn per_vrf_mup_import_is_authoritative_and_prunes() {
+        use std::collections::BTreeMap;
+
+        use bgp_packet::{MupPrefix, RouteDistinguisher};
+
+        let rd = RouteDistinguisher::from_str("65501:10").unwrap();
+        let prefix = MupPrefix::Dsd {
+            address: IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1)),
+        };
+        let attr = BgpAttr::default();
+        let rib = super::BgpRib::new(
+            super::ORIGINATED_PEER,
+            Ipv4Addr::new(10, 0, 0, 1),
+            super::BgpRibType::IBGP,
+            0,
+            0,
+            &attr,
+            None,
+            None,
+            false,
+        );
+
+        let mut tables: BTreeMap<RouteDistinguisher, super::LocalRibMupTable> = BTreeMap::new();
+
+        // MupUpdate: authoritative insert + best-path (not a bare `selected`
+        // mirror).
+        let _ = tables.entry(rd).or_default().update(prefix.clone(), rib);
+        let table = tables.get(&rd).expect("per-RD table created");
+        let best = table.selected.get(&prefix).expect("best-path selected");
+        assert!(best.best_path, "imported route is best-pathed");
+        assert_eq!(table.cands.get(&prefix).map(Vec::len), Some(1));
+
+        // MupWithdraw: remove + prune the now-empty per-RD table.
+        let empty = if let Some(table) = tables.get_mut(&rd) {
+            table.cands.remove(&prefix);
+            table.selected.remove(&prefix);
+            table.cands.is_empty() && table.selected.is_empty()
+        } else {
+            false
+        };
+        if empty {
+            tables.remove(&rd);
+        }
+        assert!(
+            tables.is_empty(),
+            "empty per-RD table pruned after withdraw"
+        );
     }
 
     #[test]

--- a/zebra-rs/src/bgp/show.rs
+++ b/zebra-rs/src/bgp/show.rs
@@ -4229,10 +4229,10 @@ fn show_bgp_mup(
 }
 
 /// `show bgp vrf <name> mup` — the per-VRF MUP view. The manager
-/// redirects this into the VRF's task, which holds the MUP best-paths the
-/// global instance mirrored to it (those whose RD matches this VRF's
-/// `rd`); renders just the route table. Generic over [`BgpShowView`] so it
-/// runs against either the per-VRF task or (in tests) any view.
+/// redirects this into the VRF's task, which imports (RT-matched) and
+/// best-paths its own slice of the global MUP RIB; renders just the route
+/// table. Generic over [`BgpShowView`] so it runs against either the
+/// per-VRF task or (in tests) any view.
 fn show_bgp_vrf_mup<V: BgpShowView>(
     bgp: &V,
     _args: Args,
@@ -4241,11 +4241,12 @@ fn show_bgp_vrf_mup<V: BgpShowView>(
     if json {
         return Ok(mup_routes_json(&bgp.local_rib().mup));
     }
-    // The per-VRF task holds only the best-paths mirrored to it (by RD) and
-    // none of the config, so ST2 -> Direct-segment resolution (which spans
-    // the whole MUP Loc-RIB on an interwork node) is rendered only by the
-    // global `show bgp mup`.
-    render_mup_table(&bgp.local_rib().mup, false)
+    // Resolve ST2 -> Direct-segment over the VRF's *own* imported set: a
+    // resolution line is emitted only when this VRF imported both a DSD
+    // (with its End.DT46 SID + Direct-segment id) and an ST2 sharing that
+    // id — so an interwork (SRGW) VRF shows the bind and a plain VRF, which
+    // imports no DSDs, renders exactly as before.
+    render_mup_table(&bgp.local_rib().mup, true)
 }
 
 /// Render the MUP Loc-RIB table body. Split out from `show_bgp_mup` so it

--- a/zebra-rs/src/bgp/vrf/inst.rs
+++ b/zebra-rs/src/bgp/vrf/inst.rs
@@ -1452,22 +1452,35 @@ impl BgpVrf {
             BgpVrfMsg::RedistDisable { afi, source } => {
                 self.redist_unsubscribe(afi, source);
             }
-            // Display-only mirror of the global MUP best-path for this
-            // VRF's RD, so `show bgp vrf <name> mup` (redirected here)
-            // renders the VRF's ST routes. We touch only `selected`
-            // (what `render_mup_table` reads) in the per-RD table; the
-            // per-VRF task never re-advertises or best-paths MUP.
+            // Authoritative per-VRF MUP import (RT-matched at the global
+            // dispatch): insert the route as a candidate in this VRF's own
+            // per-RD MUP RIB and best-path it. The VRF receives the global
+            // winner per prefix, so best-path is single-candidate here, but
+            // the table is authoritative — `show bgp vrf <name> mup`
+            // (redirected here) reads the resulting `selected`. MUP has no
+            // CE peers and no kernel FIB yet, so this neither re-advertises
+            // nor installs; it owns the control-plane RIB only.
             BgpVrfMsg::MupUpdate { rd, prefix, rib } => {
-                self.local_rib
+                let _ = self
+                    .local_rib
                     .mup
                     .entry(rd)
                     .or_default()
-                    .selected
-                    .insert(prefix, rib);
+                    .update(prefix, rib);
             }
             BgpVrfMsg::MupWithdraw { rd, prefix } => {
-                if let Some(table) = self.local_rib.mup.get_mut(&rd) {
+                // The VRF holds the single dispatched winner per prefix, so a
+                // prefix-keyed removal clears it; prune the per-RD table when
+                // it empties so an empty RD never renders.
+                let empty = if let Some(table) = self.local_rib.mup.get_mut(&rd) {
+                    table.cands.remove(&prefix);
                     table.selected.remove(&prefix);
+                    table.cands.is_empty() && table.selected.is_empty()
+                } else {
+                    false
+                };
+                if empty {
+                    self.local_rib.mup.remove(&rd);
                 }
             }
             BgpVrfMsg::Shutdown => unreachable!("handled in event_loop"),

--- a/zebra-rs/src/bgp/vrf/msg.rs
+++ b/zebra-rs/src/bgp/vrf/msg.rs
@@ -59,19 +59,22 @@ pub enum BgpVrfMsg {
         prefix: ipnet::Ipv4Net,
     },
 
-    /// A MUP (SAFI 85) best-path the global Loc-RIB selected whose RD
-    /// matches this VRF's `rd`. Forwarded for **display only**: the
-    /// per-VRF task mirrors it into `local_rib.mup.selected` so a
-    /// `show bgp vrf <name> mup` (which the manager redirects into this
-    /// task) renders the VRF's Session-Transformed routes. The global
-    /// `Bgp` instance remains the authoritative MUP RIB / advertiser.
+    /// A MUP (SAFI 85) best-path the global Loc-RIB selected whose route
+    /// targets match this VRF's `mup_import_rts` (RT-import, dispatched via
+    /// [`super::inst::dispatch_mup`]). The per-VRF task imports it
+    /// authoritatively into its own per-RD MUP Loc-RIB and best-paths it, so
+    /// `show bgp vrf <name> mup` (which the manager redirects into this task)
+    /// renders the VRF's imported MUP routes. The global `Bgp` instance
+    /// remains the BGP-peer advertiser (MUP has no CE peers); the per-VRF
+    /// task owns only the control-plane RIB — no re-advertise, no FIB yet.
     MupUpdate {
         rd: RouteDistinguisher,
         prefix: bgp_packet::MupPrefix,
         rib: crate::bgp::route::BgpRib,
     },
-    /// Withdraw a previously-forwarded MUP best-path (the global RIB no
-    /// longer has a selected path for it).
+    /// Withdraw a previously-imported MUP route (the global RIB no longer has
+    /// a selected path for it). Flooded to every VRF; the per-VRF removal is
+    /// idempotent for a VRF that never imported the prefix.
     MupWithdraw {
         rd: RouteDistinguisher,
         prefix: bgp_packet::MupPrefix,


### PR DESCRIPTION
## Summary

Promotes per-VRF MUP (SAFI 85) handling from a display-only mirror to the same **authoritative, route-target-import** model VPNv4/v6 already use — control-plane only (MUP has no CE peers and no kernel FIB yet; GTP forwarding is VPP/eBPF, deferred). Follows on from the per-RD re-key (#1677).

The per-VRF `BgpVrf` task already owns authoritative infrastructure (its own Loc-RIB with the per-RD MUP map, shard, CE peers, RIB client bound to the VRF `table_id`). MUP was the only family still display-only, dispatched by **two inconsistent rules**: peer-learned routes by RT-import, locally-originated routes by RD-equality. This collapses them into one.

### Changes
- **`vrf/inst.rs`** — `MupUpdate` inserts the route as a candidate and best-paths it into the VRF's own per-RD MUP Loc-RIB (was a bare `selected` mirror); `MupWithdraw` removes the prefix and prunes the empty per-RD table.
- **`route.rs`** — delete `forward_mup_to_vrf` (the RD-equality mirror); `mup_apply_selected` now dispatches through `dispatch_mup` (RT-matched), so received **and** originated MUP routes reach per-VRF tasks by one rule.
- **`show.rs`** — `show bgp vrf <name> mup` resolves ST2 → Direct-segment over the VRF's own imported set (data-driven; non-interwork VRFs unchanged).

### Behavior change
Because MUP origination stays global, an originating VRF now shows its own originated route in `show bgp vrf <name> mup` **only when it imports its export RT**. Three BDD originator configs (`bgp_mup_segment_dsd`, `_isd`, `_mixed_afi`) gain a matching `mup route-target import` (rt-both); `bgp_mup_e2e`'s receiver already imported it.

## Test plan
- `cargo test -p zebra-rs --bins` — **1483 pass** (incl. new `per_vrf_mup_import_is_authoritative_and_prunes`)
- `cargo fmt --all --check` + `cargo clippy --workspace --all-targets -- -D warnings` — clean
- Release build clean
- **All 7 MUP BDD features pass as root**: `bgp_mup_{segment_dsd, isd, mixed_afi, e2e, st2, interwork, dual_st}` — the first four assert `show bgp vrf <name> mup` and confirm the RT-import-authoritative path + the added import RTs.

Generated with [Claude Code](https://claude.com/claude-code)