### PR TITLE
isis: regenerate DIS pseudonode LSP on LAN membership change

### DIFF
--- a/bdd/tests/configs/isis_lan_pseudonode/a1.yaml
+++ b/bdd/tests/configs/isis_lan_pseudonode/a1.yaml
@@ -1,0 +1,24 @@
+# a1: one of three L2 IS-IS routers sharing broadcast LAN br0 (iface
+# va1ns, IP 192.168.100.1/24 assigned by the topology step). Loopback
+# 10.0.0.1/32 is advertised into IS-IS. Regression: whichever router wins
+# DIS must list all three members in its pseudonode LSP, so every loopback
+# is reachable from every speaker.
+interface:
+- if-name: lo
+  ipv4:
+    address: 10.0.0.1/32
+router:
+  isis:
+    net: 49.0000.0000.0000.0001.00
+    is-type: level-2
+    hostname: a1
+    interface:
+    - if-name: lo
+      circuit-type: level-2
+      ipv4:
+        enabled: true
+    - if-name: va1ns
+      circuit-type: level-2
+      metric: 10
+      ipv4:
+        enabled: true

--- a/bdd/tests/configs/isis_lan_pseudonode/a2.yaml
+++ b/bdd/tests/configs/isis_lan_pseudonode/a2.yaml
@@ -1,0 +1,24 @@
+# a2: one of three L2 IS-IS routers sharing broadcast LAN br0 (iface
+# va2ns, IP 192.168.100.2/24 assigned by the topology step). Loopback
+# 10.0.0.2/32 is advertised into IS-IS. Regression: whichever router wins
+# DIS must list all three members in its pseudonode LSP, so every loopback
+# is reachable from every speaker.
+interface:
+- if-name: lo
+  ipv4:
+    address: 10.0.0.2/32
+router:
+  isis:
+    net: 49.0000.0000.0000.0002.00
+    is-type: level-2
+    hostname: a2
+    interface:
+    - if-name: lo
+      circuit-type: level-2
+      ipv4:
+        enabled: true
+    - if-name: va2ns
+      circuit-type: level-2
+      metric: 10
+      ipv4:
+        enabled: true

--- a/bdd/tests/configs/isis_lan_pseudonode/a3.yaml
+++ b/bdd/tests/configs/isis_lan_pseudonode/a3.yaml
@@ -1,0 +1,24 @@
+# a3: one of three L2 IS-IS routers sharing broadcast LAN br0 (iface
+# va3ns, IP 192.168.100.3/24 assigned by the topology step). Loopback
+# 10.0.0.3/32 is advertised into IS-IS. Regression: whichever router wins
+# DIS must list all three members in its pseudonode LSP, so every loopback
+# is reachable from every speaker.
+interface:
+- if-name: lo
+  ipv4:
+    address: 10.0.0.3/32
+router:
+  isis:
+    net: 49.0000.0000.0000.0003.00
+    is-type: level-2
+    hostname: a3
+    interface:
+    - if-name: lo
+      circuit-type: level-2
+      ipv4:
+        enabled: true
+    - if-name: va3ns
+      circuit-type: level-2
+      metric: 10
+      ipv4:
+        enabled: true

