### PR TITLE
Add system/cradle/enabled knob with unix:cradle/grpc abstract tee

### DIFF
--- a/zebra-rs/Cargo.toml
+++ b/zebra-rs/Cargo.toml
@@ -21,6 +21,10 @@ tokio.workspace = true
 tokio-stream.workspace = true
 tonic.workspace = true
 tonic-prost.workspace = true
+# For dialing the cradle tee over a Linux abstract Unix socket (tonic's
+# built-in UDS connector is filesystem-path only). Mirrors vtyhelper.
+tower = { version = "0.5", default-features = false, features = ["util"] }
+hyper-util = { version = "0.1", features = ["tokio"] }
 console-subscriber = "0.5"
 libyang = "1"
 #libyang = { git = "https://github.com/zebra-rs/libyang", rev = "103b60c2d560a91d37fa26502eb3d495db1cdb99" }

--- a/zebra-rs/src/config/manager.rs
+++ b/zebra-rs/src/config/manager.rs
@@ -2697,6 +2697,37 @@ mod yang_load_tests {
         );
     }
 
+    /// The cradle eBPF integration exposes two settable knobs under the
+    /// `system` container: the `system cradle enabled <bool>` master switch
+    /// (dispatched in `rib/inst.rs` at the literal `/system/cradle/enabled`
+    /// path) and the optional `system cradle-grpc <endpoint>` override. Pin
+    /// both at the grammar level so a typo in the container/leaf naming
+    /// (which `load_mode` would not catch) fails loudly.
+    #[test]
+    fn cradle_knobs_are_settable() {
+        use crate::config::ExecCode;
+        use crate::config::parse::{State, parse};
+        use libyang::to_entry;
+
+        let mut yang = YangStore::new();
+        yang.add_path(concat!(env!("CARGO_MANIFEST_DIR"), "/yang"));
+        yang.read_with_resolve("configure")
+            .expect("configure mode loads");
+        yang.identity_resolve();
+        let module = yang
+            .find_module("configure")
+            .expect("configure module present");
+        let entry = to_entry(&yang, module);
+
+        for cmd in [
+            "set system cradle enabled true",
+            "set system cradle-grpc unix:cradle/grpc",
+        ] {
+            let (code, _comps, _state) = parse(cmd, entry.clone(), None, State::new());
+            assert_eq!(code, ExecCode::Success, "must be a settable path: {cmd}");
+        }
+    }
+
     /// A new BGP-neighbor YANG knob must be a *settable* path, not just a
     /// loadable module. Naming it the same as a leaf already present via
     /// `uses ietf-bgp:bgp` makes the augment silently dropped (RFC 7950

--- a/zebra-rs/src/fib/cradle.rs
+++ b/zebra-rs/src/fib/cradle.rs
@@ -122,9 +122,54 @@ pub struct CradleFib {
     encap_src_set: Arc<std::sync::atomic::AtomicBool>,
 }
 
