### PR TITLE
bdd: L3VPN second variant — C-CE IGP + BGP PE-CE (OSPF/IS-IS, v4+v6)

### DIFF
--- a/bdd/tests/configs/l3vpn_isis_bgppe_v4/c1.yaml
+++ b/bdd/tests/configs/l3vpn_isis_bgppe_v4/c1.yaml
@@ -1,0 +1,26 @@
+# C1 — customer site 1. IS-IS L2 to CE1; redistributes its connected
+# routes (loopback 10.0.1.1/32 + the C-CE link) into IS-IS, which reach
+# the PE through CE1.
+interface:
+- if-name: lo
+  ipv4:
+    address: 10.0.1.1/32
+- if-name: ce1
+  ipv4:
+    address: 10.1.0.1/30
+router:
+  isis:
+    net: 49.0001.0000.0000.0011.00
+    hostname: c1
+    is-type: level-2-only
+    afi-safi:
+    - name: ipv4
+      redistribute:
+        connected: {}
+    interface:
+    - if-name: ce1
+      circuit-type: level-2-only
+      network-type: point-to-point
+      metric: 10
+      ipv4:
+        enable: true

--- a/bdd/tests/configs/l3vpn_isis_bgppe_v4/c2.yaml
+++ b/bdd/tests/configs/l3vpn_isis_bgppe_v4/c2.yaml
@@ -1,0 +1,25 @@
+# C2 — customer site 2. Mirror of C1: IS-IS L2 to CE2, redistribute
+# connected (loopback 10.0.2.1/32 + C-CE link) into IS-IS.
+interface:
+- if-name: lo
+  ipv4:
+    address: 10.0.2.1/32
+- if-name: ce2
+  ipv4:
+    address: 10.2.0.1/30
+router:
+  isis:
+    net: 49.0001.0000.0000.0021.00
+    hostname: c2
+    is-type: level-2-only
+    afi-safi:
+    - name: ipv4
+      redistribute:
+        connected: {}
+    interface:
+    - if-name: ce2
+      circuit-type: level-2-only
+      network-type: point-to-point
+      metric: 10
+      ipv4:
+        enable: true

--- a/bdd/tests/configs/l3vpn_isis_bgppe_v4/ce1.yaml
+++ b/bdd/tests/configs/l3vpn_isis_bgppe_v4/ce1.yaml
@@ -1,0 +1,43 @@
+# CE1 — customer edge 1 (AS 65001). IS-IS toward C1, eBGP toward PE1,
+# with mutual redistribution: redistribute isis -> BGP (up), redistribute
+# bgp -> IS-IS (down).
+interface:
+- if-name: c1
+  ipv4:
+    address: 10.1.0.2/30
+- if-name: pe1
+  ipv4:
+    address: 10.1.0.5/30
+router:
+  isis:
+    net: 49.0001.0000.0000.0012.00
+    hostname: ce1
+    is-type: level-2-only
+    afi-safi:
+    - name: ipv4
+      redistribute:
+        bgp: {}
+    interface:
+    - if-name: c1
+      circuit-type: level-2-only
+      network-type: point-to-point
+      metric: 10
+      ipv4:
+        enable: true
+  bgp:
+    global:
+      as: 65001
+      router-id: 10.1.0.5
+    neighbor:
+    - remote-address: 10.1.0.6
+      remote-as: 65000
+      timers: {connect-retry-time: 3}
+      enabled: true
+      afi-safi:
+      - name: ipv4
+        enabled: true
+    afi-safi:
+    - name: ipv4
+      redistribute:
+        isis: {}
+        connected: {}

--- a/bdd/tests/configs/l3vpn_isis_bgppe_v4/ce2.yaml
+++ b/bdd/tests/configs/l3vpn_isis_bgppe_v4/ce2.yaml
@@ -1,0 +1,42 @@
+# CE2 — customer edge 2 (AS 65002). Mirror of CE1: IS-IS toward C2, eBGP
+# toward PE2, mutual redistribution.
+interface:
+- if-name: c2
+  ipv4:
+    address: 10.2.0.2/30
+- if-name: pe2
+  ipv4:
+    address: 10.2.0.5/30
+router:
+  isis:
+    net: 49.0001.0000.0000.0022.00
+    hostname: ce2
+    is-type: level-2-only
+    afi-safi:
+    - name: ipv4
+      redistribute:
+        bgp: {}
+    interface:
+    - if-name: c2
+      circuit-type: level-2-only
+      network-type: point-to-point
+      metric: 10
+      ipv4:
+        enable: true
+  bgp:
+    global:
+      as: 65002
+      router-id: 10.2.0.5
+    neighbor:
+    - remote-address: 10.2.0.6
+      remote-as: 65000
+      timers: {connect-retry-time: 3}
+      enabled: true
+      afi-safi:
+      - name: ipv4
+        enabled: true
+    afi-safi:
+    - name: ipv4
+      redistribute:
+        isis: {}
+        connected: {}

--- a/bdd/tests/configs/l3vpn_isis_bgppe_v4/p.yaml
+++ b/bdd/tests/configs/l3vpn_isis_bgppe_v4/p.yaml
@@ -1,0 +1,36 @@
+# P — provider core transit LSR (runs no BGP). Pure IS-IS L2 + SR-MPLS;
+# performs the SR label swap / PHP between PE1 (sid 1 -> 16001) and PE2
+# (sid 3 -> 16003).
+interface:
+- if-name: lo
+  ipv4:
+    address: 1.1.1.2/32
+- if-name: pe1
+  ipv4:
+    address: 10.250.0.2/30
+- if-name: pe2
+  ipv4:
+    address: 10.250.0.5/30
+router:
+  isis:
+    net: 49.0000.0000.0000.0002.00
+    hostname: p
+    is-type: level-2-only
+    segment-routing: mpls
+    te-router-id: 1.1.1.2
+    interface:
+    - if-name: lo
+      ipv4:
+        enable: true
+        prefix-sid:
+          index: 2
+    - if-name: pe1
+      network-type: point-to-point
+      metric: 10
+      ipv4:
+        enable: true
+    - if-name: pe2
+      network-type: point-to-point
+      metric: 10
+      ipv4:
+        enable: true

--- a/bdd/tests/configs/l3vpn_isis_bgppe_v4/pe1.yaml
+++ b/bdd/tests/configs/l3vpn_isis_bgppe_v4/pe1.yaml
@@ -1,0 +1,64 @@
+# PE1 — provider edge 1 (AS 65000). IS-IS L2 + SR-MPLS transport to PE2
+# via P (loopback Prefix-SID index 1 -> label 16001). iBGP VPNv4 to PE2
+# over loopbacks (rides the SR LSP). vrf-cust holds the eBGP PE-CE
+# session to CE1; CE-learned customer routes export to VPNv4 with
+# RD 65000:1 + RT 65000:100.
+vrf:
+- name: vrf-cust
+  ipv4:
+    route-target:
+      import:
+      - 65000:100
+      export:
+      - 65000:100
+interface:
+- if-name: lo
+  ipv4:
+    address: 1.1.1.1/32
+- if-name: p
+  ipv4:
+    address: 10.250.0.1/30
+- if-name: ce1
+  vrf: vrf-cust
+  ipv4:
+    address: 10.1.0.6/30
+router:
+  isis:
+    net: 49.0000.0000.0000.0001.00
+    hostname: pe1
+    is-type: level-2-only
+    segment-routing: mpls
+    te-router-id: 1.1.1.1
+    interface:
+    - if-name: lo
+      ipv4:
+        enable: true
+        prefix-sid:
+          index: 1
+    - if-name: p
+      network-type: point-to-point
+      metric: 10
+      ipv4:
+        enable: true
+  bgp:
+    global:
+      as: 65000
+      router-id: 1.1.1.1
+    neighbor:
+    - remote-address: 1.1.1.3
+      remote-as: 65000
+      timers: {connect-retry-time: 3}
+      update-source: 1.1.1.1
+      enabled: true
+      afi-safi:
+      - name: vpnv4
+        enabled: true
+    vrf:
+    - name: vrf-cust
+      rd: 65000:1
+      neighbor:
+      - remote-address: 10.1.0.5
+        remote-as: 65001
+        afi-safi:
+        - name: ipv4
+          enabled: true

