### PR TITLE
bgp/mup: ST2 core TEID resolution (drop access fallback, upf-teid, self-alloc)

### DIFF
--- a/bdd/tests/features/bgp_mup_dynamic_rt.feature
+++ b/bdd/tests/features/bgp_mup_dynamic_rt.feature
@@ -61,7 +61,7 @@ Feature: BGP MUP export route-target applies dynamically to an originated ST rou
 
   Scenario: Originate an ST2 with no export RT, then apply the export RT dynamically
     Given the test topology exists
-    When I execute "pfcp-inject --target 192.168.0.1 --port 8805 --ue-ipv4 192.0.2.5 --teid 0x12345678 --endpoint 10.0.0.1 --network-instance core" in namespace "z1"
+    When I execute "pfcp-inject --target 192.168.0.1 --port 8805 --ue-ipv4 192.0.2.5 --teid 0x12345678 --endpoint 10.0.0.1 --core-endpoint 10.0.0.1 --core-teid 0x12345678 --network-instance core" in namespace "z1"
     # PFCP ingest learned the session and z1 originated the ST2 — carrying
     # the Direct segment id (mup:1:2) but NO route-target yet.
     Then show command "show bgp mup-c session" in namespace "z1" should eventually contain "192.0.2.5"

--- a/bdd/tests/features/bgp_mup_interwork.feature
+++ b/bdd/tests/features/bgp_mup_interwork.feature
@@ -47,7 +47,7 @@ Feature: BGP MUP interwork node resolves ST2 to the Direct segment
 
   Scenario: z1 originates the DSD and (from PFCP) the ST2, both with id 1:2
     Given the test topology exists
-    When I execute "pfcp-inject --target 127.0.0.1 --port 8805 --ue-ipv4 192.0.2.5 --teid 0x12345678 --endpoint 10.0.0.1 --network-instance core" in namespace "z1"
+    When I execute "pfcp-inject --target 127.0.0.1 --port 8805 --ue-ipv4 192.0.2.5 --teid 0x12345678 --endpoint 10.0.0.1 --core-endpoint 10.0.0.1 --core-teid 0x12345678 --network-instance core" in namespace "z1"
     Then show command "show bgp mup" in namespace "z1" should eventually contain "[DSD][65501:10][10.0.0.1]"
     And show command "show bgp mup" in namespace "z1" should eventually contain "[ST2][65501:10][ep=10.0.0.1][teid=305419896]"
     # z1 is a `segment direct` node, not interwork, so it shows no resolution.

--- a/bdd/tests/features/bgp_mup_st2.feature
+++ b/bdd/tests/features/bgp_mup_st2.feature
@@ -58,7 +58,7 @@ Feature: BGP MUP Controller originates a Type-2 ST route from a PFCP session
 
   Scenario: PFCP session establishment originates an ST2 route received by the peer
     Given the test topology exists
-    When I execute "pfcp-inject --target 192.168.0.1 --port 8805 --ue-ipv4 192.0.2.5 --teid 0x12345678 --endpoint 10.0.0.1 --network-instance core" in namespace "z1"
+    When I execute "pfcp-inject --target 192.168.0.1 --port 8805 --ue-ipv4 192.0.2.5 --teid 0x12345678 --endpoint 10.0.0.1 --core-endpoint 10.0.0.1 --core-teid 0x12345678 --network-instance core" in namespace "z1"
     # PFCP ingest learned the session.
     Then show command "show bgp mup-c session" in namespace "z1" should eventually contain "192.0.2.5"
     # z1 originates the Type-2 ST: core endpoint + the full 32-bit GTP TEID

--- a/bdd/tests/features/bgp_mup_st2_dsd_fib.feature
+++ b/bdd/tests/features/bgp_mup_st2_dsd_fib.feature
@@ -46,7 +46,7 @@ Feature: BGP MUP interwork node installs the ST2->DSD SRv6 encap
 
   Scenario: z2 resolves the ST2 to z1's Direct segment and installs the encap
     Given the test topology exists
