### PR TITLE
vty: replace VTY service-accounts with the zebra-rs group for passwordless enable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,9 @@ CLAUDE.md
 # OpenAI Codex
 AGENTS.md
 
+# Cursor
+.cursor
+
 # IntelliJ
 .idea
 

--- a/book/src/ch-06-00-vty-access.md
+++ b/book/src/ch-06-00-vty-access.md
@@ -271,7 +271,7 @@ Package lifecycle (Debian/Ubuntu `.deb`):
   missing.
 - **`apt remove`** — the group is **kept** so memberships survive a
   reinstall.
-- **`apt purge`** — `postrm` removes the group (when `delgroup` is
+- **`apt purge`** — `postrm` removes the group (when `groupdel` is
   available).
 
 #### `configure` auto-elevate

--- a/book/src/ch-06-00-vty-access.md
+++ b/book/src/ch-06-00-vty-access.md
@@ -234,103 +234,80 @@ Three ways to acquire Admin:
 
 - **Root (uid 0)**: implicit Admin from session creation — no
   `enable` needed.
-- **Interactive**: run `enable` in the vty shell, type your
-  password (PAM auth via `vtypam`). The Admin role is held for 15
-  minutes idle (sliding — refreshed on each authorized RPC) with a
-  4-hour absolute cap.
-- **Service account**: list your uid in
-  `ZEBRA_VTY_SERVICE_ACCOUNTS` (see below) — permanent Admin from
-  session creation.
+- **`zebra-rs` group member**: run `enable` or `configure` — no
+  password prompt; Admin is held for 15 minutes idle (sliding) with
+  a 4-hour absolute cap, same as a successful PAM enable.
+- **Everyone else**: run `enable` or `configure` and enter the
+  **root password** (PAM via `vtypam`). Admin is held for 15 minutes
+  idle (sliding) with a 4-hour absolute cap.
 
 Read-only commands (`vtyctl show`, `vty` show) and Tab/`?`
 completion are not gated — a non-admin user can still see what
 commands exist.
 
+#### `zebra-rs` configure-authorization group
+
+The Debian/RPM package creates a system group named `zebra-rs`:
+
+```bash
+getent group zebra-rs
+sudo usermod -aG zebra-rs alice
+# alice must log out and back in (or `newgrp zebra-rs`) for membership
+# to take effect in an existing shell.
+```
+
+Members of this group can run `enable` or `configure` **without a
+password**. The daemon checks supplementary group membership via
+NSS (`getgrouplist`) when handling the `Enable` RPC; the group
+name defaults to `zebra-rs` and can be overridden with
+`ZEBRA_VTY_CONFIG_GROUP` on the daemon.
+
+If the group does not exist on the host, the check is skipped and
+only root-PAM elevation is available (aside from uid 0).
+
+Package lifecycle (Debian/Ubuntu `.deb`):
+
+- **Install** — `postinst` creates the `zebra-rs` system group if
+  missing.
+- **`apt remove`** — the group is **kept** so memberships survive a
+  reinstall.
+- **`apt purge`** — `postrm` removes the group (when `delgroup` is
+  available).
+
 #### `configure` auto-elevate
 
-When a non-admin user types `configure` in the vty shell, the
-shell automatically prompts for a password and authenticates
-against the **caller's own account** (sudo-style — same as
-`enable`):
+When a non-admin user types `configure`, the shell first tries
+configure directly (root succeeds immediately). On failure, group
+members run passwordless `enable`; everyone else is prompted for
+the **root password** before retry:
 
 ```text
 host> configure
-Password: ********
 host(configure)#
 ```
 
-Admin sessions (root, service-accounts, users within a current
-`enable` TTL) bypass the prompt entirely — the optimistic first
-attempt succeeds and configure mode is entered immediately. The
-prompt only appears for users who would otherwise be denied.
+Group members and users who already ran `enable` within the current
+TTL enter configure mode with no prompt. Non-members see:
 
-The same password that authenticates `enable` works here.
-`configure` is the convenience flow that combines `enable` + mode
-entry in one step for one-shot configuration sessions; `enable`
-is the standalone command for operators who want to hold the
-Admin role across multiple commands without re-authenticating.
+```text
+host> configure
+Root password: ********
+host(configure)#
+```
+
+`configure` combines `enable` + mode entry for one-shot
+configuration sessions; `enable` is for operators who want to hold
+the Admin role across multiple commands.
 
 Configure-mode locking (single-writer mutex) is intentionally not
 yet implemented; multiple admins can simultaneously enter
 configure mode and pile up candidate edits. This is deferred to
 future work.
 
-### `ZEBRA_VTY_SERVICE_ACCOUNTS` — permanent-admin uids
+#### Scripted admin (`vtyctl apply` / `clear`)
 
-Sessions for uids listed here start with the `Admin` role from
-session creation and do not require an interactive `enable`. Use
-this for automation accounts (Ansible, cron jobs, monitoring) that
-cannot meaningfully type a password.
-
-```bash
-# uid 999 and 1001 are permanent admins; no PAM auth required for them.
-ZEBRA_VTY_SERVICE_ACCOUNTS=999,1001 zebra-rs
-```
-
-The typical deployment sets this in a systemd drop-in:
-
-```ini
-# /etc/systemd/system/zebra-rs.service.d/service-accounts.conf
-[Service]
-Environment=ZEBRA_VTY_SERVICE_ACCOUNTS=999,1001
-```
-
-Notes:
-
-- The value is read once at daemon startup; runtime changes require
-  a `systemctl restart zebra-rs`.
-- Root (uid 0) is always implicit admin and does not need to be
-  listed.
-- If a service-account uid happens to type `enable`, the daemon
-  returns success without invoking PAM (no password prompt).
-- A service-account session can still call `disable` to drop to
-  View for that session only; reconnecting yields a fresh Admin
-  session.
-
-### YANG configuration (runtime-mutable)
-
-Service-accounts can also be defined via YANG, in which case they
-are mutable at runtime and persist across daemon restarts (via the
-config file):
-
-```
-host# configure
-host(configure)# set vty service-account 999 description "Ansible automation"
-host(configure)# set vty service-account 1001
-host(configure)# commit
-```
-
-YANG-defined accounts are the **union** with the env-var set;
-either source grants Admin. `delete vty service-account 999`
-removes the uid from the YANG set immediately on commit (existing
-sessions for that uid keep their Admin role until reconnect — the
-gate is applied at session creation, not on each RPC).
-
-In practice, pick **one** mechanism per deployment:
-- env var (via systemd Environment=) when admin lifecycle is
-  managed by the host (provisioning tools, package configs)
-- YANG when admin lifecycle should be managed via the CLI itself
-  (live operator changes, no daemon restart)
+`vtyctl` does not call `enable`. Use `sudo vtyctl …` for
+non-interactive pushes, or run from a root session.
 
 ## Migration from earlier versions
 

