### PR TITLE
bgp/mup: scope the per-VRF MUP RIB to the VRF's own RD

### DIFF
--- a/bdd/tests/features/bgp_mup_vrf_import.feature
+++ b/bdd/tests/features/bgp_mup_vrf_import.feature
@@ -56,10 +56,13 @@ Feature: BGP MUP cross-VRF import by route-target (RD-independent)
 
   Scenario: N3 imports N6's ISD across the RD boundary by route-target
     Given the test topology exists
-    # The crux: N3's own rd is 65501:10, but the ISD's RD is 65501:20. It
-    # appears here only because N3 imports RT 65501:10, which the ISD carries
-    # — RT-matched import, not RD-matched.
-    Then show command "show bgp vrf N3 mup" in namespace "z1" should eventually contain "[ISD][65501:20][10.60.0.0/16]"
+    # The crux: the ISD is originated under RD 65501:20, but N3 imports it
+    # because it carries RT 65501:10 (which N3 imports) — RT-matched import,
+    # not RD-matched. In N3's per-VRF view the route is keyed under N3's OWN
+    # rd (65501:10), not the origin RD 65501:20: a VRF holds its MUP routes
+    # under its own RD, the way an L3VPN VRF drops the VPNv4 RD on import.
+    # The carried route-target (rt:65501:10) is unchanged.
+    Then show command "show bgp vrf N3 mup" in namespace "z1" should eventually contain "[ISD][65501:10][10.60.0.0/16]"
     And show command "show bgp vrf N3 mup" in namespace "z1" should contain "End.DT46"
     And show command "show bgp vrf N3 mup" in namespace "z1" should contain "rt:65501:10"
 

