### PR TITLE
feat(ospf): forwarding-address origination and resolution (v2 + v3)

### DIFF
--- a/bdd/tests/configs/ospfv2_nssa_fa/a.yaml
+++ b/bdd/tests/configs/ospfv2_nssa_fa/a.yaml
@@ -1,0 +1,31 @@
+# a is the NSSA ABR / translator: area 0 toward b, NSSA area 1
+# toward c. Type-7s from c (carrying c's NSSA interface address as
+# the RFC 3101 §2.3 forwarding address) translate to Type-5s with
+# the FA preserved.
+interface:
+- if-name: lo
+  ipv4:
+    address: 10.0.0.1/32
+- if-name: ethb
+  ipv4:
+    address: 10.0.12.1/30
+- if-name: ethc
+  ipv4:
+    address: 10.0.13.1/30
+router:
+  ospf:
+    router-id: 10.0.0.1
+    area:
+    - area-id: 0.0.0.0
+      interface:
+      - if-name: lo
+        enable: true
+      - if-name: ethb
+        enable: true
+        network-type: point-to-point
+    - area-id: 0.0.0.1
+      area-type: nssa
+      interface:
+      - if-name: ethc
+        enable: true
+        network-type: point-to-point

--- a/bdd/tests/configs/ospfv2_nssa_fa/a_suppress.yaml
+++ b/bdd/tests/configs/ospfv2_nssa_fa/a_suppress.yaml
@@ -1,0 +1,31 @@
+# Same ABR with `nssa-suppress-fa`: the translated Type-5 carries
+# FA 0.0.0.0, so backbone receivers route via this ABR instead of
+# the forwarding address.
+interface:
+- if-name: lo
+  ipv4:
+    address: 10.0.0.1/32
+- if-name: ethb
+  ipv4:
+    address: 10.0.12.1/30
+- if-name: ethc
+  ipv4:
+    address: 10.0.13.1/30
+router:
+  ospf:
+    router-id: 10.0.0.1
+    area:
+    - area-id: 0.0.0.0
+      interface:
+      - if-name: lo
+        enable: true
+      - if-name: ethb
+        enable: true
+        network-type: point-to-point
+    - area-id: 0.0.0.1
+      area-type: nssa
+      nssa-suppress-fa: true
+      interface:
+      - if-name: ethc
+        enable: true
+        network-type: point-to-point

--- a/bdd/tests/configs/ospfv2_nssa_fa/b.yaml
+++ b/bdd/tests/configs/ospfv2_nssa_fa/b.yaml
@@ -1,0 +1,22 @@
+# b is a pure backbone router: it receives the translated Type-5
+# whose forwarding address (c's NSSA interface 10.0.13.2) must
+# resolve via b's inter-area route to 10.0.13.0/30 — the RFC 2328
+# §16.4 step 3 path this feature exercises.
+interface:
+- if-name: lo
+  ipv4:
+    address: 10.0.0.2/32
+- if-name: etha
+  ipv4:
+    address: 10.0.12.2/30
+router:
+  ospf:
+    router-id: 10.0.0.2
+    area:
+    - area-id: 0.0.0.0
+      interface:
+      - if-name: lo
+        enable: true
+      - if-name: etha
+        enable: true
+        network-type: point-to-point

--- a/bdd/tests/configs/ospfv2_nssa_fa/c.yaml
+++ b/bdd/tests/configs/ospfv2_nssa_fa/c.yaml
@@ -1,0 +1,26 @@
+# c is the NSSA-internal ASBR: redistributes its dummy as a P-bit
+# Type-7 which (RFC 3101 §2.3) now carries a non-zero forwarding
+# address — c's NSSA interface 10.0.13.2.
+interface:
+- if-name: lo
+  ipv4:
+    address: 10.0.0.3/32
+- if-name: etha
+  ipv4:
+    address: 10.0.13.2/30
+router:
+  ospf:
+    router-id: 10.0.0.3
+    area:
+    - area-id: 0.0.0.1
+      area-type: nssa
+      redistribute:
+        connected:
+          metric: 20
+          metric-type: type-2
+      interface:
+      - if-name: lo
+        enable: true
+      - if-name: etha
+        enable: true
+        network-type: point-to-point

--- a/bdd/tests/features/ospfv2_nssa.feature
+++ b/bdd/tests/features/ospfv2_nssa.feature
@@ -248,11 +248,15 @@ Feature: OSPFv2 NSSA (Not-So-Stubby Area) Type-7 origination and translation
     # --- d: intra-NSSA Type-7, E1 metric = cost(d->c) 20 + ext 20 = 40. ---
     Then show command "show ospf route" in namespace "d" should contain "192.168.1.0/24"
     And show command "show ospf route" in namespace "d" should contain "[40]"
