### PR TITLE
bgp: fast-external-failover (IOS-XR parity, on by default)

### DIFF
--- a/book/src/SUMMARY.md
+++ b/book/src/SUMMARY.md
@@ -31,6 +31,7 @@
   - [Well-Known Communities](ch-02-24-bgp-well-known-communities.md)
   - [Table-Map (Policy at the BGP→RIB Install Point)](ch-02-28-bgp-table-map.md)
   - [disable-connected-check](ch-02-16-bgp-disable-connected-check.md)
+  - [Fast External Failover](ch-02-37-bgp-fast-external-failover.md)
   - [ip-transparent (non-local update-source)](ch-02-29-bgp-ip-transparent.md)
   - [SRv6 Encapsulation Type (per-neighbor)](ch-02-17-bgp-srv6-encapsulation-type.md)
   - [Timer Configuration](ch-02-03-bgp-timers.md)

--- a/book/src/ch-02-37-bgp-fast-external-failover.md
+++ b/book/src/ch-02-37-bgp-fast-external-failover.md
@@ -1,0 +1,92 @@
+# Fast External Failover
+
+When the interface carrying a **directly connected eBGP** session goes
+operationally down, waiting for the hold timer (commonly 90–180 s) to
+notice is pointless — the link event already proves the session is
+dead. **Fast external failover** resets such sessions immediately on
+the link-down event, so routes via the failed peer are withdrawn in
+milliseconds instead of minutes.
+
+It is **enabled by default**, matching IOS-XR (`bgp
+fast-external-fallover`, XR spelling) and FRR
+(`bgp fast-external-failover`). You only ever configure it to turn it
+*off*.
+
+## What it does
+
+On a link-down (or link-removal) event for an interface, zebra-rs
+immediately hard-resets every session that
+
+- is **eBGP** — iBGP is never touched (it typically survives on an
+  alternate IGP path), and
+- is **single-hop** — the default TTL-1 case or `ttl-security` (GTSM,
+  directly connected by definition); a neighbor configured with
+  [`ebgp-multihop`](ch-02-11-bgp-ttl-security.md) is intentionally
+  reachable through other paths and is left to hold-timer/NHT, and
+- **rides the downed interface** — unnumbered interface-neighbors match
+  by their interface, numbered neighbors by the connected subnet their
+  address lives on.
+
+The reset is the same teardown as
+[`clear bgp <peer>`](ch-02-25-bgp-clear.md): routes learned from the
+peer are withdrawn, the TCP connection is closed (no NOTIFICATION is
+sent — the link is down, nothing would be delivered), and the session
+re-dials automatically, so it comes back on its own once the link
+returns. When the interface comes back up, zebra-rs additionally
+re-kicks peers parked on it, so recovery does not wait out the
+connect-retry backoff either.
+
+With the feature disabled, a link cut is only detected when the hold
+timer expires — or by [BFD](ch-02-08-bgp-bfd.md), which detects
+*forwarding* failures the link state never reports and works for
+multihop/iBGP too. The two are complementary: fast external failover is
+free and instant for the link-flap case; BFD covers everything else.
+
+## Configuration
+
+The knob is a global boolean, on by default. To disable (the IOS-XR
+`bgp fast-external-fallover disable` equivalent):
+
+```yaml
+router:
+  bgp:
+    global:
+      as: 65001
+      router-id: 10.255.0.1
+      fast-external-failover: false
+```
+
+CLI form:
+
+```
+set router bgp global fast-external-failover false
+```
+
+Deleting the line restores the default (enabled). Flipping the knob
+never bounces established sessions — it only changes how the *next*
+link-down is handled.
+
+| Path | Default | Meaning |
+|------|---------|---------|
+| `/router/bgp/global/fast-external-failover` | `true` | Reset directly connected eBGP sessions immediately on interface down. |
+
+## When to disable it
+
+Rarely. The classic reason is a flapping last-mile link where the
+carrier drops for hundreds of milliseconds at a time: each flap resets
+the session and forces a full route exchange, which can be worse than
+riding through the flap on the hold timer. Interface-level dampening
+(holding the link down in hardware) is usually the better fix; failing
+that, `fast-external-failover false` keeps the session pinned through
+short link drops.
+
+## Verification
+
+A triggered failover logs the reset:
+
+```
+bgp: fast-external-failover: interface down — resetting eBGP peer peer=10.0.3.2 ifindex=3
+```
+
+and the neighbor drops out of `Established` in `show bgp summary`
+immediately after the link event, rather than at hold-time expiry.

