### PR TITLE
bgp/mup: move MUP-C show command to `show bgp mup-c`

### DIFF
--- a/bdd/tests/features/bgp_mup_dual_st.feature
+++ b/bdd/tests/features/bgp_mup_dual_st.feature
@@ -54,13 +54,13 @@ Feature: BGP MUP Controller originates both ST1 and ST2 from one PFCP session
     Then BGP session in "z1" to "192.168.0.2" should be "Established"
     And BGP session in "z2" to "192.168.0.1" should be "Established"
     And show command "show bgp neighbor 192.168.0.2" in namespace "z1" should contain "IPv4 MUP: advertised and received"
-    And show command "show bgp mup mup-c" in namespace "z1" should contain "PFCP listen : 192.168.0.1:8805"
+    And show command "show bgp mup-c" in namespace "z1" should contain "PFCP listen : 192.168.0.1:8805"
 
   Scenario: One PFCP session originates both an ST1 and an ST2 route received by the peer
     Given the test topology exists
     When I execute "pfcp-inject --target 192.168.0.1 --port 8805 --ue-ipv4 192.0.2.5 --teid 0x12345678 --endpoint 10.0.0.1 --network-instance internet" in namespace "z1"
     # PFCP ingest learned the single session.
-    Then show command "show bgp mup mup-c session" in namespace "z1" should eventually contain "192.0.2.5"
+    Then show command "show bgp mup-c session" in namespace "z1" should eventually contain "192.0.2.5"
     # The downlink VRF (st1) originates a Type-1 ST: UE prefix + access tunnel.
     And show command "show bgp mup" in namespace "z1" should contain "[ST1][65000:101][ue=192.0.2.5/32][teid=305419896]"
     # The uplink VRF (st2) originates a Type-2 ST from the SAME session:

--- a/bdd/tests/features/bgp_mup_dynamic_rt.feature
+++ b/bdd/tests/features/bgp_mup_dynamic_rt.feature
@@ -57,14 +57,14 @@ Feature: BGP MUP export route-target applies dynamically to an originated ST rou
     Then BGP session in "z1" to "192.168.0.2" should be "Established"
     And BGP session in "z2" to "192.168.0.1" should be "Established"
     And show command "show bgp neighbor 192.168.0.2" in namespace "z1" should contain "IPv4 MUP: advertised and received"
-    And show command "show bgp mup mup-c" in namespace "z1" should contain "PFCP listen : 192.168.0.1:8805"
+    And show command "show bgp mup-c" in namespace "z1" should contain "PFCP listen : 192.168.0.1:8805"
 
   Scenario: Originate an ST2 with no export RT, then apply the export RT dynamically
     Given the test topology exists
     When I execute "pfcp-inject --target 192.168.0.1 --port 8805 --ue-ipv4 192.0.2.5 --teid 0x12345678 --endpoint 10.0.0.1 --network-instance core" in namespace "z1"
     # PFCP ingest learned the session and z1 originated the ST2 — carrying
     # the Direct segment id (mup:1:2) but NO route-target yet.
-    Then show command "show bgp mup mup-c session" in namespace "z1" should eventually contain "192.0.2.5"
+    Then show command "show bgp mup-c session" in namespace "z1" should eventually contain "192.0.2.5"
     And show command "show bgp mup" in namespace "z1" should eventually contain "[ST2][65000:100][ep=10.0.0.1][teid=305419896]"
     And show command "show bgp mup" in namespace "z1" should not contain "rt:100:10"
     # z2 receives the route into its global MUP Loc-RIB (RT-independent)...

--- a/bdd/tests/features/bgp_mup_e2e.feature
+++ b/bdd/tests/features/bgp_mup_e2e.feature
@@ -51,12 +51,12 @@ Feature: BGP MUP Controller originates Session-Transformed routes from PFCP
     Then BGP session in "z1" to "192.168.0.2" should be "Established"
     And BGP session in "z2" to "192.168.0.1" should be "Established"
     And show command "show bgp neighbor 192.168.0.2" in namespace "z1" should contain "IPv4 MUP: advertised and received"
-    And show command "show bgp mup mup-c" in namespace "z1" should contain "PFCP listen : 192.168.0.1:8805"
+    And show command "show bgp mup-c" in namespace "z1" should contain "PFCP listen : 192.168.0.1:8805"
 
   Scenario: PFCP session establishment originates an ST1 route received by the peer
     Given the test topology exists
     When I execute "pfcp-inject --target 192.168.0.1 --port 8805 --ue-ipv4 192.0.2.5 --teid 0x12345678 --endpoint 10.0.0.1 --network-instance access" in namespace "z1"
