### PR TITLE
ospf: native OSPFv3 auth config + fix the broken v3 RFC 7166 datapath

### DIFF
--- a/bdd/tests/configs/ospfv3_auth/a_chain.yaml
+++ b/bdd/tests/configs/ospfv3_auth/a_chain.yaml
@@ -1,0 +1,31 @@
+# RFC 8177 key-chain supplying the RFC 7166 trailer key, via the
+# native router-ospfv3 key-chain leaf.
+key-chains:
+  key-chain:
+  - name: OSPF6-KC
+    key:
+    - key-id: 1
+      crypto-algorithm: hmac-sha-256
+      key-string:
+        keystring: "zebra-v3-chain-secret"
+
+interface:
+- if-name: lo
+  ipv6:
+    address: 2001:db8::1/128
+- if-name: ethb
+  ipv6:
+    address: 2001:db8:12::1/64
+router:
+  ospfv3:
+    router-id: 10.0.0.1
+    area:
+    - area-id: 0.0.0.0
+      interface:
+      - if-name: lo
+        enable: true
+      - if-name: ethb
+        enable: true
+        network-type: point-to-point
+        authentication: message-digest
+        key-chain: OSPF6-KC

--- a/bdd/tests/configs/ospfv3_auth/a_sha256.yaml
+++ b/bdd/tests/configs/ospfv3_auth/a_sha256.yaml
@@ -1,0 +1,24 @@
+# Native router-ospfv3 RFC 7166 trailer config: HMAC-SHA-256 via
+# the per-interface crypto-key list. b must carry the same key.
+interface:
+- if-name: lo
+  ipv6:
+    address: 2001:db8::1/128
+- if-name: ethb
+  ipv6:
+    address: 2001:db8:12::1/64
+router:
+  ospfv3:
+    router-id: 10.0.0.1
+    area:
+    - area-id: 0.0.0.0
+      interface:
+      - if-name: lo
+        enable: true
+      - if-name: ethb
+        enable: true
+        network-type: point-to-point
+        authentication: message-digest
+        crypto-key:
+        - key-id: 1
+          hmac-sha-256: zebra-v3-sha256-secret

--- a/bdd/tests/configs/ospfv3_auth/b_badkey.yaml
+++ b/bdd/tests/configs/ospfv3_auth/b_badkey.yaml
@@ -1,0 +1,24 @@
+# Negative case: same mode and SA-ID, different secret — every
+# packet fails trailer verification, so no neighbor ever forms.
+interface:
+- if-name: lo
+  ipv6:
+    address: 2001:db8::2/128
+- if-name: etha
+  ipv6:
+    address: 2001:db8:12::2/64
+router:
+  ospfv3:
+    router-id: 10.0.0.2
+    area:
+    - area-id: 0.0.0.0
+      interface:
+      - if-name: lo
+        enable: true
+      - if-name: etha
+        enable: true
+        network-type: point-to-point
+        authentication: message-digest
+        crypto-key:
+        - key-id: 1
+          hmac-sha-256: wrong-v3-secret

--- a/bdd/tests/configs/ospfv3_auth/b_chain.yaml
+++ b/bdd/tests/configs/ospfv3_auth/b_chain.yaml
@@ -1,0 +1,29 @@
+key-chains:
+  key-chain:
+  - name: OSPF6-KC
+    key:
+    - key-id: 1
+      crypto-algorithm: hmac-sha-256
+      key-string:
+        keystring: "zebra-v3-chain-secret"
+
+interface:
+- if-name: lo
+  ipv6:
+    address: 2001:db8::2/128
+- if-name: etha
+  ipv6:
+    address: 2001:db8:12::2/64
+router:
+  ospfv3:
+    router-id: 10.0.0.2
+    area:
+    - area-id: 0.0.0.0
+      interface:
+      - if-name: lo
+        enable: true
+      - if-name: etha
+        enable: true
+        network-type: point-to-point
+        authentication: message-digest
+        key-chain: OSPF6-KC

--- a/bdd/tests/configs/ospfv3_auth/b_sha256.yaml
+++ b/bdd/tests/configs/ospfv3_auth/b_sha256.yaml
@@ -1,0 +1,22 @@
+interface:
+- if-name: lo
+  ipv6:
+    address: 2001:db8::2/128
+- if-name: etha
+  ipv6:
+    address: 2001:db8:12::2/64
+router:
+  ospfv3:
+    router-id: 10.0.0.2
+    area:
+    - area-id: 0.0.0.0
+      interface:
+      - if-name: lo
+        enable: true
+      - if-name: etha
+        enable: true
+        network-type: point-to-point
+        authentication: message-digest
+        crypto-key:
+        - key-id: 1
+          hmac-sha-256: zebra-v3-sha256-secret

