### PR TITLE
feat(ospf): stub-router advertisement (max-metric router-lsa, RFC 6987)

### DIFF
--- a/bdd/tests/configs/ospfv2_stub_router/r1.yaml
+++ b/bdd/tests/configs/ospfv2_stub_router/r1.yaml
@@ -1,0 +1,25 @@
+interface:
+- if-name: lo
+  ipv4:
+    address: 10.0.0.1/32
+- if-name: ethb
+  ipv4:
+    address: 10.0.12.1/30
+- if-name: ethd
+  ipv4:
+    address: 10.0.14.1/30
+router:
+  ospf:
+    router-id: 10.0.0.1
+    area:
+    - area-id: 0.0.0.0
+      interface:
+      - if-name: lo
+        enable: true
+      - if-name: ethb
+        enable: true
+        network-type: point-to-point
+      - if-name: ethd
+        enable: true
+        network-type: point-to-point
+        cost: 100

--- a/bdd/tests/configs/ospfv2_stub_router/r2.yaml
+++ b/bdd/tests/configs/ospfv2_stub_router/r2.yaml
@@ -1,0 +1,30 @@
+# r2 is the cheap transit path (cost 10+10) — and the stub router
+# under test: with max-metric active its transit links advertise
+# 0xFFFF, pushing r1->r3 traffic onto the expensive r4 path.
+interface:
+- if-name: lo
+  ipv4:
+    address: 10.0.0.2/32
+- if-name: etha
+  ipv4:
+    address: 10.0.12.2/30
+- if-name: ethc
+  ipv4:
+    address: 10.0.23.1/30
+router:
+  ospf:
+    router-id: 10.0.0.2
+    max-metric:
+      router-lsa:
+        administrative: true
+    area:
+    - area-id: 0.0.0.0
+      interface:
+      - if-name: lo
+        enable: true
+      - if-name: etha
+        enable: true
+        network-type: point-to-point
+      - if-name: ethc
+        enable: true
+        network-type: point-to-point

--- a/bdd/tests/configs/ospfv2_stub_router/r2s.yaml
+++ b/bdd/tests/configs/ospfv2_stub_router/r2s.yaml
@@ -1,0 +1,29 @@
+# on-startup variant: r2 is a stub router only for the first 60
+# seconds after the config applies, then resumes normal metrics.
+interface:
+- if-name: lo
+  ipv4:
+    address: 10.0.0.2/32
+- if-name: etha
+  ipv4:
+    address: 10.0.12.2/30
+- if-name: ethc
+  ipv4:
+    address: 10.0.23.1/30
+router:
+  ospf:
+    router-id: 10.0.0.2
+    max-metric:
+      router-lsa:
+        on-startup: 60
+    area:
+    - area-id: 0.0.0.0
+      interface:
+      - if-name: lo
+        enable: true
+      - if-name: etha
+        enable: true
+        network-type: point-to-point
+      - if-name: ethc
+        enable: true
+        network-type: point-to-point

--- a/bdd/tests/configs/ospfv2_stub_router/r3.yaml
+++ b/bdd/tests/configs/ospfv2_stub_router/r3.yaml
@@ -1,0 +1,25 @@
+interface:
+- if-name: lo
+  ipv4:
+    address: 10.0.0.3/32
+- if-name: ethb
+  ipv4:
+    address: 10.0.23.2/30
+- if-name: ethd
+  ipv4:
+    address: 10.0.34.2/30
+router:
+  ospf:
+    router-id: 10.0.0.3
+    area:
+    - area-id: 0.0.0.0
+      interface:
+      - if-name: lo
+        enable: true
+      - if-name: ethb
+        enable: true
+        network-type: point-to-point
+      - if-name: ethd
+        enable: true
+        network-type: point-to-point
+        cost: 100

