### PR TITLE
ospf: area ranges — Type-3/Inter-Area-Prefix aggregation at the ABR

### DIFF
--- a/bdd/tests/configs/ospfv2_area_range/a.yaml
+++ b/bdd/tests/configs/ospfv2_area_range/a.yaml
@@ -1,0 +1,28 @@
+interface:
+- if-name: lo
+  ipv4:
+    address: 10.0.0.1/32
+- if-name: ethb
+  ipv4:
+    address: 10.0.12.1/30
+- if-name: ethc
+  ipv4:
+    address: 10.0.13.1/30
+router:
+  ospf:
+    router-id: 10.0.0.1
+    area:
+    - area-id: 0.0.0.0
+      interface:
+      - if-name: lo
+        enable: true
+      - if-name: ethc
+        enable: true
+        network-type: point-to-point
+    - area-id: 0.0.0.1
+      range:
+      - prefix: 10.1.0.0/16
+      interface:
+      - if-name: ethb
+        enable: true
+        network-type: point-to-point

--- a/bdd/tests/configs/ospfv2_area_range/a_na.yaml
+++ b/bdd/tests/configs/ospfv2_area_range/a_na.yaml
@@ -1,0 +1,29 @@
+interface:
+- if-name: lo
+  ipv4:
+    address: 10.0.0.1/32
+- if-name: ethb
+  ipv4:
+    address: 10.0.12.1/30
+- if-name: ethc
+  ipv4:
+    address: 10.0.13.1/30
+router:
+  ospf:
+    router-id: 10.0.0.1
+    area:
+    - area-id: 0.0.0.0
+      interface:
+      - if-name: lo
+        enable: true
+      - if-name: ethc
+        enable: true
+        network-type: point-to-point
+    - area-id: 0.0.0.1
+      range:
+      - prefix: 10.1.0.0/16
+        not-advertise: true
+      interface:
+      - if-name: ethb
+        enable: true
+        network-type: point-to-point

--- a/bdd/tests/configs/ospfv2_area_range/b.yaml
+++ b/bdd/tests/configs/ospfv2_area_range/b.yaml
@@ -1,0 +1,31 @@
+# Internal router of area 0.0.0.1. The two dummy interfaces carry
+# component prefixes inside the ABR's 10.1.0.0/16 range; the loopback
+# /32 sits outside the range and must keep advertising individually.
+interface:
+- if-name: lo
+  ipv4:
+    address: 10.0.0.2/32
+- if-name: etha
+  ipv4:
+    address: 10.0.12.2/30
+- if-name: r1
+  ipv4:
+    address: 10.1.1.1/24
+- if-name: r2
+  ipv4:
+    address: 10.1.2.1/24
+router:
+  ospf:
+    router-id: 10.0.0.2
+    area:
+    - area-id: 0.0.0.1
+      interface:
+      - if-name: lo
+        enable: true
+      - if-name: etha
+        enable: true
+        network-type: point-to-point
+      - if-name: r1
+        enable: true
+      - if-name: r2
+        enable: true

--- a/bdd/tests/configs/ospfv2_area_range/c.yaml
+++ b/bdd/tests/configs/ospfv2_area_range/c.yaml
@@ -1,0 +1,18 @@
+interface:
+- if-name: lo
+  ipv4:
+    address: 10.0.0.3/32
+- if-name: etha
+  ipv4:
+    address: 10.0.13.2/30
+router:
+  ospf:
+    router-id: 10.0.0.3
+    area:
+    - area-id: 0.0.0.0
+      interface:
+      - if-name: lo
+        enable: true
+      - if-name: etha
+        enable: true
+        network-type: point-to-point

--- a/bdd/tests/configs/ospfv3_area_range/a.yaml
+++ b/bdd/tests/configs/ospfv3_area_range/a.yaml
@@ -1,0 +1,28 @@
+interface:
+- if-name: lo
+  ipv6:
+    address: 2001:db8::1/128
+- if-name: ethb
+  ipv6:
+    address: 2001:db8:12::1/64
+- if-name: ethc
+  ipv6:
+    address: 2001:db8:13::1/64
+router:
+  ospfv3:
+    router-id: 10.0.0.1
+    area:
+    - area-id: 0.0.0.0
+      interface:
+      - if-name: lo
+        enable: true
+      - if-name: ethc
+        enable: true
+        network-type: point-to-point
+    - area-id: 0.0.0.1
+      range:
+      - prefix: 2001:db8:1::/48
+      interface:
+      - if-name: ethb
+        enable: true
+        network-type: point-to-point

--- a/bdd/tests/configs/ospfv3_area_range/a_na.yaml
+++ b/bdd/tests/configs/ospfv3_area_range/a_na.yaml
@@ -1,0 +1,29 @@
+interface:
+- if-name: lo
+  ipv6:
+    address: 2001:db8::1/128
+- if-name: ethb
+  ipv6:
+    address: 2001:db8:12::1/64
+- if-name: ethc
+  ipv6:
+    address: 2001:db8:13::1/64
+router:
+  ospfv3:
+    router-id: 10.0.0.1
+    area:
+    - area-id: 0.0.0.0
+      interface:
+      - if-name: lo
+        enable: true
+      - if-name: ethc
+        enable: true
+        network-type: point-to-point
+    - area-id: 0.0.0.1
+      range:
+      - prefix: 2001:db8:1::/48
+        not-advertise: true
+      interface:
+      - if-name: ethb
+        enable: true
+        network-type: point-to-point

