### PR TITLE
feat(bgp): VLAN-scoped EVPN VPWS — vlan leaf, End.DX2V, vid-scoped xconnect tee

### DIFF
--- a/proto/cradle.proto
+++ b/proto/cradle.proto
@@ -135,13 +135,22 @@ message Xconnect {
   string remote_sid = 3;
   // When non-empty, also install this End.DX2 LocalSid bound to the same
   // AC (decap + raw emit) — one RPC binds the E-Line both directions.
+  // With a non-zero vid the LocalSid is an End.DX2V over dx2v_table.
   string local_sid  = 4;
+  // Non-zero = VLAN-scoped E-Line (RFC 8214 VLAN-based service): only
+  // 802.1Q frames with this VID on the AC enter the cross-connect (the
+  // tag rides inside the encapsulation), and local_sid's End.DX2V demuxes
+  // the return direction from its (dx2v_table, vid) entry onto the AC.
+  uint32 vid        = 5;
+  uint32 dx2v_table = 6; // End.DX2V VLAN-table id (only with vid != 0)
 }
 
 message XconnectDel {
   string port       = 1;
   uint32 port_index = 2;
-  string local_sid  = 3; // when non-empty, also remove this End.DX2 LocalSid
+  string local_sid  = 3; // when non-empty, also remove this End.DX2/DX2V LocalSid
+  uint32 vid        = 4; // non-zero = remove the VLAN-scoped binding
+  uint32 dx2v_table = 5;
 }
 
 // A BUM ingress-replication slot: one remote PE in bridge domain `bd`,

