### PR TITLE
feat(ospf): redistribution route-map filtering with live re-application

### DIFF
--- a/bdd/tests/configs/ospfv2_redist_route_map/r1.yaml
+++ b/bdd/tests/configs/ospfv2_redist_route_map/r1.yaml
@@ -1,0 +1,18 @@
+interface:
+- if-name: lo
+  ipv4:
+    address: 10.0.0.1/32
+- if-name: ethb
+  ipv4:
+    address: 10.0.12.1/30
+router:
+  ospf:
+    router-id: 10.0.0.1
+    area:
+    - area-id: 0.0.0.0
+      interface:
+      - if-name: lo
+        enable: true
+      - if-name: ethb
+        enable: true
+        network-type: point-to-point

--- a/bdd/tests/configs/ospfv2_redist_route_map/r2-both.yaml
+++ b/bdd/tests/configs/ospfv2_redist_route_map/r2-both.yaml
@@ -1,0 +1,40 @@
+# Same as r2-initial, with 10.2.2.0/24 ADDED to the prefix-set: the
+# diffing config apply produces one incremental prefix-set change,
+# which must cascade through the policy actor to the bound route-map
+# and re-filter the redistributed set live.
+prefix-set:
+- name: PS
+  prefixes:
+  - prefix: 10.1.1.0/24
+  - prefix: 10.2.2.0/24
+policy:
+- name: RM
+  entry:
+  - number: 10
+    action: permit
+    match:
+      prefix-set: PS
+    set:
+      med:
+        set: 555
+interface:
+- if-name: lo
+  ipv4:
+    address: 10.0.0.2/32
+- if-name: etha
+  ipv4:
+    address: 10.0.12.2/30
+router:
+  ospf:
+    router-id: 10.0.0.2
+    redistribute:
+      connected:
+        route-map: RM
+    area:
+    - area-id: 0.0.0.0
+      interface:
+      - if-name: lo
+        enable: true
+      - if-name: etha
+        enable: true
+        network-type: point-to-point

--- a/bdd/tests/configs/ospfv2_redist_route_map/r2-initial.yaml
+++ b/bdd/tests/configs/ospfv2_redist_route_map/r2-initial.yaml
@@ -1,0 +1,38 @@
+# r2 redistributes connected through route-map RM: only prefixes in
+# prefix-set PS are admitted (implicit deny drops the rest, including
+# the transit /30), and the matching entry sets metric 555.
+prefix-set:
+- name: PS
+  prefixes:
+  - prefix: 10.1.1.0/24
+policy:
+- name: RM
+  entry:
+  - number: 10
+    action: permit
+    match:
+      prefix-set: PS
+    set:
+      med:
+        set: 555
+interface:
+- if-name: lo
+  ipv4:
+    address: 10.0.0.2/32
+- if-name: etha
+  ipv4:
+    address: 10.0.12.2/30
+router:
+  ospf:
+    router-id: 10.0.0.2
+    redistribute:
+      connected:
+        route-map: RM
+    area:
+    - area-id: 0.0.0.0
+      interface:
+      - if-name: lo
+        enable: true
+      - if-name: etha
+        enable: true
+        network-type: point-to-point

--- a/bdd/tests/configs/ospfv2_redist_route_map/r2-other.yaml
+++ b/bdd/tests/configs/ospfv2_redist_route_map/r2-other.yaml
@@ -1,0 +1,37 @@
+# Only 10.2.2.0/24 remains in the prefix-set: removing 10.1.1.0/24
+# must flush its Type-5 LSA live (deny on re-filter).
+prefix-set:
+- name: PS
+  prefixes:
+  - prefix: 10.2.2.0/24
+policy:
+- name: RM
+  entry:
+  - number: 10
+    action: permit
+    match:
+      prefix-set: PS
+    set:
+      med:
+        set: 555
+interface:
+- if-name: lo
+  ipv4:
+    address: 10.0.0.2/32
+- if-name: etha
+  ipv4:
+    address: 10.0.12.2/30
+router:
+  ospf:
+    router-id: 10.0.0.2
+    redistribute:
+      connected:
+        route-map: RM
+    area:
+    - area-id: 0.0.0.0
+      interface:
+      - if-name: lo
+        enable: true
+      - if-name: etha
+        enable: true
+        network-type: point-to-point

