### PR TITLE
bgp/mup: fix mis-citation RFC 9833 -> draft-ietf-bess-mup-safi

### DIFF
--- a/bdd/docs/bgp_mup_e2e.md
+++ b/bdd/docs/bgp_mup_e2e.md
@@ -5,7 +5,7 @@
 As a network operator
 I want the zebra-rs BGP MUP Controller (MUP-C) to learn a mobile session
 over PFCP/N4 and originate a Type-1 Session-Transformed route (SAFI 85,
-RFC 9833) that a peer zebra-rs receives, so the end-to-end control plane
+draft-ietf-bess-mup-safi) that a peer zebra-rs receives, so the end-to-end control plane
 — PFCP ingest, NI -> VRF correlation, SRv6 SID allocation, ST route
 origination, and iBGP advertisement — is validated.
 

--- a/bdd/docs/bgp_mup_runtime_enable.md
+++ b/bdd/docs/bgp_mup_runtime_enable.md
@@ -4,7 +4,7 @@
 
 An AFI/SAFI is a BGP Multiprotocol *capability*, advertised once in the
 OPEN — the negotiated set is fixed for the life of the session. So
-enabling `afi-safi mup` (RFC 9833, which turns on BOTH IPv4-MUP
+enabling `afi-safi mup` (draft-ietf-bess-mup-safi, which turns on BOTH IPv4-MUP
 and IPv6-MUP) on an already-Established neighbor has no effect until the
 session renegotiates. zebra-rs therefore bounces the session on the
 change — the same teardown `clear bgp ... hard` uses — so the new MUP

--- a/bdd/tests/configs/bgp_mup_st2/z1.yaml
+++ b/bdd/tests/configs/bgp_mup_st2/z1.yaml
@@ -1,5 +1,5 @@
 # z1 — MUP Controller (MUP-C) originating a Type-2 Session-Transformed
-# (ST2, RFC 9833 / draft-mpmz-bess-mup-safi §3.1.4) route from a PFCP
+# (ST2, draft-mpmz-bess-mup-safi §3.1.4) route from a PFCP
 # decapsulation session. AS 65001, iBGP to z2 (192.168.0.2) with the mup
 # afi-safi negotiated; PFCP/N4 listener on 192.168.0.1:8805. When
 # pfcp-inject programs a session whose Network Instance is `core`, the VRF

--- a/bdd/tests/features/bgp_mup_capability.feature
+++ b/bdd/tests/features/bgp_mup_capability.feature
@@ -3,7 +3,7 @@
 Feature: BGP Mobile User Plane (MUP) capability negotiation
   As a network operator
   I want two zebra-rs instances to negotiate the BGP MUP multiprotocol
-  capability (SAFI 85, RFC 9833) for BOTH IPv4-MUP (AFI 1) and IPv6-MUP
+  capability (SAFI 85, draft-ietf-bess-mup-safi) for BOTH IPv4-MUP (AFI 1) and IPv6-MUP
   (AFI 2) from a single `afi-safi mup enabled true` knob, and
   bring an iBGP session to Established, so the foundation for MUP route
   exchange (ISD / DSD / ST1 / ST2) is validated before origination is

--- a/bdd/tests/features/bgp_mup_e2e.feature
+++ b/bdd/tests/features/bgp_mup_e2e.feature
@@ -4,7 +4,7 @@ Feature: BGP MUP Controller originates Session-Transformed routes from PFCP
   As a network operator
   I want the zebra-rs BGP MUP Controller (MUP-C) to learn a mobile session
   over PFCP/N4 and originate a Type-1 Session-Transformed route (SAFI 85,
-  RFC 9833) that a peer zebra-rs receives, so the end-to-end control plane
+  draft-ietf-bess-mup-safi) that a peer zebra-rs receives, so the end-to-end control plane
   — PFCP ingest, NI -> VRF correlation, SRv6 SID allocation, ST route
   origination, and iBGP advertisement — is validated.
 

--- a/bdd/tests/features/bgp_mup_isd.feature
+++ b/bdd/tests/features/bgp_mup_isd.feature
@@ -3,7 +3,7 @@
 Feature: BGP MUP PE originates an Interwork Segment Discovery (ISD) route over SRv6
   As a network operator
   I want a zebra-rs BGP MUP PE to originate an Interwork Segment Discovery
-  (ISD, type 1, SAFI 85 / RFC 9833) route for an `encapsulation srv6` VRF
+  (ISD, type 1, SAFI 85 / draft-ietf-bess-mup-safi) route for an `encapsulation srv6` VRF
   when `afi-safi mup segment interwork prefix <p>` is configured, so the
   per-VRF End.DT46 service SID is carved from the locator, installed into the
   kernel FIB, and advertised under the configured interwork prefix as the

--- a/bdd/tests/features/bgp_mup_mixed_afi.feature
+++ b/bdd/tests/features/bgp_mup_mixed_afi.feature
@@ -3,7 +3,7 @@
 Feature: BGP MUP mixed-AFI Session-Transformed route (IPv6 UE, IPv4 endpoint)
   As a network operator running 5G backhaul where the UE address family and
   the N3 transport differ, I want the zebra-rs BGP MUP Controller to
