### PR TITLE
bdd/mup: End.DT46 dataplane forwarding BDD + Plan A doc fix

### DIFF
--- a/bdd/Makefile
+++ b/bdd/Makefile
@@ -67,6 +67,16 @@ bgp_mup_st2_dsd_fib:
 	mkdir -p allure-results
 	cargo test --test cucumber -- --concurrency=1 --tags "@bgp_mup_st2_dsd_fib"
 
+# MUP End.DT46 dataplane forwarding: two collocated UPF+interwork nodes each
+# originate an ST2 (endpoint = a host behind it) + a DSD from a PFCP session,
+# import the other's, and install the ST2->DSD encap. A bidirectional ceA<->ceB
+# ping then traverses the MUP End.DT46 datapath both ways (real traffic, the
+# forwarding counterpart of bgp_mup_st2_dsd_fib). Needs `pfcp-inject` on the
+# host PATH + root netns (kernel VRF + seg6 + IS-IS SRv6 underlay).
+bgp_mup_forwarding:
+	mkdir -p allure-results
+	cargo test --test cucumber -- --concurrency=1 --tags "@bgp_mup_forwarding"
+
 # MUP ST2: the MUP-C learns a PFCP decapsulation session (Network Instance
 # `core`) and originates a Type-2 Session-Transformed route carrying the
 # core endpoint + GTP TEID and the Direct segment id (MUP Extended

--- a/bdd/tests/configs/bgp_mup_forwarding/z1.yaml
+++ b/bdd/tests/configs/bgp_mup_forwarding/z1.yaml
@@ -1,0 +1,91 @@
+# z1 — MUP anchor / UPF + interwork node A (combined MUP-C + forwarding).
+# From a PFCP session on NI `core` it originates a Type-2 ST (ST2) route whose
+# endpoint is ceA (10.10.1.2, a host in VRF N6 behind z1) plus a Direct Segment
+# Discovery (DSD, id 1:1) carrying the per-VRF End.DT46 SID from LOC1. It
+# imports z2's DSD+ST2 (id 2:2) and installs the ST2->DSD encap for ceB
+# (10.20.2.2 -> H.Encaps toward z2's End.DT46 SID, resolved through the IS-IS
+# SRv6 underlay). So ceA->ceB uplink traffic rides the SRv6 core End.DT46
+# datapath, and z1 decapsulates ceB->ceA traffic into VRF N6 for local delivery
+# to ceA. A bidirectional ceA<->ceB ping therefore traverses the MUP End.DT46
+# datapath in both directions (ST2->DSD), using only MUP-installed routes (no
+# static/redistribute). zebra-rs uses End.DT46 as the kernel stand-in for the
+# GTP-U edge behaviours (deferred to a VPP/eBPF forwarder).
+vrf:
+- name: N6
+  mup:
+    route-target:
+      export:
+      - "65501:10"
+      import:
+      - "65501:20"
+interface:
+- if-name: lo
+  ipv6:
+    address: 2001:db8::1/128
+- if-name: z1-z2
+  ipv6:
+    address: 2001:db8:0:12::1/64
+- if-name: ce1
+  vrf: N6
+  ipv4:
+    address: 10.10.1.1/24
+segment-routing:
+  locator:
+  - name: LOC1
+    prefix: fcbb:bbbb:1::/48
+    behavior: usid
+router:
+  isis:
+    net: 49.0000.0000.0000.0001.00
+    hostname: z1
+    is-type: level-2-only
+    segment-routing:
+      srv6:
+        locator: LOC1
+    interface:
+    - if-name: lo
+      ipv6:
+        enable: true
+    - if-name: z1-z2
+      network-type: point-to-point
+      metric: 1
+      ipv6:
+        enable: true
+  bgp:
+    global:
+      as: 65501
+      router-id: 10.0.0.1
+    timer:
+      adv-interval:
+        ibgp: 1
+    segment-routing:
+      srv6:
+        locator: LOC1
+    neighbor:
+    - remote-address: 2001:db8::2
+      remote-as: 65501
+      update-source: 2001:db8::1
+      enabled: true
+      afi-safi:
+      - name: mup
+        enabled: true
+    vrf:
+    - name: N6
+      rd: "65501:10"
+      encapsulation: srv6
+      afi-safi:
+        mup:
+          segment:
+          - type: direct
+            mup-ext-comm: "1:1"
+          route:
+          - type: st2
+            network-instance: core
+            mup-ext-comm: "1:1"
+    mup-c:
+      enable: true
+      controller-address: 2001:db8::1
+      pfcp:
+        listen-address: 127.0.0.1
+      srv6:
+        locator: LOC1

