### PR TITLE
bgp/mup: correct ST2 route key (reject teid=0, drop endpoint-length)

### DIFF
--- a/crates/bgp-packet/src/attrs/nlri_mup.rs
+++ b/crates/bgp-packet/src/attrs/nlri_mup.rs
@@ -697,8 +697,9 @@ pub struct MupSt1Fields {
 ///     same UE prefix *replaces* the prior one rather than coexisting.
 ///   * DSD (Type 2): the RD + Address (§3.1.2).
 ///   * ST2 (Type 4): the RD + Endpoint Address + architecture-specific
-///     Endpoint Identifier (the TEID), so `endpoint`/`endpoint_len`/`teid`
-///     stay in the key (§3.2.2).
+///     Endpoint Identifier (the TEID), so only `endpoint`/`teid` key it. The
+///     Endpoint *Length* is explicitly excluded from the key (§3.2.2), so it
+///     is not carried here.
 ///
 /// The add-path `id` lives on `BgpRib.remote_id`. Variant declaration order
 /// (`Dsd, Isd, T1st, T2st`) drives the derived `Ord`, so a RIB walk lists
@@ -713,12 +714,12 @@ pub enum MupPrefix {
     /// `prefix` (with the outer RD) keys an ST1; the TEID / QFI / endpoint /
     /// source are off-key path data ([`MupSt1Fields`] on `BgpRib.mup_st1`).
     T1st { prefix: IpNet },
-    /// Type 2 Session Transformed Route (ST2) key (§3.2.2).
-    T2st {
-        endpoint: IpAddr,
-        endpoint_len: u8,
-        teid: u32,
-    },
+    /// Type 2 Session Transformed Route (ST2) key (§3.2.2). Per the draft the
+    /// key is the RD (outer) + Endpoint Address + the architecture-specific
+    /// Endpoint Identifier (the TEID) — the Endpoint *Length* is explicitly
+    /// **not** part of the key, so it is kept only on the wire `MupRoute` and
+    /// re-derived (address bits + a full 32-bit TEID) on reconstruction.
+    T2st { endpoint: IpAddr, teid: u32 },
     /// Unrecognized route type — keyed by its raw type and opaque body so
     /// the RIB never coalesces distinct unknown routes.
     Unknown { route_type: u16, body: Vec<u8> },
@@ -749,17 +750,14 @@ impl MupPrefix {
             // TEID/QFI/endpoint/source are off-key path data, extracted
             // separately via [`MupRoute::st1_fields`].
             MupRoute::T1st { rd, prefix, .. } => (*rd, MupPrefix::T1st { prefix: *prefix }),
+            // §3.2.2: the Endpoint Length is not part of the key — only the
+            // Endpoint Address and the TEID (with the outer RD).
             MupRoute::T2st {
-                rd,
-                endpoint,
-                endpoint_len,
-                teid,
-                ..
+                rd, endpoint, teid, ..
             } => (
                 *rd,
                 MupPrefix::T2st {
                     endpoint: *endpoint,
-                    endpoint_len: *endpoint_len,
                     teid: *teid,
                 },
             ),
@@ -845,18 +843,23 @@ impl MupPrefix {
                     source,
                 }
             }
-            MupPrefix::T2st {
-                endpoint,
-                endpoint_len,
-                teid,
-            } => MupRoute::T2st {
-                id: 0,
-                arch,
-                rd,
-                endpoint: *endpoint,
-                endpoint_len: *endpoint_len,
-                teid: *teid,
-            },
+            // The Endpoint Length is off-key (§3.2.2), so re-derive the
+            // canonical value on reconstruction: the address bits plus a full
+            // 32-bit TEID (64 for IPv4, 160 for IPv6).
+            MupPrefix::T2st { endpoint, teid } => {
+                let endpoint_len = match endpoint {
+                    IpAddr::V4(_) => 64,
+                    IpAddr::V6(_) => 160,
+                };
+                MupRoute::T2st {
+                    id: 0,
+                    arch,
+                    rd,
+                    endpoint: *endpoint,
+                    endpoint_len,
+                    teid: *teid,
+                }
+            }
             MupPrefix::Unknown { route_type, body } => MupRoute::Unknown {
                 id: 0,
                 arch,
@@ -1660,6 +1663,37 @@ mod tests {
                 source: None,
             })
         );
+    }
+
+    #[test]
+    fn st2_route_key_excludes_endpoint_len() {
+        // draft §3.2.2: only the RD + Endpoint Address + TEID key an ST2 — the
+        // Endpoint Length is NOT part of the key. Two ST2 with the same
+        // endpoint + TEID but a different Endpoint Length map to one key.
+        let mk = |endpoint_len| MupRoute::T2st {
+            id: 0,
+            arch: MupArchitectureType::Gpp5g,
+            rd: sample_rd(),
+            endpoint: "10.0.0.1".parse().unwrap(),
+            endpoint_len,
+            teid: 600,
+        };
+        assert_eq!(
+            MupPrefix::from_route(&mk(64)),
+            MupPrefix::from_route(&mk(48)),
+            "Endpoint Length is off-key — same endpoint+TEID ⇒ same key"
+        );
+        assert_eq!(
+            MupPrefix::from_route(&mk(64)).1,
+            MupPrefix::T2st {
+                endpoint: "10.0.0.1".parse().unwrap(),
+                teid: 600,
+            }
+        );
+        // to_route re-derives the canonical Endpoint Length (32 addr + 32 TEID
+        // = 64 for IPv4); the key round-trips regardless of the original length.
+        let (rd, key) = MupPrefix::from_route(&mk(48));
+        assert_eq!(MupPrefix::from_route(&key.to_route(rd)), (rd, key));
     }
 
     #[test]

