### PR TITLE
yang: add ext:help for bgp global as/router-id and afi-safi network

### DIFF
--- a/zebra-rs/yang/ietf-bgp@2023-07-05.yang
+++ b/zebra-rs/yang/ietf-bgp@2023-07-05.yang
@@ -276,6 +276,7 @@ module ietf-bgp {
         uses zas:afi-safi;
 
         list network {
+          ext:help "Prefix to originate into BGP";
           key "prefix";
           leaf prefix {
             // IPv4 prefix for ipv4 / label-v4 families; IPv6 prefix for
@@ -293,6 +294,7 @@ module ietf-bgp {
         description
           "Global configuration for the BGP router.";
         leaf as {
+          ext:help "Local BGP autonomous system number";
           type inet:as-number;
           mandatory true;
           description
@@ -305,6 +307,7 @@ module ietf-bgp {
         // (`system router-id`, `vrf <name> router-id`,
         // `router ospf{,v3} router-id`, `router bgp vrf <n> router-id`).
         leaf router-id {
+          ext:help "BGP router identifier (32-bit, dotted-quad)";
           type inet:ipv4-address;
           description
             "BGP Identifier of the router - an unsigned 32-bit,


### PR DESCRIPTION
## Summary

Three BGP config nodes rendered with a blank help column in the CLI (`router bgp global ?` / `router bgp afi-safi <af> ?`) because they had no `ext:help`. Add a concise help string to each:

| Node | New `ext:help` |
|---|---|
| `/router/bgp/global/as` | `Local BGP autonomous system number` |
| `/router/bgp/global/router-id` | `BGP router identifier (32-bit, dotted-quad)` |
| `/router/bgp/afi-safi/<af>/network` | `Prefix to originate into BGP` |

YANG-only. I enumerated the live completion trees to confirm `network` was the only `afi-safi` child missing help (all others already have it), and that union keys render type hints rather than the key's help (so no help was added to `network`'s `prefix` key). Each string is sized to keep the rendered completion line ≤ 80 columns.

## Test plan

- `configure` / `exec` YANG load guards pass.
- Live daemon: `router bgp global ?` and `router bgp afi-safi ipv4 ?` now show help for `as`, `router-id`, and `network`.

Generated with [Claude Code](https://claude.com/claude-code)