--- a/bdd/tests/features/ospfv2_redist_route_map.feature
+++ b/bdd/tests/features/ospfv2_redist_route_map.feature
@@ -1,0 +1,57 @@
+@serial
+@ospfv2_redist_route_map
+Feature: OSPFv2 redistribution route-map filters and re-applies dynamically
+  As a network operator
+  I want `redistribute <source> route-map <name>` to filter and
+  modify routes entering OSPF as Type-5 AS-External LSAs — and I
+  want edits to the route-map (or a prefix-set it references) to
+  re-apply LIVE, originating newly-permitted prefixes and flushing
+  newly-denied ones without touching the OSPF session.
+
+  Test Topology:
+  ```
+    r1 -- 10.0.12.0/30 -- r2 (redistribute connected route-map RM)
+    r2 dummies (not OSPF-enabled): d1 10.1.1.0/24, d2 10.2.2.0/24
+    RM: permit prefix-set PS, set metric 555; implicit deny rest.
+  ```
+  The scenarios share one topology: setup, two live edits, teardown
+  (mirrors bgp_policy_dynamic_update).
+
+  Scenario: Setup — route-map admits only the prefix-set, with set metric
+    Given a clean test environment
+    When I create namespace "r1"
+    And I create namespace "r2"
+    And I connect namespace "r1" interface "ethb" to namespace "r2" interface "etha"
+    And I create dummy interface "d1" with address "10.1.1.1/24" in namespace "r2"
+    And I create dummy interface "d2" with address "10.2.2.1/24" in namespace "r2"
+    And I start zebra-rs in namespace "r1"
+    And I start zebra-rs in namespace "r2"
+    And I apply config "r1.yaml" to namespace "r1"
+    And I apply config "r2-initial.yaml" to namespace "r2"
+    And I wait 25 seconds
+
+    Then show command "show ospf neighbor" in namespace "r1" should contain "Full"
+    # PS-permitted prefix arrives as an external at the set metric.
+    And show command "show ospf route" in namespace "r1" should eventually contain "10.1.1.0/24          [555] via 10.0.12.2"
+    # Everything else — the other dummy AND the transit /30 the
+    # implicit deny catches — stays out.
+    And show command "show ospf route" in namespace "r1" should not contain "10.2.2.0/24"
+
+  Scenario: Live edit — adding a prefix to the referenced prefix-set originates it
+    # One incremental prefix-set change; the policy actor's cascade
+    # re-pushes the bound route-map and OSPF re-filters live.
+    When I apply config "r2-both.yaml" to namespace "r2"
+    Then show command "show ospf route" in namespace "r1" should eventually contain "10.2.2.0/24          [555] via 10.0.12.2"
+    And show command "show ospf route" in namespace "r1" should contain "10.1.1.0/24          [555] via 10.0.12.2"
+
+  Scenario: Live edit — removing a prefix flushes its Type-5 LSA
+    When I apply config "r2-other.yaml" to namespace "r2"
+    Then show command "show ospf route" in namespace "r1" should eventually not contain "10.1.1.0/24"
+    And show command "show ospf route" in namespace "r1" should contain "10.2.2.0/24          [555] via 10.0.12.2"
+
+  Scenario: Teardown topology
+    When I stop zebra-rs in namespace "r1"
+    And I stop zebra-rs in namespace "r2"
+    And I delete namespace "r1"
+    And I delete namespace "r2"
+    Then the test environment should be clean

--- a/book/src/ch-08-12-ospf-frr-gaps.md
+++ b/book/src/ch-08-12-ospf-frr-gaps.md
@@ -5,8 +5,9 @@ OSPFv2 features not yet implemented in zebra-rs:
 - NBMA and point-to-multipoint network types — the per-interface
   `network-type` knob accepts `broadcast` and `point-to-point`
   only.
-- Redistribution `route-map` filtering and the `table` source (the
-  zebra-rs sources are connected, static, kernel, IS-IS, and BGP).
+- The redistribution `table` source (the zebra-rs sources are
+  connected, static, kernel, IS-IS, and BGP; `route-map` filtering
+  on those sources is implemented — see below).
 - Forwarding-address resolution on received externals: Type-5/
   Type-7 LSAs carrying a non-zero forwarding address are skipped
   (RFC 2328 §16.4 step 3); zebra-rs itself always originates with
