### PR TITLE
ospf: passive interfaces for OSPFv2 and OSPFv3

### DIFF
--- a/bdd/tests/configs/ospfv2_passive/a.yaml
+++ b/bdd/tests/configs/ospfv2_passive/a.yaml
@@ -1,0 +1,18 @@
+interface:
+- if-name: lo
+  ipv4:
+    address: 10.0.0.1/32
+- if-name: ethb
+  ipv4:
+    address: 10.0.12.1/30
+router:
+  ospf:
+    router-id: 10.0.0.1
+    area:
+    - area-id: 0.0.0.0
+      interface:
+      - if-name: lo
+        enable: true
+      - if-name: ethb
+        enable: true
+        network-type: point-to-point

--- a/bdd/tests/configs/ospfv2_passive/b.yaml
+++ b/bdd/tests/configs/ospfv2_passive/b.yaml
@@ -1,0 +1,28 @@
+# ethc is passive: its /30 keeps advertising into the area as a stub
+# prefix, but b sends and accepts no Hellos on it — c never becomes a
+# neighbor.
+interface:
+- if-name: lo
+  ipv4:
+    address: 10.0.0.2/32
+- if-name: etha
+  ipv4:
+    address: 10.0.12.2/30
+- if-name: ethc
+  ipv4:
+    address: 10.0.23.1/30
+router:
+  ospf:
+    router-id: 10.0.0.2
+    area:
+    - area-id: 0.0.0.0
+      interface:
+      - if-name: lo
+        enable: true
+      - if-name: etha
+        enable: true
+        network-type: point-to-point
+      - if-name: ethc
+        enable: true
+        network-type: point-to-point
+        passive: true

--- a/bdd/tests/configs/ospfv2_passive/c.yaml
+++ b/bdd/tests/configs/ospfv2_passive/c.yaml
@@ -1,0 +1,20 @@
+# c actively runs OSPF toward b's passive interface — the adjacency
+# must never form.
+interface:
+- if-name: lo
+  ipv4:
+    address: 10.0.0.3/32
+- if-name: ethb
+  ipv4:
+    address: 10.0.23.2/30
+router:
+  ospf:
+    router-id: 10.0.0.3
+    area:
+    - area-id: 0.0.0.0
+      interface:
+      - if-name: lo
+        enable: true
+      - if-name: ethb
+        enable: true
+        network-type: point-to-point

--- a/bdd/tests/configs/ospfv3_passive/a.yaml
+++ b/bdd/tests/configs/ospfv3_passive/a.yaml
@@ -1,0 +1,18 @@
+interface:
+- if-name: lo
+  ipv6:
+    address: 2001:db8::1/128
+- if-name: ethb
+  ipv6:
+    address: 2001:db8:12::1/64
+router:
+  ospfv3:
+    router-id: 10.0.0.1
+    area:
+    - area-id: 0.0.0.0
+      interface:
+      - if-name: lo
+        enable: true
+      - if-name: ethb
+        enable: true
+        network-type: point-to-point

--- a/bdd/tests/configs/ospfv3_passive/b.yaml
+++ b/bdd/tests/configs/ospfv3_passive/b.yaml
@@ -1,0 +1,27 @@
+# ethc is passive: its /64 keeps advertising (Intra-Area-Prefix-LSA)
+# but no Hello flows on it — c never becomes a neighbor.
+interface:
+- if-name: lo
+  ipv6:
+    address: 2001:db8::2/128
+- if-name: etha
+  ipv6:
+    address: 2001:db8:12::2/64
+- if-name: ethc
+  ipv6:
+    address: 2001:db8:23::1/64
+router:
+  ospfv3:
+    router-id: 10.0.0.2
+    area:
+    - area-id: 0.0.0.0
+      interface:
+      - if-name: lo
+        enable: true
+      - if-name: etha
+        enable: true
+        network-type: point-to-point
+      - if-name: ethc
+        enable: true
+        network-type: point-to-point
+        passive: true

--- a/bdd/tests/configs/ospfv3_passive/c.yaml
+++ b/bdd/tests/configs/ospfv3_passive/c.yaml
@@ -1,0 +1,18 @@
+interface:
+- if-name: lo
+  ipv6:
+    address: 2001:db8::3/128
+- if-name: ethb
+  ipv6:
+    address: 2001:db8:23::2/64
+router:
+  ospfv3:
+    router-id: 10.0.0.3
+    area:
+    - area-id: 0.0.0.0
+      interface:
+      - if-name: lo
+        enable: true
+      - if-name: ethb
+        enable: true
+        network-type: point-to-point