--- a/bdd/tests/configs/l3vpn_isis_bgppe_v4/pe2.yaml
+++ b/bdd/tests/configs/l3vpn_isis_bgppe_v4/pe2.yaml
@@ -1,0 +1,62 @@
+# PE2 — provider edge 2 (AS 65000). Mirror of PE1: SR-MPLS loopback
+# Prefix-SID index 3 -> label 16003, iBGP VPNv4 to PE1, vrf-cust eBGP
+# PE-CE to CE2, export with RD 65000:2 + RT 65000:100.
+vrf:
+- name: vrf-cust
+  ipv4:
+    route-target:
+      import:
+      - 65000:100
+      export:
+      - 65000:100
+interface:
+- if-name: lo
+  ipv4:
+    address: 1.1.1.3/32
+- if-name: p
+  ipv4:
+    address: 10.250.0.6/30
+- if-name: ce2
+  vrf: vrf-cust
+  ipv4:
+    address: 10.2.0.6/30
+router:
+  isis:
+    net: 49.0000.0000.0000.0003.00
+    hostname: pe2
+    is-type: level-2-only
+    segment-routing: mpls
+    te-router-id: 1.1.1.3
+    interface:
+    - if-name: lo
+      ipv4:
+        enable: true
+        prefix-sid:
+          index: 3
+    - if-name: p
+      network-type: point-to-point
+      metric: 10
+      ipv4:
+        enable: true
+  bgp:
+    global:
+      as: 65000
+      router-id: 1.1.1.3
+    neighbor:
+    - remote-address: 1.1.1.1
+      remote-as: 65000
+      timers: {connect-retry-time: 3}
+      update-source: 1.1.1.3
+      enabled: true
+      afi-safi:
+      - name: vpnv4
+        enabled: true
+    vrf:
+    - name: vrf-cust
+      rd: 65000:2
+      neighbor:
+      - remote-address: 10.2.0.5
+        remote-as: 65002
+        afi-safi:
+        - name: ipv4
+          enabled: true

--- a/bdd/tests/configs/l3vpn_isis_bgppe_v6/c1.yaml
+++ b/bdd/tests/configs/l3vpn_isis_bgppe_v6/c1.yaml
@@ -1,0 +1,25 @@
+# C1 — customer site 1. IS-IS L2 (IPv6) to CE1; redistributes connected
+# (loopback 2001:db8:c1::1/128 + the C-CE link) into IS-IS.
+interface:
+- if-name: lo
+  ipv6:
+    address: 2001:db8:c1::1/128
+- if-name: ce1
+  ipv6:
+    address: 2001:db8:1c::1/64
+router:
+  isis:
+    net: 49.0001.0000.0000.0011.00
+    hostname: c1
+    is-type: level-2-only
+    afi-safi:
+    - name: ipv6
+      redistribute:
+        connected: {}
+    interface:
+    - if-name: ce1
+      circuit-type: level-2-only
+      network-type: point-to-point
+      metric: 10
+      ipv6:
+        enable: true

--- a/bdd/tests/configs/l3vpn_isis_bgppe_v6/c2.yaml
+++ b/bdd/tests/configs/l3vpn_isis_bgppe_v6/c2.yaml
@@ -1,0 +1,25 @@
+# C2 — customer site 2. Mirror of C1: IS-IS L2 (IPv6) to CE2,
+# redistribute connected (loopback 2001:db8:c2::1/128 + C-CE link).
+interface:
+- if-name: lo
+  ipv6:
+    address: 2001:db8:c2::1/128
+- if-name: ce2
+  ipv6:
+    address: 2001:db8:2c::1/64
+router:
+  isis:
+    net: 49.0001.0000.0000.0021.00
+    hostname: c2
+    is-type: level-2-only
+    afi-safi:
+    - name: ipv6
+      redistribute:
+        connected: {}
+    interface:
+    - if-name: ce2
+      circuit-type: level-2-only
+      network-type: point-to-point
+      metric: 10
+      ipv6:
+        enable: true

--- a/bdd/tests/configs/l3vpn_isis_bgppe_v6/ce1.yaml
+++ b/bdd/tests/configs/l3vpn_isis_bgppe_v6/ce1.yaml
@@ -1,0 +1,43 @@
+# CE1 — customer edge 1 (AS 65001). IS-IS (IPv6) toward C1, IPv6 eBGP
+# toward PE1, mutual redistribution: redistribute isis -> BGP (up),
+# redistribute bgp -> IS-IS (down).
+interface:
+- if-name: c1
+  ipv6:
+    address: 2001:db8:1c::2/64
+- if-name: pe1
+  ipv6:
+    address: 2001:db8:1e::1/64
+router:
+  isis:
+    net: 49.0001.0000.0000.0012.00
+    hostname: ce1
+    is-type: level-2-only
+    afi-safi:
+    - name: ipv6
+      redistribute:
+        bgp: {}
+    interface:
+    - if-name: c1
+      circuit-type: level-2-only
+      network-type: point-to-point
+      metric: 10
+      ipv6:
+        enable: true
+  bgp:
+    global:
+      as: 65001
+      router-id: 10.1.0.5
+    neighbor:
+    - remote-address: 2001:db8:1e::2
+      remote-as: 65000
+      timers: {connect-retry-time: 3}
+      enabled: true
+      afi-safi:
+      - name: ipv6
+        enabled: true
+    afi-safi:
+    - name: ipv6
+      redistribute:
+        isis: {}
+        connected: {}

--- a/bdd/tests/configs/l3vpn_isis_bgppe_v6/ce2.yaml
+++ b/bdd/tests/configs/l3vpn_isis_bgppe_v6/ce2.yaml
@@ -1,0 +1,42 @@
+# CE2 — customer edge 2 (AS 65002). Mirror of CE1: IS-IS (IPv6) toward
+# C2, IPv6 eBGP toward PE2, mutual redistribution.
+interface:
+- if-name: c2
+  ipv6:
+    address: 2001:db8:2c::2/64
+- if-name: pe2
+  ipv6:
+    address: 2001:db8:2e::1/64
+router:
+  isis:
+    net: 49.0001.0000.0000.0022.00
+    hostname: ce2
+    is-type: level-2-only
+    afi-safi:
+    - name: ipv6
+      redistribute:
+        bgp: {}
+    interface:
+    - if-name: c2
+      circuit-type: level-2-only
+      network-type: point-to-point
+      metric: 10
+      ipv6:
+        enable: true
+  bgp:
+    global:
+      as: 65002
+      router-id: 10.2.0.5
+    neighbor:
+    - remote-address: 2001:db8:2e::2
+      remote-as: 65000
+      timers: {connect-retry-time: 3}
+      enabled: true
+      afi-safi:
+      - name: ipv6
+        enabled: true
+    afi-safi:
+    - name: ipv6
+      redistribute:
+        isis: {}
+        connected: {}

