### PR TITLE
bgp/mup: carry origin_vrf on the ST1 endpoint-resolution re-dispatch

### DIFF
--- a/zebra-rs/src/bgp/inst.rs
+++ b/zebra-rs/src/bgp/inst.rs
@@ -4059,6 +4059,19 @@ impl Bgp {
         let Some(winner) = selected.first() else {
             return;
         };
+        // A locally-originated ST1 reaches its origin VRF by RD (not RT), so
+        // the endpoint-resolution re-dispatch must carry the same `origin_vrf`
+        // as the initial `mup_apply_selected` — otherwise a route with no
+        // export RT never gets its resolved endpoint and the `dataplane gtp`
+        // downlink encap never installs.
+        let origin_vrf = if winner.typ.is_originated() {
+            self.vrfs
+                .iter()
+                .find(|(_, cfg)| cfg.rd == Some(rd))
+                .map(|(name, _)| name.clone())
+        } else {
+            None
+        };
         let endpoint_transport = if reachable {
             self.nexthop_cache.transport_for(nh).to_vec()
         } else {
@@ -4073,7 +4086,7 @@ impl Bgp {
             rd,
             &prefix,
             Some(winner),
-            None,
+            origin_vrf.as_deref(),
             &[],
             &endpoint_transport,
         );
@@ -4397,6 +4410,18 @@ impl Bgp {
             NhtDep::MupEndpoint(rd, prefix) => {
                 let selected = top.local_rib.select_best_path_mup(rd, prefix);
                 if let Some(winner) = selected.first() {
+                    // Same RD-origin dispatch as `mup_redispatch_endpoint`: a
+                    // locally-originated ST1 with no export RT reaches its
+                    // origin VRF only by RD, so the first endpoint resolution
+                    // (a reachability flip) must carry `origin_vrf`.
+                    let origin_vrf = if winner.typ.is_originated() {
+                        self.vrfs
+                            .iter()
+                            .find(|(_, cfg)| cfg.rd == Some(*rd))
+                            .map(|(name, _)| name.clone())
+                    } else {
+                        None
+                    };
                     let endpoint_transport = if reachable {
                         self.nexthop_cache.transport_for(nh).to_vec()
                     } else {
@@ -4411,7 +4436,7 @@ impl Bgp {
                         *rd,
                         prefix,
                         Some(winner),
-                        None,
+                        origin_vrf.as_deref(),
                         &[],
                         &endpoint_transport,
                     );


### PR DESCRIPTION
## Summary

Third follow-up for the `dataplane gtp` downlink GTP4.E encap — the fix that makes it actually forward, found by building the live end-to-end BDD.

The downlink encap resolves the ST1's GTP endpoint via NHT (register-then-gate). For a **locally-originated** ST1 (the MUP-C's own PFCP session), the first dispatch (`mup_apply_selected`) runs before the endpoint resolves, so it carries an empty endpoint transport; the resolved value arrives later on the NHT callback (`mup_redispatch_endpoint` and the reachability arm of `nht_reeval_dep`).

Those callbacks dispatched with `origin_vrf = None` — reaching VRFs **only by route-target**. A locally-originated ST1 with no export RT reaches its origin VRF only by **RD**, so the resolved endpoint transport never arrived and `reconcile_mup_gtp_downlink` never installed the encap into cradle. The downlink silently did nothing once the endpoint had to resolve asynchronously.

Fix: compute the RD-matched `origin_vrf` in both callback paths, mirroring `mup_apply_selected`.

## Test plan

- Live end-to-end BDD (cradle-rs `cradle_mup_gtp_zebra`): a standalone zebra UPF + a static-cradle gNB. **z1 `gtp_encap` goes nonzero only with this fix** (downlink), alongside the already-working uplink decap. 4/4 scenarios, 51/51 steps green.
- `cargo fmt`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo test -p zebra-rs` (`dataplane_gtp`) — all clean.

Generated with [Claude Code](https://claude.com/claude-code)