### PR TITLE
feat(bgp): RFC 8214 Layer-2 Attributes on VPWS Type-1s — mtu knob + check

### DIFF
--- a/bdd/tests/configs/bgp_evpn_vpws/z1-mtu.yaml
+++ b/bdd/tests/configs/bgp_evpn_vpws/z1-mtu.yaml
@@ -1,0 +1,37 @@
+# (MTU variant) — eline1 signals L2 MTU 1500 in the RFC 8214 L2-Attributes EC.
+# z1 — EVPN VPWS PE (RFC 8214). One E-Line service (eline1, EVI 100):
+# advertises a per-EVI Ethernet A-D (Type-1) whose Ethernet Tag is the local
+# service instance id 101, carrying an End.DX2 L2-Service Prefix-SID carved
+# from LOC1, and imports z2's Type-1 (Ethernet Tag 102) as the remote end.
+# Control-plane only — no cradle dataplane; the AC name is not resolved here.
+segment-routing:
+  locator:
+  - name: LOC1
+    prefix: fcbb:bbbb:1::/48
+    behavior: usid
+router:
+  bgp:
+    global:
+      as: 65001
+      router-id: 192.168.0.1
+    segment-routing:
+      srv6:
+        locator: LOC1
+    afi-safi:
+    - name: evpn
+      vpws:
+      - name: eline1
+        evi: 100
+        local-service-id: 101
+        remote-service-id: 102
+        interface: ce1
+        mtu: 1500
+    neighbor:
+    - remote-address: 192.168.0.2
+      enabled: true
+      remote-as: 65001
+      afi-safi:
+      - name: ipv4
+        enabled: true
+      - name: evpn
+        enabled: true

--- a/bdd/tests/configs/bgp_evpn_vpws/z2-mtu.yaml
+++ b/bdd/tests/configs/bgp_evpn_vpws/z2-mtu.yaml
@@ -1,0 +1,34 @@
+# (MTU variant) — eline1 signals L2 MTU 1500, matching z1: the E-Line comes back up.
+# z2 — the other EVPN VPWS PE (mirror of z1): local service instance id 102,
+# remote 101, End.DX2 SID carved from LOC2.
+segment-routing:
+  locator:
+  - name: LOC2
+    prefix: fcbb:bbbb:2::/48
+    behavior: usid
+router:
+  bgp:
+    global:
+      as: 65001
+      router-id: 192.168.0.2
+    segment-routing:
+      srv6:
+        locator: LOC2
+    afi-safi:
+    - name: evpn
+      vpws:
+      - name: eline1
+        evi: 100
+        local-service-id: 102
+        remote-service-id: 101
+        interface: ce2
+        mtu: 1500
+    neighbor:
+    - remote-address: 192.168.0.1
+      enabled: true
+      remote-as: 65001
+      afi-safi:
+      - name: ipv4
+        enabled: true
+      - name: evpn
+        enabled: true

--- a/bdd/tests/configs/bgp_evpn_vpws/z2-mtu9k.yaml
+++ b/bdd/tests/configs/bgp_evpn_vpws/z2-mtu9k.yaml
@@ -1,0 +1,34 @@
+# (MTU variant) — eline1 signals L2 MTU 9000: clashes with z1's 1500, so neither end binds.
+# z2 — the other EVPN VPWS PE (mirror of z1): local service instance id 102,
+# remote 101, End.DX2 SID carved from LOC2.
+segment-routing:
+  locator:
+  - name: LOC2
+    prefix: fcbb:bbbb:2::/48
+    behavior: usid
+router:
+  bgp:
+    global:
+      as: 65001
+      router-id: 192.168.0.2
+    segment-routing:
+      srv6:
+        locator: LOC2
+    afi-safi:
+    - name: evpn
+      vpws:
+      - name: eline1
+        evi: 100
+        local-service-id: 102
+        remote-service-id: 101
+        interface: ce2
+        mtu: 9000
+    neighbor:
+    - remote-address: 192.168.0.1
+      enabled: true
+      remote-as: 65001
+      afi-safi:
+      - name: ipv4
+        enabled: true
+      - name: evpn
+        enabled: true