--- a/bdd/tests/configs/l3vpn_isis_bgppe_v6/p.yaml
+++ b/bdd/tests/configs/l3vpn_isis_bgppe_v6/p.yaml
@@ -1,0 +1,33 @@
+# P — provider core transit (runs no BGP, no SRv6). Pure IS-IS L2 with
+# IPv6 enabled; learns the PE loopbacks (/128) and SRv6 locators (/48)
+# via IS-IS and natively forwards the SRv6-encapsulated transit traffic
+# between PE1 and PE2.
+interface:
+- if-name: lo
+  ipv6:
+    address: 2001:db8::2/128
+- if-name: pe1
+  ipv6:
+    address: 2001:db8:cafe:1::2/64
+- if-name: pe2
+  ipv6:
+    address: 2001:db8:cafe:2::1/64
+router:
+  isis:
+    net: 49.0000.0000.0000.0002.00
+    hostname: p
+    is-type: level-2-only
+    interface:
+    - if-name: lo
+      ipv6:
+        enable: true
+    - if-name: pe1
+      network-type: point-to-point
+      metric: 10
+      ipv6:
+        enable: true
+    - if-name: pe2
+      network-type: point-to-point
+      metric: 10
+      ipv6:
+        enable: true

--- a/bdd/tests/configs/l3vpn_isis_bgppe_v6/pe1.yaml
+++ b/bdd/tests/configs/l3vpn_isis_bgppe_v6/pe1.yaml
@@ -1,0 +1,71 @@
+# PE1 — provider edge 1 (AS 65000). IS-IS L2 SRv6 underlay to PE2 via P.
+# iBGP VPNv6 to PE2 over v6 loopbacks. vrf-cust (encapsulation srv6) holds
+# the IPv6 eBGP PE-CE session to CE1; CE-learned routes export to VPNv6
+# carrying the per-VRF End.DT46 service SID from LOC1 (RT 65000:100).
+vrf:
+- name: vrf-cust
+  ipv6:
+    route-target:
+      import:
+      - 65000:100
+      export:
+      - 65000:100
+interface:
+- if-name: lo
+  ipv6:
+    address: 2001:db8::1/128
+- if-name: p
+  ipv6:
+    address: 2001:db8:cafe:1::1/64
+- if-name: ce1
+  vrf: vrf-cust
+  ipv6:
+    address: 2001:db8:1e::2/64
+segment-routing:
+  locator:
+  - name: LOC1
+    prefix: fcbb:bbbb:1::/48
+    behavior: usid
+router:
+  isis:
+    net: 49.0000.0000.0000.0001.00
+    hostname: pe1
+    is-type: level-2-only
+    segment-routing:
+      srv6:
+        locator: LOC1
+    interface:
+    - if-name: lo
+      ipv6:
+        enable: true
+    - if-name: p
+      network-type: point-to-point
+      metric: 10
+      ipv6:
+        enable: true
+  bgp:
+    global:
+      as: 65000
+      router-id: 1.1.1.1
+    segment-routing:
+      srv6:
+        locator: LOC1
+    neighbor:
+    - remote-address: 2001:db8::3
+      remote-as: 65000
+      update-source: 2001:db8::1
+      timers: {connect-retry-time: 3}
+      enabled: true
+      afi-safi:
+      - name: vpnv6
+        enabled: true
+    vrf:
+    - name: vrf-cust
+      rd: 65000:1
+      encapsulation: srv6
+      neighbor:
+      - remote-address: 2001:db8:1e::1
+        remote-as: 65001
+        afi-safi:
+        - name: ipv6
+          enabled: true

--- a/bdd/tests/configs/l3vpn_isis_bgppe_v6/pe2.yaml
+++ b/bdd/tests/configs/l3vpn_isis_bgppe_v6/pe2.yaml
@@ -1,0 +1,70 @@
+# PE2 — provider edge 2 (AS 65000). Mirror of PE1: SRv6 locator LOC2,
+# iBGP VPNv6 to PE1, vrf-cust (encapsulation srv6) IPv6 eBGP PE-CE to
+# CE2, export with RD 65000:2 + RT 65000:100.
+vrf:
+- name: vrf-cust
+  ipv6:
+    route-target:
+      import:
+      - 65000:100
+      export:
+      - 65000:100
+interface:
+- if-name: lo
+  ipv6:
+    address: 2001:db8::3/128
+- if-name: p
+  ipv6:
+    address: 2001:db8:cafe:2::2/64
+- if-name: ce2
+  vrf: vrf-cust
+  ipv6:
+    address: 2001:db8:2e::2/64
+segment-routing:
+  locator:
+  - name: LOC2
+    prefix: fcbb:bbbb:2::/48
+    behavior: usid
+router:
+  isis:
+    net: 49.0000.0000.0000.0003.00
+    hostname: pe2
+    is-type: level-2-only
+    segment-routing:
+      srv6:
+        locator: LOC2
+    interface:
+    - if-name: lo
+      ipv6:
+        enable: true
+    - if-name: p
+      network-type: point-to-point
+      metric: 10
+      ipv6:
+        enable: true
+  bgp:
+    global:
+      as: 65000
+      router-id: 1.1.1.3
+    segment-routing:
+      srv6:
+        locator: LOC2
+    neighbor:
+    - remote-address: 2001:db8::1
+      remote-as: 65000
+      update-source: 2001:db8::3
+      timers: {connect-retry-time: 3}
+      enabled: true
+      afi-safi:
+      - name: vpnv6
+        enabled: true
+    vrf:
+    - name: vrf-cust
+      rd: 65000:2
+      encapsulation: srv6
+      neighbor:
+      - remote-address: 2001:db8:2e::1
+        remote-as: 65002
+        afi-safi:
+        - name: ipv6
+          enabled: true

--- a/bdd/tests/configs/l3vpn_ospf_bgppe_v4/c1.yaml
+++ b/bdd/tests/configs/l3vpn_ospf_bgppe_v4/c1.yaml
@@ -1,0 +1,22 @@
+# C1 — customer site 1. OSPFv2 to CE1 (area 0); redistributes its
+# connected routes (loopback 10.0.1.1/32 + the C-CE link) into OSPF as
+# Type-5 AS-External LSAs, which reach the PE through CE1.
+interface:
+- if-name: lo
+  ipv4:
+    address: 10.0.1.1/32
+- if-name: ce1
+  ipv4:
+    address: 10.1.0.1/30
+router:
+  ospf:
+    router-id: 10.0.1.1
+    redistribute:
+      connected:
+        metric: 20
+    area:
+    - area-id: 0.0.0.0
+      interface:
+      - if-name: ce1
+        enable: true
+        network-type: point-to-point

--- a/bdd/tests/configs/l3vpn_ospf_bgppe_v4/c2.yaml
+++ b/bdd/tests/configs/l3vpn_ospf_bgppe_v4/c2.yaml
@@ -1,0 +1,21 @@
+# C2 — customer site 2. Mirror of C1: OSPFv2 to CE2, redistribute
+# connected (loopback 10.0.2.1/32 + C-CE link) into OSPF.
+interface:
+- if-name: lo
+  ipv4:
+    address: 10.0.2.1/32
+- if-name: ce2
+  ipv4:
+    address: 10.2.0.1/30
+router:
+  ospf:
+    router-id: 10.0.2.1
+    redistribute:
+      connected:
+        metric: 20
+    area:
+    - area-id: 0.0.0.0
+      interface:
+      - if-name: ce2
+        enable: true
+        network-type: point-to-point

