### PR TITLE
feat(ospf): configurable adaptive SPF throttle (spf-interval)

### DIFF
--- a/bdd/tests/configs/ospfv2_spf_interval/a.yaml
+++ b/bdd/tests/configs/ospfv2_spf_interval/a.yaml
@@ -1,0 +1,25 @@
+interface:
+- if-name: lo
+  ipv4:
+    address: 10.0.0.1/32
+- if-name: ethb
+  ipv4:
+    address: 10.0.12.1/30
+router:
+  ospf:
+    router-id: 10.0.0.1
+    # Non-default adaptive SPF throttle. Surfaced verbatim by
+    # `show ospf` so the BDD can confirm the config reached the
+    # instance, not just that it parsed.
+    spf-interval:
+      initial-wait: 100
+      secondary-wait: 300
+      maximum-wait: 4000
+    area:
+    - area-id: 0.0.0.0
+      interface:
+      - if-name: lo
+        enable: true
+      - if-name: ethb
+        enable: true
+        network-type: point-to-point

--- a/bdd/tests/configs/ospfv2_spf_interval/b.yaml
+++ b/bdd/tests/configs/ospfv2_spf_interval/b.yaml
@@ -1,0 +1,22 @@
+interface:
+- if-name: lo
+  ipv4:
+    address: 10.0.0.2/32
+- if-name: etha
+  ipv4:
+    address: 10.0.12.2/30
+router:
+  ospf:
+    router-id: 10.0.0.2
+    spf-interval:
+      initial-wait: 100
+      secondary-wait: 300
+      maximum-wait: 4000
+    area:
+    - area-id: 0.0.0.0
+      interface:
+      - if-name: lo
+        enable: true
+      - if-name: etha
+        enable: true
+        network-type: point-to-point

--- a/bdd/tests/features/ospfv2_spf_interval.feature
+++ b/bdd/tests/features/ospfv2_spf_interval.feature
@@ -1,0 +1,42 @@
+@serial
+@ospfv2_spf_interval
+Feature: OSPFv2 adaptive SPF throttle (spf-interval)
+  As a network operator
+  I want `router ospf spf-interval { initial-wait; secondary-wait;
+  maximum-wait; }` to configure the IOS-XR-style exponential SPF
+  hold-down (RFC-style backoff, mirroring zebra-rs IS-IS) instead of
+  the old fixed 1-second coalescing timer, so a churning area backs
+  off while a quiet topology still converges quickly.
+
+  Test Topology:
+  ```
+    a (10.0.0.1) -- 10.0.12.0/30 -- b (10.0.0.2)
+    both routers configure spf-interval 100 / 300 / 4000 ms.
+  ```
+
+  Scenario: Configured throttle is applied and the topology still converges
+    Given a clean test environment
+    When I create namespace "a"
+    And I create namespace "b"
+    And I connect namespace "a" interface "ethb" to namespace "b" interface "etha"
+    And I start zebra-rs in namespace "a"
+    And I start zebra-rs in namespace "b"
+    And I apply config "a.yaml" to namespace "a"
+    And I apply config "b.yaml" to namespace "b"
+    And I wait 20 seconds
+
+    # The configured (non-default) throttle bounds are surfaced verbatim
+    # by `show ospf`, proving the config reached the instance.
+    Then show command "show ospf" in namespace "a" should contain "SPF timers: initial 100 ms, secondary 300 ms, maximum 4000 ms"
+    # Adjacency forms and routes converge under the adaptive scheduler.
+    And show command "show ospf neighbor" in namespace "a" should contain "Full"
+    And show command "show ospf neighbor" in namespace "b" should contain "Full"
+    And show command "show ospf route" in namespace "a" should contain "10.0.0.2/32"
+    And ping from "a" to "10.0.0.2" should succeed
+
+    # Teardown.
+    When I stop zebra-rs in namespace "a"
+    And I stop zebra-rs in namespace "b"
+    And I delete namespace "a"
+    And I delete namespace "b"
+    Then the test environment should be clean

--- a/book/src/ch-08-08-ospf-timers.md
+++ b/book/src/ch-08-08-ospf-timers.md
@@ -33,3 +33,40 @@ Notes:
 - **`retransmit-interval`** governs how often unacknowledged LSAs in
   the per-neighbor `ls_rxmt` list are re-sent. The default of 5 s
   is conservative and rarely needs tuning on healthy links.
