### PR TITLE
ospf: fix authentication wiring and checksum; add auth + GR BDD

### DIFF
--- a/bdd/tests/configs/ospfv2_auth/a_chain.yaml
+++ b/bdd/tests/configs/ospfv2_auth/a_chain.yaml
@@ -1,0 +1,35 @@
+# RFC 8177 key-chain authentication: the interface references a named
+# chain instead of carrying inline keys. The chain's key supplies the
+# algorithm (crypto-algorithm), the key-id stamped on the wire, and
+# the key material; with no lifetime configured the key is always
+# active. b must define the same chain content (name may differ; the
+# wire carries only the key-id).
+key-chains:
+  key-chain:
+  - name: OSPF-KC
+    key:
+    - key-id: 1
+      crypto-algorithm: hmac-sha-256
+      key-string:
+        keystring: "zebra-ospf-chain-secret"
+
+interface:
+- if-name: lo
+  ipv4:
+    address: 10.0.0.1/32
+- if-name: ethb
+  ipv4:
+    address: 10.0.12.1/30
+router:
+  ospf:
+    router-id: 10.0.0.1
+    area:
+    - area-id: 0.0.0.0
+      interface:
+      - if-name: lo
+        enable: true
+      - if-name: ethb
+        enable: true
+        network-type: point-to-point
+        authentication: message-digest
+        key-chain: OSPF-KC

--- a/bdd/tests/configs/ospfv2_auth/a_md5.yaml
+++ b/bdd/tests/configs/ospfv2_auth/a_md5.yaml
@@ -1,0 +1,27 @@
+# Keyed-MD5 cryptographic authentication (RFC 2328 §D.4, AuType=2):
+# `authentication message-digest` selects crypto mode; the digest is
+# MD5(packet || key) with the key selected by key-id. The active send
+# key is the lowest configured key-id; receive accepts any known
+# key-id, which is what makes key rollover hitless.
+interface:
+- if-name: lo
+  ipv4:
+    address: 10.0.0.1/32
+- if-name: ethb
+  ipv4:
+    address: 10.0.12.1/30
+router:
+  ospf:
+    router-id: 10.0.0.1
+    area:
+    - area-id: 0.0.0.0
+      interface:
+      - if-name: lo
+        enable: true
+      - if-name: ethb
+        enable: true
+        network-type: point-to-point
+        authentication: message-digest
+        message-digest-key:
+        - key-id: 1
+          md5: zebra-md5-secret

--- a/bdd/tests/configs/ospfv2_auth/a_sha256.yaml
+++ b/bdd/tests/configs/ospfv2_auth/a_sha256.yaml
@@ -1,0 +1,26 @@
+# HMAC-SHA-256 cryptographic authentication (RFC 5709): same
+# `message-digest` mode as keyed-MD5, but the key lives in the
+# crypto-key list where the leaf name picks the algorithm and the
+# trailer is HMAC(key, packet) — 32 octets on the wire.
+interface:
+- if-name: lo
+  ipv4:
+    address: 10.0.0.1/32
+- if-name: ethb
+  ipv4:
+    address: 10.0.12.1/30
+router:
+  ospf:
+    router-id: 10.0.0.1
+    area:
+    - area-id: 0.0.0.0
+      interface:
+      - if-name: lo
+        enable: true
+      - if-name: ethb
+        enable: true
+        network-type: point-to-point
+        authentication: message-digest
+        crypto-key:
+        - key-id: 1
+          hmac-sha-256: zebra-ospf-sha256-secret

--- a/bdd/tests/configs/ospfv2_auth/a_simple.yaml
+++ b/bdd/tests/configs/ospfv2_auth/a_simple.yaml
@@ -1,0 +1,23 @@
+# Simple-password authentication (RFC 2328 §D.3, AuType=1): an 8-octet
+# cleartext password carried in every OSPF packet header. b must carry
+# the identical authentication-key for the adjacency to come up.
+interface:
+- if-name: lo
+  ipv4:
+    address: 10.0.0.1/32
+- if-name: ethb
+  ipv4:
+    address: 10.0.12.1/30
+router:
+  ospf:
+    router-id: 10.0.0.1
+    area:
+    - area-id: 0.0.0.0
+      interface:
+      - if-name: lo
+        enable: true
+      - if-name: ethb
+        enable: true
+        network-type: point-to-point
+        authentication: simple
+        authentication-key: zebra8ch

