### PR TITLE
feat: SRv6 endpoint flavors PSP/USP/USD (RFC 8986 4.16)

### DIFF
--- a/bdd/tests/configs/isis_srv6_flavor/z1.yaml
+++ b/bdd/tests/configs/isis_srv6_flavor/z1.yaml
@@ -1,0 +1,33 @@
+# z1 — advertises a PSP-flavored uSID locator: the End (uN) SID must go
+# out as `uN (PSP)` (IANA 44, End with NEXT-CSID & PSP) and the End.X
+# (uA) SID as `uA (PSP)` — the adjacency SID folds only the PSP bit.
+interface:
+- if-name: lo
+  ipv6:
+    address: 2001:db8::1/128
+- if-name: z1-z2
+  ipv6:
+    address: 2001:db8:0:12::1/64
+segment-routing:
+  locator:
+  - name: LOC1
+    prefix: fcbb:bbbb:1::/48
+    behavior: usid
+    flavor:
+    - psp
+router:
+  isis:
+    net: 49.0000.0000.0000.0001.00
+    hostname: z1
+    is-type: level-2-only
+    segment-routing:
+      srv6:
+        locator: LOC1
+    interface:
+    - if-name: lo
+      ipv6:
+        enable: true
+    - if-name: z1-z2
+      network-type: point-to-point
+      ipv6:
+        enable: true

--- a/bdd/tests/configs/isis_srv6_flavor/z2.yaml
+++ b/bdd/tests/configs/isis_srv6_flavor/z2.yaml
@@ -1,0 +1,31 @@
+# z2 — plain uSID locator (no flavor): its own SIDs stay `uN`/`uA`, and
+# it must still classify z1's flavored codepoints as NEXT-C-SID
+# (adjacency + SPF unaffected).
+interface:
+- if-name: lo
+  ipv6:
+    address: 2001:db8::2/128
+- if-name: z2-z1
+  ipv6:
+    address: 2001:db8:0:12::2/64
+segment-routing:
+  locator:
+  - name: LOC2
+    prefix: fcbb:bbbb:2::/48
+    behavior: usid
+router:
+  isis:
+    net: 49.0000.0000.0000.0002.00
+    hostname: z2
+    is-type: level-2-only
+    segment-routing:
+      srv6:
+        locator: LOC2
+    interface:
+    - if-name: lo
+      ipv6:
+        enable: true
+    - if-name: z2-z1
+      network-type: point-to-point
+      ipv6:
+        enable: true

--- a/bdd/tests/features/isis_srv6_flavor.feature
+++ b/bdd/tests/features/isis_srv6_flavor.feature
@@ -1,0 +1,48 @@
+@isis_srv6_flavor
+@isis
+Feature: IS-IS advertises PSP-flavored SRv6 endpoint behaviors
+  As a network operator
+  I want a locator's configured RFC 8986 §4.16 flavors folded into the
+  advertised endpoint-behavior codepoints, so receivers know the SRH
+  will be popped at this node and the data planes agree on the wire
+  format.
+
+  z1's uSID locator carries `flavor: [psp]`: its End SID must advertise
+  as `uN (PSP)` (IANA codepoint 44, End with NEXT-CSID & PSP) and its
+  End.X SID as `uA (PSP)` (53) — adjacency SIDs fold only the PSP bit.
+  z2 is flavorless and must (a) keep advertising plain `uN`/`uA` and
+  (b) still classify z1's flavored codepoints as NEXT-C-SID, so the
+  adjacency and SPF are unaffected.
+
+  Test Topology:
+  ```
+   z1 ──2001:db8:0:12::/64── z2
+   LOC1 fcbb:bbbb:1::/48      LOC2 fcbb:bbbb:2::/48
+   usid + flavor [psp]        usid (no flavor)
+  ```
+
+  Scenario: The flavored codepoints appear in the peer's database
+    Given a clean test environment
+    When I create namespace "z1"
+    And I create namespace "z2"
+    And I connect namespace "z1" interface "z1-z2" to namespace "z2" interface "z2-z1"
+    And I start zebra-rs in namespace "z1"
+    And I start zebra-rs in namespace "z2"
+    And I apply config "z1.yaml" to namespace "z1"
+    And I apply config "z2.yaml" to namespace "z2"
+    Then show command "show isis database detail" in namespace "z2" should eventually contain "uN (PSP)"
+    And show command "show isis database detail" in namespace "z2" should contain "uA (PSP)"
+    # The flavorless peer's own SIDs are unchanged — z1 sees plain uN.
+    And show command "show isis database detail" in namespace "z1" should eventually contain "Behavior: uN,"
+    # Reachability across the adjacency proves the flavored codepoints
+    # didn't disturb SPF or the SRv6 locator routes.
+    And ping from "z1" to "2001:db8::2" should eventually succeed
+    And ping from "z2" to "2001:db8::1" should eventually succeed
+
+  Scenario: Teardown topology
+    Given the test topology exists
+    When I stop zebra-rs in namespace "z1"
+    And I stop zebra-rs in namespace "z2"
+    And I delete namespace "z1"
+    And I delete namespace "z2"
+    Then the test environment should be clean

--- a/crates/isis-packet/src/sub/srv6.rs
+++ b/crates/isis-packet/src/sub/srv6.rs
@@ -120,6 +120,46 @@ impl Behavior {
                 | EndXCSIDPSPUSPUSD
         )
     }