--- a/bdd/tests/features/ospfv2_passive.feature
+++ b/bdd/tests/features/ospfv2_passive.feature
@@ -1,0 +1,58 @@
+@serial
+@ospfv2_passive
+Feature: OSPFv2 passive interfaces advertise their prefix without forming adjacencies
+  As a network operator
+  I want `area <id> interface <n> passive true` to keep advertising
+  the interface's prefix into the area while sending and accepting no
+  Hellos — so stub networks are reachable without exposing an
+  adjacency on them.
+
+  Test Topology:
+  ```
+    a (10.0.0.1) -- 10.0.12.0/30 -- b (10.0.0.2) -- 10.0.23.0/30 -- c (10.0.0.3)
+                     active link       ethc PASSIVE on b   c runs OSPF actively
+
+    on router X the interface toward router Y is named "ethY".
+  ```
+
+  b's ethc is passive. Its /30 must appear in a's routing table (the
+  stub prefix rides b's Router-LSA), while c — actively speaking OSPF
+  on that segment — must never become b's neighbor.
+
+  Scenario: Passive interface prefix advertises; no adjacency forms across it
+    Given a clean test environment
+    When I create namespace "a"
+    And I create namespace "b"
+    And I create namespace "c"
+    And I connect namespace "a" interface "ethb" to namespace "b" interface "etha"
+    And I connect namespace "b" interface "ethc" to namespace "c" interface "ethb"
+    And I start zebra-rs in namespace "a"
+    And I start zebra-rs in namespace "b"
+    And I start zebra-rs in namespace "c"
+    And I apply config "a.yaml" to namespace "a"
+    And I apply config "b.yaml" to namespace "b"
+    And I apply config "c.yaml" to namespace "c"
+    # Long enough that a c-b adjacency would certainly have formed if
+    # the passive gate leaked a single Hello in either direction.
+    And I wait 40 seconds
+
+    # The active link works normally.
+    Then show command "show ospf neighbor" in namespace "a" should contain "Full"
+    And show command "show ospf neighbor" in namespace "a" should contain "10.0.0.2"
+    # The passive interface's prefix is advertised as a stub network.
+    And show command "show ospf route" in namespace "a" should contain "10.0.23.0/30"
+    And ping from "a" to "10.0.23.1" should succeed
+    # No adjacency across the passive link, in either direction.
+    And show command "show ospf neighbor" in namespace "b" should not contain "10.0.0.3"
+    And show command "show ospf neighbor" in namespace "c" should not contain "10.0.0.2"
+    # The passive interface reports its state.
+    And show command "show ospf interface" in namespace "b" should contain "No Hellos (Passive interface)"
+
+    # Teardown.
+    When I stop zebra-rs in namespace "a"
+    And I stop zebra-rs in namespace "b"
+    And I stop zebra-rs in namespace "c"
+    And I delete namespace "a"
+    And I delete namespace "b"
+    And I delete namespace "c"
+    Then the test environment should be clean

--- a/bdd/tests/features/ospfv3_passive.feature
+++ b/bdd/tests/features/ospfv3_passive.feature
@@ -1,0 +1,46 @@
+@serial
+@ospfv3_passive
+Feature: OSPFv3 passive interfaces advertise their prefix without forming adjacencies
+  As a network operator
+  I want `area <id> interface <n> passive true` on OSPFv3 to keep
+  advertising the interface's prefix (Intra-Area-Prefix-LSA) while
+  sending and accepting no Hellos — mirroring ospfv2_passive.
+
+  Test Topology (v6 mirror of ospfv2_passive):
+  ```
+    a -- 2001:db8:12::/64 -- b -- 2001:db8:23::/64 -- c
+          active link           ethc PASSIVE on b     c active
+  ```
+
+  Scenario: Passive interface prefix advertises; no adjacency forms across it
+    Given a clean test environment
+    When I create namespace "a"
+    And I create namespace "b"
+    And I create namespace "c"
+    And I connect namespace "a" interface "ethb" to namespace "b" interface "etha"
+    And I connect namespace "b" interface "ethc" to namespace "c" interface "ethb"
+    And I start zebra-rs in namespace "a"
+    And I start zebra-rs in namespace "b"
+    And I start zebra-rs in namespace "c"
+    And I apply config "a.yaml" to namespace "a"
+    And I apply config "b.yaml" to namespace "b"
+    And I apply config "c.yaml" to namespace "c"
+    And I wait 40 seconds
+
+    Then show command "show ospfv3 neighbor" in namespace "a" should contain "Full"
+    And show command "show ospfv3 neighbor" in namespace "a" should contain "10.0.0.2"
+    # The passive interface's /64 is advertised via Intra-Area-Prefix.
+    And show command "show ospfv3 route" in namespace "a" should contain "2001:db8:23::/64"
+    And ping from "a" to "2001:db8:23::1" should succeed
+    # No adjacency across the passive link, in either direction.
+    And show command "show ospfv3 neighbor" in namespace "b" should not contain "10.0.0.3"
+    And show command "show ospfv3 neighbor" in namespace "c" should not contain "10.0.0.2"
+
+    # Teardown.
+    When I stop zebra-rs in namespace "a"
+    And I stop zebra-rs in namespace "b"
+    And I stop zebra-rs in namespace "c"
+    And I delete namespace "a"
+    And I delete namespace "b"
+    And I delete namespace "c"
+    Then the test environment should be clean

--- a/book/src/ch-08-07-ospf-per-interface.md
+++ b/book/src/ch-08-07-ospf-per-interface.md
@@ -14,6 +14,7 @@ The per-link timers (`hello-interval`, `dead-interval`,
 | `/router/ospf/area/<id>/interface/<n>/priority` | 64 | 0..255 | (count) |
 | `/router/ospf/area/<id>/interface/<n>/cost` | 10 | 0..65535 | (metric) |
 | `/router/ospf/area/<id>/interface/<n>/mtu-ignore` | `false` | — | boolean |
+| `/router/ospf/area/<id>/interface/<n>/passive` | `false` | — | boolean |
 
 Notes:
 
@@ -44,3 +45,11 @@ Notes:
   to `true` only when intentionally peering across links with
   different MTUs and accepting the resulting black-hole risk for
   jumbo packets.
+- **`passive`** keeps advertising the interface's prefix into the
+  area (as a stub network in the Router-LSA) while sending and
+  accepting no Hellos — no adjacency ever forms on the segment.
+  Use it for user-facing networks that must be reachable without
+  exposing an OSPF speaker. Loopback interfaces are implicitly
+  passive regardless of this leaf. Toggling bounces the interface
+  so an adjacency formed while active is dropped cleanly;
+  `show ospf interface` reports `No Hellos (Passive interface)`.

--- a/book/src/ch-08-11-ospf-frr-cross-reference.md
+++ b/book/src/ch-08-11-ospf-frr-cross-reference.md
@@ -12,6 +12,7 @@ configuration surface to the equivalent FRR `ospfd` commands.
 | `area/<id>/interface/<n>/dead-interval` | `ip ospf dead-interval` (interface) |
 | `area/<id>/interface/<n>/retransmit-interval` | `ip ospf retransmit-interval` (interface) |
 | `area/<id>/interface/<n>/mtu-ignore` | `ip ospf mtu-ignore` (interface) |
+| `area/<id>/interface/<n>/passive true` | `ip ospf passive` (interface) |
 | `area/<id>/interface/<n>/network-type point-to-point` | `ip ospf network point-to-point` (interface) |
 | `area/<id>/interface/<n>/cost` | `ip ospf cost` (interface) |
 | `area/<id>/area-type stub` | `area <id> stub` |

--- a/book/src/ch-08-12-ospf-frr-gaps.md
+++ b/book/src/ch-08-12-ospf-frr-gaps.md
@@ -5,8 +5,6 @@ OSPFv2 features not yet implemented in zebra-rs:
 - Virtual links across non-backbone areas.
 - Discard (Null0) routes for active area ranges — the aggregation
   and suppression themselves are implemented.
-- Passive interfaces (advertise a prefix without forming
-  adjacencies on it).
 - Instance-level `default-information originate` (Type-5 default
   route). The NSSA-scoped Type-7 default
   (`nssa-default-originate`) is implemented.

--- a/book/src/ch-15-06-ospfv3-per-interface.md
+++ b/book/src/ch-15-06-ospfv3-per-interface.md
@@ -16,6 +16,7 @@ core). Timers are covered separately in
 | `priority` | 64 | 0..255 |
 | `cost` | 10 | 0..65535 |
 | `mtu-ignore` | `false` | boolean |
+| `passive` | `false` | boolean |
 | `affinity` | — | leaf-list of `/affinity-map` names |
 
 Notes:
@@ -39,6 +40,11 @@ Notes:
   `cost`, matching v2/FRR/Junos convention.
 - **`mtu-ignore`** disables the MTU-mismatch check in the DBD
   exchange, as in v2.
+- **`passive`** advertises the interface's prefixes (via the
+  Intra-Area-Prefix-LSA) while sending and accepting no Hellos, so
+  no adjacency forms on the segment. Loopbacks are implicitly
+  passive. Semantics as in
+  [the v2 page](ch-08-07-ospf-per-interface.md).
 - **`affinity`** attaches named admin-group bits (from the global
   `/affinity-map`) to the link, advertised in the RFC 9492 ASLA
   sub-TLV of the E-Router-LSA — consumed by

