### PR TITLE
ospf: redistribute static/kernel/isis (v2), connected/static/kernel/isis (v3)

### DIFF
--- a/bdd/tests/configs/ospfv2_redistribute_static/a.yaml
+++ b/bdd/tests/configs/ospfv2_redistribute_static/a.yaml
@@ -1,0 +1,18 @@
+interface:
+- if-name: lo
+  ipv4:
+    address: 10.0.0.1/32
+- if-name: ethb
+  ipv4:
+    address: 10.0.12.1/30
+router:
+  ospf:
+    router-id: 10.0.0.1
+    area:
+    - area-id: 0.0.0.0
+      interface:
+      - if-name: lo
+        enable: true
+      - if-name: ethb
+        enable: true
+        network-type: point-to-point

--- a/bdd/tests/configs/ospfv2_redistribute_static/b.yaml
+++ b/bdd/tests/configs/ospfv2_redistribute_static/b.yaml
@@ -1,0 +1,31 @@
+# ASBR: a static route (nexthop resolves via the connected /30) plus
+# instance-level `redistribute static` — every static route in the RIB
+# becomes a Type-5 AS-External LSA with metric 20 / E2 defaults.
+interface:
+- if-name: lo
+  ipv4:
+    address: 10.0.0.2/32
+- if-name: etha
+  ipv4:
+    address: 10.0.12.2/30
+router:
+  static:
+    ipv4:
+      route:
+      - prefix: 192.168.50.0/24
+        nexthop:
+        - address: 10.0.12.1
+  ospf:
+    router-id: 10.0.0.2
+    redistribute:
+      static:
+        metric: 20
+        metric-type: type-2
+    area:
+    - area-id: 0.0.0.0
+      interface:
+      - if-name: lo
+        enable: true
+      - if-name: etha
+        enable: true
+        network-type: point-to-point

--- a/bdd/tests/configs/ospfv3_redistribute/a.yaml
+++ b/bdd/tests/configs/ospfv3_redistribute/a.yaml
@@ -1,0 +1,18 @@
+interface:
+- if-name: lo
+  ipv6:
+    address: 2001:db8::1/128
+- if-name: ethb
+  ipv6:
+    address: 2001:db8:12::1/64
+router:
+  ospfv3:
+    router-id: 10.0.0.1
+    area:
+    - area-id: 0.0.0.0
+      interface:
+      - if-name: lo
+        enable: true
+      - if-name: ethb
+        enable: true
+        network-type: point-to-point

--- a/bdd/tests/configs/ospfv3_redistribute/b.yaml
+++ b/bdd/tests/configs/ospfv3_redistribute/b.yaml
@@ -1,0 +1,35 @@
+# ASBR: instance-level `redistribute connected` picks up the dummy
+# interface's /64 (created by the feature after this config applies);
+# `redistribute static` picks up the static route below. Both become
+# AS-External (Type-5) LSAs with metric 20 / E2 defaults.
+interface:
+- if-name: lo
+  ipv6:
+    address: 2001:db8::2/128
+- if-name: etha
+  ipv6:
+    address: 2001:db8:12::2/64
+router:
+  static:
+    ipv6:
+      route:
+      - prefix: 2001:db8:99::/64
+        nexthop:
+        - address: 2001:db8:12::1
+  ospfv3:
+    router-id: 10.0.0.2
+    redistribute:
+      connected:
+        metric: 20
+        metric-type: type-2
+      static:
+        metric: 20
+        metric-type: type-2
+    area:
+    - area-id: 0.0.0.0
+      interface:
+      - if-name: lo
+        enable: true
+      - if-name: etha
+        enable: true
+        network-type: point-to-point

--- a/bdd/tests/features/ospfv2_redistribute_static.feature
+++ b/bdd/tests/features/ospfv2_redistribute_static.feature
@@ -1,0 +1,55 @@
+@serial
+@ospfv2_redistribute_static
+Feature: OSPFv2 instance-level redistribute static originates Type-5 AS-External LSAs
+  As a network operator
+  I want `router ospf redistribute static` to originate a Type-5
+  AS-External LSA for every static route in the RIB — with the E-bit
+  set in the Router-LSA so the domain computes paths to the ASBR — so
+  that statically routed prefixes are reachable OSPF-wide without
+  per-area configuration.
+
+  Two routers on a point-to-point link. b carries a static route and
+  redistributes it; a must install the prefix as an external route.
+
+  Test Topology:
+  ```
+    a (10.0.0.1) -- 10.0.12.0/30 -- b (ASBR, 10.0.0.2)
+                                    static 192.168.50.0/24 -> 10.0.12.1
+                                    redistribute static -> Type-5
+
+    on router X the interface toward router Y is named "ethY".
+    loopbacks: a .1  b .2  (10.0.0.X/32).
+  ```
+
+  The static route's nexthop deliberately points back across the OSPF
+  link (it resolves via the connected /30), so the route is installed
+  in b's RIB and delivered to OSPF through the RIB redistribution
+  subscription — the same path any real static route takes.
+
+  Scenario: Static route appears as an external route on the neighbor
+    Given a clean test environment
+    When I create namespace "a"
+    And I create namespace "b"
+    And I connect namespace "a" interface "ethb" to namespace "b" interface "etha"
+    And I start zebra-rs in namespace "a"
+    And I start zebra-rs in namespace "b"
+    And I apply config "a.yaml" to namespace "a"
+    And I apply config "b.yaml" to namespace "b"
+    # Hello/DBD exchange, Type-5 origination and flood, SPF.
+    And I wait 30 seconds
+
+    Then show command "show ospf neighbor" in namespace "a" should contain "Full"
+    And show command "show ospf neighbor" in namespace "b" should contain "Full"
+    # The redistributed prefix arrives as an AS-External route with the
+    # default metric 20 (E2: metric is flat regardless of distance).
+    And show command "show ospf route" in namespace "a" should contain "192.168.50.0/24"
+    And show command "show ospf route" in namespace "a" should contain "[20]"
+    # b itself must not self-install its own external.
+    And show command "show ospf route" in namespace "b" should not contain "192.168.50.0/24"
+
+    # Teardown.
+    When I stop zebra-rs in namespace "a"
+    And I stop zebra-rs in namespace "b"
+    And I delete namespace "a"
+    And I delete namespace "b"
+    Then the test environment should be clean

--- a/bdd/tests/features/ospfv3_redistribute.feature
+++ b/bdd/tests/features/ospfv3_redistribute.feature
@@ -1,0 +1,54 @@
+@serial
+@ospfv3_redistribute
+Feature: OSPFv3 instance-level redistribute originates AS-External LSAs
+  As a network operator
+  I want `router ospfv3 redistribute connected` and `redistribute
+  static` to originate AS-External (Type-5, 0x4005) LSAs for the
+  matching IPv6 routes — previously only `redistribute bgp` existed at
+  the v3 instance level — so that non-OSPF prefixes are reachable
+  OSPFv3-wide.
+
+  Two routers on a point-to-point link. b redistributes both a
+  connected prefix (a dummy interface outside OSPF) and a static
+  route; a must install both as external routes.
+
+  Test Topology:
+  ```
+    a (10.0.0.1) -- 2001:db8:12::/64 -- b (ASBR, 10.0.0.2)
+                                        dummy cafe0 2001:db8:cafe::1/64 (not in OSPF)
+                                        static 2001:db8:99::/64 -> 2001:db8:12::1
+                                        redistribute connected + static
+
+    on router X the interface toward router Y is named "ethY".
+    loopbacks: a 2001:db8::1/128  b 2001:db8::2/128.
+  ```
+
+  Scenario: Connected and static IPv6 routes appear as external routes on the neighbor
+    Given a clean test environment
+    When I create namespace "a"
+    And I create namespace "b"
+    And I connect namespace "a" interface "ethb" to namespace "b" interface "etha"
+    And I start zebra-rs in namespace "a"
+    And I start zebra-rs in namespace "b"
+    And I apply config "a.yaml" to namespace "a"
+    And I apply config "b.yaml" to namespace "b"
+    # The dummy is created after the config so the redistribute path is
+    # exercised by a live AddrAdd -> RIB -> subscription event, not
+    # just the initial sweep.
+    And I create dummy interface "cafe0" with address "2001:db8:cafe::1/64" in namespace "b"
+    And I wait 30 seconds
+
+    Then show command "show ospfv3 neighbor" in namespace "a" should contain "Full"
+    And show command "show ospfv3 neighbor" in namespace "b" should contain "Full"
+    # Externally learned prefixes on a: the dummy's connected /64 and
+    # the static /64, both redistributed at instance level by b.
+    And show command "show ospfv3 route" in namespace "a" should contain "2001:db8:cafe::/64"
+    And show command "show ospfv3 route" in namespace "a" should contain "2001:db8:99::/64"
+    And show command "show ospfv3 database" in namespace "a" should contain "AS-External-LSA"
+
+    # Teardown.
+    When I stop zebra-rs in namespace "a"
+    And I stop zebra-rs in namespace "b"
+    And I delete namespace "a"
+    And I delete namespace "b"
+    Then the test environment should be clean