+/// Connect a cradle gRPC client. `unix:/path` (filesystem UDS) and
+/// `http://…` dial through tonic's built-in support; `unix:NAME` (no leading
+/// `/`) is a Linux abstract socket — the default `unix:cradle/grpc` — which
+/// tonic can't dial natively, so it gets a custom connector.
+async fn connect_cradle(endpoint: &str) -> anyhow::Result<CradleClient<Channel>> {
+    if let Some(name) = endpoint.strip_prefix("unix:") {
+        if !name.starts_with('/') {
+            return connect_abstract_cradle(name.trim_start_matches('@')).await;
+        }
+    }
+    Ok(CradleClient::connect(endpoint.to_string()).await?)
+}
+
+/// Dial a cradle server on a Linux abstract Unix socket by name. tonic's UDS
+/// connector calls `UnixStream::connect(path)` (filesystem only), so we hand
+/// it a connector that dials the abstract address. Mirrors `vtyhelper`.
+async fn connect_abstract_cradle(name: &str) -> anyhow::Result<CradleClient<Channel>> {
+    use hyper_util::rt::TokioIo;
+    use std::os::linux::net::SocketAddrExt;
+    use std::os::unix::net::{SocketAddr as StdSockAddr, UnixStream as StdUnixStream};
+    use tokio::net::UnixStream;
+    use tonic::transport::Endpoint;
+    use tower::service_fn;
+
+    let name = name.to_string();
+    // The URI is a placeholder; the connector ignores it and dials the
+    // abstract Unix socket each time tonic calls it.
+    let channel = Endpoint::try_from("http://[::]:50051")?
+        .connect_with_connector(service_fn(move |_: tonic::transport::Uri| {
+            let name = name.clone();
+            async move {
+                let addr = StdSockAddr::from_abstract_name(name.as_bytes())
+                    .map_err(std::io::Error::other)?;
+                let std = StdUnixStream::connect_addr(&addr)?;
+                std.set_nonblocking(true)?;
+                let stream = UnixStream::from_std(std)?;
+                Ok::<_, std::io::Error>(TokioIo::new(stream))
+            }
+        }))
+        .await?;
+    Ok(CradleClient::new(channel))
+}
+
 impl CradleFib {
-    /// Build a tee to the cradle gRPC endpoint `ep`. `unix:/path` (UDS) and
-    /// `http://...` pass through; a bare `host:port` is treated as TCP.
+    /// Build a tee to the cradle gRPC endpoint `ep`. `unix:/path` (filesystem
+    /// UDS), `unix:NAME` (Linux abstract socket, e.g. the default
+    /// `unix:cradle/grpc`), and `http://...` pass through; a bare `host:port`
+    /// is treated as TCP.
     pub fn new(ep: &str) -> Self {
         let endpoint = if ep.starts_with("unix:") || ep.starts_with("http") {
             ep.to_string()
@@ -154,7 +199,7 @@ impl CradleFib {
     async fn client(&self) -> anyhow::Result<CradleClient<Channel>> {
         let mut guard = self.client.lock().await;
         if guard.is_none() {
-            *guard = Some(CradleClient::connect(self.endpoint.clone()).await?);
+            *guard = Some(connect_cradle(&self.endpoint).await?);
         }
         Ok(guard.as_ref().unwrap().clone())
     }

--- a/zebra-rs/src/fib/cradle.rs
+++ b/zebra-rs/src/fib/cradle.rs
@@ -127,10 +127,11 @@ pub struct CradleFib {
 /// `/`) is a Linux abstract socket — the default `unix:cradle/grpc` — which
 /// tonic can't dial natively, so it gets a custom connector.
 async fn connect_cradle(endpoint: &str) -> anyhow::Result<CradleClient<Channel>> {
-    if let Some(name) = endpoint.strip_prefix("unix:") {
-        if !name.starts_with('/') {
-            return connect_abstract_cradle(name.trim_start_matches('@')).await;
-        }
+    if let Some(name) = endpoint
+        .strip_prefix("unix:")
+        .filter(|name| !name.starts_with('/'))
+    {
+        return connect_abstract_cradle(name.trim_start_matches('@')).await;
     }
     Ok(CradleClient::connect(endpoint.to_string()).await?)
 }

--- a/zebra-rs/src/rib/inst.rs
+++ b/zebra-rs/src/rib/inst.rs
@@ -742,6 +742,11 @@ pub struct Rib {
     /// EVPN Type-2 origination); aborted and respawned when the
     /// `system cradle-grpc` endpoint changes.
     pub cradle_fdb_watch: Option<tokio::task::JoinHandle<()>>,
+    /// `system cradle enabled` — master switch for the cradle eBPF tee.
+    pub cradle_enabled: bool,
+    /// `system cradle-grpc <endpoint>` override. When the tee is enabled
+    /// but this is unset, the endpoint defaults to `unix:cradle/grpc`.
+    pub cradle_grpc: Option<String>,
     pub cm: ConfigChannel,
     pub show: ShowChannel,
     pub show_cb: HashMap<String, ShowCallback>,
@@ -973,6 +978,8 @@ impl Rib {
         let (inbound_tx, inbound_rx) = mpsc::unbounded_channel();
         let mut rib = Rib {
             cradle_fdb_watch: None,
+            cradle_enabled: false,
+            cradle_grpc: None,
             cm: ConfigChannel::new(),
             show: ShowChannel::new(),
             show_cb: HashMap::new(),
@@ -3749,9 +3756,24 @@ impl Rib {
         Some((vni, vtep_local))
     }
 
-    /// `set system cradle-grpc <endpoint>` enables (or re-points) the cradle
-    /// eBPF data-plane tee; deleting it disables the tee. Mirrors
-    /// `router_id_config_exec`. The endpoint is `unix:/path`, `http://host:port`
+    /// `set system cradle enabled <bool>` — master switch for the cradle
+    /// eBPF data-plane tee. Deleting it (or setting false) disables the tee
+    /// unless a `system cradle-grpc` endpoint keeps it on.
+    #[cfg(target_os = "linux")]
+    pub(crate) fn cradle_enabled_config_exec(
+        &mut self,
+        mut args: crate::config::Args,
+        op: ConfigOp,
+    ) -> Option<()> {
+        self.cradle_enabled = op.is_set() && args.boolean()?;
+        self.cradle_apply();
+        Some(())
+    }
+
+    /// `set system cradle-grpc <endpoint>` overrides (or re-points) the cradle
+    /// tee endpoint; deleting it falls back to the `unix:cradle/grpc` default
+    /// (when the tee is otherwise enabled). Setting it also enables the tee on
+    /// its own. The endpoint is `unix:NAME` / `unix:/path`, `http://host:port`
     /// or a bare `host:port` (treated as TCP).
     #[cfg(target_os = "linux")]
     pub(crate) fn cradle_grpc_config_exec(
@@ -3759,46 +3781,66 @@ impl Rib {
         mut args: crate::config::Args,
         op: ConfigOp,
     ) -> Option<()> {
+        self.cradle_grpc = if op.is_set() {
+            Some(args.string()?)
+        } else {
+            None
+        };
+        self.cradle_apply();
+        Some(())
+    }
+
+    /// Effective cradle tee endpoint: `None` when disabled, else the
+    /// `system cradle-grpc` override or the `unix:cradle/grpc` default.
+    #[cfg(target_os = "linux")]
+    fn cradle_endpoint(&self) -> Option<String> {
+        cradle_effective_endpoint(self.cradle_enabled, self.cradle_grpc.as_deref())
+    }
+
+    /// Re-derive the cradle tee from the current `enabled` / `cradle-grpc`
+    /// state and (re)start or stop the forward tee plus the reverse
+    /// `WatchFdb` subscriber accordingly. Called on any change to either
+    /// config knob.
+    #[cfg(target_os = "linux")]
+    fn cradle_apply(&mut self) {
         // Tear down any previous watcher before re-pointing/disabling.
         if let Some(watch) = self.cradle_fdb_watch.take() {
             watch.abort();
         }
-        if op.is_set() {
-            let endpoint = args.string()?;
-            self.fib_handle.set_cradle(Some(&endpoint));
-            // The reverse channel: subscribe to cradle's datapath MAC
-            // learning and feed each entry back into this RIB as a
-            // `CradleFdbLearn`, which re-emits it to EVPN subscribers.
-            // Reconnects with backoff for the daemon-lifetime.
-            let cradle = crate::fib::cradle::CradleFib::new(&endpoint);
-            let tx = self.tx.clone();
-            self.cradle_fdb_watch = Some(tokio::spawn(async move {
-                loop {
-                    match cradle.watch_fdb().await {
-                        Ok(mut stream) => {
-                            while let Ok(Some(ev)) = stream.message().await {
-                                let Ok(mac) = ev.mac.parse::<MacAddr>() else {
-                                    continue;
-                                };
-                                let msg = if ev.event == 1 {
-                                    Message::CradleFdbAge { vni: ev.bd, mac }
-                                } else {
-                                    Message::CradleFdbLearn { vni: ev.bd, mac }
-                                };
-                                let _ = tx.send(msg);
-                            }
-                        }
-                        Err(e) => {
-                            tracing::debug!("rib: cradle WatchFdb connect failed: {e}");
+        let Some(endpoint) = self.cradle_endpoint() else {
+            self.fib_handle.set_cradle(None);
+            return;
+        };
+        self.fib_handle.set_cradle(Some(&endpoint));
+        // The reverse channel: subscribe to cradle's datapath MAC learning
+        // and feed each entry back into this RIB as a `CradleFdbLearn`, which
+        // re-emits it to EVPN subscribers. Reconnects with backoff for the
+        // daemon lifetime.
+        let cradle = crate::fib::cradle::CradleFib::new(&endpoint);
+        let tx = self.tx.clone();
+        self.cradle_fdb_watch = Some(tokio::spawn(async move {
+            loop {
+                match cradle.watch_fdb().await {
+                    Ok(mut stream) => {
+                        while let Ok(Some(ev)) = stream.message().await {
+                            let Ok(mac) = ev.mac.parse::<MacAddr>() else {
+                                continue;
+                            };
+                            let msg = if ev.event == 1 {
+                                Message::CradleFdbAge { vni: ev.bd, mac }
+                            } else {
+                                Message::CradleFdbLearn { vni: ev.bd, mac }
+                            };
+                            let _ = tx.send(msg);
                         }
                     }
-                    tokio::time::sleep(std::time::Duration::from_secs(2)).await;
+                    Err(e) => {
+                        tracing::debug!("rib: cradle WatchFdb connect failed: {e}");
+                    }
                 }
-            }));
-        } else {
-            self.fib_handle.set_cradle(None);
-        }
-        Some(())
+                tokio::time::sleep(std::time::Duration::from_secs(2)).await;
+            }
+        }));
     }
 
     /// A cradle-datapath MAC learn: synthesize the same `FdbEntry` a kernel
@@ -3859,6 +3901,9 @@ impl Rib {
                 let (path, mut args) = path_from_command(&msg.paths);
                 if path.as_str() == "/system/router-id" {
                     let _ = self.router_id_config_exec(args, msg.op);
+                } else if path.as_str() == "/system/cradle/enabled" {
+                    #[cfg(target_os = "linux")]
+                    let _ = self.cradle_enabled_config_exec(args, msg.op);
                 } else if path.as_str() == "/system/cradle-grpc" {
                     #[cfg(target_os = "linux")]
                     let _ = self.cradle_grpc_config_exec(args, msg.op);
@@ -4240,6 +4285,18 @@ fn neighbor_key(nbr: &FibNeighbor) -> Option<NeighborKey> {
     }
 }
 
+/// Resolve the effective cradle tee endpoint from the two `system cradle`
+/// knobs. `None` disables the tee. The tee is active when `enabled` is true,
+/// or (for backward compatibility) when a `cradle-grpc` override is set on its
+/// own; the endpoint is that override, else the `unix:cradle/grpc` default.
+fn cradle_effective_endpoint(enabled: bool, grpc: Option<&str>) -> Option<String> {
+    if enabled || grpc.is_some() {
+        Some(grpc.unwrap_or("unix:cradle/grpc").to_string())
+    } else {
+        None
+    }
+}
+
 pub fn serve(mut rib: Rib) {
     let rib_tx = rib.tx.clone();
     tokio::spawn(async move {
@@ -4257,4 +4314,38 @@ pub fn serve(mut rib: Rib) {
         let _ = rx.await;
         std::process::exit(0);
     });
+}
+
+#[cfg(test)]
+mod cradle_endpoint_tests {
+    use super::cradle_effective_endpoint;
+
+    #[test]
+    fn disabled_without_override_is_none() {
+        assert_eq!(cradle_effective_endpoint(false, None), None);
+    }
+
+    #[test]
+    fn enabled_without_override_uses_default() {
+        assert_eq!(
+            cradle_effective_endpoint(true, None).as_deref(),
+            Some("unix:cradle/grpc"),
+        );
+    }
+
+    #[test]
+    fn override_wins_when_enabled() {
+        assert_eq!(
+            cradle_effective_endpoint(true, Some("unix:/tmp/c.sock")).as_deref(),
+            Some("unix:/tmp/c.sock"),
+        );
+    }
+
+    #[test]
+    fn override_alone_enables_tee_for_backward_compat() {
+        assert_eq!(
+            cradle_effective_endpoint(false, Some("127.0.0.1:50151")).as_deref(),
+            Some("127.0.0.1:50151"),
+        );
+    }
 }

--- a/zebra-rs/yang/config.yang
+++ b/zebra-rs/yang/config.yang
@@ -423,12 +423,28 @@ module config {
         ext:help "Global router identifier";
         type inet:ipv4-address;
       }
-      // gRPC endpoint of a cradle eBPF data plane to tee FIB route
+      // The zebra-rs side of the cradle-rs eBPF data-plane integration:
+      // when active, every route zebra-rs installs is teed to cradle in
+      // addition to the kernel, and cradle's datapath MAC learning is fed
+      // back into EVPN (see `rib/inst.rs cradle_apply`). The tee is active
+      // when `system cradle enabled true` is set, or (for backward
+      // compatibility) when `system cradle-grpc` is set on its own.
+      container cradle {
+        ext:help "cradle eBPF data-plane integration";
+        leaf enabled {
+          ext:help "Enable the cradle eBPF data-plane tee";
+          type boolean;
+          description
+            "Enables the cradle eBPF data-plane tee. The endpoint is
+             `system cradle-grpc` when set, otherwise the default
+             `unix:cradle/grpc` (a Linux abstract socket, matching
+             cradle's own default).";
+        }
+      }
+      // gRPC endpoint of the cradle eBPF data plane to tee FIB route
       // installs to (e.g. `unix:/run/cradle.sock` or `127.0.0.1:50151`).
-      // When set, every route zebra-rs installs is pushed to cradle in
-      // addition to the kernel (see `rib/inst.rs cradle_grpc_config_exec`);
-      // unset disables the tee. The zebra-rs side of the cradle-rs eBPF
-      // data-plane integration.
+      // Optional override for the `system cradle enabled` default endpoint
+      // `unix:cradle/grpc`; setting it also enables the tee on its own.
       leaf cradle-grpc {
         ext:help "cradle eBPF data-plane gRPC endpoint";
         type string;


### PR DESCRIPTION
## Summary
Add a `/system/cradle/enabled` boolean knob for the cradle eBPF data-plane
tee, defaulting the endpoint to `unix:cradle/grpc` when no `system cradle-grpc`
override is set. For backward compatibility, setting `cradle-grpc` alone still
enables the tee, so existing configs are unaffected.

- **yang/config.yang**: add the `cradle { enabled }` container under `system`.
- **rib/inst.rs**: store enabled/grpc state; one `cradle_apply()` re-derives the
  effective endpoint and (re)starts/stops the forward tee and the reverse
  `WatchFdb` subscriber. `cradle_effective_endpoint()` is unit-tested.
- **config/manager.rs**: grammar test pinning both settable paths.
- **fib/cradle.rs**: `CradleFib` now dials Linux abstract Unix sockets
  (`unix:NAME`) — tonic's built-in UDS connector is filesystem-only, so the
  default `unix:cradle/grpc` was unreachable (every tee call failed with a
  transport error and traffic silently fell back to kernel forwarding). One
  choke point covers the forward tee and the reverse `WatchFdb` channel.

## Test plan
- `cargo test -p zebra-rs`: new `cradle_effective_endpoint` truth-table tests
  and `cradle_knobs_are_settable` grammar test pass; config (292) and rib (217)
  modules green.
- Verified end-to-end via the cradle-rs BDD suite over netns (`system cradle
  enabled true` → tee to `unix:cradle/grpc`), with data-plane counters nonzero.

**Requires the matching cradle-rs change** (abstract-socket default); a mixed
pair silently falls back to kernel forwarding.

Generated with [Claude Code](https://claude.com/claude-code)