--- a/bdd/tests/features/ospfv3_auth.feature
+++ b/bdd/tests/features/ospfv3_auth.feature
@@ -1,0 +1,87 @@
+@serial
+@ospfv3_auth
+Feature: OSPFv3 native authentication config drives the RFC 7166 trailer
+  As a network operator
+  I want `router ospfv3 area <id> interface <n> authentication
+  message-digest` with `crypto-key` / `key-chain` to configure the
+  RFC 7166 Authentication Trailer natively — no `router ospf` block
+  required in an IPv6-only deployment — so adjacencies form only
+  between routers sharing the key.
+
+  Two routers on a point-to-point link; each scenario brings the
+  pair up under one keying mode. The final scenario proves the
+  negative: same SA-ID, different secrets, no neighbor ever forms.
+
+  Test Topology:
+  ```
+    a (10.0.0.1) -- 2001:db8:12::/64 -- b (10.0.0.2)
+  ```
+
+  Scenario: HMAC-SHA-256 trailer via native crypto-key forms a Full adjacency
+    Given a clean test environment
+    When I create namespace "a"
+    And I create namespace "b"
+    And I connect namespace "a" interface "ethb" to namespace "b" interface "etha"
+    And I start zebra-rs in namespace "a"
+    And I start zebra-rs in namespace "b"
+    And I apply config "a_sha256.yaml" to namespace "a"
+    And I apply config "b_sha256.yaml" to namespace "b"
+    And I wait 30 seconds
+
+    Then show command "show ospfv3 neighbor" in namespace "a" should contain "Full"
+    And show command "show ospfv3 neighbor" in namespace "a" should contain "10.0.0.2"
+    And show command "show ospfv3 neighbor" in namespace "b" should contain "Full"
+    And ping from "a" to "2001:db8::2" should succeed
+
+    # Teardown.
+    When I stop zebra-rs in namespace "a"
+    And I stop zebra-rs in namespace "b"
+    And I delete namespace "a"
+    And I delete namespace "b"
+    Then the test environment should be clean
+
+  Scenario: RFC 8177 key-chain supplies the trailer key
+    Given a clean test environment
+    When I create namespace "a"
+    And I create namespace "b"
+    And I connect namespace "a" interface "ethb" to namespace "b" interface "etha"
+    And I start zebra-rs in namespace "a"
+    And I start zebra-rs in namespace "b"
+    And I apply config "a_chain.yaml" to namespace "a"
+    And I apply config "b_chain.yaml" to namespace "b"
+    And I wait 30 seconds
+
+    Then show command "show ospfv3 neighbor" in namespace "a" should contain "Full"
+    And show command "show ospfv3 neighbor" in namespace "a" should contain "10.0.0.2"
+    And show command "show ospfv3 neighbor" in namespace "b" should contain "Full"
+    And ping from "a" to "2001:db8::2" should succeed
+
+    # Teardown.
+    When I stop zebra-rs in namespace "a"
+    And I stop zebra-rs in namespace "b"
+    And I delete namespace "a"
+    And I delete namespace "b"
+    Then the test environment should be clean
+
+  Scenario: Mismatched trailer secrets never form a neighbor
+    Given a clean test environment
+    When I create namespace "a"
+    And I create namespace "b"
+    And I connect namespace "a" interface "ethb" to namespace "b" interface "etha"
+    And I start zebra-rs in namespace "a"
+    And I start zebra-rs in namespace "b"
+    And I apply config "a_sha256.yaml" to namespace "a"
+    And I apply config "b_badkey.yaml" to namespace "b"
+    # Three hello cycles — plenty for a neighbor to appear if the
+    # trailer verification (wrongly) let packets through.
+    And I wait 30 seconds
+
+    Then show command "show ospfv3 neighbor" in namespace "a" should not contain "10.0.0.2"
+    And show command "show ospfv3 neighbor" in namespace "b" should not contain "10.0.0.1"
+
+    # Teardown.
+    When I stop zebra-rs in namespace "a"
+    And I stop zebra-rs in namespace "b"
+    And I delete namespace "a"
+    And I delete namespace "b"
+    Then the test environment should be clean

--- a/book/src/ch-08-16-ospf-authentication.md
+++ b/book/src/ch-08-16-ospf-authentication.md
@@ -156,18 +156,11 @@ also serves IS-IS and BGP.
 ## OSPFv3 — Authentication Trailer (RFC 7166)
 
 OSPFv3 has no authentication field of its own in the packet header;
