### PR TITLE
bgp/mup-c: add router bgp mup-c upf-address for ST2 core endpoint

### DIFF
--- a/zebra-rs/src/bgp/config.rs
+++ b/zebra-rs/src/bgp/config.rs
@@ -1946,6 +1946,18 @@ fn config_mup_c_controller_address(bgp: &mut Bgp, mut args: Args, op: ConfigOp) 
     Some(())
 }
 
+/// `… mup-c upf-address <ip>` — Core (N6) endpoint for ST2 routes when the
+/// session carries no core-side GTP tunnel.
+fn config_mup_c_upf_address(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Option<()> {
+    bgp.mup_c_config.upf_address = if op.is_set() {
+        Some(args.addr()?)
+    } else {
+        None
+    };
+    bgp.mup_c_dirty = true;
+    Some(())
+}
+
 /// `… mup-c pfcp node-id <ip>` — our PFCP Node ID for responses.
 fn config_mup_c_pfcp_node_id(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Option<()> {
     bgp.mup_c_config.node_id = if op.is_set() {
@@ -4501,6 +4513,7 @@ impl Bgp {
             "/router/bgp/mup-c/controller-address",
             config_mup_c_controller_address,
         );
+        self.callback_add("/router/bgp/mup-c/upf-address", config_mup_c_upf_address);
         self.callback_add("/router/bgp/mup-c/pfcp/node-id", config_mup_c_pfcp_node_id);
         self.callback_add(
             "/router/bgp/mup-c/pfcp/listen-address",

--- a/zebra-rs/src/config/manager.rs
+++ b/zebra-rs/src/config/manager.rs
@@ -3352,6 +3352,32 @@ mod yang_load_tests {
     }
 
     #[test]
+    fn mup_c_upf_address_is_settable() {
+        use crate::config::ExecCode;
+        use crate::config::parse::{State, parse};
+        use libyang::to_entry;
+
+        let mut yang = YangStore::new();
+        yang.add_path(concat!(env!("CARGO_MANIFEST_DIR"), "/yang"));
+        yang.read_with_resolve("configure")
+            .expect("configure mode loads");
+        yang.identity_resolve();
+        let module = yang
+            .find_module("configure")
+            .expect("configure module present");
+        let entry = to_entry(&yang, module);
+
+        // `mup-c upf-address` accepts both IPv4 and IPv6 (inet:ip-address).
+        for path in [
+            "set router bgp mup-c upf-address 10.100.0.1",
+            "set router bgp mup-c upf-address 2001:db8::1",
+        ] {
+            let (code, _comps, _state) = parse(path, entry.clone(), None, State::new());
+            assert_eq!(code, ExecCode::Success, "`{path}` must be a settable path");
+        }
+    }
+
+    #[test]
     fn bgp_evpn_segmentation_is_settable() {
         use crate::config::ExecCode;
         use crate::config::parse::{State, parse};

--- a/zebra-rs/src/mup-c/inst.rs
+++ b/zebra-rs/src/mup-c/inst.rs
@@ -29,6 +29,10 @@ pub struct MupCConfig {
     pub enable: bool,
     /// IPv6 next-hop stamped on originated ST routes (route phase).
     pub controller_address: Option<Ipv6Addr>,
+    /// Core (N6) UPF endpoint used as the Type-2 ST route endpoint when a
+    /// learned session carries no core-side GTP tunnel (the N6-breakout case).
+    /// A session that learns a core F-TEID over PFCP keeps that in preference.
+    pub upf_address: Option<IpAddr>,
     /// Our PFCP Node ID, used in responses. Falls back to the bind
     /// address / `controller_address` when unset.
     pub node_id: Option<IpAddr>,

--- a/zebra-rs/src/mup-c/pfcp.rs
+++ b/zebra-rs/src/mup-c/pfcp.rs
@@ -259,7 +259,7 @@ impl MupC {
         let (core_teid, core_endpoint) = ex.core.map_or((0, None), |(t, e)| (t, Some(e)));
 
         let seid = self.sessions.alloc_seid();
-        let session = MupSession {
+        let mut session = MupSession {
             seid,
             cp_seid,
             peer: src,
@@ -272,6 +272,11 @@ impl MupC {
             network_instance: ex.network_instance,
             qfi: None,
         };
+        // N6-breakout fallback: a session with no core-side GTP tunnel (the
+        // common case — the SMF programs only the access/gNB tunnel) has no
+        // Type-2 ST endpoint. Use the configured Core (N6) UPF address so an
+        // ST2 route can still be originated toward the anchor UPF.
+        session.core_endpoint = session.core_endpoint.or(self.config.upf_address);
         self.sessions.insert(session.clone());
 
         let local_ip = self.local_ip();
@@ -989,6 +994,57 @@ mod tests {
             created.f_teid.ipv4_address,
             Some(Ipv4Addr::LOCALHOST),
             "N3 F-TEID address = controller local_ip (default 127.0.0.1)"
+        );
+    }
+
+    /// N6 breakout: a session with only an access/gNB tunnel (no core-side
+    /// F-TEID) gets its Type-2 ST endpoint from the configured `upf-address`.
+    #[test]
+    fn upf_address_fills_core_endpoint_for_n6_breakout() {
+        let cfg = MupCConfig {
+            upf_address: Some(IpAddr::V4(Ipv4Addr::new(10, 100, 0, 1))),
+            ..Default::default()
+        };
+        let (mut mupc, _bgp_rx) = MupC::new_for_test(cfg);
+        associate(&mut mupc);
+        // establishment_bytes carries a gNB tunnel (Access FAR OHC) but no
+        // core-side tunnel.
+        let est = message::parse(&establishment_bytes()).unwrap();
+        let (_reply, events) = mupc.handle_session_establishment(est.as_ref(), peer());
+        let MupCEvent::SessionUp(session) = &events[0] else {
+            panic!("expected SessionUp");
+        };
+        assert_eq!(
+            session.core_endpoint,
+            Some(IpAddr::V4(Ipv4Addr::new(10, 100, 0, 1))),
+            "no core tunnel → ST2 endpoint from configured upf-address"
+        );
+        // The gNB (access) side is unaffected.
+        assert_eq!(
+            session.endpoint,
+            Some(IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1)))
+        );
+    }
+
+    /// A session that learns a core-side F-TEID over PFCP (e.g. an N9 tunnel)
+    /// keeps that learned endpoint in preference to the configured one.
+    #[test]
+    fn learned_core_endpoint_beats_upf_address() {
+        let cfg = MupCConfig {
+            upf_address: Some(IpAddr::V4(Ipv4Addr::new(10, 100, 0, 1))),
+            ..Default::default()
+        };
+        let (mut mupc, _bgp_rx) = MupC::new_for_test(cfg);
+        associate(&mut mupc);
+        let est = message::parse(&establishment_two_endpoints_bytes()).unwrap();
+        let (_reply, events) = mupc.handle_session_establishment(est.as_ref(), peer());
+        let MupCEvent::SessionUp(session) = &events[0] else {
+            panic!("expected SessionUp");
+        };
+        assert_eq!(
+            session.core_endpoint,
+            Some(IpAddr::V4(Ipv4Addr::new(10, 9, 0, 1))),
+            "learned core F-TEID wins over configured upf-address"
         );
     }
 

--- a/zebra-rs/yang/zebra-bgp-mup-controller.yang
+++ b/zebra-rs/yang/zebra-bgp-mup-controller.yang
@@ -41,6 +41,7 @@ module zebra-bgp-mup-controller {
          mup-c {
            enable true;
            controller-address 2001:db8::1;
+           upf-address 10.100.0.1;
            pfcp {
              node-id 10.0.0.1;
              listen-address ::;
@@ -78,6 +79,17 @@ module zebra-bgp-mup-controller {
         description
           "Controller IPv6 address advertised as the next hop on
            originated Type-1 / Type-2 Session-Transformed routes.";
+      }
+
+      leaf upf-address {
+        type inet:ip-address;
+        description
+          "Core (N6) UPF endpoint address used as the Type-2 Session
+           Transformed (ST2) route endpoint when the PFCP session carries
+           no core-side GTP tunnel (the common N6-breakout case, where the
+           SMF programs only the access/gNB tunnel). A session that does
+           learn a core-facing F-TEID over PFCP (e.g. an N9 tunnel) keeps
+           that learned endpoint in preference to this configured one.";
       }
 
       container pfcp {


### PR DESCRIPTION
## Summary

A single-UPF **N6-breakout** session carries no core-side GTP tunnel — the SMF programs only the access/gNB tunnel — so a Type-2 Session-Transformed (ST2) route has no core endpoint and falls back to the access/gNB endpoint, which is not a real core anchor. This adds a config knob so an operator can supply the Core (N6) UPF endpoint explicitly.

- New leaf **`router bgp mup-c upf-address {A.B.C.D|X:X::X:X}`** (`inet:ip-address`, v4 or v6) → `MupCConfig.upf_address`.
- When a learned session has no core-side F-TEID, the controller fills its `core_endpoint` from this value, so an ST2 route is originated toward the configured anchor.
- A session that **does** learn a core F-TEID over PFCP (e.g. an N9 tunnel) keeps that learned endpoint **in preference** to the configured one.

Note this only supplies the ST2 *endpoint* value; a route still originates only when the session's Network Instance maps to a MUP VRF. free5GC sends a Network Instance so it benefits immediately; radian-rs currently sends none (a separate SMF-side gap).

## Test plan

- `upf_address_fills_core_endpoint_for_n6_breakout` — a gNB-only session gets its ST2 endpoint from `upf-address`.
- `learned_core_endpoint_beats_upf_address` — a learned N9 core F-TEID wins over the configured value.
- `mup_c_upf_address_is_settable` — yang-load guard: `set router bgp mup-c upf-address <ip>` parses for both IPv4 and IPv6.
- `cargo clippy --workspace --all-targets -- -D warnings` clean; `cargo fmt --check` clean; full non-BDD suite green.

Generated with [Claude Code](https://claude.com/claude-code)