### PR TITLE
bgp/mup: withdraw RT-imported per-VRF copy on peer-down

### DIFF
--- a/bdd/Makefile
+++ b/bdd/Makefile
@@ -111,6 +111,14 @@ bgp_mup_dynamic_rt:
 	mkdir -p allure-results
 	cargo test --test cucumber -- --concurrency=1 --tags "@bgp_mup_dynamic_rt"
 
+# MUP peer-down withdraw: z1 originates an ISD carrying rt 65501:10 that z2
+# imports into VRF N3 (rd 65501:99) by route-target. When z1 is stopped, z2's
+# peer-down cleanup must withdraw the ISD from BOTH its main MUP Loc-RIB and
+# N3's RT-imported copy — the regression test for the leaked per-VRF copy.
+bgp_mup_peerdown:
+	mkdir -p allure-results
+	cargo test --test cucumber -- --concurrency=1 --tags "@bgp_mup_peerdown"
+
 rib_static_ipv6:
 	mkdir -p allure-results
 	cargo test --test cucumber -- --concurrency=1 --tags "@rib_static_ipv6"

--- a/bdd/tests/configs/bgp_mup_peerdown/z1.yaml
+++ b/bdd/tests/configs/bgp_mup_peerdown/z1.yaml
@@ -1,0 +1,72 @@
+# z1 — MUP PE that originates an Interwork Segment Discovery (ISD) route in
+# VRF N6 and advertises it to z2 over iBGP (mup afi-safi). When z1 is stopped
+# (the "remote peer goes down" case) z2 must withdraw the ISD from BOTH its
+# main MUP Loc-RIB and its RT-importing VRF copy.
+#
+#   * VRF N6 (rd 65501:20, `encapsulation srv6`) carves a per-VRF End.DT46 SID
+#     from locator S and originates an ISD under prefix 10.60.0.0/16, carrying
+#     its export RT 65501:10.
+vrf:
+- name: N6
+  mup:
+    route-target:
+      export:
+      - "65501:10"
+      import:
+      - "65501:10"
+interface:
+- if-name: lo
+  ipv6:
+    address: 2001:db8::1/128
+- if-name: z1-z2
+  ipv6:
+    address: 2001:db8:0:12::1/64
+segment-routing:
+  locator:
+  - name: S
+    prefix: fcbb:bbbb:1::/48
+    behavior: usid
+router:
+  isis:
+    net: 49.0000.0000.0000.0001.00
+    hostname: z1
+    is-type: level-2-only
+    segment-routing:
+      srv6:
+        locator: S
+    interface:
+    - if-name: lo
+      ipv6:
+        enable: true
+    - if-name: z1-z2
+      network-type: point-to-point
+      metric: 1
+      ipv6:
+        enable: true
+  bgp:
+    global:
+      as: 65501
+      router-id: 10.0.0.1
+    timer:
+      adv-interval:
+        ibgp: 1
+    segment-routing:
+      srv6:
+        locator: S
+    neighbor:
+    - remote-address: 2001:db8::2
+      remote-as: 65501
+      update-source: 2001:db8::1
+      enabled: true
+      afi-safi:
+      - name: mup
+        enabled: true
+    vrf:
+    - name: N6
+      rd: "65501:20"
+      encapsulation: srv6
+      afi-safi:
+        mup:
+          segment:
+          - type: interwork
+            prefix: 10.60.0.0/16

