### PR TITLE
feat(bgp): EVPN VPWS — End.DX2 E-Line over SRv6 (RFC 8214)

### DIFF
--- a/crates/bgp-packet/src/attrs/prefix_sid.rs
+++ b/crates/bgp-packet/src/attrs/prefix_sid.rs
@@ -10,14 +10,17 @@ use crate::{AttrType, ParseBe};
 use super::{AttrEmitter, AttrFlags};
 
 /// SRv6 Endpoint Behavior codepoints (IANA "SRv6 Endpoint Behaviors",
-/// RFC 8986). The L3VPN decap behaviors plus the L2 decaps used by
-/// EVPN-over-SRv6: unicast (`End.DT2U`, RFC 9252 §6.1/§6.2 on Type-2) and
-/// multicast/BUM (`End.DT2M`, §6.4 on Type-3).
+/// RFC 8986). The L3VPN decap behaviors plus the L2 behaviors used by
+/// EVPN-over-SRv6: VPWS cross-connect (`End.DX2`/`End.DX2V`, RFC 9252
+/// §6.3 on Type-1), unicast bridging (`End.DT2U`, §6.1/§6.2 on Type-2)
+/// and multicast/BUM (`End.DT2M`, §6.4 on Type-3).
 pub const SRV6_BEHAVIOR_END_DT6: u16 = 0x0012;
 pub const SRV6_BEHAVIOR_END_DT4: u16 = 0x0013;
 pub const SRV6_BEHAVIOR_END_DT46: u16 = 0x0014;
-pub const SRV6_BEHAVIOR_END_DT2U: u16 = 0x0015;
-pub const SRV6_BEHAVIOR_END_DT2M: u16 = 0x0016;
+pub const SRV6_BEHAVIOR_END_DX2: u16 = 0x0015;
+pub const SRV6_BEHAVIOR_END_DX2V: u16 = 0x0016;
+pub const SRV6_BEHAVIOR_END_DT2U: u16 = 0x0017;
+pub const SRV6_BEHAVIOR_END_DT2M: u16 = 0x0018;
 
 /// BGP Prefix-SID TLV Types (IANA "BGP Prefix-SID TLV Types", RFC 8669 /
 /// RFC 9252 §8.1).
@@ -540,6 +543,20 @@ mod tests {
         let (rest, parsed) = PrefixSid::parse_be(&bytes).expect("parse");
         assert!(rest.is_empty(), "trailing bytes after parse");
         parsed
+    }
+
+    /// Pin the IANA "SRv6 Endpoint Behaviors" codepoints — End.DX2/DX2V
+    /// sit at 21/22 and End.DT2U/DT2M at 23/24; an off-by-two here once
+    /// shipped DT2U/DT2M as 21/22.
+    #[test]
+    fn behavior_codepoints_match_iana() {
+        assert_eq!(SRV6_BEHAVIOR_END_DT6, 18);
+        assert_eq!(SRV6_BEHAVIOR_END_DT4, 19);
+        assert_eq!(SRV6_BEHAVIOR_END_DT46, 20);
+        assert_eq!(SRV6_BEHAVIOR_END_DX2, 21);
+        assert_eq!(SRV6_BEHAVIOR_END_DX2V, 22);
+        assert_eq!(SRV6_BEHAVIOR_END_DT2U, 23);
+        assert_eq!(SRV6_BEHAVIOR_END_DT2M, 24);
     }
 
     #[test]

--- a/proto/cradle.proto
+++ b/proto/cradle.proto
@@ -126,6 +126,24 @@ message FdbRemoteDel {
   uint32 bd  = 2;
 }
 
+// A VPWS cross-connect (EVPN E-Line, RFC 8214): bind the attachment
+// circuit `port` to the remote End.DX2/DX2V service SID — every frame
+// arriving on the AC is MAC-in-SRv6 encapsulated toward it (no FDB).
+message Xconnect {
+  string port      = 1;  // AC interface name (or use port_index)
+  uint32 port_index = 2; // AC ifindex (0 = resolve `port` by name)
+  string remote_sid = 3;
+  // When non-empty, also install this End.DX2 LocalSid bound to the same
+  // AC (decap + raw emit) — one RPC binds the E-Line both directions.
+  string local_sid  = 4;
+}
+
+message XconnectDel {
+  string port       = 1;
+  uint32 port_index = 2;
+  string local_sid  = 3; // when non-empty, also remove this End.DX2 LocalSid
+}
+
 // A BUM ingress-replication slot: one remote PE in bridge domain `bd`,
 // reached by MAC-in-SRv6 toward its End.DT2M `remote_sid`. cradle manages
 // the slot's plumbing itself (a veth pair in the flood list whose far end
