### PR TITLE
feat(ospf): configurable MinLSArrival (min-ls-arrival) v2 + v3

### DIFF
--- a/bdd/tests/configs/ospfv2_min_ls_arrival/a.yaml
+++ b/bdd/tests/configs/ospfv2_min_ls_arrival/a.yaml
@@ -1,0 +1,21 @@
+interface:
+- if-name: lo
+  ipv4:
+    address: 10.0.0.1/32
+- if-name: ethb
+  ipv4:
+    address: 10.0.12.1/30
+router:
+  ospf:
+    router-id: 10.0.0.1
+    # Non-default MinLSArrival (RFC 2328 §13), surfaced by `show ospf`
+    # so the BDD can confirm it reached the instance.
+    min-ls-arrival: 2000
+    area:
+    - area-id: 0.0.0.0
+      interface:
+      - if-name: lo
+        enable: true
+      - if-name: ethb
+        enable: true
+        network-type: point-to-point

--- a/bdd/tests/configs/ospfv2_min_ls_arrival/b.yaml
+++ b/bdd/tests/configs/ospfv2_min_ls_arrival/b.yaml
@@ -1,0 +1,19 @@
+interface:
+- if-name: lo
+  ipv4:
+    address: 10.0.0.2/32
+- if-name: etha
+  ipv4:
+    address: 10.0.12.2/30
+router:
+  ospf:
+    router-id: 10.0.0.2
+    min-ls-arrival: 2000
+    area:
+    - area-id: 0.0.0.0
+      interface:
+      - if-name: lo
+        enable: true
+      - if-name: etha
+        enable: true
+        network-type: point-to-point

--- a/bdd/tests/features/ospfv2_min_ls_arrival.feature
+++ b/bdd/tests/features/ospfv2_min_ls_arrival.feature
@@ -1,0 +1,43 @@
+@serial
+@ospfv2_min_ls_arrival
+Feature: OSPFv2 MinLSArrival received-LSA rate limit is configurable
+  As a network operator
+  I want `router ospf min-ls-arrival` to set the receive-side rate
+  limit (RFC 2328 §13 MinLSArrival, FRR `timers lsa min-arrival`) —
+  a flooded LSA instance arriving less than that after the last
+  accepted copy is discarded without acknowledgement — so I can tune
+  it away from the fixed 1 s default while the topology still
+  converges.
+
+  Test Topology:
+  ```
+    a (10.0.0.1) -- 10.0.12.0/30 -- b (10.0.0.2)
+    both routers set min-ls-arrival 2000 ms.
+  ```
+
+  Scenario: Configured MinLSArrival is applied and the topology still converges
+    Given a clean test environment
+    When I create namespace "a"
+    And I create namespace "b"
+    And I connect namespace "a" interface "ethb" to namespace "b" interface "etha"
+    And I start zebra-rs in namespace "a"
+    And I start zebra-rs in namespace "b"
+    And I apply config "a.yaml" to namespace "a"
+    And I apply config "b.yaml" to namespace "b"
+    And I wait 20 seconds
+
+    # The configured (non-default) MinLSArrival is surfaced verbatim by
+    # `show ospf`, proving the config reached the instance.
+    Then show command "show ospf" in namespace "a" should contain "MinLSArrival (received-LSA rate limit): 2000 ms"
+    # Adjacency forms and routes converge under the configured limit.
+    And show command "show ospf neighbor" in namespace "a" should contain "Full"
+    And show command "show ospf neighbor" in namespace "b" should contain "Full"
+    And show command "show ospf route" in namespace "a" should contain "10.0.0.2/32"
+    And ping from "a" to "10.0.0.2" should succeed
+
+    # Teardown.
+    When I stop zebra-rs in namespace "a"
+    And I stop zebra-rs in namespace "b"
+    And I delete namespace "a"
+    And I delete namespace "b"
+    Then the test environment should be clean

--- a/book/src/ch-08-08-ospf-timers.md
+++ b/book/src/ch-08-08-ospf-timers.md
@@ -101,6 +101,29 @@ promptly, bypassing the throttle.
 
 `show ospf` reports the value (`MinLSInterval (self-LSA
 re-origination): … ms`); OSPFv3 exposes the identical
