### PR TITLE
bgp/mup: resolve ST1->ISD against a remote ISD (+ MUP forwarding docs)

### DIFF
--- a/bdd/tests/configs/bgp_mup_st1_isd/z1.yaml
+++ b/bdd/tests/configs/bgp_mup_st1_isd/z1.yaml
@@ -1,56 +1,73 @@
-# z1 — a single MUP interwork node that both originates a local ISD segment
-# and (via its MUP-C) an ST1 whose UE falls inside the ISD prefix, so the
-# ST1 resolves to the local End.DT46 segment and an SRv6 H.Encaps entry for
-# the UE prefix is installed into the VRF's table.
-#
-# VRF N6 is `encapsulation srv6`, so it carves a per-VRF End.DT46 SID from
-# locator LOC1 and installs the seg6local decap into the VRF table.
-#   * `segment interwork prefix 10.60.0.0/16` originates the ISD advertising
-#     that SID under 10.60.0.0/16.
-#   * `route st1 network-instance access` makes the MUP-C originate a Type-1
-#     ST route for PFCP sessions on NI `access`.
-# A PFCP session with UE 10.60.1.5 (inside 10.60.0.0/16) therefore yields an
-# ST1 that resolves to the local ISD, and zebra-rs installs
-#   10.60.1.5/32 encap seg6 mode encap segs [End.DT46 SID] dev lo table <N6>
-segment-routing:
-  locator:
-  - name: LOC1
-    prefix: fcbb:bb01::/48
-    behavior: usid
-router:
-  bgp:
-    global:
-      as: 65001
-      router-id: 192.168.0.1
-    segment-routing:
-      srv6:
-        locator: LOC1
-    vrf:
-    - name: N6
-      rd: "65000:100"
-      encapsulation: srv6
-      afi-safi:
-        mup:
-          route:
-          - type: st1
-            network-instance: access
-          segment:
-          - type: interwork
-            prefix: 10.60.0.0/16
-    mup-c:
-      enable: true
-      controller-address: fcbb:bb01::1
-      pfcp:
-        listen-address: 192.168.0.1
-        port: 8805
-      srv6:
-        locator: LOC1
-# Top-level VRF: MUP route-targets live here (same framework as ipv4/ipv6).
+# z1 — MUP PE originating an Interwork Segment Discovery (ISD, type 1)
+# route for VRF N6 (`afi-safi mup segment interwork prefix 10.60.0.0/16`).
+# IS-IS L2 SRv6 underlay + iBGP (mup afi-safi) to z2 over loopbacks. VRF N6
+# is `encapsulation srv6`, so it carves a per-VRF End.DT46 service SID from
+# locator S and installs the seg6local decap into the VRF table; `segment
+# interwork` advertises that segment as an ISD route (NLRI = rd + the
+# configured interwork prefix) carrying the End.DT46 SID as the SRv6 L3
+# Service, received by z2. (zebra-rs uses End.DT46 for the interwork segment
+# too; the draft's GTP4.E/GTP6.E behaviours are VPP/eBPF, deferred.)
 vrf:
 - name: N6
   mup:
     route-target:
       export:
-      - "65000:200"
+      - "65501:10"
       import:
-      - "65000:200"
+      - "65501:10"
+interface:
+- if-name: lo
+  ipv6:
+    address: 2001:db8::1/128
+- if-name: z1-z2
+  ipv6:
+    address: 2001:db8:0:12::1/64
+segment-routing:
+  locator:
+  - name: S
+    prefix: fcbb:bbbb:1::/48
+    behavior: usid
+router:
+  isis:
+    net: 49.0000.0000.0000.0001.00
+    hostname: z1
+    is-type: level-2-only
+    segment-routing:
+      srv6:
+        locator: S
+    interface:
+    - if-name: lo
+      ipv6:
+        enable: true
+    - if-name: z1-z2
+      network-type: point-to-point
+      metric: 1
+      ipv6:
+        enable: true
+  bgp:
+    global:
+      as: 65501
+      router-id: 10.0.0.1
+    timer:
+      adv-interval:
+        ibgp: 1
+    segment-routing:
+      srv6:
+        locator: S
+    neighbor:
+    - remote-address: 2001:db8::2
+      remote-as: 65501
+      update-source: 2001:db8::1
+      enabled: true
+      afi-safi:
+      - name: mup
+        enabled: true
+    vrf:
+    - name: N6
+      rd: "65501:10"
+      encapsulation: srv6
+      afi-safi:
+        mup:
+          segment:
+          - type: interwork
+            prefix: 10.60.0.0/16

--- a/bdd/tests/configs/bgp_mup_st1_isd/z2.yaml
+++ b/bdd/tests/configs/bgp_mup_st1_isd/z2.yaml
@@ -1,0 +1,78 @@
+# z2 — MUP interwork / UPF node. Its MUP-C originates a Type-1 ST (ST1)
+# route from a PFCP session on NI `access` (`afi-safi mup route st1`), and
+# VRF N6 (rd 65501:20, `encapsulation srv6`, import RT 65501:10) imports
+# z1's ISD (Interwork Segment Discovery, prefix 10.60.0.0/16 + End.DT46 SID
+# from z1's locator S). Because the ST1's UE (10.60.1.5) is covered by the
+# ISD prefix, z2 resolves the ST1 to z1's *remote* segment and installs an
+# SRv6 H.Encaps route for the UE into the VRF table, resolved through the
+# IS-IS SRv6 underlay toward z1:
+#   10.60.1.5/32 via <z1 underlay> encap seg6 segs [z1 End.DT46 SID]
+interface:
+- if-name: lo
+  ipv6:
+    address: 2001:db8::2/128
+- if-name: z2-z1
+  ipv6:
+    address: 2001:db8:0:12::2/64
+segment-routing:
+  locator:
+  - name: LOC2
+    prefix: fcbb:bbbb:2::/48
+    behavior: usid
+vrf:
+- name: N6
+  mup:
+    route-target:
+      import:
+      - "65501:10"
+router:
+  isis:
+    net: 49.0000.0000.0000.0002.00
+    hostname: z2
+    is-type: level-2-only
+    segment-routing:
+      srv6:
+        locator: LOC2
+    interface:
+    - if-name: lo
+      ipv6:
+        enable: true
+    - if-name: z2-z1
+      network-type: point-to-point
+      metric: 1
+      ipv6:
+        enable: true
+  bgp:
+    global:
+      as: 65501
+      router-id: 10.0.0.2
+    timer:
+      adv-interval:
+        ibgp: 1
+    segment-routing:
+      srv6:
+        locator: LOC2
+    neighbor:
+    - remote-address: 2001:db8::1
+      remote-as: 65501
+      update-source: 2001:db8::2
+      enabled: true
+      afi-safi:
+      - name: mup
+        enabled: true
+    vrf:
+    - name: N6
+      rd: "65501:20"
+      encapsulation: srv6
+      afi-safi:
+        mup:
+          route:
+          - type: st1
+            network-instance: access
+    mup-c:
+      enable: true
+      controller-address: 2001:db8::2
+      pfcp:
+        listen-address: 127.0.0.1
+      srv6:
+        locator: LOC2

--- a/bdd/tests/features/bgp_mup_st1_isd.feature
+++ b/bdd/tests/features/bgp_mup_st1_isd.feature
@@ -1,50 +1,66 @@
 @serial
 @bgp_mup_st1_isd