--- a/book/src/ch-15-14-ospfv3-frr-cross-reference.md
+++ b/book/src/ch-15-14-ospfv3-frr-cross-reference.md
@@ -17,6 +17,7 @@ interface to an area with a per-interface command.
 | `area/<id>/interface/<n>/dead-interval` | `ipv6 ospf6 dead-interval` (interface) |
 | `area/<id>/interface/<n>/retransmit-interval` | `ipv6 ospf6 retransmit-interval` (interface) |
 | `area/<id>/interface/<n>/mtu-ignore` | `ipv6 ospf6 mtu-ignore` (interface) |
+| `area/<id>/interface/<n>/passive true` | `ipv6 ospf6 passive` (interface) |
 | `area/<id>/area-type stub` | `area <id> stub` |
 | `area/<id>/area-type nssa` | `area <id> nssa` |
 | `area/<id>/no-summary true` | `area <id> stub no-summary` / `area <id> nssa no-summary` |

--- a/book/src/ch-15-15-ospfv3-frr-gaps.md
+++ b/book/src/ch-15-15-ospfv3-frr-gaps.md
@@ -13,7 +13,6 @@ OSPFv3 features not yet implemented in zebra-rs:
   RFC 7166 Authentication Trailer is implemented, but its keys are
   configured through the shared v2 interface tree (`ospf6d` has
   `ipv6 ospf6 authentication` per interface).