--- a/bdd/tests/configs/ospfv2_stub_router/r4.yaml
+++ b/bdd/tests/configs/ospfv2_stub_router/r4.yaml
@@ -1,0 +1,27 @@
+# r4 is the expensive alternate path (cost 100+100).
+interface:
+- if-name: lo
+  ipv4:
+    address: 10.0.0.4/32
+- if-name: etha
+  ipv4:
+    address: 10.0.14.2/30
+- if-name: ethc
+  ipv4:
+    address: 10.0.34.1/30
+router:
+  ospf:
+    router-id: 10.0.0.4
+    area:
+    - area-id: 0.0.0.0
+      interface:
+      - if-name: lo
+        enable: true
+      - if-name: etha
+        enable: true
+        network-type: point-to-point
+        cost: 100
+      - if-name: ethc
+        enable: true
+        network-type: point-to-point
+        cost: 100

--- a/bdd/tests/features/ospfv2_stub_router.feature
+++ b/bdd/tests/features/ospfv2_stub_router.feature
@@ -1,0 +1,103 @@
+@serial
+@ospfv2_stub_router
+Feature: OSPFv2 stub-router advertisement (RFC 6987 max-metric router-lsa)
+  As a network operator
+  I want `max-metric router-lsa` to advertise my transit links at
+  MaxLinkMetric (0xFFFF) — administratively for maintenance, or for a
+  startup grace window — so neighbors route transit traffic around me
+  while my own prefixes (stub links, normal cost) stay reachable.
+
+  Test Topology (square, one area):
+  ```
+    r1 ---10--- r2 ---10--- r3   (via r2: cost 20 — normally wins)
+     \---100--- r4 ---100---/    (via r4: cost 200 — the detour)
+    r3-lo 10.0.0.3/32; the stub router under test is r2.
+  ```
+
+  Scenario: Administrative max-metric pushes transit traffic onto the detour
+    Given a clean test environment
+    When I create namespace "r1"
+    And I create namespace "r2"
+    And I create namespace "r3"
+    And I create namespace "r4"
+    And I connect namespace "r1" interface "ethb" to namespace "r2" interface "etha"
+    And I connect namespace "r2" interface "ethc" to namespace "r3" interface "ethb"
+    And I connect namespace "r1" interface "ethd" to namespace "r4" interface "etha"
+    And I connect namespace "r4" interface "ethc" to namespace "r3" interface "ethd"
+    And I start zebra-rs in namespace "r1"
+    And I start zebra-rs in namespace "r2"
+    And I start zebra-rs in namespace "r3"
+    And I start zebra-rs in namespace "r4"
+    And I apply config "r1.yaml" to namespace "r1"
+    And I apply config "r2.yaml" to namespace "r2"
+    And I apply config "r3.yaml" to namespace "r3"
+    And I apply config "r4.yaml" to namespace "r4"
+    And I wait 30 seconds
+
+    Then show command "show ospf neighbor" in namespace "r1" should contain "Full"
+    And show command "show ospf" in namespace "r2" should contain "Stub router: administrative"
+    # r1 detours around the stub router: r3's loopback goes via r4 at
+    # cost 200 (100+100), not via r2 at 20. (Other prefixes — r2's
+    # own stub networks — legitimately stay via r2 at normal cost, so
+    # the assertion pins the exact route line.)
+    And show command "show ospf route" in namespace "r1" should contain "10.0.0.3/32          [200] via 10.0.14.2"
+    # The stub router's own prefixes stay reachable at normal cost
+    # (stub links keep their metric): r2's loopback rides via r2.
+    And show command "show ospf route" in namespace "r1" should contain "10.0.0.2/32          [10] via 10.0.12.2"
+    And ping from "r1" to "10.0.0.2" should succeed
+    And ping from "r1" to "10.0.0.3" should succeed
+
+    # Teardown.
+    When I stop zebra-rs in namespace "r1"
+    And I stop zebra-rs in namespace "r2"
+    And I stop zebra-rs in namespace "r3"
+    And I stop zebra-rs in namespace "r4"
+    And I delete namespace "r1"
+    And I delete namespace "r2"
+    And I delete namespace "r3"
+    And I delete namespace "r4"
+    Then the test environment should be clean
+
+  Scenario: on-startup max-metric expires and normal routing resumes
+    Given a clean test environment
+    When I create namespace "r1"
+    And I create namespace "r2"
+    And I create namespace "r3"
+    And I create namespace "r4"
+    And I connect namespace "r1" interface "ethb" to namespace "r2" interface "etha"
+    And I connect namespace "r2" interface "ethc" to namespace "r3" interface "ethb"
+    And I connect namespace "r1" interface "ethd" to namespace "r4" interface "etha"
+    And I connect namespace "r4" interface "ethc" to namespace "r3" interface "ethd"
+    And I start zebra-rs in namespace "r1"
+    And I start zebra-rs in namespace "r2"
+    And I start zebra-rs in namespace "r3"
+    And I start zebra-rs in namespace "r4"
+    And I apply config "r1.yaml" to namespace "r1"
+    And I apply config "r2s.yaml" to namespace "r2"
+    And I apply config "r3.yaml" to namespace "r3"
+    And I apply config "r4.yaml" to namespace "r4"
+    And I wait 20 seconds
+
+    # Inside the 60s startup window: r2 is a stub router, r3's
+    # loopback detours via r4 at cost 200 (eventually — the r4 leg
+    # of the square may converge a few seconds later).
+    Then show command "show ospf" in namespace "r2" should contain "Stub router: on-startup"
+    And show command "show ospf route" in namespace "r1" should eventually contain "10.0.0.3/32          [200] via 10.0.14.2"
+
+    # After the window expires, r2 resumes real metrics and the cheap
+    # path (cost 20 via r2) returns.
+    When I wait 60 seconds
+    Then show command "show ospf" in namespace "r2" should not contain "Stub router"
+    And show command "show ospf route" in namespace "r1" should eventually contain "10.0.0.3/32          [20] via 10.0.12.2"
+    And ping from "r1" to "10.0.0.3" should succeed
+
+    # Teardown.
+    When I stop zebra-rs in namespace "r1"
+    And I stop zebra-rs in namespace "r2"
+    And I stop zebra-rs in namespace "r3"
+    And I stop zebra-rs in namespace "r4"
+    And I delete namespace "r1"
+    And I delete namespace "r2"
+    And I delete namespace "r3"
+    And I delete namespace "r4"
+    Then the test environment should be clean