+
+## SPF throttle (`spf-interval`)
+
+The route calculation is rate-limited by an adaptive
+exponential-backoff throttle (IOS-XR style, shared with IS-IS),
+configured at the instance level:
+
+```
+router ospf {
+  spf-interval {
+    initial-wait 50;
+    secondary-wait 200;
+    maximum-wait 5000;
+  }
+}
+```
+
+| YANG leaf (`/router/ospf[v3]/spf-interval/…`) | Default | Range | Units |
+|---|---|---|---|
+| `initial-wait` | 50 | 1..120000 | milliseconds |
+| `secondary-wait` | 200 | 1..120000 | milliseconds |
+| `maximum-wait` | 5000 | 1..120000 | milliseconds |
+
+After a quiet period, the first topology change schedules SPF
+`initial-wait` ms later — fast convergence when the network is
+stable. If further changes arrive while a burst is in progress, the
+hold-down grows to `secondary-wait`, then doubles on each successive
+run up to `maximum-wait`, damping churn during instability. Once the
+area has been quiet for longer than `2 × maximum-wait`, the backoff
+resets to `initial-wait`.
+
+The backoff *state* is per-area, so a flapping area backs off without
+slowing convergence in a stable one. `show ospf` reports the
+configured bounds (`SPF timers: initial … secondary … maximum …`).
+OSPFv3 exposes the identical `spf-interval` block under
+`router ospfv3`. These defaults replace the earlier fixed 1-second
+coalescing timer.

--- a/book/src/ch-08-12-ospf-frr-gaps.md
+++ b/book/src/ch-08-12-ospf-frr-gaps.md
@@ -13,12 +13,9 @@ OSPFv2 features not yet implemented in zebra-rs:
   Type-7 LSAs carrying a non-zero forwarding address are skipped
   (RFC 2328 §16.4 step 3); zebra-rs itself always originates with
   FA 0.0.0.0.
-- Configurable SPF / LSA-generation throttles. SPF is coalesced
-  behind a fixed 1-second timer (an LSDB change arms it; further
-  changes within the window ride the same run), but the adaptive
-  initial/secondary/maximum-wait throttle that FRR
-  (`timers throttle spf`) and zebra-rs IS-IS (`spf-interval`)
-  expose is not configurable for OSPF.
+- Configurable **LSA-generation** throttle. The SPF calculation now
+  has an adaptive throttle (see below), but LSA origination is not
+  yet rate-limited by a matching `timers throttle lsa-all`.
 
 ## Previously listed gaps that are now closed
 
@@ -58,3 +55,8 @@ per feature — see each feature's page):
   and OSPFv3 (RFC 5187). See
   [Graceful Restart](ch-08-17-ospf-graceful-restart.md) and the
   [OSPFv3 sibling](ch-15-12-ospfv3-graceful-restart.md).
+- **Adaptive SPF throttle** (`spf-interval`) — the IOS-XR-style
+  exponential backoff (`initial` / `secondary` / `maximum` wait,
+  FRR's `timers throttle spf`), per-area and shared with IS-IS,
+  for both OSPFv2 and OSPFv3. Replaces the old fixed 1-second
+  coalescing timer. See [Timer Configuration](ch-08-08-ospf-timers.md).

--- a/book/src/ch-15-15-ospfv3-frr-gaps.md
+++ b/book/src/ch-15-15-ospfv3-frr-gaps.md
@@ -6,9 +6,11 @@ OSPFv3 features not yet implemented in zebra-rs:
   connected, static, kernel, IS-IS, and BGP, matching v2).
 - Non-zero forwarding-address resolution on received externals.
 - NBMA and point-to-multipoint network types.
-- Configurable SPF throttling (SPF is coalesced behind a fixed
-  1-second timer, as in v2).
 - Configurable Instance ID (always 0 — one instance per link).
+
+The adaptive SPF throttle (`spf-interval`) is now configurable for
+OSPFv3, identical to v2 — see
+[Timer Configuration](ch-08-08-ospf-timers.md).
 
 The balance runs the other way for Segment Routing: zebra-rs
 OSPFv3 implements SR-MPLS (RFC 8666), SRv6 (RFC 9513), TI-LFA

--- a/zebra-rs/src/isis/inst.rs
+++ b/zebra-rs/src/isis/inst.rs
@@ -45,12 +45,12 @@ use super::rib::{
 };
 use super::srlg::{SrlgGroup, SrlgGroupBuilder};
 use super::srmpls::IsisLabelMap;
-use super::throttle::Throttle;
 use super::{
     Hostname, IfsmEvent, Lsdb, LsdbEvent, NfsmEvent, NfsmState, csnp_send, srm_set_for_all_lsp,
 };
 use super::{Level, Levels, process_packet};
 use crate::spf::label_pool::LabelPool;
+use crate::throttle::Throttle;
 
 pub type Callback = fn(&mut Isis, Args, ConfigOp) -> Option<()>;
 pub type ShowCallback = fn(&Isis, Args, bool) -> std::result::Result<String, std::fmt::Error>;

--- a/zebra-rs/src/isis/link.rs
+++ b/zebra-rs/src/isis/link.rs
@@ -170,7 +170,7 @@ pub struct LinkTop<'a> {
         >,
     >,
     pub spf_timer: &'a mut Levels<Option<Timer>>,
-    pub spf_throttle: &'a mut Levels<super::throttle::Throttle>,
+    pub spf_throttle: &'a mut Levels<crate::throttle::Throttle>,
 
     /// SR state needed for End.X (adjacency) SID allocation. Threaded
     /// through so packet handlers can carve a function from the ELIB

--- a/zebra-rs/src/isis/mod.rs
+++ b/zebra-rs/src/isis/mod.rs
@@ -55,8 +55,6 @@ pub mod rib;
 
 pub mod srlg;
 
