### PR TITLE
ospf: default-information originate + RIB default-route watch

### DIFF
--- a/bdd/tests/configs/ospfv2_default_originate/a.yaml
+++ b/bdd/tests/configs/ospfv2_default_originate/a.yaml
@@ -1,0 +1,18 @@
+interface:
+- if-name: lo
+  ipv4:
+    address: 10.0.0.1/32
+- if-name: ethb
+  ipv4:
+    address: 10.0.12.1/30
+router:
+  ospf:
+    router-id: 10.0.0.1
+    area:
+    - area-id: 0.0.0.0
+      interface:
+      - if-name: lo
+        enable: true
+      - if-name: ethb
+        enable: true
+        network-type: point-to-point

--- a/bdd/tests/configs/ospfv2_default_originate/b_always.yaml
+++ b/bdd/tests/configs/ospfv2_default_originate/b_always.yaml
@@ -1,0 +1,21 @@
+interface:
+- if-name: lo
+  ipv4:
+    address: 10.0.0.2/32
+- if-name: etha
+  ipv4:
+    address: 10.0.12.2/30
+router:
+  ospf:
+    router-id: 10.0.0.2
+    default-information:
+      originate:
+        always: true
+    area:
+    - area-id: 0.0.0.0
+      interface:
+      - if-name: lo
+        enable: true
+      - if-name: etha
+        enable: true
+        network-type: point-to-point

--- a/bdd/tests/configs/ospfv2_default_originate/b_cond.yaml
+++ b/bdd/tests/configs/ospfv2_default_originate/b_cond.yaml
@@ -1,0 +1,20 @@
+interface:
+- if-name: lo
+  ipv4:
+    address: 10.0.0.2/32
+- if-name: etha
+  ipv4:
+    address: 10.0.12.2/30
+router:
+  ospf:
+    router-id: 10.0.0.2
+    default-information:
+      originate: {}
+    area:
+    - area-id: 0.0.0.0
+      interface:
+      - if-name: lo
+        enable: true
+      - if-name: etha
+        enable: true
+        network-type: point-to-point

--- a/bdd/tests/configs/ospfv3_default_originate/a.yaml
+++ b/bdd/tests/configs/ospfv3_default_originate/a.yaml
@@ -1,0 +1,18 @@
+interface:
+- if-name: lo
+  ipv6:
+    address: 2001:db8::1/128
+- if-name: ethb
+  ipv6:
+    address: 2001:db8:12::1/64
+router:
+  ospfv3:
+    router-id: 10.0.0.1
+    area:
+    - area-id: 0.0.0.0
+      interface:
+      - if-name: lo
+        enable: true
+      - if-name: ethb
+        enable: true
+        network-type: point-to-point

--- a/bdd/tests/configs/ospfv3_default_originate/b_always.yaml
+++ b/bdd/tests/configs/ospfv3_default_originate/b_always.yaml
@@ -1,0 +1,21 @@
+interface:
+- if-name: lo
+  ipv6:
+    address: 2001:db8::2/128
+- if-name: etha
+  ipv6:
+    address: 2001:db8:12::2/64
+router:
+  ospfv3:
+    router-id: 10.0.0.2
+    default-information:
+      originate:
+        always: true
+    area:
+    - area-id: 0.0.0.0
+      interface:
+      - if-name: lo
+        enable: true
+      - if-name: etha
+        enable: true
+        network-type: point-to-point

--- a/bdd/tests/configs/ospfv3_default_originate/b_cond.yaml
+++ b/bdd/tests/configs/ospfv3_default_originate/b_cond.yaml
@@ -1,0 +1,20 @@
+interface:
+- if-name: lo
+  ipv6:
+    address: 2001:db8::2/128
+- if-name: etha
+  ipv6:
+    address: 2001:db8:12::2/64
+router:
+  ospfv3:
+    router-id: 10.0.0.2
+    default-information:
+      originate: {}
+    area:
+    - area-id: 0.0.0.0
+      interface:
+      - if-name: lo
+        enable: true
+      - if-name: etha
+        enable: true
+        network-type: point-to-point

--- a/bdd/tests/features/ospfv2_default_originate.feature
+++ b/bdd/tests/features/ospfv2_default_originate.feature
@@ -1,0 +1,69 @@
+@serial
+@ospfv2_default_originate
+Feature: OSPFv2 default-information originate advertises a Type-5 default
+  As a network operator
+  I want `default-information originate [always]` to advertise a
+  Type-5 default route (0.0.0.0/0) — unconditionally with `always`,
+  or tracking the presence of a non-OSPF default route in the RIB
+  without it — so downstream routers follow the ASBR for everything
+  off-net.
+
+  Test Topology:
+  ```
+    a (10.0.0.1) -- 10.0.12.0/30 -- b (ASBR, 10.0.0.2)
+                                    default-information originate
+  ```
+
+  Scenario: always originates unconditionally at the configured metric
+    Given a clean test environment
+    When I create namespace "a"
+    And I create namespace "b"
+    And I connect namespace "a" interface "ethb" to namespace "b" interface "etha"
+    And I start zebra-rs in namespace "a"
+    And I start zebra-rs in namespace "b"
+    And I apply config "a.yaml" to namespace "a"
+    And I apply config "b_always.yaml" to namespace "b"
+    And I wait 30 seconds
+
+    Then show command "show ospf neighbor" in namespace "a" should contain "Full"
+    # The default at the FRR-parity metric 10, E2.
+    And show command "show ospf route" in namespace "a" should contain "0.0.0.0/0"
+    And show command "show ospf route" in namespace "a" should contain "[10]"
+
+    # Teardown.
+    When I stop zebra-rs in namespace "a"
+    And I stop zebra-rs in namespace "b"
+    And I delete namespace "a"
+    And I delete namespace "b"
+    Then the test environment should be clean
+
+  Scenario: Without always, the default tracks a non-OSPF default route in the RIB
+    Given a clean test environment
+    When I create namespace "a"
+    And I create namespace "b"
+    And I connect namespace "a" interface "ethb" to namespace "b" interface "etha"
+    And I start zebra-rs in namespace "a"
+    And I start zebra-rs in namespace "b"
+    And I apply config "a.yaml" to namespace "a"
+    And I apply config "b_cond.yaml" to namespace "b"
+    And I wait 30 seconds
+
+    Then show command "show ospf neighbor" in namespace "a" should contain "Full"
+    # No default route in b's RIB yet -> nothing advertised.
+    And show command "show ospf route" in namespace "a" should not contain "0.0.0.0/0"
+
+    # A static default appears in b's RIB: the RIB default watch fires
+    # and the Type-5 default is originated.
+    When I apply command "set router static ipv4 route 0.0.0.0/0 nexthop 10.0.12.1" in namespace "b"
+    Then show command "show ospf route" in namespace "a" should eventually contain "0.0.0.0/0"
+
+    # Withdraw the static default: the Type-5 default is flushed.
+    When I apply command "delete router static ipv4 route 0.0.0.0/0" in namespace "b"
+    Then show command "show ospf route" in namespace "a" should eventually not contain "0.0.0.0/0"
+
+    # Teardown.
+    When I stop zebra-rs in namespace "a"
+    And I stop zebra-rs in namespace "b"
+    And I delete namespace "a"
+    And I delete namespace "b"
+    Then the test environment should be clean

