### PR TITLE
bgp/mup: install ST2->DSD SRv6 encap into the VRF table

### DIFF
--- a/bdd/Makefile
+++ b/bdd/Makefile
@@ -59,6 +59,14 @@ bgp_mup_st1_isd:
 	mkdir -p allure-results
 	cargo test --test cucumber -- --concurrency=1 --tags "@bgp_mup_st1_isd"
 
+# MUP ST2->DSD encap: an interwork node imports an ST2 + a *remote* DSD into
+# a forwarding VRF, resolves them by Direct-segment id, and installs the ST2
+# endpoint encap toward the DSD's End.DT46 SID resolved through the IS-IS
+# SRv6 underlay. Needs `pfcp-inject` on the host PATH + root netns.
+bgp_mup_st2_dsd_fib:
+	mkdir -p allure-results
+	cargo test --test cucumber -- --concurrency=1 --tags "@bgp_mup_st2_dsd_fib"
+
 # MUP ST2: the MUP-C learns a PFCP decapsulation session (Network Instance
 # `core`) and originates a Type-2 Session-Transformed route carrying the
 # core endpoint + GTP TEID and the Direct segment id (MUP Extended

--- a/bdd/tests/configs/bgp_mup_st2_dsd_fib/z1.yaml
+++ b/bdd/tests/configs/bgp_mup_st2_dsd_fib/z1.yaml
@@ -1,0 +1,82 @@
+# z1 — combined MUP UPF + Controller. It originates BOTH:
+#   * a Direct Segment Discovery (DSD) route for VRF N6 (`afi-safi mup
+#     segment direct`, `encapsulation srv6`) carrying the per-VRF End.DT46
+#     SID and the Direct-segment id (MUP Ext-Comm `1:2`), and
+#   * a Type-2 Session-Transformed (ST2) route from a PFCP session whose
+#     Network Instance is `core` (`afi-safi mup route st2 network-instance
+#     core mup-ext-comm 1:2`), carrying the same Direct-segment id `1:2`.
+# IS-IS L2 SRv6 underlay + iBGP (mup afi-safi) to z2 (the interwork SRGW)
+# over loopbacks. z2 resolves the ST2 to this End.DT46 Direct segment.
+vrf:
+- name: N6
+  mup:
+    route-target:
+      export:
+      - "65501:10"
+interface:
+- if-name: lo
+  ipv6:
+    address: 2001:db8::1/128
+- if-name: z1-z2
+  ipv6:
+    address: 2001:db8:0:12::1/64
+segment-routing:
+  locator:
+  - name: S
+    prefix: fcbb:bbbb:1::/48
+    behavior: usid
+router:
+  isis:
+    net: 49.0000.0000.0000.0001.00
+    hostname: z1
+    is-type: level-2-only
+    segment-routing:
+      srv6:
+        locator: S
+    interface:
+    - if-name: lo
+      ipv6:
+        enable: true
+    - if-name: z1-z2
+      network-type: point-to-point
+      metric: 1
+      ipv6:
+        enable: true
+  bgp:
+    global:
+      as: 65501
+      router-id: 10.0.0.1
+    timer:
+      adv-interval:
+        ibgp: 1
+    segment-routing:
+      srv6:
+        locator: S
+    neighbor:
+    - remote-address: 2001:db8::2
+      remote-as: 65501
+      update-source: 2001:db8::1
+      enabled: true
+      afi-safi:
+      - name: mup
+        enabled: true
+    vrf:
+    - name: N6
+      rd: "65501:10"
+      encapsulation: srv6
+      afi-safi:
+        mup:
+          segment:
+          - type: direct
+            mup-ext-comm: "1:2"
+          route:
+          - type: st2
+            network-instance: core
+            mup-ext-comm: "1:2"
+    mup-c:
+      enable: true
+      controller-address: 2001:db8::1
+      pfcp:
+        listen-address: 127.0.0.1
+      srv6:
+        locator: S

