### PR TITLE
bgp/mup: dataplane gtp installs the ST1 downlink GTP4.E encap via cradle

### DIFF
--- a/proto/cradle.proto
+++ b/proto/cradle.proto
@@ -35,6 +35,12 @@ message Nexthop {
   // Fast-reroute: the nexthop to switch to when this one's link goes down —
   // typically the TI-LFA repair (segs + encap_mode 2). 0 = unprotected.
   uint32 backup_id = 12;
+  // GTP-U encap (GTP4.E): a non-empty gtp_dst makes this a GTP nexthop that
+  // wraps the packet in outer IPv4 + UDP(2152) + GTP-U(gtp_teid) over the v4
+  // underlay gateway/oif. Mutually exclusive with segs/labels.
+  string gtp_src = 13;   // outer IPv4 source (local N3/N9 tunnel address)
+  string gtp_dst = 14;   // outer IPv4 destination (peer gNB / UPF address)
+  uint32 gtp_teid = 15;  // GTP-U TEID
 }
 
 // A nexthop group for ECMP: ordered member nexthop ids. A route whose flags

--- a/zebra-rs/src/bgp/inst.rs
+++ b/zebra-rs/src/bgp/inst.rs
@@ -3966,6 +3966,12 @@ impl Bgp {
             NhtDep::Mup(rd, prefix) => {
                 self.mup_redispatch_segment(nh, rd, prefix, true);
             }
+            // MUP: a received/originated ST1's GTP endpoint (gNB) rerouted →
+            // re-dispatch the ST1 with the fresh endpoint transport so the
+            // `dataplane gtp` downlink encap re-installs toward the new egress.
+            NhtDep::MupEndpoint(rd, prefix) => {
+                self.mup_redispatch_endpoint(nh, rd, prefix, true);
+            }
             NhtDep::V4(_) | NhtDep::V6(_) => {}
         }
     }
@@ -3998,7 +4004,54 @@ impl Bgp {
             rib_known_vrfs: &self.rib_known_vrfs,
             vrf_registry: &self.vrf_registry,
         };
-        super::vrf::dispatch_mup(&dispatcher, rd, &prefix, Some(winner), None, &transport);
+        super::vrf::dispatch_mup(
+            &dispatcher,
+            rd,
+            &prefix,
+            Some(winner),
+            None,
+            &transport,
+            &[],
+        );
+    }
+
+    /// Re-dispatch an ST1 route to importing VRFs with its GTP endpoint's
+    /// current v4 underlay transport (empty when `reachable` is false), so the
+    /// `dataplane gtp` downlink `GTP4.E` encap re-installs or is withdrawn. The
+    /// endpoint's register-then-gate first resolution and every later reroute
+    /// both land here. Parallel to [`Self::mup_redispatch_segment`], but the
+    /// tracked next-hop is the ST1's `st1.endpoint` (not the BGP next-hop), so
+    /// the fresh value rides `MupUpdate.endpoint_transport` (segment transport
+    /// stays empty for an ST1).
+    fn mup_redispatch_endpoint(
+        &mut self,
+        nh: std::net::IpAddr,
+        rd: bgp_packet::RouteDistinguisher,
+        prefix: bgp_packet::MupPrefix,
+        reachable: bool,
+    ) {
+        let selected = self.local_rib.select_best_path_mup(&rd, &prefix);
+        let Some(winner) = selected.first() else {
+            return;
+        };
+        let endpoint_transport = if reachable {
+            self.nexthop_cache.transport_for(nh).to_vec()
+        } else {
+            Vec::new()
+        };
+        let dispatcher = super::vrf::VrfImportDispatcher {
+            rib_known_vrfs: &self.rib_known_vrfs,
+            vrf_registry: &self.vrf_registry,
+        };
+        super::vrf::dispatch_mup(
+            &dispatcher,
+            rd,
+            &prefix,
+            Some(winner),
+            None,
+            &[],
+            &endpoint_transport,
+        );
     }
 
     /// Re-evaluate one dependent prefix after its next-hop's
@@ -4056,7 +4109,7 @@ impl Bgp {
             NhtDep::SrPolicy { .. } => Vec::new(),
             // MUP has no shard best-path; the ST2→DSD re-dispatch is done
             // inline in the match below (it needs `nexthop_cache`).
-            NhtDep::Mup(..) => Vec::new(),
+            NhtDep::Mup(..) | NhtDep::MupEndpoint(..) => Vec::new(),
         };
 
         let mut top = super::peer::BgpTop {
@@ -4308,6 +4361,34 @@ impl Bgp {
                         Some(winner),
                         None,
                         &transport,
+                        &[],
+                    );
+                }
+            }
+            // MUP endpoint reachability flip: (re)dispatch the ST1 with its GTP
+            // endpoint's resolved transport (empty when unreachable), so the
+            // `dataplane gtp` downlink encap installs or is withdrawn. The
+            // endpoint rides `endpoint_transport`; segment transport stays empty.
+            NhtDep::MupEndpoint(rd, prefix) => {
+                let selected = top.local_rib.select_best_path_mup(rd, prefix);
+                if let Some(winner) = selected.first() {
+                    let endpoint_transport = if reachable {
+                        self.nexthop_cache.transport_for(nh).to_vec()
+                    } else {
+                        Vec::new()
+                    };
+                    let dispatcher = super::vrf::VrfImportDispatcher {
+                        rib_known_vrfs: &self.rib_known_vrfs,
+                        vrf_registry: &self.vrf_registry,
+                    };
+                    super::vrf::dispatch_mup(
+                        &dispatcher,
+                        *rd,
+                        prefix,
+                        Some(winner),
+                        None,
+                        &[],
+                        &endpoint_transport,
                     );
                 }
             }

