### PR TITLE
bgp/mup: apply export route-target dynamically to ST routes

### DIFF
--- a/bdd/Makefile
+++ b/bdd/Makefile
@@ -84,6 +84,16 @@ bgp_mup_vrf_import:
 	mkdir -p allure-results
 	cargo test --test cucumber -- --concurrency=1 --tags "@bgp_mup_vrf_import"
 
+# MUP dynamic export RT: a controller ST2 is originated with no export
+# route-target, then `set vrf mobile-up mup route-target export 100:10` is
+# applied at runtime — the already-originated ST2 must be re-stamped with
+# rt:100:10 and re-advertised so the peer's per-VRF view (imports 100:10)
+# populates. Needs `pfcp-inject` on the host PATH and root netns (kernel VRF
+# for the export-RT to flow through the RIB Vrf row).
+bgp_mup_dynamic_rt:
+	mkdir -p allure-results
+	cargo test --test cucumber -- --concurrency=1 --tags "@bgp_mup_dynamic_rt"
+
 rib_static_ipv6:
 	mkdir -p allure-results
 	cargo test --test cucumber -- --concurrency=1 --tags "@rib_static_ipv6"

--- a/bdd/tests/configs/bgp_mup_dynamic_rt/z1.yaml
+++ b/bdd/tests/configs/bgp_mup_dynamic_rt/z1.yaml
@@ -1,0 +1,51 @@
+# z1 — MUP Controller (MUP-C) used to verify DYNAMIC apply of the per-VRF
+# MUP export route-target. AS 65001, iBGP to z2 (192.168.0.2) with the mup
+# afi-safi negotiated; PFCP/N4 listener on 192.168.0.1:8805.
+#
+# The VRF `mobile-up` binds Network Instance `core` to a Type-2 ST route
+# (`afi-safi mup route st2`) carrying the Direct segment id `1:2`. The
+# top-level `vrf mobile-up` exists but carries NO `mup route-target export`
+# initially — so the ST2 is first originated with no RT. The feature then
+# applies `set vrf mobile-up mup route-target export 100:10` at runtime,
+# which must re-stamp the already-originated ST2 with `rt:100:10` (the MUP
+# Extended Community `mup:1:2` preserved) and re-advertise it to z2 —
+# WITHOUT re-injecting the PFCP session. Before the fix, the export-RT
+# change only refreshed segment (DSD/ISD) routes, never the controller ST
+# routes, so the new RT never reached the route or the peer.
+#
+# No SRv6 locator is needed: a controller ST route carries no service SID
+# (the receiving PE derives forwarding from its own segments), only the
+# controller-address next hop.
+router:
+  bgp:
+    global:
+      as: 65001
+      router-id: 192.168.0.1
+    neighbor:
+    - remote-address: 192.168.0.2
+      remote-as: 65001
+      enabled: true
+      afi-safi:
+      - name: ipv4
+        enabled: true
+      - name: mup
+        enabled: true
+    vrf:
+    - name: mobile-up
+      rd: "65000:100"
+      afi-safi:
+        mup:
+          route:
+          - type: st2
+            network-instance: core
+            mup-ext-comm: "1:2"
+    mup-c:
+      enable: true
+      controller-address: 2001:db8::1
+      pfcp:
+        listen-address: 192.168.0.1
+        port: 8805
+# Top-level VRF exists but carries NO export route-target yet — the feature
+# adds `mup route-target export 100:10` at runtime.
+vrf:
+- name: mobile-up

--- a/bdd/tests/configs/bgp_mup_dynamic_rt/z2.yaml
+++ b/bdd/tests/configs/bgp_mup_dynamic_rt/z2.yaml
@@ -1,0 +1,35 @@
+# z2 — MUP ST2 route receiver. AS 65001, iBGP to z1 (192.168.0.1) with the
+# mup afi-safi negotiated. Plain BGP speaker: no controller, originates
+# nothing.
+#
+# `vrf mobile-up` imports MUP route-target 100:10. The peer-learned ST2 is
+# stored in the global MUP Loc-RIB on receipt regardless of RT, but only
+# mirrored into the per-VRF view (`show bgp vrf mobile-up mup`) when its
+# route-targets match this import set. So z2's per-VRF view stays EMPTY
+# until z1 dynamically gains `mup route-target export 100:10` and
+# re-advertises the re-stamped ST2 — which is the end-to-end proof that the
+# dynamic export-RT apply re-originated and re-advertised the route. The
+# `router bgp vrf` block spawns the per-VRF task the show is redirected to.
+vrf:
+- name: mobile-up
+  mup:
+    route-target:
+      import:
+      - "100:10"
+router:
+  bgp:
+    global:
+      as: 65001
+      router-id: 192.168.0.2
+    neighbor:
+    - remote-address: 192.168.0.1
+      remote-as: 65001
+      enabled: true
+      afi-safi:
+      - name: ipv4
+        enabled: true
+      - name: mup
+        enabled: true
+    vrf:
+    - name: mobile-up
+      rd: "65000:100"