--- a/book/src/ch-08-11-ospf-frr-cross-reference.md
+++ b/book/src/ch-08-11-ospf-frr-cross-reference.md
@@ -20,7 +20,7 @@ configuration surface to the equivalent FRR `ospfd` commands.
 | `area/<id>/nssa-default-originate true` | `area <id> nssa default-information-originate` |
 | `area/<id>/nssa-suppress-fa true` | `area <id> nssa suppress-fa` |
 | `area/<id>/nssa-translator-role` | `area <id> nssa translate-candidate` / `translate-always` / `translate-never` |
-| `redistribute connected { metric; metric-type; }` | `redistribute connected metric <m> metric-type <1\|2>` |
+| `redistribute <connected\|static\|kernel\|isis\|bgp> { metric; metric-type; }` | `redistribute <source> metric <m> metric-type <1\|2>` |
 | `area/<id>/interface/<n>/authentication simple` + `authentication-key` | `ip ospf authentication` + `ip ospf authentication-key` (interface) |
 | `area/<id>/interface/<n>/authentication message-digest` + `message-digest-key <id> { md5; }` | `ip ospf authentication message-digest` + `ip ospf message-digest-key <id> md5 <key>` (interface) |
 | `area/<id>/interface/<n>/key-chain` | `ip ospf authentication key-chain <name>` (interface) |

--- a/book/src/ch-08-12-ospf-frr-gaps.md
+++ b/book/src/ch-08-12-ospf-frr-gaps.md
@@ -14,8 +14,8 @@ OSPFv2 features not yet implemented in zebra-rs:
   `network-type` knob accepts `broadcast` and `point-to-point`
   only.
 - Stub-router advertisement (`max-metric router-lsa`, RFC 6987).
-- Redistribution sources beyond `connected` and `bgp` (FRR also
-  offers static, kernel, IS-IS, table, …).
+- Redistribution `route-map` filtering and the `table` source (the
+  zebra-rs sources are connected, static, kernel, IS-IS, and BGP).
 - Forwarding-address resolution on received externals: Type-5/
   Type-7 LSAs carrying a non-zero forwarding address are skipped
   (RFC 2328 §16.4 step 3); zebra-rs itself always originates with

--- a/book/src/ch-08-15-ospf-redistribution.md
+++ b/book/src/ch-08-15-ospf-redistribution.md
@@ -30,15 +30,19 @@ router ospf {
 | YANG leaf (`/router/ospf/redistribute/…`) | Type | Default |
 |---|---|---|
 | `connected` | presence container | — (absent = off) |
+| `static` | presence container | — (absent = off) |
+| `kernel` | presence container | — (absent = off) |
+| `isis` | presence container | — (absent = off) |
 | `bgp` | presence container | — (absent = off) |
 | `<source>/metric` | uint32, 0..16777214 | 20 |
 | `<source>/metric-type` | `type-1` \| `type-2` | `type-2` |
 
-`connected` and `bgp` are the two supported sources today; each is a
-presence container — naming it enables redistribution of that
-source, deleting it flushes the corresponding Type-5s. Both knobs
-also exist per VRF instance, where the subscription is scoped so a
-VRF's OSPF sees only that VRF's routes.
+Each source is a presence container — naming it enables
+redistribution of that source, deleting it flushes the corresponding
+Type-5s. Sources are independent subscriptions to the RIB, so any
+combination can be active at once. The knobs also exist per VRF
+instance, where the subscription is scoped so a VRF's OSPF sees only
+that VRF's routes.
 
 ## E1 vs E2 metrics
 

--- a/book/src/ch-15-09-ospfv3-redistribution.md
+++ b/book/src/ch-15-09-ospfv3-redistribution.md
@@ -2,52 +2,51 @@
 
 OSPFv3 redistribution originates **AS-External-LSAs** (LS type
 `0x4005`, RFC 5340 §A.4.7) flooded AS-wide, with the same E1/E2
-metric semantics as OSPFv2 (see
+metric semantics and source list as OSPFv2 (see
 [the v2 Route Redistribution page](ch-08-15-ospf-redistribution.md)
-for the metric model). The v3 source list differs from v2:
+for the metric model):
 
 | YANG leaf (`/router/ospfv3/redistribute/…`) | Type | Default |
 |---|---|---|
+| `connected` | presence container | — (absent = off) |
+| `static` | presence container | — (absent = off) |
+| `kernel` | presence container | — (absent = off) |
+| `isis` | presence container | — (absent = off) |
 | `bgp` | presence container | — (absent = off) |
-| `bgp/metric` | uint32, 0..16777214 | 20 |
-| `bgp/metric-type` | `type-1` \| `type-2` | `type-2` |
-
-- **Instance-level `redistribute bgp`** is the primary knob. Its
-  main role is the SRv6 L3VPN PE–CE "down" direction: a PE injects
-  the VPNv6 routes it imported into a VRF into the CE-facing OSPFv3
-  instance. Per-VRF OSPFv3 instances receive only their own VRF's
-  BGP routes.
-- **There is no instance-level `redistribute connected` for v3**
-  (v2 has one). Connected-prefix redistribution exists only
-  per-NSSA-area:
+| `<source>/metric` | uint32, 0..16777214 | 20 |
+| `<source>/metric-type` | `type-1` \| `type-2` | `type-2` |
 
 ```
 router ospfv3 {
-  area 0.0.0.1 {
-    area-type nssa;
-    redistribute {
-      connected {
-        metric 20;
-        metric-type type-2;
-      }
+  router-id 10.0.0.2;
+  redistribute {
+    connected {
+      metric 20;
+      metric-type type-2;
     }
-    interface lo {
+    static;
+  }
+  area 0 {
+    interface enp0s6 {
       enable true;
     }
   }
 }
 ```
 
-which originates area-scoped NSSA-LSAs (`0x2007`) translated to
-AS-External at the NSSA ABR — see
-[Area Types: Stub and NSSA](ch-15-03-ospfv3-area-types.md).
+Notes:
 
-In practice this asymmetry is mild: OSPFv3 already advertises the
-IPv6 prefixes of every OSPF-enabled interface through
-Intra-Area-Prefix-LSAs (including loopbacks declared under an
-area), so instance-wide connected redistribution matters mainly for
-non-OSPF interfaces — a gap noted in
-[Gaps Relative to FRR ospf6d](ch-15-15-ospfv3-frr-gaps.md).
+- `redistribute connected` matters mainly for interfaces *outside*
+  OSPF — the prefixes of OSPF-enabled interfaces are already
+  advertised through Intra-Area-Prefix-LSAs.
+- `redistribute bgp` additionally serves the SRv6 L3VPN PE–CE
+  "down" direction: a PE injects the VPNv6 routes it imported into
+  a VRF into the CE-facing OSPFv3 instance. Per-VRF OSPFv3
+  instances receive only their own VRF's routes.
+- Inside an NSSA, the per-area `redistribute connected` knob
+  originates area-scoped NSSA-LSAs (`0x2007`) instead, translated
+  to AS-External at the NSSA ABR — see
+  [Area Types: Stub and NSSA](ch-15-03-ospfv3-area-types.md).
 
 Receive-side handling installs AS-External routes with the standard
 RFC 2328 §16.4 preference and metric arithmetic; as with v2,

--- a/book/src/ch-15-14-ospfv3-frr-cross-reference.md
+++ b/book/src/ch-15-14-ospfv3-frr-cross-reference.md
@@ -20,7 +20,7 @@ interface to an area with a per-interface command.
 | `area/<id>/area-type stub` | `area <id> stub` |
 | `area/<id>/area-type nssa` | `area <id> nssa` |
 | `area/<id>/no-summary true` | `area <id> stub no-summary` / `area <id> nssa no-summary` |
-| `redistribute bgp { metric; metric-type; }` | `redistribute bgp metric <m> metric-type <1\|2>` |
+| `redistribute <connected\|static\|kernel\|isis\|bgp> { metric; metric-type; }` | `redistribute <source> metric <m> metric-type <1\|2>` |
 | `clear ospfv3 neighbor` | `clear ipv6 ospf6 interface [IFNAME]` |
 | `show ospfv3 neighbor / database / route` | `show ipv6 ospf6 neighbor / database / route` |
 

--- a/book/src/ch-15-15-ospfv3-frr-gaps.md
+++ b/book/src/ch-15-15-ospfv3-frr-gaps.md
@@ -8,9 +8,8 @@ OSPFv3 features not yet implemented in zebra-rs:
   generate inter-area routes. See
   [Multi-Area Topologies and the ABR](ch-15-04-ospfv3-multi-area-abr.md).
 - Area ranges (`area <id> range` prefix aggregation).
-- Instance-level redistribution of sources other than `bgp`
-  (`connected`, `static`, kernel routes); per-NSSA-area `connected`
-  is the only other source today.
+- Redistribution `route-map` filtering (the zebra-rs sources are
+  connected, static, kernel, IS-IS, and BGP, matching v2).
 - Graceful-restart configuration and restarter mode — v3 is
   helper-only with fixed defaults (v2 has both roles; `ospf6d` has
   helper configuration and restarting support).

--- a/zebra-rs/src/config/manager.rs
+++ b/zebra-rs/src/config/manager.rs
@@ -3491,4 +3491,36 @@ mod yang_load_tests {
             assert_eq!(code, ExecCode::Success, "`{path}` must be a settable path");
         }
     }