--- a/zebra-rs/src/bgp/nht.rs
+++ b/zebra-rs/src/bgp/nht.rs
@@ -56,6 +56,14 @@ pub enum NhtDep {
     /// Direct-segment id matches re-programs its endpoint encap. Keyed by
     /// the DSD's `(rd, MupPrefix)` like the VPN deps.
     Mup(RouteDistinguisher, bgp_packet::MupPrefix),
+    /// MUP (SAFI 85) Type-1 ST route's GTP **endpoint** (gNB) in
+    /// `local_rib.mup`. Unlike [`Self::Mup`] (which tracks the BGP next-hop),
+    /// this tracks the ST1's `st1.endpoint` address so the `dataplane gtp`
+    /// downlink `GTP4.E` encap re-resolves its outer v4 underlay when the gNB's
+    /// reachability or route changes: on a change the ST1 is re-dispatched to
+    /// importing VRFs with the freshly-resolved endpoint transport. Keyed by
+    /// the ST1's `(rd, MupPrefix)`.
+    MupEndpoint(RouteDistinguisher, bgp_packet::MupPrefix),
 }
 
 /// How a tracked next-hop's resolution changed, returned by

--- a/zebra-rs/src/bgp/route.rs
+++ b/zebra-rs/src/bgp/route.rs
@@ -3105,6 +3105,74 @@ fn mup_segment_untrack(bgp: &mut BgpTop, rd: RouteDistinguisher, prefix: &MupPre
     }
 }
 
+/// NHT for a received MUP Type-1 ST route's GTP **endpoint** (gNB): register
+/// the `st1.endpoint` address (not the BGP next-hop) so the `dataplane gtp`
+/// downlink `GTP4.E` encap re-resolves its outer v4 underlay when the gNB
+/// reroutes, and return the endpoint's currently-resolved transport (empty
+/// while a fresh registration is pending, the endpoint is unreachable, `best`
+/// is not a Type-1 ST, or carries no endpoint). No-op outside the global
+/// instance (`nexthop_cache` is `None`). Symmetric release is
+/// [`mup_endpoint_untrack`].
+fn mup_endpoint_track(
+    bgp: &mut BgpTop,
+    rd: RouteDistinguisher,
+    prefix: &MupPrefix,
+    best: Option<&BgpRib>,
+) -> Vec<rib::nht::ResolvedNexthop> {
+    let Some(cache) = bgp.nexthop_cache.as_deref_mut() else {
+        return Vec::new();
+    };
+    mup_endpoint_track_cache(cache, bgp.rib_client, rd, prefix, best)
+}
+
+/// Cache-level core of [`mup_endpoint_track`], shared with the local
+/// origination path ([`super::inst::Bgp::mup_apply_selected`]) which holds the
+/// `NexthopCache` directly rather than through a [`BgpTop`].
+pub(super) fn mup_endpoint_track_cache(
+    cache: &mut super::nht::NexthopCache,
+    rib_client: &crate::rib::client::RibClient,
+    rd: RouteDistinguisher,
+    prefix: &MupPrefix,
+    best: Option<&BgpRib>,
+) -> Vec<rib::nht::ResolvedNexthop> {
+    if !matches!(prefix, MupPrefix::T1st { .. }) {
+        return Vec::new();
+    }
+    let Some(endpoint) = best.and_then(|b| b.mup_st1).map(|st1| st1.endpoint) else {
+        return Vec::new();
+    };
+    let dep = super::nht::NhtDep::MupEndpoint(rd, prefix.clone());
+    let (needs_register, _reachable) = cache.track(endpoint, dep);
+    if needs_register {
+        let _ = rib_client.send(rib::Message::NexthopRegister {
+            proto: "bgp".to_string(),
+            nh: endpoint,
+        });
+    }
+    cache.transport_for(endpoint).to_vec()
+}
+
+/// Symmetric to [`mup_endpoint_track`]: drop the endpoint dep from `endpoint`
+/// and, once it has no deps left, unregister it. `endpoint` is the pre-withdraw
+/// ST1 GTP endpoint address.
+fn mup_endpoint_untrack(
+    bgp: &mut BgpTop,
+    rd: RouteDistinguisher,
+    prefix: &MupPrefix,
+    endpoint: IpAddr,
+) {
+    let dep = super::nht::NhtDep::MupEndpoint(rd, prefix.clone());
+    let Some(cache) = bgp.nexthop_cache.as_deref_mut() else {
+        return;
+    };
+    if cache.untrack(endpoint, &dep) {
+        let _ = bgp.rib_client.send(rib::Message::NexthopUnregister {
+            proto: "bgp".to_string(),
+            nh: endpoint,
+        });
+    }
+}
+
 /// Symmetric to [`nht_track_received`]: on a withdrawal, drop `dep` from
 /// each distinct next-hop the `removed` paths used, and unregister a
 /// next-hop from the RIB once it has no deps left. `survivor_nhs` are