--- a/book/src/ch-06-01-session-design.md
+++ b/book/src/ch-06-01-session-design.md
@@ -245,29 +245,18 @@ The Session struct carries a `role` field (`View`, `Operator`,
 - **Root (uid=0)**: implicit Admin from session creation, no enable
   required (D20). The `enable` RPC short-circuits to success
   without invoking PAM.
-- **Interactive**: type `enable`, authenticate via PAM, hold Admin
-  for the TTL.
-- **Service account** (for automation): a uid listed in the env
-  var `ZEBRA_VTY_SERVICE_ACCOUNTS` (CSV of decimal uids) is
-  permanently Admin without enable. Typically set in the
-  daemon's systemd unit:
-
-  ```ini
-  # /etc/systemd/system/zebra-rs.service.d/service-accounts.conf
-  [Service]
-  Environment=ZEBRA_VTY_SERVICE_ACCOUNTS=999,1001
-  ```
-
-  Service accounts bypass PAM (no password to ship in scripts) and
-  are identified by uid alone via SO_PEERCRED. The env var is read
-  once at daemon startup (D21); changes require restart. Future
-  YANG-driven runtime mutability is deferred to a follow-up.
+- **`zebra-rs` group member**: run `enable` or `configure` with no
+  password; the daemon promotes the session to Admin with the usual
+  sliding idle TTL and hard cap (D27).
+- **Root password via PAM**: type `enable` or `configure` and
+  authenticate the **root** account through `vtypam` (D28). Hold
+  Admin for the TTL.
 
 `vtyctl` invocations are short-lived; their sessions exist for one
 or two RPCs and then idle out. Because session state is per-bash_pid
 and `vtyctl` rarely has a long-lived parent shell, **interactive
-`enable` is effectively a `vty` shell-only feature**. Automated
-admin work uses service accounts.
+`enable` is effectively a `vty` shell-only feature**. Scripted
+admin work uses `sudo vtyctl …`.
 
 ## Pipeline / parent-process conventions
 
@@ -327,7 +316,7 @@ dispatch with or without `$(...)` capture.
 | 1 | SessionTable, `(uid, ppid)` resolver, peer-validation guards. No proto changes. |
 | 2 | Idle TTL + periodic procfs sweep. |
 | 3 | pidfd-based immediate parent-death detection. |
-| 4 | RBAC, enable RPC, vtypam helper, PAM service file, service-accounts in YANG. |
+| 4 | RBAC, enable RPC, vtypam helper, PAM service file, `zebra-rs` group auth. |
 | 5 | *(deferred)* configure-mode lock. |
 | 6 | Logout RPC + bash EXIT trap integration. |
 | 7 | Streaming RPCs (ping, traceroute, monitor terminal, commit confirmed). |
@@ -347,7 +336,7 @@ Each phase is intended to ship as an independent PR.
 | D7 | The initial Enable RPC uses a single password field. Bidirectional PAM conversation (for OTP, password change) is deferred. |
 | D8 | Session key derivation assumes the direct vty-bash-to-vtyhelper parent relationship; the daemon verifies via `/proc` (orphan check + parent uid match) but does not inspect the parent's command name. |
 | D9 | vtyctl receives no special-casing. Stateful RPCs (configure, enable, monitor) naturally fail across vtyctl invocations because the session is not continuous. |
-| D10 | Script-driven admin operations use YANG `service-accounts` (permanent admin by uid), not interactive enable. |
+| D10 | Script-driven admin operations use `sudo vtyctl …` (root), not interactive enable. |
 | D11 | Configure-mode locking is not part of the initial implementation. Concurrent edits are tolerated; conflict-resolution policy is left to commit semantics. |
 | D12 | The daemon and its clients must share a PID namespace. `peer_pid == 0` from SO_PEERCRED is rejected as cross-PID-ns access. |
 | D13 | TACACS+ integration is authentication-only via `pam_tacplus`. No login/command accounting, no per-command authorization. |
@@ -357,13 +346,13 @@ Each phase is intended to ship as an independent PR.
 | D17 | enable failure rate-limit lives in the daemon (per-uid counter, 5 failures within 30 s triggers a 30 s lockout, in-memory only). `pam_faillock` is documented as an optional stronger layer that admins can stack in the PAM service file. |
 | D18 | RBAC is 3-tier: `View`, `Operator`, `Admin`. Maps cleanly onto Cisco priv-lvl ranges 0-1 / 2-14 / 15. YANG-configurable roles are explicitly out of scope. |
 | D19 | Default idle session TTL is **600 s** with a 60 s sweep interval (Cisco IOS `exec-timeout 10 0` convention). Configurable later if a deployment needs it. |
-| D20 | **Root (uid=0) is implicitly Admin.** New sessions for uid=0 are created with `role=Admin` / `enabled=true` / no deadlines; the `enable` RPC short-circuits to success without spawning vtypam. Service-account configuration does not need to list uid 0. Reason: root already owns the host and `pam_unix` against the daemon's own owning account is awkward UX. |
-| D21 | **Service-accounts via env var** for the initial implementation. `ZEBRA_VTY_SERVICE_ACCOUNTS=999,1001,...` (CSV of decimal uids) names uids that are permanent Admin from session creation, with the same shape as root (no deadlines, enable short-circuits to success). State is fixed at daemon startup; runtime changes require a restart. Full YANG integration is deferred to a follow-up if a deployment demands runtime mutability. |
+| D20 | **Root (uid=0) is implicitly Admin.** New sessions for uid=0 are created with `role=Admin` / `enabled=true` / no deadlines; the `enable` RPC short-circuits to success without spawning vtypam. |
 | D22 | **Initial admin gates: Apply and Clear RPCs.** `SessionTable::require_admin` checks `enabled`, enforces sliding TTL + hard cap (with auto-downgrade on expiry), and slides the idle deadline on each authorized call. |
 | D23 | **Configure-mode admin gate** on `DoExec`. For `ExecType::Exec` only (completion paths remain free): admin is required when `mode != "exec"` (catches a client that sets `mode=configure` directly) and when `mode == "exec" && first_word == "configure"` (UX courtesy — block at entry so the prompt doesn't flip uselessly). Configure-mode mutex/lock is deliberately NOT included; multiple admins can enter configure simultaneously (D11 still deferred). |
-| D24 | **Auto-elevate on `configure`**. When a non-admin user types `configure`, the vty bash shell function optimistically tries first (admins succeed silently). On `PermissionDenied` it prompts for `Password:` (echo off) and sends an `Enable` RPC against the caller's own account (sudo-style) — so the same password that works for `enable` works here. On success it retries `configure` and flips `CLI_PRIVILEGE`. `EnableRequest` carries an optional `auth_user` field that the daemon honors when non-empty (kept for future su-style flows); the configure auto-elevate path leaves it empty. |
-| D25 | **YANG-driven service-accounts** (follow-up). New `vty.yang` module with `list service-account { key uid; leaf description; }` under `container vty` in the global `grouping config`. `ConfigManager` maintains an `Arc<RwLock<HashSet<u32>>>` updated by `commit_config` on `vty service-account uid N` Set/Delete diffs; `SessionTable` reads the union of this set and the env-var set in `is_service_account`. The env var (D21) remains as a startup-only seed for environments where YANG config is unavailable; YANG is the runtime-mutable path. |
+| D24 | **Auto-elevate on `configure`**. When a non-admin user types `configure`, the vty bash shell optimistically tries configure first (root succeeds). On failure, group members send a passwordless `Enable` RPC; non-members are prompted for **Root password:** before retry. |
 | D26 | **Root peers bypass the parent-uid check.** `resolve_session_key` skips Guard 2 when `peer_uid == 0`. Rationale: the strict match rejected the common `sudo <cmd>` pattern, where the outer `sudo` process retains the invoking user's ruid while the client itself runs as uid 0. Risk surface: any uid-0 connector is trusted regardless of ancestry, but `SO_PEERCRED`'s effective-uid attestation already implies that — a process running as root can already do anything on the host. The remaining guards (D12 cross-PID-namespace, OrphanClient, ParentVanished) still fire for root peers. Non-root peers are unaffected — the parent-uid match is still enforced, so a setuid escalation to a non-zero uid is still refused. |
+| D27 | **`zebra-rs` Linux group for passwordless enable.** Package postinstall creates the group. Supplementary membership is checked on `enable` via `getgrouplist`; members are promoted without PAM. Group name overridable with `ZEBRA_VTY_CONFIG_GROUP`. Missing group → PAM-only fallback. |
+| D28 | **PAM authenticates root for non-group callers.** Non-members who type `enable`/`configure` are prompted for the root password immediately (no passwordless probe). Client `auth_user` is ignored. |
 
 ## Deferred work
 

--- a/etc/pam.d/zebra-rs.example
+++ b/etc/pam.d/zebra-rs.example
@@ -5,8 +5,9 @@
 # Copy this file to /etc/pam.d/zebra-rs and adjust to match your
 # distribution's PAM conventions. The daemon (via the `vtypam` helper)
 # starts a PAM transaction with the service name "zebra-rs" and runs
-# the `auth` and `account` phases. No session or password phases are
-# used today.
+# the `auth` and `account` phases against the **root** account for
+# callers who are not members of the `zebra-rs` group. No session or
+# password phases are used today.
 #
 # ------------------------------------------------------------
 # Option A — Distribution-stacked configuration (recommended)
@@ -63,5 +64,5 @@ account   required  pam_unix.so
 #
 # zebra-rs uses TACACS+ for authentication only. It does NOT consume
 # the priv-lvl attribute from TACACS+ responses; role assignment is
-# decided locally via `enable` + service-accounts. See
+# decided locally via `enable` and the `zebra-rs` group. See
 # book/src/ch-06-01-session-design.md (D13, D14).

--- a/packaging/nfpm-amd64.yaml
+++ b/packaging/nfpm-amd64.yaml
@@ -60,3 +60,4 @@ overrides:
   deb:
     scripts:
       postinstall: ./scripts/postinstall.sh
+      postremove: ./scripts/postrm.sh

--- a/packaging/nfpm-arm64.yaml
+++ b/packaging/nfpm-arm64.yaml
@@ -60,3 +60,4 @@ overrides:
   deb:
     scripts:
       postinstall: ./scripts/postinstall.sh
+      postremove: ./scripts/postrm.sh

--- a/packaging/scripts/postinstall.sh
+++ b/packaging/scripts/postinstall.sh
@@ -1,5 +1,10 @@
 #! /bin/bash
 
+# Configuration operators belong to this group for passwordless enable.
+if ! getent group zebra-rs >/dev/null 2>&1; then
+    groupadd -r zebra-rs
+fi
+
 setcap 'cap_net_bind_service=ep cap_net_admin=ep cap_net_bind_service=ep cap_net_broadcast=ep cap_net_raw=ep' /usr/bin/zebra-rs
 
 # Grant vtypam the minimum capabilities it needs to authenticate users

--- a/packaging/scripts/postrm.sh
+++ b/packaging/scripts/postrm.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+set -e
+
+case "$1" in
+    purge)
+        if command -v delgroup >/dev/null 2>&1; then
+            if getent group zebra-rs >/dev/null 2>&1; then
+                delgroup --quiet --system zebra-rs >/dev/null 2>&1 || true
+            fi
+        fi
+        ;;
+esac

--- a/packaging/scripts/postrm.sh
+++ b/packaging/scripts/postrm.sh
@@ -3,9 +3,11 @@ set -e
 
 case "$1" in
     purge)