--- a/bdd/tests/features/bgp_evpn_vpws.feature
+++ b/bdd/tests/features/bgp_evpn_vpws.feature
@@ -72,6 +72,20 @@ Feature: BGP EVPN VPWS E-Line signalling over SRv6 (RFC 8214)
     Then show command "show bgp evpn vpws" in namespace "z1" should eventually contain "State: up"
     And show command "show bgp evpn vpws" in namespace "z1" should contain "Remote SID: fcbb:bbbb:2:"
 
+  Scenario: Mismatched L2 MTUs block the bind until they agree (RFC 8214 §3.1)
+    Given the test topology exists
+    # z1 signals MTU 1500, z2 signals 9000: both ends see the clash in the
+    # received Layer-2 Attributes EC and refuse to bind the remote.
+    When I apply config "z1-mtu.yaml" to namespace "z1"
+    And I apply config "z2-mtu9k.yaml" to namespace "z2"
+    Then show command "show bgp evpn" in namespace "z1" should eventually contain "l2-attr:P:mtu9000"
+    And show command "show bgp evpn vpws" in namespace "z1" should eventually contain "State: mtu-mismatch"
+    And show command "show bgp evpn vpws" in namespace "z1" should contain "Remote MTU (mismatch): 9000"
+    # Fix z2's MTU to match: the E-Line binds again without touching z1.
+    When I apply config "z2-mtu.yaml" to namespace "z2"
+    Then show command "show bgp evpn vpws" in namespace "z1" should eventually contain "State: up"
+    And show command "show bgp evpn vpws" in namespace "z2" should eventually contain "State: up"
+
   Scenario: Teardown topology
     Given the test topology exists
     When I stop zebra-rs in namespace "z1"

--- a/crates/bgp-packet/src/attrs/ext_com.rs
+++ b/crates/bgp-packet/src/attrs/ext_com.rs
@@ -236,6 +236,54 @@ impl ExtCommunityValue {
         })
     }
 
+    /// Build an EVPN Layer-2 Attributes Extended Community (RFC 8214 §3.1):
+    /// EVPN high-type (0x06) + Layer-2 Attributes sub-type (0x04). Carried on
+    /// the **per-EVI** Ethernet A-D (Type-1) route of a VPWS service. The
+    /// 2-octet Control Flags carry P (primary), B (backup) and C
+    /// (control word); the 2-octet L2 MTU is 0 when no MTU check is wanted.
+    pub fn l2_attr(primary: bool, backup: bool, control_word: bool, mtu: u16) -> Self {
+        let mut flags: u16 = 0;
+        if primary {
+            flags |= L2AttrEc::PRIMARY;
+        }
+        if backup {
+            flags |= L2AttrEc::BACKUP;
+        }
+        if control_word {
+            flags |= L2AttrEc::CONTROL_WORD;
+        }
+        let mut val = [0u8; 6];
+        val[0..2].copy_from_slice(&flags.to_be_bytes());
+        val[2..4].copy_from_slice(&mtu.to_be_bytes());
+        ExtCommunityValue {
+            high_type: ExtCommunityType::Evpn as u8,
+            low_type: EVPN_L2_ATTR_SUB_TYPE,
+            val,
+        }
+    }
+
+    /// True iff this entry is an EVPN Layer-2 Attributes EC (RFC 8214 §3.1):
+    /// EVPN high-type (0x06) + Layer-2 Attributes sub-type (0x04).
+    pub fn is_l2_attr(&self) -> bool {
+        self.high_type == ExtCommunityType::Evpn as u8 && self.low_type == EVPN_L2_ATTR_SUB_TYPE
+    }
+
+    /// Decode the Layer-2 Attributes EC (RFC 8214 §3.1): the P/B/C control
+    /// flags and the L2 MTU (0 = no MTU check). `None` for any non-matching
+    /// EC.
+    pub fn as_l2_attr(&self) -> Option<L2AttrEc> {
+        if !self.is_l2_attr() {
+            return None;
+        }
+        let flags = u16::from_be_bytes([self.val[0], self.val[1]]);
+        Some(L2AttrEc {
+            primary: flags & L2AttrEc::PRIMARY != 0,
+            backup: flags & L2AttrEc::BACKUP != 0,
+            control_word: flags & L2AttrEc::CONTROL_WORD != 0,
+            mtu: u16::from_be_bytes([self.val[2], self.val[3]]),
+        })
+    }
+
     /// Build an EVI-RT Extended Community (RFC 9251 §9.5) from the EVI's
     /// (BD's) Route Target. The EVI-RT carries the same 6-octet RT value
     /// under the EVPN high-type (0x06), with the sub-type selecting the RT
