### PR TITLE
bgp/mup: key ST1 by RD+Prefix only per draft §3.2.1

### DIFF
--- a/crates/bgp-packet/src/attrs/nlri_mup.rs
+++ b/crates/bgp-packet/src/attrs/nlri_mup.rs
@@ -218,6 +218,29 @@ impl MupRoute {
         }
     }
 
+    /// The off-key ST1 (Type-1 Session-Transformed) NLRI fields
+    /// (TEID/QFI/endpoint/source), or `None` for every other route type.
+    /// draft-ietf-bess-mup-safi §3.2.1 keeps these out of the route key, so
+    /// they ride on the path; pair with [`MupPrefix::to_route_with`] to
+    /// rebuild the wire NLRI for re-advertisement.
+    pub fn st1_fields(&self) -> Option<MupSt1Fields> {
+        match self {
+            MupRoute::T1st {
+                teid,
+                qfi,
+                endpoint,
+                source,
+                ..
+            } => Some(MupSt1Fields {
+                teid: *teid,
+                qfi: *qfi,
+                endpoint: *endpoint,
+                source: *source,
+            }),
+            _ => None,
+        }
+    }
+
     /// Wire-encoded payload length (the value the Length byte carries
     /// on the wire — bytes *after* the length byte itself).
     pub fn body_len(&self) -> usize {
@@ -519,6 +542,18 @@ fn t2st_teid_size(endpoint_len: u8, addr_bits: u8) -> usize {
     nlri_psize(endpoint_len.saturating_sub(addr_bits)).min(4)
 }
 
+/// The unspecified host address (`0.0.0.0` / `::`) in the same family as
+/// `prefix`. Used as the ST1 endpoint placeholder when reconstructing a
+/// key-only [`MupPrefix::T1st`] for a withdraw — the endpoint is not part of
+/// the ST1 route key (draft §3.2.1), so its value is immaterial to the peer's
+/// key match.
+fn unspecified_host(prefix: &IpNet) -> IpAddr {
+    match prefix {
+        IpNet::V4(_) => IpAddr::V4(Ipv4Addr::UNSPECIFIED),
+        IpNet::V6(_) => IpAddr::V6(Ipv6Addr::UNSPECIFIED),
+    }
+}
+
 impl MupRoute {
     /// Emit one MUP NLRI (optional Path Identifier + architecture +
     /// route type + length + body) onto `buf`. Mirror of `parse`.
@@ -630,32 +665,54 @@ impl MupRoute {
     }
 }
 
+/// The Type-1 Session-Transformed (ST1) NLRI fields that
+/// draft-ietf-bess-mup-safi §3.2.1 excludes from the BGP route key: the GTP
+/// TEID, the QFI, the GTP endpoint (gNB) address and the optional source
+/// (UPF) address. Only the RD + Prefix Length + Prefix key an ST1, so these
+/// ride on the path (`BgpRib.mup_st1`) rather than the [`MupPrefix`] key —
+/// a re-advertised ST1 for the same UE prefix therefore *replaces* the prior
+/// session transform (new TEID/endpoint) instead of coexisting with it.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct MupSt1Fields {
+    pub teid: u32,
+    pub qfi: u8,
+    pub endpoint: IpAddr,
+    pub source: Option<IpAddr>,
+}
+
 /// MUP NLRI key with the add-path Path Identifier, the constant
 /// architecture type, *and* the Route Distinguisher stripped off, used as
 /// the inner key of the per-RD MUP RIB tables.
 ///
 /// Like EVPN's `EvpnPrefix` (and VPN's `Ipv4Net`), the RD is **not** part
 /// of this key — it is the outer `BTreeMap<RouteDistinguisher, _>` key, so
