### PR TITLE
bgp: pin session ifindex at establish for fast-external-failover

### DIFF
--- a/docs/design/bgp-fast-external-failover.md
+++ b/docs/design/bgp-fast-external-failover.md
@@ -365,21 +365,21 @@ Notes on the sweep:
 
 ### Edge cases & deliberate simplifications
 
-1. **Live ifindex resolution vs FRR's cached `nexthop.ifp`.** We
-   resolve peer→ifindex at link-down time. This works because the RIB
-   emits `LinkDown` *before* withdrawing anything and does not emit
-   `AddrDel` on a flap — `ConnectedSubnets` still holds the mapping.
-   The one ordering that escapes: operator deletes the address
-   (`AddrDel` prunes the subnet) *and then* the link goes down — the
-   session survives until hold-timer, as today. Caching a
-   `session_ifindex: Option<u32>` on the Established transition (FRR's
-   approach) closes that hole; deferred as a follow-up since the flap
-   path — the case the feature exists for — is fully covered.
+1. **Live ifindex resolution vs FRR's cached `nexthop.ifp`.**
+   *Closed by the follow-up:* `Peer.session_ifindex` is snapshotted on
+   the transition into Established (from
+   `Peer::resolve_session_ifindex`, which prefers the session's
+   **local** socket address — a v6 scope-id directly, else the
+   connected subnet the local address sits on) and cleared when the
+   session ends; the link-down sweep consults it before live
+   resolution. An established session now survives `AddrDel`
+   reordering. Live resolution remains the fallback for
+   never-established peers.
 2. **Peer address covered by two connected subnets on different
-   interfaces** (parallel links): `ifindex_for` returns the first
-   match, so the reset may key on the wrong link or be skipped. Same
-   limitation as the BFD single-hop keying that `ifindex_for` was built
-   for; the cached-ifindex follow-up fixes this too.
+   interfaces** (parallel links): *closed by the same follow-up* for
+   established sessions — the local socket address is unambiguous per
+   link. Non-established peers still fall back to first-match
+   `ifindex_for` on the peer address.
 3. **GTSM iBGP.** FRR technically fails over a directly connected GTSM
    *iBGP* peer; we scope to eBGP only — the feature is named
    *external*, XR documents "directly adjacent **external** peers",
@@ -443,7 +443,9 @@ Smallest-first; each lands green on its own.
   table row. This is the whole IOS-XR-parity feature.
 - **PR 2 — BDD.** Feature file + configs + doc page as above.
 - **Follow-ups (separate, optional):**
-  - cached `session_ifindex` at Established (closes edge cases 1–2);
+  - cached `session_ifindex` at Established — **done** (closes edge
+    cases 1–2; snapshot in the `became_established` block of
+    `process_msg`, keyed off `PeerParam::local_addr`);
   - `Peer.last_reset` reason plumbed into `show bgp neighbors`
     (serves BFD-down/hold-timer/collision too);
   - per-neighbor override via `InheritableKnobs` (classic-IOS-style

--- a/zebra-rs/src/bgp/config.rs
+++ b/zebra-rs/src/bgp/config.rs
@@ -5767,6 +5767,82 @@ mod neighbor_group_wiring_tests {
         );
     }
 
