### PR TITLE
feat: EVPN over SRv6 unicast (End.DT2U) + the cradle L2 tee

### DIFF
--- a/crates/bgp-packet/src/attrs/prefix_sid.rs
+++ b/crates/bgp-packet/src/attrs/prefix_sid.rs
@@ -10,11 +10,13 @@ use crate::{AttrType, ParseBe};
 use super::{AttrEmitter, AttrFlags};
 
 /// SRv6 Endpoint Behavior codepoints (IANA "SRv6 Endpoint Behaviors",
-/// RFC 8986). The L3VPN decap behaviors plus the L2 multicast/BUM decap
-/// (`End.DT2M`) used by EVPN-over-SRv6 (RFC 9252 §6.4).
+/// RFC 8986). The L3VPN decap behaviors plus the L2 decaps used by
+/// EVPN-over-SRv6: unicast (`End.DT2U`, RFC 9252 §6.1/§6.2 on Type-2) and
+/// multicast/BUM (`End.DT2M`, §6.4 on Type-3).
 pub const SRV6_BEHAVIOR_END_DT6: u16 = 0x0012;
 pub const SRV6_BEHAVIOR_END_DT4: u16 = 0x0013;
 pub const SRV6_BEHAVIOR_END_DT46: u16 = 0x0014;
+pub const SRV6_BEHAVIOR_END_DT2U: u16 = 0x0015;
 pub const SRV6_BEHAVIOR_END_DT2M: u16 = 0x0016;
 
 /// BGP Prefix-SID TLV Types (IANA "BGP Prefix-SID TLV Types", RFC 8669 /

