### PR TITLE
yang: move shards/peer-task under a sharding container

### DIFF
--- a/bdd/docs/bgp_network_origin_shard_pet.md
+++ b/bdd/docs/bgp_network_origin_shard_pet.md
@@ -3,7 +3,7 @@
 ## Overview
 
 Repro for a reported bug: a speaker with the RIB sharded
-(router bgp shards 4) AND per-peer egress tasks (router bgp peer-task true)
+(router bgp sharding rib-sharding 4) AND per-peer egress tasks (router bgp sharding peer-sharding true)
 configured with IPv4 network statements never advertises those networks to
 its neighbor.
 Key fact: IPv4-unicast AFI/SAFI is enabled by DEFAULT on every neighbor,

--- a/bdd/docs/bgp_peer_task_config_knob.md
+++ b/bdd/docs/bgp_peer_task_config_knob.md
@@ -1,9 +1,9 @@
-# BGP per-peer egress task configured via the router bgp peer-task knob
+# BGP per-peer egress task configured via the router bgp sharding peer-sharding knob
 
 ## Overview
 
 Validates the shipping form of the per-peer egress task (PET): the egress
-model comes from config (router bgp peer-task true, zebra-bgp-sharding.yang)
+model comes from config (router bgp sharding peer-sharding true, zebra-bgp-sharding.yang)
 instead of the ZEBRA_BGP_PEER_TASK environment variable. The device z2 is
 started with the PLAIN start step — no env vars — and reads BOTH its shard
 count (shards: 4) and its egress model (peer-task: true) from config.

--- a/bdd/docs/bgp_shard_config_knob.md
+++ b/bdd/docs/bgp_shard_config_knob.md
@@ -1,9 +1,9 @@
-# BGP RIB sharding configured via the router bgp shards YANG knob
+# BGP RIB sharding configured via the router bgp sharding rib-sharding YANG knob
 
 ## Overview
 
 Validates the C.4 shipping form of RIB sharding: the shard count comes
-from config (`router bgp shards <1-64>`, zebra-bgp-sharding.yang) instead
+from config (`router bgp sharding rib-sharding <1-64>`, zebra-bgp-sharding.yang) instead
 of the `ZEBRA_BGP_SHARDS` environment variable. The sharded device z2 is
 started with the PLAIN `start zebra-rs` step — no env var — and gets its
 shard count purely from `shards: 4` in its applied config.

--- a/bdd/tests/configs/bgp_network_origin_shard_pet/z1-withdraw.yaml
+++ b/bdd/tests/configs/bgp_network_origin_shard_pet/z1-withdraw.yaml
@@ -3,8 +3,9 @@ router:
     global:
       as: 65501
       router-id: 10.0.0.1
-    peer-task: true
-    shards: 4
+    sharding:
+      rib-sharding: 4
+      peer-sharding: true
     timer:
       adv-interval:
         ebgp: 1

--- a/bdd/tests/configs/bgp_network_origin_shard_pet/z1.yaml
+++ b/bdd/tests/configs/bgp_network_origin_shard_pet/z1.yaml
@@ -3,8 +3,9 @@ router:
     global:
       as: 65501
       router-id: 10.0.0.1
-    peer-task: true
-    shards: 4
+    sharding:
+      rib-sharding: 4
+      peer-sharding: true
     timer:
       adv-interval:
         ebgp: 1

--- a/bdd/tests/configs/bgp_peer_task_config_knob/z2.yaml
+++ b/bdd/tests/configs/bgp_peer_task_config_knob/z2.yaml
@@ -3,8 +3,9 @@ router:
     global:
       as: 65002
       router-id: 10.0.0.2
-    shards: 4
-    peer-task: true
+    sharding:
+      rib-sharding: 4
+      peer-sharding: true
     timer:
       adv-interval:
         ebgp: 1

--- a/bdd/tests/configs/bgp_shard_config_knob/z2.yaml
+++ b/bdd/tests/configs/bgp_shard_config_knob/z2.yaml
@@ -3,7 +3,8 @@ router:
     global:
       as: 65002
       router-id: 10.0.0.2
-    shards: 4
+    sharding:
+      rib-sharding: 4
     timer:
       adv-interval:
         ebgp: 1

