### PR TITLE
chore: remove internal dev-tracking refs for release (comments + book)

### DIFF
--- a/book/src/ch-02-29-bgp-ip-transparent.md
+++ b/book/src/ch-02-29-bgp-ip-transparent.md
@@ -10,8 +10,7 @@ to emit packets with a non-local source; IP_TRANSPARENT (which requires
 together: **`update-source` names the address you don't own,
 `ip-transparent` makes the kernel accept it.**
 
-This mirrors FRR 10.4 `neighbor PEER ip-transparent`
-(FRRouting/frr PR #18789).
+This mirrors FRR 10.4 `neighbor PEER ip-transparent`.
 
 ## When you need it
 

--- a/book/src/ch-06-00-vty-access.md
+++ b/book/src/ch-06-00-vty-access.md
@@ -272,8 +272,8 @@ Admin role across multiple commands without re-authenticating.
 
 Configure-mode locking (single-writer mutex) is intentionally not
 yet implemented; multiple admins can simultaneously enter
-configure mode and pile up candidate edits. This will land with
-the deferred Phase 5 work.
+configure mode and pile up candidate edits. This is deferred to
+future work.
 
 ### `ZEBRA_VTY_SERVICE_ACCOUNTS` — permanent-admin uids
 

--- a/book/src/ch-06-01-session-design.md
+++ b/book/src/ch-06-01-session-design.md
@@ -261,7 +261,7 @@ The Session struct carries a `role` field (`View`, `Operator`,
   Service accounts bypass PAM (no password to ship in scripts) and
   are identified by uid alone via SO_PEERCRED. The env var is read
   once at daemon startup (D21); changes require restart. Future
-  YANG-driven runtime mutability is the deferred Phase 4-d-ii.
+  YANG-driven runtime mutability is deferred to a follow-up.
 
 `vtyctl` invocations are short-lived; their sessions exist for one
 or two RPCs and then idle out. Because session state is per-bash_pid
@@ -300,7 +300,7 @@ When `SO_PEERCRED` returns `peer_pid == 0`, the peer is not visible
 in the daemon's PID namespace; the connection is rejected with
 `FailedPrecondition`.
 
-## Streaming RPCs (Phase 7)
+## Streaming RPCs
 
 Some commands need server-streaming RPCs rather than unary calls:
 
@@ -342,7 +342,7 @@ Each phase is intended to ship as an independent PR.
 | D2 | enable TTL is sliding 15 min with a 4 h hard cap. |
 | D3 | enable state is not persisted across daemon restart. |
 | D4 | enable does not propagate to other shell tabs. Each bash is its own session. |
-| D5 | The Phase 1 Session struct is minimal; enable-related fields are added in Phase 4. |
+| D5 | The initial Session struct is minimal; enable-related fields are added later. |
 | D6 | PAM is invoked via a separate setuid (or capability-restricted) helper named `vtypam`, installed at `/usr/sbin/vtypam` for distribution. |
 | D7 | The initial Enable RPC uses a single password field. Bidirectional PAM conversation (for OTP, password change) is deferred. |
 | D8 | Session key derivation assumes the direct vty-bash-to-vtyhelper parent relationship; the daemon verifies via `/proc` (orphan check + parent uid match) but does not inspect the parent's command name. |
@@ -357,19 +357,19 @@ Each phase is intended to ship as an independent PR.
 | D17 | enable failure rate-limit lives in the daemon (per-uid counter, 5 failures within 30 s triggers a 30 s lockout, in-memory only). `pam_faillock` is documented as an optional stronger layer that admins can stack in the PAM service file. |
 | D18 | RBAC is 3-tier: `View`, `Operator`, `Admin`. Maps cleanly onto Cisco priv-lvl ranges 0-1 / 2-14 / 15. YANG-configurable roles are explicitly out of scope. |
 | D19 | Default idle session TTL is **600 s** with a 60 s sweep interval (Cisco IOS `exec-timeout 10 0` convention). Configurable later if a deployment needs it. |
-| D20 | **Root (uid=0) is implicitly Admin.** New sessions for uid=0 are created with `role=Admin` / `enabled=true` / no deadlines; the `enable` RPC short-circuits to success without spawning vtypam. Service-account configuration (Phase 4-d) does not need to list uid 0. Reason: root already owns the host and `pam_unix` against the daemon's own owning account is awkward UX. |
-| D21 | **Service-accounts via env var** for Phase 4-d initial implementation. `ZEBRA_VTY_SERVICE_ACCOUNTS=999,1001,...` (CSV of decimal uids) names uids that are permanent Admin from session creation, with the same shape as root (no deadlines, enable short-circuits to success). State is fixed at daemon startup; runtime changes require a restart. Full YANG integration is deferred to a follow-up (Phase 4-d-ii) if a deployment demands runtime mutability. |
+| D20 | **Root (uid=0) is implicitly Admin.** New sessions for uid=0 are created with `role=Admin` / `enabled=true` / no deadlines; the `enable` RPC short-circuits to success without spawning vtypam. Service-account configuration does not need to list uid 0. Reason: root already owns the host and `pam_unix` against the daemon's own owning account is awkward UX. |
+| D21 | **Service-accounts via env var** for the initial implementation. `ZEBRA_VTY_SERVICE_ACCOUNTS=999,1001,...` (CSV of decimal uids) names uids that are permanent Admin from session creation, with the same shape as root (no deadlines, enable short-circuits to success). State is fixed at daemon startup; runtime changes require a restart. Full YANG integration is deferred to a follow-up if a deployment demands runtime mutability. |
 | D22 | **Initial admin gates: Apply and Clear RPCs.** `SessionTable::require_admin` checks `enabled`, enforces sliding TTL + hard cap (with auto-downgrade on expiry), and slides the idle deadline on each authorized call. |
 | D23 | **Configure-mode admin gate** on `DoExec`. For `ExecType::Exec` only (completion paths remain free): admin is required when `mode != "exec"` (catches a client that sets `mode=configure` directly) and when `mode == "exec" && first_word == "configure"` (UX courtesy — block at entry so the prompt doesn't flip uselessly). Configure-mode mutex/lock is deliberately NOT included; multiple admins can enter configure simultaneously (D11 still deferred). |
 | D24 | **Auto-elevate on `configure`**. When a non-admin user types `configure`, the vty bash shell function optimistically tries first (admins succeed silently). On `PermissionDenied` it prompts for `Password:` (echo off) and sends an `Enable` RPC against the caller's own account (sudo-style) — so the same password that works for `enable` works here. On success it retries `configure` and flips `CLI_PRIVILEGE`. `EnableRequest` carries an optional `auth_user` field that the daemon honors when non-empty (kept for future su-style flows); the configure auto-elevate path leaves it empty. |
-| D25 | **YANG-driven service-accounts** (Phase 4-d-ii). New `vty.yang` module with `list service-account { key uid; leaf description; }` under `container vty` in the global `grouping config`. `ConfigManager` maintains an `Arc<RwLock<HashSet<u32>>>` updated by `commit_config` on `vty service-account uid N` Set/Delete diffs; `SessionTable` reads the union of this set and the env-var set in `is_service_account`. The env var (D21) remains as a startup-only seed for environments where YANG config is unavailable; YANG is the runtime-mutable path. |
+| D25 | **YANG-driven service-accounts** (follow-up). New `vty.yang` module with `list service-account { key uid; leaf description; }` under `container vty` in the global `grouping config`. `ConfigManager` maintains an `Arc<RwLock<HashSet<u32>>>` updated by `commit_config` on `vty service-account uid N` Set/Delete diffs; `SessionTable` reads the union of this set and the env-var set in `is_service_account`. The env var (D21) remains as a startup-only seed for environments where YANG config is unavailable; YANG is the runtime-mutable path. |
 | D26 | **Root peers bypass the parent-uid check.** `resolve_session_key` skips Guard 2 when `peer_uid == 0`. Rationale: the strict match rejected the common `sudo <cmd>` pattern, where the outer `sudo` process retains the invoking user's ruid while the client itself runs as uid 0. Risk surface: any uid-0 connector is trusted regardless of ancestry, but `SO_PEERCRED`'s effective-uid attestation already implies that — a process running as root can already do anything on the host. The remaining guards (D12 cross-PID-namespace, OrphanClient, ParentVanished) still fire for root peers. Non-root peers are unaffected — the parent-uid match is still enforced, so a setuid escalation to a non-zero uid is still refused. |
 
 ## Deferred work
 
 Items intentionally left out of the initial roadmap:
 
-- **Configure-mode lock** (Phase 5). Add if multi-operator
+- **Configure-mode lock** (future work). Add if multi-operator
   contention becomes a real problem.
 - **TACACS+ per-command authorization and accounting**. Requires
   a TACACS+ client in the daemon (Rust `tacacs-plus` crate or

--- a/crates/bfd-packet/src/auth.rs
+++ b/crates/bfd-packet/src/auth.rs
@@ -5,7 +5,7 @@ use crate::typ::AuthType;
 
 /// Authentication Section (RFC 5880 §4.2 – §4.4).
 ///
-/// Phase 1 parses the section but does not validate digests, sequence
+/// This parses the section but does not validate digests, sequence
 /// numbers, or password contents — the session layer decides whether to
 /// honour or drop authenticated packets.
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/crates/bgp-packet/src/attrs/mp_reach.rs
+++ b/crates/bgp-packet/src/attrs/mp_reach.rs
@@ -925,7 +925,7 @@ pub(crate) fn evpn_attr_emit(_snpa: u8, nhop: &IpAddr, updates: &[EvpnRoute], bu
 /// Nexthop is encoded per the address family of `nhop` (`IpAddr::V4`
 /// → 4 octets, `IpAddr::V6` → 16 octets); senders that need the
 /// 32-octet "global || link-local" form will be added when a caller
-/// asks for it (Phase 3 keeps the emit side single-address).
+/// asks for it (the emit side is single-address for now).
 pub(crate) fn mup_attr_emit(
     afi: Afi,
     _snpa: u8,

--- a/crates/bgp-packet/src/attrs/mp_unreach.rs
+++ b/crates/bgp-packet/src/attrs/mp_unreach.rs
@@ -155,7 +155,7 @@ impl MpUnreachAttr {
 ///
 /// MP_UNREACH carries neither nexthop nor SNPA — only the AFI/SAFI
 /// header and the NLRI list. The NLRI body bytes are produced by
-/// `EvpnRoute::nlri_emit` (PR #399), the same encoder used by the
+/// `EvpnRoute::nlri_emit`, the same encoder used by the
 /// MP_REACH advertise path.
 /// Serialize an `MpUnreachAttr::Ipv6Nlri(withdraws)` (or `Ipv6Eor`
 /// when `withdraws` is empty) as a complete MP_UNREACH_NLRI path

--- a/crates/bgp-packet/tests/parser.rs
+++ b/crates/bgp-packet/tests/parser.rs
@@ -106,7 +106,7 @@ ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff
 }
 
 // Test that ESI field exists and is properly structured in EvpnMac
-// This verifies the Phase 4D change where esi was changed from a type field to full 10-byte array
+// This verifies the change where esi was changed from a type field to full 10-byte array
 #[test]
 pub fn evpn_mac_esi_field_structure() {
     use bgp_packet::attrs::nlri_evpn::EvpnMac;
@@ -164,7 +164,7 @@ pub fn bgp_rib_esi_propagation() {
     // should contain the full ESI for downstream use in:
     // - Route Distinguisher handling
     // - MAC Mobility conflict resolution
-    // - ECMP nexthop group formation (Phase 5)
+    // - ECMP nexthop group formation
     //
     // The ESI preservation test above validates that parsing works correctly.
     // This test validates that the information is available for route selection.

--- a/crates/isis-packet/src/parser.rs
+++ b/crates/isis-packet/src/parser.rs
@@ -797,7 +797,7 @@ pub const ISIS_AUTH_HMAC_SHA512_LEN: usize = 64;
 
 impl IsisTlvAuth {
     /// Build a placeholder Auth TLV with the digest area zero-filled.
-    /// The signer (Phase 4) emits this into the PDU first, then computes
+    /// The signer emits this into the PDU first, then computes
     /// the HMAC over the serialized PDU and patches the digest bytes in
     /// place — RFC 5304 §3 / RFC 5310 §3.
     pub fn placeholder(auth_type: u8, value_len: usize) -> Self {
@@ -1425,7 +1425,7 @@ mod tests {
 
     /// Round-trip a TLV 14 LSP Buffer Size: emit through tlv_emit,
     /// then re-parse via parse_tlvs and recover the original size.
-    /// Frags emitted by the send-side packer (Phase 3) will rely on
+    /// Frags emitted by the send-side packer will rely on
     /// the type+length header being exactly 4 bytes (2 header + 2
     /// value) so reach packing math stays predictable.
     #[test]
@@ -1644,7 +1644,7 @@ mod tests {
         }
     }
 
-    /// Phase 4 LSP signer builds the PDU with a zero-filled placeholder,
+    /// The LSP signer builds the PDU with a zero-filled placeholder,
     /// then patches the digest in. Verify placeholder() shape and that
     /// the emitted bytes match `[type, len, auth_type, 0x00 * N]`.
     #[test]

--- a/crates/isis-packet/src/sub/restart.rs
+++ b/crates/isis-packet/src/sub/restart.rs
@@ -31,7 +31,7 @@ use crate::util::{ParseBe, TlvEmitter};
 /// `remaining_time` and `restarting_neighbor` are required by the RFC
 /// when `RA=1` and otherwise MUST be absent. The codec carries them as
 /// `Option` so the absent case is representable; the IIH-level state
-/// machine (Phase 3) is responsible for enforcing the RA-bit pairing.
+/// machine is responsible for enforcing the RA-bit pairing.
 #[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
 pub struct IsisTlvRestart {
     pub flags: u8,

--- a/zebra-rs/src/bgp/config.rs
+++ b/zebra-rs/src/bgp/config.rs
@@ -3432,7 +3432,7 @@ pub(super) fn apply_disable_connected_check(peer: &mut Peer, want: bool) -> bool
 }
 
 /// `[no] router bgp neighbor <addr> ip-transparent` (presence container,
-/// FRR 10.4 PR #18789) — set IP_TRANSPARENT / IPV6_TRANSPARENT on this
+/// FRR 10.4) — set IP_TRANSPARENT / IPV6_TRANSPARENT on this
 /// neighbor's TCP socket so the session can use a local address the
 /// host does not own (the address itself comes from `update-source`;
 /// the two are used together). Consumed at connect time by
@@ -5499,9 +5499,9 @@ mod bfd_wiring_tests {
 #[cfg(test)]
 mod neighbor_group_wiring_tests {
     //! End-to-end exercise of the neighbor-group inheritance callback
-    //! paths landed across PR #758 (static-peer resolver), PR #760
-    //! (reactive sweep on group remote-as Set/Delete), and PR #762
-    //! (group-level delete cascade). Asserts the user-observable
+    //! paths for the static-peer resolver, the reactive sweep on group
+    //! remote-as Set/Delete, and the group-level delete cascade. Asserts
+    //! the user-observable
     //! state after each callback rather than the internal sweep
     //! decision — the decision matrix itself is unit-tested in
     //! `neighbor_group::tests`.

--- a/zebra-rs/src/bgp/ethernet_segment.rs
+++ b/zebra-rs/src/bgp/ethernet_segment.rs
@@ -1,6 +1,6 @@
 //! EVPN Ethernet Segment (RFC 7432) configuration state.
 //!
-//! Phase 2 of the ES foundation (see `docs/design/bgp-evpn-ethernet-segment.md`):
+//! Part of the ES foundation (see `docs/design/bgp-evpn-ethernet-segment.md`):
 //! the `router bgp afi-safi evpn ethernet-segment <name>` config surface and
 //! the per-ES state it populates. No routes / DF election / data plane yet —
 //! those are later phases. The config handlers live in `config.rs` alongside

--- a/zebra-rs/src/bgp/flowspec.rs
+++ b/zebra-rs/src/bgp/flowspec.rs
@@ -10,11 +10,11 @@
 //!   * **(b.1)** the originator of the flow spec matches the originator
 //!     of the best-match unicast route for the destination prefix.
 //!
-//! Phase 2 computes this verdict on demand for `show bgp flowspec`;
+//! This computes the verdict on demand for `show bgp flowspec`;
 //! nothing yet *gates* behaviour on it. Stored verdicts, event-driven
 //! re-validation when the unicast RIB changes, the more-specific-route
 //! check (RFC 8955 rule c), and the per-neighbor disable knob land with
-//! the Phase 3 enforcement path (where validity gates re-advertise and,
+//! the enforcement path (where validity gates re-advertise and,
 //! later, install).
 
 use std::fmt;

--- a/zebra-rs/src/bgp/group_egress.rs
+++ b/zebra-rs/src/bgp/group_egress.rs
@@ -1,4 +1,4 @@
-//! Per-update-group egress task — **Phase 1a (the engine; not yet reduce-wired)**.
+//! Per-update-group egress task — **the engine (not yet reduce-wired)**.
 //!
 //! Plan: `docs/design/bgp-egress-group-task-migration.md`. One persistent task
 //! per [`UpdateGroup`](super::update_group::UpdateGroup) that — at the end of
@@ -6,16 +6,16 @@
 //! member peers: **M tasks (groups), not N (peers)**, coalescing *and*
 //! off-main-parallel. A per-peer egress task (PET) is the M=1 case.
 //!
-//! Phase 0 was the lifecycle shell (member tracking, idle). **Phase 1a** adds
+//! The lifecycle shell (member tracking, idle) came first. This step adds
 //! the [`Engine`]: it captures each member's [`SyncCtx`] and can build one
 //! best-path advertisement **once** (the shared group transform), record it in
 //! the group's `adj_out`, encode it **once**, and **fan** the bytes to every
 //! member except the path's source (split-horizon). It is the per-group twin
 //! of the PET `Engine` — `send_ipv4_direct` fanned across members.
 //!
-//! 1a is **not wired into the reduce yet**: `attach`/`detach` feed the member
+//! The engine is **not wired into the reduce yet**: `attach`/`detach` feed the member
 //! set live (so the engine holds real `SyncCtx`s at gate-on), but no
-//! `Advertise`/`Withdraw` delta is routed to it — those land in Phase 1b. So
+//! `Advertise`/`Withdraw` delta is routed to it — those land later. So
 //! gate-on egress is unchanged; the engine is exercised by the unit tests.
 //! Default off; gate-off is byte-identical.
 
@@ -47,7 +47,7 @@ pub fn egress_group_task_enabled() -> bool {
     })
 }
 
-/// One egress operation the `attach`/`detach` (and, from Phase 1b, the reduce)
+/// One egress operation the `attach`/`detach` (and, later, the reduce)
 /// machinery forwards to a group's task. `AddMember` carries the member's
 /// `SyncCtx` (its packet sink and the shared egress identity) so the engine can
 /// build and fan, plus the group's `add_path` flag. `Advertise` and `Withdraw`
@@ -110,7 +110,7 @@ pub enum GroupEgressDeltaV4 {
 /// closes the channel.
 #[derive(Debug)]
 pub struct GroupEgressTask {
-    /// `attach` / `detach` (and, from Phase 1b, the reduce) push deltas here.
+    /// `attach` / `detach` (and, later, the reduce) push deltas here.
     delta_tx: UnboundedSender<GroupEgressDeltaV4>,
     // Held only for its abort-on-drop teardown; the task is driven entirely by
     // the channel, so the handle is never read after spawn.

--- a/zebra-rs/src/bgp/inst.rs
+++ b/zebra-rs/src/bgp/inst.rs
@@ -862,7 +862,7 @@ pub struct Bgp {
 
     /// Local shadow of `Rib::flex_algo_routes`, populated by
     /// `RibRx::FlexAlgoRouteAdd/Del` events emitted from IS-IS via
-    /// RIB (PR #697). Outer key is the IS-IS Flex-Algorithm id; inner
+    /// RIB. Outer key is the IS-IS Flex-Algorithm id; inner
     /// map is the per-algo IPv4 RIB. The colour-aware resolver does
     /// a longest-prefix match on the BGP next-hop against the
     /// inner map for the algo bound to the route's Color extcomm,
@@ -3539,7 +3539,7 @@ impl Bgp {
             RibRx::RouteDel { rtype, routes, .. } => {
                 self.route_redist_del(rtype, routes);
             }
-            // IS-IS per-algo routes published via RIB (#697). We
+            // IS-IS per-algo routes published via RIB. We
             // shadow only the first nexthop per (algo, prefix); a
             // future ECMP-aware resolver can extend this to walk the
             // full set.
@@ -4675,7 +4675,7 @@ impl Bgp {
                     // At gate-on `adj_out` lives in the egress task (group or
                     // PET), so forward the dump rows there as record-only — the
                     // shard already put the bytes on the wire. Group-task first
-                    // (the N>1 twin of route_sync_ipv4's RecordAdjOut, Phase 3),
+                    // (the N>1 twin of route_sync_ipv4's RecordAdjOut),
                     // then the per-peer PET, then main's adj_out at gate-off.
                     let v4 =
                         bgp_packet::AfiSafi::new(bgp_packet::Afi::Ip, bgp_packet::Safi::Unicast);
@@ -6015,7 +6015,7 @@ mod tests {
 
         #[test]
         fn mup_dispatch_origin_plus_cross_vrf_rt_import() {
-            // The #1681 cross-VRF case: N6 originates a route (RD origin),
+            // The cross-VRF case: N6 originates a route (RD origin),
             // and a sibling N3 imports the route's RT. Both are targets —
             // N6 by RD origin, N3 by RT import.
             let mut index = BTreeMap::new();

--- a/zebra-rs/src/bgp/peer.rs
+++ b/zebra-rs/src/bgp/peer.rs
@@ -933,9 +933,9 @@ pub struct Peer {
     /// Per-peer egress task (A2 ⑥ / (a′)). `Some` only at gate-on
     /// (`ZEBRA_BGP_PEER_TASK`) while Established: it owns the v4-unicast
     /// egress off the main loop. `None` at gate-off (egress on main via
-    /// update-groups, today's default) and between sessions. Phase 0: the
-    /// task is spawned/torn down here but idle; Phase 1 routes the egress
-    /// through it.
+    /// update-groups, today's default) and between sessions. For now the
+    /// task is spawned/torn down here but idle; routing the egress
+    /// through it comes later.
     pub pet: Option<super::peer_egress::PeerEgressTask>,
     /// Egress backlog gauge (Tier 1b backpressure): the per-peer writer
     /// task publishes `packet_rx.len()` (pending UPDATE messages) here
@@ -1376,7 +1376,7 @@ impl Peer {
         self.reflector_client
     }
 
-    /// Borrowed view of this peer's outbound policy (A2 Phase 0). The
+    /// Borrowed view of this peer's outbound policy. The
     /// egress build takes this instead of `&Peer` so the same evaluation
     /// can run in a shard worker (which holds a `SyncCtx`, not a `Peer`).
     /// Rebuild the cached outbound-policy snapshot from the current
@@ -1821,8 +1821,8 @@ pub fn fsm(
             // with the session coming up) must not mislabel the next
             // reset.
             peer.down_reason = None;
-            // A2 ⑥ (gate-on): spawn the per-peer egress task. Phase 0 — it
-            // is idle (lifecycle only); Phase 1 routes the v4 egress to it.
+            // A2 ⑥ (gate-on): spawn the per-peer egress task. For now it
+            // is idle (lifecycle only); routing the v4 egress to it comes later.
             if super::peer_egress::peer_egress_task_enabled() {
                 let ctx = peer.sync_ctx(*bgp_ref.router_id);
                 let add_path = peer.opt.is_add_path_send(Afi::Ip, Safi::Unicast);

--- a/zebra-rs/src/bgp/peer_egress.rs
+++ b/zebra-rs/src/bgp/peer_egress.rs
@@ -10,9 +10,9 @@
 //! connection's `packet_tx`, which the unchanged per-connection writer
 //! drains.
 //!
-//! **Phase 0 (this file) is lifecycle only:** the task is spawned at
+//! **This file is lifecycle only:** the task is spawned at
 //! Established and dropped on session end, and it drains its delta channel
-//! without acting. `adj_out` and the egress work move into it in Phase 1.
+//! without acting. `adj_out` and the egress work move into it later.
 //! Gate-off (the default) is untouched — the egress stays on the main task
 //! via update-groups.
 
@@ -90,7 +90,7 @@ pub fn peer_egress_task_enabled() -> bool {
 
 /// One v4-unicast egress operation main forwards to a peer's task — the
 /// ordered delta stream (main sequences for per-prefix ordering; the PET
-/// does the work). Phase 0 defines the protocol; Phase 1 sends + handles it.
+/// does the work). This defines the protocol; sending + handling come later.
 #[derive(Debug)]
 pub enum EgressDeltaV4 {
     /// A best path won for `prefix` (the event-driven advertise): build +
@@ -165,7 +165,7 @@ impl PeerEgressTask {
 }
 
 /// A peer's owned v4-unicast egress state + per-delta logic, run inside the
-/// task. Build / policy / send reuse the `&SyncCtx` primitives (A2 Phase 0),
+/// task. Build / policy / send reuse the `&SyncCtx` primitives,
 /// so this is the per-peer, off-main twin of `compute_advertise_outcome` +
 /// `send_ipv4_direct` — no update-groups (gate-on is the GoBGP model).
 struct Engine {

--- a/zebra-rs/src/bgp/route.rs
+++ b/zebra-rs/src/bgp/route.rs
@@ -3705,7 +3705,7 @@ fn apply_ipv4_advertise_job(
         added,
         replaced,
     } = job;
-    // Group-task migration Phase 1b (gate-on): the v4-unicast event-driven
+    // Group-task migration (gate-on): the v4-unicast event-driven
     // advertise/withdraw runs in the per-update-group egress tasks — fan one
     // delta per group and bypass the update-group flush. Takes precedence over
     // the per-peer PET below (they are alternative egress models). VPNv4
@@ -4113,7 +4113,7 @@ fn fan_advertise_to_pets(prefix: Ipv4Net, selected: &[BgpRib], peers: &PeerMap) 
     }
 }
 
-/// Group-task migration Phase 1b — fan the reduce's best-path delta to the
+/// Group-task migration — fan the reduce's best-path delta to the
 /// per-update-group egress tasks: **one** delta per group (deduped across the
 /// established members), keyed by `peer.update_group_id`. An empty `selected`
 /// is a withdraw (the path is gone). The per-member split-horizon is the
@@ -4278,7 +4278,7 @@ fn soft_out_v4_to_pet(peer_idx: usize, bgp: &BgpTop, peers: &PeerMap) {
     }
 }
 
-/// Group-task migration Phase 4 — soft-out for a v4-unicast peer at gate-on.
+/// Group-task migration — soft-out for a v4-unicast peer at gate-on.
 /// Refresh every member of the peer's update group with a fresh `SyncCtx` (the
 /// out-policy snapshot changed) by re-sending `AddMember` (which overwrites the
 /// member's ctx), then re-fan the whole v4 Loc-RIB so the group re-evaluates
@@ -4336,7 +4336,7 @@ fn soft_out_v4_to_group(peer_idx: usize, bgp: &BgpTop, peers: &PeerMap) {
 }
 
 /// Per-AF hooks for the generic update-group/memo advertise path
-/// ([`route_advertise_batch`]). Phase 2 of the Adj-RIB-Out unification:
+/// ([`route_advertise_batch`]). Part of the Adj-RIB-Out unification:
 /// v4-unicast/VPNv4 (`V4Batch`) and v6-unicast/VPNv6 (`V6Batch`) share the
 /// memo loop + group-counter logic; the AF impls own the prefix/NLRI type,
 /// the build (`compute_outcome`), and the per-peer `advertise` / `withdraw`
@@ -6383,7 +6383,7 @@ pub fn route_labelv4_update(
             rib.weight = decision.weight;
             nht_track_received(bgp, &mut rib, dep.clone());
             // Allocate a per-prefix local label so re-advertising with
-            // next-hop-self forwards via a swap ILM (Phase 5b). `None`
+            // next-hop-self forwards via a swap ILM. `None`
             // when no dynamic block is granted yet — advertise the
             // received label until then.
             rib.local_label = bgp
@@ -7652,9 +7652,9 @@ pub fn route_evpn_withdraw(ident: usize, route: &EvpnRoute, bgp: &mut BgpTop, pe
 /// Store one received MUP NLRI (draft-ietf-bess-mup-safi, SAFI 85) in the peer's
 /// Adj-RIB-In and the MUP Loc-RIB, then re-run best-path.
 ///
-/// Phase 2 is receive + show only: there is no inbound route-policy, no
-/// VRF import, no re-advertise, and no FIB install yet (those land in
-/// P3/P4/P6). The caller stamps the MP_REACH next-hop into `attr` so
+/// This is receive + show only: there is no inbound route-policy, no
+/// VRF import, no re-advertise, and no FIB install yet (those land
+/// later). The caller stamps the MP_REACH next-hop into `attr` so
 /// `show bgp mup` can render it. Loop detection mirrors
 /// `route_evpn_update` — a route carrying our own AS / ORIGINATOR_ID /
 /// CLUSTER_LIST is dropped silently.
@@ -8237,10 +8237,10 @@ pub fn route_sync_mup(peer: &mut Peer, bgp: &mut BgpTop) {
 
 /// Store one received Flow Specification NLRI in the peer's Adj-RIB-In.
 ///
-/// Phase 1 (receive/reflect) is control-plane only: the flow spec is
+/// Receive/reflect is control-plane only: the flow spec is
 /// kept in Adj-RIB-In so it can be shown, but it is not validated
-/// (RFC 9117 — Phase 2), not selected into a Loc-RIB or re-advertised
-/// (Phase 3), and not installed (Phase 4). Loop detection mirrors
+/// (RFC 9117), not selected into a Loc-RIB or re-advertised, and
+/// not installed. Loop detection mirrors
 /// `route_evpn_update` so a route carrying our own AS / ORIGINATOR_ID /
 /// CLUSTER_LIST is dropped silently.
 pub fn route_flowspec_update(
@@ -8306,13 +8306,13 @@ pub fn route_flowspec_update(
         peer.adj_in.add_flowspec(afi, nlri.clone(), rib.clone());
     }
 
-    // Phase 3: run best-path selection into the Loc-RIB. Validity
-    // (Phase 2 / RFC 9117) gates re-advertise and install, not Loc-RIB
+    // Run best-path selection into the Loc-RIB. Validity
+    // (RFC 9117) gates re-advertise and install, not Loc-RIB
     // membership, so the selected best path is recorded regardless of
     // the validation verdict.
     let (_, selected, _) = bgp.local_rib.update_flowspec(afi, nlri.clone(), rib);
 
-    // Phase 3b: re-advertise (or withdraw) the new best path to flowspec
+    // Re-advertise (or withdraw) the new best path to flowspec
     // peers, gated on RFC 9117 validity.
     route_flowspec_propagate(afi, nlri, &selected, bgp, peers);
 }
@@ -10069,7 +10069,7 @@ pub fn route_clean(
         peer.adj_in.evpn.clear();
     }
 
-    // MUP (draft-ietf-bess-mup-safi). Phase 2 is receive-only with no LLGR
+    // MUP (draft-ietf-bess-mup-safi) is receive-only with no LLGR
     // retention, so peer-down withdraws every MUP route the peer gave us.
     // Route it through the same `route_mup_locrib_withdraw` helper the
     // explicit MP_UNREACH path uses so the withdrawal is *propagated*, not
@@ -11110,8 +11110,8 @@ fn bgp_nexthop_to_ipaddr(nh: &BgpNexthop) -> Option<IpAddr> {
 ///
 /// The advertised label is the row's label — the received label when
 /// propagating, implicit-null (3) for self-originated FECs. The real
-/// per-prefix local label + ILM swap is Phase 5; Phase 4 installs
-/// nothing in the dataplane, so this is control-plane only.
+/// per-prefix local label + ILM swap comes later; nothing is
+/// installed in the dataplane yet, so this is control-plane only.
 ///
 /// `attrs.nexthop` is cleared: an MP_REACH carries the next-hop itself,
 /// and a `BgpNexthop::Ipv4` left on the attr would also emit a legacy
@@ -11272,7 +11272,7 @@ fn route_update_labelv6(
 }
 
 /// Per-AF hooks that let one generic [`route_advertise_labeled`] cover the
-/// SAFI-4 (labeled-unicast) v4 and v6 advertise paths. Phase 2 of the
+/// SAFI-4 (labeled-unicast) v4 and v6 advertise paths. Part of the
 /// Adj-RIB-Out unification: the two families differ only in prefix/NLRI
 /// type, which `adj_out` table records reach, their update builder and
 /// out-policy, and which `Mp{Reach,Unreach}Attr` variant they encode.
@@ -12422,7 +12422,7 @@ pub fn route_sync_ipv4(peer: &mut Peer, bgp: &mut BgpTop) {
         // Register to AdjOut.
         rib.attr = bgp.attr_store.intern(decision.attr);
         let arc_attr = rib.attr.clone();
-        // Group-task migration Phase 3: also record the synced route into the
+        // Group-task migration: also record the synced route into the
         // group adj_out (without re-sending — the direct dump below delivers
         // the bytes) so a late member that is the first of its group stays
         // withdrawable by the group's later withdraws.
@@ -13607,7 +13607,7 @@ impl Bgp {
     /// advertised label is implicit-null (3): we are the egress for this
     /// FEC, so a labeled-unicast peer does penultimate-hop-pop and
     /// forwards as IP to us. The real per-prefix local label + ILM swap
-    /// is Phase 5; no FIB install here (control-plane only).
+    /// comes later; no FIB install here (control-plane only).
     pub fn route_add_label_v4(&mut self, prefix: Ipv4Net) {
         let ident = ORIGINATED_PEER;
         let attr = BgpAttr::new();
@@ -14040,7 +14040,7 @@ impl Bgp {
     /// `redist_remote_id` discriminator and MED-from-metric, but
     /// originates into `v4lu` with implicit-null (we are the egress FEC)
     /// and advertises via the labelv4 path. No FIB install (control-plane
-    /// only; the per-prefix local label + ILM is Phase 5).
+    /// only; the per-prefix local label + ILM comes later).
     pub fn route_redist_inject_labelv4(
         &mut self,
         rtype: crate::rib::RibType,
@@ -15682,7 +15682,7 @@ fn evpn_withdraw_leaf_ad(
 ///
 /// Note: RFC 9574 has the leaf join a *single* chosen replicator's set; we
 /// currently join every selective replicator. Harmless with no replicator
-/// dataplane (Phase 4); chosen-replicator selection is a follow-up.
+/// dataplane; chosen-replicator selection is a follow-up.
 fn evpn_selective_ar_on_receive(
     route: &EvpnRoute,
     attr: &BgpAttr,

--- a/zebra-rs/src/bgp/shard/msg.rs
+++ b/zebra-rs/src/bgp/shard/msg.rs
@@ -129,7 +129,7 @@ pub enum ShardMsg {
     /// [`ShardOut::BestPathV4`] per contributed prefix — re-electing
     /// any surviving path (another peer may now win) or signalling a
     /// withdraw (empty winners). Centralizing the sweep here closes the
-    /// "new SAFI forgot a route_clean block" bug-class (#1329). At N>1
+    /// "new SAFI forgot a route_clean block" bug-class. At N>1
     /// `route_clean` dispatches this to every pool shard so each sweeps
     /// the peer's v4-unicast slice.
     PeerDown { ident: usize },

--- a/zebra-rs/src/bgp/show.rs
+++ b/zebra-rs/src/bgp/show.rs
@@ -4594,7 +4594,7 @@ fn show_flowspec_actions(attr: &BgpAttr) -> String {
 
 /// `show bgp flowspec [ipv6]` — list the Flow Specification rules in
 /// Adj-RIB-In across all peers for the given AFI, each with its decoded
-/// traffic-filtering actions and the advertising neighbor. Phase 1 is
+/// traffic-filtering actions and the advertising neighbor. It is
 /// receive-only: there is no Loc-RIB / best-path for flow specs yet, so
 /// this is the raw received view.
 fn show_bgp_flowspec(

--- a/zebra-rs/src/bgp/transparent.rs
+++ b/zebra-rs/src/bgp/transparent.rs
@@ -1,4 +1,4 @@
-// BGP `neighbor X ip-transparent` (FRR 10.4, FRRouting/frr PR #18789):
+// BGP `neighbor X ip-transparent` (FRR 10.4):
 // the IP_TRANSPARENT / IPV6_TRANSPARENT socket option, which lets a BGP
 // session use a local address the host does not own.
 //

--- a/zebra-rs/src/bgp/update_group.rs
+++ b/zebra-rs/src/bgp/update_group.rs
@@ -281,10 +281,10 @@ pub struct UpdateGroup {
     pub flush_inflight_ipv6: bool,
     pub flush_pending_ipv6: bool,
     pub deferred_withdraw_ipv6: Vec<(usize, Ipv6Nlri)>,
-    /// Per-update-group egress task (migration Phase 0,
+    /// Per-update-group egress task (see
     /// `docs/design/bgp-egress-group-task-migration.md`). `Some` only at
     /// gate-on (`ZEBRA_BGP_EGRESS_GROUP_TASK`); spawned when the group is
-    /// created, dropped (abort-on-drop) when it empties. Phase 0 is idle —
+    /// created, dropped (abort-on-drop) when it empties. For now it is idle —
     /// it tracks the member set and routes no egress yet.
     pub task: Option<super::group_egress::GroupEgressTask>,
 }
@@ -489,7 +489,7 @@ pub fn attach(
         let entry = af.groups.entry(sig.clone()).or_insert_with(|| {
             let id = UpdateGroupId::new(afi_safi.afi, afi_safi.safi, af.next_seq);
             af.next_seq += 1;
-            // Phase 0/1a: spawn the per-group egress task at gate-on for
+            // Spawn the per-group egress task at gate-on for
             // v4-unicast (the family being migrated); dropped (abort-on-drop)
             // when this group is removed in `detach`.
             let task = (afi_safi.afi == Afi::Ip
@@ -519,9 +519,9 @@ pub fn attach(
             }
         });
         entry.members.insert(peer_idx);
-        // Phase 1a: mirror the membership into the group's egress task with the
+        // Mirror the membership into the group's egress task with the
         // member's SyncCtx (its packet sink + the shared egress identity) so the
-        // engine can build + fan once advertises are routed there (Phase 1b).
+        // engine can build + fan once advertises are routed there (later).
         if let Some(t) = &entry.task
             && let Some(peer) = peers.get_by_idx(peer_idx)
         {

--- a/zebra-rs/src/config/manager.rs
+++ b/zebra-rs/src/config/manager.rs
@@ -562,7 +562,7 @@ impl ConfigManager {
                 // same contract as `bfd_client_tx` — bring STAMP up
                 // first so `te-metric measurement` works regardless of
                 // commit order. (The ospfv3 arm doesn't: OSPFv3 has no
-                // measurement YANG in Phase 1.)
+                // measurement YANG yet.)
                 if !stamp {
                     stamp = true;
                     spawn_stamp(self);
@@ -2419,7 +2419,7 @@ mod yang_load_tests {
         }
     }
 
-    /// STAMP Phase 1 grammar: the `te-metric measurement` block on
+    /// STAMP measurement grammar: the `te-metric measurement` block on
     /// both IGP interfaces (configure mode) and the `show stamp`
     /// surface (exec mode). Pinned because vtyctl apply/show are
     /// garbage-tolerant — an unwired grammar silently no-ops.

--- a/zebra-rs/src/isis/egress_protection.rs
+++ b/zebra-rs/src/isis/egress_protection.rs
@@ -1,13 +1,13 @@
 // IS-IS Mirror SID egress node/link protection — configuration and
-// state (Phase 2).
+// state.
 //
 // draft-ietf-rtgwg-srv6-egress-protection (SRv6 End.M) and RFC 8667 /
 // RFC 8679 (SR-MPLS context label). A protector node (PEB) advertises a
 // Mirror SID and the protected egress's locator(s); on egress failure a
 // PLR redirects traffic to PEB, which processes the inner packet in the
 // failed egress's mirrored context. This module only holds the operator
-// config and the parsed state — origination (Phase 3), dataplane (Phase
-// 4) and PLR repair (Phase 6) consume it later.
+// config and the parsed state — origination, dataplane and PLR
+// repair consume it later.
 
 use std::collections::BTreeMap;
 use std::net::Ipv6Addr;
@@ -58,7 +58,7 @@ pub struct MirrorProtect {
     /// (IPv4, since the SR-MPLS dataplane has no IPv6 prefix-SID).
     pub protected_locator: IpNet,
     /// Mirror SID (End.M) to advertise. `None` ⇒ auto-allocate from
-    /// the local SRv6 locator at origination time (Phase 3).
+    /// the local SRv6 locator at origination time.
     pub mirror_sid: Option<Ipv6Addr>,
     /// Local VRF whose forwarding reaches the dual-homed CE. `None` ⇒
     /// no static context mapping yet (BGP-learned path, later phase).
@@ -138,7 +138,7 @@ pub(crate) fn desired_context_labels(
         .collect()
 }
 
-// ── PLR-side reception (Phase 6a) ─────────────────────────────────────
+// ── PLR-side reception ────────────────────────────────────────────────
 
 /// A Mirror SID advertisement received from a peer — the PLR's view of
 /// the network. The `protector` node advertises `mirror_sid` (End.M)
@@ -272,9 +272,9 @@ pub fn node_te_router_id(lsdb: &Lsdb, sys_id: IsisSysId) -> Option<std::net::Ipv
 //
 // Each shim parses the list key (`protected-locator`) and, for leaf
 // callbacks, the leaf value, mutates the config map, then re-originates
-// the self LSP so the Phase 3 emit picks the change up. Today nothing is
+// the self LSP so the origination emit picks the change up. Today nothing is
 // emitted, so the re-origination is a harmless no-op; keeping it wired
-// here means Phase 3 needs no callback changes.
+// here means origination needs no callback changes.
 
 /// `/router/isis/egress-protection/protect` — list-entry lifecycle.
 /// Creates the entry on set, removes it on delete.

--- a/zebra-rs/src/isis/inst.rs
+++ b/zebra-rs/src/isis/inst.rs
@@ -511,7 +511,7 @@ pub struct Isis {
     /// by [`Self::stamp_reconcile_link`] to (un)subscribe measurement
     /// sessions for `te-metric measurement` interfaces. Same capture
     /// contract as `bfd_client_tx`; `None` for per-VRF children
-    /// (sessions are default-VRF only in Phase 1).
+    /// (sessions are default-VRF only).
     pub stamp_client_tx: Option<UnboundedSender<crate::stamp::client::ClientReq>>,
     /// Sender half of the per-instance `StampEvent` channel, handed to
     /// STAMP as the `notifier` on every `Subscribe`.
@@ -2823,7 +2823,7 @@ impl Isis {
         // if the neighbour entry is absent from `nbrs` at that point (race:
         // BFD Up fires before the next IIH re-creates the entry).
         link.state.bfd_holddown_nbr.insert(*key, (level, sys_id));
-        // Fast-reroute switchover (kernel-failover phase 3): rewire the
+        // Fast-reroute switchover: rewire the
         // pre-installed protection groups onto their TI-LFA repairs NOW,
         // before the LSP regeneration / SPF / per-prefix reinstall pipeline
         // even starts. One message per failed nexthop address; the RIB

--- a/zebra-rs/src/isis/lsdb.rs
+++ b/zebra-rs/src/isis/lsdb.rs
@@ -389,7 +389,7 @@ pub(super) fn rebuild_sys_state(
     // neighbor_id. Multiple entries for the same neighbor_id across
     // fragments (or across TLV 22 / TLV 222 for the same link) yield
     // last-wins via BTreeMap::insert — by construction the producer
-    // emits the same bytes on both topologies (PR #613), so any
+    // emits the same bytes on both topologies, so any
     // duplication is benign.
     let mut link_affinity: BTreeMap<IsisNeighborId, ExtAdminGroup> = BTreeMap::new();
     for f in &frags {

--- a/zebra-rs/src/isis/rib.rs
+++ b/zebra-rs/src/isis/rib.rs
@@ -416,7 +416,7 @@ impl<F: IsisRibFamily> PartialEq for SpfNexthop<F> {
 /// backup's metric inside a `NexthopProtect`. The value is RIB-internal
 /// and never reaches the wire — it only governs the metric grouping
 /// that makes the lower-metric group the `primary` member. See the
-/// design discussion that landed PR #489: blanket `+1` keeps show
+/// design rationale: blanket `+1` keeps show
 /// output legible and avoids `u32::MAX` sentinels.
 pub const BACKUP_METRIC_OFFSET: u32 = 1;
 

--- a/zebra-rs/src/isis/tilfa.rs
+++ b/zebra-rs/src/isis/tilfa.rs
@@ -523,8 +523,8 @@ fn repair_segments_to_mpls_labels(
 
 /// Plan the TI-LFA targets from the primary SPF result: every
 /// destination that isn't `source`, has a single primary first-hop
-/// (ECMP at the SPF level is skipped — see PR #547 for the design
-/// rationale), and isn't a pseudonode, paired with the protected
+/// (ECMP at the SPF level is skipped by design), and isn't a
+/// pseudonode, paired with the protected
 /// vertex X. Pure planning — the SPF work happens in
 /// `spf::tilfa_compute`.
 pub(super) fn tilfa_targets(

--- a/zebra-rs/src/isis/vrf.rs
+++ b/zebra-rs/src/isis/vrf.rs
@@ -109,7 +109,7 @@ pub fn spawn_isis_vrf(
         ctx,
         rib_rx,
         /* bfd_client_tx */ None,
-        /* stamp_client_tx (default-VRF only in Phase 1) */ None,
+        /* stamp_client_tx (default-VRF only) */ None,
         /* bgp_tx */ None,
         policy_tx.clone(),
         proto.clone(),

--- a/zebra-rs/src/nd/engine.rs
+++ b/zebra-rs/src/nd/engine.rs
@@ -757,7 +757,7 @@ mod tests {
         assert!(eng.is_enabled(7));
     }
 
-    // ── New tests for PR 2 ───────────────────────────────────────────────
+    // ── New tests ────────────────────────────────────────────────────────
 
     #[test]
     fn rx_counters_increment_per_type() {

--- a/zebra-rs/src/ospf/area.rs
+++ b/zebra-rs/src/ospf/area.rs
@@ -12,7 +12,7 @@ pub const AREA0: Ipv4Addr = Ipv4Addr::UNSPECIFIED;
 /// RFC 3101 §2.2 NSSA translator-role configuration knob for an
 /// NSSA ABR. `Candidate` is the default and triggers election among
 /// the area's ABRs via the Nt-bit. `Always` forces translation
-/// unconditionally; `Never` disables it. Storage-only in phase 1.
+/// unconditionally; `Never` disables it. Storage-only for now.
 #[derive(Debug, Default, PartialEq, Clone, Copy)]
 pub enum NssaTranslatorRole {
     #[default]

--- a/zebra-rs/src/ospf/config_v3.rs
+++ b/zebra-rs/src/ospf/config_v3.rs
@@ -516,7 +516,7 @@ fn config_ospfv3_area_type(ospf: &mut Ospf<Ospfv3>, mut args: Args, op: ConfigOp
     // fresh on entry, flushes on exit.
     ospf.nssa_redist_connected_resync_v3(area_id);
     // Area-type also flips whether we should be translating
-    // Type-7→Type-5 for this area (phase 6d). Resync clears
+    // Type-7→Type-5 for this area. Resync clears
     // stale Type-5s on exit and seeds fresh ones on entry (if
     // we are an ABR with translator-role = Always or are the
     // Candidate-elected winner).
@@ -1737,7 +1737,7 @@ fn config_ospfv3_interface_flex_algo_prefix_sid_absolute(
 /// originated (on enable) or flushed (on disable). Mirrors v2's
 /// `config_ospf_sr_mpls`.
 /// `/router/ospfv3/segment-routing/srv6/locator` — name of a locator
-/// from the global /segment-routing/locator list (RFC 9513 Phase 2,
+/// from the global /segment-routing/locator list (RFC 9513,
 /// `docs/design/ospfv3-srv6-plan.md`). Mirrors the IS-IS staging
 /// convention: the name is held as a string and only resolves once
 /// the global locator commits — `reconcile_locator_watch` registers

--- a/zebra-rs/src/ospf/inst.rs
+++ b/zebra-rs/src/ospf/inst.rs
@@ -512,7 +512,7 @@ pub struct Ospf<V: OspfVersion = Ospfv2> {
     /// before OSPF). Used by [`Ospf::stamp_reconcile_link`] to
     /// (un)subscribe per-link measurement sessions for `te-metric
     /// measurement` interfaces. `None` for per-VRF children (sessions
-    /// are default-VRF only in Phase 1) or if STAMP failed to start.
+    /// are default-VRF only) or if STAMP failed to start.
     /// Only v2 ever subscribes — the v3 config tree has no
     /// measurement block.
     pub stamp_client_tx: Option<UnboundedSender<crate::stamp::client::ClientReq>>,
@@ -907,7 +907,7 @@ impl<V: OspfVersion> Ospf<V> {
             nbr.bfd_session_key = None;
             nbr.bfd_session_params = None;
         }
-        // Fast-reroute switchover (kernel-failover phase 4): rewire the
+        // Fast-reroute switchover (kernel-failover): rewire the
         // pre-installed protection groups onto their TI-LFA repairs NOW,
         // before the teardown-driven SPF / per-prefix reinstall pipeline
         // starts. The address is the neighbour's hello source — exactly
@@ -6656,7 +6656,7 @@ impl Ospf<Ospfv3> {
 
     /// Look up the v3 YANG-path handler for `msg.paths` and invoke
     /// it. Mirrors v2's `process_cm_msg`. Currently only
-    /// `/router/ospfv3/area/interface/enable` is registered (#791-stub
+    /// `/router/ospfv3/area/interface/enable` is registered (stub
     /// path); more leaves land alongside the YANG schema expansion.
     pub fn process_cm_msg(&mut self, msg: ConfigRequest) {
         // CommitEnd: fan out to per-VRF children and prune deleted
@@ -7223,7 +7223,7 @@ impl Ospf<Ospfv3> {
         // interface address as a /128 host prefix. Peers use it as the
         // SRv6 End.X nexthop — Linux's seg6local End.X cannot resolve
         // a link-local nexthop correctly (it re-looks nh6 up with the
-        // packet's ingress iif, PR #1361), so the global is the only
+        // packet's ingress iif), so the global is the only
         // reliable kernel programming and OSPFv3 has no other channel
         // that carries neighbor global addresses.
         prefixes.extend(
@@ -10144,7 +10144,7 @@ impl Ospf<Ospfv3> {
     /// Per RFC 2328 §13.3 step 1(d), every LSA sent to a neighbor
     /// is added to that neighbor's retransmit list so the
     /// retransmit timer can resend it until acknowledged. Same
-    /// shape as `flood_lsa_through_area`'s bookkeeping (#808).
+    /// shape as `flood_lsa_through_area`'s bookkeeping.
     fn flood_link_scope_lsa(&mut self, ifindex: u32, lsa: &ospf_packet::Ospfv3Lsa) {
         use ospf_packet::{Ospfv3LsUpdate, Ospfv3Packet, Ospfv3Payload};
 
@@ -10219,7 +10219,7 @@ impl Ospf<Ospfv3> {
     ///   in that case, flush the previous LSA so receivers age it
     ///   out.
     /// - Look up the existing area-LSDB entry via
-    ///   `lookup_by_raw_key` (#779). Key is
+    ///   `lookup_by_raw_key`. Key is
     ///   `(OSPFV3_INTRA_AREA_PREFIX_LSA_TYPE, link_state_id=0,
     ///   advertising_router=self.router_id)`.
     /// - Bump `ls_seq_number` past the prior entry, restamp via
@@ -10831,8 +10831,8 @@ impl Ospf<Ospfv3> {
     /// caller then uses the hello-source link-local, and the
     /// Link-LSA-arrival reconcile upgrades the install later.
     ///
-    /// The preference is the same Linux kernel constraint as IS-IS
-    /// (PR #1361): seg6local End.X resolves nh6 with iif = the
+    /// The preference is the same Linux kernel constraint as IS-IS:
+    /// seg6local End.X resolves nh6 with iif = the
     /// packet's ingress interface, so a link-local nexthop matches
     /// fe80::/64 on the wrong link and blackholes.
     fn neighbor_global_nh6(&self, ifindex: u32, nbr_router_id: Ipv4Addr) -> Option<Ipv6Addr> {
@@ -10944,7 +10944,7 @@ impl Ospf<Ospfv3> {
 
     /// Send the SidAdd pair for an End.X: the advertised /128 (classic
     /// End.X or uA) and, for uSID locators, the LIB twin at
-    /// block:function with the NEXT-CSID flavor (PR #1364 semantics).
+    /// block:function with the NEXT-CSID flavor.
     /// Returns the LIB twin address when one was installed.
     fn install_endx_kernel(
         &self,
@@ -11041,7 +11041,7 @@ impl Ospf<Ospfv3> {
     /// the catch-up sweep after a locator resolves (adjacencies may
     /// have reached Full before SRv6 was active). Enumerates ALL
     /// links unconditionally: filtering on config/state here is the
-    /// PR #1358 disable-after-teardown trap.
+    /// disable-after-teardown trap.
     fn sweep_endx_sids(&mut self) {
         let pairs: Vec<(u32, Ipv4Addr)> = self
             .links
@@ -11166,7 +11166,7 @@ impl Ospf<Ospfv3> {
             }
         }
 
-        // Adjacency-SID label allocation. Mirrors v2 (#850): each Full
+        // Adjacency-SID label allocation. Mirrors v2: each Full
         // adjacency claims one label out of the SRLB on transition
         // into Full and releases it on regression. Consumed by the
         // LAN-Adj-SID origination path (broadcast / NBMA links) and
@@ -11656,7 +11656,7 @@ impl Ospf<Ospfv3> {
     /// `self.v3_recv_rx` is taken out of the `Option` at start so
     /// the `select!` arm doesn't have to re-borrow it through the
     /// `&mut self` used by `process_*`. `Ospf<Ospfv3>::new` always
-    /// populates it (#768).
+    /// populates it.
     pub async fn event_loop(&mut self) {
         let mut v3_recv_rx = self
             .v3_recv_rx
@@ -11790,7 +11790,7 @@ pub enum Message<V: OspfVersion = Ospfv2> {
     /// re-evaluate SRv6 End.X nexthops, because the neighbor's global
     /// address (LA-bit /128 in its Link-LSA) may have just arrived
     /// and the kernel End.X entry must drift from the link-local to
-    /// it (Linux resolves End.X nh6 by ingress iif — PR #1361).
+    /// it (Linux resolves End.X nh6 by ingress iif).
     /// v3-only; the v2 handler ignores it.
     Srv6EndxReconcile(u32),
     /// Retransmit LSAs to a specific neighbor.

--- a/zebra-rs/src/ospf/packet_v3.rs
+++ b/zebra-rs/src/ospf/packet_v3.rs
@@ -716,7 +716,7 @@ fn ospfv3_lsa_lookup_raw<'a>(
 }
 
 /// Convenience wrapper that takes an `Ospfv3LsaHeader`. Used by
-/// DBD recv (#779) where the header is what gets iterated.
+/// DBD recv where the header is what gets iterated.
 fn ospfv3_lsa_lookup<'a>(
     oi: &'a OspfInterface<Ospfv3>,
     h: &Ospfv3LsaHeader,
@@ -921,7 +921,7 @@ fn ospfv3_packet_ls_req_set(nbr: &Neighbor<Ospfv3>, ls_req: &mut Ospfv3LsRequest
 /// 12-octet `Ospfv3LsRequestEntry` records (reserved/u16 + ls_type/u16 +
 /// link_state_id/u32 + advertising_router/Ipv4Addr), one for each
 /// LSA the peer holds but we don't (populated by
-/// `ospfv3_db_desc_proc` in #779). Sent unicast to the neighbor's
+/// `ospfv3_db_desc_proc`). Sent unicast to the neighbor's
 /// link-local v6 via the dedicated v3 send channel.
 #[ospf_packet_handler(LsRequest, Send)]
 pub fn ospfv3_ls_req_send(
@@ -1385,7 +1385,7 @@ fn ospfv3_ls_upd_proc(
     }
     // RFC 3101 §2.5 (inherited by v3): Type-7 NSSA-LSAs (0x2007)
     // are accepted only in NSSA areas. Option-bit negotiation
-    // (phase 1) usually prevents the adjacency in the first
+    // usually prevents the adjacency in the first
     // place, but defend against misconfigured peers.
     if h.ls_type == OSPFV3_NSSA_LSA_TYPE && !oi.area_type.is_nssa() {
         tracing::info!(

--- a/zebra-rs/src/ospf/show_v3.rs
+++ b/zebra-rs/src/ospf/show_v3.rs
@@ -2531,7 +2531,7 @@ fn render_ospfv3_srv6_text(v: &Ospfv3Srv6Json) -> Result<String, std::fmt::Error
 /// `show ospfv3 srv6` — the operational SRv6 view: the configured /
 /// resolved locator, the End/uN SID, and one row per adjacency End.X
 /// with the *installed* nexthop (the neighbor's global once its
-/// Link-LSA delivered one — the #1361 kernel constraint makes this
+/// Link-LSA delivered one — the kernel constraint makes this
 /// the column operators check first) and the uA(LIB) twin.
 fn show_ospfv3_srv6(
     top: &Ospf<Ospfv3>,

--- a/zebra-rs/src/ospf/srv6.rs
+++ b/zebra-rs/src/ospf/srv6.rs
@@ -1,4 +1,4 @@
-//! OSPFv3 SRv6 (RFC 9513) — SRv6 Locator LSA origination. Phase 2 of
+//! OSPFv3 SRv6 (RFC 9513) — SRv6 Locator LSA origination. Part of
 //! `docs/design/ospfv3-srv6-plan.md`: the locator configured under
 //! `router ospfv3 segment-routing srv6 locator <name>` resolves
 //! against the RIB locator registry and is advertised as an SRv6

--- a/zebra-rs/src/ospf/tilfa.rs
+++ b/zebra-rs/src/ospf/tilfa.rs
@@ -467,7 +467,7 @@ fn adj_sid_label_for_link_v3(
 }
 
 // ---------------------------------------------------------------------
-// SRv6 TI-LFA repairs (RFC 9513) — Phase 5 of
+// SRv6 TI-LFA repairs (RFC 9513) — Part of
 // docs/design/ospfv3-srv6-plan.md.
 // ---------------------------------------------------------------------
 

--- a/zebra-rs/src/ospf/vrf.rs
+++ b/zebra-rs/src/ospf/vrf.rs
@@ -120,7 +120,7 @@ pub fn spawn_ospf_vrf_v2(
         // Per-VRF OSPF BFD is deferred (the BFD instance is default-table
         // only); `None` makes per-interface `bfd` inert in a VRF for now.
         None,
-        // Per-VRF STAMP likewise (sessions are default-VRF only, Phase 1).
+        // Per-VRF STAMP likewise (sessions are default-VRF only).
         None,
     );
     let cm_tx = ospf.cm.tx.clone();

--- a/zebra-rs/src/rib/client.rs
+++ b/zebra-rs/src/rib/client.rs
@@ -132,7 +132,7 @@ impl RibClient {
 
     /// Trigger the fast-reroute switchover for every protection
     /// indirection group whose primary rides the failed adjacency at
-    /// `addr` (phase 2 of the kernel-failover design). Protocols call
+    /// `addr` (the switchover in the kernel-failover design). Protocols call
     /// this on a BFD-down-with-link-up detection, BEFORE starting
     /// SPF, so traffic moves to the pre-installed TI-LFA repairs in
     /// O(adjacencies) while reconvergence runs.

--- a/zebra-rs/src/rib/inst.rs
+++ b/zebra-rs/src/rib/inst.rs
@@ -167,7 +167,7 @@ pub enum Message {
         proto: String,
         nh: std::net::IpAddr,
     },
-    /// Fast-reroute switchover trigger (phase 2 of
+    /// Fast-reroute switchover trigger (see
     /// `docs/design/nexthop-protect-kernel-failover.md`): the sender
     /// detected a primary-adjacency failure the kernel can't see (BFD
     /// down while the link stays up) at gateway `addr`. RIB rewires
@@ -176,7 +176,7 @@ pub enum Message {
     /// per group, independent of prefix count. The sender's normal
     /// SPF reconvergence then supersedes the bridge.
     // Constructed by RibClient::protect_switch, whose own
-    // expect(dead_code) (callers land in phase 3/4) roots it — and
+    // expect(dead_code) (callers arrive later) roots it — and
     // the construction inside keeps this variant live with it.
     ProtectSwitch {
         addr: IpAddr,

--- a/zebra-rs/src/rib/nexthop/inst.rs
+++ b/zebra-rs/src/rib/nexthop/inst.rs
@@ -198,7 +198,7 @@ pub struct NexthopProtect {
 
     // Kernel id of the protection indirection group (a 1-member
     // NHA_GROUP holding the primary) that protected routes reference
-    // instead of the member's own gid — the handle the phase-2
+    // instead of the member's own gid — the handle the
     // switchover swaps. 0 = no indirection: producers always emit 0
     // and the resolver allocates one only for a Uni primary (groups
     // can't nest, so a Multi primary's ECMP group is itself the

--- a/zebra-rs/src/rib/nexthop/map.rs
+++ b/zebra-rs/src/rib/nexthop/map.rs
@@ -208,7 +208,7 @@ impl NexthopMap {
 
     /// Fetch (or create) the protection indirection group for a
     /// (primary, backup) member pair. Protected routes reference this
-    /// gid; phase 2's switchover replaces its membership in place.
+    /// gid; the switchover replaces its membership in place.
     pub fn fetch_protect(&mut self, primary_gid: usize, backup_gid: usize) -> Option<&mut Group> {
         let key = (primary_gid, backup_gid);
         if let Some(&gid) = self.protect.get(&key) {

--- a/zebra-rs/src/rib/route.rs
+++ b/zebra-rs/src/rib/route.rs
@@ -1750,7 +1750,7 @@ fn rib_resolve_nexthop(
 /// primary and stamp its id into `pro.gid`. Only a Uni primary gets
 /// one — kernel groups can't nest, so a Multi primary's ECMP group is
 /// itself the future switch point and `pro.gid` stays 0 (routes then
-/// reference the member gids directly, exactly as before phase 1).
+/// reference the member gids directly, exactly as without protection).
 fn resolve_nexthop_protect(pro: &mut NexthopProtect, nmap: &mut NexthopMap) {
     let NexthopMember::Uni(primary) = &pro.primary else {
         return;
@@ -1787,7 +1787,7 @@ fn resolve_nexthop_protect(pro: &mut NexthopProtect, nmap: &mut NexthopMap) {
     pro.gid = group.gid();
 }
 
-/// Fast-reroute switchover (phase 2 of the kernel-failover design):
+/// Fast-reroute switchover in the kernel-failover design:
 /// rewire every protection indirection group whose primary rides the
 /// failed `(table_id, addr)` adjacency onto its repair — one atomic
 /// `RTM_NEWNEXTHOP` replace per group, O(protected adjacencies) and
@@ -1818,7 +1818,7 @@ pub async fn protect_switch(
         switched += 1;
     }
 
-    // ECMP leg eviction (phase 5): TI-LFA computes no repair for
+    // ECMP leg eviction: TI-LFA computes no repair for
     // SPF-level ECMP destinations — the surviving legs are the
     // protection — so for Multi groups the fast path is dropping the
     // dead leg from the kernel membership, one atomic replace per
@@ -1844,7 +1844,7 @@ pub async fn protect_switch(
             // deleting the group would cascade-remove its routes out
             // from under the route sync. Mark it invalid and let the
             // teardown-driven SPF replace the routes (same blackhole
-            // window as before phase 5).
+            // window as without leg eviction).
             multi.set_valid(false);
             continue;
         }
@@ -2851,11 +2851,11 @@ mod tests {
         assert!(backup_uni.gid != 0, "backup Uni gets its own group");
     }
 
-    /// Phase 1 of the kernel-failover design: a Uni primary gets a
+    /// In the kernel-failover design, a Uni primary gets a
     /// protection indirection group allocated and stamped into
     /// `pro.gid`; the same (primary, backup) pair on a second entry
     /// dedupes onto the same gid (that sharing is what makes the
-    /// phase-2 switchover O(1) in prefixes).
+    /// switchover O(1) in prefixes).
     #[test]
     fn protect_uni_primary_allocates_indirection_group() {
         use super::super::entry::RibEntry;
@@ -2912,7 +2912,7 @@ mod tests {
         assert_eq!(nmap.get(pro_b.gid).unwrap().refcnt(), 2);
     }
 
-    /// Phase 2: candidate selection for the switchover walks only
+    /// Candidate selection for the switchover walks only
     /// protection groups whose ACTIVE primary rides the failed
     /// (table, addr) adjacency and whose repair is actually usable.
     #[test]
@@ -3016,7 +3016,7 @@ mod tests {
         );
     }
 
-    /// Phase 2: a switched group encodes the repair as its kernel
+    /// A switched group encodes the repair as its kernel
     /// member, and a producer re-adding the same pair (post-flap SPF)
     /// reverts it to the primary with a pending re-install.
     #[test]
@@ -3079,7 +3079,7 @@ mod tests {
         );
     }
 
-    /// Phase 5: a BFD-dead leg makes its ECMP groups eviction
+    /// A BFD-dead leg makes its ECMP groups eviction
     /// candidates, keyed by the leg's (table, addr); the leg itself
     /// is marked invalid so the sync passes can't resurrect it.
     #[test]
@@ -3195,7 +3195,7 @@ mod tests {
     /// The nesting constraint: a Multi (ECMP) primary gets NO
     /// indirection group — its own ECMP group is the future switch
     /// point — so `pro.gid` stays 0 and routes reference member gids
-    /// exactly as before phase 1.
+    /// exactly as without protection.
     #[test]
     fn protect_multi_primary_gets_no_indirection_group() {
         use super::super::entry::RibEntry;

--- a/zebra-rs/src/stamp/inst.rs
+++ b/zebra-rs/src/stamp/inst.rs
@@ -135,8 +135,8 @@ pub struct Stamp {
     /// requested and the bind succeeded (the `[::]:862` listener is
     /// non-fatal — `None` means v6 sessions can't be reflected).
     pub local_addr_v6: Option<SocketAddrV6>,
-    /// Config-manager subscription endpoints. STAMP has no own config
-    /// in Phase 1; every commit broadcast is drained (registering as a
+    /// Config-manager subscription endpoints. STAMP has no own config;
+    /// every commit broadcast is drained (registering as a
     /// config client also lets the manager see the task is running).
     pub cm: ConfigChannel,
     /// `show stamp ...` endpoints, dispatched through [`Self::show_cb`].
@@ -488,7 +488,7 @@ impl Stamp {
             return;
         }
         session.rx_count += 1;
-        // Track the T4 source on accepted samples (Phase 1.5 rung 1) —
+        // Track the T4 source on accepted samples —
         // the figure of merit for "is kernel timestamping live".
         if t4_kernel {
             session.t4_kernel += 1;
@@ -577,7 +577,7 @@ impl Stamp {
         }
     }
 
-    /// STAMP has no own config in Phase 1 — drain every broadcast.
+    /// STAMP has no own config — drain every broadcast.
     fn process_cm_msg(&mut self, _msg: ConfigRequest) {}
 
     async fn process_show_msg(&self, msg: DisplayRequest) {
@@ -875,7 +875,7 @@ mod tests {
         }
     }
 
-    /// Step 3: with a v6 reflector bound, a v6 session key takes the
+    /// With a v6 reflector bound, a v6 session key takes the
     /// `add_session` v6 branch — a v6 connected sender socket and a
     /// live session with a real ssid.
     #[tokio::test]
@@ -890,7 +890,7 @@ mod tests {
         assert_ne!(stamp.sessions.get(&key).unwrap().ssid, 0);
     }
 
-    /// Step 3: a probe from a registered v6 remote is reflected over the
+    /// A probe from a registered v6 remote is reflected over the
     /// v6 write loop; the same probe is dropped (no reflection counted)
     /// when no v6 reflector bound — the family-routing in `on_probe_recv`.
     #[tokio::test]

--- a/zebra-rs/src/stamp/mod.rs
+++ b/zebra-rs/src/stamp/mod.rs
@@ -1,6 +1,6 @@
 //! STAMP (RFC 8762) active link-delay measurement.
 //!
-//! Phase 1 of the SR-MPLS TE plan (`docs/design/stamp-sr-mpls-te-plan.md`,
+//! Part of the SR-MPLS TE plan (`docs/design/stamp-sr-mpls-te-plan.md`,
 //! steps in `docs/design/stamp-phase1-implementation-plan.md`): an
 //! unauthenticated Session-Sender per measured P2P link plus an
 //! implicit Session-Reflector for registered peers. The damped

--- a/zebra-rs/src/stamp/network.rs
+++ b/zebra-rs/src/stamp/network.rs
@@ -5,7 +5,7 @@
 //!   * [`reflector_read`] — `recvmsg` on the wildcard reflector socket
 //!     with `IP_PKTINFO` + `IP_RECVTTL` + `SCM_TIMESTAMPING` ancillary
 //!     data; takes T2 from the kernel software receive stamp when
-//!     present (Phase 1.5 rung 1), else a userspace read, and forwards
+//!     present, else a userspace read, and forwards
 //!     parsed probes to the event loop;
 //!   * [`reflector_write`] — drains [`ReflectRequest`]s, sending each
 //!     reply via `sendmsg` with the source address forced to the
@@ -135,7 +135,7 @@ pub async fn reflector_read(sock: Arc<AsyncFd<Socket>>, tx: UnboundedSender<Mess
 /// `SCM_TIMESTAMPING` ancillary data. The probe `src` carries its
 /// scope id (the ingress ifindex), and the probed link-local
 /// destination (`dst`) plus the ingress `ifindex` flow through so the
-/// reply can be stamped and pinned (Step 3 / [`reflector_write_v6`]).
+/// reply can be stamped and pinned (see [`reflector_write_v6`]).
 /// T2 comes from the kernel software stamp when present, else a
 /// userspace read — identical to the v4 path.
 pub async fn reflector_read_v6(sock: Arc<AsyncFd<Socket>>, tx: UnboundedSender<Message>) {
@@ -226,7 +226,7 @@ pub async fn reflector_write(
 ) {
     while let Some(req) = rx.recv().await {
         let SocketAddr::V4(dst) = req.dst else {
-            continue; // IPv4 only in Phase 1
+            continue; // IPv4 only
         };
         let mut buf = BytesMut::new();
         req.reply.emit(&mut buf);
@@ -323,8 +323,8 @@ pub async fn reflector_write_v6(
 }
 
 /// Extract the software receive timestamp from an `SCM_TIMESTAMPING`
-/// ancillary message, if the kernel attached one (Phase 1.5 rung 1,
-/// enabled by [`super::socket::set_so_timestamping_rx`]). The `system`
+/// ancillary message, if the kernel attached one (enabled by
+/// [`super::socket::set_so_timestamping_rx`]). The `system`
 /// field carries the software (CLOCK_REALTIME) stamp; an all-zero value
 /// means the kernel didn't stamp this datagram, so we report `None` and
 /// the caller falls back to a userspace `now_ntp()`.
@@ -406,7 +406,7 @@ mod tests {
     use crate::context::ProtoContext;
     use crate::stamp::socket::{stamp_reflector_socket, stamp_reflector_socket_v6};
 
-    /// Phase 1.5 rung 1: a socket built with `set_so_timestamping_rx`
+    /// A socket built with `set_so_timestamping_rx`
     /// receives a software RX timestamp in the `SCM_TIMESTAMPING`
     /// ancillary message on loopback (software stamps are stack-level,
     /// so they work without NIC support), and `kernel_rx_stamp`
@@ -456,7 +456,7 @@ mod tests {
         );
     }
 
-    /// v6 parity for the rung-1 RX stamp (Step 6): a `[::]`-bound v6
+    /// v6 parity for the rung-1 RX stamp: a `[::]`-bound v6
     /// reflector socket also gets a software `SCM_TIMESTAMPING` stamp on
     /// the `::1` loopback, decoded the same way as the v4 path. This
     /// exercises the v6 receive cmsg set (`in6_pktinfo` + hop-limit +

--- a/zebra-rs/src/stamp/session.rs
+++ b/zebra-rs/src/stamp/session.rs
@@ -111,7 +111,7 @@ pub struct Session {
     /// computed negative / absurd (clock step during the probe).
     pub rx_invalid_count: u64,
     /// Accepted samples whose T4 came from a kernel `SO_TIMESTAMPING`
-    /// stamp (Phase 1.5 rung 1) vs a userspace fallback read. The ratio
+    /// stamp vs a userspace fallback read. The ratio
     /// is the figure of merit for whether kernel timestamping is live.
     pub t4_kernel: u64,
     pub t4_userspace: u64,
@@ -299,7 +299,7 @@ mod tests {
         Session::new(key, SessionParams::default(), ssid, sock, read_task)
     }
 
-    /// Step 4: two IPv6 link-local sessions share remote `fe80::1` but
+    /// Two IPv6 link-local sessions share remote `fe80::1` but
     /// hang off different interfaces. The allow-list disambiguates by
     /// ingress ifindex, matching the probe to the session on its own
     /// link — never the other that merely shares the address.

--- a/zebra-rs/src/stamp/show.rs
+++ b/zebra-rs/src/stamp/show.rs
@@ -74,7 +74,7 @@ struct StampSessionJson {
     tx_failed_count: u64,
     reflected_count: u64,
     /// Accepted samples whose T4 came from a kernel `SO_TIMESTAMPING`
-    /// stamp vs a userspace fallback (Phase 1.5 rung 1).
+    /// stamp vs a userspace fallback.
     t4_kernel: u64,
     t4_userspace: u64,
     window_sent: u32,

--- a/zebra-rs/src/stamp/socket.rs
+++ b/zebra-rs/src/stamp/socket.rs
@@ -14,15 +14,15 @@
 //!     `SocketAddrV6` scope id (ifindex) makes the 4-tuple unambiguous
 //!     across interfaces that share an `fe80::` address.
 //!
-//! All of them enable software RX `SO_TIMESTAMPING` (Phase 1.5 rung 1)
+//! All of them enable software RX `SO_TIMESTAMPING`
 //! so the receive timestamps (T2 / T4) come from the kernel network
 //! stack rather than a post-wakeup userspace read — see
 //! [`set_so_timestamping_rx`].
 //!
 //! Egress TTL / Hop Limit is 255 on every socket: probes between direct
 //! IGP neighbors should arrive with TTL 255, and the received value is
-//! surfaced for `show stamp` (a GTSM-style floor is *not* enforced in
-//! Phase 1 — the reflector allow-list is the admission gate).
+//! surfaced for `show stamp` (a GTSM-style floor is *not* enforced —
+//! the reflector allow-list is the admission gate).
 
 use std::net::{SocketAddrV4, SocketAddrV6};
 use std::os::fd::AsRawFd;
@@ -44,7 +44,7 @@ pub fn stamp_reflector_socket(ctx: &ProtoContext, bind: SocketAddrV4) -> std::io
     socket.set_ttl_v4(255)?;
     set_ipv4_recvttl(&socket)?;
     set_ipv4_pktinfo(&socket)?;
-    // Phase 1.5 rung 1: kernel-stamp the probe receive (T2) so the
+    // Kernel-stamp the probe receive (T2) so the
     // reflector residence we report to peers excludes our RX scheduling
     // latency. Non-fatal — falls back to the userspace stamp.
     set_so_timestamping_rx(&socket);
@@ -66,7 +66,7 @@ pub fn stamp_sender_socket(
 
     socket.set_nonblocking(true)?;
     socket.set_ttl_v4(255)?;
-    // Phase 1.5 rung 1: kernel-stamp the reply receive (T4) so our own
+    // Kernel-stamp the reply receive (T4) so our own
     // delay math excludes the daemon RX scheduling tail (the `d` term
     // in the offload-notes §9b.1 error budget). Non-fatal.
     set_so_timestamping_rx(&socket);
@@ -95,7 +95,7 @@ pub fn stamp_reflector_socket_v6(
     socket.set_unicast_hops_v6(255)?;
     set_ipv6_recvhoplimit(&socket)?;
     set_ipv6_recvpktinfo(&socket)?;
-    // Phase 1.5 rung 1: kernel-stamp the probe receive (T2). Non-fatal.
+    // Kernel-stamp the probe receive (T2). Non-fatal.
     set_so_timestamping_rx(&socket);
 
     socket.bind(&bind.into())?;
@@ -117,7 +117,7 @@ pub fn stamp_sender_socket_v6(
 
     socket.set_nonblocking(true)?;
     socket.set_unicast_hops_v6(255)?;
-    // Phase 1.5 rung 1: kernel-stamp the reply receive (T4). Non-fatal.
+    // Kernel-stamp the reply receive (T4). Non-fatal.
     set_so_timestamping_rx(&socket);
 
     socket.bind(&local.into())?;
@@ -230,13 +230,13 @@ mod tests {
     use super::*;
     use crate::context::ProtoContext;
 
-    /// Step 1 of the STAMP IPv6 slice: both v6 socket builders succeed
+    /// Both v6 socket builders succeed
     /// on the `::1` loopback. This pins the option set the kernel must
     /// accept — `IPV6_V6ONLY`, hop-limit 255, `IPV6_RECVHOPLIMIT` /
     /// `IPV6_RECVPKTINFO`, and software RX `SO_TIMESTAMPING` — and that
     /// a connected sender can be `bind`/`connect`ed to the reflector's
     /// ephemeral port. The v6 read/write/stamp paths are exercised in
-    /// the `network` module (Step 2).
+    /// the `network` module.
     #[tokio::test]
     async fn ipv6_sockets_build() {
         let ctx = ProtoContext::default_table_no_rib();
@@ -252,7 +252,7 @@ mod tests {
             .port();
 
         // Loopback has no link scope, so scope id 0 is correct here; the
-        // ifindex-scoped link-local path is covered by the BDD (Step 6).
+        // ifindex-scoped link-local path is covered by the BDD.
         let local = SocketAddrV6::new(Ipv6Addr::LOCALHOST, 0, 0, 0);
         let remote = SocketAddrV6::new(Ipv6Addr::LOCALHOST, port, 0, 0);
         let _sender = stamp_sender_socket_v6(&ctx, local, remote).expect("v6 sender socket builds");


### PR DESCRIPTION
## Summary

Release prep: strip development-tracking artifacts — internal PR numbers and implementation-rollout phase/slice labels — that leaked into **source comments** and **user-facing book chapters**. These reference the dev team's own staged rollout and issue tracker, not anything a reader needs.

- **Source comments** (~47 files across bgp, ospf, isis, stamp, rib, nd, config, and the `bgp-packet`/`isis-packet`/`bfd-packet` crates): drop `#NNNN` / `PR #NNNN` references and `Phase N` / `slice N` rollout labels, rewording each to keep the technical statement intact (e.g. *"Phase 2 computes the verdict"* → *"This computes the verdict"*; *"the #1361 kernel constraint"* → *"the kernel constraint"*).
- **Book**: rework the `Phase N` references in `ch-06-01-session-design` and `ch-06-00-vty-access` into plain "future work" / "follow-up" wording, and drop the external `FRR PR #18789` citation in `ch-02-29` (kept the "FRR 10.4" attribution).

**Preserved deliberately:** RFC/spec algorithm terminology (OSPF SPF "phase 4a/4b", RFC 2328 "step N"), router names (`p1`/`p2`), and everything under `docs/design/` (internal design docs keep their phase/PR history).

## Test plan

Comment/doc-only — no code, identifiers, or behaviour changed. `cargo fmt --check` clean; `cargo build` clean; re-grep confirms the only remaining `Phase N` in source is the legitimate `RFC 3101 §3 … phase 4a/4b`.

Generated with [Claude Code](https://claude.com/claude-code)