### PR TITLE
feat(ospfv3): stub-router advertisement via R/V6-bit clear (RFC 5340)

### DIFF
--- a/bdd/tests/configs/ospfv3_stub_router/r1.yaml
+++ b/bdd/tests/configs/ospfv3_stub_router/r1.yaml
@@ -1,0 +1,25 @@
+interface:
+- if-name: lo
+  ipv6:
+    address: 2001:db8::1/128
+- if-name: ethb
+  ipv6:
+    address: 2001:db8:12::1/64
+- if-name: ethd
+  ipv6:
+    address: 2001:db8:14::1/64
+router:
+  ospfv3:
+    router-id: 10.0.0.1
+    area:
+    - area-id: 0.0.0.0
+      interface:
+      - if-name: lo
+        enable: true
+      - if-name: ethb
+        enable: true
+        network-type: point-to-point
+      - if-name: ethd
+        enable: true
+        network-type: point-to-point
+        cost: 100

--- a/bdd/tests/configs/ospfv3_stub_router/r2.yaml
+++ b/bdd/tests/configs/ospfv3_stub_router/r2.yaml
@@ -1,0 +1,31 @@
+# r2 is the cheap transit path — and the stub router under test:
+# with max-metric active its Router-LSAs carry R=0/V6=0, so
+# neighbors exclude it from transit (RFC 5340 §4.8.1) and r1->r3
+# traffic detours via r4.
+interface:
+- if-name: lo
+  ipv6:
+    address: 2001:db8::2/128
+- if-name: etha
+  ipv6:
+    address: 2001:db8:12::2/64
+- if-name: ethc
+  ipv6:
+    address: 2001:db8:23::1/64
+router:
+  ospfv3:
+    router-id: 10.0.0.2
+    max-metric:
+      router-lsa:
+        administrative: true
+    area:
+    - area-id: 0.0.0.0
+      interface:
+      - if-name: lo
+        enable: true
+      - if-name: etha
+        enable: true
+        network-type: point-to-point
+      - if-name: ethc
+        enable: true
+        network-type: point-to-point

--- a/bdd/tests/configs/ospfv3_stub_router/r2s.yaml
+++ b/bdd/tests/configs/ospfv3_stub_router/r2s.yaml
@@ -1,0 +1,28 @@
+# on-startup variant: stub router for the first 60 seconds only.
+interface:
+- if-name: lo
+  ipv6:
+    address: 2001:db8::2/128
+- if-name: etha
+  ipv6:
+    address: 2001:db8:12::2/64
+- if-name: ethc
+  ipv6:
+    address: 2001:db8:23::1/64
+router:
+  ospfv3:
+    router-id: 10.0.0.2
+    max-metric:
+      router-lsa:
+        on-startup: 60
+    area:
+    - area-id: 0.0.0.0
+      interface:
+      - if-name: lo
+        enable: true
+      - if-name: etha
+        enable: true
+        network-type: point-to-point
+      - if-name: ethc
+        enable: true
+        network-type: point-to-point

--- a/bdd/tests/configs/ospfv3_stub_router/r3.yaml
+++ b/bdd/tests/configs/ospfv3_stub_router/r3.yaml
@@ -1,0 +1,25 @@
+interface:
+- if-name: lo
+  ipv6:
+    address: 2001:db8::3/128
+- if-name: ethb
+  ipv6:
+    address: 2001:db8:23::2/64
+- if-name: ethd
+  ipv6:
+    address: 2001:db8:34::2/64
+router:
+  ospfv3:
+    router-id: 10.0.0.3
+    area:
+    - area-id: 0.0.0.0
+      interface:
+      - if-name: lo
+        enable: true
+      - if-name: ethb
+        enable: true
+        network-type: point-to-point
+      - if-name: ethd
+        enable: true
+        network-type: point-to-point
+        cost: 100

--- a/bdd/tests/configs/ospfv3_stub_router/r4.yaml
+++ b/bdd/tests/configs/ospfv3_stub_router/r4.yaml
@@ -1,0 +1,27 @@
+# r4 is the expensive alternate path (cost 100+100).
+interface:
+- if-name: lo
+  ipv6:
+    address: 2001:db8::4/128
+- if-name: etha
+  ipv6:
+    address: 2001:db8:14::2/64
+- if-name: ethc
+  ipv6:
+    address: 2001:db8:34::1/64
+router:
+  ospfv3:
+    router-id: 10.0.0.4
+    area:
+    - area-id: 0.0.0.0
+      interface:
+      - if-name: lo
+        enable: true
+      - if-name: etha
+        enable: true
+        network-type: point-to-point
+        cost: 100
+      - if-name: ethc
+        enable: true
+        network-type: point-to-point
+        cost: 100

