### PR TITLE
feat(ospf): virtual links (RFC 2328 §15), single-hop transit

### DIFF
--- a/bdd/tests/configs/ospfv2_virtual_link/r1.yaml
+++ b/bdd/tests/configs/ospfv2_virtual_link/r1.yaml
@@ -1,0 +1,23 @@
+interface:
+- if-name: lo
+  ipv4:
+    address: 10.0.0.1/32
+- if-name: ethb
+  ipv4:
+    address: 10.0.12.1/30
+router:
+  ospf:
+    router-id: 10.0.0.1
+    area:
+    - area-id: 0.0.0.0
+      interface:
+      - if-name: lo
+        enable: true
+    - area-id: 0.0.0.1
+      # RFC 2328 §15: virtual link to r2 through transit area 1.
+      virtual-link:
+      - router-id: 10.0.0.2
+      interface:
+      - if-name: ethb
+        enable: true
+        network-type: point-to-point

--- a/bdd/tests/configs/ospfv2_virtual_link/r2.yaml
+++ b/bdd/tests/configs/ospfv2_virtual_link/r2.yaml
@@ -1,0 +1,31 @@
+# r2 is the far-end ABR: attached to areas 1 and 2 but with NO
+# physical backbone interface. The virtual link through area 1 is
+# what makes it backbone-attached.
+interface:
+- if-name: lo
+  ipv4:
+    address: 10.0.0.2/32
+- if-name: etha
+  ipv4:
+    address: 10.0.12.2/30
+- if-name: ethc
+  ipv4:
+    address: 10.0.23.1/30
+router:
+  ospf:
+    router-id: 10.0.0.2
+    area:
+    - area-id: 0.0.0.1
+      virtual-link:
+      - router-id: 10.0.0.1
+      interface:
+      - if-name: lo
+        enable: true
+      - if-name: etha
+        enable: true
+        network-type: point-to-point
+    - area-id: 0.0.0.2
+      interface:
+      - if-name: ethc
+        enable: true
+        network-type: point-to-point

--- a/bdd/tests/configs/ospfv2_virtual_link/r3.yaml
+++ b/bdd/tests/configs/ospfv2_virtual_link/r3.yaml
@@ -1,0 +1,21 @@
+# r3 is internal to area 2 — it can only learn area-0 destinations
+# through r2's summaries, which require r2 to be backbone-attached
+# via the virtual link.
+interface:
+- if-name: lo
+  ipv4:
+    address: 10.0.0.3/32
+- if-name: ethb
+  ipv4:
+    address: 10.0.23.2/30
+router:
+  ospf:
+    router-id: 10.0.0.3
+    area:
+    - area-id: 0.0.0.2
+      interface:
+      - if-name: lo
+        enable: true
+      - if-name: ethb
+        enable: true
+        network-type: point-to-point

--- a/bdd/tests/features/ospfv2_virtual_link.feature
+++ b/bdd/tests/features/ospfv2_virtual_link.feature
@@ -1,0 +1,64 @@
+@serial
+@ospfv2_virtual_link
+Feature: OSPFv2 virtual links connect a remote ABR to the backbone
+  As a network operator
+  I want `area <transit-id> virtual-link <router-id>` (RFC 2328 §15)
+  to form a logical backbone adjacency between two ABRs across a
+  non-backbone transit area — so an area with no physical backbone
+  connection (area 2 below) still exchanges inter-area routes with
+  area 0.
+
+  Test Topology:
+  ```
+     area 0        area 0.0.0.1 (transit)      area 0.0.0.2
+    lo 10.0.0.1   r1 -- 10.0.12.0/30 -- r2 -- 10.0.23.0/30 -- r3
+                   \____ virtual-link ____/     lo 10.0.0.3
+    r2 has NO physical area-0 interface; without the VL, r2 is not
+    backbone-attached and area 2 never learns 10.0.0.1/32.
+  ```
+
+  Scenario: Virtual link forms and carries inter-area routes end to end
+    Given a clean test environment
+    When I create namespace "r1"
+    And I create namespace "r2"
+    And I create namespace "r3"
+    And I connect namespace "r1" interface "ethb" to namespace "r2" interface "etha"
+    And I connect namespace "r2" interface "ethc" to namespace "r3" interface "ethb"
+    And I start zebra-rs in namespace "r1"
+    And I start zebra-rs in namespace "r2"
+    And I start zebra-rs in namespace "r3"
+    And I apply config "r1.yaml" to namespace "r1"
+    And I apply config "r2.yaml" to namespace "r2"
+    And I apply config "r3.yaml" to namespace "r3"
+    And I wait 40 seconds
+
+    # Physical adjacencies in the transit area and area 2.
+    Then show command "show ospf neighbor" in namespace "r1" should contain "Full"
+    And show command "show ospf neighbor" in namespace "r3" should contain "Full"
+
+    # The virtual link itself: both endpoints carry a VLINK interface
+    # whose neighbor reached Full (the VL runs in area 0.0.0.0).
+    And show command "show ospf interface" in namespace "r1" should contain "VLINK"
+    And show command "show ospf interface" in namespace "r2" should contain "VLINK"
+
+    # Backbone reachability through the VL: r2 (no physical area-0
+    # interface) learns r1's area-0 loopback...
+    And show command "show ospf route" in namespace "r2" should contain "10.0.0.1/32"
+    # ...and re-advertises area-2 destinations into the backbone, so
+    # r1 reaches r3's loopback across the VL.
+    And show command "show ospf route" in namespace "r1" should contain "10.0.0.3/32"
+
+    # End to end: the area-2 internal router reaches the area-0
+    # prefix — impossible without the virtual link.
+    And show command "show ospf route" in namespace "r3" should contain "10.0.0.1/32"
+    And ping from "r3" to "10.0.0.1" should succeed
+    And ping from "r1" to "10.0.0.3" should succeed
+
+    # Teardown.
+    When I stop zebra-rs in namespace "r1"
+    And I stop zebra-rs in namespace "r2"
+    And I stop zebra-rs in namespace "r3"
+    And I delete namespace "r1"
+    And I delete namespace "r2"
+    And I delete namespace "r3"
+    Then the test environment should be clean

