### PR TITLE
feat: cradle tee — carry the VRF table id on route installs

### DIFF
--- a/proto/cradle.proto
+++ b/proto/cradle.proto
@@ -15,6 +15,7 @@ message Port {
   string mac = 2;   // empty => read from the interface
   bool l3 = 3;      // routed port; false => L2 bridge member in `vlan`
   uint32 vlan = 4;
+  uint32 vrf_id = 5;  // VRF table for L3 ports (0 = global)
 }
 
 message L2Domain {
@@ -43,10 +44,12 @@ message Route4 {
   string prefix = 1;   // "a.b.c.d/len"
   uint32 nexthop_id = 2;
   uint32 flags = 3;
+  uint32 vrf_table_id = 4;  // 0 = global (mirrors Ilm.vrf_table_id)
 }
 
 message Route4Del {
   string prefix = 1;
+  uint32 vrf_table_id = 2;
 }
 
 // Bulk route install — the initial-load path. In dir24 mode each affected

--- a/zebra-rs/src/fib/cradle.rs
+++ b/zebra-rs/src/fib/cradle.rs
@@ -28,6 +28,17 @@ const FIB_F_ECMP: u32 = 1 << 3;
 pub const MPLS_OP_SWAP: u32 = 0;
 pub const MPLS_OP_POP_L3: u32 = 1;
 
+/// Map a kernel routing-table id to cradle's VRF-table convention: 0 is
+/// global, and so is RT_TABLE_MAIN (254) — connected routes arrive with it.
+/// Any other value is the RIB-allocated VRF table id, which is byte-identical
+/// to the `vrf_table_id` the DecapVrf ILM tee sends.
+fn cradle_vrf(table_id: u32) -> u32 {
+    match table_id {
+        0 | 254 => 0,
+        id => id,
+    }
+}
+
 #[derive(Clone)]
 pub struct CradleFib {
     endpoint: String,
@@ -108,13 +119,16 @@ impl CradleFib {
     /// Install an IPv4 route with one or more nexthops. A single member becomes
     /// a plain route; multiple members become an ECMP nexthop group. Each
     /// member is `(gateway, oif, out-label stack)` — a non-empty stack makes
-    /// the leg an MPLS imposition (ingress LER).
+    /// the leg an MPLS imposition (ingress LER). `table_id` is the kernel
+    /// routing table the route belongs to; VRF tables map to cradle's
+    /// per-VRF FIB.
     pub async fn route_install(
         &self,
         prefix: Ipv4Net,
+        table_id: u32,
         members: Vec<(Option<Ipv4Addr>, u32, Vec<u32>)>,
     ) {
-        if let Err(e) = self.try_route_install(prefix, members).await {
+        if let Err(e) = self.try_route_install(prefix, table_id, members).await {
             tracing::warn!("fib: cradle route_install {prefix} failed: {e}");
         }
     }
@@ -122,11 +136,13 @@ impl CradleFib {
     async fn try_route_install(
         &self,
         prefix: Ipv4Net,
+        table_id: u32,
         members: Vec<(Option<Ipv4Addr>, u32, Vec<u32>)>,
     ) -> anyhow::Result<()> {
         if members.is_empty() {
             return Ok(());
         }
+        let vrf_table_id = cradle_vrf(table_id);
         if members.len() == 1 {
             let (gw, oif, labels) = &members[0];
             let id = self.nexthop_id(*gw, *oif, labels).await?;
@@ -136,6 +152,7 @@ impl CradleFib {
                     prefix: prefix.to_string(),
                     nexthop_id: id,
                     flags: 0,
+                    vrf_table_id,
                 })
                 .await?;
             return Ok(());
@@ -158,6 +175,7 @@ impl CradleFib {
                 prefix: prefix.to_string(),
                 nexthop_id: gid,
                 flags: FIB_F_ECMP,
+                vrf_table_id,
             })
             .await?;
         tracing::debug!(
@@ -167,12 +185,13 @@ impl CradleFib {
         Ok(())
     }
 
-    pub async fn route_del(&self, prefix: Ipv4Net) {
+    pub async fn route_del(&self, prefix: Ipv4Net, table_id: u32) {
         let result = async {
             self.client()
                 .await?
                 .del_route4(pb::Route4Del {
                     prefix: prefix.to_string(),
+                    vrf_table_id: cradle_vrf(table_id),
                 })
                 .await?;
             anyhow::Ok(())
@@ -221,8 +240,17 @@ impl CradleFib {
     pub async fn route_install6(
         &self,
         prefix: Ipv6Net,
+        table_id: u32,
         members: Vec<(Option<Ipv6Addr>, u32, Vec<u32>)>,
     ) {
+        // cradle has no per-VRF v6 FIB yet: skip VRF-scoped v6 routes rather
+        // than leak them into the global table.
+        if cradle_vrf(table_id) != 0 {
+            tracing::debug!(
+                "fib: cradle route_install6 {prefix}: v6 VRF tee not supported, skipped"
+            );
+            return;
+        }
         if let Err(e) = self.try_route_install6(prefix, members).await {
             tracing::warn!("fib: cradle route_install6 {prefix} failed: {e}");
         }
@@ -271,7 +299,10 @@ impl CradleFib {
         Ok(())
     }
 
-    pub async fn route_del6(&self, prefix: Ipv6Net) {
+    pub async fn route_del6(&self, prefix: Ipv6Net, table_id: u32) {
+        if cradle_vrf(table_id) != 0 {
+            return; // v6 VRF routes are never teed (see route_install6)
+        }
         let result = async {
             self.client()
                 .await?

--- a/zebra-rs/src/fib/netlink/handle.rs
+++ b/zebra-rs/src/fib/netlink/handle.rs
@@ -662,7 +662,7 @@ impl FibHandle {
         if let Some(cradle) = &self.cradle {
             let members = cradle_members_v4(&entry.nexthop);
             if !members.is_empty() {
-                cradle.route_install(*prefix, members).await;
+                cradle.route_install(*prefix, table_id, members).await;
             }
         }
         match &entry.nexthop {
@@ -818,7 +818,7 @@ impl FibHandle {
             return;
         }
         if let Some(cradle) = &self.cradle {
-            cradle.route_del(*prefix).await;
+            cradle.route_del(*prefix, table_id).await;
         }
 
         match &entry.nexthop {
@@ -1101,7 +1101,7 @@ impl FibHandle {
         if let Some(cradle) = &self.cradle {
             let members = cradle_members_v6(&entry.nexthop);
             if !members.is_empty() {
-                cradle.route_install6(*prefix, members).await;
+                cradle.route_install6(*prefix, table_id, members).await;
             }
         }
         match &entry.nexthop {
@@ -1274,7 +1274,7 @@ impl FibHandle {
             return;
         }
         if let Some(cradle) = &self.cradle {
-            cradle.route_del6(*prefix).await;
+            cradle.route_del6(*prefix, table_id).await;
         }
 
         match &entry.nexthop {


### PR DESCRIPTION
## Summary

Companion to cradle-rs PR #21 (MPLS L3VPN Phase 3). The route tee dropped the `table_id` that `route_ipv4_add`/`route_ipv6_add` always receive, so **VRF routes were teed into cradle's global FIB** — a live mis-programming now that cradle has a per-VRF FIB.

- Vendored proto synced (`Route4/Route4Del.vrf_table_id`, `Port.vrf_id`).
- `cradle.rs`: `route_install`/`route_del` (+v6) take `table_id`; `cradle_vrf()` normalizes `{0, 254} → 0`; any other value is the RIB-allocated VRF table id — byte-identical to the `vrf_table_id` the `DecapVrf` ILM tee already sends, so a VPN label's decap and its VRF's routes land in the same cradle table.
- v6 VRF routes are **skipped** (no per-VRF v6 FIB yet) rather than leaked globally.
- `handle.rs`: the four tee call sites pass the `table_id` already in scope.

## Test plan

- End-to-end: cradle-rs `cradle_l3vpn_zebra` BDD — iBGP VPNv4 over IS-IS SR with cradle on pe1/p/pe2; customer sites ping across an all-eBPF core (imposition, PHP pop-and-forward, DecapVrf into the per-VRF FIB).
- Existing `cradle_zebra` / `cradle_zebrav6` / `cradle_mpls_zebra` / `cradle_mpls_isis` features stay green.
- `cargo build` clean; `cargo fmt --check` and clippy clean locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)