### PR TITLE
bdd: sweep stale shared startup config in clean-env step

### DIFF
--- a/bdd/src/netns.rs
+++ b/bdd/src/netns.rs
@@ -29,6 +29,30 @@ async fn run_cmd(args: &[&str], error_msg: &str) -> Result<()> {
     }
 }
 
+/// Remove the shared daemon startup config, best effort.
+///
+/// A BDD daemon is launched without `--config-file`, so it falls back to
+/// loading `<yang-path>/../zebra-rs.conf` at startup — and under `sudo ip
+/// netns exec` (HOME=/root) the yang path resolves to `/etc/zebra-rs/yang`,
+/// so that file is `/etc/zebra-rs/zebra-rs.conf`. This path is host-global
+/// and shared by every namespace's daemon. A stale copy left there (e.g. a
+/// manual `save`, or a hand-run debug session) is loaded by EVERY BDD daemon
+/// before the feature applies its own config — and because `vtyctl apply`
+/// is a diff, any element that overlaps the leftover (a neighbor address, a
+/// VRF, an `interface lo` address, a global `as`) keeps the leftover's stale
+/// attributes, silently breaking dozens of unrelated features. BDD daemons
+/// must always start from an empty config, so sweep it here like the host
+/// loopback addresses above — it is only ever a leftover, never anything a
+/// live feature needs.
+pub async fn remove_stale_startup_config() {
+    let _ = Command::new("sudo")
+        .args(["rm", "-f", "/etc/zebra-rs/zebra-rs.conf"])
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .status()
+        .await;
+}
+
 /// Execute a command in a network namespace
 pub async fn exec_in_netns(netns: &str, cmd: &str, args: &[&str]) -> Result<String> {
     let output = Command::new("sudo")

--- a/bdd/tests/cucumber.rs
+++ b/bdd/tests/cucumber.rs
@@ -125,6 +125,13 @@ async fn clean_test_environment(world: &mut World) {
     // loopback-peered sessions (see `sweep_host_loopback_addrs`).
     let _ = netns::sweep_host_loopback_addrs().await;
 
+    // 6. Remove the shared daemon startup config. BDD daemons launch without
+    // `--config-file` and would otherwise load `/etc/zebra-rs/zebra-rs.conf`
+    // at startup; a stale copy (from a manual `save` or a debug session)
+    // poisons every namespace's daemon before its feature config is applied.
+    // See `netns::remove_stale_startup_config` for the full mechanism.
+    netns::remove_stale_startup_config().await;
+
     println!(
         "✓ Test environment cleaned for feature {}",
         world.feature_tag


### PR DESCRIPTION
## Summary

A full BDD run surfaced **54/203 features failing** — deterministically, even at `--concurrency=1`. The root cause was a leftover **`/etc/zebra-rs/zebra-rs.conf`** (from a manual/debug session) that every BDD daemon loads at startup.

BDD daemons launch **without `--config-file`**, so they fall back to `<yang>/../zebra-rs.conf`; under `sudo ip netns exec` (HOME=/root) that resolves to the host-global `/etc/zebra-rs/zebra-rs.conf`, shared by every namespace's daemon. Because `vtyctl apply -f` is a **diff** against the loaded running-config, any element overlapping the leftover kept its stale attributes:
- a shared `neighbor 2001:db8::2` inherited the leftover's global `as 65501` → daemon emitted OPEN with the wrong AS → peer rejected it (Bad Peer AS) → session wedged Idle.
- leaked `vrf N3/N6` (e.g. `bgp_vrf_show` expected "(no VRFs configured)").
- leaked `interface lo` addrs + IS-IS `level-2-only` + SRv6 locator (e.g. `isis_l1l2` saw an unexpected L2 database; OSPF/IS-IS ping failures).

## Fix

Add `netns::remove_stale_startup_config()` (best-effort `sudo rm -f /etc/zebra-rs/zebra-rs.conf`) and call it as step 6 of `Given a clean test environment`, mirroring the existing host-loopback-address sweep, so BDD daemons always start from an empty config. This is a test-harness change only — no product code is touched.

## Test plan

- Removed the stale file and re-ran the full suite: **203/203 pass, 0 failed** (was 149/203).
- 6-feature isolation probe (one per failure category): **6/6 pass** (was 0/6).
- `cargo fmt --check` clean; `cargo clippy -p bdd --all-targets` clean.
- Binary md5 stable before/after the run (no stomp); no leaked daemons/namespaces after teardown.

Generated with [Claude Code](https://claude.com/claude-code)