--- a/zebra-rs/src/bgp/config.rs
+++ b/zebra-rs/src/bgp/config.rs
@@ -1908,7 +1908,12 @@ fn config_vpws(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Option<()> {
 
 /// Shared body for the VPWS leaf handlers: mutate one field, then
 /// reconcile the service (withdraw + re-originate + re-push the AC
-/// cross-connect as needed).
+/// cross-connect as needed). Two invariants ride here so every leaf gets
+/// them: a live binding whose `(vid, VLAN-table)` scoping changed (vlan
+/// or evi edits) is unbound under its OLD pair first — the reconcile's
+/// re-add can't reach the stale cradle entry — and a vlan-presence flip
+/// releases the End.DX2/DX2V SID so the re-originate allocates one with
+/// the right behavior.
 fn config_vpws_leaf(
     bgp: &mut Bgp,
     mut args: Args,
@@ -1932,7 +1937,26 @@ fn config_vpws_leaf(
         .services
         .entry(name.clone())
         .or_default();
+    let old_bound = svc.remote_sid.is_some().then(|| svc.interface.clone());
+    let old_vt = svc.vid_table();
+    let old_vlan_set = svc.vlan.is_some();
     set(svc, value);
+    let new_vt = svc.vid_table();
+    let vlan_flipped = svc.vlan.is_some() != old_vlan_set;
+    if old_vt != new_vt
+        && let Some(Some(ifname)) = old_bound
+    {
+        let local_sid = bgp.local_rib.evpn_vpws.sids.get(&name).map(|(a, _)| *a);
+        let _ = bgp.ctx.rib.send(crate::rib::Message::XconnectDel {
+            ifname,
+            local_sid,
+            vid: old_vt.0,
+            table: old_vt.1,
+        });
+    }
+    if vlan_flipped {
+        bgp.free_vpws_dx2_sid(&name);
+    }
     bgp.vpws_reconcile(&name);
     Some(())
 }
@@ -1961,6 +1985,13 @@ fn config_vpws_mtu(bgp: &mut Bgp, args: Args, op: ConfigOp) -> Option<()> {
     config_vpws_leaf(bgp, args, op, |svc, v| svc.mtu = v.map(|m| m as u16), true)
 }
 
+/// `router bgp afi-safi evpn vpws <name> vlan <1..4094>` — scope the AC to
+/// one 802.1Q VID (RFC 8214 VLAN-based E-Line, End.DX2V). The shared leaf
+/// body unbinds the old scoping and re-allocates the SID on a flip.
+fn config_vpws_vlan(bgp: &mut Bgp, args: Args, op: ConfigOp) -> Option<()> {
+    config_vpws_leaf(bgp, args, op, |svc, v| svc.vlan = v.map(|x| x as u16), true)
+}
+
 /// `router bgp afi-safi evpn vpws <name> interface <name>` — the
 /// attachment circuit. Changing (or clearing) it unbinds the old AC's
 /// cross-connect first.
@@ -1982,6 +2013,7 @@ fn config_vpws_interface(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Option<
         .entry(name.clone())
         .or_default();
     let old = std::mem::replace(&mut svc.interface, interface);
+    let (vid, table) = svc.vid_table();
     if old != svc.interface
         && svc.remote_sid.is_some()
         && let Some(old_ifname) = old
@@ -1990,6 +2022,8 @@ fn config_vpws_interface(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Option<
         let _ = bgp.ctx.rib.send(crate::rib::Message::XconnectDel {
             ifname: old_ifname,
             local_sid,
+            vid,
+            table,
         });
     }
     bgp.vpws_reconcile(&name);
@@ -4644,6 +4678,7 @@ impl Bgp {
         );
         self.callback_add("/router/bgp/afi-safi/vpws/interface", config_vpws_interface);
         self.callback_add("/router/bgp/afi-safi/vpws/mtu", config_vpws_mtu);
+        self.callback_add("/router/bgp/afi-safi/vpws/vlan", config_vpws_vlan);
 
         // MUP controller (`router bgp mup-c …`, draft-ietf-bess-mup-safi).
         // Augmented in by zebra-bgp-mup-controller.yang; the controller

--- a/zebra-rs/src/bgp/inst.rs
+++ b/zebra-rs/src/bgp/inst.rs
@@ -1538,16 +1538,25 @@ impl Bgp {
         ))
     }
 
-    /// Allocate (or return the existing) `End.DX2` SID for VPWS service
-    /// `name` — the EVPN VPWS egress SID (RFC 9252 §6.3), advertised on
-    /// the service's Type-1 Ethernet A-D per-EVI route. Registry-only at
-    /// this point: the cradle datapath entry is programmed by the
-    /// `XconnectAdd` tee once the AC binding is known (import side), so
-    /// `route_sid_install` skips the cradle LocalSid write for `EndDX2`.
+    /// Allocate (or return the existing) `End.DX2` / `End.DX2V` SID for
+    /// VPWS service `name` — the EVPN VPWS egress SID (RFC 9252 §6.3),
+    /// advertised on the service's Type-1 Ethernet A-D per-EVI route. A
+    /// VLAN-scoped service (`vlan` set) gets `End.DX2V` with the EVI as
+    /// its VLAN-table id. Registry-only at this point: the cradle datapath
+    /// entry is programmed by the `XconnectAdd` tee once the AC binding is
+    /// known (import side), so `route_sid_install` skips the cradle
+    /// LocalSid write for `EndDX2`/`EndDX2V`.
     fn alloc_vpws_dx2_sid(&mut self, name: &str) -> Option<std::net::Ipv6Addr> {
         if let Some((addr, _function)) = self.local_rib.evpn_vpws.sids.get(name) {
             return Some(*addr);
         }
+        let (vid, table) = self
+            .local_rib
+            .evpn_vpws
+            .services
+            .get(name)
+            .map(|s| s.vid_table())
+            .unwrap_or((0, 0));
         let prefix = self.srv6_locator.as_ref().and_then(|l| l.prefix)?;
         let function = self.srv6_sid_pool.allocate()?;
         match crate::isis::srv6::function_addr(prefix, function) {
@@ -1558,7 +1567,11 @@ impl Bgp {
                     .insert(name.to_string(), (addr, function));
                 let sid = crate::rib::Sid {
                     addr,
-                    behavior: crate::rib::SidBehavior::EndDX2,
+                    behavior: if vid != 0 {
+                        crate::rib::SidBehavior::EndDX2V
+                    } else {
+                        crate::rib::SidBehavior::EndDX2
+                    },
                     context: crate::rib::SidContext::None,
                     owner: crate::rib::SidOwner::new("bgp", 0),
                     locator: self.srv6_locator_name.clone().unwrap_or_default(),
@@ -1566,7 +1579,7 @@ impl Bgp {
                     ifindex: 0,
                     nh6: None,
                     structure: None,
-                    table_id: 0,
+                    table_id: table,
                     segs: Vec::new(),
                     flavors: 0,
                 };
@@ -1580,7 +1593,8 @@ impl Bgp {
         }
     }
 
-    /// Release VPWS service `name`'s `End.DX2` SID back to the pool.
+    /// Release VPWS service `name`'s `End.DX2`/`End.DX2V` SID back to the
+    /// pool.
     pub(super) fn free_vpws_dx2_sid(&mut self, name: &str) {
         if let Some((addr, function)) = self.local_rib.evpn_vpws.sids.remove(name) {
             self.srv6_sid_pool.release(function);
@@ -1589,15 +1603,26 @@ impl Bgp {
     }
 
     /// Build the SRv6 L2 Service Prefix-SID attribute advertised on VPWS
-    /// service `name`'s Type-1 route — this PE's `End.DX2` SID. `None`
-    /// when no locator has resolved.
+    /// service `name`'s Type-1 route — this PE's `End.DX2` (or, for a
+    /// VLAN-scoped service, `End.DX2V`) SID. `None` when no locator has
+    /// resolved.
     pub(super) fn vpws_dx2_prefix_sid(&mut self, name: &str) -> Option<bgp_packet::PrefixSid> {
         let sid = self.alloc_vpws_dx2_sid(name)?;
+        let vlan_scoped = self
+            .local_rib
+            .evpn_vpws
+            .services
+            .get(name)
+            .is_some_and(|s| s.vid_table().0 != 0);
         let structure = self.srv6_locator.as_ref().and_then(|l| l.sid_structure());
         Some(srv6_l2_service_prefix_sid(
             sid,
             structure,
-            bgp_packet::SRV6_BEHAVIOR_END_DX2,
+            if vlan_scoped {
+                bgp_packet::SRV6_BEHAVIOR_END_DX2V
+            } else {
+                bgp_packet::SRV6_BEHAVIOR_END_DX2
+            },
         ))
     }
 

--- a/zebra-rs/src/bgp/route.rs
+++ b/zebra-rs/src/bgp/route.rs
@@ -6810,6 +6810,14 @@ fn evpn_srv6_sid(attr: &BgpAttr, behavior: u16) -> Option<std::net::Ipv6Addr> {
         .map(|(sid, _)| sid)
 }
 
+/// The remote VPWS service SID on a Type-1 (RFC 9252 §6.3): `End.DX2`, or
+/// `End.DX2V` when the remote's attachment circuit is VLAN-scoped. The
+/// ingress encapsulation treats the SID as opaque either way.
+fn evpn_vpws_sid(attr: &BgpAttr) -> Option<std::net::Ipv6Addr> {
+    evpn_srv6_sid(attr, bgp_packet::SRV6_BEHAVIOR_END_DX2)
+        .or_else(|| evpn_srv6_sid(attr, bgp_packet::SRV6_BEHAVIOR_END_DX2V))
+}
+
 /// The L2 MTU from an EVPN route's Layer-2 Attributes EC (RFC 8214 §3.1).
 /// 0 when the EC is absent or carries no MTU — either way, no MTU check.
 fn evpn_l2_attr_mtu(attr: &BgpAttr) -> u16 {
@@ -6938,9 +6946,13 @@ fn route_evpn_export_selected(
                         svc.remote_mtu_mismatch = None;
                         if let Some(ifname) = svc.interface.clone() {
                             let local_sid = vpws.sids.get(name).map(|(a, _)| *a);
-                            let _ = bgp
-                                .rib_client
-                                .send(rib::Message::XconnectDel { ifname, local_sid });
+                            let (vid, table) = svc.vid_table();
+                            let _ = bgp.rib_client.send(rib::Message::XconnectDel {
+                                ifname,
+                                local_sid,
+                                vid,
+                                table,
+                            });
                         }
                     }
                 }
@@ -7122,10 +7134,9 @@ fn route_evpn_export_selected(
                 && best.typ != BgpRibType::Originated
                 && let Some(evi) = extract_vni_from_attr(&best.attr)
             {
-                let Some(remote_sid) = evpn_srv6_sid(&best.attr, bgp_packet::SRV6_BEHAVIOR_END_DX2)
-                else {
-                    // A Type-1 without an End.DX2 L2-Service SID (e.g. an
-                    // RFC 9572 A-D form) has no SRv6 dataplane binding.
+                let Some(remote_sid) = evpn_vpws_sid(&best.attr) else {
+                    // A Type-1 without an End.DX2/DX2V L2-Service SID (e.g.
+                    // an RFC 9572 A-D form) has no SRv6 dataplane binding.
                     return;
                 };
                 let remote_mtu = evpn_l2_attr_mtu(&best.attr);
@@ -7134,6 +7145,7 @@ fn route_evpn_export_selected(
                     if svc.remote_service_id != Some(*eth_tag) || svc.evi != Some(evi) {
                         continue;
                     }
+                    let (vid, table) = svc.vid_table();
                     // RFC 8214 §3.1: both ends non-zero and different —
                     // the remote MUST NOT be used. Unbind if it had been.
                     if !svc.mtu_compatible(remote_mtu) {
@@ -7142,9 +7154,12 @@ fn route_evpn_export_selected(
                             && let Some(ifname) = svc.interface.clone()
                         {
                             let local_sid = vpws.sids.get(name).map(|(a, _)| *a);
-                            let _ = bgp
-                                .rib_client
-                                .send(rib::Message::XconnectDel { ifname, local_sid });
+                            let _ = bgp.rib_client.send(rib::Message::XconnectDel {
+                                ifname,
+                                local_sid,
+                                vid,
+                                table,
+                            });
                         }
                         continue;
                     }
@@ -7156,6 +7171,8 @@ fn route_evpn_export_selected(
                             ifname,
                             remote_sid,
                             local_sid,
+                            vid,
+                            table,
                         });
                     }
                 }
@@ -15099,7 +15116,7 @@ impl Bgp {
                 {
                     continue;
                 }
-                if let Some(sid) = evpn_srv6_sid(&rib.attr, bgp_packet::SRV6_BEHAVIOR_END_DX2) {
+                if let Some(sid) = evpn_vpws_sid(&rib.attr) {
                     return Some((sid, evpn_l2_attr_mtu(&rib.attr)));
                 }
             }
@@ -15132,6 +15149,7 @@ impl Bgp {
             Some((_, remote_mtu)) => (None, Some(remote_mtu)),
             None => (None, None),
         };
+        let (vid, table) = svc.vid_table();
         if let Some(svc) = self.local_rib.evpn_vpws.services.get_mut(name) {
             svc.remote_sid = remote;
             svc.remote_mtu_mismatch = mismatch;
@@ -15143,6 +15161,8 @@ impl Bgp {
                     ifname,
                     remote_sid,
                     local_sid,
+                    vid,
+                    table,
                 });
             }
             // A previously-bound AC whose remote no longer matches (config
@@ -15150,28 +15170,33 @@ impl Bgp {
             // Interface *changes* are unbound by `config_vpws_interface`,
             // which still knows the old AC name.
             (None, Some(ifname)) if cached.is_some() => {
-                let _ = self
-                    .ctx
-                    .rib
-                    .send(crate::rib::Message::XconnectDel { ifname, local_sid });
+                let _ = self.ctx.rib.send(crate::rib::Message::XconnectDel {
+                    ifname,
+                    local_sid,
+                    vid,
+                    table,
+                });
             }
             _ => {}
         }
     }
 
     /// Full teardown for a deleted VPWS service: withdraw the Type-1,
-    /// unbind the AC cross-connect, release the `End.DX2` SID.
+    /// unbind the AC cross-connect, release the `End.DX2`/`End.DX2V` SID.
     pub fn vpws_teardown(&mut self, name: &str) {
         self.evpn_withdraw_vpws(name);
         if let Some(svc) = self.local_rib.evpn_vpws.services.get_mut(name)
             && svc.remote_sid.take().is_some()
             && let Some(ifname) = svc.interface.clone()
         {
+            let (vid, table) = svc.vid_table();
             let local_sid = self.local_rib.evpn_vpws.sids.get(name).map(|(a, _)| *a);
-            let _ = self
-                .ctx
-                .rib
-                .send(crate::rib::Message::XconnectDel { ifname, local_sid });
+            let _ = self.ctx.rib.send(crate::rib::Message::XconnectDel {
+                ifname,
+                local_sid,
+                vid,
+                table,
+            });
         }
         self.free_vpws_dx2_sid(name);
     }

--- a/zebra-rs/src/bgp/show.rs
+++ b/zebra-rs/src/bgp/show.rs
@@ -2506,6 +2506,7 @@ struct VpwsServiceJson {
     local_service_id: Option<u32>,
     remote_service_id: Option<u32>,
     interface: Option<String>,
+    vlan: Option<u16>,
     mtu: Option<u16>,
     local_sid: Option<String>,
     remote_sid: Option<String>,
@@ -2545,6 +2546,7 @@ fn show_bgp_evpn_vpws(
                 local_service_id: svc.local_service_id,
                 remote_service_id: svc.remote_service_id,
                 interface: svc.interface.clone(),
+                vlan: svc.vlan,
                 mtu: svc.mtu,
                 local_sid: vpws.sids.get(name).map(|(addr, _)| addr.to_string()),
                 remote_sid: svc.remote_sid.map(|sid| sid.to_string()),
@@ -2578,11 +2580,19 @@ fn show_bgp_evpn_vpws(
         if let Some(ifname) = &svc.interface {
             writeln!(buf, "  Interface: {ifname}")?;
         }
+        if let Some(vid) = svc.vlan {
+            writeln!(buf, "  VLAN: {vid}")?;
+        }
         if let Some(mtu) = svc.mtu.filter(|m| *m != 0) {
             writeln!(buf, "  MTU: {mtu}")?;
         }
         if let Some((sid, _)) = vpws.sids.get(name) {
-            writeln!(buf, "  Local SID (End.DX2): {sid}")?;
+            let behavior = if svc.vlan.is_some() {
+                "End.DX2V"
+            } else {
+                "End.DX2"
+            };
+            writeln!(buf, "  Local SID ({behavior}): {sid}")?;
         }
         if let Some(sid) = svc.remote_sid {
             writeln!(buf, "  Remote SID: {sid}")?;

--- a/zebra-rs/src/bgp/vpws.rs
+++ b/zebra-rs/src/bgp/vpws.rs
@@ -40,6 +40,11 @@ pub struct VpwsService {
     /// L2 MTU signalled in our Type-1's Layer-2 Attributes EC (RFC 8214
     /// §3.1) and checked against the remote's. `None`/0 = no MTU check.
     pub mtu: Option<u16>,
+    /// 802.1Q VID scoping the AC (RFC 8214 VLAN-based E-Line): only tagged
+    /// frames with this VID enter the cross-connect and the local SID
+    /// becomes `End.DX2V` (VLAN table = the EVI). `None` = whole-port
+    /// service (`End.DX2`).
+    pub vlan: Option<u16>,
     /// The remote's L2 MTU when a matching Type-1 was **rejected** for an
     /// MTU mismatch — the service shows `mtu-mismatch` instead of `up`.
     pub remote_mtu_mismatch: Option<u16>,
@@ -63,6 +68,15 @@ impl VpwsService {
         match self.mtu {
             Some(local) if local != 0 && remote_mtu != 0 => local == remote_mtu,
             _ => true,
+        }
+    }
+
+    /// The cradle xconnect scoping pair `(802.1Q VID, End.DX2V VLAN-table
+    /// id — the EVI)`; `(0, 0)` for a whole-port `End.DX2` service.
+    pub fn vid_table(&self) -> (u16, u32) {
+        match self.vlan {
+            Some(vid) if vid != 0 => (vid, self.evi.unwrap_or(0)),
+            _ => (0, 0),
         }
     }
 }

--- a/zebra-rs/src/config/manager.rs
+++ b/zebra-rs/src/config/manager.rs
@@ -3468,6 +3468,7 @@ mod yang_load_tests {
             "set router bgp afi-safi evpn vpws eline1 remote-service-id 102",
             "set router bgp afi-safi evpn vpws eline1 interface eth0",
             "set router bgp afi-safi evpn vpws eline1 mtu 1500",
+            "set router bgp afi-safi evpn vpws eline1 vlan 30",
         ] {
             let (code, _comps, _state) = parse(path, entry.clone(), None, State::new());
             assert_eq!(code, ExecCode::Success, "`{path}` must be a settable path");

--- a/zebra-rs/src/fib/cradle.rs
+++ b/zebra-rs/src/fib/cradle.rs
@@ -71,6 +71,7 @@ fn srv6_behavior(b: crate::rib::SidBehavior) -> u32 {
         EndDX4 => 15,  // decap + IPv4 cross-connect (per-CE VPN egress)
         EndDX6 => 16,  // decap + IPv6 cross-connect
         EndDX2 => 17,  // decap + raw L2 emit on the AC (EVPN VPWS egress)
+        EndDX2V => 18, // decap + VLAN-table AC demux (VLAN-scoped VPWS egress)
         // uT = a uN whose end-of-carrier lookup is table-scoped: cradle
         // models it as UN with a non-zero vrf_id (vrf_table_id below).
         UT => 6,
@@ -797,16 +798,19 @@ impl CradleFib {
         }
     }
 
-    /// Remove a `(vni, sid)` replication slot.
     /// EVPN VPWS cross-connect (RFC 8214 / RFC 9252 §6.3): bind AC `port`
-    /// to the remote PE's End.DX2 service SID. `local_sid`, when present,
-    /// rides in the same RPC so cradle also installs the local End.DX2
+    /// to the remote PE's End.DX2/DX2V service SID. `local_sid`, when
+    /// present, rides in the same RPC so cradle also installs the local
     /// decap bound to the AC — one message programs the E-Line both ways.
+    /// A non-zero `vid` makes the binding VLAN-scoped (End.DX2V over VLAN
+    /// table `table`).
     pub async fn xconnect_add(
         &self,
         port: &str,
         remote_sid: std::net::Ipv6Addr,
         local_sid: Option<std::net::Ipv6Addr>,
+        vid: u16,
+        table: u32,
     ) {
         let result = async {
             self.client()
@@ -816,6 +820,8 @@ impl CradleFib {
                     port_index: 0,
                     remote_sid: remote_sid.to_string(),
                     local_sid: local_sid.map(|s| s.to_string()).unwrap_or_default(),
+                    vid: vid as u32,
+                    dx2v_table: table,
                 })
                 .await?;
             anyhow::Ok(())
@@ -826,9 +832,15 @@ impl CradleFib {
         }
     }
 
-    /// Remove a VPWS cross-connect (and its local End.DX2 decap, when
+    /// Remove a VPWS cross-connect (and its local End.DX2/DX2V decap, when
     /// `local_sid` is present).
-    pub async fn xconnect_del(&self, port: &str, local_sid: Option<std::net::Ipv6Addr>) {
+    pub async fn xconnect_del(
+        &self,
+        port: &str,
+        local_sid: Option<std::net::Ipv6Addr>,
+        vid: u16,
+        table: u32,
+    ) {
         let result = async {
             self.client()
                 .await?
@@ -836,6 +848,8 @@ impl CradleFib {
                     port: port.to_string(),
                     port_index: 0,
                     local_sid: local_sid.map(|s| s.to_string()).unwrap_or_default(),
+                    vid: vid as u32,
+                    dx2v_table: table,
                 })
                 .await?;
             anyhow::Ok(())
@@ -846,6 +860,7 @@ impl CradleFib {
         }
     }
 
+    /// Remove a `(vni, sid)` replication slot.
     pub async fn repl_slot_del(&self, vni: u32, sid: std::net::Ipv6Addr) {
         let result = async {
             self.client()

--- a/zebra-rs/src/fib/netlink/handle.rs
+++ b/zebra-rs/src/fib/netlink/handle.rs
@@ -309,9 +309,10 @@ fn sid_route_target(
         // they never reach the kernel (no End.DT2U/DT2M seg6local action) —
         // `route_sid_install` returns after the cradle tee. The target is
         // computed anyway so the tee gets the right prefix length.
-        SidBehavior::EndDT2U | SidBehavior::EndDT2M | SidBehavior::EndDX2 => {
-            (RouteHeader::RT_TABLE_MAIN, RouteType::Unicast, 128, addr)
-        }
+        SidBehavior::EndDT2U
+        | SidBehavior::EndDT2M
+        | SidBehavior::EndDX2
+        | SidBehavior::EndDX2V => (RouteHeader::RT_TABLE_MAIN, RouteType::Unicast, 128, addr),
         // End.B6.Encaps (SR Policy Binding SID): a /128 host route in
         // table=main; the SRH it pushes rides inside the seg6local
         // encap, not in the route header.
@@ -566,23 +567,35 @@ impl FibHandle {
     }
 
     /// Tee an EVPN VPWS cross-connect to cradle (RFC 8214 Type-1 with an
-    /// SRv6 End.DX2 SID): bind AC `port` to the remote service SID, and —
-    /// when `local_sid` is present — install the local End.DX2 decap on
-    /// the same AC. No kernel counterpart — cradle is the L2 data plane.
+    /// SRv6 End.DX2/DX2V SID): bind AC `port` to the remote service SID,
+    /// and — when `local_sid` is present — install the local decap on the
+    /// same AC. A non-zero `vid` scopes the binding to that 802.1Q VID
+    /// (End.DX2V over VLAN table `table`). No kernel counterpart — cradle
+    /// is the L2 data plane.
     pub async fn cradle_xconnect_add(
         &self,
         port: &str,
         remote_sid: std::net::Ipv6Addr,
         local_sid: Option<std::net::Ipv6Addr>,
+        vid: u16,
+        table: u32,
     ) {
         if let Some(cradle) = &self.cradle {
-            cradle.xconnect_add(port, remote_sid, local_sid).await;
+            cradle
+                .xconnect_add(port, remote_sid, local_sid, vid, table)
+                .await;
         }
     }
 
-    pub async fn cradle_xconnect_del(&self, port: &str, local_sid: Option<std::net::Ipv6Addr>) {
+    pub async fn cradle_xconnect_del(
+        &self,
+        port: &str,
+        local_sid: Option<std::net::Ipv6Addr>,
+        vid: u16,
+        table: u32,
+    ) {
         if let Some(cradle) = &self.cradle {
-            cradle.xconnect_del(port, local_sid).await;
+            cradle.xconnect_del(port, local_sid, vid, table).await;
         }
     }
 
@@ -1896,17 +1909,21 @@ impl FibHandle {
         let (table, kind, prefix_len, dest_addr) =
             sid_route_target(sid.behavior, sid.addr, sid.structure);
         // Tee the local SID to the cradle eBPF data plane (mirrors the netlink
-        // install below) — the SRv6 analogue of the ILM tee. End.DX2 is
-        // registry-only here: its cradle entry is owned by the AddXconnect
-        // tee (which knows the AC binding); installing from the Sid — whose
-        // ifindex is 0 — would clobber a live cross-connect on replay.
+        // install below) — the SRv6 analogue of the ILM tee. End.DX2/DX2V are
+        // registry-only here: their cradle entries are owned by the
+        // AddXconnect tee (which knows the AC / VLAN-table binding);
+        // installing from the Sid — whose ifindex is 0 — would clobber a
+        // live cross-connect on replay.
         if let Some(cradle) = &self.cradle
-            && sid.behavior != crate::rib::SidBehavior::EndDX2
+            && !matches!(
+                sid.behavior,
+                crate::rib::SidBehavior::EndDX2 | crate::rib::SidBehavior::EndDX2V
+            )
         {
             cradle.local_sid_install(sid, prefix_len, ifindex).await;
         }
         // EVPN-over-SRv6 L2 SIDs are cradle-only: the kernel has no
-        // End.DT2U/DT2M/DX2 seg6local actions, so there is nothing to
+        // End.DT2U/DT2M/DX2/DX2V seg6local actions, so there is nothing to
         // install via netlink. Same for REPLACE-C-SID (RFC 9800 §4.2): no kernel
         // flavor op exists through 6.8, and a plain-End fallback would
         // misread the packed containers as full SIDs — worse than no entry.
@@ -1915,6 +1932,7 @@ impl FibHandle {
             crate::rib::SidBehavior::EndDT2U
                 | crate::rib::SidBehavior::EndDT2M
                 | crate::rib::SidBehavior::EndDX2
+                | crate::rib::SidBehavior::EndDX2V
                 | crate::rib::SidBehavior::EndRep
                 | crate::rib::SidBehavior::EndXRep
                 | crate::rib::SidBehavior::UT
@@ -2085,6 +2103,7 @@ impl FibHandle {
             crate::rib::SidBehavior::EndDT2U
                 | crate::rib::SidBehavior::EndDT2M
                 | crate::rib::SidBehavior::EndDX2
+                | crate::rib::SidBehavior::EndDX2V
                 | crate::rib::SidBehavior::EndRep
                 | crate::rib::SidBehavior::EndXRep
                 | crate::rib::SidBehavior::UT

--- a/zebra-rs/src/fib/netlink/srv6.rs
+++ b/zebra-rs/src/fib/netlink/srv6.rs
@@ -128,10 +128,13 @@ fn seg6local_action(behavior: SidBehavior) -> Seg6LocalAction {
         SidBehavior::EndDX4 => Seg6LocalAction::EndDx4,
         SidBehavior::EndDX6 => Seg6LocalAction::EndDx6,
         // EVPN L2 SIDs never reach the kernel (route_sid_install returns
-        // after the cradle tee — no End.DT2U/DT2M/DX2 seg6local action exists);
-        // map to End so an unexpected call is a visible no-op rather than
-        // a panic.
-        SidBehavior::EndDT2U | SidBehavior::EndDT2M | SidBehavior::EndDX2 => Seg6LocalAction::End,
+        // after the cradle tee — no End.DT2U/DT2M/DX2/DX2V seg6local action
+        // exists); map to End so an unexpected call is a visible no-op
+        // rather than a panic.
+        SidBehavior::EndDT2U
+        | SidBehavior::EndDT2M
+        | SidBehavior::EndDX2
+        | SidBehavior::EndDX2V => Seg6LocalAction::End,
         SidBehavior::EndX | SidBehavior::UA | SidBehavior::UALib => Seg6LocalAction::EndX,
         // REPLACE-C-SID never reaches the kernel (route_sid_install
         // returns after the cradle tee — no kernel flavor op exists);

--- a/zebra-rs/src/rib/inst.rs
+++ b/zebra-rs/src/rib/inst.rs
@@ -348,19 +348,24 @@ pub enum Message {
         teid: u32,
     },
     /// EVPN VPWS (RFC 8214): bind attachment circuit `ifname` to a remote
-    /// PE's `End.DX2` service SID — teed to cradle as an XCONNECT entry
-    /// (every AC frame MAC-in-SRv6 encapsulates toward it, no FDB) plus,
-    /// when `local_sid` is present, the local `End.DX2` LocalSid whose
-    /// decap emits raw on the same AC. No kernel counterpart — cradle is
-    /// the L2 data plane.
+    /// PE's `End.DX2`/`End.DX2V` service SID — teed to cradle as an
+    /// XCONNECT entry (every AC frame MAC-in-SRv6 encapsulates toward it,
+    /// no FDB) plus, when `local_sid` is present, the local decap LocalSid
+    /// that emits raw on the same AC. A non-zero `vid` scopes the binding
+    /// to that 802.1Q VID (End.DX2V over VLAN table `table`). No kernel
+    /// counterpart — cradle is the L2 data plane.
     XconnectAdd {
         ifname: String,
         remote_sid: std::net::Ipv6Addr,
         local_sid: Option<std::net::Ipv6Addr>,
+        vid: u16,
+        table: u32,
     },
     XconnectDel {
         ifname: String,
         local_sid: Option<std::net::Ipv6Addr>,
+        vid: u16,
+        table: u32,
     },
     /// A MAC the cradle eBPF datapath learned on a local L2 port (via the
     /// `WatchFdb` stream). Re-emitted to EVPN subscribers as a synthesized
@@ -3166,14 +3171,21 @@ impl Rib {
                 ifname,
                 remote_sid,
                 local_sid,
+                vid,
+                table,
             } => {
                 self.fib_handle
-                    .cradle_xconnect_add(&ifname, remote_sid, local_sid)
+                    .cradle_xconnect_add(&ifname, remote_sid, local_sid, vid, table)
                     .await;
             }
-            Message::XconnectDel { ifname, local_sid } => {
+            Message::XconnectDel {
+                ifname,
+                local_sid,
+                vid,
+                table,
+            } => {
                 self.fib_handle
-                    .cradle_xconnect_del(&ifname, local_sid)
+                    .cradle_xconnect_del(&ifname, local_sid, vid, table)
                     .await;
             }
             Message::MdbAdd {

--- a/zebra-rs/src/rib/segment_routing/sid.rs
+++ b/zebra-rs/src/rib/segment_routing/sid.rs
@@ -81,6 +81,12 @@ pub enum SidBehavior {
     /// L2 Service Prefix-SID (RFC 9252 §6.3). Cradle-tee-only, like
     /// End.DT2U.
     EndDX2,
+    /// End.DX2V — decapsulation and VLAN L2 table lookup (IANA codepoint
+    /// 22, RFC 8986 §4.10): the VLAN-scoped EVPN VPWS (E-Line) egress —
+    /// the inner frame's 802.1Q VID picks the attachment circuit from
+    /// the SID's VLAN table ([`Sid::table_id`]). Cradle-tee-only, like
+    /// End.DX2.
+    EndDX2V,
     /// End.M — Mirroring Context segment (IANA codepoint 74,
     /// draft-ietf-rtgwg-srv6-egress-protection). A variant of End.DT6:
     /// the protector decapsulates the outer IPv6/SRH and looks the inner
@@ -141,6 +147,7 @@ impl fmt::Display for SidBehavior {
             Self::EndDX4 => write!(f, "End.DX4"),
             Self::EndDX6 => write!(f, "End.DX6"),
             Self::EndDX2 => write!(f, "End.DX2"),
+            Self::EndDX2V => write!(f, "End.DX2V"),
         }
     }
 }
@@ -165,9 +172,9 @@ impl FromStr for SidBehavior {
             "End.DT6" => Ok(Self::EndDT6),
             "End.DT46" => Ok(Self::EndDT46),
             "End.B6.Encaps" => Ok(Self::EndB6Encap),
-            // End.DT2U / End.DT2M / End.DX2 are deliberately absent: they
-            // are allocated by BGP EVPN (per-VNI or per-VPWS service),
-            // never named in config.
+            // End.DT2U / End.DT2M / End.DX2 / End.DX2V are deliberately
+            // absent: they are allocated by BGP EVPN (per-VNI or per-VPWS
+            // service), never named in config.
             "End.M" => Ok(Self::EndM),
             other => Err(SidBehaviorParseError(other.to_string())),
         }
@@ -324,7 +331,8 @@ impl Sid {
             | SidBehavior::EndT
             | SidBehavior::EndDX4
             | SidBehavior::EndDX6
-            | SidBehavior::EndDX2 => Ipv6Net::new(self.addr, 128).expect("/128 is always valid"),
+            | SidBehavior::EndDX2
+            | SidBehavior::EndDX2V => Ipv6Net::new(self.addr, 128).expect("/128 is always valid"),
             SidBehavior::UALib => {
                 let plen = self
                     .structure

--- a/zebra-rs/yang/zebra-bgp-evpn.yang
+++ b/zebra-rs/yang/zebra-bgp-evpn.yang
@@ -213,6 +213,17 @@ module zebra-bgp-evpn {
            check; when both ends signal non-zero MTUs that differ, the
            remote is not bound (the service shows mtu-mismatch).";
       }
+      leaf vlan {
+        type uint16 {
+          range "1..4094";
+        }
+        description
+          "802.1Q VID scoping the attachment circuit (RFC 8214 VLAN-based
+           E-Line): only tagged frames with this VID enter the
+           cross-connect (the tag rides through the service), and the
+           local SID becomes End.DX2V demuxed over the EVI's VLAN table.
+           Absent = whole-port service (End.DX2).";
+      }
     }
     leaf bum-tunnel-type {
       type enumeration {


### PR DESCRIPTION
## Summary

Phase 3 of the EVPN VPWS arc (#1762, #1778, #1779) — RFC 8214 VLAN-based E-Line. Companion to cradle-rs #48.

- **`vpws <name> vlan <1..4094>`** (yang + callback): scopes the AC to one 802.1Q VID. The service's SID becomes **End.DX2V** (IANA 22) demuxed over the EVI's VLAN table, advertised as such in the L2-Service Prefix-SID; import accepts End.DX2 **or** End.DX2V from the remote (ingress encap treats the SID as opaque).
- **`SidBehavior::EndDX2V`**: same 8-site sweep as EndDX2 — registry-only (kernel netlink skipped; the cradle entry is owned by the AddXconnect tee, which knows the VLAN-table binding).
- **Xconnect tee carries `(vid, table)`**: `rib::Message::XconnectAdd/Del`, the FibHandle pass-through, and the cradle RPC gain the pair (proto in sync with cradle-rs #48).
- **Re-scoping correctness**: the shared VPWS leaf-config body unbinds a live cross-connect under its OLD `(vid, table)` when a vlan/evi edit re-scopes it (the reconcile's re-add can't reach the stale cradle entry), and releases the SID on a vlan-presence flip so re-origination allocates the right behavior.
- Show: `VLAN:` line + `vlan` json field; local SID labelled End.DX2/End.DX2V accordingly.

## Test plan
- workspace clippy `-D warnings` clean; full `cargo test --workspace --exclude bdd` clean; `bgp_evpn_vpws_is_settable` grows the `vlan` path
- BDD locally: zebra `bgp_evpn_vpws` 6/6 scenarios; cradle-rs `cradle_vpws_zebra` 3/3 end-to-end with both fresh binaries — an untagged and a VLAN-scoped E-Line share the same AC ports, tagged ping crosses via End.DX2V both directions (zero skipped steps)

🤖 Generated with [Claude Code](https://claude.com/claude-code)