### PR TITLE
bgp/mup: show originated routes in their originating VRF

### DIFF
--- a/book/src/ch-02-35-bgp-mup.md
+++ b/book/src/ch-02-35-bgp-mup.md
@@ -243,30 +243,35 @@ while carrying the IPv4 endpoint.
 
 ## Route-target import and cross-VRF import
 
-Per-VRF MUP follows the **same route-target import model as VPNv4/v6**: a
-MUP route lands in a VRF when the route's route-targets overlap that VRF's
-`mup route-target import` set — **not** when the route's RD matches the
-VRF's `rd`. The RD on a MUP NLRI is just an identifier; which VRFs a route
-reaches is driven entirely by route-targets.
+Per-VRF MUP populates `show bgp vrf <name> mup` two ways, mirroring
+VPNv4/v6:
 
-This makes **cross-VRF import** work exactly as it does for L3VPN: a route
-originated under one RD can be imported into a VRF whose own `rd` is
-different, purely because the importing VRF's `import` RT matches an RT the
-route carries.
+* **Locally-originated routes** always appear in the VRF that originated
+  them — the VRF whose `rd` the route carries — **regardless of
+  route-targets**, even with no `mup route-target` configured at all. A
+  `route st1`/`st2` ST route and a `segment` DSD/ISD are born in their VRF,
+  so that VRF owns them. (Origination itself runs in the global BGP task;
+  the route is mirrored back to its VRF by RD.)
+* **Route-target import** pulls in routes from *other* VRFs and from peers:
+  a route also lands in any VRF whose `mup route-target import` set overlaps
+  the route's route-targets, regardless of whether its RD matches.
+
+The second rule is what makes **cross-VRF import** work, exactly as it does
+for L3VPN: a route originated under one RD can be imported into a VRF whose
+own `rd` is different, purely because the importing VRF's `import` RT matches
+an RT the route carries.
 
 ```
 vrf N6 {                      # rd 65501:20 — originates the ISD
   mup {
     route-target {
       export 65501:10;        # the ISD it originates carries RT 65501:10
-      import 65501:10;        # …and N6 self-imports it, so it shows its own ISD
     }
   }
 }
 vrf N3 {                      # rd 65501:10 — a different VRF
   mup {
     route-target {
-      export 65501:20;
       import 65501:10;        # N3 imports RT 65501:10 → pulls in N6's ISD
     }
   }
@@ -274,16 +279,11 @@ vrf N3 {                      # rd 65501:10 — a different VRF
 ```
 
 Here VRF N6 originates an ISD (`segment interwork`) whose NLRI carries RD
-`65501:20` and RT `65501:10`. VRF N3's `rd` is `65501:10`, which does **not**
-match the ISD's RD — yet because N3 imports RT `65501:10`, the ISD appears in
-`show bgp vrf N3 mup`. N6 also imports `65501:10`, so it still shows its own
-originated ISD.
-
-Note the consequence: origination is **global**, while the per-VRF view is
-**import-only**. A VRF therefore shows a route it originated in
-`show bgp vrf <name> mup` only if it also imports that route's RT (as N6 does
-above). The `@bgp_mup_vrf_import` BDD feature exercises exactly this cross-RD
-import.
+`65501:20` and RT `65501:10`. N6 shows that ISD in `show bgp vrf N6 mup` by
+virtue of having originated it (the RD-origin rule) — no import is needed.
+VRF N3's `rd` is `65501:10`, which does **not** match the ISD's RD, yet
+because N3 imports RT `65501:10` the ISD also appears in `show bgp vrf N3
+mup`. The `@bgp_mup_vrf_import` BDD feature exercises this cross-RD import.
 
 ## Showing MUP state
 
