### PR TITLE
rib: blackhole discard nexthop type + static nexthop blackhole

### DIFF
--- a/bdd/tests/configs/static_blackhole/r.yaml
+++ b/bdd/tests/configs/static_blackhole/r.yaml
@@ -1,0 +1,21 @@
+# Discard routes via `nexthop blackhole` — the keyword sits at the
+# nexthop-key position, satisfying the route's ext:non-empty "nexthop"
+# while installing a kernel RTN_BLACKHOLE route (no gateway).
+interface:
+- if-name: lo
+  ipv4:
+    address: 10.0.0.1/32
+  ipv6:
+    address: 2001:db8::1/128
+router:
+  static:
+    ipv4:
+      route:
+      - prefix: 10.9.9.0/24
+        nexthop:
+        - address: blackhole
+    ipv6:
+      route:
+      - prefix: 2001:db8:dead::/48
+        nexthop:
+        - address: blackhole

--- a/bdd/tests/features/static_blackhole.feature
+++ b/bdd/tests/features/static_blackhole.feature
@@ -1,0 +1,31 @@
+@serial
+@static_blackhole
+Feature: Static blackhole routes install RTN_BLACKHOLE discard entries
+  As a network operator
+  I want `router static <afi> route <prefix> nexthop blackhole` to
+  install a discard route in the forwarding plane (kernel
+  RTN_BLACKHOLE) with no gateway — so that traffic to the prefix is
+  dropped at this router instead of forwarded or looped. This
+  exercises the RIB `Nexthop::Blackhole` type end to end (config →
+  RIB → netlink → kernel FIB).
+
+  Scenario: IPv4 and IPv6 blackhole static routes reach the kernel FIB
+    Given a clean test environment
+    When I create namespace "r"
+    And I start zebra-rs in namespace "r"
+    And I apply config "r.yaml" to namespace "r"
+    And I wait 5 seconds
+
+    # The kernel FIB renders a discard route as `blackhole <prefix>`
+    # with no `via`/`dev` gateway.
+    Then kernel route "10.9.9.0/24" in namespace "r" should eventually contain "blackhole"
+    And kernel route "2001:db8:dead::/48" in namespace "r" should eventually contain "blackhole"
+
+    # Removing the route withdraws the discard entry.
+    When I apply command "delete router static ipv4 route 10.9.9.0/24 nexthop blackhole" in namespace "r"
+    Then kernel route "10.9.9.0/24" in namespace "r" should eventually be gone
+
+    # Teardown.
+    When I stop zebra-rs in namespace "r"
+    And I delete namespace "r"
+    Then the test environment should be clean

--- a/book/src/SUMMARY.md
+++ b/book/src/SUMMARY.md
@@ -12,6 +12,7 @@
 - [Static Route](ch-01-00-what-is-static-route.md)
   - [Floating Static Route](ch-01-01-floating-static-route.md)
   - [Recursive Static Route](ch-01-02-recursive-static-route.md)
+  - [Blackhole (Discard) Static Route](ch-01-03-blackhole-static-route.md)
 
 ## Routing Protocols
 

--- a/book/src/ch-01-03-blackhole-static-route.md
+++ b/book/src/ch-01-03-blackhole-static-route.md
@@ -1,0 +1,50 @@
+# Blackhole (Discard) Static Route
+
+A blackhole static route drops all traffic to a prefix in the
+forwarding plane instead of forwarding it. The discard decision is
+expressed as a nexthop keyword, `blackhole`, so a route configured
+this way still satisfies the requirement that every static route
+carry a nexthop:
+
+```
+router static {
+  ipv4 {
+    route 10.9.9.0/24 {
+      nexthop blackhole;
+    }
+  }
+  ipv6 {
+    route 2001:db8:dead::/48 {
+      nexthop blackhole;
+    }
+  }
+}
+```
+
+The keyword sits at the nexthop-address position (the address key is
+a union of an IP address and the `blackhole` enum), so
+`nexthop blackhole` and `nexthop <address>` are alternatives at the
+same point in the tree.
+
+zebra-rs installs the route into the kernel FIB as an
+`RTN_BLACKHOLE` entry with no gateway — `ip route show` renders it
+as `blackhole 10.9.9.0/24`. Packets matching the prefix (and not a
+more specific route) are dropped by the kernel with an
+`ICMP net unreachable` / `EACCES` locally, rather than being
+forwarded along a default route or looping.
+
+## Why aggregate with a discard route
+
+The common use is at an aggregation boundary. When a router
+advertises a summary prefix (for example an OSPF `area range` or a
+BGP aggregate) it originates one covering route for a block whose
+components may be only partially populated. Without a discard route
+for the aggregate, traffic to an *unpopulated* part of the block can
+match the aggregator's own default and loop back. A blackhole route
+for the aggregate prefix, less specific than every real component,
+absorbs that traffic locally instead.
+
+This makes the discard route the forwarding-plane companion to
+summarization; the aggregate origination features consume the same
+RIB `Nexthop::Blackhole` primitive that `nexthop blackhole` exposes
+here.

