### PR TITLE
ospf: OSPFv3 AS-External redistribute bgp; L3VPN OSPFv3 PE-CE BDD

### DIFF
--- a/bdd/tests/configs/l3vpn_ospf_v6/c1.yaml
+++ b/bdd/tests/configs/l3vpn_ospf_v6/c1.yaml
@@ -1,0 +1,22 @@
+# C1 — customer site 1. OSPFv3 to CE1 (area 0). The loopback
+# 2001:db8:c1::1/128 and the C-CE link are advertised as intra-area
+# prefixes (OSPFv3 has no instance-level redistribute-connected; enabling
+# the interfaces in the area is the idiomatic way to originate them).
+interface:
+- if-name: lo
+  ipv6:
+    address: 2001:db8:c1::1/128
+- if-name: ce1
+  ipv6:
+    address: 2001:db8:1c::1/64
+router:
+  ospfv3:
+    router-id: 10.0.1.1
+    area:
+    - area-id: 0.0.0.0
+      interface:
+      - if-name: lo
+        enable: true
+      - if-name: ce1
+        enable: true
+        network-type: point-to-point

--- a/bdd/tests/configs/l3vpn_ospf_v6/c2.yaml
+++ b/bdd/tests/configs/l3vpn_ospf_v6/c2.yaml
@@ -1,0 +1,20 @@
+# C2 — customer site 2. Mirror of C1: OSPFv3 to CE2; loopback
+# 2001:db8:c2::1/128 + C-CE link advertised intra-area.
+interface:
+- if-name: lo
+  ipv6:
+    address: 2001:db8:c2::1/128
+- if-name: ce2
+  ipv6:
+    address: 2001:db8:2c::1/64
+router:
+  ospfv3:
+    router-id: 10.0.2.1
+    area:
+    - area-id: 0.0.0.0
+      interface:
+      - if-name: lo
+        enable: true
+      - if-name: ce2
+        enable: true
+        network-type: point-to-point

--- a/bdd/tests/configs/l3vpn_ospf_v6/ce1.yaml
+++ b/bdd/tests/configs/l3vpn_ospf_v6/ce1.yaml
@@ -1,0 +1,21 @@
+# CE1 — customer edge 1. Transit OSPFv3 router in area 0, peering with C1
+# and PE1 on its two point-to-point links.
+interface:
+- if-name: c1
+  ipv6:
+    address: 2001:db8:1c::2/64
+- if-name: pe1
+  ipv6:
+    address: 2001:db8:1e::1/64
+router:
+  ospfv3:
+    router-id: 10.1.0.5
+    area:
+    - area-id: 0.0.0.0
+      interface:
+      - if-name: c1
+        enable: true
+        network-type: point-to-point
+      - if-name: pe1
+        enable: true
+        network-type: point-to-point

--- a/bdd/tests/configs/l3vpn_ospf_v6/ce2.yaml
+++ b/bdd/tests/configs/l3vpn_ospf_v6/ce2.yaml
@@ -1,0 +1,21 @@
+# CE2 — customer edge 2. Mirror of CE1: transit OSPFv3 in area 0 between
+# C2 and PE2.
+interface:
+- if-name: c2
+  ipv6:
+    address: 2001:db8:2c::2/64
+- if-name: pe2
+  ipv6:
+    address: 2001:db8:2e::1/64
+router:
+  ospfv3:
+    router-id: 10.2.0.5
+    area:
+    - area-id: 0.0.0.0
+      interface:
+      - if-name: c2
+        enable: true
+        network-type: point-to-point
+      - if-name: pe2
+        enable: true
+        network-type: point-to-point

--- a/bdd/tests/configs/l3vpn_ospf_v6/p.yaml
+++ b/bdd/tests/configs/l3vpn_ospf_v6/p.yaml
@@ -1,0 +1,33 @@
+# P — provider core transit (runs no BGP, no SRv6). Pure IS-IS L2 with
+# IPv6 enabled; learns the PE loopbacks (/128) and SRv6 locators (/48)
+# via IS-IS and natively forwards the SRv6-encapsulated transit traffic
+# between PE1 and PE2.
+interface:
+- if-name: lo
+  ipv6:
+    address: 2001:db8::2/128
+- if-name: pe1
+  ipv6:
+    address: 2001:db8:cafe:1::2/64
+- if-name: pe2
+  ipv6:
+    address: 2001:db8:cafe:2::1/64
+router:
+  isis:
+    net: 49.0000.0000.0000.0002.00
+    hostname: p
+    is-type: level-2-only
+    interface:
+    - if-name: lo
+      ipv6:
+        enable: true
+    - if-name: pe1
+      network-type: point-to-point
+      metric: 10
+      ipv6:
+        enable: true
+    - if-name: pe2
+      network-type: point-to-point
+      metric: 10
+      ipv6:
+        enable: true