--- a/bdd/tests/configs/l3vpn_ospf_bgppe_v4/ce1.yaml
+++ b/bdd/tests/configs/l3vpn_ospf_bgppe_v4/ce1.yaml
@@ -1,0 +1,43 @@
+# CE1 — customer edge 1 (AS 65001). Second L3VPN variant: OSPFv2 toward
+# C1, eBGP toward PE1, with mutual redistribution on the CE:
+#   - up:   router bgp ... redistribute ospf  -> C1's OSPF-learned routes
+#           are advertised to PE1 over eBGP.
+#   - down: router ospf ... redistribute bgp  -> the routes PE1 sends over
+#           eBGP (remote customers) are injected into the C-facing OSPF as
+#           Type-5 AS-External LSAs.
+interface:
+- if-name: c1
+  ipv4:
+    address: 10.1.0.2/30
+- if-name: pe1
+  ipv4:
+    address: 10.1.0.5/30
+router:
+  ospf:
+    router-id: 10.1.0.5
+    redistribute:
+      bgp:
+        metric: 20
+    area:
+    - area-id: 0.0.0.0
+      interface:
+      - if-name: c1
+        enable: true
+        network-type: point-to-point
+  bgp:
+    global:
+      as: 65001
+      router-id: 10.1.0.5
+    neighbor:
+    - remote-address: 10.1.0.6
+      remote-as: 65000
+      timers: {connect-retry-time: 3}
+      enabled: true
+      afi-safi:
+      - name: ipv4
+        enabled: true
+    afi-safi:
+    - name: ipv4
+      redistribute:
+        ospf: {}
+        connected: {}

--- a/bdd/tests/configs/l3vpn_ospf_bgppe_v4/ce2.yaml
+++ b/bdd/tests/configs/l3vpn_ospf_bgppe_v4/ce2.yaml
@@ -1,0 +1,39 @@
+# CE2 — customer edge 2 (AS 65002). Mirror of CE1: OSPFv2 toward C2,
+# eBGP toward PE2, mutual redistribution (redistribute ospf -> BGP up,
+# redistribute bgp -> OSPF down).
+interface:
+- if-name: c2
+  ipv4:
+    address: 10.2.0.2/30
+- if-name: pe2
+  ipv4:
+    address: 10.2.0.5/30
+router:
+  ospf:
+    router-id: 10.2.0.5
+    redistribute:
+      bgp:
+        metric: 20
+    area:
+    - area-id: 0.0.0.0
+      interface:
+      - if-name: c2
+        enable: true
+        network-type: point-to-point
+  bgp:
+    global:
+      as: 65002
+      router-id: 10.2.0.5
+    neighbor:
+    - remote-address: 10.2.0.6
+      remote-as: 65000
+      timers: {connect-retry-time: 3}
+      enabled: true
+      afi-safi:
+      - name: ipv4
+        enabled: true
+    afi-safi:
+    - name: ipv4
+      redistribute:
+        ospf: {}
+        connected: {}

--- a/bdd/tests/configs/l3vpn_ospf_bgppe_v4/p.yaml
+++ b/bdd/tests/configs/l3vpn_ospf_bgppe_v4/p.yaml
@@ -1,0 +1,36 @@
+# P — provider core transit LSR (runs no BGP). Pure IS-IS L2 + SR-MPLS;
+# performs the SR label swap / PHP between PE1 (sid 1 -> 16001) and PE2
+# (sid 3 -> 16003).
+interface:
+- if-name: lo
+  ipv4:
+    address: 1.1.1.2/32
+- if-name: pe1
+  ipv4:
+    address: 10.250.0.2/30
+- if-name: pe2
+  ipv4:
+    address: 10.250.0.5/30
+router:
+  isis:
+    net: 49.0000.0000.0000.0002.00
+    hostname: p
+    is-type: level-2-only
+    segment-routing: mpls
+    te-router-id: 1.1.1.2
+    interface:
+    - if-name: lo
+      ipv4:
+        enable: true
+        prefix-sid:
+          index: 2
+    - if-name: pe1
+      network-type: point-to-point
+      metric: 10
+      ipv4:
+        enable: true
+    - if-name: pe2
+      network-type: point-to-point
+      metric: 10
+      ipv4:
+        enable: true

--- a/bdd/tests/configs/l3vpn_ospf_bgppe_v4/pe1.yaml
+++ b/bdd/tests/configs/l3vpn_ospf_bgppe_v4/pe1.yaml
@@ -1,0 +1,64 @@
+# PE1 — provider edge 1 (AS 65000). IS-IS L2 + SR-MPLS transport to PE2
+# via P (loopback Prefix-SID index 1 -> label 16001). iBGP VPNv4 to PE2
+# over loopbacks (rides the SR LSP). vrf-cust holds the eBGP PE-CE
+# session to CE1; CE-learned customer routes export to VPNv4 with
+# RD 65000:1 + RT 65000:100.
+vrf:
+- name: vrf-cust
+  ipv4:
+    route-target:
+      import:
+      - 65000:100
+      export:
+      - 65000:100
+interface:
+- if-name: lo
+  ipv4:
+    address: 1.1.1.1/32
+- if-name: p
+  ipv4:
+    address: 10.250.0.1/30
+- if-name: ce1
+  vrf: vrf-cust
+  ipv4:
+    address: 10.1.0.6/30
+router:
+  isis:
+    net: 49.0000.0000.0000.0001.00
+    hostname: pe1
+    is-type: level-2-only
+    segment-routing: mpls
+    te-router-id: 1.1.1.1
+    interface:
+    - if-name: lo
+      ipv4:
+        enable: true
+        prefix-sid:
+          index: 1
+    - if-name: p
+      network-type: point-to-point
+      metric: 10
+      ipv4:
+        enable: true
+  bgp:
+    global:
+      as: 65000
+      router-id: 1.1.1.1
+    neighbor:
+    - remote-address: 1.1.1.3
+      remote-as: 65000
+      timers: {connect-retry-time: 3}
+      update-source: 1.1.1.1
+      enabled: true
+      afi-safi:
+      - name: vpnv4
+        enabled: true
+    vrf:
+    - name: vrf-cust
+      rd: 65000:1
+      neighbor:
+      - remote-address: 10.1.0.5
+        remote-as: 65001
+        afi-safi:
+        - name: ipv4
+          enabled: true

--- a/bdd/tests/configs/l3vpn_ospf_bgppe_v4/pe2.yaml
+++ b/bdd/tests/configs/l3vpn_ospf_bgppe_v4/pe2.yaml
@@ -1,0 +1,62 @@
+# PE2 — provider edge 2 (AS 65000). Mirror of PE1: SR-MPLS loopback
+# Prefix-SID index 3 -> label 16003, iBGP VPNv4 to PE1, vrf-cust eBGP
+# PE-CE to CE2, export with RD 65000:2 + RT 65000:100.
+vrf:
+- name: vrf-cust
+  ipv4:
+    route-target:
+      import:
+      - 65000:100
+      export:
+      - 65000:100
+interface:
+- if-name: lo
+  ipv4:
+    address: 1.1.1.3/32
+- if-name: p
+  ipv4:
+    address: 10.250.0.6/30
+- if-name: ce2
+  vrf: vrf-cust
+  ipv4:
+    address: 10.2.0.6/30
+router:
+  isis:
+    net: 49.0000.0000.0000.0003.00
+    hostname: pe2
+    is-type: level-2-only
+    segment-routing: mpls
+    te-router-id: 1.1.1.3
+    interface:
+    - if-name: lo
+      ipv4:
+        enable: true
+        prefix-sid:
+          index: 3
+    - if-name: p
+      network-type: point-to-point
+      metric: 10
+      ipv4:
+        enable: true
+  bgp:
+    global:
+      as: 65000
+      router-id: 1.1.1.3
+    neighbor:
+    - remote-address: 1.1.1.1
+      remote-as: 65000
+      timers: {connect-retry-time: 3}
+      update-source: 1.1.1.3
+      enabled: true
+      afi-safi:
+      - name: vpnv4
+        enabled: true
+    vrf:
+    - name: vrf-cust
+      rd: 65000:2
+      neighbor:
+      - remote-address: 10.2.0.5
+        remote-as: 65002
+        afi-safi:
+        - name: ipv4
+          enabled: true

