### PR TITLE
ospf: OSPFv2 redistribute bgp + per-VRF redist fix; L3VPN OSPF PE-CE BDD

### DIFF
--- a/bdd/tests/configs/l3vpn_ospf_v4/c1.yaml
+++ b/bdd/tests/configs/l3vpn_ospf_v4/c1.yaml
@@ -1,0 +1,22 @@
+# C1 — customer site 1. OSPFv2 to CE1 (area 0); redistributes its
+# connected routes (loopback 10.0.1.1/32 + the C-CE link) into OSPF as
+# Type-5 AS-External LSAs, which reach the PE through CE1.
+interface:
+- if-name: lo
+  ipv4:
+    address: 10.0.1.1/32
+- if-name: ce1
+  ipv4:
+    address: 10.1.0.1/30
+router:
+  ospf:
+    router-id: 10.0.1.1
+    redistribute:
+      connected:
+        metric: 20
+    area:
+    - area-id: 0.0.0.0
+      interface:
+      - if-name: ce1
+        enable: true
+        network-type: point-to-point

--- a/bdd/tests/configs/l3vpn_ospf_v4/c2.yaml
+++ b/bdd/tests/configs/l3vpn_ospf_v4/c2.yaml
@@ -1,0 +1,21 @@
+# C2 — customer site 2. Mirror of C1: OSPFv2 to CE2, redistribute
+# connected (loopback 10.0.2.1/32 + C-CE link) into OSPF.
+interface:
+- if-name: lo
+  ipv4:
+    address: 10.0.2.1/32
+- if-name: ce2
+  ipv4:
+    address: 10.2.0.1/30
+router:
+  ospf:
+    router-id: 10.0.2.1
+    redistribute:
+      connected:
+        metric: 20
+    area:
+    - area-id: 0.0.0.0
+      interface:
+      - if-name: ce2
+        enable: true
+        network-type: point-to-point

--- a/bdd/tests/configs/l3vpn_ospf_v4/ce1.yaml
+++ b/bdd/tests/configs/l3vpn_ospf_v4/ce1.yaml
@@ -1,0 +1,22 @@
+# CE1 — customer edge 1. Transit OSPFv2 router in area 0, peering with C1
+# and PE1 on its two point-to-point links; floods C1's externals up to
+# PE1 and PE1's externals (the remote customer routes) down to C1.
+interface:
+- if-name: c1
+  ipv4:
+    address: 10.1.0.2/30
+- if-name: pe1
+  ipv4:
+    address: 10.1.0.5/30
+router:
+  ospf:
+    router-id: 10.1.0.5
+    area:
+    - area-id: 0.0.0.0
+      interface:
+      - if-name: c1
+        enable: true
+        network-type: point-to-point
+      - if-name: pe1
+        enable: true
+        network-type: point-to-point

--- a/bdd/tests/configs/l3vpn_ospf_v4/ce2.yaml
+++ b/bdd/tests/configs/l3vpn_ospf_v4/ce2.yaml
@@ -1,0 +1,21 @@
+# CE2 — customer edge 2. Mirror of CE1: transit OSPFv2 in area 0 between
+# C2 and PE2.
+interface:
+- if-name: c2
+  ipv4:
+    address: 10.2.0.2/30
+- if-name: pe2
+  ipv4:
+    address: 10.2.0.5/30
+router:
+  ospf:
+    router-id: 10.2.0.5
+    area:
+    - area-id: 0.0.0.0
+      interface:
+      - if-name: c2
+        enable: true
+        network-type: point-to-point
+      - if-name: pe2
+        enable: true
+        network-type: point-to-point