--- a/bdd/tests/configs/l3vpn_ospf_v6/pe1.yaml
+++ b/bdd/tests/configs/l3vpn_ospf_v6/pe1.yaml
@@ -1,0 +1,82 @@
+# PE1 — provider edge 1 (AS 65000). Global IS-IS L2 SRv6 core to PE2 via
+# P; iBGP VPNv6. Per-VRF OSPFv3 in vrf-cust toward CE1 with two-way
+# redistribution: redistribute ospf -> VPNv6 (up), redistribute bgp ->
+# OSPFv3 AS-External (down). The VRF carries End.DT46 (encapsulation srv6).
+vrf:
+- name: vrf-cust
+  ipv6:
+    route-target:
+      import:
+      - 65000:100
+      export:
+      - 65000:100
+interface:
+- if-name: lo
+  ipv6:
+    address: 2001:db8::1/128
+- if-name: p
+  ipv6:
+    address: 2001:db8:cafe:1::1/64
+- if-name: ce1
+  vrf: vrf-cust
+  ipv6:
+    address: 2001:db8:1e::2/64
+segment-routing:
+  locator:
+  - name: LOC1
+    prefix: fcbb:bbbb:1::/48
+    behavior: usid
+router:
+  isis:
+    net: 49.0000.0000.0000.0001.00
+    hostname: pe1
+    is-type: level-2-only
+    segment-routing:
+      srv6:
+        locator: LOC1
+    interface:
+    - if-name: lo
+      ipv6:
+        enable: true
+    - if-name: p
+      network-type: point-to-point
+      metric: 10
+      ipv6:
+        enable: true
+  ospfv3:
+    vrf:
+    - name: vrf-cust
+      router-id: 1.1.1.1
+      redistribute:
+        bgp:
+          metric: 20
+      area:
+      - area-id: 0.0.0.0
+        interface:
+        - if-name: ce1
+          enable: true
+          network-type: point-to-point
+  bgp:
+    global:
+      as: 65000
+      router-id: 1.1.1.1
+    segment-routing:
+      srv6:
+        locator: LOC1
+    neighbor:
+    - remote-address: 2001:db8::3
+      remote-as: 65000
+      timers: {connect-retry-time: 3}
+      update-source: 2001:db8::1
+      enabled: true
+      afi-safi:
+      - name: vpnv6
+        enabled: true
+    vrf:
+    - name: vrf-cust
+      rd: 65000:1
+      encapsulation: srv6
+      afi-safi:
+        ipv6:
+          redistribute:
+            ospf: {}

--- a/bdd/tests/configs/l3vpn_ospf_v6/pe2.yaml
+++ b/bdd/tests/configs/l3vpn_ospf_v6/pe2.yaml
@@ -1,0 +1,81 @@
+# PE2 — provider edge 2 (AS 65000). Mirror of PE1: SRv6 locator LOC2,
+# iBGP VPNv6 to PE1, per-VRF OSPFv3 to CE2 with two-way redistribution
+# (redistribute ospf -> VPNv6 up, redistribute bgp -> OSPFv3 down).
+vrf:
+- name: vrf-cust
+  ipv6:
+    route-target:
+      import:
+      - 65000:100
+      export:
+      - 65000:100
+interface:
+- if-name: lo
+  ipv6:
+    address: 2001:db8::3/128
+- if-name: p
+  ipv6:
+    address: 2001:db8:cafe:2::2/64
+- if-name: ce2
+  vrf: vrf-cust
+  ipv6:
+    address: 2001:db8:2e::2/64
+segment-routing:
+  locator:
+  - name: LOC2
+    prefix: fcbb:bbbb:2::/48
+    behavior: usid
+router:
+  isis:
+    net: 49.0000.0000.0000.0003.00
+    hostname: pe2
+    is-type: level-2-only
+    segment-routing:
+      srv6:
+        locator: LOC2
+    interface:
+    - if-name: lo
+      ipv6:
+        enable: true
+    - if-name: p
+      network-type: point-to-point
+      metric: 10
+      ipv6:
+        enable: true
+  ospfv3:
+    vrf:
+    - name: vrf-cust
+      router-id: 1.1.1.3
+      redistribute:
+        bgp:
+          metric: 20
+      area:
+      - area-id: 0.0.0.0
+        interface:
+        - if-name: ce2
+          enable: true
+          network-type: point-to-point
+  bgp:
+    global:
+      as: 65000
+      router-id: 1.1.1.3
+    segment-routing:
+      srv6:
+        locator: LOC2
+    neighbor:
+    - remote-address: 2001:db8::1
+      remote-as: 65000
+      timers: {connect-retry-time: 3}
+      update-source: 2001:db8::3
+      enabled: true
+      afi-safi:
+      - name: vpnv6
+        enabled: true
+    vrf:
+    - name: vrf-cust
+      rd: 65000:2
+      encapsulation: srv6
+      afi-safi:
+        ipv6:
+          redistribute:
+            ospf: {}