-Feature: BGP MUP ST1 resolves to a local ISD segment and installs SRv6 encap
-  A single MUP interwork node originates a local Interwork Segment Discovery
-  (ISD, type 1, SAFI 85 / draft-ietf-bess-mup-safi) route advertising its
-  per-VRF End.DT46 SID under a prefix, and — via its MUP controller — a
-  Type-1 Session-Transformed (ST1) route whose UE address falls inside that
-  prefix. Because the UE is covered by the local ISD, zebra-rs resolves the
-  ST1 to the ISD's End.DT46 segment (`show bgp vrf <name> mup` prints the
-  bind) and installs an oif-only recursive SRv6 H.Encaps route for the UE
-  prefix into the VRF's table, so UE-bound traffic in the VRF is encapsulated
-  toward that segment.
+Feature: BGP MUP ST1 resolves to a remote ISD segment and installs SRv6 encap
+  An interwork / UPF node imports a remote Interwork Segment Discovery (ISD,
+  type 1, SAFI 85 / draft-ietf-bess-mup-safi) route and — via its MUP
+  controller — originates a Type-1 Session-Transformed (ST1) route whose UE
+  address falls inside the ISD's advertised prefix. Because the UE is covered
+  by the (remote) ISD, the node resolves the ST1 to the ISD's End.DT46
+  segment and installs an SRv6 H.Encaps route for the UE prefix into the VRF
+  table, resolved through the IS-IS SRv6 underlay toward the ISD's next-hop.
 
-  Topology: one node z1.
+  Test Topology:
+  ```
+        2001:db8::1/128            2001:db8::2/128
+       ┌──────────┐  IS-IS L2 SRv6  ┌──────────┐
+       │    z1    │═════════════════│    z2    │
+       │ access PE│   iBGP (mup)    │ UPF +    │
+       │  (ISD)   │                 │ MUP-C    │
+       └──────────┘                 └──────────┘
+   z1-z2 2001:db8:0:12::1/64   2001:db8:0:12::2/64
+  ```
 
-       ┌──────────┐
-       │    z1    │  VRF N6: encapsulation srv6
-       │ MUP-C +  │    segment interwork prefix 10.60.0.0/16 (ISD)
-       │ interwork│    route st1 network-instance access     (ST1 via PFCP)
-       └──────────┘
+  z1 (VRF N6, rd 65501:10, `segment interwork prefix 10.60.0.0/16`, export RT
+  65501:10) originates the ISD (End.DT46 SID from locator S). z2 (VRF N6, rd
+  65501:20, `encapsulation srv6`, import RT 65501:10) imports the ISD and,
+  from a PFCP session on NI `access`, originates an ST1 (UE 10.60.1.5, inside
+  10.60.0.0/16). z2 resolves the ST1 to z1's Direct segment and installs the
+  UE encap.
 
-  Scenario: Build a single interwork node and turn on the MUP controller
+  NOTE: needs `pfcp-inject` on the BDD host PATH and root netns (kernel VRF +
+  seg6 + IS-IS SRv6 underlay).
+
+  Scenario: Build topology and establish iBGP with the MUP capability
     Given a clean test environment
-    When I create bridge "br0"
-    And I create namespace "z1" with IP "192.168.0.1/24" on bridge "br0"
+    When I create namespace "z1"
+    And I create namespace "z2"
+    And I connect namespace "z1" interface "z1-z2" to namespace "z2" interface "z2-z1"
     And I start zebra-rs in namespace "z1"
+    And I start zebra-rs in namespace "z2"
     And I apply config "z1.yaml" to namespace "z1"
-    And I wait 5 seconds for BGP to operate
-    Then show command "show bgp mup-c" in namespace "z1" should contain "PFCP listen : 192.168.0.1:8805"
-    # The ISD originates from the segment config, keyed under the VRF's own RD.
-    And show command "show bgp mup" in namespace "z1" should eventually contain "[ISD][65000:100][10.60.0.0/16]"
+    And I apply config "z2.yaml" to namespace "z2"
+    And I wait 45 seconds
+    Then BGP session in "z1" to "2001:db8::2" should be "Established"
+    And BGP session in "z2" to "2001:db8::1" should be "Established"
+    # z2 imports z1's ISD (re-keyed under its own rd 65501:20).
+    And show command "show bgp vrf N6 mup" in namespace "z2" should eventually contain "[ISD][65501:20][10.60.0.0/16]"
 
-  Scenario: A PFCP session inside the ISD prefix installs the SRv6 encap
+  Scenario: z2 resolves the ST1 to z1's ISD segment and installs the encap
     Given the test topology exists
-    When I execute "pfcp-inject --target 192.168.0.1 --port 8805 --ue-ipv4 10.60.1.5 --teid 0x12345678 --endpoint 10.0.0.1 --network-instance access" in namespace "z1"
-    Then show command "show bgp mup-c session" in namespace "z1" should eventually contain "10.60.1.5"
-    And show command "show bgp mup" in namespace "z1" should contain "ue=10.60.1.5/32"
-    # The ST1's UE (10.60.1.5) is covered by the local ISD 10.60.0.0/16, so
-    # the per-VRF view shows the resolution to the ISD's End.DT46 segment ...
-    And show command "show bgp vrf N6 mup" in namespace "z1" should eventually contain "resolved 10.60.1.5/32 -> End.DT46"
-    # ... and the SRv6 H.Encaps route is installed into the VRF table (an
-    # oif-only recursive seg6 encap toward the locator-LOC1 End.DT46 SID).
-    And command "ip route show table all" in namespace "z1" should eventually contain "encap seg6 mode encap segs 1 [ fcbb:bb01:"
+    When I execute "pfcp-inject --target 127.0.0.1 --port 8805 --ue-ipv4 10.60.1.5 --teid 0x12345678 --endpoint 10.0.0.1 --network-instance access" in namespace "z2"
+    # The ST1's UE (10.60.1.5) is covered by the ISD 10.60.0.0/16, so the
+    # per-VRF view shows the resolution to the ISD's End.DT46 segment.
+    Then show command "show bgp vrf N6 mup" in namespace "z2" should eventually contain "resolved 10.60.1.5/32 -> End.DT46"
+    # The SRv6 H.Encaps route for the UE is installed into the VRF table,
+    # resolved through the underlay toward z1's End.DT46 SID (locator S =
+    # fcbb:bbbb:1::/48).
+    And command "ip route show table all" in namespace "z2" should eventually contain "encap seg6 mode encap segs 1 [ fcbb:bbbb:1:"
+    And command "ip route show table all" in namespace "z2" should eventually contain "10.60.1.5"
 
   Scenario: Teardown topology
     Given the test topology exists
     When I stop zebra-rs in namespace "z1"
+    And I stop zebra-rs in namespace "z2"
     And I delete namespace "z1"
-    And I delete bridge "br0"
+    And I delete namespace "z2"
     Then the test environment should be clean

--- a/book/src/ch-02-35-bgp-mup.md
+++ b/book/src/ch-02-35-bgp-mup.md
@@ -196,19 +196,15 @@ it:
 * **`segment direct { mup-ext-comm <2:4>; }`** originates a **Direct
   Segment Discovery (DSD, type 2)** route — NLRI = RD + router-id — carrying
   the End.DT46 SID and the Direct-segment id (`mup-ext-comm`). A receiving