-/// [`MupPrefix::from_route`] returns `(rd, key)`. Every other wire field
-/// except the add-path `id` (which lives on `BgpRib.remote_id`) is part of
-/// the key, so two routes that differ only in TEID/QFI/endpoint/source
-/// coexist, and replacement is by explicit withdraw. Variant declaration
-/// order (`Dsd, Isd, T1st, T2st`) drives the derived `Ord`, so a RIB walk
-/// lists routes grouped by type (DSD then ISD then ST1 then ST2).
+/// [`MupPrefix::from_route`] returns `(rd, key)`.
+///
+/// Only the fields the draft designates part of the prefix in the NLRI
+/// "for the purpose of BGP route key processing" are kept here:
+///   * ISD / ST1 (Type 1 / Type 3): the RD + Prefix Length + Prefix only
+///     (§3.1.1 / §3.2.1). An ST1's TEID / QFI / GTP endpoint / source are
+///     **excluded** from the key, so they ride on the path as a
+///     [`MupSt1Fields`] (`BgpRib.mup_st1`) — a re-advertised ST1 for the
+///     same UE prefix *replaces* the prior one rather than coexisting.
+///   * DSD (Type 2): the RD + Address (§3.1.2).
+///   * ST2 (Type 4): the RD + Endpoint Address + architecture-specific
+///     Endpoint Identifier (the TEID), so `endpoint`/`endpoint_len`/`teid`
+///     stay in the key (§3.2.2).
+///
+/// The add-path `id` lives on `BgpRib.remote_id`. Variant declaration order
+/// (`Dsd, Isd, T1st, T2st`) drives the derived `Ord`, so a RIB walk lists
+/// routes grouped by type (DSD then ISD then ST1 then ST2).
 #[derive(Debug, Clone, Eq, PartialEq, Ord, PartialOrd, Hash)]
 pub enum MupPrefix {
     /// Direct Segment Discovery Route key (draft-ietf-bess-mup-safi §3.1.2).
     Dsd { address: IpAddr },
     /// Interwork Segment Discovery Route key (§3.1.1).
     Isd { prefix: IpNet },
-    /// Type 1 Session Transformed Route (ST1) key (§3.2.1).
-    T1st {
-        prefix: IpNet,
-        teid: u32,
-        qfi: u8,
-        endpoint: IpAddr,
-        source: Option<IpAddr>,
-    },
+    /// Type 1 Session Transformed Route (ST1) key (§3.2.1). Only the UE
+    /// `prefix` (with the outer RD) keys an ST1; the TEID / QFI / endpoint /
+    /// source are off-key path data ([`MupSt1Fields`] on `BgpRib.mup_st1`).
+    T1st { prefix: IpNet },
     /// Type 2 Session Transformed Route (ST2) key (§3.2.2).
     T2st {
         endpoint: IpAddr,
@@ -688,24 +745,10 @@ impl MupPrefix {
         match route {
             MupRoute::Isd { rd, prefix, .. } => (*rd, MupPrefix::Isd { prefix: *prefix }),
             MupRoute::Dsd { rd, address, .. } => (*rd, MupPrefix::Dsd { address: *address }),
-            MupRoute::T1st {
-                rd,
-                prefix,
-                teid,
-                qfi,
-                endpoint,
-                source,
-                ..
-            } => (
-                *rd,
-                MupPrefix::T1st {
-                    prefix: *prefix,
-                    teid: *teid,
-                    qfi: *qfi,
-                    endpoint: *endpoint,
-                    source: *source,
-                },
-            ),
+            // §3.2.1: only the RD + Prefix Length + Prefix key an ST1. The
+            // TEID/QFI/endpoint/source are off-key path data, extracted
+            // separately via [`MupRoute::st1_fields`].
+            MupRoute::T1st { rd, prefix, .. } => (*rd, MupPrefix::T1st { prefix: *prefix }),
             MupRoute::T2st {
                 rd,
                 endpoint,
@@ -750,12 +793,28 @@ impl MupPrefix {
         if v6 { Afi::Ip6 } else { Afi::Ip }
     }
 
-    /// Reconstruct a wire `MupRoute` from the inner key and its RD (the
-    /// outer per-RD map key) for re-advertisement. The only other
-    /// synthesized values are the 3GPP-5G architecture type and a zero
-    /// add-path id. The RD is ignored for the `Unknown` variant (its
-    /// opaque body already carries the original bytes).
+    /// Reconstruct a wire `MupRoute` from the inner key and its RD (the outer
+    /// per-RD map key), with no off-key ST1 fields. Equivalent to
+    /// [`Self::to_route_with`] with `st1 = None`: for an ST1 key the resulting
+    /// TEID/QFI/endpoint/source are zero placeholders, which is valid for an
+    /// MP_UNREACH withdraw (the peer matches on the RD+Prefix key alone) but
+    /// **not** for advertisement — advertisement must overlay the selected
+    /// path's real [`MupSt1Fields`] via [`Self::to_route_with`].
     pub fn to_route(&self, rd: RouteDistinguisher) -> MupRoute {
+        self.to_route_with(rd, None)
+    }
+
+    /// Reconstruct a wire `MupRoute` from the key + its RD, overlaying an ST1
+    /// key with its off-key fields (`st1`). The 3GPP-5G architecture type and
+    /// a zero add-path id are synthesized; the RD is ignored for the
+    /// `Unknown` variant (its opaque body already carries the original bytes).
+    ///
+    /// `st1` is ignored for every non-ST1 variant (they carry no off-key
+    /// data). For a [`MupPrefix::T1st`] key, `Some(fields)` restores the real
+    /// TEID/QFI/endpoint/source for re-advertisement; `None` yields zero
+    /// placeholders (endpoint = the UE prefix's unspecified address) — only
+    /// safe for a key-matched withdraw, never for an advertised route.
+    pub fn to_route_with(&self, rd: RouteDistinguisher, st1: Option<&MupSt1Fields>) -> MupRoute {
         let arch = MupArchitectureType::Gpp5g;
         match self {
             MupPrefix::Isd { prefix } => MupRoute::Isd {
@@ -770,22 +829,22 @@ impl MupPrefix {
                 rd,
                 address: *address,
             },
-            MupPrefix::T1st {
-                prefix,
-                teid,
-                qfi,
-                endpoint,
-                source,
-            } => MupRoute::T1st {
-                id: 0,
-                arch,
-                rd,
-                prefix: *prefix,
-                teid: *teid,
-                qfi: *qfi,
-                endpoint: *endpoint,
-                source: *source,
-            },
+            MupPrefix::T1st { prefix } => {
+                let (teid, qfi, endpoint, source) = match st1 {
+                    Some(f) => (f.teid, f.qfi, f.endpoint, f.source),
+                    None => (0, 0, unspecified_host(prefix), None),
+                };
+                MupRoute::T1st {
+                    id: 0,
+                    arch,
+                    rd,
+                    prefix: *prefix,
+                    teid,
+                    qfi,
+                    endpoint,
+                    source,
+                }
+            }
             MupPrefix::T2st {
                 endpoint,
                 endpoint_len,
@@ -1526,6 +1585,81 @@ mod tests {
             prefix: "10.0.0.0/24".parse().unwrap(),
         };
         assert_eq!(MupPrefix::from_route(&a), MupPrefix::from_route(&b));
+    }
+
+    #[test]
+    fn st1_route_key_is_rd_and_prefix_only() {
+        // draft-ietf-bess-mup-safi §3.2.1: only the RD + Prefix Length +
+        // Prefix key an ST1. Two ST1 routes for the same UE prefix but
+        // different TEID / QFI / endpoint / source must therefore map to the
+        // SAME (rd, key) — a re-advertisement *replaces* rather than
+        // coexists. Their off-key fields differ, extracted via `st1_fields`.
+        let base = |teid, qfi, endpoint: &str, source: Option<&str>| MupRoute::T1st {
+            id: 0,
+            arch: MupArchitectureType::Gpp5g,
+            rd: sample_rd(),
+            prefix: "2001:db8::/64".parse().unwrap(),
+            teid,
+            qfi,
+            endpoint: endpoint.parse().unwrap(),
+            source: source.map(|s| s.parse().unwrap()),
+        };
+        let a = base(1, 1, "10.0.0.1", None);
+        let b = base(999, 5, "10.0.0.2", Some("198.51.100.7"));
+
+        // Same route key despite different off-key fields.
+        assert_eq!(MupPrefix::from_route(&a), MupPrefix::from_route(&b));
+        assert_eq!(
+            MupPrefix::from_route(&a).1,
+            MupPrefix::T1st {
+                prefix: "2001:db8::/64".parse().unwrap(),
+            }
+        );
+        // ...but the off-key fields are distinct and preserved.
+        assert_ne!(a.st1_fields(), b.st1_fields());
+        assert_eq!(
+            a.st1_fields(),
+            Some(MupSt1Fields {
+                teid: 1,
+                qfi: 1,
+                endpoint: "10.0.0.1".parse().unwrap(),
+                source: None,
+            })
+        );
+    }
+
+    #[test]
+    fn st1_to_route_with_restores_off_key_fields() {
+        // Advertisement fidelity: from a (rd, key) + the path's `MupSt1Fields`,
+        // `to_route_with` reconstructs the exact wire ST1 — endpoint/TEID/QFI/
+        // source all restored. This is how re-advertise rebuilds the NLRI.
+        let orig = MupRoute::T1st {
+            id: 0,
+            arch: MupArchitectureType::Gpp5g,
+            rd: sample_rd(),
+            prefix: "2001:db8::5/128".parse().unwrap(),
+            teid: 601,
+            qfi: 9,
+            endpoint: "10.0.0.9".parse().unwrap(),
+            source: Some("198.51.100.7".parse().unwrap()),
+        };
+        let (rd, key) = MupPrefix::from_route(&orig);
+        let st1 = orig.st1_fields();
+        assert_eq!(key.to_route_with(rd, st1.as_ref()), orig);
+
+        // Key-only reconstruction (a withdraw) drops the off-key fields to
+        // zero placeholders but preserves the RD+Prefix key the peer matches.
+        let withdraw = key.to_route(rd);
+        assert_eq!(MupPrefix::from_route(&withdraw), (rd, key));
+        assert_eq!(
+            withdraw.st1_fields(),
+            Some(MupSt1Fields {
+                teid: 0,
+                qfi: 0,
+                endpoint: "::".parse().unwrap(),
+                source: None,
+            })
+        );
     }
 
     #[test]

--- a/zebra-rs/src/bgp/config.rs
+++ b/zebra-rs/src/bgp/config.rs
@@ -8090,14 +8090,14 @@ mod mup_dual_origination_tests {
     /// boundary, so the bare attr here carries only the route-specific ecom.
     #[test]
     fn st1_builds_t1st_st2_builds_t2st_with_ext_comm() {
-        let (p1, attr1) =
+        let (p1, _st1, attr1) =
             build_mup_st_route(&session("internet"), MupSrv6Direction::Encapsulation, None)
                 .unwrap();
         assert!(matches!(p1, MupPrefix::T1st { .. }), "st1 → Type-1 ST");
         assert!(attr1.ecom.is_none(), "st1 carries no ext-comm");
 
         let seg = RouteDistinguisher::from_str("100:1").unwrap();
-        let (p2, attr2) = build_mup_st_route(
+        let (p2, _st1, attr2) = build_mup_st_route(
             &session("internet"),
             MupSrv6Direction::Decapsulation,
             Some(seg),

--- a/zebra-rs/src/bgp/inst.rs
+++ b/zebra-rs/src/bgp/inst.rs
@@ -4928,6 +4928,7 @@ impl Bgp {
                     smet_flags: 0,
                     igmp_max_resp_time: 0,
                     ingress_region: None,
+                    mup_st1: None,
                 };
 
                 let (_, selected, _gen) = self.shard.update(Some(rd), prefix, rib);
@@ -5212,6 +5213,7 @@ impl Bgp {
                     smet_flags: 0,
                     igmp_max_resp_time: 0,
                     ingress_region: None,
+                    mup_st1: None,
                 };
 
                 let (_, selected, _gen) = self.shard.update_v6vpn(rd, prefix, rib);
@@ -5382,8 +5384,13 @@ impl Bgp {
             // VRF-first MUP origination: a per-VRF task built a controller ST
             // route and exported it. Stamp the RD / export-RTs / controller
             // next-hop and promote it into the SAFI-85 Loc-RIB + advertise.
-            super::vrf::BgpGlobalMsg::MupExport { vrf, prefix, attr } => {
-                self.mup_export(vrf, prefix, attr);
+            super::vrf::BgpGlobalMsg::MupExport {
+                vrf,
+                prefix,
+                st1,
+                attr,
+            } => {
+                self.mup_export(vrf, prefix, st1, attr);
             }
             super::vrf::BgpGlobalMsg::WithdrawMupExport { vrf, prefix } => {
                 self.mup_withdraw_export(vrf, prefix);

--- a/zebra-rs/src/bgp/route.rs
+++ b/zebra-rs/src/bgp/route.rs
@@ -1235,6 +1235,13 @@ pub struct BgpRib {
     /// advertise gate uses it to suppress per-PE IMET (Type-3) across region
     /// boundaries. `None` for originated/local rows and non-region peers.
     pub ingress_region: Option<[u8; 8]>,
+    /// MUP Type-1 Session-Transformed (ST1) off-key NLRI fields (TEID, QFI,
+    /// GTP endpoint, optional source). draft-ietf-bess-mup-safi §3.2.1 keys an
+    /// ST1 by RD+Prefix only, so these ride here on the path — exactly like
+    /// EVPN's `smet_flags`/`igmp_max_resp_time` — and the advertise/rebuild
+    /// helpers (`to_route_with`) and the SRv6 ST1→ISD FIB reconcile re-read
+    /// them from the selected path. `None` on every non-ST1 row.
+    pub mup_st1: Option<MupSt1Fields>,
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -1334,6 +1341,7 @@ impl BgpRib {
             smet_flags: 0,
             igmp_max_resp_time: 0,
             ingress_region: None,
+            mup_st1: None,
         }
     }
 
@@ -7703,6 +7711,11 @@ pub fn route_mup_update(
         None, // nexthop (VpnNexthop) — not used by MUP at this layer
         stale,
     );
+    // §3.2.1: an ST1's TEID/QFI/endpoint/source are off the route key, so
+    // carry them on the path — the FIB reconcile, show and re-advertise all
+    // read them here rather than from the (RD+Prefix-only) key. `None` for
+    // every other MUP route type.
+    rib.mup_st1 = route.st1_fields();
 
     {
         let peer = peers.get_mut_by_idx(ident).expect("peer must exist");
@@ -7920,7 +7933,10 @@ fn route_update_mup(
         return None;
     }
 
-    let route = prefix.to_route(rd);
+    // Overlay the selected path's off-key ST1 fields (TEID/QFI/endpoint/
+    // source) onto the RD+Prefix key so the advertised NLRI carries the real
+    // session transform; ignored for non-ST1 keys (§3.2.1).
+    let route = prefix.to_route_with(rd, rib.mup_st1.as_ref());
     let mut attrs = (*rib.attr).clone();
     ebgp_egress_aspath(&peer.egress_as(), &mut attrs);
 
@@ -8081,20 +8097,25 @@ pub(super) fn build_mup_st_route(
     session: &crate::mup_c::session::MupSession,
     direction: super::vrf_config::MupSrv6Direction,
     ext_comm: Option<RouteDistinguisher>,
-) -> Option<(MupPrefix, BgpAttr)> {
+) -> Option<(MupPrefix, Option<MupSt1Fields>, BgpAttr)> {
     use super::vrf_config::MupSrv6Direction;
-    let prefix = match direction {
+    // ST1 carries off-key fields (§3.2.1); an ST2 key is self-contained, so
+    // `st1` stays `None` for it.
+    let (prefix, st1): (MupPrefix, Option<MupSt1Fields>) = match direction {
         // Encapsulation (N6 / downlink): Type-1 ST carries the UE prefix +
         // access tunnel. The endpoint (gNB) family may differ from the UE
-        // prefix family (mixed-AFI 5G).
+        // prefix family (mixed-AFI 5G). Only the UE prefix keys the route; the
+        // TEID/QFI/endpoint ride on the path.
         MupSrv6Direction::Encapsulation => match (mup_ue_prefix(session), session.endpoint) {
-            (Some(prefix), Some(endpoint)) => MupPrefix::T1st {
-                prefix,
-                teid: session.teid,
-                qfi: session.qfi.unwrap_or(0),
-                endpoint,
-                source: None,
-            },
+            (Some(prefix), Some(endpoint)) => (
+                MupPrefix::T1st { prefix },
+                Some(MupSt1Fields {
+                    teid: session.teid,
+                    qfi: session.qfi.unwrap_or(0),
+                    endpoint,
+                    source: None,
+                }),
+            ),
             _ => return None,
         },
         // Decapsulation (N3 / uplink): Type-2 ST carries the *core-side*
@@ -8104,15 +8125,18 @@ pub(super) fn build_mup_st_route(
         // Length (§3.1.4.1) spans the address *and* the trailing 32-bit GTP
         // TEID, so it is 64 (IPv4) / 160 (IPv6).
         MupSrv6Direction::Decapsulation => match session.core_endpoint.or(session.endpoint) {
-            Some(endpoint) => MupPrefix::T2st {
-                endpoint,
-                endpoint_len: if endpoint.is_ipv4() { 64 } else { 160 },
-                teid: if session.core_teid != 0 {
-                    session.core_teid
-                } else {
-                    session.teid
+            Some(endpoint) => (
+                MupPrefix::T2st {
+                    endpoint,
+                    endpoint_len: if endpoint.is_ipv4() { 64 } else { 160 },
+                    teid: if session.core_teid != 0 {
+                        session.core_teid
+                    } else {
+                        session.teid
+                    },
                 },
-            },
+                None,
+            ),
             None => return None,
         },
     };
@@ -8125,7 +8149,7 @@ pub(super) fn build_mup_st_route(
     {
         attr_add_ecom(&mut attr, mup_direct_segment_ecom(&seg));
     }
-    Some((prefix, attr))
+    Some((prefix, st1, attr))
 }
 
 /// Replay every selected MUP route from the Loc-RIB to a peer that just
@@ -12999,7 +13023,13 @@ impl Bgp {
     /// `Originated` and runs best-path → advertise + mirror (the mirror feeds
     /// the route back to the originating VRF, so its `show bgp vrf <name> mup`
     /// reflects the fully-stamped route). No-op when the VRF has no RD.
-    pub fn mup_export(&mut self, vrf: String, prefix: MupPrefix, attr: BgpAttr) {
+    pub fn mup_export(
+        &mut self,
+        vrf: String,
+        prefix: MupPrefix,
+        st1: Option<MupSt1Fields>,
+        attr: BgpAttr,
+    ) {
         let Some(rd) = self.vrfs.get(&vrf).and_then(|c| c.rd) else {
             return;
         };
@@ -13059,6 +13089,10 @@ impl Bgp {
             None,
             false,
         );
+        // Carry the ST1 off-key fields on the originated path (§3.2.1) so the
+        // mirror-back to the VRF, the re-advertise and the FIB reconcile see
+        // the real TEID/QFI/endpoint. `None` for DSD/ISD/ST2 exports.
+        rib.mup_st1 = st1;
         rib.attr = self.attr_store.intern(attr);
         let _ = self.local_rib.update_mup(rd, prefix.clone(), rib);
         let selected = self.local_rib.select_best_path_mup(&rd, &prefix);
@@ -18269,7 +18303,7 @@ mod tests {
         // next-hop are stamped later at the global export boundary
         // (`Bgp::mup_export`), so the bare attr here has no next-hop / RT and
         // no Prefix-SID (the receiving PE derives the SID from its ISD/DSD).
-        let (prefix, attr) = super::build_mup_st_route(
+        let (prefix, _st1, attr) = super::build_mup_st_route(
             &session(Some(v4), None),
             MupSrv6Direction::Encapsulation,
             None,
@@ -18286,14 +18320,20 @@ mod tests {
             "no Prefix-SID on a controller ST"
         );
 
-        // Type-1 (access) uses the access endpoint/TEID.
-        assert!(matches!(
-            super::build_mup_st_route(&session(Some(v4), None), MupSrv6Direction::Encapsulation, None)
-                .unwrap()
-                .0,
-            MupPrefix::T1st { endpoint, teid, .. }
-                if endpoint == "10.0.0.1".parse::<std::net::IpAddr>().unwrap() && teid == 0x1234
-        ));
+        // Type-1 (access) carries the access endpoint/TEID on the ST1 *path*
+        // fields, which are off the route key (draft §3.2.1).
+        let (_prefix, st1, _attr) = super::build_mup_st_route(
+            &session(Some(v4), None),
+            MupSrv6Direction::Encapsulation,
+            None,
+        )
+        .unwrap();
+        let st1 = st1.expect("ST1 carries off-key fields");
+        assert_eq!(
+            st1.endpoint,
+            "10.0.0.1".parse::<std::net::IpAddr>().unwrap()
+        );
+        assert_eq!(st1.teid, 0x1234);
 
         // Type-2 (Decapsulation) uses the *core-side* endpoint/TEID when the
         // session carries one — distinct from the Type-1 access endpoint.

--- a/zebra-rs/src/bgp/show.rs
+++ b/zebra-rs/src/bgp/show.rs
@@ -728,7 +728,7 @@ fn mup_routes_json(
             table.selected.iter().map(move |(prefix, rib)| {
                 let ecom = show_mup_ecom(&rib.attr);
                 MupRouteJson {
-                    prefix: mup_prefix_display(rd, prefix),
+                    prefix: mup_prefix_display(rd, prefix, rib.mup_st1.as_ref()),
                     attrs: common_route_attrs(rib),
                     extended_communities: (!ecom.is_empty()).then_some(ecom),
                 }
@@ -4064,21 +4064,33 @@ fn show_mup_ecom(attr: &BgpAttr) -> String {
 /// Render a `MupPrefix` (plus its outer-map RD) as the bracketed
 /// `[TYPE][rd][fields]` form used by `show bgp mup`, following the MUP NLRI
 /// layout (draft-ietf-bess-mup-safi).
-fn mup_prefix_display(rd: &RouteDistinguisher, prefix: &MupPrefix) -> String {
+fn mup_prefix_display(
+    rd: &RouteDistinguisher,
+    prefix: &MupPrefix,
+    st1: Option<&MupSt1Fields>,
+) -> String {
     match prefix {
         MupPrefix::Dsd { address } => format!("[DSD][{rd}][{address}]"),
         MupPrefix::Isd { prefix } => format!("[ISD][{rd}][{prefix}]"),
-        MupPrefix::T1st {
-            prefix,
-            teid,
-            qfi,
-            endpoint,
-            source,
-        } => match source {
-            Some(src) => {
+        // An ST1's TEID/QFI/endpoint/source are off the route key (§3.2.1) and
+        // ride on the path, so render them from `st1` (the selected `BgpRib`'s
+        // `mup_st1`). A key-only render (no path) shows just the UE prefix.
+        MupPrefix::T1st { prefix } => match st1 {
+            Some(MupSt1Fields {
+                teid,
+                qfi,
+                endpoint,
+                source: Some(src),
+            }) => {
                 format!("[ST1][{rd}][ue={prefix}][teid={teid}][qfi={qfi}][ep={endpoint}:src={src}]")
             }
-            None => format!("[ST1][{rd}][ue={prefix}][teid={teid}][qfi={qfi}][ep={endpoint}]"),
+            Some(MupSt1Fields {
+                teid,
+                qfi,
+                endpoint,
+                source: None,
+            }) => format!("[ST1][{rd}][ue={prefix}][teid={teid}][qfi={qfi}][ep={endpoint}]"),
+            None => format!("[ST1][{rd}][ue={prefix}]"),
         },
         MupPrefix::T2st {
             endpoint,
@@ -4378,7 +4390,11 @@ fn render_mup_table(
     for (rd, table) in tables.iter() {
         for (prefix, rib) in table.selected.iter() {
             let best = if rib.best_path { ">" } else { " " };
-            writeln!(buf, " *{best} {}", mup_prefix_display(rd, prefix))?;
+            writeln!(
+                buf,
+                " *{best} {}",
+                mup_prefix_display(rd, prefix, rib.mup_st1.as_ref())
+            )?;
 
             let nexthop = show_nexthop(&rib.attr);
             writeln!(buf, "       next-hop {nexthop}  weight {}", rib.weight)?;
@@ -4418,7 +4434,7 @@ fn render_mup_table(
                     fmt_direct_segment_id(&seg),
                     srv6_behavior_name(*behavior),
                     sid,
-                    mup_prefix_display(dsd_rd, dsd)
+                    mup_prefix_display(dsd_rd, dsd, None)
                 )?;
             }
 
@@ -4432,24 +4448,21 @@ fn render_mup_table(
             // the gNB's segment. Matching by the endpoint also handles the
             // mixed-AFI case (an IPv6 UE route may carry an IPv4 gNB endpoint).
             if resolve_segments
-                && let MupPrefix::T1st {
-                    prefix: ue,
-                    endpoint,
-                    ..
-                } = prefix
+                && let MupPrefix::T1st { prefix: ue } = prefix
+                && let Some(st1) = &rib.mup_st1
                 && let Some((isd_rd, isd, _, sid, behavior)) = isd_index
                     .iter()
-                    .filter(|(_, _, isd_prefix, _, _)| isd_prefix.contains(endpoint))
+                    .filter(|(_, _, isd_prefix, _, _)| isd_prefix.contains(&st1.endpoint))
                     .max_by_key(|(_, _, isd_prefix, _, _)| isd_prefix.prefix_len())
             {
                 writeln!(
                     buf,
                     "       resolved {} (endpoint {}) -> {} {} (via {})",
                     ue,
-                    endpoint,
+                    st1.endpoint,
                     srv6_behavior_name(*behavior),
                     sid,
-                    mup_prefix_display(isd_rd, isd)
+                    mup_prefix_display(isd_rd, isd, None)
                 )?;
             }
         }
@@ -5725,8 +5738,12 @@ mod detail_tests {
         // RD-major, like `show bgp evpn`; that is covered by the resolve test.)
         let rd = "65000:1";
         {
-            let mut insert = |route: &MupRoute, rib| {
+            let mut insert = |route: &MupRoute, mut rib: BgpRib| {
                 let (rd, prefix) = MupPrefix::from_route(route);
+                // Carry an ST1's off-key fields on the path, as the live
+                // receive path (`route_mup_update`) does, so the render shows
+                // the TEID/QFI/endpoint.
+                rib.mup_st1 = route.st1_fields();
                 let _ = tables.entry(rd).or_default().update(prefix, rib);
             };
             insert(
@@ -5929,8 +5946,8 @@ mod detail_tests {
 
         // An ST1 whose gNB endpoint (10.0.0.9) falls inside the ISD prefix —
         // the UE (10.60.1.5/32) is a different network and is not the key.
-        let st1_in = mup_rib("fc00::9".parse::<IpAddr>().unwrap(), 32768, &[]);
-        let (rd_in, p_in) = MupPrefix::from_route(&MupRoute::T1st {
+        let mut st1_in = mup_rib("fc00::9".parse::<IpAddr>().unwrap(), 32768, &[]);
+        let route_in = MupRoute::T1st {
             id: 0,
             arch: MupArchitectureType::Gpp5g,
             rd: "65501:10".parse().unwrap(),
@@ -5939,13 +5956,16 @@ mod detail_tests {
             qfi: 9,
             endpoint: "10.0.0.9".parse().unwrap(),
             source: None,
-        });
+        };
+        // The gNB endpoint is off the ST1 key (§3.2.1); it rides on the path.
+        st1_in.mup_st1 = route_in.st1_fields();
+        let (rd_in, p_in) = MupPrefix::from_route(&route_in);
         let _ = tables.entry(rd_in).or_default().update(p_in, st1_in);
 
         // An ST1 whose gNB endpoint (10.70.0.9) is outside the ISD prefix,
         // even though its UE happens to sit in a nearby network.
-        let st1_out = mup_rib("fc00::a".parse::<IpAddr>().unwrap(), 32768, &[]);
-        let (rd_out, p_out) = MupPrefix::from_route(&MupRoute::T1st {
+        let mut st1_out = mup_rib("fc00::a".parse::<IpAddr>().unwrap(), 32768, &[]);
+        let route_out = MupRoute::T1st {
             id: 0,
             arch: MupArchitectureType::Gpp5g,
             rd: "65501:10".parse().unwrap(),
@@ -5954,7 +5974,9 @@ mod detail_tests {
             qfi: 9,
             endpoint: "10.70.0.9".parse().unwrap(),
             source: None,
-        });
+        };
+        st1_out.mup_st1 = route_out.st1_fields();
+        let (rd_out, p_out) = MupPrefix::from_route(&route_out);
         let _ = tables.entry(rd_out).or_default().update(p_out, st1_out);
 
         // Not opted in: no resolution shown.

--- a/zebra-rs/src/bgp/vrf/inst.rs
+++ b/zebra-rs/src/bgp/vrf/inst.rs
@@ -713,21 +713,19 @@ impl BgpVrf {
         let mut desired: std::collections::BTreeMap<ipnet::IpNet, (Ipv6Addr, Transport)> =
             std::collections::BTreeMap::new();
         if !isd_index.is_empty() {
-            for (prefix, _rib) in self.local_rib.mup.values().flat_map(|t| t.selected.iter()) {
+            for (prefix, rib) in self.local_rib.mup.values().flat_map(|t| t.selected.iter()) {
                 // Resolve on the ST1 GTP endpoint (gNB) — the ISD advertises
                 // the gNB N3 network, so the endpoint is what falls inside it
                 // (draft §3.3.9; also handles a mixed-AFI IPv6-UE /
                 // IPv4-endpoint route) — but install the *UE prefix* as the
                 // FIB destination (§3.1.3): downlink traffic to the UE is
-                // steered toward the gNB's segment.
-                if let bgp_packet::MupPrefix::T1st {
-                    prefix: ue,
-                    endpoint,
-                    ..
-                } = prefix
+                // steered toward the gNB's segment. The endpoint is off the
+                // ST1 route key (§3.2.1), so read it from the path.
+                if let bgp_packet::MupPrefix::T1st { prefix: ue } = prefix
+                    && let Some(st1) = &rib.mup_st1
                     && let Some((_p, sid, transport)) = isd_index
                         .iter()
-                        .filter(|(p, _, _)| p.contains(endpoint))
+                        .filter(|(p, _, _)| p.contains(&st1.endpoint))
                         .max_by_key(|(p, _, _)| p.prefix_len())
                 {
                     desired.insert(*ue, (*sid, transport.clone()));
@@ -1127,6 +1125,7 @@ impl BgpVrf {
             smet_flags: 0,
             igmp_max_resp_time: 0,
             ingress_region: None,
+            mup_st1: None,
         };
 
         let (_, selected, _gen) = self.shard.update(None, prefix, rib);
@@ -1352,6 +1351,7 @@ impl BgpVrf {
             smet_flags: 0,
             igmp_max_resp_time: 0,
             ingress_region: None,
+            mup_st1: None,
         };
 
         let (_, selected, _gen) = self.shard.update_v6(prefix, rib);
@@ -1768,6 +1768,7 @@ impl BgpVrf {
             smet_flags: 0,
             igmp_max_resp_time: 0,
             ingress_region: None,
+            mup_st1: None,
         }
     }
 
@@ -1941,7 +1942,7 @@ impl BgpVrf {
                 ext_comm,
             } => {
                 self.withdraw_mup_originate(session.seid);
-                if let Some((prefix, attr)) =
+                if let Some((prefix, st1, attr)) =
                     super::super::route::build_mup_st_route(&session, direction, ext_comm)
                 {
                     self.mup_originated
@@ -1951,6 +1952,7 @@ impl BgpVrf {
                     let _ = self.global_tx.send(BgpGlobalMsg::MupExport {
                         vrf: self.name.clone(),
                         prefix,
+                        st1,
                         attr,
                     });
                 }
@@ -1986,6 +1988,8 @@ impl BgpVrf {
                     let _ = self.global_tx.send(BgpGlobalMsg::MupExport {
                         vrf: self.name.clone(),
                         prefix,
+                        // A DSD/ISD segment carries no off-key ST1 fields.
+                        st1: None,
                         attr,
                     });
                 }

--- a/zebra-rs/src/bgp/vrf/msg.rs
+++ b/zebra-rs/src/bgp/vrf/msg.rs
@@ -256,6 +256,11 @@ pub enum BgpGlobalMsg {
     MupExport {
         vrf: String,
         prefix: bgp_packet::MupPrefix,
+        /// The ST1 (Type-1 Session-Transformed) off-key NLRI fields
+        /// (draft §3.2.1), when `prefix` is a `MupPrefix::T1st`. Stamped onto
+        /// the originated path so the global re-advertise / FIB reconcile see
+        /// the real TEID/QFI/endpoint. `None` for DSD/ISD/ST2.
+        st1: Option<bgp_packet::MupSt1Fields>,
         attr: BgpAttr,
     },
 


### PR DESCRIPTION
## Summary

`MupPrefix::T1st` keyed on the **entire** ST1 NLRI (`prefix + teid + qfi + endpoint + source`). draft-ietf-bess-mup-safi §3.2.1 says the opposite: *"For the purpose of BGP route key processing, only the RD, Prefix Length and Prefix are considered to be part of the prefix in the NLRI."* GoBGP keys it the same way the draft prescribes (`[type:t1st][rd][prefix]`).

The over-broad key meant two ST1 routes for the same UE prefix but a different TEID/gNB endpoint **coexisted** in the RIB instead of the second replacing the first — leaking stale GTP tunnels across a session handover.

## Fix

- Reduce the key to `MupPrefix::T1st { prefix }`.
- Carry the off-key TEID/QFI/endpoint/source on the path as `BgpRib.mup_st1: Option<MupSt1Fields>` — the same "rides on the path, re-emitted by the advertise/rebuild helpers" pattern EVPN already uses for `smet_flags`/`igmp_max_resp_time`.
- Advertise rebuilds the wire NLRI via the new `MupPrefix::to_route_with(rd, st1)`; a withdraw uses the key-only `to_route` (zero placeholders the peer matches by RD+Prefix alone).
- `route_mup_update` stamps the fields from the wire; `build_mup_st_route` / `mup_export` / the `MupExport` message thread them through VRF-first origination; the SRv6 ST1→ISD FIB reconcile and `show bgp mup` read the endpoint from the path.
- The VRF import dispatch already deep-clones the rib, so an RT-imported copy inherits `mup_st1` for its own FIB install and show output.

With the reduced key, `LocalRibMup::update` / `AdjRibMupTable::add` collapse same-(peer, prefix) ST1s to a **replace**, matching the draft semantics. DSD/ISD/ST2 keys are unchanged (already draft-correct).

## Test plan

- New `bgp-packet` regression tests: `st1_route_key_is_rd_and_prefix_only` (differing TEID/QFI/endpoint → same `(rd, key)`, off-key fields still distinct) and `st1_to_route_with_restores_off_key_fields` (advertise round-trip + withdraw placeholder re-keys correctly).
- Full non-BDD workspace suite green (1518 zebra-rs + 402 bgp-packet, 0 failed).
- `cargo clippy --workspace --all-targets -- -D warnings` clean; `cargo fmt --check` clean.

Generated with [Claude Code](https://claude.com/claude-code)