### PR TITLE
L3VPN PE-CE BDD (BGP): IPv4/MPLS + IPv6/SRv6, fix SRv6 SID leak

### DIFF
--- a/bdd/tests/configs/l3vpn_bgp_v4/c1.yaml
+++ b/bdd/tests/configs/l3vpn_bgp_v4/c1.yaml
@@ -1,0 +1,27 @@
+# C1 — customer site 1 (AS 65101). Originates its loopback 10.0.1.1/32
+# into BGP via `redistribute connected` and eBGPs to CE1. The loopback
+# is the ping target reached from C2 across the MPLS/VPN core.
+interface:
+- if-name: lo
+  ipv4:
+    address: 10.0.1.1/32
+- if-name: ce1
+  ipv4:
+    address: 10.1.0.1/30
+router:
+  bgp:
+    global:
+      as: 65101
+      router-id: 10.0.1.1
+    neighbor:
+    - remote-address: 10.1.0.2
+      remote-as: 65001
+      timers: {connect-retry-time: 3}
+      enabled: true
+      afi-safi:
+      - name: ipv4
+        enabled: true
+    afi-safi:
+    - name: ipv4
+      redistribute:
+        connected: {}

--- a/bdd/tests/configs/l3vpn_bgp_v4/c2.yaml
+++ b/bdd/tests/configs/l3vpn_bgp_v4/c2.yaml
@@ -1,0 +1,26 @@
+# C2 — customer site 2 (AS 65102). Mirror of C1: originates loopback
+# 10.0.2.1/32 into BGP via `redistribute connected` and eBGPs to CE2.
+interface:
+- if-name: lo
+  ipv4:
+    address: 10.0.2.1/32
+- if-name: ce2
+  ipv4:
+    address: 10.2.0.1/30
+router:
+  bgp:
+    global:
+      as: 65102
+      router-id: 10.0.2.1
+    neighbor:
+    - remote-address: 10.2.0.2
+      remote-as: 65002
+      timers: {connect-retry-time: 3}
+      enabled: true
+      afi-safi:
+      - name: ipv4
+        enabled: true
+    afi-safi:
+    - name: ipv4
+      redistribute:
+        connected: {}

--- a/bdd/tests/configs/l3vpn_bgp_v4/ce1.yaml
+++ b/bdd/tests/configs/l3vpn_bgp_v4/ce1.yaml
@@ -1,0 +1,30 @@
+# CE1 — customer edge 1 (AS 65001). eBGP relay between C1 (AS 65101) and
+# PE1 (AS 65000); re-advertises C1's loopback up to PE1 and PE1's
+# VPN-learned remote routes back down to C1. No VRF (CE is customer space).
+interface:
+- if-name: c1
+  ipv4:
+    address: 10.1.0.2/30
+- if-name: pe1
+  ipv4:
+    address: 10.1.0.5/30
+router:
+  bgp:
+    global:
+      as: 65001
+      router-id: 10.1.0.5
+    neighbor:
+    - remote-address: 10.1.0.1
+      remote-as: 65101
+      timers: {connect-retry-time: 3}
+      enabled: true
+      afi-safi:
+      - name: ipv4
+        enabled: true
+    - remote-address: 10.1.0.6
+      remote-as: 65000
+      timers: {connect-retry-time: 3}
+      enabled: true
+      afi-safi:
+      - name: ipv4
+        enabled: true

--- a/bdd/tests/configs/l3vpn_bgp_v4/ce2.yaml
+++ b/bdd/tests/configs/l3vpn_bgp_v4/ce2.yaml
@@ -1,0 +1,29 @@
+# CE2 — customer edge 2 (AS 65002). Mirror of CE1: eBGP relay between C2
+# (AS 65102) and PE2 (AS 65000).
+interface:
+- if-name: c2
+  ipv4:
+    address: 10.2.0.2/30
+- if-name: pe2
+  ipv4:
+    address: 10.2.0.5/30
+router:
+  bgp:
+    global:
+      as: 65002
+      router-id: 10.2.0.5
+    neighbor:
+    - remote-address: 10.2.0.1
+      remote-as: 65102
+      timers: {connect-retry-time: 3}
+      enabled: true
+      afi-safi:
+      - name: ipv4
+        enabled: true
+    - remote-address: 10.2.0.6
+      remote-as: 65000
+      timers: {connect-retry-time: 3}
+      enabled: true
+      afi-safi:
+      - name: ipv4
+        enabled: true