--- a/zebra-rs/src/config/configs.rs
+++ b/zebra-rs/src/config/configs.rs
@@ -60,6 +60,13 @@ impl Args {
         self.0.pop_front()
     }
 
+    /// Peek the next argument without consuming it. Used where a
+    /// list-key position accepts a keyword (e.g. static `nexthop
+    /// blackhole`) alongside a typed value.
+    pub fn peek_str(&self) -> Option<&str> {
+        self.0.front().map(|s| s.as_str())
+    }
+
     pub fn u8(&mut self) -> Option<u8> {
         arg_parse_type!(self, u8);
     }

--- a/zebra-rs/src/config/manager.rs
+++ b/zebra-rs/src/config/manager.rs
@@ -3670,4 +3670,35 @@ mod yang_load_tests {
             assert_ne!(code, ExecCode::Success, "`{path}` must NOT be settable");
         }
     }
+
+    /// `router static <afi> route <prefix> nexthop blackhole` — the
+    /// discard keyword sits at the nexthop-key position (a union with
+    /// the address type). Pin both AFIs as settable alongside a normal
+    /// address nexthop.
+    #[test]
+    fn static_route_nexthop_blackhole_paths_parse() {
+        use crate::config::ExecCode;
+        use crate::config::parse::{State, parse};
+        use libyang::to_entry;
+
+        let mut yang = YangStore::new();
+        yang.add_path(concat!(env!("CARGO_MANIFEST_DIR"), "/yang"));
+        yang.read_with_resolve("configure")
+            .expect("configure mode loads");
+        yang.identity_resolve();
+        let module = yang
+            .find_module("configure")
+            .expect("configure module present");
+        let entry = to_entry(&yang, module);
+
+        for path in [
+            "set router static ipv4 route 10.9.9.0/24 nexthop blackhole",
+            "set router static ipv4 route 10.9.9.0/24 nexthop 10.0.0.2",
+            "set router static ipv6 route 2001:db8:dead::/48 nexthop blackhole",
+            "set router static ipv6 route 2001:db8:dead::/48 nexthop 2001:db8::2",
+        ] {
+            let (code, _comps, _state) = parse(path, entry.clone(), None, State::new());
+            assert_eq!(code, ExecCode::Success, "`{path}` must be a settable path");
+        }
+    }
 }

--- a/zebra-rs/src/fib/netlink/handle.rs
+++ b/zebra-rs/src/fib/netlink/handle.rs
@@ -110,6 +110,7 @@ fn fmt_nexthop_for_trace(nh: &Nexthop) -> String {
             )
         }
         Nexthop::Link(ifindex) => format!("Link(ifindex={ifindex})"),
+        Nexthop::Blackhole(metric) => format!("Blackhole(metric={metric})"),
     }
 }
 
@@ -726,8 +727,79 @@ impl FibHandle {
                     .await;
                 ok
             }
+            Nexthop::Blackhole(metric) => {
+                self.route_ipv4_blackhole(prefix, entry, *metric, table_id, true)
+                    .await
+            }
             _ => true,
         }
