### PR TITLE
bgp/mup: install ST1->ISD SRv6 encap into the VRF table

### DIFF
--- a/bdd/Makefile
+++ b/bdd/Makefile
@@ -50,6 +50,15 @@ bgp_mup_isd:
 	mkdir -p allure-results
 	cargo test --test cucumber -- --concurrency=1 --tags "@bgp_mup_isd"
 
+# MUP ST1->ISD encap: one interwork node originates a local ISD (`segment
+# interwork prefix <p>`) and, via its MUP-C, an ST1 whose UE is inside <p>.
+# The ST1 resolves to the local End.DT46 segment and an oif-only recursive
+# seg6 H.Encaps route for the UE is installed into the VRF table. Needs
+# `pfcp-inject` on the host PATH + root netns (kernel VRF + seg6).
+bgp_mup_st1_isd:
+	mkdir -p allure-results
+	cargo test --test cucumber -- --concurrency=1 --tags "@bgp_mup_st1_isd"
+
 # MUP ST2: the MUP-C learns a PFCP decapsulation session (Network Instance
 # `core`) and originates a Type-2 Session-Transformed route carrying the
 # core endpoint + GTP TEID and the Direct segment id (MUP Extended

--- a/bdd/tests/configs/bgp_mup_st1_isd/z1.yaml
+++ b/bdd/tests/configs/bgp_mup_st1_isd/z1.yaml
@@ -1,0 +1,56 @@
+# z1 — a single MUP interwork node that both originates a local ISD segment
+# and (via its MUP-C) an ST1 whose UE falls inside the ISD prefix, so the
+# ST1 resolves to the local End.DT46 segment and an SRv6 H.Encaps entry for
+# the UE prefix is installed into the VRF's table.
+#
+# VRF N6 is `encapsulation srv6`, so it carves a per-VRF End.DT46 SID from
+# locator LOC1 and installs the seg6local decap into the VRF table.
+#   * `segment interwork prefix 10.60.0.0/16` originates the ISD advertising
+#     that SID under 10.60.0.0/16.
+#   * `route st1 network-instance access` makes the MUP-C originate a Type-1
+#     ST route for PFCP sessions on NI `access`.
+# A PFCP session with UE 10.60.1.5 (inside 10.60.0.0/16) therefore yields an
+# ST1 that resolves to the local ISD, and zebra-rs installs
+#   10.60.1.5/32 encap seg6 mode encap segs [End.DT46 SID] dev lo table <N6>
+segment-routing:
+  locator:
+  - name: LOC1
+    prefix: fcbb:bb01::/48
+    behavior: usid
+router:
+  bgp:
+    global:
+      as: 65001
+      router-id: 192.168.0.1
+    segment-routing:
+      srv6:
+        locator: LOC1
+    vrf:
+    - name: N6
+      rd: "65000:100"
+      encapsulation: srv6
+      afi-safi:
+        mup:
+          route:
+          - type: st1
+            network-instance: access
+          segment:
+          - type: interwork
+            prefix: 10.60.0.0/16
+    mup-c:
+      enable: true
+      controller-address: fcbb:bb01::1
+      pfcp:
+        listen-address: 192.168.0.1
+        port: 8805
+      srv6:
+        locator: LOC1
+# Top-level VRF: MUP route-targets live here (same framework as ipv4/ipv6).
+vrf:
+- name: N6
+  mup:
+    route-target:
+      export:
+      - "65000:200"
+      import:
+      - "65000:200"

