### PR TITLE
isis: per-VRF redist proto fix; L3VPN IS-IS PE-CE BDD (v4+v6)

### DIFF
--- a/bdd/tests/configs/l3vpn_isis_v4/c1.yaml
+++ b/bdd/tests/configs/l3vpn_isis_v4/c1.yaml
@@ -1,0 +1,26 @@
+# C1 — customer site 1. IS-IS L2 to CE1; redistributes its connected
+# routes (loopback 10.0.1.1/32 + the C-CE link) into IS-IS, which reach
+# the PE through CE1.
+interface:
+- if-name: lo
+  ipv4:
+    address: 10.0.1.1/32
+- if-name: ce1
+  ipv4:
+    address: 10.1.0.1/30
+router:
+  isis:
+    net: 49.0001.0000.0000.0011.00
+    hostname: c1
+    is-type: level-2-only
+    afi-safi:
+    - name: ipv4
+      redistribute:
+        connected: {}
+    interface:
+    - if-name: ce1
+      circuit-type: level-2-only
+      network-type: point-to-point
+      metric: 10
+      ipv4:
+        enable: true

--- a/bdd/tests/configs/l3vpn_isis_v4/c2.yaml
+++ b/bdd/tests/configs/l3vpn_isis_v4/c2.yaml
@@ -1,0 +1,25 @@
+# C2 — customer site 2. Mirror of C1: IS-IS L2 to CE2, redistribute
+# connected (loopback 10.0.2.1/32 + C-CE link) into IS-IS.
+interface:
+- if-name: lo
+  ipv4:
+    address: 10.0.2.1/32
+- if-name: ce2
+  ipv4:
+    address: 10.2.0.1/30
+router:
+  isis:
+    net: 49.0001.0000.0000.0021.00
+    hostname: c2
+    is-type: level-2-only
+    afi-safi:
+    - name: ipv4
+      redistribute:
+        connected: {}
+    interface:
+    - if-name: ce2
+      circuit-type: level-2-only
+      network-type: point-to-point
+      metric: 10
+      ipv4:
+        enable: true

--- a/bdd/tests/configs/l3vpn_isis_v4/ce1.yaml
+++ b/bdd/tests/configs/l3vpn_isis_v4/ce1.yaml
@@ -1,0 +1,28 @@
+# CE1 — customer edge 1. Transit IS-IS L2 router peering with C1 and PE1
+# on its two point-to-point links; carries C1's routes up to PE1 and
+# PE1's redistributed remote routes down to C1.
+interface:
+- if-name: c1
+  ipv4:
+    address: 10.1.0.2/30
+- if-name: pe1
+  ipv4:
+    address: 10.1.0.5/30
+router:
+  isis:
+    net: 49.0001.0000.0000.0012.00
+    hostname: ce1
+    is-type: level-2-only
+    interface:
+    - if-name: c1
+      circuit-type: level-2-only
+      network-type: point-to-point
+      metric: 10
+      ipv4:
+        enable: true
+    - if-name: pe1
+      circuit-type: level-2-only
+      network-type: point-to-point
+      metric: 10
+      ipv4:
+        enable: true

--- a/bdd/tests/configs/l3vpn_isis_v4/ce2.yaml
+++ b/bdd/tests/configs/l3vpn_isis_v4/ce2.yaml
@@ -1,0 +1,26 @@
+# CE2 — customer edge 2. Mirror of CE1: transit IS-IS L2 between C2 and PE2.
+interface:
+- if-name: c2
+  ipv4:
+    address: 10.2.0.2/30
+- if-name: pe2
+  ipv4:
+    address: 10.2.0.5/30
+router:
+  isis:
+    net: 49.0001.0000.0000.0022.00
+    hostname: ce2
+    is-type: level-2-only
+    interface:
+    - if-name: c2
+      circuit-type: level-2-only
+      network-type: point-to-point
+      metric: 10
+      ipv4:
+        enable: true
+    - if-name: pe2
+      circuit-type: level-2-only
+      network-type: point-to-point
+      metric: 10
+      ipv4:
+        enable: true

