### PR TITLE
vty: drop less -R so wrapped route lines don't lose the top of the page

### DIFF
--- a/vty/additions/vty.sh
+++ b/vty/additions/vty.sh
@@ -76,12 +76,19 @@ _cli_prompt_setup ()
 
 _cli_pager_setup ()
 {
+  # NOTE: deliberately no --raw-control-chars (-R). `show` output is plain
+  # ASCII (no ANSI colour is emitted anywhere), and -R makes less mis-count
+  # how many screen rows a wrapped line occupies: a `show ip route` entry that
+  # is one column too wide (e.g. an ECMP leg with an MPLS label + "weight 1")
+  # folds onto two physical rows, and under -R less overshoots the first page
+  # so the top lines scroll off before the ":" prompt appears. Without -R less
+  # counts the folded rows correctly and the first screen starts at the top.
+  # Re-add -R only alongside genuine colour output, and re-test wrapping.
   [[ -z ${CLI_PAGER} ]] && \
     CLI_PAGER="less \
       --no-lessopen\
       --quit-at-eof\
       --quit-if-one-screen\
-      --raw-control-chars\
       --squeeze-blank-lines\
       --no-init"
 }


### PR DESCRIPTION
## Summary

The interactive CLI pager (`_cli_pager_setup` in `vty/additions/vty.sh`) launched `less` with `--raw-control-chars` (`-R`). `show` output is plain ASCII — no ANSI colour is emitted anywhere in the daemon — so `-R` bought nothing, but it makes **less 590 mis-count how many screen rows a wrapped line occupies**.

A `show ip route` entry that is one column too wide — e.g. an ECMP leg carrying an MPLS label plus `weight 1` (81 chars at an 80-col terminal) — folds onto two physical rows. Under `-R`, `less` overshoots the first page, so the top lines (`Codes:` …) scroll off before the `:` prompt appears. This is the "first few lines are not displayed" symptom.

Removing `-R` makes `less` count the folded rows correctly. `--quit-if-one-screen` / `--no-init` are kept, so short output still prints-and-stays and long output pages from the top.

## Test plan

Reproduced the exact failure and verified the fix in tmux panes of several sizes (route table containing an 81-col ECMP+label line that folds):

- **Before** (`-R`): 80×25 → top row is `E1/E2 …` (first two header lines lost); 60×20 → even more lost.
- **After** (no `-R`): 80×25 / 60×20 / 100×15 → row 1 is always `Codes: K - kernel …`, long output pages with `:`, short output prints without a prompt.

Pick up locally with `make -C vty` (rebuilds the vty binary from these additions); `make install` if running via `/usr/bin`.

Generated with [Claude Code](https://claude.com/claude-code)