### PR TITLE
feat: tee connected routes to cradle; withdraw static seg6local SIDs

### DIFF
--- a/zebra-rs/src/fib/cradle.rs
+++ b/zebra-rs/src/fib/cradle.rs
@@ -571,6 +571,24 @@ impl CradleFib {
         }
     }
 
+    /// Withdraw a static seg6local action SID teed by `static_sid_install`.
+    pub async fn static_sid_uninstall(&self, prefix: Ipv6Net) {
+        let result = async {
+            self.client()
+                .await?
+                .del_local_sid(pb::LocalSidDel {
+                    sid: prefix.addr().to_string(),
+                    prefix_len: prefix.prefix_len() as u32,
+                })
+                .await?;
+            anyhow::Ok(())
+        }
+        .await;
+        if let Err(e) = result {
+            tracing::warn!("fib: cradle static_sid_uninstall {} failed: {e}", prefix);
+        }
+    }
+
     pub async fn local_sid_install(&self, sid: &crate::rib::Sid, prefix_len: u8, ifindex: u32) {
         let result = async {
             let nexthop_id =

--- a/zebra-rs/src/fib/netlink/handle.rs
+++ b/zebra-rs/src/fib/netlink/handle.rs
@@ -389,6 +389,11 @@ fn cradle_members(nexthop: &Nexthop) -> Vec<CradleMember> {
     }
     match nexthop {
         Nexthop::Uni(u) => vec![member(u)],
+        // Connected routes: an interface-only (gateway-less) member. The
+        // eBPF forward falls back to `bpf_redirect_neigh` on the
+        // destination itself, which also drives kernel ND — so delivery
+        // to directly-connected hosts needs no pinned neighbors.
+        Nexthop::Link(ifindex) => vec![(None, *ifindex, vec![], vec![], 0, None)],
         Nexthop::Multi(m) => m.nexthops.iter().map(member).collect(),
         Nexthop::List(l) => l
             .nexthops
@@ -709,14 +714,17 @@ impl FibHandle {
     /// clear and forces the nexthop's recreation so the next resolve
     /// pass re-adds it.
     pub async fn route_ipv4_add(&self, prefix: &Ipv4Net, entry: &RibEntry, table_id: u32) -> bool {
-        if !entry.is_protocol() {
-            return true;
-        }
-        if let Some(cradle) = &self.cradle {
+        // Tee protocol AND connected routes — see the v6 sibling.
+        if (entry.is_protocol() || matches!(entry.rtype, RibType::Connected))
+            && let Some(cradle) = &self.cradle
+        {
             let members = cradle_members(&entry.nexthop);
             if !members.is_empty() {
                 cradle.route_install(*prefix, table_id, members).await;
             }
+        }
+        if !entry.is_protocol() {
+            return true;
         }
         match &entry.nexthop {
             Nexthop::Uni(_) | Nexthop::Multi(_) => {
@@ -938,11 +946,13 @@ impl FibHandle {
     }
 
     pub async fn route_ipv4_del(&self, prefix: &Ipv4Net, entry: &RibEntry, table_id: u32) {
+        if (entry.is_protocol() || matches!(entry.rtype, RibType::Connected))
+            && let Some(cradle) = &self.cradle
+        {
+            cradle.route_del(*prefix, table_id).await;
+        }
         if !entry.is_protocol() {
             return;
-        }
-        if let Some(cradle) = &self.cradle {
-            cradle.route_del(*prefix, table_id).await;
         }
 
         match &entry.nexthop {
@@ -1238,14 +1248,21 @@ impl FibHandle {
     /// IPv6 sibling of [`Self::route_ipv4_add`]; returns whether the
     /// kernel accepted the install.
     pub async fn route_ipv6_add(&self, prefix: &Ipv6Net, entry: &RibEntry, table_id: u32) -> bool {
-        if !entry.is_protocol() {
-            return true;
-        }
-        if let Some(cradle) = &self.cradle {
+        // The kernel originates connected routes itself, so they never
+        // take the netlink-install path below — but the cradle datapath
+        // still needs them or a zebra-driven node cannot deliver to
+        // directly-connected hosts. Tee protocol AND connected routes;
+        // kernel-learned ones stay out (they would echo).
+        if (entry.is_protocol() || matches!(entry.rtype, RibType::Connected))
+            && let Some(cradle) = &self.cradle
+        {
             let members = cradle_members(&entry.nexthop);
             if !members.is_empty() {
                 cradle.route_install6(*prefix, table_id, members).await;
             }
+        }
+        if !entry.is_protocol() {
+            return true;
         }
         match &entry.nexthop {
             Nexthop::Uni(_) | Nexthop::Multi(_) => {
@@ -1480,11 +1497,20 @@ impl FibHandle {
     }
 
     pub async fn route_ipv6_del(&self, prefix: &Ipv6Net, entry: &RibEntry, table_id: u32) {
+        if (entry.is_protocol() || matches!(entry.rtype, RibType::Connected))
+            && let Some(cradle) = &self.cradle
+        {
+            cradle.route_del6(*prefix, table_id).await;
+            // A static seg6local action route also teed a local SID
+            // on install — withdraw it or the eBPF entry goes stale.
+            if let Nexthop::Uni(uni) = &entry.nexthop
+                && uni.seg6local_action.is_some()
+            {
+                cradle.static_sid_uninstall(*prefix).await;
+            }
+        }
         if !entry.is_protocol() {
             return;
-        }
-        if let Some(cradle) = &self.cradle {
-            cradle.route_del6(*prefix, table_id).await;
         }
 
         match &entry.nexthop {


### PR DESCRIPTION
## Summary
- **Connected routes now tee to cradle.** The `is_protocol` gate rightly keeps them out of the kernel install (the kernel originates them), but it also starved the eBPF FIB — a zebra-driven node could not deliver to its own connected subnets without hand-pinned neighbors and synthetic static routes, and every zebra-driven BDD worked around it. The v4/v6 route add/del paths tee protocol AND connected routes; `cradle_members` yields an interface-only member for `Nexthop::Link`, which the eBPF forward serves via its `bpf_redirect_neigh` fallback (kernel ND/ARP resolves per-destination neighbors autonomously). Kernel-learned routes stay excluded.
- **Static seg6local delete tee**: withdrawing a config-static `action` route now sends `DelLocalSid` (`CradleFib::static_sid_uninstall`) — previously the teed eBPF local SID went stale on config removal.

## Test plan
- fmt --check, clippy --workspace --all-targets, clippy --no-default-features clean; `cargo test -p zebra-rs` 1518 passed.
- Cradle BDD `cradle_tee_connected`: r's zebra config is nothing but interface addresses — no static routes, no pinned neighbors, no pinned MACs — and c1↔c2 pings work in both families with kernel forwarding off on r. Green against this branch.
- Full 24-feature cradle sweep green (every zebra-driven feature now carries the extra connected routes in its eBPF FIB).

🤖 Generated with [Claude Code](https://claude.com/claude-code)