--- a/bdd/tests/features/bgp_network_origin_shard_pet.feature
+++ b/bdd/tests/features/bgp_network_origin_shard_pet.feature
@@ -3,7 +3,7 @@
 Feature: BGP IPv4 network origination is advertised under shards + peer-task
 
   Repro for a reported bug: a speaker with the RIB sharded
-  (router bgp shards 4) AND per-peer egress tasks (router bgp peer-task true)
+  (router bgp sharding rib-sharding 4) AND per-peer egress tasks (router bgp sharding peer-sharding true)
   configured with IPv4 network statements never advertises those networks to
   its neighbor.
 

--- a/bdd/tests/features/bgp_peer_task_config_knob.feature
+++ b/bdd/tests/features/bgp_peer_task_config_knob.feature
@@ -1,9 +1,9 @@
 @serial
 @bgp_peer_task_config_knob
-Feature: BGP per-peer egress task configured via the router bgp peer-task knob
+Feature: BGP per-peer egress task configured via the router bgp sharding peer-sharding knob
 
   Validates the shipping form of the per-peer egress task (PET): the egress
-  model comes from config (router bgp peer-task true, zebra-bgp-sharding.yang)
+  model comes from config (router bgp sharding peer-sharding true, zebra-bgp-sharding.yang)
   instead of the ZEBRA_BGP_PEER_TASK environment variable. The device z2 is
   started with the PLAIN start step — no env vars — and reads BOTH its shard
   count (shards: 4) and its egress model (peer-task: true) from config.

--- a/bdd/tests/features/bgp_shard_config_knob.feature
+++ b/bdd/tests/features/bgp_shard_config_knob.feature
@@ -1,9 +1,9 @@
 @serial
 @bgp_shard_config_knob
-Feature: BGP RIB sharding configured via the router bgp shards YANG knob
+Feature: BGP RIB sharding configured via the router bgp sharding rib-sharding YANG knob
 
   Validates the C.4 shipping form of RIB sharding: the shard count comes
-  from config (`router bgp shards <1-64>`, zebra-bgp-sharding.yang) instead
+  from config (`router bgp sharding rib-sharding <1-64>`, zebra-bgp-sharding.yang) instead
   of the `ZEBRA_BGP_SHARDS` environment variable. The sharded device z2 is
   started with the PLAIN `start zebra-rs` step — no env var — and gets its
   shard count purely from `shards: 4` in its applied config.

--- a/docs/orphan-report.txt
+++ b/docs/orphan-report.txt
@@ -1,7 +1,7 @@
 == Collapsed orphan report ==
 ORPHAN leaf         /router/bgp/neighbor/enabled
-ORPHAN leaf         /router/bgp/shards
-ORPHAN leaf         /router/bgp/peer-task
+ORPHAN leaf         /router/bgp/sharding/rib-sharding
+ORPHAN leaf         /router/bgp/sharding/peer-sharding
 
 == Bare list/presence-container path unhandled (children handled) ==
   /router/bgp/global  [p-container]
@@ -19,14 +19,14 @@ Handled: 271
 Orphans: 3
 
 Note: these orphans have no config callback but are kept intentionally.
-shards / peer-task are consumed at BGP task spawn by the flattened-config
-text scan in src/config/bgp.rs (configured_shards / configured_peer_task).
-neighbor/enabled is a standard IETF/OpenConfig/FRR idiom (`neighbor X
-enabled true`, present in ~418 test configs); it is accepted and inert (a
-neighbor is enabled by configuring remote-as) and the schema must accept
-it so those configs load. The other 42 handler-less neighbor nodes were
-removed from the BGP YANG (vendored ietf leftovers / duplicates of handled
-zebra knobs).
+sharding/rib-sharding and sharding/peer-sharding are consumed at BGP task
+spawn by the flattened-config text scan in src/config/bgp.rs
+(configured_shards / configured_peer_task). neighbor/enabled is a standard
+IETF/OpenConfig/FRR idiom (`neighbor X enabled true`, present in ~418 test
+configs); it is accepted and inert (a neighbor is enabled by configuring
+remote-as) and the schema must accept it so those configs load. The other
+42 handler-less neighbor nodes were removed from the BGP YANG (vendored
+ietf leftovers / duplicates of handled zebra knobs).
 
 == Handler paths with no schema node (stale/other) ==
   /router/bgp/neighbor/flowspec/validation

