### PR TITLE
bgp: FRR-compatible AS-path regex + set ext/large-community

### DIFF
--- a/bdd/docs/bgp_as_path_match.md
+++ b/bdd/docs/bgp_as_path_match.md
@@ -1,0 +1,64 @@
+# BGP match as-path-set with FRR-compatible regular expressions
+
+## Overview
+
+As a network operator
+I want zebra-rs `match as-path` to accept the same AS-path regular
+expressions as FRR's `bgp as-path access-list`, so that policies port
+between the two routers unchanged.
+
+The AS-path regex engine mirrors FRR's `bgp_regcomp`
+(bgpd/bgp_regex.c): the `_` magic character expands to
+`(^|[,{}() ]|$)`, matching a separator, the start, or the end of the
+path. Regexes run against the AS_PATH rendered exactly like FRR's
+`aspath->str` (space-separated ASNs; AS_SET members comma-separated).
+This feature exercises exact anchored matching plus the three classic
+`_` idioms — neighbor-is (`^ASN_`), originates-from (`_ASN$`), and
+transits (`_ASN_`).
+
+Re-evaluation rides the policy-change trigger (PolicyRx -> soft-in):
+applying a config whose as-path-set/policy changed re-runs the inbound
+policy over the Adj-RIB-In — no `clear` needed.
+
+## Test Topology
+
+Linear eBGP chain, all three routers on one L2 segment. z1 and z3 are
+never peered, so z1's prefixes reach z3 only via the transit AS z2 and
+arrive with AS_PATH `65002 65001`.
+
+```
+  ┌──────────────────────────────────────────────────┐
+  │                        br0                        │
+  └───────┬───────────────┬───────────────┬───────────┘
+          │               │               │
+     ┌────┴────┐     ┌────┴────┐     ┌────┴────┐
+     │   z1    │────▶│   z2    │────▶│   z3    │
+     │ AS65001 │     │ AS65002 │     │ AS65003 │
+     │ .0.1/24 │     │ .0.2/24 │     │ .0.3/24 │
+     └─────────┘     └─────────┘     └─────────┘
+```
+
+## Config Files
+
+- z1.yaml: AS 65001, advertises 10.0.0.1/32 + 10.0.0.2/32 to z2.
+- z2.yaml: AS 65002, transit; peers z1 and z3, no policy.
+- z3-base.yaml: AS 65003, no input policy; both prefixes accepted.
+- z3-exact-pass.yaml: `^65002 65001$` — exact whole-path match.
+- z3-exact-fail.yaml: `^65001 65002$` — right ASNs, wrong order.
+- z3-origin-pass.yaml: `_65001$` — originated by 65001.
+- z3-origin-fail.yaml: `_65003$` — 65003 is not on the received path.
+- z3-neighbor-pass.yaml: `^65002_` — leftmost (neighbor) AS is 65002.
+- z3-transit-fail.yaml: `_65099_` — 65099 is nowhere in the path.
+
+## Test Scenarios
+
+| Scenario | Result |
+|----------|--------|
+| Setup topology and establish the eBGP chain | |
+| exact match accepts the whole AS_PATH anchored with ^ and $ | |
+| exact match rejects the same ASNs in the wrong order | |
+| _ASN$ accepts routes originated by that AS | |
+| _ASN$ rejects routes not originated by that AS | |
+| ^ASN_ accepts routes whose neighbor (leftmost) AS matches | |
+| _ASN_ rejects routes that do not transit that AS | |
+| Teardown topology | |

--- a/bdd/docs/bgp_set_ext_large_community.md
+++ b/bdd/docs/bgp_set_ext_large_community.md
@@ -1,0 +1,53 @@
+# BGP policy set ext-community and set large-community
+
+## Overview
+
+As a network operator
+I want policy-list `set ext-community` and `set large-community`
+actions to stamp the EXT_COMMUNITIES and LARGE_COMMUNITIES attributes
+on routes, so that I can tag routes the same way `set community` tags
+the standard COMMUNITIES attribute.
+
+Both actions reference a named set (`ext-community-set` /
+`large-community-set`); only the set's exact members contribute
+concrete values (regex members are skipped). `replace` (default)
+overwrites the attribute, `additive` merges, `delete` removes — the
+same {replace|additive|delete} choice as `set community`.
+
+The set is applied as z2's INBOUND policy so the modified attribute
+lands in z2's own Loc-RIB and is directly observable via
+`show bgp -j`, which now surfaces `community`, `ext_community`, and
+`large_community` fields.
+
+## Test Topology
+
+```
+  ┌─────────────────────────────────────────┐
+  │                   br0                    │
+  └─────────────┬───────────────┬───────────┘
+                │               │
+           ┌────┴────┐     ┌────┴────┐
+           │   z1    │     │   z2    │
+           │ AS65001 │     │ AS65002 │
+           │192.168. │     │192.168. │
+           │  0.1/24 │     │  0.2/24 │
+           └─────────┘     └─────────┘
+```
+
+## Config Files
+
+- z1.yaml: AS 65001, advertises 10.0.0.1/32 + 10.0.0.2/32.
+- z2-base.yaml: AS 65002, no input policy; routes carry no communities.
+- z2-set-ext.yaml: `set ext-community RT-SET` (rt:65001:100).
+- z2-set-large.yaml: `set large-community LC-SET` (65001:100:200).
+- z2-set-both.yaml: one entry sets both rt:65002:300 and 65002:400:500.
+
+## Test Scenarios
+
+| Scenario | Result |
+|----------|--------|
+| Setup topology and establish BGP session | |
+| set ext-community stamps the EXT_COMMUNITIES attribute | |
+| set large-community stamps the LARGE_COMMUNITIES attribute | |
+| one entry sets both ext-community and large-community | |
+| Teardown topology | |

--- a/bdd/tests/configs/bgp_as_path_match/z1.yaml
+++ b/bdd/tests/configs/bgp_as_path_match/z1.yaml
@@ -1,0 +1,17 @@
+router:
+  bgp:
+    global:
+      as: 65001
+      router-id: 192.168.0.1
+    neighbor:
+    - remote-address: 192.168.0.2
+      afi-safi:
+      - name: ipv4
+        enabled: true
+      enabled: true
+      remote-as: 65002
+    afi-safi:
+    - name: ipv4
+      network:
+      - prefix: 10.0.0.1/32
+      - prefix: 10.0.0.2/32

--- a/bdd/tests/configs/bgp_as_path_match/z2.yaml
+++ b/bdd/tests/configs/bgp_as_path_match/z2.yaml
@@ -1,0 +1,18 @@
+router:
+  bgp:
+    global:
+      as: 65002
+      router-id: 192.168.0.2
+    neighbor:
+    - remote-address: 192.168.0.1
+      afi-safi:
+      - name: ipv4
+        enabled: true
+      enabled: true
+      remote-as: 65001
+    - remote-address: 192.168.0.3
+      afi-safi:
+      - name: ipv4
+        enabled: true
+      enabled: true
+      remote-as: 65003

--- a/bdd/tests/configs/bgp_as_path_match/z3-base.yaml
+++ b/bdd/tests/configs/bgp_as_path_match/z3-base.yaml
@@ -1,0 +1,12 @@
+router:
+  bgp:
+    global:
+      as: 65003
+      router-id: 192.168.0.3
+    neighbor:
+    - remote-address: 192.168.0.2
+      afi-safi:
+      - name: ipv4
+        enabled: true
+      enabled: true
+      remote-as: 65002

--- a/bdd/tests/configs/bgp_as_path_match/z3-exact-fail.yaml
+++ b/bdd/tests/configs/bgp_as_path_match/z3-exact-fail.yaml
@@ -1,0 +1,25 @@
+as-path-set:
+- name: EXACT-BAD
+  members:
+  - "^65001 65002$"
+policy:
+- name: IN-ASPATH
+  entry:
+  - number: 10
+    action: permit
+    match:
+      as-path: EXACT-BAD
+router:
+  bgp:
+    global:
+      as: 65003
+      router-id: 192.168.0.3
+    neighbor:
+    - remote-address: 192.168.0.2
+      afi-safi:
+      - name: ipv4
+        enabled: true
+        policy:
+          in: IN-ASPATH
+      enabled: true
+      remote-as: 65002

--- a/bdd/tests/configs/bgp_as_path_match/z3-exact-pass.yaml
+++ b/bdd/tests/configs/bgp_as_path_match/z3-exact-pass.yaml
@@ -1,0 +1,25 @@
+as-path-set:
+- name: EXACT-OK
+  members:
+  - "^65002 65001$"
+policy:
+- name: IN-ASPATH
+  entry:
+  - number: 10
+    action: permit
+    match:
+      as-path: EXACT-OK
+router:
+  bgp:
+    global:
+      as: 65003
+      router-id: 192.168.0.3
+    neighbor:
+    - remote-address: 192.168.0.2
+      afi-safi:
+      - name: ipv4
+        enabled: true
+        policy:
+          in: IN-ASPATH
+      enabled: true
+      remote-as: 65002

--- a/bdd/tests/configs/bgp_as_path_match/z3-neighbor-pass.yaml
+++ b/bdd/tests/configs/bgp_as_path_match/z3-neighbor-pass.yaml
@@ -1,0 +1,25 @@
+as-path-set:
+- name: NEIGH-65002
+  members:
+  - "^65002_"
+policy:
+- name: IN-ASPATH
+  entry:
+  - number: 10
+    action: permit
+    match:
+      as-path: NEIGH-65002
+router:
+  bgp:
+    global:
+      as: 65003
+      router-id: 192.168.0.3
+    neighbor:
+    - remote-address: 192.168.0.2
+      afi-safi:
+      - name: ipv4
+        enabled: true
+        policy:
+          in: IN-ASPATH
+      enabled: true
+      remote-as: 65002

