### PR TITLE
L3VPN PE-CE BDD: static routing (IPv4/MPLS + IPv6/SRv6)

### DIFF
--- a/bdd/tests/configs/l3vpn_static_v4/c1.yaml
+++ b/bdd/tests/configs/l3vpn_static_v4/c1.yaml
@@ -1,0 +1,17 @@
+# C1 — customer site 1. Loopback 10.0.1.1/32 + a static default toward
+# CE1. No routing protocol: the loopback is reached from the far side by
+# a static route on CE1, and C1 reaches everything via the default.
+interface:
+- if-name: lo
+  ipv4:
+    address: 10.0.1.1/32
+- if-name: ce1
+  ipv4:
+    address: 10.1.0.1/30
+router:
+  static:
+    ipv4:
+      route:
+      - prefix: 0.0.0.0/0
+        nexthop:
+        - address: 10.1.0.2

--- a/bdd/tests/configs/l3vpn_static_v4/c2.yaml
+++ b/bdd/tests/configs/l3vpn_static_v4/c2.yaml
@@ -1,0 +1,16 @@
+# C2 — customer site 2. Mirror of C1: loopback 10.0.2.1/32 + static
+# default toward CE2.
+interface:
+- if-name: lo
+  ipv4:
+    address: 10.0.2.1/32
+- if-name: ce2
+  ipv4:
+    address: 10.2.0.1/30
+router:
+  static:
+    ipv4:
+      route:
+      - prefix: 0.0.0.0/0
+        nexthop:
+        - address: 10.2.0.2

--- a/bdd/tests/configs/l3vpn_static_v4/ce1.yaml
+++ b/bdd/tests/configs/l3vpn_static_v4/ce1.yaml
@@ -1,0 +1,20 @@
+# CE1 — customer edge 1. Static PE-CE: a static route to C1's loopback
+# via C1, and a default toward PE1 (so C2's loopback, learned by PE1 via
+# VPNv4, is reached through the PE). No routing protocol.
+interface:
+- if-name: c1
+  ipv4:
+    address: 10.1.0.2/30
+- if-name: pe1
+  ipv4:
+    address: 10.1.0.5/30
+router:
+  static:
+    ipv4:
+      route:
+      - prefix: 10.0.1.1/32
+        nexthop:
+        - address: 10.1.0.1
+      - prefix: 0.0.0.0/0
+        nexthop:
+        - address: 10.1.0.6

--- a/bdd/tests/configs/l3vpn_static_v4/ce2.yaml
+++ b/bdd/tests/configs/l3vpn_static_v4/ce2.yaml
@@ -1,0 +1,19 @@
+# CE2 — customer edge 2. Mirror of CE1: static route to C2's loopback via
+# C2, default toward PE2.
+interface:
+- if-name: c2
+  ipv4:
+    address: 10.2.0.2/30
+- if-name: pe2
+  ipv4:
+    address: 10.2.0.5/30
+router:
+  static:
+    ipv4:
+      route:
+      - prefix: 10.0.2.1/32
+        nexthop:
+        - address: 10.2.0.1
+      - prefix: 0.0.0.0/0
+        nexthop:
+        - address: 10.2.0.6

--- a/bdd/tests/configs/l3vpn_static_v4/p.yaml
+++ b/bdd/tests/configs/l3vpn_static_v4/p.yaml
@@ -1,0 +1,36 @@
+# P — provider core transit LSR (runs no BGP). Pure IS-IS L2 + SR-MPLS;
+# performs the SR label swap / PHP between PE1 (sid 1 -> 16001) and PE2
+# (sid 3 -> 16003).
+interface:
+- if-name: lo
+  ipv4:
+    address: 1.1.1.2/32
+- if-name: pe1
+  ipv4:
+    address: 10.250.0.2/30
+- if-name: pe2
+  ipv4:
+    address: 10.250.0.5/30
+router:
+  isis:
+    net: 49.0000.0000.0000.0002.00
+    hostname: p
+    is-type: level-2-only
+    segment-routing: mpls
+    te-router-id: 1.1.1.2
+    interface:
+    - if-name: lo
+      ipv4:
+        enable: true
+        prefix-sid:
+          index: 2
+    - if-name: pe1
+      network-type: point-to-point
+      metric: 10
+      ipv4:
+        enable: true
+    - if-name: pe2
+      network-type: point-to-point
+      metric: 10
+      ipv4:
+        enable: true