--- a/bdd/tests/configs/l3vpn_bgp_v4/p.yaml
+++ b/bdd/tests/configs/l3vpn_bgp_v4/p.yaml
@@ -1,0 +1,36 @@
+# P — provider core transit LSR (runs no BGP). Pure IS-IS L2 + SR-MPLS;
+# performs the SR label swap / PHP between PE1 (sid 1 -> 16001) and PE2
+# (sid 3 -> 16003).
+interface:
+- if-name: lo
+  ipv4:
+    address: 1.1.1.2/32
+- if-name: pe1
+  ipv4:
+    address: 10.250.0.2/30
+- if-name: pe2
+  ipv4:
+    address: 10.250.0.5/30
+router:
+  isis:
+    net: 49.0000.0000.0000.0002.00
+    hostname: p
+    is-type: level-2-only
+    segment-routing: mpls
+    te-router-id: 1.1.1.2
+    interface:
+    - if-name: lo
+      ipv4:
+        enable: true
+        prefix-sid:
+          index: 2
+    - if-name: pe1
+      network-type: point-to-point
+      metric: 10
+      ipv4:
+        enable: true
+    - if-name: pe2
+      network-type: point-to-point
+      metric: 10
+      ipv4:
+        enable: true

--- a/bdd/tests/configs/l3vpn_bgp_v4/pe1.yaml
+++ b/bdd/tests/configs/l3vpn_bgp_v4/pe1.yaml
@@ -1,0 +1,64 @@
+# PE1 — provider edge 1 (AS 65000). IS-IS L2 + SR-MPLS transport to PE2
+# via P (loopback Prefix-SID index 1 -> label 16001). iBGP VPNv4 to PE2
+# over loopbacks (rides the SR LSP). vrf-cust holds the eBGP PE-CE
+# session to CE1; CE-learned customer routes export to VPNv4 with
+# RD 65000:1 + RT 65000:100.
+vrf:
+- name: vrf-cust
+  ipv4:
+    route-target:
+      import:
+      - 65000:100
+      export:
+      - 65000:100
+interface:
+- if-name: lo
+  ipv4:
+    address: 1.1.1.1/32
+- if-name: p
+  ipv4:
+    address: 10.250.0.1/30
+- if-name: ce1
+  vrf: vrf-cust
+  ipv4:
+    address: 10.1.0.6/30
+router:
+  isis:
+    net: 49.0000.0000.0000.0001.00
+    hostname: pe1
+    is-type: level-2-only
+    segment-routing: mpls
+    te-router-id: 1.1.1.1
+    interface:
+    - if-name: lo
+      ipv4:
+        enable: true
+        prefix-sid:
+          index: 1
+    - if-name: p
+      network-type: point-to-point
+      metric: 10
+      ipv4:
+        enable: true
+  bgp:
+    global:
+      as: 65000
+      router-id: 1.1.1.1
+    neighbor:
+    - remote-address: 1.1.1.3
+      remote-as: 65000
+      timers: {connect-retry-time: 3}
+      update-source: 1.1.1.1
+      enabled: true
+      afi-safi:
+      - name: vpnv4
+        enabled: true
+    vrf:
+    - name: vrf-cust
+      rd: 65000:1
+      neighbor:
+      - remote-address: 10.1.0.5
+        remote-as: 65001
+        afi-safi:
+        - name: ipv4
+          enabled: true

--- a/bdd/tests/configs/l3vpn_bgp_v4/pe2.yaml
+++ b/bdd/tests/configs/l3vpn_bgp_v4/pe2.yaml
@@ -1,0 +1,62 @@
+# PE2 — provider edge 2 (AS 65000). Mirror of PE1: SR-MPLS loopback
+# Prefix-SID index 3 -> label 16003, iBGP VPNv4 to PE1, vrf-cust eBGP
+# PE-CE to CE2, export with RD 65000:2 + RT 65000:100.
+vrf:
+- name: vrf-cust
+  ipv4:
+    route-target:
+      import:
+      - 65000:100
+      export:
+      - 65000:100
+interface:
+- if-name: lo
+  ipv4:
+    address: 1.1.1.3/32
+- if-name: p
+  ipv4:
+    address: 10.250.0.6/30
+- if-name: ce2
+  vrf: vrf-cust
+  ipv4:
+    address: 10.2.0.6/30
+router:
+  isis:
+    net: 49.0000.0000.0000.0003.00
+    hostname: pe2
+    is-type: level-2-only
+    segment-routing: mpls
+    te-router-id: 1.1.1.3
+    interface:
+    - if-name: lo
+      ipv4:
+        enable: true
+        prefix-sid:
+          index: 3
+    - if-name: p
+      network-type: point-to-point
+      metric: 10
+      ipv4:
+        enable: true
+  bgp:
+    global:
+      as: 65000
+      router-id: 1.1.1.3
+    neighbor:
+    - remote-address: 1.1.1.1
+      remote-as: 65000
+      timers: {connect-retry-time: 3}
+      update-source: 1.1.1.3
+      enabled: true
+      afi-safi:
+      - name: vpnv4
+        enabled: true
+    vrf:
+    - name: vrf-cust
+      rd: 65000:2
+      neighbor:
+      - remote-address: 10.2.0.5
+        remote-as: 65002
+        afi-safi:
+        - name: ipv4
+          enabled: true

