### PR TITLE
yang: restore handler-less neighbor enabled leaf (fix #1813 regression)

### DIFF
--- a/docs/orphan-report.txt
+++ b/docs/orphan-report.txt
@@ -1,4 +1,5 @@
 == Collapsed orphan report ==
+ORPHAN leaf         /router/bgp/neighbor/enabled
 ORPHAN leaf         /router/bgp/shards
 ORPHAN leaf         /router/bgp/peer-task
 
@@ -13,16 +14,19 @@ ORPHAN leaf         /router/bgp/peer-task
   /router/bgp/color-policy  [p-container]
   /router/bgp/vrf/neighbor/afi-safi  [list]
 
-Total settable schema nodes: 282
+Total settable schema nodes: 283
 Handled: 271
-Orphans: 2
+Orphans: 3
 
-Note: the two remaining orphans (shards, peer-task) have no config
-callback but are NOT dead — they are consumed at BGP task spawn by the
-flattened-config text scan in src/config/bgp.rs (configured_shards /
-configured_peer_task). The 43 handler-less nodes formerly listed under
-/router/bgp/neighbor were removed from the BGP YANG (they duplicated
-handled zebra knobs or were vendored ietf leftovers).
+Note: these orphans have no config callback but are kept intentionally.
+shards / peer-task are consumed at BGP task spawn by the flattened-config
+text scan in src/config/bgp.rs (configured_shards / configured_peer_task).
+neighbor/enabled is a standard IETF/OpenConfig/FRR idiom (`neighbor X
+enabled true`, present in ~418 test configs); it is accepted and inert (a
+neighbor is enabled by configuring remote-as) and the schema must accept
+it so those configs load. The other 42 handler-less neighbor nodes were
+removed from the BGP YANG (vendored ietf leftovers / duplicates of handled
+zebra knobs).
 
 == Handler paths with no schema node (stale/other) ==
   /router/bgp/neighbor/flowspec/validation

--- a/zebra-rs/yang/ietf-bgp@2023-07-05.yang
+++ b/zebra-rs/yang/ietf-bgp@2023-07-05.yang
@@ -516,6 +516,25 @@ module ietf-bgp {
               dynamically.";
         }
 
+        // `enabled` is a standard IETF/OpenConfig/FRR neighbor knob
+        // (`neighbor X enabled true`) present in many configs. It has no
+        // config handler yet, so it is accepted and inert (a neighbor is
+        // brought up by configuring remote-as); the schema keeps it so
+        // those configs load. Intentionally retained, not a removal
+        // candidate — wire a handler if administrative disable is wanted.
+        leaf enabled {
+          ext:help "Administratively enable this neighbor";
+          type boolean;
+          default "true";
+          description
+            "Whether the BGP peer is enabled. When set to false the local
+             system should not initiate connections to the neighbor and
+             should tear down an established session. zebra-rs currently
+             accepts this leaf but does not enforce it.";
+          reference
+            "RFC 4271: A Border Gateway Protocol 4 (BGP-4), Section 8.1.2.";
+        }
+
         uses neighbor-group-config;
         // The per-neighbor `prefix-set {in,out}` moved under
         // `afi-safi <name> prefix-set {in,out}` (per-family). No


### PR DESCRIPTION
## Summary

**Bug fix for `main`.** PR #1813 removed the ietf-bgp neighbor `enabled` leaf as a handler-less orphan, but `neighbor X enabled true` is a standard IETF/OpenConfig/FRR idiom and is set in **418 BDD configs** (always the default `true`). Because the config layer rejects the whole document on an unknown key, that removal makes every one of those configs fail to apply — a live regression across the BGP BDD suite that CI does not catch (BDD is not in CI).

This restores the leaf (with an `ext:help` and a note that it is currently accepted-but-inert — a neighbor is brought up by configuring `remote-as`), so those configs load again. No handler is added; wire one later if administrative enable/disable is wanted. `docs/orphan-report.txt` re-lists it and notes it is intentionally retained as a standard idiom.

## Test plan

- `configure` / `exec` YANG load guards pass; full `config::` suite (291) green.
- Live daemon: `enabled` is back under `neighbor`, and BDD configs carrying `enabled: true` apply cleanly again (previously rejected with `unknown key 'enabled'`).

Generated with [Claude Code](https://claude.com/claude-code)