### PR TITLE
bgp/mup: ST1->ISD FIB destination is the UE prefix, not the endpoint

### DIFF
--- a/bdd/tests/configs/bgp_mup_st1_isd/z2.yaml
+++ b/bdd/tests/configs/bgp_mup_st1_isd/z2.yaml
@@ -4,9 +4,10 @@
 # z1's ISD (Interwork Segment Discovery, prefix 10.0.0.0/24 + End.DT46 SID
 # from z1's locator S). Because the ST1's gNB endpoint (10.0.0.1) is covered
 # by the ISD prefix (the gNB N3 network), z2 resolves the ST1 to z1's
-# *remote* segment and installs an SRv6 H.Encaps route for the endpoint into
-# the VRF table, resolved through the IS-IS SRv6 underlay toward z1:
-#   10.0.0.1/32 via <z1 underlay> encap seg6 segs [z1 End.DT46 SID]
+# *remote* segment and installs an SRv6 H.Encaps route for the ST1's UE
+# prefix into the VRF table (endpoint = lookup key, UE prefix = forwarded
+# destination), resolved through the IS-IS SRv6 underlay toward z1:
+#   10.60.1.5/32 via <z1 underlay> encap seg6 segs [z1 End.DT46 SID]
 interface:
 - if-name: lo
   ipv6:

--- a/bdd/tests/features/bgp_mup_st1_isd.feature
+++ b/bdd/tests/features/bgp_mup_st1_isd.feature
@@ -7,8 +7,9 @@ Feature: BGP MUP ST1 resolves to a remote ISD segment and installs SRv6 encap
   Session-Transformed (ST1) route whose GTP endpoint (gNB) address falls
   inside that prefix. Because the endpoint is covered by the (remote) ISD,
   the node resolves the ST1 to the ISD's End.DT46 segment and installs an