+    }
+
+    /// Install (or delete) a discard route (`RTN_BLACKHOLE`): kernel
+    /// drops packets to `prefix` with no gateway or nexthop group.
+    /// `add` selects `RTM_NEWROUTE` vs `RTM_DELROUTE`.
+    pub async fn route_ipv4_blackhole(
+        &self,
+        prefix: &Ipv4Net,
+        entry: &RibEntry,
+        metric: u32,
+        table_id: u32,
+        add: bool,
+    ) -> bool {
+        let mut msg = RouteMessage::default();
+        msg.header.address_family = AddressFamily::Inet;
+        msg.header.destination_prefix_length = prefix.prefix_len();
+        set_route_table(&mut msg, table_id);
+        msg.header.protocol = match entry.rtype {
+            RibType::Static => RouteProtocol::Static,
+            RibType::Bgp => RouteProtocol::Bgp,
+            RibType::Ospf => RouteProtocol::Ospf,
+            RibType::Isis => RouteProtocol::Isis,
+            _ => RouteProtocol::Static,
+        };
+        msg.header.scope = RouteScope::Universe;
+        msg.header.kind = RouteType::BlackHole;
+        msg.attributes
+            .push(RouteAttribute::Destination(RouteAddress::Inet(
+                prefix.addr(),
+            )));
+        msg.attributes.push(RouteAttribute::Priority(metric));
+
+        let inner = if add {
+            RouteNetlinkMessage::NewRoute(msg)
+        } else {
+            RouteNetlinkMessage::DelRoute(msg)
+        };
+        let mut req = NetlinkMessage::from(inner);
+        req.header.flags = if add {
+            NLM_F_REQUEST | NLM_F_ACK | NLM_F_CREATE | NLM_F_EXCL
+        } else {
+            NLM_F_REQUEST | NLM_F_ACK
+        };
+
+        let mut ok = true;
+        let mut response = self.handle.clone().request(req).unwrap();
+        while let Some(msg) = response.next().await {
+            if let NetlinkPayload::Error(e) = msg.payload {
+                let errno = e.to_io().raw_os_error();
+                // EEXIST on add / ESRCH|ENOENT on delete: the kernel
+                // is already in the desired state — treat as success.
+                if (add && errno == Some(libc::EEXIST))
+                    || (!add && matches!(errno, Some(libc::ESRCH) | Some(libc::ENOENT)))
+                {
+                    continue;
+                }
+                ok = false;
+                if fib_route() {
+                    tracing::info!(
+                        "Blackhole {} error: {prefix} {e} table={table_id} rtype={:?}",
+                        if add { "add" } else { "del" },
+                        entry.rtype,
+                    );
+                }
+            }
+        }
+        ok
     }
 
     pub async fn route_ipv4_del_uni(
@@ -871,6 +943,10 @@ impl FibHandle {
                 self.route_ipv4_del_uni(prefix, entry, &protect_primary_nexthop(pro), table_id)
                     .await;
                 self.route_ipv4_del_uni(prefix, entry, &pro.backup.as_nexthop(), table_id)
+                    .await;
+            }
+            Nexthop::Blackhole(metric) => {
+                self.route_ipv4_blackhole(prefix, entry, *metric, table_id, false)
                     .await;
             }
         }
@@ -1165,8 +1241,75 @@ impl FibHandle {
                     .await;
                 ok
             }
+            Nexthop::Blackhole(metric) => {
+                self.route_ipv6_blackhole(prefix, entry, *metric, table_id, true)
+                    .await
+            }
             _ => true,
         }
