### PR TITLE
feat: OSPFv2 redistribute table source (FRR parity)

### DIFF
--- a/bdd/tests/configs/ospfv2_redist_table/r1.yaml
+++ b/bdd/tests/configs/ospfv2_redist_table/r1.yaml
@@ -1,0 +1,18 @@
+interface:
+- if-name: lo
+  ipv4:
+    address: 10.0.0.1/32
+- if-name: ethb
+  ipv4:
+    address: 10.0.12.1/30
+router:
+  ospf:
+    router-id: 10.0.0.1
+    area:
+    - area-id: 0.0.0.0
+      interface:
+      - if-name: lo
+        enable: true
+      - if-name: ethb
+        enable: true
+        network-type: point-to-point

--- a/bdd/tests/configs/ospfv2_redist_table/r2.yaml
+++ b/bdd/tests/configs/ospfv2_redist_table/r2.yaml
@@ -1,0 +1,25 @@
+# r2 redistributes kernel routing table 100 (routes installed
+# externally via `ip route ... table 100`) as Type-5 externals at
+# metric 30.
+interface:
+- if-name: lo
+  ipv4:
+    address: 10.0.0.2/32
+- if-name: etha
+  ipv4:
+    address: 10.0.12.2/30
+router:
+  ospf:
+    router-id: 10.0.0.2
+    redistribute:
+      table:
+      - id: 100
+        metric: 30
+    area:
+    - area-id: 0.0.0.0
+      interface:
+      - if-name: lo
+        enable: true
+      - if-name: etha
+        enable: true
+        network-type: point-to-point

--- a/bdd/tests/features/ospfv2_redist_table.feature
+++ b/bdd/tests/features/ospfv2_redist_table.feature
@@ -1,0 +1,55 @@
+@serial
+@ospfv2_redist_table
+Feature: OSPFv2 redistributes routes from a kernel routing table
+  As a network operator
+  I want `redistribute table <id>` (FRR parity) to import routes the
+  kernel holds in a non-main routing table — installed externally
+  via `ip route ... table N` — as Type-5 AS-External LSAs, tracking
+  the table live: routes added later originate, deleted ones flush.
+
+  Test Topology:
+  ```
+    r1 -- 10.0.12.0/30 -- r2 (redistribute table 100, metric 30)
+    table 100 on r2 (unicast dev-lo routes): 10.55.1.0/24
+    (pre-start, covers the netlink dump path) and 10.55.2.0/24
+    (added live, covers the monitor delta path).
+  ```
+
+  Scenario: Kernel-table routes originate as externals and track live changes
+    Given a clean test environment
+    When I create namespace "r1"
+    And I create namespace "r2"
+    And I connect namespace "r1" interface "ethb" to namespace "r2" interface "etha"
+    # Installed BEFORE the daemon starts: exercised via the startup
+    # netlink route dump. (Unicast device routes — the RIB's netlink
+    # parse accepts only unicast kinds.)
+    And I execute "ip link set lo up" in namespace "r2"
+    And I execute "ip route add 10.55.1.0/24 dev lo table 100" in namespace "r2"
+    And I start zebra-rs in namespace "r1"
+    And I start zebra-rs in namespace "r2"
+    And I apply config "r1.yaml" to namespace "r1"
+    And I apply config "r2.yaml" to namespace "r2"
+    And I wait 25 seconds
+
+    Then show command "show ospf neighbor" in namespace "r1" should contain "Full"
+    # The pre-start table route arrives on r1 as an external at the
+    # configured metric.
+    And show command "show ospf route" in namespace "r1" should eventually contain "10.55.1.0/24"
+    And show command "show ospf route" in namespace "r1" should contain "[30]"
+
+    # A route added to the table while everything runs must
+    # originate live (netlink monitor -> RIB table store -> OSPF).
+    When I execute "ip route add 10.55.2.0/24 dev lo table 100" in namespace "r2"
+    Then show command "show ospf route" in namespace "r1" should eventually contain "10.55.2.0/24"
+
+    # And a deleted one must flush its Type-5 live.
+    When I execute "ip route del 10.55.1.0/24 dev lo table 100" in namespace "r2"
+    Then show command "show ospf route" in namespace "r1" should eventually not contain "10.55.1.0/24"
+    And show command "show ospf route" in namespace "r1" should contain "10.55.2.0/24"
+
+    # Teardown.
+    When I stop zebra-rs in namespace "r1"
+    And I stop zebra-rs in namespace "r2"
+    And I delete namespace "r1"
+    And I delete namespace "r2"
+    Then the test environment should be clean

--- a/book/src/ch-08-12-ospf-frr-gaps.md
+++ b/book/src/ch-08-12-ospf-frr-gaps.md
@@ -5,9 +5,6 @@ OSPFv2 features not yet implemented in zebra-rs:
 - NBMA and point-to-multipoint network types — the per-interface
   `network-type` knob accepts `broadcast` and `point-to-point`
   only.
