### PR TITLE
bgp/mup: key ST1->ISD resolution on the endpoint, not the UE prefix

### DIFF
--- a/bdd/tests/configs/bgp_mup_st1_isd/z1.yaml
+++ b/bdd/tests/configs/bgp_mup_st1_isd/z1.yaml
@@ -1,5 +1,6 @@
 # z1 — MUP PE originating an Interwork Segment Discovery (ISD, type 1)
-# route for VRF N6 (`afi-safi mup segment interwork prefix 10.60.0.0/16`).
+# route for VRF N6 (`afi-safi mup segment interwork prefix 10.0.0.0/24` —
+# the gNB N3 network the ST1 endpoints resolve against).
 # IS-IS L2 SRv6 underlay + iBGP (mup afi-safi) to z2 over loopbacks. VRF N6
 # is `encapsulation srv6`, so it carves a per-VRF End.DT46 service SID from
 # locator S and installs the seg6local decap into the VRF table; `segment
@@ -70,4 +71,4 @@ router:
         mup:
           segment:
           - type: interwork
-            prefix: 10.60.0.0/16
+            prefix: 10.0.0.0/24

--- a/bdd/tests/configs/bgp_mup_st1_isd/z2.yaml
+++ b/bdd/tests/configs/bgp_mup_st1_isd/z2.yaml
@@ -1,12 +1,12 @@
 # z2 — MUP interwork / UPF node. Its MUP-C originates a Type-1 ST (ST1)
 # route from a PFCP session on NI `access` (`afi-safi mup route st1`), and
 # VRF N6 (rd 65501:20, `encapsulation srv6`, import RT 65501:10) imports
-# z1's ISD (Interwork Segment Discovery, prefix 10.60.0.0/16 + End.DT46 SID
-# from z1's locator S). Because the ST1's UE (10.60.1.5) is covered by the
-# ISD prefix, z2 resolves the ST1 to z1's *remote* segment and installs an
-# SRv6 H.Encaps route for the UE into the VRF table, resolved through the
-# IS-IS SRv6 underlay toward z1:
-#   10.60.1.5/32 via <z1 underlay> encap seg6 segs [z1 End.DT46 SID]
+# z1's ISD (Interwork Segment Discovery, prefix 10.0.0.0/24 + End.DT46 SID
+# from z1's locator S). Because the ST1's gNB endpoint (10.0.0.1) is covered
+# by the ISD prefix (the gNB N3 network), z2 resolves the ST1 to z1's
+# *remote* segment and installs an SRv6 H.Encaps route for the endpoint into
+# the VRF table, resolved through the IS-IS SRv6 underlay toward z1:
+#   10.0.0.1/32 via <z1 underlay> encap seg6 segs [z1 End.DT46 SID]
 interface:
 - if-name: lo
   ipv6:

--- a/bdd/tests/features/bgp_mup_st1_isd.feature
+++ b/bdd/tests/features/bgp_mup_st1_isd.feature
@@ -2,12 +2,13 @@
 @bgp_mup_st1_isd
 Feature: BGP MUP ST1 resolves to a remote ISD segment and installs SRv6 encap
   An interwork / UPF node imports a remote Interwork Segment Discovery (ISD,
-  type 1, SAFI 85 / draft-ietf-bess-mup-safi) route and — via its MUP
-  controller — originates a Type-1 Session-Transformed (ST1) route whose UE
-  address falls inside the ISD's advertised prefix. Because the UE is covered
-  by the (remote) ISD, the node resolves the ST1 to the ISD's End.DT46
-  segment and installs an SRv6 H.Encaps route for the UE prefix into the VRF
-  table, resolved through the IS-IS SRv6 underlay toward the ISD's next-hop.
+  type 1, SAFI 85 / draft-ietf-bess-mup-safi) route — whose prefix is the gNB
+  N3 network — and — via its MUP controller — originates a Type-1
+  Session-Transformed (ST1) route whose GTP endpoint (gNB) address falls
+  inside that prefix. Because the endpoint is covered by the (remote) ISD,
+  the node resolves the ST1 to the ISD's End.DT46 segment and installs an
+  SRv6 H.Encaps route for the endpoint into the VRF table, resolved through
+  the IS-IS SRv6 underlay toward the ISD's next-hop.
 
   Test Topology:
   ```
@@ -20,12 +21,12 @@ Feature: BGP MUP ST1 resolves to a remote ISD segment and installs SRv6 encap
    z1-z2 2001:db8:0:12::1/64   2001:db8:0:12::2/64
   ```
 
