### PR TITLE
isis: converge LAN DIS re-election on priority change

### DIFF
--- a/bdd/Makefile
+++ b/bdd/Makefile
@@ -139,6 +139,10 @@ isis:
 	mkdir -p allure-results
 	cargo test --test cucumber -- --concurrency=20 --tags "@isis"
 
+isis_lan_dis_reelection:
+	mkdir -p allure-results
+	cargo test --test cucumber -- --concurrency=1 --tags "@isis_lan_dis_reelection"
+
 # Run all BFD tests.
 bfd:
 	rm -rf allure-results

--- a/bdd/tests/configs/isis_lan_dis_reelection/a1-pri.yaml
+++ b/bdd/tests/configs/isis_lan_dis_reelection/a1-pri.yaml
@@ -1,0 +1,26 @@
+# a1 with LAN priority raised to 200 (above a3's 100), applied to the
+# running a1 daemon mid-scenario so a1 takes the DIS over from a3. This is
+# the trigger for the DIS re-election: a1 goes Other -> Myself, a3 goes
+# Myself -> Other (and purges its pseudonode), and the non-DIS bystander
+# a2 goes Other -> Other, re-pointing its pseudonode adjacency from a3 to
+# a1. Only the va1ns priority differs from a1.yaml.
+interface:
+- if-name: lo
+  ipv4:
+    address: 10.0.0.1/32
+router:
+  isis:
+    net: 49.0000.0000.0000.0001.00
+    is-type: level-2
+    hostname: a1
+    interface:
+    - if-name: lo
+      circuit-type: level-2
+      ipv4:
+        enabled: true
+    - if-name: va1ns
+      circuit-type: level-2
+      metric: 10
+      priority: 200
+      ipv4:
+        enabled: true

--- a/bdd/tests/configs/isis_lan_dis_reelection/a1.yaml
+++ b/bdd/tests/configs/isis_lan_dis_reelection/a1.yaml
@@ -1,0 +1,23 @@
+# a1: L2 IS-IS router on broadcast LAN br0 (iface va1ns, IP
+# 192.168.100.1/24 assigned by the topology step). Loopback 10.0.0.1/32.
+# Starts at the default LAN priority so a3 (priority 100) wins DIS;
+# a1-pri.yaml later raises a1 to 200 to take the DIS over.
+interface:
+- if-name: lo
+  ipv4:
+    address: 10.0.0.1/32
+router:
+  isis:
+    net: 49.0000.0000.0000.0001.00
+    is-type: level-2
+    hostname: a1
+    interface:
+    - if-name: lo
+      circuit-type: level-2
+      ipv4:
+        enabled: true
+    - if-name: va1ns
+      circuit-type: level-2
+      metric: 10
+      ipv4:
+        enabled: true

--- a/bdd/tests/configs/isis_lan_dis_reelection/a2.yaml
+++ b/bdd/tests/configs/isis_lan_dis_reelection/a2.yaml
@@ -1,0 +1,24 @@
+# a2: L2 IS-IS router on broadcast LAN br0 (iface va2ns, IP
+# 192.168.100.2/24 assigned by the topology step). Loopback 10.0.0.2/32.
+# Default LAN priority. a2 is the non-DIS bystander that switches its
+# elected DIS from a3 to a1 (DisStatus Other -> Other) when a1's priority
+# is raised — the transition the regression targets.
+interface:
+- if-name: lo
+  ipv4:
+    address: 10.0.0.2/32
+router:
+  isis:
+    net: 49.0000.0000.0000.0002.00
+    is-type: level-2
+    hostname: a2
+    interface:
+    - if-name: lo
+      circuit-type: level-2
+      ipv4:
+        enabled: true
+    - if-name: va2ns
+      circuit-type: level-2
+      metric: 10
+      ipv4:
+        enabled: true