--- a/book/src/ch-08-12-ospf-frr-gaps.md
+++ b/book/src/ch-08-12-ospf-frr-gaps.md
@@ -2,7 +2,10 @@
 
 OSPFv2 features not yet implemented in zebra-rs:
 
-- Virtual links across non-backbone areas.
+- Multi-hop virtual-link transit — virtual links themselves are
+  implemented (see below), but the two ABRs must be directly
+  adjacent within the transit area; per-interface authentication on
+  a virtual link is also not yet configurable.
 - NBMA and point-to-multipoint network types — the per-interface
   `network-type` knob accepts `broadcast` and `point-to-point`
   only.
@@ -66,3 +69,9 @@ per feature — see each feature's page):
   FRR `timers lsa min-arrival`) — the receive-side per-LSA rate limit
   was already enforced but fixed at 1 s; it is now tunable for both
   OSPFv2 and OSPFv3. See [Timer Configuration](ch-08-08-ospf-timers.md).
+- **Virtual links** (RFC 2328 §15, `area <transit> virtual-link
+  <router-id>`) — a synthetic backbone interface derived from the
+  transit area's SPF, unicast OSPF over the transit area, the
+  VirtualLink Router-LSA entry and transit-area V-bit. Single-hop
+  transit; OSPFv2 only (`ospf6d` has no virtual links either). See
+  [Multi-Area Routing and the ABR](ch-08-14-ospf-multi-area-abr.md#virtual-links).

--- a/book/src/ch-08-14-ospf-multi-area-abr.md
+++ b/book/src/ch-08-14-ospf-multi-area-abr.md
@@ -137,6 +137,51 @@ picking the cheapest advertising ABR. This is what makes E1
 external metrics come out right across area boundaries — see
 [Route Redistribution](ch-08-15-ospf-redistribution.md).
 
+## Virtual links
+
+RFC 2328 requires every area to attach to the backbone, but topology
+does not always cooperate — an ABR may sit behind another area with
+no physical area-0 interface. A **virtual link** (RFC 2328 §15)
+closes the gap: a logical backbone point-to-point link between two
+ABRs, tunneled *through* a shared non-backbone area (the **transit
+area**):
+
+```
+router ospf {
+  area 0.0.0.1 {
+    virtual-link 10.0.0.2;         # remote ABR's router-id
+    interface enp0s7 { enable true; }
+  }
+}
+```
+
+Both endpoints configure the link under the transit area, naming the
+*other* router's router-id. Optional `hello-interval`,
+`dead-interval`, and `retransmit-interval` leaves override the
+RFC defaults (10/40/5 s) and must match on both ends.
+
+Everything else is derived, not configured. When the transit area's
+SPF finds the peer ABR reachable, zebra-rs materializes a synthetic
+backbone interface (`VLINK<area>-<router-id>` in `show ospf
+interface`): its cost is the transit-area path cost, its endpoint
+addresses come from the SPF next hops, and its OSPF packets travel
+as **unicast** IP between the two endpoint addresses, routed by the
+transit area (VL packets carry Area ID 0.0.0.0 per §A.3.1). The
+adjacency runs the normal point-to-point state machine to Full, at
+which point each ABR advertises a type-4 **VirtualLink** entry in
+its area-0 Router-LSA and sets the V-bit in the transit area's — so
+backbone SPF flows through the link and the far ABR becomes
+backbone-attached, originating summaries for its other areas as
+usual. If the transit path fails, the SPF re-run tears the VL down.
+
+Current limits: the transit area must be a normal area (not stub /
+NSSA — §3.6 forbids it), and the two ABRs must be **directly
+adjacent within the transit area** (single-hop transit); a
+multi-hop transit path keeps the VL down with a debug log. OSPFv2
+only — same as FRR, whose `ospf6d` has no virtual-link support
+either. Validated end to end by `ospfv2_virtual_link.feature`
+(area 2 reaching an area-0 loopback exclusively through the VL).
+
 ## OSPFv3
 
 OSPFv3 implements the same ABR machinery using its own LSA types —

--- a/zebra-rs/src/ospf/area.rs
+++ b/zebra-rs/src/ospf/area.rs
@@ -280,6 +280,14 @@ pub struct OspfArea<V: OspfVersion = Ospfv2> {
     pub ranges: BTreeMap<Ipv4Net, AreaRange>,
     /// v6 sibling of `ranges` (OSPFv3 Inter-Area-Prefix aggregation).
     pub ranges_v6: BTreeMap<Ipv6Net, AreaRange>,
+
+    /// RFC 2328 §15 virtual links configured *through* this area
+    /// (`area <id> virtual-link <router-id>`) — this area is the
+    /// transit area; the key is the remote ABR's router-id. The VL
+    /// itself is a synthetic area-0 interface materialized by
+    /// `Ospf::vl_reconcile` once the transit-area SPF finds the peer
+    /// reachable. v2-only today.
+    pub virtual_links: BTreeMap<Ipv4Addr, VirtualLinkConfig>,
 }
 
 /// Instance-level `default-information originate` configuration.
@@ -315,6 +323,18 @@ pub struct AreaRange {
     pub cost: Option<u32>,
 }
 
+/// One configured `area <id> virtual-link <router-id>` entry
+/// (RFC 2328 §15). Interval overrides mirror the per-interface
+/// leaves; `None` falls back to the RFC defaults the synthetic
+/// link's `LinkConfig` already carries (hello 10s / dead 40s /
+/// retransmit 5s).
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+pub struct VirtualLinkConfig {
+    pub hello_interval: Option<u16>,
+    pub dead_interval: Option<u32>,
+    pub retransmit_interval: Option<u16>,
+}
+
 impl<V: OspfVersion> OspfArea<V> {
     pub fn new(id: Ipv4Addr) -> Self {
         Self {
@@ -333,6 +353,7 @@ impl<V: OspfVersion> OspfArea<V> {
             asbr_summaries_originated: BTreeSet::new(),
             ranges: BTreeMap::new(),
             ranges_v6: BTreeMap::new(),
+            virtual_links: BTreeMap::new(),
         }
     }
 }

--- a/zebra-rs/src/ospf/config.rs
+++ b/zebra-rs/src/ospf/config.rs
@@ -72,6 +72,19 @@ impl Ospf {
             config_ospf_area_range_not_advertise,
         );
         self.ospf_add("/area/range/cost", config_ospf_area_range_cost);
+        self.ospf_add("/area/virtual-link", config_ospf_area_virtual_link);
+        self.ospf_add(
+            "/area/virtual-link/hello-interval",
+            config_ospf_area_virtual_link_hello_interval,
+        );
+        self.ospf_add(
+            "/area/virtual-link/dead-interval",
+            config_ospf_area_virtual_link_dead_interval,
+        );
+        self.ospf_add(
+            "/area/virtual-link/retransmit-interval",
+            config_ospf_area_virtual_link_retransmit_interval,
+        );
         self.ospf_add("/area/interface/enable", config_ospf_interface_enable);
         self.ospf_add(
             "/area/interface/bfd/enable",
@@ -829,6 +842,84 @@ fn config_ospf_area_range_cost(ospf: &mut Ospf, mut args: Args, op: ConfigOp) ->
         .or_default()
         .cost = cost;
     ospf.abr_summary_originate();
+    Some(())
+}
+
+/// `/router/ospf/area/<transit-id>/virtual-link/<router-id>` —
+/// RFC 2328 §15 virtual link through the list-key (transit) area to
+/// the ABR `router-id`. The synthetic backbone interface itself is
+/// materialized/torn down by `vl_reconcile` (driven off the transit
+/// area's SPF), so config just records intent and reconciles.
+fn config_ospf_area_virtual_link(ospf: &mut Ospf, mut args: Args, op: ConfigOp) -> Option<()> {
+    let area_id = parse_area_id(&args.string()?)?;
+    let peer = args.v4addr()?;
+    if op.is_set() {
+        ospf.areas
+            .fetch(area_id)
+            .virtual_links
+            .entry(peer)
+            .or_default();
+    } else if let Some(area) = ospf.areas.get_mut(area_id) {
+        area.virtual_links.remove(&peer);
+    }
+    ospf.vl_reconcile();
+    Some(())
+}
+
+/// `/router/ospf/area/<id>/virtual-link/<rid>/hello-interval`.
+fn config_ospf_area_virtual_link_hello_interval(
+    ospf: &mut Ospf,
+    mut args: Args,
+    op: ConfigOp,
+) -> Option<()> {
+    let area_id = parse_area_id(&args.string()?)?;
+    let peer = args.v4addr()?;
+    let value = if op.is_set() { Some(args.u16()?) } else { None };
+    ospf.areas
+        .fetch(area_id)
+        .virtual_links
+        .entry(peer)
+        .or_default()
+        .hello_interval = value;
+    ospf.vl_reconcile();
+    Some(())
+}
+
+/// `/router/ospf/area/<id>/virtual-link/<rid>/dead-interval`.
+fn config_ospf_area_virtual_link_dead_interval(
+    ospf: &mut Ospf,
+    mut args: Args,
+    op: ConfigOp,
+) -> Option<()> {
+    let area_id = parse_area_id(&args.string()?)?;
+    let peer = args.v4addr()?;
+    let value = if op.is_set() { Some(args.u32()?) } else { None };
+    ospf.areas
+        .fetch(area_id)
+        .virtual_links
+        .entry(peer)
+        .or_default()
+        .dead_interval = value;
+    ospf.vl_reconcile();
+    Some(())
+}
+
+/// `/router/ospf/area/<id>/virtual-link/<rid>/retransmit-interval`.
+fn config_ospf_area_virtual_link_retransmit_interval(
+    ospf: &mut Ospf,
+    mut args: Args,
+    op: ConfigOp,
+) -> Option<()> {
+    let area_id = parse_area_id(&args.string()?)?;
+    let peer = args.v4addr()?;
+    let value = if op.is_set() { Some(args.u16()?) } else { None };
+    ospf.areas
+        .fetch(area_id)
+        .virtual_links
+        .entry(peer)
+        .or_default()
+        .retransmit_interval = value;
+    ospf.vl_reconcile();
     Some(())
 }
 

--- a/zebra-rs/src/ospf/ifsm.rs
+++ b/zebra-rs/src/ospf/ifsm.rs
@@ -163,7 +163,11 @@ pub fn ospf_ifsm_interface_up<V: OspfVersion>(link: &mut OspfLink<V>) -> Option<
     // same (group, ifindex) returns EADDRINUSE; the tracked flag
     // lets us no-op the second join instead. Same pattern the DR
     // path already uses for AllDRouters.
-    if !link.multicast_memberships.all_routers() {
+    //
+    // Virtual links skip the join entirely: their ifindex is
+    // synthetic (no kernel interface behind it) and every VL packet
+    // is unicast (RFC 2328 §15).
+    if link.vl.is_none() && !link.multicast_memberships.all_routers() {
         V::join_if(&link.sock, link.index);
         link.multicast_memberships.set_all_routers(true);
     }

--- a/zebra-rs/src/ospf/inst.rs
+++ b/zebra-rs/src/ospf/inst.rs
@@ -330,6 +330,11 @@ pub struct Ospf<V: OspfVersion = Ospfv2> {
     /// less than this after the last accepted copy is discarded
     /// without acknowledgement. Default [`OSPF_MIN_LS_ARRIVAL_MS`].
     pub min_ls_arrival_ms: u32,
+    /// Next synthetic ifindex to hand to a virtual-link `OspfLink`
+    /// (RFC 2328 §15). Starts at [`super::link::VL_IFINDEX_BASE`];
+    /// monotonically increasing so a torn-down-and-recreated VL never
+    /// aliases stale timers keyed on the old index. v2-only.
+    vl_ifindex_next: u32,
     /// Per-self-LSA MinLSInterval throttle state, keyed by
     /// [`LsaGenKey`]. Runtime-only (not checkpointed / inherited).
     lsa_gen: std::collections::HashMap<LsaGenKey, LsaGenState>,
@@ -1409,6 +1414,7 @@ impl Ospf<Ospfv2> {
             spf_interval: SpfIntervalConfig::default(),
             min_ls_interval_ms: OSPF_MIN_LS_INTERVAL_MS,
             min_ls_arrival_ms: OSPF_MIN_LS_ARRIVAL_MS,
+            vl_ifindex_next: super::link::VL_IFINDEX_BASE,
             lsa_gen: std::collections::HashMap::new(),
             restarting: None,
             key_chains: BTreeMap::new(),
@@ -1683,6 +1689,17 @@ impl Ospf<Ospfv2> {
         if self.is_asbr() {
             router_lsa.flags |= 0x0002;
         }
+        // RFC 2328 §12.4.2 V-bit (0x04): set in the *transit area's*
+        // Router-LSA when this router is the endpoint of one or more
+        // fully-adjacent virtual links transiting that area — it is
+        // what marks the area transit-capable for §16.3.
+        let vl_full_through_area = self.links.values().any(|l| {
+            l.vl.as_ref().is_some_and(|vl| vl.transit_area == area_id)
+                && l.nbrs.values().any(|n| n.state == NfsmState::Full)
+        });
+        if vl_full_through_area {
+            router_lsa.flags |= 0x0004;
+        }
 
         for link in self.links.values() {
             if !link.enabled {
@@ -1704,6 +1721,34 @@ impl Ospf<Ospfv2> {
             } else {
                 link.output_cost.min(u16::MAX as u32) as u16
             };
+
+            // RFC 2328 §12.4.1.1, virtual link: once the VL neighbor
+            // is Full, emit one Type-4 VirtualLink entry into the
+            // backbone Router-LSA — link_id = the far ABR's router-id,
+            // link_data = our (SPF-derived) VL endpoint address,
+            // metric = the transit-area path cost. Never a stub link:
+            // the endpoint address belongs to the transit area, and
+            // §12.4.1.1 gives a VL no associated network.
+            if let Some(vl) = &link.vl {
+                for nbr in link.nbrs.values() {
+                    if nbr.state != NfsmState::Full {
+                        continue;
+                    }
+                    router_lsa.links.push(RouterLsaLink {
+                        link_id: vl.peer_router_id,
+                        link_data: link
+                            .addr
+                            .first()
+                            .map(|a| a.prefix.addr())
+                            .unwrap_or(Ipv4Addr::UNSPECIFIED),
+                        link_type: OspfLinkType::VirtualLink,
+                        num_tos: 0,
+                        tos_0_metric: metric,
+                        toses: vec![],
+                    });
+                }
+                continue;
+            }
 
             // RFC 2328 §12.4.1.1, numbered point-to-point: one Type-1
             // P2p link per Full neighbor (pointing at the neighbor's
@@ -1974,6 +2019,207 @@ impl Ospf<Ospfv2> {
                 });
                 self.range_discards.insert(*prefix);
             }
+        }
+    }
+
+    /// RFC 2328 §15: reconcile the synthetic backbone interfaces
+    /// backing configured virtual links against the latest transit-area
+    /// SPF results. Called after every SPF apply and on VL config
+    /// change.
+    ///
+    /// A VL is *viable* when its transit area is a non-backbone,
+    /// non-stub area whose SPF reaches the peer ABR **as a direct
+    /// adjacency** (single-hop transit — the peer is our SPF first hop,
+    /// so the first-hop neighbor address IS the far VL endpoint).
+    /// Multi-hop transit needs the FRR-style backlink walk over a
+    /// full-path SPF and is deferred; such VLs stay down with a debug
+    /// log.
+    ///
+    /// Viable VLs materialize as a synthetic `OspfLink` in area 0
+    /// (making this router backbone-attached): unicast Hellos to
+    /// `peer_addr` drive a normal P2P adjacency, and `router_lsa_build`
+    /// emits a `VirtualLink` entry once the neighbor is Full. VLs that
+    /// stop being viable (or are deconfigured) tear down synchronously.
+    ///
+    /// Loop-safety: `router_lsa_originate` fires only when something
+    /// actually changed, so a converged topology re-floods nothing and
+    /// the SPF -> reconcile -> SPF chain terminates.
+    pub fn vl_reconcile(&mut self) {
+        use super::link::VL_IFINDEX_BASE;
+        const LS_INFINITY: u32 = 0x00FF_FFFF;
+
+        struct Viable {
+            cost: u32,
+            local_addr: Ipv4Addr,
+            peer_addr: Ipv4Addr,
+            first_hop_ifindex: u32,
+        }
+
+        // Pass 1 (immutable): resolve every configured VL to its
+        // desired state. `None` viable = configured but unreachable.
+        let mut desired: Vec<(Ipv4Addr, Ipv4Addr, Option<Viable>)> = Vec::new();
+        for (area_id, area) in self.areas.iter() {
+            if area.virtual_links.is_empty() {
+                continue;
+            }
+            // The backbone cannot be a transit area, and stub/NSSA
+            // areas cannot carry virtual links (RFC 2328 §3.6).
+            if *area_id == AREA0 || area.area_type.is_stub_or_nssa() {
+                continue;
+            }
+            for peer in area.virtual_links.keys() {
+                let viable = self
+                    .spf_results
+                    .get(area_id)
+                    .zip(self.lsp_map.lookup(*peer))
+                    .and_then(|(spf, vertex)| spf.get(&vertex).map(|p| (vertex, p)))
+                    .filter(|(_, path)| path.cost < LS_INFINITY)
+                    .and_then(|(vertex, path)| {
+                        let nhops = build_spf_nexthops(self, vertex, path);
+                        let direct = nhops.iter().find(|(_, nh)| nh.adjacency);
+                        if direct.is_none() && !nhops.is_empty() {
+                            tracing::debug!(
+                                "[VL] peer {} reachable in area {} but not adjacent (multi-hop transit unsupported)",
+                                peer,
+                                area_id
+                            );
+                        }
+                        direct.and_then(|(addr, nh)| {
+                            let local_addr = self
+                                .links
+                                .get(&nh.ifindex)
+                                .and_then(|l| l.addr.first())
+                                .map(|a| a.prefix.addr())?;
+                            Some(Viable {
+                                cost: path.cost,
+                                local_addr,
+                                peer_addr: *addr,
+                                first_hop_ifindex: nh.ifindex,
+                            })
+                        })
+                    });
+                desired.push((*area_id, *peer, viable));
+            }
+        }
+
+        // Existing synthetic links, keyed by (transit_area, peer).
+        let existing: BTreeMap<(Ipv4Addr, Ipv4Addr), u32> = self
+            .links
+            .values()
+            .filter_map(|l| {
+                l.vl.as_ref()
+                    .map(|vl| ((vl.transit_area, vl.peer_router_id), l.index))
+            })
+            .collect();
+
+        let mut changed = false;
+        let mut keep: BTreeSet<u32> = BTreeSet::new();
+
+        // Pass 2 (mutable): create / refresh viable VLs.
+        for (transit, peer, viable) in &desired {
+            let Some(v) = viable else {
+                continue;
+            };
+            if let Some(&idx) = existing.get(&(*transit, *peer)) {
+                keep.insert(idx);
+                let Some(link) = self.links.get_mut(&idx) else {
+                    continue;
+                };
+                let prefix = Ipv4Net::new(v.local_addr, 32).unwrap();
+                let vl = link.vl.as_mut().unwrap();
+                if vl.peer_addr != v.peer_addr
+                    || vl.first_hop_ifindex != v.first_hop_ifindex
+                    || link.output_cost != v.cost
+                    || link.addr.first().map(|a| a.prefix.addr()) != Some(v.local_addr)
+                {
+                    vl.peer_addr = v.peer_addr;
+                    vl.first_hop_ifindex = v.first_hop_ifindex;
+                    link.output_cost = v.cost;
+                    link.addr = vec![super::addr::OspfAddr { prefix }];
+                    link.ident.prefix = prefix;
+                    changed = true;
+                    tracing::info!(
+                        "[VL] area {} peer {} refreshed: cost={} local={} remote={}",
+                        transit,
+                        peer,
+                        v.cost,
+                        v.local_addr,
+                        v.peer_addr
+                    );
+                }
+            } else {
+                let idx = self.vl_ifindex_next;
+                self.vl_ifindex_next = self.vl_ifindex_next.wrapping_add(1).max(VL_IFINDEX_BASE);
+                let mut link = OspfLink::new_virtual(
+                    self.tx.clone(),
+                    idx,
+                    self.sock.clone(),
+                    self.router_id,
+                    self.ptx.clone(),
+                    *transit,
+                    *peer,
+                );
+                // Interval overrides from the transit area's config.
+                if let Some(cfg) = self
+                    .areas
+                    .get(*transit)
+                    .and_then(|a| a.virtual_links.get(peer))
+                {
+                    link.config.hello_interval = cfg.hello_interval;
+                    link.config.dead_interval = cfg.dead_interval;
+                    link.config.retransmit_interval = cfg.retransmit_interval;
+                }
+                let prefix = Ipv4Net::new(v.local_addr, 32).unwrap();
+                link.output_cost = v.cost;
+                link.addr = vec![super::addr::OspfAddr { prefix }];
+                link.ident.prefix = prefix;
+                {
+                    let vl = link.vl.as_mut().unwrap();
+                    vl.peer_addr = v.peer_addr;
+                    vl.first_hop_ifindex = v.first_hop_ifindex;
+                }
+                self.links.insert(idx, link);
+                self.areas.fetch(AREA0).links.insert(idx);
+                keep.insert(idx);
+                let _ = self.tx.send(Message::Ifsm(idx, IfsmEvent::InterfaceUp));
+                changed = true;
+                tracing::info!(
+                    "[VL] area {} peer {} up: cost={} local={} remote={} ifindex={:#x}",
+                    transit,
+                    peer,
+                    v.cost,
+                    v.local_addr,
+                    v.peer_addr,
+                    idx
+                );
+            }
+        }
+
+        // Pass 3: tear down VLs that are gone from config or no
+        // longer viable.
+        let stale: Vec<u32> = existing
+            .values()
+            .filter(|idx| !keep.contains(idx))
+            .copied()
+            .collect();
+        for idx in stale {
+            if let Some(link) = self.links.get_mut(&idx) {
+                tracing::info!("[VL] {} down (unreachable or deconfigured)", link.name);
+                ospf_ifsm(link, IfsmEvent::InterfaceDown);
+            }
+            if let Some(area0) = self.areas.get_mut(AREA0) {
+                area0.links.remove(&idx);
+            }
+            self.links.remove(&idx);
+            changed = true;
+        }
+
+        // Becoming (or ceasing to be) backbone-attached changes the
+        // Router-LSA link set and the ABR summary sets.
+        if changed {
+            self.router_lsa_originate();
+            self.abr_summary_originate();
+            self.nssa_translate_resync_all();
         }
     }
 
@@ -4970,8 +5216,10 @@ impl Ospf<Ospfv2> {
         let mut packet =
             Ospfv2Packet::new(&self.router_id, &link.area, Ospfv2Payload::LsAck(ls_ack));
         apply_link_auth(&mut packet, &link.auth_send_ctx(chains, now));
-        // Send to AllSPFRouters multicast.
-        let _ = link.ptx.send(Message::Send(packet, ifindex, None));
+        // AllSPFRouters multicast on physical interfaces; unicast to
+        // the far ABR on a virtual link.
+        let dest = link.vl.as_ref().map(|vl| vl.peer_addr);
+        let _ = link.ptx.send(Message::Send(packet, ifindex, dest));
     }
 
     /// Queue delayed ack headers and start delayed ack timer if needed.
@@ -5188,12 +5436,37 @@ impl Ospf<Ospfv2> {
         packet: Ospfv2Packet,
         src: Ipv4Addr,
         _from: Ipv4Addr,
-        index: u32,
-        _dest: Ipv4Addr,
+        mut index: u32,
+        dest: Ipv4Addr,
     ) {
         // Drop self-originated packets (e.g. received on loopback interface).
         if packet.router_id == self.router_id {
             return;
+        }
+
+        // RFC 2328 §15 virtual-link association (FRR's
+        // `ospf_associate_packet_vl`): VL packets are unicast, carry
+        // the backbone Area ID (RFC §A.3.1), and arrive on the
+        // physical transit-area interface. Re-associate them with the
+        // matching synthetic VL interface — keyed by (ingress link's
+        // area == VL transit area, header router-id == VL peer) — so
+        // the adjacency runs on the VL, not the physical link.
+        if !dest.is_multicast() && packet.area_id == AREA0 {
+            let ingress_area = self.links.get(&index).map(|l| l.area);
+            if let Some(ingress_area) = ingress_area
+                && ingress_area != AREA0
+            {
+                let vl_index = self.links.values().find_map(|l| {
+                    l.vl.as_ref()
+                        .filter(|vl| {
+                            vl.transit_area == ingress_area && vl.peer_router_id == packet.router_id
+                        })
+                        .map(|_| l.index)
+                });
+                if let Some(vl_index) = vl_index {
+                    index = vl_index;
+                }
+            }
         }
 
         // RFC 2328 §D.4: AuType + auth field must match the
@@ -5839,6 +6112,7 @@ impl Ospf<Ospfv3> {
             spf_interval: SpfIntervalConfig::default(),
             min_ls_interval_ms: OSPF_MIN_LS_INTERVAL_MS,
             min_ls_arrival_ms: OSPF_MIN_LS_ARRIVAL_MS,
+            vl_ifindex_next: super::link::VL_IFINDEX_BASE,
             lsa_gen: std::collections::HashMap::new(),
             restarting: None,
             key_chains: BTreeMap::new(),
@@ -11648,8 +11922,17 @@ fn build_spf_nexthops(
             for (_, nbr) in link.nbrs.iter() {
                 if *nhop_id == nbr.ident.router_id {
                     let addr = nbr.ident.prefix.addr();
+                    // A virtual-link adjacency has a synthetic ifindex
+                    // with no kernel interface behind it; forwarding
+                    // toward the VL peer egresses the physical
+                    // transit-area interface (RFC 2328 §16.1.1 — the
+                    // VL inherits the transit path's next hop).
+                    let egress = match &link.vl {
+                        Some(vl) => vl.first_hop_ifindex,
+                        None => *ifindex,
+                    };
                     let nhop = SpfNexthop {
-                        ifindex: *ifindex,
+                        ifindex: egress,
                         adjacency: p[0] == target_id,
                         router_id: Some(*nhop_id),
                         // Stamped by the TI-LFA second pass (single-
@@ -14146,6 +14429,11 @@ fn apply_spf_result(top: &mut Ospf, output: SpfOutput) {
     // reachable in the other area. Enables non-backbone routers to
     // compute E1 metrics to ASBRs they cannot reach intra-area.
     top.abr_summary_asbr_originate();
+    // Virtual links ride the transit area's SPF: (re)derive each VL's
+    // cost / endpoints from the fresh results, bringing VLs up or
+    // down as reachability changes. Change-gated internally, so a
+    // converged topology triggers nothing.
+    top.vl_reconcile();
 }
 
 /// Merge every attached area's route slice (`rib_areas`) into one

--- a/zebra-rs/src/ospf/link.rs
+++ b/zebra-rs/src/ospf/link.rs
@@ -483,6 +483,42 @@ pub struct OspfLink<V: OspfVersion = Ospfv2> {
         crate::stamp::session::SessionKey,
         crate::stamp::session::SessionParams,
     )>,
+    /// `Some` when this is a synthetic RFC 2328 §15 virtual link
+    /// rather than a physical interface. The discriminator gates the
+    /// VL-specific behavior: no multicast join, unicast sends to
+    /// `peer_addr` over `first_hop_ifindex`, a `VirtualLink` entry
+    /// (never a stub) in the area-0 Router-LSA, and `output_cost`
+    /// tracking the transit-area SPF distance. Maintained by
+    /// `Ospf::vl_reconcile`.
+    pub vl: Option<VirtualLinkState>,
+}
+
+/// First synthetic ifindex used for virtual-link `OspfLink`s. Kernel
+/// ifindexes are small positive integers, so the top-bit range can
+/// never collide. `network::write_packet` uses the same bound to
+/// route VL packets by the kernel FIB (`ipi_ifindex = 0`) instead of
+/// forcing egress out a (non-existent) interface.
+pub const VL_IFINDEX_BASE: u32 = 0x8000_0000;
+
+/// Runtime state of one virtual link (RFC 2328 §15), carried on its
+/// synthetic `OspfLink`. Configuration lives on the transit area
+/// (`OspfArea::virtual_links`); everything here is *derived* from the
+/// transit-area SPF and refreshed by `Ospf::vl_reconcile` after each
+/// SPF run.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct VirtualLinkState {
+    /// The non-backbone area the virtual link transits.
+    pub transit_area: Ipv4Addr,
+    /// Router-ID of the ABR at the far end (the config key).
+    pub peer_router_id: Ipv4Addr,
+    /// Unicast destination for OSPF packets on this VL: the peer's
+    /// interface address on the transit-area path (single-hop transit:
+    /// the first-hop neighbor address from `build_spf_nexthops`).
+    pub peer_addr: Ipv4Addr,
+    /// Physical egress ifindex toward the peer through the transit
+    /// area — the ifindex handed to `Message::Send` in place of the
+    /// synthetic one.
+    pub first_hop_ifindex: u32,
 }
 
 #[derive(Default)]
@@ -544,6 +580,74 @@ where
             lsdb: super::lsdb::Lsdb::new(),
             measured_te_metric: LinkTeMetric::default(),
             stamp_session: None,
+            vl: None,
+        }
+    }
+
+    /// Construct the synthetic `OspfLink` backing one RFC 2328 §15
+    /// virtual link. `index` is a synthetic ifindex (allocated from
+    /// the `VL_IFINDEX_BASE` range, never a kernel ifindex); the
+    /// socket is the instance's shared raw socket. The link is born
+    /// point-to-point in the backbone; `vl_reconcile` populates
+    /// `addr` / `output_cost` / `vl.{peer_addr,first_hop_ifindex}`
+    /// from the transit-area SPF before firing `InterfaceUp`.
+    pub fn new_virtual(
+        tx: UnboundedSender<Message<V>>,
+        index: u32,
+        sock: Arc<AsyncFd<Socket>>,
+        router_id: Ipv4Addr,
+        ptx: UnboundedSender<Message<V>>,
+        transit_area: Ipv4Addr,
+        peer_router_id: Ipv4Addr,
+    ) -> Self {
+        let config = LinkConfig {
+            enable: true,
+            network_type: Some(OspfNetworkType::PointToPoint),
+            ..LinkConfig::default()
+        };
+        Self {
+            index,
+            name: format!("VLINK{}-{}", transit_area, peer_router_id),
+            mtu: 1500,
+            enabled: true,
+            addr: Vec::new(),
+            area: crate::ospf::AREA0,
+            area_id: crate::ospf::AREA0,
+            area_type: super::area::AreaType::default(),
+            state: IfsmState::Down,
+            ostate: IfsmState::Down,
+            sock,
+            ident: Identity::<V>::new(router_id),
+            tx,
+            nbrs: BTreeMap::new(),
+            flags: 0.into(),
+            link_flags: LinkFlags::Up | LinkFlags::LowerUp | LinkFlags::Pointopoint,
+            network_type: OspfNetworkType::PointToPoint,
+            output_cost: OSPF_DEFAULT_OUTPUT_COST,
+            multicast_memberships: 0.into(),
+            timer: LinkTimer::default(),
+            state_change: 0,
+            db_desc_in: 0,
+            full_nbr_count: 0,
+            ptx,
+            config,
+            md5_seq: std::sync::atomic::AtomicU32::new(
+                std::time::SystemTime::now()
+                    .duration_since(std::time::UNIX_EPOCH)
+                    .map(|d| d.as_secs() as u32)
+                    .unwrap_or(0),
+            ),
+            ls_ack_delayed: Vec::new(),
+            interface_id: index,
+            lsdb: super::lsdb::Lsdb::new(),
+            measured_te_metric: LinkTeMetric::default(),
+            stamp_session: None,
+            vl: Some(VirtualLinkState {
+                transit_area,
+                peer_router_id,
+                peer_addr: Ipv4Addr::UNSPECIFIED,
+                first_hop_ifindex: 0,
+            }),
         }
     }
 }

--- a/zebra-rs/src/ospf/network.rs
+++ b/zebra-rs/src/ospf/network.rs
@@ -122,8 +122,19 @@ pub async fn write_packet(sock: Arc<AsyncFd<Socket>>, mut rx: UnboundedReceiver<
             Ipv4Addr::from_str("224.0.0.5").unwrap()
         };
         let sockaddr: SockaddrIn = std::net::SocketAddrV4::new(dest, 0).into();
+        // Virtual-link packets carry a synthetic ifindex (no kernel
+        // interface behind it). They are always unicast to the far
+        // ABR through the transit area, so hand egress selection to
+        // the kernel FIB (`ipi_ifindex = 0`) instead of forcing an
+        // interface — this also keeps multi-hop transit paths
+        // working. Physical interfaces keep the forced egress.
+        let egress_ifindex = if ifindex >= super::link::VL_IFINDEX_BASE {
+            0
+        } else {
+            ifindex as i32
+        };
         let pktinfo = libc::in_pktinfo {
-            ipi_ifindex: ifindex as i32,
+            ipi_ifindex: egress_ifindex,
             ipi_spec_dst: libc::in_addr { s_addr: 0 },
             ipi_addr: libc::in_addr { s_addr: 0 },
         };

--- a/zebra-rs/src/ospf/packet.rs
+++ b/zebra-rs/src/ospf/packet.rs
@@ -487,7 +487,10 @@ pub fn ospf_hello_send(
     ospf_pdu_trace!(tracing, "[Hello:Send] on {}", oi.name);
 
     let packet = ospf_hello_packet(oi, chains, now).unwrap();
-    if let Err(e) = oi.ptx.send(Message::Send(packet, oi.index, None)) {
+    // Virtual links unicast their Hellos to the far ABR (RFC 2328
+    // §15); physical interfaces multicast to AllSPFRouters (None).
+    let dest = oi.vl.as_ref().map(|vl| vl.peer_addr);
+    if let Err(e) = oi.ptx.send(Message::Send(packet, oi.index, dest)) {
         tracing::warn!("[Hello:Send] channel send failed: {}", e);
         return;
     }

--- a/zebra-rs/yang/config.yang
+++ b/zebra-rs/yang/config.yang
@@ -737,6 +737,39 @@ module config {
               }
             }
           }
+          list virtual-link {
+            ext:help "Virtual link through this (transit) area to a remote ABR";
+            // RFC 2328 §15: a logical backbone point-to-point link to
+            // the ABR `router-id`, transiting THIS area. Comes up when
+            // the transit-area SPF finds the peer reachable; cost and
+            // endpoints are derived from that SPF. The list-key area
+            // must be a non-backbone, non-stub area.
+            key "router-id";
+            leaf router-id {
+              type inet:ipv4-address;
+            }
+            leaf hello-interval {
+              type uint16 {
+                range "1..65535";
+              }
+              units "seconds";
+              default 10;
+            }
+            leaf dead-interval {
+              type uint32 {
+                range "1..4294967295";
+              }
+              units "seconds";
+              default 40;
+            }
+            leaf retransmit-interval {
+              type uint16 {
+                range "1..65535";
+              }
+              units "seconds";
+              default 5;
+            }
+          }
           list interface {
             key "if-name";
             leaf if-name {


### PR DESCRIPTION
## Summary

Implements **OSPFv2 virtual links** (RFC 2328 §15) — the largest remaining OSPF gap vs FRR. A virtual link is a logical backbone P2P link between two ABRs through a shared non-backbone **transit area**, letting an area with no physical area-0 interface attach to the backbone.

Research first: the *consumption* side already existed in zebra-rs (the SPF graph builder treats `VirtualLink` Router-LSA edges like P2P with the bidirectional back-link check; show rendering exists). This PR adds the **origination** side:

- **Config**: `area <transit-id> virtual-link <router-id>` (+ optional hello/dead/retransmit intervals), stored on `OspfArea::virtual_links`.
- **`vl_reconcile`** (after every SPF apply + on config change): derives each VL's **cost, endpoint addresses, and physical egress from the transit area's SPF** (`spf_results` + `build_spf_nexthops`), materializing a synthetic `OspfLink` in area 0 when the peer is reachable as a direct adjacency, tearing it down when not. Change-gated — a converged topology triggers nothing (no SPF↔LSA loops).
- **Packet paths**: VL packets are **unicast** between the derived endpoints with Area ID 0.0.0.0 (§A.3.1). Synthetic-ifindex sends (`>= VL_IFINDEX_BASE`) hand egress to the kernel FIB (`ipi_ifindex = 0`) — one choke-point change in `write_packet`, since all per-neighbor sends already pass `nbr.ifindex + Some(addr)`. Receive-side association (port of FRR's `ospf_associate_packet_vl`) remaps unicast backbone packets from the physical transit interface onto the synthetic VL interface. IFSM skips the multicast join; the existing P2P machine drives the adjacency to Full.
- **Router-LSA**: type-4 `VirtualLink` entry in the area-0 Router-LSA once the VL neighbor is Full (link_id = peer router-id, link_data = local endpoint, metric = transit cost, no stub), plus the §12.4.2 **V-bit** in the transit area's Router-LSA. `build_spf_nexthops` substitutes the physical egress ifindex for VL adjacencies so backbone-via-VL routes install correctly.

### Documented limits
- **Single-hop transit**: the two ABRs must be directly adjacent within the transit area (multi-hop needs the FRR-style full-path backlink walk — future work; such VLs stay down with a debug log).
- No VL authentication config yet.
- OSPFv2 only — matching FRR, whose `ospf6d` has no virtual links either.

## Test plan
- New **`ospfv2_virtual_link` BDD**: 3 routers / 3 areas — r2 has areas 1+2 but **no physical backbone interface**; area 2's r3 reaches r1's area-0 loopback exclusively through the VL. Asserts `VLINK` interfaces on both ABRs, backbone routes both directions, and end-to-end pings. **Passes locally** (first run, binary md5-bracketed).
- `ospfv2_multi_area` regression BDD: passes.
- Full `cargo test`: 1514 passed; yang-load clean; fmt + workspace clippy + mdbook clean.

## Docs
"Virtual links" section on the Multi-Area/ABR page (config, derivation model, limits); FRR-gaps page updated (VL moved to closed; residual multi-hop/auth limitation noted).

🤖 Generated with [Claude Code](https://claude.com/claude-code)