### PR TITLE
bgp/mup: originate controller ST routes VRF-first

### DIFF
--- a/zebra-rs/src/bgp/config.rs
+++ b/zebra-rs/src/bgp/config.rs
@@ -7662,52 +7662,22 @@ mod afi_safi_next_hop_self_tests {
 
 #[cfg(test)]
 mod mup_dual_origination_tests {
-    //! `build_mup_origination` fans one PFCP session out to *every* VRF
-    //! whose `afi-safi mup route {st1|st2}` binding matches the session's
-    //! Network Instance — so a single session under `internet` originates
-    //! both the downlink (st1 / Type-1 ST, the N6 VRF) and the uplink
-    //! (st2 / Type-2 ST, the N3 VRF) routes. The earlier `find_map`
-    //! returned only the first match. Independent test module with its own
-    //! mock channels, mirroring `afi_safi_next_hop_self_tests`.
+    //! VRF-first MUP origination splits into a pure NI→VRF correlation
+    //! (`mup_session_targets`) and per-direction NLRI building
+    //! (`build_mup_st_route`). `mup_session_targets` fans one PFCP session out
+    //! to *every* VRF whose `afi-safi mup route {st1|st2}` binding matches the
+    //! session's Network Instance — so a single session under `internet`
+    //! targets both the downlink (st1 / N6) and uplink (st2 / N3) VRF —
+    //! and `build_mup_st_route` builds the RD-free T1ST / T2ST NLRI.
 
+    use std::collections::BTreeMap;
     use std::str::FromStr;
 
     use bgp_packet::{MupPrefix, RouteDistinguisher};
-    use tokio::sync::mpsc;
 
+    use super::super::route::build_mup_st_route;
+    use super::super::vrf::inst::mup_session_targets;
     use super::super::vrf_config::{BgpVrfConfig, MupSrv6Direction, MupSrv6Mobile};
-    use super::*;
-
-    fn fresh_bgp() -> Bgp {
-        let (inbound_tx, _inbound_rx) = mpsc::unbounded_channel();
-        let (_rib_rx_tx, rib_rx) = mpsc::unbounded_channel();
-        let client = crate::rib::client::RibClient::new(
-            inbound_tx,
-            crate::rib::client::ProtoId::from_raw(0),
-        );
-        Box::leak(Box::new(_inbound_rx));
-        let ctx = crate::context::ProtoContext::default_table(client);
-
-        let (rib_tx, _rib_rx) = mpsc::unbounded_channel();
-        let (rib_inbound_tx, _sub_inbound_rx) = mpsc::unbounded_channel();
-        Box::leak(Box::new(_rib_rx));
-        Box::leak(Box::new(_sub_inbound_rx));
-        let next_proto_id = std::sync::Arc::new(std::sync::atomic::AtomicU32::new(1));
-        let subscriber =
-            crate::config::RibSubscriber::for_test(rib_tx, rib_inbound_tx, next_proto_id);
-
-        let (policy_tx, _policy_rx) = mpsc::unbounded_channel();
-        Box::leak(Box::new(_policy_rx));
-        Bgp::new(
-            ctx,
-            rib_rx,
-            subscriber,
-            policy_tx,
-            None,
-            None,
-            tokio::sync::mpsc::channel(1).0,
-        )
-    }
 
     fn mup_vrf(rd: &str, direction: MupSrv6Direction, ni: &str, ext: Option<&str>) -> BgpVrfConfig {
         let mut cfg = BgpVrfConfig {
@@ -7737,16 +7707,16 @@ mod mup_dual_origination_tests {
     }
 
     /// One NI bound by both an st1 (N6 / downlink) VRF and an st2 (N3 /
-    /// uplink) VRF originates BOTH Session-Transformed routes from a single
-    /// session.
+    /// uplink) VRF targets BOTH VRFs from a single session — the dual-ST
+    /// fan-out.
     #[test]
-    fn one_session_originates_both_st1_and_st2() {
-        let mut bgp = fresh_bgp();
-        bgp.vrfs.insert(
+    fn one_session_targets_both_st1_and_st2() {
+        let mut vrfs = BTreeMap::new();
+        vrfs.insert(
             "N6".to_string(),
             mup_vrf("65501:1", MupSrv6Direction::Encapsulation, "internet", None),
         );
-        bgp.vrfs.insert(
+        vrfs.insert(
             "N3".to_string(),
             mup_vrf(
                 "65501:2",
@@ -7756,33 +7726,63 @@ mod mup_dual_origination_tests {
             ),
         );
 
-        let routes = bgp.build_mup_origination(&session("internet"));
-        assert_eq!(routes.len(), 2, "one session → both st1 and st2 routes");
+        let targets = mup_session_targets(&vrfs, &session("internet"));
+        assert_eq!(targets.len(), 2, "one session → both st1 and st2 VRFs");
         assert!(
-            routes
+            targets
                 .iter()
-                .any(|(_, p, _)| matches!(p, MupPrefix::T1st { .. })),
-            "downlink Type-1 ST originated from the st1 VRF",
+                .any(|(_, d, _)| matches!(d, MupSrv6Direction::Encapsulation)),
+            "downlink st1 (N6) is a target",
         );
         assert!(
-            routes
+            targets
                 .iter()
-                .any(|(_, p, _)| matches!(p, MupPrefix::T2st { .. })),
-            "uplink Type-2 ST originated from the st2 VRF",
+                .any(|(_, d, _)| matches!(d, MupSrv6Direction::Decapsulation)),
+            "uplink st2 (N3) is a target",
         );
     }
 
-    /// A session whose NI matches no VRF binding originates nothing.
+    /// A session whose NI matches no VRF binding targets nothing.
     #[test]
-    fn unmatched_ni_originates_nothing() {
-        let mut bgp = fresh_bgp();
-        bgp.vrfs.insert(
+    fn unmatched_ni_targets_nothing() {
+        let mut vrfs = BTreeMap::new();
+        vrfs.insert(
             "N3".to_string(),
             mup_vrf("65501:2", MupSrv6Direction::Decapsulation, "internet", None),
         );
         assert!(
-            bgp.build_mup_origination(&session("ims")).is_empty(),
+            mup_session_targets(&vrfs, &session("ims")).is_empty(),
             "no VRF binds NI `ims`",
+        );
+    }
+
+    /// st1 (Encapsulation) builds a Type-1 ST NLRI; st2 (Decapsulation)
+    /// builds a Type-2 ST NLRI carrying the Direct-segment MUP ext-comm. The
+    /// RD / export-RTs / next-hop are applied later at the global export
+    /// boundary, so the bare attr here carries only the route-specific ecom.
+    #[test]
+    fn st1_builds_t1st_st2_builds_t2st_with_ext_comm() {
+        let (p1, attr1) =
+            build_mup_st_route(&session("internet"), MupSrv6Direction::Encapsulation, None)
+                .unwrap();
+        assert!(matches!(p1, MupPrefix::T1st { .. }), "st1 → Type-1 ST");
+        assert!(attr1.ecom.is_none(), "st1 carries no ext-comm");
+
+        let seg = RouteDistinguisher::from_str("100:1").unwrap();
+        let (p2, attr2) = build_mup_st_route(
+            &session("internet"),
+            MupSrv6Direction::Decapsulation,
+            Some(seg),
+        )
+        .unwrap();
+        assert!(matches!(p2, MupPrefix::T2st { .. }), "st2 → Type-2 ST");
+        assert!(
+            attr2.ecom.is_some(),
+            "st2 carries the Direct-segment MUP ext-comm",
+        );
+        assert!(
+            attr2.nexthop.is_none(),
+            "next-hop applied at export, not here"
         );
     }
 }

--- a/zebra-rs/src/bgp/inst.rs
+++ b/zebra-rs/src/bgp/inst.rs
@@ -697,15 +697,6 @@ pub struct Bgp {
     /// commit; consumed (and cleared) at `CommitEnd` to decide whether to
     /// reconfigure a running controller.
     pub mup_c_dirty: bool,
-    /// MUP routes the controller has originated, keyed by session SEID →
-    /// the originated NLRIs. One session can map to several ST routes (an
-    /// st1 and an st2 VRF binding the same Network Instance), so a Vec of
-    /// prefixes is retained — a Session Deletion / Modification withdraws
-    /// the exact prior routes. No SRv6 SID is allocated for these (the PE
-    /// derives forwarding from its ISD/DSD routes), so only the prefixes
-    /// are retained.
-    pub mup_c_originated:
-        BTreeMap<u64, Vec<(bgp_packet::RouteDistinguisher, bgp_packet::MupPrefix)>>,
     /// Config-driven MUP Segment Discovery routes originated per VRF — a DSD
     /// (Direct, type 2, `afi-safi mup segment direct`) or an ISD (Interwork,
     /// type 1, `afi-safi mup segment interwork prefix <p>`); a VRF has at
@@ -1168,7 +1159,6 @@ impl Bgp {
             mup_c: None,
             mup_c_view: crate::mup_c::inst::MupCView::default(),
             mup_c_dirty: false,
-            mup_c_originated: BTreeMap::new(),
             mup_segment_originated: BTreeMap::new(),
             local_fdb: BTreeMap::new(),
             local_vxlans: BTreeMap::new(),
@@ -2091,8 +2081,17 @@ impl Bgp {
                 // renders.
                 use crate::mup_c::inst::MupCEvent;
                 match &ev {
-                    MupCEvent::SessionUp(session) => self.originate_mup_route(session),
-                    MupCEvent::SessionDown { seid } => self.withdraw_mup_route(*seid),
+                    // VRF-first origination: dispatch the session to the
+                    // matching VRF task(s), which build the RD-free ST NLRI and
+                    // export it back. A Modification (SessionUp for an existing
+                    // seid) is handled per-VRF: the `MupOriginate` handler
+                    // withdraws the session's prior exports before re-building.
+                    MupCEvent::SessionUp(session) => {
+                        super::vrf::dispatch_mup_session(&self.vrfs, &self.vrf_registry, session)
+                    }
+                    MupCEvent::SessionDown { seid } => {
+                        super::vrf::withdraw_mup_session(&self.vrf_registry, *seid)
+                    }
                     MupCEvent::AssocDown { peer } => {
                         // The peer's sessions are about to drop from the
                         // view; withdraw their routes first.
@@ -2104,7 +2103,7 @@ impl Bgp {
                             .map(|(seid, _)| *seid)
                             .collect();
                         for seid in seids {
-                            self.withdraw_mup_route(seid);
+                            super::vrf::withdraw_mup_session(&self.vrf_registry, seid);
                         }
                     }
                     MupCEvent::Listener { .. } | MupCEvent::AssocUp { .. } => {}
@@ -5119,6 +5118,15 @@ impl Bgp {
             }
             super::vrf::BgpGlobalMsg::RegisterPeer { vrf, addr } => {
                 peer_index_register(&mut self.peer_index, vrf, addr);
+            }
+            // VRF-first MUP origination: a per-VRF task built a controller ST
+            // route and exported it. Stamp the RD / export-RTs / controller
+            // next-hop and promote it into the SAFI-85 Loc-RIB + advertise.
+            super::vrf::BgpGlobalMsg::MupExport { vrf, prefix, attr } => {
+                self.mup_export(vrf, prefix, attr);
+            }
+            super::vrf::BgpGlobalMsg::WithdrawMupExport { vrf, prefix } => {
+                self.mup_withdraw_export(vrf, prefix);
             }
         }
     }

--- a/zebra-rs/src/bgp/route.rs
+++ b/zebra-rs/src/bgp/route.rs
@@ -7898,6 +7898,60 @@ fn build_mup_attr(
     attr
 }
 
+/// Build the RD-free Session-Transformed NLRI and route-specific attributes
+/// for a controller MUP route from a PFCP session, given the resolved
+/// direction (st1 = Encapsulation / st2 = Decapsulation) and the optional st2
+/// Direct-segment ext-comm. Used by the per-VRF task for VRF-first
+/// origination ([`super::vrf::inst`] `MupOriginate`): the returned `attr`
+/// carries only the route-specific extended community — the RD, export
+/// route-targets and the controller next-hop are applied at the global export
+/// boundary ([`Bgp::mup_export`]), mirroring how an L3VPN VRF emits a bare
+/// route and the global `Export` handler stamps the RD/RTs. Returns `None`
+/// when the session lacks the addresses that ST route type needs.
+pub(super) fn build_mup_st_route(
+    session: &crate::mup_c::session::MupSession,
+    direction: super::vrf_config::MupSrv6Direction,
+    ext_comm: Option<RouteDistinguisher>,
+) -> Option<(MupPrefix, BgpAttr)> {
+    use super::vrf_config::MupSrv6Direction;
+    let prefix = match direction {
+        // Encapsulation (N6 / downlink): Type-1 ST carries the UE prefix +
+        // access tunnel. The endpoint (gNB) family may differ from the UE
+        // prefix family (mixed-AFI 5G).
+        MupSrv6Direction::Encapsulation => match (mup_ue_prefix(session), session.endpoint) {
+            (Some(prefix), Some(endpoint)) => MupPrefix::T1st {
+                prefix,
+                teid: session.teid,
+                qfi: session.qfi.unwrap_or(0),
+                endpoint,
+                source: None,
+            },
+            _ => return None,
+        },
+        // Decapsulation (N3 / uplink): Type-2 ST carries the core endpoint +
+        // TEID. The Endpoint Length (draft §3.1.4.1) spans the address *and*
+        // the trailing 32-bit GTP TEID, so it is 64 (IPv4) / 160 (IPv6).
+        MupSrv6Direction::Decapsulation => match session.endpoint {
+            Some(endpoint) => MupPrefix::T2st {
+                endpoint,
+                endpoint_len: if endpoint.is_ipv4() { 64 } else { 160 },
+                teid: session.teid,
+            },
+            None => return None,
+        },
+    };
+    let mut attr = BgpAttr::new();
+    // §3.3.10: a Type-2 ST route SHOULD carry the BGP MUP Extended Community
+    // of the Direct segment it resolves to. RD / export-RTs / next-hop are
+    // stamped at the global export boundary, not here.
+    if matches!(direction, MupSrv6Direction::Decapsulation)
+        && let Some(seg) = ext_comm
+    {
+        attr_add_ecom(&mut attr, mup_direct_segment_ecom(&seg));
+    }
+    Some((prefix, attr))
+}
+
 /// Replay every selected MUP route from the Loc-RIB to a peer that just
 /// reached Established, for whichever MUP AFI(s) it negotiated, then send
 /// the MUP End-of-RIB per negotiated AFI. Without this a route learned
@@ -12748,60 +12802,64 @@ pub fn route_sync(peer: &mut Peer, bgp: &mut BgpTop, v4_via_pool: bool) {
 }
 
 impl Bgp {
-    /// Originate (or re-originate) a MUP Session-Transformed route for one
-    /// controller-learned session. Correlates the session's Network
-    /// Instance to a `router bgp vrf <name> mup` config, builds
-    /// the ST route with its attributes, installs into the MUP Loc-RIB as
-    /// `Originated`, and advertises. A prior route for the same session is
-    /// withdrawn first, so a Session Modification cleanly replaces it.
-    /// No-op when no VRF matches the NI or the VRF has no RD. No SRv6 SID
-    /// is allocated — the receiving PE derives forwarding from its own
-    /// ISD/DSD routes (draft-ietf-bess-mup-safi default).
-    pub fn originate_mup_route(&mut self, session: &crate::mup_c::session::MupSession) {
-        // Replace any prior routes for this session (Modification path).
-        self.withdraw_mup_route(session.seid);
-
-        let originations = self.build_mup_origination(session);
-        if originations.is_empty() {
-            return;
-        }
-        // One session can map to several ST routes (an st1 and an st2 VRF
-        // sharing the NI). Install + advertise each, recording every prefix
-        // so the deletion / next modification withdraws all of them.
-        let mut prefixes = Vec::with_capacity(originations.len());
-        for (rd, prefix, attr) in originations {
-            let mut rib = BgpRib::new(
-                ORIGINATED_PEER,
-                Ipv4Addr::UNSPECIFIED,
-                BgpRibType::Originated,
-                0,
-                32768,
-                &attr,
-                None,
-                None,
-                false,
-            );
-            rib.attr = self.attr_store.intern(attr);
-            let _ = self.local_rib.update_mup(rd, prefix.clone(), rib);
-            let selected = self.local_rib.select_best_path_mup(&rd, &prefix);
-            self.mup_apply_selected(rd, prefix.clone(), selected);
-            prefixes.push((rd, prefix));
-        }
-        self.mup_c_originated.insert(session.seid, prefixes);
-    }
-
-    /// Withdraw the MUP route(s) originated for `seid` (Session Deletion or
-    /// the replace step of a Modification). No-op when nothing was
-    /// originated.
-    pub fn withdraw_mup_route(&mut self, seid: u64) {
-        let Some(prefixes) = self.mup_c_originated.remove(&seid) else {
+    /// Promote a per-VRF-originated controller ST route into the global
+    /// SAFI-85 Loc-RIB and advertise it — the MUP export handler
+    /// (`BgpGlobalMsg::MupExport`), counterpart of the VPNv4 `Export`
+    /// handler. The per-VRF task built the RD-free NLRI + route-specific
+    /// ext-comm; here the global side stamps the infrastructure attributes
+    /// **at the export boundary**: the VRF's RD (`vrfs[vrf].rd`, also the
+    /// table key), its export route-targets (`rib_known_vrfs`), and the
+    /// controller next-hop (`mup_c_config`). Installs as `Originated` and
+    /// runs best-path → advertise + mirror (the mirror feeds the route back
+    /// to the originating VRF, so its `show bgp vrf <name> mup` reflects the
+    /// fully-stamped route). No-op when the VRF has no RD. No SRv6 SID — the
+    /// receiving PE derives forwarding from its own ISD/DSD routes.
+    pub fn mup_export(&mut self, vrf: String, prefix: MupPrefix, attr: BgpAttr) {
+        let Some(rd) = self.vrfs.get(&vrf).and_then(|c| c.rd) else {
             return;
         };
-        for (rd, prefix) in prefixes {
-            self.local_rib.remove_mup(rd, &prefix, 0, ORIGINATED_PEER);
-            let selected = self.local_rib.select_best_path_mup(&rd, &prefix);
-            self.mup_apply_selected(rd, prefix, selected);
+        let rts = self
+            .rib_known_vrfs
+            .get(&vrf)
+            .map(|k| k.mup_export_rts.clone())
+            .unwrap_or_default();
+        // Stamp the controller next-hop + export route-targets onto the bare
+        // attr the VRF emitted (it already carries any route-specific ecom,
+        // e.g. the st2 Direct-segment id, which `tag_attr_with_export_rts`
+        // preserves).
+        let mut attr = attr;
+        if let Some(addr) = self.mup_c_config.controller_address {
+            attr.nexthop = Some(BgpNexthop::Ipv6(addr));
         }
+        let attr = super::inst::tag_attr_with_export_rts(attr, &rts);
+        let mut rib = BgpRib::new(
+            ORIGINATED_PEER,
+            Ipv4Addr::UNSPECIFIED,
+            BgpRibType::Originated,
+            0,
+            32768,
+            &attr,
+            None,
+            None,
+            false,
+        );
+        rib.attr = self.attr_store.intern(attr);
+        let _ = self.local_rib.update_mup(rd, prefix.clone(), rib);
+        let selected = self.local_rib.select_best_path_mup(&rd, &prefix);
+        self.mup_apply_selected(rd, prefix, selected);
+    }
+
+    /// Inverse of [`Self::mup_export`] (`BgpGlobalMsg::WithdrawMupExport`):
+    /// remove the per-VRF-originated ST route under this VRF's RD and re-run
+    /// best-path → withdraw from peers + un-mirror. No-op when the VRF has no
+    /// RD (nothing was ever installed under it).
+    pub fn mup_withdraw_export(&mut self, vrf: String, prefix: MupPrefix) {
+        let Some(rd) = self.vrfs.get(&vrf).and_then(|c| c.rd) else {
+            return;
+        };
+        self.local_rib.remove_mup(rd, &prefix, 0, ORIGINATED_PEER);
+        let selected = self.local_rib.select_best_path_mup(&rd, &prefix);
+        self.mup_apply_selected(rd, prefix, selected);
     }
 
     /// Re-stamp this VRF's originated controller Session-Transformed routes
@@ -12860,92 +12918,6 @@ impl Bgp {
             let selected = self.local_rib.select_best_path_mup(&rd, &prefix);
             self.mup_apply_selected(rd, prefix, selected);
         }
-    }
-
-    /// Correlate a session to the VRF `mup` configs and build one ST prefix +
-    /// attributes per matching VRF. A single Network Instance can be bound by
-    /// more than one VRF — e.g. an N3 VRF binds `route st1` and an N6 VRF
-    /// binds `route st2` to the same `internet` NI — so one PFCP session
-    /// originates *both* Session-Transformed routes, one per matching VRF.
-    /// Returns an empty Vec when no VRF matches the session's Network
-    /// Instance. A matching VRF is skipped (no entry) when it has no RD or
-    /// the session lacks the addresses that ST route type needs.
-    pub(super) fn build_mup_origination(
-        &self,
-        session: &crate::mup_c::session::MupSession,
-    ) -> Vec<(
-        bgp_packet::RouteDistinguisher,
-        bgp_packet::MupPrefix,
-        BgpAttr,
-    )> {
-        use super::vrf_config::MupSrv6Direction;
-        let Some(ni) = session.network_instance.as_deref() else {
-            return Vec::new();
-        };
-        // Correlate the session NI to *every* `router bgp vrf <name> afi-safi
-        // mup route {st1|st2}` binding that matches it, building one ST route
-        // per match (RD + direction + the st2 ext-comm come from each VRF).
-        self.vrfs
-            .iter()
-            .filter_map(|(name, cfg)| {
-                let sm = cfg.mobile_uplane.srv6_mobile.as_ref()?;
-                if sm.network_instance.as_deref() != Some(ni) {
-                    return None;
-                }
-                let rd = cfg.rd?;
-                // The export route-targets now live on the top-level
-                // `vrf <name> mup route-target export` (RIB-owned, pushed to
-                // `rib_known_vrfs` via `VrfRouteTargets`), the same framework
-                // as ipv4 / ipv6.
-                let rts = self
-                    .rib_known_vrfs
-                    .get(name)
-                    .map(|k| k.mup_export_rts.clone())
-                    .unwrap_or_default();
-                let prefix = match sm.direction {
-                    // Encapsulation (N6 / downlink): Type-1 ST carries the UE
-                    // prefix + access tunnel. The endpoint (gNB) family may
-                    // differ from the UE prefix family (mixed-AFI 5G).
-                    MupSrv6Direction::Encapsulation => {
-                        match (mup_ue_prefix(session), session.endpoint) {
-                            (Some(prefix), Some(endpoint)) => bgp_packet::MupPrefix::T1st {
-                                prefix,
-                                teid: session.teid,
-                                qfi: session.qfi.unwrap_or(0),
-                                endpoint,
-                                source: None,
-                            },
-                            _ => return None,
-                        }
-                    }
-                    // Decapsulation (N3 / uplink): Type-2 ST carries the core
-                    // endpoint + TEID. The Endpoint Length (draft §3.1.4.1)
-                    // spans the address *and* the trailing 32-bit GTP TEID, so
-                    // it is 64 (IPv4) / 160 (IPv6) — using the bare address
-                    // width (32 / 128) would drop the TEID from the wire (a
-                    // TEID of 0 is a malformed NLRI per the draft).
-                    MupSrv6Direction::Decapsulation => match session.endpoint {
-                        Some(endpoint) => bgp_packet::MupPrefix::T2st {
-                            endpoint,
-                            endpoint_len: if endpoint.is_ipv4() { 64 } else { 160 },
-                            teid: session.teid,
-                        },
-                        None => return None,
-                    },
-                };
-                let mut attr = build_mup_attr(self.mup_c_config.controller_address, &rts);
-                // §3.3.10: a Type-2 ST route SHOULD carry the BGP MUP Extended
-                // Community of the Direct segment it resolves to, so a
-                // receiving PE maps the (endpoint, TEID) tunnel onto the
-                // End.DT46 segment.
-                if matches!(sm.direction, MupSrv6Direction::Decapsulation)
-                    && let Some(seg) = sm.mup_ext_comm
-                {
-                    attr_add_ecom(&mut attr, mup_direct_segment_ecom(&seg));
-                }
-                Some((rd, prefix, attr))
-            })
-            .collect()
     }
 
     /// Apply the post-update best path of one MUP prefix to peers:

--- a/zebra-rs/src/bgp/vrf/inst.rs
+++ b/zebra-rs/src/bgp/vrf/inst.rs
@@ -149,6 +149,12 @@ pub struct BgpVrf {
     /// SID. Empty until the first snapshot arrives.
     pub color_policy: super::super::color_policy::ColorPolicy,
     pub flex_algo_srv6_routes: super::super::color_policy::FlexAlgoSrv6Shadow,
+    /// VRF-first MUP origination tracking: per PFCP SEID, the RD-free ST
+    /// prefixes this VRF exported to the global SAFI-85 RIB. Lets a Session
+    /// Deletion / Modification (`MupWithdrawOriginate`) withdraw exactly the
+    /// routes that session created. A VRF binds one direction, so this is
+    /// normally one prefix per SEID.
+    pub mup_originated: std::collections::BTreeMap<u64, Vec<bgp_packet::MupPrefix>>,
 }
 
 /// Sender side of the per-VRF inbound channel — handed back to
@@ -421,6 +427,71 @@ pub fn dispatch_mup(
     }
 }
 
+/// The VRFs a PFCP session should originate ST routes in: every VRF whose
+/// `afi-safi mup route {st1|st2}` binding (`srv6_mobile.network_instance`)
+/// matches the session's Network Instance, paired with its resolved direction
+/// (st1 = Encapsulation / st2 = Decapsulation) and st2 Direct-segment
+/// ext-comm. This is the dual-ST fan-out: one NI bound by both an st1 and an
+/// st2 VRF yields two targets. Pure (no I/O) so the correlation is unit
+/// testable; [`dispatch_mup_session`] turns each target into a `MupOriginate`.
+pub fn mup_session_targets(
+    vrfs: &std::collections::BTreeMap<String, super::super::vrf_config::BgpVrfConfig>,
+    session: &crate::mup_c::session::MupSession,
+) -> Vec<(
+    String,
+    super::super::vrf_config::MupSrv6Direction,
+    Option<bgp_packet::RouteDistinguisher>,
+)> {
+    let Some(ni) = session.network_instance.as_deref() else {
+        return Vec::new();
+    };
+    vrfs.iter()
+        .filter_map(|(name, cfg)| {
+            let sm = cfg.mobile_uplane.srv6_mobile.as_ref()?;
+            if sm.network_instance.as_deref() != Some(ni) {
+                return None;
+            }
+            Some((name.clone(), sm.direction, sm.mup_ext_comm))
+        })
+        .collect()
+}
+
+/// VRF-first MUP session dispatch: send each VRF that [`mup_session_targets`]
+/// matches a `MupOriginate` with its resolved direction + st2 Direct-segment
+/// ext-comm. The per-VRF task builds the RD-free ST NLRI and exports it back
+/// via `MupExport`; the global export handler stamps the RD / export-RTs /
+/// controller next-hop. One session can fan out to several VRFs (an st1 and an
+/// st2 VRF sharing the NI). Replaces the old global `build_mup_origination` +
+/// `originate_mup_route`.
+pub fn dispatch_mup_session(
+    vrfs: &std::collections::BTreeMap<String, super::super::vrf_config::BgpVrfConfig>,
+    vrf_registry: &std::collections::BTreeMap<String, super::spawn::BgpVrfHandle>,
+    session: &crate::mup_c::session::MupSession,
+) {
+    for (name, direction, ext_comm) in mup_session_targets(vrfs, session) {
+        let Some(handle) = vrf_registry.get(&name) else {
+            continue;
+        };
+        let _ = handle.inbox.send(BgpVrfMsg::MupOriginate {
+            session: session.clone(),
+            direction,
+            ext_comm,
+        });
+    }
+}
+
+/// Withdraw the ST routes a PFCP session originated across all VRFs (Session
+/// Deletion / association teardown). Broadcasts `MupWithdrawOriginate`; the
+/// per-VRF removal is idempotent for a VRF that never originated for `seid`.
+pub fn withdraw_mup_session(
+    vrf_registry: &std::collections::BTreeMap<String, super::spawn::BgpVrfHandle>,
+    seid: u64,
+) {
+    for handle in vrf_registry.values() {
+        let _ = handle.inbox.send(BgpVrfMsg::MupWithdrawOriginate { seid });
+    }
+}
+
 /// Per-rtype `remote_id` discriminator for redistribute-originated VRF
 /// rows (matches the global `Bgp::redist_remote_id`), so connected /
 /// static / IGP sources — and a `network` row at id 0 — coexist for
@@ -491,8 +562,25 @@ impl BgpVrf {
             transport_v6: std::collections::BTreeMap::new(),
             color_policy: Default::default(),
             flex_algo_srv6_routes: Default::default(),
+            mup_originated: std::collections::BTreeMap::new(),
         };
         (vrf, inbox_tx)
+    }
+
+    /// Withdraw every controller ST route this VRF exported for `seid`: emit a
+    /// `WithdrawMupExport` for each tracked RD-free prefix so the global
+    /// SAFI-85 RIB removes it and re-runs best-path. No-op when nothing was
+    /// originated for the session.
+    fn withdraw_mup_originate(&mut self, seid: u64) {
+        let Some(prefixes) = self.mup_originated.remove(&seid) else {
+            return;
+        };
+        for prefix in prefixes {
+            let _ = self.global_tx.send(BgpGlobalMsg::WithdrawMupExport {
+                vrf: self.name.clone(),
+                prefix,
+            });
+        }
     }
 
     /// Drive the per-VRF task. The loop exits cleanly when the
@@ -1510,6 +1598,36 @@ impl BgpVrf {
                 if empty {
                     self.local_rib.mup.remove(&rd);
                 }
+            }
+            // VRF-first MUP origination: build the RD-free ST NLRI from the
+            // dispatched session + resolved direction, and export it to the
+            // global SAFI-85 RIB. The global export handler applies the RD,
+            // export route-targets and controller next-hop; the resulting
+            // route is mirrored back here (RT/RD-origin) so this VRF's own
+            // `show bgp vrf <name> mup` reflects it. A Modification replaces:
+            // withdraw the session's prior exports first.
+            BgpVrfMsg::MupOriginate {
+                session,
+                direction,
+                ext_comm,
+            } => {
+                self.withdraw_mup_originate(session.seid);
+                if let Some((prefix, attr)) =
+                    super::super::route::build_mup_st_route(&session, direction, ext_comm)
+                {
+                    self.mup_originated
+                        .entry(session.seid)
+                        .or_default()
+                        .push(prefix.clone());
+                    let _ = self.global_tx.send(BgpGlobalMsg::MupExport {
+                        vrf: self.name.clone(),
+                        prefix,
+                        attr,
+                    });
+                }
+            }
+            BgpVrfMsg::MupWithdrawOriginate { seid } => {
+                self.withdraw_mup_originate(seid);
             }
             BgpVrfMsg::Shutdown => unreachable!("handled in event_loop"),
         }

--- a/zebra-rs/src/bgp/vrf/mod.rs
+++ b/zebra-rs/src/bgp/vrf/mod.rs
@@ -26,8 +26,9 @@ pub use sid::{BgpSidPool, Srv6VrfSid};
 // inside `vrf::spawn` only.
 pub use inst::{
     VrfExporter, VrfImportDispatcher, dispatch_import_v4, dispatch_import_v6, dispatch_mup,
-    dispatch_withdraw_import_v4, dispatch_withdraw_import_v6, vrf_emit_export, vrf_emit_export_v6,
-    vrf_emit_withdraw, vrf_emit_withdraw_v6,
+    dispatch_mup_session, dispatch_withdraw_import_v4, dispatch_withdraw_import_v6,
+    vrf_emit_export, vrf_emit_export_v6, vrf_emit_withdraw, vrf_emit_withdraw_v6,
+    withdraw_mup_session,
 };
 pub use msg::BgpGlobalMsg;
 pub use spawn::{BgpVrfHandle, compute_vrf_diff, despawn_bgp_vrf, spawn_bgp_vrf};

--- a/zebra-rs/src/bgp/vrf/msg.rs
+++ b/zebra-rs/src/bgp/vrf/msg.rs
@@ -80,6 +80,28 @@ pub enum BgpVrfMsg {
         prefix: bgp_packet::MupPrefix,
     },
 
+    /// Originate a controller Session-Transformed (ST1/ST2) route in this
+    /// VRF (VRF-first MUP origination). The global task correlates a PFCP
+    /// session's Network Instance to the matching VRF(s) and forwards the
+    /// session here with the resolved `direction` (st1=Encapsulation /
+    /// st2=Decapsulation) and the optional st2 Direct-segment ext-comm. The
+    /// per-VRF task builds the **RD-free** ST NLRI and emits
+    /// [`BgpGlobalMsg::MupExport`]; the global export handler applies the RD,
+    /// export route-targets and controller next-hop. One session can fan out
+    /// to several VRFs (an st1 and an st2 VRF sharing the NI) — each gets its
+    /// own `MupOriginate` for its direction.
+    MupOriginate {
+        session: crate::mup_c::session::MupSession,
+        direction: crate::bgp::vrf_config::MupSrv6Direction,
+        ext_comm: Option<RouteDistinguisher>,
+    },
+
+    /// Withdraw every ST route this VRF originated for `seid` (PFCP Session
+    /// Deletion, association teardown, or the replace step of a
+    /// Modification). Broadcast to every VRF; the per-VRF removal is
+    /// idempotent for a VRF that never originated for this session.
+    MupWithdrawOriginate { seid: u64 },
+
     /// VPNv6 counterpart of [`Self::ImportV4`] — a VPNv6 route whose
     /// RT list intersects this VRF's `import_rts_v6`; inserted into
     /// the VRF's IPv6 unicast Loc-RIB and advertised to CE peers.
@@ -194,6 +216,27 @@ pub enum BgpGlobalMsg {
 
     /// Inverse of [`Self::ExportV6`].
     WithdrawExportV6 { vrf: String, prefix: Ipv6Net },
+
+    /// A controller ST route this VRF originated (VRF-first MUP), for the
+    /// global task to promote into the SAFI-85 Loc-RIB and advertise. The
+    /// VRF name lets the global side resolve the RD (from `Bgp::vrfs`), the
+    /// export route-targets (from `Bgp::rib_known_vrfs`) and the controller
+    /// next-hop (from `Bgp::mup_c_config`) — applied at this export boundary,
+    /// mirroring [`Self::Export`] for VPNv4. `prefix` is RD-free; `attr`
+    /// carries only route-specific extended communities (e.g. the st2
+    /// Direct-segment id), no RD / RT / next-hop.
+    MupExport {
+        vrf: String,
+        prefix: bgp_packet::MupPrefix,
+        attr: BgpAttr,
+    },
+
+    /// Inverse of [`Self::MupExport`]. The global instance removes the
+    /// originated ST route under this VRF's RD and re-runs best-path.
+    WithdrawMupExport {
+        vrf: String,
+        prefix: bgp_packet::MupPrefix,
+    },
 
     /// Register a peer IP with the global accept dispatcher so an
     /// inbound `:179` connect from that IP is handed to this VRF


### PR DESCRIPTION
## Summary

PR 2 of the VRF-first MUP restructure. Controller Session-Transformed (ST1/ST2) routes were built and installed entirely on the global task. This relocates origination into the per-VRF tasks, mirroring the L3VPN VRF→global export model: the VRF emits a bare route and the global stamps RD + route-targets + next-hop **at the export boundary**.

## Flow

- Controller `SessionUp` → global correlates the session's NI to the matching VRF(s) (`mup_session_targets`, the dual-ST fan-out) → sends each `BgpVrfMsg::MupOriginate{session, direction, ext_comm}`.
- Per-VRF task builds the **RD-free** ST NLRI (`build_mup_st_route`) and emits `BgpGlobalMsg::MupExport{vrf, prefix, attr}` (bare attr: only route-specific ecoms, e.g. the st2 Direct-segment id).
- Global `MupExport` handler (`Bgp::mup_export`) stamps RD (`vrfs[vrf].rd`), export-RTs (`rib_known_vrfs`), controller next-hop (`mup_c_config`); installs into the SAFI-85 Loc-RIB; advertises; mirrors back so the originating VRF's `show bgp vrf <name> mup` reflects the fully-stamped route.
- Withdraw symmetric (`MupWithdrawOriginate` → `WithdrawMupExport` → `Bgp::mup_withdraw_export`). Per-session prefix tracking moved off global `mup_c_originated` onto each VRF's `mup_originated`.

Segment (DSD/ISD) origination is untouched (still global; relocated in PR 3). `retag_mup_st_exports` stays global (re-tags exported ST rows on an export-RT change).

## Test plan

- `cargo test -p zebra-rs --bins` — 1493 pass (new `mup_session_targets` fan-out + `build_mup_st_route` per-direction NLRI tests replace the old `build_mup_origination` test); clippy + fmt clean.
- Full MUP BDD suite as root — **11 features pass**: e2e, st2, dual_st, dynamic_rt, mixed_afi (ST origination, the changed path) + isd, segment_dsd, interwork, vrf_import, capability, runtime_enable (unchanged paths). No binary stomp.

Generated with [Claude Code](https://claude.com/claude-code)