### PR TITLE
feat(ospf): install discard routes for active area ranges

### DIFF
--- a/bdd/tests/features/ospfv2_area_range.feature
+++ b/bdd/tests/features/ospfv2_area_range.feature
@@ -54,6 +54,10 @@ Feature: OSPFv2 area ranges aggregate Type-3 summaries at the ABR
     And show command "show ospf route" in namespace "c" should contain "10.0.0.2/32"
     # Traffic to a component follows the aggregate end to end.
     And ping from "c" to "10.1.1.1" should succeed
+    # The ABR installs a discard (blackhole) route for the active
+    # range so traffic to a non-existent component (e.g. 10.1.9.9)
+    # is dropped locally instead of following a default and looping.
+    And kernel route "10.1.0.0/16" in namespace "a" should eventually contain "blackhole"
 
     # Teardown.
     When I stop zebra-rs in namespace "a"
@@ -88,6 +92,10 @@ Feature: OSPFv2 area ranges aggregate Type-3 summaries at the ABR
     And show command "show ospf route" in namespace "c" should not contain "10.1.2.0/24"
     # Prefixes outside the range are unaffected.
     And show command "show ospf route" in namespace "c" should contain "10.0.0.2/32"
+    # The discard route is installed even with not-advertise — hiding
+    # the aggregate from neighbors doesn't remove the local loop
+    # protection for the range's gaps.
+    And kernel route "10.1.0.0/16" in namespace "a" should eventually contain "blackhole"
 
     # Teardown.
     When I stop zebra-rs in namespace "a"

--- a/bdd/tests/features/ospfv3_area_range.feature
+++ b/bdd/tests/features/ospfv3_area_range.feature
@@ -44,6 +44,10 @@ Feature: OSPFv3 area ranges aggregate Inter-Area-Prefix-LSAs at the ABR
     And show command "show ospfv3 route" in namespace "c" should contain "2001:db8::2/128"
     # Traffic to a component follows the aggregate end to end.
     And ping from "c" to "2001:db8:1:1::1" should succeed
+    # The ABR installs a discard (blackhole) route for the active
+    # range so traffic to a non-existent component is dropped locally
+    # instead of following a default and looping.
+    And kernel route "2001:db8:1::/48" in namespace "a" should eventually contain "blackhole"
 
     # Teardown.
     When I stop zebra-rs in namespace "a"
@@ -76,6 +80,8 @@ Feature: OSPFv3 area ranges aggregate Inter-Area-Prefix-LSAs at the ABR
     And show command "show ospfv3 route" in namespace "c" should not contain "2001:db8:1:1::/64"
     And show command "show ospfv3 route" in namespace "c" should not contain "2001:db8:1:2::/64"
     And show command "show ospfv3 route" in namespace "c" should contain "2001:db8::2/128"
+    # The discard route is installed even with not-advertise.
+    And kernel route "2001:db8:1::/48" in namespace "a" should eventually contain "blackhole"
 
     # Teardown.
     When I stop zebra-rs in namespace "a"

--- a/book/src/ch-08-12-ospf-frr-gaps.md
+++ b/book/src/ch-08-12-ospf-frr-gaps.md
@@ -3,8 +3,6 @@
 OSPFv2 features not yet implemented in zebra-rs:
 
 - Virtual links across non-backbone areas.
-- Discard (Null0) routes for active area ranges — the aggregation
-  and suppression themselves are implemented.
 - NBMA and point-to-multipoint network types — the per-interface
   `network-type` knob accepts `broadcast` and `point-to-point`
   only.
@@ -40,6 +38,11 @@ per feature — see each feature's page):
   Type-4 fallback for inter-area ASBR resolution. v2 only —
   OSPFv3 ABR summary origination is still pending. See
   [Multi-Area Routing and the ABR](ch-08-14-ospf-multi-area-abr.md).