+    /// The link-down sweep prefers the ifindex pinned at session
+    /// establish over live subnet resolution, so a session whose
+    /// connected address was already deleted (AddrDel raced ahead of
+    /// LinkDown) is still reset — and only by the pinned interface.
+    #[tokio::test]
+    async fn fast_external_failover_uses_pinned_session_ifindex() {
+        use crate::bgp::peer::State;
+        use crate::rib::api::RibRx;
+        let mut bgp = fresh_bgp();
+        config_global_asn(&mut bgp, arg_words(&["65000"]), ConfigOp::Set).unwrap();
+        config_peer(&mut bgp, arg_words(&["10.0.3.2"]), ConfigOp::Set).unwrap();
+        config_remote_as(&mut bgp, arg_words(&["10.0.3.2", "65001"]), ConfigOp::Set).unwrap();
+        let _ = drain_stop_events(&mut bgp);
+
+        // No connected-subnet knowledge at all — live resolution has
+        // nothing to offer; only the pinned mapping can match.
+        let victim = park_peer(&mut bgp, "10.0.3.2", State::Established);
+        let ip: IpAddr = "10.0.3.2".parse().unwrap();
+        bgp.peers.get_mut(&ip).unwrap().session_ifindex = Some(3);
+
+        bgp.process_rib_msg(RibRx::LinkDown(4));
+        assert!(
+            drain_stop_events(&mut bgp).is_empty(),
+            "a different interface going down must not reset the peer",
+        );
+        bgp.process_rib_msg(RibRx::LinkDown(3));
+        assert_eq!(
+            drain_stop_events(&mut bgp),
+            vec![victim],
+            "the pinned ifindex must drive the reset",
+        );
+    }
+
+    /// `resolve_session_ifindex` precedence: the *local* socket address
+    /// beats the peer-address subnet (it stays unambiguous across
+    /// parallel links), and a link-local v6 local address resolves by
+    /// its scope-id outright.
+    #[tokio::test]
+    async fn resolve_session_ifindex_prefers_local_address() {
+        use std::net::{SocketAddr, SocketAddrV6};
+        let mut bgp = fresh_bgp();
+        config_peer(&mut bgp, arg_words(&["10.0.3.2"]), ConfigOp::Set).unwrap();
+        bgp.connected_subnets
+            .record(&link_addr_on("10.0.3.1/24", 8));
+        bgp.connected_subnets
+            .record(&link_addr_on("10.0.99.1/24", 7));
+        let ip: IpAddr = "10.0.3.2".parse().unwrap();
+        let subnets = &bgp.connected_subnets;
+        let peer = bgp.peers.get_mut(&ip).unwrap();
+
+        assert_eq!(
+            peer.resolve_session_ifindex(subnets),
+            Some(8),
+            "without a local address, the peer-address subnet decides",
+        );
+
+        peer.param.local_addr = Some("10.0.99.1:34567".parse().unwrap());
+        assert_eq!(
+            peer.resolve_session_ifindex(subnets),
+            Some(7),
+            "the local socket address must win over the peer-address subnet",
+        );
+
+        peer.param.local_addr = Some(SocketAddr::V6(SocketAddrV6::new(
+            "fe80::1".parse().unwrap(),
+            179,
+            0,
+            9,
+        )));
+        assert_eq!(
+            peer.resolve_session_ifindex(subnets),
+            Some(9),
+            "a link-local local address must resolve by its scope-id",
+        );
+    }
+
     /// `disable-connected-check` is a presence flag: Set/Delete toggle
     /// it and a change to a live session is bounced (FRR resets the peer
     /// on this flag); a no-op set does not bounce, an Idle peer is not

--- a/zebra-rs/src/bgp/inst.rs
+++ b/zebra-rs/src/bgp/inst.rs
@@ -1994,6 +1994,23 @@ impl Bgp {
                     self.broadcast_dump_v4(ident);
                 }
 