-  z1 (VRF N6, rd 65501:10, `segment interwork prefix 10.60.0.0/16`, export RT
+  z1 (VRF N6, rd 65501:10, `segment interwork prefix 10.0.0.0/24`, export RT
   65501:10) originates the ISD (End.DT46 SID from locator S). z2 (VRF N6, rd
   65501:20, `encapsulation srv6`, import RT 65501:10) imports the ISD and,
-  from a PFCP session on NI `access`, originates an ST1 (UE 10.60.1.5, inside
-  10.60.0.0/16). z2 resolves the ST1 to z1's Direct segment and installs the
-  UE encap.
+  from a PFCP session on NI `access`, originates an ST1 (UE 10.60.1.5, gNB
+  endpoint 10.0.0.1 inside 10.0.0.0/24). z2 resolves the ST1's endpoint to
+  z1's segment and installs the endpoint encap.
 
   NOTE: needs `pfcp-inject` on the BDD host PATH and root netns (kernel VRF +
   seg6 + IS-IS SRv6 underlay).
@@ -43,19 +44,19 @@ Feature: BGP MUP ST1 resolves to a remote ISD segment and installs SRv6 encap
     Then BGP session in "z1" to "2001:db8::2" should be "Established"
     And BGP session in "z2" to "2001:db8::1" should be "Established"
     # z2 imports z1's ISD (re-keyed under its own rd 65501:20).
-    And show command "show bgp vrf N6 mup" in namespace "z2" should eventually contain "[ISD][65501:20][10.60.0.0/16]"
+    And show command "show bgp vrf N6 mup" in namespace "z2" should eventually contain "[ISD][65501:20][10.0.0.0/24]"
 
   Scenario: z2 resolves the ST1 to z1's ISD segment and installs the encap
     Given the test topology exists
     When I execute "pfcp-inject --target 127.0.0.1 --port 8805 --ue-ipv4 10.60.1.5 --teid 0x12345678 --endpoint 10.0.0.1 --network-instance access" in namespace "z2"
-    # The ST1's UE (10.60.1.5) is covered by the ISD 10.60.0.0/16, so the
-    # per-VRF view shows the resolution to the ISD's End.DT46 segment.
-    Then show command "show bgp vrf N6 mup" in namespace "z2" should eventually contain "resolved 10.60.1.5/32 -> End.DT46"
-    # The SRv6 H.Encaps route for the UE is installed into the VRF table,
-    # resolved through the underlay toward z1's End.DT46 SID (locator S =
-    # fcbb:bbbb:1::/48).
+    # The ST1's gNB endpoint (10.0.0.1) is covered by the ISD 10.0.0.0/24, so
+    # the per-VRF view shows the resolution to the ISD's End.DT46 segment.
+    Then show command "show bgp vrf N6 mup" in namespace "z2" should eventually contain "resolved 10.0.0.1 -> End.DT46"
+    # The SRv6 H.Encaps route for the endpoint is installed into the VRF
+    # table, resolved through the underlay toward z1's End.DT46 SID (locator S
+    # = fcbb:bbbb:1::/48).
     And command "ip route show table all" in namespace "z2" should eventually contain "encap seg6 mode encap segs 1 [ fcbb:bbbb:1:"
-    And command "ip route show table all" in namespace "z2" should eventually contain "10.60.1.5"
+    And command "ip route show table all" in namespace "z2" should eventually contain "10.0.0.1"
 
   Scenario: Teardown topology
     Given the test topology exists

--- a/book/src/ch-02-35-bgp-mup.md
+++ b/book/src/ch-02-35-bgp-mup.md
@@ -200,11 +200,12 @@ it:
   **Direct-segment id**.
 * **`segment interwork { prefix <p>; }`** originates an **Interwork Segment
   Discovery (ISD, type 1)** route — NLRI = RD + the configured `prefix`
-  (typically the locally connected gNodeB N3 prefix; its family selects the
-  AFI) — carrying the End.DT46 SID. The ISD does not originate until the
-  prefix is set, and carries no `mup-ext-comm`: a receiving interwork node
-  matches each received **ST1** to the ISD by **prefix containment**
-  (longest-match when several ISDs cover the UE).
+  (the locally connected **gNodeB N3 network**; its family selects the AFI) —
+  carrying the End.DT46 SID. The ISD does not originate until the prefix is
+  set, and carries no `mup-ext-comm`: a receiving interwork node matches each
+  received **ST1** to the ISD by **endpoint containment** — the ST1's GTP
+  endpoint (gNB) address falling inside the ISD prefix (longest-match when
+  several ISDs cover the endpoint).
 
 ```
 vrf N6 {
@@ -212,7 +213,7 @@ vrf N6 {
   encapsulation srv6;
   afi-safi mup {
     segment interwork {
-      prefix 10.60.0.0/16;     # originate the End.DT46 ISD under this prefix
+      prefix 10.0.0.0/24;      # the gNB N3 network the ST1 endpoints resolve against
     }
   }
 }
@@ -223,10 +224,11 @@ vrf N6 {
 An interwork node imports the ST routes **and** the segment routes into a
 forwarding VRF (`encapsulation srv6` + a matching `route-target import`),
 resolves each ST route to its segment, and installs an SRv6 **H.Encaps**
-route for the ST route's destination into the VRF table:
+route for the ST route's **endpoint** into the VRF table:
 
 * **ST2 → DSD** (by Direct-segment id): `dst = the ST2 endpoint /32|/128`.
-* **ST1 → ISD** (by prefix containment): `dst = the ST1 UE prefix`.
+* **ST1 → ISD** (the ST1's gNB endpoint contained in the ISD prefix):
+  `dst = the ST1 endpoint /32|/128`.
 
 The segment is **remote** (received from the peer that owns the End.DT46
 SID), so the encap resolves through the IS-IS SRv6 underlay via Next-Hop

--- a/docs/design/bgp-mup-followups.md
+++ b/docs/design/bgp-mup-followups.md
@@ -578,12 +578,15 @@ sibling of the slice-1 DSD:
 #### P6 slice 5 — ST1 → ISD resolution + show — **DONE**
 
 The prefix-containment twin of slice 3's ST2 → DSD resolution: a selected
-ST1 whose UE prefix is covered (longest-match) by an ISD's advertised
-prefix resolves to that ISD's End.DT46 segment. `render_mup_table` indexes
-the ISD routes by prefix and prints `resolved <ue> -> End.DT46 <sid> (via
-[ISD]…)` in `show bgp mup` / `show bgp vrf <name> mup`. Matched by prefix
-containment (no MUP Extended Community). A `render_mup_table` unit test
-covers in-range resolve, out-of-range no-resolve, and the opt-in gate.
+ST1 whose **GTP endpoint (gNB) address** is covered (longest-match) by an
+ISD's advertised prefix (the gNB N3 network) resolves to that ISD's End.DT46
+segment. The key is the ST1 *endpoint*, not the UE prefix — mirroring
+ST2 → DSD's endpoint dst, and it handles the mixed-AFI case (an IPv6 UE route
+carrying an IPv4 gNB endpoint). `render_mup_table` indexes the ISD routes by
+prefix and prints `resolved <endpoint> -> End.DT46 <sid> (via [ISD]…)` in
+`show bgp mup` / `show bgp vrf <name> mup` (no MUP Extended Community). A
+`render_mup_table` unit test covers in-range resolve, out-of-range
+no-resolve, and the opt-in gate.
 
 #### P6 slice 6 — SRv6 forwarding install (ST → segment H.Encaps) — **DONE**
 
@@ -591,10 +594,11 @@ The interwork node now programs the FIB for each resolved ST route. On a
 **forwarding VRF** (`encapsulation srv6` + `route-target import`) the ST
 routes and the segment routes both land in the per-VRF MUP RIB, and the
 per-VRF task installs an SRv6 **H.Encaps** route for the ST route's
-destination into the VRF table:
+**endpoint** into the VRF table:
 
 - **ST2 → DSD** (by Direct-segment id): `dst = the ST2 endpoint /32|/128`.
-- **ST1 → ISD** (by prefix containment): `dst = the ST1 UE prefix`.
+- **ST1 → ISD** (ST1 gNB endpoint contained in the ISD prefix):
+  `dst = the ST1 endpoint /32|/128`.
 
 The segment is **remote** (received from the peer owning the End.DT46 SID),
 so the encap resolves through the underlay via **Next-Hop Tracking** — this

--- a/zebra-rs/src/bgp/show.rs
+++ b/zebra-rs/src/bgp/show.rs
@@ -4396,21 +4396,24 @@ fn render_mup_table(
                 )?;
             }
 
-            // ST1 -> ISD resolution on the ISD's originating node: a selected
-            // ST1 whose UE prefix is covered by a local ISD's prefix is
-            // encapsulated into that ISD's End.DT46 segment (longest-match
-            // when several ISDs cover the UE).
+            // ST1 -> ISD resolution: a selected ST1 whose GTP endpoint (gNB)
+            // address falls within an ISD's advertised prefix (the gNB N3
+            // network) is encapsulated toward that ISD's End.DT46 segment
+            // (longest-match when several ISDs cover the endpoint). The key
+            // is the ST1 *endpoint*, not the UE prefix — mirroring ST2->DSD
+            // (`dst = the ST route's endpoint`) and handling the mixed-AFI
+            // case (an IPv6 UE route may carry an IPv4 gNB endpoint).
             if resolve_segments
-                && let MupPrefix::T1st { prefix: ue, .. } = prefix
+                && let MupPrefix::T1st { endpoint, .. } = prefix
                 && let Some((isd_rd, isd, _, sid, behavior)) = isd_index
                     .iter()
-                    .filter(|(_, _, isd_prefix, _, _)| isd_prefix.contains(ue))
+                    .filter(|(_, _, isd_prefix, _, _)| isd_prefix.contains(endpoint))
                     .max_by_key(|(_, _, isd_prefix, _, _)| isd_prefix.prefix_len())
             {
                 writeln!(
                     buf,
                     "       resolved {} -> {} {} (via {})",
-                    ue,
+                    endpoint,
                     srv6_behavior_name(*behavior),
                     sid,
                     mup_prefix_display(isd_rd, isd)
@@ -5834,7 +5837,8 @@ mod detail_tests {
             super::super::route::LocalRibMupTable,
         > = std::collections::BTreeMap::new();
 
-        // A received ISD advertising 10.60.0.0/16 + an End.DT46 SID.
+        // A received ISD advertising the gNB N3 network 10.0.0.0/24 + an
+        // End.DT46 SID.
         let mut isd_attr = BgpAttr::new();
         isd_attr.nexthop = Some(BgpNexthop::Ipv6("fcbb:bbbb:1::".parse().unwrap()));
         isd_attr.prefix_sid = Some(super::super::inst::srv6_l3_service_prefix_sid(
@@ -5857,14 +5861,15 @@ mod detail_tests {
             id: 0,
             arch: MupArchitectureType::Gpp5g,
             rd: "65501:10".parse().unwrap(),
-            prefix: "10.60.0.0/16".parse().unwrap(),
+            prefix: "10.0.0.0/24".parse().unwrap(),
         });
         let _ = tables
             .entry(isd_rd)
             .or_default()
             .update(isd_prefix, isd_rib);
 
-        // An ST1 whose UE (10.60.1.5/32) falls inside the ISD prefix.
+        // An ST1 whose gNB endpoint (10.0.0.9) falls inside the ISD prefix —
+        // the UE (10.60.1.5/32) is a different network and is not the key.
         let st1_in = mup_rib("fc00::9".parse::<IpAddr>().unwrap(), 32768, &[]);
         let (rd_in, p_in) = MupPrefix::from_route(&MupRoute::T1st {
             id: 0,
@@ -5878,16 +5883,17 @@ mod detail_tests {
         });
         let _ = tables.entry(rd_in).or_default().update(p_in, st1_in);
 
-        // An ST1 whose UE (10.70.1.5/32) is outside the ISD prefix.
+        // An ST1 whose gNB endpoint (10.70.0.9) is outside the ISD prefix,
+        // even though its UE happens to sit in a nearby network.
         let st1_out = mup_rib("fc00::a".parse::<IpAddr>().unwrap(), 32768, &[]);
         let (rd_out, p_out) = MupPrefix::from_route(&MupRoute::T1st {
             id: 0,
             arch: MupArchitectureType::Gpp5g,
             rd: "65501:10".parse().unwrap(),
-            prefix: "10.70.1.5/32".parse().unwrap(),
+            prefix: "10.60.2.5/32".parse().unwrap(),
             teid: 2,
             qfi: 9,
-            endpoint: "10.0.0.10".parse().unwrap(),
+            endpoint: "10.70.0.9".parse().unwrap(),
             source: None,
         });
         let _ = tables.entry(rd_out).or_default().update(p_out, st1_out);
@@ -5896,16 +5902,17 @@ mod detail_tests {
         let plain = render_mup_table(&tables, false).unwrap();
         assert!(!plain.contains("resolved"), "{plain}");
 
-        // Opted in: the in-range ST1 resolves to the ISD's End.DT46 segment;
-        // the out-of-range ST1 does not.
+        // Opted in: the ST1 whose endpoint is in-range resolves to the ISD's
+        // End.DT46 segment (keyed on the endpoint, not the UE prefix); the
+        // out-of-range endpoint does not.
         let out = render_mup_table(&tables, true).unwrap();
         assert!(
             out.contains(
-                "resolved 10.60.1.5/32 -> End.DT46 fcbb:bbbb:1:40:: (via [ISD][65501:10][10.60.0.0/16])"
+                "resolved 10.0.0.9 -> End.DT46 fcbb:bbbb:1:40:: (via [ISD][65501:10][10.0.0.0/24])"
             ),
             "{out}"
         );
-        assert!(!out.contains("resolved 10.70.1.5/32"), "{out}");
+        assert!(!out.contains("resolved 10.70.0.9"), "{out}");
     }
 
     #[test]

--- a/zebra-rs/src/bgp/vrf/inst.rs
+++ b/zebra-rs/src/bgp/vrf/inst.rs
@@ -161,13 +161,13 @@ pub struct BgpVrf {
     /// (direct↔interwork switch / router-id change) withdraws this prior one
     /// first.
     pub mup_segment_prefix: Option<bgp_packet::MupPrefix>,
-    /// Installed ST1→ISD encap FIB entries: UE prefix → the local ISD's
-    /// End.DT46 SID it is steered into. A selected ST1 whose UE prefix is
-    /// covered by a locally-originated ISD's prefix installs an oif-only
-    /// recursive seg6 H.Encaps route into this VRF's table (`dst = UE
-    /// prefix, via <underlay egress> encap seg6 segs [SID]`). Tracked so
-    /// `reconcile_mup_st1_isd` can diff and withdraw when the ST1 or the
-    /// covering ISD goes away.
+    /// Installed ST1→ISD encap FIB entries: ST1 endpoint host prefix → the
+    /// ISD's End.DT46 SID it is steered into. A selected ST1 whose GTP
+    /// endpoint (gNB) address is covered by an imported ISD's prefix installs
+    /// a resolved-underlay seg6 H.Encaps route into this VRF's table (`dst =
+    /// endpoint /32|/128, via <underlay egress> encap seg6 segs [SID]`).
+    /// Tracked so `reconcile_mup_st1_isd` can diff and withdraw when the ST1
+    /// or the covering ISD goes away.
     pub mup_st1_isd_installed: std::collections::BTreeMap<ipnet::IpNet, std::net::Ipv6Addr>,
     /// Resolved underlay transport for each imported segment route (DSD/ISD)
     /// next-hop, keyed by its `(rd, prefix)`. Supplied by the global NHT via
@@ -671,16 +671,17 @@ impl BgpVrf {
     }
 
     /// Reconcile ST1→ISD encap FIB entries for this VRF. A selected ST1
-    /// whose UE prefix is covered (longest-match) by an imported ISD's prefix
-    /// is steered into that ISD's End.DT46 SID: install a resolved-underlay
-    /// seg6 H.Encaps route for the UE prefix (`dst = UE prefix, via <underlay
-    /// egress> encap seg6 segs [SID]`) into this VRF's table so UE-bound
-    /// traffic in the VRF is encapsulated toward that segment. The ISD is
-    /// remote (received from the access-side PE), so the encap resolves
-    /// through the global-supplied `mup_segment_transport`; an unresolved ISD
-    /// next-hop yields no install. Diff-gated against `mup_st1_isd_installed`.
-    /// Mirrors the show-side resolution in `render_mup_table` and the ST2→DSD
-    /// reconcile (matched by prefix containment instead of Direct-segment id).
+    /// whose GTP endpoint (gNB) address is covered (longest-match) by an
+    /// imported ISD's prefix (the gNB N3 network) is steered into that ISD's
+    /// End.DT46 SID: install a resolved-underlay seg6 H.Encaps route for the
+    /// endpoint (`dst = endpoint /32|/128, via <underlay egress> encap seg6
+    /// segs [SID]`) into this VRF's table. The ISD is remote (received from
+    /// the access-side PE), so the encap resolves through the global-supplied
+    /// `mup_segment_transport`; an unresolved ISD next-hop yields no install.
+    /// Diff-gated against `mup_st1_isd_installed`. Mirrors the show-side
+    /// resolution in `render_mup_table` and the ST2→DSD reconcile — both key
+    /// on the ST route's endpoint, ST2→DSD matching by Direct-segment id and
+    /// ST1→ISD by the endpoint's containment in the ISD prefix.
     fn reconcile_mup_st1_isd(&mut self) {
         use std::net::Ipv6Addr;
         type Transport = Vec<crate::rib::nht::ResolvedNexthop>;
@@ -711,13 +712,17 @@ impl BgpVrf {
             std::collections::BTreeMap::new();
         if !isd_index.is_empty() {
             for (prefix, _rib) in self.local_rib.mup.values().flat_map(|t| t.selected.iter()) {
-                if let bgp_packet::MupPrefix::T1st { prefix: ue, .. } = prefix
+                // Key on the ST1 GTP endpoint (gNB), not the UE prefix: the
+                // ISD advertises the gNB N3 network, so the endpoint is what
+                // falls inside it (mirrors ST2->DSD's endpoint dst, and works
+                // for a mixed-AFI IPv6-UE / IPv4-endpoint route).
+                if let bgp_packet::MupPrefix::T1st { endpoint, .. } = prefix
                     && let Some((_p, sid, transport)) = isd_index
                         .iter()
-                        .filter(|(p, _, _)| p.contains(ue))
+                        .filter(|(p, _, _)| p.contains(endpoint))
                         .max_by_key(|(p, _, _)| p.prefix_len())
                 {
-                    desired.insert(*ue, (*sid, transport.clone()));
+                    desired.insert(host_net(*endpoint), (*sid, transport.clone()));
                 }
             }
         }


### PR DESCRIPTION
## Summary

Fix the ST1→ISD resolution: match the ST1's **GTP endpoint (gNB) address**
against the ISD's advertised prefix (the gNB N3 network), **not** the UE
prefix. The ISD prefix *is* the gNB N3 network, so it's the endpoint that
falls inside it — matching the UE prefix never resolved (a UE address is a
different network), and it also broke the mixed-AFI case (an IPv6 UE route
carrying an IPv4 gNB endpoint).

Confirmed against **draft-ietf-bess-mup-safi §3.3.9**:

> "the PE SHOULD use the received **Tunnel Endpoint Address** in this NLRI as
> a key to lookup the associated Interwork Segment Discovery route and
> extract the locator and the function in the prefix SID attribute."

The installed encap keys on the endpoint (`dst = endpoint /32|/128`),
symmetric with ST2→DSD. (The draft pins the lookup key but not the FIB
destination prefix — the SRv6-mobile forwarding is deferred to
`draft-ietf-dmm-srv6-mobile-uplane`; `dst = endpoint` is the chosen,
ST2→DSD-symmetric approximation.)

## Changes

- `render_mup_table` (show) + `reconcile_mup_st1_isd` (FIB) now match and key
  on `T1st.endpoint`; the resolved line prints the endpoint.
- Unit test reworked: ISD = gNB N3 net `10.0.0.0/24`, ST1 endpoint
  `10.0.0.9` in-range (UE `10.60.1.5` out-of-range), plus a second ST1 whose
  endpoint is out-of-range.
- BDD `@bgp_mup_st1_isd`: z1's ISD prefix is now `10.0.0.0/24`; the ST1's
  endpoint `10.0.0.1` resolves and installs `10.0.0.1/32 … encap seg6 …`.
- book + design docs updated (endpoint-keyed resolution; `dst = endpoint`).

## Test plan

- `cargo fmt --all` + `cargo clippy --workspace --all-targets -- -D warnings`
  clean.
- Full workspace test suite (excl bdd) green — 1494 zebra-rs + all crates,
  0 failed.
- BDD `@bgp_mup_st1_isd` passed end-to-end (root netns, 23 steps): z2
  imports `[ISD][65501:20][10.0.0.0/24]`, resolves `10.0.0.1 -> End.DT46`,
  and installs `10.0.0.1/32 encap seg6 mode encap segs 1 [ fcbb:bbbb:1:40:: ]
  via <underlay>`. (BDD is CI-excluded; run locally.)

Generated with [Claude Code](https://claude.com/claude-code)