--- a/docs/design/bgp-fast-external-failover.md
+++ b/docs/design/bgp-fast-external-failover.md
@@ -1,0 +1,459 @@
+# BGP Fast External Failover — Design
+
+IOS-XR-parity `fast-external-failover` for zebra-rs: when the interface
+carrying a **directly connected eBGP** session goes operationally down,
+reset the session **immediately** instead of waiting for the hold timer
+(typically 90–180 s) to expire. On by default, disable-able globally —
+exactly IOS-XR's `bgp fast-external-fallover disable` (XR spells it
+"fallover"; FRR and this design spell it `fast-external-failover`).
+
+## Status (2026-07-02)
+
+**PR 1 (knob + failover core, unit tests, book chapter) implemented on
+branch `fast-external-failover`**, as specified below. PR 2 (BDD) and
+the listed follow-ups are still open. Original recon, kept for context:
+before PR 1, no `fast-external`/`fast_external` symbol existed
+anywhere in the tree, and BGP **silently discarded link events** —
+`process_rib_msg` has no arm for `RibRx::LinkUp/LinkDown/LinkDel`; they
+fall through the `_ => {}` catch-all at `zebra-rs/src/bgp/inst.rs:3388`.
+An eBGP link cut is therefore detected only by hold-timer expiry (or an
+eventual TCP error). Every other piece of plumbing already exists; this
+feature is essentially "stop dropping `LinkDown` on the floor."
+
+## Prior art
+
+### IOS-XR
+
+```
+router bgp 65000
+ bgp fast-external-fallover disable
+```
+
+Default **enabled**: "the BGP session of neighbors that are directly
+connected through an interface is immediately reset if the link goes
+down." The knob is global-only (no per-neighbor form in XR; classic IOS
+has a per-interface `ip bgp fast-external-fallover permit|deny`, out of
+scope here).
+
+### FRR (`bgpd/bgp_zebra.c:bgp_ifp_down`, flag `BGP_FLAG_NO_FAST_EXT_FAILOVER`)
+
+```c
+/* Fast external-failover */
+if (!CHECK_FLAG(bgp->flags, BGP_FLAG_NO_FAST_EXT_FAILOVER)) {
+        for (ALL_LIST_ELEMENTS(bgp->peer, node, nnode, peer)) {
+                /* Take down directly connected peers. */
+                if ((peer->ttl != BGP_DEFAULT_TTL)
+                    && (peer->gtsm_hops != BGP_GTSM_HOPS_CONNECTED))
+                        continue;
+                if (ifp == peer->nexthop.ifp) {
+                        BGP_EVENT_ADD(peer->connection, BGP_Stop);
+                        peer_set_last_reset(peer, PEER_DOWN_IF_DOWN);
+                }
+        }
+}
+```
+
+Facts to carry over:
+
+- **Eligibility is TTL-based**: single-hop peers (TTL 1) plus GTSM
+  connected (`gtsm_hops == 1`). iBGP is skipped implicitly (its TTL is
+  255). `ebgp-multihop` opts a peer out.
+- **Match by session interface** (`peer->nexthop.ifp`, resolved when the
+  session came up), not by re-deriving reachability.
+- **Reset = `BGP_Stop`, no NOTIFICATION** (the link is down; nothing
+  would be delivered anyway). Reset reason recorded as
+  `PEER_DOWN_IF_DOWN` ("Interface down").
+- Address-delete does **not** reset sessions — only interface-down does.
+- CLI: `bgp fast-external-failover` / `no bgp fast-external-failover`,
+  default enabled.
+
+## What zebra-rs already has (recon, file:line)
+
+- **RIB → protocol link events.** `RibRx::LinkDown(u32)` /
+  `LinkUp(u32)` / `LinkDel(u32)` exist (`zebra-rs/src/rib/api.rs:94`),
+  are emitted VRF-filtered to every subscriber
+  (`api_link_down`, `rib/api.rs:318`) from the netlink flap detector
+  (`rib/link.rs:518-548`) via `rib/route.rs:252 link_down()`. BGP's
+  event loop already drains the channel
+  (`bgp/inst.rs:4394 process_rib_msg`) — it just has no `LinkDown` arm.
+- **Ordering guarantee that makes matching easy:** on a flap the RIB
+  emits `RibRx::LinkDown` *first*, then withdraws connected routes; it
+  does **not** emit `AddrDel` (addresses are usually retained on down —
+  `keep_addr_on_down`, `rib/link.rs:565`). So when BGP processes
+  `LinkDown`, its `ConnectedSubnets` table still maps the peer address
+  to the downed ifindex. This is also why keying the feature off
+  `AddrDel`/`refresh_connected` would *miss* link-down entirely.
+- **Peer ↔ interface resolution.**
+  - Unnumbered/interface peers: `PeerOrigin::Interface { ifindex }`
+    (`bgp/peer_key.rs:33`), addressable via
+    `PeerKey::Interface(ifindex)`.
+  - v6 link-local numbered peers: `Peer.scope_id: Option<u32>`
+    (`bgp/peer.rs:758`).
+  - Ordinary address peers: `ConnectedSubnets::ifindex_for(ip)`
+    (`bgp/connected.rs:92`), maintained from `AddrAdd/AddrDel`.
+- **Single-hop classification.** `Peer::session_ttl()`
+  (`bgp/peer.rs:1200`): iBGP/GTSM ⇒ 255, else
+  `ebgp_multihop.unwrap_or(1)`. zebra-rs GTSM (`ttl-security`,
+  `zebra-bgp-transport.yang:112`) is **connected-only by design** (no
+  `hops <N>`), i.e. exactly FRR's `BGP_GTSM_HOPS_CONNECTED` case — so
+  "eBGP && no ebgp-multihop" is the complete FRR-parity eligibility
+  test. Do **not** reuse `connected_check_applies()`
+  (`bgp/peer.rs:1218`) here: it also excludes `disable-connected-check`
+  and link-local peers, which FRR *does* fail over.
+- **The teardown primitive.** `Message::Event(ident, Event::Stop)` on
+  `bgp.tx` → `fsm_stop` (`bgp/peer.rs:1779`, returns `Idle`, **no
+  NOTIFICATION**) → the Established→Idle transition in `fsm()`
+  (`bgp/peer.rs:1629`) runs `route_clean`, withdraws update-group /
+  egress-task membership, and `timer::update_timers`
+  (`bgp/timer.rs:206`) tears the socket down and re-arms the idle-hold
+  timer (which fires `Event::Start` → auto-reconnect with backoff).
+  This is precisely what BFD-down already does
+  (`bgp/inst.rs:5229 process_bfd_event`, RFC 5882 §5) and what
+  `clear bgp … hard` does (`bgp/peer.rs:3214`). Fast external failover
+  is "BFD-down, triggered by `RibRx::LinkDown` instead."
+- **Post-reset behavior needs nothing new.** After Stop→Idle the
+  idle-hold timer re-dials; if the link is still down the dial fails
+  fast (ENETUNREACH → retry) or, if addresses were also removed,
+  `fsm_start`'s connected-check gate holds the peer in `Active` until
+  `refresh_connected()` (`bgp/inst.rs:2920`) re-kicks it on `AddrAdd`.
+
+## Design
+
+### Semantics (IOS-XR / FRR parity)
+
+- **Scope:** per-BGP-instance, global knob. Applies to sessions whose
+  transport rides the downed interface *and* whose peer is
+  **single-hop eBGP**: `is_ebgp() && ebgp_multihop.is_none()`. This
+  includes `ttl-security` (GTSM ⇒ directly connected in zebra-rs) and
+  `disable-connected-check` peers, unnumbered interface peers, and
+  dynamic peers; it excludes iBGP and `ebgp-multihop` peers.
+- **Default: enabled.** Disabling requires explicit config, like XR.
+- **Trigger:** `RibRx::LinkDown` (operational down) and `RibRx::LinkDel`
+  (interface removed). **Not** `AddrDel` (FRR parity; address events
+  keep their existing `refresh_connected` role of gating *new* dials).
+- **Action:** post `Event::Stop` — full hard reset (route_clean, TCP
+  close, Idle, idle-hold auto-reconnect). **No NOTIFICATION** is sent:
+  `fsm_stop` emits none, matching FRR's interface-down path, and the
+  link is down so a Cease couldn't be delivered anyway.
+- **Config flips do not bounce sessions.** The knob only changes how a
+  *future* link-down is handled (unlike `disable-connected-check`,
+  which bounces on change). Nothing to reconcile at commit time.
+- **Bonus (small, recommended):** on `RibRx::LinkUp`, kick matching
+  non-Established eligible peers with `Event::Start` so reconvergence
+  after the flap doesn't wait out the connect-retry backstop (up to
+  120 s). FRR gets this for free via NHT; we get it in three lines.
+
+### YANG schema
+
+Mirror the existing global boolean `no-fib-install` — a plain leaf in
+the ietf-bgp `container global`
+(`zebra-rs/yang/ietf-bgp@2023-07-05.yang:293`, add next to
+`no-fib-install` at :329). No new module, no `config.yang` import, and
+the config path comes out as `/router/bgp/global/fast-external-failover`.
+
+```yang
+leaf fast-external-failover {
+  type boolean;
+  default "true";
+  description
+    "When true (the default), immediately reset the session of any
+     directly connected (single-hop) eBGP neighbor whose interface
+     goes operationally down, instead of waiting for the hold timer
+     to expire. Single-hop means the session TTL is 1 or the
+     neighbor uses ttl-security (GTSM, directly connected by
+     definition); neighbors configured with ebgp-multihop and all
+     iBGP neighbors are unaffected. Setting this to false restores
+     hold-timer-only failure detection, equivalent to IOS-XR
+     'bgp fast-external-fallover disable' and FRR
+     'no bgp fast-external-failover'.";
+}
+```
+
+*Alternative considered:* a dedicated `zebra-bgp-fast-external-failover.yang`
+augment module (the `zebra-bgp-transport.yang` pattern). Rejected for
+v1 — that pattern earns its keep for multi-leaf feature groups and
+per-neighbor knobs; a single global boolean sits naturally beside
+`no-fib-install`, and one file beats four (module + 2 augments +
+import).
+
+### CLI sample config
+
+```
+router bgp {
+  global {
+    as 65001;
+    router-id 10.255.0.1;
+    fast-external-failover false;   # disable; absent/true = enabled (default)
+  }
+  neighbor 10.107.0.2 {
+    remote-as 65002;
+    afi-safi ipv4 {
+      enabled true;
+    }
+  }
+}
+```
+
+BDD / `vtyctl apply` YAML form:
+
+```yaml
+router:
+  bgp:
+    global:
+      as: 65001
+      router-id: 10.255.0.1
+      fast-external-failover: false
+```
+
+Book doc table row (`book/src/` BGP chapter, mirror the
+`no-fib-install` row):
+
+```
+| /router/bgp/global/fast-external-failover | true | Reset directly connected eBGP sessions immediately on interface down |
+```
+
+### CLI handler
+
+State: one field on `Bgp` (`zebra-rs/src/bgp/inst.rs:641`), initialized
+`true` (`inst.rs:1159` block):
+
+```rust
+/// IOS-XR `bgp fast-external-fallover` (default on): reset directly
+/// connected eBGP sessions immediately on RibRx::LinkDown instead of
+/// waiting for hold-timer expiry.
+pub fast_external_failover: bool,
+```
+
+Handler in `zebra-rs/src/bgp/config.rs`, next to
+`config_global_no_fib_install` (:71). One asymmetry vs `no-fib-install`:
+this knob defaults **true**, so `Delete` must restore `true`, not
+`false`, and a missing value token on delete must not early-return into
+stale state:
+
+```rust
+fn config_global_fast_external_failover(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Option<()> {
+    // Default-on knob: `set … false` disables; delete restores the default.
+    let flag = args.boolean().unwrap_or(true);
+    bgp.fast_external_failover = !op.is_set() || flag;
+    Some(())
+}
+```
+
+Registration in `callback_build` (`config.rs:3899` block):
+
+```rust
+self.callback_add(
+    "/router/bgp/global/fast-external-failover",
+    config_global_fast_external_failover,
+);
+```
+
+Plus the two standing guards every new knob gets:
+
+- schema-path parse-settability test in
+  `zebra-rs/src/config/manager.rs` (:2712-2917 block, mirror the
+  `ip-transparent` case);
+- a `#[tokio::test]` in `config.rs` asserting set-false/delete/set-true
+  transitions of `bgp.fast_external_failover` (mirror
+  `disable_connected_check_toggles_field_and_bounces_live_session`
+  minus the bounce — assert the knob does *not* bounce sessions).
+
+### Apply logic
+
+**1. Stop discarding link events.** In `process_rib_msg`
+(`bgp/inst.rs:3124`), ahead of the `_ => {}` catch-all:
+
+```rust
+RibRx::LinkDown(ifindex) | RibRx::LinkDel(ifindex) => {
+    self.link_down_failover(ifindex);
+}
+RibRx::LinkUp(ifindex) => {
+    self.link_up_kick(ifindex);
+}
+```
+
+**2. Peer-side predicates** (in `bgp/peer.rs`, next to
+`connected_check_applies` at :1218):
+
+```rust
+/// Whether fast-external-failover governs this peer: single-hop eBGP.
+/// FRR parity (`bgp_ifp_down`): default TTL-1 eBGP and GTSM
+/// (`ttl-security` — connected-only in zebra-rs) participate;
+/// `ebgp-multihop` opts out; iBGP (TTL 255) never participates.
+/// Deliberately NOT `connected_check_applies()`: that also exempts
+/// `disable-connected-check` and link-local peers, which FRR does
+/// fail over.
+pub fn fast_failover_applies(&self) -> bool {
+    self.is_ebgp() && self.config.transport.ebgp_multihop.is_none()
+}
+
+/// The interface this peer's session rides, as far as it can be
+/// determined at link-down time (FRR caches `peer->nexthop.ifp` at
+/// establish; we resolve live — see "edge cases" in the design doc).
+pub fn session_ifindex(&self, subnets: &ConnectedSubnets) -> Option<u32> {
+    match self.origin {
+        PeerOrigin::Interface { ifindex } => Some(ifindex),
+        _ => self
+            .scope_id // v6 link-local numbered peer
+            .or_else(|| subnets.ifindex_for(self.address)),
+    }
+}
+```
+
+**3. The failover sweep** (in `bgp/inst.rs`, next to
+`refresh_connected` at :2920; shape copied from `process_bfd_event` at
+:5229):
+
+```rust
+/// RibRx::LinkDown/LinkDel handler — RFC-agnostic fast external
+/// failover (IOS-XR `bgp fast-external-fallover`, on by default).
+/// Hard-resets every non-Idle single-hop eBGP peer whose session
+/// rides the downed interface. No NOTIFICATION (fsm_stop sends
+/// none; the link is down). The idle-hold timer re-dials.
+fn link_down_failover(&mut self, ifindex: u32) {
+    if !self.fast_external_failover {
+        return;
+    }
+    let victims: Vec<_> = self
+        .peers
+        .iter_all() // NOT iter(): that skips interface peers
+        .filter(|(_, p)| p.state != State::Idle)
+        .filter(|(_, p)| p.fast_failover_applies())
+        .filter(|(_, p)| p.session_ifindex(&self.connected_subnets) == Some(ifindex))
+        .map(|(_, p)| (p.ident, p.address))
+        .collect();
+    for (ident, addr) in victims {
+        tracing::warn!(
+            "fast-external-failover: interface {ifindex} down — resetting eBGP peer {addr}"
+        );
+        let _ = self.tx.try_send(Message::Event(ident, Event::Stop));
+    }
+}
+
+/// RibRx::LinkUp — re-kick eligible peers parked by an earlier
+/// failover so reconvergence doesn't wait out connect-retry.
+fn link_up_kick(&mut self, ifindex: u32) {
+    let kicks: Vec<_> = self
+        .peers
+        .iter_all()
+        .filter(|(_, p)| matches!(p.state, State::Idle | State::Active))
+        .filter(|(_, p)| p.session_ifindex(&self.connected_subnets) == Some(ifindex))
+        .map(|(_, p)| p.ident)
+        .collect();
+    for ident in kicks {
+        let _ = self.tx.try_send(Message::Event(ident, Event::Start));
+    }
+}
+```
+
+Notes on the sweep:
+
+- **Skip `Idle`.** Stop on an Idle peer is a no-op (`fsm()`
+  early-returns on `prev == new`), so filtering is just noise
+  avoidance. Every other state (Connect/Active/OpenSent/OpenConfirm/
+  Established) transitions cleanly to Idle with full teardown.
+- **`iter_all()`, not `iter()`** — `PeerMap::iter()` skips
+  interface-keyed peers, which are exactly the peers most obviously
+  governed by an interface-down.
+- **VRF instances work for free**: the RIB fans `LinkDown` out
+  VRF-filtered (`client_registry.iter_vrf`), so each per-VRF BGP
+  instance only ever sees its own interfaces.
+- **Dynamic peers** are address-keyed and matched via `ifindex_for`
+  like static ones; their teardown path is the normal FSM one.
+
+### Edge cases & deliberate simplifications
+
+1. **Live ifindex resolution vs FRR's cached `nexthop.ifp`.** We
+   resolve peer→ifindex at link-down time. This works because the RIB
+   emits `LinkDown` *before* withdrawing anything and does not emit
+   `AddrDel` on a flap — `ConnectedSubnets` still holds the mapping.
+   The one ordering that escapes: operator deletes the address
+   (`AddrDel` prunes the subnet) *and then* the link goes down — the
+   session survives until hold-timer, as today. Caching a
+   `session_ifindex: Option<u32>` on the Established transition (FRR's
+   approach) closes that hole; deferred as a follow-up since the flap
+   path — the case the feature exists for — is fully covered.
+2. **Peer address covered by two connected subnets on different
+   interfaces** (parallel links): `ifindex_for` returns the first
+   match, so the reset may key on the wrong link or be skipped. Same
+   limitation as the BFD single-hop keying that `ifindex_for` was built
+   for; the cached-ifindex follow-up fixes this too.
+3. **GTSM iBGP.** FRR technically fails over a directly connected GTSM
+   *iBGP* peer; we scope to eBGP only — the feature is named
+   *external*, XR documents "directly adjacent **external** peers",
+   and zebra-rs GTSM on iBGP is uncommon. Noted, not a bug.
+4. **`LinkDel` is treated as `LinkDown`.** Permanent removal implies
+   operational down; the peer parks in Active/Idle-hold and, for
+   interface peers, existing `LinkAdd` rematerialization brings it back
+   if the interface reappears.
+5. **No reset-reason bookkeeping yet.** `Peer` has no `last_reset`
+   field today, so "Interface down" as a `show bgp neighbors`-visible
+   reset reason (FRR's `PEER_DOWN_IF_DOWN`) is out of scope; the
+   `tracing::warn!` line is the v1 observability. A general
+   last-reset-reason field is a worthwhile standalone follow-up (it
+   would also serve BFD-down, hold-timer, collision, …).
+
+### Testing
+
+**Unit (config.rs / inst.rs, `cargo test -p zebra-rs`):**
+
+- knob transitions: default `true`; `set false` → `false`; `delete` →
+  `true`; no session bounce on flip.
+- sweep selection: build an instance with (a) single-hop eBGP peer on
+  ifindex 3, (b) `ebgp-multihop 2` eBGP peer on ifindex 3, (c) iBGP
+  peer on ifindex 3, (d) single-hop eBGP peer on ifindex 4 — feed
+  `RibRx::LinkDown(3)`, assert exactly (a) got `Event::Stop`; repeat
+  with the knob off, assert nobody did.
+- `session_ifindex`: interface-origin peer, scope_id peer,
+  connected-subnet peer, unresolvable peer.
+- manager.rs parse-settability guard for the new path.
+
+**BDD (`bdd/tests/features/bgp_fast_external_failover.feature`):**
+
+Two namespaces (z1, z2), one veth pair (feature-unique names), direct
+eBGP 10.107.0.1/24 ↔ 10.107.0.2/24, AS 65001/65002, default timers
+(hold 90). Note downing *either* veth end drops carrier on both — fine
+for both scenarios.
+
+- *Scenario: failover enabled (default)* — establish (settle ~10 s per
+  the session-timing house rule), `ip link set <veth> down` in z1,
+  assert z1's neighbor leaves `Established` within ~5 s (≪ hold time).
+- *Scenario: failover disabled* — apply `fast-external-failover: false`
+  on both, re-establish, link down, wait 10 s, assert **still**
+  `Established` on both (hold timer hasn't expired; TCP retransmits
+  silently — this is the discriminating assertion that the knob works).
+- *Scenario: recovery* — link back up (enabled case), assert
+  re-`Established` well under connect-retry (exercises `link_up_kick`).
+- *Scenario: Teardown topology* — stop zebra-rs in each namespace,
+  delete namespaces, assert clean environment (house rule; mirror
+  `bgp_allowas_in.feature`).
+
+BDD doc page `bdd/docs/bgp_fast_external_failover.md` mirroring
+`bgp_disable_connected_check.md`.
+
+## Phasing
+
+Smallest-first; each lands green on its own.
+
+- **PR 1 — knob + failover core.** YANG leaf, `Bgp` field, config
+  handler + registration, `LinkDown/LinkDel` arm + `link_down_failover`
+  + peer predicates, `LinkUp` kick, unit tests, manager.rs guard, book
+  table row. This is the whole IOS-XR-parity feature.
+- **PR 2 — BDD.** Feature file + configs + doc page as above.
+- **Follow-ups (separate, optional):**
+  - cached `session_ifindex` at Established (closes edge cases 1–2);
+  - `Peer.last_reset` reason plumbed into `show bgp neighbors`
+    (serves BFD-down/hold-timer/collision too);
+  - per-neighbor override via `InheritableKnobs` (classic-IOS-style
+    granularity; XR itself has none — only add on real demand).
+
+## Open questions
+
+1. Should `LinkUp` also re-kick peers that were *not* reset by us
+   (e.g. parked by the connected-check gate)? The sketch above kicks
+   any Idle/Active peer on that interface — harmless (`fsm_start`
+   re-runs its own gates) and simpler than tracking "who we downed".
+   Recommend yes as sketched.
+2. Is `warn!` the right log level for a triggered failover? It's an
+   expected, correct reaction to a link event — `info!` may fit the
+   house style better. Cosmetic; decide in review.

--- a/zebra-rs/src/bgp/config.rs
+++ b/zebra-rs/src/bgp/config.rs
@@ -76,6 +76,20 @@ fn config_global_no_fib_install(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> 
     Some(())
 }
 
+/// `set router bgp global fast-external-failover <true|false>` —
+/// IOS-XR `bgp fast-external-fallover` parity, on by default: reset
+/// directly connected eBGP sessions immediately on interface down
+/// (`Bgp::link_down_failover`) instead of waiting for hold-timer
+/// expiry. Unlike `no-fib-install` this knob defaults *true*, so
+/// Delete restores `true`; and a missing value token must not
+/// early-return into stale state. Flipping the knob never bounces
+/// sessions — it only changes how a future link-down is handled.
+fn config_global_fast_external_failover(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Option<()> {
+    let flag = args.boolean().unwrap_or(true);
+    bgp.fast_external_failover = !op.is_set() || flag;
+    Some(())
+}
+
 /// `set router bgp lua-script <name> source-path <path>` — load a named
 /// Lua script from a file into the global script registry. With the `lua`
 /// build feature off the registry is still populated (so a config
@@ -3903,6 +3917,10 @@ impl Bgp {
             "/router/bgp/global/no-fib-install",
             config_global_no_fib_install,
         );
+        self.callback_add(
+            "/router/bgp/global/fast-external-failover",
+            config_global_fast_external_failover,
+        );
         // `router bgp port <0-65535>` (zebra-bgp-transport.yang): the
         // listener port; 0 disables listening.
         self.callback_add("/router/bgp/port", config_global_port);
@@ -5615,6 +5633,138 @@ mod neighbor_group_wiring_tests {
             config: false,
             fib: true,
         }
+    }
+
+    /// Like [`link_addr`] but on a caller-chosen interface.
+    fn link_addr_on(cidr: &str, ifindex: u32) -> crate::rib::link::LinkAddr {
+        crate::rib::link::LinkAddr {
+            ifindex,
+            ..link_addr(cidr)
+        }
+    }
+
+    /// Drain `bgp.rx`, returning the peer-ident of every queued
+    /// `Event::Start`. Other event variants are ignored.
+    fn drain_start_events(bgp: &mut Bgp) -> Vec<usize> {
+        use crate::bgp::inst::Message;
+        use crate::bgp::peer::Event;
+        let mut out = Vec::new();
+        while let Ok(msg) = bgp.rx.try_recv() {
+            if let Message::Event(ident, Event::Start) = msg {
+                out.push(ident);
+            }
+        }
+        out
+    }
+
+    /// `fast-external-failover` is a default-ON global boolean (IOS-XR
+    /// `bgp fast-external-fallover` parity): Set false disables, Set
+    /// true re-enables, and Delete restores the default (true) rather
+    /// than clearing to false. Flipping the knob never bounces
+    /// sessions — it only changes how a future link-down is handled.
+    #[tokio::test]
+    async fn fast_external_failover_knob_transitions() {
+        use crate::bgp::peer::State;
+        let mut bgp = fresh_bgp();
+        assert!(bgp.fast_external_failover, "must default to enabled");
+
+        config_peer(&mut bgp, arg_words(&["10.0.0.1"]), ConfigOp::Set).unwrap();
+        config_remote_as(&mut bgp, arg_words(&["10.0.0.1", "65001"]), ConfigOp::Set).unwrap();
+        let _ = drain_stop_events(&mut bgp);
+        bgp.peers.get_mut(&peer_addr()).unwrap().state = State::Established;
+
+        config_global_fast_external_failover(&mut bgp, arg_words(&["false"]), ConfigOp::Set)
+            .unwrap();
+        assert!(!bgp.fast_external_failover, "set false must disable");
+
+        config_global_fast_external_failover(&mut bgp, arg_words(&["true"]), ConfigOp::Set)
+            .unwrap();
+        assert!(bgp.fast_external_failover, "set true must re-enable");
+
+        config_global_fast_external_failover(&mut bgp, arg_words(&["false"]), ConfigOp::Set)
+            .unwrap();
+        config_global_fast_external_failover(&mut bgp, arg_words(&["false"]), ConfigOp::Delete)
+            .unwrap();
+        assert!(
+            bgp.fast_external_failover,
+            "delete must restore the default (true)",
+        );
+
+        assert!(
+            drain_stop_events(&mut bgp).is_empty(),
+            "knob flips must not bounce sessions",
+        );
+    }
+
+    /// Park a configured peer in a chosen FSM state, returning its ident.
+    fn park_peer(bgp: &mut Bgp, addr: &str, state: crate::bgp::peer::State) -> usize {
+        let ip: IpAddr = addr.parse().unwrap();
+        let peer = bgp.peers.get_mut(&ip).unwrap();
+        peer.state = state;
+        peer.ident
+    }
+
+    /// `RibRx::LinkDown` resets exactly the non-Idle single-hop eBGP
+    /// peers whose session rides the downed interface: `ebgp-multihop`,
+    /// iBGP and other-interface peers survive; with the knob off nobody
+    /// is reset. `RibRx::LinkUp` re-kicks parked (Idle/Active) peers on
+    /// that interface with `Event::Start`.
+    #[tokio::test]
+    async fn fast_external_failover_sweep_selection() {
+        use crate::bgp::peer::State;
+        use crate::rib::api::RibRx;
+        let mut bgp = fresh_bgp();
+        config_global_asn(&mut bgp, arg_words(&["65000"]), ConfigOp::Set).unwrap();
+
+        // Two connected subnets: 10.0.3.0/24 on ifindex 3, 10.0.4.0/24 on 4.
+        bgp.connected_subnets
+            .record(&link_addr_on("10.0.3.1/24", 3));
+        bgp.connected_subnets
+            .record(&link_addr_on("10.0.4.1/24", 4));
+
+        for (addr, remote_as) in [
+            ("10.0.3.2", "65001"), // single-hop eBGP on ifindex 3 — the victim
+            ("10.0.3.3", "65001"), // eBGP but multihop — survives
+            ("10.0.3.4", "65000"), // iBGP on ifindex 3 — survives
+            ("10.0.4.2", "65001"), // single-hop eBGP on ifindex 4 — survives
+        ] {
+            config_peer(&mut bgp, arg_words(&[addr]), ConfigOp::Set).unwrap();
+            config_remote_as(&mut bgp, arg_words(&[addr, remote_as]), ConfigOp::Set).unwrap();
+        }
+        config_ebgp_multihop(&mut bgp, arg_words(&["10.0.3.3", "2"]), ConfigOp::Set).unwrap();
+        let _ = drain_stop_events(&mut bgp);
+        let _ = drain_start_events(&mut bgp);
+
+        let victim = park_peer(&mut bgp, "10.0.3.2", State::Established);
+        park_peer(&mut bgp, "10.0.3.3", State::Established);
+        park_peer(&mut bgp, "10.0.3.4", State::Established);
+        park_peer(&mut bgp, "10.0.4.2", State::Established);
+
+        bgp.process_rib_msg(RibRx::LinkDown(3));
+        assert_eq!(
+            drain_stop_events(&mut bgp),
+            vec![victim],
+            "exactly the single-hop eBGP peer on the downed interface must be reset",
+        );
+
+        // LinkUp re-kicks a parked peer on that interface; Established
+        // peers are left alone.
+        park_peer(&mut bgp, "10.0.3.2", State::Active);
+        bgp.process_rib_msg(RibRx::LinkUp(3));
+        assert_eq!(
+            drain_start_events(&mut bgp),
+            vec![victim],
+            "LinkUp must re-kick the parked peer (and only it)",
+        );
+
+        // Knob off: even an eligible peer survives its interface going down.
+        config_global_fast_external_failover(&mut bgp, arg_words(&["false"]), ConfigOp::Set)
+            .unwrap();
+        bgp.process_rib_msg(RibRx::LinkDown(4));
+        assert!(
+            drain_stop_events(&mut bgp).is_empty(),
+            "knob off must disable the failover sweep",
+        );
     }
 
     /// `disable-connected-check` is a presence flag: Set/Delete toggle

--- a/zebra-rs/src/bgp/inst.rs
+++ b/zebra-rs/src/bgp/inst.rs
@@ -753,6 +753,12 @@ pub struct Bgp {
     /// field mirrors it for `show` / re-application. Scope is the
     /// default-VRF instance; per-VRF suppression is a follow-up.
     pub no_fib_install: bool,
+    /// `router bgp global fast-external-failover` (IOS-XR
+    /// `bgp fast-external-fallover`, on by default): on
+    /// `RibRx::LinkDown`/`LinkDel`, immediately hard-reset every
+    /// single-hop eBGP session riding the downed interface instead of
+    /// waiting out the hold timer. See [`Self::link_down_failover`].
+    pub fast_external_failover: bool,
     pub peers: PeerMap,
     /// Instance-level BFD defaults (`router bgp { bfd {} }`), inherited by
     /// every neighbor and overridden per neighbor (see
@@ -1157,6 +1163,7 @@ impl Bgp {
             ethernet_segments: BTreeMap::new(),
             hostname: None,
             no_fib_install: false,
+            fast_external_failover: true,
             peers: PeerMap::new(),
             bfd: PeerBfdConfig::default(),
             tx,
@@ -2940,6 +2947,60 @@ impl Bgp {
         }
     }
 
+    /// `RibRx::LinkDown`/`LinkDel` handler — fast external failover
+    /// (IOS-XR `bgp fast-external-fallover`, FRR
+    /// `bgp fast-external-failover`; on by default). Hard-resets every
+    /// non-Idle single-hop eBGP peer whose session rides the downed
+    /// interface, so failure detection is the link event rather than
+    /// hold-timer expiry. `Event::Stop` → `fsm_stop` sends no
+    /// NOTIFICATION — matching FRR's interface-down path, and the link
+    /// is down so nothing would be delivered anyway. The idle-hold
+    /// timer re-dials afterwards as usual.
+    fn link_down_failover(&mut self, ifindex: u32) {
+        use super::peer::State;
+        if !self.fast_external_failover {
+            return;
+        }
+        let victims: Vec<_> = self
+            .peers
+            .iter_all() // NOT iter(): that skips interface-keyed peers
+            .map(|(_, p)| p)
+            .filter(|p| p.state != State::Idle)
+            .filter(|p| p.fast_failover_applies())
+            .filter(|p| p.session_ifindex(&self.connected_subnets) == Some(ifindex))
+            .map(|p| (p.ident, p.address))
+            .collect();
+        for (ident, addr) in victims {
+            tracing::warn!(
+                peer = %addr,
+                ifindex,
+                "bgp: fast-external-failover: interface down — resetting eBGP peer",
+            );
+            let _ = self.tx.try_send(Message::Event(ident, Event::Stop));
+        }
+    }
+
+    /// `RibRx::LinkUp` — re-kick peers parked on this interface
+    /// (by an earlier failover reset, a failed dial while the link was
+    /// down, or the connected-check gate) so reconvergence doesn't wait
+    /// out the connect-retry backstop. Not gated on
+    /// `fast_external_failover`: `fsm_start` re-runs its own gates, so
+    /// an early Start is harmless for peers we didn't reset.
+    fn link_up_kick(&mut self, ifindex: u32) {
+        use super::peer::State;
+        let kicks: Vec<_> = self
+            .peers
+            .iter_all()
+            .map(|(_, p)| p)
+            .filter(|p| p.active && matches!(p.state, State::Idle | State::Active))
+            .filter(|p| p.session_ifindex(&self.connected_subnets) == Some(ifindex))
+            .map(|p| p.ident)
+            .collect();
+        for ident in kicks {
+            let _ = self.tx.try_send(Message::Event(ident, Event::Start));
+        }
+    }
+
     /// Re-tag and re-advertise a VRF's locally-originated VPNv4 routes
     /// with the current export route-targets. Called when a VRF's RT
     /// policy is (re-)learned: the per-VRF route export can race ahead of
@@ -3139,6 +3200,17 @@ impl Bgp {
                 if self.interface_neighbors.contains_key(&link.name) {
                     super::interface_neighbor::materialize_dormant(self, &link.name);
                 }
+            }
+            // Fast external failover: a link going operationally down
+            // (or disappearing) immediately resets the single-hop eBGP
+            // sessions riding it, instead of leaving them to hold-timer
+            // expiry. LinkUp re-kicks parked peers for fast
+            // reconvergence.
+            RibRx::LinkDown(ifindex) | RibRx::LinkDel(ifindex) => {
+                self.link_down_failover(ifindex);
+            }
+            RibRx::LinkUp(ifindex) => {
+                self.link_up_kick(ifindex);
             }
             RibRx::AddrAdd(addr) => {
                 self.interface_addrs.record(&addr);

--- a/zebra-rs/src/bgp/peer.rs
+++ b/zebra-rs/src/bgp/peer.rs
@@ -1233,6 +1233,34 @@ impl Peer {
         !self.connected_check_applies() || self.shared_network
     }
 
+    /// Whether fast-external-failover governs this peer: single-hop
+    /// eBGP. FRR parity (`bgp_ifp_down`): default TTL-1 eBGP and GTSM
+    /// (`ttl-security` — connected-only in zebra-rs) participate;
+    /// `ebgp-multihop` opts out; iBGP (TTL 255) never participates.
+    /// Deliberately NOT [`Self::connected_check_applies`]: that also
+    /// exempts `disable-connected-check` and link-local peers, which
+    /// FRR does fail over.
+    pub fn fast_failover_applies(&self) -> bool {
+        self.is_ebgp() && self.config.transport.ebgp_multihop.is_none()
+    }
+
+    /// The interface this peer's session rides, as far as it can be
+    /// determined at link-down time. FRR caches `peer->nexthop.ifp` at
+    /// session establish; we resolve live instead — safe on a flap
+    /// because the RIB emits `LinkDown` before withdrawing anything
+    /// and does not emit `AddrDel` for retained addresses, so the
+    /// subnet table still maps the peer to the downed ifindex. (The
+    /// escape — operator deletes the address, then downs the link — is
+    /// an accepted v1 gap; see the design doc.)
+    pub fn session_ifindex(&self, subnets: &super::connected::ConnectedSubnets) -> Option<u32> {
+        match self.origin {
+            PeerOrigin::Interface { ifindex } => Some(ifindex),
+            _ => self
+                .scope_id // v6 link-local numbered peer
+                .or_else(|| subnets.ifindex_for(self.address)),
+        }
+    }
+
     /// Effective BFD hop mode for this neighbour: the explicit
     /// `bfd multihop` override if set, else inferred from the BGP
     /// session type (iBGP ⇒ multihop), mirroring FRR's

--- a/zebra-rs/src/config/manager.rs
+++ b/zebra-rs/src/config/manager.rs
@@ -2797,6 +2797,47 @@ mod yang_load_tests {
         );
     }
 
+    /// `router bgp global fast-external-failover <bool>` (a zebra-rs
+    /// leaf added to the ietf-bgp `container global`) must be a
+    /// settable path, and — being a boolean leaf, not a presence
+    /// container — the value-less spelling must not parse.
+    #[test]
+    fn bgp_global_fast_external_failover_is_settable() {
+        use crate::config::ExecCode;
+        use crate::config::parse::{State, parse};
+        use libyang::to_entry;
+
+        let mut yang = YangStore::new();
+        yang.add_path(concat!(env!("CARGO_MANIFEST_DIR"), "/yang"));
+        yang.read_with_resolve("configure")
+            .expect("configure mode loads");
+        yang.identity_resolve();
+        let module = yang
+            .find_module("configure")
+            .expect("configure module present");
+        let entry = to_entry(&yang, module);
+
+        for cmd in [
+            "set router bgp global fast-external-failover false",
+            "set router bgp global fast-external-failover true",
+        ] {
+            let (code, _comps, _state) = parse(cmd, entry.clone(), None, State::new());
+            assert_eq!(code, ExecCode::Success, "`{cmd}` must be a valid path",);
+        }
+
+        let (code, _comps, _state) = parse(
+            "set router bgp global fast-external-failover",
+            entry,
+            None,
+            State::new(),
+        );
+        assert_ne!(
+            code,
+            ExecCode::Success,
+            "boolean leaf — the value-less spelling must not parse",
+        );
+    }
+
     /// `neighbor X ip-transparent` (zebra-bgp-transport.yang) must be a
     /// settable path on the neighbor and on the neighbor-group (the
     /// group reuses the transport grouping via `uses`). Guards against

--- a/zebra-rs/yang/ietf-bgp@2023-07-05.yang
+++ b/zebra-rs/yang/ietf-bgp@2023-07-05.yang
@@ -342,6 +342,23 @@ module ietf-bgp {
              rather than retroactively withdrawing already-installed
              entries.";
         }
+        // zebra-rs extension: not part of the IETF model.
+        leaf fast-external-failover {
+          type boolean;
+          default "true";
+          description
+            "When true (the default), immediately reset the session of
+             any directly connected (single-hop) eBGP neighbor whose
+             interface goes operationally down, instead of waiting for
+             the hold timer to expire. Single-hop means the session TTL
+             is 1 or the neighbor uses ttl-security (GTSM, directly
+             connected by definition); neighbors configured with
+             ebgp-multihop and all iBGP neighbors are unaffected.
+             Setting this to false restores hold-timer-only failure
+             detection, equivalent to IOS-XR
+             'bgp fast-external-fallover disable' and FRR
+             'no bgp fast-external-failover'.";
+        }
         container distance {
           description
             "Administrative distances (or preferences) assigned to


### PR DESCRIPTION
## Summary

- Reset **directly connected (single-hop) eBGP** sessions immediately when their interface goes operationally down, instead of waiting out the hold timer — IOS-XR `bgp fast-external-fallover` / FRR `bgp fast-external-failover` parity, **enabled by default**; disable with `set router bgp global fast-external-failover false`.
- BGP already received `RibRx::LinkDown` but discarded it in the `process_rib_msg` catch-all. New `LinkDown`/`LinkDel` arms drive a `link_down_failover()` sweep: hard reset via `Event::Stop` (no NOTIFICATION — matching FRR's interface-down path; the link is down anyway) for every non-Idle peer that is single-hop eBGP (`is_ebgp() && ebgp_multihop.is_none()`; `ttl-security` GTSM is connected-only in zebra-rs so it participates) and whose `session_ifindex()` (interface-origin ifindex → v6 link-local `scope_id` → `ConnectedSubnets::ifindex_for`) matches the downed interface.
- Live ifindex resolution is safe: the RIB emits `LinkDown` **before** withdrawing anything and does not emit `AddrDel` for addresses retained on down (`keep_addr_on_down`).
- `LinkUp` re-kicks parked (Idle/Active) peers on that interface with `Event::Start` so recovery doesn't wait out the connect-retry backstop.
- YANG: boolean leaf in the ietf-bgp `container global` beside `no-fib-install`, `default "true"` — so, unlike `no-fib-install`, Delete restores *true*. Flipping the knob never bounces sessions; it only changes how the next link-down is handled.
- Includes the design doc (`docs/design/bgp-fast-external-failover.md`) and a book chapter (`ch-02-37`). This is PR 1 of the design's phasing; the BDD feature is PR 2.

## Testing

- New unit tests: knob transitions (default true / set false / set true / delete restores true; no session bounce), sweep selection (`ebgp-multihop`, iBGP and other-interface peers survive; knob off disables the sweep; LinkUp kicks exactly the parked peer), and a manager.rs parse-settability guard for the new path (value-less spelling rejected).
- `cargo fmt`, `cargo clippy --workspace --all-targets -- -D warnings` clean.
- `cargo test --workspace --exclude bdd`: 2124 passed, 0 failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)