### PR TITLE
feat: SRv6 REPLACE-C-SID locators (RFC 9800 4.2)

### DIFF
--- a/bdd/tests/configs/isis_srv6_replace/z1.yaml
+++ b/bdd/tests/configs/isis_srv6_replace/z1.yaml
@@ -1,0 +1,35 @@
+# z1 — REPLACE-C-SID locator: the End SID must advertise as
+# `End (REP, PSP, USD)` (IANA 129) with structure LB 48 / LN 16 /
+# Fun 16 / Arg 48, and the End.X SID as `End.X (REP, PSP)` (106) —
+# adjacency SIDs fold only the PSP bit.
+interface:
+- if-name: lo
+  ipv6:
+    address: 2001:db8::1/128
+- if-name: z1-z2
+  ipv6:
+    address: 2001:db8:0:12::1/64
+segment-routing:
+  locator:
+  - name: LOC1
+    prefix: fcbb:bbbb:1:1::/64
+    behavior: replace
+    flavor:
+    - psp
+    - usd
+router:
+  isis:
+    net: 49.0000.0000.0000.0001.00
+    hostname: z1
+    is-type: level-2-only
+    segment-routing:
+      srv6:
+        locator: LOC1
+    interface:
+    - if-name: lo
+      ipv6:
+        enable: true
+    - if-name: z1-z2
+      network-type: point-to-point
+      ipv6:
+        enable: true

--- a/bdd/tests/configs/isis_srv6_replace/z2.yaml
+++ b/bdd/tests/configs/isis_srv6_replace/z2.yaml
@@ -1,0 +1,30 @@
+# z2 — plain uSID locator: its own SIDs stay `uN`/`uA`, and the
+# adjacency + SPF must be unaffected by z1's REPLACE codepoints.
+interface:
+- if-name: lo
+  ipv6:
+    address: 2001:db8::2/128
+- if-name: z2-z1
+  ipv6:
+    address: 2001:db8:0:12::2/64
+segment-routing:
+  locator:
+  - name: LOC2
+    prefix: fcbb:bbbb:2::/48
+    behavior: usid
+router:
+  isis:
+    net: 49.0000.0000.0000.0002.00
+    hostname: z2
+    is-type: level-2-only
+    segment-routing:
+      srv6:
+        locator: LOC2
+    interface:
+    - if-name: lo
+      ipv6:
+        enable: true
+    - if-name: z2-z1
+      network-type: point-to-point
+      ipv6:
+        enable: true

--- a/bdd/tests/features/isis_srv6_replace.feature
+++ b/bdd/tests/features/isis_srv6_replace.feature
@@ -1,0 +1,51 @@
+@isis_srv6_replace
+@isis
+Feature: IS-IS advertises REPLACE-C-SID SRv6 endpoint behaviors
+  As a network operator
+  I want a locator's RFC 9800 REPLACE-C-SID format reflected in the
+  advertised endpoint-behavior codepoints and SID structure, so SR
+  source nodes can compress segment lists with 32-bit C-SIDs and the
+  data planes agree on the wire format.
+
+  z1's locator carries `behavior: replace` and `flavor: [psp, usd]`:
+  its End SID must advertise as `End (REP, PSP, USD)` (IANA codepoint
+  129, End with REPLACE-CSID, PSP & USD) and its End.X SID as
+  `End.X (REP, PSP)` (106) — adjacency SIDs fold only the PSP bit.
+  The advertised structure is LB 48 / LN 16 / Fun 16 / Arg 48 — the
+  non-zero argument length is how receivers infer 32-bit compression
+  (RFC 9800 §6.4). z2 is a plain uSID locator and must keep
+  advertising `uN`/`uA`, and the adjacency and SPF must be unaffected
+  by the REPLACE codepoints.
+
+  Test Topology:
+  ```
+   z1 ──2001:db8:0:12::/64── z2
+   LOC1 fcbb:bbbb:1:1::/64    LOC2 fcbb:bbbb:2::/48
+   replace + psp,usd          usid (no flavor)
+  ```
+
+  Scenario: The REPLACE-C-SID codepoints appear in the peer's database
+    Given a clean test environment
+    When I create namespace "z1"
+    And I create namespace "z2"
+    And I connect namespace "z1" interface "z1-z2" to namespace "z2" interface "z2-z1"
+    And I start zebra-rs in namespace "z1"
+    And I start zebra-rs in namespace "z2"
+    And I apply config "z1.yaml" to namespace "z1"
+    And I apply config "z2.yaml" to namespace "z2"
+    Then show command "show isis database detail" in namespace "z2" should eventually contain "End (REP, PSP, USD)"
+    And show command "show isis database detail" in namespace "z2" should contain "End.X (REP, PSP)"
+    # The uSID peer's own SIDs are unchanged — z1 sees plain uN.
+    And show command "show isis database detail" in namespace "z1" should eventually contain "Behavior: uN,"
+    # Reachability across the adjacency proves the REPLACE codepoints
+    # didn't disturb SPF or the locator routes.
+    And ping from "z1" to "2001:db8::2" should eventually succeed
+    And ping from "z2" to "2001:db8::1" should eventually succeed
+
+  Scenario: Teardown topology
+    Given the test topology exists
+    When I stop zebra-rs in namespace "z1"
+    And I stop zebra-rs in namespace "z2"
+    And I delete namespace "z1"
+    And I delete namespace "z2"
+    Then the test environment should be clean

