### PR TITLE
feat(ospf): send-side MinLSInterval self-LSA throttle (v2 + v3)

### DIFF
--- a/bdd/tests/configs/ospfv2_min_ls_interval/a.yaml
+++ b/bdd/tests/configs/ospfv2_min_ls_interval/a.yaml
@@ -1,0 +1,22 @@
+interface:
+- if-name: lo
+  ipv4:
+    address: 10.0.0.1/32
+- if-name: ethb
+  ipv4:
+    address: 10.0.12.1/30
+router:
+  ospf:
+    router-id: 10.0.0.1
+    # Non-default MinLSInterval (RFC 2328 §12.4), surfaced by
+    # `show ospf` so the BDD can confirm it reached the instance.
+    # 1500ms keeps convergence brisk while still exercising the knob.
+    min-ls-interval: 1500
+    area:
+    - area-id: 0.0.0.0
+      interface:
+      - if-name: lo
+        enable: true
+      - if-name: ethb
+        enable: true
+        network-type: point-to-point

--- a/bdd/tests/configs/ospfv2_min_ls_interval/b.yaml
+++ b/bdd/tests/configs/ospfv2_min_ls_interval/b.yaml
@@ -1,0 +1,19 @@
+interface:
+- if-name: lo
+  ipv4:
+    address: 10.0.0.2/32
+- if-name: etha
+  ipv4:
+    address: 10.0.12.2/30
+router:
+  ospf:
+    router-id: 10.0.0.2
+    min-ls-interval: 1500
+    area:
+    - area-id: 0.0.0.0
+      interface:
+      - if-name: lo
+        enable: true
+      - if-name: etha
+        enable: true
+        network-type: point-to-point

--- a/bdd/tests/features/ospfv2_min_ls_interval.feature
+++ b/bdd/tests/features/ospfv2_min_ls_interval.feature
@@ -1,0 +1,42 @@
+@serial
+@ospfv2_min_ls_interval
+Feature: OSPFv2 MinLSInterval self-LSA re-origination throttle
+  As a network operator
+  I want `router ospf min-ls-interval` to bound how often the router
+  re-originates the same self-LSA (RFC 2328 §12.4 MinLSInterval, FRR
+  `timers throttle lsa all`), so a burst of topology changes coalesces
+  into one Router-LSA / Network-LSA update instead of a storm — while
+  a stable topology still converges.
+
+  Test Topology:
+  ```
+    a (10.0.0.1) -- 10.0.12.0/30 -- b (10.0.0.2)
+    both routers set min-ls-interval 1500 ms.
+  ```
+
+  Scenario: Configured MinLSInterval is applied and the topology still converges
+    Given a clean test environment
+    When I create namespace "a"
+    And I create namespace "b"
+    And I connect namespace "a" interface "ethb" to namespace "b" interface "etha"
+    And I start zebra-rs in namespace "a"
+    And I start zebra-rs in namespace "b"
+    And I apply config "a.yaml" to namespace "a"
+    And I apply config "b.yaml" to namespace "b"
+    And I wait 20 seconds
+
+    # The configured (non-default) MinLSInterval is surfaced verbatim by
+    # `show ospf`, proving the config reached the instance.
+    Then show command "show ospf" in namespace "a" should contain "MinLSInterval (self-LSA re-origination): 1500 ms"
+    # Adjacency forms and routes converge under the throttle.
+    And show command "show ospf neighbor" in namespace "a" should contain "Full"
+    And show command "show ospf neighbor" in namespace "b" should contain "Full"
+    And show command "show ospf route" in namespace "a" should contain "10.0.0.2/32"
+    And ping from "a" to "10.0.0.2" should succeed
+
+    # Teardown.
+    When I stop zebra-rs in namespace "a"
+    And I stop zebra-rs in namespace "b"
+    And I delete namespace "a"
+    And I delete namespace "b"
+    Then the test environment should be clean

--- a/book/src/ch-08-08-ospf-timers.md
+++ b/book/src/ch-08-08-ospf-timers.md
@@ -70,3 +70,37 @@ configured bounds (`SPF timers: initial … secondary … maximum …`).
 OSPFv3 exposes the identical `spf-interval` block under
 `router ospfv3`. These defaults replace the earlier fixed 1-second
 coalescing timer.