--- a/bdd/tests/configs/bgp_mup_peerdown/z2.yaml
+++ b/bdd/tests/configs/bgp_mup_peerdown/z2.yaml
@@ -1,0 +1,72 @@
+# z2 — MUP peer that receives z1's ISD and imports it into VRF N3 by
+# route-target. VRF N3's own rd (65501:99) does NOT match the ISD's origin RD
+# (65501:20); N3 pulls the route in purely because its `mup route-target
+# import` (65501:10) overlaps the ISD's RTs, so on import the route is re-keyed
+# under N3's own rd — the RT-matched per-VRF MUP import model.
+#
+# This is the receiver side of the peer-down leak test: when z1 goes down, z2's
+# peer-down cleanup must withdraw the ISD from BOTH its main MUP Loc-RIB and
+# this RT-imported VRF copy. Before the fix only the main copy was dropped.
+vrf:
+- name: N3
+  mup:
+    route-target:
+      export:
+      - "65501:99"
+      import:
+      - "65501:10"
+interface:
+- if-name: lo
+  ipv6:
+    address: 2001:db8::2/128
+- if-name: z2-z1
+  ipv6:
+    address: 2001:db8:0:12::2/64
+segment-routing:
+  locator:
+  - name: LOC2
+    prefix: fcbb:bbbb:2::/48
+    behavior: usid
+router:
+  isis:
+    net: 49.0000.0000.0000.0002.00
+    hostname: z2
+    is-type: level-2-only
+    segment-routing:
+      srv6:
+        locator: LOC2
+    interface:
+    - if-name: lo
+      ipv6:
+        enable: true
+    - if-name: z2-z1
+      network-type: point-to-point
+      metric: 1
+      ipv6:
+        enable: true
+  bgp:
+    global:
+      as: 65501
+      router-id: 10.0.0.2
+    timer:
+      adv-interval:
+        ibgp: 1
+    segment-routing:
+      srv6:
+        locator: LOC2
+    neighbor:
+    - remote-address: 2001:db8::1
+      remote-as: 65501
+      update-source: 2001:db8::2
+      enabled: true
+      afi-safi:
+      - name: mup
+        enabled: true
+    vrf:
+    - name: N3
+      rd: "65501:99"
+      afi-safi:
+        mup:
+          route:
+          - type: st1
+            network-instance: internet

