### PR TITLE
feat(ospfv3): configurable per-interface Instance ID (RFC 5340)

### DIFF
--- a/bdd/tests/configs/ospfv3_instance_id/a.yaml
+++ b/bdd/tests/configs/ospfv3_instance_id/a.yaml
@@ -1,0 +1,19 @@
+interface:
+- if-name: lo
+  ipv6:
+    address: 2001:db8::1/128
+- if-name: ethb
+  ipv6:
+    address: 2001:db8:12::1/64
+router:
+  ospfv3:
+    router-id: 10.0.0.1
+    area:
+    - area-id: 0.0.0.0
+      interface:
+      - if-name: lo
+        enable: true
+      - if-name: ethb
+        enable: true
+        network-type: point-to-point
+        instance-id: 5

--- a/bdd/tests/configs/ospfv3_instance_id/b.yaml
+++ b/bdd/tests/configs/ospfv3_instance_id/b.yaml
@@ -1,0 +1,19 @@
+interface:
+- if-name: lo
+  ipv6:
+    address: 2001:db8::2/128
+- if-name: etha
+  ipv6:
+    address: 2001:db8:12::2/64
+router:
+  ospfv3:
+    router-id: 10.0.0.2
+    area:
+    - area-id: 0.0.0.0
+      interface:
+      - if-name: lo
+        enable: true
+      - if-name: etha
+        enable: true
+        network-type: point-to-point
+        instance-id: 5

--- a/bdd/tests/configs/ospfv3_instance_id/b_mismatch.yaml
+++ b/bdd/tests/configs/ospfv3_instance_id/b_mismatch.yaml
@@ -1,0 +1,21 @@
+# Same as b.yaml but instance-id 7: a (instance 5) must drop b's
+# packets and vice versa — no adjacency may form.
+interface:
+- if-name: lo
+  ipv6:
+    address: 2001:db8::2/128
+- if-name: etha
+  ipv6:
+    address: 2001:db8:12::2/64
+router:
+  ospfv3:
+    router-id: 10.0.0.2
+    area:
+    - area-id: 0.0.0.0
+      interface:
+      - if-name: lo
+        enable: true
+      - if-name: etha
+        enable: true
+        network-type: point-to-point
+        instance-id: 7

--- a/bdd/tests/features/ospfv3_instance_id.feature
+++ b/bdd/tests/features/ospfv3_instance_id.feature
@@ -1,0 +1,63 @@
+@serial
+@ospfv3_instance_id
+Feature: OSPFv3 Instance ID separates instances on a link (RFC 5340)
+  As a network operator
+  I want the per-interface `instance-id` to be stamped into every
+  OSPFv3 packet header (RFC 5340 §A.3.1) and enforced on receive
+  (§8.2: drop on mismatch) — so multiple OSPFv3 instances can share
+  one link without forming cross-instance adjacencies.
+
+  Test Topology:
+  ```
+    a (10.0.0.1) -- 2001:db8:12::/64 -- b (10.0.0.2)
+    matched scenario: both interfaces instance-id 5
+    mismatch scenario: a=5, b=7 — no adjacency may form
+  ```
+
+  Scenario: Matching non-zero instance IDs form a normal adjacency
+    Given a clean test environment
+    When I create namespace "a"
+    And I create namespace "b"
+    And I connect namespace "a" interface "ethb" to namespace "b" interface "etha"
+    And I start zebra-rs in namespace "a"
+    And I start zebra-rs in namespace "b"
+    And I apply config "a.yaml" to namespace "a"
+    And I apply config "b.yaml" to namespace "b"
+    And I wait 25 seconds
+
+    Then show command "show ospfv3 interface" in namespace "a" should contain "Instance ID: 5"
+    And show command "show ospfv3 neighbor" in namespace "a" should contain "Full"
+    And show command "show ospfv3 neighbor" in namespace "b" should contain "Full"
+    And show command "show ospfv3 route" in namespace "a" should contain "2001:db8::2/128"
+    And ping from "a" to "2001:db8::2" should succeed
+
+    # Teardown.
+    When I stop zebra-rs in namespace "a"
+    And I stop zebra-rs in namespace "b"
+    And I delete namespace "a"
+    And I delete namespace "b"
+    Then the test environment should be clean
+
+  Scenario: Mismatched instance IDs never form an adjacency
+    Given a clean test environment
+    When I create namespace "a"
+    And I create namespace "b"
+    And I connect namespace "a" interface "ethb" to namespace "b" interface "etha"
+    And I start zebra-rs in namespace "a"
+    And I start zebra-rs in namespace "b"
+    And I apply config "a.yaml" to namespace "a"
+    And I apply config "b_mismatch.yaml" to namespace "b"
+    And I wait 25 seconds
+
+    # Each side drops the other's packets (instance 5 vs 7): no
+    # neighbor entry may exist in either direction.
+    Then show command "show ospfv3 neighbor" in namespace "a" should not contain "10.0.0.2"
+    And show command "show ospfv3 neighbor" in namespace "b" should not contain "10.0.0.1"
+    And show command "show ospfv3 route" in namespace "a" should not contain "2001:db8::2/128"
+
+    # Teardown.
+    When I stop zebra-rs in namespace "a"
+    And I stop zebra-rs in namespace "b"
+    And I delete namespace "a"
+    And I delete namespace "b"
+    Then the test environment should be clean

