### PR TITLE
bgp: record last-reset reason, shown in show bgp neighbor

### DIFF
--- a/bdd/tests/features/bgp_fast_external_failover.feature
+++ b/bdd/tests/features/bgp_fast_external_failover.feature
@@ -51,6 +51,7 @@ Feature: BGP fast-external-failover (immediate eBGP reset on link down)
     And BGP session in "z2" to "10.107.0.1" should eventually not be "Established"
     And the zebra-rs log in namespace "z1" should contain "fast-external-failover: interface down"
     And the zebra-rs log in namespace "z2" should contain "fast-external-failover: interface down"
+    And show command "show bgp neighbor" in namespace "z1" should contain "due to Interface down"
 
   Scenario: Link up re-establishes the session without waiting out connect-retry
     Given the test topology exists

--- a/book/src/ch-02-37-bgp-fast-external-failover.md
+++ b/book/src/ch-02-37-bgp-fast-external-failover.md
@@ -99,6 +99,17 @@ WARN zebra-rs/src/bgp/inst.rs: bgp: fast-external-failover: interface down — r
 
 and the neighbor drops out of `Established` in `show bgp summary`
 immediately after the link event, rather than at hold-time expiry.
+The cause is recorded on the neighbor and survives re-establishment:
+
+```
+show bgp neighbor 10.107.0.2
+  ...
+  Last reset 00:00:07, due to Interface down
+```
+
+(Other reset causes — `BFD down`, `Hold timer expired`, `NOTIFICATION
+received`, `Admin. reset` for `clear bgp … hard`, `Config change` for a
+knob bounce — are reported on the same line.)
 When the link returns, the session re-establishes right away — link-up
 re-kicks peers parked on that interface instead of leaving them to the
 connect-retry backoff.

--- a/docs/design/bgp-fast-external-failover.md
+++ b/docs/design/bgp-fast-external-failover.md
@@ -446,8 +446,14 @@ Smallest-first; each lands green on its own.
   - cached `session_ifindex` at Established — **done** (closes edge
     cases 1–2; snapshot in the `became_established` block of
     `process_msg`, keyed off `PeerParam::local_addr`);
-  - `Peer.last_reset` reason plumbed into `show bgp neighbors`
-    (serves BFD-down/hold-timer/collision too);
+  - `Peer.last_reset` reason plumbed into `show bgp neighbor` —
+    **done**: initiators park a `PeerDownReason` on the peer
+    (failover → `InterfaceDown`, BFD → `BfdDown`, hard clear →
+    `AdminReset`) and the FSM stamps `last_reset` on leaving
+    Established, deriving the cause from the event when nothing is
+    parked (hold-timer, NOTIFICATION, TCP fail, update error;
+    unattributed `Stop` = config bounce). Shown as
+    `Last reset <elapsed>, due to <reason>` (text + JSON);
   - per-neighbor override via `InheritableKnobs` (classic-IOS-style
     granularity; XR itself has none — only add on real demand).
 

--- a/zebra-rs/src/bgp/config.rs
+++ b/zebra-rs/src/bgp/config.rs
@@ -5800,6 +5800,53 @@ mod neighbor_group_wiring_tests {
         );
     }
 
+    /// Reset initiators park the session-down cause on the peer just
+    /// before sending `Event::Stop`: the fast-external-failover sweep
+    /// parks `InterfaceDown`, `clear … hard` parks `AdminReset`. (The
+    /// FSM consumes the parked cause into `last_reset` when the
+    /// session actually leaves Established.)
+    #[tokio::test]
+    async fn reset_initiators_park_down_reason() {
+        use crate::bgp::peer::{BgpClearOp, PeerDownReason, State, clear_bgp_action};
+        use crate::rib::api::RibRx;
+        let mut bgp = fresh_bgp();
+        config_global_asn(&mut bgp, arg_words(&["65000"]), ConfigOp::Set).unwrap();
+        config_peer(&mut bgp, arg_words(&["10.0.3.2"]), ConfigOp::Set).unwrap();
+        config_remote_as(&mut bgp, arg_words(&["10.0.3.2", "65001"]), ConfigOp::Set).unwrap();
+        bgp.connected_subnets
+            .record(&link_addr_on("10.0.3.1/24", 3));
+        let _ = drain_stop_events(&mut bgp);
+        park_peer(&mut bgp, "10.0.3.2", State::Established);
+        let ip: IpAddr = "10.0.3.2".parse().unwrap();
+
+        bgp.process_rib_msg(RibRx::LinkDown(3));
+        assert_eq!(
+            bgp.peers.get(&ip).unwrap().down_reason,
+            Some(PeerDownReason::InterfaceDown),
+            "failover sweep must park InterfaceDown",
+        );
+        assert_eq!(drain_stop_events(&mut bgp).len(), 1);
+
+        bgp.peers.get_mut(&ip).unwrap().down_reason = None;
+        let msg = clear_bgp_action(
+            &mut bgp,
+            &mut arg_words(&["10.0.3.2"]),
+            None,
+            BgpClearOp::Hard,
+        )
+        .unwrap();
+        assert!(
+            msg.contains("cleared 1 peer"),
+            "unexpected clear reply: {msg}"
+        );
+        assert_eq!(
+            bgp.peers.get(&ip).unwrap().down_reason,
+            Some(PeerDownReason::AdminReset),
+            "hard clear must park AdminReset",
+        );
+        assert_eq!(drain_stop_events(&mut bgp).len(), 1);
+    }
+
     /// `resolve_session_ifindex` precedence: the *local* socket address
     /// beats the peer-address subnet (it stays unambiguous across
     /// parallel links), and a link-local v6 local address resolves by