--- a/bdd/tests/configs/l3vpn_ospf_bgppe_v6/c1.yaml
+++ b/bdd/tests/configs/l3vpn_ospf_bgppe_v6/c1.yaml
@@ -1,0 +1,22 @@
+# C1 — customer site 1. OSPFv3 to CE1 (area 0). The loopback
+# 2001:db8:c1::1/128 and the C-CE link are advertised as intra-area
+# prefixes (OSPFv3 has no instance-level redistribute-connected; enabling
+# the interfaces in the area is the idiomatic way to originate them).
+interface:
+- if-name: lo
+  ipv6:
+    address: 2001:db8:c1::1/128
+- if-name: ce1
+  ipv6:
+    address: 2001:db8:1c::1/64
+router:
+  ospfv3:
+    router-id: 10.0.1.1
+    area:
+    - area-id: 0.0.0.0
+      interface:
+      - if-name: lo
+        enable: true
+      - if-name: ce1
+        enable: true
+        network-type: point-to-point

--- a/bdd/tests/configs/l3vpn_ospf_bgppe_v6/c2.yaml
+++ b/bdd/tests/configs/l3vpn_ospf_bgppe_v6/c2.yaml
@@ -1,0 +1,20 @@
+# C2 — customer site 2. Mirror of C1: OSPFv3 to CE2; loopback
+# 2001:db8:c2::1/128 + C-CE link advertised intra-area.
+interface:
+- if-name: lo
+  ipv6:
+    address: 2001:db8:c2::1/128
+- if-name: ce2
+  ipv6:
+    address: 2001:db8:2c::1/64
+router:
+  ospfv3:
+    router-id: 10.0.2.1
+    area:
+    - area-id: 0.0.0.0
+      interface:
+      - if-name: lo
+        enable: true
+      - if-name: ce2
+        enable: true
+        network-type: point-to-point

--- a/bdd/tests/configs/l3vpn_ospf_bgppe_v6/ce1.yaml
+++ b/bdd/tests/configs/l3vpn_ospf_bgppe_v6/ce1.yaml
@@ -1,0 +1,39 @@
+# CE1 — customer edge 1 (AS 65001). OSPFv3 toward C1, IPv6 eBGP toward
+# PE1, mutual redistribution: redistribute ospf -> BGP (up), redistribute
+# bgp -> OSPFv3 AS-External (down).
+interface:
+- if-name: c1
+  ipv6:
+    address: 2001:db8:1c::2/64
+- if-name: pe1
+  ipv6:
+    address: 2001:db8:1e::1/64
+router:
+  ospfv3:
+    router-id: 10.1.0.5
+    redistribute:
+      bgp:
+        metric: 20
+    area:
+    - area-id: 0.0.0.0
+      interface:
+      - if-name: c1
+        enable: true
+        network-type: point-to-point
+  bgp:
+    global:
+      as: 65001
+      router-id: 10.1.0.5
+    neighbor:
+    - remote-address: 2001:db8:1e::2
+      remote-as: 65000
+      timers: {connect-retry-time: 3}
+      enabled: true
+      afi-safi:
+      - name: ipv6
+        enabled: true
+    afi-safi:
+    - name: ipv6
+      redistribute:
+        ospf: {}
+        connected: {}

--- a/bdd/tests/configs/l3vpn_ospf_bgppe_v6/ce2.yaml
+++ b/bdd/tests/configs/l3vpn_ospf_bgppe_v6/ce2.yaml
@@ -1,0 +1,38 @@
+# CE2 — customer edge 2 (AS 65002). Mirror of CE1: OSPFv3 toward C2,
+# IPv6 eBGP toward PE2, mutual redistribution.
+interface:
+- if-name: c2
+  ipv6:
+    address: 2001:db8:2c::2/64
+- if-name: pe2
+  ipv6:
+    address: 2001:db8:2e::1/64
+router:
+  ospfv3:
+    router-id: 10.2.0.5
+    redistribute:
+      bgp:
+        metric: 20
+    area:
+    - area-id: 0.0.0.0
+      interface:
+      - if-name: c2
+        enable: true
+        network-type: point-to-point
+  bgp:
+    global:
+      as: 65002
+      router-id: 10.2.0.5
+    neighbor:
+    - remote-address: 2001:db8:2e::2
+      remote-as: 65000
+      timers: {connect-retry-time: 3}
+      enabled: true
+      afi-safi:
+      - name: ipv6
+        enabled: true
+    afi-safi:
+    - name: ipv6
+      redistribute:
+        ospf: {}
+        connected: {}

--- a/bdd/tests/configs/l3vpn_ospf_bgppe_v6/p.yaml
+++ b/bdd/tests/configs/l3vpn_ospf_bgppe_v6/p.yaml
@@ -1,0 +1,33 @@
+# P — provider core transit (runs no BGP, no SRv6). Pure IS-IS L2 with
+# IPv6 enabled; learns the PE loopbacks (/128) and SRv6 locators (/48)
+# via IS-IS and natively forwards the SRv6-encapsulated transit traffic
+# between PE1 and PE2.
+interface:
+- if-name: lo
+  ipv6:
+    address: 2001:db8::2/128
+- if-name: pe1
+  ipv6:
+    address: 2001:db8:cafe:1::2/64
+- if-name: pe2
+  ipv6:
+    address: 2001:db8:cafe:2::1/64
+router:
+  isis:
+    net: 49.0000.0000.0000.0002.00
+    hostname: p
+    is-type: level-2-only
+    interface:
+    - if-name: lo
+      ipv6:
+        enable: true
+    - if-name: pe1
+      network-type: point-to-point
+      metric: 10
+      ipv6:
+        enable: true
+    - if-name: pe2
+      network-type: point-to-point
+      metric: 10
+      ipv6:
+        enable: true

--- a/bdd/tests/configs/l3vpn_ospf_bgppe_v6/pe1.yaml
+++ b/bdd/tests/configs/l3vpn_ospf_bgppe_v6/pe1.yaml
@@ -1,0 +1,71 @@
+# PE1 — provider edge 1 (AS 65000). IS-IS L2 SRv6 underlay to PE2 via P.
+# iBGP VPNv6 to PE2 over v6 loopbacks. vrf-cust (encapsulation srv6) holds
+# the IPv6 eBGP PE-CE session to CE1; CE-learned routes export to VPNv6
+# carrying the per-VRF End.DT46 service SID from LOC1 (RT 65000:100).
+vrf:
+- name: vrf-cust
+  ipv6:
+    route-target:
+      import:
+      - 65000:100
+      export:
+      - 65000:100
+interface:
+- if-name: lo
+  ipv6:
+    address: 2001:db8::1/128
+- if-name: p
+  ipv6:
+    address: 2001:db8:cafe:1::1/64
+- if-name: ce1
+  vrf: vrf-cust
+  ipv6:
+    address: 2001:db8:1e::2/64
+segment-routing:
+  locator:
+  - name: LOC1
+    prefix: fcbb:bbbb:1::/48
+    behavior: usid
+router:
+  isis:
+    net: 49.0000.0000.0000.0001.00
+    hostname: pe1
+    is-type: level-2-only
+    segment-routing:
+      srv6:
+        locator: LOC1
+    interface:
+    - if-name: lo
+      ipv6:
+        enable: true
+    - if-name: p
+      network-type: point-to-point
+      metric: 10
+      ipv6:
+        enable: true
+  bgp:
+    global:
+      as: 65000
+      router-id: 1.1.1.1
+    segment-routing:
+      srv6:
+        locator: LOC1
+    neighbor:
+    - remote-address: 2001:db8::3
+      remote-as: 65000
+      update-source: 2001:db8::1
+      timers: {connect-retry-time: 3}
+      enabled: true
+      afi-safi:
+      - name: vpnv6
+        enabled: true
+    vrf:
+    - name: vrf-cust
+      rd: 65000:1
+      encapsulation: srv6
+      neighbor:
+      - remote-address: 2001:db8:1e::1
+        remote-as: 65001
+        afi-safi:
+        - name: ipv6
+          enabled: true

