### PR TITLE
bdd/mup: cross-VRF MUP import by route-target

### DIFF
--- a/bdd/Makefile
+++ b/bdd/Makefile
@@ -76,6 +76,14 @@ bgp_mup_dual_st:
 	mkdir -p allure-results
 	cargo test --test cucumber -- --concurrency=1 --tags "@bgp_mup_dual_st"
 
+# MUP cross-VRF import: a PE originates an ISD route in one VRF (rd 65501:20)
+# and imports it into a DIFFERENT VRF (rd 65501:10) purely by route-target,
+# proving per-VRF MUP import is RT-matched (like VPNv4/v6), not RD-matched.
+# Needs root netns (kernel VRF + seg6local for the End.DT46 install).
+bgp_mup_vrf_import:
+	mkdir -p allure-results
+	cargo test --test cucumber -- --concurrency=1 --tags "@bgp_mup_vrf_import"
+
 rib_static_ipv6:
 	mkdir -p allure-results
 	cargo test --test cucumber -- --concurrency=1 --tags "@rib_static_ipv6"

--- a/bdd/tests/configs/bgp_mup_vrf_import/z1.yaml
+++ b/bdd/tests/configs/bgp_mup_vrf_import/z1.yaml
@@ -1,0 +1,96 @@
+# z1 — MUP PE that originates an Interwork Segment Discovery (ISD) route in
+# one VRF and imports it into a DIFFERENT VRF by route-target. This is the
+# cross-VRF MUP import case: per-VRF MUP is RT-matched (like VPNv4/v6), not
+# RD-matched, so a route whose NLRI carries RD 65501:20 lands in a VRF whose
+# own `rd` is 65501:10 purely because its `mup route-target import` overlaps
+# the route's RTs.
+#
+#   * VRF N6 (rd 65501:20, `encapsulation srv6`) carves a per-VRF End.DT46
+#     SID from locator S and originates an ISD under prefix 10.60.0.0/16,
+#     carrying its export RT 65501:10.
+#   * VRF N3 (rd 65501:10) is a plain downlink VRF (`afi-safi mup route
+#     st1`). It imports RT 65501:10, so it pulls in N6's ISD even though the
+#     ISD's RD (65501:20) does not match N3's own rd.
+#
+# Both VRFs import RT 65501:10 (the ISD's RT): N6 imports its own export, so it
+# still shows its originated ISD; N3 imports N6's export, so it pulls the ISD in
+# across the RD boundary. iBGP (mup afi-safi) to z2 over loopbacks verifies the
+# ISD still advertises normally.
+vrf:
+- name: N6
+  mup:
+    route-target:
+      export:
+      - "65501:10"
+      import:
+      - "65501:10"
+- name: N3
+  mup:
+    route-target:
+      export:
+      - "65501:20"
+      import:
+      - "65501:10"
+interface:
+- if-name: lo
+  ipv6:
+    address: 2001:db8::1/128
+- if-name: z1-z2
+  ipv6:
+    address: 2001:db8:0:12::1/64
+segment-routing:
+  locator:
+  - name: S
+    prefix: fcbb:bbbb:1::/48
+    behavior: usid
+router:
+  isis:
+    net: 49.0000.0000.0000.0001.00
+    hostname: z1
+    is-type: level-2-only
+    segment-routing:
+      srv6:
+        locator: S
+    interface:
+    - if-name: lo
+      ipv6:
+        enable: true
+    - if-name: z1-z2
+      network-type: point-to-point
+      metric: 1
+      ipv6:
+        enable: true
+  bgp:
+    global:
+      as: 65501
+      router-id: 10.0.0.1
+    timer:
+      adv-interval:
+        ibgp: 1
+    segment-routing:
+      srv6:
+        locator: S
+    neighbor:
+    - remote-address: 2001:db8::2
+      remote-as: 65501
+      update-source: 2001:db8::1
+      enabled: true
+      afi-safi:
+      - name: mup
+        enabled: true
+    vrf:
+    - name: N6
+      rd: "65501:20"
+      encapsulation: srv6
+      afi-safi:
+        mup:
+          segment:
+          - type: interwork
+            prefix: 10.60.0.0/16
+    - name: N3
+      rd: "65501:10"
+      afi-safi:
+        mup:
+          route:
+          - type: st1
+            network-instance: internet

