### PR TITLE
bdd: fast-external-failover feature (link-down reset, recovery, knob off)

### DIFF
--- a/bdd/Makefile
+++ b/bdd/Makefile
@@ -369,6 +369,14 @@ bgp_unknown_attr_transitive:
 	mkdir -p allure-results
 	cargo test --test cucumber -- --concurrency=1 --tags "@bgp_unknown_attr_transitive"
 
+# Fast external failover: a direct single-hop eBGP session must be reset
+# the moment its veth link goes down (both ends — carrier drops on both),
+# recover on link-up without waiting out connect-retry, and survive the
+# same link cut when `fast-external-failover false` is set.
+bgp_fast_external_failover:
+	mkdir -p allure-results
+	cargo test --test cucumber -- --concurrency=1 --tags "@bgp_fast_external_failover"
+
 generate:
 	rm -rf allure-report
 	allure generate
@@ -388,4 +396,4 @@ docs/%.md: tests/features/%.feature docs/feature2md.sh FORCE
 
 FORCE:
 
-.PHONY: ecmp_bfd_evict ospfv2_bfd_frr ospfv3_bfd_frr tilfa_bfd all run ibgp ebgp rr rib_static_ipv6 isis_ipv6 isis_srv6 isis_fragmentation_ipv6 isis_fragmentation_ipv4 isis_l1p2p isis_tilfa isis_l1l2 isis_redist isis_hello_auth_keychain isis_passive isis_afi_enable isis_endx_ipv6 isis_bfd_ipv6_p2p isis_bfd_ipv6_p2p_echo isis_bfd_ipv6_lan isis_bfd_ipv6_lan_echo isis_bfd_ipv4_p2p isis_bfd_ipv4_p2p_echo isis_bfd_ipv4_lan isis_bfd_ipv4_lan_echo ospf_clear_neighbor ospfv2_nssa ospfv2_stub ospfv2_tilfa ospfv3_nssa ospfv3_tilfa stamp_te_metric stamp_v6_te_metric bgp_peer_down_cleanup bgp_ipv6_over_v4_session bgp_evpn_capability bgp_vrf_evpn_type5 bgp_evpn_outpolicy_undef bgp_route_map_match bgp_policy_dynamic_update bgp_table_map bgp_v6_table_map bgp_community bgp_neighbor_group bgp_unnumbered_neighbor nd_show bgp_interas_option_c bgp_interas_option_a bgp_interas_option_b bgp_interas_option_ab bgp_port bgp_ip_transparent bgp_local_as bgp_unknown_attr_transitive generate open docs FORCE
+.PHONY: ecmp_bfd_evict ospfv2_bfd_frr ospfv3_bfd_frr tilfa_bfd all run ibgp ebgp rr rib_static_ipv6 isis_ipv6 isis_srv6 isis_fragmentation_ipv6 isis_fragmentation_ipv4 isis_l1p2p isis_tilfa isis_l1l2 isis_redist isis_hello_auth_keychain isis_passive isis_afi_enable isis_endx_ipv6 isis_bfd_ipv6_p2p isis_bfd_ipv6_p2p_echo isis_bfd_ipv6_lan isis_bfd_ipv6_lan_echo isis_bfd_ipv4_p2p isis_bfd_ipv4_p2p_echo isis_bfd_ipv4_lan isis_bfd_ipv4_lan_echo ospf_clear_neighbor ospfv2_nssa ospfv2_stub ospfv2_tilfa ospfv3_nssa ospfv3_tilfa stamp_te_metric stamp_v6_te_metric bgp_peer_down_cleanup bgp_ipv6_over_v4_session bgp_evpn_capability bgp_vrf_evpn_type5 bgp_evpn_outpolicy_undef bgp_route_map_match bgp_policy_dynamic_update bgp_table_map bgp_v6_table_map bgp_community bgp_neighbor_group bgp_unnumbered_neighbor nd_show bgp_interas_option_c bgp_interas_option_a bgp_interas_option_b bgp_interas_option_ab bgp_port bgp_ip_transparent bgp_local_as bgp_unknown_attr_transitive bgp_fast_external_failover generate open docs FORCE

--- a/bdd/docs/bgp_fast_external_failover.md
+++ b/bdd/docs/bgp_fast_external_failover.md
@@ -1,0 +1,43 @@
+# BGP fast-external-failover (immediate eBGP reset on link down)
+
+## Overview
+
+As a network operator
+I want a directly connected eBGP session to be reset the moment its
+interface goes down (IOS-XR `bgp fast-external-fallover`, on by
+default), instead of waiting out the 180-second hold timer — and I
+want `fast-external-failover false` to restore hold-timer-only
+detection.
+
+## Test Topology
+
+```
+   ┌─────────┐   10.107.0.0/24   ┌─────────┐
+   │   z1    │ i1─────────────i1 │   z2    │
+   │ AS65001 │                   │ AS65002 │
+   │  .0.1   │                   │  .0.2   │
+   └─────────┘                   └─────────┘
+```
+
+## Notes
+
+Downing z1's veth end drops carrier on BOTH ends (a veth pair has no
+independent carrier), so each router sees its own LinkDown and both
+must reset. The default hold time is 180s and the session-state polls
+budget 30s, so every "eventually not Established" assertion passing
+is itself proof the reset did not come from the hold timer.
+
+## Config Files
+
+- z1.yaml / z2.yaml: direct eBGP over the veth, one originated
+
+## Test Scenarios
+
+| Scenario | Result |
+|----------|--------|
+| Setup direct eBGP topology and establish the session | |
+| Link down resets the session immediately (default enabled) | |
+| Link up re-establishes the session without waiting out connect-retry | |
+| Disabling fast-external-failover does not bounce the session | |
+| With the knob disabled, link down leaves the session to the hold timer | |
+| Teardown topology | |

