### PR TITLE
feat: VRF-bound SRv6 locators — End.T / uT (RFC 8986 4.3)

### DIFF
--- a/bdd/tests/configs/isis_srv6_endt/z1.yaml
+++ b/bdd/tests/configs/isis_srv6_endt/z1.yaml
@@ -1,0 +1,35 @@
+# z1 — classic locator bound to vrf-one: the End SID must advertise as
+# `End.T (PSP)` (IANA 10) — the End walk's egress lookup is scoped to
+# the VRF's table (RFC 8986 4.3).
+vrf:
+- name: vrf-one
+interface:
+- if-name: lo
+  ipv6:
+    address: 2001:db8::1/128
+- if-name: z1-z2
+  ipv6:
+    address: 2001:db8:0:12::1/64
+segment-routing:
+  locator:
+  - name: LOC1
+    prefix: fcbb:bbbb:1::/48
+    vrf: vrf-one
+    flavor:
+    - psp
+router:
+  isis:
+    net: 49.0000.0000.0000.0001.00
+    hostname: z1
+    is-type: level-2-only
+    segment-routing:
+      srv6:
+        locator: LOC1
+    interface:
+    - if-name: lo
+      ipv6:
+        enable: true
+    - if-name: z1-z2
+      network-type: point-to-point
+      ipv6:
+        enable: true

--- a/bdd/tests/configs/isis_srv6_endt/z2.yaml
+++ b/bdd/tests/configs/isis_srv6_endt/z2.yaml
@@ -1,0 +1,33 @@
+# z2 — uSID locator bound to vrf-two: the node SID must advertise as
+# `uT` (End.T with NEXT-CSID, IANA 85).
+vrf:
+- name: vrf-two
+interface:
+- if-name: lo
+  ipv6:
+    address: 2001:db8::2/128
+- if-name: z2-z1
+  ipv6:
+    address: 2001:db8:0:12::2/64
+segment-routing:
+  locator:
+  - name: LOC2
+    prefix: fcbb:bbbb:2::/48
+    behavior: usid
+    vrf: vrf-two
+router:
+  isis:
+    net: 49.0000.0000.0000.0002.00
+    hostname: z2
+    is-type: level-2-only
+    segment-routing:
+      srv6:
+        locator: LOC2
+    interface:
+    - if-name: lo
+      ipv6:
+        enable: true
+    - if-name: z2-z1
+      network-type: point-to-point
+      ipv6:
+        enable: true

--- a/bdd/tests/features/isis_srv6_endt.feature
+++ b/bdd/tests/features/isis_srv6_endt.feature
@@ -1,0 +1,44 @@
+@isis_srv6_endt
+@isis
+Feature: IS-IS advertises End.T / uT for VRF-bound SRv6 locators
+  As a network operator
+  I want a locator bound to a VRF (`vrf` leaf) to advertise its node
+  SID as End.T — or uT for a uSID locator — so receivers know the End
+  walk's egress lookup happens in the bound table (RFC 8986 §4.3).
+
+  z1's classic locator carries `vrf: vrf-one` and `flavor: [psp]`: its
+  End SID must advertise as `End.T (PSP)` (IANA codepoint 10). z2's
+  uSID locator carries `vrf: vrf-two`: its node SID advertises as `uT`
+  (End.T with NEXT-CSID, codepoint 85). The adjacency SIDs stay
+  End.X/uA, and SPF/reachability must be unaffected.
+
+  Test Topology:
+  ```
+   z1 ──2001:db8:0:12::/64── z2
+   LOC1 fcbb:bbbb:1::/48      LOC2 fcbb:bbbb:2::/48
+   classic + vrf-one + psp    usid + vrf-two
+  ```
+
+  Scenario: The table-scoped codepoints appear in the peer's database
+    Given a clean test environment
+    When I create namespace "z1"
+    And I create namespace "z2"
+    And I connect namespace "z1" interface "z1-z2" to namespace "z2" interface "z2-z1"
+    And I start zebra-rs in namespace "z1"
+    And I start zebra-rs in namespace "z2"
+    And I apply config "z1.yaml" to namespace "z1"
+    And I apply config "z2.yaml" to namespace "z2"
+    Then show command "show isis database detail" in namespace "z2" should eventually contain "End.T (PSP)"
+    And show command "show isis database detail" in namespace "z1" should eventually contain "Behavior: uT,"
+    # Reachability across the adjacency proves the End.T codepoints
+    # didn't disturb SPF or the locator routes.
+    And ping from "z1" to "2001:db8::2" should eventually succeed
+    And ping from "z2" to "2001:db8::1" should eventually succeed
+
+  Scenario: Teardown topology
+    Given the test topology exists
+    When I stop zebra-rs in namespace "z1"
+    And I stop zebra-rs in namespace "z2"
+    And I delete namespace "z1"
+    And I delete namespace "z2"
+    Then the test environment should be clean

