### PR TITLE
bdd/mup: dual_st expects the ST1 Source Address stamped by #1784

### DIFF
--- a/bdd/tests/features/bgp_mup_dual_st.feature
+++ b/bdd/tests/features/bgp_mup_dual_st.feature
@@ -66,9 +66,11 @@ Feature: BGP MUP Controller originates both ST1 and ST2 from one PFCP session
     # core-side F-TEID).
     Then show command "show bgp mup-c session" in namespace "z1" should eventually contain "192.0.2.5"
     # The downlink VRF (st1) originates a Type-1 ST: UE prefix + the ACCESS
-    # tunnel endpoint (gNB, 10.0.0.1).
+    # tunnel endpoint (gNB, 10.0.0.1), with the Source Address (draft §3.2.1)
+    # stamped from the session's core-side endpoint (the UPF anchor) so a
+    # `dataplane gtp` receiver can build the GTP4.E outer header.
     And show command "show bgp mup" in namespace "z1" should contain "[ST1][65000:101][ue=192.0.2.5/32][teid=305419896]"
-    And show command "show bgp mup" in namespace "z1" should contain "[ep=10.0.0.1]"
+    And show command "show bgp mup" in namespace "z1" should contain "[ep=10.0.0.1:src=10.9.0.1]"
     # The uplink VRF (st2) originates a Type-2 ST from the SAME session with
     # the distinct CORE endpoint (10.9.0.1) + its own TEID (0x87654321), plus
     # the Direct segment id.


### PR DESCRIPTION
## Summary
- `bgp_mup_dual_st` broke after #1784: `build_mup_st_route` now stamps the Type-1 ST's optional Source Address (draft §3.2.1) from the session's core-side endpoint, so `show bgp mup` renders the ST1 as `[ep=10.0.0.1:src=10.9.0.1]` and the feature's exact-substring assertion `[ep=10.0.0.1]` no longer matches (the closing bracket moved).
- Update the assertion to the full `[ep=10.0.0.1:src=10.9.0.1]` form — strictly stronger, since it now also verifies the source is the UPF anchor (the session's core endpoint, `--core-endpoint 10.9.0.1` in pfcp-inject).
- Swept the rest of the MUP suite: every other `[ep=…]` assertion is on ST2 lines (whose render carries no `src`) or an unclosed `ep=10.0.0.1` substring, so this was the only stale expectation.

## Test plan
- Rebuilt `zebra-rs` / `vtyctl` / `pfcp-inject` from this branch, staged to `/usr/bin` (md5 verified before and after the run).
- `cargo test --test cucumber -- --concurrency=1 --tags "@bgp_mup_dual_st"`: 1 feature, 3 scenarios, 25 steps — all pass, teardown clean.

Generated with [Claude Code](https://claude.com/claude-code)