@@ -7830,12 +7898,24 @@ pub fn route_mup_update(
     // resolved transport to hand the importing VRF. Empty for non-DSD /
     // unresolved. Must precede the `bgp.vrf_import` borrow below.
     let transport = mup_segment_track(bgp, rd, &prefix, selected.first());
+    // A received ST1: register its GTP endpoint (gNB) with NHT and read the
+    // resolved v4 underlay so the `dataplane gtp` downlink encap can steer
+    // toward it. Empty for non-ST1 / unresolved.
+    let endpoint_transport = mup_endpoint_track(bgp, rd, &prefix, selected.first());
     // Mirror the new best-path to every VRF whose `mup import` RT set
     // matches, so `show bgp vrf <name> mup` reflects peer-learned routes.
     // A peer-learned route has no local originating VRF (`origin_vrf =
     // None`), so it is imported purely by route-target.
     if let Some(dispatcher) = bgp.vrf_import {
-        super::vrf::dispatch_mup(dispatcher, rd, &prefix, selected.first(), None, &transport);
+        super::vrf::dispatch_mup(
+            dispatcher,
+            rd,
+            &prefix,
+            selected.first(),
+            None,
+            &transport,
+            &endpoint_transport,
+        );
     }
     if !selected.is_empty() {
         route_advertise_mup_to_peers(rd, prefix, &selected, bgp, peers);
@@ -7879,6 +7959,15 @@ fn route_mup_locrib_withdraw(
         .first()
         .filter(|_| matches!(prefix, MupPrefix::Dsd { .. } | MupPrefix::Isd { .. }))
         .and_then(|r| super::nht::nht_target(&r.attr));
+    // Likewise the pre-withdraw ST1 GTP endpoint (tracked separately from the
+    // BGP next-hop), so its `dataplane gtp` endpoint registration is released.
+    let old_endpoint = bgp
+        .local_rib
+        .select_best_path_mup(&rd, &prefix)
+        .first()
+        .filter(|_| matches!(prefix, MupPrefix::T1st { .. }))
+        .and_then(|r| r.mup_st1)
+        .map(|st1| st1.endpoint);
     let removed = bgp.local_rib.remove_mup(rd, &prefix, id, ident);
     let selected = bgp.local_rib.select_best_path_mup(&rd, &prefix);
     // Release the NHT registration when no surviving path keeps the
@@ -7891,13 +7980,28 @@ fn route_mup_locrib_withdraw(
     {
         mup_segment_untrack(bgp, rd, &prefix, nh);
     }
+    // Same for the ST1 endpoint registration.
+    if let Some(endpoint) = old_endpoint
+        && selected.first().and_then(|r| r.mup_st1).map(|s| s.endpoint) != Some(endpoint)
+    {
+        mup_endpoint_untrack(bgp, rd, &prefix, endpoint);
+    }
     let transport = mup_segment_track(bgp, rd, &prefix, selected.first());
+    let endpoint_transport = mup_endpoint_track(bgp, rd, &prefix, selected.first());
     // Mirror the post-withdraw state to per-VRF tasks: a remaining best
     // path is re-forwarded (matched by RT), otherwise the prefix is
     // withdrawn from every VRF's copy. A peer-learned route has no local
     // originating VRF (`origin_vrf = None`).
     if let Some(dispatcher) = bgp.vrf_import {
-        super::vrf::dispatch_mup(dispatcher, rd, &prefix, selected.first(), None, &transport);
+        super::vrf::dispatch_mup(
+            dispatcher,
+            rd,
+            &prefix,
+            selected.first(),
+            None,
+            &transport,
+            &endpoint_transport,
+        );
     }
     // Only propagate when the Loc-RIB actually changed. A withdraw for an
     // already-absent route (nothing removed, no surviving best path) is a
@@ -13328,13 +13432,25 @@ impl Bgp {
                         .find(|(_, cfg)| cfg.rd == Some(rd))
                         .map(|(name, _)| name.clone())
                 });
+            // A locally-originated ST1 (the MUP-C's downlink session) still
+            // needs its GTP endpoint (gNB) resolved against the local underlay
+            // so the `dataplane gtp` downlink `GTP4.E` encap can steer toward
+            // it — register it here (this global task holds the cache directly)
+            // and hand the resolved v4 transport to the VRF. Empty for non-ST1.
+            let endpoint_transport = super::route::mup_endpoint_track_cache(
+                &mut self.nexthop_cache,
+                &self.ctx.rib,
+                rd,
+                &prefix,
+                selected.first(),
+            );
             let dispatcher = super::vrf::VrfImportDispatcher {
                 rib_known_vrfs: &self.rib_known_vrfs,
                 vrf_registry: &self.vrf_registry,
             };
             // Locally-originated / exported routes carry no remote underlay
-            // transport (a local DSD's SID is on this node); the ST2→DSD
-            // encap only fires for *received* DSDs, tracked in
+            // segment transport (a local DSD's SID is on this node); the
+            // ST2→DSD encap only fires for *received* DSDs, tracked in
             // `route_mup_update`.
             super::vrf::dispatch_mup(
                 &dispatcher,
@@ -13343,6 +13459,7 @@ impl Bgp {
                 selected.first(),
                 origin_vrf.as_deref(),
                 &[],
+                &endpoint_transport,
             );
         }
         if selected.is_empty() {

--- a/zebra-rs/src/bgp/vrf/inst.rs
+++ b/zebra-rs/src/bgp/vrf/inst.rs
@@ -192,7 +192,33 @@ pub struct BgpVrf {
     /// `H.M.GTP4.D`): the set of (endpoint, TEID) tunnels teed to cradle. Diff
     /// base for `reconcile_mup_gtp`.
     pub mup_gtp_pdr_installed: std::collections::BTreeSet<(std::net::Ipv4Addr, u32)>,
+    /// Resolved v4 underlay transport for each selected ST1's GTP endpoint
+    /// (gNB), keyed by the ST1's `(rd, prefix)`. Supplied by the global NHT via
+    /// `MupUpdate.endpoint_transport` (register-then-gate on `st1.endpoint`) and
+    /// consumed by the `dataplane gtp` downlink reconcile to fill the cradle
+    /// GTP encap nexthop's underlay gateway/oif. Absent/empty ⇒ the endpoint
+    /// hasn't resolved, so no `GTP4.E` encap is installable for it.
+    pub mup_endpoint_transport: std::collections::BTreeMap<
+        (bgp_packet::RouteDistinguisher, bgp_packet::MupPrefix),
+        Vec<crate::rib::nht::ResolvedNexthop>,
+    >,
+    /// Installed GTP-U encap routes for `dataplane gtp` (the ST1 downlink /
+    /// `GTP4.E`): UE prefix → the encap key `(gtp_src, endpoint, TEID, gw,
+    /// oif)` teed to cradle. Diff base for the downlink reconcile — a changed
+    /// key re-installs, a vanished UE prefix withdraws.
+    pub mup_gtp_encap_installed: std::collections::BTreeMap<ipnet::Ipv4Net, MupGtpEncapKey>,
 }
+
+/// The cradle GTP-U encap install key for one downlink (`GTP4.E`) UE prefix:
+/// outer source, gNB endpoint, TEID, and the resolved v4 underlay
+/// `(gateway, oif)`. Re-installed only when this tuple changes.
+pub type MupGtpEncapKey = (
+    std::net::Ipv4Addr,
+    std::net::Ipv4Addr,
+    u32,
+    Option<std::net::Ipv4Addr>,
+    u32,
+);
 
 /// Sender side of the per-VRF inbound channel — handed back to
 /// the global task at spawn time so `despawn_bgp_vrf` can send
@@ -435,6 +461,7 @@ pub fn dispatch_mup(
     best: Option<&super::super::route::BgpRib>,
     origin_vrf: Option<&str>,
     transport: &[crate::rib::nht::ResolvedNexthop],
+    endpoint_transport: &[crate::rib::nht::ResolvedNexthop],
 ) {
     match best {
         Some(rib) => {
@@ -452,6 +479,7 @@ pub fn dispatch_mup(
                     prefix: prefix.clone(),
                     rib: rib.clone(),
                     transport: transport.to_vec(),
+                    endpoint_transport: endpoint_transport.to_vec(),
                 });
             }
         }
@@ -661,6 +689,8 @@ impl BgpVrf {
             mup_segment_transport: std::collections::BTreeMap::new(),
             mup_st2_dsd_installed: std::collections::BTreeMap::new(),
             mup_gtp_pdr_installed: std::collections::BTreeSet::new(),
+            mup_endpoint_transport: std::collections::BTreeMap::new(),
+            mup_gtp_encap_installed: std::collections::BTreeMap::new(),
         };
         (vrf, inbox_tx)
     }
@@ -864,15 +894,21 @@ impl BgpVrf {
         }
     }
 
+    /// Program the real GTP-U datapath for a `dataplane gtp` VRF via cradle:
+    /// the ST2 uplink decap (`H.M.GTP4.D`) and the ST1 downlink encap
+    /// (`GTP4.E`). Runs in place of the End.DT46 reconcilers when the VRF's
+    /// `dataplane` is `gtp`.
+    fn reconcile_mup_gtp(&mut self) {
+        self.reconcile_mup_gtp_uplink();
+        self.reconcile_mup_gtp_downlink();
+    }
+
     /// Install GTP-U decap PDRs for a `dataplane gtp` VRF — the ST2 uplink
     /// (`H.M.GTP4.D`). Each selected Type-2 ST route's `(endpoint, TEID)`
     /// becomes a cradle PDR: a G-PDU arriving on that tunnel is stripped and
     /// its inner packet forwarded in this VRF's table. Cradle-only (the kernel
-    /// has no GTP action), diff-gated against `mup_gtp_pdr_installed`. The
-    /// downlink `GTP4.E` encap (ST1 → the gNB) is a follow-up; only the uplink
-    /// decap is installed here. Runs in place of the End.DT46 reconcilers when
-    /// the VRF's `dataplane` is `gtp`.
-    fn reconcile_mup_gtp(&mut self) {
+    /// has no GTP action), diff-gated against `mup_gtp_pdr_installed`.
+    fn reconcile_mup_gtp_uplink(&mut self) {
         use std::net::{IpAddr, Ipv4Addr};
         let table_id = self.ctx.vrf_id();
         // Desired PDRs: each selected ST2 with a v4 endpoint + non-zero TEID.
@@ -912,6 +948,92 @@ impl BgpVrf {
                 teid: *teid,
                 table_id,
             });
+        }
+    }
+
+    /// Install GTP-U encap routes for a `dataplane gtp` VRF — the ST1 downlink
+    /// (`GTP4.E`). Each selected Type-1 ST route with a v4 UE prefix, a v4 GTP
+    /// endpoint (gNB), a non-zero TEID and a v4 source becomes a cradle GTP
+    /// encap route: traffic to the UE prefix in this VRF's table is wrapped in
+    /// outer IPv4 + UDP(2152) + GTP-U(TEID) toward the endpoint (sourced from
+    /// the ST1 source), forwarded over the endpoint's resolved v4 underlay
+    /// (`mup_endpoint_transport`, register-then-gate on the global NHT). An
+    /// unresolved endpoint or a missing source yields no install. Cradle-only,
+    /// diff-gated against `mup_gtp_encap_installed`. The ST1 endpoint is the
+    /// lookup key; the UE prefix is the FIB destination (draft §3.1.3 / §3.3.9)
+    /// — the same key/destination split as `reconcile_mup_st1_isd`, but a real
+    /// GTP tunnel instead of the End.DT46 stand-in.
+    fn reconcile_mup_gtp_downlink(&mut self) {
+        use std::net::IpAddr;
+        let table_id = self.ctx.vrf_id();
+        // Desired encaps: each selected ST1 (v4 UE prefix) whose GTP endpoint
+        // has resolved to a v4 underlay next-hop → the cradle encap key.
+        let mut desired: std::collections::BTreeMap<ipnet::Ipv4Net, MupGtpEncapKey> =
+            std::collections::BTreeMap::new();
+        for (rd, table) in self.local_rib.mup.iter() {
+            for (prefix, rib) in table.selected.iter() {
+                let bgp_packet::MupPrefix::T1st { prefix: ue } = prefix else {
+                    continue;
+                };
+                let ipnet::IpNet::V4(ue4) = ue else {
+                    continue;
+                };
+                let Some(st1) = &rib.mup_st1 else {
+                    continue;
+                };
+                let (IpAddr::V4(endpoint), Some(IpAddr::V4(src))) = (st1.endpoint, st1.source)
+                else {
+                    continue;
+                };
+                if st1.teid == 0 {
+                    continue;
+                }
+                // The gNB endpoint must have resolved to a v4 underlay egress
+                // (register-then-gate); take the first (primary) next-hop.
+                let Some(nh) = self
+                    .mup_endpoint_transport
+                    .get(&(*rd, prefix.clone()))
+                    .and_then(|t| t.first())
+                else {
+                    continue;
+                };
+                let gw = match nh.addr {
+                    IpAddr::V4(a) if !a.is_unspecified() => Some(a),
+                    _ => None,
+                };
+                desired.insert(*ue4, (src, endpoint, st1.teid, gw, nh.ifindex));
+            }
+        }
+        // Withdraw encaps no longer desired (or whose key changed).
+        let stale: Vec<ipnet::Ipv4Net> = self
+            .mup_gtp_encap_installed
+            .iter()
+            .filter(|(ue, key)| desired.get(*ue) != Some(*key))
+            .map(|(ue, _)| *ue)
+            .collect();
+        for ue in stale {
+            let _ = self.ctx.rib.send(crate::rib::Message::CradleGtpEncapDel {
+                prefix: ue,
+                table_id,
+            });
+            self.mup_gtp_encap_installed.remove(&ue);
+        }
+        // Install new / changed encaps.
+        for (ue, key) in &desired {
+            if self.mup_gtp_encap_installed.get(ue) == Some(key) {
+                continue;
+            }
+            let (gtp_src, gtp_dst, teid, gw, oif) = *key;
+            let _ = self.ctx.rib.send(crate::rib::Message::CradleGtpEncapAdd {
+                prefix: *ue,
+                table_id,
+                gtp_src,
+                gtp_dst,
+                teid,
+                gw,
+                oif,
+            });
+            self.mup_gtp_encap_installed.insert(*ue, *key);
         }
     }
 
@@ -1944,6 +2066,7 @@ impl BgpVrf {
                 prefix,
                 rib,
                 transport,
+                endpoint_transport,
             } => {
                 let rd = self.rd.unwrap_or(rd);
                 // A received segment route (DSD/ISD) carries the
@@ -1960,6 +2083,17 @@ impl BgpVrf {
                     } else {
                         self.mup_segment_transport
                             .insert((rd, prefix.clone()), transport);
+                    }
+                }
+                // A Type-1 ST carries the global-resolved v4 underlay transport
+                // for its GTP endpoint (gNB); stash it for the `dataplane gtp`
+                // downlink `GTP4.E` encap. Empty ⇒ the endpoint is unresolved.
+                if matches!(prefix, bgp_packet::MupPrefix::T1st { .. }) {
+                    if endpoint_transport.is_empty() {
+                        self.mup_endpoint_transport.remove(&(rd, prefix.clone()));
+                    } else {
+                        self.mup_endpoint_transport
+                            .insert((rd, prefix.clone()), endpoint_transport);
                     }
                 }
                 let _ = self
@@ -1983,6 +2117,7 @@ impl BgpVrf {
                 // empty RD never renders.
                 let rd = self.rd.unwrap_or(rd);
                 self.mup_segment_transport.remove(&(rd, prefix.clone()));
+                self.mup_endpoint_transport.remove(&(rd, prefix.clone()));
                 let empty = if let Some(table) = self.local_rib.mup.get_mut(&rd) {
                     table.cands.remove(&prefix);
                     table.selected.remove(&prefix);
@@ -2214,6 +2349,117 @@ mod tests {
         assert!(
             vrf.mup_gtp_pdr_installed.is_empty(),
             "the decap PDR is withdrawn when its ST2 is gone"
+        );
+    }
+
+    #[tokio::test]
+    async fn dataplane_gtp_reconciles_st1_to_encaps() {
+        use crate::bgp::route::{BgpRib, BgpRibType};
+        use crate::rib::nht::ResolvedNexthop;
+        use bgp_packet::{BgpAttr, MupPrefix, MupSt1Fields};
+        use std::net::{IpAddr, Ipv4Addr};
+
+        let (global_tx, _global_rx) = unbounded_channel::<BgpGlobalMsg>();
+        let ctx = test_ctx_for_vrf(43, "vrf-gtp-dl");
+        let (_rib_tx, rib_rx) = mpsc::unbounded_channel();
+        let (mut vrf, _inbox) = BgpVrf::new(
+            "vrf-gtp-dl".to_string(),
+            ctx,
+            Ipv4Addr::UNSPECIFIED,
+            65000,
+            /* label */ 16,
+            global_tx,
+            rib_rx,
+        );
+        vrf.dataplane = crate::bgp::vrf_config::MupDataplane::Gtp;
+
+        let attr = BgpAttr::new();
+        let mk_st1 = |teid: u32, endpoint: IpAddr, source: Option<IpAddr>| {
+            let mut rib = BgpRib::new(
+                1,
+                Ipv4Addr::UNSPECIFIED,
+                BgpRibType::EBGP,
+                0,
+                0,
+                &attr,
+                None,
+                None,
+                false,
+            );
+            rib.mup_st1 = Some(MupSt1Fields {
+                teid,
+                qfi: 5,
+                endpoint,
+                source,
+            });
+            rib
+        };
+        let rd: bgp_packet::RouteDistinguisher = "65000:1".parse().unwrap();
+        let gnb = IpAddr::V4(Ipv4Addr::new(10, 0, 12, 1));
+        let src = IpAddr::V4(Ipv4Addr::new(10, 0, 12, 2));
+        // A fully-specified ST1 whose gNB endpoint has resolved to a v4
+        // underlay egress (gateway 10.0.99.1, oif 7).
+        let ue_ok: ipnet::Ipv4Net = "10.60.1.0/24".parse().unwrap();
+        let p_ok = MupPrefix::T1st {
+            prefix: ipnet::IpNet::V4(ue_ok),
+        };
+        // An ST1 with no source → cannot build a GTP outer header → skipped.
+        let ue_nosrc: ipnet::Ipv4Net = "10.60.2.0/24".parse().unwrap();
+        let p_nosrc = MupPrefix::T1st {
+            prefix: ipnet::IpNet::V4(ue_nosrc),
+        };
+        // An ST1 whose endpoint hasn't resolved (no endpoint transport) →
+        // skipped.
+        let ue_unres: ipnet::Ipv4Net = "10.60.3.0/24".parse().unwrap();
+        let p_unres = MupPrefix::T1st {
+            prefix: ipnet::IpNet::V4(ue_unres),
+        };
+        {
+            let table = vrf.local_rib.mup.entry(rd).or_default();
+            table
+                .selected
+                .insert(p_ok.clone(), mk_st1(0x2222, gnb, Some(src)));
+            table
+                .selected
+                .insert(p_nosrc.clone(), mk_st1(0x3333, gnb, None));
+            table
+                .selected
+                .insert(p_unres.clone(), mk_st1(0x4444, gnb, Some(src)));
+        }
+        // Only the first ST1's endpoint is resolved.
+        vrf.mup_endpoint_transport.insert(
+            (rd, p_ok.clone()),
+            vec![ResolvedNexthop {
+                addr: IpAddr::V4(Ipv4Addr::new(10, 0, 99, 1)),
+                ifindex: 7,
+                labels: Vec::new(),
+            }],
+        );
+
+        vrf.reconcile_mup_gtp();
+        assert_eq!(
+            vrf.mup_gtp_encap_installed.get(&ue_ok),
+            Some(&(
+                Ipv4Addr::new(10, 0, 12, 2),       // gtp_src
+                Ipv4Addr::new(10, 0, 12, 1),       // gtp_dst (gNB endpoint)
+                0x2222,                            // teid
+                Some(Ipv4Addr::new(10, 0, 99, 1)), // resolved gateway
+                7,                                 // resolved oif
+            )),
+            "the resolved ST1 with a source installs a GTP4.E encap"
+        );
+        assert_eq!(
+            vrf.mup_gtp_encap_installed.len(),
+            1,
+            "only the source-carrying, endpoint-resolved ST1 installs an encap"
+        );
+
+        // The endpoint resolution goes away → the encap is withdrawn.
+        vrf.mup_endpoint_transport.remove(&(rd, p_ok.clone()));
+        vrf.reconcile_mup_gtp();
+        assert!(
+            vrf.mup_gtp_encap_installed.is_empty(),
+            "the GTP4.E encap is withdrawn when its endpoint stops resolving"
         );
     }
 

--- a/zebra-rs/src/bgp/vrf/msg.rs
+++ b/zebra-rs/src/bgp/vrf/msg.rs
@@ -78,6 +78,13 @@ pub enum BgpVrfMsg {
         /// route types the install doesn't steer. Mirrors `ImportV4`'s
         /// `transport`.
         transport: Vec<ResolvedNexthop>,
+        /// Resolved v4 underlay transport for a Type-1 ST route's GTP endpoint
+        /// (gNB), when the global instance has NHT-resolved it
+        /// (register-then-gate on `st1.endpoint`). Consumed by the `dataplane
+        /// gtp` downlink reconcile to fill the cradle `GTP4.E` encap nexthop's
+        /// underlay gateway/oif. Empty for non-ST1 routes and unresolved
+        /// endpoints.
+        endpoint_transport: Vec<ResolvedNexthop>,
     },
     /// Withdraw a previously-imported MUP route (the global RIB no longer has
     /// a selected path for it). Flooded to every VRF; the per-VRF removal is

--- a/zebra-rs/src/fib/cradle.rs
+++ b/zebra-rs/src/fib/cradle.rs
@@ -112,6 +112,9 @@ pub struct CradleFib {
     nh_ids6: Arc<Mutex<HashMap<([u8; 16], u32, Vec<u32>, u32), u32>>>,
     /// SRv6 nexthop dedup: `(underlay gateway, oif, segment list) -> id`.
     nh_ids_srv6: Arc<Mutex<HashMap<([u8; 16], u32, Vec<[u8; 16]>), u32>>>,
+    /// GTP-U encap nexthop dedup:
+    /// `(gtp_src, gtp_dst, teid, underlay gateway, oif) -> id`.
+    nh_ids_gtp: Arc<Mutex<HashMap<([u8; 4], [u8; 4], u32, u32, u32), u32>>>,
     next_id: Arc<AtomicU32>,
     /// The SRv6 H.Encaps source is pushed once (best-effort).
     encap_src_set: Arc<std::sync::atomic::AtomicBool>,
@@ -133,6 +136,7 @@ impl CradleFib {
             nh_ids: Arc::new(Mutex::new(HashMap::new())),
             nh_ids6: Arc::new(Mutex::new(HashMap::new())),
             nh_ids_srv6: Arc::new(Mutex::new(HashMap::new())),
+            nh_ids_gtp: Arc::new(Mutex::new(HashMap::new())),
             next_id: Arc::new(AtomicU32::new(1)),
             encap_src_set: Arc::new(std::sync::atomic::AtomicBool::new(false)),
         }
@@ -182,6 +186,9 @@ impl CradleFib {
                 segs: Vec::new(),
                 encap_mode: 0,
                 backup_id: 0,
+                gtp_src: String::new(),
+                gtp_dst: String::new(),
+                gtp_teid: 0,
             })
             .await?;
         self.nh_ids.lock().await.insert(key, id);
@@ -221,6 +228,9 @@ impl CradleFib {
                 segs: segs.iter().map(|a| a.to_string()).collect(),
                 encap_mode,
                 backup_id: 0,
+                gtp_src: String::new(),
+                gtp_dst: String::new(),
+                gtp_teid: 0,
             })
             .await?;
         self.nh_ids_srv6.lock().await.insert(key, id);
@@ -391,6 +401,9 @@ impl CradleFib {
                 segs: Vec::new(),
                 encap_mode: 0,
                 backup_id,
+                gtp_src: String::new(),
+                gtp_dst: String::new(),
+                gtp_teid: 0,
             })
             .await?;
         self.nh_ids6.lock().await.insert(key, id);
@@ -710,6 +723,105 @@ impl CradleFib {
         .await
         {
             tracing::debug!("fib: cradle gtp_pdr_del {dst} teid {teid} failed: {e}");
+        }
+    }
+
+    /// Resolve (creating if needed) a GTP-U encap nexthop id: a v4 underlay
+    /// nexthop (`gw`/`oif`) that wraps the packet in outer IPv4 + UDP(2152) +
+    /// GTP-U toward `gtp_dst` (sourced from `gtp_src`, TEID `teid`).
+    async fn gtp_nexthop_id(
+        &self,
+        gtp_src: Ipv4Addr,
+        gtp_dst: Ipv4Addr,
+        teid: u32,
+        gw: Option<Ipv4Addr>,
+        oif: u32,
+    ) -> anyhow::Result<u32> {
+        let key = (
+            gtp_src.octets(),
+            gtp_dst.octets(),
+            teid,
+            gw.map(u32::from).unwrap_or(0),
+            oif,
+        );
+        {
+            let ids = self.nh_ids_gtp.lock().await;
+            if let Some(id) = ids.get(&key) {
+                return Ok(*id);
+            }
+        }
+        let id = self.next_id.fetch_add(1, Ordering::Relaxed);
+        self.client()
+            .await?
+            .set_nexthop(pb::Nexthop {
+                id,
+                gateway: gw.map(|a| a.to_string()).unwrap_or_default(),
+                oif: String::new(),
+                oif_index: oif,
+                v6: false,
+                labels: Vec::new(),
+                segs: Vec::new(),
+                encap_mode: 0,
+                backup_id: 0,
+                gtp_src: gtp_src.to_string(),
+                gtp_dst: gtp_dst.to_string(),
+                gtp_teid: teid,
+            })
+            .await?;
+        self.nh_ids_gtp.lock().await.insert(key, id);
+        Ok(id)
+    }
+
+    /// Install a GTP-U encap route (`GTP4.E`): traffic to `prefix` in `table_id`
+    /// is wrapped in outer IPv4 + UDP(2152) + GTP-U(`teid`) toward `gtp_dst`
+    /// (sourced from `gtp_src`) over the resolved v4 underlay `gw`/`oif`.
+    #[allow(clippy::too_many_arguments)]
+    pub async fn gtp_encap_install(
+        &self,
+        prefix: Ipv4Net,
+        table_id: u32,
+        gtp_src: Ipv4Addr,
+        gtp_dst: Ipv4Addr,
+        teid: u32,
+        gw: Option<Ipv4Addr>,
+        oif: u32,
+    ) {
+        if let Err(e) = async {
+            let id = self.gtp_nexthop_id(gtp_src, gtp_dst, teid, gw, oif).await?;
+            self.client()
+                .await?
+                .add_route4(pb::Route4 {
+                    prefix: prefix.to_string(),
+                    nexthop_id: id,
+                    flags: 0,
+                    vrf_table_id: cradle_vrf(table_id),
+                })
+                .await?;
+            anyhow::Ok(())
+        }
+        .await
+        {
+            tracing::warn!(
+                "fib: cradle gtp_encap_install {prefix} -> {gtp_dst} teid {teid} failed: {e}"
+            );
+        }
+    }
+
+    /// Remove a GTP-U encap route (the nexthop is kept for dedup reuse).
+    pub async fn gtp_encap_del(&self, prefix: Ipv4Net, table_id: u32) {
+        if let Err(e) = async {
+            self.client()
+                .await?
+                .del_route4(pb::Route4Del {
+                    prefix: prefix.to_string(),
+                    vrf_table_id: cradle_vrf(table_id),
+                })
+                .await?;
+            anyhow::Ok(())
+        }
+        .await
+        {
+            tracing::debug!("fib: cradle gtp_encap_del {prefix} failed: {e}");
         }
     }
 

--- a/zebra-rs/src/fib/netlink/handle.rs
+++ b/zebra-rs/src/fib/netlink/handle.rs
@@ -564,6 +564,28 @@ impl FibHandle {
             cradle.gtp_pdr_del(dst, teid).await;
         }
     }