--- a/bdd/tests/configs/ospfv3_area_range/b.yaml
+++ b/bdd/tests/configs/ospfv3_area_range/b.yaml
@@ -1,0 +1,31 @@
+# Internal router of area 0.0.0.1. The two dummy interfaces carry
+# component /64s inside the ABR's 2001:db8:1::/48 range; the loopback
+# /128 sits outside and must keep advertising individually.
+interface:
+- if-name: lo
+  ipv6:
+    address: 2001:db8::2/128
+- if-name: etha
+  ipv6:
+    address: 2001:db8:12::2/64
+- if-name: r1
+  ipv6:
+    address: 2001:db8:1:1::1/64
+- if-name: r2
+  ipv6:
+    address: 2001:db8:1:2::1/64
+router:
+  ospfv3:
+    router-id: 10.0.0.2
+    area:
+    - area-id: 0.0.0.1
+      interface:
+      - if-name: lo
+        enable: true
+      - if-name: etha
+        enable: true
+        network-type: point-to-point
+      - if-name: r1
+        enable: true
+      - if-name: r2
+        enable: true

--- a/bdd/tests/configs/ospfv3_area_range/c.yaml
+++ b/bdd/tests/configs/ospfv3_area_range/c.yaml
@@ -1,0 +1,18 @@
+interface:
+- if-name: lo
+  ipv6:
+    address: 2001:db8::3/128
+- if-name: etha
+  ipv6:
+    address: 2001:db8:13::2/64
+router:
+  ospfv3:
+    router-id: 10.0.0.3
+    area:
+    - area-id: 0.0.0.0
+      interface:
+      - if-name: lo
+        enable: true
+      - if-name: etha
+        enable: true
+        network-type: point-to-point

--- a/bdd/tests/features/ospfv2_area_range.feature
+++ b/bdd/tests/features/ospfv2_area_range.feature
@@ -1,0 +1,99 @@
+@serial
+@ospfv2_area_range
+Feature: OSPFv2 area ranges aggregate Type-3 summaries at the ABR
+  As a network operator
+  I want `area <id> range <prefix>` on an ABR to fold that area's
+  intra-area routes into one aggregate Type-3 (RFC 2328 §12.4.3) —
+  or hide the whole range with `not-advertise` — so that backbone
+  routers carry one summary instead of every component prefix.
+
+  Test Topology:
+  ```
+       area 0.0.0.1                          area 0.0.0.0
+    b (10.0.0.2) -- 10.0.12.0/30 -- a (ABR, 10.0.0.1) -- 10.0.13.0/30 -- c (10.0.0.3)
+    r1 10.1.1.0/24  <- inside the      area 0.0.0.1
+    r2 10.1.2.0/24  <- 10.1.0.0/16     range 10.1.0.0/16
+    lo 10.0.0.2/32  <- outside the range
+
+    on router X the interface toward router Y is named "ethY".
+  ```
+
+  b's dummy interfaces r1/r2 are OSPF-enabled stub prefixes inside
+  the range; its loopback /32 is outside. Metric check: components
+  cost 20 at the ABR (link 10 + stub 10), so the aggregate rides at
+  the largest component metric 20 and lands on c at [30].
+
+  Scenario: Components fold into one aggregate; prefixes outside the range still advertise
+    Given a clean test environment
+    When I create namespace "a"
+    And I create namespace "b"
+    And I create namespace "c"
+    And I connect namespace "a" interface "ethb" to namespace "b" interface "etha"
+    And I connect namespace "a" interface "ethc" to namespace "c" interface "etha"
+    # Dummies must exist before the config applies so their OSPF
+    # interface entries bind at enable time.
+    And I create dummy interface "r1" with address "10.1.1.1/24" in namespace "b"
+    And I create dummy interface "r2" with address "10.1.2.1/24" in namespace "b"
+    And I start zebra-rs in namespace "a"
+    And I start zebra-rs in namespace "b"
+    And I start zebra-rs in namespace "c"
+    And I apply config "a.yaml" to namespace "a"
+    And I apply config "b.yaml" to namespace "b"
+    And I apply config "c.yaml" to namespace "c"
+    And I wait 40 seconds
+
+    Then show command "show ospf neighbor" in namespace "a" should contain "Full"
+    And show command "show ospf neighbor" in namespace "c" should contain "Full"
+    # The aggregate — at the largest component metric (20) + c's link (10).
+    And show command "show ospf route" in namespace "c" should contain "10.1.0.0/16"
+    And show command "show ospf route" in namespace "c" should contain "[30]"
+    # The components must NOT leak individually.
+    And show command "show ospf route" in namespace "c" should not contain "10.1.1.0/24"
+    And show command "show ospf route" in namespace "c" should not contain "10.1.2.0/24"
+    # Outside the range: still summarized individually.
+    And show command "show ospf route" in namespace "c" should contain "10.0.0.2/32"
+    # Traffic to a component follows the aggregate end to end.
+    And ping from "c" to "10.1.1.1" should succeed
+
+    # Teardown.
+    When I stop zebra-rs in namespace "a"
+    And I stop zebra-rs in namespace "b"
+    And I stop zebra-rs in namespace "c"
+    And I delete namespace "a"
+    And I delete namespace "b"
+    And I delete namespace "c"
+    Then the test environment should be clean
+
+  Scenario: not-advertise hides the aggregate and the components
+    Given a clean test environment
+    When I create namespace "a"
+    And I create namespace "b"
+    And I create namespace "c"
+    And I connect namespace "a" interface "ethb" to namespace "b" interface "etha"
+    And I connect namespace "a" interface "ethc" to namespace "c" interface "etha"
+    And I create dummy interface "r1" with address "10.1.1.1/24" in namespace "b"
+    And I create dummy interface "r2" with address "10.1.2.1/24" in namespace "b"
+    And I start zebra-rs in namespace "a"
+    And I start zebra-rs in namespace "b"
+    And I start zebra-rs in namespace "c"
+    And I apply config "a_na.yaml" to namespace "a"
+    And I apply config "b.yaml" to namespace "b"
+    And I apply config "c.yaml" to namespace "c"
+    And I wait 40 seconds
+
+    Then show command "show ospf neighbor" in namespace "c" should contain "Full"
+    # The whole range is hidden — no aggregate, no components.
+    And show command "show ospf route" in namespace "c" should not contain "10.1.0.0/16"
+    And show command "show ospf route" in namespace "c" should not contain "10.1.1.0/24"
+    And show command "show ospf route" in namespace "c" should not contain "10.1.2.0/24"
+    # Prefixes outside the range are unaffected.
+    And show command "show ospf route" in namespace "c" should contain "10.0.0.2/32"
+
+    # Teardown.
+    When I stop zebra-rs in namespace "a"
+    And I stop zebra-rs in namespace "b"
+    And I stop zebra-rs in namespace "c"
+    And I delete namespace "a"
+    And I delete namespace "b"
+    And I delete namespace "c"
+    Then the test environment should be clean

