### PR TITLE
yang: remove handler-less BGP neighbor nodes; fill/trim ext:help

### DIFF
--- a/docs/orphan-report.txt
+++ b/docs/orphan-report.txt
@@ -1,57 +1,4 @@
 == Collapsed orphan report ==
-ORPHAN leaf         /router/bgp/neighbor/route-reflector/cluster-id
-ORPHAN-SUBTREE container    /router/bgp/neighbor/as-path-options  (3 settable nodes)
-    - /router/bgp/neighbor/as-path-options/allow-own-as  [leaf]
-    - /router/bgp/neighbor/as-path-options/replace-peer-as  [leaf]
-    - /router/bgp/neighbor/as-path-options/disable-peer-as-filter  [leaf]
-ORPHAN-SUBTREE container    /router/bgp/neighbor/add-paths  (5 settable nodes)
-    - /router/bgp/neighbor/add-paths/receive  [leaf]
-    - /router/bgp/neighbor/add-paths/send-max  [leaf]
-    - /router/bgp/neighbor/add-paths/eligible-prefix-policy  [leaf]
-    - /router/bgp/neighbor/add-paths/max  [leaf]
-    - /router/bgp/neighbor/add-paths/all  [leaf]
-ORPHAN-SUBTREE container    /router/bgp/neighbor/use-multiple-paths  (2 settable nodes)
-    - /router/bgp/neighbor/use-multiple-paths/ebgp/allow-multiple-as  [leaf]
-    - /router/bgp/neighbor/use-multiple-paths/enabled  [leaf]
-ORPHAN leaf         /router/bgp/neighbor/timers/keepalive
-ORPHAN-SUBTREE container    /router/bgp/neighbor/transport/ebgp-multihop  (2 settable nodes)
-    - /router/bgp/neighbor/transport/ebgp-multihop/enabled  [leaf]
-    - /router/bgp/neighbor/transport/ebgp-multihop/multihop-ttl  [leaf]
-ORPHAN-SUBTREE container    /router/bgp/neighbor/transport/secure-session  (4 settable nodes)
-    - /router/bgp/neighbor/transport/secure-session/options/ao-keychain  [leaf]
-    - /router/bgp/neighbor/transport/secure-session/options/md5-keychain  [leaf]
-    - /router/bgp/neighbor/transport/secure-session/options/sa  [leaf]
-    - /router/bgp/neighbor/transport/secure-session/enabled  [leaf]
-ORPHAN-SUBTREE container    /router/bgp/neighbor/transport/bfd  (5 settable nodes)
-    - /router/bgp/neighbor/transport/bfd/local-multiplier  [leaf]
-    - /router/bgp/neighbor/transport/bfd/desired-min-tx-interval  [leaf]
-    - /router/bgp/neighbor/transport/bfd/required-min-rx-interval  [leaf]
-    - /router/bgp/neighbor/transport/bfd/min-interval  [leaf]
-    - /router/bgp/neighbor/transport/bfd/enabled  [leaf]
-ORPHAN leaf         /router/bgp/neighbor/transport/tcp-mss
-ORPHAN leaf         /router/bgp/neighbor/transport/mtu-discovery
-ORPHAN leaf         /router/bgp/neighbor/transport/ttl-security
-ORPHAN-SUBTREE container    /router/bgp/neighbor/logging-options  (1 settable nodes)
-    - /router/bgp/neighbor/logging-options/log-neighbor-state-changes  [leaf]
-ORPHAN leaf         /router/bgp/neighbor/description
-ORPHAN leaf         /router/bgp/neighbor/treat-as-withdraw
-ORPHAN leaf-list    /router/bgp/neighbor/send-community
-ORPHAN-SUBTREE container    /router/bgp/neighbor/afi-safi/use-multiple-paths  (2 settable nodes)
-    - /router/bgp/neighbor/afi-safi/use-multiple-paths/ebgp/allow-multiple-as  [leaf]
-    - /router/bgp/neighbor/afi-safi/use-multiple-paths/enabled  [leaf]
-ORPHAN-SUBTREE container    /router/bgp/neighbor/graceful-restart  (5 settable nodes)
-    - /router/bgp/neighbor/graceful-restart/enabled  [leaf]
-    - /router/bgp/neighbor/graceful-restart/restart-time  [leaf]
-    - /router/bgp/neighbor/graceful-restart/stale-routes-time  [leaf]
-    - /router/bgp/neighbor/graceful-restart/helper-only  [leaf]
-    - /router/bgp/neighbor/graceful-restart/long-lived-enabled  [leaf]
-ORPHAN-SUBTREE container    /router/bgp/neighbor/prefix-limit  (4 settable nodes)
-    - /router/bgp/neighbor/prefix-limit/max-prefixes  [leaf]
-    - /router/bgp/neighbor/prefix-limit/warning-threshold-pct  [leaf]
-    - /router/bgp/neighbor/prefix-limit/teardown  [leaf]
-    - /router/bgp/neighbor/prefix-limit/idle-time  [leaf]
-ORPHAN leaf         /router/bgp/neighbor/enabled
-ORPHAN leaf         /router/bgp/neighbor/session-state
 ORPHAN leaf         /router/bgp/shards
 ORPHAN leaf         /router/bgp/peer-task
 