--- a/crates/isis-packet/src/sub/srv6.rs
+++ b/crates/isis-packet/src/sub/srv6.rs
@@ -76,6 +76,25 @@ pub enum Behavior {
     EndBMCSID,
     EndLBSCSID,
     EndXLBSCSID,
+    // RFC 9800 §4.2 — REPLACE-C-SID variants: the segment list carries
+    // packed containers of 16/32-bit C-SIDs and the DA argument indexes
+    // the active position; the endpoint rewrites only the C-SID bits.
+    EndRep,
+    EndRepPSP,
+    EndRepUSP,
+    EndRepPSPUSP,
+    EndRepUSD,
+    EndRepPSPUSD,
+    EndRepUSPUSD,
+    EndRepPSPUSPUSD,
+    EndXRep,
+    EndXRepPSP,
+    EndXRepUSP,
+    EndXRepPSPUSP,
+    EndXRepUSD,
+    EndXRepPSPUSD,
+    EndXRepUSPUSD,
+    EndXRepPSPUSPUSD,
     // draft-ietf-rtgwg-srv6-egress-protection — End.M (Mirroring
     // Context segment). Egress-protection variant of End.DT6: the
     // protector decapsulates and submits the inner packet to the
@@ -121,10 +140,47 @@ impl Behavior {
         )
     }
 
+    /// RFC 9800 REPLACE-C-SID flavor of End, any PSP/USP/USD
+    /// combination. A SID advertised with one of these is consumed from
+    /// packed C-SID containers — it must never appear as a plain
+    /// 128-bit segment in an uncompressed list.
+    pub fn is_end_replace_csid(&self) -> bool {
+        use Behavior::*;
+        matches!(
+            self,
+            EndRep
+                | EndRepPSP
+                | EndRepUSP
+                | EndRepPSPUSP
+                | EndRepUSD
+                | EndRepPSPUSD
+                | EndRepUSPUSD
+                | EndRepPSPUSPUSD
+        )
+    }
+
+    /// RFC 9800 REPLACE-C-SID flavor of End.X, any PSP/USP/USD
+    /// combination.
+    pub fn is_endx_replace_csid(&self) -> bool {
+        use Behavior::*;
+        matches!(
+            self,
+            EndXRep
+                | EndXRepPSP
+                | EndXRepUSP
+                | EndXRepPSPUSP
+                | EndXRepUSD
+                | EndXRepPSPUSD
+                | EndXRepUSPUSD
+                | EndXRepPSPUSPUSD
+        )
+    }
+
     /// Fold RFC 8986 §4.16 flavors into a base endpoint behavior,
     /// returning the flavored IANA codepoint. Supported bases: `End`,
-    /// `EndX`, `EndCSID` (uN) and `EndXCSID` (uA); any other base — and
-    /// an empty flavor set — returns `self` unchanged.
+    /// `EndX`, `EndCSID` (uN), `EndXCSID` (uA), `EndRep` and `EndXRep`
+    /// (REPLACE-C-SID); any other base — and an empty flavor set —
+    /// returns `self` unchanged.
     pub fn with_flavors(self, psp: bool, usp: bool, usd: bool) -> Behavior {
         use Behavior::*;
         match (self, psp, usp, usd) {
@@ -157,6 +213,20 @@ impl Behavior {
             (EndXCSID, true, false, true) => EndXCSIDPSPUSD,
             (EndXCSID, false, true, true) => EndXCSIDUSPUSD,
             (EndXCSID, true, true, true) => EndXCSIDPSPUSPUSD,
+            (EndRep, true, false, false) => EndRepPSP,
+            (EndRep, false, true, false) => EndRepUSP,
+            (EndRep, true, true, false) => EndRepPSPUSP,
+            (EndRep, false, false, true) => EndRepUSD,
+            (EndRep, true, false, true) => EndRepPSPUSD,
+            (EndRep, false, true, true) => EndRepUSPUSD,
+            (EndRep, true, true, true) => EndRepPSPUSPUSD,
+            (EndXRep, true, false, false) => EndXRepPSP,
+            (EndXRep, false, true, false) => EndXRepUSP,
+            (EndXRep, true, true, false) => EndXRepPSPUSP,
+            (EndXRep, false, false, true) => EndXRepUSD,
+            (EndXRep, true, false, true) => EndXRepPSPUSD,
+            (EndXRep, false, true, true) => EndXRepUSPUSD,
+            (EndXRep, true, true, true) => EndXRepPSPUSPUSD,
             _ => self,
         }
     }
@@ -231,6 +301,22 @@ impl From<Behavior> for u16 {
             EndBMCSID => 95,
             EndLBSCSID => 96,
             EndXLBSCSID => 97,
+            EndRep => 101,
+            EndRepPSP => 102,
+            EndRepUSP => 103,
+            EndRepPSPUSP => 104,
+            EndXRep => 105,
+            EndXRepPSP => 106,
+            EndXRepUSP => 107,
+            EndXRepPSPUSP => 108,
+            EndRepUSD => 128,
+            EndRepPSPUSD => 129,
+            EndRepUSPUSD => 130,
+            EndRepPSPUSPUSD => 131,
+            EndXRepUSD => 132,
+            EndXRepPSPUSD => 133,
+            EndXRepUSPUSD => 134,
+            EndXRepPSPUSPUSD => 135,
             EndM => 74,
             Resv(v) => v,
         }
@@ -307,6 +393,22 @@ impl From<u16> for Behavior {
             95 => EndBMCSID,
             96 => EndLBSCSID,
             97 => EndXLBSCSID,
+            101 => EndRep,
+            102 => EndRepPSP,
+            103 => EndRepUSP,
+            104 => EndRepPSPUSP,
+            105 => EndXRep,
+            106 => EndXRepPSP,
+            107 => EndXRepUSP,
+            108 => EndXRepPSPUSP,
+            128 => EndRepUSD,
+            129 => EndRepPSPUSD,
+            130 => EndRepUSPUSD,
+            131 => EndRepPSPUSPUSD,
+            132 => EndXRepUSD,
+            133 => EndXRepPSPUSD,
+            134 => EndXRepUSPUSD,
+            135 => EndXRepPSPUSPUSD,
             v => Resv(v),
         }
     }