--- a/bdd/tests/configs/l3vpn_isis_v4/p.yaml
+++ b/bdd/tests/configs/l3vpn_isis_v4/p.yaml
@@ -1,0 +1,36 @@
+# P — provider core transit LSR (runs no BGP). Pure IS-IS L2 + SR-MPLS;
+# performs the SR label swap / PHP between PE1 (sid 1 -> 16001) and PE2
+# (sid 3 -> 16003).
+interface:
+- if-name: lo
+  ipv4:
+    address: 1.1.1.2/32
+- if-name: pe1
+  ipv4:
+    address: 10.250.0.2/30
+- if-name: pe2
+  ipv4:
+    address: 10.250.0.5/30
+router:
+  isis:
+    net: 49.0000.0000.0000.0002.00
+    hostname: p
+    is-type: level-2-only
+    segment-routing: mpls
+    te-router-id: 1.1.1.2
+    interface:
+    - if-name: lo
+      ipv4:
+        enable: true
+        prefix-sid:
+          index: 2
+    - if-name: pe1
+      network-type: point-to-point
+      metric: 10
+      ipv4:
+        enable: true
+    - if-name: pe2
+      network-type: point-to-point
+      metric: 10
+      ipv4:
+        enable: true

--- a/bdd/tests/configs/l3vpn_isis_v4/pe1.yaml
+++ b/bdd/tests/configs/l3vpn_isis_v4/pe1.yaml
@@ -1,0 +1,80 @@
+# PE1 — provider edge 1 (AS 65000). Two IS-IS instances: the GLOBAL core
+# (IS-IS L2 + SR-MPLS underlay to PE2 via P) and a per-VRF IS-IS in
+# vrf-cust for the PE-CE link to CE1. iBGP VPNv4 to PE2. Two-way
+# redistribution in the VRF:
+#   - up:   router bgp vrf ... redistribute isis  -> VPNv4 carries the
+#           customer routes IS-IS learned from CE1.
+#   - down: router isis vrf ... redistribute bgp  -> the VPNv4 routes
+#           imported into the VRF are injected into the CE-facing IS-IS.
+vrf:
+- name: vrf-cust
+  ipv4:
+    route-target:
+      import:
+      - 65000:100
+      export:
+      - 65000:100
+interface:
+- if-name: lo
+  ipv4:
+    address: 1.1.1.1/32
+- if-name: p
+  ipv4:
+    address: 10.250.0.1/30
+- if-name: ce1
+  vrf: vrf-cust
+  ipv4:
+    address: 10.1.0.6/30
+router:
+  isis:
+    net: 49.0000.0000.0000.0001.00
+    hostname: pe1
+    is-type: level-2-only
+    segment-routing: mpls
+    te-router-id: 1.1.1.1
+    interface:
+    - if-name: lo
+      ipv4:
+        enable: true
+        prefix-sid:
+          index: 1
+    - if-name: p
+      network-type: point-to-point
+      metric: 10
+      ipv4:
+        enable: true
+    vrf:
+    - name: vrf-cust
+      net: 49.0001.0000.0000.0013.00
+      is-type: level-2-only
+      afi-safi:
+      - name: ipv4
+        redistribute:
+          bgp: {}
+      interface:
+      - if-name: ce1
+        circuit-type: level-2-only
+        network-type: point-to-point
+        metric: 10
+        ipv4:
+          enable: true
+  bgp:
+    global:
+      as: 65000
+      router-id: 1.1.1.1
+    neighbor:
+    - remote-address: 1.1.1.3
+      remote-as: 65000
+      timers: {connect-retry-time: 3}
+      update-source: 1.1.1.1
+      enabled: true
+      afi-safi:
+      - name: vpnv4
+        enabled: true
+    vrf:
+    - name: vrf-cust
+      rd: 65000:1
+      afi-safi:
+        ipv4:
+          redistribute:
+            isis: {}