--- a/bdd/tests/features/ospfv3_area_range.feature
+++ b/bdd/tests/features/ospfv3_area_range.feature
@@ -1,0 +1,87 @@
+@serial
+@ospfv3_area_range
+Feature: OSPFv3 area ranges aggregate Inter-Area-Prefix-LSAs at the ABR
+  As a network operator
+  I want `area <id> range <prefix>` on an OSPFv3 ABR to fold that
+  area's intra-area routes into one aggregate Inter-Area-Prefix-LSA
+  (RFC 2328 §12.4.3 over the RFC 5340 LSA model) — or hide the whole
+  range with `not-advertise` — mirroring ospfv2_area_range.
+
+  Test Topology (v6 mirror of ospfv2_area_range):
+  ```
+       area 0.0.0.1                            area 0.0.0.0
+    b -- 2001:db8:12::/64 -- a (ABR) -- 2001:db8:13::/64 -- c
+    r1 2001:db8:1:1::/64  <- inside the   area 0.0.0.1
+    r2 2001:db8:1:2::/64  <- 2001:db8:1::/48 range
+    lo 2001:db8::2/128    <- outside the range
+  ```
+
+  Scenario: Components fold into one aggregate; prefixes outside the range still advertise
+    Given a clean test environment
+    When I create namespace "a"
+    And I create namespace "b"
+    And I create namespace "c"
+    And I connect namespace "a" interface "ethb" to namespace "b" interface "etha"
+    And I connect namespace "a" interface "ethc" to namespace "c" interface "etha"
+    And I create dummy interface "r1" with address "2001:db8:1:1::1/64" in namespace "b"
+    And I create dummy interface "r2" with address "2001:db8:1:2::1/64" in namespace "b"
+    And I start zebra-rs in namespace "a"
+    And I start zebra-rs in namespace "b"
+    And I start zebra-rs in namespace "c"
+    And I apply config "a.yaml" to namespace "a"
+    And I apply config "b.yaml" to namespace "b"
+    And I apply config "c.yaml" to namespace "c"
+    And I wait 40 seconds
+
+    Then show command "show ospfv3 neighbor" in namespace "a" should contain "Full"
+    And show command "show ospfv3 neighbor" in namespace "c" should contain "Full"
+    # The aggregate at largest-component metric 20 + c's link 10.
+    And show command "show ospfv3 route" in namespace "c" should contain "2001:db8:1::/48 metric 30"
+    # The components must NOT leak individually.
+    And show command "show ospfv3 route" in namespace "c" should not contain "2001:db8:1:1::/64"
+    And show command "show ospfv3 route" in namespace "c" should not contain "2001:db8:1:2::/64"
+    # Outside the range: still summarized individually.
+    And show command "show ospfv3 route" in namespace "c" should contain "2001:db8::2/128"
+    # Traffic to a component follows the aggregate end to end.
+    And ping from "c" to "2001:db8:1:1::1" should succeed
+
+    # Teardown.
+    When I stop zebra-rs in namespace "a"
+    And I stop zebra-rs in namespace "b"
+    And I stop zebra-rs in namespace "c"
+    And I delete namespace "a"
+    And I delete namespace "b"
+    And I delete namespace "c"
+    Then the test environment should be clean
+
+  Scenario: not-advertise hides the aggregate and the components
+    Given a clean test environment
+    When I create namespace "a"
+    And I create namespace "b"
+    And I create namespace "c"
+    And I connect namespace "a" interface "ethb" to namespace "b" interface "etha"
+    And I connect namespace "a" interface "ethc" to namespace "c" interface "etha"
+    And I create dummy interface "r1" with address "2001:db8:1:1::1/64" in namespace "b"
+    And I create dummy interface "r2" with address "2001:db8:1:2::1/64" in namespace "b"
+    And I start zebra-rs in namespace "a"
+    And I start zebra-rs in namespace "b"
+    And I start zebra-rs in namespace "c"
+    And I apply config "a_na.yaml" to namespace "a"
+    And I apply config "b.yaml" to namespace "b"
+    And I apply config "c.yaml" to namespace "c"
+    And I wait 40 seconds
+
+    Then show command "show ospfv3 neighbor" in namespace "c" should contain "Full"
+    And show command "show ospfv3 route" in namespace "c" should not contain "2001:db8:1::/48"
+    And show command "show ospfv3 route" in namespace "c" should not contain "2001:db8:1:1::/64"
+    And show command "show ospfv3 route" in namespace "c" should not contain "2001:db8:1:2::/64"
+    And show command "show ospfv3 route" in namespace "c" should contain "2001:db8::2/128"
+
+    # Teardown.
+    When I stop zebra-rs in namespace "a"
+    And I stop zebra-rs in namespace "b"
+    And I stop zebra-rs in namespace "c"
+    And I delete namespace "a"
+    And I delete namespace "b"
+    And I delete namespace "c"
+    Then the test environment should be clean

