### PR TITLE
feat: tee EVPN Type-3 as BUM replication slots + locator re-origination

### DIFF
--- a/proto/cradle.proto
+++ b/proto/cradle.proto
@@ -120,6 +120,17 @@ message FdbRemoteDel {
   uint32 bd  = 2;
 }
 
+// A BUM ingress-replication slot: one remote PE in bridge domain `bd`,
+// reached by MAC-in-SRv6 toward its End.DT2M `remote_sid`. cradle manages
+// the slot's plumbing itself (a veth pair in the flood list whose far end
+// per-copy encapsulates — see docs/design/evpn-srv6.md). Idempotent per
+// (bd, remote_sid). The EVPN Type-3 tee drives these; a bridge domain using
+// slots must not also program the all-ones-MAC sentinel.
+message ReplSlot {
+  uint32 bd         = 1;
+  string remote_sid = 2;
+}
+
 // Subscribe to datapath MAC learning (EVPN over SRv6): cradle streams every
 // locally-learned (mac, bridge-domain) so the control plane can originate
 // EVPN Type-2 routes for it. Only local entries are reported (never
@@ -223,6 +234,8 @@ service Cradle {
   rpc AddFdbRemote(FdbRemote) returns (Empty);
   rpc DelFdbRemote(FdbRemoteDel) returns (Empty);
   rpc WatchFdb(WatchFdbRequest) returns (stream FdbEvent);
+  rpc AddReplSlot(ReplSlot) returns (Empty);
+  rpc DelReplSlot(ReplSlot) returns (Empty);
   rpc AddService(Service) returns (Empty);
   rpc GetStats(StatsRequest) returns (StatsReply);
   rpc AddL7Service(L7Service) returns (Empty);

--- a/zebra-rs/src/bgp/config.rs
+++ b/zebra-rs/src/bgp/config.rs
@@ -2002,7 +2002,7 @@ fn config_mup_c_architecture(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Opt
 /// next hop. `evpn_originate_imet` replaces the existing Originated path
 /// in place (the prefix key is the local VTEP, which does not change) and
 /// re-advertises to peers. No-op unless `advertise-all-vni` is on.
-fn reoriginate_all_imet(bgp: &mut Bgp) {
+pub(super) fn reoriginate_all_imet(bgp: &mut Bgp) {
     if !bgp.advertise_all_vni {
         return;
     }

--- a/zebra-rs/src/bgp/inst.rs
+++ b/zebra-rs/src/bgp/inst.rs
@@ -1354,6 +1354,19 @@ impl Bgp {
                 // Re-stamp originated IPv6 routes now the SID exists (the
                 // route delivery may have raced ahead of locator resolution).
                 self.reoriginate_srv6_ipv6();
+                // EVPN: Type-2s / IMETs originated before the locator
+                // resolved went out without their DT2U/DT2M SIDs (or carry
+                // stale ones after a prefix move) — re-originate them so
+                // the SIDs are (re)attached. The per-VNI allocators
+                // re-allocate lazily inside the origination path
+                // (`reconcile_srv6_vrfs` above just cleared them).
+                if self.advertise_all_vni {
+                    let entries: Vec<FdbEntry> = self.local_fdb.values().cloned().collect();
+                    for entry in entries {
+                        self.evpn_originate_macip(&entry);
+                    }
+                }
+                super::config::reoriginate_all_imet(self);
             }
             crate::rib::RibSrRx::Block { .. } => {}
         }

--- a/zebra-rs/src/bgp/route.rs
+++ b/zebra-rs/src/bgp/route.rs
@@ -6841,12 +6841,12 @@ fn route_evpn_export_selected(
             EvpnPrefix::InclusiveMulticast { orig, .. } => {
                 if let Some(vni) = extract_vni_from_attr(&wd.attr) {
                     // Mirror the announce side: the withdrawn IMET carried a
-                    // DT2M SID -> remove the BUM sentinel.
-                    if evpn_srv6_sid(&wd.attr, bgp_packet::SRV6_BEHAVIOR_END_DT2M).is_some() {
-                        let _ = bgp.rib_client.send(rib::Message::MacDel {
-                            vni,
-                            mac: MacAddr::from([0xff; 6]),
-                        });
+                    // DT2M SID -> drop its replication slot.
+                    if let Some(dt2m) = evpn_srv6_sid(&wd.attr, bgp_packet::SRV6_BEHAVIOR_END_DT2M)
+                    {
+                        let _ = bgp
+                            .rib_client
+                            .send(rib::Message::CradleReplDel { vni, sid: dt2m });
                     }
                     bgp.local_rib.evpn_flood.remove_remote(vni, *orig);
                     evpn_gateway_tree_set(bgp.local_rib, *bgp.router_id, vni);
@@ -6944,21 +6944,16 @@ fn route_evpn_export_selected(
             // type 0x0A carries the AR-IP) and reconcile the role-aware flood
             // list, rather than blindly flooding toward the originating IP.
             if let Some(vni) = extract_vni_from_attr(&best.attr) {
-                // RFC 9252 §6.4: a remote End.DT2M SID on the IMET is the BUM
-                // tunnel target for this VNI. Install it as the bridge
-                // domain's all-ones BUM sentinel (the cradle-tee L2 data
-                // plane encapsulates broadcast/multicast toward it);
-                // independent of the PMSI mode below.
+                // RFC 9252 §6.4: a remote End.DT2M SID on the IMET is a BUM
+                // flood-set member for this VNI. Tee it to cradle as a
+                // replication slot — per-copy MAC-in-SRv6 encap in the
+                // bridge domain's flood list, one slot per remote PE, so any
+                // number of remotes works (the old single-remote all-ones
+                // sentinel is superseded). Independent of the PMSI mode.
                 if let Some(dt2m) = evpn_srv6_sid(&best.attr, bgp_packet::SRV6_BEHAVIOR_END_DT2M) {
-                    let _ = bgp.rib_client.send(rib::Message::MacAdd {
-                        vni,
-                        mac: MacAddr::from([0xff; 6]),
-                        tunnel_endpoint: None,
-                        flags: 0,
-                        seq: 0,
-                        esi: None,
-                        srv6_sid: Some(dt2m),
-                    });
+                    let _ = bgp
+                        .rib_client
+                        .send(rib::Message::CradleReplAdd { vni, sid: dt2m });
                 }
                 let pmsi = best.attr.pmsi_tunnel.as_ref();
                 if let Some(p) = pmsi.filter(|p| p.is_sr_p2mp()) {

--- a/zebra-rs/src/fib/cradle.rs
+++ b/zebra-rs/src/fib/cradle.rs
@@ -591,6 +591,45 @@ impl CradleFib {
         Ok(resp.into_inner())
     }
 
+    /// Add a BUM replication slot (EVPN Type-3 tee): the remote PE behind
+    /// `sid` (its `End.DT2M`) joins VNI `vni`'s flood set. cradle owns the
+    /// slot plumbing (veth pair + flood membership + per-copy encap);
+    /// idempotent per `(vni, sid)`.
+    pub async fn repl_slot_add(&self, vni: u32, sid: std::net::Ipv6Addr) {
+        let result = async {
+            self.client()
+                .await?
+                .add_repl_slot(pb::ReplSlot {
+                    bd: vni,
+                    remote_sid: sid.to_string(),
+                })
+                .await?;
+            anyhow::Ok(())
+        }
+        .await;
+        if let Err(e) = result {
+            tracing::warn!("fib: cradle repl_slot_add vni {vni} {sid} failed: {e}");
+        }
+    }
+
+    /// Remove a `(vni, sid)` replication slot.
+    pub async fn repl_slot_del(&self, vni: u32, sid: std::net::Ipv6Addr) {
+        let result = async {
+            self.client()
+                .await?
+                .del_repl_slot(pb::ReplSlot {
+                    bd: vni,
+                    remote_sid: sid.to_string(),
+                })
+                .await?;
+            anyhow::Ok(())
+        }
+        .await;
+        if let Err(e) = result {
+            tracing::warn!("fib: cradle repl_slot_del vni {vni} {sid} failed: {e}");
+        }
+    }
+
     /// Feed a resolved neighbor (ARP/ND) into the cradle data plane — the
     /// MPLS egress rewrite (`mpls_l2_xmit`) resolves destination MACs from
     /// this state rather than the kernel neighbor table.

--- a/zebra-rs/src/fib/netlink/handle.rs
+++ b/zebra-rs/src/fib/netlink/handle.rs
@@ -480,6 +480,20 @@ impl FibHandle {
         }
     }
 
+    /// Tee an EVPN BUM replication slot to cradle (Type-3 with an SRv6
+    /// End.DT2M SID). No kernel counterpart — cradle is the L2 data plane.
+    pub async fn cradle_repl_add(&self, vni: u32, sid: std::net::Ipv6Addr) {
+        if let Some(cradle) = &self.cradle {
+            cradle.repl_slot_add(vni, sid).await;
+        }
+    }
+
+    pub async fn cradle_repl_del(&self, vni: u32, sid: std::net::Ipv6Addr) {
+        if let Some(cradle) = &self.cradle {
+            cradle.repl_slot_del(vni, sid).await;
+        }
+    }
+
     /// Tee a resolved neighbor (ARP/ND) into the cradle data plane — its MPLS
     /// egress rewrite resolves destination MACs from this state. No-op when
     /// the tee is disabled.

--- a/zebra-rs/src/rib/inst.rs
+++ b/zebra-rs/src/rib/inst.rs
@@ -324,6 +324,17 @@ pub enum Message {
         vni: u32,
         mac: MacAddr,
     },
+    /// A remote PE joined/left a VNI's BUM flood set (EVPN Type-3 with an
+    /// SRv6 `End.DT2M` SID, RFC 9252 §6.4) — teed to cradle as a BUM
+    /// replication slot (per-copy MAC-in-SRv6 encap in the flood list).
+    CradleReplAdd {
+        vni: u32,
+        sid: std::net::Ipv6Addr,
+    },
+    CradleReplDel {
+        vni: u32,
+        sid: std::net::Ipv6Addr,
+    },
     /// A MAC the cradle eBPF datapath learned on a local L2 port (via the
     /// `WatchFdb` stream). Re-emitted to EVPN subscribers as a synthesized
     /// `RibRx::FdbAdd` — the cradle analogue of a kernel bridge FDB learn —
@@ -2924,6 +2935,12 @@ impl Rib {
             }
             Message::CradleFdbLearn { vni, mac } => {
                 self.cradle_fdb_learn(vni, mac);
+            }
+            Message::CradleReplAdd { vni, sid } => {
+                self.fib_handle.cradle_repl_add(vni, sid).await;
+            }
+            Message::CradleReplDel { vni, sid } => {
+                self.fib_handle.cradle_repl_del(vni, sid).await;
             }
             Message::MdbAdd {
                 vni,


### PR DESCRIPTION
## Summary

Multi-PE BUM over SRv6, BGP-driven: every received IMET carrying an
`End.DT2M` SID now tees to cradle as a **replication slot** (`AddReplSlot`;
cradle owns the veth/flood/per-copy-encap plumbing, one slot per remote PE)
instead of the single-remote all-ones sentinel; withdraws mirror with
`DelReplSlot`. `Message::CradleReplAdd/Del` → `FibHandle::cradle_repl_add/del`
→ `CradleFib::repl_slot_add/del`. `proto/cradle.proto` synced.

**Also fixes a pre-existing origination race** the old sentinel path shared:
EVPN routes originated before the BGP SRv6 locator resolved went out
**without** their DT2U/DT2M SIDs and were never re-originated — the
`RibSrRx::Locator` handler reconciled VRF and IPv6-unicast SIDs but not EVPN.
It now re-originates the local FDB (Type-2s) and all IMETs (Type-3s) under
the new locator, closing the window on whichever side of the race
origination lands. (Confirmed as the cause of a one-in-many BDD flake by
reproducing with the pre-fix binary.)

## Test plan

- `cargo fmt --check`, both clippy variants with `-D warnings`: clean.
- cradle-rs `cradle_evpn_srv6_zebra_multi` (new): 3 PEs, iBGP EVPN full mesh
  over an IS-IS SRv6 hub, fully dynamic — Type-3s become cradle-managed
  slots, learned MACs become Type-2s; all CE pairs reach on attempt 1,
  bounded BUM counters (split horizon).
- `cradle_evpn_srv6_zebra` (2-PE, now riding slots) run twice + 6-feature
  sweep (`cradle_evpn_srv6`, `_bum`, `_multi`, `_zebra_multi`, `cradle_l2`,
  `cradle_srv6_l3vpn_zebra`): all pass.

Generated with [Claude Code](https://claude.com/claude-code)