--- a/bdd/tests/configs/l3vpn_ospf_v4/p.yaml
+++ b/bdd/tests/configs/l3vpn_ospf_v4/p.yaml
@@ -1,0 +1,36 @@
+# P — provider core transit LSR (runs no BGP). Pure IS-IS L2 + SR-MPLS;
+# performs the SR label swap / PHP between PE1 (sid 1 -> 16001) and PE2
+# (sid 3 -> 16003).
+interface:
+- if-name: lo
+  ipv4:
+    address: 1.1.1.2/32
+- if-name: pe1
+  ipv4:
+    address: 10.250.0.2/30
+- if-name: pe2
+  ipv4:
+    address: 10.250.0.5/30
+router:
+  isis:
+    net: 49.0000.0000.0000.0002.00
+    hostname: p
+    is-type: level-2-only
+    segment-routing: mpls
+    te-router-id: 1.1.1.2
+    interface:
+    - if-name: lo
+      ipv4:
+        enable: true
+        prefix-sid:
+          index: 2
+    - if-name: pe1
+      network-type: point-to-point
+      metric: 10
+      ipv4:
+        enable: true
+    - if-name: pe2
+      network-type: point-to-point
+      metric: 10
+      ipv4:
+        enable: true

--- a/bdd/tests/configs/l3vpn_ospf_v4/pe1.yaml
+++ b/bdd/tests/configs/l3vpn_ospf_v4/pe1.yaml
@@ -1,0 +1,78 @@
+# PE1 — provider edge 1 (AS 65000). IS-IS L2 + SR-MPLS core; iBGP VPNv4
+# to PE2. OSPFv2 PE-CE in vrf-cust (area 0 to CE1), with two-way
+# redistribution:
+#   - up:   router bgp vrf ... redistribute ospf  -> VPNv4 carries the
+#           customer routes OSPF learned from CE1.
+#   - down: router ospf vrf ... redistribute bgp  -> the VPNv4 routes
+#           imported into the VRF are injected into the CE-facing OSPF as
+#           Type-5 AS-External LSAs, so CE1/C1 learn the remote customers.
+vrf:
+- name: vrf-cust
+  ipv4:
+    route-target:
+      import:
+      - 65000:100
+      export:
+      - 65000:100
+interface:
+- if-name: lo
+  ipv4:
+    address: 1.1.1.1/32
+- if-name: p
+  ipv4:
+    address: 10.250.0.1/30
+- if-name: ce1
+  vrf: vrf-cust
+  ipv4:
+    address: 10.1.0.6/30
+router:
+  ospf:
+    vrf:
+    - name: vrf-cust
+      router-id: 1.1.1.1
+      redistribute:
+        bgp:
+          metric: 20
+      area:
+      - area-id: 0.0.0.0
+        interface:
+        - if-name: ce1
+          enable: true
+          network-type: point-to-point
+  isis:
+    net: 49.0000.0000.0000.0001.00
+    hostname: pe1
+    is-type: level-2-only
+    segment-routing: mpls
+    te-router-id: 1.1.1.1
+    interface:
+    - if-name: lo
+      ipv4:
+        enable: true
+        prefix-sid:
+          index: 1
+    - if-name: p
+      network-type: point-to-point
+      metric: 10
+      ipv4:
+        enable: true
+  bgp:
+    global:
+      as: 65000
+      router-id: 1.1.1.1
+    neighbor:
+    - remote-address: 1.1.1.3
+      remote-as: 65000
+      timers: {connect-retry-time: 3}
+      update-source: 1.1.1.1
+      enabled: true
+      afi-safi:
+      - name: vpnv4
+        enabled: true
+    vrf:
+    - name: vrf-cust
+      rd: 65000:1
+      afi-safi:
+        ipv4:
+          redistribute:
+            ospf: {}

