### PR TITLE
feat(ospf): per-virtual-link authentication (RFC 2328 §15)

### DIFF
--- a/bdd/tests/configs/ospfv2_virtual_link/r1a.yaml
+++ b/bdd/tests/configs/ospfv2_virtual_link/r1a.yaml
@@ -1,0 +1,28 @@
+interface:
+- if-name: lo
+  ipv4:
+    address: 10.0.0.1/32
+- if-name: ethb
+  ipv4:
+    address: 10.0.12.1/30
+router:
+  ospf:
+    router-id: 10.0.0.1
+    area:
+    - area-id: 0.0.0.0
+      interface:
+      - if-name: lo
+        enable: true
+    - area-id: 0.0.0.1
+      # RFC 2328 §15: the virtual link carries its OWN authentication,
+      # independent of the (unauthenticated) transit-area interfaces.
+      virtual-link:
+      - router-id: 10.0.0.2
+        authentication: message-digest
+        message-digest-key:
+        - key-id: 1
+          md5: VLSECRET
+      interface:
+      - if-name: ethb
+        enable: true
+        network-type: point-to-point

--- a/bdd/tests/configs/ospfv2_virtual_link/r2a.yaml
+++ b/bdd/tests/configs/ospfv2_virtual_link/r2a.yaml
@@ -1,0 +1,32 @@
+interface:
+- if-name: lo
+  ipv4:
+    address: 10.0.0.2/32
+- if-name: etha
+  ipv4:
+    address: 10.0.12.2/30
+- if-name: ethc
+  ipv4:
+    address: 10.0.23.1/30
+router:
+  ospf:
+    router-id: 10.0.0.2
+    area:
+    - area-id: 0.0.0.1
+      virtual-link:
+      - router-id: 10.0.0.1
+        authentication: message-digest
+        message-digest-key:
+        - key-id: 1
+          md5: VLSECRET
+      interface:
+      - if-name: lo
+        enable: true
+      - if-name: etha
+        enable: true
+        network-type: point-to-point
+    - area-id: 0.0.0.2
+      interface:
+      - if-name: ethc
+        enable: true
+        network-type: point-to-point

--- a/bdd/tests/features/ospfv2_virtual_link.feature
+++ b/bdd/tests/features/ospfv2_virtual_link.feature
@@ -115,3 +115,38 @@ Feature: OSPFv2 virtual links connect a remote ABR to the backbone
     And I delete namespace "r2"
     And I delete namespace "r3"
     Then the test environment should be clean
+
+  Scenario: Virtual link with MD5 authentication forms and carries routes
+    # RFC 2328 §15: the VL has its own authentication (message-digest
+    # key VLSECRET on both ends), independent of the unauthenticated
+    # transit-area adjacency. Same topology as the first scenario.
+    Given a clean test environment
+    When I create namespace "r1"
+    And I create namespace "r2"
+    And I create namespace "r3"
+    And I connect namespace "r1" interface "ethb" to namespace "r2" interface "etha"
+    And I connect namespace "r2" interface "ethc" to namespace "r3" interface "ethb"
+    And I start zebra-rs in namespace "r1"
+    And I start zebra-rs in namespace "r2"
+    And I start zebra-rs in namespace "r3"
+    And I apply config "r1a.yaml" to namespace "r1"
+    And I apply config "r2a.yaml" to namespace "r2"
+    And I apply config "r3.yaml" to namespace "r3"
+    And I wait 40 seconds
+
+    # The authenticated VL is up on both ABRs and carries routes.
+    Then show command "show ospf interface" in namespace "r1" should contain "VLINK"
+    And show command "show ospf interface" in namespace "r2" should contain "VLINK"
+    And show command "show ospf route" in namespace "r2" should contain "10.0.0.1/32"
+    And show command "show ospf route" in namespace "r1" should contain "10.0.0.3/32"
+    And show command "show ospf route" in namespace "r3" should contain "10.0.0.1/32"
+    And ping from "r3" to "10.0.0.1" should succeed
+
+    # Teardown.
+    When I stop zebra-rs in namespace "r1"
+    And I stop zebra-rs in namespace "r2"
+    And I stop zebra-rs in namespace "r3"
+    And I delete namespace "r1"
+    And I delete namespace "r2"
+    And I delete namespace "r3"
+    Then the test environment should be clean

--- a/book/src/ch-08-12-ospf-frr-gaps.md
+++ b/book/src/ch-08-12-ospf-frr-gaps.md
@@ -2,10 +2,6 @@
 
 OSPFv2 features not yet implemented in zebra-rs:
 
