### PR TITLE
yang: hoist BGP global knobs (hostname/no-fib-install/fast-external-failover) to bgp

### DIFF
--- a/bdd/tests/configs/bgp_fast_external_failover/z1.yaml
+++ b/bdd/tests/configs/bgp_fast_external_failover/z1.yaml
@@ -1,7 +1,7 @@
 # z1 (AS 65001): single-hop eBGP to z2 over the direct veth link
 # (10.107.0.0/24). fast-external-failover is left at its default
 # (enabled); the feature flips it off at runtime with
-# `set router bgp global fast-external-failover false` for the
+# `set router bgp fast-external-failover false` for the
 # disabled-case scenario. Default timers (hold 180) on purpose — the
 # feature under test is exactly "don't wait for the hold timer".
 interface:

--- a/bdd/tests/features/bgp_fast_external_failover.feature
+++ b/bdd/tests/features/bgp_fast_external_failover.feature
@@ -27,7 +27,7 @@ Feature: BGP fast-external-failover (immediate eBGP reset on link down)
   - z1.yaml / z2.yaml: direct eBGP over the veth, one originated
     prefix each, fast-external-failover left at its default (enabled).
     The disabled case is applied at runtime with
-    `set router bgp global fast-external-failover false`.
+    `set router bgp fast-external-failover false`.
 
   Scenario: Setup direct eBGP topology and establish the session
     Given a clean test environment
@@ -61,8 +61,8 @@ Feature: BGP fast-external-failover (immediate eBGP reset on link down)
 
   Scenario: Disabling fast-external-failover does not bounce the session
     Given the test topology exists
-    When I apply command "set router bgp global fast-external-failover false" in namespace "z1"
-    And I apply command "set router bgp global fast-external-failover false" in namespace "z2"
+    When I apply command "set router bgp fast-external-failover false" in namespace "z1"
+    And I apply command "set router bgp fast-external-failover false" in namespace "z2"
     And I wait 2 seconds
     Then BGP session in "z1" to "10.107.0.2" should be "Established"
     And BGP session in "z2" to "10.107.0.1" should be "Established"

--- a/docs/design/bgp-fast-external-failover.md
+++ b/docs/design/bgp-fast-external-failover.md
@@ -153,6 +153,16 @@ the ietf-bgp `container global`
 `no-fib-install` at :329). No new module, no `config.yang` import, and
 the config path comes out as `/router/bgp/global/fast-external-failover`.
 