--- a/bdd/tests/features/bgp_mup_dynamic_rt.feature
+++ b/bdd/tests/features/bgp_mup_dynamic_rt.feature
@@ -1,0 +1,93 @@
+@serial
+@bgp_mup_dynamic_rt
+Feature: BGP MUP export route-target applies dynamically to an originated ST route
+  As a network operator
+  I want a `set vrf <name> mup route-target export <rt>` change to take
+  effect on an already-originated controller Session-Transformed route,
+  re-stamping it with the new route-target and re-advertising it — without
+  re-establishing the PFCP session. The export RTs are read from the VRF
+  table at session-establish time, so a route originated before the RT is
+  configured (or before a later export-RT commit) must be re-tagged in
+  place. This regressed: the export-RT change refreshed only the DSD/ISD
+  segment routes, never the controller's ST1/ST2 routes, so the new RT
+  never reached the route or the peer.
+
+  Test Topology:
+  ```
+  ┌─────────────────────────────────────────┐
+  │                   br0                    │
+  └─────────────┬───────────────┬───────────┘
+                │               │
+           ┌────┴────┐     ┌────┴────┐
+           │   z1    │     │   z2    │
+           │ MUP-C   │ iBGP│ receiver│
+           │192.168. │◄───►│192.168. │
+           │  0.1/24 │     │  0.2/24 │
+           └────┬────┘     └─────────┘
+                │ PFCP/N4 (UDP 8805)
+           ┌────┴──────┐
+           │ pfcp-inject│  (SMF simulator, run in z1)
+           └───────────┘
+  ```
+
+  z1 runs the controller (PFCP listener on 192.168.0.1:8805, VRF
+  `mobile-up` binding Network Instance `core` to a Type-2 ST route with the
+  Direct segment id `1:2`). The top-level `vrf mobile-up` starts with NO
+  `mup route-target export`. z2 imports MUP route-target 100:10. The
+  feature injects a session (z1 originates the ST2 with no RT), then applies
+  `set vrf mobile-up mup route-target export 100:10` at runtime and checks
+  the ST2 is re-stamped on z1 and the re-advertised route reaches z2's
+  per-VRF view (which only imports 100:10).
+
+  NOTE: this feature runs `pfcp-inject` inside z1, so the `pfcp-inject`
+  binary (`tools/pfcp-inject`) must be on the BDD host PATH — build with
+  `cargo build --release -p pfcp-inject` and copy `target/release/pfcp-inject`
+  to /usr/bin, the same way the zebra-rs / vtyctl binaries are staged.
+
+  Scenario: Setup topology and establish iBGP session with MUP capability
+    Given a clean test environment
+    When I create bridge "br0"
+    And I create namespace "z1" with IP "192.168.0.1/24" on bridge "br0"
+    And I create namespace "z2" with IP "192.168.0.2/24" on bridge "br0"
+    And I start zebra-rs in namespace "z1"
+    And I start zebra-rs in namespace "z2"
+    And I apply config "z1.yaml" to namespace "z1"
+    And I apply config "z2.yaml" to namespace "z2"
+    And I wait 5 seconds for BGP to operate
+    Then BGP session in "z1" to "192.168.0.2" should be "Established"
+    And BGP session in "z2" to "192.168.0.1" should be "Established"
+    And show command "show bgp neighbor 192.168.0.2" in namespace "z1" should contain "IPv4 MUP: advertised and received"
+    And show command "show bgp mup mup-c" in namespace "z1" should contain "PFCP listen : 192.168.0.1:8805"
+
+  Scenario: Originate an ST2 with no export RT, then apply the export RT dynamically
+    Given the test topology exists
+    When I execute "pfcp-inject --target 192.168.0.1 --port 8805 --ue-ipv4 192.0.2.5 --teid 0x12345678 --endpoint 10.0.0.1 --network-instance core" in namespace "z1"
+    # PFCP ingest learned the session and z1 originated the ST2 — carrying
+    # the Direct segment id (mup:1:2) but NO route-target yet.
+    Then show command "show bgp mup mup-c session" in namespace "z1" should eventually contain "192.0.2.5"
+    And show command "show bgp mup" in namespace "z1" should eventually contain "[ST2][65000:100][ep=10.0.0.1][teid=305419896]"
+    And show command "show bgp mup" in namespace "z1" should not contain "rt:100:10"
+    # z2 receives the route into its global MUP Loc-RIB (RT-independent)...
+    And show command "show bgp mup" in namespace "z2" should eventually contain "[ST2][65000:100][ep=10.0.0.1][teid=305419896]"
+    # ...but its per-VRF view (imports 100:10) is empty: the route has no RT.
+    And show command "show bgp vrf mobile-up mup" in namespace "z2" should not contain "[ST2]"
+    # Apply the export route-target on the live VRF.
+    When I apply command "set vrf mobile-up mup route-target export 100:10" in namespace "z1"
+    # The already-originated ST2 is re-stamped in place: rt:100:10 is added,
+    # the Direct segment id mup:1:2 preserved.
+    Then show command "show bgp mup" in namespace "z1" should eventually contain "rt:100:10 mup:1:2"
+    # The re-advertised route reaches z2 carrying the new RT...
+    And show command "show bgp mup" in namespace "z2" should eventually contain "rt:100:10 mup:1:2"
+    # ...so z2's per-VRF view (imports 100:10) now mirrors it — the
+    # end-to-end proof that the export-RT change re-originated AND
+    # re-advertised the controller ST route.
+    And show command "show bgp vrf mobile-up mup" in namespace "z2" should eventually contain "[ST2][65000:100][ep=10.0.0.1][teid=305419896]"
+
+  Scenario: Teardown topology
+    Given the test topology exists
+    When I stop zebra-rs in namespace "z1"
+    And I stop zebra-rs in namespace "z2"
+    And I delete namespace "z1"
+    And I delete namespace "z2"
+    And I delete bridge "br0"
+    Then the test environment should be clean

