### PR TITLE
changelog: add VTY access control to 26.7.1

### DIFF
--- a/CHANGELOG.yaml
+++ b/CHANGELOG.yaml
@@ -6,7 +6,7 @@
 # them, the defaults from .chglog.yml (or chglog config) are used.
 
 - semver: 26.7.1
-  date: 2026-07-04T18:00:00+09:00
+  date: 2026-07-06T18:00:00+09:00
   distribution: unstable
   urgency: medium
   packager: Kunihiro Ishiguro <kunihiro@zebra.rs>
@@ -20,6 +20,7 @@
           UPF address, SEID echo) and session show commands
         * GTP-U dataplane via cradle: downlink encapsulation, forwarding
           install, local-endpoint re-dispatch, dataplane selector
+        * In-place ST export replace on PFCP Session Modification (handover)
 
     - note: |
         ### BGP EVPN
@@ -56,7 +57,8 @@
         * cradle dataplane tees: VRF, MPLS, SRv6, EVPN-over-SRv6,
           replication slots, FDB watch/aging, End.M mirror context,
           TI-LFA repair pairs and SR-MPLS backup, connected routes
-        * RIB: `nexthop blackhole` discard routes; static routes in VRF
+        * RIB: `nexthop blackhole` discard routes; static routes in VRF;
+          close a redistribute-registration cross-channel race
 
     - note: |
         ### BGP (other)
@@ -70,6 +72,20 @@
           audit follow-up); soft-out stale update-group cache fix
 
     - note: |
+        ### VTY access control
+        * Per-session RBAC (View / Operator / Admin) keyed on SO_PEERCRED
+          (uid + parent PID) with procfs validation and idle-TTL session GC
+        * `enable` authenticates via PAM (the capability-scoped `vtypam`
+          helper) and holds Admin on a sliding idle TTL with a hard cap;
+          per-uid enable rate-limiting; TACACS+ supported through PAM
+        * Root (uid 0) is implicitly Admin; members of the `zebra-rs` Linux
+          group run `enable` / `configure` with no password; everyone else
+          authenticates the root account via PAM
+        * `configure` auto-elevate: root and group members enter configure
+          mode silently, non-members are prompted for the root password;
+          the package creates the `zebra-rs` group on install
+
+    - note: |
         ### Infrastructure
         * JSON output across show commands (RIB, BGP, OSPF, OSPFv3,
           IS-IS, policy) and interactive `show version`
@@ -78,7 +94,8 @@
           consolidated on `enabled`, tokenizer and format fixes,
           bridge/vxlan ordering, `--config-file` option
         * mdBook documentation expansion (OSPFv2/v3, MUP, VPWS, Lua,
-          L3VPN PE-CE); BDD hardening (fail on unmatched steps)
+          L3VPN PE-CE, Install / Building, VTY access, supported-RFCs
+          appendix); BDD hardening (fail on unmatched steps)
 
 - semver: 26.6.2
   date: 2026-06-19T18:00:00+09:00


### PR DESCRIPTION
## Summary

Updates the `26.7.1` changelog entry with the changes that landed **after** the `v26.7.1` tag was cut, ahead of re-tagging `v26.7.1`:

- **New "VTY access control" note** — per-session RBAC (View/Operator/Admin) over `SO_PEERCRED`, PAM-backed `enable` via the `vtypam` helper (sliding TTL + hard cap, per-uid rate limit, TACACS+ through PAM), the root / `zebra-rs`-group / root-password model, and silent `configure` auto-elevate. This covers PRs #1798–#1800.
- **MUP** — in-place ST export replace on PFCP Session Modification (handover, #1791).
- **RIB** — redistribute-registration cross-channel race fix.
- **Docs** — Install/Building pages, VTY access chapter, supported-RFCs appendix.
- Entry date bumped `2026-07-04` → `2026-07-06` to match the re-cut tag.

## Test plan
- `python3 -c "import yaml; yaml.safe_load(open('CHANGELOG.yaml'))"` parses cleanly (4 entries; 8 notes in 26.7.1).
- Docs/metadata only — no code, so cargo fmt/clippy/test are unaffected.

Generated with [Claude Code](https://claude.com/claude-code)