+> **Update (post-landing):** `fast-external-failover`, `hostname` and
+> `no-fib-install` were later hoisted out of the `global` container to be
+> direct children of `bgp`, so the CLI is now `router bgp
+> fast-external-failover ...` and the config path is
+> `/router/bgp/fast-external-failover` (likewise
+> `/router/bgp/{hostname,no-fib-install}`). `as` and `router-id` stay
+> under `global`. The handlers are otherwise unchanged; the `global {`
+> CLI/YAML examples and the callback path below reflect the original
+> layout.
+
 ```yang
 leaf fast-external-failover {
   type boolean;

--- a/zebra-rs/src/bgp/config.rs
+++ b/zebra-rs/src/bgp/config.rs
@@ -4111,13 +4111,15 @@ impl Bgp {
     pub fn callback_build(&mut self) {
         self.callback_add("/router/bgp/global/as", config_global_asn);
         self.callback_add("/router/bgp/global/router-id", config_global_router_id);
-        self.callback_add("/router/bgp/global/hostname", config_global_hostname);
+        // `hostname`, `no-fib-install` and `fast-external-failover` were
+        // hoisted out of the `global` container to be direct children of
+        // `bgp` (ietf-bgp.yang), so the paths dropped the `/global`
+        // segment. The handlers are unchanged — `global` is a presence
+        // container with no key, so it never contributed an arg.
+        self.callback_add("/router/bgp/hostname", config_global_hostname);
+        self.callback_add("/router/bgp/no-fib-install", config_global_no_fib_install);
         self.callback_add(
-            "/router/bgp/global/no-fib-install",
-            config_global_no_fib_install,
-        );
-        self.callback_add(
-            "/router/bgp/global/fast-external-failover",
+            "/router/bgp/fast-external-failover",
             config_global_fast_external_failover,
         );
         // `router bgp port <0-65535>` (zebra-bgp-transport.yang): the

--- a/zebra-rs/src/config/manager.rs
+++ b/zebra-rs/src/config/manager.rs
@@ -2785,12 +2785,15 @@ mod yang_load_tests {
         );
     }
 
-    /// `router bgp global fast-external-failover <bool>` (a zebra-rs
-    /// leaf added to the ietf-bgp `container global`) must be a
-    /// settable path, and — being a boolean leaf, not a presence
-    /// container — the value-less spelling must not parse.
+    /// `fast-external-failover`, `hostname` and `no-fib-install` are
+    /// zebra-rs leaves hoisted out of the ietf-bgp `container global` to
+    /// be direct children of `bgp` (`router bgp <knob>`, FRR/IOS-XR
+    /// shape). Each new path must be settable; the two boolean leaves
+    /// must reject the value-less spelling; and the old `global/` paths
+    /// must no longer parse (locks in the move so a stray re-add under
+    /// `global` doesn't silently resurrect the old path).
     #[test]
-    fn bgp_global_fast_external_failover_is_settable() {
+    fn bgp_hoisted_global_leaves_are_settable() {
         use crate::config::ExecCode;
         use crate::config::parse::{State, parse};
         use libyang::to_entry;
@@ -2805,25 +2808,43 @@ mod yang_load_tests {
             .expect("configure module present");
         let entry = to_entry(&yang, module);
 
+        // New, hoisted paths parse as valid `set` commands.
         for cmd in [
-            "set router bgp global fast-external-failover false",
-            "set router bgp global fast-external-failover true",
+            "set router bgp fast-external-failover false",
+            "set router bgp fast-external-failover true",
+            "set router bgp hostname r1",
+            "set router bgp no-fib-install true",
         ] {
             let (code, _comps, _state) = parse(cmd, entry.clone(), None, State::new());
-            assert_eq!(code, ExecCode::Success, "`{cmd}` must be a valid path",);
+            assert_eq!(code, ExecCode::Success, "`{cmd}` must be a valid path");
         }
 
-        let (code, _comps, _state) = parse(
-            "set router bgp global fast-external-failover",
-            entry,
-            None,
-            State::new(),
-        );
-        assert_ne!(
-            code,
-            ExecCode::Success,
-            "boolean leaf — the value-less spelling must not parse",
-        );
+        // Boolean leaves reject the value-less spelling.
+        for cmd in [
+            "set router bgp fast-external-failover",
+            "set router bgp no-fib-install",
+        ] {
+            let (code, _comps, _state) = parse(cmd, entry.clone(), None, State::new());
+            assert_ne!(
+                code,
+                ExecCode::Success,
+                "`{cmd}`: boolean leaf — the value-less spelling must not parse",
+            );
+        }
+
+        // The pre-move paths under `global` no longer exist.
+        for cmd in [
+            "set router bgp global fast-external-failover false",
+            "set router bgp global hostname r1",
+            "set router bgp global no-fib-install true",
+        ] {
+            let (code, _comps, _state) = parse(cmd, entry.clone(), None, State::new());
+            assert_ne!(
+                code,
+                ExecCode::Success,
+                "`{cmd}`: the leaf moved out of `global`, so this path must not parse",
+            );
+        }
     }
 
     /// `neighbor X ip-transparent` (zebra-bgp-transport.yang) must be a

--- a/zebra-rs/yang/ietf-bgp@2023-07-05.yang
+++ b/zebra-rs/yang/ietf-bgp@2023-07-05.yang
@@ -315,49 +315,57 @@ module ietf-bgp {
           reference
             "RFC 6286: AS-Wide Unique BGP ID for BGP-4. Section 2.1";
         }
-        leaf hostname {
-          type string;
-          description
-            "Hostname of the local BGP speaker. Advertised to peers
-             via the FQDN capability (draft-walton-bgp-hostname-
-             capability-02, capability code 73). When unset, the OS
-             hostname is used; when neither is available the
-             capability is not sent.";
-        }
-        leaf no-fib-install {
-          type boolean;
-          default "false";
-          description
-            "When true, routes selected by this BGP speaker are not
-             installed into the forwarding table (FIB). The Loc-RIB is
-             still built and routes are still reflected and advertised
-             to peers, but no kernel forwarding entry is programmed for
-             IPv4/IPv6 unicast or for VPN, EVPN and labeled-unicast
-             MPLS routes. Next-hop tracking and best-path selection are
-             unaffected. Intended for a dedicated route reflector that
-             is out of the forwarding path. Best set at startup;
-             toggling at run time applies to subsequent route updates
-             rather than retroactively withdrawing already-installed
-             entries.";
-        }
-        // zebra-rs extension: not part of the IETF model.
-        leaf fast-external-failover {
-          type boolean;
-          default "true";
-          description
-            "When true (the default), immediately reset the session of
-             any directly connected (single-hop) eBGP neighbor whose
-             interface goes operationally down, instead of waiting for
-             the hold timer to expire. Single-hop means the session TTL
-             is 1 or the neighbor uses ttl-security (GTSM, directly
-             connected by definition); neighbors configured with
-             ebgp-multihop and all iBGP neighbors are unaffected.
-             Setting this to false restores hold-timer-only failure
-             detection, equivalent to IOS-XR
-             'bgp fast-external-fallover disable' and FRR
-             'no bgp fast-external-failover'.";
-        }
         uses state;
+      }
+
+      // zebra-rs divergence: hoisted out of `global` to be direct
+      // children of `bgp` so the CLI reads `router bgp <knob>` (FRR /
+      // IOS-XR shape) rather than `router bgp global <knob>`. The
+      // config handlers lower onto the same `Bgp` fields as before.
+      leaf hostname {
+        ext:help "Hostname advertised to peers via the FQDN capability";
+        type string;
+        description
+          "Hostname of the local BGP speaker. Advertised to peers
+           via the FQDN capability (draft-walton-bgp-hostname-
+           capability-02, capability code 73). When unset, the OS
+           hostname is used; when neither is available the
+           capability is not sent.";
+      }
+      leaf no-fib-install {
+        ext:help "Keep selected routes out of the kernel FIB";
+        type boolean;
+        default "false";
+        description
+          "When true, routes selected by this BGP speaker are not
+           installed into the forwarding table (FIB). The Loc-RIB is
+           still built and routes are still reflected and advertised
+           to peers, but no kernel forwarding entry is programmed for
+           IPv4/IPv6 unicast or for VPN, EVPN and labeled-unicast
+           MPLS routes. Next-hop tracking and best-path selection are
+           unaffected. Intended for a dedicated route reflector that
+           is out of the forwarding path. Best set at startup;
+           toggling at run time applies to subsequent route updates
+           rather than retroactively withdrawing already-installed
+           entries.";
+      }
+      // zebra-rs extension: not part of the IETF model.
+      leaf fast-external-failover {
+        ext:help "Reset single-hop eBGP sessions on link down";
+        type boolean;
+        default "true";
+        description
+          "When true (the default), immediately reset the session of
+           any directly connected (single-hop) eBGP neighbor whose
+           interface goes operationally down, instead of waiting for
+           the hold timer to expire. Single-hop means the session TTL
+           is 1 or the neighbor uses ttl-security (GTSM, directly
+           connected by definition); neighbors configured with
+           ebgp-multihop and all iBGP neighbors are unaffected.
+           Setting this to false restores hold-timer-only failure
+           detection, equivalent to IOS-XR
+           'bgp fast-external-fallover disable' and FRR
+           'no bgp fast-external-failover'.";
       }
 
       container segment-routing {


### PR DESCRIPTION
## Summary

Moves three zebra-rs knobs out of the ietf-bgp `container global` to be direct children of `bgp`, so the CLI reads `router bgp <knob>` (FRR / IOS-XR shape) instead of `router bgp global <knob>`, and gives each a `ext:help` string (they previously had none):

| Old path | New path |
|---|---|
| `/router/bgp/global/hostname` | `/router/bgp/hostname` |
| `/router/bgp/global/no-fib-install` | `/router/bgp/no-fib-install` |
| `/router/bgp/global/fast-external-failover` | `/router/bgp/fast-external-failover` |

`as` and `router-id` stay under `global`.

The config handlers are functionally unchanged and lower onto the same `Bgp` fields — `global` is a keyless presence container, so it never contributed an arg; only the three `callback_add` paths drop the `/global` segment.

Also updated: the `bgp_fast_external_failover` BDD feature/config that drove `set router bgp global fast-external-failover false`; the parse guard test (now `bgp_hoisted_global_leaves_are_settable`, which additionally asserts the old `global/` paths no longer parse); and a post-landing note in the design doc.

## Test plan

- `configure` / `exec` YANG load guards pass.
- Full `config::` test module: **291 pass** (incl. new `bgp_hoisted_global_leaves_are_settable`).
- Workspace `cargo clippy --all-targets -- -D warnings`: clean.
- Live daemon (`--yang-path` on this branch): `set router bgp {fast-external-failover|hostname|no-fib-install}` apply successfully; the old `set router bgp global ...` paths are rejected as unknown keys.

Generated with [Claude Code](https://claude.com/claude-code)