--- a/book/src/ch-08-11-ospf-frr-cross-reference.md
+++ b/book/src/ch-08-11-ospf-frr-cross-reference.md
@@ -20,6 +20,7 @@ configuration surface to the equivalent FRR `ospfd` commands.
 | `area/<id>/nssa-default-originate true` | `area <id> nssa default-information-originate` |
 | `area/<id>/nssa-suppress-fa true` | `area <id> nssa suppress-fa` |
 | `area/<id>/nssa-translator-role` | `area <id> nssa translate-candidate` / `translate-always` / `translate-never` |
+| `area/<id>/range <prefix> { not-advertise; cost; }` | `area <id> range <prefix> [not-advertise \| cost <c>]` |
 | `redistribute <connected\|static\|kernel\|isis\|bgp> { metric; metric-type; }` | `redistribute <source> metric <m> metric-type <1\|2>` |
 | `area/<id>/interface/<n>/authentication simple` + `authentication-key` | `ip ospf authentication` + `ip ospf authentication-key` (interface) |
 | `area/<id>/interface/<n>/authentication message-digest` + `message-digest-key <id> { md5; }` | `ip ospf authentication message-digest` + `ip ospf message-digest-key <id> md5 <key>` (interface) |

--- a/book/src/ch-08-12-ospf-frr-gaps.md
+++ b/book/src/ch-08-12-ospf-frr-gaps.md
@@ -3,8 +3,8 @@
 OSPFv2 features not yet implemented in zebra-rs:
 
 - Virtual links across non-backbone areas.
-- Area ranges (`area <id> range` Type-3 summary aggregation and
-  suppression at the ABR).
+- Discard (Null0) routes for active area ranges — the aggregation
+  and suppression themselves are implemented.
 - Passive interfaces (advertise a prefix without forming
   adjacencies on it).
 - Instance-level `default-information originate` (Type-5 default

--- a/book/src/ch-08-14-ospf-multi-area-abr.md
+++ b/book/src/ch-08-14-ospf-multi-area-abr.md
@@ -56,9 +56,41 @@ standard backbone split-horizon:
   see [Area Types](ch-08-13-ospf-area-types.md)) receive no Type-3
   at all.
 
-There is no `area range` prefix aggregation yet — each routing
-table entry becomes its own Type-3 (see
-[Gaps Relative to FRR ospfd](ch-08-12-ospf-frr-gaps.md)).
+## Area ranges
+
+`area <id> range <prefix>` condenses an area's own intra-area
+routes at the ABR (RFC 2328 §12.4.3): components falling inside a
+configured range are not advertised individually — one aggregate
+Type-3 is originated instead, as long as at least one component
+exists.
+
+```
+router ospf {
+  area 0.0.0.1 {
+    range 10.1.0.0/16;
+    range 10.9.0.0/16 {
+      not-advertise true;
+    }
+    interface enp0s7 {
+      enable true;
+    }
+  }
+}
+```
+
+| YANG leaf (`/router/ospf/area/<id>/range/<prefix>/…`) | Default | Notes |
+|---|---|---|
+| `<prefix>` | list key | The aggregate to advertise. |
+| `not-advertise` | `false` | Hide the whole range — no aggregate, no components. |
+| `cost` | — (largest component) | Fixed aggregate metric instead of the RFC's largest-component rule. |
+
+The most-specific configured range wins when several contain a
+component. Ranges apply only to the area's own intra-area routes —
+inter-area routes re-advertised from the backbone pass through
+unaffected — and prefixes outside every range keep advertising
+individually. The RFC's companion discard route for active ranges
+(FRR's Null0) is not installed yet; see
+[Gaps Relative to FRR ospfd](ch-08-12-ospf-frr-gaps.md).
 
 ## Type-4 ASBR-Summary origination
 

--- a/book/src/ch-15-04-ospfv3-multi-area-abr.md
+++ b/book/src/ch-15-04-ospfv3-multi-area-abr.md
@@ -67,8 +67,27 @@ use), and the prefix itself rides in the LSA body.
 The whole path — two ABRs, three areas, cross-area reachability in
 both directions, and cost-honoring metrics — is BDD-validated by
 `ospfv3_multi_area.feature`, the v6 mirror of the v2 multi-area
-topology. Area ranges (`area <id> range` aggregation) remain
-unimplemented for both versions — see
-[Gaps Relative to FRR ospf6d](ch-15-15-ospfv3-frr-gaps.md). For the
-v2 behavior this chapter mirrors, see
+topology. For the v2 behavior this chapter mirrors, see
 [Multi-Area Routing and the ABR](ch-08-14-ospf-multi-area-abr.md).