--- a/bdd/tests/configs/bgp_mup_forwarding/z2.yaml
+++ b/bdd/tests/configs/bgp_mup_forwarding/z2.yaml
@@ -1,0 +1,85 @@
+# z2 — MUP anchor / UPF + interwork node B (mirror of z1). From a PFCP session
+# on NI `core` it originates an ST2 whose endpoint is ceB (10.20.2.2, a host in
+# VRF N6 behind z2) plus a DSD (id 2:2) carrying the per-VRF End.DT46 SID from
+# LOC2. It imports z1's DSD+ST2 (id 1:1) and installs the ST2->DSD encap for
+# ceA (10.10.1.2 -> H.Encaps toward z1's End.DT46 SID). Together with z1 this
+# closes a bidirectional ceA<->ceB End.DT46 datapath (ST2->DSD both ways).
+vrf:
+- name: N6
+  mup:
+    route-target:
+      export:
+      - "65501:20"
+      import:
+      - "65501:10"
+interface:
+- if-name: lo
+  ipv6:
+    address: 2001:db8::2/128
+- if-name: z2-z1
+  ipv6:
+    address: 2001:db8:0:12::2/64
+- if-name: ce2
+  vrf: N6
+  ipv4:
+    address: 10.20.2.1/24
+segment-routing:
+  locator:
+  - name: LOC2
+    prefix: fcbb:bbbb:2::/48
+    behavior: usid
+router:
+  isis:
+    net: 49.0000.0000.0000.0002.00
+    hostname: z2
+    is-type: level-2-only
+    segment-routing:
+      srv6:
+        locator: LOC2
+    interface:
+    - if-name: lo
+      ipv6:
+        enable: true
+    - if-name: z2-z1
+      network-type: point-to-point
+      metric: 1
+      ipv6:
+        enable: true
+  bgp:
+    global:
+      as: 65501
+      router-id: 10.0.0.2
+    timer:
+      adv-interval:
+        ibgp: 1
+    segment-routing:
+      srv6:
+        locator: LOC2
+    neighbor:
+    - remote-address: 2001:db8::1
+      remote-as: 65501
+      update-source: 2001:db8::2
+      enabled: true
+      afi-safi:
+      - name: mup
+        enabled: true
+    vrf:
+    - name: N6
+      rd: "65501:20"
+      encapsulation: srv6
+      afi-safi:
+        mup:
+          segment:
+          - type: direct
+            mup-ext-comm: "2:2"
+          route:
+          - type: st2
+            network-instance: core
+            mup-ext-comm: "2:2"
+    mup-c:
+      enable: true
+      controller-address: 2001:db8::2
+      pfcp:
+        listen-address: 127.0.0.1
+      srv6:
+        locator: LOC2