-zebra-rs implements the RFC 7166 Authentication Trailer instead:
-the AT-bit is set in the options of Hellos and DBDs, and an
-HMAC-SHA trailer — with a 16-bit Security Association ID, a 64-bit
-sequence number, and the Apad construction of RFC 7166 §3.5
-covering the IPv6 source address — is appended outside the OSPF
-length and checksum. The same HMAC-SHA algorithm set as v2 applies,
-and the per-interface authentication state (mode, keys, key-chain)
-is shared between the v2 and v3 instances of a link.
-
-Note the configuration caveat: the authentication leaves shown
-above attach to the `router ospf` (v2) interface tree only — there
-is currently no separate `router ospfv3 … authentication` path.
+zebra-rs implements the RFC 7166 Authentication Trailer, configured
+natively on the `router ospfv3` interface tree (`authentication
+message-digest` plus `crypto-key` / `key-chain` — HMAC-SHA only, per
+the RFC). See
+[the OSPFv3 chapter's Authentication page](ch-15-08-ospfv3-authentication.md).
 
 All four OSPFv2 modes — simple password, keyed-MD5, HMAC-SHA-256,
 and key-chain — are BDD-validated end to end

--- a/book/src/ch-15-08-ospfv3-authentication.md
+++ b/book/src/ch-15-08-ospfv3-authentication.md
@@ -3,8 +3,8 @@
 OSPFv3 removed the per-packet authentication field that OSPFv2
 carries in its header — the original design delegated security to
 IPsec (RFC 4552). zebra-rs implements the modern alternative: the
-**Authentication Trailer** of RFC 7166, which appends an HMAC-SHA
-digest to each packet without IPsec infrastructure.
+**Authentication Trailer** of RFC 7166, configured natively on the
+`router ospfv3` interface tree.
 
 How it works on the wire:
 
@@ -12,29 +12,18 @@ How it works on the wire:
   Description packets (RFC 7166 §2.2), announcing that packets carry
   the trailer.
 - Each packet ends with a trailer holding a 16-bit **Security
-  Association ID** (the key-id), a **64-bit sequence number** for
-  replay protection, and the digest.
+  Association ID** (the configured key-id), a **64-bit sequence
+  number** for replay protection, and the digest.
 - The digest is `HMAC-SHA-x(key, source-address ‖ packet ‖ trailer)`
   with the Apad construction of RFC 7166 §3.5 — including the IPv6
-  source address defeats packet-replay from a different link.
+  source address defeats packet replay from a different link.
 - The trailer rides *outside* the OSPF length field and checksum, as
   a pure tail (RFC 7166 §4.1).
 
-The algorithm set matches OSPFv2's cryptographic authentication:
-HMAC-SHA-1, -256, -384, and -512.
-
 ## Configuration
 
-The authentication state (mode, keys, key-chain reference) is
-per-interface and **shared between the v2 and v3 instances of a
-link** — the same leaves documented in the OSPFv2 chapter's
-[Authentication page](ch-08-16-ospf-authentication.md) drive both
-versions. Configure `authentication message-digest` plus a
-`crypto-key` (or `key-chain`) on the interface entry, and the v3
-side emits and requires the RFC 7166 trailer:
-
 ```
-router ospf {
+router ospfv3 {
   area 0 {
     interface enp0s6 {
       enable true;
@@ -45,19 +34,24 @@ router ospf {
     }
   }
 }
-router ospfv3 {
-  area 0 {
-    interface enp0s6 {
-      enable true;
-    }
-  }
-}
 ```
 
-Note the caveat: there is currently no separate
-`router ospfv3 … authentication` configuration path — the leaves
-attach to the `router ospf` interface tree only, which is awkward
-for an IPv6-only deployment (a `router ospf` block must exist to
-carry the keys). Key rollover semantics, silent-drop behavior on
-verification failure, and RFC 8177 key-chain handling are identical
-to v2.
+| YANG leaf (`/router/ospfv3/area/<id>/interface/<n>/…`) | Type | Notes |
+|---|---|---|
+| `authentication` | `null` \| `message-digest` | Trailer on/off. RFC 7166 defines only HMAC-SHA algorithms, so unlike OSPFv2 there is no `simple` mode and no keyed-MD5 list. |
+| `crypto-key/<key-id>/hmac-sha-1` … `hmac-sha-512` | key-id 1..255 | The key-id is carried as the trailer's Security Association ID; the secret is capped at the digest length (20/32/48/64). |
+| `key-chain` | string | An RFC 8177 `/key-chains/key-chain` reference — supersedes inline `crypto-key` entries, with send/accept-lifetime driven rollover. |
+
+Key rollover, chain semantics, silent-drop behavior on verification
+failure, and the send-lowest / accept-any key-id model are identical
+to [the OSPFv2 page](ch-08-16-ospf-authentication.md); the same
+`/key-chains` tree serves IS-IS, BGP, and both OSPF versions.
+
+All three modes — inline HMAC-SHA-256, key-chain, and the
+mismatched-secret negative — are BDD-validated end to end over the
+native config path (`ospfv3_auth.feature`), with no `router ospf`
+block required in an IPv6-only deployment.
+
+For OSPFv2's authentication surface (simple password, keyed-MD5,
+RFC 5709 HMAC-SHA), see
+[the v2 Authentication page](ch-08-16-ospf-authentication.md).

--- a/book/src/ch-15-14-ospfv3-frr-cross-reference.md
+++ b/book/src/ch-15-14-ospfv3-frr-cross-reference.md
@@ -18,6 +18,7 @@ interface to an area with a per-interface command.
 | `area/<id>/interface/<n>/retransmit-interval` | `ipv6 ospf6 retransmit-interval` (interface) |
 | `area/<id>/interface/<n>/mtu-ignore` | `ipv6 ospf6 mtu-ignore` (interface) |
 | `area/<id>/interface/<n>/passive true` | `ipv6 ospf6 passive` (interface) |
+| `area/<id>/interface/<n>/authentication message-digest` + `key-chain` | `ipv6 ospf6 authentication keychain <name>` (interface) |
 | `area/<id>/area-type stub` | `area <id> stub` |
 | `area/<id>/area-type nssa` | `area <id> nssa` |
 | `area/<id>/no-summary true` | `area <id> stub no-summary` / `area <id> nssa no-summary` |

--- a/book/src/ch-15-15-ospfv3-frr-gaps.md
+++ b/book/src/ch-15-15-ospfv3-frr-gaps.md
@@ -6,10 +6,6 @@ OSPFv3 features not yet implemented in zebra-rs:
   and suppression themselves are implemented.
 - Redistribution `route-map` filtering (the zebra-rs sources are
   connected, static, kernel, IS-IS, and BGP, matching v2).