+    #[allow(clippy::too_many_arguments)]
+    pub async fn cradle_gtp_encap_add(
+        &self,
+        prefix: ipnet::Ipv4Net,
+        table_id: u32,
+        gtp_src: std::net::Ipv4Addr,
+        gtp_dst: std::net::Ipv4Addr,
+        teid: u32,
+        gw: Option<std::net::Ipv4Addr>,
+        oif: u32,
+    ) {
+        if let Some(cradle) = &self.cradle {
+            cradle
+                .gtp_encap_install(prefix, table_id, gtp_src, gtp_dst, teid, gw, oif)
+                .await;
+        }
+    }
+    pub async fn cradle_gtp_encap_del(&self, prefix: ipnet::Ipv4Net, table_id: u32) {
+        if let Some(cradle) = &self.cradle {
+            cradle.gtp_encap_del(prefix, table_id).await;
+        }
+    }
 
     /// Tee an EVPN VPWS cross-connect to cradle (RFC 8214 Type-1 with an
     /// SRv6 End.DX2 SID): bind AC `port` to the remote service SID, and —

--- a/zebra-rs/src/rib/inst.rs
+++ b/zebra-rs/src/rib/inst.rs
@@ -362,6 +362,23 @@ pub enum Message {
         ifname: String,
         local_sid: Option<std::net::Ipv6Addr>,
     },
