### PR TITLE
mcp(vtyctl): Phase 0 read-only show tool + live command discovery

### DIFF
--- a/docs/design/mcp-server-auth-plan.md
+++ b/docs/design/mcp-server-auth-plan.md
@@ -1,86 +1,83 @@
-# MCP Server Authentication — Design & Phasing Plan
+# MCP Server Authentication — Design & Phasing Plan (stdio)
 
 Tracks the addition of authentication and authorization to the zebra-rs
 MCP (Model Context Protocol) server that ships inside `vtyctl` (the
 `vtyctl mcp` subcommand). This document is the living plan + status: it
 captures the trust model, how it reuses the daemon's existing VTY
-auth/authz stack, the architecture decisions, the transport/credential
-choices, the phase-by-phase slice, and **what has landed vs what's left**
-so a contributor can resume without the conversation history.
+auth/authz stack, the architecture decisions, the tool surface, the
+phase-by-phase slice, and **what has landed vs what's left** so a
+contributor can resume without the conversation history.
 
-Read this first if you're touching `vtyctl/src/mcp/*`, the daemon VTY
-gRPC server `zebra-rs/src/config/serve.rs`, session/RBAC in
-`zebra-rs/src/config/session.rs`, the VTY proto `proto/vty.proto`, or
-`zebra-rs/yang/vty.yang`.
+**Scope: stdio transport only.** A network-exposed transport (Streamable
+HTTP) and OAuth 2.1 are **out of scope** and were dropped 2026-06-27 (see
+Status). The MCP server runs only as a **local subprocess spawned per
+user** over stdin/stdout — there is no network listener, no bearer
+tokens, and no trusted-asserter delegation. If a network transport is
+revived later, restore it from git history rather than carrying dead
+HTTP/OAuth scaffolding in this plan.
+
+Read this first if you're touching `vtyctl/src/mcp/*`. You should **not**
+need to touch the daemon for this work — the daemon's VTY auth stack is
+reused unchanged (see §4).
 
 References:
 
-- Model Context Protocol — base spec and **Authorization** spec (OAuth 2.1
-  for the Streamable HTTP transport). <https://modelcontextprotocol.io/>
-- RFC 9728 — OAuth 2.0 Protected Resource Metadata (required by the MCP
-  auth spec for resource-server discovery).
-- RFC 6749 / OAuth 2.1 draft — authorization framework; PKCE mandatory.
-- RFC 7519 / RFC 7515 / RFC 7517 — JWT, JWS, JWKS (access-token validation).
+- Model Context Protocol — base spec. <https://modelcontextprotocol.io/>
 - `book/src/ch-06-01-session-design.md` — the existing VTY session/RBAC
-  design (decisions D1–D26). **This plan extends it; new decisions are
-  numbered D27+.**
+  design (decisions D1–D26). **This plan reuses it as-is; stdio requires
+  no new daemon-side decisions.**
 - `book/src/ch-13-00-mcp-server.md` — the user-facing MCP chapter.
 
 ## Decisions captured up front
 
-The scope was fixed by three product decisions:
+The scope is fixed by three product decisions:
 
-1. **Both transports** — keep local **stdio** (subprocess) and add a
-   network-exposed **Streamable HTTP** transport. Build stdio first.
+1. **stdio only** — local subprocess (stdin/stdout) transport. No network
+   transport, no OAuth. (HTTP + OAuth 2.1 were considered and dropped.)
 2. **Read + write** — MCP tools may run `show` *and* push configuration
    (`configure`/`apply`/`clear`), not read-only.
-3. **OAuth 2.1** — the network transport authenticates clients with OAuth
-   2.1 bearer tokens per the MCP Authorization spec.
+3. **Least privilege by default** — a session exposes read-only tools
+   unless the human who spawned it explicitly opts the process into write
+   mode (see §5 / §8.1). The daemon's RBAC remains the hard gate
+   regardless.
 
-## 1. The core problem
+## 1. Trust model — `SO_PEERCRED`, exact reuse
 
 The daemon's trust anchor is **`SO_PEERCRED`**: the VTY gRPC server reads
 the connecting process's uid/gid/pid from the kernel and derives identity
 and role from it (`serve.rs` `VtyPeerInterceptor`, ~lines 621–716). A
 client cannot forge this.
 
-That model is exact for **stdio**: one human spawns their *own*
+That model is **exact** for stdio: one human spawns their *own*
 `vtyctl mcp` process, so their uid flows to the daemon and existing RBAC
-(`View`/`Admin`) applies directly.
+(`View`/`Admin`) applies directly. The MCP server is just another VTY
+client — JSON-RPC to an AI assistant on one side, gRPC to the daemon on
+the other — that happens to run as the invoking user.
 
-It **breaks for HTTP**: a single long-lived `vtyctl mcp` process serves
-many remote OAuth users. `SO_PEERCRED` only tells the daemon "this is
-vtyctl's uid" — it cannot distinguish remote user Alice from Bob, so the
-daemon's per-uid RBAC cannot apply to remote identities.
-
-**Resolution — Trusted Subsystem (constrained delegation).** In HTTP mode
-`vtyctl mcp` runs as a dedicated, *allowlisted* service-account uid. It
-authenticates the remote client itself (OAuth), then **asserts** the
-authenticated principal + requested role to the daemon via gRPC metadata.
-The daemon honors that assertion **only** when the connecting
-`SO_PEERCRED` uid is in a new "trusted asserter" allowlist. The kernel
-remains the root of trust; an authorized front-end is permitted to speak
-for end users. **The daemon never sees the OAuth token.**
-
-This is the spine of the design; everything else hangs off it.
+**Consequence: no new trust mechanism, and no daemon-side change.** This
+is the whole reason stdio ships cleanly on its own. The entire
+trusted-asserter / asserted-identity apparatus that a multi-user network
+transport would require (a single front-end process speaking for many
+remote principals) is unnecessary here and has been removed from this
+plan.
 
 ## 2. Identity & role model
 
 | Transport | Authn of MCP client | Identity reaching daemon | Role source |
 | --- | --- | --- | --- |