-- A native `router ospfv3` authentication config path — the
-  RFC 7166 Authentication Trailer is implemented, but its keys are
-  configured through the shared v2 interface tree (`ospf6d` has
-  `ipv6 ospf6 authentication` per interface).
 - Non-zero forwarding-address resolution on received externals.
 - NBMA and point-to-multipoint network types.
 - Configurable SPF throttling (SPF is coalesced behind a fixed

--- a/crates/ospf-packet/src/v3.rs
+++ b/crates/ospf-packet/src/v3.rs
@@ -132,14 +132,20 @@ pub fn parse_v3(input: &[u8]) -> IResult<&[u8], Ospfv3Packet> {
     let (_, mut packet) = Ospfv3Packet::parse_be(&input[..pkt_len])?;
     packet.raw_body = input[..pkt_len].to_vec();
 
-    // RFC 7166: the trailer follows the OSPF body when the AT-bit
-    // is set in the packet's Options. The trailer's own
-    // `auth_data_len` field (first 4 octets at offset 2..4 of the
-    // trailer) gives its total length. We probe rather than parse
-    // the full struct here so an unknown auth_type still consumes
-    // the right number of bytes.
+    // RFC 7166: once the AT-bit is negotiated (advertised in the
+    // Hello/DBD Options), EVERY subsequent OSPF packet carries the
+    // trailer — but LSReq / LSUpd / LSAck have no Options field to
+    // re-signal it, so the packet type alone can't tell us. The
+    // trailer is instead identified positionally: any bytes trailing
+    // the OSPF `len` are the trailer. We probe its `auth_data_len`
+    // (offset 2..4 of the trailer) rather than parsing the full
+    // struct so an unknown auth_type still consumes the right length.
+    // (`packet_has_at_bit` remains the cheap confirmation for the
+    // Options-bearing types but is not required — gating on it
+    // dropped the trailer on LSUpd/LSReq/LSAck and wedged
+    // authenticated adjacencies in Loading.)
     let mut consumed = pkt_len;
-    if packet_has_at_bit(&packet) && input.len() >= pkt_len + 4 {
+    if input.len() >= pkt_len + 4 {
         let trailer_len = BigEndian::read_u16(&input[pkt_len + 2..pkt_len + 4]) as usize;
         // Minimum sanity bound: 16-byte fixed prefix; reject
         // obviously-bogus lengths so we don't allocate gigabytes.
@@ -149,20 +155,6 @@ pub fn parse_v3(input: &[u8]) -> IResult<&[u8], Ospfv3Packet> {
         }
     }
     Ok((&input[consumed..], packet))
-}
-
-/// Peek at a parsed v3 packet's Options field for the AT-bit.
-/// Only Hello and DBD carry Options on the wire; LSReq / LSUpd /
-/// LSAck don't, so the trailer is signaled by the adjacency's
-/// negotiated state (out of scope for the parser — we still
-/// consume a trailer if one happens to be present, but the
-/// AT-bit probe is the cheap check).
-fn packet_has_at_bit(packet: &Ospfv3Packet) -> bool {
-    match &packet.payload {
-        Ospfv3Payload::Hello(h) => h.options.at(),
-        Ospfv3Payload::DbDesc(d) => d.options.at(),
-        _ => false,
-    }
 }
 
 /// RFC 7166 §4.1 Authentication Trailer header. Sits between the

--- a/zebra-rs/src/config/manager.rs
+++ b/zebra-rs/src/config/manager.rs
@@ -3627,4 +3627,47 @@ mod yang_load_tests {
             assert_eq!(code, ExecCode::Success, "`{path}` must be a settable path");
         }
     }
+    /// Native `router ospfv3` authentication paths (RFC 7166 trailer)
+    /// — previously the v3 trailer was configurable only through the
+    /// shared v2 interface tree. Pin every spelling settable.
+    #[test]
+    fn ospfv3_interface_authentication_paths_parse() {
+        use crate::config::ExecCode;
+        use crate::config::parse::{State, parse};
+        use libyang::to_entry;
+
+        let mut yang = YangStore::new();
+        yang.add_path(concat!(env!("CARGO_MANIFEST_DIR"), "/yang"));
+        yang.read_with_resolve("configure")
+            .expect("configure mode loads");
+        yang.identity_resolve();
+        let module = yang
+            .find_module("configure")
+            .expect("configure module present");
+        let entry = to_entry(&yang, module);
+
+        for path in [
+            "set router ospfv3 area 0 interface eth0 authentication null",
+            "set router ospfv3 area 0 interface eth0 authentication message-digest",
+            "set router ospfv3 area 0 interface eth0 crypto-key 1 hmac-sha-1 shasecret",
+            "set router ospfv3 area 0 interface eth0 crypto-key 1 hmac-sha-256 shasecret",
+            "set router ospfv3 area 0 interface eth0 crypto-key 1 hmac-sha-384 shasecret",
+            "set router ospfv3 area 0 interface eth0 crypto-key 1 hmac-sha-512 shasecret",
+            "set router ospfv3 area 0 interface eth0 key-chain OSPF-KC",
+        ] {
+            let (code, _comps, _state) = parse(path, entry.clone(), None, State::new());
+            assert_eq!(code, ExecCode::Success, "`{path}` must be a settable path");
+        }
+
+        // RFC 7166 has no simple-password mode — the v2-only
+        // spellings must NOT parse under router ospfv3.
+        for path in [
+            "set router ospfv3 area 0 interface eth0 authentication simple",
+            "set router ospfv3 area 0 interface eth0 authentication-key secret08",
+            "set router ospfv3 area 0 interface eth0 message-digest-key 1 md5 md5secret",
+        ] {
+            let (code, _comps, _state) = parse(path, entry.clone(), None, State::new());
+            assert_ne!(code, ExecCode::Success, "`{path}` must NOT be settable");
+        }
+    }
 }