--- a/crates/isis-packet/src/sub/srv6.rs
+++ b/crates/isis-packet/src/sub/srv6.rs
@@ -213,6 +213,20 @@ impl Behavior {
             (EndXCSID, true, false, true) => EndXCSIDPSPUSD,
             (EndXCSID, false, true, true) => EndXCSIDUSPUSD,
             (EndXCSID, true, true, true) => EndXCSIDPSPUSPUSD,
+            (EndT, true, false, false) => EndTPSP,
+            (EndT, false, true, false) => EndTUSP,
+            (EndT, true, true, false) => EndTPSPUSP,
+            (EndT, false, false, true) => EndTUSD,
+            (EndT, true, false, true) => EndTPSPUSD,
+            (EndT, false, true, true) => EndTUSPUSD,
+            (EndT, true, true, true) => EndTPSPUSPUSD,
+            (EndTCSID, true, false, false) => EndTCSIDPSP,
+            (EndTCSID, false, true, false) => EndTCSIDUSP,
+            (EndTCSID, true, true, false) => EndTCSIDPSPUSP,
+            (EndTCSID, false, false, true) => EndTCSIDUSD,
+            (EndTCSID, true, false, true) => EndTCSIDPSPUSD,
+            (EndTCSID, false, true, true) => EndTCSIDUSPUSD,
+            (EndTCSID, true, true, true) => EndTCSIDPSPUSPUSD,
             (EndRep, true, false, false) => EndRepPSP,
             (EndRep, false, true, false) => EndRepUSP,
             (EndRep, true, true, false) => EndRepPSPUSP,
@@ -622,7 +636,9 @@ mod tests {
     #[test]
     fn with_flavors_folds_every_combination() {
         use Behavior::*;
-        for base in [End, EndX, EndCSID, EndXCSID, EndRep, EndXRep] {
+        for base in [
+            End, EndX, EndT, EndCSID, EndXCSID, EndTCSID, EndRep, EndXRep,
+        ] {
             let mut seen = std::collections::BTreeSet::new();
             for bits in 0u8..8 {
                 let (psp, usp, usd) = (bits & 1 != 0, bits & 2 != 0, bits & 4 != 0);

--- a/zebra-rs/src/fib/cradle.rs
+++ b/zebra-rs/src/fib/cradle.rs
@@ -67,6 +67,10 @@ fn srv6_behavior(b: crate::rib::SidBehavior) -> u32 {
         EndM => 11,    // egress-protection mirror (decap + mirror-context lookup)
         EndRep => 12,  // RFC 9800 REPLACE-C-SID (C-SID rewrite from containers)
         EndXRep => 13, // REPLACE-C-SID + adjacency cross-connect
+        EndT => 14,    // End walk + table-scoped egress lookup (vrf_table_id)
+        // uT = a uN whose end-of-carrier lookup is table-scoped: cradle
+        // models it as UN with a non-zero vrf_id (vrf_table_id below).
+        UT => 6,
     }
 }
 

--- a/zebra-rs/src/fib/netlink/handle.rs
+++ b/zebra-rs/src/fib/netlink/handle.rs
@@ -246,9 +246,11 @@ fn sid_route_target(
 ) -> (u8, RouteType, u8, std::net::Ipv6Addr) {
     use crate::rib::SidBehavior;
     match behavior {
-        SidBehavior::End => (RouteHeader::RT_TABLE_MAIN, RouteType::Unicast, 128, addr),
+        SidBehavior::End | SidBehavior::EndT => {
+            (RouteHeader::RT_TABLE_MAIN, RouteType::Unicast, 128, addr)
+        }
         SidBehavior::EndX => (RouteHeader::RT_TABLE_MAIN, RouteType::Unicast, 128, addr),
-        SidBehavior::UN => {
+        SidBehavior::UN | SidBehavior::UT => {
             let plen = structure
                 .map(|s| s.lb_bits.saturating_add(s.ln_bits))
                 .unwrap_or(128);
@@ -1831,6 +1833,7 @@ impl FibHandle {
                 | crate::rib::SidBehavior::EndDT2M
                 | crate::rib::SidBehavior::EndRep
                 | crate::rib::SidBehavior::EndXRep
+                | crate::rib::SidBehavior::UT
         ) {
             return;
         }
@@ -1998,6 +2001,7 @@ impl FibHandle {
                 | crate::rib::SidBehavior::EndDT2M
                 | crate::rib::SidBehavior::EndRep
                 | crate::rib::SidBehavior::EndXRep
+                | crate::rib::SidBehavior::UT
         ) {
             return;
         }

--- a/zebra-rs/src/fib/netlink/srv6.rs
+++ b/zebra-rs/src/fib/netlink/srv6.rs
@@ -119,6 +119,12 @@ fn build_srh(segments: &[Ipv6Addr]) -> Ipv6SrHdr {
 fn seg6local_action(behavior: SidBehavior) -> Seg6LocalAction {
     match behavior {
         SidBehavior::End | SidBehavior::UN => Seg6LocalAction::End,
+        // End.T has a native kernel action (+ SEG6_LOCAL_TABLE). uT never
+        // reaches the kernel (no NEXT-CSID composition with End.T exists;
+        // route_sid_install returns after the cradle tee) — map like the
+        // other cradle-only behaviors so a stray call is a visible no-op.
+        SidBehavior::EndT => Seg6LocalAction::EndT,
+        SidBehavior::UT => Seg6LocalAction::End,
         // EVPN L2 SIDs never reach the kernel (route_sid_install returns
         // after the cradle tee — no End.DT2U/DT2M seg6local action exists);
         // map to End so an unexpected call is a visible no-op rather than
@@ -259,7 +265,7 @@ fn build_seg6local_lwtunnel(
     }
     if matches!(
         behavior,
-        SidBehavior::EndDT4 | SidBehavior::EndDT6 | SidBehavior::EndM
+        SidBehavior::EndDT4 | SidBehavior::EndDT6 | SidBehavior::EndM | SidBehavior::EndT
     ) {
         // `SEG6_LOCAL_TABLE`: 0 maps to RT_TABLE_MAIN to preserve the
         // existing static / IS-IS terminal behavior. End.M passes the

--- a/zebra-rs/src/isis/inst.rs
+++ b/zebra-rs/src/isis/inst.rs
@@ -3139,10 +3139,16 @@ impl Isis {
             && let Some(addr) = locator.node_sid_addr()
             && let Some(loc_name) = self.watched_flex_algo_locators.get(&algo).cloned()
         {
-            let (behavior, structure) = match locator.behavior {
-                Some(LocatorBehavior::Usid) => (SidBehavior::UN, locator.sid_structure()),
-                Some(LocatorBehavior::Replace) => (SidBehavior::EndRep, locator.sid_structure()),
-                None => (SidBehavior::End, None),
+            let (behavior, structure) = match (&locator.behavior, locator.table_id) {
+                (Some(LocatorBehavior::Usid), 0) => (SidBehavior::UN, locator.sid_structure()),
+                // A VRF-bound locator's node SID is uT / End.T — the End
+                // walk's egress lookup scoped to the VRF's table.
+                (Some(LocatorBehavior::Usid), _) => (SidBehavior::UT, locator.sid_structure()),
+                (Some(LocatorBehavior::Replace), _) => {
+                    (SidBehavior::EndRep, locator.sid_structure())
+                }
+                (None, 0) => (SidBehavior::End, None),
+                (None, _) => (SidBehavior::EndT, None),
             };
             let sid = Sid {
                 addr,
@@ -3154,7 +3160,7 @@ impl Isis {
                 ifindex: 0,
                 nh6: None,
                 structure,
-                table_id: 0,
+                table_id: locator.table_id,
                 segs: Vec::new(),
                 flavors: locator.flavors,
             };
@@ -3202,10 +3208,16 @@ impl Isis {
             && let Some(addr) = locator.node_sid_addr()
             && let Some(loc_name) = self.watched_locator.clone()
         {
-            let (behavior, structure) = match locator.behavior {
-                Some(LocatorBehavior::Usid) => (SidBehavior::UN, locator.sid_structure()),
-                Some(LocatorBehavior::Replace) => (SidBehavior::EndRep, locator.sid_structure()),
-                None => (SidBehavior::End, None),
+            let (behavior, structure) = match (&locator.behavior, locator.table_id) {
+                (Some(LocatorBehavior::Usid), 0) => (SidBehavior::UN, locator.sid_structure()),
+                // A VRF-bound locator's node SID is uT / End.T — the End
+                // walk's egress lookup scoped to the VRF's table.
+                (Some(LocatorBehavior::Usid), _) => (SidBehavior::UT, locator.sid_structure()),
+                (Some(LocatorBehavior::Replace), _) => {
+                    (SidBehavior::EndRep, locator.sid_structure())
+                }
+                (None, 0) => (SidBehavior::End, None),
+                (None, _) => (SidBehavior::EndT, None),
             };
             let sid = Sid {
                 addr,
@@ -3220,8 +3232,9 @@ impl Isis {
                 ifindex: 0,
                 nh6: None,
                 structure,
-                // End / uN is local-processing, no table decap.
-                table_id: 0,
+                // End.T / uT scope the walk's egress lookup to the bound
+                // VRF's table; plain End / uN carry 0.
+                table_id: locator.table_id,
                 segs: Vec::new(),
                 flavors: locator.flavors,
             };

--- a/zebra-rs/src/isis/lsp.rs
+++ b/zebra-rs/src/isis/lsp.rs
@@ -494,9 +494,14 @@ fn flavored(base: Behavior, mask: u8) -> Behavior {
 /// `EndRep`; each folded with the locator's flavors. Per-locator so
 /// each per-Flex-Algorithm locator gets its own structure.
 fn srv6_end_structure(locator: &Locator) -> (Behavior, Vec<IsisSub2Tlv>) {
+    // A VRF-bound locator advertises its node SID as End.T / uT
+    // (RFC 8986 §4.3): the End walk's egress lookup is table-scoped.
+    let table_bound = locator.table_id != 0;
     let (base, subs) = match srv6_sid_structure(locator) {
+        Some((Some(LocatorBehavior::Usid), subs)) if table_bound => (Behavior::EndTCSID, subs),
         Some((Some(LocatorBehavior::Usid), subs)) => (Behavior::EndCSID, subs),
         Some((Some(LocatorBehavior::Replace), subs)) => (Behavior::EndRep, subs),
+        Some((None, subs)) if table_bound => (Behavior::EndT, subs),
         Some((None, subs)) => (Behavior::End, subs),
         None => (Behavior::End, Vec::new()),
     };

--- a/zebra-rs/src/isis/show.rs
+++ b/zebra-rs/src/isis/show.rs
@@ -1505,13 +1505,14 @@ fn write_local_sids(buf: &mut String, isis: &Isis) -> std::fmt::Result {
 
     // End / uN — at most one entry, derived from the configured locator.
     if let (Some(addr), Some(locator)) = (isis.sr_end_sid, isis.sr_locator.as_ref()) {
+        let table_bound = locator.table_id != 0;
         let (behavior, prefix_len) = match locator.behavior {
             Some(crate::rib::LocatorBehavior::Usid) => {
                 let plen = locator
                     .sid_structure()
                     .map(|s| s.lb_bits.saturating_add(s.ln_bits))
                     .unwrap_or(128);
-                ("uN", plen)
+                (if table_bound { "uT" } else { "uN" }, plen)
             }
             Some(crate::rib::LocatorBehavior::Replace) => {
                 let plen = locator
@@ -1524,7 +1525,7 @@ fn write_local_sids(buf: &mut String, isis: &Isis) -> std::fmt::Result {
                     .unwrap_or(128);
                 ("End(REP)", plen)
             }
-            None => ("End", 128),
+            None => (if table_bound { "End.T" } else { "End" }, 128),
         };
         let masked = mask_v6(addr, prefix_len);
         // End / uN SIDs install on the sr0 dummy in the FIB. IS-IS
@@ -3972,6 +3973,8 @@ mod tests {
             prefix: Some("2001:db8:a:2::/64".parse().unwrap()),
             behavior: None,
             flavors: 0,
+            vrf: None,
+            table_id: 0,
         };
         let row = render_locator_row("LOC_N1", Some(&loc));
         assert!(row.contains("LOC_N1"));
@@ -3986,6 +3989,8 @@ mod tests {
             prefix: Some("2001:db8:a:2::/64".parse().unwrap()),
             behavior: Some(LocatorBehavior::Usid),
             flavors: 0,
+            vrf: None,
+            table_id: 0,
         };
         let row = render_locator_row("LOC_N1", Some(&loc));
         assert!(row.contains("uSID"));
@@ -4012,6 +4017,8 @@ mod tests {
             prefix: None,
             behavior: None,
             flavors: 0,
+            vrf: None,
+            table_id: 0,
         };
         let row = render_locator_row("LOC_N1", Some(&loc));
         assert!(row.trim_end().ends_with("Down"));

--- a/zebra-rs/src/ospf/inst.rs
+++ b/zebra-rs/src/ospf/inst.rs
@@ -9891,10 +9891,14 @@ impl Ospf<Ospfv3> {
             && let Some(addr) = locator.node_sid_addr()
             && let Some(loc_name) = self.watched_locator.clone()
         {
-            let (behavior, structure) = match locator.behavior {
-                Some(LocatorBehavior::Usid) => (SidBehavior::UN, locator.sid_structure()),
-                Some(LocatorBehavior::Replace) => (SidBehavior::EndRep, locator.sid_structure()),
-                None => (SidBehavior::End, None),
+            let (behavior, structure) = match (&locator.behavior, locator.table_id) {
+                (Some(LocatorBehavior::Usid), 0) => (SidBehavior::UN, locator.sid_structure()),
+                (Some(LocatorBehavior::Usid), _) => (SidBehavior::UT, locator.sid_structure()),
+                (Some(LocatorBehavior::Replace), _) => {
+                    (SidBehavior::EndRep, locator.sid_structure())
+                }
+                (None, 0) => (SidBehavior::End, None),
+                (None, _) => (SidBehavior::EndT, None),
             };
             let sid = Sid {
                 addr,
@@ -9908,7 +9912,7 @@ impl Ospf<Ospfv3> {
                 ifindex: 0,
                 nh6: None,
                 structure,
-                table_id: 0,
+                table_id: locator.table_id,
                 segs: Vec::new(),
                 flavors: locator.flavors,
             };

--- a/zebra-rs/src/ospf/srv6.rs
+++ b/zebra-rs/src/ospf/srv6.rs
@@ -36,10 +36,13 @@ pub fn srv6_locator_lsa_build(router_id: Ipv4Addr, locator: &Locator) -> Option<
     let prefix = locator.prefix?;
     let end_sid = locator.node_sid_addr()?;
 
-    let base = match locator.behavior {
-        Some(LocatorBehavior::Usid) => isis_packet::Behavior::EndCSID,
-        Some(LocatorBehavior::Replace) => isis_packet::Behavior::EndRep,
-        None => isis_packet::Behavior::End,
+    let base = match (&locator.behavior, locator.table_id) {
+        (Some(LocatorBehavior::Usid), 0) => isis_packet::Behavior::EndCSID,
+        // VRF-bound: the node SID is uT / End.T (RFC 8986 §4.3).
+        (Some(LocatorBehavior::Usid), _) => isis_packet::Behavior::EndTCSID,
+        (Some(LocatorBehavior::Replace), _) => isis_packet::Behavior::EndRep,
+        (None, 0) => isis_packet::Behavior::End,
+        (None, _) => isis_packet::Behavior::EndT,
     };
     let behavior = u16::from(base.with_flavors(
         locator.flavors & crate::rib::FLAVOR_PSP != 0,
@@ -103,6 +106,8 @@ mod tests {
             prefix: Some(prefix.parse::<Ipv6Net>().unwrap()),
             behavior: usid.then_some(LocatorBehavior::Usid),
             flavors: 0,
+            vrf: None,
+            table_id: 0,
         }
     }
 
@@ -174,6 +179,8 @@ mod tests {
             prefix: None,
             behavior: None,
             flavors: 0,
+            vrf: None,
+            table_id: 0,
         };
         assert!(srv6_locator_lsa_build("10.0.0.1".parse().unwrap(), &unresolved).is_none());
     }
@@ -263,6 +270,8 @@ mod endx_tests {
             prefix: Some("fcbb:bbbb:1::/48".parse::<Ipv6Net>().unwrap()),
             behavior: Some(LocatorBehavior::Usid),
             flavors: 0,
+            vrf: None,
+            table_id: 0,
         }
     }
 
@@ -286,6 +295,8 @@ mod endx_tests {
             prefix: Some("2001:db8:f:2::/64".parse::<Ipv6Net>().unwrap()),
             behavior: None,
             flavors: 0,
+            vrf: None,
+            table_id: 0,
         };
         let sub = build_v3_lan_endx_sub(
             &classic,

--- a/zebra-rs/src/rib/inst.rs
+++ b/zebra-rs/src/rib/inst.rs
@@ -1216,6 +1216,8 @@ impl Rib {
             | SidBehavior::EndDT6
             | SidBehavior::EndDT46
             | SidBehavior::EndM
+            | SidBehavior::EndT
+            | SidBehavior::UT
             // End.B6.Encaps is a seg6local action too — bound to `lo` the
             // kernel strips it exactly like the decap group.
             | SidBehavior::EndB6Encap => self.resolve_sr0_ifindex(),
@@ -2538,6 +2540,22 @@ impl Rib {
                 // per-`ProtoId` dispatcher writes routes here when a
                 // VRF-attached protocol installs.
                 self.vrf_tables.insert(table_id, VrfRibTables::new());
+                // A locator may bind this VRF by name (End.T/uT). If it
+                // was configured before the VRF existed its snapshot holds
+                // table 0 — resolve it now and re-notify the IGPs.
+                let bound: Vec<String> = self
+                    .locators
+                    .iter()
+                    .filter(|(_, l)| l.vrf.as_deref() == Some(name.as_str()))
+                    .filter(|(_, l)| l.table_id != table_id)
+                    .map(|(n, _)| n.clone())
+                    .collect();
+                for lname in bound {
+                    if let Some(l) = self.locators.get_mut(&lname) {
+                        l.table_id = table_id;
+                    }
+                    self.notify_locator_watchers(&lname);
+                }
                 // Adopting a pre-existing kernel VRF can surface members
                 // that were already enslaved before we knew this VRF, so
                 // their connected routes were filed in the default table
@@ -2610,6 +2628,22 @@ impl Rib {
                 self.router_id_update();
             }
             Message::VrfDel { name } => {
+                // Unbind any End.T/uT locator that referenced this VRF —
+                // its node SID degrades to plain End/uN until the VRF
+                // returns.
+                let bound: Vec<String> = self
+                    .locators
+                    .iter()
+                    .filter(|(_, l)| l.vrf.as_deref() == Some(name.as_str()))
+                    .filter(|(_, l)| l.table_id != 0)
+                    .map(|(n, _)| n.clone())
+                    .collect();
+                for lname in bound {
+                    if let Some(l) = self.locators.get_mut(&lname) {
+                        l.table_id = 0;
+                    }
+                    self.notify_locator_watchers(&lname);
+                }
                 let Some(vrf) = self.vrfs.remove(&name) else {
                     // Either never created, or a previous VrfAdd failed
                     // partway through. Nothing to undo locally; defer to
@@ -2844,7 +2878,13 @@ impl Rib {
                 self.notify_block_watchers(&name);
             }
             Message::LocatorAdd { name, config } => {
-                let locator = config.to_locator();
+                let mut locator = config.to_locator();
+                // Resolve the End.T/uT VRF binding against the registry.
+                // The VRF may not exist yet (netlink creation is async) —
+                // vrf_add re-resolves and re-notifies when it appears.
+                if let Some(vrf) = &locator.vrf {
+                    locator.table_id = self.vrfs.get(vrf).map(|v| v.table_id).unwrap_or(0);
+                }
                 self.locators.insert(name.clone(), locator);
                 self.notify_locator_watchers(&name);
             }

--- a/zebra-rs/src/rib/segment_routing/locator.rs
+++ b/zebra-rs/src/rib/segment_routing/locator.rs
@@ -60,6 +60,13 @@ pub struct Locator {
     pub behavior: Option<LocatorBehavior>,
     /// `FLAVOR_*` bitmask applied to the SIDs allocated from this locator.
     pub flavors: u8,
+    /// VRF the node SID's egress lookup is scoped to (End.T / uT,
+    /// RFC 8986 §4.3). `None` = plain End/uN.
+    pub vrf: Option<String>,
+    /// The VRF's resolved table id — filled by the RIB when the locator
+    /// snapshot is committed (and re-resolved when the VRF appears or
+    /// disappears); 0 while unresolved.
+    pub table_id: u32,
 }
 
 impl Locator {
@@ -130,6 +137,7 @@ pub struct LocatorConfig {
     pub prefix: Option<Ipv6Net>,
     pub behavior: Option<LocatorBehavior>,
     pub flavors: u8,
+    pub vrf: Option<String>,
 }
 
 impl LocatorConfig {
@@ -138,6 +146,9 @@ impl LocatorConfig {
             prefix: self.prefix,
             behavior: self.behavior.clone(),
             flavors: self.flavors,
+            vrf: self.vrf.clone(),
+            // Resolved by the RIB against its VRF registry at commit.
+            table_id: 0,
         }
     }
 }
@@ -239,6 +250,7 @@ impl ConfigBuilder {
         const PREFIX_ERR: &str = "expected ipv6 prefix";
         const BEHAVIOR_ERR: &str = "unknown locator behavior";
         const FLAVOR_ERR: &str = "unknown locator flavor";
+        const VRF_ERR: &str = "locator vrf must be a string";
 
         ConfigBuilder::default()
             .path("")
@@ -279,6 +291,18 @@ impl ConfigBuilder {
             .del(|config, cache, name, _args| {
                 let s = cache_lookup(config, cache, name).context(CONFIG_ERR)?;
                 s.behavior = None;
+                Ok(())
+            })
+            .path("/vrf")
+            .set(|config, cache, name, args| {
+                let raw = args.string().context(VRF_ERR)?;
+                let s = cache_get(config, cache, name).context(CONFIG_ERR)?;
+                s.vrf = Some(raw);
+                Ok(())
+            })
+            .del(|config, cache, name, _args| {
+                let s = cache_lookup(config, cache, name).context(CONFIG_ERR)?;
+                s.vrf = None;
                 Ok(())
             })
             // Leaf-list: set ORs one member's bit in, delete removes that
@@ -328,6 +352,8 @@ mod tests {
             prefix: Some("2001:db8:a:2::/64".parse().unwrap()),
             behavior: None,
             flavors: 0,
+            vrf: None,
+            table_id: 0,
         };
         assert_eq!(loc.node_sid_addr(), Some("2001:db8:a:2::".parse().unwrap()));
     }
@@ -341,6 +367,8 @@ mod tests {
             prefix: Some("2001:db8:a:2::5/64".parse().unwrap()),
             behavior: None,
             flavors: 0,
+            vrf: None,
+            table_id: 0,
         };
         assert_eq!(loc.node_sid_addr(), Some("2001:db8:a:2::".parse().unwrap()));
     }
@@ -351,6 +379,8 @@ mod tests {
             prefix: None,
             behavior: None,
             flavors: 0,
+            vrf: None,
+            table_id: 0,
         };
         assert_eq!(loc.node_sid_addr(), None);
     }

--- a/zebra-rs/src/rib/segment_routing/sid.rs
+++ b/zebra-rs/src/rib/segment_routing/sid.rs
@@ -92,6 +92,16 @@ pub enum SidBehavior {
     /// As `EndRep`, then forwards out the bound adjacency. Cradle tee
     /// only, like `EndRep`.
     EndXRep,
+    /// End.T — RFC 8986 §4.3 (IANA codepoint 9). The End walk with the
+    /// egress lookup scoped to the table in [`Sid::table_id`] (a locator
+    /// bound to a VRF via its `vrf` leaf). Installs at /128; the kernel
+    /// has a native End.T seg6local action.
+    EndT,
+    /// uT — End.T with NEXT-C-SID (IANA codepoint 85): a uN whose
+    /// end-of-carrier lookup is scoped to [`Sid::table_id`]. Installs as
+    /// a /(LB+LN) prefix like uN. No kernel flavor op composes NEXT-CSID
+    /// with End.T — cradle tee only.
+    UT,
 }
 
 impl fmt::Display for SidBehavior {
@@ -111,6 +121,8 @@ impl fmt::Display for SidBehavior {
             Self::EndM => write!(f, "End.M"),
             Self::EndRep => write!(f, "End(REP)"),
             Self::EndXRep => write!(f, "End.X(REP)"),
+            Self::EndT => write!(f, "End.T"),
+            Self::UT => write!(f, "uT"),
         }
     }
 }
@@ -288,7 +300,8 @@ impl Sid {
             | SidBehavior::EndB6Encap
             | SidBehavior::EndDT2U
             | SidBehavior::EndDT2M
-            | SidBehavior::EndM => Ipv6Net::new(self.addr, 128).expect("/128 is always valid"),
+            | SidBehavior::EndM
+            | SidBehavior::EndT => Ipv6Net::new(self.addr, 128).expect("/128 is always valid"),
             SidBehavior::UALib => {
                 let plen = self
                     .structure
@@ -298,7 +311,7 @@ impl Sid {
                 Ipv6Net::new(masked, plen)
                     .unwrap_or_else(|_| Ipv6Net::new(self.addr, 128).expect("/128 is always valid"))
             }
-            SidBehavior::UN => {
+            SidBehavior::UN | SidBehavior::UT => {
                 let plen = self
                     .structure
                     .map(|s| s.lb_bits.saturating_add(s.ln_bits))

--- a/zebra-rs/yang/config.yang
+++ b/zebra-rs/yang/config.yang
@@ -3319,6 +3319,16 @@ module config {
              LB 48 / LN 16 / Fun 16 / Arg 48); absent means the
              classic RFC 8986 full-SID layout.";
         }
+        leaf vrf {
+          type string;
+          description
+            "Bind the locator's node SID to this VRF's IPv6 table:
+             the End SID becomes End.T (RFC 8986 4.3) — or uT when
+             the locator behavior is usid — and the End walk's
+             egress lookup happens in the VRF's table. Adjacency
+             (End.X/uA) SIDs are unaffected. Ignored for behavior
+             replace.";
+        }
         leaf-list flavor {
           type enumeration {
             enum psp;


### PR DESCRIPTION
## Summary
- New locator `vrf` leaf: the node SID becomes **End.T** (classic) or **uT** (usid), scoping the End walk's egress lookup to the VRF's IPv6 table. The RIB resolves the VRF name when the locator snapshot commits and re-resolves (with watcher re-notify) when the VRF appears or disappears — netlink VRF creation is async, so config order doesn't matter. Adjacency SIDs unaffected; `behavior replace` ignores the leaf.
- `SidBehavior::EndT` installs at /128 with the kernel's native End.T seg6local action + `SEG6_LOCAL_TABLE`; `SidBehavior::UT` installs at /(LB+LN) and is cradle-only (the kernel has no NEXT-CSID × End.T composition), like the REPLACE behaviors.
- IS-IS and OSPFv3 advertise the End.T / uT codepoints folded with locator flavors (`with_flavors` grew the EndT/EndTCSID arms, covered by the fold test).
- Tee: behavior 14 for End.T; uT rides as UN + `vrf_table_id` (cradle models it as a table-bound uN).

## Test plan
- fmt --check, clippy --workspace --all-targets, clippy --no-default-features clean; `cargo test -p zebra-rs` 1516 passed.
- New BDD `isis_srv6_endt`: z1 (classic + vrf + psp) advertises `End.T (PSP)`, z2 (usid + vrf) advertises `uT`; adjacency/SPF unaffected; teardown. Passed.
- `isis_srv6_flavor` / `isis_srv6_replace` regressions green.
- Cradle e2e `cradle_endt_zebra` (yang → RIB table resolution → tee → eBPF USD decap + table-scoped forward over a teed static VRF route) green against this branch, plus the full 23-feature cradle sweep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)