### PR TITLE
feat: tee SRv6 uALib to cradle as a distinct behavior

### DIFF
--- a/zebra-rs/src/fib/cradle.rs
+++ b/zebra-rs/src/fib/cradle.rs
@@ -47,8 +47,9 @@ fn srv6_behavior(b: crate::rib::SidBehavior) -> u32 {
         EndDT46 => 4,
         EndB6Encap => 5,
         UN => 6,
-        UA | UALib => 7,
-        EndM => 3, // mirror-context ~ End.DT6 (best-effort; not implemented)
+        UA => 7,    // classic End.X at /128 (no shift)
+        UALib => 8, // compressed carrier: shift + adjacency
+        EndM => 3,  // mirror-context ~ End.DT6 (best-effort; not implemented)
     }
 }
 


### PR DESCRIPTION
## Summary

cradle now handles `uA` and `uALib` differently, so the tee must too:

- `uA` → `7` (`SRV6_BH_UA`) — classic `End.X` at /128 (no shift).
- `uALib` → `8` (`SRV6_BH_UALIB`) — the compressed-carrier adjacency form
  (shift the uSID container mid-carrier, then forward out the cross-connect).

Previously both folded into `7`, so a teed `uALib` would have been mis-handled
as `End.X` (no shift) and mis-forwarded. This one-line mapping fix routes it to
cradle's new shift-and-adjacency path.

Pairs with cradle-rs (the `uA`/`uALib` datapath + `cradle_srv6_ualib` BDD).

## Test plan

- `cargo fmt --check`, `clippy --workspace --all-targets -- -D warnings`,
  `cargo build`: clean.
- cradle-rs `cradle_srv6_l3vpn_zebra` (drives this binary) still passes — the
  mapping change only affects `uALib`, which the L3VPN path does not use.

Generated with [Claude Code](https://claude.com/claude-code)