--- a/bdd/tests/configs/l3vpn_isis_v4/pe2.yaml
+++ b/bdd/tests/configs/l3vpn_isis_v4/pe2.yaml
@@ -1,0 +1,76 @@
+# PE2 — provider edge 2 (AS 65000). Mirror of PE1: core IS-IS+SR-MPLS
+# (Prefix-SID index 3), iBGP VPNv4 to PE1, per-VRF IS-IS to CE2 with
+# two-way redistribution (redistribute isis -> VPNv4 up, redistribute bgp
+# -> IS-IS down).
+vrf:
+- name: vrf-cust
+  ipv4:
+    route-target:
+      import:
+      - 65000:100
+      export:
+      - 65000:100
+interface:
+- if-name: lo
+  ipv4:
+    address: 1.1.1.3/32
+- if-name: p
+  ipv4:
+    address: 10.250.0.6/30
+- if-name: ce2
+  vrf: vrf-cust
+  ipv4:
+    address: 10.2.0.6/30
+router:
+  isis:
+    net: 49.0000.0000.0000.0003.00
+    hostname: pe2
+    is-type: level-2-only
+    segment-routing: mpls
+    te-router-id: 1.1.1.3
+    interface:
+    - if-name: lo
+      ipv4:
+        enable: true
+        prefix-sid:
+          index: 3
+    - if-name: p
+      network-type: point-to-point
+      metric: 10
+      ipv4:
+        enable: true
+    vrf:
+    - name: vrf-cust
+      net: 49.0001.0000.0000.0023.00
+      is-type: level-2-only
+      afi-safi:
+      - name: ipv4
+        redistribute:
+          bgp: {}
+      interface:
+      - if-name: ce2
+        circuit-type: level-2-only
+        network-type: point-to-point
+        metric: 10
+        ipv4:
+          enable: true
+  bgp:
+    global:
+      as: 65000
+      router-id: 1.1.1.3
+    neighbor:
+    - remote-address: 1.1.1.1
+      remote-as: 65000
+      timers: {connect-retry-time: 3}
+      update-source: 1.1.1.3
+      enabled: true
+      afi-safi:
+      - name: vpnv4
+        enabled: true
+    vrf:
+    - name: vrf-cust
+      rd: 65000:2
+      afi-safi:
+        ipv4:
+          redistribute:
+            isis: {}

--- a/bdd/tests/configs/l3vpn_isis_v6/c1.yaml
+++ b/bdd/tests/configs/l3vpn_isis_v6/c1.yaml
@@ -1,0 +1,25 @@
+# C1 — customer site 1. IS-IS L2 (IPv6) to CE1; redistributes connected
+# (loopback 2001:db8:c1::1/128 + the C-CE link) into IS-IS.
+interface:
+- if-name: lo
+  ipv6:
+    address: 2001:db8:c1::1/128
+- if-name: ce1
+  ipv6:
+    address: 2001:db8:1c::1/64
+router:
+  isis:
+    net: 49.0001.0000.0000.0011.00
+    hostname: c1
+    is-type: level-2-only
+    afi-safi:
+    - name: ipv6
+      redistribute:
+        connected: {}
+    interface:
+    - if-name: ce1
+      circuit-type: level-2-only
+      network-type: point-to-point
+      metric: 10
+      ipv6:
+        enable: true

--- a/bdd/tests/configs/l3vpn_isis_v6/c2.yaml
+++ b/bdd/tests/configs/l3vpn_isis_v6/c2.yaml
@@ -1,0 +1,25 @@
+# C2 — customer site 2. Mirror of C1: IS-IS L2 (IPv6) to CE2,
+# redistribute connected (loopback 2001:db8:c2::1/128 + C-CE link).
+interface:
+- if-name: lo
+  ipv6:
+    address: 2001:db8:c2::1/128
+- if-name: ce2
+  ipv6:
+    address: 2001:db8:2c::1/64
+router:
+  isis:
+    net: 49.0001.0000.0000.0021.00
+    hostname: c2
+    is-type: level-2-only
+    afi-safi:
+    - name: ipv6
+      redistribute:
+        connected: {}
+    interface:
+    - if-name: ce2
+      circuit-type: level-2-only
+      network-type: point-to-point
+      metric: 10
+      ipv6:
+        enable: true