--- a/bdd/tests/configs/isis_lan_dis_reelection/a3.yaml
+++ b/bdd/tests/configs/isis_lan_dis_reelection/a3.yaml
@@ -1,0 +1,25 @@
+# a3: L2 IS-IS router on broadcast LAN br0 (iface va3ns, IP
+# 192.168.100.3/24 assigned by the topology step). Loopback 10.0.0.3/32.
+# LAN priority 100 makes a3 the initial DIS deterministically (a1/a2 sit
+# at the default 64). When a1 is later raised to 200, a3 resigns
+# (DisStatus Myself -> Other) and must purge its pseudonode LSP cleanly.
+interface:
+- if-name: lo
+  ipv4:
+    address: 10.0.0.3/32
+router:
+  isis:
+    net: 49.0000.0000.0000.0003.00
+    is-type: level-2
+    hostname: a3
+    interface:
+    - if-name: lo
+      circuit-type: level-2
+      ipv4:
+        enabled: true
+    - if-name: va3ns
+      circuit-type: level-2
+      metric: 10
+      priority: 100
+      ipv4:
+        enabled: true

--- a/bdd/tests/features/isis_lan_dis_reelection.feature
+++ b/bdd/tests/features/isis_lan_dis_reelection.feature
@@ -1,0 +1,69 @@
+@serial
+@isis_lan_dis_reelection
+Feature: IS-IS LAN DIS re-election converges when priority changes
+
+  Regression for a DIS-election convergence bug on a broadcast LAN.
+
+  Three L2 routers (a1, a2, a3) share one LAN (br0), loopbacks
+  10.0.0.{1,2,3}/32. a3 starts as DIS (LAN priority 100; a1/a2 at the
+  default 64). Raising a1's LAN priority to 200 must move the DIS to a1 on
+  *every* speaker while full loopback reachability is preserved.
+
+  The bug: a non-DIS bystander (a2) that switched its elected DIS from a3
+  to a1 while staying a non-DIS member (DisStatus Other -> Other) never
+  re-registered its pseudonode adjacency — the adjacency update was gated
+  on a DIS *status* change, and Other -> Other is not one. a2 kept
+  pointing at a3's old pseudonode LSP, which the resigning DIS a3 had
+  purged, so a2's SPF routed through a pseudonode that no longer existed
+  and it lost the route to a1's loopback. The decisive assertions are
+  that after the DIS moves, a2's interface adjacency points at a1's
+  pseudonode (0000.0000.0001.*) and a2 still reaches 10.0.0.1/32.
+
+  Scenario: raising a non-DIS router's priority moves the DIS and the LAN stays reachable
+    Given a clean test environment
+    When I create bridge "br0"
+    And I create namespace "a1" with IP "192.168.100.1/24" on bridge "br0"
+    And I create namespace "a2" with IP "192.168.100.2/24" on bridge "br0"
+    And I create namespace "a3" with IP "192.168.100.3/24" on bridge "br0"
+    And I start zebra-rs in namespace "a1"
+    And I start zebra-rs in namespace "a2"
+    And I start zebra-rs in namespace "a3"
+    And I apply config "a1.yaml" to namespace "a1"
+    And I apply config "a2.yaml" to namespace "a2"
+    And I apply config "a3.yaml" to namespace "a3"
+    And I wait 20 seconds
+    # Baseline: a3 (priority 100) is DIS, so the bystander a2 points its
+    # pseudonode adjacency at a3, and every loopback is reachable.
+    Then show command "show isis interface" in namespace "a2" should eventually contain "0000.0000.0003."
+    And show command "show isis route" in namespace "a1" should eventually contain "10.0.0.2/32"
+    And show command "show isis route" in namespace "a1" should eventually contain "10.0.0.3/32"
+    And show command "show isis route" in namespace "a2" should eventually contain "10.0.0.1/32"
+    And show command "show isis route" in namespace "a2" should eventually contain "10.0.0.3/32"
+    And show command "show isis route" in namespace "a3" should eventually contain "10.0.0.1/32"
+    And show command "show isis route" in namespace "a3" should eventually contain "10.0.0.2/32"
+    # Raise a1's priority above a3 so a1 takes over as DIS.
+    When I apply config "a1-pri.yaml" to namespace "a1"
+    And I wait 15 seconds
+    # a2 must now point its adjacency at a1's pseudonode (Other -> Other
+    # switch) — the bug left it stuck on 0000.0000.0003.* here.
+    Then show command "show isis interface" in namespace "a2" should eventually contain "0000.0000.0001."
+    And show command "show isis interface" in namespace "a3" should eventually contain "0000.0000.0001."
+    # ... and every router STILL reaches every loopback. a2's route to
+    # a1's loopback (10.0.0.1/32) is the one the Other -> Other bug dropped.
+    And show command "show isis route" in namespace "a1" should eventually contain "10.0.0.2/32"
+    And show command "show isis route" in namespace "a1" should eventually contain "10.0.0.3/32"
+    And show command "show isis route" in namespace "a2" should eventually contain "10.0.0.1/32"
+    And show command "show isis route" in namespace "a2" should eventually contain "10.0.0.3/32"
+    And show command "show isis route" in namespace "a3" should eventually contain "10.0.0.1/32"
+    And show command "show isis route" in namespace "a3" should eventually contain "10.0.0.2/32"
+
+  Scenario: Teardown topology
+    Given the test topology exists
+    When I stop zebra-rs in namespace "a1"
+    And I stop zebra-rs in namespace "a2"
+    And I stop zebra-rs in namespace "a3"
+    And I delete namespace "a1"
+    And I delete namespace "a2"
+    And I delete namespace "a3"
+    And I delete bridge "br0"
+    Then the test environment should be clean

