### PR TITLE
bgp/mup: distinct access (ST1) and core (ST2) tunnel endpoints

### DIFF
--- a/bdd/tests/features/bgp_mup_dual_st.feature
+++ b/bdd/tests/features/bgp_mup_dual_st.feature
@@ -32,9 +32,12 @@ Feature: BGP MUP Controller originates both ST1 and ST2 from one PFCP session
   (rd 65000:101, `afi-safi mup route st1`) for the downlink Type-1 ST, and
   `mobile-ul` (rd 65000:100, `afi-safi mup route st2` carrying Direct
   segment id `1:2`) for the uplink Type-2 ST. `pfcp-inject` plays the SMF:
-  it sends an Association Setup + Session Establishment for UE 192.0.2.5 /
-  endpoint 10.0.0.1 / TEID 0x12345678 (Network Instance `internet`), so z1
-  originates BOTH ST routes and advertises them to z2.
+  it sends an Association Setup + Session Establishment for UE 192.0.2.5 with
+  an ACCESS-side F-TEID (gNB endpoint 10.0.0.1 / TEID 0x12345678) and a
+  CORE-side F-TEID (endpoint 10.9.0.1 / TEID 0x87654321), Network Instance
+  `internet`. The Type-1 ST carries the access endpoint, the Type-2 ST the
+  core endpoint (draft §3.3.7 / §3.3.10 — they are distinct), and z1
+  advertises BOTH to z2.
 
   NOTE: this feature runs `pfcp-inject` inside z1, so the `pfcp-inject`
   binary (`tools/pfcp-inject`) must be on the BDD host PATH — build with
@@ -58,18 +61,22 @@ Feature: BGP MUP Controller originates both ST1 and ST2 from one PFCP session
 
   Scenario: One PFCP session originates both an ST1 and an ST2 route received by the peer
     Given the test topology exists
-    When I execute "pfcp-inject --target 192.168.0.1 --port 8805 --ue-ipv4 192.0.2.5 --teid 0x12345678 --endpoint 10.0.0.1 --network-instance internet" in namespace "z1"
-    # PFCP ingest learned the single session.
+    When I execute "pfcp-inject --target 192.168.0.1 --port 8805 --ue-ipv4 192.0.2.5 --teid 0x12345678 --endpoint 10.0.0.1 --core-endpoint 10.9.0.1 --network-instance internet" in namespace "z1"
+    # PFCP ingest learned the single session (with an access-side and a
+    # core-side F-TEID).
     Then show command "show bgp mup-c session" in namespace "z1" should eventually contain "192.0.2.5"
-    # The downlink VRF (st1) originates a Type-1 ST: UE prefix + access tunnel.
+    # The downlink VRF (st1) originates a Type-1 ST: UE prefix + the ACCESS
+    # tunnel endpoint (gNB, 10.0.0.1).
     And show command "show bgp mup" in namespace "z1" should contain "[ST1][65000:101][ue=192.0.2.5/32][teid=305419896]"
-    # The uplink VRF (st2) originates a Type-2 ST from the SAME session:
-    # core endpoint + the full 32-bit GTP TEID, plus the Direct segment id.
-    And show command "show bgp mup" in namespace "z1" should contain "[ST2][65000:100][ep=10.0.0.1][teid=305419896]"
+    And show command "show bgp mup" in namespace "z1" should contain "[ep=10.0.0.1]"
+    # The uplink VRF (st2) originates a Type-2 ST from the SAME session with
+    # the distinct CORE endpoint (10.9.0.1) + its own TEID (0x87654321), plus
+    # the Direct segment id.
+    And show command "show bgp mup" in namespace "z1" should contain "[ST2][65000:100][ep=10.9.0.1][teid=2271560481]"
     And show command "show bgp mup" in namespace "z1" should contain "rt:65000:200 mup:1:2"
     # The peer receives both Session-Transformed routes.
     And show command "show bgp mup" in namespace "z2" should eventually contain "[ST1][65000:101][ue=192.0.2.5/32][teid=305419896]"