-| **stdio** | OS — user spawns their own `vtyctl mcp` | `SO_PEERCRED` uid (unchanged) | Existing RBAC; new `enable` tool (PAM) for Admin |
-| **HTTP** | OAuth 2.1 bearer JWT | **Asserted** principal + role in gRPC metadata; vtyctl runs as a *trusted-asserter* service account | Token `scope` → View/Admin, bounded by asserter's max grant |
+| **stdio** | OS — user spawns their own `vtyctl mcp` | `SO_PEERCRED` uid (unchanged) | Existing RBAC (uid/gid → View/Admin) |
 
-Two invariants hold across both transports:
+Two invariants:
 
 - **The daemon is the source of truth.** The MCP server pre-checks the
   required role for fast, clear errors, but `enforce_admin()` in the
   daemon (`serve.rs` ~lines 44–64, applied to `Apply`/`Clear`/configure
   entry) is the real gate. The front-end check is defense in depth, never
   the sole control.
-- **Least privilege by default.** Every session starts `View`. Writes
-  require explicit elevation: the OAuth `zebra.write` scope (HTTP) or a
-  PAM `enable` (stdio). Existing admin-session TTLs (15-min idle / 4-h
+- **Least privilege by default.** A spawned MCP session exposes read-only
+  tools unless the user opted it into write mode at launch (§5). Even in
+  write mode, a write only succeeds if the user's uid already maps to
+  `Admin` in daemon RBAC. Existing admin-session TTLs (15-min idle / 4-h
   hard cap, session-design D2) apply unchanged.
 
 ## 3. Tool surface (read + write)
@@ -92,108 +89,132 @@ re-checks:
 
 | Tool | Daemon RPC | Required role | Notes |
 | --- | --- | --- | --- |
-| `show` (+ keep `get-isis-graph`) | `Show` (stream) | View | unchanged path |
-| `configure` / `apply` | `Apply` (stream) | Admin | every call audited (principal + lines) |
-| `clear` | `Clear` | Admin | audited |
-| `enable` | `Enable` (PAM) | — | **stdio only**; elevates the session for the TTL window |
+| `list-show-commands` | `Exec` (completion) | View | discovery; flat `command → help` list generated live from the grammar |
+| `show` (+ keep `get-isis-graph`) | `Show` (stream) | View | unchanged path; rejects any command not starting with `show` |
+| `configure` / `apply` | `Apply` (stream) | Admin | only registered in write mode; every call audited (principal + lines) |
+| `clear` | `Clear` | Admin | only registered in write mode; audited |
 
-For HTTP, `enable` is unnecessary: elevation comes from the token's
-`scope`, not an interactive password.
+Write tools are **not even advertised** in `tools/list` unless the
+process was launched in write mode — the AI cannot call a tool it cannot
+see, and a read-only session has no write surface to misuse.
 
-## 4. Daemon-side changes (new — D27+)
+**Command discovery.** The MCP client cannot guess zebra-rs's
+YANG-defined command surface, so `list-show-commands` enumerates it by
+walking the daemon's completion engine (`DoExec` with
+`COMPLETE_TRAILING_SPACE`, the same path that backs CLI `?`/TAB) from
+`show` downward. Every token already carries an `ext:help` string in
+`exec.yang`, so each entry gets a one-line explanation *and* a `kind`
+(`command` runnable keyword / `category` has subcommands / `value` expects
+an argument) and a `runnable` flag — all generated live, no hand-maintained
+list to drift. `<cr>` markers are folded into `runnable`; bare value
+placeholders (`<A.B.C.D>`) are never descended into. The result is cached
+for the process lifetime.
 
-Slots into the existing `serve.rs` / `session.rs` design:
+## 4. Daemon-side changes — none
 
-- **D27 — Trusted-asserter allowlist.** `ZEBRA_VTY_TRUSTED_ASSERTERS`
-  (env, CSV uids) **and** YANG `vty trusted-asserter uid N`, unioned the
-  same way the existing service-account sources are (env
-  `ZEBRA_VTY_SERVICE_ACCOUNTS` ∪ YANG `vty service-account uid N`).
-- **D28 — Asserted-identity metadata.** New gRPC metadata keys
-  (`x-zebra-principal`, `x-zebra-role`, `x-zebra-auth-method`).
-  `VtyPeerInterceptor` reads them **only** if the peer `SO_PEERCRED` uid ∈
-  trusted asserters; otherwise it ignores them and falls back to plain uid
-  identity. A non-asserter that sets the headers is rejected
-  (`permission_denied`).
-- **D29 — Session keying for asserted sessions.** Key on
-  `(asserter_uid, principal)` instead of `(uid, pid)`, so each remote
-  principal gets its own View/Admin session and independent TTL.
-- **D30 — Bounded grant.** An asserter may only assert *up to* a
-  configured maximum role, so a compromised front-end cannot exceed its
-  mandate. Default cap configurable per asserter.
-- **D31 — Audit.** Record the asserted principal + auth method on every
-  `Apply`/`Clear` (extend existing logging). This is what makes exposing
-  "read + write" safe.
+Dropping the network transport removes the entire daemon-side workstream.
+The former plan's D27–D31 (trusted-asserter allowlist, asserted-identity
+metadata, asserted-session keying, bounded grant, asserted-write audit)
+existed **only** to let one front-end process speak for many remote OAuth
+users. stdio has no such multiplexing: each user is their own process.
 