--- a/bdd/tests/configs/bgp_mup_st2_dsd_fib/z2.yaml
+++ b/bdd/tests/configs/bgp_mup_st2_dsd_fib/z2.yaml
@@ -1,0 +1,68 @@
+# z2 — MUP interwork node (SRGW) with a *forwarding* VRF. Unlike the
+# show-only interwork test, VRF N6 here has its own `rd` +
+# `encapsulation srv6` (a kernel table) and imports RT 65501:10, so z1's
+# DSD (Direct segment, End.DT46 + id `1:2`) and the ST2 (id `1:2`) land in
+# z2's per-VRF MUP RIB. z2 resolves each ST2 to the matching DSD by that id
+# and installs an SRv6 H.Encaps route for the ST2 endpoint into the VRF
+# table, resolved through the IS-IS SRv6 underlay toward z1's DSD next-hop:
+#   10.0.0.1/32 via <z1 underlay> encap seg6 segs [z1 End.DT46 SID]
+interface:
+- if-name: lo
+  ipv6:
+    address: 2001:db8::2/128
+- if-name: z2-z1
+  ipv6:
+    address: 2001:db8:0:12::2/64
+segment-routing:
+  locator:
+  - name: LOC2
+    prefix: fcbb:bbbb:2::/48
+    behavior: usid
+vrf:
+- name: N6
+  mup:
+    route-target:
+      import:
+      - "65501:10"
+router:
+  isis:
+    net: 49.0000.0000.0000.0002.00
+    hostname: z2
+    is-type: level-2-only
+    segment-routing:
+      srv6:
+        locator: LOC2
+    interface:
+    - if-name: lo
+      ipv6:
+        enable: true
+    - if-name: z2-z1
+      network-type: point-to-point
+      metric: 1
+      ipv6:
+        enable: true
+  bgp:
+    global:
+      as: 65501
+      router-id: 10.0.0.2
+    timer:
+      adv-interval:
+        ibgp: 1
+    segment-routing:
+      srv6:
+        locator: LOC2
+    neighbor:
+    - remote-address: 2001:db8::1
+      remote-as: 65501
+      update-source: 2001:db8::2
+      enabled: true
+      afi-safi:
+      - name: mup
+        enabled: true
+    vrf:
+    - name: N6
+      rd: "65501:20"
+      encapsulation: srv6
+      afi-safi:
+        mup:
+          segment: interwork

--- a/bdd/tests/features/bgp_mup_st2_dsd_fib.feature
+++ b/bdd/tests/features/bgp_mup_st2_dsd_fib.feature
@@ -1,0 +1,67 @@
+@serial
+@bgp_mup_st2_dsd_fib
+Feature: BGP MUP interwork node installs the ST2->DSD SRv6 encap
+  An interwork (SRGW) node imports a Type-2 Session-Transformed (ST2) route
+  and a Direct Segment Discovery (DSD) route (SAFI 85 /
+  draft-ietf-bess-mup-safi) into a *forwarding* VRF, resolves each ST2 to the
+  matching DSD by their Direct-segment id (MUP Extended Community), and — the
+  DSD being remote — installs an SRv6 H.Encaps route for the ST2 endpoint
+  into the VRF table, resolved through the IS-IS SRv6 underlay toward the
+  DSD's next-hop. This is the forwarding counterpart of the show-only
+  interwork resolution.
+
+  Test Topology:
+  ```
+        2001:db8::1/128            2001:db8::2/128
+       ┌──────────┐  IS-IS L2 SRv6  ┌──────────┐
+       │    z1    │═════════════════│    z2    │
+       │ UPF +    │   iBGP (mup)    │ interwork│
+       │ MUP-C    │                 │ (SRGW,   │
+       │ (DSD+ST2)│                 │  VRF N6) │
+       └──────────┘                 └──────────┘
+   z1-z2 2001:db8:0:12::1/64   2001:db8:0:12::2/64
+  ```
+
+  z1 (VRF N6, rd 65501:10, `segment direct` + `route st2`, export RT
+  65501:10) originates a DSD (End.DT46 SID from locator S + id 1:2) and, from
+  a PFCP session on NI `core`, an ST2 (endpoint 10.0.0.1, id 1:2). z2 (VRF
+  N6, rd 65501:20, `encapsulation srv6`, import RT 65501:10) imports both,
+  resolves the ST2 to z1's Direct segment, and installs the endpoint encap.
+
+  NOTE: needs `pfcp-inject` on the BDD host PATH and root netns (kernel VRF +
+  seg6 + IS-IS SRv6 underlay).
+
+  Scenario: Build topology and establish iBGP with the MUP capability
+    Given a clean test environment
+    When I create namespace "z1"
+    And I create namespace "z2"
+    And I connect namespace "z1" interface "z1-z2" to namespace "z2" interface "z2-z1"
+    And I start zebra-rs in namespace "z1"
+    And I start zebra-rs in namespace "z2"
+    And I apply config "z1.yaml" to namespace "z1"
+    And I apply config "z2.yaml" to namespace "z2"
+    And I wait 45 seconds
+    Then BGP session in "z1" to "2001:db8::2" should be "Established"
+    And BGP session in "z2" to "2001:db8::1" should be "Established"
+
+  Scenario: z2 resolves the ST2 to z1's Direct segment and installs the encap
+    Given the test topology exists
+    When I execute "pfcp-inject --target 127.0.0.1 --port 8805 --ue-ipv4 192.0.2.5 --teid 0x12345678 --endpoint 10.0.0.1 --network-instance core" in namespace "z1"
+    # z2 imports the ST2 + DSD into VRF N6 (re-keyed under its own rd) and
+    # resolves the ST2 to the DSD's End.DT46 segment by the id 1:2.
+    Then show command "show bgp vrf N6 mup" in namespace "z2" should eventually contain "[ST2][65501:20][ep=10.0.0.1]"
+    And show command "show bgp vrf N6 mup" in namespace "z2" should eventually contain "resolved mup:1:2 -> End.DT46"
+    # The SRv6 H.Encaps route for the ST2 endpoint is installed into the VRF
+    # table, resolved through the underlay toward z1's End.DT46 SID (locator
+    # S = fcbb:bbbb:1::/48).
+    And command "ip route show table all" in namespace "z2" should eventually contain "encap seg6 mode encap segs 1 [ fcbb:bbbb:1:"
+    # ... for the ST2 endpoint (10.0.0.1), which is only routed by that encap.
+    And command "ip route show table all" in namespace "z2" should eventually contain "10.0.0.1"
+
+  Scenario: Teardown topology
+    Given the test topology exists
+    When I stop zebra-rs in namespace "z1"
+    And I stop zebra-rs in namespace "z2"
+    And I delete namespace "z1"
+    And I delete namespace "z2"
+    Then the test environment should be clean