--- a/bdd/tests/features/ospfv3_default_originate.feature
+++ b/bdd/tests/features/ospfv3_default_originate.feature
@@ -1,0 +1,62 @@
+@serial
+@ospfv3_default_originate
+Feature: OSPFv3 default-information originate advertises an AS-External default
+  As a network operator
+  I want `default-information originate [always]` on OSPFv3 to
+  advertise an AS-External default (::/0) — unconditionally with
+  `always`, or tracking a non-OSPF default route in the RIB without
+  it — mirroring ospfv2_default_originate.
+
+  Test Topology (v6 mirror):
+  ```
+    a -- 2001:db8:12::/64 -- b (ASBR)
+                             default-information originate
+  ```
+
+  Scenario: always originates unconditionally at the configured metric
+    Given a clean test environment
+    When I create namespace "a"
+    And I create namespace "b"
+    And I connect namespace "a" interface "ethb" to namespace "b" interface "etha"
+    And I start zebra-rs in namespace "a"
+    And I start zebra-rs in namespace "b"
+    And I apply config "a.yaml" to namespace "a"
+    And I apply config "b_always.yaml" to namespace "b"
+    And I wait 30 seconds
+
+    Then show command "show ospfv3 neighbor" in namespace "a" should contain "Full"
+    And show command "show ospfv3 route" in namespace "a" should contain "::/0 metric 10"
+
+    # Teardown.
+    When I stop zebra-rs in namespace "a"
+    And I stop zebra-rs in namespace "b"
+    And I delete namespace "a"
+    And I delete namespace "b"
+    Then the test environment should be clean
+
+  Scenario: Without always, the default tracks a non-OSPF default route in the RIB
+    Given a clean test environment
+    When I create namespace "a"
+    And I create namespace "b"
+    And I connect namespace "a" interface "ethb" to namespace "b" interface "etha"
+    And I start zebra-rs in namespace "a"
+    And I start zebra-rs in namespace "b"
+    And I apply config "a.yaml" to namespace "a"
+    And I apply config "b_cond.yaml" to namespace "b"
+    And I wait 30 seconds
+
+    Then show command "show ospfv3 neighbor" in namespace "a" should contain "Full"
+    And show command "show ospfv3 route" in namespace "a" should not contain "::/0"
+
+    When I apply command "set router static ipv6 route ::/0 nexthop 2001:db8:12::1" in namespace "b"
+    Then show command "show ospfv3 route" in namespace "a" should eventually contain "::/0"
+
+    When I apply command "delete router static ipv6 route ::/0" in namespace "b"
+    Then show command "show ospfv3 route" in namespace "a" should eventually not contain "::/0"
+
+    # Teardown.
+    When I stop zebra-rs in namespace "a"
+    And I stop zebra-rs in namespace "b"
+    And I delete namespace "a"
+    And I delete namespace "b"
+    Then the test environment should be clean

--- a/book/src/ch-08-11-ospf-frr-cross-reference.md
+++ b/book/src/ch-08-11-ospf-frr-cross-reference.md
@@ -23,6 +23,7 @@ configuration surface to the equivalent FRR `ospfd` commands.
 | `area/<id>/nssa-translator-role` | `area <id> nssa translate-candidate` / `translate-always` / `translate-never` |
 | `area/<id>/range <prefix> { not-advertise; cost; }` | `area <id> range <prefix> [not-advertise \| cost <c>]` |
 | `redistribute <connected\|static\|kernel\|isis\|bgp> { metric; metric-type; }` | `redistribute <source> metric <m> metric-type <1\|2>` |
+| `default-information originate { always; metric; metric-type; }` | `default-information originate [always] [metric <m>] [metric-type <1\|2>]` |
 | `area/<id>/interface/<n>/authentication simple` + `authentication-key` | `ip ospf authentication` + `ip ospf authentication-key` (interface) |
 | `area/<id>/interface/<n>/authentication message-digest` + `message-digest-key <id> { md5; }` | `ip ospf authentication message-digest` + `ip ospf message-digest-key <id> md5 <key>` (interface) |
 | `area/<id>/interface/<n>/key-chain` | `ip ospf authentication key-chain <name>` (interface) |

--- a/book/src/ch-08-12-ospf-frr-gaps.md
+++ b/book/src/ch-08-12-ospf-frr-gaps.md
@@ -5,9 +5,6 @@ OSPFv2 features not yet implemented in zebra-rs:
 - Virtual links across non-backbone areas.
 - Discard (Null0) routes for active area ranges — the aggregation
   and suppression themselves are implemented.
-- Instance-level `default-information originate` (Type-5 default
-  route). The NSSA-scoped Type-7 default
-  (`nssa-default-originate`) is implemented.
 - NBMA and point-to-multipoint network types — the per-interface
   `network-type` knob accepts `broadcast` and `point-to-point`
   only.

--- a/book/src/ch-08-15-ospf-redistribution.md
+++ b/book/src/ch-08-15-ospf-redistribution.md
@@ -69,6 +69,35 @@ LSAs carrying a non-zero forwarding address are currently skipped —
 resolving the FA against an intra-area route (RFC 2328 §16.4
 step 3) is not yet implemented.
 
+## Default route origination
+
+`default-information originate` advertises a Type-5 default
+(0.0.0.0/0) from this router:
+
+```
+router ospf {
+  default-information {
+    originate {
+      always true;
+    }
+  }
+}
+```
+
+| YANG leaf (`/router/ospf/default-information/originate/…`) | Default | Notes |
+|---|---|---|
+| `originate` | presence | Makes the router an ASBR (E-bit set). |
+| `always` | `false` | Originate unconditionally. |
+| `metric` | 10 | FRR-parity default for the originated default (redistribute uses 20). |
+| `metric-type` | `type-2` | E1/E2 semantics as for redistribution. |
+
+Without `always`, the default is originated **only while a non-OSPF
+default route exists in the RIB** — zebra-rs tracks this through a
+dedicated RIB default-route watch, so a static or BGP default
+appearing or disappearing originates or flushes the Type-5 without
+any table-wide subscription. With `always`, it is advertised
+unconditionally.
+
 ## Redistribution into NSSA areas
 
 Stub and NSSA areas do not carry Type-5. To originate externals

--- a/book/src/ch-15-09-ospfv3-redistribution.md
+++ b/book/src/ch-15-09-ospfv3-redistribution.md
@@ -48,6 +48,15 @@ Notes:
   to AS-External at the NSSA ABR — see
   [Area Types: Stub and NSSA](ch-15-03-ospfv3-area-types.md).
 