+    /// MUP `dataplane gtp` downlink encap (`GTP4.E`): a GTP-U encap route teed
+    /// to cradle — traffic to `prefix` in VRF `table_id` is wrapped in outer
+    /// IPv4 + UDP(2152) + GTP-U(`teid`) toward `gtp_dst` (sourced from
+    /// `gtp_src`) over the resolved v4 underlay `gw`/`oif`. Cradle-only.
+    CradleGtpEncapAdd {
+        prefix: ipnet::Ipv4Net,
+        table_id: u32,
+        gtp_src: std::net::Ipv4Addr,
+        gtp_dst: std::net::Ipv4Addr,
+        teid: u32,
+        gw: Option<std::net::Ipv4Addr>,
+        oif: u32,
+    },
+    CradleGtpEncapDel {
+        prefix: ipnet::Ipv4Net,
+        table_id: u32,
+    },
     /// A MAC the cradle eBPF datapath learned on a local L2 port (via the
     /// `WatchFdb` stream). Re-emitted to EVPN subscribers as a synthesized
     /// `RibRx::FdbAdd` — the cradle analogue of a kernel bridge FDB learn —
@@ -3175,6 +3192,22 @@ impl Rib {
                 self.fib_handle
                     .cradle_xconnect_del(&ifname, local_sid)
                     .await;
+            }
+            Message::CradleGtpEncapAdd {
+                prefix,
+                table_id,
+                gtp_src,
+                gtp_dst,
+                teid,
+                gw,
+                oif,
+            } => {
+                self.fib_handle
+                    .cradle_gtp_encap_add(prefix, table_id, gtp_src, gtp_dst, teid, gw, oif)
+                    .await;
+            }
+            Message::CradleGtpEncapDel { prefix, table_id } => {
+                self.fib_handle.cradle_gtp_encap_del(prefix, table_id).await;
             }
             Message::MdbAdd {
                 vni,


### PR DESCRIPTION
## Summary

Completes the `dataplane gtp` datapath. Alongside the merged ST2 uplink decap (`H.M.GTP4.D`, #1777), a selected **Type-1 ST** route now programs a real GTP-U **downlink encap** (`GTP4.E`) toward the gNB via the cradle eBPF forwarder.

**Endpoint resolution (register-then-gate).** The BGP task has no synchronous RIB access, so the gNB endpoint is resolved through the global NHT:
- A new `NhtDep::MupEndpoint` tracks the ST1's `st1.endpoint` (distinct from the BGP-next-hop `NhtDep::Mup`).
- Its resolved v4 underlay `(gateway, oif)` rides a new `MupUpdate.endpoint_transport` to the per-VRF task.
- Covers **received** ST1s (`route_mup_update`/`withdraw`) and the MUP-C's **locally-originated** ST1s (`mup_apply_selected`), plus reroute/reachability re-dispatch (`mup_redispatch_endpoint`).

**VRF reconcile.** `reconcile_mup_gtp` splits into uplink (existing PDR) + downlink. For each selected `T1st{ue}` with a v4 UE prefix, v4 endpoint, non-zero TEID, a v4 source, and a resolved endpoint → install a cradle GTP encap nexthop `{gtp_src, gtp_dst=endpoint, gtp_teid}` + a UE-prefix route into the VRF table. The endpoint is the lookup key, the UE prefix the FIB destination — mirroring `reconcile_mup_st1_isd` but with a real tunnel instead of the End.DT46 stand-in. Diff-gated; v4-UE-prefix scoped (v6 inner is a follow-up).

**Cradle seam.** proto `Nexthop` gains `gtp_src`/`gtp_dst`/`gtp_teid` (13/14/15); `CradleFib::gtp_encap_install/del` + a GTP nexthop dedup map; `FibHandle::cradle_gtp_encap_add/del`; `Message::CradleGtpEncapAdd/Del`. **cradle needs no change** — its GTP nexthop with a resolved oif already forwards directly (proven by `cradle_gtp`). zebra-rs resolves the oif here rather than re-FIBing inside the eBPF, because the 512-byte BPF combined-stack ceiling ruled that out.

## Test plan

- New unit test `dataplane_gtp_reconciles_st1_to_encaps` (install/skip/withdraw paths).
- `cargo fmt` — clean
- `cargo clippy --workspace --all-targets -- -D warnings` — clean
- `cargo test -p zebra-rs mup` — 40 passed (incl. both GTP up/downlink tests)
- Live zebra-rs↔cradle end-to-end GTP BDD is a dedicated follow-up (mirrors how the uplink shipped).

Generated with [Claude Code](https://claude.com/claude-code)