--- a/bdd/tests/configs/l3vpn_isis_v6/ce1.yaml
+++ b/bdd/tests/configs/l3vpn_isis_v6/ce1.yaml
@@ -1,0 +1,26 @@
+# CE1 — customer edge 1. Transit IS-IS L2 (IPv6) between C1 and PE1.
+interface:
+- if-name: c1
+  ipv6:
+    address: 2001:db8:1c::2/64
+- if-name: pe1
+  ipv6:
+    address: 2001:db8:1e::1/64
+router:
+  isis:
+    net: 49.0001.0000.0000.0012.00
+    hostname: ce1
+    is-type: level-2-only
+    interface:
+    - if-name: c1
+      circuit-type: level-2-only
+      network-type: point-to-point
+      metric: 10
+      ipv6:
+        enable: true
+    - if-name: pe1
+      circuit-type: level-2-only
+      network-type: point-to-point
+      metric: 10
+      ipv6:
+        enable: true

--- a/bdd/tests/configs/l3vpn_isis_v6/ce2.yaml
+++ b/bdd/tests/configs/l3vpn_isis_v6/ce2.yaml
@@ -1,0 +1,27 @@
+# CE2 — customer edge 2. Mirror of CE1: transit IS-IS L2 (IPv6) between
+# C2 and PE2.
+interface:
+- if-name: c2
+  ipv6:
+    address: 2001:db8:2c::2/64
+- if-name: pe2
+  ipv6:
+    address: 2001:db8:2e::1/64
+router:
+  isis:
+    net: 49.0001.0000.0000.0022.00
+    hostname: ce2
+    is-type: level-2-only
+    interface:
+    - if-name: c2
+      circuit-type: level-2-only
+      network-type: point-to-point
+      metric: 10
+      ipv6:
+        enable: true
+    - if-name: pe2
+      circuit-type: level-2-only
+      network-type: point-to-point
+      metric: 10
+      ipv6:
+        enable: true

--- a/bdd/tests/configs/l3vpn_isis_v6/p.yaml
+++ b/bdd/tests/configs/l3vpn_isis_v6/p.yaml
@@ -1,0 +1,33 @@
+# P — provider core transit (runs no BGP, no SRv6). Pure IS-IS L2 with
+# IPv6 enabled; learns the PE loopbacks (/128) and SRv6 locators (/48)
+# via IS-IS and natively forwards the SRv6-encapsulated transit traffic
+# between PE1 and PE2.
+interface:
+- if-name: lo
+  ipv6:
+    address: 2001:db8::2/128
+- if-name: pe1
+  ipv6:
+    address: 2001:db8:cafe:1::2/64
+- if-name: pe2
+  ipv6:
+    address: 2001:db8:cafe:2::1/64
+router:
+  isis:
+    net: 49.0000.0000.0000.0002.00
+    hostname: p
+    is-type: level-2-only
+    interface:
+    - if-name: lo
+      ipv6:
+        enable: true
+    - if-name: pe1
+      network-type: point-to-point
+      metric: 10
+      ipv6:
+        enable: true
+    - if-name: pe2
+      network-type: point-to-point
+      metric: 10
+      ipv6:
+        enable: true