@@ -301,12 +301,13 @@ MUP VRFs:
        rt:65000:200
 ```
 
-`show bgp vrf <name> mup` renders the MUP routes that VRF imports — every
-route whose route-targets overlap the VRF's `mup route-target import` set
-(see [Route-target import and cross-VRF import](#route-target-import-and-cross-vrf-import) above), which may include routes
-originated under a different RD. The authoritative MUP Loc-RIB and the
-advertiser stay on the global instance; the RT-matched best-paths are
-mirrored into the per-VRF task so the per-VRF view renders them:
+`show bgp vrf <name> mup` renders the MUP routes that belong to one VRF:
+the routes that VRF **originated** (matched by RD) plus the routes it
+**imports** by route-target (see
+[Route-target import and cross-VRF import](#route-target-import-and-cross-vrf-import)
+above) — the latter possibly originated under a different RD. The global
+MUP Loc-RIB stays the authoritative advertiser; the per-VRF task holds its
+own RIB of these routes so the per-VRF view renders them:
 
 ```
 # show bgp vrf mobile-up mup

--- a/zebra-rs/src/bgp/inst.rs
+++ b/zebra-rs/src/bgp/inst.rs
@@ -319,6 +319,28 @@ pub(crate) fn matching_import_vrfs_mup(
         .collect()
 }
 
+/// The set of per-VRF tasks a MUP best-path should be mirrored into: the
+/// RT-importing VRFs ([`matching_import_vrfs_mup`]) plus the originating
+/// VRF `origin_vrf` when set. The originating VRF (the one whose `rd`
+/// equals the route's RD) is included **regardless of route-targets** —
+/// a route is always shown in the VRF that originated it, even with no
+/// import/export configured, mirroring VPNv4/v6 where a VRF owns the
+/// routes it originates. The receive path passes `origin_vrf = None`
+/// (a peer-learned route has no local originating VRF).
+pub(crate) fn mup_dispatch_targets(
+    vrf_index: &BTreeMap<String, RibKnownVrf>,
+    ecom: &Option<bgp_packet::ExtCommunity>,
+    origin_vrf: Option<&str>,
+) -> Vec<String> {
+    let mut targets = matching_import_vrfs_mup(vrf_index, ecom);
+    if let Some(origin) = origin_vrf
+        && !targets.iter().any(|n| n == origin)
+    {
+        targets.push(origin.to_string());
+    }
+    targets
+}
+
 /// Extract the route-target set a route carries: every extended
 /// community with RT sub-type (`low_type == 0x02`), reinterpreted as a
 /// `RouteDistinguisher` (RT and RD share the on-wire 6-octet shape).