-  originate a Type-1 Session-Transformed route (SAFI 85, RFC 9833 /
+  originate a Type-1 Session-Transformed route (SAFI 85,
   draft-ietf-bess-mup-safi) for an IPv6 UE whose GTP endpoint (gNB) is IPv4,
   and a peer zebra-rs to receive and show it. This validates two behaviours:
 

--- a/bdd/tests/features/bgp_mup_runtime_enable.feature
+++ b/bdd/tests/features/bgp_mup_runtime_enable.feature
@@ -3,7 +3,7 @@
 Feature: BGP MUP capability (re)negotiates when enabled on a live session
   An AFI/SAFI is a BGP Multiprotocol *capability*, advertised once in the
   OPEN — the negotiated set is fixed for the life of the session. So
-  enabling `afi-safi mup` (RFC 9833, which turns on BOTH IPv4-MUP
+  enabling `afi-safi mup` (draft-ietf-bess-mup-safi, which turns on BOTH IPv4-MUP
   and IPv6-MUP) on an already-Established neighbor has no effect until the
   session renegotiates. zebra-rs therefore bounces the session on the
   change — the same teardown `clear bgp ... hard` uses — so the new MUP

--- a/bdd/tests/features/bgp_mup_segment_dsd.feature
+++ b/bdd/tests/features/bgp_mup_segment_dsd.feature
@@ -3,7 +3,7 @@
 Feature: BGP MUP PE originates a Direct Segment Discovery (DSD) route over SRv6
   As a network operator
   I want a zebra-rs BGP MUP PE to originate a Direct Segment Discovery
-  (DSD, type 2, SAFI 85 / RFC 9833) route for an `encapsulation srv6` VRF
+  (DSD, type 2, SAFI 85 / draft-ietf-bess-mup-safi) route for an `encapsulation srv6` VRF
   when `afi-safi mup segment direct` is configured, so the per-VRF End.DT46
   service SID is carved from the locator, installed into the kernel FIB, and
   advertised as the segment a receiving PE resolves for matching

--- a/bdd/tests/features/bgp_mup_st2.feature
+++ b/bdd/tests/features/bgp_mup_st2.feature
@@ -4,7 +4,7 @@ Feature: BGP MUP Controller originates a Type-2 ST route from a PFCP session
   As a network operator
   I want the zebra-rs BGP MUP Controller (MUP-C) to learn a mobile session
   over PFCP/N4 and originate a Type-2 Session-Transformed route (ST2, SAFI
-  85, RFC 9833 / draft-mpmz-bess-mup-safi §3.1.4) for the uplink (N3) — the
+  85, draft-mpmz-bess-mup-safi §3.1.4) for the uplink (N3) — the
   core endpoint + GTP TEID with the BGP MUP Extended Community of the Direct
   segment — so a peer zebra-rs receives it and the End.DT46 uplink/downlink
   forwarding model can be programmed from the Direct segment.

--- a/bdd/tests/features/bgp_mup_vrf_import.feature
+++ b/bdd/tests/features/bgp_mup_vrf_import.feature
@@ -2,7 +2,7 @@
 @bgp_mup_vrf_import
 Feature: BGP MUP cross-VRF import by route-target (RD-independent)
   As a network operator
-  I want a locally-originated BGP MUP route (SAFI 85 / RFC 9833) to be
+  I want a locally-originated BGP MUP route (SAFI 85 / draft-ietf-bess-mup-safi) to be
   imported into every VRF whose `mup route-target import` overlaps the
   route's RTs — not just the VRF that owns the route's RD — so per-VRF MUP
   matches the VPNv4/v6 import model and a downlink VRF can pull in the

--- a/book/src/ch-02-35-bgp-mup.md
+++ b/book/src/ch-02-35-bgp-mup.md
@@ -1,7 +1,7 @@
 # BGP Mobile User Plane (MUP) and the MUP Controller
 
 zebra-rs implements **BGP Mobile User Plane** (BGP-MUP, SAFI 85) as
-specified in RFC 9833 / `draft-mpmz-bess-mup-safi`. BGP-MUP carries 5G
+specified in `draft-ietf-bess-mup-safi`. BGP-MUP carries 5G
 mobile-backhaul session state in BGP so that a GTP-U tunnel between a
 mobile gateway and the radio access network can be stitched into an
 **SRv6** transport network — the GTP encap/decap happens at the SRv6

--- a/crates/bgp-packet/src/attrs/ext_com.rs
+++ b/crates/bgp-packet/src/attrs/ext_com.rs
@@ -90,7 +90,7 @@ impl ExtCommunityValue {
         Color { flags, color }.into()
     }
 
-    /// True iff this entry is a MUP Extended Community (RFC 9833 §5):
+    /// True iff this entry is a MUP Extended Community (draft-ietf-bess-mup-safi §5):
     /// high-type byte 0x0c.
     pub fn is_mup(&self) -> bool {
         self.high_type == ExtCommunityType::Mup as u8
@@ -98,7 +98,7 @@ impl ExtCommunityValue {
 
     /// Decode the MUP Extended Community sub-type and surface the
     /// 6-octet payload as opaque bytes. Typed payload decoding per
-    /// RFC 9833 §5 is deferred to a follow-up.
+    /// draft-ietf-bess-mup-safi §5 is deferred to a follow-up.
     pub fn as_mup(&self) -> Option<MupExtCom> {
         if !self.is_mup() {
             return None;
@@ -456,7 +456,7 @@ impl From<DfElectionEc> for ExtCommunityValue {
     }
 }
 
-/// Decoded MUP Extended Community (RFC 9833 §5). The `value` field
+/// Decoded MUP Extended Community (draft-ietf-bess-mup-safi §5). The `value` field
 /// is the raw 6-octet payload; typed accessors per sub-type will
 /// follow once the spec layout is in-tree.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
@@ -523,7 +523,7 @@ impl fmt::Display for ExtCommunityValue {
                 ExtCommunitySubType::display(self.low_type)
             )
         } else if let Some(m) = self.as_mup() {
-            // MUP Extended Community (RFC 9833 §5). Until typed
+            // MUP Extended Community (draft-ietf-bess-mup-safi §5). Until typed
             // payloads land, render the sub-type identifier plus the
             // raw 6-byte value as a colon-joined hex string.
             write!(

--- a/crates/bgp-packet/src/attrs/ext_com_type.rs
+++ b/crates/bgp-packet/src/attrs/ext_com_type.rs
@@ -11,7 +11,7 @@ pub enum ExtCommunityType {
     /// Sub-type 0x09 is the Multicast Flags EC (IGMP/MLD proxy
     /// capability); see `ExtCommunityValue::as_evpn_mcast_flags`.
     Evpn = 0x06,
-    /// RFC 9833 — BGP MUP Extended Community high-type byte. Sub-type
+    /// draft-ietf-bess-mup-safi — BGP MUP Extended Community high-type byte. Sub-type
     /// decode is deferred to a later phase; raw 8-byte value passes
     /// through the generic ExtCommunity path for now.
     Mup = 0x0c,
@@ -54,10 +54,10 @@ impl ExtCommunitySubType {
     }
 }
 
-/// MUP Extended Community sub-type values (high-type 0x0c, RFC 9833 §5).
+/// MUP Extended Community sub-type values (high-type 0x0c, draft-ietf-bess-mup-safi §5).
 ///
 /// Names are kept numeric for now because the exact IANA-assigned
-/// names and payload layouts in RFC 9833 §5 haven't been confirmed
+/// names and payload layouts in draft-ietf-bess-mup-safi §5 haven't been confirmed
 /// against the spec in-tree; the 6-octet value travels as opaque
 /// bytes via `ExtCommunityValue::val`. A follow-up phase will rename
 /// these and add typed accessors once the per-sub-type layout is

--- a/crates/bgp-packet/src/attrs/mp_reach.rs
+++ b/crates/bgp-packet/src/attrs/mp_reach.rs
@@ -45,7 +45,7 @@ pub enum MpReachAttr {
     },
     Rtcv4(Rtcv4Reach),
     Rtcv6(Rtcv6Reach),
-    /// BGP MUP (RFC 9833), SAFI 85. The outer AFI distinguishes the
+    /// BGP MUP (draft-ietf-bess-mup-safi), SAFI 85. The outer AFI distinguishes the
     /// IPv4 from the IPv6 MUP address family; per-route-type bodies
     /// stay opaque at this phase.
     Mup {
@@ -442,7 +442,7 @@ impl MpReachAttr {
             return Ok((input, mp_nlri));
         }
         if (header.afi == Afi::Ip || header.afi == Afi::Ip6) && header.safi == Safi::Mup {
-            // RFC 9833 §11: MUP nexthop matches the underlying IP
+            // draft-ietf-bess-mup-safi §11: MUP nexthop matches the underlying IP
             // SAFI's. Accept 4 (IPv4), 16 (IPv6 single), or 32 (IPv6
             // global || link-local — RFC 8950 style), and surface the
             // global half. Anything else is malformed.
@@ -912,7 +912,7 @@ pub(crate) fn evpn_attr_emit(_snpa: u8, nhop: &IpAddr, updates: &[EvpnRoute], bu
 /// Serialize an `MpReachAttr::Mup { afi, snpa, nhop, updates }` as a
 /// complete `MP_REACH_NLRI` path attribute (header + value).
 ///
-/// Wire format (RFC 4760 §3 + RFC 9833 §11):
+/// Wire format (RFC 4760 §3 + draft-ietf-bess-mup-safi §11):
 /// ```text
 ///   AFI  (2 octets) = 1 (IPv4) or 2 (IPv6)
 ///   SAFI (1 octet)  = 85 (MUP)
@@ -1297,7 +1297,7 @@ mod tests {
     /// Minimal T1ST body for the IPv6 outer AFI (its only caller): RD(8),
     /// plen=0 (no prefix), TEID(4), QFI(1), ep_len=128, endpoint(16),
     /// src_len=0. The endpoint length must equal the AFI host width and
-    /// the source-address-length octet is mandatory (RFC 9833 §3.2.1).
+    /// the source-address-length octet is mandatory (draft-ietf-bess-mup-safi §3.2.1).
     fn min_t1st_body() -> Vec<u8> {
         let mut v = vec![0u8; 8]; // RD
         v.push(0); // plen

--- a/crates/bgp-packet/src/attrs/mp_unreach.rs
+++ b/crates/bgp-packet/src/attrs/mp_unreach.rs
@@ -34,7 +34,7 @@ pub enum MpUnreachAttr {
     Rtcv4Eor,
     Rtcv6(Vec<Rtcv6>),
     Rtcv6Eor,
-    /// BGP MUP withdraws (RFC 9833 §11). The outer AFI is preserved
+    /// BGP MUP withdraws (draft-ietf-bess-mup-safi §11). The outer AFI is preserved
     /// so the emitter can re-encode it without a separate Eor
     /// variant; an empty `withdraws` list represents end-of-RIB.
     Mup {
@@ -218,7 +218,7 @@ fn evpn_unreach_attr_emit(withdraw: &[EvpnRoute], buf: &mut BytesMut) {
 /// `withdraws` encodes an end-of-RIB marker) as a complete
 /// `MP_UNREACH_NLRI` path attribute.
 ///
-/// Wire format (RFC 4760 §4 + RFC 9833 §11):
+/// Wire format (RFC 4760 §4 + draft-ietf-bess-mup-safi §11):
 /// ```text
 ///   AFI  (2 octets) = 1 (IPv4) or 2 (IPv6)
 ///   SAFI (1 octet)  = 85 (MUP)
@@ -773,7 +773,7 @@ mod tests {
 
     /// Minimal T2ST body for the IPv4 outer AFI (its only caller): RD(8),
     /// ep_len=32, endpoint(4) (no TEID bits). The endpoint length covers
-    /// the full-width address per RFC 9833 §3.2.2.
+    /// the full-width address per draft-ietf-bess-mup-safi §3.2.2.
     fn min_t2st_body() -> Vec<u8> {
         let mut v = vec![0u8; 8];
         v.push(32); // endpoint_len = IPv4 address width

--- a/crates/bgp-packet/src/attrs/nlri_mup.rs
+++ b/crates/bgp-packet/src/attrs/nlri_mup.rs
@@ -1,6 +1,6 @@
 //! BGP MUP (Mobile User Plane) SAFI 85 NLRI.
 //!
-//! Outer envelope (RFC 9833 §3.1):
+//! Outer envelope (draft-ietf-bess-mup-safi §3.1):
 //!
 //! ```text
 //! +------------------------------------+
@@ -43,7 +43,7 @@ use crate::{Afi, RouteDistinguisher, nlri_psize};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum MupArchitectureType {
-    /// 3GPP 5G (RFC 9833 §3.1.1).
+    /// 3GPP 5G (draft-ietf-bess-mup-safi §3.1.1).
     Gpp5g,
     Unknown(u8),
 }
@@ -70,7 +70,7 @@ impl From<u8> for MupArchitectureType {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum MupRouteType {
-    /// Interwork Segment Discovery (RFC 9833 §3.1.1).
+    /// Interwork Segment Discovery (draft-ietf-bess-mup-safi §3.1.1).
     Isd,
     /// Direct Segment Discovery (§3.1.2).
     Dsd,
@@ -114,7 +114,7 @@ impl From<u16> for MupRouteType {
 /// opaque body so the dispatch shell never drops an UPDATE.
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum MupRoute {
-    /// Interwork Segment Discovery Route (RFC 9833 §3.1.1).
+    /// Interwork Segment Discovery Route (draft-ietf-bess-mup-safi §3.1.1).
     ///
     /// Wire body: 8-octet RD + 1-octet prefix length + prefix bytes
     /// (variable, sized to cover the prefix length). The address
@@ -125,7 +125,7 @@ pub enum MupRoute {
         rd: RouteDistinguisher,
         prefix: IpNet,
     },
-    /// Direct Segment Discovery Route (RFC 9833 §3.1.2).
+    /// Direct Segment Discovery Route (draft-ietf-bess-mup-safi §3.1.2).
     ///
     /// Wire body: 8-octet RD + 4-octet (IPv4) or 16-octet (IPv6)
     /// segment endpoint address. The address family is selected by
@@ -136,7 +136,7 @@ pub enum MupRoute {
         rd: RouteDistinguisher,
         address: IpAddr,
     },
-    /// Type 1 Session Transformed Route (RFC 9833 §3.2.1).
+    /// Type 1 Session Transformed Route (draft-ietf-bess-mup-safi §3.2.1).
     ///
     /// Wire body: 8-octet RD + 1-octet prefix length (bits) + prefix
     /// bytes + 4-octet TEID + 1-octet QFI + 1-octet endpoint address
@@ -144,10 +144,11 @@ pub enum MupRoute {
     /// source address length (bits, 0/32/128) + optional source
     /// address bytes. The source-address-length octet is always
     /// present on the wire (zero when no source is carried), matching
-    /// GoBGP and RFC 9833 §3.2.1. Only the UE `prefix` follows the outer
-    /// AFI; the `endpoint` (gNB) and `source` (UPF) families are decided
-    /// by their own length octets (32 = IPv4, 128 = IPv6), so an IPv6 UE
-    /// route may carry an IPv4 endpoint/source (the mixed-AFI 5G case).
+    /// GoBGP and draft-ietf-bess-mup-safi §3.2.1. Only the UE `prefix`
+    /// follows the outer AFI; the `endpoint` (gNB) and `source` (UPF)
+    /// families are decided by their own length octets (32 = IPv4,
+    /// 128 = IPv6), so an IPv6 UE route may carry an IPv4 endpoint/source
+    /// (the mixed-AFI 5G case).
     T1st {
         id: u32,
         arch: MupArchitectureType,
@@ -160,7 +161,7 @@ pub enum MupRoute {
         /// source-address-length of 0 on the wire.
         source: Option<IpAddr>,
     },
-    /// Type 2 Session Transformed Route (RFC 9833 §3.2.2).
+    /// Type 2 Session Transformed Route (draft-ietf-bess-mup-safi §3.2.2).
     ///
     /// Wire body: 8-octet RD + 1-octet endpoint address length (bits,
     /// up to 64 for IPv4 / 160 for IPv6) + full-width endpoint address
@@ -383,12 +384,11 @@ impl MupRoute {
                 let (rest, qfi) = be_u8(rest)?;
                 // The endpoint-address-length octet selects the endpoint's
                 // address family on its own (32 = IPv4 gNB, 128 = IPv6
-                // gNB), independent of the outer AFI: draft-ietf-bess-mup-
-                // safi / RFC 9833 §3.2.1 deliberately permits an IPv6 UE
-                // prefix to carry an IPv4 endpoint/source — the real 5G
-                // case where the N3 transport is IPv4. (GoBGP infers the
-                // family from this octet the same way; only the UE prefix
-                // is tied to the outer AFI.)
+                // gNB), independent of the outer AFI: draft-ietf-bess-mup-safi
+                // §3.2.1 deliberately permits an IPv6 UE prefix to carry an
+                // IPv4 endpoint/source — the real 5G case where the N3
+                // transport is IPv4. (GoBGP infers the family from this octet
+                // the same way; only the UE prefix is tied to the outer AFI.)
                 let (rest, ep_len) = be_u8(rest)?;
                 let (endpoint, rest) = match ep_len {
                     32 => {
@@ -644,7 +644,7 @@ impl MupRoute {
 /// lists routes grouped by type (DSD then ISD then ST1 then ST2).
 #[derive(Debug, Clone, Eq, PartialEq, Ord, PartialOrd, Hash)]
 pub enum MupPrefix {
-    /// Direct Segment Discovery Route key (RFC 9833 §3.1.2).
+    /// Direct Segment Discovery Route key (draft-ietf-bess-mup-safi §3.1.2).
     Dsd { address: IpAddr },
     /// Interwork Segment Discovery Route key (§3.1.1).
     Isd { prefix: IpNet },
@@ -1417,7 +1417,7 @@ mod tests {
 
     #[test]
     fn t1st_rejects_non_host_endpoint_len() {
-        // ep_len = 24 is neither 32 nor 128 → malformed (RFC 9833 §3.2.1).
+        // ep_len = 24 is neither 32 nor 128 → malformed (draft-ietf-bess-mup-safi §3.2.1).
         let mut body = vec![0u8; 8];
         body.push(0); // plen=0
         body.extend_from_slice(&[0; 4]); // TEID

--- a/crates/bgp-packet/src/attrs/nlri_srpolicy.rs
+++ b/crates/bgp-packet/src/attrs/nlri_srpolicy.rs
@@ -23,7 +23,7 @@ use crate::Afi;
 ///
 /// The endpoint address family comes from the enclosing
 /// MP_REACH/MP_UNREACH header AFI, not from the NLRI itself — the same
-/// way BGP MUP (RFC 9833) threads the outer AFI down to
+/// way BGP MUP (draft-ietf-bess-mup-safi) threads the outer AFI down to
 /// `MupRoute::parse`. The candidate-path content (preference, binding
 /// SID, segment lists, …) rides in the Tunnel Encapsulation attribute
 /// (Tunnel-Type 15), decoded separately.

--- a/docs/design/bgp-mup-followups.md
+++ b/docs/design/bgp-mup-followups.md
@@ -1,7 +1,7 @@
 # BGP MUP (Mobile User Plane) — deferred follow-ups
 
-Status as of 2026-06-21. The MUP **control plane** (RFC 9833 /
-draft-mpmz-bess-mup-safi, SAFI 85) landed on branch `bgp-mup` over four
+Status as of 2026-06-21. The MUP **control plane**
+(draft-mpmz-bess-mup-safi, SAFI 85) landed on branch `bgp-mup` over four
 phases, committed and pushed (rebased onto `origin/main`):
 
 - **P0 codec** — completed the `MupRoute` codec to be GoBGP byte-exact:
@@ -259,7 +259,7 @@ an Add-Path id dimension like the v4 path).
 ### 11. eBGP next-hop-self next-hop family
 
 **What:** For eBGP / originated routes, `route_update_mup` sets the
-next-hop to `peer.param.local_addr.ip()`, which may be IPv4. RFC 9833
+next-hop to `peer.param.local_addr.ip()`, which may be IPv4. draft-ietf-bess-mup-safi
 next-hops are IPv6 (PE/controller address).
 
 **Why deferred:** iBGP / route-reflector — the common controller→PE path

--- a/tools/pfcp-inject/README.md
+++ b/tools/pfcp-inject/README.md
@@ -6,7 +6,7 @@ controller in tests and by hand.
 It pretends to be a 5G SMF (Session Management Function) and pushes one
 mobile session into the controller (`router bgp mup-c`): a UE IP address,
 an access-side GTP-U F-TEID, and a Network Instance. The controller learns
-the session and **originates a MUP Session-Transformed route** (RFC 9833,
+the session and **originates a MUP Session-Transformed route** (draft-ietf-bess-mup-safi,
 SAFI 85). With `--delete` it tears the session down again.
 
 It is intentionally tiny and synchronous: the [`rs-pfcp`](https://crates.io/crates/rs-pfcp)

--- a/zebra-rs/src/bgp/config.rs
+++ b/zebra-rs/src/bgp/config.rs
@@ -1567,7 +1567,7 @@ fn config_afi_safi(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Option<()> {
         // simply forgets the statement: IPv4 unicast falls back to the
         // built-in default (or the group's opinion), other families to
         // off (or the group's opinion). The `mup` name expands to
-        // both the IPv4 and IPv6 MUP families (RFC 9833).
+        // both the IPv4 and IPv6 MUP families (draft-ietf-bess-mup-safi).
         if op.is_set() {
             let enabled = enabled?;
             for fam in super::neighbor_group::mp_family_expand(key) {
@@ -4422,7 +4422,7 @@ impl Bgp {
             config_ethernet_segment_interface,
         );
 
-        // MUP controller (`router bgp mup-c …`, RFC 9833).
+        // MUP controller (`router bgp mup-c …`, draft-ietf-bess-mup-safi).
         // Augmented in by zebra-bgp-mup-controller.yang; the controller
         // task is spawned/torn down at CommitEnd by `apply_mup_c_commit_diff`.
         self.callback_add("/router/bgp/mup-c/enable", config_mup_c_enable);

--- a/zebra-rs/src/bgp/neighbor_group.rs
+++ b/zebra-rs/src/bgp/neighbor_group.rs
@@ -223,7 +223,7 @@ pub fn config_neighbor_group_afi_safi_enabled(
     match op {
         ConfigOp::Set => {
             let enabled = args.boolean()?;
-            // `mup` toggles both MUP families at once (RFC 9833).
+            // `mup` toggles both MUP families at once (draft-ietf-bess-mup-safi).
             for fam in mp_family_expand(family) {
                 group.afi_safi.entry(fam).or_default().enabled = enabled;
             }
@@ -862,7 +862,7 @@ pub(super) fn sweep_members(
     }
 }
 
-/// MUP (RFC 9833) is exposed through a single `mup` config
+/// MUP (draft-ietf-bess-mup-safi) is exposed through a single `mup` config
 /// name that enables *both* the IPv4 (AFI 1) and IPv6 (AFI 2) MUP
 /// families at once. Every other family is one config name → one
 /// `(AFI, SAFI)`. Expand a parsed family into the concrete set of
@@ -1420,7 +1420,7 @@ mod tests {
 
     #[test]
     fn mp_family_expand_fans_out_mup_to_both_afis() {
-        // `mup` enables both IPv4-MUP and IPv6-MUP (RFC 9833).
+        // `mup` enables both IPv4-MUP and IPv6-MUP (draft-ietf-bess-mup-safi).
         assert_eq!(
             mp_family_expand(AfiSafi::new(Afi::Ip, Safi::Mup)),
             vec![

--- a/zebra-rs/src/bgp/route.rs
+++ b/zebra-rs/src/bgp/route.rs
@@ -2568,7 +2568,7 @@ pub struct LocalRib {
     /// Per-RD EVPN Loc-RIB tables.
     pub evpn: BTreeMap<RouteDistinguisher, LocalRibEvpnTable>,
 
-    /// Per-RD MUP (SAFI 85, RFC 9833) Loc-RIB tables, mirroring `evpn`.
+    /// Per-RD MUP (SAFI 85, draft-ietf-bess-mup-safi) Loc-RIB tables, mirroring `evpn`.
     pub mup: BTreeMap<RouteDistinguisher, LocalRibMupTable>,
 
     /// IPv4 / IPv6 Flow Specification Loc-RIB (SAFI 133).
@@ -7538,7 +7538,7 @@ pub fn route_evpn_withdraw(ident: usize, route: &EvpnRoute, bgp: &mut BgpTop, pe
     }
 }
 
-/// Store one received MUP NLRI (RFC 9833, SAFI 85) in the peer's
+/// Store one received MUP NLRI (draft-ietf-bess-mup-safi, SAFI 85) in the peer's
 /// Adj-RIB-In and the MUP Loc-RIB, then re-run best-path.
 ///
 /// Phase 2 is receive + show only: there is no inbound route-policy, no
@@ -7751,7 +7751,7 @@ impl MupSegmentDesired {
 /// iBGP-to-iBGP suppression unless the peer is a route-reflector client,
 /// RFC 1997 NO_ADVERTISE/NO_EXPORT, eBGP AS_PATH prepend + next-hop-self,
 /// iBGP default LOCAL_PREF, and stripping iBGP-only attrs on eBGP. The
-/// next-hop rides in MP_REACH (RFC 9833), so the path-attr NEXT_HOP is
+/// next-hop rides in MP_REACH (draft-ietf-bess-mup-safi), so the path-attr NEXT_HOP is
 /// cleared.
 fn route_update_mup(
     peer: &mut Peer,
@@ -7781,7 +7781,7 @@ fn route_update_mup(
     // carrying an End.DT46 Prefix-SID) advertises the PE locator node carried
     // in the attr, so a receiving PE H.Encaps to it; next-hop-self toward
     // eBGP and for our other originations; otherwise preserve the received
-    // next-hop (RFC 9833 — the PE/controller address the ingress PE resolves).
+    // next-hop (draft-ietf-bess-mup-safi — the PE/controller address the ingress PE resolves).
     let nhop: IpAddr = if rib.is_originated() && attrs.prefix_sid.is_some() {
         bgp_nexthop_ip(attrs.nexthop.as_ref()?)?
     } else if peer.is_ebgp() || rib.is_originated() {
@@ -9848,7 +9848,7 @@ pub fn route_clean(
         peer.adj_in.evpn.clear();
     }
 
-    // MUP (RFC 9833). Phase 2 is receive-only with no LLGR retention, so
+    // MUP (draft-ietf-bess-mup-safi). Phase 2 is receive-only with no LLGR retention, so
     // peer-down simply drops every MUP route the peer gave us from the
     // Loc-RIB and clears its Adj-RIB-In. (LLGR stale retention for MUP is
     // a later phase, mirroring the EVPN/VPN two-branch logic above.)
@@ -12801,7 +12801,7 @@ pub fn route_sync(peer: &mut Peer, bgp: &mut BgpTop, v4_via_pool: bool) {
     if peer.is_afi_safi(Afi::L2vpn, Safi::Evpn) {
         route_sync_evpn(peer, bgp);
     }
-    // SAFI 85 (RFC 9833): dump the MUP Loc-RIB. Like EVPN/label, MUP is
+    // SAFI 85 (draft-ietf-bess-mup-safi): dump the MUP Loc-RIB. Like EVPN/label, MUP is
     // advertised event-driven, so a route learned before this peer came
     // up would otherwise never be sent.
     if peer.is_afi_safi(Afi::Ip, Safi::Mup) || peer.is_afi_safi(Afi::Ip6, Safi::Mup) {

--- a/zebra-rs/src/bgp/show.rs
+++ b/zebra-rs/src/bgp/show.rs
@@ -153,7 +153,7 @@ fn rib_entries_count<V: BgpShowView>(bgp: &V, afi_safi: &AfiSafi) -> usize {
 }
 
 /// Address family a MUP Loc-RIB entry belongs to. The MUP table is a
-/// single flat map (RFC 9833 routes for both AFIs share it), so attribute
+/// single flat map (draft-ietf-bess-mup-safi routes for both AFIs share it), so attribute
 /// each route to v4/v6 by the family of its principal address — the DSD
 /// address, the ISD / ST1 session prefix, or the ST2 endpoint. `Unknown`
 /// routes carry no decoded address and belong to neither family.
@@ -2480,9 +2480,9 @@ fn show_bgp_evpn_summary(
     show_bgp_summary_one(bgp, AfiSafi::new(Afi::L2vpn, Safi::Evpn), json)
 }
 
-/// `show bgp mup summary` — the MUP (SAFI 85, RFC 9833)
+/// `show bgp mup summary` — the MUP (SAFI 85, draft-ietf-bess-mup-safi)
 /// neighbor summary. `mup` enables both IPv4-MUP and IPv6-MUP
-/// at once (RFC 9833), so this renders both sections — the MUP slice of
+/// at once (draft-ietf-bess-mup-safi), so this renders both sections — the MUP slice of
 /// `show bgp summary` — listing the neighbors that have each MUP family
 /// enabled and whether they negotiated the capability.
 fn show_bgp_mup_summary(
@@ -4000,7 +4000,7 @@ fn show_bgp_evpn(
 
 /// Decode a MUP path's extended communities for display: two-octet AS
 /// Route Targets render as `RT:<asn>:<u32>`; the MUP Extended Community
-/// (RFC 9833 §5, type 0x0c) and anything else fall through to a raw
+/// (draft-ietf-bess-mup-safi §5, type 0x0c) and anything else fall through to a raw
 /// 8-octet hex dump (e.g. `0x0c0000010000003d`).
 fn format_mup_ecom_value(v: &ExtCommunityValue) -> String {
     match (v.high_type, v.low_type) {
@@ -4037,7 +4037,7 @@ fn show_mup_ecom(attr: &BgpAttr) -> String {
 
 /// Render a `MupPrefix` (plus its outer-map RD) as the bracketed
 /// `[TYPE][rd][fields]` form used by `show bgp mup`, following the MUP NLRI
-/// layout (RFC 9833).
+/// layout (draft-ietf-bess-mup-safi).
 fn mup_prefix_display(rd: &RouteDistinguisher, prefix: &MupPrefix) -> String {
     match prefix {
         MupPrefix::Dsd { address } => format!("[DSD][{rd}][{address}]"),
@@ -4200,7 +4200,7 @@ fn show_bgp_mup_c_association(
     Ok(buf)
 }
 
-/// `show bgp mup` — the MUP (SAFI 85, RFC 9833) view: the
+/// `show bgp mup` — the MUP (SAFI 85, draft-ietf-bess-mup-safi) view: the
 /// config-driven `MUP VRFs:` block (per-VRF `mup` services)
 /// followed by the Loc-RIB route table. The full `MUP controller:`
 /// wrapper (zenoh source + ingested sessions) lands with the controller

--- a/zebra-rs/src/bgp/vrf_config.rs
+++ b/zebra-rs/src/bgp/vrf_config.rs
@@ -176,7 +176,7 @@ pub struct MupSrv6Mobile {
     pub mup_ext_comm: Option<RouteDistinguisher>,
 }
 
-/// Per-VRF BGP MUP (RFC 9833) service config — the `mup`
+/// Per-VRF BGP MUP (draft-ietf-bess-mup-safi) service config — the `mup`
 /// container under `router bgp vrf <name>` in zebra-bgp-vrf.yang. Holds
 /// only the `route {st1|st2}` origination binding; the export/import
 /// route-targets live on the top-level `vrf <name> mup
@@ -231,7 +231,7 @@ pub struct BgpVrfConfig {
     /// its own PEs over a single MP-eBGP VPNv4 session while still
     /// forwarding per-VRF. Default `false` (ordinary L3VPN VRF).
     pub inter_as_hybrid: bool,
-    /// Per-VRF BGP MUP (RFC 9833) service config. Mirrors the
+    /// Per-VRF BGP MUP (draft-ietf-bess-mup-safi) service config. Mirrors the
     /// `mup` container in zebra-bgp-vrf.yang.
     pub mobile_uplane: BgpVrfMobileUplane,
 }

--- a/zebra-rs/src/config/configs.rs
+++ b/zebra-rs/src/config/configs.rs
@@ -154,7 +154,7 @@ impl Args {
             "sr-policy-v4" => Some(AfiSafi::new(Afi::Ip, Safi::SrTePolicy)),
             "sr-policy-v6" => Some(AfiSafi::new(Afi::Ip6, Safi::SrTePolicy)),
             "link-state" => Some(AfiSafi::new(Afi::LinkState, Safi::LinkState)),
-            // MUP (RFC 9833) is one config name that enables both the
+            // MUP (draft-ietf-bess-mup-safi) is one config name that enables both the
             // IPv4 and IPv6 MUP families; (Ip, Mup) is the canonical
             // tuple returned here and `mp_family_expand` fans it out to
             // both AFIs at the `enabled` handlers.
@@ -987,7 +987,7 @@ mod tests {
     #[test]
     fn afi_safi_parses_mobile_uplane_as_v4_mup() {
         // The single `mup` name canonicalizes to (Ip, Mup);
-        // the enabled handlers fan it out to both MUP AFIs (RFC 9833).
+        // the enabled handlers fan it out to both MUP AFIs (draft-ietf-bess-mup-safi).
         let mut args = Args(["mup".to_string()].into_iter().collect());
         assert_eq!(args.afi_safi(), Some(AfiSafi::new(Afi::Ip, Safi::Mup)));
     }

--- a/zebra-rs/src/mup-c/mod.rs
+++ b/zebra-rs/src/mup-c/mod.rs
@@ -1,7 +1,7 @@
 //! BGP MUP Controller (MUP-C) — Mobile User Plane controller.
 //!
-//! Implements the controller half of BGP MUP (RFC 9833 /
-//! `draft-mpmz-bess-mup-safi`, SAFI 85). Per the draft §3.3.7/§3.3.10 a
+//! Implements the controller half of BGP MUP
+//! (`draft-mpmz-bess-mup-safi`, SAFI 85). Per the draft §3.3.7/§3.3.10 a
 //! MUP Controller learns per-session mobile state through a "northbound
 //! API" (left out of scope by the draft) and originates Type-1 / Type-2
 //! Session-Transformed routes from it. zebra-rs uses **PFCP / N4** (3GPP

--- a/zebra-rs/yang/config.yang
+++ b/zebra-rs/yang/config.yang
@@ -3124,7 +3124,7 @@ module config {
       }
       container mup {
         description
-          "BGP MUP (RFC 9833 / draft-ietf-bess-mup-safi) route policy for
+          "BGP MUP (draft-ietf-bess-mup-safi) route policy for
            this VRF. The export RTs tag the Session-Transformed routes the
            MUP controller originates from this VRF; the import RTs select
            which received ST routes belong to it (the import side is

--- a/zebra-rs/yang/zebra-afi-safi.yang
+++ b/zebra-rs/yang/zebra-afi-safi.yang
@@ -90,7 +90,7 @@ module zebra-afi-safi {
         }
         enum mup {
           description
-            "BGP Mobile User Plane (MUP), SAFI 85, RFC 9833. A single
+            "BGP Mobile User Plane (MUP), SAFI 85, draft-ietf-bess-mup-safi. A single
              config name that negotiates BOTH IPv4-MUP (AFI 1) and
              IPv6-MUP (AFI 2).";
         }

--- a/zebra-rs/yang/zebra-bgp-mup-controller.yang
+++ b/zebra-rs/yang/zebra-bgp-mup-controller.yang
@@ -29,7 +29,8 @@ module zebra-bgp-mup-controller {
   description
     "BGP MUP Controller (MUP-C) extensions to the BGP candidate-config
      tree. Adds a `mup-c` container directly under the BGP instance
-     (SAFI 85, RFC 9833). When enabled, the BGP task spawns an in-process
+     (SAFI 85, draft-ietf-bess-mup-safi). When enabled, the BGP task
+     spawns an in-process
      MUP controller that terminates PFCP/N4 (3GPP TS 29.244) as a UP-node,
      learns mobile sessions and originates Type-1 / Type-2
      Session-Transformed routes.
@@ -50,7 +51,8 @@ module zebra-bgp-mup-controller {
        }";
 
   reference
-    "RFC 9833: A YANG ... (BGP MUP, draft-mpmz-bess-mup-safi)
+    "draft-ietf-bess-mup-safi: BGP Extensions for the Mobile User Plane
+     (MUP) SAFI
      3GPP TS 29.244: Interface between the Control Plane and the User
      Plane Nodes (PFCP)";
 

--- a/zebra-rs/yang/zebra-bgp-vrf.yang
+++ b/zebra-rs/yang/zebra-bgp-vrf.yang
@@ -274,7 +274,7 @@ module zebra-bgp-vrf {
       }
       container mup {
         description
-          "Per-VRF MUP (RFC 9833) service. The `segment` list is the PE
+          "Per-VRF MUP (draft-ietf-bess-mup-safi) service. The `segment` list is the PE
            side: `segment direct` originates a Direct Segment Discovery
            (DSD, type 2) route for this VRF carrying the VRF's End.DT46
            SID (carved from `encapsulation srv6`); `segment interwork` an


### PR DESCRIPTION
## Summary

The BGP MUP (SAFI 85) code, YANG, book, design docs, and BDD features cited
**RFC 9833** as the MUP SAFI specification. RFC 9833 is actually *"A Common
YANG Data Model for Attachment Circuits"* and is unrelated to MUP. The MUP
SAFI is still an Internet-Draft: `draft-ietf-bess-mup-safi` (from the
individual `draft-mpmz-bess-mup-safi`).

This replaces every mis-cited `RFC 9833` MUP reference (~65 occurrences
across 31 files) with the draft:

- Bare and `§`-qualified refs → `draft-ietf-bess-mup-safi`, section numbers
  (§3.x, §5, §11) preserved — they came from the draft.
- Lines already pairing the draft with the wrong RFC (e.g.
  `RFC 9833 / draft-mpmz-bess-mup-safi`) → drop the RFC, keep the existing
  draft name.
- Fixed a broken YANG `reference` placeholder in
  `zebra-bgp-mup-controller.yang` to a proper draft citation.
- Reflowed the few comment lines that became over-long.

No logic change — comments, YANG description/reference strings, docs, and
Gherkin prose only.

### Verified while here

Both zebra-rs and current GoBGP decode a Type-1 ST route's endpoint (gNB) /
source (UPF) address family from its **own length octet** (32 = IPv4,
128 = IPv6), independent of the outer AFI; only the UE prefix follows the
outer AFI — matching draft §3.2.1. So the mixed-AFI doc comment is accurate.

## Test plan

- `cargo fmt --all` + `cargo clippy --workspace --all-targets -- -D warnings`
  clean.
- `cargo test -p zebra-rs --bins -p bgp-packet` → 1494 + bgp-packet pass;
  `yang_load` guard tests pass (YANG still parses).
- Edited YANG synced to `/etc/zebra-rs/yang` and `~/.zebra-rs/yang`.

Generated with [Claude Code](https://claude.com/claude-code)