-  *interwork* node (`segment interwork`) matches each received ST2 to the
-  DSD by this id and `show bgp mup` prints the resolution.
+  interwork node matches each received **ST2** to the DSD by this
+  **Direct-segment id**.
 * **`segment interwork { prefix <p>; }`** originates an **Interwork Segment
   Discovery (ISD, type 1)** route — NLRI = RD + the configured `prefix`
   (typically the locally connected gNodeB N3 prefix; its family selects the
   AFI) — carrying the End.DT46 SID. The ISD does not originate until the
-  prefix is set, and carries no `mup-ext-comm`: an ISD is resolved by
-  **prefix containment** instead. On the ISD's originating node, a selected
-  ST1 whose UE address falls within a local ISD's prefix is bound to that
-  ISD's End.DT46 segment (longest-match when several ISDs cover the UE), and
-  `show bgp mup` / `show bgp vrf <name> mup` print the resolution
-  (`resolved <ue> -> End.DT46 <sid> (via [ISD]…)`). UE-bound traffic in the
-  VRF is then encapsulated into that segment.
+  prefix is set, and carries no `mup-ext-comm`: a receiving interwork node
+  matches each received **ST1** to the ISD by **prefix containment**
+  (longest-match when several ISDs cover the UE).
 
 ```
 vrf N6 {
@@ -222,9 +218,33 @@ vrf N6 {
 }
 ```
 
+#### Resolving ST routes to a segment (forwarding)
+
+An interwork node imports the ST routes **and** the segment routes into a
+forwarding VRF (`encapsulation srv6` + a matching `route-target import`),
+resolves each ST route to its segment, and installs an SRv6 **H.Encaps**
+route for the ST route's destination into the VRF table:
+
+* **ST2 → DSD** (by Direct-segment id): `dst = the ST2 endpoint /32|/128`.
+* **ST1 → ISD** (by prefix containment): `dst = the ST1 UE prefix`.
+
+The segment is **remote** (received from the peer that owns the End.DT46
+SID), so the encap resolves through the IS-IS SRv6 underlay via Next-Hop
+Tracking toward the segment's next-hop:
+
+```
+dst  via <underlay egress> dev <link>  encap seg6 mode encap segs [End.DT46 SID]  table <VRF>
+```
+
+`show bgp mup` / `show bgp vrf <name> mup` print the resolution
+(`resolved <key> -> End.DT46 <sid> (via [DSD|ISD]…)`), and the entry
+re-installs (or withdraws) automatically as the underlay reroutes or the ST
+/ segment route comes and goes.
+
 zebra-rs uses **End.DT46** for both Direct and Interwork segments; the
-draft's GTP-interwork behaviours (GTP4.E / GTP6.E / H.M.GTP4.D) are
-VPP/eBPF and not yet implemented.
+draft's GTP-U endpoint behaviours (GTP4.E / GTP6.E / H.M.GTP4.D) themselves
+are VPP/eBPF and not yet implemented — the kernel dataplane performs the
+SRv6 H.Encaps toward the segment, and the End.DT46 decap at the far end.
 
 ## From PFCP session to ST route
 
@@ -412,13 +432,19 @@ The control plane is complete: capability negotiation, ISD/DSD/T1ST/T2ST
 codec, Loc-RIB receive/store/show, controller ST origination, PE-side
 Segment Discovery origination (DSD and ISD, each with the per-VRF End.DT46
 SID + `seg6local` decap installed into the kernel FIB), and the interwork
-node's control-plane resolution of received ST2 routes to the matching
-Direct segment.
+node's resolution of received ST routes to the matching segment.
 
-The **GTP-interwork forwarding plane** is **not** implemented: the
-End.DT46 decap that the segment routes advertise is installed, but the
-GTP-U SRv6 endpoint behaviours themselves (GTP4.E / GTP6.E / H.M.GTP4.D)
-have no stock-Linux `seg6local` action, so the actual GTP encap/decap is
-left to a VPP/eBPF-based forwarder. The controller's PFCP northbound
-currently handles Association and Session lifecycle messages;
-heartbeat-driven eviction of idle associations is a follow-up.
+The interwork node's **SRv6 forwarding** is installed: on a forwarding VRF
+(`encapsulation srv6` + `route-target import`), each resolved ST route
+programs an SRv6 H.Encaps entry for its destination (ST2 endpoint / ST1 UE
+prefix) toward the remote segment's End.DT46 SID, resolved through the
+underlay via Next-Hop Tracking (`dst via <underlay egress> encap seg6 segs
+[SID]`), and the far-end PE's `seg6local End.DT46` decaps into its VRF.
+
+The **GTP-U endpoint behaviours** themselves (GTP4.E / GTP6.E / H.M.GTP4.D)
+are **not** implemented: they have no stock-Linux `seg6local` action, so the
+GTP encap/decap at the mobile edge is left to a VPP/eBPF-based forwarder —
+zebra-rs uses End.DT46 as the kernel stand-in for the segment. The
+controller's PFCP northbound currently handles Association and Session
+lifecycle messages; heartbeat-driven eviction of idle associations is a
+follow-up.

--- a/book/src/ch-14-02-show-bgp.md
+++ b/book/src/ch-14-02-show-bgp.md
@@ -120,8 +120,11 @@ JSON: an array of `{ nlri_type, nlri, neighbor, best }`.
 
 The Mobile User Plane Loc-RIB (SAFI 85): Direct-Segment, ISD, and
 Type-1/Type-2 Session-Transformed routes. `summary` shows the
-IPv4-MUP / IPv6-MUP neighbor sections. See
-[Mobile User Plane (MUP)](ch-02-35-bgp-mup.md).
+IPv4-MUP / IPv6-MUP neighbor sections. On an interwork node, each ST route
+resolved to its segment prints a `resolved <key> -> End.DT46 <sid> (via
+[DSD|ISD]…)` line (ST2→DSD by Direct-segment id, ST1→ISD by prefix
+containment); the per-VRF `show bgp vrf <name> mup` shows the same for a
+forwarding VRF. See [Mobile User Plane (MUP)](ch-02-35-bgp-mup.md).
 
 ### `show bgp mup-c [session|association]`
 

--- a/docs/design/bgp-mup-followups.md
+++ b/docs/design/bgp-mup-followups.md
@@ -33,8 +33,12 @@ Tests on the rebased base: 342 `bgp-packet` + 1378 `zebra-rs`, fmt +
 workspace clippy clean.
 
 **P5 (the MUP Controller) is now built** over PR-A/B/C using a **PFCP/N4**
-northbound (not zenoh) — see the P5 section below. **P6 (the
-SRv6-mobile dataplane) remains the one large deferred phase.**
+northbound (not zenoh) — see the P5 section below. **P6 (the SRv6-mobile
+dataplane) is now largely done**: origination, ST↔segment resolution, and
+the interwork node's SRv6 H.Encaps forwarding (both ST2→DSD and ST1→ISD)
+all land (P6 slices 1–6). Only the mobile-edge **GTP-U endpoint
+behaviours** (GTP4.E / GTP6.E / H.M.GTP4.D) remain, and those are out of
+stock-Linux scope (VPP/eBPF).
 
 The items below were consciously left out so each phase could ship as a
 small PR. None block the control-plane path for the common case