--- a/bdd/tests/features/isis_lan_pseudonode.feature
+++ b/bdd/tests/features/isis_lan_pseudonode.feature
@@ -1,0 +1,48 @@
+@serial
+@isis_lan_pseudonode
+Feature: IS-IS DIS pseudonode LSP lists every LAN member
+
+  Regression for a DIS pseudonode-LSP bug. On a broadcast LAN the
+  Designated IS originates a pseudonode LSP whose TLV 22 must list every
+  Up IS adjacency on the circuit (ISO 10589 §7.3.16). We previously
+  (re)originated it only on a DIS *status* change, so a router that came
+  up after DIS election — while the DIS stayed DIS — was never folded
+  into the pseudonode's IS-reach list and was unreachable in every
+  speaker's SPF.
+
+  Three L2 routers (a1, a2, a3) share one broadcast LAN (br0), with
+  loopbacks 10.0.0.{1,2,3}/32. Whichever wins DIS must list all three in
+  its pseudonode LSP; the decisive assertion is that every router has an
+  IS-IS route to every other loopback — including the last member to
+  converge, which the bug dropped.
+
+  Scenario: every router on the LAN reaches every loopback
+    Given a clean test environment
+    When I create bridge "br0"
+    And I create namespace "a1" with IP "192.168.100.1/24" on bridge "br0"
+    And I create namespace "a2" with IP "192.168.100.2/24" on bridge "br0"
+    And I create namespace "a3" with IP "192.168.100.3/24" on bridge "br0"
+    And I start zebra-rs in namespace "a1"
+    And I start zebra-rs in namespace "a2"
+    And I start zebra-rs in namespace "a3"
+    And I apply config "a1.yaml" to namespace "a1"
+    And I apply config "a2.yaml" to namespace "a2"
+    And I apply config "a3.yaml" to namespace "a3"
+    And I wait 20 seconds
+    Then show command "show isis route" in namespace "a1" should eventually contain "10.0.0.2/32"
+    And show command "show isis route" in namespace "a1" should eventually contain "10.0.0.3/32"
+    And show command "show isis route" in namespace "a2" should eventually contain "10.0.0.1/32"
+    And show command "show isis route" in namespace "a2" should eventually contain "10.0.0.3/32"
+    And show command "show isis route" in namespace "a3" should eventually contain "10.0.0.1/32"
+    And show command "show isis route" in namespace "a3" should eventually contain "10.0.0.2/32"
+
+  Scenario: Teardown topology
+    Given the test topology exists
+    When I stop zebra-rs in namespace "a1"
+    And I stop zebra-rs in namespace "a2"
+    And I stop zebra-rs in namespace "a3"
+    And I delete namespace "a1"
+    And I delete namespace "a2"
+    And I delete namespace "a3"
+    And I delete bridge "br0"
+    Then the test environment should be clean

--- a/zebra-rs/src/isis/ifsm.rs
+++ b/zebra-rs/src/isis/ifsm.rs
@@ -656,15 +656,6 @@ pub fn dis_selection(link: &mut LinkTop, level: Level) {
         // Update link's DIS status to the new one.
         *link.state.dis_status.get_mut(&level) = new_status;
 
-        // If my role is DIS, we originate DIS. dis_becoming has just
-        // registered the pseudonode adjacency on this link, so the
-        // neighbor_id we pass identifies our pseudonode LSP.
-        if new_status == DisStatus::Myself
-            && let Some((neighbor_id, _)) = link.state.adj.get(&level)
-        {
-            link.event(Message::DisOriginate(level, *neighbor_id, None));
-        }
-
         // LSP Originate.
         link.event(Message::LspOriginate(level, None));
 
@@ -678,5 +669,25 @@ pub fn dis_selection(link: &mut LinkTop, level: Level) {
             .dis_stats
             .get_mut(&level)
             .record_change(old_status, new_status, new_sys_id, new_sys_id, reason);
+    }
+
+    // (Re)originate our pseudonode LSP whenever we are the DIS on this
+    // LAN — not only when we *became* DIS. `dis_selection` runs on every
+    // LAN adjacency Up/Down transition (packet.rs Init<->Up, nfsm hold
+    // expiry), so a router that joins or leaves while we stay DIS reaches
+    // this point with old_status == new_status == Myself and the block
+    // above is skipped. Without re-originating here that member is never
+    // folded into (ISO 10589 §7.3.16) — or out of — the pseudonode LSP's
+    // TLV 22 IS-reach list, so it is unreachable in every speaker's SPF.
+    // `process_dis_originate` is idempotent on the member set (it only
+    // bumps the sequence when the set actually changed), so firing this on
+    // every transition does not churn the LSP. `dis_becoming` registered
+    // the pseudonode adjacency when we first became DIS, so the
+    // neighbor_id is present. Mirrors FRR lsp_regenerate_schedule_pseudo()
+    // on adjacency state change (isis_adjacency.c).
+    if new_status == DisStatus::Myself
+        && let Some((neighbor_id, _)) = link.state.adj.get(&level)
+    {
+        link.event(Message::DisOriginate(level, *neighbor_id, None));
     }
 }