--- a/zebra-rs/src/bgp/route.rs
+++ b/zebra-rs/src/bgp/route.rs
@@ -7669,6 +7669,16 @@ pub fn route_mup_update(
     let (rd, prefix) = MupPrefix::from_route(route);
     let id = route.add_path_id();
 
+    // draft §3.1.4.1: an ST2 (Type-2 ST) with TEID 0 is malformed. RFC 7606
+    // §7 treat-as-withdraw: drop any stale copy of this key and do not install
+    // it, rather than reset the session. (The TEID is part of the ST2 route
+    // key, so a `teid=0` route would also collapse distinct sessions onto one
+    // key.)
+    if matches!(prefix, MupPrefix::T2st { teid: 0, .. }) {
+        route_mup_withdraw(ident, route, bgp, peers);
+        return;
+    }
+
     let (peer_ident, peer_router_id, typ) = {
         let peer = peers.get_mut_by_idx(ident).expect("peer must exist");
 
@@ -8135,21 +8145,23 @@ pub(super) fn build_mup_st_route(
         // carried no core-side F-TEID (single-endpoint session). The Endpoint
         // Length (§3.1.4.1) spans the address *and* the trailing 32-bit GTP
         // TEID, so it is 64 (IPv4) / 160 (IPv6).
-        MupSrv6Direction::Decapsulation => match session.core_endpoint.or(session.endpoint) {
-            Some(endpoint) => (
-                MupPrefix::T2st {
-                    endpoint,
-                    endpoint_len: if endpoint.is_ipv4() { 64 } else { 160 },
-                    teid: if session.core_teid != 0 {
-                        session.core_teid
-                    } else {
-                        session.teid
-                    },
-                },
-                None,
-            ),
-            None => return None,
-        },
+        MupSrv6Direction::Decapsulation => {
+            let endpoint = session.core_endpoint.or(session.endpoint)?;
+            let teid = if session.core_teid != 0 {
+                session.core_teid
+            } else {
+                session.teid
+            };
+            // draft §3.1.4.1: a TEID of 0 is invalid / malformed. A session
+            // with no usable core (or fallback access) TEID must not originate
+            // an ST2 — a `teid=0` route would be malformed and, because the
+            // TEID is part of the ST2 route key, several such sessions would
+            // collapse onto the single `(endpoint, teid=0)` key.
+            if teid == 0 {
+                return None;
+            }
+            (MupPrefix::T2st { endpoint, teid }, None)
+        }
     };
     let mut attr = BgpAttr::new();
     // §3.3.10: a Type-2 ST route SHOULD carry the BGP MUP Extended Community
@@ -18374,6 +18386,16 @@ mod tests {
             MupPrefix::T2st { endpoint, teid, .. }
                 if endpoint == "10.0.0.1".parse::<std::net::IpAddr>().unwrap() && teid == 0x1234
         ));
+
+        // draft §3.1.4.1: a session with no usable TEID (both core and access
+        // TEID are 0) must NOT originate a malformed `teid=0` ST2.
+        let mut s0 = session(Some(v4), None);
+        s0.teid = 0;
+        s0.core_teid = 0;
+        assert!(
+            super::build_mup_st_route(&s0, MupSrv6Direction::Decapsulation, None).is_none(),
+            "no ST2 for a session with TEID 0 (malformed per draft)"
+        );
     }
 
     // The Segment Discovery NLRI selector: `segment direct` keys a DSD off

