### PR TITLE
Tee End.M mirror-context routes into cradle

### DIFF
--- a/proto/cradle.proto
+++ b/proto/cradle.proto
@@ -134,6 +134,25 @@ message ReplSlot {
   string remote_sid = 2;
 }
 
+// An egress-protection mirror route (End.M context): traffic exposed by an
+// End.M decap whose destination falls in `prefix` (the FAILED egress PE's
+// SID space) is served locally with DT-style semantics — decap once more
+// and look the inner packet up in `vrf_table_id`. `ctx` scopes the entry to
+// the End.M SID's context id.
+message MirrorRoute {
+  uint32 ctx          = 1;
+  string prefix       = 2;  // the protected locator, e.g. fcbb:bbbb:3::/48
+  uint32 prefix_len   = 3;
+  uint32 behavior     = 4;  // SRV6_BH_END_DT4/DT6/DT46
+  uint32 vrf_table_id = 5;
+}
+
+message MirrorRouteDel {
+  uint32 ctx        = 1;
+  string prefix     = 2;
+  uint32 prefix_len = 3;
+}
+
 // Subscribe to datapath MAC learning (EVPN over SRv6): cradle streams every
 // locally-learned (mac, bridge-domain) so the control plane can originate
 // EVPN Type-2 routes for it. Only local entries are reported (never
@@ -242,6 +261,8 @@ service Cradle {
   rpc WatchFdb(WatchFdbRequest) returns (stream FdbEvent);
   rpc AddReplSlot(ReplSlot) returns (Empty);
   rpc DelReplSlot(ReplSlot) returns (Empty);
+  rpc AddMirrorRoute(MirrorRoute) returns (Empty);
+  rpc DelMirrorRoute(MirrorRouteDel) returns (Empty);
   rpc AddService(Service) returns (Empty);
   rpc GetStats(StatsRequest) returns (StatsReply);
   rpc AddL7Service(L7Service) returns (Empty);

--- a/zebra-rs/src/fib/cradle.rs
+++ b/zebra-rs/src/fib/cradle.rs
@@ -63,7 +63,7 @@ fn srv6_behavior(b: crate::rib::SidBehavior) -> u32 {
         UALib => 8,    // compressed carrier: shift + adjacency
         EndDT2U => 9,  // EVPN L2 unicast decap+bridge
         EndDT2M => 10, // EVPN L2 BUM decap+flood
-        EndM => 3,     // mirror-context ~ End.DT6 (best-effort; not implemented)
+        EndM => 11,    // egress-protection mirror (decap + mirror-context lookup)
     }
 }
 
@@ -683,6 +683,49 @@ impl CradleFib {
         .await;
         if let Err(e) = result {
             tracing::warn!("fib: cradle repl_slot_del vni {vni} {sid} failed: {e}");
+        }
+    }
+
+    /// Install an egress-protection mirror route (the End.M context): the
+    /// protected egress PE's locator `prefix` reproduces locally as an
+    /// `End.DT46` decap into `vrf_table` — the cradle twin of the kernel's
+    /// mirror-context-table route.
+    pub async fn mirror_route_add(&self, ctx: u32, prefix: ipnet::Ipv6Net, vrf_table: u32) {
+        let result = async {
+            self.client()
+                .await?
+                .add_mirror_route(pb::MirrorRoute {
+                    ctx,
+                    prefix: prefix.addr().to_string(),
+                    prefix_len: prefix.prefix_len() as u32,
+                    behavior: 4, // SRV6_BH_END_DT46
+                    vrf_table_id: cradle_vrf(vrf_table),
+                })
+                .await?;
+            anyhow::Ok(())
+        }
+        .await;
+        if let Err(e) = result {
+            tracing::warn!("fib: cradle mirror_route_add {prefix} failed: {e}");
+        }
+    }
+
+    /// Remove a mirror route.
+    pub async fn mirror_route_del(&self, ctx: u32, prefix: ipnet::Ipv6Net) {
+        let result = async {
+            self.client()
+                .await?
+                .del_mirror_route(pb::MirrorRouteDel {
+                    ctx,
+                    prefix: prefix.addr().to_string(),
+                    prefix_len: prefix.prefix_len() as u32,
+                })
+                .await?;
+            anyhow::Ok(())
+        }
+        .await;
+        if let Err(e) = result {
+            tracing::warn!("fib: cradle mirror_route_del {prefix} failed: {e}");
         }
     }
 

--- a/zebra-rs/src/fib/netlink/handle.rs
+++ b/zebra-rs/src/fib/netlink/handle.rs
@@ -1866,6 +1866,11 @@ impl FibHandle {
         vrf_table: u32,
         ifindex: u32,
     ) {
+        if let Some(cradle) = &self.cradle {
+            cradle
+                .mirror_route_add(context_table, *prefix, vrf_table)
+                .await;
+        }
         let mut msg = RouteMessage::default();
         msg.header.address_family = AddressFamily::Inet6;
         set_route_table(&mut msg, context_table);
@@ -1914,6 +1919,9 @@ impl FibHandle {
     /// matches RTM_DELROUTE on (table, family, dst, prefixlen, kind), so
     /// only the prefix and context table are needed.
     pub async fn route_mirror_context_uninstall(&self, prefix: &Ipv6Net, context_table: u32) {
+        if let Some(cradle) = &self.cradle {
+            cradle.mirror_route_del(context_table, *prefix).await;
+        }
         let mut msg = RouteMessage::default();
         msg.header.address_family = AddressFamily::Inet6;
         set_route_table(&mut msg, context_table);


### PR DESCRIPTION
## Summary
- Map `SidBehavior::EndM` to cradle behavior 11 (native End.M) instead of the best-effort End.DT6 (3).
- New `CradleFib::mirror_route_add` / `mirror_route_del`, teeing `route_mirror_context_install` / `route_mirror_context_uninstall`: the protected locator reproduces in cradle's `MIRROR` trie as an End.DT46 decap into the via-vrf table, scoped by the mirror-context id.
- Proto synced from cradle-rs (`AddMirrorRoute` / `DelMirrorRoute`).

The End.M SID itself and the PLR-side retention/backup routes already flow through the existing SID and route tees.

## Test plan
- `cargo fmt --check`, `clippy --workspace --all-targets`, `clippy -p zebra-rs --no-default-features`, `cargo test -p zebra-rs` (1504 passed) — all clean locally.
- End-to-end proof in cradle-rs's `cradle_endm` BDD: egress PE node death; the BGP VPNv6-over-SRv6 ping survives via the protector's End.M, double-decapped in XDP (plus a 10-feature regression sweep, all green).

Generated with [Claude Code](https://claude.com/claude-code)