--- a/bdd/tests/configs/l3vpn_static_v4/pe1.yaml
+++ b/bdd/tests/configs/l3vpn_static_v4/pe1.yaml
@@ -1,0 +1,76 @@
+# PE1 — provider edge 1 (AS 65000). IS-IS L2 + SR-MPLS transport to PE2
+# via P; iBGP VPNv4 to PE2 over loopbacks. Static PE-CE: a per-VRF static
+# route to C1's loopback via CE1, redistributed into VPNv4 (RD 65000:1 /
+# RT 65000:100). Returning traffic to C1 rides this static route; the CE
+# reaches remote customers via its own default toward this PE.
+vrf:
+- name: vrf-cust
+  ipv4:
+    route-target:
+      import:
+      - 65000:100
+      export:
+      - 65000:100
+interface:
+- if-name: lo
+  ipv4:
+    address: 1.1.1.1/32
+- if-name: p
+  ipv4:
+    address: 10.250.0.1/30
+- if-name: ce1
+  vrf: vrf-cust
+  ipv4:
+    address: 10.1.0.6/30
+router:
+  static:
+    vrf:
+    - name: vrf-cust
+      ipv4:
+        route:
+        # The customer loopback, and the C-CE link subnet (so a customer
+        # ping sourced from its link address has a return path — the BGP
+        # phase gets this for free via redistribute-connected).
+        - prefix: 10.0.1.1/32
+          nexthop:
+          - address: 10.1.0.5
+        - prefix: 10.1.0.0/30
+          nexthop:
+          - address: 10.1.0.5
+  isis:
+    net: 49.0000.0000.0000.0001.00
+    hostname: pe1
+    is-type: level-2-only
+    segment-routing: mpls
+    te-router-id: 1.1.1.1
+    interface:
+    - if-name: lo
+      ipv4:
+        enable: true
+        prefix-sid:
+          index: 1
+    - if-name: p
+      network-type: point-to-point
+      metric: 10
+      ipv4:
+        enable: true
+  bgp:
+    global:
+      as: 65000
+      router-id: 1.1.1.1
+    neighbor:
+    - remote-address: 1.1.1.3
+      remote-as: 65000
+      timers: {connect-retry-time: 3}
+      update-source: 1.1.1.1
+      enabled: true
+      afi-safi:
+      - name: vpnv4
+        enabled: true
+    vrf:
+    - name: vrf-cust
+      rd: 65000:1
+      afi-safi:
+        ipv4:
+          redistribute:
+            static: {}

--- a/bdd/tests/configs/l3vpn_static_v4/pe2.yaml
+++ b/bdd/tests/configs/l3vpn_static_v4/pe2.yaml
@@ -1,0 +1,73 @@
+# PE2 — provider edge 2 (AS 65000). Mirror of PE1: SR-MPLS Prefix-SID
+# index 3, iBGP VPNv4 to PE1, per-VRF static route to C2's loopback via
+# CE2, redistributed into VPNv4 (RD 65000:2 / RT 65000:100).
+vrf:
+- name: vrf-cust
+  ipv4:
+    route-target:
+      import:
+      - 65000:100
+      export:
+      - 65000:100
+interface:
+- if-name: lo
+  ipv4:
+    address: 1.1.1.3/32
+- if-name: p
+  ipv4:
+    address: 10.250.0.6/30
+- if-name: ce2
+  vrf: vrf-cust
+  ipv4:
+    address: 10.2.0.6/30
+router:
+  static:
+    vrf:
+    - name: vrf-cust
+      ipv4:
+        route:
+        # Customer loopback + the C-CE link subnet (return path for a
+        # link-sourced customer ping).
+        - prefix: 10.0.2.1/32
+          nexthop:
+          - address: 10.2.0.5
+        - prefix: 10.2.0.0/30
+          nexthop:
+          - address: 10.2.0.5
+  isis:
+    net: 49.0000.0000.0000.0003.00
+    hostname: pe2
+    is-type: level-2-only
+    segment-routing: mpls
+    te-router-id: 1.1.1.3
+    interface:
+    - if-name: lo
+      ipv4:
+        enable: true
+        prefix-sid:
+          index: 3
+    - if-name: p
+      network-type: point-to-point
+      metric: 10
+      ipv4:
+        enable: true
+  bgp:
+    global:
+      as: 65000
+      router-id: 1.1.1.3
+    neighbor:
+    - remote-address: 1.1.1.1
+      remote-as: 65000
+      timers: {connect-retry-time: 3}
+      update-source: 1.1.1.3
+      enabled: true
+      afi-safi:
+      - name: vpnv4
+        enabled: true
+    vrf:
+    - name: vrf-cust
+      rd: 65000:2
+      afi-safi:
+        ipv4:
+          redistribute:
+            static: {}