--- a/bdd/tests/features/bgp_mup_peerdown.feature
+++ b/bdd/tests/features/bgp_mup_peerdown.feature
@@ -1,0 +1,72 @@
+@serial
+@bgp_mup_peerdown
+Feature: BGP MUP peer-down withdraws the RT-imported per-VRF copy
+  As a network operator
+  I want a BGP MUP route (SAFI 85 / draft-ietf-bess-mup-safi) learned from a
+  peer to be withdrawn from EVERY table when that peer goes down — not just
+  the main-instance MUP Loc-RIB but also every VRF that imported it by
+  route-target — so a session loss cannot leak a stale route (and its derived
+  SRv6 FIB entry) into a downlink VRF's RIB forever.
+
+  Test Topology:
+  ```
+        2001:db8::1/128            2001:db8::2/128
+       ┌──────────┐  IS-IS L2 SRv6  ┌──────────┐
+       │    z1    │═════════════════│    z2    │
+       │ MUP PE   │   iBGP (mup)    │ receiver │
+       │ N6 (ISD) │                 │ N3 (imp) │
+       └──────────┘                 └──────────┘
+   z1-z2 2001:db8:0:12::1/64   2001:db8:0:12::2/64
+  ```
+
+  z1's VRF N6 (rd 65501:20, `encapsulation srv6`, `afi-safi mup segment
+  interwork prefix 10.60.0.0/16`) originates an ISD carrying export RT
+  65501:10 and advertises it to z2. z2's VRF N3 (rd 65501:99) imports RT
+  65501:10, so it pulls the peer-learned ISD in across the RD boundary and
+  re-keys it under its own rd (65501:99). When z1 is stopped, z2's peer-down
+  cleanup must drop the ISD from BOTH z2's main MUP Loc-RIB (`show bgp mup`)
+  and N3's imported copy (`show bgp vrf N3 mup`). Before the fix the main copy
+  was dropped but N3's RT-imported copy leaked.
+
+  Scenario: Build topology and establish iBGP with the MUP capability
+    Given a clean test environment
+    When I create namespace "z1"
+    And I create namespace "z2"
+    And I connect namespace "z1" interface "z1-z2" to namespace "z2" interface "z2-z1"
+    And I start zebra-rs in namespace "z1"
+    And I start zebra-rs in namespace "z2"
+    And I apply config "z1.yaml" to namespace "z1"
+    And I apply config "z2.yaml" to namespace "z2"
+    And I wait 45 seconds
+    Then BGP session in "z1" to "2001:db8::2" should be "Established"
+    And BGP session in "z2" to "2001:db8::1" should be "Established"
+    And show command "show bgp neighbor 2001:db8::1" in namespace "z2" should contain "IPv4 MUP: advertised and received"
+
+  Scenario: z2 receives the ISD and imports it into VRF N3 by route-target
+    Given the test topology exists
+    # The peer-learned ISD lands in z2's main MUP Loc-RIB under the origin RD.
+    Then show command "show bgp mup" in namespace "z2" should eventually contain "[ISD][65501:20][10.60.0.0/16]"
+    And show command "show bgp mup" in namespace "z2" should contain "End.DT46"
+    # N3 imports it across the RD boundary by RT (65501:10) and re-keys it
+    # under N3's own rd (65501:99) — RT-matched, not RD-matched.
+    And show command "show bgp vrf N3 mup" in namespace "z2" should eventually contain "[ISD][65501:99][10.60.0.0/16]"
+    And show command "show bgp vrf N3 mup" in namespace "z2" should contain "rt:65501:10"
+
+  Scenario: When the peer (z1) goes down z2 withdraws the ISD from BOTH tables
+    Given the test topology exists
+    When I stop zebra-rs in namespace "z1"
+    # The main-instance MUP Loc-RIB drops the peer-learned ISD (this already
+    # worked before the fix).
+    Then show command "show bgp mup" in namespace "z2" should eventually not contain "10.60.0.0/16"
+    # The crux: the RT-imported per-VRF copy must be withdrawn too. Before the
+    # fix `route_clean` dropped the route from the main Loc-RIB only and never
+    # dispatched the withdrawal to the importing VRF, so this leaked forever.
+    And show command "show bgp vrf N3 mup" in namespace "z2" should eventually not contain "10.60.0.0/16"
+
+  Scenario: Teardown topology
+    Given the test topology exists
+    When I stop zebra-rs in namespace "z1"
+    And I stop zebra-rs in namespace "z2"
+    And I delete namespace "z1"
+    And I delete namespace "z2"
+    Then the test environment should be clean

--- a/zebra-rs/src/bgp/route.rs
+++ b/zebra-rs/src/bgp/route.rs
@@ -7686,6 +7686,26 @@ pub fn route_mup_withdraw(ident: usize, route: &MupRoute, bgp: &mut BgpTop, peer
         let peer = peers.get_mut_by_idx(ident).expect("peer must exist");
         peer.adj_in.remove_mup(rd, &prefix, id);
     }
+    route_mup_locrib_withdraw(ident, rd, prefix, id, bgp, peers);
+}
+
+/// Drop one MUP path from the Loc-RIB and propagate the consequences: release
+/// the NHT registration when no surviving path keeps the pre-withdraw DSD/ISD
+/// next-hop, mirror the post-withdraw best path (or a withdrawal) to every
+/// RT-importing per-VRF task, and withdraw / re-advertise to downstream peers.
+///
+/// Shared by the explicit MP_UNREACH path ([`route_mup_withdraw`]) and the
+/// peer-down cleanup ([`route_clean`]) so both clean the RT-imported per-VRF
+/// copy identically — the caller is responsible only for removing the entry
+/// from the peer's Adj-RIB-In (individually, or in bulk on session down).
+fn route_mup_locrib_withdraw(
+    ident: usize,
+    rd: RouteDistinguisher,
+    prefix: MupPrefix,
+    id: u32,
+    bgp: &mut BgpTop,
+    peers: &mut PeerMap,
+) {
     // Capture the pre-withdraw DSD next-hop so it can be released from NHT
     // if this withdrawal drops the last path using it.
     let old_segment_nh = bgp
@@ -9930,10 +9950,16 @@ pub fn route_clean(
         peer.adj_in.evpn.clear();
     }
 
-    // MUP (draft-ietf-bess-mup-safi). Phase 2 is receive-only with no LLGR retention, so
-    // peer-down simply drops every MUP route the peer gave us from the
-    // Loc-RIB and clears its Adj-RIB-In. (LLGR stale retention for MUP is
-    // a later phase, mirroring the EVPN/VPN two-branch logic above.)
+    // MUP (draft-ietf-bess-mup-safi). Phase 2 is receive-only with no LLGR
+    // retention, so peer-down withdraws every MUP route the peer gave us.
+    // Route it through the same `route_mup_locrib_withdraw` helper the
+    // explicit MP_UNREACH path uses so the withdrawal is *propagated*, not
+    // just dropped locally: RT-importing per-VRF copies are withdrawn (with
+    // their derived SRv6 FIB entries), the received DSD/ISD next-hop is
+    // released from NHT, and downstream peers get the MP_UNREACH. Dropping it
+    // from `bgp.local_rib` alone leaked the imported VRF RIB + FIB.
+    // (LLGR stale retention for MUP is a later phase, mirroring the EVPN/VPN
+    // two-branch logic above.)
     let mup_keys: Vec<(RouteDistinguisher, MupPrefix, u32)> = {
         let peer = peers.get_mut_by_idx(peer_id).expect("peer must exist");
         let mut out = Vec::new();
@@ -9946,12 +9972,13 @@ pub fn route_clean(
         }
         out
     };
-    for (rd, prefix, id) in mup_keys.iter() {
-        let _ = bgp.local_rib.remove_mup(*rd, prefix, *id, peer_id);
-        let _ = bgp.local_rib.select_best_path_mup(rd, prefix);
-    }
+    // Clear the peer's Adj-RIB-In up front; the helper re-selects best-path
+    // from the Loc-RIB (a distinct store), so it never re-picks these paths.
     let peer = peers.get_mut_by_idx(peer_id).expect("peer must exist");
     peer.adj_in.mup.clear();
+    for (rd, prefix, id) in mup_keys.into_iter() {
+        route_mup_locrib_withdraw(peer_id, rd, prefix, id, bgp, peers);
+    }
 
     let peer = peers.get_mut_by_idx(peer_id).expect("peer must exist");
     peer.adj_out.evpn.clear();


### PR DESCRIPTION
## Problem

When a BGP MUP peer (SAFI 85, `draft-ietf-bess-mup-safi`) went down, the MUP route it had advertised was removed from the **main-instance** MUP Loc-RIB but **not** from any VRF that had imported it by route-target. The stale route lingered in `show bgp vrf <name> mup` (and its derived SRv6 FIB entry) forever.

## Root cause

`route_clean` (the peer-down cleanup) handled MUP *inline* — `bgp.local_rib.remove_mup` + a discarded `select_best_path_mup`, then cleared the Adj-RIB-In — and never called `dispatch_mup`. The explicit MP_UNREACH path (`route_mup_withdraw`) *does* dispatch the withdrawal to every RT-importing per-VRF task (which removes the imported copy and tears down its FIB entry via the ST1→ISD / ST2→DSD reconcile). The peer-down path skipped that entirely, and also skipped the NHT release and the downstream MP_UNREACH.

## Fix

Extract the Loc-RIB withdraw tail of `route_mup_withdraw` into a shared `route_mup_locrib_withdraw` helper (re-run best-path, release NHT when the pre-withdraw DSD/ISD next-hop is gone, mirror the result to RT-importing VRFs via `dispatch_mup`, withdraw / re-advertise to peers). `route_clean`'s MUP block now calls it per key. Both the explicit-withdraw and peer-down paths clean the imported per-VRF copy identically.

## Test

New `bgp_mup_peerdown.feature`: z1 originates an ISD carrying `rt:65501:10` that z2 imports into VRF N3 (`rd 65501:99`) by route-target. When z1 is stopped, z2 must withdraw the ISD from **both** `show bgp mup` and `show bgp vrf N3 mup`.

- **With the fix:** 4/4 scenarios pass.
- **Without the fix (control):** scenario 3 fails — `show bgp vrf N3 mup` still contains `10.60.0.0/16` after the 60s poll. Confirms the guard is non-vacuous and reproduces the reported leak.

Workspace clippy clean; full workspace test suite (excl. bdd) green; `cargo fmt --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)