### PR TITLE
docs(ospf): correct stale FRR-gaps claims (v3 GR restarter, v3 ABR)

### DIFF
--- a/book/src/ch-08-12-ospf-frr-gaps.md
+++ b/book/src/ch-08-12-ospf-frr-gaps.md
@@ -35,8 +35,9 @@ per feature — see each feature's page):
   OSPFv3. See [Area Types](ch-08-13-ospf-area-types.md).
 - **ABR Type-3 (Summary) and Type-4 (ASBR-Summary) origination**,
   including cross-area E1/E2 external-route computation and
-  Type-4 fallback for inter-area ASBR resolution. v2 only —
-  OSPFv3 ABR summary origination is still pending. See
+  Type-4 fallback for inter-area ASBR resolution. Implemented for
+  both OSPFv2 and OSPFv3 (v3 Inter-Area-Prefix 0x2003 /
+  Inter-Area-Router 0x2004). See
   [Multi-Area Routing and the ABR](ch-08-14-ospf-multi-area-abr.md).
 - **Discard (blackhole) routes for active area ranges**
   (RFC 2328 §12.4.3) — the loop-safety companion to range
@@ -51,8 +52,9 @@ per feature — see each feature's page):
   (RFC 5709), RFC 8177 key-chains, and the OSPFv3 Authentication
   Trailer (RFC 7166). See
   [Authentication](ch-08-16-ospf-authentication.md).
-- **Graceful Restart** (RFC 3623) — helper mode (Grace-LSA
-  acceptance with optional strict-LSA-checking) and restarter
-  mode backed by an on-disk LSDB checkpoint; OSPFv3 is
-  helper-only. See
-  [Graceful Restart](ch-08-17-ospf-graceful-restart.md).
+- **Graceful Restart** — helper mode (Grace-LSA acceptance with
+  optional strict-LSA-checking) and restarter mode backed by an
+  on-disk LSDB checkpoint, in **both** roles for OSPFv2 (RFC 3623)
+  and OSPFv3 (RFC 5187). See
+  [Graceful Restart](ch-08-17-ospf-graceful-restart.md) and the
+  [OSPFv3 sibling](ch-15-12-ospfv3-graceful-restart.md).

--- a/zebra-rs/src/ospf/inst.rs
+++ b/zebra-rs/src/ospf/inst.rs
@@ -5668,12 +5668,11 @@ impl Ospf<Ospfv3> {
         ospf.tracing.proto = Ospfv3::PROTO;
         ospf.callback_build();
         ospf.show_build();
-        // v3 has no on-disk GR checkpoint load today, so nothing to
-        // gate here (a per-VRF child would otherwise need the same
-        // default-instance guard the v2 path uses).
         // Restart-aware boot (v3): replay a fresh ospfv3 checkpoint
-        // before any adjacency forms. Only the default instance —
-        // per-VRF children have no checkpoint file.
+        // before any adjacency forms, so a committed graceful restart
+        // resumes from the saved LSDB. Only the default instance —
+        // per-VRF children have no checkpoint file (they'd otherwise
+        // need the same default-instance guard the v2 path uses).
         if ospf.proto_label == "ospfv3" {
             ospf.gr_restart_load_checkpoint_v3();
         }


### PR DESCRIPTION
## Summary

While picking up "v3 GR restarter" as the next OSPF gap, I found the feature **already fully implemented and wired** — it shipped in the #1730–1739 FRR-parity arc. The only thing stale was the documentation. This PR corrects it (no functional change).

Two entries in the OSPFv2 FRR-gaps page (`ch-08-12`) described features as v2-only that already exist for OSPFv3:

- **Graceful Restart restarter mode** — the page said *"OSPFv3 is helper-only"*, but v3 has the complete restarter: checkpoint on `ospfv3.cbor`, `clear ospfv3 graceful-restart begin/commit/abort`, checkpoint replay from `Ospf::<Ospfv3>::new()`, and exit-on-adjacency-recovery. Already documented on `ch-15-12` and validated by `ospfv3_graceful_restart.feature`.
- **ABR Type-3/Type-4 summary origination** — the page said v3 origination was *"still pending"*, but #1733 landed the v3 Inter-Area-Prefix (0x2003) / Inter-Area-Router (0x2004) mirror.

Also drops a contradictory comment in `Ospf::<Ospfv3>::new()` that claimed *"v3 has no on-disk GR checkpoint load today"* immediately above the code that loads it.

## Verification
- Re-ran `ospfv3_graceful_restart.feature` on a fresh build: **both scenarios pass**, including the committed-restart-survives-past-the-dead-interval-and-resumes-from-checkpoint round trip. This confirms the restarter genuinely works, not just compiles.
- `mdbook build`, `cargo fmt`, and `cargo check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)