--- a/bdd/tests/configs/bgp_as_path_match/z3-origin-fail.yaml
+++ b/bdd/tests/configs/bgp_as_path_match/z3-origin-fail.yaml
@@ -1,0 +1,25 @@
+as-path-set:
+- name: ORIG-65003
+  members:
+  - "_65003$"
+policy:
+- name: IN-ASPATH
+  entry:
+  - number: 10
+    action: permit
+    match:
+      as-path: ORIG-65003
+router:
+  bgp:
+    global:
+      as: 65003
+      router-id: 192.168.0.3
+    neighbor:
+    - remote-address: 192.168.0.2
+      afi-safi:
+      - name: ipv4
+        enabled: true
+        policy:
+          in: IN-ASPATH
+      enabled: true
+      remote-as: 65002

--- a/bdd/tests/configs/bgp_as_path_match/z3-origin-pass.yaml
+++ b/bdd/tests/configs/bgp_as_path_match/z3-origin-pass.yaml
@@ -1,0 +1,25 @@
+as-path-set:
+- name: ORIG-65001
+  members:
+  - "_65001$"
+policy:
+- name: IN-ASPATH
+  entry:
+  - number: 10
+    action: permit
+    match:
+      as-path: ORIG-65001
+router:
+  bgp:
+    global:
+      as: 65003
+      router-id: 192.168.0.3
+    neighbor:
+    - remote-address: 192.168.0.2
+      afi-safi:
+      - name: ipv4
+        enabled: true
+        policy:
+          in: IN-ASPATH
+      enabled: true
+      remote-as: 65002

--- a/bdd/tests/configs/bgp_as_path_match/z3-transit-fail.yaml
+++ b/bdd/tests/configs/bgp_as_path_match/z3-transit-fail.yaml
@@ -1,0 +1,25 @@
+as-path-set:
+- name: TRANSIT-65099
+  members:
+  - "_65099_"
+policy:
+- name: IN-ASPATH
+  entry:
+  - number: 10
+    action: permit
+    match:
+      as-path: TRANSIT-65099
+router:
+  bgp:
+    global:
+      as: 65003
+      router-id: 192.168.0.3
+    neighbor:
+    - remote-address: 192.168.0.2
+      afi-safi:
+      - name: ipv4
+        enabled: true
+        policy:
+          in: IN-ASPATH
+      enabled: true
+      remote-as: 65002

--- a/bdd/tests/configs/bgp_set_ext_large_community/z1.yaml
+++ b/bdd/tests/configs/bgp_set_ext_large_community/z1.yaml
@@ -1,0 +1,17 @@
+router:
+  bgp:
+    global:
+      as: 65001
+      router-id: 192.168.0.1
+    neighbor:
+    - remote-address: 192.168.0.2
+      afi-safi:
+      - name: ipv4
+        enabled: true
+      enabled: true
+      remote-as: 65002
+    afi-safi:
+    - name: ipv4
+      network:
+      - prefix: 10.0.0.1/32
+      - prefix: 10.0.0.2/32

--- a/bdd/tests/configs/bgp_set_ext_large_community/z2-base.yaml
+++ b/bdd/tests/configs/bgp_set_ext_large_community/z2-base.yaml
@@ -1,0 +1,12 @@
+router:
+  bgp:
+    global:
+      as: 65002
+      router-id: 192.168.0.2
+    neighbor:
+    - remote-address: 192.168.0.1
+      afi-safi:
+      - name: ipv4
+        enabled: true
+      enabled: true
+      remote-as: 65001

--- a/bdd/tests/configs/bgp_set_ext_large_community/z2-set-both.yaml
+++ b/bdd/tests/configs/bgp_set_ext_large_community/z2-set-both.yaml
@@ -1,0 +1,32 @@
+ext-community-set:
+- name: RT-SET
+  members:
+  - "rt:65002:300"
+large-community-set:
+- name: LC-SET
+  members:
+  - "65002:400:500"
+policy:
+- name: STAMP-BOTH
+  entry:
+  - number: 10
+    action: permit
+    set:
+      ext-community:
+        name: RT-SET
+      large-community:
+        name: LC-SET
+router:
+  bgp:
+    global:
+      as: 65002
+      router-id: 192.168.0.2
+    neighbor:
+    - remote-address: 192.168.0.1
+      afi-safi:
+      - name: ipv4
+        enabled: true
+        policy:
+          in: STAMP-BOTH
+      enabled: true
+      remote-as: 65001

--- a/bdd/tests/configs/bgp_set_ext_large_community/z2-set-ext.yaml
+++ b/bdd/tests/configs/bgp_set_ext_large_community/z2-set-ext.yaml
@@ -1,0 +1,26 @@
+ext-community-set:
+- name: RT-SET
+  members:
+  - "rt:65001:100"
+policy:
+- name: STAMP-EXT
+  entry:
+  - number: 10
+    action: permit
+    set:
+      ext-community:
+        name: RT-SET
+router:
+  bgp:
+    global:
+      as: 65002
+      router-id: 192.168.0.2
+    neighbor:
+    - remote-address: 192.168.0.1
+      afi-safi:
+      - name: ipv4
+        enabled: true
+        policy:
+          in: STAMP-EXT
+      enabled: true
+      remote-as: 65001

--- a/bdd/tests/configs/bgp_set_ext_large_community/z2-set-large.yaml
+++ b/bdd/tests/configs/bgp_set_ext_large_community/z2-set-large.yaml
@@ -1,0 +1,26 @@
+large-community-set:
+- name: LC-SET
+  members:
+  - "65001:100:200"
+policy:
+- name: STAMP-LARGE
+  entry:
+  - number: 10
+    action: permit
+    set:
+      large-community:
+        name: LC-SET
+router:
+  bgp:
+    global:
+      as: 65002
+      router-id: 192.168.0.2
+    neighbor:
+    - remote-address: 192.168.0.1
+      afi-safi:
+      - name: ipv4
+        enabled: true
+        policy:
+          in: STAMP-LARGE
+      enabled: true
+      remote-as: 65001

--- a/bdd/tests/features/bgp_as_path_match.feature
+++ b/bdd/tests/features/bgp_as_path_match.feature
@@ -1,0 +1,120 @@
+@serial
+@bgp_as_path_match
+Feature: BGP match as-path-set with FRR-compatible regular expressions
+  As a network operator
+  I want zebra-rs `match as-path` to accept the same AS-path regular
+  expressions as FRR's `bgp as-path access-list`, so that policies port
+  between the two routers unchanged.
+
+  The AS-path regex engine mirrors FRR's `bgp_regcomp`
+  (bgpd/bgp_regex.c): the `_` magic character expands to
+  `(^|[,{}() ]|$)`, matching a separator, the start, or the end of the
+  path. Regexes run against the AS_PATH rendered exactly like FRR's
+  `aspath->str` (space-separated ASNs; AS_SET members comma-separated).
+  This feature exercises exact anchored matching plus the three classic
+  `_` idioms — neighbor-is (`^ASN_`), originates-from (`_ASN$`), and
+  transits (`_ASN_`).
+
+  Test Topology (linear eBGP chain, all on one L2 segment):
+  ```
+  ┌──────────────────────────────────────────────────┐
+  │                        br0                        │
+  └───────┬───────────────┬───────────────┬───────────┘
+          │               │               │
+     ┌────┴────┐     ┌────┴────┐     ┌────┴────┐
+     │   z1    │────▶│   z2    │────▶│   z3    │
+     │ AS65001 │     │ AS65002 │     │ AS65003 │
+     │ .0.1/24 │     │ .0.2/24 │     │ .0.3/24 │
+     └─────────┘     └─────────┘     └─────────┘
+  ```
+
+  z1 originates 10.0.0.1/32 + 10.0.0.2/32 and peers only z2. z2 is a
+  transit AS with no policy, peering z1 and z3. z3 peers only z2, so the
+  two prefixes reach z3 with AS_PATH `65002 65001`. Each scenario swaps
+  z3's inbound policy and asserts which prefixes survive in z3's RIB.
+  Re-evaluation rides the policy-change trigger (PolicyRx -> soft-in):
+  applying a config whose as-path-set/policy changed re-runs the inbound
+  policy over the Adj-RIB-In — no `clear` needed.
+
+  Config files:
+  - z1.yaml: AS 65001, advertises 10.0.0.1/32 + 10.0.0.2/32 to z2.
+  - z2.yaml: AS 65002, transit; peers z1 and z3, no policy.
+  - z3-base.yaml: AS 65003, no input policy; both prefixes accepted.
+  - z3-exact-pass.yaml: `^65002 65001$` — exact whole-path match.
+  - z3-exact-fail.yaml: `^65001 65002$` — right ASNs, wrong order.
+  - z3-origin-pass.yaml: `_65001$` — originated by 65001.
+  - z3-origin-fail.yaml: `_65003$` — 65003 is not on the received path.
+  - z3-neighbor-pass.yaml: `^65002_` — leftmost (neighbor) AS is 65002.
+  - z3-transit-fail.yaml: `_65099_` — 65099 is nowhere in the path.
+
+  Scenario: Setup topology and establish the eBGP chain
+    Given a clean test environment
+    When I create bridge "br0"
+    And I create namespace "z1" with IP "192.168.0.1/24" on bridge "br0"
+    And I create namespace "z2" with IP "192.168.0.2/24" on bridge "br0"
+    And I create namespace "z3" with IP "192.168.0.3/24" on bridge "br0"
+    And I start zebra-rs in namespace "z1"
+    And I start zebra-rs in namespace "z2"
+    And I start zebra-rs in namespace "z3"
+    And I apply config "z1.yaml" to namespace "z1"
+    And I apply config "z2.yaml" to namespace "z2"
+    And I apply config "z3-base.yaml" to namespace "z3"
+    And I wait 10 seconds for BGP to operate
+    Then BGP session in "z2" to "192.168.0.1" should be "Established"
+    And BGP session in "z2" to "192.168.0.3" should be "Established"
+    And BGP session in "z3" to "192.168.0.2" should be "Established"
+    And BGP route in "z3" has "10.0.0.1/32"
+    And BGP route in "z3" has "10.0.0.2/32"
+
+  Scenario: exact match accepts the whole AS_PATH anchored with ^ and $
+    Given the test topology exists
+    When I apply config "z3-exact-pass.yaml" to namespace "z3"
+    And I wait 5 seconds for BGP to operate
+    Then BGP route in "z3" has "10.0.0.1/32"
+    And BGP route in "z3" has "10.0.0.2/32"
+
+  Scenario: exact match rejects the same ASNs in the wrong order
+    Given the test topology exists
+    When I apply config "z3-exact-fail.yaml" to namespace "z3"
+    And I wait 5 seconds for BGP to operate
+    Then BGP route in "z3" does not have "10.0.0.1/32"
+    And BGP route in "z3" does not have "10.0.0.2/32"
+
+  Scenario: _ASN$ accepts routes originated by that AS
+    Given the test topology exists
+    When I apply config "z3-origin-pass.yaml" to namespace "z3"
+    And I wait 5 seconds for BGP to operate
+    Then BGP route in "z3" has "10.0.0.1/32"
+    And BGP route in "z3" has "10.0.0.2/32"
+
+  Scenario: _ASN$ rejects routes not originated by that AS
+    Given the test topology exists
+    When I apply config "z3-origin-fail.yaml" to namespace "z3"
+    And I wait 5 seconds for BGP to operate
+    Then BGP route in "z3" does not have "10.0.0.1/32"
+    And BGP route in "z3" does not have "10.0.0.2/32"
+
+  Scenario: ^ASN_ accepts routes whose neighbor (leftmost) AS matches
+    Given the test topology exists
+    When I apply config "z3-neighbor-pass.yaml" to namespace "z3"
+    And I wait 5 seconds for BGP to operate
+    Then BGP route in "z3" has "10.0.0.1/32"
+    And BGP route in "z3" has "10.0.0.2/32"
+
+  Scenario: _ASN_ rejects routes that do not transit that AS
+    Given the test topology exists
+    When I apply config "z3-transit-fail.yaml" to namespace "z3"
+    And I wait 5 seconds for BGP to operate
+    Then BGP route in "z3" does not have "10.0.0.1/32"
+    And BGP route in "z3" does not have "10.0.0.2/32"
+
+  Scenario: Teardown topology
+    Given the test topology exists
+    When I stop zebra-rs in namespace "z1"
+    And I stop zebra-rs in namespace "z2"
+    And I stop zebra-rs in namespace "z3"
+    And I delete namespace "z1"
+    And I delete namespace "z2"
+    And I delete namespace "z3"
+    And I delete bridge "br0"
+    Then the test environment should be clean