--- a/bdd/tests/configs/l3vpn_static_v6/c1.yaml
+++ b/bdd/tests/configs/l3vpn_static_v6/c1.yaml
@@ -1,0 +1,15 @@
+# C1 — customer site 1. IPv6 loopback + static default toward CE1.
+interface:
+- if-name: lo
+  ipv6:
+    address: 2001:db8:c1::1/128
+- if-name: ce1
+  ipv6:
+    address: 2001:db8:1c::1/64
+router:
+  static:
+    ipv6:
+      route:
+      - prefix: ::/0
+        nexthop:
+        - address: 2001:db8:1c::2

--- a/bdd/tests/configs/l3vpn_static_v6/c2.yaml
+++ b/bdd/tests/configs/l3vpn_static_v6/c2.yaml
@@ -1,0 +1,16 @@
+# C2 — customer site 2. Mirror of C1: IPv6 loopback + static default
+# toward CE2.
+interface:
+- if-name: lo
+  ipv6:
+    address: 2001:db8:c2::1/128
+- if-name: ce2
+  ipv6:
+    address: 2001:db8:2c::1/64
+router:
+  static:
+    ipv6:
+      route:
+      - prefix: ::/0
+        nexthop:
+        - address: 2001:db8:2c::2

--- a/bdd/tests/configs/l3vpn_static_v6/ce1.yaml
+++ b/bdd/tests/configs/l3vpn_static_v6/ce1.yaml
@@ -1,0 +1,19 @@
+# CE1 — customer edge 1. IPv6 static PE-CE: static route to C1's loopback
+# via C1, default toward PE1.
+interface:
+- if-name: c1
+  ipv6:
+    address: 2001:db8:1c::2/64
+- if-name: pe1
+  ipv6:
+    address: 2001:db8:1e::1/64
+router:
+  static:
+    ipv6:
+      route:
+      - prefix: 2001:db8:c1::1/128
+        nexthop:
+        - address: 2001:db8:1c::1
+      - prefix: ::/0
+        nexthop:
+        - address: 2001:db8:1e::2

--- a/bdd/tests/configs/l3vpn_static_v6/ce2.yaml
+++ b/bdd/tests/configs/l3vpn_static_v6/ce2.yaml
@@ -1,0 +1,19 @@
+# CE2 — customer edge 2. Mirror of CE1: IPv6 static route to C2's
+# loopback via C2, default toward PE2.
+interface:
+- if-name: c2
+  ipv6:
+    address: 2001:db8:2c::2/64
+- if-name: pe2
+  ipv6:
+    address: 2001:db8:2e::1/64
+router:
+  static:
+    ipv6:
+      route:
+      - prefix: 2001:db8:c2::1/128
+        nexthop:
+        - address: 2001:db8:2c::1
+      - prefix: ::/0
+        nexthop:
+        - address: 2001:db8:2e::2