@@ -276,6 +294,8 @@ service Cradle {
   rpc AddFdbRemote(FdbRemote) returns (Empty);
   rpc DelFdbRemote(FdbRemoteDel) returns (Empty);
   rpc WatchFdb(WatchFdbRequest) returns (stream FdbEvent);
+  rpc AddXconnect(Xconnect) returns (Empty);
+  rpc DelXconnect(XconnectDel) returns (Empty);
   rpc AddReplSlot(ReplSlot) returns (Empty);
   rpc DelReplSlot(ReplSlot) returns (Empty);
   rpc AddMirrorRoute(MirrorRoute) returns (Empty);

--- a/zebra-rs/src/bgp/config.rs
+++ b/zebra-rs/src/bgp/config.rs
@@ -1884,6 +1884,111 @@ fn config_ethernet_segment_interface(bgp: &mut Bgp, mut args: Args, op: ConfigOp
     Some(())
 }
 
+/// `router bgp afi-safi evpn vpws <name>` (RFC 8214) — create or delete a
+/// VPWS E-Line service. Deleting withdraws its Type-1, unbinds the AC
+/// cross-connect, and releases its End.DX2 SID.
+fn config_vpws(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Option<()> {
+    let afi_safi: AfiSafi = args.afi_safi()?;
+    if afi_safi.afi != Afi::L2vpn || afi_safi.safi != Safi::Evpn {
+        return None;
+    }
+    let name = args.string()?;
+    match op {
+        ConfigOp::Set => {
+            bgp.local_rib.evpn_vpws.services.entry(name).or_default();
+        }
+        ConfigOp::Delete => {
+            bgp.vpws_teardown(&name);
+            bgp.local_rib.evpn_vpws.services.remove(&name);
+        }
+        _ => {}
+    }
+    Some(())
+}
+
+/// Shared body for the VPWS leaf handlers: mutate one field, then
+/// reconcile the service (withdraw + re-originate + re-push the AC
+/// cross-connect as needed).
+fn config_vpws_leaf(
+    bgp: &mut Bgp,
+    mut args: Args,
+    op: ConfigOp,
+    set: impl FnOnce(&mut super::vpws::VpwsService, Option<u32>),
+    parse_u32: bool,
+) -> Option<()> {
+    let afi_safi: AfiSafi = args.afi_safi()?;
+    if afi_safi.afi != Afi::L2vpn || afi_safi.safi != Safi::Evpn {
+        return None;
+    }
+    let name = args.string()?;
+    let value = if op.is_set() && parse_u32 {
+        Some(args.u32()?)
+    } else {
+        None
+    };
+    let svc = bgp
+        .local_rib
+        .evpn_vpws
+        .services
+        .entry(name.clone())
+        .or_default();
+    set(svc, value);
+    bgp.vpws_reconcile(&name);
+    Some(())
+}
+
+/// `router bgp afi-safi evpn vpws <name> evi <1..16777215>`.
+fn config_vpws_evi(bgp: &mut Bgp, args: Args, op: ConfigOp) -> Option<()> {
+    config_vpws_leaf(bgp, args, op, |svc, v| svc.evi = v, true)
+}
+
+/// `router bgp afi-safi evpn vpws <name> local-service-id <id>` — the
+/// Ethernet Tag of our Type-1.
+fn config_vpws_local_service_id(bgp: &mut Bgp, args: Args, op: ConfigOp) -> Option<()> {
+    config_vpws_leaf(bgp, args, op, |svc, v| svc.local_service_id = v, true)
+}
+
+/// `router bgp afi-safi evpn vpws <name> remote-service-id <id>` — the
+/// Ethernet Tag expected on the remote PE's Type-1.
+fn config_vpws_remote_service_id(bgp: &mut Bgp, args: Args, op: ConfigOp) -> Option<()> {
+    config_vpws_leaf(bgp, args, op, |svc, v| svc.remote_service_id = v, true)
+}
+
+/// `router bgp afi-safi evpn vpws <name> interface <name>` — the
+/// attachment circuit. Changing (or clearing) it unbinds the old AC's
+/// cross-connect first.
+fn config_vpws_interface(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Option<()> {
+    let afi_safi: AfiSafi = args.afi_safi()?;
+    if afi_safi.afi != Afi::L2vpn || afi_safi.safi != Safi::Evpn {
+        return None;
+    }
+    let name = args.string()?;
+    let interface = if op.is_set() {
+        Some(args.string()?)
+    } else {
+        None
+    };
+    let svc = bgp
+        .local_rib
+        .evpn_vpws
+        .services
+        .entry(name.clone())
+        .or_default();
+    let old = std::mem::replace(&mut svc.interface, interface);
+    if old != svc.interface
+        && svc.remote_sid.is_some()
+        && let Some(old_ifname) = old
+    {
+        let local_sid = bgp.local_rib.evpn_vpws.sids.get(&name).map(|(a, _)| *a);
+        let _ = bgp.ctx.rib.send(crate::rib::Message::XconnectDel {
+            ifname: old_ifname,
+            local_sid,
+        });
+    }
+    bgp.vpws_reconcile(&name);
+    Some(())
+}
+
 /// `router bgp afi-safi evpn segmentation <bool>` (RFC 9572 §8). When
 /// enabled, the Multicast Flags Extended Community's segmentation-support
 /// bit (bit 8) is attached to every originated Type-3 IMET route, telling
@@ -4516,6 +4621,21 @@ impl Bgp {
             "/router/bgp/afi-safi/ethernet-segment/interface",
             config_ethernet_segment_interface,
         );
+
+        // EVPN VPWS E-Line services (RFC 8214), under
+        // `router bgp afi-safi evpn vpws <name> …`. Augmented in by
+        // zebra-bgp-evpn.yang.
+        self.callback_add("/router/bgp/afi-safi/vpws", config_vpws);
+        self.callback_add("/router/bgp/afi-safi/vpws/evi", config_vpws_evi);
+        self.callback_add(
+            "/router/bgp/afi-safi/vpws/local-service-id",
+            config_vpws_local_service_id,
+        );
+        self.callback_add(
+            "/router/bgp/afi-safi/vpws/remote-service-id",
+            config_vpws_remote_service_id,
+        );
+        self.callback_add("/router/bgp/afi-safi/vpws/interface", config_vpws_interface);
 
         // MUP controller (`router bgp mup-c …`, draft-ietf-bess-mup-safi).
         // Augmented in by zebra-bgp-mup-controller.yang; the controller

--- a/zebra-rs/src/bgp/inst.rs
+++ b/zebra-rs/src/bgp/inst.rs
@@ -1367,6 +1367,14 @@ impl Bgp {
                     }
                 }
                 super::config::reoriginate_all_imet(self);
+                // VPWS Type-1s carry a per-service End.DX2 SID from the
+                // same pool — re-originate so each re-allocates under the
+                // new prefix (the reconcile above cleared them).
+                let vpws_names: Vec<String> =
+                    self.local_rib.evpn_vpws.services.keys().cloned().collect();
+                for name in vpws_names {
+                    self.vpws_reconcile(&name);
+                }
             }
             crate::rib::RibSrRx::Block { .. } => {}
         }
@@ -1530,6 +1538,69 @@ impl Bgp {
         ))
     }
 
+    /// Allocate (or return the existing) `End.DX2` SID for VPWS service
+    /// `name` — the EVPN VPWS egress SID (RFC 9252 §6.3), advertised on
+    /// the service's Type-1 Ethernet A-D per-EVI route. Registry-only at
+    /// this point: the cradle datapath entry is programmed by the
+    /// `XconnectAdd` tee once the AC binding is known (import side), so
+    /// `route_sid_install` skips the cradle LocalSid write for `EndDX2`.
+    fn alloc_vpws_dx2_sid(&mut self, name: &str) -> Option<std::net::Ipv6Addr> {
+        if let Some((addr, _function)) = self.local_rib.evpn_vpws.sids.get(name) {
+            return Some(*addr);
+        }
+        let prefix = self.srv6_locator.as_ref().and_then(|l| l.prefix)?;
+        let function = self.srv6_sid_pool.allocate()?;
+        match crate::isis::srv6::function_addr(prefix, function) {
+            Some(addr) => {
+                self.local_rib
+                    .evpn_vpws
+                    .sids
+                    .insert(name.to_string(), (addr, function));
+                let sid = crate::rib::Sid {
+                    addr,
+                    behavior: crate::rib::SidBehavior::EndDX2,
+                    context: crate::rib::SidContext::None,
+                    owner: crate::rib::SidOwner::new("bgp", 0),
+                    locator: self.srv6_locator_name.clone().unwrap_or_default(),
+                    allocation_type: crate::rib::SidAllocationType::Dynamic,
+                    ifindex: 0,
+                    nh6: None,
+                    structure: None,
+                    table_id: 0,
+                    segs: Vec::new(),
+                    flavors: 0,
+                };
+                let _ = self.ctx.rib.send(crate::rib::Message::SidAdd { sid });
+                Some(addr)
+            }
+            None => {
+                self.srv6_sid_pool.release(function);
+                None
+            }
+        }
+    }
+
+    /// Release VPWS service `name`'s `End.DX2` SID back to the pool.
+    pub(super) fn free_vpws_dx2_sid(&mut self, name: &str) {
+        if let Some((addr, function)) = self.local_rib.evpn_vpws.sids.remove(name) {
+            self.srv6_sid_pool.release(function);
+            let _ = self.ctx.rib.send(crate::rib::Message::SidDel { addr });
+        }
+    }
+
+    /// Build the SRv6 L2 Service Prefix-SID attribute advertised on VPWS
+    /// service `name`'s Type-1 route — this PE's `End.DX2` SID. `None`
+    /// when no locator has resolved.
+    pub(super) fn vpws_dx2_prefix_sid(&mut self, name: &str) -> Option<bgp_packet::PrefixSid> {
+        let sid = self.alloc_vpws_dx2_sid(name)?;
+        let structure = self.srv6_locator.as_ref().and_then(|l| l.sid_structure());
+        Some(srv6_l2_service_prefix_sid(
+            sid,
+            structure,
+            bgp_packet::SRV6_BEHAVIOR_END_DX2,
+        ))
+    }
+
     /// Rebuild a [`super::vrf::Srv6VrfSid`] from a handle's preserved
     /// `(addr, function)` so a relabel / kernel-ctx respawn re-installs
     /// the *same* SID rather than churning the address.