--- a/bdd/tests/features/bgp_set_ext_large_community.feature
+++ b/bdd/tests/features/bgp_set_ext_large_community.feature
@@ -1,0 +1,90 @@
+@serial
+@bgp_set_ext_large_community
+Feature: BGP policy set ext-community and set large-community
+  As a network operator
+  I want policy-list `set ext-community` and `set large-community`
+  actions to stamp the EXT_COMMUNITIES and LARGE_COMMUNITIES attributes
+  on routes, so that I can tag routes the same way `set community` tags
+  the standard COMMUNITIES attribute.
+
+  Both actions reference a named set (`ext-community-set` /
+  `large-community-set`); only the set's exact members contribute
+  concrete values (regex members are skipped). `replace` (default)
+  overwrites the attribute, `additive` merges, `delete` removes — the
+  same {replace|additive|delete} choice as `set community`.
+
+  The set is applied as z2's INBOUND policy so the modified attribute
+  lands in z2's own Loc-RIB and is directly observable via
+  `show bgp -j`, which now surfaces `community`, `ext_community`, and
+  `large_community` fields. Re-evaluation rides the policy-change
+  trigger (PolicyRx -> soft-in): applying a config whose policy content
+  changed re-runs the inbound policy over the Adj-RIB-In.
+
+  Test Topology:
+  ```
+  ┌─────────────────────────────────────────┐
+  │                   br0                    │
+  └─────────────┬───────────────┬───────────┘
+                │               │
+           ┌────┴────┐     ┌────┴────┐
+           │   z1    │     │   z2    │
+           │ AS65001 │     │ AS65002 │
+           │192.168. │     │192.168. │
+           │  0.1/24 │     │  0.2/24 │
+           └─────────┘     └─────────┘
+  ```
+
+  z1 originates 10.0.0.1/32 + 10.0.0.2/32 with no communities. z2
+  swaps its inbound policy and we read back the stamped attributes.
+
+  Config files:
+  - z1.yaml: AS 65001, advertises 10.0.0.1/32 + 10.0.0.2/32.
+  - z2-base.yaml: AS 65002, no input policy; routes carry no communities.
+  - z2-set-ext.yaml: `set ext-community RT-SET` (rt:65001:100).
+  - z2-set-large.yaml: `set large-community LC-SET` (65001:100:200).
+  - z2-set-both.yaml: one entry sets both rt:65002:300 and 65002:400:500.
+
+  Scenario: Setup topology and establish BGP session
+    Given a clean test environment
+    When I create bridge "br0"
+    And I create namespace "z1" with IP "192.168.0.1/24" on bridge "br0"
+    And I create namespace "z2" with IP "192.168.0.2/24" on bridge "br0"
+    And I start zebra-rs in namespace "z1"
+    And I start zebra-rs in namespace "z2"
+    And I apply config "z1.yaml" to namespace "z1"
+    And I apply config "z2-base.yaml" to namespace "z2"
+    And I wait 10 seconds for BGP to operate
+    Then BGP session in "z1" to "192.168.0.2" should be "Established"
+    And BGP session in "z2" to "192.168.0.1" should be "Established"
+    And BGP route in "z2" has "10.0.0.1/32"
+    And BGP route in "z2" has "10.0.0.2/32"
+
+  Scenario: set ext-community stamps the EXT_COMMUNITIES attribute
+    Given the test topology exists
+    When I apply config "z2-set-ext.yaml" to namespace "z2"
+    And I wait 5 seconds for BGP to operate
+    Then BGP route in "z2" has "10.0.0.1/32" with "ext_community" value "rt:65001:100"
+    And BGP route in "z2" has "10.0.0.2/32" with "ext_community" value "rt:65001:100"
+
+  Scenario: set large-community stamps the LARGE_COMMUNITIES attribute
+    Given the test topology exists
+    When I apply config "z2-set-large.yaml" to namespace "z2"
+    And I wait 5 seconds for BGP to operate
+    Then BGP route in "z2" has "10.0.0.1/32" with "large_community" value "65001:100:200"
+    And BGP route in "z2" has "10.0.0.2/32" with "large_community" value "65001:100:200"
+
+  Scenario: one entry sets both ext-community and large-community
+    Given the test topology exists
+    When I apply config "z2-set-both.yaml" to namespace "z2"
+    And I wait 5 seconds for BGP to operate
+    Then BGP route in "z2" has "10.0.0.1/32" with "ext_community" value "rt:65002:300"
+    And BGP route in "z2" has "10.0.0.1/32" with "large_community" value "65002:400:500"
+
+  Scenario: Teardown topology
+    Given the test topology exists
+    When I stop zebra-rs in namespace "z1"
+    And I stop zebra-rs in namespace "z2"
+    And I delete namespace "z1"
+    And I delete namespace "z2"
+    And I delete bridge "br0"
+    Then the test environment should be clean