--- a/zebra-rs/src/bgp/inst.rs
+++ b/zebra-rs/src/bgp/inst.rs
@@ -479,7 +479,7 @@ fn shard_count_env() -> Option<usize> {
         .and_then(|s| s.parse::<usize>().ok())
 }
 
-/// Pure resolution policy (unit-tested): the YANG `router bgp shards <n>`
+/// Pure resolution policy (unit-tested): the YANG `router bgp sharding rib-sharding <n>`
 /// leaf (C.4) wins over the env var, which wins over the default `1`. The
 /// chosen value is clamped to `1..=64` (so `0` and out-of-range fold to the
 /// nearest valid degree).

--- a/zebra-rs/src/bgp/peer_egress.rs
+++ b/zebra-rs/src/bgp/peer_egress.rs
@@ -44,7 +44,7 @@ fn peer_task_env() -> Option<bool> {
         .map(|v| v == "1" || v.eq_ignore_ascii_case("true"))
 }
 
-/// Pure resolution policy (unit-tested): the YANG `router bgp peer-task` leaf
+/// Pure resolution policy (unit-tested): the YANG `router bgp sharding peer-sharding` leaf
 /// wins over the env var, which wins over the default `false` (update-group
 /// egress, unchanged).
 fn resolve_peer_task(config: Option<bool>, env: Option<bool>) -> bool {

--- a/zebra-rs/src/config/bgp.rs
+++ b/zebra-rs/src/config/bgp.rs
@@ -9,7 +9,7 @@ pub fn spawn_bgp(config: &ConfigManager) {
     // replace the live task and tear down every BGP session + Loc-RIB.
     // Config reaches the running instance via its `cm` subscription.
     if config.protocol_tasks.borrow().contains_key("bgp") {
-        // Already spawned. The shard count (C.4 `router bgp shards <n>`) is
+        // Already spawned. The shard count (`router bgp sharding rib-sharding <n>`) is
         // frozen at spawn — the pool can't be resized without re-hashing the
         // whole RIB — so warn rather than silently diverge if the operator
         // changes it on the live instance.
@@ -17,7 +17,7 @@ pub fn spawn_bgp(config: &ConfigManager) {
             let live = inst::shard_count();
             if requested.clamp(1, 64) != live {
                 tracing::warn!(
-                    "router bgp shards {requested} ignored: the shard count is fixed \
+                    "router bgp sharding rib-sharding {requested} ignored: the shard count is fixed \
                      at {live} for the BGP instance lifetime — clear `router bgp` or \
                      restart the daemon to re-shard"
                 );
@@ -29,7 +29,7 @@ pub fn spawn_bgp(config: &ConfigManager) {
             let live = crate::bgp::peer_egress::peer_egress_task_enabled();
             if requested != live {
                 tracing::warn!(
-                    "router bgp peer-task {requested} ignored: the egress model is \
+                    "router bgp sharding peer-sharding {requested} ignored: the egress model is \
                      fixed for the BGP instance lifetime — clear `router bgp` or \
                      restart the daemon to switch"
                 );
@@ -49,11 +49,13 @@ pub fn spawn_bgp(config: &ConfigManager) {
     let nd_client_tx = config.nd_client_tx.borrow().clone();
     let (rib_client, rib_rx) = config.subscribe_to_rib("bgp");
     let ctx = crate::context::ProtoContext::default_table(rib_client);
-    // C.4: freeze the shard count from the `router bgp shards <n>` leaf (else
-    // `ZEBRA_BGP_SHARDS`, else 1) before `Bgp::new` spawns the pool.
+    // C.4: freeze the shard count from the `router bgp sharding rib-sharding
+    // <n>` leaf (else `ZEBRA_BGP_SHARDS`, else 1) before `Bgp::new` spawns the
+    // pool.
     inst::init_shard_count(configured_shards(config));
-    // Freeze the per-peer egress-task model from the `router bgp peer-task`
-    // leaf (else `ZEBRA_BGP_PEER_TASK`, else off) before any peer establishes.
+    // Freeze the per-peer egress-task model from the `router bgp sharding
+    // peer-sharding` leaf (else `ZEBRA_BGP_PEER_TASK`, else off) before any
+    // peer establishes.
     crate::bgp::peer_egress::init_peer_task(configured_peer_task(config));
     let bgp = inst::Bgp::new(
         ctx,
@@ -87,7 +89,7 @@ pub fn despawn_bgp(config: &ConfigManager) {
     });
 }
 
-/// Read the `router bgp shards <n>` leaf (RIB sharding C.4) from the
+/// Read the `router bgp sharding rib-sharding <n>` leaf (RIB sharding C.4) from the
 /// committed candidate config, if set. Scans the flattened config lines —
 /// the same text `commit_config`'s `proto_in_candidate` reads — rather than
 /// the diff, so the value is visible at spawn regardless of where the
@@ -102,19 +104,19 @@ fn configured_shards(config: &ConfigManager) -> Option<usize> {
 
 /// Pure line-scan (unit-tested): pull the `shards` value out of the
 /// flattened config text. The leaf augments `router bgp` directly, so the
-/// `Config::list` line is `router bgp shards <n>` — the same flattened form
-/// `proto_in_candidate` matches and the `bgp_shards_grammar` parse test
+/// `Config::list` line is `router bgp sharding rib-sharding <n>` — the same
+/// flattened form `proto_in_candidate` matches and the `bgp_shards_grammar` parse test
 /// pins.
 fn shards_from_config_text(text: &str) -> Option<usize> {
     text.lines().find_map(|line| {
-        line.strip_prefix("router bgp shards ")?
+        line.strip_prefix("router bgp sharding rib-sharding ")?
             .trim()
             .parse::<usize>()
             .ok()
     })
 }
 
-/// Read the `router bgp peer-task <bool>` leaf from the committed candidate
+/// Read the `router bgp sharding peer-sharding <bool>` leaf from the committed candidate
 /// config, if set. Same flattened-text scan as [`configured_shards`].
 /// `None` ⇒ the caller falls back to `ZEBRA_BGP_PEER_TASK` / off.
 fn configured_peer_task(config: &ConfigManager) -> Option<bool> {
@@ -124,11 +126,13 @@ fn configured_peer_task(config: &ConfigManager) -> Option<bool> {
 }
 
 /// Pure line-scan (unit-tested): pull the `peer-task` boolean out of the
-/// flattened config text — `router bgp peer-task <true|false>`, the form the
+/// flattened config text — `router bgp sharding peer-sharding <true|false>`, the form the
 /// `bgp_peer_task_grammar` parse test pins.
 fn peer_task_from_config_text(text: &str) -> Option<bool> {
     text.lines().find_map(|line| {
-        let v = line.strip_prefix("router bgp peer-task ")?.trim();
+        let v = line
+            .strip_prefix("router bgp sharding peer-sharding ")?
+            .trim();
         Some(v == "true" || v == "1")
     })
 }
@@ -142,13 +146,13 @@ mod tests {
         // Picked out among other `router bgp` lines.
         assert_eq!(
             shards_from_config_text(
-                "router bgp shards 4\nrouter bgp neighbor 10.0.0.1 remote-as 65000\n"
+                "router bgp sharding rib-sharding 4\nrouter bgp neighbor 10.0.0.1 remote-as 65000\n"
             ),
             Some(4)
         );
         // Order-independent — a preceding unrelated line doesn't hide it.
         assert_eq!(
-            shards_from_config_text("interface eth0\nrouter bgp shards 8\n"),
+            shards_from_config_text("interface eth0\nrouter bgp sharding rib-sharding 8\n"),
             Some(8)
         );
         // Absent ⇒ None (caller falls back to env / default).
@@ -163,17 +167,20 @@ mod tests {
     fn peer_task_line_scan() {
         use super::peer_task_from_config_text;
         assert_eq!(
-            peer_task_from_config_text("router bgp peer-task true\n"),
+            peer_task_from_config_text("router bgp sharding peer-sharding true\n"),
             Some(true)
         );
         // Explicit false is distinguishable from absent (so config can
         // override an env-on).
         assert_eq!(
-            peer_task_from_config_text("router bgp peer-task false\n"),
+            peer_task_from_config_text("router bgp sharding peer-sharding false\n"),
             Some(false)
         );
         // Absent ⇒ None (caller falls back to env / off).
-        assert_eq!(peer_task_from_config_text("router bgp shards 4\n"), None);
+        assert_eq!(
+            peer_task_from_config_text("router bgp sharding rib-sharding 4\n"),
+            None
+        );
         assert_eq!(peer_task_from_config_text(""), None);
     }
 }

--- a/zebra-rs/src/config/manager.rs
+++ b/zebra-rs/src/config/manager.rs
@@ -2268,7 +2268,7 @@ mod yang_load_tests {
         }
     }
 
-    /// C.4 `router bgp shards <1-64>` — the shipping form of the
+    /// C.4 `router bgp sharding rib-sharding <1-64>` — the shipping form of the
     /// `ZEBRA_BGP_SHARDS` env var (`zebra-bgp-sharding.yang`). Pinned
     /// because vtyctl apply is garbage-tolerant — an unwired grammar
     /// silently no-ops, and `configured_shards` reads this leaf at spawn,
@@ -2290,13 +2290,13 @@ mod yang_load_tests {
             .expect("configure module present");
         let entry = to_entry(&yang, module);
 
-        // The shards leaf must be a settable path directly under `router
-        // bgp` across the valid range — this is the exact text
-        // `configured_shards` scans for (`router bgp shards <n>`).
+        // The rib-sharding leaf must be a settable path under `router bgp
+        // sharding` across the valid range — this is the exact text
+        // `configured_shards` scans for (`router bgp sharding rib-sharding <n>`).
         for cmd in [
-            "set router bgp shards 1",
-            "set router bgp shards 4",
-            "set router bgp shards 64",
+            "set router bgp sharding rib-sharding 1",
+            "set router bgp sharding rib-sharding 4",
+            "set router bgp sharding rib-sharding 64",
         ] {
             let (code, _comps, _state) = parse(cmd, entry.clone(), None, State::new());
             assert_eq!(
@@ -2307,9 +2307,9 @@ mod yang_load_tests {
         }
     }
 
-    /// `router bgp peer-task <true|false>` — the per-peer egress-task model
-    /// knob (`zebra-bgp-sharding.yang`), the shipping form of
-    /// `ZEBRA_BGP_PEER_TASK`. Pinned for the same reason as `shards`:
+    /// `router bgp sharding peer-sharding <true|false>` — the per-peer
+    /// egress-task model knob (`zebra-bgp-sharding.yang`), the shipping form
+    /// of `ZEBRA_BGP_PEER_TASK`. Pinned for the same reason as rib-sharding:
     /// `configured_peer_task` reads this leaf at spawn, and a broken path
     /// would silently fall back to the env/default.
     #[test]
@@ -2328,11 +2328,11 @@ mod yang_load_tests {
             .expect("configure module present");
         let entry = to_entry(&yang, module);
 
-        // Both boolean forms must be settable paths directly under `router
-        // bgp` — the exact text `configured_peer_task` scans for.
+        // Both boolean forms must be settable paths under `router bgp
+        // sharding` — the exact text `configured_peer_task` scans for.
         for cmd in [
-            "set router bgp peer-task true",
-            "set router bgp peer-task false",
+            "set router bgp sharding peer-sharding true",
+            "set router bgp sharding peer-sharding false",
         ] {
             let (code, _comps, _state) = parse(cmd, entry.clone(), None, State::new());
             assert_eq!(

--- a/zebra-rs/yang/zebra-bgp-sharding.yang
+++ b/zebra-rs/yang/zebra-bgp-sharding.yang
@@ -45,38 +45,49 @@ module zebra-bgp-sharding {
      Resulting config shape:
 
        router bgp {
-         shards 4;
+         sharding {
+           rib-sharding 4;
+         }
        }";
 
   grouping bgp-sharding-extension {
     description
-      "Sharding degree leaf hung off `router bgp`.";
-    leaf shards {
-      ext:help "Number of parallel RIB shards (1-64, default 1)";
-      type uint8 {
-        range "1..64";
+      "Spawn-time sharding container hung off `router bgp`.";
+    container sharding {
+      ext:help "BGP sharding knobs (read once at instance spawn)";
+      description
+        "Spawn-time BGP sharding knobs. Both leaves are read once when the
+         BGP instance spawns (the first `router bgp` commit) and are
+         immutable thereafter; changing either on a live instance is
+         ignored with a warning.";
+      leaf rib-sharding {
+        ext:help "Number of parallel RIB shards (1-64, default 1)";
+        type uint8 {
+          range "1..64";
+        }
+        description
+          "Number of parallel BGP RIB worker shards. 1 = synchronous
+           single-shard path (default when unset). Read once at instance
+           spawn and immutable thereafter (live resharding is out of scope).
+           No YANG default is declared on purpose: an unset leaf must stay
+           absent so it does not shadow the ZEBRA_BGP_SHARDS fallback.";
       }
-      description
-        "Number of parallel BGP RIB worker shards. 1 = synchronous
-         single-shard path (default when unset). Read once at instance
-         spawn and immutable thereafter (live resharding is out of scope).
-         No YANG default is declared on purpose: an unset leaf must stay
-         absent so it does not shadow the ZEBRA_BGP_SHARDS fallback.";
-    }
-    leaf peer-task {
-      ext:help "Per-peer egress task model (GoBGP-style; default false)";
-      type boolean;
-      description
-        "Egress model for plain IPv4-unicast. false (default) keeps the
-         FRR-style update-group egress on the main task; true runs the
-         GoBGP-style per-peer egress task, spawned per peer at Established.
-         The two models are alternatives, never interleaved, so this is read
-         once at instance spawn and immutable thereafter — changing it on a
-         live instance is ignored with a warning. Supersedes the
-         ZEBRA_BGP_PEER_TASK environment variable (the fallback when unset);
-         no YANG default is declared so an unset leaf stays absent and does
-         not shadow that fallback. Experimental — the update-group model
-         remains the supported default, especially for route reflectors.";
+      leaf peer-sharding {
+        ext:help "Per-peer egress task model (default false)";
+        type boolean;
+        description
+          "Egress model for plain IPv4-unicast. false (default) keeps the
+           FRR-style update-group egress on the main task; true runs the
+           per-peer egress task, spawned per peer at Established. The two
+           models are alternatives, never interleaved, so this is read once
+           at instance spawn and immutable thereafter — changing it on a
+           live instance is ignored with a warning. Supersedes the
+           ZEBRA_BGP_PEER_TASK environment variable (the fallback when
+           unset); no YANG default is declared so an unset leaf stays absent
+           and does not shadow that fallback. Experimental — the
+           update-group model remains the supported default, especially for
+           route reflectors.";
+      }
     }
   }
 
@@ -86,14 +97,14 @@ module zebra-bgp-sharding {
 
   augment "/configure:set/config:router/bgp:bgp" {
     description
-      "Attach the shards leaf in the candidate-set subtree.";
+      "Attach the sharding container in the candidate-set subtree.";
     uses bgp-sharding-extension;
   }
 
   augment "/configure:delete/config:router/bgp:bgp" {
     description
       "Same attachment for the delete subtree so
-       `delete router bgp shards` is path-valid.";
+       `delete router bgp sharding rib-sharding` is path-valid.";
     uses bgp-sharding-extension;
   }
 }


### PR DESCRIPTION
## Summary

Groups the two spawn-time BGP sharding knobs under a new `sharding` container:

| Old path | New path |
|---|---|
| `/router/bgp/shards` | `/router/bgp/sharding/rib-sharding` |
| `/router/bgp/peer-task` | `/router/bgp/sharding/peer-sharding` |

- `zebra-bgp-sharding.yang`: wrap the two leaves in `container sharding` (renamed `rib-sharding` / `peer-sharding`). The container's `ext:help` notes it is read once at instance spawn; `peer-sharding`'s `ext:help` drops the "GoBGP-style" phrasing.
- `config/bgp.rs`: the leaves have no callback — they are read at spawn by the flattened-config text scan, so the "handler path" is the scan prefix. Updated `shards_from_config_text` / `peer_task_from_config_text` to match `router bgp sharding rib-sharding ` / `router bgp sharding peer-sharding `, plus the warnings, doc comments, and unit tests.
- `manager.rs` grammar guards + `inst.rs` / `peer_egress.rs` doc comments updated to the new paths.
- BDD: 4 configs moved to the nested `sharding:` form; feature/doc prose updated (generated allure-results left as-is).
- `orphan-report.txt`: the two orphans renamed to the `sharding/*` paths.

## Test plan

- Full `config::` + `bgp::` tests (784) pass; workspace `clippy -D warnings` clean.
- Live daemon: applies `sharding rib-sharding 4` / `peer-sharding true` and logs `BGP RIB sharding: 4 shards (from config)` — proving the flattened-path spawn scan still fires — while the old `router bgp shards` path is rejected.

Generated with [Claude Code](https://claude.com/claude-code)