### PR TITLE
book: fast-external-failover — carrier semantics, validated log, BFD cross-link

### DIFF
--- a/book/src/ch-02-08-bgp-bfd.md
+++ b/book/src/ch-02-08-bgp-bfd.md
@@ -9,6 +9,13 @@ See the [BFD overview](ch-10-00-bfd.md) for the session model, the
 single- vs multi-hop transport, and the `show bfd` commands. This
 section covers only the BGP-side configuration.
 
+For the special case of a directly connected eBGP peer whose
+*interface* goes down, no BFD is needed:
+[fast external failover](ch-02-37-bgp-fast-external-failover.md)
+resets the session on the link event itself, by default. BFD earns its
+keep on everything link state cannot see — forwarding failures,
+switched paths, multihop and iBGP sessions.
+
 ## Enabling BFD on a neighbour
 
 BFD is a flat block under the neighbour. The minimal form is just

--- a/book/src/ch-02-37-bgp-fast-external-failover.md
+++ b/book/src/ch-02-37-bgp-fast-external-failover.md
@@ -36,6 +36,15 @@ returns. When the interface comes back up, zebra-rs additionally
 re-kicks peers parked on it, so recovery does not wait out the
 connect-retry backoff either.
 
+What counts as *down* is the operational state: admin-down or loss of
+carrier (`LOWER_UP` cleared). On a point-to-point link (a veth pair, a
+direct fiber) cutting either end drops carrier on **both** routers, so
+both sides fast-reset — this is exactly what the BDD feature
+(`bgp_fast_external_failover`) validates. Across a switch, only the
+router whose own port failed loses carrier; the far side still sees
+link-up and keeps waiting on the hold timer, so pair the feature with
+BFD when the path between the peers is switched.
+
 With the feature disabled, a link cut is only detected when the hold
 timer expires — or by [BFD](ch-02-08-bgp-bfd.md), which detects
 *forwarding* failures the link state never reports and works for
@@ -82,11 +91,19 @@ short link drops.
 
 ## Verification
 
-A triggered failover logs the reset:
+A triggered failover logs the reset at `warn` level:
 
 ```
-bgp: fast-external-failover: interface down — resetting eBGP peer peer=10.0.3.2 ifindex=3
+WARN zebra-rs/src/bgp/inst.rs: bgp: fast-external-failover: interface down — resetting eBGP peer peer=10.107.0.2 ifindex=207
 ```
 
 and the neighbor drops out of `Established` in `show bgp summary`
 immediately after the link event, rather than at hold-time expiry.
+When the link returns, the session re-establishes right away — link-up
+re-kicks peers parked on that interface instead of leaving them to the
+connect-retry backoff.
+
+The full behavior — immediate reset on link-down at both ends of a
+point-to-point link, prompt recovery on link-up, and the session
+riding through the same cut when the knob is off — is exercised
+end-to-end by the BDD feature `bdd/tests/features/bgp_fast_external_failover.feature`.


### PR DESCRIPTION
## Summary

Follow-up doc polish after #1713 (feature) and #1715 (BDD), folding in what the live validation established:

- **ch-02-37 (Fast External Failover)**: documents what counts as *down* (admin-down or `LOWER_UP` carrier loss); the operationally important distinction that a point-to-point cut resets **both** ends while across a switch only the router whose own port failed sees it (pair with BFD there); the real warn-level log line from the validated run; the link-up re-kick recovery behavior; and a pointer to the BDD feature that exercises all of it.
- **ch-02-08 (BGP BFD)**: cross-links fast-external-failover as the no-BFD-needed case for directly connected eBGP interface failures, and states where BFD still earns its keep.

## Testing

- `mdbook build` succeeds with the new cross-links.

🤖 Generated with [Claude Code](https://claude.com/claude-code)