--- a/book/src/ch-08-08-ospf-timers.md
+++ b/book/src/ch-08-08-ospf-timers.md
@@ -127,3 +127,41 @@ skipped for self-originated LSAs so the §13.4 seq-reclaim path can
 still fire. `show ospf` reports the value (`MinLSArrival (received-LSA
 rate limit): … ms`); OSPFv3 exposes the identical `min-ls-arrival`
 leaf under `router ospfv3`.
+
+## Stub router (`max-metric router-lsa`)
+
+RFC 6987 stub-router advertisement: while active, every **transit**
+link (point-to-point, transit, virtual-link) in this router's
+Router-LSAs is advertised at MaxLinkMetric (`0xFFFF`), so neighbors
+route transit traffic around it — while its **stub** links keep
+their configured cost, leaving the router's own prefixes reachable:
+
+```
+router ospf {
+  max-metric {
+    router-lsa {
+      administrative true;    # indefinite (maintenance)
+      on-startup 300;         # or: a boot grace window, seconds
+    }
+  }
+}
+```
+
+| YANG leaf (`/router/ospf/max-metric/router-lsa/…`) | Default | Range | Units |
+|---|---|---|---|
+| `administrative` | false | — | boolean |
+| `on-startup` | — | 5..86400 | seconds |
+
+`administrative true` holds the stub-router state until removed —
+the standard way to drain a router before maintenance.
+`on-startup <secs>` holds it for a window after the configuration
+applies, the classic use being a reboot grace period so BGP can
+converge before the router draws transit traffic; when the window
+expires the Router-LSAs re-originate with real metrics
+automatically. `show ospf` reports the active mode (`Stub router:
+administrative` / `on-startup (Ns remaining)`). OSPFv2 only —
+FRR's `ospf6d` implements the equivalent via the RFC 5340 R-bit
+instead, which zebra-rs does not yet expose. Validated by
+`ospfv2_stub_router.feature` (traffic detours around the stub
+router onto a higher-cost path and returns when the window
+expires).