@@ -313,6 +361,43 @@ const EVPN_ES_IMPORT_RT_SUB_TYPE: u8 = 0x02;
 /// ESI Label Extended Community sub-type (RFC 7432 §7.5), carried under the
 /// EVPN high-type (0x06).
 const EVPN_ESI_LABEL_SUB_TYPE: u8 = 0x01;
+
+/// Layer-2 Attributes Extended Community sub-type (RFC 8214 §3.1), carried
+/// under the EVPN high-type (0x06).
+const EVPN_L2_ATTR_SUB_TYPE: u8 = 0x04;
+
+/// Decoded EVPN Layer-2 Attributes Extended Community (RFC 8214 §3.1).
+/// Carried on the per-EVI Ethernet A-D (Type-1) route of a VPWS service to
+/// signal the endpoint role and the attachment circuit's L2 MTU.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct L2AttrEc {
+    /// P bit: this PE is the primary endpoint for the service.
+    pub primary: bool,
+    /// B bit: this PE is the backup endpoint (multihomed single-active).
+    pub backup: bool,
+    /// C bit: a control word is inserted between the label stack and the
+    /// L2 frame (MPLS pseudowire framing; unused over SRv6).
+    pub control_word: bool,
+    /// L2 MTU of the attachment circuit; 0 = no MTU check (RFC 8214 §3.1:
+    /// mismatched non-zero MTUs mean the remote MUST NOT be used).
+    pub mtu: u16,
+}
+
+impl L2AttrEc {
+    /// Control Flags bit 15 (LSB of the 16-bit field, MSB-0 numbering):
+    /// B — backup endpoint.
+    const BACKUP: u16 = 0x0001;
+    /// Control Flags bit 14: P — primary endpoint.
+    const PRIMARY: u16 = 0x0002;
+    /// Control Flags bit 13: C — control word present.
+    const CONTROL_WORD: u16 = 0x0004;
+}
+
+impl From<L2AttrEc> for ExtCommunityValue {
+    fn from(a: L2AttrEc) -> Self {
+        ExtCommunityValue::l2_attr(a.primary, a.backup, a.control_word, a.mtu)
+    }
+}
 
 /// Decoded EVPN ESI Label Extended Community (RFC 7432 §7.5). Carried on the
 /// per-ES Ethernet A-D (Type-1) route to signal the redundancy mode and the
@@ -596,6 +681,20 @@ impl fmt::Display for ExtCommunityValue {
                 "all-active"
             };
             write!(f, "esi-label:{mode}:{}", es.label)