-`min-ls-interval` leaf under `router ospfv3`. The companion
-receive-side limit (RFC 2328 §13 MinLSArrival) is fixed at 1 s and
-not yet configurable.
+`min-ls-interval` leaf under `router ospfv3`.
+
+## MinLSArrival (`min-ls-arrival`)
+
+The receive-side companion — RFC 2328 §13 MinLSArrival, FRR's
+`timers lsa min-arrival`:
+
+```
+router ospf {
+  min-ls-arrival 1000;
+}
+```
+
+| YANG leaf (`/router/ospf[v3]/min-ls-arrival`) | Default | Range | Units |
+|---|---|---|---|
+| `min-ls-arrival` | 1000 | 0..600000 | milliseconds |
+
+A flooded instance of an LSA that arrives less than `min-ls-arrival`
+after the last accepted copy is **discarded without acknowledgement**
+(RFC 2328 §13 step 5a) — the neighbor's retransmit timer redelivers
+the genuinely newer instance once the window passes. This damps a
+neighbor that floods the same LSA in a tight loop. The gate is
+skipped for self-originated LSAs so the §13.4 seq-reclaim path can
+still fire. `show ospf` reports the value (`MinLSArrival (received-LSA
+rate limit): … ms`); OSPFv3 exposes the identical `min-ls-arrival`
+leaf under `router ospfv3`.

--- a/book/src/ch-08-12-ospf-frr-gaps.md
+++ b/book/src/ch-08-12-ospf-frr-gaps.md
@@ -13,10 +13,6 @@ OSPFv2 features not yet implemented in zebra-rs:
   Type-7 LSAs carrying a non-zero forwarding address are skipped
   (RFC 2328 §16.4 step 3); zebra-rs itself always originates with
   FA 0.0.0.0.
-- Configurable **MinLSArrival** (`timers lsa min-arrival`, RFC 2328
-  §13) — the receive-side per-LSA rate limit is enforced but fixed at
-  1 s. (The send-side MinLSInterval / `timers throttle lsa all` *is*
-  configurable — see below.)
 
 ## Previously listed gaps that are now closed
 
@@ -66,3 +62,7 @@ per feature — see each feature's page):
   rate-limited (Router-LSA and Network-LSA coalesce a burst of
   topology changes into one update), configurable for both OSPFv2 and
   OSPFv3. See [Timer Configuration](ch-08-08-ospf-timers.md).
+- **Configurable MinLSArrival** (`min-ls-arrival`, RFC 2328 §13 /
+  FRR `timers lsa min-arrival`) — the receive-side per-LSA rate limit
+  was already enforced but fixed at 1 s; it is now tunable for both
+  OSPFv2 and OSPFv3. See [Timer Configuration](ch-08-08-ospf-timers.md).

--- a/book/src/ch-15-15-ospfv3-frr-gaps.md
+++ b/book/src/ch-15-15-ospfv3-frr-gaps.md
@@ -8,12 +8,13 @@ OSPFv3 features not yet implemented in zebra-rs:
 - NBMA and point-to-multipoint network types.
 - Configurable Instance ID (always 0 — one instance per link).
 
-The adaptive SPF throttle (`spf-interval`) and the send-side
-MinLSInterval (`min-ls-interval`) are both configurable for OSPFv3,
-identical to v2 — see
-[Timer Configuration](ch-08-08-ospf-timers.md). MinLSInterval on v3
-actually goes beyond `ospf6d`, which has no `timers throttle lsa`
-command at all (only the receive-side `timers lsa min-arrival`).
+The adaptive SPF throttle (`spf-interval`), the send-side
+MinLSInterval (`min-ls-interval`), and the receive-side MinLSArrival
+(`min-ls-arrival`) are all configurable for OSPFv3, identical to v2 —
+see [Timer Configuration](ch-08-08-ospf-timers.md). MinLSInterval on
+v3 actually goes beyond `ospf6d`, which has no `timers throttle lsa`
+command at all (only the receive-side `timers lsa min-arrival`, which
+zebra-rs also exposes).
 
 The balance runs the other way for Segment Routing: zebra-rs
 OSPFv3 implements SR-MPLS (RFC 8666), SRv6 (RFC 9513), TI-LFA

--- a/zebra-rs/src/ospf/config.rs
+++ b/zebra-rs/src/ospf/config.rs
@@ -314,6 +314,7 @@ impl Ospf {
         );
         self.ospf_add("/spf-interval/maximum-wait", config_ospf_spf_maximum_wait);
         self.ospf_add("/min-ls-interval", config_ospf_min_ls_interval);
