### PR TITLE
Disable Lua scripting engine by default (for now)

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -59,15 +59,15 @@ jobs:
         # exclude them here. They are intended to be run locally.
         run: cargo test --workspace --exclude bdd
 
-  no-lua:
-    name: cargo clippy (no-lua)
+  lua:
+    name: cargo clippy (lua)
     runs-on: ubuntu-22.04
-    # The `lua` feature is ON by default, so the fmt / clippy / test jobs
-    # already build and test the embedded scripting engine. This lane
-    # guards the OTHER direction: that the feature-off build still
-    # compiles cleanly (the hooks' `#[cfg(not(feature = "lua"))]` no-op
-    # stubs and the feature-gated wiring), so `lua` stays genuinely
-    # optional.
+    # The `lua` feature is DISABLED by default for now, so the fmt /
+    # clippy / test jobs build the feature-OFF path (the hooks'
+    # `#[cfg(not(feature = "lua"))]` no-op stubs). This lane guards the
+    # OTHER direction: that the embedded scripting engine still compiles
+    # cleanly with `--features lua`, so the optional code doesn't rot
+    # while it is off.
     steps:
       - name: Checkout code
         uses: actions/checkout@v5
@@ -79,5 +79,5 @@ jobs:
         uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
           components: clippy
-      - name: Clippy (no default features)
-        run: cargo clippy -p zebra-rs --no-default-features --all-targets -- -D warnings
+      - name: Clippy (lua feature)
+        run: cargo clippy -p zebra-rs --features lua --all-targets -- -D warnings

--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,10 @@
 .PHONY: zebra
 
 zebra:
-	RUSTFLAGS="--cfg tokio_unstable" cargo build --release --features lua
+	RUSTFLAGS="--cfg tokio_unstable" cargo build --release
 
 all:
-	cargo build --release --features lua
+	cargo build --release
 	$(MAKE) -C vty
 
 console:
@@ -20,7 +20,7 @@ xdp-bfd-echo:
 	@echo '[built offload/xdp-bfd-echo/target/release/xdp-bfd-echo]'
 
 install:
-	cargo build --release --features lua
+	cargo build --release
 	sudo cp target/release/zebra-rs /usr/bin/zebra-rs
 	sudo cp target/release/vtyctl /usr/bin/vtyctl
 	sudo cp target/release/vtyhelper /usr/bin/vtyhelper
@@ -76,7 +76,7 @@ run:
 	@mkdir -p /tmp/ipc/sync
 	@sudo rm -f /tmp/ipc/pair/config-ng_isisd
 	@sudo rm -f /tmp/ipc/pair/config-ng_bgpd
-	@RUSTFLAGS="--cfg tokio_unstable" cargo build --bin zebra-rs --release --features lua
+	@RUSTFLAGS="--cfg tokio_unstable" cargo build --bin zebra-rs --release
 	@sudo setcap 'cap_net_bind_service=ep cap_net_admin=ep cap_net_bind_service=ep cap_net_broadcast=ep cap_net_raw=ep' target/release/zebra-rs
 	@target/release/zebra-rs
 	#target/release/zebra-rs --no-nhid

--- a/bdd/src/tag_guard.rs
+++ b/bdd/src/tag_guard.rs
@@ -25,7 +25,7 @@ mod tests {
             .take_while(|l| l.trim_start().starts_with('@') || l.trim().is_empty())
             .flat_map(|l| l.split_whitespace())
             .filter_map(|w| w.strip_prefix('@'))
-            .find(|t| *t != "serial" && *t != "allow.skipped")
+            .find(|t| *t != "serial" && *t != "allow.skipped" && *t != "disabled")
             .map(str::to_string)
     }
 

--- a/bdd/tests/cucumber.rs
+++ b/bdd/tests/cucumber.rs
@@ -2774,7 +2774,9 @@ async fn main() {
                             world.feature_tag = feature
                                 .tags
                                 .iter()
-                                .find(|t| *t != "serial" && *t != "allow.skipped")
+                                .find(|t| {
+                                    *t != "serial" && *t != "allow.skipped" && *t != "disabled"
+                                })
                                 .cloned()
                                 .unwrap_or_default();
                         })