--- a/bdd/tests/configs/l3vpn_static_v6/p.yaml
+++ b/bdd/tests/configs/l3vpn_static_v6/p.yaml
@@ -1,0 +1,33 @@
+# P — provider core transit (runs no BGP, no SRv6). Pure IS-IS L2 with
+# IPv6 enabled; learns the PE loopbacks (/128) and SRv6 locators (/48)
+# via IS-IS and natively forwards the SRv6-encapsulated transit traffic
+# between PE1 and PE2.
+interface:
+- if-name: lo
+  ipv6:
+    address: 2001:db8::2/128
+- if-name: pe1
+  ipv6:
+    address: 2001:db8:cafe:1::2/64
+- if-name: pe2
+  ipv6:
+    address: 2001:db8:cafe:2::1/64
+router:
+  isis:
+    net: 49.0000.0000.0000.0002.00
+    hostname: p
+    is-type: level-2-only
+    interface:
+    - if-name: lo
+      ipv6:
+        enable: true
+    - if-name: pe1
+      network-type: point-to-point
+      metric: 10
+      ipv6:
+        enable: true
+    - if-name: pe2
+      network-type: point-to-point
+      metric: 10
+      ipv6:
+        enable: true

--- a/bdd/tests/configs/l3vpn_static_v6/pe1.yaml
+++ b/bdd/tests/configs/l3vpn_static_v6/pe1.yaml
@@ -1,0 +1,80 @@
+# PE1 — provider edge 1 (AS 65000). IS-IS L2 SRv6 underlay; iBGP VPNv6 to
+# PE2. Static PE-CE (encapsulation srv6): per-VRF static routes to C1's
+# loopback and the C-CE link via CE1, redistributed into VPNv6 carrying
+# the per-VRF End.DT46 SID (RD 65000:1 / RT 65000:100).
+vrf:
+- name: vrf-cust
+  ipv6:
+    route-target:
+      import:
+      - 65000:100
+      export:
+      - 65000:100
+interface:
+- if-name: lo
+  ipv6:
+    address: 2001:db8::1/128
+- if-name: p
+  ipv6:
+    address: 2001:db8:cafe:1::1/64
+- if-name: ce1
+  vrf: vrf-cust
+  ipv6:
+    address: 2001:db8:1e::2/64
+segment-routing:
+  locator:
+  - name: LOC1
+    prefix: fcbb:bbbb:1::/48
+    behavior: usid
+router:
+  static:
+    vrf:
+    - name: vrf-cust
+      ipv6:
+        route:
+        - prefix: 2001:db8:c1::1/128
+          nexthop:
+          - address: 2001:db8:1e::1
+        - prefix: 2001:db8:1c::/64
+          nexthop:
+          - address: 2001:db8:1e::1
+  isis:
+    net: 49.0000.0000.0000.0001.00
+    hostname: pe1
+    is-type: level-2-only
+    segment-routing:
+      srv6:
+        locator: LOC1
+    interface:
+    - if-name: lo
+      ipv6:
+        enable: true
+    - if-name: p
+      network-type: point-to-point
+      metric: 10
+      ipv6:
+        enable: true
+  bgp:
+    global:
+      as: 65000
+      router-id: 1.1.1.1
+    segment-routing:
+      srv6:
+        locator: LOC1
+    neighbor:
+    - remote-address: 2001:db8::3
+      remote-as: 65000
+      timers: {connect-retry-time: 3}
+      update-source: 2001:db8::1
+      enabled: true
+      afi-safi:
+      - name: vpnv6
+        enabled: true
+    vrf:
+    - name: vrf-cust
+      rd: 65000:1
+      encapsulation: srv6
+      afi-safi:
+        ipv6:
+          redistribute:
+            static: {}