-All of D27–D31 is testable with a fake asserter and **zero MCP/HTTP
-code**, which is why it is its own phase (Phase 1).
+So stdio needs **zero** changes to `serve.rs`, `session.rs`, `vty.yang`,
+or `proto/vty.proto`. It is pure reuse of the existing `SO_PEERCRED` +
+RBAC stack. Audit of writes (§5) is done by the MCP front-end with the OS
+principal; the daemon's existing logging is unchanged.
 
 ## 5. vtyctl `mcp` changes (new)
 
-1. **Streamable-HTTP transport** alongside stdio (`axum` + `tower` /
-   `hyper-util`, already in the dep tree). **Open decision (§8):** evaluate
-   adopting the `rmcp` SDK here for a spec-compliant Streamable HTTP
-   implementation + OAuth resource-server scaffolding, versus hand-rolling
-   the JSON-RPC loop a second time.
-2. **OAuth 2.1 resource server:**
-   - Serve **Protected Resource Metadata** (RFC 9728) at
-     `/.well-known/oauth-protected-resource`, and emit `WWW-Authenticate`
-     with the `resource_metadata` pointer on 401 — both required by the
-     MCP auth spec.
-   - Validate the bearer JWT: signature via the AS's **JWKS**, plus `iss`,
-     `exp`, and **strict `aud`** equal to this server's canonical URI.
-   - **Reject any token whose `aud` is not this server** — closes the
-     confused-deputy / token-passthrough hole the MCP spec calls out. The
-     daemon never receives the token; only the validated principal +
-     mapped role.
-   - Map `scope` → role: `zebra.read` → View, `zebra.write` → Admin.
-3. **Trusted-asserter client.** HTTP mode connects to the daemon as the
-   configured asserter service account and sets the asserted-identity
-   metadata (D28) per request. Pool/reuse gRPC channels.
-4. **stdio `enable` tool.** Thin wrapper over the daemon `Enable` RPC —
-   reuses PAM, rate-limiting, and TTL as-is.
-5. **Config home.** Follow the existing env-∪-YANG convention: listen
-   addr, TLS cert/key, OAuth `issuer` / `jwks_uri` / `audience` /
-   `required_scopes`, asserter identity. CLI flags for dev, YANG
-   (`vty mcp …`) for production.
+1. **Generalize the tool set** from the single `get-isis-graph` to
+   `show` / `configure` / `clear` (keep `get-isis-graph`). Each tool is
+   tagged with its required role; the server pre-checks and the daemon
+   re-checks.
+2. **Write-mode gating.** Default the process to **read-only**: only
+   `View` tools are registered. A human opts the process into write mode
+   at spawn (e.g. a `--write` / `--allow-write` flag on `vtyctl mcp`, or
+   equivalent env var) — this is the *human's* decision, made outside the
+   AI's control. In write mode, `configure`/`apply`/`clear` are
+   registered; the daemon still gates each on the uid's `Admin` role, so
+   write mode on a non-admin uid simply yields `permission_denied`.
+3. **Audit writes.** Log the OS principal (uid + resolved username) and
+   the submitted lines on every `configure`/`apply`/`clear`.
+4. **Config home.** Minimal: the daemon host/port to connect to (already
+   present as `vtyctl mcp` args). No listen address, TLS, or OAuth config
+   — none of that exists in stdio mode.
 
 ## 6. Phase map (smallest shippable first)
 
 | Phase | Scope | Touches |
 | --- | --- | --- |
-| 0 | **stdio least-privilege + tool surface.** Generalize tools to `show`/`configure`/`clear`, gate writes, add the `enable` tool. Delivers authenticated read+write **locally** with *zero* new trust mechanisms — pure reuse of `SO_PEERCRED` + RBAC + PAM. Audit writes with the OS principal. This is the entire "stdio first" deliverable and ships independently. | `vtyctl/src/mcp/*` |
-| 1 | **Daemon trusted-asserter + asserted identity** (D27–D31). Daemon-only; fake-asserter tests. No MCP/HTTP code yet. | `serve.rs`, `session.rs`, `vty.yang`, `proto/vty.proto` (metadata) |
-| 2 | **MCP HTTP transport, loopback, no OAuth yet.** Streamable HTTP up, connecting as the asserter service account with a fixed principal. Proves transport + assertion path end-to-end. | `vtyctl/src/mcp/*` |
-| 3 | **OAuth 2.1 resource server** (§5.2). PRM, JWT/JWKS validation, audience binding, scope→role, TLS. | `vtyctl/src/mcp/*` |
-| 4 | **Hardening.** JWKS refresh/caching, rate-limit, structured write audit, TTL alignment, full YANG config, BDD coverage, threat-model doc + book chapter update. | all of the above |
+| 0 | **Read-only generalization.** Replace the single hard-coded tool with a generic `show` tool (plus the kept `get-isis-graph`), still read-only. No new privileges, no behavior change to writes. Smallest useful slice. | `vtyctl/src/mcp/*` |
+| 1 | **Write tools + write-mode gating + audit.** Add `configure`/`apply`/`clear`, register them only in write mode, audit every write with the OS principal. Daemon `enforce_admin()` is the hard gate. | `vtyctl/src/mcp/*` |
+| 2 | **Hardening.** Error-path polish, rate/size limits on tool input, BDD coverage for stdio read + write, threat-model note + book chapter (`ch-13-00`) update. | `vtyctl/src/mcp/*`, `book/` |
+
+All three phases are confined to `vtyctl/src/mcp/*`. The daemon is not
+touched.
 
 ## 7. Security properties (threat model summary)
 
