### PR TITLE
feat: subscribe to cradle datapath MAC learning (WatchFdb)

### DIFF
--- a/proto/cradle.proto
+++ b/proto/cradle.proto
@@ -120,6 +120,19 @@ message FdbRemoteDel {
   uint32 bd  = 2;
 }
 
+// Subscribe to datapath MAC learning (EVPN over SRv6): cradle streams every
+// locally-learned (mac, bridge-domain) so the control plane can originate
+// EVPN Type-2 routes for it. Only local entries are reported (never
+// FDB_F_REMOTE overlay entries or the BUM sentinel). Learns only — cradle
+// has no FDB aging yet; entries persist for the datapath's lifetime. On
+// (re)subscribe the full current set is replayed first.
+message WatchFdbRequest {}
+
+message FdbEvent {
+  string mac = 1;
+  uint32 bd  = 2;
+}
+
 message Neighbor4 {
   string oif = 1;       // interface name (used when oif_index == 0)
   string ip = 2;
@@ -209,6 +222,7 @@ service Cradle {
   rpc SetSrv6EncapSource(Srv6EncapSource) returns (Empty);
   rpc AddFdbRemote(FdbRemote) returns (Empty);
   rpc DelFdbRemote(FdbRemoteDel) returns (Empty);
+  rpc WatchFdb(WatchFdbRequest) returns (stream FdbEvent);
   rpc AddService(Service) returns (Empty);
   rpc GetStats(StatsRequest) returns (StatsReply);
   rpc AddL7Service(L7Service) returns (Empty);

--- a/zebra-rs/src/fib/cradle.rs
+++ b/zebra-rs/src/fib/cradle.rs
@@ -578,6 +578,19 @@ impl CradleFib {
         }
     }
 
+    /// Subscribe to cradle's datapath MAC learning (EVPN over SRv6): the
+    /// stream yields every locally-learned `(mac, bridge domain)` so the
+    /// caller can originate EVPN Type-2 routes. A fresh subscription
+    /// replays the full current set first; learns only (no aging yet).
+    pub async fn watch_fdb(&self) -> anyhow::Result<tonic::Streaming<pb::FdbEvent>> {
+        let resp = self
+            .client()
+            .await?
+            .watch_fdb(pb::WatchFdbRequest {})
+            .await?;
+        Ok(resp.into_inner())
+    }
+
     /// Feed a resolved neighbor (ARP/ND) into the cradle data plane — the
     /// MPLS egress rewrite (`mpls_l2_xmit`) resolves destination MACs from
     /// this state rather than the kernel neighbor table.

--- a/zebra-rs/src/rib/inst.rs
+++ b/zebra-rs/src/rib/inst.rs
@@ -324,6 +324,14 @@ pub enum Message {
         vni: u32,
         mac: MacAddr,
     },
+    /// A MAC the cradle eBPF datapath learned on a local L2 port (via the
+    /// `WatchFdb` stream). Re-emitted to EVPN subscribers as a synthesized
+    /// `RibRx::FdbAdd` — the cradle analogue of a kernel bridge FDB learn —
+    /// so BGP originates a Type-2 for it.
+    CradleFdbLearn {
+        vni: u32,
+        mac: MacAddr,
+    },
     MdbAdd {
         vni: u32,
         group: IpAddr,
@@ -617,6 +625,10 @@ pub enum NeighborKey {
 }
 
 pub struct Rib {
+    /// The cradle `WatchFdb` subscriber task (datapath MAC learning →
+    /// EVPN Type-2 origination); aborted and respawned when the
+    /// `system cradle-grpc` endpoint changes.
+    pub cradle_fdb_watch: Option<tokio::task::JoinHandle<()>>,
     pub cm: ConfigChannel,
     pub show: ShowChannel,
     pub show_cb: HashMap<String, ShowCallback>,
@@ -832,6 +844,7 @@ impl Rib {
         let (tx, rx) = mpsc::unbounded_channel();
         let (inbound_tx, inbound_rx) = mpsc::unbounded_channel();
         let mut rib = Rib {
+            cradle_fdb_watch: None,
             cm: ConfigChannel::new(),
             show: ShowChannel::new(),
             show_cb: HashMap::new(),
@@ -2909,6 +2922,9 @@ impl Rib {
             Message::MacDel { vni, mac } => {
                 self.mac_del(vni, mac).await;
             }
+            Message::CradleFdbLearn { vni, mac } => {
+                self.cradle_fdb_learn(vni, mac);
+            }
             Message::MdbAdd {
                 vni,
                 group,
@@ -3198,13 +3214,67 @@ impl Rib {
         mut args: crate::config::Args,
         op: ConfigOp,
     ) -> Option<()> {
+        // Tear down any previous watcher before re-pointing/disabling.
+        if let Some(watch) = self.cradle_fdb_watch.take() {
+            watch.abort();
+        }
         if op.is_set() {
             let endpoint = args.string()?;
             self.fib_handle.set_cradle(Some(&endpoint));
+            // The reverse channel: subscribe to cradle's datapath MAC
+            // learning and feed each entry back into this RIB as a
+            // `CradleFdbLearn`, which re-emits it to EVPN subscribers.
+            // Reconnects with backoff for the daemon-lifetime.
+            let cradle = crate::fib::cradle::CradleFib::new(&endpoint);
+            let tx = self.tx.clone();
+            self.cradle_fdb_watch = Some(tokio::spawn(async move {
+                loop {
+                    match cradle.watch_fdb().await {
+                        Ok(mut stream) => {
+                            while let Ok(Some(ev)) = stream.message().await {
+                                let Ok(mac) = ev.mac.parse::<MacAddr>() else {
+                                    continue;
+                                };
+                                let _ = tx.send(Message::CradleFdbLearn { vni: ev.bd, mac });
+                            }
+                        }
+                        Err(e) => {
+                            tracing::debug!("rib: cradle WatchFdb connect failed: {e}");
+                        }
+                    }
+                    tokio::time::sleep(std::time::Duration::from_secs(2)).await;
+                }
+            }));
         } else {
             self.fib_handle.set_cradle(None);
         }
         Some(())
+    }
+
+    /// A cradle-datapath MAC learn: synthesize the same `FdbEntry` a kernel
+    /// bridge learn produces (VNI = the cradle bridge domain) and dispatch
+    /// it to EVPN subscribers, so BGP originates a Type-2 exactly as it
+    /// would for a kernel-learned MAC. The VXLAN local address (the BGP
+    /// nexthop source) resolves from the VNI's vxlan device when one is
+    /// configured; router-id is the callers' fallback.
+    fn cradle_fdb_learn(&mut self, vni: u32, mac: MacAddr) {
+        if mac.is_multicast() {
+            return;
+        }
+        let vxlan_local = self
+            .links
+            .values()
+            .find(|link| link.vni == Some(vni))
+            .and_then(|link| link.vxlan_local);
+        let entry = FdbEntry {
+            vni,
+            mac,
+            ifindex: 0,
+            bridge_ifindex: 0,
+            flags: 0,
+            vxlan_local,
+        };
+        self.api_fdb_add(&entry);
     }
 
     async fn process_cm_msg(&mut self, msg: ConfigRequest) {

--- a/zebra-rs/src/rib/mac_addr.rs
+++ b/zebra-rs/src/rib/mac_addr.rs
@@ -30,6 +30,27 @@ impl MacAddr {
     }
 }
 
+impl std::str::FromStr for MacAddr {
+    type Err = ();
+
+    /// Parse the colon-separated form (`aa:bb:cc:dd:ee:ff`).
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let mut octets = [0u8; 6];
+        let mut n = 0;
+        for part in s.split(':') {
+            if n >= 6 {
+                return Err(());
+            }
+            octets[n] = u8::from_str_radix(part, 16).map_err(|_| ())?;
+            n += 1;
+        }
+        if n != 6 {
+            return Err(());
+        }
+        Ok(Self { octets })
+    }
+}
+
 impl From<[u8; 6]> for MacAddr {
     fn from(octets: [u8; 6]) -> Self {
         Self { octets }


### PR DESCRIPTION
## Summary

The reverse direction of the cradle tee: when `system cradle-grpc` is set,
spawn a watcher that subscribes to cradle's `WatchFdb` stream — every MAC the
eBPF datapath learns on a local L2 port arrives as a `(mac, bridge-domain)`
event and is re-emitted to EVPN subscribers as a synthesized `RibRx::FdbAdd`
(VNI = bridge domain, `vxlan_local` resolved from the VNI's vxlan device), so
BGP originates a Type-2 with the End.DT2U SID **exactly as it would for a
kernel bridge FDB learn** — the origination path is unchanged. This makes
EVPN-over-SRv6 fully dynamic: local MACs no longer need kernel bridge FDB
entries.

- `CradleFib::watch_fdb` (tonic server-streaming client).
- Rib: `cradle_fdb_watch` task (spawned/aborted with the endpoint config,
  reconnects with backoff), `Message::CradleFdbLearn`, `cradle_fdb_learn`
  synthesis + `api_fdb_add` dispatch.
- `MacAddr`: `FromStr` (colon-separated form).
- `proto/cradle.proto` synced (`WatchFdb` / `FdbEvent`).

## Test plan

- `cargo fmt --check`, both clippy variants with `-D warnings`: clean.
- Proven by cradle-rs `cradle_evpn_srv6_zebra`, now **fully dynamic** (no
  static ARP, no static cradle FDB, no static kernel FDB): CE MACs are
  datapath-learned, streamed up, advertised as Type-2, and installed back
  down on the remote PE — `srv6_l2_encap` nonzero proves the full loop.
- cradle-rs regressions 5/5 (`cradle_evpn_srv6`, `cradle_evpn_srv6_bum`,
  `cradle_l2`, `cradle_l3vpn_zebra`, `cradle_srv6_l3vpn_zebra`).

Generated with [Claude Code](https://claude.com/claude-code)