@@ -5506,7 +5528,7 @@ mod tests {
 
         use super::super::{
             RibKnownVrf, import_targets, import_targets_v6, matching_import_vrfs,
-            matching_import_vrfs_mup, matching_import_vrfs_v6,
+            matching_import_vrfs_mup, matching_import_vrfs_v6, mup_dispatch_targets,
         };
 
         fn rt(s: &str) -> RouteDistinguisher {
@@ -5678,6 +5700,62 @@ mod tests {
             let mut index = BTreeMap::new();
             index.insert("N3".to_string(), vrf_with_mup_imports(&["65501:10"]));
             assert!(matching_import_vrfs_mup(&index, &None).is_empty());
+        }
+
+        #[test]
+        fn mup_dispatch_includes_origin_vrf_without_rt() {
+            // A locally-originated MUP route whose VRF has NO matching
+            // import RT (and the route carries no RTs at all) is still
+            // mirrored into its originating VRF, so `show bgp vrf <name>
+            // mup` shows it with no import/export configured.
+            let mut index = BTreeMap::new();
+            index.insert("N6".to_string(), vrf_with_mup_imports(&[]));
+            assert_eq!(
+                mup_dispatch_targets(&index, &None, Some("N6")),
+                vec!["N6".to_string()]
+            );
+        }
+
+        #[test]
+        fn mup_dispatch_origin_not_duplicated_when_rt_also_matches() {
+            // When the originating VRF also imports the route's own RT, it
+            // is a target exactly once (not via both the RT match and the
+            // RD origin).
+            let mut index = BTreeMap::new();
+            index.insert("N6".to_string(), vrf_with_mup_imports(&["65501:10"]));
+            let ecom = Some(ExtCommunity::from([rt_extcom("65501:10")]));
+            assert_eq!(
+                mup_dispatch_targets(&index, &ecom, Some("N6")),
+                vec!["N6".to_string()]
+            );
+        }
+
+        #[test]
+        fn mup_dispatch_origin_plus_cross_vrf_rt_import() {
+            // The #1681 cross-VRF case: N6 originates a route (RD origin),
+            // and a sibling N3 imports the route's RT. Both are targets —
+            // N6 by RD origin, N3 by RT import.
+            let mut index = BTreeMap::new();
+            index.insert("N3".to_string(), vrf_with_mup_imports(&["65501:10"]));
+            index.insert("N6".to_string(), vrf_with_mup_imports(&[]));
+            let ecom = Some(ExtCommunity::from([rt_extcom("65501:10")]));
+            let mut got = mup_dispatch_targets(&index, &ecom, Some("N6"));
+            got.sort();
+            assert_eq!(got, vec!["N3".to_string(), "N6".to_string()]);
+        }
+
+        #[test]
+        fn mup_dispatch_no_origin_is_rt_only() {
+            // The receive path passes `origin = None` → pure RT import,
+            // identical to `matching_import_vrfs_mup`.
+            let mut index = BTreeMap::new();
+            index.insert("N3".to_string(), vrf_with_mup_imports(&["65501:10"]));
+            index.insert("N6".to_string(), vrf_with_mup_imports(&[]));
+            let ecom = Some(ExtCommunity::from([rt_extcom("65501:10")]));
+            assert_eq!(
+                mup_dispatch_targets(&index, &ecom, None),
+                vec!["N3".to_string()]
+            );
         }
 
         #[test]

--- a/zebra-rs/src/bgp/route.rs
+++ b/zebra-rs/src/bgp/route.rs
@@ -7610,10 +7610,11 @@ pub fn route_mup_update(
     let _ = bgp.local_rib.update_mup(rd, prefix.clone(), rib);
     let selected = bgp.local_rib.select_best_path_mup(&rd, &prefix);
     // Mirror the new best-path to every VRF whose `mup import` RT set
-    // matches, so `show bgp vrf <name> mup` reflects peer-learned routes
-    // (display only; the global Loc-RIB stays authoritative).
+    // matches, so `show bgp vrf <name> mup` reflects peer-learned routes.
+    // A peer-learned route has no local originating VRF (`origin_vrf =
+    // None`), so it is imported purely by route-target.
     if let Some(dispatcher) = bgp.vrf_import {
-        super::vrf::dispatch_mup(dispatcher, rd, &prefix, selected.first());
+        super::vrf::dispatch_mup(dispatcher, rd, &prefix, selected.first(), None);
     }
     if !selected.is_empty() {
         route_advertise_mup_to_peers(rd, prefix, &selected, bgp, peers);
@@ -7633,9 +7634,10 @@ pub fn route_mup_withdraw(ident: usize, route: &MupRoute, bgp: &mut BgpTop, peer
     let selected = bgp.local_rib.select_best_path_mup(&rd, &prefix);
     // Mirror the post-withdraw state to per-VRF tasks: a remaining best
     // path is re-forwarded (matched by RT), otherwise the prefix is
-    // withdrawn from every VRF's display copy.
+    // withdrawn from every VRF's copy. A peer-learned route has no local
+    // originating VRF (`origin_vrf = None`).
     if let Some(dispatcher) = bgp.vrf_import {
-        super::vrf::dispatch_mup(dispatcher, rd, &prefix, selected.first());
+        super::vrf::dispatch_mup(dispatcher, rd, &prefix, selected.first(), None);
     }
     if selected.is_empty() {
         route_withdraw_mup_to_peers(rd, prefix, peers);
@@ -12896,17 +12898,35 @@ impl Bgp {
         prefix: bgp_packet::MupPrefix,
         selected: Vec<BgpRib>,
     ) {
-        // Import the best-path into every VRF whose `mup_import_rts` match
-        // the route's RTs — the same RT-matched dispatch the receive path
-        // uses, so locally-originated and peer-learned MUP routes reach the
-        // per-VRF tasks by one consistent rule. (Originated routes carry the
-        // VRF's export RTs; a VRF self-imports when it also imports them.)
+        // Mirror the best-path into the per-VRF tasks. Other VRFs import it
+        // by route-target (cross-VRF import). The VRF that *originated* it —
+        // the one whose `rd` equals the route's RD — also gets it regardless
+        // of route-targets: origination runs in this global task, but the
+        // route is conceptually born in that VRF (an ST route from its
+        // `route st1/st2`, or its `segment` DSD/ISD), so it must appear in
+        // `show bgp vrf <name> mup` even with no import/export configured,
+        // mirroring VPNv4/v6 where a VRF owns the routes it originates.
         {
+            let origin_vrf = selected
+                .first()
+                .filter(|best| best.typ.is_originated())
+                .and_then(|_| {
+                    self.vrfs
+                        .iter()
+                        .find(|(_, cfg)| cfg.rd == Some(rd))
+                        .map(|(name, _)| name.clone())
+                });
             let dispatcher = super::vrf::VrfImportDispatcher {
                 rib_known_vrfs: &self.rib_known_vrfs,
                 vrf_registry: &self.vrf_registry,
             };
-            super::vrf::dispatch_mup(&dispatcher, rd, &prefix, selected.first());
+            super::vrf::dispatch_mup(
+                &dispatcher,
+                rd,
+                &prefix,
+                selected.first(),
+                origin_vrf.as_deref(),
+            );
         }
         if selected.is_empty() {
             route_withdraw_mup_to_peers(rd, prefix, &mut self.peers);

--- a/zebra-rs/src/bgp/vrf/inst.rs
+++ b/zebra-rs/src/bgp/vrf/inst.rs
@@ -357,34 +357,40 @@ pub fn dispatch_withdraw_import_v6(
     }
 }
 
-/// Mirror a peer-learned MUP (SAFI 85) best-path — or its withdrawal —
-/// to every VRF whose `mup_import_rts` intersects the route's RT
-/// extcomms, so `show bgp vrf <name> mup` reflects routes received from
-/// peers (not just locally-originated Session-Transformed routes). This
-/// is **display only**: the global `Bgp` Loc-RIB stays the authoritative
-/// MUP RIB and advertiser. It mirrors the originate-side
-/// [`super::super::route::Bgp::forward_mup_to_vrf`], which keys on `rd`
-/// because it already knows the originating VRF; the receive path has no
-/// such context, so it keys on the route's RTs like the VPNv4/v6 import
-/// fan-out.
+/// Mirror a MUP (SAFI 85) best-path — or its withdrawal — into the
+/// per-VRF tasks so `show bgp vrf <name> mup` reflects it. A route reaches
+/// a VRF two ways, mirroring VPNv4/v6:
+///   * **RT import** — every VRF whose `mup_import_rts` intersects the
+///     route's RT extcomms (cross-VRF import + peer-learned routes).
+///   * **RD origin** — when `origin_vrf` is `Some`, the VRF that locally
+///     originated the route (its `rd` equals the route's RD) always
+///     receives it, *regardless of route-targets*, because the route is
+///     conceptually born in that VRF (an N6/N3 ST route, or a per-VRF
+///     DSD/ISD segment route). The receive path passes `None` — a
+///     peer-learned route has no local originating VRF — so it keys purely
+///     on RTs; the originate path passes the RD-matched VRF name.
 ///
-/// On withdrawal (`best` is `None`) the route's RTs are no longer
-/// available, so `BgpVrfMsg::MupWithdraw` is flooded to every VRF — the
-/// per-VRF `selected.remove` is idempotent, so a VRF that never held the
-/// prefix simply ignores it.
+/// The per-VRF MUP RIB is authoritative for its own imported set (it owns
+/// best-path selection); the global `Bgp` Loc-RIB stays the authoritative
+/// advertiser. On withdrawal (`best` is `None`) the route's RTs are no
+/// longer available, so `BgpVrfMsg::MupWithdraw` is flooded to every VRF —
+/// the per-VRF removal is idempotent, so a VRF that never held the prefix
+/// simply ignores it (this covers the RD-origin VRF too).
 pub fn dispatch_mup(
     dispatcher: &VrfImportDispatcher<'_>,
     rd: bgp_packet::RouteDistinguisher,
     prefix: &bgp_packet::MupPrefix,
     best: Option<&super::super::route::BgpRib>,
+    origin_vrf: Option<&str>,
 ) {
     match best {
         Some(rib) => {
-            let matches = super::super::inst::matching_import_vrfs_mup(
+            let targets = super::super::inst::mup_dispatch_targets(
                 dispatcher.rib_known_vrfs,
                 &rib.attr.ecom,
+                origin_vrf,
             );
-            for vrf_name in matches {
+            for vrf_name in targets {
                 let Some(handle) = dispatcher.vrf_registry.get(&vrf_name) else {
                     continue;
                 };


### PR DESCRIPTION
## Summary

`show bgp vrf <name> mup` showed nothing for a VRF that originated an ST/segment route unless that VRF also imported its own export RT. Since PR #1679 unified all per-VRF MUP mirroring onto route-target import, a VRF with **no `mup route-target` configured at all** saw an empty per-VRF view even though it had originated the route — while the route was present in the global `show bgp mup`.

A locally-originated MUP route is conceptually born in the VRF whose `rd` it carries (an N6/N3 `route st1/st2` ST route, or a per-VRF `segment` DSD/ISD), so it must appear in that VRF's view regardless of route-targets, mirroring VPNv4/v6 where a VRF owns the routes it originates.

## Changes

- New pure `mup_dispatch_targets()` = RT-importing VRFs ∪ the originating VRF (deduped).
- `dispatch_mup()` gains an `origin_vrf: Option<&str>` param and delegates to the helper.
- `mup_apply_selected()` (the origination apply path) resolves the originating VRF by matching the route's RD against each VRF's `rd`, gated on the best path being `Originated`, and passes it.
- The two receive-path callers pass `origin_vrf = None` (a peer-learned route has no local originating VRF), so the receive path stays pure RT-import.
- 4 unit tests for the target-set logic (origin without RT, no duplicate when RT also matches, origin + cross-VRF RT import, receive-path None).
- Book ch-02-35 corrected: the per-VRF view is now described as RD-origin (always) + RT-import (cross-VRF / peer-learned), replacing the #1683 "import-only" wording.

Cross-VRF import (#1681) is unaffected: a sibling VRF still imports by RT; the originator now self-shows by RD instead of via its own import.

## Test plan

- `cargo test -p zebra-rs --bins` — 1492 pass (incl. 4 new `mup_dispatch_*` tests); `cargo test -p bgp-packet` — 393 pass.
- `cargo clippy --workspace --all-targets -- -D warnings` clean; `cargo fmt --check` clean.
- `mdbook build` clean.
- Live-validated (non-root debug daemon + pfcp-inject): two VRFs N3 (st2) / N6 (st1) bound to one NI with **no route-targets** → `show bgp vrf N3 mup` shows the ST2 and `show bgp vrf N6 mup` shows the ST1; `pfcp-inject --delete` clears the global and both per-VRF views.

Generated with [Claude Code](https://claude.com/claude-code)