--- a/bdd/tests/configs/ospfv2_auth/b_chain.yaml
+++ b/bdd/tests/configs/ospfv2_auth/b_chain.yaml
@@ -1,0 +1,29 @@
+key-chains:
+  key-chain:
+  - name: OSPF-KC
+    key:
+    - key-id: 1
+      crypto-algorithm: hmac-sha-256
+      key-string:
+        keystring: "zebra-ospf-chain-secret"
+
+interface:
+- if-name: lo
+  ipv4:
+    address: 10.0.0.2/32
+- if-name: etha
+  ipv4:
+    address: 10.0.12.2/30
+router:
+  ospf:
+    router-id: 10.0.0.2
+    area:
+    - area-id: 0.0.0.0
+      interface:
+      - if-name: lo
+        enable: true
+      - if-name: etha
+        enable: true
+        network-type: point-to-point
+        authentication: message-digest
+        key-chain: OSPF-KC

--- a/bdd/tests/configs/ospfv2_auth/b_md5.yaml
+++ b/bdd/tests/configs/ospfv2_auth/b_md5.yaml
@@ -1,0 +1,22 @@
+interface:
+- if-name: lo
+  ipv4:
+    address: 10.0.0.2/32
+- if-name: etha
+  ipv4:
+    address: 10.0.12.2/30
+router:
+  ospf:
+    router-id: 10.0.0.2
+    area:
+    - area-id: 0.0.0.0
+      interface:
+      - if-name: lo
+        enable: true
+      - if-name: etha
+        enable: true
+        network-type: point-to-point
+        authentication: message-digest
+        message-digest-key:
+        - key-id: 1
+          md5: zebra-md5-secret

--- a/bdd/tests/configs/ospfv2_auth/b_md5_badkey.yaml
+++ b/bdd/tests/configs/ospfv2_auth/b_md5_badkey.yaml
@@ -1,0 +1,26 @@
+# Negative case: same mode (message-digest) and same key-id 1 as a's
+# config, but a different secret. Every packet from a fails digest
+# verification here (and vice versa), so neither side ever creates a
+# neighbor — the drop happens before neighbor state exists.
+interface:
+- if-name: lo
+  ipv4:
+    address: 10.0.0.2/32
+- if-name: etha
+  ipv4:
+    address: 10.0.12.2/30
+router:
+  ospf:
+    router-id: 10.0.0.2
+    area:
+    - area-id: 0.0.0.0
+      interface:
+      - if-name: lo
+        enable: true
+      - if-name: etha
+        enable: true
+        network-type: point-to-point
+        authentication: message-digest
+        message-digest-key:
+        - key-id: 1
+          md5: wrong-md5-secret

--- a/bdd/tests/configs/ospfv2_auth/b_sha256.yaml
+++ b/bdd/tests/configs/ospfv2_auth/b_sha256.yaml
@@ -1,0 +1,22 @@
+interface:
+- if-name: lo
+  ipv4:
+    address: 10.0.0.2/32
+- if-name: etha
+  ipv4:
+    address: 10.0.12.2/30
+router:
+  ospf:
+    router-id: 10.0.0.2
+    area:
+    - area-id: 0.0.0.0
+      interface:
+      - if-name: lo
+        enable: true
+      - if-name: etha
+        enable: true
+        network-type: point-to-point
+        authentication: message-digest
+        crypto-key:
+        - key-id: 1
+          hmac-sha-256: zebra-ospf-sha256-secret

--- a/bdd/tests/configs/ospfv2_auth/b_simple.yaml
+++ b/bdd/tests/configs/ospfv2_auth/b_simple.yaml
@@ -1,0 +1,20 @@
+interface:
+- if-name: lo
+  ipv4:
+    address: 10.0.0.2/32
+- if-name: etha
+  ipv4:
+    address: 10.0.12.2/30
+router:
+  ospf:
+    router-id: 10.0.0.2
+    area:
+    - area-id: 0.0.0.0
+      interface:
+      - if-name: lo
+        enable: true
+      - if-name: etha
+        enable: true
+        network-type: point-to-point
+        authentication: simple
+        authentication-key: zebra8ch