--- a/bdd/tests/configs/l3vpn_isis_v6/pe1.yaml
+++ b/bdd/tests/configs/l3vpn_isis_v6/pe1.yaml
@@ -1,0 +1,84 @@
+# PE1 — provider edge 1 (AS 65000). Global IS-IS L2 SRv6 core to PE2 via
+# P; iBGP VPNv6. Per-VRF IS-IS (IPv6) in vrf-cust toward CE1 with two-way
+# redistribution: redistribute isis -> VPNv6 (up), redistribute bgp ->
+# IS-IS (down). The VRF carries End.DT46 (encapsulation srv6).
+vrf:
+- name: vrf-cust
+  ipv6:
+    route-target:
+      import:
+      - 65000:100
+      export:
+      - 65000:100
+interface:
+- if-name: lo
+  ipv6:
+    address: 2001:db8::1/128
+- if-name: p
+  ipv6:
+    address: 2001:db8:cafe:1::1/64
+- if-name: ce1
+  vrf: vrf-cust
+  ipv6:
+    address: 2001:db8:1e::2/64
+segment-routing:
+  locator:
+  - name: LOC1
+    prefix: fcbb:bbbb:1::/48
+    behavior: usid
+router:
+  isis:
+    net: 49.0000.0000.0000.0001.00
+    hostname: pe1
+    is-type: level-2-only
+    segment-routing:
+      srv6:
+        locator: LOC1
+    interface:
+    - if-name: lo
+      ipv6:
+        enable: true
+    - if-name: p
+      network-type: point-to-point
+      metric: 10
+      ipv6:
+        enable: true
+    vrf:
+    - name: vrf-cust
+      net: 49.0001.0000.0000.0013.00
+      is-type: level-2-only
+      afi-safi:
+      - name: ipv6
+        redistribute:
+          bgp: {}
+      interface:
+      - if-name: ce1
+        circuit-type: level-2-only
+        network-type: point-to-point
+        metric: 10
+        ipv6:
+          enable: true
+  bgp:
+    global:
+      as: 65000
+      router-id: 1.1.1.1
+    segment-routing:
+      srv6:
+        locator: LOC1
+    neighbor:
+    - remote-address: 2001:db8::3
+      remote-as: 65000
+      timers: {connect-retry-time: 3}
+      update-source: 2001:db8::1
+      enabled: true
+      afi-safi:
+      - name: vpnv6
+        enabled: true
+    vrf:
+    - name: vrf-cust
+      rd: 65000:1
+      encapsulation: srv6
+      afi-safi:
+        ipv6:
+          redistribute:
+            isis: {}

--- a/bdd/tests/configs/l3vpn_isis_v6/pe2.yaml
+++ b/bdd/tests/configs/l3vpn_isis_v6/pe2.yaml
@@ -1,0 +1,84 @@
+# PE2 — provider edge 2 (AS 65000). Mirror of PE1: SRv6 locator LOC2,
+# iBGP VPNv6 to PE1, per-VRF IS-IS (IPv6) to CE2 with two-way
+# redistribution (redistribute isis -> VPNv6 up, redistribute bgp ->
+# IS-IS down).
+vrf:
+- name: vrf-cust
+  ipv6:
+    route-target:
+      import:
+      - 65000:100
+      export:
+      - 65000:100
+interface:
+- if-name: lo
+  ipv6:
+    address: 2001:db8::3/128
+- if-name: p
+  ipv6:
+    address: 2001:db8:cafe:2::2/64
+- if-name: ce2
+  vrf: vrf-cust
+  ipv6:
+    address: 2001:db8:2e::2/64
+segment-routing:
+  locator:
+  - name: LOC2
+    prefix: fcbb:bbbb:2::/48
+    behavior: usid
+router:
+  isis:
+    net: 49.0000.0000.0000.0003.00
+    hostname: pe2
+    is-type: level-2-only
+    segment-routing:
+      srv6:
+        locator: LOC2
+    interface:
+    - if-name: lo
+      ipv6:
+        enable: true
+    - if-name: p
+      network-type: point-to-point
+      metric: 10
+      ipv6:
+        enable: true
+    vrf:
+    - name: vrf-cust
+      net: 49.0001.0000.0000.0023.00
+      is-type: level-2-only
+      afi-safi:
+      - name: ipv6
+        redistribute:
+          bgp: {}
+      interface:
+      - if-name: ce2
+        circuit-type: level-2-only
+        network-type: point-to-point
+        metric: 10
+        ipv6:
+          enable: true
+  bgp:
+    global:
+      as: 65000
+      router-id: 1.1.1.3
+    segment-routing:
+      srv6:
+        locator: LOC2
+    neighbor:
+    - remote-address: 2001:db8::1
+      remote-as: 65000
+      timers: {connect-retry-time: 3}
+      update-source: 2001:db8::3
+      enabled: true
+      afi-safi:
+      - name: vpnv6
+        enabled: true
+    vrf:
+    - name: vrf-cust
+      rd: 65000:2
+      encapsulation: srv6
+      afi-safi:
+        ipv6:
+          redistribute:
+            isis: {}