--- a/bdd/tests/features/bgp_mup_st1_isd.feature
+++ b/bdd/tests/features/bgp_mup_st1_isd.feature
@@ -1,0 +1,50 @@
+@serial
+@bgp_mup_st1_isd
+Feature: BGP MUP ST1 resolves to a local ISD segment and installs SRv6 encap
+  A single MUP interwork node originates a local Interwork Segment Discovery
+  (ISD, type 1, SAFI 85 / draft-ietf-bess-mup-safi) route advertising its
+  per-VRF End.DT46 SID under a prefix, and — via its MUP controller — a
+  Type-1 Session-Transformed (ST1) route whose UE address falls inside that
+  prefix. Because the UE is covered by the local ISD, zebra-rs resolves the
+  ST1 to the ISD's End.DT46 segment (`show bgp vrf <name> mup` prints the
+  bind) and installs an oif-only recursive SRv6 H.Encaps route for the UE
+  prefix into the VRF's table, so UE-bound traffic in the VRF is encapsulated
+  toward that segment.
+
+  Topology: one node z1.
+
+       ┌──────────┐
+       │    z1    │  VRF N6: encapsulation srv6
+       │ MUP-C +  │    segment interwork prefix 10.60.0.0/16 (ISD)
+       │ interwork│    route st1 network-instance access     (ST1 via PFCP)
+       └──────────┘
+
+  Scenario: Build a single interwork node and turn on the MUP controller
+    Given a clean test environment
+    When I create bridge "br0"
+    And I create namespace "z1" with IP "192.168.0.1/24" on bridge "br0"
+    And I start zebra-rs in namespace "z1"
+    And I apply config "z1.yaml" to namespace "z1"
+    And I wait 5 seconds for BGP to operate
+    Then show command "show bgp mup-c" in namespace "z1" should contain "PFCP listen : 192.168.0.1:8805"
+    # The ISD originates from the segment config, keyed under the VRF's own RD.
+    And show command "show bgp mup" in namespace "z1" should eventually contain "[ISD][65000:100][10.60.0.0/16]"
+
+  Scenario: A PFCP session inside the ISD prefix installs the SRv6 encap
+    Given the test topology exists
+    When I execute "pfcp-inject --target 192.168.0.1 --port 8805 --ue-ipv4 10.60.1.5 --teid 0x12345678 --endpoint 10.0.0.1 --network-instance access" in namespace "z1"
+    Then show command "show bgp mup-c session" in namespace "z1" should eventually contain "10.60.1.5"
+    And show command "show bgp mup" in namespace "z1" should contain "ue=10.60.1.5/32"
+    # The ST1's UE (10.60.1.5) is covered by the local ISD 10.60.0.0/16, so
+    # the per-VRF view shows the resolution to the ISD's End.DT46 segment ...
+    And show command "show bgp vrf N6 mup" in namespace "z1" should eventually contain "resolved 10.60.1.5/32 -> End.DT46"
+    # ... and the SRv6 H.Encaps route is installed into the VRF table (an
+    # oif-only recursive seg6 encap toward the locator-LOC1 End.DT46 SID).
+    And command "ip route show table all" in namespace "z1" should eventually contain "encap seg6 mode encap segs 1 [ fcbb:bb01:"
+
+  Scenario: Teardown topology
+    Given the test topology exists
+    When I stop zebra-rs in namespace "z1"
+    And I delete namespace "z1"
+    And I delete bridge "br0"
+    Then the test environment should be clean

--- a/zebra-rs/src/bgp/vrf/inst.rs
+++ b/zebra-rs/src/bgp/vrf/inst.rs
@@ -161,6 +161,13 @@ pub struct BgpVrf {
     /// (direct↔interwork switch / router-id change) withdraws this prior one
     /// first.
     pub mup_segment_prefix: Option<bgp_packet::MupPrefix>,
+    /// Installed ST1→ISD encap FIB entries: UE prefix → the local ISD's
+    /// End.DT46 SID it is steered into. A selected ST1 whose UE prefix is
+    /// covered by a locally-originated ISD's prefix installs an oif-only
+    /// recursive seg6 H.Encaps route into this VRF's table (`dst = UE
+    /// prefix, encap seg6 segs [SID]`). Tracked so `reconcile_mup_st1_isd`
+    /// can diff and withdraw when the ST1 or the covering ISD goes away.
+    pub mup_st1_isd_installed: std::collections::BTreeMap<ipnet::IpNet, std::net::Ipv6Addr>,
 }
 
 /// Sender side of the per-VRF inbound channel — handed back to