--- a/bdd/tests/configs/ospfv2_graceful_restart/a.yaml
+++ b/bdd/tests/configs/ospfv2_graceful_restart/a.yaml
@@ -1,0 +1,25 @@
+# Helper side. graceful-restart defaults (helper-enabled true,
+# max-grace-period 1800s, strict LSA checking) are already what the
+# test needs; the block is spelled out so the feature also covers the
+# config path.
+interface:
+- if-name: lo
+  ipv4:
+    address: 10.0.0.1/32
+- if-name: ethb
+  ipv4:
+    address: 10.0.12.1/30
+router:
+  ospf:
+    router-id: 10.0.0.1
+    graceful-restart:
+      helper-enabled: true
+      max-grace-period: 1800
+    area:
+    - area-id: 0.0.0.0
+      interface:
+      - if-name: lo
+        enable: true
+      - if-name: ethb
+        enable: true
+        network-type: point-to-point

--- a/bdd/tests/configs/ospfv2_graceful_restart/b.yaml
+++ b/bdd/tests/configs/ospfv2_graceful_restart/b.yaml
@@ -1,0 +1,22 @@
+# Restarter side. The restart itself is operator-driven
+# (`clear ospf graceful-restart begin|commit|abort`), not config;
+# the same file is re-applied after the daemon restarts, and the
+# checkpoint restores router-id/LSDB underneath it.
+interface:
+- if-name: lo
+  ipv4:
+    address: 10.0.0.2/32
+- if-name: etha
+  ipv4:
+    address: 10.0.12.2/30
+router:
+  ospf:
+    router-id: 10.0.0.2
+    area:
+    - area-id: 0.0.0.0
+      interface:
+      - if-name: lo
+        enable: true
+      - if-name: etha
+        enable: true
+        network-type: point-to-point

