### PR TITLE
feat: tee the SRv6 Binding SID's policy to cradle (End.B6.Encaps)

### DIFF
--- a/zebra-rs/src/fib/cradle.rs
+++ b/zebra-rs/src/fib/cradle.rs
@@ -46,9 +46,10 @@ type Member = (
     Option<Leaf>,
 );
 
-/// Map zebra's `SidBehavior` to cradle's `SRV6_BH_*` (data-plane ABI). cradle
-/// executes End/End.X/End.DT4/DT6/DT46; uN/uA/B6/M are teed but the datapath
-/// passes them (they never match in single-service-SID L3VPN).
+/// Map zebra's `SidBehavior` to cradle's `SRV6_BH_*` (data-plane ABI). The
+/// cradle datapath executes every behavior below; End.B6.Encaps additionally
+/// carries its bound policy as a synthesized SRv6 nexthop (see
+/// `local_sid_install`).
 fn srv6_behavior(b: crate::rib::SidBehavior) -> u32 {
     use crate::rib::SidBehavior::*;
     match b {
@@ -517,10 +518,21 @@ impl CradleFib {
     /// cross-connect adjacency (`nh6`) to a cradle nexthop.
     pub async fn local_sid_install(&self, sid: &crate::rib::Sid, prefix_len: u8, ifindex: u32) {
         let result = async {
-            let nexthop_id = match sid.nh6 {
-                Some(nh6) => self.nexthop_id6(Some(nh6), ifindex, &[], 0).await?,
-                None => 0,
-            };
+            let nexthop_id =
+                if sid.behavior == crate::rib::SidBehavior::EndB6Encap && !sid.segs.is_empty() {
+                    // The Binding SID's bound policy rides as a cradle SRv6
+                    // nexthop (its id keys the `SRV6_ENCAP` segment list, which
+                    // the eBPF End.B6 handler reads through
+                    // `LocalSid.nexthop_id`). The gw/oif of this nexthop are
+                    // not used by the push — the packet re-enters the FIB by
+                    // the new outer DA, per S19.
+                    self.srv6_nexthop_id(None, ifindex, &sid.segs, 0).await?
+                } else {
+                    match sid.nh6 {
+                        Some(nh6) => self.nexthop_id6(Some(nh6), ifindex, &[], 0).await?,
+                        None => 0,
+                    }
+                };
             let (lb, ln, fun, arg) = sid
                 .structure
                 .map(|s| (s.lb_bits, s.ln_bits, s.fun_bits, s.arg_bits))

--- a/zebra-rs/src/rib/inst.rs
+++ b/zebra-rs/src/rib/inst.rs
@@ -1215,7 +1215,10 @@ impl Rib {
             | SidBehavior::EndDT4
             | SidBehavior::EndDT6
             | SidBehavior::EndDT46
-            | SidBehavior::EndM => self.resolve_sr0_ifindex(),
+            | SidBehavior::EndM
+            // End.B6.Encaps is a seg6local action too — bound to `lo` the
+            // kernel strips it exactly like the decap group.
+            | SidBehavior::EndB6Encap => self.resolve_sr0_ifindex(),
             _ => self.resolve_lo_ifindex(),
         }
     }


### PR DESCRIPTION
## Summary
- The BGP SAFI 73 receive path already installs `EndB6Encap` Sids carrying the selected candidate path's segment list, but the cradle tee dropped `Sid.segs` — the eBPF datapath saw a Binding SID with no policy. `local_sid_install` now synthesizes a cradle SRv6 nexthop for the policy list (the same deduped `SetNexthop` machinery routes use — `SRV6_ENCAP` keyed by the id) and passes its id in `LocalSid.nexthop_id`, which the eBPF End.B6.Encaps handler reads. No proto change.
- Bind End.B6.Encaps to `sr0` instead of `lo` in `resolve_sid_ifindex` — it is a seg6local action, and the kernel silently strips seg6local encaps whose oif is `lo` (same class as the decap group).

## Test plan
- fmt --check, clippy --workspace --all-targets, clippy --no-default-features clean; `cargo test -p zebra-rs` 1514 passed.
- Proven end-to-end by cradle-rs's new `cradle_b6_zebra` BDD (the first BGP SR Policy BDD): a controller-originated candidate path over iBGP SAFI 73 (route-target = the headend's BGP Identifier per RFC 9830 §4.2) → headend policy selection → BSID install through this tee → eBPF End.B6.Encaps push → USD at the policy egress → DT46 delivery. Green against this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)