--- a/book/src/ch-05-02-policy-match.md
+++ b/book/src/ch-05-02-policy-match.md
@@ -131,13 +131,17 @@ policy MATCH-LARGE {
 
 ### `match as-path`
 
-References an `as-path-set`. Each member is a regex matched
-against the AS_PATH formatted as a space-separated list of ASNs.
+References an `as-path-set`. Each member is a regular expression
+matched against the route's AS_PATH. The regex syntax is
+**compatible with FRR's `bgp as-path access-list`** — patterns port
+between zebra-rs and FRR unchanged (see
+[AS-path regex syntax](#as-path-regex-syntax) below). The entry
+matches if **any** member of the set matches the AS_PATH.
 
 ```console
 as-path-set FROM-65003 {
     members {
-        \\b65003\\b;
+        _65003_;
     }
 }
 
@@ -154,8 +158,47 @@ policy DROP-65003-TRANSIT {
 }
 ```
 
-`\\b` is a regex word-boundary anchor that prevents `65003` from
-matching `650030` or `650031`.
+`_65003_` matches AS 65003 anywhere in the path without also matching
+`650030` or `165003` — see below for why.
+
+#### AS-path regex syntax
+
+The AS_PATH is rendered as a space-separated list of ASNs — for
+example `65001 65002 65003`. AS_SET segments (created by route
+aggregation) render inside braces with **comma-separated** members,
+exactly as FRR does: `65001 {65010,65011} 65003`. Confederation
+segments render as `(65001 65002)` (sequence) and `[65001,65002]`
+(set). Members are matched against this string.
+
+The **`_` magic character** is the key to FRR compatibility. It
+expands to `(^|[,{}() ]|$)` — the start of the string, the end of the
+string, or any one of the separators `, { } ( ) <space>`. This is the
+same substitution FRR's `bgp_regcomp` performs, so a `_` matches a
+"word boundary" between ASNs regardless of which separator sits there.
+Use it instead of a bare space or a Perl-style `\b`:
+
+| Pattern | Meaning | Matches `65002 65001` |
+|---------|---------|-----------------------|
+| `^65002_` | neighbor (leftmost) AS is 65002 | yes |
+| `_65001$` | route originated by 65001 | yes |
+| `_65002_` | 65002 appears anywhere (transit) | yes |
+| `^65002 65001$` | exact whole-path match | yes |
+| `_65099_` | 65099 appears anywhere | no |
+| `^65001_` | neighbor AS is 65001 | no |
+
+Anchoring with `^` and `$` gives an **exact match** of the entire
+AS_PATH; `_` on one side matches the origin or the neighbor; `_` on
+both sides matches a transit AS. Because `_` requires a boundary,
+`_65003_` does not match `650030` (no boundary after `65003`) or
+`165003` (no boundary before it).
+
+> **Porting from FRR.** FRR expresses the same idea with
+> `bgp as-path access-list NAME permit REGEX`. Copy the regex verbatim
+> into an `as-path-set` member — `^65002_`, `_65001$`, `_65002_`, and
+> exact `^65002 65001$` all behave identically. zebra-rs additionally
+> accepts the richer Rust `regex` syntax (e.g. `\b`, `\d`) as a
+> superset, but stick to the FRR-portable subset if you need both
+> routers to agree.
 
 ## Direct address
 

--- a/book/src/ch-05-03-policy-set.md
+++ b/book/src/ch-05-03-policy-set.md
@@ -12,7 +12,8 @@ This chapter walks every `set` clause grouped by what it touches:
 2. **Numeric attribute (plain assign)** — `weight`.
 3. **Enum** — `origin`.
 4. **Address** — `next-hop` (IPv4 / IPv6 / `self`).
-5. **Communities** — `community` (replace / additive / delete).
+5. **Communities** — `community`, `ext-community`, and
+   `large-community` (each replace / additive / delete).
 6. **AS path** — `as-path-prepend`.
 
 ## Numeric attributes with deltas
@@ -275,6 +276,73 @@ policy STRIP-NO-EXPORT {
 }
 ```
 
+## `set ext-community`
+
+The extended-community twin of `set community`: apply an
+`ext-community-set` to the route's EXT_COMMUNITIES attribute, with
+the same three modes (`replace` default / `additive` / `delete`).
+Only the set's **exact** `rt:` / `soo:` members contribute concrete
+values — regex members (e.g. `rt:^65001:.*`) are matchers, not
+values, and are skipped.
+
+```console
+ext-community-set TENANT-RTS {
+    members {
+        rt:65001:100;
+        rt:1.2.3.4:200;
+    }
+}
+
+policy TAG-TENANT {
+    entry 10 {
+        action permit;
+        set {
+            ext-community {
+                name TENANT-RTS;
+                additive;
+            }
+        }
+    }
+}
+```
+
+`replace` (no keyword) overwrites the whole EXT_COMMUNITIES
+attribute — **including any route targets or Color community the
+route already carried** — so reach for `additive` whenever you mean
+to add rather than reset. `delete` removes the named members
+(set difference).
+
+## `set large-community`
+
+The large-community twin, over the LARGE_COMMUNITIES attribute.
+Members are exact `A:B:C` triples (RFC 8092); the three modes match
+`set community`.
+
+```console
+large-community-set REGION-TAGS {
+    members {
+        65001:1:100;
+        65001:1:200;
+    }
+}
+
+policy TAG-REGION {
+    entry 10 {
+        action permit;
+        set {
+            large-community {
+                name REGION-TAGS;
+                additive;
+            }
+        }
+    }
+}
+```
+
+All three community set-actions surface in `show bgp -j` as the
+`community`, `ext_community`, and `large_community` route fields, so
+you can confirm what a policy stamped.
+
 ## `set as-path-prepend`
 
 Prepend an ASN onto the AS_PATH a configurable number of times.
@@ -309,9 +377,11 @@ order against the working attribute set:
 2. `med`
 3. `weight`
 4. `community`
-5. `as-path-prepend`
-6. `next-hop`
-7. `origin`
+5. `ext-community`
+6. `large-community`
+7. `as-path-prepend`
+8. `next-hop`
+9. `origin`
 
 The order matters in two cases:
 

--- a/crates/bgp-packet/src/attrs/aspath.rs
+++ b/crates/bgp-packet/src/attrs/aspath.rs
@@ -169,6 +169,33 @@ impl As4Segment {
             _ => v,
         }
     }
+
+    /// Render this segment exactly like FRR's `aspath_make_str_count`
+    /// (`bgpd/bgp_aspath.c`), for AS-path regular-expression matching.
+    ///
+    /// FRR joins the members of an AS_SET / AS_CONFED_SET with a comma and
+    /// an AS_SEQUENCE / AS_CONFED_SEQUENCE with a space, wrapping SET and
+    /// CONFED segments in their delimiter characters. Matching against this
+    /// exact form keeps zebra-rs byte-compatible with FRR AS-path regexes,
+    /// including patterns that reference the internal `,` separator.
+    fn format_frr(&self) -> String {
+        let separator = match self.typ {
+            AS_SET | AS_CONFED_SET => ",",
+            _ => " ",
+        };
+        let v = self
+            .asn
+            .iter()
+            .map(|x| asn_to_string(*x))
+            .collect::<Vec<String>>()
+            .join(separator);
+        match self.typ {
+            AS_SET => format!("{{{v}}}"),
+            AS_CONFED_SEQ => format!("({v})"),
+            AS_CONFED_SET => format!("[{v}]"),
+            _ => v,
+        }
+    }
 }
 
 impl fmt::Display for As4Segment {
@@ -228,6 +255,20 @@ impl As4Path {
         self.segs
             .iter()
             .map(|x| x.format_explicit())
+            .collect::<Vec<String>>()
+            .join(" ")
+    }
+
+    /// AS-Path rendered exactly like FRR's `aspath->str`, the form FRR runs
+    /// its AS-path access-list regexes against. Segments are space-joined;
+    /// AS_SET / AS_CONFED_SET members are comma-separated inside their
+    /// delimiters (e.g. `65001 {65010,65011} 65003`). Used only for policy
+    /// AS-path matching so patterns behave identically to FRR; `show`
+    /// output continues to use [`as_path_display`](Self::as_path_display).
+    pub fn as_path_frr_string(&self) -> String {
+        self.segs
+            .iter()
+            .map(|x| x.format_frr())
             .collect::<Vec<String>>()
             .join(" ")
     }
@@ -621,6 +662,20 @@ mod tests {
         let mut aspath: As4Path = As4Path::from_str("{1 2} (3 4)").unwrap();
         aspath.consolidate();
         assert_eq!(aspath.as_path_explicit(), "{1 2} (3 4)");
+    }
+
+    #[test]
+    fn frr_string_uses_comma_in_sets() {
+        // FRR's aspath->str comma-joins AS_SET / AS_CONFED_SET members and
+        // space-joins AS_SEQUENCE / AS_CONFED_SEQUENCE members. This is the
+        // string AS-path regexes run against, so it must match FRR exactly.
+        let aspath: As4Path = As4Path::from_str("1 2 3 {4 5} (6 7) [8 9]").unwrap();
+        assert_eq!(aspath.as_path_display(), "1 2 3 {4 5} (6 7) [8 9]");
+        assert_eq!(aspath.as_path_frr_string(), "1 2 3 {4,5} (6 7) [8,9]");
+
+        // A plain AS_SEQUENCE is identical in both renderings.
+        let aspath: As4Path = As4Path::from_str("65001 65002 65003").unwrap();
+        assert_eq!(aspath.as_path_frr_string(), "65001 65002 65003");
     }
 
     #[test]

--- a/zebra-rs/src/bgp/route.rs
+++ b/zebra-rs/src/bgp/route.rs
@@ -12086,6 +12086,12 @@ pub fn policy_list_apply_net(
                 if let Some(cfg) = &entry.set_community {
                     apply_set_community(&mut decision.attr, cfg);
                 }
+                if let Some(cfg) = &entry.set_ext_community {
+                    apply_set_ext_community(&mut decision.attr, cfg);
+                }
+                if let Some(cfg) = &entry.set_large_community {
+                    apply_set_large_community(&mut decision.attr, cfg);
+                }
                 if let Some(prepend) = &entry.set_as_path_prepend {
                     apply_set_as_path_prepend(&mut decision.attr, prepend);
                 }
@@ -12296,6 +12302,12 @@ pub fn policy_list_apply_evpn(
                 if let Some(cfg) = &entry.set_community {
                     apply_set_community(&mut decision.attr, cfg);
                 }
+                if let Some(cfg) = &entry.set_ext_community {
+                    apply_set_ext_community(&mut decision.attr, cfg);
+                }
+                if let Some(cfg) = &entry.set_large_community {
+                    apply_set_large_community(&mut decision.attr, cfg);
+                }
                 if let Some(prepend) = &entry.set_as_path_prepend {
                     apply_set_as_path_prepend(&mut decision.attr, prepend);
                 }
@@ -12474,6 +12486,97 @@ fn apply_set_community(bgp_attr: &mut BgpAttr, cfg: &crate::policy::SetCommunity
             let drop: std::collections::HashSet<u32> = new_vals.into_iter().collect();
             com.0.retain(|v| !drop.contains(v));
             bgp_attr.com = if com.0.is_empty() { None } else { Some(com) };
+        }
+    }
+}
+
+/// Apply a `set ext-community <ext-community-set> [additive|delete]`
+/// action to `bgp_attr`. The extended-community twin of
+/// [`apply_set_community`]: only `Exact` matchers (`rt:`/`soo:`)
+/// contribute concrete values; regex matchers are skipped. `Replace`
+/// overwrites the EXT_COMMUNITIES attribute (dropping any route
+/// targets / Color already present), `Additive` merges, `Delete`
+/// removes (set difference). The result stays sorted and deduplicated
+/// via the underlying `BTreeSet`.
+fn apply_set_ext_community(bgp_attr: &mut BgpAttr, cfg: &crate::policy::SetExtCommunityConfig) {
+    let Some(set) = cfg.resolved.as_ref() else {
+        return;
+    };
+    let new_vals: Vec<ExtCommunityValue> = set
+        .vals
+        .iter()
+        .filter_map(|m| match m {
+            crate::policy::ExtCommunityMatcher::Exact(v) => Some(v.clone()),
+            _ => None,
+        })
+        .collect();
+
+    use crate::policy::SetCommunityMode;
+    match cfg.mode {
+        SetCommunityMode::Replace => {
+            if new_vals.is_empty() {
+                bgp_attr.ecom = None;
+                return;
+            }
+            bgp_attr.ecom = Some(new_vals.into_iter().collect());
+        }
+        SetCommunityMode::Additive => {
+            let mut ecom = bgp_attr.ecom.clone().unwrap_or_default();
+            for v in new_vals {
+                ecom.0.insert(v);
+            }
+            bgp_attr.ecom = Some(ecom);
+        }
+        SetCommunityMode::Delete => {
+            let Some(mut ecom) = bgp_attr.ecom.clone() else {
+                return;
+            };
+            ecom.0.retain(|v| !new_vals.contains(v));
+            bgp_attr.ecom = if ecom.0.is_empty() { None } else { Some(ecom) };
+        }
+    }
+}
+
+/// Apply a `set large-community <large-community-set> [additive|delete]`
+/// action to `bgp_attr`. The large-community twin of
+/// [`apply_set_community`]: only `Exact` `A:B:C` matchers contribute
+/// concrete values; regex matchers are skipped. `Replace` overwrites
+/// the LARGE_COMMUNITIES attribute, `Additive` merges, `Delete` removes.
+fn apply_set_large_community(bgp_attr: &mut BgpAttr, cfg: &crate::policy::SetLargeCommunityConfig) {
+    let Some(set) = cfg.resolved.as_ref() else {
+        return;
+    };
+    let new_vals: Vec<LargeCommunityValue> = set
+        .vals
+        .iter()
+        .filter_map(|m| match m {
+            crate::policy::LargeCommunityMatcher::Exact(v) => Some(v.clone()),
+            _ => None,
+        })
+        .collect();
+
+    use crate::policy::SetCommunityMode;
+    match cfg.mode {
+        SetCommunityMode::Replace => {
+            if new_vals.is_empty() {
+                bgp_attr.lcom = None;
+                return;
+            }
+            bgp_attr.lcom = Some(new_vals.into_iter().collect());
+        }
+        SetCommunityMode::Additive => {
+            let mut lcom = bgp_attr.lcom.clone().unwrap_or_default();
+            for v in new_vals {
+                lcom.0.insert(v);
+            }
+            bgp_attr.lcom = Some(lcom);
+        }
+        SetCommunityMode::Delete => {
+            let Some(mut lcom) = bgp_attr.lcom.clone() else {
+                return;
+            };
+            lcom.0.retain(|v| !new_vals.contains(v));
+            bgp_attr.lcom = if lcom.0.is_empty() { None } else { Some(lcom) };
         }
     }
 }
@@ -17059,8 +17162,8 @@ mod policy_apply_tests {
     #[test]
     fn match_as_path_set() {
         let mut set = AsPathSet::default();
-        set.vals
-            .insert(AsPathMatcher::from_str("\\b65001\\b").unwrap());
+        // FRR `_` magic char: 65001 anywhere in the path.
+        set.vals.insert(AsPathMatcher::from_str("_65001_").unwrap());
 
         let mut list = PolicyList::default();
         let entry = list.entry(10);
@@ -17190,8 +17293,8 @@ mod policy_apply_tests {
     #[test]
     fn multiple_match_clauses_all_required() {
         let mut set = AsPathSet::default();
-        set.vals
-            .insert(AsPathMatcher::from_str("^65001\\b").unwrap());
+        // FRR `_` magic char: path whose neighbor (leftmost) AS is 65001.
+        set.vals.insert(AsPathMatcher::from_str("^65001_").unwrap());
 
         let mut list = PolicyList::default();
         let entry = list.entry(10);
@@ -18288,14 +18391,17 @@ mod tests {
     use std::net::{IpAddr, Ipv4Addr};
 
     use bgp_packet::{
-        As4Path, BgpAttr, BgpNexthop, Community, CommunityValue, Ipv4Nlri, LocalPref,
+        As4Path, BgpAttr, BgpNexthop, Community, CommunityValue, ExtCommunity, ExtCommunityValue,
+        Ipv4Nlri, LargeCommunity, LargeCommunityValue, LocalPref,
     };
     use ipnet::Ipv4Net;
 
     use crate::policy::prefix::set::PrefixSetEntry;
     use crate::policy::{
-        AsPathPrependConfig, CommunityMatcher, CommunitySet, NumericSet, PolicyList, PrefixSet,
-        SetCommunityConfig, SetCommunityMode, SetNextHop,
+        AsPathPrependConfig, CommunityMatcher, CommunitySet, ExtCommunityMatcher, ExtCommunitySet,
+        LargeCommunityMatcher, LargeCommunitySet, NumericSet, PolicyList, PrefixSet,
+        SetCommunityConfig, SetCommunityMode, SetExtCommunityConfig, SetLargeCommunityConfig,
+        SetNextHop,
     };
 
     #[test]
@@ -18607,6 +18713,187 @@ mod tests {
 
         let out = policy_list_apply(&list, &nlri("10.0.0.0/24"), attr).unwrap();
         assert!(out.com.is_none());
+    }
+
+    // --- set ext-community -----------------------------------------------
+
+    fn ext_community_set(members: &[&str]) -> ExtCommunitySet {
+        let mut set = ExtCommunitySet::default();
+        for m in members {
+            set.vals
+                .insert(ExtCommunityMatcher::from_str(m).unwrap_or_else(|_| panic!("parse {m}")));
+        }
+        set
+    }
+
+    fn set_ext_community_cfg(members: &[&str], mode: SetCommunityMode) -> SetExtCommunityConfig {
+        SetExtCommunityConfig {
+            name: "test".into(),
+            mode,
+            resolved: Some(ext_community_set(members)),
+        }
+    }
+
+    fn ext_val(s: &str) -> ExtCommunityValue {
+        ExtCommunity::from_str(s)
+            .unwrap_or_else(|_| panic!("parse {s}"))
+            .0
+            .into_iter()
+            .next()
+            .unwrap()
+    }
+
+    #[test]
+    fn policy_list_apply_ext_community_replace() {
+        let mut list = PolicyList::default();
+        list.entry(10).set_ext_community = Some(set_ext_community_cfg(
+            &["rt:100:200"],
+            SetCommunityMode::Replace,
+        ));
+
+        // Existing rt:999:999 must be wiped on replace.
+        let attr = BgpAttr {
+            ecom: Some(ExtCommunity::from([ext_val("rt:999:999")])),
+            ..Default::default()
+        };
+        let out = policy_list_apply(&list, &nlri("10.0.0.0/24"), attr).unwrap();
+        let ecom = out.ecom.expect("ext-community attribute set");
+        assert_eq!(ecom, ExtCommunity::from([ext_val("rt:100:200")]));
+    }
+
+    #[test]
+    fn policy_list_apply_ext_community_additive_preserves_existing() {
+        let mut list = PolicyList::default();
+        list.entry(10).set_ext_community = Some(set_ext_community_cfg(
+            &["soo:100:200"],
+            SetCommunityMode::Additive,
+        ));
+
+        let attr = BgpAttr {
+            ecom: Some(ExtCommunity::from([ext_val("rt:65001:100")])),
+            ..Default::default()
+        };
+        let out = policy_list_apply(&list, &nlri("10.0.0.0/24"), attr).unwrap();
+        let ecom = out.ecom.expect("ext-community attribute set");
+        assert!(ecom.0.contains(&ext_val("rt:65001:100")));
+        assert!(ecom.0.contains(&ext_val("soo:100:200")));
+        assert_eq!(ecom.0.len(), 2);
+    }
+
+    #[test]
+    fn policy_list_apply_ext_community_replace_skips_regex() {
+        let mut list = PolicyList::default();
+        // Regex member has no concrete value to set; only rt:100:200 lands.
+        list.entry(10).set_ext_community = Some(set_ext_community_cfg(
+            &["rt:100:200", "rt:^65000:.*"],
+            SetCommunityMode::Replace,
+        ));
+        let out = policy_list_apply(&list, &nlri("10.0.0.0/24"), BgpAttr::default()).unwrap();
+        let ecom = out.ecom.expect("ext-community attribute set");
+        assert_eq!(ecom, ExtCommunity::from([ext_val("rt:100:200")]));
+    }
+
+    #[test]
+    fn policy_list_apply_ext_community_delete_removes_matching() {
+        let mut list = PolicyList::default();
+        list.entry(10).set_ext_community = Some(set_ext_community_cfg(
+            &["rt:100:200"],
+            SetCommunityMode::Delete,
+        ));
+
+        let attr = BgpAttr {
+            ecom: Some(ExtCommunity::from([
+                ext_val("rt:100:200"),
+                ext_val("rt:999:999"),
+            ])),
+            ..Default::default()
+        };
+        let out = policy_list_apply(&list, &nlri("10.0.0.0/24"), attr).unwrap();
+        let ecom = out.ecom.expect("ext-community survives");
+        assert_eq!(ecom, ExtCommunity::from([ext_val("rt:999:999")]));
+    }
+
+    // --- set large-community ---------------------------------------------
+
+    fn large_community_set(members: &[&str]) -> LargeCommunitySet {
+        let mut set = LargeCommunitySet::default();
+        for m in members {
+            set.vals
+                .insert(LargeCommunityMatcher::from_str(m).unwrap_or_else(|_| panic!("parse {m}")));
+        }
+        set
+    }
+
+    fn set_large_community_cfg(
+        members: &[&str],
+        mode: SetCommunityMode,
+    ) -> SetLargeCommunityConfig {
+        SetLargeCommunityConfig {
+            name: "test".into(),
+            mode,
+            resolved: Some(large_community_set(members)),
+        }
+    }
+
+    fn lc_val(s: &str) -> LargeCommunityValue {
+        LargeCommunity::from_str(s)
+            .unwrap_or_else(|_| panic!("parse {s}"))
+            .0
+            .into_iter()
+            .next()
+            .unwrap()
+    }
+
+    #[test]
+    fn policy_list_apply_large_community_replace() {
+        let mut list = PolicyList::default();
+        list.entry(10).set_large_community = Some(set_large_community_cfg(
+            &["65001:100:200"],
+            SetCommunityMode::Replace,
+        ));
+
+        let attr = BgpAttr {
+            lcom: Some(LargeCommunity::from_iter([lc_val("1:2:3")])),
+            ..Default::default()
+        };
+        let out = policy_list_apply(&list, &nlri("10.0.0.0/24"), attr).unwrap();
+        let lcom = out.lcom.expect("large-community attribute set");
+        assert_eq!(lcom, LargeCommunity::from_iter([lc_val("65001:100:200")]));
+    }
+
+    #[test]
+    fn policy_list_apply_large_community_additive_preserves_existing() {
+        let mut list = PolicyList::default();
+        list.entry(10).set_large_community = Some(set_large_community_cfg(
+            &["65001:100:200"],
+            SetCommunityMode::Additive,
+        ));
+
+        let attr = BgpAttr {
+            lcom: Some(LargeCommunity::from_iter([lc_val("1:2:3")])),
+            ..Default::default()
+        };
+        let out = policy_list_apply(&list, &nlri("10.0.0.0/24"), attr).unwrap();
+        let lcom = out.lcom.expect("large-community attribute set");
+        assert!(lcom.0.contains(&lc_val("1:2:3")));
+        assert!(lcom.0.contains(&lc_val("65001:100:200")));
+        assert_eq!(lcom.0.len(), 2);
+    }
+
+    #[test]
+    fn policy_list_apply_large_community_delete_drops_attr_when_empty() {
+        let mut list = PolicyList::default();
+        list.entry(10).set_large_community = Some(set_large_community_cfg(
+            &["65001:100:200"],
+            SetCommunityMode::Delete,
+        ));
+
+        let attr = BgpAttr {
+            lcom: Some(LargeCommunity::from_iter([lc_val("65001:100:200")])),
+            ..Default::default()
+        };
+        let out = policy_list_apply(&list, &nlri("10.0.0.0/24"), attr).unwrap();
+        assert!(out.lcom.is_none());
     }
 
     #[test]

--- a/zebra-rs/src/bgp/show.rs
+++ b/zebra-rs/src/bgp/show.rs
@@ -440,6 +440,14 @@ fn show_ecom(attr: &BgpAttr) -> String {
     }
 }
 
+fn show_lcom(attr: &BgpAttr) -> String {
+    if let Some(lcom) = &attr.lcom {
+        lcom.to_string()
+    } else {
+        "".to_string()
+    }
+}
+
 /// Human-readable name for an SRv6 endpoint-behavior codepoint (IANA
 /// "SRv6 Endpoint Behaviors", RFC 8986). Only the L3-service decap
 /// behaviors that ride a BGP Prefix-SID SRv6 L3 Service TLV are named;
@@ -504,10 +512,34 @@ struct BgpRouteJson {
     as_path: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     origin: Option<String>,
+    /// COMMUNITIES attribute rendered as a space-separated list
+    /// (e.g. "65001:100 no-export"); absent when the route carries none.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    community: Option<String>,
+    /// EXT_COMMUNITIES attribute (e.g. "rt:65001:100"); absent when none.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    ext_community: Option<String>,
+    /// LARGE_COMMUNITIES attribute (e.g. "65001:100:200"); absent when none.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    large_community: Option<String>,
     /// Unrecognized optional transitive path attributes (RFC 4271 §9)
     /// carried verbatim on this route. Empty for routes without any.
     #[serde(skip_serializing_if = "Vec::is_empty")]
     unknown_attributes: Vec<UnknownAttrJson>,
+}
+
+/// Render the standard / extended / large COMMUNITIES attributes of a
+/// route into the three optional `show bgp -j` fields (None when the
+/// attribute is absent), shared by every `BgpRouteJson` construction.
+fn show_communities(attr: &BgpAttr) -> (Option<String>, Option<String>, Option<String>) {
+    let com = show_com(attr);
+    let ecom = show_ecom(attr);
+    let lcom = show_lcom(attr);
+    (
+        (!com.is_empty()).then_some(com),
+        (!ecom.is_empty()).then_some(ecom),
+        (!lcom.is_empty()).then_some(lcom),
+    )
 }
 
 /// One unrecognized path attribute (RFC 4271 §9) as rendered for
@@ -546,6 +578,7 @@ fn show_unknown_attrs(attr: &BgpAttr) -> Vec<UnknownAttrJson> {
 fn bgp_route_json(prefix: String, rib: &BgpRib) -> BgpRouteJson {
     let aspath_str = show_aspath(&rib.attr);
     let origin_str = show_origin(&rib.attr);
+    let (community, ext_community, large_community) = show_communities(&rib.attr);
     BgpRouteJson {
         prefix,
         valid: true,
@@ -562,6 +595,9 @@ fn bgp_route_json(prefix: String, rib: &BgpRib) -> BgpRouteJson {
         weight: rib.weight,
         as_path: (!aspath_str.is_empty()).then_some(aspath_str),
         origin: (!origin_str.is_empty()).then_some(origin_str),
+        community,
+        ext_community,
+        large_community,
         unknown_attributes: show_unknown_attrs(&rib.attr),
     }
 }
@@ -822,6 +858,7 @@ where
             for rib in value.iter() {
                 let aspath_str = show_aspath(&rib.attr);
                 let origin_str = show_origin(&rib.attr);
+                let (community, ext_community, large_community) = show_communities(&rib.attr);
                 routes.push(BgpRouteJson {
                     prefix: key.to_string(),
                     valid: true,
@@ -846,6 +883,9 @@ where
                     } else {
                         Some(origin_str)
                     },
+                    community,
+                    ext_community,
+                    large_community,
                     unknown_attributes: show_unknown_attrs(&rib.attr),
                 });
             }
@@ -1978,6 +2018,7 @@ pub(super) fn show_adj_rib_routes<P: std::fmt::Display>(
             for rib in value.iter() {
                 let aspath_str = show_aspath(&rib.attr);
                 let origin_str = show_origin(&rib.attr);
+                let (community, ext_community, large_community) = show_communities(&rib.attr);
 
                 route_list.push(BgpRouteJson {
                     prefix: key.to_string(),
@@ -2003,6 +2044,9 @@ pub(super) fn show_adj_rib_routes<P: std::fmt::Display>(
                     } else {
                         Some(origin_str)
                     },
+                    community,
+                    ext_community,
+                    large_community,
                     unknown_attributes: show_unknown_attrs(&rib.attr),
                 });
             }

--- a/zebra-rs/src/policy/aspath/parser.rs
+++ b/zebra-rs/src/policy/aspath/parser.rs
@@ -2,19 +2,25 @@
 //
 // Each member of an as-path-set is a regular expression matched against the
 // route's AS_PATH attribute rendered as a space-separated string (e.g.
-// "65001 65002 65003" or "65001 {65010 65011} 65003").
+// "65001 65002 65003" or "65001 {65010,65011} 65003"). The regex syntax is
+// compatible with FRR's `bgp as-path access-list`: the `_` magic character
+// expands to `(^|[,{}() ]|$)` (see [`crate::policy::regex::regcomp`]), so the
+// same patterns behave identically on both routers.
 //
 // Examples:
 //   as-path-set CUSTOMER {
-//     member ^65001 .*;        // path starts with 65001 (neighbor-is)
-//     member 65535$;           // path ends with 65535 (originates-from)
-//     member \\b65001\\b;      // 65001 anywhere in the path
+//     member ^65001_;          // path starts with 65001 (neighbor-is)
+//     member _65535$;          // path ends with 65535 (originates-from)
+//     member _65001_;          // 65001 anywhere in the path (transit)
+//     member ^65001 65002$;    // exact two-hop path
 //   }
 
 use std::str::FromStr;
 
 use bgp_packet::BgpAttr;
 use regex::Regex;
+
+use crate::policy::regex::regcomp;
 
 #[derive(Clone)]
 pub struct AsPathMatcher {
@@ -32,7 +38,9 @@ impl FromStr for AsPathMatcher {
     type Err = ();
 
     fn from_str(input: &str) -> Result<Self, Self::Err> {
-        let regex = Regex::new(input).map_err(|_| ())?;
+        // Compile with FRR's `_` magic-character expansion; keep the original
+        // text as `pattern` for show/config round-tripping and dedup.
+        let regex = regcomp(input).map_err(|_| ())?;
         Ok(Self {
             pattern: input.to_string(),
             regex,
@@ -72,7 +80,9 @@ pub fn match_as_path_set(matcher: &AsPathMatcher, bgp_attr: &BgpAttr) -> bool {
     let Some(aspath) = &bgp_attr.aspath else {
         return false;
     };
-    let rendered = aspath.as_path_display();
+    // Match against the FRR-compatible rendering (comma-separated AS_SET
+    // members) so patterns behave exactly as they do on FRR.
+    let rendered = aspath.as_path_frr_string();
     matcher.regex.is_match(&rendered)
 }
 
@@ -120,5 +130,69 @@ mod tests {
     #[test]
     fn invalid_regex_rejected() {
         assert!(AsPathMatcher::from_str("[invalid(").is_err());
+    }
+
+    // --- FRR-compatible `_` magic character -----------------------------
+    //
+    // `_` expands to `(^|[,{}() ]|$)`, so these mirror FRR's `bgp as-path
+    // access-list` behaviour exactly. All patterns below are byte-for-byte
+    // what an operator would configure on FRR.
+
+    #[test]
+    fn magic_neighbor_is() {
+        // `^65002_` — leftmost (neighbor) AS is 65002.
+        let m = AsPathMatcher::from_str("^65002_").unwrap();
+        assert!(match_as_path_set(&m, &attr_with_path("65002 65001")));
+        assert!(!match_as_path_set(&m, &attr_with_path("65001 65002")));
+        // Must not match a longer ASN that merely starts with 65002.
+        assert!(!match_as_path_set(&m, &attr_with_path("650020 65001")));
+    }
+
+    #[test]
+    fn magic_originates_from() {
+        // `_65001$` — rightmost (origin) AS is 65001.
+        let m = AsPathMatcher::from_str("_65001$").unwrap();
+        assert!(match_as_path_set(&m, &attr_with_path("65002 65001")));
+        assert!(match_as_path_set(&m, &attr_with_path("65001")));
+        assert!(!match_as_path_set(&m, &attr_with_path("65001 65002")));
+    }
+
+    #[test]
+    fn magic_transit() {
+        // `_65002_` — 65002 anywhere in the path.
+        let m = AsPathMatcher::from_str("_65002_").unwrap();
+        assert!(match_as_path_set(&m, &attr_with_path("65001 65002 65003")));
+        assert!(match_as_path_set(&m, &attr_with_path("65002 65001")));
+        assert!(match_as_path_set(&m, &attr_with_path("65001 65002")));
+        assert!(!match_as_path_set(
+            &m,
+            &attr_with_path("65001 650020 65003")
+        ));
+        assert!(!match_as_path_set(&m, &attr_with_path("65099")));
+    }
+
+    #[test]
+    fn exact_full_path() {
+        // Anchored exact match of the whole AS_PATH.
+        let m = AsPathMatcher::from_str("^65002 65001$").unwrap();
+        assert!(match_as_path_set(&m, &attr_with_path("65002 65001")));
+        assert!(!match_as_path_set(&m, &attr_with_path("65001 65002")));
+        assert!(!match_as_path_set(&m, &attr_with_path("65002 65001 65003")));
+    }
+
+    #[test]
+    fn magic_matches_across_set_delimiter() {
+        // FRR renders AS_SET members comma-separated: `{65010,65011}`. The
+        // `_` class contains `,` `{` `}`, so `_65010_` matches inside a set.
+        let m = AsPathMatcher::from_str("_65010_").unwrap();
+        assert!(match_as_path_set(
+            &m,
+            &attr_with_path("65001 {65010 65011} 65003")
+        ));
+        let m = AsPathMatcher::from_str("_65011_").unwrap();
+        assert!(match_as_path_set(
+            &m,
+            &attr_with_path("65001 {65010 65011} 65003")
+        ));
     }
 }

--- a/zebra-rs/src/policy/policy_list.rs
+++ b/zebra-rs/src/policy/policy_list.rs
@@ -217,6 +217,49 @@ impl SetCommunityConfig {
     }
 }
 
+/// Set-action config for `set ext-community NAME {|additive|delete}`.
+/// `name` references an ext-community-set; `resolved` is populated by
+/// `policy_entry_sync` from the ext-community-set registry. Reuses
+/// [`SetCommunityMode`]: replace overwrites the EXT_COMMUNITIES
+/// attribute with the set's members, additive merges, delete removes.
+#[derive(Clone, Debug, PartialEq)]
+pub struct SetExtCommunityConfig {
+    pub name: String,
+    pub mode: SetCommunityMode,
+    pub resolved: Option<ExtCommunitySet>,
+}
+
+impl SetExtCommunityConfig {
+    pub fn new(name: String) -> Self {
+        Self {
+            name,
+            mode: SetCommunityMode::Replace,
+            resolved: None,
+        }
+    }
+}
+
+/// Set-action config for `set large-community NAME {|additive|delete}`.
+/// `name` references a large-community-set; `resolved` is populated by
+/// `policy_entry_sync` from the large-community-set registry. Reuses
+/// [`SetCommunityMode`] over the LARGE_COMMUNITIES attribute.
+#[derive(Clone, Debug, PartialEq)]
+pub struct SetLargeCommunityConfig {
+    pub name: String,
+    pub mode: SetCommunityMode,
+    pub resolved: Option<LargeCommunitySet>,
+}
+
+impl SetLargeCommunityConfig {
+    pub fn new(name: String) -> Self {
+        Self {
+            name,
+            mode: SetCommunityMode::Replace,
+            resolved: None,
+        }
+    }
+}
+
 #[derive(Default, Clone, Debug, PartialEq)]
 pub struct PolicyEntry {
     // Match.
@@ -249,6 +292,8 @@ pub struct PolicyEntry {
     pub med: Option<NumericSet>,
     pub weight: Option<u32>,
     pub set_community: Option<SetCommunityConfig>,
+    pub set_ext_community: Option<SetExtCommunityConfig>,
+    pub set_large_community: Option<SetLargeCommunityConfig>,
     pub set_as_path_prepend: Option<AsPathPrependConfig>,
     pub set_next_hop: Option<SetNextHop>,
     pub set_origin: Option<Origin>,
@@ -307,6 +352,12 @@ pub fn policy_entry_sync(
         }
         if let Some(cfg) = policy.set_community.as_mut() {
             cfg.resolved = community_set.config.get(&cfg.name).cloned();
+        }
+        if let Some(cfg) = policy.set_ext_community.as_mut() {
+            cfg.resolved = ext_community_set.config.get(&cfg.name).cloned();
+        }
+        if let Some(cfg) = policy.set_large_community.as_mut() {
+            cfg.resolved = large_community_set.config.get(&cfg.name).cloned();
         }
     }
 }
@@ -1071,6 +1122,135 @@ impl ConfigBuilder {
                 entry.set_community = None;
                 Ok(())
             })