-- Per-virtual-link authentication — virtual links themselves,
-  including multi-hop transit, are implemented (see below), but the
-  `authentication` / key leaves under `virtual-link` are not yet
-  wired.
 - NBMA and point-to-multipoint network types — the per-interface
   `network-type` knob accepts `broadcast` and `point-to-point`
   only.
@@ -73,6 +69,7 @@ per feature — see each feature's page):
   <router-id>`) — a synthetic backbone interface derived from the
   transit area's SPF, unicast OSPF over the transit area, the
   VirtualLink Router-LSA entry and transit-area V-bit; multi-hop
-  transit supported via the full-path SPF backlink walk. OSPFv2
-  only (`ospf6d` has no virtual links either). See
+  transit via the full-path SPF backlink walk, and per-virtual-link
+  authentication (simple / MD5 / key-chain). OSPFv2 only (`ospf6d`
+  has no virtual links either). See
   [Multi-Area Routing and the ABR](ch-08-14-ospf-multi-area-abr.md#virtual-links).

--- a/book/src/ch-08-14-ospf-multi-area-abr.md
+++ b/book/src/ch-08-14-ospf-multi-area-abr.md
@@ -160,6 +160,28 @@ Both endpoints configure the link under the transit area, naming the
 `dead-interval`, and `retransmit-interval` leaves override the
 RFC defaults (10/40/5 s) and must match on both ends.
 
+A virtual link carries its **own authentication**, independent of
+the transit area's interfaces (§15) — the same leaves as a physical
+interface, on the `virtual-link` entry:
+
+```
+router ospf {
+  area 0.0.0.1 {
+    virtual-link 10.0.0.2 {
+      authentication message-digest;
+      message-digest-key 1 {
+        md5 SECRET;
+      }
+    }
+  }
+}
+```
+
+`authentication` (`null` / `simple` / `message-digest`),
+`authentication-key`, the `message-digest-key` list, and `key-chain`
+(RFC 8177) behave exactly as on
+[a physical interface](ch-08-16-ospf-authentication.md).
+
 Everything else is derived, not configured. When the transit area's
 SPF finds the peer ABR reachable, zebra-rs materializes a synthetic
 backbone interface (`VLINK<area>-<router-id>` in `show ospf
@@ -184,12 +206,11 @@ transit path's first hop as their forwarding next hop
 (RFC 2328 §16.1.1).
 
 Current limits: the transit area must be a normal area (not stub /
-NSSA — §3.6 forbids it), and per-virtual-link authentication is not
-yet configurable. OSPFv2 only — same as FRR, whose `ospf6d` has no
-virtual-link support either. Validated end to end by
-`ospfv2_virtual_link.feature`: single-hop and two-hop transit
-topologies, each with area 2 reaching an area-0 loopback exclusively
-through the VL.
+NSSA — §3.6 forbids it). OSPFv2 only — same as FRR, whose `ospf6d`
+has no virtual-link support either. Validated end to end by
+`ospfv2_virtual_link.feature`: single-hop, two-hop, and
+MD5-authenticated transit topologies, each with area 2 reaching an
+area-0 loopback exclusively through the VL.
 
 ## OSPFv3
 

--- a/zebra-rs/src/ospf/area.rs
+++ b/zebra-rs/src/ospf/area.rs
@@ -324,15 +324,25 @@ pub struct AreaRange {
 }
 
 /// One configured `area <id> virtual-link <router-id>` entry