-  SRv6 H.Encaps route for the endpoint into the VRF table, resolved through
-  the IS-IS SRv6 underlay toward the ISD's next-hop.
+  SRv6 H.Encaps route for the ST1's **UE prefix** into the VRF table (the
+  endpoint is the lookup key; the UE prefix is the forwarded destination),
+  resolved through the IS-IS SRv6 underlay toward the ISD's next-hop.
 
   Test Topology:
   ```
@@ -26,7 +27,7 @@ Feature: BGP MUP ST1 resolves to a remote ISD segment and installs SRv6 encap
   65501:20, `encapsulation srv6`, import RT 65501:10) imports the ISD and,
   from a PFCP session on NI `access`, originates an ST1 (UE 10.60.1.5, gNB
   endpoint 10.0.0.1 inside 10.0.0.0/24). z2 resolves the ST1's endpoint to
-  z1's segment and installs the endpoint encap.
+  z1's segment and installs the UE-prefix encap.
 
   NOTE: needs `pfcp-inject` on the BDD host PATH and root netns (kernel VRF +
   seg6 + IS-IS SRv6 underlay).
@@ -50,13 +51,14 @@ Feature: BGP MUP ST1 resolves to a remote ISD segment and installs SRv6 encap
     Given the test topology exists
     When I execute "pfcp-inject --target 127.0.0.1 --port 8805 --ue-ipv4 10.60.1.5 --teid 0x12345678 --endpoint 10.0.0.1 --network-instance access" in namespace "z2"
     # The ST1's gNB endpoint (10.0.0.1) is covered by the ISD 10.0.0.0/24, so
-    # the per-VRF view shows the resolution to the ISD's End.DT46 segment.
-    Then show command "show bgp vrf N6 mup" in namespace "z2" should eventually contain "resolved 10.0.0.1 -> End.DT46"
-    # The SRv6 H.Encaps route for the endpoint is installed into the VRF
+    # the per-VRF view resolves the UE prefix to the ISD's End.DT46 segment
+    # (keyed on the endpoint, forwarding the UE prefix).
+    Then show command "show bgp vrf N6 mup" in namespace "z2" should eventually contain "resolved 10.60.1.5/32 (endpoint 10.0.0.1) -> End.DT46"
+    # The SRv6 H.Encaps route for the UE prefix is installed into the VRF
     # table, resolved through the underlay toward z1's End.DT46 SID (locator S
     # = fcbb:bbbb:1::/48).
     And command "ip route show table all" in namespace "z2" should eventually contain "encap seg6 mode encap segs 1 [ fcbb:bbbb:1:"
-    And command "ip route show table all" in namespace "z2" should eventually contain "10.0.0.1"
+    And command "ip route show table all" in namespace "z2" should eventually contain "10.60.1.5"
 
   Scenario: Teardown topology
     Given the test topology exists

--- a/book/src/ch-02-35-bgp-mup.md
+++ b/book/src/ch-02-35-bgp-mup.md
@@ -226,9 +226,12 @@ forwarding VRF (`encapsulation srv6` + a matching `route-target import`),
 resolves each ST route to its segment, and installs an SRv6 **H.Encaps**
 route for the ST route's **endpoint** into the VRF table:
 
-* **ST2 → DSD** (by Direct-segment id): `dst = the ST2 endpoint /32|/128`.
-* **ST1 → ISD** (the ST1's gNB endpoint contained in the ISD prefix):
-  `dst = the ST1 endpoint /32|/128`.
+* **ST2 → DSD** — matched by Direct-segment id; `dst = the ST2 endpoint
+  /32|/128` (the uplink core endpoint; the ST2 carries no UE prefix).
+* **ST1 → ISD** — matched by the ST1's gNB **endpoint** contained in the ISD
+  prefix (the lookup key, draft §3.3.9); `dst = the ST1 **UE prefix**` (the
+  Prefix field, §3.1.3) — downlink traffic to the UE is steered toward the
+  gNB's segment.
 
 The segment is **remote** (received from the peer that owns the End.DT46
 SID), so the encap resolves through the IS-IS SRv6 underlay via Next-Hop

--- a/book/src/ch-14-02-show-bgp.md
+++ b/book/src/ch-14-02-show-bgp.md
@@ -121,10 +121,12 @@ JSON: an array of `{ nlri_type, nlri, neighbor, best }`.
 The Mobile User Plane Loc-RIB (SAFI 85): Direct-Segment, ISD, and
 Type-1/Type-2 Session-Transformed routes. `summary` shows the
 IPv4-MUP / IPv6-MUP neighbor sections. On an interwork node, each ST route
-resolved to its segment prints a `resolved <key> -> End.DT46 <sid> (via
-[DSD|ISD]…)` line (ST2→DSD by Direct-segment id, ST1→ISD by prefix
-containment); the per-VRF `show bgp vrf <name> mup` shows the same for a
-forwarding VRF. See [Mobile User Plane (MUP)](ch-02-35-bgp-mup.md).
+resolved to its segment prints a `resolved … -> End.DT46 <sid> (via
+[DSD|ISD]…)` line — ST2→DSD as `resolved <ep> -> …` (matched by
+Direct-segment id), ST1→ISD as `resolved <ue> (endpoint <ep>) -> …` (the gNB
+endpoint is the lookup key, the UE prefix the forwarded destination); the
+per-VRF `show bgp vrf <name> mup` shows the same for a forwarding VRF. See
+[Mobile User Plane (MUP)](ch-02-35-bgp-mup.md).
 
 ### `show bgp mup-c [session|association]`
 

--- a/docs/design/bgp-mup-followups.md
+++ b/docs/design/bgp-mup-followups.md
@@ -580,10 +580,11 @@ sibling of the slice-1 DSD:
 The prefix-containment twin of slice 3's ST2 → DSD resolution: a selected
 ST1 whose **GTP endpoint (gNB) address** is covered (longest-match) by an
 ISD's advertised prefix (the gNB N3 network) resolves to that ISD's End.DT46
-segment. The key is the ST1 *endpoint*, not the UE prefix — mirroring
-ST2 → DSD's endpoint dst, and it handles the mixed-AFI case (an IPv6 UE route
-carrying an IPv4 gNB endpoint). `render_mup_table` indexes the ISD routes by
-prefix and prints `resolved <endpoint> -> End.DT46 <sid> (via [ISD]…)` in
+segment. The *lookup key* is the ST1 endpoint, not the UE prefix (draft
+§3.3.9), which also handles the mixed-AFI case (an IPv6 UE route carrying an
+IPv4 gNB endpoint); the *forwarding destination* is the UE prefix (the Prefix
+field, §3.1.3). `render_mup_table` indexes the ISD routes by prefix and
+prints `resolved <ue> (endpoint <ep>) -> End.DT46 <sid> (via [ISD]…)` in
 `show bgp mup` / `show bgp vrf <name> mup` (no MUP Extended Community). A
 `render_mup_table` unit test covers in-range resolve, out-of-range
 no-resolve, and the opt-in gate.
@@ -596,9 +597,10 @@ routes and the segment routes both land in the per-VRF MUP RIB, and the
 per-VRF task installs an SRv6 **H.Encaps** route for the ST route's
 **endpoint** into the VRF table:
 
-- **ST2 → DSD** (by Direct-segment id): `dst = the ST2 endpoint /32|/128`.
-- **ST1 → ISD** (ST1 gNB endpoint contained in the ISD prefix):
-  `dst = the ST1 endpoint /32|/128`.
+- **ST2 → DSD** (by Direct-segment id): `dst = the ST2 endpoint /32|/128`
+  (uplink; the ST2 carries no UE prefix).
+- **ST1 → ISD** (lookup key = the ST1 gNB endpoint contained in the ISD
+  prefix): `dst = the ST1 UE prefix` (downlink to the UE).
 
 The segment is **remote** (received from the peer owning the End.DT46 SID),
 so the encap resolves through the underlay via **Next-Hop Tracking** — this

--- a/zebra-rs/src/bgp/show.rs
+++ b/zebra-rs/src/bgp/show.rs
@@ -4398,13 +4398,19 @@ fn render_mup_table(
 
             // ST1 -> ISD resolution: a selected ST1 whose GTP endpoint (gNB)
             // address falls within an ISD's advertised prefix (the gNB N3
-            // network) is encapsulated toward that ISD's End.DT46 segment
-            // (longest-match when several ISDs cover the endpoint). The key
-            // is the ST1 *endpoint*, not the UE prefix — mirroring ST2->DSD
-            // (`dst = the ST route's endpoint`) and handling the mixed-AFI
-            // case (an IPv6 UE route may carry an IPv4 gNB endpoint).
+            // network) has its UE prefix encapsulated toward that ISD's
+            // End.DT46 segment (longest-match when several ISDs cover the
+            // endpoint). The lookup *key* is the ST1 endpoint (draft §3.3.9),
+            // but the forwarding destination is the UE prefix (the Prefix
+            // field, §3.1.3) — downlink traffic to the UE is steered toward
+            // the gNB's segment. Matching by the endpoint also handles the
+            // mixed-AFI case (an IPv6 UE route may carry an IPv4 gNB endpoint).
             if resolve_segments