--- a/zebra-rs/src/bgp/inst.rs
+++ b/zebra-rs/src/bgp/inst.rs
@@ -3671,8 +3671,45 @@ impl Bgp {
                     endpoint,
                 );
             }
+            // MUP: a received DSD's next-hop rerouted → re-dispatch it to
+            // importing VRFs with the fresh transport so each dependent
+            // ST2→DSD endpoint encap re-installs toward the new egress.
+            NhtDep::Mup(rd, prefix) => {
+                self.mup_redispatch_dsd(nh, rd, prefix, true);
+            }
             NhtDep::V4(_) | NhtDep::V6(_) => {}
         }
+    }
+
+    /// Re-dispatch a received DSD to importing VRFs with its current
+    /// underlay transport (empty when `reachable` is false), so each
+    /// dependent ST2→DSD endpoint encap re-installs or is withdrawn. The
+    /// register-then-gate first resolution and every later reroute both
+    /// land here. Standalone (`&mut self`, no live `BgpTop`), so it is
+    /// safe to call from `nht_reinstall_transport`; the reachability path
+    /// (`nht_reeval_dep`) inlines the same logic because a `BgpTop`
+    /// already borrows `local_rib` there.
+    fn mup_redispatch_dsd(
+        &mut self,
+        nh: std::net::IpAddr,
+        rd: bgp_packet::RouteDistinguisher,
+        prefix: bgp_packet::MupPrefix,
+        reachable: bool,
+    ) {
+        let selected = self.local_rib.select_best_path_mup(&rd, &prefix);
+        let Some(winner) = selected.first() else {
+            return;
+        };
+        let transport = if reachable {
+            self.nexthop_cache.transport_for(nh).to_vec()
+        } else {
+            Vec::new()
+        };
+        let dispatcher = super::vrf::VrfImportDispatcher {
+            rib_known_vrfs: &self.rib_known_vrfs,
+            vrf_registry: &self.vrf_registry,
+        };
+        super::vrf::dispatch_mup(&dispatcher, rd, &prefix, Some(winner), None, &transport);
     }
 
     /// Re-evaluate one dependent prefix after its next-hop's
@@ -3728,6 +3765,9 @@ impl Bgp {
             // SR Policy has no BGP best-path / advertise step; its ILM is
             // reconciled in the dispatch below, not via `selected`.
             NhtDep::SrPolicy { .. } => Vec::new(),
+            // MUP has no shard best-path; the ST2→DSD re-dispatch is done
+            // inline in the match below (it needs `nexthop_cache`).
+            NhtDep::Mup(..) => Vec::new(),
         };
 
         let mut top = super::peer::BgpTop {
@@ -3954,6 +3994,33 @@ impl Bgp {
                     *color,
                     *endpoint,
                 );
+            }
+            // MUP reachability flip: (re)dispatch the received DSD to
+            // importing VRFs with its resolved transport (empty when
+            // unreachable), so each dependent ST2→DSD endpoint encap
+            // installs or is withdrawn. Inlined rather than
+            // `mup_redispatch_dsd` because `top` already borrows local_rib.
+            NhtDep::Mup(rd, prefix) => {
+                let selected = top.local_rib.select_best_path_mup(rd, prefix);
+                if let Some(winner) = selected.first() {
+                    let transport = if reachable {
+                        self.nexthop_cache.transport_for(nh).to_vec()
+                    } else {
+                        Vec::new()
+                    };
+                    let dispatcher = super::vrf::VrfImportDispatcher {
+                        rib_known_vrfs: &self.rib_known_vrfs,
+                        vrf_registry: &self.vrf_registry,
+                    };
+                    super::vrf::dispatch_mup(
+                        &dispatcher,
+                        *rd,
+                        prefix,
+                        Some(winner),
+                        None,
+                        &transport,
+                    );
+                }
             }
         }
     }

--- a/zebra-rs/src/bgp/nht.rs
+++ b/zebra-rs/src/bgp/nht.rs
@@ -48,6 +48,14 @@ pub enum NhtDep {
         color: u32,
         endpoint: IpAddr,
     },
