### PR TITLE
docs(design): mark MCP Phase 0 merged (PR #1703)

### DIFF
--- a/docs/design/mcp-server-auth-plan.md
+++ b/docs/design/mcp-server-auth-plan.md
@@ -202,19 +202,19 @@ touched.
   changes**: it reuses `SO_PEERCRED` + RBAC directly. (If a network
   transport is ever revived, recover the prior design from this file's git
   history.)
-- **2026-06-27** — **Phase 0 landed (read-only) on branch
-  `mcp-stdio-phase0`.** Added the generic `show` tool (rejects non-`show`
-  commands) and `list-show-commands` (live grammar discovery), alongside
-  the kept `get-isis-graph`. Response wrapping factored into a shared
-  helper for the upcoming write tools. Also fixed a pre-existing bug: the
-  MCP entrypoint prepended `http://` to the host, corrupting `unix:`
-  sockets — including the default `unix:zebra-rs/vty` — so the server
-  could never reach a socket daemon; it now passes the host through to
+- **2026-07-01** — **Phase 0 merged to `main` (PR #1703).** Added the
+  generic `show` tool (rejects non-`show` commands) and
+  `list-show-commands` (live grammar discovery), alongside the kept
+  `get-isis-graph`. Response wrapping factored into a shared helper for
+  the upcoming write tools. Also fixed a pre-existing bug: the MCP
+  entrypoint prepended `http://` to the host, corrupting `unix:` sockets
+  — including the default `unix:zebra-rs/vty` — so the server could never
+  reach a socket daemon; it now passes the host through to
   `ZebraClient::endpoint()` for normalization. Verified end-to-end against
   a live daemon (`show version` runs, `configure terminal` rejected,
   discovery returns 188 entries with help/kind/runnable). 7 unit tests;
-  `cargo fmt`/`clippy --all-targets -D warnings`/`test` green. Not yet
-  committed. **Next: Phase 1** (write tools + `--write` gating + audit).
+  CI green (`cargo fmt`/`clippy`/`test`/`clippy (no-lua)`). **Next:
+  Phase 1** (write tools + `--write` gating + audit).
 - **2026-06-27** — Plan drafted. No code landed yet. Current MCP server is
   stdio-only, unauthenticated, single read-only tool (`get-isis-graph`).
   Daemon-side VTY auth stack (SO_PEERCRED, service accounts, RBAC, PAM)


### PR DESCRIPTION
## Summary

Docs-only follow-up to #1703. Updates the status log in `docs/design/mcp-server-auth-plan.md` to record that the read-only Phase 0 of the vtyctl MCP server — the generic `show` tool, `list-show-commands` live discovery, and the `unix:` socket-normalization fix — has merged to `main` with CI green.

Next up: Phase 1 (write tools + `--write` gating + audit).

## Test plan

Documentation only; no code changes.

Generated with [Claude Code](https://claude.com/claude-code)