--- a/zebra-rs/src/bgp/inst.rs
+++ b/zebra-rs/src/bgp/inst.rs
@@ -3001,6 +3001,9 @@ impl Bgp {
                 ifindex,
                 "bgp: fast-external-failover: interface down — resetting eBGP peer",
             );
+            if let Some(peer) = self.peers.get_mut_by_idx(ident) {
+                peer.down_reason = Some(super::peer::PeerDownReason::InterfaceDown);
+            }
             let _ = self.tx.try_send(Message::Event(ident, Event::Stop));
         }
     }
@@ -5347,7 +5350,7 @@ impl Bgp {
         // SessionKey.remote is the BGP neighbor address — direct
         // lookup. A missing peer means the user removed the
         // neighbor since BGP last subscribed; safe to ignore.
-        let Some(peer) = self.peers.get(&key.remote) else {
+        let Some(peer) = self.peers.get_mut(&key.remote) else {
             bgp_bfd_trace!(
                 self.tracing,
                 ?key,
@@ -5356,6 +5359,7 @@ impl Bgp {
             return;
         };
         let peer_idx = peer.ident;
+        peer.down_reason = Some(super::peer::PeerDownReason::BfdDown);
         tracing::warn!(
             peer = %key.remote,
             diag = %change.diag,

--- a/zebra-rs/src/bgp/peer.rs
+++ b/zebra-rs/src/bgp/peer.rs
@@ -157,6 +157,66 @@ pub enum Event {
     AdvTimerEvpnExpires,
 }
 
+/// Why the last established session ended — FRR's `PEER_DOWN_*`
+/// analog, shown as `Last reset …, due to <reason>` in
+/// `show bgp neighbor`. Initiators that know the cause park it in
+/// [`Peer::down_reason`] just before sending `Event::Stop`
+/// (fast-external-failover, BFD-down, `clear … hard`); causes the FSM
+/// can see for itself are derived from the triggering event.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PeerDownReason {
+    /// fast-external-failover: the session's interface went down.
+    InterfaceDown,
+    /// BFD declared the forwarding path dead (RFC 5882 §5).
+    BfdDown,
+    /// RFC 4271 hold timer expired.
+    HoldTimerExpired,
+    /// The peer sent a NOTIFICATION.
+    NotificationReceived,
+    /// The TCP connection failed (reset / EOF / unreachable).
+    ConnectionFailed,
+    /// A received UPDATE failed validation (NOTIFICATION sent).
+    UpdateError,
+    /// Operator `clear bgp … hard`.
+    AdminReset,
+    /// A neighbor knob change bounced the session.
+    ConfigChange,
+    /// The FSM left Established on an event with no self-evident cause.
+    Unknown,
+}
+
+impl PeerDownReason {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::InterfaceDown => "Interface down",
+            Self::BfdDown => "BFD down",
+            Self::HoldTimerExpired => "Hold timer expired",
+            Self::NotificationReceived => "NOTIFICATION received",
+            Self::ConnectionFailed => "TCP connection failed",
+            Self::UpdateError => "Update error",
+            Self::AdminReset => "Admin. reset",
+            Self::ConfigChange => "Config change",
+            Self::Unknown => "Unknown",
+        }
+    }
+
+    /// The cause implied by the FSM event that ended the session, for
+    /// events whose meaning is self-evident. `Event::Stop` maps to
+    /// `ConfigChange`: every Stop initiator with a more specific cause
+    /// (clear / BFD / failover) parks it in [`Peer::down_reason`]
+    /// first, so an unattributed Stop is a config-driven bounce.
+    fn from_event(event: &Event) -> Option<Self> {
+        match event {
+            Event::Stop => Some(Self::ConfigChange),
+            Event::HoldTimerExpires => Some(Self::HoldTimerExpired),
+            Event::ConnFail(_) | Event::DialFail => Some(Self::ConnectionFailed),
+            Event::NotifMsg(..) => Some(Self::NotificationReceived),
+            Event::UpdateError(..) => Some(Self::UpdateError),
+            _ => None,
+        }
+    }
+}
+
 pub enum FsmEffect {
     None,
     RouteUpdate(UpdatePacket),
@@ -809,6 +869,18 @@ pub struct Peer {
     /// (FRR's cached `peer->nexthop.ifp`). `None` while not
     /// established — the sweep falls back to live resolution.
     pub session_ifindex: Option<u32>,
+    /// Pending session-down cause, parked by the initiator right
+    /// before it sends `Event::Stop` (fast-external-failover,
+    /// BFD-down, `clear … hard`). Consumed (`take`) by [`fsm`] when
+    /// the session actually leaves Established; cleared on entering
+    /// Established so a stale label cannot mis-attribute a later
+    /// reset.
+    pub down_reason: Option<PeerDownReason>,
+    /// Why and when the last established session ended — the
+    /// `Last reset …, due to <reason>` line in `show bgp neighbor`.
+    /// Survives re-establishment (FRR semantics: it describes the
+    /// *last* reset, not the current session).
+    pub last_reset: Option<(PeerDownReason, Instant)>,
     pub peer_type: PeerType,
     /// RFC 9572 §6.1 region identifier, resolved from this peer's
     /// neighbor-group (`region-id`) by `apply_inherited`. `Some` marks the
@@ -1019,6 +1091,8 @@ impl Peer {
             // interface-address events (see `shared_network`).
             shared_network: true,
             session_ifindex: None,
+            down_reason: None,
+            last_reset: None,
             peer_type: PeerType::IBGP,
             region_id: None,
             state: State::Idle,
@@ -1689,6 +1763,10 @@ pub fn fsm(
     event: Event,
     shards: Option<&super::shard::pool::ShardPool>,
 ) {
+    // Captured before `event` is consumed: the down-cause this event
+    // implies, in case it ends the established session below.
+    let event_reason = PeerDownReason::from_event(&event);
+
     // Compute new state (single match, only &mut Peer).
     let (prev_state, effect) = {
         let peer = peer_map.get_mut_by_idx(id).unwrap();
@@ -1727,9 +1805,22 @@ pub fn fsm(
         }
         if prev_state.is_established() && !peer.state.is_established() {
             peer.instant = Some(Instant::now());
+            // Record why the session ended: the initiator's parked
+            // cause wins; else derive from the event itself.
+            peer.last_reset = Some((
+                peer.down_reason
+                    .take()
+                    .or(event_reason)
+                    .unwrap_or(PeerDownReason::Unknown),
+                Instant::now(),
+            ));
         }
         if !prev_state.is_established() && peer.state.is_established() {
             peer.instant = Some(Instant::now());
+            // A parked cause that never fired (its Stop lost a race
+            // with the session coming up) must not mislabel the next
+            // reset.
+            peer.down_reason = None;
             // A2 ⑥ (gate-on): spawn the per-peer egress task. Phase 0 — it
             // is idle (lifecycle only); Phase 1 routes the v4 egress to it.
             if super::peer_egress::peer_egress_task_enabled() {
@@ -3268,6 +3359,9 @@ pub fn clear_bgp_action(
     for &peer_idx in &targets {
         match op {
             BgpClearOp::Hard => {
+                if let Some(peer) = bgp.peers.get_mut_by_idx(peer_idx) {
+                    peer.down_reason = Some(PeerDownReason::AdminReset);
+                }
                 let _ = bgp.tx.try_send(Message::Event(peer_idx, Event::Stop));
             }
             BgpClearOp::SoftBoth => {

--- a/zebra-rs/src/bgp/show.rs
+++ b/zebra-rs/src/bgp/show.rs
@@ -2531,6 +2531,11 @@ struct Neighbor<'a> {
     remote_router_id: Ipv4Addr,
     state: &'a str,
     uptime: String,
+    /// Why and when the last established session ended (`Last reset
+    /// <elapsed>, due to <reason>`). Absent until a session has been
+    /// reset at least once; survives re-establishment.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    last_reset: Option<LastReset>,
     timer: PeerParam,
     timer_sent: PeerParam,
     timer_recv: PeerParam,
@@ -2811,6 +2816,15 @@ fn uptime(instant: &Option<Instant>) -> String {
     peer_uptime(instant, false).0
 }
 
+/// `show bgp neighbor` view of [`Peer::last_reset`].
+#[derive(Debug, Serialize)]
+struct LastReset {
+    /// Elapsed time since the reset, `peer_uptime` format.
+    ago: String,
+    /// Human-readable cause ([`super::peer::PeerDownReason::as_str`]).
+    reason: &'static str,
+}
+
 fn fetch(peer: &Peer) -> Neighbor<'_> {
     // Get remaining time for keepalive and hold timers
     let keepalive_timer_rem = peer.timer.keepalive.as_ref().map(|t| t.rem_sec());
@@ -2854,6 +2868,10 @@ fn fetch(peer: &Peer) -> Neighbor<'_> {
         remote_router_id: peer.remote_id,
         state: peer.state.to_str(),
         uptime: uptime(&peer.instant),
+        last_reset: peer.last_reset.map(|(reason, at)| LastReset {
+            ago: uptime(&Some(at)),
+            reason: reason.as_str(),
+        }),
         timer: peer.param.clone(),
         timer_sent: peer.param_tx.clone(),
         timer_recv: peer.param_rx.clone(),
@@ -2997,6 +3015,14 @@ fn render(out: &mut String, neighbor: &Neighbor) -> std::fmt::Result {
         neighbor.timer_recv.hold_time,
         neighbor.timer_recv.keepalive,
     )?;
+
+    if let Some(last_reset) = &neighbor.last_reset {
+        writeln!(
+            out,
+            "  Last reset {}, due to {}",
+            last_reset.ago, last_reset.reason
+        )?;
+    }
 
     // ND discovery block — interface-keyed (unnumbered) peers only.
     if let Some(discovered_secs) = neighbor.nd_discovered_secs_ago {
@@ -5255,6 +5281,31 @@ Neighbor        V         AS   MsgRcvd   MsgSent   TblVer  InQ OutQ  Up/Down Sta
         );
     }
 
+    /// A peer that has never been reset renders no `Last reset` line;
+    /// one that has renders elapsed time and the cause.
+    #[test]
+    fn last_reset_line_rendered_only_when_present() {
+        let mut out = String::new();
+        let n = minimal_neighbor(None);
+        render(&mut out, &n).unwrap();
+        assert!(
+            !out.contains("Last reset"),
+            "no Last reset line before any reset:\n{out}"
+        );
+
+        let mut out = String::new();
+        let mut n = minimal_neighbor(None);
+        n.last_reset = Some(LastReset {
+            ago: "00:01:02".to_string(),
+            reason: "Interface down",
+        });
+        render(&mut out, &n).unwrap();
+        assert!(
+            out.contains("Last reset 00:01:02, due to Interface down"),
+            "Last reset line missing or malformed:\n{out}"
+        );
+    }
+
     /// Build a `Neighbor` DTO directly (all-`None` ND fields) and
     /// verify that `render` does NOT emit any ND block — address-keyed
     /// peers must be unaffected.
@@ -5392,6 +5443,7 @@ Neighbor        V         AS   MsgRcvd   MsgSent   TblVer  InQ OutQ  Up/Down Sta
             remote_router_id: Ipv4Addr::UNSPECIFIED,
             state: "Idle",
             uptime: String::from("never"),
+            last_reset: None,
             timer: PeerParam::default(),
             timer_sent: PeerParam::default(),
             timer_recv: PeerParam::default(),


### PR DESCRIPTION
## Summary

Second follow-up from the fast-external-failover design (stacked on #1717): FRR-style `PEER_DOWN_*` attribution.

- **Model**: initiators that know the cause park a `PeerDownReason` on the peer just before sending `Event::Stop` — the fast-external-failover sweep parks `InterfaceDown`, BFD-down parks `BfdDown`, `clear … hard` parks `AdminReset`. When the FSM actually leaves Established it stamps `Peer.last_reset` with the parked cause (`take()`), falling back to a cause derived from the triggering event: hold-timer expiry, NOTIFICATION received, TCP connection failed, update error; an unattributed `Stop` reads as a config-driven bounce.
- **Races handled**: the parked value is cleared on entering Established (a Stop that lost the race can't mislabel a later reset), and `last_reset` survives re-establishment — it describes the *last* reset, not the current session.
- **Surface**: `show bgp neighbor` prints `Last reset <elapsed>, due to <reason>` after the timer block; the JSON view carries `lastReset {ago, reason}` (absent until the first reset).

## Testing

- Unit: initiator parking (failover sweep → `InterfaceDown`, hard clear → `AdminReset`), render line present only after a reset.
- BDD: the `bgp_fast_external_failover` feature now asserts `due to Interface down` in `show bgp neighbor` after the link-down scenario — ran live: 6 scenarios, all steps passed (one more recorded step than the previous run, confirming the new assertion executed).
- `cargo fmt` / workspace clippy clean; `cargo test --workspace --exclude bdd`: 2128 passed, 0 failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)