+    /// MUP (SAFI 85) Direct Segment Discovery (DSD) route in
+    /// `local_rib.mup`. A *received* DSD's next-hop is tracked so the
+    /// per-VRF ST2→DSD encap install re-runs when the underlay resolves
+    /// or reroutes: on a change the DSD is re-dispatched to importing
+    /// VRFs with the freshly-resolved transport, so each ST2 whose
+    /// Direct-segment id matches re-programs its endpoint encap. Keyed by
+    /// the DSD's `(rd, MupPrefix)` like the VPN deps.
+    Mup(RouteDistinguisher, bgp_packet::MupPrefix),
 }
 
 /// How a tracked next-hop's resolution changed, returned by

--- a/zebra-rs/src/bgp/route.rs
+++ b/zebra-rs/src/bgp/route.rs
@@ -473,7 +473,7 @@ fn build_vpn_fib_entry(
 /// is installable and the caller withdraws instead. This is the SRv6
 /// analogue of [`build_vpn_fib_entry`]; the SID + seg6 encap replace the
 /// `{transport,service}` MPLS label stack.
-fn build_srv6_vpn_fib_entry(
+pub(crate) fn build_srv6_vpn_fib_entry(
     sid: std::net::Ipv6Addr,
     transport: &[rib::nht::ResolvedNexthop],
 ) -> Option<rib::entry::RibEntry> {
@@ -3028,6 +3028,55 @@ fn nht_track_received_attr(bgp: &mut BgpTop, attr: &BgpAttr, dep: super::nht::Nh
         });
     }
     reachable
+}
+
+/// NHT for a received MUP **DSD**: register its next-hop so an underlay
+/// reroute re-installs the dependent ST2→DSD encap, and return the
+/// next-hop's currently-resolved underlay transport (empty while a fresh
+/// registration is pending, the next-hop is unreachable, or `best` is not
+/// a DSD). No-op outside the global instance (`nexthop_cache` is `None`).
+fn mup_dsd_track(
+    bgp: &mut BgpTop,
+    rd: RouteDistinguisher,
+    prefix: &MupPrefix,
+    best: Option<&BgpRib>,
+) -> Vec<rib::nht::ResolvedNexthop> {
+    if !matches!(prefix, MupPrefix::Dsd { .. }) {
+        return Vec::new();
+    }
+    let Some(best) = best else {
+        return Vec::new();
+    };
+    let Some(nh) = super::nht::nht_target(&best.attr) else {
+        return Vec::new();
+    };
+    let dep = super::nht::NhtDep::Mup(rd, prefix.clone());
+    let Some(cache) = bgp.nexthop_cache.as_deref_mut() else {
+        return Vec::new();
+    };
+    let (needs_register, _reachable) = cache.track(nh, dep);
+    if needs_register {
+        let _ = bgp.rib_client.send(rib::Message::NexthopRegister {
+            proto: "bgp".to_string(),
+            nh,
+        });
+    }
+    cache.transport_for(nh).to_vec()
+}
+
+/// Symmetric to [`mup_dsd_track`]: drop the DSD dep from `nh` and, once it
+/// has no deps left, unregister it. `nh` is the pre-withdraw next-hop.
+fn mup_dsd_untrack(bgp: &mut BgpTop, rd: RouteDistinguisher, prefix: &MupPrefix, nh: IpAddr) {
+    let dep = super::nht::NhtDep::Mup(rd, prefix.clone());
+    let Some(cache) = bgp.nexthop_cache.as_deref_mut() else {
+        return;
+    };
+    if cache.untrack(nh, &dep) {
+        let _ = bgp.rib_client.send(rib::Message::NexthopUnregister {
+            proto: "bgp".to_string(),
+            nh,
+        });
+    }
 }
 
 /// Symmetric to [`nht_track_received`]: on a withdrawal, drop `dep` from