--- a/bdd/tests/features/ospfv3_stub_router.feature
+++ b/bdd/tests/features/ospfv3_stub_router.feature
@@ -1,0 +1,100 @@
+@serial
+@ospfv3_stub_router
+Feature: OSPFv3 stub-router advertisement (RFC 5340 R-bit clear)
+  As a network operator
+  I want `max-metric router-lsa` on OSPFv3 to clear the R and V6
+  option bits in my Router-LSAs (ospf6d's `stub-router`) so
+  neighbors exclude me from transit paths (RFC 5340 §4.8.1) while my
+  own prefixes stay reachable — the v3 counterpart of v2's
+  RFC 6987 MaxLinkMetric.
+
+  Test Topology (square, one area — v6 mirror of ospfv2_stub_router):
+  ```
+    r1 ---10--- r2 ---10--- r3   (via r2: cost 20 — normally wins)
+     \---100--- r4 ---100---/    (via r4: cost 200 — the detour)
+    r3-lo 2001:db8::3/128; the stub router under test is r2.
+  ```
+
+  Scenario: Administrative R-bit clear pushes transit traffic onto the detour
+    Given a clean test environment
+    When I create namespace "r1"
+    And I create namespace "r2"
+    And I create namespace "r3"
+    And I create namespace "r4"
+    And I connect namespace "r1" interface "ethb" to namespace "r2" interface "etha"
+    And I connect namespace "r2" interface "ethc" to namespace "r3" interface "ethb"
+    And I connect namespace "r1" interface "ethd" to namespace "r4" interface "etha"
+    And I connect namespace "r4" interface "ethc" to namespace "r3" interface "ethd"
+    And I start zebra-rs in namespace "r1"
+    And I start zebra-rs in namespace "r2"
+    And I start zebra-rs in namespace "r3"
+    And I start zebra-rs in namespace "r4"
+    And I apply config "r1.yaml" to namespace "r1"
+    And I apply config "r2.yaml" to namespace "r2"
+    And I apply config "r3.yaml" to namespace "r3"
+    And I apply config "r4.yaml" to namespace "r4"
+    And I wait 30 seconds
+
+    Then show command "show ospfv3 neighbor" in namespace "r1" should contain "Full"
+    And show command "show ospfv3" in namespace "r2" should contain "Stub router: administrative"
+    # r1 detours around the stub router: r3's loopback rides the
+    # 200-cost r4 path, not the 20-cost r2 path.
+    And show command "show ospfv3 route" in namespace "r1" should eventually contain "2001:db8::3/128 metric 200 via"
+    # The stub router's own loopback stays reachable through it at
+    # normal cost — its prefixes anchor at the (reachable) vertex.
+    And show command "show ospfv3 route" in namespace "r1" should contain "2001:db8::2/128 metric 10 via"
+    And ping from "r1" to "2001:db8::2" should succeed
+    And ping from "r1" to "2001:db8::3" should succeed
+
+    # Teardown.
+    When I stop zebra-rs in namespace "r1"
+    And I stop zebra-rs in namespace "r2"
+    And I stop zebra-rs in namespace "r3"
+    And I stop zebra-rs in namespace "r4"
+    And I delete namespace "r1"
+    And I delete namespace "r2"
+    And I delete namespace "r3"
+    And I delete namespace "r4"
+    Then the test environment should be clean
+
+  Scenario: on-startup R-bit clear expires and the cheap path returns
+    Given a clean test environment
+    When I create namespace "r1"
+    And I create namespace "r2"
+    And I create namespace "r3"
+    And I create namespace "r4"
+    And I connect namespace "r1" interface "ethb" to namespace "r2" interface "etha"
+    And I connect namespace "r2" interface "ethc" to namespace "r3" interface "ethb"
+    And I connect namespace "r1" interface "ethd" to namespace "r4" interface "etha"
+    And I connect namespace "r4" interface "ethc" to namespace "r3" interface "ethd"
+    And I start zebra-rs in namespace "r1"
+    And I start zebra-rs in namespace "r2"
+    And I start zebra-rs in namespace "r3"
+    And I start zebra-rs in namespace "r4"
+    And I apply config "r1.yaml" to namespace "r1"
+    And I apply config "r2s.yaml" to namespace "r2"
+    And I apply config "r3.yaml" to namespace "r3"
+    And I apply config "r4.yaml" to namespace "r4"
+    And I wait 20 seconds
+
+    # Inside the 60s startup window: detour via r4.
+    Then show command "show ospfv3" in namespace "r2" should contain "Stub router: on-startup"
+    And show command "show ospfv3 route" in namespace "r1" should eventually contain "2001:db8::3/128 metric 200 via"
+
+    # After the window expires, normal options resume and the cheap
+    # path returns.
+    When I wait 60 seconds
+    Then show command "show ospfv3" in namespace "r2" should not contain "Stub router"
+    And show command "show ospfv3 route" in namespace "r1" should eventually contain "2001:db8::3/128 metric 20 via"
+    And ping from "r1" to "2001:db8::3" should succeed
+
+    # Teardown.
+    When I stop zebra-rs in namespace "r1"
+    And I stop zebra-rs in namespace "r2"
+    And I stop zebra-rs in namespace "r3"
+    And I stop zebra-rs in namespace "r4"
+    And I delete namespace "r1"
+    And I delete namespace "r2"
+    And I delete namespace "r3"
+    And I delete namespace "r4"
+    Then the test environment should be clean

--- a/book/src/ch-08-08-ospf-timers.md
+++ b/book/src/ch-08-08-ospf-timers.md
@@ -159,9 +159,15 @@ applies, the classic use being a reboot grace period so BGP can
 converge before the router draws transit traffic; when the window
 expires the Router-LSAs re-originate with real metrics
 automatically. `show ospf` reports the active mode (`Stub router:
-administrative` / `on-startup (Ns remaining)`). OSPFv2 only —
-FRR's `ospf6d` implements the equivalent via the RFC 5340 R-bit
-instead, which zebra-rs does not yet expose. Validated by
-`ospfv2_stub_router.feature` (traffic detours around the stub
+administrative` / `on-startup (Ns remaining)`).
+
+OSPFv3 exposes the identical `max-metric { router-lsa { ... } }`
+block under `router ospfv3`, realized the RFC 5340 way (as in
+FRR's `ospf6d stub-router`): while active, the router's own
+Router-LSAs carry the **R and V6 option bits cleared**, and
+receivers exclude such a vertex from transit paths (§4.8.1) while
+its own prefixes stay reachable. `show ospfv3` reports the mode.
+Validated by `ospfv2_stub_router.feature` and
+`ospfv3_stub_router.feature` (traffic detours around the stub
 router onto a higher-cost path and returns when the window
 expires).

--- a/book/src/ch-08-12-ospf-frr-gaps.md
+++ b/book/src/ch-08-12-ospf-frr-gaps.md
@@ -69,10 +69,11 @@ per feature — see each feature's page):
   authentication (simple / MD5 / key-chain). OSPFv2 only (`ospf6d`
   has no virtual links either). See
   [Multi-Area Routing and the ABR](ch-08-14-ospf-multi-area-abr.md#virtual-links).
-- **Stub-router advertisement** (`max-metric router-lsa`, RFC 6987)
-  — administrative and `on-startup` modes advertise transit links at
-  MaxLinkMetric while stub links keep their cost. OSPFv2 only
-  (`ospf6d` uses the R-bit mechanism instead). See
+- **Stub-router advertisement** (`max-metric router-lsa`) —
+  administrative and `on-startup` modes; OSPFv2 advertises transit
+  links at MaxLinkMetric (RFC 6987) while OSPFv3 clears the R/V6
+  option bits (RFC 5340 §4.8.1, `ospf6d stub-router` parity), with
+  matching receive-side transit exclusion in the v3 SPF. See
   [Timer Configuration](ch-08-08-ospf-timers.md#stub-router-max-metric-router-lsa).
 - **Redistribution `route-map` filtering** — `redistribute <source>
   route-map <name>` binds a policy list (shared with BGP) as the

--- a/book/src/ch-15-15-ospfv3-frr-gaps.md
+++ b/book/src/ch-15-15-ospfv3-frr-gaps.md
@@ -12,6 +12,11 @@ The per-interface Instance ID (RFC 5340 §A.3.1) is configurable —
 `instance-id` on the interface entry, enforced on receive — see
 [Per-Interface Settings](ch-15-06-ospfv3-per-interface.md).
 
+Stub-router advertisement (`max-metric router-lsa`, `ospf6d`'s
+`stub-router`) is implemented via the RFC 5340 R/V6 option bits,
+including receive-side transit exclusion — see
+[Timer Configuration](ch-08-08-ospf-timers.md#stub-router-max-metric-router-lsa).
+
 Redistribution `route-map` filtering is implemented for OSPFv3
 identically to v2 (policy lists shared with BGP, live
 re-application) — see

--- a/zebra-rs/src/ospf/config_v3.rs
+++ b/zebra-rs/src/ospf/config_v3.rs
@@ -89,6 +89,18 @@ impl Ospf<Ospfv3> {
             ),
             ("/spf-interval/maximum-wait", config_ospfv3_spf_maximum_wait),
             ("/min-ls-interval", config_ospfv3_min_ls_interval),
+            (
+                "/max-metric/router-lsa",
+                config_ospfv3_max_metric_router_lsa,
+            ),
+            (
+                "/max-metric/router-lsa/administrative",
+                config_ospfv3_max_metric_administrative,
+            ),
+            (
+                "/max-metric/router-lsa/on-startup",
+                config_ospfv3_max_metric_on_startup,
+            ),
             ("/min-ls-arrival", config_ospfv3_min_ls_arrival),
             (
                 "/default-information/originate",
@@ -842,6 +854,50 @@ fn config_ospfv3_spf_maximum_wait(
 ) -> Option<()> {
     let default = super::inst::SpfIntervalConfig::default().maximum_wait_ms;
     ospf.spf_interval.maximum_wait_ms = if op.is_set() { args.u32()? } else { default };
+    Some(())
+}
+
+/// `/router/ospfv3/max-metric/router-lsa` — RFC 5340 stub-router
+/// presence container (v6 sibling of the v2 handler; realized by
+/// clearing the R/V6 option bits instead of MaxLinkMetric).
+fn config_ospfv3_max_metric_router_lsa(
+    ospf: &mut Ospf<Ospfv3>,
+    _args: Args,
+    op: ConfigOp,
+) -> Option<()> {
+    if !op.is_set() {
+        ospf.stub_router_admin = false;
+        ospf.stub_router_startup_clear_v3();
+    }
+    Some(())
+}
+
+/// `/router/ospfv3/max-metric/router-lsa/administrative`.
+fn config_ospfv3_max_metric_administrative(
+    ospf: &mut Ospf<Ospfv3>,
+    mut args: Args,
+    op: ConfigOp,
+) -> Option<()> {
+    let value = if op.is_set() { args.boolean()? } else { false };
+    if ospf.stub_router_admin != value {
+        ospf.stub_router_admin = value;
+        ospf.router_lsa_originate();
+    }
+    Some(())
+}
+
+/// `/router/ospfv3/max-metric/router-lsa/on-startup`.
+fn config_ospfv3_max_metric_on_startup(
+    ospf: &mut Ospf<Ospfv3>,
+    mut args: Args,
+    op: ConfigOp,
+) -> Option<()> {
+    if op.is_set() {
+        let secs = args.u32()?;
+        ospf.stub_router_startup_arm_v3(secs);
+    } else {
+        ospf.stub_router_startup_clear_v3();
+    }
     Some(())
 }
 

--- a/zebra-rs/src/ospf/inst.rs
+++ b/zebra-rs/src/ospf/inst.rs
@@ -1349,6 +1349,15 @@ impl<V: OspfVersion> Ospf<V> {
             .and_then(|e| e.pending_min_seq.take())
     }
 
+    /// `true` while this router should advertise itself as a stub
+    /// router — administratively (`max-metric router-lsa
+    /// administrative`, indefinite) or during the `on-startup` grace
+    /// window. v2 realizes it as RFC 6987 MaxLinkMetric on transit
+    /// links; v3 clears the RFC 5340 R/V6 option bits.
+    pub fn stub_router_active(&self) -> bool {
+        self.stub_router_admin || self.stub_router_startup_active
+    }
+
     /// A `LsaGenFire` deferral window elapsed: clear the (already-fired)
     /// timer, stamp the new origination time, and return the folded
     /// seq floor. The caller re-runs the matching `*_now` originator.
@@ -1957,14 +1966,6 @@ impl Ospf<Ospfv2> {
 
         router_lsa.num_links = router_lsa.links.len() as u16;
         router_lsa
-    }
-
-    /// RFC 6987: `true` while this router should advertise its
-    /// transit links at MaxLinkMetric — either administratively
-    /// (`max-metric router-lsa administrative`, indefinite) or during
-    /// the `on-startup` grace window.
-    pub fn stub_router_active(&self) -> bool {
-        self.stub_router_admin || self.stub_router_startup_active
     }
 
     /// Arm (or re-arm) the RFC 6987 `on-startup` stub-router window:
@@ -7284,7 +7285,23 @@ impl Ospf<Ospfv3> {
         if self.is_abr() {
             router_flags |= OSPFV3_ROUTER_LSA_FLAG_B;
         }
-        let body = Ospfv3RouterLsa::new(router_flags, Ospfv3Options::default(), links);
+        // RFC 5340 §A.2 options: an active router advertises V6 + R
+        // (+E outside stub/NSSA). The v3 stub router (`max-metric
+        // router-lsa`, ospf6d's `stub-router`) clears R and V6, so
+        // other routers exclude this vertex from transit paths
+        // (§4.8.1) while its own prefixes stay reachable — the v3
+        // counterpart of v2's MaxLinkMetric mechanism.
+        let stub_router = self.stub_router_active();
+        let area_e_bit = self
+            .areas
+            .get(area_id)
+            .map(|a| a.area_type.e_bit())
+            .unwrap_or(true);
+        let mut options = Ospfv3Options::default();
+        options.set_v6(!stub_router);
+        options.set_r(!stub_router);
+        options.set_e(area_e_bit);
+        let body = Ospfv3RouterLsa::new(router_flags, options, links);
         let mut lsa = Ospfv3Lsa {
             h: Ospfv3LsaHeader {
                 ls_age: 0,
@@ -7741,6 +7758,30 @@ impl Ospf<Ospfv3> {
                 }
             }
         }
+    }
+
+    /// v3 sibling of `stub_router_startup_arm`: hold the RFC 5340
+    /// R/V6-clear stub-router state for `secs` after config apply,
+    /// then `StubRouterExpire` resumes normal options.
+    pub fn stub_router_startup_arm_v3(&mut self, secs: u32) {
+        let tx = self.tx.clone();
+        self.stub_router_startup_active = true;
+        self.stub_router_startup_timer =
+            Some(Timer::new(secs as u64, TimerType::Once, move || {
+                let tx = tx.clone();
+                async move {
+                    let _ = tx.send(Message::StubRouterExpire);
+                }
+            }));
+        tracing::info!("[StubRouter v3] on-startup window armed for {}s", secs);
+        self.router_lsa_originate();
+    }
+
+    /// v3 sibling of `stub_router_startup_clear`.
+    pub fn stub_router_startup_clear_v3(&mut self) {
+        self.stub_router_startup_active = false;
+        self.stub_router_startup_timer = None;
+        self.router_lsa_originate();
     }
 
     /// RFC 3101 §2.3 forwarding-address selection, v6: the first
@@ -9809,6 +9850,14 @@ impl Ospf<Ospfv3> {
                     LsaGenKey::Router => self.router_lsa_originate_now(),
                     LsaGenKey::Network(ifindex) => self.network_lsa_originate_now(ifindex),
                 }
+            }
+            Message::StubRouterExpire => {
+                // RFC 5340 stub-router on-startup window over —
+                // re-originate Router-LSAs with R/V6 set again.
+                self.stub_router_startup_active = false;
+                self.stub_router_startup_timer = None;
+                tracing::info!("[StubRouter v3] on-startup window expired");
+                self.router_lsa_originate();
             }
             other => {
                 tracing::debug!(
@@ -13292,6 +13341,18 @@ fn graph_v3(top: &mut Ospf<Ospfv3>, area_id: Ipv4Addr) -> (spf::Graph, Option<us
         let Ospfv3LsBody::Router(ref router_body) = lsa_data.body else {
             continue;
         };
+        // RFC 5340 §4.8.1: a remote Router-LSA with the R-bit (or
+        // V6-bit) clear is a stub router — it must not be used for
+        // transit, so none of its outgoing edges enter the graph.
+        // Edges INTO it still wire from its neighbors' LSAs (their
+        // back-link checks read this LSA's link list directly), so
+        // the vertex stays reachable and its Intra-Area-Prefix
+        // routes resolve. The root's own edges always wire (the
+        // "V != root" rule) so a stub router still computes its own
+        // full SPF.
+        if !originated && (!router_body.options.r() || !router_body.options.v6()) {
+            continue;
+        }
         for link in &router_body.links {
             use ospf_packet::Ospfv3RouterLinkType;
             match link.link_type {

--- a/zebra-rs/src/ospf/show_v3.rs
+++ b/zebra-rs/src/ospf/show_v3.rs
@@ -497,6 +497,20 @@ fn show_ospfv3_summary(
     )?;
     writeln!(text, "  MinLSInterval: {} ms", summary.min_ls_interval_ms,)?;
     writeln!(text, "  MinLSArrival: {} ms", summary.min_ls_arrival_ms,)?;
+    if top.stub_router_admin {
+        writeln!(text, "  Stub router: administrative (R/V6 bits clear)")?;
+    } else if top.stub_router_startup_active {
+        let remaining = top
+            .stub_router_startup_timer
+            .as_ref()
+            .map(|t| t.remaining().as_secs())
+            .unwrap_or(0);
+        writeln!(
+            text,
+            "  Stub router: on-startup ({}s remaining, R/V6 bits clear)",
+            remaining
+        )?;
+    }
     if let Some(tilfa) = &summary.tilfa_compute {
         writeln!(text, "  TI-LFA compute: {}", tilfa)?;
     }

--- a/zebra-rs/yang/config.yang
+++ b/zebra-rs/yang/config.yang
@@ -1601,6 +1601,31 @@ module config {
           units "milliseconds";
           default 5000;
         }
+        container max-metric {
+          ext:help "Advertise self as a stub router (RFC 5340 R-bit clear)";
+          container router-lsa {
+            ext:help "Clear the R/V6 option bits in own Router-LSAs";
+            // v6 sibling of the v2 max-metric block, realized the
+            // RFC 5340 way (ospf6d's `stub-router`): while active,
+            // own Router-LSAs carry R=0/V6=0 so other routers
+            // exclude this vertex from transit paths (§4.8.1) while
+            // its own prefixes stay reachable.
+            presence "RFC 5340 stub-router configuration";
+            leaf administrative {
+              ext:help "Indefinite (administrative) stub router";
+              type boolean;
+              default false;
+            }
+            leaf on-startup {
+              ext:help "Stub-router window after startup, seconds";
+              type uint32 {
+                range "5..86400";
+              }
+              units "seconds";
+            }
+          }
+        }
+
         // MinLSArrival — v6 sibling of the v2 min-ls-arrival leaf.
         leaf min-ls-arrival {
           ext:help "Minimum interval between accepted flooded copies of an LSA (MinLSArrival)";


### PR DESCRIPTION
## Summary

The v3 counterpart of #1753's stub router, realized the RFC 5340 way (`ospf6d stub-router` parity): while active, the router's own Router-LSAs carry the **R and V6 option bits cleared**, and receivers exclude such a vertex from transit paths (§4.8.1) while its own prefixes stay reachable.

- **Origination**: `router_lsa_originate_now` (v3) now builds real options — **V6 + R set on an active router**. Notably, `Ospfv3Options::default()` is all-zero, so zebra-rs v3 Router-LSAs had been advertising R=0/V6=0 since inception — harmless zebra-rs↔zebra-rs (our SPF ignored options) but an interop landmine with implementations honoring §4.8.1. Fixed as part of this PR: E follows the area type, and R/V6 clear only while `stub_router_active()`.
- **Consumption**: `graph_v3` pass 2 skips wiring the *outgoing* edges of a remote Router-LSA whose R or V6 bit is clear. The vertex stays reachable (edges into it wire from its neighbors' LSAs — the back-link checks read LSA bodies, not graph edges), so its Intra-Area-Prefix routes resolve, but nothing transits it. The root's own edges always wire (the "V ≠ root" rule).
- **Config**: the same `max-metric { router-lsa { administrative | on-startup } }` block as v2, under `router ospfv3` (config-surface consistency; the wire realization differs per RFC). `show ospfv3` reports the mode.

**Interop note**: older zebra-rs v3 routers (emitting all-zero options) will be treated as stub routers by upgraded ones until they're upgraded too — the RFC-correct reading of the LSAs they send.

## Test plan
- New **`ospfv3_stub_router` BDD** (v6 mirror of the v2 square topology): administrative scenario detours r1→r3 onto the 200-cost path while **r2's own loopback stays reachable through it at cost 10** (the two-sided §4.8.1 behavior); on-startup scenario resumes the 20-cost path after expiry. Both pass on the first run.
- v3 regressions all green — `ospfv3_area_range`, `ospfv3_nssa`, `ospfv3_instance_id` — all now exercising the R/V6-set origination *and* the consumption gate.
- Full `cargo test`: 1518; yang-load; fmt, workspace clippy, mdbook clean.

## Docs
Timers page stub-router section covers both AFs; v2/v3 FRR-gaps pages updated. The OSPF-vs-FRR gap list is now **NBMA/P2MP and the redistribute `table` source only**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)