@@ -127,19 +131,15 @@ policy plumbing in `zebra-rs/src/bgp/config.rs` (`config_afi_safi_policy_*`)
 
 **Size:** medium (~250 lines: policy binding + apply + tests).
 
-### 2. Next-Hop Tracking (NHT) for MUP next-hops
+### 2. Next-Hop Tracking (NHT) for MUP segment next-hops — **DONE (P6 slice 6)**
 
-**What:** The MUP next-hop (PE/controller IPv6 address) is not registered
-with NHT, so reachability/recursive-resolution gating isn't applied to
-MUP routes.
-
-**Why deferred:** P2/P4 are control-plane only; the NHT gate matters once
-MUP routes drive forwarding (P6) or feed the controller's resolution.
-
-**Where:** `route_mup_update` + the NHT register/gate path
-(`zebra-rs/src/bgp/nht*`), mirroring how VPNv4/VPNv6 next-hops register.
-
-**Size:** medium (~200 lines).
+A received **segment** route (DSD/ISD) now registers its next-hop with NHT
+(`NhtDep::Mup`, `mup_segment_track` in `route.rs`), so the dependent ST →
+segment H.Encaps re-installs on the first resolution and every underlay
+reroute, and withdraws when unreachable. This is what drives the interwork
+node's forwarding (P6 slice 6). The ST routes' own next-hops (the
+controller address, in the draft-default no-SID model) are not FIB-relevant
+and stay untracked.
 
 ### 3. VRF import (route-target → VRF) for received MUP routes
 
@@ -575,24 +575,73 @@ sibling of the slice-1 DSD:
   selection + the empty-prefix / zero-router-id gates). Run live via
   `make -C bdd bgp_mup_isd`.
 
+#### P6 slice 5 — ST1 → ISD resolution + show — **DONE**
+
+The prefix-containment twin of slice 3's ST2 → DSD resolution: a selected
+ST1 whose UE prefix is covered (longest-match) by an ISD's advertised
+prefix resolves to that ISD's End.DT46 segment. `render_mup_table` indexes
+the ISD routes by prefix and prints `resolved <ue> -> End.DT46 <sid> (via
+[ISD]…)` in `show bgp mup` / `show bgp vrf <name> mup`. Matched by prefix
+containment (no MUP Extended Community). A `render_mup_table` unit test
+covers in-range resolve, out-of-range no-resolve, and the opt-in gate.
+
+#### P6 slice 6 — SRv6 forwarding install (ST → segment H.Encaps) — **DONE**
+
+The interwork node now programs the FIB for each resolved ST route. On a
+**forwarding VRF** (`encapsulation srv6` + `route-target import`) the ST
+routes and the segment routes both land in the per-VRF MUP RIB, and the
+per-VRF task installs an SRv6 **H.Encaps** route for the ST route's
+destination into the VRF table:
+
+- **ST2 → DSD** (by Direct-segment id): `dst = the ST2 endpoint /32|/128`.
+- **ST1 → ISD** (by prefix containment): `dst = the ST1 UE prefix`.
+
+The segment is **remote** (received from the peer owning the End.DT46 SID),
+so the encap resolves through the underlay via **Next-Hop Tracking** — this
+closes followup #2 (*NHT for MUP next-hops*). The pipeline mirrors the L3VPN
+import + NHT path:
+
+- **`nht.rs`** — `NhtDep::Mup(rd, prefix)` tracks a received segment route's
+  next-hop.
+- **`route.rs`** — `mup_segment_track` / `mup_segment_untrack` register /
+  release a received DSD **or** ISD next-hop (register-then-gate) and read
+  its resolved transport; `build_srv6_vpn_fib_entry` is reused.
+- **`vrf/msg.rs`** — `MupUpdate.transport` carries the resolved transport to
+  the importing VRF (like `ImportV4`).
+- **`vrf/inst.rs`** — the per-VRF task stashes each segment route's transport
+  (`mup_segment_transport`) and `reconcile_mup_st2_dsd` /
+  `reconcile_mup_st1_isd` install/withdraw the endpoint / UE encap
+  (`mup_encap_install`), diff-gated.
+- **`inst.rs`** — the NHT reachability + transport-reroute handlers
+  re-dispatch the segment route with fresh transport, so the encap
+  (re)installs on first resolution and every underlay reroute, and withdraws
+  when unreachable.
+
+Both directions install `dst via <underlay egress> encap seg6 mode encap
+segs [End.DT46 SID] table <VRF>`. **History:** ST1→ISD first landed as an
+*oif-only, local-SID* install (the ISD originated on the same node); it was
+then revisited to the *remote-SID, NHT-resolved* model so both directions
+share one path. The oif-only seg6-encap netlink capability is retained as a
+general FIB primitive.
+
+Tests: `@bgp_mup_st2_dsd_fib` and `@bgp_mup_st1_isd` BDDs (root, two-node) —
+z-access-PE originates the segment, z-interwork imports it + originates the
+ST, and the kernel installs `<dst> via <underlay> encap seg6 segs [SID]`.
+Run live via `make -C bdd bgp_mup_st2_dsd_fib` / `bgp_mup_st1_isd`.
+
 #### Remaining
 
-**What:** Install the FIB state that actually forwards MUP traffic. With
-the draft-default model (see *Draft-default forwarding* above), the PE
-receiving an ST route resolves its forwarding SID from the matching
-ISD / DSD route rather than from a SID carried on the ST route — so P6
-gains an *ISD/DSD-route → segment-SID resolution* step ahead of the FIB
-write. Per the chosen "install what the kernel supports" scope: program
-`End.DT4/6` + the route-level SIDs we already do for L3VPN/SRv6, and flag
-the GTP behaviours (`End.M.GTP4.E` / `End.M.GTP6.E` / `GTP4.E` /
-`GTP6.E`) as needing VPP or eBPF — mainline Linux `seg6local` has no
-`End.M.GTP*` actions. See the kernel-support note in
-[`bgp-prefix-sid-rfc9252.md`](bgp-prefix-sid-rfc9252.md) and
-[`srv6-l3vpn` forwarding notes](../../zebra-rs-srv6-l3vpn-forwarding-bugs.md).
+**What:** the **GTP-U endpoint behaviours** at the mobile edge (GTP4.E /
+GTP6.E / H.M.GTP4.D / `End.M.GTP*`). Mainline Linux `seg6local` has no
+`End.M.GTP*` actions, so the actual GTP encap/decap is left to a VPP/eBPF
+forwarder — zebra-rs uses End.DT46 as the kernel stand-in for the segment.
+The control plane, the ST↔segment resolution, and the SRv6 H.Encaps toward
+the segment are all done (slices 5–6). See the kernel-support note in
+[`bgp-prefix-sid-rfc9252.md`](bgp-prefix-sid-rfc9252.md).
 
-**Where:** the FIB install path + `seg6local` programming.
+**Where:** a VPP/eBPF dataplane.
 
-**Size:** large.
+**Size:** large (out of stock-Linux scope).
 
 ## Quick-pick recommendations
 

--- a/zebra-rs/src/bgp/inst.rs
+++ b/zebra-rs/src/bgp/inst.rs
@@ -3671,25 +3671,26 @@ impl Bgp {
                     endpoint,
                 );
             }