@@ -602,6 +609,7 @@ impl BgpVrf {
             flex_algo_srv6_routes: Default::default(),
             mup_originated: std::collections::BTreeMap::new(),
             mup_segment_prefix: None,
+            mup_st1_isd_installed: std::collections::BTreeMap::new(),
         };
         (vrf, inbox_tx)
     }
@@ -619,6 +627,128 @@ impl BgpVrf {
                 vrf: self.name.clone(),
                 prefix,
             });
+        }
+    }
+
+    /// Reconcile ST1→ISD encap FIB entries for this VRF. A selected ST1
+    /// whose UE prefix is covered by a locally-originated ISD's prefix is
+    /// steered into that ISD's local End.DT46 SID: install an oif-only
+    /// recursive seg6 H.Encaps route (`dst = UE prefix, encap seg6 segs
+    /// [SID]`) into this VRF's table so UE-bound traffic in the VRF is
+    /// encapsulated toward that segment. Longest-match when several local
+    /// ISDs cover the UE. Diff-gated against `mup_st1_isd_installed` so an
+    /// unchanged binding doesn't churn the FIB, and a binding that lost its
+    /// ST1 or its covering ISD is withdrawn. Mirrors the show-side
+    /// resolution in `render_mup_table`.
+    fn reconcile_mup_st1_isd(&mut self) {
+        use std::net::Ipv6Addr;
+        // Locally-originated ISD prefixes → their End.DT46 SID.
+        let isd: Vec<(ipnet::IpNet, Ipv6Addr)> = self
+            .local_rib
+            .mup
+            .values()
+            .flat_map(|t| t.selected.iter())
+            .filter_map(|(prefix, rib)| {
+                let bgp_packet::MupPrefix::Isd { prefix: p } = prefix else {
+                    return None;
+                };
+                if !rib.is_originated() {
+                    return None;
+                }
+                let (sid, _behavior) = rib.attr.srv6_l3_sid()?;
+                Some((*p, sid))
+            })
+            .collect();
+        // Desired: each selected ST1 UE prefix → the most-specific covering
+        // local ISD's SID.
+        let mut desired: std::collections::BTreeMap<ipnet::IpNet, Ipv6Addr> =
+            std::collections::BTreeMap::new();
+        if !isd.is_empty() {
+            for (prefix, _rib) in self.local_rib.mup.values().flat_map(|t| t.selected.iter()) {
+                if let bgp_packet::MupPrefix::T1st { prefix: ue, .. } = prefix
+                    && let Some((_p, sid)) = isd
+                        .iter()
+                        .filter(|(p, _)| p.contains(ue))
+                        .max_by_key(|(p, _)| p.prefix_len())
+                {
+                    desired.insert(*ue, *sid);
+                }
+            }
+        }
+        // Withdraw entries no longer desired (or whose SID changed).
+        let stale: Vec<ipnet::IpNet> = self
+            .mup_st1_isd_installed
+            .iter()
+            .filter(|(ue, sid)| desired.get(*ue) != Some(*sid))
+            .map(|(ue, _)| *ue)
+            .collect();
+        for ue in stale {
+            self.mup_st1_isd_withdraw(ue);
+            self.mup_st1_isd_installed.remove(&ue);
+        }
+        // Install new / changed entries.
+        for (ue, sid) in &desired {
+            if self.mup_st1_isd_installed.get(ue) == Some(sid) {
+                continue;
+            }
+            self.mup_st1_isd_install(*ue, *sid);
+            self.mup_st1_isd_installed.insert(*ue, *sid);
+        }
+    }
+
+    /// Build + send the oif-only recursive seg6 H.Encaps RibEntry for one
+    /// resolved ST1→ISD binding into this VRF's table. The local End.DT46
+    /// SID is delivered locally (its decap resolves to loopback), so the
+    /// encap route carries no gateway — just the loopback oif + the seg6
+    /// encap; the kernel re-routes the encapped packet by its outer SID DA
+    /// (see the oif-only branch in the netlink route path).
+    fn mup_st1_isd_install(&self, ue: ipnet::IpNet, sid: std::net::Ipv6Addr) {
+        use std::net::{IpAddr, Ipv6Addr};
+        let mut uni = crate::rib::NexthopUni::new(IpAddr::V6(Ipv6Addr::UNSPECIFIED), 0, Vec::new());
+        uni.ifindex_origin = Some(1); // loopback: the local SID is delivered locally
+        uni.segs = vec![sid];
+        uni.encap_type = Some(isis_packet::srv6::EncapType::HEncap);
+        uni.valid = true;
+        let mut entry = crate::rib::entry::RibEntry::new(crate::rib::RibType::Bgp);
+        entry.distance = 200;
+        entry.metric = 0;
+        entry.valid = true;
+        entry.nexthop = crate::rib::Nexthop::Uni(uni);
+        match ue {
+            ipnet::IpNet::V4(prefix) => {
+                let _ = self
+                    .ctx
+                    .rib
+                    .send(crate::rib::Message::Ipv4Add { prefix, rib: entry });
+            }
+            ipnet::IpNet::V6(prefix) => {
+                let _ = self
+                    .ctx
+                    .rib
+                    .send(crate::rib::Message::Ipv6Add { prefix, rib: entry });
+            }
+        }
+    }
+
+    /// Withdraw a previously-installed ST1→ISD encap entry. The RIB dels
+    /// the kernel route using its own stored nexthop, so a valueless stub
+    /// (like `fib_install_v4`'s withdraw) is enough to trigger it.
+    fn mup_st1_isd_withdraw(&self, ue: ipnet::IpNet) {
+        let mut stub = crate::rib::entry::RibEntry::new(crate::rib::RibType::Bgp);
+        stub.valid = false;
+        match ue {
+            ipnet::IpNet::V4(prefix) => {
+                let _ = self
+                    .ctx
+                    .rib
+                    .send(crate::rib::Message::Ipv4Del { prefix, rib: stub });
+            }
+            ipnet::IpNet::V6(prefix) => {
+                let _ = self
+                    .ctx
+                    .rib
+                    .send(crate::rib::Message::Ipv6Del { prefix, rib: stub });
+            }
         }
     }
 