@@ -1558,6 +1629,8 @@ impl Bgp {
         // prefix.
         self.evpn_dt2m_sids.clear();
         self.evpn_dt2u_sids.clear();
+        // Same for the per-service VPWS End.DX2 SIDs.
+        self.local_rib.evpn_vpws.sids.clear();
         let srv6_vrfs: Vec<String> = self
             .vrf_registry
             .keys()
@@ -1807,6 +1880,13 @@ impl Bgp {
             for esi in esis {
                 self.evpn_withdraw_es_routes(esi, std::net::IpAddr::V4(old_router_id));
             }
+            // VPWS Type-1s are keyed by the <router-id>:<evi> RD — same
+            // rebind story; withdraw under the old id before it changes.
+            let vpws_names: Vec<String> =
+                self.local_rib.evpn_vpws.services.keys().cloned().collect();
+            for name in vpws_names {
+                self.evpn_withdraw_vpws(&name);
+            }
         }
 
         self.router_id = router_id;
@@ -1846,6 +1926,13 @@ impl Bgp {
                 .collect();
             for (esi, single_active) in es_list {
                 self.evpn_originate_es_routes(esi, std::net::IpAddr::V4(router_id), single_active);
+            }
+            // Re-originate VPWS Type-1s under the new router-id RD (the
+            // originate body re-checks that the config is complete).
+            let vpws_names: Vec<String> =
+                self.local_rib.evpn_vpws.services.keys().cloned().collect();
+            for name in vpws_names {
+                self.evpn_originate_vpws(&name);
             }
         }
 

--- a/zebra-rs/src/bgp/mod.rs
+++ b/zebra-rs/src/bgp/mod.rs
@@ -21,6 +21,7 @@ pub mod peer_map;
 pub mod show;
 pub mod show_update_group;
 pub mod update_group;
+pub mod vpws;
 pub mod vrf;
 pub mod vrf_config;
 

--- a/zebra-rs/src/bgp/route.rs
+++ b/zebra-rs/src/bgp/route.rs
@@ -15040,25 +15040,74 @@ impl Bgp {
         route_withdraw_evpn_to_peers(rd, prefix, &mut self.peers);
     }
 
+    /// Find the currently-selected remote end of a VPWS service in the EVPN
+    /// Loc-RIB: a non-originated per-EVI Type-1 (RFC 8214) whose Ethernet Tag
+    /// is the service's `remote-service-id` within the same EVI, carrying an
+    /// `End.DX2` L2-Service SID. `None` while no such route is selected.
+    fn vpws_lookup_remote_sid(&self, evi: u32, remote_id: u32) -> Option<std::net::Ipv6Addr> {
+        if remote_id == MAX_ET {
+            // MAX-ET tags per-ES A-D routes, never a VPWS service instance.
+            return None;
+        }
+        for table in self.local_rib.evpn.values() {
+            for (prefix, rib) in table.selected.iter() {
+                let EvpnPrefix::EthernetAd { eth_tag, .. } = prefix else {
+                    continue;
+                };
+                if *eth_tag != remote_id
+                    || rib.typ == BgpRibType::Originated
+                    || extract_vni_from_attr(&rib.attr) != Some(evi)
+                {
+                    continue;
+                }
+                if let Some(sid) = evpn_srv6_sid(&rib.attr, bgp_packet::SRV6_BEHAVIOR_END_DX2) {
+                    return Some(sid);
+                }
+            }
+        }
+        None
+    }
+
     /// Re-sync VPWS service `name` after a config or locator change:
     /// withdraw the stale Type-1 (if any), originate afresh when the
-    /// config is complete, and re-push the AC cross-connect if a remote
-    /// SID had already been imported (so the change takes effect without
-    /// waiting for a route churn).
+    /// config is complete, and re-derive the AC cross-connect from the
+    /// Loc-RIB — the matching remote Type-1 may have arrived before this
+    /// service was (fully) configured, or a re-pointed `remote-service-id`
+    /// / `evi` may now select a different remote, or none at all.
     pub fn vpws_reconcile(&mut self, name: &str) {
         self.evpn_withdraw_vpws(name);
         self.evpn_originate_vpws(name);
         let Some(svc) = self.local_rib.evpn_vpws.services.get(name) else {
             return;
         };
-        if let (Some(remote_sid), Some((_, _, _, ifname))) = (svc.remote_sid, svc.params()) {
-            let ifname = ifname.to_string();
-            let local_sid = self.local_rib.evpn_vpws.sids.get(name).map(|(a, _)| *a);
-            let _ = self.ctx.rib.send(crate::rib::Message::XconnectAdd {
-                ifname,
-                remote_sid,
-                local_sid,
-            });
+        let cached = svc.remote_sid;
+        let ifname = svc.interface.clone();
+        let remote = svc
+            .params()
+            .and_then(|(evi, _, remote_id, _)| self.vpws_lookup_remote_sid(evi, remote_id));
+        if let Some(svc) = self.local_rib.evpn_vpws.services.get_mut(name) {
+            svc.remote_sid = remote;
+        }
+        let local_sid = self.local_rib.evpn_vpws.sids.get(name).map(|(a, _)| *a);
+        match (remote, ifname) {
+            (Some(remote_sid), Some(ifname)) => {
+                let _ = self.ctx.rib.send(crate::rib::Message::XconnectAdd {
+                    ifname,
+                    remote_sid,
+                    local_sid,
+                });
+            }
+            // A previously-bound AC whose remote no longer matches (config
+            // re-pointed, or now partial): unbind. Interface *changes* are
+            // unbound by `config_vpws_interface`, which still knows the old
+            // AC name.
+            (None, Some(ifname)) if cached.is_some() => {
+                let _ = self
+                    .ctx
+                    .rib
+                    .send(crate::rib::Message::XconnectDel { ifname, local_sid });
+            }
+            _ => {}
         }
     }
 

--- a/zebra-rs/src/bgp/route.rs
+++ b/zebra-rs/src/bgp/route.rs
@@ -2620,6 +2620,12 @@ pub struct LocalRib {
     /// The sequence number on our own current Type-2 origination per
     /// `(vni, mac)`, for monotonicity across re-advertisements.
     pub evpn_local_mac_seq: std::collections::BTreeMap<(u32, MacAddr), u32>,
+
+    /// EVPN VPWS (RFC 8214) services + their allocated `End.DX2` SIDs.
+    /// Lives here — like `sr_policy_local` — so both the config callbacks
+    /// (`&mut Bgp`) and the Type-1 import arm (`BgpTop`) reach it without
+    /// threading a new `BgpTop` field.
+    pub evpn_vpws: super::vpws::VpwsState,
 }
 
 impl LocalRib {
@@ -6904,11 +6910,34 @@ fn route_evpn_export_selected(
                     });
                 }
             }