+        } else if let Some(a) = self.as_l2_attr() {
+            // Layer-2 Attributes EC (RFC 8214 §3.1): the P/B/C control
+            // flags then the L2 MTU, e.g. `l2-attr:P:mtu1500`.
+            let mut s = String::new();
+            if a.primary {
+                s.push('P');
+            }
+            if a.backup {
+                s.push('B');
+            }
+            if a.control_word {
+                s.push('C');
+            }
+            write!(f, "l2-attr:{s}:mtu{}", a.mtu)
         } else if self.is_evi_rt() {
             // EVI-RT EC (RFC 9251 §9.5): render `evi-rt:` then the underlying
             // Route Target. The IPv6 form (0x0D) has no 8-octet RT, so fall
@@ -862,6 +961,39 @@ mod tests {
         }
         .into();
         assert_eq!(mld.to_string(), "mcast-flags:M");
+    }
+
+    #[test]
+    fn evpn_l2_attr_roundtrip() {
+        // RFC 8214 §3.1: single-homed primary, MTU 1500. Wire layout: flags
+        // in val[0..2] (B=0x0001, P=0x0002, C=0x0004), MTU in val[2..4].
+        let ec = ExtCommunityValue::l2_attr(true, false, false, 1500);
+        assert_eq!(ec.high_type, 0x06);
+        assert_eq!(ec.low_type, 0x04);
+        assert_eq!(ec.val, [0x00, 0x02, 0x05, 0xdc, 0x00, 0x00]);
+        let a = ec.as_l2_attr().expect("decodes");
+        assert!(a.primary && !a.backup && !a.control_word);
+        assert_eq!(a.mtu, 1500);
+        assert_eq!(ec.to_string(), "l2-attr:P:mtu1500");
+
+        let all: ExtCommunityValue = L2AttrEc {
+            primary: true,
+            backup: true,
+            control_word: true,
+            mtu: 0,
+        }
+        .into();
+        assert_eq!(all.val[0..2], [0x00, 0x07]);
+        assert_eq!(all.to_string(), "l2-attr:PBC:mtu0");
+    }
+
+    #[test]
+    fn evpn_l2_attr_false_for_esi_label() {
+        // Same EVPN high-type, different sub-type — must not cross-decode.
+        let esi = ExtCommunityValue::esi_label(false, 0);
+        assert!(esi.as_l2_attr().is_none());
+        let l2 = ExtCommunityValue::l2_attr(true, false, false, 0);
+        assert!(l2.as_esi_label().is_none());
     }
 
     #[test]

--- a/zebra-rs/src/bgp/config.rs
+++ b/zebra-rs/src/bgp/config.rs
@@ -1954,6 +1954,13 @@ fn config_vpws_remote_service_id(bgp: &mut Bgp, args: Args, op: ConfigOp) -> Opt
     config_vpws_leaf(bgp, args, op, |svc, v| svc.remote_service_id = v, true)
 }
 
+/// `router bgp afi-safi evpn vpws <name> mtu <0..65535>` — the L2 MTU
+/// signalled in the Type-1's Layer-2 Attributes EC (RFC 8214 §3.1);
+/// 0 (or unset) disables the MTU check.
+fn config_vpws_mtu(bgp: &mut Bgp, args: Args, op: ConfigOp) -> Option<()> {
+    config_vpws_leaf(bgp, args, op, |svc, v| svc.mtu = v.map(|m| m as u16), true)
+}
+
 /// `router bgp afi-safi evpn vpws <name> interface <name>` — the
 /// attachment circuit. Changing (or clearing) it unbinds the old AC's
 /// cross-connect first.
@@ -4636,6 +4643,7 @@ impl Bgp {
             config_vpws_remote_service_id,
         );
         self.callback_add("/router/bgp/afi-safi/vpws/interface", config_vpws_interface);
+        self.callback_add("/router/bgp/afi-safi/vpws/mtu", config_vpws_mtu);
 
         // MUP controller (`router bgp mup-c …`, draft-ietf-bess-mup-safi).
         // Augmented in by zebra-bgp-mup-controller.yang; the controller