--- a/bdd/tests/features/ospfv2_auth.feature
+++ b/bdd/tests/features/ospfv2_auth.feature
@@ -1,0 +1,140 @@
+@serial
+@ospfv2_auth
+Feature: OSPFv2 per-interface authentication gates adjacency formation
+  As a network operator
+  I want zebra-rs to authenticate OSPFv2 packets per interface — simple
+  password (RFC 2328 §D.3), keyed-MD5 (§D.4), HMAC-SHA (RFC 5709) and
+  RFC 8177 key-chains — so that adjacencies form only between routers
+  sharing the key, and packets with mismatched keys are dropped.
+
+  Two routers on a point-to-point link; each scenario brings the pair
+  up under one authentication mode and proves the adjacency reaches
+  Full and the loopbacks route. The final scenario proves the negative:
+  same mode, different secrets, no neighbor ever appears.
+
+  Test Topology:
+  ```
+    a (10.0.0.1) -- 10.0.12.0/30 -- b (10.0.0.2)
+
+    on router X the interface toward router Y is named "ethY".
+    loopbacks: a .1  b .2  (10.0.0.X/32).
+  ```
+
+  Scenario: Simple-password authentication forms a Full adjacency
+    Given a clean test environment
+    When I create namespace "a"
+    And I create namespace "b"
+    And I connect namespace "a" interface "ethb" to namespace "b" interface "etha"
+    And I start zebra-rs in namespace "a"
+    And I start zebra-rs in namespace "b"
+    And I apply config "a_simple.yaml" to namespace "a"
+    And I apply config "b_simple.yaml" to namespace "b"
+    # First Hello (<=10s) + DBD exchange + SPF/route install.
+    And I wait 30 seconds
+
+    Then show command "show ospf neighbor" in namespace "a" should contain "Full"
+    And show command "show ospf neighbor" in namespace "a" should contain "10.0.0.2"
+    And show command "show ospf neighbor" in namespace "b" should contain "Full"
+    And show command "show ospf neighbor" in namespace "b" should contain "10.0.0.1"
+    And ping from "a" to "10.0.0.2" should succeed
+
+    # Teardown.
+    When I stop zebra-rs in namespace "a"
+    And I stop zebra-rs in namespace "b"
+    And I delete namespace "a"
+    And I delete namespace "b"
+    Then the test environment should be clean
+
+  Scenario: Keyed-MD5 authentication forms a Full adjacency
+    Given a clean test environment
+    When I create namespace "a"
+    And I create namespace "b"
+    And I connect namespace "a" interface "ethb" to namespace "b" interface "etha"
+    And I start zebra-rs in namespace "a"
+    And I start zebra-rs in namespace "b"
+    And I apply config "a_md5.yaml" to namespace "a"
+    And I apply config "b_md5.yaml" to namespace "b"
+    And I wait 30 seconds
+
+    Then show command "show ospf neighbor" in namespace "a" should contain "Full"
+    And show command "show ospf neighbor" in namespace "a" should contain "10.0.0.2"
+    And show command "show ospf neighbor" in namespace "b" should contain "Full"
+    And ping from "a" to "10.0.0.2" should succeed
+
+    # Teardown.
+    When I stop zebra-rs in namespace "a"
+    And I stop zebra-rs in namespace "b"
+    And I delete namespace "a"
+    And I delete namespace "b"
+    Then the test environment should be clean
+
+  Scenario: HMAC-SHA-256 cryptographic authentication forms a Full adjacency
+    Given a clean test environment
+    When I create namespace "a"
+    And I create namespace "b"
+    And I connect namespace "a" interface "ethb" to namespace "b" interface "etha"
+    And I start zebra-rs in namespace "a"
+    And I start zebra-rs in namespace "b"
+    And I apply config "a_sha256.yaml" to namespace "a"
+    And I apply config "b_sha256.yaml" to namespace "b"
+    And I wait 30 seconds
+
+    Then show command "show ospf neighbor" in namespace "a" should contain "Full"
+    And show command "show ospf neighbor" in namespace "a" should contain "10.0.0.2"
+    And show command "show ospf neighbor" in namespace "b" should contain "Full"
+    And ping from "a" to "10.0.0.2" should succeed
+
+    # Teardown.
+    When I stop zebra-rs in namespace "a"
+    And I stop zebra-rs in namespace "b"
+    And I delete namespace "a"
+    And I delete namespace "b"
+    Then the test environment should be clean
+
+  Scenario: RFC 8177 key-chain authentication forms a Full adjacency
+    Given a clean test environment
+    When I create namespace "a"
+    And I create namespace "b"
+    And I connect namespace "a" interface "ethb" to namespace "b" interface "etha"
+    And I start zebra-rs in namespace "a"
+    And I start zebra-rs in namespace "b"
+    And I apply config "a_chain.yaml" to namespace "a"
+    And I apply config "b_chain.yaml" to namespace "b"
+    And I wait 30 seconds
+
+    Then show command "show ospf neighbor" in namespace "a" should contain "Full"
+    And show command "show ospf neighbor" in namespace "a" should contain "10.0.0.2"
+    And show command "show ospf neighbor" in namespace "b" should contain "Full"
+    And ping from "a" to "10.0.0.2" should succeed
+
+    # Teardown.
+    When I stop zebra-rs in namespace "a"
+    And I stop zebra-rs in namespace "b"
+    And I delete namespace "a"
+    And I delete namespace "b"
+    Then the test environment should be clean
+
+  Scenario: Mismatched MD5 secrets never form a neighbor
+    Given a clean test environment
+    When I create namespace "a"
+    And I create namespace "b"
+    And I connect namespace "a" interface "ethb" to namespace "b" interface "etha"
+    And I start zebra-rs in namespace "a"
+    And I start zebra-rs in namespace "b"
+    And I apply config "a_md5.yaml" to namespace "a"
+    # Same mode and key-id, different secret: every Hello fails digest
+    # verification and is dropped before neighbor creation.
+    And I apply config "b_md5_badkey.yaml" to namespace "b"
+    # Three hello cycles — plenty for a neighbor to appear if auth were
+    # (wrongly) letting packets through.
+    And I wait 30 seconds
+
+    Then show command "show ospf neighbor" in namespace "a" should not contain "10.0.0.2"
+    And show command "show ospf neighbor" in namespace "b" should not contain "10.0.0.1"
+
+    # Teardown.
+    When I stop zebra-rs in namespace "a"
+    And I stop zebra-rs in namespace "b"
+    And I delete namespace "a"
+    And I delete namespace "b"
+    Then the test environment should be clean

--- a/bdd/tests/features/ospfv2_graceful_restart.feature
+++ b/bdd/tests/features/ospfv2_graceful_restart.feature
@@ -114,7 +114,10 @@ Feature: OSPFv2 graceful restart keeps forwarding through a daemon restart
     And I apply config "b.yaml" to namespace "b"
     Then show command "show ospf neighbor" in namespace "b" should eventually contain "Full"
     And show command "show ospf neighbor" in namespace "a" should eventually contain "Full"