-            // RFC 7432 Type-1/4 ES routes, RFC 9251 Type-7/8 Synch, and RFC
+            // A withdrawn per-EVI Type-1 (RFC 8214): the remote end of a
+            // VPWS E-Line went away — unbind the AC cross-connect of every
+            // service that had matched it. Per-ES A-D (eth-tag MAX-ET) and
+            // our own originations don't bind anything.
+            EvpnPrefix::EthernetAd { eth_tag, .. } => {
+                if *eth_tag != MAX_ET
+                    && wd.typ != BgpRibType::Originated
+                    && let Some(evi) = extract_vni_from_attr(&wd.attr)
+                {
+                    let vpws = &mut bgp.local_rib.evpn_vpws;
+                    for (name, svc) in vpws.services.iter_mut() {
+                        if svc.remote_service_id != Some(*eth_tag) || svc.evi != Some(evi) {
+                            continue;
+                        }
+                        svc.remote_sid = None;
+                        if let Some(ifname) = svc.interface.clone() {
+                            let local_sid = vpws.sids.get(name).map(|(a, _)| *a);
+                            let _ = bgp
+                                .rib_client
+                                .send(rib::Message::XconnectDel { ifname, local_sid });
+                        }
+                    }
+                }
+            }
+            // RFC 7432 Type-4 ES routes, RFC 9251 Type-7/8 Synch, and RFC
             // 9572 A-D routes have no VXLAN dataplane action here — withdraw
             // is a control-plane no-op.
-            EvpnPrefix::EthernetAd { .. }
-            | EvpnPrefix::EthernetSeg { .. }
+            EvpnPrefix::EthernetSeg { .. }
             | EvpnPrefix::IgmpJoinSync { .. }
             | EvpnPrefix::IgmpLeaveSync { .. }
             | EvpnPrefix::PerRegionImet { .. }
@@ -7070,13 +7099,47 @@ fn route_evpn_export_selected(
                 });
             }
         }
-        // RFC 7432 Type-1/4 ES routes, RFC 9251 Type-7/8 Synch, and RFC 9572
+        // A per-EVI Type-1 (RFC 8214): a remote VPWS endpoint. Match its
+        // Ethernet Tag against each configured service's remote-service-id
+        // (within the same EVI, via the RT) and cross-connect the service's
+        // AC to the route's End.DX2 SID through the cradle tee — the
+        // XconnectAdd carries our own End.DX2 SID too, so one message
+        // programs both the ingress encap and the egress decap. Per-ES A-D
+        // (eth-tag MAX-ET) and our own originations bind nothing.
+        EvpnPrefix::EthernetAd { eth_tag, .. } => {
+            if *eth_tag != MAX_ET
+                && best.typ != BgpRibType::Originated
+                && let Some(evi) = extract_vni_from_attr(&best.attr)
+            {
+                let Some(remote_sid) = evpn_srv6_sid(&best.attr, bgp_packet::SRV6_BEHAVIOR_END_DX2)
+                else {
+                    // A Type-1 without an End.DX2 L2-Service SID (e.g. an
+                    // RFC 9572 A-D form) has no SRv6 dataplane binding.
+                    return;
+                };
+                let vpws = &mut bgp.local_rib.evpn_vpws;
+                for (name, svc) in vpws.services.iter_mut() {
+                    if svc.remote_service_id != Some(*eth_tag) || svc.evi != Some(evi) {
+                        continue;
+                    }
+                    svc.remote_sid = Some(remote_sid);
+                    if let Some(ifname) = svc.interface.clone() {
+                        let local_sid = vpws.sids.get(name).map(|(a, _)| *a);
+                        let _ = bgp.rib_client.send(rib::Message::XconnectAdd {
+                            ifname,
+                            remote_sid,
+                            local_sid,
+                        });
+                    }
+                }
+            }
+        }
+        // RFC 7432 Type-4 ES routes, RFC 9251 Type-7/8 Synch, and RFC 9572
         // Per-Region I-PMSI / S-PMSI / Leaf A-D have no VXLAN dataplane action
         // in the current control-plane phase — install is a no-op (the routes
         // are still stored and re-advertised; only kernel programming is
         // skipped).
-        EvpnPrefix::EthernetAd { .. }
-        | EvpnPrefix::EthernetSeg { .. }
+        EvpnPrefix::EthernetSeg { .. }
         | EvpnPrefix::IgmpJoinSync { .. }
         | EvpnPrefix::IgmpLeaveSync { .. }
         | EvpnPrefix::PerRegionImet { .. }