--- a/bdd/tests/configs/l3vpn_ospf_v4/pe2.yaml
+++ b/bdd/tests/configs/l3vpn_ospf_v4/pe2.yaml
@@ -1,0 +1,74 @@
+# PE2 — provider edge 2 (AS 65000). Mirror of PE1: SR-MPLS Prefix-SID
+# index 3, iBGP VPNv4 to PE1, OSPFv2 PE-CE in vrf-cust to CE2 with two-way
+# redistribution (redistribute ospf -> VPNv4 up, redistribute bgp -> OSPF
+# down).
+vrf:
+- name: vrf-cust
+  ipv4:
+    route-target:
+      import:
+      - 65000:100
+      export:
+      - 65000:100
+interface:
+- if-name: lo
+  ipv4:
+    address: 1.1.1.3/32
+- if-name: p
+  ipv4:
+    address: 10.250.0.6/30
+- if-name: ce2
+  vrf: vrf-cust
+  ipv4:
+    address: 10.2.0.6/30
+router:
+  ospf:
+    vrf:
+    - name: vrf-cust
+      router-id: 1.1.1.3
+      redistribute:
+        bgp:
+          metric: 20
+      area:
+      - area-id: 0.0.0.0
+        interface:
+        - if-name: ce2
+          enable: true
+          network-type: point-to-point
+  isis:
+    net: 49.0000.0000.0000.0003.00
+    hostname: pe2
+    is-type: level-2-only
+    segment-routing: mpls
+    te-router-id: 1.1.1.3
+    interface:
+    - if-name: lo
+      ipv4:
+        enable: true
+        prefix-sid:
+          index: 3
+    - if-name: p
+      network-type: point-to-point
+      metric: 10
+      ipv4:
+        enable: true
+  bgp:
+    global:
+      as: 65000
+      router-id: 1.1.1.3
+    neighbor:
+    - remote-address: 1.1.1.1
+      remote-as: 65000
+      timers: {connect-retry-time: 3}
+      update-source: 1.1.1.3
+      enabled: true
+      afi-safi:
+      - name: vpnv4
+        enabled: true
+    vrf:
+    - name: vrf-cust
+      rd: 65000:2
+      afi-safi:
+        ipv4:
+          redistribute:
+            ospf: {}