+## Default route origination
+
+`default-information originate [always] [metric] [metric-type]`
+advertises an AS-External default (`::/0`) with the same knobs and
+semantics as [the v2 page](ch-08-15-ospf-redistribution.md): with
+`always` unconditionally, without it only while a non-OSPF default
+route exists in the RIB (tracked via the RIB default-route watch).
+The metric defaults to 10, E2.
+
 Receive-side handling installs AS-External routes with the standard
 RFC 2328 §16.4 preference and metric arithmetic, including
 inter-area ASBR resolution through Inter-Area-Router-LSAs (§16.4

--- a/book/src/ch-15-14-ospfv3-frr-cross-reference.md
+++ b/book/src/ch-15-14-ospfv3-frr-cross-reference.md
@@ -23,6 +23,7 @@ interface to an area with a per-interface command.
 | `area/<id>/no-summary true` | `area <id> stub no-summary` / `area <id> nssa no-summary` |
 | `area/<id>/range <prefix> { not-advertise; cost; }` | `area <id> range <prefix> [not-advertise \| cost <c>]` |
 | `redistribute <connected\|static\|kernel\|isis\|bgp> { metric; metric-type; }` | `redistribute <source> metric <m> metric-type <1\|2>` |
+| `default-information originate { always; metric; metric-type; }` | `default-information originate [always] [metric <m>] [metric-type <1\|2>]` |
 | `clear ospfv3 neighbor` | `clear ipv6 ospf6 interface [IFNAME]` |
 | `show ospfv3 neighbor / database / route` | `show ipv6 ospf6 neighbor / database / route` |
 

--- a/book/src/ch-15-15-ospfv3-frr-gaps.md
+++ b/book/src/ch-15-15-ospfv3-frr-gaps.md
@@ -13,8 +13,6 @@ OSPFv3 features not yet implemented in zebra-rs:
   RFC 7166 Authentication Trailer is implemented, but its keys are
   configured through the shared v2 interface tree (`ospf6d` has
   `ipv6 ospf6 authentication` per interface).
-- Instance-level `default-information originate` (the NSSA-scoped
-  default via `nssa-default-originate` is implemented).
 - Non-zero forwarding-address resolution on received externals.
 - NBMA and point-to-multipoint network types.
 - Configurable SPF throttling (SPF is coalesced behind a fixed

--- a/zebra-rs/src/config/manager.rs
+++ b/zebra-rs/src/config/manager.rs
@@ -3572,4 +3572,30 @@ mod yang_load_tests {
             assert_eq!(code, ExecCode::Success, "`{path}` must be a settable path");
         }
     }
+    /// `default-information originate [always|metric|metric-type]` —
+    /// Type-5 default origination, v2 and v3. Pin every spelling.
+    #[test]
+    fn ospf_default_information_paths_parse() {
+        use crate::config::ExecCode;
+        use crate::config::parse::{State, parse};
+        use libyang::to_entry;
+
+        let mut yang = YangStore::new();
+        yang.add_path(concat!(env!("CARGO_MANIFEST_DIR"), "/yang"));
+        yang.read_with_resolve("configure")
+            .expect("configure mode loads");
+        yang.identity_resolve();
+        let module = yang
+            .find_module("configure")
+            .expect("configure module present");
+        let entry = to_entry(&yang, module);
+
+        for proto in ["ospf", "ospfv3"] {
+            for suffix in ["", " always true", " metric 5", " metric-type type-1"] {
+                let path = format!("set router {proto} default-information originate{suffix}");
+                let (code, _comps, _state) = parse(&path, entry.clone(), None, State::new());
+                assert_eq!(code, ExecCode::Success, "`{path}` must be a settable path");
+            }
+        }
+    }
 }

--- a/zebra-rs/src/ospf/area.rs
+++ b/zebra-rs/src/ospf/area.rs
@@ -275,6 +275,28 @@ pub struct OspfArea<V: OspfVersion = Ospfv2> {
     pub ranges_v6: BTreeMap<Ipv6Net, AreaRange>,
 }
 