@@ -77,3 +78,9 @@ per feature — see each feature's page):
   MaxLinkMetric while stub links keep their cost. OSPFv2 only
   (`ospf6d` uses the R-bit mechanism instead). See
   [Timer Configuration](ch-08-08-ospf-timers.md#stub-router-max-metric-router-lsa).
+- **Redistribution `route-map` filtering** — `redistribute <source>
+  route-map <name>` binds a policy list (shared with BGP) as the
+  Type-5 filter, with `set med` as the metric override and FRR
+  route-map semantics; edits to the list or its prefix-sets re-apply
+  live. Both OSPFv2 and OSPFv3. See
+  [Route Redistribution](ch-08-15-ospf-redistribution.md#route-map-filtering).

--- a/book/src/ch-08-15-ospf-redistribution.md
+++ b/book/src/ch-08-15-ospf-redistribution.md
@@ -36,6 +36,7 @@ router ospf {
 | `bgp` | presence container | — (absent = off) |
 | `<source>/metric` | uint32, 0..16777214 | 20 |
 | `<source>/metric-type` | `type-1` \| `type-2` | `type-2` |
+| `<source>/route-map` | string (policy name) | — (no filtering) |
 
 Each source is a presence container — naming it enables
 redistribution of that source, deleting it flushes the corresponding
@@ -43,6 +44,51 @@ Type-5s. Sources are independent subscriptions to the RIB, so any
 combination can be active at once. The knobs also exist per VRF
 instance, where the subscription is scoped so a VRF's OSPF sees only
 that VRF's routes.
+
+## Route-map filtering
+
+`route-map <name>` binds a policy list (the same `policy` /
+`prefix-set` objects BGP uses) as the redistribution filter for that
+source, mirroring FRR's `redistribute <proto> route-map <name>`:
+
+```
+prefix-set PS {
+  prefix 10.1.0.0/16;
+}
+policy RM {
+  entry 10 {
+    action permit;
+    match prefix-set PS;
+    set med set 555;       # doubles as FRR's `set metric`
+  }
+}
+router ospf {
+  redistribute {
+    connected {
+      route-map RM;
+    }
+  }
+}
+```
+
+Entries run in sequence order with FRR route-map semantics: an entry
+with no `match prefix-set` matches everything, an entry naming an
+undefined prefix-set never matches, and falling off the end of the
+list is an **implicit deny** — so the map above admits only
+`10.1.0.0/16` and drops every other connected prefix. A matching
+entry's `set med` overrides the advertised external metric.
+BGP-specific match clauses (communities, as-path, MED, origin, …)
+never match a redistributed IGP route. Binding a `route-map` name
+that has no definition is deny-all, matching FRR.
+
+**Edits re-apply live.** OSPF subscribes to the policy engine's
+change feed, so editing the policy list — or a prefix-set it
+references — immediately re-filters the redistributed set: newly
+permitted prefixes originate Type-5s, newly denied ones flush,
+without touching adjacencies. Validated by
+`ospfv2_redist_route_map.feature`, whose scenarios add and remove
+prefixes from a live prefix-set and assert the externals appear and
+disappear on the neighbor.
 
 ## E1 vs E2 metrics
 
@@ -110,9 +156,11 @@ semantics.
 
 ## OSPFv3
 
-`router ospfv3` has instance-level `redistribute bgp` only (no
-instance-level `connected`) — its primary role is the SRv6 L3VPN
-PE–CE "down" direction, where a PE injects the VPNv6 routes it
+`router ospfv3` exposes the same five instance-level redistribute
+sources (connected, static, kernel, isis, bgp) with the same
+`metric` / `metric-type` / `route-map` leaves — including the live
+route-map re-application. The bgp source's flagship role is the SRv6
+L3VPN PE–CE "down" direction, where a PE injects the VPNv6 routes it
 imported into a VRF into the CE-facing OSPFv3 instance. Per-area
 NSSA `redistribute connected` is available for v3 exactly as for
 v2.

--- a/book/src/ch-15-15-ospfv3-frr-gaps.md
+++ b/book/src/ch-15-15-ospfv3-frr-gaps.md
@@ -2,11 +2,14 @@
 
 OSPFv3 features not yet implemented in zebra-rs:
 
-- Redistribution `route-map` filtering (the zebra-rs sources are
-  connected, static, kernel, IS-IS, and BGP, matching v2).
 - Non-zero forwarding-address resolution on received externals.
 - NBMA and point-to-multipoint network types.
 - Configurable Instance ID (always 0 — one instance per link).
+
+Redistribution `route-map` filtering is implemented for OSPFv3
+identically to v2 (policy lists shared with BGP, live
+re-application) — see
+[Route Redistribution](ch-08-15-ospf-redistribution.md#route-map-filtering).
 
 The adaptive SPF throttle (`spf-interval`), the send-side
 MinLSInterval (`min-ls-interval`), and the receive-side MinLSArrival

--- a/zebra-rs/src/ospf/config.rs
+++ b/zebra-rs/src/ospf/config.rs
@@ -166,6 +166,26 @@ impl Ospf {
             "/redistribute/connected/metric-type",
             config_ospf_redist_connected_metric_type,
         );
+        self.ospf_add(
+            "/redistribute/connected/route-map",
+            config_ospf_redist_connected_route_map,
+        );
+        self.ospf_add(
+            "/redistribute/static/route-map",
+            config_ospf_redist_static_route_map,
+        );
+        self.ospf_add(
+            "/redistribute/kernel/route-map",
+            config_ospf_redist_kernel_route_map,
+        );
+        self.ospf_add(
+            "/redistribute/isis/route-map",
+            config_ospf_redist_isis_route_map,
+        );
+        self.ospf_add(
+            "/redistribute/bgp/route-map",
+            config_ospf_redist_bgp_route_map,
+        );
         // Instance-level `router ospf { bfd { ... } }` defaults.
         self.ospf_add("/bfd/enable", config_ospf_bfd_enable);
         self.ospf_add(
@@ -685,8 +705,29 @@ fn ospf_redist_metric_type_set(
     Some(())
 }
 
+/// `/router/ospf/redistribute/<source>/route-map` — bind a named
+/// policy-list as the redistribution filter for this source (FRR
+/// `redistribute <proto> route-map <name>`). The bind registers with
+/// the policy actor (immediate definition push + change watching)
+/// and resyncs; an unresolved name is deny-all.
+fn ospf_redist_route_map_set(
+    ospf: &mut Ospf,
+    rtype: crate::rib::RibType,
+    mut args: Args,
+    op: ConfigOp,
+) -> Option<()> {
+    let name = if op.is_set() {
+        Some(args.string()?)
+    } else {
+        None
+    };
+    ospf.redist_route_map_bind(rtype, name);
+    ospf.as_external_redist_resync(rtype);
+    Some(())
+}
+
 macro_rules! ospf_redist_handlers {
-    ($set:ident, $metric:ident, $mtype:ident, $rtype:expr) => {
+    ($set:ident, $metric:ident, $mtype:ident, $rmap:ident, $rtype:expr) => {
         fn $set(ospf: &mut Ospf, _args: Args, op: ConfigOp) -> Option<()> {
             ospf_redist_set(ospf, $rtype, op)
         }
@@ -696,6 +737,9 @@ macro_rules! ospf_redist_handlers {
         fn $mtype(ospf: &mut Ospf, args: Args, op: ConfigOp) -> Option<()> {
             ospf_redist_metric_type_set(ospf, $rtype, args, op)
         }
+        fn $rmap(ospf: &mut Ospf, args: Args, op: ConfigOp) -> Option<()> {
+            ospf_redist_route_map_set(ospf, $rtype, args, op)
+        }
     };
 }
 
@@ -703,24 +747,28 @@ ospf_redist_handlers!(
     config_ospf_redist_bgp,
     config_ospf_redist_bgp_metric,
     config_ospf_redist_bgp_metric_type,
+    config_ospf_redist_bgp_route_map,
     crate::rib::RibType::Bgp
 );
 ospf_redist_handlers!(
     config_ospf_redist_static,
     config_ospf_redist_static_metric,
     config_ospf_redist_static_metric_type,
+    config_ospf_redist_static_route_map,
     crate::rib::RibType::Static
 );
 ospf_redist_handlers!(
     config_ospf_redist_kernel,
     config_ospf_redist_kernel_metric,
     config_ospf_redist_kernel_metric_type,
+    config_ospf_redist_kernel_route_map,
     crate::rib::RibType::Kernel
 );
 ospf_redist_handlers!(
     config_ospf_redist_isis,
     config_ospf_redist_isis_metric,
     config_ospf_redist_isis_metric_type,
+    config_ospf_redist_isis_route_map,
     crate::rib::RibType::Isis
 );
 
@@ -2459,5 +2507,6 @@ ospf_redist_handlers!(
     config_ospf_redist_connected,
     config_ospf_redist_connected_metric,
     config_ospf_redist_connected_metric_type,
+    config_ospf_redist_connected_route_map,
     crate::rib::RibType::Connected
 );

--- a/zebra-rs/src/ospf/config_v3.rs
+++ b/zebra-rs/src/ospf/config_v3.rs
@@ -154,6 +154,26 @@ impl Ospf<Ospfv3> {
                 "/redistribute/bgp/metric-type",
                 config_ospfv3_redist_bgp_metric_type,
             ),
+            (
+                "/redistribute/connected/route-map",
+                config_ospfv3_redist_connected_route_map,
+            ),
+            (
+                "/redistribute/static/route-map",
+                config_ospfv3_redist_static_route_map,
+            ),
+            (
+                "/redistribute/kernel/route-map",
+                config_ospfv3_redist_kernel_route_map,
+            ),
+            (
+                "/redistribute/isis/route-map",
+                config_ospfv3_redist_isis_route_map,
+            ),
+            (
+                "/redistribute/bgp/route-map",
+                config_ospfv3_redist_bgp_route_map,
+            ),
             ("/area/interface/enable", config_ospfv3_interface_enable),
             (
                 "/area/interface/bfd/enable",
@@ -668,8 +688,29 @@ fn ospfv3_redist_metric_type_set(
     Some(())
 }
 
+/// `/router/ospfv3/redistribute/<source>/route-map` — v6 sibling of
+/// the v2 handler: bind a named policy-list as the redistribution
+/// filter and resync. Changes to the bound list (or a prefix-set it
+/// references) re-apply dynamically via the policy actor's watch +
+/// cascade machinery.
+fn ospfv3_redist_route_map_set(
+    ospf: &mut Ospf<Ospfv3>,
+    rtype: crate::rib::RibType,
+    mut args: Args,
+    op: ConfigOp,
+) -> Option<()> {
+    let name = if op.is_set() {
+        Some(args.string()?)
+    } else {
+        None
+    };
+    ospf.redist_route_map_bind(rtype, name);
+    ospf.as_external_redist_resync_v3(rtype);
+    Some(())
+}
+
 macro_rules! ospfv3_redist_handlers {
-    ($set:ident, $metric:ident, $mtype:ident, $rtype:expr) => {
+    ($set:ident, $metric:ident, $mtype:ident, $rmap:ident, $rtype:expr) => {
         fn $set(ospf: &mut Ospf<Ospfv3>, _args: Args, op: ConfigOp) -> Option<()> {
             ospfv3_redist_set(ospf, $rtype, op)
         }
@@ -679,6 +720,9 @@ macro_rules! ospfv3_redist_handlers {
         fn $mtype(ospf: &mut Ospf<Ospfv3>, args: Args, op: ConfigOp) -> Option<()> {
             ospfv3_redist_metric_type_set(ospf, $rtype, args, op)
         }
+        fn $rmap(ospf: &mut Ospf<Ospfv3>, args: Args, op: ConfigOp) -> Option<()> {
+            ospfv3_redist_route_map_set(ospf, $rtype, args, op)
+        }
     };
 }
 
@@ -686,30 +730,35 @@ ospfv3_redist_handlers!(
     config_ospfv3_redist_connected,
     config_ospfv3_redist_connected_metric,
     config_ospfv3_redist_connected_metric_type,
+    config_ospfv3_redist_connected_route_map,
     crate::rib::RibType::Connected
 );
 ospfv3_redist_handlers!(
     config_ospfv3_redist_static,
     config_ospfv3_redist_static_metric,
     config_ospfv3_redist_static_metric_type,
+    config_ospfv3_redist_static_route_map,
     crate::rib::RibType::Static
 );
 ospfv3_redist_handlers!(
     config_ospfv3_redist_kernel,
     config_ospfv3_redist_kernel_metric,
     config_ospfv3_redist_kernel_metric_type,
+    config_ospfv3_redist_kernel_route_map,
     crate::rib::RibType::Kernel
 );
 ospfv3_redist_handlers!(
     config_ospfv3_redist_isis,
     config_ospfv3_redist_isis_metric,
     config_ospfv3_redist_isis_metric_type,
+    config_ospfv3_redist_isis_route_map,
     crate::rib::RibType::Isis
 );
 ospfv3_redist_handlers!(
     config_ospfv3_redist_bgp,
     config_ospfv3_redist_bgp_metric,
     config_ospfv3_redist_bgp_metric_type,
+    config_ospfv3_redist_bgp_route_map,
     crate::rib::RibType::Bgp
 );
 

--- a/zebra-rs/src/ospf/inst.rs
+++ b/zebra-rs/src/ospf/inst.rs
@@ -401,6 +401,15 @@ pub struct Ospf<V: OspfVersion = Ospfv2> {
     /// VPNv4/VPNv6 routes BGP imported into the VRF into the CE-facing
     /// OSPF (the L3VPN PE-CE down direction).
     pub redist: BTreeMap<crate::rib::RibType, crate::ospf::area::RedistEntry>,
+    /// `redistribute <source> route-map <name>` bindings (FRR
+    /// parity): the named policy-list filters/modifies routes as
+    /// they redistribute into AS-External LSAs. An unresolved name
+    /// is deny-all, matching FRR.
+    pub redist_route_map: BTreeMap<crate::rib::RibType, String>,
+    /// Policy-list snapshots pushed by the policy actor for the
+    /// names bound in `redist_route_map` (kept fresh via the
+    /// Register/watch machinery, like BGP's per-peer policies).
+    pub policy_lists: BTreeMap<String, crate::policy::PolicyList>,
     /// Per-source prefixes of Type-5 LSAs we self-originated from the
     /// instance-level `redistribute` knobs (v2 / IPv4). Diffed by
     /// `as_external_redist_resync`; flushed when the knob is removed.
@@ -1344,6 +1353,113 @@ impl<V: OspfVersion> Ospf<V> {
         entry.last_originate = Some(tokio::time::Instant::now());
         entry.pending_min_seq.take()
     }
+
+    /// Bind (or unbind, `name == None`) a `redistribute <source>
+    /// route-map` to a named policy-list. Registers with the policy
+    /// actor so the current definition arrives immediately and every
+    /// later edit is pushed (`process_policy_msg` keeps
+    /// `policy_lists` fresh and resyncs). Rebinding unregisters the
+    /// old watch so the actor's watcher list doesn't grow unbounded.
+    pub fn redist_route_map_bind(&mut self, rtype: crate::rib::RibType, name: Option<String>) {
+        use crate::policy::{Message as PolicyMsg, PolicyType};
+        let ident = redist_rtype_ident(rtype);
+        if let Some(old) = self.redist_route_map.remove(&rtype) {
+            let _ = self.policy_tx.send(PolicyMsg::Unregister {
+                proto: self.proto_label.clone(),
+                name: old,
+                ident,
+                policy_type: PolicyType::PolicyListIn,
+            });
+        }
+        if let Some(name) = name {
+            let _ = self.policy_tx.send(PolicyMsg::Register {
+                proto: self.proto_label.clone(),
+                name: name.clone(),
+                ident,
+                policy_type: PolicyType::PolicyListIn,
+            });
+            self.redist_route_map.insert(rtype, name);
+        }
+    }
+}
+
+/// Stable per-source ident for the policy actor's watch registry, so
+/// two redistribute sources bound to the same policy-list name hold
+/// distinct watch entries (unbinding one must not drop the other's).
+fn redist_rtype_ident(rtype: crate::rib::RibType) -> usize {
+    use crate::rib::RibType;
+    match rtype {
+        RibType::Connected => 1,
+        RibType::Static => 2,
+        RibType::Kernel => 3,
+        RibType::Isis => 4,
+        RibType::Bgp => 5,
+        _ => 0,
+    }
+}
+
+/// Evaluate a policy-list (route-map) against one redistributed
+/// prefix. Returns the final metric (`base_metric` unless a matching
+/// entry `set med`/metric) or `None` when the route is denied.
+///
+/// Semantics mirror the BGP engine and FRR route-maps: entries run
+/// in sequence order; an entry with no prefix-set matches
+/// everything; an entry naming an unresolved prefix-set never
+/// matches; an entry carrying any BGP-only match clause (communities,
+/// as-path, MED, origin, ...) never matches a redistributed IGP
+/// route; falling off the end of the list is an implicit deny.
+fn redist_policy_eval(
+    list: &crate::policy::PolicyList,
+    prefix: ipnet::IpNet,
+    base_metric: u32,
+) -> Option<u32> {
+    use crate::policy::PolicyAction;
+    let mut metric = base_metric;
+    for entry in list.entry.values() {
+        // BGP-only match clauses can never hold for a redistributed
+        // IGP route — the entry is skipped, mirroring FRR's "match
+        // of an inapplicable type never matches".
+        if entry.community_set_name.is_some()
+            || entry.ext_community_set_name.is_some()
+            || entry.large_community_set_name.is_some()
+            || entry.as_path_set_name.is_some()
+            || entry.match_next_hop.is_some()
+            || entry.match_med.is_some()
+            || entry.match_as_path_len.is_some()
+            || entry.match_as_path_len_uniq.is_some()
+            || entry.match_local_pref.is_some()
+            || entry.match_weight.is_some()
+            || entry.match_origin.is_some()
+            || entry.match_evpn_route_type.is_some()
+            || entry.match_evpn_vni.is_some()
+            || entry.match_color.is_some()
+        {
+            continue;
+        }
+        let matched = match (&entry.prefix_set_name, &entry.prefix_set) {
+            // No prefix match clause — matches everything.
+            (None, _) => true,
+            // Named but unresolved — never matches (deny-ish),
+            // consistent with the BGP policy engine.
+            (Some(_), None) => false,
+            (Some(_), Some(set)) => set.matches(prefix),
+        };
+        if !matched {
+            continue;
+        }
+        // `set med` doubles as FRR's `set metric` for IGP
+        // redistribution.
+        if let Some(med) = &entry.med {
+            metric = med.apply(metric);
+        }
+        match entry.action {
+            PolicyAction::Permit => return Some(metric),
+            PolicyAction::Deny => return None,
+            PolicyAction::Next => continue,
+        }
+    }
+    // Implicit deny at end-of-list (FRR route-map semantics).
+    None
 }
 
 impl Ospf<Ospfv2> {
@@ -1441,6 +1557,8 @@ impl Ospf<Ospfv2> {
             redist_v4: BTreeMap::new(),
             redist_v6: BTreeMap::new(),
             redist: BTreeMap::new(),
+            redist_route_map: BTreeMap::new(),
+            policy_lists: BTreeMap::new(),
             redist_originated: BTreeMap::new(),
             redist_originated_v6: BTreeMap::new(),
             default_originate: None,
@@ -3196,18 +3314,34 @@ impl Ospf<Ospfv2> {
             .cloned()
             .unwrap_or_default();
 
-        let desired: BTreeSet<Ipv4Net> = if entry.is_some() {
+        // Desired prefix -> advertised metric. A bound route-map
+        // filters (deny drops the prefix from the set, so a stale
+        // LSA flushes below) and can override the metric via
+        // `set med`; an unresolved map name is deny-all (FRR
+        // parity).
+        let route_map = self.redist_route_map.get(&rtype);
+        let desired: BTreeMap<Ipv4Net, u32> = if let Some(e) = entry {
             self.redist_v4
                 .iter()
                 .filter(|((rt, _), _)| *rt == rtype)
-                .map(|((_, prefix), _)| *prefix)
+                .filter_map(|((_, prefix), _)| {
+                    let metric = match route_map {
+                        None => e.metric,
+                        Some(name) => {
+                            let list = self.policy_lists.get(name)?;
+                            redist_policy_eval(list, (*prefix).into(), e.metric)?
+                        }
+                    };
+                    Some((*prefix, metric))
+                })
                 .collect()
         } else {
-            BTreeSet::new()
+            BTreeMap::new()
         };
 
         for prefix in prev_originated
-            .difference(&desired)
+            .iter()
+            .filter(|p| !desired.contains_key(p))
             .copied()
             .collect::<Vec<_>>()
         {
@@ -3218,10 +3352,10 @@ impl Ospf<Ospfv2> {
         }
 
         if let Some(redist_entry) = entry {
-            for prefix in &desired {
+            for (prefix, metric) in &desired {
                 self.as_external_lsa_originate_for_prefix(
                     *prefix,
-                    redist_entry.metric,
+                    *metric,
                     redist_entry.metric_type.is_type_2(),
                 );
                 self.redist_originated
@@ -6100,9 +6234,24 @@ impl Ospf<Ospfv2> {
                     self.key_chains.remove(&name);
                 }
             }
-            crate::policy::PolicyRx::PrefixSet { .. }
-            | crate::policy::PolicyRx::PolicyList { .. } => {
-                // OSPF doesn't subscribe to prefix-set or policy-list.
+            crate::policy::PolicyRx::PolicyList {
+                name, policy_list, ..
+            } => {
+                // A `redistribute ... route-map` binding: keep the
+                // snapshot fresh and re-filter the redistributed
+                // set. `None` (deleted / undefined list) clears the
+                // snapshot — an unresolved map is deny-all, so the
+                // resync flushes everything the map had admitted.
+                if let Some(list) = policy_list {
+                    self.policy_lists.insert(name, list);
+                } else {
+                    self.policy_lists.remove(&name);
+                }
+                self.as_external_redist_resync_all();
+            }
+            crate::policy::PolicyRx::PrefixSet { .. } => {
+                // OSPF doesn't subscribe to bare prefix-sets (the
+                // policy actor resolves them into pushed lists).
             }
         }
     }
@@ -6264,6 +6413,8 @@ impl Ospf<Ospfv3> {
             redist_v4: BTreeMap::new(),
             redist_v6: BTreeMap::new(),
             redist: BTreeMap::new(),
+            redist_route_map: BTreeMap::new(),
+            policy_lists: BTreeMap::new(),
             redist_originated: BTreeMap::new(),
             redist_originated_v6: BTreeMap::new(),
             default_originate: None,
@@ -7415,18 +7566,31 @@ impl Ospf<Ospfv3> {
             .cloned()
             .unwrap_or_default();
 
-        let desired: BTreeSet<ipnet::Ipv6Net> = if entry.is_some() {
+        // Desired prefix -> advertised metric, filtered/modified by a
+        // bound route-map exactly like the v2 sibling.
+        let route_map = self.redist_route_map.get(&rtype);
+        let desired: BTreeMap<ipnet::Ipv6Net, u32> = if let Some(e) = entry {
             self.redist_v6
                 .iter()
                 .filter(|((rt, _), _)| *rt == rtype)
-                .map(|((_, prefix), _)| *prefix)
+                .filter_map(|((_, prefix), _)| {
+                    let metric = match route_map {
+                        None => e.metric,
+                        Some(name) => {
+                            let list = self.policy_lists.get(name)?;
+                            redist_policy_eval(list, (*prefix).into(), e.metric)?
+                        }
+                    };
+                    Some((*prefix, metric))
+                })
                 .collect()
         } else {
-            BTreeSet::new()
+            BTreeMap::new()
         };
 
         for prefix in prev_originated
-            .difference(&desired)
+            .iter()
+            .filter(|p| !desired.contains_key(p))
             .copied()
             .collect::<Vec<_>>()
         {
@@ -7437,10 +7601,10 @@ impl Ospf<Ospfv3> {
         }
 
         if let Some(redist_entry) = entry {
-            for prefix in &desired {
+            for (prefix, metric) in &desired {
                 self.as_external_lsa_originate_for_prefix_v3(
                     *prefix,
-                    redist_entry.metric,
+                    *metric,
                     redist_entry.metric_type.is_type_2(),
                 );
                 self.redist_originated_v6
@@ -11243,8 +11407,8 @@ impl Ospf<Ospfv3> {
     }
 
     /// Mirror of `Ospf<Ospfv2>::process_policy_msg` for the v3
-    /// instance. Same shape — only key-chain updates are consumed
-    /// today.
+    /// instance: key-chain updates (auth) and policy-list updates
+    /// (redistribute route-maps).
     fn process_policy_msg(&mut self, msg: crate::policy::PolicyRx) {
         match msg {
             crate::policy::PolicyRx::KeyChain {
@@ -11256,8 +11420,17 @@ impl Ospf<Ospfv3> {
                     self.key_chains.remove(&name);
                 }
             }
-            crate::policy::PolicyRx::PrefixSet { .. }
-            | crate::policy::PolicyRx::PolicyList { .. } => {}
+            crate::policy::PolicyRx::PolicyList {
+                name, policy_list, ..
+            } => {
+                if let Some(list) = policy_list {
+                    self.policy_lists.insert(name, list);
+                } else {
+                    self.policy_lists.remove(&name);
+                }
+                self.as_external_redist_resync_all_v3();
+            }
+            crate::policy::PolicyRx::PrefixSet { .. } => {}
         }
     }
 }

--- a/zebra-rs/yang/config.yang
+++ b/zebra-rs/yang/config.yang
@@ -533,6 +533,10 @@ module config {
               }
               default type-2;
             }
+            leaf route-map {
+              ext:help "Filter/modify redistributed routes via a named policy-list";
+              type string;
+            }
           }
           container static {
             presence "Redistribute static routes as Type-5 AS-External LSAs";
@@ -548,6 +552,10 @@ module config {
                 enum type-2;
               }
               default type-2;
+            }
+            leaf route-map {
+              ext:help "Filter/modify redistributed routes via a named policy-list";
+              type string;
             }
           }
           container kernel {
@@ -565,6 +573,10 @@ module config {
               }
               default type-2;
             }
+            leaf route-map {
+              ext:help "Filter/modify redistributed routes via a named policy-list";
+              type string;
+            }
           }
           container isis {
             presence "Redistribute IS-IS routes as Type-5 AS-External LSAs";
@@ -581,6 +593,10 @@ module config {
               }
               default type-2;
             }
+            leaf route-map {
+              ext:help "Filter/modify redistributed routes via a named policy-list";
+              type string;
+            }
           }
           container bgp {
             presence "Redistribute BGP routes as Type-5 AS-External LSAs";
@@ -596,6 +612,10 @@ module config {
                 enum type-2;
               }
               default type-2;
+            }
+            leaf route-map {
+              ext:help "Filter/modify redistributed routes via a named policy-list";
+              type string;
             }
           }
         }
@@ -1431,6 +1451,10 @@ module config {
               }
               default type-2;
             }
+            leaf route-map {
+              ext:help "Filter/modify redistributed routes via a named policy-list";
+              type string;
+            }
           }
           container static {
             presence "Redistribute static routes as AS-External (Type-5) LSAs";
@@ -1446,6 +1470,10 @@ module config {
                 enum type-2;
               }
               default type-2;
+            }
+            leaf route-map {
+              ext:help "Filter/modify redistributed routes via a named policy-list";
+              type string;
             }
           }
           container kernel {
@@ -1463,6 +1491,10 @@ module config {
               }
               default type-2;
             }
+            leaf route-map {
+              ext:help "Filter/modify redistributed routes via a named policy-list";
+              type string;
+            }
           }
           container isis {
             presence "Redistribute IS-IS routes as AS-External (Type-5) LSAs";
@@ -1479,6 +1511,10 @@ module config {
               }
               default type-2;
             }
+            leaf route-map {
+              ext:help "Filter/modify redistributed routes via a named policy-list";
+              type string;
+            }
           }
           container bgp {
             presence "Redistribute BGP routes as AS-External (Type-5) LSAs";
@@ -1494,6 +1530,10 @@ module config {
                 enum type-2;
               }
               default type-2;
+            }
+            leaf route-map {
+              ext:help "Filter/modify redistributed routes via a named policy-list";
+              type string;
             }
           }
         }


### PR DESCRIPTION
## Summary

`redistribute <source> route-map <name>` (FRR parity) binds a named **policy list** — the same `policy` / `prefix-set` objects BGP uses — as the filter for routes entering OSPF as AS-External LSAs. All five sources (connected/static/kernel/isis/bgp), **both OSPFv2 and OSPFv3**.

- **Evaluation** (`redist_policy_eval`), FRR route-map semantics: entries in sequence order; no prefix-set = match-all; unresolved prefix-set never matches; BGP-only match clauses (communities, as-path, MED, origin, …) never match a redistributed IGP route; permit/deny/next; **implicit deny** at end of list; `set med` doubles as FRR's `set metric` (external-metric override). A bound-but-undefined map name is deny-all (FRR parity).
- The desired-set computation in `as_external_redist_resync` (+ v3 sibling) becomes prefix → metric filtered through the map, so newly-denied prefixes **flush** and metric changes re-originate.
- **Live re-application** (the key requirement): the bind registers with the policy actor (`PolicyType::PolicyListIn`, distinct per-source idents), which pushes the current definition immediately and re-pushes on every edit — including **cascaded** re-pushes when a referenced prefix-set changes (`cascade_indirect_policy_updates`). `process_policy_msg` (v2 + v3) refreshes the snapshot and resyncs.
- YANG `route-map` leaf on all ten source containers; handlers via the extended redist macros.

## Test plan
- New **`ospfv2_redist_route_map` BDD** — 4 scenarios on one shared topology (the `bgp_policy_dynamic_update` pattern), explicitly proving dynamic behavior:
  1. *Setup*: only the prefix-set-permitted connected prefix appears on the neighbor, at the map's `set med 555` metric; the implicit deny drops the other dummy **and** the transit /30.
  2. *Live add*: adding a prefix to the referenced prefix-set cascades through the policy actor and the new Type-5 **appears** on the neighbor — no session churn.
  3. *Live remove*: removing a prefix **flushes** its Type-5 on the neighbor.
  4. Teardown. **All pass locally on the first run.**
- `ospfv2_redistribute_static` regression (no-route-map path) passes.
- Full `cargo test`: 1516; yang-load; fmt, workspace clippy, mdbook clean.

## Docs
Route-map section on the redistribution page (semantics, live re-application, example) — plus a stale claim fixed in passing (the page said v3 had `redistribute bgp` only; all five sources exist since the redistribute arc). FRR-gaps updated on both v2 and v3 pages; the remaining redistribution gap narrows to the `table` source.

🤖 Generated with [Claude Code](https://claude.com/claude-code)