### PR TITLE
yang: clean up BGP config help strings

### DIFF
--- a/zebra-rs/yang/ietf-bgp@2023-07-05.yang
+++ b/zebra-rs/yang/ietf-bgp@2023-07-05.yang
@@ -267,6 +267,7 @@ module ietf-bgp {
         "Top-level configuration for the BGP router.";
 
       list afi-safi {
+        ext:help "Per-address-family (AFI/SAFI) configuration";
         ext:sort "-1";
         key "name";
         description
@@ -287,6 +288,7 @@ module ietf-bgp {
         }
       }
       container global {
+        ext:help "Global BGP configuration (local AS, router-id)";
         presence "Enables global configuration of BGP";
         description
           "Global configuration for the BGP router.";
@@ -407,6 +409,7 @@ module ietf-bgp {
         // child is deleted, so a meaningless neighbor can't linger.
         // Interface-based (unnumbered) and dynamic listen-range peers are
         // separate lists and unaffected.
+        ext:help "BGP neighbor configuration (keyed by remote address)";
         ext:non-empty "remote-as";
         key "remote-address";
         description

--- a/zebra-rs/yang/zebra-bgp-color-policy.yang
+++ b/zebra-rs/yang/zebra-bgp-color-policy.yang
@@ -68,18 +68,18 @@ module zebra-bgp-color-policy {
        at runtime (ascending color id).";
 
     container color-policy {
-      ext:help "Color → Flex-Algorithm binding table";
+      ext:help "Color to Flex-Algorithm binding table";
       presence "Configure color-policy entries";
 
       list color {
-        ext:help "One color → flex-algorithm binding";
+        ext:help "One color to flex-algorithm binding";
         key value;
         leaf value {
-          ext:help "BGP Color community value (RFC 9012 §4.3, 0..2^32-1)";
+          ext:help "BGP Color community value (RFC 9012, 0..2^32-1)";
           type uint32;
         }
         leaf flex-algorithm {
-          ext:help "IS-IS Flex-Algorithm id (128..255 per RFC 9350 §4)";
+          ext:help "IS-IS Flex-Algorithm id (128..255 per RFC 9350)";
           type uint8 {
             range "128..255";
           }

--- a/zebra-rs/yang/zebra-bgp-sr-policy.yang
+++ b/zebra-rs/yang/zebra-bgp-sr-policy.yang
@@ -84,7 +84,7 @@ module zebra-bgp-sr-policy {
           type string;
         }
         leaf color {
-          ext:help "Policy color (RFC 9256 §2.1, non-zero)";
+          ext:help "Policy color (RFC 9256, non-zero)";
           type uint32;
         }
         leaf endpoint {

--- a/zebra-rs/yang/zebra-bgp-transport.yang
+++ b/zebra-rs/yang/zebra-bgp-transport.yang
@@ -310,7 +310,7 @@ module zebra-bgp-transport {
       "FRR-style transport leaves on the BGP instance itself.";
 
     leaf port {
-      ext:help "TCP port the BGP listener binds (0-65535; 0 disables listening, default 179)";
+      ext:help "TCP listen port (0-65535; 0 disables, default 179)";
       type uint16 {
         range "0..65535";
       }


### PR DESCRIPTION
## Summary

Fixes three CLI help-string issues visible under `router bgp ?`, all in the BGP YANG config models, plus a related ASCII cleanup.

1. **Phantom "empty node"** — the `color-policy` help used a Unicode arrow (`Color → Flex-Algorithm binding table`). The vty readline completion renderer miscounts the multi-byte character's display width (3 bytes / 1 column) and splits the help across lines, so it renders as a bogus node whose "help" is `Flex-Algorithm binding table`. Replaced the arrow with ASCII `to` (both occurrences).
2. **`router bgp port` help overran 80 columns** — the short `port` label pushes help to column 24, and the 76-char string rendered to 100 columns. Shortened to a 50-char string; the full behaviour detail stays in the leaf `description`.
3. **Missing `ext:help`** — `afi-safi`, `global`, and `neighbor` (in `ietf-bgp`) had only a YANG `description`, which the CLI does not display, so they showed blank. Added `ext:help` to each, each sized to render within 80 columns.

Also stripped the remaining non-ASCII section signs (`§`) from BGP `ext:help` strings so every BGP CLI help string is plain ASCII.

## Test plan

- `configure_mode_loads` / `exec_mode_loads` YANG guard tests pass (full config tree parses with all BGP augments).
- Confirmed no non-ASCII characters remain in any `ext:help` across `zebra-rs/yang/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)