--- a/bdd/tests/configs/l3vpn_static_v6/pe2.yaml
+++ b/bdd/tests/configs/l3vpn_static_v6/pe2.yaml
@@ -1,0 +1,79 @@
+# PE2 — provider edge 2 (AS 65000). Mirror of PE1: SRv6 locator LOC2,
+# iBGP VPNv6 to PE1, per-VRF static routes to C2's loopback + C-CE link
+# via CE2, redistributed into VPNv6 (RD 65000:2 / RT 65000:100).
+vrf:
+- name: vrf-cust
+  ipv6:
+    route-target:
+      import:
+      - 65000:100
+      export:
+      - 65000:100
+interface:
+- if-name: lo
+  ipv6:
+    address: 2001:db8::3/128
+- if-name: p
+  ipv6:
+    address: 2001:db8:cafe:2::2/64
+- if-name: ce2
+  vrf: vrf-cust
+  ipv6:
+    address: 2001:db8:2e::2/64
+segment-routing:
+  locator:
+  - name: LOC2
+    prefix: fcbb:bbbb:2::/48
+    behavior: usid
+router:
+  static:
+    vrf:
+    - name: vrf-cust
+      ipv6:
+        route:
+        - prefix: 2001:db8:c2::1/128
+          nexthop:
+          - address: 2001:db8:2e::1
+        - prefix: 2001:db8:2c::/64
+          nexthop:
+          - address: 2001:db8:2e::1
+  isis:
+    net: 49.0000.0000.0000.0003.00
+    hostname: pe2
+    is-type: level-2-only
+    segment-routing:
+      srv6:
+        locator: LOC2
+    interface:
+    - if-name: lo
+      ipv6:
+        enable: true
+    - if-name: p
+      network-type: point-to-point
+      metric: 10
+      ipv6:
+        enable: true
+  bgp:
+    global:
+      as: 65000
+      router-id: 1.1.1.3
+    segment-routing:
+      srv6:
+        locator: LOC2
+    neighbor:
+    - remote-address: 2001:db8::1
+      remote-as: 65000
+      timers: {connect-retry-time: 3}
+      update-source: 2001:db8::3
+      enabled: true
+      afi-safi:
+      - name: vpnv6
+        enabled: true
+    vrf:
+    - name: vrf-cust
+      rd: 65000:2
+      encapsulation: srv6
+      afi-safi:
+        ipv6:
+          redistribute:
+            static: {}

--- a/bdd/tests/features/l3vpn_static_v4.feature
+++ b/bdd/tests/features/l3vpn_static_v4.feature
@@ -1,0 +1,93 @@
+@serial
+@l3vpn_static_v4
+Feature: MPLS/VPN L3VPN (IPv4) with static PE-CE and a customer site
+  As a service provider running RFC 4364 L3VPN over SR-MPLS
+  I want a full [C]-[CE]-[PE]-[P]-[PE]-[CE]-[C] topology where the PE-CE
+  and C-CE segments are statically routed and the PE redistributes the
+  customer static route into VPNv4, so that C1 and C2 can reach each
+  other's loopback across the MPLS/VPN core.
+
+  Test Topology (7 namespaces) — same core as @l3vpn_bgp_v4; the customer
+  side is static instead of eBGP:
+  ```
+   c1 --- ce1 --- pe1 --- p --- pe2 --- ce2 --- c2
+   lo      |       lo     lo     lo      |       lo
+  10.0.1.1 |    1.1.1.1 1.1.1.2 1.1.1.3  |    10.0.2.1
+           |    (sid 1) (sid 2) (sid 3)  |
+           \__ static __/ vrf-cust \__ static __/
+  ```
+  - Core (pe1-p-pe2): IS-IS L2 + segment-routing mpls; iBGP VPNv4.
+  - PE-CE: PE holds a per-VRF static route to the customer loopback via
+    the CE and `redistribute static` into VPNv4. The CE has a static
+    route to the customer loopback and a default toward the PE; the
+    customer has a default toward the CE. Down-direction traffic rides
+    the CE/customer default routes.
+
+  Scenario: Build the L3VPN topology and bring up the core
+    Given a clean test environment
+    When I create namespace "c1"
+    And I create namespace "ce1"
+    And I create namespace "pe1"
+    And I create namespace "p"
+    And I create namespace "pe2"
+    And I create namespace "ce2"
+    And I create namespace "c2"
+    And I connect namespace "c1" interface "ce1" to namespace "ce1" interface "c1"
+    And I connect namespace "ce1" interface "pe1" to namespace "pe1" interface "ce1"
+    And I connect namespace "pe1" interface "p" to namespace "p" interface "pe1"
+    And I connect namespace "p" interface "pe2" to namespace "pe2" interface "p"
+    And I connect namespace "pe2" interface "ce2" to namespace "ce2" interface "pe2"
+    And I connect namespace "ce2" interface "c2" to namespace "c2" interface "ce2"
+    And I start zebra-rs in namespace "c1"
+    And I start zebra-rs in namespace "ce1"
+    And I start zebra-rs in namespace "pe1"
+    And I start zebra-rs in namespace "p"
+    And I start zebra-rs in namespace "pe2"
+    And I start zebra-rs in namespace "ce2"
+    And I start zebra-rs in namespace "c2"
+    And I apply config "c1.yaml" to namespace "c1"
+    And I apply config "ce1.yaml" to namespace "ce1"
+    And I apply config "pe1.yaml" to namespace "pe1"
+    And I apply config "p.yaml" to namespace "p"
+    And I apply config "pe2.yaml" to namespace "pe2"
+    And I apply config "ce2.yaml" to namespace "ce2"
+    And I apply config "c2.yaml" to namespace "c2"
+    And I wait 40 seconds for BGP to operate
+    Then isis neighbor in namespace "pe1" at level 2 on interface "p" should be up
+    And isis neighbor in namespace "pe2" at level 2 on interface "p" should be up
+
+  Scenario: SR-MPLS transport LSPs are installed on the core P router
+    Given the test topology exists
+    Then mpls ilm in namespace "p" should contain label 16001
+    And mpls ilm in namespace "p" should contain label 16003
+
+  Scenario: PE-PE VPNv4 session is Established and carries the customer loopbacks
+    Given the test topology exists
+    Then BGP session in "pe1" to "1.1.1.3" should be "Established"
+    And BGP session in "pe2" to "1.1.1.1" should be "Established"
+    # The redistributed static route is exported to VPNv4 across the core.
+    And show command "show bgp vpnv4" in namespace "pe1" should eventually contain "10.0.2.1/32"
+    And show command "show bgp vpnv4" in namespace "pe2" should eventually contain "10.0.1.1/32"
+
+  Scenario: End-to-end customer loopback reachability across the MPLS/VPN core
+    Given the test topology exists
+    Then ping from "c1" to "10.0.2.1" should eventually succeed
+    And ping from "c2" to "10.0.1.1" should eventually succeed
+
+  Scenario: Teardown topology
+    Given the test topology exists
+    When I stop zebra-rs in namespace "c1"
+    And I stop zebra-rs in namespace "ce1"
+    And I stop zebra-rs in namespace "pe1"
+    And I stop zebra-rs in namespace "p"
+    And I stop zebra-rs in namespace "pe2"
+    And I stop zebra-rs in namespace "ce2"
+    And I stop zebra-rs in namespace "c2"
+    And I delete namespace "c1"
+    And I delete namespace "ce1"
+    And I delete namespace "pe1"
+    And I delete namespace "p"
+    And I delete namespace "pe2"
+    And I delete namespace "ce2"
+    And I delete namespace "c2"
+    Then the test environment should be clean