--- a/proto/cradle.proto
+++ b/proto/cradle.proto
@@ -103,6 +103,23 @@ message LocalSidDel {
 
 message Srv6EncapSource { string addr = 1; }  // outer IPv6 SA for H.Encaps
 
+// EVPN-over-SRv6 overlay FDB entry: MAC `mac` in bridge domain `bd` sits
+// behind the remote PE's End.DT2U/DT2M service SID. `nexthop_id` selects the
+// underlay adjacency; 0 = resolve by a FIB6 lookup on `remote_sid` in the
+// datapath (the control plane doesn't need to pre-resolve). The all-ones MAC
+// is the per-BD BUM sentinel (remote End.DT2M).
+message FdbRemote {
+  string mac        = 1;
+  uint32 bd         = 2;
+  string remote_sid = 3;
+  uint32 nexthop_id = 4;
+}
+
+message FdbRemoteDel {
+  string mac = 1;
+  uint32 bd  = 2;
+}
+
 message Neighbor4 {
   string oif = 1;       // interface name (used when oif_index == 0)
   string ip = 2;
@@ -190,6 +207,8 @@ service Cradle {
   rpc AddLocalSid(LocalSid) returns (Empty);
   rpc DelLocalSid(LocalSidDel) returns (Empty);
   rpc SetSrv6EncapSource(Srv6EncapSource) returns (Empty);
+  rpc AddFdbRemote(FdbRemote) returns (Empty);
+  rpc DelFdbRemote(FdbRemoteDel) returns (Empty);
   rpc AddService(Service) returns (Empty);
   rpc GetStats(StatsRequest) returns (StatsReply);
   rpc AddL7Service(L7Service) returns (Empty);

--- a/zebra-rs/src/bgp/config.rs
+++ b/zebra-rs/src/bgp/config.rs
@@ -1706,6 +1706,39 @@ fn config_advertise_all_vni(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Opti
     Some(())
 }
 
+/// `router bgp afi-safi evpn encapsulation {vxlan|srv6}` (RFC 9252).
+/// With `srv6`, Type-2 routes carry a per-VNI End.DT2U SID and Type-3
+/// IMETs an End.DT2M SID (SRv6 L2 Service TLVs), both carved from the
+/// BGP SRv6 locator; received MACs install against the peer's SIDs.
+/// Toggling re-originates the local FDB and IMETs so the SIDs are
+/// attached/dropped in place.
+fn config_evpn_encapsulation(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Option<()> {
+    let afi_safi: AfiSafi = args.afi_safi()?;
+    if afi_safi.afi != Afi::L2vpn || afi_safi.safi != Safi::Evpn {
+        return None;
+    }
+    let srv6 = if op.is_set() {
+        args.string()?.as_str() == "srv6"
+    } else {
+        false
+    };
+    if bgp.evpn_encap_srv6 == srv6 {
+        return Some(());
+    }
+    bgp.evpn_encap_srv6 = srv6;
+    // Re-originate under the new encapsulation (no-op when
+    // advertise-all-vni is off; the config-load gate replay covers
+    // cold boot, where this leaf lands before the FdbAdds arrive).
+    if bgp.advertise_all_vni {
+        let entries: Vec<FdbEntry> = bgp.local_fdb.values().cloned().collect();
+        for entry in entries {
+            bgp.evpn_originate_macip(&entry);
+        }
+    }
+    reoriginate_all_imet(bgp);
+    Some(())
+}
+
 /// `router bgp afi-safi evpn igmp-mld-proxy <bool>` (RFC 9251 §6).
 /// When enabled, the Multicast Flags Extended Community (IGMP + MLD
 /// proxy capability) is attached to every originated Type-3 IMET
@@ -4420,6 +4453,14 @@ impl Bgp {
         self.callback_add(
             "/router/bgp/afi-safi/advertise-all-vni",
             config_advertise_all_vni,
+        );
+
+        // EVPN overlay encapsulation (RFC 9252) under
+        // `router bgp afi-safi evpn encapsulation {vxlan|srv6}`. With
+        // srv6, Type-2/Type-3 routes carry End.DT2U/End.DT2M SIDs.
+        self.callback_add(
+            "/router/bgp/afi-safi/encapsulation",
+            config_evpn_encapsulation,
         );
 
         // EVPN IGMP/MLD proxy capability (RFC 9251 §6) under

--- a/zebra-rs/src/bgp/inst.rs
+++ b/zebra-rs/src/bgp/inst.rs
@@ -975,6 +975,15 @@ pub struct Bgp {
     /// [`Self::srv6_sid_pool`] (same band as a per-VRF SID) and freed when
     /// the VNI stops originating.
     pub evpn_dt2m_sids: BTreeMap<u32, (std::net::Ipv6Addr, u16)>,
+    /// Per-VNI `End.DT2U` service SID `(addr, function)` for EVPN unicast
+    /// over SRv6 (RFC 9252 §6.1/§6.2), carved like the DT2M SID and
+    /// advertised on every Type-2 the VNI originates when
+    /// [`Self::evpn_encap_srv6`] is set.
+    pub evpn_dt2u_sids: BTreeMap<u32, (std::net::Ipv6Addr, u16)>,
+    /// `router bgp afi-safi evpn encapsulation srv6` (RFC 9252): EVPN rides
+    /// SRv6 L2 service SIDs (End.DT2U on Type-2, End.DT2M on Type-3) instead
+    /// of VXLAN. The L2 data plane is the cradle eBPF tee.
+    pub evpn_encap_srv6: bool,
     /// `sr-p2mp-dataplane` config (interfaces + next hop for the SRv6 P2MP BUM
     /// replication eBPF dataplane), pushed to the RIB supervisor on change.
     pub evpn_sr_dataplane: EvpnSrDataplaneCfg,
@@ -1211,6 +1220,8 @@ impl Bgp {
             srv6_ipv6_unicast: false,
             srv6_ipv6_sid: None,
             evpn_dt2m_sids: BTreeMap::new(),
+            evpn_dt2u_sids: BTreeMap::new(),
+            evpn_encap_srv6: false,
             evpn_sr_dataplane: EvpnSrDataplaneCfg::default(),
             srv6_ipv6_export: None,
             networks_v6: std::collections::BTreeSet::new(),
@@ -1383,6 +1394,32 @@ impl Bgp {
         }
     }
 
+    /// Register a per-VNI L2 service SID (`End.DT2U`/`End.DT2M`) with the
+    /// RIB SID registry — `table_id` carries the VNI (the bridge domain).
+    /// The kernel has no L2 seg6local actions, so `route_sid_install`
+    /// skips netlink for these; the cradle eBPF tee is the data plane.
+    fn send_vni_l2_sid_add(
+        &self,
+        vni: u32,
+        addr: std::net::Ipv6Addr,
+        behavior: crate::rib::SidBehavior,
+    ) {
+        let sid = crate::rib::Sid {
+            addr,
+            behavior,
+            context: crate::rib::SidContext::None,
+            owner: crate::rib::SidOwner::new("bgp", 0),
+            locator: self.srv6_locator_name.clone().unwrap_or_default(),
+            allocation_type: crate::rib::SidAllocationType::Dynamic,
+            ifindex: 0,
+            nh6: None,
+            structure: None,
+            table_id: vni,
+            segs: Vec::new(),
+        };
+        let _ = self.ctx.rib.send(crate::rib::Message::SidAdd { sid });
+    }
+
     /// Allocate (or return the existing) `End.DT2M` SID for `vni`, carved from
     /// the resolved locator. Stable per VNI for as long as it originates;
     /// `None` when no locator has resolved or the function band is exhausted.
@@ -1401,6 +1438,8 @@ impl Bgp {
                     .ctx
                     .rib
                     .send(crate::rib::Message::ReplLeafAdd { vni, sid: addr });
+                // And the SID registry / cradle tee (decap + BD flood there).
+                self.send_vni_l2_sid_add(vni, addr, crate::rib::SidBehavior::EndDT2M);
                 Some(addr)
             }
             None => {
@@ -1413,10 +1452,54 @@ impl Bgp {
     /// Release `vni`'s `End.DT2M` SID back to the pool (it stopped
     /// originating). No-op if it had none (e.g. no locator was resolved).
     pub(super) fn free_vni_dt2m_sid(&mut self, vni: u32) {
-        if let Some((_addr, function)) = self.evpn_dt2m_sids.remove(&vni) {
+        if let Some((addr, function)) = self.evpn_dt2m_sids.remove(&vni) {
             self.srv6_sid_pool.release(function);
             let _ = self.ctx.rib.send(crate::rib::Message::ReplLeafDel { vni });
+            let _ = self.ctx.rib.send(crate::rib::Message::SidDel { addr });
         }
+    }
+
+    /// Allocate (or return the existing) `End.DT2U` SID for `vni` — the
+    /// EVPN-over-SRv6 unicast service SID (RFC 9252 §6.1/§6.2), advertised
+    /// on every Type-2 the VNI originates under `encapsulation srv6`.
+    fn alloc_vni_dt2u_sid(&mut self, vni: u32) -> Option<std::net::Ipv6Addr> {
+        if let Some((addr, _function)) = self.evpn_dt2u_sids.get(&vni) {
+            return Some(*addr);
+        }
+        let prefix = self.srv6_locator.as_ref().and_then(|l| l.prefix)?;
+        let function = self.srv6_sid_pool.allocate()?;
+        match crate::isis::srv6::function_addr(prefix, function) {
+            Some(addr) => {
+                self.evpn_dt2u_sids.insert(vni, (addr, function));
+                self.send_vni_l2_sid_add(vni, addr, crate::rib::SidBehavior::EndDT2U);
+                Some(addr)
+            }
+            None => {
+                self.srv6_sid_pool.release(function);
+                None
+            }
+        }
+    }
+
+    /// Release `vni`'s `End.DT2U` SID back to the pool.
+    pub(super) fn free_vni_dt2u_sid(&mut self, vni: u32) {
+        if let Some((addr, function)) = self.evpn_dt2u_sids.remove(&vni) {
+            self.srv6_sid_pool.release(function);
+            let _ = self.ctx.rib.send(crate::rib::Message::SidDel { addr });
+        }
+    }
+
+    /// Build the SRv6 L2 Service Prefix-SID attribute advertised on `vni`'s
+    /// Type-2 MAC/IP routes — this PE's `End.DT2U` SID for the VNI. `None`
+    /// when no locator has resolved.
+    pub(super) fn vni_dt2u_prefix_sid(&mut self, vni: u32) -> Option<bgp_packet::PrefixSid> {
+        let sid = self.alloc_vni_dt2u_sid(vni)?;
+        let structure = self.srv6_locator.as_ref().and_then(|l| l.sid_structure());
+        Some(srv6_l2_service_prefix_sid(
+            sid,
+            structure,
+            bgp_packet::SRV6_BEHAVIOR_END_DT2U,
+        ))
     }
 
     /// Build the SRv6 L2 Service Prefix-SID attribute advertised on `vni`'s
@@ -1456,9 +1539,11 @@ impl Bgp {
         // maps to a now-invalid address. Throw the pool away and
         // re-allocate from the base under the new prefix.
         self.srv6_sid_pool.reset();
-        // Per-VNI End.DT2M SIDs were carved from the same pool; drop them so
-        // the next Type-3 (re)origination re-allocates under the new prefix.
+        // Per-VNI End.DT2M / End.DT2U SIDs were carved from the same pool;
+        // drop them so the next (re)origination re-allocates under the new
+        // prefix.
         self.evpn_dt2m_sids.clear();
+        self.evpn_dt2u_sids.clear();
         let srv6_vrfs: Vec<String> = self
             .vrf_registry
             .keys()

--- a/zebra-rs/src/bgp/route.rs
+++ b/zebra-rs/src/bgp/route.rs
@@ -6778,6 +6778,14 @@ fn extract_mac_mobility_seq(attr: &BgpAttr) -> u32 {
 /// produced `tunnel_endpoint = None` for every received Type-2,
 /// which made `mac_add` build an FDB row with no NDA_DST and the
 /// kernel rejected the install with EINVAL.
+/// The SRv6 L2 Service SID of the wanted behavior on an EVPN route's
+/// Prefix-SID attribute (RFC 9252), if any.
+fn evpn_srv6_sid(attr: &BgpAttr, behavior: u16) -> Option<std::net::Ipv6Addr> {
+    attr.srv6_l2_sid()
+        .filter(|(_, b)| *b == behavior)
+        .map(|(sid, _)| sid)
+}
+
 fn extract_tunnel_endpoint(rib: &BgpRib) -> Option<IpAddr> {
     match rib.attr.nexthop.as_ref()? {
         BgpNexthop::Evpn(addr) => Some(*addr),
@@ -6832,6 +6840,14 @@ fn route_evpn_export_selected(
             }
             EvpnPrefix::InclusiveMulticast { orig, .. } => {
                 if let Some(vni) = extract_vni_from_attr(&wd.attr) {
+                    // Mirror the announce side: the withdrawn IMET carried a
+                    // DT2M SID -> remove the BUM sentinel.
+                    if evpn_srv6_sid(&wd.attr, bgp_packet::SRV6_BEHAVIOR_END_DT2M).is_some() {
+                        let _ = bgp.rib_client.send(rib::Message::MacDel {
+                            vni,
+                            mac: MacAddr::from([0xff; 6]),
+                        });
+                    }
                     bgp.local_rib.evpn_flood.remove_remote(vni, *orig);
                     evpn_gateway_tree_set(bgp.local_rib, *bgp.router_id, vni);
                     bgp.local_rib.evpn_flood.reconcile(vni, bgp.rib_client);
@@ -6908,6 +6924,9 @@ fn route_evpn_export_selected(
                     flags: extract_flags_from_attr(&best.attr),
                     seq: extract_mac_mobility_seq(&best.attr),
                     esi: best.esi, // Extracted from EVPN route.
+                    // RFC 9252: a remote End.DT2U SID selects the SRv6 L2
+                    // data plane (cradle tee) over the kernel VXLAN FDB.
+                    srv6_sid: evpn_srv6_sid(&best.attr, bgp_packet::SRV6_BEHAVIOR_END_DT2U),
                 };
                 let _ = bgp.rib_client.send(msg);
             } else {
@@ -6925,6 +6944,22 @@ fn route_evpn_export_selected(
             // type 0x0A carries the AR-IP) and reconcile the role-aware flood
             // list, rather than blindly flooding toward the originating IP.
             if let Some(vni) = extract_vni_from_attr(&best.attr) {
+                // RFC 9252 §6.4: a remote End.DT2M SID on the IMET is the BUM
+                // tunnel target for this VNI. Install it as the bridge
+                // domain's all-ones BUM sentinel (the cradle-tee L2 data
+                // plane encapsulates broadcast/multicast toward it);
+                // independent of the PMSI mode below.
+                if let Some(dt2m) = evpn_srv6_sid(&best.attr, bgp_packet::SRV6_BEHAVIOR_END_DT2M) {
+                    let _ = bgp.rib_client.send(rib::Message::MacAdd {
+                        vni,
+                        mac: MacAddr::from([0xff; 6]),
+                        tunnel_endpoint: None,
+                        flags: 0,
+                        seq: 0,
+                        esi: None,
+                        srv6_sid: Some(dt2m),
+                    });
+                }
                 let pmsi = best.attr.pmsi_tunnel.as_ref();
                 if let Some(p) = pmsi.filter(|p| p.is_sr_p2mp()) {
                     // SR P2MP tree (RFC 9574 -> RFC 9524): record the
@@ -14194,6 +14229,12 @@ impl Bgp {
             );
         }
         attr.nexthop = Some(BgpNexthop::Evpn(nexthop));
+        // RFC 9252 §6.1/§6.2: under `encapsulation srv6` the Type-2 carries
+        // this PE's per-VNI End.DT2U SID (SRv6 L2 Service TLV) so receivers
+        // install the MAC against the SID instead of a VXLAN VTEP.
+        if self.evpn_encap_srv6 {
+            attr.prefix_sid = self.vni_dt2u_prefix_sid(entry.vni);
+        }
 
         let mut rib = BgpRib::new(
             ORIGINATED_PEER,
@@ -14456,7 +14497,7 @@ impl Bgp {
         // for the VNI on the IMET route (SRv6 L2 Service TLV in the Prefix-SID
         // attribute) so remote roots fan replicated BUM to it. SID-less when no
         // locator has resolved yet (reconciled on the next locator update).
-        if matches!(bum, EvpnBumTunnel::SrV6P2mp) {
+        if matches!(bum, EvpnBumTunnel::SrV6P2mp) || self.evpn_encap_srv6 {
             attr.prefix_sid = self.vni_dt2m_prefix_sid(vni);
         }
 
@@ -14520,9 +14561,10 @@ impl Bgp {
         route_withdraw_evpn_to_peers(rd, prefix, &mut self.peers);
         // We no longer originate this VNI — drop its SR P2MP tree Root so a
         // subsequent reconcile withdraws any replication segment, and release
-        // its End.DT2M SID back to the pool.
+        // its End.DT2M / End.DT2U SIDs back to the pool.
         self.local_rib.evpn_flood.clear_local_root(vni);
         self.free_vni_dt2m_sid(vni);
+        self.free_vni_dt2u_sid(vni);
     }
 
     /// Originate a Type-6 SMET route for a locally-snooped `(*,G)` /

--- a/zebra-rs/src/fib/cradle.rs
+++ b/zebra-rs/src/fib/cradle.rs
@@ -47,9 +47,11 @@ fn srv6_behavior(b: crate::rib::SidBehavior) -> u32 {
         EndDT46 => 4,
         EndB6Encap => 5,
         UN => 6,
-        UA => 7,    // classic End.X at /128 (no shift)
-        UALib => 8, // compressed carrier: shift + adjacency
-        EndM => 3,  // mirror-context ~ End.DT6 (best-effort; not implemented)
+        UA => 7,       // classic End.X at /128 (no shift)
+        UALib => 8,    // compressed carrier: shift + adjacency
+        EndDT2U => 9,  // EVPN L2 unicast decap+bridge
+        EndDT2M => 10, // EVPN L2 BUM decap+flood
+        EndM => 3,     // mirror-context ~ End.DT6 (best-effort; not implemented)
     }
 }
 
@@ -523,6 +525,56 @@ impl CradleFib {
         .await;
         if let Err(e) = result {
             tracing::warn!("fib: cradle local_sid_uninstall {} failed: {e}", sid.addr);
+        }
+    }
+
+    /// EVPN-over-SRv6 overlay FDB entry (RFC 9252): `mac` in bridge domain
+    /// `vni` sits behind the remote PE's L2 service SID (End.DT2U for
+    /// unicast; the all-ones BUM sentinel carries End.DT2M). `nexthop_id: 0`
+    /// — cradle resolves the underlay adjacency with a FIB6 lookup on the
+    /// SID (the IGP's locator route, already teed).
+    pub async fn fdb_add(&self, vni: u32, mac: [u8; 6], sid: std::net::Ipv6Addr) {
+        let mac_str = format!(
+            "{:02x}:{:02x}:{:02x}:{:02x}:{:02x}:{:02x}",
+            mac[0], mac[1], mac[2], mac[3], mac[4], mac[5]
+        );
+        let result = async {
+            self.client()
+                .await?
+                .add_fdb_remote(pb::FdbRemote {
+                    mac: mac_str.clone(),
+                    bd: vni,
+                    remote_sid: sid.to_string(),
+                    nexthop_id: 0,
+                })
+                .await?;
+            anyhow::Ok(())
+        }
+        .await;
+        if let Err(e) = result {
+            tracing::warn!("fib: cradle fdb_add {mac_str} vni {vni} failed: {e}");
+        }
+    }
+
+    /// Remove an overlay FDB entry.
+    pub async fn fdb_del(&self, vni: u32, mac: [u8; 6]) {
+        let mac_str = format!(
+            "{:02x}:{:02x}:{:02x}:{:02x}:{:02x}:{:02x}",
+            mac[0], mac[1], mac[2], mac[3], mac[4], mac[5]
+        );
+        let result = async {
+            self.client()
+                .await?
+                .del_fdb_remote(pb::FdbRemoteDel {
+                    mac: mac_str.clone(),
+                    bd: vni,
+                })
+                .await?;
+            anyhow::Ok(())
+        }
+        .await;
+        if let Err(e) = result {
+            tracing::warn!("fib: cradle fdb_del {mac_str} vni {vni} failed: {e}");
         }
     }
 

--- a/zebra-rs/src/fib/netlink/handle.rs
+++ b/zebra-rs/src/fib/netlink/handle.rs
@@ -284,6 +284,13 @@ fn sid_route_target(
         SidBehavior::EndDT4 | SidBehavior::EndDT6 | SidBehavior::EndDT46 | SidBehavior::EndM => {
             (RouteHeader::RT_TABLE_MAIN, RouteType::Unicast, 128, addr)
         }
+        // EVPN-over-SRv6 L2 service SIDs: same /128 host-route shape, but
+        // they never reach the kernel (no End.DT2U/DT2M seg6local action) —
+        // `route_sid_install` returns after the cradle tee. The target is
+        // computed anyway so the tee gets the right prefix length.
+        SidBehavior::EndDT2U | SidBehavior::EndDT2M => {
+            (RouteHeader::RT_TABLE_MAIN, RouteType::Unicast, 128, addr)
+        }
         // End.B6.Encaps (SR Policy Binding SID): a /128 host route in
         // table=main; the SRH it pushes rides inside the seg6local
         // encap, not in the route header.
@@ -1605,6 +1612,15 @@ impl FibHandle {
         if let Some(cradle) = &self.cradle {
             cradle.local_sid_install(sid, prefix_len, ifindex).await;
         }
+        // EVPN-over-SRv6 L2 SIDs are cradle-only: the kernel has no
+        // End.DT2U/DT2M seg6local actions, so there is nothing to install
+        // via netlink.
+        if matches!(
+            sid.behavior,
+            crate::rib::SidBehavior::EndDT2U | crate::rib::SidBehavior::EndDT2M
+        ) {
+            return;
+        }
         msg.header.table = table;
         msg.header.destination_prefix_length = prefix_len;
         msg.header.protocol = RouteProtocol::Isis;
@@ -1760,6 +1776,13 @@ impl FibHandle {
             sid_route_target(sid.behavior, sid.addr, sid.structure);
         if let Some(cradle) = &self.cradle {
             cradle.local_sid_uninstall(sid, prefix_len).await;
+        }
+        // Cradle-only L2 SIDs (see route_sid_install): nothing in the kernel.
+        if matches!(
+            sid.behavior,
+            crate::rib::SidBehavior::EndDT2U | crate::rib::SidBehavior::EndDT2M
+        ) {
+            return;
         }
         msg.header.table = table;
         msg.header.destination_prefix_length = prefix_len;
@@ -2743,6 +2766,7 @@ impl FibHandle {
     /// from BGP. Both are required and FRR programs both. The third
     /// VLAN-tagged variant FRR sometimes adds is only needed when the
     /// bridge is `vlan_filtering 1`; not implemented here yet.
+    #[allow(clippy::too_many_arguments)]
     pub async fn mac_add(
         &self,
         vni: u32,
@@ -2751,7 +2775,18 @@ impl FibHandle {
         flags: u8,
         _seq: u32,
         esi: Option<[u8; 10]>,
+        srv6_sid: Option<std::net::Ipv6Addr>,
     ) {
+        // EVPN over SRv6 (RFC 9252): the MAC sits behind a remote L2 service
+        // SID (End.DT2U; the all-ones BUM sentinel behind End.DT2M). The
+        // cradle eBPF tee is the L2 data plane — there is no kernel VXLAN
+        // FDB row to install (and no VXLAN device is required).
+        if let Some(sid) = srv6_sid {
+            if let Some(cradle) = &self.cradle {
+                cradle.fdb_add(vni, mac.octets(), sid).await;
+            }
+            return;
+        }
         let Some(&vxlan_ifindex) = self.vni_ifindex_map.get(&vni) else {
             if fib_l2_fdb() {
                 tracing::info!(
@@ -3038,6 +3073,11 @@ impl FibHandle {
 
     /// Delete EVPN MAC entry from bridge FDB
     pub async fn mac_del(&self, vni: u32, mac: &MacAddr) {
+        // Tee the delete to cradle first (harmless when the entry was never
+        // teed): `MacDel` doesn't say whether the add was VXLAN or SRv6.
+        if let Some(cradle) = &self.cradle {
+            cradle.fdb_del(vni, mac.octets()).await;
+        }
         // Mirror `mac_add` — skip when no local VXLAN registered for
         // this VNI. With `mac_add` skipping installs in the same case,
         // there's nothing in the kernel to delete; the old

--- a/zebra-rs/src/fib/netlink/srv6.rs
+++ b/zebra-rs/src/fib/netlink/srv6.rs
@@ -119,6 +119,11 @@ fn build_srh(segments: &[Ipv6Addr]) -> Ipv6SrHdr {
 fn seg6local_action(behavior: SidBehavior) -> Seg6LocalAction {
     match behavior {
         SidBehavior::End | SidBehavior::UN => Seg6LocalAction::End,
+        // EVPN L2 SIDs never reach the kernel (route_sid_install returns
+        // after the cradle tee — no End.DT2U/DT2M seg6local action exists);
+        // map to End so an unexpected call is a visible no-op rather than
+        // a panic.
+        SidBehavior::EndDT2U | SidBehavior::EndDT2M => Seg6LocalAction::End,
         SidBehavior::EndX | SidBehavior::UA | SidBehavior::UALib => Seg6LocalAction::EndX,
         SidBehavior::EndDT4 => Seg6LocalAction::EndDt4,
         // End.M reuses the End.DT6 kernel action: decapsulate and look the

--- a/zebra-rs/src/rib/inst.rs
+++ b/zebra-rs/src/rib/inst.rs
@@ -314,6 +314,11 @@ pub enum Message {
         flags: u8,
         seq: u32,
         esi: Option<[u8; 10]>,
+        /// EVPN-over-SRv6 (RFC 9252): the remote PE's L2 service SID this
+        /// MAC sits behind — End.DT2U for a unicast MAC, End.DT2M for the
+        /// all-ones BUM sentinel. `Some` selects the cradle L2 tee over the
+        /// kernel VXLAN FDB.
+        srv6_sid: Option<std::net::Ipv6Addr>,
     },
     MacDel {
         vni: u32,
@@ -2896,8 +2901,9 @@ impl Rib {
                 flags,
                 seq,
                 esi,
+                srv6_sid,
             } => {
-                self.mac_add(vni, mac, tunnel_endpoint, flags, seq, esi)
+                self.mac_add(vni, mac, tunnel_endpoint, flags, seq, esi, srv6_sid)
                     .await;
             }
             Message::MacDel { vni, mac } => {
@@ -3305,6 +3311,7 @@ impl Rib {
         }
     }
 
+    #[allow(clippy::too_many_arguments)]
     async fn mac_add(
         &mut self,
         vni: u32,
@@ -3313,6 +3320,7 @@ impl Rib {
         flags: u8,
         seq: u32,
         esi: Option<[u8; 10]>,
+        srv6_sid: Option<std::net::Ipv6Addr>,
     ) {
         // MAC Mobility: ignore stale duplicates (lower sequence number)
         if let Some(existing) = self.mac_table.get(&(vni, mac))
@@ -3330,9 +3338,10 @@ impl Rib {
 
         self.mac_table.insert((vni, mac), entry);
 
-        // Forward to kernel FIB
+        // Forward to kernel FIB (or, with an SRv6 L2 service SID, the
+        // cradle eBPF tee).
         self.fib_handle
-            .mac_add(vni, &mac, tunnel_endpoint, flags, seq, esi)
+            .mac_add(vni, &mac, tunnel_endpoint, flags, seq, esi, srv6_sid)
             .await;
     }
 

--- a/zebra-rs/src/rib/segment_routing/sid.rs
+++ b/zebra-rs/src/rib/segment_routing/sid.rs
@@ -60,6 +60,20 @@ pub enum SidBehavior {
     /// (carried in [`Sid::segs`]) and forwarded. BGP SR Policy
     /// (SAFI 73) installs the advertised SRv6 Binding SID this way.
     EndB6Encap,
+    /// End.DT2U — RFC 8986 §4.9 (IANA codepoint 0x15). Decapsulates and
+    /// switches the inner **Ethernet frame** by unicast destination MAC in
+    /// the bridge domain carried in [`Sid::table_id`] (the VNI). The EVPN-
+    /// over-SRv6 unicast service SID (RFC 9252 §6.1/§6.2), one per VNI,
+    /// advertised on Type-2 routes. The kernel has no such seg6local
+    /// action — the cradle eBPF tee is the data plane, so the FIB skips
+    /// the netlink install.
+    EndDT2U,
+    /// End.DT2M — RFC 8986 §4.10 (IANA codepoint 0x16). Decapsulates and
+    /// **floods** the inner Ethernet frame in the bridge domain
+    /// ([`Sid::table_id`] = VNI). The EVPN-over-SRv6 BUM service SID
+    /// (RFC 9252 §6.4), advertised on Type-3 IMET routes. Cradle-tee-only,
+    /// like End.DT2U.
+    EndDT2M,
     /// End.M — Mirroring Context segment (IANA codepoint 74,
     /// draft-ietf-rtgwg-srv6-egress-protection). A variant of End.DT6:
     /// the protector decapsulates the outer IPv6/SRH and looks the inner
@@ -81,6 +95,8 @@ impl fmt::Display for SidBehavior {
             Self::EndDT6 => write!(f, "End.DT6"),
             Self::EndDT46 => write!(f, "End.DT46"),
             Self::EndB6Encap => write!(f, "End.B6.Encaps"),
+            Self::EndDT2U => write!(f, "End.DT2U"),
+            Self::EndDT2M => write!(f, "End.DT2M"),
             Self::EndM => write!(f, "End.M"),
         }
     }
@@ -104,6 +120,9 @@ impl FromStr for SidBehavior {
             "End.DT6" => Ok(Self::EndDT6),
             "End.DT46" => Ok(Self::EndDT46),
             "End.B6.Encaps" => Ok(Self::EndB6Encap),
+            // End.DT2U / End.DT2M are deliberately absent: they are
+            // allocated per-VNI by BGP EVPN (`encapsulation srv6`), never
+            // named in config.
             "End.M" => Ok(Self::EndM),
             other => Err(SidBehaviorParseError(other.to_string())),
         }
@@ -249,6 +268,8 @@ impl Sid {
             | SidBehavior::EndDT6
             | SidBehavior::EndDT46
             | SidBehavior::EndB6Encap
+            | SidBehavior::EndDT2U
+            | SidBehavior::EndDT2M
             | SidBehavior::EndM => Ipv6Net::new(self.addr, 128).expect("/128 is always valid"),
             SidBehavior::UALib => {
                 let plen = self

--- a/zebra-rs/yang/zebra-bgp-evpn.yang
+++ b/zebra-rs/yang/zebra-bgp-evpn.yang
@@ -78,6 +78,29 @@ module zebra-bgp-evpn {
          Equivalent to FRR's `advertise-all-vni` under
          `address-family l2vpn evpn`.";
     }
+    leaf encapsulation {
+      type enumeration {
+        enum vxlan {
+          description
+            "VXLAN tunnels (RFC 8365) — the kernel bridge/VXLAN FDB
+             data plane. The default.";
+        }
+        enum srv6 {
+          description
+            "SRv6 (RFC 9252) — advertise a per-VNI End.DT2U SID on
+             Type-2 (MAC/IP) routes and an End.DT2M SID on Type-3
+             (IMET) routes, carved from the BGP SRv6 locator, and
+             install received MACs against the peer's L2 service SIDs.
+             Requires `segment-routing srv6 locator`; the L2 data
+             plane is the cradle eBPF tee (`system cradle-grpc`) —
+             the kernel has no End.DT2U/DT2M seg6local actions.";
+        }
+      }
+      default vxlan;
+      description
+        "EVPN overlay encapsulation for locally originated and
+         received MAC routes.";
+    }
     leaf igmp-mld-proxy {
       type boolean;
       default false;


### PR DESCRIPTION
## Summary

Implement RFC 9252 EVPN-over-SRv6 **unicast** and tee the whole EVPN overlay
into the cradle eBPF data plane — the L2 analog of the L3VPN-over-SRv6 tee.
New `router bgp afi-safi evpn encapsulation {vxlan|srv6}` knob (default
`vxlan`, fully backward compatible).

**BGP (`encapsulation srv6`)**
- bgp-packet: `SRV6_BEHAVIOR_END_DT2U` (0x0015).
- Per-VNI `End.DT2U` allocation (`alloc_vni_dt2u_sid`, mirroring the DT2M
  allocator, same locator function pool); attached as an SRv6 L2 Service TLV
  on every originated Type-2. The IMET DT2M prefix-SID now also rides under
  `encapsulation srv6` (not only `srv6-p2mp` BUM mode).
- Receive: the peer's End.DT2U SID on a Type-2 flows into `MacAdd` as
  `srv6_sid`; a remote End.DT2M SID on a Type-3 IMET becomes the
  all-ones-MAC BUM-sentinel `MacAdd` (withdraw mirrors with `MacDel`).

**RIB/FIB tee**
- `SidBehavior::EndDT2U/EndDT2M`; the per-VNI L2 SIDs register in the RIB SID
  registry (`table_id` = VNI = bridge domain) and ride the existing local-SID
  tee; `route_sid_install/uninstall` skip netlink for them (the kernel has no
  End.DT2U/DT2M seg6local action — the cradle eBPF tee is the L2 data plane).
- `Message::MacAdd` carries `srv6_sid: Option<Ipv6Addr>`. `FibHandle::mac_add`
  with a SID tees `cradle.fdb_add` (`AddFdbRemote`, nexthop 0 — cradle resolves
  the underlay adjacency by a FIB6 lookup on the SID) and skips the kernel
  VXLAN FDB entirely (no VXLAN device required); `mac_del` tees the delete.
- `proto/cradle.proto` synced (`AddFdbRemote`/`DelFdbRemote`).

## Test plan

- `cargo fmt --check`, both clippy variants with `-D warnings`, build: clean.
- Proven end to end by cradle-rs `cradle_evpn_srv6_zebra`: iBGP EVPN over
  IS-IS SRv6, **no static ARP and no static cradle FDB** — remote MACs, the
  BUM sentinel, local L2 SIDs, and locator routes all arrive via the tee;
  c1↔c2 ping + `srv6_l2_bum`/`srv6_l2_encap`/`srv6_l2_decap` all assert.
- cradle-rs regressions (both static EVPN tests, `cradle_l2`, both
  L3VPN-zebra tests, `cradle_mpls_isis`, `cradle_srv6`): 7/7 pass — VXLAN
  EVPN and the L3 tees are unchanged (`srv6_sid: None` keeps the old path).

Generated with [Claude Code](https://claude.com/claude-code)