+        self.ospf_add("/min-ls-arrival", config_ospf_min_ls_arrival);
         // `/router/ospf/tracing/...` is handled by the subtree dispatcher
         // `super::tracing::config_tracing_dispatch` (called from
         // `process_cm_msg` for paths this callback table does not claim),
@@ -2154,6 +2155,19 @@ fn config_ospf_min_ls_interval(ospf: &mut Ospf, mut args: Args, op: ConfigOp) ->
         super::inst::OSPF_MIN_LS_INTERVAL_MS
     };
     ospf.min_ls_interval_ms = value;
+    Some(())
+}
+
+// `/router/ospf/min-ls-arrival` — RFC 2328 §13 MinLSArrival (ms).
+// Receive-side rate limit; applies to LSAs received after the change.
+// Delete restores the RFC/FRR default.
+fn config_ospf_min_ls_arrival(ospf: &mut Ospf, mut args: Args, op: ConfigOp) -> Option<()> {
+    let value = if op.is_set() {
+        args.u32()?
+    } else {
+        super::inst::OSPF_MIN_LS_ARRIVAL_MS
+    };
+    ospf.min_ls_arrival_ms = value;
     Some(())
 }
 

--- a/zebra-rs/src/ospf/config_v3.rs
+++ b/zebra-rs/src/ospf/config_v3.rs
@@ -89,6 +89,7 @@ impl Ospf<Ospfv3> {
             ),
             ("/spf-interval/maximum-wait", config_ospfv3_spf_maximum_wait),
             ("/min-ls-interval", config_ospfv3_min_ls_interval),
+            ("/min-ls-arrival", config_ospfv3_min_ls_arrival),
             (
                 "/default-information/originate",
                 config_ospfv3_default_originate,
@@ -803,6 +804,21 @@ fn config_ospfv3_min_ls_interval(
         super::inst::OSPF_MIN_LS_INTERVAL_MS
     };
     ospf.min_ls_interval_ms = value;
+    Some(())
+}
+
+// `/router/ospfv3/min-ls-arrival` — v6 sibling of the v2 handler.
+fn config_ospfv3_min_ls_arrival(
+    ospf: &mut Ospf<Ospfv3>,
+    mut args: Args,
+    op: ConfigOp,
+) -> Option<()> {
+    let value = if op.is_set() {
+        args.u32()?
+    } else {
+        super::inst::OSPF_MIN_LS_ARRIVAL_MS
+    };
+    ospf.min_ls_arrival_ms = value;
     Some(())
 }
 