@@ -381,6 +483,22 @@ impl Display for Behavior {
             EndBMCSID => write!(f, "uBM"),
             EndLBSCSID => write!(f, "uLBS"),
             EndXLBSCSID => write!(f, "uXLBS"),
+            EndRep => write!(f, "End (REP)"),
+            EndRepPSP => write!(f, "End (REP, PSP)"),
+            EndRepUSP => write!(f, "End (REP, USP)"),
+            EndRepPSPUSP => write!(f, "End (REP, PSP, USP)"),
+            EndRepUSD => write!(f, "End (REP, USD)"),
+            EndRepPSPUSD => write!(f, "End (REP, PSP, USD)"),
+            EndRepUSPUSD => write!(f, "End (REP, USP, USD)"),
+            EndRepPSPUSPUSD => write!(f, "End (REP, PSP, USP, USD)"),
+            EndXRep => write!(f, "End.X (REP)"),
+            EndXRepPSP => write!(f, "End.X (REP, PSP)"),
+            EndXRepUSP => write!(f, "End.X (REP, USP)"),
+            EndXRepPSPUSP => write!(f, "End.X (REP, PSP, USP)"),
+            EndXRepUSD => write!(f, "End.X (REP, USD)"),
+            EndXRepPSPUSD => write!(f, "End.X (REP, PSP, USD)"),
+            EndXRepUSPUSD => write!(f, "End.X (REP, USP, USD)"),
+            EndXRepPSPUSPUSD => write!(f, "End.X (REP, PSP, USP, USD)"),
             EndM => write!(f, "End.M"),
             Resv(v) => write!(f, "Resv({})", v),
         }