-        if command -v delgroup >/dev/null 2>&1; then
+        # Mirror postinstall's `groupadd -r`: use shadow-utils' groupdel
+        # (same package) so the add/remove pair is symmetric.
+        if command -v groupdel >/dev/null 2>&1; then
             if getent group zebra-rs >/dev/null 2>&1; then
-                delgroup --quiet --system zebra-rs >/dev/null 2>&1 || true
+                groupdel zebra-rs >/dev/null 2>&1 || true
             fi
         fi
         ;;

--- a/vty/additions/vty.sh
+++ b/vty/additions/vty.sh
@@ -39,6 +39,11 @@ cli_command=vtyhelper
 declare -x CLI_MODE="exec"
 declare -x CLI_MODE_STR="Exec"
 declare -x CLI_MODE_PROMPT=""
+_cli_in_config_group ()
+{
+  id -nG 2>/dev/null | tr ' \t' '\n' | grep -qx zebra-rs
+}
+
 declare -x CLI_PRIVILEGE=1
 declare -a _cli_array_completions
 declare -A _cli_array_helps
@@ -379,14 +384,22 @@ enable ()
     echo "% 'enable' is only available in exec mode."
     return 1
   fi
+  if _cli_in_config_group; then
+    ${cli_command} -e -m ${CLI_MODE}
+    local rc=$?
+    if [[ ${rc} -eq 0 ]]; then
+      CLI_PRIVILEGE=15
+      _cli_prompt_setup
+    fi
+    return ${rc}
+  fi
   local pw
   if [[ -t 0 ]]; then
     stty -echo
-    read -r -p "Password: " pw
+    read -r -p "Root password: " pw
     stty echo
     echo
   else
-    # Non-interactive: read a single password line from stdin.
     IFS= read -r pw
   fi
   CLI_ENABLE_PASSWORD="${pw}" ${cli_command} -e -m ${CLI_MODE}
@@ -400,11 +413,8 @@ enable ()
   return ${rc}
 }
 
-# `configure` with auto-elevate (D24): when the caller is not already
-# admin (root / service-account / prior `enable`), prompt for a
-# password and run a PAM authentication against the caller's own
-# account (sudo-style) before entering configure mode. The same
-# password that works for `enable` works here.
+# `configure` with auto-elevate: try configure first; on failure,
+# group members run passwordless enable, everyone else enters root password.
 configure ()
 {
   if [[ ${CLI_MODE} != "exec" ]]; then
@@ -412,42 +422,40 @@ configure ()
     return 1
   fi
 
-  # Fast path: if the caller already enabled (CLI_PRIVILEGE >= 15),
-  # skip the auto-elevate probe entirely. enable() sets
-  # CLI_PRIVILEGE=15 on success, so this avoids re-prompting an
-  # already-authenticated operator under any circumstance.
   if (( CLI_PRIVILEGE < 15 )); then
-    # Optimistic first attempt — root / service-account sessions
-    # succeed immediately without any prompt.
     local out first_line
     out=$(${cli_command} -m exec configure 2>&1)
     first_line=$(echo "$out" | head -n 1)
     if [[ "${first_line}" != "SuccessExec" ]]; then
-      # Permission denied (or other error). Prompt for the root
-      # password and elevate via PAM.
-      local pw
-      if [[ -t 0 ]]; then
-        stty -echo
-        read -r -p "Password: " pw
-        stty echo
-        echo
+      if _cli_in_config_group; then
+        ${cli_command} -e -m ${CLI_MODE}
+        local rc=$?
+        if [[ ${rc} -ne 0 ]]; then
+          echo "% Configuration access denied"
+          return 1
+        fi
       else
-        IFS= read -r pw
-      fi
-      CLI_ENABLE_PASSWORD="${pw}" ${cli_command} -e -m ${CLI_MODE}
-      local rc=$?
-      pw=""
-      unset pw
-      if [[ ${rc} -ne 0 ]]; then
-        echo "% Configuration access denied"
-        return 1
+        local pw
+        if [[ -t 0 ]]; then
+          stty -echo
+          read -r -p "Root password: " pw
+          stty echo
+          echo
+        else
+          IFS= read -r pw
+        fi
+        CLI_ENABLE_PASSWORD="${pw}" ${cli_command} -e -m ${CLI_MODE}
+        local rc=$?
+        pw=""
+        unset pw
+        if [[ ${rc} -ne 0 ]]; then
+          echo "% Configuration access denied"
+          return 1
+        fi
       fi
     fi
   fi
 
-  # Either we were already admin, the optimistic attempt succeeded,
-  # or we just elevated. Run the command for real via the standard
-  # exec path so the daemon's SuccessExec script flips CLI_MODE etc.
   _cli_exec configure
   CLI_PRIVILEGE=15
   _cli_prompt_setup

--- a/vtyhelper/src/main.rs
+++ b/vtyhelper/src/main.rs
@@ -63,10 +63,7 @@ struct Cli {
 
     #[arg(
         long,
-        help = "Override the PAM account name authenticated against. \
-                Defaults to the calling uid's own username (sudo-style). \
-                Set to 'root' for su-style elevation via the configure \
-                auto-elevate flow."
+        help = "Deprecated and ignored; the daemon always authenticates enable against root."
     )]
     auth_user: Option<String>,
 

