### PR TITLE
feat(ospf): multi-hop virtual-link transit (RFC 2328 §15 / §16.1.1)

### DIFF
--- a/bdd/tests/configs/ospfv2_virtual_link/r1m.yaml
+++ b/bdd/tests/configs/ospfv2_virtual_link/r1m.yaml
@@ -1,0 +1,23 @@
+interface:
+- if-name: lo
+  ipv4:
+    address: 10.0.0.1/32
+- if-name: ethm
+  ipv4:
+    address: 10.0.12.1/30
+router:
+  ospf:
+    router-id: 10.0.0.1
+    area:
+    - area-id: 0.0.0.0
+      interface:
+      - if-name: lo
+        enable: true
+    - area-id: 0.0.0.1
+      # Multi-hop virtual link: r2 is two hops away through rm.
+      virtual-link:
+      - router-id: 10.0.0.2
+      interface:
+      - if-name: ethm
+        enable: true
+        network-type: point-to-point

--- a/bdd/tests/configs/ospfv2_virtual_link/r2m.yaml
+++ b/bdd/tests/configs/ospfv2_virtual_link/r2m.yaml
@@ -1,0 +1,30 @@
+# r2 is the far-end ABR, two transit hops away from r1 — still no
+# physical backbone interface.
+interface:
+- if-name: lo
+  ipv4:
+    address: 10.0.0.2/32
+- if-name: ethm
+  ipv4:
+    address: 10.0.24.2/30
+- if-name: ethc
+  ipv4:
+    address: 10.0.23.1/30
+router:
+  ospf:
+    router-id: 10.0.0.2
+    area:
+    - area-id: 0.0.0.1
+      virtual-link:
+      - router-id: 10.0.0.1
+      interface:
+      - if-name: lo
+        enable: true
+      - if-name: ethm
+        enable: true
+        network-type: point-to-point
+    - area-id: 0.0.0.2
+      interface:
+      - if-name: ethc
+        enable: true
+        network-type: point-to-point

--- a/bdd/tests/configs/ospfv2_virtual_link/r3m.yaml
+++ b/bdd/tests/configs/ospfv2_virtual_link/r3m.yaml
@@ -1,0 +1,18 @@
+interface:
+- if-name: lo
+  ipv4:
+    address: 10.0.0.3/32
+- if-name: ethb
+  ipv4:
+    address: 10.0.23.2/30
+router:
+  ospf:
+    router-id: 10.0.0.3
+    area:
+    - area-id: 0.0.0.2
+      interface:
+      - if-name: lo
+        enable: true
+      - if-name: ethb
+        enable: true
+        network-type: point-to-point

--- a/bdd/tests/configs/ospfv2_virtual_link/rm.yaml
+++ b/bdd/tests/configs/ospfv2_virtual_link/rm.yaml
@@ -1,0 +1,27 @@
+# rm is a plain transit-area internal router between the two VL
+# endpoints — it knows nothing about the virtual link; it just
+# forwards the unicast VL packets like any transit traffic.
+interface:
+- if-name: lo
+  ipv4:
+    address: 10.0.0.4/32
+- if-name: etha
+  ipv4:
+    address: 10.0.12.2/30
+- if-name: ethb
+  ipv4:
+    address: 10.0.24.1/30
+router:
+  ospf:
+    router-id: 10.0.0.4
+    area:
+    - area-id: 0.0.0.1
+      interface:
+      - if-name: lo
+        enable: true
+      - if-name: etha
+        enable: true
+        network-type: point-to-point
+      - if-name: ethb
+        enable: true
+        network-type: point-to-point

--- a/bdd/tests/features/ospfv2_virtual_link.feature
+++ b/bdd/tests/features/ospfv2_virtual_link.feature
@@ -62,3 +62,56 @@ Feature: OSPFv2 virtual links connect a remote ABR to the backbone
     And I delete namespace "r2"
     And I delete namespace "r3"
     Then the test environment should be clean