@@ -454,7 +572,7 @@ mod tests {
     #[test]
     fn behavior_codepoints_match_iana() {
         use Behavior::*;
-        let table: [(Behavior, u16); 24] = [
+        let table: [(Behavior, u16); 34] = [
             (End, 1),
             (EndPSP, 2),
             (EndUSP, 3),
@@ -479,6 +597,18 @@ mod tests {
             (EndXCSIDPSP, 53),
             (EndXCSIDPSPUSPUSD, 59),
             (EndM, 74),
+            // RFC 9800 REPLACE-C-SID rows: 101–108, then the USD combos
+            // continue at 128 (109–124 are End.T/DT*/B6 with REPLACE).
+            (EndRep, 101),
+            (EndRepPSP, 102),
+            (EndRepUSP, 103),
+            (EndRepPSPUSP, 104),
+            (EndXRep, 105),
+            (EndXRepPSP, 106),
+            (EndRepUSD, 128),
+            (EndRepPSPUSPUSD, 131),
+            (EndXRepUSD, 132),
+            (EndXRepPSPUSPUSD, 135),
         ];
         for (behavior, code) in table {
             assert_eq!(u16::from(behavior), code, "{behavior:?} -> {code}");
@@ -487,12 +617,12 @@ mod tests {
     }
 
     /// Every (base × flavor-set) fold, including that flavored results
-    /// keep their NEXT-C-SID classification and non-foldable bases pass
-    /// through unchanged.
+    /// keep their NEXT-C-SID / REPLACE-C-SID classification and
+    /// non-foldable bases pass through unchanged.
     #[test]
     fn with_flavors_folds_every_combination() {
         use Behavior::*;
-        for base in [End, EndX, EndCSID, EndXCSID] {
+        for base in [End, EndX, EndCSID, EndXCSID, EndRep, EndXRep] {
             let mut seen = std::collections::BTreeSet::new();
             for bits in 0u8..8 {
                 let (psp, usp, usd) = (bits & 1 != 0, bits & 2 != 0, bits & 4 != 0);
@@ -503,11 +633,15 @@ mod tests {
                 }
                 assert_eq!(folded.is_end_next_csid(), base.is_end_next_csid());
                 assert_eq!(folded.is_endx_next_csid(), base.is_endx_next_csid());
+                assert_eq!(folded.is_end_replace_csid(), base.is_end_replace_csid());
+                assert_eq!(folded.is_endx_replace_csid(), base.is_endx_replace_csid());
             }
         }
         assert_eq!(EndDT46.with_flavors(true, true, true), EndDT46);
         assert_eq!(EndCSID.with_flavors(true, false, false), EndCSIDPSP);
         assert_eq!(End.with_flavors(true, false, true), EndPSPUSD);
+        assert_eq!(EndRep.with_flavors(true, false, false), EndRepPSP);
+        assert_eq!(EndXRep.with_flavors(false, false, true), EndXRepUSD);
     }
 
     const ALL: [EncapType; 4] = [

--- a/proto/cradle.proto
+++ b/proto/cradle.proto
@@ -95,6 +95,8 @@ message LocalSid {
   uint32 vrf_table_id = 4;   // End.DT* table (0 = global)
   uint32 oif          = 5;   // seg6 device (End/uN) or egress link (End.X)
   string nh6          = 6;   // adjacency IPv6 for End.X / uA
+  // SID structure. uN/uA shift by ln (block=lb); REPLACE-C-SID rewrites a
+  // C-SID of ln+fun bits after a block of lb bits (RFC 9800).
   uint32 lb_bits = 7; uint32 ln_bits = 8; uint32 fun_bits = 9; uint32 arg_bits = 10;
   uint32 nexthop_id = 11;    // cross-connect adjacency for End.X (into NEXTHOPS)
   uint32 flavors    = 12;    // SRV6_FLAVOR_* bitmask (PSP=1, USP=2, USD=4)

--- a/zebra-rs/src/fib/cradle.rs
+++ b/zebra-rs/src/fib/cradle.rs
@@ -64,6 +64,8 @@ fn srv6_behavior(b: crate::rib::SidBehavior) -> u32 {
         EndDT2U => 9,  // EVPN L2 unicast decap+bridge
         EndDT2M => 10, // EVPN L2 BUM decap+flood
         EndM => 11,    // egress-protection mirror (decap + mirror-context lookup)
+        EndRep => 12,  // RFC 9800 REPLACE-C-SID (C-SID rewrite from containers)
+        EndXRep => 13, // REPLACE-C-SID + adjacency cross-connect
     }
 }
 

--- a/zebra-rs/src/fib/netlink/handle.rs
+++ b/zebra-rs/src/fib/netlink/handle.rs
@@ -259,6 +259,24 @@ fn sid_route_target(
             )
         }
         SidBehavior::UA => (RouteHeader::RT_TABLE_MAIN, RouteType::Unicast, 128, addr),
+        // REPLACE-C-SID (cradle-only — never reaches the kernel): the
+        // /(LB+LN+Fun) prefix leaves the index argument wild; the tee
+        // takes its prefix_len from here.
+        SidBehavior::EndRep | SidBehavior::EndXRep => {
+            let plen = structure
+                .map(|s| {
+                    s.lb_bits
+                        .saturating_add(s.ln_bits)
+                        .saturating_add(s.fun_bits)
+                })
+                .unwrap_or(128);
+            (
+                RouteHeader::RT_TABLE_MAIN,
+                RouteType::Unicast,
+                plen,
+                mask_v6(addr, plen),
+            )
+        }
         // LIB twin of a uA: a block:function prefix entry that matches
         // the uA when it is the carrier's *active* uSID (post-uN-shift
         // DA). /(LB+Fun) with the NEXT-CSID flavor — verified live on
@@ -1657,10 +1675,15 @@ impl FibHandle {
         }
         // EVPN-over-SRv6 L2 SIDs are cradle-only: the kernel has no
         // End.DT2U/DT2M seg6local actions, so there is nothing to install
-        // via netlink.
+        // via netlink. Same for REPLACE-C-SID (RFC 9800 §4.2): no kernel
+        // flavor op exists through 6.8, and a plain-End fallback would
+        // misread the packed containers as full SIDs — worse than no entry.
         if matches!(
             sid.behavior,
-            crate::rib::SidBehavior::EndDT2U | crate::rib::SidBehavior::EndDT2M
+            crate::rib::SidBehavior::EndDT2U
+                | crate::rib::SidBehavior::EndDT2M
+                | crate::rib::SidBehavior::EndRep
+                | crate::rib::SidBehavior::EndXRep
         ) {
             return;
         }
@@ -1821,10 +1844,13 @@ impl FibHandle {
         if let Some(cradle) = &self.cradle {
             cradle.local_sid_uninstall(sid, prefix_len).await;
         }
-        // Cradle-only L2 SIDs (see route_sid_install): nothing in the kernel.
+        // Cradle-only SIDs (see route_sid_install): nothing in the kernel.
         if matches!(
             sid.behavior,
-            crate::rib::SidBehavior::EndDT2U | crate::rib::SidBehavior::EndDT2M
+            crate::rib::SidBehavior::EndDT2U
+                | crate::rib::SidBehavior::EndDT2M
+                | crate::rib::SidBehavior::EndRep
+                | crate::rib::SidBehavior::EndXRep
         ) {
             return;
         }

--- a/zebra-rs/src/fib/netlink/srv6.rs
+++ b/zebra-rs/src/fib/netlink/srv6.rs
@@ -125,6 +125,11 @@ fn seg6local_action(behavior: SidBehavior) -> Seg6LocalAction {
         // a panic.
         SidBehavior::EndDT2U | SidBehavior::EndDT2M => Seg6LocalAction::End,
         SidBehavior::EndX | SidBehavior::UA | SidBehavior::UALib => Seg6LocalAction::EndX,
+        // REPLACE-C-SID never reaches the kernel (route_sid_install
+        // returns after the cradle tee — no kernel flavor op exists);
+        // map like DT2U/DT2M so an unexpected call is a visible no-op.
+        SidBehavior::EndRep => Seg6LocalAction::End,
+        SidBehavior::EndXRep => Seg6LocalAction::EndX,
         SidBehavior::EndDT4 => Seg6LocalAction::EndDt4,
         // End.M reuses the End.DT6 kernel action: decapsulate and look the
         // inner IPv6 packet up in a table — for End.M that is the

--- a/zebra-rs/src/isis/inst.rs
+++ b/zebra-rs/src/isis/inst.rs
@@ -3141,6 +3141,7 @@ impl Isis {
         {
             let (behavior, structure) = match locator.behavior {
                 Some(LocatorBehavior::Usid) => (SidBehavior::UN, locator.sid_structure()),
+                Some(LocatorBehavior::Replace) => (SidBehavior::EndRep, locator.sid_structure()),
                 None => (SidBehavior::End, None),
             };
             let sid = Sid {
@@ -3203,6 +3204,7 @@ impl Isis {
         {
             let (behavior, structure) = match locator.behavior {
                 Some(LocatorBehavior::Usid) => (SidBehavior::UN, locator.sid_structure()),
+                Some(LocatorBehavior::Replace) => (SidBehavior::EndRep, locator.sid_structure()),
                 None => (SidBehavior::End, None),
             };
             let sid = Sid {

--- a/zebra-rs/src/isis/lsp.rs
+++ b/zebra-rs/src/isis/lsp.rs
@@ -460,23 +460,22 @@ pub fn dis_generate(
     fragments
 }
 
-/// SID Structure sub-sub-TLV (RFC 9352 §9) for one locator: `Some`
-/// pair `(is_usid, [structure])` when the locator has a prefix, `None`
-/// when it doesn't (no structure to advertise). uSID locators cap LB at
-/// 32, classic at 40; function is 16 bits (what `function_addr` places),
-/// argument 0.
-fn srv6_sid_structure(locator: &Locator) -> Option<(bool, Vec<IsisSub2Tlv>)> {
-    let prefix = locator.prefix?;
-    let plen = prefix.prefix_len();
-    let is_usid = matches!(locator.behavior, Some(LocatorBehavior::Usid));
-    let lb_len = if is_usid { plen.min(32) } else { plen.min(40) };
+/// SID Structure sub-sub-TLV (RFC 9352 §9) for one locator: the
+/// locator's behavior plus `[structure]` when it has a prefix, `None`
+/// when it doesn't (no structure to advertise). Geometry comes from
+/// `Locator::sid_structure()` — the same source the FIB installs from —
+/// so the wire and the data plane can't drift. Note REPLACE-C-SID
+/// advertises a non-zero argument length (AL = 128-LBL-LNFL): that is
+/// how RFC 9800 §6.4 receivers infer the compression scheme.
+fn srv6_sid_structure(locator: &Locator) -> Option<(Option<LocatorBehavior>, Vec<IsisSub2Tlv>)> {
+    let st = locator.sid_structure()?;
     let structure = IsisSub2Tlv::SidStructure(IsisSub2SidStructure {
-        lb_len,
-        ln_len: plen.saturating_sub(lb_len),
-        fun_len: 16,
-        arg_len: 0,
+        lb_len: st.lb_bits,
+        ln_len: st.ln_bits,
+        fun_len: st.fun_bits,
+        arg_len: st.arg_bits,
     });
-    Some((is_usid, vec![structure]))
+    Some((locator.behavior.clone(), vec![structure]))
 }
 
 /// Fold a locator's configured RFC 8986 §4.16 flavor mask into a base
@@ -491,27 +490,30 @@ fn flavored(base: Behavior, mask: u8) -> Behavior {
 }
 
 /// SRv6 End-SID endpoint behavior + SID Structure for one locator
-/// (RFC 9352 §9). Classic → `End`; uSID → `EndCSID` (uN); either folded
-/// with the locator's flavors. Per-locator so each per-Flex-Algorithm
-/// locator gets its own structure.
+/// (RFC 9352 §9). Classic → `End`; uSID → `EndCSID` (uN); REPLACE →
+/// `EndRep`; each folded with the locator's flavors. Per-locator so
+/// each per-Flex-Algorithm locator gets its own structure.
 fn srv6_end_structure(locator: &Locator) -> (Behavior, Vec<IsisSub2Tlv>) {
     let (base, subs) = match srv6_sid_structure(locator) {
-        Some((true, subs)) => (Behavior::EndCSID, subs),
-        Some((false, subs)) => (Behavior::End, subs),
+        Some((Some(LocatorBehavior::Usid), subs)) => (Behavior::EndCSID, subs),
+        Some((Some(LocatorBehavior::Replace), subs)) => (Behavior::EndRep, subs),
+        Some((None, subs)) => (Behavior::End, subs),
         None => (Behavior::End, Vec::new()),
     };
     (flavored(base, locator.flavors), subs)
 }
 
 /// SRv6 End.X SID endpoint behavior + SID Structure for one locator
-/// (RFC 9352 §8/§9). Classic → `EndX`; uSID → `EndXCSID` (uA). The
-/// End.X sibling of `srv6_end_structure`. Adjacency SIDs fold only the
-/// PSP flavor — their USP/USD variants are not implemented in the data
-/// plane, so they must not be advertised either.
+/// (RFC 9352 §8/§9). Classic → `EndX`; uSID → `EndXCSID` (uA); REPLACE
+/// → `EndXRep`. The End.X sibling of `srv6_end_structure`. Adjacency
+/// SIDs fold only the PSP flavor — their USP/USD variants are not
+/// implemented in the data plane, so they must not be advertised
+/// either.
 fn srv6_endx_structure(locator: &Locator) -> (Behavior, Vec<IsisSub2Tlv>) {
     let (base, subs) = match srv6_sid_structure(locator) {
-        Some((true, subs)) => (Behavior::EndXCSID, subs),
-        Some((false, subs)) => (Behavior::EndX, subs),
+        Some((Some(LocatorBehavior::Usid), subs)) => (Behavior::EndXCSID, subs),
+        Some((Some(LocatorBehavior::Replace), subs)) => (Behavior::EndXRep, subs),
+        Some((None, subs)) => (Behavior::EndX, subs),
         None => (Behavior::EndX, Vec::new()),
     };
     (
@@ -892,42 +894,13 @@ pub fn lsp_generate(top: &mut IsisTop, level: Level, seq_floor: Option<u32>) -> 
     //
     // Function is 16 bits — the width function_addr() places into the
     // SID. Argument is 0; we don't allocate argument-bearing SIDs.
-    let (end_behavior, endx_behavior, sid_structure_subs) = match top
-        .sr_locator
-        .as_ref()
-        .and_then(|loc| loc.prefix.map(|p| (loc.behavior.as_ref(), p, loc.flavors)))
-    {
-        Some((Some(LocatorBehavior::Usid), prefix, flavors)) => {
-            let plen = prefix.prefix_len();
-            let lb_len = plen.min(32);
-            let structure = IsisSub2Tlv::SidStructure(IsisSub2SidStructure {
-                lb_len,
-                ln_len: plen.saturating_sub(lb_len),
-                fun_len: 16,
-                arg_len: 0,
-            });
-            (
-                flavored(Behavior::EndCSID, flavors),
-                flavored(Behavior::EndXCSID, flavors & crate::rib::FLAVOR_PSP),
-                vec![structure],
-            )
+    let (end_behavior, endx_behavior, sid_structure_subs) = match top.sr_locator.as_ref() {
+        Some(loc) if loc.prefix.is_some() => {
+            let (end_behavior, subs) = srv6_end_structure(loc);
+            let (endx_behavior, _) = srv6_endx_structure(loc);
+            (end_behavior, endx_behavior, subs)
         }
-        Some((None, prefix, flavors)) => {
-            let plen = prefix.prefix_len();
-            let lb_len = plen.min(40);
-            let structure = IsisSub2Tlv::SidStructure(IsisSub2SidStructure {
-                lb_len,
-                ln_len: plen.saturating_sub(lb_len),
-                fun_len: 16,
-                arg_len: 0,
-            });
-            (
-                flavored(Behavior::End, flavors),
-                flavored(Behavior::EndX, flavors & crate::rib::FLAVOR_PSP),
-                vec![structure],
-            )
-        }
-        None => (Behavior::End, Behavior::EndX, Vec::new()),
+        _ => (Behavior::End, Behavior::EndX, Vec::new()),
     };
 
     // SRv6 Locators TLV (RFC 9352 §7.1, type 27). One sub-locator for

--- a/zebra-rs/src/isis/neigh.rs
+++ b/zebra-rs/src/isis/neigh.rs
@@ -398,10 +398,14 @@ impl Neighbor {
             }
 
             // Main End.X registration; behavior from the per-algo
-            // locator (uA for uSID, End.X for classic).
+            // locator (uA for uSID, End.X(REP) for REPLACE-C-SID,
+            // End.X for classic).
             let (behavior, structure) = match locator.behavior {
                 Some(crate::rib::LocatorBehavior::Usid) => {
                     (SidBehavior::UA, locator.sid_structure())
+                }
+                Some(crate::rib::LocatorBehavior::Replace) => {
+                    (SidBehavior::EndXRep, locator.sid_structure())
                 }
                 None => (SidBehavior::EndX, None),
             };
@@ -526,6 +530,9 @@ impl Neighbor {
     ) -> Sid {
         let (behavior, structure) = match locator.behavior {
             Some(crate::rib::LocatorBehavior::Usid) => (SidBehavior::UA, locator.sid_structure()),
+            Some(crate::rib::LocatorBehavior::Replace) => {
+                (SidBehavior::EndXRep, locator.sid_structure())
+            }
             None => (SidBehavior::EndX, None),
         };
         Sid {

--- a/zebra-rs/src/isis/show.rs
+++ b/zebra-rs/src/isis/show.rs
@@ -356,6 +356,7 @@ fn show_isis_summary(
                 Some(p) => {
                     let beh = match loc.and_then(|l| l.behavior.as_ref()) {
                         Some(LocatorBehavior::Usid) => "uSID",
+                        Some(LocatorBehavior::Replace) => "REPLACE",
                         None => "Classic",
                     };
                     (Some(p.to_string()), Some(beh.to_string()), "Up")
@@ -700,6 +701,7 @@ fn render_locator_row(name: &str, locator: Option<&crate::rib::Locator>) -> Stri
             Some(p) => {
                 let beh = match loc.behavior {
                     Some(LocatorBehavior::Usid) => "uSID",
+                    Some(LocatorBehavior::Replace) => "REPLACE",
                     None => "Classic",
                 };
                 (p.to_string(), beh.to_string(), "Up")
@@ -1511,6 +1513,17 @@ fn write_local_sids(buf: &mut String, isis: &Isis) -> std::fmt::Result {
                     .unwrap_or(128);
                 ("uN", plen)
             }
+            Some(crate::rib::LocatorBehavior::Replace) => {
+                let plen = locator
+                    .sid_structure()
+                    .map(|s| {
+                        s.lb_bits
+                            .saturating_add(s.ln_bits)
+                            .saturating_add(s.fun_bits)
+                    })
+                    .unwrap_or(128);
+                ("End(REP)", plen)
+            }
             None => ("End", 128),
         };
         let masked = mask_v6(addr, prefix_len);
@@ -1542,6 +1555,7 @@ fn write_local_sids(buf: &mut String, isis: &Isis) -> std::fmt::Result {
                 };
                 let behavior = match isis.sr_locator.as_ref().and_then(|l| l.behavior.as_ref()) {
                     Some(crate::rib::LocatorBehavior::Usid) => "uA",
+                    Some(crate::rib::LocatorBehavior::Replace) => "End.X(REP)",
                     _ => "End.X",
                 };
                 rows.push(LocalSidRow {

--- a/zebra-rs/src/isis/tilfa.rs
+++ b/zebra-rs/src/isis/tilfa.rs
@@ -132,18 +132,27 @@ pub(super) fn build_repair_path_srv6(
     for (idx, seg) in rp.segs.iter().enumerate() {
         let resolved = match seg {
             spf::SrSegment::NodeSid(v) => {
-                node_sid_info(top, level, *v, algo).map(|info| RepairSeg {
-                    sid: info.sid,
-                    landing: *v,
-                    csid: csid_bits_end(&info),
-                })
+                // REPLACE-C-SID SIDs are only valid inside packed C-SID
+                // containers (RFC 9800 §6.4) — as a plain 128-bit repair
+                // segment the endpoint would misread the neighbouring
+                // list entries as containers. No compression-aware
+                // repair encoder exists, so such a hop is unprotectable.
+                node_sid_info(top, level, *v, algo)
+                    .filter(|info| !info.behavior.is_end_replace_csid())
+                    .map(|info| RepairSeg {
+                        sid: info.sid,
+                        landing: *v,
+                        csid: csid_bits_end(&info),
+                    })
             }
             spf::SrSegment::AdjSid(from, to, via) => {
-                srv6_endx_sid_for_link(top, level, *from, *to, *via, algo).map(|endx| RepairSeg {
-                    sid: endx.sid,
-                    landing: *to,
-                    csid: csid_bits_endx(&endx, *from),
-                })
+                srv6_endx_sid_for_link(top, level, *from, *to, *via, algo)
+                    .filter(|endx| !endx.behavior.is_endx_replace_csid())
+                    .map(|endx| RepairSeg {
+                        sid: endx.sid,
+                        landing: *to,
+                        csid: csid_bits_endx(&endx, *from),
+                    })
             }
         };
         let Some(part) = resolved else {

--- a/zebra-rs/src/ospf/inst.rs
+++ b/zebra-rs/src/ospf/inst.rs
@@ -9471,6 +9471,7 @@ impl Ospf<Ospfv3> {
         {
             let (behavior, structure) = match locator.behavior {
                 Some(LocatorBehavior::Usid) => (SidBehavior::UN, locator.sid_structure()),
+                Some(LocatorBehavior::Replace) => (SidBehavior::EndRep, locator.sid_structure()),
                 None => (SidBehavior::End, None),
             };
             let sid = Sid {
@@ -9678,6 +9679,7 @@ impl Ospf<Ospfv3> {
         let loc_name = self.watched_locator.clone().unwrap_or_default();
         let (behavior, structure) = match locator.behavior {
             Some(LocatorBehavior::Usid) => (SidBehavior::UA, locator.sid_structure()),
+            Some(LocatorBehavior::Replace) => (SidBehavior::EndXRep, locator.sid_structure()),
             None => (SidBehavior::EndX, None),
         };
         let sid = Sid {

--- a/zebra-rs/src/ospf/srv6.rs
+++ b/zebra-rs/src/ospf/srv6.rs
@@ -38,6 +38,7 @@ pub fn srv6_locator_lsa_build(router_id: Ipv4Addr, locator: &Locator) -> Option<
 
     let base = match locator.behavior {
         Some(LocatorBehavior::Usid) => isis_packet::Behavior::EndCSID,
+        Some(LocatorBehavior::Replace) => isis_packet::Behavior::EndRep,
         None => isis_packet::Behavior::End,
     };
     let behavior = u16::from(base.with_flavors(
@@ -199,6 +200,7 @@ pub struct EndxSidState {
 pub fn endx_behavior(locator: &Locator) -> u16 {
     let base = match locator.behavior {
         Some(LocatorBehavior::Usid) => isis_packet::Behavior::EndXCSID,
+        Some(LocatorBehavior::Replace) => isis_packet::Behavior::EndXRep,
         None => isis_packet::Behavior::EndX,
     };
     // Adjacency SIDs fold only PSP — the USP/USD End.X variants are not

--- a/zebra-rs/src/ospf/tilfa.rs
+++ b/zebra-rs/src/ospf/tilfa.rs
@@ -515,6 +515,12 @@ pub(super) fn build_repair_path_srv6_v3(
         let part = match seg {
             spf::SrSegment::NodeSid(v) => {
                 let info = srv6_end_sid_for_vertex_v3(top, area, *v)?;
+                // REPLACE-C-SID SIDs are only valid inside packed C-SID
+                // containers (RFC 9800 §6.4) — unprotectable as plain
+                // repair segments (same guard as the IS-IS builder).
+                if isis_packet::Behavior::from(info.behavior).is_end_replace_csid() {
+                    return None;
+                }
                 RepairSeg {
                     sid: info.sid,
                     landing: *v,
@@ -523,6 +529,9 @@ pub(super) fn build_repair_path_srv6_v3(
             }
             spf::SrSegment::AdjSid(from, to, _via) => {
                 let info = srv6_endx_sid_for_link_v3(top, area, *from, *to)?;
+                if isis_packet::Behavior::from(info.behavior).is_endx_replace_csid() {
+                    return None;
+                }
                 RepairSeg {
                     sid: info.sid,
                     landing: *to,

--- a/zebra-rs/src/rib/segment_routing/locator.rs
+++ b/zebra-rs/src/rib/segment_routing/locator.rs
@@ -12,20 +12,24 @@ use tokio::sync::mpsc::UnboundedSender;
 use crate::config::{Args, ConfigOp};
 use crate::rib::Message;
 
-/// Locator-wide endpoint behavior. The YANG enum currently lists only
-/// `usid` (RFC 9800 NEXT-C-SID); the variant is `Option<...>` on Locator
-/// because the absence of the leaf means the classic RFC 8986 full SID
-/// layout, not "uSID".
+/// Locator-wide endpoint behavior. The YANG enum lists `usid` (RFC 9800
+/// NEXT-C-SID) and `replace` (RFC 9800 REPLACE-C-SID); the variant is
+/// `Option<...>` on Locator because the absence of the leaf means the
+/// classic RFC 8986 full SID layout.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum LocatorBehavior {
     /// RFC 9800 NEXT-C-SID (micro-SID) format.
     Usid,
+    /// RFC 9800 REPLACE-C-SID format: 32-bit C-SIDs (LN 16 + Fun 16)
+    /// consumed from packed containers, index argument in the DA.
+    Replace,
 }
 
 impl LocatorBehavior {
     pub fn parse(s: &str) -> Option<Self> {
         match s {
             "usid" => Some(Self::Usid),
+            "replace" => Some(Self::Replace),
             _ => None,
         }
     }
@@ -78,12 +82,28 @@ impl Locator {
     /// (IPv6 DOC / SR block convention). Function is fixed at 16 bits
     /// — the width `function_addr()` actually places into the SID.
     /// Argument is 0; we don't allocate argument-bearing SIDs.
+    ///
+    /// REPLACE-C-SID locators (RFC 9800 §4.2): the locator prefix is
+    /// Block + Node with a fixed 16-bit Node, the C-SID is Node +
+    /// Function = 32 bits, and the Argument is everything left —
+    /// mandatory, since the index that drives the container walk lives
+    /// in its least significant bits (AL = 128 - LBL - LNFL, §8's
+    /// canonical example: /64 locator → LB 48, LN 16, Fun 16, Arg 48).
     pub fn sid_structure(&self) -> Option<crate::rib::SidStructure> {
         let prefix = self.prefix?;
         let plen = prefix.prefix_len();
+        if matches!(self.behavior, Some(LocatorBehavior::Replace)) {
+            let lb_bits = plen.saturating_sub(16);
+            return Some(crate::rib::SidStructure {
+                lb_bits,
+                ln_bits: plen - lb_bits,
+                fun_bits: 16,
+                arg_bits: 128u8.saturating_sub(plen).saturating_sub(16),
+            });
+        }
         let lb_bits = match self.behavior {
             Some(LocatorBehavior::Usid) => plen.min(32),
-            None => plen.min(40),
+            _ => plen.min(40),
         };
         Some(crate::rib::SidStructure {
             lb_bits,

--- a/zebra-rs/src/rib/segment_routing/sid.rs
+++ b/zebra-rs/src/rib/segment_routing/sid.rs
@@ -81,6 +81,17 @@ pub enum SidBehavior {
     /// (carried in [`Sid::table_id`]), reproducing that egress's
     /// forwarding. Installed by IS-IS egress-protection on the protector.
     EndM,
+    /// End with REPLACE-C-SID — RFC 9800 §4.2.1 (IANA codepoint 101).
+    /// The endpoint rewrites only the C-SID bits of the DA from packed
+    /// containers in the segment list, driven by the index argument in
+    /// the DA. Carries a [`SidStructure`]; installs at /(LB+LN+Fun) so
+    /// the argument stays wild. No kernel seg6local support — cradle
+    /// tee only.
+    EndRep,
+    /// End.X with REPLACE-C-SID — RFC 9800 §4.2.2 (IANA codepoint 105).
+    /// As `EndRep`, then forwards out the bound adjacency. Cradle tee
+    /// only, like `EndRep`.
+    EndXRep,
 }
 
 impl fmt::Display for SidBehavior {
@@ -98,6 +109,8 @@ impl fmt::Display for SidBehavior {
             Self::EndDT2U => write!(f, "End.DT2U"),
             Self::EndDT2M => write!(f, "End.DT2M"),
             Self::EndM => write!(f, "End.M"),
+            Self::EndRep => write!(f, "End(REP)"),
+            Self::EndXRep => write!(f, "End.X(REP)"),
         }
     }
 }
@@ -289,6 +302,21 @@ impl Sid {
                 let plen = self
                     .structure
                     .map(|s| s.lb_bits.saturating_add(s.ln_bits))
+                    .unwrap_or(128);
+                let masked = mask_v6(self.addr, plen);
+                Ipv6Net::new(masked, plen)
+                    .unwrap_or_else(|_| Ipv6Net::new(self.addr, 128).expect("/128 is always valid"))
+            }
+            // REPLACE-C-SID SIDs match Block + C-SID (LB+LN+Fun) — the
+            // argument (with its container index) must stay wild.
+            SidBehavior::EndRep | SidBehavior::EndXRep => {
+                let plen = self
+                    .structure
+                    .map(|s| {
+                        s.lb_bits
+                            .saturating_add(s.ln_bits)
+                            .saturating_add(s.fun_bits)
+                    })
                     .unwrap_or(128);
                 let masked = mask_v6(self.addr, plen);
                 Ipv6Net::new(masked, plen)

--- a/zebra-rs/yang/config.yang
+++ b/zebra-rs/yang/config.yang
@@ -3194,11 +3194,15 @@ module config {
         leaf behavior {
           type enumeration {
             enum usid;
+            enum replace;
           }
           description
             "Locator-wide endpoint behavior. 'usid' selects the
-             RFC 9800 NEXT-C-SID (micro-SID) format; absent means
-             the classic RFC 8986 full-SID layout.";
+             RFC 9800 NEXT-C-SID (micro-SID) format; 'replace' the
+             RFC 9800 REPLACE-C-SID format (32-bit C-SIDs consumed
+             from packed containers, e.g. a /64 locator advertises
+             LB 48 / LN 16 / Fun 16 / Arg 48); absent means the
+             classic RFC 8986 full-SID layout.";
         }
         leaf-list flavor {
           type enumeration {


### PR DESCRIPTION
## Summary
- Add RFC 9800 §4.2 REPLACE-C-SID support end to end: yang locator `behavior: replace` → `LocatorBehavior::Replace` (SID structure LB=plen-16 / LN 16 / Fun 16 / Arg 128-plen-16 — the non-zero argument length is how §6.4 receivers infer 32-bit compression) → `SidBehavior::EndRep`/`EndXRep` installing at /(LB+LN+Fun) so the index argument stays wild → flavored IANA codepoints in IS-IS/OSPFv3 → cradle tee (behaviors 12/13 + lb/ln/fun bits).
- isis-packet: the 16 REPLACE-C-SID codepoints (End 101–104/128–131, End.X 105–108/132–135) with Display `End (REP, …)`, classifier helpers, and `with_flavors` folds — pinned by the IANA round-trip test. End.X folds PSP only (same conformance stance as NEXT-C-SID).
- The IS-IS LSP SID-structure emission now derives from `Locator::sid_structure()` (single source of truth, replacing the inline algo-0 duplication).
- TI-LFA (IS-IS and OSPFv3) refuses REPLACE SIDs as plain repair segments — they are only valid inside packed containers (§6.4).
- Kernel: no REPLACE flavor op exists through 6.8, so `route_sid_install` returns after the cradle tee (a plain-End fallback would misread packed containers as full SIDs).

## Test plan
- `cargo test -p zebra-rs` (1512 passed) + isis-packet IANA round-trip tests; fmt, clippy --workspace --all-targets, clippy --no-default-features all clean.
- New BDD `isis_srv6_replace`: two-node IS-IS, z1 `behavior: replace` + `flavor: [psp, usd]` — the peer database shows `End (REP, PSP, USD)` (129) and `End.X (REP, PSP)` (106), the uSID peer is unaffected, pings both ways; teardown scenario. Passed.
- `isis_srv6_flavor` regression re-run green.
- Cradle e2e `cradle_replace_zebra` (yang → advertisement → tee /80 install → eBPF container walk + USD decap) green against this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)