-    And show command "show ospf route" in namespace "a" should contain "10.0.0.2/32"
+    # Eventually: SPF runs on a 1s coalescing timer after the
+    # adjacency reaches Full, so the route install trails the
+    # neighbor-state check by a beat.
+    And show command "show ospf route" in namespace "a" should eventually contain "10.0.0.2/32"
     And ping from "a" to "10.0.0.2" should eventually succeed
 
     # Teardown.

--- a/bdd/tests/features/ospfv2_graceful_restart.feature
+++ b/bdd/tests/features/ospfv2_graceful_restart.feature
@@ -1,0 +1,126 @@
+@serial
+@ospfv2_graceful_restart
+Feature: OSPFv2 graceful restart keeps forwarding through a daemon restart
+  As a network operator
+  I want zebra-rs to implement RFC 3623 graceful restart — the helper
+  holding a restarting neighbor's adjacency past the dead interval, and
+  the restarter checkpointing its LSDB, exiting, and resuming inside
+  the grace window — so that a planned restart does not disturb
+  forwarding.
+
+  Two routers on a point-to-point link: a is the helper, b the
+  restarter. The first scenario stages a restart and aborts it,
+  proving the Grace-LSA drives helper entry on a. The second commits
+  the restart: b's daemon exits, a holds the adjacency and the route
+  well past the 40s dead interval, and b resumes from its checkpoint.
+
+  Test Topology:
+  ```
+    a (helper, 10.0.0.1) -- 10.0.12.0/30 -- b (restarter, 10.0.0.2)
+
+    on router X the interface toward router Y is named "ethY".
+    loopbacks: a .1  b .2  (10.0.0.X/32).
+  ```
+
+  The restarter's checkpoint lands at the fixed path
+  /var/lib/zebra-rs/checkpoint/ospf.cbor, which is shared by every
+  namespace (netns does not isolate the filesystem). The restarted
+  daemon deletes it after a successful load, but each scenario also
+  removes it defensively so an aborted run can never poison a later
+  zebra-rs start (any OSPF instance started within 1.5x the grace
+  period would replay it).
+
+  Scenario: Grace-LSA from a staged restart drives helper entry; abort recovers
+    Given a clean test environment
+    When I create namespace "a"
+    And I create namespace "b"
+    And I execute "rm -f /var/lib/zebra-rs/checkpoint/ospf.cbor" in namespace "a"
+    And I connect namespace "a" interface "ethb" to namespace "b" interface "etha"
+    And I start zebra-rs in namespace "a"
+    And I start zebra-rs in namespace "b"
+    And I apply config "a.yaml" to namespace "a"
+    And I apply config "b.yaml" to namespace "b"
+    # First Hello (<=10s) + DBD exchange + SPF/route install.
+    And I wait 30 seconds
+
+    Then show command "show ospf neighbor" in namespace "a" should contain "Full"
+    And show command "show ospf neighbor" in namespace "b" should contain "Full"
+    And show command "show ospf graceful-restart" in namespace "a" should contain "Helper enabled: true"
+
+    # Stage (but do not commit) a restart on b: Grace-LSAs flood out
+    # every OSPF interface and a enters helper mode for b.
+    When I run "clear ospf graceful-restart begin" in namespace "b"
+    And I wait 3 seconds
+    Then show command "show ospf graceful-restart" in namespace "b" should contain "Restart staged"
+    And show command "show ospf graceful-restart" in namespace "a" should contain "10.0.0.2"
+    And show command "show ospf graceful-restart" in namespace "a" should contain "SoftwareRestart"
+    # The held adjacency stays Full while helping.
+    And show command "show ospf neighbor" in namespace "a" should contain "Full"
+
+    # Abort: b flushes its Grace-LSAs and resumes normal operation.
+    When I run "clear ospf graceful-restart abort" in namespace "b"
+    And I wait 3 seconds
+    Then show command "show ospf graceful-restart" in namespace "b" should not contain "Restart staged"
+    # Adjacency settles back to Full (the helper-exit path re-forms it
+    # from scratch, like a dead-timer expiry, so allow a re-exchange).
+    And show command "show ospf neighbor" in namespace "a" should eventually contain "Full"
+    And ping from "a" to "10.0.0.2" should eventually succeed
+
+    # Teardown.
+    When I execute "rm -f /var/lib/zebra-rs/checkpoint/ospf.cbor" in namespace "a"
+    And I stop zebra-rs in namespace "a"
+    And I stop zebra-rs in namespace "b"
+    And I delete namespace "a"
+    And I delete namespace "b"
+    Then the test environment should be clean
+
+  Scenario: Committed restart survives past the dead interval and resumes from the checkpoint
+    Given a clean test environment
+    When I create namespace "a"
+    And I create namespace "b"
+    And I execute "rm -f /var/lib/zebra-rs/checkpoint/ospf.cbor" in namespace "a"
+    And I connect namespace "a" interface "ethb" to namespace "b" interface "etha"
+    And I start zebra-rs in namespace "a"
+    And I start zebra-rs in namespace "b"
+    And I apply config "a.yaml" to namespace "a"
+    And I apply config "b.yaml" to namespace "b"
+    And I wait 30 seconds
+
+    Then show command "show ospf neighbor" in namespace "a" should contain "Full"
+    And show command "show ospf route" in namespace "a" should contain "10.0.0.2/32"
+    And ping from "a" to "10.0.0.2" should succeed
+
+    # Stage and commit: b floods Grace-LSAs (120s grace), writes the
+    # checkpoint, drains 200ms, and exits the process. Forwarding
+    # state is deliberately left in the kernel.
+    When I run "clear ospf graceful-restart begin" in namespace "b"
+    And I run "clear ospf graceful-restart commit" in namespace "b"
+    And I wait 3 seconds
+    Then show command "show ospf graceful-restart" in namespace "a" should contain "10.0.0.2"
+
+    # Hold b down well past a's 40s dead interval. Without helper mode
+    # the inactivity timer would have killed the neighbor and withdrawn
+    # the route; in helper mode both survive.
+    When I wait 45 seconds
+    Then show command "show ospf neighbor" in namespace "a" should contain "10.0.0.2"
+    And show command "show ospf neighbor" in namespace "a" should contain "Full"
+    And show command "show ospf route" in namespace "a" should contain "10.0.0.2/32"
+
+    # Restart b inside the grace window. The fresh daemon replays the
+    # checkpoint (same router-id, LSDB at identical seq/checksum — so
+    # a's snapshot check stays quiescent), deletes the file, re-forms
+    # the adjacency, and re-originates at seq+1 once Full.
+    When I start zebra-rs in namespace "b"
+    And I apply config "b.yaml" to namespace "b"
+    Then show command "show ospf neighbor" in namespace "b" should eventually contain "Full"
+    And show command "show ospf neighbor" in namespace "a" should eventually contain "Full"
+    And show command "show ospf route" in namespace "a" should contain "10.0.0.2/32"
+    And ping from "a" to "10.0.0.2" should eventually succeed
+
+    # Teardown.
+    When I execute "rm -f /var/lib/zebra-rs/checkpoint/ospf.cbor" in namespace "a"
+    And I stop zebra-rs in namespace "a"
+    And I stop zebra-rs in namespace "b"
+    And I delete namespace "a"
+    And I delete namespace "b"
+    Then the test environment should be clean