--- a/zebra-rs/src/isis/ifsm.rs
+++ b/zebra-rs/src/isis/ifsm.rs
@@ -482,6 +482,37 @@ pub fn csnp_timer(link: &LinkTop, level: Level) -> Timer {
 }
 
 // DIS Selection
+/// Debounce interval for a LAN DIS (re)election, in milliseconds.
+/// Election triggers that arrive within this window coalesce into one
+/// run — long enough to let a burst of hellos (each carrying a peer's
+/// priority / SNPA / LAN-ID) settle, short enough that convergence is
+/// not visibly delayed.
+const DIS_ELECT_DEBOUNCE_MS: u64 = 100;
+
+/// Schedule a debounced LAN DIS (re)election on this circuit and level.
+///
+/// Running `dis_selection` synchronously at every trigger (each hello,
+/// each adjacency change) elected from inconsistent, mid-update snapshots
+/// and could split-brain / flap the DIS. Instead every trigger arms this
+/// single coalescing timer: the first arms it, later ones fold in while
+/// it is pending, and when it fires exactly one election runs against the
+/// settled neighbour state. Mirrors FRR's scheduled `isis_run_dr`
+/// (`run_dr_elect` flag + `t_run_dr` timer, isis_dr.c). The timer slot is
+/// cleared in the `DisSelection` handler so the next trigger re-arms it.
+pub fn dis_schedule(link: &mut LinkTop, level: Level) {
+    if link.timer.dis.get(&level).is_some() {
+        return;
+    }
+    let tx = link.tx.clone();
+    let ifindex = link.ifindex;
+    *link.timer.dis.get_mut(&level) = Some(Timer::once_ms(DIS_ELECT_DEBOUNCE_MS, move || {
+        let tx = tx.clone();
+        async move {
+            let _ = tx.send(Message::Ifsm(IfsmEvent::DisSelection, ifindex, Some(level)));
+        }
+    }));
+}
+
 pub fn dis_selection(link: &mut LinkTop, level: Level) {
     // 8.4.5 LAN designated intermediate systems
     //
@@ -563,9 +594,10 @@ pub fn dis_selection(link: &mut LinkTop, level: Level) {
         // csnp_recv guards on adj.is_some()), the self LSP would miss
         // its pseudonode reach entry, and `show isis interface` would
         // report an inconsistent DIS without a binding. Election
-        // outcome is recorded (`nbr.is_dis = true`); the late-LAN-ID
-        // path in hello_recv re-fires DisSelection once lan_id arrives,
-        // and that run will complete the transition cleanly.
+        // outcome is recorded (`nbr.is_dis = true`); the next hello from
+        // this DIS carries a non-empty LAN-ID, which hello_recv detects
+        // as a changed DIS input and schedules a re-election for — and
+        // that run completes the transition cleanly.
         if nbr.lan_id.is_empty() {
             if link.tracing.should_trace_fsm() {
                 tracing::info!(
@@ -604,8 +636,22 @@ pub fn dis_selection(link: &mut LinkTop, level: Level) {
         );
     }
 
-    // Perform DIS change when status or sys_id has been changed.
-    if old_status != new_status {
+    // A change of the *elected DIS* while our status stays Other (a
+    // higher-priority IS joined or a peer raised its priority, so the LAN
+    // switches from DIS X to DIS Y — both leaving us a non-DIS member).
+    // Status is unchanged (Other -> Other), but the pseudonode we point at
+    // moved: the currently registered adjacency LAN-ID no longer matches
+    // the newly elected DIS's. Without treating this as a change, the block
+    // below is skipped and we keep a dangling adjacency to the old DIS's
+    // pseudonode — which that ex-DIS has since purged — so SPF routes
+    // through a pseudonode that no longer exists and the LAN splits.
+    let dis_identity_changed = match (link.state.adj.get(&level), &lan_id) {
+        (Some((cur_lan_id, _)), Some(new_lan_id)) => cur_lan_id != new_lan_id,
+        _ => false,
+    };
+
+    // Perform DIS change when status or the elected DIS identity changed.
+    if old_status != new_status || dis_identity_changed {
         match old_status {
             DisStatus::NotSelected => {
                 // Nothing to do.

--- a/zebra-rs/src/isis/inst.rs
+++ b/zebra-rs/src/isis/inst.rs
@@ -2636,11 +2636,25 @@ impl Isis {
             },
             IfsmEvent::DisSelection => match level {
                 Some(level) => {
+                    // Consume the debounce slot so the next trigger re-arms
+                    // it (a trigger that lands while we are running here
+                    // then schedules a fresh follow-up election).
+                    *top.timer.dis.get_mut(&level) = None;
                     ifsm::dis_selection(&mut top, level);
                 }
                 None => {
-                    // ifsm::dis_selection(&mut top, Level::L1);
-                    // ifsm::dis_selection(&mut top, Level::L2);
+                    // Level-agnostic re-election (e.g. a `priority` config
+                    // change on the interface, which fires DisSelection
+                    // with no level): run both levels. `dis_selection` is a
+                    // no-op for a level with no Up neighbours, so this is
+                    // safe on a link that only runs one level. Without this
+                    // the priority change was silently dropped and the DIS
+                    // never re-elected — a higher-priority router could not
+                    // take over an already-elected LAN (ISO 10589 §8.4.5).
+                    for lvl in [Level::L1, Level::L2] {
+                        *top.timer.dis.get_mut(&lvl) = None;
+                        ifsm::dis_selection(&mut top, lvl);
+                    }
                 }
             },
         }

--- a/zebra-rs/src/isis/link.rs
+++ b/zebra-rs/src/isis/link.rs
@@ -41,6 +41,11 @@ use crate::spf::label_pool::LabelPool;
 pub struct LinkTimer {
     pub hello: Levels<Option<Timer>>,
     pub csnp: Levels<Option<Timer>>,
+    /// Debounce timer for LAN DIS (re)election. Coalesces the election
+    /// triggers (adjacency up/down, a neighbour's priority/SNPA/LAN-ID
+    /// change) that arrive close together into a single run against the
+    /// settled neighbour state — see `ifsm::dis_schedule`.
+    pub dis: Levels<Option<Timer>>,
 }
 
 #[derive(Default, Debug)]

--- a/zebra-rs/src/isis/lsdb.rs
+++ b/zebra-rs/src/isis/lsdb.rs
@@ -743,6 +743,19 @@ pub fn refresh_lsp(top: &mut IsisTop, level: Level, key: IsisLspId) {
         return;
     }
     if let Some(lsa) = top.lsdb.get(&level).get(&key) {
+        // Never refresh a purge (Remaining Lifetime == 0). A purge is
+        // meant to die — its ZeroAgeLifetime `hold_timer` evicts it —
+        // but `insert_self_originate` arms a ~1s refresh timer for any
+        // entry whose remaining lifetime is below the refresh threshold,
+        // a purge included. Without this guard the refresh clones the
+        // purge into a live LSP at seq+1 every second, un-purging it and
+        // climbing the sequence unbounded. The `has_level` guard above
+        // only catches an is-type demotion; a DIS that *resigns* purges
+        // its pseudonode LSP while staying in the level, so it slips past
+        // that guard and needs this one. Covers any self-purge.
+        if lsa.lsp.hold_time == 0 {
+            return;
+        }
         let mut lsp = lsp_clone_with_seqno_inc(&lsa.lsp);
         let auth_cfg = crate::isis::lsp::level_auth_cfg(top.config, level).clone();
         let resolved =

--- a/zebra-rs/src/isis/packet.rs
+++ b/zebra-rs/src/isis/packet.rs
@@ -116,7 +116,7 @@ fn stamp_nfsm_dispatch(link: &super::link::LinkTop<'_>, was_up: bool, state: Nfs
 
 use super::Level;
 use super::flood;
-use super::ifsm::has_level;
+use super::ifsm::{dis_schedule, has_level};
 use super::link::{LinkTop, NetworkType};
 use super::lsdb;
 use super::lsp::{Packet, PacketMessage};
@@ -405,11 +405,22 @@ pub fn hello_recv(link: &mut LinkTop, level: Level, pdu: IsisHello, mac: Option<
     //    areaAddressesOfNeighbour according to the values in the PDU., and
     // c) set the neighbourSNPAAddress according to the MAC source address of
     //    the PDU.
+    // Capture the DIS-election inputs (priority, SNPA, LAN-ID) before
+    // overwriting them, so we can schedule a (debounced) re-election below
+    // whenever any of them changes while the adjacency stays Up: a peer
+    // raising/lowering its priority, and — importantly — the elected DIS
+    // first publishing its LAN-ID, which is what resolves a deferred
+    // Other transition and lets a DIS switch complete.
+    let old_priority = nbr.priority;
+    let old_mac = nbr.mac;
+    let old_lan_id = nbr.lan_id;
     nbr.circuit_type = pdu.circuit_type;
     nbr.hold_time = pdu.hold_time;
     nbr.priority = pdu.priority;
     nbr.lan_id = pdu.lan_id;
     nbr.mac = mac;
+    let dis_input_changed =
+        nbr.priority != old_priority || nbr.mac != old_mac || nbr.lan_id != old_lan_id;
 
     // Interpret TLVs first so the Restart TLV — if present — has fed
     // helper-mode state before we decide whether to refresh the hold
@@ -499,7 +510,6 @@ pub fn hello_recv(link: &mut LinkTop, level: Level, pdu: IsisHello, mac: Option<
             }
             // XXX Adjacency(Up)
             nbr.event(Message::Ifsm(HelloOriginate, nbr.ifindex, Some(level)));
-            nbr.event(Message::Ifsm(DisSelection, nbr.ifindex, Some(level)));
             // Drive exit-success when every checkpointed peer has
             // come back to Up. No-op outside a loaded-checkpoint
             // restart.
@@ -520,26 +530,7 @@ pub fn hello_recv(link: &mut LinkTop, level: Level, pdu: IsisHello, mac: Option<
             }
             // XXX Adjacency(Down)
             nbr.event(Message::Ifsm(HelloOriginate, nbr.ifindex, Some(level)));
-            nbr.event(Message::Ifsm(DisSelection, nbr.ifindex, Some(level)));
         }
-    }
-
-    // Late-LAN-ID arrival: dis_selection deferred the
-    // DisStatus::Other transition because the elected DIS hadn't
-    // published a LAN ID yet. Now that this Hello carries one and we
-    // still have no pseudonode adjacency on this link, re-fire DIS
-    // selection — this time `nbr.lan_id` is non-empty, so the
-    // election will transition to Other and register the adjacency
-    // through the normal path (no inline state mutation here).
-    if nbr.is_dis() && !nbr.lan_id.is_empty() && link.state.adj.get(&level).is_none() {
-        if link.tracing.should_trace_fsm() {
-            tracing::info!(
-                "[NBR] Late LAN ID {} from elected DIS {} - re-running DIS selection",
-                nbr.lan_id,
-                nbr.sys_id
-            );
-        }
-        nbr.event(Message::Ifsm(DisSelection, nbr.ifindex, Some(level)));
     }
 
     // When neighbor state has been changed.
@@ -565,6 +556,21 @@ pub fn hello_recv(link: &mut LinkTop, level: Level, pdu: IsisHello, mac: Option<
     if was_up && state != NfsmState::Up {
         let _ = link.tx.send(Message::LspOriginate(level, None));
         spf_schedule(link, level);
+    }
+
+    // Schedule a debounced DIS (re)election whenever this Hello could have
+    // changed the election outcome: an adjacency Up/Down transition changes
+    // the member set, and a priority/SNPA/LAN-ID change on an Up neighbour
+    // changes who wins (ISO 10589 §8.4.5 elects by priority then SNPA).
+    // `dis_schedule` coalesces the burst of Hellos a topology change
+    // produces into one election run against the settled neighbour table
+    // (100ms debounce), mirroring FRR's debounced DR election (isis_dr.c).
+    // Running the election synchronously on every trigger caused
+    // split-brain flapping: speakers re-elected against half-updated
+    // neighbour state and never agreed on a single DIS.
+    let now_up = state == NfsmState::Up;
+    if (was_up != now_up) || (now_up && dis_input_changed) {
+        dis_schedule(link, level);
     }
 
     // RFC 5882 §5 BFD attachment, post-FSM. nbr has been dropped so


### PR DESCRIPTION
## Summary

On a broadcast LAN, the DIS was elected synchronously on every trigger (each hello, each adjacency change) from mid-update neighbour snapshots. When a peer raised its LAN priority the LAN could split-brain — no single node settled as DIS and a bystander could lose reachability. Three defects, fixed together:

1. **Debounced election.** `dis_schedule` arms one coalescing per-circuit timer (100 ms); the burst of hellos a topology change produces folds into a single election against the settled neighbour table (mirrors FRR's scheduled DR election, `isis_dr.c`). The synchronous `DisSelection` fires in `hello_recv` are replaced by this schedule.

2. **`Other → Other` adjacency switch.** When the elected DIS changed identity while our status stayed `Other` (peer X was DIS, now peer Y is — both leaving us a non-DIS member), the adjacency-update block was skipped because it was gated on a DIS *status* change. The bystander kept a dangling pseudonode adjacency to the ex-DIS, which that node had since purged, so SPF routed through a pseudonode that no longer existed and the LAN split. The block now also runs when the elected DIS's LAN-ID changed.

3. **Purge no longer un-purges.** A resigning DIS purges its pseudonode LSP, but `insert_self_originate` arms a ~1 s refresh timer for any entry below the refresh threshold — a purge included — and `refresh_lsp` cloned it into a live LSP at `seq+1` every second, climbing the sequence unbounded. The existing guard only caught an is-type demotion; a DIS that resigns stays in the level. `refresh_lsp` now skips any purge (Remaining Lifetime == 0), leaving the ZeroAgeLifetime hold timer to evict it.

## Test plan

- **Live 3-node LAN** (netns + bridge): raising a non-DIS node's priority moves the DIS on every speaker with full reachability preserved; the old pseudonode purges cleanly (stable seq, then evicted after ~60 s). Verified twice (a3→a1 and a1→a2 takeovers). Final LSDB holds exactly the expected LSPs with no seq churn.
- **New BDD regression** `@isis_lan_dis_reelection`: a3 starts DIS (priority 100); raising a1 to 200 must re-point the bystander a2's adjacency at a1's pseudonode (`0000.0000.0001.*`) and keep a2's route to `10.0.0.1/32`. **Confirmed it fails without fix #2** and passes with it.
- Existing `@isis_lan_pseudonode` BDD still passes.
- `cargo test --workspace --exclude bdd` — all green. `cargo clippy --workspace --all-targets -- -D warnings` — clean. `cargo fmt --all`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)