--- a/bdd/tests/configs/l3vpn_bgp_v6/c1.yaml
+++ b/bdd/tests/configs/l3vpn_bgp_v6/c1.yaml
@@ -1,0 +1,28 @@
+# C1 — customer site 1 (AS 65101). Originates its IPv6 loopback
+# 2001:db8:c1::1/128 into BGP via `redistribute connected` and eBGPs to
+# CE1. The loopback is the ping target reached from C2 across the SRv6
+# L3VPN core.
+interface:
+- if-name: lo
+  ipv6:
+    address: 2001:db8:c1::1/128
+- if-name: ce1
+  ipv6:
+    address: 2001:db8:1c::1/64
+router:
+  bgp:
+    global:
+      as: 65101
+      router-id: 10.0.1.1
+    neighbor:
+    - remote-address: 2001:db8:1c::2
+      remote-as: 65001
+      timers: {connect-retry-time: 3}
+      enabled: true
+      afi-safi:
+      - name: ipv6
+        enabled: true
+    afi-safi:
+    - name: ipv6
+      redistribute:
+        connected: {}

--- a/bdd/tests/configs/l3vpn_bgp_v6/c2.yaml
+++ b/bdd/tests/configs/l3vpn_bgp_v6/c2.yaml
@@ -1,0 +1,26 @@
+# C2 — customer site 2 (AS 65102). Mirror of C1: originates IPv6 loopback
+# 2001:db8:c2::1/128 into BGP via `redistribute connected` and eBGPs to CE2.
+interface:
+- if-name: lo
+  ipv6:
+    address: 2001:db8:c2::1/128
+- if-name: ce2
+  ipv6:
+    address: 2001:db8:2c::1/64
+router:
+  bgp:
+    global:
+      as: 65102
+      router-id: 10.0.2.1
+    neighbor:
+    - remote-address: 2001:db8:2c::2
+      remote-as: 65002
+      timers: {connect-retry-time: 3}
+      enabled: true
+      afi-safi:
+      - name: ipv6
+        enabled: true
+    afi-safi:
+    - name: ipv6
+      redistribute:
+        connected: {}

--- a/bdd/tests/configs/l3vpn_bgp_v6/ce1.yaml
+++ b/bdd/tests/configs/l3vpn_bgp_v6/ce1.yaml
@@ -1,0 +1,30 @@
+# CE1 — customer edge 1 (AS 65001). IPv6 eBGP relay between C1 (AS 65101)
+# and PE1 (AS 65000); re-advertises C1's loopback up to PE1 and PE1's
+# VPN-learned remote routes back down to C1.
+interface:
+- if-name: c1
+  ipv6:
+    address: 2001:db8:1c::2/64
+- if-name: pe1
+  ipv6:
+    address: 2001:db8:1e::1/64
+router:
+  bgp:
+    global:
+      as: 65001
+      router-id: 10.1.0.5
+    neighbor:
+    - remote-address: 2001:db8:1c::1
+      remote-as: 65101
+      timers: {connect-retry-time: 3}
+      enabled: true
+      afi-safi:
+      - name: ipv6
+        enabled: true
+    - remote-address: 2001:db8:1e::2
+      remote-as: 65000
+      timers: {connect-retry-time: 3}
+      enabled: true
+      afi-safi:
+      - name: ipv6
+        enabled: true

--- a/bdd/tests/configs/l3vpn_bgp_v6/ce2.yaml
+++ b/bdd/tests/configs/l3vpn_bgp_v6/ce2.yaml
@@ -1,0 +1,29 @@
+# CE2 — customer edge 2 (AS 65002). Mirror of CE1: IPv6 eBGP relay
+# between C2 (AS 65102) and PE2 (AS 65000).
+interface:
+- if-name: c2
+  ipv6:
+    address: 2001:db8:2c::2/64
+- if-name: pe2
+  ipv6:
+    address: 2001:db8:2e::1/64
+router:
+  bgp:
+    global:
+      as: 65002
+      router-id: 10.2.0.5
+    neighbor:
+    - remote-address: 2001:db8:2c::1
+      remote-as: 65102
+      timers: {connect-retry-time: 3}
+      enabled: true
+      afi-safi:
+      - name: ipv6
+        enabled: true
+    - remote-address: 2001:db8:2e::2
+      remote-as: 65000
+      timers: {connect-retry-time: 3}
+      enabled: true
+      afi-safi:
+      - name: ipv6
+        enabled: true