+
+## MinLSInterval (`min-ls-interval`)
+
+Where `spf-interval` throttles the *route calculation*,
+`min-ls-interval` throttles *self-LSA origination* — RFC 2328 §12.4
+MinLSInterval, the same knob as FRR's `timers throttle lsa all`:
+
+```
+router ospf {
+  min-ls-interval 5000;
+}
+```
+
+| YANG leaf (`/router/ospf[v3]/min-ls-interval`) | Default | Range | Units |
+|---|---|---|---|
+| `min-ls-interval` | 5000 | 0..5000 | milliseconds |
+
+A self-LSA may be re-originated at most once per `min-ls-interval`. A
+re-origination requested sooner (the second of two rapid topology
+changes) is deferred to the interval boundary, and further triggers
+in that window coalesce into the single deferred update — so a
+flapping link produces one Router-LSA every `min-ls-interval` instead
+of a flood. The first origination after a quiet period is always
+immediate. The throttle covers the topology-churn LSAs — the
+**Router-LSA** and the per-interface **Network-LSA**; Summary /
+AS-External LSAs re-originate only on route changes and are already
+diff-gated, so they don't storm. Graceful-restart exit re-originates
+promptly, bypassing the throttle.
+
+`show ospf` reports the value (`MinLSInterval (self-LSA
+re-origination): … ms`); OSPFv3 exposes the identical
+`min-ls-interval` leaf under `router ospfv3`. The companion
+receive-side limit (RFC 2328 §13 MinLSArrival) is fixed at 1 s and
+not yet configurable.

--- a/book/src/ch-08-12-ospf-frr-gaps.md
+++ b/book/src/ch-08-12-ospf-frr-gaps.md
@@ -13,9 +13,10 @@ OSPFv2 features not yet implemented in zebra-rs:
   Type-7 LSAs carrying a non-zero forwarding address are skipped
   (RFC 2328 §16.4 step 3); zebra-rs itself always originates with
   FA 0.0.0.0.
-- Configurable **LSA-generation** throttle. The SPF calculation now
-  has an adaptive throttle (see below), but LSA origination is not
-  yet rate-limited by a matching `timers throttle lsa-all`.
+- Configurable **MinLSArrival** (`timers lsa min-arrival`, RFC 2328
+  §13) — the receive-side per-LSA rate limit is enforced but fixed at
+  1 s. (The send-side MinLSInterval / `timers throttle lsa all` *is*
+  configurable — see below.)
 
 ## Previously listed gaps that are now closed
 
@@ -60,3 +61,8 @@ per feature — see each feature's page):
   FRR's `timers throttle spf`), per-area and shared with IS-IS,
   for both OSPFv2 and OSPFv3. Replaces the old fixed 1-second
   coalescing timer. See [Timer Configuration](ch-08-08-ospf-timers.md).
+- **Send-side MinLSInterval** (`min-ls-interval`, RFC 2328 §12.4 /
+  FRR `timers throttle lsa all`) — self-LSA re-origination is now
+  rate-limited (Router-LSA and Network-LSA coalesce a burst of
+  topology changes into one update), configurable for both OSPFv2 and
+  OSPFv3. See [Timer Configuration](ch-08-08-ospf-timers.md).

--- a/book/src/ch-15-15-ospfv3-frr-gaps.md
+++ b/book/src/ch-15-15-ospfv3-frr-gaps.md
@@ -8,9 +8,12 @@ OSPFv3 features not yet implemented in zebra-rs:
 - NBMA and point-to-multipoint network types.
 - Configurable Instance ID (always 0 — one instance per link).
 