@@ -2805,6 +2807,23 @@ async fn main() {
                     // the tag / name filter is re-applied in the closure below.
                     .with_default_cli()
                     .filter_run(path, move |feat, rule, scenario| {
+                        // A feature/scenario tagged `@disabled` is turned off
+                        // by annotation: never run it, even under an explicit
+                        // `--tags` / `--name` selection. Used to park scenarios
+                        // whose product feature is temporarily compiled out
+                        // (e.g. `@bgp_lua_gbp` while the `lua` build feature is
+                        // off). Remove the tag to re-enable. Skipped features
+                        // stay at `matched == 0`, so their empty artifacts are
+                        // dropped below like any unmatched feature.
+                        let disabled = feat
+                            .tags
+                            .iter()
+                            .chain(rule.iter().flat_map(|r| &r.tags))
+                            .chain(scenario.tags.iter())
+                            .any(|t| t == "disabled");
+                        if disabled {
+                            return false;
+                        }
                         let pass = match &re_filter {
                             Some(re) => re.is_match(&scenario.name),
                             None => match &tags_filter {

--- a/bdd/tests/features/bgp_lua_gbp.feature
+++ b/bdd/tests/features/bgp_lua_gbp.feature
@@ -1,6 +1,15 @@
 @serial
+@disabled
 @bgp_lua_gbp
 Feature: BGP EVPN Group-Based Policy via Lua scripting
+  DISABLED for now: the embedded Lua scripting engine is off (the `lua`
+  build feature defaults off and its BGP config schema is commented out),
+  so this scenario's lua-script / lua-map / adj-rib-out-hook config no
+  longer applies. The `@disabled` tag makes the harness skip this feature
+  in every run (full suite and explicit --tags). To re-enable: remove
+  `@disabled`, rebuild with `--features lua`, and uncomment the
+  zebra-bgp-lua schema.
+
   As a network operator
   I want zebra-rs to carry a Group-Based Policy tag on EVPN Type-2 routes
   and enforce it in the dataplane, driven entirely by embedded Lua hooks,

--- a/book/src/ch-05-04-lua-scripting.md
+++ b/book/src/ch-05-04-lua-scripting.md
@@ -8,8 +8,18 @@ the route — or trigger a non-blocking side effect such as programming
 nftables. This is zebra-rs's analogue of FRR's `route-map match script`,
 redesigned around that feature's limitations.
 
-The embedded Lua 5.4 engine is **on by default**. Builds without it
-(`cargo build --no-default-features`) compile every hook to a no-op.
+> **Note: the Lua engine is currently disabled by default.** The `lua`
+> Cargo feature is **off** for now, so stock builds (`make all`,
+> `cargo build`) ship without the scripting engine and every hook
+> compiles to a no-op. To use the features described in this chapter,
+> build with the feature explicitly enabled:
+>
+> ```sh
+> cargo build --release --features lua
+> ```
+>
+> The rest of this chapter describes the engine as it behaves once that
+> feature is enabled.
 
 ## Hook points
 

--- a/zebra-rs/Cargo.toml
+++ b/zebra-rs/Cargo.toml
@@ -77,17 +77,18 @@ sha1 = "0.11"
 sha2 = "0.11"
 hmac = "0.13"
 rs-pfcp = "0.3.1"
-# Embedded Lua scripting engine, enabled by the `lua` feature (on by
-# default). `vendored` bundles the Lua 5.4 interpreter so the build stays
-# hermetic (no system liblua) — it does need a C compiler at build time.
+# Embedded Lua scripting engine, gated behind the `lua` feature.
+# `vendored` bundles the Lua 5.4 interpreter so the build stays hermetic
+# (no system liblua) — it does need a C compiler at build time.
 mlua = { version = "0.10", features = ["lua54", "vendored"], optional = true }
 
 [features]
-# `lua` is on by default so stock builds (and the BDD binary) ship the
-# embedded scripting engine. Build without it via
-# `--no-default-features` (the hooks compile to no-ops); that path is
-# guarded by the `no-lua` CI lane.
-default = ["lua"]
+# `lua` is DISABLED by default for now: stock builds (and the BDD binary)
+# ship WITHOUT the embedded scripting engine, and the hooks compile to
+# no-ops via their `#[cfg(not(feature = "lua"))]` stubs. Re-enable the
+# scripting engine with `--features lua` (that build is guarded by the
+# `lua` CI lane so the optional code keeps compiling).
+default = []
 # Compile the embedded Lua scripting engine (src/script).
 lua = ["dep:mlua"]
 

--- a/zebra-rs/yang/config.yang
+++ b/zebra-rs/yang/config.yang
@@ -60,9 +60,18 @@ module config {
     prefix zbt;
   }
 
+  // Temporarily disabled: the embedded Lua scripting engine is turned
+  // off for now (the `lua` build feature defaults off). This bootstrap
+  // import is the only thing that pulls zebra-bgp-lua's augments into
+  // the configure tree, so commenting it out removes `router bgp
+  // lua-script / lua-map / loc-rib-hook / adj-rib-out-hook` from the
+  // schema. Re-enable together with the `lua` feature (and uncomment the
+  // schema body in zebra-bgp-lua.yang).
+  /*
   import zebra-bgp-lua {
     prefix zbl;
   }
+  */
 
   import zebra-bgp-password {
     prefix zbp;

--- a/zebra-rs/yang/zebra-bgp-lua.yang
+++ b/zebra-rs/yang/zebra-bgp-lua.yang
@@ -55,6 +55,12 @@ module zebra-bgp-lua {
        per-AFI Loc-RIB import hook binding for ipv4-unicast.";
   }
 
+  // Temporarily disabled: the embedded Lua scripting engine is turned
+  // off for now (the `lua` build feature defaults off), so this BGP
+  // config surface is commented out and the bootstrap import in
+  // config.yang is disabled as well. Re-enable both together with the
+  // `lua` feature.
+  /*
   grouping bgp-lua-extension {
     description
       "Lua script definitions and Loc-RIB hook bindings on the BGP
@@ -147,4 +153,5 @@ module zebra-bgp-lua {
        ipv4-unicast import` are path-valid.";
     uses bgp-lua-extension;
   }
+  */
 }


### PR DESCRIPTION
## Summary

Turns the embedded Lua scripting engine off by default, end to end — build feature, BGP config schema, and its BDD scenario — in a reversible way. Each layer can be re-enabled together later.

- **Build (`zebra-rs/Cargo.toml`)**: flip `default = ["lua"]` → `default = []`; the `lua` feature stays intact (re-enable with `--features lua`). The hooks compile to their `#[cfg(not(feature = "lua"))]` no-op stubs.
- **Makefile**: drop the explicit `--features lua` from the `zebra` / `all` / `install` / `run` targets, which would otherwise force it back on.
- **CI (`.github/workflows/ci.yaml`)**: repurpose the `no-lua` lane into a `lua` lane (`cargo clippy -p zebra-rs --features lua`) so the now-optional scripting code keeps compiling. The `fmt`/`clippy`/`test` lanes now cover the feature-off path. (`cargo clippy (no-lua)` was not a required check, so the lane rename is merge-safe.)
- **YANG schema**: comment out the Lua BGP config surface — the `import zebra-bgp-lua` bootstrap import in `config.yang` and the grouping/augments in `zebra-bgp-lua.yang` — so `router bgp lua-script / lua-map / loc-rib-hook / adj-rib-out-hook` are no longer settable. The Rust `callback_add` registrations are left intact (harmless dead map inserts) so re-enabling is just uncommenting.
- **BDD**: mark `bgp_lua_gbp.feature` `@disabled`. The cucumber harness now short-circuits any `@disabled` feature/scenario in every run (incl. explicit `--tags`), since the default suite runs without a tag filter. `@disabled` also joins `@serial`/`@allow.skipped` as a non-scoping tag in both `feature_tag` selectors.
- **Docs**: note in the Lua Scripting book chapter that the engine is disabled by default and how to re-enable.

## Test plan

- `cargo check -p zebra-rs` (new default, lua off) and `cargo check -p zebra-rs --features lua` both compile.
- `cargo test -p zebra-rs --bin zebra-rs yang` — 62 yang tests pass, incl. `yang_load_tests::{configure,exec}_mode_loads` (schema parses with the Lua module detached).
- Live daemon on the edited schema rejects `router bgp lua-script` with `unknown key`; normal BGP config still applies.
- `cargo test -p bdd --lib` (tag_guard) passes; running the harness with `--tags "@bgp_lua_gbp"` matches 0 scenarios (skipped) with no namespace/daemon activity.
- `cargo fmt --all` and `cargo clippy -p bdd --all-targets -- -D warnings` clean.
- `mdbook build` renders.

Generated with [Claude Code](https://claude.com/claude-code)