-- **Trust anchor stays the kernel.** Asserted identity is honored only
-  from allowlisted asserter uids → a random local process cannot
-  impersonate a user.
-- **No token passthrough.** Strict `aud` binding + the daemon never seeing
-  the OAuth token kills the confused-deputy class.
-- **Bounded blast radius.** A compromised asserter is capped by its
-  max-grant role (D30) and fully audited (D31).
-- **TLS mandatory** for the HTTP transport (bearer tokens require
-  confidentiality).
+- **Trust anchor stays the kernel.** Identity is the `SO_PEERCRED` uid of
+  the user who spawned the process; a user can only ever act as
+  themselves. No impersonation surface exists.
+- **No network surface.** No listener, no bearer tokens, no TLS to
+  misconfigure, no remote-auth code to get wrong.
+- **Least privilege.** Read-only by default; write tools are not even
+  advertised unless the human opted in at spawn, and the daemon still
+  requires `Admin` for each write.
 - **Defense in depth.** Front-end pre-check + daemon `enforce_admin()`
-  re-check; daemon is authoritative.
+  re-check; the daemon is authoritative.
+- **Audited writes.** Every `configure`/`apply`/`clear` records the OS
+  principal and the lines submitted.
+- **Residual risk (inherent to MCP):** the tools are driven by an AI
+  assistant running as the user, so the AI can do anything the user's
+  role permits. Read-only-by-default + explicit, human-gated write mode
+  bound the blast radius; the AI never gains privilege the user didn't
+  deliberately grant.
 
-## 8. Open decisions
+## 8. Decisions resolved / still open
 
-1. **`rmcp` SDK vs. extend the hand-rolled server** for the HTTP transport
-   (§5.1). Leaning `rmcp` for spec compliance; biggest architectural call.
-2. **Which OAuth Authorization Server** (Keycloak / Auth0 / Okta /
-   internal)? The resource server is AS-agnostic but needs `issuer` /
-   `jwks_uri` / `audience`. Also: support **Dynamic Client Registration**
-   (spec-recommended) or pre-register clients?
-3. **Authz granularity** — scope→role (View/Admin) only for now, or start
+1. **Write mode & `enable`/PAM — RESOLVED (2026-06-27): no `enable` tool.**
+   In stdio the process already runs as the user's uid, so daemon RBAC
+   grants `Admin` to admin users directly — no Cisco-style `enable`
+   password is needed to *have* the role. A PAM `enable` flow would also
+   force a **secret through the AI assistant** (the human would paste the
+   enable password into the chat, where it is visible to and logged by the
+   model), which is undesirable. **Decision:** drop the `enable` tool
+   entirely. Writes are gated purely by (a) a human-set spawn flag
+   (`--write`) that decides whether write tools are advertised, plus
+   (b) the daemon's existing uid→`Admin` RBAC check. Revisit only if a
+   future use case needs elevation *within* a running session.
+2. **Authz granularity — OPEN.** View/Admin only for now, or start
    leveraging the proto's currently-unused `privilege` field for
-   per-command levels later?
+   per-command levels later? Not needed for the initial stdio slice.
 
 ## Status
 
+- **2026-06-27** — **Scope reduced to stdio only; HTTP transport and
+  OAuth 2.1 dropped.** This removes the entire trusted-asserter /
+  asserted-identity design (former decisions D27–D31), the OAuth 2.1
+  resource server (PRM, JWT/JWKS validation, audience binding,
+  scope→role), the Streamable HTTP transport, and the
+  `rmcp`-vs-hand-rolled open question — all of which existed only to serve
+  many remote users through one process. stdio needs **no daemon-side
+  changes**: it reuses `SO_PEERCRED` + RBAC directly. (If a network
+  transport is ever revived, recover the prior design from this file's git
+  history.)
+- **2026-06-27** — **Phase 0 landed (read-only) on branch
+  `mcp-stdio-phase0`.** Added the generic `show` tool (rejects non-`show`
+  commands) and `list-show-commands` (live grammar discovery), alongside
+  the kept `get-isis-graph`. Response wrapping factored into a shared
+  helper for the upcoming write tools. Also fixed a pre-existing bug: the
+  MCP entrypoint prepended `http://` to the host, corrupting `unix:`
+  sockets — including the default `unix:zebra-rs/vty` — so the server
+  could never reach a socket daemon; it now passes the host through to
+  `ZebraClient::endpoint()` for normalization. Verified end-to-end against
+  a live daemon (`show version` runs, `configure terminal` rejected,
+  discovery returns 188 entries with help/kind/runnable). 7 unit tests;
+  `cargo fmt`/`clippy --all-targets -D warnings`/`test` green. Not yet
+  committed. **Next: Phase 1** (write tools + `--write` gating + audit).
 - **2026-06-27** — Plan drafted. No code landed yet. Current MCP server is
   stdio-only, unauthenticated, single read-only tool (`get-isis-graph`).
   Daemon-side VTY auth stack (SO_PEERCRED, service accounts, RBAC, PAM)

--- a/vtyctl/src/mcp/client.rs
+++ b/vtyctl/src/mcp/client.rs
@@ -3,8 +3,32 @@ use tokio_stream::StreamExt;
 use tonic::Request;
 use tracing::{debug, error};
 
+use crate::vty::exec_client::ExecClient;
 use crate::vty::show_client::ShowClient;
