### PR TITLE
bgp: guard no-op MUP and SR-Policy withdraws against reflection storms

### DIFF
--- a/zebra-rs/src/bgp/route.rs
+++ b/zebra-rs/src/bgp/route.rs
@@ -7779,7 +7779,7 @@ fn route_mup_locrib_withdraw(
         .first()
         .filter(|_| matches!(prefix, MupPrefix::Dsd { .. } | MupPrefix::Isd { .. }))
         .and_then(|r| super::nht::nht_target(&r.attr));
-    let _ = bgp.local_rib.remove_mup(rd, &prefix, id, ident);
+    let removed = bgp.local_rib.remove_mup(rd, &prefix, id, ident);
     let selected = bgp.local_rib.select_best_path_mup(&rd, &prefix);
     // Release the NHT registration when no surviving path keeps the
     // pre-withdraw DSD next-hop.
@@ -7799,8 +7799,13 @@ fn route_mup_locrib_withdraw(
     if let Some(dispatcher) = bgp.vrf_import {
         super::vrf::dispatch_mup(dispatcher, rd, &prefix, selected.first(), None, &transport);
     }
+    // Only propagate when the Loc-RIB actually changed. A withdraw for an
+    // already-absent route (nothing removed, no surviving best path) is a
+    // no-op; re-flooding it makes peers echo it back — the MUP withdraw storm.
     if selected.is_empty() {
-        route_withdraw_mup_to_peers(rd, prefix, peers);
+        if !removed.is_empty() {
+            route_withdraw_mup_to_peers(rd, prefix, peers);
+        }
     } else {
         // Another path remains best for this key — re-advertise it.
         route_advertise_mup_to_peers(rd, prefix, &selected, bgp, peers);
@@ -8030,10 +8035,16 @@ pub fn route_advertise_mup_to_peers(
     }
 }
 
-/// Send one id-less MUP MP_UNREACH to a peer and drop the Adj-RIB-Out
-/// entry so a later policy diff doesn't re-withdraw it.
+/// Send one id-less MUP MP_UNREACH to a peer — but only if the peer actually
+/// holds the route in its Adj-RIB-Out. Sending an MP_UNREACH for a route we
+/// never advertised (or already withdrew) is a no-op the peer echoes straight
+/// back: with the empty-Loc-RIB withdraw path also un-gated, that ping-pongs
+/// into a MUP withdraw storm (TCP ZeroWindow). Gating on Adj-RIB-Out makes
+/// every MUP withdraw idempotent, mirroring the adj_out-gated v4/v6 withdraw.
 fn mup_withdraw_one(peer: &mut Peer, rd: RouteDistinguisher, prefix: &MupPrefix) {
-    peer.adj_out.remove_mup(rd, prefix, 0);
+    if peer.adj_out.remove_mup(rd, prefix, 0).is_none() {
+        return;
+    }
     let mut update = UpdatePacket::with_max_packet_size(peer.max_packet_size());
     update.mp_withdraw = Some(MpUnreachAttr::Mup {
         afi: prefix.afi(),
@@ -8400,11 +8411,18 @@ pub fn route_srpolicy_withdraw(
     bgp: &mut BgpTop,
     peers: &mut PeerMap,
 ) {
-    srpolicy_reflect_withdraw(ident, nlri, peers);
-    let delta =
+    // Withdraw from the Loc-RIB first, then reflect to RR peers ONLY if a
+    // candidate was actually removed. Reflecting a no-op withdrawal (policy
+    // already absent) would echo back around a route-reflector cycle into an
+    // SR-Policy withdraw storm — withdraws carry no AS_PATH/ORIGINATOR_ID, so
+    // loop detection cannot stop them (the same class of bug fixed in MUP).
+    let (removed, delta) =
         bgp.local_rib
             .sr_policy
             .withdraw(nlri.color, nlri.endpoint, nlri.distinguisher, ident);
+    if removed {
+        srpolicy_reflect_withdraw(ident, nlri, peers);
+    }
     apply_srpolicy_fib(delta, bgp);
     sr_policy_mpls_sync(bgp, nlri.color, nlri.endpoint);
 }

--- a/zebra-rs/src/bgp/sr_policy.rs
+++ b/zebra-rs/src/bgp/sr_policy.rs
@@ -258,33 +258,43 @@ impl SrPolicyDb {
     /// `<color, endpoint, discriminator>`, re-run selection, and return
     /// the FIB delta. Drops the whole policy (tearing down any installed
     /// Binding SID) when its last candidate is withdrawn.
+    /// Withdraw one candidate path (keyed by `discriminator` + originating
+    /// `peer`). Returns `(removed, delta)`: `removed` is `true` only when a
+    /// candidate was actually present and dropped — the caller reflects the
+    /// withdrawal to RR peers only then, so a no-op withdraw (policy/candidate
+    /// already absent) is not re-flooded into a reflection-cycle storm.
     pub fn withdraw(
         &mut self,
         color: u32,
         endpoint: IpAddr,
         discriminator: u32,
         peer: usize,
-    ) -> SrPolicyFibDelta {
+    ) -> (bool, SrPolicyFibDelta) {
         let key = SrPolicyKey { color, endpoint };
         let Some(policy) = self.policies.get_mut(&key) else {
-            return SrPolicyFibDelta::default();
+            return (false, SrPolicyFibDelta::default());
         };
         let prev = policy.active.clone();
+        let before = policy.candidates.len();
         policy
             .candidates
             .retain(|k, cp| !(k.discriminator == discriminator && cp.peer == peer));
+        let removed = policy.candidates.len() != before;
         if policy.candidates.is_empty() {
             let remove = policy.installed.take().map(|b| b.bsid);
             let mpls_remove = policy.installed_mpls.take();
             self.policies.remove(&key);
-            SrPolicyFibDelta {
-                remove,
-                install: None,
-                mpls_remove,
-            }
+            (
+                removed,
+                SrPolicyFibDelta {
+                    remove,
+                    install: None,
+                    mpls_remove,
+                },
+            )
         } else {
             policy.active = select_active(&policy.candidates, prev.as_ref());
-            policy.reconcile_fib()
+            (removed, policy.reconcile_fib())
         }
     }
 
@@ -955,6 +965,38 @@ mod tests {
         assert!(!db.policies.contains_key(&key));
     }
 
+    /// The `removed` flag drives the reflection guard: it is `true` only when
+    /// a candidate was actually dropped. A no-op withdraw (absent policy,
+    /// absent candidate, or re-withdraw) returns `false`, so the caller does
+    /// not reflect it — breaking the SR-Policy withdraw ping-pong.
+    #[test]
+    fn withdraw_removed_flag_gates_reflection() {
+        let mut db = SrPolicyDb::default();
+        let key = SrPolicyKey {
+            color: 100,
+            endpoint: endpoint("10.0.0.9"),
+        };
+        let mut a = cp(20, "10.0.0.1", 1, 100, true);
+        a.peer = 1;
+        db.insert(key.clone(), a.clone());
+
+        // Absent policy color → no-op.
+        let (removed, _) = db.withdraw(999, endpoint("10.0.0.9"), 1, 1);
+        assert!(!removed, "withdraw of an absent policy removes nothing");
+        // Policy exists but not this (discriminator, peer) → no-op.
+        let (removed, _) = db.withdraw(100, endpoint("10.0.0.9"), 7, 7);
+        assert!(!removed, "withdraw of an absent candidate removes nothing");
+        // The real candidate → removed.
+        let (removed, _) = db.withdraw(100, endpoint("10.0.0.9"), 1, 1);
+        assert!(removed, "withdraw of a present candidate removes it");
+        // Re-withdraw the now-absent candidate → no-op (breaks the storm).
+        let (removed, _) = db.withdraw(100, endpoint("10.0.0.9"), 1, 1);
+        assert!(
+            !removed,
+            "re-withdraw of an already-absent candidate is a no-op"
+        );
+    }
+
     #[test]
     fn invalid_only_policy_has_no_active() {
         let mut db = SrPolicyDb::default();
@@ -1024,7 +1066,7 @@ mod tests {
         assert_eq!(delta.remove, Some(v6("fc00:0:9::1")));
         assert_eq!(delta.install.unwrap().bsid, v6("fc00:0:9::2"));
         // Withdrawing the winner falls back to the remaining path's BSID.
-        let delta = db.withdraw(100, ep, 2, 2);
+        let (_, delta) = db.withdraw(100, ep, 2, 2);
         assert_eq!(delta.remove, Some(v6("fc00:0:9::2")));
         assert_eq!(delta.install.unwrap().bsid, v6("fc00:0:9::1"));
     }
@@ -1038,7 +1080,7 @@ mod tests {
             endpoint: ep,
         };
         db.insert(key.clone(), srv6_cp(1, 100, 1, "fc00:0:9::1", "fc00:0:2::"));
-        let delta = db.withdraw(5, ep, 1, 1);
+        let (_, delta) = db.withdraw(5, ep, 1, 1);
         assert_eq!(delta.remove, Some(v6("fc00:0:9::1")));
         assert_eq!(delta.install, None);
         assert!(!db.policies.contains_key(&key));
@@ -1133,7 +1175,7 @@ mod tests {
         // Install it (records installed_mpls).
         assert!(db.mpls_reconcile(9, ep, true).install.is_some());
         // Withdrawing the last path reports the LFIB label to tear down.
-        let delta = db.withdraw(9, ep, 1, 1);
+        let (_, delta) = db.withdraw(9, ep, 1, 1);
         assert_eq!(delta.mpls_remove, Some(1000));
     }
 


### PR DESCRIPTION
## Summary

A received MP_UNREACH withdraw for a route **already absent** from the Loc-RIB was re-propagated to peers, which echoed it back — an infinite withdraw **ping-pong storm** that saturated the session (TCP ZeroWindow). MP_UNREACH carries no AS_PATH / ORIGINATOR_ID, so BGP loop detection cannot stop it; only an explicit idempotence guard can. Observed on a **MUP (SAFI 85)** peering.

An audit of **every** AFI/SAFI's withdraw path found two exposed:

- **MUP (SAFI 85):** `route_mup_locrib_withdraw` discarded the `remove_mup` result and called `route_withdraw_mup_to_peers` whenever best-path was empty — including for an already-absent route — and `mup_withdraw_one` sent the MP_UNREACH without checking Adj-RIB-Out. Added **both** guards: a Loc-RIB `!removed` guard, and an Adj-RIB-Out gate in `mup_withdraw_one` (only withdraw a route the peer actually holds), mirroring v4/v6/Flowspec.
- **SR-Policy (SAFI 73):** `route_srpolicy_withdraw` reflected the withdrawal to route-reflector peers *before* the Loc-RIB removal and unconditionally. Harmless in a plain mesh / single-RR star (source excluded + RR rules), but a **reflection cycle** (hierarchical / redundant RRs, or eBGP SR-Policy) loops a no-op withdraw. `SrPolicyTable::withdraw` now returns `(removed, delta)`; the handler withdraws from the Loc-RIB first and reflects **only when a candidate was actually removed**.

Every other SAFI (v4/v6 unicast, VPNv4/v6, EVPN, Labeled-Unicast v4/v6, Flowspec, Link-State, RTC) already has at least one of the two guards — verified in the audit.

## Test plan

- New `withdraw_removed_flag_gates_reflection` (SR-Policy): absent-policy / absent-candidate / re-withdraw all return `removed=false`.
- MUP validated end-to-end: `bgp_mup_peerdown` confirms **legitimate** withdraws still propagate through the Adj-RIB-Out gate; `bgp_mup_dual_st` / `bgp_mup_e2e` pass.
- `cargo clippy --workspace --all-targets -- -D warnings` clean; `cargo fmt --check` clean; full non-BDD suite green.

Generated with [Claude Code](https://claude.com/claude-code)