-    # --- b: translated Type-5 advertised by ABR a, E1 metric =
-    #     cost(b->a) 10 + ext 20 = 30. The differing metric (30 vs 40)
-    #     is the proof E1's distance term survives translation. ---
+    # --- b: translated Type-5. The Type-7 carries c's NSSA address
+    #     as the RFC 3101 §2.3 forwarding address and translation
+    #     preserves it, so b's E1 distance term measures the path to
+    #     the FA (the true AS exit at c), not to the translator a:
+    #     cost(b->FA 10.0.13.2) 20 + ext 20 = 40 — matching d, which
+    #     is equally 2 hops from c. (Before FA support this read
+    #     cost(b->a) 10 + 20 = 30.) ---
     And show command "show ospf route" in namespace "b" should contain "192.168.1.0/24"
-    And show command "show ospf route" in namespace "b" should contain "[30]"
+    And show command "show ospf route" in namespace "b" should contain "[40]"
 
     When I stop zebra-rs in namespace "a"
     And I stop zebra-rs in namespace "b"

--- a/bdd/tests/features/ospfv2_nssa_fa.feature
+++ b/bdd/tests/features/ospfv2_nssa_fa.feature
@@ -1,0 +1,83 @@
+@serial
+@ospfv2_nssa_fa
+Feature: NSSA Type-7 forwarding address is originated, translated, and resolved
+  As a network operator
+  I want NSSA ASBRs to originate P-bit Type-7 LSAs with a non-zero
+  forwarding address (RFC 3101 §2.3), the ABR to preserve it when
+  translating to Type-5 (or zero it under `nssa-suppress-fa`), and
+  backbone receivers to resolve the external route via the FA's
+  intra/inter-area path (RFC 2328 §16.4 step 3) — previously such
+  LSAs were skipped entirely.
+
+  Test Topology:
+  ```
+     backbone            NSSA area 0.0.0.1
+    b -- 10.0.12.0/30 -- a (ABR/translator) -- 10.0.13.0/30 -- c (ASBR)
+                                          dummy on c: 10.9.9.0/24
+    Type-7 from c carries FA 10.0.13.2 (c's NSSA interface); b's
+    route to the external exists ONLY if it can resolve that FA via
+    its inter-area route to 10.0.13.0/30.
+  ```
+
+  Scenario: FA-carrying external resolves on the backbone end to end
+    Given a clean test environment
+    When I create namespace "a"
+    And I create namespace "b"
+    And I create namespace "c"
+    And I connect namespace "a" interface "ethb" to namespace "b" interface "etha"
+    And I connect namespace "a" interface "ethc" to namespace "c" interface "etha"
+    And I create dummy interface "d9" with address "10.9.9.1/24" in namespace "c"
+    And I start zebra-rs in namespace "a"
+    And I start zebra-rs in namespace "b"
+    And I start zebra-rs in namespace "c"
+    And I apply config "a.yaml" to namespace "a"
+    And I apply config "b.yaml" to namespace "b"
+    And I apply config "c.yaml" to namespace "c"
+    And I wait 30 seconds
+
+    Then show command "show ospf neighbor" in namespace "b" should contain "Full"
+    # The FA's covering prefix reaches b as an inter-area route...
+    And show command "show ospf route" in namespace "b" should contain "10.0.13.0/30"
+    # ...so the FA-carrying translated Type-5 resolves and installs.
+    And show command "show ospf route" in namespace "b" should eventually contain "10.9.9.0/24"
+    And show command "show ospf route" in namespace "b" should contain "[20]"
+    And ping from "b" to "10.9.9.1" should succeed
+
+    # Teardown.
+    When I stop zebra-rs in namespace "a"
+    And I stop zebra-rs in namespace "b"
+    And I stop zebra-rs in namespace "c"
+    And I delete namespace "a"
+    And I delete namespace "b"
+    And I delete namespace "c"
+    Then the test environment should be clean
+
+  Scenario: nssa-suppress-fa zeroes the FA and routing still works via the ABR
+    Given a clean test environment
+    When I create namespace "a"
+    And I create namespace "b"
+    And I create namespace "c"
+    And I connect namespace "a" interface "ethb" to namespace "b" interface "etha"
+    And I connect namespace "a" interface "ethc" to namespace "c" interface "etha"
+    And I create dummy interface "d9" with address "10.9.9.1/24" in namespace "c"
+    And I start zebra-rs in namespace "a"
+    And I start zebra-rs in namespace "b"
+    And I start zebra-rs in namespace "c"
+    And I apply config "a_suppress.yaml" to namespace "a"
+    And I apply config "b.yaml" to namespace "b"
+    And I apply config "c.yaml" to namespace "c"
+    And I wait 30 seconds
+
+    # With the FA suppressed the Type-5 falls back to via-the-ABR
+    # semantics — the route must still install and forward.
+    Then show command "show ospf route" in namespace "b" should eventually contain "10.9.9.0/24"
+    And ping from "b" to "10.9.9.1" should succeed
+
+    # Teardown.
+    When I stop zebra-rs in namespace "a"
+    And I stop zebra-rs in namespace "b"
+    And I stop zebra-rs in namespace "c"
+    And I delete namespace "a"
+    And I delete namespace "b"
+    And I delete namespace "c"
+    Then the test environment should be clean