--- a/bdd/tests/configs/bgp_fast_external_failover/z1.yaml
+++ b/bdd/tests/configs/bgp_fast_external_failover/z1.yaml
@@ -1,0 +1,30 @@
+# z1 (AS 65001): single-hop eBGP to z2 over the direct veth link
+# (10.107.0.0/24). fast-external-failover is left at its default
+# (enabled); the feature flips it off at runtime with
+# `set router bgp global fast-external-failover false` for the
+# disabled-case scenario. Default timers (hold 180) on purpose — the
+# feature under test is exactly "don't wait for the hold timer".
+interface:
+- if-name: i1
+  ipv4:
+    address: 10.107.0.1/24
+router:
+  bgp:
+    global:
+      as: 65001
+      router-id: 10.107.0.1
+    timer:
+      adv-interval:
+        ibgp: 1
+        ebgp: 1
+    neighbor:
+    - remote-address: 10.107.0.2
+      afi-safi:
+      - name: ipv4
+        enabled: true
+      enabled: true
+      remote-as: 65002
+    afi-safi:
+    - name: ipv4
+      network:
+      - prefix: 10.1.1.1/32

--- a/bdd/tests/configs/bgp_fast_external_failover/z2.yaml
+++ b/bdd/tests/configs/bgp_fast_external_failover/z2.yaml
@@ -1,0 +1,25 @@
+# z2 (AS 65002): mirror of z1.yaml — see that file for the rationale.
+interface:
+- if-name: i1
+  ipv4:
+    address: 10.107.0.2/24
+router:
+  bgp:
+    global:
+      as: 65002
+      router-id: 10.107.0.2
+    timer:
+      adv-interval:
+        ibgp: 1
+        ebgp: 1
+    neighbor:
+    - remote-address: 10.107.0.1
+      afi-safi:
+      - name: ipv4
+        enabled: true
+      enabled: true
+      remote-as: 65001
+    afi-safi:
+    - name: ipv4
+      network:
+      - prefix: 10.2.2.2/32

--- a/bdd/tests/features/bgp_fast_external_failover.feature
+++ b/bdd/tests/features/bgp_fast_external_failover.feature
@@ -1,0 +1,89 @@
+@serial
+@bgp_fast_external_failover
+Feature: BGP fast-external-failover (immediate eBGP reset on link down)
+  As a network operator
+  I want a directly connected eBGP session to be reset the moment its
+  interface goes down (IOS-XR `bgp fast-external-fallover`, on by
+  default), instead of waiting out the 180-second hold timer — and I
+  want `fast-external-failover false` to restore hold-timer-only
+  detection.
+
+  Test Topology (direct P2P veth, single-hop eBGP):
+  ```
+   ┌─────────┐   10.107.0.0/24   ┌─────────┐
+   │   z1    │ i1─────────────i1 │   z2    │
+   │ AS65001 │                   │ AS65002 │
+   │  .0.1   │                   │  .0.2   │
+   └─────────┘                   └─────────┘
+  ```
+
+  Downing z1's veth end drops carrier on BOTH ends (a veth pair has no
+  independent carrier), so each router sees its own LinkDown and both
+  must reset. The default hold time is 180s and the session-state polls
+  budget 30s, so every "eventually not Established" assertion passing
+  is itself proof the reset did not come from the hold timer.
+
+  Config files:
+  - z1.yaml / z2.yaml: direct eBGP over the veth, one originated
+    prefix each, fast-external-failover left at its default (enabled).
+    The disabled case is applied at runtime with
+    `set router bgp global fast-external-failover false`.
+
+  Scenario: Setup direct eBGP topology and establish the session
+    Given a clean test environment
+    When I create namespace "z1"
+    And I create namespace "z2"
+    And I connect namespace "z1" interface "i1" to namespace "z2" interface "i1"
+    And I start zebra-rs in namespace "z1"
+    And I start zebra-rs in namespace "z2"
+    And I apply config "z1.yaml" to namespace "z1"
+    And I apply config "z2.yaml" to namespace "z2"
+    And I wait 10 seconds for BGP to operate
+    Then BGP session in "z1" to "10.107.0.2" should eventually be "Established"
+    And BGP session in "z2" to "10.107.0.1" should eventually be "Established"
+    And BGP route in "z2" has "10.1.1.1/32"
+    And BGP route in "z1" has "10.2.2.2/32"
+
+  Scenario: Link down resets the session immediately (default enabled)
+    Given the test topology exists
+    When I make namespace "z1" interface "i1" down
+    Then BGP session in "z1" to "10.107.0.2" should eventually not be "Established"
+    And BGP session in "z2" to "10.107.0.1" should eventually not be "Established"
+    And the zebra-rs log in namespace "z1" should contain "fast-external-failover: interface down"
+    And the zebra-rs log in namespace "z2" should contain "fast-external-failover: interface down"
+
+  Scenario: Link up re-establishes the session without waiting out connect-retry
+    Given the test topology exists
+    When I make namespace "z1" interface "i1" up
+    Then BGP session in "z1" to "10.107.0.2" should eventually be "Established"
+    And BGP session in "z2" to "10.107.0.1" should eventually be "Established"
+
+  Scenario: Disabling fast-external-failover does not bounce the session
+    Given the test topology exists
+    When I apply command "set router bgp global fast-external-failover false" in namespace "z1"
+    And I apply command "set router bgp global fast-external-failover false" in namespace "z2"
+    And I wait 2 seconds
+    Then BGP session in "z1" to "10.107.0.2" should be "Established"
+    And BGP session in "z2" to "10.107.0.1" should be "Established"
+
+  Scenario: With the knob disabled, link down leaves the session to the hold timer
+    Given the test topology exists
+    When I make namespace "z1" interface "i1" down
+    And I wait 10 seconds
+    # Hold time is 180s and TCP retransmits silently on a dead link, so
+    # with the knob off the session must still be up 10s after the cut —
+    # this is the assertion that discriminates the feature from ambient
+    # TCP/hold-timer behaviour.
+    Then BGP session in "z1" to "10.107.0.2" should be "Established"
+    And BGP session in "z2" to "10.107.0.1" should be "Established"
+
+  # Pure P2P topology (no bridge): deleting each namespace destroys the
+  # veth pair ends it holds, so only the daemons and namespaces need
+  # teardown.
+  Scenario: Teardown topology
+    Given the test topology exists
+    When I stop zebra-rs in namespace "z1"
+    And I stop zebra-rs in namespace "z2"
+    And I delete namespace "z1"
+    And I delete namespace "z2"
+    Then the test environment should be clean