@@ -7609,12 +7658,17 @@ pub fn route_mup_update(
     rib.attr = bgp.attr_store.intern(attr.clone());
     let _ = bgp.local_rib.update_mup(rd, prefix.clone(), rib);
     let selected = bgp.local_rib.select_best_path_mup(&rd, &prefix);
+    // A received DSD: register its next-hop with NHT (so an underlay
+    // reroute re-installs the dependent ST2→DSD encap) and read the
+    // resolved transport to hand the importing VRF. Empty for non-DSD /
+    // unresolved. Must precede the `bgp.vrf_import` borrow below.
+    let transport = mup_dsd_track(bgp, rd, &prefix, selected.first());
     // Mirror the new best-path to every VRF whose `mup import` RT set
     // matches, so `show bgp vrf <name> mup` reflects peer-learned routes.
     // A peer-learned route has no local originating VRF (`origin_vrf =
     // None`), so it is imported purely by route-target.
     if let Some(dispatcher) = bgp.vrf_import {
-        super::vrf::dispatch_mup(dispatcher, rd, &prefix, selected.first(), None);
+        super::vrf::dispatch_mup(dispatcher, rd, &prefix, selected.first(), None, &transport);
     }
     if !selected.is_empty() {
         route_advertise_mup_to_peers(rd, prefix, &selected, bgp, peers);
@@ -7630,14 +7684,33 @@ pub fn route_mup_withdraw(ident: usize, route: &MupRoute, bgp: &mut BgpTop, peer
         let peer = peers.get_mut_by_idx(ident).expect("peer must exist");
         peer.adj_in.remove_mup(rd, &prefix, id);
     }
+    // Capture the pre-withdraw DSD next-hop so it can be released from NHT
+    // if this withdrawal drops the last path using it.
+    let old_dsd_nh = bgp
+        .local_rib
+        .select_best_path_mup(&rd, &prefix)
+        .first()
+        .filter(|_| matches!(prefix, MupPrefix::Dsd { .. }))
+        .and_then(|r| super::nht::nht_target(&r.attr));
     let _ = bgp.local_rib.remove_mup(rd, &prefix, id, ident);
     let selected = bgp.local_rib.select_best_path_mup(&rd, &prefix);
+    // Release the NHT registration when no surviving path keeps the
+    // pre-withdraw DSD next-hop.
+    if let Some(nh) = old_dsd_nh
+        && selected
+            .first()
+            .and_then(|r| super::nht::nht_target(&r.attr))
+            != Some(nh)
+    {
+        mup_dsd_untrack(bgp, rd, &prefix, nh);
+    }
+    let transport = mup_dsd_track(bgp, rd, &prefix, selected.first());
     // Mirror the post-withdraw state to per-VRF tasks: a remaining best
     // path is re-forwarded (matched by RT), otherwise the prefix is
     // withdrawn from every VRF's copy. A peer-learned route has no local
     // originating VRF (`origin_vrf = None`).
     if let Some(dispatcher) = bgp.vrf_import {
-        super::vrf::dispatch_mup(dispatcher, rd, &prefix, selected.first(), None);
+        super::vrf::dispatch_mup(dispatcher, rd, &prefix, selected.first(), None, &transport);
     }
     if selected.is_empty() {
         route_withdraw_mup_to_peers(rd, prefix, peers);
@@ -13004,12 +13077,17 @@ impl Bgp {
                 rib_known_vrfs: &self.rib_known_vrfs,
                 vrf_registry: &self.vrf_registry,
             };
+            // Locally-originated / exported routes carry no remote underlay
+            // transport (a local DSD's SID is on this node); the ST2→DSD
+            // encap only fires for *received* DSDs, tracked in
+            // `route_mup_update`.
             super::vrf::dispatch_mup(
                 &dispatcher,
                 rd,
                 &prefix,
                 selected.first(),
                 origin_vrf.as_deref(),
+                &[],
             );
         }
         if selected.is_empty() {

--- a/zebra-rs/src/bgp/vrf/inst.rs
+++ b/zebra-rs/src/bgp/vrf/inst.rs
@@ -168,6 +168,20 @@ pub struct BgpVrf {
     /// prefix, encap seg6 segs [SID]`). Tracked so `reconcile_mup_st1_isd`
     /// can diff and withdraw when the ST1 or the covering ISD goes away.
     pub mup_st1_isd_installed: std::collections::BTreeMap<ipnet::IpNet, std::net::Ipv6Addr>,
+    /// Resolved underlay transport for each imported DSD's next-hop, keyed
+    /// by the DSD's `(rd, prefix)`. Supplied by the global NHT via
+    /// `MupUpdate.transport` and consumed by `reconcile_mup_st2_dsd` to
+    /// build the resolved-underlay seg6 encap for an ST2 whose
+    /// Direct-segment id matches the DSD. Absent/empty ⇒ the DSD next-hop
+    /// hasn't resolved, so no ST2 encap is installable for it.
+    pub mup_dsd_transport: std::collections::BTreeMap<
+        (bgp_packet::RouteDistinguisher, bgp_packet::MupPrefix),
+        Vec<crate::rib::nht::ResolvedNexthop>,
+    >,
+    /// Installed ST2→DSD encap FIB entries: ST2 endpoint host prefix → the
+    /// DSD's End.DT46 SID it is steered into. Diff base for
+    /// `reconcile_mup_st2_dsd`, mirroring `mup_st1_isd_installed`.
+    pub mup_st2_dsd_installed: std::collections::BTreeMap<ipnet::IpNet, std::net::Ipv6Addr>,
 }
 
 /// Sender side of the per-VRF inbound channel — handed back to
@@ -410,6 +424,7 @@ pub fn dispatch_mup(
     prefix: &bgp_packet::MupPrefix,
     best: Option<&super::super::route::BgpRib>,
     origin_vrf: Option<&str>,
+    transport: &[crate::rib::nht::ResolvedNexthop],
 ) {
     match best {
         Some(rib) => {
@@ -426,6 +441,7 @@ pub fn dispatch_mup(
                     rd,
                     prefix: prefix.clone(),
                     rib: rib.clone(),
+                    transport: transport.to_vec(),
                 });
             }
         }
@@ -476,6 +492,26 @@ pub fn mup_session_targets(
 /// controller next-hop. One session can fan out to several VRFs (an st1 and an
 /// st2 VRF sharing the NI). Replaces the old global `build_mup_origination` +
 /// `originate_mup_route`.
+/// The 6-octet Direct-segment id carried by a MUP Extended Community
+/// (transitive type 0x0c, sub-type 0x00), if present — the id an ST2
+/// route resolves to a DSD by. Mirrors the same-named helper in `show.rs`.
+fn mup_direct_segment_id(attr: &bgp_packet::BgpAttr) -> Option<[u8; 6]> {
+    attr.ecom
+        .as_ref()?
+        .0
+        .iter()
+        .find(|v| v.high_type == 0x0c && v.low_type == 0x00)
+        .map(|v| v.val)
+}
+
+/// A single IP address as a host prefix (`/32` for IPv4, `/128` for IPv6).
+fn host_net(addr: std::net::IpAddr) -> ipnet::IpNet {
+    match addr {
+        std::net::IpAddr::V4(a) => ipnet::IpNet::V4(ipnet::Ipv4Net::new(a, 32).unwrap()),
+        std::net::IpAddr::V6(a) => ipnet::IpNet::V6(ipnet::Ipv6Net::new(a, 128).unwrap()),
+    }
+}
+
 pub fn dispatch_mup_session(
     vrfs: &std::collections::BTreeMap<String, super::super::vrf_config::BgpVrfConfig>,
     vrf_registry: &std::collections::BTreeMap<String, super::spawn::BgpVrfHandle>,
@@ -610,6 +646,8 @@ impl BgpVrf {
             mup_originated: std::collections::BTreeMap::new(),
             mup_segment_prefix: None,
             mup_st1_isd_installed: std::collections::BTreeMap::new(),
+            mup_dsd_transport: std::collections::BTreeMap::new(),
+            mup_st2_dsd_installed: std::collections::BTreeMap::new(),
         };
         (vrf, inbox_tx)
     }
@@ -683,7 +721,7 @@ impl BgpVrf {
             .map(|(ue, _)| *ue)
             .collect();
         for ue in stale {
-            self.mup_st1_isd_withdraw(ue);
+            self.mup_encap_withdraw(ue);
             self.mup_st1_isd_installed.remove(&ue);
         }
         // Install new / changed entries.
@@ -733,10 +771,14 @@ impl BgpVrf {
     /// Withdraw a previously-installed ST1→ISD encap entry. The RIB dels
     /// the kernel route using its own stored nexthop, so a valueless stub
     /// (like `fib_install_v4`'s withdraw) is enough to trigger it.
-    fn mup_st1_isd_withdraw(&self, ue: ipnet::IpNet) {
+    /// Withdraw a previously-installed MUP encap entry (ST1→ISD or
+    /// ST2→DSD). The RIB dels the kernel route using its own stored
+    /// nexthop, so a valueless stub (like `fib_install_v4`'s withdraw) is
+    /// enough to trigger it.
+    fn mup_encap_withdraw(&self, dst: ipnet::IpNet) {
         let mut stub = crate::rib::entry::RibEntry::new(crate::rib::RibType::Bgp);
         stub.valid = false;
-        match ue {
+        match dst {
             ipnet::IpNet::V4(prefix) => {
                 let _ = self
                     .ctx
@@ -748,6 +790,110 @@ impl BgpVrf {
                     .ctx
                     .rib
                     .send(crate::rib::Message::Ipv6Del { prefix, rib: stub });
+            }
+        }
+    }
+
+    /// Reconcile ST2→DSD encap FIB entries for this VRF. A selected ST2
+    /// whose Direct-segment id (MUP Extended Community) matches an imported
+    /// DSD is steered into that DSD's End.DT46 SID: install a resolved-
+    /// underlay seg6 H.Encaps route for the ST2 endpoint (`dst = endpoint
+    /// /32|/128, via <underlay egress> encap seg6 segs [SID]`) into this
+    /// VRF's table. Unlike ST1→ISD (a local SID, oif-only), the DSD is
+    /// remote, so the encap resolves through the global-supplied
+    /// `mup_dsd_transport`; an unresolved DSD next-hop yields no install.
+    /// Diff-gated against `mup_st2_dsd_installed`. Mirrors the show-side
+    /// ST2→DSD resolution in `render_mup_table`.
+    fn reconcile_mup_st2_dsd(&mut self) {
+        use std::net::Ipv6Addr;
+        type Transport = Vec<crate::rib::nht::ResolvedNexthop>;
+        // Index imported DSDs by Direct-segment id → (SID, transport). Only
+        // a DSD with both a SID and a resolved underlay transport qualifies.
+        let mut dsd_index: std::collections::BTreeMap<[u8; 6], (Ipv6Addr, Transport)> =
+            std::collections::BTreeMap::new();
+        for (rd, table) in self.local_rib.mup.iter() {
+            for (prefix, rib) in table.selected.iter() {
+                if !matches!(prefix, bgp_packet::MupPrefix::Dsd { .. }) {
+                    continue;
+                }
+                let Some(seg) = mup_direct_segment_id(&rib.attr) else {
+                    continue;
+                };
+                let Some((sid, _behavior)) = rib.attr.srv6_l3_sid() else {
+                    continue;
+                };
+                let Some(transport) = self.mup_dsd_transport.get(&(*rd, prefix.clone())) else {
+                    continue;
+                };
+                if transport.is_empty() {
+                    continue;
+                }
+                dsd_index.insert(seg, (sid, transport.clone()));
+            }
+        }
+        // Desired: each selected ST2 whose Direct-segment id matches a DSD →
+        // the ST2 endpoint host prefix → (SID, transport).
+        let mut desired: std::collections::BTreeMap<ipnet::IpNet, (Ipv6Addr, Transport)> =
+            std::collections::BTreeMap::new();
+        if !dsd_index.is_empty() {
+            for table in self.local_rib.mup.values() {
+                for (prefix, rib) in table.selected.iter() {
+                    if let bgp_packet::MupPrefix::T2st { endpoint, .. } = prefix
+                        && let Some(seg) = mup_direct_segment_id(&rib.attr)
+                        && let Some((sid, transport)) = dsd_index.get(&seg)
+                    {
+                        desired.insert(host_net(*endpoint), (*sid, transport.clone()));
+                    }
+                }
+            }
+        }
+        // Withdraw entries no longer desired (or whose SID changed).
+        let stale: Vec<ipnet::IpNet> = self
+            .mup_st2_dsd_installed
+            .iter()
+            .filter(|(ep, sid)| desired.get(*ep).map(|(s, _)| s) != Some(*sid))
+            .map(|(ep, _)| *ep)
+            .collect();
+        for ep in stale {
+            self.mup_encap_withdraw(ep);
+            self.mup_st2_dsd_installed.remove(&ep);
+        }
+        // Install new / changed entries.
+        for (ep, (sid, transport)) in &desired {
+            if self.mup_st2_dsd_installed.get(ep) == Some(sid) {
+                continue;
+            }
+            self.mup_st2_dsd_install(*ep, *sid, transport);
+            self.mup_st2_dsd_installed.insert(*ep, *sid);
+        }
+    }
+
+    /// Build + send the resolved-underlay seg6 H.Encaps RibEntry for one
+    /// ST2→DSD binding into this VRF's table. The remote DSD's End.DT46 SID
+    /// rides an `H.Encaps` toward the resolved underlay egress(es) — the
+    /// SRv6-L3VPN dataplane shape ([`build_srv6_vpn_fib_entry`]). A no-op
+    /// when the transport doesn't resolve to any egress.
+    fn mup_st2_dsd_install(
+        &self,
+        ep: ipnet::IpNet,
+        sid: std::net::Ipv6Addr,
+        transport: &[crate::rib::nht::ResolvedNexthop],
+    ) {
+        let Some(entry) = super::super::route::build_srv6_vpn_fib_entry(sid, transport) else {
+            return;
+        };
+        match ep {
+            ipnet::IpNet::V4(prefix) => {
+                let _ = self
+                    .ctx
+                    .rib
+                    .send(crate::rib::Message::Ipv4Add { prefix, rib: entry });
+            }
+            ipnet::IpNet::V6(prefix) => {
+                let _ = self
+                    .ctx
+                    .rib
+                    .send(crate::rib::Message::Ipv6Add { prefix, rib: entry });
             }
         }
     }
@@ -1742,8 +1888,25 @@ impl BgpVrf {
             // originated under RD 65501:20, imported by a VRF whose rd is
             // 65501:10) lands under 65501:10 here. A VRF with no `rd` falls
             // back to the message RD.
-            BgpVrfMsg::MupUpdate { rd, prefix, rib } => {
+            BgpVrfMsg::MupUpdate {
+                rd,
+                prefix,
+                rib,
+                transport,
+            } => {
                 let rd = self.rd.unwrap_or(rd);
+                // A received DSD carries the global-resolved underlay
+                // transport for its next-hop; stash it (keyed by the
+                // re-keyed rd + prefix) so `reconcile_mup_st2_dsd` can build
+                // the ST2 endpoint encap. Empty transport ⇒ unresolved.
+                if matches!(prefix, bgp_packet::MupPrefix::Dsd { .. }) {
+                    if transport.is_empty() {
+                        self.mup_dsd_transport.remove(&(rd, prefix.clone()));
+                    } else {
+                        self.mup_dsd_transport
+                            .insert((rd, prefix.clone()), transport);
+                    }
+                }
                 let _ = self
                     .local_rib
                     .mup
@@ -1751,6 +1914,7 @@ impl BgpVrf {
                     .or_default()
                     .update(prefix, rib);
                 self.reconcile_mup_st1_isd();
+                self.reconcile_mup_st2_dsd();
             }
             BgpVrfMsg::MupWithdraw { rd, prefix } => {
                 // Same own-RD scoping as MupUpdate. The VRF holds the single
@@ -1758,6 +1922,7 @@ impl BgpVrf {
                 // clears it; prune the per-RD table when it empties so an
                 // empty RD never renders.
                 let rd = self.rd.unwrap_or(rd);
+                self.mup_dsd_transport.remove(&(rd, prefix.clone()));
                 let empty = if let Some(table) = self.local_rib.mup.get_mut(&rd) {
                     table.cands.remove(&prefix);
                     table.selected.remove(&prefix);
@@ -1769,6 +1934,7 @@ impl BgpVrf {
                     self.local_rib.mup.remove(&rd);
                 }
                 self.reconcile_mup_st1_isd();
+                self.reconcile_mup_st2_dsd();
             }
             // VRF-first MUP origination: build the RD-free ST NLRI from the
             // dispatched session + resolved direction, and export it to the

--- a/zebra-rs/src/bgp/vrf/msg.rs
+++ b/zebra-rs/src/bgp/vrf/msg.rs
@@ -71,6 +71,13 @@ pub enum BgpVrfMsg {
         rd: RouteDistinguisher,
         prefix: bgp_packet::MupPrefix,
         rib: crate::bgp::route::BgpRib,
+        /// Resolved underlay transport for the route's next-hop, when the
+        /// global instance has NHT-resolved it (currently only populated
+        /// for a received DSD, whose next-hop the ST2→DSD encap install
+        /// resolves through). Empty for locally-originated routes and for
+        /// route types the install doesn't steer. Mirrors `ImportV4`'s
+        /// `transport`.
+        transport: Vec<ResolvedNexthop>,
     },
     /// Withdraw a previously-imported MUP route (the global RIB no longer has
     /// a selected path for it). Flooded to every VRF; the per-VRF removal is


### PR DESCRIPTION
## Summary

On an interwork (SRGW) node, a received ST2 whose Direct-segment id (MUP
Extended Community) matches a received DSD is now steered into that DSD's
**End.DT46** SID: zebra-rs installs an SRv6 **H.Encaps** route for the ST2
endpoint (`dst = endpoint /32|/128, via <underlay egress> encap seg6 segs
[SID]`) into the importing VRF's table. The DSD is **remote**, so the encap
resolves through the underlay via **Next-Hop Tracking** — the counterpart of
the ST1→ISD install (local SID, oif-only; #1700) and the forwarding half of
the existing show-only ST2→DSD resolution (#1698-era).

### Pipeline (mirrors the L3VPN import + NHT path)

- **`nht.rs`** — a `NhtDep::Mup(rd, prefix)` variant tracks a received DSD's
  next-hop.
- **`route.rs`** — `route_mup_update` registers the DSD next-hop with NHT
  (register-then-gate) and reads its resolved transport;
  `route_mup_withdraw` releases it. `build_srv6_vpn_fib_entry` is reused
  (made `pub(crate)`).
- **`vrf/msg.rs`** — `MupUpdate` carries the resolved `transport` (empty for
  non-DSD / local-origin), like `ImportV4`.
- **`vrf/inst.rs`** — the per-VRF task stashes each DSD's transport and
  `reconcile_mup_st2_dsd` resolves ST2→DSD by Direct-segment id and
  installs/withdraws the endpoint encap, diff-gated.
- **`inst.rs`** — the NHT reachability + transport-reroute handlers
  re-dispatch the DSD with fresh transport, so the encap (re)installs on
  first resolution and every underlay reroute, and withdraws when
  unreachable.

## Test plan

- `cargo fmt --all` + `cargo clippy --workspace --all-targets -- -D warnings`
  clean.
- Full workspace test suite (excl bdd) green — 1494 zebra-rs + all crates,
  0 failed.
- New BDD `@bgp_mup_st2_dsd_fib` passed end-to-end (root netns, 23 steps):
  z1 (UPF+MUP-C) originates the DSD + ST2; z2 (interwork, forwarding VRF N6
  with `encapsulation srv6` + RT import) imports both, resolves
  `mup:1:2 -> End.DT46`, and the kernel confirms
  `10.0.0.1 encap seg6 mode encap segs 1 [ fcbb:bbbb:1:40:: ] via <underlay>
  dev z2-z1 table 1 proto bgp`. (BDD is CI-excluded; run locally.)

This completes the MUP forwarding story both directions: ST1→ISD (local
SID) and ST2→DSD (remote SID).

Generated with [Claude Code](https://claude.com/claude-code)