@@ -1620,6 +1750,7 @@ impl BgpVrf {
                     .entry(rd)
                     .or_default()
                     .update(prefix, rib);
+                self.reconcile_mup_st1_isd();
             }
             BgpVrfMsg::MupWithdraw { rd, prefix } => {
                 // Same own-RD scoping as MupUpdate. The VRF holds the single
@@ -1637,6 +1768,7 @@ impl BgpVrf {
                 if empty {
                     self.local_rib.mup.remove(&rd);
                 }
+                self.reconcile_mup_st1_isd();
             }
             // VRF-first MUP origination: build the RD-free ST NLRI from the
             // dispatched session + resolved direction, and export it to the

--- a/zebra-rs/src/fib/netlink/handle.rs
+++ b/zebra-rs/src/fib/netlink/handle.rs
@@ -516,7 +516,36 @@ impl FibHandle {
         let attr = RouteAttribute::Destination(RouteAddress::Inet(prefix.addr()));
         msg.attributes.push(attr);
 
-        if self.use_nhid {
+        if let Nexthop::Uni(uni) = &nexthop
+            && !uni.segs.is_empty()
+            && uni.addr.is_unspecified()
+        {
+            // Oif-only recursive seg6 H.Encaps (e.g. a MUP ST1 UE prefix
+            // steered into a *local* End.DT46 ISD segment): there is no
+            // on-link underlay next-hop — the encapped packet's outer DA is
+            // the SID, which the kernel re-routes via the (local) locator
+            // route. So emit `dev <oif> encap seg6 …` with NO gateway, and
+            // embed the seg6 encap on the route: an unspecified-addr nexthop
+            // has no kernel nh_id, so the Nhid path can't carry it. Mirrors
+            // the seg6local oif-only branch in `route_ipv6_add_uni`.
+            if let Some(ifindex) = uni.ifindex() {
+                msg.attributes.push(RouteAttribute::Oif(ifindex));
+            }
+            let encap_type = uni
+                .encap_type
+                .unwrap_or(isis_packet::srv6::EncapType::HEncap);
+            match super::srv6::build_seg6_attrs(&uni.segs, encap_type) {
+                Ok((encap, encap_type_attr)) => {
+                    msg.attributes.push(encap);
+                    msg.attributes.push(encap_type_attr);
+                }
+                Err(e) => {
+                    tracing::warn!("SRv6 oif-only encap build failed for {prefix}: {e:#}");
+                    return false;
+                }
+            }
+            msg.attributes.push(RouteAttribute::Priority(uni.metric));
+        } else if self.use_nhid {
             // Kernel >= 5.3: use nexthop ID
             if let Nexthop::Uni(uni) = &nexthop {
                 msg.attributes.push(RouteAttribute::Nhid(uni.gid as u32));
@@ -690,7 +719,17 @@ impl FibHandle {
         let attr = RouteAttribute::Priority(entry.metric);
         msg.attributes.push(attr);
 
-        if self.use_nhid {
+        if let Nexthop::Uni(uni) = &nexthop
+            && !uni.segs.is_empty()
+            && uni.addr.is_unspecified()
+        {
+            // Oif-only recursive seg6 encap: delete by {dest, table, oif}.
+            // The route carries no gateway / nh_id, so pushing either would
+            // stop the kernel from matching it (see the add-path branch).
+            if let Some(ifindex) = uni.ifindex() {
+                msg.attributes.push(RouteAttribute::Oif(ifindex));
+            }
+        } else if self.use_nhid {
             // Kernel >= 5.3: use nexthop ID
             if let Nexthop::Uni(uni) = &nexthop {
                 msg.attributes.push(RouteAttribute::Nhid(uni.gid as u32));
@@ -871,7 +910,33 @@ impl FibHandle {
             return ok;
         }
 
-        if self.use_nhid {
+        if let Nexthop::Uni(uni) = &nexthop
+            && !uni.segs.is_empty()
+            && uni.addr.is_unspecified()
+        {
+            // Oif-only recursive seg6 H.Encaps — see the same branch in
+            // `route_ipv4_add_uni` for the rationale. No gateway; embed the
+            // seg6 encap and let the kernel re-route by the outer SID DA.
+            // Must precede the `use_nhid` arm: an unspecified-addr nexthop
+            // has gid 0, which the sanity check below would reject.
+            if let Some(ifindex) = uni.ifindex() {
+                msg.attributes.push(RouteAttribute::Oif(ifindex));
+            }
+            let encap_type = uni
+                .encap_type
+                .unwrap_or(isis_packet::srv6::EncapType::HEncap);
+            match super::srv6::build_seg6_attrs(&uni.segs, encap_type) {
+                Ok((encap, encap_type_attr)) => {
+                    msg.attributes.push(encap);
+                    msg.attributes.push(encap_type_attr);
+                }
+                Err(e) => {
+                    tracing::warn!("SRv6 oif-only encap build failed for {prefix}: {e:#}");
+                    return false;
+                }
+            }
+            msg.attributes.push(RouteAttribute::Priority(uni.metric));
+        } else if self.use_nhid {
             // Pre-send sanity check — mirror of route_ipv4_add_uni.
             let gid_for_check = match &nexthop {
                 Nexthop::Uni(u) => Some(u.gid),
@@ -1117,7 +1182,16 @@ impl FibHandle {
             return;
         }
 
-        if self.use_nhid {
+        if let Nexthop::Uni(uni) = &nexthop
+            && !uni.segs.is_empty()
+            && uni.addr.is_unspecified()
+        {
+            // Oif-only recursive seg6 encap: delete by {dest, table, oif}
+            // (no gateway / nh_id — see route_ipv4_del_uni).
+            if let Some(ifindex) = uni.ifindex() {
+                msg.attributes.push(RouteAttribute::Oif(ifindex));
+            }
+        } else if self.use_nhid {
             if let Nexthop::Uni(uni) = &nexthop {
                 msg.attributes.push(RouteAttribute::Nhid(uni.gid as u32));
                 let attr = RouteAttribute::Priority(uni.metric);


### PR DESCRIPTION
## Summary

On the node that originates a local ISD (Interwork Segment Discovery)
segment, a selected ST1 whose UE prefix is covered by the ISD's advertised
prefix is now steered into that ISD's local **End.DT46** SID: zebra-rs
installs an SRv6 **H.Encaps** route for the UE prefix into the VRF's table,
so UE-bound traffic in the VRF is encapsulated toward the segment. This is
the forwarding half of the ST1→ISD resolution added in #1698 (which added
the control-plane `resolved …` show line).

### 1. `fib/netlink` — oif-only recursive seg6 H.Encaps
A `Uni` nexthop carrying an SRv6 segment list (`segs`) with an unspecified
gateway now installs as `dev <oif> encap seg6 …` with **no gateway** (the
encap is embedded on the route rather than via a kernel nh_id, which an
unspecified-addr nexthop never gets). This is the shape a *local*-SID
recursive H.Encaps needs: the encapped packet's outer DA is the SID, which
the kernel re-routes via the local locator route, so there is no on-link
underlay next-hop. Added to the IPv4/IPv6 add + del paths; mirrors the
existing oif-only seg6local branch. Kernel form confirmed empirically.

### 2. `bgp/mup` — ST1→ISD install in the per-VRF task
On every MUP RIB change the VRF task reconciles ST1→ISD bindings: each
selected ST1 whose UE prefix is covered (longest-match) by a
locally-originated ISD installs an oif-only seg6 H.Encaps route
(`dst = UE prefix, encap seg6 segs [SID]`, loopback oif) into the VRF table
via the VRF-scoped RibClient. Diff-gated; withdrawn when the ST1 or its
covering ISD disappears.

The oif is loopback — the proper egress for a local SID (its own End.DT46
decap resolves to loopback and the encapped packet is delivered locally).

### 3. BDD `@bgp_mup_st1_isd`
Single interwork node z1: VRF N6 (`encapsulation srv6`) originates a local
ISD (`segment interwork prefix 10.60.0.0/16`) and, via its MUP-C/PFCP, an
ST1 with UE 10.60.1.5. Asserts the `resolved 10.60.1.5/32 -> End.DT46` bind
and the installed kernel route (`ip route show table all` →
`encap seg6 mode encap segs 1 [ fcbb:bb01:…`). Ends with a Teardown
scenario asserting a clean environment.

## Test plan

- `cargo fmt --all` + `cargo clippy --workspace --all-targets -- -D warnings`
  clean.
- Full workspace test suite (excl bdd) green — 1494 zebra-rs + all crates,
  0 failed.
- New BDD `@bgp_mup_st1_isd` passed end-to-end (root netns): the daemon
  carved SID `fcbb:bb01:0:40::`, rendered the resolution, and installed the
  `10.60.1.5/32 encap seg6 mode encap segs [SID]` route into the VRF table.
  No skipped steps. (BDD is CI-excluded; run locally.)

Follow-up: the symmetric ST2→DSD FIB install.

Generated with [Claude Code](https://claude.com/claude-code)