### PR TITLE
config: consolidate activation leaves on `enabled` (OpenConfig spelling)

### DIFF
--- a/bdd/tests/configs/bgp_interas_option_a/asbr1.yaml
+++ b/bdd/tests/configs/bgp_interas_option_a/asbr1.yaml
@@ -35,14 +35,14 @@ router:
     interface:
     - if-name: lo
       ipv4:
-        enable: true
+        enabled: true
         prefix-sid:
           index: 3
     - if-name: p1
       network-type: point-to-point
       metric: 10
       ipv4:
-        enable: true
+        enabled: true
   bgp:
     global:
       as: 65000

--- a/bdd/tests/configs/bgp_interas_option_a/asbr2.yaml
+++ b/bdd/tests/configs/bgp_interas_option_a/asbr2.yaml
@@ -31,14 +31,14 @@ router:
     interface:
     - if-name: lo
       ipv4:
-        enable: true
+        enabled: true
         prefix-sid:
           index: 6
     - if-name: p2
       network-type: point-to-point
       metric: 10
       ipv4:
-        enable: true
+        enabled: true
   bgp:
     global:
       as: 65001

--- a/bdd/tests/configs/bgp_interas_option_a/p1.yaml
+++ b/bdd/tests/configs/bgp_interas_option_a/p1.yaml
@@ -22,16 +22,16 @@ router:
     interface:
     - if-name: lo
       ipv4:
-        enable: true
+        enabled: true
         prefix-sid:
           index: 2
     - if-name: pe1
       network-type: point-to-point
       metric: 10
       ipv4:
-        enable: true
+        enabled: true
     - if-name: asbr1
       network-type: point-to-point
       metric: 10
       ipv4:
-        enable: true
+        enabled: true

--- a/bdd/tests/configs/bgp_interas_option_a/p2.yaml
+++ b/bdd/tests/configs/bgp_interas_option_a/p2.yaml
@@ -19,16 +19,16 @@ router:
     interface:
     - if-name: lo
       ipv4:
-        enable: true
+        enabled: true
         prefix-sid:
           index: 5
     - if-name: asbr2
       network-type: point-to-point
       metric: 10
       ipv4:
-        enable: true
+        enabled: true
     - if-name: pe2
       network-type: point-to-point
       metric: 10
       ipv4:
-        enable: true
+        enabled: true

--- a/bdd/tests/configs/bgp_interas_option_a/pe1.yaml
+++ b/bdd/tests/configs/bgp_interas_option_a/pe1.yaml
@@ -31,14 +31,14 @@ router:
     interface:
     - if-name: lo
       ipv4:
-        enable: true
+        enabled: true
         prefix-sid:
           index: 1
     - if-name: p1
       network-type: point-to-point
       metric: 10
       ipv4:
-        enable: true
+        enabled: true
   bgp:
     global:
       as: 65000

--- a/bdd/tests/configs/bgp_interas_option_a/pe2.yaml
+++ b/bdd/tests/configs/bgp_interas_option_a/pe2.yaml
@@ -29,14 +29,14 @@ router:
     interface:
     - if-name: lo
       ipv4:
-        enable: true
+        enabled: true
         prefix-sid:
           index: 4
     - if-name: p2
       network-type: point-to-point
       metric: 10
       ipv4:
-        enable: true
+        enabled: true
   bgp:
     global:
       as: 65001

--- a/bdd/tests/configs/bgp_interas_option_ab/asbr1.yaml
+++ b/bdd/tests/configs/bgp_interas_option_ab/asbr1.yaml
@@ -42,14 +42,14 @@ router:
     interface:
     - if-name: lo
       ipv4:
-        enable: true
+        enabled: true
         prefix-sid:
           index: 3
     - if-name: p1
       network-type: point-to-point
       metric: 10
       ipv4:
-        enable: true
+        enabled: true
   bgp:
     global:
       as: 65000

--- a/bdd/tests/configs/bgp_interas_option_ab/asbr2.yaml
+++ b/bdd/tests/configs/bgp_interas_option_ab/asbr2.yaml
@@ -30,14 +30,14 @@ router:
     interface:
     - if-name: lo
       ipv4:
-        enable: true
+        enabled: true
         prefix-sid:
           index: 6
     - if-name: p2
       network-type: point-to-point
       metric: 10
       ipv4:
-        enable: true
+        enabled: true
   bgp:
     global:
       as: 65001

--- a/bdd/tests/configs/bgp_interas_option_ab/p1.yaml
+++ b/bdd/tests/configs/bgp_interas_option_ab/p1.yaml
@@ -22,16 +22,16 @@ router:
     interface:
     - if-name: lo
       ipv4:
-        enable: true
+        enabled: true
         prefix-sid:
           index: 2
     - if-name: pe1
       network-type: point-to-point
       metric: 10
       ipv4:
-        enable: true
+        enabled: true
     - if-name: asbr1
       network-type: point-to-point
       metric: 10
       ipv4:
-        enable: true
+        enabled: true

--- a/bdd/tests/configs/bgp_interas_option_ab/p2.yaml
+++ b/bdd/tests/configs/bgp_interas_option_ab/p2.yaml
@@ -19,16 +19,16 @@ router:
     interface:
     - if-name: lo
       ipv4:
-        enable: true
+        enabled: true
         prefix-sid:
           index: 5
     - if-name: asbr2
       network-type: point-to-point
       metric: 10
       ipv4:
-        enable: true
+        enabled: true
     - if-name: pe2
       network-type: point-to-point
       metric: 10
       ipv4:
-        enable: true
+        enabled: true

--- a/bdd/tests/configs/bgp_interas_option_ab/pe1.yaml
+++ b/bdd/tests/configs/bgp_interas_option_ab/pe1.yaml
@@ -32,14 +32,14 @@ router:
     interface:
     - if-name: lo
       ipv4:
-        enable: true
+        enabled: true
         prefix-sid:
           index: 1
     - if-name: p1
       network-type: point-to-point
       metric: 10
       ipv4:
-        enable: true
+        enabled: true
   bgp:
     global:
       as: 65000

--- a/bdd/tests/configs/bgp_interas_option_ab/pe2.yaml
+++ b/bdd/tests/configs/bgp_interas_option_ab/pe2.yaml
@@ -29,14 +29,14 @@ router:
     interface:
     - if-name: lo
       ipv4:
-        enable: true
+        enabled: true
         prefix-sid:
           index: 4
     - if-name: p2
       network-type: point-to-point
       metric: 10
       ipv4:
-        enable: true
+        enabled: true
   bgp:
     global:
       as: 65001

--- a/bdd/tests/configs/bgp_interas_option_b/asbr1.yaml
+++ b/bdd/tests/configs/bgp_interas_option_b/asbr1.yaml
@@ -31,14 +31,14 @@ router:
     interface:
     - if-name: lo
       ipv4:
-        enable: true
+        enabled: true
         prefix-sid:
           index: 3
     - if-name: p1
       network-type: point-to-point
       metric: 10
       ipv4:
-        enable: true
+        enabled: true
   bgp:
     global:
       as: 65000

--- a/bdd/tests/configs/bgp_interas_option_b/asbr2.yaml
+++ b/bdd/tests/configs/bgp_interas_option_b/asbr2.yaml
@@ -25,14 +25,14 @@ router:
     interface:
     - if-name: lo
       ipv4:
-        enable: true
+        enabled: true
         prefix-sid:
           index: 6
     - if-name: p2
       network-type: point-to-point
       metric: 10
       ipv4:
-        enable: true
+        enabled: true
   bgp:
     global:
       as: 65001

--- a/bdd/tests/configs/bgp_interas_option_b/p1.yaml
+++ b/bdd/tests/configs/bgp_interas_option_b/p1.yaml
@@ -22,16 +22,16 @@ router:
     interface:
     - if-name: lo
       ipv4:
-        enable: true
+        enabled: true
         prefix-sid:
           index: 2
     - if-name: pe1
       network-type: point-to-point
       metric: 10
       ipv4:
-        enable: true
+        enabled: true
     - if-name: asbr1
       network-type: point-to-point
       metric: 10
       ipv4:
-        enable: true
+        enabled: true

--- a/bdd/tests/configs/bgp_interas_option_b/p2.yaml
+++ b/bdd/tests/configs/bgp_interas_option_b/p2.yaml
@@ -19,16 +19,16 @@ router:
     interface:
     - if-name: lo
       ipv4:
-        enable: true
+        enabled: true
         prefix-sid:
           index: 5
     - if-name: asbr2
       network-type: point-to-point
       metric: 10
       ipv4:
-        enable: true
+        enabled: true
     - if-name: pe2
       network-type: point-to-point
       metric: 10
       ipv4:
-        enable: true
+        enabled: true

--- a/bdd/tests/configs/bgp_interas_option_b/pe1.yaml
+++ b/bdd/tests/configs/bgp_interas_option_b/pe1.yaml
@@ -34,14 +34,14 @@ router:
     interface:
     - if-name: lo
       ipv4:
-        enable: true
+        enabled: true
         prefix-sid:
           index: 1
     - if-name: p1
       network-type: point-to-point
       metric: 10
       ipv4:
-        enable: true
+        enabled: true
   bgp:
     global:
       as: 65000

--- a/bdd/tests/configs/bgp_interas_option_b/pe2.yaml
+++ b/bdd/tests/configs/bgp_interas_option_b/pe2.yaml
@@ -29,14 +29,14 @@ router:
     interface:
     - if-name: lo
       ipv4:
-        enable: true
+        enabled: true
         prefix-sid:
           index: 4
     - if-name: p2
       network-type: point-to-point
       metric: 10
       ipv4:
-        enable: true
+        enabled: true
   bgp:
     global:
       as: 65001

--- a/bdd/tests/configs/bgp_interas_option_c/asbr1.yaml
+++ b/bdd/tests/configs/bgp_interas_option_c/asbr1.yaml
@@ -27,14 +27,14 @@ router:
     interface:
     - if-name: lo
       ipv4:
-        enable: true
+        enabled: true
         prefix-sid:
           index: 3
     - if-name: p1
       network-type: point-to-point
       metric: 10
       ipv4:
-        enable: true
+        enabled: true
   bgp:
     global:
       as: 65000

--- a/bdd/tests/configs/bgp_interas_option_c/asbr2.yaml
+++ b/bdd/tests/configs/bgp_interas_option_c/asbr2.yaml
@@ -23,14 +23,14 @@ router:
     interface:
     - if-name: lo
       ipv4:
-        enable: true
+        enabled: true
         prefix-sid:
           index: 6
     - if-name: p2
       network-type: point-to-point
       metric: 10
       ipv4:
-        enable: true
+        enabled: true
   bgp:
     global:
       as: 65001

--- a/bdd/tests/configs/bgp_interas_option_c/p1.yaml
+++ b/bdd/tests/configs/bgp_interas_option_c/p1.yaml
@@ -22,16 +22,16 @@ router:
     interface:
     - if-name: lo
       ipv4:
-        enable: true
+        enabled: true
         prefix-sid:
           index: 2
     - if-name: pe1
       network-type: point-to-point
       metric: 10
       ipv4:
-        enable: true
+        enabled: true
     - if-name: asbr1
       network-type: point-to-point
       metric: 10
       ipv4:
-        enable: true
+        enabled: true

--- a/bdd/tests/configs/bgp_interas_option_c/p2.yaml
+++ b/bdd/tests/configs/bgp_interas_option_c/p2.yaml
@@ -19,16 +19,16 @@ router:
     interface:
     - if-name: lo
       ipv4:
-        enable: true
+        enabled: true
         prefix-sid:
           index: 5
     - if-name: asbr2
       network-type: point-to-point
       metric: 10
       ipv4:
-        enable: true
+        enabled: true
     - if-name: pe2
       network-type: point-to-point
       metric: 10
       ipv4:
-        enable: true
+        enabled: true

--- a/bdd/tests/configs/bgp_interas_option_c/pe1.yaml
+++ b/bdd/tests/configs/bgp_interas_option_c/pe1.yaml
@@ -37,14 +37,14 @@ router:
     interface:
     - if-name: lo
       ipv4:
-        enable: true
+        enabled: true
         prefix-sid:
           index: 1
     - if-name: p1
       network-type: point-to-point
       metric: 10
       ipv4:
-        enable: true
+        enabled: true
   bgp:
     global:
       as: 65000

--- a/bdd/tests/configs/bgp_interas_option_c/pe2.yaml
+++ b/bdd/tests/configs/bgp_interas_option_c/pe2.yaml
@@ -33,14 +33,14 @@ router:
     interface:
     - if-name: lo
       ipv4:
-        enable: true
+        enabled: true
         prefix-sid:
           index: 4
     - if-name: p2
       network-type: point-to-point
       metric: 10
       ipv4:
-        enable: true
+        enabled: true
   bgp:
     global:
       as: 65001

--- a/bdd/tests/configs/bgp_mup_dual_st/z1.yaml
+++ b/bdd/tests/configs/bgp_mup_dual_st/z1.yaml
@@ -52,7 +52,7 @@ router:
             network-instance: internet
             mup-ext-comm: "1:2"
     mup-c:
-      enable: true
+      enabled: true
       controller-address: fcbb:bb01::1
       pfcp:
         listen-address: 192.168.0.1

--- a/bdd/tests/configs/bgp_mup_dynamic_rt/z1.yaml
+++ b/bdd/tests/configs/bgp_mup_dynamic_rt/z1.yaml
@@ -40,7 +40,7 @@ router:
             network-instance: core
             mup-ext-comm: "1:2"
     mup-c:
-      enable: true
+      enabled: true
       controller-address: 2001:db8::1
       pfcp:
         listen-address: 192.168.0.1

--- a/bdd/tests/configs/bgp_mup_e2e/z1.yaml
+++ b/bdd/tests/configs/bgp_mup_e2e/z1.yaml
@@ -37,7 +37,7 @@ router:
           - type: st1
             network-instance: access
     mup-c:
-      enable: true
+      enabled: true
       controller-address: fcbb:bb01::1
       pfcp:
         listen-address: 192.168.0.1

--- a/bdd/tests/configs/bgp_mup_forwarding/z1.yaml
+++ b/bdd/tests/configs/bgp_mup_forwarding/z1.yaml
@@ -45,12 +45,12 @@ router:
     interface:
     - if-name: lo
       ipv6:
-        enable: true
+        enabled: true
     - if-name: z1-z2
       network-type: point-to-point
       metric: 1
       ipv6:
-        enable: true
+        enabled: true
   bgp:
     global:
       as: 65501
@@ -83,7 +83,7 @@ router:
             network-instance: core
             mup-ext-comm: "1:1"
     mup-c:
-      enable: true
+      enabled: true
       controller-address: 2001:db8::1
       pfcp:
         listen-address: 127.0.0.1

--- a/bdd/tests/configs/bgp_mup_forwarding/z2.yaml
+++ b/bdd/tests/configs/bgp_mup_forwarding/z2.yaml
@@ -39,12 +39,12 @@ router:
     interface:
     - if-name: lo
       ipv6:
-        enable: true
+        enabled: true
     - if-name: z2-z1
       network-type: point-to-point
       metric: 1
       ipv6:
-        enable: true
+        enabled: true
   bgp:
     global:
       as: 65501
@@ -77,7 +77,7 @@ router:
             network-instance: core
             mup-ext-comm: "2:2"
     mup-c:
-      enable: true
+      enabled: true
       controller-address: 2001:db8::2
       pfcp:
         listen-address: 127.0.0.1

--- a/bdd/tests/configs/bgp_mup_interwork/z1.yaml
+++ b/bdd/tests/configs/bgp_mup_interwork/z1.yaml
@@ -36,12 +36,12 @@ router:
     interface:
     - if-name: lo
       ipv6:
-        enable: true
+        enabled: true
     - if-name: z1-z2
       network-type: point-to-point
       metric: 1
       ipv6:
-        enable: true
+        enabled: true
   bgp:
     global:
       as: 65501
@@ -74,7 +74,7 @@ router:
             network-instance: core
             mup-ext-comm: "1:2"
     mup-c:
-      enable: true
+      enabled: true
       controller-address: 2001:db8::1
       pfcp:
         listen-address: 127.0.0.1

--- a/bdd/tests/configs/bgp_mup_interwork/z2.yaml
+++ b/bdd/tests/configs/bgp_mup_interwork/z2.yaml
@@ -29,12 +29,12 @@ router:
     interface:
     - if-name: lo
       ipv6:
-        enable: true
+        enabled: true
     - if-name: z2-z1
       network-type: point-to-point
       metric: 1
       ipv6:
-        enable: true
+        enabled: true
   bgp:
     global:
       as: 65501

--- a/bdd/tests/configs/bgp_mup_isd/z1.yaml
+++ b/bdd/tests/configs/bgp_mup_isd/z1.yaml
@@ -38,12 +38,12 @@ router:
     interface:
     - if-name: lo
       ipv6:
-        enable: true
+        enabled: true
     - if-name: z1-z2
       network-type: point-to-point
       metric: 1
       ipv6:
-        enable: true
+        enabled: true
   bgp:
     global:
       as: 65501

--- a/bdd/tests/configs/bgp_mup_isd/z2.yaml
+++ b/bdd/tests/configs/bgp_mup_isd/z2.yaml
@@ -26,12 +26,12 @@ router:
     interface:
     - if-name: lo
       ipv6:
-        enable: true
+        enabled: true
     - if-name: z2-z1
       network-type: point-to-point
       metric: 1
       ipv6:
-        enable: true
+        enabled: true
   bgp:
     global:
       as: 65501

--- a/bdd/tests/configs/bgp_mup_mixed_afi/z1.yaml
+++ b/bdd/tests/configs/bgp_mup_mixed_afi/z1.yaml
@@ -36,7 +36,7 @@ router:
           - type: st1
             network-instance: access
     mup-c:
-      enable: true
+      enabled: true
       controller-address: fcbb:bb01::1
       pfcp:
         listen-address: 192.168.0.1

--- a/bdd/tests/configs/bgp_mup_peerdown/z1.yaml
+++ b/bdd/tests/configs/bgp_mup_peerdown/z1.yaml
@@ -37,12 +37,12 @@ router:
     interface:
     - if-name: lo
       ipv6:
-        enable: true
+        enabled: true
     - if-name: z1-z2
       network-type: point-to-point
       metric: 1
       ipv6:
-        enable: true
+        enabled: true
   bgp:
     global:
       as: 65501

--- a/bdd/tests/configs/bgp_mup_peerdown/z2.yaml
+++ b/bdd/tests/configs/bgp_mup_peerdown/z2.yaml
@@ -38,12 +38,12 @@ router:
     interface:
     - if-name: lo
       ipv6:
-        enable: true
+        enabled: true
     - if-name: z2-z1
       network-type: point-to-point
       metric: 1
       ipv6:
-        enable: true
+        enabled: true
   bgp:
     global:
       as: 65501

--- a/bdd/tests/configs/bgp_mup_segment_dsd/z1.yaml
+++ b/bdd/tests/configs/bgp_mup_segment_dsd/z1.yaml
@@ -36,12 +36,12 @@ router:
     interface:
     - if-name: lo
       ipv6:
-        enable: true
+        enabled: true
     - if-name: z1-z2
       network-type: point-to-point
       metric: 1
       ipv6:
-        enable: true
+        enabled: true
   bgp:
     global:
       as: 65501

--- a/bdd/tests/configs/bgp_mup_segment_dsd/z2.yaml
+++ b/bdd/tests/configs/bgp_mup_segment_dsd/z2.yaml
@@ -25,12 +25,12 @@ router:
     interface:
     - if-name: lo
       ipv6:
-        enable: true
+        enabled: true
     - if-name: z2-z1
       network-type: point-to-point
       metric: 1
       ipv6:
-        enable: true
+        enabled: true
   bgp:
     global:
       as: 65501

--- a/bdd/tests/configs/bgp_mup_st1_isd/z1.yaml
+++ b/bdd/tests/configs/bgp_mup_st1_isd/z1.yaml
@@ -39,12 +39,12 @@ router:
     interface:
     - if-name: lo
       ipv6:
-        enable: true
+        enabled: true
     - if-name: z1-z2
       network-type: point-to-point
       metric: 1
       ipv6:
-        enable: true
+        enabled: true
   bgp:
     global:
       as: 65501

--- a/bdd/tests/configs/bgp_mup_st1_isd/z2.yaml
+++ b/bdd/tests/configs/bgp_mup_st1_isd/z2.yaml
@@ -37,12 +37,12 @@ router:
     interface:
     - if-name: lo
       ipv6:
-        enable: true
+        enabled: true
     - if-name: z2-z1
       network-type: point-to-point
       metric: 1
       ipv6:
-        enable: true
+        enabled: true
   bgp:
     global:
       as: 65501
@@ -71,7 +71,7 @@ router:
           - type: st1
             network-instance: access
     mup-c:
-      enable: true
+      enabled: true
       controller-address: 2001:db8::2
       pfcp:
         listen-address: 127.0.0.1

--- a/bdd/tests/configs/bgp_mup_st2/z1.yaml
+++ b/bdd/tests/configs/bgp_mup_st2/z1.yaml
@@ -47,7 +47,7 @@ router:
             network-instance: core
             mup-ext-comm: "1:2"
     mup-c:
-      enable: true
+      enabled: true
       controller-address: fcbb:bb01::1
       pfcp:
         listen-address: 192.168.0.1

--- a/bdd/tests/configs/bgp_mup_st2_dsd_fib/z1.yaml
+++ b/bdd/tests/configs/bgp_mup_st2_dsd_fib/z1.yaml
@@ -36,12 +36,12 @@ router:
     interface:
     - if-name: lo
       ipv6:
-        enable: true
+        enabled: true
     - if-name: z1-z2
       network-type: point-to-point
       metric: 1
       ipv6:
-        enable: true
+        enabled: true
   bgp:
     global:
       as: 65501
@@ -74,7 +74,7 @@ router:
             network-instance: core
             mup-ext-comm: "1:2"
     mup-c:
-      enable: true
+      enabled: true
       controller-address: 2001:db8::1
       pfcp:
         listen-address: 127.0.0.1

--- a/bdd/tests/configs/bgp_mup_st2_dsd_fib/z2.yaml
+++ b/bdd/tests/configs/bgp_mup_st2_dsd_fib/z2.yaml
@@ -35,12 +35,12 @@ router:
     interface:
     - if-name: lo
       ipv6:
-        enable: true
+        enabled: true
     - if-name: z2-z1
       network-type: point-to-point
       metric: 1
       ipv6:
-        enable: true
+        enabled: true
   bgp:
     global:
       as: 65501

--- a/bdd/tests/configs/bgp_mup_vrf_import/z1.yaml
+++ b/bdd/tests/configs/bgp_mup_vrf_import/z1.yaml
@@ -54,12 +54,12 @@ router:
     interface:
     - if-name: lo
       ipv6:
-        enable: true
+        enabled: true
     - if-name: z1-z2
       network-type: point-to-point
       metric: 1
       ipv6:
-        enable: true
+        enabled: true
   bgp:
     global:
       as: 65501

--- a/bdd/tests/configs/bgp_mup_vrf_import/z2.yaml
+++ b/bdd/tests/configs/bgp_mup_vrf_import/z2.yaml
@@ -27,12 +27,12 @@ router:
     interface:
     - if-name: lo
       ipv6:
-        enable: true
+        enabled: true
     - if-name: z2-z1
       network-type: point-to-point
       metric: 1
       ipv6:
-        enable: true
+        enabled: true
   bgp:
     global:
       as: 65501

--- a/bdd/tests/configs/bgp_vrf_ospf_redist/ce.yaml
+++ b/bdd/tests/configs/bgp_vrf_ospf_redist/ce.yaml
@@ -16,7 +16,7 @@ router:
     - area-id: 0.0.0.0
       interface:
       - if-name: lo
-        enable: true
+        enabled: true
       - if-name: eth0
-        enable: true
+        enabled: true
         network-type: point-to-point

--- a/bdd/tests/configs/bgp_vrf_ospf_redist/z1-1.yaml
+++ b/bdd/tests/configs/bgp_vrf_ospf_redist/z1-1.yaml
@@ -26,7 +26,7 @@ router:
       - area-id: 0.0.0.0
         interface:
         - if-name: oc1
-          enable: true
+          enabled: true
           network-type: point-to-point
   bgp:
     global:

--- a/bdd/tests/configs/classic_tilfa_v3/d.yaml
+++ b/bdd/tests/configs/classic_tilfa_v3/d.yaml
@@ -26,12 +26,12 @@ router:
     - area-id: 0.0.0.0
       interface:
       - if-name: lo
-        enable: true
+        enabled: true
       - if-name: d-n1
-        enable: true
+        enabled: true
         network-type: point-to-point
         cost: 1
       - if-name: d-r3
-        enable: true
+        enabled: true
         network-type: point-to-point
         cost: 1

--- a/bdd/tests/configs/classic_tilfa_v3/n1.yaml
+++ b/bdd/tests/configs/classic_tilfa_v3/n1.yaml
@@ -32,20 +32,20 @@ router:
     - area-id: 0.0.0.0
       interface:
       - if-name: lo
-        enable: true
+        enabled: true
       - if-name: n1-s
-        enable: true
+        enabled: true
         network-type: point-to-point
         cost: 1
       - if-name: n1-r1
-        enable: true
+        enabled: true
         network-type: point-to-point
         cost: 1
       - if-name: n1-r2
-        enable: true
+        enabled: true
         network-type: point-to-point
         cost: 1
       - if-name: n1-d
-        enable: true
+        enabled: true
         network-type: point-to-point
         cost: 1

--- a/bdd/tests/configs/classic_tilfa_v3/n2.yaml
+++ b/bdd/tests/configs/classic_tilfa_v3/n2.yaml
@@ -26,12 +26,12 @@ router:
     - area-id: 0.0.0.0
       interface:
       - if-name: lo
-        enable: true
+        enabled: true
       - if-name: n2-s
-        enable: true
+        enabled: true
         network-type: point-to-point
         cost: 1
       - if-name: n2-r1
-        enable: true
+        enabled: true
         network-type: point-to-point
         cost: 1

--- a/bdd/tests/configs/classic_tilfa_v3/n3.yaml
+++ b/bdd/tests/configs/classic_tilfa_v3/n3.yaml
@@ -26,12 +26,12 @@ router:
     - area-id: 0.0.0.0
       interface:
       - if-name: lo
-        enable: true
+        enabled: true
       - if-name: n3-s
-        enable: true
+        enabled: true
         network-type: point-to-point
         cost: 1000
       - if-name: n3-r1
-        enable: true
+        enabled: true
         network-type: point-to-point
         cost: 1000

--- a/bdd/tests/configs/classic_tilfa_v3/r1.yaml
+++ b/bdd/tests/configs/classic_tilfa_v3/r1.yaml
@@ -32,20 +32,20 @@ router:
     - area-id: 0.0.0.0
       interface:
       - if-name: lo
-        enable: true
+        enabled: true
       - if-name: r1-n1
-        enable: true
+        enabled: true
         network-type: point-to-point
         cost: 1
       - if-name: r1-n2
-        enable: true
+        enabled: true
         network-type: point-to-point
         cost: 1
       - if-name: r1-n3
-        enable: true
+        enabled: true
         network-type: point-to-point
         cost: 1000
       - if-name: r1-r2
-        enable: true
+        enabled: true
         network-type: point-to-point
         cost: 1000

--- a/bdd/tests/configs/classic_tilfa_v3/r2.yaml
+++ b/bdd/tests/configs/classic_tilfa_v3/r2.yaml
@@ -29,16 +29,16 @@ router:
     - area-id: 0.0.0.0
       interface:
       - if-name: lo
-        enable: true
+        enabled: true
       - if-name: r2-n1
-        enable: true
+        enabled: true
         network-type: point-to-point
         cost: 1
       - if-name: r2-r1
-        enable: true
+        enabled: true
         network-type: point-to-point
         cost: 1000
       - if-name: r2-r3
-        enable: true
+        enabled: true
         network-type: point-to-point
         cost: 1000

--- a/bdd/tests/configs/classic_tilfa_v3/r3.yaml
+++ b/bdd/tests/configs/classic_tilfa_v3/r3.yaml
@@ -26,12 +26,12 @@ router:
     - area-id: 0.0.0.0
       interface:
       - if-name: lo
-        enable: true
+        enabled: true
       - if-name: r3-r2
-        enable: true
+        enabled: true
         network-type: point-to-point
         cost: 1000
       - if-name: r3-d
-        enable: true
+        enabled: true
         network-type: point-to-point
         cost: 1

--- a/bdd/tests/configs/classic_tilfa_v3/s.yaml
+++ b/bdd/tests/configs/classic_tilfa_v3/s.yaml
@@ -29,16 +29,16 @@ router:
     - area-id: 0.0.0.0
       interface:
       - if-name: lo
-        enable: true
+        enabled: true
       - if-name: s-n1
-        enable: true
+        enabled: true
         network-type: point-to-point
         cost: 1
       - if-name: s-n2
-        enable: true
+        enabled: true
         network-type: point-to-point
         cost: 1
       - if-name: s-n3
-        enable: true
+        enabled: true
         network-type: point-to-point
         cost: 1000

--- a/bdd/tests/configs/ecmp_bfd_evict/a.yaml
+++ b/bdd/tests/configs/ecmp_bfd_evict/a.yaml
@@ -16,14 +16,14 @@ router:
     interface:
     - if-name: lo
       ipv4:
-        enable: true
+        enabled: true
     - if-name: a-s
       ipv4:
-        enable: true
+        enabled: true
       metric: 1
       bfd:
-        enable: true
+        enabled: true
     - if-name: a-d
       ipv4:
-        enable: true
+        enabled: true
       metric: 1

--- a/bdd/tests/configs/ecmp_bfd_evict/b.yaml
+++ b/bdd/tests/configs/ecmp_bfd_evict/b.yaml
@@ -16,12 +16,12 @@ router:
     interface:
     - if-name: lo
       ipv4:
-        enable: true
+        enabled: true
     - if-name: b-s
       ipv4:
-        enable: true
+        enabled: true
       metric: 1
     - if-name: b-d
       ipv4:
-        enable: true
+        enabled: true
       metric: 1

--- a/bdd/tests/configs/ecmp_bfd_evict/d.yaml
+++ b/bdd/tests/configs/ecmp_bfd_evict/d.yaml
@@ -16,12 +16,12 @@ router:
     interface:
     - if-name: lo
       ipv4:
-        enable: true
+        enabled: true
     - if-name: d-a
       ipv4:
-        enable: true
+        enabled: true
       metric: 1
     - if-name: d-b
       ipv4:
-        enable: true
+        enabled: true
       metric: 1

--- a/bdd/tests/configs/ecmp_bfd_evict/s.yaml
+++ b/bdd/tests/configs/ecmp_bfd_evict/s.yaml
@@ -16,14 +16,14 @@ router:
     interface:
     - if-name: lo
       ipv4:
-        enable: true
+        enabled: true
     - if-name: s-a
       ipv4:
-        enable: true
+        enabled: true
       metric: 1
       bfd:
-        enable: true
+        enabled: true
     - if-name: s-b
       ipv4:
-        enable: true
+        enabled: true
       metric: 1

--- a/bdd/tests/configs/flexalgo_tilfa_srv6/d.yaml
+++ b/bdd/tests/configs/flexalgo_tilfa_srv6/d.yaml
@@ -41,14 +41,14 @@ router:
     interface:
     - if-name: lo
       ipv6:
-        enable: true
+        enabled: true
     - if-name: d-n1
       network-type: point-to-point
       metric: 1
       ipv6:
-        enable: true
+        enabled: true
     - if-name: d-r3
       network-type: point-to-point
       metric: 1
       ipv6:
-        enable: true
+        enabled: true

--- a/bdd/tests/configs/flexalgo_tilfa_srv6/n1.yaml
+++ b/bdd/tests/configs/flexalgo_tilfa_srv6/n1.yaml
@@ -46,24 +46,24 @@ router:
     interface:
     - if-name: lo
       ipv6:
-        enable: true
+        enabled: true
     - if-name: n1-s
       network-type: point-to-point
       metric: 1
       ipv6:
-        enable: true
+        enabled: true
     - if-name: n1-r1
       network-type: point-to-point
       metric: 1
       ipv6:
-        enable: true
+        enabled: true
     - if-name: n1-r2
       network-type: point-to-point
       metric: 1
       ipv6:
-        enable: true
+        enabled: true
     - if-name: n1-d
       network-type: point-to-point
       metric: 1
       ipv6:
-        enable: true
+        enabled: true

--- a/bdd/tests/configs/flexalgo_tilfa_srv6/n2.yaml
+++ b/bdd/tests/configs/flexalgo_tilfa_srv6/n2.yaml
@@ -40,14 +40,14 @@ router:
     interface:
     - if-name: lo
       ipv6:
-        enable: true
+        enabled: true
     - if-name: n2-s
       network-type: point-to-point
       metric: 1
       ipv6:
-        enable: true
+        enabled: true
     - if-name: n2-r1
       network-type: point-to-point
       metric: 1
       ipv6:
-        enable: true
+        enabled: true

--- a/bdd/tests/configs/flexalgo_tilfa_srv6/n3.yaml
+++ b/bdd/tests/configs/flexalgo_tilfa_srv6/n3.yaml
@@ -40,14 +40,14 @@ router:
     interface:
     - if-name: lo
       ipv6:
-        enable: true
+        enabled: true
     - if-name: n3-s
       network-type: point-to-point
       metric: 1000
       ipv6:
-        enable: true
+        enabled: true
     - if-name: n3-r1
       network-type: point-to-point
       metric: 1000
       ipv6:
-        enable: true
+        enabled: true

--- a/bdd/tests/configs/flexalgo_tilfa_srv6/r1.yaml
+++ b/bdd/tests/configs/flexalgo_tilfa_srv6/r1.yaml
@@ -46,24 +46,24 @@ router:
     interface:
     - if-name: lo
       ipv6:
-        enable: true
+        enabled: true
     - if-name: r1-n1
       network-type: point-to-point
       metric: 1
       ipv6:
-        enable: true
+        enabled: true
     - if-name: r1-n2
       network-type: point-to-point
       metric: 1
       ipv6:
-        enable: true
+        enabled: true
     - if-name: r1-n3
       network-type: point-to-point
       metric: 1000
       ipv6:
-        enable: true
+        enabled: true
     - if-name: r1-r2
       network-type: point-to-point
       metric: 1000
       ipv6:
-        enable: true
+        enabled: true

--- a/bdd/tests/configs/flexalgo_tilfa_srv6/r2.yaml
+++ b/bdd/tests/configs/flexalgo_tilfa_srv6/r2.yaml
@@ -43,19 +43,19 @@ router:
     interface:
     - if-name: lo
       ipv6:
-        enable: true
+        enabled: true
     - if-name: r2-n1
       network-type: point-to-point
       metric: 1
       ipv6:
-        enable: true
+        enabled: true
     - if-name: r2-r1
       network-type: point-to-point
       metric: 1000
       ipv6:
-        enable: true
+        enabled: true
     - if-name: r2-r3
       network-type: point-to-point
       metric: 1000
       ipv6:
-        enable: true
+        enabled: true

--- a/bdd/tests/configs/flexalgo_tilfa_srv6/r3.yaml
+++ b/bdd/tests/configs/flexalgo_tilfa_srv6/r3.yaml
@@ -40,14 +40,14 @@ router:
     interface:
     - if-name: lo
       ipv6:
-        enable: true
+        enabled: true
     - if-name: r3-r2
       network-type: point-to-point
       metric: 1000
       ipv6:
-        enable: true
+        enabled: true
     - if-name: r3-d
       network-type: point-to-point
       metric: 1
       ipv6:
-        enable: true
+        enabled: true

--- a/bdd/tests/configs/flexalgo_tilfa_srv6/s.yaml
+++ b/bdd/tests/configs/flexalgo_tilfa_srv6/s.yaml
@@ -49,19 +49,19 @@ router:
     interface:
     - if-name: lo
       ipv6:
-        enable: true
+        enabled: true
     - if-name: s-n1
       network-type: point-to-point
       metric: 1
       ipv6:
-        enable: true
+        enabled: true
     - if-name: s-n2
       network-type: point-to-point
       metric: 1
       ipv6:
-        enable: true
+        enabled: true
     - if-name: s-n3
       network-type: point-to-point
       metric: 1000
       ipv6:
-        enable: true
+        enabled: true

--- a/bdd/tests/configs/isis_afi_enable/a1-lo-v6.yaml
+++ b/bdd/tests/configs/isis_afi_enable/a1-lo-v6.yaml
@@ -18,14 +18,14 @@ router:
     - if-name: lo
       circuit-type: level-2-only
       ipv4:
-        enable: true
+        enabled: true
       ipv6:
-        enable: true
+        enabled: true
     - if-name: i2
       circuit-type: level-2-only
       network-type: point-to-point
       metric: 10
       ipv4:
-        enable: true
+        enabled: true
       ipv6:
-        enable: true
+        enabled: true

--- a/bdd/tests/configs/isis_afi_enable/a1.yaml
+++ b/bdd/tests/configs/isis_afi_enable/a1.yaml
@@ -18,12 +18,12 @@ router:
     - if-name: lo
       circuit-type: level-2-only
       ipv4:
-        enable: true
+        enabled: true
     - if-name: i2
       circuit-type: level-2-only
       network-type: point-to-point
       metric: 10
       ipv4:
-        enable: true
+        enabled: true
       ipv6:
-        enable: true
+        enabled: true

--- a/bdd/tests/configs/isis_afi_enable/a2.yaml
+++ b/bdd/tests/configs/isis_afi_enable/a2.yaml
@@ -18,14 +18,14 @@ router:
     - if-name: lo
       circuit-type: level-2-only
       ipv4:
-        enable: true
+        enabled: true
       ipv6:
-        enable: true
+        enabled: true
     - if-name: i1
       circuit-type: level-2-only
       network-type: point-to-point
       metric: 10
       ipv4:
-        enable: true
+        enabled: true
       ipv6:
-        enable: true
+        enabled: true

--- a/bdd/tests/configs/isis_bfd_ipv4_lan/z1-echo-both.yaml
+++ b/bdd/tests/configs/isis_bfd_ipv4_lan/z1-echo-both.yaml
@@ -14,11 +14,11 @@ router:
     - if-name: lo
       circuit-type: level-2-only
       ipv4:
-        enable: true
+        enabled: true
     - if-name: vz1ns
       circuit-type: level-2-only
       ipv4:
-        enable: true
+        enabled: true
       bfd:
-        enable: true
+        enabled: true
         echo-mode: both

--- a/bdd/tests/configs/isis_bfd_ipv4_lan/z1-echo-tx.yaml
+++ b/bdd/tests/configs/isis_bfd_ipv4_lan/z1-echo-tx.yaml
@@ -14,11 +14,11 @@ router:
     - if-name: lo
       circuit-type: level-2-only
       ipv4:
-        enable: true
+        enabled: true
     - if-name: vz1ns
       circuit-type: level-2-only
       ipv4:
-        enable: true
+        enabled: true
       bfd:
-        enable: true
+        enabled: true
         echo-mode: transmit

--- a/bdd/tests/configs/isis_bfd_ipv4_lan/z1-noecho.yaml
+++ b/bdd/tests/configs/isis_bfd_ipv4_lan/z1-noecho.yaml
@@ -14,10 +14,10 @@ router:
     - if-name: lo
       circuit-type: level-2-only
       ipv4:
-        enable: true
+        enabled: true
     - if-name: vz1ns
       circuit-type: level-2-only
       ipv4:
-        enable: true
+        enabled: true
       bfd:
-        enable: true
+        enabled: true

--- a/bdd/tests/configs/isis_bfd_ipv4_lan/z2-echo-both.yaml
+++ b/bdd/tests/configs/isis_bfd_ipv4_lan/z2-echo-both.yaml
@@ -14,11 +14,11 @@ router:
     - if-name: lo
       circuit-type: level-2-only
       ipv4:
-        enable: true
+        enabled: true
     - if-name: vz2ns
       circuit-type: level-2-only
       ipv4:
-        enable: true
+        enabled: true
       bfd:
-        enable: true
+        enabled: true
         echo-mode: both

--- a/bdd/tests/configs/isis_bfd_ipv4_lan/z2-echo-rx.yaml
+++ b/bdd/tests/configs/isis_bfd_ipv4_lan/z2-echo-rx.yaml
@@ -14,11 +14,11 @@ router:
     - if-name: lo
       circuit-type: level-2-only
       ipv4:
-        enable: true
+        enabled: true
     - if-name: vz2ns
       circuit-type: level-2-only
       ipv4:
-        enable: true
+        enabled: true
       bfd:
-        enable: true
+        enabled: true
         echo-mode: receive

--- a/bdd/tests/configs/isis_bfd_ipv4_lan/z2-noecho.yaml
+++ b/bdd/tests/configs/isis_bfd_ipv4_lan/z2-noecho.yaml
@@ -14,10 +14,10 @@ router:
     - if-name: lo
       circuit-type: level-2-only
       ipv4:
-        enable: true
+        enabled: true
     - if-name: vz2ns
       circuit-type: level-2-only
       ipv4:
-        enable: true
+        enabled: true
       bfd:
-        enable: true
+        enabled: true

--- a/bdd/tests/configs/isis_bfd_ipv4_p2p/z1-echo-both.yaml
+++ b/bdd/tests/configs/isis_bfd_ipv4_p2p/z1-echo-both.yaml
@@ -14,12 +14,12 @@ router:
     - if-name: lo
       circuit-type: level-2-only
       ipv4:
-        enable: true
+        enabled: true
     - if-name: i1
       circuit-type: level-2-only
       network-type: point-to-point
       ipv4:
-        enable: true
+        enabled: true
       bfd:
-        enable: true
+        enabled: true
         echo-mode: both

--- a/bdd/tests/configs/isis_bfd_ipv4_p2p/z1-echo-tx.yaml
+++ b/bdd/tests/configs/isis_bfd_ipv4_p2p/z1-echo-tx.yaml
@@ -14,12 +14,12 @@ router:
     - if-name: lo
       circuit-type: level-2-only
       ipv4:
-        enable: true
+        enabled: true
     - if-name: i1
       circuit-type: level-2-only
       network-type: point-to-point
       ipv4:
-        enable: true
+        enabled: true
       bfd:
-        enable: true
+        enabled: true
         echo-mode: transmit

--- a/bdd/tests/configs/isis_bfd_ipv4_p2p/z1-noecho.yaml
+++ b/bdd/tests/configs/isis_bfd_ipv4_p2p/z1-noecho.yaml
@@ -14,11 +14,11 @@ router:
     - if-name: lo
       circuit-type: level-2-only
       ipv4:
-        enable: true
+        enabled: true
     - if-name: i1
       circuit-type: level-2-only
       network-type: point-to-point
       ipv4:
-        enable: true
+        enabled: true
       bfd:
-        enable: true
+        enabled: true

--- a/bdd/tests/configs/isis_bfd_ipv4_p2p/z2-echo-both.yaml
+++ b/bdd/tests/configs/isis_bfd_ipv4_p2p/z2-echo-both.yaml
@@ -14,12 +14,12 @@ router:
     - if-name: lo
       circuit-type: level-2-only
       ipv4:
-        enable: true
+        enabled: true
     - if-name: i1
       circuit-type: level-2-only
       network-type: point-to-point
       ipv4:
-        enable: true
+        enabled: true
       bfd:
-        enable: true
+        enabled: true
         echo-mode: both

--- a/bdd/tests/configs/isis_bfd_ipv4_p2p/z2-echo-rx.yaml
+++ b/bdd/tests/configs/isis_bfd_ipv4_p2p/z2-echo-rx.yaml
@@ -14,12 +14,12 @@ router:
     - if-name: lo
       circuit-type: level-2-only
       ipv4:
-        enable: true
+        enabled: true
     - if-name: i1
       circuit-type: level-2-only
       network-type: point-to-point
       ipv4:
-        enable: true
+        enabled: true
       bfd:
-        enable: true
+        enabled: true
         echo-mode: receive

--- a/bdd/tests/configs/isis_bfd_ipv4_p2p/z2-noecho.yaml
+++ b/bdd/tests/configs/isis_bfd_ipv4_p2p/z2-noecho.yaml
@@ -14,11 +14,11 @@ router:
     - if-name: lo
       circuit-type: level-2-only
       ipv4:
-        enable: true
+        enabled: true
     - if-name: i1
       circuit-type: level-2-only
       network-type: point-to-point
       ipv4:
-        enable: true
+        enabled: true
       bfd:
-        enable: true
+        enabled: true

--- a/bdd/tests/configs/isis_bfd_ipv6_lan/z1-echo-both.yaml
+++ b/bdd/tests/configs/isis_bfd_ipv6_lan/z1-echo-both.yaml
@@ -14,11 +14,11 @@ router:
     - if-name: lo
       circuit-type: level-2-only
       ipv6:
-        enable: true
+        enabled: true
     - if-name: vz1ns
       circuit-type: level-2-only
       ipv6:
-        enable: true
+        enabled: true
       bfd:
-        enable: true
+        enabled: true
         echo-mode: both

--- a/bdd/tests/configs/isis_bfd_ipv6_lan/z1-echo-tx.yaml
+++ b/bdd/tests/configs/isis_bfd_ipv6_lan/z1-echo-tx.yaml
@@ -14,11 +14,11 @@ router:
     - if-name: lo
       circuit-type: level-2-only
       ipv6:
-        enable: true
+        enabled: true
     - if-name: vz1ns
       circuit-type: level-2-only
       ipv6:
-        enable: true
+        enabled: true
       bfd:
-        enable: true
+        enabled: true
         echo-mode: transmit

--- a/bdd/tests/configs/isis_bfd_ipv6_lan/z1-noecho.yaml
+++ b/bdd/tests/configs/isis_bfd_ipv6_lan/z1-noecho.yaml
@@ -14,10 +14,10 @@ router:
     - if-name: lo
       circuit-type: level-2-only
       ipv6:
-        enable: true
+        enabled: true
     - if-name: vz1ns
       circuit-type: level-2-only
       ipv6:
-        enable: true
+        enabled: true
       bfd:
-        enable: true
+        enabled: true

--- a/bdd/tests/configs/isis_bfd_ipv6_lan/z2-echo-both.yaml
+++ b/bdd/tests/configs/isis_bfd_ipv6_lan/z2-echo-both.yaml
@@ -14,11 +14,11 @@ router:
     - if-name: lo
       circuit-type: level-2-only
       ipv6:
-        enable: true
+        enabled: true
     - if-name: vz2ns
       circuit-type: level-2-only
       ipv6:
-        enable: true
+        enabled: true
       bfd:
-        enable: true
+        enabled: true
         echo-mode: both

--- a/bdd/tests/configs/isis_bfd_ipv6_lan/z2-echo-rx.yaml
+++ b/bdd/tests/configs/isis_bfd_ipv6_lan/z2-echo-rx.yaml
@@ -14,11 +14,11 @@ router:
     - if-name: lo
       circuit-type: level-2-only
       ipv6:
-        enable: true
+        enabled: true
     - if-name: vz2ns
       circuit-type: level-2-only
       ipv6:
-        enable: true
+        enabled: true
       bfd:
-        enable: true
+        enabled: true
         echo-mode: receive

--- a/bdd/tests/configs/isis_bfd_ipv6_lan/z2-noecho.yaml
+++ b/bdd/tests/configs/isis_bfd_ipv6_lan/z2-noecho.yaml
@@ -14,10 +14,10 @@ router:
     - if-name: lo
       circuit-type: level-2-only
       ipv6:
-        enable: true
+        enabled: true
     - if-name: vz2ns
       circuit-type: level-2-only
       ipv6:
-        enable: true
+        enabled: true
       bfd:
-        enable: true
+        enabled: true

--- a/bdd/tests/configs/isis_bfd_ipv6_p2p/z1-echo-both.yaml
+++ b/bdd/tests/configs/isis_bfd_ipv6_p2p/z1-echo-both.yaml
@@ -14,12 +14,12 @@ router:
     - if-name: lo
       circuit-type: level-2-only
       ipv6:
-        enable: true
+        enabled: true
     - if-name: i1
       circuit-type: level-2-only
       network-type: point-to-point
       ipv6:
-        enable: true
+        enabled: true
       bfd:
-        enable: true
+        enabled: true
         echo-mode: both

--- a/bdd/tests/configs/isis_bfd_ipv6_p2p/z1-echo-tx.yaml
+++ b/bdd/tests/configs/isis_bfd_ipv6_p2p/z1-echo-tx.yaml
@@ -14,12 +14,12 @@ router:
     - if-name: lo
       circuit-type: level-2-only
       ipv6:
-        enable: true
+        enabled: true
     - if-name: i1
       circuit-type: level-2-only
       network-type: point-to-point
       ipv6:
-        enable: true
+        enabled: true
       bfd:
-        enable: true
+        enabled: true
         echo-mode: transmit

--- a/bdd/tests/configs/isis_bfd_ipv6_p2p/z1-noecho.yaml
+++ b/bdd/tests/configs/isis_bfd_ipv6_p2p/z1-noecho.yaml
@@ -14,11 +14,11 @@ router:
     - if-name: lo
       circuit-type: level-2-only
       ipv6:
-        enable: true
+        enabled: true
     - if-name: i1
       circuit-type: level-2-only
       network-type: point-to-point
       ipv6:
-        enable: true
+        enabled: true
       bfd:
-        enable: true
+        enabled: true

--- a/bdd/tests/configs/isis_bfd_ipv6_p2p/z2-echo-both.yaml
+++ b/bdd/tests/configs/isis_bfd_ipv6_p2p/z2-echo-both.yaml
@@ -14,12 +14,12 @@ router:
     - if-name: lo
       circuit-type: level-2-only
       ipv6:
-        enable: true
+        enabled: true
     - if-name: i1
       circuit-type: level-2-only
       network-type: point-to-point
       ipv6:
-        enable: true
+        enabled: true
       bfd:
-        enable: true
+        enabled: true
         echo-mode: both

--- a/bdd/tests/configs/isis_bfd_ipv6_p2p/z2-echo-rx.yaml
+++ b/bdd/tests/configs/isis_bfd_ipv6_p2p/z2-echo-rx.yaml
@@ -14,12 +14,12 @@ router:
     - if-name: lo
       circuit-type: level-2-only
       ipv6:
-        enable: true
+        enabled: true
     - if-name: i1
       circuit-type: level-2-only
       network-type: point-to-point
       ipv6:
-        enable: true
+        enabled: true
       bfd:
-        enable: true
+        enabled: true
         echo-mode: receive

--- a/bdd/tests/configs/isis_bfd_ipv6_p2p/z2-noecho.yaml
+++ b/bdd/tests/configs/isis_bfd_ipv6_p2p/z2-noecho.yaml
@@ -14,11 +14,11 @@ router:
     - if-name: lo
       circuit-type: level-2-only
       ipv6:
-        enable: true
+        enabled: true
     - if-name: i1
       circuit-type: level-2-only
       network-type: point-to-point
       ipv6:
-        enable: true
+        enabled: true
       bfd:
-        enable: true
+        enabled: true

--- a/bdd/tests/configs/isis_endx_ipv6/x1-v6.conf
+++ b/bdd/tests/configs/isis_endx_ipv6/x1-v6.conf
@@ -26,17 +26,17 @@ router {
     interface lo {
       circuit-type level-2-only;
       ipv4 {
-        enable true;
+        enabled true;
       }
     }
     interface i2 {
       circuit-type level-2-only;
       network-type point-to-point;
       ipv4 {
-        enable true;
+        enabled true;
       }
       ipv6 {
-        enable true;
+        enabled true;
       }
     }
   }

--- a/bdd/tests/configs/isis_endx_ipv6/x1.conf
+++ b/bdd/tests/configs/isis_endx_ipv6/x1.conf
@@ -26,14 +26,14 @@ router {
     interface lo {
       circuit-type level-2-only;
       ipv4 {
-        enable true;
+        enabled true;
       }
     }
     interface i2 {
       circuit-type level-2-only;
       network-type point-to-point;
       ipv4 {
-        enable true;
+        enabled true;
       }
     }
   }

--- a/bdd/tests/configs/isis_endx_ipv6/x2-v6.conf
+++ b/bdd/tests/configs/isis_endx_ipv6/x2-v6.conf
@@ -21,17 +21,17 @@ router {
     interface lo {
       circuit-type level-2-only;
       ipv4 {
-        enable true;
+        enabled true;
       }
     }
     interface i1 {
       circuit-type level-2-only;
       network-type point-to-point;
       ipv4 {
-        enable true;
+        enabled true;
       }
       ipv6 {
-        enable true;
+        enabled true;
       }
     }
   }

--- a/bdd/tests/configs/isis_endx_ipv6/x2.conf
+++ b/bdd/tests/configs/isis_endx_ipv6/x2.conf
@@ -21,14 +21,14 @@ router {
     interface lo {
       circuit-type level-2-only;
       ipv4 {
-        enable true;
+        enabled true;
       }
     }
     interface i1 {
       circuit-type level-2-only;
       network-type point-to-point;
       ipv4 {
-        enable true;
+        enabled true;
       }
     }
   }

--- a/bdd/tests/configs/isis_flex_srv6/ch.yaml
+++ b/bdd/tests/configs/isis_flex_srv6/ch.yaml
@@ -57,28 +57,28 @@ router:
     interface:
     - if-name: lo
       ipv4:
-        enable: true
+        enabled: true
       ipv6:
-        enable: true
+        enabled: true
     - if-name: ch-se
       ipv4:
-        enable: true
+        enabled: true
       ipv6:
-        enable: true
+        enabled: true
       affinity:
       - us
     - if-name: ch-va
       ipv4:
-        enable: true
+        enabled: true
       ipv6:
-        enable: true
+        enabled: true
       affinity:
       - us
     - if-name: ch-ln
       ipv4:
-        enable: true
+        enabled: true
       ipv6:
-        enable: true
+        enabled: true
       affinity:
       - transatlantic
     flex-algo:

--- a/bdd/tests/configs/isis_flex_srv6/fr.yaml
+++ b/bdd/tests/configs/isis_flex_srv6/fr.yaml
@@ -52,21 +52,21 @@ router:
     interface:
     - if-name: lo
       ipv4:
-        enable: true
+        enabled: true
       ipv6:
-        enable: true
+        enabled: true
     - if-name: fr-va
       ipv4:
-        enable: true
+        enabled: true
       ipv6:
-        enable: true
+        enabled: true
       affinity:
       - transatlantic
     - if-name: fr-ln
       ipv4:
-        enable: true
+        enabled: true
       ipv6:
-        enable: true
+        enabled: true
       affinity:
       - eu
     flex-algo:

--- a/bdd/tests/configs/isis_flex_srv6/ln.yaml
+++ b/bdd/tests/configs/isis_flex_srv6/ln.yaml
@@ -52,21 +52,21 @@ router:
     interface:
     - if-name: lo
       ipv4:
-        enable: true
+        enabled: true
       ipv6:
-        enable: true
+        enabled: true
     - if-name: ln-ch
       ipv4:
-        enable: true
+        enabled: true
       ipv6:
-        enable: true
+        enabled: true
       affinity:
       - transatlantic
     - if-name: ln-fr
       ipv4:
-        enable: true
+        enabled: true
       ipv6:
-        enable: true
+        enabled: true
       affinity:
       - eu
     flex-algo:

--- a/bdd/tests/configs/isis_flex_srv6/se.yaml
+++ b/bdd/tests/configs/isis_flex_srv6/se.yaml
@@ -49,14 +49,14 @@ router:
     interface:
     - if-name: lo
       ipv4:
-        enable: true
+        enabled: true
       ipv6:
-        enable: true
+        enabled: true
     - if-name: se-ch
       ipv4:
-        enable: true
+        enabled: true
       ipv6:
-        enable: true
+        enabled: true
       affinity:
       - us
     flex-algo:

--- a/bdd/tests/configs/isis_flex_srv6/va.yaml
+++ b/bdd/tests/configs/isis_flex_srv6/va.yaml
@@ -52,21 +52,21 @@ router:
     interface:
     - if-name: lo
       ipv4:
-        enable: true
+        enabled: true
       ipv6:
-        enable: true
+        enabled: true
     - if-name: va-ch
       ipv4:
-        enable: true
+        enabled: true
       ipv6:
-        enable: true
+        enabled: true
       affinity:
       - us
     - if-name: va-fr
       ipv4:
-        enable: true
+        enabled: true
       ipv6:
-        enable: true
+        enabled: true
       affinity:
       - transatlantic
     flex-algo:

--- a/bdd/tests/configs/isis_flexalgo/ch.yaml
+++ b/bdd/tests/configs/isis_flexalgo/ch.yaml
@@ -31,7 +31,7 @@ router:
     interface:
     - if-name: lo
       ipv4:
-        enable: true
+        enabled: true
         prefix-sid:
           index: 2
         flex-algo-prefix-sid:
@@ -41,17 +41,17 @@ router:
           index: 22
     - if-name: ch-se
       ipv4:
-        enable: true
+        enabled: true
       affinity:
       - us
     - if-name: ch-va
       ipv4:
-        enable: true
+        enabled: true
       affinity:
       - us
     - if-name: ch-ln
       ipv4:
-        enable: true
+        enabled: true
       affinity:
       - transatlantic
     flex-algo:

--- a/bdd/tests/configs/isis_flexalgo/fr.yaml
+++ b/bdd/tests/configs/isis_flexalgo/fr.yaml
@@ -28,7 +28,7 @@ router:
     interface:
     - if-name: lo
       ipv4:
-        enable: true
+        enabled: true
         prefix-sid:
           index: 5
         flex-algo-prefix-sid:
@@ -38,12 +38,12 @@ router:
           index: 25
     - if-name: fr-va
       ipv4:
-        enable: true
+        enabled: true
       affinity:
       - transatlantic
     - if-name: fr-ln
       ipv4:
-        enable: true
+        enabled: true
       affinity:
       - eu
     flex-algo:

--- a/bdd/tests/configs/isis_flexalgo/ln.yaml
+++ b/bdd/tests/configs/isis_flexalgo/ln.yaml
@@ -28,7 +28,7 @@ router:
     interface:
     - if-name: lo
       ipv4:
-        enable: true
+        enabled: true
         prefix-sid:
           index: 4
         flex-algo-prefix-sid:
@@ -38,12 +38,12 @@ router:
           index: 24
     - if-name: ln-ch
       ipv4:
-        enable: true
+        enabled: true
       affinity:
       - transatlantic
     - if-name: ln-fr
       ipv4:
-        enable: true
+        enabled: true
       affinity:
       - eu
     flex-algo:

--- a/bdd/tests/configs/isis_flexalgo/se.yaml
+++ b/bdd/tests/configs/isis_flexalgo/se.yaml
@@ -25,7 +25,7 @@ router:
     interface:
     - if-name: lo
       ipv4:
-        enable: true
+        enabled: true
         prefix-sid:
           index: 1
         flex-algo-prefix-sid:
@@ -35,7 +35,7 @@ router:
           index: 21
     - if-name: se-ch
       ipv4:
-        enable: true
+        enabled: true
       affinity:
       - us
     flex-algo:

--- a/bdd/tests/configs/isis_flexalgo/va.yaml
+++ b/bdd/tests/configs/isis_flexalgo/va.yaml
@@ -28,7 +28,7 @@ router:
     interface:
     - if-name: lo
       ipv4:
-        enable: true
+        enabled: true
         prefix-sid:
           index: 3
         flex-algo-prefix-sid:
@@ -38,12 +38,12 @@ router:
           index: 23
     - if-name: va-ch
       ipv4:
-        enable: true
+        enabled: true
       affinity:
       - us
     - if-name: va-fr
       ipv4:
-        enable: true
+        enabled: true
       affinity:
       - transatlantic
     flex-algo:

--- a/bdd/tests/configs/isis_fragmentation_ipv4/z1-1.yaml
+++ b/bdd/tests/configs/isis_fragmentation_ipv4/z1-1.yaml
@@ -86,8 +86,8 @@ router:
     - if-name: lo
       circuit-type: level-2-only
       ipv4:
-        enable: true
+        enabled: true
     - if-name: vz1ns
       circuit-type: level-2-only
       ipv4:
-        enable: true
+        enabled: true

--- a/bdd/tests/configs/isis_fragmentation_ipv4/z1-2.yaml
+++ b/bdd/tests/configs/isis_fragmentation_ipv4/z1-2.yaml
@@ -226,8 +226,8 @@ router:
     - if-name: lo
       circuit-type: level-2-only
       ipv4:
-        enable: true
+        enabled: true
     - if-name: vz1ns
       circuit-type: level-2-only
       ipv4:
-        enable: true
+        enabled: true

--- a/bdd/tests/configs/isis_fragmentation_ipv4/z1-3.yaml
+++ b/bdd/tests/configs/isis_fragmentation_ipv4/z1-3.yaml
@@ -235,8 +235,8 @@ router:
     - if-name: lo
       circuit-type: level-2-only
       ipv4:
-        enable: true
+        enabled: true
     - if-name: vz1ns
       circuit-type: level-2-only
       ipv4:
-        enable: true
+        enabled: true

--- a/bdd/tests/configs/isis_fragmentation_ipv4/z1-4.yaml
+++ b/bdd/tests/configs/isis_fragmentation_ipv4/z1-4.yaml
@@ -232,8 +232,8 @@ router:
     - if-name: lo
       circuit-type: level-2-only
       ipv4:
-        enable: true
+        enabled: true
     - if-name: vz1ns
       circuit-type: level-2-only
       ipv4:
-        enable: true
+        enabled: true

--- a/bdd/tests/configs/isis_fragmentation_ipv4/z2-1.yaml
+++ b/bdd/tests/configs/isis_fragmentation_ipv4/z2-1.yaml
@@ -14,8 +14,8 @@ router:
     - if-name: lo
       circuit-type: level-2-only
       ipv4:
-        enable: true
+        enabled: true
     - if-name: vz2ns
       circuit-type: level-2-only
       ipv4:
-        enable: true
+        enabled: true

--- a/bdd/tests/configs/isis_fragmentation_ipv6/z1-1.yaml
+++ b/bdd/tests/configs/isis_fragmentation_ipv6/z1-1.yaml
@@ -66,8 +66,8 @@ router:
     - if-name: lo
       circuit-type: level-2-only
       ipv6:
-        enable: true
+        enabled: true
     - if-name: vz1ns
       circuit-type: level-2-only
       ipv6:
-        enable: true
+        enabled: true

--- a/bdd/tests/configs/isis_fragmentation_ipv6/z2-1.yaml
+++ b/bdd/tests/configs/isis_fragmentation_ipv6/z2-1.yaml
@@ -14,8 +14,8 @@ router:
     - if-name: lo
       circuit-type: level-2-only
       ipv6:
-        enable: true
+        enabled: true
     - if-name: vz2ns
       circuit-type: level-2-only
       ipv6:
-        enable: true
+        enabled: true

--- a/bdd/tests/configs/isis_hello_auth_keychain/z1.yaml
+++ b/bdd/tests/configs/isis_hello_auth_keychain/z1.yaml
@@ -41,17 +41,17 @@ router:
     - if-name: lo
       circuit-type: level-1
       ipv4:
-        enable: true
+        enabled: true
       ipv6:
-        enable: true
+        enabled: true
     - if-name: i2
       circuit-type: level-1
       network-type: point-to-point
       metric: 10
       ipv4:
-        enable: true
+        enabled: true
       ipv6:
-        enable: true
+        enabled: true
       # Authenticate IIH/CSNP/PSNP on this link via the ISIS-HELLO chain.
       hello-authentication:
         key-chain: ISIS-HELLO

--- a/bdd/tests/configs/isis_hello_auth_keychain/z2-badkey.yaml
+++ b/bdd/tests/configs/isis_hello_auth_keychain/z2-badkey.yaml
@@ -35,16 +35,16 @@ router:
     - if-name: lo
       circuit-type: level-1
       ipv4:
-        enable: true
+        enabled: true
       ipv6:
-        enable: true
+        enabled: true
     - if-name: i1
       circuit-type: level-1
       network-type: point-to-point
       metric: 10
       ipv4:
-        enable: true
+        enabled: true
       ipv6:
-        enable: true
+        enabled: true
       hello-authentication:
         key-chain: ISIS-HELLO

--- a/bdd/tests/configs/isis_hello_auth_keychain/z2.yaml
+++ b/bdd/tests/configs/isis_hello_auth_keychain/z2.yaml
@@ -31,17 +31,17 @@ router:
     - if-name: lo
       circuit-type: level-1
       ipv4:
-        enable: true
+        enabled: true
       ipv6:
-        enable: true
+        enabled: true
     - if-name: i1
       circuit-type: level-1
       network-type: point-to-point
       metric: 10
       ipv4:
-        enable: true
+        enabled: true
       ipv6:
-        enable: true
+        enabled: true
       # Authenticate IIH/CSNP/PSNP on this link via the ISIS-HELLO chain.
       hello-authentication:
         key-chain: ISIS-HELLO

--- a/bdd/tests/configs/isis_ipv6/z1-1.yaml
+++ b/bdd/tests/configs/isis_ipv6/z1-1.yaml
@@ -14,8 +14,8 @@ router:
     - if-name: lo
       circuit-type: level-2-only
       ipv6:
-        enable: true
+        enabled: true
     - if-name: vz1ns
       circuit-type: level-2-only
       ipv6:
-        enable: true
+        enabled: true

--- a/bdd/tests/configs/isis_ipv6/z2-1.yaml
+++ b/bdd/tests/configs/isis_ipv6/z2-1.yaml
@@ -14,8 +14,8 @@ router:
     - if-name: lo
       circuit-type: level-2-only
       ipv6:
-        enable: true
+        enabled: true
     - if-name: vz2ns
       circuit-type: level-2-only
       ipv6:
-        enable: true
+        enabled: true

--- a/bdd/tests/configs/isis_l1l2/r1.yaml
+++ b/bdd/tests/configs/isis_l1l2/r1.yaml
@@ -18,14 +18,14 @@ router:
     - if-name: lo
       circuit-type: level-1
       ipv4:
-        enable: true
+        enabled: true
       ipv6:
-        enable: true
+        enabled: true
     - if-name: i2
       circuit-type: level-1
       network-type: point-to-point
       metric: 10
       ipv4:
-        enable: true
+        enabled: true
       ipv6:
-        enable: true
+        enabled: true

--- a/bdd/tests/configs/isis_l1l2/r2.yaml
+++ b/bdd/tests/configs/isis_l1l2/r2.yaml
@@ -23,22 +23,22 @@ router:
     - if-name: lo
       circuit-type: level-1
       ipv4:
-        enable: true
+        enabled: true
       ipv6:
-        enable: true
+        enabled: true
     - if-name: i1
       circuit-type: level-1
       network-type: point-to-point
       metric: 10
       ipv4:
-        enable: true
+        enabled: true
       ipv6:
-        enable: true
+        enabled: true
     - if-name: i3
       circuit-type: level-1
       network-type: point-to-point
       metric: 10
       ipv4:
-        enable: true
+        enabled: true
       ipv6:
-        enable: true
+        enabled: true

--- a/bdd/tests/configs/isis_l1l2/r3-backbone-l1l2.yaml
+++ b/bdd/tests/configs/isis_l1l2/r3-backbone-l1l2.yaml
@@ -23,22 +23,22 @@ router:
     - if-name: lo
       circuit-type: level-1-2
       ipv4:
-        enable: true
+        enabled: true
       ipv6:
-        enable: true
+        enabled: true
     - if-name: i2
       circuit-type: level-1
       network-type: point-to-point
       metric: 10
       ipv4:
-        enable: true
+        enabled: true
       ipv6:
-        enable: true
+        enabled: true
     - if-name: i4
       circuit-type: level-1-2
       network-type: point-to-point
       metric: 10
       ipv4:
-        enable: true
+        enabled: true
       ipv6:
-        enable: true
+        enabled: true

--- a/bdd/tests/configs/isis_l1l2/r3.yaml
+++ b/bdd/tests/configs/isis_l1l2/r3.yaml
@@ -23,22 +23,22 @@ router:
     - if-name: lo
       circuit-type: level-1-2
       ipv4:
-        enable: true
+        enabled: true
       ipv6:
-        enable: true
+        enabled: true
     - if-name: i2
       circuit-type: level-1
       network-type: point-to-point
       metric: 10
       ipv4:
-        enable: true
+        enabled: true
       ipv6:
-        enable: true
+        enabled: true
     - if-name: i4
       circuit-type: level-2-only
       network-type: point-to-point
       metric: 10
       ipv4:
-        enable: true
+        enabled: true
       ipv6:
-        enable: true
+        enabled: true

--- a/bdd/tests/configs/isis_l1l2/r4-backbone-l1l2.yaml
+++ b/bdd/tests/configs/isis_l1l2/r4-backbone-l1l2.yaml
@@ -22,22 +22,22 @@ router:
     - if-name: lo
       circuit-type: level-2-only
       ipv4:
-        enable: true
+        enabled: true
       ipv6:
-        enable: true
+        enabled: true
     - if-name: i3
       circuit-type: level-1-2
       network-type: point-to-point
       metric: 10
       ipv4:
-        enable: true
+        enabled: true
       ipv6:
-        enable: true
+        enabled: true
     - if-name: i5
       circuit-type: level-1-2
       network-type: point-to-point
       metric: 10
       ipv4:
-        enable: true
+        enabled: true
       ipv6:
-        enable: true
+        enabled: true

--- a/bdd/tests/configs/isis_l1l2/r4-l1l2.yaml
+++ b/bdd/tests/configs/isis_l1l2/r4-l1l2.yaml
@@ -22,22 +22,22 @@ router:
     - if-name: lo
       circuit-type: level-2-only
       ipv4:
-        enable: true
+        enabled: true
       ipv6:
-        enable: true
+        enabled: true
     - if-name: i3
       circuit-type: level-2-only
       network-type: point-to-point
       metric: 10
       ipv4:
-        enable: true
+        enabled: true
       ipv6:
-        enable: true
+        enabled: true
     - if-name: i5
       circuit-type: level-1-2
       network-type: point-to-point
       metric: 10
       ipv4:
-        enable: true
+        enabled: true
       ipv6:
-        enable: true
+        enabled: true

--- a/bdd/tests/configs/isis_l1l2/r4.yaml
+++ b/bdd/tests/configs/isis_l1l2/r4.yaml
@@ -23,22 +23,22 @@ router:
     - if-name: lo
       circuit-type: level-2-only
       ipv4:
-        enable: true
+        enabled: true
       ipv6:
-        enable: true
+        enabled: true
     - if-name: i3
       circuit-type: level-2-only
       network-type: point-to-point
       metric: 10
       ipv4:
-        enable: true
+        enabled: true
       ipv6:
-        enable: true
+        enabled: true
     - if-name: i5
       circuit-type: level-1-2
       network-type: point-to-point
       metric: 10
       ipv4:
-        enable: true
+        enabled: true
       ipv6:
-        enable: true
+        enabled: true

--- a/bdd/tests/configs/isis_l1l2/r5.yaml
+++ b/bdd/tests/configs/isis_l1l2/r5.yaml
@@ -18,14 +18,14 @@ router:
     - if-name: lo
       circuit-type: level-1
       ipv4:
-        enable: true
+        enabled: true
       ipv6:
-        enable: true
+        enabled: true
     - if-name: i4
       circuit-type: level-1
       network-type: point-to-point
       metric: 10
       ipv4:
-        enable: true
+        enabled: true
       ipv6:
-        enable: true
+        enabled: true

--- a/bdd/tests/configs/isis_l1p2p/z1-auth.yaml
+++ b/bdd/tests/configs/isis_l1p2p/z1-auth.yaml
@@ -27,17 +27,17 @@ router:
     - if-name: lo
       circuit-type: level-1
       ipv4:
-        enable: true
+        enabled: true
       ipv6:
-        enable: true
+        enabled: true
     - if-name: i2
       circuit-type: level-1
       network-type: point-to-point
       metric: 10
       ipv4:
-        enable: true
+        enabled: true
       ipv6:
-        enable: true
+        enabled: true
       hello-authentication:
         password: zebra-isis-secret
         auth-type: hmac-sha-256
@@ -47,9 +47,9 @@ router:
       network-type: point-to-point
       metric: 40
       ipv4:
-        enable: true
+        enabled: true
       ipv6:
-        enable: true
+        enabled: true
       hello-authentication:
         password: zebra-isis-secret
         auth-type: hmac-sha-256

--- a/bdd/tests/configs/isis_l1p2p/z1.yaml
+++ b/bdd/tests/configs/isis_l1p2p/z1.yaml
@@ -23,22 +23,22 @@ router:
     - if-name: lo
       circuit-type: level-1
       ipv4:
-        enable: true
+        enabled: true
       ipv6:
-        enable: true
+        enabled: true
     - if-name: i2
       circuit-type: level-1
       network-type: point-to-point
       metric: 10
       ipv4:
-        enable: true
+        enabled: true
       ipv6:
-        enable: true
+        enabled: true
     - if-name: i6
       circuit-type: level-1
       network-type: point-to-point
       metric: 40
       ipv4:
-        enable: true
+        enabled: true
       ipv6:
-        enable: true
+        enabled: true

--- a/bdd/tests/configs/isis_l1p2p/z10-auth.yaml
+++ b/bdd/tests/configs/isis_l1p2p/z10-auth.yaml
@@ -27,17 +27,17 @@ router:
     - if-name: lo
       circuit-type: level-1
       ipv4:
-        enable: true
+        enabled: true
       ipv6:
-        enable: true
+        enabled: true
     - if-name: i9
       circuit-type: level-1
       network-type: point-to-point
       metric: 20
       ipv4:
-        enable: true
+        enabled: true
       ipv6:
-        enable: true
+        enabled: true
       hello-authentication:
         password: zebra-isis-secret
         auth-type: hmac-sha-256
@@ -47,9 +47,9 @@ router:
       network-type: point-to-point
       metric: 40
       ipv4:
-        enable: true
+        enabled: true
       ipv6:
-        enable: true
+        enabled: true
       hello-authentication:
         password: zebra-isis-secret
         auth-type: hmac-sha-256

--- a/bdd/tests/configs/isis_l1p2p/z10.yaml
+++ b/bdd/tests/configs/isis_l1p2p/z10.yaml
@@ -23,22 +23,22 @@ router:
     - if-name: lo
       circuit-type: level-1
       ipv4:
-        enable: true
+        enabled: true
       ipv6:
-        enable: true
+        enabled: true
     - if-name: i9
       circuit-type: level-1
       network-type: point-to-point
       metric: 20
       ipv4:
-        enable: true
+        enabled: true
       ipv6:
-        enable: true
+        enabled: true
     - if-name: i5
       circuit-type: level-1
       network-type: point-to-point
       metric: 40
       ipv4:
-        enable: true
+        enabled: true
       ipv6:
-        enable: true
+        enabled: true

--- a/bdd/tests/configs/isis_l1p2p/z2-auth.yaml
+++ b/bdd/tests/configs/isis_l1p2p/z2-auth.yaml
@@ -32,17 +32,17 @@ router:
     - if-name: lo
       circuit-type: level-1
       ipv4:
-        enable: true
+        enabled: true
       ipv6:
-        enable: true
+        enabled: true
     - if-name: i1
       circuit-type: level-1
       network-type: point-to-point
       metric: 10
       ipv4:
-        enable: true
+        enabled: true
       ipv6:
-        enable: true
+        enabled: true
       hello-authentication:
         password: zebra-isis-secret
         auth-type: hmac-sha-256
@@ -52,9 +52,9 @@ router:
       network-type: point-to-point
       metric: 10
       ipv4:
-        enable: true
+        enabled: true
       ipv6:
-        enable: true
+        enabled: true
       hello-authentication:
         password: zebra-isis-secret
         auth-type: hmac-sha-256
@@ -64,9 +64,9 @@ router:
       network-type: point-to-point
       metric: 30
       ipv4:
-        enable: true
+        enabled: true
       ipv6:
-        enable: true
+        enabled: true
       hello-authentication:
         password: zebra-isis-secret
         auth-type: hmac-sha-256

--- a/bdd/tests/configs/isis_l1p2p/z2.yaml
+++ b/bdd/tests/configs/isis_l1p2p/z2.yaml
@@ -28,30 +28,30 @@ router:
     - if-name: lo
       circuit-type: level-1
       ipv4:
-        enable: true
+        enabled: true
       ipv6:
-        enable: true
+        enabled: true
     - if-name: i1
       circuit-type: level-1
       network-type: point-to-point
       metric: 10
       ipv4:
-        enable: true
+        enabled: true
       ipv6:
-        enable: true
+        enabled: true
     - if-name: i3
       circuit-type: level-1
       network-type: point-to-point
       metric: 10
       ipv4:
-        enable: true
+        enabled: true
       ipv6:
-        enable: true
+        enabled: true
     - if-name: i7
       circuit-type: level-1
       network-type: point-to-point
       metric: 30
       ipv4:
-        enable: true
+        enabled: true
       ipv6:
-        enable: true
+        enabled: true

--- a/bdd/tests/configs/isis_l1p2p/z3-auth.yaml
+++ b/bdd/tests/configs/isis_l1p2p/z3-auth.yaml
@@ -32,17 +32,17 @@ router:
     - if-name: lo
       circuit-type: level-1
       ipv4:
-        enable: true
+        enabled: true
       ipv6:
-        enable: true
+        enabled: true
     - if-name: i2
       circuit-type: level-1
       network-type: point-to-point
       metric: 10
       ipv4:
-        enable: true
+        enabled: true
       ipv6:
-        enable: true
+        enabled: true
       hello-authentication:
         password: zebra-isis-secret
         auth-type: hmac-sha-256
@@ -52,9 +52,9 @@ router:
       network-type: point-to-point
       metric: 10
       ipv4:
-        enable: true
+        enabled: true
       ipv6:
-        enable: true
+        enabled: true
       hello-authentication:
         password: zebra-isis-secret
         auth-type: hmac-sha-256
@@ -64,9 +64,9 @@ router:
       network-type: point-to-point
       metric: 30
       ipv4:
-        enable: true
+        enabled: true
       ipv6:
-        enable: true
+        enabled: true
       hello-authentication:
         password: zebra-isis-secret
         auth-type: hmac-sha-256

--- a/bdd/tests/configs/isis_l1p2p/z3.yaml
+++ b/bdd/tests/configs/isis_l1p2p/z3.yaml
@@ -28,30 +28,30 @@ router:
     - if-name: lo
       circuit-type: level-1
       ipv4:
-        enable: true
+        enabled: true
       ipv6:
-        enable: true
+        enabled: true
     - if-name: i2
       circuit-type: level-1
       network-type: point-to-point
       metric: 10
       ipv4:
-        enable: true
+        enabled: true
       ipv6:
-        enable: true
+        enabled: true
     - if-name: i4
       circuit-type: level-1
       network-type: point-to-point
       metric: 10
       ipv4:
-        enable: true
+        enabled: true
       ipv6:
-        enable: true
+        enabled: true
     - if-name: i8
       circuit-type: level-1
       network-type: point-to-point
       metric: 30
       ipv4:
-        enable: true
+        enabled: true
       ipv6:
-        enable: true
+        enabled: true

--- a/bdd/tests/configs/isis_l1p2p/z4-auth.yaml
+++ b/bdd/tests/configs/isis_l1p2p/z4-auth.yaml
@@ -32,17 +32,17 @@ router:
     - if-name: lo
       circuit-type: level-1
       ipv4:
-        enable: true
+        enabled: true
       ipv6:
-        enable: true
+        enabled: true
     - if-name: i3
       circuit-type: level-1
       network-type: point-to-point
       metric: 10
       ipv4:
-        enable: true
+        enabled: true
       ipv6:
-        enable: true
+        enabled: true
       hello-authentication:
         password: zebra-isis-secret
         auth-type: hmac-sha-256
@@ -52,9 +52,9 @@ router:
       network-type: point-to-point
       metric: 10
       ipv4:
-        enable: true
+        enabled: true
       ipv6:
-        enable: true
+        enabled: true
       hello-authentication:
         password: zebra-isis-secret
         auth-type: hmac-sha-256
@@ -64,9 +64,9 @@ router:
       network-type: point-to-point
       metric: 30
       ipv4:
-        enable: true
+        enabled: true
       ipv6:
-        enable: true
+        enabled: true
       hello-authentication:
         password: zebra-isis-secret
         auth-type: hmac-sha-256

--- a/bdd/tests/configs/isis_l1p2p/z4.yaml
+++ b/bdd/tests/configs/isis_l1p2p/z4.yaml
@@ -28,30 +28,30 @@ router:
     - if-name: lo
       circuit-type: level-1
       ipv4:
-        enable: true
+        enabled: true
       ipv6:
-        enable: true
+        enabled: true
     - if-name: i3
       circuit-type: level-1
       network-type: point-to-point
       metric: 10
       ipv4:
-        enable: true
+        enabled: true
       ipv6:
-        enable: true
+        enabled: true
     - if-name: i5
       circuit-type: level-1
       network-type: point-to-point
       metric: 10
       ipv4:
-        enable: true
+        enabled: true
       ipv6:
-        enable: true
+        enabled: true
     - if-name: i9
       circuit-type: level-1
       network-type: point-to-point
       metric: 30
       ipv4:
-        enable: true
+        enabled: true
       ipv6:
-        enable: true
+        enabled: true

--- a/bdd/tests/configs/isis_l1p2p/z5-auth.yaml
+++ b/bdd/tests/configs/isis_l1p2p/z5-auth.yaml
@@ -27,17 +27,17 @@ router:
     - if-name: lo
       circuit-type: level-1
       ipv4:
-        enable: true
+        enabled: true
       ipv6:
-        enable: true
+        enabled: true
     - if-name: i4
       circuit-type: level-1
       network-type: point-to-point
       metric: 10
       ipv4:
-        enable: true
+        enabled: true
       ipv6:
-        enable: true
+        enabled: true
       hello-authentication:
         password: zebra-isis-secret
         auth-type: hmac-sha-256
@@ -47,9 +47,9 @@ router:
       network-type: point-to-point
       metric: 40
       ipv4:
-        enable: true
+        enabled: true
       ipv6:
-        enable: true
+        enabled: true
       hello-authentication:
         password: zebra-isis-secret
         auth-type: hmac-sha-256

--- a/bdd/tests/configs/isis_l1p2p/z5.yaml
+++ b/bdd/tests/configs/isis_l1p2p/z5.yaml
@@ -23,22 +23,22 @@ router:
     - if-name: lo
       circuit-type: level-1
       ipv4:
-        enable: true
+        enabled: true
       ipv6:
-        enable: true
+        enabled: true
     - if-name: i4
       circuit-type: level-1
       network-type: point-to-point
       metric: 10
       ipv4:
-        enable: true
+        enabled: true
       ipv6:
-        enable: true
+        enabled: true
     - if-name: i10
       circuit-type: level-1
       network-type: point-to-point
       metric: 40
       ipv4:
-        enable: true
+        enabled: true
       ipv6:
-        enable: true
+        enabled: true

--- a/bdd/tests/configs/isis_l1p2p/z6-auth.yaml
+++ b/bdd/tests/configs/isis_l1p2p/z6-auth.yaml
@@ -27,17 +27,17 @@ router:
     - if-name: lo
       circuit-type: level-1
       ipv4:
-        enable: true
+        enabled: true
       ipv6:
-        enable: true
+        enabled: true
     - if-name: i1
       circuit-type: level-1
       network-type: point-to-point
       metric: 40
       ipv4:
-        enable: true
+        enabled: true
       ipv6:
-        enable: true
+        enabled: true
       hello-authentication:
         password: zebra-isis-secret
         auth-type: hmac-sha-256
@@ -47,9 +47,9 @@ router:
       network-type: point-to-point
       metric: 20
       ipv4:
-        enable: true
+        enabled: true
       ipv6:
-        enable: true
+        enabled: true
       hello-authentication:
         password: zebra-isis-secret
         auth-type: hmac-sha-256

--- a/bdd/tests/configs/isis_l1p2p/z6.yaml
+++ b/bdd/tests/configs/isis_l1p2p/z6.yaml
@@ -23,22 +23,22 @@ router:
     - if-name: lo
       circuit-type: level-1
       ipv4:
-        enable: true
+        enabled: true
       ipv6:
-        enable: true
+        enabled: true
     - if-name: i1
       circuit-type: level-1
       network-type: point-to-point
       metric: 40
       ipv4:
-        enable: true
+        enabled: true
       ipv6:
-        enable: true
+        enabled: true
     - if-name: i7
       circuit-type: level-1
       network-type: point-to-point
       metric: 20
       ipv4:
-        enable: true
+        enabled: true
       ipv6:
-        enable: true
+        enabled: true

--- a/bdd/tests/configs/isis_l1p2p/z7-auth.yaml
+++ b/bdd/tests/configs/isis_l1p2p/z7-auth.yaml
@@ -32,17 +32,17 @@ router:
     - if-name: lo
       circuit-type: level-1
       ipv4:
-        enable: true
+        enabled: true
       ipv6:
-        enable: true
+        enabled: true
     - if-name: i6
       circuit-type: level-1
       network-type: point-to-point
       metric: 20
       ipv4:
-        enable: true
+        enabled: true
       ipv6:
-        enable: true
+        enabled: true
       hello-authentication:
         password: zebra-isis-secret
         auth-type: hmac-sha-256
@@ -52,9 +52,9 @@ router:
       network-type: point-to-point
       metric: 20
       ipv4:
-        enable: true
+        enabled: true
       ipv6:
-        enable: true
+        enabled: true
       hello-authentication:
         password: zebra-isis-secret
         auth-type: hmac-sha-256
@@ -64,9 +64,9 @@ router:
       network-type: point-to-point
       metric: 30
       ipv4:
-        enable: true
+        enabled: true
       ipv6:
-        enable: true
+        enabled: true
       hello-authentication:
         password: zebra-isis-secret
         auth-type: hmac-sha-256

--- a/bdd/tests/configs/isis_l1p2p/z7.yaml
+++ b/bdd/tests/configs/isis_l1p2p/z7.yaml
@@ -28,30 +28,30 @@ router:
     - if-name: lo
       circuit-type: level-1
       ipv4:
-        enable: true
+        enabled: true
       ipv6:
-        enable: true
+        enabled: true
     - if-name: i6
       circuit-type: level-1
       network-type: point-to-point
       metric: 20
       ipv4:
-        enable: true
+        enabled: true
       ipv6:
-        enable: true
+        enabled: true
     - if-name: i8
       circuit-type: level-1
       network-type: point-to-point
       metric: 20
       ipv4:
-        enable: true
+        enabled: true
       ipv6:
-        enable: true
+        enabled: true
     - if-name: i2
       circuit-type: level-1
       network-type: point-to-point
       metric: 30
       ipv4:
-        enable: true
+        enabled: true
       ipv6:
-        enable: true
+        enabled: true

--- a/bdd/tests/configs/isis_l1p2p/z8-auth.yaml
+++ b/bdd/tests/configs/isis_l1p2p/z8-auth.yaml
@@ -32,17 +32,17 @@ router:
     - if-name: lo
       circuit-type: level-1
       ipv4:
-        enable: true
+        enabled: true
       ipv6:
-        enable: true
+        enabled: true
     - if-name: i7
       circuit-type: level-1
       network-type: point-to-point
       metric: 20
       ipv4:
-        enable: true
+        enabled: true
       ipv6:
-        enable: true
+        enabled: true
       hello-authentication:
         password: zebra-isis-secret
         auth-type: hmac-sha-256
@@ -52,9 +52,9 @@ router:
       network-type: point-to-point
       metric: 20
       ipv4:
-        enable: true
+        enabled: true
       ipv6:
-        enable: true
+        enabled: true
       hello-authentication:
         password: zebra-isis-secret
         auth-type: hmac-sha-256
@@ -64,9 +64,9 @@ router:
       network-type: point-to-point
       metric: 30
       ipv4:
-        enable: true
+        enabled: true
       ipv6:
-        enable: true
+        enabled: true
       hello-authentication:
         password: zebra-isis-secret
         auth-type: hmac-sha-256

--- a/bdd/tests/configs/isis_l1p2p/z8.yaml
+++ b/bdd/tests/configs/isis_l1p2p/z8.yaml
@@ -28,30 +28,30 @@ router:
     - if-name: lo
       circuit-type: level-1
       ipv4:
-        enable: true
+        enabled: true
       ipv6:
-        enable: true
+        enabled: true
     - if-name: i7
       circuit-type: level-1
       network-type: point-to-point
       metric: 20
       ipv4:
-        enable: true
+        enabled: true
       ipv6:
-        enable: true
+        enabled: true
     - if-name: i9
       circuit-type: level-1
       network-type: point-to-point
       metric: 20
       ipv4:
-        enable: true
+        enabled: true
       ipv6:
-        enable: true
+        enabled: true
     - if-name: i3
       circuit-type: level-1
       network-type: point-to-point
       metric: 30
       ipv4:
-        enable: true
+        enabled: true
       ipv6:
-        enable: true
+        enabled: true

--- a/bdd/tests/configs/isis_l1p2p/z9-auth.yaml
+++ b/bdd/tests/configs/isis_l1p2p/z9-auth.yaml
@@ -32,17 +32,17 @@ router:
     - if-name: lo
       circuit-type: level-1
       ipv4:
-        enable: true
+        enabled: true
       ipv6:
-        enable: true
+        enabled: true
     - if-name: i8
       circuit-type: level-1
       network-type: point-to-point
       metric: 20
       ipv4:
-        enable: true
+        enabled: true
       ipv6:
-        enable: true
+        enabled: true
       hello-authentication:
         password: zebra-isis-secret
         auth-type: hmac-sha-256
@@ -52,9 +52,9 @@ router:
       network-type: point-to-point
       metric: 20
       ipv4:
-        enable: true
+        enabled: true
       ipv6:
-        enable: true
+        enabled: true
       hello-authentication:
         password: zebra-isis-secret
         auth-type: hmac-sha-256
@@ -64,9 +64,9 @@ router:
       network-type: point-to-point
       metric: 30
       ipv4:
-        enable: true
+        enabled: true
       ipv6:
-        enable: true
+        enabled: true
       hello-authentication:
         password: zebra-isis-secret
         auth-type: hmac-sha-256

--- a/bdd/tests/configs/isis_l1p2p/z9.yaml
+++ b/bdd/tests/configs/isis_l1p2p/z9.yaml
@@ -28,30 +28,30 @@ router:
     - if-name: lo
       circuit-type: level-1
       ipv4:
-        enable: true
+        enabled: true
       ipv6:
-        enable: true
+        enabled: true
     - if-name: i8
       circuit-type: level-1
       network-type: point-to-point
       metric: 20
       ipv4:
-        enable: true
+        enabled: true
       ipv6:
-        enable: true
+        enabled: true
     - if-name: i10
       circuit-type: level-1
       network-type: point-to-point
       metric: 20
       ipv4:
-        enable: true
+        enabled: true
       ipv6:
-        enable: true
+        enabled: true
     - if-name: i4
       circuit-type: level-1
       network-type: point-to-point
       metric: 30
       ipv4:
-        enable: true
+        enabled: true
       ipv6:
-        enable: true
+        enabled: true

--- a/bdd/tests/configs/isis_multi_topology/z1-1.yaml
+++ b/bdd/tests/configs/isis_multi_topology/z1-1.yaml
@@ -15,8 +15,8 @@ router:
     - if-name: lo
       circuit-type: level-2-only
       ipv6:
-        enable: true
+        enabled: true
     - if-name: vz1ns
       circuit-type: level-2-only
       ipv6:
-        enable: true
+        enabled: true

--- a/bdd/tests/configs/isis_multi_topology/z2-1.yaml
+++ b/bdd/tests/configs/isis_multi_topology/z2-1.yaml
@@ -15,8 +15,8 @@ router:
     - if-name: lo
       circuit-type: level-2-only
       ipv6:
-        enable: true
+        enabled: true
     - if-name: vz2ns
       circuit-type: level-2-only
       ipv6:
-        enable: true
+        enabled: true

--- a/bdd/tests/configs/isis_passive/z1.yaml
+++ b/bdd/tests/configs/isis_passive/z1.yaml
@@ -21,20 +21,20 @@ router:
     - if-name: lo
       circuit-type: level-2-only
       ipv4:
-        enable: true
+        enabled: true
       ipv6:
-        enable: true
+        enabled: true
     - if-name: i2
       circuit-type: level-2-only
       network-type: point-to-point
       metric: 10
       ipv4:
-        enable: true
+        enabled: true
       ipv6:
-        enable: true
+        enabled: true
     - if-name: i3
       circuit-type: level-2-only
       passive: true
       metric: 10
       ipv4:
-        enable: true
+        enabled: true

--- a/bdd/tests/configs/isis_passive/z2.yaml
+++ b/bdd/tests/configs/isis_passive/z2.yaml
@@ -18,14 +18,14 @@ router:
     - if-name: lo
       circuit-type: level-2-only
       ipv4:
-        enable: true
+        enabled: true
       ipv6:
-        enable: true
+        enabled: true
     - if-name: i1
       circuit-type: level-2-only
       network-type: point-to-point
       metric: 10
       ipv4:
-        enable: true
+        enabled: true
       ipv6:
-        enable: true
+        enabled: true

--- a/bdd/tests/configs/isis_passive/z3.yaml
+++ b/bdd/tests/configs/isis_passive/z3.yaml
@@ -16,12 +16,12 @@ router:
     - if-name: lo
       circuit-type: level-2-only
       ipv4:
-        enable: true
+        enabled: true
       ipv6:
-        enable: true
+        enabled: true
     - if-name: i1
       circuit-type: level-2-only
       network-type: point-to-point
       metric: 10
       ipv4:
-        enable: true
+        enabled: true

--- a/bdd/tests/configs/isis_passive/z4.yaml
+++ b/bdd/tests/configs/isis_passive/z4.yaml
@@ -19,18 +19,18 @@ router:
     - if-name: lo
       circuit-type: level-2-only
       ipv4:
-        enable: true
+        enabled: true
       ipv6:
-        enable: true
+        enabled: true
     - if-name: sa
       circuit-type: level-2-only
       network-type: point-to-point
       metric: 10
       ipv4:
-        enable: true
+        enabled: true
     - if-name: sb
       circuit-type: level-2-only
       network-type: point-to-point
       metric: 10
       ipv4:
-        enable: true
+        enabled: true

--- a/bdd/tests/configs/isis_redist/r1-noredist.yaml
+++ b/bdd/tests/configs/isis_redist/r1-noredist.yaml
@@ -31,16 +31,16 @@ router:
     - if-name: lo
       circuit-type: level-1
       ipv4:
-        enable: true
+        enabled: true
     - if-name: i2
       circuit-type: level-1
       network-type: point-to-point
       metric: 10
       ipv4:
-        enable: true
+        enabled: true
     - if-name: i4
       circuit-type: level-1
       network-type: point-to-point
       metric: 10
       ipv4:
-        enable: true
+        enabled: true

--- a/bdd/tests/configs/isis_redist/r1.yaml
+++ b/bdd/tests/configs/isis_redist/r1.yaml
@@ -37,16 +37,16 @@ router:
     - if-name: lo
       circuit-type: level-1
       ipv4:
-        enable: true
+        enabled: true
     - if-name: i2
       circuit-type: level-1
       network-type: point-to-point
       metric: 10
       ipv4:
-        enable: true
+        enabled: true
     - if-name: i4
       circuit-type: level-1
       network-type: point-to-point
       metric: 10
       ipv4:
-        enable: true
+        enabled: true

--- a/bdd/tests/configs/isis_redist/r2.yaml
+++ b/bdd/tests/configs/isis_redist/r2.yaml
@@ -18,16 +18,16 @@ router:
     - if-name: lo
       circuit-type: level-1
       ipv4:
-        enable: true
+        enabled: true
     - if-name: i1
       circuit-type: level-1
       network-type: point-to-point
       metric: 10
       ipv4:
-        enable: true
+        enabled: true
     - if-name: i3
       circuit-type: level-1
       network-type: point-to-point
       metric: 10
       ipv4:
-        enable: true
+        enabled: true

--- a/bdd/tests/configs/isis_redist/r3.yaml
+++ b/bdd/tests/configs/isis_redist/r3.yaml
@@ -25,22 +25,22 @@ router:
     - if-name: lo
       circuit-type: level-1
       ipv4:
-        enable: true
+        enabled: true
     - if-name: i2
       circuit-type: level-1
       network-type: point-to-point
       metric: 10
       ipv4:
-        enable: true
+        enabled: true
     - if-name: i5
       circuit-type: level-1
       network-type: point-to-point
       metric: 10
       ipv4:
-        enable: true
+        enabled: true
     - if-name: ie2
       circuit-type: level-1
       network-type: point-to-point
       metric: 10
       ipv4:
-        enable: true
+        enabled: true

--- a/bdd/tests/configs/isis_redist/r4.yaml
+++ b/bdd/tests/configs/isis_redist/r4.yaml
@@ -18,16 +18,16 @@ router:
     - if-name: lo
       circuit-type: level-1
       ipv4:
-        enable: true
+        enabled: true
     - if-name: i1
       circuit-type: level-1
       network-type: point-to-point
       metric: 10
       ipv4:
-        enable: true
+        enabled: true
     - if-name: i5
       circuit-type: level-1
       network-type: point-to-point
       metric: 10
       ipv4:
-        enable: true
+        enabled: true

--- a/bdd/tests/configs/isis_redist/r5.yaml
+++ b/bdd/tests/configs/isis_redist/r5.yaml
@@ -18,16 +18,16 @@ router:
     - if-name: lo
       circuit-type: level-1
       ipv4:
-        enable: true
+        enabled: true
     - if-name: i4
       circuit-type: level-1
       network-type: point-to-point
       metric: 10
       ipv4:
-        enable: true
+        enabled: true
     - if-name: i3
       circuit-type: level-1
       network-type: point-to-point
       metric: 10
       ipv4:
-        enable: true
+        enabled: true

--- a/bdd/tests/configs/isis_srv6/z1.conf
+++ b/bdd/tests/configs/isis_srv6/z1.conf
@@ -30,10 +30,10 @@ router {
     interface enp0s6 {
       circuit-type level-2-only;
       ipv4 {
-        enable true;
+        enabled true;
       }
       ipv6 {
-        enable true;
+        enabled true;
       }
       priority 63;
     }
@@ -41,7 +41,7 @@ router {
     interface lo {
       circuit-type level-2-only;
       ipv4 {
-        enable true;
+        enabled true;
       }
     }
   }

--- a/bdd/tests/configs/isis_srv6/z2.conf
+++ b/bdd/tests/configs/isis_srv6/z2.conf
@@ -21,13 +21,13 @@ router {
     interface enp0s6 {
       circuit-type level-2-only;
       ipv6 {
-        enable true;
+        enabled true;
       }
     }
     interface enp0s7 {
       circuit-type level-2-only;
       ipv6 {
-        enable true;
+        enabled true;
       }
       network-type point-to-point;
     }

--- a/bdd/tests/configs/isis_srv6/z3.conf
+++ b/bdd/tests/configs/isis_srv6/z3.conf
@@ -21,7 +21,7 @@ router {
     interface enp0s6 {
       circuit-type level-2-only;
       ipv6 {
-        enable true;
+        enabled true;
       }
       network-type point-to-point;
     }

--- a/bdd/tests/configs/isis_srv6_endt/z1.yaml
+++ b/bdd/tests/configs/isis_srv6_endt/z1.yaml
@@ -28,8 +28,8 @@ router:
     interface:
     - if-name: lo
       ipv6:
-        enable: true
+        enabled: true
     - if-name: z1-z2
       network-type: point-to-point
       ipv6:
-        enable: true
+        enabled: true

--- a/bdd/tests/configs/isis_srv6_endt/z2.yaml
+++ b/bdd/tests/configs/isis_srv6_endt/z2.yaml
@@ -26,8 +26,8 @@ router:
     interface:
     - if-name: lo
       ipv6:
-        enable: true
+        enabled: true
     - if-name: z2-z1
       network-type: point-to-point
       ipv6:
-        enable: true
+        enabled: true

--- a/bdd/tests/configs/isis_srv6_flavor/z1.yaml
+++ b/bdd/tests/configs/isis_srv6_flavor/z1.yaml
@@ -26,8 +26,8 @@ router:
     interface:
     - if-name: lo
       ipv6:
-        enable: true
+        enabled: true
     - if-name: z1-z2
       network-type: point-to-point
       ipv6:
-        enable: true
+        enabled: true

--- a/bdd/tests/configs/isis_srv6_flavor/z2.yaml
+++ b/bdd/tests/configs/isis_srv6_flavor/z2.yaml
@@ -24,8 +24,8 @@ router:
     interface:
     - if-name: lo
       ipv6:
-        enable: true
+        enabled: true
     - if-name: z2-z1
       network-type: point-to-point
       ipv6:
-        enable: true
+        enabled: true

--- a/bdd/tests/configs/isis_srv6_replace/z1.yaml
+++ b/bdd/tests/configs/isis_srv6_replace/z1.yaml
@@ -28,8 +28,8 @@ router:
     interface:
     - if-name: lo
       ipv6:
-        enable: true
+        enabled: true
     - if-name: z1-z2
       network-type: point-to-point
       ipv6:
-        enable: true
+        enabled: true

--- a/bdd/tests/configs/isis_srv6_replace/z2.yaml
+++ b/bdd/tests/configs/isis_srv6_replace/z2.yaml
@@ -23,8 +23,8 @@ router:
     interface:
     - if-name: lo
       ipv6:
-        enable: true
+        enabled: true
     - if-name: z2-z1
       network-type: point-to-point
       ipv6:
-        enable: true
+        enabled: true

--- a/bdd/tests/configs/isis_tilfa/d.yaml
+++ b/bdd/tests/configs/isis_tilfa/d.yaml
@@ -15,16 +15,16 @@ router:
     interface:
     - if-name: lo
       ipv4:
-        enable: true
+        enabled: true
         prefix-sid:
           index: 800
     - if-name: d-n1
       ipv4:
-        enable: true
+        enabled: true
       metric: 1
     - if-name: d-r3
       ipv4:
-        enable: true
+        enabled: true
       metric: 1
     is-type: level-2-only
     segment-routing: mpls

--- a/bdd/tests/configs/isis_tilfa/n1.yaml
+++ b/bdd/tests/configs/isis_tilfa/n1.yaml
@@ -25,22 +25,22 @@ router:
     interface:
     - if-name: lo
       ipv4:
-        enable: true
+        enabled: true
         prefix-sid:
           index: 200
     - if-name: n1-s
       ipv4:
-        enable: true
+        enabled: true
       metric: 1
     - if-name: n1-r1
       ipv4:
-        enable: true
+        enabled: true
       metric: 1
     - if-name: n1-r2
       ipv4:
-        enable: true
+        enabled: true
       metric: 1
     - if-name: n1-d
       ipv4:
-        enable: true
+        enabled: true
       metric: 1

--- a/bdd/tests/configs/isis_tilfa/n2.yaml
+++ b/bdd/tests/configs/isis_tilfa/n2.yaml
@@ -19,14 +19,14 @@ router:
     interface:
     - if-name: lo
       ipv4:
-        enable: true
+        enabled: true
         prefix-sid:
           index: 300
     - if-name: n2-s
       ipv4:
-        enable: true
+        enabled: true
       metric: 1
     - if-name: n2-r1
       ipv4:
-        enable: true
+        enabled: true
       metric: 1

--- a/bdd/tests/configs/isis_tilfa/n3.yaml
+++ b/bdd/tests/configs/isis_tilfa/n3.yaml
@@ -15,16 +15,16 @@ router:
     interface:
     - if-name: lo
       ipv4:
-        enable: true
+        enabled: true
         prefix-sid:
           index: 400
     - if-name: n3-s
       ipv4:
-        enable: true
+        enabled: true
       metric: 1000
     - if-name: n3-r1
       ipv4:
-        enable: true
+        enabled: true
       metric: 1000
     is-type: level-2-only
     segment-routing: mpls

--- a/bdd/tests/configs/isis_tilfa/r1.yaml
+++ b/bdd/tests/configs/isis_tilfa/r1.yaml
@@ -21,24 +21,24 @@ router:
     interface:
     - if-name: lo
       ipv4:
-        enable: true
+        enabled: true
         prefix-sid:
           index: 500
     - if-name: r1-n1
       ipv4:
-        enable: true
+        enabled: true
       metric: 1
     - if-name: r1-n2
       ipv4:
-        enable: true
+        enabled: true
       metric: 1
     - if-name: r1-n3
       ipv4:
-        enable: true
+        enabled: true
       metric: 1000
     - if-name: r1-r2
       ipv4:
-        enable: true
+        enabled: true
       metric: 1000
     is-type: level-2-only
     segment-routing: mpls

--- a/bdd/tests/configs/isis_tilfa/r2.yaml
+++ b/bdd/tests/configs/isis_tilfa/r2.yaml
@@ -18,20 +18,20 @@ router:
     interface:
     - if-name: lo
       ipv4:
-        enable: true
+        enabled: true
         prefix-sid:
           index: 600
     - if-name: r2-n1
       ipv4:
-        enable: true
+        enabled: true
       metric: 1
     - if-name: r2-r1
       ipv4:
-        enable: true
+        enabled: true
       metric: 1000
     - if-name: r2-r3
       ipv4:
-        enable: true
+        enabled: true
       metric: 1000
     is-type: level-2-only
     segment-routing: mpls

--- a/bdd/tests/configs/isis_tilfa/r3.yaml
+++ b/bdd/tests/configs/isis_tilfa/r3.yaml
@@ -15,16 +15,16 @@ router:
     interface:
     - if-name: lo
       ipv4:
-        enable: true
+        enabled: true
         prefix-sid:
           index: 700
     - if-name: r3-r2
       ipv4:
-        enable: true
+        enabled: true
       metric: 1000
     - if-name: r3-d
       ipv4:
-        enable: true
+        enabled: true
       metric: 1
     is-type: level-2-only
     segment-routing: mpls

--- a/bdd/tests/configs/isis_tilfa/s-lspmtu-ok.yaml
+++ b/bdd/tests/configs/isis_tilfa/s-lspmtu-ok.yaml
@@ -28,20 +28,20 @@ router:
     interface:
     - if-name: lo
       ipv4:
-        enable: true
+        enabled: true
         prefix-sid:
           index: 100
     - if-name: s-n1
       ipv4:
-        enable: true
+        enabled: true
       metric: 1
     - if-name: s-n2
       ipv4:
-        enable: true
+        enabled: true
       metric: 1
     - if-name: s-n3
       ipv4:
-        enable: true
+        enabled: true
       metric: 1000
     is-type: level-2-only
     segment-routing: mpls

--- a/bdd/tests/configs/isis_tilfa/s-lspmtu.yaml
+++ b/bdd/tests/configs/isis_tilfa/s-lspmtu.yaml
@@ -29,20 +29,20 @@ router:
     interface:
     - if-name: lo
       ipv4:
-        enable: true
+        enabled: true
         prefix-sid:
           index: 100
     - if-name: s-n1
       ipv4:
-        enable: true
+        enabled: true
       metric: 1
     - if-name: s-n2
       ipv4:
-        enable: true
+        enabled: true
       metric: 1
     - if-name: s-n3
       ipv4:
-        enable: true
+        enabled: true
       metric: 1000
     is-type: level-2-only
     segment-routing: mpls

--- a/bdd/tests/configs/isis_tilfa/s-nolocal.yaml
+++ b/bdd/tests/configs/isis_tilfa/s-nolocal.yaml
@@ -18,20 +18,20 @@ router:
     interface:
     - if-name: lo
       ipv4:
-        enable: true
+        enabled: true
         prefix-sid:
           index: 100
     - if-name: s-n1
       ipv4:
-        enable: true
+        enabled: true
       metric: 1
     - if-name: s-n2
       ipv4:
-        enable: true
+        enabled: true
       metric: 1
     - if-name: s-n3
       ipv4:
-        enable: true
+        enabled: true
       metric: 1000
     is-type: level-2-only
     segment-routing:

--- a/bdd/tests/configs/isis_tilfa/s-nophp.yaml
+++ b/bdd/tests/configs/isis_tilfa/s-nophp.yaml
@@ -18,21 +18,21 @@ router:
     interface:
     - if-name: lo
       ipv4:
-        enable: true
+        enabled: true
         prefix-sid:
           index: 100
           no-php:
     - if-name: s-n1
       ipv4:
-        enable: true
+        enabled: true
       metric: 1
     - if-name: s-n2
       ipv4:
-        enable: true
+        enabled: true
       metric: 1
     - if-name: s-n3
       ipv4:
-        enable: true
+        enabled: true
       metric: 1000
     is-type: level-2-only
     segment-routing: mpls

--- a/bdd/tests/configs/isis_tilfa/s-nosr.yaml
+++ b/bdd/tests/configs/isis_tilfa/s-nosr.yaml
@@ -18,20 +18,20 @@ router:
     interface:
     - if-name: lo
       ipv4:
-        enable: true
+        enabled: true
         prefix-sid:
           index: 100
     - if-name: s-n1
       ipv4:
-        enable: true
+        enabled: true
       metric: 1
     - if-name: s-n2
       ipv4:
-        enable: true
+        enabled: true
       metric: 1
     - if-name: s-n3
       ipv4:
-        enable: true
+        enabled: true
       metric: 1000
     is-type: level-2-only
     fast-reroute: ti-lfa

--- a/bdd/tests/configs/isis_tilfa/s.yaml
+++ b/bdd/tests/configs/isis_tilfa/s.yaml
@@ -18,20 +18,20 @@ router:
     interface:
     - if-name: lo
       ipv4:
-        enable: true
+        enabled: true
         prefix-sid:
           index: 100
     - if-name: s-n1
       ipv4:
-        enable: true
+        enabled: true
       metric: 1
     - if-name: s-n2
       ipv4:
-        enable: true
+        enabled: true
       metric: 1
     - if-name: s-n3
       ipv4:
-        enable: true
+        enabled: true
       metric: 1000
     is-type: level-2-only
     segment-routing: mpls

--- a/bdd/tests/configs/l3vpn_bgp_v4/p.yaml
+++ b/bdd/tests/configs/l3vpn_bgp_v4/p.yaml
@@ -21,16 +21,16 @@ router:
     interface:
     - if-name: lo
       ipv4:
-        enable: true
+        enabled: true
         prefix-sid:
           index: 2
     - if-name: pe1
       network-type: point-to-point
       metric: 10
       ipv4:
-        enable: true
+        enabled: true
     - if-name: pe2
       network-type: point-to-point
       metric: 10
       ipv4:
-        enable: true
+        enabled: true

--- a/bdd/tests/configs/l3vpn_bgp_v4/pe1.yaml
+++ b/bdd/tests/configs/l3vpn_bgp_v4/pe1.yaml
@@ -32,14 +32,14 @@ router:
     interface:
     - if-name: lo
       ipv4:
-        enable: true
+        enabled: true
         prefix-sid:
           index: 1
     - if-name: p
       network-type: point-to-point
       metric: 10
       ipv4:
-        enable: true
+        enabled: true
   bgp:
     global:
       as: 65000

--- a/bdd/tests/configs/l3vpn_bgp_v4/pe2.yaml
+++ b/bdd/tests/configs/l3vpn_bgp_v4/pe2.yaml
@@ -30,14 +30,14 @@ router:
     interface:
     - if-name: lo
       ipv4:
-        enable: true
+        enabled: true
         prefix-sid:
           index: 3
     - if-name: p
       network-type: point-to-point
       metric: 10
       ipv4:
-        enable: true
+        enabled: true
   bgp:
     global:
       as: 65000

--- a/bdd/tests/configs/l3vpn_bgp_v6/p.yaml
+++ b/bdd/tests/configs/l3vpn_bgp_v6/p.yaml
@@ -20,14 +20,14 @@ router:
     interface:
     - if-name: lo
       ipv6:
-        enable: true
+        enabled: true
     - if-name: pe1
       network-type: point-to-point
       metric: 10
       ipv6:
-        enable: true
+        enabled: true
     - if-name: pe2
       network-type: point-to-point
       metric: 10
       ipv6:
-        enable: true
+        enabled: true

--- a/bdd/tests/configs/l3vpn_bgp_v6/pe1.yaml
+++ b/bdd/tests/configs/l3vpn_bgp_v6/pe1.yaml
@@ -37,12 +37,12 @@ router:
     interface:
     - if-name: lo
       ipv6:
-        enable: true
+        enabled: true
     - if-name: p
       network-type: point-to-point
       metric: 10
       ipv6:
-        enable: true
+        enabled: true
   bgp:
     global:
       as: 65000

--- a/bdd/tests/configs/l3vpn_bgp_v6/pe2.yaml
+++ b/bdd/tests/configs/l3vpn_bgp_v6/pe2.yaml
@@ -36,12 +36,12 @@ router:
     interface:
     - if-name: lo
       ipv6:
-        enable: true
+        enabled: true
     - if-name: p
       network-type: point-to-point
       metric: 10
       ipv6:
-        enable: true
+        enabled: true
   bgp:
     global:
       as: 65000

--- a/bdd/tests/configs/l3vpn_isis_bgppe_v4/c1.yaml
+++ b/bdd/tests/configs/l3vpn_isis_bgppe_v4/c1.yaml
@@ -23,4 +23,4 @@ router:
       network-type: point-to-point
       metric: 10
       ipv4:
-        enable: true
+        enabled: true

--- a/bdd/tests/configs/l3vpn_isis_bgppe_v4/c2.yaml
+++ b/bdd/tests/configs/l3vpn_isis_bgppe_v4/c2.yaml
@@ -22,4 +22,4 @@ router:
       network-type: point-to-point
       metric: 10
       ipv4:
-        enable: true
+        enabled: true

--- a/bdd/tests/configs/l3vpn_isis_bgppe_v4/ce1.yaml
+++ b/bdd/tests/configs/l3vpn_isis_bgppe_v4/ce1.yaml
@@ -23,7 +23,7 @@ router:
       network-type: point-to-point
       metric: 10
       ipv4:
-        enable: true
+        enabled: true
   bgp:
     global:
       as: 65001

--- a/bdd/tests/configs/l3vpn_isis_bgppe_v4/ce2.yaml
+++ b/bdd/tests/configs/l3vpn_isis_bgppe_v4/ce2.yaml
@@ -22,7 +22,7 @@ router:
       network-type: point-to-point
       metric: 10
       ipv4:
-        enable: true
+        enabled: true
   bgp:
     global:
       as: 65002

--- a/bdd/tests/configs/l3vpn_isis_bgppe_v4/p.yaml
+++ b/bdd/tests/configs/l3vpn_isis_bgppe_v4/p.yaml
@@ -21,16 +21,16 @@ router:
     interface:
     - if-name: lo
       ipv4:
-        enable: true
+        enabled: true
         prefix-sid:
           index: 2
     - if-name: pe1
       network-type: point-to-point
       metric: 10
       ipv4:
-        enable: true
+        enabled: true
     - if-name: pe2
       network-type: point-to-point
       metric: 10
       ipv4:
-        enable: true
+        enabled: true

--- a/bdd/tests/configs/l3vpn_isis_bgppe_v4/pe1.yaml
+++ b/bdd/tests/configs/l3vpn_isis_bgppe_v4/pe1.yaml
@@ -32,14 +32,14 @@ router:
     interface:
     - if-name: lo
       ipv4:
-        enable: true
+        enabled: true
         prefix-sid:
           index: 1
     - if-name: p
       network-type: point-to-point
       metric: 10
       ipv4:
-        enable: true
+        enabled: true
   bgp:
     global:
       as: 65000

--- a/bdd/tests/configs/l3vpn_isis_bgppe_v4/pe2.yaml
+++ b/bdd/tests/configs/l3vpn_isis_bgppe_v4/pe2.yaml
@@ -30,14 +30,14 @@ router:
     interface:
     - if-name: lo
       ipv4:
-        enable: true
+        enabled: true
         prefix-sid:
           index: 3
     - if-name: p
       network-type: point-to-point
       metric: 10
       ipv4:
-        enable: true
+        enabled: true
   bgp:
     global:
       as: 65000

--- a/bdd/tests/configs/l3vpn_isis_bgppe_v6/c1.yaml
+++ b/bdd/tests/configs/l3vpn_isis_bgppe_v6/c1.yaml
@@ -22,4 +22,4 @@ router:
       network-type: point-to-point
       metric: 10
       ipv6:
-        enable: true
+        enabled: true

--- a/bdd/tests/configs/l3vpn_isis_bgppe_v6/c2.yaml
+++ b/bdd/tests/configs/l3vpn_isis_bgppe_v6/c2.yaml
@@ -22,4 +22,4 @@ router:
       network-type: point-to-point
       metric: 10
       ipv6:
-        enable: true
+        enabled: true

--- a/bdd/tests/configs/l3vpn_isis_bgppe_v6/ce1.yaml
+++ b/bdd/tests/configs/l3vpn_isis_bgppe_v6/ce1.yaml
@@ -23,7 +23,7 @@ router:
       network-type: point-to-point
       metric: 10
       ipv6:
-        enable: true
+        enabled: true
   bgp:
     global:
       as: 65001

--- a/bdd/tests/configs/l3vpn_isis_bgppe_v6/ce2.yaml
+++ b/bdd/tests/configs/l3vpn_isis_bgppe_v6/ce2.yaml
@@ -22,7 +22,7 @@ router:
       network-type: point-to-point
       metric: 10
       ipv6:
-        enable: true
+        enabled: true
   bgp:
     global:
       as: 65002

--- a/bdd/tests/configs/l3vpn_isis_bgppe_v6/p.yaml
+++ b/bdd/tests/configs/l3vpn_isis_bgppe_v6/p.yaml
@@ -20,14 +20,14 @@ router:
     interface:
     - if-name: lo
       ipv6:
-        enable: true
+        enabled: true
     - if-name: pe1
       network-type: point-to-point
       metric: 10
       ipv6:
-        enable: true
+        enabled: true
     - if-name: pe2
       network-type: point-to-point
       metric: 10
       ipv6:
-        enable: true
+        enabled: true

--- a/bdd/tests/configs/l3vpn_isis_bgppe_v6/pe1.yaml
+++ b/bdd/tests/configs/l3vpn_isis_bgppe_v6/pe1.yaml
@@ -37,12 +37,12 @@ router:
     interface:
     - if-name: lo
       ipv6:
-        enable: true
+        enabled: true
     - if-name: p
       network-type: point-to-point
       metric: 10
       ipv6:
-        enable: true
+        enabled: true
   bgp:
     global:
       as: 65000

--- a/bdd/tests/configs/l3vpn_isis_bgppe_v6/pe2.yaml
+++ b/bdd/tests/configs/l3vpn_isis_bgppe_v6/pe2.yaml
@@ -36,12 +36,12 @@ router:
     interface:
     - if-name: lo
       ipv6:
-        enable: true
+        enabled: true
     - if-name: p
       network-type: point-to-point
       metric: 10
       ipv6:
-        enable: true
+        enabled: true
   bgp:
     global:
       as: 65000

--- a/bdd/tests/configs/l3vpn_isis_v4/c1.yaml
+++ b/bdd/tests/configs/l3vpn_isis_v4/c1.yaml
@@ -23,4 +23,4 @@ router:
       network-type: point-to-point
       metric: 10
       ipv4:
-        enable: true
+        enabled: true

--- a/bdd/tests/configs/l3vpn_isis_v4/c2.yaml
+++ b/bdd/tests/configs/l3vpn_isis_v4/c2.yaml
@@ -22,4 +22,4 @@ router:
       network-type: point-to-point
       metric: 10
       ipv4:
-        enable: true
+        enabled: true

--- a/bdd/tests/configs/l3vpn_isis_v4/ce1.yaml
+++ b/bdd/tests/configs/l3vpn_isis_v4/ce1.yaml
@@ -19,10 +19,10 @@ router:
       network-type: point-to-point
       metric: 10
       ipv4:
-        enable: true
+        enabled: true
     - if-name: pe1
       circuit-type: level-2-only
       network-type: point-to-point
       metric: 10
       ipv4:
-        enable: true
+        enabled: true

--- a/bdd/tests/configs/l3vpn_isis_v4/ce2.yaml
+++ b/bdd/tests/configs/l3vpn_isis_v4/ce2.yaml
@@ -17,10 +17,10 @@ router:
       network-type: point-to-point
       metric: 10
       ipv4:
-        enable: true
+        enabled: true
     - if-name: pe2
       circuit-type: level-2-only
       network-type: point-to-point
       metric: 10
       ipv4:
-        enable: true
+        enabled: true

--- a/bdd/tests/configs/l3vpn_isis_v4/p.yaml
+++ b/bdd/tests/configs/l3vpn_isis_v4/p.yaml
@@ -21,16 +21,16 @@ router:
     interface:
     - if-name: lo
       ipv4:
-        enable: true
+        enabled: true
         prefix-sid:
           index: 2
     - if-name: pe1
       network-type: point-to-point
       metric: 10
       ipv4:
-        enable: true
+        enabled: true
     - if-name: pe2
       network-type: point-to-point
       metric: 10
       ipv4:
-        enable: true
+        enabled: true

--- a/bdd/tests/configs/l3vpn_isis_v4/pe1.yaml
+++ b/bdd/tests/configs/l3vpn_isis_v4/pe1.yaml
@@ -35,14 +35,14 @@ router:
     interface:
     - if-name: lo
       ipv4:
-        enable: true
+        enabled: true
         prefix-sid:
           index: 1
     - if-name: p
       network-type: point-to-point
       metric: 10
       ipv4:
-        enable: true
+        enabled: true
     vrf:
     - name: vrf-cust
       net: 49.0001.0000.0000.0013.00
@@ -57,7 +57,7 @@ router:
         network-type: point-to-point
         metric: 10
         ipv4:
-          enable: true
+          enabled: true
   bgp:
     global:
       as: 65000

--- a/bdd/tests/configs/l3vpn_isis_v4/pe2.yaml
+++ b/bdd/tests/configs/l3vpn_isis_v4/pe2.yaml
@@ -31,14 +31,14 @@ router:
     interface:
     - if-name: lo
       ipv4:
-        enable: true
+        enabled: true
         prefix-sid:
           index: 3
     - if-name: p
       network-type: point-to-point
       metric: 10
       ipv4:
-        enable: true
+        enabled: true
     vrf:
     - name: vrf-cust
       net: 49.0001.0000.0000.0023.00
@@ -53,7 +53,7 @@ router:
         network-type: point-to-point
         metric: 10
         ipv4:
-          enable: true
+          enabled: true
   bgp:
     global:
       as: 65000

--- a/bdd/tests/configs/l3vpn_isis_v6/c1.yaml
+++ b/bdd/tests/configs/l3vpn_isis_v6/c1.yaml
@@ -22,4 +22,4 @@ router:
       network-type: point-to-point
       metric: 10
       ipv6:
-        enable: true
+        enabled: true

--- a/bdd/tests/configs/l3vpn_isis_v6/c2.yaml
+++ b/bdd/tests/configs/l3vpn_isis_v6/c2.yaml
@@ -22,4 +22,4 @@ router:
       network-type: point-to-point
       metric: 10
       ipv6:
-        enable: true
+        enabled: true

--- a/bdd/tests/configs/l3vpn_isis_v6/ce1.yaml
+++ b/bdd/tests/configs/l3vpn_isis_v6/ce1.yaml
@@ -17,10 +17,10 @@ router:
       network-type: point-to-point
       metric: 10
       ipv6:
-        enable: true
+        enabled: true
     - if-name: pe1
       circuit-type: level-2-only
       network-type: point-to-point
       metric: 10
       ipv6:
-        enable: true
+        enabled: true

--- a/bdd/tests/configs/l3vpn_isis_v6/ce2.yaml
+++ b/bdd/tests/configs/l3vpn_isis_v6/ce2.yaml
@@ -18,10 +18,10 @@ router:
       network-type: point-to-point
       metric: 10
       ipv6:
-        enable: true
+        enabled: true
     - if-name: pe2
       circuit-type: level-2-only
       network-type: point-to-point
       metric: 10
       ipv6:
-        enable: true
+        enabled: true

--- a/bdd/tests/configs/l3vpn_isis_v6/p.yaml
+++ b/bdd/tests/configs/l3vpn_isis_v6/p.yaml
@@ -20,14 +20,14 @@ router:
     interface:
     - if-name: lo
       ipv6:
-        enable: true
+        enabled: true
     - if-name: pe1
       network-type: point-to-point
       metric: 10
       ipv6:
-        enable: true
+        enabled: true
     - if-name: pe2
       network-type: point-to-point
       metric: 10
       ipv6:
-        enable: true
+        enabled: true

--- a/bdd/tests/configs/l3vpn_isis_v6/pe1.yaml
+++ b/bdd/tests/configs/l3vpn_isis_v6/pe1.yaml
@@ -37,12 +37,12 @@ router:
     interface:
     - if-name: lo
       ipv6:
-        enable: true
+        enabled: true
     - if-name: p
       network-type: point-to-point
       metric: 10
       ipv6:
-        enable: true
+        enabled: true
     vrf:
     - name: vrf-cust
       net: 49.0001.0000.0000.0013.00
@@ -57,7 +57,7 @@ router:
         network-type: point-to-point
         metric: 10
         ipv6:
-          enable: true
+          enabled: true
   bgp:
     global:
       as: 65000

--- a/bdd/tests/configs/l3vpn_isis_v6/pe2.yaml
+++ b/bdd/tests/configs/l3vpn_isis_v6/pe2.yaml
@@ -37,12 +37,12 @@ router:
     interface:
     - if-name: lo
       ipv6:
-        enable: true
+        enabled: true
     - if-name: p
       network-type: point-to-point
       metric: 10
       ipv6:
-        enable: true
+        enabled: true
     vrf:
     - name: vrf-cust
       net: 49.0001.0000.0000.0023.00
@@ -57,7 +57,7 @@ router:
         network-type: point-to-point
         metric: 10
         ipv6:
-          enable: true
+          enabled: true
   bgp:
     global:
       as: 65000

--- a/bdd/tests/configs/l3vpn_ospf_bgppe_v4/c1.yaml
+++ b/bdd/tests/configs/l3vpn_ospf_bgppe_v4/c1.yaml
@@ -18,5 +18,5 @@ router:
     - area-id: 0.0.0.0
       interface:
       - if-name: ce1
-        enable: true
+        enabled: true
         network-type: point-to-point

--- a/bdd/tests/configs/l3vpn_ospf_bgppe_v4/c2.yaml
+++ b/bdd/tests/configs/l3vpn_ospf_bgppe_v4/c2.yaml
@@ -17,5 +17,5 @@ router:
     - area-id: 0.0.0.0
       interface:
       - if-name: ce2
-        enable: true
+        enabled: true
         network-type: point-to-point

--- a/bdd/tests/configs/l3vpn_ospf_bgppe_v4/ce1.yaml
+++ b/bdd/tests/configs/l3vpn_ospf_bgppe_v4/ce1.yaml
@@ -22,7 +22,7 @@ router:
     - area-id: 0.0.0.0
       interface:
       - if-name: c1
-        enable: true
+        enabled: true
         network-type: point-to-point
   bgp:
     global:

--- a/bdd/tests/configs/l3vpn_ospf_bgppe_v4/ce2.yaml
+++ b/bdd/tests/configs/l3vpn_ospf_bgppe_v4/ce2.yaml
@@ -18,7 +18,7 @@ router:
     - area-id: 0.0.0.0
       interface:
       - if-name: c2
-        enable: true
+        enabled: true
         network-type: point-to-point
   bgp:
     global:

--- a/bdd/tests/configs/l3vpn_ospf_bgppe_v4/p.yaml
+++ b/bdd/tests/configs/l3vpn_ospf_bgppe_v4/p.yaml
@@ -21,16 +21,16 @@ router:
     interface:
     - if-name: lo
       ipv4:
-        enable: true
+        enabled: true
         prefix-sid:
           index: 2
     - if-name: pe1
       network-type: point-to-point
       metric: 10
       ipv4:
-        enable: true
+        enabled: true
     - if-name: pe2
       network-type: point-to-point
       metric: 10
       ipv4:
-        enable: true
+        enabled: true

--- a/bdd/tests/configs/l3vpn_ospf_bgppe_v4/pe1.yaml
+++ b/bdd/tests/configs/l3vpn_ospf_bgppe_v4/pe1.yaml
@@ -32,14 +32,14 @@ router:
     interface:
     - if-name: lo
       ipv4:
-        enable: true
+        enabled: true
         prefix-sid:
           index: 1
     - if-name: p
       network-type: point-to-point
       metric: 10
       ipv4:
-        enable: true
+        enabled: true
   bgp:
     global:
       as: 65000

--- a/bdd/tests/configs/l3vpn_ospf_bgppe_v4/pe2.yaml
+++ b/bdd/tests/configs/l3vpn_ospf_bgppe_v4/pe2.yaml
@@ -30,14 +30,14 @@ router:
     interface:
     - if-name: lo
       ipv4:
-        enable: true
+        enabled: true
         prefix-sid:
           index: 3
     - if-name: p
       network-type: point-to-point
       metric: 10
       ipv4:
-        enable: true
+        enabled: true
   bgp:
     global:
       as: 65000

--- a/bdd/tests/configs/l3vpn_ospf_bgppe_v6/c1.yaml
+++ b/bdd/tests/configs/l3vpn_ospf_bgppe_v6/c1.yaml
@@ -16,7 +16,7 @@ router:
     - area-id: 0.0.0.0
       interface:
       - if-name: lo
-        enable: true
+        enabled: true
       - if-name: ce1
-        enable: true
+        enabled: true
         network-type: point-to-point

--- a/bdd/tests/configs/l3vpn_ospf_bgppe_v6/c2.yaml
+++ b/bdd/tests/configs/l3vpn_ospf_bgppe_v6/c2.yaml
@@ -14,7 +14,7 @@ router:
     - area-id: 0.0.0.0
       interface:
       - if-name: lo
-        enable: true
+        enabled: true
       - if-name: ce2
-        enable: true
+        enabled: true
         network-type: point-to-point

--- a/bdd/tests/configs/l3vpn_ospf_bgppe_v6/ce1.yaml
+++ b/bdd/tests/configs/l3vpn_ospf_bgppe_v6/ce1.yaml
@@ -18,7 +18,7 @@ router:
     - area-id: 0.0.0.0
       interface:
       - if-name: c1
-        enable: true
+        enabled: true
         network-type: point-to-point
   bgp:
     global:

--- a/bdd/tests/configs/l3vpn_ospf_bgppe_v6/ce2.yaml
+++ b/bdd/tests/configs/l3vpn_ospf_bgppe_v6/ce2.yaml
@@ -17,7 +17,7 @@ router:
     - area-id: 0.0.0.0
       interface:
       - if-name: c2
-        enable: true
+        enabled: true
         network-type: point-to-point
   bgp:
     global:

--- a/bdd/tests/configs/l3vpn_ospf_bgppe_v6/p.yaml
+++ b/bdd/tests/configs/l3vpn_ospf_bgppe_v6/p.yaml
@@ -20,14 +20,14 @@ router:
     interface:
     - if-name: lo
       ipv6:
-        enable: true
+        enabled: true
     - if-name: pe1
       network-type: point-to-point
       metric: 10
       ipv6:
-        enable: true
+        enabled: true
     - if-name: pe2
       network-type: point-to-point
       metric: 10
       ipv6:
-        enable: true
+        enabled: true

--- a/bdd/tests/configs/l3vpn_ospf_bgppe_v6/pe1.yaml
+++ b/bdd/tests/configs/l3vpn_ospf_bgppe_v6/pe1.yaml
@@ -37,12 +37,12 @@ router:
     interface:
     - if-name: lo
       ipv6:
-        enable: true
+        enabled: true
     - if-name: p
       network-type: point-to-point
       metric: 10
       ipv6:
-        enable: true
+        enabled: true
   bgp:
     global:
       as: 65000

--- a/bdd/tests/configs/l3vpn_ospf_bgppe_v6/pe2.yaml
+++ b/bdd/tests/configs/l3vpn_ospf_bgppe_v6/pe2.yaml
@@ -36,12 +36,12 @@ router:
     interface:
     - if-name: lo
       ipv6:
-        enable: true
+        enabled: true
     - if-name: p
       network-type: point-to-point
       metric: 10
       ipv6:
-        enable: true
+        enabled: true
   bgp:
     global:
       as: 65000

--- a/bdd/tests/configs/l3vpn_ospf_v4/c1.yaml
+++ b/bdd/tests/configs/l3vpn_ospf_v4/c1.yaml
@@ -18,5 +18,5 @@ router:
     - area-id: 0.0.0.0
       interface:
       - if-name: ce1
-        enable: true
+        enabled: true
         network-type: point-to-point

--- a/bdd/tests/configs/l3vpn_ospf_v4/c2.yaml
+++ b/bdd/tests/configs/l3vpn_ospf_v4/c2.yaml
@@ -17,5 +17,5 @@ router:
     - area-id: 0.0.0.0
       interface:
       - if-name: ce2
-        enable: true
+        enabled: true
         network-type: point-to-point

--- a/bdd/tests/configs/l3vpn_ospf_v4/ce1.yaml
+++ b/bdd/tests/configs/l3vpn_ospf_v4/ce1.yaml
@@ -15,8 +15,8 @@ router:
     - area-id: 0.0.0.0
       interface:
       - if-name: c1
-        enable: true
+        enabled: true
         network-type: point-to-point
       - if-name: pe1
-        enable: true
+        enabled: true
         network-type: point-to-point

--- a/bdd/tests/configs/l3vpn_ospf_v4/ce2.yaml
+++ b/bdd/tests/configs/l3vpn_ospf_v4/ce2.yaml
@@ -14,8 +14,8 @@ router:
     - area-id: 0.0.0.0
       interface:
       - if-name: c2
-        enable: true
+        enabled: true
         network-type: point-to-point
       - if-name: pe2
-        enable: true
+        enabled: true
         network-type: point-to-point

--- a/bdd/tests/configs/l3vpn_ospf_v4/p.yaml
+++ b/bdd/tests/configs/l3vpn_ospf_v4/p.yaml
@@ -21,16 +21,16 @@ router:
     interface:
     - if-name: lo
       ipv4:
-        enable: true
+        enabled: true
         prefix-sid:
           index: 2
     - if-name: pe1
       network-type: point-to-point
       metric: 10
       ipv4:
-        enable: true
+        enabled: true
     - if-name: pe2
       network-type: point-to-point
       metric: 10
       ipv4:
-        enable: true
+        enabled: true

--- a/bdd/tests/configs/l3vpn_ospf_v4/pe1.yaml
+++ b/bdd/tests/configs/l3vpn_ospf_v4/pe1.yaml
@@ -37,7 +37,7 @@ router:
       - area-id: 0.0.0.0
         interface:
         - if-name: ce1
-          enable: true
+          enabled: true
           network-type: point-to-point
   isis:
     net: 49.0000.0000.0000.0001.00
@@ -48,14 +48,14 @@ router:
     interface:
     - if-name: lo
       ipv4:
-        enable: true
+        enabled: true
         prefix-sid:
           index: 1
     - if-name: p
       network-type: point-to-point
       metric: 10
       ipv4:
-        enable: true
+        enabled: true
   bgp:
     global:
       as: 65000

--- a/bdd/tests/configs/l3vpn_ospf_v4/pe2.yaml
+++ b/bdd/tests/configs/l3vpn_ospf_v4/pe2.yaml
@@ -33,7 +33,7 @@ router:
       - area-id: 0.0.0.0
         interface:
         - if-name: ce2
-          enable: true
+          enabled: true
           network-type: point-to-point
   isis:
     net: 49.0000.0000.0000.0003.00
@@ -44,14 +44,14 @@ router:
     interface:
     - if-name: lo
       ipv4:
-        enable: true
+        enabled: true
         prefix-sid:
           index: 3
     - if-name: p
       network-type: point-to-point
       metric: 10
       ipv4:
-        enable: true
+        enabled: true
   bgp:
     global:
       as: 65000

--- a/bdd/tests/configs/l3vpn_ospf_v6/c1.yaml
+++ b/bdd/tests/configs/l3vpn_ospf_v6/c1.yaml
@@ -16,7 +16,7 @@ router:
     - area-id: 0.0.0.0
       interface:
       - if-name: lo
-        enable: true
+        enabled: true
       - if-name: ce1
-        enable: true
+        enabled: true
         network-type: point-to-point

--- a/bdd/tests/configs/l3vpn_ospf_v6/c2.yaml
+++ b/bdd/tests/configs/l3vpn_ospf_v6/c2.yaml
@@ -14,7 +14,7 @@ router:
     - area-id: 0.0.0.0
       interface:
       - if-name: lo
-        enable: true
+        enabled: true
       - if-name: ce2
-        enable: true
+        enabled: true
         network-type: point-to-point

--- a/bdd/tests/configs/l3vpn_ospf_v6/ce1.yaml
+++ b/bdd/tests/configs/l3vpn_ospf_v6/ce1.yaml
@@ -14,8 +14,8 @@ router:
     - area-id: 0.0.0.0
       interface:
       - if-name: c1
-        enable: true
+        enabled: true
         network-type: point-to-point
       - if-name: pe1
-        enable: true
+        enabled: true
         network-type: point-to-point

--- a/bdd/tests/configs/l3vpn_ospf_v6/ce2.yaml
+++ b/bdd/tests/configs/l3vpn_ospf_v6/ce2.yaml
@@ -14,8 +14,8 @@ router:
     - area-id: 0.0.0.0
       interface:
       - if-name: c2
-        enable: true
+        enabled: true
         network-type: point-to-point
       - if-name: pe2
-        enable: true
+        enabled: true
         network-type: point-to-point

--- a/bdd/tests/configs/l3vpn_ospf_v6/p.yaml
+++ b/bdd/tests/configs/l3vpn_ospf_v6/p.yaml
@@ -20,14 +20,14 @@ router:
     interface:
     - if-name: lo
       ipv6:
-        enable: true
+        enabled: true
     - if-name: pe1
       network-type: point-to-point
       metric: 10
       ipv6:
-        enable: true
+        enabled: true
     - if-name: pe2
       network-type: point-to-point
       metric: 10
       ipv6:
-        enable: true
+        enabled: true

--- a/bdd/tests/configs/l3vpn_ospf_v6/pe1.yaml
+++ b/bdd/tests/configs/l3vpn_ospf_v6/pe1.yaml
@@ -37,12 +37,12 @@ router:
     interface:
     - if-name: lo
       ipv6:
-        enable: true
+        enabled: true
     - if-name: p
       network-type: point-to-point
       metric: 10
       ipv6:
-        enable: true
+        enabled: true
   ospfv3:
     vrf:
     - name: vrf-cust
@@ -54,7 +54,7 @@ router:
       - area-id: 0.0.0.0
         interface:
         - if-name: ce1
-          enable: true
+          enabled: true
           network-type: point-to-point
   bgp:
     global:

--- a/bdd/tests/configs/l3vpn_ospf_v6/pe2.yaml
+++ b/bdd/tests/configs/l3vpn_ospf_v6/pe2.yaml
@@ -36,12 +36,12 @@ router:
     interface:
     - if-name: lo
       ipv6:
-        enable: true
+        enabled: true
     - if-name: p
       network-type: point-to-point
       metric: 10
       ipv6:
-        enable: true
+        enabled: true
   ospfv3:
     vrf:
     - name: vrf-cust
@@ -53,7 +53,7 @@ router:
       - area-id: 0.0.0.0
         interface:
         - if-name: ce2
-          enable: true
+          enabled: true
           network-type: point-to-point
   bgp:
     global:

--- a/bdd/tests/configs/l3vpn_static_v4/p.yaml
+++ b/bdd/tests/configs/l3vpn_static_v4/p.yaml
@@ -21,16 +21,16 @@ router:
     interface:
     - if-name: lo
       ipv4:
-        enable: true
+        enabled: true
         prefix-sid:
           index: 2
     - if-name: pe1
       network-type: point-to-point
       metric: 10
       ipv4:
-        enable: true
+        enabled: true
     - if-name: pe2
       network-type: point-to-point
       metric: 10
       ipv4:
-        enable: true
+        enabled: true

--- a/bdd/tests/configs/l3vpn_static_v4/pe1.yaml
+++ b/bdd/tests/configs/l3vpn_static_v4/pe1.yaml
@@ -46,14 +46,14 @@ router:
     interface:
     - if-name: lo
       ipv4:
-        enable: true
+        enabled: true
         prefix-sid:
           index: 1
     - if-name: p
       network-type: point-to-point
       metric: 10
       ipv4:
-        enable: true
+        enabled: true
   bgp:
     global:
       as: 65000

--- a/bdd/tests/configs/l3vpn_static_v4/pe2.yaml
+++ b/bdd/tests/configs/l3vpn_static_v4/pe2.yaml
@@ -43,14 +43,14 @@ router:
     interface:
     - if-name: lo
       ipv4:
-        enable: true
+        enabled: true
         prefix-sid:
           index: 3
     - if-name: p
       network-type: point-to-point
       metric: 10
       ipv4:
-        enable: true
+        enabled: true
   bgp:
     global:
       as: 65000

--- a/bdd/tests/configs/l3vpn_static_v6/p.yaml
+++ b/bdd/tests/configs/l3vpn_static_v6/p.yaml
@@ -20,14 +20,14 @@ router:
     interface:
     - if-name: lo
       ipv6:
-        enable: true
+        enabled: true
     - if-name: pe1
       network-type: point-to-point
       metric: 10
       ipv6:
-        enable: true
+        enabled: true
     - if-name: pe2
       network-type: point-to-point
       metric: 10
       ipv6:
-        enable: true
+        enabled: true

--- a/bdd/tests/configs/l3vpn_static_v6/pe1.yaml
+++ b/bdd/tests/configs/l3vpn_static_v6/pe1.yaml
@@ -48,12 +48,12 @@ router:
     interface:
     - if-name: lo
       ipv6:
-        enable: true
+        enabled: true
     - if-name: p
       network-type: point-to-point
       metric: 10
       ipv6:
-        enable: true
+        enabled: true
   bgp:
     global:
       as: 65000

--- a/bdd/tests/configs/l3vpn_static_v6/pe2.yaml
+++ b/bdd/tests/configs/l3vpn_static_v6/pe2.yaml
@@ -47,12 +47,12 @@ router:
     interface:
     - if-name: lo
       ipv6:
-        enable: true
+        enabled: true
     - if-name: p
       network-type: point-to-point
       metric: 10
       ipv6:
-        enable: true
+        enabled: true
   bgp:
     global:
       as: 65000

--- a/bdd/tests/configs/mirror_sid_egress_link/pe1.yaml
+++ b/bdd/tests/configs/mirror_sid_egress_link/pe1.yaml
@@ -40,12 +40,12 @@ router:
     interface:
     - if-name: lo
       ipv6:
-        enable: true
+        enabled: true
     - if-name: pe1-pea
       network-type: point-to-point
       metric: 1
       ipv6:
-        enable: true
+        enabled: true
   bgp:
     global:
       as: 65001

--- a/bdd/tests/configs/mirror_sid_egress_link/pea.yaml
+++ b/bdd/tests/configs/mirror_sid_egress_link/pea.yaml
@@ -53,17 +53,17 @@ router:
     interface:
     - if-name: lo
       ipv6:
-        enable: true
+        enabled: true
     - if-name: pea-pe1
       network-type: point-to-point
       metric: 1
       ipv6:
-        enable: true
+        enabled: true
     - if-name: pea-peb
       network-type: point-to-point
       metric: 1
       ipv6:
-        enable: true
+        enabled: true
   bgp:
     global:
       as: 65001

--- a/bdd/tests/configs/mirror_sid_egress_link/peb.yaml
+++ b/bdd/tests/configs/mirror_sid_egress_link/peb.yaml
@@ -60,12 +60,12 @@ router:
     interface:
     - if-name: lo
       ipv6:
-        enable: true
+        enabled: true
     - if-name: peb-pea
       network-type: point-to-point
       metric: 1
       ipv6:
-        enable: true
+        enabled: true
   bgp:
     global:
       as: 65001

--- a/bdd/tests/configs/mirror_sid_mpls/pe1.yaml
+++ b/bdd/tests/configs/mirror_sid_mpls/pe1.yaml
@@ -34,14 +34,14 @@ router:
     interface:
     - if-name: lo
       ipv4:
-        enable: true
+        enabled: true
         prefix-sid:
           index: 1
     - if-name: pe1-pea
       network-type: point-to-point
       metric: 10
       ipv4:
-        enable: true
+        enabled: true
   bgp:
     global:
       as: 65000

--- a/bdd/tests/configs/mirror_sid_mpls/pea.yaml
+++ b/bdd/tests/configs/mirror_sid_mpls/pea.yaml
@@ -48,19 +48,19 @@ router:
     interface:
     - if-name: lo
       ipv4:
-        enable: true
+        enabled: true
         prefix-sid:
           index: 3
     - if-name: pea-pe1
       network-type: point-to-point
       metric: 10
       ipv4:
-        enable: true
+        enabled: true
     - if-name: pea-peb
       network-type: point-to-point
       metric: 10
       ipv4:
-        enable: true
+        enabled: true
   bgp:
     global:
       as: 65000

--- a/bdd/tests/configs/mirror_sid_mpls/peb.yaml
+++ b/bdd/tests/configs/mirror_sid_mpls/peb.yaml
@@ -51,14 +51,14 @@ router:
     interface:
     - if-name: lo
       ipv4:
-        enable: true
+        enabled: true
         prefix-sid:
           index: 4
     - if-name: peb-pea
       network-type: point-to-point
       metric: 10
       ipv4:
-        enable: true
+        enabled: true
   bgp:
     global:
       as: 65000

--- a/bdd/tests/configs/mirror_sid_node/pe1.yaml
+++ b/bdd/tests/configs/mirror_sid_node/pe1.yaml
@@ -35,7 +35,7 @@ router:
     interface:
     - if-name: lo
       ipv6:
-        enable: true
+        enabled: true
     - if-name: pe1-pea
       network-type: point-to-point
       metric: 1
@@ -43,9 +43,9 @@ router:
         interval: 1
         multiplier: 3
       ipv6:
-        enable: true
+        enabled: true
     - if-name: pe1-peb
       network-type: point-to-point
       metric: 1
       ipv6:
-        enable: true
+        enabled: true

--- a/bdd/tests/configs/mirror_sid_node/pea.yaml
+++ b/bdd/tests/configs/mirror_sid_node/pea.yaml
@@ -30,7 +30,7 @@ router:
     interface:
     - if-name: lo
       ipv6:
-        enable: true
+        enabled: true
     - if-name: pea-pe1
       network-type: point-to-point
       metric: 1
@@ -38,4 +38,4 @@ router:
         interval: 1
         multiplier: 3
       ipv6:
-        enable: true
+        enabled: true

--- a/bdd/tests/configs/mirror_sid_node/peb.yaml
+++ b/bdd/tests/configs/mirror_sid_node/peb.yaml
@@ -57,9 +57,9 @@ router:
     interface:
     - if-name: lo
       ipv6:
-        enable: true
+        enabled: true
     - if-name: peb-pe1
       network-type: point-to-point
       metric: 1
       ipv6:
-        enable: true
+        enabled: true

--- a/bdd/tests/configs/mirror_sid_node_vpn/pe1.yaml
+++ b/bdd/tests/configs/mirror_sid_node_vpn/pe1.yaml
@@ -52,7 +52,7 @@ router:
     interface:
     - if-name: lo
       ipv6:
-        enable: true
+        enabled: true
     - if-name: pe1-pea
       network-type: point-to-point
       metric: 1
@@ -60,12 +60,12 @@ router:
         interval: 1
         multiplier: 3
       ipv6:
-        enable: true
+        enabled: true
     - if-name: pe1-peb
       network-type: point-to-point
       metric: 1
       ipv6:
-        enable: true
+        enabled: true
   bgp:
     global:
       as: 65001

--- a/bdd/tests/configs/mirror_sid_node_vpn/pea.yaml
+++ b/bdd/tests/configs/mirror_sid_node_vpn/pea.yaml
@@ -50,7 +50,7 @@ router:
     interface:
     - if-name: lo
       ipv6:
-        enable: true
+        enabled: true
     - if-name: pea-pe1
       network-type: point-to-point
       metric: 1
@@ -58,7 +58,7 @@ router:
         interval: 1
         multiplier: 3
       ipv6:
-        enable: true
+        enabled: true
   bgp:
     global:
       as: 65001

--- a/bdd/tests/configs/mirror_sid_node_vpn/peb.yaml
+++ b/bdd/tests/configs/mirror_sid_node_vpn/peb.yaml
@@ -59,12 +59,12 @@ router:
     interface:
     - if-name: lo
       ipv6:
-        enable: true
+        enabled: true
     - if-name: peb-pe1
       network-type: point-to-point
       metric: 1
       ipv6:
-        enable: true
+        enabled: true
   bgp:
     global:
       as: 65001

--- a/bdd/tests/configs/mirror_sid_srv6/p1.yaml
+++ b/bdd/tests/configs/mirror_sid_srv6/p1.yaml
@@ -34,19 +34,19 @@ router:
     interface:
     - if-name: lo
       ipv6:
-        enable: true
+        enabled: true
     - if-name: p1-pe1
       network-type: point-to-point
       metric: 1
       ipv6:
-        enable: true
+        enabled: true
     - if-name: p1-pea
       network-type: point-to-point
       metric: 1
       ipv6:
-        enable: true
+        enabled: true
     - if-name: p1-peb
       network-type: point-to-point
       metric: 1
       ipv6:
-        enable: true
+        enabled: true

--- a/bdd/tests/configs/mirror_sid_srv6/pe1.yaml
+++ b/bdd/tests/configs/mirror_sid_srv6/pe1.yaml
@@ -24,9 +24,9 @@ router:
     interface:
     - if-name: lo
       ipv6:
-        enable: true
+        enabled: true
     - if-name: pe1-p1
       network-type: point-to-point
       metric: 1
       ipv6:
-        enable: true
+        enabled: true

--- a/bdd/tests/configs/mirror_sid_srv6/pea.yaml
+++ b/bdd/tests/configs/mirror_sid_srv6/pea.yaml
@@ -27,14 +27,14 @@ router:
     interface:
     - if-name: lo
       ipv6:
-        enable: true
+        enabled: true
     - if-name: pea-p1
       network-type: point-to-point
       metric: 1
       ipv6:
-        enable: true
+        enabled: true
     - if-name: pea-peb
       network-type: point-to-point
       metric: 1
       ipv6:
-        enable: true
+        enabled: true

--- a/bdd/tests/configs/mirror_sid_srv6/peb.yaml
+++ b/bdd/tests/configs/mirror_sid_srv6/peb.yaml
@@ -37,14 +37,14 @@ router:
     interface:
     - if-name: lo
       ipv6:
-        enable: true
+        enabled: true
     - if-name: peb-p1
       network-type: point-to-point
       metric: 1
       ipv6:
-        enable: true
+        enabled: true
     - if-name: peb-pea
       network-type: point-to-point
       metric: 1
       ipv6:
-        enable: true
+        enabled: true

--- a/bdd/tests/configs/mirror_sid_vpnsrv6_base/z1.yaml
+++ b/bdd/tests/configs/mirror_sid_vpnsrv6_base/z1.yaml
@@ -46,12 +46,12 @@ router:
     interface:
     - if-name: lo
       ipv6:
-        enable: true
+        enabled: true
     - if-name: z1-z2
       network-type: point-to-point
       metric: 1
       ipv6:
-        enable: true
+        enabled: true
   bgp:
     global:
       as: 65001

--- a/bdd/tests/configs/mirror_sid_vpnsrv6_base/z2.yaml
+++ b/bdd/tests/configs/mirror_sid_vpnsrv6_base/z2.yaml
@@ -44,12 +44,12 @@ router:
     interface:
     - if-name: lo
       ipv6:
-        enable: true
+        enabled: true
     - if-name: z2-z1
       network-type: point-to-point
       metric: 1
       ipv6:
-        enable: true
+        enabled: true
   bgp:
     global:
       as: 65001

--- a/bdd/tests/configs/ospf_clear_neighbor/o1.yaml
+++ b/bdd/tests/configs/ospf_clear_neighbor/o1.yaml
@@ -12,7 +12,7 @@ router:
     - area-id: 0.0.0.0
       interface:
       - if-name: lo
-        enable: true
+        enabled: true
       - if-name: eth1
-        enable: true
+        enabled: true
         network-type: point-to-point

--- a/bdd/tests/configs/ospf_clear_neighbor/o2.yaml
+++ b/bdd/tests/configs/ospf_clear_neighbor/o2.yaml
@@ -12,7 +12,7 @@ router:
     - area-id: 0.0.0.0
       interface:
       - if-name: lo
-        enable: true
+        enabled: true
       - if-name: eth2
-        enable: true
+        enabled: true
         network-type: point-to-point

--- a/bdd/tests/configs/ospf_router_id_change/r1.yaml
+++ b/bdd/tests/configs/ospf_router_id_change/r1.yaml
@@ -12,7 +12,7 @@ router:
     - area-id: 0.0.0.0
       interface:
       - if-name: lo
-        enable: true
+        enabled: true
       - if-name: eth1
-        enable: true
+        enabled: true
         network-type: point-to-point

--- a/bdd/tests/configs/ospf_router_id_change/r2.yaml
+++ b/bdd/tests/configs/ospf_router_id_change/r2.yaml
@@ -12,7 +12,7 @@ router:
     - area-id: 0.0.0.0
       interface:
       - if-name: lo
-        enable: true
+        enabled: true
       - if-name: eth2
-        enable: true
+        enabled: true
         network-type: point-to-point

--- a/bdd/tests/configs/ospfv2_area_range/a.yaml
+++ b/bdd/tests/configs/ospfv2_area_range/a.yaml
@@ -15,14 +15,14 @@ router:
     - area-id: 0.0.0.0
       interface:
       - if-name: lo
-        enable: true
+        enabled: true
       - if-name: ethc
-        enable: true
+        enabled: true
         network-type: point-to-point
     - area-id: 0.0.0.1
       range:
       - prefix: 10.1.0.0/16
       interface:
       - if-name: ethb
-        enable: true
+        enabled: true
         network-type: point-to-point

--- a/bdd/tests/configs/ospfv2_area_range/a_na.yaml
+++ b/bdd/tests/configs/ospfv2_area_range/a_na.yaml
@@ -15,9 +15,9 @@ router:
     - area-id: 0.0.0.0
       interface:
       - if-name: lo
-        enable: true
+        enabled: true
       - if-name: ethc
-        enable: true
+        enabled: true
         network-type: point-to-point
     - area-id: 0.0.0.1
       range:
@@ -25,5 +25,5 @@ router:
         not-advertise: true
       interface:
       - if-name: ethb
-        enable: true
+        enabled: true
         network-type: point-to-point

--- a/bdd/tests/configs/ospfv2_area_range/b.yaml
+++ b/bdd/tests/configs/ospfv2_area_range/b.yaml
@@ -21,11 +21,11 @@ router:
     - area-id: 0.0.0.1
       interface:
       - if-name: lo
-        enable: true
+        enabled: true
       - if-name: etha
-        enable: true
+        enabled: true
         network-type: point-to-point
       - if-name: r1
-        enable: true
+        enabled: true
       - if-name: r2
-        enable: true
+        enabled: true

--- a/bdd/tests/configs/ospfv2_area_range/c.yaml
+++ b/bdd/tests/configs/ospfv2_area_range/c.yaml
@@ -12,7 +12,7 @@ router:
     - area-id: 0.0.0.0
       interface:
       - if-name: lo
-        enable: true
+        enabled: true
       - if-name: etha
-        enable: true
+        enabled: true
         network-type: point-to-point

--- a/bdd/tests/configs/ospfv2_as_external/a.yaml
+++ b/bdd/tests/configs/ospfv2_as_external/a.yaml
@@ -18,16 +18,16 @@ router:
     - area-id: 0.0.0.0
       interface:
       - if-name: lo
-        enable: true
+        enabled: true
       - if-name: ethb
-        enable: true
+        enabled: true
         network-type: point-to-point
       - if-name: ethd
-        enable: true
+        enabled: true
         network-type: point-to-point
         cost: 20
     - area-id: 0.0.0.1
       interface:
       - if-name: ethe
-        enable: true
+        enabled: true
         network-type: point-to-point

--- a/bdd/tests/configs/ospfv2_as_external/b_e1.yaml
+++ b/bdd/tests/configs/ospfv2_as_external/b_e1.yaml
@@ -22,13 +22,13 @@ router:
     - area-id: 0.0.0.0
       interface:
       - if-name: lo
-        enable: true
+        enabled: true
       - if-name: etha
-        enable: true
+        enabled: true
         network-type: point-to-point
       - if-name: ethc
-        enable: true
+        enabled: true
         network-type: point-to-point
       - if-name: ethd
-        enable: true
+        enabled: true
         network-type: point-to-point

--- a/bdd/tests/configs/ospfv2_as_external/b_e2.yaml
+++ b/bdd/tests/configs/ospfv2_as_external/b_e2.yaml
@@ -22,13 +22,13 @@ router:
     - area-id: 0.0.0.0
       interface:
       - if-name: lo
-        enable: true
+        enabled: true
       - if-name: etha
-        enable: true
+        enabled: true
         network-type: point-to-point
       - if-name: ethc
-        enable: true
+        enabled: true
         network-type: point-to-point
       - if-name: ethd
-        enable: true
+        enabled: true
         network-type: point-to-point

--- a/bdd/tests/configs/ospfv2_as_external/c.yaml
+++ b/bdd/tests/configs/ospfv2_as_external/c.yaml
@@ -18,16 +18,16 @@ router:
     - area-id: 0.0.0.0
       interface:
       - if-name: lo
-        enable: true
+        enabled: true
       - if-name: ethb
-        enable: true
+        enabled: true
         network-type: point-to-point
       - if-name: ethd
-        enable: true
+        enabled: true
         network-type: point-to-point
         cost: 20
     - area-id: 0.0.0.2
       interface:
       - if-name: ethf
-        enable: true
+        enabled: true
         network-type: point-to-point

--- a/bdd/tests/configs/ospfv2_as_external/d.yaml
+++ b/bdd/tests/configs/ospfv2_as_external/d.yaml
@@ -18,15 +18,15 @@ router:
     - area-id: 0.0.0.0
       interface:
       - if-name: lo
-        enable: true
+        enabled: true
       - if-name: etha
-        enable: true
+        enabled: true
         network-type: point-to-point
         cost: 20
       - if-name: ethb
-        enable: true
+        enabled: true
         network-type: point-to-point
       - if-name: ethc
-        enable: true
+        enabled: true
         network-type: point-to-point
         cost: 20

--- a/bdd/tests/configs/ospfv2_as_external/e.yaml
+++ b/bdd/tests/configs/ospfv2_as_external/e.yaml
@@ -12,7 +12,7 @@ router:
     - area-id: 0.0.0.1
       interface:
       - if-name: lo
-        enable: true
+        enabled: true
       - if-name: etha
-        enable: true
+        enabled: true
         network-type: point-to-point

--- a/bdd/tests/configs/ospfv2_as_external/f.yaml
+++ b/bdd/tests/configs/ospfv2_as_external/f.yaml
@@ -12,7 +12,7 @@ router:
     - area-id: 0.0.0.2
       interface:
       - if-name: lo
-        enable: true
+        enabled: true
       - if-name: ethc
-        enable: true
+        enabled: true
         network-type: point-to-point

--- a/bdd/tests/configs/ospfv2_auth/a_chain.yaml
+++ b/bdd/tests/configs/ospfv2_auth/a_chain.yaml
@@ -27,9 +27,9 @@ router:
     - area-id: 0.0.0.0
       interface:
       - if-name: lo
-        enable: true
+        enabled: true
       - if-name: ethb
-        enable: true
+        enabled: true
         network-type: point-to-point
         authentication: message-digest
         key-chain: OSPF-KC

--- a/bdd/tests/configs/ospfv2_auth/a_md5.yaml
+++ b/bdd/tests/configs/ospfv2_auth/a_md5.yaml
@@ -17,9 +17,9 @@ router:
     - area-id: 0.0.0.0
       interface:
       - if-name: lo
-        enable: true
+        enabled: true
       - if-name: ethb
-        enable: true
+        enabled: true
         network-type: point-to-point
         authentication: message-digest
         message-digest-key:

--- a/bdd/tests/configs/ospfv2_auth/a_sha256.yaml
+++ b/bdd/tests/configs/ospfv2_auth/a_sha256.yaml
@@ -16,9 +16,9 @@ router:
     - area-id: 0.0.0.0
       interface:
       - if-name: lo
-        enable: true
+        enabled: true
       - if-name: ethb
-        enable: true
+        enabled: true
         network-type: point-to-point
         authentication: message-digest
         crypto-key:

--- a/bdd/tests/configs/ospfv2_auth/a_simple.yaml
+++ b/bdd/tests/configs/ospfv2_auth/a_simple.yaml
@@ -15,9 +15,9 @@ router:
     - area-id: 0.0.0.0
       interface:
       - if-name: lo
-        enable: true
+        enabled: true
       - if-name: ethb
-        enable: true
+        enabled: true
         network-type: point-to-point
         authentication: simple
         authentication-key: zebra8ch

--- a/bdd/tests/configs/ospfv2_auth/b_chain.yaml
+++ b/bdd/tests/configs/ospfv2_auth/b_chain.yaml
@@ -21,9 +21,9 @@ router:
     - area-id: 0.0.0.0
       interface:
       - if-name: lo
-        enable: true
+        enabled: true
       - if-name: etha
-        enable: true
+        enabled: true
         network-type: point-to-point
         authentication: message-digest
         key-chain: OSPF-KC

--- a/bdd/tests/configs/ospfv2_auth/b_md5.yaml
+++ b/bdd/tests/configs/ospfv2_auth/b_md5.yaml
@@ -12,9 +12,9 @@ router:
     - area-id: 0.0.0.0
       interface:
       - if-name: lo
-        enable: true
+        enabled: true
       - if-name: etha
-        enable: true
+        enabled: true
         network-type: point-to-point
         authentication: message-digest
         message-digest-key:

--- a/bdd/tests/configs/ospfv2_auth/b_md5_badkey.yaml
+++ b/bdd/tests/configs/ospfv2_auth/b_md5_badkey.yaml
@@ -16,9 +16,9 @@ router:
     - area-id: 0.0.0.0
       interface:
       - if-name: lo
-        enable: true
+        enabled: true
       - if-name: etha
-        enable: true
+        enabled: true
         network-type: point-to-point
         authentication: message-digest
         message-digest-key:

--- a/bdd/tests/configs/ospfv2_auth/b_sha256.yaml
+++ b/bdd/tests/configs/ospfv2_auth/b_sha256.yaml
@@ -12,9 +12,9 @@ router:
     - area-id: 0.0.0.0
       interface:
       - if-name: lo
-        enable: true
+        enabled: true
       - if-name: etha
-        enable: true
+        enabled: true
         network-type: point-to-point
         authentication: message-digest
         crypto-key:

--- a/bdd/tests/configs/ospfv2_auth/b_simple.yaml
+++ b/bdd/tests/configs/ospfv2_auth/b_simple.yaml
@@ -12,9 +12,9 @@ router:
     - area-id: 0.0.0.0
       interface:
       - if-name: lo
-        enable: true
+        enabled: true
       - if-name: etha
-        enable: true
+        enabled: true
         network-type: point-to-point
         authentication: simple
         authentication-key: zebra8ch

--- a/bdd/tests/configs/ospfv2_bfd_frr/d.yaml
+++ b/bdd/tests/configs/ospfv2_bfd_frr/d.yaml
@@ -19,14 +19,14 @@ router:
     - area-id: 0.0.0.0
       interface:
       - if-name: lo
-        enable: true
+        enabled: true
         prefix-sid:
           index: 800
       - if-name: d-n1
-        enable: true
+        enabled: true
         network-type: point-to-point
         cost: 1
       - if-name: d-r3
-        enable: true
+        enabled: true
         network-type: point-to-point
         cost: 1

--- a/bdd/tests/configs/ospfv2_bfd_frr/n1.yaml
+++ b/bdd/tests/configs/ospfv2_bfd_frr/n1.yaml
@@ -25,24 +25,24 @@ router:
     - area-id: 0.0.0.0
       interface:
       - if-name: lo
-        enable: true
+        enabled: true
         prefix-sid:
           index: 200
       - if-name: n1-s
-        enable: true
+        enabled: true
         network-type: point-to-point
         cost: 1
         bfd:
-          enable: true
+          enabled: true
       - if-name: n1-r1
-        enable: true
+        enabled: true
         network-type: point-to-point
         cost: 1
       - if-name: n1-r2
-        enable: true
+        enabled: true
         network-type: point-to-point
         cost: 1
       - if-name: n1-d
-        enable: true
+        enabled: true
         network-type: point-to-point
         cost: 1

--- a/bdd/tests/configs/ospfv2_bfd_frr/n2.yaml
+++ b/bdd/tests/configs/ospfv2_bfd_frr/n2.yaml
@@ -19,14 +19,14 @@ router:
     - area-id: 0.0.0.0
       interface:
       - if-name: lo
-        enable: true
+        enabled: true
         prefix-sid:
           index: 300
       - if-name: n2-s
-        enable: true
+        enabled: true
         network-type: point-to-point
         cost: 1
       - if-name: n2-r1
-        enable: true
+        enabled: true
         network-type: point-to-point
         cost: 1

--- a/bdd/tests/configs/ospfv2_bfd_frr/n3.yaml
+++ b/bdd/tests/configs/ospfv2_bfd_frr/n3.yaml
@@ -19,14 +19,14 @@ router:
     - area-id: 0.0.0.0
       interface:
       - if-name: lo
-        enable: true
+        enabled: true
         prefix-sid:
           index: 400
       - if-name: n3-s
-        enable: true
+        enabled: true
         network-type: point-to-point
         cost: 1000
       - if-name: n3-r1
-        enable: true
+        enabled: true
         network-type: point-to-point
         cost: 1000

--- a/bdd/tests/configs/ospfv2_bfd_frr/r1.yaml
+++ b/bdd/tests/configs/ospfv2_bfd_frr/r1.yaml
@@ -25,22 +25,22 @@ router:
     - area-id: 0.0.0.0
       interface:
       - if-name: lo
-        enable: true
+        enabled: true
         prefix-sid:
           index: 500
       - if-name: r1-n1
-        enable: true
+        enabled: true
         network-type: point-to-point
         cost: 1
       - if-name: r1-n2
-        enable: true
+        enabled: true
         network-type: point-to-point
         cost: 1
       - if-name: r1-n3
-        enable: true
+        enabled: true
         network-type: point-to-point
         cost: 1000
       - if-name: r1-r2
-        enable: true
+        enabled: true
         network-type: point-to-point
         cost: 1000

--- a/bdd/tests/configs/ospfv2_bfd_frr/r2.yaml
+++ b/bdd/tests/configs/ospfv2_bfd_frr/r2.yaml
@@ -22,18 +22,18 @@ router:
     - area-id: 0.0.0.0
       interface:
       - if-name: lo
-        enable: true
+        enabled: true
         prefix-sid:
           index: 600
       - if-name: r2-n1
-        enable: true
+        enabled: true
         network-type: point-to-point
         cost: 1
       - if-name: r2-r1
-        enable: true
+        enabled: true
         network-type: point-to-point
         cost: 1000
       - if-name: r2-r3
-        enable: true
+        enabled: true
         network-type: point-to-point
         cost: 1000

--- a/bdd/tests/configs/ospfv2_bfd_frr/r3.yaml
+++ b/bdd/tests/configs/ospfv2_bfd_frr/r3.yaml
@@ -19,14 +19,14 @@ router:
     - area-id: 0.0.0.0
       interface:
       - if-name: lo
-        enable: true
+        enabled: true
         prefix-sid:
           index: 700
       - if-name: r3-r2
-        enable: true
+        enabled: true
         network-type: point-to-point
         cost: 1000
       - if-name: r3-d
-        enable: true
+        enabled: true
         network-type: point-to-point
         cost: 1

--- a/bdd/tests/configs/ospfv2_bfd_frr/s.yaml
+++ b/bdd/tests/configs/ospfv2_bfd_frr/s.yaml
@@ -22,20 +22,20 @@ router:
     - area-id: 0.0.0.0
       interface:
       - if-name: lo
-        enable: true
+        enabled: true
         prefix-sid:
           index: 100
       - if-name: s-n1
-        enable: true
+        enabled: true
         network-type: point-to-point
         cost: 1
         bfd:
-          enable: true
+          enabled: true
       - if-name: s-n2
-        enable: true
+        enabled: true
         network-type: point-to-point
         cost: 1
       - if-name: s-n3
-        enable: true
+        enabled: true
         network-type: point-to-point
         cost: 1000

--- a/bdd/tests/configs/ospfv2_default_originate/a.yaml
+++ b/bdd/tests/configs/ospfv2_default_originate/a.yaml
@@ -12,7 +12,7 @@ router:
     - area-id: 0.0.0.0
       interface:
       - if-name: lo
-        enable: true
+        enabled: true
       - if-name: ethb
-        enable: true
+        enabled: true
         network-type: point-to-point

--- a/bdd/tests/configs/ospfv2_default_originate/b_always.yaml
+++ b/bdd/tests/configs/ospfv2_default_originate/b_always.yaml
@@ -15,7 +15,7 @@ router:
     - area-id: 0.0.0.0
       interface:
       - if-name: lo
-        enable: true
+        enabled: true
       - if-name: etha
-        enable: true
+        enabled: true
         network-type: point-to-point

--- a/bdd/tests/configs/ospfv2_default_originate/b_cond.yaml
+++ b/bdd/tests/configs/ospfv2_default_originate/b_cond.yaml
@@ -14,7 +14,7 @@ router:
     - area-id: 0.0.0.0
       interface:
       - if-name: lo
-        enable: true
+        enabled: true
       - if-name: etha
-        enable: true
+        enabled: true
         network-type: point-to-point

--- a/bdd/tests/configs/ospfv2_graceful_restart/a.yaml
+++ b/bdd/tests/configs/ospfv2_graceful_restart/a.yaml
@@ -19,7 +19,7 @@ router:
     - area-id: 0.0.0.0
       interface:
       - if-name: lo
-        enable: true
+        enabled: true
       - if-name: ethb
-        enable: true
+        enabled: true
         network-type: point-to-point

--- a/bdd/tests/configs/ospfv2_graceful_restart/b.yaml
+++ b/bdd/tests/configs/ospfv2_graceful_restart/b.yaml
@@ -16,7 +16,7 @@ router:
     - area-id: 0.0.0.0
       interface:
       - if-name: lo
-        enable: true
+        enabled: true
       - if-name: etha
-        enable: true
+        enabled: true
         network-type: point-to-point

--- a/bdd/tests/configs/ospfv2_min_ls_arrival/a.yaml
+++ b/bdd/tests/configs/ospfv2_min_ls_arrival/a.yaml
@@ -15,7 +15,7 @@ router:
     - area-id: 0.0.0.0
       interface:
       - if-name: lo
-        enable: true
+        enabled: true
       - if-name: ethb
-        enable: true
+        enabled: true
         network-type: point-to-point

--- a/bdd/tests/configs/ospfv2_min_ls_arrival/b.yaml
+++ b/bdd/tests/configs/ospfv2_min_ls_arrival/b.yaml
@@ -13,7 +13,7 @@ router:
     - area-id: 0.0.0.0
       interface:
       - if-name: lo
-        enable: true
+        enabled: true
       - if-name: etha
-        enable: true
+        enabled: true
         network-type: point-to-point

--- a/bdd/tests/configs/ospfv2_min_ls_interval/a.yaml
+++ b/bdd/tests/configs/ospfv2_min_ls_interval/a.yaml
@@ -16,7 +16,7 @@ router:
     - area-id: 0.0.0.0
       interface:
       - if-name: lo
-        enable: true
+        enabled: true
       - if-name: ethb
-        enable: true
+        enabled: true
         network-type: point-to-point

--- a/bdd/tests/configs/ospfv2_min_ls_interval/b.yaml
+++ b/bdd/tests/configs/ospfv2_min_ls_interval/b.yaml
@@ -13,7 +13,7 @@ router:
     - area-id: 0.0.0.0
       interface:
       - if-name: lo
-        enable: true
+        enabled: true
       - if-name: etha
-        enable: true
+        enabled: true
         network-type: point-to-point

--- a/bdd/tests/configs/ospfv2_multi_area/a.yaml
+++ b/bdd/tests/configs/ospfv2_multi_area/a.yaml
@@ -18,16 +18,16 @@ router:
     - area-id: 0.0.0.0
       interface:
       - if-name: lo
-        enable: true
+        enabled: true
       - if-name: ethb
-        enable: true
+        enabled: true
         network-type: point-to-point
       - if-name: ethd
-        enable: true
+        enabled: true
         network-type: point-to-point
         cost: 20
     - area-id: 0.0.0.1
       interface:
       - if-name: ethe
-        enable: true
+        enabled: true
         network-type: point-to-point

--- a/bdd/tests/configs/ospfv2_multi_area/b.yaml
+++ b/bdd/tests/configs/ospfv2_multi_area/b.yaml
@@ -18,13 +18,13 @@ router:
     - area-id: 0.0.0.0
       interface:
       - if-name: lo
-        enable: true
+        enabled: true
       - if-name: etha
-        enable: true
+        enabled: true
         network-type: point-to-point
       - if-name: ethc
-        enable: true
+        enabled: true
         network-type: point-to-point
       - if-name: ethd
-        enable: true
+        enabled: true
         network-type: point-to-point

--- a/bdd/tests/configs/ospfv2_multi_area/c.yaml
+++ b/bdd/tests/configs/ospfv2_multi_area/c.yaml
@@ -18,16 +18,16 @@ router:
     - area-id: 0.0.0.0
       interface:
       - if-name: lo
-        enable: true
+        enabled: true
       - if-name: ethb
-        enable: true
+        enabled: true
         network-type: point-to-point
       - if-name: ethd
-        enable: true
+        enabled: true
         network-type: point-to-point
         cost: 20
     - area-id: 0.0.0.2
       interface:
       - if-name: ethf
-        enable: true
+        enabled: true
         network-type: point-to-point

--- a/bdd/tests/configs/ospfv2_multi_area/d.yaml
+++ b/bdd/tests/configs/ospfv2_multi_area/d.yaml
@@ -18,15 +18,15 @@ router:
     - area-id: 0.0.0.0
       interface:
       - if-name: lo
-        enable: true
+        enabled: true
       - if-name: etha
-        enable: true
+        enabled: true
         network-type: point-to-point
         cost: 20
       - if-name: ethb
-        enable: true
+        enabled: true
         network-type: point-to-point
       - if-name: ethc
-        enable: true
+        enabled: true
         network-type: point-to-point
         cost: 20

--- a/bdd/tests/configs/ospfv2_multi_area/e.yaml
+++ b/bdd/tests/configs/ospfv2_multi_area/e.yaml
@@ -12,7 +12,7 @@ router:
     - area-id: 0.0.0.1
       interface:
       - if-name: lo
-        enable: true
+        enabled: true
       - if-name: etha
-        enable: true
+        enabled: true
         network-type: point-to-point

--- a/bdd/tests/configs/ospfv2_multi_area/f.yaml
+++ b/bdd/tests/configs/ospfv2_multi_area/f.yaml
@@ -12,7 +12,7 @@ router:
     - area-id: 0.0.0.2
       interface:
       - if-name: lo
-        enable: true
+        enabled: true
       - if-name: ethc
-        enable: true
+        enabled: true
         network-type: point-to-point

--- a/bdd/tests/configs/ospfv2_nssa/a.yaml
+++ b/bdd/tests/configs/ospfv2_nssa/a.yaml
@@ -19,9 +19,9 @@ router:
     - area-id: 0.0.0.0
       interface:
       - if-name: lo
-        enable: true
+        enabled: true
       - if-name: ethb
-        enable: true
+        enabled: true
         network-type: point-to-point
     # NSSA (0.0.0.1). a is the (sole) ABR, so it elects itself the
     # RFC 3101 Type-7->Type-5 translator under the default `candidate`
@@ -31,8 +31,8 @@ router:
       nssa-default-originate: true
       interface:
       - if-name: ethc
-        enable: true
+        enabled: true
         network-type: point-to-point
       - if-name: ethd
-        enable: true
+        enabled: true
         network-type: point-to-point

--- a/bdd/tests/configs/ospfv2_nssa/a_never.yaml
+++ b/bdd/tests/configs/ospfv2_nssa/a_never.yaml
@@ -18,9 +18,9 @@ router:
     - area-id: 0.0.0.0
       interface:
       - if-name: lo
-        enable: true
+        enabled: true
       - if-name: ethb
-        enable: true
+        enabled: true
         network-type: point-to-point
     # `nssa-translator-role: never` disables Type-7->Type-5 translation
     # on this ABR (RFC 3101 §2.2). The Type-7 still floods the NSSA and
@@ -32,8 +32,8 @@ router:
       nssa-translator-role: never
       interface:
       - if-name: ethc
-        enable: true
+        enabled: true
         network-type: point-to-point
       - if-name: ethd
-        enable: true
+        enabled: true
         network-type: point-to-point

--- a/bdd/tests/configs/ospfv2_nssa/a_totally.yaml
+++ b/bdd/tests/configs/ospfv2_nssa/a_totally.yaml
@@ -18,9 +18,9 @@ router:
     - area-id: 0.0.0.0
       interface:
       - if-name: lo
-        enable: true
+        enabled: true
       - if-name: ethb
-        enable: true
+        enabled: true
         network-type: point-to-point
     # Totally-NSSA: `no-summary` makes the ABR suppress every Type-3
     # summary into the area, so the only way out is the default Type-7
@@ -32,8 +32,8 @@ router:
       nssa-default-originate: true
       interface:
       - if-name: ethc
-        enable: true
+        enabled: true
         network-type: point-to-point
       - if-name: ethd
-        enable: true
+        enabled: true
         network-type: point-to-point

--- a/bdd/tests/configs/ospfv2_nssa/b.yaml
+++ b/bdd/tests/configs/ospfv2_nssa/b.yaml
@@ -16,7 +16,7 @@ router:
     - area-id: 0.0.0.0
       interface:
       - if-name: lo
-        enable: true
+        enabled: true
       - if-name: etha
-        enable: true
+        enabled: true
         network-type: point-to-point

--- a/bdd/tests/configs/ospfv2_nssa/c.yaml
+++ b/bdd/tests/configs/ospfv2_nssa/c.yaml
@@ -23,7 +23,7 @@ router:
           metric-type: type-2
       interface:
       - if-name: lo
-        enable: true
+        enabled: true
       - if-name: etha
-        enable: true
+        enabled: true
         network-type: point-to-point

--- a/bdd/tests/configs/ospfv2_nssa/c_e1.yaml
+++ b/bdd/tests/configs/ospfv2_nssa/c_e1.yaml
@@ -21,7 +21,7 @@ router:
           metric-type: type-1
       interface:
       - if-name: lo
-        enable: true
+        enabled: true
       - if-name: etha
-        enable: true
+        enabled: true
         network-type: point-to-point

--- a/bdd/tests/configs/ospfv2_nssa/d.yaml
+++ b/bdd/tests/configs/ospfv2_nssa/d.yaml
@@ -18,7 +18,7 @@ router:
       area-type: nssa
       interface:
       - if-name: lo
-        enable: true
+        enabled: true
       - if-name: etha
-        enable: true
+        enabled: true
         network-type: point-to-point

--- a/bdd/tests/configs/ospfv2_nssa_fa/a.yaml
+++ b/bdd/tests/configs/ospfv2_nssa_fa/a.yaml
@@ -19,13 +19,13 @@ router:
     - area-id: 0.0.0.0
       interface:
       - if-name: lo
-        enable: true
+        enabled: true
       - if-name: ethb
-        enable: true
+        enabled: true
         network-type: point-to-point
     - area-id: 0.0.0.1
       area-type: nssa
       interface:
       - if-name: ethc
-        enable: true
+        enabled: true
         network-type: point-to-point

--- a/bdd/tests/configs/ospfv2_nssa_fa/a_suppress.yaml
+++ b/bdd/tests/configs/ospfv2_nssa_fa/a_suppress.yaml
@@ -18,14 +18,14 @@ router:
     - area-id: 0.0.0.0
       interface:
       - if-name: lo
-        enable: true
+        enabled: true
       - if-name: ethb
-        enable: true
+        enabled: true
         network-type: point-to-point
     - area-id: 0.0.0.1
       area-type: nssa
       nssa-suppress-fa: true
       interface:
       - if-name: ethc
-        enable: true
+        enabled: true
         network-type: point-to-point

--- a/bdd/tests/configs/ospfv2_nssa_fa/b.yaml
+++ b/bdd/tests/configs/ospfv2_nssa_fa/b.yaml
@@ -16,7 +16,7 @@ router:
     - area-id: 0.0.0.0
       interface:
       - if-name: lo
-        enable: true
+        enabled: true
       - if-name: etha
-        enable: true
+        enabled: true
         network-type: point-to-point

--- a/bdd/tests/configs/ospfv2_nssa_fa/c.yaml
+++ b/bdd/tests/configs/ospfv2_nssa_fa/c.yaml
@@ -20,7 +20,7 @@ router:
           metric-type: type-2
       interface:
       - if-name: lo
-        enable: true
+        enabled: true
       - if-name: etha
-        enable: true
+        enabled: true
         network-type: point-to-point

--- a/bdd/tests/configs/ospfv2_passive/a.yaml
+++ b/bdd/tests/configs/ospfv2_passive/a.yaml
@@ -12,7 +12,7 @@ router:
     - area-id: 0.0.0.0
       interface:
       - if-name: lo
-        enable: true
+        enabled: true
       - if-name: ethb
-        enable: true
+        enabled: true
         network-type: point-to-point

--- a/bdd/tests/configs/ospfv2_passive/b.yaml
+++ b/bdd/tests/configs/ospfv2_passive/b.yaml
@@ -18,11 +18,11 @@ router:
     - area-id: 0.0.0.0
       interface:
       - if-name: lo
-        enable: true
+        enabled: true
       - if-name: etha
-        enable: true
+        enabled: true
         network-type: point-to-point
       - if-name: ethc
-        enable: true
+        enabled: true
         network-type: point-to-point
         passive: true

--- a/bdd/tests/configs/ospfv2_passive/c.yaml
+++ b/bdd/tests/configs/ospfv2_passive/c.yaml
@@ -14,7 +14,7 @@ router:
     - area-id: 0.0.0.0
       interface:
       - if-name: lo
-        enable: true
+        enabled: true
       - if-name: ethb
-        enable: true
+        enabled: true
         network-type: point-to-point

--- a/bdd/tests/configs/ospfv2_redist_route_map/r1.yaml
+++ b/bdd/tests/configs/ospfv2_redist_route_map/r1.yaml
@@ -12,7 +12,7 @@ router:
     - area-id: 0.0.0.0
       interface:
       - if-name: lo
-        enable: true
+        enabled: true
       - if-name: ethb
-        enable: true
+        enabled: true
         network-type: point-to-point

--- a/bdd/tests/configs/ospfv2_redist_route_map/r2-both.yaml
+++ b/bdd/tests/configs/ospfv2_redist_route_map/r2-both.yaml
@@ -34,7 +34,7 @@ router:
     - area-id: 0.0.0.0
       interface:
       - if-name: lo
-        enable: true
+        enabled: true
       - if-name: etha
-        enable: true
+        enabled: true
         network-type: point-to-point

--- a/bdd/tests/configs/ospfv2_redist_route_map/r2-initial.yaml
+++ b/bdd/tests/configs/ospfv2_redist_route_map/r2-initial.yaml
@@ -32,7 +32,7 @@ router:
     - area-id: 0.0.0.0
       interface:
       - if-name: lo
-        enable: true
+        enabled: true
       - if-name: etha
-        enable: true
+        enabled: true
         network-type: point-to-point

--- a/bdd/tests/configs/ospfv2_redist_route_map/r2-other.yaml
+++ b/bdd/tests/configs/ospfv2_redist_route_map/r2-other.yaml
@@ -31,7 +31,7 @@ router:
     - area-id: 0.0.0.0
       interface:
       - if-name: lo
-        enable: true
+        enabled: true
       - if-name: etha
-        enable: true
+        enabled: true
         network-type: point-to-point

--- a/bdd/tests/configs/ospfv2_redist_table/r1.yaml
+++ b/bdd/tests/configs/ospfv2_redist_table/r1.yaml
@@ -12,7 +12,7 @@ router:
     - area-id: 0.0.0.0
       interface:
       - if-name: lo
-        enable: true
+        enabled: true
       - if-name: ethb
-        enable: true
+        enabled: true
         network-type: point-to-point

--- a/bdd/tests/configs/ospfv2_redist_table/r2.yaml
+++ b/bdd/tests/configs/ospfv2_redist_table/r2.yaml
@@ -19,7 +19,7 @@ router:
     - area-id: 0.0.0.0
       interface:
       - if-name: lo
-        enable: true
+        enabled: true
       - if-name: etha
-        enable: true
+        enabled: true
         network-type: point-to-point

--- a/bdd/tests/configs/ospfv2_redistribute_static/a.yaml
+++ b/bdd/tests/configs/ospfv2_redistribute_static/a.yaml
@@ -12,7 +12,7 @@ router:
     - area-id: 0.0.0.0
       interface:
       - if-name: lo
-        enable: true
+        enabled: true
       - if-name: ethb
-        enable: true
+        enabled: true
         network-type: point-to-point

--- a/bdd/tests/configs/ospfv2_redistribute_static/b.yaml
+++ b/bdd/tests/configs/ospfv2_redistribute_static/b.yaml
@@ -25,7 +25,7 @@ router:
     - area-id: 0.0.0.0
       interface:
       - if-name: lo
-        enable: true
+        enabled: true
       - if-name: etha
-        enable: true
+        enabled: true
         network-type: point-to-point

--- a/bdd/tests/configs/ospfv2_spf_interval/a.yaml
+++ b/bdd/tests/configs/ospfv2_spf_interval/a.yaml
@@ -19,7 +19,7 @@ router:
     - area-id: 0.0.0.0
       interface:
       - if-name: lo
-        enable: true
+        enabled: true
       - if-name: ethb
-        enable: true
+        enabled: true
         network-type: point-to-point

--- a/bdd/tests/configs/ospfv2_spf_interval/b.yaml
+++ b/bdd/tests/configs/ospfv2_spf_interval/b.yaml
@@ -16,7 +16,7 @@ router:
     - area-id: 0.0.0.0
       interface:
       - if-name: lo
-        enable: true
+        enabled: true
       - if-name: etha
-        enable: true
+        enabled: true
         network-type: point-to-point

--- a/bdd/tests/configs/ospfv2_stub/a.yaml
+++ b/bdd/tests/configs/ospfv2_stub/a.yaml
@@ -16,9 +16,9 @@ router:
     - area-id: 0.0.0.0
       interface:
       - if-name: lo
-        enable: true
+        enabled: true
       - if-name: ethb
-        enable: true
+        enabled: true
         network-type: point-to-point
     # Stub (0.0.0.1): drops Type-5 AS-External (E-bit clear in
     # Hello/DBD) but still floods inter-area Type-3 summaries inward.
@@ -26,5 +26,5 @@ router:
       area-type: stub
       interface:
       - if-name: ethc
-        enable: true
+        enabled: true
         network-type: point-to-point

--- a/bdd/tests/configs/ospfv2_stub/b.yaml
+++ b/bdd/tests/configs/ospfv2_stub/b.yaml
@@ -19,7 +19,7 @@ router:
     - area-id: 0.0.0.0
       interface:
       - if-name: lo
-        enable: true
+        enabled: true
       - if-name: etha
-        enable: true
+        enabled: true
         network-type: point-to-point

--- a/bdd/tests/configs/ospfv2_stub/c.yaml
+++ b/bdd/tests/configs/ospfv2_stub/c.yaml
@@ -16,7 +16,7 @@ router:
       area-type: stub
       interface:
       - if-name: lo
-        enable: true
+        enabled: true
       - if-name: etha
-        enable: true
+        enabled: true
         network-type: point-to-point

--- a/bdd/tests/configs/ospfv2_stub_router/r1.yaml
+++ b/bdd/tests/configs/ospfv2_stub_router/r1.yaml
@@ -15,11 +15,11 @@ router:
     - area-id: 0.0.0.0
       interface:
       - if-name: lo
-        enable: true
+        enabled: true
       - if-name: ethb
-        enable: true
+        enabled: true
         network-type: point-to-point
       - if-name: ethd
-        enable: true
+        enabled: true
         network-type: point-to-point
         cost: 100

--- a/bdd/tests/configs/ospfv2_stub_router/r2.yaml
+++ b/bdd/tests/configs/ospfv2_stub_router/r2.yaml
@@ -21,10 +21,10 @@ router:
     - area-id: 0.0.0.0
       interface:
       - if-name: lo
-        enable: true
+        enabled: true
       - if-name: etha
-        enable: true
+        enabled: true
         network-type: point-to-point
       - if-name: ethc
-        enable: true
+        enabled: true
         network-type: point-to-point

--- a/bdd/tests/configs/ospfv2_stub_router/r2s.yaml
+++ b/bdd/tests/configs/ospfv2_stub_router/r2s.yaml
@@ -20,10 +20,10 @@ router:
     - area-id: 0.0.0.0
       interface:
       - if-name: lo
-        enable: true
+        enabled: true
       - if-name: etha
-        enable: true
+        enabled: true
         network-type: point-to-point
       - if-name: ethc
-        enable: true
+        enabled: true
         network-type: point-to-point

--- a/bdd/tests/configs/ospfv2_stub_router/r3.yaml
+++ b/bdd/tests/configs/ospfv2_stub_router/r3.yaml
@@ -15,11 +15,11 @@ router:
     - area-id: 0.0.0.0
       interface:
       - if-name: lo
-        enable: true
+        enabled: true
       - if-name: ethb
-        enable: true
+        enabled: true
         network-type: point-to-point
       - if-name: ethd
-        enable: true
+        enabled: true
         network-type: point-to-point
         cost: 100

--- a/bdd/tests/configs/ospfv2_stub_router/r4.yaml
+++ b/bdd/tests/configs/ospfv2_stub_router/r4.yaml
@@ -16,12 +16,12 @@ router:
     - area-id: 0.0.0.0
       interface:
       - if-name: lo
-        enable: true
+        enabled: true
       - if-name: etha
-        enable: true
+        enabled: true
         network-type: point-to-point
         cost: 100
       - if-name: ethc
-        enable: true
+        enabled: true
         network-type: point-to-point
         cost: 100

--- a/bdd/tests/configs/ospfv2_tilfa/d.yaml
+++ b/bdd/tests/configs/ospfv2_tilfa/d.yaml
@@ -19,14 +19,14 @@ router:
     - area-id: 0.0.0.0
       interface:
       - if-name: lo
-        enable: true
+        enabled: true
         prefix-sid:
           index: 800
       - if-name: d-n1
-        enable: true
+        enabled: true
         network-type: point-to-point
         cost: 1
       - if-name: d-r3
-        enable: true
+        enabled: true
         network-type: point-to-point
         cost: 1

--- a/bdd/tests/configs/ospfv2_tilfa/n1.yaml
+++ b/bdd/tests/configs/ospfv2_tilfa/n1.yaml
@@ -25,22 +25,22 @@ router:
     - area-id: 0.0.0.0
       interface:
       - if-name: lo
-        enable: true
+        enabled: true
         prefix-sid:
           index: 200
       - if-name: n1-s
-        enable: true
+        enabled: true
         network-type: point-to-point
         cost: 1
       - if-name: n1-r1
-        enable: true
+        enabled: true
         network-type: point-to-point
         cost: 1
       - if-name: n1-r2
-        enable: true
+        enabled: true
         network-type: point-to-point
         cost: 1
       - if-name: n1-d
-        enable: true
+        enabled: true
         network-type: point-to-point
         cost: 1

--- a/bdd/tests/configs/ospfv2_tilfa/n2.yaml
+++ b/bdd/tests/configs/ospfv2_tilfa/n2.yaml
@@ -19,14 +19,14 @@ router:
     - area-id: 0.0.0.0
       interface:
       - if-name: lo
-        enable: true
+        enabled: true
         prefix-sid:
           index: 300
       - if-name: n2-s
-        enable: true
+        enabled: true
         network-type: point-to-point
         cost: 1
       - if-name: n2-r1
-        enable: true
+        enabled: true
         network-type: point-to-point
         cost: 1

--- a/bdd/tests/configs/ospfv2_tilfa/n3.yaml
+++ b/bdd/tests/configs/ospfv2_tilfa/n3.yaml
@@ -19,14 +19,14 @@ router:
     - area-id: 0.0.0.0
       interface:
       - if-name: lo
-        enable: true
+        enabled: true
         prefix-sid:
           index: 400
       - if-name: n3-s
-        enable: true
+        enabled: true
         network-type: point-to-point
         cost: 1000
       - if-name: n3-r1
-        enable: true
+        enabled: true
         network-type: point-to-point
         cost: 1000

--- a/bdd/tests/configs/ospfv2_tilfa/r1.yaml
+++ b/bdd/tests/configs/ospfv2_tilfa/r1.yaml
@@ -25,22 +25,22 @@ router:
     - area-id: 0.0.0.0
       interface:
       - if-name: lo
-        enable: true
+        enabled: true
         prefix-sid:
           index: 500
       - if-name: r1-n1
-        enable: true
+        enabled: true
         network-type: point-to-point
         cost: 1
       - if-name: r1-n2
-        enable: true
+        enabled: true
         network-type: point-to-point
         cost: 1
       - if-name: r1-n3
-        enable: true
+        enabled: true
         network-type: point-to-point
         cost: 1000
       - if-name: r1-r2
-        enable: true
+        enabled: true
         network-type: point-to-point
         cost: 1000

--- a/bdd/tests/configs/ospfv2_tilfa/r2.yaml
+++ b/bdd/tests/configs/ospfv2_tilfa/r2.yaml
@@ -22,18 +22,18 @@ router:
     - area-id: 0.0.0.0
       interface:
       - if-name: lo
-        enable: true
+        enabled: true
         prefix-sid:
           index: 600
       - if-name: r2-n1
-        enable: true
+        enabled: true
         network-type: point-to-point
         cost: 1
       - if-name: r2-r1
-        enable: true
+        enabled: true
         network-type: point-to-point
         cost: 1000
       - if-name: r2-r3
-        enable: true
+        enabled: true
         network-type: point-to-point
         cost: 1000

--- a/bdd/tests/configs/ospfv2_tilfa/r3.yaml
+++ b/bdd/tests/configs/ospfv2_tilfa/r3.yaml
@@ -19,14 +19,14 @@ router:
     - area-id: 0.0.0.0
       interface:
       - if-name: lo
-        enable: true
+        enabled: true
         prefix-sid:
           index: 700
       - if-name: r3-r2
-        enable: true
+        enabled: true
         network-type: point-to-point
         cost: 1000
       - if-name: r3-d
-        enable: true
+        enabled: true
         network-type: point-to-point
         cost: 1

--- a/bdd/tests/configs/ospfv2_tilfa/s-nofrr.yaml
+++ b/bdd/tests/configs/ospfv2_tilfa/s-nofrr.yaml
@@ -20,18 +20,18 @@ router:
     - area-id: 0.0.0.0
       interface:
       - if-name: lo
-        enable: true
+        enabled: true
         prefix-sid:
           index: 100
       - if-name: s-n1
-        enable: true
+        enabled: true
         network-type: point-to-point
         cost: 1
       - if-name: s-n2
-        enable: true
+        enabled: true
         network-type: point-to-point
         cost: 1
       - if-name: s-n3
-        enable: true
+        enabled: true
         network-type: point-to-point
         cost: 1000

--- a/bdd/tests/configs/ospfv2_tilfa/s-nosr.yaml
+++ b/bdd/tests/configs/ospfv2_tilfa/s-nosr.yaml
@@ -20,18 +20,18 @@ router:
     - area-id: 0.0.0.0
       interface:
       - if-name: lo
-        enable: true
+        enabled: true
         prefix-sid:
           index: 100
       - if-name: s-n1
-        enable: true
+        enabled: true
         network-type: point-to-point
         cost: 1
       - if-name: s-n2
-        enable: true
+        enabled: true
         network-type: point-to-point
         cost: 1
       - if-name: s-n3
-        enable: true
+        enabled: true
         network-type: point-to-point
         cost: 1000

--- a/bdd/tests/configs/ospfv2_tilfa/s.yaml
+++ b/bdd/tests/configs/ospfv2_tilfa/s.yaml
@@ -22,18 +22,18 @@ router:
     - area-id: 0.0.0.0
       interface:
       - if-name: lo
-        enable: true
+        enabled: true
         prefix-sid:
           index: 100
       - if-name: s-n1
-        enable: true
+        enabled: true
         network-type: point-to-point
         cost: 1
       - if-name: s-n2
-        enable: true
+        enabled: true
         network-type: point-to-point
         cost: 1
       - if-name: s-n3
-        enable: true
+        enabled: true
         network-type: point-to-point
         cost: 1000

--- a/bdd/tests/configs/ospfv2_virtual_link/r1.yaml
+++ b/bdd/tests/configs/ospfv2_virtual_link/r1.yaml
@@ -12,12 +12,12 @@ router:
     - area-id: 0.0.0.0
       interface:
       - if-name: lo
-        enable: true
+        enabled: true
     - area-id: 0.0.0.1
       # RFC 2328 §15: virtual link to r2 through transit area 1.
       virtual-link:
       - router-id: 10.0.0.2
       interface:
       - if-name: ethb
-        enable: true
+        enabled: true
         network-type: point-to-point

--- a/bdd/tests/configs/ospfv2_virtual_link/r1a.yaml
+++ b/bdd/tests/configs/ospfv2_virtual_link/r1a.yaml
@@ -12,7 +12,7 @@ router:
     - area-id: 0.0.0.0
       interface:
       - if-name: lo
-        enable: true
+        enabled: true
     - area-id: 0.0.0.1
       # RFC 2328 §15: the virtual link carries its OWN authentication,
       # independent of the (unauthenticated) transit-area interfaces.
@@ -24,5 +24,5 @@ router:
           md5: VLSECRET
       interface:
       - if-name: ethb
-        enable: true
+        enabled: true
         network-type: point-to-point

--- a/bdd/tests/configs/ospfv2_virtual_link/r1m.yaml
+++ b/bdd/tests/configs/ospfv2_virtual_link/r1m.yaml
@@ -12,12 +12,12 @@ router:
     - area-id: 0.0.0.0
       interface:
       - if-name: lo
-        enable: true
+        enabled: true
     - area-id: 0.0.0.1
       # Multi-hop virtual link: r2 is two hops away through rm.
       virtual-link:
       - router-id: 10.0.0.2
       interface:
       - if-name: ethm
-        enable: true
+        enabled: true
         network-type: point-to-point

--- a/bdd/tests/configs/ospfv2_virtual_link/r2.yaml
+++ b/bdd/tests/configs/ospfv2_virtual_link/r2.yaml
@@ -20,12 +20,12 @@ router:
       - router-id: 10.0.0.1
       interface:
       - if-name: lo
-        enable: true
+        enabled: true
       - if-name: etha
-        enable: true
+        enabled: true
         network-type: point-to-point
     - area-id: 0.0.0.2
       interface:
       - if-name: ethc
-        enable: true
+        enabled: true
         network-type: point-to-point

--- a/bdd/tests/configs/ospfv2_virtual_link/r2a.yaml
+++ b/bdd/tests/configs/ospfv2_virtual_link/r2a.yaml
@@ -21,12 +21,12 @@ router:
           md5: VLSECRET
       interface:
       - if-name: lo
-        enable: true
+        enabled: true
       - if-name: etha
-        enable: true
+        enabled: true
         network-type: point-to-point
     - area-id: 0.0.0.2
       interface:
       - if-name: ethc
-        enable: true
+        enabled: true
         network-type: point-to-point

--- a/bdd/tests/configs/ospfv2_virtual_link/r2m.yaml
+++ b/bdd/tests/configs/ospfv2_virtual_link/r2m.yaml
@@ -19,12 +19,12 @@ router:
       - router-id: 10.0.0.1
       interface:
       - if-name: lo
-        enable: true
+        enabled: true
       - if-name: ethm
-        enable: true
+        enabled: true
         network-type: point-to-point
     - area-id: 0.0.0.2
       interface:
       - if-name: ethc
-        enable: true
+        enabled: true
         network-type: point-to-point

--- a/bdd/tests/configs/ospfv2_virtual_link/r3.yaml
+++ b/bdd/tests/configs/ospfv2_virtual_link/r3.yaml
@@ -15,7 +15,7 @@ router:
     - area-id: 0.0.0.2
       interface:
       - if-name: lo
-        enable: true
+        enabled: true
       - if-name: ethb
-        enable: true
+        enabled: true
         network-type: point-to-point

--- a/bdd/tests/configs/ospfv2_virtual_link/r3m.yaml
+++ b/bdd/tests/configs/ospfv2_virtual_link/r3m.yaml
@@ -12,7 +12,7 @@ router:
     - area-id: 0.0.0.2
       interface:
       - if-name: lo
-        enable: true
+        enabled: true
       - if-name: ethb
-        enable: true
+        enabled: true
         network-type: point-to-point

--- a/bdd/tests/configs/ospfv2_virtual_link/rm.yaml
+++ b/bdd/tests/configs/ospfv2_virtual_link/rm.yaml
@@ -18,10 +18,10 @@ router:
     - area-id: 0.0.0.1
       interface:
       - if-name: lo
-        enable: true
+        enabled: true
       - if-name: etha
-        enable: true
+        enabled: true
         network-type: point-to-point
       - if-name: ethb
-        enable: true
+        enabled: true
         network-type: point-to-point

--- a/bdd/tests/configs/ospfv3_adjacency/o1.yaml
+++ b/bdd/tests/configs/ospfv3_adjacency/o1.yaml
@@ -12,7 +12,7 @@ router:
     - area-id: 0.0.0.0
       interface:
       - if-name: lo
-        enable: true
+        enabled: true
       - if-name: eth1
-        enable: true
+        enabled: true
         network-type: point-to-point

--- a/bdd/tests/configs/ospfv3_adjacency/o2.yaml
+++ b/bdd/tests/configs/ospfv3_adjacency/o2.yaml
@@ -12,7 +12,7 @@ router:
     - area-id: 0.0.0.0
       interface:
       - if-name: lo
-        enable: true
+        enabled: true
       - if-name: eth2
-        enable: true
+        enabled: true
         network-type: point-to-point

--- a/bdd/tests/configs/ospfv3_area_range/a.yaml
+++ b/bdd/tests/configs/ospfv3_area_range/a.yaml
@@ -15,14 +15,14 @@ router:
     - area-id: 0.0.0.0
       interface:
       - if-name: lo
-        enable: true
+        enabled: true
       - if-name: ethc
-        enable: true
+        enabled: true
         network-type: point-to-point
     - area-id: 0.0.0.1
       range:
       - prefix: 2001:db8:1::/48
       interface:
       - if-name: ethb
-        enable: true
+        enabled: true
         network-type: point-to-point

--- a/bdd/tests/configs/ospfv3_area_range/a_na.yaml
+++ b/bdd/tests/configs/ospfv3_area_range/a_na.yaml
@@ -15,9 +15,9 @@ router:
     - area-id: 0.0.0.0
       interface:
       - if-name: lo
-        enable: true
+        enabled: true
       - if-name: ethc
-        enable: true
+        enabled: true
         network-type: point-to-point
     - area-id: 0.0.0.1
       range:
@@ -25,5 +25,5 @@ router:
         not-advertise: true
       interface:
       - if-name: ethb
-        enable: true
+        enabled: true
         network-type: point-to-point

--- a/bdd/tests/configs/ospfv3_area_range/b.yaml
+++ b/bdd/tests/configs/ospfv3_area_range/b.yaml
@@ -21,11 +21,11 @@ router:
     - area-id: 0.0.0.1
       interface:
       - if-name: lo
-        enable: true
+        enabled: true
       - if-name: etha
-        enable: true
+        enabled: true
         network-type: point-to-point
       - if-name: r1
-        enable: true
+        enabled: true
       - if-name: r2
-        enable: true
+        enabled: true

--- a/bdd/tests/configs/ospfv3_area_range/c.yaml
+++ b/bdd/tests/configs/ospfv3_area_range/c.yaml
@@ -12,7 +12,7 @@ router:
     - area-id: 0.0.0.0
       interface:
       - if-name: lo
-        enable: true
+        enabled: true
       - if-name: etha
-        enable: true
+        enabled: true
         network-type: point-to-point

--- a/bdd/tests/configs/ospfv3_auth/a_chain.yaml
+++ b/bdd/tests/configs/ospfv3_auth/a_chain.yaml
@@ -23,9 +23,9 @@ router:
     - area-id: 0.0.0.0
       interface:
       - if-name: lo
-        enable: true
+        enabled: true
       - if-name: ethb
-        enable: true
+        enabled: true
         network-type: point-to-point
         authentication: message-digest
         key-chain: OSPF6-KC

--- a/bdd/tests/configs/ospfv3_auth/a_sha256.yaml
+++ b/bdd/tests/configs/ospfv3_auth/a_sha256.yaml
@@ -14,9 +14,9 @@ router:
     - area-id: 0.0.0.0
       interface:
       - if-name: lo
-        enable: true
+        enabled: true
       - if-name: ethb
-        enable: true
+        enabled: true
         network-type: point-to-point
         authentication: message-digest
         crypto-key:

--- a/bdd/tests/configs/ospfv3_auth/b_badkey.yaml
+++ b/bdd/tests/configs/ospfv3_auth/b_badkey.yaml
@@ -14,9 +14,9 @@ router:
     - area-id: 0.0.0.0
       interface:
       - if-name: lo
-        enable: true
+        enabled: true
       - if-name: etha
-        enable: true
+        enabled: true
         network-type: point-to-point
         authentication: message-digest
         crypto-key:

--- a/bdd/tests/configs/ospfv3_auth/b_chain.yaml
+++ b/bdd/tests/configs/ospfv3_auth/b_chain.yaml
@@ -21,9 +21,9 @@ router:
     - area-id: 0.0.0.0
       interface:
       - if-name: lo
-        enable: true
+        enabled: true
       - if-name: etha
-        enable: true
+        enabled: true
         network-type: point-to-point
         authentication: message-digest
         key-chain: OSPF6-KC

--- a/bdd/tests/configs/ospfv3_auth/b_sha256.yaml
+++ b/bdd/tests/configs/ospfv3_auth/b_sha256.yaml
@@ -12,9 +12,9 @@ router:
     - area-id: 0.0.0.0
       interface:
       - if-name: lo
-        enable: true
+        enabled: true
       - if-name: etha
-        enable: true
+        enabled: true
         network-type: point-to-point
         authentication: message-digest
         crypto-key:

--- a/bdd/tests/configs/ospfv3_bfd_frr/d.yaml
+++ b/bdd/tests/configs/ospfv3_bfd_frr/d.yaml
@@ -19,14 +19,14 @@ router:
     - area-id: 0.0.0.0
       interface:
       - if-name: lo
-        enable: true
+        enabled: true
         prefix-sid:
           index: 800
       - if-name: d-n1
-        enable: true
+        enabled: true
         network-type: point-to-point
         cost: 1
       - if-name: d-r3
-        enable: true
+        enabled: true
         network-type: point-to-point
         cost: 1

--- a/bdd/tests/configs/ospfv3_bfd_frr/n1.yaml
+++ b/bdd/tests/configs/ospfv3_bfd_frr/n1.yaml
@@ -25,24 +25,24 @@ router:
     - area-id: 0.0.0.0
       interface:
       - if-name: lo
-        enable: true
+        enabled: true
         prefix-sid:
           index: 200
       - if-name: n1-s
-        enable: true
+        enabled: true
         network-type: point-to-point
         cost: 1
         bfd:
-          enable: true
+          enabled: true
       - if-name: n1-r1
-        enable: true
+        enabled: true
         network-type: point-to-point
         cost: 1
       - if-name: n1-r2
-        enable: true
+        enabled: true
         network-type: point-to-point
         cost: 1
       - if-name: n1-d
-        enable: true
+        enabled: true
         network-type: point-to-point
         cost: 1

--- a/bdd/tests/configs/ospfv3_bfd_frr/n2.yaml
+++ b/bdd/tests/configs/ospfv3_bfd_frr/n2.yaml
@@ -19,14 +19,14 @@ router:
     - area-id: 0.0.0.0
       interface:
       - if-name: lo
-        enable: true
+        enabled: true
         prefix-sid:
           index: 300
       - if-name: n2-s
-        enable: true
+        enabled: true
         network-type: point-to-point
         cost: 1
       - if-name: n2-r1
-        enable: true
+        enabled: true
         network-type: point-to-point
         cost: 1

--- a/bdd/tests/configs/ospfv3_bfd_frr/n3.yaml
+++ b/bdd/tests/configs/ospfv3_bfd_frr/n3.yaml
@@ -19,14 +19,14 @@ router:
     - area-id: 0.0.0.0
       interface:
       - if-name: lo
-        enable: true
+        enabled: true
         prefix-sid:
           index: 400
       - if-name: n3-s
-        enable: true
+        enabled: true
         network-type: point-to-point
         cost: 1000
       - if-name: n3-r1
-        enable: true
+        enabled: true
         network-type: point-to-point
         cost: 1000

--- a/bdd/tests/configs/ospfv3_bfd_frr/r1.yaml
+++ b/bdd/tests/configs/ospfv3_bfd_frr/r1.yaml
@@ -25,22 +25,22 @@ router:
     - area-id: 0.0.0.0
       interface:
       - if-name: lo
-        enable: true
+        enabled: true
         prefix-sid:
           index: 500
       - if-name: r1-n1
-        enable: true
+        enabled: true
         network-type: point-to-point
         cost: 1
       - if-name: r1-n2
-        enable: true
+        enabled: true
         network-type: point-to-point
         cost: 1
       - if-name: r1-n3
-        enable: true
+        enabled: true
         network-type: point-to-point
         cost: 1000
       - if-name: r1-r2
-        enable: true
+        enabled: true
         network-type: point-to-point
         cost: 1000

--- a/bdd/tests/configs/ospfv3_bfd_frr/r2.yaml
+++ b/bdd/tests/configs/ospfv3_bfd_frr/r2.yaml
@@ -22,18 +22,18 @@ router:
     - area-id: 0.0.0.0
       interface:
       - if-name: lo
-        enable: true
+        enabled: true
         prefix-sid:
           index: 600
       - if-name: r2-n1
-        enable: true
+        enabled: true
         network-type: point-to-point
         cost: 1
       - if-name: r2-r1
-        enable: true
+        enabled: true
         network-type: point-to-point
         cost: 1000
       - if-name: r2-r3
-        enable: true
+        enabled: true
         network-type: point-to-point
         cost: 1000

--- a/bdd/tests/configs/ospfv3_bfd_frr/r3.yaml
+++ b/bdd/tests/configs/ospfv3_bfd_frr/r3.yaml
@@ -19,14 +19,14 @@ router:
     - area-id: 0.0.0.0
       interface:
       - if-name: lo
-        enable: true
+        enabled: true
         prefix-sid:
           index: 700
       - if-name: r3-r2
-        enable: true
+        enabled: true
         network-type: point-to-point
         cost: 1000
       - if-name: r3-d
-        enable: true
+        enabled: true
         network-type: point-to-point
         cost: 1

--- a/bdd/tests/configs/ospfv3_bfd_frr/s.yaml
+++ b/bdd/tests/configs/ospfv3_bfd_frr/s.yaml
@@ -22,20 +22,20 @@ router:
     - area-id: 0.0.0.0
       interface:
       - if-name: lo
-        enable: true
+        enabled: true
         prefix-sid:
           index: 100
       - if-name: s-n1
-        enable: true
+        enabled: true
         network-type: point-to-point
         cost: 1
         bfd:
-          enable: true
+          enabled: true
       - if-name: s-n2
-        enable: true
+        enabled: true
         network-type: point-to-point
         cost: 1
       - if-name: s-n3
-        enable: true
+        enabled: true
         network-type: point-to-point
         cost: 1000

--- a/bdd/tests/configs/ospfv3_default_originate/a.yaml
+++ b/bdd/tests/configs/ospfv3_default_originate/a.yaml
@@ -12,7 +12,7 @@ router:
     - area-id: 0.0.0.0
       interface:
       - if-name: lo
-        enable: true
+        enabled: true
       - if-name: ethb
-        enable: true
+        enabled: true
         network-type: point-to-point

--- a/bdd/tests/configs/ospfv3_default_originate/b_always.yaml
+++ b/bdd/tests/configs/ospfv3_default_originate/b_always.yaml
@@ -15,7 +15,7 @@ router:
     - area-id: 0.0.0.0
       interface:
       - if-name: lo
-        enable: true
+        enabled: true
       - if-name: etha
-        enable: true
+        enabled: true
         network-type: point-to-point

--- a/bdd/tests/configs/ospfv3_default_originate/b_cond.yaml
+++ b/bdd/tests/configs/ospfv3_default_originate/b_cond.yaml
@@ -14,7 +14,7 @@ router:
     - area-id: 0.0.0.0
       interface:
       - if-name: lo
-        enable: true
+        enabled: true
       - if-name: etha
-        enable: true
+        enabled: true
         network-type: point-to-point

--- a/bdd/tests/configs/ospfv3_graceful_restart/a.yaml
+++ b/bdd/tests/configs/ospfv3_graceful_restart/a.yaml
@@ -18,7 +18,7 @@ router:
     - area-id: 0.0.0.0
       interface:
       - if-name: lo
-        enable: true
+        enabled: true
       - if-name: ethb
-        enable: true
+        enabled: true
         network-type: point-to-point

--- a/bdd/tests/configs/ospfv3_graceful_restart/b.yaml
+++ b/bdd/tests/configs/ospfv3_graceful_restart/b.yaml
@@ -16,7 +16,7 @@ router:
     - area-id: 0.0.0.0
       interface:
       - if-name: lo
-        enable: true
+        enabled: true
       - if-name: etha
-        enable: true
+        enabled: true
         network-type: point-to-point

--- a/bdd/tests/configs/ospfv3_instance_id/a.yaml
+++ b/bdd/tests/configs/ospfv3_instance_id/a.yaml
@@ -12,8 +12,8 @@ router:
     - area-id: 0.0.0.0
       interface:
       - if-name: lo
-        enable: true
+        enabled: true
       - if-name: ethb
-        enable: true
+        enabled: true
         network-type: point-to-point
         instance-id: 5

--- a/bdd/tests/configs/ospfv3_instance_id/b.yaml
+++ b/bdd/tests/configs/ospfv3_instance_id/b.yaml
@@ -12,8 +12,8 @@ router:
     - area-id: 0.0.0.0
       interface:
       - if-name: lo
-        enable: true
+        enabled: true
       - if-name: etha
-        enable: true
+        enabled: true
         network-type: point-to-point
         instance-id: 5

--- a/bdd/tests/configs/ospfv3_instance_id/b_mismatch.yaml
+++ b/bdd/tests/configs/ospfv3_instance_id/b_mismatch.yaml
@@ -14,8 +14,8 @@ router:
     - area-id: 0.0.0.0
       interface:
       - if-name: lo
-        enable: true
+        enabled: true
       - if-name: etha
-        enable: true
+        enabled: true
         network-type: point-to-point
         instance-id: 7

--- a/bdd/tests/configs/ospfv3_multi_area/a.yaml
+++ b/bdd/tests/configs/ospfv3_multi_area/a.yaml
@@ -18,16 +18,16 @@ router:
     - area-id: 0.0.0.0
       interface:
       - if-name: lo
-        enable: true
+        enabled: true
       - if-name: ethb
-        enable: true
+        enabled: true
         network-type: point-to-point
       - if-name: ethd
-        enable: true
+        enabled: true
         network-type: point-to-point
         cost: 20
     - area-id: 0.0.0.1
       interface:
       - if-name: ethe
-        enable: true
+        enabled: true
         network-type: point-to-point

--- a/bdd/tests/configs/ospfv3_multi_area/b.yaml
+++ b/bdd/tests/configs/ospfv3_multi_area/b.yaml
@@ -18,13 +18,13 @@ router:
     - area-id: 0.0.0.0
       interface:
       - if-name: lo
-        enable: true
+        enabled: true
       - if-name: etha
-        enable: true
+        enabled: true
         network-type: point-to-point
       - if-name: ethc
-        enable: true
+        enabled: true
         network-type: point-to-point
       - if-name: ethd
-        enable: true
+        enabled: true
         network-type: point-to-point

--- a/bdd/tests/configs/ospfv3_multi_area/c.yaml
+++ b/bdd/tests/configs/ospfv3_multi_area/c.yaml
@@ -18,16 +18,16 @@ router:
     - area-id: 0.0.0.0
       interface:
       - if-name: lo
-        enable: true
+        enabled: true
       - if-name: ethb
-        enable: true
+        enabled: true
         network-type: point-to-point
       - if-name: ethd
-        enable: true
+        enabled: true
         network-type: point-to-point
         cost: 20
     - area-id: 0.0.0.2
       interface:
       - if-name: ethf
-        enable: true
+        enabled: true
         network-type: point-to-point

--- a/bdd/tests/configs/ospfv3_multi_area/d.yaml
+++ b/bdd/tests/configs/ospfv3_multi_area/d.yaml
@@ -18,15 +18,15 @@ router:
     - area-id: 0.0.0.0
       interface:
       - if-name: lo
-        enable: true
+        enabled: true
       - if-name: etha
-        enable: true
+        enabled: true
         network-type: point-to-point
         cost: 20
       - if-name: ethb
-        enable: true
+        enabled: true
         network-type: point-to-point
       - if-name: ethc
-        enable: true
+        enabled: true
         network-type: point-to-point
         cost: 20

--- a/bdd/tests/configs/ospfv3_multi_area/e.yaml
+++ b/bdd/tests/configs/ospfv3_multi_area/e.yaml
@@ -12,7 +12,7 @@ router:
     - area-id: 0.0.0.1
       interface:
       - if-name: lo
-        enable: true
+        enabled: true
       - if-name: etha
-        enable: true
+        enabled: true
         network-type: point-to-point

--- a/bdd/tests/configs/ospfv3_multi_area/f.yaml
+++ b/bdd/tests/configs/ospfv3_multi_area/f.yaml
@@ -12,7 +12,7 @@ router:
     - area-id: 0.0.0.2
       interface:
       - if-name: lo
-        enable: true
+        enabled: true
       - if-name: ethc
-        enable: true
+        enabled: true
         network-type: point-to-point

--- a/bdd/tests/configs/ospfv3_nssa/a.yaml
+++ b/bdd/tests/configs/ospfv3_nssa/a.yaml
@@ -19,9 +19,9 @@ router:
     - area-id: 0.0.0.0
       interface:
       - if-name: lo
-        enable: true
+        enabled: true
       - if-name: ethb
-        enable: true
+        enabled: true
         network-type: point-to-point
     # NSSA (0.0.0.1). a is the sole ABR, so it elects itself the
     # RFC 5340 / RFC 3101 Type-7->Type-5 translator under the default
@@ -31,8 +31,8 @@ router:
       nssa-default-originate: true
       interface:
       - if-name: ethc
-        enable: true
+        enabled: true
         network-type: point-to-point
       - if-name: ethd
-        enable: true
+        enabled: true
         network-type: point-to-point

--- a/bdd/tests/configs/ospfv3_nssa/a_never.yaml
+++ b/bdd/tests/configs/ospfv3_nssa/a_never.yaml
@@ -18,9 +18,9 @@ router:
     - area-id: 0.0.0.0
       interface:
       - if-name: lo
-        enable: true
+        enabled: true
       - if-name: ethb
-        enable: true
+        enabled: true
         network-type: point-to-point
     # nssa-translator-role = never disables Type-7->Type-5 translation
     # on this ABR. The Type-7 still floods the NSSA, but must not leak
@@ -31,8 +31,8 @@ router:
       nssa-translator-role: never
       interface:
       - if-name: ethc
-        enable: true
+        enabled: true
         network-type: point-to-point
       - if-name: ethd
-        enable: true
+        enabled: true
         network-type: point-to-point

--- a/bdd/tests/configs/ospfv3_nssa/b.yaml
+++ b/bdd/tests/configs/ospfv3_nssa/b.yaml
@@ -15,7 +15,7 @@ router:
     - area-id: 0.0.0.0
       interface:
       - if-name: lo
-        enable: true
+        enabled: true
       - if-name: etha
-        enable: true
+        enabled: true
         network-type: point-to-point

--- a/bdd/tests/configs/ospfv3_nssa/c.yaml
+++ b/bdd/tests/configs/ospfv3_nssa/c.yaml
@@ -21,7 +21,7 @@ router:
           metric-type: type-2
       interface:
       - if-name: lo
-        enable: true
+        enabled: true
       - if-name: etha
-        enable: true
+        enabled: true
         network-type: point-to-point

--- a/bdd/tests/configs/ospfv3_nssa/d.yaml
+++ b/bdd/tests/configs/ospfv3_nssa/d.yaml
@@ -16,7 +16,7 @@ router:
       area-type: nssa
       interface:
       - if-name: lo
-        enable: true
+        enabled: true
       - if-name: etha
-        enable: true
+        enabled: true
         network-type: point-to-point

--- a/bdd/tests/configs/ospfv3_passive/a.yaml
+++ b/bdd/tests/configs/ospfv3_passive/a.yaml
@@ -12,7 +12,7 @@ router:
     - area-id: 0.0.0.0
       interface:
       - if-name: lo
-        enable: true
+        enabled: true
       - if-name: ethb
-        enable: true
+        enabled: true
         network-type: point-to-point

--- a/bdd/tests/configs/ospfv3_passive/b.yaml
+++ b/bdd/tests/configs/ospfv3_passive/b.yaml
@@ -17,11 +17,11 @@ router:
     - area-id: 0.0.0.0
       interface:
       - if-name: lo
-        enable: true
+        enabled: true
       - if-name: etha
-        enable: true
+        enabled: true
         network-type: point-to-point
       - if-name: ethc
-        enable: true
+        enabled: true
         network-type: point-to-point
         passive: true

--- a/bdd/tests/configs/ospfv3_passive/c.yaml
+++ b/bdd/tests/configs/ospfv3_passive/c.yaml
@@ -12,7 +12,7 @@ router:
     - area-id: 0.0.0.0
       interface:
       - if-name: lo
-        enable: true
+        enabled: true
       - if-name: ethb
-        enable: true
+        enabled: true
         network-type: point-to-point

--- a/bdd/tests/configs/ospfv3_redistribute/a.yaml
+++ b/bdd/tests/configs/ospfv3_redistribute/a.yaml
@@ -12,7 +12,7 @@ router:
     - area-id: 0.0.0.0
       interface:
       - if-name: lo
-        enable: true
+        enabled: true
       - if-name: ethb
-        enable: true
+        enabled: true
         network-type: point-to-point

--- a/bdd/tests/configs/ospfv3_redistribute/b.yaml
+++ b/bdd/tests/configs/ospfv3_redistribute/b.yaml
@@ -29,7 +29,7 @@ router:
     - area-id: 0.0.0.0
       interface:
       - if-name: lo
-        enable: true
+        enabled: true
       - if-name: etha
-        enable: true
+        enabled: true
         network-type: point-to-point

--- a/bdd/tests/configs/ospfv3_router_id_change/o1.yaml
+++ b/bdd/tests/configs/ospfv3_router_id_change/o1.yaml
@@ -12,7 +12,7 @@ router:
     - area-id: 0.0.0.0
       interface:
       - if-name: lo
-        enable: true
+        enabled: true
       - if-name: eth1
-        enable: true
+        enabled: true
         network-type: point-to-point

--- a/bdd/tests/configs/ospfv3_router_id_change/o2.yaml
+++ b/bdd/tests/configs/ospfv3_router_id_change/o2.yaml
@@ -12,7 +12,7 @@ router:
     - area-id: 0.0.0.0
       interface:
       - if-name: lo
-        enable: true
+        enabled: true
       - if-name: eth2
-        enable: true
+        enabled: true
         network-type: point-to-point

--- a/bdd/tests/configs/ospfv3_srv6/z1.yaml
+++ b/bdd/tests/configs/ospfv3_srv6/z1.yaml
@@ -23,7 +23,7 @@ router:
     - area-id: 0.0.0.0
       interface:
       - if-name: lo
-        enable: true
+        enabled: true
       - if-name: i2
-        enable: true
+        enabled: true
         network-type: point-to-point

--- a/bdd/tests/configs/ospfv3_srv6/z2.yaml
+++ b/bdd/tests/configs/ospfv3_srv6/z2.yaml
@@ -21,7 +21,7 @@ router:
     - area-id: 0.0.0.0
       interface:
       - if-name: lo
-        enable: true
+        enabled: true
       - if-name: i1
-        enable: true
+        enabled: true
         network-type: point-to-point

--- a/bdd/tests/configs/ospfv3_stub_router/r1.yaml
+++ b/bdd/tests/configs/ospfv3_stub_router/r1.yaml
@@ -15,11 +15,11 @@ router:
     - area-id: 0.0.0.0
       interface:
       - if-name: lo
-        enable: true
+        enabled: true
       - if-name: ethb
-        enable: true
+        enabled: true
         network-type: point-to-point
       - if-name: ethd
-        enable: true
+        enabled: true
         network-type: point-to-point
         cost: 100

--- a/bdd/tests/configs/ospfv3_stub_router/r2.yaml
+++ b/bdd/tests/configs/ospfv3_stub_router/r2.yaml
@@ -22,10 +22,10 @@ router:
     - area-id: 0.0.0.0
       interface:
       - if-name: lo
-        enable: true
+        enabled: true
       - if-name: etha
-        enable: true
+        enabled: true
         network-type: point-to-point
       - if-name: ethc
-        enable: true
+        enabled: true
         network-type: point-to-point

--- a/bdd/tests/configs/ospfv3_stub_router/r2s.yaml
+++ b/bdd/tests/configs/ospfv3_stub_router/r2s.yaml
@@ -19,10 +19,10 @@ router:
     - area-id: 0.0.0.0
       interface:
       - if-name: lo
-        enable: true
+        enabled: true
       - if-name: etha
-        enable: true
+        enabled: true
         network-type: point-to-point
       - if-name: ethc
-        enable: true
+        enabled: true
         network-type: point-to-point

--- a/bdd/tests/configs/ospfv3_stub_router/r3.yaml
+++ b/bdd/tests/configs/ospfv3_stub_router/r3.yaml
@@ -15,11 +15,11 @@ router:
     - area-id: 0.0.0.0
       interface:
       - if-name: lo
-        enable: true
+        enabled: true
       - if-name: ethb
-        enable: true
+        enabled: true
         network-type: point-to-point
       - if-name: ethd
-        enable: true
+        enabled: true
         network-type: point-to-point
         cost: 100

--- a/bdd/tests/configs/ospfv3_stub_router/r4.yaml
+++ b/bdd/tests/configs/ospfv3_stub_router/r4.yaml
@@ -16,12 +16,12 @@ router:
     - area-id: 0.0.0.0
       interface:
       - if-name: lo
-        enable: true
+        enabled: true
       - if-name: etha
-        enable: true
+        enabled: true
         network-type: point-to-point
         cost: 100
       - if-name: ethc
-        enable: true
+        enabled: true
         network-type: point-to-point
         cost: 100

--- a/bdd/tests/configs/ospfv3_tilfa/d.yaml
+++ b/bdd/tests/configs/ospfv3_tilfa/d.yaml
@@ -19,14 +19,14 @@ router:
     - area-id: 0.0.0.0
       interface:
       - if-name: lo
-        enable: true
+        enabled: true
         prefix-sid:
           index: 800
       - if-name: d-n1
-        enable: true
+        enabled: true
         network-type: point-to-point
         cost: 1
       - if-name: d-r3
-        enable: true
+        enabled: true
         network-type: point-to-point
         cost: 1

--- a/bdd/tests/configs/ospfv3_tilfa/n1.yaml
+++ b/bdd/tests/configs/ospfv3_tilfa/n1.yaml
@@ -25,22 +25,22 @@ router:
     - area-id: 0.0.0.0
       interface:
       - if-name: lo
-        enable: true
+        enabled: true
         prefix-sid:
           index: 200
       - if-name: n1-s
-        enable: true
+        enabled: true
         network-type: point-to-point
         cost: 1
       - if-name: n1-r1
-        enable: true
+        enabled: true
         network-type: point-to-point
         cost: 1
       - if-name: n1-r2
-        enable: true
+        enabled: true
         network-type: point-to-point
         cost: 1
       - if-name: n1-d
-        enable: true
+        enabled: true
         network-type: point-to-point
         cost: 1

--- a/bdd/tests/configs/ospfv3_tilfa/n2.yaml
+++ b/bdd/tests/configs/ospfv3_tilfa/n2.yaml
@@ -19,14 +19,14 @@ router:
     - area-id: 0.0.0.0
       interface:
       - if-name: lo
-        enable: true
+        enabled: true
         prefix-sid:
           index: 300
       - if-name: n2-s
-        enable: true
+        enabled: true
         network-type: point-to-point
         cost: 1
       - if-name: n2-r1
-        enable: true
+        enabled: true
         network-type: point-to-point
         cost: 1

--- a/bdd/tests/configs/ospfv3_tilfa/n3.yaml
+++ b/bdd/tests/configs/ospfv3_tilfa/n3.yaml
@@ -19,14 +19,14 @@ router:
     - area-id: 0.0.0.0
       interface:
       - if-name: lo
-        enable: true
+        enabled: true
         prefix-sid:
           index: 400
       - if-name: n3-s
-        enable: true
+        enabled: true
         network-type: point-to-point
         cost: 1000
       - if-name: n3-r1
-        enable: true
+        enabled: true
         network-type: point-to-point
         cost: 1000

--- a/bdd/tests/configs/ospfv3_tilfa/r1.yaml
+++ b/bdd/tests/configs/ospfv3_tilfa/r1.yaml
@@ -25,22 +25,22 @@ router:
     - area-id: 0.0.0.0
       interface:
       - if-name: lo
-        enable: true
+        enabled: true
         prefix-sid:
           index: 500
       - if-name: r1-n1
-        enable: true
+        enabled: true
         network-type: point-to-point
         cost: 1
       - if-name: r1-n2
-        enable: true
+        enabled: true
         network-type: point-to-point
         cost: 1
       - if-name: r1-n3
-        enable: true
+        enabled: true
         network-type: point-to-point
         cost: 1000
       - if-name: r1-r2
-        enable: true
+        enabled: true
         network-type: point-to-point
         cost: 1000

--- a/bdd/tests/configs/ospfv3_tilfa/r2.yaml
+++ b/bdd/tests/configs/ospfv3_tilfa/r2.yaml
@@ -22,18 +22,18 @@ router:
     - area-id: 0.0.0.0
       interface:
       - if-name: lo
-        enable: true
+        enabled: true
         prefix-sid:
           index: 600
       - if-name: r2-n1
-        enable: true
+        enabled: true
         network-type: point-to-point
         cost: 1
       - if-name: r2-r1
-        enable: true
+        enabled: true
         network-type: point-to-point
         cost: 1000
       - if-name: r2-r3
-        enable: true
+        enabled: true
         network-type: point-to-point
         cost: 1000

--- a/bdd/tests/configs/ospfv3_tilfa/r3.yaml
+++ b/bdd/tests/configs/ospfv3_tilfa/r3.yaml
@@ -19,14 +19,14 @@ router:
     - area-id: 0.0.0.0
       interface:
       - if-name: lo
-        enable: true
+        enabled: true
         prefix-sid:
           index: 700
       - if-name: r3-r2
-        enable: true
+        enabled: true
         network-type: point-to-point
         cost: 1000
       - if-name: r3-d
-        enable: true
+        enabled: true
         network-type: point-to-point
         cost: 1

--- a/bdd/tests/configs/ospfv3_tilfa/s-nofrr.yaml
+++ b/bdd/tests/configs/ospfv3_tilfa/s-nofrr.yaml
@@ -20,18 +20,18 @@ router:
     - area-id: 0.0.0.0
       interface:
       - if-name: lo
-        enable: true
+        enabled: true
         prefix-sid:
           index: 100
       - if-name: s-n1
-        enable: true
+        enabled: true
         network-type: point-to-point
         cost: 1
       - if-name: s-n2
-        enable: true
+        enabled: true
         network-type: point-to-point
         cost: 1
       - if-name: s-n3
-        enable: true
+        enabled: true
         network-type: point-to-point
         cost: 1000

--- a/bdd/tests/configs/ospfv3_tilfa/s-nosr.yaml
+++ b/bdd/tests/configs/ospfv3_tilfa/s-nosr.yaml
@@ -20,18 +20,18 @@ router:
     - area-id: 0.0.0.0
       interface:
       - if-name: lo
-        enable: true
+        enabled: true
         prefix-sid:
           index: 100
       - if-name: s-n1
-        enable: true
+        enabled: true
         network-type: point-to-point
         cost: 1
       - if-name: s-n2
-        enable: true
+        enabled: true
         network-type: point-to-point
         cost: 1
       - if-name: s-n3
-        enable: true
+        enabled: true
         network-type: point-to-point
         cost: 1000

--- a/bdd/tests/configs/ospfv3_tilfa/s.yaml
+++ b/bdd/tests/configs/ospfv3_tilfa/s.yaml
@@ -22,18 +22,18 @@ router:
     - area-id: 0.0.0.0
       interface:
       - if-name: lo
-        enable: true
+        enabled: true
         prefix-sid:
           index: 100
       - if-name: s-n1
-        enable: true
+        enabled: true
         network-type: point-to-point
         cost: 1
       - if-name: s-n2
-        enable: true
+        enabled: true
         network-type: point-to-point
         cost: 1
       - if-name: s-n3
-        enable: true
+        enabled: true
         network-type: point-to-point
         cost: 1000

--- a/bdd/tests/configs/srv6_tilfa_v3/d.yaml
+++ b/bdd/tests/configs/srv6_tilfa_v3/d.yaml
@@ -27,12 +27,12 @@ router:
     - area-id: 0.0.0.0
       interface:
       - if-name: lo
-        enable: true
+        enabled: true
       - if-name: d-n1
-        enable: true
+        enabled: true
         network-type: point-to-point
         cost: 1
       - if-name: d-r3
-        enable: true
+        enabled: true
         network-type: point-to-point
         cost: 1

--- a/bdd/tests/configs/srv6_tilfa_v3/n1.yaml
+++ b/bdd/tests/configs/srv6_tilfa_v3/n1.yaml
@@ -33,20 +33,20 @@ router:
     - area-id: 0.0.0.0
       interface:
       - if-name: lo
-        enable: true
+        enabled: true
       - if-name: n1-s
-        enable: true
+        enabled: true
         network-type: point-to-point
         cost: 1
       - if-name: n1-r1
-        enable: true
+        enabled: true
         network-type: point-to-point
         cost: 1
       - if-name: n1-r2
-        enable: true
+        enabled: true
         network-type: point-to-point
         cost: 1
       - if-name: n1-d
-        enable: true
+        enabled: true
         network-type: point-to-point
         cost: 1

--- a/bdd/tests/configs/srv6_tilfa_v3/n2.yaml
+++ b/bdd/tests/configs/srv6_tilfa_v3/n2.yaml
@@ -27,12 +27,12 @@ router:
     - area-id: 0.0.0.0
       interface:
       - if-name: lo
-        enable: true
+        enabled: true
       - if-name: n2-s
-        enable: true
+        enabled: true
         network-type: point-to-point
         cost: 1
       - if-name: n2-r1
-        enable: true
+        enabled: true
         network-type: point-to-point
         cost: 1

--- a/bdd/tests/configs/srv6_tilfa_v3/n3.yaml
+++ b/bdd/tests/configs/srv6_tilfa_v3/n3.yaml
@@ -27,12 +27,12 @@ router:
     - area-id: 0.0.0.0
       interface:
       - if-name: lo
-        enable: true
+        enabled: true
       - if-name: n3-s
-        enable: true
+        enabled: true
         network-type: point-to-point
         cost: 1000
       - if-name: n3-r1
-        enable: true
+        enabled: true
         network-type: point-to-point
         cost: 1000

--- a/bdd/tests/configs/srv6_tilfa_v3/r1.yaml
+++ b/bdd/tests/configs/srv6_tilfa_v3/r1.yaml
@@ -33,20 +33,20 @@ router:
     - area-id: 0.0.0.0
       interface:
       - if-name: lo
-        enable: true
+        enabled: true
       - if-name: r1-n1
-        enable: true
+        enabled: true
         network-type: point-to-point
         cost: 1
       - if-name: r1-n2
-        enable: true
+        enabled: true
         network-type: point-to-point
         cost: 1
       - if-name: r1-n3
-        enable: true
+        enabled: true
         network-type: point-to-point
         cost: 1000
       - if-name: r1-r2
-        enable: true
+        enabled: true
         network-type: point-to-point
         cost: 1000

--- a/bdd/tests/configs/srv6_tilfa_v3/r2.yaml
+++ b/bdd/tests/configs/srv6_tilfa_v3/r2.yaml
@@ -30,16 +30,16 @@ router:
     - area-id: 0.0.0.0
       interface:
       - if-name: lo
-        enable: true
+        enabled: true
       - if-name: r2-n1
-        enable: true
+        enabled: true
         network-type: point-to-point
         cost: 1
       - if-name: r2-r1
-        enable: true
+        enabled: true
         network-type: point-to-point
         cost: 1000
       - if-name: r2-r3
-        enable: true
+        enabled: true
         network-type: point-to-point
         cost: 1000

--- a/bdd/tests/configs/srv6_tilfa_v3/r3.yaml
+++ b/bdd/tests/configs/srv6_tilfa_v3/r3.yaml
@@ -27,12 +27,12 @@ router:
     - area-id: 0.0.0.0
       interface:
       - if-name: lo
-        enable: true
+        enabled: true
       - if-name: r3-r2
-        enable: true
+        enabled: true
         network-type: point-to-point
         cost: 1000
       - if-name: r3-d
-        enable: true
+        enabled: true
         network-type: point-to-point
         cost: 1

--- a/bdd/tests/configs/srv6_tilfa_v3/s.yaml
+++ b/bdd/tests/configs/srv6_tilfa_v3/s.yaml
@@ -30,16 +30,16 @@ router:
     - area-id: 0.0.0.0
       interface:
       - if-name: lo
-        enable: true
+        enabled: true
       - if-name: s-n1
-        enable: true
+        enabled: true
         network-type: point-to-point
         cost: 1
       - if-name: s-n2
-        enable: true
+        enabled: true
         network-type: point-to-point
         cost: 1
       - if-name: s-n3
-        enable: true
+        enabled: true
         network-type: point-to-point
         cost: 1000

--- a/bdd/tests/configs/stamp_te_metric/st1.yaml
+++ b/bdd/tests/configs/stamp_te_metric/st1.yaml
@@ -14,14 +14,14 @@ router:
     interface:
     - if-name: lo
       ipv4:
-        enable: true
+        enabled: true
     - if-name: st1-st2
       network-type: point-to-point
       ipv4:
-        enable: true
+        enabled: true
       te-metric:
         measurement:
-          enable: true
+          enabled: true
           interval: 100
           damping-period: 2
   ospf:
@@ -32,12 +32,12 @@ router:
     - area-id: 0.0.0.0
       interface:
       - if-name: lo
-        enable: true
+        enabled: true
       - if-name: st1-st2
-        enable: true
+        enabled: true
         network-type: point-to-point
         te-metric:
           measurement:
-            enable: true
+            enabled: true
             interval: 100
             damping-period: 2

--- a/bdd/tests/configs/stamp_te_metric/st2.yaml
+++ b/bdd/tests/configs/stamp_te_metric/st2.yaml
@@ -14,14 +14,14 @@ router:
     interface:
     - if-name: lo
       ipv4:
-        enable: true
+        enabled: true
     - if-name: st2-st1
       network-type: point-to-point
       ipv4:
-        enable: true
+        enabled: true
       te-metric:
         measurement:
-          enable: true
+          enabled: true
           interval: 100
           damping-period: 2
   ospf:
@@ -32,12 +32,12 @@ router:
     - area-id: 0.0.0.0
       interface:
       - if-name: lo
-        enable: true
+        enabled: true
       - if-name: st2-st1
-        enable: true
+        enabled: true
         network-type: point-to-point
         te-metric:
           measurement:
-            enable: true
+            enabled: true
             interval: 100
             damping-period: 2

--- a/bdd/tests/configs/stamp_v6_te_metric/st1.yaml
+++ b/bdd/tests/configs/stamp_v6_te_metric/st1.yaml
@@ -14,13 +14,13 @@ router:
     interface:
     - if-name: lo
       ipv6:
-        enable: true
+        enabled: true
     - if-name: st1-st2
       network-type: point-to-point
       ipv6:
-        enable: true
+        enabled: true
       te-metric:
         measurement:
-          enable: true
+          enabled: true
           interval: 100
           damping-period: 2

--- a/bdd/tests/configs/stamp_v6_te_metric/st2.yaml
+++ b/bdd/tests/configs/stamp_v6_te_metric/st2.yaml
@@ -14,13 +14,13 @@ router:
     interface:
     - if-name: lo
       ipv6:
-        enable: true
+        enabled: true
     - if-name: st2-st1
       network-type: point-to-point
       ipv6:
-        enable: true
+        enabled: true
       te-metric:
         measurement:
-          enable: true
+          enabled: true
           interval: 100
           damping-period: 2

--- a/bdd/tests/configs/tilfa_bfd/d.yaml
+++ b/bdd/tests/configs/tilfa_bfd/d.yaml
@@ -15,16 +15,16 @@ router:
     interface:
     - if-name: lo
       ipv4:
-        enable: true
+        enabled: true
         prefix-sid:
           index: 800
     - if-name: d-n1
       ipv4:
-        enable: true
+        enabled: true
       metric: 1
     - if-name: d-r3
       ipv4:
-        enable: true
+        enabled: true
       metric: 1
     is-type: level-2-only
     segment-routing: mpls

--- a/bdd/tests/configs/tilfa_bfd/n1.yaml
+++ b/bdd/tests/configs/tilfa_bfd/n1.yaml
@@ -25,24 +25,24 @@ router:
     interface:
     - if-name: lo
       ipv4:
-        enable: true
+        enabled: true
         prefix-sid:
           index: 200
     - if-name: n1-s
       ipv4:
-        enable: true
+        enabled: true
       metric: 1
       bfd:
-        enable: true
+        enabled: true
     - if-name: n1-r1
       ipv4:
-        enable: true
+        enabled: true
       metric: 1
     - if-name: n1-r2
       ipv4:
-        enable: true
+        enabled: true
       metric: 1
     - if-name: n1-d
       ipv4:
-        enable: true
+        enabled: true
       metric: 1

--- a/bdd/tests/configs/tilfa_bfd/n2.yaml
+++ b/bdd/tests/configs/tilfa_bfd/n2.yaml
@@ -19,14 +19,14 @@ router:
     interface:
     - if-name: lo
       ipv4:
-        enable: true
+        enabled: true
         prefix-sid:
           index: 300
     - if-name: n2-s
       ipv4:
-        enable: true
+        enabled: true
       metric: 1
     - if-name: n2-r1
       ipv4:
-        enable: true
+        enabled: true
       metric: 1

--- a/bdd/tests/configs/tilfa_bfd/n3.yaml
+++ b/bdd/tests/configs/tilfa_bfd/n3.yaml
@@ -15,16 +15,16 @@ router:
     interface:
     - if-name: lo
       ipv4:
-        enable: true
+        enabled: true
         prefix-sid:
           index: 400
     - if-name: n3-s
       ipv4:
-        enable: true
+        enabled: true
       metric: 1000
     - if-name: n3-r1
       ipv4:
-        enable: true
+        enabled: true
       metric: 1000
     is-type: level-2-only
     segment-routing: mpls

--- a/bdd/tests/configs/tilfa_bfd/r1.yaml
+++ b/bdd/tests/configs/tilfa_bfd/r1.yaml
@@ -21,24 +21,24 @@ router:
     interface:
     - if-name: lo
       ipv4:
-        enable: true
+        enabled: true
         prefix-sid:
           index: 500
     - if-name: r1-n1
       ipv4:
-        enable: true
+        enabled: true
       metric: 1
     - if-name: r1-n2
       ipv4:
-        enable: true
+        enabled: true
       metric: 1
     - if-name: r1-n3
       ipv4:
-        enable: true
+        enabled: true
       metric: 1000
     - if-name: r1-r2
       ipv4:
-        enable: true
+        enabled: true
       metric: 1000
     is-type: level-2-only
     segment-routing: mpls

--- a/bdd/tests/configs/tilfa_bfd/r2.yaml
+++ b/bdd/tests/configs/tilfa_bfd/r2.yaml
@@ -18,20 +18,20 @@ router:
     interface:
     - if-name: lo
       ipv4:
-        enable: true
+        enabled: true
         prefix-sid:
           index: 600
     - if-name: r2-n1
       ipv4:
-        enable: true
+        enabled: true
       metric: 1
     - if-name: r2-r1
       ipv4:
-        enable: true
+        enabled: true
       metric: 1000
     - if-name: r2-r3
       ipv4:
-        enable: true
+        enabled: true
       metric: 1000
     is-type: level-2-only
     segment-routing: mpls

--- a/bdd/tests/configs/tilfa_bfd/r3.yaml
+++ b/bdd/tests/configs/tilfa_bfd/r3.yaml
@@ -15,16 +15,16 @@ router:
     interface:
     - if-name: lo
       ipv4:
-        enable: true
+        enabled: true
         prefix-sid:
           index: 700
     - if-name: r3-r2
       ipv4:
-        enable: true
+        enabled: true
       metric: 1000
     - if-name: r3-d
       ipv4:
-        enable: true
+        enabled: true
       metric: 1
     is-type: level-2-only
     segment-routing: mpls

--- a/bdd/tests/configs/tilfa_bfd/s.yaml
+++ b/bdd/tests/configs/tilfa_bfd/s.yaml
@@ -18,22 +18,22 @@ router:
     interface:
     - if-name: lo
       ipv4:
-        enable: true
+        enabled: true
         prefix-sid:
           index: 100
     - if-name: s-n1
       ipv4:
-        enable: true
+        enabled: true
       metric: 1
       bfd:
-        enable: true
+        enabled: true
     - if-name: s-n2
       ipv4:
-        enable: true
+        enabled: true
       metric: 1
     - if-name: s-n3
       ipv4:
-        enable: true
+        enabled: true
       metric: 1000
     is-type: level-2-only
     segment-routing: mpls

--- a/bdd/tests/configs/tilfa_classic_srv6/d.yaml
+++ b/bdd/tests/configs/tilfa_classic_srv6/d.yaml
@@ -32,17 +32,17 @@ router:
     interface:
     - if-name: lo
       ipv6:
-        enable: true
+        enabled: true
     - if-name: d-n1
       network-type: point-to-point
       metric: 1
       ipv6:
-        enable: true
+        enabled: true
     - if-name: d-r3
       network-type: point-to-point
       metric: 1
       ipv6:
-        enable: true
+        enabled: true
   bgp:
     global:
       as: 65000

--- a/bdd/tests/configs/tilfa_classic_srv6/n1.yaml
+++ b/bdd/tests/configs/tilfa_classic_srv6/n1.yaml
@@ -34,24 +34,24 @@ router:
     interface:
     - if-name: lo
       ipv6:
-        enable: true
+        enabled: true
     - if-name: n1-s
       network-type: point-to-point
       metric: 1
       ipv6:
-        enable: true
+        enabled: true
     - if-name: n1-r1
       network-type: point-to-point
       metric: 1
       ipv6:
-        enable: true
+        enabled: true
     - if-name: n1-r2
       network-type: point-to-point
       metric: 1
       ipv6:
-        enable: true
+        enabled: true
     - if-name: n1-d
       network-type: point-to-point
       metric: 1
       ipv6:
-        enable: true
+        enabled: true

--- a/bdd/tests/configs/tilfa_classic_srv6/n2.yaml
+++ b/bdd/tests/configs/tilfa_classic_srv6/n2.yaml
@@ -28,14 +28,14 @@ router:
     interface:
     - if-name: lo
       ipv6:
-        enable: true
+        enabled: true
     - if-name: n2-s
       network-type: point-to-point
       metric: 1
       ipv6:
-        enable: true
+        enabled: true
     - if-name: n2-r1
       network-type: point-to-point
       metric: 1
       ipv6:
-        enable: true
+        enabled: true

--- a/bdd/tests/configs/tilfa_classic_srv6/n3.yaml
+++ b/bdd/tests/configs/tilfa_classic_srv6/n3.yaml
@@ -28,14 +28,14 @@ router:
     interface:
     - if-name: lo
       ipv6:
-        enable: true
+        enabled: true
     - if-name: n3-s
       network-type: point-to-point
       metric: 1000
       ipv6:
-        enable: true
+        enabled: true
     - if-name: n3-r1
       network-type: point-to-point
       metric: 1000
       ipv6:
-        enable: true
+        enabled: true

--- a/bdd/tests/configs/tilfa_classic_srv6/r1.yaml
+++ b/bdd/tests/configs/tilfa_classic_srv6/r1.yaml
@@ -34,24 +34,24 @@ router:
     interface:
     - if-name: lo
       ipv6:
-        enable: true
+        enabled: true
     - if-name: r1-n1
       network-type: point-to-point
       metric: 1
       ipv6:
-        enable: true
+        enabled: true
     - if-name: r1-n2
       network-type: point-to-point
       metric: 1
       ipv6:
-        enable: true
+        enabled: true
     - if-name: r1-n3
       network-type: point-to-point
       metric: 1000
       ipv6:
-        enable: true
+        enabled: true
     - if-name: r1-r2
       network-type: point-to-point
       metric: 1000
       ipv6:
-        enable: true
+        enabled: true

--- a/bdd/tests/configs/tilfa_classic_srv6/r2.yaml
+++ b/bdd/tests/configs/tilfa_classic_srv6/r2.yaml
@@ -31,19 +31,19 @@ router:
     interface:
     - if-name: lo
       ipv6:
-        enable: true
+        enabled: true
     - if-name: r2-n1
       network-type: point-to-point
       metric: 1
       ipv6:
-        enable: true
+        enabled: true
     - if-name: r2-r1
       network-type: point-to-point
       metric: 1000
       ipv6:
-        enable: true
+        enabled: true
     - if-name: r2-r3
       network-type: point-to-point
       metric: 1000
       ipv6:
-        enable: true
+        enabled: true

--- a/bdd/tests/configs/tilfa_classic_srv6/r3.yaml
+++ b/bdd/tests/configs/tilfa_classic_srv6/r3.yaml
@@ -28,14 +28,14 @@ router:
     interface:
     - if-name: lo
       ipv6:
-        enable: true
+        enabled: true
     - if-name: r3-r2
       network-type: point-to-point
       metric: 1000
       ipv6:
-        enable: true
+        enabled: true
     - if-name: r3-d
       network-type: point-to-point
       metric: 1
       ipv6:
-        enable: true
+        enabled: true

--- a/bdd/tests/configs/tilfa_classic_srv6/s.yaml
+++ b/bdd/tests/configs/tilfa_classic_srv6/s.yaml
@@ -36,22 +36,22 @@ router:
     interface:
     - if-name: lo
       ipv6:
-        enable: true
+        enabled: true
     - if-name: s-n1
       network-type: point-to-point
       metric: 1
       ipv6:
-        enable: true
+        enabled: true
     - if-name: s-n2
       network-type: point-to-point
       metric: 1
       ipv6:
-        enable: true
+        enabled: true
     - if-name: s-n3
       network-type: point-to-point
       metric: 1000
       ipv6:
-        enable: true
+        enabled: true
   bgp:
     global:
       as: 65000

--- a/bdd/tests/configs/tilfa_srv6/d.yaml
+++ b/bdd/tests/configs/tilfa_srv6/d.yaml
@@ -31,17 +31,17 @@ router:
     interface:
     - if-name: lo
       ipv6:
-        enable: true
+        enabled: true
     - if-name: d-n1
       network-type: point-to-point
       metric: 1
       ipv6:
-        enable: true
+        enabled: true
     - if-name: d-r3
       network-type: point-to-point
       metric: 1
       ipv6:
-        enable: true
+        enabled: true
   bgp:
     global:
       as: 65000

--- a/bdd/tests/configs/tilfa_srv6/n1.yaml
+++ b/bdd/tests/configs/tilfa_srv6/n1.yaml
@@ -33,24 +33,24 @@ router:
     interface:
     - if-name: lo
       ipv6:
-        enable: true
+        enabled: true
     - if-name: n1-s
       network-type: point-to-point
       metric: 1
       ipv6:
-        enable: true
+        enabled: true
     - if-name: n1-r1
       network-type: point-to-point
       metric: 1
       ipv6:
-        enable: true
+        enabled: true
     - if-name: n1-r2
       network-type: point-to-point
       metric: 1
       ipv6:
-        enable: true
+        enabled: true
     - if-name: n1-d
       network-type: point-to-point
       metric: 1
       ipv6:
-        enable: true
+        enabled: true

--- a/bdd/tests/configs/tilfa_srv6/n2.yaml
+++ b/bdd/tests/configs/tilfa_srv6/n2.yaml
@@ -27,14 +27,14 @@ router:
     interface:
     - if-name: lo
       ipv6:
-        enable: true
+        enabled: true
     - if-name: n2-s
       network-type: point-to-point
       metric: 1
       ipv6:
-        enable: true
+        enabled: true
     - if-name: n2-r1
       network-type: point-to-point
       metric: 1
       ipv6:
-        enable: true
+        enabled: true

--- a/bdd/tests/configs/tilfa_srv6/n3.yaml
+++ b/bdd/tests/configs/tilfa_srv6/n3.yaml
@@ -27,14 +27,14 @@ router:
     interface:
     - if-name: lo
       ipv6:
-        enable: true
+        enabled: true
     - if-name: n3-s
       network-type: point-to-point
       metric: 1000
       ipv6:
-        enable: true
+        enabled: true
     - if-name: n3-r1
       network-type: point-to-point
       metric: 1000
       ipv6:
-        enable: true
+        enabled: true

--- a/bdd/tests/configs/tilfa_srv6/r1.yaml
+++ b/bdd/tests/configs/tilfa_srv6/r1.yaml
@@ -33,24 +33,24 @@ router:
     interface:
     - if-name: lo
       ipv6:
-        enable: true
+        enabled: true
     - if-name: r1-n1
       network-type: point-to-point
       metric: 1
       ipv6:
-        enable: true
+        enabled: true
     - if-name: r1-n2
       network-type: point-to-point
       metric: 1
       ipv6:
-        enable: true
+        enabled: true
     - if-name: r1-n3
       network-type: point-to-point
       metric: 1000
       ipv6:
-        enable: true
+        enabled: true
     - if-name: r1-r2
       network-type: point-to-point
       metric: 1000
       ipv6:
-        enable: true
+        enabled: true

--- a/bdd/tests/configs/tilfa_srv6/r2.yaml
+++ b/bdd/tests/configs/tilfa_srv6/r2.yaml
@@ -30,19 +30,19 @@ router:
     interface:
     - if-name: lo
       ipv6:
-        enable: true
+        enabled: true
     - if-name: r2-n1
       network-type: point-to-point
       metric: 1
       ipv6:
-        enable: true
+        enabled: true
     - if-name: r2-r1
       network-type: point-to-point
       metric: 1000
       ipv6:
-        enable: true
+        enabled: true
     - if-name: r2-r3
       network-type: point-to-point
       metric: 1000
       ipv6:
-        enable: true
+        enabled: true

--- a/bdd/tests/configs/tilfa_srv6/r3.yaml
+++ b/bdd/tests/configs/tilfa_srv6/r3.yaml
@@ -27,14 +27,14 @@ router:
     interface:
     - if-name: lo
       ipv6:
-        enable: true
+        enabled: true
     - if-name: r3-r2
       network-type: point-to-point
       metric: 1000
       ipv6:
-        enable: true
+        enabled: true
     - if-name: r3-d
       network-type: point-to-point
       metric: 1
       ipv6:
-        enable: true
+        enabled: true

--- a/bdd/tests/configs/tilfa_srv6/s.yaml
+++ b/bdd/tests/configs/tilfa_srv6/s.yaml
@@ -35,22 +35,22 @@ router:
     interface:
     - if-name: lo
       ipv6:
-        enable: true
+        enabled: true
     - if-name: s-n1
       network-type: point-to-point
       metric: 1
       ipv6:
-        enable: true
+        enabled: true
     - if-name: s-n2
       network-type: point-to-point
       metric: 1
       ipv6:
-        enable: true
+        enabled: true
     - if-name: s-n3
       network-type: point-to-point
       metric: 1000
       ipv6:
-        enable: true
+        enabled: true
   bgp:
     global:
       as: 65000

--- a/bdd/tests/configs/vrf_phantom_instance/z1.yaml
+++ b/bdd/tests/configs/vrf_phantom_instance/z1.yaml
@@ -27,13 +27,13 @@ router:
     - if-name: lo
       circuit-type: level-2-only
       ipv4:
-        enable: true
+        enabled: true
       ipv6:
-        enable: true
+        enabled: true
   ospf:
     router-id: 10.0.0.1
     area:
     - area-id: 0.0.0.0
       interface:
       - if-name: lo
-        enable: true
+        enabled: true

--- a/bdd/tests/features/isis_afi_enable.feature
+++ b/bdd/tests/features/isis_afi_enable.feature
@@ -51,7 +51,7 @@ Feature: IS-IS re-originates its LSP when an interface address-family is toggled
 
   Scenario: Enabling IPv6 on the loopback re-originates the LSP and advertises the prefix
     Given the test topology exists
-    # Re-apply a1's config with one line added: `ipv6 enable true` on lo. The
+    # Re-apply a1's config with one line added: `ipv6 enabled true` on lo. The
     # diff-based apply turns that single leaf on. With the fix, a1 immediately
     # re-originates its L2 LSP carrying 2001:db8::1/128 in the IPv6
     # Reachability TLV; a2 floods it in, runs SPF, and installs the route.

--- a/bdd/tests/features/isis_endx_ipv6.feature
+++ b/bdd/tests/features/isis_endx_ipv6.feature
@@ -20,7 +20,7 @@ Feature: IS-IS SRv6 End.X (adjacency) SID is gated on the neighbor's IPv6
 
   x1 runs SRv6 with a classic locator, so it owns an End SID and would carve
   an End.X for each IPv6-capable adjacency. The x1–x2 IS-IS circuit starts
-  IPv4-only (IS-IS `ipv4 enable` only), so x2 advertises no IPv6 and x1 must
+  IPv4-only (IS-IS `ipv4 enabled` only), so x2 advertises no IPv6 and x1 must
   NOT allocate an End.X for it. A later scenario enables IPv6 on the circuit;
   x2 then advertises IPv6 and x1 allocates the End.X by re-evaluation.
 
@@ -53,7 +53,7 @@ Feature: IS-IS SRv6 End.X (adjacency) SID is gated on the neighbor's IPv6
   Scenario: Enabling IPv6 on the neighbor re-evaluates and allocates the End.X SID
     Given the test topology exists
     # Turn IPv6 on for the IS-IS circuit at both ends. The diff-based apply
-    # adds `ipv6 enable true`; the adjacency stays Up. x2 now advertises the
+    # adds `ipv6 enabled true`; the adjacency stays Up. x2 now advertises the
     # IPv6 NLPID and an IPv6 link-local, so x1 re-evaluates this neighbor,
     # allocates an End.X SID, and re-originates its LSP.
     When I apply config "x1-v6.conf" to namespace "x1"

--- a/book/src/ch-02-08-bgp-bfd.md
+++ b/book/src/ch-02-08-bgp-bfd.md
@@ -25,7 +25,7 @@ BFD is a flat block under the neighbour. The minimal form is just
 router bgp {
   neighbor 10.0.0.2 {
     remote-as 65002;
-    bfd { enable true; }
+    bfd { enabled true; }
   }
 }
 ```
@@ -37,7 +37,7 @@ overridden per neighbour (see [Instance-level defaults](#instance-level-defaults
 
 | Leaf | Type | Default | Meaning |
 |---|---|---|---|
-| `enable` | boolean | _(off)_ | Attach (or, on `false` / delete, detach) a BFD session for this neighbour. |
+| `enabled` | boolean | _(off)_ | Attach (or, on `false` / delete, detach) a BFD session for this neighbour. |
 | `multihop` | boolean | *inferred* | Force the hop mode. Unset ⇒ inferred (see below). Per-neighbour only. |
 | `minimum-ttl` | 1–254 | 254 | Multi-hop only: lowest accepted received TTL (RFC 5883). Ignored single-hop. Per-neighbour only. |
 | `echo-mode` | `transmit` \| `receive` \| `both` | _(off)_ | [Echo function](ch-10-00-bfd.md#echo-function) role — **single-hop only** (see [Echo](#echo)). |
@@ -72,7 +72,7 @@ router bgp {
     remote-as 65002;
     update-source 10.0.0.1;
     bfd {
-      enable true;
+      enabled true;
       multihop true;       // eBGP-over-loopback; iBGP would infer this
       minimum-ttl 250;
     }
@@ -103,7 +103,7 @@ router bgp {
   neighbor 10.0.0.2 {        // directly-connected eBGP
     remote-as 65002;
     bfd {
-      enable true;
+      enabled true;
       echo-mode both;
       echo-transmit-interval 50;
       echo-receive-interval 50;
@@ -126,7 +126,7 @@ router bgp {
   neighbor 10.0.0.2 {        // directly-connected eBGP
     remote-as 65002;
     bfd {
-      enable true;
+      enabled true;
       detect-offload true;   // expiration detection in kernel/XDP
     }
   }
@@ -144,15 +144,15 @@ same keying also lets the Echo helper attach for BGP neighbours.
 
 A `bfd {}` block directly under `router bgp` supplies defaults for **every**
 neighbour; the effective value of each leaf is the per-neighbour setting if
-present, else the instance default, else the hard default. `enable true` at the
+present, else the instance default, else the hard default. `enabled true` at the
 instance level **blanket-enables** BFD on all neighbours; a per-neighbour
-`bfd { enable false }` opts one out. (`multihop` / `minimum-ttl` are
+`bfd { enabled false }` opts one out. (`multihop` / `minimum-ttl` are
 per-neighbour only — they are not inherited.)
 
 ```
 router bgp {
   bfd {
-    enable true;          // BFD on every neighbour…
+    enabled true;          // BFD on every neighbour…
     echo-mode receive;    // …default Echo role (single-hop neighbours)
   }
   neighbor 10.0.0.2 {

--- a/book/src/ch-02-19-bgp-interas-option-c.md
+++ b/book/src/ch-02-19-bgp-interas-option-c.md
@@ -56,11 +56,11 @@ router:
     segment-routing: mpls
     interface:
     - if-name: lo
-      ipv4: { enable: true, prefix-sid: { index: 1 } }
+      ipv4: { enabled: true, prefix-sid: { index: 1 } }
     - if-name: p1
       network-type: point-to-point
       metric: 10
-      ipv4: { enable: true }
+      ipv4: { enabled: true }
 ```
 
 This gives `pe1` a transport LSP to `asbr1` (its BGP-LU peer's

--- a/book/src/ch-02-35-bgp-mup.md
+++ b/book/src/ch-02-35-bgp-mup.md
@@ -106,7 +106,7 @@ router bgp {
   # Turn on the controller: the PFCP/N4 listener + route origination.
   # The `mup-c` block sits directly under the BGP instance.
   mup-c {
-    enable true;
+    enabled true;
     controller-address fcbb:bb01::1;
     pfcp {
       listen-address 192.168.0.1;
@@ -131,7 +131,7 @@ vrf mobile-up {
 }
 ```
 
-* **`enable true`** spawns the in-process controller. It is configured
+* **`enabled true`** spawns the in-process controller. It is configured
   under the BGP instance (not as a separate daemon) so that it is handed
   the BGP instance's own channel, the same way a per-VRF BGP instance is
   — route origination is a direct in-process call, not a cross-process

--- a/book/src/ch-07-03-isis-bfd.md
+++ b/book/src/ch-07-03-isis-bfd.md
@@ -18,7 +18,7 @@ BFD is a flat block under the IS-IS interface:
 ```
 router isis {
   interface eth0 {
-    bfd { enable true; }
+    bfd { enabled true; }
   }
 }
 ```
@@ -31,7 +31,7 @@ interface, overridden per interface (see
 
 | Leaf | Type | Default | Meaning |
 |---|---|---|---|
-| `enable` | boolean | _(off)_ | Attach (or detach) BFD for adjacencies on this interface. |
+| `enabled` | boolean | _(off)_ | Attach (or detach) BFD for adjacencies on this interface. |
 | `echo-mode` | `transmit` \| `receive` \| `both` | _(off)_ | Enable the [BFD Echo function](ch-10-00-bfd.md#echo-function) on this interface's single-hop adjacencies (IPv4 or IPv6). |
 | `echo-transmit-interval` | uint (ms) | `50` | Rate we originate Echo at (`transmit` / `both`). |
 | `echo-receive-interval` | uint (ms) | `50` | Advertised Required Min Echo RX (`receive` / `both`). |
@@ -61,7 +61,7 @@ zebra-rs therefore pins a neighbour whose BFD session is `Down` at the
 reports the session `Down` (alongside the adjacency teardown), and
 lifted the moment BFD reports it `Up` again — the next received IIH
 then promotes the neighbour normally. It applies per neighbour and
-level, and only while `bfd enable` is in effect for the interface.
+level, and only while `bfd enabled` is in effect for the interface.
 
 > To make this work, the BFD session deliberately stays subscribed
 > across the teardown — it keeps probing while the adjacency is down,
@@ -83,7 +83,7 @@ helper, whose XDP reflector handles 0x0800 and 0x86DD frames alike.
 router isis {
   interface eth0 {
     bfd {
-      enable true;
+      enabled true;
       echo-mode both;
       echo-transmit-interval 50;
       echo-receive-interval 50;
@@ -108,7 +108,7 @@ for the mechanism and guard-rails.
 router isis {
   interface eth0 {
     bfd {
-      enable true;
+      enabled true;
       detect-offload true;   // expiration detection in kernel/XDP
     }
   }
@@ -119,14 +119,14 @@ router isis {
 
 A `bfd {}` block directly under `router isis` supplies defaults for **every**
 interface; each leaf's effective value is the per-interface setting if present,
-else the instance default, else the hard default. `enable true` at the instance
+else the instance default, else the hard default. `enabled true` at the instance
 level **blanket-enables** BFD on all IS-IS interfaces; a per-interface
-`bfd { enable false }` opts one out.
+`bfd { enabled false }` opts one out.
 
 ```
 router isis {
   bfd {
-    enable true;          // BFD on every interface…
+    enabled true;          // BFD on every interface…
     echo-mode receive;    // …default Echo role
   }
   interface eth0 {
@@ -144,7 +144,7 @@ show bfd peers <neighbor-address>
 
 If a session stays `Down` with a remote discriminator of `0x0`, the
 local side is transmitting but nothing is coming back — confirm the
-neighbour also has `bfd enable` on its side of the link and that UDP
+neighbour also has `bfd enabled` on its side of the link and that UDP
 3784 is not filtered. See the
 [overview](ch-10-00-bfd.md#verifying-sessions) for the full command set.
 

--- a/book/src/ch-07-07-isis-passive.md
+++ b/book/src/ch-07-07-isis-passive.md
@@ -26,7 +26,7 @@ router isis {
   net 49.0000.0000.0000.0001.00;
   interface lo {
     ipv4 {
-      enable true;
+      enabled true;
       prefix-sid {
         index 100;
       }
@@ -35,7 +35,7 @@ router isis {
   interface eth2 {
     passive true;          // advertise eth2's subnet, run no Hellos on it
     ipv4 {
-      enable true;
+      enabled true;
     }
   }
 }
@@ -50,7 +50,7 @@ router:
     - if-name: eth2
       passive: true
       ipv4:
-        enable: true
+        enabled: true
 ```
 
 What `passive` changes, and what it does not:
@@ -59,7 +59,7 @@ What `passive` changes, and what it does not:
   ignored, so **no adjacency** ever forms over it.
 - The interface's prefixes **are still advertised** into the LSP. Prefix
   advertisement is gated on the interface being IS-IS-enabled
-  (`ipv4`/`ipv6 enable`) and participating at the circuit's level — not
+  (`ipv4`/`ipv6 enabled`) and participating at the circuit's level — not
   on any adjacency — so a passive circuit's subnet stays reachable from
   the rest of the network.
 - Any Prefix-SID configured on the interface is advertised as usual.
@@ -75,7 +75,7 @@ set**. Running the Hello protocol on a loopback would make the router
 peer with itself (the loopback echoes its own Hellos), which is never
 useful, so zebra-rs suppresses Hellos on every loopback and still
 advertises its prefixes. You therefore do **not** need to write `passive
-true` on `lo`; enabling IS-IS (`ipv4 { enable true; }`) is enough to get
+true` on `lo`; enabling IS-IS (`ipv4 { enabled true; }`) is enough to get
 the loopback advertised.
 
 ## The self-sourced-Hello guard

--- a/book/src/ch-08-02-ospf-bfd.md
+++ b/book/src/ch-08-02-ospf-bfd.md
@@ -20,7 +20,7 @@ applies to OSPFv2 (`router ospf`) and OSPFv3 (`router ospfv3`):
 router ospf {
   area 0 {
     interface eth0 {
-      bfd { enable true; }
+      bfd { enabled true; }
     }
   }
 }
@@ -36,7 +36,7 @@ The same `bfd {}` leaves can also be set once at the **instance level**
 
 | Leaf | Type | Default | Meaning |
 |---|---|---|---|
-| `enable` | boolean | `false` | Attach (or detach) BFD for neighbours on this interface. |
+| `enabled` | boolean | `false` | Attach (or detach) BFD for neighbours on this interface. |
 | `min-neighbor-state` | `two-way` \| `full` | `two-way` | Neighbour state at which the session starts / stops. |
 | `echo-mode` | `transmit` \| `receive` \| `both` | _(off)_ | Enable the [BFD Echo function](ch-10-00-bfd.md#echo-function) on this interface's sessions (IPv4 on OSPFv2, IPv6 on OSPFv3), choosing which half is active. |
 | `echo-transmit-interval` | uint (ms) | `50` | Rate we originate Echo at (`transmit` / `both`). |
@@ -68,7 +68,7 @@ router ospf {
   area 0 {
     interface eth0 {
       bfd {
-        enable true;
+        enabled true;
         min-neighbor-state full;   // Cisco-style; default is two-way
       }
     }
@@ -97,7 +97,7 @@ router ospf {
   area 0 {
     interface eth0 {
       bfd {
-        enable true;
+        enabled true;
         echo-mode both;
         echo-transmit-interval 50;   // ms; rate we send Echo (default 50)
         echo-receive-interval 50;    // ms; advertised RX floor (default 50)
@@ -132,7 +132,7 @@ router ospf {
   area 0 {
     interface eth0 {
       bfd {
-        enable true;
+        enabled true;
         detect-offload true;   // expiration detection in kernel/XDP
       }
     }
@@ -161,13 +161,13 @@ defaults for **every** interface in the instance. Each leaf is the same as the
 per-interface block, and the effective value for an interface is its own
 setting if present, otherwise the instance default, otherwise the hard default.
 
-`enable true` at the instance level **blanket-enables** BFD on all of the
-instance's interfaces; a per-interface `bfd { enable false }` opts one out.
+`enabled true` at the instance level **blanket-enables** BFD on all of the
+instance's interfaces; a per-interface `bfd { enabled false }` opts one out.
 
 ```
 router ospf {
   bfd {
-    enable true;            // BFD on every interface…
+    enabled true;            // BFD on every interface…
     echo-mode receive;      // …default Echo role: reflect only
     echo-receive-interval 50;
   }
@@ -176,7 +176,7 @@ router ospf {
       bfd { echo-mode both; }   // eth0 also originates; inherits enable + interval
     }
     interface eth1 {
-      bfd { enable false; }     // opt eth1 out of the blanket enable
+      bfd { enabled false; }     // opt eth1 out of the blanket enable
     }
   }
 }
@@ -200,6 +200,6 @@ show bfd peers <neighbor-address>
 ```
 
 If a session stays `Down` with a remote discriminator of `0x0`, confirm
-the neighbour also has `bfd enable` on its side and that UDP 3784 is not
+the neighbour also has `bfd enabled` on its side and that UDP 3784 is not
 filtered on the link. See the
 [overview](ch-10-00-bfd.md#verifying-sessions) for the full command set.

--- a/book/src/ch-08-04-ospf-minimum-working-example.md
+++ b/book/src/ch-08-04-ospf-minimum-working-example.md
@@ -5,7 +5,7 @@ shaped around the standard `area { interface }` hierarchy: each
 participating interface is declared inside the area it belongs to.
 There is no separate `network X area Y` table — an interface
 participates in OSPF if and only if it appears under some area with
-`enable true`, and the area it belongs to is implicit from the parent
+`enabled true`, and the area it belongs to is implicit from the parent
 list entry.
 
 The smallest useful topology is two routers on a shared segment, both
@@ -17,7 +17,7 @@ router ospf {
   router-id 10.0.0.1;
   area 0 {
     interface enp0s6 {
-      enable true;
+      enabled true;
     }
   }
 }
@@ -29,7 +29,7 @@ router ospf {
   router-id 10.0.0.2;
   area 0 {
     interface enp0s6 {
-      enable true;
+      enabled true;
     }
   }
 }

--- a/book/src/ch-08-05-ospf-area-configuration.md
+++ b/book/src/ch-08-05-ospf-area-configuration.md
@@ -9,12 +9,12 @@ router ospf {
   router-id 10.0.0.1;
   area 0 {
     interface enp0s6 {
-      enable true;
+      enabled true;
     }
   }
   area 0.0.0.1 {
     interface enp0s7 {
-      enable true;
+      enabled true;
     }
   }
 }

--- a/book/src/ch-08-06-ospf-interface-area-move.md
+++ b/book/src/ch-08-06-ospf-interface-area-move.md
@@ -5,7 +5,7 @@ interface from area 0 to area 0.0.0.1 is two operations:
 
 ```
 no router ospf area 0 interface enp0s6
-router ospf area 0.0.0.1 interface enp0s6 enable true
+router ospf area 0.0.0.1 interface enp0s6 enabled true
 ```
 
 zebra-rs handles this internally via a `Disable → Enable` transition
@@ -14,6 +14,6 @@ new area-id), which tears down the old IFSM state machine and starts
 a fresh one in the new area. No daemon restart is required.
 
 If the same interface name accidentally appears under two areas at
-once, the second area's `enable true` wins (the link's
+once, the second area's `enabled true` wins (the link's
 `config.area` is overwritten). This is not a supported configuration
 and zebra-rs may add a validation error for it in a future release.

--- a/book/src/ch-08-07-ospf-per-interface.md
+++ b/book/src/ch-08-07-ospf-per-interface.md
@@ -19,7 +19,7 @@ The per-link timers (`hello-interval`, `dead-interval`,
 Notes:
 
 - **`enable`** is the participation switch: an interface runs OSPF if
-  and only if it appears under some area with `enable true`. There is
+  and only if it appears under some area with `enabled true`. There is
   no separate `network X area Y` statement.
 - **`network-type`** selects the interface's OSPF network type,
   mirroring the IS-IS knob of the same name. `broadcast` (the

--- a/book/src/ch-08-08-ospf-timers.md
+++ b/book/src/ch-08-08-ospf-timers.md
@@ -8,7 +8,7 @@ area/interface entry. All defaults match RFC 2328 Appendix C
 router ospf {
   area 0.0.0.1 {
     interface enp0s7 {
-      enable true;
+      enabled true;
       hello-interval 5;
       dead-interval 20;
     }

--- a/book/src/ch-08-09-ospf-segment-routing.md
+++ b/book/src/ch-08-09-ospf-segment-routing.md
@@ -8,7 +8,7 @@ router ospf {
   segment-routing mpls;
   area 0 {
     interface enp0s6 {
-      enable true;
+      enabled true;
       prefix-sid {
         index 16001;
       }

--- a/book/src/ch-08-11-ospf-frr-cross-reference.md
+++ b/book/src/ch-08-11-ospf-frr-cross-reference.md
@@ -6,7 +6,7 @@ configuration surface to the equivalent FRR `ospfd` commands.
 | zebra-rs YANG | FRR `ospfd` command |
 |---|---|
 | `router-id` | `ospf router-id` |
-| `area/<id>/interface/<n>/enable true` | `network <prefix> area <id>` (interface inferred from prefix) |
+| `area/<id>/interface/<n>/enabled true` | `network <prefix> area <id>` (interface inferred from prefix) |
 | `area/<id>/interface/<n>/priority` | `ip ospf priority` (interface) |
 | `area/<id>/interface/<n>/hello-interval` | `ip ospf hello-interval` (interface) |
 | `area/<id>/interface/<n>/dead-interval` | `ip ospf dead-interval` (interface) |

--- a/book/src/ch-08-13-ospf-area-types.md
+++ b/book/src/ch-08-13-ospf-area-types.md
@@ -45,7 +45,7 @@ router ospf {
   area 0.0.0.1 {
     area-type stub;
     interface enp0s7 {
-      enable true;
+      enabled true;
     }
   }
 }
@@ -70,14 +70,14 @@ originating a default Type-7 into the area (RFC 3101 §2.3):
 router ospf {
   area 0 {
     interface enp0s6 {
-      enable true;
+      enabled true;
     }
   }
   area 0.0.0.1 {
     area-type nssa;
     nssa-default-originate true;
     interface enp0s7 {
-      enable true;
+      enabled true;
     }
   }
 }
@@ -99,10 +99,10 @@ router ospf {
       }
     }
     interface lo {
-      enable true;
+      enabled true;
     }
     interface enp0s8 {
-      enable true;
+      enabled true;
     }
   }
 }

--- a/book/src/ch-08-14-ospf-multi-area-abr.md
+++ b/book/src/ch-08-14-ospf-multi-area-abr.md
@@ -12,16 +12,16 @@ router ospf {
   router-id 10.0.0.1;
   area 0 {
     interface lo {
-      enable true;
+      enabled true;
     }
     interface enp0s6 {
-      enable true;
+      enabled true;
       network-type point-to-point;
     }
   }
   area 0.0.0.1 {
     interface enp0s7 {
-      enable true;
+      enabled true;
       network-type point-to-point;
     }
   }
@@ -72,7 +72,7 @@ router ospf {
       not-advertise true;
     }
     interface enp0s7 {
-      enable true;
+      enabled true;
     }
   }
 }
@@ -150,7 +150,7 @@ area**):
 router ospf {
   area 0.0.0.1 {
     virtual-link 10.0.0.2;         # remote ABR's router-id
-    interface enp0s7 { enable true; }
+    interface enp0s7 { enabled true; }
   }
 }
 ```

--- a/book/src/ch-08-15-ospf-redistribution.md
+++ b/book/src/ch-08-15-ospf-redistribution.md
@@ -17,10 +17,10 @@ router ospf {
   }
   area 0 {
     interface lo {
-      enable true;
+      enabled true;
     }
     interface enp0s6 {
-      enable true;
+      enabled true;
       network-type point-to-point;
     }
   }

--- a/book/src/ch-08-16-ospf-authentication.md
+++ b/book/src/ch-08-16-ospf-authentication.md
@@ -31,7 +31,7 @@ Both ends must carry the same password:
 router ospf {
   area 0 {
     interface enp0s6 {
-      enable true;
+      enabled true;
       authentication simple;
       authentication-key MYPASS;
     }
@@ -45,7 +45,7 @@ router ospf {
 router ospf {
   area 0 {
     interface enp0s6 {
-      enable true;
+      enabled true;
       authentication message-digest;
       message-digest-key 1 {
         md5 SECRET;
@@ -64,7 +64,7 @@ inside a `crypto-key` entry:
 router ospf {
   area 0 {
     interface enp0s6 {
-      enable true;
+      enabled true;
       authentication message-digest;
       crypto-key 1 {
         hmac-sha-256 SECRET;
@@ -110,7 +110,7 @@ key-chains {
 router ospf {
   area 0 {
     interface enp0s6 {
-      enable true;
+      enabled true;
       authentication message-digest;
       key-chain OSPF-KC;
     }

--- a/book/src/ch-09-00-twamp-stamp.md
+++ b/book/src/ch-09-00-twamp-stamp.md
@@ -126,7 +126,7 @@ router isis {
     network-type point-to-point;
     te-metric {
       measurement {
-        enable true;
+        enabled true;
         interval 100;        # probe TX interval, ms  (100..60000, default 1000)
         damping-period 2;    # export window, seconds  (1..3600, default 30)
       }

--- a/book/src/ch-10-00-bfd.md
+++ b/book/src/ch-10-00-bfd.md
@@ -37,7 +37,7 @@ neighbour is then a single per-neighbour / per-interface flag:
 router ospf {
   area 0 {
     interface eth0 {
-      bfd { enable true; }
+      bfd { enabled true; }
     }
   }
 }

--- a/book/src/ch-12-00-nexthop-protect.md
+++ b/book/src/ch-12-00-nexthop-protect.md
@@ -56,8 +56,8 @@ router isis {
   segment-routing mpls;
   fast-reroute { ti-lfa; }
   interface eth0 {
-    ipv4 { enable true; }
-    bfd { enable true; }      // sub-second detection on this adjacency
+    ipv4 { enabled true; }
+    bfd { enabled true; }      // sub-second detection on this adjacency
   }
 }
 ```
@@ -70,9 +70,9 @@ router ospf {
   fast-reroute { ti-lfa; }
   area 0 {
     interface eth0 {
-      enable true;
+      enabled true;
       network-type point-to-point;
-      bfd { enable true; }
+      bfd { enabled true; }
     }
   }
 }

--- a/book/src/ch-15-01-ospfv3-minimum-working-example.md
+++ b/book/src/ch-15-01-ospfv3-minimum-working-example.md
@@ -2,7 +2,7 @@
 
 OSPFv3 configuration lives under `router ospfv3` and uses the same
 `area { interface }` hierarchy as OSPFv2: an interface participates
-if and only if it appears under some area with `enable true`. The
+if and only if it appears under some area with `enabled true`. The
 smallest useful topology is two routers on a point-to-point link.
 
 R1:
@@ -14,10 +14,10 @@ router ospfv3 {
   router-id 10.0.0.1;
   area 0 {
     interface lo {
-      enable true;
+      enabled true;
     }
     interface enp0s6 {
-      enable true;
+      enabled true;
       network-type point-to-point;
     }
   }
@@ -33,10 +33,10 @@ router ospfv3 {
   router-id 10.0.0.2;
   area 0 {
     interface lo {
-      enable true;
+      enabled true;
     }
     interface enp0s6 {
-      enable true;
+      enabled true;
       network-type point-to-point;
     }
   }

--- a/book/src/ch-15-02-ospfv3-area-configuration.md
+++ b/book/src/ch-15-02-ospfv3-area-configuration.md
@@ -8,12 +8,12 @@ router ospfv3 {
   router-id 10.0.0.1;
   area 0 {
     interface enp0s6 {
-      enable true;
+      enabled true;
     }
   }
   area 0.0.0.1 {
     interface enp0s7 {
-      enable true;
+      enabled true;
     }
   }
 }

--- a/book/src/ch-15-03-ospfv3-area-types.md
+++ b/book/src/ch-15-03-ospfv3-area-types.md
@@ -32,14 +32,14 @@ The ABR of an NSSA, originating a default into the area:
 router ospfv3 {
   area 0 {
     interface enp0s6 {
-      enable true;
+      enabled true;
     }
   }
   area 0.0.0.1 {
     area-type nssa;
     nssa-default-originate true;
     interface enp0s7 {
-      enable true;
+      enabled true;
     }
   }
 }
@@ -60,10 +60,10 @@ router ospfv3 {
       }
     }
     interface lo {
-      enable true;
+      enabled true;
     }
     interface enp0s8 {
-      enable true;
+      enabled true;
     }
   }
 }

--- a/book/src/ch-15-04-ospfv3-multi-area-abr.md
+++ b/book/src/ch-15-04-ospfv3-multi-area-abr.md
@@ -11,16 +11,16 @@ router ospfv3 {
   router-id 10.0.0.1;
   area 0 {
     interface lo {
-      enable true;
+      enabled true;
     }
     interface enp0s6 {
-      enable true;
+      enabled true;
       network-type point-to-point;
     }
   }
   area 0.0.0.1 {
     interface enp0s7 {
-      enable true;
+      enabled true;
       network-type point-to-point;
     }
   }
@@ -82,7 +82,7 @@ router ospfv3 {
   area 0.0.0.1 {
     range 2001:db8:1::/48;
     interface enp0s7 {
-      enable true;
+      enabled true;
     }
   }
 }

--- a/book/src/ch-15-05-ospfv3-interface-area-move.md
+++ b/book/src/ch-15-05-ospfv3-interface-area-move.md
@@ -5,7 +5,7 @@ an interface from area 0 to area 0.0.0.1 is two operations:
 
 ```
 no router ospfv3 area 0 interface enp0s6
-router ospfv3 area 0.0.0.1 interface enp0s6 enable true
+router ospfv3 area 0.0.0.1 interface enp0s6 enabled true
 ```
 
 Internally this is the same `Disable → Enable` transition pair as
@@ -18,6 +18,6 @@ link-scoped Link-LSA re-originates on the fresh interface state. No
 daemon restart is required.
 
 The same caveat as v2 applies if one interface name accidentally
-appears under two areas at once: the last-applied `enable true`
+appears under two areas at once: the last-applied `enabled true`
 wins, because the link's cached area is a single value. This is not
 a supported configuration.

--- a/book/src/ch-15-06-ospfv3-per-interface.md
+++ b/book/src/ch-15-06-ospfv3-per-interface.md
@@ -11,7 +11,7 @@ core). Timers are covered separately in
 
 | YANG leaf (`/router/ospfv3/area/<id>/interface/<n>/…`) | Default | Range |
 |---|---|---|
-| `enable` | `false` | boolean |
+| `enabled` | `false` | boolean |
 | `network-type` | `broadcast` | `broadcast` \| `point-to-point` |
 | `priority` | 64 | 0..255 |
 | `cost` | 10 | 0..65535 |

--- a/book/src/ch-15-07-ospfv3-timers.md
+++ b/book/src/ch-15-07-ospfv3-timers.md
@@ -8,7 +8,7 @@ versions share the OSPF core's timer constants).
 router ospfv3 {
   area 0 {
     interface enp0s6 {
-      enable true;
+      enabled true;
       hello-interval 5;
       dead-interval 20;
     }

--- a/book/src/ch-15-08-ospfv3-authentication.md
+++ b/book/src/ch-15-08-ospfv3-authentication.md
@@ -26,7 +26,7 @@ How it works on the wire:
 router ospfv3 {
   area 0 {
     interface enp0s6 {
-      enable true;
+      enabled true;
       authentication message-digest;
       crypto-key 1 {
         hmac-sha-256 SECRET;

--- a/book/src/ch-15-09-ospfv3-redistribution.md
+++ b/book/src/ch-15-09-ospfv3-redistribution.md
@@ -28,7 +28,7 @@ router ospfv3 {
   }
   area 0 {
     interface enp0s6 {
-      enable true;
+      enabled true;
     }
   }
 }

--- a/book/src/ch-15-10-ospfv3-segment-routing.md
+++ b/book/src/ch-15-10-ospfv3-segment-routing.md
@@ -13,13 +13,13 @@ router ospfv3 {
   }
   area 0 {
     interface lo {
-      enable true;
+      enabled true;
       prefix-sid {
         index 100;
       }
     }
     interface enp0s6 {
-      enable true;
+      enabled true;
       network-type point-to-point;
     }
   }
@@ -82,7 +82,7 @@ router ospfv3 {
   }
   area 0 {
     interface lo {
-      enable true;
+      enabled true;
       flex-algo-prefix-sid 128 {
         index 1100;
       }

--- a/book/src/ch-15-11-ospfv3-srv6.md
+++ b/book/src/ch-15-11-ospfv3-srv6.md
@@ -27,10 +27,10 @@ router ospfv3 {
   }
   area 0 {
     interface lo {
-      enable true;
+      enabled true;
     }
     interface enp0s6 {
-      enable true;
+      enabled true;
       network-type point-to-point;
     }
   }

--- a/book/src/ch-15-14-ospfv3-frr-cross-reference.md
+++ b/book/src/ch-15-14-ospfv3-frr-cross-reference.md
@@ -9,7 +9,7 @@ interface to an area with a per-interface command.
 | zebra-rs YANG (`router ospfv3 …`) | FRR `ospf6d` command |
 |---|---|
 | `router-id` | `ospf6 router-id` |
-| `area/<id>/interface/<n>/enable true` | `ipv6 ospf6 area <id>` (interface) |
+| `area/<id>/interface/<n>/enabled true` | `ipv6 ospf6 area <id>` (interface) |
 | `area/<id>/interface/<n>/network-type point-to-point` | `ipv6 ospf6 network point-to-point` (interface) |
 | `area/<id>/interface/<n>/priority` | `ipv6 ospf6 priority` (interface) |
 | `area/<id>/interface/<n>/cost` | `ipv6 ospf6 cost` (interface) |

--- a/book/src/ch-15-17-ospfv3-bfd.md
+++ b/book/src/ch-15-17-ospfv3-bfd.md
@@ -14,10 +14,10 @@ interface entry (with instance-level defaults available under
 router ospfv3 {
   area 0 {
     interface enp0s6 {
-      enable true;
+      enabled true;
       network-type point-to-point;
       bfd {
-        enable true;
+        enabled true;
       }
     }
   }

--- a/docs/design/bfd-echo-plan.md
+++ b/docs/design/bfd-echo-plan.md
@@ -29,7 +29,7 @@ Tracks the BFD **Echo function** (RFC 5880 §6.4 / §6.8.5 / §6.8.8 /
 >   (`router ospf|isis|bgp { bfd {} }`) as a default and overridden per
 >   interface / neighbor *per leaf*
 >   (`{Ospf,}LinkBfdConfig::resolve` / `PeerBfdConfig::resolve`); instance
->   `enable true` blanket-enables, a per-link/neighbor `enable false` opts
+>   `enabled true` blanket-enables, a per-link/neighbor `enabled false` opts
 >   out. There is **no global top-level `bfd {}`** container — BFD spawns
 >   eagerly with its first consumer. BGP echo is **single-hop only**
 >   (RFC 5883 multihop has no Echo) — inert on iBGP / multihop eBGP.
@@ -169,12 +169,12 @@ reflector.
 ## Config surface (when/if built)
 
 Mirror FRR. Since standalone `bfd { … }` config was removed this cycle,
-Echo config would live **per-protocol** alongside `bfd { enable; }`:
+Echo config would live **per-protocol** alongside `bfd { enabled; }`:
 
 ```
 # illustrative — not implemented
 router ospf { area 0 { interface eth0 {
-  bfd { enable true; echo-mode true; echo-interval 50; }
+  bfd { enabled true; echo-mode true; echo-interval 50; }
 }}}
 ```
 

--- a/docs/design/bfd-sbfd-stamp-xdp-offload-notes.md
+++ b/docs/design/bfd-sbfd-stamp-xdp-offload-notes.md
@@ -171,7 +171,7 @@ BFD control packets on UDP/3784**.
   start**, so BGP echo was effectively inert. `ConnectedSubnets` now keeps the
   recording ifindex (`ifindex_for`, v6 link-locals excluded), and single-hop
   sessions are keyed by the connected interface. If the address is learned
-  after `bfd enable`, the `RibRx::AddrAdd` hook's `bfd_reconcile_all` re-keys
+  after `bfd enabled`, the `RibRx::AddrAdd` hook's `bfd_reconcile_all` re-keys
   the session (unsubscribe → subscribe). With this, both BGP echo and BGP
   detect-offload actually work.
 - **Validation**: `scripts/veth-detect-test.sh` — with a 600 ms detection

--- a/docs/design/bgp-labeled-unicast.md
+++ b/docs/design/bgp-labeled-unicast.md
@@ -24,8 +24,8 @@ Config surface:
 router {
   bgp {
     neighbor 10.0.0.1 {
-      afi-safi label-v4 { enable true; }
-      afi-safi label-v6 { enable true; }
+      afi-safi label-v4 { enabled true; }
+      afi-safi label-v6 { enabled true; }
     }
     afi-safi label-v4 {
       network 10.0.0.0/24;

--- a/docs/design/stamp-phase1-implementation-plan.md
+++ b/docs/design/stamp-phase1-implementation-plan.md
@@ -172,7 +172,7 @@ New files, mirroring `bfd/` file-for-file where a sibling exists:
 
 3. Pin with parse tests in `config/manager.rs` `yang_load_tests` (`:1263`, the
    `remove_private_as` test is the template): one config path per protocol
-   (`set router isis interface eth0 te-metric measurement enable true`,
+   (`set router isis interface eth0 te-metric measurement enabled true`,
    `set router ospf area 0 interface eth0 te-metric measurement interval 100`) and the three
    show paths. (`configure_mode_loads` / `exec_mode_loads` already gate schema validity.)
 
@@ -278,7 +278,7 @@ New files, mirroring `bfd/` file-for-file where a sibling exists:
    - Both routers run **both** `router isis` (P2P, ipv4 enable) and `router ospf`
      (area 0, `network-type: point-to-point`, `segment-routing: mpls` — required for the
      Extended-Link LSA gate) with
-     `te-metric: { measurement: { enable: true, interval: 100, damping-period: 2 } }`
+     `te-metric: { measurement: { enabled: true, interval: 100, damping-period: 2 } }`
      on the link interface — deliberately exercising the shared-session/multi-client path (D11).
    - Scenario 1 (bring-up): clean env, namespaces, veth, start, apply, wait, ping across.
    - Scenario 2 (IS-IS): `show isis database detail` **eventually contains**

--- a/docs/design/stamp-sr-mpls-te-plan.md
+++ b/docs/design/stamp-sr-mpls-te-plan.md
@@ -342,7 +342,7 @@ router isis {
   interface eth1 {
     te-metric {
       measurement {
-        enable true;
+        enabled true;
         interval 100;        # ms between probes
         damping-period 30;   # s minimum between IGP exports
       }
@@ -358,7 +358,7 @@ router ospf {
     interface eth1 {
       te-metric {
         measurement {
-          enable true;
+          enabled true;
           interval 100;
           damping-period 30;
         }

--- a/offload/xdp-bfd-echo/README.md
+++ b/offload/xdp-bfd-echo/README.md
@@ -190,9 +190,9 @@ router {
       interface enp0s6 {
         bfd {
           echo-mode receive;
-          enable true;
+          enabled true;
         }
-        enable true;
+        enabled true;
       }
     }
   }

--- a/zebra-rs/src/bgp/config.rs
+++ b/zebra-rs/src/bgp/config.rs
@@ -1226,12 +1226,12 @@ fn config_local_as_dual_as(bgp: &mut Bgp, args: Args, op: ConfigOp) -> Option<()
     config_local_as_flag(bgp, args, op, |la, v| la.dual_as = v)
 }
 
-/// `set router bgp neighbor X bfd enable true|false` — flips the
+/// `set router bgp neighbor X bfd enabled true|false` — flips the
 /// Reconcile this neighbor's live BFD subscription with its current
 /// `peer.config.bfd` state. Idempotent and order-independent: every
 /// `/bfd/*` callback funnels through here, so whichever leaf lands last
 /// in a commit leaves the correct session subscribed regardless of the
-/// order `enable` / `multihop` / `minimum-ttl` arrive.
+/// order `enabled` / `multihop` / `minimum-ttl` arrive.
 ///
 /// The desired key is recomputed from scratch (local source, hop mode,
 /// remote). It's compared against `peer.bfd_session_key` — the key we
@@ -1390,7 +1390,7 @@ fn config_peer_bfd_enable(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Option
     let enable = args.boolean()?;
     {
         let peer = bgp.peers.get_mut(&addr)?;
-        // `None` ⇒ inherit `router bgp { bfd { enable } }`; `Some(false)` opts
+        // `None` ⇒ inherit `router bgp { bfd { enabled } }`; `Some(false)` opts
         // this neighbor out of a blanket instance enable.
         peer.config.bfd.enable = op.is_set().then_some(enable);
     }
@@ -1488,7 +1488,7 @@ fn config_peer_bfd_detect_offload(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -
 
 /// Re-reconcile BFD for every neighbor — used by the instance-level
 /// `router bgp { bfd {} }` callbacks, whose defaults (notably a blanket
-/// `enable`) affect neighbors that set nothing of their own, and by the
+/// `enabled`) affect neighbors that set nothing of their own, and by the
 /// `RibRx::AddrAdd`/`AddrDel` handlers, whose connected-interface knowledge
 /// feeds the single-hop session key's ifindex. `bfd_apply` is a per-neighbor
 /// reconcile that diffs against the recorded session key, so this is just a
@@ -1502,7 +1502,7 @@ pub(super) fn bfd_reconcile_all(bgp: &mut Bgp) {
 // ---- instance-level `router bgp { bfd { ... } }` defaults -------------------
 
 /// `router bgp bfd enable <bool>` — blanket-enable BFD on every neighbor
-/// (a per-neighbor `bfd { enable false }` opts one out).
+/// (a per-neighbor `bfd { enabled false }` opts one out).
 fn config_bgp_bfd_enable(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Option<()> {
     let enable = args.boolean()?;
     bgp.bfd.enable = op.is_set().then_some(enable);
@@ -4397,7 +4397,7 @@ impl Bgp {
         // zebra-bgp-bfd.yang. Stores the leaves on
         // `peer.config.bfd` and wires the runtime subscribe /
         // unsubscribe path to the BFD client API.
-        self.callback_peer("/bfd/enable", config_peer_bfd_enable);
+        self.callback_peer("/bfd/enabled", config_peer_bfd_enable);
         self.callback_peer("/bfd/multihop", config_peer_bfd_multihop);
         self.callback_peer("/bfd/minimum-ttl", config_peer_bfd_min_ttl);
         self.callback_peer("/bfd/echo-mode", config_peer_bfd_echo_mode);
@@ -4405,7 +4405,7 @@ impl Bgp {
         self.callback_peer("/bfd/echo-receive-interval", config_peer_bfd_echo_rx);
         self.callback_peer("/bfd/detect-offload", config_peer_bfd_detect_offload);
         // Instance-level `router bgp { bfd { ... } }` defaults.
-        self.callback_add("/router/bgp/bfd/enable", config_bgp_bfd_enable);
+        self.callback_add("/router/bgp/bfd/enabled", config_bgp_bfd_enable);
         self.callback_add("/router/bgp/bfd/echo-mode", config_bgp_bfd_echo_mode);
         self.callback_add(
             "/router/bgp/bfd/echo-transmit-interval",
@@ -4516,7 +4516,7 @@ impl Bgp {
         // MUP controller (`router bgp mup-c …`, draft-ietf-bess-mup-safi).
         // Augmented in by zebra-bgp-mup-controller.yang; the controller
         // task is spawned/torn down at CommitEnd by `apply_mup_c_commit_diff`.
-        self.callback_add("/router/bgp/mup-c/enable", config_mup_c_enable);
+        self.callback_add("/router/bgp/mup-c/enabled", config_mup_c_enable);
         self.callback_add(
             "/router/bgp/mup-c/controller-address",
             config_mup_c_controller_address,
@@ -4847,7 +4847,7 @@ mod bfd_wiring_tests {
         (bgp, bfd_client_rx)
     }
 
-    /// `bfd enable true` on a known iBGP neighbor (the default peer
+    /// `bfd enabled true` on a known iBGP neighbor (the default peer
     /// type) auto-infers multihop and subscribes on the 4784 port.
     #[tokio::test]
     async fn enable_sends_subscribe() {

--- a/zebra-rs/src/bgp/inst.rs
+++ b/zebra-rs/src/bgp/inst.rs
@@ -119,7 +119,7 @@ pub enum Message {
     },
     /// A session/association change reported by the in-process MUP
     /// controller (`src/mup-c/`), which the BGP task spawns when
-    /// `router bgp mup-c enable true` is committed and hands
+    /// `router bgp mup-c enabled true` is committed and hands
     /// `self.tx`. Recorded in [`Bgp::mup_c_view`] for `show bgp
     /// mup-c`; MUP route origination from these lands in a
     /// follow-up. Mirrors the IS-IS `BgpLs` producer seam.
@@ -1045,7 +1045,7 @@ pub struct Bgp {
     pub policy_tx: UnboundedSender<policy::Message>,
     pub policy_rx: UnboundedReceiver<policy::PolicyRx>,
     /// Handle into the BFD instance's client-request channel — used
-    /// by the per-neighbor `bfd { enable }` path to submit
+    /// by the per-neighbor `bfd { enabled }` path to submit
     /// `ClientReq::Subscribe` / `Unsubscribe`. `None` means BFD has
     /// not (yet) been configured: BGP silently skips its BFD attach
     /// logic in that case. Captured at spawn time from

--- a/zebra-rs/src/bgp/peer.rs
+++ b/zebra-rs/src/bgp/peer.rs
@@ -349,14 +349,14 @@ pub struct PeerTransportConfig {
 }
 
 /// Per-neighbor BFD attachment recorded from
-/// `set router bgp neighbor <addr> bfd { enable | multihop |
+/// `set router bgp neighbor <addr> bfd { enabled | multihop |
 /// minimum-ttl }` (zebra-bgp-bfd.yang). The configuration is
-/// stored here; `enable` flips translate into subscribe / unsubscribe
+/// stored here; `enabled` flips translate into subscribe / unsubscribe
 /// calls on the BFD instance via `bfd::inst::Bfd::client_req_tx`.
 #[derive(Debug, Default, Clone, PartialEq, Eq)]
 pub struct PeerBfdConfig {
     /// Activate BFD. `None` ⇒ inherit the instance-level
-    /// `router bgp { bfd { enable } }`; `Some(false)` opts this neighbor out
+    /// `router bgp { bfd { enabled } }`; `Some(false)` opts this neighbor out
     /// of a blanket instance enable. Off if unset everywhere.
     pub enable: Option<bool>,
     /// Hop-mode override. `None` (the default) means "infer": the
@@ -3433,7 +3433,7 @@ mod bfd_config_tests {
     }
 
     /// Round-trip: setting enable + multihop + minimum-ttl mirrors the CLI
-    /// flow (`bfd enable true; bfd multihop true; bfd minimum-ttl 250`)
+    /// flow (`bfd enabled true; bfd multihop true; bfd minimum-ttl 250`)
     /// producing the recorded state the BFD subscribe path reads.
     #[test]
     fn enable_and_multihop_round_trip() {

--- a/zebra-rs/src/config/bgp.rs
+++ b/zebra-rs/src/config/bgp.rs
@@ -37,7 +37,7 @@ pub fn spawn_bgp(config: &ConfigManager) {
         }
         return;
     }
-    // Capture BFD / ND client handles so per-neighbor `bfd { enable }`
+    // Capture BFD / ND client handles so per-neighbor `bfd { enabled }`
     // and IPv6 unnumbered RA hand-off can submit requests later. Both
     // are guaranteed to be populated when BGP is spawned via
     // `commit_config`: the BGP arm there spawns ND *and* BFD eagerly,

--- a/zebra-rs/src/config/manager.rs
+++ b/zebra-rs/src/config/manager.rs
@@ -1542,6 +1542,95 @@ mod yang_load_tests {
         load_mode("exec");
     }
 
+    /// Naming-convention guard for the `enable` → `enabled` consolidation.
+    /// Boolean activation leaves in zebra-owned modules are spelled
+    /// `enabled` — the OpenConfig style-guide name, and already the
+    /// spelling of the inherited `ietf-bgp` knobs (`afi-safi <af>
+    /// enabled`). The vendored `ietf-*` modules keep their published
+    /// spelling (including the two `leaf enable` holdouts:
+    /// `route-flap-damping` and RFC 8177 AES key wrap, neither wired to a
+    /// handler), and `exec.yang` is excluded because its (commented-out)
+    /// `enable` is the session privilege-promotion command, not a config
+    /// boolean.
+    #[test]
+    fn zebra_yang_activation_leaves_are_named_enabled() {
+        let dir = concat!(env!("CARGO_MANIFEST_DIR"), "/yang");
+        let mut offenders = Vec::new();
+        for entry in std::fs::read_dir(dir).expect("yang dir readable") {
+            let path = entry.expect("dir entry").path();
+            let name = path.file_name().unwrap().to_string_lossy().into_owned();
+            let owned = name == "config.yang"
+                || name == "config-static.yang"
+                || name == "configure.yang"
+                || name == "vty.yang"
+                || name.starts_with("zebra-");
+            if !owned {
+                continue;
+            }
+            let text = std::fs::read_to_string(&path).expect("yang file readable");
+            for (lineno, line) in text.lines().enumerate() {
+                let t = line.trim_start();
+                if t == "leaf enable"
+                    || t.starts_with("leaf enable ")
+                    || t.starts_with("leaf enable{")
+                {
+                    offenders.push(format!("{name}:{}", lineno + 1));
+                }
+            }
+        }
+        assert!(
+            offenders.is_empty(),
+            "zebra-owned YANG must spell activation leaves `enabled` \
+             (OpenConfig convention); found `leaf enable` at: {offenders:?}"
+        );
+    }
+
+    /// The other half of the consolidation guard: every renamed activation
+    /// leaf must resolve as a settable path under its new `enabled` name,
+    /// so a silent schema regression (leaf dropped, grouping unwired) is
+    /// caught here and not only in the BDD.
+    #[test]
+    fn enabled_activation_leaf_paths_parse() {
+        use crate::config::ExecCode;
+        use crate::config::parse::{State, parse};
+        use libyang::to_entry;
+
+        let mut yang = YangStore::new();
+        yang.add_path(concat!(env!("CARGO_MANIFEST_DIR"), "/yang"));
+        yang.read_with_resolve("configure")
+            .unwrap_or_else(|e| panic!("configure failed to load: {e:#}"));
+        yang.identity_resolve();
+        let module = yang.find_module("configure").unwrap();
+        let entry = to_entry(&yang, module);
+
+        for cmd in [
+            "set router ospf area 0.0.0.0 interface eth0 enabled true",
+            "set router ospf area 0.0.0.0 interface eth0 bfd enabled true",
+            "set router ospf bfd enabled true",
+            "set router ospf vrf blue area 0.0.0.0 interface eth0 enabled true",
+            "set router ospfv3 area 0.0.0.0 interface eth0 enabled true",
+            "set router ospfv3 area 0.0.0.0 interface eth0 bfd enabled true",
+            "set router ospfv3 bfd enabled true",
+            "set router ospfv3 vrf blue area 0.0.0.0 interface eth0 enabled true",
+            "set router isis interface eth0 ipv4 enabled true",
+            "set router isis interface eth0 ipv6 enabled true",
+            "set router isis interface eth0 bfd enabled true",
+            "set router isis bfd enabled true",
+            "set router isis vrf blue interface eth0 ipv4 enabled true",
+            "set router isis vrf blue interface eth0 ipv6 enabled true",
+            "set router bgp bfd enabled true",
+            "set router bgp neighbor 192.168.1.3 bfd enabled true",
+            "set router bgp mup-c enabled true",
+        ] {
+            let (code, _comps, _state) = parse(cmd, entry.clone(), None, State::new());
+            assert_eq!(
+                code,
+                ExecCode::Success,
+                "should parse as a settable path: {cmd}"
+            );
+        }
+    }
+
     /// Regression guard for `remove-private-as`. The IETF model
     /// (`ietf-bgp`) shipped a `remove-private-as` identityref leaf on the
     /// neighbor whose IANA base this libyang can't resolve to a value
@@ -2440,10 +2529,10 @@ mod yang_load_tests {
         let entry = to_entry(&yang, module);
 
         for cmd in [
-            "set router isis interface eth0 te-metric measurement enable true",
+            "set router isis interface eth0 te-metric measurement enabled true",
             "set router isis interface eth0 te-metric measurement interval 100",
             "set router isis interface eth0 te-metric measurement damping-period 2",
-            "set router ospf area 0 interface eth0 te-metric measurement enable true",
+            "set router ospf area 0 interface eth0 te-metric measurement enabled true",
             "set router ospf area 0 interface eth0 te-metric measurement interval 100",
             "set router ospf area 0 interface eth0 te-metric measurement damping-period 2",
         ] {

--- a/zebra-rs/src/config/paths.rs
+++ b/zebra-rs/src/config/paths.rs
@@ -201,7 +201,7 @@ mod tests {
             cp("ospf", 0),
             cp("vrf", 2),
             cp("blue", 3),
-            cp("enable", 4),
+            cp("enabled", 4),
         ];
         assert!(vrf_config_split("isis", &paths).is_none());
         // ...but the OSPFv2 instance itself still splits it.

--- a/zebra-rs/src/isis/config.rs
+++ b/zebra-rs/src/isis/config.rs
@@ -298,11 +298,14 @@ impl Isis {
             link::config_hello_padding,
         );
         self.callback_add(
-            "/router/isis/interface/ipv4/enable",
+            "/router/isis/interface/ipv4/enabled",
             link::config_ipv4_enable,
         );
         // Per-interface BFD attachment.
-        self.callback_add("/router/isis/interface/bfd/enable", link::config_bfd_enable);
+        self.callback_add(
+            "/router/isis/interface/bfd/enabled",
+            link::config_bfd_enable,
+        );
         self.callback_add(
             "/router/isis/interface/bfd/echo-mode",
             link::config_bfd_echo_mode,
@@ -320,7 +323,7 @@ impl Isis {
             link::config_bfd_detect_offload,
         );
         // Instance-level `router isis { bfd { ... } }` defaults.
-        self.callback_add("/router/isis/bfd/enable", link::config_isis_bfd_enable);
+        self.callback_add("/router/isis/bfd/enabled", link::config_isis_bfd_enable);
         self.callback_add(
             "/router/isis/bfd/echo-mode",
             link::config_isis_bfd_echo_mode,
@@ -394,7 +397,7 @@ impl Isis {
             link::config_te_loss,
         );
         self.callback_add(
-            "/router/isis/interface/te-metric/measurement/enable",
+            "/router/isis/interface/te-metric/measurement/enabled",
             link::config_te_measurement_enable,
         );
         self.callback_add(
@@ -418,7 +421,7 @@ impl Isis {
             config_sr_srv6_flex_algo_locator,
         );
         self.callback_add(
-            "/router/isis/interface/ipv6/enable",
+            "/router/isis/interface/ipv6/enabled",
             link::config_ipv6_enable,
         );
         self.callback_add("/router/isis/distribute/rib", config_distribute_rib);

--- a/zebra-rs/src/isis/inst.rs
+++ b/zebra-rs/src/isis/inst.rs
@@ -486,7 +486,7 @@ pub struct Isis {
 
     /// Handle into the BFD instance's client-request channel — used
     /// by [`Self::process_bfd_subscribe`] / [`Self::process_bfd_unsubscribe`]
-    /// when an adjacency on a `bfd { enable true }` interface
+    /// when an adjacency on a `bfd { enabled true }` interface
     /// reaches Up (or backslides). `None` means BFD has not (yet)
     /// been configured. Captured at spawn time from
     /// `ConfigManager::bfd_client_tx`; not refreshed if BFD respawns
@@ -2101,7 +2101,7 @@ impl Isis {
 
     /// Re-evaluate BFD for every Up adjacency on every interface — used by the
     /// `bfd {}` config callbacks (per-interface and instance-level), whose
-    /// changes (notably a blanket `enable`) affect adjacencies that are already
+    /// changes (notably a blanket `enabled`) affect adjacencies that are already
     /// Up. Subscribe / Unsubscribe is idempotent at the BFD instance (keyed by
     /// client+key), so we can re-drive without tracking per-adjacency state;
     /// a re-Subscribe also applies Echo-param changes to the live session
@@ -3636,14 +3636,14 @@ pub enum Message {
     /// which will compute seq = 1 for the freshly-unfrozen fragment
     /// (no existing entry in LSDB once the purge has been removed).
     LspSeqWrapClear(Level, u8),
-    /// An adjacency on a `bfd { enable true }` interface reached
+    /// An adjacency on a `bfd { enabled true }` interface reached
     /// Up. The IS-IS event loop forwards this as a
     /// `ClientReq::Subscribe` against the BFD instance — see
     /// [`Isis::process_bfd_subscribe`].
     BfdSubscribe(crate::bfd::session::SessionKey),
     /// An adjacency on a previously-subscribed interface backslid
     /// from Up (Hello timer expiry, peer signaling Down, etc.) or
-    /// the interface had `bfd { enable }` removed; release the BFD
+    /// the interface had `bfd { enabled }` removed; release the BFD
     /// session by sending `ClientReq::Unsubscribe`.
     BfdUnsubscribe(crate::bfd::session::SessionKey),
     /// Something that can flip this interface's STAMP measurement

--- a/zebra-rs/src/isis/link.rs
+++ b/zebra-rs/src/isis/link.rs
@@ -979,7 +979,7 @@ pub fn config_priority(isis: &mut Isis, mut args: Args, _op: ConfigOp) -> Option
     Some(())
 }
 
-/// `set router isis interface X bfd enable true|false` — flips the
+/// `set router isis interface X bfd enabled true|false` — flips the
 /// per-interface BFD attachment recorded on the IS-IS link. The
 /// runtime subscribe path runs on adjacency FSM Up; the teardown
 /// path runs on `BfdEvent::Down`.
@@ -987,7 +987,7 @@ pub fn config_bfd_enable(isis: &mut Isis, mut args: Args, op: ConfigOp) -> Optio
     let name = args.string()?;
     let enable = args.boolean()?;
     let link = isis.links.get_mut_by_name(&name)?;
-    // `None` ⇒ inherit `router isis { bfd { enable } }`; `Some(false)` opts this
+    // `None` ⇒ inherit `router isis { bfd { enabled } }`; `Some(false)` opts this
     // interface out of a blanket instance enable.
     link.config.bfd.enable = op.is_set().then_some(enable);
     isis.bfd_reconcile_all();
@@ -1066,7 +1066,7 @@ pub fn config_bfd_detect_offload(isis: &mut Isis, mut args: Args, op: ConfigOp) 
 // ---- instance-level `router isis { bfd { ... } }` defaults ------------------
 
 /// `router isis bfd enable <bool>` — blanket-enable BFD on every IS-IS
-/// interface (a per-interface `bfd { enable false }` opts one out).
+/// interface (a per-interface `bfd { enabled false }` opts one out).
 pub fn config_isis_bfd_enable(isis: &mut Isis, mut args: Args, op: ConfigOp) -> Option<()> {
     let enable = args.boolean()?;
     isis.config.bfd.enable = op.is_set().then_some(enable);
@@ -1217,7 +1217,7 @@ fn config_afi_enable(isis: &mut Isis, mut args: Args, op: ConfigOp, afi: Afi) ->
     // TLVs depend on which interfaces have the AFI enabled (and, on a
     // 0<->non-zero *global* transition, so does the Protocols Supported /
     // NLPID TLV). Gating only on the global transition missed the common
-    // case — e.g. `set router isis interface lo ipv6 enable true` while
+    // case — e.g. `set router isis interface lo ipv6 enabled true` while
     // another interface already carries IPv6 — leaving the loopback's IPv6
     // prefix out of the LSP until the next periodic refresh. The per-level
     // guard skips a level whose self-LSP hasn't been originated yet (e.g.
@@ -2443,7 +2443,7 @@ mod bfd_config_tests {
     }
 
     /// Round-trip: setting enable + echo-mode mirrors the CLI flow
-    /// (`bfd enable true; bfd echo-mode both`) producing the state
+    /// (`bfd enabled true; bfd echo-mode both`) producing the state
     /// the adjacency-FSM subscribe path reads.
     #[test]
     fn enable_round_trip() {

--- a/zebra-rs/src/ospf/config.rs
+++ b/zebra-rs/src/ospf/config.rs
@@ -101,9 +101,9 @@ impl Ospf {
             "/area/virtual-link/key-chain",
             config_ospf_area_virtual_link_key_chain,
         );
-        self.ospf_add("/area/interface/enable", config_ospf_interface_enable);
+        self.ospf_add("/area/interface/enabled", config_ospf_interface_enable);
         self.ospf_add(
-            "/area/interface/bfd/enable",
+            "/area/interface/bfd/enabled",
             config_ospf_interface_bfd_enable,
         );
         self.ospf_add(
@@ -200,7 +200,7 @@ impl Ospf {
             config_ospf_redist_table_route_map,
         );
         // Instance-level `router ospf { bfd { ... } }` defaults.
-        self.ospf_add("/bfd/enable", config_ospf_bfd_enable);
+        self.ospf_add("/bfd/enabled", config_ospf_bfd_enable);
         self.ospf_add(
             "/bfd/min-neighbor-state",
             config_ospf_bfd_min_neighbor_state,
@@ -247,7 +247,7 @@ impl Ospf {
         // `impl Ospf<Ospfv2>`; `config_v3.rs` registers nothing here,
         // so the v3 instance never enables measurement).
         self.ospf_add(
-            "/area/interface/te-metric/measurement/enable",
+            "/area/interface/te-metric/measurement/enabled",
             config_ospf_interface_te_measurement_enable,
         );
         self.ospf_add(
@@ -1589,7 +1589,7 @@ pub(super) fn config_ospf_interface_bfd_enable<V: OspfVersion>(
 
     let ifindex = {
         let link = ospf_link_get_mut_by_name(&mut ospf.links, &name)?;
-        // `None` ⇒ inherit the instance-level `bfd { enable }`; `Some(false)`
+        // `None` ⇒ inherit the instance-level `bfd { enabled }`; `Some(false)`
         // explicitly opts this interface out of a blanket instance enable.
         link.config.bfd.enable = op.is_set().then_some(enable);
         link.index
@@ -1729,7 +1729,7 @@ pub(super) fn config_ospf_interface_bfd_min_neighbor_state<V: OspfVersion>(
 // `V`; registered by both v2 (`config.rs`) and v3 (`config_v3.rs`).
 
 /// `router ospf bfd enable <bool>` — blanket-enable BFD on every interface in
-/// the instance (a per-interface `bfd { enable false }` opts one out).
+/// the instance (a per-interface `bfd { enabled false }` opts one out).
 pub(super) fn config_ospf_bfd_enable<V: OspfVersion>(
     ospf: &mut Ospf<V>,
     mut args: Args,

--- a/zebra-rs/src/ospf/config_v3.rs
+++ b/zebra-rs/src/ospf/config_v3.rs
@@ -1,7 +1,7 @@
 //! OSPFv3 YANG-path callback handlers.
 //!
 //! Sibling of v2's `config.rs`. Registers the
-//! `/router/ospfv3/area/interface/*` handlers — `enable`,
+//! `/router/ospfv3/area/interface/*` handlers — `enabled`,
 //! `priority`, `hello-interval`, `dead-interval`,
 //! `retransmit-interval`, `mtu-ignore`. The handler bodies mirror
 //! v2 almost line-for-line; the generic helpers in `config.rs`
@@ -34,7 +34,7 @@ const OSPFV3: &str = "/router/ospfv3";
 impl Ospf<Ospfv3> {
     /// Register the v3 YANG-path → handler dispatch table. Mirrors
     /// v2's `callback_build` shape; the table is keyed by full path
-    /// (e.g. `/router/ospfv3/area/interface/enable`) so `process_msg`
+    /// (e.g. `/router/ospfv3/area/interface/enabled`) so `process_msg`
     /// can look up handlers directly.
     pub fn callback_build(&mut self) {
         let prefix = OSPFV3;
@@ -186,9 +186,9 @@ impl Ospf<Ospfv3> {
                 "/redistribute/bgp/route-map",
                 config_ospfv3_redist_bgp_route_map,
             ),
-            ("/area/interface/enable", config_ospfv3_interface_enable),
+            ("/area/interface/enabled", config_ospfv3_interface_enable),
             (
-                "/area/interface/bfd/enable",
+                "/area/interface/bfd/enabled",
                 config_ospf_interface_bfd_enable,
             ),
             (
@@ -212,7 +212,7 @@ impl Ospf<Ospfv3> {
                 config_ospf_interface_bfd_detect_offload,
             ),
             // Instance-level `router ospfv3 { bfd { ... } }` defaults.
-            ("/bfd/enable", config_ospf_bfd_enable),
+            ("/bfd/enabled", config_ospf_bfd_enable),
             (
                 "/bfd/min-neighbor-state",
                 config_ospf_bfd_min_neighbor_state,

--- a/zebra-rs/src/ospf/inst.rs
+++ b/zebra-rs/src/ospf/inst.rs
@@ -627,7 +627,7 @@ impl<V: OspfVersion> Ospf<V> {
     fn bfd_reconcile_nbr(&mut self, ifindex: u32, nbr_addr: Ipv4Addr) {
         // Effective BFD config for this interface = the per-interface `bfd {}`
         // merged over the instance-level `router ospf { bfd {} }` default, per
-        // leaf (so an instance `enable true` blanket-enables interfaces that
+        // leaf (so an instance `enabled true` blanket-enables interfaces that
         // didn't set their own). No link ⇒ nothing to reconcile.
         let eff = match self.links.get(&ifindex) {
             Some(link) => link.config.bfd.resolve(&self.bfd),
@@ -721,7 +721,7 @@ impl<V: OspfVersion> Ospf<V> {
 
     /// Re-evaluate every neighbor on every interface — used by the
     /// instance-level `bfd {}` config callbacks, whose defaults (e.g. a
-    /// blanket `enable`) affect interfaces that set nothing of their own.
+    /// blanket `enabled`) affect interfaces that set nothing of their own.
     pub(crate) fn bfd_reconcile_all(&mut self) {
         let ifindexes: Vec<u32> = self.links.keys().copied().collect();
         for ifindex in ifindexes {
@@ -11665,7 +11665,7 @@ impl Ospf<Ospfv3> {
         // Pre-roll: drain the RIB subscribe-time replay (LinkAdd,
         // AddrAdd, RouterIdUpdate, ...) before touching `cm.rx`.
         // Without this, a `set router ospfv3 area ... interface
-        // <name> enable true` config message can race ahead of the
+        // <name> enabled true` config message can race ahead of the
         // `LinkAdd` for that ifname; `ospf_link_get_mut_by_name`
         // then returns `None` and the enable silently no-ops.
         // Mirrors v2's pre-roll in `Ospf<Ospfv2>::event_loop`.

--- a/zebra-rs/yang/config.yang
+++ b/zebra-rs/yang/config.yang
@@ -828,7 +828,7 @@ module config {
               ext:dynamic "rib:interface";
               type string;
             }
-            leaf enable {
+            leaf enabled {
               type boolean;
             }
             leaf network-type {
@@ -983,7 +983,7 @@ module config {
                    probes are answered by the neighbor's implicit
                    Session-Reflector, so measurement must be enabled on
                    both ends of the link.";
-                leaf enable {
+                leaf enabled {
                   type boolean;
                   description "Activate measurement on this interface.";
                 }
@@ -1334,7 +1334,7 @@ module config {
           // `router static`'s per-VRF list) so the VRF need not yet
           // exist at the top-level `vrf` list when parsed. The exposed
           // subset tracks the default instance's per-interface knobs
-          // (enable / network-type / priority / timers) plus per-area
+          // (enabled / network-type / priority / timers) plus per-area
           // NSSA `redistribute connected`; more leaves land as the
           // per-VRF surface widens.
           key "name";
@@ -1420,7 +1420,7 @@ module config {
                 ext:dynamic "rib:interface";
                 type string;
               }
-              leaf enable {
+              leaf enabled {
                 type boolean;
               }
               leaf network-type {
@@ -1784,7 +1784,7 @@ module config {
               ext:dynamic "rib:interface";
               type string;
             }
-            leaf enable {
+            leaf enabled {
               type boolean;
             }
             leaf network-type {
@@ -2049,7 +2049,7 @@ module config {
         list vrf {
           // Per-VRF OSPFv3 instance. See `container ospf`'s `vrf`
           // list for the forwarding model. Exposes the per-interface
-          // knobs the v3 instance handles (enable / network-type /
+          // knobs the v3 instance handles (enabled / network-type /
           // priority / timers) plus `router-id` (the forwarded line
           // hits the same `/router/ospfv3/router-id` callback on the
           // child). `redistribute` stays omitted — the v3 instance
@@ -2099,7 +2099,7 @@ module config {
                 ext:dynamic "rib:interface";
                 type string;
               }
-              leaf enable {
+              leaf enabled {
                 type boolean;
               }
               leaf network-type {
@@ -2147,11 +2147,11 @@ module config {
           ext:help "BFD defaults for this IS-IS instance";
           description
             "Instance-level BFD defaults applied to every IS-IS
-             interface, overridable per interface. `enable true` here
+             interface, overridable per interface. `enabled true` here
              blanket-enables BFD on all of the instance's interfaces; a
-             per-interface `bfd { enable false }` opts one out. Each leaf
+             per-interface `bfd { enabled false }` opts one out. Each leaf
              is overridable per interface.";
-          leaf enable {
+          leaf enabled {
             ext:help "Blanket-enable BFD on all IS-IS interfaces";
             type boolean;
             description
@@ -2870,7 +2870,7 @@ module config {
           }
 
           container ipv4 {
-            leaf enable {
+            leaf enabled {
               type boolean;
             }
             container prefix-sid {
@@ -2911,7 +2911,7 @@ module config {
             }
           }
           container ipv6 {
-            leaf enable {
+            leaf enabled {
               type boolean;
             }
           }
@@ -2975,14 +2975,14 @@ module config {
           container bfd {
             ext:help "BFD attachment for this IS-IS interface";
             description
-              "Per-interface BFD attachment for IS-IS. When `enable`
+              "Per-interface BFD attachment for IS-IS. When `enabled`
                is true the IS-IS adjacency FSM subscribes a BFD
                session at the moment it reaches Up; a subsequent
                BFD Down event drives the adjacency back to Down
                per RFC 5882 §5. Storage-only in PR 6; PR 7 wires
                the runtime subscribe / teardown calls.";
 
-            leaf enable {
+            leaf enabled {
               type boolean;
               default false;
               description
@@ -3107,7 +3107,7 @@ module config {
                  are answered by the neighbor's implicit
                  Session-Reflector, so measurement must be enabled on
                  both ends of the link.";
-              leaf enable {
+              leaf enabled {
                 type boolean;
                 description "Activate measurement on this interface.";
               }
@@ -3366,12 +3366,12 @@ module config {
               type uint32;
             }
             container ipv4 {
-              leaf enable {
+              leaf enabled {
                 type boolean;
               }
             }
             container ipv6 {
-              leaf enable {
+              leaf enabled {
                 type boolean;
               }
             }

--- a/zebra-rs/yang/zebra-bgp-bfd.yang
+++ b/zebra-rs/yang/zebra-bgp-bfd.yang
@@ -33,13 +33,13 @@ module zebra-bgp-bfd {
 
        router bgp {
          bfd {
-           enable true;          // blanket-enable all neighbors
+           enabled true;          // blanket-enable all neighbors
            echo-mode receive;    // default Echo role
          }
          neighbor 10.0.0.5 {
            remote-as 65501;
            bfd {
-             enable true;
+             enabled true;
              multihop true;       // eBGP-over-loopback; iBGP infers this
              minimum-ttl 250;
              echo-mode both;      // override (single-hop neighbors only)
@@ -48,9 +48,9 @@ module zebra-bgp-bfd {
        }
 
      The effective value of each `bfd` leaf is the per-neighbor setting if
-     present, else the instance default, else a hard default. `enable true`
+     present, else the instance default, else a hard default. `enabled true`
      at the instance level activates BFD on every neighbor (a per-neighbor
-     `enable false` opts one out). Echo is **single-hop only** (RFC 5883
+     `enabled false` opts one out). Echo is **single-hop only** (RFC 5883
      multihop has no Echo), so `echo-mode` is inert on multihop sessions
      (iBGP and multihop eBGP). Hop-mode (`multihop`) and `minimum-ttl` are
      per-neighbor only.";
@@ -92,7 +92,7 @@ module zebra-bgp-bfd {
   // Leaves shared by the instance-level and per-neighbor `bfd {}` containers.
   // No YANG `default` (absent ⇒ inherit, then a hard default in code).
   grouping bgp-bfd-common {
-    leaf enable {
+    leaf enabled {
       ext:help "Activate BFD (omit to inherit the instance default)";
       type boolean;
       description
@@ -190,9 +190,9 @@ module zebra-bgp-bfd {
     container bfd {
       ext:help "BFD defaults for this BGP instance";
       description
-        "Defaults applied to every neighbor's BFD session. `enable true`
+        "Defaults applied to every neighbor's BFD session. `enabled true`
          here blanket-enables BFD on all neighbors; a per-neighbor
-         `bfd { enable false }` opts one out. Every leaf is overridable per
+         `bfd { enabled false }` opts one out. Every leaf is overridable per
          neighbor. (Hop-mode / minimum-ttl are per-neighbor only.)";
       uses bgp-bfd-common;
     }

--- a/zebra-rs/yang/zebra-bgp-mup-controller.yang
+++ b/zebra-rs/yang/zebra-bgp-mup-controller.yang
@@ -39,7 +39,7 @@ module zebra-bgp-mup-controller {
 
        router bgp {
          mup-c {
-           enable true;
+           enabled true;
            controller-address 2001:db8::1;
            upf-address 10.100.0.1;
            pfcp {
@@ -66,7 +66,7 @@ module zebra-bgp-mup-controller {
         "BGP MUP Controller (MUP-C). Terminates PFCP/N4 as a UP-node and
          originates MUP Session-Transformed routes from learned sessions.";
 
-      leaf enable {
+      leaf enabled {
         type boolean;
         default false;
         description

--- a/zebra-rs/yang/zebra-ospf-bfd.yang
+++ b/zebra-rs/yang/zebra-ospf-bfd.yang
@@ -29,7 +29,7 @@ module zebra-ospf-bfd {
 
        router ospf {
          bfd {
-           enable true;          // blanket-enable all interfaces
+           enabled true;          // blanket-enable all interfaces
            echo-mode receive;    // default Echo role for the instance
          }
          area 0 {
@@ -43,8 +43,8 @@ module zebra-ospf-bfd {
 
      The effective value of each `bfd` leaf is the per-interface setting
      if present, else the instance-level default, else a hard default.
-     `enable true` at the instance level activates BFD on every interface
-     in the instance; a per-interface `enable false` opts one out. When
+     `enabled true` at the instance level activates BFD on every interface
+     in the instance; a per-interface `enabled false` opts one out. When
      enabled, OSPF attaches a single-hop BFD session to each neighbor on
      the interface once it reaches the configured `min-neighbor-state`; a
      session going Down tears the adjacency down (RFC 5882 §5). OSPF
@@ -90,7 +90,7 @@ module zebra-ospf-bfd {
   // default, then a hard default in code) — that is how a per-interface
   // value can override an instance default per leaf.
   grouping ospf-bfd-params {
-    leaf enable {
+    leaf enabled {
       ext:help "Activate BFD (omit to inherit the instance default)";
       type boolean;
       description
@@ -209,8 +209,8 @@ module zebra-ospf-bfd {
       ext:help "BFD defaults for this OSPF instance";
       description
         "Defaults applied to every interface's BFD sessions in this OSPF
-         instance. `enable true` here activates BFD on all of the
-         instance's interfaces (blanket); a per-interface `bfd { enable
+         instance. `enabled true` here activates BFD on all of the
+         instance's interfaces (blanket); a per-interface `bfd { enabled
          false }` opts one out. Every leaf is overridable per interface.";
       uses ospf-bfd-params;
     }


### PR DESCRIPTION
## Summary

zebra-owned YANG modules spelled boolean activation leaves both ways: `leaf enable` (OSPF/OSPFv3 interface + VRF variants, IS-IS `ipv4`/`ipv6`/`bfd`, OSPF/IS-IS `te-metric measurement`, BGP/OSPF `bfd` groupings, MUP-C) versus `leaf enabled` (zebra-bgp-vrf, zebra-bgp-neighbor-group, and everything inherited from ietf-bgp such as `afi-safi <af> enabled`). OpenConfig mandates `enabled` for boolean activation leaves and the modern IETF models (ietf-interfaces, ietf-ip, ietf-ospf, ietf-bgp) agree, so this consolidates on `enabled`.

- **yang**: rename the 15 zebra-owned `leaf enable` definitions to `enabled` (config.yang ×12, zebra-bgp-bfd, zebra-ospf-bfd, zebra-bgp-mup-controller). Vendored `ietf-*` modules keep their published spelling — including the two `leaf enable` holdouts (`route-flap-damping`, RFC 8177 AES key wrap), neither wired to a handler. `exec.yang`'s commented-out `enable` (session privilege command) is out of scope.
- **daemon**: sweep the 16 callback path registrations (ospf/config.rs, ospf/config_v3.rs, isis/config.rs, bgp/config.rs) plus doc comments and the te-metric grammar test.
- **bdd**: mechanical `enable:` → `enabled:` across 458 topology YAMLs (1396 occurrences) plus the curly-brace `.conf` fixtures.
- **book/docs/offload**: update config snippets and FRR cross-reference tables.
- **regression guard**: `yang_load_tests` now asserts (a) no `leaf enable` creeps back into zebra-owned modules and (b) all 17 renamed paths parse as settable.

## Breaking change

Existing configs using `enable true` / `enable: true` must be updated to `enabled`. The exec-mode `enable` command (session privilege promotion) is unchanged. Should be release-noted in CHANGELOG.yaml at the next release cut.

## Verification

- `cargo test --workspace --exclude bdd`: 37 test binaries, 0 failures
- `cargo clippy --workspace --all-targets -- -D warnings`: clean
- BDD smoke run covering every renamed leaf family against a live daemon (fresh binary + synced `/etc/zebra-rs/yang`): `@isis_afi_enable`, `@isis_bfd_ipv4_p2p`, `@stamp_te_metric`, `@ospf_clear_neighbor`, `@ospfv3_nssa`, `@ecmp_bfd_evict`, `@bgp_mup_st2` — 21 scenarios, 322/322 steps passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)