-- Passive interfaces.
 - Instance-level `default-information originate` (the NSSA-scoped
   default via `nssa-default-originate` is implemented).
 - Non-zero forwarding-address resolution on received externals.

--- a/zebra-rs/src/config/manager.rs
+++ b/zebra-rs/src/config/manager.rs
@@ -3549,4 +3549,27 @@ mod yang_load_tests {
             }
         }
     }
+    /// `area <id> interface <n> passive` — passive interfaces, v2+v3.
+    #[test]
+    fn ospf_interface_passive_paths_parse() {
+        use crate::config::ExecCode;
+        use crate::config::parse::{State, parse};
+        use libyang::to_entry;
+
+        let mut yang = YangStore::new();
+        yang.add_path(concat!(env!("CARGO_MANIFEST_DIR"), "/yang"));
+        yang.read_with_resolve("configure")
+            .expect("configure mode loads");
+        yang.identity_resolve();
+        let module = yang
+            .find_module("configure")
+            .expect("configure module present");
+        let entry = to_entry(&yang, module);
+
+        for proto in ["ospf", "ospfv3"] {
+            let path = format!("set router {proto} area 0 interface eth0 passive true");
+            let (code, _comps, _state) = parse(&path, entry.clone(), None, State::new());
+            assert_eq!(code, ExecCode::Success, "`{path}` must be a settable path");
+        }
+    }
 }

--- a/zebra-rs/src/ospf/config.rs
+++ b/zebra-rs/src/ospf/config.rs
@@ -141,6 +141,7 @@ impl Ospf {
             "/area/interface/network-type",
             config_ospf_interface_network_type,
         );
+        self.ospf_add("/area/interface/passive", config_ospf_interface_passive);
         self.ospf_add("/area/interface/priority", config_ospf_interface_priority);
         self.ospf_add("/area/interface/cost", config_ospf_interface_cost);
         self.ospf_add("/area/interface/affinity", config_ospf_interface_affinity);