--- a/bdd/tests/features/l3vpn_isis_v4.feature
+++ b/bdd/tests/features/l3vpn_isis_v4.feature
@@ -1,0 +1,84 @@
+@serial
+@l3vpn_isis_v4
+Feature: MPLS/VPN L3VPN (IPv4) with IS-IS PE-CE both segments
+  As a service provider running RFC 4364 L3VPN over SR-MPLS
+  I want a full [C]-[CE]-[PE]-[P]-[PE]-[CE]-[C] topology where both the
+  C-CE and PE-CE segments run IS-IS and the PE does two-way
+  redistribution (IS-IS<->VPNv4), so that C1 and C2 can reach each
+  other's loopback across the MPLS/VPN core.
+
+  The PE runs two IS-IS instances: the GLOBAL core (IS-IS L2 + SR-MPLS)
+  and a per-VRF IS-IS (vrf-cust) toward the CE. Up: `router bgp vrf ...
+  redistribute isis` -> VPNv4. Down: `router isis vrf ... redistribute
+  bgp` -> the VPNv4 routes imported into the VRF are injected into the
+  CE-facing IS-IS (IS-IS already supports redistribute bgp; only the
+  per-VRF redist subscription proto needed fixing).
+
+  Scenario: Build the L3VPN topology and bring up the core
+    Given a clean test environment
+    When I create namespace "c1"
+    And I create namespace "ce1"
+    And I create namespace "pe1"
+    And I create namespace "p"
+    And I create namespace "pe2"
+    And I create namespace "ce2"
+    And I create namespace "c2"
+    And I connect namespace "c1" interface "ce1" to namespace "ce1" interface "c1"
+    And I connect namespace "ce1" interface "pe1" to namespace "pe1" interface "ce1"
+    And I connect namespace "pe1" interface "p" to namespace "p" interface "pe1"
+    And I connect namespace "p" interface "pe2" to namespace "pe2" interface "p"
+    And I connect namespace "pe2" interface "ce2" to namespace "ce2" interface "pe2"
+    And I connect namespace "ce2" interface "c2" to namespace "c2" interface "ce2"
+    And I start zebra-rs in namespace "c1"
+    And I start zebra-rs in namespace "ce1"
+    And I start zebra-rs in namespace "pe1"
+    And I start zebra-rs in namespace "p"
+    And I start zebra-rs in namespace "pe2"
+    And I start zebra-rs in namespace "ce2"
+    And I start zebra-rs in namespace "c2"
+    And I apply config "c1.yaml" to namespace "c1"
+    And I apply config "ce1.yaml" to namespace "ce1"
+    And I apply config "pe1.yaml" to namespace "pe1"
+    And I apply config "p.yaml" to namespace "p"
+    And I apply config "pe2.yaml" to namespace "pe2"
+    And I apply config "ce2.yaml" to namespace "ce2"
+    And I apply config "c2.yaml" to namespace "c2"
+    And I wait 60 seconds for BGP to operate
+    # Core SR-MPLS adjacencies (global IS-IS).
+    Then isis neighbor in namespace "pe1" at level 2 on interface "p" should be up
+    And isis neighbor in namespace "pe2" at level 2 on interface "p" should be up
+
+  Scenario: Customer routes are carried as VPNv4 (IS-IS -> BGP, up direction)
+    Given the test topology exists
+    Then BGP session in "pe1" to "1.1.1.3" should be "Established"
+    And BGP session in "pe2" to "1.1.1.1" should be "Established"
+    And show command "show bgp vpnv4" in namespace "pe1" should eventually contain "10.0.2.1/32"
+    And show command "show bgp vpnv4" in namespace "pe2" should eventually contain "10.0.1.1/32"
+
+  Scenario: Remote customer loopbacks reach the customer site (BGP -> IS-IS, down direction)
+    Given the test topology exists
+    Then show command "show ip route" in namespace "c1" should eventually contain "10.0.2.1"
+    And show command "show ip route" in namespace "c2" should eventually contain "10.0.1.1"
+
+  Scenario: End-to-end customer loopback reachability across the MPLS/VPN core
+    Given the test topology exists
+    Then ping from "c1" to "10.0.2.1" should eventually succeed
+    And ping from "c2" to "10.0.1.1" should eventually succeed
+
+  Scenario: Teardown topology
+    Given the test topology exists
+    When I stop zebra-rs in namespace "c1"
+    And I stop zebra-rs in namespace "ce1"
+    And I stop zebra-rs in namespace "pe1"
+    And I stop zebra-rs in namespace "p"
+    And I stop zebra-rs in namespace "pe2"
+    And I stop zebra-rs in namespace "ce2"
+    And I stop zebra-rs in namespace "c2"
+    And I delete namespace "c1"
+    And I delete namespace "ce1"
+    And I delete namespace "pe1"
+    And I delete namespace "p"
+    And I delete namespace "pe2"
+    And I delete namespace "ce2"
+    And I delete namespace "c2"
+    Then the test environment should be clean