-The adaptive SPF throttle (`spf-interval`) is now configurable for
-OSPFv3, identical to v2 — see
-[Timer Configuration](ch-08-08-ospf-timers.md).
+The adaptive SPF throttle (`spf-interval`) and the send-side
+MinLSInterval (`min-ls-interval`) are both configurable for OSPFv3,
+identical to v2 — see
+[Timer Configuration](ch-08-08-ospf-timers.md). MinLSInterval on v3
+actually goes beyond `ospf6d`, which has no `timers throttle lsa`
+command at all (only the receive-side `timers lsa min-arrival`).
 
 The balance runs the other way for Segment Routing: zebra-rs
 OSPFv3 implements SR-MPLS (RFC 8666), SRv6 (RFC 9513), TI-LFA

--- a/zebra-rs/src/ospf/config.rs
+++ b/zebra-rs/src/ospf/config.rs
@@ -313,6 +313,7 @@ impl Ospf {
             config_ospf_spf_secondary_wait,
         );
         self.ospf_add("/spf-interval/maximum-wait", config_ospf_spf_maximum_wait);
+        self.ospf_add("/min-ls-interval", config_ospf_min_ls_interval);
         // `/router/ospf/tracing/...` is handled by the subtree dispatcher
         // `super::tracing::config_tracing_dispatch` (called from
         // `process_cm_msg` for paths this callback table does not claim),
@@ -2140,6 +2141,19 @@ fn config_ospf_spf_secondary_wait(ospf: &mut Ospf, mut args: Args, op: ConfigOp)
 fn config_ospf_spf_maximum_wait(ospf: &mut Ospf, mut args: Args, op: ConfigOp) -> Option<()> {
     let default = super::inst::SpfIntervalConfig::default().maximum_wait_ms;
     ospf.spf_interval.maximum_wait_ms = if op.is_set() { args.u32()? } else { default };
+    Some(())
+}
+
+// `/router/ospf/min-ls-interval` — RFC 2328 §12.4 MinLSInterval (ms).
+// Delete restores the RFC/FRR default. Applies from the next
+// re-origination; a deferral already in flight keeps its timer.
+fn config_ospf_min_ls_interval(ospf: &mut Ospf, mut args: Args, op: ConfigOp) -> Option<()> {
+    let value = if op.is_set() {
+        args.u32()?
+    } else {
+        super::inst::OSPF_MIN_LS_INTERVAL_MS
+    };
+    ospf.min_ls_interval_ms = value;
     Some(())
 }
 

--- a/zebra-rs/src/ospf/config_v3.rs
+++ b/zebra-rs/src/ospf/config_v3.rs
@@ -88,6 +88,7 @@ impl Ospf<Ospfv3> {
                 config_ospfv3_spf_secondary_wait,
             ),
             ("/spf-interval/maximum-wait", config_ospfv3_spf_maximum_wait),
+            ("/min-ls-interval", config_ospfv3_min_ls_interval),
             (
                 "/default-information/originate",
                 config_ospfv3_default_originate,
@@ -787,6 +788,21 @@ fn config_ospfv3_spf_maximum_wait(
 ) -> Option<()> {
     let default = super::inst::SpfIntervalConfig::default().maximum_wait_ms;
     ospf.spf_interval.maximum_wait_ms = if op.is_set() { args.u32()? } else { default };
+    Some(())
+}
+
+// `/router/ospfv3/min-ls-interval` — v6 sibling of the v2 handler.
+fn config_ospfv3_min_ls_interval(
+    ospf: &mut Ospf<Ospfv3>,
+    mut args: Args,
+    op: ConfigOp,
+) -> Option<()> {
+    let value = if op.is_set() {
+        args.u32()?
+    } else {
+        super::inst::OSPF_MIN_LS_INTERVAL_MS
+    };
+    ospf.min_ls_interval_ms = value;
     Some(())
 }
 

--- a/zebra-rs/src/ospf/inst.rs
+++ b/zebra-rs/src/ospf/inst.rs
@@ -97,6 +97,45 @@ impl Default for SpfIntervalConfig {
     }
 }
 