--- a/bdd/tests/features/l3vpn_ospf_v4.feature
+++ b/bdd/tests/features/l3vpn_ospf_v4.feature
@@ -1,0 +1,86 @@
+@serial
+@l3vpn_ospf_v4
+Feature: MPLS/VPN L3VPN (IPv4) with OSPFv2 PE-CE both segments
+  As a service provider running RFC 4364 L3VPN over SR-MPLS
+  I want a full [C]-[CE]-[PE]-[P]-[PE]-[CE]-[C] topology where both the
+  C-CE and PE-CE segments run OSPFv2 and the PE does two-way
+  redistribution (OSPF<->VPNv4), so that C1 and C2 can reach each other's
+  loopback across the MPLS/VPN core.
+
+  Same core as @l3vpn_bgp_v4 (IS-IS L2 + SR-MPLS, iBGP VPNv4). The
+  customer side runs OSPFv2 in area 0 (C-CE and CE-PE). The PE:
+  - `router bgp vrf ... redistribute ospf` carries the customer routes
+    OSPF learned from the CE up into VPNv4 (up direction);
+  - `router ospf vrf ... redistribute bgp` injects the VPNv4 routes
+    imported into the VRF back into the CE-facing OSPF as Type-5
+    AS-External LSAs (down direction — the feature added for this).
+
+  Scenario: Build the L3VPN topology and bring up the core
+    Given a clean test environment
+    When I create namespace "c1"
+    And I create namespace "ce1"
+    And I create namespace "pe1"
+    And I create namespace "p"
+    And I create namespace "pe2"
+    And I create namespace "ce2"
+    And I create namespace "c2"
+    And I connect namespace "c1" interface "ce1" to namespace "ce1" interface "c1"
+    And I connect namespace "ce1" interface "pe1" to namespace "pe1" interface "ce1"
+    And I connect namespace "pe1" interface "p" to namespace "p" interface "pe1"
+    And I connect namespace "p" interface "pe2" to namespace "pe2" interface "p"
+    And I connect namespace "pe2" interface "ce2" to namespace "ce2" interface "pe2"
+    And I connect namespace "ce2" interface "c2" to namespace "c2" interface "ce2"
+    And I start zebra-rs in namespace "c1"
+    And I start zebra-rs in namespace "ce1"
+    And I start zebra-rs in namespace "pe1"
+    And I start zebra-rs in namespace "p"
+    And I start zebra-rs in namespace "pe2"
+    And I start zebra-rs in namespace "ce2"
+    And I start zebra-rs in namespace "c2"
+    And I apply config "c1.yaml" to namespace "c1"
+    And I apply config "ce1.yaml" to namespace "ce1"
+    And I apply config "pe1.yaml" to namespace "pe1"
+    And I apply config "p.yaml" to namespace "p"
+    And I apply config "pe2.yaml" to namespace "pe2"
+    And I apply config "ce2.yaml" to namespace "ce2"
+    And I apply config "c2.yaml" to namespace "c2"
+    And I wait 60 seconds for BGP to operate
+    Then isis neighbor in namespace "pe1" at level 2 on interface "p" should be up
+    And isis neighbor in namespace "pe2" at level 2 on interface "p" should be up
+
+  Scenario: Customer routes are carried as VPNv4 (OSPF -> BGP, up direction)
+    Given the test topology exists
+    Then BGP session in "pe1" to "1.1.1.3" should be "Established"
+    And BGP session in "pe2" to "1.1.1.1" should be "Established"
+    And show command "show bgp vpnv4" in namespace "pe1" should eventually contain "10.0.2.1/32"
+    And show command "show bgp vpnv4" in namespace "pe2" should eventually contain "10.0.1.1/32"
+
+  Scenario: Remote customer loopbacks reach the customer site (BGP -> OSPF, down direction)
+    Given the test topology exists
+    # PE1 injects the VPNv4-imported C2 loopback into the CE-facing OSPF;
+    # C1 learns it as an OSPF AS-External route.
+    Then show command "show ip route" in namespace "c1" should eventually contain "10.0.2.1"
+    And show command "show ip route" in namespace "c2" should eventually contain "10.0.1.1"
+
+  Scenario: End-to-end customer loopback reachability across the MPLS/VPN core
+    Given the test topology exists
+    Then ping from "c1" to "10.0.2.1" should eventually succeed
+    And ping from "c2" to "10.0.1.1" should eventually succeed
+
+  Scenario: Teardown topology
+    Given the test topology exists
+    When I stop zebra-rs in namespace "c1"
+    And I stop zebra-rs in namespace "ce1"
+    And I stop zebra-rs in namespace "pe1"
+    And I stop zebra-rs in namespace "p"
+    And I stop zebra-rs in namespace "pe2"
+    And I stop zebra-rs in namespace "ce2"
+    And I stop zebra-rs in namespace "c2"
+    And I delete namespace "c1"
+    And I delete namespace "ce1"
+    And I delete namespace "pe1"
+    And I delete namespace "p"
+    And I delete namespace "pe2"
+    And I delete namespace "ce2"
+    And I delete namespace "c2"
+    Then the test environment should be clean

--- a/zebra-rs/src/config/manager.rs
+++ b/zebra-rs/src/config/manager.rs
@@ -1724,6 +1724,42 @@ mod yang_load_tests {
         }
     }
 