+
+## Area ranges
+
+`area <id> range <prefix>` aggregates exactly as in OSPFv2 — the
+area's intra-area components fold into one Inter-Area-Prefix-LSA at
+the largest component metric (or a fixed `cost`), `not-advertise`
+hides the whole range, and the most-specific range wins:
+
+```
+router ospfv3 {
+  area 0.0.0.1 {
+    range 2001:db8:1::/48;
+    interface enp0s7 {
+      enable true;
+    }
+  }
+}
+```
+
+The `not-advertise` and `cost` leaves match
+[the v2 page's table](ch-08-14-ospf-multi-area-abr.md); the discard
+route for active ranges is likewise not installed yet.

--- a/book/src/ch-15-14-ospfv3-frr-cross-reference.md
+++ b/book/src/ch-15-14-ospfv3-frr-cross-reference.md
@@ -20,6 +20,7 @@ interface to an area with a per-interface command.
 | `area/<id>/area-type stub` | `area <id> stub` |
 | `area/<id>/area-type nssa` | `area <id> nssa` |
 | `area/<id>/no-summary true` | `area <id> stub no-summary` / `area <id> nssa no-summary` |
+| `area/<id>/range <prefix> { not-advertise; cost; }` | `area <id> range <prefix> [not-advertise \| cost <c>]` |
 | `redistribute <connected\|static\|kernel\|isis\|bgp> { metric; metric-type; }` | `redistribute <source> metric <m> metric-type <1\|2>` |
 | `clear ospfv3 neighbor` | `clear ipv6 ospf6 interface [IFNAME]` |
 | `show ospfv3 neighbor / database / route` | `show ipv6 ospf6 neighbor / database / route` |

--- a/book/src/ch-15-15-ospfv3-frr-gaps.md
+++ b/book/src/ch-15-15-ospfv3-frr-gaps.md
@@ -2,7 +2,8 @@
 
 OSPFv3 features not yet implemented in zebra-rs:
 
-- Area ranges (`area <id> range` prefix aggregation).
+- Discard (Null0) routes for active area ranges — the aggregation
+  and suppression themselves are implemented.
 - Redistribution `route-map` filtering (the zebra-rs sources are
   connected, static, kernel, IS-IS, and BGP, matching v2).
 - Graceful-restart configuration and restarter mode — v3 is

--- a/zebra-rs/src/config/manager.rs
+++ b/zebra-rs/src/config/manager.rs
@@ -3523,4 +3523,30 @@ mod yang_load_tests {
             }
         }
     }
+    /// `area <id> range <prefix> [not-advertise|cost]` — RFC 2328
+    /// §12.4.3 aggregation, v2 and v3. Pin every spelling settable.
+    #[test]
+    fn ospf_area_range_paths_parse() {
+        use crate::config::ExecCode;
+        use crate::config::parse::{State, parse};
+        use libyang::to_entry;
+
+        let mut yang = YangStore::new();
+        yang.add_path(concat!(env!("CARGO_MANIFEST_DIR"), "/yang"));
+        yang.read_with_resolve("configure")
+            .expect("configure mode loads");
+        yang.identity_resolve();
+        let module = yang
+            .find_module("configure")
+            .expect("configure module present");
+        let entry = to_entry(&yang, module);
+
+        for (proto, prefix) in [("ospf", "10.1.0.0/16"), ("ospfv3", "2001:db8:1::/48")] {
+            for suffix in ["", " not-advertise true", " cost 100"] {
+                let path = format!("set router {proto} area 1 range {prefix}{suffix}");
+                let (code, _comps, _state) = parse(&path, entry.clone(), None, State::new());
+                assert_eq!(code, ExecCode::Success, "`{path}` must be a settable path");
+            }
+        }
+    }
 }

--- a/zebra-rs/src/ospf/area.rs
+++ b/zebra-rs/src/ospf/area.rs
@@ -262,6 +262,28 @@ pub struct OspfArea<V: OspfVersion = Ospfv2> {
     /// Type-4 Summary-ASBR LSA into this area. Flushed when the
     /// ABR loses connectivity to the ASBR or the area.
     pub asbr_summaries_originated: BTreeSet<Ipv4Addr>,
+
+    /// RFC 2328 §12.4.3 address ranges configured on this area
+    /// (`area <id> range <prefix>`), consulted by the ABR summary
+    /// desired-set computation: intra-area routes of this area that
+    /// fall inside a range are folded into one aggregate (largest
+    /// component metric, or the configured cost) or suppressed
+    /// entirely (`not-advertise`). The generic `OspfArea<V>` carries
+    /// both the v4 and v6 maps; each version touches its own.
+    pub ranges: BTreeMap<Ipv4Net, AreaRange>,
+    /// v6 sibling of `ranges` (OSPFv3 Inter-Area-Prefix aggregation).
+    pub ranges_v6: BTreeMap<Ipv6Net, AreaRange>,
+}
+
+/// One configured `area <id> range <prefix>` entry.
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+pub struct AreaRange {
+    /// Suppress the aggregate as well — the whole range (components
+    /// and summary) stays hidden from the other areas.
+    pub not_advertise: bool,
+    /// Advertise the aggregate at this fixed cost instead of the
+    /// largest component metric.
+    pub cost: Option<u32>,
 }
 
 impl<V: OspfVersion> OspfArea<V> {
@@ -279,6 +301,8 @@ impl<V: OspfVersion> OspfArea<V> {
             redist_connected_originated_v6: BTreeSet::new(),
             nssa_translated: BTreeSet::new(),
             asbr_summaries_originated: BTreeSet::new(),
+            ranges: BTreeMap::new(),
+            ranges_v6: BTreeMap::new(),
         }
     }
 }

--- a/zebra-rs/src/ospf/config.rs
+++ b/zebra-rs/src/ospf/config.rs
@@ -50,6 +50,12 @@ impl Ospf {
             "/area/redistribute/connected/metric-type",
             config_ospf_area_redist_connected_metric_type,
         );