-    When I execute "pfcp-inject --target 127.0.0.1 --port 8805 --ue-ipv4 192.0.2.5 --teid 0x12345678 --endpoint 10.0.0.1 --network-instance core" in namespace "z1"
+    When I execute "pfcp-inject --target 127.0.0.1 --port 8805 --ue-ipv4 192.0.2.5 --teid 0x12345678 --endpoint 10.0.0.1 --core-endpoint 10.0.0.1 --core-teid 0x12345678 --network-instance core" in namespace "z1"
     # z2 imports the ST2 + DSD into VRF N6 (re-keyed under its own rd) and
     # resolves the ST2 to the DSD's End.DT46 segment by the id 1:2.
     Then show command "show bgp vrf N6 mup" in namespace "z2" should eventually contain "[ST2][65501:20][ep=10.0.0.1]"

--- a/zebra-rs/src/bgp/config.rs
+++ b/zebra-rs/src/bgp/config.rs
@@ -1958,6 +1958,14 @@ fn config_mup_c_upf_address(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Opti
     Some(())
 }
 
+/// `… mup-c upf-teid <u32>` — Core (N6) TEID paired with `upf-address` for ST2
+/// routes when the session carries no core-side F-TEID.
+fn config_mup_c_upf_teid(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Option<()> {
+    bgp.mup_c_config.upf_teid = if op.is_set() { Some(args.u32()?) } else { None };
+    bgp.mup_c_dirty = true;
+    Some(())
+}
+
 /// `… mup-c pfcp node-id <ip>` — our PFCP Node ID for responses.
 fn config_mup_c_pfcp_node_id(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Option<()> {
     bgp.mup_c_config.node_id = if op.is_set() {
@@ -4514,6 +4522,7 @@ impl Bgp {
             config_mup_c_controller_address,
         );
         self.callback_add("/router/bgp/mup-c/upf-address", config_mup_c_upf_address);
+        self.callback_add("/router/bgp/mup-c/upf-teid", config_mup_c_upf_teid);
         self.callback_add("/router/bgp/mup-c/pfcp/node-id", config_mup_c_pfcp_node_id);
         self.callback_add(
             "/router/bgp/mup-c/pfcp/listen-address",
@@ -8109,13 +8118,14 @@ mod mup_dual_origination_tests {
         assert!(matches!(p1, MupPrefix::T1st { .. }), "st1 → Type-1 ST");
         assert!(attr1.ecom.is_none(), "st1 carries no ext-comm");
 
+        // ST2 needs a real core tunnel (endpoint + non-zero TEID); it never
+        // borrows the access tunnel.
         let seg = RouteDistinguisher::from_str("100:1").unwrap();
-        let (p2, _st1, attr2) = build_mup_st_route(
-            &session("internet"),
-            MupSrv6Direction::Decapsulation,
-            Some(seg),
-        )
-        .unwrap();
+        let mut s2 = session("internet");
+        s2.core_endpoint = Some("10.9.0.1".parse().unwrap());
+        s2.core_teid = 0x9999;
+        let (p2, _st1, attr2) =
+            build_mup_st_route(&s2, MupSrv6Direction::Decapsulation, Some(seg)).unwrap();
         assert!(matches!(p2, MupPrefix::T2st { .. }), "st2 → Type-2 ST");
         assert!(
             attr2.ecom.is_some(),

--- a/zebra-rs/src/bgp/route.rs
+++ b/zebra-rs/src/bgp/route.rs
@@ -8154,21 +8154,25 @@ pub(super) fn build_mup_st_route(
         // Length (§3.1.4.1) spans the address *and* the trailing 32-bit GTP
         // TEID, so it is 64 (IPv4) / 160 (IPv6).
         MupSrv6Direction::Decapsulation => {
-            let endpoint = session.core_endpoint.or(session.endpoint)?;
-            let teid = if session.core_teid != 0 {
-                session.core_teid
-            } else {
-                session.teid
-            };
-            // draft §3.1.4.1: a TEID of 0 is invalid / malformed. A session
-            // with no usable core (or fallback access) TEID must not originate
-            // an ST2 — a `teid=0` route would be malformed and, because the
-            // TEID is part of the ST2 route key, several such sessions would
-            // collapse onto the single `(endpoint, teid=0)` key.
-            if teid == 0 {
+            // ST2 is the core / uplink decapsulation route: it must carry the
+            // *core* GTP tunnel — endpoint + TEID from a `Dest=Core` FAR Outer
+            // Header Creation (an N9 tunnel) or the configured `upf-address` /
+            // `upf-teid`. It must NOT borrow the access (gNB) tunnel: that is
+            // the wrong direction, and `session.teid` (the gNB *downlink*
+            // F-TEID) is 0 whenever the access tunnel isn't currently
+            // programmed. So a session with no core endpoint, or a core TEID
+            // of 0 (invalid per draft §3.1.4.1), originates no ST2.
+            let endpoint = session.core_endpoint?;
+            if session.core_teid == 0 {
                 return None;
             }
-            (MupPrefix::T2st { endpoint, teid }, None)
+            (
+                MupPrefix::T2st {
+                    endpoint,
+                    teid: session.core_teid,
+                },
+                None,
+            )
         }
     };
     let mut attr = BgpAttr::new();
@@ -18376,8 +18380,7 @@ mod tests {
         );
         assert_eq!(st1.teid, 0x1234);
 
-        // Type-2 (Decapsulation) uses the *core-side* endpoint/TEID when the
-        // session carries one — distinct from the Type-1 access endpoint.
+        // Type-2 (Decapsulation) carries the *core-side* endpoint/TEID only.
         let mut s2 = session(Some(v4), None);
         s2.core_endpoint = Some("10.9.0.1".parse().unwrap());
         s2.core_teid = 0x9999;
@@ -18385,27 +18388,31 @@ mod tests {
             super::build_mup_st_route(&s2, MupSrv6Direction::Decapsulation, None)
                 .unwrap()
                 .0,
-            MupPrefix::T2st { endpoint, teid, .. }
+            MupPrefix::T2st { endpoint, teid }
                 if endpoint == "10.9.0.1".parse::<std::net::IpAddr>().unwrap() && teid == 0x9999
         ));
 
-        // Falls back to the access endpoint/TEID when no core-side F-TEID.
-        assert!(matches!(
-            super::build_mup_st_route(&session(Some(v4), None), MupSrv6Direction::Decapsulation, None)
-                .unwrap()
-                .0,
-            MupPrefix::T2st { endpoint, teid, .. }
-                if endpoint == "10.0.0.1".parse::<std::net::IpAddr>().unwrap() && teid == 0x1234
-        ));
+        // No core-side tunnel → no ST2. The access (gNB) endpoint/TEID is never
+        // borrowed — `session(Some(v4), None)` has only an access tunnel.
+        assert!(
+            super::build_mup_st_route(
+                &session(Some(v4), None),
+                MupSrv6Direction::Decapsulation,
+                None
+            )
+            .is_none(),
+            "no ST2 for a session without a core tunnel"
+        );
 
-        // draft §3.1.4.1: a session with no usable TEID (both core and access
-        // TEID are 0) must NOT originate a malformed `teid=0` ST2.
+        // A core endpoint with TEID 0 is still no ST2 (draft §3.1.4.1) — and a
+        // core TEID is never faked from the access TEID.
         let mut s0 = session(Some(v4), None);
-        s0.teid = 0;
+        s0.core_endpoint = Some("10.9.0.1".parse().unwrap());
         s0.core_teid = 0;
+        s0.teid = 0x1234; // access TEID present but must NOT be used
         assert!(
             super::build_mup_st_route(&s0, MupSrv6Direction::Decapsulation, None).is_none(),
-            "no ST2 for a session with TEID 0 (malformed per draft)"
+            "no ST2 when the core TEID is 0, even with an access TEID"
         );
     }
 

--- a/zebra-rs/src/config/manager.rs
+++ b/zebra-rs/src/config/manager.rs
@@ -3367,10 +3367,12 @@ mod yang_load_tests {
             .expect("configure module present");
         let entry = to_entry(&yang, module);
 
-        // `mup-c upf-address` accepts both IPv4 and IPv6 (inet:ip-address).
+        // `mup-c upf-address` accepts both IPv4 and IPv6 (inet:ip-address);
+        // `mup-c upf-teid` is a uint32.
         for path in [
             "set router bgp mup-c upf-address 10.100.0.1",
             "set router bgp mup-c upf-address 2001:db8::1",
+            "set router bgp mup-c upf-teid 305419896",
         ] {
             let (code, _comps, _state) = parse(path, entry.clone(), None, State::new());
             assert_eq!(code, ExecCode::Success, "`{path}` must be a settable path");

--- a/zebra-rs/src/mup-c/inst.rs
+++ b/zebra-rs/src/mup-c/inst.rs
@@ -33,9 +33,12 @@ pub struct MupCConfig {
     /// learned session carries no core-side GTP tunnel (the N6-breakout case).
     /// A session that learns a core F-TEID over PFCP keeps that in preference.
     pub upf_address: Option<IpAddr>,
-    /// Core (N6) GTP-U TEID paired with [`Self::upf_address`], used as the ST2
-    /// route TEID when the session carries no core-side F-TEID. An ST2 needs a
-    /// (non-zero) core TEID; without a learned or configured one, no ST2.
+    /// Core (N6/N9) GTP-U TEID paired with [`Self::upf_address`], used as the
+    /// ST2 route TEID when the session carries no learned core-side F-TEID.
+    /// When neither is set (or the configured TEID is 0), MUP-U acts as the
+    /// anchor UPF and self-allocates its own core receive F-TEID, so an ST2
+    /// still originates (a real UPF owns the TEIDs of the tunnels it
+    /// terminates).
     pub upf_teid: Option<u32>,
     /// Our PFCP Node ID, used in responses. Falls back to the bind
     /// address / `controller_address` when unset.

--- a/zebra-rs/src/mup-c/inst.rs
+++ b/zebra-rs/src/mup-c/inst.rs
@@ -33,6 +33,10 @@ pub struct MupCConfig {
     /// learned session carries no core-side GTP tunnel (the N6-breakout case).
     /// A session that learns a core F-TEID over PFCP keeps that in preference.
     pub upf_address: Option<IpAddr>,
+    /// Core (N6) GTP-U TEID paired with [`Self::upf_address`], used as the ST2
+    /// route TEID when the session carries no core-side F-TEID. An ST2 needs a
+    /// (non-zero) core TEID; without a learned or configured one, no ST2.
+    pub upf_teid: Option<u32>,
     /// Our PFCP Node ID, used in responses. Falls back to the bind
     /// address / `controller_address` when unset.
     pub node_id: Option<IpAddr>,

--- a/zebra-rs/src/mup-c/pfcp.rs
+++ b/zebra-rs/src/mup-c/pfcp.rs
@@ -274,9 +274,14 @@ impl MupC {
         };
         // N6-breakout fallback: a session with no core-side GTP tunnel (the
         // common case — the SMF programs only the access/gNB tunnel) has no
-        // Type-2 ST endpoint. Use the configured Core (N6) UPF address so an
-        // ST2 route can still be originated toward the anchor UPF.
+        // core-side endpoint/TEID, so an ST2 could not be originated. Use the
+        // configured Core (N6) `upf-address` + `upf-teid` so an ST2 can still
+        // be built toward the anchor UPF; a learned core F-TEID takes
+        // precedence over both.
         session.core_endpoint = session.core_endpoint.or(self.config.upf_address);
+        if session.core_teid == 0 {
+            session.core_teid = self.config.upf_teid.unwrap_or(0);
+        }
         self.sessions.insert(session.clone());
 
         let local_ip = self.local_ip();
@@ -998,11 +1003,13 @@ mod tests {
     }
 
     /// N6 breakout: a session with only an access/gNB tunnel (no core-side
-    /// F-TEID) gets its Type-2 ST endpoint from the configured `upf-address`.
+    /// F-TEID) gets its Type-2 ST endpoint AND TEID from the configured
+    /// `upf-address` / `upf-teid` (both are needed for an ST2).
     #[test]
     fn upf_address_fills_core_endpoint_for_n6_breakout() {
         let cfg = MupCConfig {
             upf_address: Some(IpAddr::V4(Ipv4Addr::new(10, 100, 0, 1))),
+            upf_teid: Some(0x0102_0304),
             ..Default::default()
         };
         let (mut mupc, _bgp_rx) = MupC::new_for_test(cfg);
@@ -1019,7 +1026,11 @@ mod tests {
             Some(IpAddr::V4(Ipv4Addr::new(10, 100, 0, 1))),
             "no core tunnel → ST2 endpoint from configured upf-address"
         );
-        // The gNB (access) side is unaffected.
+        assert_eq!(
+            session.core_teid, 0x0102_0304,
+            "no core F-TEID → ST2 TEID from configured upf-teid"
+        );
+        // The gNB (access) side is unaffected (and is NOT copied to the core).
         assert_eq!(
             session.endpoint,
             Some(IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1)))

--- a/zebra-rs/src/mup-c/pfcp.rs
+++ b/zebra-rs/src/mup-c/pfcp.rs
@@ -272,15 +272,34 @@ impl MupC {
             network_instance: ex.network_instance,
             qfi: None,
         };
-        // N6-breakout fallback: a session with no core-side GTP tunnel (the
-        // common case — the SMF programs only the access/gNB tunnel) has no
-        // core-side endpoint/TEID, so an ST2 could not be originated. Use the
-        // configured Core (N6) `upf-address` + `upf-teid` so an ST2 can still
-        // be built toward the anchor UPF; a learned core F-TEID takes
-        // precedence over both.
-        session.core_endpoint = session.core_endpoint.or(self.config.upf_address);
+        // Core (N9) tunnel for the ST2 (decapsulation / uplink) route. Its
+        // endpoint + TEID identify the *core* GTP-U tunnel uplink traffic is
+        // decapsulated toward; the access/gNB tunnel is never borrowed (wrong
+        // direction). Resolved in three tiers, most-specific first, endpoint
+        // and TEID independently:
+        //   1. learned over PFCP — a Dest = Core FAR Outer Header Creation, a
+        //      real N9 tunnel to a downstream anchor. Already on the session.
+        //   2. the statically configured anchor: `upf-address` + `upf-teid`.
+        //   3. self-allocated — MUP-U *is* the anchor UPF, so it owns the core
+        //      receive F-TEID: its own address (`local_ip`) plus a fresh TEID
+        //      from the same pool as the N3 F-TEID. A real UPF allocates the
+        //      TEIDs of the tunnels it terminates; today (control-plane only)
+        //      this is a nominal value like the N3 one, and a real datapath
+        //      must install it. `local_ip` mirrors the N3 F-TEID's address; a
+        //      full deployment would use the interwork gateway's N9 endpoint
+        //      (a future config knob).
+        // teid 0 is the null TEID and never a valid tunnel, so a learned or
+        // configured 0 self-allocates too — an ST2 always carries a non-zero
+        // core TEID.
+        session.core_endpoint = session
+            .core_endpoint
+            .or(self.config.upf_address)
+            .or(Some(self.local_ip()));
         if session.core_teid == 0 {
-            session.core_teid = self.config.upf_teid.unwrap_or(0);
+            session.core_teid = match self.config.upf_teid {
+                Some(teid) if teid != 0 => teid,
+                _ => self.sessions.alloc_teid(),
+            };
         }
         self.sessions.insert(session.clone());
 
@@ -1056,6 +1075,37 @@ mod tests {
             session.core_endpoint,
             Some(IpAddr::V4(Ipv4Addr::new(10, 9, 0, 1))),
             "learned core F-TEID wins over configured upf-address"
+        );
+    }
+
+    /// MUP-U as the anchor UPF: a session with no learned core F-TEID and no
+    /// configured `upf-address`/`upf-teid` still originates an ST2 — the UPF
+    /// allocates its own core receive F-TEID (a non-zero TEID at its own
+    /// `local_ip`), just as it allocates the N3 F-TEID. It is never borrowed
+    /// from the access/gNB tunnel.
+    #[test]
+    fn anchor_upf_self_allocates_core_teid() {
+        let (mut mupc, _bgp_rx) = MupC::new_for_test(MupCConfig::default());
+        associate(&mut mupc);
+        // A gNB tunnel (access teid 0x1234_5678) but no core tunnel, and no
+        // upf-address / upf-teid configured.
+        let est = message::parse(&establishment_bytes()).unwrap();
+        let (_reply, events) = mupc.handle_session_establishment(est.as_ref(), peer());
+        let MupCEvent::SessionUp(session) = &events[0] else {
+            panic!("expected SessionUp");
+        };
+        assert_ne!(
+            session.core_teid, 0,
+            "anchor UPF self-allocates a non-zero core F-TEID for the ST2"
+        );
+        assert_eq!(
+            session.core_endpoint,
+            Some(IpAddr::V4(Ipv4Addr::LOCALHOST)),
+            "self-allocated core tunnel terminates at the UPF's own address"
+        );
+        assert_ne!(
+            session.core_teid, session.teid,
+            "core F-TEID is self-allocated, not copied from the access tunnel"
         );
     }
 

--- a/zebra-rs/yang/zebra-bgp-mup-controller.yang
+++ b/zebra-rs/yang/zebra-bgp-mup-controller.yang
@@ -89,7 +89,20 @@ module zebra-bgp-mup-controller {
            no core-side GTP tunnel (the common N6-breakout case, where the
            SMF programs only the access/gNB tunnel). A session that does
            learn a core-facing F-TEID over PFCP (e.g. an N9 tunnel) keeps
-           that learned endpoint in preference to this configured one.";
+           that learned endpoint in preference to this configured one.
+           Pair with `upf-teid`: an ST2 needs both a core endpoint and a
+           (non-zero) core TEID to be originated.";
+      }
+
+      leaf upf-teid {
+        type uint32;
+        description
+          "Core (N6) GTP-U TEID paired with `upf-address`. Used as the ST2
+           route TEID when the PFCP session carries no core-side F-TEID. An
+           ST2 is a core/uplink route, so it never borrows the access (gNB)
+           tunnel's TEID; without a learned or configured core TEID no ST2 is
+           originated. A learned core F-TEID takes precedence. A TEID of 0 is
+           invalid (draft §3.1.4.1) and yields no ST2.";
       }
 
       container pfcp {


### PR DESCRIPTION
## Summary

An **ST2** (Type-2 Session Transformed / decapsulation) route is the **core / uplink** route, so its TEID must identify the **core** GTP tunnel — never the access (gNB) tunnel. This PR makes the ST2 core-tunnel resolution correct and complete.

`build_mup_st_route` (Decapsulation) previously fell back to `session.teid` when the session carried no core F-TEID. After the FAR-OHC sourcing change (#1765), `session.teid` is the gNB **downlink** F-TEID, so that fallback advertised the **wrong tunnel/direction** and was **0** whenever the access tunnel wasn't programmed (establishment, decap-only session, or after AN-release deactivation) — collapsing distinct sessions onto one `(RD, endpoint, 0)` key.

The core (N9) tunnel for an ST2 now resolves in three tiers, endpoint and TEID independently, most-specific first:

| tier | endpoint | TEID |
|---|---|---|
| 1. learned | Dest=Core FAR OHC (real N9 tunnel) | learned F-TEID |
| 2. configured | `upf-address` (#1767) | `upf-teid` (new) |
| 3. self-allocated | MUP-U's own `local_ip` | fresh TEID from the N3 pool |

- **Drop the access fallback:** ST2 never borrows the access/gNB TEID (wrong direction). A genuine `teid=0` never originates (draft §3.1.4.1: the null TEID is invalid).
- **`router bgp mup-c upf-teid <u32>`:** pairs with `upf-address` for a statically configured anchor.
- **Self-allocation (tier 3):** MUP-U *is* the anchor UPF, so it owns its core receive F-TEID — a real UPF allocates the TEIDs of the tunnels it terminates. So an ST2 **always** carries a non-zero core TEID even with no learned tunnel and no config. A learned/configured `teid=0` self-allocates too.

As with the N3 F-TEID (#1766), the self-allocated core TEID is a nominal control-plane value today; a real MUP-U datapath must install it as forwarding state and learn peer TEIDs over PFCP.

## Test plan

- `build_mup_st_route` Decapsulation: no-core / core-teid-0 ⇒ no ST2; access TEID never borrowed.
- `anchor_upf_self_allocates_core_teid`: no config, no learned core ⇒ non-zero core TEID at `local_ip`, distinct from the access tunnel.
- `upf_address_fills_core_endpoint_for_n6_breakout`: `upf-teid` fills `core_teid`; `learned_core_endpoint_beats_upf_address`: learned wins.
- yang-load guard for `set router bgp mup-c upf-teid`.
- The four ST2 BDDs that relied on the access fallback now inject a real core tunnel (`--core-endpoint 10.0.0.1 --core-teid 0x12345678`); assertions unchanged. **All five ST2 BDDs pass end-to-end** (`st2`, `interwork`, `dynamic_rt`, `dual_st`, `st2_dsd_fib`).
- `cargo clippy --workspace --all-targets -- -D warnings` clean; `cargo fmt --check` clean; full non-BDD suite green (1527 bin tests).

Generated with [Claude Code](https://claude.com/claude-code)