@@ -848,6 +849,30 @@ fn config_ospf_interface_network_type(ospf: &mut Ospf, mut args: Args, op: Confi
     // shouldn't be in PointToPoint) and the cached neighbor list.
     // Disable+Enable through the existing channel rebuilds both.
     if old != new && link.enabled {
+        let area_id = link.area_id;
+        let _ = link.tx.send(Message::Disable(link.index, area_id));
+        let _ = link.tx.send(Message::Enable(link.index, area_id));
+    }
+
+    Some(())
+}
+
+/// `/router/ospf/area/<id>/interface/<name>/passive` — passive
+/// interface: prefixes keep advertising, but the Hello send/receive
+/// paths gate on `OspfLink::is_passive()`, so no Hello flows and no
+/// adjacency forms. Toggling bounces the interface (Disable→Enable)
+/// so an adjacency formed while active is dropped and the IFSM
+/// re-enters from the correct state.
+fn config_ospf_interface_passive(ospf: &mut Ospf, mut args: Args, op: ConfigOp) -> Option<()> {
+    let _area_id = parse_area_id(&args.string()?)?;
+    let name = args.string()?;
+    let passive = args.boolean()?;
+
+    let link = ospf_link_get_mut_by_name(&mut ospf.links, &name)?;
+    let old = link.config.passive;
+    link.config.passive = op.is_set() && passive;
+
+    if old != link.config.passive && link.enabled {
         let area_id = link.area_id;
         let _ = link.tx.send(Message::Disable(link.index, area_id));
         let _ = link.tx.send(Message::Enable(link.index, area_id));

--- a/zebra-rs/src/ospf/config_v3.rs
+++ b/zebra-rs/src/ospf/config_v3.rs
@@ -159,6 +159,7 @@ impl Ospf<Ospfv3> {
                 "/area/interface/network-type",
                 config_ospfv3_interface_network_type,
             ),
+            ("/area/interface/passive", config_ospfv3_interface_passive),
             ("/area/interface/priority", config_ospfv3_interface_priority),
             ("/area/interface/cost", config_ospfv3_interface_cost),
             (
@@ -845,6 +846,30 @@ fn config_ospfv3_interface_network_type(
     let new = link.config_network_type();
 
     if old != new && link.enabled {
+        let area_id = link.area_id;
+        let _ = link.tx.send(Message::Disable(link.index, area_id));
+        let _ = link.tx.send(Message::Enable(link.index, area_id));
+    }
+
+    Some(())
+}
+
+/// `/router/ospfv3/area/<id>/interface/<name>/passive` — v3 sibling
+/// of `config_ospf_interface_passive`.
+fn config_ospfv3_interface_passive(
+    ospf: &mut Ospf<Ospfv3>,
+    mut args: Args,
+    op: ConfigOp,
+) -> Option<()> {
+    let _area_id = parse_area_id(&args.string()?)?;
+    let name = args.string()?;
+    let passive = args.boolean()?;
+
+    let link = ospf_link_get_mut_by_name(&mut ospf.links, &name)?;
+    let old = link.config.passive;
+    link.config.passive = op.is_set() && passive;
+
+    if old != link.config.passive && link.enabled {
         let area_id = link.area_id;
         let _ = link.tx.send(Message::Disable(link.index, area_id));
         let _ = link.tx.send(Message::Enable(link.index, area_id));

--- a/zebra-rs/src/ospf/link.rs
+++ b/zebra-rs/src/ospf/link.rs
@@ -1,3 +1,4 @@
+use crate::rib::LinkFlagsExt;
 use std::fmt::Display;
 use std::str::FromStr;
 use std::sync::Arc;
@@ -82,6 +83,13 @@ pub struct LinkConfig {
     pub retransmit_interval: Option<u16>,
     pub transmit_delay: Option<u16>,
     pub mtu_ignore: bool,
+    /// Passive interface (`/router/ospf{,v3}/area/<id>/interface/<n>/
+    /// passive`): the interface's prefixes keep advertising (Router-LSA
+    /// stub / Intra-Area-Prefix-LSA — the LSA builds gate on `enable`,
+    /// not on adjacency), but no Hello is sent or accepted, so no
+    /// adjacency ever forms. `OspfLink::is_passive()` also folds in
+    /// loopback interfaces, which are implicitly passive.
+    pub passive: bool,
     pub prefix_sid: Option<PrefixSid>,
     /// Per-Flexible-Algorithm Prefix-SIDs for this interface's prefix
     /// (RFC 9350 §7), keyed by algo id (128..=255). Emitted as extra
@@ -577,8 +585,13 @@ impl<V: OspfVersion> OspfLink<V> {
             .unwrap_or(OSPF_DEFAULT_TRANSMIT_DELAY)
     }
 
+    /// A passive interface runs no Hello protocol: it advertises its
+    /// prefixes but sends/accepts no Hellos and forms no adjacency.
+    /// True when the operator set `passive`, and implicitly for
+    /// loopback interfaces (which have no segment to speak on) —
+    /// mirroring the IS-IS `is_passive` semantics.
     pub fn is_passive(&self) -> bool {
-        false
+        self.config.passive || self.link_flags.is_loopback()
     }
 
     pub fn is_multicast_if(&self) -> bool {

--- a/zebra-rs/src/ospf/packet.rs
+++ b/zebra-rs/src/ospf/packet.rs
@@ -482,6 +482,9 @@ pub fn ospf_hello_send(
     now: chrono::DateTime<chrono::Utc>,
     tracing: &OspfTracing,
 ) {
+    if oi.is_passive() {
+        return;
+    }
     ospf_pdu_trace!(tracing, "[Hello:Send] on {}", oi.name);
 
     let packet = ospf_hello_packet(oi, chains, now).unwrap();

--- a/zebra-rs/src/ospf/packet_v3.rs
+++ b/zebra-rs/src/ospf/packet_v3.rs
@@ -300,6 +300,9 @@ pub fn ospfv3_hello_send(
     now: chrono::DateTime<chrono::Utc>,
     tracing: &OspfTracing,
 ) {
+    if link.is_passive() {
+        return;
+    }
     ospf_pdu_trace!(tracing, "[Hello:Send] on {}", link.name);
     let Some(src) = link_local_src(link) else {
         tracing::debug!(

--- a/zebra-rs/yang/config.yang
+++ b/zebra-rs/yang/config.yang
@@ -739,6 +739,14 @@ module config {
             leaf mtu-ignore {
               type boolean;
             }
+            // Passive interface: its prefixes keep advertising into
+            // the area (Router-LSA stub / Intra-Area-Prefix-LSA) but
+            // no Hello is sent or accepted, so no adjacency forms.
+            // Loopbacks are implicitly passive even when unset.
+            leaf passive {
+              type boolean;
+              default false;
+            }
             container prefix-sid {
               leaf index {
                 type uint32;
@@ -1444,6 +1452,11 @@ module config {
             }
             leaf mtu-ignore {
               type boolean;
+            }
+            // Passive interface — same semantics as the v2 sibling.
+            leaf passive {
+              type boolean;
+              default false;
             }
             container prefix-sid {
               leaf index {


### PR DESCRIPTION
## Summary

Implements `area <id> interface <n> passive true` for both protocol versions, closing the passive-interface gap against FRR:

- A passive interface's prefixes keep advertising into the area (Router-LSA stub for v2, Intra-Area-Prefix-LSA for v3 — the LSA builds gate on `enable`, not adjacency), while the Hello send and receive paths gate on `OspfLink::is_passive()`, so no Hello flows and no adjacency forms in either direction.
- `is_passive()` folds in loopback interfaces (implicitly passive — IS-IS/FRR parity), wiring up the receive gates and the `No Hellos (Passive interface)` show line that were already pre-plumbed in the code.
- Toggling bounces the interface (Disable→Enable) so an adjacency formed while active drops cleanly, mirroring the network-type knob.
- Book: per-interface pages, gaps pages, and FRR cross-references (`ip ospf passive` / `ipv6 ospf6 passive`) updated.

## Test plan

- Parse regression test pins both spellings.
- New BDD features pass first run: `ospfv2_passive` and `ospfv3_passive` — the passive prefix reaches the far router and pings, an actively-speaking third router never becomes a neighbor in either direction, and the v2 scenario asserts the passive show line. Zero skipped steps.
- `cargo fmt --check`, clippy `-D warnings` (default and no-lua), `cargo test --workspace --exclude bdd` (2134 passed, 0 failed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)