### PR TITLE
feat: static End.DX4/DX6 + tee static seg6local SIDs to cradle

### DIFF
--- a/zebra-rs/src/fib/cradle.rs
+++ b/zebra-rs/src/fib/cradle.rs
@@ -68,6 +68,8 @@ fn srv6_behavior(b: crate::rib::SidBehavior) -> u32 {
         EndRep => 12,  // RFC 9800 REPLACE-C-SID (C-SID rewrite from containers)
         EndXRep => 13, // REPLACE-C-SID + adjacency cross-connect
         EndT => 14,    // End walk + table-scoped egress lookup (vrf_table_id)
+        EndDX4 => 15,  // decap + IPv4 cross-connect (per-CE VPN egress)
+        EndDX6 => 16,  // decap + IPv6 cross-connect
         // uT = a uN whose end-of-carrier lookup is table-scoped: cradle
         // models it as UN with a non-zero vrf_id (vrf_table_id below).
         UT => 6,
@@ -520,6 +522,55 @@ impl CradleFib {
     /// the SRv6 analogue of the ILM tee. Maps the behavior to `SRV6_BH_*`;
     /// `End.DT*` carry the VRF table id; `End.X`/`uA` resolve their
     /// cross-connect adjacency (`nh6`) to a cradle nexthop.
+    /// Tee a STATIC seg6local action route (config-static `action` leaf)
+    /// as a cradle local SID. These install as route-embedded encaps on
+    /// the kernel side and never pass through the SID registry, so
+    /// `local_sid_install` never sees them — without this tee a static
+    /// End/uN/DT*/DX* SID exists in the kernel but not in eBPF. `adj` is
+    /// the DX cross-connect adjacency (v6 or v4), unspecified/absent for
+    /// the decap-only actions.
+    pub async fn static_sid_install(
+        &self,
+        prefix: Ipv6Net,
+        behavior: crate::rib::SidBehavior,
+        adj: Option<IpAddr>,
+        oif: u32,
+    ) {
+        let result = async {
+            let nexthop_id = match adj {
+                Some(IpAddr::V6(a)) if !a.is_unspecified() => {
+                    self.nexthop_id6(Some(a), oif, &[], 0).await?
+                }
+                Some(IpAddr::V4(a)) if !a.is_unspecified() => {
+                    self.nexthop_id(Some(a), oif, &[]).await?
+                }
+                _ => 0,
+            };
+            self.client()
+                .await?
+                .add_local_sid(pb::LocalSid {
+                    sid: prefix.addr().to_string(),
+                    prefix_len: prefix.prefix_len() as u32,
+                    behavior: srv6_behavior(behavior),
+                    vrf_table_id: 0,
+                    oif,
+                    nh6: String::new(),
+                    lb_bits: 0,
+                    ln_bits: 0,
+                    fun_bits: 0,
+                    arg_bits: 0,
+                    nexthop_id,
+                    flavors: 0,
+                })
+                .await?;
+            anyhow::Ok(())
+        }
+        .await;
+        if let Err(e) = result {
+            tracing::warn!("fib: cradle static_sid_install {} failed: {e}", prefix);
+        }
+    }
+
     pub async fn local_sid_install(&self, sid: &crate::rib::Sid, prefix_len: u8, ifindex: u32) {
         let result = async {
             let nexthop_id =

--- a/zebra-rs/src/fib/netlink/handle.rs
+++ b/zebra-rs/src/fib/netlink/handle.rs
@@ -246,7 +246,7 @@ fn sid_route_target(
 ) -> (u8, RouteType, u8, std::net::Ipv6Addr) {
     use crate::rib::SidBehavior;
     match behavior {
-        SidBehavior::End | SidBehavior::EndT => {
+        SidBehavior::End | SidBehavior::EndT | SidBehavior::EndDX4 | SidBehavior::EndDX6 => {
             (RouteHeader::RT_TABLE_MAIN, RouteType::Unicast, 128, addr)
         }
         SidBehavior::EndX => (RouteHeader::RT_TABLE_MAIN, RouteType::Unicast, 128, addr),
@@ -1022,11 +1022,26 @@ impl FibHandle {
             if let Some(ifindex) = uni.ifindex() {
                 msg.attributes.push(RouteAttribute::Oif(ifindex));
             }
+            // Tee the static action SID to cradle — these never pass
+            // through the SID registry (route-embedded install), so the
+            // eBPF datapath would otherwise not know them.
+            if let Some(cradle) = &self.cradle {
+                cradle
+                    .static_sid_install(*prefix, action, Some(uni.addr), uni.ifindex().unwrap_or(0))
+                    .await;
+            }
+            // The DX cross-connect adjacency rides on the uni's addr
+            // (End.DX6 / End.X families in `nh6`, End.DX4 in `nh4`).
+            let (nh6, nh4) = match uni.addr {
+                std::net::IpAddr::V6(a) if !a.is_unspecified() => (Some(a), None),
+                std::net::IpAddr::V4(a) if !a.is_unspecified() => (None, Some(a)),
+                _ => (None, None),
+            };
             if let Some((encap, encap_type)) =
                 // Static seg6local action routes keep the legacy
                 // RT_TABLE_MAIN decap (table_id 0); per-VRF table
                 // selection arrives via the protocol SID path.
-                super::srv6::build_seg6local_attrs(action, None, None, 0, &[], 0)
+                super::srv6::build_seg6local_attrs(action, nh6, nh4, None, 0, &[], 0)
             {
                 msg.attributes.push(encap);
                 msg.attributes.push(encap_type);
@@ -1858,6 +1873,7 @@ impl FibHandle {
         let Some((encap, encap_type)) = super::srv6::build_seg6local_attrs(
             sid.behavior,
             sid.nh6,
+            None,
             sid.structure,
             sid.table_id,
             &sid.segs,
@@ -2065,6 +2081,7 @@ impl FibHandle {
         }
         let Some((encap, encap_type)) = super::srv6::build_seg6local_attrs(
             crate::rib::SidBehavior::EndDT46,
+            None,
             None,
             None,
             vrf_table,

--- a/zebra-rs/src/fib/netlink/srv6.rs
+++ b/zebra-rs/src/fib/netlink/srv6.rs
@@ -1,4 +1,4 @@
-use std::net::Ipv6Addr;
+use std::net::{Ipv4Addr, Ipv6Addr};
 
 use anyhow::{Result, bail};
 use isis_packet::srv6::EncapType;
@@ -125,6 +125,8 @@ fn seg6local_action(behavior: SidBehavior) -> Seg6LocalAction {
         // other cradle-only behaviors so a stray call is a visible no-op.
         SidBehavior::EndT => Seg6LocalAction::EndT,
         SidBehavior::UT => Seg6LocalAction::End,
+        SidBehavior::EndDX4 => Seg6LocalAction::EndDx4,
+        SidBehavior::EndDX6 => Seg6LocalAction::EndDx6,
         // EVPN L2 SIDs never reach the kernel (route_sid_install returns
         // after the cradle tee — no End.DT2U/DT2M seg6local action exists);
         // map to End so an unexpected call is a visible no-op rather than
@@ -240,6 +242,7 @@ fn build_seg6local_flavors(
 fn build_seg6local_lwtunnel(
     behavior: SidBehavior,
     nh6: Option<Ipv6Addr>,
+    nh4: Option<Ipv4Addr>,
     structure: Option<SidStructure>,
     table_id: u32,
     segs: &[Ipv6Addr],
@@ -249,10 +252,16 @@ fn build_seg6local_lwtunnel(
         vec![RouteSeg6LocalIpTunnel::Action(seg6local_action(behavior))];
     if matches!(
         behavior,
-        SidBehavior::EndX | SidBehavior::UA | SidBehavior::UALib
+        SidBehavior::EndX | SidBehavior::UA | SidBehavior::UALib | SidBehavior::EndDX6
     ) {
         let nh = nh6?;
         attrs.push(RouteSeg6LocalIpTunnel::Nh6(nh));
+    }
+    if matches!(behavior, SidBehavior::EndDX4) {
+        // `SEG6_LOCAL_NH4`: the IPv4 cross-connect adjacency. Missing →
+        // skip the FIB install (the registry row is harmless).
+        let nh = nh4?;
+        attrs.push(RouteSeg6LocalIpTunnel::Nh4(nh));
     }
     if matches!(behavior, SidBehavior::EndB6Encap) {
         // `SEG6_LOCAL_SRH`: the SR Policy segment list this Binding SID
@@ -301,12 +310,13 @@ fn build_seg6local_lwtunnel(
 pub fn build_seg6local_attrs(
     behavior: SidBehavior,
     nh6: Option<Ipv6Addr>,
+    nh4: Option<Ipv4Addr>,
     structure: Option<SidStructure>,
     table_id: u32,
     segs: &[Ipv6Addr],
     flavors: u8,
 ) -> Option<(RouteAttribute, RouteAttribute)> {
-    let encaps = build_seg6local_lwtunnel(behavior, nh6, structure, table_id, segs, flavors)?;
+    let encaps = build_seg6local_lwtunnel(behavior, nh6, nh4, structure, table_id, segs, flavors)?;
     Some((
         RouteAttribute::Encap(encaps),
         RouteAttribute::EncapType(RouteLwEnCapType::Seg6Local),
@@ -339,7 +349,7 @@ mod tests {
     fn end_dt46_uses_vrftable_with_given_table() {
         // BGP L3VPN-over-SRv6: an End.DT46 SID decaps into the VRF's
         // kernel table via SEG6_LOCAL_VRFTABLE, never a plain table.
-        let encaps = build_seg6local_lwtunnel(SidBehavior::EndDT46, None, None, 100, &[], 0)
+        let encaps = build_seg6local_lwtunnel(SidBehavior::EndDT46, None, None, None, 100, &[], 0)
             .expect("encap built");
         assert!(
             encaps.iter().any(|e| matches!(
@@ -357,7 +367,7 @@ mod tests {
     #[test]
     fn end_dt6_table_zero_maps_to_main() {
         // table_id 0 must preserve the legacy static / IS-IS default.
-        let encaps = build_seg6local_lwtunnel(SidBehavior::EndDT6, None, None, 0, &[], 0)
+        let encaps = build_seg6local_lwtunnel(SidBehavior::EndDT6, None, None, None, 0, &[], 0)
             .expect("encap built");
         assert_eq!(table_attr(&encaps), Some(RouteHeader::RT_TABLE_MAIN as u32));
         assert_eq!(vrftable_attr(&encaps), None);
@@ -365,7 +375,7 @@ mod tests {
 
     #[test]
     fn end_dt4_honors_nonzero_table() {
-        let encaps = build_seg6local_lwtunnel(SidBehavior::EndDT4, None, None, 42, &[], 0)
+        let encaps = build_seg6local_lwtunnel(SidBehavior::EndDT4, None, None, None, 42, &[], 0)
             .expect("encap built");
         assert_eq!(table_attr(&encaps), Some(42));
     }
@@ -375,8 +385,9 @@ mod tests {
         // End.M (egress protection): reuses the End.DT6 kernel action and
         // looks the inner packet up in the mirror-context table via a
         // plain SEG6_LOCAL_TABLE — never a VRF table.
-        let encaps = build_seg6local_lwtunnel(SidBehavior::EndM, None, None, 0x4D00_0000, &[], 0)
-            .expect("encap built");
+        let encaps =
+            build_seg6local_lwtunnel(SidBehavior::EndM, None, None, None, 0x4D00_0000, &[], 0)
+                .expect("encap built");
         assert!(
             encaps.iter().any(|e| matches!(
                 e,
@@ -395,8 +406,9 @@ mod tests {
         // SR Policy Binding SID: End.B6.Encaps carries the policy's
         // segment list as a SEG6_LOCAL_SRH attribute.
         let segs = vec!["fc00:0:2::".parse().unwrap(), "fc00:0:9::".parse().unwrap()];
-        let encaps = build_seg6local_lwtunnel(SidBehavior::EndB6Encap, None, None, 0, &segs, 0)
-            .expect("encap built");
+        let encaps =
+            build_seg6local_lwtunnel(SidBehavior::EndB6Encap, None, None, None, 0, &segs, 0)
+                .expect("encap built");
         assert!(encaps.iter().any(|e| matches!(
             e,
             RouteLwTunnelEncap::Seg6Local(RouteSeg6LocalIpTunnel::Action(
@@ -413,7 +425,50 @@ mod tests {
     #[test]
     fn end_b6_encaps_without_segments_skips_install() {
         // No segment list → no SRH to push → skip the FIB install.
-        assert!(build_seg6local_lwtunnel(SidBehavior::EndB6Encap, None, None, 0, &[], 0).is_none());
+        assert!(
+            build_seg6local_lwtunnel(SidBehavior::EndB6Encap, None, None, None, 0, &[], 0)
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn end_dx6_pushes_nh6_adjacency() {
+        // End.DX6 (RFC 8986 §4.4): decap + v6 cross-connect — the
+        // adjacency rides as SEG6_LOCAL_NH6; without one there is
+        // nothing to cross-connect to, so the install is skipped.
+        let nh6: Ipv6Addr = "fc00:0:2::1".parse().unwrap();
+        let encaps =
+            build_seg6local_lwtunnel(SidBehavior::EndDX6, Some(nh6), None, None, 0, &[], 0)
+                .expect("encap built");
+        assert!(encaps.iter().any(|e| matches!(
+            e,
+            RouteLwTunnelEncap::Seg6Local(RouteSeg6LocalIpTunnel::Action(Seg6LocalAction::EndDx6))
+        )));
+        assert!(encaps.iter().any(
+            |e| matches!(e, RouteLwTunnelEncap::Seg6Local(RouteSeg6LocalIpTunnel::Nh6(a)) if *a == nh6)
+        ));
+        assert!(
+            build_seg6local_lwtunnel(SidBehavior::EndDX6, None, None, None, 0, &[], 0).is_none()
+        );
+    }
+
+    #[test]
+    fn end_dx4_pushes_nh4_adjacency() {
+        // End.DX4 (RFC 8986 §4.5): the IPv4 sibling — SEG6_LOCAL_NH4.
+        let nh4: Ipv4Addr = "10.0.2.1".parse().unwrap();
+        let encaps =
+            build_seg6local_lwtunnel(SidBehavior::EndDX4, None, Some(nh4), None, 0, &[], 0)
+                .expect("encap built");
+        assert!(encaps.iter().any(|e| matches!(
+            e,
+            RouteLwTunnelEncap::Seg6Local(RouteSeg6LocalIpTunnel::Action(Seg6LocalAction::EndDx4))
+        )));
+        assert!(encaps.iter().any(
+            |e| matches!(e, RouteLwTunnelEncap::Seg6Local(RouteSeg6LocalIpTunnel::Nh4(a)) if *a == nh4)
+        ));
+        assert!(
+            build_seg6local_lwtunnel(SidBehavior::EndDX4, None, None, None, 0, &[], 0).is_none()
+        );
     }
 
     #[test]
@@ -448,8 +503,9 @@ mod tests {
             fun_bits: 16,
             arg_bits: 64,
         });
-        let encaps = build_seg6local_lwtunnel(SidBehavior::UA, Some(nh6), structure, 0, &[], 0)
-            .expect("encap built");
+        let encaps =
+            build_seg6local_lwtunnel(SidBehavior::UA, Some(nh6), None, structure, 0, &[], 0)
+                .expect("encap built");
         assert!(
             !encaps.iter().any(|e| matches!(
                 e,
@@ -464,7 +520,7 @@ mod tests {
 
         // uN keeps the flavor — it is a prefix install where carriers
         // with a remaining argument legitimately shift.
-        let encaps = build_seg6local_lwtunnel(SidBehavior::UN, None, structure, 0, &[], 0)
+        let encaps = build_seg6local_lwtunnel(SidBehavior::UN, None, None, structure, 0, &[], 0)
             .expect("encap built");
         assert!(encaps.iter().any(|e| matches!(
             e,

--- a/zebra-rs/src/rib/inst.rs
+++ b/zebra-rs/src/rib/inst.rs
@@ -1218,6 +1218,8 @@ impl Rib {
             | SidBehavior::EndM
             | SidBehavior::EndT
             | SidBehavior::UT
+            | SidBehavior::EndDX4
+            | SidBehavior::EndDX6
             // End.B6.Encaps is a seg6local action too — bound to `lo` the
             // kernel strips it exactly like the decap group.
             | SidBehavior::EndB6Encap => self.resolve_sr0_ifindex(),

--- a/zebra-rs/src/rib/segment_routing/sid.rs
+++ b/zebra-rs/src/rib/segment_routing/sid.rs
@@ -102,6 +102,14 @@ pub enum SidBehavior {
     /// a /(LB+LN) prefix like uN. No kernel flavor op composes NEXT-CSID
     /// with End.T — cradle tee only.
     UT,
+    /// End.DX4 — RFC 8986 §4.5 (IANA codepoint 17): decapsulate and
+    /// cross-connect the inner IPv4 packet to a bound adjacency — the
+    /// per-CE VPN egress. Static-config only today (`action End.DX4` +
+    /// `nh4`); kernel-native seg6local action.
+    EndDX4,
+    /// End.DX6 — RFC 8986 §4.4 (IANA codepoint 16): the IPv6 sibling of
+    /// `EndDX4` (`action End.DX6` + `nh6`).
+    EndDX6,
 }
 
 impl fmt::Display for SidBehavior {
@@ -123,6 +131,8 @@ impl fmt::Display for SidBehavior {
             Self::EndXRep => write!(f, "End.X(REP)"),
             Self::EndT => write!(f, "End.T"),
             Self::UT => write!(f, "uT"),
+            Self::EndDX4 => write!(f, "End.DX4"),
+            Self::EndDX6 => write!(f, "End.DX6"),
         }
     }
 }
@@ -141,6 +151,8 @@ impl FromStr for SidBehavior {
             // UALib is deliberately absent: it is derived from a uA at
             // install time, never named in config.
             "uA" => Ok(Self::UA),
+            "End.DX4" => Ok(Self::EndDX4),
+            "End.DX6" => Ok(Self::EndDX6),
             "End.DT4" => Ok(Self::EndDT4),
             "End.DT6" => Ok(Self::EndDT6),
             "End.DT46" => Ok(Self::EndDT46),
@@ -301,7 +313,9 @@ impl Sid {
             | SidBehavior::EndDT2U
             | SidBehavior::EndDT2M
             | SidBehavior::EndM
-            | SidBehavior::EndT => Ipv6Net::new(self.addr, 128).expect("/128 is always valid"),
+            | SidBehavior::EndT
+            | SidBehavior::EndDX4
+            | SidBehavior::EndDX6 => Ipv6Net::new(self.addr, 128).expect("/128 is always valid"),
             SidBehavior::UALib => {
                 let plen = self
                     .structure

--- a/zebra-rs/src/rib/static/config.rs
+++ b/zebra-rs/src/rib/static/config.rs
@@ -471,6 +471,32 @@ fn config_builder<F: StaticFamily>(base: &str) -> ConfigBuilder<F> {
             s.encap_type = None;
             Ok(())
         })
+        .path(&format!("{base}/{}/route/nh6", F::FAMILY))
+        .set(|config, cache, prefix, args| {
+            const NH6_ERR: &str = "nh6 address parse error";
+            let s = cache_get::<F>(config, cache, prefix).context(CONFIG_ERR)?;
+            let arg = args.string().context(NH6_ERR)?;
+            s.nh6 = Some(arg.parse::<Ipv6Addr>().context(NH6_ERR)?);
+            Ok(())
+        })
+        .del(|config, cache, prefix, _args| {
+            let s = cache_lookup::<F>(config, cache, prefix).context(CONFIG_ERR)?;
+            s.nh6 = None;
+            Ok(())
+        })
+        .path(&format!("{base}/{}/route/nh4", F::FAMILY))
+        .set(|config, cache, prefix, args| {
+            const NH4_ERR: &str = "nh4 address parse error";
+            let s = cache_get::<F>(config, cache, prefix).context(CONFIG_ERR)?;
+            let arg = args.string().context(NH4_ERR)?;
+            s.nh4 = Some(arg.parse::<std::net::Ipv4Addr>().context(NH4_ERR)?);
+            Ok(())
+        })
+        .del(|config, cache, prefix, _args| {
+            let s = cache_lookup::<F>(config, cache, prefix).context(CONFIG_ERR)?;
+            s.nh4 = None;
+            Ok(())
+        })
         .path(&format!("{base}/{}/route/action", F::FAMILY))
         .set(|config, cache, prefix, args| {
             const ACTION_ERR: &str = "missing seg6local action arg";

--- a/zebra-rs/src/rib/static/route.rs
+++ b/zebra-rs/src/rib/static/route.rs
@@ -28,6 +28,11 @@ pub struct StaticRoute<F: StaticFamily> {
     /// produces a Uni nexthop that the FIB installs as a kernel
     /// `seg6local` route on the sr0 dummy.
     pub seg6local_action: Option<SidBehavior>,
+    /// IPv6 cross-connect adjacency for `action End.DX6` (also honored
+    /// for End.X / uA), mirroring iproute2's `nh6`.
+    pub nh6: Option<Ipv6Addr>,
+    /// IPv4 cross-connect adjacency for `action End.DX4` (`nh4`).
+    pub nh4: Option<std::net::Ipv4Addr>,
     /// Discard route (`route <prefix> blackhole`): `to_entry`
     /// produces a `Nexthop::Blackhole` the FIB installs as an
     /// `RTN_BLACKHOLE` kernel route. Mutually exclusive with
@@ -45,6 +50,8 @@ impl<F: StaticFamily> Default for StaticRoute<F> {
             segs: Vec::new(),
             encap_type: None,
             seg6local_action: None,
+            nh6: None,
+            nh4: None,
             blackhole: false,
             delete: false,
         }
@@ -60,6 +67,8 @@ impl<F: StaticFamily> Clone for StaticRoute<F> {
             segs: self.segs.clone(),
             encap_type: self.encap_type,
             seg6local_action: self.seg6local_action,
+            nh6: self.nh6,
+            nh4: self.nh4,
             blackhole: self.blackhole,
             delete: self.delete,
         }
@@ -89,6 +98,8 @@ impl<F: StaticFamily> StaticRoute<F> {
         if self.nexthops.is_empty()
             && self.segs.is_empty()
             && self.seg6local_action.is_none()
+            && self.nh6.is_none()
+            && self.nh4.is_none()
             && !self.blackhole
         {
             return None;
@@ -121,8 +132,21 @@ impl<F: StaticFamily> StaticRoute<F> {
             // a separate shared-state reference into the static
             // commit pipeline, which isn't worth it for a one-line
             // fill-in.
+            // The DX cross-connect adjacency rides on the uni addr:
+            // `nh4` for End.DX4, `nh6` for End.DX6 (and End.X / uA).
+            // The other actions keep the unspecified placeholder.
+            let addr = match action {
+                SidBehavior::EndDX4 => self
+                    .nh4
+                    .map(IpAddr::V4)
+                    .unwrap_or(IpAddr::V6(Ipv6Addr::UNSPECIFIED)),
+                _ => self
+                    .nh6
+                    .map(IpAddr::V6)
+                    .unwrap_or(IpAddr::V6(Ipv6Addr::UNSPECIFIED)),
+            };
             let nhop = NexthopUni {
-                addr: IpAddr::V6(Ipv6Addr::UNSPECIFIED),
+                addr,
                 metric,
                 weight: 1,
                 seg6local_action: Some(action),

--- a/zebra-rs/yang/config-static.yang
+++ b/zebra-rs/yang/config-static.yang
@@ -257,10 +257,10 @@ module config-static {
             "SRv6 endpoint behavior installed as a seg6local
              terminal action on this prefix. Mutually exclusive
              with `segments` (which configures an outer H.Encap
-             push). Only the local-action variants — End, uN,
-             End.DT4, End.DT6, End.DT46 — are usable today;
-             End.X / uA require a per-adjacency nexthop that this
-             list doesn't model yet.
+             push). Usable variants: End, uN, End.DT4, End.DT6,
+             End.DT46, and — with the sibling `nh6`/`nh4`
+             adjacency leaves — End.DX6 / End.DX4. End.X / uA
+             also take `nh6`.
 
              End.DT4 / End.DT6 / End.DT46 decapsulate the outer
              IPv6 header and look the inner packet up in the VRF
@@ -276,7 +276,23 @@ module config-static {
             enum "End.DT4";
             enum "End.DT6";
             enum "End.DT46";
+            enum "End.DX4";
+            enum "End.DX6";
           }
+        }
+        leaf nh6 {
+          type inet:ipv6-address;
+          description
+            "IPv6 cross-connect adjacency for `action End.DX6`
+             (decap + forward straight to this neighbor, RFC 8986
+             4.4) — also honored for End.X / uA. Mirrors
+             iproute2's `nh6` keyword.";
+        }
+        leaf nh4 {
+          type inet:ipv4-address;
+          description
+            "IPv4 cross-connect adjacency for `action End.DX4`
+             (RFC 8986 4.5). Mirrors iproute2's `nh4` keyword.";
         }
         leaf vrf {
           type string;


### PR DESCRIPTION
## Summary
- config-static grows `action End.DX4` / `action End.DX6` with dedicated `nh4` / `nh6` adjacency leaves (iproute2's keywords): the route's prefix is the SID, the leaf is the CE cross-connect (RFC 8986 §4.5 / §4.4 — the per-CE VPN egress). `SidBehavior::EndDX4/EndDX6` install at /128 with the kernel-native seg6local actions; new `SEG6_LOCAL_NH4` arm and End.DX6 in the Nh6 group of `build_seg6local_lwtunnel` (missing adjacency → install skipped), unit-tested.
- **Gap-fill**: static seg6local action routes install as route-embedded encaps and never pass the SID registry, so the cradle tee never saw them — a static End/uN/DT*/DX* SID existed in the kernel but not in eBPF. `CradleFib::static_sid_install` now tees them as local SIDs, resolving the DX adjacency to a cradle nexthop by family.

## Test plan
- fmt --check, clippy --workspace --all-targets, clippy --no-default-features clean; `cargo test -p zebra-rs` 1518 passed (incl. new `end_dx6_pushes_nh6_adjacency` / `end_dx4_pushes_nh4_adjacency`).
- Cradle e2e `cradle_dx_zebra`: static `action End.DX6 nh6` / `action End.DX4 nh4` → the new static tee → eBPF decap + cross-connect for both inner families, no IGP involved. Green against this branch, plus the full 23-feature cradle sweep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)