--- a/bdd/tests/features/l3vpn_static_v6.feature
+++ b/bdd/tests/features/l3vpn_static_v6.feature
@@ -1,0 +1,76 @@
+@serial
+@l3vpn_static_v6
+Feature: SRv6 L3VPN (IPv6) with static PE-CE and a customer site
+  As a service provider running L3VPN over SRv6 (zebra-rs has no 6VPE)
+  I want a full [C]-[CE]-[PE]-[P]-[PE]-[CE]-[C] topology where the PE-CE
+  and C-CE segments are statically routed and the PE redistributes the
+  customer static route into VPNv6 (End.DT46), so that C1 and C2 can
+  reach each other's IPv6 loopback across the SRv6 core.
+
+  Same core as @l3vpn_bgp_v6 (IS-IS L2 SRv6, iBGP VPNv6); the customer
+  side is static instead of eBGP. The PE holds per-VRF static routes to
+  the customer loopback + C-CE link via the CE and `redistribute static`;
+  the CE/customer use default routes for the down direction.
+
+  Scenario: Build the SRv6 L3VPN topology and bring up the core
+    Given a clean test environment
+    When I create namespace "c1"
+    And I create namespace "ce1"
+    And I create namespace "pe1"
+    And I create namespace "p"
+    And I create namespace "pe2"
+    And I create namespace "ce2"
+    And I create namespace "c2"
+    And I connect namespace "c1" interface "ce1" to namespace "ce1" interface "c1"
+    And I connect namespace "ce1" interface "pe1" to namespace "pe1" interface "ce1"
+    And I connect namespace "pe1" interface "p" to namespace "p" interface "pe1"
+    And I connect namespace "p" interface "pe2" to namespace "pe2" interface "p"
+    And I connect namespace "pe2" interface "ce2" to namespace "ce2" interface "pe2"
+    And I connect namespace "ce2" interface "c2" to namespace "c2" interface "ce2"
+    And I start zebra-rs in namespace "c1"
+    And I start zebra-rs in namespace "ce1"
+    And I start zebra-rs in namespace "pe1"
+    And I start zebra-rs in namespace "p"
+    And I start zebra-rs in namespace "pe2"
+    And I start zebra-rs in namespace "ce2"
+    And I start zebra-rs in namespace "c2"
+    And I apply config "c1.yaml" to namespace "c1"
+    And I apply config "ce1.yaml" to namespace "ce1"
+    And I apply config "pe1.yaml" to namespace "pe1"
+    And I apply config "p.yaml" to namespace "p"
+    And I apply config "pe2.yaml" to namespace "pe2"
+    And I apply config "ce2.yaml" to namespace "ce2"
+    And I apply config "c2.yaml" to namespace "c2"
+    And I wait 45 seconds
+    Then isis neighbor in namespace "pe1" at level 2 on interface "p" should be up
+    And isis neighbor in namespace "pe2" at level 2 on interface "p" should be up
+
+  Scenario: PE-PE VPNv6 session is Established and carries the customer loopbacks
+    Given the test topology exists
+    Then BGP session in "pe1" to "2001:db8::3" should be "Established"
+    And BGP session in "pe2" to "2001:db8::1" should be "Established"
+    And show command "show bgp vpnv6" in namespace "pe1" should eventually contain "2001:db8:c2::1/128"
+    And show command "show bgp vpnv6" in namespace "pe2" should eventually contain "2001:db8:c1::1/128"
+
+  Scenario: End-to-end customer loopback reachability across the SRv6 core
+    Given the test topology exists
+    Then ping from "c1" to "2001:db8:c2::1" should eventually succeed
+    And ping from "c2" to "2001:db8:c1::1" should eventually succeed
+
+  Scenario: Teardown topology
+    Given the test topology exists
+    When I stop zebra-rs in namespace "c1"
+    And I stop zebra-rs in namespace "ce1"
+    And I stop zebra-rs in namespace "pe1"
+    And I stop zebra-rs in namespace "p"
+    And I stop zebra-rs in namespace "pe2"
+    And I stop zebra-rs in namespace "ce2"
+    And I stop zebra-rs in namespace "c2"
+    And I delete namespace "c1"
+    And I delete namespace "ce1"
+    And I delete namespace "pe1"
+    And I delete namespace "p"
+    And I delete namespace "pe2"
+    And I delete namespace "ce2"
+    And I delete namespace "c2"
+    Then the test environment should be clean