-    Then show command "show bgp mup mup-c session" in namespace "z1" should eventually contain "192.0.2.5"
+    Then show command "show bgp mup-c session" in namespace "z1" should eventually contain "192.0.2.5"
     And show command "show bgp mup" in namespace "z1" should contain "ue=192.0.2.5/32"
     And show command "show bgp mup" in namespace "z2" should eventually contain "ue=192.0.2.5/32"
     # The peer-learned route is mirrored into z2's `mobile-up` VRF (it

--- a/bdd/tests/features/bgp_mup_mixed_afi.feature
+++ b/bdd/tests/features/bgp_mup_mixed_afi.feature
@@ -51,12 +51,12 @@ Feature: BGP MUP mixed-AFI Session-Transformed route (IPv6 UE, IPv4 endpoint)
     Then BGP session in "z1" to "192.168.0.2" should be "Established"
     And BGP session in "z2" to "192.168.0.1" should be "Established"
     And show command "show bgp neighbor 192.168.0.2" in namespace "z1" should contain "IPv6 MUP: advertised and received"
-    And show command "show bgp mup mup-c" in namespace "z1" should contain "PFCP listen : 192.168.0.1:8805"
+    And show command "show bgp mup-c" in namespace "z1" should contain "PFCP listen : 192.168.0.1:8805"
 
   Scenario: IPv6 UE with IPv4 endpoint originates an ST1 route the peer parses
     Given the test topology exists
     When I execute "pfcp-inject --target 192.168.0.1 --port 8805 --ue-ipv6 2001:db8::5 --teid 0x12345678 --endpoint 10.0.0.1 --network-instance access" in namespace "z1"
-    Then show command "show bgp mup mup-c session" in namespace "z1" should eventually contain "2001:db8::5"
+    Then show command "show bgp mup-c session" in namespace "z1" should eventually contain "2001:db8::5"
     And show command "show bgp mup" in namespace "z1" should contain "ue=2001:db8::5/128"
     And show command "show bgp mup" in namespace "z1" should contain "ep=10.0.0.1"
     # The export route-target comes from the top-level `vrf mobile-up mup

--- a/bdd/tests/features/bgp_mup_st2.feature
+++ b/bdd/tests/features/bgp_mup_st2.feature
@@ -54,13 +54,13 @@ Feature: BGP MUP Controller originates a Type-2 ST route from a PFCP session
     Then BGP session in "z1" to "192.168.0.2" should be "Established"
     And BGP session in "z2" to "192.168.0.1" should be "Established"
     And show command "show bgp neighbor 192.168.0.2" in namespace "z1" should contain "IPv4 MUP: advertised and received"
-    And show command "show bgp mup mup-c" in namespace "z1" should contain "PFCP listen : 192.168.0.1:8805"
+    And show command "show bgp mup-c" in namespace "z1" should contain "PFCP listen : 192.168.0.1:8805"
 
   Scenario: PFCP session establishment originates an ST2 route received by the peer
     Given the test topology exists
     When I execute "pfcp-inject --target 192.168.0.1 --port 8805 --ue-ipv4 192.0.2.5 --teid 0x12345678 --endpoint 10.0.0.1 --network-instance core" in namespace "z1"
     # PFCP ingest learned the session.
-    Then show command "show bgp mup mup-c session" in namespace "z1" should eventually contain "192.0.2.5"
+    Then show command "show bgp mup-c session" in namespace "z1" should eventually contain "192.0.2.5"
     # z1 originates the Type-2 ST: core endpoint + the full 32-bit GTP TEID
     # (0x12345678 = 305419896). A TEID of 0 here would mean the endpoint
     # length dropped it from the wire.

--- a/book/src/ch-02-35-bgp-mup.md
+++ b/book/src/ch-02-35-bgp-mup.md
@@ -361,18 +361,18 @@ these routes so the per-VRF view renders them:
        rt:65000:200
 ```
 
-`show bgp mup mup-c` shows the controller status, and the
+`show bgp mup-c` shows the controller status, and the
 `session` / `association` sub-commands show the learned PFCP state:
 
 ```
-# show bgp mup mup-c
+# show bgp mup-c
 MUP controller (MUP-C)
   Admin state : enabled
   PFCP listen : 192.168.0.1:8805
   Associations: 1
   Sessions    : 1
 
-# show bgp mup mup-c session
+# show bgp mup-c session
 SEID       UE address     TEID         Endpoint     QFI   Network-Instance
 1          192.0.2.5      0x12345678   10.0.0.1     -     access
 ```
@@ -397,7 +397,7 @@ pfcp-inject --target 192.168.0.1 --port 8805 \
             --endpoint 10.0.0.1 --network-instance access
 ```
 