+
+    /// Instance-level OSPF redistribution grew beyond connected/bgp:
+    /// static, kernel and isis are settable for OSPFv2, and OSPFv3
+    /// gained connected/static/kernel/isis alongside bgp. Pin every
+    /// source spelling (with its metric knobs) as a settable path so
+    /// the YANG containers can't drift from the config handlers.
+    #[test]
+    fn ospf_redistribute_source_paths_parse() {
+        use crate::config::ExecCode;
+        use crate::config::parse::{State, parse};
+        use libyang::to_entry;
+
+        let mut yang = YangStore::new();
+        yang.add_path(concat!(env!("CARGO_MANIFEST_DIR"), "/yang"));
+        yang.read_with_resolve("configure")
+            .expect("configure mode loads");
+        yang.identity_resolve();
+        let module = yang
+            .find_module("configure")
+            .expect("configure module present");
+        let entry = to_entry(&yang, module);
+
+        for proto in ["ospf", "ospfv3"] {
+            for source in ["connected", "static", "kernel", "isis", "bgp"] {
+                for suffix in ["", " metric 30", " metric-type type-1"] {
+                    let path = format!("set router {proto} redistribute {source}{suffix}");
+                    let (code, _comps, _state) = parse(&path, entry.clone(), None, State::new());
+                    assert_eq!(code, ExecCode::Success, "`{path}` must be a settable path");
+                }
+            }
+        }
+    }
 }