-pub mod throttle;
-
 pub mod affinity_map;
 
 pub mod flex_algo;

--- a/zebra-rs/src/isis/rib.rs
+++ b/zebra-rs/src/isis/rib.rs
@@ -9,12 +9,12 @@ use tokio::sync::mpsc::UnboundedSender;
 
 use super::config::IsisConfig;
 use super::level::Levels;
-use super::throttle::Throttle;
 use crate::context::Timer;
 use crate::rib::inst::{IlmEntry, IlmType};
 use crate::rib::link_ext::LinkFlagsExt;
 use crate::rib::{self, Nexthop, NexthopMulti, NexthopUni, RibSubType, RibType};
 use crate::spf;
+use crate::throttle::Throttle;
 // EncapType: TI-LFA repairs route through `tilfa::build_repair_path_srv6`,
 // but the Mirror SID egress-protection backup builds an H.Encaps repair
 // here directly (`inject_mirror_sid_backups`).

--- a/zebra-rs/src/main.rs
+++ b/zebra-rs/src/main.rs
@@ -42,6 +42,9 @@ mod script;
 mod spf;
 mod srv6;
 mod stamp;
+/// IOS-XR-style exponential-backoff throttle, shared by the IS-IS and
+/// OSPF SPF/LSA schedulers.
+mod throttle;
 mod version;
 
 #[derive(Parser)]