--- a/zebra-rs/src/ospf/config_v3.rs
+++ b/zebra-rs/src/ospf/config_v3.rs
@@ -192,6 +192,30 @@ impl Ospf<Ospfv3> {
                 config_ospfv3_interface_network_type,
             ),
             ("/area/interface/passive", config_ospfv3_interface_passive),
+            (
+                "/area/interface/authentication",
+                config_ospfv3_interface_authentication,
+            ),
+            (
+                "/area/interface/key-chain",
+                config_ospfv3_interface_key_chain,
+            ),
+            (
+                "/area/interface/crypto-key/hmac-sha-1",
+                config_ospfv3_interface_crypto_key_hmac_sha_1,
+            ),
+            (
+                "/area/interface/crypto-key/hmac-sha-256",
+                config_ospfv3_interface_crypto_key_hmac_sha_256,
+            ),
+            (
+                "/area/interface/crypto-key/hmac-sha-384",
+                config_ospfv3_interface_crypto_key_hmac_sha_384,
+            ),
+            (
+                "/area/interface/crypto-key/hmac-sha-512",
+                config_ospfv3_interface_crypto_key_hmac_sha_512,
+            ),
             ("/area/interface/priority", config_ospfv3_interface_priority),
             ("/area/interface/cost", config_ospfv3_interface_cost),
             (
@@ -725,6 +749,148 @@ fn config_ospfv3_gr_drain_time_ms(
 ) -> Option<()> {
     let value = if op.is_set() { args.u32()? } else { 200 };
     ospf.gr_config.drain_time_ms = value.clamp(50, 2000);
+    Some(())
+}
+
+/// `/router/ospfv3/area/<id>/interface/<name>/authentication` —
+/// RFC 7166 trailer mode. Only `null` and `message-digest` exist for
+/// v3 (RFC 7166 §4 defines only HMAC-SHA algorithms; there is no
+/// simple-password equivalent).
+fn config_ospfv3_interface_authentication(
+    ospf: &mut Ospf<Ospfv3>,
+    mut args: Args,
+    op: ConfigOp,
+) -> Option<()> {
+    use super::link::OspfAuthMode;
+
+    let _area_id = parse_area_id(&args.string()?)?;
+    let name = args.string()?;
+    let mode = args.string()?;
+
+    let link = ospf_link_get_mut_by_name(&mut ospf.links, &name)?;
+    if op.is_set() {
+        link.config.auth_mode = Some(match mode.as_str() {
+            "null" => OspfAuthMode::Null,
+            "message-digest" => OspfAuthMode::MessageDigest,
+            _ => return None,
+        });
+    } else {
+        link.config.auth_mode = None;
+    }
+
+    Some(())
+}
+
+/// Shared body for the four v3 `/area/interface/crypto-key/hmac-sha-*`
+/// callbacks — v3 sibling of `install_crypto_hmac_key`. Keys land in
+/// the same per-link keyring the RFC 7166 trailer send/verify reads.
+fn install_crypto_hmac_key_v3(
+    ospf: &mut Ospf<Ospfv3>,
+    mut args: Args,
+    op: ConfigOp,
+    algo: super::link::OspfCryptoAlgo,
+) -> Option<()> {
+    use super::link::AuthKey;
+
+    let _area_id = parse_area_id(&args.string()?)?;
+    let name = args.string()?;
+    let key_id: u8 = args.string()?.parse().ok()?;
+    if key_id == 0 {
+        return None;
+    }
+
+    let link = ospf_link_get_mut_by_name(&mut ospf.links, &name)?;
+    if op.is_set() {
+        let key = args.string()?;
+        let bytes = key.as_bytes();
+        // RFC 5709 §3.4 block-size cap, shared with the v2 path.
+        if bytes.is_empty() || bytes.len() > algo.digest_len() {
+            return None;
+        }
+        link.config.crypto_keys.insert(
+            key_id,
+            AuthKey {
+                algo,
+                raw: bytes.to_vec(),
+            },
+        );
+    } else {
+        link.config.crypto_keys.remove(&key_id);
+    }
+
+    Some(())
+}
+
+fn config_ospfv3_interface_crypto_key_hmac_sha_1(
+    ospf: &mut Ospf<Ospfv3>,
+    args: Args,
+    op: ConfigOp,
+) -> Option<()> {
+    install_crypto_hmac_key_v3(ospf, args, op, super::link::OspfCryptoAlgo::HmacSha1)
+}
+
+fn config_ospfv3_interface_crypto_key_hmac_sha_256(
+    ospf: &mut Ospf<Ospfv3>,
+    args: Args,
+    op: ConfigOp,
+) -> Option<()> {
+    install_crypto_hmac_key_v3(ospf, args, op, super::link::OspfCryptoAlgo::HmacSha256)
+}
+
+fn config_ospfv3_interface_crypto_key_hmac_sha_384(
+    ospf: &mut Ospf<Ospfv3>,
+    args: Args,
+    op: ConfigOp,
+) -> Option<()> {
+    install_crypto_hmac_key_v3(ospf, args, op, super::link::OspfCryptoAlgo::HmacSha384)
+}
+
+fn config_ospfv3_interface_crypto_key_hmac_sha_512(
+    ospf: &mut Ospf<Ospfv3>,
+    args: Args,
+    op: ConfigOp,
+) -> Option<()> {
+    install_crypto_hmac_key_v3(ospf, args, op, super::link::OspfCryptoAlgo::HmacSha512)
+}
+
+/// `/router/ospfv3/area/<id>/interface/<name>/key-chain` — v3
+/// sibling of `config_ospf_interface_key_chain`, registering under
+/// proto "ospfv3" so the policy actor pushes chain updates to this
+/// instance's `key_chains` (the v3 policy_rx arm already consumes
+/// them).
+fn config_ospfv3_interface_key_chain(
+    ospf: &mut Ospf<Ospfv3>,
+    mut args: Args,
+    op: ConfigOp,
+) -> Option<()> {
+    let _area_id = parse_area_id(&args.string()?)?;
+    let name = args.string()?;
+    let link = ospf_link_get_mut_by_name(&mut ospf.links, &name)?;
+    let link_index = link.index;
+    let prev = link.config.key_chain.clone();
+    let next = if op.is_set() { args.string() } else { None };
+    link.config.key_chain = next.clone();
+
+    use crate::policy::{KeyChainScope, Message as PolicyMsg, PolicyType};
+    let scope = PolicyType::KeyChain(KeyChainScope::OspfInterface);
+    if prev != next {
+        if let Some(prev_name) = prev {
+            let _ = ospf.policy_tx.send(PolicyMsg::Unregister {
+                proto: "ospfv3".into(),
+                name: prev_name,
+                ident: link_index as usize,
+                policy_type: scope,
+            });
+        }
+        if let Some(new_name) = next {
+            let _ = ospf.policy_tx.send(PolicyMsg::Register {
+                proto: "ospfv3".into(),
+                name: new_name,
+                ident: link_index as usize,
+                policy_type: scope,
+            });
+        }
+    }
     Some(())
 }
 

--- a/zebra-rs/src/ospf/inst.rs
+++ b/zebra-rs/src/ospf/inst.rs
@@ -8148,6 +8148,16 @@ impl Ospf<Ospfv3> {
                 continue;
             };
             let retransmit_interval = link.retransmit_interval();
+            // Auth send state captured before the neighbor loop (it
+            // borrows `link` immutably; the per-packet seq comes from
+            // the `md5_seq` atomic field directly). RFC 7166: a flood
+            // LSU needs the trailer just like any other packet — the
+            // earlier gap here left authenticated adjacencies unable
+            // to converge re-originated LSAs.
+            let auth_mode = link.auth_mode();
+            let auth_simple_key = link.config.auth_key;
+            let auth_crypto_key =
+                link.resolve_active_send_key(&self.key_chains, chrono::Utc::now());
 
             for nbr in link.nbrs.values_mut() {
                 if nbr.state < NfsmState::Exchange {
@@ -8169,16 +8179,26 @@ impl Ospf<Ospfv3> {
                 let ls_upd = Ospfv3LsUpdate {
                     lsas: vec![lsa.clone()],
                 };
-                let packet = Ospfv3Packet::new(
+                let mut packet = Ospfv3Packet::new(
                     &self.router_id,
                     &area_id,
                     0,
                     Ospfv3Payload::LsUpdate(ls_upd),
                 );
+                let dst = nbr.ident.prefix.addr();
+                let ctx = super::packet::AuthSendCtx {
+                    mode: auth_mode,
+                    simple_key: auth_simple_key,
+                    crypto_key: auth_crypto_key.clone(),
+                    md5_seq: link
+                        .md5_seq
+                        .fetch_add(1, std::sync::atomic::Ordering::Relaxed),
+                };
+                super::packet_v3::apply_v3_auth_trailer(&mut packet, &ctx, &src, &dst);
                 let item = super::network_v6::Ospfv3Send {
                     packet,
                     ifindex,
-                    dest: Some(nbr.ident.prefix.addr()),
+                    dest: Some(dst),
                     src,
                 };
                 if let Err(e) = tx.send(item) {
@@ -8231,6 +8251,14 @@ impl Ospf<Ospfv3> {
         }) else {
             return;
         };
+        // Auth send state captured before the neighbor borrow (see
+        // `flood_lsa_through_area`).
+        let auth_mode = link.auth_mode();
+        let auth_simple_key = link.config.auth_key;
+        let auth_crypto_key = link.resolve_active_send_key(&self.key_chains, chrono::Utc::now());
+        let auth_seq = link
+            .md5_seq
+            .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
         let Some(nbr) = link.nbrs.get_mut(&router_id) else {
             return;
         };
@@ -8247,12 +8275,22 @@ impl Ospf<Ospfv3> {
         );
         let dest = nbr.ident.prefix.addr();
         let ls_upd = Ospfv3LsUpdate { lsas };
-        let packet = Ospfv3Packet::new(
+        let mut packet = Ospfv3Packet::new(
             &self.router_id,
             &area_id,
             0,
             Ospfv3Payload::LsUpdate(ls_upd),
         );
+        // RFC 7166: a retransmitted LSU carries the trailer like any
+        // other packet, else an authenticated neighbor drops it and
+        // the retransmit never clears.
+        let ctx = super::packet::AuthSendCtx {
+            mode: auth_mode,
+            simple_key: auth_simple_key,
+            crypto_key: auth_crypto_key,
+            md5_seq: auth_seq,
+        };
+        super::packet_v3::apply_v3_auth_trailer(&mut packet, &ctx, &src, &dest);
         let item = super::network_v6::Ospfv3Send {
             packet,
             ifindex,
@@ -8844,6 +8882,11 @@ impl Ospf<Ospfv3> {
             return;
         };
         let retransmit_interval = link.retransmit_interval();
+        // Auth send state captured before the neighbor loop (see
+        // `flood_lsa_through_area`).
+        let auth_mode = link.auth_mode();
+        let auth_simple_key = link.config.auth_key;
+        let auth_crypto_key = link.resolve_active_send_key(&self.key_chains, chrono::Utc::now());
 
         for nbr in link.nbrs.values_mut() {
             if nbr.state < NfsmState::Exchange {
@@ -8858,16 +8901,26 @@ impl Ospf<Ospfv3> {
             let ls_upd = Ospfv3LsUpdate {
                 lsas: vec![lsa.clone()],
             };
-            let packet = Ospfv3Packet::new(
+            let mut packet = Ospfv3Packet::new(
                 &self.router_id,
                 &area_id,
                 0,
                 Ospfv3Payload::LsUpdate(ls_upd),
             );
+            let dst = nbr.ident.prefix.addr();
+            let ctx = super::packet::AuthSendCtx {
+                mode: auth_mode,
+                simple_key: auth_simple_key,
+                crypto_key: auth_crypto_key.clone(),
+                md5_seq: link
+                    .md5_seq
+                    .fetch_add(1, std::sync::atomic::Ordering::Relaxed),
+            };
+            super::packet_v3::apply_v3_auth_trailer(&mut packet, &ctx, &src, &dst);
             let item = super::network_v6::Ospfv3Send {
                 packet,
                 ifindex,
-                dest: Some(nbr.ident.prefix.addr()),
+                dest: Some(dst),
                 src,
             };
             if let Err(e) = tx.send(item) {

--- a/zebra-rs/src/ospf/network_v6.rs
+++ b/zebra-rs/src/ospf/network_v6.rs
@@ -105,7 +105,23 @@ pub async fn read_packet_v6(sock: Arc<AsyncFd<Socket>>, tx: UnboundedSender<Ospf
 
                 // RFC 5340 §4.4: drop packets whose pseudo-header
                 // checksum is wrong before any further processing.
-                if !ospfv3_verify_checksum(&src, &dst, input) {
+                // RFC 7166 §2.3/§4.1: an Authentication Trailer rides
+                // after the OSPF packet, excluded from the header
+                // length field and from the checksum — when one is
+                // present (datagram longer than the length field),
+                // checksum verification is omitted entirely and
+                // integrity comes from the digest in the auth gate.
+                // Verifying over the full datagram here corrupted the
+                // sum on every AT ingress.
+                if input.len() < 16 {
+                    return Err(ErrorKind::UnexpectedEof.into());
+                }
+                let pkt_len = u16::from_be_bytes([input[2], input[3]]) as usize;
+                if pkt_len < 16 || input.len() < pkt_len {
+                    return Err(ErrorKind::InvalidData.into());
+                }
+                let has_trailer = input.len() > pkt_len;
+                if !has_trailer && !ospfv3_verify_checksum(&src, &dst, input) {
                     return Err(ErrorKind::InvalidData.into());
                 }
 

--- a/zebra-rs/yang/config.yang
+++ b/zebra-rs/yang/config.yang
@@ -88,6 +88,10 @@ module config {
     prefix zoat;
   }
 
+  import zebra-ospfv3-auth {
+    prefix zo3a;
+  }
+
   import zebra-ospf-tracing {
     prefix zotr;
   }

--- a/zebra-rs/yang/zebra-ospfv3-auth.yang
+++ b/zebra-rs/yang/zebra-ospfv3-auth.yang
@@ -1,0 +1,165 @@
+module zebra-ospfv3-auth {
+  yang-version "1";
+
+  namespace "urn:ietf:params:xml:ns:yang:zebra-ospfv3-auth";
+  prefix "zo3a";
+
+  import config {
+    prefix config;
+  }
+
+  import configure {
+    prefix configure;
+  }
+
+  import extension {
+    prefix ext;
+  }
+
+  organization
+    "zebra-rs";
+
+  contact
+    "https://github.com/zebra-rs";
+
+  description
+    "Native per-interface OSPFv3 authentication configuration for the
+     RFC 7166 Authentication Trailer. OSPFv3 has no per-packet
+     authentication field of its own (RFC 5340 delegated security to
+     IPsec); zebra-rs appends the RFC 7166 trailer instead — an
+     HMAC-SHA digest with a 16-bit Security Association ID and a
+     64-bit sequence number, computed with the Apad construction over
+     the IPv6 source address and packet.
+
+     The surface is deliberately narrower than the OSPFv2 siblings
+     (zebra-ospf-auth-simple / -md5 / -trailer): RFC 7166 §4 defines
+     only HMAC-SHA algorithms, so there is no simple-password mode
+     and no keyed-MD5 list here. `authentication message-digest`
+     turns the trailer on; keys come from the `crypto-key` list (the
+     leaf name selects the algorithm) or from an RFC 8177 key-chain
+     referenced by name, which supersedes inline keys.
+
+     Example:
+
+       router ospfv3 {
+         area 0 {
+           interface eth0 {
+             authentication message-digest;
+             crypto-key 1 {
+               hmac-sha-256 SECRET;
+             }
+           }
+         }
+       }";
+
+  revision 2026-07-03 {
+    description
+      "Initial version — native `router ospfv3` authentication path
+       (previously the v3 trailer was configurable only through the
+       shared OSPFv2 interface tree, which required a `router ospf`
+       block to exist in an IPv6-only deployment).";
+  }
+
+  grouping ospfv3-interface-auth-extension {
+    leaf authentication {
+      ext:help "OSPFv3 authentication mode (RFC 7166 trailer)";
+      type enumeration {
+        enum null {
+          description
+            "No authentication trailer (the default when unset).";
+        }
+        enum message-digest {
+          description
+            "Append and require the RFC 7166 Authentication
+             Trailer (AT-bit set in Hello/DBD options).";
+        }
+      }
+      description
+        "Authentication mode for this interface. RFC 7166 has no
+         simple-password equivalent, so unlike the v2 leaf the enum
+         carries only `null` and `message-digest`.";
+    }
+
+    leaf key-chain {
+      ext:help "RFC 8177 key chain supplying the trailer keys";
+      type string;
+      description
+        "Name of a key chain defined under /key-chains/key-chain.
+         When set and `authentication` is `message-digest`, the
+         chain supersedes per-interface `crypto-key` entries:
+         send-side uses the chain's currently active key (lowest
+         key-id whose send-lifetime contains now); receive-side
+         validates the sender's SA-ID against the accept-lifetime
+         window.";
+      reference
+        "RFC 8177: YANG Data Model for Key Chains";
+    }
+
+    list crypto-key {
+      ext:help "RFC 7166 trailer key (algorithm chosen by leaf)";
+      key "key-id";
+      description
+        "One trailer key. Exactly one per-algorithm leaf should be
+         set per entry; the leaf name selects the HMAC-SHA
+         algorithm. The key-id is carried on the wire as the
+         trailer's Security Association ID.";
+
+      leaf key-id {
+        ext:help "Security Association ID (1-255)";
+        type uint8 {
+          range "1..255";
+        }
+        description
+          "Key identifier carried as the RFC 7166 §4.1 Security
+           Association ID. Zero is reserved and rejected. The
+           16-bit wire field is constrained to 8 bits so keys stay
+           interchangeable with the shared per-link keyring.";
+      }
+
+      leaf hmac-sha-1 {
+        ext:help "HMAC-SHA-1 secret (1..20 octets)";
+        type string {
+          length "1..20";
+        }
+      }
+
+      leaf hmac-sha-256 {
+        ext:help "HMAC-SHA-256 secret (1..32 octets)";
+        type string {
+          length "1..32";
+        }
+      }
+
+      leaf hmac-sha-384 {
+        ext:help "HMAC-SHA-384 secret (1..48 octets)";
+        type string {
+          length "1..48";
+        }
+      }
+
+      leaf hmac-sha-512 {
+        ext:help "HMAC-SHA-512 secret (1..64 octets)";
+        type string {
+          length "1..64";
+        }
+      }
+    }
+  }
+
+  augment "/configure:set/config:router"
+        + "/config:ospfv3/config:area/config:interface" {
+    description
+      "Attach the OSPFv3 authentication leaves to each interface
+       in the candidate-set subtree.";
+    uses ospfv3-interface-auth-extension;
+  }
+
+  augment "/configure:delete/config:router"
+        + "/config:ospfv3/config:area/config:interface" {
+    description
+      "Same attachment in the delete subtree so
+       `delete router ospfv3 area X interface Y crypto-key Z`
+       is path-valid.";
+    uses ospfv3-interface-auth-extension;
+  }
+}


### PR DESCRIPTION
## Summary

Adds a native `router ospfv3` authentication config path — and, in the process of testing it end to end, fixes three real bugs that made the pre-existing OSPFv3 RFC 7166 Authentication Trailer non-functional for routing.

**The config path** (`zebra-ospfv3-auth.yang` + `config_v3.rs`): `authentication null | message-digest`, an HMAC-SHA `crypto-key` list, and a `key-chain` reference on the OSPFv3 interface tree. RFC 7166 has no simple-password or keyed-MD5 mode, so the surface is deliberately narrower than the v2 siblings. Previously the v3 trailer was configurable only through the shared v2 interface tree, requiring a `router ospf` block to exist in an IPv6-only deployment.

**Three datapath bugs the BDD uncovered** (all made authenticated v3 non-working before):
1. **Ingress checksum over the trailer** — the v3 receive path verified the pseudo-header checksum over the whole datagram including the trailer, which RFC 7166 §4.1 excludes; every authenticated packet was dropped at ingress. (`network_v6.rs`)
2. **Trailer parsed only on the AT-bit** — that bit lives in the Hello/DBD Options field, but LS-Request/Update/Ack have none, so their trailers were never extracted and they were dropped, wedging adjacencies in Loading. Now extracted positionally per RFC 7166 §2.3. (`v3.rs`)
3. **Flood/retransmit LSUs never stamped the trailer** — unlike the DBD/LSR/direct-LSU paths. So initial sync worked but every re-originated LSA flooded afterward went out trailerless and was dropped: adjacencies reached Full but never converged routes. (`inst.rs`)

## Test plan

- New BDD `ospfv3_auth` (3 scenarios: inline HMAC-SHA-256, RFC 8177 key-chain, mismatch-negative) passes — the positive cases ping across the link, exercising authenticated flood/retransmit convergence.
- Regression sweep of the shared v3 flood/retransmit path all green: `ospfv3_adjacency`, `ospfv3_multi_area`, `ospfv3_graceful_restart`, `ospfv2_auth`.
- Parse test pins the native v3 spellings and asserts the v2-only ones (simple / authentication-key / message-digest-key) do NOT parse under `router ospfv3`.
- `cargo fmt --check`, clippy `-D warnings` (default and no-lua), `cargo test --workspace --exclude bdd` (2137 passed, 0 failed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)