+/// Instance-level `default-information originate` configuration.
+/// Without `always`, the Type-5 default is originated only while a
+/// non-OSPF default route sits in the RIB (tracked via the RIB
+/// default watch); `always` originates unconditionally. Metric
+/// defaults to 10 (FRR parity) with E2 semantics.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct DefaultOriginate {
+    pub always: bool,
+    pub metric: u32,
+    pub metric_type: ExternalMetricType,
+}
+
+impl Default for DefaultOriginate {
+    fn default() -> Self {
+        Self {
+            always: false,
+            metric: 10,
+            metric_type: ExternalMetricType::default(),
+        }
+    }
+}
+
 /// One configured `area <id> range <prefix>` entry.
 #[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
 pub struct AreaRange {

--- a/zebra-rs/src/ospf/config.rs
+++ b/zebra-rs/src/ospf/config.rs
@@ -50,6 +50,22 @@ impl Ospf {
             "/area/redistribute/connected/metric-type",
             config_ospf_area_redist_connected_metric_type,
         );
+        self.ospf_add(
+            "/default-information/originate",
+            config_ospf_default_originate,
+        );
+        self.ospf_add(
+            "/default-information/originate/always",
+            config_ospf_default_originate_always,
+        );
+        self.ospf_add(
+            "/default-information/originate/metric",
+            config_ospf_default_originate_metric,
+        );
+        self.ospf_add(
+            "/default-information/originate/metric-type",
+            config_ospf_default_originate_metric_type,
+        );
         self.ospf_add("/area/range", config_ospf_area_range);
         self.ospf_add(
             "/area/range/not-advertise",
@@ -661,6 +677,100 @@ ospf_redist_handlers!(
     config_ospf_redist_isis_metric_type,
     crate::rib::RibType::Isis
 );
+
+/// Keep the RIB default watch aligned with the knob: subscribed
+/// while `default-information originate` is set without `always`.
+/// When the watch turns off, purge cached default entries that no
+/// active per-rtype redistribute row covers — the RIB deliberately
+/// does no Del replay (an overlapping row's cache entry must
+/// survive), so the consumer owns this cleanup.
+fn ospf_sync_default_watch(ospf: &mut Ospf) {
+    use crate::rib::{Message as RibMsg, RedistAfi};
+    let want = matches!(ospf.default_originate, Some(cfg) if !cfg.always);
+    if want == ospf.default_watch_active {
+        return;
+    }
+    let proto = ospf.proto_label.clone();
+    let msg = if want {
+        RibMsg::RedistDefaultAdd {
+            proto,
+            afi: RedistAfi::Ipv4,
+        }
+    } else {
+        RibMsg::RedistDefaultDel {
+            proto,
+            afi: RedistAfi::Ipv4,
+        }
+    };
+    let _ = ospf.ctx.rib.send(msg);
+    ospf.default_watch_active = want;
+    if !want {
+        let covered = ospf.redist.clone();
+        ospf.redist_v4
+            .retain(|(rt, p), _| p.prefix_len() != 0 || covered.contains_key(rt));
+    }
+}
+
+/// `/router/ospf/default-information/originate` — presence. Makes
+/// this router an ASBR and (conditionally or with `always`)
+/// originates the Type-5 default.
+fn config_ospf_default_originate(ospf: &mut Ospf, _args: Args, op: ConfigOp) -> Option<()> {
+    if op.is_set() {
+        ospf.default_originate.get_or_insert_with(Default::default);
+    } else {
+        ospf.default_originate = None;
+    }
+    ospf_sync_default_watch(ospf);
+    ospf.default_originate_resync();
+    Some(())
+}
+
+/// `/router/ospf/default-information/originate/always`.
+fn config_ospf_default_originate_always(
+    ospf: &mut Ospf,
+    mut args: Args,
+    op: ConfigOp,
+) -> Option<()> {
+    let value = if op.is_set() { args.boolean()? } else { false };
+    ospf.default_originate
+        .get_or_insert_with(Default::default)
+        .always = value;
+    ospf_sync_default_watch(ospf);
+    ospf.default_originate_resync();
+    Some(())
+}
+
+/// `/router/ospf/default-information/originate/metric`.
+fn config_ospf_default_originate_metric(
+    ospf: &mut Ospf,
+    mut args: Args,
+    op: ConfigOp,
+) -> Option<()> {
+    let value = if op.is_set() { args.u32()? } else { 10 };
+    ospf.default_originate
+        .get_or_insert_with(Default::default)
+        .metric = value;
+    ospf.default_originate_resync();
+    Some(())
+}
+
+/// `/router/ospf/default-information/originate/metric-type`.
+fn config_ospf_default_originate_metric_type(
+    ospf: &mut Ospf,
+    mut args: Args,
+    op: ConfigOp,
+) -> Option<()> {
+    let value = if op.is_set() {
+        ExternalMetricType::from_yang(&args.string()?)?
+    } else {
+        ExternalMetricType::default()
+    };
+    ospf.default_originate
+        .get_or_insert_with(Default::default)
+        .metric_type = value;
+    ospf.default_originate_resync();
+    Some(())
+}
 
 /// `/router/ospf/area/<id>/range` — one RFC 2328 §12.4.3 address
 /// range entry (list keyed by prefix). Set creates it with defaults

--- a/zebra-rs/src/ospf/config_v3.rs
+++ b/zebra-rs/src/ospf/config_v3.rs
@@ -66,6 +66,22 @@ impl Ospf<Ospfv3> {
                 "/area/redistribute/connected/metric-type",
                 config_ospfv3_area_redist_connected_metric_type,
             ),
+            (
+                "/default-information/originate",
+                config_ospfv3_default_originate,
+            ),
+            (
+                "/default-information/originate/always",
+                config_ospfv3_default_originate_always,
+            ),
+            (
+                "/default-information/originate/metric",
+                config_ospfv3_default_originate_metric,
+            ),
+            (
+                "/default-information/originate/metric-type",
+                config_ospfv3_default_originate_metric_type,
+            ),
             ("/area/range", config_ospfv3_area_range),
             (
                 "/area/range/not-advertise",
@@ -648,6 +664,97 @@ ospfv3_redist_handlers!(
     config_ospfv3_redist_bgp_metric_type,
     crate::rib::RibType::Bgp
 );
+
+/// v3 sibling of `ospf_sync_default_watch` (IPv6 default watch).
+fn ospfv3_sync_default_watch(ospf: &mut Ospf<Ospfv3>) {
+    use crate::rib::{Message as RibMsg, RedistAfi};
+    let want = matches!(ospf.default_originate, Some(cfg) if !cfg.always);
+    if want == ospf.default_watch_active {
+        return;
+    }
+    let proto = ospf.proto_label.clone();
+    let msg = if want {
+        RibMsg::RedistDefaultAdd {
+            proto,
+            afi: RedistAfi::Ipv6,
+        }
+    } else {
+        RibMsg::RedistDefaultDel {
+            proto,
+            afi: RedistAfi::Ipv6,
+        }
+    };
+    let _ = ospf.ctx.rib.send(msg);
+    ospf.default_watch_active = want;
+    if !want {
+        let covered = ospf.redist.clone();
+        ospf.redist_v6
+            .retain(|(rt, p), _| p.prefix_len() != 0 || covered.contains_key(rt));
+    }
+}
+
+/// `/router/ospfv3/default-information/originate` — presence.
+fn config_ospfv3_default_originate(
+    ospf: &mut Ospf<Ospfv3>,
+    _args: Args,
+    op: ConfigOp,
+) -> Option<()> {
+    if op.is_set() {
+        ospf.default_originate.get_or_insert_with(Default::default);
+    } else {
+        ospf.default_originate = None;
+    }
+    ospfv3_sync_default_watch(ospf);
+    ospf.default_originate_resync_v3();
+    Some(())
+}
+
+/// `/router/ospfv3/default-information/originate/always`.
+fn config_ospfv3_default_originate_always(
+    ospf: &mut Ospf<Ospfv3>,
+    mut args: Args,
+    op: ConfigOp,
+) -> Option<()> {
+    let value = if op.is_set() { args.boolean()? } else { false };
+    ospf.default_originate
+        .get_or_insert_with(Default::default)
+        .always = value;
+    ospfv3_sync_default_watch(ospf);
+    ospf.default_originate_resync_v3();
+    Some(())
+}
+
+/// `/router/ospfv3/default-information/originate/metric`.
+fn config_ospfv3_default_originate_metric(
+    ospf: &mut Ospf<Ospfv3>,
+    mut args: Args,
+    op: ConfigOp,
+) -> Option<()> {
+    let value = if op.is_set() { args.u32()? } else { 10 };
+    ospf.default_originate
+        .get_or_insert_with(Default::default)
+        .metric = value;
+    ospf.default_originate_resync_v3();
+    Some(())
+}
+
+/// `/router/ospfv3/default-information/originate/metric-type`.
+fn config_ospfv3_default_originate_metric_type(
+    ospf: &mut Ospf<Ospfv3>,
+    mut args: Args,
+    op: ConfigOp,
+) -> Option<()> {
+    let value = if op.is_set() {
+        ExternalMetricType::from_yang(&args.string()?)?
+    } else {
+        ExternalMetricType::default()
+    };
+    ospf.default_originate
+        .get_or_insert_with(Default::default)
+        .metric_type = value;
+    ospf.default_originate_resync_v3();
+    Some(())
+}
 
 /// `/router/ospfv3/area/<id>/range` — v3 sibling of
 /// `config_ospf_area_range` (Inter-Area-Prefix aggregation).

--- a/zebra-rs/src/ospf/inst.rs
+++ b/zebra-rs/src/ospf/inst.rs
@@ -300,6 +300,19 @@ pub struct Ospf<V: OspfVersion = Ospfv2> {
     /// prefixes of OSPFv3 AS-External (Type-5) LSAs self-originated from
     /// instance-level `redistribute`. A v2 instance leaves this empty.
     pub redist_originated_v6: BTreeMap<crate::rib::RibType, BTreeSet<ipnet::Ipv6Net>>,
+    /// Instance-level `default-information originate` knob. `Some`
+    /// makes this router an ASBR; whether the Type-5 default is
+    /// actually on the wire depends on `always` / the RIB default
+    /// watch — see `default_originate_resync`.
+    pub default_originate: Option<crate::ospf::area::DefaultOriginate>,
+    /// True while we have a self-originated Type-5 default installed
+    /// (v4 / v6 respectively) — the flush guard, so removing the knob
+    /// never flushes a 0/0 Type-5 that `redistribute` owns.
+    pub default_originated: bool,
+    pub default_originated_v6: bool,
+    /// True while the RIB default watch subscription is active,
+    /// avoiding duplicate RedistDefaultAdd/Del sends.
+    pub default_watch_active: bool,
     /// Staged Flexible Algorithm definitions for this instance
     /// (`/router/ospf{,v3}/flex-algo`, RFC 9350). Shared staging engine
     /// keyed by the version's `FLEX_ALGO_PREFIX`; origination from the
@@ -1235,6 +1248,10 @@ impl Ospf<Ospfv2> {
             redist: BTreeMap::new(),
             redist_originated: BTreeMap::new(),
             redist_originated_v6: BTreeMap::new(),
+            default_originate: None,
+            default_originated: false,
+            default_originated_v6: false,
+            default_watch_active: false,
             flex_algo: crate::flex_algo::FlexAlgoConfig::new(Ospfv2::FLEX_ALGO_PREFIX),
             affinity_map: crate::flex_algo::AffinityMap::new(),
             srlg_config: crate::flex_algo::SrlgGroupBuilder::new(),
@@ -2706,7 +2723,42 @@ impl Ospf<Ospfv2> {
     /// (RFC 2328 §3.3 ASBR definition). Today this requires the
     /// instance-level `redistribute connected` knob to be set.
     pub fn is_asbr(&self) -> bool {
-        !self.redist.is_empty()
+        !self.redist.is_empty() || self.default_originate.is_some()
+    }
+
+    /// Reconcile the self-originated Type-5 default (0.0.0.0/0)
+    /// against the `default-information originate` knob: originate
+    /// when configured with `always`, or when the RIB default watch
+    /// has delivered a non-OSPF default route; flush (guarded by
+    /// `default_originated`, so a redistribute-owned 0/0 survives)
+    /// otherwise. Called from config changes and the RIB route-churn
+    /// handlers.
+    pub fn default_originate_resync(&mut self) {
+        use crate::rib::RibType;
+        let prefix = Ipv4Net::new(Ipv4Addr::UNSPECIFIED, 0).unwrap();
+        let should = match self.default_originate {
+            None => false,
+            Some(cfg) => {
+                cfg.always
+                    || self
+                        .redist_v4
+                        .iter()
+                        .any(|((rt, p), _)| p.prefix_len() == 0 && *rt != RibType::Ospf)
+            }
+        };
+        if should {
+            let cfg = self.default_originate.expect("gated on Some above");
+            self.as_external_lsa_originate_for_prefix(
+                prefix,
+                cfg.metric,
+                cfg.metric_type.is_type_2(),
+            );
+            self.default_originated = true;
+        } else if self.default_originated {
+            self.as_external_lsa_flush_for_prefix(prefix);
+            self.default_originated = false;
+        }
+        self.router_lsa_originate();
     }
 
     /// True when this router should translate Type-7 → Type-5 for
@@ -2993,6 +3045,7 @@ impl Ospf<Ospfv2> {
             self.nssa_redist_connected_resync(area_id);
         }
         self.as_external_redist_resync_all();
+        self.default_originate_resync();
     }
 
     /// `RibRx::RouteDel` handler. Mirror of `route_redist_add`.
@@ -3008,6 +3061,7 @@ impl Ospf<Ospfv2> {
             self.nssa_redist_connected_resync(area_id);
         }
         self.as_external_redist_resync_all();
+        self.default_originate_resync();
     }
 
     fn process_lsdb(&mut self, ev: LsdbEvent, area_id: Option<Ipv4Addr>, key: OspfLsaKey) {
@@ -3292,6 +3346,7 @@ impl Ospf<Ospfv2> {
                         received_seq
                     );
                     self.as_external_redist_resync_all();
+                    self.default_originate_resync();
                 } else {
                     let owning_area = self
                         .areas
@@ -4660,6 +4715,23 @@ impl Ospf<Ospfv2> {
             link.ident.router_id = router_id;
         }
         self.router_lsa_originate();
+        // Re-originate the config-driven LSAs under the new identity —
+        // the flush above withdrew them under the old Router-ID, and
+        // unlike the RIB-driven originations (which recover on the
+        // next route churn) `default-information originate always` and
+        // the NSSA defaults have no later trigger.
+        self.as_external_redist_resync_all();
+        self.default_originate_resync();
+        let nssa_areas: Vec<Ipv4Addr> = self
+            .areas
+            .iter()
+            .filter(|(_, a)| a.area_type.is_nssa())
+            .map(|(id, _)| *id)
+            .collect();
+        for area_id in nssa_areas {
+            self.nssa_default_lsa_originate(area_id);
+            self.nssa_redist_connected_resync(area_id);
+        }
     }
 
     /// Flush (pre-age to MaxAge + re-flood) every LSA we originated
@@ -5463,6 +5535,10 @@ impl Ospf<Ospfv3> {
             redist: BTreeMap::new(),
             redist_originated: BTreeMap::new(),
             redist_originated_v6: BTreeMap::new(),
+            default_originate: None,
+            default_originated: false,
+            default_originated_v6: false,
+            default_watch_active: false,
             flex_algo: crate::flex_algo::FlexAlgoConfig::new(Ospfv3::FLEX_ALGO_PREFIX),
             affinity_map: crate::flex_algo::AffinityMap::new(),
             srlg_config: crate::flex_algo::SrlgGroupBuilder::new(),
@@ -5647,6 +5723,7 @@ impl Ospf<Ospfv3> {
             self.nssa_redist_connected_resync_v3(area_id);
         }
         self.as_external_redist_resync_all_v3();
+        self.default_originate_resync_v3();
     }
 
     /// `RibRx::RouteDel` handler (v3). Mirror of `route_redist_add`.
@@ -5661,6 +5738,7 @@ impl Ospf<Ospfv3> {
             self.nssa_redist_connected_resync_v3(area_id);
         }
         self.as_external_redist_resync_all_v3();
+        self.default_originate_resync_v3();
     }
 
     /// Stash an IPv6 address learned from netlink on the matching
@@ -5721,6 +5799,20 @@ impl Ospf<Ospfv3> {
             link.ident.router_id = router_id;
         }
         self.router_lsa_originate();
+        // See the v2 sibling: re-originate the config-driven LSAs
+        // under the new identity.
+        self.as_external_redist_resync_all_v3();
+        self.default_originate_resync_v3();
+        let nssa_areas: Vec<Ipv4Addr> = self
+            .areas
+            .iter()
+            .filter(|(_, a)| a.area_type.is_nssa())
+            .map(|(id, _)| *id)
+            .collect();
+        for area_id in nssa_areas {
+            self.nssa_default_lsa_originate(area_id);
+            self.nssa_redist_connected_resync_v3(area_id);
+        }
     }
 
     /// v3 sibling of the v2 `flush_self_originated_under`: pre-age to
@@ -6720,9 +6812,39 @@ impl Ospf<Ospfv3> {
 
     /// True when this router originates AS-External LSAs (RFC 2328
     /// §3.3 ASBR definition) — any instance-level `redistribute`
-    /// source is configured. v3 sibling of the v2 `is_asbr`.
+    /// source or `default-information originate` is configured. v3
+    /// sibling of the v2 `is_asbr`.
     pub fn is_asbr(&self) -> bool {
-        !self.redist.is_empty()
+        !self.redist.is_empty() || self.default_originate.is_some()
+    }
+
+    /// v3 sibling of `default_originate_resync` (::/0).
+    pub fn default_originate_resync_v3(&mut self) {
+        use crate::rib::RibType;
+        let prefix = ipnet::Ipv6Net::new(std::net::Ipv6Addr::UNSPECIFIED, 0).unwrap();
+        let should = match self.default_originate {
+            None => false,
+            Some(cfg) => {
+                cfg.always
+                    || self
+                        .redist_v6
+                        .iter()
+                        .any(|((rt, p), _)| p.prefix_len() == 0 && *rt != RibType::Ospf)
+            }
+        };
+        if should {
+            let cfg = self.default_originate.expect("gated on Some above");
+            self.as_external_lsa_originate_for_prefix_v3(
+                prefix,
+                cfg.metric,
+                cfg.metric_type.is_type_2(),
+            );
+            self.default_originated_v6 = true;
+        } else if self.default_originated_v6 {
+            self.as_external_lsa_flush_for_prefix_v3(prefix);
+            self.default_originated_v6 = false;
+        }
+        self.router_lsa_originate();
     }
 
     /// RFC 2328 §12.4.3 for OSPFv3 (RFC 5340 §4.4.3.4) — an Area

--- a/zebra-rs/src/rib/inst.rs
+++ b/zebra-rs/src/rib/inst.rs
@@ -483,6 +483,22 @@ pub enum Message {
         afi: super::RedistAfi,
         rtype: RibType,
     },
+    /// Watch the default route (0.0.0.0/0 or ::/0) for
+    /// `default-information originate` tracking: RIB replays the
+    /// current default (if any, self-routes excluded) and keeps
+    /// delivering RouteAdd/RouteDel for the default prefix from any
+    /// source protocol.
+    RedistDefaultAdd {
+        proto: String,
+        afi: super::RedistAfi,
+    },
+    /// Tear down a default-route watch. No Del replay: the default
+    /// prefix may also be covered by an overlapping per-rtype
+    /// subscription, so cache cleanup is the consumer's job.
+    RedistDefaultDel {
+        proto: String,
+        afi: super::RedistAfi,
+    },
     /// Tear down all RIB state owned by a protocol whose task is
     /// being despawned (`no router bgp` / `no router isis` / `no
     /// router ospf`). Withdraws every route / ILM whose `rtype`
@@ -673,6 +689,12 @@ pub struct Rib {
     /// RedistDel; consulted by `redist::notify_v*_delta`, which
     /// resolves each row's sender through `client_registry`.
     pub redist_filters: HashMap<String, super::redist::FilterMap>,
+    /// Default-prefix watch registry (`default-information originate`
+    /// tracking): per-proto set of AFIs for which the subscriber wants
+    /// RouteAdd/RouteDel deliveries for the default route only, any
+    /// rtype (self-routes excluded). Updated by RedistDefaultAdd /
+    /// RedistDefaultDel; consulted by `redist::notify_v*_delta`.
+    pub redist_default_watch: HashMap<String, std::collections::BTreeSet<super::RedistAfi>>,
     pub links: BTreeMap<u32, Link>,
     pub bridges: BTreeMap<String, Bridge>,
     pub vxlan: BTreeMap<String, Vxlan>,
@@ -872,6 +894,7 @@ impl Rib {
             inbound_tx,
             inbound_rx,
             redist_filters: HashMap::new(),
+            redist_default_watch: HashMap::new(),
             links: BTreeMap::new(),
             bridges: BTreeMap::new(),
             vxlan: BTreeMap::new(),
@@ -2063,6 +2086,80 @@ impl Rib {
     /// `0` walks the default `self.table` / `self.table_v6`; any other
     /// value is the kernel table id keying `vrf_tables`. A VRF whose
     /// table has since been torn down walks nothing.
+    /// `RedistDefaultAdd`: record the watch and replay the currently
+    /// selected default route (if any and not the subscriber's own)
+    /// as a RouteAdd, mirroring the walk-and-replay of `redist_add`.
+    fn redist_default_add(&mut self, proto: String, afi: super::RedistAfi) {
+        self.redist_default_watch
+            .entry(proto.clone())
+            .or_default()
+            .insert(afi);
+        self.redist_default_replay_add(&proto, afi);
+    }
+
+    /// `RedistDefaultDel`: drop the watch. Deliberately no Del
+    /// replay — the default prefix may also match an overlapping
+    /// per-rtype subscription whose cache entry must survive, so the
+    /// consumer purges its own cache when it stops watching.
+    fn redist_default_del(&mut self, proto: String, afi: super::RedistAfi) {
+        let emptied = if let Some(afis) = self.redist_default_watch.get_mut(&proto) {
+            afis.remove(&afi);
+            afis.is_empty()
+        } else {
+            false
+        };
+        if emptied {
+            self.redist_default_watch.remove(&proto);
+        }
+    }
+
+    /// Emit the current default route (per the subscriber's VRF) as a
+    /// single RouteAdd, self-routes excluded. No-op when no default
+    /// exists or the subscriber is unknown.
+    fn redist_default_replay_add(&self, proto: &str, afi: super::RedistAfi) {
+        let Some(sub) = self.client_registry.subscriber_for_proto(proto) else {
+            return;
+        };
+        let vrf_id = sub.vrf_id;
+        let tx = sub.rib_rx_tx.clone();
+        match afi {
+            super::RedistAfi::Ipv4 => {
+                let prefix: Ipv4Net = Ipv4Net::new(std::net::Ipv4Addr::UNSPECIFIED, 0).unwrap();
+                let table = if vrf_id == 0 {
+                    &self.table
+                } else {
+                    match self.vrf_tables.get(&vrf_id) {
+                        Some(t) => &t.table,
+                        None => return,
+                    }
+                };
+                let entry = table
+                    .get(&prefix)
+                    .and_then(|entries| entries.iter().find(|e| e.is_selected()));
+                if let Some((rt, e)) = super::redist::entry_for_default_v4(&prefix, entry, proto) {
+                    super::redist::emit_default_v4(&tx, None, Some((rt, e)));
+                }
+            }
+            super::RedistAfi::Ipv6 => {
+                let prefix: Ipv6Net = Ipv6Net::new(std::net::Ipv6Addr::UNSPECIFIED, 0).unwrap();
+                let table = if vrf_id == 0 {
+                    &self.table_v6
+                } else {
+                    match self.vrf_tables.get(&vrf_id) {
+                        Some(t) => &t.table_v6,
+                        None => return,
+                    }
+                };
+                let entry = table
+                    .get(&prefix)
+                    .and_then(|entries| entries.iter().find(|e| e.is_selected()));
+                if let Some((rt, e)) = super::redist::entry_for_default_v6(&prefix, entry, proto) {
+                    super::redist::emit_default_v6(&tx, None, Some((rt, e)));
+                }
+            }
+        }
+    }
+
     fn redist_walk(
         &self,
         proto: &str,
@@ -3042,6 +3139,12 @@ impl Rib {
             }
             Message::RedistDel { proto, afi, rtype } => {
                 self.redist_del(proto, afi, rtype);
+            }
+            Message::RedistDefaultAdd { proto, afi } => {
+                self.redist_default_add(proto, afi);
+            }
+            Message::RedistDefaultDel { proto, afi } => {
+                self.redist_default_del(proto, afi);
             }
         }
     }

--- a/zebra-rs/src/rib/redist.rs
+++ b/zebra-rs/src/rib/redist.rs
@@ -402,6 +402,7 @@ pub(super) fn selected_changed_v6(
 /// versa.
 pub fn notify_v4_delta(
     filters: &HashMap<String, FilterMap>,
+    default_watch: &HashMap<String, BTreeSet<super::RedistAfi>>,
     registry: &ClientRegistry,
     prefix: &Ipv4Net,
     before: Option<&RibEntry>,
@@ -411,6 +412,14 @@ pub fn notify_v4_delta(
     if before.is_none() && after.is_none() {
         return;
     }
+    notify_default_v4(
+        default_watch,
+        registry,
+        prefix,
+        before,
+        after,
+        target_vrf_id,
+    );
     for (proto, filter_map) in filters {
         let Some(sub) = registry.subscriber_for_proto(proto) else {
             continue;
@@ -437,6 +446,7 @@ pub fn notify_v4_delta(
 /// `target_vrf_id` scoping rules.
 pub fn notify_v6_delta(
     filters: &HashMap<String, FilterMap>,
+    default_watch: &HashMap<String, BTreeSet<super::RedistAfi>>,
     registry: &ClientRegistry,
     prefix: &Ipv6Net,
     before: Option<&RibEntry>,
@@ -446,6 +456,14 @@ pub fn notify_v6_delta(
     if before.is_none() && after.is_none() {
         return;
     }
+    notify_default_v6(
+        default_watch,
+        registry,
+        prefix,
+        before,
+        after,
+        target_vrf_id,
+    );
     for (proto, filter_map) in filters {
         let Some(sub) = registry.subscriber_for_proto(proto) else {
             continue;
@@ -461,6 +479,133 @@ pub fn notify_v6_delta(
             let old = entry_for_subscriber_v6(prefix, before, *rtype, subtypes, proto);
             let new = entry_for_subscriber_v6(prefix, after, *rtype, subtypes, proto);
             emit_v6_diff(tx, *rtype, old, new);
+        }
+    }
+}
+
+/// Default-prefix watch: like the per-rtype rows but matching only
+/// the default route (0.0.0.0/0), any rtype, self-routes excluded.
+/// Feeds `default-information originate` tracking — the consumer
+/// learns whether a non-self default exists without subscribing to
+/// whole routing tables. Deliveries ride the ordinary RouteAdd /
+/// RouteDel channel with the route's real rtype.
+fn notify_default_v4(
+    default_watch: &HashMap<String, BTreeSet<super::RedistAfi>>,
+    registry: &ClientRegistry,
+    prefix: &Ipv4Net,
+    before: Option<&RibEntry>,
+    after: Option<&RibEntry>,
+    target_vrf_id: u32,
+) {
+    if prefix.prefix_len() != 0 {
+        return;
+    }
+    for (proto, afis) in default_watch {
+        if !afis.contains(&super::RedistAfi::Ipv4) {
+            continue;
+        }
+        let Some(sub) = registry.subscriber_for_proto(proto) else {
+            continue;
+        };
+        if sub.vrf_id != target_vrf_id {
+            continue;
+        }
+        let old = entry_for_default_v4(prefix, before, proto);
+        let new = entry_for_default_v4(prefix, after, proto);
+        emit_default_v4(&sub.rib_rx_tx, old, new);
+    }
+}
+
+/// IPv6 sibling of [`notify_default_v4`] (::/0).
+fn notify_default_v6(
+    default_watch: &HashMap<String, BTreeSet<super::RedistAfi>>,
+    registry: &ClientRegistry,
+    prefix: &Ipv6Net,
+    before: Option<&RibEntry>,
+    after: Option<&RibEntry>,
+    target_vrf_id: u32,
+) {
+    if prefix.prefix_len() != 0 {
+        return;
+    }
+    for (proto, afis) in default_watch {
+        if !afis.contains(&super::RedistAfi::Ipv6) {
+            continue;
+        }
+        let Some(sub) = registry.subscriber_for_proto(proto) else {
+            continue;
+        };
+        if sub.vrf_id != target_vrf_id {
+            continue;
+        }
+        let old = entry_for_default_v6(prefix, before, proto);
+        let new = entry_for_default_v6(prefix, after, proto);
+        emit_default_v6(&sub.rib_rx_tx, old, new);
+    }
+}
+
+/// Watch-entry builder: any rtype accepted (the watch is per-prefix,
+/// not per-source), self-routes still excluded via `deliverable`.
+pub(super) fn entry_for_default_v4(
+    prefix: &Ipv4Net,
+    entry: Option<&RibEntry>,
+    proto: &str,
+) -> Option<(RibType, RouteEntryV4)> {
+    let e = entry?;
+    if !deliverable(proto, e.rtype) {
+        return None;
+    }
+    build_v4_entry(prefix, e).map(|b| (e.rtype, b))
+}
+
+/// IPv6 sibling of [`entry_for_default_v4`].
+pub(super) fn entry_for_default_v6(
+    prefix: &Ipv6Net,
+    entry: Option<&RibEntry>,
+    proto: &str,
+) -> Option<(RibType, RouteEntryV6)> {
+    let e = entry?;
+    if !deliverable(proto, e.rtype) {
+        return None;
+    }
+    build_v6_entry(prefix, e).map(|b| (e.rtype, b))
+}
+
+/// Diff-emit for the default watch. Unlike `emit_v4_diff` the rtype
+/// can change across the transition (default moved from static to
+/// bgp), so a changed entry is a Del under the old rtype followed by
+/// an Add under the new one.
+pub(super) fn emit_default_v4(
+    tx: &UnboundedSender<RibRx>,
+    old: Option<(RibType, RouteEntryV4)>,
+    new: Option<(RibType, RouteEntryV4)>,
+) {
+    match (old, new) {
+        (None, None) => {}
+        (Some((rt, o)), None) => send_v4_one(tx, rt, WalkOp::Del, o),
+        (None, Some((rt, n))) => send_v4_one(tx, rt, WalkOp::Add, n),
+        (Some((ort, o)), Some((nrt, n))) if ort == nrt && o == n => {}
+        (Some((ort, o)), Some((nrt, n))) => {
+            send_v4_one(tx, ort, WalkOp::Del, o);
+            send_v4_one(tx, nrt, WalkOp::Add, n);
+        }
+    }
+}
+
+/// IPv6 sibling of [`emit_default_v4`].
+pub(super) fn emit_default_v6(
+    tx: &UnboundedSender<RibRx>,
+    old: Option<(RibType, RouteEntryV6)>,
+    new: Option<(RibType, RouteEntryV6)>,
+) {
+    match (old, new) {
+        (None, None) => {}
+        (Some((rt, o)), None) => send_v6_one(tx, rt, WalkOp::Del, o),
+        (None, Some((rt, n))) => send_v6_one(tx, rt, WalkOp::Add, n),
+        (Some((ort, o)), Some((nrt, n))) if ort == nrt && o == n => {}
+        (Some((ort, o)), Some((nrt, n))) => {
+            send_v6_one(tx, ort, WalkOp::Del, o);
+            send_v6_one(tx, nrt, WalkOp::Add, n);
         }
     }
 }
@@ -747,7 +892,15 @@ mod tests {
         let conn = connected_link(7);
 
         // Connected route appears in VRF 100 → only the VRF subscriber.
-        notify_v4_delta(&filters, &reg, &prefix, None, Some(&conn), 100);
+        notify_v4_delta(
+            &filters,
+            &HashMap::new(),
+            &reg,
+            &prefix,
+            None,
+            Some(&conn),
+            100,
+        );
         assert!(
             matches!(rx_vrf.try_recv(), Ok(RibRx::RouteAdd { .. })),
             "VRF subscriber must hear the VRF-100 add"
@@ -759,7 +912,15 @@ mod tests {
 
         // Same prefix appears in the default table → only the default
         // subscriber.
-        notify_v4_delta(&filters, &reg, &prefix, None, Some(&conn), 0);
+        notify_v4_delta(
+            &filters,
+            &HashMap::new(),
+            &reg,
+            &prefix,
+            None,
+            Some(&conn),
+            0,
+        );
         assert!(
             matches!(rx_def.try_recv(), Ok(RibRx::RouteAdd { .. })),
             "default subscriber must hear the default-table add"
@@ -779,7 +940,15 @@ mod tests {
         let prefix: Ipv4Net = "203.0.113.0/24".parse().unwrap();
         let conn = connected_link(7);
 
-        notify_v4_delta(&filters, &reg, &prefix, None, Some(&conn), 777);
+        notify_v4_delta(
+            &filters,
+            &HashMap::new(),
+            &reg,
+            &prefix,
+            None,
+            Some(&conn),
+            777,
+        );
         assert!(rx_def.try_recv().is_err());
         assert!(rx_vrf.try_recv().is_err());
     }

--- a/zebra-rs/src/rib/route.rs
+++ b/zebra-rs/src/rib/route.rs
@@ -590,6 +590,7 @@ impl Rib {
             .cloned();
         super::redist::notify_v4_delta(
             &self.redist_filters,
+            &self.redist_default_watch,
             &self.client_registry,
             prefix,
             before.as_ref(),
@@ -622,6 +623,7 @@ impl Rib {
             .cloned();
         super::redist::notify_v4_delta(
             &self.redist_filters,
+            &self.redist_default_watch,
             &self.client_registry,
             prefix,
             before.as_ref(),
@@ -668,6 +670,7 @@ impl Rib {
             .cloned();
         super::redist::notify_v6_delta(
             &self.redist_filters,
+            &self.redist_default_watch,
             &self.client_registry,
             prefix,
             before.as_ref(),
@@ -700,6 +703,7 @@ impl Rib {
             .cloned();
         super::redist::notify_v6_delta(
             &self.redist_filters,
+            &self.redist_default_watch,
             &self.client_registry,
             prefix,
             before.as_ref(),
@@ -785,6 +789,7 @@ impl Rib {
         let after = selected_v4(&self.table, prefix).cloned();
         super::redist::notify_v4_delta(
             &self.redist_filters,
+            &self.redist_default_watch,
             &self.client_registry,
             prefix,
             before.as_ref(),
@@ -811,6 +816,7 @@ impl Rib {
         let after = selected_v4(&self.table, prefix).cloned();
         super::redist::notify_v4_delta(
             &self.redist_filters,
+            &self.redist_default_watch,
             &self.client_registry,
             prefix,
             before.as_ref(),
@@ -933,6 +939,7 @@ impl Rib {
         let after = selected_v6(&self.table_v6, prefix).cloned();
         super::redist::notify_v6_delta(
             &self.redist_filters,
+            &self.redist_default_watch,
             &self.client_registry,
             prefix,
             before.as_ref(),
@@ -959,6 +966,7 @@ impl Rib {
         let after = selected_v6(&self.table_v6, prefix).cloned();
         super::redist::notify_v6_delta(
             &self.redist_filters,
+            &self.redist_default_watch,
             &self.client_registry,
             prefix,
             before.as_ref(),
@@ -998,6 +1006,7 @@ impl Rib {
         for (prefix, before, after) in deltas {
             super::redist::notify_v4_delta(
                 &self.redist_filters,
+                &self.redist_default_watch,
                 &self.client_registry,
                 &prefix,
                 before.as_ref(),
@@ -1029,6 +1038,7 @@ impl Rib {
         for (prefix, before, after) in deltas {
             super::redist::notify_v6_delta(
                 &self.redist_filters,
+                &self.redist_default_watch,
                 &self.client_registry,
                 &prefix,
                 before.as_ref(),
@@ -1070,6 +1080,7 @@ impl Rib {
         for (prefix, before, after) in deltas {
             super::redist::notify_v4_delta(
                 &self.redist_filters,
+                &self.redist_default_watch,
                 &self.client_registry,
                 &prefix,
                 before.as_ref(),
@@ -1095,6 +1106,7 @@ impl Rib {
         for (prefix, before, after) in deltas {
             super::redist::notify_v6_delta(
                 &self.redist_filters,
+                &self.redist_default_watch,
                 &self.client_registry,
                 &prefix,
                 before.as_ref(),

--- a/zebra-rs/yang/config.yang
+++ b/zebra-rs/yang/config.yang
@@ -595,6 +595,35 @@ module config {
             }
           }
         }
+        // FRR-parity `default-information originate`: advertise a
+        // Type-5 default route. Without `always` it is originated
+        // only while a non-OSPF default route sits in the RIB
+        // (tracked via the RIB default-route watch); `always`
+        // originates unconditionally. Metric defaults to 10 (FRR
+        // convention for the originated default; redistribute uses
+        // 20), E2 semantics.
+        container default-information {
+          container originate {
+            presence "Originate a Type-5 default route";
+            leaf always {
+              type boolean;
+              default false;
+            }
+            leaf metric {
+              type uint32 {
+                range "0..16777214";
+              }
+              default 10;
+            }
+            leaf metric-type {
+              type enumeration {
+                enum type-1;
+                enum type-2;
+              }
+              default type-2;
+            }
+          }
+        }
         list area {
           // Area key accepts either a plain decimal (`area 0`) or a
           // dotted-quad (`area 0.0.0.1`). Both normalize to a 32-bit
@@ -1321,6 +1350,35 @@ module config {
                 range "0..16777214";
               }
               default 20;
+            }
+            leaf metric-type {
+              type enumeration {
+                enum type-1;
+                enum type-2;
+              }
+              default type-2;
+            }
+          }
+        }
+        // FRR-parity `default-information originate`: advertise a
+        // Type-5 default route. Without `always` it is originated
+        // only while a non-OSPF default route sits in the RIB
+        // (tracked via the RIB default-route watch); `always`
+        // originates unconditionally. Metric defaults to 10 (FRR
+        // convention for the originated default; redistribute uses
+        // 20), E2 semantics.
+        container default-information {
+          container originate {
+            presence "Originate a Type-5 default route";
+            leaf always {
+              type boolean;
+              default false;
+            }
+            leaf metric {
+              type uint32 {
+                range "0..16777214";
+              }
+              default 10;
             }
             leaf metric-type {
               type enumeration {


### PR DESCRIPTION
## Summary

Implements `default-information originate [always] [metric <m>] [metric-type <1|2>]` for OSPFv2 and OSPFv3, closing the default-origination gap against FRR:

- **RIB default-route watch** (`RedistDefaultAdd/Del`): a protocol subscribes to RouteAdd/RouteDel deliveries for the default prefix only (any source rtype, self-routes excluded), so "does a non-OSPF default exist" is trackable without table-wide subscriptions. Add replays the current default; Del deliberately does no replay (the prefix may also match an overlapping per-rtype subscription), so cache cleanup is consumer-owned. Reusable by IS-IS later.
- **OSPF**: with `always` the Type-5 default (0.0.0.0/0 / ::/0) is originated unconditionally; without, it tracks the watch — originating when a non-OSPF default appears and flushing when it disappears. Metric defaults to 10 (FRR parity; redistribute uses 20), E2 semantics; the knob makes the router an ASBR (E-bit). The flush is guarded so a redistribute-owned 0/0 survives knob removal.
- **Bug fix found by the BDD**: config-time originations (default-originate `always`, NSSA defaults) raced the router-id assignment when they preceded the `router-id` leaf in commit order, stranding LSAs under the constructor-default 10.0.0.1 — silently ignored by any peer owning that Router-ID. `router_id_update` (both versions) now re-runs the config-driven originators after adopting the new identity, complementing its existing old-identity flush.
- Book: default-origination sections on both redistribution pages, gaps bullets removed, FRR cross-reference rows added.

## Test plan

- New BDD features pass: `ospfv2_default_originate` and `ospfv3_default_originate` (2 scenarios each) — `always` at metric 10, and the conditional cycle: silent → static default configured live → advertised → static deleted → flushed.
- Parse regression test pins all eight spellings.
- `cargo fmt --check`, clippy `-D warnings` (default and no-lua), `cargo test --workspace --exclude bdd` (2135 passed, 0 failed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)