--- a/zebra-rs/src/config/manager.rs
+++ b/zebra-rs/src/config/manager.rs
@@ -270,10 +270,6 @@ pub struct ConfigManager {
     /// by-value contract as `bfd_client_tx`).
     pub bgp_tx: RefCell<Option<mpsc::Sender<crate::bgp::inst::Message>>>,
     pub protocol_tasks: RefCell<HashMap<String, Task<()>>>,
-    /// Runtime-mutable YANG-defined service-accounts (D25). Updated by
-    /// `commit_config` when `vty service-account uid N` changes; read by
-    /// `SessionTable::is_service_account` at session creation.
-    pub yang_service_accounts: std::sync::Arc<std::sync::RwLock<std::collections::HashSet<u32>>>,
 }
 
 impl ConfigManager {
@@ -283,7 +279,6 @@ impl ConfigManager {
         rib_tx: UnboundedSender<crate::rib::Message>,
         rib_inbound_tx: UnboundedSender<crate::rib::client::RibInbound>,
         policy_tx: UnboundedSender<crate::policy::Message>,
-        yang_service_accounts: std::sync::Arc<std::sync::RwLock<std::collections::HashSet<u32>>>,
     ) -> anyhow::Result<Self> {
         // `--config-file FILENAME` overrides the load/save target; with no
         // override fall back to `zebra-rs.conf` next to the YANG tree. The
@@ -319,7 +314,6 @@ impl ConfigManager {
             stamp_client_tx: RefCell::new(None),
             nd_client_tx: RefCell::new(None),
             protocol_tasks: RefCell::new(HashMap::new()),
-            yang_service_accounts,
         };
         cm.init()?;
 
@@ -633,11 +627,6 @@ impl ConfigManager {
             // Handle logging configuration changes
             if op == ConfigOp::Set && line.starts_with("logging output") {
                 self.handle_logging_config(&line);
-            }
-            // Handle vty service-account changes (D25). Inline because
-            // it mutates daemon-internal state shared with serve.rs.
-            if line.starts_with("vty service-account") {
-                self.handle_vty_service_account(&op, &line);
             }
         }
         for line in diff.lines() {
@@ -1168,35 +1157,6 @@ impl ConfigManager {
         serde_json::to_string_pretty(&tasks).unwrap_or_else(|e| format!("{{\"error\": \"{e}\"}}"))
     }
 
-    /// Apply a `vty service-account uid N` change to the in-memory
-    /// service-account allow-list (D25).
-    ///
-    /// Tolerates both CLI forms the YANG renderer might emit:
-    /// - `vty service-account 999` (key-only)
-    /// - `vty service-account uid 999` (key-explicit)
-    /// - `vty service-account 999 description "foo"` (with leaves;
-    ///   the uid is still extracted)
-    fn handle_vty_service_account(&self, op: &ConfigOp, line: &str) {
-        let Some(uid) = parse_service_account_uid(line) else {
-            return;
-        };
-        let Ok(mut set) = self.yang_service_accounts.write() else {
-            tracing::error!(
-                "yang_service_accounts RwLock poisoned; \
-                 cannot apply vty service-account update"
-            );
-            return;
-        };
-        let verb = match op {
-            ConfigOp::Set => set.insert(uid).then_some("added"),
-            ConfigOp::Delete => set.remove(&uid).then_some("removed"),
-            _ => None,
-        };
-        if let Some(verb) = verb {
-            tracing::info!(uid, verb, "vty service-account change (yang)");
-        }
-    }
-
     fn handle_logging_config(&self, line: &str) {
         // Parse logging output configuration: "logging output stdout|syslog|file"
         let parts: Vec<&str> = line.split_whitespace().collect();
@@ -1369,68 +1329,6 @@ pub enum ConfigFormat {
     Json,
     Yaml,
     SetDelete,
-}
-
-/// Extract the uid from a `vty service-account ...` CLI line.
-///
-/// The YANG renderer may emit either the key-only form
-/// `vty service-account 999`, the key-explicit form
-/// `vty service-account uid 999`, or one with trailing leaves
-/// (`vty service-account 999 description "foo"`). Returns `Some(uid)`
-/// for any of these; `None` if the line isn't a vty-service-account
-/// statement or the uid isn't numeric.
-fn parse_service_account_uid(line: &str) -> Option<u32> {
-    let mut parts = line.split_whitespace();
-    if parts.next()? != "vty" {
-        return None;
-    }
-    if parts.next()? != "service-account" {
-        return None;
-    }
-    let next = parts.next()?;
-    let uid_str = if next == "uid" { parts.next()? } else { next };
-    uid_str.parse::<u32>().ok()
-}
-
-#[cfg(all(test, target_os = "linux"))]
-mod manager_tests {
-    use super::parse_service_account_uid;
-
-    #[test]
-    fn parses_key_only_form() {
-        assert_eq!(
-            parse_service_account_uid("vty service-account 999"),
-            Some(999)
-        );
-    }
-
-    #[test]
-    fn parses_key_explicit_form() {
-        assert_eq!(
-            parse_service_account_uid("vty service-account uid 1001"),
-            Some(1001)
-        );
-    }
-
-    #[test]
-    fn parses_with_trailing_leaves() {
-        assert_eq!(
-            parse_service_account_uid("vty service-account 999 description \"ansible\""),
-            Some(999)
-        );
-        assert_eq!(
-            parse_service_account_uid("vty service-account uid 1001 description test"),
-            Some(1001)
-        );
-    }
-
-    #[test]
-    fn rejects_unrelated_lines() {
-        assert!(parse_service_account_uid("logging output stdout").is_none());
-        assert!(parse_service_account_uid("vty other 1").is_none());
-        assert!(parse_service_account_uid("vty service-account abc").is_none());
-        assert!(parse_service_account_uid("").is_none());
-    }
 }
 
 pub fn config_format_type(config_str: &str) -> ConfigFormat {

--- a/zebra-rs/src/config/serve.rs
+++ b/zebra-rs/src/config/serve.rs
@@ -11,7 +11,8 @@ use crate::config::api::DeployRequest;
 use crate::config::enable_rate::EnableRateLimiter;
 use crate::config::session::{
     AuthzError, DEFAULT_GC_INTERVAL, DEFAULT_IDLE_TTL, ENABLE_HARD_CAP, ENABLE_IDLE_TTL,
-    ProcfsReader, SessionContext, SessionError, SessionTable, run_gc, watch_bash_death,
+    ENABLE_PAM_USER, ProcfsReader, SessionContext, SessionError, SessionTable, run_gc,
+    watch_bash_death,
 };
 
 use super::api::{
@@ -61,20 +62,6 @@ fn enforce_admin<T>(
             "enable session expired; run 'enable' again",
         )),
     }
-}
-
-/// Parse the `ZEBRA_VTY_SERVICE_ACCOUNTS` env var into a uid set (D21).
-///
-/// Format: comma-separated decimal uids, optional whitespace around each
-/// entry. Anything that doesn't parse as a `u32` is silently dropped so a
-/// typo in one entry doesn't take out the rest.
-fn parse_service_accounts(raw: Option<&str>) -> std::collections::HashSet<u32> {
-    let Some(raw) = raw else {
-        return std::collections::HashSet::new();
-    };
-    raw.split(',')
-        .filter_map(|s| s.trim().parse::<u32>().ok())
-        .collect()
 }
 
 /// Resolve the path to the `vtypam` helper.
@@ -247,17 +234,33 @@ impl Exec for ExecService {
             .ok_or_else(|| tonic::Status::unauthenticated("no session"))?;
         let uid = key.0;
 
-        // Root (D20) and configured service accounts (D21) are already
-        // Admin from session creation. Acknowledge the enable RPC without
-        // spawning PAM so no password is prompted.
-        if uid == 0 || self.sessions.is_service_account(uid) {
+        // Root (D20) is already Admin from session creation.
+        if uid == 0 {
             if VTY_TRACING {
-                tracing::info!(uid, "enable noop (permanent admin)");
+                tracing::info!(uid, "enable noop (root permanent admin)");
             }
             return Ok(Response::new(EnableReply {
                 ok: true,
                 message: String::new(),
                 ttl_secs: 0,
+            }));
+        }
+
+        // Configure-authorization group: passwordless enable (D27).
+        if self.sessions.is_config_group_member(&ProcfsReader, uid) {
+            let promoted = self
+                .sessions
+                .promote_to_admin(&key, ENABLE_IDLE_TTL, ENABLE_HARD_CAP);
+            if !promoted {
+                return Err(tonic::Status::unauthenticated("session vanished"));
+            }
+            if VTY_TRACING {
+                tracing::info!(uid, "enable success (config group)");
+            }
+            return Ok(Response::new(EnableReply {
+                ok: true,
+                message: String::new(),
+                ttl_secs: ENABLE_IDLE_TTL.as_secs() as u32,
             }));
         }
 
@@ -275,21 +278,10 @@ impl Exec for ExecService {
 
         let inner = request.into_inner();
         let password = inner.password;
-        // su-style: when the client passes auth_user explicitly, PAM
-        // authenticates against that account name instead of the caller's
-        // own. The vty `configure` auto-elevate flow uses this with
-        // auth_user="root". When auth_user is empty, fall back to the
-        // session's resolved username (the standard `enable` flow).
-        let target_user = if !inner.auth_user.is_empty() {
-            inner.auth_user.clone()
-        } else {
-            self.sessions.username(&key).ok_or_else(|| {
-                tracing::warn!(uid, "enable refused: uid not in passwd db");
-                tonic::Status::permission_denied("uid has no system account")
-            })?
-        };
+        let _ = inner.auth_user;
+        let target_user = ENABLE_PAM_USER;
 
-        let exit = match spawn_vtypam(&target_user, &password).await {
+        let exit = match spawn_vtypam(target_user, &password).await {
             Ok(code) => code,
             Err(e) => {
                 tracing::error!(uid, error = %e, "vtypam spawn failed");
@@ -512,21 +504,11 @@ impl Clear for ClearService {
 
 pub struct Cli {
     pub tx: mpsc::Sender<Message>,
-    /// Runtime-mutable set of YANG-defined service-account uids. Shared
-    /// with `ConfigManager`, which updates it on commit of
-    /// `vty service-account uid N` changes (D25).
-    pub yang_service_accounts: Arc<std::sync::RwLock<std::collections::HashSet<u32>>>,
 }
 
 impl Cli {
-    pub fn new(
-        config_tx: Sender<Message>,
-        yang_service_accounts: Arc<std::sync::RwLock<std::collections::HashSet<u32>>>,
-    ) -> Self {
-        Self {
-            tx: config_tx,
-            yang_service_accounts,
-        }
+    pub fn new(config_tx: Sender<Message>) -> Self {
+        Self { tx: config_tx }
     }
 }
 
@@ -716,17 +698,13 @@ impl tonic::service::Interceptor for VtyPeerInterceptor {
 }
 
 pub fn serve(cli: Cli, addr: VtyAddr) -> anyhow::Result<()> {
-    let sessions = {
-        let env_accounts =
-            parse_service_accounts(std::env::var("ZEBRA_VTY_SERVICE_ACCOUNTS").ok().as_deref());
-        if !env_accounts.is_empty() && VTY_TRACING {
-            tracing::info!(
-                uids = ?env_accounts,
-                "VTY service-account uids from env (permanent admin)",
-            );
-        }
-        SessionTable::with_service_accounts(env_accounts, cli.yang_service_accounts.clone())
-    };
+    let config_group_gid = SessionTable::resolve_config_group_gid();
+    if let Some(gid) = config_group_gid {
+        tracing::info!(gid, "VTY configure-authorization group active");
+    } else {
+        tracing::debug!("VTY configure-authorization group not found; PAM-only fallback");
+    }
+    let sessions = SessionTable::with_config_group(config_group_gid);
     let enable_rate = EnableRateLimiter::new();
 
     let exec_service = ExecService {
@@ -832,34 +810,4 @@ fn bind_abstract_uds(name: &str) -> anyhow::Result<tokio_stream::wrappers::UnixL
     let listener = UnixListener::from_std(std_listener)
         .map_err(|e| anyhow::anyhow!("register abstract VTY socket '@{name}' with tokio: {e}"))?;
     Ok(UnixListenerStream::new(listener))
-}
-
-#[cfg(test)]
-mod tests {
-    use super::parse_service_accounts;
-
-    #[test]
-    fn parse_service_accounts_handles_csv_with_whitespace() {
-        let set = parse_service_accounts(Some(" 999, 1001 ,1003"));
-        assert_eq!(set.len(), 3);
-        assert!(set.contains(&999));
-        assert!(set.contains(&1001));
-        assert!(set.contains(&1003));
-    }
-
-    #[test]
-    fn parse_service_accounts_silently_drops_non_numeric_entries() {
-        // One bad entry should not take out the rest of the list.
-        let set = parse_service_accounts(Some("999,not-a-uid,1001"));
-        assert_eq!(set.len(), 2);
-        assert!(set.contains(&999));
-        assert!(set.contains(&1001));
-    }
-
-    #[test]
-    fn parse_service_accounts_unset_yields_empty() {
-        assert!(parse_service_accounts(None).is_empty());
-        assert!(parse_service_accounts(Some("")).is_empty());
-        assert!(parse_service_accounts(Some(",,,")).is_empty());
-    }
 }

--- a/zebra-rs/src/config/session.rs
+++ b/zebra-rs/src/config/session.rs
@@ -7,8 +7,7 @@
 //! sources (`SO_PEERCRED` plus `/proc/{pid}/status`) and never from
 //! client-supplied data. Per-RPC integration lives in `serve.rs`.
 
-use std::collections::HashSet;
-use std::sync::{Arc, RwLock};
+use std::sync::Arc;
 use std::time::{Duration, Instant};
 
 #[cfg(target_os = "linux")]
@@ -34,10 +33,9 @@ pub type SessionKey = (u32, u32);
 /// - `Operator`: intermediate (clear, restart, ping/traceroute, etc.).
 /// - `Admin`: full configuration access; required for configure/commit.
 ///
-/// Sessions start at `View`. The `enable` command authenticates the
-/// operator via PAM and promotes them to `Admin` for a bounded window
-/// (see [`Session::enable_expires`] / [`Session::enable_hard_deadline`]).
-/// Service accounts start at `Admin` permanently.
+/// Sessions start at `View`. Root (uid 0) and members of the
+/// `zebra-rs` group start at Admin permanently. Everyone else must
+/// `enable` with the root password (PAM).
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum Role {
     View,
@@ -59,9 +57,9 @@ pub struct SessionContext {
 #[derive(Debug, Clone)]
 pub struct Session {
     pub bash_pid: u32,
-    /// Resolved via `getpwuid_r` at session creation. `None` only when the
-    /// lookup failed (uid not in passwd db); in that case enable cannot
-    /// run and admin operations fail closed.
+    /// Resolved via `getpwuid_r` at session creation. Retained for
+    /// future audit logging; not used by the enable/PAM path today.
+    #[allow(dead_code)]
     pub username: Option<String>,
     pub last_active: Instant,
     /// Current authorization role. Defaults to `View`.
@@ -76,6 +74,12 @@ pub struct Session {
     /// activity (see D2).
     pub enable_hard_deadline: Option<Instant>,
 }
+
+/// Default Linux group whose members may `enable` without a password.
+pub const CONFIG_GROUP_NAME: &str = "zebra-rs";
+
+/// PAM account verified for non-group callers who type `enable`.
+pub const ENABLE_PAM_USER: &str = "root";
 
 /// Default sliding idle TTL for the admin role granted by `enable`.
 /// 15 minutes per D2.
@@ -143,50 +147,48 @@ pub enum SessionError {
 
 /// Concurrent table of active sessions.
 #[cfg(target_os = "linux")]
-#[derive(Debug, Default)]
+#[derive(Debug)]
 pub struct SessionTable {
     sessions: DashMap<SessionKey, Session>,
-    /// uids that are permanently Admin via the `ZEBRA_VTY_SERVICE_ACCOUNTS`
-    /// env var (D21). Fixed at daemon startup; immutable thereafter.
-    env_service_accounts: HashSet<u32>,
-    /// uids that are permanently Admin via the YANG config (D25). Mutable
-    /// at runtime — `commit_config` updates this set when the operator
-    /// adds or removes `vty service-account uid N`.
-    yang_service_accounts: Arc<RwLock<HashSet<u32>>>,
+    /// Gid of the configure-authorization group (`zebra-rs` by default).
+    /// `None` when the group does not exist at daemon startup.
+    config_group_gid: Option<u32>,
 }
 
 #[cfg(target_os = "linux")]
 impl SessionTable {
     #[cfg(test)]
-    pub fn new() -> Arc<Self> {
-        Self::with_service_accounts(HashSet::new(), Arc::new(RwLock::new(HashSet::new())))
+    pub fn new() -> std::sync::Arc<Self> {
+        Self::with_config_group(None)
     }
 
-    /// Construct a SessionTable with the two service-account sources
-    /// (env-driven and YANG-driven). uid 0 is always implicitly Admin via
-    /// [D20]; passing it in either set is allowed but redundant.
-    pub fn with_service_accounts(
-        env_service_accounts: HashSet<u32>,
-        yang_service_accounts: Arc<RwLock<HashSet<u32>>>,
-    ) -> Arc<Self> {
-        Arc::new(Self {
+    /// Construct a SessionTable. uid 0 is always implicitly Admin (D20).
+    pub fn with_config_group(config_group_gid: Option<u32>) -> std::sync::Arc<Self> {
+        std::sync::Arc::new(Self {
             sessions: DashMap::new(),
-            env_service_accounts,
-            yang_service_accounts,
+            config_group_gid,
         })
     }
 
-    /// Whether the given uid is permanently Admin via either of the
-    /// service-account sources (env var or YANG). Used by the Enable
-    /// handler to short-circuit PAM (a service account that mistakenly
-    /// runs `enable` gets fast success instead of a baffling PAM failure).
-    pub fn is_service_account(&self, uid: u32) -> bool {
-        self.env_service_accounts.contains(&uid)
-            || self
-                .yang_service_accounts
-                .read()
-                .map(|s| s.contains(&uid))
-                .unwrap_or(false)
+    /// Resolve the configure-authorization group gid at startup.
+    ///
+    /// Reads `ZEBRA_VTY_CONFIG_GROUP` when set; otherwise [`CONFIG_GROUP_NAME`].
+    /// Returns `None` when the group is absent (PAM-only fallback).
+    pub fn resolve_config_group_gid() -> Option<u32> {
+        let name = std::env::var("ZEBRA_VTY_CONFIG_GROUP")
+            .unwrap_or_else(|_| CONFIG_GROUP_NAME.to_string());
+        lookup_group_gid(&name)
+    }
+
+    /// Whether the given uid belongs to the configure-authorization group.
+    pub fn is_config_group_member<P: ProcStatusReader>(&self, reader: &P, uid: u32) -> bool {
+        let Some(gid) = self
+            .config_group_gid
+            .or_else(Self::resolve_config_group_gid)
+        else {
+            return false;
+        };
+        reader.user_in_group(uid, gid)
     }
 
     /// Resolve the session for an incoming RPC.
@@ -245,11 +247,8 @@ impl SessionTable {
 
         let username = reader.resolve_username(peer_uid);
         let mut session = Session::new(ppid_u32, username);
-        // Permanent-admin uids: root (D20) and any uid in the
-        // service-account allow-list (D21/D25). Both bypass enable and
-        // have no deadlines. The yang set is consulted via the same
-        // is_service_account helper used by the Enable handler.
-        if peer_uid == 0 || self.is_service_account(peer_uid) {
+        // Permanent admin: root only (D20).
+        if peer_uid == 0 {
             session.role = Role::Admin;
             session.enabled = true;
         }
@@ -292,16 +291,11 @@ impl SessionTable {
         }
     }
 
-    /// Read the username cached on the session, if present.
-    pub fn username(&self, key: &SessionKey) -> Option<String> {
-        self.sessions.get(key).and_then(|s| s.username.clone())
-    }
-
     /// Authorize an Admin-required RPC for the given session.
     ///
     /// On success, also extends the sliding idle TTL by `ENABLE_IDLE_TTL`
-    /// (D2). For permanent admins (root, service-accounts) deadlines stay
-    /// `None` and are not touched. Time-bounded admins whose `expires` or
+    /// (D2). For permanent admins (root) deadlines stay `None` and are
+    /// not touched. Time-bounded admins whose `expires` or
     /// `hard_deadline` have passed are downgraded to View as a side effect
     /// and `EnableExpired` is returned.
     pub fn require_admin(&self, key: &SessionKey) -> Result<(), AuthzError> {
@@ -323,7 +317,7 @@ impl SessionTable {
                 s.enable_expires = Some(now + ENABLE_IDLE_TTL);
             }
             (None, None) => {
-                // Permanent admin (root or service-account). No deadlines.
+                // Permanent admin (root). No deadlines.
             }
             _ => {
                 // Defensive: invariant says either both are Some or both
@@ -534,6 +528,82 @@ pub trait ProcStatusReader {
     /// Resolve uid -> username via the system passwd database. `None` when
     /// the uid has no passwd entry.
     fn resolve_username(&self, uid: u32) -> Option<String>;
+    /// Whether `uid` belongs to supplementary group `gid`.
+    fn user_in_group(&self, uid: u32, gid: u32) -> bool;
+}
+
+/// Look up a group name via NSS and return its gid.
+#[cfg(target_os = "linux")]
+pub fn lookup_group_gid(name: &str) -> Option<u32> {
+    use std::ffi::CString;
+
+    let name_c = CString::new(name).ok()?;
+    let mut grp = std::mem::MaybeUninit::<libc::group>::uninit();
+    let mut buf = vec![0u8; 1024];
+    let mut result: *mut libc::group = std::ptr::null_mut();
+    let rc = unsafe {
+        libc::getgrnam_r(
+            name_c.as_ptr(),
+            grp.as_mut_ptr(),
+            buf.as_mut_ptr() as *mut libc::c_char,
+            buf.len(),
+            &mut result,
+        )
+    };
+    if rc != 0 || result.is_null() {
+        return None;
+    }
+    Some(unsafe { grp.assume_init().gr_gid })
+}
+
+/// Return every gid (primary + supplementary) for `uid`.
+#[cfg(target_os = "linux")]
+pub fn user_group_list(uid: u32) -> Vec<u32> {
+    use std::ffi::{CStr, CString};
+
+    let mut buf = vec![0u8; 1024];
+    let mut pwd: std::mem::MaybeUninit<libc::passwd> = std::mem::MaybeUninit::uninit();
+    let mut result: *mut libc::passwd = std::ptr::null_mut();
+    let rc = unsafe {
+        libc::getpwuid_r(
+            uid,
+            pwd.as_mut_ptr(),
+            buf.as_mut_ptr() as *mut libc::c_char,
+            buf.len(),
+            &mut result,
+        )
+    };
+    if rc != 0 || result.is_null() {
+        return Vec::new();
+    }
+    let pwd = unsafe { pwd.assume_init() };
+    let username = unsafe { CStr::from_ptr(pwd.pw_name) };
+    let username = match username.to_str() {
+        Ok(s) => s,
+        Err(_) => return vec![pwd.pw_gid],
+    };
+    let user_c = match CString::new(username) {
+        Ok(c) => c,
+        Err(_) => return vec![pwd.pw_gid],
+    };
+    let mut ngroups: libc::c_int = 64;
+    loop {
+        let mut groups = vec![0 as libc::gid_t; ngroups as usize];
+        let mut count = ngroups;
+        let rc = unsafe {
+            libc::getgrouplist(user_c.as_ptr(), pwd.pw_gid, groups.as_mut_ptr(), &mut count)
+        };
+        if rc >= 0 {
+            groups.truncate(rc as usize);
+            return groups;
+        }
+        // rc == -1: buffer too small; `count` holds the required size.
+        if count <= ngroups {
+            break;
+        }
+        ngroups = count;
+    }
+    vec![pwd.pw_gid]
 }
 
 #[cfg(target_os = "linux")]
@@ -592,6 +662,10 @@ impl ProcStatusReader for ProcfsReader {
         let name = unsafe { CStr::from_ptr(pwd.pw_name) };
         name.to_str().ok().map(String::from)
     }
+
+    fn user_in_group(&self, uid: u32, gid: u32) -> bool {
+        user_group_list(uid).contains(&gid)
+    }
 }
 
 #[cfg(all(test, target_os = "linux"))]
@@ -605,6 +679,8 @@ mod tests {
     struct StubReader {
         ppid: Mutex<HashMap<i32, i32>>,
         ruid: Mutex<HashMap<i32, u32>>,
+        /// Supplementary groups keyed by uid.
+        groups: Mutex<HashMap<u32, Vec<u32>>>,
         /// When set, the named pid returns `NotFound` to simulate a vanished
         /// parent.
         missing: Mutex<Vec<i32>>,
@@ -616,6 +692,9 @@ mod tests {
         }
         fn set_ruid(&self, pid: i32, ruid: u32) {
             self.ruid.lock().unwrap().insert(pid, ruid);
+        }
+        fn set_groups(&self, uid: u32, gids: Vec<u32>) {
+            self.groups.lock().unwrap().insert(uid, gids);
         }
         fn set_missing(&self, pid: i32) {
             self.missing.lock().unwrap().push(pid);
@@ -649,9 +728,14 @@ mod tests {
             !self.missing.lock().unwrap().contains(&pid)
         }
         fn resolve_username(&self, uid: u32) -> Option<String> {
-            // Tests don't care about the real passwd db; synthesize a
-            // deterministic name so they can verify the field is populated.
             Some(format!("u{uid}"))
+        }
+        fn user_in_group(&self, uid: u32, gid: u32) -> bool {
+            self.groups
+                .lock()
+                .unwrap()
+                .get(&uid)
+                .is_some_and(|gids| gids.contains(&gid))
         }
     }
 
@@ -747,33 +831,106 @@ mod tests {
     }
 
     #[test]
-    fn service_account_session_starts_as_permanent_admin() {
-        // D21: any uid listed in service_accounts is implicit Admin from
-        // session creation, with no deadlines (same shape as root).
-        let mut accounts = HashSet::new();
-        accounts.insert(999);
-        let table =
-            SessionTable::with_service_accounts(accounts, Arc::new(RwLock::new(HashSet::new())));
+    fn config_group_member_is_detected() {
+        let table = SessionTable::with_config_group(Some(4242));
+        let reader = StubReader::default();
+        reader.set_groups(1000, vec![1000, 4242]);
+        assert!(table.is_config_group_member(&reader, 1000));
+        reader.set_groups(2000, vec![2000]);
+        assert!(!table.is_config_group_member(&reader, 2000));
+    }
+
+    #[test]
+    fn config_group_absent_yields_no_members() {
+        let table = SessionTable::with_config_group(None);
+        let reader = StubReader::default();
+        reader.set_groups(1000, vec![1000, 4242]);
+        assert!(!table.is_config_group_member(&reader, 1000));
+    }
+
+    #[test]
+    fn non_root_group_member_starts_as_view() {
+        let table = SessionTable::with_config_group(Some(4242));
         let reader = StubReader::default();
         reader.set_ppid(1234, 2000);
         reader.set_ruid(2000, 999);
+        reader.set_groups(999, vec![999, 4242]);
 
         let (key, is_new) = table.resolve(&reader, 999, 1234).unwrap();
-        assert_eq!(key, (999, 2000));
         assert!(is_new);
+        let sess = table.get(&key).unwrap();
+        assert_eq!(sess.role, Role::View);
+        assert!(!sess.enabled);
+        assert_eq!(table.require_admin(&key).unwrap_err(), AuthzError::NotAdmin);
+    }
+
+    #[test]
+    fn group_member_promoted_by_enable() {
+        let table = SessionTable::with_config_group(Some(4242));
+        let reader = StubReader::default();
+        reader.set_ppid(1234, 2000);
+        reader.set_ruid(2000, 999);
+        reader.set_groups(999, vec![999, 4242]);
+
+        let (key, _) = table.resolve(&reader, 999, 1234).unwrap();
+        assert!(
+            table.promote_to_admin(&key, Duration::from_secs(900), Duration::from_secs(14400),)
+        );
         let sess = table.get(&key).unwrap();
         assert_eq!(sess.role, Role::Admin);
         assert!(sess.enabled);
-        assert!(sess.enable_expires.is_none());
-        assert!(sess.enable_hard_deadline.is_none());
+        assert!(sess.enable_expires.is_some());
+        assert!(sess.enable_hard_deadline.is_some());
+        assert!(table.require_admin(&key).is_ok());
+    }
 
-        // Non-service-account uid on the same table stays View.
-        reader.set_ppid(1235, 3000);
-        reader.set_ruid(3000, 1000);
-        let (other, _) = table.resolve(&reader, 1000, 1235).unwrap();
-        let other_sess = table.get(&other).unwrap();
-        assert_eq!(other_sess.role, Role::View);
-        assert!(!other_sess.enabled);
+    /// Regression: `getgrouplist(3)` returns the number of groups on success
+    /// (not 0). A mistaken `rc == 0` check dropped supplementary groups and
+    /// broke passwordless enable for `zebra-rs` members.
+    #[test]
+    #[cfg(target_os = "linux")]
+    fn user_group_list_matches_getgrouplist() {
+        use std::ffi::{CStr, CString};
+
+        let uid = unsafe { libc::getuid() };
+        let mut buf = vec![0u8; 1024];
+        let mut pwd: std::mem::MaybeUninit<libc::passwd> = std::mem::MaybeUninit::uninit();
+        let mut result: *mut libc::passwd = std::ptr::null_mut();
+        let rc = unsafe {
+            libc::getpwuid_r(
+                uid,
+                pwd.as_mut_ptr(),
+                buf.as_mut_ptr() as *mut libc::c_char,
+                buf.len(),
+                &mut result,
+            )
+        };
+        assert_eq!(rc, 0);
+        assert!(!result.is_null());
+        let pwd = unsafe { pwd.assume_init() };
+        let name = unsafe { CStr::from_ptr(pwd.pw_name) };
+        let user_c = CString::new(name.to_str().unwrap()).unwrap();
+
+        let mut ngroups: libc::c_int = 64;
+        let expected: Vec<u32> = loop {
+            let mut groups = vec![0 as libc::gid_t; ngroups as usize];
+            let mut count = ngroups;
+            let rc = unsafe {
+                libc::getgrouplist(user_c.as_ptr(), pwd.pw_gid, groups.as_mut_ptr(), &mut count)
+            };
+            if rc >= 0 {
+                break groups[..rc as usize].to_vec();
+            }
+            assert_eq!(rc, -1);
+            ngroups = count;
+        };
+
+        let actual = user_group_list(uid);
+        assert_eq!(actual, expected);
+        assert!(
+            expected.len() > 1 || expected == [pwd.pw_gid],
+            "expected at least primary gid"
+        );
     }
 
     #[test]
@@ -851,78 +1008,17 @@ mod tests {
     }
 
     #[test]
-    fn require_admin_is_noop_for_permanent_admin() {
-        // Root and service-account sessions have no deadlines; require_admin
-        // should succeed without touching the (None) deadline fields.
-        let mut accounts = HashSet::new();
-        accounts.insert(999);
-        let table =
-            SessionTable::with_service_accounts(accounts, Arc::new(RwLock::new(HashSet::new())));
+    fn require_admin_is_noop_for_root_session() {
+        let table = SessionTable::new();
         let reader = StubReader::default();
-        reader.set_ppid(1234, 2000);
-        reader.set_ruid(2000, 999);
-        table.resolve(&reader, 999, 1234).unwrap();
-        assert!(table.require_admin(&(999, 2000)).is_ok());
-        let s = table.get(&(999, 2000)).unwrap();
+        reader.set_ppid(1234, 999);
+        reader.set_ruid(999, 0);
+        table.resolve(&reader, 0, 1234).unwrap();
+        assert!(table.require_admin(&(0, 999)).is_ok());
+        let s = table.get(&(0, 999)).unwrap();
         assert!(s.enabled);
         assert!(s.enable_expires.is_none());
         assert!(s.enable_hard_deadline.is_none());
-    }
-
-    #[test]
-    fn is_service_account_reports_membership() {
-        let mut accounts = HashSet::new();
-        accounts.insert(999);
-        accounts.insert(1001);
-        let table =
-            SessionTable::with_service_accounts(accounts, Arc::new(RwLock::new(HashSet::new())));
-        assert!(table.is_service_account(999));
-        assert!(table.is_service_account(1001));
-        assert!(!table.is_service_account(1000));
-        assert!(!table.is_service_account(0));
-    }
-
-    #[test]
-    fn yang_service_accounts_union_with_env() {
-        // Env contributes 999. YANG arc is mutated externally to add 1001.
-        // is_service_account reports the union.
-        let mut env_accounts = HashSet::new();
-        env_accounts.insert(999);
-        let yang = Arc::new(RwLock::new(HashSet::new()));
-        let table = SessionTable::with_service_accounts(env_accounts, yang.clone());
-
-        assert!(table.is_service_account(999));
-        assert!(!table.is_service_account(1001));
-
-        // Simulate ConfigManager committing `set vty service-account uid 1001`.
-        yang.write().unwrap().insert(1001);
-
-        assert!(table.is_service_account(999));
-        assert!(table.is_service_account(1001));
-        assert!(!table.is_service_account(2000));
-
-        // Simulate a delete commit.
-        yang.write().unwrap().remove(&1001);
-        assert!(table.is_service_account(999));
-        assert!(!table.is_service_account(1001));
-    }
-
-    #[test]
-    fn yang_service_account_session_starts_as_permanent_admin() {
-        // Mirror of the env-set test, but the uid lives in the YANG arc.
-        let yang = Arc::new(RwLock::new(HashSet::new()));
-        yang.write().unwrap().insert(1001);
-        let table = SessionTable::with_service_accounts(HashSet::new(), yang);
-        let reader = StubReader::default();
-        reader.set_ppid(1234, 4000);
-        reader.set_ruid(4000, 1001);
-
-        let (key, is_new) = table.resolve(&reader, 1001, 1234).unwrap();
-        assert!(is_new);
-        let sess = table.get(&key).unwrap();
-        assert_eq!(sess.role, Role::Admin);
-        assert!(sess.enabled);
-        assert!(sess.enable_expires.is_none());
     }
 
     #[test]

--- a/zebra-rs/src/main.rs
+++ b/zebra-rs/src/main.rs
@@ -1,8 +1,5 @@
-use std::collections::HashSet;
 use std::path::Path;
 use std::path::PathBuf;
-use std::sync::Arc;
-use std::sync::RwLock;
 
 use clap::Parser;
 use daemonize::Daemonize;
@@ -198,17 +195,12 @@ async fn run(arg: Arg) -> anyhow::Result<()> {
 
     let policy = Policy::new();
 
-    // Runtime-mutable YANG-defined service-accounts. Shared between
-    // ConfigManager and SessionTable.
-    let service_accounts: Arc<RwLock<HashSet<u32>>> = Arc::new(RwLock::new(HashSet::new()));
-
     let config = ConfigManager::new(
         yang_path,
         arg.config_file.clone(),
         rib.tx.clone(),
         rib.inbound_tx.clone(),
         policy.tx.clone(),
-        service_accounts.clone(),
     )?;
 
     config.subscribe("rib", rib.cm.tx.clone());
@@ -216,7 +208,7 @@ async fn run(arg: Arg) -> anyhow::Result<()> {
     config.subscribe_show("rib", rib.show.tx.clone());
     config.subscribe_show("policy", policy.show.tx.clone());
 
-    let cli = Cli::new(config.tx.clone(), service_accounts);
+    let cli = Cli::new(config.tx.clone());
 
     let vty_addr = config::VtyAddr::parse(&arg.vty_socket)?;
 

--- a/zebra-rs/yang/vty.yang
+++ b/zebra-rs/yang/vty.yang
@@ -13,12 +13,7 @@ module vty {
   contact
     "https://zebra.dev";
   description
-    "VTY (CLI) configuration for zebra-rs.
-
-     Phase 4-d-ii (D25): service-accounts can be defined via YANG
-     in addition to (and on top of) the ZEBRA_VTY_SERVICE_ACCOUNTS
-     env var. Both sources are unioned; a uid present in either is
-     a permanent Admin from session creation.";
+    "VTY (CLI) configuration for zebra-rs.";
 
   revision "2026-05-18" {
     description
@@ -28,27 +23,5 @@ module vty {
   grouping vty {
     description
       "VTY configuration container.";
-
-    list service-account {
-      ext:help "Permanent Admin uid (no enable required)";
-      key uid;
-      description
-        "A uid that is permanently granted the Admin role from
-         session creation. Use for automation accounts (Ansible,
-         monitoring, cron) that cannot meaningfully type a
-         password. SO_PEERCRED supplies the uid; matching the
-         configured list grants Admin without spawning vtypam.";
-      leaf uid {
-        type uint32;
-        description
-          "Numeric uid as reported by SO_PEERCRED.";
-      }
-      leaf description {
-        type string;
-        description
-          "Free-form note about the account's purpose. Ignored
-           by the daemon — present only for operator clarity.";
-      }
-    }
   }
 }


### PR DESCRIPTION
## Summary

Retires the VTY **service-account** admin path and replaces it with a single OS-native mechanism: membership in a Linux group named **`zebra-rs`**. This removes two parallel service-account sources (the `ZEBRA_VTY_SERVICE_ACCOUNTS` env var and the runtime-mutable `vty service-account uid N` YANG config) and the su-style `auth_user` PAM elevation.

### Acquiring Admin after this change

| Caller | How | Role |
| --- | --- | --- |
| Root (uid 0) | implicit at session creation (D20) | permanent Admin |
| `zebra-rs` group member | `enable` / `configure` — **no password** (D27) | time-bounded Admin (15 min sliding idle, 4 h hard cap) |
| Everyone else | `enable` / `configure` → **root password** via PAM/vtypam (D28) | time-bounded Admin |

- Group membership is resolved at the `Enable` RPC via `getpwuid_r` + `getgrouplist` (supplementary groups from NSS). The group name defaults to `zebra-rs` and is overridable with `ZEBRA_VTY_CONFIG_GROUP`. A missing group falls back to PAM-only.
- PAM now always authenticates the **root** account for non-members; the client-supplied `auth_user` field is ignored (kept as a deprecated no-op on the wire).

### Packaging
- `postinstall` creates the `zebra-rs` system group (`groupadd -r`) if missing.
- New `postremove` (`postrm.sh`) drops the group on **purge** only (kept on plain `apt remove` so memberships survive a reinstall); wired into both deb nfpm configs.

### CLI / docs
- `vty.sh`: `enable`/`configure` skip the prompt for group members and prompt `Root password:` for everyone else.
- `vtyhelper --auth-user` help text marked deprecated/ignored.
- Book ch-06-00 / ch-06-01 rewritten around the group; PAM example updated. `service-account` list removed from `vty.yang`. New design records D27/D28.

## Review notes / fixes applied during review
While preparing this PR I fixed CI-blocking issues in the new code that `cargo clippy -D warnings` flags:
- Removed an unused `#[cfg(test)] SessionTable::config_group_gid` accessor (dead method).
- Removed unnecessary `as u32` casts on `gid_t` (already `u32` on Linux) in `lookup_group_gid` / `user_group_list` and the group-list regression test.
- Rewrote a loop that triggered `unused_assignments` in `user_group_list_matches_getgrouplist` into a `loop { break … }`.

Minor observation (not changed): `postinstall.sh` uses `groupadd` (shadow-utils) while `postrm.sh` uses `delgroup` (adduser); both are guarded and deb-only, so this is functional but slightly asymmetric.

## Testing
- `cargo fmt --all -- --check` — clean
- `cargo clippy --workspace --all-targets -- -D warnings` — clean
- `cargo test --workspace --exclude bdd` — all pass (incl. new `config::session` group tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)