### PR TITLE
bgp/mup: dataplane gtp programs the ST2 uplink decap via cradle

### DIFF
--- a/book/src/ch-02-35-bgp-mup.md
+++ b/book/src/ch-02-35-bgp-mup.md
@@ -214,7 +214,10 @@ dataplane`:
 * **`gtp`** — real **GTP-U**. The tunnel is programmed from the ST route's own
   endpoint and TEID (`GTP4.E` downlink / `H.M.GTP4.D` uplink) by the **cradle**
   eBPF forwarder, which zebra-rs drives over gRPC (`system cradle-grpc`). The
-  mainline kernel has no GTP action, so this mode requires cradle.
+  mainline kernel has no GTP action, so this mode requires cradle. The uplink
+  decap is wired: each Type-2 ST route's `(endpoint, TEID)` becomes a cradle
+  GTP-U PDR (`H.M.GTP4.D`) that strips a matching G-PDU into the VRF. The
+  downlink `GTP4.E` encap (the Type-1 ST toward the gNB) follows.
 
 ```
 vrf N6 {

--- a/proto/cradle.proto
+++ b/proto/cradle.proto
@@ -241,6 +241,18 @@ message L7Service {
   repeated L7Route routes = 3;
 }
 
+// A GTP-U decap PDR (H.M.GTP4.D): a G-PDU arriving on (dst, teid) is stripped
+// and its inner packet forwarded in vrf (0 = global). Mirrors the cradle server.
+message GtpPdr {
+  string dst = 1;   // local outer IPv4 destination the G-PDU arrives on
+  uint32 teid = 2;  // GTP-U TEID
+  uint32 vrf = 3;   // inner VRF table id (0 = global)
+}
+message GtpPdrDel {
+  string dst = 1;
+  uint32 teid = 2;
+}
+
 service Cradle {
   rpc SetPort(Port) returns (Empty);
   rpc SetL2Domain(L2Domain) returns (Empty);
@@ -258,6 +270,8 @@ service Cradle {
   rpc DelIlm(IlmDel) returns (Empty);
   rpc AddLocalSid(LocalSid) returns (Empty);
   rpc DelLocalSid(LocalSidDel) returns (Empty);
+  rpc AddGtpPdr(GtpPdr) returns (Empty);
+  rpc DelGtpPdr(GtpPdrDel) returns (Empty);
   rpc SetSrv6EncapSource(Srv6EncapSource) returns (Empty);
   rpc AddFdbRemote(FdbRemote) returns (Empty);
   rpc DelFdbRemote(FdbRemoteDel) returns (Empty);

--- a/zebra-rs/src/bgp/vrf/inst.rs
+++ b/zebra-rs/src/bgp/vrf/inst.rs
@@ -62,6 +62,10 @@ pub struct BgpVrf {
     /// doesn't yet re-key the running task (same spawn-time-capture
     /// limitation as `router_id`).
     pub rd: Option<bgp_packet::RouteDistinguisher>,
+    /// MUP `dataplane {end-dt46|gtp}` mode for this VRF, captured from the
+    /// config at spawn (same spawn-time-capture as `rd`/`router_id`). `Gtp`
+    /// programs GTP-U tunnels via cradle instead of the End.DT46 stand-in.
+    pub dataplane: super::super::vrf_config::MupDataplane,
     /// Config-manager subscription. Path-dispatch routes
     /// `/router/bgp/vrf/<name>/...` callbacks here so the per-VRF
     /// runtime owns its own commit sequencing.
@@ -184,6 +188,10 @@ pub struct BgpVrf {
     /// DSD's End.DT46 SID it is steered into. Diff base for
     /// `reconcile_mup_st2_dsd`, mirroring `mup_st1_isd_installed`.
     pub mup_st2_dsd_installed: std::collections::BTreeMap<ipnet::IpNet, std::net::Ipv6Addr>,
+    /// Installed GTP-U decap PDRs for `dataplane gtp` (the ST2 uplink /
+    /// `H.M.GTP4.D`): the set of (endpoint, TEID) tunnels teed to cradle. Diff
+    /// base for `reconcile_mup_gtp`.
+    pub mup_gtp_pdr_installed: std::collections::BTreeSet<(std::net::Ipv4Addr, u32)>,
 }
 
 /// Sender side of the per-VRF inbound channel — handed back to
@@ -627,6 +635,8 @@ impl BgpVrf {
             router_id,
             // Default unset; `spawn_bgp_vrf` sets it from the VRF config.
             rd: None,
+            // Default End.DT46; `spawn_bgp_vrf` sets it from the VRF config.
+            dataplane: super::super::vrf_config::MupDataplane::default(),
             cm: ConfigChannel::new(),
             show: ShowChannel::new(),
             global_tx,
@@ -650,6 +660,7 @@ impl BgpVrf {
             mup_st1_isd_installed: std::collections::BTreeMap::new(),
             mup_segment_transport: std::collections::BTreeMap::new(),
             mup_st2_dsd_installed: std::collections::BTreeMap::new(),
+            mup_gtp_pdr_installed: std::collections::BTreeSet::new(),
         };
         (vrf, inbox_tx)
     }
@@ -850,6 +861,57 @@ impl BgpVrf {
             }
             self.mup_encap_install(*ep, *sid, transport);
             self.mup_st2_dsd_installed.insert(*ep, *sid);
+        }
+    }
+
+    /// Install GTP-U decap PDRs for a `dataplane gtp` VRF — the ST2 uplink
+    /// (`H.M.GTP4.D`). Each selected Type-2 ST route's `(endpoint, TEID)`
+    /// becomes a cradle PDR: a G-PDU arriving on that tunnel is stripped and
+    /// its inner packet forwarded in this VRF's table. Cradle-only (the kernel
+    /// has no GTP action), diff-gated against `mup_gtp_pdr_installed`. The
+    /// downlink `GTP4.E` encap (ST1 → the gNB) is a follow-up; only the uplink
+    /// decap is installed here. Runs in place of the End.DT46 reconcilers when
+    /// the VRF's `dataplane` is `gtp`.
+    fn reconcile_mup_gtp(&mut self) {
+        use std::net::{IpAddr, Ipv4Addr};
+        let table_id = self.ctx.vrf_id();
+        // Desired PDRs: each selected ST2 with a v4 endpoint + non-zero TEID.
+        let mut desired: std::collections::BTreeSet<(Ipv4Addr, u32)> =
+            std::collections::BTreeSet::new();
+        for table in self.local_rib.mup.values() {
+            for prefix in table.selected.keys() {
+                if let bgp_packet::MupPrefix::T2st { endpoint, teid } = prefix
+                    && let IpAddr::V4(v4) = endpoint
+                    && *teid != 0
+                {
+                    desired.insert((*v4, *teid));
+                }
+            }
+        }
+        // Withdraw PDRs no longer desired.
+        let stale: Vec<(Ipv4Addr, u32)> = self
+            .mup_gtp_pdr_installed
+            .iter()
+            .filter(|k| !desired.contains(k))
+            .copied()
+            .collect();
+        for (dst, teid) in stale {
+            let _ = self
+                .ctx
+                .rib
+                .send(crate::rib::Message::CradleGtpPdrDel { dst, teid });
+            self.mup_gtp_pdr_installed.remove(&(dst, teid));
+        }
+        // Install new PDRs.
+        for (dst, teid) in &desired {
+            if !self.mup_gtp_pdr_installed.insert((*dst, *teid)) {
+                continue;
+            }
+            let _ = self.ctx.rib.send(crate::rib::Message::CradleGtpPdrAdd {
+                dst: *dst,
+                teid: *teid,
+                table_id,
+            });
         }
     }
 
@@ -1906,8 +1968,13 @@ impl BgpVrf {
                     .entry(rd)
                     .or_default()
                     .update(prefix, rib);
-                self.reconcile_mup_st1_isd();
-                self.reconcile_mup_st2_dsd();
+                match self.dataplane {
+                    super::super::vrf_config::MupDataplane::Gtp => self.reconcile_mup_gtp(),
+                    super::super::vrf_config::MupDataplane::EndDt46 => {
+                        self.reconcile_mup_st1_isd();
+                        self.reconcile_mup_st2_dsd();
+                    }
+                }
             }
             BgpVrfMsg::MupWithdraw { rd, prefix } => {
                 // Same own-RD scoping as MupUpdate. The VRF holds the single
@@ -1926,8 +1993,13 @@ impl BgpVrf {
                 if empty {
                     self.local_rib.mup.remove(&rd);
                 }
-                self.reconcile_mup_st1_isd();
-                self.reconcile_mup_st2_dsd();
+                match self.dataplane {
+                    super::super::vrf_config::MupDataplane::Gtp => self.reconcile_mup_gtp(),
+                    super::super::vrf_config::MupDataplane::EndDt46 => {
+                        self.reconcile_mup_st1_isd();
+                        self.reconcile_mup_st2_dsd();
+                    }
+                }
             }
             // VRF-first MUP origination: build the RD-free ST NLRI from the
             // dispatched session + resolved direction, and export it to the
@@ -2060,6 +2132,89 @@ mod tests {
         tokio::time::timeout(Duration::from_secs(2), vrf.event_loop())
             .await
             .expect("event_loop returns after Shutdown");
+    }
+
+    #[tokio::test]
+    async fn dataplane_gtp_reconciles_st2_endpoints_to_pdrs() {
+        use crate::bgp::route::{BgpRib, BgpRibType};
+        use bgp_packet::{BgpAttr, MupPrefix};
+        use std::net::{IpAddr, Ipv4Addr};
+
+        let (global_tx, _global_rx) = unbounded_channel::<BgpGlobalMsg>();
+        let ctx = test_ctx_for_vrf(42, "vrf-gtp");
+        let (_rib_tx, rib_rx) = mpsc::unbounded_channel();
+        let (mut vrf, _inbox) = BgpVrf::new(
+            "vrf-gtp".to_string(),
+            ctx,
+            Ipv4Addr::UNSPECIFIED,
+            65000,
+            /* label */ 16,
+            global_tx,
+            rib_rx,
+        );
+        vrf.dataplane = crate::bgp::vrf_config::MupDataplane::Gtp;
+
+        let attr = BgpAttr::new();
+        let mk = || {
+            BgpRib::new(
+                1,
+                Ipv4Addr::UNSPECIFIED,
+                BgpRibType::EBGP,
+                0,
+                0,
+                &attr,
+                None,
+                None,
+                false,
+            )
+        };
+        let rd: bgp_packet::RouteDistinguisher = "65000:1".parse().unwrap();
+        {
+            let table = vrf.local_rib.mup.entry(rd).or_default();
+            // v4 endpoint + non-zero TEID → a decap PDR.
+            table.selected.insert(
+                MupPrefix::T2st {
+                    endpoint: IpAddr::V4(Ipv4Addr::new(10, 9, 0, 1)),
+                    teid: 0x1234,
+                },
+                mk(),
+            );
+            // teid 0 (the null TEID) → skipped.
+            table.selected.insert(
+                MupPrefix::T2st {
+                    endpoint: IpAddr::V4(Ipv4Addr::new(10, 9, 0, 2)),
+                    teid: 0,
+                },
+                mk(),
+            );
+            // v6 endpoint → skipped (GTP4 only in this slice).
+            table.selected.insert(
+                MupPrefix::T2st {
+                    endpoint: "2001:db8::1".parse().unwrap(),
+                    teid: 0x5678,
+                },
+                mk(),
+            );
+        }
+
+        vrf.reconcile_mup_gtp();
+        assert!(
+            vrf.mup_gtp_pdr_installed
+                .contains(&(Ipv4Addr::new(10, 9, 0, 1), 0x1234))
+        );
+        assert_eq!(
+            vrf.mup_gtp_pdr_installed.len(),
+            1,
+            "only the v4, non-zero-TEID ST2 installs a decap PDR"
+        );
+
+        // The ST2 goes away → its PDR is withdrawn from the tracker.
+        vrf.local_rib.mup.get_mut(&rd).unwrap().selected.clear();
+        vrf.reconcile_mup_gtp();
+        assert!(
+            vrf.mup_gtp_pdr_installed.is_empty(),
+            "the decap PDR is withdrawn when its ST2 is gone"
+        );
     }
 
     #[tokio::test]

--- a/zebra-rs/src/bgp/vrf/spawn.rs
+++ b/zebra-rs/src/bgp/vrf/spawn.rs
@@ -178,6 +178,9 @@ pub fn spawn_bgp_vrf(
     // like router-id; an `rd` edit on a live VRF doesn't re-key the running
     // task yet (a follow-up adds respawn-on-edit, same as router-id).
     vrf.rd = cfg.rd;
+    // The MUP forwarding-plane mode (End.DT46 stand-in vs cradle GTP-U).
+    // Spawn-time capture like `rd`; a live `dataplane` edit respawns the VRF.
+    vrf.dataplane = cfg.mobile_uplane.dataplane;
 
     // Materialise per-VRF peers from the BgpVrfConfig snapshot.
     // `peer.start()`'s timer events get logged at debug and

--- a/zebra-rs/src/fib/cradle.rs
+++ b/zebra-rs/src/fib/cradle.rs
@@ -672,6 +672,46 @@ impl CradleFib {
         }
     }
 
+    /// Install a GTP-U decap PDR (`H.M.GTP4.D`): a G-PDU arriving on
+    /// (`dst`, `teid`) is stripped and its inner packet forwarded in the VRF
+    /// table `table_id` (0 = global). Cradle-only — the mainline kernel has no
+    /// GTP action, so this is never a kernel route.
+    pub async fn gtp_pdr_add(&self, dst: Ipv4Addr, teid: u32, table_id: u32) {
+        if let Err(e) = async {
+            self.client()
+                .await?
+                .add_gtp_pdr(pb::GtpPdr {
+                    dst: dst.to_string(),
+                    teid,
+                    vrf: cradle_vrf(table_id),
+                })
+                .await?;
+            anyhow::Ok(())
+        }
+        .await
+        {
+            tracing::warn!("fib: cradle gtp_pdr_add {dst} teid {teid} failed: {e}");
+        }
+    }
+
+    /// Remove a GTP-U decap PDR.
+    pub async fn gtp_pdr_del(&self, dst: Ipv4Addr, teid: u32) {
+        if let Err(e) = async {
+            self.client()
+                .await?
+                .del_gtp_pdr(pb::GtpPdrDel {
+                    dst: dst.to_string(),
+                    teid,
+                })
+                .await?;
+            anyhow::Ok(())
+        }
+        .await
+        {
+            tracing::debug!("fib: cradle gtp_pdr_del {dst} teid {teid} failed: {e}");
+        }
+    }
+
     /// EVPN-over-SRv6 overlay FDB entry (RFC 9252): `mac` in bridge domain
     /// `vni` sits behind the remote PE's L2 service SID (End.DT2U for
     /// unicast; the all-ones BUM sentinel carries End.DT2M). `nexthop_id: 0`

--- a/zebra-rs/src/fib/netlink/handle.rs
+++ b/zebra-rs/src/fib/netlink/handle.rs
@@ -549,6 +549,22 @@ impl FibHandle {
         }
     }
 
+    /// Install a GTP-U decap PDR (`H.M.GTP4.D`) into the cradle data plane: a
+    /// G-PDU on (`dst`, `teid`) is stripped and its inner packet forwarded in
+    /// VRF `table_id`. No kernel counterpart — the mainline kernel has no GTP
+    /// action, so cradle is the only forwarder for the MUP `dataplane gtp` mode.
+    pub async fn cradle_gtp_pdr_add(&self, dst: std::net::Ipv4Addr, teid: u32, table_id: u32) {
+        if let Some(cradle) = &self.cradle {
+            cradle.gtp_pdr_add(dst, teid, table_id).await;
+        }
+    }
+
+    pub async fn cradle_gtp_pdr_del(&self, dst: std::net::Ipv4Addr, teid: u32) {
+        if let Some(cradle) = &self.cradle {
+            cradle.gtp_pdr_del(dst, teid).await;
+        }
+    }
+
     /// Tee a resolved neighbor (ARP/ND) into the cradle data plane — its MPLS
     /// egress rewrite resolves destination MACs from this state. No-op when
     /// the tee is disabled.

--- a/zebra-rs/src/rib/inst.rs
+++ b/zebra-rs/src/rib/inst.rs
@@ -335,6 +335,18 @@ pub enum Message {
         vni: u32,
         sid: std::net::Ipv6Addr,
     },
+    /// MUP `dataplane gtp` uplink decap (`H.M.GTP4.D`): a GTP-U decap PDR teed
+    /// to cradle — a G-PDU on (`dst`, `teid`) is stripped and its inner packet
+    /// forwarded in VRF `table_id`. Cradle-only (the kernel has no GTP action).
+    CradleGtpPdrAdd {
+        dst: std::net::Ipv4Addr,
+        teid: u32,
+        table_id: u32,
+    },
+    CradleGtpPdrDel {
+        dst: std::net::Ipv4Addr,
+        teid: u32,
+    },
     /// A MAC the cradle eBPF datapath learned on a local L2 port (via the
     /// `WatchFdb` stream). Re-emitted to EVPN subscribers as a synthesized
     /// `RibRx::FdbAdd` — the cradle analogue of a kernel bridge FDB learn —
@@ -3122,6 +3134,18 @@ impl Rib {
             }
             Message::CradleReplDel { vni, sid } => {
                 self.fib_handle.cradle_repl_del(vni, sid).await;
+            }
+            Message::CradleGtpPdrAdd {
+                dst,
+                teid,
+                table_id,
+            } => {
+                self.fib_handle
+                    .cradle_gtp_pdr_add(dst, teid, table_id)
+                    .await;
+            }
+            Message::CradleGtpPdrDel { dst, teid } => {
+                self.fib_handle.cradle_gtp_pdr_del(dst, teid).await;
             }
             Message::MdbAdd {
                 vni,


### PR DESCRIPTION
## Summary

Make `router bgp vrf <name> afi-safi mup dataplane gtp` **actually forward**: a VRF in that mode now programs a real GTP-U decap PDR (**H.M.GTP4.D**) for each Type-2 ST route it holds, driven directly by the ST2's own `(endpoint, TEID)` — no segment resolution, **no kernel route** (the mainline kernel has no GTP action, so the tunnel is cradle-only).

The zebra-rs → cradle wire-up mirrors the EVPN FDB / replication-slot tee:

- **`proto/cradle.proto`** — `GtpPdr`/`GtpPdrDel` messages + `AddGtpPdr`/`DelGtpPdr` RPCs, matching the cradle server (added in cradle-rs#47).
- **`fib/cradle.rs`** — `gtp_pdr_add`/`del` build the pb message + gRPC call.
- **`fib/netlink/handle.rs`** — `cradle_gtp_pdr_add`/`del` tee wrappers on `FibHandle`.
- **`rib/inst.rs`** — `Message::CradleGtpPdrAdd`/`Del` + a handler that calls the tee (**cradle-only; never a kernel install**).
- **`bgp/vrf`** — `BgpVrf` gains the spawn-captured `dataplane` mode + a PDR tracker; `reconcile_mup_gtp` installs/withdraws a PDR per selected v4/non-zero-TEID ST2, and the MupUpdate/Withdraw handlers branch on `dataplane` (`Gtp` → `reconcile_mup_gtp`, else the End.DT46 reconcilers). A `gtp` VRF no longer installs the End.DT46 stand-in.

## Scope

The **uplink decap** only — the cleanest self-contained slice (one cradle call, no NHT). The downlink `GTP4.E` encap (Type-1 ST → gNB: a GTP nexthop + route + NHT) is a follow-up, as is a zebra-rs↔cradle end-to-end BDD (the cradle GTP datapath itself is already validated by `cradle_gtp`).

## Test plan

- New unit test `dataplane_gtp_reconciles_st2_endpoints_to_pdrs` — v4/non-zero-TEID ST2 installs a PDR; v6 and `teid=0` are skipped; withdraw removes it.
- fmt `--check` ✓ · clippy `--workspace --all-targets -D warnings` ✓ · build ✓ · mup suite (40) ✓.
- Book: the selector section notes the uplink decap is wired.

Generated with [Claude Code](https://claude.com/claude-code)