--- a/bdd/tests/features/bgp_mup_forwarding.feature
+++ b/bdd/tests/features/bgp_mup_forwarding.feature
@@ -1,0 +1,87 @@
+@serial
+@bgp_mup_forwarding
+Feature: BGP MUP End.DT46 datapath forwards real traffic (ST2 -> DSD)
+  Two combined MUP UPF + interwork nodes (z1, z2) each terminate a PFCP
+  session (NI `core`) and originate a Type-2 Session-Transformed (ST2) route
+  whose endpoint is a host behind it (ceA behind z1, ceB behind z2), plus a
+  Direct Segment Discovery (DSD) route carrying the per-VRF End.DT46 SID
+  (draft-ietf-bess-mup-safi, SAFI 85). Each imports the other's DSD + ST2 and
+  resolves them by Direct-segment id (MUP Extended Community), installing an
+  SRv6 H.Encaps route for the remote ST2 endpoint toward the remote End.DT46
+  SID, resolved through the IS-IS SRv6 underlay. So a bidirectional ceA<->ceB
+  ping traverses the MUP End.DT46 datapath in BOTH directions using only
+  MUP-installed routes — the forwarding counterpart of bgp_mup_st2_dsd_fib
+  (which asserts the install; this drives real packets through it).
+
+  zebra-rs uses End.DT46 as the mainline-kernel stand-in for the draft's
+  GTP-U edge behaviours (GTP4.E / H.M.GTP4.D), which need a VPP/eBPF forwarder
+  (see docs/design/bgp-mup-dataplane-plan.md, Plan A). Because a VRF binds a
+  single MUP direction, one bidirectional subscriber path is realized by two
+  collocated nodes (each an ST2 anchor for its own host), not one.
+
+  Test Topology:
+  ```
+        2001:db8::1/128            2001:db8::2/128
+   ceA ─┤    z1    │══ IS-IS L2 ══│    z2    ├─ ceB
+ 10.10.1.2  UPF+MUP-C  SRv6+iBGP   UPF+MUP-C  10.20.2.2
+   /24  │ VRF N6   │   (mup)      │ VRF N6   │  /24
+        └──────────┘              └──────────┘
+   z1-z2 2001:db8:0:12::1/64  2001:db8:0:12::2/64
+  ```
+
+  NOTE: needs `pfcp-inject` on the BDD host PATH and root netns (kernel VRF +
+  seg6 + IS-IS SRv6 underlay).
+
+  Scenario: Build topology and establish iBGP with the MUP capability
+    Given a clean test environment
+    When I create namespace "z1"
+    And I create namespace "z2"
+    And I create namespace "ceA"
+    And I create namespace "ceB"
+    And I connect namespace "z1" interface "z1-z2" to namespace "z2" interface "z2-z1"
+    And I connect namespace "z1" interface "ce1" to namespace "ceA" interface "eth0"
+    And I connect namespace "z2" interface "ce2" to namespace "ceB" interface "eth0"
+    And I add address "10.10.1.2/24" to interface "eth0" in namespace "ceA"
+    And I add address "10.20.2.2/24" to interface "eth0" in namespace "ceB"
+    And I add route "0.0.0.0/0" via "10.10.1.1" in namespace "ceA"
+    And I add route "0.0.0.0/0" via "10.20.2.1" in namespace "ceB"
+    And I start zebra-rs in namespace "z1"
+    And I start zebra-rs in namespace "z2"
+    And I apply config "z1.yaml" to namespace "z1"
+    And I apply config "z2.yaml" to namespace "z2"
+    And I wait 45 seconds
+    Then BGP session in "z1" to "2001:db8::2" should be "Established"
+    And BGP session in "z2" to "2001:db8::1" should be "Established"
+
+  Scenario: Each node resolves the peer ST2 to its DSD and installs the encap
+    Given the test topology exists
+    # z1 anchors ceA (10.10.1.2); z2 anchors ceB (10.20.2.2). Each originates
+    # its ST2 (endpoint = its host) + a DSD, from a PFCP session on NI `core`.
+    When I execute "pfcp-inject --target 127.0.0.1 --port 8805 --ue-ipv4 192.0.2.1 --teid 0x11 --endpoint 10.10.1.2 --core-endpoint 10.10.1.2 --core-teid 0x11 --network-instance core" in namespace "z1"
+    And I execute "pfcp-inject --target 127.0.0.1 --port 8805 --ue-ipv4 192.0.2.2 --teid 0x22 --endpoint 10.20.2.2 --core-endpoint 10.20.2.2 --core-teid 0x22 --network-instance core" in namespace "z2"
+    # z1 imports z2's ST2 + DSD (id 2:2) and installs the encap for ceB.
+    Then show command "show bgp vrf N6 mup" in namespace "z1" should eventually contain "[ST2][65501:10][ep=10.20.2.2]"
+    And show command "show bgp vrf N6 mup" in namespace "z1" should eventually contain "resolved mup:2:2 -> End.DT46"
+    And command "ip route show table all" in namespace "z1" should eventually contain "encap seg6 mode encap segs 1 [ fcbb:bbbb:2:"
+    And command "ip route show table all" in namespace "z1" should eventually contain "10.20.2.2"
+    # z2 imports z1's ST2 + DSD (id 1:1) and installs the encap for ceA.
+    And show command "show bgp vrf N6 mup" in namespace "z2" should eventually contain "[ST2][65501:20][ep=10.10.1.2]"
+    And command "ip route show table all" in namespace "z2" should eventually contain "encap seg6 mode encap segs 1 [ fcbb:bbbb:1:"
+    And command "ip route show table all" in namespace "z2" should eventually contain "10.10.1.2"
+
+  Scenario: ceA <-> ceB traffic forwards over the MUP End.DT46 datapath
+    Given the test topology exists
+    # ceA -> ceB: z1 H.Encaps toward z2's DSD (ceB /32), z2 decaps into VRF N6.
+    Then ping from "ceA" to "10.20.2.2" should eventually succeed
+    # ceB -> ceA: z2 H.Encaps toward z1's DSD (ceA /32), z1 decaps into VRF N6.
+    And ping from "ceB" to "10.10.1.2" should eventually succeed
+
+  Scenario: Teardown topology
+    Given the test topology exists
+    When I stop zebra-rs in namespace "z1"
+    And I stop zebra-rs in namespace "z2"
+    And I delete namespace "z1"
+    And I delete namespace "z2"
+    And I delete namespace "ceA"
+    And I delete namespace "ceB"
+    Then the test environment should be clean