--- a/zebra-rs/src/isis/inst.rs
+++ b/zebra-rs/src/isis/inst.rs
@@ -2521,6 +2521,49 @@ impl Isis {
             return;
         }
 
+        // Idempotency (ISO 10589 §7.3.16 / minimumLSPGenerationInterval
+        // intent): only re-originate when the pseudonode's IS-reach
+        // member set actually changed. `dis_selection` fires DisOriginate
+        // on every LAN adjacency transition, and the §7.3.16.4 reflection
+        // path re-fires it when a peer echoes a higher seq — without this
+        // guard each trigger would bump the sequence and re-flood, and the
+        // reflected bump would loop the sequence unbounded. A pseudonode
+        // LSP carries only ExtIsReach (TLV 22), so comparing the
+        // neighbor-id set is exact and ignores auth/other TLVs. `base =
+        // Some` means we must reclaim ownership above a reflected seq, so
+        // originate regardless.
+        if base.is_none() {
+            let members = |lsp: &IsisLsp| -> std::collections::BTreeSet<IsisNeighborId> {
+                lsp.tlvs
+                    .iter()
+                    .filter_map(|t| match t {
+                        IsisTlv::ExtIsReach(r) => Some(r.entries.iter().map(|e| e.neighbor_id)),
+                        _ => None,
+                    })
+                    .flatten()
+                    .collect()
+            };
+            let new_members: std::collections::BTreeSet<IsisNeighborId> =
+                fragments.iter().flat_map(&members).collect();
+            let self_sys = top.config.net.sys_id();
+            let pseudo_id = neighbor_id.pseudo_id();
+            let cur_members: std::collections::BTreeSet<IsisNeighborId> = top
+                .lsdb
+                .get(&level)
+                .iter()
+                .filter(|(id, lsa)| {
+                    lsa.originated
+                        && id.sys_id() == self_sys
+                        && id.pseudo_id() == pseudo_id
+                        && id.is_pseudo()
+                })
+                .flat_map(|(_, lsa)| members(&lsa.lsp))
+                .collect();
+            if !cur_members.is_empty() && new_members == cur_members {
+                return;
+            }
+        }
+
         let max_frag = fragments
             .iter()
             .map(|l| l.lsp_id.fragment_id())


### PR DESCRIPTION
## Summary

On a broadcast LAN the DIS advertises a pseudonode LSP whose TLV 22 must list every Up IS adjacency on the circuit (ISO 10589 §7.3.16). We only (re)originated it on a DIS **status** change (`dis_selection`'s `old_status != new_status` block). So a router that came up *after* DIS election — while we stayed DIS (`Myself → Myself`) — was never folded into the pseudonode's IS-reach list, and was therefore **unreachable in every speaker's SPF**.

### Fix (2 parts)
1. **`ifsm.rs dis_selection`** — emit `DisOriginate` whenever we are the DIS on this run, not only when the status changed. `dis_selection` already runs on every LAN adjacency Up/Down transition (packet.rs `Init<->Up`, nfsm hold expiry), so this folds a joining/leaving member into (or out of) the pseudonode LSP. Mirrors FRR's `lsp_regenerate_schedule_pseudo()` on adjacency state change.
2. **`inst.rs process_dis_originate`** — make pseudonode origination **idempotent**: skip re-origination when the IS-reach member set is unchanged (unless a §7.3.16.4 reflected-seq reclaim is pending, i.e. `base` is `Some`). Without this, firing (1) on every transition — plus the reflect-back bump — churned the sequence number unbounded. This realises the ISO 10589 `minimumLSPGenerationInterval` intent: the seq advances exactly once per real membership change.

## Test plan

- **Live 3-router broadcast LAN** (netns + bridge): the DIS's pseudonode LSP lists all three members; every speaker routes to every loopback; a member leaving is dropped with a single seq bump; seq is otherwise stable (no churn). The pre-fix binary left the 3rd router unreachable with the pseudonode LSP stuck at seq 1 / two members.
- **New BDD regression test** `isis_lan_pseudonode` (3 L2 routers on one bridge; asserts every speaker routes to every loopback incl. the last to converge) — passes with the fix.
- 175 isis unit tests pass; `cargo clippy` clean.

Generated with [Claude Code](https://claude.com/claude-code)