--- a/bdd/tests/configs/bgp_mup_vrf_import/z2.yaml
+++ b/bdd/tests/configs/bgp_mup_vrf_import/z2.yaml
@@ -1,0 +1,53 @@
+# z2 — MUP peer that receives z1's Interwork Segment Discovery (ISD) route.
+# IS-IS L2 SRv6 underlay + iBGP (mup afi-safi) to z1 over loopbacks. No
+# VRF / segment of its own — it just stores the ISD route (RD 65501:20 + z1's
+# interwork prefix 10.60.0.0/16) carrying z1's End.DT46 SID in its MUP
+# Loc-RIB, confirming the cross-VRF import on z1 does not disturb normal
+# peer advertisement.
+interface:
+- if-name: lo
+  ipv6:
+    address: 2001:db8::2/128
+- if-name: z2-z1
+  ipv6:
+    address: 2001:db8:0:12::2/64
+segment-routing:
+  locator:
+  - name: LOC2
+    prefix: fcbb:bbbb:2::/48
+    behavior: usid
+router:
+  isis:
+    net: 49.0000.0000.0000.0002.00
+    hostname: z2
+    is-type: level-2-only
+    segment-routing:
+      srv6:
+        locator: LOC2
+    interface:
+    - if-name: lo
+      ipv6:
+        enable: true
+    - if-name: z2-z1
+      network-type: point-to-point
+      metric: 1
+      ipv6:
+        enable: true
+  bgp:
+    global:
+      as: 65501
+      router-id: 10.0.0.2
+    timer:
+      adv-interval:
+        ibgp: 1
+    segment-routing:
+      srv6:
+        locator: LOC2
+    neighbor:
+    - remote-address: 2001:db8::1
+      remote-as: 65501
+      update-source: 2001:db8::2
+      enabled: true
+      afi-safi:
+      - name: mup
+        enabled: true