--- a/bdd/tests/features/l3vpn_ospf_v6.feature
+++ b/bdd/tests/features/l3vpn_ospf_v6.feature
@@ -1,0 +1,79 @@
+@serial
+@l3vpn_ospf_v6
+Feature: SRv6 L3VPN (IPv6) with OSPFv3 PE-CE both segments
+  As a service provider running L3VPN over SRv6 (zebra-rs has no 6VPE)
+  I want a full [C]-[CE]-[PE]-[P]-[PE]-[CE]-[C] topology where both the
+  C-CE and PE-CE segments run OSPFv3 and the PE does two-way
+  redistribution (OSPFv3<->VPNv6 over SRv6 End.DT46), so that C1 and C2
+  can reach each other's IPv6 loopback across the SRv6 core.
+
+  The PE runs the global IS-IS SRv6 core plus a per-VRF OSPFv3 to the CE.
+  Up: `router bgp vrf ... redistribute ospf` -> VPNv6. Down: `router
+  ospfv3 vrf ... redistribute bgp` -> the VPNv6 routes imported into the
+  VRF are injected into the CE-facing OSPFv3 as AS-External (Type-5)
+  LSAs (the net-new OSPFv3 feature added for this). The customer
+  loopbacks are advertised intra-area (OSPFv3 has no instance-level
+  redistribute-connected).
+
+  Scenario: Build the SRv6 L3VPN topology and bring up the core
+    Given a clean test environment
+    When I create namespace "c1"
+    And I create namespace "ce1"
+    And I create namespace "pe1"
+    And I create namespace "p"
+    And I create namespace "pe2"
+    And I create namespace "ce2"
+    And I create namespace "c2"
+    And I connect namespace "c1" interface "ce1" to namespace "ce1" interface "c1"
+    And I connect namespace "ce1" interface "pe1" to namespace "pe1" interface "ce1"
+    And I connect namespace "pe1" interface "p" to namespace "p" interface "pe1"
+    And I connect namespace "p" interface "pe2" to namespace "pe2" interface "p"
+    And I connect namespace "pe2" interface "ce2" to namespace "ce2" interface "pe2"
+    And I connect namespace "ce2" interface "c2" to namespace "c2" interface "ce2"
+    And I start zebra-rs in namespace "c1"
+    And I start zebra-rs in namespace "ce1"
+    And I start zebra-rs in namespace "pe1"
+    And I start zebra-rs in namespace "p"
+    And I start zebra-rs in namespace "pe2"
+    And I start zebra-rs in namespace "ce2"
+    And I start zebra-rs in namespace "c2"
+    And I apply config "c1.yaml" to namespace "c1"
+    And I apply config "ce1.yaml" to namespace "ce1"
+    And I apply config "pe1.yaml" to namespace "pe1"
+    And I apply config "p.yaml" to namespace "p"
+    And I apply config "pe2.yaml" to namespace "pe2"
+    And I apply config "ce2.yaml" to namespace "ce2"
+    And I apply config "c2.yaml" to namespace "c2"
+    And I wait 90 seconds for BGP to operate
+    Then isis neighbor in namespace "pe1" at level 2 on interface "p" should be up
+    And isis neighbor in namespace "pe2" at level 2 on interface "p" should be up
+
+  Scenario: Customer routes are carried as VPNv6 (OSPFv3 -> BGP, up direction)
+    Given the test topology exists
+    Then BGP session in "pe1" to "2001:db8::3" should be "Established"
+    And BGP session in "pe2" to "2001:db8::1" should be "Established"
+    And show command "show bgp vpnv6" in namespace "pe1" should eventually contain "2001:db8:c2::1/128"
+    And show command "show bgp vpnv6" in namespace "pe2" should eventually contain "2001:db8:c1::1/128"
+
+  Scenario: End-to-end customer loopback reachability across the SRv6 core
+    Given the test topology exists
+    Then ping from "c1" to "2001:db8:c2::1" should eventually succeed
+    And ping from "c2" to "2001:db8:c1::1" should eventually succeed
+
+  Scenario: Teardown topology
+    Given the test topology exists
+    When I stop zebra-rs in namespace "c1"
+    And I stop zebra-rs in namespace "ce1"
+    And I stop zebra-rs in namespace "pe1"
+    And I stop zebra-rs in namespace "p"
+    And I stop zebra-rs in namespace "pe2"
+    And I stop zebra-rs in namespace "ce2"
+    And I stop zebra-rs in namespace "c2"
+    And I delete namespace "c1"
+    And I delete namespace "ce1"
+    And I delete namespace "pe1"
+    And I delete namespace "p"
+    And I delete namespace "pe2"
+    And I delete namespace "ce2"
+    And I delete namespace "c2"
+    Then the test environment should be clean