--- a/zebra-rs/src/ospf/inst.rs
+++ b/zebra-rs/src/ospf/inst.rs
@@ -102,6 +102,11 @@ impl Default for SpfIntervalConfig {
 /// same self-LSA.
 pub const OSPF_MIN_LS_INTERVAL_MS: u32 = 5000;
 
+/// RFC 2328 §13 MinLSArrival default (FRR `timers lsa min-arrival`
+/// default; ms). The minimum spacing between two accepted flooded
+/// copies of the same LSA.
+pub const OSPF_MIN_LS_ARRIVAL_MS: u32 = 1000;
+
 /// Identifies a self-originated LSA for the MinLSInterval throttle, so
 /// a deferred re-origination knows which originator to re-run. One
 /// entry per distinct self-LSA the throttle covers (the topology-churn
@@ -320,6 +325,11 @@ pub struct Ospf<V: OspfVersion = Ospfv2> {
     /// the minimum spacing between two originations of the same
     /// self-LSA. Default [`OSPF_MIN_LS_INTERVAL_MS`].
     pub min_ls_interval_ms: u32,
+    /// RFC 2328 §13 MinLSArrival, ms (`timers lsa min-arrival`): the
+    /// receive-side per-LSA rate limit — a flooded instance arriving
+    /// less than this after the last accepted copy is discarded
+    /// without acknowledgement. Default [`OSPF_MIN_LS_ARRIVAL_MS`].
+    pub min_ls_arrival_ms: u32,
     /// Per-self-LSA MinLSInterval throttle state, keyed by
     /// [`LsaGenKey`]. Runtime-only (not checkpointed / inherited).
     lsa_gen: std::collections::HashMap<LsaGenKey, LsaGenState>,
@@ -519,6 +529,10 @@ pub struct OspfInterface<'a, V: OspfVersion = Ospfv2> {
     /// policy. Read by `gr_maybe_enter_helper` to gate Grace-LSA
     /// acceptance against `helper_enabled` and `max_grace_period`.
     pub gr_config: super::neigh::GracefulRestartConfig,
+    /// RFC 2328 §13 MinLSArrival, ms (`timers lsa min-arrival`): the
+    /// receive-side per-LSA rate limit, read by `ospf_ls_upd_proc`.
+    /// Snapshot of the instance's `min_ls_arrival_ms`.
+    pub min_ls_arrival_ms: u32,
     pub tracing: &'a OspfTracing,
     /// v3-only outbound packet channel borrow. Carries the `Ospfv3Send`
     /// sender that the `network_v6::write_packet_v6` task consumes.
@@ -1087,6 +1101,7 @@ impl<V: OspfVersion> Ospf<V> {
                             crypto_key,
                             md5_seq: &link.md5_seq,
                             gr_config: self.gr_config,
+                            min_ls_arrival_ms: self.min_ls_arrival_ms,
                             tracing: &self.tracing,
                             v3_send_tx: self.v3_send_tx.as_ref(),
                             link_lsdb: &mut link.lsdb,
@@ -1393,6 +1408,7 @@ impl Ospf<Ospfv2> {
             gr_config: super::neigh::GracefulRestartConfig::default(),
             spf_interval: SpfIntervalConfig::default(),
             min_ls_interval_ms: OSPF_MIN_LS_INTERVAL_MS,
+            min_ls_arrival_ms: OSPF_MIN_LS_ARRIVAL_MS,
             lsa_gen: std::collections::HashMap::new(),
             restarting: None,
             key_chains: BTreeMap::new(),
@@ -5822,6 +5838,7 @@ impl Ospf<Ospfv3> {
             gr_config: super::neigh::GracefulRestartConfig::default(),
             spf_interval: SpfIntervalConfig::default(),
             min_ls_interval_ms: OSPF_MIN_LS_INTERVAL_MS,
+            min_ls_arrival_ms: OSPF_MIN_LS_ARRIVAL_MS,
             lsa_gen: std::collections::HashMap::new(),
             restarting: None,
             key_chains: BTreeMap::new(),

--- a/zebra-rs/src/ospf/lsdb.rs
+++ b/zebra-rs/src/ospf/lsdb.rs
@@ -16,7 +16,8 @@ pub const OSPF_MAX_AGE: u16 = 3600;
 pub const OSPF_MAX_AGE_DIFF: u16 = 900; // 15 minutes (RFC 2328 Section 13.1)
 pub const OSPF_LS_REFRESH_TIME: u64 = 1800;
 pub const OSPF_MAX_LSA_SEQ: u32 = 0x7FFFFFFF;
-pub const OSPF_MIN_LS_ARRIVAL: u64 = 1; // 1 second (RFC 2328)
+// MinLSArrival (RFC 2328 §13) is now configurable per instance —
+// see `Ospf::min_ls_arrival_ms` / `OSPF_MIN_LS_ARRIVAL_MS`.
 
 /// Signed-aware max for LS Sequence Numbers. RFC 2328 §13.1 /
 /// §A.4.1 treats `ls_seq_number` as a SIGNED 32-bit integer —

--- a/zebra-rs/src/ospf/packet.rs
+++ b/zebra-rs/src/ospf/packet.rs
@@ -16,9 +16,8 @@ use crate::{
 use super::{
     FloodScope, Identity, IfsmEvent, IfsmState, Message, Neighbor, NfsmEvent, NfsmState, OspfLink,
     inst::OspfInterface, link::OspfAuthMode, lsa_flood_scope, lsdb::OSPF_MAX_AGE,
-    lsdb::OSPF_MAX_AGE_DIFF, lsdb::OSPF_MAX_LSA_SEQ, lsdb::OSPF_MIN_LS_ARRIVAL, ospf_flood,
-    ospf_flood_self_originated_lsa, ospf_is_self_originated, ospf_ls_request_lookup,
-    tracing::OspfTracing,
+    lsdb::OSPF_MAX_AGE_DIFF, lsdb::OSPF_MAX_LSA_SEQ, ospf_flood, ospf_flood_self_originated_lsa,
+    ospf_is_self_originated, ospf_ls_request_lookup, tracing::OspfTracing,
 };
 
 /// Resolved authentication state for a single outbound packet.
@@ -1079,7 +1078,8 @@ fn ospf_ls_upd_proc(oi: &mut OspfInterface, nbr: &mut Neighbor, lsa: &OspfLsa) -
         // never catch up to a high-seq pre-restart LSA the neighbors
         // still hold — especially one carrying DO_NOT_AGE).
         if let Some(install_time) = current_install_time
-            && install_time.elapsed() < std::time::Duration::from_secs(OSPF_MIN_LS_ARRIVAL)
+            && install_time.elapsed()
+                < std::time::Duration::from_millis(oi.min_ls_arrival_ms as u64)
             && !ospf_is_self_originated(oi, lsa)
         {
             tracing::debug!(
@@ -1175,7 +1175,7 @@ fn ospf_ls_upd_proc(oi: &mut OspfInterface, nbr: &mut Neighbor, lsa: &OspfLsa) -
     // send-back per LSDB entry and skip when we're inside the
     // MinLSArrival window.
     if let Some(last) = current_last_flood_out
-        && last.elapsed() < std::time::Duration::from_secs(OSPF_MIN_LS_ARRIVAL)
+        && last.elapsed() < std::time::Duration::from_millis(oi.min_ls_arrival_ms as u64)
     {
         tracing::debug!(
             "[LS Update] DB copy newer but within MinLSArrival, skip send: type={:?} id={} adv={} seq={:#x}",

--- a/zebra-rs/src/ospf/packet_v3.rs
+++ b/zebra-rs/src/ospf/packet_v3.rs
@@ -1358,7 +1358,7 @@ fn ospfv3_ls_upd_proc(
     lsa: &Ospfv3Lsa,
     src: &Ipv6Addr,
 ) -> LsaProcessResult {
-    use super::lsdb::{OSPF_MAX_AGE, OSPF_MAX_LSA_SEQ, OSPF_MIN_LS_ARRIVAL};
+    use super::lsdb::{OSPF_MAX_AGE, OSPF_MAX_LSA_SEQ};
 
     let h = &lsa.h;
     let scope = ospfv3_ls_type_scope(h.ls_type);
@@ -1421,7 +1421,8 @@ fn ospfv3_ls_upd_proc(
         // hold the stale copy until the next refresh. Mirror of
         // v2's `ospf_ls_upd_proc` step 5(a).
         if let Some(install_time) = current_install_time
-            && install_time.elapsed() < std::time::Duration::from_secs(OSPF_MIN_LS_ARRIVAL)
+            && install_time.elapsed()
+                < std::time::Duration::from_millis(oi.min_ls_arrival_ms as u64)
         {
             tracing::info!(
                 "[v3 LSUpd] Step 5(a) MinLSArrival: discarding (no ack) LSA type={:#x} id={} adv={} seq={:#x}",

--- a/zebra-rs/src/ospf/show.rs
+++ b/zebra-rs/src/ospf/show.rs
@@ -585,6 +585,11 @@ fn show_ospf(ospf: &Ospf, _args: Args, json: bool) -> std::result::Result<String
         " MinLSInterval (self-LSA re-origination): {} ms",
         ospf.min_ls_interval_ms,
     )?;
+    writeln!(
+        buf,
+        " MinLSArrival (received-LSA rate limit): {} ms",
+        ospf.min_ls_arrival_ms,
+    )?;
     // TI-LFA compute telemetry for the same run (last-area-wins, like
     // `spf_duration`). None while TI-LFA is disabled.
     if let Some(stats) = &ospf.tilfa_stats {

--- a/zebra-rs/src/ospf/show_v3.rs
+++ b/zebra-rs/src/ospf/show_v3.rs
@@ -427,6 +427,8 @@ struct Ospfv3SummaryJson {
     spf_maximum_wait_ms: u32,
     /// RFC 2328 §12.4 MinLSInterval (`min-ls-interval`), ms.
     min_ls_interval_ms: u32,
+    /// RFC 2328 §13 MinLSArrival (`min-ls-arrival`), ms.
+    min_ls_arrival_ms: u32,
     /// TI-LFA compute telemetry for the most-recent run, preformatted
     /// (`targets=… mode=… workers=… spf{…} took … us`). None until
     /// TI-LFA runs (and cleared when it is disabled).
@@ -459,6 +461,7 @@ fn show_ospfv3_summary(
         spf_last_ms_ago: top.spf_last.map(|t| t.elapsed().as_millis()),
         spf_duration_us: top.spf_duration.map(|d| d.as_micros()),
         min_ls_interval_ms: top.min_ls_interval_ms,
+        min_ls_arrival_ms: top.min_ls_arrival_ms,
         spf_initial_wait_ms: top.spf_interval.initial_wait_ms,
         spf_secondary_wait_ms: top.spf_interval.secondary_wait_ms,
         spf_maximum_wait_ms: top.spf_interval.maximum_wait_ms,
@@ -493,6 +496,7 @@ fn show_ospfv3_summary(
         summary.spf_initial_wait_ms, summary.spf_secondary_wait_ms, summary.spf_maximum_wait_ms,
     )?;
     writeln!(text, "  MinLSInterval: {} ms", summary.min_ls_interval_ms,)?;
+    writeln!(text, "  MinLSArrival: {} ms", summary.min_ls_arrival_ms,)?;
     if let Some(tilfa) = &summary.tilfa_compute {
         writeln!(text, "  TI-LFA compute: {}", tilfa)?;
     }

--- a/zebra-rs/yang/config.yang
+++ b/zebra-rs/yang/config.yang
@@ -1155,6 +1155,19 @@ module config {
           default 5000;
         }
 
+        leaf min-ls-arrival {
+          ext:help "Minimum interval between accepted flooded copies of an LSA (MinLSArrival)";
+          // RFC 2328 §13 MinLSArrival (FRR `timers lsa min-arrival`):
+          // the receive-side rate limit. A flooded instance arriving
+          // less than this after the last accepted copy is discarded
+          // without acknowledgement. Default 1000ms per the RFC.
+          type uint32 {
+            range "0..600000";
+          }
+          units "milliseconds";
+          default 1000;
+        }
+
         container spf-interval {
           ext:help "SPF calculation throttle timers";
           // Adaptive IOS-XR-style exponential hold-down, replacing the
@@ -1485,6 +1498,15 @@ module config {
           }
           units "milliseconds";
           default 5000;
+        }
+        // MinLSArrival — v6 sibling of the v2 min-ls-arrival leaf.
+        leaf min-ls-arrival {
+          ext:help "Minimum interval between accepted flooded copies of an LSA (MinLSArrival)";
+          type uint32 {
+            range "0..600000";
+          }
+          units "milliseconds";
+          default 1000;
         }
         // Adaptive SPF throttle — v6 sibling of the v2 spf-interval
         // block. Same IOS-XR backoff and 50/200/5000ms defaults.


### PR DESCRIPTION
## Summary

The receive-side **MinLSArrival** gate (RFC 2328 §13 step 5a — discard a flooded LSA instance that arrives less than MinLSArrival after the last accepted copy, without acknowledging) was already enforced but **hardcoded to 1 s**. FRR exposes it as `timers lsa min-arrival`; this makes it configurable — the receive-side twin of the send-side MinLSInterval (`min-ls-interval`) added in #1746, completing the RFC 2328 §12.4/§13 LSA-rate-limit pair.

- Add `min_ls_arrival_ms` on the OSPF instance (default 1000 ms) and snapshot it onto `OspfInterface`, so the receive paths read `oi.min_ls_arrival_ms` instead of the fixed-1s constant. All three gate sites updated (two v2 in `ospf_ls_upd_proc`, one v3 in `ospfv3_ls_upd_proc`); the `OSPF_MIN_LS_ARRIVAL` constant is retired.
- Config `min-ls-arrival` (ms, range 0..600000 matching FRR ospf6d) under `router ospf` / `router ospfv3`; `show ospf` / `show ospfv3` surface it alongside MinLSInterval.
- The self-originated bypass (so the §13.4 seq-reclaim path still fires) is preserved.

## FRR reference
`timers lsa min-arrival` — default 1000 ms (`OSPF_MIN_LS_ARRIVAL`). v2 range 0..5000 (plus a deprecated 5001..60000); ospf6d 0..600000. This PR uses 0..600000 for both.

## Test plan
- Full `cargo test`: **1514 passed**; yang-load clean.
- New **`ospfv2_min_ls_arrival` BDD**: a non-default `min-ls-arrival` is applied (confirmed via `show ospf`), adjacency forms, routes converge, ping succeeds. Passes locally.
- `cargo fmt`, workspace clippy, `mdbook build` clean.

## Docs
`min-ls-arrival` documented on the Timer Configuration page; the MinLSArrival gap moved to "closed" for v2 and v3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)