### PR TITLE
feat: cradle tee — labeled nexthops, ILM entries, resolved neighbors

### DIFF
--- a/proto/cradle.proto
+++ b/proto/cradle.proto
@@ -28,6 +28,7 @@ message Nexthop {
   string oif = 3;         // output interface name (used when oif_index == 0)
   uint32 oif_index = 4;   // output ifindex; preferred when non-zero
   bool v6 = 5;            // IPv6 nexthop (gateway parsed as IPv6)
+  repeated uint32 labels = 6;  // MPLS out-label stack, [0] = outermost
 }
 
 // A nexthop group for ECMP: ordered member nexthop ids. A route whose flags
@@ -48,6 +49,22 @@ message Route4Del {
   string prefix = 1;
 }
 
+// Bulk route install — the initial-load path. In dir24 mode each affected
+// /24 block is recomputed once per batch instead of once per route.
+message Route4Batch {
+  repeated Route4 routes = 1;
+}
+
+message FibSummaryRequest {}
+
+// IPv4 FIB engine state (`cradle ctl fib`).
+message FibSummary {
+  string fib4_mode = 1;  // "lpm" | "dir24"
+  uint64 routes4 = 2;    // dir24 shadow route count (0 in lpm mode)
+  uint32 tbl8_used = 3;
+  uint32 tbl8_free = 4;
+}
+
 message Route6 {
   string prefix = 1;   // "addr/len"
   uint32 nexthop_id = 2;
@@ -59,9 +76,32 @@ message Route6Del {
 }
 
 message Neighbor4 {
-  string oif = 1;
+  string oif = 1;       // interface name (used when oif_index == 0)
   string ip = 2;
   string mac = 3;
+  uint32 oif_index = 4; // ifindex; preferred when non-zero
+}
+
+message Neighbor6 {
+  string oif = 1;       // interface name (used when oif_index == 0)
+  string ip = 2;
+  string mac = 3;
+  uint32 oif_index = 4; // ifindex; preferred when non-zero
+}
+
+// An incoming-label map (ILM) entry — mirrors zebra-rs's FibHandle
+// ilm_add/ilm_replace/ilm_del. `action` is MPLS_OP_*: 0 = swap (the nexthop's
+// labels are the out stack), 1 = pop-to-IP (PHP / L3VPN egress),
+// 2 = pop one label.
+message Ilm {
+  uint32 in_label = 1;      // 20-bit incoming label (the LFIB key)
+  uint32 nexthop_id = 2;    // resolved nexthop; its labels are the swap stack
+  uint32 action = 3;        // MPLS_OP_SWAP | POP_L3 | POP
+  uint32 vrf_table_id = 4;  // for POP_L3 into a VRF (0 = global)
+}
+
+message IlmDel {
+  uint32 in_label = 1;
 }
 
 message Backend {
@@ -77,15 +117,49 @@ message Service {
   repeated Backend backends = 5;
 }
 
+message StatsRequest {}
+
+// One datapath counter: a packet count at a forwarding decision point.
+message StatEntry {
+  string name = 1;
+  uint64 packets = 2;
+}
+
+message StatsReply {
+  repeated StatEntry entries = 1;
+}
+
+// An L7 (HTTP) path-prefix route to a backend.
+message L7Route {
+  string path_prefix = 1;  // longest-prefix match on the request path
+  string backend_ip = 2;
+  uint32 backend_port = 3;
+}
+
+// An L7 service: TCP flows to vip:port are steered to the transparent proxy,
+// which routes by HTTP path to one of `routes`.
+message L7Service {
+  string vip = 1;
+  uint32 port = 2;
+  repeated L7Route routes = 3;
+}
+
 service Cradle {
   rpc SetPort(Port) returns (Empty);
   rpc SetL2Domain(L2Domain) returns (Empty);
   rpc SetNexthop(Nexthop) returns (Empty);
   rpc SetNexthopGroup(NexthopGroup) returns (Empty);
   rpc AddRoute4(Route4) returns (Empty);
+  rpc AddRoute4Batch(Route4Batch) returns (Empty);
   rpc DelRoute4(Route4Del) returns (Empty);
+  rpc GetFibSummary(FibSummaryRequest) returns (FibSummary);
   rpc AddRoute6(Route6) returns (Empty);
   rpc DelRoute6(Route6Del) returns (Empty);
   rpc SetNeighbor4(Neighbor4) returns (Empty);
+  rpc SetNeighbor6(Neighbor6) returns (Empty);
+  rpc AddIlm(Ilm) returns (Empty);
+  rpc DelIlm(IlmDel) returns (Empty);
   rpc AddService(Service) returns (Empty);
+  rpc GetStats(StatsRequest) returns (StatsReply);
+  rpc AddL7Service(L7Service) returns (Empty);
 }

--- a/zebra-rs/src/fib/cradle.rs
+++ b/zebra-rs/src/fib/cradle.rs
@@ -8,7 +8,7 @@
 //! integration.
 
 use std::collections::HashMap;
-use std::net::{Ipv4Addr, Ipv6Addr};
+use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
 use std::sync::Arc;
 use std::sync::atomic::{AtomicU32, Ordering};
 
@@ -24,14 +24,18 @@ use pb::cradle_client::CradleClient;
 /// Mirrors `cradle_common::FIB_F_ECMP` (data-plane ABI; kept local so this file
 /// has no dependency on the cradle crates).
 const FIB_F_ECMP: u32 = 1 << 3;
+/// Mirrors `cradle_common::MPLS_OP_*` — the ILM `action` values.
+pub const MPLS_OP_SWAP: u32 = 0;
+pub const MPLS_OP_POP_L3: u32 = 1;
 
 #[derive(Clone)]
 pub struct CradleFib {
     endpoint: String,
     client: Arc<Mutex<Option<CradleClient<Channel>>>>,
-    /// Dedup `(gateway, oif) -> nexthop id` so we `SetNexthop` once per nexthop.
-    nh_ids: Arc<Mutex<HashMap<(u32, u32), u32>>>,
-    nh_ids6: Arc<Mutex<HashMap<([u8; 16], u32), u32>>>,
+    /// Dedup `(gateway, oif, out-label stack) -> nexthop id` so we
+    /// `SetNexthop` once per distinct nexthop.
+    nh_ids: Arc<Mutex<HashMap<(u32, u32, Vec<u32>), u32>>>,
+    nh_ids6: Arc<Mutex<HashMap<([u8; 16], u32, Vec<u32>), u32>>>,
     next_id: Arc<AtomicU32>,
 }
 
@@ -69,9 +73,16 @@ impl CradleFib {
         Ok(guard.as_ref().unwrap().clone())
     }
 
-    /// Resolve (creating if needed) the cradle nexthop id for `(gw, oif)`.
-    async fn nexthop_id(&self, gw: Option<Ipv4Addr>, oif: u32) -> anyhow::Result<u32> {
-        let key = (gw.map(u32::from).unwrap_or(0), oif);
+    /// Resolve (creating if needed) the cradle nexthop id for
+    /// `(gw, oif, out-label stack)`. A non-empty `labels` makes this an MPLS
+    /// nexthop: the stack is the imposition (route) or swap (ILM) labels.
+    async fn nexthop_id(
+        &self,
+        gw: Option<Ipv4Addr>,
+        oif: u32,
+        labels: &[u32],
+    ) -> anyhow::Result<u32> {
+        let key = (gw.map(u32::from).unwrap_or(0), oif, labels.to_vec());
         {
             let ids = self.nh_ids.lock().await;
             if let Some(id) = ids.get(&key) {
@@ -87,6 +98,7 @@ impl CradleFib {
                 oif: String::new(),
                 oif_index: oif,
                 v6: false,
+                labels: labels.to_vec(),
             })
             .await?;
         self.nh_ids.lock().await.insert(key, id);
@@ -94,8 +106,14 @@ impl CradleFib {
     }
 
     /// Install an IPv4 route with one or more nexthops. A single member becomes
-    /// a plain route; multiple members become an ECMP nexthop group.
-    pub async fn route_install(&self, prefix: Ipv4Net, members: Vec<(Option<Ipv4Addr>, u32)>) {
+    /// a plain route; multiple members become an ECMP nexthop group. Each
+    /// member is `(gateway, oif, out-label stack)` — a non-empty stack makes
+    /// the leg an MPLS imposition (ingress LER).
+    pub async fn route_install(
+        &self,
+        prefix: Ipv4Net,
+        members: Vec<(Option<Ipv4Addr>, u32, Vec<u32>)>,
+    ) {
         if let Err(e) = self.try_route_install(prefix, members).await {
             tracing::warn!("fib: cradle route_install {prefix} failed: {e}");
         }
@@ -104,14 +122,14 @@ impl CradleFib {
     async fn try_route_install(
         &self,
         prefix: Ipv4Net,
-        members: Vec<(Option<Ipv4Addr>, u32)>,
+        members: Vec<(Option<Ipv4Addr>, u32, Vec<u32>)>,
     ) -> anyhow::Result<()> {
         if members.is_empty() {
             return Ok(());
         }
         if members.len() == 1 {
-            let (gw, oif) = members[0];
-            let id = self.nexthop_id(gw, oif).await?;
+            let (gw, oif, labels) = &members[0];
+            let id = self.nexthop_id(*gw, *oif, labels).await?;
             self.client()
                 .await?
                 .add_route4(pb::Route4 {
@@ -124,8 +142,8 @@ impl CradleFib {
         }
         // ECMP: one nexthop per member, then a group the route points at.
         let mut ids = Vec::with_capacity(members.len());
-        for (gw, oif) in &members {
-            ids.push(self.nexthop_id(*gw, *oif).await?);
+        for (gw, oif, labels) in &members {
+            ids.push(self.nexthop_id(*gw, *oif, labels).await?);
         }
         let gid = self.next_id.fetch_add(1, Ordering::Relaxed);
         let mut client = self.client().await?;
@@ -165,8 +183,17 @@ impl CradleFib {
         }
     }
 
-    async fn nexthop_id6(&self, gw: Option<Ipv6Addr>, oif: u32) -> anyhow::Result<u32> {
-        let key = (gw.map(|a| a.octets()).unwrap_or([0; 16]), oif);
+    async fn nexthop_id6(
+        &self,
+        gw: Option<Ipv6Addr>,
+        oif: u32,
+        labels: &[u32],
+    ) -> anyhow::Result<u32> {
+        let key = (
+            gw.map(|a| a.octets()).unwrap_or([0; 16]),
+            oif,
+            labels.to_vec(),
+        );
         {
             let ids = self.nh_ids6.lock().await;
             if let Some(id) = ids.get(&key) {
@@ -182,6 +209,7 @@ impl CradleFib {
                 oif: String::new(),
                 oif_index: oif,
                 v6: true,
+                labels: labels.to_vec(),
             })
             .await?;
         self.nh_ids6.lock().await.insert(key, id);
@@ -190,7 +218,11 @@ impl CradleFib {
 
     /// Install an IPv6 route with one or more nexthops (single = plain route,
     /// multiple = ECMP nexthop group).
-    pub async fn route_install6(&self, prefix: Ipv6Net, members: Vec<(Option<Ipv6Addr>, u32)>) {
+    pub async fn route_install6(
+        &self,
+        prefix: Ipv6Net,
+        members: Vec<(Option<Ipv6Addr>, u32, Vec<u32>)>,
+    ) {
         if let Err(e) = self.try_route_install6(prefix, members).await {
             tracing::warn!("fib: cradle route_install6 {prefix} failed: {e}");
         }
@@ -199,14 +231,14 @@ impl CradleFib {
     async fn try_route_install6(
         &self,
         prefix: Ipv6Net,
-        members: Vec<(Option<Ipv6Addr>, u32)>,
+        members: Vec<(Option<Ipv6Addr>, u32, Vec<u32>)>,
     ) -> anyhow::Result<()> {
         if members.is_empty() {
             return Ok(());
         }
         if members.len() == 1 {
-            let (gw, oif) = members[0];
-            let id = self.nexthop_id6(gw, oif).await?;
+            let (gw, oif, labels) = &members[0];
+            let id = self.nexthop_id6(*gw, *oif, labels).await?;
             self.client()
                 .await?
                 .add_route6(pb::Route6 {
@@ -218,8 +250,8 @@ impl CradleFib {
             return Ok(());
         }
         let mut ids = Vec::with_capacity(members.len());
-        for (gw, oif) in &members {
-            ids.push(self.nexthop_id6(*gw, *oif).await?);
+        for (gw, oif, labels) in &members {
+            ids.push(self.nexthop_id6(*gw, *oif, labels).await?);
         }
         let gid = self.next_id.fetch_add(1, Ordering::Relaxed);
         let mut client = self.client().await?;
@@ -252,6 +284,96 @@ impl CradleFib {
         .await;
         if let Err(e) = result {
             tracing::warn!("fib: cradle route_del6 {prefix} failed: {e}");
+        }
+    }
+
+    /// Install an ILM (incoming-label map) entry: `in_label` gets `action`
+    /// (`MPLS_OP_SWAP` with the nexthop's `out_labels` as the imposed stack —
+    /// empty = PHP, popped by the data plane on the S bit — or
+    /// `MPLS_OP_POP_L3` with `vrf_table_id` for VPN decap) via `(gw, oif)`.
+    pub async fn ilm_install(
+        &self,
+        in_label: u32,
+        action: u32,
+        vrf_table_id: u32,
+        gw: Option<IpAddr>,
+        oif: u32,
+        out_labels: &[u32],
+    ) {
+        let result = async {
+            let nexthop_id = match gw {
+                Some(IpAddr::V6(v6)) => self.nexthop_id6(Some(v6), oif, out_labels).await?,
+                Some(IpAddr::V4(v4)) => self.nexthop_id(Some(v4), oif, out_labels).await?,
+                None => self.nexthop_id(None, oif, out_labels).await?,
+            };
+            self.client()
+                .await?
+                .add_ilm(pb::Ilm {
+                    in_label,
+                    nexthop_id,
+                    action,
+                    vrf_table_id,
+                })
+                .await?;
+            anyhow::Ok(())
+        }
+        .await;
+        if let Err(e) = result {
+            tracing::warn!("fib: cradle ilm_install {in_label} failed: {e}");
+        }
+    }
+
+    pub async fn ilm_uninstall(&self, in_label: u32) {
+        let result = async {
+            self.client()
+                .await?
+                .del_ilm(pb::IlmDel { in_label })
+                .await?;
+            anyhow::Ok(())
+        }
+        .await;
+        if let Err(e) = result {
+            tracing::warn!("fib: cradle ilm_uninstall {in_label} failed: {e}");
+        }
+    }
+
+    /// Feed a resolved neighbor (ARP/ND) into the cradle data plane — the
+    /// MPLS egress rewrite (`mpls_l2_xmit`) resolves destination MACs from
+    /// this state rather than the kernel neighbor table.
+    pub async fn neighbor_add(&self, ip: IpAddr, oif_index: u32, mac: [u8; 6]) {
+        let mac = format!(
+            "{:02x}:{:02x}:{:02x}:{:02x}:{:02x}:{:02x}",
+            mac[0], mac[1], mac[2], mac[3], mac[4], mac[5]
+        );
+        let result = async {
+            let mut client = self.client().await?;
+            match ip {
+                IpAddr::V4(v4) => {
+                    client
+                        .set_neighbor4(pb::Neighbor4 {
+                            oif: String::new(),
+                            ip: v4.to_string(),
+                            mac,
+                            oif_index,
+                        })
+                        .await?;
+                }
+                IpAddr::V6(v6) => {
+                    client
+                        .set_neighbor6(pb::Neighbor6 {
+                            oif: String::new(),
+                            ip: v6.to_string(),
+                            mac,
+                            oif_index,
+                        })
+                        .await?;
+                }
+            }
+            anyhow::Ok(())
+        }
+        .await;
+        if let Err(e) = result {
+            tracing::warn!("fib: cradle neighbor_add {ip} failed: {e}");
         }
     }
 }

--- a/zebra-rs/src/fib/netlink/handle.rs
+++ b/zebra-rs/src/fib/netlink/handle.rs
@@ -328,17 +328,18 @@ pub struct FibHandle {
     pub cradle: Option<CradleFib>,
 }
 
-/// Extract all IPv4 `(gateway, oif)` members of a nexthop for the cradle tee.
-/// A single member installs a plain route; multiple members install an ECMP
-/// group. (Protect/backup nexthops are not teed.)
-fn cradle_members_v4(nexthop: &Nexthop) -> Vec<(Option<Ipv4Addr>, u32)> {
-    fn member(u: &NexthopUni) -> (Option<Ipv4Addr>, u32) {
+/// Extract all IPv4 `(gateway, oif, out-label stack)` members of a nexthop
+/// for the cradle tee. A single member installs a plain route; multiple
+/// members install an ECMP group. A non-empty label stack makes the leg an
+/// MPLS imposition. (Protect/backup nexthops are not teed.)
+fn cradle_members_v4(nexthop: &Nexthop) -> Vec<(Option<Ipv4Addr>, u32, Vec<u32>)> {
+    fn member(u: &NexthopUni) -> (Option<Ipv4Addr>, u32, Vec<u32>) {
         let oif = u.ifindex().unwrap_or(0);
         let gw = match u.addr {
             IpAddr::V4(a) if !a.is_unspecified() => Some(a),
             _ => None,
         };
-        (gw, oif)
+        (gw, oif, u.mpls_label.clone())
     }
     match nexthop {
         Nexthop::Uni(u) => vec![member(u)],
@@ -356,14 +357,14 @@ fn cradle_members_v4(nexthop: &Nexthop) -> Vec<(Option<Ipv4Addr>, u32)> {
 }
 
 /// IPv6 counterpart of [`cradle_members_v4`].
-fn cradle_members_v6(nexthop: &Nexthop) -> Vec<(Option<Ipv6Addr>, u32)> {
-    fn member(u: &NexthopUni) -> (Option<Ipv6Addr>, u32) {
+fn cradle_members_v6(nexthop: &Nexthop) -> Vec<(Option<Ipv6Addr>, u32, Vec<u32>)> {
+    fn member(u: &NexthopUni) -> (Option<Ipv6Addr>, u32, Vec<u32>) {
         let oif = u.ifindex().unwrap_or(0);
         let gw = match u.addr {
             IpAddr::V6(a) if !a.is_unspecified() => Some(a),
             _ => None,
         };
-        (gw, oif)
+        (gw, oif, u.mpls_label.clone())
     }
     match nexthop {
         Nexthop::Uni(u) => vec![member(u)],
@@ -487,6 +488,15 @@ impl FibHandle {
         self.cradle = endpoint.map(CradleFib::new);
         if self.cradle.is_none() {
             tracing::info!("fib: cradle eBPF tee disabled");
+        }
+    }
+
+    /// Tee a resolved neighbor (ARP/ND) into the cradle data plane — its MPLS
+    /// egress rewrite resolves destination MACs from this state. No-op when
+    /// the tee is disabled.
+    pub async fn cradle_neighbor_add(&self, ip: IpAddr, oif_index: u32, mac: [u8; 6]) {
+        if let Some(cradle) = &self.cradle {
+            cradle.neighbor_add(ip, oif_index, mac).await;
         }
     }
 
@@ -2456,6 +2466,52 @@ impl FibHandle {
     }
 
     async fn ilm_install(&self, label: u32, ilm: &IlmEntry, replace: bool) {
+        // Tee the ILM to the cradle eBPF data plane (mirrors the netlink
+        // install below). DecapVrf/ContextLabel decap to IP in a VRF; every
+        // other type is a swap whose out stack rides the nexthop — an empty
+        // stack is PHP, popped by the data plane on the packet's S bit.
+        // Multi-member ILM ECMP is not teed yet (first member only).
+        if let Some(cradle) = &self.cradle {
+            match &ilm.ilm_type {
+                IlmType::DecapVrf { table_id, .. } | IlmType::ContextLabel { table_id, .. } => {
+                    cradle
+                        .ilm_install(
+                            label,
+                            crate::fib::cradle::MPLS_OP_POP_L3,
+                            *table_id,
+                            None,
+                            0,
+                            &[],
+                        )
+                        .await;
+                }
+                _ => {
+                    let uni = match &ilm.nexthop {
+                        Nexthop::Uni(u) => Some(u),
+                        Nexthop::Multi(m) => m.nexthops.first(),
+                        _ => None,
+                    };
+                    if let Some(u) = uni {
+                        let gw = if u.addr.is_unspecified() {
+                            None
+                        } else {
+                            Some(u.addr)
+                        };
+                        cradle
+                            .ilm_install(
+                                label,
+                                crate::fib::cradle::MPLS_OP_SWAP,
+                                0,
+                                gw,
+                                u.ifindex().unwrap_or(0),
+                                &u.mpls_label,
+                            )
+                            .await;
+                    }
+                }
+            }
+        }
+
         let create_flags = if replace {
             NLM_F_REPLACE | NLM_F_CREATE
         } else {
@@ -2614,6 +2670,10 @@ impl FibHandle {
     }
 
     pub async fn ilm_del(&self, label: u32, ilm: &IlmEntry) {
+        if let Some(cradle) = &self.cradle {
+            cradle.ilm_uninstall(label).await;
+        }
+
         let mut msg = RouteMessage::default();
         msg.header.address_family = AddressFamily::Mpls;
         msg.header.destination_prefix_length = 20;

--- a/zebra-rs/src/rib/inst.rs
+++ b/zebra-rs/src/rib/inst.rs
@@ -3134,6 +3134,13 @@ impl Rib {
                 self.fib_nexthop_removed(id);
             }
             FibMessage::NewNeighbor(nbr) => {
+                // Tee resolved ARP/ND to the cradle eBPF data plane — its
+                // MPLS egress rewrite resolves next-hop MACs from this state.
+                if let (Some(dst), Some(mac)) = (nbr.dst, &nbr.lladdr) {
+                    self.fib_handle
+                        .cradle_neighbor_add(dst, nbr.ifindex, mac.octets())
+                        .await;
+                }
                 let fdb_entry = fdb_entry_from_neighbor(self, &nbr);
                 if let Some(key) = neighbor_key(&nbr) {
                     self.neighbors.insert(key, nbr);


### PR DESCRIPTION
## Summary

Extends the `CradleFib` eBPF tee (`system cradle-grpc`) with the MPLS surface, mirroring what the netlink `FibHandle` already installs. Companion to cradle-rs PR #19 (MPLS Phase 2).

- **Vendored proto synced** with cradle-rs: `Nexthop.labels`, `Ilm`/`IlmDel` + `AddIlm`/`DelIlm`, `Neighbor6`/`SetNeighbor6`, `oif_index` on neighbors.
- **Labeled nexthops**: `cradle_members_v4/v6` carry `uni.mpls_label` through (previously dropped) — a static/BGP/IGP route with an out-label stack tees as an MPLS imposition nexthop; the dedup key now includes the stack.
- **ILM tee**: `ilm_add`/`ilm_replace`/`ilm_del` mirror to `AddIlm`/`DelIlm`. `DecapVrf`/`ContextLabel` → POP_L3 + VRF table id; all other `IlmType`s → SWAP with the first `Uni` member's out stack (empty = PHP, popped by the cradle data plane on the packet's S bit). Multi-member ILM ECMP is a noted follow-up.
- **Neighbor tee**: resolved ARP/ND (`FibMessage::NewNeighbor`) tees as `SetNeighbor4/6` by ifindex — cradle's MPLS egress rewrite resolves next-hop MACs from this state. Deletes are a follow-up (no DelNeighbor RPC yet).

## Test plan

- End-to-end: cradle-rs's `cradle_mpls_zebra` BDD passes — a zebra static labeled route (imposition) + static MPLS label binding (disposition) drive an all-eBPF LSP through two zebra+cradle routers.
- Existing IP-tee features `cradle_zebra` / `cradle_zebrav6` stay green.
- `cargo build` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)