-- The redistribution `table` source (the zebra-rs sources are
-  connected, static, kernel, IS-IS, and BGP; `route-map` filtering
-  on those sources is implemented — see below).
 
 ## Previously listed gaps that are now closed
 
@@ -81,6 +78,13 @@ per feature — see each feature's page):
   route-map semantics; edits to the list or its prefix-sets re-apply
   live. Both OSPFv2 and OSPFv3. See
   [Route Redistribution](ch-08-15-ospf-redistribution.md#route-map-filtering).
+- **Redistribution `table` source** (`redistribute table
+  (1-65535)`) — imports routes from a non-main kernel routing
+  table as Type-5s, tracked live through the RIB's netlink dump +
+  monitor, with the same `metric` / `metric-type` / `route-map`
+  knobs as the other sources. OSPFv2 only, matching FRR (`ospf6d`
+  has no table source). See
+  [Route Redistribution](ch-08-15-ospf-redistribution.md#kernel-routing-tables-redistribute-table).
 - **Forwarding-address origination and resolution** — NSSA ASBRs
   now originate P-bit Type-7s with a non-zero forwarding address
   (RFC 3101 §2.3, an address on an NSSA-connected interface); the

--- a/book/src/ch-08-15-ospf-redistribution.md
+++ b/book/src/ch-08-15-ospf-redistribution.md
@@ -34,6 +34,7 @@ router ospf {
 | `kernel` | presence container | — (absent = off) |
 | `isis` | presence container | — (absent = off) |
 | `bgp` | presence container | — (absent = off) |
+| `table` | list, key `id` (1..65535) | — (empty = off) |
 | `<source>/metric` | uint32, 0..16777214 | 20 |
 | `<source>/metric-type` | `type-1` \| `type-2` | `type-2` |
 | `<source>/route-map` | string (policy name) | — (no filtering) |
@@ -44,6 +45,47 @@ Type-5s. Sources are independent subscriptions to the RIB, so any
 combination can be active at once. The knobs also exist per VRF
 instance, where the subscription is scoped so a VRF's OSPF sees only
 that VRF's routes.
+
+## Kernel routing tables (`redistribute table`)
+
+`redistribute table <id>` — FRR's `redistribute table (1-65535)` —
+imports the routes a specific **non-main kernel routing table**
+holds, regardless of who installed them. This is the classic escape
+hatch for advertising routes maintained outside the routing daemon:
+policy-routing tables, routes injected by an external controller or
+script via `ip route ... table N`, or tables populated by another
+routing stack.
+
+```
+router ospf {
+  redistribute {
+    table 100 {
+      metric 30;
+      metric-type type-2;
+      route-map RM;    # optional, same live-re-apply semantics
+    }
+  }
+}
+```
+
+`table` is a list keyed by table ID, so several tables can be
+redistributed at once, each with its own `metric` / `metric-type` /
+`route-map`. The RIB watches the kernel table through netlink — the
+startup route dump seeds it and the monitor tracks it live — so a
+route added to the table while OSPF runs originates its Type-5
+immediately, and a deleted one flushes it, without any daemon
+restart. Configuring a `table` source makes the router an ASBR
+exactly as the other sources do.
+
+Two scope notes, both matching FRR: the `table` source exists on
+**OSPFv2 only** (`ospf6d` has no `redistribute table`), and the
+**main** table is not a valid target — routes there are covered by
+the ordinary `kernel` / `static` / protocol sources.
+
+Validated by `ospfv2_redist_table.feature`, which installs kernel
+routes into table 100 both before the daemon starts (dump path) and
+while it runs (monitor path), and asserts the externals appear on —
+and, on deletion, disappear from — the neighbor.
 
 ## Route-map filtering
 
@@ -109,11 +151,13 @@ internal cost (RFC 2328 §16.4):
 
 ## Forwarding address
 
-zebra-rs always originates Type-5 LSAs with forwarding address
-0.0.0.0, meaning traffic flows via the ASBR itself. On receipt,
-LSAs carrying a non-zero forwarding address are currently skipped —
-resolving the FA against an intra-area route (RFC 2328 §16.4
-step 3) is not yet implemented.
+Instance-level Type-5s are originated with forwarding address
+0.0.0.0, meaning traffic flows via the ASBR itself. NSSA Type-7s
+originate with a non-zero FA where RFC 3101 §2.3 calls for one, and
+received LSAs carrying a non-zero forwarding address are resolved
+against the intra/inter-area route to the FA (RFC 2328 §16.4
+step 3) — see [Area Types](ch-08-13-ospf-area-types.md) for the
+full forwarding-address story.
 
 ## Default route origination
 
@@ -159,7 +203,9 @@ semantics.
 `router ospfv3` exposes the same five instance-level redistribute
 sources (connected, static, kernel, isis, bgp) with the same
 `metric` / `metric-type` / `route-map` leaves — including the live
-route-map re-application. The bgp source's flagship role is the SRv6
+route-map re-application. The `table` source is the one exception:
+it is OSPFv2-only, matching FRR, where `ospf6d` has no
+`redistribute table` either. The bgp source's flagship role is the SRv6
 L3VPN PE–CE "down" direction, where a PE injects the VPNv6 routes it
 imported into a VRF into the CE-facing OSPFv3 instance. Per-area
 NSSA `redistribute connected` is available for v3 exactly as for

--- a/book/src/ch-15-15-ospfv3-frr-gaps.md
+++ b/book/src/ch-15-15-ospfv3-frr-gaps.md
@@ -21,6 +21,8 @@ Redistribution `route-map` filtering is implemented for OSPFv3
 identically to v2 (policy lists shared with BGP, live
 re-application) — see
 [Route Redistribution](ch-08-15-ospf-redistribution.md#route-map-filtering).
+The `redistribute table` source is OSPFv2-only in zebra-rs, but
+that is parity, not a gap: `ospf6d` has no table source either.
 
 The adaptive SPF throttle (`spf-interval`), the send-side
 MinLSInterval (`min-ls-interval`), and the receive-side MinLSArrival

--- a/zebra-rs/src/ospf/config.rs
+++ b/zebra-rs/src/ospf/config.rs
@@ -186,6 +186,19 @@ impl Ospf {
             "/redistribute/bgp/route-map",
             config_ospf_redist_bgp_route_map,
         );
+        self.ospf_add("/redistribute/table", config_ospf_redist_table);
+        self.ospf_add(
+            "/redistribute/table/metric",
+            config_ospf_redist_table_metric,
+        );
+        self.ospf_add(
+            "/redistribute/table/metric-type",
+            config_ospf_redist_table_metric_type,
+        );
+        self.ospf_add(
+            "/redistribute/table/route-map",
+            config_ospf_redist_table_route_map,
+        );
         // Instance-level `router ospf { bfd { ... } }` defaults.
         self.ospf_add("/bfd/enable", config_ospf_bfd_enable);
         self.ospf_add(
@@ -723,6 +736,77 @@ fn ospf_redist_route_map_set(
     };
     ospf.redist_route_map_bind(rtype, name);
     ospf.as_external_redist_resync(rtype);
+    Some(())
+}
+
+/// `/router/ospf/redistribute/table/<id>` — FRR `redistribute
+/// table (1-65535)`: import routes the kernel holds in routing
+/// table `<id>` as Type-5 AS-External LSAs. Set subscribes the RIB's
+/// table watch (replay + deltas via `RibRx::TableRouteAdd/Del`);
+/// delete unsubscribes, which replays withdrawals so the cache and
+/// LSAs flush.
+fn config_ospf_redist_table(ospf: &mut Ospf, mut args: Args, op: ConfigOp) -> Option<()> {
+    let table_id = args.u32()?;
+    if op.is_set() {
+        ospf.redist_table.entry(table_id).or_default();
+        let _ = ospf.ctx.rib.send(crate::rib::Message::RedistTableAdd {
+            proto: ospf.proto_label.clone(),
+            table_id,
+        });
+    } else {
+        ospf.redist_table.remove(&table_id);
+        let _ = ospf.ctx.rib.send(crate::rib::Message::RedistTableDel {
+            proto: ospf.proto_label.clone(),
+            table_id,
+        });
+        // The Del replay will clear the cache entries; drop them
+        // eagerly too so the resync below flushes immediately.
+        ospf.redist_table_v4.retain(|(t, _), _| *t != table_id);
+    }
+    ospf.as_external_table_resync(table_id);
+    Some(())
+}
+
+/// `/router/ospf/redistribute/table/<id>/metric`.
+fn config_ospf_redist_table_metric(ospf: &mut Ospf, mut args: Args, op: ConfigOp) -> Option<()> {
+    let table_id = args.u32()?;
+    let metric = if op.is_set() {
+        args.u32()?
+    } else {
+        crate::ospf::area::RedistEntry::DEFAULT_METRIC
+    };
+    ospf.redist_table.entry(table_id).or_default().metric = metric;
+    ospf.as_external_table_resync(table_id);
+    Some(())
+}
+
+/// `/router/ospf/redistribute/table/<id>/metric-type`.
+fn config_ospf_redist_table_metric_type(
+    ospf: &mut Ospf,
+    mut args: Args,
+    op: ConfigOp,
+) -> Option<()> {
+    let table_id = args.u32()?;
+    let mtype = if op.is_set() {
+        ExternalMetricType::from_yang(&args.string()?)?
+    } else {
+        ExternalMetricType::default()
+    };
+    ospf.redist_table.entry(table_id).or_default().metric_type = mtype;
+    ospf.as_external_table_resync(table_id);
+    Some(())
+}
+
+/// `/router/ospf/redistribute/table/<id>/route-map`.
+fn config_ospf_redist_table_route_map(ospf: &mut Ospf, mut args: Args, op: ConfigOp) -> Option<()> {
+    let table_id = args.u32()?;
+    let name = if op.is_set() {
+        Some(args.string()?)
+    } else {
+        None
+    };
+    ospf.redist_table_route_map_bind(table_id, name);
+    ospf.as_external_table_resync(table_id);
     Some(())
 }
 

--- a/zebra-rs/src/ospf/inst.rs
+++ b/zebra-rs/src/ospf/inst.rs
@@ -410,6 +410,18 @@ pub struct Ospf<V: OspfVersion = Ospfv2> {
     /// names bound in `redist_route_map` (kept fresh via the
     /// Register/watch machinery, like BGP's per-peer policies).
     pub policy_lists: BTreeMap<String, crate::policy::PolicyList>,
+    /// `redistribute table <id>` config (FRR parity, v2-only):
+    /// kernel routing-table id -> metric/metric-type. Routes arrive
+    /// via `RibRx::TableRouteAdd/Del` from the RIB's table watch.
+    pub redist_table: BTreeMap<u32, crate::ospf::area::RedistEntry>,
+    /// Per-table `route-map` bindings, mirroring `redist_route_map`.
+    pub redist_table_route_map: BTreeMap<u32, String>,
+    /// Cached kernel-table routes, keyed by `(table_id, prefix)` —
+    /// the table sibling of `redist_v4`.
+    pub redist_table_v4: BTreeMap<(u32, Ipv4Net), crate::rib::RouteEntryV4>,
+    /// Per-table originated Type-5 prefixes — the table sibling of
+    /// `redist_originated`.
+    pub redist_table_originated: BTreeMap<u32, BTreeSet<Ipv4Net>>,
     /// Per-source prefixes of Type-5 LSAs we self-originated from the
     /// instance-level `redistribute` knobs (v2 / IPv4). Diffed by
     /// `as_external_redist_resync`; flushed when the knob is removed.
@@ -1573,6 +1585,10 @@ impl Ospf<Ospfv2> {
             redist: BTreeMap::new(),
             redist_route_map: BTreeMap::new(),
             policy_lists: BTreeMap::new(),
+            redist_table: BTreeMap::new(),
+            redist_table_route_map: BTreeMap::new(),
+            redist_table_v4: BTreeMap::new(),
+            redist_table_originated: BTreeMap::new(),
             redist_originated: BTreeMap::new(),
             redist_originated_v6: BTreeMap::new(),
             default_originate: None,
@@ -3542,7 +3558,7 @@ impl Ospf<Ospfv2> {
     /// (RFC 2328 §3.3 ASBR definition). Today this requires the
     /// instance-level `redistribute connected` knob to be set.
     pub fn is_asbr(&self) -> bool {
-        !self.redist.is_empty() || self.default_originate.is_some()
+        !self.redist.is_empty() || !self.redist_table.is_empty() || self.default_originate.is_some()
     }
 
     /// Reconcile the self-originated Type-5 default (0.0.0.0/0)
@@ -3889,6 +3905,135 @@ impl Ospf<Ospfv2> {
         }
         self.as_external_redist_resync_all();
         self.default_originate_resync();
+    }
+
+    /// `RibRx::TableRouteAdd` handler (`redistribute table <id>`).
+    fn table_route_add(&mut self, table_id: u32, batch: crate::rib::RouteBatch) {
+        if let crate::rib::RouteBatch::V4(entries) = batch {
+            for e in entries {
+                self.redist_table_v4.insert((table_id, e.prefix), e);
+            }
+        }
+        self.as_external_table_resync(table_id);
+    }
+
+    /// `RibRx::TableRouteDel` handler — mirror of `table_route_add`.
+    fn table_route_del(&mut self, table_id: u32, batch: crate::rib::RouteBatch) {
+        if let crate::rib::RouteBatch::V4(entries) = batch {
+            for e in entries {
+                self.redist_table_v4.remove(&(table_id, e.prefix));
+            }
+        }
+        self.as_external_table_resync(table_id);
+    }
+
+    /// Reconcile the self-originated Type-5 set for one
+    /// `redistribute table <id>` row — the table sibling of
+    /// `as_external_redist_resync`, sharing its route-map semantics
+    /// (deny drops the prefix so the stale LSA flushes; `set med`
+    /// overrides the metric; unresolved map = deny-all).
+    pub fn as_external_table_resync(&mut self, table_id: u32) {
+        let entry = self.redist_table.get(&table_id).copied();
+        let prev_originated = self
+            .redist_table_originated
+            .get(&table_id)
+            .cloned()
+            .unwrap_or_default();
+
+        let route_map = self.redist_table_route_map.get(&table_id);
+        let desired: BTreeMap<Ipv4Net, u32> = if let Some(e) = entry {
+            self.redist_table_v4
+                .iter()
+                .filter(|((t, _), _)| *t == table_id)
+                .filter_map(|((_, prefix), _)| {
+                    let metric = match route_map {
+                        None => e.metric,
+                        Some(name) => {
+                            let list = self.policy_lists.get(name)?;
+                            redist_policy_eval(list, (*prefix).into(), e.metric)?
+                        }
+                    };
+                    Some((*prefix, metric))
+                })
+                .collect()
+        } else {
+            BTreeMap::new()
+        };
+
+        for prefix in prev_originated
+            .iter()
+            .filter(|p| !desired.contains_key(p))
+            .copied()
+            .collect::<Vec<_>>()
+        {
+            self.as_external_lsa_flush_for_prefix(prefix);
+            if let Some(set) = self.redist_table_originated.get_mut(&table_id) {
+                set.remove(&prefix);
+            }
+        }
+
+        if let Some(redist_entry) = entry {
+            for (prefix, metric) in &desired {
+                self.as_external_lsa_originate_for_prefix(
+                    *prefix,
+                    *metric,
+                    redist_entry.metric_type.is_type_2(),
+                );
+                self.redist_table_originated
+                    .entry(table_id)
+                    .or_default()
+                    .insert(*prefix);
+            }
+        }
+        if self
+            .redist_table_originated
+            .get(&table_id)
+            .is_some_and(|s| s.is_empty())
+        {
+            self.redist_table_originated.remove(&table_id);
+        }
+
+        self.router_lsa_originate();
+    }
+
+    /// Run [`Self::as_external_table_resync`] for every table that is
+    /// configured or still has originated state to clean up.
+    pub fn as_external_table_resync_all(&mut self) {
+        let tables: BTreeSet<u32> = self
+            .redist_table
+            .keys()
+            .copied()
+            .chain(self.redist_table_originated.keys().copied())
+            .collect();
+        for table_id in tables {
+            self.as_external_table_resync(table_id);
+        }
+    }
+
+    /// Bind (or unbind) a `redistribute table <id> route-map` —
+    /// table sibling of `redist_route_map_bind`, with a disjoint
+    /// ident space so table and rtype bindings to the same list name
+    /// hold distinct policy-actor watches.
+    pub fn redist_table_route_map_bind(&mut self, table_id: u32, name: Option<String>) {
+        use crate::policy::{Message as PolicyMsg, PolicyType};
+        let ident = 0x10000 + table_id as usize;
+        if let Some(old) = self.redist_table_route_map.remove(&table_id) {
+            let _ = self.policy_tx.send(PolicyMsg::Unregister {
+                proto: self.proto_label.clone(),
+                name: old,
+                ident,
+                policy_type: PolicyType::PolicyListIn,
+            });
+        }
+        if let Some(name) = name {
+            let _ = self.policy_tx.send(PolicyMsg::Register {
+                proto: self.proto_label.clone(),
+                name: name.clone(),
+                ident,
+                policy_type: PolicyType::PolicyListIn,
+            });
+            self.redist_table_route_map.insert(table_id, name);
+        }
     }
 
     fn process_lsdb(&mut self, ev: LsdbEvent, area_id: Option<Ipv4Addr>, key: OspfLsaKey) {
@@ -6192,6 +6337,16 @@ impl Ospf<Ospfv2> {
             RibRx::RouteAdd { rtype, routes, .. } => {
                 self.route_redist_add(rtype, routes);
             }
+            RibRx::TableRouteAdd {
+                table_id, routes, ..
+            } => {
+                self.table_route_add(table_id, routes);
+            }
+            RibRx::TableRouteDel {
+                table_id, routes, ..
+            } => {
+                self.table_route_del(table_id, routes);
+            }
             RibRx::RouteDel { rtype, routes, .. } => {
                 self.route_redist_del(rtype, routes);
             }
@@ -6286,6 +6441,7 @@ impl Ospf<Ospfv2> {
                     self.policy_lists.remove(&name);
                 }
                 self.as_external_redist_resync_all();
+                self.as_external_table_resync_all();
             }
             crate::policy::PolicyRx::PrefixSet { .. } => {
                 // OSPF doesn't subscribe to bare prefix-sets (the
@@ -6453,6 +6609,10 @@ impl Ospf<Ospfv3> {
             redist: BTreeMap::new(),
             redist_route_map: BTreeMap::new(),
             policy_lists: BTreeMap::new(),
+            redist_table: BTreeMap::new(),
+            redist_table_route_map: BTreeMap::new(),
+            redist_table_v4: BTreeMap::new(),
+            redist_table_originated: BTreeMap::new(),
             redist_originated: BTreeMap::new(),
             redist_originated_v6: BTreeMap::new(),
             default_originate: None,

--- a/zebra-rs/src/rib/api.rs
+++ b/zebra-rs/src/rib/api.rs
@@ -210,6 +210,26 @@ pub enum RibRx {
         bulk: BulkPhase,
     },
 
+    // ---- `redistribute table <id>` route push ---------------------
+    //
+    // Per-kernel-table delivery for `Message::RedistTableAdd`
+    // subscribers: routes the kernel holds in a non-main, non-VRF
+    // routing table (installed externally, e.g. `ip route ... table
+    // N`). Same batch/EoR discipline as RouteAdd/RouteDel; keyed by
+    // `table_id` so a consumer redistributing several tables can
+    // demux. v4-only today (FRR parity: only ospfd has a `table`
+    // source).
+    TableRouteAdd {
+        table_id: u32,
+        routes: RouteBatch,
+        bulk: BulkPhase,
+    },
+    TableRouteDel {
+        table_id: u32,
+        routes: RouteBatch,
+        bulk: BulkPhase,
+    },
+
     // ---- IS-IS Flex-Algorithm route fan-out -----------------------
     //
     // BGP ↔ IS-IS Flex-Algorithm integration: IS-IS publishes per-algo

--- a/zebra-rs/src/rib/inst.rs
+++ b/zebra-rs/src/rib/inst.rs
@@ -492,6 +492,24 @@ pub enum Message {
         proto: String,
         afi: super::RedistAfi,
     },
+    /// Subscribe to `redistribute table <id>`: routes the kernel
+    /// holds in the non-main, non-VRF routing table `table_id`
+    /// (installed externally, e.g. `ip route ... table N`). RIB
+    /// replays the table's current contents as
+    /// `RibRx::TableRouteAdd` batches ending in `BulkPhase::Eor`,
+    /// then streams deltas. v4-only today (FRR parity: only ospfd
+    /// has a `table` redistribute source).
+    RedistTableAdd {
+        proto: String,
+        table_id: u32,
+    },
+    /// Tear down a table subscription. RIB replays the table's
+    /// current contents as `TableRouteDel` (ending in Eor) so the
+    /// consumer can withdraw without duplicating per-table state.
+    RedistTableDel {
+        proto: String,
+        table_id: u32,
+    },
     /// Tear down a default-route watch. No Del replay: the default
     /// prefix may also be covered by an overlapping per-rtype
     /// subscription, so cache cleanup is the consumer's job.
@@ -695,6 +713,15 @@ pub struct Rib {
     /// rtype (self-routes excluded). Updated by RedistDefaultAdd /
     /// RedistDefaultDel; consulted by `redist::notify_v*_delta`.
     pub redist_default_watch: HashMap<String, std::collections::BTreeSet<super::RedistAfi>>,
+    /// `redistribute table <id>` watches: kernel table id -> the
+    /// protocols subscribed to it (`Message::RedistTableAdd`).
+    pub redist_table_watch: BTreeMap<u32, std::collections::BTreeSet<String>>,
+    /// v4 routes the kernel holds in non-main, non-VRF tables,
+    /// stored in the redistribute delivery shape. Populated from the
+    /// netlink dump/monitor (previously these routes were dropped);
+    /// consulted for `RedistTableAdd` replay and kept fresh so
+    /// deltas notify `redist_table_watch` subscribers.
+    pub table_routes_v4: BTreeMap<u32, BTreeMap<Ipv4Net, super::RouteEntryV4>>,
     pub links: BTreeMap<u32, Link>,
     pub bridges: BTreeMap<String, Bridge>,
     pub vxlan: BTreeMap<String, Vxlan>,
@@ -895,6 +922,8 @@ impl Rib {
             inbound_rx,
             redist_filters: HashMap::new(),
             redist_default_watch: HashMap::new(),
+            redist_table_watch: BTreeMap::new(),
+            table_routes_v4: BTreeMap::new(),
             links: BTreeMap::new(),
             bridges: BTreeMap::new(),
             vxlan: BTreeMap::new(),
@@ -3191,6 +3220,131 @@ impl Rib {
             Message::RedistDefaultDel { proto, afi } => {
                 self.redist_default_del(proto, afi);
             }
+            Message::RedistTableAdd { proto, table_id } => {
+                self.redist_table_add(proto, table_id);
+            }
+            Message::RedistTableDel { proto, table_id } => {
+                self.redist_table_del(proto, table_id);
+            }
+        }
+    }
+
+    /// Store or refresh one non-main, non-VRF kernel-table route and
+    /// stream the delta to `redistribute table <id>` subscribers.
+    fn table_route_upsert(&mut self, table_id: u32, prefix: Ipv4Net, entry: &RibEntry) {
+        if !super::redist::redistributable_v4(&prefix) {
+            return;
+        }
+        let e = super::RouteEntryV4 {
+            prefix,
+            nexthop: super::redist::first_v4_nexthop(&entry.nexthop)
+                .unwrap_or(std::net::Ipv4Addr::UNSPECIFIED),
+            subtype: entry.rsubtype.clone(),
+            metric: entry.metric,
+            tag: 0,
+            ifindex: entry.ifindex,
+        };
+        let slot = self
+            .table_routes_v4
+            .entry(table_id)
+            .or_default()
+            .insert(prefix, e.clone());
+        if slot.as_ref() == Some(&e) {
+            return;
+        }
+        if let Some(protos) = self.redist_table_watch.get(&table_id) {
+            for proto in protos {
+                if let Some(sub) = self.client_registry.subscriber_for_proto(proto) {
+                    let _ = sub.rib_rx_tx.send(RibRx::TableRouteAdd {
+                        table_id,
+                        routes: super::RouteBatch::V4(vec![e.clone()]),
+                        bulk: super::BulkPhase::Eor,
+                    });
+                }
+            }
+        }
+    }
+
+    /// Remove one kernel-table route and stream the withdrawal.
+    fn table_route_remove(&mut self, table_id: u32, prefix: Ipv4Net) {
+        let Some(routes) = self.table_routes_v4.get_mut(&table_id) else {
+            return;
+        };
+        let Some(e) = routes.remove(&prefix) else {
+            return;
+        };
+        if routes.is_empty() {
+            self.table_routes_v4.remove(&table_id);
+        }
+        if let Some(protos) = self.redist_table_watch.get(&table_id) {
+            for proto in protos {
+                if let Some(sub) = self.client_registry.subscriber_for_proto(proto) {
+                    let _ = sub.rib_rx_tx.send(RibRx::TableRouteDel {
+                        table_id,
+                        routes: super::RouteBatch::V4(vec![e.clone()]),
+                        bulk: super::BulkPhase::Eor,
+                    });
+                }
+            }
+        }
+    }
+
+    /// `Message::RedistTableAdd`: register the watch and replay the
+    /// table's current contents, ending in Eor.
+    fn redist_table_add(&mut self, proto: String, table_id: u32) {
+        self.redist_table_watch
+            .entry(table_id)
+            .or_default()
+            .insert(proto.clone());
+        let entries: Vec<super::RouteEntryV4> = self
+            .table_routes_v4
+            .get(&table_id)
+            .map(|m| m.values().cloned().collect())
+            .unwrap_or_default();
+        if let Some(sub) = self.client_registry.subscriber_for_proto(&proto) {
+            for chunk in entries.chunks(super::types::REDIST_BATCH_MAX.max(1)) {
+                let _ = sub.rib_rx_tx.send(RibRx::TableRouteAdd {
+                    table_id,
+                    routes: super::RouteBatch::V4(chunk.to_vec()),
+                    bulk: super::BulkPhase::More,
+                });
+            }
+            let _ = sub.rib_rx_tx.send(RibRx::TableRouteAdd {
+                table_id,
+                routes: super::RouteBatch::V4(Vec::new()),
+                bulk: super::BulkPhase::Eor,
+            });
+        }
+    }
+
+    /// `Message::RedistTableDel`: drop the watch and replay the
+    /// table's contents as withdrawals so the consumer can flush
+    /// without duplicating per-table state.
+    fn redist_table_del(&mut self, proto: String, table_id: u32) {
+        if let Some(protos) = self.redist_table_watch.get_mut(&table_id) {
+            protos.remove(&proto);
+            if protos.is_empty() {
+                self.redist_table_watch.remove(&table_id);
+            }
+        }
+        let entries: Vec<super::RouteEntryV4> = self
+            .table_routes_v4
+            .get(&table_id)
+            .map(|m| m.values().cloned().collect())
+            .unwrap_or_default();
+        if let Some(sub) = self.client_registry.subscriber_for_proto(&proto) {
+            for chunk in entries.chunks(super::types::REDIST_BATCH_MAX.max(1)) {
+                let _ = sub.rib_rx_tx.send(RibRx::TableRouteDel {
+                    table_id,
+                    routes: super::RouteBatch::V4(chunk.to_vec()),
+                    bulk: super::BulkPhase::More,
+                });
+            }
+            let _ = sub.rib_rx_tx.send(RibRx::TableRouteDel {
+                table_id,
+                routes: super::RouteBatch::V4(Vec::new()),
+                bulk: super::BulkPhase::Eor,
+            });
         }
     }
 
@@ -3310,6 +3464,11 @@ impl Rib {
                         // are ignored rather than dumped into the default.
                         self.ipv4_route_add_vrf(route.table_id, &prefix, route.entry)
                             .await;
+                    } else {
+                        // A non-main, non-VRF kernel table: keep it in
+                        // the `redistribute table <id>` store and
+                        // notify subscribers.
+                        self.table_route_upsert(route.table_id, prefix, &route.entry);
                     }
                 }
             }
@@ -3321,6 +3480,8 @@ impl Rib {
                     } else if self.vrf_tables.contains_key(&route.table_id) {
                         self.ipv4_route_del_vrf(route.table_id, &prefix, route.entry)
                             .await;
+                    } else {
+                        self.table_route_remove(route.table_id, prefix);
                     }
                 }
             }

--- a/zebra-rs/src/rib/redist.rs
+++ b/zebra-rs/src/rib/redist.rs
@@ -184,7 +184,7 @@ fn pick_entry<'a>(
 /// they're not routable beyond the local host. Mirrors the Router-LSA
 /// builder's 127.x skip, but here it also guards Type-5 / NSSA Type-7
 /// origination and every other redistribute consumer.
-fn redistributable_v4(prefix: &Ipv4Net) -> bool {
+pub(crate) fn redistributable_v4(prefix: &Ipv4Net) -> bool {
     let a = prefix.addr();
     !a.is_loopback() && !a.is_link_local()
 }
@@ -204,7 +204,7 @@ fn redistributable_v6(prefix: &Ipv6Net) -> bool {
 /// `None` for Link-only (connected) or empty / non-v4 Multi/List —
 /// callers skip the route in that case rather than emit a malformed
 /// entry.
-fn first_v4_nexthop(nh: &Nexthop) -> Option<std::net::Ipv4Addr> {
+pub(crate) fn first_v4_nexthop(nh: &Nexthop) -> Option<std::net::Ipv4Addr> {
     match nh {
         Nexthop::Uni(uni) => match uni.addr {
             std::net::IpAddr::V4(a) => Some(a),

--- a/zebra-rs/yang/config.yang
+++ b/zebra-rs/yang/config.yang
@@ -618,6 +618,38 @@ module config {
               type string;
             }
           }
+          list table {
+            ext:help "Redistribute routes from a kernel routing table";
+            // FRR `redistribute table (1-65535)`: import routes the
+            // kernel holds in a non-main routing table (installed
+            // externally, e.g. `ip route ... table N`) as Type-5
+            // AS-External LSAs. Keyed by table id so several tables
+            // can redistribute at once, each with its own metric /
+            // metric-type / route-map.
+            key "id";
+            leaf id {
+              type uint32 {
+                range "1..65535";
+              }
+            }
+            leaf metric {
+              type uint32 {
+                range "0..16777214";
+              }
+              default 20;
+            }
+            leaf metric-type {
+              type enumeration {
+                enum type-1;
+                enum type-2;
+              }
+              default type-2;
+            }
+            leaf route-map {
+              ext:help "Filter/modify redistributed routes via a named policy-list";
+              type string;
+            }
+          }
         }
         // FRR-parity `default-information originate`: advertise a
         // Type-5 default route. Without `always` it is originated


### PR DESCRIPTION
## Summary

Implements FRR's `redistribute table (1-65535)` for OSPFv2: routes the kernel holds in a **non-main routing table** (installed externally via `ip route ... table N`) are imported as Type-5 AS-External LSAs and tracked live — routes added to the table originate, deleted ones flush.

### RIB side
- New `RibRx::TableRouteAdd` / `TableRouteDel` subscriber messages and `Message::RedistTableAdd` / `RedistTableDel` registration messages.
- The RIB now retains v4 routes from watched non-main tables (`table_routes_v4`), fed by both the startup netlink route dump and the netlink monitor, and replays/notifies watchers in `REDIST_BATCH_MAX` chunks with proper `Eor` bulk phases.

### OSPF side
- `redistribute table <id>` YANG list (key 1..65535) with per-table `metric` (default 20), `metric-type` (default type-2), and `route-map` — the route-map re-applies live through the policy cascade, same as the other redistribute sources.
- Per-table route cache and `as_external_table_resync` mirroring the existing per-source resync; configuring a table source makes the router an ASBR (E-bit).
- **OSPFv2 only, matching FRR** — `ospf6d` has no `redistribute table`.

### Book
- Redistribution chapter: new "Kernel routing tables" section; stale forwarding-address paragraph refreshed to match the implemented FA resolution.
- v2 FRR-gaps page: `table` source moves to the closed list — **NBMA/P2MP network types are now the only remaining v2 gap**.
- v3 gaps page: note that table-source absence on v3 is parity, not a gap.

## Test plan
- [x] `ospfv2_redist_table.feature` (new BDD): pre-start route in table 100 (netlink **dump** path) arrives on the neighbor at the configured metric; a route added live (**monitor** path) originates; a deleted one flushes its Type-5. Passed locally.
- [x] `cargo test --workspace --exclude bdd` — all green (1518 zebra-rs unit tests).
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean.
- [x] `cargo fmt` — applied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)