+- **Discard (blackhole) routes for active area ranges**
+  (RFC 2328 §12.4.3) — the loop-safety companion to range
+  aggregation, installed via the RIB `nexthop blackhole` type for
+  both OSPFv2 and OSPFv3. See
+  [Multi-Area Routing and the ABR](ch-08-14-ospf-multi-area-abr.md#discard-route).
 - **Type-5 (AS-External) origination from redistribution** and
   **Type-7 (NSSA-External) translation**. See
   [Route Redistribution](ch-08-15-ospf-redistribution.md).

--- a/book/src/ch-08-14-ospf-multi-area-abr.md
+++ b/book/src/ch-08-14-ospf-multi-area-abr.md
@@ -88,9 +88,37 @@ The most-specific configured range wins when several contain a
 component. Ranges apply only to the area's own intra-area routes —
 inter-area routes re-advertised from the backbone pass through
 unaffected — and prefixes outside every range keep advertising
-individually. The RFC's companion discard route for active ranges
-(FRR's Null0) is not installed yet; see
-[Gaps Relative to FRR ospfd](ch-08-12-ospf-frr-gaps.md).
+individually.
+
+### Discard route
+
+Advertising one aggregate for a whole range means the ABR draws
+traffic for *every* address in the range, including sub-prefixes
+that no component actually covers. Without protection that traffic
+would fall through to the ABR's own default route and could loop
+straight back. RFC 2328 §12.4.3 closes the hole with a companion
+*discard* route: while a range is active the ABR installs a
+blackhole covering the aggregate, so a packet to a non-existent
+component is dropped locally instead of forwarded.
+
+zebra-rs installs this discard through the RIB `nexthop blackhole`
+type (kernel `RTN_BLACKHOLE`, the same primitive as
+[static blackhole routes](ch-01-03-blackhole-static-route.md)):
+
+```
+$ ip route show 10.1.0.0/16
+blackhole 10.1.0.0/16 proto ospf
+```
+
+The discard is more general (shorter prefix) than every component,
+so real destinations still match their specific intra-area route by
+longest-prefix; only the gaps hit the blackhole. It is installed for
+every active range — including `not-advertise` ranges, since hiding
+the aggregate from neighbors does not remove the local loop
+exposure — and withdrawn as soon as the range loses its last
+component or the router stops being an ABR. A range prefix that a
+real OSPF route already reaches exactly is left alone rather than
+blackholed.
 
 ## Type-4 ASBR-Summary origination
 

--- a/book/src/ch-15-04-ospfv3-multi-area-abr.md
+++ b/book/src/ch-15-04-ospfv3-multi-area-abr.md
@@ -89,5 +89,12 @@ router ospfv3 {
 ```
 
 The `not-advertise` and `cost` leaves match
-[the v2 page's table](ch-08-14-ospf-multi-area-abr.md); the discard
-route for active ranges is likewise not installed yet.
+[the v2 page's table](ch-08-14-ospf-multi-area-abr.md). The
+loop-safety [discard route](ch-08-14-ospf-multi-area-abr.md#discard-route)
+for active ranges is installed identically — a `nexthop blackhole`
+covering the aggregate, withdrawn when the range empties:
+
+```
+$ ip -6 route show 2001:db8:1::/48
+blackhole 2001:db8:1::/48 proto ospf
+```

--- a/book/src/ch-15-15-ospfv3-frr-gaps.md
+++ b/book/src/ch-15-15-ospfv3-frr-gaps.md
@@ -2,8 +2,6 @@
 
 OSPFv3 features not yet implemented in zebra-rs:
 
-- Discard (Null0) routes for active area ranges — the aggregation
-  and suppression themselves are implemented.
 - Redistribution `route-map` filtering (the zebra-rs sources are
   connected, static, kernel, IS-IS, and BGP, matching v2).
 - Non-zero forwarding-address resolution on received externals.

--- a/zebra-rs/src/ospf/inst.rs
+++ b/zebra-rs/src/ospf/inst.rs
@@ -216,6 +216,14 @@ pub struct Ospf<V: OspfVersion = Ospfv2> {
     /// area's SPF; merged into `rib6` by `merge_area_ribs6` and read
     /// by the ABR Inter-Area-Prefix origination (`abr_summary_*_v3`).
     pub rib6_areas: BTreeMap<Ipv4Addr, PrefixMap<ipnet::Ipv6Net, SpfRouteV3>>,
+    /// Aggregate prefixes for which this ABR has installed a discard
+    /// (blackhole) route into the RIB — the forwarding-plane companion
+    /// to an active `area range` (RFC 2328 §12.4.3). Traffic to a
+    /// non-existent component of the range is dropped locally instead
+    /// of following a default and looping. Diffed by
+    /// `abr_range_discard_sync`; v6 sibling below.
+    pub range_discards: BTreeSet<Ipv4Net>,
+    pub range_discards_v6: BTreeSet<ipnet::Ipv6Net>,
     pub tracing: OspfTracing,
     pub segment_routing: super::srmpls::SegmentRoutingMode,
 
@@ -1227,6 +1235,8 @@ impl Ospf<Ospfv2> {
             lan_adj_sids: BTreeMap::new(),
             rib6: PrefixMap::new(),
             rib6_areas: BTreeMap::new(),
+            range_discards: BTreeSet::new(),
+            range_discards_v6: BTreeSet::new(),
             tracing: OspfTracing::default(),
             segment_routing: super::srmpls::SegmentRoutingMode::default(),
             srv6_locator_name: None,
@@ -1688,12 +1698,106 @@ impl Ospf<Ospfv2> {
             for area_id in all {
                 self.abr_summary_sync_area(area_id, &BTreeMap::new());
             }
+            // No longer an ABR — withdraw any range discard routes too.
+            self.abr_range_discard_sync(&BTreeMap::new());
             return;
         }
 
         for &area_a in &attached {
             let desired = self.abr_summary_desired(area_a, &attached);
             self.abr_summary_sync_area(area_a, &desired);
+        }
+
+        // Forwarding-plane companion to the summaries: a discard
+        // (blackhole) route for each active range so traffic to a
+        // non-existent component is dropped locally rather than
+        // following a default and looping.
+        let discards = self.active_range_discards_v4();
+        self.abr_range_discard_sync(&discards);
+    }
+
+    /// Compute the active `area range` prefixes and their discard-route
+    /// metric (RFC 2328 §12.4.3). A range is active when its own area's
+    /// intra-area RIB slice holds at least one *strictly more-specific*
+    /// component; the metric is the configured `cost`, else the largest
+    /// component metric. Installed regardless of `not-advertise` — the
+    /// discard prevents loops whether or not the aggregate is
+    /// advertised.
+    fn active_range_discards_v4(&self) -> BTreeMap<Ipv4Net, u32> {
+        let mut desired: BTreeMap<Ipv4Net, u32> = BTreeMap::new();
+        for (area_id, area) in self.areas.iter() {
+            if area.ranges.is_empty() {
+                continue;
+            }
+            let Some(rib) = self.rib_areas.get(area_id) else {
+                continue;
+            };
+            for (prefix, route) in rib.iter() {
+                if route.path_type != RouteType::IntraArea {
+                    continue;
+                }
+                let Some(range_prefix) = area
+                    .ranges
+                    .keys()
+                    .filter(|r| r.prefix_len() < prefix.prefix_len() && r.contains(&prefix))
+                    .max_by_key(|r| r.prefix_len())
+                    .copied()
+                else {
+                    continue;
+                };
+                // Never blackhole a prefix a real OSPF route already
+                // reaches at the exact range prefix (e.g. an inter-area
+                // route from another area) — that would fight the SPF
+                // install for the same `RibType::Ospf` slot.
+                if self.rib.get(&range_prefix).is_some() {
+                    continue;
+                }
+                let cost = area.ranges.get(&range_prefix).and_then(|e| e.cost);
+                match cost {
+                    Some(c) => {
+                        desired.entry(range_prefix).or_insert(c);
+                    }
+                    None => {
+                        desired
+                            .entry(range_prefix)
+                            .and_modify(|m| *m = (*m).max(route.metric))
+                            .or_insert(route.metric);
+                    }
+                }
+            }
+        }
+        desired
+    }
+
+    /// Reconcile the installed range discard routes against `desired`:
+    /// install a blackhole route for each newly-active range, withdraw
+    /// those no longer active.
+    fn abr_range_discard_sync(&mut self, desired: &BTreeMap<Ipv4Net, u32>) {
+        let installed = self.range_discards.clone();
+        for prefix in &installed {
+            if !desired.contains_key(prefix) {
+                let mut rib = rib::entry::RibEntry::new(RibType::Ospf);
+                rib.distance = 110;
+                rib.nexthop = rib::Nexthop::Blackhole(0);
+                let _ = self.ctx.rib.send(rib::Message::Ipv4Del {
+                    prefix: *prefix,
+                    rib,
+                });
+                self.range_discards.remove(prefix);
+            }
+        }
+        for (prefix, metric) in desired {
+            if !installed.contains(prefix) {
+                let mut rib = rib::entry::RibEntry::new(RibType::Ospf);
+                rib.distance = 110;
+                rib.metric = *metric;
+                rib.nexthop = rib::Nexthop::Blackhole(*metric);
+                let _ = self.ctx.rib.send(rib::Message::Ipv4Add {
+                    prefix: *prefix,
+                    rib,
+                });
+                self.range_discards.insert(*prefix);
+            }
         }
     }
 
@@ -5514,6 +5618,8 @@ impl Ospf<Ospfv3> {
             lan_adj_sids: BTreeMap::new(),
             rib6: PrefixMap::new(),
             rib6_areas: BTreeMap::new(),
+            range_discards: BTreeSet::new(),
+            range_discards_v6: BTreeSet::new(),
             tracing: OspfTracing::default(),
             segment_routing: super::srmpls::SegmentRoutingMode::default(),
             srv6_locator_name: None,
@@ -6896,12 +7002,91 @@ impl Ospf<Ospfv3> {
             for area_id in all {
                 self.abr_summary_sync_area_v3(area_id, &BTreeMap::new());
             }
+            // No longer an ABR — withdraw any range discard routes too.
+            self.abr_range_discard_sync_v3(&BTreeMap::new());
             return;
         }
 
         for &area_a in &attached {
             let desired = self.abr_summary_desired_v3(area_a, &attached);
             self.abr_summary_sync_area_v3(area_a, &desired);
+        }
+
+        let discards = self.active_range_discards_v6();
+        self.abr_range_discard_sync_v3(&discards);
+    }
+
+    /// v6 sibling of `active_range_discards_v4`: the active
+    /// Inter-Area-Prefix ranges and their discard-route metric.
+    fn active_range_discards_v6(&self) -> BTreeMap<ipnet::Ipv6Net, u32> {
+        let mut desired: BTreeMap<ipnet::Ipv6Net, u32> = BTreeMap::new();
+        for (area_id, area) in self.areas.iter() {
+            if area.ranges_v6.is_empty() {
+                continue;
+            }
+            let Some(rib) = self.rib6_areas.get(area_id) else {
+                continue;
+            };
+            for (prefix, route) in rib.iter() {
+                if route.path_type != RouteType::IntraArea {
+                    continue;
+                }
+                let Some(range_prefix) = area
+                    .ranges_v6
+                    .keys()
+                    .filter(|r| r.prefix_len() < prefix.prefix_len() && r.contains(&prefix))
+                    .max_by_key(|r| r.prefix_len())
+                    .copied()
+                else {
+                    continue;
+                };
+                if self.rib6.get(&range_prefix).is_some() {
+                    continue;
+                }
+                let cost = area.ranges_v6.get(&range_prefix).and_then(|e| e.cost);
+                match cost {
+                    Some(c) => {
+                        desired.entry(range_prefix).or_insert(c);
+                    }
+                    None => {
+                        desired
+                            .entry(range_prefix)
+                            .and_modify(|m| *m = (*m).max(route.metric))
+                            .or_insert(route.metric);
+                    }
+                }
+            }
+        }
+        desired
+    }
+
+    /// v6 sibling of `abr_range_discard_sync`.
+    fn abr_range_discard_sync_v3(&mut self, desired: &BTreeMap<ipnet::Ipv6Net, u32>) {
+        let installed = self.range_discards_v6.clone();
+        for prefix in &installed {
+            if !desired.contains_key(prefix) {
+                let mut rib = rib::entry::RibEntry::new(RibType::Ospf);
+                rib.distance = 110;
+                rib.nexthop = rib::Nexthop::Blackhole(0);
+                let _ = self.ctx.rib.send(rib::Message::Ipv6Del {
+                    prefix: *prefix,
+                    rib,
+                });
+                self.range_discards_v6.remove(prefix);
+            }
+        }
+        for (prefix, metric) in desired {
+            if !installed.contains(prefix) {
+                let mut rib = rib::entry::RibEntry::new(RibType::Ospf);
+                rib.distance = 110;
+                rib.metric = *metric;
+                rib.nexthop = rib::Nexthop::Blackhole(*metric);
+                let _ = self.ctx.rib.send(rib::Message::Ipv6Add {
+                    prefix: *prefix,
+                    rib,
+                });
+                self.range_discards_v6.insert(*prefix);
+            }
         }
     }
 


### PR DESCRIPTION
## Summary

RFC 2328 §12.4.3 pairs each active `area range` aggregate with a **discard route** so that traffic to a non-existent component of the range is dropped at the ABR instead of following a default and looping back. zebra-rs already originated the aggregate Type-3 (v2) / Inter-Area-Prefix-LSA (v3) but installed no such forwarding-plane protection — this closes that gap for both address families.

- `active_range_discards_v4` / `active_range_discards_v6` compute the active range prefixes: a range holding ≥1 *strictly more-specific* IntraArea component in its own area's route slice. Metric is the configured `cost`, else the largest component metric.
- `abr_range_discard_sync` / `_v3` diff the desired set against the installed set (`range_discards` / `range_discards_v6`), installing a `Nexthop::Blackhole` covering route (kernel `RTN_BLACKHOLE`) for each newly-active range and withdrawing those no longer active.
- Hooked into `abr_summary_originate` / `abr_summary_originate_v3`, including the `<2`-area path that withdraws all discards when the router stops being an ABR.

### Design notes
- Installed for `not-advertise` ranges too — hiding the aggregate from neighbors does not remove the local loop exposure.
- Skipped when a real OSPF route already reaches the exact range prefix (e.g. an inter-area route from another area), which would otherwise fight the SPF install for the same `RibType::Ospf` slot.
- The discard is shorter-prefix than every component, so real destinations still match their specific route by longest-prefix; only the gaps hit the blackhole.

## Test plan
- `ospfv2_area_range` / `ospfv3_area_range` BDDs extended to assert the ABR's kernel FIB carries `blackhole <range>` in both the advertise and not-advertise scenarios — **both pass locally** (2 scenarios each).
- OSPF unit tests: 93 passed.
- `cargo fmt`, workspace clippy (`--all-targets -D warnings`), and `mdbook build` clean.
- Book updated: multi-area/ABR pages (v2 §Discard route + v3 sibling) and FRR-gaps pages (moved from open gap to implemented).

🤖 Generated with [Claude Code](https://claude.com/claude-code)