### PR TITLE
yang: remove orphan BGP config nodes (global GR, RFD, peer-groups)

### DIFF
--- a/zebra-rs/src/config/manager.rs
+++ b/zebra-rs/src/config/manager.rs
@@ -1445,9 +1445,9 @@ mod yang_load_tests {
     /// `enabled` — the OpenConfig style-guide name, and already the
     /// spelling of the inherited `ietf-bgp` knobs (`afi-safi <af>
     /// enabled`). The vendored `ietf-*` modules keep their published
-    /// spelling (including the two `leaf enable` holdouts:
-    /// `route-flap-damping` and RFC 8177 AES key wrap, neither wired to a
-    /// handler), and `exec.yang` is excluded because its (commented-out)
+    /// spelling (including the remaining `leaf enable` holdout, the
+    /// RFC 8177 AES key wrap, not wired to a handler), and `exec.yang`
+    /// is excluded because its (commented-out)
     /// `enable` is the session privilege-promotion command, not a config
     /// boolean.
     #[test]
@@ -2040,11 +2040,10 @@ mod yang_load_tests {
     }
 
     /// `router bgp neighbor <addr>` is dead config on its own — without a
-    /// `remote-as` (or a `peer-group` that supplies one) it can never form a
-    /// session. The address-keyed neighbor list is tagged
-    /// `ext:non-empty "remote-as or peer-group"`: a bare entry is rejected at
-    /// commit, and deleting its last child prunes it. Same generic machinery
-    /// as the IS-IS afi-safi / static-route cases — this pins the
+    /// `remote-as` it can never form a session. The address-keyed neighbor
+    /// list is tagged `ext:non-empty "remote-as"`: a bare entry is rejected
+    /// at commit, and deleting its last child prunes it. Same generic
+    /// machinery as the IS-IS afi-safi / static-route cases — this pins the
     /// `ietf-bgp` neighbor tag through the real schema.
     #[test]
     fn bgp_neighbor_bare_entry_rejected_and_pruned() {
@@ -2085,9 +2084,9 @@ mod yang_load_tests {
         // Bare `neighbor 192.168.1.3` → rejected.
         let errors = validate_errors(&paths("router bgp neighbor 192.168.1.3"));
         assert!(
-            errors.iter().any(
-                |e| e.contains("neighbor 192.168.1.3") && e.contains("remote-as or peer-group")
-            ),
+            errors
+                .iter()
+                .any(|e| e.contains("neighbor 192.168.1.3") && e.contains("remote-as")),
             "bare bgp neighbor must be rejected, got: {errors:?}"
         );
 

--- a/zebra-rs/yang/ietf-bgp-common-structure@2023-07-05.yang
+++ b/zebra-rs/yang/ietf-bgp-common-structure@2023-07-05.yang
@@ -188,30 +188,4 @@ submodule ietf-bgp-common-structure {
       }
     }
   }
-
-  grouping structure-dynamic-peers {
-    description
-      "Structural grouping to contain dyamic BGP peers. Dynamic
-       peers are configured from a list of IP prefixes matching the
-       IP source address of the dynamic peer.";
-
-    container dynamic-peers {
-      description
-        "Configuration and operational state for dynamically
-         configured peers.";
-
-      list dynamic-peer-list {
-        key "prefix";
-        description
-          "List of peers by IP prefix for this configuration scope
-           that are dynamically configured.";
-
-        leaf prefix {
-          type inet:ip-prefix;
-          description
-            "Prefix for dynamic peer at this configuration scope.";
-        }
-      }
-    }
-  }
 }