--- a/bdd/tests/configs/l3vpn_bgp_v6/p.yaml
+++ b/bdd/tests/configs/l3vpn_bgp_v6/p.yaml
@@ -1,0 +1,33 @@
+# P — provider core transit (runs no BGP, no SRv6). Pure IS-IS L2 with
+# IPv6 enabled; learns the PE loopbacks (/128) and SRv6 locators (/48)
+# via IS-IS and natively forwards the SRv6-encapsulated transit traffic
+# between PE1 and PE2.
+interface:
+- if-name: lo
+  ipv6:
+    address: 2001:db8::2/128
+- if-name: pe1
+  ipv6:
+    address: 2001:db8:cafe:1::2/64
+- if-name: pe2
+  ipv6:
+    address: 2001:db8:cafe:2::1/64
+router:
+  isis:
+    net: 49.0000.0000.0000.0002.00
+    hostname: p
+    is-type: level-2-only
+    interface:
+    - if-name: lo
+      ipv6:
+        enable: true
+    - if-name: pe1
+      network-type: point-to-point
+      metric: 10
+      ipv6:
+        enable: true
+    - if-name: pe2
+      network-type: point-to-point
+      metric: 10
+      ipv6:
+        enable: true

--- a/bdd/tests/configs/l3vpn_bgp_v6/pe1.yaml
+++ b/bdd/tests/configs/l3vpn_bgp_v6/pe1.yaml
@@ -1,0 +1,71 @@
+# PE1 — provider edge 1 (AS 65000). IS-IS L2 SRv6 underlay to PE2 via P.
+# iBGP VPNv6 to PE2 over v6 loopbacks. vrf-cust (encapsulation srv6) holds
+# the IPv6 eBGP PE-CE session to CE1; CE-learned routes export to VPNv6
+# carrying the per-VRF End.DT46 service SID from LOC1 (RT 65000:100).
+vrf:
+- name: vrf-cust
+  ipv6:
+    route-target:
+      import:
+      - 65000:100
+      export:
+      - 65000:100
+interface:
+- if-name: lo
+  ipv6:
+    address: 2001:db8::1/128
+- if-name: p
+  ipv6:
+    address: 2001:db8:cafe:1::1/64
+- if-name: ce1
+  vrf: vrf-cust
+  ipv6:
+    address: 2001:db8:1e::2/64
+segment-routing:
+  locator:
+  - name: LOC1
+    prefix: fcbb:bbbb:1::/48
+    behavior: usid
+router:
+  isis:
+    net: 49.0000.0000.0000.0001.00
+    hostname: pe1
+    is-type: level-2-only
+    segment-routing:
+      srv6:
+        locator: LOC1
+    interface:
+    - if-name: lo
+      ipv6:
+        enable: true
+    - if-name: p
+      network-type: point-to-point
+      metric: 10
+      ipv6:
+        enable: true
+  bgp:
+    global:
+      as: 65000
+      router-id: 1.1.1.1
+    segment-routing:
+      srv6:
+        locator: LOC1
+    neighbor:
+    - remote-address: 2001:db8::3
+      remote-as: 65000
+      update-source: 2001:db8::1
+      timers: {connect-retry-time: 3}
+      enabled: true
+      afi-safi:
+      - name: vpnv6
+        enabled: true
+    vrf:
+    - name: vrf-cust
+      rd: 65000:1
+      encapsulation: srv6
+      neighbor:
+      - remote-address: 2001:db8:1e::1
+        remote-as: 65001
+        afi-safi:
+        - name: ipv6
+          enabled: true

--- a/bdd/tests/configs/l3vpn_bgp_v6/pe2.yaml
+++ b/bdd/tests/configs/l3vpn_bgp_v6/pe2.yaml
@@ -1,0 +1,70 @@
+# PE2 — provider edge 2 (AS 65000). Mirror of PE1: SRv6 locator LOC2,
+# iBGP VPNv6 to PE1, vrf-cust (encapsulation srv6) IPv6 eBGP PE-CE to
+# CE2, export with RD 65000:2 + RT 65000:100.
+vrf:
+- name: vrf-cust
+  ipv6:
+    route-target:
+      import:
+      - 65000:100
+      export:
+      - 65000:100
+interface:
+- if-name: lo
+  ipv6:
+    address: 2001:db8::3/128
+- if-name: p
+  ipv6:
+    address: 2001:db8:cafe:2::2/64
+- if-name: ce2
+  vrf: vrf-cust
+  ipv6:
+    address: 2001:db8:2e::2/64
+segment-routing:
+  locator:
+  - name: LOC2
+    prefix: fcbb:bbbb:2::/48
+    behavior: usid
+router:
+  isis:
+    net: 49.0000.0000.0000.0003.00
+    hostname: pe2
+    is-type: level-2-only
+    segment-routing:
+      srv6:
+        locator: LOC2
+    interface:
+    - if-name: lo
+      ipv6:
+        enable: true
+    - if-name: p
+      network-type: point-to-point
+      metric: 10
+      ipv6:
+        enable: true
+  bgp:
+    global:
+      as: 65000
+      router-id: 1.1.1.3
+    segment-routing:
+      srv6:
+        locator: LOC2
+    neighbor:
+    - remote-address: 2001:db8::1
+      remote-as: 65000
+      update-source: 2001:db8::3
+      timers: {connect-retry-time: 3}
+      enabled: true
+      afi-safi:
+      - name: vpnv6
+        enabled: true
+    vrf:
+    - name: vrf-cust
+      rd: 65000:2
+      encapsulation: srv6
+      neighbor:
+      - remote-address: 2001:db8:2e::1
+        remote-as: 65002
+        afi-safi:
+        - name: ipv6
+          enabled: true