+    }
+
+    /// IPv6 sibling of [`Self::route_ipv4_blackhole`].
+    pub async fn route_ipv6_blackhole(
+        &self,
+        prefix: &Ipv6Net,
+        entry: &RibEntry,
+        metric: u32,
+        table_id: u32,
+        add: bool,
+    ) -> bool {
+        let mut msg = RouteMessage::default();
+        msg.header.address_family = AddressFamily::Inet6;
+        msg.header.destination_prefix_length = prefix.prefix_len();
+        set_route_table(&mut msg, table_id);
+        msg.header.protocol = match entry.rtype {
+            RibType::Static => RouteProtocol::Static,
+            RibType::Bgp => RouteProtocol::Bgp,
+            RibType::Ospf => RouteProtocol::Ospf,
+            RibType::Isis => RouteProtocol::Isis,
+            _ => RouteProtocol::Static,
+        };
+        msg.header.scope = RouteScope::Universe;
+        msg.header.kind = RouteType::BlackHole;
+        msg.attributes
+            .push(RouteAttribute::Destination(RouteAddress::Inet6(
+                prefix.addr(),
+            )));
+        msg.attributes.push(RouteAttribute::Priority(metric));
+
+        let inner = if add {
+            RouteNetlinkMessage::NewRoute(msg)
+        } else {
+            RouteNetlinkMessage::DelRoute(msg)
+        };
+        let mut req = NetlinkMessage::from(inner);
+        req.header.flags = if add {
+            NLM_F_REQUEST | NLM_F_ACK | NLM_F_CREATE | NLM_F_EXCL
+        } else {
+            NLM_F_REQUEST | NLM_F_ACK
+        };
+
+        let mut ok = true;
+        let mut response = self.handle.clone().request(req).unwrap();
+        while let Some(msg) = response.next().await {
+            if let NetlinkPayload::Error(e) = msg.payload {
+                let errno = e.to_io().raw_os_error();
+                if (add && errno == Some(libc::EEXIST))
+                    || (!add && matches!(errno, Some(libc::ESRCH) | Some(libc::ENOENT)))
+                {
+                    continue;
+                }
+                ok = false;
+                if fib_route() {
+                    tracing::info!(
+                        "Blackhole {} error: {prefix} {e} table={table_id} rtype={:?}",
+                        if add { "add" } else { "del" },
+                        entry.rtype,
+                    );
+                }
+            }
+        }
+        ok
     }
 
     pub async fn route_ipv6_del_uni(
@@ -1327,6 +1470,10 @@ impl FibHandle {
                 self.route_ipv6_del_uni(prefix, entry, &protect_primary_nexthop(pro), table_id)
                     .await;
                 self.route_ipv6_del_uni(prefix, entry, &pro.backup.as_nexthop(), table_id)
+                    .await;
+            }
+            Nexthop::Blackhole(metric) => {
+                self.route_ipv6_blackhole(prefix, entry, *metric, table_id, false)
                     .await;
             }
         }

--- a/zebra-rs/src/rib/entry.rs
+++ b/zebra-rs/src/rib/entry.rs
@@ -102,6 +102,9 @@ impl RibEntry {
             Nexthop::Protect(pro) => pro
                 .iter_unis()
                 .any(|nhop| nmap.get(nhop.gid).is_some_and(|group| group.is_valid())),
+            // A discard route is self-contained — no gateway to
+            // resolve, so it is always installable.
+            Nexthop::Blackhole(_) => true,
             _ => false,
         }
     }
@@ -136,7 +139,9 @@ impl RibEntry {
             return;
         }
         match &self.nexthop {
-            Nexthop::Link(_) => {}
+            // No kernel nexthop group backs a Link or Blackhole route,
+            // so there is nothing to unsync.
+            Nexthop::Link(_) | Nexthop::Blackhole(_) => {}
             Nexthop::Uni(uni) => {
                 // println!(" uni {}", uni.addr);
                 self.handle_nexthop_group(nmap, fib, uni.gid).await;

--- a/zebra-rs/src/rib/nexthop/disp.rs
+++ b/zebra-rs/src/rib/nexthop/disp.rs
@@ -20,6 +20,9 @@ impl Display for Nexthop {
             Nexthop::Protect(pro) => {
                 write!(f, "{}", pro)
             }
+            Nexthop::Blackhole(_) => {
+                write!(f, "blackhole")
+            }
         }
     }
 }

--- a/zebra-rs/src/rib/nexthop/inst.rs
+++ b/zebra-rs/src/rib/nexthop/inst.rs
@@ -113,6 +113,13 @@ pub enum Nexthop {
     Multi(NexthopMulti),
     List(NexthopList),
     Protect(NexthopProtect),
+    /// A discard route — packets to the prefix are dropped in the
+    /// forwarding plane (kernel `RTN_BLACKHOLE`) with no gateway or
+    /// nexthop group. Used for aggregate summarization discards
+    /// (OSPF `area range` / BGP `aggregate-address`) so component
+    /// traffic that no more-specific route covers is dropped at the
+    /// aggregator instead of looping. Carries only the route metric.
+    Blackhole(u32),
 }
 
 impl Default for Nexthop {

--- a/zebra-rs/src/rib/redist.rs
+++ b/zebra-rs/src/rib/redist.rs
@@ -231,7 +231,7 @@ fn first_v4_nexthop(nh: &Nexthop) -> Option<std::net::Ipv4Addr> {
             std::net::IpAddr::V4(a) => Some(a),
             _ => None,
         }),
