### PR TITLE
feat: withdraw Type-2 on cradle WatchFdb age events

### DIFF
--- a/proto/cradle.proto
+++ b/proto/cradle.proto
@@ -142,6 +142,9 @@ message WatchFdbRequest {}
 message FdbEvent {
   string mac = 1;
   uint32 bd  = 2;
+  // 0 = learned; 1 = aged out (the entry was removed after `fdb_age_secs`
+  // idle — the control plane should withdraw its Type-2).
+  uint32 event = 3;
 }
 
 message Neighbor4 {

--- a/zebra-rs/src/rib/inst.rs
+++ b/zebra-rs/src/rib/inst.rs
@@ -343,6 +343,13 @@ pub enum Message {
         vni: u32,
         mac: MacAddr,
     },
+    /// A cradle-learned MAC aged out (idle past `fdb_age_secs`) — withdraw
+    /// its Type-2 by re-emitting the same synthesized entry as a
+    /// `RibRx::FdbDel`.
+    CradleFdbAge {
+        vni: u32,
+        mac: MacAddr,
+    },
     MdbAdd {
         vni: u32,
         group: IpAddr,
@@ -2936,6 +2943,9 @@ impl Rib {
             Message::CradleFdbLearn { vni, mac } => {
                 self.cradle_fdb_learn(vni, mac);
             }
+            Message::CradleFdbAge { vni, mac } => {
+                self.cradle_fdb_age(vni, mac);
+            }
             Message::CradleReplAdd { vni, sid } => {
                 self.fib_handle.cradle_repl_add(vni, sid).await;
             }
@@ -3252,7 +3262,12 @@ impl Rib {
                                 let Ok(mac) = ev.mac.parse::<MacAddr>() else {
                                     continue;
                                 };
-                                let _ = tx.send(Message::CradleFdbLearn { vni: ev.bd, mac });
+                                let msg = if ev.event == 1 {
+                                    Message::CradleFdbAge { vni: ev.bd, mac }
+                                } else {
+                                    Message::CradleFdbLearn { vni: ev.bd, mac }
+                                };
+                                let _ = tx.send(msg);
                             }
                         }
                         Err(e) => {
@@ -3292,6 +3307,29 @@ impl Rib {
             vxlan_local,
         };
         self.api_fdb_add(&entry);
+    }
+
+    /// A cradle-datapath MAC aged out: dispatch the same synthesized entry
+    /// as an `FdbDel` so BGP withdraws the Type-2 it originated for the
+    /// learn (`evpn_withdraw_macip` matches on `(vni, mac)`).
+    fn cradle_fdb_age(&mut self, vni: u32, mac: MacAddr) {
+        if mac.is_multicast() {
+            return;
+        }
+        let vxlan_local = self
+            .links
+            .values()
+            .find(|link| link.vni == Some(vni))
+            .and_then(|link| link.vxlan_local);
+        let entry = FdbEntry {
+            vni,
+            mac,
+            ifindex: 0,
+            bridge_ifindex: 0,
+            flags: 0,
+            vxlan_local,
+        };
+        self.api_fdb_del(&entry);
     }
 
     async fn process_cm_msg(&mut self, msg: ConfigRequest) {


### PR DESCRIPTION
## Summary

cradle's FDB aging now expires idle locally-learned MACs and reports them on
the `WatchFdb` stream (`FdbEvent.event = 1`). The watcher re-emits an aged
entry as `Message::CradleFdbAge` → `cradle_fdb_age`, which synthesizes the
same `FdbEntry` the learn produced and dispatches it as an `FdbDel` — BGP
withdraws the Type-2 (`evpn_withdraw_macip`, the existing path), and the
remote PE's overlay FDB entry is removed by the existing `MacDel` tee. A
later frame re-learns and the L2VPN reconverges by itself.

`proto/cradle.proto` synced (`FdbEvent.event`). Pairs with cradle-rs #34.

## Test plan

- `cargo fmt --check`, both clippy variants with `-D warnings`: clean.
- cradle-rs `cradle_evpn_srv6_age` (new): 2-PE dynamic EVPN, 5s age,
  IPv6-quieted CE links — learn + converge, 15s idle, `fdb_aged` nonzero on
  both PEs, re-ping reconverges on attempt 1.
- Regression sweep 6/6: `cradle_l2`, `cradle_evpn_srv6`, `_bum`, `_multi`,
  `_zebra`, `_zebra_multi`.

Generated with [Claude Code](https://claude.com/claude-code)