### PR TITLE
book: bring OSPF auth and GR pages current with the merged fixes

### DIFF
--- a/book/src/ch-08-16-ospf-authentication.md
+++ b/book/src/ch-08-16-ospf-authentication.md
@@ -126,8 +126,16 @@ validates the sender's key-id against its accept-lifetime window.
 Key chains are shared infrastructure — the same `/key-chains` tree
 also serves IS-IS and BGP.
 
-## Verification behavior
+## Wire format and verification behavior
 
+- The OSPF packet checksum follows RFC 2328 Appendix D exactly:
+  for Null and Simple authentication it is computed over the packet
+  *excluding* the 64-bit authentication field, and for
+  cryptographic authentication (AuType 2) it is **not computed at
+  all** — the field stays zero and the digest trailer carries the
+  integrity check (§D.4.3). Ingress likewise skips checksum
+  validation on AuType-2 packets, so FRR's checksum-zero
+  cryptographic packets interoperate in both directions.
 - Cryptographic packets carry a per-link 32-bit sequence number;
   a received sequence lower than the neighbor's last-seen value is
   dropped as a replay (equal is accepted, matching FRR, so
@@ -160,3 +168,8 @@ is shared between the v2 and v3 instances of a link.
 Note the configuration caveat: the authentication leaves shown
 above attach to the `router ospf` (v2) interface tree only — there
 is currently no separate `router ospfv3 … authentication` path.
+
+All four OSPFv2 modes — simple password, keyed-MD5, HMAC-SHA-256,
+and key-chain — are BDD-validated end to end
+(`ospfv2_auth.feature`), including the negative case: mismatched
+secrets never create a neighbor.

--- a/book/src/ch-08-17-ospf-graceful-restart.md
+++ b/book/src/ch-08-17-ospf-graceful-restart.md
@@ -104,6 +104,14 @@ summarizes the on-disk checkpoint, and `show ospf database` marks
 neighbors advertising the Router Information "Graceful Restart
 helper" capability.
 
+The full cycle is BDD-validated (`ospfv2_graceful_restart.feature`):
+a staged restart drives helper entry on the peer and abort recovers,
+and a committed restart holds the adjacency and route on the helper
+well past the 40 s dead interval while the daemon is down, then
+resumes from the checkpoint — the adjacency re-exchanges
+(Full → ExStart → Full) inside the grace window without ever taking
+a dead-timer kill.
+
 ## OSPFv3
 
 OSPFv3 implements the helper side only, with the default policy

--- a/book/src/ch-15-00-ospfv3.md
+++ b/book/src/ch-15-00-ospfv3.md
@@ -26,8 +26,8 @@ zebra-rs shares one generic OSPF core between v2 and v3, so the
 configuration shape mirrors [the OSPFv2 chapter](ch-08-00-ospf.md)
 — a v3 config differs from v2 only in the top-level keyword
 (`router ospfv3`). The implementation is validated against FRR's
-`ospf6d` and by the BDD suite (adjacency, NSSA, SRv6, TI-LFA,
-router-id change, BFD topologies).
+`ospf6d` and by the BDD suite (adjacency, NSSA, redistribution,
+SRv6, TI-LFA, router-id change, BFD topologies).
 
 This chapter documents the OSPFv3 configuration surface. Where
 behavior is identical to OSPFv2 the pages summarize and link to the


### PR DESCRIPTION
## Summary

- Authentication page (9.8) documents the RFC 2328 Appendix D checksum wire behavior implemented by the recent fix: the checksum excludes the auth field for Null/Simple, stays zero for AuType 2 (integrity is the digest trailer's job), and ingress skips validation on AuType-2 packets — making FRR's checksum-zero cryptographic packets interoperate both ways. Notes all four modes are BDD-validated including the mismatched-secret negative.
- Graceful Restart page (9.11) notes the full staged/abort and commit/resume cycle is BDD-validated (adjacency and route held past the dead interval, checkpoint resume without a dead-timer kill).
- OSPFv3 chapter intro adds redistribution to the BDD-validated list.

## Test plan

- `mdbook build` clean. Docs-only change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)