--- a/docs/design/bgp-mup-dataplane-plan.md
+++ b/docs/design/bgp-mup-dataplane-plan.md
@@ -80,9 +80,8 @@ This is achievable on **mainline Linux** — `End.DT46` maps to kernel seg6local
 actions 7/8/16, "already wired" (`bgp-prefix-sid-rfc9252.md:124-159`) — and
 reuses every primitive from P6 slices 5–6.
 
-Plan A's job is to make the **co-located PFCP-terminating node forward its own
-sessions' subscriber traffic**, which today only a *separate* interwork node
-does for *received* routes.
+Plan A's job is to prove the **PFCP-terminating node forwards its own sessions'
+subscriber traffic** end-to-end over `End.DT46`.
 
 ### What already exists (reuse, don't rebuild)
 
@@ -91,75 +90,65 @@ does for *received* routes.
 - ST↔segment resolution (`reconcile_mup_st1_isd` / `reconcile_mup_st2_dsd`).
 - NHT for remote segment next-hops (`nht.rs` `NhtDep::Mup`, followup #2, DONE).
 
-### Plan-A gaps (what to build)
+### Verified findings (2026-07-04) — the per-session install already works
 
-- **A-gap-1 — no local per-session downlink encap.** The session's own UE
-  prefix gets an `H.Encaps` only on a separate interwork node (received ST1 +
-  covering ISD + non-empty NHT transport). On the origin node the re-imported
-  route has `transport = &[]` → no-op.
-- **A-gap-2 — no N6 / breakout egress.** `End.DT46` drops the inner packet into
-  the VRF table, but nothing routes it toward the data network.
-  `session.core_endpoint` (`pfcp.rs:294-297`) is never converted to FIB.
-- **A-gap-3 — collocated ingress (gNB-facing) encap.** The uplink ingress encap
-  (dst = gNB endpoint) runs only on the interwork node; a node that both
-  terminates PFCP and faces the gNB has no ingress-encap install.
+An earlier draft of this plan (following an imprecise investigation summary)
+claimed the PFCP-terminating node "installs nothing per-session". **That is
+wrong** — verified by running the BDDs against the tree:
 
-### Phases
+- **The origin/UPF node installs its own encap.** `reconcile_mup_st1_isd` /
+  `reconcile_mup_st2_dsd` gate on the *segment's* resolved transport
+  (`mup_segment_transport`), **not** the ST route's. The node's own ST route
+  re-imports into its per-VRF MUP RIB (carrying `mup_st1`) and the reconcile
+  installs the encap as soon as a covering **remote** segment (imported by RT)
+  resolves via NHT. The `transport = &[]` on the re-imported ST route is
+  irrelevant to that gate. `bgp_mup_st1_isd` already proves the UPF+MUP-C node
+  (z2) originates the ST1 *and* installs the UE-prefix `H.Encaps` itself.
+- **Real packets forward end-to-end.** The new `@bgp_mup_forwarding` BDD drives
+  a bidirectional `ceA↔ceB` ping through the `End.DT46` datapath (downlink and
+  uplink), passing on the first run — not just route presence, actual ICMP.
 
-#### A1 — local per-session downlink encap — *the loop-closer*
+So the "A1 — local per-session downlink encap" gap the earlier draft posited is
+**already implemented (DONE)**, and A2/A3 are not shaped the way it assumed.
 
-For a locally-originated ST1 (and the co-located ST2's endpoint), install the
-UE-prefix `H.Encaps` toward the **downlink segment SID** on the origin node
-itself, resolving the local transport (the node's own `End.DT46` for the N6
-VRF, or a resolvable remote via NHT).
+### One real structural constraint
 
-- **Where:** a new same-node reconcile in `bgp/vrf/inst.rs` called from the
-  `MupOriginate` handler (`:1939`), **or** extend `dispatch_mup`
-  (`bgp/route.rs:13249`) to pass a resolved local transport for `origin_vrf`
-  instead of `&[]`. Reuse `mup_encap_install` unchanged.
-- **Size:** S–M. First per-session FIB write MUP-C ever makes.
+`mup_session_targets` (`bgp/vrf/inst.rs:468`) reads a **single** `srv6_mobile`
+binding per VRF, so **a VRF carries exactly one MUP direction** (st1 *or* st2).
+A single anchor VRF therefore cannot do both the downlink encap and the uplink
+decap for one subscriber: a *bidirectional* subscriber path is realized by two
+collocated ST2 anchors (each terminating one host), as `@bgp_mup_forwarding`
+does, not by one anchor VRF. Lifting this — one VRF binding both directions —
+is the only genuine code change Plan A could still make, and it is optional
+(the two-node model forwards correctly today).
 
-#### A2 — N6 breakout egress
+### A2 — N6 breakout egress (config, not per-session code)
 
-On `SessionUp`, install a VRF route toward `core_endpoint` / the N6 next-hop so
-the decapped inner subscriber packet has a path to the data network.
-
-- **Where:** `mup-c/inst.rs` `SessionUp` path, or a new VRF-task install in
-  `bgp/vrf/inst.rs`. Withdraw on Session Deletion / AN-release deactivation
-  (mirror the #1766 deactivation handling).
-- **Size:** S–M.
-
-#### A3 — collocated ingress encap (topology-dependent, optional)
-
-For a node that also faces the gNB, install the ingress SRv6 encap (dst = gNB
-endpoint, like `reconcile_mup_st2_dsd`) on the same node, so uplink works
-without a separate interwork hop. Skip when the deployment keeps a distinct
-access PE.
-
-- **Size:** M.
-
-### Config model
-
-No new grammar required for A1–A2 in the collocated model: a VRF with
-`encapsulation srv6` + `afi-safi mup route st1|st2 network-instance <ni>` + an
-RD already carries everything. A1 changes *when* the encap fires (local origin,
-not only received). Optionally add an explicit `mup dataplane end-dt46` opt-in
-so the local-install is gated and the pure-signalling deployments are
-unaffected.
+The remaining honest gap is N6 egress: after `End.DT46` decap the inner packet
+is in the VRF table, but reaching an arbitrary **data network** needs a route
+out of the VRF. This is **operator config** (a per-VRF default/static route, or
+redistribution of the DN prefix), *not* a per-session PFCP-derived install —
+and note `session.core_endpoint` is the **ST2 core-tunnel endpoint**, not the
+N6 DN gateway, so routing toward it is not "breakout". If a per-session N6
+route is ever wanted, its semantics (target next-hop, config vs PFCP-derived)
+need a product decision first; `router static vrf` covers the lab case today.
 
 ### Tests
 
-Extend the existing MUP BDDs (`bgp_mup_st2_dsd_fib`, `bgp_mup_st1_isd`) with an
-assertion that the **originating collocated node** (z1) installs its own
-UE-prefix `H.Encaps` and an N6 route — assert via `ip -6 route show table all`
-in z1's namespace, alongside the existing z2 interwork assertions.
+`@bgp_mup_forwarding` (`bdd/tests/features/bgp_mup_forwarding.feature`) — two
+collocated UPF+interwork nodes, each originates an ST2 (endpoint = a host
+behind it) + a DSD from a PFCP session, imports the other's, installs the
+ST2→DSD encap, and a bidirectional `ceA↔ceB` ping traverses the `End.DT46`
+datapath both ways. Run live via `make -C bdd bgp_mup_forwarding` (root netns).
+Complements `bgp_mup_st2_dsd_fib` / `bgp_mup_st1_isd` (which assert the install;
+this drives real traffic through it).
 
 ### Limits / non-goals
 
 No GTP-U on the wire; the gNB↔fabric edge must speak SRv6 (or a separate SRGW
 does the GTP⇄SRv6 bridge — that's Plan B). No per-QFI, buffering, or usage
-reporting. This is an SRv6 L3VPN user plane with MUP control-plane semantics —
-not a 3GPP-conformant N3 UPF.
+reporting. A single VRF binds one MUP direction (above). This is an SRv6 L3VPN
+user plane with MUP control-plane semantics — not a 3GPP-conformant N3 UPF.
 
 ---
 


### PR DESCRIPTION
## Summary

Proves the BGP MUP **End.DT46 user plane forwards real subscriber traffic**, and corrects the Plan A design doc to match what the BDDs actually show. **Docs/BDD only — no zebra-rs code change.**

### `@bgp_mup_forwarding` — live-traffic BDD

The forwarding counterpart of `bgp_mup_st2_dsd_fib` (which only asserts the install). Two collocated UPF+interwork nodes each originate an **ST2** (endpoint = a host behind it) + a **DSD** from a PFCP session, import the other's, resolve ST2→DSD by Direct-segment id, and install the SRv6 `H.Encaps` toward the remote `End.DT46` SID. A **bidirectional `ceA↔ceB` ping** then traverses the `End.DT46` datapath in both directions using only MUP-installed routes (downlink + uplink, real ICMP). **Passes on the first run.**

### Plan A doc correction

The BDDs contradict the doc's original premise (inherited from an imprecise investigation summary):

- **"Local per-session downlink encap" is already implemented.** The ST reconcilers gate on the *segment's* resolved transport, not the ST route's, so the origin/UPF node installs its own encap once a covering remote segment resolves — `bgp_mup_st1_isd` already proves the UPF+MUP-C node installs its own UE-prefix `H.Encaps`.
- **One genuine remaining code option is structural:** `mup_session_targets` binds a *single* MUP direction per VRF, so a bidirectional subscriber path is realized by **two collocated ST2 anchors** (as this BDD does), not one anchor VRF. Lifting that is optional — the two-node model forwards correctly today.
- **N6 breakout is operator config** (per-VRF static/redistribute), not a per-session install; `core_endpoint` is the ST2 tunnel endpoint, not the N6 DN gateway.

## Test plan

- `make -C bdd bgp_mup_forwarding` — passes (4 scenarios, root netns; kernel VRF + seg6 + IS-IS SRv6 underlay). Validated locally; BDD is CI-excluded.
- No Rust changed → CI `fmt` / `clippy` / `test` unaffected.

Generated with [Claude Code](https://claude.com/claude-code)