+    /// Regression guard for OSPFv2 `redistribute bgp` (config.yang) at both
+    /// the instance level and the per-VRF instance level — the L3VPN PE-CE
+    /// down direction (PE injects VPNv4 routes into the CE-facing OSPF as
+    /// Type-5 AS-External LSAs). Pins the new paths so a broken container or
+    /// a stale callback registration is caught in the unit suite.
+    #[test]
+    fn ospf_redistribute_bgp_paths_parse() {
+        use crate::config::ExecCode;
+        use crate::config::parse::{State, parse};
+        use libyang::to_entry;
+
+        let mut yang = YangStore::new();
+        yang.add_path(concat!(env!("CARGO_MANIFEST_DIR"), "/yang"));
+        yang.read_with_resolve("configure")
+            .unwrap_or_else(|e| panic!("configure failed to load: {e:#}"));
+        yang.identity_resolve();
+        let module = yang.find_module("configure").unwrap();
+        let entry = to_entry(&yang, module);
+
+        for cmd in [
+            "set router ospf redistribute bgp",
+            "set router ospf redistribute bgp metric 30",
+            "set router ospf redistribute bgp metric-type type-1",
+            "set router ospf vrf vrf-cust redistribute bgp",
+            "set router ospf vrf vrf-cust redistribute bgp metric 30",
+            "set router ospf vrf vrf-cust redistribute connected",
+        ] {
+            let (code, _comps, _state) = parse(cmd, entry.clone(), None, State::new());
+            assert_eq!(
+                code,
+                ExecCode::Success,
+                "should parse as a settable path: {cmd}"
+            );
+        }
+    }
+
     /// Regression guard for the per-VRF MUP `route` list (zebra-bgp-vrf.yang).
     /// Both ST bindings now live under `afi-safi mup route {st1|st2}`
     /// (collapsed enum-keyed list): st1 (downlink / N6) and st2 (uplink /

--- a/zebra-rs/src/ospf/config.rs
+++ b/zebra-rs/src/ospf/config.rs
@@ -77,6 +77,12 @@ impl Ospf {
         );
         // Instance-level `router ospf { redistribute connected ... }`.
         self.ospf_add("/redistribute/connected", config_ospf_redist_connected);
