### PR TITLE
packaging: correct homepage and license metadata

### DIFF
--- a/packaging/nfpm-amd64.yaml
+++ b/packaging/nfpm-amd64.yaml
@@ -19,8 +19,8 @@ provides:
 maintainer: "Kunihiro Ishiguro <kunihiro@zebra.rs>"
 description: |
   zebra-rs is reincarnation of GNU zebra in Rust.
-homepage: "https://zebra.dev"
-license: "MIT"
+homepage: "https://zebra.rs"
+license: "AGPLv3"
 changelog: "../CHANGELOG.yaml"
 contents:
   - src: ../target/release/zebra-rs

--- a/packaging/nfpm-arm64.yaml
+++ b/packaging/nfpm-arm64.yaml
@@ -19,8 +19,8 @@ provides:
 maintainer: "Kunihiro Ishiguro <kunihiro@zebra.rs>"
 description: |
   zebra-rs is reincarnation of GNU zebra in Rust.
-homepage: "https://zebra.dev"
-license: "MIT"
+homepage: "https://zebra.rs"
+license: "AGPLv3"
 changelog: "../CHANGELOG.yaml"
 contents:
   - src: ../target/release/zebra-rs


### PR DESCRIPTION
## Summary

Fixes incorrect package metadata in the nfpm packaging configs for both architectures:

- **homepage**: `https://zebra.dev` → `https://zebra.rs`
- **license**: `MIT` → `AGPLv3`

The license correction aligns the packages with the project's actual license, declared as `AGPL-3.0-or-later` in the workspace `Cargo.toml`.

## Test plan

- Metadata-only change to `packaging/nfpm-{amd64,arm64}.yaml`; no code paths affected.
- Verified `license = "AGPL-3.0-or-later"` in the workspace `Cargo.toml`.

Generated with [Claude Code](https://claude.com/claude-code)