-            // MUP: a received DSD's next-hop rerouted → re-dispatch it to
-            // importing VRFs with the fresh transport so each dependent
-            // ST2→DSD endpoint encap re-installs toward the new egress.
+            // MUP: a received segment route (DSD/ISD) next-hop rerouted →
+            // re-dispatch it to importing VRFs with the fresh transport so
+            // each dependent encap (ST2→DSD / ST1→ISD) re-installs toward the
+            // new egress.
             NhtDep::Mup(rd, prefix) => {
-                self.mup_redispatch_dsd(nh, rd, prefix, true);
+                self.mup_redispatch_segment(nh, rd, prefix, true);
             }
             NhtDep::V4(_) | NhtDep::V6(_) => {}
         }
     }
 
-    /// Re-dispatch a received DSD to importing VRFs with its current
-    /// underlay transport (empty when `reachable` is false), so each
-    /// dependent ST2→DSD endpoint encap re-installs or is withdrawn. The
-    /// register-then-gate first resolution and every later reroute both
-    /// land here. Standalone (`&mut self`, no live `BgpTop`), so it is
-    /// safe to call from `nht_reinstall_transport`; the reachability path
-    /// (`nht_reeval_dep`) inlines the same logic because a `BgpTop`
+    /// Re-dispatch a received MUP segment route (DSD or ISD) to importing
+    /// VRFs with its current underlay transport (empty when `reachable` is
+    /// false), so each dependent encap (ST2→DSD / ST1→ISD) re-installs or is
+    /// withdrawn. The register-then-gate first resolution and every later
+    /// reroute both land here. Standalone (`&mut self`, no live `BgpTop`), so
+    /// it is safe to call from `nht_reinstall_transport`; the reachability
+    /// path (`nht_reeval_dep`) inlines the same logic because a `BgpTop`
     /// already borrows `local_rib` there.
