### PR TITLE
feat(bgp): show bgp evpn vpws + EVPN VPWS control-plane BDD

### DIFF
--- a/bdd/tests/configs/bgp_evpn_vpws/z1-1.yaml
+++ b/bdd/tests/configs/bgp_evpn_vpws/z1-1.yaml
@@ -1,0 +1,35 @@
+# z1 — EVPN VPWS PE (RFC 8214). One E-Line service (eline1, EVI 100):
+# advertises a per-EVI Ethernet A-D (Type-1) whose Ethernet Tag is the local
+# service instance id 101, carrying an End.DX2 L2-Service Prefix-SID carved
+# from LOC1, and imports z2's Type-1 (Ethernet Tag 102) as the remote end.
+# Control-plane only — no cradle dataplane; the AC name is not resolved here.
+segment-routing:
+  locator:
+  - name: LOC1
+    prefix: fcbb:bbbb:1::/48
+    behavior: usid
+router:
+  bgp:
+    global:
+      as: 65001
+      router-id: 192.168.0.1
+    segment-routing:
+      srv6:
+        locator: LOC1
+    afi-safi:
+    - name: evpn
+      vpws:
+      - name: eline1
+        evi: 100
+        local-service-id: 101
+        remote-service-id: 102
+        interface: ce1
+    neighbor:
+    - remote-address: 192.168.0.2
+      enabled: true
+      remote-as: 65001
+      afi-safi:
+      - name: ipv4
+        enabled: true
+      - name: evpn
+        enabled: true

--- a/bdd/tests/configs/bgp_evpn_vpws/z1-repoint.yaml
+++ b/bdd/tests/configs/bgp_evpn_vpws/z1-repoint.yaml
@@ -1,0 +1,34 @@
+# z1 with eline1's remote-service-id re-pointed at a service instance id
+# nobody advertises (999): the reconcile must drop the previously-bound
+# remote SID (state falls back from up to advertised) even though z2's
+# Type-1 (Ethernet Tag 102) is still in the Loc-RIB.
+segment-routing:
+  locator:
+  - name: LOC1
+    prefix: fcbb:bbbb:1::/48
+    behavior: usid
+router:
+  bgp:
+    global:
+      as: 65001
+      router-id: 192.168.0.1
+    segment-routing:
+      srv6:
+        locator: LOC1
+    afi-safi:
+    - name: evpn
+      vpws:
+      - name: eline1
+        evi: 100
+        local-service-id: 101
+        remote-service-id: 999
+        interface: ce1
+    neighbor:
+    - remote-address: 192.168.0.2
+      enabled: true
+      remote-as: 65001
+      afi-safi:
+      - name: ipv4
+        enabled: true
+      - name: evpn
+        enabled: true

--- a/bdd/tests/configs/bgp_evpn_vpws/z2-1.yaml
+++ b/bdd/tests/configs/bgp_evpn_vpws/z2-1.yaml
@@ -1,0 +1,32 @@
+# z2 — the other EVPN VPWS PE (mirror of z1): local service instance id 102,
+# remote 101, End.DX2 SID carved from LOC2.
+segment-routing:
+  locator:
+  - name: LOC2
+    prefix: fcbb:bbbb:2::/48
+    behavior: usid
+router:
+  bgp:
+    global:
+      as: 65001
+      router-id: 192.168.0.2
+    segment-routing:
+      srv6:
+        locator: LOC2
+    afi-safi:
+    - name: evpn
+      vpws:
+      - name: eline1
+        evi: 100
+        local-service-id: 102
+        remote-service-id: 101
+        interface: ce2
+    neighbor:
+    - remote-address: 192.168.0.1
+      enabled: true
+      remote-as: 65001
+      afi-safi:
+      - name: ipv4
+        enabled: true
+      - name: evpn
+        enabled: true