### PR DESCRIPTION
## Summary

Static-routing phase of the `[C]-[CE]-[PE]-[P]-[PE]-[CE]-[C]` MPLS/VPN L3VPN BDD matrix (follows the BGP phase in #1684). Same provider core; the C-CE and PE-CE segments are statically routed instead of eBGP.

- **`l3vpn_static_v4`** (MPLS / VPNv4) and **`l3vpn_static_v6`** (SRv6 / VPNv6, End.DT46).
- **PE**: per-VRF static routes to the customer loopback + the C-CE link via the CE, `redistribute static` into VPNv4/VPNv6.
- **CE**: static route to the customer loopback via C, default toward the PE.
- **C**: loopback + default toward the CE.
- Down direction rides the CE/customer default routes (no BGP→IGP needed). The C-CE link subnet is redistributed alongside the loopback so a customer ping sourced from its link address has a return path (the BGP phase gets this for free via `redistribute connected`).

## Test plan
- BDD (local, manual): `@l3vpn_static_v4` 5/5, `@l3vpn_static_v6` 4/4 — C1↔C2 loopback ping over the VPN dataplane; VPNv4/VPNv6 route exchange asserted on the PEs. (BDD is excluded from CI as usual.)
- No source changes — BDD-only; nothing for fmt/clippy/test to gate beyond the unchanged tree.

## Follow-ups
OSPF and IS-IS PE-CE phases (each MPLS-v4 + SRv6-v6, plus the IGP-both-segments vs BGP-PE-CE variants).

Generated with [Claude Code](https://claude.com/claude-code)