+        self.ospf_add("/redistribute/bgp", config_ospf_redist_bgp);
+        self.ospf_add("/redistribute/bgp/metric", config_ospf_redist_bgp_metric);
+        self.ospf_add(
+            "/redistribute/bgp/metric-type",
+            config_ospf_redist_bgp_metric_type,
+        );
         self.ospf_add(
             "/redistribute/connected/metric",
             config_ospf_redist_connected_metric,
@@ -487,7 +493,12 @@ fn config_ospf_area_nssa_translator_role(
 /// whether the subscription should exist at all.
 fn ospf_send_redist_connected(ospf: &Ospf, first_time: bool) {
     use crate::rib::{Message as RibMsg, RedistAfi, RibType};
-    let proto = "ospf".to_string();
+    // Use this instance's proto label, not the literal "ospf": a per-VRF
+    // instance registers as "ospf:vrf:<name>", and the RIB routes the
+    // redistribute subscription by the proto string in the message. With
+    // the literal, a VRF child's subscription resolved to the default
+    // instance — so per-VRF redistribute never delivered. See proto_label.
+    let proto = ospf.proto_label.clone();
     let afi = RedistAfi::Ipv4;
     let rtype = RibType::Connected;
 
@@ -515,6 +526,81 @@ fn ospf_send_redist_connected(ospf: &Ospf, first_time: bool) {
         }
     };
     let _ = ospf.ctx.rib.send(msg);
+}
+
+/// Subscribe / unsubscribe this instance's RIB redistribution for the
+/// IPv4 BGP source, gated on the instance-level `redistribute bgp` knob.
+/// Independent of the connected subscription (each `(afi, rtype)` row is
+/// its own subscription). Uses `proto_label` so a per-VRF instance
+/// receives only its VRF's BGP routes.
+fn ospf_send_redist_bgp(ospf: &Ospf, first_time: bool) {
+    use crate::rib::{Message as RibMsg, RedistAfi, RibType};
+    let proto = ospf.proto_label.clone();
+    let afi = RedistAfi::Ipv4;
+    let rtype = RibType::Bgp;
+
+    let msg = if ospf.redist_bgp.is_none() {
+        RibMsg::RedistDel { proto, afi, rtype }
+    } else if first_time {
+        RibMsg::RedistAdd {
+            proto,
+            afi,
+            rtype,
+            subtypes: std::collections::BTreeSet::new(),
+        }
+    } else {
+        RibMsg::RedistUpdate {
+            proto,
+            afi,
+            rtype,
+            subtypes: std::collections::BTreeSet::new(),
+        }
+    };
+    let _ = ospf.ctx.rib.send(msg);
+}
+
+/// `/router/ospf/redistribute/bgp` — instance-level presence container.
+/// On Set: subscribe to the VRF's BGP routes and originate a Type-5
+/// AS-External LSA for each. On Delete: unsubscribe and flush them.
+fn config_ospf_redist_bgp(ospf: &mut Ospf, _args: Args, op: ConfigOp) -> Option<()> {
+    let first_time = ospf.redist_bgp.is_none();
+    if op.is_set() {
+        ospf.redist_bgp = Some(RedistEntry {
+            metric: RedistEntry::DEFAULT_METRIC,
+            ..Default::default()
+        });
+    } else {
+        ospf.redist_bgp = None;
+    }
+    ospf_send_redist_bgp(ospf, first_time && op.is_set());
+    ospf.as_external_redist_bgp_resync();
+    Some(())
+}
+
+/// `/router/ospf/redistribute/bgp/metric`.
+fn config_ospf_redist_bgp_metric(ospf: &mut Ospf, mut args: Args, op: ConfigOp) -> Option<()> {
+    let metric = if op.is_set() {
+        args.u32()?
+    } else {
+        RedistEntry::DEFAULT_METRIC
+    };
+    ospf.redist_bgp.get_or_insert_with(Default::default).metric = metric;
+    ospf.as_external_redist_bgp_resync();
+    Some(())
+}
+
+/// `/router/ospf/redistribute/bgp/metric-type`.
+fn config_ospf_redist_bgp_metric_type(ospf: &mut Ospf, mut args: Args, op: ConfigOp) -> Option<()> {
+    let mtype = if op.is_set() {
+        ExternalMetricType::from_yang(&args.string()?)?
+    } else {
+        ExternalMetricType::default()
+    };
+    ospf.redist_bgp
+        .get_or_insert_with(Default::default)
+        .metric_type = mtype;
+    ospf.as_external_redist_bgp_resync();
+    Some(())
 }
 
 /// `/router/ospf/area/<id>/redistribute/connected` — presence

--- a/zebra-rs/src/ospf/inst.rs
+++ b/zebra-rs/src/ospf/inst.rs
@@ -286,6 +286,14 @@ pub struct Ospf<V: OspfVersion = Ospfv2> {
     /// Prefixes of Type-5 LSAs we self-originated from instance-level
     /// `redistribute connected`. Flushed when the knob is removed.
     pub redist_connected_originated: BTreeSet<Ipv4Net>,
+    /// Instance-level `redistribute bgp` — originates Type-5 AS-External
+    /// LSAs (FA=0) for every BGP route from `redist_v4`. In a per-VRF
+    /// OSPF instance this injects the VPNv4 routes BGP imported into the
+    /// VRF into the CE-facing OSPF (the L3VPN PE-CE down direction).
+    pub redist_bgp: Option<crate::ospf::area::RedistEntry>,
+    /// Prefixes of Type-5 LSAs we self-originated from instance-level
+    /// `redistribute bgp`. Flushed when the knob is removed.
+    pub redist_bgp_originated: BTreeSet<Ipv4Net>,
     /// Staged Flexible Algorithm definitions for this instance
     /// (`/router/ospf{,v3}/flex-algo`, RFC 9350). Shared staging engine
     /// keyed by the version's `FLEX_ALGO_PREFIX`; origination from the
@@ -1219,6 +1227,8 @@ impl Ospf<Ospfv2> {
             redist_v6: BTreeMap::new(),
             redist_connected: None,
             redist_connected_originated: BTreeSet::new(),
+            redist_bgp: None,
+            redist_bgp_originated: BTreeSet::new(),
             flex_algo: crate::flex_algo::FlexAlgoConfig::new(Ospfv2::FLEX_ALGO_PREFIX),
             affinity_map: crate::flex_algo::AffinityMap::new(),
             srlg_config: crate::flex_algo::SrlgGroupBuilder::new(),
@@ -2488,6 +2498,52 @@ impl Ospf<Ospfv2> {
         self.router_lsa_originate();
     }
 
+    /// `redistribute bgp` sibling of
+    /// [`Self::as_external_redist_connected_resync`]: rebuild this
+    /// instance's self-originated Type-5 AS-External LSAs for the cached
+    /// BGP routes (`redist_v4` entries with `rtype == RibType::Bgp`),
+    /// diffing against `redist_bgp_originated`. In a per-VRF OSPF instance
+    /// these are the VPNv4 routes BGP imported into the VRF — injecting
+    /// them into the CE-facing OSPF is the L3VPN PE-CE down direction.
+    pub fn as_external_redist_bgp_resync(&mut self) {
+        use crate::rib::RibType;
+
+        let entry = self.redist_bgp;
+        let prev_originated = self.redist_bgp_originated.clone();
+
+        let desired: BTreeSet<Ipv4Net> = if entry.is_some() {
+            self.redist_v4
+                .iter()
+                .filter(|((rtype, _), _)| *rtype == RibType::Bgp)
+                .map(|((_, prefix), _)| *prefix)
+                .collect()
+        } else {
+            BTreeSet::new()
+        };
+
+        for prefix in prev_originated
+            .difference(&desired)
+            .copied()
+            .collect::<Vec<_>>()
+        {
+            self.as_external_lsa_flush_for_prefix(prefix);
+            self.redist_bgp_originated.remove(&prefix);
+        }
+
+        if let Some(redist_entry) = entry {
+            for prefix in &desired {
+                self.as_external_lsa_originate_for_prefix(
+                    *prefix,
+                    redist_entry.metric,
+                    redist_entry.metric_type.is_type_2(),
+                );
+                self.redist_bgp_originated.insert(*prefix);
+            }
+        }
+
+        self.router_lsa_originate();
+    }
+
     /// RFC 3101 §2.3 NSSA default-LSA origination. Thin wrapper
     /// around `nssa_lsa_originate_for_prefix` that gates on area
     /// type + `nssa_default_originate` knob and calls the generic
@@ -2896,6 +2952,7 @@ impl Ospf<Ospfv2> {
             self.nssa_redist_connected_resync(area_id);
         }
         self.as_external_redist_connected_resync();
+        self.as_external_redist_bgp_resync();
     }
 
     /// `RibRx::RouteDel` handler. Mirror of `route_redist_add`.
@@ -2911,6 +2968,7 @@ impl Ospf<Ospfv2> {
             self.nssa_redist_connected_resync(area_id);
         }
         self.as_external_redist_connected_resync();
+        self.as_external_redist_bgp_resync();
     }
 
     fn process_lsdb(&mut self, ev: LsdbEvent, area_id: Option<Ipv4Addr>, key: OspfLsaKey) {
@@ -5362,6 +5420,8 @@ impl Ospf<Ospfv3> {
             redist_v6: BTreeMap::new(),
             redist_connected: None,
             redist_connected_originated: BTreeSet::new(),
+            redist_bgp: None,
+            redist_bgp_originated: BTreeSet::new(),
             flex_algo: crate::flex_algo::FlexAlgoConfig::new(Ospfv3::FLEX_ALGO_PREFIX),
             affinity_map: crate::flex_algo::AffinityMap::new(),
             srlg_config: crate::flex_algo::SrlgGroupBuilder::new(),

--- a/zebra-rs/yang/config.yang
+++ b/zebra-rs/yang/config.yang
@@ -518,6 +518,22 @@ module config {
               default type-2;
             }
           }
+          container bgp {
+            presence "Redistribute BGP routes as Type-5 AS-External LSAs";
+            leaf metric {
+              type uint32 {
+                range "0..16777214";
+              }
+              default 20;
+            }
+            leaf metric-type {
+              type enumeration {
+                enum type-1;
+                enum type-2;
+              }
+              default type-2;
+            }
+          }
         }
         list area {
           // Area key accepts either a plain decimal (`area 0`) or a
@@ -1019,6 +1035,45 @@ module config {
           }
           leaf router-id {
             type inet:ipv4-address;
+          }
+          // Instance-level redistribution into Type-5 AS-External LSAs,
+          // forwarded to the per-VRF instance (prefix stripped) and hitting
+          // the same callbacks as the default instance. `redistribute bgp`
+          // lets a PE inject VPNv4 routes it imported into this VRF into the
+          // CE-facing OSPF (the L3VPN PE-CE down direction).
+          container redistribute {
+            container connected {
+              presence "Redistribute connected routes as Type-5 AS-External LSAs";
+              leaf metric {
+                type uint32 {
+                  range "0..16777214";
+                }
+                default 20;
+              }
+              leaf metric-type {
+                type enumeration {
+                  enum type-1;
+                  enum type-2;
+                }
+                default type-2;
+              }
+            }
+            container bgp {
+              presence "Redistribute BGP routes as Type-5 AS-External LSAs";
+              leaf metric {
+                type uint32 {
+                  range "0..16777214";
+                }
+                default 20;
+              }
+              leaf metric-type {
+                type enumeration {
+                  enum type-1;
+                  enum type-2;
+                }
+                default type-2;
+              }
+            }
           }
           list area {
             key "area-id";


### PR DESCRIPTION
## Summary

Adds **OSPFv2 `redistribute bgp`** and uses it to build the OSPFv2 PE-CE phase of the L3VPN BDD matrix. This is the MPLS L3VPN OSPF PE-CE **down** direction (a PE injects the VPNv4 routes it imports into a VRF into the CE-facing OSPF as Type-5 AS-External LSAs), which zebra-rs previously couldn't do (OSPFv2 only had `redistribute connected`).

### Core feature (`ospf:` commit)
- **YANG**: `container bgp` (metric / metric-type) under `/router/ospf/redistribute`, plus a new instance-level `redistribute` (connected + bgp) under the OSPFv2 `vrf` list.
- **config/runtime**: `config_ospf_redist_bgp[_metric|_metric_type]` + registration; new `redist_bgp` / `redist_bgp_originated` on `Ospf`; `as_external_redist_bgp_resync` mirroring the connected resync but filtering `RibType::Bgp`; wired into `route_redist_add`/`del`. The RIB needs no change — `RibType::Bgp` already exists and BGP already tags VRF routes with it.
- **Prerequisite bug fix**: the redistribute subscription hardcoded the proto string `"ospf"` instead of `ospf.proto_label`, so a **per-VRF** OSPF instance's subscription resolved to the *default* instance and delivered nothing — per-VRF `redistribute connected` was effectively non-functional. Now uses `proto_label` so the RIB routes the subscription (and its VRF-scoped walk + deltas) to the right instance.

### BDD (`bdd:` commit)
`l3vpn_ospf_v4` — OSPFv2 on both the C-CE and PE-CE segments over the SR-MPLS VPNv4 core; the PE does two-way redistribution (`redistribute ospf`→VPNv4 up, `redistribute bgp`→OSPF down). C1↔C2 loopback ping crosses the core; the remote loopback arrives at the customer as an OSPF AS-External route.

## Test plan
- `cargo fmt`, `cargo clippy --workspace --all-targets -- -D warnings` — clean.
- Unit: 85 ospf + 45 yang_load pass, incl. a new `ospf_redistribute_bgp_paths_parse` guard.
- BDD (local): `@l3vpn_ospf_v4` stable 5/5 across repeated runs (BDD excluded from CI).

## Follow-ups
OSPFv3 instance-level AS-External `redistribute bgp` (net-new for v3) + the v6/SRv6 OSPF BDD; the OSPF "C-CE OSPF + BGP PE-CE" variant; the IS-IS PE-CE phase (IS-IS already has `redistribute bgp`).

Generated with [Claude Code](https://claude.com/claude-code)