--- a/bdd/tests/features/bgp_evpn_vpws.feature
+++ b/bdd/tests/features/bgp_evpn_vpws.feature
@@ -1,0 +1,82 @@
+@serial
+@bgp_evpn_vpws
+Feature: BGP EVPN VPWS E-Line signalling over SRv6 (RFC 8214)
+  As a network operator
+  I want each PE's `vpws` service to advertise a per-EVI Ethernet A-D route
+  (Type-1) whose Ethernet Tag is its local service instance id, carrying an
+  End.DX2 L2-Service Prefix-SID (RFC 9252 §6.3) carved from the BGP SRv6
+  locator, and to bind the remote PE's Type-1 — matched by Ethernet Tag ==
+  remote-service-id within the shared EVI — as the E-Line's remote end, so
+  the point-to-point service signals with zero per-peer state.
+
+  Control-plane only: no cradle dataplane is attached, so the `interface`
+  leaf is just carried state and `show bgp evpn vpws` reaching `up` means
+  the Type-1 exchange and the remote-SID bind both worked.
+
+  Test Topology — two iBGP (AS 65001) EVPN speakers on a shared transport
+  bridge br0, one E-Line service between them:
+  ```
+  ┌─────────────────────────────────┐
+  │               br0               │
+  └───────┬─────────────────┬───────┘
+     ┌────┴────┐       ┌────┴────┐
+     │   z1    │       │   z2    │   vpws eline1: evi 100
+     │ .0.1/24 │       │ .0.2/24 │   z1 svc-id 101 ⇄ z2 svc-id 102
+     │  LOC1   │       │  LOC2   │
+     └─────────┘       └─────────┘
+  ```
+
+  Scenario: Setup topology and EVPN iBGP with a VPWS service on each PE
+    Given a clean test environment
+    When I create bridge "br0"
+    And I create namespace "z1" with IP "192.168.0.1/24" on bridge "br0"
+    And I create namespace "z2" with IP "192.168.0.2/24" on bridge "br0"
+    And I start zebra-rs in namespace "z1"
+    And I start zebra-rs in namespace "z2"
+    And I apply config "z1-1.yaml" to namespace "z1"
+    And I apply config "z2-1.yaml" to namespace "z2"
+    And I wait 10 seconds for BGP to operate
+    Then BGP session in "z1" to "192.168.0.2" should be "Established"
+
+  Scenario: Each PE originates a per-EVI Type-1 the other imports
+    Given the test topology exists
+    # z1 sees z2's per-EVI Ethernet A-D: [1]:[zero-ESI]:[eth-tag=102 — z2's
+    # local service instance id], distinct from a per-ES A-D (MAX-ET).
+    Then show command "show bgp evpn" in namespace "z1" should eventually contain "[1]:[00:00:00:00:00:00:00:00:00:00]:[102]"
+    # z2 symmetrically sees z1's Type-1 with Ethernet Tag 101.
+    And show command "show bgp evpn" in namespace "z2" should eventually contain "[1]:[00:00:00:00:00:00:00:00:00:00]:[101]"
+
+  Scenario: The VPWS service binds the remote End.DX2 SID and reaches up
+    Given the test topology exists
+    Then show command "show bgp evpn vpws" in namespace "z1" should eventually contain "VPWS service: eline1"
+    And show command "show bgp evpn vpws" in namespace "z1" should contain "EVI: 100"
+    And show command "show bgp evpn vpws" in namespace "z1" should contain "Service ID: local 101, remote 102"
+    # Our Type-1's End.DX2 SID is carved from LOC1's prefix ...
+    And show command "show bgp evpn vpws" in namespace "z1" should contain "Local SID (End.DX2): fcbb:bbbb:1:"
+    # ... and the bound remote SID from z2's LOC2.
+    And show command "show bgp evpn vpws" in namespace "z1" should eventually contain "Remote SID: fcbb:bbbb:2:"
+    And show command "show bgp evpn vpws" in namespace "z1" should contain "State: up"
+    And show command "show bgp evpn vpws" in namespace "z2" should eventually contain "State: up"
+
+  Scenario: Re-pointing remote-service-id rebinds from the Loc-RIB without a route churn
+    Given the test topology exists
+    # Point eline1 at a service instance id nobody advertises: the reconcile
+    # drops the stale remote SID (z2's Type-1 no longer matches) and the
+    # service falls back to advertised.
+    When I apply config "z1-repoint.yaml" to namespace "z1"
+    Then show command "show bgp evpn vpws" in namespace "z1" should eventually contain "State: advertised"
+    And show command "show bgp evpn vpws" in namespace "z1" should not contain "Remote SID:"
+    # Point it back: the already-imported Type-1 is re-found by the Loc-RIB
+    # rescan alone — z2 re-advertises nothing here.
+    When I apply config "z1-1.yaml" to namespace "z1"
+    Then show command "show bgp evpn vpws" in namespace "z1" should eventually contain "State: up"
+    And show command "show bgp evpn vpws" in namespace "z1" should contain "Remote SID: fcbb:bbbb:2:"
+
+  Scenario: Teardown topology
+    Given the test topology exists
+    When I stop zebra-rs in namespace "z1"
+    And I stop zebra-rs in namespace "z2"
+    And I delete namespace "z1"
+    And I delete namespace "z2"
+    And I delete bridge "br0"
+    Then the test environment should be clean

