### PR TITLE
vty: root enters configure mode silently

### DIFF
--- a/vty/additions/vty.sh
+++ b/vty/additions/vty.sh
@@ -413,9 +413,9 @@ enable ()
   return ${rc}
 }
 
-# `configure` with auto-elevate: root and group members run passwordless
-# enable; everyone else is prompted for the root password immediately (no
-# probe).
+# `configure` with auto-elevate: root enters silently (already admin
+# server-side); group members run passwordless enable; everyone else is
+# prompted for the root password immediately (no probe).
 configure ()
 {
   if [[ ${CLI_MODE} != "exec" ]]; then
@@ -423,8 +423,11 @@ configure ()
     return 1
   fi
 
-  if (( CLI_PRIVILEGE < 15 )); then
-    if [[ ${EUID} -eq 0 ]] || _cli_in_config_group; then
+  # Root is admin server-side, so `_cli_exec configure` below enters
+  # configure mode on its own — skip the enable RPC so no "% Enabled"
+  # line is printed.
+  if (( CLI_PRIVILEGE < 15 )) && [[ ${EUID} -ne 0 ]]; then
+    if _cli_in_config_group; then
       ${cli_command} -e -m ${CLI_MODE}
       local rc=$?
       if [[ ${rc} -ne 0 ]]; then


### PR DESCRIPTION
## Summary

Follow-up to #1799. With the root fast-path, running `configure` as **root** called the enable RPC, which made `vtyhelper` print `% Enabled (admin role active for 0 seconds)` (root is a permanent admin, so `ttl_secs` is 0) before the mode switch.

Root is already admin server-side, so `_cli_exec configure` enters configure mode on its own. This gates the auto-elevate block on `[[ ${EUID} -ne 0 ]]` so root falls straight through to `_cli_exec configure` and enters configure mode **silently** — no `% Enabled` line.

Group-member (passwordless enable, shows the 900s message) and root-password paths are unchanged.

**Before (root):**
```text
ubuntu>configure
% Enabled (admin role active for 0 seconds)
ubuntu#
```

**After (root):**
```text
ubuntu>configure
ubuntu#
```

## Test plan
- `bash -n vty/additions/vty.sh` passes.
- Control-flow trace: root (EUID 0) skips the elevate block and reaches `_cli_exec configure` directly — the same call that already entered configure mode for root in every prior version; only the additive `-e` output is removed.
- No Rust changes, so cargo fmt/clippy/test are unaffected.

Generated with [Claude Code](https://claude.com/claude-code)