+
+  Scenario: Multi-hop transit — the ABRs are two hops apart through the transit area
+    # r1 -- rm -- r2 inside area 1: the VL endpoints are NOT
+    # adjacent, so the peer endpoint address comes from the
+    # full-path SPF backlink walk (FRR ospf_vl_set_params), and the
+    # unicast VL packets are forwarded by rm like ordinary transit
+    # traffic. Routes through the VL must inherit the transit path's
+    # first hop (rm), not the far endpoint (RFC 2328 §16.1.1).
+    Given a clean test environment
+    When I create namespace "r1"
+    And I create namespace "rm"
+    And I create namespace "r2"
+    And I create namespace "r3"
+    And I connect namespace "r1" interface "ethm" to namespace "rm" interface "etha"
+    And I connect namespace "rm" interface "ethb" to namespace "r2" interface "ethm"
+    And I connect namespace "r2" interface "ethc" to namespace "r3" interface "ethb"
+    And I start zebra-rs in namespace "r1"
+    And I start zebra-rs in namespace "rm"
+    And I start zebra-rs in namespace "r2"
+    And I start zebra-rs in namespace "r3"
+    And I apply config "r1m.yaml" to namespace "r1"
+    And I apply config "rm.yaml" to namespace "rm"
+    And I apply config "r2m.yaml" to namespace "r2"
+    And I apply config "r3m.yaml" to namespace "r3"
+    And I wait 45 seconds
+
+    # Transit-area adjacencies (r1-rm, rm-r2) and area 2 (r2-r3).
+    Then show command "show ospf neighbor" in namespace "rm" should contain "Full"
+    And show command "show ospf neighbor" in namespace "r3" should contain "Full"
+
+    # The multi-hop virtual link is up on both ABRs.
+    And show command "show ospf interface" in namespace "r1" should contain "VLINK"
+    And show command "show ospf interface" in namespace "r2" should contain "VLINK"
+
+    # Backbone routes cross the two-hop VL in both directions.
+    And show command "show ospf route" in namespace "r2" should contain "10.0.0.1/32"
+    And show command "show ospf route" in namespace "r1" should contain "10.0.0.3/32"
+    And show command "show ospf route" in namespace "r3" should contain "10.0.0.1/32"
+
+    # End to end across the multi-hop transit path.
+    And ping from "r3" to "10.0.0.1" should succeed
+    And ping from "r1" to "10.0.0.3" should succeed
+
+    # Teardown.
+    When I stop zebra-rs in namespace "r1"
+    And I stop zebra-rs in namespace "rm"
+    And I stop zebra-rs in namespace "r2"
+    And I stop zebra-rs in namespace "r3"
+    And I delete namespace "r1"
+    And I delete namespace "rm"
+    And I delete namespace "r2"
+    And I delete namespace "r3"
+    Then the test environment should be clean

--- a/book/src/ch-08-12-ospf-frr-gaps.md
+++ b/book/src/ch-08-12-ospf-frr-gaps.md
@@ -2,10 +2,10 @@
 
 OSPFv2 features not yet implemented in zebra-rs:
 
-- Multi-hop virtual-link transit — virtual links themselves are
-  implemented (see below), but the two ABRs must be directly
-  adjacent within the transit area; per-interface authentication on
-  a virtual link is also not yet configurable.
+- Per-virtual-link authentication — virtual links themselves,
+  including multi-hop transit, are implemented (see below), but the
+  `authentication` / key leaves under `virtual-link` are not yet
+  wired.
 - NBMA and point-to-multipoint network types — the per-interface
   `network-type` knob accepts `broadcast` and `point-to-point`
   only.
@@ -72,6 +72,7 @@ per feature — see each feature's page):
 - **Virtual links** (RFC 2328 §15, `area <transit> virtual-link
   <router-id>`) — a synthetic backbone interface derived from the
   transit area's SPF, unicast OSPF over the transit area, the
