### PR TITLE
bgp/mup: advertise the IPv6 UE /64, not a /128 host route

### DIFF
--- a/bdd/tests/features/bgp_mup_mixed_afi.feature
+++ b/bdd/tests/features/bgp_mup_mixed_afi.feature
@@ -57,7 +57,7 @@ Feature: BGP MUP mixed-AFI Session-Transformed route (IPv6 UE, IPv4 endpoint)
     Given the test topology exists
     When I execute "pfcp-inject --target 192.168.0.1 --port 8805 --ue-ipv6 2001:db8::5 --teid 0x12345678 --endpoint 10.0.0.1 --network-instance access" in namespace "z1"
     Then show command "show bgp mup-c session" in namespace "z1" should eventually contain "2001:db8::5"
-    And show command "show bgp mup" in namespace "z1" should contain "ue=2001:db8::5/128"
+    And show command "show bgp mup" in namespace "z1" should contain "ue=2001:db8::/64"
     And show command "show bgp mup" in namespace "z1" should contain "ep=10.0.0.1"
     # The export route-target comes from the top-level `vrf mobile-up mup
     # route-target export` (the ipv4/ipv6 framework), proving it reaches
@@ -65,8 +65,8 @@ Feature: BGP MUP mixed-AFI Session-Transformed route (IPv6 UE, IPv4 endpoint)
     And show command "show bgp mup" in namespace "z1" should contain "rt:65000:200"
     # Per-VRF MUP view: the global best-path is mirrored into the
     # mobile-up per-VRF task, so `show bgp vrf mobile-up mup` renders it.
-    And show command "show bgp vrf mobile-up mup" in namespace "z1" should contain "ue=2001:db8::5/128"
-    And show command "show bgp mup" in namespace "z2" should eventually contain "ue=2001:db8::5/128"
+    And show command "show bgp vrf mobile-up mup" in namespace "z1" should contain "ue=2001:db8::/64"
+    And show command "show bgp mup" in namespace "z2" should eventually contain "ue=2001:db8::/64"
     And show command "show bgp mup" in namespace "z2" should contain "ep=10.0.0.1"
 
   Scenario: Teardown topology

--- a/zebra-rs/src/bgp/route.rs
+++ b/zebra-rs/src/bgp/route.rs
@@ -8096,9 +8096,17 @@ fn attr_add_ecom(attr: &mut BgpAttr, ecv: ExtCommunityValue) {
 /// prefix carried in a Type-1 Session-Transformed route.
 fn mup_ue_prefix(session: &crate::mup_c::session::MupSession) -> Option<IpNet> {
     if let Some(v4) = session.ue_ipv4 {
+        // 3GPP assigns the UE a single IPv4 address → a /32 host route.
         Ipv4Net::new(v4, 32).ok().map(IpNet::V4)
     } else if let Some(v6) = session.ue_ipv6 {
-        Ipv6Net::new(v6, 128).ok().map(IpNet::V6)
+        // 3GPP assigns each IPv6 PDU session a /64 prefix (RFC 7066 §4.1, TS
+        // 23.501), not a single address — the UE forms its address(es) inside
+        // it via SLAAC. Advertise that /64, masked to the network so it equals
+        // the zero-filled form a *received* prefix parses to (keeping the
+        // ST1 route key stable). The PFCP UE IP Address IE can carry an
+        // explicit IPv6 prefix length, but the `rs-pfcp` codec doesn't expose
+        // it, so /64 (the architecture default) is used.
+        Ipv6Net::new(v6, 64).ok().map(|n| IpNet::V6(n.trunc()))
     } else {
         None
     }
@@ -18317,14 +18325,17 @@ mod tests {
         let v4: Ipv4Addr = "192.0.2.5".parse().unwrap();
         let v6: Ipv6Addr = "2001:db8::5".parse().unwrap();
 
-        // UE host prefix: /32 for v4, /128 for v6, prefer v4, None when absent.
+        // UE prefix: /32 host route for IPv4; the 3GPP-assigned /64 for IPv6
+        // (masked to the network — `2001:db8::5` → `2001:db8::/64`). Prefer
+        // IPv4; None when the session has neither.
         assert_eq!(
             super::mup_ue_prefix(&session(Some(v4), None)),
             "192.0.2.5/32".parse::<ipnet::IpNet>().ok()
         );
         assert_eq!(
             super::mup_ue_prefix(&session(None, Some(v6))),
-            "2001:db8::5/128".parse::<ipnet::IpNet>().ok()
+            "2001:db8::/64".parse::<ipnet::IpNet>().ok(),
+            "IPv6 UE → /64 (RFC 7066), masked to the network"
         );
         assert_eq!(super::mup_ue_prefix(&session(None, None)), None);
 


### PR DESCRIPTION
## Summary

3GPP allocates each IPv6 PDU session a **/64** prefix (RFC 7066 §4.1, TS 23.501) — the UE forms its address(es) inside it via SLAAC — so the ST1/ISD route should carry that **/64**, not a single-address **/128**.

`mup_ue_prefix` originated the IPv6 UE prefix as `/128`. This advertises the **/64** instead, **masked to the network** so it equals the zero-filled form a *received* prefix parses to — which keeps the ST1 route key stable between the originator and its peers. IPv4 stays `/32` (the UE gets a single IPv4 address).

```rust
} else if let Some(v6) = session.ue_ipv6 {
    Ipv6Net::new(v6, 64).ok().map(|n| IpNet::V6(n.trunc()))   // 2001:db8::5 → 2001:db8::/64
}
```

The PFCP UE IP Address IE can carry an explicit IPv6 prefix length, but the `rs-pfcp` codec doesn't expose it, so `/64` (the architecture default) is used — noted at the call site for a future codec upgrade.

## Test plan

- `mup_ue_prefix` unit test now expects `2001:db8::5` → `2001:db8::/64` (masked).
- `bgp_mup_mixed_afi` BDD updated to assert `ue=2001:db8::/64` and **passes end-to-end** — z1 originates it, z2 parses it off the wire.
- `cargo clippy --workspace --all-targets -- -D warnings` clean; `cargo fmt --check` clean; full non-BDD suite green (39 mup tests).

(Other `/128` occurrences — router loopbacks in configs, bgp-packet parser/show tests using hand-built prefixes — are unaffected: the parser/render still handle any prefix length; only the origination default changed.)

Generated with [Claude Code](https://claude.com/claude-code)