### PR TITLE
docs: declare NBMA/P2MP network types a non-goal

### DIFF
--- a/book/src/ch-08-07-ospf-per-interface.md
+++ b/book/src/ch-08-07-ospf-per-interface.md
@@ -28,7 +28,9 @@ Notes:
   a single adjacency. Changing it on a live interface bounces the
   IFSM (an internal `Disable → Enable` pair) so state machine and
   neighbor list re-initialize under the new type. NBMA and
-  point-to-multipoint are not supported.
+  point-to-multipoint are deliberately not supported: they serve
+  legacy WAN fabrics (Frame Relay, X.25, ATM), which modern
+  Ethernet networks no longer use.
 - **`priority`** is the DR-election priority advertised in Hellos.
   Higher wins; zero forbids the router from becoming DR or BDR on
   that segment. The zebra-rs default of 64 is the IOS-XR baseline; a

--- a/book/src/ch-08-12-ospf-frr-gaps.md
+++ b/book/src/ch-08-12-ospf-frr-gaps.md
@@ -1,10 +1,17 @@
 # Gaps Relative to FRR ospfd
 
-OSPFv2 features not yet implemented in zebra-rs:
+zebra-rs OSPFv2 has reached feature parity with FRR ospfd — there
+are no open gaps.
 
-- NBMA and point-to-multipoint network types — the per-interface
-  `network-type` knob accepts `broadcast` and `point-to-point`
-  only.
+## Deliberately not supported
+
+- **NBMA and point-to-multipoint network types** — the
+  per-interface `network-type` knob accepts `broadcast` and
+  `point-to-point` only. NBMA and P2MP exist for legacy
+  multi-access WAN fabrics (Frame Relay, X.25, ATM); modern
+  networks are Ethernet, which broadcast and point-to-point cover.
+  zebra-rs does not support them by design — this is a non-goal,
+  not a to-do.
 
 ## Previously listed gaps that are now closed
 

--- a/book/src/ch-15-06-ospfv3-per-interface.md
+++ b/book/src/ch-15-06-ospfv3-per-interface.md
@@ -27,7 +27,9 @@ Notes:
 - **`network-type`** mirrors the v2 knob: `point-to-point` skips
   Waiting and DR election; changing it on a live interface bounces
   the IFSM through an internal `Disable → Enable` pair. NBMA and
-  point-to-multipoint are not supported.
+  point-to-multipoint are deliberately not supported: they serve
+  legacy WAN fabrics (Frame Relay, X.25, ATM), which modern
+  Ethernet networks no longer use.
 - **`priority`** is the DR-election priority carried in v3 Hellos
   (and recorded in the Link-LSA). Semantics as v2: higher wins,
   zero forbids DR/BDR.

--- a/book/src/ch-15-15-ospfv3-frr-gaps.md
+++ b/book/src/ch-15-15-ospfv3-frr-gaps.md
@@ -1,8 +1,14 @@
 # Gaps Relative to FRR ospf6d
 
-OSPFv3 features not yet implemented in zebra-rs:
+zebra-rs OSPFv3 has reached feature parity with FRR ospf6d — there
+are no open gaps.
 
-- NBMA and point-to-multipoint network types.
+One item is deliberately not supported: **NBMA and
+point-to-multipoint network types**. They exist for legacy
+multi-access WAN fabrics (Frame Relay, X.25, ATM); modern networks
+are Ethernet, which `broadcast` and `point-to-point` cover, so
+zebra-rs omits them by design (see
+[the v2 gaps page](ch-08-12-ospf-frr-gaps.md#deliberately-not-supported)).
 
 Forwarding-address origination (NSSA Type-7, F-flag) and resolution
 on received externals are implemented for OSPFv3 identically to v2


### PR DESCRIPTION
## Summary

NBMA and point-to-multipoint network types serve legacy multi-access WAN fabrics (Frame Relay, X.25, ATM) that modern Ethernet networks no longer use, so zebra-rs will not implement them.

- Both FRR-gaps pages (`ch-08-12` ospfd, `ch-15-15` ospf6d) now open with "feature parity, no open gaps" and list NBMA/P2MP under **Deliberately not supported** with the rationale.
- Both per-interface `network-type` notes (v2 `ch-08-07`, v3 `ch-15-06`) explain *why* the knob stops at `broadcast` / `point-to-point`.

## Test plan
- [x] `mdbook build` succeeds; docs-only change (no code touched).

🤖 Generated with [Claude Code](https://claude.com/claude-code)