-After it runs, the session appears under `show bgp mup mup-c
+After it runs, the session appears under `show bgp mup-c
 session` and the controller's ST route appears in `show bgp
 mup` on both the controller and its peers.
 

--- a/book/src/ch-14-02-show-bgp.md
+++ b/book/src/ch-14-02-show-bgp.md
@@ -123,10 +123,12 @@ Type-1/Type-2 Session-Transformed routes. `summary` shows the
 IPv4-MUP / IPv6-MUP neighbor sections. See
 [Mobile User Plane (MUP)](ch-02-35-bgp-mup.md).
 
-- `show bgp mup mup-c [session|association]` — the MUP Controller
-  (MUP-C): admin state and PFCP listen address; `session` lists learned
-  PFCP sessions (SEID, UE address, TEID, QFI); `association` lists PFCP
-  CP/UP associations.
+### `show bgp mup-c [session|association]`
+
+The MUP Controller (MUP-C): admin state and PFCP listen address;
+`session` lists learned PFCP sessions (SEID, UE address, TEID, QFI);
+`association` lists PFCP CP/UP associations. See
+[Mobile User Plane (MUP)](ch-02-35-bgp-mup.md).
 
 JSON: an array of MUP route objects; `mup-c` returns a controller object
 or an array of session / association objects.

--- a/docs/design/bgp-mup-followups.md
+++ b/docs/design/bgp-mup-followups.md
@@ -193,7 +193,7 @@ mirror the EVPN LLGR two-branch.
 
 ### 6. Full `MUP controller:` show block — **DONE (P5)**
 
-`show bgp mup mup-c [session|association]` now renders the
+`show bgp mup-c [session|association]` now renders the
 controller runtime (admin state, PFCP listen address, association /
 session counts, and the per-session table) from the BGP-held
 `mup_c_view` the controller feeds over `Message::MupC`. The
@@ -358,7 +358,7 @@ zenoh encoding to design).
   reconfigure / teardown in `Bgp::apply_mup_c_commit_diff`.
 * **PR-A (ingest):** PFCP listener (own tokio UDP socket); Association
   Setup/Release, Heartbeat, Session Establishment/Modification/Deletion;
-  per-session table; `show bgp mup mup-c [session|association]`.
+  per-session table; `show bgp mup-c [session|association]`.
   Hardened (commit security review): session-ownership check on
   Modify/Delete, association precondition on Establish, bounded tables.
 * **PR-B (origination):** `Bgp::originate_mup_route` correlates the

--- a/docs/design/show-commands-json-output.md
+++ b/docs/design/show-commands-json-output.md
@@ -116,7 +116,7 @@ its non-VRF sibling** in the tables below.
 | `show bgp neighbor-group [<name>]` | Neighbor-group inheritance state | ✅ |
 | `show bgp update-group [<id>]` | Update-groups (IOS-XR style) | ✅ |
 | `show bgp mup [summary]` | Mobile User Plane RIB (SAFI 85) | ✅ |
-| `show bgp mup mup-c [session\|association]` | MUP Controller status | ✅ |
+| `show bgp mup-c [session\|association]` | MUP Controller status | ✅ |
 | `show bgp vrf [<name>] [summary\|neighbor\|ipv4\|ipv6\|mup]` | Per-VRF BGP (redirected) | ✅ |
 
 Every per-AFI route dump (EVPN / labeled-unicast / flowspec / sr-policy /

--- a/zebra-rs/src/bgp/inst.rs
+++ b/zebra-rs/src/bgp/inst.rs
@@ -121,7 +121,7 @@ pub enum Message {
     /// controller (`src/mup-c/`), which the BGP task spawns when
     /// `router bgp mup-c enable true` is committed and hands
     /// `self.tx`. Recorded in [`Bgp::mup_c_view`] for `show bgp
-    /// mup mup-c`; MUP route origination from these lands in a
+    /// mup-c`; MUP route origination from these lands in a
     /// follow-up. Mirrors the IS-IS `BgpLs` producer seam.
     MupC(crate::mup_c::inst::MupCEvent),
     /// `router bgp port <0-65535>` changed: close the BGP listen