--- a/crates/ospf-packet/src/parser.rs
+++ b/crates/ospf-packet/src/parser.rs
@@ -88,11 +88,23 @@ impl Ospfv2Packet {
         let len = buf.len() as u16;
         BigEndian::write_u16(&mut buf[2..4], len);
 
-        // Update checksum.
-        const CHECKSUM_RANGE: std::ops::Range<usize> = 12..14;
-        let mut cksum = Checksum::new();
-        cksum.add_bytes(buf);
-        buf[CHECKSUM_RANGE].copy_from_slice(&cksum.checksum());
+        // Update checksum. RFC 2328 §D.4.1-D.4.3: the checksum is
+        // computed over the packet EXCLUDING the 64-bit
+        // authentication field (bytes 16..24) — summing it too
+        // corrupts the value for any nonzero auth field (a Simple
+        // password, the Crypto key-id/seq overlay), and the peer's
+        // `validate_checksum` (which excludes the field) drops every
+        // packet. For cryptographic authentication (AuType 2) the
+        // standard checksum is not computed at all and the field
+        // stays zero — integrity is the digest trailer's job.
+        if self.auth_type != 2 {
+            const CHECKSUM_RANGE: std::ops::Range<usize> = 12..14;
+            const AUTH_RANGE: std::ops::Range<usize> = 16..24;
+            let mut cksum = Checksum::new();
+            cksum.add_bytes(&buf[..AUTH_RANGE.start]);
+            cksum.add_bytes(&buf[AUTH_RANGE.end..]);
+            buf[CHECKSUM_RANGE].copy_from_slice(&cksum.checksum());
+        }
 
         if !self.auth_trailer.is_empty() {
             buf.put(&self.auth_trailer[..]);
@@ -2859,6 +2871,39 @@ mod tests {
         assert_eq!(parsed.auth_type, 0);
         assert!(matches!(parsed.auth, Ospfv2Auth::Null(_)));
         assert!(parsed.auth_trailer.is_empty());
+    }
+
+    /// RFC 2328 §D.4.1-D.4.2: the checksum excludes the 64-bit
+    /// authentication field, so an emitted Simple-password packet
+    /// must verify at a receiver that also excludes it. This was
+    /// broken (emit summed the password too) and every
+    /// authenticated packet was dropped at ingress checksum
+    /// validation before the auth gate ever ran.
+    #[test]
+    fn simple_password_checksum_excludes_auth_field() {
+        let mut pkt = null_hello_packet();
+        pkt.auth_type = 1;
+        pkt.auth = Ospfv2Auth::Simple(*b"zebra8ch");
+        let mut buf = BytesMut::new();
+        pkt.emit(&mut buf);
+        validate_checksum(&buf).expect("Simple-auth checksum must verify");
+    }
+
+    /// RFC 2328 §D.4.3: with cryptographic authentication the
+    /// standard checksum is not computed — the field stays zero and
+    /// the digest trailer carries the integrity check.
+    #[test]
+    fn crypto_auth_leaves_checksum_zero() {
+        let mut pkt = null_hello_packet();
+        pkt.auth_type = 2;
+        pkt.auth = Ospfv2Auth::Crypto(Ospfv2AuthCrypto {
+            key_id: 1,
+            auth_data_len: 16,
+            seq: 42,
+        });
+        let mut buf = BytesMut::new();
+        pkt.emit(&mut buf);
+        assert_eq!(&buf[12..14], &[0, 0], "AuType 2 checksum must stay zero");
     }
 
     #[test]

--- a/zebra-rs/src/config/manager.rs
+++ b/zebra-rs/src/config/manager.rs
@@ -3453,4 +3453,42 @@ mod yang_load_tests {
             assert_eq!(code, ExecCode::Success, "`{path}` must be a settable path");
         }
     }
+
+    /// The three OSPF authentication modules (zebra-ospf-auth-simple /
+    /// -md5 / -trailer) augment the per-interface subtree but were
+    /// never imported by config.yang, so their leaves resolved as
+    /// "unknown key" and per-interface authentication was
+    /// unconfigurable. Pin every auth spelling as settable so the
+    /// imports can't be dropped again.
+    #[test]
+    fn ospf_interface_authentication_paths_parse() {
+        use crate::config::ExecCode;
+        use crate::config::parse::{State, parse};
+        use libyang::to_entry;
+
+        let mut yang = YangStore::new();
+        yang.add_path(concat!(env!("CARGO_MANIFEST_DIR"), "/yang"));
+        yang.read_with_resolve("configure")
+            .expect("configure mode loads");
+        yang.identity_resolve();
+        let module = yang
+            .find_module("configure")
+            .expect("configure module present");
+        let entry = to_entry(&yang, module);
+
+        for path in [
+            "set router ospf area 0 interface eth0 authentication simple",
+            "set router ospf area 0 interface eth0 authentication message-digest",
+            "set router ospf area 0 interface eth0 authentication-key secret08",
+            "set router ospf area 0 interface eth0 message-digest-key 1 md5 md5secret",
+            "set router ospf area 0 interface eth0 crypto-key 1 hmac-sha-1 shasecret",
+            "set router ospf area 0 interface eth0 crypto-key 1 hmac-sha-256 shasecret",
+            "set router ospf area 0 interface eth0 crypto-key 1 hmac-sha-384 shasecret",
+            "set router ospf area 0 interface eth0 crypto-key 1 hmac-sha-512 shasecret",
+            "set router ospf area 0 interface eth0 key-chain OSPF-KC",
+        ] {
+            let (code, _comps, _state) = parse(path, entry.clone(), None, State::new());
+            assert_eq!(code, ExecCode::Success, "`{path}` must be a settable path");
+        }
+    }
 }