--- a/bdd/tests/features/l3vpn_bgp_v4.feature
+++ b/bdd/tests/features/l3vpn_bgp_v4.feature
@@ -1,0 +1,108 @@
+@serial
+@l3vpn_bgp_v4
+Feature: MPLS/VPN L3VPN (IPv4) with BGP PE-CE and a customer site
+  As a service provider running RFC 4364 L3VPN over SR-MPLS
+  I want a full [C]-[CE]-[PE]-[P]-[PE]-[CE]-[C] topology where the
+  customer edge runs eBGP to the PE and the customer site originates a
+  loopback, so that C1 and C2 can reach each other's loopback across the
+  MPLS/VPN core (VPNv4 over an SR-MPLS LSP through the P transit).
+
+  Test Topology (7 namespaces):
+  ```
+   c1 --- ce1 --- pe1 --- p --- pe2 --- ce2 --- c2
+   lo      |       lo     lo     lo      |       lo
+  10.0.1.1 |    1.1.1.1 1.1.1.2 1.1.1.3  |    10.0.2.1
+           |    (sid 1) (sid 2) (sid 3)  |
+   AS65101 \_AS65001_/  vrf-cust  \_AS65002_/  AS65102
+  ```
+  - Core (pe1-p-pe2): IS-IS L2 + segment-routing mpls; loopback
+    Prefix-SIDs build the PE-PE transport LSP (SRGB 16000), P is the
+    transit LSR. pe1<->pe2 iBGP carries VPNv4 over loopbacks.
+  - PE-CE (ce<->pe, inside vrf-cust): eBGP; CE-learned routes export to
+    VPNv4 (RD 65000:1 / 65000:2, RT 65000:100).
+  - C-CE (c<->ce): eBGP; C redistributes its loopback (connected) into
+    BGP and CE re-advertises it to the PE.
+  - The C1<->C2 loopback ping exercises C-CE eBGP + PE-CE eBGP + VPNv4
+    over the SR-MPLS core.
+
+  Scenario: Build the L3VPN topology and bring up every session
+    Given a clean test environment
+    When I create namespace "c1"
+    And I create namespace "ce1"
+    And I create namespace "pe1"
+    And I create namespace "p"
+    And I create namespace "pe2"
+    And I create namespace "ce2"
+    And I create namespace "c2"
+    And I connect namespace "c1" interface "ce1" to namespace "ce1" interface "c1"
+    And I connect namespace "ce1" interface "pe1" to namespace "pe1" interface "ce1"
+    And I connect namespace "pe1" interface "p" to namespace "p" interface "pe1"
+    And I connect namespace "p" interface "pe2" to namespace "pe2" interface "p"
+    And I connect namespace "pe2" interface "ce2" to namespace "ce2" interface "pe2"
+    And I connect namespace "ce2" interface "c2" to namespace "c2" interface "ce2"
+    And I start zebra-rs in namespace "c1"
+    And I start zebra-rs in namespace "ce1"
+    And I start zebra-rs in namespace "pe1"
+    And I start zebra-rs in namespace "p"
+    And I start zebra-rs in namespace "pe2"
+    And I start zebra-rs in namespace "ce2"
+    And I start zebra-rs in namespace "c2"
+    And I apply config "c1.yaml" to namespace "c1"
+    And I apply config "ce1.yaml" to namespace "ce1"
+    And I apply config "pe1.yaml" to namespace "pe1"
+    And I apply config "p.yaml" to namespace "p"
+    And I apply config "pe2.yaml" to namespace "pe2"
+    And I apply config "ce2.yaml" to namespace "ce2"
+    And I apply config "c2.yaml" to namespace "c2"
+    And I wait 40 seconds for BGP to operate
+    # IS-IS SR adjacencies form the core transport LSP.
+    Then isis neighbor in namespace "pe1" at level 2 on interface "p" should be up
+    And isis neighbor in namespace "pe2" at level 2 on interface "p" should be up
+    And isis neighbor in namespace "p" at level 2 on interface "pe1" should be up
+    And isis neighbor in namespace "p" at level 2 on interface "pe2" should be up
+
+  Scenario: SR-MPLS transport LSPs are installed on the core P router
+    Given the test topology exists
+    # P is penultimate to PE1 (sid 1 -> 16001) and PE2 (sid 3 -> 16003).
+    Then mpls ilm in namespace "p" should contain label 16001
+    And mpls ilm in namespace "p" should contain label 16003
+
+  Scenario: PE-PE VPNv4 and C-CE eBGP sessions are Established
+    Given the test topology exists
+    # pe1<->pe2 iBGP (VPNv4) over loopbacks via the SR-MPLS LSP.
+    Then BGP session in "pe1" to "1.1.1.3" should be "Established"
+    And BGP session in "pe2" to "1.1.1.1" should be "Established"
+    # C-CE eBGP (the PE-CE session lives in vrf-cust and is proven by the
+    # VPNv4 route exchange below; the `BGP session` step only queries the
+    # global instance, so VRF neighbors aren't asserted here).
+    And BGP session in "c1" to "10.1.0.2" should be "Established"
+    And BGP session in "c2" to "10.2.0.2" should be "Established"
+
+  Scenario: Customer loopbacks are exchanged as VPNv4 between the PEs
+    Given the test topology exists
+    # PE1 learns C2's loopback under PE2's RD (65000:2) and vice versa.
+    Then show command "show bgp vpnv4" in namespace "pe1" should eventually contain "10.0.2.1/32"
+    And show command "show bgp vpnv4" in namespace "pe2" should eventually contain "10.0.1.1/32"
+
+  Scenario: End-to-end customer loopback reachability across the MPLS/VPN core
+    Given the test topology exists
+    Then ping from "c1" to "10.0.2.1" should eventually succeed
+    And ping from "c2" to "10.0.1.1" should eventually succeed
+
+  Scenario: Teardown topology
+    Given the test topology exists
+    When I stop zebra-rs in namespace "c1"
+    And I stop zebra-rs in namespace "ce1"
+    And I stop zebra-rs in namespace "pe1"
+    And I stop zebra-rs in namespace "p"
+    And I stop zebra-rs in namespace "pe2"
+    And I stop zebra-rs in namespace "ce2"
+    And I stop zebra-rs in namespace "c2"
+    And I delete namespace "c1"
+    And I delete namespace "ce1"
+    And I delete namespace "pe1"
+    And I delete namespace "p"
+    And I delete namespace "pe2"
+    And I delete namespace "ce2"
+    And I delete namespace "c2"
+    Then the test environment should be clean