--- a/zebra-rs/src/bgp/inst.rs
+++ b/zebra-rs/src/bgp/inst.rs
@@ -3324,10 +3324,17 @@ impl Bgp {
                 if export_v6_changed {
                     self.retag_vrf_exports_v6(&name);
                 }
-                // Re-stamp the VRF's DSD segment route with the new MUP
-                // export RTs (same race the v4/v6 retag above closes).
+                // Re-stamp the VRF's originated MUP routes with the new
+                // export RTs (same race the v4/v6 retag above closes, plus
+                // a later `set ... mup route-target export` commit). The
+                // DSD/ISD segment is rebuilt by `reconcile_mup_segment`
+                // (its skip-check compares the full ecom); the controller's
+                // ST1/ST2 routes are re-tagged in place by
+                // `retag_mup_st_exports` — without it they keep the RTs
+                // present at session-establish time.
                 if export_mup_changed {
                     self.reconcile_mup_segment();
+                    self.retag_mup_st_exports(&name);
                 }
             }
             // Redistribute deliveries from RIB — initial walk

--- a/zebra-rs/src/bgp/route.rs
+++ b/zebra-rs/src/bgp/route.rs
@@ -12804,6 +12804,64 @@ impl Bgp {
         }
     }
 
+    /// Re-stamp this VRF's originated controller Session-Transformed routes
+    /// (T1ST / T2ST) with the current `mup route-target export` set, then
+    /// re-advertise. The MUP counterpart of
+    /// [`super::inst::Bgp::retag_vrf_exports_v4`]: `build_mup_origination`
+    /// reads the export RTs from `rib_known_vrfs` at session-establish time,
+    /// so an ST route originated before its `VrfRouteTargets` lands — or
+    /// before a later `set vrf <name> mup route-target export` commit —
+    /// keeps stale (or empty) RTs until this runs. Only the Route-Target
+    /// ecoms (sub-type 0x02) are replaced; the MUP Extended Community (0x0c)
+    /// and the controller next-hop are preserved. Segment (DSD/ISD) routes
+    /// are refreshed separately by [`Self::reconcile_mup_segment`], whose
+    /// skip-check already compares the full ecom set.
+    pub(super) fn retag_mup_st_exports(&mut self, vrf: &str) {
+        let Some(rd) = self.vrfs.get(vrf).and_then(|c| c.rd) else {
+            return;
+        };
+        let export_rts = self
+            .rib_known_vrfs
+            .get(vrf)
+            .map(|k| k.mup_export_rts.clone())
+            .unwrap_or_default();
+        // Snapshot the originated ST rows (clone to release the `local_rib`
+        // borrow before re-advertising mutates it / `peers`).
+        let rows: Vec<(MupPrefix, BgpRib)> = self
+            .local_rib
+            .mup
+            .get(&rd)
+            .map(|t| {
+                t.cands
+                    .iter()
+                    .filter(|(p, _)| matches!(p, MupPrefix::T1st { .. } | MupPrefix::T2st { .. }))
+                    .filter_map(|(p, ribs)| {
+                        ribs.iter()
+                            .find(|r| r.typ == BgpRibType::Originated)
+                            .map(|r| (p.clone(), r.clone()))
+                    })
+                    .collect()
+            })
+            .unwrap_or_default();
+        for (prefix, mut rib) in rows {
+            let mut attr = (*rib.attr).clone();
+            // Strip existing Route-Target ecoms (sub-type 0x02) so a genuine
+            // RT change replaces rather than accumulates; keep the MUP
+            // Extended Community and anything else.
+            if let Some(ref mut ecom) = attr.ecom {
+                ecom.0.retain(|v| v.low_type != 0x02);
+                if ecom.0.is_empty() {
+                    attr.ecom = None;
+                }
+            }
+            let tagged = super::inst::tag_attr_with_export_rts(attr, &export_rts);
+            rib.attr = self.attr_store.intern(tagged);
+            let _ = self.local_rib.update_mup(rd, prefix.clone(), rib);
+            let selected = self.local_rib.select_best_path_mup(&rd, &prefix);
+            self.mup_apply_selected(rd, prefix, selected);
+        }
+    }
+
     /// Correlate a session to the VRF `mup` configs and build one ST prefix +
     /// attributes per matching VRF. A single Network Instance can be bound by
     /// more than one VRF — e.g. an N3 VRF binds `route st1` and an N6 VRF