@@ -2068,7 +2068,7 @@ impl Bgp {
             Message::MupC(ev) => {
                 // A session/association change from the in-process MUP
                 // controller. Drive MUP route origination, then record it
-                // in the read-only view `show bgp mup mup-c`
+                // in the read-only view `show bgp mup-c`
                 // renders.
                 use crate::mup_c::inst::MupCEvent;
                 match &ev {

--- a/zebra-rs/src/bgp/show.rs
+++ b/zebra-rs/src/bgp/show.rs
@@ -4063,7 +4063,7 @@ fn mup_prefix_display(rd: &RouteDistinguisher, prefix: &MupPrefix) -> String {
     }
 }
 
-/// `show bgp mup mup-c` — MUP controller (MUP-C) status: admin
+/// `show bgp mup-c` — MUP controller (MUP-C) status: admin
 /// state, the PFCP listener, and association / session counts. Rendered
 /// from the read-only [`crate::mup_c::inst::MupCView`] the controller
 /// feeds over `Message::MupC`.
@@ -4110,7 +4110,7 @@ fn show_bgp_mup_c(
     Ok(buf)
 }
 
-/// `show bgp mup mup-c session` — the PFCP sessions the
+/// `show bgp mup-c session` — the PFCP sessions the
 /// controller has learned (one row each).
 fn show_bgp_mup_c_session(
     bgp: &Bgp,
@@ -4172,7 +4172,7 @@ fn show_bgp_mup_c_session(
     Ok(buf)
 }
 
-/// `show bgp mup mup-c association` — the PFCP associations
+/// `show bgp mup-c association` — the PFCP associations
 /// (control-plane peers) the controller currently holds.
 fn show_bgp_mup_c_association(
     bgp: &Bgp,
@@ -6623,11 +6623,11 @@ impl Bgp {
             .set(show_bgp_mup)
             .path("/show/bgp/mup/summary")
             .set(show_bgp_mup_summary)
-            .path("/show/bgp/mup/mup-c")
+            .path("/show/bgp/mup-c")
             .set(show_bgp_mup_c)
-            .path("/show/bgp/mup/mup-c/session")
+            .path("/show/bgp/mup-c/session")
             .set(show_bgp_mup_c_session)
-            .path("/show/bgp/mup/mup-c/association")
+            .path("/show/bgp/mup-c/association")
             .set(show_bgp_mup_c_association)
             .path("/show/bgp/summary")
             .set(show_bgp_summary::<Bgp>)

--- a/zebra-rs/src/mup-c/inst.rs
+++ b/zebra-rs/src/mup-c/inst.rs
@@ -70,7 +70,7 @@ pub enum MupCEvent {
 }
 
 /// Read-only controller snapshot held by the BGP task, fed by
-/// [`MupCEvent`]. Renders `show bgp mup mup-c [session |
+/// [`MupCEvent`]. Renders `show bgp mup-c [session |
 /// association]`.
 #[derive(Debug, Default)]
 pub struct MupCView {

--- a/zebra-rs/src/mup-c/mod.rs
+++ b/zebra-rs/src/mup-c/mod.rs
@@ -17,7 +17,7 @@
 //! instance receives the global BGP channel. The controller reports
 //! neutral session/association events back over that channel
 //! ([`inst::MupCEvent`]); the BGP task records them for
-//! `show bgp mup mup-c` (this slice) and originates MUP routes
+//! `show bgp mup-c` (this slice) and originates MUP routes
 //! from them (follow-up).
 //!
 //! Module layout: [`inst`] owns the task + the BGP-facing types,

--- a/zebra-rs/yang/exec.yang
+++ b/zebra-rs/yang/exec.yang
@@ -416,17 +416,17 @@ module exec {
           ext:help "Summary of MUP-enabled neighbors";
           type empty;
         }
-        container mup-c {
-          ext:help "MUP Controller (MUP-C) status";
-          presence "MUP Controller (MUP-C) status";
-          leaf session {
-            ext:help "Learned PFCP sessions";
-            type empty;
-          }
-          leaf association {
-            ext:help "PFCP associations";
-            type empty;
-          }
+      }
+      container mup-c {
+        ext:help "MUP Controller (MUP-C) status";
+        presence "MUP Controller (MUP-C) status";
+        leaf session {
+          ext:help "Learned PFCP sessions";
+          type empty;
+        }
+        leaf association {
+          ext:help "PFCP associations";
+          type empty;
         }
       }
       list update-group {


### PR DESCRIPTION
## Summary

The MUP Controller view was nested under the MUP RIB container as
`show bgp mup mup-c`. Promote it to a top-level sibling so the command
is `show bgp mup-c [session|association]`, matching the config path
`router bgp mup-c` and dropping the awkward `mup mup-c` repetition.

- `exec.yang`: lift the `mup-c` container out of `mup`, placing it
  directly under `bgp`.
- `show.rs`: dispatch paths `/show/bgp/mup-c[/session|/association]`.
- Sweep doc comments, the book (ch-02-35, ch-14-02), design docs, and
  the five MUP BDD features that invoke the command.

The config path (`router bgp mup-c`) is unchanged.

## Test plan

- `cargo fmt --all` clean.
- `cargo clippy --workspace --all-targets -- -D warnings` clean.
- `cargo test -p zebra-rs --bins` → 1493 passed.
- Live vty against a running daemon + config: `show bgp mup-c` and
  `show bgp mup-c session` resolve and render the controller view;
  `show bgp mup` still renders the RIB.

Generated with [Claude Code](https://claude.com/claude-code)