--- a/book/src/ch-15-06-ospfv3-per-interface.md
+++ b/book/src/ch-15-06-ospfv3-per-interface.md
@@ -49,6 +49,14 @@ Notes:
   `/affinity-map`) to the link, advertised in the RFC 9492 ASLA
   sub-TLV of the E-Router-LSA — consumed by
   [Flex-Algo](ch-15-10-ospfv3-segment-routing.md) constraints.
+- **`instance-id`** (0..255, default 0) sets the RFC 5340 §A.3.1
+  OSPFv3 Instance ID stamped into every packet sent on the link;
+  received packets whose Instance ID differs are dropped (§8.2).
+  This separates multiple OSPFv3 instances sharing one link — both
+  ends of an adjacency must configure the same value, and a
+  mismatch simply never forms a neighbor. Shown by
+  `show ospfv3 interface`; validated by
+  `ospfv3_instance_id.feature` (matched and mismatched scenarios).
 
 The v2-only `te-metric` block (RFC 7471 delay/loss attributes and
 the STAMP measurement hook) has no OSPFv3 counterpart yet.

--- a/book/src/ch-15-15-ospfv3-frr-gaps.md
+++ b/book/src/ch-15-15-ospfv3-frr-gaps.md
@@ -3,11 +3,14 @@
 OSPFv3 features not yet implemented in zebra-rs:
 
 - NBMA and point-to-multipoint network types.
-- Configurable Instance ID (always 0 — one instance per link).
 
 Forwarding-address origination (NSSA Type-7, F-flag) and resolution
 on received externals are implemented for OSPFv3 identically to v2
 — see [the v2 gaps page](ch-08-12-ospf-frr-gaps.md).