--- a/book/src/ch-08-12-ospf-frr-gaps.md
+++ b/book/src/ch-08-12-ospf-frr-gaps.md
@@ -8,10 +8,6 @@ OSPFv2 features not yet implemented in zebra-rs:
 - The redistribution `table` source (the zebra-rs sources are
   connected, static, kernel, IS-IS, and BGP; `route-map` filtering
   on those sources is implemented — see below).
-- Forwarding-address resolution on received externals: Type-5/
-  Type-7 LSAs carrying a non-zero forwarding address are skipped
-  (RFC 2328 §16.4 step 3); zebra-rs itself always originates with
-  FA 0.0.0.0.
 
 ## Previously listed gaps that are now closed
 
@@ -84,3 +80,12 @@ per feature — see each feature's page):
   route-map semantics; edits to the list or its prefix-sets re-apply
   live. Both OSPFv2 and OSPFv3. See
   [Route Redistribution](ch-08-15-ospf-redistribution.md#route-map-filtering).
+- **Forwarding-address origination and resolution** — NSSA ASBRs
+  now originate P-bit Type-7s with a non-zero forwarding address
+  (RFC 3101 §2.3, an address on an NSSA-connected interface); the
+  translator preserves it (or zeroes it under `nssa-suppress-fa`,
+  which previously had no effect); and receivers resolve
+  FA-carrying Type-5/Type-7s via the intra/inter-area path to the
+  FA (RFC 2328 §16.4 step 3) instead of skipping them — E1 metrics
+  now measure the distance to the true AS exit. Both OSPFv2 and
+  OSPFv3. See [Area Types](ch-08-13-ospf-area-types.md).

--- a/book/src/ch-08-13-ospf-area-types.md
+++ b/book/src/ch-08-13-ospf-area-types.md
@@ -137,10 +137,20 @@ Election is computed locally with no protocol negotiation; the
 Nt-bit announcement in the Router-LSA is intentionally not emitted,
 matching how FRR, IOS and Junos behave in practice.
 
+An NSSA ASBR originates its P-bit Type-7s with a **non-zero
+forwarding address** — an address on one of its NSSA-connected
+interfaces (RFC 3101 §2.3) — and the translator preserves it in the
+Type-5, so backbone receivers route (and measure E1 metrics) to the
+true AS exit rather than the translating ABR. Receivers resolve a
+non-zero FA via their intra-/inter-area route to it (RFC 2328 §16.4
+step 3); an FA with no such route makes the LSA unusable, as the RFC
+requires.
+
 `nssa-suppress-fa true` zeroes the forwarding address when
 translating Type-7 to Type-5 (RFC 3101 §2.6), forcing traffic
 through the translating ABR instead of the FA — useful when the FA
-prefix is not reachable outside the NSSA.
+prefix is not reachable outside the NSSA. Both behaviors are
+validated by `ospfv2_nssa_fa.feature`.
 
 ## Runtime transitions
 

--- a/book/src/ch-15-15-ospfv3-frr-gaps.md
+++ b/book/src/ch-15-15-ospfv3-frr-gaps.md
@@ -2,9 +2,12 @@
 
 OSPFv3 features not yet implemented in zebra-rs:
 
-- Non-zero forwarding-address resolution on received externals.
 - NBMA and point-to-multipoint network types.
 - Configurable Instance ID (always 0 — one instance per link).
+
+Forwarding-address origination (NSSA Type-7, F-flag) and resolution
+on received externals are implemented for OSPFv3 identically to v2
+— see [the v2 gaps page](ch-08-12-ospf-frr-gaps.md).
 
 Redistribution `route-map` filtering is implemented for OSPFv3
 identically to v2 (policy lists shared with BGP, live

--- a/zebra-rs/src/ospf/inst.rs
+++ b/zebra-rs/src/ospf/inst.rs
@@ -3481,19 +3481,43 @@ impl Ospf<Ospfv2> {
         if let Some(redist_entry) = entry
             && area_type.is_nssa()
         {
+            // RFC 3101 §2.3: a P-bit Type-7 must carry a non-zero
+            // forwarding address so translated Type-5 receivers can
+            // route to the prefix without an NSSA-internal path to
+            // this ASBR — use an address on one of our
+            // NSSA-connected interfaces.
+            let fwd_addr = self
+                .nssa_fa_for_area(area_id)
+                .unwrap_or(Ipv4Addr::UNSPECIFIED);
             for prefix in &desired {
                 self.nssa_lsa_originate_for_prefix(
                     area_id,
                     *prefix,
                     redist_entry.metric,
                     redist_entry.metric_type.is_type_2(),
-                    Ipv4Addr::UNSPECIFIED,
+                    fwd_addr,
                 );
                 if let Some(area) = self.areas.get_mut(area_id) {
                     area.redist_connected_originated.insert(*prefix);
                 }
             }
         }
+    }
+
+    /// RFC 3101 §2.3 forwarding-address selection: the first
+    /// non-loopback-range address on an enabled interface in the
+    /// NSSA. Deterministic (lowest ifindex first) so refreshes don't
+    /// flap the LSA body.
+    fn nssa_fa_for_area(&self, area_id: Ipv4Addr) -> Option<Ipv4Addr> {
+        self.links.values().find_map(|l| {
+            if !l.enabled || l.area_id != area_id {
+                return None;
+            }
+            l.addr
+                .iter()
+                .map(|a| a.prefix.addr())
+                .find(|a| a.octets()[0] != 127)
+        })
     }
 
     /// True when this router has interfaces in two or more OSPF
@@ -3630,13 +3654,13 @@ impl Ospf<Ospfv2> {
     /// - P-bit set in the source — RFC 3101 §3.2.1
     ///
     /// The forwarding address is copied verbatim into the Type-5
-    /// (RFC 3101 §3.2). A zero FA is permitted: the translated
-    /// Type-5 then also carries FA=0, so receivers reach the prefix
-    /// via the path to *this* ABR (the Type-5's advertising router),
-    /// which itself installs the Type-7 route into the NSSA — the
-    /// same FA=0 semantics `add_as_external_routes` /
-    /// `add_nssa_routes` already implement on the receive side.
-    fn nssa_translate_one(&mut self, type7: &OspfLsa) -> bool {
+    /// (RFC 3101 §3.2), unless the area's `nssa-suppress-fa` knob is
+    /// set — then it is zeroed, and receivers reach the prefix via
+    /// the path to *this* ABR (the Type-5's advertising router),
+    /// which itself installs the Type-7 route into the NSSA. A zero
+    /// FA on the source Type-7 is also permitted, with the same
+    /// via-the-ABR semantics on the receive side.
+    fn nssa_translate_one(&mut self, type7: &OspfLsa, suppress_fa: bool) -> bool {
         use crate::ospf::lsdb::OSPF_MAX_AGE;
         const P_BIT: u8 = 0x08;
 
@@ -3668,7 +3692,11 @@ impl Ospf<Ospfv2> {
             // RFC 3101 §3.2: preserve E-bit + TOS byte verbatim.
             ext_and_resvd: body.ext_and_tos,
             metric: body.metric,
-            forwarding_address: body.forwarding_address,
+            forwarding_address: if suppress_fa {
+                Ipv4Addr::UNSPECIFIED
+            } else {
+                body.forwarding_address
+            },
             external_route_tag: body.external_route_tag,
             tos_list: body.tos_list.clone(),
         };
@@ -3792,8 +3820,12 @@ impl Ospf<Ospfv2> {
         // Adv-Router)`, so iteration here yields at most one
         // source per ls_id — fine until cross-NSSA collision
         // becomes a real shape worth handling (deferred).
+        let suppress_fa = self
+            .areas
+            .get(area_id)
+            .is_some_and(|a| a.area_type.nssa_suppress_fa);
         for source in &sources {
-            if self.nssa_translate_one(source)
+            if self.nssa_translate_one(source, suppress_fa)
                 && let Some(area) = self.areas.get_mut(area_id)
             {
                 area.nssa_translated.insert(source.h.ls_id);
@@ -7685,19 +7717,40 @@ impl Ospf<Ospfv3> {
         if let Some(redist_entry) = entry
             && area_type.is_nssa()
         {
+            // RFC 3101 §2.3 (over the RFC 5340 F-flag): carry a
+            // forwarding address on one of our NSSA-connected
+            // interfaces so translated Type-5 receivers can route
+            // to the prefix directly. v6 sibling of the v2 FA
+            // selection.
+            let fwd_addr = self.nssa_fa_for_area_v3(area_id);
             for prefix in &desired {
                 self.nssa_lsa_originate_for_prefix_v3(
                     area_id,
                     *prefix,
                     redist_entry.metric,
                     redist_entry.metric_type.is_type_2(),
-                    None,
+                    fwd_addr,
                 );
                 if let Some(area) = self.areas.get_mut(area_id) {
                     area.redist_connected_originated_v6.insert(*prefix);
                 }
             }
         }
+    }
+
+    /// RFC 3101 §2.3 forwarding-address selection, v6: the first
+    /// global (non-link-local, non-loopback) address on an enabled
+    /// interface in the NSSA. Deterministic (lowest ifindex first).
+    fn nssa_fa_for_area_v3(&self, area_id: Ipv4Addr) -> Option<std::net::Ipv6Addr> {
+        self.links.values().find_map(|l| {
+            if !l.enabled || l.area_id != area_id {
+                return None;
+            }
+            l.addr
+                .iter()
+                .map(|a| a.prefix.addr())
+                .find(|a| !a.is_loopback() && (a.segments()[0] & 0xffc0) != 0xfe80)
+        })
     }
 
     /// RFC 3101 §2.3 v3 NSSA default-LSA origination. Thin
@@ -8795,7 +8848,7 @@ impl Ospf<Ospfv3> {
     ///   the LSA header as in v2)
     /// - forwarding-address present — FA=None mirrors v2's
     ///   FA=0.0.0.0 skip (defer FA-resolution symmetrically)
-    fn nssa_translate_one_v3(&mut self, type7: &ospf_packet::Ospfv3Lsa) -> bool {
+    fn nssa_translate_one_v3(&mut self, type7: &ospf_packet::Ospfv3Lsa, suppress_fa: bool) -> bool {
         use crate::ospf::lsdb::OSPF_MAX_AGE;
         use ospf_packet::{OSPFV3_AS_EXTERNAL_LSA_TYPE, Ospfv3LsBody, Ospfv3Lsa, Ospfv3LsaHeader};
 
@@ -8815,12 +8868,18 @@ impl Ospf<Ospfv3> {
         // translated Type-5 also carries no FA, so receivers reach the
         // prefix via the path to this ABR, which itself installs the
         // Type-7 route. Mirrors the v2 `nssa_translate_one` FA=0
-        // handling.
+        // handling. `nssa-suppress-fa` strips a present FA the same
+        // way.
 
         let link_state_id = type7.h.link_state_id;
         // Build a Type-5 wrapping the same body — RFC 5340 §A.4.9
         // says NSSA-LSA and AS-External-LSA share the wire body.
-        let translated_body = body.clone();
+        let mut translated_body = body.clone();
+        if suppress_fa && translated_body.forwarding_address.is_some() {
+            translated_body.forwarding_address = None;
+            // The F-flag advertises FA presence (RFC 5340 §A.4.7).
+            translated_body.flags &= !ospf_packet::OSPFV3_AS_EXTERNAL_FLAG_F;
+        }
         let header = Ospfv3LsaHeader {
             ls_age: 0,
             ls_type: OSPFV3_AS_EXTERNAL_LSA_TYPE,
@@ -8938,8 +8997,12 @@ impl Ospf<Ospfv3> {
             })
             .unwrap_or_default();
 
+        let suppress_fa = self
+            .areas
+            .get(area_id)
+            .is_some_and(|a| a.area_type.nssa_suppress_fa);
         for source in &sources {
-            if self.nssa_translate_one_v3(source)
+            if self.nssa_translate_one_v3(source, suppress_fa)
                 && let Some(area) = self.areas.get_mut(area_id)
             {
                 area.nssa_translated
@@ -12882,10 +12945,6 @@ fn add_as_external_routes(
         if ext.metric >= LS_INFINITY {
             continue;
         }
-        // Forwarding-address resolution (§16.4 step 3) deferred.
-        if !ext.forwarding_address.is_unspecified() {
-            continue;
-        }
 
         let asbr_id = lsa.data.h.adv_router;
         // The ASBR may not appear in THIS area's lsp_map / SPF at all when
@@ -12941,11 +13000,43 @@ fn add_as_external_routes(
             }
         };
 
+        // §16.4 step 3: with a zero forwarding address, packets go to
+        // the ASBR itself — cost and nexthops come from the ASBR
+        // path resolved above. With a NON-zero forwarding address,
+        // packets go to the FA: look it up in the routing table
+        // built so far (intra + inter-area routes precede externals
+        // in `build_rib_from_spf`); the match must be an intra- or
+        // inter-area path, else the LSA is unusable. Cost and
+        // nexthops then come from the FA's route, so traffic can
+        // bypass the ASBR entirely.
+        let (base_cost, nhops, dest_vertex) = if ext.forwarding_address.is_unspecified() {
+            let nhops = build_spf_nexthops(top, nexthop_vertex, &nexthop_path);
+            (asbr_cost, nhops, Some(nexthop_vertex))
+        } else {
+            let Ok(host) = Ipv4Net::new(ext.forwarding_address, 32) else {
+                continue;
+            };
+            let Some((_, fa_route)) = rib.get_lpm(&host) else {
+                continue;
+            };
+            if !matches!(
+                fa_route.path_type,
+                RouteType::IntraArea | RouteType::InterArea
+            ) {
+                continue;
+            }
+            (
+                fa_route.metric,
+                fa_route.nhops.clone(),
+                fa_route.dest_vertex,
+            )
+        };
+
         let is_type2 = (ext.ext_and_resvd & E_FLAG) != 0;
         let metric = if is_type2 {
             ext.metric
         } else {
-            asbr_cost.saturating_add(ext.metric)
+            base_cost.saturating_add(ext.metric)
         };
 
         let mask = u32::from(ext.netmask).leading_ones() as u8;
@@ -12954,7 +13045,6 @@ fn add_as_external_routes(
         };
         let prefix = prefix.trunc();
 
-        let nhops = build_spf_nexthops(top, nexthop_vertex, &nexthop_path);
         if nhops.is_empty() {
             continue;
         }
@@ -12965,7 +13055,7 @@ fn add_as_external_routes(
             nhops,
             sid: None,
             prefix_sid: None,
-            dest_vertex: Some(nexthop_vertex),
+            dest_vertex,
             backup_as_primary: top.fast_reroute_backup_as_primary,
         };
         rib_insert(rib, prefix, spf_route);
@@ -13017,14 +13107,6 @@ fn add_nssa_routes(
         if ext.metric >= LS_INFINITY {
             continue;
         }
-        // RFC 3101 §2.5 step 5: non-zero FA resolves the route via
-        // an intra-area path to the FA, not to the originator. The
-        // resolver lands in a follow-up — same shape that Type-5
-        // is missing today.
-        if !ext.forwarding_address.is_unspecified() {
-            continue;
-        }
-
         let Some(originator_vertex) = top.lsp_map.lookup(lsa.data.h.adv_router) else {
             continue;
         };
@@ -13032,11 +13114,41 @@ fn add_nssa_routes(
             continue;
         };
 
+        // RFC 3101 §2.5 step 5: a non-zero forwarding address
+        // resolves the route via the path to the FA, not to the
+        // originator. The FA must match an *intra-area* route within
+        // this NSSA (Type-7s never leave the area, so neither may
+        // their FA resolution).
+        let (base_cost, nhops, dest_vertex) = if ext.forwarding_address.is_unspecified() {
+            let nhops = build_spf_nexthops(top, originator_vertex, originator_path);
+            (
+                originator_path.cost,
+                nhops,
+                // Protect the path to the NSSA originator (ASBR).
+                Some(originator_vertex),
+            )
+        } else {
+            let Ok(host) = Ipv4Net::new(ext.forwarding_address, 32) else {
+                continue;
+            };
+            let Some((_, fa_route)) = rib.get_lpm(&host) else {
+                continue;
+            };
+            if fa_route.path_type != RouteType::IntraArea {
+                continue;
+            }
+            (
+                fa_route.metric,
+                fa_route.nhops.clone(),
+                fa_route.dest_vertex,
+            )
+        };
+
         let is_e2 = (ext.ext_and_tos & E_FLAG) != 0;
         let metric = if is_e2 {
             ext.metric
         } else {
-            originator_path.cost.saturating_add(ext.metric)
+            base_cost.saturating_add(ext.metric)
         };
 
         let mask = u32::from(ext.netmask).leading_ones() as u8;
@@ -13045,7 +13157,6 @@ fn add_nssa_routes(
         };
         let prefix = prefix.trunc();
 
-        let nhops = build_spf_nexthops(top, originator_vertex, originator_path);
         if nhops.is_empty() {
             continue;
         }
@@ -13056,8 +13167,7 @@ fn add_nssa_routes(
             nhops,
             sid: None,
             prefix_sid: None,
-            // Protect the path to the NSSA originator (ASBR).
-            dest_vertex: Some(originator_vertex),
+            dest_vertex,
             backup_as_primary: top.fast_reroute_backup_as_primary,
         };
         rib_insert(rib, prefix, spf_route);
@@ -14055,9 +14165,6 @@ fn add_as_external_routes_v3(
         if ext.metric >= OSPFV3_LS_INFINITY {
             continue;
         }
-        if ext.forwarding_address.is_some() {
-            continue;
-        }
 
         // Resolve the path to the ASBR: intra-area SPF first, else the
         // Inter-Area-Router-LSA fallback (RFC 2328 §16.4 step 5) so a
@@ -14073,34 +14180,64 @@ fn add_as_external_routes_v3(
             continue;
         };
 
+        // RFC 5340 §4.8.5 / RFC 2328 §16.4 step 3: an F-flagged
+        // forwarding address routes the external via the FA — its
+        // route (looked up in the intra + inter routes already in
+        // `rib`) supplies cost and nexthops; the ASBR resolution
+        // above stays as the reachability gate.
+        let (base_cost, nhops_map, dest_vertex) = match ext.forwarding_address {
+            None => {
+                let nhops = collect_v3_nexthops(top, asbr_path);
+                let nhops_map: BTreeMap<std::net::Ipv6Addr, SpfNexthopV3> = nhops
+                    .into_iter()
+                    .map(|(addr, ifindex)| {
+                        (
+                            addr,
+                            SpfNexthopV3 {
+                                ifindex,
+                                adjacency: false,
+                                backup: None,
+                            },
+                        )
+                    })
+                    .collect();
+                (asbr_cost, nhops_map, Some(asbr_vertex))
+            }
+            Some(fa) => {
+                let Ok(host) = ipnet::Ipv6Net::new(fa, 128) else {
+                    continue;
+                };
+                let Some((_, fa_route)) = rib.get_lpm(&host) else {
+                    continue;
+                };
+                if !matches!(
+                    fa_route.path_type,
+                    RouteType::IntraArea | RouteType::InterArea
+                ) {
+                    continue;
+                }
+                (
+                    fa_route.metric,
+                    fa_route.nhops.clone(),
+                    fa_route.dest_vertex,
+                )
+            }
+        };
+
         let is_e2 = (ext.flags & OSPFV3_AS_EXTERNAL_FLAG_E) != 0;
         let metric = if is_e2 {
             ext.metric
         } else {
-            asbr_cost.saturating_add(ext.metric)
+            base_cost.saturating_add(ext.metric)
         };
 
         let Some(net) = ospfv3_prefix_to_ipv6net(ext.prefix_length, &ext.address_prefix) else {
             continue;
         };
 
-        let nhops = collect_v3_nexthops(top, asbr_path);
-        if nhops.is_empty() {
+        if nhops_map.is_empty() {
             continue;
         }
-        let nhops_map: BTreeMap<std::net::Ipv6Addr, SpfNexthopV3> = nhops
-            .into_iter()
-            .map(|(addr, ifindex)| {
-                (
-                    addr,
-                    SpfNexthopV3 {
-                        ifindex,
-                        adjacency: false,
-                        backup: None,
-                    },
-                )
-            })
-            .collect();
 
         let entry = SpfRouteV3 {
             metric,
@@ -14108,7 +14245,7 @@ fn add_as_external_routes_v3(
             nhops: nhops_map,
             sid: None,
             prefix_sid: None,
-            dest_vertex: Some(asbr_vertex),
+            dest_vertex,
             backup_as_primary: top.fast_reroute_backup_as_primary,
         };
         rib6_insert(rib, net, entry);
@@ -14169,14 +14306,6 @@ fn add_nssa_routes_v3(
         if ext.metric >= OSPFV3_LS_INFINITY {
             continue;
         }
-        // RFC 3101 §2.5 step 5: non-zero FA resolves the route via
-        // an intra-area path to the FA, not to the originator. The
-        // resolver lands in a follow-up (same shape as v2 and the
-        // not-yet-written v3 AS-External walker).
-        if ext.forwarding_address.is_some() {
-            continue;
-        }
-
         let Some(originator_vertex) = top.lsp_map.lookup(lsa.data.h.advertising_router) else {
             continue;
         };
@@ -14184,34 +14313,65 @@ fn add_nssa_routes_v3(
             continue;
         };
 
+        // RFC 3101 §2.5 step 5: a non-zero forwarding address
+        // resolves the route via the path to the FA, which must be
+        // an intra-area route within this NSSA (v3 mirror of the v2
+        // walker).
+        let (base_cost, nhops_map, dest_vertex) = match ext.forwarding_address {
+            None => {
+                let nhops = collect_v3_nexthops(top, originator_path);
+                let nhops_map: BTreeMap<std::net::Ipv6Addr, SpfNexthopV3> = nhops
+                    .into_iter()
+                    .map(|(addr, ifindex)| {
+                        (
+                            addr,
+                            SpfNexthopV3 {
+                                ifindex,
+                                adjacency: false,
+                                backup: None,
+                            },
+                        )
+                    })
+                    .collect();
+                (
+                    originator_path.cost,
+                    nhops_map,
+                    // Protect the path to the NSSA originator (ASBR).
+                    Some(originator_vertex),
+                )
+            }
+            Some(fa) => {
+                let Ok(host) = ipnet::Ipv6Net::new(fa, 128) else {
+                    continue;
+                };
+                let Some((_, fa_route)) = rib.get_lpm(&host) else {
+                    continue;
+                };
+                if fa_route.path_type != RouteType::IntraArea {
+                    continue;
+                }
+                (
+                    fa_route.metric,
+                    fa_route.nhops.clone(),
+                    fa_route.dest_vertex,
+                )
+            }
+        };
+
         let is_e2 = (ext.flags & OSPFV3_AS_EXTERNAL_FLAG_E) != 0;
         let metric = if is_e2 {
             ext.metric
         } else {
-            originator_path.cost.saturating_add(ext.metric)
+            base_cost.saturating_add(ext.metric)
         };
 
         let Some(net) = ospfv3_prefix_to_ipv6net(ext.prefix_length, &ext.address_prefix) else {
             continue;
         };
 
-        let nhops = collect_v3_nexthops(top, originator_path);
-        if nhops.is_empty() {
+        if nhops_map.is_empty() {
             continue;
         }
-        let nhops_map: BTreeMap<std::net::Ipv6Addr, SpfNexthopV3> = nhops
-            .into_iter()
-            .map(|(addr, ifindex)| {
-                (
-                    addr,
-                    SpfNexthopV3 {
-                        ifindex,
-                        adjacency: false,
-                        backup: None,
-                    },
-                )
-            })
-            .collect();
 
         let entry = SpfRouteV3 {
             metric,
@@ -14219,8 +14379,7 @@ fn add_nssa_routes_v3(
             nhops: nhops_map,
             sid: None,
             prefix_sid: None,
-            // Protect the path to the NSSA originator (ASBR).
-            dest_vertex: Some(originator_vertex),
+            dest_vertex,
             backup_as_primary: top.fast_reroute_backup_as_primary,
         };
         // Equal-cost merge — same shape as the intra-area insert


### PR DESCRIPTION
## Summary

Closes the last correctness-relevant OSPF gap: received Type-5/Type-7 LSAs carrying a **non-zero forwarding address** were skipped entirely (RFC 2328 §16.4 step 3), silently dropping legitimate external routes; zebra-rs never originated one; and `nssa-suppress-fa` was stored but never consumed. All three fixed, both address families.

- **Resolution (§16.4 step 3)**: all four external walkers (Type-5 + Type-7, v2 + v3) resolve a non-zero FA by LPM against the routing table under construction (intra + inter-area routes precede externals in `build_rib_from_spf`, so the ordering gives exactly the table the RFC wants). The match must be intra-/inter-area (intra-only for Type-7, RFC 3101 §2.5); **cost, nexthops, and the TI-LFA dest_vertex come from the FA's route**, so traffic can bypass the ASBR/translator. The step-2 ASBR-reachability gate (incl. Type-4 / Inter-Area-Router fallback) stays.
- **Origination (RFC 3101 §2.3)**: NSSA ASBRs stamp P-bit Type-7s with an address on an NSSA-connected interface (v3: first global address, F-flag set). Deterministic selection.
- **Translation**: the FA is preserved into the Type-5 — and `nssa-suppress-fa` now actually works, zeroing it (v3 also clears the F-flag) to force traffic through the ABR.

### Behavioral consequence (RFC-correct, caught by regression)
E1 metrics on translated externals now measure distance to the **FA (the real AS exit)** rather than to the translator. The `ospfv2_nssa` E1 assertion updates from `[30]` (cost to translator) to `[40]` (cost to the exit — now matching the in-NSSA router's metric, both being 2 hops from the ASBR).

## Test plan
- New **`ospfv2_nssa_fa` BDD**: a backbone router resolves the FA-carrying translated Type-5 via its inter-area route to the FA and forwards end-to-end (this route cannot exist unless origination→translation→resolution all work); scenario 2 proves `nssa-suppress-fa` routes via the ABR. Both pass on first run.
- Regressions all green: `ospfv2_nssa` (4 scenarios, incl. the updated E1 metric), `ospfv3_nssa`, `ospfv2_as_external`, `ospfv2_redistribute_static`.
- Full `cargo test`: 1516; fmt, workspace clippy, mdbook clean.

## Docs
FA origination/resolution/suppression documented on the Area Types page; both FRR-gaps pages updated — the OSPFv2 list is now down to NBMA/P2MP and the redistribute `table` source.

🤖 Generated with [Claude Code](https://claude.com/claude-code)