--- a/bdd/tests/features/l3vpn_bgp_v6.feature
+++ b/bdd/tests/features/l3vpn_bgp_v6.feature
@@ -1,0 +1,104 @@
+@serial
+@l3vpn_bgp_v6
+Feature: SRv6 L3VPN (IPv6) with BGP PE-CE and a customer site
+  As a service provider running L3VPN over SRv6 (zebra-rs has no 6VPE, so
+  IPv6 customer VPN traffic rides SRv6 End.DT46 rather than MPLS)
+  I want a full [C]-[CE]-[PE]-[P]-[PE]-[CE]-[C] topology where the
+  customer edge runs IPv6 eBGP to the PE and the customer site originates
+  an IPv6 loopback, so that C1 and C2 can reach each other's loopback
+  across the SRv6 VPNv6 core.
+
+  Test Topology (7 namespaces):
+  ```
+   c1 --- ce1 --- pe1 --- p --- pe2 --- ce2 --- c2
+   lo      |       lo     lo     lo      |       lo
+  c1::1    |    db8::1  db8::2 db8::3    |     c2::1
+           |   LOC1 fcbb:bbbb:1::/48     |
+           |        LOC2 fcbb:bbbb:2::/48|
+   AS65101 \_AS65001_/  vrf-cust  \_AS65002_/  AS65102
+  ```
+  - Core (pe1-p-pe2): IS-IS L2 SRv6; PE loopbacks + locators are reached
+    natively over IPv6 through the P transit. pe1<->pe2 iBGP carries
+    VPNv6 over v6 loopbacks; the per-VRF End.DT46 SID (from each PE's
+    locator) is the service SID.
+  - PE-CE (ce<->pe, inside vrf-cust, encapsulation srv6): IPv6 eBGP;
+    CE-learned routes export to VPNv6. Exercises the per-VRF neighbor
+    `afi-safi ipv6 enabled` knob.
+  - C-CE (c<->ce): IPv6 eBGP; C redistributes its loopback (connected)
+    into BGP and CE re-advertises it to the PE.
+  - The C1<->C2 IPv6 loopback ping exercises C-CE eBGP + PE-CE eBGP +
+    VPNv6 over the SRv6 core (z2 H.Encaps toward z1's End.DT46, z1 decaps).
+
+  Scenario: Build the SRv6 L3VPN topology and bring up every session
+    Given a clean test environment
+    When I create namespace "c1"
+    And I create namespace "ce1"
+    And I create namespace "pe1"
+    And I create namespace "p"
+    And I create namespace "pe2"
+    And I create namespace "ce2"
+    And I create namespace "c2"
+    And I connect namespace "c1" interface "ce1" to namespace "ce1" interface "c1"
+    And I connect namespace "ce1" interface "pe1" to namespace "pe1" interface "ce1"
+    And I connect namespace "pe1" interface "p" to namespace "p" interface "pe1"
+    And I connect namespace "p" interface "pe2" to namespace "pe2" interface "p"
+    And I connect namespace "pe2" interface "ce2" to namespace "ce2" interface "pe2"
+    And I connect namespace "ce2" interface "c2" to namespace "c2" interface "ce2"
+    And I start zebra-rs in namespace "c1"
+    And I start zebra-rs in namespace "ce1"
+    And I start zebra-rs in namespace "pe1"
+    And I start zebra-rs in namespace "p"
+    And I start zebra-rs in namespace "pe2"
+    And I start zebra-rs in namespace "ce2"
+    And I start zebra-rs in namespace "c2"
+    And I apply config "c1.yaml" to namespace "c1"
+    And I apply config "ce1.yaml" to namespace "ce1"
+    And I apply config "pe1.yaml" to namespace "pe1"
+    And I apply config "p.yaml" to namespace "p"
+    And I apply config "pe2.yaml" to namespace "pe2"
+    And I apply config "ce2.yaml" to namespace "ce2"
+    And I apply config "c2.yaml" to namespace "c2"
+    And I wait 45 seconds
+    # IS-IS SRv6 adjacencies form the v6 core.
+    Then isis neighbor in namespace "pe1" at level 2 on interface "p" should be up
+    And isis neighbor in namespace "pe2" at level 2 on interface "p" should be up
+    And isis neighbor in namespace "p" at level 2 on interface "pe1" should be up
+    And isis neighbor in namespace "p" at level 2 on interface "pe2" should be up
+
+  Scenario: PE-PE VPNv6 and C-CE eBGP sessions are Established
+    Given the test topology exists
+    # pe1<->pe2 iBGP (VPNv6) over v6 loopbacks.
+    Then BGP session in "pe1" to "2001:db8::3" should be "Established"
+    And BGP session in "pe2" to "2001:db8::1" should be "Established"
+    # C-CE IPv6 eBGP (the PE-CE session lives in vrf-cust and is proven by
+    # the VPNv6 route exchange below).
+    And BGP session in "c1" to "2001:db8:1c::2" should be "Established"
+    And BGP session in "c2" to "2001:db8:2c::2" should be "Established"
+
+  Scenario: Customer loopbacks are exchanged as VPNv6 between the PEs
+    Given the test topology exists
+    Then show command "show bgp vpnv6" in namespace "pe1" should eventually contain "2001:db8:c2::1/128"
+    And show command "show bgp vpnv6" in namespace "pe2" should eventually contain "2001:db8:c1::1/128"
+
+  Scenario: End-to-end customer loopback reachability across the SRv6 core
+    Given the test topology exists
+    Then ping from "c1" to "2001:db8:c2::1" should eventually succeed
+    And ping from "c2" to "2001:db8:c1::1" should eventually succeed
+
+  Scenario: Teardown topology
+    Given the test topology exists
+    When I stop zebra-rs in namespace "c1"
+    And I stop zebra-rs in namespace "ce1"
+    And I stop zebra-rs in namespace "pe1"
+    And I stop zebra-rs in namespace "p"
+    And I stop zebra-rs in namespace "pe2"
+    And I stop zebra-rs in namespace "ce2"
+    And I stop zebra-rs in namespace "c2"
+    And I delete namespace "c1"
+    And I delete namespace "ce1"
+    And I delete namespace "pe1"
+    And I delete namespace "p"
+    And I delete namespace "pe2"
+    And I delete namespace "ce2"
+    And I delete namespace "c2"
+    Then the test environment should be clean

--- a/zebra-rs/src/bgp/route.rs
+++ b/zebra-rs/src/bgp/route.rs
@@ -10486,6 +10486,34 @@ pub fn route_update_ipv6(
         }
     }
 