@@ -66,9 +13,16 @@ ORPHAN leaf         /router/bgp/peer-task
   /router/bgp/color-policy  [p-container]
   /router/bgp/vrf/neighbor/afi-safi  [list]
 
-Total settable schema nodes: 325
+Total settable schema nodes: 282
 Handled: 271
-Orphans: 45
+Orphans: 2
+
+Note: the two remaining orphans (shards, peer-task) have no config
+callback but are NOT dead — they are consumed at BGP task spawn by the
+flattened-config text scan in src/config/bgp.rs (configured_shards /
+configured_peer_task). The 43 handler-less nodes formerly listed under
+/router/bgp/neighbor were removed from the BGP YANG (they duplicated
+handled zebra knobs or were vendored ietf leftovers).
 
 == Handler paths with no schema node (stale/other) ==
   /router/bgp/neighbor/flowspec/validation

--- a/zebra-rs/yang/ietf-bgp-common-multiprotocol@2023-07-05.yang
+++ b/zebra-rs/yang/ietf-bgp-common-multiprotocol@2023-07-05.yang
@@ -124,6 +124,7 @@ submodule ietf-bgp-common-multiprotocol {
       "BGP graceful restart parameters that apply on a per-AFI-SAFI
        basis";
     leaf enabled {
+      ext:help "Enable graceful-restart for this family";
       type boolean;
       must ". = ../../../../graceful-restart/enabled";
       default "false";
@@ -140,6 +141,7 @@ submodule ietf-bgp-common-multiprotocol {
       "Configuration parameters used for all BGP AFI-SAFIs";
     uses zas:afi-safi;
     leaf enabled {
+      ext:help "Enable this address family for the neighbor";
       ext:sort "50";
       mandatory true;
       type boolean;

--- a/zebra-rs/yang/ietf-bgp-common-structure@2023-07-05.yang
+++ b/zebra-rs/yang/ietf-bgp-common-structure@2023-07-05.yang
@@ -19,6 +19,9 @@ submodule ietf-bgp-common-structure {
     reference
       "RFC 6991: Common YANG Data Types.";
   }
+  import extension {
+    prefix ext;
+  }
   include ietf-bgp-common-multiprotocol;
 
   // meta
@@ -72,22 +75,13 @@ submodule ietf-bgp-common-structure {
        configuration and state for both BGP neighbors and peer
        groups";
     container route-reflector {
+      ext:help "Route reflector settings for this neighbor";
       description
         "Route reflector parameters for the BGP peer-group";
       reference
         "RFC 4456: BGP Route Reflection.";
-      leaf cluster-id {
-        type bt:rr-cluster-id-type;
-        description
-          "Route Reflector cluster id to use when local router is
-           configured as a route reflector.  Commonly set at the
-           group level, but allows a different cluster id to be set
-           for each neighbor.";
-        reference
-          "RFC 4456: BGP Route Reflection: An Alternative to
-                     Full Mesh.";
-      }
       leaf client {
+        ext:help "Treat this neighbor as a route-reflector client";
         type boolean;
         default "false";
         description
@@ -99,93 +93,4 @@ submodule ietf-bgp-common-structure {
     }
   }
 
-  grouping structure-neighbor-group-as-path-options {
-    description
-      "Structural grouping used to include AS_PATH manipulation
-       configuration and state for both BGP neighbors and peer
-       groups";
-    container as-path-options {
-      description
-        "AS_PATH manipulation parameters for the BGP neighbor or
-         group";
-      leaf allow-own-as {
-        type uint8;
-        default "0";
-        description
-          "Specify the number of occurrences of the local BGP
-           speaker's AS that can occur within the AS_PATH before it
-           is rejected as looped.";
-      }
-      leaf replace-peer-as {
-        type boolean;
-        default "false";
-        description
-          "Replace occurrences of the peer's AS in the AS_PATH with
-           the local autonomous system number";
-      }
-      leaf disable-peer-as-filter {
-        type boolean;
-        default "false";
-        description
-          "When set to true, the system advertises routes to a peer
-           even if the peer's AS was in the AS path.  The default
-           behavior (false) suppresses advertisements to peers if
-           their AS number is in the AS path of the route.";
-      }
-    }
-  }
-
-  grouping structure-add-paths {
-    description
-      "Structural grouping used to include ADD-PATHs configuration
-       and state.";
-    container add-paths {
-      if-feature "bt:add-paths";
-      description
-        "Parameters relating to the advertisement and receipt of
-         multiple paths for a single NLRI (add-paths)";
-      reference
-        "RFC 7911: Advertisements of Multiple Paths in BGP.";
-      leaf receive {
-        type boolean;
-        default "false";
-        description
-          "Enable ability to receive multiple path advertisements for
-           an NLRI from the neighbor or group";
-      }
-      leaf send-max {
-        type uint8;
-      }
-      choice send {
-        description
-          "Choice of sending the max. number of paths or to send
-           all.";
-        case max {
-          leaf max {
-            type uint8;
-            description
-              "The maximum number of paths to advertise to neighbors
-               for a single NLRI";
-          }
-        }
-        case all {
-          leaf all {
-            type empty;
-            description
-              "Send all the path advertisements to neighbors for a
-               single NLRI.";
-          }
-        }
-      }
-      leaf eligible-prefix-policy {
-        type leafref {
-          path "/rt-pol:routing-policy/rt-pol:policy-definitions/"
-             + "rt-pol:policy-definition/rt-pol:name";
-        }
-        description
-          "A reference to a routing policy which can be used to
-           restrict the prefixes for which add-paths is enabled";
-      }
-    }
-  }
 }

--- a/zebra-rs/yang/ietf-bgp-common@2023-07-05.yang
+++ b/zebra-rs/yang/ietf-bgp-common@2023-07-05.yang
@@ -51,6 +51,9 @@ submodule ietf-bgp-common {
       "I-D.ietf-tcpm-yang-tcp: Transmission Control Protocol (TCP)
        YANG Model.";
   }
+  import extension {
+    prefix ext;
+  }
   include ietf-bgp-common-structure {
     revision-date 2023-07-05;
   }
@@ -104,6 +107,7 @@ submodule ietf-bgp-common {
       "Config parameters related to timers associated with the BGP
        peer";
     leaf connect-retry-time {
+      ext:help "ConnectRetry timer (seconds)";
       type uint16 {
         range "1..max";
       }
@@ -117,6 +121,7 @@ submodule ietf-bgp-common {
          Section 8.2.2.";
     }
     leaf hold-time {
+      ext:help "Hold timer negotiated with the peer (seconds)";
       type uint16 {
         range "0 | 3..65535";
       }
@@ -152,42 +157,20 @@ submodule ietf-bgp-common {
         "RFC 4271: A Border Gateway Protocol 4 (BGP-4), Section 4.2,
          RFC 4271: A Border Gateway Protocol 4 (BGP-4), Section 10.";
     }
-    leaf keepalive {
-      type uint16 {
-        range "0..21845";
-      }
-      units "seconds";
-      description
-        "When used as a configuration (rw) value, this Time interval
-         (in seconds) for the KeepAlive timer configured for this BGP
-         speaker with this peer.  A reasonable maximum value for this
-         timer would be one-third of the configured hold-time.
-
-         In the absence of explicit configuration of the keepalive
-         value, operationally it SHOULD have a value of one-third of
-         the negotiated hold-time.
-
-         If the value of this object is zero (0), no periodic
-         KEEPALIVE messages are sent to the peer after the BGP
-         connection has been established.
-
-         The actual time interval for the KEEPALIVE messages is
-         indicated by operational value of keepalive.";
-      reference
-        "RFC 4271: A Border Gateway Protocol 4 (BGP-4), Section 4.4,
-         RFC 4271: A Border Gateway Protocol 4 (BGP-4), Section 10.";
-    }
     leaf idle-hold-time {
+      ext:help "IdleHold timer before reconnect (seconds)";
       type uint16 {
         range "0..max";
       }
     }
     leaf delay-open-time {
+      ext:help "DelayOpen timer (seconds)";
       type uint16 {
         range "0..max";
       }
     }
     leaf originate-interval {
+      ext:help "Minimum AS-origination interval (seconds)";
       type uint16 {
         range "0..max";
       }
@@ -201,6 +184,7 @@ submodule ietf-bgp-common {
          RFC 4271: A Border Gateway Protocol 4 (BGP-4), Section 10.";
     }
     leaf advertisement-interval {
+      ext:help "Minimum route advertisement interval (MRAI)";
       type uint16 {
         range "0..max";
       }
@@ -218,40 +202,11 @@ submodule ietf-bgp-common {
     }
   }
 
-  grouping bgp-neighbor-use-multiple-paths {
-    description
-      "Multi-path configuration and state applicable to a BGP
-       neighbor";
-    container use-multiple-paths {
-      description
-        "Parameters related to the use of multiple-paths for the same
-         NLRI when they are received only from this neighbor";
-      leaf enabled {
-        type boolean;
-        default "false";
-        description
-          "Whether the use of multiple paths for the same NLRI is
-           enabled for the neighbor.";
-      }
-      container ebgp {
-        description
-          "Multi-path configuration for eBGP";
-        leaf allow-multiple-as {
-          type boolean;
-          default "false";
-          description
-            "Allow multi-path to use paths from different neighboring
-             ASes. The default is to only consider multiple paths
-             from the same neighboring AS.";
-        }
-      }
-    }
-  }
-
   grouping neighbor-group-config {
     description
       "Neighbor level configuration items.";
     leaf remote-as {
+      ext:help "Autonomous system number of the peer";
       type inet:as-number;
       description
         "AS number of the peer.";
@@ -278,68 +233,21 @@ submodule ietf-bgp-common {
     // route-flap-damping was removed from neighbor-group-config: it was an
     // unhandled orphan (no config handler) on every consumer of this
     // grouping and has been dropped.
-    leaf-list send-community {
-      if-feature "bct:send-communities";
-      type identityref {
-        base "bct:send-community-feature";
-      }
-      description
-        "When supported, this tells the router to propagate any
-         prefixes that are attached to these community-types.";
-    }
-    leaf description {
-      type string {
-        pattern '.*';
-      }
-      description
-        "An optional textual description (intended primarily for use
-         with a peer or group";
-    }
-
     container timers {
+      ext:help "Per-neighbor BGP timers";
       description
         "Timers related to a BGP neighbor";
       uses neighbor-group-timers;
     }
 
     container transport {
+      ext:help "Transport (TCP) session parameters";
       description
         "Transport session parameters for the BGP neighbor";
       uses neighbor-group-transport-config;
     }
 
-    leaf treat-as-withdraw {
-      type boolean;
-      default "false";
-      description
-        "Specify whether erroneous UPDATE messages for which the NLRI
-         can be extracted are treated as though the NLRI is withdrawn
-         - avoiding session reset";
-      reference
-        "RFC 7606: Revised Error Handling for BGP UPDATE Messages.";
-    }
-
-    container logging-options {
-      description
-        "Logging options for events related to the BGP neighbor or
-         group";
-      leaf log-neighbor-state-changes {
-        type boolean;
-        default "true";
-        description
-          "Configure logging of peer state changes.  Default is to
-           enable logging of peer state changes.
-
-           Note: Documenting demotion from ESTABLISHED state is
-                 desirable, but documenting all backward transitions
-                 is problematic, and should be avoided.";
-      }
-    }
-
     uses structure-neighbor-group-route-reflector;
-    uses structure-neighbor-group-as-path-options;
-    uses structure-add-paths;
-    uses bgp-neighbor-use-multiple-paths;
     // The peer-wide `neighbor X policy {in,out}` (rt-pol:apply-policy-group)
     // was retired; per-family route-policy now lives under
     // `neighbor X afi-safi <name> policy {in,out}` (ietf-bgp-neighbor).
@@ -351,6 +259,7 @@ submodule ietf-bgp-common {
        used by the BGP session to the peer.";
 
     leaf local-address {
+      ext:help "Local address to bind for the BGP session";
       type union {
         type inet:ipv4-address;
         type inet:ipv6-address;
@@ -362,48 +271,8 @@ submodule ietf-bgp-common {
          of an interface.";
     }
 
-    leaf tcp-mss {
-      type tcp:mss;
-      description
-        "Maximum Segment Size (MSS) desired on this connection.
-         Note, the 'effective send MSS' can be smaller than
-         what is configured here.";
-       reference
-         "RFC 9293: Transmission Control Protocol (TCP)
-                    Specification.";
-    }
-
-    leaf mtu-discovery {
-      type boolean;
-      default "true";
-      description
-        "Turns path mtu discovery for BGP TCP sessions on (true) or
-         off (false).";
-      reference
-        "RFC 1191: Path MTU discovery.";
-    }
-
-    container ebgp-multihop {
-      description
-        "eBGP multi-hop parameters for the BGP peer-group";
-      leaf enabled {
-        type boolean;
-        default "false";
-        description
-          "When enabled, the referenced group or neighbors are
-           permitted to be indirectly connected - including cases
-           where the TTL can be decremented between the BGP peers";
-      }
-      leaf multihop-ttl {
-        type uint8;
-        description
-          "Time-to-live value to use when packets are sent to the
-           referenced group or neighbors and ebgp-multihop is
-           enabled";
-      }
-    }
-
     leaf passive-mode {
+      ext:help "Wait for the peer to initiate the connection";
       type boolean;
       default "false";
       description
@@ -411,151 +280,6 @@ submodule ietf-bgp-common {
          rather than initiating sessions from the local router.";
     }
 
-    leaf ttl-security {
-      if-feature "bt:ttl-security";
-      type uint8;
-      default "255";
-      description
-        "BGP Time To Live (TTL) security check.";
-      reference
-        "RFC 5082: The Generalized TTL Security Mechanism (GTSM),
-         RFC 7454: BGP Operations and Security.";
-    }
-
-    container secure-session {
-      must "enabled = 'false' or " +
-           "(enabled = 'true' and options)" {
-        error-message "When secure-session is enabled " +
-          "secure-session options MUST be set";
-      }
-      description
-        "Container for describing how a particular BGP session
-         is to be secured.";
-
-      leaf enabled {
-        type boolean;
-        default "false";
-        description
-          "When set to true, session is secured with the
-           configured options.";
-      }
-
-      container options {
-        description
-          "Options for securing the BGP session.";
-        choice option {
-          case ao {
-            leaf ao-keychain {
-              type key-chain:key-chain-ref;
-              description
-                "Reference to the key chain that will be used by this
-                 model. Applicable for TCP-AO and TCP-MD5 only";
-              reference
-                "RFC 8177: YANG Data Model for Key Chains.";
-            }
-            description
-              "Uses TCP-AO to secure the session. Parameters for
-               those are defined as a grouping in the TCP YANG
-               model.";
-            reference
-              "RFC 5925: The TCP Authentication Option.";
-          }
-
-          case md5 {
-            leaf md5-keychain {
-              type key-chain:key-chain-ref;
-              description
-                "Reference to the key chain that will be used by this
-                 model. Applicable for TCP-AO and TCP-MD5 only";
-              reference
-                "RFC 8177: YANG Data Model for Key Chains.";
-            }
-            description
-              "Uses TCP-MD5 to secure the session. Parameters for
-               those are defined as a grouping in the TCP YANG
-               model.";
-            reference
-              "RFC 5925: The TCP Authentication Option.";
-          }
-
-          case ipsec {
-            leaf sa {
-              type string;
-              description
-                "Security Association (SA) name.";
-            }
-            description
-              "Currently, the IPsec/IKE YANG model has no
-               grouping defined that this model can use. When
-               such a grouping is defined, this model can import
-               the grouping to add the key parameters
-               needed to kick of IKE.";
-          }
-
-          description
-            "Choice of authentication options.";
-        }
-      }
-    }
-
-    container bfd {
-      if-feature "bt:bfd";
-      uses bfd-types:client-cfg-parms;
-      description
-        "BFD client configuration.";
-      reference
-        "RFC 9127: YANG Data Model for Bidirectional Forwarding
-         Detection.";
-    }
-  }
-
-  grouping graceful-restart-config {
-    description
-      "Configuration parameters relating to BGP graceful restart.";
-    leaf enabled {
-      type boolean;
-      default "false";
-      description
-        "Enable or disable the graceful-restart capability.";
-    }
-    leaf restart-time {
-      type bt:graceful-restart-time-type;
-      description
-        "Estimated time (in seconds) for the local BGP speaker to
-         restart a session. This value is advertise in the graceful
-         restart BGP capability.  This is a 12-bit value, referred to
-         as Restart Time in RFC4724.  Per RFC4724, the suggested
-         default value is <= the hold-time value.";
-      reference
-        "RFC 4724: Graceful Restart Mechanism for BGP.";
-    }
-    leaf stale-routes-time {
-      type uint32;
-      description
-        "An upper-bound on the time that stale routes will be
-         retained by a router after a session is restarted. If an
-         End-of-RIB (EOR) marker is received prior to this timer
-         expiring, stale-routes will be flushed upon its receipt - if
-         no EOR is received, then when this timer expires stale paths
-         will be purged. This timer is referred to as the
-         Selection_Deferral_Timer in RFC4724";
-      reference
-        "RFC 4724: Graceful Restart Mechanism for BGP.";
-    }
-    leaf helper-only {
-      type boolean;
-      default "true";
-      description
-        "Enable graceful-restart in helper mode only. When this leaf
-         is set, the local system does not retain forwarding its own
-         state during a restart, but supports procedures for the
-         receiving speaker, as defined in RFC4724.";
-      reference
-        "RFC 4724: Graceful Restart Mechanism for BGP.";
-    }
-    leaf long-lived-enabled {
-      type boolean;
-    }
   }
 
   grouping global-group-use-multiple-paths {

--- a/zebra-rs/yang/ietf-bgp-neighbor@2023-07-05.yang
+++ b/zebra-rs/yang/ietf-bgp-neighbor@2023-07-05.yang
@@ -73,6 +73,7 @@ submodule ietf-bgp-neighbor {
     description
       "List of address-families associated with the BGP neighbor";
     list afi-safi {
+      ext:help "Per-address-family (AFI/SAFI) configuration";
       key "name";
       description
         "AFI, SAFI configuration available for the neighbor or
@@ -110,14 +111,18 @@ submodule ietf-bgp-neighbor {
         }
       }
       container long-lived-graceful-restart {
+        ext:help "Per-family long-lived GR settings (RFC 9494)";
         leaf enabled {
+          ext:help "Enable long-lived graceful-restart (RFC 9494)";
           type boolean;
         }
         leaf restart-time {
+          ext:help "LLGR stale-retention time (seconds)";
           type uint32;
         }
       }
       container graceful-restart {
+        ext:help "Per-family graceful-restart settings";
         if-feature "bt:graceful-restart";
         description
           "Parameters relating to BGP graceful-restart";
@@ -178,8 +183,8 @@ submodule ietf-bgp-neighbor {
         }
       }
       // uses mp-all-afi-safi-list-contents;
-      uses bgp-neighbor-use-multiple-paths;
       leaf add-path {
+        ext:help "Additional-Paths send/receive mode (RFC 7911)";
         ext:sort "10";
         type enumeration {
           enum send;
@@ -188,6 +193,7 @@ submodule ietf-bgp-neighbor {
         }
       }
       leaf encapsulation-type {
+        ext:help "Encapsulation for advertised routes (srv6)";
         when "../name = 'ipv6'" {
           description
             "SRv6 encapsulation only applies to the IPv6 unicast
@@ -216,6 +222,7 @@ submodule ietf-bgp-neighbor {
            family.";
       }
       leaf next-hop-self {
+        ext:help "Advertise self as next hop to this neighbor";
         ext:sort "30";
         type boolean;
         description
@@ -248,9 +255,11 @@ submodule ietf-bgp-neighbor {
            it falls back to a route-policy inherited from a
            neighbor-group (if any).";
         leaf in {
+          ext:help "Inbound route-policy for this family";
           type string;
         }
         leaf out {
+          ext:help "Outbound route-policy for this family";
           type string;
         }
       }
@@ -262,9 +271,11 @@ submodule ietf-bgp-neighbor {
            address family. The per-family successor of the (removed)
            peer-wide `neighbor X prefix-set {in,out}`.";
         leaf in {
+          ext:help "Inbound prefix-set filter for this family";
           type string;
         }
         leaf out {
+          ext:help "Outbound prefix-set filter for this family";
           type string;
         }
       }

--- a/zebra-rs/yang/ietf-bgp@2023-07-05.yang
+++ b/zebra-rs/yang/ietf-bgp@2023-07-05.yang
@@ -428,6 +428,7 @@ module ietf-bgp {
              uniquely identified by remote IPv[46] address.";
 
         leaf local-identifier {
+          ext:help "Local BGP identifier (router-id) for this session";
           type inet:ipv4-address;
           description
             "When present, this peer has been created
@@ -515,112 +516,10 @@ module ietf-bgp {
               dynamically.";
         }
 
-        leaf enabled {
-          type boolean;
-          default "true";
-          description
-            "Whether the BGP peer is enabled. In cases where the
-               enabled leaf is set to false, the local system should
-               not initiate connections to the neighbor, and should
-               not respond to TCP connections attempts from the
-               neighbor. If the state of the BGP session is
-               Established at the time that this leaf is set to
-               false, the BGP session should be ceased.
-
-               A transition from 'false' to 'true' will cause
-               the BGP Manual Start Event to be generated.
-               A transition from 'true' to 'false' will cause
-               the BGP Manual Stop Event to be generated.
-               This parameter can be used to restart BGP peer
-               connections. Care should be used in providing
-               write access to this object without adequate
-               authentication.";
-          reference
-            "RFC 4271: A Border Gateway Protocol 4 (BGP-4),
-               Section 8.1.2.";
-        }
-
         uses neighbor-group-config;
-
-        container graceful-restart {
-          if-feature "bt:graceful-restart";
-          description
-            "Parameters relating the graceful restart mechanism for
-               BGP";
-          reference
-            "RFC 4724: Graceful Restart Mechanism for BGP.";
-          uses graceful-restart-config;
-          leaf peer-restart-time {
-            type uint16 {
-              range "0..4096";
-            }
-            config false;
-            description
-              "The period of time (advertised by the peer) that the
-                 peer expects a restart of a BGP session to take.";
-          }
-
-          leaf peer-restarting {
-            type boolean;
-            config false;
-            description
-              "This flag indicates whether the remote neighbor is
-                 currently in the process of restarting, and hence
-                 received routes are currently stale.";
-          }
-
-          leaf local-restarting {
-            type boolean;
-            config false;
-            description
-              "This flag indicates whether the local neighbor is
-                 currently restarting. The flag is cleared after all
-                 NLRI have been advertised to the peer, and the
-                 End-of-RIB (EOR) marker has been cleared.";
-          }
-
-          leaf mode {
-            type enumeration {
-              enum helper-only {
-                description
-                  "The local router is operating in helper-only
-                     mode, and hence will not retain forwarding state
-                     during a local session restart, but will do so
-                     during a restart of the remote peer";
-              }
-              enum bilateral {
-                description
-                "The local router is operating in both helper
-                     mode, and hence retains forwarding state during
-                     a remote restart, and also maintains forwarding
-                     state during local session restart";
-              }
-              enum remote-helper {
-                description
-                  "The local system is able to retain routes during
-                     restart but the remote system is only able to
-                     act as a helper";
-              }
-            }
-            config false;
-            description
-              "This leaf indicates the mode of operation of BGP
-                 graceful restart with the peer";
-          }
-        }
         // The per-neighbor `prefix-set {in,out}` moved under
         // `afi-safi <name> prefix-set {in,out}` (per-family). No
         // backward-compatibility alias is kept (unlike `policy`).
-
-        container prefix-limit {
-          description
-            "Parameters relating to the prefix limit for the
-               AFI-SAFI";
-
-          uses prefix-limit-config-common;
-
-          uses prefix-limit-state-common;
-        }
 
         //container afi-safis {
           description
@@ -629,49 +528,6 @@ module ietf-bgp {
           uses bgp-neighbor-afi-safi-list;
         //}
 
-        leaf session-state {
-          type enumeration {
-            enum idle {
-              description
-              "Neighbor is down, and in the Idle state of the
-                   FSM.";
-            }
-            enum connect {
-              description
-              "Neighbor is down, and the session is waiting for
-                   the underlying transport session to be
-                   established.";
-            }
-            enum active {
-              description
-              "Neighbor is down, and the local system is awaiting
-                   a connection from the remote peer.";
-            }
-            enum opensent {
-              description
-              "Neighbor is in the process of being established.
-                   The local system has sent an OPEN message.";
-            }
-            enum openconfirm {
-              description
-              "Neighbor is in the process of being established.
-                   The local system is awaiting a NOTIFICATION or
-                   KEEPALIVE message.";
-            }
-            enum established {
-              description
-              "Neighbor is up - the BGP session with the peer is
-                   established.";
-            }
-          }
-          //  notification does not like a non-config statement.
-          //  config false;
-          description
-            "The BGP peer connection state.";
-          reference
-            "RFC 4271: A Border Gateway Protocol 4 (BGP-4),
-               Section 8.1.2.";
-        }
         leaf last-established {
           type yang:date-and-time;
           config false;

--- a/zebra-rs/yang/zebra-bgp-as-override.yang
+++ b/zebra-rs/yang/zebra-bgp-as-override.yang
@@ -59,7 +59,7 @@ module zebra-bgp-as-override {
       "FRR-style `as-override` presence container on a BGP neighbor.";
 
     container as-override {
-      ext:help "Override the neighbor's AS in outbound AS_PATH with the local AS";
+      ext:help "Replace the peer's AS in outbound AS_PATH";
       presence "Enable as-override on the egress path toward this neighbor";
       description
         "When present, replace every occurrence of this neighbor's AS in

--- a/zebra-rs/yang/zebra-bgp-enforce-first-as.yang
+++ b/zebra-rs/yang/zebra-bgp-enforce-first-as.yang
@@ -65,7 +65,7 @@ module zebra-bgp-enforce-first-as {
        neighbor.";
 
     container enforce-first-as {
-      ext:help "Discard updates whose AS_PATH does not start with this neighbor's AS";
+      ext:help "Require AS_PATH to start with the peer's AS";
       presence "Enable the first-AS check on inbound updates from this neighbor";
       description
         "When present, drop an inbound eBGP UPDATE from this neighbor

--- a/zebra-rs/yang/zebra-bgp-pic-retention.yang
+++ b/zebra-rs/yang/zebra-bgp-pic-retention.yang
@@ -69,7 +69,7 @@ module zebra-bgp-pic-retention {
       "Per-neighbor NHT-gated route retention presence container.";
 
     container pic-retention {
-      ext:help "Keep this peer's VPN routes on session-down while their next hop stays reachable";
+      ext:help "Retain VPN routes on session-down while NH reachable";
       presence "Enable NHT-gated route retention for this neighbor";
       description
         "When present, a session-down marks this peer's VPN routes stale

--- a/zebra-rs/yang/zebra-bgp-remove-private-as.yang
+++ b/zebra-rs/yang/zebra-bgp-remove-private-as.yang
@@ -96,7 +96,7 @@ module zebra-bgp-remove-private-as {
          The bare form acts only on an all-private path.";
 
       leaf all {
-        ext:help "Remove private ASNs even from a mixed public/private AS_PATH";
+        ext:help "Remove private ASNs from a mixed AS_PATH";
         type empty;
         description
           "Act on any AS_PATH containing a private AS, not only one
@@ -104,7 +104,7 @@ module zebra-bgp-remove-private-as {
       }
 
       leaf replace-as {
-        ext:help "Replace each private ASN with the local AS instead of removing it";
+        ext:help "Replace private ASNs with the local AS";
         type empty;
         description
           "Rewrite each stripped private AS to the local AS rather than

--- a/zebra-rs/yang/zebra-bgp-soft-reconfiguration.yang
+++ b/zebra-rs/yang/zebra-bgp-soft-reconfiguration.yang
@@ -69,7 +69,7 @@ module zebra-bgp-soft-reconfiguration {
         "Soft-reconfiguration knobs for this neighbor.";
 
       leaf inbound {
-        ext:help "Store received UPDATEs so inbound policy can be re-applied without a session reset";
+        ext:help "Store received UPDATEs for inbound re-application";
         type boolean;
         default "false";
         description

--- a/zebra-rs/yang/zebra-bgp-transport.yang
+++ b/zebra-rs/yang/zebra-bgp-transport.yang
@@ -110,7 +110,7 @@ module zebra-bgp-transport {
     }
 
     container ttl-security {
-      ext:help "Enable GTSM: accept this peer only when directly connected (TTL 255)";
+      ext:help "Enable GTSM: require directly-connected peer (TTL 255)";
       presence "Enable GTSM (TTL 255 send + receive enforcement) for this neighbor";
       description
         "When present, enable the Generalized TTL Security Mechanism
@@ -137,7 +137,7 @@ module zebra-bgp-transport {
     }
 
     leaf ebgp-multihop {
-      ext:help "Allow an eBGP peer up to N hops away; sets the BGP TTL (1-255)";
+      ext:help "Allow an eBGP peer up to N hops away (TTL 1-255)";
       type uint8 {
         range "1..255";
       }
@@ -164,7 +164,7 @@ module zebra-bgp-transport {
     }
 
     leaf tcp-mss {
-      ext:help "Cap the TCP Maximum Segment Size for this neighbor (1-65535)";
+      ext:help "Cap the TCP MSS for this neighbor (1-65535)";
       type uint16 {
         range "1..65535";
       }
@@ -200,7 +200,7 @@ module zebra-bgp-transport {
     }
 
     leaf port {
-      ext:help "TCP destination port used to connect to this neighbor (1-65535, default 179)";
+      ext:help "TCP port to dial this neighbor (default 179)";
       type uint16 {
         range "1..65535";
       }
@@ -229,7 +229,7 @@ module zebra-bgp-transport {
     }
 
     container ip-transparent {
-      ext:help "Allow this session to use a local address the host does not own (with update-source)";
+      ext:help "Bind a local address the host does not own";
       presence "Set IP_TRANSPARENT on this neighbor's TCP socket";
       description
         "When present, set the IP_TRANSPARENT (IPv4) / IPV6_TRANSPARENT
@@ -272,7 +272,7 @@ module zebra-bgp-transport {
     }
 
     container disable-connected-check {
-      ext:help "Allow a single-hop eBGP peer that is not on a connected subnet";
+      ext:help "Allow a single-hop eBGP peer off-subnet";
       presence "Skip the directly-connected-network check for this eBGP neighbor";
       description
         "When present, skip the directly-connected-network check for this

--- a/zebra-rs/yang/zebra-bgp-unknown-attr.yang
+++ b/zebra-rs/yang/zebra-bgp-unknown-attr.yang
@@ -66,7 +66,7 @@ module zebra-bgp-unknown-attr {
 
     leaf attach-unknown-attribute {
       type string;
-      ext:help "Attach a synthetic unrecognized attribute: <type>:<flags>:<value-hex>";
+      ext:help "Attach a synthetic unrecognized attribute";
       description
         "When set, stamp a synthetic unrecognized path attribute onto
          every IPv4-unicast route advertised to this neighbor. Format is


### PR DESCRIPTION
## Summary

A two-part cleanup of the `/router/bgp/neighbor/*` config subtree, driven by `docs/orphan-report.txt` and cross-checked against the live handler map.

### Part 1 — remove 43 handler-less nodes (20 groups)
`route-reflector/cluster-id`, `as-path-options`, `add-paths`, `use-multiple-paths`, `timers/keepalive`, `transport/{ebgp-multihop,secure-session,bfd,tcp-mss,mtu-discovery,ttl-security}`, `logging-options`, `description`, `treat-as-withdraw`, `send-community`, `afi-safi/use-multiple-paths`, `graceful-restart`, `prefix-limit`, `enabled`, `session-state`.

These were vendored ietf-bgp leftovers with no config callback; several duplicated handled zebra knobs (the flat `ttl-security`/`tcp-mss`/`ebgp-multihop` and the zebra-bgp-bfd BFD attachment stay). Kept the `transport`/`timers`/`route-reflector`/`afi-safi` containers (they carry handled children). Dead groupings were deleted (`bgp-neighbor-use-multiple-paths`, `graceful-restart-config`, `structure-{as-path-options,add-paths}`); shared groupings preserved (`prefix-limit-config-common/-state-common`, still used by the afi-safi prefix-limit).

### Part 2 — ext:help audit on remaining nodes
- Added `ext:help` to **28** blank nodes (`remote-as`, `local-identifier`, timers/transport/route-reflector containers + leaves, per-family afi-safi knobs).
- Trimmed **13** strings that overran the 80-column CLI help line (`ip-transparent`, `pic-retention`, `port`, `ttl-security`, `ebgp-multihop`, `tcp-mss`, `as-override`, `enforce-first-as`, `disable-connected-check`, `attach-unknown-attribute`, `soft-reconfiguration/inbound`, `remove-private-as/{all,replace-as}`).
- Added `import extension` to `ietf-bgp-common` and `-structure` (needed for `ext:help`).

`docs/orphan-report.txt` refreshed (2 orphans remain: `shards`/`peer-task`, both consumed at BGP-task spawn, not dead).

## Test plan

- `configure` / `exec` YANG load guards pass.
- Full `config::` + `bgp::` suites: **784 pass** (no test asserted a removed path).
- Live daemon (`--yang-path` on this branch): every removed path is gone, every handler intact, and a full re-enumeration of the neighbor tree (67 nodes) shows **0 blank help, 0 over-80**.

Generated with [Claude Code](https://claude.com/claude-code)