### PR TITLE
config: emit one command line per leaf-list value

### DIFF
--- a/zebra-rs/src/config/configs.rs
+++ b/zebra-rs/src/config/configs.rs
@@ -450,6 +450,13 @@ impl Config {
         }
     }
 
+    /// Command-path tokens up to and including this node's name and (leaf)
+    /// value — the prefix shared by every command line this node emits.
+    /// Leaf-list values are deliberately NOT appended here: each one forms
+    /// its own command line in [`Self::list`], because a leaf-list `set`
+    /// command takes a single value. Bundling them (`… import A B`) produces
+    /// a line that fails to re-parse, so the commit text-diff would skip it
+    /// and silently drop every value.
     pub fn list_command(&self) -> Vec<String> {
         let mut commands = Vec::new();
         if let Some(parent) = self.parent.as_ref() {
@@ -460,9 +467,6 @@ impl Config {
             if !self.value.borrow().is_empty() {
                 commands.push(self.value.borrow().clone());
             }
-            for list in self.list.borrow().iter() {
-                commands.push(list.clone());
-            }
         }
         commands
     }
@@ -471,8 +475,24 @@ impl Config {
         if !self.has_dir() || self.presence || !self.prefix.is_empty() {
             let commands = self.list_command();
             if !commands.is_empty() {
-                output.push_str(&commands.join(" "));
-                output.push('\n');
+                let base = commands.join(" ");
+                let list = self.list.borrow();
+                if list.is_empty() {
+                    output.push_str(&base);
+                    output.push('\n');
+                } else {
+                    // Leaf-list: one command line per value. A single joined
+                    // line (`… import A B`) does not re-parse as a leaf-list
+                    // command, so the commit text-diff would skip it and
+                    // silently drop every value (only single-value leaf-lists
+                    // round-tripped). See [`Self::list_command`].
+                    for value in list.iter() {
+                        output.push_str(&base);
+                        output.push(' ');
+                        output.push_str(value);
+                        output.push('\n');
+                    }
+                }
             }
         }
         for key in self.keys.borrow().iter() {
@@ -1026,6 +1046,57 @@ mod tests {
         assert!(output.contains("    10.0.0.1/32;"));
         assert!(output.contains("    10.0.0.2/32;"));
         assert!(output.contains("  }"));
+    }
+
+    /// Regression: `list()` (the flat "set command" form the commit
+    /// text-diff compares) must emit ONE line per leaf-list value. Bundling
+    /// every value onto one line (`… member A B`) produced a command that
+    /// failed to re-parse as a leaf-list set, so the commit text-diff skipped
+    /// it and silently dropped all values — only single-value leaf-lists
+    /// survived a commit. Hit `vrf … route-target import` across every AFI.
+    #[test]
+    fn test_leaf_list_list_emits_one_line_per_value() {
+        let root = Rc::new(Config::new("".to_string(), None));
+
+        for value in ["10.0.0.1/32", "10.0.0.2/32"] {
+            let paths = vec![
+                CommandPath {
+                    name: "prefix-test".to_string(),
+                    ymatch: YangMatch::Dir as i32,
+                    ..Default::default()
+                },
+                CommandPath {
+                    name: "member".to_string(),
+                    ymatch: YangMatch::LeafList as i32,
+                    ..Default::default()
+                },
+                CommandPath {
+                    name: value.to_string(),
+                    ymatch: YangMatch::LeafListMatched as i32,
+                    ..Default::default()
+                },
+            ];
+            set(paths, root.clone());
+        }
+
+        let mut output = String::new();
+        root.list(&mut output);
+
+        let lines: Vec<&str> = output.lines().collect();
+        assert!(
+            lines.contains(&"prefix-test member 10.0.0.1/32"),
+            "expected a per-value line for the first value; output:\n{output}"
+        );
+        assert!(
+            lines.contains(&"prefix-test member 10.0.0.2/32"),
+            "expected a per-value line for the second value; output:\n{output}"
+        );
+        // The bug rendered both values on one line, which fails to re-parse
+        // and is dropped by the commit diff.
+        assert!(
+            !output.contains("10.0.0.1/32 10.0.0.2/32"),
+            "leaf-list values must not be bundled onto one line; output:\n{output}"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

A YANG **leaf-list with 2+ values was silently dropped at commit**, generic across all leaf-lists and address families.

`Config::list()` renders the running and candidate configs to flat `set …` lines; the commit text-diff compares them to derive per-leaf `Set`/`Delete` operations. `list_command()` bundled **every** leaf-list value onto **one** line (`… import A B`). That line doesn't re-parse as a leaf-list command (which takes a single value), so `paths()` returned `None` and the diff **skipped it entirely** — dropping all values. Only single-value leaf-lists survived a commit.

Confirmed for `vrf <name> {ipv4|ipv6|mup} route-target {import|export}`. It went unnoticed because every existing config uses single-value RTs. The curly-brace `.conf` dump (`{ A; B; }`) and the JSON dump (`[A, B]`) already handled leaf-lists correctly and are untouched.

**Fix:** `list_command()` now returns only the command prefix (path + name + leaf value); `list()` emits **one line per leaf-list value**, so each forms a parseable single-value command the diff applies.

## Test plan

- New `test_leaf_list_list_emits_one_line_per_value` (asserts one parseable line per value, never a bundled line) + the 14 existing config tests pass.
- Full `zebra-rs` suite: **1487 passed / 0 failed**.
- `cargo clippy --workspace --all-targets -- -D warnings`: clean. `cargo fmt`: clean.
- **Live before/after** (root netns):
  - 2-value `route-target export`: pre-fix the VRF exported 0 RTs (originated route carried none); post-fix the route carries **both** (`rt:65501:10 rt:65501:30`) and the VRF shows `route-targets=2`.
  - 2-value `route-target import`: post-fix the route is imported into every matching VRF across the RD boundary.

Generated with [Claude Code](https://claude.com/claude-code)