### PR TITLE
bgp/mup: populate ST1 downlink source from the UPF anchor endpoint

### DIFF
--- a/zebra-rs/src/bgp/config.rs
+++ b/zebra-rs/src/bgp/config.rs
@@ -8279,11 +8279,28 @@ mod mup_dual_origination_tests {
     /// boundary, so the bare attr here carries only the route-specific ecom.
     #[test]
     fn st1_builds_t1st_st2_builds_t2st_with_ext_comm() {
-        let (p1, _st1, attr1) =
-            build_mup_st_route(&session("internet"), MupSrv6Direction::Encapsulation, None)
-                .unwrap();
+        // ST1's downlink outer source is the UPF anchor (core-side) endpoint,
+        // so a session with a core endpoint carries it as the ST1 source.
+        let mut s1 = session("internet");
+        s1.core_endpoint = Some("10.9.0.1".parse().unwrap());
+        let (p1, st1, attr1) =
+            build_mup_st_route(&s1, MupSrv6Direction::Encapsulation, None).unwrap();
         assert!(matches!(p1, MupPrefix::T1st { .. }), "st1 → Type-1 ST");
         assert!(attr1.ecom.is_none(), "st1 carries no ext-comm");
+        assert_eq!(
+            st1.and_then(|f| f.source),
+            Some("10.9.0.1".parse().unwrap()),
+            "st1 source is the UPF anchor (core) endpoint for the GTP4.E outer src",
+        );
+        // No core endpoint ⇒ no anchor source ⇒ the GTP encap can't be built.
+        let (_p, st1_nosrc, _a) =
+            build_mup_st_route(&session("internet"), MupSrv6Direction::Encapsulation, None)
+                .unwrap();
+        assert_eq!(
+            st1_nosrc.and_then(|f| f.source),
+            None,
+            "st1 source is absent when the session has no core endpoint",
+        );
 
         // ST2 needs a real core tunnel (endpoint + non-zero TEID); it never
         // borrows the access tunnel.

--- a/zebra-rs/src/bgp/route.rs
+++ b/zebra-rs/src/bgp/route.rs
@@ -8353,7 +8353,15 @@ pub(super) fn build_mup_st_route(
                     teid: session.teid,
                     qfi: session.qfi.unwrap_or(0),
                     endpoint,
-                    source: None,
+                    // The downlink outer source is the UPF's own anchor tunnel
+                    // address — the same core-side endpoint the gNB tunnels
+                    // uplink *to* (ST2's endpoint), populated from the core FAR
+                    // or the configured `mup-c upf-address`. Carrying it here
+                    // lets a `dataplane gtp` VRF build the GTP4.E outer header
+                    // (draft §3.2.1 optional Source Address). `None` when the
+                    // session has no core-side endpoint (no anchor source, so
+                    // the GTP encap can't be built).
+                    source: session.core_endpoint,
                 }),
             ),
             _ => return None,


### PR DESCRIPTION
## Summary

Follow-up correctness fix for the `dataplane gtp` downlink GTP4.E encap (#1781).

The downlink reconcile requires the ST1's `source` (the outer IPv4 source of the GTP-U packet), but `build_mup_st_route` hardcoded `source: None`. So a **PFCP-originated ST1 never carried a source**, and `reconcile_mup_gtp_downlink` skipped it — the downlink encap could not actually install for a real session.

This sets the ST1 source to the session's **core-side endpoint** — the UPF's own anchor tunnel address, populated from a `Dest=Core` FAR or the configured `mup-c upf-address`. That's exactly the address the gNB tunnels uplink *to* (ST2's endpoint), so the GTP tunnel is symmetric: **downlink outer src = uplink outer dst = the UPF anchor**. `source` stays `None` when the session has no core endpoint (no anchor ⇒ no GTP4.E outer header ⇒ no install), matching the reconcile's source-required gate.

This unblocks the live zebra↔cradle end-to-end GTP BDD (the encap now installs from a PFCP session).

## Test plan

- `build_mup_st_route` unit test extended: source present when the session has a core endpoint, absent without one.
- `cargo fmt` — clean
- `cargo clippy --workspace --all-targets -- -D warnings` — clean
- `cargo test -p zebra-rs` (`build_mup_st_route` + `dataplane_gtp`) — passing

Generated with [Claude Code](https://claude.com/claude-code)