-                && let MupPrefix::T1st { endpoint, .. } = prefix
+                && let MupPrefix::T1st {
+                    prefix: ue,
+                    endpoint,
+                    ..
+                } = prefix
                 && let Some((isd_rd, isd, _, sid, behavior)) = isd_index
                     .iter()
                     .filter(|(_, _, isd_prefix, _, _)| isd_prefix.contains(endpoint))
@@ -4412,7 +4418,8 @@ fn render_mup_table(
             {
                 writeln!(
                     buf,
-                    "       resolved {} -> {} {} (via {})",
+                    "       resolved {} (endpoint {}) -> {} {} (via {})",
+                    ue,
                     endpoint,
                     srv6_behavior_name(*behavior),
                     sid,
@@ -5903,16 +5910,20 @@ mod detail_tests {
         assert!(!plain.contains("resolved"), "{plain}");
 
         // Opted in: the ST1 whose endpoint is in-range resolves to the ISD's
-        // End.DT46 segment (keyed on the endpoint, not the UE prefix); the
-        // out-of-range endpoint does not.
+        // End.DT46 segment (keyed on the endpoint); the installed / shown
+        // destination is the UE prefix, not the endpoint. The out-of-range
+        // endpoint does not resolve.
         let out = render_mup_table(&tables, true).unwrap();
         assert!(
             out.contains(
-                "resolved 10.0.0.9 -> End.DT46 fcbb:bbbb:1:40:: (via [ISD][65501:10][10.0.0.0/24])"
+                "resolved 10.60.1.5/32 (endpoint 10.0.0.9) -> End.DT46 fcbb:bbbb:1:40:: (via [ISD][65501:10][10.0.0.0/24])"
             ),
             "{out}"
         );
-        assert!(!out.contains("resolved 10.70.0.9"), "{out}");
+        // The out-of-range ST1 (endpoint 10.70.0.9, UE 10.60.2.5) resolves
+        // to nothing (10.70.0.9 still appears in its own [ST1] NLRI line, so
+        // assert on the absence of a *resolved* line for its UE).
+        assert!(!out.contains("resolved 10.60.2.5"), "{out}");
     }
 
     #[test]

--- a/zebra-rs/src/bgp/vrf/inst.rs
+++ b/zebra-rs/src/bgp/vrf/inst.rs
@@ -161,13 +161,13 @@ pub struct BgpVrf {
     /// (direct↔interwork switch / router-id change) withdraws this prior one
     /// first.
     pub mup_segment_prefix: Option<bgp_packet::MupPrefix>,
-    /// Installed ST1→ISD encap FIB entries: ST1 endpoint host prefix → the
-    /// ISD's End.DT46 SID it is steered into. A selected ST1 whose GTP
-    /// endpoint (gNB) address is covered by an imported ISD's prefix installs
-    /// a resolved-underlay seg6 H.Encaps route into this VRF's table (`dst =
-    /// endpoint /32|/128, via <underlay egress> encap seg6 segs [SID]`).
-    /// Tracked so `reconcile_mup_st1_isd` can diff and withdraw when the ST1
-    /// or the covering ISD goes away.
+    /// Installed ST1→ISD encap FIB entries: ST1 UE prefix → the ISD's
+    /// End.DT46 SID it is steered into. A selected ST1 whose GTP endpoint
+    /// (gNB) address is covered by an imported ISD's prefix installs a
+    /// resolved-underlay seg6 H.Encaps route for its UE prefix into this
+    /// VRF's table (`dst = UE prefix, via <underlay egress> encap seg6 segs
+    /// [SID]`). Tracked so `reconcile_mup_st1_isd` can diff and withdraw when
+    /// the ST1 or the covering ISD goes away.
     pub mup_st1_isd_installed: std::collections::BTreeMap<ipnet::IpNet, std::net::Ipv6Addr>,
     /// Resolved underlay transport for each imported segment route (DSD/ISD)
     /// next-hop, keyed by its `(rd, prefix)`. Supplied by the global NHT via
@@ -672,16 +672,18 @@ impl BgpVrf {
 
     /// Reconcile ST1→ISD encap FIB entries for this VRF. A selected ST1
     /// whose GTP endpoint (gNB) address is covered (longest-match) by an
-    /// imported ISD's prefix (the gNB N3 network) is steered into that ISD's
-    /// End.DT46 SID: install a resolved-underlay seg6 H.Encaps route for the
-    /// endpoint (`dst = endpoint /32|/128, via <underlay egress> encap seg6
-    /// segs [SID]`) into this VRF's table. The ISD is remote (received from
+    /// imported ISD's prefix (the gNB N3 network) has its **UE prefix**
+    /// steered into that ISD's End.DT46 SID: install a resolved-underlay seg6
+    /// H.Encaps route for the UE prefix (`dst = UE prefix, via <underlay
+    /// egress> encap seg6 segs [SID]`) into this VRF's table, so downlink
+    /// traffic to the UE is encapsulated toward the gNB's segment. The lookup
+    /// *key* is the endpoint (draft §3.3.9); the FIB *destination* is the UE
+    /// prefix (the Prefix field, §3.1.3). The ISD is remote (received from
     /// the access-side PE), so the encap resolves through the global-supplied
     /// `mup_segment_transport`; an unresolved ISD next-hop yields no install.
     /// Diff-gated against `mup_st1_isd_installed`. Mirrors the show-side
-    /// resolution in `render_mup_table` and the ST2→DSD reconcile — both key
-    /// on the ST route's endpoint, ST2→DSD matching by Direct-segment id and
-    /// ST1→ISD by the endpoint's containment in the ISD prefix.
+    /// resolution in `render_mup_table`; the ST2→DSD reconcile is the uplink
+    /// twin (dst = the ST2 endpoint, matched by Direct-segment id).
     fn reconcile_mup_st1_isd(&mut self) {
         use std::net::Ipv6Addr;
         type Transport = Vec<crate::rib::nht::ResolvedNexthop>;
@@ -712,17 +714,23 @@ impl BgpVrf {
             std::collections::BTreeMap::new();
         if !isd_index.is_empty() {
             for (prefix, _rib) in self.local_rib.mup.values().flat_map(|t| t.selected.iter()) {
-                // Key on the ST1 GTP endpoint (gNB), not the UE prefix: the
-                // ISD advertises the gNB N3 network, so the endpoint is what
-                // falls inside it (mirrors ST2->DSD's endpoint dst, and works
-                // for a mixed-AFI IPv6-UE / IPv4-endpoint route).
-                if let bgp_packet::MupPrefix::T1st { endpoint, .. } = prefix
+                // Resolve on the ST1 GTP endpoint (gNB) — the ISD advertises
+                // the gNB N3 network, so the endpoint is what falls inside it
+                // (draft §3.3.9; also handles a mixed-AFI IPv6-UE /
+                // IPv4-endpoint route) — but install the *UE prefix* as the
+                // FIB destination (§3.1.3): downlink traffic to the UE is
+                // steered toward the gNB's segment.
+                if let bgp_packet::MupPrefix::T1st {
+                    prefix: ue,
+                    endpoint,
+                    ..
+                } = prefix
                     && let Some((_p, sid, transport)) = isd_index
                         .iter()
                         .filter(|(p, _, _)| p.contains(endpoint))
                         .max_by_key(|(p, _, _)| p.prefix_len())
                 {
-                    desired.insert(host_net(*endpoint), (*sid, transport.clone()));
+                    desired.insert(*ue, (*sid, transport.clone()));
                 }
             }
         }


### PR DESCRIPTION
## Summary

Correct the ST1→ISD forwarding destination. The GTP endpoint (gNB) is the
resolution **lookup key** (draft-ietf-bess-mup-safi §3.3.9 — *"use the
received Tunnel Endpoint Address … as a key to lookup the associated
Interwork Segment Discovery route"*), but the FIB **destination** is the
ST1's **UE prefix** (the Prefix field, §3.1.3 — *"Prefix is the prefix
allocated to a UE"*): downlink traffic to the UE is steered toward the gNB's
segment.

The previous behaviour installed `dst = endpoint`, which is the ST2→DSD
(uplink, no UE prefix) shape, not the ST1 downlink one.

- **ST1→ISD**: resolve on the endpoint (endpoint ∈ ISD prefix), install
  `dst = UE prefix` (`render_mup_table` + `reconcile_mup_st1_isd`). The
  resolved line is now `resolved <ue> (endpoint <ep>) -> End.DT46 <sid> (via
  [ISD]…)`.
- **ST2→DSD** unchanged (`dst = the ST2 endpoint`; the ST2 carries no UE
  prefix).

## Test plan

- `cargo fmt --all` + `cargo clippy --workspace --all-targets -- -D warnings`
  clean.
- Full workspace test suite (excl bdd) green — 1494 zebra-rs + all crates,
  0 failed. Unit test asserts the new `resolved <ue> (endpoint <ep>)` form.
- BDD `@bgp_mup_st1_isd` passed end-to-end (root netns, 23 steps): z2
  resolves `resolved 10.60.1.5/32 (endpoint 10.0.0.1) -> End.DT46` and
  installs the **UE-prefix** route `10.60.1.5/32 encap seg6 … [z1 SID]` into
  the VRF table. (BDD is CI-excluded; run locally.)
- book + design docs updated.

Generated with [Claude Code](https://claude.com/claude-code)