--- a/docs/design/bgp-fast-external-failover.md
+++ b/docs/design/bgp-fast-external-failover.md
@@ -9,9 +9,11 @@ exactly IOS-XR's `bgp fast-external-fallover disable` (XR spells it
 
 ## Status (2026-07-02)
 
-**PR 1 (knob + failover core, unit tests, book chapter) implemented on
-branch `fast-external-failover`**, as specified below. PR 2 (BDD) and
-the listed follow-ups are still open. Original recon, kept for context:
+**PR 1 (knob + failover core, unit tests, book chapter) merged
+(#1713); PR 2 (BDD feature, validated live: both the admin-down and
+the carrier-down side reset and recover) implemented on branch
+`fast-external-failover-bdd`.** Only the listed follow-ups remain
+open. Original recon, kept for context:
 before PR 1, no `fast-external`/`fast_external` symbol existed
 anywhere in the tree, and BGP **silently discarded link events** —
 `process_rib_msg` has no arm for `RibRx::LinkUp/LinkDown/LinkDel`; they


### PR DESCRIPTION
## Summary

PR 2 of the fast-external-failover design (`docs/design/bgp-fast-external-failover.md`; core landed in #1713). Adds the BDD feature `@bgp_fast_external_failover`: a direct z1↔z2 veth eBGP pair (10.107.0.0/24, AS 65001/65002, default 180 s hold timer), six scenarios:

1. **Setup/establish** — direct single-hop eBGP, one originated prefix each way.
2. **Link down (default enabled)** — both ends must leave `Established` inside the 30 s poll budget (≪ 180 s hold): the admin-down side via its own `LinkDown`, the peer via veth carrier loss (`is_up()` = admin-up && LOWER_UP). Both daemon logs must carry the `fast-external-failover: interface down — resetting eBGP peer` line.
3. **Link up** — both re-`Established` without waiting out connect-retry (exercises the `LinkUp` kick).
4. **Knob off at runtime** — `set router bgp global fast-external-failover false` on both; the flip must not bounce the established sessions.
5. **Link down with the knob off** — still `Established` 10 s after the cut (hold timer untouched, TCP retransmits silently): the assertion that discriminates the feature from ambient behaviour.
6. **Teardown** — stops daemons, deletes namespaces, asserts the environment is clean (P2P veth topology, no bridge).

Also: config YAMLs under `bdd/tests/configs/bgp_fast_external_failover/`, a `bgp_fast_external_failover` Makefile target, the generated `bdd/docs/` page, and a design-doc status update.

## Testing

Ran live (`make bgp_fast_external_failover` from `bdd/`, freshly installed binaries + YANG): **1 feature, 6 scenarios, 46 recorded steps — all passed, zero skipped**. Verified in the daemon logs that z1 *and* z2 each logged exactly one failover reset line with the correct peer and ifindex, and that the environment check came back clean. `/usr/bin/zebra-rs` md5 confirmed unchanged before/after the run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)