### PR TITLE
bgp/mup: replace ST exports in place on PFCP Modification (handover)

### DIFF
--- a/zebra-rs/src/bgp/inst.rs
+++ b/zebra-rs/src/bgp/inst.rs
@@ -2313,7 +2313,9 @@ impl Bgp {
                     // matching VRF task(s), which build the RD-free ST NLRI and
                     // export it back. A Modification (SessionUp for an existing
                     // seid) is handled per-VRF: the `MupOriginate` handler
-                    // withdraws the session's prior exports before re-building.
+                    // re-exports in place when the rebuilt NLRI key is
+                    // unchanged (a handover only moves off-key tunnel fields)
+                    // and withdraws only the prior exports whose key changed.
                     MupCEvent::SessionUp(session) => {
                         super::vrf::dispatch_mup_session(&self.vrfs, &self.vrf_registry, session)
                     }

--- a/zebra-rs/src/bgp/route.rs
+++ b/zebra-rs/src/bgp/route.rs
@@ -3161,12 +3161,29 @@ fn mup_endpoint_untrack(
     prefix: &MupPrefix,
     endpoint: IpAddr,
 ) {
-    let dep = super::nht::NhtDep::MupEndpoint(rd, prefix.clone());
     let Some(cache) = bgp.nexthop_cache.as_deref_mut() else {
         return;
     };
+    mup_endpoint_untrack_cache(cache, bgp.rib_client, rd, prefix, endpoint);
+}
+
+/// Cache-level core of [`mup_endpoint_untrack`], shared with the local
+/// origination path ([`super::inst::Bgp::mup_export`] /
+/// [`super::inst::Bgp::mup_withdraw_export`]) which holds the `NexthopCache`
+/// directly rather than through a [`BgpTop`]. Releases the stale endpoint when
+/// a re-exported ST1 moves its GTP endpoint in place (handover — the RD+Prefix
+/// key survives, so no withdraw path runs to release it) or when the
+/// originated ST1 is withdrawn outright.
+pub(super) fn mup_endpoint_untrack_cache(
+    cache: &mut super::nht::NexthopCache,
+    rib_client: &crate::rib::client::RibClient,
+    rd: RouteDistinguisher,
+    prefix: &MupPrefix,
+    endpoint: IpAddr,
+) {
+    let dep = super::nht::NhtDep::MupEndpoint(rd, prefix.clone());
     if cache.untrack(endpoint, &dep) {
-        let _ = bgp.rib_client.send(rib::Message::NexthopUnregister {
+        let _ = rib_client.send(rib::Message::NexthopUnregister {
             proto: "bgp".to_string(),
             nh: endpoint,
         });
@@ -13355,9 +13372,45 @@ impl Bgp {
         // the real TEID/QFI/endpoint. `None` for DSD/ISD/ST2 exports.
         rib.mup_st1 = st1;
         rib.attr = self.attr_store.intern(attr);
+        // A re-export for the same RD+Prefix key can move the ST1 GTP
+        // endpoint in place (handover) — capture the pre-update endpoint so
+        // its NHT registration is released when the new best no longer uses
+        // it (mirrors the peer-learned path in `route_mup_locrib_withdraw`).
+        let old_endpoint = self.mup_st1_selected_endpoint(rd, &prefix);
         let _ = self.local_rib.update_mup(rd, prefix.clone(), rib);
         let selected = self.local_rib.select_best_path_mup(&rd, &prefix);
+        if let Some(old) = old_endpoint
+            && selected.first().and_then(|r| r.mup_st1).map(|s| s.endpoint) != Some(old)
+        {
+            super::route::mup_endpoint_untrack_cache(
+                &mut self.nexthop_cache,
+                &self.ctx.rib,
+                rd,
+                &prefix,
+                old,
+            );
+        }
         self.mup_apply_selected(rd, prefix, selected);
+    }
+
+    /// The GTP endpoint (gNB) of the currently-selected ST1 path for
+    /// `rd`+`prefix`, or `None` for non-ST1 keys / no selected path / a path
+    /// without off-key fields. Read before a Loc-RIB mutation so the caller
+    /// can release the old endpoint's NHT registration if the mutation moved
+    /// (or removed) it.
+    fn mup_st1_selected_endpoint(
+        &mut self,
+        rd: RouteDistinguisher,
+        prefix: &MupPrefix,
+    ) -> Option<IpAddr> {
+        if !matches!(prefix, MupPrefix::T1st { .. }) {
+            return None;
+        }
+        self.local_rib
+            .select_best_path_mup(&rd, prefix)
+            .first()
+            .and_then(|r| r.mup_st1)
+            .map(|s| s.endpoint)
     }
 
     /// Inverse of [`Self::mup_export`] (`BgpGlobalMsg::WithdrawMupExport`):
@@ -13368,8 +13421,23 @@ impl Bgp {
         let Some(rd) = self.vrfs.get(&vrf).and_then(|c| c.rd) else {
             return;
         };
+        // Same pre-mutation capture as `mup_export`: release the withdrawn
+        // ST1's GTP-endpoint NHT registration unless a surviving path (e.g. a
+        // peer-learned candidate) still uses the same endpoint.
+        let old_endpoint = self.mup_st1_selected_endpoint(rd, &prefix);
         self.local_rib.remove_mup(rd, &prefix, 0, ORIGINATED_PEER);
         let selected = self.local_rib.select_best_path_mup(&rd, &prefix);
+        if let Some(old) = old_endpoint
+            && selected.first().and_then(|r| r.mup_st1).map(|s| s.endpoint) != Some(old)
+        {
+            super::route::mup_endpoint_untrack_cache(
+                &mut self.nexthop_cache,
+                &self.ctx.rib,
+                rd,
+                &prefix,
+                old,
+            );
+        }
         self.mup_apply_selected(rd, prefix, selected);
     }
 

--- a/zebra-rs/src/bgp/vrf/inst.rs
+++ b/zebra-rs/src/bgp/vrf/inst.rs
@@ -2141,17 +2141,34 @@ impl BgpVrf {
             // global SAFI-85 RIB. The global export handler applies the RD,
             // export route-targets and controller next-hop; the resulting
             // route is mirrored back here (RT/RD-origin) so this VRF's own
-            // `show bgp vrf <name> mup` reflects it. A Modification replaces:
-            // withdraw the session's prior exports first.
+            // `show bgp vrf <name> mup` reflects it. A Modification replaces —
+            // but the ST keys exclude the session-transform fields (an ST1
+            // keys on RD+Prefix alone, §3.2.1), so a handover that only moves
+            // the tunnel (new TEID/QFI/endpoint) rebuilds the *same* NLRI key:
+            // re-export it and let the Loc-RIB replace in place (an implicit
+            // withdraw on the wire). Only a prior export whose key actually
+            // changed (UE prefix / ST2 core tunnel) — or one the modified
+            // session no longer builds — gets an explicit withdraw, so peers
+            // and the dataplane never see the route flap mid-handover.
             BgpVrfMsg::MupOriginate {
                 session,
                 direction,
                 ext_comm,
             } => {
-                self.withdraw_mup_originate(session.seid);
-                if let Some((prefix, st1, attr)) =
-                    super::super::route::build_mup_st_route(&session, direction, ext_comm)
-                {
+                let built = super::super::route::build_mup_st_route(&session, direction, ext_comm);
+                let prior = self
+                    .mup_originated
+                    .remove(&session.seid)
+                    .unwrap_or_default();
+                for old in prior {
+                    if built.as_ref().map(|(p, _, _)| p) != Some(&old) {
+                        let _ = self.global_tx.send(BgpGlobalMsg::WithdrawMupExport {
+                            vrf: self.name.clone(),
+                            prefix: old,
+                        });
+                    }
+                }
+                if let Some((prefix, st1, attr)) = built {
                     self.mup_originated
                         .entry(session.seid)
                         .or_default()
@@ -2542,5 +2559,110 @@ mod tests {
             }
             other => panic!("expected WithdrawExport, got {other:?}"),
         }
+    }
+
+    /// A PFCP Modification that only moves the GTP tunnel (handover: new
+    /// gNB endpoint / TEID) rebuilds the *same* ST1 NLRI key — RD+Prefix
+    /// alone keys an ST1 (§3.2.1) — so the repeat `MupOriginate` must
+    /// re-export in place with NO `WithdrawMupExport`: peers replace via
+    /// implicit withdraw and the UE prefix never flaps mid-handover. A
+    /// modification after which the ST no longer builds still withdraws
+    /// the prior export explicitly.
+    #[tokio::test]
+    async fn mup_handover_reexports_in_place_without_withdraw() {
+        use crate::bgp::vrf_config::MupSrv6Direction;
+        use crate::mup_c::session::MupSession;
+        use std::net::IpAddr;
+
+        fn session(endpoint: Option<&str>, teid: u32) -> MupSession {
+            MupSession {
+                seid: 7,
+                cp_seid: 0x1111,
+                peer: "10.0.0.2:8805".parse().unwrap(),
+                ue_ipv4: Some("192.0.2.5".parse().unwrap()),
+                ue_ipv6: None,
+                teid,
+                endpoint: endpoint.map(|e| e.parse().unwrap()),
+                core_teid: 0,
+                core_endpoint: None,
+                network_instance: Some("internet".to_string()),
+                qfi: Some(9),
+            }
+        }
+
+        let (global_tx, mut global_rx) = unbounded_channel::<BgpGlobalMsg>();
+        let ctx = test_ctx_for_vrf(12, "vrf-ho");
+        let (_rib_tx, rib_rx) = mpsc::unbounded_channel();
+        let (mut vrf, _inbox) = BgpVrf::new(
+            "vrf-ho".to_string(),
+            ctx,
+            Ipv4Addr::UNSPECIFIED,
+            65000,
+            /* label */ 16,
+            global_tx,
+            rib_rx,
+        );
+
+        // Establishment: one export, nothing withdrawn.
+        vrf.process_global_msg(BgpVrfMsg::MupOriginate {
+            session: session(Some("10.0.1.1"), 0x100),
+            direction: MupSrv6Direction::Encapsulation,
+            ext_comm: None,
+        });
+        let first = global_rx.try_recv().expect("establishment exports");
+        let BgpGlobalMsg::MupExport {
+            prefix: key,
+            st1: Some(st1),
+            ..
+        } = first
+        else {
+            panic!("expected MupExport, got {first:?}");
+        };
+        assert_eq!(st1.teid, 0x100);
+        assert!(
+            global_rx.try_recv().is_err(),
+            "establishment sends exactly one message"
+        );
+
+        // Handover: same seid + UE prefix, new endpoint/TEID.
+        vrf.process_global_msg(BgpVrfMsg::MupOriginate {
+            session: session(Some("10.0.2.1"), 0x200),
+            direction: MupSrv6Direction::Encapsulation,
+            ext_comm: None,
+        });
+        let second = global_rx.try_recv().expect("handover re-exports");
+        let BgpGlobalMsg::MupExport {
+            prefix: rekey,
+            st1: Some(moved),
+            ..
+        } = second
+        else {
+            panic!("handover must re-export in place, got {second:?}");
+        };
+        assert_eq!(rekey, key, "handover keeps the RD-free ST1 key");
+        assert_eq!(moved.teid, 0x200);
+        assert_eq!(moved.endpoint, "10.0.2.1".parse::<IpAddr>().unwrap());
+        assert!(
+            global_rx.try_recv().is_err(),
+            "no WithdrawMupExport around the handover re-export"
+        );
+
+        // The access tunnel drops out of the session → the ST1 no longer
+        // builds → the prior export is withdrawn explicitly.
+        vrf.process_global_msg(BgpVrfMsg::MupOriginate {
+            session: session(None, 0),
+            direction: MupSrv6Direction::Encapsulation,
+            ext_comm: None,
+        });
+        let third = global_rx.try_recv().expect("unbuildable ST withdraws");
+        let BgpGlobalMsg::WithdrawMupExport { prefix: gone, .. } = third else {
+            panic!("expected WithdrawMupExport, got {third:?}");
+        };
+        assert_eq!(gone, key);
+        assert!(global_rx.try_recv().is_err());
+        assert!(
+            vrf.mup_originated.is_empty(),
+            "nothing is tracked once the session exports no ST"
+        );
     }
 }

--- a/zebra-rs/src/bgp/vrf/msg.rs
+++ b/zebra-rs/src/bgp/vrf/msg.rs
@@ -103,7 +103,11 @@ pub enum BgpVrfMsg {
     /// [`BgpGlobalMsg::MupExport`]; the global export handler applies the RD,
     /// export route-targets and controller next-hop. One session can fan out
     /// to several VRFs (an st1 and an st2 VRF sharing the NI) — each gets its
-    /// own `MupOriginate` for its direction.
+    /// own `MupOriginate` for its direction. A repeat for a known seid (PFCP
+    /// Modification) re-exports in place when the rebuilt NLRI key is
+    /// unchanged — an ST1 keys on RD+Prefix alone, so a handover's new
+    /// TEID/QFI/endpoint replaces without a withdraw — and explicitly
+    /// withdraws only a prior export whose key changed.
     MupOriginate {
         session: crate::mup_c::session::MupSession,
         direction: crate::bgp::vrf_config::MupSrv6Direction,
@@ -111,9 +115,9 @@ pub enum BgpVrfMsg {
     },
 
     /// Withdraw every ST route this VRF originated for `seid` (PFCP Session
-    /// Deletion, association teardown, or the replace step of a
-    /// Modification). Broadcast to every VRF; the per-VRF removal is
-    /// idempotent for a VRF that never originated for this session.
+    /// Deletion or association teardown; a Modification instead replaces via
+    /// [`Self::MupOriginate`]). Broadcast to every VRF; the per-VRF removal
+    /// is idempotent for a VRF that never originated for this session.
     MupWithdrawOriginate { seid: u64 },
 
     /// Originate (or refresh) this VRF's MUP Segment Discovery route — a DSD


### PR DESCRIPTION
## Summary

Since the MUP RIB keys an ST1 on RD+Prefix alone (draft-ietf-bess-mup-safi §3.2.1 — the TEID/QFI/endpoint ride off-key on the path), a handover that only moves the GTP tunnel rebuilds the **same** NLRI key. The `MupOriginate` handler nevertheless withdrew every prior export for the seid before re-exporting, so each PFCP Modification flapped the UE prefix at every peer (MP_UNREACH followed by re-advertise) and momentarily tore down the GTP dataplane — exactly the flap a mid-handover UE should not see.

- **`MupOriginate` (per-VRF)**: build the new ST NLRI first and withdraw only a prior export whose key actually changed (UE prefix, ST2 core tunnel, or a session that no longer builds an ST). An unchanged key is re-exported as-is; the Loc-RIB replaces the Originated path in place, which is an implicit withdraw on the wire — mirroring what `MupSegmentOriginate` already does for direct↔interwork/router-id key changes.
- **`mup_export` / `mup_withdraw_export` (global)**: with the in-place replace now the steady-state handover path, release the old ST1 GTP endpoint's `NhtDep::MupEndpoint` registration when the selected path stops using it. Previously the registration leaked (also on the old withdraw+re-add flow) and a dead gNB's reachability churn kept re-dispatching the route.

## Test plan

- New unit test `mup_handover_reexports_in_place_without_withdraw`: establishment exports once; a same-key Modification (new endpoint + TEID) emits exactly one `MupExport` and **no** `WithdrawMupExport`; a Modification that drops the access tunnel still withdraws explicitly.
- `cargo test --workspace --exclude bdd` green (zebra-rs: 1533 passed), `cargo clippy --workspace --all-targets -- -D warnings` clean, `cargo fmt` applied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)