### PR TITLE
vty: page "?" help through the pager

### DIFF
--- a/vty/additions/vty.sh
+++ b/vty/additions/vty.sh
@@ -140,6 +140,20 @@ _cli_help_mode ()
   done
 }
 
+# Render the "?" / possible-completions help through the pager so a help
+# list taller than the terminal doesn't scroll off the top of the screen.
+# CLI_PAGER already carries `less --quit-if-one-screen`, so help that fits
+# on one screen is printed inline and less exits immediately (identical to
+# the previous direct echo); only over-long help enters interactive paging.
+# This runs inside the readline completion callback: less reads keystrokes
+# from /dev/tty and writes to the callback's stdout (the terminal), then
+# readline redraws the prompt with the typed input restored. In a
+# non-interactive shell CLI_PAGER is `cat`, so this stays a plain dump.
+_cli_page_help ()
+{
+  _cli_help_mode "$@" | ${CLI_PAGER}
+}
+
 get_prefix_filtered_list ()
 {
   # $1: prefix
@@ -240,7 +254,7 @@ _cli_completion ()
   fi
 
   if [[ "$COMP_KEY" -eq 63 ]];then
-    _cli_help_mode ${current_empty} "${CLI_MODE_STR}" "${completions[@]}"
+    _cli_page_help ${current_empty} "${CLI_MODE_STR}" "${completions[@]}"
     COMPREPLY=("" " ")
   else
     COMPREPLY=($(compgen -W "${_cli_array_completions[*]}" -- $current_prefix))
@@ -250,7 +264,7 @@ _cli_completion ()
       COMPREPLY=( "${COMPREPLY[0]} " )
     else
       if [[ ${#COMP_WORDS[@]} -eq 0 ]];then
-        _cli_help_mode ${current_empty} "${CLI_MODE_STR}" "${_cli_array_completions[@]}"
+        _cli_page_help ${current_empty} "${CLI_MODE_STR}" "${_cli_array_completions[@]}"
         COMPREPLY=("" " ")
       fi
     fi


### PR DESCRIPTION
## Summary

The vty CLI pager (`CLI_PAGER`, `less --quit-if-one-screen …`) was applied in exactly one place — the `"Show"` branch of `_cli_exec`, which pipes `show …` command output through the pager. The `?` help took a different path and was never paged: `?` is bound to readline's `possible-completions` → `_cli_completion` (COMP_KEY 63) → `_cli_help_mode`, which `echo`s the help list straight to the terminal from inside the completion callback. A help list taller than the screen (e.g. `show ?` = 31 lines) scrolled off the top.

This adds `_cli_page_help`, which pipes `_cli_help_mode` output through `${CLI_PAGER}`, and routes both help-display sites (the `?` case and the TAB-with-no-words case) through it.

- `less --quit-if-one-screen` (already in `CLI_PAGER`) keeps short help inline and only pages over-long help — identical to the existing `show` behavior.
- `CLI_PAGER` is `cat` in non-interactive shells, so that path is unchanged.
- Running `less` from inside the readline completion callback works: it reads keystrokes from `/dev/tty` and writes to the callback's stdout (the terminal), then readline redraws the prompt with the typed input restored. No `>/dev/tty` redirect needed.

## Test plan

Rebuilt `vty/vty` and drove the real binary against a running daemon via a 24-row PTY:

- **`show ?` (31 lines)** → pages with `less`: first screen, `:` prompt, SPACE advances to page 2, `(END)`, `q` quits and restores the `show ` input line. ✅
- **Top-level `?` (6 lines)** → prints inline, no pager. ✅
- **Old `/usr/bin/vty`** → dumped all 31 lines raw (reproduces the reported bug). ✅

Only `vty/additions/vty.sh` changed (bash script; no Rust touched).

Generated with [Claude Code](https://claude.com/claude-code)