+/// RFC 2328 §12.4 MinLSInterval default (FRR `timers throttle lsa all`
+/// default; ms). The minimum spacing between two originations of the
+/// same self-LSA.
+pub const OSPF_MIN_LS_INTERVAL_MS: u32 = 5000;
+
+/// Identifies a self-originated LSA for the MinLSInterval throttle, so
+/// a deferred re-origination knows which originator to re-run. One
+/// entry per distinct self-LSA the throttle covers (the topology-churn
+/// LSAs — Router-LSA and the per-interface Network-LSA); summaries /
+/// externals re-originate on route changes and are diff-gated, so they
+/// don't storm and aren't tracked here.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub enum LsaGenKey {
+    /// The router's own Router-LSA(s) — regenerated for every attached
+    /// area in a single pass, so one key covers them all.
+    Router,
+    /// The Network-LSA this router originates as DR on `ifindex`.
+    Network(u32),
+}
+
+/// Per-self-LSA MinLSInterval throttle state (RFC 2328 §12.4): hold a
+/// self-LSA back if it was originated less than `min_ls_interval` ago,
+/// coalescing the burst of triggers into one deferred origination.
+#[derive(Default)]
+struct LsaGenState {
+    /// When this LSA was last actually originated. `None` until the
+    /// first origination, which is never throttled.
+    last_originate: Option<tokio::time::Instant>,
+    /// Armed while a throttled re-origination waits out the interval;
+    /// fires `Message::LsaGenFire(key)`. Held so `Drop` doesn't cancel
+    /// it before it fires.
+    timer: Option<Timer>,
+    /// Highest sequence floor demanded by any request coalesced into
+    /// the current deferral window (Router-LSA seq reclaim, RFC 2328
+    /// §13.4). Folded as `max`; consumed when the LSA finally
+    /// originates.
+    pending_min_seq: Option<u32>,
+}
+
 pub struct Ospf<V: OspfVersion = Ospfv2> {
     pub tx: UnboundedSender<Message<V>>,
     pub rx: UnboundedReceiver<Message<V>>,
@@ -277,6 +316,13 @@ pub struct Ospf<V: OspfVersion = Ospfv2> {
     /// *state* is per-area (`OspfArea::spf_throttle`); this holds the
     /// configured bounds fed into it each time a run is scheduled.
     pub spf_interval: SpfIntervalConfig,
+    /// RFC 2328 §12.4 MinLSInterval, ms (`timers throttle lsa all`):
+    /// the minimum spacing between two originations of the same
+    /// self-LSA. Default [`OSPF_MIN_LS_INTERVAL_MS`].
+    pub min_ls_interval_ms: u32,
+    /// Per-self-LSA MinLSInterval throttle state, keyed by
+    /// [`LsaGenKey`]. Runtime-only (not checkpointed / inherited).
+    lsa_gen: std::collections::HashMap<LsaGenKey, LsaGenState>,
     /// RFC 3623 §2 restarting-router state. `Some` once
     /// `gr_restart_begin` floods Grace LSAs and stages the
     /// restart; `None` in steady state. While `Some`, the
@@ -1210,6 +1256,61 @@ impl<V: OspfVersion> Ospf<V> {
             area.spf_timer = Some(Self::ospf_spf_timer_generic(tx, area.id, wait_ms as u64));
         }
     }
+
+    /// MinLSInterval gate (RFC 2328 §12.4) for self-LSA `key`. Folds
+    /// `min_seq` into the pending sequence floor, then either returns
+    /// `true` — clear to originate now, recording the time — or, if
+    /// this LSA was originated less than `min_ls_interval` ago, arms a
+    /// deferred `LsaGenFire(key)` timer and returns `false`. Idempotent
+    /// while a deferral is pending: further calls only fold the seq
+    /// floor, so a burst of triggers collapses to one origination.
+    fn lsa_gen_allow(&mut self, key: LsaGenKey, min_seq: Option<u32>) -> bool {
+        let interval = std::time::Duration::from_millis(self.min_ls_interval_ms as u64);
+        let tx = self.tx.clone();
+        let entry = self.lsa_gen.entry(key).or_default();
+        entry.pending_min_seq = match (entry.pending_min_seq, min_seq) {
+            (Some(a), Some(b)) => Some(a.max(b)),
+            (a, None) => a,
+            (None, b) => b,
+        };
+        if let Some(last) = entry.last_originate {
+            let elapsed = last.elapsed();
+            if elapsed < interval {
+                if entry.timer.is_none() {
+                    let remaining_ms = (interval - elapsed).as_millis().max(1) as u64;
+                    entry.timer = Some(Timer::once_ms(remaining_ms, move || {
+                        let tx = tx.clone();
+                        async move {
+                            let _ = tx.send(Message::LsaGenFire(key));
+                        }
+                    }));
+                }
+                return false;
+            }
+        }
+        entry.last_originate = Some(tokio::time::Instant::now());
+        entry.timer = None;
+        true
+    }
+
+    /// Consume the folded pending sequence floor for `key` after a
+    /// successful `lsa_gen_allow` (or a fire), so the origination bumps
+    /// past the highest seq any coalesced request demanded.
+    fn lsa_gen_take_pending(&mut self, key: LsaGenKey) -> Option<u32> {
+        self.lsa_gen
+            .get_mut(&key)
+            .and_then(|e| e.pending_min_seq.take())
+    }
+
+    /// A `LsaGenFire` deferral window elapsed: clear the (already-fired)
+    /// timer, stamp the new origination time, and return the folded
+    /// seq floor. The caller re-runs the matching `*_now` originator.
+    fn lsa_gen_fire_prepare(&mut self, key: LsaGenKey) -> Option<u32> {
+        let entry = self.lsa_gen.entry(key).or_default();
+        entry.timer = None;
+        entry.last_originate = Some(tokio::time::Instant::now());
+        entry.pending_min_seq.take()
+    }
 }
 
 impl Ospf<Ospfv2> {
@@ -1291,6 +1392,8 @@ impl Ospf<Ospfv2> {
             sr_rx,
             gr_config: super::neigh::GracefulRestartConfig::default(),
             spf_interval: SpfIntervalConfig::default(),
+            min_ls_interval_ms: OSPF_MIN_LS_INTERVAL_MS,
+            lsa_gen: std::collections::HashMap::new(),
             restarting: None,
             key_chains: BTreeMap::new(),
             policy_tx,
@@ -1655,6 +1758,21 @@ impl Ospf<Ospfv2> {
         // `gr_helper_check_exit`. Skip; the exit-restart path
         // re-originates at seq+1 once we declare the restart
         // complete.
+        if self.in_restart() {
+            return;
+        }
+        // MinLSInterval (RFC 2328 §12.4): if we originated a Router-LSA
+        // less than `min_ls_interval` ago, defer — the throttle arms a
+        // `LsaGenFire(Router)` timer and folds `min_seq` for the
+        // coalesced run.
+        if !self.lsa_gen_allow(LsaGenKey::Router, min_seq) {
+            return;
+        }
+        let min_seq = self.lsa_gen_take_pending(LsaGenKey::Router);
+        self.router_lsa_originate_now(min_seq);
+    }
+
+    fn router_lsa_originate_now(&mut self, min_seq: Option<u32>) {
         if self.in_restart() {
             return;
         }
@@ -3662,6 +3780,18 @@ impl Ospf<Ospfv2> {
     /// Network-LSA per RFC 2328 §14.1) does not fire while a
     /// helper-mode neighbor remains.
     fn update_network_lsa_by_interface(&mut self, ifindex: u32) {
+        if self.in_restart() {
+            return;
+        }
+        // MinLSInterval (RFC 2328 §12.4): coalesce rapid Network-LSA
+        // regenerations (DR neighbor churn) on this interface.
+        if !self.lsa_gen_allow(LsaGenKey::Network(ifindex), None) {
+            return;
+        }
+        self.update_network_lsa_by_interface_now(ifindex);
+    }
+
+    fn update_network_lsa_by_interface_now(&mut self, ifindex: u32) {
         // Network-LSA is topology-affecting, so the checkpoint-loaded
         // copy stays verbatim during restart. The exit-restart path
         // re-emits at seq+1 once adjacencies re-converge.
@@ -4377,9 +4507,12 @@ impl Ospf<Ospfv2> {
         // `update_network_lsa_by_interface` /
         // `ext_link_lsa_originate` per DR-eligible link. The
         // `in_restart()` gates were lifted by the take() above.
-        self.router_lsa_originate();
+        // GR exit must originate promptly (helpers are waiting on the
+        // fresh-seq LSA before dropping helper mode), so bypass the
+        // MinLSInterval throttle via the `_now` originators.
+        self.router_lsa_originate_now(None);
         for ifindex in &ifindices {
-            self.update_network_lsa_by_interface(*ifindex);
+            self.update_network_lsa_by_interface_now(*ifindex);
             self.ext_link_lsa_originate(*ifindex);
         }
         // Router-Info refresh clears the gr_capable bit.
@@ -5405,6 +5538,18 @@ impl Ospf<Ospfv2> {
             Message::NssaTranslateResync(area_id) => {
                 self.nssa_translate_resync(area_id);
             }
+            Message::LsaGenFire(key) => {
+                // MinLSInterval deferral elapsed — clear the timer,
+                // stamp the origination, and re-run the matching
+                // originator with the folded seq floor.
+                let min_seq = self.lsa_gen_fire_prepare(key);
+                match key {
+                    LsaGenKey::Router => self.router_lsa_originate_now(min_seq),
+                    LsaGenKey::Network(ifindex) => {
+                        self.update_network_lsa_by_interface_now(ifindex)
+                    }
+                }
+            }
             _ => {}
         }
     }
@@ -5676,6 +5821,8 @@ impl Ospf<Ospfv3> {
             sr_rx,
             gr_config: super::neigh::GracefulRestartConfig::default(),
             spf_interval: SpfIntervalConfig::default(),
+            min_ls_interval_ms: OSPF_MIN_LS_INTERVAL_MS,
+            lsa_gen: std::collections::HashMap::new(),
             restarting: None,
             key_chains: BTreeMap::new(),
             policy_tx,
@@ -6551,6 +6698,19 @@ impl Ospf<Ospfv3> {
     /// - After install, flood the LSA to every Exchange-or-later
     ///   neighbor in the area via `flood_self_originated_lsa`.
     pub fn router_lsa_originate(&mut self) {
+        if self.in_restart() {
+            return;
+        }
+        // MinLSInterval (RFC 2328 §12.4 / RFC 5340): coalesce rapid
+        // Router-LSA regenerations. v3 manages its own seq internally,
+        // so no seq floor to fold.
+        if !self.lsa_gen_allow(LsaGenKey::Router, None) {
+            return;
+        }
+        self.router_lsa_originate_now();
+    }
+
+    fn router_lsa_originate_now(&mut self) {
         if self.in_restart() {
             return;
         }
@@ -7833,14 +7993,16 @@ impl Ospf<Ospfv3> {
         // Re-originate at seq+1. Router-LSA covers topology; the
         // per-area Intra-Area-Prefix and per-link Link/Network/
         // E-Intra-Area-Prefix LSAs cover addressing and SR.
-        self.router_lsa_originate();
+        // Bypass the MinLSInterval throttle (`_now`) — GR exit must
+        // flood the fresh-seq LSAs promptly so helpers drop helper mode.
+        self.router_lsa_originate_now();
         let area_ids: Vec<Ipv4Addr> = self.areas.iter().map(|(id, _)| *id).collect();
         for area_id in area_ids {
             self.router_intra_area_prefix_lsa_originate(area_id);
         }
         for ifindex in &ifindices {
             self.link_lsa_originate(*ifindex);
-            self.network_lsa_originate(*ifindex);
+            self.network_lsa_originate_now(*ifindex);
             self.ext_intra_area_prefix_v3_lsa_originate(*ifindex);
         }
 
@@ -8971,6 +9133,16 @@ impl Ospf<Ospfv3> {
             }
             Message::NssaTranslateResync(area_id) => {
                 self.nssa_translate_resync(area_id);
+            }
+            Message::LsaGenFire(key) => {
+                // MinLSInterval deferral elapsed — re-run the matching
+                // v3 originator (seq is managed internally, so the
+                // folded floor is unused here).
+                let _ = self.lsa_gen_fire_prepare(key);
+                match key {
+                    LsaGenKey::Router => self.router_lsa_originate_now(),
+                    LsaGenKey::Network(ifindex) => self.network_lsa_originate_now(ifindex),
+                }
             }
             other => {
                 tracing::debug!(
@@ -10192,6 +10364,18 @@ impl Ospf<Ospfv3> {
         if self.in_restart() {
             return;
         }
+        // MinLSInterval (RFC 2328 §12.4): coalesce Network-LSA churn on
+        // this interface.
+        if !self.lsa_gen_allow(LsaGenKey::Network(ifindex), None) {
+            return;
+        }
+        self.network_lsa_originate_now(ifindex);
+    }
+
+    fn network_lsa_originate_now(&mut self, ifindex: u32) {
+        if self.in_restart() {
+            return;
+        }
         use ospf_packet::OSPFV3_NETWORK_LSA_TYPE;
 
         let Some(link) = self.links.get(&ifindex) else {
@@ -10750,6 +10934,9 @@ pub enum Message<V: OspfVersion = Ospfv2> {
     /// changed. The handler is idempotent; multiple coalescing
     /// triggers in flight is fine.
     NssaTranslateResync(Ipv4Addr),
+    /// A MinLSInterval deferral window elapsed — re-originate the
+    /// self-LSA identified by the key now (RFC 2328 §12.4).
+    LsaGenFire(LsaGenKey),
 }
 
 use crate::spf::{self, Path};

--- a/zebra-rs/src/ospf/show.rs
+++ b/zebra-rs/src/ospf/show.rs
@@ -580,6 +580,11 @@ fn show_ospf(ospf: &Ospf, _args: Args, json: bool) -> std::result::Result<String
         ospf.spf_interval.secondary_wait_ms,
         ospf.spf_interval.maximum_wait_ms,
     )?;
+    writeln!(
+        buf,
+        " MinLSInterval (self-LSA re-origination): {} ms",
+        ospf.min_ls_interval_ms,
+    )?;
     // TI-LFA compute telemetry for the same run (last-area-wins, like
     // `spf_duration`). None while TI-LFA is disabled.
     if let Some(stats) = &ospf.tilfa_stats {

--- a/zebra-rs/src/ospf/show_v3.rs
+++ b/zebra-rs/src/ospf/show_v3.rs
@@ -425,6 +425,8 @@ struct Ospfv3SummaryJson {
     spf_initial_wait_ms: u32,
     spf_secondary_wait_ms: u32,
     spf_maximum_wait_ms: u32,
+    /// RFC 2328 §12.4 MinLSInterval (`min-ls-interval`), ms.
+    min_ls_interval_ms: u32,
     /// TI-LFA compute telemetry for the most-recent run, preformatted
     /// (`targets=… mode=… workers=… spf{…} took … us`). None until
     /// TI-LFA runs (and cleared when it is disabled).
@@ -456,6 +458,7 @@ fn show_ospfv3_summary(
         link_count: top.links.len(),
         spf_last_ms_ago: top.spf_last.map(|t| t.elapsed().as_millis()),
         spf_duration_us: top.spf_duration.map(|d| d.as_micros()),
+        min_ls_interval_ms: top.min_ls_interval_ms,
         spf_initial_wait_ms: top.spf_interval.initial_wait_ms,
         spf_secondary_wait_ms: top.spf_interval.secondary_wait_ms,
         spf_maximum_wait_ms: top.spf_interval.maximum_wait_ms,
@@ -489,6 +492,7 @@ fn show_ospfv3_summary(
         "  SPF timers:   initial {} ms, secondary {} ms, maximum {} ms",
         summary.spf_initial_wait_ms, summary.spf_secondary_wait_ms, summary.spf_maximum_wait_ms,
     )?;
+    writeln!(text, "  MinLSInterval: {} ms", summary.min_ls_interval_ms,)?;
     if let Some(tilfa) = &summary.tilfa_compute {
         writeln!(text, "  TI-LFA compute: {}", tilfa)?;
     }

--- a/zebra-rs/yang/config.yang
+++ b/zebra-rs/yang/config.yang
@@ -1140,6 +1140,21 @@ module config {
           }
         }
 
+        leaf min-ls-interval {
+          ext:help "Minimum interval between re-originations of a self-LSA (MinLSInterval)";
+          // RFC 2328 §12.4 MinLSInterval (FRR `timers throttle lsa
+          // all`): the minimum spacing between two originations of the
+          // same self-LSA. A re-origination requested sooner is
+          // deferred to the interval boundary, coalescing a burst of
+          // topology changes into one Router-LSA / Network-LSA update.
+          // Default 5000ms per the RFC.
+          type uint32 {
+            range "0..5000";
+          }
+          units "milliseconds";
+          default 5000;
+        }
+
         container spf-interval {
           ext:help "SPF calculation throttle timers";
           // Adaptive IOS-XR-style exponential hold-down, replacing the
@@ -1461,6 +1476,15 @@ module config {
             units "milliseconds";
             default 200;
           }
+        }
+        // MinLSInterval — v6 sibling of the v2 min-ls-interval leaf.
+        leaf min-ls-interval {
+          ext:help "Minimum interval between re-originations of a self-LSA (MinLSInterval)";
+          type uint32 {
+            range "0..5000";
+          }
+          units "milliseconds";
+          default 5000;
         }
         // Adaptive SPF throttle — v6 sibling of the v2 spf-interval
         // block. Same IOS-XR backoff and 50/200/5000ms defaults.


### PR DESCRIPTION
## Summary

zebra-rs re-originated self-LSAs **immediately** on every trigger, with no rate limit — both an RFC 2328 §12.4 conformance gap (MinLSInterval) and the FRR `timers throttle lsa all` gap. A flapping link could storm the area with Router-LSA re-originations.

This adds the **send-side MinLSInterval** hold-down (default 5000 ms, the RFC/FRR default) for **OSPFv2 and OSPFv3**: a self-LSA may re-originate at most once per interval; a re-origination requested sooner is deferred to the interval boundary, coalescing a burst of triggers into one update.

### Mechanism
A generic keyed throttle (`LsaGenKey` / `LsaGenState` + a `Message::LsaGenFire` deferral timer) wired at the origination **front door**, so existing call sites (22+ for Router-LSA) are unchanged:
- `router_lsa_originate` / `update_network_lsa_by_interface` (v2) and `router_lsa_originate` / `network_lsa_originate` (v3) gate through the throttle; the actual work moves to `*_now` bodies the fire handler re-runs.
- The Router-LSA sequence floor (§13.4 seq reclaim) is folded across a deferral as `max`.

### Scope & safety
- Covers the **topology-churn** LSAs — Router-LSA and the per-interface Network-LSA. Summary / AS-External LSAs re-originate only on route changes and are already diff-gated, so they don't storm.
- **Graceful-restart exit bypasses the throttle** (via the `_now` originators) so helpers see the fresh-seq LSA promptly.
- Config `min-ls-interval` (ms) under `router ospf` / `router ospfv3`; `show ospf` / `show ospfv3` surface it. The receive-side MinLSArrival (RFC 2328 §13) is already enforced (fixed 1 s) and left as a separate future knob.

## FRR reference
Verified against local FRR source: `timers throttle lsa all (0-5000)` → `min_ls_interval` (default 5000 ms). `all` is the only variant (no per-type). ospf6d has no such command, so **v3 here goes beyond FRR**.

## Test plan
- Full `cargo test`: **1514 passed**; yang-load clean.
- `ospfv2_area_range` converges under the default 5 s throttle (no regression).
- New **`ospfv2_min_ls_interval` BDD**: a non-default `min-ls-interval` is applied (confirmed via `show ospf`), adjacency forms, routes converge, ping succeeds. Passes locally.
- `cargo fmt`, workspace clippy, `mdbook build` clean.

## Docs
`min-ls-interval` documented on the Timer Configuration page; the LSA-generation-throttle gap moved to "closed" for v2 and v3. The remaining LSA gap (configurable receive-side MinLSArrival) is called out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)