--- a/zebra-rs/src/config/manager.rs
+++ b/zebra-rs/src/config/manager.rs
@@ -1750,6 +1750,11 @@ mod yang_load_tests {
             "set router ospf vrf vrf-cust redistribute bgp",
             "set router ospf vrf vrf-cust redistribute bgp metric 30",
             "set router ospf vrf vrf-cust redistribute connected",
+            "set router ospfv3 redistribute bgp",
+            "set router ospfv3 redistribute bgp metric 30",
+            "set router ospfv3 redistribute bgp metric-type type-1",
+            "set router ospfv3 vrf vrf-cust redistribute bgp",
+            "set router ospfv3 vrf vrf-cust redistribute bgp metric 30",
         ] {
             let (code, _comps, _state) = parse(cmd, entry.clone(), None, State::new());
             assert_eq!(

--- a/zebra-rs/src/ospf/config_v3.rs
+++ b/zebra-rs/src/ospf/config_v3.rs
@@ -66,6 +66,12 @@ impl Ospf<Ospfv3> {
                 "/area/redistribute/connected/metric-type",
                 config_ospfv3_area_redist_connected_metric_type,
             ),
+            ("/redistribute/bgp", config_ospfv3_redist_bgp),
+            ("/redistribute/bgp/metric", config_ospfv3_redist_bgp_metric),
+            (
+                "/redistribute/bgp/metric-type",
+                config_ospfv3_redist_bgp_metric_type,
+            ),
             ("/area/interface/enable", config_ospfv3_interface_enable),
             (
                 "/area/interface/bfd/enable",
@@ -452,11 +458,14 @@ fn config_ospfv3_area_nssa_translator_role(
 /// into NSSA Type-7 LSAs. Keyed by `(proto, afi, rtype)` — not per
 /// area — so multiple NSSA areas share one subscription.
 fn ospfv3_send_redist_connected(ospf: &Ospf<Ospfv3>, first_time: bool) {
-    use super::version::OspfVersion;
     use crate::rib::{Message as RibMsg, RedistAfi, RibType};
-    // Subscribe under the v3 proto ("ospfv3"); the RIB routes redist
-    // delivery by proto, and "ospf" would land on the v2 instance.
-    let proto = Ospfv3::PROTO.to_string();
+    // Subscribe under this instance's proto label, not the literal
+    // "ospfv3": a per-VRF v3 instance registers as "ospfv3:vrf:<name>",
+    // and the RIB routes redist delivery by the proto string. With the
+    // literal, a VRF child's subscription resolved to the default v3
+    // instance — so per-VRF redistribute never delivered. Same bug fixed
+    // for v2 (config.rs) and IS-IS.
+    let proto = ospf.proto_label.clone();
     let afi = RedistAfi::Ipv6;
     let rtype = RibType::Connected;
 
@@ -483,6 +492,88 @@ fn ospfv3_send_redist_connected(ospf: &Ospf<Ospfv3>, first_time: bool) {
         }
     };
     let _ = ospf.ctx.rib.send(msg);
+}
+
+/// Subscribe / unsubscribe this v3 instance's RIB redistribution for the
+/// IPv6 BGP source, gated on the instance-level `redistribute bgp` knob.
+/// Uses `proto_label` so a per-VRF instance receives only its VRF's BGP
+/// routes. v3 sibling of v2's `ospf_send_redist_bgp`.
+fn ospfv3_send_redist_bgp(ospf: &Ospf<Ospfv3>, first_time: bool) {
+    use crate::rib::{Message as RibMsg, RedistAfi, RibType};
+    let proto = ospf.proto_label.clone();
+    let afi = RedistAfi::Ipv6;
+    let rtype = RibType::Bgp;
+
+    let msg = if ospf.redist_bgp.is_none() {
+        RibMsg::RedistDel { proto, afi, rtype }
+    } else if first_time {
+        RibMsg::RedistAdd {
+            proto,
+            afi,
+            rtype,
+            subtypes: std::collections::BTreeSet::new(),
+        }
+    } else {
+        RibMsg::RedistUpdate {
+            proto,
+            afi,
+            rtype,
+            subtypes: std::collections::BTreeSet::new(),
+        }
+    };
+    let _ = ospf.ctx.rib.send(msg);
+}
+
+/// `/router/ospfv3/redistribute/bgp` — instance-level presence container.
+/// On Set: subscribe to the VRF's BGP routes and originate an AS-External
+/// (Type-5) LSA for each. On Delete: unsubscribe and flush them.
+fn config_ospfv3_redist_bgp(ospf: &mut Ospf<Ospfv3>, _args: Args, op: ConfigOp) -> Option<()> {
+    let first_time = ospf.redist_bgp.is_none();
+    if op.is_set() {
+        ospf.redist_bgp = Some(RedistEntry {
+            metric: RedistEntry::DEFAULT_METRIC,
+            ..Default::default()
+        });
+    } else {
+        ospf.redist_bgp = None;
+    }
+    ospfv3_send_redist_bgp(ospf, first_time && op.is_set());
+    ospf.as_external_redist_bgp_resync_v3();
+    Some(())
+}
+
+/// `/router/ospfv3/redistribute/bgp/metric`.
+fn config_ospfv3_redist_bgp_metric(
+    ospf: &mut Ospf<Ospfv3>,
+    mut args: Args,
+    op: ConfigOp,
+) -> Option<()> {
+    let metric = if op.is_set() {
+        args.u32()?
+    } else {
+        RedistEntry::DEFAULT_METRIC
+    };
+    ospf.redist_bgp.get_or_insert_with(Default::default).metric = metric;
+    ospf.as_external_redist_bgp_resync_v3();
+    Some(())
+}
+
+/// `/router/ospfv3/redistribute/bgp/metric-type`.
+fn config_ospfv3_redist_bgp_metric_type(
+    ospf: &mut Ospf<Ospfv3>,
+    mut args: Args,
+    op: ConfigOp,
+) -> Option<()> {
+    let mtype = if op.is_set() {
+        ExternalMetricType::from_yang(&args.string()?)?
+    } else {
+        ExternalMetricType::default()
+    };
+    ospf.redist_bgp
+        .get_or_insert_with(Default::default)
+        .metric_type = mtype;
+    ospf.as_external_redist_bgp_resync_v3();
+    Some(())
 }
 
 /// `/router/ospfv3/area/<id>/redistribute/connected` — presence

--- a/zebra-rs/src/ospf/inst.rs
+++ b/zebra-rs/src/ospf/inst.rs
@@ -294,6 +294,10 @@ pub struct Ospf<V: OspfVersion = Ospfv2> {
     /// Prefixes of Type-5 LSAs we self-originated from instance-level
     /// `redistribute bgp`. Flushed when the knob is removed.
     pub redist_bgp_originated: BTreeSet<Ipv4Net>,
+    /// IPv6 counterpart of [`Self::redist_bgp_originated`]: prefixes of
+    /// OSPFv3 AS-External (Type-5) LSAs self-originated from instance-level
+    /// `redistribute bgp`. A v2 instance leaves this empty.
+    pub redist_bgp_originated_v6: BTreeSet<ipnet::Ipv6Net>,
     /// Staged Flexible Algorithm definitions for this instance
     /// (`/router/ospf{,v3}/flex-algo`, RFC 9350). Shared staging engine
     /// keyed by the version's `FLEX_ALGO_PREFIX`; origination from the
@@ -1229,6 +1233,7 @@ impl Ospf<Ospfv2> {
             redist_connected_originated: BTreeSet::new(),
             redist_bgp: None,
             redist_bgp_originated: BTreeSet::new(),
+            redist_bgp_originated_v6: BTreeSet::new(),
             flex_algo: crate::flex_algo::FlexAlgoConfig::new(Ospfv2::FLEX_ALGO_PREFIX),
             affinity_map: crate::flex_algo::AffinityMap::new(),
             srlg_config: crate::flex_algo::SrlgGroupBuilder::new(),
@@ -2665,7 +2670,7 @@ impl Ospf<Ospfv2> {
     /// (RFC 2328 §3.3 ASBR definition). Today this requires the
     /// instance-level `redistribute connected` knob to be set.
     pub fn is_asbr(&self) -> bool {
-        self.redist_connected.is_some()
+        self.redist_connected.is_some() || self.redist_bgp.is_some()
     }
 
     /// True when this router should translate Type-7 → Type-5 for
@@ -5422,6 +5427,7 @@ impl Ospf<Ospfv3> {
             redist_connected_originated: BTreeSet::new(),
             redist_bgp: None,
             redist_bgp_originated: BTreeSet::new(),
+            redist_bgp_originated_v6: BTreeSet::new(),
             flex_algo: crate::flex_algo::FlexAlgoConfig::new(Ospfv3::FLEX_ALGO_PREFIX),
             affinity_map: crate::flex_algo::AffinityMap::new(),
             srlg_config: crate::flex_algo::SrlgGroupBuilder::new(),
@@ -5605,6 +5611,7 @@ impl Ospf<Ospfv3> {
         for area_id in area_ids {
             self.nssa_redist_connected_resync_v3(area_id);
         }
+        self.as_external_redist_bgp_resync_v3();
     }
 
     /// `RibRx::RouteDel` handler (v3). Mirror of `route_redist_add`.
@@ -5618,6 +5625,7 @@ impl Ospf<Ospfv3> {
         for area_id in area_ids {
             self.nssa_redist_connected_resync_v3(area_id);
         }
+        self.as_external_redist_bgp_resync_v3();
     }
 
     /// Stash an IPv6 address learned from netlink on the matching
@@ -6405,6 +6413,141 @@ impl Ospf<Ospfv3> {
         if let Some(lsa) = flushed {
             self.flood_self_originated_lsa(area_id, &lsa);
         }
+    }
+
+    /// Originate (or refresh) an OSPFv3 AS-External (Type-5, 0x4005) LSA
+    /// for `prefix` into the AS-scope LSDB and flood it AS-wide. The v3
+    /// sibling of `as_external_lsa_originate_for_prefix`; the body build
+    /// mirrors `nssa_lsa_originate_for_prefix_v3` but with the AS-External
+    /// LSA type, no P-bit (Propagate is NSSA-only), FA absent, and
+    /// AS-scope install/flood instead of per-area.
+    fn as_external_lsa_originate_for_prefix_v3(
+        &mut self,
+        prefix: ipnet::Ipv6Net,
+        metric: u32,
+        metric_type_2: bool,
+    ) {
+        use ospf_packet::{
+            OSPFV3_AS_EXTERNAL_FLAG_E, OSPFV3_AS_EXTERNAL_LSA_TYPE, Ospfv3AsExternalLsa,
+            Ospfv3LsBody, Ospfv3LsaHeader, Ospfv3PrefixOptions, ospfv3_prefix_wire_len,
+        };
+
+        let link_state_id = nssa_v3_ls_id(&prefix);
+
+        let mut flags = 0u8;
+        if metric_type_2 {
+            flags |= OSPFV3_AS_EXTERNAL_FLAG_E;
+        }
+
+        let wire_len = ospfv3_prefix_wire_len(prefix.prefix_len());
+        let mut address_prefix = vec![0u8; wire_len];
+        let net_bytes = prefix.network().octets();
+        let copy_len = wire_len.min(net_bytes.len());
+        address_prefix[..copy_len].copy_from_slice(&net_bytes[..copy_len]);
+
+        // No P-bit: that is an NSSA-LSA construct (RFC 3101). A Type-5
+        // ASBR leaves prefix-options clear and emits no forwarding address.
+        let body = Ospfv3AsExternalLsa {
+            flags,
+            metric,
+            prefix_length: prefix.prefix_len(),
+            prefix_options: Ospfv3PrefixOptions::new(),
+            referenced_ls_type: 0,
+            address_prefix,
+            forwarding_address: None,
+            external_route_tag: None,
+            referenced_link_state_id: None,
+        };
+
+        let header = Ospfv3LsaHeader {
+            ls_age: 0,
+            ls_type: OSPFV3_AS_EXTERNAL_LSA_TYPE,
+            link_state_id,
+            advertising_router: self.router_id,
+            ls_seq_number: 0x8000_0001,
+            ls_checksum: 0,
+            length: 0,
+        };
+        let mut lsa = ospf_packet::Ospfv3Lsa {
+            h: header,
+            body: Ospfv3LsBody::AsExternal(body),
+            raw: None,
+        };
+
+        let key: super::lsdb::OspfLsaKey =
+            (OSPFV3_AS_EXTERNAL_LSA_TYPE, link_state_id, self.router_id);
+        if let Some(existing) = self.lsdb_as.lookup_by_raw_key(key) {
+            lsa.h.ls_seq_number = seq_max(
+                lsa.h.ls_seq_number,
+                existing.h.ls_seq_number.saturating_add(1),
+            );
+        }
+        lsa.update();
+
+        let flood_lsa = lsa.clone();
+        self.lsdb_as.install_originated(lsa, &self.tx, None);
+        self.flood_lsa_through_as_v3(&flood_lsa, None);
+    }
+
+    /// Flush a self-originated v3 AS-External LSA keyed by the
+    /// prefix-derived ls-id and reflood the MaxAge copy AS-wide.
+    fn as_external_lsa_flush_for_prefix_v3(&mut self, prefix: ipnet::Ipv6Net) {
+        use ospf_packet::OSPFV3_AS_EXTERNAL_LSA_TYPE;
+        let link_state_id = nssa_v3_ls_id(&prefix);
+        let key: super::lsdb::OspfLsaKey =
+            (OSPFV3_AS_EXTERNAL_LSA_TYPE, link_state_id, self.router_id);
+        let flushed = self.lsdb_as.flush_lsa_by_raw_key(key, &self.tx, None);
+        if let Some(lsa) = flushed {
+            self.flood_lsa_through_as_v3(&lsa, None);
+        }
+    }
+
+    /// v3 sibling of `as_external_redist_bgp_resync`: rebuild this
+    /// instance's self-originated AS-External (Type-5) LSAs for the cached
+    /// BGP routes (`redist_v6` entries with `rtype == RibType::Bgp`),
+    /// diffing against `redist_bgp_originated_v6`. In a per-VRF OSPFv3
+    /// instance these are the VPNv6 routes BGP imported into the VRF —
+    /// injecting them into the CE-facing OSPFv3 is the L3VPN PE-CE down
+    /// direction.
+    pub fn as_external_redist_bgp_resync_v3(&mut self) {
+        use crate::rib::RibType;
+
+        let entry = self.redist_bgp;
+        let prev_originated = self.redist_bgp_originated_v6.clone();
+
+        let desired: BTreeSet<ipnet::Ipv6Net> = if entry.is_some() {
+            self.redist_v6
+                .iter()
+                .filter(|((rtype, _), _)| *rtype == RibType::Bgp)
+                .map(|((_, prefix), _)| *prefix)
+                .collect()
+        } else {
+            BTreeSet::new()
+        };
+
+        for prefix in prev_originated
+            .difference(&desired)
+            .copied()
+            .collect::<Vec<_>>()
+        {
+            self.as_external_lsa_flush_for_prefix_v3(prefix);
+            self.redist_bgp_originated_v6.remove(&prefix);
+        }
+
+        if let Some(redist_entry) = entry {
+            for prefix in &desired {
+                self.as_external_lsa_originate_for_prefix_v3(
+                    *prefix,
+                    redist_entry.metric,
+                    redist_entry.metric_type.is_type_2(),
+                );
+                self.redist_bgp_originated_v6.insert(*prefix);
+            }
+        }
+
+        // A v3 router that redistributes is an ASBR; refresh the
+        // Router-LSA so the E-bit reflects it.
+        self.router_lsa_originate();
     }
 
     /// v3 sibling of `nssa_redist_connected_resync`: rebuild this

--- a/zebra-rs/yang/config.yang
+++ b/zebra-rs/yang/config.yang
@@ -1150,6 +1150,28 @@ module config {
         leaf router-id {
           type inet:ipv4-address;
         }
+        // Instance-level redistribution into AS-External (Type-5) LSAs.
+        // `redistribute bgp` is the SRv6 L3VPN PE-CE down direction: a PE
+        // injects the VPNv6 routes it imported into a VRF into the
+        // CE-facing OSPFv3.
+        container redistribute {
+          container bgp {
+            presence "Redistribute BGP routes as AS-External (Type-5) LSAs";
+            leaf metric {
+              type uint32 {
+                range "0..16777214";
+              }
+              default 20;
+            }
+            leaf metric-type {
+              type enumeration {
+                enum type-1;
+                enum type-2;
+              }
+              default type-2;
+            }
+          }
+        }
         list area {
           key "area-id";
           leaf area-id {
@@ -1482,6 +1504,28 @@ module config {
           }
           leaf router-id {
             type inet:ipv4-address;
+          }
+          // Instance-level redistribution, forwarded to the per-VRF v3
+          // instance (prefix stripped). `redistribute bgp` injects the
+          // VPNv6 routes imported into this VRF into the CE-facing OSPFv3
+          // (the L3VPN PE-CE down direction).
+          container redistribute {
+            container bgp {
+              presence "Redistribute BGP routes as AS-External (Type-5) LSAs";
+              leaf metric {
+                type uint32 {
+                  range "0..16777214";
+                }
+                default 20;
+              }
+              leaf metric-type {
+                type enumeration {
+                  enum type-1;
+                  enum type-2;
+                }
+                default type-2;
+              }
+            }
           }
           list area {
             key "area-id";


### PR DESCRIPTION
## Summary

Completes the both-segments L3VPN PE-CE BDD matrix: adds **OSPFv3 instance-level AS-External `redistribute bgp`** (net-new — OSPFv3 previously had only per-area NSSA Type-7 redistribute) and the OSPFv3 PE-CE BDD over SRv6.

### Core feature (`ospf:` commit)
- **runtime** (`impl Ospf<Ospfv3>`): `as_external_lsa_originate_for_prefix_v3` (builds an AS-External Type-5/0x4005 body like the NSSA originate but with no P-bit, no forwarding address, installed into the AS-scope LSDB and flooded via `flood_lsa_through_as_v3`), `as_external_lsa_flush_for_prefix_v3`, and `as_external_redist_bgp_resync_v3` (filters `RibType::Bgp` from `redist_v6` against a new `redist_bgp_originated_v6`); wired into the v3 `route_redist_add`/`del`. Reuses `nssa_v3_ls_id` for ls-ids; the existing self-origin skip in `add_as_external_routes_v3` prevents a redistribute loop. `is_asbr()` now also reflects `redist_bgp` (v2 + v3).
- **YANG**: `container redistribute { bgp }` under `container ospfv3` and the ospfv3 `vrf` list.
- **config_v3**: `config_ospfv3_redist_bgp[_metric|_metric_type]` + `ospfv3_send_redist_bgp` + registration; plus the per-VRF subscription proto fix (hardcoded `"ospfv3"` → `proto_label`, same class as the v2/IS-IS fixes).

### BDD (`bdd:` commit)
`l3vpn_ospf_v6` — OSPFv3 on both the C-CE and PE-CE segments over the IS-IS SRv6 VPNv6 core, PE doing two-way redistribution (`redistribute ospf`→VPNv6 up, `redistribute bgp`→OSPFv3 down). Customer loopbacks advertised intra-area (v3 has no instance-level redistribute-connected). C1↔C2 IPv6 loopback ping crosses the SRv6 core.

## Test plan
- `cargo fmt`, `cargo clippy --workspace --all-targets -- -D warnings` — clean; 86 ospf unit tests + the (extended) `ospf_redistribute_bgp_paths_parse` guard pass.
- BDD (local): `@l3vpn_ospf_v6` stable 4/4 across re-runs (90s convergence wait — OSPFv3+SRv6+mutual-redistribution is the slowest combination).

## Matrix
This finishes the both-segments variant across all 4 protocol families × {IPv4/MPLS, IPv6/SRv6}: BGP (#1684), static (#1685), OSPFv2 (#1686), IS-IS (#1687), OSPFv3 (this). The optional "C-CE IGP + BGP PE-CE" second variant remains.

Generated with [Claude Code](https://claude.com/claude-code)