### PR TITLE
book: rename intro section to Introduction

### DIFF
--- a/book/src/SUMMARY.md
+++ b/book/src/SUMMARY.md
@@ -1,6 +1,6 @@
-# zebra-rs Routing Software
+# Introduction
 
-[zebra-rs Routing Software](ch-00-00-introduction.md)
+[Introduction](ch-00-00-introduction.md)
 - [Install](ch-00-06-install.md)
 - [Building](ch-00-07-building.md)
 - [Router ID Selection](ch-00-01-router-id.md)


### PR DESCRIPTION
## Summary

- Rename the introduction section header and link text in `book/src/SUMMARY.md` from "zebra-rs Routing Software" to "Introduction".

## Test plan

- Docs-only change; `mdbook build` renders the SUMMARY with the new "Introduction" heading.

Generated with [Claude Code](https://claude.com/claude-code)