--- a/zebra-rs/yang/ietf-bgp-common@2023-07-05.yang
+++ b/zebra-rs/yang/ietf-bgp-common@2023-07-05.yang
@@ -275,83 +275,9 @@ submodule ietf-bgp-common {
     //  leaf remove-private-as {
     //    type bt:remove-private-as-option;
     //  }
-    container route-flap-damping {
-      if-feature "bt:damping";
-      leaf enable {
-        type boolean;
-        default "false";
-        description
-          "Enable route flap damping.";
-      }
-      leaf suppress-above {
-        type decimal64 {
-          fraction-digits 1;
-        }
-        default "3.0";
-        description
-          "This is the value of the instability metric at which
-           route suppression takes place. A route is not installed
-           in the forwarding information base (FIB), or announced
-           even if it is reachable during the period that it is
-           suppressed.";
-      }
-      leaf reuse-above {
-        type decimal64 {
-          fraction-digits 1;
-        }
-        default "2.0";
-        description
-          "This is the value of the instability metric at which a
-           suppressed route becomes unsuppressed if it is reachable
-           but currently suppressed. The value assigned to
-           reuse-below must be less than suppress-above.";
-      }
-      leaf max-flap {
-        type decimal64 {
-          fraction-digits 1;
-        }
-        default "16.0";
-        description
-          "This is the upper limit of the instability metric. This
-           value must be greater than the larger of 1 and
-           suppress-above.";
-      }
-      leaf reach-decay {
-        type uint32;
-        units "seconds";
-        default "300";
-        description
-          "This value specifies the time desired for the instability
-           metric value to reach one-half of its current value when
-           the route is reachable. This half-life value determines
-           the rate at which the metric value is decayed. A smaller
-           half-life value makes a suppressed route reusable sooner
-           than a larger value.";
-      }
-      leaf unreach-decay {
-        type uint32;
-        units "seconds";
-        default "900";
-        description
-          "This value acts the same as reach-decay except that it
-           specifies the rate at which the instability metric is
-           decayed when a route is unreachable. It should have a
-           value greater than or equal to reach-decay.";
-      }
-      leaf keep-history {
-        type uint32;
-        units "seconds";
-        default "1800";
-        description
-          "This value specifies the period over which the route
-           flapping history is to be maintained for a given route.
-           The size of the configuration arrays described below is
-           directly affected by this value.";
-      }
-      description
-        "Routes learned via BGP are subject to weighted route
-         dampening.";
-    }
+    // route-flap-damping was removed from neighbor-group-config: it was an
+    // unhandled orphan (no config handler) on every consumer of this
+    // grouping and has been dropped.
     leaf-list send-community {
       if-feature "bct:send-communities";
       type identityref {

--- a/zebra-rs/yang/ietf-bgp@2023-07-05.yang
+++ b/zebra-rs/yang/ietf-bgp@2023-07-05.yang
@@ -93,12 +93,8 @@ module ietf-bgp {
         |
         +-> [ global BGP configuration ]
           +-> AFI / SAFI global
-        +-> peer group
-          +-> [ peer group config ]
-          +-> AFI / SAFI [ per-AFI overrides ]
         +-> neighbor
           +-> [ neighbor config ]
-          +-> [ optional pointer to peer-group ]
           +-> AFI / SAFI [ per-AFI overrides ]
 
      Copyright (c) 2023 IETF Trust and the persons identified as
@@ -359,15 +355,6 @@ module ietf-bgp {
              'bgp fast-external-fallover disable' and FRR
              'no bgp fast-external-failover'.";
         }
-        container graceful-restart {
-          if-feature "bt:graceful-restart";
-          description
-            "Parameters relating the graceful restart mechanism for
-             BGP.";
-          reference
-            "RFC 4724: Graceful Restart Mechanism for BGP.";
-          uses graceful-restart-config;
-        }
         uses state;
       }
 
@@ -415,12 +402,12 @@ module ietf-bgp {
 
       list neighbor {
         // A bare `neighbor <addr>` carries no session intent — without a
-        // `remote-as` (or a `peer-group` that supplies one) it can never
-        // form a session, so it's dead config. Reject the key-only entry at
-        // commit, and prune it when its last child is deleted, so a
-        // meaningless neighbor can't linger. Interface-based (unnumbered)
-        // and dynamic listen-range peers are separate lists and unaffected.
-        ext:non-empty "remote-as or peer-group";
+        // `remote-as` it can never form a session, so it's dead config.
+        // Reject the key-only entry at commit, and prune it when its last
+        // child is deleted, so a meaningless neighbor can't linger.
+        // Interface-based (unnumbered) and dynamic listen-range peers are
+        // separate lists and unaffected.
+        ext:non-empty "remote-as";
         key "remote-address";
         description
           "List of BGP neighbors configured on the local system,
@@ -451,15 +438,6 @@ module ietf-bgp {
           output {
             leaf result { type string; }
           }
-        }
-
-        leaf peer-group {
-          type leafref {
-            path "../../../peer-groups/peer-group/name";
-          }
-          description
-            "The peer-group with which this neighbor is
-               associated.";
         }
 
         leaf local-address {
@@ -944,69 +922,6 @@ module ietf-bgp {
           "The backward-transition event is
              generated when the BGP FSM moves from a higher
              numbered state to a lower numbered state.";
-      }
-
-      container peer-groups {
-        description
-          "Configuration for BGP peer-groups";
-
-        list peer-group {
-          key "name";
-          description
-            "List of BGP peer-groups configured on the local system -
-             uniquely identified by peer-group name";
-
-          leaf name {
-            type string;
-            description
-              "Name of the BGP peer-group";
-          }
-
-          uses neighbor-group-config;
-          uses structure-dynamic-peers;
-
-          container graceful-restart {
-            if-feature "bt:graceful-restart";
-            description
-              "Parameters relating the graceful restart mechanism for
-               BGP";
-            reference
-              "RFC 4724: Graceful Restart Mechanism for BGP.";
-            uses graceful-restart-config;
-          }
-
-          container prefix-limit {
-            description
-              "Parameters relating to the prefix limit for the
-               AFI-SAFI";
-
-            uses prefix-limit-config-common;
-          }
-
-          container afi-safis {
-            description
-              "Per-address-family configuration parameters
-               associated with the peer-group.";
-            list afi-safi {
-              key "name";
-              description
-                "AFI, SAFI configuration available for the
-                 neighbor or group";
-              reference
-                "RFC 4724: Graceful Restart Mechanism for BGP.";
-              uses mp-afi-safi-config;
-              container graceful-restart {
-                if-feature "bt:graceful-restart";
-                description
-                  "Parameters relating to BGP graceful-restart";
-                uses mp-afi-safi-graceful-restart-config;
-              }
-              uses structure-add-paths;
-              uses bgp-neighbor-use-multiple-paths;
-              uses mp-all-afi-safi-list-contents;
-            }
-          }
-        }
       }
 
       uses rib;

--- a/zebra-rs/yang/zebra-bgp-neighbor-group.yang
+++ b/zebra-rs/yang/zebra-bgp-neighbor-group.yang
@@ -59,10 +59,11 @@ module zebra-bgp-neighbor-group {
     "https://github.com/zebra-rs";
 
   description
-    "IOS-XR-style `neighbor-group` for zebra-rs BGP. Sits alongside
-     the existing `peer-groups/peer-group` with a deliberately
-     focused attribute surface — the goal is to make the common
-     'these N peers share these few attributes' case ergonomic,
+    "IOS-XR-style `neighbor-group` for zebra-rs BGP. The sole
+     peer-grouping mechanism (the unimplemented IETF
+     `peer-groups/peer-group` container was removed), with a
+     deliberately focused attribute surface — the goal is to make the
+     common 'these N peers share these few attributes' case ergonomic,
      not to mirror every leaf of `neighbor-group-config`.
 
      The surface exposes `remote-as` and per-family `afi-safi


### PR DESCRIPTION
## Summary

Removes BGP YANG schema nodes that had no config handler (orphans listed in `docs/orphan-report.txt`):

- `/router/bgp/global/graceful-restart` container
- `/router/bgp/neighbor/route-flap-damping` — dropped from the shared `neighbor-group-config` grouping (its only other consumer was `peer-groups`)
- `/router/bgp/peer-groups` container in full

### Cascading cleanups from the peer-groups removal
- Removed the neighbor `peer-group` **leafref** (`path ../../../peer-groups/peer-group/name`) — it would dangle once its target was gone; it was itself an orphan.
- Updated the neighbor `ext:non-empty` message (`"remote-as or peer-group"` → `"remote-as"`; this string is only a rejection message, not a semantic node ref) and the module ASCII tree diagram.
- Deleted the now-unused `structure-dynamic-peers` grouping (uniquely consumed by `peer-groups`; `uses` count dropped to 0).
- Updated the `zebra-bgp-neighbor-group` module description to note it is now the sole peer-grouping mechanism.

### Safety
- `/router/bgp/vrf/neighbor/peer-group` **is** handled (`config_vrf_neighbor_peer_group`), but its `peer-group` leaf is a plain `string` resolved by name against the independent zebra `neighbor-group` module — not a structural reference to the removed IETF `peer-groups`. That feature is unaffected.
- Verified no other grouping or whole `.yang` module became unused.

## Test plan
- `cargo fmt --all` — clean
- `cargo build -p zebra-rs` — clean, no warnings
- `cargo test -p zebra-rs yang_load_tests` — 59/59 pass (schema still resolves)
- `cargo test -p zebra-rs config::` — 291/291 pass
- Updated `bgp_neighbor_bare_entry_rejected_and_pruned` and the `enabled`-naming guard comment to match the new `ext:non-empty` message.

Generated with [Claude Code](https://claude.com/claude-code)