--- a/zebra-rs/src/bgp/show.rs
+++ b/zebra-rs/src/bgp/show.rs
@@ -2492,6 +2492,97 @@ fn show_bgp_evpn_summary(
     show_bgp_summary_one(bgp, AfiSafi::new(Afi::L2vpn, Safi::Evpn), json)
 }
 
+/// `show bgp evpn vpws` — the configured EVPN VPWS E-Line services (RFC
+/// 8214): EVI, service instance ids, attachment circuit, the local End.DX2
+/// SID our Type-1 advertises, the imported remote SID, and the service
+/// state — `partial-config` (mandatory leaves missing), `pending` (config
+/// complete, Type-1 not originated: no router-id / locator yet),
+/// `advertised` (Type-1 out, remote not yet matched), `up` (remote SID
+/// bound to the AC).
+#[derive(Serialize)]
+struct VpwsServiceJson {
+    name: String,
+    evi: Option<u32>,
+    local_service_id: Option<u32>,
+    remote_service_id: Option<u32>,
+    interface: Option<String>,
+    local_sid: Option<String>,
+    remote_sid: Option<String>,
+    state: String,
+}
+
+fn vpws_state(svc: &super::vpws::VpwsService) -> &'static str {
+    if svc.params().is_none() {
+        "partial-config"
+    } else if svc.originated.is_none() {
+        "pending"
+    } else if svc.remote_sid.is_none() {
+        "advertised"
+    } else {
+        "up"
+    }
+}
+
+fn show_bgp_evpn_vpws(
+    bgp: &Bgp,
+    _args: Args,
+    json: bool,
+) -> std::result::Result<String, std::fmt::Error> {
+    use std::fmt::Write;
+
+    let vpws = &bgp.local_rib.evpn_vpws;
+    if json {
+        let list: Vec<VpwsServiceJson> = vpws
+            .services
+            .iter()
+            .map(|(name, svc)| VpwsServiceJson {
+                name: name.clone(),
+                evi: svc.evi,
+                local_service_id: svc.local_service_id,
+                remote_service_id: svc.remote_service_id,
+                interface: svc.interface.clone(),
+                local_sid: vpws.sids.get(name).map(|(addr, _)| addr.to_string()),
+                remote_sid: svc.remote_sid.map(|sid| sid.to_string()),
+                state: vpws_state(svc).to_string(),
+            })
+            .collect();
+        return Ok(serde_json::to_string_pretty(&list)
+            .unwrap_or_else(|e| format!("{{\"error\": \"{e}\"}}")));
+    }
+
+    let mut buf = String::new();
+    if vpws.services.is_empty() {
+        writeln!(buf, "No EVPN VPWS services configured")?;
+        return Ok(buf);
+    }
+    for (name, svc) in vpws.services.iter() {
+        writeln!(buf, "VPWS service: {name}")?;
+        match svc.evi {
+            Some(evi) => writeln!(buf, "  EVI: {evi}")?,
+            None => writeln!(buf, "  EVI: (unset)")?,
+        }
+        writeln!(
+            buf,
+            "  Service ID: local {}, remote {}",
+            svc.local_service_id
+                .map_or("(unset)".to_string(), |id| id.to_string()),
+            svc.remote_service_id
+                .map_or("(unset)".to_string(), |id| id.to_string()),
+        )?;
+        if let Some(ifname) = &svc.interface {
+            writeln!(buf, "  Interface: {ifname}")?;
+        }
+        if let Some((sid, _)) = vpws.sids.get(name) {
+            writeln!(buf, "  Local SID (End.DX2): {sid}")?;
+        }
+        if let Some(sid) = svc.remote_sid {
+            writeln!(buf, "  Remote SID: {sid}")?;
+        }
+        writeln!(buf, "  State: {}", vpws_state(svc))?;
+    }
+    Ok(buf)
+}
+
 /// `show bgp mup summary` — the MUP (SAFI 85, draft-ietf-bess-mup-safi)
 /// neighbor summary. `mup` enables both IPv4-MUP and IPv6-MUP
 /// at once (draft-ietf-bess-mup-safi), so this renders both sections — the MUP slice of