--- a/book/src/ch-08-12-ospf-frr-gaps.md
+++ b/book/src/ch-08-12-ospf-frr-gaps.md
@@ -5,7 +5,6 @@ OSPFv2 features not yet implemented in zebra-rs:
 - NBMA and point-to-multipoint network types — the per-interface
   `network-type` knob accepts `broadcast` and `point-to-point`
   only.
-- Stub-router advertisement (`max-metric router-lsa`, RFC 6987).
 - Redistribution `route-map` filtering and the `table` source (the
   zebra-rs sources are connected, static, kernel, IS-IS, and BGP).
 - Forwarding-address resolution on received externals: Type-5/
@@ -73,3 +72,8 @@ per feature — see each feature's page):
   authentication (simple / MD5 / key-chain). OSPFv2 only (`ospf6d`
   has no virtual links either). See
   [Multi-Area Routing and the ABR](ch-08-14-ospf-multi-area-abr.md#virtual-links).
+- **Stub-router advertisement** (`max-metric router-lsa`, RFC 6987)
+  — administrative and `on-startup` modes advertise transit links at
+  MaxLinkMetric while stub links keep their cost. OSPFv2 only
+  (`ospf6d` uses the R-bit mechanism instead). See
+  [Timer Configuration](ch-08-08-ospf-timers.md#stub-router-max-metric-router-lsa).

--- a/zebra-rs/src/ospf/config.rs
+++ b/zebra-rs/src/ospf/config.rs
@@ -336,6 +336,15 @@ impl Ospf {
             "/graceful-restart/drain-time-ms",
             config_ospf_gr_drain_time_ms,
         );
+        self.ospf_add("/max-metric/router-lsa", config_ospf_max_metric_router_lsa);
+        self.ospf_add(
+            "/max-metric/router-lsa/administrative",
+            config_ospf_max_metric_administrative,
+        );
+        self.ospf_add(
+            "/max-metric/router-lsa/on-startup",
+            config_ospf_max_metric_on_startup,
+        );
         self.ospf_add("/spf-interval/initial-wait", config_ospf_spf_initial_wait);
         self.ospf_add(
             "/spf-interval/secondary-wait",
@@ -2354,6 +2363,44 @@ fn config_ospf_gr_helper_strict_lsa_checking(
 fn config_ospf_gr_drain_time_ms(ospf: &mut Ospf, mut args: Args, op: ConfigOp) -> Option<()> {
     let value = if op.is_set() { args.u32()? } else { 200 };
     ospf.gr_config.drain_time_ms = value.clamp(50, 2000);
+    Some(())
+}
+
+/// `/router/ospf/max-metric/router-lsa` — RFC 6987 stub-router
+/// presence container. Set is a no-op (the sub-leaves drive the
+/// modes); delete clears both administrative and on-startup state.
+fn config_ospf_max_metric_router_lsa(ospf: &mut Ospf, _args: Args, op: ConfigOp) -> Option<()> {
+    if !op.is_set() {
+        ospf.stub_router_admin = false;
+        ospf.stub_router_startup_clear();
+    }
+    Some(())
+}
+
+/// `/router/ospf/max-metric/router-lsa/administrative` — indefinite
+/// stub router (maintenance mode).
+fn config_ospf_max_metric_administrative(
+    ospf: &mut Ospf,
+    mut args: Args,
+    op: ConfigOp,
+) -> Option<()> {
+    let value = if op.is_set() { args.boolean()? } else { false };
+    if ospf.stub_router_admin != value {
+        ospf.stub_router_admin = value;
+        ospf.router_lsa_originate();
+    }
+    Some(())
+}
+
+/// `/router/ospf/max-metric/router-lsa/on-startup` — stub router for
+/// N seconds after the config applies (boot grace window).
+fn config_ospf_max_metric_on_startup(ospf: &mut Ospf, mut args: Args, op: ConfigOp) -> Option<()> {
+    if op.is_set() {
+        let secs = args.u32()?;
+        ospf.stub_router_startup_arm(secs);
+    } else {
+        ospf.stub_router_startup_clear();
+    }
     Some(())
 }
 

--- a/zebra-rs/src/ospf/inst.rs
+++ b/zebra-rs/src/ospf/inst.rs
@@ -335,6 +335,19 @@ pub struct Ospf<V: OspfVersion = Ospfv2> {
     /// monotonically increasing so a torn-down-and-recreated VL never
     /// aliases stale timers keyed on the old index. v2-only.
     vl_ifindex_next: u32,
+    /// RFC 6987 stub router, administrative mode (`max-metric
+    /// router-lsa administrative`): advertise every transit link in
+    /// our Router-LSAs at MaxLinkMetric (0xFFFF) indefinitely, so
+    /// other routers stop using us for transit while our own
+    /// prefixes (stub links, normal cost) stay reachable. v2-only.
+    pub stub_router_admin: bool,
+    /// RFC 6987 stub router, `on-startup <secs>` window: true while
+    /// the post-config grace timer runs; cleared by
+    /// `Message::StubRouterExpire`. v2-only.
+    pub stub_router_startup_active: bool,
+    /// The armed on-startup timer (held so Drop doesn't cancel it).
+    /// Its `remaining()` feeds the `show ospf` stub-router line.
+    pub stub_router_startup_timer: Option<Timer>,
     /// Per-self-LSA MinLSInterval throttle state, keyed by
     /// [`LsaGenKey`]. Runtime-only (not checkpointed / inherited).
     lsa_gen: std::collections::HashMap<LsaGenKey, LsaGenState>,
@@ -1415,6 +1428,9 @@ impl Ospf<Ospfv2> {
             min_ls_interval_ms: OSPF_MIN_LS_INTERVAL_MS,
             min_ls_arrival_ms: OSPF_MIN_LS_ARRIVAL_MS,
             vl_ifindex_next: super::link::VL_IFINDEX_BASE,
+            stub_router_admin: false,
+            stub_router_startup_active: false,
+            stub_router_startup_timer: None,
             lsa_gen: std::collections::HashMap::new(),
             restarting: None,
             key_chains: BTreeMap::new(),
@@ -1701,6 +1717,12 @@ impl Ospf<Ospfv2> {
             router_lsa.flags |= 0x0004;
         }
 
+        // RFC 6987 stub router: transit links (P2p / Transit /
+        // VirtualLink) advertise MaxLinkMetric so other routers stop
+        // using us for transit; stub links keep their configured cost
+        // so our own prefixes remain reachable (§2).
+        let stub_router = self.stub_router_active();
+
         for link in self.links.values() {
             if !link.enabled {
                 continue;
@@ -1721,6 +1743,8 @@ impl Ospf<Ospfv2> {
             } else {
                 link.output_cost.min(u16::MAX as u32) as u16
             };
+            // Transit-link metric: MaxLinkMetric while stub-routed.
+            let transit_metric = if stub_router { u16::MAX } else { metric };
 
             // RFC 2328 §12.4.1.1, virtual link: once the VL neighbor
             // is Full, emit one Type-4 VirtualLink entry into the
@@ -1743,7 +1767,7 @@ impl Ospf<Ospfv2> {
                             .unwrap_or(Ipv4Addr::UNSPECIFIED),
                         link_type: OspfLinkType::VirtualLink,
                         num_tos: 0,
-                        tos_0_metric: metric,
+                        tos_0_metric: transit_metric,
                         toses: vec![],
                     });
                 }
@@ -1770,7 +1794,7 @@ impl Ospf<Ospfv2> {
                             link_data: addr.prefix.addr(),
                             link_type: OspfLinkType::P2p,
                             num_tos: 0,
-                            tos_0_metric: metric,
+                            tos_0_metric: transit_metric,
                             toses: vec![],
                         });
                     }
@@ -1798,7 +1822,7 @@ impl Ospf<Ospfv2> {
                         link_data: addr.prefix.addr(),
                         link_type: OspfLinkType::Transit,
                         num_tos: 0,
-                        tos_0_metric: metric,
+                        tos_0_metric: transit_metric,
                         toses: vec![],
                     }
                 } else {
@@ -1810,6 +1834,38 @@ impl Ospf<Ospfv2> {
 
         router_lsa.num_links = router_lsa.links.len() as u16;
         router_lsa
+    }
+
+    /// RFC 6987: `true` while this router should advertise its
+    /// transit links at MaxLinkMetric — either administratively
+    /// (`max-metric router-lsa administrative`, indefinite) or during
+    /// the `on-startup` grace window.
+    pub fn stub_router_active(&self) -> bool {
+        self.stub_router_admin || self.stub_router_startup_active
+    }
+
+    /// Arm (or re-arm) the RFC 6987 `on-startup` stub-router window:
+    /// advertise MaxLinkMetric for `secs`, then `StubRouterExpire`
+    /// resumes real metrics.
+    pub fn stub_router_startup_arm(&mut self, secs: u32) {
+        let tx = self.tx.clone();
+        self.stub_router_startup_active = true;
+        self.stub_router_startup_timer =
+            Some(Timer::new(secs as u64, TimerType::Once, move || {
+                let tx = tx.clone();
+                async move {
+                    let _ = tx.send(Message::StubRouterExpire);
+                }
+            }));
+        tracing::info!("[StubRouter] on-startup window armed for {}s", secs);
+        self.router_lsa_originate();
+    }
+
+    /// Cancel a pending `on-startup` window (config delete).
+    pub fn stub_router_startup_clear(&mut self) {
+        self.stub_router_startup_active = false;
+        self.stub_router_startup_timer = None;
+        self.router_lsa_originate();
     }
 
     fn router_lsa_originate_with_min_seq(&mut self, min_seq: Option<u32>) {
@@ -5912,6 +5968,15 @@ impl Ospf<Ospfv2> {
                     }
                 }
             }
+            Message::StubRouterExpire => {
+                // RFC 6987 on-startup window over — resume real
+                // transit metrics (unless administrative mode holds
+                // the stub state).
+                self.stub_router_startup_active = false;
+                self.stub_router_startup_timer = None;
+                tracing::info!("[StubRouter] on-startup window expired");
+                self.router_lsa_originate();
+            }
             _ => {}
         }
     }
@@ -6186,6 +6251,9 @@ impl Ospf<Ospfv3> {
             min_ls_interval_ms: OSPF_MIN_LS_INTERVAL_MS,
             min_ls_arrival_ms: OSPF_MIN_LS_ARRIVAL_MS,
             vl_ifindex_next: super::link::VL_IFINDEX_BASE,
+            stub_router_admin: false,
+            stub_router_startup_active: false,
+            stub_router_startup_timer: None,
             lsa_gen: std::collections::HashMap::new(),
             restarting: None,
             key_chains: BTreeMap::new(),
@@ -11303,6 +11371,9 @@ pub enum Message<V: OspfVersion = Ospfv2> {
     /// A MinLSInterval deferral window elapsed — re-originate the
     /// self-LSA identified by the key now (RFC 2328 §12.4).
     LsaGenFire(LsaGenKey),
+    /// The RFC 6987 `max-metric router-lsa on-startup` window
+    /// elapsed — resume advertising real transit metrics.
+    StubRouterExpire,
 }
 
 use crate::spf::{self, Path};

--- a/zebra-rs/src/ospf/show.rs
+++ b/zebra-rs/src/ospf/show.rs
@@ -590,6 +590,24 @@ fn show_ospf(ospf: &Ospf, _args: Args, json: bool) -> std::result::Result<String
         " MinLSArrival (received-LSA rate limit): {} ms",
         ospf.min_ls_arrival_ms,
     )?;
+    // RFC 6987 stub router — only shown while active, mirroring FRR.
+    if ospf.stub_router_admin {
+        writeln!(
+            buf,
+            " Stub router: administrative (transit links at max-metric)"
+        )?;
+    } else if ospf.stub_router_startup_active {
+        let remaining = ospf
+            .stub_router_startup_timer
+            .as_ref()
+            .map(|t| t.remaining().as_secs())
+            .unwrap_or(0);
+        writeln!(
+            buf,
+            " Stub router: on-startup ({}s remaining, transit links at max-metric)",
+            remaining
+        )?;
+    }
     // TI-LFA compute telemetry for the same run (last-area-wins, like
     // `spf_duration`). None while TI-LFA is disabled.
     if let Some(stats) = &ospf.tilfa_stats {

--- a/zebra-rs/yang/config.yang
+++ b/zebra-rs/yang/config.yang
@@ -1201,6 +1201,35 @@ module config {
           default 1000;
         }
 
+        container max-metric {
+          ext:help "Advertise own Router-LSA with maximum metric (RFC 6987 stub router)";
+          container router-lsa {
+            ext:help "Advertise transit links at MaxLinkMetric (0xFFFF)";
+            // RFC 6987 stub router (FRR `max-metric router-lsa ...`):
+            // while active, every transit link (P2p / Transit /
+            // VirtualLink) in our Router-LSAs carries MaxLinkMetric so
+            // neighbors stop routing transit traffic through us; stub
+            // links keep their configured cost, so our own prefixes
+            // stay reachable. `administrative` holds the state
+            // indefinitely (maintenance); `on-startup` holds it for N
+            // seconds after the config applies (boot grace, e.g. to
+            // let BGP converge before drawing transit traffic).
+            presence "RFC 6987 stub-router configuration";
+            leaf administrative {
+              ext:help "Indefinite (administrative) stub router";
+              type boolean;
+              default false;
+            }
+            leaf on-startup {
+              ext:help "Stub-router window after startup, seconds";
+              type uint32 {
+                range "5..86400";
+              }
+              units "seconds";
+            }
+          }
+        }
+
         container spf-interval {
           ext:help "SPF calculation throttle timers";
           // Adaptive IOS-XR-style exponential hold-down, replacing the


### PR DESCRIPTION
## Summary

RFC 6987 stub-router advertisement (FRR `max-metric router-lsa`): while active, every **transit** link (P2p / Transit / VirtualLink) in this router's Router-LSAs advertises MaxLinkMetric (`0xFFFF`) so neighbors route transit traffic around it — while **stub** links keep their configured cost, leaving the router's own prefixes reachable. Matches FRR's `ospf_link_cost` transit/stub split exactly.

- **Config** `max-metric { router-lsa { administrative true | on-startup <5-86400> } }` under `router ospf`:
  - `administrative` — indefinite (maintenance drain).
  - `on-startup <secs>` — grace window from config apply (the classic reboot pattern: let BGP converge before drawing transit traffic); `Message::StubRouterExpire` resumes real metrics automatically at expiry.
- **`router_lsa_build`** splits the per-link metric: `transit_metric` (0xFFFF while `stub_router_active()`) for P2p/Transit/VirtualLink entries; the configured `metric` for stub entries.
- **`show ospf`** reports the active mode (`Stub router: administrative` / `on-startup (Ns remaining)`).
- OSPFv2 only: `ospf6d` implements the v3 equivalent via the RFC 5340 **R-bit** options mechanism — a different feature shape, left for later.

## Test plan
- New **`ospfv2_stub_router` BDD**, square topology (cheap 20-cost path through the stub router, expensive 200-cost detour):
  - *administrative*: the exact route line flips to `[200] via <detour>` while the stub router's **own loopback stays reachable through it at normal cost** (`[10] via <stub router>`) — the two-sided RFC 6987 behavior.
  - *on-startup*: detour during the window (`Stub router: on-startup` in `show ospf`), cheap path returns after expiry (`[20] via <stub router>`).
  - Both pass locally.
- Full `cargo test`: 1516 passed; yang-load; fmt, workspace clippy, mdbook clean.

## Docs
Stub-router section on the Timer Configuration page; FRR-gaps entry moved to closed (with the ospf6d R-bit note).

🤖 Generated with [Claude Code](https://claude.com/claude-code)