+
+    /// Fold RFC 8986 §4.16 flavors into a base endpoint behavior,
+    /// returning the flavored IANA codepoint. Supported bases: `End`,
+    /// `EndX`, `EndCSID` (uN) and `EndXCSID` (uA); any other base — and
+    /// an empty flavor set — returns `self` unchanged.
+    pub fn with_flavors(self, psp: bool, usp: bool, usd: bool) -> Behavior {
+        use Behavior::*;
+        match (self, psp, usp, usd) {
+            (_, false, false, false) => self,
+            (End, true, false, false) => EndPSP,
+            (End, false, true, false) => EndUSP,
+            (End, true, true, false) => EndPSPUSP,
+            (End, false, false, true) => EndUSD,
+            (End, true, false, true) => EndPSPUSD,
+            (End, false, true, true) => EndUSPUSD,
+            (End, true, true, true) => EndPSPUSPUSD,
+            (EndX, true, false, false) => EndXPSP,
+            (EndX, false, true, false) => EndXUSP,
+            (EndX, true, true, false) => EndXPSPUSP,
+            (EndX, false, false, true) => EndXUSD,
+            (EndX, true, false, true) => EndXPSPUSD,
+            (EndX, false, true, true) => EndXUSPUSD,
+            (EndX, true, true, true) => EndXPSPUSPUSD,
+            (EndCSID, true, false, false) => EndCSIDPSP,
+            (EndCSID, false, true, false) => EndCSIDUSP,
+            (EndCSID, true, true, false) => EndCSIDPSPUSP,
+            (EndCSID, false, false, true) => EndCSIDUSD,
+            (EndCSID, true, false, true) => EndCSIDPSPUSD,
+            (EndCSID, false, true, true) => EndCSIDUSPUSD,
+            (EndCSID, true, true, true) => EndCSIDPSPUSPUSD,
+            (EndXCSID, true, false, false) => EndXCSIDPSP,
+            (EndXCSID, false, true, false) => EndXCSIDUSP,
+            (EndXCSID, true, true, false) => EndXCSIDPSPUSP,
+            (EndXCSID, false, false, true) => EndXCSIDUSD,
+            (EndXCSID, true, false, true) => EndXCSIDPSPUSD,
+            (EndXCSID, false, true, true) => EndXCSIDUSPUSD,
+            (EndXCSID, true, true, true) => EndXCSIDPSPUSPUSD,
+            _ => self,
+        }
+    }
 }
 
 impl From<Behavior> for u16 {
@@ -149,19 +189,19 @@ impl From<Behavior> for u16 {
             EndDX2V => 22,
             EndDT2U => 23,
             EndDT2M => 24,
-            EndB6EncapsRed => 26,
-            EndUSD => 27,
-            EndPSPUSD => 28,
-            EndUSPUSD => 29,
-            EndPSPUSPUSD => 30,
-            EndXUSD => 31,
-            EndXPSPUSD => 32,
-            EndXUSPUSD => 33,
-            EndXPSPUSPUSD => 34,
-            EndTUSD => 35,
-            EndTPSPUSD => 36,
-            EndTUSPUSD => 37,
-            EndTPSPUSPUSD => 38,
+            EndB6EncapsRed => 27,
+            EndUSD => 28,
+            EndPSPUSD => 29,
+            EndUSPUSD => 30,
+            EndPSPUSPUSD => 31,
+            EndXUSD => 32,
+            EndXPSPUSD => 33,
+            EndXUSPUSD => 34,
+            EndXPSPUSPUSD => 35,
+            EndTUSD => 36,
+            EndTPSPUSD => 37,
+            EndTUSPUSD => 38,
+            EndTPSPUSPUSD => 39,
             EndCSID => 43,
             EndCSIDPSP => 44,
             EndCSIDUSP => 45,
@@ -224,19 +264,19 @@ impl From<u16> for Behavior {
             22 => EndDX2V,
             23 => EndDT2U,
             24 => EndDT2M,
-            26 => EndB6EncapsRed,
-            27 => EndUSD,
-            28 => EndPSPUSD,
-            29 => EndUSPUSD,
-            30 => EndPSPUSPUSD,
-            31 => EndXUSD,
-            32 => EndXPSPUSD,
-            33 => EndXUSPUSD,
-            34 => EndXPSPUSPUSD,
-            35 => EndTUSD,
-            36 => EndTPSPUSD,
-            37 => EndTUSPUSD,
-            38 => EndTPSPUSPUSD,
+            27 => EndB6EncapsRed,
+            28 => EndUSD,
+            29 => EndPSPUSD,
+            30 => EndUSPUSD,
+            31 => EndPSPUSPUSD,
+            32 => EndXUSD,
+            33 => EndXPSPUSD,
+            34 => EndXUSPUSD,
+            35 => EndXPSPUSPUSD,
+            36 => EndTUSD,
+            37 => EndTPSPUSD,
+            38 => EndTUSPUSD,
+            39 => EndTPSPUSPUSD,
             43 => EndCSID,
             44 => EndCSIDPSP,
             45 => EndCSIDUSP,
@@ -405,6 +445,70 @@ impl FromStr for EncapType {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// Pin the flavored endpoint-behavior codepoints to the IANA "SRv6
+    /// Endpoint Behaviors" registry (RFC 8986 §10.2 + RFC 9800). The
+    /// classic USD block was once off by one (shifted onto
+    /// End.B6.Encaps.Red), which a conformant receiver would misread —
+    /// this test keeps the registry values load-bearing.
+    #[test]
+    fn behavior_codepoints_match_iana() {
+        use Behavior::*;
+        let table: [(Behavior, u16); 24] = [
+            (End, 1),
+            (EndPSP, 2),
+            (EndUSP, 3),
+            (EndPSPUSP, 4),
+            (EndX, 5),
+            (EndXPSP, 6),
+            (EndB6EncapsRed, 27),
+            (EndUSD, 28),
+            (EndPSPUSD, 29),
+            (EndUSPUSD, 30),
+            (EndPSPUSPUSD, 31),
+            (EndXUSD, 32),
+            (EndXPSPUSPUSD, 35),
+            (EndTUSD, 36),
+            (EndTPSPUSPUSD, 39),
+            (EndCSID, 43),
+            (EndCSIDPSP, 44),
+            (EndCSIDUSP, 45),
+            (EndCSIDUSD, 47),
+            (EndCSIDPSPUSPUSD, 50),
+            (EndXCSID, 52),
+            (EndXCSIDPSP, 53),
+            (EndXCSIDPSPUSPUSD, 59),
+            (EndM, 74),
+        ];
+        for (behavior, code) in table {
+            assert_eq!(u16::from(behavior), code, "{behavior:?} -> {code}");
+            assert_eq!(Behavior::from(code), behavior, "{code} -> {behavior:?}");
+        }
+    }
+
+    /// Every (base × flavor-set) fold, including that flavored results
+    /// keep their NEXT-C-SID classification and non-foldable bases pass
+    /// through unchanged.
+    #[test]
+    fn with_flavors_folds_every_combination() {
+        use Behavior::*;
+        for base in [End, EndX, EndCSID, EndXCSID] {
+            let mut seen = std::collections::BTreeSet::new();
+            for bits in 0u8..8 {
+                let (psp, usp, usd) = (bits & 1 != 0, bits & 2 != 0, bits & 4 != 0);
+                let folded = base.with_flavors(psp, usp, usd);
+                assert!(seen.insert(u16::from(folded)), "collision at {bits:03b}");
+                if bits == 0 {
+                    assert_eq!(folded, base);
+                }
+                assert_eq!(folded.is_end_next_csid(), base.is_end_next_csid());
+                assert_eq!(folded.is_endx_next_csid(), base.is_endx_next_csid());
+            }
+        }
+        assert_eq!(EndDT46.with_flavors(true, true, true), EndDT46);
+        assert_eq!(EndCSID.with_flavors(true, false, false), EndCSIDPSP);
+        assert_eq!(End.with_flavors(true, false, true), EndPSPUSD);
+    }
 
     const ALL: [EncapType; 4] = [
         EncapType::HEncap,

--- a/proto/cradle.proto
+++ b/proto/cradle.proto
@@ -97,6 +97,7 @@ message LocalSid {
   string nh6          = 6;   // adjacency IPv6 for End.X / uA
   uint32 lb_bits = 7; uint32 ln_bits = 8; uint32 fun_bits = 9; uint32 arg_bits = 10;
   uint32 nexthop_id = 11;    // cross-connect adjacency for End.X (into NEXTHOPS)
+  uint32 flavors    = 12;    // SRV6_FLAVOR_* bitmask (PSP=1, USP=2, USD=4)
 }
 
 message LocalSidDel {

--- a/zebra-rs/src/bgp/inst.rs
+++ b/zebra-rs/src/bgp/inst.rs
@@ -1429,6 +1429,7 @@ impl Bgp {
             structure: None,
             table_id: vni,
             segs: Vec::new(),
+            flavors: 0,
         };
         let _ = self.ctx.rib.send(crate::rib::Message::SidAdd { sid });
     }
@@ -1648,6 +1649,7 @@ impl Bgp {
             nh6: None,
             structure: None,
             table_id: 0,
+            flavors: 0,
             segs: Vec::new(),
         });
         self.srv6_ipv6_sid = Some((addr, function));

--- a/zebra-rs/src/bgp/route.rs
+++ b/zebra-rs/src/bgp/route.rs
@@ -8625,6 +8625,7 @@ fn apply_srpolicy_fib(delta: super::sr_policy::SrPolicyFibDelta, bgp: &mut BgpTo
             structure: None,
             table_id: 0,
             segs: install.segments,
+            flavors: 0,
         };
         let _ = bgp.rib_client.send(rib::Message::SidAdd { sid });
     }

--- a/zebra-rs/src/bgp/vrf/spawn.rs
+++ b/zebra-rs/src/bgp/vrf/spawn.rs
@@ -265,6 +265,7 @@ pub fn spawn_bgp_vrf(
             structure: None,
             table_id,
             segs: Vec::new(),
+            flavors: 0,
         };
         rib_subscriber.send_sid_add(sid);
     }

--- a/zebra-rs/src/fib/cradle.rs
+++ b/zebra-rs/src/fib/cradle.rs
@@ -537,6 +537,7 @@ impl CradleFib {
                     fun_bits: fun as u32,
                     arg_bits: arg as u32,
                     nexthop_id,
+                    flavors: sid.flavors as u32,
                 })
                 .await?;
             anyhow::Ok(())

--- a/zebra-rs/src/fib/netlink/handle.rs
+++ b/zebra-rs/src/fib/netlink/handle.rs
@@ -930,7 +930,7 @@ impl FibHandle {
                 // Static seg6local action routes keep the legacy
                 // RT_TABLE_MAIN decap (table_id 0); per-VRF table
                 // selection arrives via the protocol SID path.
-                super::srv6::build_seg6local_attrs(action, None, None, 0, &[])
+                super::srv6::build_seg6local_attrs(action, None, None, 0, &[], 0)
             {
                 msg.attributes.push(encap);
                 msg.attributes.push(encap_type);
@@ -1688,6 +1688,7 @@ impl FibHandle {
             sid.structure,
             sid.table_id,
             &sid.segs,
+            sid.flavors,
         ) else {
             tracing::warn!(
                 "seg6local route encap build skipped for {} (End.X / uA without IPv6 nexthop)",
@@ -1891,6 +1892,7 @@ impl FibHandle {
             None,
             vrf_table,
             &[],
+            0,
         ) else {
             return;
         };

--- a/zebra-rs/src/fib/netlink/srv6.rs
+++ b/zebra-rs/src/fib/netlink/srv6.rs
@@ -156,7 +156,22 @@ fn seg6local_action(behavior: SidBehavior) -> Seg6LocalAction {
 fn build_seg6local_flavors(
     behavior: SidBehavior,
     structure: Option<SidStructure>,
+    flavors: u8,
 ) -> Option<RouteSeg6LocalIpTunnel> {
+    // `SEG6_LOCAL_FLV_OPERATION` is ONE u32 NLA carrying an OR'd bitmask
+    // of operations — composing NEXT-CSID with PSP/USP/USD means one
+    // `Operation` attribute holding the combined mask (`Other`), never two.
+    let mut flavor_mask = 0u32;
+    if flavors & crate::rib::FLAVOR_PSP != 0 {
+        flavor_mask |= u32::from(Seg6LocalFlavorOps::Psp);
+    }
+    if flavors & crate::rib::FLAVOR_USP != 0 {
+        flavor_mask |= u32::from(Seg6LocalFlavorOps::Usp);
+    }
+    if flavors & crate::rib::FLAVOR_USD != 0 {
+        flavor_mask |= u32::from(Seg6LocalFlavorOps::Usd);
+    }
+
     // Nflen is the width of the uSID identifier being consumed at this
     // entry — the bits the kernel shifts out to expose the next uSID.
     // Lblen is the shared block portion that stays put. For uN that
@@ -166,11 +181,26 @@ fn build_seg6local_flavors(
     let nflen = match behavior {
         SidBehavior::UN => structure?.ln_bits,
         SidBehavior::UALib => structure?.fun_bits,
-        _ => return None,
+        _ => {
+            // Classic End / End.X: a flavor-only Operation attribute (the
+            // kernel supports PSP on End from ~6.6; unsupported combos
+            // fail the install, which the caller logs non-fatally).
+            if flavor_mask == 0 {
+                return None;
+            }
+            return Some(RouteSeg6LocalIpTunnel::Flavors(vec![
+                Seg6LocalFlavors::Operation(Seg6LocalFlavorOps::Other(flavor_mask)),
+            ]));
+        }
     };
     let s = structure?;
+    let op = if flavor_mask == 0 {
+        Seg6LocalFlavorOps::NextCsid
+    } else {
+        Seg6LocalFlavorOps::Other(u32::from(Seg6LocalFlavorOps::NextCsid) | flavor_mask)
+    };
     Some(RouteSeg6LocalIpTunnel::Flavors(vec![
-        Seg6LocalFlavors::Operation(Seg6LocalFlavorOps::NextCsid),
+        Seg6LocalFlavors::Operation(op),
         Seg6LocalFlavors::Lblen(s.lb_bits),
         Seg6LocalFlavors::Nflen(nflen),
     ]))
@@ -202,6 +232,7 @@ fn build_seg6local_lwtunnel(
     structure: Option<SidStructure>,
     table_id: u32,
     segs: &[Ipv6Addr],
+    flavors: u8,
 ) -> Option<Vec<RouteLwTunnelEncap>> {
     let mut attrs: Vec<RouteSeg6LocalIpTunnel> =
         vec![RouteSeg6LocalIpTunnel::Action(seg6local_action(behavior))];
@@ -241,7 +272,7 @@ fn build_seg6local_lwtunnel(
         // table id — BGP passes the VRF's kernel table.
         attrs.push(RouteSeg6LocalIpTunnel::VrfTable(table_id));
     }
-    if let Some(flavors) = build_seg6local_flavors(behavior, structure) {
+    if let Some(flavors) = build_seg6local_flavors(behavior, structure, flavors) {
         attrs.push(flavors);
     }
     Some(
@@ -262,8 +293,9 @@ pub fn build_seg6local_attrs(
     structure: Option<SidStructure>,
     table_id: u32,
     segs: &[Ipv6Addr],
+    flavors: u8,
 ) -> Option<(RouteAttribute, RouteAttribute)> {
-    let encaps = build_seg6local_lwtunnel(behavior, nh6, structure, table_id, segs)?;
+    let encaps = build_seg6local_lwtunnel(behavior, nh6, structure, table_id, segs, flavors)?;
     Some((
         RouteAttribute::Encap(encaps),
         RouteAttribute::EncapType(RouteLwEnCapType::Seg6Local),
@@ -296,7 +328,7 @@ mod tests {
     fn end_dt46_uses_vrftable_with_given_table() {
         // BGP L3VPN-over-SRv6: an End.DT46 SID decaps into the VRF's
         // kernel table via SEG6_LOCAL_VRFTABLE, never a plain table.
-        let encaps = build_seg6local_lwtunnel(SidBehavior::EndDT46, None, None, 100, &[])
+        let encaps = build_seg6local_lwtunnel(SidBehavior::EndDT46, None, None, 100, &[], 0)
             .expect("encap built");
         assert!(
             encaps.iter().any(|e| matches!(
@@ -314,15 +346,15 @@ mod tests {
     #[test]
     fn end_dt6_table_zero_maps_to_main() {
         // table_id 0 must preserve the legacy static / IS-IS default.
-        let encaps =
-            build_seg6local_lwtunnel(SidBehavior::EndDT6, None, None, 0, &[]).expect("encap built");
+        let encaps = build_seg6local_lwtunnel(SidBehavior::EndDT6, None, None, 0, &[], 0)
+            .expect("encap built");
         assert_eq!(table_attr(&encaps), Some(RouteHeader::RT_TABLE_MAIN as u32));
         assert_eq!(vrftable_attr(&encaps), None);
     }
 
     #[test]
     fn end_dt4_honors_nonzero_table() {
-        let encaps = build_seg6local_lwtunnel(SidBehavior::EndDT4, None, None, 42, &[])
+        let encaps = build_seg6local_lwtunnel(SidBehavior::EndDT4, None, None, 42, &[], 0)
             .expect("encap built");
         assert_eq!(table_attr(&encaps), Some(42));
     }
@@ -332,7 +364,7 @@ mod tests {
         // End.M (egress protection): reuses the End.DT6 kernel action and
         // looks the inner packet up in the mirror-context table via a
         // plain SEG6_LOCAL_TABLE — never a VRF table.
-        let encaps = build_seg6local_lwtunnel(SidBehavior::EndM, None, None, 0x4D00_0000, &[])
+        let encaps = build_seg6local_lwtunnel(SidBehavior::EndM, None, None, 0x4D00_0000, &[], 0)
             .expect("encap built");
         assert!(
             encaps.iter().any(|e| matches!(
@@ -352,7 +384,7 @@ mod tests {
         // SR Policy Binding SID: End.B6.Encaps carries the policy's
         // segment list as a SEG6_LOCAL_SRH attribute.
         let segs = vec!["fc00:0:2::".parse().unwrap(), "fc00:0:9::".parse().unwrap()];
-        let encaps = build_seg6local_lwtunnel(SidBehavior::EndB6Encap, None, None, 0, &segs)
+        let encaps = build_seg6local_lwtunnel(SidBehavior::EndB6Encap, None, None, 0, &segs, 0)
             .expect("encap built");
         assert!(encaps.iter().any(|e| matches!(
             e,
@@ -370,7 +402,7 @@ mod tests {
     #[test]
     fn end_b6_encaps_without_segments_skips_install() {
         // No segment list → no SRH to push → skip the FIB install.
-        assert!(build_seg6local_lwtunnel(SidBehavior::EndB6Encap, None, None, 0, &[]).is_none());
+        assert!(build_seg6local_lwtunnel(SidBehavior::EndB6Encap, None, None, 0, &[], 0).is_none());
     }
 
     #[test]
@@ -405,7 +437,7 @@ mod tests {
             fun_bits: 16,
             arg_bits: 64,
         });
-        let encaps = build_seg6local_lwtunnel(SidBehavior::UA, Some(nh6), structure, 0, &[])
+        let encaps = build_seg6local_lwtunnel(SidBehavior::UA, Some(nh6), structure, 0, &[], 0)
             .expect("encap built");
         assert!(
             !encaps.iter().any(|e| matches!(
@@ -421,7 +453,7 @@ mod tests {
 
         // uN keeps the flavor — it is a prefix install where carriers
         // with a remaining argument legitimately shift.
-        let encaps = build_seg6local_lwtunnel(SidBehavior::UN, None, structure, 0, &[])
+        let encaps = build_seg6local_lwtunnel(SidBehavior::UN, None, structure, 0, &[], 0)
             .expect("encap built");
         assert!(encaps.iter().any(|e| matches!(
             e,

--- a/zebra-rs/src/isis/inst.rs
+++ b/zebra-rs/src/isis/inst.rs
@@ -3155,6 +3155,7 @@ impl Isis {
                 structure,
                 table_id: 0,
                 segs: Vec::new(),
+                flavors: locator.flavors,
             };
             let _ = self.ctx.rib.send(rib::Message::SidAdd { sid });
             self.sr_flex_algo_end_sid.insert(algo, addr);
@@ -3220,6 +3221,7 @@ impl Isis {
                 // End / uN is local-processing, no table decap.
                 table_id: 0,
                 segs: Vec::new(),
+                flavors: locator.flavors,
             };
             let _ = self.ctx.rib.send(rib::Message::SidAdd { sid });
             self.sr_end_sid = Some(addr);
@@ -3280,6 +3282,8 @@ impl Isis {
                 // mirror-context table.
                 table_id: Self::MIRROR_CONTEXT_TABLE,
                 segs: Vec::new(),
+                // Flavors don't apply to the End.M mirror decap.
+                flavors: 0,
             };
             let _ = self.ctx.rib.send(rib::Message::SidAdd { sid });
             self.installed_mirror_sids.insert(addr);

--- a/zebra-rs/src/isis/lsp.rs
+++ b/zebra-rs/src/isis/lsp.rs
@@ -479,26 +479,45 @@ fn srv6_sid_structure(locator: &Locator) -> Option<(bool, Vec<IsisSub2Tlv>)> {
     Some((is_usid, vec![structure]))
 }
 
+/// Fold a locator's configured RFC 8986 §4.16 flavor mask into a base
+/// endpoint behavior — the advertised codepoint must carry the flavors
+/// the data plane executes.
+fn flavored(base: Behavior, mask: u8) -> Behavior {
+    base.with_flavors(
+        mask & crate::rib::FLAVOR_PSP != 0,
+        mask & crate::rib::FLAVOR_USP != 0,
+        mask & crate::rib::FLAVOR_USD != 0,
+    )
+}
+
 /// SRv6 End-SID endpoint behavior + SID Structure for one locator
-/// (RFC 9352 §9). Classic → `End`; uSID → `EndCSID` (uN). Per-locator so
-/// each per-Flex-Algorithm locator gets its own structure.
+/// (RFC 9352 §9). Classic → `End`; uSID → `EndCSID` (uN); either folded
+/// with the locator's flavors. Per-locator so each per-Flex-Algorithm
+/// locator gets its own structure.
 fn srv6_end_structure(locator: &Locator) -> (Behavior, Vec<IsisSub2Tlv>) {
-    match srv6_sid_structure(locator) {
+    let (base, subs) = match srv6_sid_structure(locator) {
         Some((true, subs)) => (Behavior::EndCSID, subs),
         Some((false, subs)) => (Behavior::End, subs),
         None => (Behavior::End, Vec::new()),
-    }
+    };
+    (flavored(base, locator.flavors), subs)
 }
 
 /// SRv6 End.X SID endpoint behavior + SID Structure for one locator
 /// (RFC 9352 §8/§9). Classic → `EndX`; uSID → `EndXCSID` (uA). The
-/// End.X sibling of `srv6_end_structure`.
+/// End.X sibling of `srv6_end_structure`. Adjacency SIDs fold only the
+/// PSP flavor — their USP/USD variants are not implemented in the data
+/// plane, so they must not be advertised either.
 fn srv6_endx_structure(locator: &Locator) -> (Behavior, Vec<IsisSub2Tlv>) {
-    match srv6_sid_structure(locator) {
+    let (base, subs) = match srv6_sid_structure(locator) {
         Some((true, subs)) => (Behavior::EndXCSID, subs),
         Some((false, subs)) => (Behavior::EndX, subs),
         None => (Behavior::EndX, Vec::new()),
-    }
+    };
+    (
+        flavored(base, locator.flavors & crate::rib::FLAVOR_PSP),
+        subs,
+    )
 }
 
 /// SRv6 Mirror SID sub-TLVs to advertise inside the base SRv6 Locator
@@ -876,9 +895,9 @@ pub fn lsp_generate(top: &mut IsisTop, level: Level, seq_floor: Option<u32>) -> 
     let (end_behavior, endx_behavior, sid_structure_subs) = match top
         .sr_locator
         .as_ref()
-        .and_then(|loc| loc.prefix.map(|p| (loc.behavior.as_ref(), p)))
+        .and_then(|loc| loc.prefix.map(|p| (loc.behavior.as_ref(), p, loc.flavors)))
     {
-        Some((Some(LocatorBehavior::Usid), prefix)) => {
+        Some((Some(LocatorBehavior::Usid), prefix, flavors)) => {
             let plen = prefix.prefix_len();
             let lb_len = plen.min(32);
             let structure = IsisSub2Tlv::SidStructure(IsisSub2SidStructure {
@@ -887,9 +906,13 @@ pub fn lsp_generate(top: &mut IsisTop, level: Level, seq_floor: Option<u32>) -> 
                 fun_len: 16,
                 arg_len: 0,
             });
-            (Behavior::EndCSID, Behavior::EndXCSID, vec![structure])
+            (
+                flavored(Behavior::EndCSID, flavors),
+                flavored(Behavior::EndXCSID, flavors & crate::rib::FLAVOR_PSP),
+                vec![structure],
+            )
         }
-        Some((None, prefix)) => {
+        Some((None, prefix, flavors)) => {
             let plen = prefix.prefix_len();
             let lb_len = plen.min(40);
             let structure = IsisSub2Tlv::SidStructure(IsisSub2SidStructure {
@@ -898,7 +921,11 @@ pub fn lsp_generate(top: &mut IsisTop, level: Level, seq_floor: Option<u32>) -> 
                 fun_len: 16,
                 arg_len: 0,
             });
-            (Behavior::End, Behavior::EndX, vec![structure])
+            (
+                flavored(Behavior::End, flavors),
+                flavored(Behavior::EndX, flavors & crate::rib::FLAVOR_PSP),
+                vec![structure],
+            )
         }
         None => (Behavior::End, Behavior::EndX, Vec::new()),
     };

--- a/zebra-rs/src/isis/neigh.rs
+++ b/zebra-rs/src/isis/neigh.rs
@@ -417,6 +417,9 @@ impl Neighbor {
                 structure,
                 table_id: 0,
                 segs: Vec::new(),
+                // Adjacency SIDs take only PSP — their USP/USD variants
+                // (adjacency-forward decap) are not implemented.
+                flavors: locator.flavors & crate::rib::FLAVOR_PSP,
             };
             let _ = rib_client.send(rib::Message::SidAdd { sid });
 
@@ -439,6 +442,7 @@ impl Neighbor {
                             structure: Some(st),
                             table_id: 0,
                             segs: Vec::new(),
+                            flavors: locator.flavors & crate::rib::FLAVOR_PSP,
                         };
                         let _ = rib_client.send(rib::Message::SidAdd { sid: lib_sid });
                         la
@@ -505,6 +509,7 @@ impl Neighbor {
             structure: Some(structure),
             table_id: 0,
             segs: Vec::new(),
+            flavors: locator.flavors & crate::rib::FLAVOR_PSP,
         };
         let _ = rib_client.send(rib::Message::SidAdd { sid });
         self.endx_lib_sid = Some(addr);
@@ -536,6 +541,8 @@ impl Neighbor {
             // End.X is a local cross-connect, not a table decap.
             table_id: 0,
             segs: Vec::new(),
+            // Adjacency SIDs take only PSP (see the main registration).
+            flavors: locator.flavors & crate::rib::FLAVOR_PSP,
         }
     }
 

--- a/zebra-rs/src/isis/show.rs
+++ b/zebra-rs/src/isis/show.rs
@@ -3957,6 +3957,7 @@ mod tests {
         let loc = Locator {
             prefix: Some("2001:db8:a:2::/64".parse().unwrap()),
             behavior: None,
+            flavors: 0,
         };
         let row = render_locator_row("LOC_N1", Some(&loc));
         assert!(row.contains("LOC_N1"));
@@ -3970,6 +3971,7 @@ mod tests {
         let loc = Locator {
             prefix: Some("2001:db8:a:2::/64".parse().unwrap()),
             behavior: Some(LocatorBehavior::Usid),
+            flavors: 0,
         };
         let row = render_locator_row("LOC_N1", Some(&loc));
         assert!(row.contains("uSID"));
@@ -3995,6 +3997,7 @@ mod tests {
         let loc = Locator {
             prefix: None,
             behavior: None,
+            flavors: 0,
         };
         let row = render_locator_row("LOC_N1", Some(&loc));
         assert!(row.trim_end().ends_with("Down"));

--- a/zebra-rs/src/ospf/inst.rs
+++ b/zebra-rs/src/ospf/inst.rs
@@ -8871,6 +8871,7 @@ impl Ospf<Ospfv3> {
                 structure,
                 table_id: 0,
                 segs: Vec::new(),
+                flavors: locator.flavors,
             };
             let _ = self.ctx.rib.send(rib::Message::SidAdd { sid });
             self.sr_end_sid = Some(addr);
@@ -9075,6 +9076,9 @@ impl Ospf<Ospfv3> {
             structure,
             table_id: 0,
             segs: Vec::new(),
+            // Adjacency SIDs take only PSP (USP/USD would need an
+            // adjacency-forward decap — not implemented).
+            flavors: locator.flavors & crate::rib::FLAVOR_PSP,
         };
         let _ = self.ctx.rib.send(rib::Message::SidAdd { sid });
 
@@ -9099,6 +9103,7 @@ impl Ospf<Ospfv3> {
             structure: Some(structure),
             table_id: 0,
             segs: Vec::new(),
+            flavors: locator.flavors & crate::rib::FLAVOR_PSP,
         };
         let _ = self.ctx.rib.send(rib::Message::SidAdd { sid });
         Some(lib)

--- a/zebra-rs/src/ospf/srv6.rs
+++ b/zebra-rs/src/ospf/srv6.rs
@@ -36,10 +36,15 @@ pub fn srv6_locator_lsa_build(router_id: Ipv4Addr, locator: &Locator) -> Option<
     let prefix = locator.prefix?;
     let end_sid = locator.node_sid_addr()?;
 
-    let behavior = match locator.behavior {
-        Some(LocatorBehavior::Usid) => u16::from(isis_packet::Behavior::EndCSID),
-        None => u16::from(isis_packet::Behavior::End),
+    let base = match locator.behavior {
+        Some(LocatorBehavior::Usid) => isis_packet::Behavior::EndCSID,
+        None => isis_packet::Behavior::End,
     };
+    let behavior = u16::from(base.with_flavors(
+        locator.flavors & crate::rib::FLAVOR_PSP != 0,
+        locator.flavors & crate::rib::FLAVOR_USP != 0,
+        locator.flavors & crate::rib::FLAVOR_USD != 0,
+    ));
     let structure = locator.sid_structure().map(|s| Ospfv3Srv6SidStructure {
         lb_len: s.lb_bits,
         ln_len: s.ln_bits,
@@ -96,6 +101,7 @@ mod tests {
         Locator {
             prefix: Some(prefix.parse::<Ipv6Net>().unwrap()),
             behavior: usid.then_some(LocatorBehavior::Usid),
+            flavors: 0,
         }
     }
 
@@ -166,6 +172,7 @@ mod tests {
         let unresolved = Locator {
             prefix: None,
             behavior: None,
+            flavors: 0,
         };
         assert!(srv6_locator_lsa_build("10.0.0.1".parse().unwrap(), &unresolved).is_none());
     }
@@ -190,10 +197,13 @@ pub struct EndxSidState {
 /// `End.X with NEXT-CSID` (uA) for uSID locators, plain `End.X`
 /// otherwise. Shared by the LSA advertisement and the show side.
 pub fn endx_behavior(locator: &Locator) -> u16 {
-    match locator.behavior {
-        Some(LocatorBehavior::Usid) => u16::from(isis_packet::Behavior::EndXCSID),
-        None => u16::from(isis_packet::Behavior::EndX),
-    }
+    let base = match locator.behavior {
+        Some(LocatorBehavior::Usid) => isis_packet::Behavior::EndXCSID,
+        None => isis_packet::Behavior::EndX,
+    };
+    // Adjacency SIDs fold only PSP — the USP/USD End.X variants are not
+    // implemented in the data plane, so they must not be advertised.
+    u16::from(base.with_flavors(locator.flavors & crate::rib::FLAVOR_PSP != 0, false, false))
 }
 
 /// Nested SID-Structure sub-TLV (Extended-LSA registry type 30) for
@@ -250,6 +260,7 @@ mod endx_tests {
         Locator {
             prefix: Some("fcbb:bbbb:1::/48".parse::<Ipv6Net>().unwrap()),
             behavior: Some(LocatorBehavior::Usid),
+            flavors: 0,
         }
     }
 
@@ -272,6 +283,7 @@ mod endx_tests {
         let classic = Locator {
             prefix: Some("2001:db8:f:2::/64".parse::<Ipv6Net>().unwrap()),
             behavior: None,
+            flavors: 0,
         };
         let sub = build_v3_lan_endx_sub(
             &classic,

--- a/zebra-rs/src/rib/segment_routing/locator.rs
+++ b/zebra-rs/src/rib/segment_routing/locator.rs
@@ -31,12 +31,31 @@ impl LocatorBehavior {
     }
 }
 
+/// RFC 8986 §4.16 endpoint-flavor bits, OR-able in `Locator::flavors`.
+/// Deliberately the same encoding as cradle's `SRV6_FLAVOR_*` ABI so the
+/// mask travels the tee unchanged.
+pub const FLAVOR_PSP: u8 = 1;
+pub const FLAVOR_USP: u8 = 2;
+pub const FLAVOR_USD: u8 = 4;
+
+/// Parse one YANG `flavor` leaf-list member to its bit.
+pub fn flavor_bit(s: &str) -> Option<u8> {
+    match s {
+        "psp" => Some(FLAVOR_PSP),
+        "usp" => Some(FLAVOR_USP),
+        "usd" => Some(FLAVOR_USD),
+        _ => None,
+    }
+}
+
 /// Applied snapshot of an SRv6 locator, exported to the rest of the system
 /// once a config commit lands. Keyed by name in `Rib::locators`.
 #[derive(Debug, Default, Clone, PartialEq, Eq)]
 pub struct Locator {
     pub prefix: Option<Ipv6Net>,
     pub behavior: Option<LocatorBehavior>,
+    /// `FLAVOR_*` bitmask applied to the SIDs allocated from this locator.
+    pub flavors: u8,
 }
 
 impl Locator {
@@ -90,6 +109,7 @@ pub struct LocatorConfig {
     pub delete: bool,
     pub prefix: Option<Ipv6Net>,
     pub behavior: Option<LocatorBehavior>,
+    pub flavors: u8,
 }
 
 impl LocatorConfig {
@@ -97,6 +117,7 @@ impl LocatorConfig {
         Locator {
             prefix: self.prefix,
             behavior: self.behavior.clone(),
+            flavors: self.flavors,
         }
     }
 }
@@ -197,6 +218,7 @@ impl ConfigBuilder {
         const CONFIG_ERR: &str = "missing config";
         const PREFIX_ERR: &str = "expected ipv6 prefix";
         const BEHAVIOR_ERR: &str = "unknown locator behavior";
+        const FLAVOR_ERR: &str = "unknown locator flavor";
 
         ConfigBuilder::default()
             .path("")
@@ -239,6 +261,24 @@ impl ConfigBuilder {
                 s.behavior = None;
                 Ok(())
             })
+            // Leaf-list: set ORs one member's bit in, delete removes that
+            // one member (the value rides as the argument) — not the whole
+            // field.
+            .path("/flavor")
+            .set(|config, cache, name, args| {
+                let raw = args.string().context(FLAVOR_ERR)?;
+                let bit = flavor_bit(&raw).context(FLAVOR_ERR)?;
+                let s = cache_get(config, cache, name).context(CONFIG_ERR)?;
+                s.flavors |= bit;
+                Ok(())
+            })
+            .del(|config, cache, name, args| {
+                let raw = args.string().context(FLAVOR_ERR)?;
+                let bit = flavor_bit(&raw).context(FLAVOR_ERR)?;
+                let s = cache_lookup(config, cache, name).context(CONFIG_ERR)?;
+                s.flavors &= !bit;
+                Ok(())
+            })
     }
 
     pub fn path(mut self, path: &str) -> Self {
@@ -267,6 +307,7 @@ mod tests {
         let loc = Locator {
             prefix: Some("2001:db8:a:2::/64".parse().unwrap()),
             behavior: None,
+            flavors: 0,
         };
         assert_eq!(loc.node_sid_addr(), Some("2001:db8:a:2::".parse().unwrap()));
     }
@@ -279,6 +320,7 @@ mod tests {
         let loc = Locator {
             prefix: Some("2001:db8:a:2::5/64".parse().unwrap()),
             behavior: None,
+            flavors: 0,
         };
         assert_eq!(loc.node_sid_addr(), Some("2001:db8:a:2::".parse().unwrap()));
     }
@@ -288,6 +330,7 @@ mod tests {
         let loc = Locator {
             prefix: None,
             behavior: None,
+            flavors: 0,
         };
         assert_eq!(loc.node_sid_addr(), None);
     }

--- a/zebra-rs/src/rib/segment_routing/mod.rs
+++ b/zebra-rs/src/rib/segment_routing/mod.rs
@@ -8,7 +8,9 @@ pub mod block;
 pub use block::{Block, BlockBuilder, BlockConfig, DEFAULT_BLOCK_NAME};
 
 pub mod locator;
-pub use locator::{Locator, LocatorBehavior, LocatorBuilder, LocatorConfig};
+pub use locator::{
+    FLAVOR_PSP, FLAVOR_USD, FLAVOR_USP, Locator, LocatorBehavior, LocatorBuilder, LocatorConfig,
+};
 
 pub mod sid;
 pub use sid::{Sid, SidAllocationType, SidBehavior, SidContext, SidOwner, SidStructure};

--- a/zebra-rs/src/rib/segment_routing/sid.rs
+++ b/zebra-rs/src/rib/segment_routing/sid.rs
@@ -248,6 +248,11 @@ pub struct Sid {
     /// SRH segment list pushed by `End.B6.Encaps` (RFC 8986 §4.14), in
     /// forwarding order. Empty for every other behavior.
     pub segs: Vec<Ipv6Addr>,
+    /// RFC 8986 §4.16 flavor bits (`locator::FLAVOR_*`), copied from the
+    /// owning locator at allocation. Meaningful for End/uN (full mask) and
+    /// End.X/uA (PSP only — their USP/USD variants are not implemented);
+    /// always 0 for the DT*/B6/End.M service behaviors.
+    pub flavors: u8,
 }
 
 impl Sid {

--- a/zebra-rs/src/rib/show.rs
+++ b/zebra-rs/src/rib/show.rs
@@ -2249,6 +2249,7 @@ mod tests {
             structure: None,
             table_id: 0,
             segs: Vec::new(),
+            flavors: 0,
         }
     }
 

--- a/zebra-rs/yang/config.yang
+++ b/zebra-rs/yang/config.yang
@@ -3099,6 +3099,19 @@ module config {
              RFC 9800 NEXT-C-SID (micro-SID) format; absent means
              the classic RFC 8986 full-SID layout.";
         }
+        leaf-list flavor {
+          type enumeration {
+            enum psp;
+            enum usp;
+            enum usd;
+          }
+          description
+            "RFC 8986 4.16 endpoint flavors applied to the End/uN and
+             End.X/uA SIDs allocated from this locator (End.X SIDs take
+             only psp — their usp/usd variants are not implemented).
+             psp pops the SRH at the penultimate segment, usp pops it
+             at the ultimate segment, usd decapsulates there.";
+        }
       }
     }
 


### PR DESCRIPTION
## Summary
- Add RFC 8986 §4.16 flavor support (PSP/USP/USD) end to end: yang `flavor` leaf-list on the SRv6 locator → `Locator.flavors`/`Sid.flavors` → flavored IGP endpoint-behavior codepoints → kernel seg6local flavor install → cradle tee (`LocalSid.flavors`, proto field 12).
- Fix isis-packet classic-USD codepoint block, which was off-by-one vs IANA (End.B6.Encaps.Red=27, End-USD=28…End.T-USD block ending 39); pinned by a round-trip unit test.
- `Behavior::with_flavors` folds base End/End.X/uN/uA into flavored codepoints; adjacency SIDs (End.X/uA/uA-LIB) fold the PSP bit only, at allocation, advertisement, and install (documented deviation: no End.X USD/USP).
- Kernel install encodes `SEG6_LOCAL_FLV_OPERATION` as a single OR'd bitmask NLA (composed with NEXT-CSID for uN/uA-LIB); failures stay warn-not-fatal (USP/USD EINVAL expected on 6.8).

## Test plan
- `cargo test -p zebra-rs` (1505 passed) and isis-packet codepoint round-trip tests.
- New BDD `isis_srv6_flavor`: two-node IS-IS, z1 locator `flavor: [psp]`; z2's database shows `uN (PSP)` / `uA (PSP)`, flavorless peer unaffected, pings both ways; teardown scenario. Passed locally.
- Cradle e2e `cradle_tilfa_psp` (yang → EndCSIDPSP advertisement → tee → eBPF pop, no `seg6_enabled` on the handoff node) passed against this branch's binary.
- fmt --check, clippy --workspace --all-targets, clippy -p zebra-rs --no-default-features: clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)