@@ -14906,6 +14969,114 @@ impl Bgp {
         let _ = self.local_rib.remove_evpn(rd, &prefix, 0, ORIGINATED_PEER);
         let _ = self.local_rib.select_best_path_evpn(&rd, &prefix);
         route_withdraw_evpn_to_peers(rd, prefix, &mut self.peers);
+    }
+
+    /// Originate VPWS service `name`'s Ethernet A-D per-EVI route (Type-1,
+    /// RFC 8214 §3.1): RD = `<router-id>:<evi>`, Ethernet Tag = the local
+    /// service instance id, all-zero ESI (single-homed), the EVI RT, and
+    /// this PE's `End.DX2` L2-Service Prefix-SID (RFC 9252 §6.3). No-op
+    /// while the config is partial or the router-id is unset.
+    pub fn evpn_originate_vpws(&mut self, name: &str) {
+        if self.router_id.is_unspecified() {
+            return;
+        }
+        let Some((evi, local_id)) = self
+            .local_rib
+            .evpn_vpws
+            .services
+            .get(name)
+            .and_then(|s| s.params().map(|(evi, local, _, _)| (evi, local)))
+        else {
+            return;
+        };
+        let Some(rd) = rd_from_router_id_vni(self.router_id, evi) else {
+            return;
+        };
+        let prefix_sid = self.vpws_dx2_prefix_sid(name);
+        let prefix = EvpnPrefix::EthernetAd {
+            esi: [0; 10],
+            eth_tag: local_id,
+        };
+        let mut attr = BgpAttr::new();
+        attr.ecom = Some(ExtCommunity::from([evpn_route_target(self.asn, evi)]));
+        attr.prefix_sid = prefix_sid;
+        attr.nexthop = Some(BgpNexthop::Evpn(IpAddr::V4(self.router_id)));
+        let rib = BgpRib::new(
+            ORIGINATED_PEER,
+            Ipv4Addr::UNSPECIFIED,
+            BgpRibType::Originated,
+            0,
+            32768,
+            &attr,
+            None,
+            None,
+            false,
+        );
+        if let Some(svc) = self.local_rib.evpn_vpws.services.get_mut(name) {
+            svc.originated = Some((evi, local_id));
+        }
+        self.evpn_originate_synch(rd, prefix, rib);
+    }
+
+    /// Withdraw VPWS service `name`'s Type-1 — keyed by what was actually
+    /// originated, so it stays correct after config-field changes. No-op
+    /// if nothing is originated.
+    pub fn evpn_withdraw_vpws(&mut self, name: &str) {
+        let Some(svc) = self.local_rib.evpn_vpws.services.get_mut(name) else {
+            return;
+        };
+        let Some((evi, eth_tag)) = svc.originated.take() else {
+            return;
+        };
+        let Some(rd) = rd_from_router_id_vni(self.router_id, evi) else {
+            return;
+        };
+        let prefix = EvpnPrefix::EthernetAd {
+            esi: [0; 10],
+            eth_tag,
+        };
+        let _ = self.local_rib.remove_evpn(rd, &prefix, 0, ORIGINATED_PEER);
+        let _ = self.local_rib.select_best_path_evpn(&rd, &prefix);
+        route_withdraw_evpn_to_peers(rd, prefix, &mut self.peers);
+    }
+
+    /// Re-sync VPWS service `name` after a config or locator change:
+    /// withdraw the stale Type-1 (if any), originate afresh when the
+    /// config is complete, and re-push the AC cross-connect if a remote
+    /// SID had already been imported (so the change takes effect without
+    /// waiting for a route churn).
+    pub fn vpws_reconcile(&mut self, name: &str) {
+        self.evpn_withdraw_vpws(name);
+        self.evpn_originate_vpws(name);
+        let Some(svc) = self.local_rib.evpn_vpws.services.get(name) else {
+            return;
+        };
+        if let (Some(remote_sid), Some((_, _, _, ifname))) = (svc.remote_sid, svc.params()) {
+            let ifname = ifname.to_string();
+            let local_sid = self.local_rib.evpn_vpws.sids.get(name).map(|(a, _)| *a);
+            let _ = self.ctx.rib.send(crate::rib::Message::XconnectAdd {
+                ifname,
+                remote_sid,
+                local_sid,
+            });
+        }
+    }
+
+    /// Full teardown for a deleted VPWS service: withdraw the Type-1,
+    /// unbind the AC cross-connect, release the `End.DX2` SID.
+    pub fn vpws_teardown(&mut self, name: &str) {
+        self.evpn_withdraw_vpws(name);
+        if let Some(svc) = self.local_rib.evpn_vpws.services.get_mut(name)
+            && svc.remote_sid.take().is_some()
+            && let Some(ifname) = svc.interface.clone()
+        {
+            let local_sid = self.local_rib.evpn_vpws.sids.get(name).map(|(a, _)| *a);
+            let _ = self
+                .ctx
+                .rib
+                .send(crate::rib::Message::XconnectDel { ifname, local_sid });
+        }
+        self.free_vpws_dx2_sid(name);
     }
 
     /// Originate the full set of routes for a locally-configured ES: the Type-4

--- a/zebra-rs/src/bgp/vpws.rs
+++ b/zebra-rs/src/bgp/vpws.rs
@@ -1,0 +1,63 @@
+//! EVPN VPWS (RFC 8214): point-to-point E-Line services over SRv6.
+//!
+//! A VPWS service binds one local attachment circuit to one remote PE's AC
+//! with no MAC learning: the PE advertises an Ethernet A-D per-EVI route
+//! (Type-1) whose Ethernet Tag is the *local* VPWS service instance id,
+//! carrying an `End.DX2` L2-Service Prefix-SID (RFC 9252 §6.3). Importing
+//! the remote PE's Type-1 — matched by Ethernet Tag == `remote_service_id`
+//! and the EVI Route Target — yields the remote service SID, and the AC is
+//! cross-connected to it through the cradle tee (`rib::Message::XconnectAdd`
+//! → cradle `AddXconnect`, which programs both the ingress XCONNECT map and
+//! the local `End.DX2` decap).
+//!
+//! Scope: single-homed (all-zero ESI), untagged AC (`End.DX2`). The RFC
+//! 8214 Layer-2 Attributes extended community (MTU/control-flags
+//! signalling) is not attached yet.
+
+use std::collections::BTreeMap;
+use std::net::Ipv6Addr;
+
+/// One configured VPWS service (`router bgp afi-safi evpn vpws <name>`).
+#[derive(Debug, Default, Clone)]
+pub struct VpwsService {
+    /// EVPN Instance — scopes the auto-derived RD (`router-id:evi`) and
+    /// RT (`AS:evi`) both ends must share.
+    pub evi: Option<u32>,
+    /// Advertised as the Ethernet Tag of our Type-1 route.
+    pub local_service_id: Option<u32>,
+    /// Ethernet Tag expected on the remote PE's Type-1 route.
+    pub remote_service_id: Option<u32>,
+    /// The attachment circuit (CE-facing port) of the E-Line.
+    pub interface: Option<String>,
+    /// The `(evi, eth_tag)` our Type-1 is currently originated under —
+    /// what a withdraw must key on even after config fields change.
+    pub originated: Option<(u32, u32)>,
+    /// The remote `End.DX2` SID currently cross-connected (set by the
+    /// import side) — lets a config change re-program the xconnect
+    /// without waiting for a route churn.
+    pub remote_sid: Option<Ipv6Addr>,
+}
+
+impl VpwsService {
+    /// All mandatory parameters, or `None` while the config is partial:
+    /// `(evi, local_service_id, remote_service_id, interface)`.
+    pub fn params(&self) -> Option<(u32, u32, u32, &str)> {
+        Some((
+            self.evi?,
+            self.local_service_id?,
+            self.remote_service_id?,
+            self.interface.as_deref()?,
+        ))
+    }
+}
+
+/// All VPWS state. Lives on `LocalRib` — like `sr_policy_local` — so both
+/// the config callbacks (`&mut Bgp`) and the Type-1 import arm (`BgpTop`)
+/// reach it without threading a new `BgpTop` field.
+#[derive(Debug, Default)]
+pub struct VpwsState {
+    /// Configured services, keyed by name.
+    pub services: BTreeMap<String, VpwsService>,
+    /// Allocated `End.DX2` SID `(addr, locator function)` per service name.
+    pub sids: BTreeMap<String, (Ipv6Addr, u16)>,
+}