-/// (RFC 2328 §15). Interval overrides mirror the per-interface
-/// leaves; `None` falls back to the RFC defaults the synthetic
-/// link's `LinkConfig` already carries (hello 10s / dead 40s /
-/// retransmit 5s).
-#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+/// (RFC 2328 §15). Interval and authentication overrides mirror the
+/// per-interface leaves; `None`/empty falls back to the defaults the
+/// synthetic link's `LinkConfig` already carries (hello 10s / dead
+/// 40s / retransmit 5s, Null auth). Copied onto the synthetic link
+/// by `Ospf::vl_reconcile` on every create/refresh.
+#[derive(Debug, Default, Clone)]
 pub struct VirtualLinkConfig {
     pub hello_interval: Option<u16>,
     pub dead_interval: Option<u32>,
     pub retransmit_interval: Option<u16>,
+    /// RFC 2328 §D authentication mode (null / simple /
+    /// message-digest), same semantics as the per-interface leaf.
+    pub auth_mode: Option<super::link::OspfAuthMode>,
+    /// Simple-password key, zero-padded to the 8-octet wire field.
+    pub auth_key: Option<[u8; 8]>,
+    /// MD5 keys keyed by key-id (`message-digest-key <id> md5 <key>`).
+    pub crypto_keys: BTreeMap<u8, super::link::AuthKey>,
+    /// RFC 8177 key-chain name; supersedes `crypto_keys` when set.
+    pub key_chain: Option<String>,
 }
 
 impl<V: OspfVersion> OspfArea<V> {

--- a/zebra-rs/src/ospf/config.rs
+++ b/zebra-rs/src/ospf/config.rs
@@ -85,6 +85,22 @@ impl Ospf {
             "/area/virtual-link/retransmit-interval",
             config_ospf_area_virtual_link_retransmit_interval,
         );
+        self.ospf_add(
+            "/area/virtual-link/authentication",
+            config_ospf_area_virtual_link_authentication,
+        );
+        self.ospf_add(
+            "/area/virtual-link/authentication-key",
+            config_ospf_area_virtual_link_authentication_key,
+        );
+        self.ospf_add(
+            "/area/virtual-link/message-digest-key/md5",
+            config_ospf_area_virtual_link_md5_key,
+        );
+        self.ospf_add(
+            "/area/virtual-link/key-chain",
+            config_ospf_area_virtual_link_key_chain,
+        );
         self.ospf_add("/area/interface/enable", config_ospf_interface_enable);
         self.ospf_add(
             "/area/interface/bfd/enable",
@@ -919,6 +935,134 @@ fn config_ospf_area_virtual_link_retransmit_interval(
         .entry(peer)
         .or_default()
         .retransmit_interval = value;
+    ospf.vl_reconcile();
+    Some(())
+}
+
+/// `/router/ospf/area/<id>/virtual-link/<rid>/authentication` —
+/// RFC 2328 §15: a virtual link carries its own authentication,
+/// independent of the transit area's interfaces. Same modes as the
+/// per-interface leaf.
+fn config_ospf_area_virtual_link_authentication(
+    ospf: &mut Ospf,
+    mut args: Args,
+    op: ConfigOp,
+) -> Option<()> {
+    let area_id = parse_area_id(&args.string()?)?;
+    let peer = args.v4addr()?;
+    let mode = if op.is_set() {
+        Some(match args.string()?.as_str() {
+            "null" => OspfAuthMode::Null,
+            "simple" => OspfAuthMode::Simple,
+            "message-digest" => OspfAuthMode::MessageDigest,
+            _ => return None,
+        })
+    } else {
+        None
+    };
+    ospf.areas
+        .fetch(area_id)
+        .virtual_links
+        .entry(peer)
+        .or_default()
+        .auth_mode = mode;
+    ospf.vl_reconcile();
+    Some(())
+}
+
+/// `/router/ospf/area/<id>/virtual-link/<rid>/authentication-key`.
+fn config_ospf_area_virtual_link_authentication_key(
+    ospf: &mut Ospf,
+    mut args: Args,
+    op: ConfigOp,
+) -> Option<()> {
+    let area_id = parse_area_id(&args.string()?)?;
+    let peer = args.v4addr()?;
+    let key = if op.is_set() {
+        let key = args.string()?;
+        let bytes = key.as_bytes();
+        // RFC 2328 §D.3 caps the simple-password at 8 octets.
+        if bytes.is_empty() || bytes.len() > 8 {
+            return None;
+        }
+        let mut padded = [0u8; 8];
+        padded[..bytes.len()].copy_from_slice(bytes);
+        Some(padded)
+    } else {
+        None
+    };
+    ospf.areas
+        .fetch(area_id)
+        .virtual_links
+        .entry(peer)
+        .or_default()
+        .auth_key = key;
+    ospf.vl_reconcile();
+    Some(())
+}
+
+/// `/router/ospf/area/<id>/virtual-link/<rid>/message-digest-key/<key-id>/md5`.
+fn config_ospf_area_virtual_link_md5_key(
+    ospf: &mut Ospf,
+    mut args: Args,
+    op: ConfigOp,
+) -> Option<()> {
+    use super::link::{AuthKey, OspfCryptoAlgo};
+
+    let area_id = parse_area_id(&args.string()?)?;
+    let peer = args.v4addr()?;
+    let key_id: u8 = args.string()?.parse().ok()?;
+    if key_id == 0 {
+        return None;
+    }
+    let vl = ospf
+        .areas
+        .fetch(area_id)
+        .virtual_links
+        .entry(peer)
+        .or_default();
+    if op.is_set() {
+        let key = args.string()?;
+        let bytes = key.as_bytes();
+        // RFC 2328 §D.4 caps the simple MD5 key at 16 octets.
+        if bytes.is_empty() || bytes.len() > 16 {
+            return None;
+        }
+        let mut padded = vec![0u8; 16];
+        padded[..bytes.len()].copy_from_slice(bytes);
+        vl.crypto_keys.insert(
+            key_id,
+            AuthKey {
+                algo: OspfCryptoAlgo::Md5,
+                raw: padded,
+            },
+        );
+    } else {
+        vl.crypto_keys.remove(&key_id);
+    }
+    ospf.vl_reconcile();
+    Some(())
+}
+
+/// `/router/ospf/area/<id>/virtual-link/<rid>/key-chain`.
+fn config_ospf_area_virtual_link_key_chain(
+    ospf: &mut Ospf,
+    mut args: Args,
+    op: ConfigOp,
+) -> Option<()> {
+    let area_id = parse_area_id(&args.string()?)?;
+    let peer = args.v4addr()?;
+    let value = if op.is_set() {
+        Some(args.string()?)
+    } else {
+        None
+    };
+    ospf.areas
+        .fetch(area_id)
+        .virtual_links
+        .entry(peer)
+        .or_default()
+        .key_chain = value;
     ospf.vl_reconcile();
     Some(())
 }

--- a/zebra-rs/src/ospf/inst.rs
+++ b/zebra-rs/src/ospf/inst.rs
@@ -2058,7 +2058,13 @@ impl Ospf<Ospfv2> {
 
         // Pass 1 (immutable): resolve every configured VL to its
         // desired state. `None` viable = configured but unreachable.
-        let mut desired: Vec<(Ipv4Addr, Ipv4Addr, Option<Viable>)> = Vec::new();
+        type VlDesired = (
+            Ipv4Addr,
+            Ipv4Addr,
+            super::area::VirtualLinkConfig,
+            Option<Viable>,
+        );
+        let mut desired: Vec<VlDesired> = Vec::new();
         for (area_id, area) in self.areas.iter() {
             if area.virtual_links.is_empty() {
                 continue;
@@ -2068,7 +2074,7 @@ impl Ospf<Ospfv2> {
             if *area_id == AREA0 || area.area_type.is_stub_or_nssa() {
                 continue;
             }
-            for peer in area.virtual_links.keys() {
+            for (peer, cfg) in area.virtual_links.iter() {
                 let viable = self
                     .spf_results
                     .get(area_id)
@@ -2105,7 +2111,7 @@ impl Ospf<Ospfv2> {
                             first_hop_ifindex: nh.ifindex,
                         })
                     });
-                desired.push((*area_id, *peer, viable));
+                desired.push((*area_id, *peer, cfg.clone(), viable));
             }
         }
 
@@ -2123,7 +2129,7 @@ impl Ospf<Ospfv2> {
         let mut keep: BTreeSet<u32> = BTreeSet::new();
 
         // Pass 2 (mutable): create / refresh viable VLs.
-        for (transit, peer, viable) in &desired {
+        for (transit, peer, cfg, viable) in &desired {
             let Some(v) = viable else {
                 continue;
             };
@@ -2132,6 +2138,11 @@ impl Ospf<Ospfv2> {
                 let Some(link) = self.links.get_mut(&idx) else {
                     continue;
                 };
+                // Config (intervals + authentication) re-applies on
+                // every refresh so a live VL picks up changes; auth
+                // affects only packet emit/verify, not the LSA state,
+                // so it doesn't count as a `changed` trigger.
+                Self::vl_apply_config(link, cfg);
                 let prefix = Ipv4Net::new(v.local_addr, 32).unwrap();
                 let vl = link.vl.as_mut().unwrap();
                 if vl.peer_addr != v.peer_addr
@@ -2168,16 +2179,9 @@ impl Ospf<Ospfv2> {
                     *transit,
                     *peer,
                 );
-                // Interval overrides from the transit area's config.
-                if let Some(cfg) = self
-                    .areas
-                    .get(*transit)
-                    .and_then(|a| a.virtual_links.get(peer))
-                {
-                    link.config.hello_interval = cfg.hello_interval;
-                    link.config.dead_interval = cfg.dead_interval;
-                    link.config.retransmit_interval = cfg.retransmit_interval;
-                }
+                // Intervals + authentication from the transit area's
+                // virtual-link config.
+                Self::vl_apply_config(&mut link, cfg);
                 let prefix = Ipv4Net::new(v.local_addr, 32).unwrap();
                 link.output_cost = v.cost;
                 link.addr = vec![super::addr::OspfAddr { prefix }];
@@ -2231,6 +2235,20 @@ impl Ospf<Ospfv2> {
             self.abr_summary_originate();
             self.nssa_translate_resync_all();
         }
+    }
+
+    /// Copy a virtual link's configuration (interval overrides +
+    /// authentication) onto its synthetic link's `LinkConfig`.
+    /// Re-applied on every reconcile so a live VL picks up config
+    /// changes; the send/verify paths read `link.config` directly.
+    fn vl_apply_config(link: &mut OspfLink, cfg: &super::area::VirtualLinkConfig) {
+        link.config.hello_interval = cfg.hello_interval;
+        link.config.dead_interval = cfg.dead_interval;
+        link.config.retransmit_interval = cfg.retransmit_interval;
+        link.config.auth_mode = cfg.auth_mode;
+        link.config.auth_key = cfg.auth_key;
+        link.config.crypto_keys = cfg.crypto_keys.clone();
+        link.config.key_chain = cfg.key_chain.clone();
     }
 
     /// Multi-hop VL peer-endpoint derivation — the FRR

--- a/zebra-rs/yang/zebra-ospf-auth-md5.yang
+++ b/zebra-rs/yang/zebra-ospf-auth-md5.yang
@@ -108,4 +108,20 @@ module zebra-ospf-auth-md5 {
        is path-valid.";
     uses ospf-interface-md5-extension;
   }
+
+  augment "/configure:set/config:router"
+        + "/config:ospf/config:area/config:virtual-link" {
+    description
+      "RFC 2328 §15 gives a virtual link its own authentication —
+       attach the message-digest-key list to each virtual-link
+       entry.";
+    uses ospf-interface-md5-extension;
+  }
+
+  augment "/configure:delete/config:router"
+        + "/config:ospf/config:area/config:virtual-link" {
+    description
+      "Delete-subtree mirror for the virtual-link attachment.";
+    uses ospf-interface-md5-extension;
+  }
 }

--- a/zebra-rs/yang/zebra-ospf-auth-simple.yang
+++ b/zebra-rs/yang/zebra-ospf-auth-simple.yang
@@ -131,4 +131,20 @@ module zebra-ospf-auth-simple {
        is path-valid.";
     uses ospf-interface-auth-simple-extension;
   }
+
+  augment "/configure:set/config:router"
+        + "/config:ospf/config:area/config:virtual-link" {
+    description
+      "RFC 2328 §15 gives a virtual link its own authentication,
+       independent of the transit area's interfaces — attach the
+       same flat leaves to each virtual-link entry.";
+    uses ospf-interface-auth-simple-extension;
+  }
+
+  augment "/configure:delete/config:router"
+        + "/config:ospf/config:area/config:virtual-link" {
+    description
+      "Delete-subtree mirror for the virtual-link attachment.";
+    uses ospf-interface-auth-simple-extension;
+  }
 }


### PR DESCRIPTION
## Summary

A virtual link carries its **own authentication**, independent of the transit area's interfaces (RFC 2328 §15). #1749/#1750 left VLs always at Null auth; this wires the config surface, **completing §15 entirely**.

- **YANG**: the `virtual-link` list is augmented with the *same groupings* the per-interface auth already uses — `authentication` (null/simple/message-digest), `authentication-key`, `key-chain` (from `zebra-ospf-auth-simple.yang`) and the `message-digest-key` list (from `zebra-ospf-auth-md5.yang`). No new leaf shapes.
- **Config**: `VirtualLinkConfig` gains `auth_mode`/`auth_key`/`crypto_keys`/`key_chain`; four handlers under `/area/virtual-link/…` mirror the interface bodies but store on the area's VL entry, since the synthetic link may not exist at config time.
- **Reconcile**: `vl_apply_config` copies the full VL config (intervals + auth) onto the synthetic link on **both** create and refresh — which also fixes a small pre-existing gap where interval overrides only applied at VL creation.
- **Packet paths needed zero changes**: emit reads `link.auth_send_ctx()` (now populated), and the receive-side VL association already remaps to the synthetic link *before* the auth verification block, so incoming VL packets verify against the VL's own keys — exactly the RFC semantics.

## Test plan
- `ospfv2_virtual_link` BDD gains an **MD5-authenticated scenario**: `message-digest-key 1 md5 VLSECRET` on both VL ends over an *unauthenticated* transit adjacency; asserts VLINK interfaces, routes both directions, end-to-end ping. **All three scenarios (single-hop, multi-hop, authenticated) pass locally.**
- Full `cargo test`: 1516 passed; yang-load clean; fmt, workspace clippy, mdbook clean.

## Docs
VL authentication documented on the Multi-Area/ABR page; the FRR-gaps virtual-link entry is now fully closed (multi-hop + auth).

🤖 Generated with [Claude Code](https://claude.com/claude-code)