--- a/zebra-rs/src/bgp/show.rs
+++ b/zebra-rs/src/bgp/show.rs
@@ -4104,11 +4104,7 @@ fn mup_prefix_display(
             }) => format!("[ST1][{rd}][ue={prefix}][teid={teid}][qfi={qfi}][ep={endpoint}]"),
             None => format!("[ST1][{rd}][ue={prefix}]"),
         },
-        MupPrefix::T2st {
-            endpoint,
-            endpoint_len: _,
-            teid,
-        } => format!("[ST2][{rd}][ep={endpoint}][teid={teid}]"),
+        MupPrefix::T2st { endpoint, teid } => format!("[ST2][{rd}][ep={endpoint}][teid={teid}]"),
         MupPrefix::Unknown { route_type, .. } => format!("[UNKNOWN type {route_type}]"),
     }
 }


### PR DESCRIPTION
## Summary

Two ST2 (Type-2 Session Transformed) **route-key** defects, both surfaced by a VRF MUP RIB showing distinct sessions collapsing onto one key.

**1. TEID 0 is invalid.** draft §3.1.4.1: *"The TEID value of 0 is considered as an invalid and a malformed TEID."* We neither rejected it on receive nor avoided originating it, so a session with no usable TEID produced a `teid=0` ST2 — and because the TEID **is** part of the ST2 key, several such sessions overwrote one another on the single `(RD, endpoint, 0)` key.
- `build_mup_st_route` (Decapsulation) now returns `None` when the resolved TEID is 0.
- `route_mup_update` treats a received `teid=0` ST2 as an **RFC 7606 §7 treat-as-withdraw** (drop any stale copy, do not install) rather than storing it or resetting the session.

**2. Endpoint Length was wrongly part of the key.** draft §3.2.2 keys an ST2 by RD + Endpoint Address + the architecture-specific Endpoint Identifier (the TEID) and **excludes** the Endpoint Length. `MupPrefix::T2st` is reduced from `{ endpoint, endpoint_len, teid }` to `{ endpoint, teid }`; the Endpoint Length stays on the wire `MupRoute` and is re-derived (address bits + a full 32-bit TEID = 64 for IPv4 / 160 for IPv6) on reconstruction. Two ST2 differing only in Endpoint Length now map to one key.

(Verified TEID-in-key and TEID-0-invalid against both the draft and GoBGP.)

## Test plan

- New `st2_route_key_excludes_endpoint_len`: same endpoint+TEID / different Endpoint Length ⇒ one key, and the key round-trips through `to_route`.
- Build-side assertion: a TEID-0 session originates no ST2.
- Valid `teid != 0` ST2 still originate and round-trip peer-to-peer — `bgp_mup_st2` / `bgp_mup_dual_st` BDDs pass; the `[ST2][rd][ep][teid]` show output is unchanged.
- `cargo clippy --workspace --all-targets -- -D warnings` clean; `cargo fmt --check` clean; full non-BDD suite green.

Generated with [Claude Code](https://claude.com/claude-code)