@@ -6970,6 +7061,8 @@ impl Bgp {
             .set(show_bgp_evpn)
             .path("/show/bgp/evpn/ethernet-segment")
             .set(show_bgp_evpn_ethernet_segment)
+            .path("/show/bgp/evpn/vpws")
+            .set(show_bgp_evpn_vpws)
             .path("/show/bgp/mup")
             .set(show_bgp_mup)
             .path("/show/bgp/mup/summary")

--- a/zebra-rs/yang/exec.yang
+++ b/zebra-rs/yang/exec.yang
@@ -388,6 +388,10 @@ module exec {
           ext:help "Locally-configured EVPN Ethernet Segments (RFC 7432)";
           type empty;
         }
+        leaf vpws {
+          ext:help "EVPN VPWS E-Line services (RFC 8214)";
+          type empty;
+        }
         leaf route-type {
           ext:help "Filter the EVPN RIB by route type";
           // ethernet-ad=1, macip=2, multicast=3, ethernet-segment=4,


### PR DESCRIPTION
## Summary

Phase 1 follow-up to #1762 (EVPN VPWS, RFC 8214) — operator visibility and a zebra-rs-side BDD.

- **`show bgp evpn vpws` (text + json)**: per-service EVI, local/remote service instance ids, AC interface, the local End.DX2 SID our Type-1 advertises, the imported remote SID, and a state derived from what has actually happened: `partial-config` → `pending` (config complete but no router-id/locator) → `advertised` (Type-1 out, no remote match) → `up` (remote SID bound to the AC).
- **`bgp_evpn_vpws.feature`** (control-plane only, no cradle): two PEs over a bridge exchange per-EVI Type-1s and both services reach `up`; then a **re-point scenario regression-tests the Loc-RIB rescan** from #1762 — `remote-service-id` re-pointed at an unadvertised id drops the remote SID (`up` → `advertised`), and pointing it back re-binds purely from the rescan (the remote re-advertises nothing).

## Test plan
- `cargo test --workspace --exclude bdd` clean; workspace clippy `-D warnings` clean
- BDD: `bgp_evpn_vpws` — 5 scenarios pass locally, zero skipped steps (fresh /usr/bin/zebra-rs, md5-verified)

🤖 Generated with [Claude Code](https://claude.com/claude-code)