+                // Pin (or drop) the session↔interface mapping for
+                // fast-external-failover: snapshot on the transition
+                // into Established — while the connection is up the
+                // local socket address resolves the link
+                // unambiguously — and clear when the session ends, so
+                // the link-down sweep never acts on a stale mapping.
+                {
+                    let subnets = &self.connected_subnets;
+                    if let Some(peer) = self.peers.get_mut_by_idx(ident) {
+                        if became_established {
+                            peer.session_ifindex = peer.resolve_session_ifindex(subnets);
+                        } else if !peer.state.is_established() {
+                            peer.session_ifindex = None;
+                        }
+                    }
+                }
+
                 self.gc_dynamic_peer_if_session_ended(ident, prev_state);
             }
             Message::Accept(socket, sockaddr) => {
@@ -2967,7 +2984,15 @@ impl Bgp {
             .map(|(_, p)| p)
             .filter(|p| p.state != State::Idle)
             .filter(|p| p.fast_failover_applies())
-            .filter(|p| p.session_ifindex(&self.connected_subnets) == Some(ifindex))
+            .filter(|p| {
+                // Prefer the ifindex pinned at session establish — it
+                // survives AddrDel reordering and disambiguates
+                // parallel links; live resolution covers peers that
+                // never established.
+                p.session_ifindex
+                    .or_else(|| p.resolve_session_ifindex(&self.connected_subnets))
+                    == Some(ifindex)
+            })
             .map(|p| (p.ident, p.address))
             .collect();
         for (ident, addr) in victims {
@@ -2993,7 +3018,7 @@ impl Bgp {
             .iter_all()
             .map(|(_, p)| p)
             .filter(|p| p.active && matches!(p.state, State::Idle | State::Active))
-            .filter(|p| p.session_ifindex(&self.connected_subnets) == Some(ifindex))
+            .filter(|p| p.resolve_session_ifindex(&self.connected_subnets) == Some(ifindex))
             .map(|p| p.ident)
             .collect();
         for ident in kicks {

--- a/zebra-rs/src/bgp/peer.rs
+++ b/zebra-rs/src/bgp/peer.rs
@@ -800,6 +800,15 @@ pub struct Peer {
     /// fails open (see [`super::connected::ConnectedSubnets`]). Consulted
     /// only by [`Peer::connected_check_ok`].
     pub shared_network: bool,
+    /// The interface the established session rides, snapshotted by the
+    /// owning instance on the transition into Established (from
+    /// [`Self::resolve_session_ifindex`]) and cleared when the session
+    /// ends. Consulted first by fast-external-failover's link-down
+    /// sweep, so a session outlives `AddrDel` reordering and parallel
+    /// links: the mapping was pinned while the connection was up
+    /// (FRR's cached `peer->nexthop.ifp`). `None` while not
+    /// established — the sweep falls back to live resolution.
+    pub session_ifindex: Option<u32>,
     pub peer_type: PeerType,
     /// RFC 9572 §6.1 region identifier, resolved from this peer's
     /// neighbor-group (`region-id`) by `apply_inherited`. `Some` marks the
@@ -1009,6 +1018,7 @@ impl Peer {
             // Fail open until the instance computes connectedness from
             // interface-address events (see `shared_network`).
             shared_network: true,
+            session_ifindex: None,
             peer_type: PeerType::IBGP,
             region_id: None,
             state: State::Idle,
@@ -1244,21 +1254,39 @@ impl Peer {
         self.is_ebgp() && self.config.transport.ebgp_multihop.is_none()
     }
 
-    /// The interface this peer's session rides, as far as it can be
-    /// determined at link-down time. FRR caches `peer->nexthop.ifp` at
-    /// session establish; we resolve live instead — safe on a flap
-    /// because the RIB emits `LinkDown` before withdrawing anything
-    /// and does not emit `AddrDel` for retained addresses, so the
-    /// subnet table still maps the peer to the downed ifindex. (The
-    /// escape — operator deletes the address, then downs the link — is
-    /// an accepted v1 gap; see the design doc.)
-    pub fn session_ifindex(&self, subnets: &super::connected::ConnectedSubnets) -> Option<u32> {
-        match self.origin {
-            PeerOrigin::Interface { ifindex } => Some(ifindex),
-            _ => self
-                .scope_id // v6 link-local numbered peer
-                .or_else(|| subnets.ifindex_for(self.address)),
+    /// Resolve the interface this peer's session rides right now, most
+    /// precise source first: the interface key itself for unnumbered
+    /// peers; the link-local connect scope; then the *local* socket
+    /// address of the live/last connection (a v6 scope-id directly,
+    /// else the connected subnet the local address sits on — unlike
+    /// the peer address, the local address stays unambiguous across
+    /// parallel links to the same neighbor); and only then the subnet
+    /// covering the peer address. The owning instance snapshots this
+    /// into [`Self::session_ifindex`] when the session establishes
+    /// (FRR caches `peer->nexthop.ifp` the same way); the live form
+    /// remains the fallback for peers that never established.
+    pub fn resolve_session_ifindex(
+        &self,
+        subnets: &super::connected::ConnectedSubnets,
+    ) -> Option<u32> {
+        if let PeerOrigin::Interface { ifindex } = self.origin {
+            return Some(ifindex);
         }
+        if let Some(scope) = self.scope_id {
+            // v6 link-local numbered peer
+            return Some(scope);
+        }
+        if let Some(local) = self.param.local_addr {
+            if let std::net::SocketAddr::V6(v6) = local
+                && v6.scope_id() != 0
+            {
+                return Some(v6.scope_id());
+            }
+            if let Some(ifindex) = subnets.ifindex_for(local.ip()) {
+                return Some(ifindex);
+            }
+        }
+        subnets.ifindex_for(self.address)
     }
 
     /// Effective BFD hop mode for this neighbour: the explicit


### PR DESCRIPTION
## Summary

Follow-up to #1713 (design doc follow-up #1), closing edge cases 1–2:

- The link-down sweep resolved peer→interface **live** at `LinkDown` time. That missed a session whose connected address was deleted *before* the link went down (`AddrDel` prunes `ConnectedSubnets`), and was first-match-ambiguous across parallel links to the same neighbor.
- `Peer.session_ifindex` is now **snapshotted on the transition into Established** (in `process_msg`'s `became_established` block — FRR's cached `peer->nexthop.ifp` equivalent) and **cleared when the session ends**, so the sweep never acts on a stale mapping.
- `resolve_session_ifindex` prefers the session's **local** socket address: a v6 scope-id directly, else the connected subnet the local address sits on — unambiguous per link even with parallel links; the peer-address subnet remains the last resort. The sweep consults the pin first, falling back to live resolution for never-established peers; the LinkUp kick keeps live resolution (parked peers have no pin by definition).

## Testing

- New tests: sweep honors the pin with an empty subnet table (the AddrDel-raced case) and only for the pinned interface; resolver precedence (peer-address fallback → local-address override → link-local scope-id).
- `cargo fmt` / `cargo clippy --workspace --all-targets -- -D warnings` clean; `cargo test --workspace --exclude bdd`: 2126 passed, 0 failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)