+    // Don't leak a *relayed* SRv6 L3 Service SID onto a plain v6-unicast
+    // advertisement to a non-SRv6 peer. The SID is a provider-side
+    // construct: when a PE imports a VPNv6 route into a VRF (carrying the
+    // remote PE's End.DT46 service SID) and re-advertises it to a plain
+    // eBGP CE, the route keeps that SID in its Prefix-SID attribute.
+    // Leaking it to a non-SRv6 CE is fatal — `nht_target` prefers the SID
+    // over the BGP next-hop, so the CE tracks the unresolvable provider
+    // locator, the route never becomes reachable, and it is never
+    // re-advertised onward toward the customer site. Strip the Prefix-SID
+    // attribute when ALL hold:
+    //   - this speaker does not originate SRv6 IPv6-unicast service
+    //     (`srv6_ipv6_export` is `None`) — a node advertising its OWN
+    //     SRv6 service SID (e.g. `redistribute` under a local locator with
+    //     `segment-routing srv6 ipv6-unicast`) must keep it; a per-VRF
+    //     task (which always carries `srv6_ipv6_export: None`) relaying an
+    //     imported VPN SID is exactly the leak case;
+    //   - the peer did not negotiate SRv6 IPv6-unicast (`afi-safi ipv6
+    //     encapsulation-type srv6[-relax]`);
+    //   - the advertisement is plain v6-unicast (a bare IPv6 next-hop, not
+    //     a VPNv6 next-hop).
+    if bgp.srv6_ipv6_export.is_none()
+        && peer.ipv6_srv6_encap().is_none()
+        && matches!(attrs.nexthop, Some(BgpNexthop::Ipv6(_)))
+        && attrs.srv6_l3_sid().is_some()
+    {
+        attrs.prefix_sid = None;
+    }
+
     // LOCAL_PREF for iBGP.
     if peer.is_ibgp() && attrs.local_pref.is_none() {
         attrs.local_pref = Some(LocalPref::default());


### PR DESCRIPTION
## Summary

First phase of a full `[C]-[CE]-[PE]-[P]-[PE]-[CE]-[C]` MPLS/VPN L3VPN BDD matrix: customer-site loopback reachability across the provider core with **BGP** on both the C-CE and PE-CE segments. The customer router originates its loopback (`redistribute connected`); it flows C→CE→PE→VPN→remote PE→CE→C.

zebra-rs has **no 6VPE** (VPNv6 can't ride a v4 iBGP session) and no v6 SR-MPLS, so the dual-stack VPN splits by transport: **IPv4 over MPLS, IPv6 over SRv6**.

### Commits
- **`bdd: L3VPN MPLS PE-CE BGP (IPv4)`** — `l3vpn_bgp_v4`: IS-IS L2 + SR-MPLS core (P transit LSR, SRGB 16000), iBGP VPNv4 over loopbacks, eBGP PE-CE in `vrf-cust` (RD/RT export), eBGP C-CE. A single-AS collapse of `bgp_interas_option_c` / `mirror_sid_mpls`. Per-neighbor `connect-retry-time: 3` keeps convergence inside the poll budget (the 120s default parks on start-order races).
- **`bgp: don't leak a relayed SRv6 L3 Service SID to a non-SRv6 v6 peer`** — core fix (below).
- **`bdd: SRv6 L3VPN PE-CE BGP (IPv6)`** — `l3vpn_bgp_v6`: IS-IS SRv6 core (per-PE locator, End.DT46), v6 iBGP VPNv6, v6 eBGP PE-CE (exercises the per-VRF neighbor `afi-safi ipv6 enabled` activation), eBGP C-CE.

### The bug fixed
Dual-stack SRv6 PE-CE forwarded **up** (CE→PE→VPNv6) but the **down** direction (VPNv6→PE→CE→C) silently black-holed; the v4/MPLS path was fine. Root cause: a PE re-advertising a VPNv6-imported route to a plain eBGP CE kept the **remote** PE's End.DT46 SID in the Prefix-SID attribute. `nht_target` prefers an SRv6 L3 Service SID over the BGP next-hop, so the CE tracked the unresolvable provider locator → the route never became reachable → was never re-advertised toward the customer.

Fix in `route_update_ipv6`: strip the Prefix-SID attribute on a plain v6-unicast advertisement when the speaker doesn't originate SRv6 IPv6-unicast service (`srv6_ipv6_export` is `None` — always true in a per-VRF task relaying an import) **and** the peer didn't negotiate SRv6 IPv6-unicast encap **and** the next-hop is a bare IPv6 (not VPNv6). A node advertising its own SRv6 service SID keeps it; the VPNv6-to-PE path is untouched.

## Test plan
- `cargo fmt`, `cargo clippy --workspace --all-targets -- -D warnings`, and the bgp unit suite (573 passed) — clean. CI gates on these (BDD is excluded from CI).
- BDD (local, manual): `@l3vpn_bgp_v4` 6/6, `@l3vpn_bgp_v6` 5/5 — full C1↔C2 loopback ping over the VPN dataplane (MPLS label stack / SRv6 End.DT46 verified on the PEs).
- Regression: `@bgp_srv6_redistribute` (own SID kept) and `@mirror_sid_vpnsrv6_base` (VPNv6-to-PE kept) green — the fix only strips the relayed-to-non-SRv6-CE case.

## Follow-ups (not in this PR)
Static, OSPFv2/v3, and IS-IS PE-CE phases (each with an MPLS-v4 + SRv6-v6 variant), including the IGP-both-segments variant which will exercise BGP→IGP down-redistribution in a VRF.

Generated with [Claude Code](https://claude.com/claude-code)