--- a/bdd/tests/features/bgp_mup_vrf_import.feature
+++ b/bdd/tests/features/bgp_mup_vrf_import.feature
@@ -1,0 +1,78 @@
+@serial
+@bgp_mup_vrf_import
+Feature: BGP MUP cross-VRF import by route-target (RD-independent)
+  As a network operator
+  I want a locally-originated BGP MUP route (SAFI 85 / RFC 9833) to be
+  imported into every VRF whose `mup route-target import` overlaps the
+  route's RTs — not just the VRF that owns the route's RD — so per-VRF MUP
+  matches the VPNv4/v6 import model and a downlink VRF can pull in the
+  upstream segment another VRF originated.
+
+  Test Topology:
+  ```
+        2001:db8::1/128            2001:db8::2/128
+       ┌──────────┐  IS-IS L2 SRv6  ┌──────────┐
+       │    z1    │═════════════════│    z2    │
+       │ MUP PE   │   iBGP (mup)    │ receiver │
+       │ N6 + N3  │                 │          │
+       └──────────┘                 └──────────┘
+   z1-z2 2001:db8:0:12::1/64   2001:db8:0:12::2/64
+  ```
+
+  On z1, VRF N6 (rd 65501:20, `encapsulation srv6`, `afi-safi mup segment
+  interwork prefix 10.60.0.0/16`) originates an ISD route carrying its export
+  RT 65501:10. VRF N3 (rd 65501:10) imports RT 65501:10, so it pulls in N6's
+  ISD even though the ISD's RD (65501:20) does not equal N3's own rd — the
+  proof that per-VRF MUP import is route-target matched, not RD matched.
+
+  Scenario: Build topology and establish iBGP with the MUP capability
+    Given a clean test environment
+    When I create namespace "z1"
+    And I create namespace "z2"
+    And I connect namespace "z1" interface "z1-z2" to namespace "z2" interface "z2-z1"
+    And I start zebra-rs in namespace "z1"
+    And I start zebra-rs in namespace "z2"
+    And I apply config "z1.yaml" to namespace "z1"
+    And I apply config "z2.yaml" to namespace "z2"
+    And I wait 45 seconds
+    Then BGP session in "z1" to "2001:db8::2" should be "Established"
+    And BGP session in "z2" to "2001:db8::1" should be "Established"
+    And show command "show bgp neighbor 2001:db8::2" in namespace "z1" should contain "IPv4 MUP: advertised and received"
+
+  Scenario: z1 originates the ISD in N6 and installs the End.DT46 SID
+    Given the test topology exists
+    # The ISD NLRI is N6's RD (65501:20) + the configured interwork prefix.
+    Then show command "show bgp mup" in namespace "z1" should eventually contain "[ISD][65501:20][10.60.0.0/16]"
+    And show command "show bgp mup" in namespace "z1" should contain "End.DT46"
+    # The ISD carries N6's export route-target.
+    And show command "show bgp mup" in namespace "z1" should contain "rt:65501:10"
+    # The End.DT46 decap is installed into the kernel FIB.
+    And command "ip -6 route show table all" in namespace "z1" should eventually contain "End.DT46"
+
+  Scenario: N6 self-imports its own ISD (rd 65501:20 imports rt 65501:10)
+    Given the test topology exists
+    Then show command "show bgp vrf N6 mup" in namespace "z1" should eventually contain "[ISD][65501:20][10.60.0.0/16]"
+    And show command "show bgp vrf N6 mup" in namespace "z1" should contain "End.DT46"
+
+  Scenario: N3 imports N6's ISD across the RD boundary by route-target
+    Given the test topology exists
+    # The crux: N3's own rd is 65501:10, but the ISD's RD is 65501:20. It
+    # appears here only because N3 imports RT 65501:10, which the ISD carries
+    # — RT-matched import, not RD-matched.
+    Then show command "show bgp vrf N3 mup" in namespace "z1" should eventually contain "[ISD][65501:20][10.60.0.0/16]"
+    And show command "show bgp vrf N3 mup" in namespace "z1" should contain "End.DT46"
+    And show command "show bgp vrf N3 mup" in namespace "z1" should contain "rt:65501:10"
+
+  Scenario: z2 receives the ISD route with the End.DT46 SID
+    Given the test topology exists
+    Then show command "show bgp mup" in namespace "z2" should eventually contain "[ISD][65501:20][10.60.0.0/16]"
+    And show command "show bgp mup" in namespace "z2" should contain "Remote SID"
+    And show command "show bgp mup" in namespace "z2" should contain "End.DT46"
+
+  Scenario: Teardown topology
+    Given the test topology exists
+    When I stop zebra-rs in namespace "z1"
+    And I stop zebra-rs in namespace "z2"
+    And I delete namespace "z1"
+    And I delete namespace "z2"
+    Then the test environment should be clean


### PR DESCRIPTION
## Summary

Adds a BDD feature exercising **locally-originated** BGP MUP (SAFI 85 / RFC 9833) route import **across the RD boundary**, locking in the RT-matched per-VRF MUP import promoted in #1679.

A single PE (z1) originates an Interwork Segment Discovery (ISD) route in **VRF N6** (`rd 65501:20`, `encapsulation srv6`, `segment interwork prefix 10.60.0.0/16`) and imports it into a **different VRF N3** (`rd 65501:10`) purely by route-target. Both VRFs import the ISD's RT (`65501:10`):

- **N6** imports its own export → self-shows its originated ISD.
- **N3** imports N6's export → pulls the ISD in cross-VRF. The NLRI still carries RD `65501:20`, so its appearance in `show bgp vrf N3 mup` (whose own `rd` is `65501:10`) proves the import is **RT-matched, not RD-matched**.

z2 receives the ISD over iBGP, confirming the cross-VRF import on z1 does not disturb normal peer advertisement.

This guards against the pre-#1679 regression where the originate-side mirror keyed on `rd`, so a locally-originated MUP route only ever reached the VRF that owned its RD — never an RT-importing VRF.

BDD-only; no production code changes.

## Test plan

- `make bgp_mup_vrf_import` as root — **6/6 scenarios, 31/31 steps pass**, including the cross-VRF crux and a teardown asserting `the test environment should be clean`.

Generated with [Claude Code](https://claude.com/claude-code)