--- a/zebra-rs/src/bgp/route.rs
+++ b/zebra-rs/src/bgp/route.rs
@@ -6810,6 +6810,16 @@ fn evpn_srv6_sid(attr: &BgpAttr, behavior: u16) -> Option<std::net::Ipv6Addr> {
         .map(|(sid, _)| sid)
 }
 
+/// The L2 MTU from an EVPN route's Layer-2 Attributes EC (RFC 8214 §3.1).
+/// 0 when the EC is absent or carries no MTU — either way, no MTU check.
+fn evpn_l2_attr_mtu(attr: &BgpAttr) -> u16 {
+    attr.ecom
+        .as_ref()
+        .and_then(|ecom| ecom.0.iter().find_map(|v| v.as_l2_attr()))
+        .map(|a| a.mtu)
+        .unwrap_or(0)
+}
+
 fn extract_tunnel_endpoint(rib: &BgpRib) -> Option<IpAddr> {
     match rib.attr.nexthop.as_ref()? {
         BgpNexthop::Evpn(addr) => Some(*addr),
@@ -6925,6 +6935,7 @@ fn route_evpn_export_selected(
                             continue;
                         }
                         svc.remote_sid = None;
+                        svc.remote_mtu_mismatch = None;
                         if let Some(ifname) = svc.interface.clone() {
                             let local_sid = vpws.sids.get(name).map(|(a, _)| *a);
                             let _ = bgp
@@ -7117,11 +7128,27 @@ fn route_evpn_export_selected(
                     // RFC 9572 A-D form) has no SRv6 dataplane binding.
                     return;
                 };
+                let remote_mtu = evpn_l2_attr_mtu(&best.attr);
                 let vpws = &mut bgp.local_rib.evpn_vpws;
                 for (name, svc) in vpws.services.iter_mut() {
                     if svc.remote_service_id != Some(*eth_tag) || svc.evi != Some(evi) {
                         continue;
                     }
+                    // RFC 8214 §3.1: both ends non-zero and different —
+                    // the remote MUST NOT be used. Unbind if it had been.
+                    if !svc.mtu_compatible(remote_mtu) {
+                        svc.remote_mtu_mismatch = Some(remote_mtu);
+                        if svc.remote_sid.take().is_some()
+                            && let Some(ifname) = svc.interface.clone()
+                        {
+                            let local_sid = vpws.sids.get(name).map(|(a, _)| *a);
+                            let _ = bgp
+                                .rib_client
+                                .send(rib::Message::XconnectDel { ifname, local_sid });
+                        }
+                        continue;
+                    }
+                    svc.remote_mtu_mismatch = None;
                     svc.remote_sid = Some(remote_sid);
                     if let Some(ifname) = svc.interface.clone() {
                         let local_sid = vpws.sids.get(name).map(|(a, _)| *a);
@@ -14980,12 +15007,12 @@ impl Bgp {
         if self.router_id.is_unspecified() {
             return;
         }
-        let Some((evi, local_id)) = self
+        let Some((evi, local_id, mtu)) = self
             .local_rib
             .evpn_vpws
             .services
             .get(name)
-            .and_then(|s| s.params().map(|(evi, local, _, _)| (evi, local)))
+            .and_then(|s| s.params().map(|(evi, local, _, _)| (evi, local, s.mtu)))
         else {
             return;
         };
@@ -14998,7 +15025,13 @@ impl Bgp {
             eth_tag: local_id,
         };
         let mut attr = BgpAttr::new();
-        attr.ecom = Some(ExtCommunity::from([evpn_route_target(self.asn, evi)]));
+        // The EVI RT plus the RFC 8214 §3.1 Layer-2 Attributes EC: P bit
+        // (single-homed primary), no backup, no control word (SRv6), and
+        // the configured L2 MTU (0 = no MTU check at the remote).
+        attr.ecom = Some(ExtCommunity::from([
+            evpn_route_target(self.asn, evi),
+            ExtCommunityValue::l2_attr(true, false, false, mtu.unwrap_or(0)),
+        ]));
         attr.prefix_sid = prefix_sid;
         attr.nexthop = Some(BgpNexthop::Evpn(IpAddr::V4(self.router_id)));
         let rib = BgpRib::new(
@@ -15043,8 +15076,14 @@ impl Bgp {
     /// Find the currently-selected remote end of a VPWS service in the EVPN
     /// Loc-RIB: a non-originated per-EVI Type-1 (RFC 8214) whose Ethernet Tag
     /// is the service's `remote-service-id` within the same EVI, carrying an
-    /// `End.DX2` L2-Service SID. `None` while no such route is selected.
-    fn vpws_lookup_remote_sid(&self, evi: u32, remote_id: u32) -> Option<std::net::Ipv6Addr> {
+    /// `End.DX2` L2-Service SID. Returns the SID plus the route's Layer-2
+    /// Attributes MTU (0 = none signalled); `None` while no such route is
+    /// selected.
+    fn vpws_lookup_remote_sid(
+        &self,
+        evi: u32,
+        remote_id: u32,
+    ) -> Option<(std::net::Ipv6Addr, u16)> {
         if remote_id == MAX_ET {
             // MAX-ET tags per-ES A-D routes, never a VPWS service instance.
             return None;
@@ -15061,7 +15100,7 @@ impl Bgp {
                     continue;
                 }
                 if let Some(sid) = evpn_srv6_sid(&rib.attr, bgp_packet::SRV6_BEHAVIOR_END_DX2) {
-                    return Some(sid);
+                    return Some((sid, evpn_l2_attr_mtu(&rib.attr)));
                 }
             }
         }
@@ -15082,11 +15121,20 @@ impl Bgp {
         };
         let cached = svc.remote_sid;
         let ifname = svc.interface.clone();
-        let remote = svc
+        // The RFC 8214 §3.1 MTU gate: a found remote whose non-zero MTU
+        // differs from our non-zero MTU is unusable — treated as no match,
+        // remembered for `show` as mtu-mismatch.
+        let found = svc
             .params()
             .and_then(|(evi, _, remote_id, _)| self.vpws_lookup_remote_sid(evi, remote_id));
+        let (remote, mismatch) = match found {
+            Some((sid, remote_mtu)) if svc.mtu_compatible(remote_mtu) => (Some(sid), None),
+            Some((_, remote_mtu)) => (None, Some(remote_mtu)),
+            None => (None, None),
+        };
         if let Some(svc) = self.local_rib.evpn_vpws.services.get_mut(name) {
             svc.remote_sid = remote;
+            svc.remote_mtu_mismatch = mismatch;
         }
         let local_sid = self.local_rib.evpn_vpws.sids.get(name).map(|(a, _)| *a);
         match (remote, ifname) {
@@ -15098,9 +15146,9 @@ impl Bgp {
                 });
             }
             // A previously-bound AC whose remote no longer matches (config
-            // re-pointed, or now partial): unbind. Interface *changes* are
-            // unbound by `config_vpws_interface`, which still knows the old
-            // AC name.
+            // re-pointed, MTU now clashing, or partial config): unbind.
+            // Interface *changes* are unbound by `config_vpws_interface`,
+            // which still knows the old AC name.
             (None, Some(ifname)) if cached.is_some() => {
                 let _ = self
                     .ctx

--- a/zebra-rs/src/bgp/show.rs
+++ b/zebra-rs/src/bgp/show.rs
@@ -2506,8 +2506,10 @@ struct VpwsServiceJson {
     local_service_id: Option<u32>,
     remote_service_id: Option<u32>,
     interface: Option<String>,
+    mtu: Option<u16>,
     local_sid: Option<String>,
     remote_sid: Option<String>,
+    remote_mtu_mismatch: Option<u16>,
     state: String,
 }
 
@@ -2516,6 +2518,8 @@ fn vpws_state(svc: &super::vpws::VpwsService) -> &'static str {
         "partial-config"
     } else if svc.originated.is_none() {
         "pending"
+    } else if svc.remote_mtu_mismatch.is_some() {
+        "mtu-mismatch"
     } else if svc.remote_sid.is_none() {
         "advertised"
     } else {
@@ -2541,8 +2545,10 @@ fn show_bgp_evpn_vpws(
                 local_service_id: svc.local_service_id,
                 remote_service_id: svc.remote_service_id,
                 interface: svc.interface.clone(),
+                mtu: svc.mtu,
                 local_sid: vpws.sids.get(name).map(|(addr, _)| addr.to_string()),
                 remote_sid: svc.remote_sid.map(|sid| sid.to_string()),
+                remote_mtu_mismatch: svc.remote_mtu_mismatch,
                 state: vpws_state(svc).to_string(),
             })
             .collect();
@@ -2572,11 +2578,17 @@ fn show_bgp_evpn_vpws(
         if let Some(ifname) = &svc.interface {
             writeln!(buf, "  Interface: {ifname}")?;
         }
+        if let Some(mtu) = svc.mtu.filter(|m| *m != 0) {
+            writeln!(buf, "  MTU: {mtu}")?;
+        }
         if let Some((sid, _)) = vpws.sids.get(name) {
             writeln!(buf, "  Local SID (End.DX2): {sid}")?;
         }
         if let Some(sid) = svc.remote_sid {
             writeln!(buf, "  Remote SID: {sid}")?;
+        }
+        if let Some(remote_mtu) = svc.remote_mtu_mismatch {
+            writeln!(buf, "  Remote MTU (mismatch): {remote_mtu}")?;
         }
         writeln!(buf, "  State: {}", vpws_state(svc))?;
     }
@@ -3824,6 +3836,10 @@ fn format_evpn_ecom_value(v: &ExtCommunityValue) -> String {
         // EVPN ESI Label EC — RFC 7432 §7.5, carried on the per-ES Type-1
         // A-D route. Reuse the codec's Display: `esi-label:<mode>:<label>`.
         (0x06, 0x01) => v.to_string(),
+        // EVPN Layer-2 Attributes EC — RFC 8214 §3.1, carried on the
+        // per-EVI Type-1 of a VPWS service. Reuse the codec's Display:
+        // `l2-attr:<PBC flags>:mtu<N>`.
+        (0x06, 0x04) => v.to_string(),
         // EVPN EVI-RT EC — RFC 9251 §9.5 (Type 0..3 sub-types 0x0a-0x0d),
         // carried on the Type-7/8 Synch routes. Reuse the codec's Display:
         // `evi-rt:<route-target>`.

--- a/zebra-rs/src/bgp/vpws.rs
+++ b/zebra-rs/src/bgp/vpws.rs
@@ -10,9 +10,10 @@
 //! → cradle `AddXconnect`, which programs both the ingress XCONNECT map and
 //! the local `End.DX2` decap).
 //!
-//! Scope: single-homed (all-zero ESI), untagged AC (`End.DX2`). The RFC
-//! 8214 Layer-2 Attributes extended community (MTU/control-flags
-//! signalling) is not attached yet.
+//! Scope: single-homed (all-zero ESI), untagged AC (`End.DX2`). The Type-1
+//! carries the RFC 8214 §3.1 Layer-2 Attributes extended community (P bit
+//! set — single-homed primary — plus the configured L2 MTU); a remote whose
+//! non-zero MTU differs from our non-zero MTU is not bound (`mtu-mismatch`).
 
 use std::collections::BTreeMap;
 use std::net::Ipv6Addr;
@@ -36,6 +37,12 @@ pub struct VpwsService {
     /// import side) — lets a config change re-program the xconnect
     /// without waiting for a route churn.
     pub remote_sid: Option<Ipv6Addr>,
+    /// L2 MTU signalled in our Type-1's Layer-2 Attributes EC (RFC 8214
+    /// §3.1) and checked against the remote's. `None`/0 = no MTU check.
+    pub mtu: Option<u16>,
+    /// The remote's L2 MTU when a matching Type-1 was **rejected** for an
+    /// MTU mismatch — the service shows `mtu-mismatch` instead of `up`.
+    pub remote_mtu_mismatch: Option<u16>,
 }
 
 impl VpwsService {
@@ -48,6 +55,15 @@ impl VpwsService {
             self.remote_service_id?,
             self.interface.as_deref()?,
         ))
+    }
+
+    /// RFC 8214 §3.1 MTU check: a remote is usable unless **both** ends
+    /// signal a non-zero L2 MTU and they differ.
+    pub fn mtu_compatible(&self, remote_mtu: u16) -> bool {
+        match self.mtu {
+            Some(local) if local != 0 && remote_mtu != 0 => local == remote_mtu,
+            _ => true,
+        }
     }
 }
 

--- a/zebra-rs/src/config/manager.rs
+++ b/zebra-rs/src/config/manager.rs
@@ -3378,6 +3378,7 @@ mod yang_load_tests {
             "set router bgp afi-safi evpn vpws eline1 local-service-id 101",
             "set router bgp afi-safi evpn vpws eline1 remote-service-id 102",
             "set router bgp afi-safi evpn vpws eline1 interface eth0",
+            "set router bgp afi-safi evpn vpws eline1 mtu 1500",
         ] {
             let (code, _comps, _state) = parse(path, entry.clone(), None, State::new());
             assert_eq!(code, ExecCode::Success, "`{path}` must be a settable path");

--- a/zebra-rs/yang/zebra-bgp-evpn.yang
+++ b/zebra-rs/yang/zebra-bgp-evpn.yang
@@ -204,6 +204,15 @@ module zebra-bgp-evpn {
         mandatory true;
         description "Attachment circuit (CE-facing port) of the E-Line.";
       }
+      leaf mtu {
+        type uint16;
+        default 0;
+        description
+          "L2 MTU signalled in the RFC 8214 §3.1 Layer-2 Attributes
+           extended community on the Type-1 route. 0 disables the MTU
+           check; when both ends signal non-zero MTUs that differ, the
+           remote is not bound (the service shows mtu-mismatch).";
+      }
     }
     leaf bum-tunnel-type {
       type enumeration {


### PR DESCRIPTION
## Summary

Phase 2 of the EVPN VPWS arc (#1762, #1778): the RFC 8214 §3.1 Layer-2 Attributes extended community.

- **bgp-packet**: EVPN Layer-2 Attributes EC (type 0x06, sub-type 0x04) — P/B/C control flags + 2-octet L2 MTU; build/decode/Display (`l2-attr:P:mtu1500`) with a wire-layout pin test, plus a cross-decode guard against the ESI Label EC.
- **`vpws <name> mtu <0..65535>`** (yang + config callback): the L2 MTU signalled on our Type-1; 0/unset disables the check. Every VPWS Type-1 now carries the EC with P=1 (single-homed primary).
- **Import-side MTU check** (RFC 8214 §3.1) in both the install arm and the reconcile rescan: both ends non-zero and different ⇒ the remote is not bound (a live bind is torn down), and `show bgp evpn vpws` shows `mtu-mismatch` + the remote's MTU until the ends agree.

## Test plan
- `cargo test --workspace --exclude bdd` clean; workspace clippy `-D warnings` clean
- BDD `bgp_evpn_vpws` extended with a mismatch scenario (1500 vs 9000 blocks both PEs; fixing z2 to 1500 re-binds with no other churn) — 6 scenarios pass locally, zero skipped steps

🤖 Generated with [Claude Code](https://claude.com/claude-code)