-use crate::vty::{CommandPath, ShowRequest, YangMatch};
+use crate::vty::{CommandPath, ExecRequest, ExecType, ShowRequest, YangMatch};
+
+/// A single completion candidate for the token following a command line,
+/// parsed from the daemon's completion engine output.
+#[derive(Debug, Clone, PartialEq)]
+pub struct Candidate {
+    /// The candidate token (a keyword, or a value placeholder for `Value`).
+    pub name: String,
+    pub kind: CandidateKind,
+    /// One-line help (the `ext:help` string from the YANG grammar).
+    pub help: String,
+}
+
+/// What a completion candidate represents.
+#[derive(Debug, Clone, PartialEq)]
+pub enum CandidateKind {
+    /// Has children — keep descending to reach full commands.
+    Dir,
+    /// A terminal keyword — a complete, runnable command.
+    Leaf,
+    /// A value-argument position (address, prefix, name, ...) — not a
+    /// keyword and not enumerable, so we record but do not descend.
+    Value,
+}
 
 /// Client for communicating with zebra-rs daemon via gRPC
 #[derive(Clone)]
@@ -18,13 +42,18 @@ impl ZebraClient {
         Self { base_url, port }
     }
 
-    /// Execute a show command and return the result as JSON
-    pub async fn show_command(&self, command: &str, json: bool) -> Result<String> {
-        let endpoint = if self.base_url.starts_with("unix:") || self.base_url.contains("://") {
+    /// gRPC endpoint URI for the configured daemon.
+    fn endpoint(&self) -> String {
+        if self.base_url.starts_with("unix:") || self.base_url.contains("://") {
             self.base_url.clone()
         } else {
             format!("http://{}:{}", self.base_url, self.port)
-        };
+        }
+    }
+
+    /// Execute a show command and return the result as JSON
+    pub async fn show_command(&self, command: &str, json: bool) -> Result<String> {
+        let endpoint = self.endpoint();
         debug!("Connecting to zebra-rs at {}", endpoint);
 
         let channel = crate::endpoint::connect(&endpoint).await?;
@@ -82,6 +111,31 @@ impl ZebraClient {
         self.show_command(&command, json).await
     }
 
+    /// Return the completion candidates for the token *after* `line`, using
+    /// the daemon's completion engine (the same one that backs CLI `?`/TAB).
+    /// Completion is not admin-gated, so a View session can enumerate the
+    /// full command surface.
+    pub async fn complete_children(&self, line: &str) -> Result<Vec<Candidate>> {
+        let endpoint = self.endpoint();
+        let channel = crate::endpoint::connect(&endpoint).await?;
+        let mut client = ExecClient::new(channel);
+
+        // CompleteTrailingSpace appends a space server-side, so this returns
+        // the candidates that may follow `line` rather than completions of
+        // its last token.
+        let request = Request::new(ExecRequest {
+            r#type: ExecType::CompleteTrailingSpace as i32,
+            mode: String::from("exec"),
+            privilege: 1,
+            line: line.to_string(),
+            args: Vec::new(),
+            ..Default::default()
+        });
+
+        let reply = client.do_exec(request).await?.into_inner();
+        Ok(parse_completion_lines(&reply.lines))
+    }
+
     /// Test connectivity to the zebra-rs daemon
     pub async fn test_connection(&self) -> Result<()> {
         match self.show_command("show version", false).await {
@@ -94,5 +148,75 @@ impl ZebraClient {
                 Err(e)
             }
         }
+    }
+}
+
+/// Parse the daemon completion engine's `lines` output into candidates.
+///
+/// The format (see `comp_commands` in `zebra-rs/src/config/serve.rs`) is a
+/// status word on the first line (`Success`/`Incomplete`/`NoMatch`/
+/// `Ambiguous`) followed by one candidate per line as
+/// `name\t<marker>\thelp`, where the marker is `->` (Dir), `+>` (value/Key),
+/// or two spaces (terminal leaf).
+pub fn parse_completion_lines(lines: &str) -> Vec<Candidate> {
+    let mut out = Vec::new();
+    for line in lines.lines().skip(1) {
+        if line.is_empty() {
+            continue;
+        }
+        let mut parts = line.splitn(3, '\t');
+        let name = match parts.next() {
+            Some(n) if !n.is_empty() => n.to_string(),
+            _ => continue,
+        };
+        let marker = parts.next().unwrap_or("");
+        let help = parts.next().unwrap_or("").trim().to_string();
+        let kind = match marker.trim() {
+            "->" => CandidateKind::Dir,
+            "+>" => CandidateKind::Value,
+            _ => CandidateKind::Leaf,
+        };
+        out.push(Candidate { name, kind, help });
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_marker_kinds_and_skips_status() {
+        let lines = "Success\n\
+                     bgp\t->\tBGP information\n\
+                     version\t  \tShow version\n\
+                     ipv4\t+>\tAddress (routes containing it) or prefix\n";
+        let got = parse_completion_lines(lines);
+        assert_eq!(
+            got,
+            vec![
+                Candidate {
+                    name: "bgp".to_string(),
+                    kind: CandidateKind::Dir,
+                    help: "BGP information".to_string(),
+                },
+                Candidate {
+                    name: "version".to_string(),
+                    kind: CandidateKind::Leaf,
+                    help: "Show version".to_string(),
+                },
+                Candidate {
+                    name: "ipv4".to_string(),
+                    kind: CandidateKind::Value,
+                    help: "Address (routes containing it) or prefix".to_string(),
+                },
+            ]
+        );
+    }
+
+    #[test]
+    fn nomatch_yields_no_candidates() {
+        assert!(parse_completion_lines("NoMatch\n").is_empty());
+        assert!(parse_completion_lines("").is_empty());
     }
 }

--- a/vtyctl/src/mcp/mod.rs
+++ b/vtyctl/src/mcp/mod.rs
@@ -30,13 +30,12 @@ pub async fn run(host: &str, port: u32, debug_mode: bool) -> Result<()> {
     debug!("Starting vtyctl mcp server v{}", env!("CARGO_PKG_VERSION"));
     debug!("Connecting to zebra-rs at {}:{}", host, port);
 
-    let base_url = if host.starts_with("http://") || host.starts_with("https://") {
-        host.to_string()
-    } else {
-        format!("http://{}", host)
-    };
-
-    let server = ZmcpServer::new(base_url, port);
+    // Pass the host through unchanged; `ZebraClient::endpoint()` normalizes
+    // it (bare host → `http://host:port`, while `unix:NAME` and full
+    // `http(s)://` / `tcp://` URIs are used as-is). Pre-prepending `http://`
+    // here would corrupt `unix:` sockets — including the default
+    // `unix:zebra-rs/vty` — into the unparseable `http://unix:...`.
+    let server = ZmcpServer::new(host.to_string(), port);
 
     // Test connection to zebra-rs
     if let Err(e) = server.zebra_client().test_connection().await {

--- a/vtyctl/src/mcp/server.rs
+++ b/vtyctl/src/mcp/server.rs
@@ -5,21 +5,42 @@ use tokio::io::{self, AsyncBufReadExt, AsyncWriteExt, BufReader};
 use tracing::{debug, error, warn};
 
 use super::client::ZebraClient;
+use super::tools::commands::CommandsTool;
 use super::tools::isis::IsisTools;
+use super::tools::show::ShowTool;
+
+/// Wrap tool output in the MCP `tools/call` result shape.
+fn tool_result(text: String, is_error: bool) -> Value {
+    json!({
+        "content": [
+            {
+                "type": "text",
+                "text": text
+            }
+        ],
+        "isError": is_error
+    })
+}
 
 pub struct ZmcpServer {
     zebra_client: ZebraClient,
     isis_tools: IsisTools,
+    show_tool: ShowTool,
+    commands_tool: CommandsTool,
 }
 
 impl ZmcpServer {
     pub fn new(base_url: String, port: u32) -> Self {
         let zebra_client = ZebraClient::new(base_url, port);
         let isis_tools = IsisTools::new(zebra_client.clone());
+        let show_tool = ShowTool::new(zebra_client.clone());
+        let commands_tool = CommandsTool::new(zebra_client.clone());
 
         Self {
             zebra_client,
             isis_tools,
+            show_tool,
+            commands_tool,
         }
     }
 
@@ -68,6 +89,34 @@ impl ZmcpServer {
                 debug!("Listing available tools");
                 json!({
                     "tools": [
+                        {
+                            "name": "list-show-commands",
+                            "description": "List every available read-only `show` command with a one-line explanation of each, generated live from the daemon's command grammar. Call this first to discover what `show` can do.",
+                            "inputSchema": {
+                                "type": "object",
+                                "properties": {},
+                                "additionalProperties": false
+                            }
+                        },
+                        {
+                            "name": "show",
+                            "description": "Run a read-only zebra-rs operational `show` command and return its output. The command must begin with 'show' (e.g. 'show ip route', 'show bgp summary', 'show isis neighbor'). Use 'list-show-commands' to discover the available commands.",
+                            "inputSchema": {
+                                "type": "object",
+                                "properties": {
+                                    "command": {
+                                        "type": "string",
+                                        "description": "Full show command to execute, beginning with 'show'."
+                                    },
+                                    "json": {
+                                        "type": "boolean",
+                                        "description": "Return JSON-formatted output when the command supports it (default false)."
+                                    }
+                                },
+                                "required": ["command"],
+                                "additionalProperties": false
+                            }
+                        },
                         {
                             "name": "get-isis-graph",
                             "description": "Get IS-IS topology graph data for network visualization and analysis",
@@ -131,41 +180,21 @@ impl ZmcpServer {
 
         debug!("Calling tool: {}", tool_name);
 
-        match tool_name {
-            "get-isis-graph" => match self.isis_tools.get_isis_graph(arguments).await {
-                Ok(result) => json!({
-                    "content": [
-                        {
-                            "type": "text",
-                            "text": result
-                        }
-                    ],
-                    "isError": false
-                }),
-                Err(e) => {
-                    error!("Tool execution failed: {}", e);
-                    json!({
-                        "content": [
-                            {
-                                "type": "text",
-                                "text": format!("Error: {}", e)
-                            }
-                        ],
-                        "isError": true
-                    })
-                }
-            },
+        let result = match tool_name {
+            "list-show-commands" => self.commands_tool.list_show_commands().await,
+            "show" => self.show_tool.run(arguments).await,
+            "get-isis-graph" => self.isis_tools.get_isis_graph(arguments).await,
             _ => {
                 warn!("Unknown tool requested: {}", tool_name);
-                json!({
-                    "content": [
-                        {
-                            "type": "text",
-                            "text": format!("Unknown tool: {}", tool_name)
-                        }
-                    ],
-                    "isError": true
-                })
+                return tool_result(format!("Unknown tool: {}", tool_name), true);
+            }
+        };
+
+        match result {
+            Ok(text) => tool_result(text, false),
+            Err(e) => {
+                error!("Tool execution failed: {}", e);
+                tool_result(format!("Error: {}", e), true)
             }
         }
     }
@@ -218,5 +247,44 @@ impl ZmcpServer {
 
         debug!("MCP server shutdown");
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn server() -> ZmcpServer {
+        ZmcpServer::new("127.0.0.1".to_string(), 2650)
+    }
+
+    #[tokio::test]
+    async fn tools_list_advertises_expected_tools() {
+        let req = json!({"jsonrpc": "2.0", "id": 1, "method": "tools/list"});
+        let resp = server().handle_request(req).await.expect("response");
+        let names: Vec<&str> = resp["result"]["tools"]
+            .as_array()
+            .expect("tools array")
+            .iter()
+            .filter_map(|t| t["name"].as_str())
+            .collect();
+        for expected in ["list-show-commands", "show", "get-isis-graph"] {
+            assert!(
+                names.contains(&expected),
+                "missing {expected}; tools: {names:?}"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn unknown_tool_call_is_error() {
+        let req = json!({
+            "jsonrpc": "2.0",
+            "id": 2,
+            "method": "tools/call",
+            "params": {"name": "configure", "arguments": {}}
+        });
+        let resp = server().handle_request(req).await.expect("response");
+        assert_eq!(resp["result"]["isError"], json!(true));
     }
 }

--- a/vtyctl/src/mcp/tools/commands.rs
+++ b/vtyctl/src/mcp/tools/commands.rs
@@ -1,0 +1,149 @@
+use anyhow::Result;
+use serde_json::{Value, json};
+use std::collections::{BTreeMap, HashSet};
+use std::sync::Arc;
+use tokio::sync::OnceCell;
+use tracing::debug;
+
+use crate::mcp::client::{CandidateKind, ZebraClient};
+
+/// One node in the flattened command list.
+struct Node {
+    help: String,
+    /// "command" (runnable keyword), "category" (has subcommands), or
+    /// "value" (expects a user-supplied argument).
+    kind: &'static str,
+    /// Whether the path is runnable as typed (a terminal keyword, or a
+    /// category/value-list the grammar accepts bare — signalled by `<cr>`).
+    runnable: bool,
+}
+
+/// Maximum command depth (token count) to descend, a guard against a
+/// pathological or unexpectedly deep grammar.
+const MAX_DEPTH: usize = 8;
+/// Hard cap on emitted entries, a safety backstop.
+const MAX_ENTRIES: usize = 4000;
+
+/// Generates a flat list of every `show` command with its one-line help by
+/// walking the daemon's live command grammar (via the completion engine).
+///
+/// The result is generated once and cached for the process lifetime — the
+/// grammar is effectively static for a running daemon.
+#[derive(Clone)]
+pub struct CommandsTool {
+    client: ZebraClient,
+    cache: Arc<OnceCell<String>>,
+}
+
+impl CommandsTool {
+    pub fn new(client: ZebraClient) -> Self {
+        Self {
+            client,
+            cache: Arc::new(OnceCell::new()),
+        }
+    }
+
+    /// Return the cached flat `show` command list, generating it on first use.
+    pub async fn list_show_commands(&self) -> Result<String> {
+        self.cache
+            .get_or_try_init(|| self.generate())
+            .await
+            .cloned()
+    }
+
+    /// Walk the grammar under `show` and render the flat list as JSON.
+    async fn generate(&self) -> Result<String> {
+        // BTreeMap keeps the output sorted by command and dedups paths that
+        // the grammar reaches more than once.
+        let mut nodes: BTreeMap<String, Node> = BTreeMap::new();
+        let mut visited: HashSet<String> = HashSet::new();
+        let mut stack: Vec<String> = vec!["show".to_string()];
+
+        while let Some(prefix) = stack.pop() {
+            if nodes.len() >= MAX_ENTRIES {
+                debug!("list-show-commands hit MAX_ENTRIES cap");
+                break;
+            }
+            if !visited.insert(prefix.clone()) {
+                continue;
+            }
+            if prefix.split_whitespace().count() >= MAX_DEPTH {
+                continue;
+            }
+
+            let is_root = prefix == "show";
+            let candidates = match self.client.complete_children(&prefix).await {
+                Ok(c) => c,
+                Err(e) if is_root => {
+                    // Failing to enumerate the root means the daemon is
+                    // unreachable — surface it rather than an empty list.
+                    return Err(e);
+                }
+                Err(e) => {
+                    debug!("completion failed for '{}': {}", prefix, e);
+                    continue;
+                }
+            };
+
+            for cand in candidates {
+                // `<cr>` is the engine's "this path is complete/runnable here"
+                // marker, not a subcommand — record it against the parent.
+                if cand.name == "<cr>" {
+                    if let Some(node) = nodes.get_mut(&prefix) {
+                        node.runnable = true;
+                    }
+                    continue;
+                }
+
+                let full = format!("{} {}", prefix, cand.name);
+                // A bare value placeholder (e.g. `<A.B.C.D>`) is an argument,
+                // not a keyword: classify as value and never descend into it.
+                let placeholder = cand.name.starts_with('<');
+                let kind = if placeholder {
+                    "value"
+                } else {
+                    match cand.kind {
+                        CandidateKind::Dir => "category",
+                        CandidateKind::Value => "value",
+                        CandidateKind::Leaf => "command",
+                    }
+                };
+                nodes.entry(full.clone()).or_insert_with(|| Node {
+                    help: cand.help.clone(),
+                    kind,
+                    runnable: !placeholder && cand.kind == CandidateKind::Leaf,
+                });
+
+                // Descend into keyword categories and named value-lists (which
+                // may carry keyword sub-options such as `summary`), but never
+                // into bare value placeholders.
+                if !placeholder && matches!(cand.kind, CandidateKind::Dir | CandidateKind::Value) {
+                    stack.push(full);
+                }
+            }
+        }
+
+        let entries: Vec<Value> = nodes
+            .into_iter()
+            .map(|(command, node)| {
+                json!({
+                    "command": command,
+                    "help": node.help,
+                    "kind": node.kind,
+                    "runnable": node.runnable,
+                })
+            })
+            .collect();
+
+        let doc = json!({
+            "commands": entries,
+            "note": "Generated live from the daemon command grammar. \
+                     kind=command is a runnable keyword; kind=category has \
+                     further subcommands; kind=value expects a user-supplied \
+                     argument (address, prefix, name, ...). 'runnable' marks a \
+                     path the daemon accepts as typed. Pass any runnable path \
+                     to the `show` tool.",
+        });
+        Ok(serde_json::to_string_pretty(&doc)?)
+    }
+}

--- a/vtyctl/src/mcp/tools/mod.rs
+++ b/vtyctl/src/mcp/tools/mod.rs
@@ -1,1 +1,3 @@
+pub mod commands;
 pub mod isis;
+pub mod show;

--- a/vtyctl/src/mcp/tools/show.rs
+++ b/vtyctl/src/mcp/tools/show.rs
@@ -1,0 +1,106 @@
+use anyhow::Result;
+use serde_json::Value;
+use std::collections::HashMap;
+use tracing::{debug, warn};
+
+use crate::mcp::client::ZebraClient;
+
+/// Generic read-only `show` command tool.
+///
+/// Phase 0 is read-only: this tool runs the daemon `Show` RPC for any
+/// operational `show` command and returns its output. Commands that do not
+/// begin with `show` are rejected so the read-only contract is explicit.
+#[derive(Clone)]
+pub struct ShowTool {
+    client: ZebraClient,
+}
+
+impl ShowTool {
+    pub fn new(client: ZebraClient) -> Self {
+        Self { client }
+    }
+
+    /// Execute a read-only `show` command against the daemon.
+    pub async fn run(&self, args: HashMap<String, Value>) -> Result<String> {
+        let command = args
+            .get("command")
+            .and_then(|v| v.as_str())
+            .map(str::trim)
+            .unwrap_or("");
+
+        if command.is_empty() {
+            return Err(anyhow::anyhow!("Missing required 'command' argument"));
+        }
+
+        // Read-only contract: only `show` commands are permitted.
+        if command.split_whitespace().next() != Some("show") {
+            warn!("Rejected non-show command: {}", command);
+            return Err(anyhow::anyhow!(
+                "Only 'show' commands are permitted; got '{}'",
+                command
+            ));
+        }
+
+        let json = args.get("json").and_then(|v| v.as_bool()).unwrap_or(false);
+
+        debug!("Executing show command: {} (json={})", command, json);
+        let output = self.client.show_command(command, json).await?;
+
+        if output.trim().is_empty() {
+            Ok(String::from("(no output)"))
+        } else {
+            Ok(output)
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn tool() -> ShowTool {
+        ShowTool::new(ZebraClient::new("127.0.0.1".to_string(), 2650))
+    }
+
+    fn args(pairs: &[(&str, Value)]) -> HashMap<String, Value> {
+        pairs
+            .iter()
+            .map(|(k, v)| (k.to_string(), v.clone()))
+            .collect()
+    }
+
+    #[tokio::test]
+    async fn rejects_missing_command() {
+        let err = tool().run(args(&[])).await.unwrap_err().to_string();
+        assert!(err.contains("Missing required 'command'"), "{err}");
+    }
+
+    #[tokio::test]
+    async fn rejects_empty_command() {
+        let err = tool()
+            .run(args(&[("command", Value::String("   ".to_string()))]))
+            .await
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("Missing required 'command'"), "{err}");
+    }
+
+    #[tokio::test]
+    async fn rejects_non_show_command() {
+        for cmd in [
+            "configure terminal",
+            "clear bgp ipv4 neighbor *",
+            "showtime",
+        ] {
+            let err = tool()
+                .run(args(&[("command", Value::String(cmd.to_string()))]))
+                .await
+                .unwrap_err()
+                .to_string();
+            assert!(
+                err.contains("Only 'show' commands are permitted"),
+                "{cmd}: {err}"
+            );
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Phase 0 of the vtyctl MCP server (stdio transport). Generalizes the server from the single hard-coded `get-isis-graph` tool to a small read-only surface, and fixes a pre-existing socket-connection bug.

- **`show`** — runs any operational `show` command via the daemon `Show` RPC; rejects anything not starting with `show`, so the read-only contract is explicit.
- **`list-show-commands`** — enumerates the full `show` command surface by walking the daemon's completion engine (`DoExec`/`CompleteTrailingSpace`, the path behind CLI `?`/TAB). Emits a flat `command → help` list with a `kind` (command/category/value) and a `runnable` flag. Help comes from the `ext:help` strings in `exec.yang`; nothing is hand-maintained. Result is cached for the process lifetime.
- **`client.rs`** — adds `complete_children()` + a completion-line parser; factors endpoint-URI logic into a shared `endpoint()`.
- **`server.rs`** — advertises and dispatches the two tools; shares one `tool_result()` wrapper.
- **Bug fix** — the MCP entrypoint prepended `http://` to the host, corrupting `unix:` sockets (including the default `unix:zebra-rs/vty`) into an unparseable URI, so the server could never reach a socket daemon. It now passes the host through to `ZebraClient::endpoint()` for normalization.

The daemon is untouched: stdio reuses `SO_PEERCRED` + RBAC directly. Design/status recorded in `docs/design/mcp-server-auth-plan.md`.

## Test plan

- `cargo fmt --all` — clean
- `cargo clippy -p vtyctl --all-targets -- -D warnings` — clean
- `cargo test -p vtyctl mcp` — 7 unit tests pass (show rejection paths, completion parser, tools/list advertisement, unknown-tool error)
- Verified end-to-end against a live daemon: `show version` runs, `configure terminal` rejected, discovery returns 188 entries with help/kind/runnable.

Generated with [Claude Code](https://claude.com/claude-code)