--- a/zebra-rs/src/config/manager.rs
+++ b/zebra-rs/src/config/manager.rs
@@ -3353,6 +3353,37 @@ mod yang_load_tests {
         }
     }
 
+    /// `router bgp afi-safi evpn vpws <name> …` (RFC 8214, the `vpws` list in
+    /// zebra-bgp-evpn.yang). Guards the VPWS service grammar so a regression
+    /// is caught in the unit suite.
+    #[test]
+    fn bgp_evpn_vpws_is_settable() {
+        use crate::config::ExecCode;
+        use crate::config::parse::{State, parse};
+        use libyang::to_entry;
+
+        let mut yang = YangStore::new();
+        yang.add_path(concat!(env!("CARGO_MANIFEST_DIR"), "/yang"));
+        yang.read_with_resolve("configure")
+            .expect("configure mode loads");
+        yang.identity_resolve();
+        let module = yang
+            .find_module("configure")
+            .expect("configure module present");
+        let entry = to_entry(&yang, module);
+
+        for path in [
+            "set router bgp afi-safi evpn vpws eline1",
+            "set router bgp afi-safi evpn vpws eline1 evi 100",
+            "set router bgp afi-safi evpn vpws eline1 local-service-id 101",
+            "set router bgp afi-safi evpn vpws eline1 remote-service-id 102",
+            "set router bgp afi-safi evpn vpws eline1 interface eth0",
+        ] {
+            let (code, _comps, _state) = parse(path, entry.clone(), None, State::new());
+            assert_eq!(code, ExecCode::Success, "`{path}` must be a settable path");
+        }
+    }
+
     #[test]
     fn mup_c_upf_address_is_settable() {
         use crate::config::ExecCode;

--- a/zebra-rs/src/fib/cradle.rs
+++ b/zebra-rs/src/fib/cradle.rs
@@ -70,6 +70,7 @@ fn srv6_behavior(b: crate::rib::SidBehavior) -> u32 {
         EndT => 14,    // End walk + table-scoped egress lookup (vrf_table_id)
         EndDX4 => 15,  // decap + IPv4 cross-connect (per-CE VPN egress)
         EndDX6 => 16,  // decap + IPv6 cross-connect
+        EndDX2 => 17,  // decap + raw L2 emit on the AC (EVPN VPWS egress)
         // uT = a uN whose end-of-carrier lookup is table-scoped: cradle
         // models it as UN with a non-zero vrf_id (vrf_table_id below).
         UT => 6,
@@ -797,6 +798,54 @@ impl CradleFib {
     }
 
     /// Remove a `(vni, sid)` replication slot.
+    /// EVPN VPWS cross-connect (RFC 8214 / RFC 9252 §6.3): bind AC `port`
+    /// to the remote PE's End.DX2 service SID. `local_sid`, when present,
+    /// rides in the same RPC so cradle also installs the local End.DX2
+    /// decap bound to the AC — one message programs the E-Line both ways.
+    pub async fn xconnect_add(
+        &self,
+        port: &str,
+        remote_sid: std::net::Ipv6Addr,
+        local_sid: Option<std::net::Ipv6Addr>,
+    ) {
+        let result = async {
+            self.client()
+                .await?
+                .add_xconnect(pb::Xconnect {
+                    port: port.to_string(),
+                    port_index: 0,
+                    remote_sid: remote_sid.to_string(),
+                    local_sid: local_sid.map(|s| s.to_string()).unwrap_or_default(),
+                })
+                .await?;
+            anyhow::Ok(())
+        }
+        .await;
+        if let Err(e) = result {
+            tracing::warn!("fib: cradle xconnect_add {port} -> {remote_sid} failed: {e}");
+        }
+    }
+
+    /// Remove a VPWS cross-connect (and its local End.DX2 decap, when
+    /// `local_sid` is present).
+    pub async fn xconnect_del(&self, port: &str, local_sid: Option<std::net::Ipv6Addr>) {
+        let result = async {
+            self.client()
+                .await?
+                .del_xconnect(pb::XconnectDel {
+                    port: port.to_string(),
+                    port_index: 0,
+                    local_sid: local_sid.map(|s| s.to_string()).unwrap_or_default(),
+                })
+                .await?;
+            anyhow::Ok(())
+        }
+        .await;
+        if let Err(e) = result {
+            tracing::warn!("fib: cradle xconnect_del {port} failed: {e}");
+        }
+    }
+
     pub async fn repl_slot_del(&self, vni: u32, sid: std::net::Ipv6Addr) {
         let result = async {
             self.client()

--- a/zebra-rs/src/fib/netlink/handle.rs
+++ b/zebra-rs/src/fib/netlink/handle.rs
@@ -309,7 +309,7 @@ fn sid_route_target(
         // they never reach the kernel (no End.DT2U/DT2M seg6local action) —
         // `route_sid_install` returns after the cradle tee. The target is
         // computed anyway so the tee gets the right prefix length.
-        SidBehavior::EndDT2U | SidBehavior::EndDT2M => {
+        SidBehavior::EndDT2U | SidBehavior::EndDT2M | SidBehavior::EndDX2 => {
             (RouteHeader::RT_TABLE_MAIN, RouteType::Unicast, 128, addr)
         }
         // End.B6.Encaps (SR Policy Binding SID): a /128 host route in
@@ -562,6 +562,27 @@ impl FibHandle {
     pub async fn cradle_gtp_pdr_del(&self, dst: std::net::Ipv4Addr, teid: u32) {
         if let Some(cradle) = &self.cradle {
             cradle.gtp_pdr_del(dst, teid).await;
+        }
+    }
+
+    /// Tee an EVPN VPWS cross-connect to cradle (RFC 8214 Type-1 with an
+    /// SRv6 End.DX2 SID): bind AC `port` to the remote service SID, and —
+    /// when `local_sid` is present — install the local End.DX2 decap on
+    /// the same AC. No kernel counterpart — cradle is the L2 data plane.
+    pub async fn cradle_xconnect_add(
+        &self,
+        port: &str,
+        remote_sid: std::net::Ipv6Addr,
+        local_sid: Option<std::net::Ipv6Addr>,
+    ) {
+        if let Some(cradle) = &self.cradle {
+            cradle.xconnect_add(port, remote_sid, local_sid).await;
+        }
+    }
+
+    pub async fn cradle_xconnect_del(&self, port: &str, local_sid: Option<std::net::Ipv6Addr>) {
+        if let Some(cradle) = &self.cradle {
+            cradle.xconnect_del(port, local_sid).await;
         }
     }
 
@@ -1875,19 +1896,25 @@ impl FibHandle {
         let (table, kind, prefix_len, dest_addr) =
             sid_route_target(sid.behavior, sid.addr, sid.structure);
         // Tee the local SID to the cradle eBPF data plane (mirrors the netlink
-        // install below) — the SRv6 analogue of the ILM tee.
-        if let Some(cradle) = &self.cradle {
+        // install below) — the SRv6 analogue of the ILM tee. End.DX2 is
+        // registry-only here: its cradle entry is owned by the AddXconnect
+        // tee (which knows the AC binding); installing from the Sid — whose
+        // ifindex is 0 — would clobber a live cross-connect on replay.
+        if let Some(cradle) = &self.cradle
+            && sid.behavior != crate::rib::SidBehavior::EndDX2
+        {
             cradle.local_sid_install(sid, prefix_len, ifindex).await;
         }
         // EVPN-over-SRv6 L2 SIDs are cradle-only: the kernel has no
-        // End.DT2U/DT2M seg6local actions, so there is nothing to install
-        // via netlink. Same for REPLACE-C-SID (RFC 9800 §4.2): no kernel
+        // End.DT2U/DT2M/DX2 seg6local actions, so there is nothing to
+        // install via netlink. Same for REPLACE-C-SID (RFC 9800 §4.2): no kernel
         // flavor op exists through 6.8, and a plain-End fallback would
         // misread the packed containers as full SIDs — worse than no entry.
         if matches!(
             sid.behavior,
             crate::rib::SidBehavior::EndDT2U
                 | crate::rib::SidBehavior::EndDT2M
+                | crate::rib::SidBehavior::EndDX2
                 | crate::rib::SidBehavior::EndRep
                 | crate::rib::SidBehavior::EndXRep
                 | crate::rib::SidBehavior::UT
@@ -2057,6 +2084,7 @@ impl FibHandle {
             sid.behavior,
             crate::rib::SidBehavior::EndDT2U
                 | crate::rib::SidBehavior::EndDT2M
+                | crate::rib::SidBehavior::EndDX2
                 | crate::rib::SidBehavior::EndRep
                 | crate::rib::SidBehavior::EndXRep
                 | crate::rib::SidBehavior::UT

--- a/zebra-rs/src/fib/netlink/srv6.rs
+++ b/zebra-rs/src/fib/netlink/srv6.rs
@@ -128,10 +128,10 @@ fn seg6local_action(behavior: SidBehavior) -> Seg6LocalAction {
         SidBehavior::EndDX4 => Seg6LocalAction::EndDx4,
         SidBehavior::EndDX6 => Seg6LocalAction::EndDx6,
         // EVPN L2 SIDs never reach the kernel (route_sid_install returns
-        // after the cradle tee — no End.DT2U/DT2M seg6local action exists);
+        // after the cradle tee — no End.DT2U/DT2M/DX2 seg6local action exists);
         // map to End so an unexpected call is a visible no-op rather than
         // a panic.
-        SidBehavior::EndDT2U | SidBehavior::EndDT2M => Seg6LocalAction::End,
+        SidBehavior::EndDT2U | SidBehavior::EndDT2M | SidBehavior::EndDX2 => Seg6LocalAction::End,
         SidBehavior::EndX | SidBehavior::UA | SidBehavior::UALib => Seg6LocalAction::EndX,
         // REPLACE-C-SID never reaches the kernel (route_sid_install
         // returns after the cradle tee — no kernel flavor op exists);

--- a/zebra-rs/src/rib/inst.rs
+++ b/zebra-rs/src/rib/inst.rs
@@ -347,6 +347,21 @@ pub enum Message {
         dst: std::net::Ipv4Addr,
         teid: u32,
     },
+    /// EVPN VPWS (RFC 8214): bind attachment circuit `ifname` to a remote
+    /// PE's `End.DX2` service SID — teed to cradle as an XCONNECT entry
+    /// (every AC frame MAC-in-SRv6 encapsulates toward it, no FDB) plus,
+    /// when `local_sid` is present, the local `End.DX2` LocalSid whose
+    /// decap emits raw on the same AC. No kernel counterpart — cradle is
+    /// the L2 data plane.
+    XconnectAdd {
+        ifname: String,
+        remote_sid: std::net::Ipv6Addr,
+        local_sid: Option<std::net::Ipv6Addr>,
+    },
+    XconnectDel {
+        ifname: String,
+        local_sid: Option<std::net::Ipv6Addr>,
+    },
     /// A MAC the cradle eBPF datapath learned on a local L2 port (via the
     /// `WatchFdb` stream). Re-emitted to EVPN subscribers as a synthesized
     /// `RibRx::FdbAdd` — the cradle analogue of a kernel bridge FDB learn —
@@ -3146,6 +3161,20 @@ impl Rib {
             }
             Message::CradleGtpPdrDel { dst, teid } => {
                 self.fib_handle.cradle_gtp_pdr_del(dst, teid).await;
+            }
+            Message::XconnectAdd {
+                ifname,
+                remote_sid,
+                local_sid,
+            } => {
+                self.fib_handle
+                    .cradle_xconnect_add(&ifname, remote_sid, local_sid)
+                    .await;
+            }
+            Message::XconnectDel { ifname, local_sid } => {
+                self.fib_handle
+                    .cradle_xconnect_del(&ifname, local_sid)
+                    .await;
             }
             Message::MdbAdd {
                 vni,

--- a/zebra-rs/src/rib/segment_routing/sid.rs
+++ b/zebra-rs/src/rib/segment_routing/sid.rs
@@ -60,7 +60,7 @@ pub enum SidBehavior {
     /// (carried in [`Sid::segs`]) and forwarded. BGP SR Policy
     /// (SAFI 73) installs the advertised SRv6 Binding SID this way.
     EndB6Encap,
-    /// End.DT2U — RFC 8986 §4.9 (IANA codepoint 0x15). Decapsulates and
+    /// End.DT2U — RFC 8986 §4.11 (IANA codepoint 23). Decapsulates and
     /// switches the inner **Ethernet frame** by unicast destination MAC in
     /// the bridge domain carried in [`Sid::table_id`] (the VNI). The EVPN-
     /// over-SRv6 unicast service SID (RFC 9252 §6.1/§6.2), one per VNI,
@@ -68,12 +68,19 @@ pub enum SidBehavior {
     /// action — the cradle eBPF tee is the data plane, so the FIB skips
     /// the netlink install.
     EndDT2U,
-    /// End.DT2M — RFC 8986 §4.10 (IANA codepoint 0x16). Decapsulates and
+    /// End.DT2M — RFC 8986 §4.12 (IANA codepoint 24). Decapsulates and
     /// **floods** the inner Ethernet frame in the bridge domain
     /// ([`Sid::table_id`] = VNI). The EVPN-over-SRv6 BUM service SID
     /// (RFC 9252 §6.4), advertised on Type-3 IMET routes. Cradle-tee-only,
     /// like End.DT2U.
     EndDT2M,
+    /// End.DX2 — RFC 8986 §4.9 (IANA codepoint 21). Decapsulates and
+    /// emits the inner Ethernet frame **raw** on one bound attachment
+    /// circuit ([`Sid::ifindex`]) — the EVPN VPWS (E-Line, RFC 8214)
+    /// egress, advertised on Type-1 Ethernet A-D per-EVI routes with an
+    /// L2 Service Prefix-SID (RFC 9252 §6.3). Cradle-tee-only, like
+    /// End.DT2U.
+    EndDX2,
     /// End.M — Mirroring Context segment (IANA codepoint 74,
     /// draft-ietf-rtgwg-srv6-egress-protection). A variant of End.DT6:
     /// the protector decapsulates the outer IPv6/SRH and looks the inner
@@ -133,6 +140,7 @@ impl fmt::Display for SidBehavior {
             Self::UT => write!(f, "uT"),
             Self::EndDX4 => write!(f, "End.DX4"),
             Self::EndDX6 => write!(f, "End.DX6"),
+            Self::EndDX2 => write!(f, "End.DX2"),
         }
     }
 }
@@ -157,9 +165,9 @@ impl FromStr for SidBehavior {
             "End.DT6" => Ok(Self::EndDT6),
             "End.DT46" => Ok(Self::EndDT46),
             "End.B6.Encaps" => Ok(Self::EndB6Encap),
-            // End.DT2U / End.DT2M are deliberately absent: they are
-            // allocated per-VNI by BGP EVPN (`encapsulation srv6`), never
-            // named in config.
+            // End.DT2U / End.DT2M / End.DX2 are deliberately absent: they
+            // are allocated by BGP EVPN (per-VNI or per-VPWS service),
+            // never named in config.
             "End.M" => Ok(Self::EndM),
             other => Err(SidBehaviorParseError(other.to_string())),
         }
@@ -315,7 +323,8 @@ impl Sid {
             | SidBehavior::EndM
             | SidBehavior::EndT
             | SidBehavior::EndDX4
-            | SidBehavior::EndDX6 => Ipv6Net::new(self.addr, 128).expect("/128 is always valid"),
+            | SidBehavior::EndDX6
+            | SidBehavior::EndDX2 => Ipv6Net::new(self.addr, 128).expect("/128 is always valid"),
             SidBehavior::UALib => {
                 let plen = self
                     .structure

--- a/zebra-rs/yang/zebra-bgp-evpn.yang
+++ b/zebra-rs/yang/zebra-bgp-evpn.yang
@@ -161,6 +161,50 @@ module zebra-bgp-evpn {
         description "Access interface (CE-facing port) bound to this ES.";
       }
     }
+    list vpws {
+      key "name";
+      description
+        "EVPN VPWS service (RFC 8214) — a point-to-point E-Line between one
+         local attachment circuit and one remote PE's AC, no MAC learning.
+         Advertises an Ethernet A-D per-EVI route (Type-1) whose Ethernet
+         Tag is the local VPWS service instance id, carrying an End.DX2
+         L2-Service Prefix-SID (RFC 9252 §6.3); imports the remote's
+         Type-1 by matching its Ethernet Tag against remote-service-id and
+         cross-connects the AC to the remote SID.";
+      leaf name {
+        type string;
+        description "Operator-chosen VPWS service name (the list key).";
+      }
+      leaf evi {
+        type uint32 {
+          range "1..16777215";
+        }
+        mandatory true;
+        description
+          "EVPN Instance the service belongs to — scopes the auto-derived
+           RD (router-id:evi) and RT (AS:evi) both ends must share.";
+      }
+      leaf local-service-id {
+        type uint32;
+        mandatory true;
+        description
+          "VPWS service instance id advertised as the Ethernet Tag of the
+           local Type-1 route; the remote end configures this value as its
+           remote-service-id.";
+      }
+      leaf remote-service-id {
+        type uint32;
+        mandatory true;
+        description
+          "Ethernet Tag expected on the remote PE's Type-1 route; a match
+           binds the remote End.DX2 SID as this AC's cross-connect target.";
+      }
+      leaf interface {
+        type string;
+        mandatory true;
+        description "Attachment circuit (CE-facing port) of the E-Line.";
+      }
+    }
     leaf bum-tunnel-type {
       type enumeration {
         enum ingress-replication {


### PR DESCRIPTION
## Summary

EVPN VPWS (RFC 8214): point-to-point E-Line services over SRv6, executed in the cradle eBPF dataplane.

- **`vpws` service config** under `router bgp afi-safi evpn` (yang list: `evi`, `local-service-id`, `remote-service-id`, `interface`): originates a per-EVI Ethernet A-D (Type-1) route whose Ethernet Tag is the local service instance id, carrying an **End.DX2 L2-Service Prefix-SID** (RFC 9252 §6.3) carved from the BGP SRv6 locator. EVI RT (`AS:evi`), `router-id:evi` RD, all-zero ESI (single-homed).
- **Import**: the peer's Type-1 — Ethernet Tag matched against `remote-service-id` within the EVI — tees one cradle `AddXconnect` binding the E-Line both directions (ingress AC encap toward the remote SID + local End.DX2 decap on the same AC; `local_sid` rides in the Xconnect RPC). Reconciled on config change, router-id rebind, and locator (re)resolution; withdraw unbinds the AC.
- **Codepoint fix (bgp-packet)**: IANA "SRv6 Endpoint Behaviors" has End.DX2=21, End.DX2V=22, End.DT2U=23, End.DT2M=24 — `SRV6_BEHAVIOR_END_DT2U/DT2M` were shipped two low (21/22). Corrected, `END_DX2`/`END_DX2V` added, and a pin test guards the registry values.
- `SidBehavior::EndDX2`: registry + tee plumbing; kernel netlink skipped (no seg6local action — cradle is the L2 dataplane), and the SidAdd tee is registry-only for EndDX2 so a replay can't clobber a live cross-connect.
- VPWS state lives on `LocalRib` (the `sr_policy_local` pattern) so config callbacks and the Type-1 import arm share it without new `BgpTop` plumbing.

## Test plan

- `cargo test` (includes the bgp-packet codepoint pin test + zebra BDD suite)
- fmt + clippy (workspace `--all-targets`, and `-p zebra-rs --no-default-features`) clean
- e2e in cradle-rs: `cradle_vpws_zebra` — two zebra+cradle PEs, IS-IS SRv6 underlay, iBGP EVPN vpws (evi 100, service ids 101⇄102), CEs ping through the BGP-signalled cross-connect with zero static state (cradle-rs PR #44 follow-up)

🤖 Generated with [Claude Code](https://claude.com/claude-code)