-    And show command "show bgp mup" in namespace "z2" should contain "[ST2][65000:100][ep=10.0.0.1][teid=305419896]"
+    And show command "show bgp mup" in namespace "z2" should contain "[ST2][65000:100][ep=10.9.0.1][teid=2271560481]"
 
   Scenario: Teardown topology
     Given the test topology exists

--- a/book/src/ch-02-35-bgp-mup.md
+++ b/book/src/ch-02-35-bgp-mup.md
@@ -151,12 +151,18 @@ mup route {st1|st2}`; the two read identically:
 
 * **Downlink (Type-1 ST).** `afi-safi mup route st1 { network-instance
   <ni>; }` — the N6 VRF originates a **Type-1 ST** route carrying the UE
-  prefix (ingress GTP encapsulation).
+  prefix and the **access-side** GTP endpoint (the gNB; draft §3.3.7).
 * **Uplink (Type-2 ST).** `afi-safi mup route st2 { network-instance <ni>;
   mup-ext-comm <2:4>; }` — the N3 VRF originates a **Type-2 ST** route
-  carrying the core endpoint and the GTP TEID (egress GTP decapsulation).
-  The optional `mup-ext-comm` is the BGP MUP Extended Community
-  (Direct-segment id in RD/RT 2:4 form, e.g. `1:2`) the ST2 resolves to.
+  carrying the **core-side** GTP endpoint and the GTP TEID (§3.3.10). The
+  optional `mup-ext-comm` is the BGP MUP Extended Community (Direct-segment
+  id in RD/RT 2:4 form, e.g. `1:2`) the ST2 resolves to.
+
+The access (Type-1) and core (Type-2) endpoints are **distinct** tunnel
+ends: the controller learns each from its own PFCP F-TEID — the
+`SourceInterface=Access` PDR feeds the Type-1 endpoint, the
+`SourceInterface=Core` PDR the Type-2 endpoint. A session that carries only
+one F-TEID reuses it for both (the Type-2 falls back to the access endpoint).
 
 The configured network-instance is matched exactly against the PFCP
 session's Network Instance. The export route-targets the ST route carries

--- a/tools/pfcp-inject/README.md
+++ b/tools/pfcp-inject/README.md
@@ -49,7 +49,9 @@ sudo cp target/release/pfcp-inject /usr/bin/
 | `--ue-ipv4 <v4>` | — | UE IPv4 address. At least one of `--ue-ipv4` / `--ue-ipv6` is **required**. |
 | `--ue-ipv6 <v6>` | — | UE IPv6 address. |
 | `--teid <u32>` | `0x12345678` | Access-side GTP-U TEID — decimal or `0x`-prefixed hex. |
-| `--endpoint <IP>` | `10.0.0.1` | Access-side GTP-U (F-TEID) endpoint address (the gNB). |
+| `--endpoint <IP>` | `10.0.0.1` | Access-side GTP-U (F-TEID) endpoint address (the gNB) — used for the **Type-1 ST**. |
+| `--core-endpoint <IP>` | — | Core-side GTP-U (F-TEID) endpoint address — used for the **Type-2 ST**. When set, a second `SourceInterface=Core` PDR is added so the controller learns a distinct core endpoint; omit and the Type-2 ST falls back to the access endpoint. |
+| `--core-teid <u32>` | `0x87654321` | Core-side GTP-U TEID (only used with `--core-endpoint`). |
 | `--network-instance <s>` | `access` | Network Instance (APN/DNN). Matched against a per-VRF `mup` config on the controller. |
 | `--seid <u64>` | `1` | CP-side F-SEID advertised in the Session Establishment Request. |
 | `--delete` | `false` | Also delete the session after establishing it. |
@@ -60,9 +62,10 @@ it to a `router bgp vrf <name> afi-safi mup route {st1|st2} network-instance
 <ni>` binding, which decides the route type that gets originated:
 
 - a VRF binding the NI under `route st1` → a **Type-1 ST** (downlink / access;
-  carries the UE prefix + access tunnel);
+  carries the UE prefix + the **access** endpoint, `--endpoint`);
 - a VRF binding the NI under `route st2` → a **Type-2 ST** (uplink / core;
-  carries the endpoint + GTP TEID).
+  carries the **core** endpoint, `--core-endpoint`, + GTP TEID). The access
+  and core endpoints are distinct network functions (draft §3.3.7 / §3.3.10).
 
 A single session can originate both at once when two VRFs (one st1, one st2)
 bind the same NI.

--- a/tools/pfcp-inject/src/main.rs
+++ b/tools/pfcp-inject/src/main.rs
@@ -68,9 +68,22 @@ struct Args {
     #[arg(long, default_value_t = 0x1234_5678, value_parser = parse_u32)]
     teid: u32,
 
-    /// Access-side GTP-U endpoint (F-TEID) address.
+    /// Access-side GTP-U endpoint (F-TEID) address. Used for the Type-1 ST
+    /// (access side).
     #[arg(long, default_value = "10.0.0.1")]
     endpoint: IpAddr,
+
+    /// Core-side GTP-U endpoint (F-TEID) address, used for the Type-2 ST
+    /// (core side). When set, a second `SourceInterface=Core` PDR is added so
+    /// the controller can distinguish the access and core endpoints; omit for
+    /// a single-endpoint session (Type-2 falls back to the access endpoint).
+    #[arg(long)]
+    core_endpoint: Option<IpAddr>,
+
+    /// Core-side GTP-U TEID (decimal, or `0x`-prefixed hex). Only used when
+    /// `--core-endpoint` is set.
+    #[arg(long, default_value_t = 0x8765_4321, value_parser = parse_u32)]
+    core_teid: u32,
 
     /// Network Instance (APN/DNN) — matched against a VRF `mup`
     /// config on the controller.
@@ -151,10 +164,36 @@ fn main() -> Result<()> {
         .forward_to(Interface::Core)
         .build()
         .context("build Create FAR")?;
+    // Optional second (`SourceInterface=Core`) PDR carrying the core-side
+    // F-TEID, so the controller learns a distinct Type-2 (core) endpoint.
+    let mut create_pdrs = vec![pdr.to_ie()];
+    if let Some(core_endpoint) = args.core_endpoint {
+        let core_fteid = {
+            let b = FteidBuilder::new().teid(args.core_teid);
+            match core_endpoint {
+                IpAddr::V4(v4) => b.ipv4(v4),
+                IpAddr::V6(v6) => b.ipv6(v6),
+            }
+            .build()
+            .context("build core F-TEID")?
+        };
+        let core_pdi = PdiBuilder::new(SourceInterface::new(SourceInterfaceValue::Core))
+            .f_teid(core_fteid)
+            .network_instance(NetworkInstance::new(&args.network_instance))
+            .build()
+            .context("build core PDI")?;
+        let core_pdr = CreatePdrBuilder::new(PdrId::new(2))
+            .precedence(Precedence::new(200))
+            .pdi(core_pdi)
+            .far_id(FarId::new(1))
+            .build()
+            .context("build core Create PDR")?;
+        create_pdrs.push(core_pdr.to_ie());
+    }
     let establish = SessionEstablishmentRequestBuilder::new(args.seid, 2u32)
         .node_id(args.node_id)
         .fseid(args.seid, args.node_id)
-        .create_pdrs(vec![pdr.to_ie()])
+        .create_pdrs(create_pdrs)
         .create_fars(vec![far.to_ie()])
         .build()
         .context("build Session Establishment Request")?;

--- a/zebra-rs/src/bgp/config.rs
+++ b/zebra-rs/src/bgp/config.rs
@@ -7713,6 +7713,8 @@ mod mup_dual_origination_tests {
             ue_ipv6: None,
             teid: 0x1234,
             endpoint: Some("10.0.0.1".parse().unwrap()),
+            core_teid: 0,
+            core_endpoint: None,
             network_instance: Some(ni.to_string()),
             qfi: Some(9),
         }

--- a/zebra-rs/src/bgp/route.rs
+++ b/zebra-rs/src/bgp/route.rs
@@ -8025,14 +8025,21 @@ pub(super) fn build_mup_st_route(
             },
             _ => return None,
         },
-        // Decapsulation (N3 / uplink): Type-2 ST carries the core endpoint +
-        // TEID. The Endpoint Length (draft §3.1.4.1) spans the address *and*
-        // the trailing 32-bit GTP TEID, so it is 64 (IPv4) / 160 (IPv6).
-        MupSrv6Direction::Decapsulation => match session.endpoint {
+        // Decapsulation (N3 / uplink): Type-2 ST carries the *core-side*
+        // endpoint + TEID (draft §3.3.10), distinct from the Type-1 access
+        // endpoint. Falls back to the access endpoint/TEID when the session
+        // carried no core-side F-TEID (single-endpoint session). The Endpoint
+        // Length (§3.1.4.1) spans the address *and* the trailing 32-bit GTP
+        // TEID, so it is 64 (IPv4) / 160 (IPv6).
+        MupSrv6Direction::Decapsulation => match session.core_endpoint.or(session.endpoint) {
             Some(endpoint) => MupPrefix::T2st {
                 endpoint,
                 endpoint_len: if endpoint.is_ipv4() { 64 } else { 160 },
-                teid: session.teid,
+                teid: if session.core_teid != 0 {
+                    session.core_teid
+                } else {
+                    session.teid
+                },
             },
             None => return None,
         },
@@ -18117,6 +18124,8 @@ mod tests {
                 ue_ipv6: v6,
                 teid: 0x1234,
                 endpoint: Some("10.0.0.1".parse().unwrap()),
+                core_teid: 0,
+                core_endpoint: None,
                 network_instance: Some("internet.apn".to_string()),
                 qfi: Some(9),
             }
@@ -18157,6 +18166,37 @@ mod tests {
             attr.prefix_sid.is_none(),
             "no Prefix-SID on a controller ST"
         );
+
+        // Type-1 (access) uses the access endpoint/TEID.
+        assert!(matches!(
+            super::build_mup_st_route(&session(Some(v4), None), MupSrv6Direction::Encapsulation, None)
+                .unwrap()
+                .0,
+            MupPrefix::T1st { endpoint, teid, .. }
+                if endpoint == "10.0.0.1".parse::<std::net::IpAddr>().unwrap() && teid == 0x1234
+        ));
+
+        // Type-2 (Decapsulation) uses the *core-side* endpoint/TEID when the
+        // session carries one — distinct from the Type-1 access endpoint.
+        let mut s2 = session(Some(v4), None);
+        s2.core_endpoint = Some("10.9.0.1".parse().unwrap());
+        s2.core_teid = 0x9999;
+        assert!(matches!(
+            super::build_mup_st_route(&s2, MupSrv6Direction::Decapsulation, None)
+                .unwrap()
+                .0,
+            MupPrefix::T2st { endpoint, teid, .. }
+                if endpoint == "10.9.0.1".parse::<std::net::IpAddr>().unwrap() && teid == 0x9999
+        ));
+
+        // Falls back to the access endpoint/TEID when no core-side F-TEID.
+        assert!(matches!(
+            super::build_mup_st_route(&session(Some(v4), None), MupSrv6Direction::Decapsulation, None)
+                .unwrap()
+                .0,
+            MupPrefix::T2st { endpoint, teid, .. }
+                if endpoint == "10.0.0.1".parse::<std::net::IpAddr>().unwrap() && teid == 0x1234
+        ));
     }
 
     // The Segment Discovery NLRI selector: `segment direct` keys a DSD off

--- a/zebra-rs/src/mup-c/pfcp.rs
+++ b/zebra-rs/src/mup-c/pfcp.rs
@@ -241,26 +241,43 @@ impl MupC {
             );
         }
 
-        // Walk the Create PDRs for the access-side F-TEID, UE IP and NI.
+        // Walk the Create PDRs for the F-TEIDs, UE IP and NI. The PDI Source
+        // Interface tells access (gNB-facing, → Type-1 ST) from core
+        // (core-facing, → Type-2 ST), so each direction's endpoint is
+        // captured separately.
+        use rs_pfcp::ie::source_interface::SourceInterfaceValue;
         let mut ue_ipv4 = None;
         let mut ue_ipv6 = None;
         let mut teid = 0u32;
         let mut endpoint = None;
+        let mut core_teid = 0u32;
+        let mut core_endpoint = None;
         let mut network_instance = None;
         for ie in msg.ies(IeType::CreatePdr) {
             let Ok(pdr) = CreatePdr::unmarshal(&ie.payload) else {
                 continue;
             };
             let pdi = &pdr.pdi;
+            let is_core = pdi.source_interface.value == SourceInterfaceValue::Core;
             if let Some(f) = &pdi.f_teid {
-                if teid == 0 {
-                    teid = f.teid.value();
-                }
-                if endpoint.is_none() {
-                    endpoint = f
-                        .ipv4_address
-                        .map(IpAddr::V4)
-                        .or(f.ipv6_address.map(IpAddr::V6));
+                let addr = f
+                    .ipv4_address
+                    .map(IpAddr::V4)
+                    .or(f.ipv6_address.map(IpAddr::V6));
+                if is_core {
+                    if core_teid == 0 {
+                        core_teid = f.teid.value();
+                    }
+                    if core_endpoint.is_none() {
+                        core_endpoint = addr;
+                    }
+                } else {
+                    if teid == 0 {
+                        teid = f.teid.value();
+                    }
+                    if endpoint.is_none() {
+                        endpoint = addr;
+                    }
                 }
             }
             if let Some(ue) = &pdi.ue_ip_address {
@@ -287,6 +304,8 @@ impl MupC {
             ue_ipv6,
             teid,
             endpoint,
+            core_teid,
+            core_endpoint,
             network_instance,
             qfi: None,
         };
@@ -511,6 +530,77 @@ mod tests {
             .build()
             .unwrap()
             .marshal()
+    }
+
+    /// A Session Establishment Request with both an `Access` PDR (gNB-facing
+    /// F-TEID → Type-1) and a `Core` PDR (core-facing F-TEID → Type-2), so
+    /// the controller captures a distinct endpoint per direction.
+    fn establishment_two_endpoints_bytes() -> Vec<u8> {
+        let mk_pdr = |id, si, teid, addr: Ipv4Addr, ue: Option<Ipv4Addr>| {
+            let fteid = FteidBuilder::new().teid(teid).ipv4(addr).build().unwrap();
+            let mut b = PdiBuilder::new(SourceInterface::new(si))
+                .f_teid(fteid)
+                .network_instance(NetworkInstance::new("internet.apn"));
+            if let Some(ue) = ue {
+                b = b.ue_ip_address(UeIpAddress::new(Some(ue), None));
+            }
+            CreatePdrBuilder::new(PdrId::new(id))
+                .precedence(Precedence::new(100))
+                .pdi(b.build().unwrap())
+                .far_id(FarId::new(1))
+                .build()
+                .unwrap()
+        };
+        let access = mk_pdr(
+            1,
+            SourceInterfaceValue::Access,
+            0x1234_5678,
+            Ipv4Addr::new(10, 0, 0, 1),
+            Some(Ipv4Addr::new(192, 0, 2, 5)),
+        );
+        let core = mk_pdr(
+            2,
+            SourceInterfaceValue::Core,
+            0x8765_4321,
+            Ipv4Addr::new(10, 9, 0, 1),
+            None,
+        );
+        let far = CreateFar::builder(FarId::new(1))
+            .forward_to(Interface::Core)
+            .build()
+            .unwrap();
+        SessionEstablishmentRequestBuilder::new(0u64, 1u32)
+            .node_id(Ipv4Addr::new(10, 0, 0, 2))
+            .fseid(0x1111u64, Ipv4Addr::new(10, 0, 0, 2))
+            .create_pdrs(vec![access.to_ie(), core.to_ie()])
+            .create_fars(vec![far.to_ie()])
+            .build()
+            .unwrap()
+            .marshal()
+    }
+
+    #[test]
+    fn session_establishment_captures_access_and_core_endpoints() {
+        let (mut mupc, _bgp_rx) = MupC::new_for_test(MupCConfig::default());
+        associate(&mut mupc);
+        let bytes = establishment_two_endpoints_bytes();
+        let msg = message::parse(&bytes).unwrap();
+        let (_reply, events) = mupc.handle_session_establishment(msg.as_ref(), peer());
+        let MupCEvent::SessionUp(session) = &events[0] else {
+            panic!("expected SessionUp, got {:?}", events[0]);
+        };
+        // Access (Type-1) endpoint from the SourceInterface=Access PDR.
+        assert_eq!(session.teid, 0x1234_5678);
+        assert_eq!(
+            session.endpoint,
+            Some(IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1)))
+        );
+        // Core (Type-2) endpoint from the SourceInterface=Core PDR — distinct.
+        assert_eq!(session.core_teid, 0x8765_4321);
+        assert_eq!(
+            session.core_endpoint,
+            Some(IpAddr::V4(Ipv4Addr::new(10, 9, 0, 1)))
+        );
     }
 
     #[test]

--- a/zebra-rs/src/mup-c/session.rs
+++ b/zebra-rs/src/mup-c/session.rs
@@ -29,10 +29,20 @@ pub struct MupSession {
     pub ue_ipv4: Option<Ipv4Addr>,
     /// UE IPv6 address/prefix, if assigned.
     pub ue_ipv6: Option<Ipv6Addr>,
-    /// Access-side GTP-U TEID (from the uplink PDR's F-TEID).
+    /// Access-side GTP-U TEID (from the `SourceInterface=Access` PDR's
+    /// F-TEID). Used for the **Type-1 ST** route (access side, draft §3.3.7).
     pub teid: u32,
-    /// Access-side GTP-U endpoint (the F-TEID address).
+    /// Access-side GTP-U endpoint — the gNB-facing F-TEID address. Used for
+    /// the **Type-1 ST** route.
     pub endpoint: Option<IpAddr>,
+    /// Core-side GTP-U TEID (from the `SourceInterface=Core` PDR's F-TEID).
+    /// Used for the **Type-2 ST** route (core side, draft §3.3.10). `0` when
+    /// the session carried no core-side F-TEID.
+    pub core_teid: u32,
+    /// Core-side GTP-U endpoint — the core-facing F-TEID address. Used for
+    /// the **Type-2 ST** route. `None` falls back to the access endpoint so a
+    /// single-endpoint session still originates an ST2.
+    pub core_endpoint: Option<IpAddr>,
     /// Network Instance (APN/DNN). Correlated to a BGP VRF `mup`
     /// config when routes are originated.
     pub network_instance: Option<String>,


### PR DESCRIPTION
## Summary

A Type-1 ST route carries the **access-side** GTP endpoint (the gNB, draft
§3.3.7); a Type-2 ST carries the **core-side** endpoint (§3.3.10) — they are
different tunnel ends. The MUP-C previously captured a single
`MupSession.endpoint` (access-side) and reused it for both, so an ST2's
endpoint was wrong (it echoed the access endpoint).

- `MupSession` gains `core_endpoint` / `core_teid`.
- The PFCP parse distinguishes Create PDRs by **PDI Source Interface**: an
  `Access` PDR's F-TEID feeds the access endpoint, a `Core` PDR's the core
  endpoint.
- `build_mup_st_route` uses the core endpoint/TEID for the Type-2 ST,
  **falling back** to the access endpoint when the session carried no
  core-side F-TEID (single-endpoint session — no behaviour change for
  existing configs/tests).
- `pfcp-inject` gains `--core-endpoint` / `--core-teid`, adding a second
  `SourceInterface=Core` PDR.

## Test plan

- `cargo fmt --all` + `cargo clippy --workspace --all-targets -- -D warnings`
  clean.
- Full workspace test suite (excl bdd) green — 1495 zebra-rs + all crates,
  0 failed. New unit tests: PFCP parse captures both Access/Core endpoints;
  `build_mup_st_route` uses the core endpoint for ST2 (+ access fallback).
- BDD `@bgp_mup_dual_st` reworked to inject an access endpoint `10.0.0.1`
  and a distinct core endpoint `10.9.0.1`; asserts the ST1 carries
  `[ep=10.0.0.1]` and the ST2 `[ST2]…[ep=10.9.0.1][teid=2271560481]`. Passed
  end-to-end (root netns, 29 steps). (BDD is CI-excluded; run locally.)
- book + pfcp-inject README updated.

Generated with [Claude Code](https://claude.com/claude-code)