--- a/zebra-rs/src/ospf/network.rs
+++ b/zebra-rs/src/ospf/network.rs
@@ -65,7 +65,13 @@ pub async fn read_packet(sock: Arc<AsyncFd<Socket>>, tx: UnboundedSender<Message
                 if pkt_len < 24 || ospf_input.len() < pkt_len {
                     return Err(ErrorKind::InvalidData.into());
                 }
-                if ospf_packet::validate_checksum(&ospf_input[..pkt_len]).is_err() {
+                // RFC 2328 §D.4.3: cryptographic authentication
+                // (AuType 2) does not use the standard checksum —
+                // the field is zero on the wire and integrity is
+                // verified via the digest trailer in the auth gate.
+                let auth_type = u16::from_be_bytes([ospf_input[14], ospf_input[15]]);
+                if auth_type != 2 && ospf_packet::validate_checksum(&ospf_input[..pkt_len]).is_err()
+                {
                     return Err(ErrorKind::InvalidData.into());
                 }
 

--- a/zebra-rs/yang/config.yang
+++ b/zebra-rs/yang/config.yang
@@ -76,6 +76,18 @@ module config {
     prefix zob;
   }
 
+  import zebra-ospf-auth-simple {
+    prefix zoas;
+  }
+
+  import zebra-ospf-auth-md5 {
+    prefix zoam;
+  }
+
+  import zebra-ospf-auth-trailer {
+    prefix zoat;
+  }
+
   import zebra-ospf-tracing {
     prefix zotr;
   }


### PR DESCRIPTION
## Summary

Adding BDD coverage for OSPFv2 authentication and graceful restart exposed two real bugs, both fixed here:

- **Auth YANG modules were never imported** (`config.yang`): the three per-interface authentication modules (`zebra-ospf-auth-simple/-md5/-trailer`) augment the OSPF interface subtree but weren't imported, so every auth leaf was rejected as "unknown key" — per-interface authentication was unconfigurable despite the handlers being wired. Fixed with imports plus a parse regression test pinning all nine auth spellings.
- **OSPFv2 packet checksum included the auth field** (`ospf-packet::Ospfv2Packet::emit`): the send side summed the whole packet including bytes 16..24 while the receive side correctly excludes them (RFC 2328 §D.4.1), so any nonzero auth field (Simple password, Crypto key-id/seq overlay) corrupted the sum and the peer dropped every authenticated packet at ingress — no authenticated adjacency could ever form. Fixed per Appendix D: AuType 0/1 checksums exclude the auth field; AuType 2 skips the standard checksum entirely (field stays zero, digest trailer carries integrity — §D.4.3) and ingress skips validation for AuType 2, which also accepts FRR's checksum-zero cryptographic packets. Pinned by emit/validate round-trip tests.

New BDD features (both passing locally end-to-end):

- **`ospfv2_auth`** (5 scenarios): simple password, keyed-MD5, HMAC-SHA-256, and RFC 8177 key-chain each form a Full adjacency on a two-router p2p link; mismatched MD5 secrets never create a neighbor.
- **`ospfv2_graceful_restart`** (2 scenarios): a staged restart (`clear ospf graceful-restart begin`) floods Grace-LSAs and drives helper entry on the peer, and abort recovers; a committed restart exits the daemon, the helper holds the adjacency and route past the 40s dead interval, and the restarted daemon resumes from its checkpoint inside the grace window (Full → ExStart re-exchange → Full, no dead-timer kill). The shared checkpoint file is removed defensively around each scenario.

## Test plan

- `cargo test -p ospf-packet` — new checksum round-trip tests pass.
- `cargo test -p zebra-rs ospf_interface_authentication_paths_parse` — auth paths parse.
- BDD locally: `@ospfv2_auth` 5/5 scenarios, `@ospfv2_graceful_restart` 2/2 scenarios, zero skipped steps.
- Full gates: `cargo fmt --check`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo test --workspace --exclude bdd` all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)