-        Nexthop::Link(_) => None,
+        Nexthop::Link(_) | Nexthop::Blackhole(_) => None,
     }
 }
 
@@ -262,7 +262,7 @@ fn first_v6_nexthop(nh: &Nexthop) -> Option<std::net::Ipv6Addr> {
             std::net::IpAddr::V6(a) => Some(a),
             _ => None,
         }),
-        Nexthop::Link(_) => None,
+        Nexthop::Link(_) | Nexthop::Blackhole(_) => None,
     }
 }
 

--- a/zebra-rs/src/rib/route.rs
+++ b/zebra-rs/src/rib/route.rs
@@ -1591,6 +1591,12 @@ fn entry_resolve(entry: &mut RibEntry, nmap: &NexthopMap, _ifdown: bool) {
         Nexthop::Link(iflink) => {
             tracing::info!("Nexthop::Link({}): this won't happen", iflink);
         }
+        // A discard route needs no gateway resolution — it is always
+        // valid and forwards nothing.
+        Nexthop::Blackhole(_) => {
+            entry.valid = true;
+            entry.fib = true;
+        }
         Nexthop::Uni(uni) => {
             nexthop_uni_resolve(uni, nmap);
             entry.valid = uni.valid;
@@ -1979,6 +1985,7 @@ fn rib_replace_system(
         }
         // System (kernel) routes are never primary+backup protected.
         Nexthop::Protect(_) => false,
+        Nexthop::Blackhole(m) => *m == entry.metric,
     };
     // println!("replace {}", replace);
     if replace {
@@ -2250,6 +2257,7 @@ fn rib_replace_system_v6(
         }
         // System (kernel) routes are never primary+backup protected.
         Nexthop::Protect(_) => false,
+        Nexthop::Blackhole(m) => *m == entry.metric,
     };
     if replace {
         return rib_replace_v6(table, prefix, entry.rtype);

--- a/zebra-rs/src/rib/show.rs
+++ b/zebra-rs/src/rib/show.rs
@@ -139,6 +139,16 @@ fn rib_entry_to_json(rib: &Rib, prefix: &Ipv4Net, e: &RibEntry) -> RouteEntry {
                 backup: false,
             }]
         }
+        Nexthop::Blackhole(metric) => {
+            vec![NexthopJson {
+                address: None,
+                interface: "blackhole".to_string(),
+                weight: None,
+                metric: Some(*metric),
+                mpls_labels: vec![],
+                backup: false,
+            }]
+        }
         Nexthop::Uni(uni) => {
             let grp = rib.nmap.get(uni.gid);
             // Prefer the group's view (post-resolution) but fall back
@@ -275,6 +285,16 @@ fn rib_entry_to_json_v6(rib: &Rib, prefix: &Ipv6Net, e: &RibEntry) -> RouteEntry
                 interface: rib.link_name(*ifindex),
                 weight: None,
                 metric: None,
+                mpls_labels: vec![],
+                backup: false,
+            }]
+        }
+        Nexthop::Blackhole(metric) => {
+            vec![NexthopJson {
+                address: None,
+                interface: "blackhole".to_string(),
+                weight: None,
+                metric: Some(*metric),
                 mpls_labels: vec![],
                 backup: false,
             }]
@@ -424,6 +444,9 @@ pub fn rib_entry_show(
             Nexthop::Link(_ifindex) => {
                 let _ = writeln!(buf, " via {}, {}", rib.link_name(e.ifindex), uptime);
             }
+            Nexthop::Blackhole(_) => {
+                let _ = writeln!(buf, " is a discard (blackhole), {}", uptime);
+            }
             Nexthop::Uni(uni) => {
                 let grp = rib.nmap.get(uni.gid);
 
@@ -513,6 +536,9 @@ pub fn rib_entry_show_v6(
         match &e.nexthop {
             Nexthop::Link(_ifindex) => {
                 let _ = writeln!(buf, " via {}, {}", rib.link_name(e.ifindex), uptime);
+            }
+            Nexthop::Blackhole(_) => {
+                let _ = writeln!(buf, " is a discard (blackhole), {}", uptime);
             }
             Nexthop::Uni(uni) => {
                 let grp = rib.nmap.get(uni.gid);
@@ -806,7 +832,7 @@ fn entry_has_mpls(e: &RibEntry) -> bool {
             NexthopMember::Multi(mm) => mm.nexthops.iter().any(uni_has),
         }),
         Nexthop::Protect(p) => p.iter_unis().any(uni_has),
-        Nexthop::Link(_) => false,
+        Nexthop::Link(_) | Nexthop::Blackhole(_) => false,
     }
 }
 
@@ -824,7 +850,7 @@ fn entry_has_srv6(e: &RibEntry) -> bool {
             NexthopMember::Multi(mm) => mm.nexthops.iter().any(uni_has),
         }),
         Nexthop::Protect(p) => p.iter_unis().any(uni_has),
-        Nexthop::Link(_) => false,
+        Nexthop::Link(_) | Nexthop::Blackhole(_) => false,
     }
 }
 