--- a/zebra-rs/src/ospf/config.rs
+++ b/zebra-rs/src/ospf/config.rs
@@ -560,12 +560,12 @@ fn ospf_send_redist(ospf: &Ospf, rtype: crate::rib::RibType, first_time: bool) {
 /// Type-5 AS-External LSA for each. On Delete: unsubscribe and flush.
 fn ospf_redist_set(ospf: &mut Ospf, rtype: crate::rib::RibType, op: ConfigOp) -> Option<()> {
     use crate::rib::RibType;
-    let first_time = !ospf.redist.contains_key(&rtype)
-        && !(rtype == RibType::Connected
-            && ospf
-                .areas
-                .iter()
-                .any(|(_, area)| area.redistribute.connected.is_some()));
+    let nssa_connected = rtype == RibType::Connected
+        && ospf
+            .areas
+            .iter()
+            .any(|(_, area)| area.redistribute.connected.is_some());
+    let first_time = !(ospf.redist.contains_key(&rtype) || nssa_connected);
     if op.is_set() {
         ospf.redist.insert(
             rtype,

--- a/zebra-rs/src/ospf/config.rs
+++ b/zebra-rs/src/ospf/config.rs
@@ -77,6 +77,30 @@ impl Ospf {
         );
         // Instance-level `router ospf { redistribute connected ... }`.
         self.ospf_add("/redistribute/connected", config_ospf_redist_connected);
+        self.ospf_add("/redistribute/static", config_ospf_redist_static);
+        self.ospf_add(
+            "/redistribute/static/metric",
+            config_ospf_redist_static_metric,
+        );
+        self.ospf_add(
+            "/redistribute/static/metric-type",
+            config_ospf_redist_static_metric_type,
+        );
+        self.ospf_add("/redistribute/kernel", config_ospf_redist_kernel);
+        self.ospf_add(
+            "/redistribute/kernel/metric",
+            config_ospf_redist_kernel_metric,
+        );
+        self.ospf_add(
+            "/redistribute/kernel/metric-type",
+            config_ospf_redist_kernel_metric_type,
+        );
+        self.ospf_add("/redistribute/isis", config_ospf_redist_isis);
+        self.ospf_add("/redistribute/isis/metric", config_ospf_redist_isis_metric);
+        self.ospf_add(
+            "/redistribute/isis/metric-type",
+            config_ospf_redist_isis_metric_type,
+        );
         self.ospf_add("/redistribute/bgp", config_ospf_redist_bgp);
         self.ospf_add("/redistribute/bgp/metric", config_ospf_redist_bgp_metric);
         self.ospf_add(
@@ -491,22 +515,25 @@ fn config_ospf_area_nssa_translator_role(
 /// area — so multiple NSSA areas with `redistribute connected`
 /// share a single subscription. `any_connected_enabled` decides
 /// whether the subscription should exist at all.
-fn ospf_send_redist_connected(ospf: &Ospf, first_time: bool) {
+/// Subscribe / unsubscribe this instance's RIB redistribution for one
+/// IPv4 source, gated on the instance-level knob (and, for connected,
+/// the per-NSSA-area knobs too). Each `(afi, rtype)` row is its own
+/// subscription. Uses this instance's proto label, not the literal
+/// "ospf": a per-VRF instance registers as "ospf:vrf:<name>", and the
+/// RIB routes the redistribute subscription by the proto string in the
+/// message. With the literal, a VRF child's subscription resolved to
+/// the default instance — so per-VRF redistribute never delivered.
+fn ospf_send_redist(ospf: &Ospf, rtype: crate::rib::RibType, first_time: bool) {
     use crate::rib::{Message as RibMsg, RedistAfi, RibType};
-    // Use this instance's proto label, not the literal "ospf": a per-VRF
-    // instance registers as "ospf:vrf:<name>", and the RIB routes the
-    // redistribute subscription by the proto string in the message. With
-    // the literal, a VRF child's subscription resolved to the default
-    // instance — so per-VRF redistribute never delivered. See proto_label.
     let proto = ospf.proto_label.clone();
     let afi = RedistAfi::Ipv4;
-    let rtype = RibType::Connected;
 
-    let any_enabled = ospf
-        .areas
-        .iter()
-        .any(|(_, area)| area.redistribute.connected.is_some())
-        || ospf.redist_connected.is_some();
+    let any_enabled = ospf.redist.contains_key(&rtype)
+        || (rtype == RibType::Connected
+            && ospf
+                .areas
+                .iter()
+                .any(|(_, area)| area.redistribute.connected.is_some()));
 
     let msg = if !any_enabled {
         RibMsg::RedistDel { proto, afi, rtype }
@@ -528,80 +555,105 @@ fn ospf_send_redist_connected(ospf: &Ospf, first_time: bool) {
     let _ = ospf.ctx.rib.send(msg);
 }
 
-/// Subscribe / unsubscribe this instance's RIB redistribution for the
-/// IPv4 BGP source, gated on the instance-level `redistribute bgp` knob.
-/// Independent of the connected subscription (each `(afi, rtype)` row is
-/// its own subscription). Uses `proto_label` so a per-VRF instance
-/// receives only its VRF's BGP routes.
-fn ospf_send_redist_bgp(ospf: &Ospf, first_time: bool) {
-    use crate::rib::{Message as RibMsg, RedistAfi, RibType};
-    let proto = ospf.proto_label.clone();
-    let afi = RedistAfi::Ipv4;
-    let rtype = RibType::Bgp;
-
-    let msg = if ospf.redist_bgp.is_none() {
-        RibMsg::RedistDel { proto, afi, rtype }
-    } else if first_time {
-        RibMsg::RedistAdd {
-            proto,
-            afi,
-            rtype,
-            subtypes: std::collections::BTreeSet::new(),
-        }
-    } else {
-        RibMsg::RedistUpdate {
-            proto,
-            afi,
-            rtype,
-            subtypes: std::collections::BTreeSet::new(),
-        }
-    };
-    let _ = ospf.ctx.rib.send(msg);
-}
-
-/// `/router/ospf/redistribute/bgp` — instance-level presence container.
-/// On Set: subscribe to the VRF's BGP routes and originate a Type-5
-/// AS-External LSA for each. On Delete: unsubscribe and flush them.
-fn config_ospf_redist_bgp(ospf: &mut Ospf, _args: Args, op: ConfigOp) -> Option<()> {
-    let first_time = ospf.redist_bgp.is_none();
+/// Shared body of the instance-level `redistribute <source>` presence
+/// handlers. On Set: subscribe to the source's routes and originate a
+/// Type-5 AS-External LSA for each. On Delete: unsubscribe and flush.
+fn ospf_redist_set(ospf: &mut Ospf, rtype: crate::rib::RibType, op: ConfigOp) -> Option<()> {
+    use crate::rib::RibType;
+    let first_time = !ospf.redist.contains_key(&rtype)
+        && !(rtype == RibType::Connected
+            && ospf
+                .areas
+                .iter()
+                .any(|(_, area)| area.redistribute.connected.is_some()));
     if op.is_set() {
-        ospf.redist_bgp = Some(RedistEntry {
-            metric: RedistEntry::DEFAULT_METRIC,
-            ..Default::default()
-        });
+        ospf.redist.insert(
+            rtype,
+            RedistEntry {
+                metric: RedistEntry::DEFAULT_METRIC,
+                ..Default::default()
+            },
+        );
     } else {
-        ospf.redist_bgp = None;
+        ospf.redist.remove(&rtype);
     }
-    ospf_send_redist_bgp(ospf, first_time && op.is_set());
-    ospf.as_external_redist_bgp_resync();
+    ospf_send_redist(ospf, rtype, first_time && op.is_set());
+    ospf.as_external_redist_resync(rtype);
     Some(())
 }
 
-/// `/router/ospf/redistribute/bgp/metric`.
-fn config_ospf_redist_bgp_metric(ospf: &mut Ospf, mut args: Args, op: ConfigOp) -> Option<()> {
+/// Shared body of `redistribute <source> metric`.
+fn ospf_redist_metric_set(
+    ospf: &mut Ospf,
+    rtype: crate::rib::RibType,
+    mut args: Args,
+    op: ConfigOp,
+) -> Option<()> {
     let metric = if op.is_set() {
         args.u32()?
     } else {
         RedistEntry::DEFAULT_METRIC
     };
-    ospf.redist_bgp.get_or_insert_with(Default::default).metric = metric;
-    ospf.as_external_redist_bgp_resync();
+    ospf.redist.entry(rtype).or_default().metric = metric;
+    ospf.as_external_redist_resync(rtype);
     Some(())
 }
 
-/// `/router/ospf/redistribute/bgp/metric-type`.
-fn config_ospf_redist_bgp_metric_type(ospf: &mut Ospf, mut args: Args, op: ConfigOp) -> Option<()> {
+/// Shared body of `redistribute <source> metric-type`.
+fn ospf_redist_metric_type_set(
+    ospf: &mut Ospf,
+    rtype: crate::rib::RibType,
+    mut args: Args,
+    op: ConfigOp,
+) -> Option<()> {
     let mtype = if op.is_set() {
         ExternalMetricType::from_yang(&args.string()?)?
     } else {
         ExternalMetricType::default()
     };
-    ospf.redist_bgp
-        .get_or_insert_with(Default::default)
-        .metric_type = mtype;
-    ospf.as_external_redist_bgp_resync();
+    ospf.redist.entry(rtype).or_default().metric_type = mtype;
+    ospf.as_external_redist_resync(rtype);
     Some(())
 }
+
+macro_rules! ospf_redist_handlers {
+    ($set:ident, $metric:ident, $mtype:ident, $rtype:expr) => {
+        fn $set(ospf: &mut Ospf, _args: Args, op: ConfigOp) -> Option<()> {
+            ospf_redist_set(ospf, $rtype, op)
+        }
+        fn $metric(ospf: &mut Ospf, args: Args, op: ConfigOp) -> Option<()> {
+            ospf_redist_metric_set(ospf, $rtype, args, op)
+        }
+        fn $mtype(ospf: &mut Ospf, args: Args, op: ConfigOp) -> Option<()> {
+            ospf_redist_metric_type_set(ospf, $rtype, args, op)
+        }
+    };
+}
+
+ospf_redist_handlers!(
+    config_ospf_redist_bgp,
+    config_ospf_redist_bgp_metric,
+    config_ospf_redist_bgp_metric_type,
+    crate::rib::RibType::Bgp
+);
+ospf_redist_handlers!(
+    config_ospf_redist_static,
+    config_ospf_redist_static_metric,
+    config_ospf_redist_static_metric_type,
+    crate::rib::RibType::Static
+);
+ospf_redist_handlers!(
+    config_ospf_redist_kernel,
+    config_ospf_redist_kernel_metric,
+    config_ospf_redist_kernel_metric_type,
+    crate::rib::RibType::Kernel
+);
+ospf_redist_handlers!(
+    config_ospf_redist_isis,
+    config_ospf_redist_isis_metric,
+    config_ospf_redist_isis_metric_type,
+    crate::rib::RibType::Isis
+);
 
 /// `/router/ospf/area/<id>/redistribute/connected` — presence
 /// container. On Set: create the area's `RedistEntry` with
@@ -616,7 +668,8 @@ fn config_ospf_area_redist_connected(ospf: &mut Ospf, mut args: Args, op: Config
     let first_time = !ospf
         .areas
         .iter()
-        .any(|(_, area)| area.redistribute.connected.is_some());
+        .any(|(_, area)| area.redistribute.connected.is_some())
+        && !ospf.redist.contains_key(&crate::rib::RibType::Connected);
 
     if op.is_set() {
         ospf.areas.fetch(area_id).redistribute.connected = Some(RedistEntry {
@@ -627,7 +680,11 @@ fn config_ospf_area_redist_connected(ospf: &mut Ospf, mut args: Args, op: Config
         area.redistribute.connected = None;
     }
 
-    ospf_send_redist_connected(ospf, first_time && op.is_set());
+    ospf_send_redist(
+        ospf,
+        crate::rib::RibType::Connected,
+        first_time && op.is_set(),
+    );
     ospf.nssa_redist_connected_resync(area_id);
     Some(())
 }
@@ -1864,62 +1921,11 @@ fn config_ospf_gr_drain_time_ms(ospf: &mut Ospf, mut args: Args, op: ConfigOp) -
     Some(())
 }
 
-/// `/router/ospf/redistribute/connected` — instance-level presence
-/// container. On Set: enable Type-5 AS-External origination for every
-/// connected route. On Delete: flush all self-originated Type-5s.
-fn config_ospf_redist_connected(ospf: &mut Ospf, _args: Args, op: ConfigOp) -> Option<()> {
-    let first_time = !ospf
-        .areas
-        .iter()
-        .any(|(_, area)| area.redistribute.connected.is_some())
-        && ospf.redist_connected.is_none();
-
-    if op.is_set() {
-        ospf.redist_connected = Some(RedistEntry {
-            metric: RedistEntry::DEFAULT_METRIC,
-            ..Default::default()
-        });
-    } else {
-        ospf.redist_connected = None;
-    }
-
-    ospf_send_redist_connected(ospf, first_time && op.is_set());
-    ospf.as_external_redist_connected_resync();
-    Some(())
-}
-
-/// `/router/ospf/redistribute/connected/metric`.
-fn config_ospf_redist_connected_metric(
-    ospf: &mut Ospf,
-    mut args: Args,
-    op: ConfigOp,
-) -> Option<()> {
-    let metric = if op.is_set() {
-        args.u32()?
-    } else {
-        RedistEntry::DEFAULT_METRIC
-    };
-    ospf.redist_connected
-        .get_or_insert_with(Default::default)
-        .metric = metric;
-    ospf.as_external_redist_connected_resync();
-    Some(())
-}
-
-/// `/router/ospf/redistribute/connected/metric-type`.
-fn config_ospf_redist_connected_metric_type(
-    ospf: &mut Ospf,
-    mut args: Args,
-    op: ConfigOp,
-) -> Option<()> {
-    let mtype = if op.is_set() {
-        ExternalMetricType::from_yang(&args.string()?)?
-    } else {
-        ExternalMetricType::default()
-    };
-    ospf.redist_connected
-        .get_or_insert_with(Default::default)
-        .metric_type = mtype;
-    ospf.as_external_redist_connected_resync();
-    Some(())
-}
+// `/router/ospf/redistribute/connected` and its metric knobs share
+// the generic instance-level redistribute bodies above.
+ospf_redist_handlers!(
+    config_ospf_redist_connected,
+    config_ospf_redist_connected_metric,
+    config_ospf_redist_connected_metric_type,
+    crate::rib::RibType::Connected
+);

--- a/zebra-rs/src/ospf/config_v3.rs
+++ b/zebra-rs/src/ospf/config_v3.rs
@@ -541,12 +541,12 @@ fn ospfv3_redist_set(
     op: ConfigOp,
 ) -> Option<()> {
     use crate::rib::RibType;
-    let first_time = !ospf.redist.contains_key(&rtype)
-        && !(rtype == RibType::Connected
-            && ospf
-                .areas
-                .iter()
-                .any(|(_, area)| area.redistribute.connected.is_some()));
+    let nssa_connected = rtype == RibType::Connected
+        && ospf
+            .areas
+            .iter()
+            .any(|(_, area)| area.redistribute.connected.is_some());
+    let first_time = !(ospf.redist.contains_key(&rtype) || nssa_connected);
     if op.is_set() {
         ospf.redist.insert(
             rtype,

--- a/zebra-rs/src/ospf/config_v3.rs
+++ b/zebra-rs/src/ospf/config_v3.rs
@@ -66,6 +66,42 @@ impl Ospf<Ospfv3> {
                 "/area/redistribute/connected/metric-type",
                 config_ospfv3_area_redist_connected_metric_type,
             ),
+            ("/redistribute/connected", config_ospfv3_redist_connected),
+            (
+                "/redistribute/connected/metric",
+                config_ospfv3_redist_connected_metric,
+            ),
+            (
+                "/redistribute/connected/metric-type",
+                config_ospfv3_redist_connected_metric_type,
+            ),
+            ("/redistribute/static", config_ospfv3_redist_static),
+            (
+                "/redistribute/static/metric",
+                config_ospfv3_redist_static_metric,
+            ),
+            (
+                "/redistribute/static/metric-type",
+                config_ospfv3_redist_static_metric_type,
+            ),
+            ("/redistribute/kernel", config_ospfv3_redist_kernel),
+            (
+                "/redistribute/kernel/metric",
+                config_ospfv3_redist_kernel_metric,
+            ),
+            (
+                "/redistribute/kernel/metric-type",
+                config_ospfv3_redist_kernel_metric_type,
+            ),
+            ("/redistribute/isis", config_ospfv3_redist_isis),
+            (
+                "/redistribute/isis/metric",
+                config_ospfv3_redist_isis_metric,
+            ),
+            (
+                "/redistribute/isis/metric-type",
+                config_ospfv3_redist_isis_metric_type,
+            ),
             ("/redistribute/bgp", config_ospfv3_redist_bgp),
             ("/redistribute/bgp/metric", config_ospfv3_redist_bgp_metric),
             (
@@ -453,26 +489,27 @@ fn config_ospfv3_area_nssa_translator_role(
     Some(())
 }
 
-/// v3 sibling of `ospf_send_redist_connected` (`config.rs`): subscribe
-/// (or unsubscribe) to RIB IPv6 connected routes for redistribution
-/// into NSSA Type-7 LSAs. Keyed by `(proto, afi, rtype)` — not per
-/// area — so multiple NSSA areas share one subscription.
-fn ospfv3_send_redist_connected(ospf: &Ospf<Ospfv3>, first_time: bool) {
+/// Subscribe / unsubscribe this v3 instance's RIB redistribution for
+/// one IPv6 source, gated on the instance-level knob (and, for
+/// connected, the per-NSSA-area knobs too). Keyed by
+/// `(proto, afi, rtype)` — not per area — so multiple NSSA areas share
+/// one subscription. Subscribes under this instance's proto label, not
+/// the literal "ospfv3": a per-VRF v3 instance registers as
+/// "ospfv3:vrf:<name>", and the RIB routes redist delivery by the proto
+/// string. With the literal, a VRF child's subscription resolved to the
+/// default v3 instance — so per-VRF redistribute never delivered. Same
+/// bug fixed for v2 (config.rs) and IS-IS.
+fn ospfv3_send_redist(ospf: &Ospf<Ospfv3>, rtype: crate::rib::RibType, first_time: bool) {
     use crate::rib::{Message as RibMsg, RedistAfi, RibType};
-    // Subscribe under this instance's proto label, not the literal
-    // "ospfv3": a per-VRF v3 instance registers as "ospfv3:vrf:<name>",
-    // and the RIB routes redist delivery by the proto string. With the
-    // literal, a VRF child's subscription resolved to the default v3
-    // instance — so per-VRF redistribute never delivered. Same bug fixed
-    // for v2 (config.rs) and IS-IS.
     let proto = ospf.proto_label.clone();
     let afi = RedistAfi::Ipv6;
-    let rtype = RibType::Connected;
 
-    let any_enabled = ospf
-        .areas
-        .iter()
-        .any(|(_, area)| area.redistribute.connected.is_some());
+    let any_enabled = ospf.redist.contains_key(&rtype)
+        || (rtype == RibType::Connected
+            && ospf
+                .areas
+                .iter()
+                .any(|(_, area)| area.redistribute.connected.is_some()));
 
     let msg = if !any_enabled {
         RibMsg::RedistDel { proto, afi, rtype }
@@ -494,57 +531,42 @@ fn ospfv3_send_redist_connected(ospf: &Ospf<Ospfv3>, first_time: bool) {
     let _ = ospf.ctx.rib.send(msg);
 }
 
-/// Subscribe / unsubscribe this v3 instance's RIB redistribution for the
-/// IPv6 BGP source, gated on the instance-level `redistribute bgp` knob.
-/// Uses `proto_label` so a per-VRF instance receives only its VRF's BGP
-/// routes. v3 sibling of v2's `ospf_send_redist_bgp`.
-fn ospfv3_send_redist_bgp(ospf: &Ospf<Ospfv3>, first_time: bool) {
-    use crate::rib::{Message as RibMsg, RedistAfi, RibType};
-    let proto = ospf.proto_label.clone();
-    let afi = RedistAfi::Ipv6;
-    let rtype = RibType::Bgp;
-
-    let msg = if ospf.redist_bgp.is_none() {
-        RibMsg::RedistDel { proto, afi, rtype }
-    } else if first_time {
-        RibMsg::RedistAdd {
-            proto,
-            afi,
-            rtype,
-            subtypes: std::collections::BTreeSet::new(),
-        }
-    } else {
-        RibMsg::RedistUpdate {
-            proto,
-            afi,
-            rtype,
-            subtypes: std::collections::BTreeSet::new(),
-        }
-    };
-    let _ = ospf.ctx.rib.send(msg);
-}
-
-/// `/router/ospfv3/redistribute/bgp` — instance-level presence container.
-/// On Set: subscribe to the VRF's BGP routes and originate an AS-External
-/// (Type-5) LSA for each. On Delete: unsubscribe and flush them.
-fn config_ospfv3_redist_bgp(ospf: &mut Ospf<Ospfv3>, _args: Args, op: ConfigOp) -> Option<()> {
-    let first_time = ospf.redist_bgp.is_none();
+/// Shared body of the v3 instance-level `redistribute <source>`
+/// presence handlers. On Set: subscribe to the source's IPv6 routes and
+/// originate an AS-External (Type-5) LSA for each. On Delete:
+/// unsubscribe and flush.
+fn ospfv3_redist_set(
+    ospf: &mut Ospf<Ospfv3>,
+    rtype: crate::rib::RibType,
+    op: ConfigOp,
+) -> Option<()> {
+    use crate::rib::RibType;
+    let first_time = !ospf.redist.contains_key(&rtype)
+        && !(rtype == RibType::Connected
+            && ospf
+                .areas
+                .iter()
+                .any(|(_, area)| area.redistribute.connected.is_some()));
     if op.is_set() {
-        ospf.redist_bgp = Some(RedistEntry {
-            metric: RedistEntry::DEFAULT_METRIC,
-            ..Default::default()
-        });
+        ospf.redist.insert(
+            rtype,
+            RedistEntry {
+                metric: RedistEntry::DEFAULT_METRIC,
+                ..Default::default()
+            },
+        );
     } else {
-        ospf.redist_bgp = None;
+        ospf.redist.remove(&rtype);
     }
-    ospfv3_send_redist_bgp(ospf, first_time && op.is_set());
-    ospf.as_external_redist_bgp_resync_v3();
+    ospfv3_send_redist(ospf, rtype, first_time && op.is_set());
+    ospf.as_external_redist_resync_v3(rtype);
     Some(())
 }
 
-/// `/router/ospfv3/redistribute/bgp/metric`.
-fn config_ospfv3_redist_bgp_metric(
+/// Shared body of the v3 `redistribute <source> metric` handlers.
+fn ospfv3_redist_metric_set(
     ospf: &mut Ospf<Ospfv3>,
+    rtype: crate::rib::RibType,
     mut args: Args,
     op: ConfigOp,
 ) -> Option<()> {
@@ -553,14 +575,15 @@ fn config_ospfv3_redist_bgp_metric(
     } else {
         RedistEntry::DEFAULT_METRIC
     };
-    ospf.redist_bgp.get_or_insert_with(Default::default).metric = metric;
-    ospf.as_external_redist_bgp_resync_v3();
+    ospf.redist.entry(rtype).or_default().metric = metric;
+    ospf.as_external_redist_resync_v3(rtype);
     Some(())
 }
 
-/// `/router/ospfv3/redistribute/bgp/metric-type`.
-fn config_ospfv3_redist_bgp_metric_type(
+/// Shared body of the v3 `redistribute <source> metric-type` handlers.
+fn ospfv3_redist_metric_type_set(
     ospf: &mut Ospf<Ospfv3>,
+    rtype: crate::rib::RibType,
     mut args: Args,
     op: ConfigOp,
 ) -> Option<()> {
@@ -569,12 +592,55 @@ fn config_ospfv3_redist_bgp_metric_type(
     } else {
         ExternalMetricType::default()
     };
-    ospf.redist_bgp
-        .get_or_insert_with(Default::default)
-        .metric_type = mtype;
-    ospf.as_external_redist_bgp_resync_v3();
+    ospf.redist.entry(rtype).or_default().metric_type = mtype;
+    ospf.as_external_redist_resync_v3(rtype);
     Some(())
 }
+
+macro_rules! ospfv3_redist_handlers {
+    ($set:ident, $metric:ident, $mtype:ident, $rtype:expr) => {
+        fn $set(ospf: &mut Ospf<Ospfv3>, _args: Args, op: ConfigOp) -> Option<()> {
+            ospfv3_redist_set(ospf, $rtype, op)
+        }
+        fn $metric(ospf: &mut Ospf<Ospfv3>, args: Args, op: ConfigOp) -> Option<()> {
+            ospfv3_redist_metric_set(ospf, $rtype, args, op)
+        }
+        fn $mtype(ospf: &mut Ospf<Ospfv3>, args: Args, op: ConfigOp) -> Option<()> {
+            ospfv3_redist_metric_type_set(ospf, $rtype, args, op)
+        }
+    };
+}
+
+ospfv3_redist_handlers!(
+    config_ospfv3_redist_connected,
+    config_ospfv3_redist_connected_metric,
+    config_ospfv3_redist_connected_metric_type,
+    crate::rib::RibType::Connected
+);
+ospfv3_redist_handlers!(
+    config_ospfv3_redist_static,
+    config_ospfv3_redist_static_metric,
+    config_ospfv3_redist_static_metric_type,
+    crate::rib::RibType::Static
+);
+ospfv3_redist_handlers!(
+    config_ospfv3_redist_kernel,
+    config_ospfv3_redist_kernel_metric,
+    config_ospfv3_redist_kernel_metric_type,
+    crate::rib::RibType::Kernel
+);
+ospfv3_redist_handlers!(
+    config_ospfv3_redist_isis,
+    config_ospfv3_redist_isis_metric,
+    config_ospfv3_redist_isis_metric_type,
+    crate::rib::RibType::Isis
+);
+ospfv3_redist_handlers!(
+    config_ospfv3_redist_bgp,
+    config_ospfv3_redist_bgp_metric,
+    config_ospfv3_redist_bgp_metric_type,
+    crate::rib::RibType::Bgp
+);
 
 /// `/router/ospfv3/area/<id>/redistribute/connected` — presence
 /// container. Mirrors v2's `config_ospf_area_redist_connected` but
@@ -589,7 +655,8 @@ fn config_ospfv3_area_redist_connected(
     let first_time = !ospf
         .areas
         .iter()
-        .any(|(_, area)| area.redistribute.connected.is_some());
+        .any(|(_, area)| area.redistribute.connected.is_some())
+        && !ospf.redist.contains_key(&crate::rib::RibType::Connected);
 
     if op.is_set() {
         ospf.areas.fetch(area_id).redistribute.connected = Some(RedistEntry {
@@ -600,7 +667,11 @@ fn config_ospfv3_area_redist_connected(
         area.redistribute.connected = None;
     }
 
-    ospfv3_send_redist_connected(ospf, first_time && op.is_set());
+    ospfv3_send_redist(
+        ospf,
+        crate::rib::RibType::Connected,
+        first_time && op.is_set(),
+    );
     ospf.nssa_redist_connected_resync_v3(area_id);
     Some(())
 }

--- a/zebra-rs/src/ospf/inst.rs
+++ b/zebra-rs/src/ospf/inst.rs
@@ -279,25 +279,22 @@ pub struct Ospf<V: OspfVersion = Ospfv2> {
     /// `nssa_redist_connected_resync_v3`. The generic `Ospf<V>` carries
     /// both maps; a v2 instance leaves this empty.
     pub redist_v6: BTreeMap<(crate::rib::RibType, ipnet::Ipv6Net), crate::rib::RouteEntryV6>,
-    /// Instance-level `redistribute connected` — originates Type-5
-    /// AS-External LSAs (FA=0) for every connected route from
-    /// `redist_v4`. `Some(entry)` enables origination; `None` stops it.
-    pub redist_connected: Option<crate::ospf::area::RedistEntry>,
-    /// Prefixes of Type-5 LSAs we self-originated from instance-level
-    /// `redistribute connected`. Flushed when the knob is removed.
-    pub redist_connected_originated: BTreeSet<Ipv4Net>,
-    /// Instance-level `redistribute bgp` — originates Type-5 AS-External
-    /// LSAs (FA=0) for every BGP route from `redist_v4`. In a per-VRF
-    /// OSPF instance this injects the VPNv4 routes BGP imported into the
-    /// VRF into the CE-facing OSPF (the L3VPN PE-CE down direction).
-    pub redist_bgp: Option<crate::ospf::area::RedistEntry>,
-    /// Prefixes of Type-5 LSAs we self-originated from instance-level
-    /// `redistribute bgp`. Flushed when the knob is removed.
-    pub redist_bgp_originated: BTreeSet<Ipv4Net>,
-    /// IPv6 counterpart of [`Self::redist_bgp_originated`]: prefixes of
-    /// OSPFv3 AS-External (Type-5) LSAs self-originated from instance-level
-    /// `redistribute bgp`. A v2 instance leaves this empty.
-    pub redist_bgp_originated_v6: BTreeSet<ipnet::Ipv6Net>,
+    /// Instance-level `redistribute <source>` knobs, keyed by the RIB
+    /// route type (connected / static / kernel / isis / bgp). An entry
+    /// enables Type-5 AS-External origination (FA=0) for every route of
+    /// that source in `redist_v4` / `redist_v6`; removing it stops and
+    /// flushes. In a per-VRF instance the bgp source injects the
+    /// VPNv4/VPNv6 routes BGP imported into the VRF into the CE-facing
+    /// OSPF (the L3VPN PE-CE down direction).
+    pub redist: BTreeMap<crate::rib::RibType, crate::ospf::area::RedistEntry>,
+    /// Per-source prefixes of Type-5 LSAs we self-originated from the
+    /// instance-level `redistribute` knobs (v2 / IPv4). Diffed by
+    /// `as_external_redist_resync`; flushed when the knob is removed.
+    pub redist_originated: BTreeMap<crate::rib::RibType, BTreeSet<Ipv4Net>>,
+    /// IPv6 counterpart of [`Self::redist_originated`]: per-source
+    /// prefixes of OSPFv3 AS-External (Type-5) LSAs self-originated from
+    /// instance-level `redistribute`. A v2 instance leaves this empty.
+    pub redist_originated_v6: BTreeMap<crate::rib::RibType, BTreeSet<ipnet::Ipv6Net>>,
     /// Staged Flexible Algorithm definitions for this instance
     /// (`/router/ospf{,v3}/flex-algo`, RFC 9350). Shared staging engine
     /// keyed by the version's `FLEX_ALGO_PREFIX`; origination from the
@@ -1229,11 +1226,9 @@ impl Ospf<Ospfv2> {
             spf_duration: None,
             redist_v4: BTreeMap::new(),
             redist_v6: BTreeMap::new(),
-            redist_connected: None,
-            redist_connected_originated: BTreeSet::new(),
-            redist_bgp: None,
-            redist_bgp_originated: BTreeSet::new(),
-            redist_bgp_originated_v6: BTreeSet::new(),
+            redist: BTreeMap::new(),
+            redist_originated: BTreeMap::new(),
+            redist_originated_v6: BTreeMap::new(),
             flex_algo: crate::flex_algo::FlexAlgoConfig::new(Ospfv2::FLEX_ALGO_PREFIX),
             affinity_map: crate::flex_algo::AffinityMap::new(),
             srlg_config: crate::flex_algo::SrlgGroupBuilder::new(),
@@ -2458,22 +2453,25 @@ impl Ospf<Ospfv2> {
         }
     }
 
-    /// Rebuild self-originated Type-5 AS-External LSAs from the
-    /// instance-level `redistribute connected` knob and `redist_v4`.
+    /// Rebuild self-originated Type-5 AS-External LSAs for one
+    /// instance-level `redistribute <source>` knob from `redist_v4`.
     /// Idempotent: originates missing, refreshes changed, flushes stale.
-    pub fn as_external_redist_connected_resync(&mut self) {
-        use crate::rib::RibType;
-
-        let (entry, prev_originated) = {
-            let entry = self.redist_connected;
-            let prev = self.redist_connected_originated.clone();
-            (entry, prev)
-        };
+    /// Generic over the source — connected, static, kernel, isis, and
+    /// bgp all share this body; for a per-VRF instance the bgp source
+    /// carries the VPNv4 routes BGP imported into the VRF (the L3VPN
+    /// PE-CE down direction).
+    pub fn as_external_redist_resync(&mut self, rtype: crate::rib::RibType) {
+        let entry = self.redist.get(&rtype).copied();
+        let prev_originated = self
+            .redist_originated
+            .get(&rtype)
+            .cloned()
+            .unwrap_or_default();
 
         let desired: BTreeSet<Ipv4Net> = if entry.is_some() {
             self.redist_v4
                 .iter()
-                .filter(|((rtype, _), _)| *rtype == RibType::Connected)
+                .filter(|((rt, _), _)| *rt == rtype)
                 .map(|((_, prefix), _)| *prefix)
                 .collect()
         } else {
@@ -2486,7 +2484,9 @@ impl Ospf<Ospfv2> {
             .collect::<Vec<_>>()
         {
             self.as_external_lsa_flush_for_prefix(prefix);
-            self.redist_connected_originated.remove(&prefix);
+            if let Some(set) = self.redist_originated.get_mut(&rtype) {
+                set.remove(&prefix);
+            }
         }
 
         if let Some(redist_entry) = entry {
@@ -2496,57 +2496,37 @@ impl Ospf<Ospfv2> {
                     redist_entry.metric,
                     redist_entry.metric_type.is_type_2(),
                 );
-                self.redist_connected_originated.insert(*prefix);
+                self.redist_originated
+                    .entry(rtype)
+                    .or_default()
+                    .insert(*prefix);
             }
+        }
+        if self
+            .redist_originated
+            .get(&rtype)
+            .is_some_and(|s| s.is_empty())
+        {
+            self.redist_originated.remove(&rtype);
         }
 
         self.router_lsa_originate();
     }
 
-    /// `redistribute bgp` sibling of
-    /// [`Self::as_external_redist_connected_resync`]: rebuild this
-    /// instance's self-originated Type-5 AS-External LSAs for the cached
-    /// BGP routes (`redist_v4` entries with `rtype == RibType::Bgp`),
-    /// diffing against `redist_bgp_originated`. In a per-VRF OSPF instance
-    /// these are the VPNv4 routes BGP imported into the VRF — injecting
-    /// them into the CE-facing OSPF is the L3VPN PE-CE down direction.
-    pub fn as_external_redist_bgp_resync(&mut self) {
-        use crate::rib::RibType;
-
-        let entry = self.redist_bgp;
-        let prev_originated = self.redist_bgp_originated.clone();
-
-        let desired: BTreeSet<Ipv4Net> = if entry.is_some() {
-            self.redist_v4
-                .iter()
-                .filter(|((rtype, _), _)| *rtype == RibType::Bgp)
-                .map(|((_, prefix), _)| *prefix)
-                .collect()
-        } else {
-            BTreeSet::new()
-        };
-
-        for prefix in prev_originated
-            .difference(&desired)
+    /// Run [`Self::as_external_redist_resync`] for every source that is
+    /// either configured or still has originated state to clean up.
+    /// Called from the RIB route-churn handlers, where any subscribed
+    /// source may have changed.
+    pub fn as_external_redist_resync_all(&mut self) {
+        let rtypes: BTreeSet<crate::rib::RibType> = self
+            .redist
+            .keys()
             .copied()
-            .collect::<Vec<_>>()
-        {
-            self.as_external_lsa_flush_for_prefix(prefix);
-            self.redist_bgp_originated.remove(&prefix);
+            .chain(self.redist_originated.keys().copied())
+            .collect();
+        for rtype in rtypes {
+            self.as_external_redist_resync(rtype);
         }
-
-        if let Some(redist_entry) = entry {
-            for prefix in &desired {
-                self.as_external_lsa_originate_for_prefix(
-                    *prefix,
-                    redist_entry.metric,
-                    redist_entry.metric_type.is_type_2(),
-                );
-                self.redist_bgp_originated.insert(*prefix);
-            }
-        }
-
-        self.router_lsa_originate();
     }
 
     /// RFC 3101 §2.3 NSSA default-LSA origination. Thin wrapper
@@ -2670,7 +2650,7 @@ impl Ospf<Ospfv2> {
     /// (RFC 2328 §3.3 ASBR definition). Today this requires the
     /// instance-level `redistribute connected` knob to be set.
     pub fn is_asbr(&self) -> bool {
-        self.redist_connected.is_some() || self.redist_bgp.is_some()
+        !self.redist.is_empty()
     }
 
     /// True when this router should translate Type-7 → Type-5 for
@@ -2956,8 +2936,7 @@ impl Ospf<Ospfv2> {
         for area_id in area_ids {
             self.nssa_redist_connected_resync(area_id);
         }
-        self.as_external_redist_connected_resync();
-        self.as_external_redist_bgp_resync();
+        self.as_external_redist_resync_all();
     }
 
     /// `RibRx::RouteDel` handler. Mirror of `route_redist_add`.
@@ -2972,8 +2951,7 @@ impl Ospf<Ospfv2> {
         for area_id in area_ids {
             self.nssa_redist_connected_resync(area_id);
         }
-        self.as_external_redist_connected_resync();
-        self.as_external_redist_bgp_resync();
+        self.as_external_redist_resync_all();
     }
 
     fn process_lsdb(&mut self, ev: LsdbEvent, area_id: Option<Ipv4Addr>, key: OspfLsaKey) {
@@ -3231,7 +3209,7 @@ impl Ospf<Ospfv2> {
             }
             OspfLsType::AsExternal => {
                 // Type-5s can be self-originated via two paths:
-                //   1. instance-level `redistribute connected` → `redist_connected_originated`
+                //   1. instance-level `redistribute <source>` → `redist_originated`
                 //   2. NSSA Type-7→Type-5 translation → `nssa_translated`
                 // Check the redistribute set first, then NSSA, then flush.
                 let network = {
@@ -3249,13 +3227,15 @@ impl Ospf<Ospfv2> {
                         .and_then(|plen| Ipv4Net::new(ls_id, plen).ok())
                         .map(|p| p.trunc())
                 };
-                if network.is_some_and(|p| self.redist_connected_originated.contains(&p)) {
+                if network
+                    .is_some_and(|p| self.redist_originated.values().any(|set| set.contains(&p)))
+                {
                     tracing::info!(
                         "[Self-Originated] Re-originating redistribute Type-5 id={} seq={:#x}",
                         ls_id,
                         received_seq
                     );
-                    self.as_external_redist_connected_resync();
+                    self.as_external_redist_resync_all();
                 } else {
                     let owning_area = self
                         .areas
@@ -5423,11 +5403,9 @@ impl Ospf<Ospfv3> {
             spf_duration: None,
             redist_v4: BTreeMap::new(),
             redist_v6: BTreeMap::new(),
-            redist_connected: None,
-            redist_connected_originated: BTreeSet::new(),
-            redist_bgp: None,
-            redist_bgp_originated: BTreeSet::new(),
-            redist_bgp_originated_v6: BTreeSet::new(),
+            redist: BTreeMap::new(),
+            redist_originated: BTreeMap::new(),
+            redist_originated_v6: BTreeMap::new(),
             flex_algo: crate::flex_algo::FlexAlgoConfig::new(Ospfv3::FLEX_ALGO_PREFIX),
             affinity_map: crate::flex_algo::AffinityMap::new(),
             srlg_config: crate::flex_algo::SrlgGroupBuilder::new(),
@@ -5611,7 +5589,7 @@ impl Ospf<Ospfv3> {
         for area_id in area_ids {
             self.nssa_redist_connected_resync_v3(area_id);
         }
-        self.as_external_redist_bgp_resync_v3();
+        self.as_external_redist_resync_all_v3();
     }
 
     /// `RibRx::RouteDel` handler (v3). Mirror of `route_redist_add`.
@@ -5625,7 +5603,7 @@ impl Ospf<Ospfv3> {
         for area_id in area_ids {
             self.nssa_redist_connected_resync_v3(area_id);
         }
-        self.as_external_redist_bgp_resync_v3();
+        self.as_external_redist_resync_all_v3();
     }
 
     /// Stash an IPv6 address learned from netlink on the matching
@@ -6502,23 +6480,26 @@ impl Ospf<Ospfv3> {
         }
     }
 
-    /// v3 sibling of `as_external_redist_bgp_resync`: rebuild this
-    /// instance's self-originated AS-External (Type-5) LSAs for the cached
-    /// BGP routes (`redist_v6` entries with `rtype == RibType::Bgp`),
-    /// diffing against `redist_bgp_originated_v6`. In a per-VRF OSPFv3
-    /// instance these are the VPNv6 routes BGP imported into the VRF —
+    /// v3 sibling of `as_external_redist_resync`: rebuild this
+    /// instance's self-originated AS-External (Type-5) LSAs for one
+    /// instance-level `redistribute <source>` knob from the cached
+    /// routes (`redist_v6` entries with a matching rtype), diffing
+    /// against `redist_originated_v6`. In a per-VRF OSPFv3 instance the
+    /// bgp source carries the VPNv6 routes BGP imported into the VRF —
     /// injecting them into the CE-facing OSPFv3 is the L3VPN PE-CE down
     /// direction.
-    pub fn as_external_redist_bgp_resync_v3(&mut self) {
-        use crate::rib::RibType;
-
-        let entry = self.redist_bgp;
-        let prev_originated = self.redist_bgp_originated_v6.clone();
+    pub fn as_external_redist_resync_v3(&mut self, rtype: crate::rib::RibType) {
+        let entry = self.redist.get(&rtype).copied();
+        let prev_originated = self
+            .redist_originated_v6
+            .get(&rtype)
+            .cloned()
+            .unwrap_or_default();
 
         let desired: BTreeSet<ipnet::Ipv6Net> = if entry.is_some() {
             self.redist_v6
                 .iter()
-                .filter(|((rtype, _), _)| *rtype == RibType::Bgp)
+                .filter(|((rt, _), _)| *rt == rtype)
                 .map(|((_, prefix), _)| *prefix)
                 .collect()
         } else {
@@ -6531,7 +6512,9 @@ impl Ospf<Ospfv3> {
             .collect::<Vec<_>>()
         {
             self.as_external_lsa_flush_for_prefix_v3(prefix);
-            self.redist_bgp_originated_v6.remove(&prefix);
+            if let Some(set) = self.redist_originated_v6.get_mut(&rtype) {
+                set.remove(&prefix);
+            }
         }
 
         if let Some(redist_entry) = entry {
@@ -6541,13 +6524,38 @@ impl Ospf<Ospfv3> {
                     redist_entry.metric,
                     redist_entry.metric_type.is_type_2(),
                 );
-                self.redist_bgp_originated_v6.insert(*prefix);
+                self.redist_originated_v6
+                    .entry(rtype)
+                    .or_default()
+                    .insert(*prefix);
             }
+        }
+        if self
+            .redist_originated_v6
+            .get(&rtype)
+            .is_some_and(|s| s.is_empty())
+        {
+            self.redist_originated_v6.remove(&rtype);
         }
 
         // A v3 router that redistributes is an ASBR; refresh the
         // Router-LSA so the E-bit reflects it.
         self.router_lsa_originate();
+    }
+
+    /// Run [`Self::as_external_redist_resync_v3`] for every source that
+    /// is either configured or still has originated state to clean up.
+    /// Called from the RIB route-churn handlers.
+    pub fn as_external_redist_resync_all_v3(&mut self) {
+        let rtypes: BTreeSet<crate::rib::RibType> = self
+            .redist
+            .keys()
+            .copied()
+            .chain(self.redist_originated_v6.keys().copied())
+            .collect();
+        for rtype in rtypes {
+            self.as_external_redist_resync_v3(rtype);
+        }
     }
 
     /// v3 sibling of `nssa_redist_connected_resync`: rebuild this

--- a/zebra-rs/yang/config.yang
+++ b/zebra-rs/yang/config.yang
@@ -530,6 +530,54 @@ module config {
               default type-2;
             }
           }
+          container static {
+            presence "Redistribute static routes as Type-5 AS-External LSAs";
+            leaf metric {
+              type uint32 {
+                range "0..16777214";
+              }
+              default 20;
+            }
+            leaf metric-type {
+              type enumeration {
+                enum type-1;
+                enum type-2;
+              }
+              default type-2;
+            }
+          }
+          container kernel {
+            presence "Redistribute kernel routes as Type-5 AS-External LSAs";
+            leaf metric {
+              type uint32 {
+                range "0..16777214";
+              }
+              default 20;
+            }
+            leaf metric-type {
+              type enumeration {
+                enum type-1;
+                enum type-2;
+              }
+              default type-2;
+            }
+          }
+          container isis {
+            presence "Redistribute IS-IS routes as Type-5 AS-External LSAs";
+            leaf metric {
+              type uint32 {
+                range "0..16777214";
+              }
+              default 20;
+            }
+            leaf metric-type {
+              type enumeration {
+                enum type-1;
+                enum type-2;
+              }
+              default type-2;
+            }
+          }
           container bgp {
             presence "Redistribute BGP routes as Type-5 AS-External LSAs";
             leaf metric {
@@ -1163,10 +1211,78 @@ module config {
           type inet:ipv4-address;
         }
         // Instance-level redistribution into AS-External (Type-5) LSAs.
-        // `redistribute bgp` is the SRv6 L3VPN PE-CE down direction: a PE
-        // injects the VPNv6 routes it imported into a VRF into the
-        // CE-facing OSPFv3.
+        // Instance-level redistribute into AS-External (Type-5) LSAs,
+        // flooded AS-wide into all normal areas. Sources mirror the v2
+        // sibling (connected / static / kernel / isis / bgp);
+        // `redistribute bgp` additionally serves the SRv6 L3VPN PE-CE
+        // down direction: a PE injects the VPNv6 routes it imported
+        // into a VRF into the CE-facing OSPFv3. Per-area NSSA
+        // redistribution is under list area / redistribute.
         container redistribute {
+          container connected {
+            presence "Redistribute connected routes as AS-External (Type-5) LSAs";
+            leaf metric {
+              type uint32 {
+                range "0..16777214";
+              }
+              default 20;
+            }
+            leaf metric-type {
+              type enumeration {
+                enum type-1;
+                enum type-2;
+              }
+              default type-2;
+            }
+          }
+          container static {
+            presence "Redistribute static routes as AS-External (Type-5) LSAs";
+            leaf metric {
+              type uint32 {
+                range "0..16777214";
+              }
+              default 20;
+            }
+            leaf metric-type {
+              type enumeration {
+                enum type-1;
+                enum type-2;
+              }
+              default type-2;
+            }
+          }
+          container kernel {
+            presence "Redistribute kernel routes as AS-External (Type-5) LSAs";
+            leaf metric {
+              type uint32 {
+                range "0..16777214";
+              }
+              default 20;
+            }
+            leaf metric-type {
+              type enumeration {
+                enum type-1;
+                enum type-2;
+              }
+              default type-2;
+            }
+          }
+          container isis {
+            presence "Redistribute IS-IS routes as AS-External (Type-5) LSAs";
+            leaf metric {
+              type uint32 {
+                range "0..16777214";
+              }
+              default 20;
+            }
+            leaf metric-type {
+              type enumeration {
+                enum type-1;
+                enum type-2;
+              }
+              default type-2;
+            }
+          }
           container bgp {
             presence "Redistribute BGP routes as AS-External (Type-5) LSAs";
             leaf metric {


### PR DESCRIPTION
## Summary

Closes the OSPF redistribution gap against FRR for both protocol versions:

- **Generalized plumbing**: instance-level redistribution moves from two hardcoded per-source fields to a per-`RibType` map (`redist: BTreeMap<RibType, RedistEntry>`) with per-source originated-prefix tracking (v4/v6), one generic resync per version plus resync-all on RIB churn, and one generic RIB subscription sender per version. The connected source unions the instance-level knob with the per-NSSA-area knobs; `is_asbr()` and the RFC 2328 §13.4 self-originated Type-5 re-origination path cover every source.
- **New sources**: OSPFv2 gains `redistribute static | kernel | isis` (alongside connected/bgp); OSPFv3 gains `redistribute connected | static | kernel | isis` (alongside bgp). Each carries `metric` (default 20) and `metric-type` (default type-2), matching the existing sources.
- **BDD**: `ospfv2_redistribute_static` (static route → Type-5 at [20] on the neighbor, not self-installed) and `ospfv3_redistribute` (instance-level connected via a live dummy AddrAdd, plus static → AS-External-LSA on the neighbor).
- **Book**: both redistribution pages document the five sources; the FRR gaps pages now cite only route-map filtering / the `table` source as remaining; cross-reference tables generalized.

## Test plan

- New parse regression test pins all 30 source/metric spellings (2 protocols × 5 sources × 3 forms).
- Both new BDD features pass locally end-to-end, zero skipped steps.
- `cargo fmt --check`, `cargo clippy --workspace --all-targets -- -D warnings`, and `cargo test --workspace --exclude bdd` (2132 passed, 0 failed) all clean.
- `mdbook build` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)