--- a/bdd/tests/features/l3vpn_isis_v6.feature
+++ b/bdd/tests/features/l3vpn_isis_v6.feature
@@ -1,0 +1,76 @@
+@serial
+@l3vpn_isis_v6
+Feature: SRv6 L3VPN (IPv6) with IS-IS PE-CE both segments
+  As a service provider running L3VPN over SRv6 (zebra-rs has no 6VPE)
+  I want a full [C]-[CE]-[PE]-[P]-[PE]-[CE]-[C] topology where both the
+  C-CE and PE-CE segments run IS-IS (IPv6) and the PE does two-way
+  redistribution (IS-IS<->VPNv6 over SRv6 End.DT46), so that C1 and C2
+  can reach each other's IPv6 loopback across the SRv6 core.
+
+  The PE runs the global IS-IS SRv6 core plus a per-VRF IS-IS (IPv6) to
+  the CE. Up: `router bgp vrf ... redistribute isis` -> VPNv6. Down:
+  `router isis vrf ... afi-safi ipv6 redistribute bgp` -> the VPNv6
+  routes imported into the VRF are injected into the CE-facing IS-IS.
+
+  Scenario: Build the SRv6 L3VPN topology and bring up the core
+    Given a clean test environment
+    When I create namespace "c1"
+    And I create namespace "ce1"
+    And I create namespace "pe1"
+    And I create namespace "p"
+    And I create namespace "pe2"
+    And I create namespace "ce2"
+    And I create namespace "c2"
+    And I connect namespace "c1" interface "ce1" to namespace "ce1" interface "c1"
+    And I connect namespace "ce1" interface "pe1" to namespace "pe1" interface "ce1"
+    And I connect namespace "pe1" interface "p" to namespace "p" interface "pe1"
+    And I connect namespace "p" interface "pe2" to namespace "pe2" interface "p"
+    And I connect namespace "pe2" interface "ce2" to namespace "ce2" interface "pe2"
+    And I connect namespace "ce2" interface "c2" to namespace "c2" interface "ce2"
+    And I start zebra-rs in namespace "c1"
+    And I start zebra-rs in namespace "ce1"
+    And I start zebra-rs in namespace "pe1"
+    And I start zebra-rs in namespace "p"
+    And I start zebra-rs in namespace "pe2"
+    And I start zebra-rs in namespace "ce2"
+    And I start zebra-rs in namespace "c2"
+    And I apply config "c1.yaml" to namespace "c1"
+    And I apply config "ce1.yaml" to namespace "ce1"
+    And I apply config "pe1.yaml" to namespace "pe1"
+    And I apply config "p.yaml" to namespace "p"
+    And I apply config "pe2.yaml" to namespace "pe2"
+    And I apply config "ce2.yaml" to namespace "ce2"
+    And I apply config "c2.yaml" to namespace "c2"
+    And I wait 60 seconds for BGP to operate
+    Then isis neighbor in namespace "pe1" at level 2 on interface "p" should be up
+    And isis neighbor in namespace "pe2" at level 2 on interface "p" should be up
+
+  Scenario: Customer routes are carried as VPNv6 (IS-IS -> BGP, up direction)
+    Given the test topology exists
+    Then BGP session in "pe1" to "2001:db8::3" should be "Established"
+    And BGP session in "pe2" to "2001:db8::1" should be "Established"
+    And show command "show bgp vpnv6" in namespace "pe1" should eventually contain "2001:db8:c2::1/128"
+    And show command "show bgp vpnv6" in namespace "pe2" should eventually contain "2001:db8:c1::1/128"
+
+  Scenario: End-to-end customer loopback reachability across the SRv6 core
+    Given the test topology exists
+    Then ping from "c1" to "2001:db8:c2::1" should eventually succeed
+    And ping from "c2" to "2001:db8:c1::1" should eventually succeed
+
+  Scenario: Teardown topology
+    Given the test topology exists
+    When I stop zebra-rs in namespace "c1"
+    And I stop zebra-rs in namespace "ce1"
+    And I stop zebra-rs in namespace "pe1"
+    And I stop zebra-rs in namespace "p"
+    And I stop zebra-rs in namespace "pe2"
+    And I stop zebra-rs in namespace "ce2"
+    And I stop zebra-rs in namespace "c2"
+    And I delete namespace "c1"
+    And I delete namespace "ce1"
+    And I delete namespace "pe1"
+    And I delete namespace "p"
+    And I delete namespace "pe2"
+    And I delete namespace "ce2"
+    And I delete namespace "c2"
+    Then the test environment should be clean