+            // `set ext-community NAME {|additive|delete}` — same presence
+            // container shape as `set community`, over the EXT_COMMUNITIES
+            // attribute. Only exact `rt:`/`soo:` members contribute values.
+            .path("/entry/set/ext-community/name")
+            .set(|policy, cache, name, seq, args| {
+                let list = cache_get(policy, cache, &name).context(ARG_ERR)?;
+                let entry = list.entry(seq);
+                let ext_name = args.string().context(ARG_ERR)?;
+                match entry.set_ext_community.as_mut() {
+                    Some(cfg) => cfg.name = ext_name,
+                    None => entry.set_ext_community = Some(SetExtCommunityConfig::new(ext_name)),
+                }
+                Ok(())
+            })
+            .del(|policy, cache, name, seq, _args| {
+                let list = cache_lookup(policy, cache, &name).context(ARG_ERR)?;
+                let entry = list.lookup(&seq).context(ARG_ERR)?;
+                entry.set_ext_community = None;
+                Ok(())
+            })
+            .path("/entry/set/ext-community/additive")
+            .set(|policy, cache, name, seq, _args| {
+                let list = cache_get(policy, cache, &name).context(ARG_ERR)?;
+                let entry = list.entry(seq);
+                if let Some(cfg) = entry.set_ext_community.as_mut() {
+                    cfg.mode = SetCommunityMode::Additive;
+                }
+                Ok(())
+            })
+            .del(|policy, cache, name, seq, _args| {
+                let list = cache_lookup(policy, cache, &name).context(ARG_ERR)?;
+                let entry = list.lookup(&seq).context(ARG_ERR)?;
+                if let Some(cfg) = entry.set_ext_community.as_mut()
+                    && cfg.mode == SetCommunityMode::Additive
+                {
+                    cfg.mode = SetCommunityMode::Replace;
+                }
+                Ok(())
+            })
+            .path("/entry/set/ext-community/delete")
+            .set(|policy, cache, name, seq, _args| {
+                let list = cache_get(policy, cache, &name).context(ARG_ERR)?;
+                let entry = list.entry(seq);
+                if let Some(cfg) = entry.set_ext_community.as_mut() {
+                    cfg.mode = SetCommunityMode::Delete;
+                }
+                Ok(())
+            })
+            .del(|policy, cache, name, seq, _args| {
+                let list = cache_lookup(policy, cache, &name).context(ARG_ERR)?;
+                let entry = list.lookup(&seq).context(ARG_ERR)?;
+                if let Some(cfg) = entry.set_ext_community.as_mut()
+                    && cfg.mode == SetCommunityMode::Delete
+                {
+                    cfg.mode = SetCommunityMode::Replace;
+                }
+                Ok(())
+            })
+            .path("/entry/set/ext-community")
+            .del(|policy, cache, name, seq, _args| {
+                let list = cache_lookup(policy, cache, &name).context(ARG_ERR)?;
+                let entry = list.lookup(&seq).context(ARG_ERR)?;
+                entry.set_ext_community = None;
+                Ok(())
+            })
+            // `set large-community NAME {|additive|delete}` — same shape,
+            // over the LARGE_COMMUNITIES attribute.
+            .path("/entry/set/large-community/name")
+            .set(|policy, cache, name, seq, args| {
+                let list = cache_get(policy, cache, &name).context(ARG_ERR)?;
+                let entry = list.entry(seq);
+                let lc_name = args.string().context(ARG_ERR)?;
+                match entry.set_large_community.as_mut() {
+                    Some(cfg) => cfg.name = lc_name,
+                    None => entry.set_large_community = Some(SetLargeCommunityConfig::new(lc_name)),
+                }
+                Ok(())
+            })
+            .del(|policy, cache, name, seq, _args| {
+                let list = cache_lookup(policy, cache, &name).context(ARG_ERR)?;
+                let entry = list.lookup(&seq).context(ARG_ERR)?;
+                entry.set_large_community = None;
+                Ok(())
+            })
+            .path("/entry/set/large-community/additive")
+            .set(|policy, cache, name, seq, _args| {
+                let list = cache_get(policy, cache, &name).context(ARG_ERR)?;
+                let entry = list.entry(seq);
+                if let Some(cfg) = entry.set_large_community.as_mut() {
+                    cfg.mode = SetCommunityMode::Additive;
+                }
+                Ok(())
+            })
+            .del(|policy, cache, name, seq, _args| {
+                let list = cache_lookup(policy, cache, &name).context(ARG_ERR)?;
+                let entry = list.lookup(&seq).context(ARG_ERR)?;
+                if let Some(cfg) = entry.set_large_community.as_mut()
+                    && cfg.mode == SetCommunityMode::Additive
+                {
+                    cfg.mode = SetCommunityMode::Replace;
+                }
+                Ok(())
+            })
+            .path("/entry/set/large-community/delete")
+            .set(|policy, cache, name, seq, _args| {
+                let list = cache_get(policy, cache, &name).context(ARG_ERR)?;
+                let entry = list.entry(seq);
+                if let Some(cfg) = entry.set_large_community.as_mut() {
+                    cfg.mode = SetCommunityMode::Delete;
+                }
+                Ok(())
+            })
+            .del(|policy, cache, name, seq, _args| {
+                let list = cache_lookup(policy, cache, &name).context(ARG_ERR)?;
+                let entry = list.lookup(&seq).context(ARG_ERR)?;
+                if let Some(cfg) = entry.set_large_community.as_mut()
+                    && cfg.mode == SetCommunityMode::Delete
+                {
+                    cfg.mode = SetCommunityMode::Replace;
+                }
+                Ok(())
+            })
+            .path("/entry/set/large-community")
+            .del(|policy, cache, name, seq, _args| {
+                let list = cache_lookup(policy, cache, &name).context(ARG_ERR)?;
+                let entry = list.lookup(&seq).context(ARG_ERR)?;
+                entry.set_large_community = None;
+                Ok(())
+            })
             // `set as-path-prepend ASN [repeat NUM]` is modeled as
             // a presence container with two leaves. YANG fires
             // callbacks per leaf, so we patch the partial config
