### PR TITLE
packaging: drop redundant --features lua from release build

### DIFF
--- a/packaging/Makefile
+++ b/packaging/Makefile
@@ -1,12 +1,12 @@
 all: arm64
 
 arm64: ../vty/vty
-	cargo build --release --features lua
+	cargo build --release
 	$(MAKE) -C .. xdp-bfd-echo
 	nfpm package --packager=deb --config=nfpm-arm64.yaml
 
 amd64: ../vty/vty
-	cargo build --release --features lua
+	cargo build --release
 	$(MAKE) -C .. xdp-bfd-echo
 	nfpm package --packager=deb --config=nfpm-amd64.yaml
 


### PR DESCRIPTION
## Summary
- Lua policy scripting is now enabled by default, so the explicit `--features lua` flag is no longer required when building the packaged release binaries.
- Removes `--features lua` from both the `arm64` and `amd64` targets in `packaging/Makefile`.

## Test plan
- `make -C packaging amd64` / `arm64` build the release binary and produce the `.deb` package as before (Lua still compiled in via the default feature set).

Generated with [Claude Code](https://claude.com/claude-code)