+        self.ospf_add("/area/range", config_ospf_area_range);
+        self.ospf_add(
+            "/area/range/not-advertise",
+            config_ospf_area_range_not_advertise,
+        );
+        self.ospf_add("/area/range/cost", config_ospf_area_range_cost);
         self.ospf_add("/area/interface/enable", config_ospf_interface_enable);
         self.ospf_add(
             "/area/interface/bfd/enable",
@@ -654,6 +660,58 @@ ospf_redist_handlers!(
     config_ospf_redist_isis_metric_type,
     crate::rib::RibType::Isis
 );
+
+/// `/router/ospf/area/<id>/range` — one RFC 2328 §12.4.3 address
+/// range entry (list keyed by prefix). Set creates it with defaults
+/// (advertise, largest-component metric); delete removes it. Either
+/// way the ABR summary reconciliation re-runs so aggregation applies
+/// immediately.
+fn config_ospf_area_range(ospf: &mut Ospf, mut args: Args, op: ConfigOp) -> Option<()> {
+    let area_id = parse_area_id(&args.string()?)?;
+    let prefix = args.v4net()?.trunc();
+    if op.is_set() {
+        ospf.areas.fetch(area_id).ranges.entry(prefix).or_default();
+    } else if let Some(area) = ospf.areas.get_mut(area_id) {
+        area.ranges.remove(&prefix);
+    }
+    ospf.abr_summary_originate();
+    Some(())
+}
+
+/// `/router/ospf/area/<id>/range/<prefix>/not-advertise`.
+fn config_ospf_area_range_not_advertise(
+    ospf: &mut Ospf,
+    mut args: Args,
+    op: ConfigOp,
+) -> Option<()> {
+    let area_id = parse_area_id(&args.string()?)?;
+    let prefix = args.v4net()?.trunc();
+    let value = if op.is_set() { args.boolean()? } else { false };
+    ospf.areas
+        .fetch(area_id)
+        .ranges
+        .entry(prefix)
+        .or_default()
+        .not_advertise = value;
+    ospf.abr_summary_originate();
+    Some(())
+}
+
+/// `/router/ospf/area/<id>/range/<prefix>/cost` — fixed aggregate
+/// metric; delete reverts to largest-component.
+fn config_ospf_area_range_cost(ospf: &mut Ospf, mut args: Args, op: ConfigOp) -> Option<()> {
+    let area_id = parse_area_id(&args.string()?)?;
+    let prefix = args.v4net()?.trunc();
+    let cost = if op.is_set() { Some(args.u32()?) } else { None };
+    ospf.areas
+        .fetch(area_id)
+        .ranges
+        .entry(prefix)
+        .or_default()
+        .cost = cost;
+    ospf.abr_summary_originate();
+    Some(())
+}
 
 /// `/router/ospf/area/<id>/redistribute/connected` — presence
 /// container. On Set: create the area's `RedistEntry` with

--- a/zebra-rs/src/ospf/config_v3.rs
+++ b/zebra-rs/src/ospf/config_v3.rs
@@ -66,6 +66,12 @@ impl Ospf<Ospfv3> {
                 "/area/redistribute/connected/metric-type",
                 config_ospfv3_area_redist_connected_metric_type,
             ),
+            ("/area/range", config_ospfv3_area_range),
+            (
+                "/area/range/not-advertise",
+                config_ospfv3_area_range_not_advertise,
+            ),
+            ("/area/range/cost", config_ospfv3_area_range_cost),
             ("/redistribute/connected", config_ospfv3_redist_connected),
             (
                 "/redistribute/connected/metric",
@@ -641,6 +647,62 @@ ospfv3_redist_handlers!(
     config_ospfv3_redist_bgp_metric_type,
     crate::rib::RibType::Bgp
 );
+
+/// `/router/ospfv3/area/<id>/range` — v3 sibling of
+/// `config_ospf_area_range` (Inter-Area-Prefix aggregation).
+fn config_ospfv3_area_range(ospf: &mut Ospf<Ospfv3>, mut args: Args, op: ConfigOp) -> Option<()> {
+    let area_id = parse_area_id(&args.string()?)?;
+    let prefix = args.v6net()?.trunc();
+    if op.is_set() {
+        ospf.areas
+            .fetch(area_id)
+            .ranges_v6
+            .entry(prefix)
+            .or_default();
+    } else if let Some(area) = ospf.areas.get_mut(area_id) {
+        area.ranges_v6.remove(&prefix);
+    }
+    ospf.abr_summary_originate_v3();
+    Some(())
+}
+
+/// `/router/ospfv3/area/<id>/range/<prefix>/not-advertise`.
+fn config_ospfv3_area_range_not_advertise(
+    ospf: &mut Ospf<Ospfv3>,
+    mut args: Args,
+    op: ConfigOp,
+) -> Option<()> {
+    let area_id = parse_area_id(&args.string()?)?;
+    let prefix = args.v6net()?.trunc();
+    let value = if op.is_set() { args.boolean()? } else { false };
+    ospf.areas
+        .fetch(area_id)
+        .ranges_v6
+        .entry(prefix)
+        .or_default()
+        .not_advertise = value;
+    ospf.abr_summary_originate_v3();
+    Some(())
+}
+
+/// `/router/ospfv3/area/<id>/range/<prefix>/cost`.
+fn config_ospfv3_area_range_cost(
+    ospf: &mut Ospf<Ospfv3>,
+    mut args: Args,
+    op: ConfigOp,
+) -> Option<()> {
+    let area_id = parse_area_id(&args.string()?)?;
+    let prefix = args.v6net()?.trunc();
+    let cost = if op.is_set() { Some(args.u32()?) } else { None };
+    ospf.areas
+        .fetch(area_id)
+        .ranges_v6
+        .entry(prefix)
+        .or_default()
+        .cost = cost;
+    ospf.abr_summary_originate_v3();
+    Some(())
+}
 
 /// `/router/ospfv3/area/<id>/redistribute/connected` — presence
 /// container. Mirrors v2's `config_ospf_area_redist_connected` but

--- a/zebra-rs/src/ospf/inst.rs
+++ b/zebra-rs/src/ospf/inst.rs
@@ -1722,6 +1722,14 @@ impl Ospf<Ospfv2> {
             let Some(rib_b) = self.rib_areas.get(&area_b) else {
                 continue;
             };
+            let ranges_b = self
+                .areas
+                .get(area_b)
+                .map(|a| a.ranges.clone())
+                .unwrap_or_default();
+            // Active ranges of area B this walk: range prefix ->
+            // largest component metric (RFC 2328 §12.4.3).
+            let mut active_ranges: BTreeMap<Ipv4Net, u32> = BTreeMap::new();
             for (prefix, route) in rib_b.iter() {
                 let advertise = match route.path_type {
                     RouteType::IntraArea => true,
@@ -1730,6 +1738,24 @@ impl Ospf<Ospfv2> {
                 };
                 if !advertise || route.metric >= LS_INFINITY {
                     continue;
+                }
+                // Address ranges condense area B's own intra-area
+                // routes: a component inside a configured range is
+                // never advertised individually — it activates the
+                // aggregate instead (most-specific range wins).
+                if route.path_type == RouteType::IntraArea {
+                    if let Some(range_prefix) = ranges_b
+                        .keys()
+                        .filter(|r| r.contains(&prefix))
+                        .max_by_key(|r| r.prefix_len())
+                        .copied()
+                    {
+                        active_ranges
+                            .entry(range_prefix)
+                            .and_modify(|m| *m = (*m).max(route.metric))
+                            .or_insert(route.metric);
+                        continue;
+                    }
                 }
                 // Don't summarize a prefix that A reaches intra-area.
                 let intra_in_a = self
@@ -1744,6 +1770,31 @@ impl Ospf<Ospfv2> {
                 let metric = route.metric.min(LS_INFINITY - 1);
                 desired
                     .entry(prefix)
+                    .and_modify(|m| *m = (*m).min(metric))
+                    .or_insert(metric);
+            }
+            // Fold the aggregates in: an active range advertises one
+            // summary at the largest component metric (or the
+            // configured cost); `not-advertise` hides it entirely.
+            for (range_prefix, max_metric) in active_ranges {
+                let Some(entry) = ranges_b.get(&range_prefix) else {
+                    continue;
+                };
+                if entry.not_advertise {
+                    continue;
+                }
+                let intra_in_a = self
+                    .rib_areas
+                    .get(&area_a)
+                    .and_then(|r| r.get(&range_prefix))
+                    .map(|r| r.path_type == RouteType::IntraArea)
+                    .unwrap_or(false);
+                if intra_in_a {
+                    continue;
+                }
+                let metric = entry.cost.unwrap_or(max_metric).min(LS_INFINITY - 1);
+                desired
+                    .entry(range_prefix)
                     .and_modify(|m| *m = (*m).min(metric))
                     .or_insert(metric);
             }
@@ -6739,6 +6790,14 @@ impl Ospf<Ospfv3> {
             let Some(rib_b) = self.rib6_areas.get(&area_b) else {
                 continue;
             };
+            let ranges_b = self
+                .areas
+                .get(area_b)
+                .map(|a| a.ranges_v6.clone())
+                .unwrap_or_default();
+            // Active ranges of area B this walk: range prefix ->
+            // largest component metric (RFC 2328 §12.4.3).
+            let mut active_ranges: BTreeMap<ipnet::Ipv6Net, u32> = BTreeMap::new();
             for (prefix, route) in rib_b.iter() {
                 let advertise = match route.path_type {
                     RouteType::IntraArea => true,
@@ -6747,6 +6806,23 @@ impl Ospf<Ospfv3> {
                 };
                 if !advertise || route.metric >= OSPFV3_LS_INFINITY {
                     continue;
+                }
+                // Address ranges condense area B's own intra-area
+                // routes — the component activates the aggregate
+                // instead of advertising (most-specific range wins).
+                if route.path_type == RouteType::IntraArea {
+                    if let Some(range_prefix) = ranges_b
+                        .keys()
+                        .filter(|r| r.contains(&prefix))
+                        .max_by_key(|r| r.prefix_len())
+                        .copied()
+                    {
+                        active_ranges
+                            .entry(range_prefix)
+                            .and_modify(|m| *m = (*m).max(route.metric))
+                            .or_insert(route.metric);
+                        continue;
+                    }
                 }
                 let intra_in_a = self
                     .rib6_areas
@@ -6760,6 +6836,30 @@ impl Ospf<Ospfv3> {
                 let metric = route.metric.min(OSPFV3_LS_INFINITY - 1);
                 desired
                     .entry(prefix)
+                    .and_modify(|m| *m = (*m).min(metric))
+                    .or_insert(metric);
+            }
+            // Fold the aggregates in — largest component metric or
+            // the configured cost; `not-advertise` hides the range.
+            for (range_prefix, max_metric) in active_ranges {
+                let Some(entry) = ranges_b.get(&range_prefix) else {
+                    continue;
+                };
+                if entry.not_advertise {
+                    continue;
+                }
+                let intra_in_a = self
+                    .rib6_areas
+                    .get(&area_a)
+                    .and_then(|r| r.get(&range_prefix))
+                    .map(|r| r.path_type == RouteType::IntraArea)
+                    .unwrap_or(false);
+                if intra_in_a {
+                    continue;
+                }
+                let metric = entry.cost.unwrap_or(max_metric).min(OSPFV3_LS_INFINITY - 1);
+                desired
+                    .entry(range_prefix)
                     .and_modify(|m| *m = (*m).min(metric))
                     .or_insert(metric);
             }

--- a/zebra-rs/src/ospf/inst.rs
+++ b/zebra-rs/src/ospf/inst.rs
@@ -1743,19 +1743,18 @@ impl Ospf<Ospfv2> {
                 // routes: a component inside a configured range is
                 // never advertised individually — it activates the
                 // aggregate instead (most-specific range wins).
-                if route.path_type == RouteType::IntraArea {
-                    if let Some(range_prefix) = ranges_b
+                if route.path_type == RouteType::IntraArea
+                    && let Some(range_prefix) = ranges_b
                         .keys()
                         .filter(|r| r.contains(&prefix))
                         .max_by_key(|r| r.prefix_len())
                         .copied()
-                    {
-                        active_ranges
-                            .entry(range_prefix)
-                            .and_modify(|m| *m = (*m).max(route.metric))
-                            .or_insert(route.metric);
-                        continue;
-                    }
+                {
+                    active_ranges
+                        .entry(range_prefix)
+                        .and_modify(|m| *m = (*m).max(route.metric))
+                        .or_insert(route.metric);
+                    continue;
                 }
                 // Don't summarize a prefix that A reaches intra-area.
                 let intra_in_a = self
@@ -6810,19 +6809,18 @@ impl Ospf<Ospfv3> {
                 // Address ranges condense area B's own intra-area
                 // routes — the component activates the aggregate
                 // instead of advertising (most-specific range wins).
-                if route.path_type == RouteType::IntraArea {
-                    if let Some(range_prefix) = ranges_b
+                if route.path_type == RouteType::IntraArea
+                    && let Some(range_prefix) = ranges_b
                         .keys()
                         .filter(|r| r.contains(&prefix))
                         .max_by_key(|r| r.prefix_len())
                         .copied()
-                    {
-                        active_ranges
-                            .entry(range_prefix)
-                            .and_modify(|m| *m = (*m).max(route.metric))
-                            .or_insert(route.metric);
-                        continue;
-                    }
+                {
+                    active_ranges
+                        .entry(range_prefix)
+                        .and_modify(|m| *m = (*m).max(route.metric))
+                        .or_insert(route.metric);
+                    continue;
                 }
                 let intra_in_a = self
                     .rib6_areas

--- a/zebra-rs/yang/config.yang
+++ b/zebra-rs/yang/config.yang
@@ -681,6 +681,29 @@ module config {
               }
             }
           }
+          // RFC 2328 §12.4.3 address ranges: at an ABR, intra-area
+          // routes of THIS area that fall inside a range are not
+          // advertised individually into the other areas — one
+          // aggregate is advertised instead, at the largest component
+          // metric (or the configured `cost`). `not-advertise`
+          // suppresses the aggregate too, hiding the whole range.
+          // Ranges never apply to routes re-advertised from other
+          // areas.
+          list range {
+            key "prefix";
+            leaf prefix {
+              type inet:ipv4-prefix;
+            }
+            leaf not-advertise {
+              type boolean;
+              default false;
+            }
+            leaf cost {
+              type uint32 {
+                range "0..16777214";
+              }
+            }
+          }
           list interface {
             key "if-name";
             leaf if-name {
@@ -1359,6 +1382,29 @@ module config {
                   enum type-2;
                 }
                 default type-2;
+              }
+            }
+          }
+          // RFC 2328 §12.4.3 address ranges: at an ABR, intra-area
+          // routes of THIS area that fall inside a range are not
+          // advertised individually into the other areas — one
+          // aggregate is advertised instead, at the largest component
+          // metric (or the configured `cost`). `not-advertise`
+          // suppresses the aggregate too, hiding the whole range.
+          // Ranges never apply to routes re-advertised from other
+          // areas.
+          list range {
+            key "prefix";
+            leaf prefix {
+              type inet:ipv6-prefix;
+            }
+            leaf not-advertise {
+              type boolean;
+              default false;
+            }
+            leaf cost {
+              type uint32 {
+                range "0..16777214";
               }
             }
           }


### PR DESCRIPTION
## Summary

Implements `area <id> range <prefix> [not-advertise] [cost <c>]` for OSPFv2 and OSPFv3 (RFC 2328 §12.4.3), closing the area-range gap against FRR:

- In the ABR's desired-set computation, intra-area routes of the range's own area that fall inside a configured range are no longer advertised individually — they activate one aggregate (Type-3 for v2, Inter-Area-Prefix-LSA for v3) at the largest component metric, or a fixed `cost`. `not-advertise` suppresses the aggregate too, hiding the whole range.
- The most-specific containing range wins; inter-area routes re-advertised from the backbone pass through unaffected; a range with no live component advertises nothing. Config changes re-run the diff-gated summary reconciliation immediately.
- Per-area storage (`ranges`/`ranges_v6` on `OspfArea`), YANG lists under both `router ospf area` and `router ospfv3 area`, handlers for both versions.
- The RFC's companion discard (Null0) route for active ranges is deferred — the RIB has no blackhole nexthop type yet; documented in both gaps pages.
- Book: area-range sections on both multi-area pages, FRR cross-reference rows, gaps pages narrowed to the discard route.

## Test plan

- Parse regression test pins all six spellings (`range`, `not-advertise`, `cost` × v2/v3).
- New BDD features pass first run: `ospfv2_area_range` and `ospfv3_area_range` (2 scenarios each) — aggregate present at the largest-component metric (asserted numerically), components never leak, out-of-range prefixes unaffected, ping through the aggregate works, `not-advertise` hides everything.
- `cargo fmt --check`, clippy `-D warnings` (default and no-lua), `cargo test --workspace --exclude bdd` (2133 passed, 0 failed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)