### PR DESCRIPTION
## Summary

A `set vrf <name> mup route-target export <rt>` commit (or the `VrfRouteTargets` that arrives after a route is already originated) did **not** update the controller-originated ST1/ST2 routes. `build_mup_origination` reads the export RTs from `rib_known_vrfs` at session-establish time, and the `export_mup_changed` branch of the `VrfRouteTargets` handler only called `reconcile_mup_segment()` (DSD/ISD). So an already-originated ST route kept whatever RTs it had at establish time (usually none), and a later export-RT change never reached the route or the peer.

ipv4/ipv6 already handle this via `retag_vrf_exports_v4/v6` (snapshot the VRF's originated rows, replace the Route-Target ecoms, re-advertise). This adds the MUP counterpart.

## Changes

- `retag_mup_st_exports(vrf)` (route.rs) — re-tags the VRF's originated T1ST/T2ST rows in place with the current `mup route-target export` set and re-advertises. Only the RT ecoms (sub-type 0x02) are replaced; the MUP Extended Community (0x0c) and the controller next-hop are preserved.
- The `export_mup_changed` branch of the `VrfRouteTargets` handler (inst.rs) now calls `retag_mup_st_exports` alongside `reconcile_mup_segment` (segments were already refreshed correctly — their skip-check compares the full ecom).
- New BDD `@bgp_mup_dynamic_rt`: z1 originates an ST2 with no export RT, z2 imports `100:10`; after a runtime `set ... export 100:10`, z1's ST2 gains `rt:100:10`, z2 receives the re-advertised route, and z2's per-VRF view (imports `100:10`) — empty before — now mirrors it.

## Test plan

- `cargo test -p zebra-rs --bins` — 1492 pass; `cargo clippy --workspace --all-targets -- -D warnings` clean; `cargo fmt --check` clean.
- Live-validated (root netns): `set vrf N3 mup route-target export 100:10` stamps `rt:100:10` onto the existing ST2 (mup ext-comm preserved, the other VRF untouched); removing the export RT strips it again; `show bgp vrf N3 mup` reflects both.
- BDD `@bgp_mup_dynamic_rt` run as root: **3 scenarios / 31 steps pass**, clean teardown. (BDD is CI-excluded; needs root netns + `pfcp-inject` on PATH.)

Generated with [Claude Code](https://claude.com/claude-code)