--- a/bdd/tests/configs/l3vpn_ospf_bgppe_v6/pe2.yaml
+++ b/bdd/tests/configs/l3vpn_ospf_bgppe_v6/pe2.yaml
@@ -1,0 +1,70 @@
+# PE2 — provider edge 2 (AS 65000). Mirror of PE1: SRv6 locator LOC2,
+# iBGP VPNv6 to PE1, vrf-cust (encapsulation srv6) IPv6 eBGP PE-CE to
+# CE2, export with RD 65000:2 + RT 65000:100.
+vrf:
+- name: vrf-cust
+  ipv6:
+    route-target:
+      import:
+      - 65000:100
+      export:
+      - 65000:100
+interface:
+- if-name: lo
+  ipv6:
+    address: 2001:db8::3/128
+- if-name: p
+  ipv6:
+    address: 2001:db8:cafe:2::2/64
+- if-name: ce2
+  vrf: vrf-cust
+  ipv6:
+    address: 2001:db8:2e::2/64
+segment-routing:
+  locator:
+  - name: LOC2
+    prefix: fcbb:bbbb:2::/48
+    behavior: usid
+router:
+  isis:
+    net: 49.0000.0000.0000.0003.00
+    hostname: pe2
+    is-type: level-2-only
+    segment-routing:
+      srv6:
+        locator: LOC2
+    interface:
+    - if-name: lo
+      ipv6:
+        enable: true
+    - if-name: p
+      network-type: point-to-point
+      metric: 10
+      ipv6:
+        enable: true
+  bgp:
+    global:
+      as: 65000
+      router-id: 1.1.1.3
+    segment-routing:
+      srv6:
+        locator: LOC2
+    neighbor:
+    - remote-address: 2001:db8::1
+      remote-as: 65000
+      update-source: 2001:db8::3
+      timers: {connect-retry-time: 3}
+      enabled: true
+      afi-safi:
+      - name: vpnv6
+        enabled: true
+    vrf:
+    - name: vrf-cust
+      rd: 65000:2
+      encapsulation: srv6
+      neighbor:
+      - remote-address: 2001:db8:2e::1
+        remote-as: 65002
+        afi-safi:
+        - name: ipv6
+          enabled: true

--- a/bdd/tests/features/l3vpn_isis_bgppe_v4.feature
+++ b/bdd/tests/features/l3vpn_isis_bgppe_v4.feature
@@ -1,0 +1,75 @@
+@serial
+@l3vpn_isis_bgppe_v4
+Feature: MPLS/VPN L3VPN (IPv4) with IS-IS C-CE and BGP PE-CE
+  Second L3VPN PE-CE variant: the customer runs IS-IS to the CE, the
+  CE-PE link is eBGP, and the CE bridges them with mutual redistribution
+  (IS-IS<->BGP). The PE is a plain BGP PE-CE edge (like @l3vpn_bgp_v4).
+  C1 and C2 reach each other's loopback across the MPLS/VPN core.
+
+  Scenario: Build the L3VPN topology and bring up the core
+    Given a clean test environment
+    When I create namespace "c1"
+    And I create namespace "ce1"
+    And I create namespace "pe1"
+    And I create namespace "p"
+    And I create namespace "pe2"
+    And I create namespace "ce2"
+    And I create namespace "c2"
+    And I connect namespace "c1" interface "ce1" to namespace "ce1" interface "c1"
+    And I connect namespace "ce1" interface "pe1" to namespace "pe1" interface "ce1"
+    And I connect namespace "pe1" interface "p" to namespace "p" interface "pe1"
+    And I connect namespace "p" interface "pe2" to namespace "pe2" interface "p"
+    And I connect namespace "pe2" interface "ce2" to namespace "ce2" interface "pe2"
+    And I connect namespace "ce2" interface "c2" to namespace "c2" interface "ce2"
+    And I start zebra-rs in namespace "c1"
+    And I start zebra-rs in namespace "ce1"
+    And I start zebra-rs in namespace "pe1"
+    And I start zebra-rs in namespace "p"
+    And I start zebra-rs in namespace "pe2"
+    And I start zebra-rs in namespace "ce2"
+    And I start zebra-rs in namespace "c2"
+    And I apply config "c1.yaml" to namespace "c1"
+    And I apply config "ce1.yaml" to namespace "ce1"
+    And I apply config "pe1.yaml" to namespace "pe1"
+    And I apply config "p.yaml" to namespace "p"
+    And I apply config "pe2.yaml" to namespace "pe2"
+    And I apply config "ce2.yaml" to namespace "ce2"
+    And I apply config "c2.yaml" to namespace "c2"
+    And I wait 120 seconds for BGP to operate
+    Then isis neighbor in namespace "pe1" at level 2 on interface "p" should be up
+    And isis neighbor in namespace "pe2" at level 2 on interface "p" should be up
+
+  Scenario: Customer routes are carried as VPNv4 (CE IS-IS->eBGP, up direction)
+    Given the test topology exists
+    Then BGP session in "pe1" to "1.1.1.3" should be "Established"
+    And BGP session in "pe2" to "1.1.1.1" should be "Established"
+    And show command "show bgp vpnv4" in namespace "pe1" should eventually contain "10.0.2.1/32"
+    And show command "show bgp vpnv4" in namespace "pe2" should eventually contain "10.0.1.1/32"
+
+  Scenario: Remote customer loopbacks reach the customer site (CE eBGP->IS-IS, down direction)
+    Given the test topology exists
+    Then show command "show ip route" in namespace "c1" should eventually contain "10.0.2.1"
+    And show command "show ip route" in namespace "c2" should eventually contain "10.0.1.1"
+
+  Scenario: End-to-end customer loopback reachability across the MPLS/VPN core
+    Given the test topology exists
+    Then ping from "c1" to "10.0.2.1" should eventually succeed
+    And ping from "c2" to "10.0.1.1" should eventually succeed
+
+  Scenario: Teardown topology
+    Given the test topology exists
+    When I stop zebra-rs in namespace "c1"
+    And I stop zebra-rs in namespace "ce1"
+    And I stop zebra-rs in namespace "pe1"
+    And I stop zebra-rs in namespace "p"
+    And I stop zebra-rs in namespace "pe2"
+    And I stop zebra-rs in namespace "ce2"
+    And I stop zebra-rs in namespace "c2"
+    And I delete namespace "c1"
+    And I delete namespace "ce1"
+    And I delete namespace "pe1"
+    And I delete namespace "p"
+    And I delete namespace "pe2"
+    And I delete namespace "ce2"
+    And I delete namespace "c2"
+    Then the test environment should be clean