--- a/zebra-rs/src/isis/config.rs
+++ b/zebra-rs/src/isis/config.rs
@@ -1710,7 +1710,13 @@ fn wire_subtypes(
 fn send_redist(isis: &Isis, afi: IsisRedistAfi, src: IsisRedistSource, first_time: bool) {
     let wire_afi = wire_afi(afi);
     let rtype = wire_rtype(src);
-    let proto = "isis".to_string();
+    // Use this instance's proto label, not the literal "isis": a per-VRF
+    // instance registers as "isis:vrf:<name>", and the RIB routes the
+    // redistribute subscription by the proto string in the message. With
+    // the literal, a VRF child's subscription resolved to the default
+    // instance — so per-VRF redistribute never delivered. Mirrors the
+    // equivalent OSPF fix.
+    let proto = isis.proto_label.clone();
     let msg = match isis.config.redistribute.get(&(afi, src)) {
         None => crate::rib::Message::RedistDel {
             proto,


### PR DESCRIPTION
## Summary

Adds the **IS-IS PE-CE** phase of the L3VPN BDD matrix (both-segments, IPv4/MPLS + IPv6/SRv6) and fixes the per-VRF IS-IS redistribute bug that blocked it.

### Fix (`isis:` commit)
`send_redist` hardcoded the RIB redistribute subscription's proto string to the literal `"isis"` instead of `isis.proto_label`. The RIB routes a redistribute subscription by the proto string in the message, so a per-VRF IS-IS instance (registered as `isis:vrf:<name>`) had its subscription resolved to the **default** instance and delivered nothing — per-VRF `redistribute {connected,static,bgp,ospf}` was effectively non-functional. Now uses `proto_label`. (Same class of bug as the OSPF fix in #1686; IS-IS already had `redistribute bgp` wired — `RibType::Bgp` — so no other code change was needed.)

### BDD (`bdd:` commit)
`l3vpn_isis_v4` (MPLS/VPNv4) and `l3vpn_isis_v6` (SRv6/VPNv6, End.DT46): IS-IS on both the C-CE and PE-CE segments. The PE runs the global core IS-IS (SR-MPLS / SRv6) **plus** a per-VRF IS-IS to the CE, with two-way redistribution — `redistribute isis`→VPN (up) and `redistribute bgp`→IS-IS (down). C1↔C2 loopback ping crosses the core; remote loopbacks are learned at the customer via IS-IS.

## Test plan
- `cargo fmt`, `cargo clippy --workspace --all-targets -- -D warnings` — clean; 185 IS-IS unit tests pass.
- BDD (local): `@l3vpn_isis_v4` 5/5 and `@l3vpn_isis_v6` 4/4, stable across re-runs (BDD excluded from CI).

## Follow-ups
OSPFv3 instance-level AS-External `redistribute bgp` (net-new for v3) + the v6/SRv6 OSPF BDD; the optional "C-CE IGP + BGP PE-CE" second variant.

Generated with [Claude Code](https://claude.com/claude-code)