+
+The per-interface Instance ID (RFC 5340 §A.3.1) is configurable —
+`instance-id` on the interface entry, enforced on receive — see
+[Per-Interface Settings](ch-15-06-ospfv3-per-interface.md).
 
 Redistribution `route-map` filtering is implemented for OSPFv3
 identically to v2 (policy lists shared with BGP, live

--- a/zebra-rs/src/ospf/config_v3.rs
+++ b/zebra-rs/src/ospf/config_v3.rs
@@ -247,6 +247,10 @@ impl Ospf<Ospfv3> {
             ("/area/interface/priority", config_ospfv3_interface_priority),
             ("/area/interface/cost", config_ospfv3_interface_cost),
             (
+                "/area/interface/instance-id",
+                config_ospfv3_interface_instance_id,
+            ),
+            (
                 "/area/interface/hello-interval",
                 config_ospfv3_interface_hello_interval,
             ),
@@ -1390,6 +1394,26 @@ fn config_ospfv3_interface_cost(
     ospf.router_intra_area_prefix_lsa_originate(area_id);
     ospf.ext_intra_area_prefix_v3_lsa_originate(ifindex);
 
+    Some(())
+}
+
+/// `/router/ospfv3/area/<id>/interface/<name>/instance-id` —
+/// RFC 5340 §A.3.1 OSPFv3 Instance ID. Applies to the next packets
+/// sent/received on the link; a live mismatch ages the neighbor out
+/// via the dead interval (both ends must be configured alike).
+fn config_ospfv3_interface_instance_id(
+    ospf: &mut Ospf<Ospfv3>,
+    mut args: Args,
+    op: ConfigOp,
+) -> Option<()> {
+    let _area_id = parse_area_id(&args.string()?)?;
+    let name = args.string()?;
+    let link = ospf_link_get_mut_by_name(&mut ospf.links, &name)?;
+    if op.is_set() {
+        link.config.instance_id = Some(args.u8()?);
+    } else {
+        link.config.instance_id = None;
+    }
     Some(())
 }
 

--- a/zebra-rs/src/ospf/inst.rs
+++ b/zebra-rs/src/ospf/inst.rs
@@ -560,6 +560,9 @@ pub struct OspfInterface<'a, V: OspfVersion = Ospfv2> {
     /// receive-side per-LSA rate limit, read by `ospf_ls_upd_proc`.
     /// Snapshot of the instance's `min_ls_arrival_ms`.
     pub min_ls_arrival_ms: u32,
+    /// RFC 5340 §A.3.1 OSPFv3 Instance ID stamped into outbound v3
+    /// packets (0 on v2). Snapshot of the link's configured value.
+    pub v3_instance_id: u8,
     pub tracing: &'a OspfTracing,
     /// v3-only outbound packet channel borrow. Carries the `Ospfv3Send`
     /// sender that the `network_v6::write_packet_v6` task consumes.
@@ -1104,6 +1107,7 @@ impl<V: OspfVersion> Ospf<V> {
             let auth_mode = link.auth_mode();
             let auth_key = link.config.auth_key;
             let crypto_key = link.resolve_active_send_key(&self.key_chains, chrono::Utc::now());
+            let v3_instance_id = link.v3_instance_id();
             self.areas.get_mut(link_area).and_then(|area| {
                 let area_type = area.area_type;
                 link.nbrs.get_mut(src).map(|nbr| {
@@ -1129,6 +1133,7 @@ impl<V: OspfVersion> Ospf<V> {
                             md5_seq: &link.md5_seq,
                             gr_config: self.gr_config,
                             min_ls_arrival_ms: self.min_ls_arrival_ms,
+                            v3_instance_id,
                             tracing: &self.tracing,
                             v3_send_tx: self.v3_send_tx.as_ref(),
                             link_lsdb: &mut link.lsdb,
@@ -9206,6 +9211,7 @@ impl Ospf<Ospfv3> {
             // earlier gap here left authenticated adjacencies unable
             // to converge re-originated LSAs.
             let auth_mode = link.auth_mode();
+            let v3_instance_id = link.v3_instance_id();
             let auth_simple_key = link.config.auth_key;
             let auth_crypto_key =
                 link.resolve_active_send_key(&self.key_chains, chrono::Utc::now());
@@ -9233,7 +9239,7 @@ impl Ospf<Ospfv3> {
                 let mut packet = Ospfv3Packet::new(
                     &self.router_id,
                     &area_id,
-                    0,
+                    v3_instance_id,
                     Ospfv3Payload::LsUpdate(ls_upd),
                 );
                 let dst = nbr.ident.prefix.addr();
@@ -9295,6 +9301,7 @@ impl Ospf<Ospfv3> {
             return;
         };
         let area_id = link.area;
+        let v3_instance_id = link.v3_instance_id();
         let retransmit_interval = link.retransmit_interval();
         let Some(src) = link.addr.iter().find_map(|a| {
             let addr = a.prefix.addr();
@@ -9329,7 +9336,7 @@ impl Ospf<Ospfv3> {
         let mut packet = Ospfv3Packet::new(
             &self.router_id,
             &area_id,
-            0,
+            v3_instance_id,
             Ospfv3Payload::LsUpdate(ls_upd),
         );
         // RFC 7166: a retransmitted LSU carries the trailer like any
@@ -9946,6 +9953,7 @@ impl Ospf<Ospfv3> {
             return;
         };
         let retransmit_interval = link.retransmit_interval();
+        let v3_instance_id = link.v3_instance_id();
         // Auth send state captured before the neighbor loop (see
         // `flood_lsa_through_area`).
         let auth_mode = link.auth_mode();
@@ -9968,7 +9976,7 @@ impl Ospf<Ospfv3> {
             let mut packet = Ospfv3Packet::new(
                 &self.router_id,
                 &area_id,
-                0,
+                v3_instance_id,
                 Ospfv3Payload::LsUpdate(ls_upd),
             );
             let dst = nbr.ident.prefix.addr();
@@ -11307,6 +11315,26 @@ impl Ospf<Ospfv3> {
         } = recv;
         let our_router_id = self.router_id;
         let nbr_router_id = packet.router_id;
+
+        // RFC 5340 §8.2: the packet's Instance ID must match the
+        // receiving interface's — a mismatch means the packet belongs
+        // to a different OSPFv3 instance sharing this link, so drop
+        // it silently (before any further processing, auth included).
+        {
+            let Some(link) = self.links.get(&ifindex) else {
+                return;
+            };
+            if packet.instance_id != link.v3_instance_id() {
+                tracing::debug!(
+                    "[v3 Recv] Instance ID mismatch on {} from {}: got {}, ours {}",
+                    link.name,
+                    src,
+                    packet.instance_id,
+                    link.v3_instance_id()
+                );
+                return;
+            }
+        }
 
         // RFC 7166 Authentication Trailer verification — chain-
         // aware via `KeySource`, mirrors the v2 path in

--- a/zebra-rs/src/ospf/link.rs
+++ b/zebra-rs/src/ospf/link.rs
@@ -83,6 +83,11 @@ pub struct LinkConfig {
     pub retransmit_interval: Option<u16>,
     pub transmit_delay: Option<u16>,
     pub mtu_ignore: bool,
+    /// RFC 5340 §A.3.1 OSPFv3 Instance ID for this link (default 0).
+    /// Stamped into every outbound v3 packet header; inbound packets
+    /// whose Instance ID differs are dropped (§8.2), separating
+    /// multiple OSPFv3 instances sharing one link. v2 ignores it.
+    pub instance_id: Option<u8>,
     /// Passive interface (`/router/ospf{,v3}/area/<id>/interface/<n>/
     /// passive`): the interface's prefixes keep advertising (Router-LSA
     /// stub / Intra-Area-Prefix-LSA — the LSA builds gate on `enable`,
@@ -677,6 +682,12 @@ impl<V: OspfVersion> OspfLink<V> {
         self.config
             .hello_interval
             .unwrap_or(OSPF_DEFAULT_HELLO_INTERVAL)
+    }
+
+    /// RFC 5340 §A.3.1 OSPFv3 Instance ID (default 0). Meaningless
+    /// on v2 links.
+    pub fn v3_instance_id(&self) -> u8 {
+        self.config.instance_id.unwrap_or(0)
     }
 
     pub fn dead_interval(&self) -> u32 {

--- a/zebra-rs/src/ospf/packet_v3.rs
+++ b/zebra-rs/src/ospf/packet_v3.rs
@@ -281,9 +281,9 @@ fn build_hello_packet(link: &OspfLink<Ospfv3>) -> Option<Ospfv3Packet> {
     let packet = Ospfv3Packet::new(
         &link.ident.router_id,
         &link.area_id,
-        0, // Instance ID — RFC 5340 §A.3.1: zero unless multiple
-        //   OSPF processes share the link. zebra-rs doesn't yet
-        //   support multi-instance, so we always emit zero.
+        // RFC 5340 §A.3.1 Instance ID: separates multiple OSPFv3
+        // instances sharing this link; receivers drop mismatches.
+        link.v3_instance_id(),
         Ospfv3Payload::Hello(hello),
     );
     Some(packet)
@@ -594,7 +594,7 @@ pub fn ospfv3_db_desc_send(
     let mut packet = Ospfv3Packet::new(
         &oident.router_id,
         &area,
-        0, // instance_id (RFC 5340 §A.3.1)
+        oi.v3_instance_id,
         Ospfv3Payload::DbDesc(dd),
     );
 
@@ -655,7 +655,7 @@ pub(super) fn ospfv3_db_desc_resend(oi: &OspfInterface<Ospfv3>, nbr: &Neighbor<O
     let mut packet = Ospfv3Packet::new(
         oi.router_id,
         &oi.area_id,
-        0,
+        oi.v3_instance_id,
         Ospfv3Payload::DbDesc(sent.clone()),
     );
     let dst = nbr.ident.prefix.addr();
@@ -942,7 +942,7 @@ pub fn ospfv3_ls_req_send(
     let mut packet = Ospfv3Packet::new(
         &oident.router_id,
         &area,
-        0,
+        oi.v3_instance_id,
         Ospfv3Payload::LsRequest(ls_req),
     );
 
@@ -987,7 +987,12 @@ pub fn ospfv3_ls_upd_send(
     );
     let ls_upd = Ospfv3LsUpdate { lsas };
 
-    let mut packet = Ospfv3Packet::new(oi.router_id, &area, 0, Ospfv3Payload::LsUpdate(ls_upd));
+    let mut packet = Ospfv3Packet::new(
+        oi.router_id,
+        &area,
+        oi.v3_instance_id,
+        Ospfv3Payload::LsUpdate(ls_upd),
+    );
 
     let Some(tx) = oi.v3_send_tx else {
         tracing::debug!("[v3 LSUpd:Send] no v3 send channel on OspfInterface");
@@ -1081,7 +1086,12 @@ pub fn ospfv3_ls_ack_send(
     );
     let ls_ack = Ospfv3LsAck { lsa_headers };
 
-    let mut packet = Ospfv3Packet::new(oi.router_id, &area, 0, Ospfv3Payload::LsAck(ls_ack));
+    let mut packet = Ospfv3Packet::new(
+        oi.router_id,
+        &area,
+        oi.v3_instance_id,
+        Ospfv3Payload::LsAck(ls_ack),
+    );
 
     let Some(tx) = oi.v3_send_tx else {
         tracing::debug!("[v3 LSAck:Send] no v3 send channel on OspfInterface");

--- a/zebra-rs/src/ospf/show_v3.rs
+++ b/zebra-rs/src/ospf/show_v3.rs
@@ -529,6 +529,8 @@ struct Ospfv3InterfaceJson {
     cost: u32,
     hello_interval: u16,
     dead_interval: u32,
+    /// RFC 5340 §A.3.1 Instance ID (`instance-id`, default 0).
+    instance_id: u8,
     neighbor_count: usize,
 }
 
@@ -558,6 +560,7 @@ fn show_ospfv3_interface(
             cost: link.output_cost,
             hello_interval: link.hello_interval(),
             dead_interval: link.dead_interval(),
+            instance_id: link.v3_instance_id(),
             neighbor_count: link.nbrs.len(),
         })
         .collect();
@@ -570,8 +573,8 @@ fn show_ospfv3_interface(
         )?;
         writeln!(
             text,
-            "  Interface ID: {}  Priority: {}  Cost: {}  Hello {}s  Dead {}s",
-            e.interface_id, e.priority, e.cost, e.hello_interval, e.dead_interval
+            "  Interface ID: {}  Instance ID: {}  Priority: {}  Cost: {}  Hello {}s  Dead {}s",
+            e.interface_id, e.instance_id, e.priority, e.cost, e.hello_interval, e.dead_interval
         )?;
         writeln!(text, "  DR: {}  BDR: {}", e.d_router, e.bd_router)?;
     }

--- a/zebra-rs/yang/config.yang
+++ b/zebra-rs/yang/config.yang
@@ -1755,6 +1755,15 @@ module config {
             leaf retransmit-interval {
               type uint16;
             }
+            leaf instance-id {
+              ext:help "OSPFv3 Instance ID carried in packet headers (RFC 5340)";
+              // RFC 5340 §A.3.1: separates multiple OSPFv3 instances
+              // sharing one link. Both ends must match — a receiver
+              // drops packets whose Instance ID differs from the
+              // interface's (§8.2). Default 0.
+              type uint8;
+              default 0;
+            }
             leaf mtu-ignore {
               type boolean;
             }


### PR DESCRIPTION
## Summary

The OSPFv3 packet header's 8-bit **Instance ID** (RFC 5340 §A.3.1) was hardcoded to 0 on send and ignored on receive — limiting a link to one instance. This makes it configurable and enforced, closing the last v3-specific FRR gap:

- **Config**: `instance-id` (0..255, default 0) on the v3 `area/interface` entry.
- **TX**: every v3 packet build site (Hello, DBD + resend, LSReq, LSU flood/retransmit/link-scope, LSAck) stamps the link's Instance ID; the `OspfInterface` borrow struct carries the snapshot for the packet_v3 send paths.
- **RX (§8.2)**: `process_recv` drops packets whose Instance ID differs from the receiving interface's — before any further processing (auth included), since a mismatch means the packet belongs to a different instance sharing the link.
- `show ospfv3 interface` displays the Instance ID.

## Test plan
- New **`ospfv3_instance_id` BDD**: matched non-zero IDs (5/5) form a normal adjacency with routes + ping; **mismatched IDs (5/7) never form a neighbor in either direction** (the §8.2 drop). Both scenarios pass locally on the first run.
- `ospfv3_area_range` regression (default ID 0 path) passes.
- Full `cargo test`: 1518; yang-load; fmt, workspace clippy, mdbook clean.

## Docs
`instance-id` documented on the v3 Per-Interface page; the OSPFv3 FRR-gaps list is now down to **NBMA/P2MP only**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)