@@ -1323,6 +1503,28 @@ fn entry_to_json(seq: u32, entry: &PolicyEntry) -> serde_json::Value {
             json!({ "name": cfg.name, "mode": mode }),
         );
     }
+    if let Some(cfg) = &entry.set_ext_community {
+        let mode = match cfg.mode {
+            SetCommunityMode::Replace => "replace",
+            SetCommunityMode::Additive => "additive",
+            SetCommunityMode::Delete => "delete",
+        };
+        s.insert(
+            "ext_community".into(),
+            json!({ "name": cfg.name, "mode": mode }),
+        );
+    }
+    if let Some(cfg) = &entry.set_large_community {
+        let mode = match cfg.mode {
+            SetCommunityMode::Replace => "replace",
+            SetCommunityMode::Additive => "additive",
+            SetCommunityMode::Delete => "delete",
+        };
+        s.insert(
+            "large_community".into(),
+            json!({ "name": cfg.name, "mode": mode }),
+        );
+    }
     if let Some(p) = &entry.set_as_path_prepend {
         s.insert(
             "as_path_prepend".into(),
@@ -1439,6 +1641,22 @@ pub fn show(policy: &Policy, _args: Args, json: bool) -> Result<String, Error> {
                     SetCommunityMode::Delete => " delete",
                 };
                 let _ = writeln!(buf, "  set: community {}{}", cfg.name, suffix);
+            }
+            if let Some(cfg) = &entry.set_ext_community {
+                let suffix = match cfg.mode {
+                    SetCommunityMode::Replace => "",
+                    SetCommunityMode::Additive => " additive",
+                    SetCommunityMode::Delete => " delete",
+                };
+                let _ = writeln!(buf, "  set: ext-community {}{}", cfg.name, suffix);
+            }
+            if let Some(cfg) = &entry.set_large_community {
+                let suffix = match cfg.mode {
+                    SetCommunityMode::Replace => "",
+                    SetCommunityMode::Additive => " additive",
+                    SetCommunityMode::Delete => " delete",
+                };
+                let _ = writeln!(buf, "  set: large-community {}{}", cfg.name, suffix);
             }
             if let Some(prepend) = &entry.set_as_path_prepend {
                 let _ = writeln!(

--- a/zebra-rs/src/policy/regex.rs
+++ b/zebra-rs/src/policy/regex.rs
@@ -1,19 +1,28 @@
-#![allow(dead_code)]
-
-// Character '_' has special meanings. It represents [,{}() ] and the beginning of
-// the line(^) and the end of the line ($).
+// BGP AS-path regular-expression compilation, compatible with FRR's
+// `bgp_regcomp` (`bgpd/bgp_regex.c`).
+//
+// The character `_` has a special meaning in AS-path regexes: it stands for
+// the set `[,{}() ]` plus the beginning of the line (`^`) and the end of the
+// line (`$`) — i.e. it is expanded to `(^|[,{}() ]|$)`. This lets patterns
+// like `_65001_` match an ASN wherever it sits in the path (origin, transit,
+// or neighbor) regardless of the surrounding separators. FRR does exactly the
+// same textual substitution before compiling the POSIX regex.
 
 use regex::Regex;
 use std::sync::LazyLock;
 
 static UNDERSCORE_RE: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"_").unwrap());
 
+/// Expand FRR's `_` magic character to `(^|[,{}() ]|$)`.
 fn magic_replace(s: &str) -> String {
     let magic_regxp = "(^|[,{}() ]|$)";
     let replaced = UNDERSCORE_RE.replace_all(s, magic_regxp);
     replaced.to_string()
 }
 
+/// Compile an AS-path regular expression with FRR-compatible `_` handling.
+/// Mirrors FRR's `bgp_regcomp`: the `_` magic character is expanded before
+/// the pattern is handed to the regex engine.
 pub fn regcomp(s: &str) -> Result<Regex, regex::Error> {
     let replaced = magic_replace(s);
     Regex::new(&replaced)

--- a/zebra-rs/yang/config.yang
+++ b/zebra-rs/yang/config.yang
@@ -4038,7 +4038,12 @@ module config {
         description
           "Regular expression members matched against the route's
            AS_PATH attribute, rendered as a space-separated list of
-           ASNs (e.g. \"65001 65002 65003\").";
+           ASNs (e.g. \"65001 65002 65003\"; AS_SET members are
+           comma-separated, e.g. \"{65010,65011}\"). Syntax is
+           compatible with FRR's `bgp as-path access-list`: the `_`
+           magic character expands to (^|[,{}() ]|$), so `_65001_`
+           matches AS 65001 anywhere in the path, `^65001_` matches the
+           neighbor AS, and `_65001$` matches the origin AS.";
       }
     }
 
@@ -4669,6 +4674,97 @@ module config {
                   description
                     "Remove the set's members from the existing
                      COMMUNITIES attribute.";
+                }
+              }
+            }
+          }
+          container "ext-community" {
+            ext:help "Set/add/delete route extended communities";
+            presence "set ext-community";
+            description
+              "Apply an ext-community-set to the route. Same
+               {replace|additive|delete} choice as `set community`,
+               applied to the EXT_COMMUNITIES attribute. Only exact
+               `rt:`/`soo:` members of the set contribute concrete
+               values; regex members are skipped. replace (default)
+               overwrites the attribute — including any route targets
+               or Color community already present — so use additive to
+               preserve them.";
+            leaf "name" {
+              ext:help "Ext-community-set to apply";
+              type string;
+              mandatory true;
+              description
+                "Reference to an ext-community-set by name.";
+            }
+            choice "mode" {
+              default replace-case;
+              description
+                "Operation applied to the route's EXT_COMMUNITIES
+                 attribute.";
+              case replace-case {
+                description "Default — overwrite the attribute.";
+              }
+              case additive-case {
+                leaf "additive" {
+                  ext:help "Merge into existing ext-communities";
+                  type empty;
+                  description
+                    "Merge the set's members into the existing
+                     EXT_COMMUNITIES attribute.";
+                }
+              }
+              case delete-case {
+                leaf "delete" {
+                  ext:help "Remove from existing ext-communities";
+                  type empty;
+                  description
+                    "Remove the set's members from the existing
+                     EXT_COMMUNITIES attribute.";
+                }
+              }
+            }
+          }
+          container "large-community" {
+            ext:help "Set/add/delete route large communities";
+            presence "set large-community";
+            description
+              "Apply a large-community-set to the route. Same
+               {replace|additive|delete} choice as `set community`,
+               applied to the LARGE_COMMUNITIES attribute. Only exact
+               `A:B:C` members contribute concrete values; regex
+               members are skipped.";
+            leaf "name" {
+              ext:help "Large-community-set to apply";
+              type string;
+              mandatory true;
+              description
+                "Reference to a large-community-set by name.";
+            }
+            choice "mode" {
+              default replace-case;
+              description
+                "Operation applied to the route's LARGE_COMMUNITIES
+                 attribute.";
+              case replace-case {
+                description "Default — overwrite the attribute.";
+              }
+              case additive-case {
+                leaf "additive" {
+                  ext:help "Merge into existing large communities";
+                  type empty;
+                  description
+                    "Merge the set's members into the existing
+                     LARGE_COMMUNITIES attribute.";
+                }
+              }
+              case delete-case {
+                leaf "delete" {
+                  ext:help "Remove from existing large communities";
+                  type empty;
+                  description
+                    "Remove the set's members from the existing
+                     LARGE_COMMUNITIES attribute.";
                 }
               }
             }


### PR DESCRIPTION
## Summary

Two related BGP routing-policy improvements, developed and tested together.

### 1. FRR-compatible AS-path match regex
- `as-path-set` members now compile through FRR's `_` magic-character expansion (`regcomp` → `(^|[,{}() ]|$)`), matching against FRR's `aspath->str` rendering (AS_SET members comma-separated). Previously members compiled as raw Rust regex, so FRR patterns like `_65001_` did not work.
- Exact (`^…$`), origin (`_ASN$`), neighbor (`^ASN_`), and transit (`_ASN_`) idioms now behave identically to FRR's `bgp as-path access-list`.
- New `bgp_as_path_match` BDD (3-node eBGP chain).

### 2. `set ext-community` / `set large-community` policy actions
- New set-actions mirroring `set community` (replace / additive / delete); only exact members contribute concrete values, regex members are skipped.
- `show bgp -j` now surfaces `community`, `ext_community`, and `large_community` route fields (backward-compatible, optional).
- New `bgp_set_ext_large_community` BDD.

Book: policy Match and Set chapters updated for both.

## Test plan
- `cargo fmt --all` clean; `cargo clippy --workspace --all-targets -- -D warnings` clean.
- Unit tests: 1514 zebra-rs bin + 400+ bgp-packet pass (incl. new `_`-magic matcher tests, FRR-string rendering test, and 7 `set ext/large-community` apply tests).
- BDD: `@bgp_as_path_match` (8 scenarios) and `@bgp_set_ext_large_community` (5 scenarios) both green; tag-guard passes.
- Book builds with mdbook.

Generated with [Claude Code](https://claude.com/claude-code)