--- a/bdd/tests/features/l3vpn_isis_bgppe_v6.feature
+++ b/bdd/tests/features/l3vpn_isis_bgppe_v6.feature
@@ -1,0 +1,71 @@
+@serial
+@l3vpn_isis_bgppe_v6
+Feature: SRv6 L3VPN (IPv6) with IS-IS C-CE and BGP PE-CE
+  Second L3VPN PE-CE variant over SRv6: the customer runs IS-IS (IPv6) to
+  the CE, the CE-PE link is IPv6 eBGP, and the CE bridges them with
+  mutual redistribution (IS-IS<->BGP). The PE is a plain BGP PE-CE edge
+  (like @l3vpn_bgp_v6). C1 and C2 reach each other's IPv6 loopback across
+  the SRv6 core.
+
+  Scenario: Build the SRv6 L3VPN topology and bring up the core
+    Given a clean test environment
+    When I create namespace "c1"
+    And I create namespace "ce1"
+    And I create namespace "pe1"
+    And I create namespace "p"
+    And I create namespace "pe2"
+    And I create namespace "ce2"
+    And I create namespace "c2"
+    And I connect namespace "c1" interface "ce1" to namespace "ce1" interface "c1"
+    And I connect namespace "ce1" interface "pe1" to namespace "pe1" interface "ce1"
+    And I connect namespace "pe1" interface "p" to namespace "p" interface "pe1"
+    And I connect namespace "p" interface "pe2" to namespace "pe2" interface "p"
+    And I connect namespace "pe2" interface "ce2" to namespace "ce2" interface "pe2"
+    And I connect namespace "ce2" interface "c2" to namespace "c2" interface "ce2"
+    And I start zebra-rs in namespace "c1"
+    And I start zebra-rs in namespace "ce1"
+    And I start zebra-rs in namespace "pe1"
+    And I start zebra-rs in namespace "p"
+    And I start zebra-rs in namespace "pe2"
+    And I start zebra-rs in namespace "ce2"
+    And I start zebra-rs in namespace "c2"
+    And I apply config "c1.yaml" to namespace "c1"
+    And I apply config "ce1.yaml" to namespace "ce1"
+    And I apply config "pe1.yaml" to namespace "pe1"
+    And I apply config "p.yaml" to namespace "p"
+    And I apply config "pe2.yaml" to namespace "pe2"
+    And I apply config "ce2.yaml" to namespace "ce2"
+    And I apply config "c2.yaml" to namespace "c2"
+    And I wait 120 seconds for BGP to operate
+    Then isis neighbor in namespace "pe1" at level 2 on interface "p" should be up
+    And isis neighbor in namespace "pe2" at level 2 on interface "p" should be up
+
+  Scenario: Customer routes are carried as VPNv6 (CE IS-IS->eBGP, up direction)
+    Given the test topology exists
+    Then BGP session in "pe1" to "2001:db8::3" should be "Established"
+    And BGP session in "pe2" to "2001:db8::1" should be "Established"
+    And show command "show bgp vpnv6" in namespace "pe1" should eventually contain "2001:db8:c2::1/128"
+    And show command "show bgp vpnv6" in namespace "pe2" should eventually contain "2001:db8:c1::1/128"
+
+  Scenario: End-to-end customer loopback reachability across the SRv6 core
+    Given the test topology exists
+    Then ping from "c1" to "2001:db8:c2::1" should eventually succeed
+    And ping from "c2" to "2001:db8:c1::1" should eventually succeed
+
+  Scenario: Teardown topology
+    Given the test topology exists
+    When I stop zebra-rs in namespace "c1"
+    And I stop zebra-rs in namespace "ce1"
+    And I stop zebra-rs in namespace "pe1"
+    And I stop zebra-rs in namespace "p"
+    And I stop zebra-rs in namespace "pe2"
+    And I stop zebra-rs in namespace "ce2"
+    And I stop zebra-rs in namespace "c2"
+    And I delete namespace "c1"
+    And I delete namespace "ce1"
+    And I delete namespace "pe1"
+    And I delete namespace "p"
+    And I delete namespace "pe2"
+    And I delete namespace "ce2"
+    And I delete namespace "c2"
+    Then the test environment should be clean

--- a/bdd/tests/features/l3vpn_ospf_bgppe_v4.feature
+++ b/bdd/tests/features/l3vpn_ospf_bgppe_v4.feature
@@ -1,0 +1,80 @@
+@serial
+@l3vpn_ospf_bgppe_v4
+Feature: MPLS/VPN L3VPN (IPv4) with OSPFv2 C-CE and BGP PE-CE
+  Second L3VPN PE-CE variant: the customer runs OSPFv2 to the CE, but the
+  CE-PE link is eBGP (not OSPF). The CE bridges the two with mutual
+  redistribution (OSPF<->BGP); the PE is a plain BGP PE-CE edge. So C1
+  and C2 reach each other's loopback across the MPLS/VPN core.
+
+  vs @l3vpn_ospf_v4 (OSPF on both segments): here the PE has no VRF OSPF
+  — it runs an eBGP PE-CE session into vrf-cust like @l3vpn_bgp_v4, and
+  the CE does `redistribute ospf`->BGP (up) and `redistribute bgp`->OSPF
+  (down).
+
+  Scenario: Build the L3VPN topology and bring up the core
+    Given a clean test environment
+    When I create namespace "c1"
+    And I create namespace "ce1"
+    And I create namespace "pe1"
+    And I create namespace "p"
+    And I create namespace "pe2"
+    And I create namespace "ce2"
+    And I create namespace "c2"
+    And I connect namespace "c1" interface "ce1" to namespace "ce1" interface "c1"
+    And I connect namespace "ce1" interface "pe1" to namespace "pe1" interface "ce1"
+    And I connect namespace "pe1" interface "p" to namespace "p" interface "pe1"
+    And I connect namespace "p" interface "pe2" to namespace "pe2" interface "p"
+    And I connect namespace "pe2" interface "ce2" to namespace "ce2" interface "pe2"
+    And I connect namespace "ce2" interface "c2" to namespace "c2" interface "ce2"
+    And I start zebra-rs in namespace "c1"
+    And I start zebra-rs in namespace "ce1"
+    And I start zebra-rs in namespace "pe1"
+    And I start zebra-rs in namespace "p"
+    And I start zebra-rs in namespace "pe2"
+    And I start zebra-rs in namespace "ce2"
+    And I start zebra-rs in namespace "c2"
+    And I apply config "c1.yaml" to namespace "c1"
+    And I apply config "ce1.yaml" to namespace "ce1"
+    And I apply config "pe1.yaml" to namespace "pe1"
+    And I apply config "p.yaml" to namespace "p"
+    And I apply config "pe2.yaml" to namespace "pe2"
+    And I apply config "ce2.yaml" to namespace "ce2"
+    And I apply config "c2.yaml" to namespace "c2"
+    And I wait 120 seconds for BGP to operate
+    Then isis neighbor in namespace "pe1" at level 2 on interface "p" should be up
+    And isis neighbor in namespace "pe2" at level 2 on interface "p" should be up
+
+  Scenario: Customer routes are carried as VPNv4 (CE OSPF->eBGP, up direction)
+    Given the test topology exists
+    Then BGP session in "pe1" to "1.1.1.3" should be "Established"
+    And BGP session in "pe2" to "1.1.1.1" should be "Established"
+    And show command "show bgp vpnv4" in namespace "pe1" should eventually contain "10.0.2.1/32"
+    And show command "show bgp vpnv4" in namespace "pe2" should eventually contain "10.0.1.1/32"
+
+  Scenario: Remote customer loopbacks reach the customer site (CE eBGP->OSPF, down direction)
+    Given the test topology exists
+    Then show command "show ip route" in namespace "c1" should eventually contain "10.0.2.1"
+    And show command "show ip route" in namespace "c2" should eventually contain "10.0.1.1"
+
+  Scenario: End-to-end customer loopback reachability across the MPLS/VPN core
+    Given the test topology exists
+    Then ping from "c1" to "10.0.2.1" should eventually succeed
+    And ping from "c2" to "10.0.1.1" should eventually succeed
+
+  Scenario: Teardown topology
+    Given the test topology exists
+    When I stop zebra-rs in namespace "c1"
+    And I stop zebra-rs in namespace "ce1"
+    And I stop zebra-rs in namespace "pe1"
+    And I stop zebra-rs in namespace "p"
+    And I stop zebra-rs in namespace "pe2"
+    And I stop zebra-rs in namespace "ce2"
+    And I stop zebra-rs in namespace "c2"
+    And I delete namespace "c1"
+    And I delete namespace "ce1"
+    And I delete namespace "pe1"
+    And I delete namespace "p"
+    And I delete namespace "pe2"
+    And I delete namespace "ce2"
+    And I delete namespace "c2"
+    Then the test environment should be clean