--- a/zebra-rs/src/ospf/area.rs
+++ b/zebra-rs/src/ospf/area.rs
@@ -221,6 +221,13 @@ pub struct OspfArea<V: OspfVersion = Ospfv2> {
     // SPF calculation timer.
     pub spf_timer: Option<Timer>,
 
+    // Per-area adaptive SPF-throttle backoff state (IOS-XR style).
+    // Fed the `spf-interval` bounds each time a run is scheduled; the
+    // wait grows initial -> secondary -> ... -> maximum within a burst
+    // and resets after a quiet period. Isolated per area so a churning
+    // area backs off without slowing a stable one.
+    pub spf_throttle: crate::throttle::Throttle,
+
     // SPF in-flight gate: true while a SPF run for this area is
     // executing. New `Message::SpfCalc(area_id)` events that arrive
     // during a run set `spf_pending` instead of starting a second
@@ -316,6 +323,7 @@ impl<V: OspfVersion> OspfArea<V> {
             links: BTreeSet::new(),
             lsdb: Lsdb::<V>::new(),
             spf_timer: None,
+            spf_throttle: crate::throttle::Throttle::default(),
             spf_inflight: false,
             spf_pending: false,
             redistribute: AreaRedistribute::default(),

--- a/zebra-rs/src/ospf/config.rs
+++ b/zebra-rs/src/ospf/config.rs
@@ -307,6 +307,12 @@ impl Ospf {
             "/graceful-restart/drain-time-ms",
             config_ospf_gr_drain_time_ms,
         );
+        self.ospf_add("/spf-interval/initial-wait", config_ospf_spf_initial_wait);
+        self.ospf_add(
+            "/spf-interval/secondary-wait",
+            config_ospf_spf_secondary_wait,
+        );
+        self.ospf_add("/spf-interval/maximum-wait", config_ospf_spf_maximum_wait);
         // `/router/ospf/tracing/...` is handled by the subtree dispatcher
         // `super::tracing::config_tracing_dispatch` (called from
         // `process_cm_msg` for paths this callback table does not claim),
@@ -2111,6 +2117,29 @@ fn config_ospf_gr_helper_strict_lsa_checking(
 fn config_ospf_gr_drain_time_ms(ospf: &mut Ospf, mut args: Args, op: ConfigOp) -> Option<()> {
     let value = if op.is_set() { args.u32()? } else { 200 };
     ospf.gr_config.drain_time_ms = value.clamp(50, 2000);
+    Some(())
+}
+
+// `/router/ospf/spf-interval/{initial,secondary,maximum}-wait`.
+// Adaptive SPF-throttle bounds (milliseconds). Delete restores the
+// per-field default from `SpfIntervalConfig::default()` (50/200/5000).
+// Live per-area timers pick the new bounds up on the next schedule; a
+// mid-flight timer keeps its already-computed wait.
+fn config_ospf_spf_initial_wait(ospf: &mut Ospf, mut args: Args, op: ConfigOp) -> Option<()> {
+    let default = super::inst::SpfIntervalConfig::default().initial_wait_ms;
+    ospf.spf_interval.initial_wait_ms = if op.is_set() { args.u32()? } else { default };
+    Some(())
+}
+
+fn config_ospf_spf_secondary_wait(ospf: &mut Ospf, mut args: Args, op: ConfigOp) -> Option<()> {
+    let default = super::inst::SpfIntervalConfig::default().secondary_wait_ms;
+    ospf.spf_interval.secondary_wait_ms = if op.is_set() { args.u32()? } else { default };
+    Some(())
+}
+
+fn config_ospf_spf_maximum_wait(ospf: &mut Ospf, mut args: Args, op: ConfigOp) -> Option<()> {
+    let default = super::inst::SpfIntervalConfig::default().maximum_wait_ms;
+    ospf.spf_interval.maximum_wait_ms = if op.is_set() { args.u32()? } else { default };
     Some(())
 }
 

--- a/zebra-rs/src/ospf/config_v3.rs
+++ b/zebra-rs/src/ospf/config_v3.rs
@@ -82,6 +82,12 @@ impl Ospf<Ospfv3> {
                 "/graceful-restart/drain-time-ms",
                 config_ospfv3_gr_drain_time_ms,
             ),
+            ("/spf-interval/initial-wait", config_ospfv3_spf_initial_wait),
+            (
+                "/spf-interval/secondary-wait",
+                config_ospfv3_spf_secondary_wait,
+            ),
+            ("/spf-interval/maximum-wait", config_ospfv3_spf_maximum_wait),
             (
                 "/default-information/originate",
                 config_ospfv3_default_originate,
@@ -749,6 +755,38 @@ fn config_ospfv3_gr_drain_time_ms(
 ) -> Option<()> {
     let value = if op.is_set() { args.u32()? } else { 200 };
     ospf.gr_config.drain_time_ms = value.clamp(50, 2000);
+    Some(())
+}
+
+// `/router/ospfv3/spf-interval/{initial,secondary,maximum}-wait` —
+// v6 siblings of the v2 spf-interval handlers.
+fn config_ospfv3_spf_initial_wait(
+    ospf: &mut Ospf<Ospfv3>,
+    mut args: Args,
+    op: ConfigOp,
+) -> Option<()> {
+    let default = super::inst::SpfIntervalConfig::default().initial_wait_ms;
+    ospf.spf_interval.initial_wait_ms = if op.is_set() { args.u32()? } else { default };
+    Some(())
+}
+
+fn config_ospfv3_spf_secondary_wait(
+    ospf: &mut Ospf<Ospfv3>,
+    mut args: Args,
+    op: ConfigOp,
+) -> Option<()> {
+    let default = super::inst::SpfIntervalConfig::default().secondary_wait_ms;
+    ospf.spf_interval.secondary_wait_ms = if op.is_set() { args.u32()? } else { default };
+    Some(())
+}
+
+fn config_ospfv3_spf_maximum_wait(
+    ospf: &mut Ospf<Ospfv3>,
+    mut args: Args,
+    op: ConfigOp,
+) -> Option<()> {
+    let default = super::inst::SpfIntervalConfig::default().maximum_wait_ms;
+    ospf.spf_interval.maximum_wait_ms = if op.is_set() { args.u32()? } else { default };
     Some(())
 }
 

--- a/zebra-rs/src/ospf/inst.rs
+++ b/zebra-rs/src/ospf/inst.rs
@@ -74,6 +74,29 @@ pub const DEFAULT_ROUTER_ID: Ipv4Addr = Ipv4Addr::new(10, 0, 0, 1);
 /// `Message` enum directly. They generalize when the
 /// `OspfVersion` trait grows accessor methods, in a future round
 /// of trait expansion.
+/// Adaptive SPF-throttle configuration (`router ospf[v3] spf-interval`).
+/// Feeds the per-area [`crate::throttle::Throttle`]: the first SPF after a
+/// quiet period waits `initial_wait_ms`; a run inside a burst backs off
+/// `secondary_wait_ms` then doubles up to `maximum_wait_ms`. Defaults
+/// mirror zebra-rs IS-IS (`50 / 200 / 5000`), replacing the old fixed
+/// 1-second coalescing timer.
+#[derive(Clone, Copy, Debug)]
+pub struct SpfIntervalConfig {
+    pub initial_wait_ms: u32,
+    pub secondary_wait_ms: u32,
+    pub maximum_wait_ms: u32,
+}
+
+impl Default for SpfIntervalConfig {
+    fn default() -> Self {
+        Self {
+            initial_wait_ms: 50,
+            secondary_wait_ms: 200,
+            maximum_wait_ms: 5000,
+        }
+    }
+}
+
 pub struct Ospf<V: OspfVersion = Ospfv2> {
     pub tx: UnboundedSender<Message<V>>,
     pub rx: UnboundedReceiver<Message<V>>,
@@ -250,6 +273,10 @@ pub struct Ospf<V: OspfVersion = Ospfv2> {
     /// Defaults: helper enabled, max grace 1800s, strict LSA
     /// checking on — same as the YANG model's defaults.
     pub gr_config: super::neigh::GracefulRestartConfig,
+    /// Adaptive SPF-throttle timers (`spf-interval`). The backoff
+    /// *state* is per-area (`OspfArea::spf_throttle`); this holds the
+    /// configured bounds fed into it each time a run is scheduled.
+    pub spf_interval: SpfIntervalConfig,
     /// RFC 3623 §2 restarting-router state. `Some` once
     /// `gr_restart_begin` floods Grace LSAs and stages the
     /// restart; `None` in steady state. While `Some`, the
@@ -1145,12 +1172,16 @@ impl<V: OspfVersion> Ospf<V> {
             .map_or_else(|| "unknown".to_string(), |link| link.name.clone())
     }
 
-    /// One-second deferred SPF trigger for `area_id`. Same shape
-    /// for v2 and v3; the `Message::SpfCalc` variant doesn't carry
-    /// V-specific data, so the timer body is generic.
-    fn ospf_spf_timer_generic(tx: &UnboundedSender<Message<V>>, area_id: Ipv4Addr) -> Timer {
+    /// Deferred SPF trigger for `area_id`, fired after `wait_ms`.
+    /// Same shape for v2 and v3; the `Message::SpfCalc` variant
+    /// doesn't carry V-specific data, so the timer body is generic.
+    fn ospf_spf_timer_generic(
+        tx: &UnboundedSender<Message<V>>,
+        area_id: Ipv4Addr,
+        wait_ms: u64,
+    ) -> Timer {
         let tx = tx.clone();
-        Timer::new(1, TimerType::Once, move || {
+        Timer::once_ms(wait_ms, move || {
             let tx = tx.clone();
             async move {
                 let _ = tx.send(Message::SpfCalc(area_id));
@@ -1158,13 +1189,25 @@ impl<V: OspfVersion> Ospf<V> {
         })
     }
 
-    /// Arm the SPF timer on `area` if not already armed. v3 calls
-    /// this from `router_lsa_originate` / `network_lsa_originate`
-    /// / `router_intra_area_prefix_lsa_originate` so any LSA
-    /// install kicks off an SPF after a 1-second coalescing window.
-    fn ospf_spf_schedule_generic(tx: &UnboundedSender<Message<V>>, area: &mut OspfArea<V>) {
+    /// Arm the adaptive SPF timer on `area` if not already armed.
+    /// Called from every LSA-install / topology-change path so a
+    /// change kicks off an SPF after the throttle-computed delay:
+    /// `initial_wait` when the area has been quiet, backing off to
+    /// `maximum_wait` under sustained churn (`spf-interval`). The
+    /// timer clears `spf_timer` and calls `spf_throttle.mark_run()`
+    /// when it fires (see the `Message::SpfCalc` handlers).
+    fn ospf_spf_schedule_generic(
+        tx: &UnboundedSender<Message<V>>,
+        area: &mut OspfArea<V>,
+        cfg: SpfIntervalConfig,
+    ) {
         if area.spf_timer.is_none() {
-            area.spf_timer = Some(Self::ospf_spf_timer_generic(tx, area.id));
+            let wait_ms = area.spf_throttle.schedule(
+                cfg.initial_wait_ms,
+                cfg.secondary_wait_ms,
+                cfg.maximum_wait_ms,
+            );
+            area.spf_timer = Some(Self::ospf_spf_timer_generic(tx, area.id, wait_ms as u64));
         }
     }
 }
@@ -1247,6 +1290,7 @@ impl Ospf<Ospfv2> {
             endx_sids: BTreeMap::new(),
             sr_rx,
             gr_config: super::neigh::GracefulRestartConfig::default(),
+            spf_interval: SpfIntervalConfig::default(),
             restarting: None,
             key_chains: BTreeMap::new(),
             policy_tx,
@@ -1447,14 +1491,12 @@ impl Ospf<Ospfv2> {
         }
     }
 
-    fn ospf_spf_timer(tx: &UnboundedSender<Message>, area_id: Ipv4Addr) -> Timer {
-        Self::ospf_spf_timer_generic(tx, area_id)
-    }
-
-    fn ospf_spf_schedule(tx: &UnboundedSender<Message>, area: &mut OspfArea) {
-        if area.spf_timer.is_none() {
-            area.spf_timer = Some(Self::ospf_spf_timer(tx, area.id));
-        }
+    fn ospf_spf_schedule(
+        tx: &UnboundedSender<Message>,
+        area: &mut OspfArea,
+        cfg: SpfIntervalConfig,
+    ) {
+        Self::ospf_spf_schedule_generic(tx, area, cfg);
     }
 
     fn router_lsa_stub_link(prefix: Ipv4Net, metric: u16) -> RouterLsaLink {
@@ -1649,7 +1691,7 @@ impl Ospf<Ospfv2> {
                 let flood_lsa = lsa.clone();
                 area.lsdb
                     .insert_self_originated(lsa, &self.tx, Some(area_id));
-                Self::ospf_spf_schedule(&self.tx, area);
+                Self::ospf_spf_schedule(&self.tx, area, self.spf_interval);
                 Some(flood_lsa)
             } else {
                 None
@@ -3280,7 +3322,7 @@ impl Ospf<Ospfv2> {
                     if let Some(area_id) = area_id
                         && let Some(area) = self.areas.get_mut(area_id)
                     {
-                        Self::ospf_spf_schedule(&self.tx, area);
+                        Self::ospf_spf_schedule(&self.tx, area, self.spf_interval);
                     }
                 }
                 OspfLsType::AsExternal => {
@@ -3703,7 +3745,7 @@ impl Ospf<Ospfv2> {
         if let Some(lsa) = flood_lsa {
             self.flood_self_originated_lsa(area_id, &lsa);
             if let Some(area) = self.areas.get_mut(area_id) {
-                Self::ospf_spf_schedule(&self.tx, area);
+                Self::ospf_spf_schedule(&self.tx, area, self.spf_interval);
             }
         }
     }
@@ -5289,7 +5331,7 @@ impl Ospf<Ospfv2> {
             Message::SpfSchedule(area_id) => {
                 if let Some(area_id) = area_id {
                     if let Some(area) = self.areas.get_mut(area_id) {
-                        Self::ospf_spf_schedule(&self.tx, area);
+                        Self::ospf_spf_schedule(&self.tx, area, self.spf_interval);
                     }
                 } else {
                     // None = AS-scope event (e.g. AS-external LSA install /
@@ -5298,7 +5340,7 @@ impl Ospf<Ospfv2> {
                     let area_ids: Vec<Ipv4Addr> = self.areas.iter().map(|(id, _)| *id).collect();
                     for id in area_ids {
                         if let Some(area) = self.areas.get_mut(id) {
-                            Self::ospf_spf_schedule(&self.tx, area);
+                            Self::ospf_spf_schedule(&self.tx, area, self.spf_interval);
                         }
                     }
                 }
@@ -5315,6 +5357,9 @@ impl Ospf<Ospfv2> {
                     return;
                 }
                 area.spf_timer = None;
+                // Record the run so the throttle backs off the *next*
+                // schedule (initial -> secondary -> ... -> maximum).
+                area.spf_throttle.mark_run();
                 // Build the SPF input (graph + source vertex) on the
                 // main task — reads the LSDB and is cheap. If there
                 // is no source node yet, there is nothing to compute.
@@ -5630,6 +5675,7 @@ impl Ospf<Ospfv3> {
             endx_sids: BTreeMap::new(),
             sr_rx,
             gr_config: super::neigh::GracefulRestartConfig::default(),
+            spf_interval: SpfIntervalConfig::default(),
             restarting: None,
             key_chains: BTreeMap::new(),
             policy_tx,
@@ -6546,7 +6592,7 @@ impl Ospf<Ospfv3> {
         let flood_lsa = lsa.clone();
         if let Some(area) = self.areas.get_mut(area_id) {
             area.lsdb.install_originated(lsa, &self.tx, Some(area_id));
-            Self::ospf_spf_schedule_generic(&self.tx, area);
+            Self::ospf_spf_schedule_generic(&self.tx, area, self.spf_interval);
         }
 
         self.flood_self_originated_lsa(area_id, &flood_lsa);
@@ -8716,7 +8762,7 @@ impl Ospf<Ospfv3> {
             Message::SpfSchedule(area_id) => {
                 if let Some(area_id) = area_id {
                     if let Some(area) = self.areas.get_mut(area_id) {
-                        Self::ospf_spf_schedule_generic(&self.tx, area);
+                        Self::ospf_spf_schedule_generic(&self.tx, area, self.spf_interval);
                     }
                 } else {
                     // None = AS-scope event (Type-5 AS-External install /
@@ -8726,7 +8772,7 @@ impl Ospf<Ospfv3> {
                     let area_ids: Vec<Ipv4Addr> = self.areas.iter().map(|(id, _)| *id).collect();
                     for id in area_ids {
                         if let Some(area) = self.areas.get_mut(id) {
-                            Self::ospf_spf_schedule_generic(&self.tx, area);
+                            Self::ospf_spf_schedule_generic(&self.tx, area, self.spf_interval);
                         }
                     }
                 }
@@ -8743,6 +8789,9 @@ impl Ospf<Ospfv3> {
                     return;
                 }
                 area.spf_timer = None;
+                // Record the run so the throttle backs off the next
+                // schedule (v3 sibling of the v2 handler).
+                area.spf_throttle.mark_run();
                 // Build the SPF input on the main task; if there is
                 // no source Router-LSA yet there is nothing to do.
                 let Some(input) = build_v3_spf_input(self, area_id) else {
@@ -9166,7 +9215,7 @@ impl Ospf<Ospfv3> {
         let flood_lsa = lsa.clone();
         if let Some(area) = self.areas.get_mut(area_id) {
             area.lsdb.install_originated(lsa, &self.tx, Some(area_id));
-            Self::ospf_spf_schedule_generic(&self.tx, area);
+            Self::ospf_spf_schedule_generic(&self.tx, area, self.spf_interval);
         }
         self.flood_self_originated_lsa(area_id, &flood_lsa);
     }
@@ -10190,7 +10239,7 @@ impl Ospf<Ospfv3> {
         let flood_lsa = lsa.clone();
         if let Some(area) = self.areas.get_mut(area_id) {
             area.lsdb.install_originated(lsa, &self.tx, Some(area_id));
-            Self::ospf_spf_schedule_generic(&self.tx, area);
+            Self::ospf_spf_schedule_generic(&self.tx, area, self.spf_interval);
         }
         self.flood_self_originated_lsa(area_id, &flood_lsa);
     }
@@ -10362,7 +10411,7 @@ impl Ospf<Ospfv3> {
         let flood_lsa = lsa.clone();
         if let Some(area) = self.areas.get_mut(area_id) {
             area.lsdb.install_originated(lsa, &self.tx, Some(area_id));
-            Self::ospf_spf_schedule_generic(&self.tx, area);
+            Self::ospf_spf_schedule_generic(&self.tx, area, self.spf_interval);
         }
         self.flood_self_originated_lsa(area_id, &flood_lsa);
     }

--- a/zebra-rs/src/ospf/show.rs
+++ b/zebra-rs/src/ospf/show.rs
@@ -573,6 +573,13 @@ fn show_ospf(ospf: &Ospf, _args: Args, json: bool) -> std::result::Result<String
     if let Some(spf_duration) = ospf.spf_duration {
         writeln!(buf, " Last SPF duration {} usecs", spf_duration.as_micros())?;
     }
+    writeln!(
+        buf,
+        " SPF timers: initial {} ms, secondary {} ms, maximum {} ms",
+        ospf.spf_interval.initial_wait_ms,
+        ospf.spf_interval.secondary_wait_ms,
+        ospf.spf_interval.maximum_wait_ms,
+    )?;
     // TI-LFA compute telemetry for the same run (last-area-wins, like
     // `spf_duration`). None while TI-LFA is disabled.
     if let Some(stats) = &ospf.tilfa_stats {

--- a/zebra-rs/src/ospf/show_v3.rs
+++ b/zebra-rs/src/ospf/show_v3.rs
@@ -421,6 +421,10 @@ struct Ospfv3SummaryJson {
     link_count: usize,
     spf_last_ms_ago: Option<u128>,
     spf_duration_us: Option<u128>,
+    /// Configured adaptive SPF-throttle bounds (`spf-interval`), ms.
+    spf_initial_wait_ms: u32,
+    spf_secondary_wait_ms: u32,
+    spf_maximum_wait_ms: u32,
     /// TI-LFA compute telemetry for the most-recent run, preformatted
     /// (`targets=… mode=… workers=… spf{…} took … us`). None until
     /// TI-LFA runs (and cleared when it is disabled).
@@ -452,6 +456,9 @@ fn show_ospfv3_summary(
         link_count: top.links.len(),
         spf_last_ms_ago: top.spf_last.map(|t| t.elapsed().as_millis()),
         spf_duration_us: top.spf_duration.map(|d| d.as_micros()),
+        spf_initial_wait_ms: top.spf_interval.initial_wait_ms,
+        spf_secondary_wait_ms: top.spf_interval.secondary_wait_ms,
+        spf_maximum_wait_ms: top.spf_interval.maximum_wait_ms,
         tilfa_compute: top.tilfa_stats.as_ref().map(|s| {
             format!(
                 "targets={} mode={} workers={} spf{{q={} pc={} dedup-saved={}}} took {} us",
@@ -477,6 +484,11 @@ fn show_ospfv3_summary(
     if let Some(us) = summary.spf_duration_us {
         writeln!(text, "  SPF duration: {} us", us)?;
     }
+    writeln!(
+        text,
+        "  SPF timers:   initial {} ms, secondary {} ms, maximum {} ms",
+        summary.spf_initial_wait_ms, summary.spf_secondary_wait_ms, summary.spf_maximum_wait_ms,
+    )?;
     if let Some(tilfa) = &summary.tilfa_compute {
         writeln!(text, "  TI-LFA compute: {}", tilfa)?;
     }

--- a/zebra-rs/src/throttle.rs
+++ b/zebra-rs/src/throttle.rs
@@ -46,3 +46,39 @@ impl Throttle {
         self.last_run_at = Some(Instant::now());
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A schedule/run alternation (as the OSPF and IS-IS schedulers do)
+    /// yields the initial wait first, then the secondary, then doubles
+    /// up to — and holds at — the maximum.
+    #[test]
+    fn backoff_progression_within_burst() {
+        let (init, sec, max) = (50, 200, 5000);
+        let mut t = Throttle::default();
+        let mut seq = Vec::new();
+        for _ in 0..9 {
+            seq.push(t.schedule(init, sec, max));
+            t.mark_run();
+        }
+        assert_eq!(seq, vec![50, 200, 400, 800, 1600, 3200, 5000, 5000, 5000]);
+    }
+
+    /// A quiet period longer than `2 × maximum` resets the next
+    /// schedule back to `initial`.
+    #[test]
+    fn resets_after_quiet_period() {
+        // Tiny maximum (>= secondary) so the quiet window (2×max = 6ms)
+        // elapses in a short sleep with generous margin.
+        let (init, sec, max) = (1, 2, 3);
+        let mut t = Throttle::default();
+        assert_eq!(t.schedule(init, sec, max), 1); // initial
+        t.mark_run();
+        assert_eq!(t.schedule(init, sec, max), 2); // secondary (in burst)
+        t.mark_run();
+        std::thread::sleep(Duration::from_millis(30));
+        assert_eq!(t.schedule(init, sec, max), 1); // quiet → back to initial
+    }
+}

--- a/zebra-rs/yang/config.yang
+++ b/zebra-rs/yang/config.yang
@@ -1140,6 +1140,49 @@ module config {
           }
         }
 
+        container spf-interval {
+          ext:help "SPF calculation throttle timers";
+          // Adaptive IOS-XR-style exponential hold-down, replacing the
+          // old fixed 1-second coalescing timer. The first SPF after a
+          // quiet period waits `initial-wait`; sustained churn backs
+          // off `secondary-wait` then doubles up to `maximum-wait`.
+          // Per-area state, so a churning area backs off without
+          // slowing a stable one. Defaults 50/200/5000ms match
+          // zebra-rs IS-IS `spf-interval`.
+          leaf initial-wait {
+            type uint32 {
+              range "1..120000";
+            }
+            units "milliseconds";
+            default 50;
+            description
+              "Delay from the first topology change after a quiet
+               period to the first SPF run.";
+          }
+          leaf secondary-wait {
+            type uint32 {
+              range "1..120000";
+            }
+            units "milliseconds";
+            default 200;
+            description
+              "Hold-down before the next SPF while a burst is in
+               progress; doubles each successive run up to
+               maximum-wait.";
+          }
+          leaf maximum-wait {
+            type uint32 {
+              range "1..120000";
+            }
+            units "milliseconds";
+            default 5000;
+            description
+              "Upper bound on the SPF hold-down. A quiet period
+               longer than twice this value resets the backoff to
+               initial-wait.";
+          }
+        }
+
         list vrf {
           // Per-VRF OSPFv2 instance. The default `router ospf` task
           // forwards each `vrf <name> ...` line (with the `vrf <name>`
@@ -1417,6 +1460,32 @@ module config {
             }
             units "milliseconds";
             default 200;
+          }
+        }
+        // Adaptive SPF throttle — v6 sibling of the v2 spf-interval
+        // block. Same IOS-XR backoff and 50/200/5000ms defaults.
+        container spf-interval {
+          ext:help "SPF calculation throttle timers";
+          leaf initial-wait {
+            type uint32 {
+              range "1..120000";
+            }
+            units "milliseconds";
+            default 50;
+          }
+          leaf secondary-wait {
+            type uint32 {
+              range "1..120000";
+            }
+            units "milliseconds";
+            default 200;
+          }
+          leaf maximum-wait {
+            type uint32 {
+              range "1..120000";
+            }
+            units "milliseconds";
+            default 5000;
           }
         }
         list area {


### PR DESCRIPTION
## Summary

OSPF scheduled SPF behind a **fixed 1-second** coalescing timer with no operator control. FRR (`timers throttle spf`) and zebra-rs IS-IS (`spf-interval`) both expose an IOS-XR-style exponential backoff — this brings the same adaptive throttle to **OSPFv2 and OSPFv3**.

- **Shared throttle infra**: promote the IS-IS `Throttle` (exponential-backoff state machine) from `crate::isis::throttle` to a crate-level `crate::throttle` — it's protocol-agnostic (its own doc comment says so). IS-IS imports updated, behaviour unchanged. Added unit tests for the backoff progression and quiet-period reset (it had none).
- **OSPF wiring**: `SpfIntervalConfig` (initial/secondary/maximum wait, defaults 50/200/5000ms matching IS-IS) on the instance, plus a **per-area** `Throttle` state field on `OspfArea`. `ospf_spf_schedule_generic` computes the wait from the throttle instead of arming a fixed 1s timer; the `SpfCalc` handlers call `mark_run()`. Per-area state means a churning area backs off without slowing a stable one.
- **Config surface**: YANG `spf-interval { initial-wait; secondary-wait; maximum-wait; }` under `router ospf` and `router ospfv3`, with handlers for both AFs (delete restores the per-field default).
- **Observability**: `show ospf` / `show ospfv3` surface the configured bounds (`SPF timers: initial … secondary … maximum …`).

## Behaviour
After a quiet period the first change schedules SPF `initial-wait` ms later (fast convergence when stable); sustained churn backs off to `secondary-wait` then doubles up to `maximum-wait`; a quiet period longer than `2 × maximum-wait` resets to `initial-wait`.

## Test plan
- Throttle unit tests (backoff progression + reset) — pass.
- `yang-load` + full `cargo test`: **1514 passed** (includes IS-IS, confirming the module move is safe).
- `ospfv2_area_range` / `ospfv3_area_range` converge under the new scheduler (default path).
- New `ospfv2_spf_interval` BDD: a non-default `spf-interval` is applied (confirmed via `show ospf`), adjacency forms, routes converge, ping succeeds. All pass locally.
- `cargo fmt`, workspace clippy, `mdbook build` clean.

## Docs
`spf-interval` documented on the Timer Configuration page; the SPF-throttle gap moved to "closed" for both v2 and v3. The remaining throttle gap (LSA-generation `timers throttle lsa-all`) is called out separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)