@@ -896,6 +922,9 @@ fn write_nexthop_blocks_v4(buf: &mut String, rib: &Rib, nh: &Nexthop) {
         Nexthop::Link(ifindex) => {
             let _ = writeln!(buf, "    directly attached via {}", rib.link_name(*ifindex));
         }
+        Nexthop::Blackhole(_) => {
+            let _ = writeln!(buf, "    discard (blackhole)");
+        }
         Nexthop::Uni(uni) => write_descriptor_block_v4(buf, rib, uni, "Protected"),
         Nexthop::Multi(multi) => {
             for uni in multi.nexthops.iter() {
@@ -925,6 +954,9 @@ fn write_nexthop_blocks_v6(buf: &mut String, rib: &Rib, nh: &Nexthop) {
     match nh {
         Nexthop::Link(ifindex) => {
             let _ = writeln!(buf, "    directly attached via {}", rib.link_name(*ifindex));
+        }
+        Nexthop::Blackhole(_) => {
+            let _ = writeln!(buf, "    discard (blackhole)");
         }
         Nexthop::Uni(uni) => write_descriptor_block_v6(buf, rib, uni, "Protected"),
         Nexthop::Multi(multi) => {

--- a/zebra-rs/src/rib/static/config.rs
+++ b/zebra-rs/src/rib/static/config.rs
@@ -366,12 +366,25 @@ fn config_builder<F: StaticFamily>(base: &str) -> ConfigBuilder<F> {
         .path(&format!("{base}/{}/route/nexthop", F::FAMILY))
         .set(|config, cache, prefix, args| {
             let s = cache_get::<F>(config, cache, prefix).context(CONFIG_ERR)?;
+            // `nexthop blackhole` — the discard keyword sits at the
+            // nexthop key position (a union with the address type),
+            // so it satisfies the route's `ext:non-empty "nexthop"`.
+            if args.peek_str() == Some("blackhole") {
+                let _ = args.string();
+                s.blackhole = true;
+                return Ok(());
+            }
             let naddr = F::parse_addr(args).context(NEXTHOP_ERR)?;
             let _ = s.nexthops.entry(naddr).or_default();
             Ok(())
         })
         .del(|config, cache, prefix, args| {
             let s = cache_lookup::<F>(config, cache, prefix).context(CONFIG_ERR)?;
+            if args.peek_str() == Some("blackhole") {
+                let _ = args.string();
+                s.blackhole = false;
+                return Ok(());
+            }
             let naddr = F::parse_addr(args).context(NEXTHOP_ERR)?;
             s.nexthops.remove(&naddr).context(CONFIG_ERR)?;
             Ok(())

--- a/zebra-rs/src/rib/static/route.rs
+++ b/zebra-rs/src/rib/static/route.rs
@@ -28,6 +28,11 @@ pub struct StaticRoute<F: StaticFamily> {
     /// produces a Uni nexthop that the FIB installs as a kernel
     /// `seg6local` route on the sr0 dummy.
     pub seg6local_action: Option<SidBehavior>,
+    /// Discard route (`route <prefix> blackhole`): `to_entry`
+    /// produces a `Nexthop::Blackhole` the FIB installs as an
+    /// `RTN_BLACKHOLE` kernel route. Mutually exclusive with
+    /// nexthops / segs.
+    pub blackhole: bool,
     pub delete: bool,
 }
 
@@ -40,6 +45,7 @@ impl<F: StaticFamily> Default for StaticRoute<F> {
             segs: Vec::new(),
             encap_type: None,
             seg6local_action: None,
+            blackhole: false,
             delete: false,
         }
     }
@@ -54,6 +60,7 @@ impl<F: StaticFamily> Clone for StaticRoute<F> {
             segs: self.segs.clone(),
             encap_type: self.encap_type,
             seg6local_action: self.seg6local_action,
+            blackhole: self.blackhole,
             delete: self.delete,
         }
     }
@@ -71,6 +78,7 @@ where
             .field("segs", &self.segs)
             .field("encap_type", &self.encap_type)
             .field("seg6local_action", &self.seg6local_action)
+            .field("blackhole", &self.blackhole)
             .field("delete", &self.delete)
             .finish()
     }
@@ -78,7 +86,11 @@ where
 
 impl<F: StaticFamily> StaticRoute<F> {
     pub fn to_entry(&self) -> Option<RibEntry> {
-        if self.nexthops.is_empty() && self.segs.is_empty() && self.seg6local_action.is_none() {
+        if self.nexthops.is_empty()
+            && self.segs.is_empty()
+            && self.seg6local_action.is_none()
+            && !self.blackhole
+        {
             return None;
         }
 
@@ -86,6 +98,13 @@ impl<F: StaticFamily> StaticRoute<F> {
         entry.distance = self.distance.unwrap_or(1);
 
         let metric = self.metric.unwrap_or(0);
+
+        if self.blackhole {
+            // A discard route drops matching traffic; no nexthop.
+            entry.nexthop = Nexthop::Blackhole(metric);
+            entry.metric = metric;
+            return Some(entry);
+        }
 
         if let Some(action) = self.seg6local_action {
             // Terminal seg6local action (End.DT6 etc.). The address
@@ -396,5 +415,25 @@ mod tests {
         let uni = as_uni(&entry);
         assert_eq!(uni.seg6local_action, Some(SidBehavior::EndDT6));
         assert!(uni.segs.is_empty());
+    }
+
+    #[test]
+    fn blackhole_route_builds_blackhole_nexthop() {
+        // A `blackhole` route carries no gateway; to_entry yields a
+        // Nexthop::Blackhole even with an empty nexthops map, and the
+        // metric flows through.
+        let mut r = StaticRoute::<V4>::default();
+        r.blackhole = true;
+        r.metric = Some(50);
+        let entry = r.to_entry().expect("blackhole entry built");
+        assert_eq!(entry.nexthop, Nexthop::Blackhole(50));
+        assert_eq!(entry.metric, 50);
+    }
+
+    #[test]
+    fn empty_route_without_blackhole_yields_none() {
+        // No nexthop, no segs, no blackhole → nothing to install.
+        let r = StaticRoute::<V4>::default();
+        assert!(r.to_entry().is_none());
     }
 }

--- a/zebra-rs/src/rib/static/route.rs
+++ b/zebra-rs/src/rib/static/route.rs
@@ -422,9 +422,11 @@ mod tests {
         // A `blackhole` route carries no gateway; to_entry yields a
         // Nexthop::Blackhole even with an empty nexthops map, and the
         // metric flows through.
-        let mut r = StaticRoute::<V4>::default();
-        r.blackhole = true;
-        r.metric = Some(50);
+        let r = StaticRoute::<V4> {
+            blackhole: true,
+            metric: Some(50),
+            ..Default::default()
+        };
         let entry = r.to_entry().expect("blackhole entry built");
         assert_eq!(entry.nexthop, Nexthop::Blackhole(50));
         assert_eq!(entry.metric, 50);

--- a/zebra-rs/yang/config-static.yang
+++ b/zebra-rs/yang/config-static.yang
@@ -39,8 +39,16 @@ module config-static {
         list nexthop {
           key "address";
           leaf "address" {
-            type inet:ipv4-address;
-            description "Nexthop of the route";
+            type union {
+              type inet:ipv4-address;
+              // `blackhole` at the nexthop-key position turns the
+              // route into a discard route (kernel RTN_BLACKHOLE),
+              // satisfying the route's `ext:non-empty "nexthop"`.
+              type enumeration {
+                enum blackhole;
+              }
+            }
+            description "Nexthop address, or `blackhole` to discard";
           }
           leaf "outgoing-label" {
             type uint32;
@@ -64,8 +72,16 @@ module config-static {
         list nexthop {
           key "address";
           leaf "address" {
-            type inet:ipv4-address;
-            description "Nexthop of the route";
+            type union {
+              type inet:ipv4-address;
+              // `blackhole` at the nexthop-key position turns the
+              // route into a discard route (kernel RTN_BLACKHOLE),
+              // satisfying the route's `ext:non-empty "nexthop"`.
+              type enumeration {
+                enum blackhole;
+              }
+            }
+            description "Nexthop address, or `blackhole` to discard";
           }
           leaf metric {
             type uint32;
@@ -82,6 +98,13 @@ module config-static {
         leaf distance {
           type uint8;
           description "Distance of the route.";
+        }
+        leaf blackhole {
+          type boolean;
+          description
+            "Discard route: matching traffic is dropped in the
+             forwarding plane (kernel RTN_BLACKHOLE) with no
+             nexthop. Mutually exclusive with `nexthop`.";
         }
         leaf metric {
           type uint32;
@@ -188,8 +211,13 @@ module config-static {
         list nexthop {
           key "address";
           leaf "address" {
-            type inet:ipv6-address;
-            description "Nexthop of the route";
+            type union {
+              type inet:ipv6-address;
+              type enumeration {
+                enum blackhole;
+              }
+            }
+            description "Nexthop address, or `blackhole` to discard";
           }
           leaf metric {
             type uint32;
@@ -203,6 +231,13 @@ module config-static {
         leaf distance {
           type uint8;
           description "Distance of the route.";
+        }
+        leaf blackhole {
+          type boolean;
+          description
+            "Discard route: matching traffic is dropped in the
+             forwarding plane (kernel RTN_BLACKHOLE) with no
+             nexthop. Mutually exclusive with `nexthop`.";
         }
         leaf metric {
           type uint32;


### PR DESCRIPTION
## Summary

Adds a RIB blackhole (discard) nexthop type — the forwarding-plane primitive needed for aggregate discard routes (OSPF `area range`, BGP `aggregate-address`) — and exposes it through static config as its validation vehicle.

- **RIB primitive**: `Nexthop::Blackhole(metric)` — packets to the prefix are dropped in the kernel (`RTN_BLACKHOLE`) with no gateway or nexthop group. `route_ipv4_blackhole` / `route_ipv6_blackhole` build the netlink message (destination + priority, no gateway) and are wired into all four v4/v6 add/delete dispatches. Handled at every match site: always installable, no nexthop-group sync, no redistribute address, resolve marks valid+fib, renders as `blackhole`/`discard` in show output.
- **Consumer**: `router static <afi> route <prefix> nexthop blackhole`. The discard keyword sits at the nexthop-key position (the address key is a union of an IP address and the `blackhole` enum), so it satisfies the route's `ext:non-empty "nexthop"` while producing a `Nexthop::Blackhole`. StaticRoute gains a `blackhole` field + to_entry branch; the nexthop handlers intercept the keyword (new `Args::peek_str`).
- **Book**: a static blackhole-route page covering the config, the kernel install, and the aggregation motivation.

## Test plan

- Unit tests: `to_entry` produces `Nexthop::Blackhole(metric)`; an empty route without blackhole yields `None`.
- Parse test pins `nexthop blackhole` settable for both AFIs (alongside a normal address nexthop).
- New BDD `static_blackhole`: v4 and v6 `nexthop blackhole` routes appear as `blackhole <prefix>` in the kernel FIB (`ip route show`), and deleting withdraws the entry — exercising config → RIB → netlink → kernel.
- `cargo fmt --check`, clippy `-D warnings` (default and no-lua), `cargo test --workspace --exclude bdd` (2140 passed, 0 failed), `mdbook build` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)