### PR TITLE
feat(fib): SR-MPLS TI-LFA in the cradle tee — v4 backup_id + local-pop ILM shape

### DIFF
--- a/zebra-rs/src/fib/cradle.rs
+++ b/zebra-rs/src/fib/cradle.rs
@@ -35,8 +35,9 @@ pub const MPLS_OP_POP_L3: u32 = 1;
 pub type Leaf = (Option<IpAddr>, u32, Vec<u32>, Vec<Ipv6Addr>, u32);
 
 /// A teed route member: a leaf plus an optional fast-reroute backup leaf
-/// (`Nexthop::Protect` — the backup carries the TI-LFA SRv6 repair: packed
-/// uSID carriers + H.Insert). Backups never nest.
+/// (`Nexthop::Protect` — the backup carries the TI-LFA repair: packed uSID
+/// carriers + H.Insert for SRv6, the repair label stack for SR-MPLS).
+/// Backups never nest.
 type Member = (
     Option<IpAddr>,
     u32,
@@ -107,9 +108,9 @@ fn cradle_vrf(table_id: u32) -> u32 {
 pub struct CradleFib {
     endpoint: String,
     client: Arc<Mutex<Option<CradleClient<Channel>>>>,
-    /// Dedup `(gateway, oif, out-label stack) -> nexthop id` so we
+    /// Dedup `(gateway, oif, out-label stack, backup id) -> nexthop id` so we
     /// `SetNexthop` once per distinct nexthop.
-    nh_ids: Arc<Mutex<HashMap<(u32, u32, Vec<u32>), u32>>>,
+    nh_ids: Arc<Mutex<HashMap<(u32, u32, Vec<u32>, u32), u32>>>,
     nh_ids6: Arc<Mutex<HashMap<([u8; 16], u32, Vec<u32>, u32), u32>>>,
     /// SRv6 nexthop dedup: `(underlay gateway, oif, segment list) -> id`.
     nh_ids_srv6: Arc<Mutex<HashMap<([u8; 16], u32, Vec<[u8; 16]>), u32>>>,
@@ -161,13 +162,21 @@ impl CradleFib {
     /// Resolve (creating if needed) the cradle nexthop id for
     /// `(gw, oif, out-label stack)`. A non-empty `labels` makes this an MPLS
     /// nexthop: the stack is the imposition (route) or swap (ILM) labels.
+    /// A non-zero `backup_id` marks a protected primary — the data plane
+    /// fails over to that nexthop on link-down (SR-MPLS TI-LFA).
     async fn nexthop_id(
         &self,
         gw: Option<Ipv4Addr>,
         oif: u32,
         labels: &[u32],
+        backup_id: u32,
     ) -> anyhow::Result<u32> {
-        let key = (gw.map(u32::from).unwrap_or(0), oif, labels.to_vec());
+        let key = (
+            gw.map(u32::from).unwrap_or(0),
+            oif,
+            labels.to_vec(),
+            backup_id,
+        );
         {
             let ids = self.nh_ids.lock().await;
             if let Some(id) = ids.get(&key) {
@@ -186,7 +195,7 @@ impl CradleFib {
                 labels: labels.to_vec(),
                 segs: Vec::new(),
                 encap_mode: 0,
-                backup_id: 0,
+                backup_id,
                 gtp_src: String::new(),
                 gtp_dst: String::new(),
                 gtp_teid: 0,
@@ -243,9 +252,10 @@ impl CradleFib {
     /// gateway, or `route_v6` for an on-link (gateway-less) member.
     async fn member_nexthop_id(&self, m: &Member, route_v6: bool) -> anyhow::Result<u32> {
         let (gw, oif, labels, segs, encap_mode, backup) = m;
-        // Fast-reroute: resolve the backup leaf first (typically the TI-LFA
-        // SRv6 repair: packed carriers + H.Insert), then hang its id off the
-        // primary so the datapath fails over on link-down.
+        // Fast-reroute: resolve the backup leaf first (the TI-LFA repair —
+        // packed carriers + H.Insert for SRv6, the repair label stack for
+        // SR-MPLS), then hang its id off the primary so the datapath fails
+        // over on link-down.
         let backup_id = match backup {
             Some((bgw, boif, blabels, bsegs, bmode)) => {
                 self.leaf_nexthop_id(bgw, *boif, blabels, bsegs, *bmode, route_v6)
@@ -261,10 +271,10 @@ impl CradleFib {
             return self.srv6_nexthop_id(gw6, *oif, segs, *encap_mode).await;
         }
         match gw {
-            Some(IpAddr::V4(a)) => self.nexthop_id(Some(*a), *oif, labels).await,
+            Some(IpAddr::V4(a)) => self.nexthop_id(Some(*a), *oif, labels, backup_id).await,
             Some(IpAddr::V6(a)) => self.nexthop_id6(Some(*a), *oif, labels, backup_id).await,
             None if route_v6 => self.nexthop_id6(None, *oif, labels, backup_id).await,
-            None => self.nexthop_id(None, *oif, labels).await,
+            None => self.nexthop_id(None, *oif, labels, backup_id).await,
         }
     }
 
@@ -286,10 +296,10 @@ impl CradleFib {
             return self.srv6_nexthop_id(gw6, oif, segs, encap_mode).await;
         }
         match gw {
-            Some(IpAddr::V4(a)) => self.nexthop_id(Some(*a), oif, labels).await,
+            Some(IpAddr::V4(a)) => self.nexthop_id(Some(*a), oif, labels, 0).await,
             Some(IpAddr::V6(a)) => self.nexthop_id6(Some(*a), oif, labels, 0).await,
             None if route_v6 => self.nexthop_id6(None, oif, labels, 0).await,
-            None => self.nexthop_id(None, oif, labels).await,
+            None => self.nexthop_id(None, oif, labels, 0).await,
         }
     }
 
@@ -499,8 +509,8 @@ impl CradleFib {
         let result = async {
             let nexthop_id = match gw {
                 Some(IpAddr::V6(v6)) => self.nexthop_id6(Some(v6), oif, out_labels, 0).await?,
-                Some(IpAddr::V4(v4)) => self.nexthop_id(Some(v4), oif, out_labels).await?,
-                None => self.nexthop_id(None, oif, out_labels).await?,
+                Some(IpAddr::V4(v4)) => self.nexthop_id(Some(v4), oif, out_labels, 0).await?,
+                None => self.nexthop_id(None, oif, out_labels, 0).await?,
             };
             self.client()
                 .await?
@@ -557,7 +567,7 @@ impl CradleFib {
                     self.nexthop_id6(Some(a), oif, &[], 0).await?
                 }
                 Some(IpAddr::V4(a)) if !a.is_unspecified() => {
-                    self.nexthop_id(Some(a), oif, &[]).await?
+                    self.nexthop_id(Some(a), oif, &[], 0).await?
                 }
                 _ => 0,
             };

--- a/zebra-rs/src/fib/netlink/handle.rs
+++ b/zebra-rs/src/fib/netlink/handle.rs
@@ -405,9 +405,9 @@ fn cradle_members(nexthop: &Nexthop) -> Vec<CradleMember> {
             })
             .collect(),
         // Fast-reroute: the primary rides with its backup leaf attached (the
-        // TI-LFA SRv6 repair — packed uSID carriers + H.Insert), so cradle
-        // programs a protected nexthop pair. ECMP primaries are teed
-        // unprotected (MVP).
+        // TI-LFA repair — packed uSID carriers + H.Insert for SRv6, the
+        // repair label stack for SR-MPLS), so cradle programs a protected
+        // nexthop pair. ECMP primaries are teed unprotected (MVP).
         Nexthop::Protect(pro) => {
             let backup = match &pro.backup {
                 NexthopMember::Uni(u) => Some(leaf(u)),
@@ -2854,6 +2854,17 @@ impl FibHandle {
                             0,
                             &[],
                         )
+                        .await;
+                }
+                // Self prefix-SID (UHP local pop): the loopback nexthop is
+                // for the kernel LFIB only — teeing it would make the eBPF
+                // pop-and-forward resolve an L2 neighbor on `lo` and punt.
+                // A nexthop-less pop takes the chained-pop path instead:
+                // whatever sits underneath (a further label, or the IP
+                // payload) is also this node's to process.
+                _ if ilm.local_pop => {
+                    cradle
+                        .ilm_install(label, crate::fib::cradle::MPLS_OP_SWAP, 0, None, 0, &[])
                         .await;
                 }
                 _ => {

--- a/zebra-rs/src/rib/inst.rs
+++ b/zebra-rs/src/rib/inst.rs
@@ -662,6 +662,17 @@ pub struct IlmEntry {
     /// True for the winning candidate at this label — the one
     /// installed to the kernel LFIB. Set by `Rib::ilm_select_sync`.
     pub selected: bool,
+    /// The pop delivers locally: the nexthop egress is a loopback
+    /// (a node's own prefix-SID / UHP entry), so whatever sits under
+    /// the label is also ours. Stamped by `Rib::ilm_add` from the
+    /// link table — producers install the loopback nexthop the
+    /// kernel LFIB needs and don't set this themselves. The cradle
+    /// tee keys on it: a local pop must NOT be teed with the
+    /// loopback nexthop (the eBPF pop-and-forward would try to
+    /// resolve an L2 neighbor on `lo` and punt); it becomes a
+    /// nexthop-less pop so the data plane's chained-pop path
+    /// continues into the label(s)/IP underneath.
+    pub local_pop: bool,
 }
 
 impl IlmEntry {
@@ -673,6 +684,7 @@ impl IlmEntry {
             distance: ilm_distance(rtype),
             metric: 0,
             selected: false,
+            local_pop: false,
         }
     }
 }

--- a/zebra-rs/src/rib/route.rs
+++ b/zebra-rs/src/rib/route.rs
@@ -835,7 +835,16 @@ impl Rib {
     /// table per VRF. So `ilm_add` / `ilm_del` don't take a
     /// `table_id` parameter, and the inbound dispatcher doesn't pass
     /// one for these variants.
-    pub async fn ilm_add(&mut self, label: u32, ilm: IlmEntry) {
+    pub async fn ilm_add(&mut self, label: u32, mut ilm: IlmEntry) {
+        // Stamp the local-delivery pops (see `IlmEntry::local_pop`): a
+        // nexthop egressing a loopback means the label's owner is this
+        // node — every producer's self prefix-SID entry has this shape.
+        ilm.local_pop = match &ilm.nexthop {
+            Nexthop::Uni(u) => u
+                .ifindex()
+                .is_some_and(|i| self.links.get(&i).is_some_and(|l| l.flags.is_loopback())),
+            _ => false,
+        };
         let prev = self.ilm_installed(label);
         let entries = self.ilm.entry(label).or_default();
         // One candidate per protocol: drop this protocol's previous


### PR DESCRIPTION
Two gaps kept IS-IS SR-MPLS TI-LFA from working in the cradle eBPF data plane (the SRv6 sibling already did):

* **v4 fast-reroute pairing dropped in the tee**: `nexthop_id()` hardcoded `backup_id: 0`, so a protected primary was teed unprotected and the data plane had nothing to fail over to. `backup_id` now rides the signature, the dedup key, and all call sites — mirroring the v6 path.

* **Self prefix-SID pop ILMs teed with the kernel-shaped loopback nexthop**: the eBPF pop-and-forward then tries to resolve an L2 neighbor on `lo`, punts the frame untouched, and the kernel MPLS stack silently takes over — repair label stacks such as TI-LFA's `[node-SID(P), adj-SID(P→Q)]` never ran in eBPF (green pings, zero cradle stats). `Rib::ilm_add` now stamps such entries `IlmEntry::local_pop` (nexthop egress is a loopback — protocol-agnostic, covers IS-IS and OSPF alike) and the tee sends them as a nexthop-less pop, so the data plane's chained-pop path continues into the label(s)/IP underneath. The kernel LFIB install is unchanged.

Proven end-to-end by cradle's new `cradle_tilfa_mpls` BDD (cradle-rs side): the IGP-computed repair stack forwards through the P-node in eBPF (`backup-as-primary`), and a link-down with the PLR's control plane paused fails over onto the repair via `LINK_DOWN` + `resolve_nh` (`nh_backup` counts it).

Local gates: `cargo fmt --check`, `clippy --workspace --all-targets -- -D warnings`, `clippy -p zebra-rs --no-default-features -- -D warnings`, `cargo test --workspace --exclude bdd` — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)