-    fn mup_redispatch_dsd(
+    fn mup_redispatch_segment(
         &mut self,
         nh: std::net::IpAddr,
         rd: bgp_packet::RouteDistinguisher,
@@ -3999,7 +4000,7 @@ impl Bgp {
             // importing VRFs with its resolved transport (empty when
             // unreachable), so each dependent ST2→DSD endpoint encap
             // installs or is withdrawn. Inlined rather than
-            // `mup_redispatch_dsd` because `top` already borrows local_rib.
+            // `mup_redispatch_segment` because `top` already borrows local_rib.
             NhtDep::Mup(rd, prefix) => {
                 let selected = top.local_rib.select_best_path_mup(rd, prefix);
                 if let Some(winner) = selected.first() {

--- a/zebra-rs/src/bgp/route.rs
+++ b/zebra-rs/src/bgp/route.rs
@@ -3030,18 +3030,19 @@ fn nht_track_received_attr(bgp: &mut BgpTop, attr: &BgpAttr, dep: super::nht::Nh
     reachable
 }
 
-/// NHT for a received MUP **DSD**: register its next-hop so an underlay
-/// reroute re-installs the dependent ST2→DSD encap, and return the
-/// next-hop's currently-resolved underlay transport (empty while a fresh
-/// registration is pending, the next-hop is unreachable, or `best` is not
-/// a DSD). No-op outside the global instance (`nexthop_cache` is `None`).
-fn mup_dsd_track(
+/// NHT for a received MUP **segment** route (DSD or ISD): register its
+/// next-hop so an underlay reroute re-installs the dependent encap (ST2→DSD
+/// or ST1→ISD), and return the next-hop's currently-resolved underlay
+/// transport (empty while a fresh registration is pending, the next-hop is
+/// unreachable, or `best` is not a segment route). No-op outside the global
+/// instance (`nexthop_cache` is `None`).
+fn mup_segment_track(
     bgp: &mut BgpTop,
     rd: RouteDistinguisher,
     prefix: &MupPrefix,
     best: Option<&BgpRib>,
 ) -> Vec<rib::nht::ResolvedNexthop> {
-    if !matches!(prefix, MupPrefix::Dsd { .. }) {
+    if !matches!(prefix, MupPrefix::Dsd { .. } | MupPrefix::Isd { .. }) {
         return Vec::new();
     }
     let Some(best) = best else {
@@ -3064,9 +3065,10 @@ fn mup_dsd_track(
     cache.transport_for(nh).to_vec()
 }
 
-/// Symmetric to [`mup_dsd_track`]: drop the DSD dep from `nh` and, once it
-/// has no deps left, unregister it. `nh` is the pre-withdraw next-hop.
-fn mup_dsd_untrack(bgp: &mut BgpTop, rd: RouteDistinguisher, prefix: &MupPrefix, nh: IpAddr) {
+/// Symmetric to [`mup_segment_track`]: drop the segment dep from `nh` and,
+/// once it has no deps left, unregister it. `nh` is the pre-withdraw
+/// next-hop.
+fn mup_segment_untrack(bgp: &mut BgpTop, rd: RouteDistinguisher, prefix: &MupPrefix, nh: IpAddr) {
     let dep = super::nht::NhtDep::Mup(rd, prefix.clone());
     let Some(cache) = bgp.nexthop_cache.as_deref_mut() else {
         return;
@@ -7662,7 +7664,7 @@ pub fn route_mup_update(
     // reroute re-installs the dependent ST2→DSD encap) and read the
     // resolved transport to hand the importing VRF. Empty for non-DSD /
     // unresolved. Must precede the `bgp.vrf_import` borrow below.
-    let transport = mup_dsd_track(bgp, rd, &prefix, selected.first());
+    let transport = mup_segment_track(bgp, rd, &prefix, selected.first());
     // Mirror the new best-path to every VRF whose `mup import` RT set
     // matches, so `show bgp vrf <name> mup` reflects peer-learned routes.
     // A peer-learned route has no local originating VRF (`origin_vrf =
@@ -7686,25 +7688,25 @@ pub fn route_mup_withdraw(ident: usize, route: &MupRoute, bgp: &mut BgpTop, peer
     }
     // Capture the pre-withdraw DSD next-hop so it can be released from NHT
     // if this withdrawal drops the last path using it.
-    let old_dsd_nh = bgp
+    let old_segment_nh = bgp
         .local_rib
         .select_best_path_mup(&rd, &prefix)
         .first()
-        .filter(|_| matches!(prefix, MupPrefix::Dsd { .. }))
+        .filter(|_| matches!(prefix, MupPrefix::Dsd { .. } | MupPrefix::Isd { .. }))
         .and_then(|r| super::nht::nht_target(&r.attr));
     let _ = bgp.local_rib.remove_mup(rd, &prefix, id, ident);
     let selected = bgp.local_rib.select_best_path_mup(&rd, &prefix);
     // Release the NHT registration when no surviving path keeps the
     // pre-withdraw DSD next-hop.
-    if let Some(nh) = old_dsd_nh
+    if let Some(nh) = old_segment_nh
         && selected
             .first()
             .and_then(|r| super::nht::nht_target(&r.attr))
             != Some(nh)
     {
-        mup_dsd_untrack(bgp, rd, &prefix, nh);
+        mup_segment_untrack(bgp, rd, &prefix, nh);
     }
-    let transport = mup_dsd_track(bgp, rd, &prefix, selected.first());
+    let transport = mup_segment_track(bgp, rd, &prefix, selected.first());
     // Mirror the post-withdraw state to per-VRF tasks: a remaining best
     // path is re-forwarded (matched by RT), otherwise the prefix is
     // withdrawn from every VRF's copy. A peer-learned route has no local

--- a/zebra-rs/src/bgp/show.rs
+++ b/zebra-rs/src/bgp/show.rs
@@ -4306,13 +4306,14 @@ fn render_mup_table(
         std::collections::BTreeMap::new()
     };
 
-    // On the node that originated a local ISD (Interwork Segment Discovery)
-    // segment, a selected ST1 route whose UE prefix is covered by the ISD's
-    // advertised prefix is "resolved" by that ISD: UE-bound traffic in the
-    // VRF is encapsulated into the ISD's (local) End.DT46 segment. Index the
-    // local ISD routes (originated, with an SRv6 L3 Service SID) so each ST1
-    // can pick the most-specific covering ISD (longest-prefix match). The FIB
-    // install of this H.Encaps entry lands in a follow-up.
+    // On an interwork node, a selected ST1 route whose UE prefix is covered
+    // by an ISD (Interwork Segment Discovery) route's advertised prefix is
+    // "resolved" by that ISD: UE-bound traffic in the VRF is encapsulated
+    // toward the ISD's End.DT46 segment. Index the ISD routes (with an SRv6
+    // L3 Service SID) so each ST1 can pick the most-specific covering ISD
+    // (longest-prefix match). Like the DSD index, this resolves against
+    // *received* (remote) ISDs — the interwork node imports the ISD from the
+    // access-side PE and steers the UE prefix through the underlay toward it.
     let isd_index: Vec<(
         RouteDistinguisher,
         MupPrefix,
@@ -4332,9 +4333,6 @@ fn render_mup_table(
                 let MupPrefix::Isd { prefix: isd_prefix } = prefix else {
                     return None;
                 };
-                if !rib.is_originated() {
-                    return None;
-                }
                 let (sid, behavior) = rib.attr.srv6_l3_sid()?;
                 Some((*rd, prefix.clone(), *isd_prefix, sid, behavior))
             })
@@ -5823,11 +5821,11 @@ mod detail_tests {
         );
     }
 
-    /// On the ISD's originating node, a selected ST1 whose UE prefix is
-    /// covered by the local ISD's advertised prefix resolves to that ISD's
-    /// End.DT46 segment (the encap the UE-bound traffic takes). A UE outside
-    /// the ISD prefix does not resolve, and resolution is only shown when the
-    /// caller opts in (`resolve_segments`).
+    /// On an interwork node, a selected ST1 whose UE prefix is covered by a
+    /// received ISD's advertised prefix resolves to that ISD's End.DT46
+    /// segment (the encap the UE-bound traffic takes). A UE outside the ISD
+    /// prefix does not resolve, and resolution is only shown when the caller
+    /// opts in (`resolve_segments`).
     #[test]
     fn render_mup_table_resolves_st1_to_isd_segment() {
         use std::net::{IpAddr, Ipv4Addr};
@@ -5836,7 +5834,7 @@ mod detail_tests {
             super::super::route::LocalRibMupTable,
         > = std::collections::BTreeMap::new();
 
-        // A locally-originated ISD advertising 10.60.0.0/16 + an End.DT46 SID.
+        // A received ISD advertising 10.60.0.0/16 + an End.DT46 SID.
         let mut isd_attr = BgpAttr::new();
         isd_attr.nexthop = Some(BgpNexthop::Ipv6("fcbb:bbbb:1::".parse().unwrap()));
         isd_attr.prefix_sid = Some(super::super::inst::srv6_l3_service_prefix_sid(
@@ -5847,7 +5845,7 @@ mod detail_tests {
         let isd_rib = BgpRib::new(
             0,
             Ipv4Addr::new(10, 0, 0, 1),
-            BgpRibType::Originated,
+            BgpRibType::IBGP,
             0,
             32768,
             &isd_attr,

--- a/zebra-rs/src/bgp/vrf/inst.rs
+++ b/zebra-rs/src/bgp/vrf/inst.rs
@@ -165,16 +165,18 @@ pub struct BgpVrf {
     /// End.DT46 SID it is steered into. A selected ST1 whose UE prefix is
     /// covered by a locally-originated ISD's prefix installs an oif-only
     /// recursive seg6 H.Encaps route into this VRF's table (`dst = UE
-    /// prefix, encap seg6 segs [SID]`). Tracked so `reconcile_mup_st1_isd`
-    /// can diff and withdraw when the ST1 or the covering ISD goes away.
+    /// prefix, via <underlay egress> encap seg6 segs [SID]`). Tracked so
+    /// `reconcile_mup_st1_isd` can diff and withdraw when the ST1 or the
+    /// covering ISD goes away.
     pub mup_st1_isd_installed: std::collections::BTreeMap<ipnet::IpNet, std::net::Ipv6Addr>,
-    /// Resolved underlay transport for each imported DSD's next-hop, keyed
-    /// by the DSD's `(rd, prefix)`. Supplied by the global NHT via
-    /// `MupUpdate.transport` and consumed by `reconcile_mup_st2_dsd` to
-    /// build the resolved-underlay seg6 encap for an ST2 whose
-    /// Direct-segment id matches the DSD. Absent/empty ⇒ the DSD next-hop
-    /// hasn't resolved, so no ST2 encap is installable for it.
-    pub mup_dsd_transport: std::collections::BTreeMap<
+    /// Resolved underlay transport for each imported segment route (DSD/ISD)
+    /// next-hop, keyed by its `(rd, prefix)`. Supplied by the global NHT via
+    /// `MupUpdate.transport` and consumed by `reconcile_mup_st2_dsd` /
+    /// `reconcile_mup_st1_isd` to build the resolved-underlay seg6 encap for
+    /// an ST2 (by Direct-segment id) / ST1 (by prefix containment) that
+    /// matches. Absent/empty ⇒ the segment next-hop hasn't resolved, so no
+    /// encap is installable for it.
+    pub mup_segment_transport: std::collections::BTreeMap<
         (bgp_packet::RouteDistinguisher, bgp_packet::MupPrefix),
         Vec<crate::rib::nht::ResolvedNexthop>,
     >,
@@ -646,7 +648,7 @@ impl BgpVrf {
             mup_originated: std::collections::BTreeMap::new(),
             mup_segment_prefix: None,
             mup_st1_isd_installed: std::collections::BTreeMap::new(),
-            mup_dsd_transport: std::collections::BTreeMap::new(),
+            mup_segment_transport: std::collections::BTreeMap::new(),
             mup_st2_dsd_installed: std::collections::BTreeMap::new(),
         };
         (vrf, inbox_tx)
@@ -669,47 +671,53 @@ impl BgpVrf {
     }
 
     /// Reconcile ST1→ISD encap FIB entries for this VRF. A selected ST1
-    /// whose UE prefix is covered by a locally-originated ISD's prefix is
-    /// steered into that ISD's local End.DT46 SID: install an oif-only
-    /// recursive seg6 H.Encaps route (`dst = UE prefix, encap seg6 segs
-    /// [SID]`) into this VRF's table so UE-bound traffic in the VRF is
-    /// encapsulated toward that segment. Longest-match when several local
-    /// ISDs cover the UE. Diff-gated against `mup_st1_isd_installed` so an
-    /// unchanged binding doesn't churn the FIB, and a binding that lost its
-    /// ST1 or its covering ISD is withdrawn. Mirrors the show-side
-    /// resolution in `render_mup_table`.
+    /// whose UE prefix is covered (longest-match) by an imported ISD's prefix
+    /// is steered into that ISD's End.DT46 SID: install a resolved-underlay
+    /// seg6 H.Encaps route for the UE prefix (`dst = UE prefix, via <underlay
+    /// egress> encap seg6 segs [SID]`) into this VRF's table so UE-bound
+    /// traffic in the VRF is encapsulated toward that segment. The ISD is
+    /// remote (received from the access-side PE), so the encap resolves
+    /// through the global-supplied `mup_segment_transport`; an unresolved ISD
+    /// next-hop yields no install. Diff-gated against `mup_st1_isd_installed`.
+    /// Mirrors the show-side resolution in `render_mup_table` and the ST2→DSD
+    /// reconcile (matched by prefix containment instead of Direct-segment id).
     fn reconcile_mup_st1_isd(&mut self) {
         use std::net::Ipv6Addr;
-        // Locally-originated ISD prefixes → their End.DT46 SID.
-        let isd: Vec<(ipnet::IpNet, Ipv6Addr)> = self
-            .local_rib
-            .mup
-            .values()
-            .flat_map(|t| t.selected.iter())
-            .filter_map(|(prefix, rib)| {
-                let bgp_packet::MupPrefix::Isd { prefix: p } = prefix else {
-                    return None;
+        type Transport = Vec<crate::rib::nht::ResolvedNexthop>;
+        // Index imported ISDs by their advertised prefix → (SID, transport).
+        // Only an ISD with both a SID and a resolved underlay transport
+        // qualifies.
+        let mut isd_index: Vec<(ipnet::IpNet, Ipv6Addr, Transport)> = Vec::new();
+        for (rd, table) in self.local_rib.mup.iter() {
+            for (prefix, rib) in table.selected.iter() {
+                let bgp_packet::MupPrefix::Isd { prefix: isd_prefix } = prefix else {
+                    continue;
                 };
-                if !rib.is_originated() {
-                    return None;
+                let Some((sid, _behavior)) = rib.attr.srv6_l3_sid() else {
+                    continue;
+                };
+                let Some(transport) = self.mup_segment_transport.get(&(*rd, prefix.clone())) else {
+                    continue;
+                };
+                if transport.is_empty() {
+                    continue;
                 }
-                let (sid, _behavior) = rib.attr.srv6_l3_sid()?;
-                Some((*p, sid))
-            })
-            .collect();
+                isd_index.push((*isd_prefix, sid, transport.clone()));
+            }
+        }
         // Desired: each selected ST1 UE prefix → the most-specific covering
-        // local ISD's SID.
-        let mut desired: std::collections::BTreeMap<ipnet::IpNet, Ipv6Addr> =
+        // ISD's (SID, transport).
+        let mut desired: std::collections::BTreeMap<ipnet::IpNet, (Ipv6Addr, Transport)> =
             std::collections::BTreeMap::new();
-        if !isd.is_empty() {
+        if !isd_index.is_empty() {
             for (prefix, _rib) in self.local_rib.mup.values().flat_map(|t| t.selected.iter()) {
                 if let bgp_packet::MupPrefix::T1st { prefix: ue, .. } = prefix
-                    && let Some((_p, sid)) = isd
+                    && let Some((_p, sid, transport)) = isd_index
                         .iter()
-                        .filter(|(p, _)| p.contains(ue))
-                        .max_by_key(|(p, _)| p.prefix_len())
+                        .filter(|(p, _, _)| p.contains(ue))
+                        .max_by_key(|(p, _, _)| p.prefix_len())
                 {
-                    desired.insert(*ue, *sid);
+                    desired.insert(*ue, (*sid, transport.clone()));
                 }
             }
         }
@@ -717,7 +725,7 @@ impl BgpVrf {
         let stale: Vec<ipnet::IpNet> = self
             .mup_st1_isd_installed
             .iter()
-            .filter(|(ue, sid)| desired.get(*ue) != Some(*sid))
+            .filter(|(ue, sid)| desired.get(*ue).map(|(s, _)| s) != Some(*sid))
             .map(|(ue, _)| *ue)
             .collect();
         for ue in stale {
@@ -725,46 +733,12 @@ impl BgpVrf {
             self.mup_st1_isd_installed.remove(&ue);
         }
         // Install new / changed entries.
-        for (ue, sid) in &desired {
+        for (ue, (sid, transport)) in &desired {
             if self.mup_st1_isd_installed.get(ue) == Some(sid) {
                 continue;
             }
-            self.mup_st1_isd_install(*ue, *sid);
+            self.mup_encap_install(*ue, *sid, transport);
             self.mup_st1_isd_installed.insert(*ue, *sid);
-        }
-    }
-
-    /// Build + send the oif-only recursive seg6 H.Encaps RibEntry for one
-    /// resolved ST1→ISD binding into this VRF's table. The local End.DT46
-    /// SID is delivered locally (its decap resolves to loopback), so the
-    /// encap route carries no gateway — just the loopback oif + the seg6
-    /// encap; the kernel re-routes the encapped packet by its outer SID DA
-    /// (see the oif-only branch in the netlink route path).
-    fn mup_st1_isd_install(&self, ue: ipnet::IpNet, sid: std::net::Ipv6Addr) {
-        use std::net::{IpAddr, Ipv6Addr};
-        let mut uni = crate::rib::NexthopUni::new(IpAddr::V6(Ipv6Addr::UNSPECIFIED), 0, Vec::new());
-        uni.ifindex_origin = Some(1); // loopback: the local SID is delivered locally
-        uni.segs = vec![sid];
-        uni.encap_type = Some(isis_packet::srv6::EncapType::HEncap);
-        uni.valid = true;
-        let mut entry = crate::rib::entry::RibEntry::new(crate::rib::RibType::Bgp);
-        entry.distance = 200;
-        entry.metric = 0;
-        entry.valid = true;
-        entry.nexthop = crate::rib::Nexthop::Uni(uni);
-        match ue {
-            ipnet::IpNet::V4(prefix) => {
-                let _ = self
-                    .ctx
-                    .rib
-                    .send(crate::rib::Message::Ipv4Add { prefix, rib: entry });
-            }
-            ipnet::IpNet::V6(prefix) => {
-                let _ = self
-                    .ctx
-                    .rib
-                    .send(crate::rib::Message::Ipv6Add { prefix, rib: entry });
-            }
         }
     }
 
@@ -799,11 +773,11 @@ impl BgpVrf {
     /// DSD is steered into that DSD's End.DT46 SID: install a resolved-
     /// underlay seg6 H.Encaps route for the ST2 endpoint (`dst = endpoint
     /// /32|/128, via <underlay egress> encap seg6 segs [SID]`) into this
-    /// VRF's table. Unlike ST1→ISD (a local SID, oif-only), the DSD is
-    /// remote, so the encap resolves through the global-supplied
-    /// `mup_dsd_transport`; an unresolved DSD next-hop yields no install.
-    /// Diff-gated against `mup_st2_dsd_installed`. Mirrors the show-side
-    /// ST2→DSD resolution in `render_mup_table`.
+    /// VRF's table. The DSD is remote, so the encap resolves through the
+    /// global-supplied `mup_segment_transport`; an unresolved DSD next-hop
+    /// yields no install. Diff-gated against `mup_st2_dsd_installed`. The
+    /// prefix-containment twin is `reconcile_mup_st1_isd`; both mirror the
+    /// show-side resolution in `render_mup_table`.
     fn reconcile_mup_st2_dsd(&mut self) {
         use std::net::Ipv6Addr;
         type Transport = Vec<crate::rib::nht::ResolvedNexthop>;
@@ -822,7 +796,7 @@ impl BgpVrf {
                 let Some((sid, _behavior)) = rib.attr.srv6_l3_sid() else {
                     continue;
                 };
-                let Some(transport) = self.mup_dsd_transport.get(&(*rd, prefix.clone())) else {
+                let Some(transport) = self.mup_segment_transport.get(&(*rd, prefix.clone())) else {
                     continue;
                 };
                 if transport.is_empty() {
@@ -863,26 +837,27 @@ impl BgpVrf {
             if self.mup_st2_dsd_installed.get(ep) == Some(sid) {
                 continue;
             }
-            self.mup_st2_dsd_install(*ep, *sid, transport);
+            self.mup_encap_install(*ep, *sid, transport);
             self.mup_st2_dsd_installed.insert(*ep, *sid);
         }
     }
 
-    /// Build + send the resolved-underlay seg6 H.Encaps RibEntry for one
-    /// ST2→DSD binding into this VRF's table. The remote DSD's End.DT46 SID
-    /// rides an `H.Encaps` toward the resolved underlay egress(es) — the
-    /// SRv6-L3VPN dataplane shape ([`build_srv6_vpn_fib_entry`]). A no-op
-    /// when the transport doesn't resolve to any egress.
-    fn mup_st2_dsd_install(
+    /// Build + send the resolved-underlay seg6 H.Encaps RibEntry for one MUP
+    /// encap binding (ST2→DSD endpoint or ST1→ISD UE prefix) into this VRF's
+    /// table. The remote segment's End.DT46 SID rides an `H.Encaps` toward
+    /// the resolved underlay egress(es) — the SRv6-L3VPN dataplane shape
+    /// ([`build_srv6_vpn_fib_entry`]). A no-op when the transport doesn't
+    /// resolve to any egress.
+    fn mup_encap_install(
         &self,
-        ep: ipnet::IpNet,
+        dst: ipnet::IpNet,
         sid: std::net::Ipv6Addr,
         transport: &[crate::rib::nht::ResolvedNexthop],
     ) {
         let Some(entry) = super::super::route::build_srv6_vpn_fib_entry(sid, transport) else {
             return;
         };
-        match ep {
+        match dst {
             ipnet::IpNet::V4(prefix) => {
                 let _ = self
                     .ctx
@@ -1895,15 +1870,19 @@ impl BgpVrf {
                 transport,
             } => {
                 let rd = self.rd.unwrap_or(rd);
-                // A received DSD carries the global-resolved underlay
-                // transport for its next-hop; stash it (keyed by the
-                // re-keyed rd + prefix) so `reconcile_mup_st2_dsd` can build
-                // the ST2 endpoint encap. Empty transport ⇒ unresolved.
-                if matches!(prefix, bgp_packet::MupPrefix::Dsd { .. }) {
+                // A received segment route (DSD/ISD) carries the
+                // global-resolved underlay transport for its next-hop; stash
+                // it (keyed by the re-keyed rd + prefix) so the ST2→DSD /
+                // ST1→ISD reconcile can build the endpoint / UE encap. Empty
+                // transport ⇒ unresolved.
+                if matches!(
+                    prefix,
+                    bgp_packet::MupPrefix::Dsd { .. } | bgp_packet::MupPrefix::Isd { .. }
+                ) {
                     if transport.is_empty() {
-                        self.mup_dsd_transport.remove(&(rd, prefix.clone()));
+                        self.mup_segment_transport.remove(&(rd, prefix.clone()));
                     } else {
-                        self.mup_dsd_transport
+                        self.mup_segment_transport
                             .insert((rd, prefix.clone()), transport);
                     }
                 }
@@ -1922,7 +1901,7 @@ impl BgpVrf {
                 // clears it; prune the per-RD table when it empties so an
                 // empty RD never renders.
                 let rd = self.rd.unwrap_or(rd);
-                self.mup_dsd_transport.remove(&(rd, prefix.clone()));
+                self.mup_segment_transport.remove(&(rd, prefix.clone()));
                 let empty = if let Some(table) = self.local_rib.mup.get_mut(&rd) {
                     table.cands.remove(&prefix);
                     table.selected.remove(&prefix);


### PR DESCRIPTION
## Summary

Revisit the ST1→ISD encap so the ISD is a **received (remote)** segment,
not a locally-originated one — making it symmetric with ST2→DSD. On an
interwork / UPF node a selected ST1 whose UE prefix is covered by an
imported ISD is steered into that ISD's End.DT46 SID via a resolved-underlay
SRv6 **H.Encaps** route (`dst = UE prefix, via <underlay egress> encap seg6
segs [SID]`), resolved through the IS-IS SRv6 underlay via Next-Hop
Tracking. ST1→ISD and ST2→DSD now share the segment-NHT +
transport-on-`MupUpdate` plumbing and the `mup_encap_install` /
`build_srv6_vpn_fib_entry` path.

### Code

- The segment-route NHT tracking (`mup_segment_track` / `_untrack`, née
  `mup_dsd_*`) and the per-VRF `mup_segment_transport` now cover ISD as well
  as DSD.
- `reconcile_mup_st1_isd` is rewritten to index imported ISDs (with a SID +
  a resolved transport), longest-match the ST1 UE prefix, and install
  through the shared `mup_encap_install`; the local oif-only builder is
  removed.
- The show-side ISD resolution (`render_mup_table`) no longer requires the
  ISD to be locally originated.
- NHT re-dispatch helper generalized (`mup_redispatch_segment`).

### Docs

- **book ch-02-35** — a "Resolving ST routes to a segment (forwarding)"
  subsection; "Scope and limitations" now says the SRv6 forwarding is
  installed and narrows the gap to the GTP-U endpoint behaviours.
- **book ch-14-02** — `show bgp mup` documents the `resolved …` line.
- **docs/design/bgp-mup-followups** — P6 slices 5 (ST1→ISD resolution+show)
  and 6 (SRv6 H.Encaps install) marked DONE; followup #2 (MUP NHT) closed;
  top-level P6 summary updated.

## Test plan

- `cargo fmt --all` + `cargo clippy --workspace --all-targets -- -D warnings`
  clean.
- Full workspace test suite (excl bdd) green — 1494 zebra-rs + all crates,
  0 failed.
- BDD `@bgp_mup_st1_isd` reworked from single-node to two-node and passed
  end-to-end (root netns, 23 steps): z1 (access PE) originates the ISD; z2
  (UPF + MUP-C, `encapsulation srv6`, import RT) imports it, originates the
  ST1, resolves `10.60.1.5/32 -> End.DT46`, and installs
  `10.60.1.5 encap seg6 mode encap segs 1 [ fcbb:bbbb:1:40:: ] via <underlay>`
  into the VRF table. (BDD is CI-excluded; run locally.)

Generated with [Claude Code](https://claude.com/claude-code)