--- a/zebra-rs/src/bgp/vrf/inst.rs
+++ b/zebra-rs/src/bgp/vrf/inst.rs
@@ -53,6 +53,15 @@ pub struct BgpVrf {
     /// `set router bgp vrf <name> router-id <addr>`, in which case
     /// the VRF is respawned with the new value.
     pub router_id: Ipv4Addr,
+    /// This VRF's Route Distinguisher (`set router bgp vrf <name> rd`),
+    /// or `None` if unset. The per-VRF MUP RIB is scoped to this single
+    /// RD: an imported MUP route is re-keyed under the VRF's *own* RD,
+    /// not the route's origin RD — the MUP analog of L3VPN dropping the
+    /// VPNv4 RD on import (a VRF owns its routes under its own RD).
+    /// Captured from the VRF config at spawn; an `rd` edit on a live VRF
+    /// doesn't yet re-key the running task (same spawn-time-capture
+    /// limitation as `router_id`).
+    pub rd: Option<bgp_packet::RouteDistinguisher>,
     /// Config-manager subscription. Path-dispatch routes
     /// `/router/bgp/vrf/<name>/...` callbacks here so the per-VRF
     /// runtime owns its own commit sequencing.
@@ -462,6 +471,8 @@ impl BgpVrf {
             local_rib: LocalRib::default(),
             shard: BgpShard::default(),
             router_id,
+            // Default unset; `spawn_bgp_vrf` sets it from the VRF config.
+            rd: None,
             cm: ConfigChannel::new(),
             show: ShowChannel::new(),
             global_tx,
@@ -1460,13 +1471,22 @@ impl BgpVrf {
             }
             // Authoritative per-VRF MUP import (RT-matched at the global
             // dispatch): insert the route as a candidate in this VRF's own
-            // per-RD MUP RIB and best-path it. The VRF receives the global
-            // winner per prefix, so best-path is single-candidate here, but
-            // the table is authoritative — `show bgp vrf <name> mup`
-            // (redirected here) reads the resulting `selected`. MUP has no
-            // CE peers and no kernel FIB yet, so this neither re-advertises
-            // nor installs; it owns the control-plane RIB only.
+            // MUP RIB and best-path it. The VRF receives the global winner
+            // per prefix, so best-path is single-candidate here, but the
+            // table is authoritative — `show bgp vrf <name> mup` (redirected
+            // here) reads the resulting `selected`. MUP has no CE peers and
+            // no kernel FIB yet, so this neither re-advertises nor installs;
+            // it owns the control-plane RIB only.
+            //
+            // The route is keyed under the VRF's *own* RD, not the message's
+            // origin RD: a VRF holds its MUP routes under its own RD (the one
+            // it would re-originate them with), exactly as an L3VPN VRF drops
+            // the VPNv4 RD on import. So a cross-RD import (e.g. an ISD
+            // originated under RD 65501:20, imported by a VRF whose rd is
+            // 65501:10) lands under 65501:10 here. A VRF with no `rd` falls
+            // back to the message RD.
             BgpVrfMsg::MupUpdate { rd, prefix, rib } => {
+                let rd = self.rd.unwrap_or(rd);
                 let _ = self
                     .local_rib
                     .mup
@@ -1475,9 +1495,11 @@ impl BgpVrf {
                     .update(prefix, rib);
             }
             BgpVrfMsg::MupWithdraw { rd, prefix } => {
-                // The VRF holds the single dispatched winner per prefix, so a
-                // prefix-keyed removal clears it; prune the per-RD table when
-                // it empties so an empty RD never renders.
+                // Same own-RD scoping as MupUpdate. The VRF holds the single
+                // dispatched winner per prefix, so a prefix-keyed removal
+                // clears it; prune the per-RD table when it empties so an
+                // empty RD never renders.
+                let rd = self.rd.unwrap_or(rd);
                 let empty = if let Some(table) = self.local_rib.mup.get_mut(&rd) {
                     table.cands.remove(&prefix);
                     table.selected.remove(&prefix);

--- a/zebra-rs/src/bgp/vrf/spawn.rs
+++ b/zebra-rs/src/bgp/vrf/spawn.rs
@@ -173,6 +173,11 @@ pub fn spawn_bgp_vrf(
     // Inter-AS Option AB: re-export imported VPNv4 routes (see the field
     // doc on `BgpVrf`). Carried from the staged VRF config.
     vrf.inter_as_hybrid = cfg.inter_as_hybrid;
+    // The VRF's RD scopes its per-VRF MUP RIB to its own RD (imported MUP
+    // routes are re-keyed under it, not their origin RD). Captured at spawn
+    // like router-id; an `rd` edit on a live VRF doesn't re-key the running
+    // task yet (a follow-up adds respawn-on-edit, same as router-id).
+    vrf.rd = cfg.rd;
 
     // Materialise per-VRF peers from the BgpVrfConfig snapshot.
     // `peer.start()`'s timer events get logged at debug and


### PR DESCRIPTION
## Summary

First step of the VRF-first MUP restructure (RD organization). The per-VRF MUP RIB previously keyed imported routes under the route's **origin** RD, so a cross-VRF import surfaced a foreign RD in `show bgp vrf <name> mup` — inconsistent with L3VPN, where a VRF drops the VPNv4 RD on import and holds the route under its own RD.

This captures the VRF's `rd` on the per-VRF `BgpVrf` task and re-keys imported MUP routes under it. A route imported by RT match now lands under the **importing VRF's own RD**, not the origin RD. The global SAFI-85 Loc-RIB stays RD-keyed by origin RD (it is the advertiser of record) — only the per-VRF view changes.

A MUP NLRI inherently carries an RD (unlike an IPv4 prefix), so the per-VRF view shows the VRF's own RD rather than dropping it entirely — the RD the VRF would re-originate the route with.

## Changes

- New `BgpVrf.rd` field, set from `cfg.rd` in `spawn_bgp_vrf` (spawn-time capture, same limitation as `router_id`).
- `MupUpdate`/`MupWithdraw` handlers key by `self.rd.unwrap_or(rd)`.
- `@bgp_mup_vrf_import` BDD updated: N3 (rd 65501:10) importing N6's ISD (origin rd 65501:20) now shows it as `[ISD][65501:10]`, not `[ISD][65501:20]`.

## Test plan

- `cargo test -p zebra-rs --bins` — 1492 pass; clippy + fmt clean.
- Root BDD: `@bgp_mup_vrf_import` 6/6 (cross-RD re-key + N6 self-show unchanged + both global RIBs keep origin RD); `@bgp_mup_{isd,segment_dsd,dynamic_rt,e2e}` green (same-RD cases unchanged). No binary stomp.

This is PR 1 of a staged VRF-first MUP series; subsequent PRs relocate origination into the per-VRF tasks with a `MupExport` channel.

Generated with [Claude Code](https://claude.com/claude-code)