-  VirtualLink Router-LSA entry and transit-area V-bit. Single-hop
-  transit; OSPFv2 only (`ospf6d` has no virtual links either). See
+  VirtualLink Router-LSA entry and transit-area V-bit; multi-hop
+  transit supported via the full-path SPF backlink walk. OSPFv2
+  only (`ospf6d` has no virtual links either). See
   [Multi-Area Routing and the ABR](ch-08-14-ospf-multi-area-abr.md#virtual-links).

--- a/book/src/ch-08-14-ospf-multi-area-abr.md
+++ b/book/src/ch-08-14-ospf-multi-area-abr.md
@@ -174,13 +174,22 @@ backbone SPF flows through the link and the far ABR becomes
 backbone-attached, originating summaries for its other areas as
 usual. If the transit path fails, the SPF re-run tears the VL down.
 
+The two ABRs need not be adjacent: on a **multi-hop transit path**
+the peer's endpoint address is derived from the full-path SPF
+backlink walk (the peer's transit-area Router-LSA link pointing back
+at the penultimate SPF hop — FRR's `ospf_vl_set_params`), the VL
+packets are forwarded by the intermediate transit routers like any
+unicast traffic, and routes computed *through* the VL inherit the
+transit path's first hop as their forwarding next hop
+(RFC 2328 §16.1.1).
+
 Current limits: the transit area must be a normal area (not stub /
-NSSA — §3.6 forbids it), and the two ABRs must be **directly
-adjacent within the transit area** (single-hop transit); a
-multi-hop transit path keeps the VL down with a debug log. OSPFv2
-only — same as FRR, whose `ospf6d` has no virtual-link support
-either. Validated end to end by `ospfv2_virtual_link.feature`
-(area 2 reaching an area-0 loopback exclusively through the VL).
+NSSA — §3.6 forbids it), and per-virtual-link authentication is not
+yet configurable. OSPFv2 only — same as FRR, whose `ospf6d` has no
+virtual-link support either. Validated end to end by
+`ospfv2_virtual_link.feature`: single-hop and two-hop transit
+topologies, each with area 2 reaching an area-0 loopback exclusively
+through the VL.
 
 ## OSPFv3
 

--- a/zebra-rs/src/ospf/inst.rs
+++ b/zebra-rs/src/ospf/inst.rs
@@ -2052,6 +2052,7 @@ impl Ospf<Ospfv2> {
             cost: u32,
             local_addr: Ipv4Addr,
             peer_addr: Ipv4Addr,
+            first_hop_addr: Ipv4Addr,
             first_hop_ifindex: u32,
         }
 
@@ -2076,26 +2077,32 @@ impl Ospf<Ospfv2> {
                     .filter(|(_, path)| path.cost < LS_INFINITY)
                     .and_then(|(vertex, path)| {
                         let nhops = build_spf_nexthops(self, vertex, path);
+                        // The far endpoint address: for a directly-
+                        // adjacent peer the SPF first-hop address IS
+                        // the peer; otherwise walk the peer's
+                        // Router-LSA backlink toward the penultimate
+                        // SPF vertex (RFC 2328 §15 / FRR
+                        // `ospf_vl_set_params`).
                         let direct = nhops.iter().find(|(_, nh)| nh.adjacency);
-                        if direct.is_none() && !nhops.is_empty() {
-                            tracing::debug!(
-                                "[VL] peer {} reachable in area {} but not adjacent (multi-hop transit unsupported)",
-                                peer,
-                                area_id
-                            );
-                        }
-                        direct.and_then(|(addr, nh)| {
-                            let local_addr = self
-                                .links
-                                .get(&nh.ifindex)
-                                .and_then(|l| l.addr.first())
-                                .map(|a| a.prefix.addr())?;
-                            Some(Viable {
-                                cost: path.cost,
-                                local_addr,
-                                peer_addr: *addr,
-                                first_hop_ifindex: nh.ifindex,
-                            })
+                        let (peer_addr, first_hop_addr, nh) = match direct {
+                            Some((addr, nh)) => (*addr, *addr, nh),
+                            None => {
+                                let addr = self.vl_peer_addr_backlink(*area_id, *peer, path)?;
+                                let (fh_addr, nh) = nhops.iter().next()?;
+                                (addr, *fh_addr, nh)
+                            }
+                        };
+                        let local_addr = self
+                            .links
+                            .get(&nh.ifindex)
+                            .and_then(|l| l.addr.first())
+                            .map(|a| a.prefix.addr())?;
+                        Some(Viable {
+                            cost: path.cost,
+                            local_addr,
+                            peer_addr,
+                            first_hop_addr,
+                            first_hop_ifindex: nh.ifindex,
                         })
                     });
                 desired.push((*area_id, *peer, viable));
@@ -2128,11 +2135,13 @@ impl Ospf<Ospfv2> {
                 let prefix = Ipv4Net::new(v.local_addr, 32).unwrap();
                 let vl = link.vl.as_mut().unwrap();
                 if vl.peer_addr != v.peer_addr
+                    || vl.first_hop_addr != v.first_hop_addr
                     || vl.first_hop_ifindex != v.first_hop_ifindex
                     || link.output_cost != v.cost
                     || link.addr.first().map(|a| a.prefix.addr()) != Some(v.local_addr)
                 {
                     vl.peer_addr = v.peer_addr;
+                    vl.first_hop_addr = v.first_hop_addr;
                     vl.first_hop_ifindex = v.first_hop_ifindex;
                     link.output_cost = v.cost;
                     link.addr = vec![super::addr::OspfAddr { prefix }];
@@ -2176,6 +2185,7 @@ impl Ospf<Ospfv2> {
                 {
                     let vl = link.vl.as_mut().unwrap();
                     vl.peer_addr = v.peer_addr;
+                    vl.first_hop_addr = v.first_hop_addr;
                     vl.first_hop_ifindex = v.first_hop_ifindex;
                 }
                 self.links.insert(idx, link);
@@ -2221,6 +2231,51 @@ impl Ospf<Ospfv2> {
             self.abr_summary_originate();
             self.nssa_translate_resync_all();
         }
+    }
+
+    /// Multi-hop VL peer-endpoint derivation — the FRR
+    /// `ospf_vl_set_params` backlink walk. Given the transit-area SPF
+    /// `path` to the peer ABR (computed with `SpfOpt::full_path()`,
+    /// which `build_spf_input` enables for VL transit areas), take a
+    /// full vertex chain `[first_hop, ..., penultimate, peer]`,
+    /// resolve the penultimate vertex to its `lsp_map` key (a
+    /// router-id for router vertices, the DR interface address for
+    /// network pseudo-vertices — both live in the same id-space), and
+    /// return the `link_data` of the peer's transit-area Router-LSA
+    /// link that points back at it. That link_data is the peer's
+    /// interface address on the last hop of the path: a unicast
+    /// destination the transit area can route to.
+    fn vl_peer_addr_backlink(
+        &self,
+        transit_area: Ipv4Addr,
+        peer: Ipv4Addr,
+        path: &spf::Path,
+    ) -> Option<Ipv4Addr> {
+        let chain = path.paths.iter().find(|c| c.len() >= 2)?;
+        let penultimate = chain[chain.len() - 2];
+        let prev_key = *self.lsp_map.resolve(penultimate)?;
+        let area = self.areas.get(transit_area)?;
+        let lsa = area.lsdb.lookup_by_id(OspfLsType::Router, peer, peer)?;
+        let OspfLsp::Router(ref rl) = lsa.lsp else {
+            return None;
+        };
+        let addr = rl
+            .links
+            .iter()
+            .find(|l| {
+                matches!(l.link_type, OspfLinkType::P2p | OspfLinkType::Transit)
+                    && l.link_id == prev_key
+            })
+            .map(|l| l.link_data);
+        if addr.is_none() {
+            tracing::debug!(
+                "[VL] peer {} in area {}: no backlink toward {} in its Router-LSA",
+                peer,
+                transit_area,
+                prev_key
+            );
+        }
+        addr
     }
 
     /// Compute the set of `prefix -> metric` Type-3 summaries to
@@ -11921,15 +11976,18 @@ fn build_spf_nexthops(
         for (ifindex, link) in top.links.iter() {
             for (_, nbr) in link.nbrs.iter() {
                 if *nhop_id == nbr.ident.router_id {
-                    let addr = nbr.ident.prefix.addr();
                     // A virtual-link adjacency has a synthetic ifindex
-                    // with no kernel interface behind it; forwarding
-                    // toward the VL peer egresses the physical
-                    // transit-area interface (RFC 2328 §16.1.1 — the
-                    // VL inherits the transit path's next hop).
-                    let egress = match &link.vl {
-                        Some(vl) => vl.first_hop_ifindex,
-                        None => *ifindex,
+                    // with no kernel interface behind it, and on a
+                    // multi-hop transit path the VL neighbor's address
+                    // is not on-link. Routes through the VL inherit
+                    // the *transit-area path's* first hop instead
+                    // (RFC 2328 §16.1.1): `first_hop_addr` +
+                    // `first_hop_ifindex`, both derived by
+                    // `vl_reconcile` (equal to the neighbor address /
+                    // physical egress when the peer is adjacent).
+                    let (addr, egress) = match &link.vl {
+                        Some(vl) => (vl.first_hop_addr, vl.first_hop_ifindex),
+                        None => (nbr.ident.prefix.addr(), *ifindex),
                     };
                     let nhop = SpfNexthop {
                         ifindex: egress,
@@ -13148,6 +13206,8 @@ fn build_v3_spf_input(top: &mut Ospf<Ospfv3>, area_id: Ipv4Addr) -> Option<SpfIn
         area_id,
         graph,
         source,
+        // Virtual links are v2-only; v3 never needs full chains.
+        full_path: false,
         ti_lfa_enabled: top.ti_lfa_enabled,
         tilfa_mode: top
             .ti_lfa_compute_mode
@@ -14215,6 +14275,12 @@ struct SpfInput {
     area_id: Ipv4Addr,
     graph: spf::Graph,
     source: usize,
+    /// Run the primary SPF with `SpfOpt::full_path()` — set when this
+    /// area is the transit area of a configured virtual link, whose
+    /// multi-hop peer-endpoint derivation needs the full vertex chains
+    /// (RFC 2328 §15 / the FRR backlink walk). `nexthops` is populated
+    /// in both modes, so every other consumer is unaffected.
+    full_path: bool,
     /// `/router/ospf/fast-reroute/ti-lfa` snapshot. Gates the
     /// graph-only TI-LFA repair computation on the worker.
     ti_lfa_enabled: bool,
@@ -14292,6 +14358,13 @@ fn build_spf_input(top: &mut Ospf, area_id: Ipv4Addr) -> Option<SpfInput> {
         area_id,
         graph,
         source,
+        // Transit area of a configured VL: keep the full vertex
+        // chains so `vl_reconcile` can walk to the penultimate hop
+        // for the multi-hop peer-endpoint derivation.
+        full_path: top
+            .areas
+            .get(area_id)
+            .is_some_and(|a| !a.virtual_links.is_empty()),
         ti_lfa_enabled: top.ti_lfa_enabled,
         tilfa_mode: top
             .ti_lfa_compute_mode
@@ -14307,12 +14380,18 @@ fn compute_spf(input: SpfInput) -> SpfOutput {
         area_id,
         graph,
         source,
+        full_path,
         ti_lfa_enabled,
         tilfa_mode,
         flex_algos,
     } = input;
     let start = Instant::now();
-    let spf_result = spf::spf(&graph, source, &spf::SpfOpt::default());
+    let opt = if full_path {
+        spf::SpfOpt::full_path()
+    } else {
+        spf::SpfOpt::default()
+    };
+    let spf_result = spf::spf(&graph, source, &opt);
 
     // TI-LFA repair lists, graph-only. Gated on `fast-reroute ti-lfa`;
     // when off, the SPF primary RIB still installs — only the repair

--- a/zebra-rs/src/ospf/link.rs
+++ b/zebra-rs/src/ospf/link.rs
@@ -512,9 +512,16 @@ pub struct VirtualLinkState {
     /// Router-ID of the ABR at the far end (the config key).
     pub peer_router_id: Ipv4Addr,
     /// Unicast destination for OSPF packets on this VL: the peer's
-    /// interface address on the transit-area path (single-hop transit:
-    /// the first-hop neighbor address from `build_spf_nexthops`).
+    /// interface address on the transit-area path (single-hop: the
+    /// first-hop neighbor address; multi-hop: the backlink-derived
+    /// endpoint from the peer's transit-area Router-LSA).
     pub peer_addr: Ipv4Addr,
+    /// The transit-area path's first-hop neighbor address. Routes
+    /// computed *through* the VL inherit this as their forwarding
+    /// next hop (RFC 2328 §16.1.1) — it is on-link, unlike
+    /// `peer_addr` on a multi-hop transit path. Equal to `peer_addr`
+    /// when the peer is directly adjacent.
+    pub first_hop_addr: Ipv4Addr,
     /// Physical egress ifindex toward the peer through the transit
     /// area — the ifindex handed to `Message::Send` in place of the
     /// synthetic one.
@@ -646,6 +653,7 @@ where
                 transit_area,
                 peer_router_id,
                 peer_addr: Ipv4Addr::UNSPECIFIED,
+                first_hop_addr: Ipv4Addr::UNSPECIFIED,
                 first_hop_ifindex: 0,
             }),
         }

--- a/zebra-rs/src/spf/calc.rs
+++ b/zebra-rs/src/spf/calc.rs
@@ -237,7 +237,12 @@ pub fn spf_calc(
                 c.cost = v.cost.saturating_add(link.cost);
                 c.paths.clear();
                 // Strictly better path replaces everything; old
-                // first-hop set was from a worse-cost relaxation.
+                // first-hop / nexthop sets were from a worse-cost
+                // relaxation. (Without the `nexthops` clear, a
+                // worse-then-better relaxation order left the stale
+                // first hop in the set and it installed as phantom
+                // ECMP.)
+                c.nexthops.clear();
                 c.first_hop_links.clear();
             }
 
@@ -245,10 +250,14 @@ pub fn spf_calc(
                 let path = vec![c.id];
 
                 if opt.full_path {
-                    c.paths.push(path);
-                } else {
-                    c.nexthops.insert(path);
+                    c.paths.push(path.clone());
                 }
+                // `nexthops` is populated in BOTH modes: full-path
+                // consumers (TI-LFA target selection, the OSPF/IS-IS
+                // rib builders) read first hops from it regardless,
+                // so `full_path` is a strict superset, not a
+                // different shape.
+                c.nexthops.insert(path);
                 // c is a direct neighbour of root — this relaxation
                 // is itself the first hop. Record it with the link's
                 // identifier so the rib-builder can resolve back to
@@ -261,6 +270,14 @@ pub fn spf_calc(
                         newpath.push(c.id);
                         c.paths.push(newpath);
                     }
+                }
+                // First hops inherit exactly as in the default mode.
+                for nhop in &v.nexthops {
+                    let mut newnhop = nhop.clone();
+                    if nhop.is_empty() {
+                        newnhop.push(c.id);
+                    }
+                    c.nexthops.insert(newnhop);
                 }
                 // Deeper hop — propagate v's first-hop set unchanged.
                 c.first_hop_links.extend(v.first_hop_links.iter().copied());
@@ -284,9 +301,10 @@ pub fn spf_calc(
                 if let Some(v) = bt.get_mut(&(c.cost, c.id)) {
                     if opt.full_path {
                         v.paths = c.paths.clone();
-                    } else {
-                        v.nexthops = c.nexthops.clone();
                     }
+                    // Synced in both modes — `nexthops` is always
+                    // populated (see the relaxation above).
+                    v.nexthops = c.nexthops.clone();
                     v.first_hop_links = c.first_hop_links.clone();
                 }
             } else {
@@ -1560,5 +1578,89 @@ mod tests {
             "r1↔r2 is P2P — via must be None, not the absorbed n2.04 LAN"
         );
         assert_eq!(seg_disp(&graph, &repair.segs[2]), "AdjSid(r2, r3)");
+    }
+
+    /// Tiny triangle where the destination is relaxed via a worse
+    /// direct edge FIRST (root pops before the cheaper intermediate),
+    /// then strictly better through the intermediate. The stale
+    /// worse-cost first hop must not survive in `nexthops` as phantom
+    /// ECMP — regression test for the missing `nexthops.clear()` on
+    /// strictly-better relaxation.
+    #[test]
+    fn better_relaxation_clears_stale_nexthop() {
+        let mut graph: Graph = BTreeMap::new();
+        for (name, id) in [("root", 0), ("mid", 1), ("dest", 2)] {
+            graph.insert(id, Vertex::new_node(name, id));
+        }
+        for (from, to, cost) in [
+            (0, 2, 20),
+            (0, 1, 5),
+            (1, 2, 2),
+            (2, 0, 20),
+            (1, 0, 5),
+            (2, 1, 2),
+        ] {
+            graph
+                .get_mut(&from)
+                .unwrap()
+                .olinks
+                .push(Link::new(from, to, cost));
+            graph
+                .get_mut(&to)
+                .unwrap()
+                .ilinks
+                .push(Link::new(from, to, cost));
+        }
+
+        for opt in [SpfOpt::default(), SpfOpt::full_path()] {
+            let tree = spf(&graph, 0, &opt);
+            let dest = tree.get(&2).expect("dest reachable");
+            assert_eq!(dest.cost, 7, "0->1->2 is the only best path");
+            assert_eq!(
+                dest.nexthops.len(),
+                1,
+                "stale direct first hop must be cleared, got {:?}",
+                dest.nexthops
+            );
+            let nhop = dest.nexthops.iter().next().unwrap();
+            assert_eq!(nhop[0], 1, "first hop must be mid, not the direct edge");
+        }
+    }
+
+    /// `full_path` mode must populate `nexthops` too (a strict
+    /// superset of the default mode): TI-LFA target selection and the
+    /// OSPF/IS-IS rib builders read first hops from `nexthops`
+    /// regardless of which mode produced the tree — needed by the
+    /// virtual-link transit-area SPF, which runs full-path.
+    #[test]
+    fn full_path_also_populates_nexthops() {
+        let graph = tilfa_graph();
+        let full = spf(&graph, 0, &SpfOpt::full_path());
+        let dflt = spf(&graph, 0, &SpfOpt::default());
+
+        for (id, d_path) in dflt.iter() {
+            // The root's own entry carries the empty chain sentinel.
+            if *id == 0 {
+                continue;
+            }
+            let f_path = full.get(id).expect("same reachability");
+            assert_eq!(f_path.cost, d_path.cost, "vertex {id} cost");
+            // First-hop sets must agree between modes.
+            let f_hops: BTreeSet<usize> = f_path
+                .nexthops
+                .iter()
+                .filter_map(|p| p.first().copied())
+                .collect();
+            let d_hops: BTreeSet<usize> = d_path
+                .nexthops
+                .iter()
+                .filter_map(|p| p.first().copied())
+                .collect();
+            assert_eq!(f_hops, d_hops, "vertex {id} first hops");
+            // And every full chain's first element must be a first hop.
+            for chain in &f_path.paths {
+                assert!(f_hops.contains(&chain[0]), "vertex {id} chain {chain:?}");
+            }
+        }
     }
 }


### PR DESCRIPTION
## Summary

#1749 shipped virtual links with a **single-hop transit** restriction — the two ABRs had to be directly adjacent in the transit area, because the SPF first-hop neighbor address doubled as the peer endpoint. This lifts that restriction, completing RFC 2328 §15: the ABRs may be **any number of transit hops apart**, with the intermediate routers forwarding the unicast VL packets as plain transit traffic (they are VL-unaware).

### How
- **Full-path SPF for VL transit areas**: new `SpfInput::full_path` flag — the transit area of a configured VL runs `SpfOpt::full_path()` so the full vertex chains are available to the reconcile.
- **`spf_calc` now populates `nexthops` in BOTH modes** (full-path becomes a strict superset of default). Previously full-path trees had empty `nexthops`, which would have broken `build_spf_nexthops` and TI-LFA target selection for any area running full-path. While there, fixed a **latent SPF bug**: the strictly-better relaxation cleared `paths`/`first_hop_links` but not `nexthops`, so a worse-then-better relaxation order left the stale first hop in the set as phantom ECMP. Two new unit tests cover both.
- **Backlink walk** (port of FRR `ospf_vl_set_params`): with no direct adjacency, `vl_peer_addr_backlink` takes a full chain `[first, …, penultimate, peer]`, resolves the penultimate vertex via `lsp_map` (router-ids and DR-address pseudo-vertices share one id-space, so P2P and broadcast segments use the same match), and returns the `link_data` of the peer's transit-area Router-LSA link pointing back at it — the peer's interface address on the path's last hop.
- **§16.1.1 forwarding**: routes *through* the VL inherit the transit path's first hop. `VirtualLinkState` gains `first_hop_addr`; `build_spf_nexthops` substitutes `(first_hop_addr, first_hop_ifindex)` for VL adjacencies — the VL neighbor's own address is not on-link on a multi-hop path. Equal to the neighbor address when adjacent, so single-hop behavior is byte-identical.
- The unicast send path needed **zero changes**: synthetic-ifindex sends already hand egress to the kernel FIB, which routes through the transit area.

## Test plan
- `ospfv2_virtual_link` BDD gains a **multi-hop scenario**: `r1 — rm — r2` inside the transit area (rm knows nothing about the VL), area 2 reaching an area-0 loopback exclusively across the two-hop VL; asserts VLINK interfaces, routes both directions, end-to-end pings. **Both scenarios (single-hop regression + multi-hop) pass locally.**
- Full `cargo test`: **1516 passed** (includes the two new SPF unit tests); fmt, workspace clippy, mdbook clean.

## Docs
Multi-area/ABR page documents the multi-hop derivation; the FRR-gaps entry narrows to per-virtual-link authentication (the remaining §15 sub-item).

🤖 Generated with [Claude Code](https://claude.com/claude-code)