--- a/bdd/tests/features/l3vpn_ospf_bgppe_v6.feature
+++ b/bdd/tests/features/l3vpn_ospf_bgppe_v6.feature
@@ -1,0 +1,72 @@
+@serial
+@l3vpn_ospf_bgppe_v6
+Feature: SRv6 L3VPN (IPv6) with OSPFv3 C-CE and BGP PE-CE
+  Second L3VPN PE-CE variant over SRv6: the customer runs OSPFv3 to the
+  CE, the CE-PE link is IPv6 eBGP, and the CE bridges them with mutual
+  redistribution (OSPFv3<->BGP). The PE is a plain BGP PE-CE edge like the
+  l3vpn_bgp_v6 feature. C1 and C2 reach each other's IPv6 loopback across
+  the SRv6 core. Exercises the relayed-SRv6-SID strip on the PE->CE eBGP
+  advertisement (the CE is non-SRv6).
+
+  Scenario: Build the SRv6 L3VPN topology and bring up the core
+    Given a clean test environment
+    When I create namespace "c1"
+    And I create namespace "ce1"
+    And I create namespace "pe1"
+    And I create namespace "p"
+    And I create namespace "pe2"
+    And I create namespace "ce2"
+    And I create namespace "c2"
+    And I connect namespace "c1" interface "ce1" to namespace "ce1" interface "c1"
+    And I connect namespace "ce1" interface "pe1" to namespace "pe1" interface "ce1"
+    And I connect namespace "pe1" interface "p" to namespace "p" interface "pe1"
+    And I connect namespace "p" interface "pe2" to namespace "pe2" interface "p"
+    And I connect namespace "pe2" interface "ce2" to namespace "ce2" interface "pe2"
+    And I connect namespace "ce2" interface "c2" to namespace "c2" interface "ce2"
+    And I start zebra-rs in namespace "c1"
+    And I start zebra-rs in namespace "ce1"
+    And I start zebra-rs in namespace "pe1"
+    And I start zebra-rs in namespace "p"
+    And I start zebra-rs in namespace "pe2"
+    And I start zebra-rs in namespace "ce2"
+    And I start zebra-rs in namespace "c2"
+    And I apply config "c1.yaml" to namespace "c1"
+    And I apply config "ce1.yaml" to namespace "ce1"
+    And I apply config "pe1.yaml" to namespace "pe1"
+    And I apply config "p.yaml" to namespace "p"
+    And I apply config "pe2.yaml" to namespace "pe2"
+    And I apply config "ce2.yaml" to namespace "ce2"
+    And I apply config "c2.yaml" to namespace "c2"
+    And I wait 120 seconds for BGP to operate
+    Then isis neighbor in namespace "pe1" at level 2 on interface "p" should be up
+    And isis neighbor in namespace "pe2" at level 2 on interface "p" should be up
+
+  Scenario: Customer routes are carried as VPNv6 (CE OSPFv3->eBGP, up direction)
+    Given the test topology exists
+    Then BGP session in "pe1" to "2001:db8::3" should be "Established"
+    And BGP session in "pe2" to "2001:db8::1" should be "Established"
+    And show command "show bgp vpnv6" in namespace "pe1" should eventually contain "2001:db8:c2::1/128"
+    And show command "show bgp vpnv6" in namespace "pe2" should eventually contain "2001:db8:c1::1/128"
+
+  Scenario: End-to-end customer loopback reachability across the SRv6 core
+    Given the test topology exists
+    Then ping from "c1" to "2001:db8:c2::1" should eventually succeed
+    And ping from "c2" to "2001:db8:c1::1" should eventually succeed
+
+  Scenario: Teardown topology
+    Given the test topology exists
+    When I stop zebra-rs in namespace "c1"
+    And I stop zebra-rs in namespace "ce1"
+    And I stop zebra-rs in namespace "pe1"
+    And I stop zebra-rs in namespace "p"
+    And I stop zebra-rs in namespace "pe2"
+    And I stop zebra-rs in namespace "ce2"
+    And I stop zebra-rs in namespace "c2"
+    And I delete namespace "c1"
+    And I delete namespace "ce1"
+    And I delete namespace "pe1"
+    And I delete namespace "p"
+    And I delete namespace "pe2"
+    And I delete namespace "ce2"
+    And I delete namespace "c2"
+    Then the test environment should be clean


### PR DESCRIPTION
## Summary

The complement to the IGP-on-both-segments L3VPN PE-CE features (#1686/#1687/#1688): here only the **C-CE** segment runs an IGP, the **CE-PE** link is eBGP, and the CE bridges them with mutual redistribution. The PE is a plain BGP PE-CE edge (reuses the BGP-phase PE/core configs). Pure BDD — **no product code changes**.

- **up:** `router bgp … redistribute {ospf|isis}` → the CE advertises C's IGP-learned routes to the PE over eBGP → VPNv4/VPNv6.
- **down:** `router {ospf|isis} … redistribute bgp` → the CE injects the PE-sent (remote-customer) routes back into the C-facing IGP.
- The CE also `redistribute connected` into BGP so its C-CE link subnet is reachable across the VPN (that link is *connected* on the CE, not an IGP route, so redistribute-{ospf,isis} alone wouldn't carry it — the link-sourced customer ping would have no return path).

All the knobs already exist: instance-level `redistribute bgp` (OSPFv2/v3/IS-IS) and global BGP `redistribute {ospf,isis}`. The v6 features also re-exercise the relayed-SRv6-SID strip on the PE→CE eBGP advertisement (the CE is non-SRv6).

## Test plan
BDD (local, BDD is excluded from CI):
- `@l3vpn_ospf_bgppe_v4` 5/5, `@l3vpn_isis_bgppe_v4` 5/5
- `@l3vpn_ospf_bgppe_v6` 4/4, `@l3vpn_isis_bgppe_v6` 4/4

120s convergence wait: the eBGP→iBGP→eBGP advertisement chain plus two CE redistribution hops converges at ~90s (measured, stable thereafter), so the wait carries margin.

## Matrix
This completes the **second** PE-CE variant the design called for. With it, both variants now cover all 4 protocol families × {IPv4/MPLS, IPv6/SRv6}.

Generated with [Claude Code](https://claude.com/claude-code)