### PR TITLE
Fix clippy 1.97 lints across the workspace

### DIFF
--- a/crates/bgp-packet/src/bgp_cap.rs
+++ b/crates/bgp-packet/src/bgp_cap.rs
@@ -30,7 +30,7 @@ pub struct BgpCap {
 
 impl BgpCap {
     pub fn emit(&self, buf: &mut BytesMut) {
-        for (_, v) in self.mp.iter() {
+        for v in self.mp.values() {
             v.emit(buf, false);
         }
         if let Some(v) = &self.refresh {
@@ -50,7 +50,7 @@ impl BgpCap {
         }
         if !self.restart.is_empty() {
             let mut v = CapRestart::default();
-            for (_, val) in self.restart.iter() {
+            for val in self.restart.values() {
                 v.values.push(val.clone());
             }
             v.emit(buf, false);
@@ -63,14 +63,14 @@ impl BgpCap {
         }
         if !self.addpath.is_empty() {
             let mut v = CapAddPath::default();
-            for (_, val) in self.addpath.iter() {
+            for val in self.addpath.values() {
                 v.values.push(val.clone());
             }
             v.emit(buf, false);
         }
         if !self.llgr.is_empty() {
             let mut v = CapLlgr::default();
-            for (_, val) in self.llgr.iter() {
+            for val in self.llgr.values() {
                 v.values.push(val.clone());
             }
             v.emit(buf, false);
@@ -83,7 +83,7 @@ impl BgpCap {
         }
         if !self.path_limit.is_empty() {
             let mut v = CapPathLimit::default();
-            for (_, val) in self.path_limit.iter() {
+            for val in self.path_limit.values() {
                 v.values.push(val.clone());
             }
             v.emit(buf, false);
@@ -168,7 +168,7 @@ impl BgpCap {
 
 impl fmt::Display for BgpCap {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        for (_, v) in self.mp.iter() {
+        for v in self.mp.values() {
             writeln!(f, " {}", v)?;
         }
         if let Some(v) = &self.refresh {
@@ -185,7 +185,7 @@ impl fmt::Display for BgpCap {
         }
         if !self.restart.is_empty() {
             let mut v = CapRestart::default();
-            for (_, val) in self.restart.iter() {
+            for val in self.restart.values() {
                 v.values.push(val.clone());
             }
             writeln!(f, " {}", v)?;
@@ -198,14 +198,14 @@ impl fmt::Display for BgpCap {
         }
         if !self.addpath.is_empty() {
             let mut v = CapAddPath::default();
-            for (_, val) in self.addpath.iter() {
+            for val in self.addpath.values() {
                 v.values.push(val.clone());
             }
             writeln!(f, " {}", v)?;
         }
         if !self.llgr.is_empty() {
             let mut v = CapLlgr::default();
-            for (_, val) in self.llgr.iter() {
+            for val in self.llgr.values() {
                 v.values.push(val.clone());
             }
             writeln!(f, " {}", v)?;
@@ -218,7 +218,7 @@ impl fmt::Display for BgpCap {
         }
         if !self.path_limit.is_empty() {
             let mut v = CapPathLimit::default();
-            for (_, val) in self.path_limit.iter() {
+            for val in self.path_limit.values() {
                 v.values.push(val.clone());
             }
             writeln!(f, " {}", v)?;

--- a/zebra-rs/src/bgp/cap.rs
+++ b/zebra-rs/src/bgp/cap.rs
@@ -75,7 +75,7 @@ impl CapAfiMap {
 }
 
 pub fn cap_register_send(bgp_cap: &BgpCap, cap_map: &mut CapAfiMap) {
-    for (_, mp) in bgp_cap.mp.iter() {
+    for mp in bgp_cap.mp.values() {
         if let Some(entry) = cap_map.get_mut(mp) {
             entry.send = true;
         }
@@ -83,7 +83,7 @@ pub fn cap_register_send(bgp_cap: &BgpCap, cap_map: &mut CapAfiMap) {
 }
 
 pub fn cap_register_recv(bgp_cap: &BgpCap, cap_map: &mut CapAfiMap) {
-    for (_, mp) in bgp_cap.mp.iter() {
+    for mp in bgp_cap.mp.values() {
         if let Some(entry) = cap_map.get_mut(mp) {
             entry.recv = true;
         }
@@ -116,7 +116,7 @@ pub fn addpath_send_implemented(afi: Afi, safi: Safi) -> bool {
 }
 
 pub fn cap_addpath_recv(bgp_cap: &BgpCap, opt: &mut ParseOption, configs: &AfiSafis<AddPathValue>) {
-    for (_, cap) in bgp_cap.addpath.iter() {
+    for cap in bgp_cap.addpath.values() {
         for (_, config) in configs.iter() {
             if cap.afi == config.afi && cap.safi == config.safi {
                 // Send is additionally gated on the family having a

--- a/zebra-rs/src/bgp/config.rs
+++ b/zebra-rs/src/bgp/config.rs
@@ -317,9 +317,9 @@ fn config_peer(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Option<()> {
         // dialing yet, so no kick fires here.
         bgp.refresh_connected();
     } else {
-        let peer_idx = match bgp.peers.get(&addr) {
-            Some(peer) => peer.ident,
-            None => return None,
+        let peer_idx = {
+            let peer = bgp.peers.get(&addr)?;
+            peer.ident
         };
 
         // Defensively clear any listener auth entries associated with
@@ -3079,10 +3079,9 @@ fn config_llgr_restart_time(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Opti
 fn config_local_identifier(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Option<()> {
     let addr = if let Some(addr) = args.v4addr() {
         IpAddr::V4(addr)
-    } else if let Some(addr) = args.v6addr() {
-        IpAddr::V6(addr)
     } else {
-        return None;
+        let addr = args.v6addr()?;
+        IpAddr::V6(addr)
     };
     let identifier = if op == ConfigOp::Set {
         Some(args.v4addr()?)
@@ -3159,10 +3158,9 @@ pub(super) fn apply_passive(peer: &mut Peer, want: bool) -> bool {
 fn config_transport_local_address(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Option<()> {
     let peer_addr = if let Some(addr) = args.v4addr() {
         IpAddr::V4(addr)
-    } else if let Some(addr) = args.v6addr() {
-        IpAddr::V6(addr)
     } else {
-        return None;
+        let addr = args.v6addr()?;
+        IpAddr::V6(addr)
     };
 
     {
@@ -3174,10 +3172,9 @@ fn config_transport_local_address(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -
         if op == ConfigOp::Set {
             let source = if let Some(addr) = args.v4addr() {
                 IpAddr::V4(addr)
-            } else if let Some(addr) = args.v6addr() {
-                IpAddr::V6(addr)
             } else {
-                return None;
+                let addr = args.v6addr()?;
+                IpAddr::V6(addr)
             };
             // Address family of the source must match the peer; an
             // invalid statement is refused outright (not recorded).
@@ -3686,10 +3683,9 @@ pub(super) fn apply_ip_transparent_refresh_all(bgp: &mut Bgp) {
 fn config_peer_tcp_md5_password(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Option<()> {
     let addr = if let Some(addr) = args.v4addr() {
         IpAddr::V4(addr)
-    } else if let Some(addr) = args.v6addr() {
-        IpAddr::V6(addr)
     } else {
-        return None;
+        let addr = args.v6addr()?;
+        IpAddr::V6(addr)
     };
 
     // Record the verbatim statement on the peer if it exists, then
@@ -3850,10 +3846,9 @@ pub(super) fn apply_md5_refresh_all(bgp: &mut Bgp) {
 fn config_peer_tcp_md5_encoding(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Option<()> {
     let addr = if let Some(addr) = args.v4addr() {
         IpAddr::V4(addr)
-    } else if let Some(addr) = args.v6addr() {
-        IpAddr::V6(addr)
     } else {
-        return None;
+        let addr = args.v6addr()?;
+        IpAddr::V6(addr)
     };
 
     let peer = bgp.peers.get_mut(&addr)?;
@@ -4015,10 +4010,9 @@ pub(super) fn apply_ao_refresh_all(bgp: &mut Bgp) {
 fn config_peer_tcp_ao_key_chain(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Option<()> {
     let addr = if let Some(addr) = args.v4addr() {
         IpAddr::V4(addr)
-    } else if let Some(addr) = args.v6addr() {
-        IpAddr::V6(addr)
     } else {
-        return None;
+        let addr = args.v6addr()?;
+        IpAddr::V6(addr)
     };
 
     let (peer_ident, prior, new) = {
@@ -4074,10 +4068,9 @@ fn config_peer_tcp_ao_include_tcp_options(
 ) -> Option<()> {
     let addr = if let Some(addr) = args.v4addr() {
         IpAddr::V4(addr)
-    } else if let Some(addr) = args.v6addr() {
-        IpAddr::V6(addr)
     } else {
-        return None;
+        let addr = args.v6addr()?;
+        IpAddr::V6(addr)
     };
 
     {

--- a/zebra-rs/src/bgp/peer.rs
+++ b/zebra-rs/src/bgp/peer.rs
@@ -747,7 +747,7 @@ pub struct PeerStat(BTreeMap<AfiSafi, PeerStatEntry>);
 
 impl PeerStat {
     pub fn clear(&mut self) {
-        for (_, entry) in self.0.iter_mut() {
+        for entry in self.0.values_mut() {
             entry.tx = 0;
             entry.rx = 0;
         }
@@ -2778,7 +2778,7 @@ fn build_open_packet(peer: &mut Peer) -> BytesMut {
     }
     let mut bgp_cap = BgpCap::default();
 
-    for (afi_safi, _) in peer.config.mp.0.iter() {
+    for afi_safi in peer.config.mp.0.keys() {
         let cap = CapMultiProtocol::new(&afi_safi.afi, &afi_safi.safi);
         bgp_cap.mp.insert(*afi_safi, cap);
     }

--- a/zebra-rs/src/bgp/route.rs
+++ b/zebra-rs/src/bgp/route.rs
@@ -9926,8 +9926,8 @@ pub fn route_clean(
                 adj_in, attr_store, ..
             } = &mut *bgp.shard;
             if let Some(slice) = adj_in.get_mut(&peer_id) {
-                for (_rd, table) in slice.v4vpn.iter_mut() {
-                    for (_prefix, ribs) in table.0.iter_mut() {
+                for table in slice.v4vpn.values_mut() {
+                    for ribs in table.0.values_mut() {
                         for rib in ribs.iter_mut() {
                             rib.stale = true;
                             // LLGR_STALE community is LLGR-only (see VPNv6).
@@ -10097,8 +10097,8 @@ pub fn route_clean(
                 adj_in, attr_store, ..
             } = &mut *bgp.shard;
             if let Some(slice) = adj_in.get_mut(&peer_id) {
-                for (_rd, table) in slice.v6vpn.iter_mut() {
-                    for (_prefix, ribs) in table.0.iter_mut() {
+                for table in slice.v6vpn.values_mut() {
+                    for ribs in table.0.values_mut() {
                         for rib in ribs.iter_mut() {
                             rib.stale = true;
                             // The LLGR_STALE community is an LLGR re-advertise
@@ -10241,8 +10241,8 @@ pub fn route_clean(
         }
         let peer = peers.get_mut_by_idx(peer_id).expect("peer must exist");
 
-        for (_rd, table) in peer.adj_in.evpn.iter_mut() {
-            for (_prefix, ribs) in table.0.iter_mut() {
+        for table in peer.adj_in.evpn.values_mut() {
+            for ribs in table.0.values_mut() {
                 for rib in ribs.iter_mut() {
                     rib.stale = true;
                     let mut new_attr = (*rib.attr).clone();
@@ -12052,7 +12052,7 @@ pub fn policy_list_apply_net(
         attr: bgp_attr,
         weight,
     };
-    for (_, entry) in policy_list.entry.iter() {
+    for entry in policy_list.entry.values() {
         if !entry_matches(entry, prefix, &decision.attr, decision.weight) {
             continue;
         }
@@ -12274,7 +12274,7 @@ pub fn policy_list_apply_evpn(
         attr: bgp_attr,
         weight,
     };
-    for (_, entry) in policy_list.entry.iter() {
+    for entry in policy_list.entry.values() {
         if !entry_matches_evpn(entry, route, &decision.attr, decision.weight) {
             continue;
         }

--- a/zebra-rs/src/bgp/show.rs
+++ b/zebra-rs/src/bgp/show.rs
@@ -126,7 +126,7 @@ fn afi_safi_summary_label(afi: Afi, safi: Safi) -> &'static str {
 fn configured_afi_safis<V: BgpShowView>(bgp: &V) -> Vec<AfiSafi> {
     let mut set: std::collections::BTreeSet<AfiSafi> = std::collections::BTreeSet::new();
     for (_, peer) in bgp.peers().iter_all() {
-        for (afi_safi, _) in peer.config.mp.0.iter() {
+        for afi_safi in peer.config.mp.0.keys() {
             set.insert(*afi_safi);
         }
     }

--- a/zebra-rs/src/bgp/sr_policy.rs
+++ b/zebra-rs/src/bgp/sr_policy.rs
@@ -574,14 +574,13 @@ impl LocalSrPolicy {
         for seg in self.segments.values() {
             if let Some(label) = seg.mpls_label {
                 segments.push(Segment::TypeA { flags: 0, label });
-            } else if let Some(sid) = seg.srv6_sid {
+            } else {
+                let sid = seg.srv6_sid?;
                 segments.push(Segment::TypeB {
                     flags: 0,
                     sid,
                     structure: None,
                 });
-            } else {
-                return None;
             }
         }
         if segments.is_empty() {

--- a/zebra-rs/src/config/manager.rs
+++ b/zebra-rs/src/config/manager.rs
@@ -643,12 +643,12 @@ impl ConfigManager {
                     continue;
                 }
                 let paths = paths.unwrap();
-                for (_, tx) in self.cm_clients.borrow().iter() {
+                for tx in self.cm_clients.borrow().values() {
                     tx.send(ConfigRequest::new(paths.clone(), op)).unwrap();
                 }
             }
         }
-        for (_, tx) in self.cm_clients.borrow().iter() {
+        for tx in self.cm_clients.borrow().values() {
             tx.send(ConfigRequest::new(Vec::new(), ConfigOp::CommitEnd))
                 .unwrap();
         }
@@ -813,7 +813,7 @@ impl ConfigManager {
     }
 
     pub fn clear(&self, paths: &[CommandPath]) {
-        for (_, tx) in self.cm_clients.borrow().iter() {
+        for tx in self.cm_clients.borrow().values() {
             tx.send(ConfigRequest::new(paths.to_vec(), ConfigOp::Clear))
                 .unwrap();
         }

--- a/zebra-rs/src/isis/ifsm.rs
+++ b/zebra-rs/src/isis/ifsm.rs
@@ -161,7 +161,7 @@ pub fn hello_generate(link: &LinkTop, level: Level) -> IsisHello {
     push_if_addr_tlvs(&mut hello.tlvs, link);
 
     let mut neighbors = Vec::new();
-    for (_, nbr) in link.state.nbrs.get(&level).iter() {
+    for nbr in link.state.nbrs.get(&level).values() {
         if (nbr.state == NfsmState::Init || nbr.state == NfsmState::Up)
             && let Some(mac) = nbr.mac
         {

--- a/zebra-rs/src/isis/lsp.rs
+++ b/zebra-rs/src/isis/lsp.rs
@@ -1034,8 +1034,8 @@ pub fn lsp_generate(top: &mut IsisTop, level: Level, seq_floor: Option<u32>) -> 
         // general TE visibility (non-flex-algo consumers).
         is_reach.subs.extend(te_metric.sub_tlvs());
         // Neighbor
-        for (_, nbr) in link.state.nbrs.get(&level).iter() {
-            for (_key, value) in nbr.addr4.iter() {
+        for nbr in link.state.nbrs.get(&level).values() {
+            for value in nbr.addr4.values() {
                 if let Some(label) = value.label {
                     // RFC 8667 §2.2.1 B-flag: "Adj-SID is eligible for
                     // protection." We flip it on whenever TI-LFA is
@@ -1230,7 +1230,7 @@ pub fn lsp_generate(top: &mut IsisTop, level: Level, seq_floor: Option<u32>) -> 
             // also advertised inline for general TE visibility — link
             // delay/loss are MT-agnostic physical properties.
             entry.subs.extend(te_metric.sub_tlvs());
-            for (_, nbr) in link.state.nbrs.get(&level).iter() {
+            for nbr in link.state.nbrs.get(&level).values() {
                 if let Some((_, sid_addr)) = nbr.endx_sid {
                     if nbr.network_type.is_p2p() {
                         let sub = IsisSubSrv6EndXSid {

--- a/zebra-rs/src/isis/nfsm.rs
+++ b/zebra-rs/src/isis/nfsm.rs
@@ -100,7 +100,7 @@ pub fn nbr_hold_timer_expire(
     }
 
     // Release labels.
-    for (_key, value) in nbr.addr4.iter_mut() {
+    for value in nbr.addr4.values_mut() {
         if let Some(label) = value.label {
             if let Some(local_pool) = link.local_pool {
                 local_pool.release(label as usize);

--- a/zebra-rs/src/isis/packet.rs
+++ b/zebra-rs/src/isis/packet.rs
@@ -261,7 +261,7 @@ pub fn nbr_hello_interpret(
         }
         keep
     });
-    for (&key, _) in addr4.iter() {
+    for &key in addr4.keys() {
         if let std::collections::btree_map::Entry::Vacant(e) = nbr.addr4.entry(key) {
             // Fix borrow checker.
             let label = local_pool

--- a/zebra-rs/src/isis/rib.rs
+++ b/zebra-rs/src/isis/rib.rs
@@ -824,7 +824,7 @@ fn build_adjacency_ilm(
 
         for (ifindex, link) in top.links.iter() {
             if let Some(nbr) = link.state.nbrs.get(&level).get(nhop_id) {
-                for (addr, _) in nbr.addr4.iter() {
+                for addr in nbr.addr4.keys() {
                     let nhop = SpfNexthop::<V4> {
                         ifindex: *ifindex,
                         adjacency: true,
@@ -2236,7 +2236,7 @@ fn build_rib_from_flex_algo(
                 let Some(nbr) = link.state.nbrs.get(&level).get(&nhop_sys_id) else {
                     continue;
                 };
-                for (addr, _) in nbr.addr4.iter() {
+                for addr in nbr.addr4.keys() {
                     let nhop = SpfNexthop::<V4> {
                         ifindex: *link_id,
                         adjacency: *node == nhop_id,

--- a/zebra-rs/src/isis/show.rs
+++ b/zebra-rs/src/isis/show.rs
@@ -1551,7 +1551,7 @@ fn write_local_sids(buf: &mut String, isis: &Isis) -> std::fmt::Result {
     // End.X / uA — one per Up adjacency that has carved a function.
     for level in &[Level::L1, Level::L2] {
         for (ifindex, link) in isis.links.iter() {
-            for (_sys_id, nbr) in link.state.nbrs.get(level).iter() {
+            for nbr in link.state.nbrs.get(level).values() {
                 let Some((_, addr)) = nbr.endx_sid else {
                     continue;
                 };

--- a/zebra-rs/src/isis/tracing.rs
+++ b/zebra-rs/src/isis/tracing.rs
@@ -356,7 +356,8 @@ fn apply_tracing(t: &mut IsisTracing, rest: &str, args: &mut Args, op: ConfigOp)
                     "nfsm" => fsm_set_enable(&mut t.fsm.nfsm, op),
                     _ => return None,
                 }
-            } else if let Some(ev) = other.strip_prefix('/') {
+            } else {
+                let ev = other.strip_prefix('/')?;
                 let (name, sub) = match ev.split_once('/') {
                     Some((name, sub)) => (name, Some(sub)),
                     None => (ev, None),
@@ -372,8 +373,6 @@ fn apply_tracing(t: &mut IsisTracing, rest: &str, args: &mut Args, op: ConfigOp)
                     Some("level") => event_set_level(ec, args, op),
                     Some(_) => return None,
                 }
-            } else {
-                return None;
             }
         }
     }

--- a/zebra-rs/src/ospf/inst.rs
+++ b/zebra-rs/src/ospf/inst.rs
@@ -1261,7 +1261,7 @@ impl<V: OspfVersion> Ospf<V> {
         let mut count = 0;
         for &link_ifindex in area.links.iter() {
             if let Some(area_link) = self.links.get(&link_ifindex) {
-                for (_, nbr) in area_link.nbrs.iter() {
+                for nbr in area_link.nbrs.values() {
                     if nbr.state == NfsmState::Exchange || nbr.state == NfsmState::Loading {
                         count += 1;
                     }
@@ -4877,7 +4877,7 @@ impl Ospf<Ospfv2> {
             let Some(link) = self.links.get(&ifindex) else {
                 continue;
             };
-            for (_nbr_addr, nbr) in link.nbrs.iter() {
+            for nbr in link.nbrs.values() {
                 let Some(helper) = nbr.gr_helper.as_ref() else {
                     continue;
                 };
@@ -4908,7 +4908,7 @@ impl Ospf<Ospfv2> {
 
     /// Check if we are currently the DR for the network identified by ls_id.
     fn is_dr_for_network_lsa(&self, ls_id: Ipv4Addr) -> bool {
-        for (_, link) in self.links.iter() {
+        for link in self.links.values() {
             if !link.enabled {
                 continue;
             }
@@ -5396,7 +5396,7 @@ impl Ospf<Ospfv2> {
         };
         let area = link.area;
         let ctx = link.auth_send_ctx(&chains, now);
-        for (_, nbr) in link.nbrs.iter_mut() {
+        for nbr in link.nbrs.values_mut() {
             if nbr.state < NfsmState::Exchange {
                 continue;
             }
@@ -5472,7 +5472,7 @@ impl Ospf<Ospfv2> {
                 }
             }
 
-            for (_, nbr) in link.nbrs.iter_mut() {
+            for nbr in link.nbrs.values_mut() {
                 // RFC 2328 Section 13.3 Step 1(a): Skip neighbors below Exchange.
                 if nbr.state < NfsmState::Exchange {
                     continue;
@@ -5700,7 +5700,7 @@ impl Ospf<Ospfv2> {
         }
 
         self.router_id = router_id;
-        for (_, link) in self.links.iter_mut() {
+        for link in self.links.values_mut() {
             link.ident.router_id = router_id;
         }
         self.router_lsa_originate();
@@ -6894,7 +6894,7 @@ impl Ospf<Ospfv3> {
         }
 
         self.router_id = router_id;
-        for (_, link) in self.links.iter_mut() {
+        for link in self.links.values_mut() {
             link.ident.router_id = router_id;
         }
         self.router_lsa_originate();
@@ -11948,7 +11948,7 @@ fn graph(top: &mut Ospf, area_id: Ipv4Addr) -> (spf::Graph, Option<usize>) {
     // same trade-off IS-IS accepts.
     let mut nbr_to_ifindex: HashMap<Ipv4Addr, u32> = HashMap::new();
     for (ifindex, link) in top.links.iter() {
-        for (_, nbr) in link.nbrs.iter() {
+        for nbr in link.nbrs.values() {
             nbr_to_ifindex.insert(nbr.ident.router_id, *ifindex);
         }
     }
@@ -12540,7 +12540,7 @@ fn build_spf_nexthops(
             continue;
         };
         for (ifindex, link) in top.links.iter() {
-            for (_, nbr) in link.nbrs.iter() {
+            for nbr in link.nbrs.values() {
                 if *nhop_id == nbr.ident.router_id {
                     // A virtual-link adjacency has a synthetic ifindex
                     // with no kernel interface behind it, and on a

--- a/zebra-rs/src/ospf/packet.rs
+++ b/zebra-rs/src/ospf/packet.rs
@@ -301,7 +301,7 @@ pub fn ospf_hello_packet(
     // logs `O-bit abuse?` when it sees one here.
     hello.options.set_external(oi.area_type.e_bit());
     hello.options.set_nssa(oi.area_type.n_bit());
-    for (_, nbr) in oi.nbrs.iter() {
+    for nbr in oi.nbrs.values() {
         if nbr.state == NfsmState::Down {
             continue;
         }

--- a/zebra-rs/src/ospf/show.rs
+++ b/zebra-rs/src/ospf/show.rs
@@ -403,7 +403,7 @@ fn show_ospf_interface(
 ) -> std::result::Result<String, std::fmt::Error> {
     if json {
         let mut ifaces: Vec<OspfInterfaceJson> = Vec::new();
-        for (_, oi) in ospf.links.iter() {
+        for oi in ospf.links.values() {
             if !oi.enabled {
                 continue;
             }
@@ -491,7 +491,7 @@ fn show_ospf_interface(
 
     let mut buf = String::new();
 
-    for (_, oi) in ospf.links.iter() {
+    for oi in ospf.links.values() {
         if oi.enabled {
             render_link(&mut buf, oi, ospf);
         }
@@ -686,11 +686,11 @@ fn show_ospf_neighbor(
 ) -> std::result::Result<String, std::fmt::Error> {
     if json {
         let mut nbrs_json: Vec<OspfNeighborJson> = Vec::new();
-        for (_, oi) in ospf.links.iter() {
+        for oi in ospf.links.values() {
             if !oi.enabled {
                 continue;
             }
-            for (_, nbr) in oi.nbrs.iter() {
+            for nbr in oi.nbrs.values() {
                 let state = nbr_state_string(
                     &nbr.state,
                     &nbr.ident.prefix.addr(),
@@ -738,11 +738,11 @@ fn show_ospf_neighbor(
         "DBsmL"
     )?;
 
-    for (_, oi) in ospf.links.iter() {
+    for oi in ospf.links.values() {
         if !oi.enabled {
             continue;
         }
-        for (_, nbr) in oi.nbrs.iter() {
+        for nbr in oi.nbrs.values() {
             let state = nbr_state_string(
                 &nbr.state,
                 &nbr.ident.prefix.addr(),
@@ -921,11 +921,11 @@ fn show_ospf_neighbor_detail(
 ) -> std::result::Result<String, std::fmt::Error> {
     if json {
         let mut nbrs_json: Vec<OspfNeighborDetailJson> = Vec::new();
-        for (_, oi) in ospf.links.iter() {
+        for oi in ospf.links.values() {
             if !oi.enabled {
                 continue;
             }
-            for (_, nbr) in oi.nbrs.iter() {
+            for nbr in oi.nbrs.values() {
                 let role = nbr_role(
                     &nbr.ident.prefix.addr(),
                     &oi.ident.d_router,
@@ -979,11 +979,11 @@ fn show_ospf_neighbor_detail(
 
     let mut buf = String::new();
 
-    for (_, oi) in ospf.links.iter() {
+    for oi in ospf.links.values() {
         if !oi.enabled {
             continue;
         }
-        for (_, nbr) in oi.nbrs.iter() {
+        for nbr in oi.nbrs.values() {
             render_nbr_detail(&mut buf, oi, nbr);
         }
     }

--- a/zebra-rs/src/ospf/show_v3.rs
+++ b/zebra-rs/src/ospf/show_v3.rs
@@ -715,21 +715,21 @@ fn hdr_to_json(h: &ospf_packet::Ospfv3LsaHeader) -> Ospfv3LsaHeaderJson {
 fn collect_database(top: &Ospf<Ospfv3>) -> Ospfv3DatabaseJson {
     let mut db = Ospfv3DatabaseJson::default();
     for (_, area) in top.areas.iter() {
-        for (_, lsa) in area.lsdb.tables.iter() {
+        for lsa in area.lsdb.tables.values() {
             if lsa.data.h.ls_age >= OSPF_MAX_AGE {
                 continue;
             }
             db.area.push(hdr_to_json(&lsa.data.h));
         }
     }
-    for (_, lsa) in top.lsdb_as.tables.iter() {
+    for lsa in top.lsdb_as.tables.values() {
         if lsa.data.h.ls_age >= OSPF_MAX_AGE {
             continue;
         }
         db.as_scope.push(hdr_to_json(&lsa.data.h));
     }
     for link in top.links.values() {
-        for (_, lsa) in link.lsdb.tables.iter() {
+        for lsa in link.lsdb.tables.values() {
             if lsa.data.h.ls_age >= OSPF_MAX_AGE {
                 continue;
             }

--- a/zebra-rs/src/ospf/tracing.rs
+++ b/zebra-rs/src/ospf/tracing.rs
@@ -503,7 +503,8 @@ fn apply_tracing(t: &mut OspfTracing, rest: &str, args: &mut Args, op: ConfigOp)
                     Some("direction") => packet_set_direction(pc, args, op),
                     Some(_) => return None,
                 }
-            } else if let Some(fsm) = other.strip_prefix("/fsm/") {
+            } else {
+                let fsm = other.strip_prefix("/fsm/")?;
                 let (typ, sub) = match fsm.split_once('/') {
                     Some((typ, sub)) => (typ, Some(sub)),
                     None => (fsm, None),
@@ -514,8 +515,6 @@ fn apply_tracing(t: &mut OspfTracing, rest: &str, args: &mut Args, op: ConfigOp)
                     Some("detail") => fsm_set_detail(fc, op),
                     Some(_) => return None,
                 }
-            } else {
-                return None;
             }
         }
     }

--- a/zebra-rs/src/policy/policy_list.rs
+++ b/zebra-rs/src/policy/policy_list.rs
@@ -322,7 +322,7 @@ pub fn policy_entry_sync(
     large_community_set: &LargeCommunitySetConfig,
     as_path_set: &AsPathSetConfig,
 ) {
-    for (_, policy) in policy_list.entry.iter_mut() {
+    for policy in policy_list.entry.values_mut() {
         if let Some(name) = &policy.prefix_set_name {
             if let Some(prefix_set) = prefix_set.config.get(name) {
                 policy.prefix_set = Some(prefix_set.clone());

--- a/zebra-rs/src/rib/inst.rs
+++ b/zebra-rs/src/rib/inst.rs
@@ -1835,7 +1835,7 @@ impl Rib {
             return;
         }
         // Link dump.
-        for (_, link) in self.links.iter() {
+        for link in self.links.values() {
             let msg = RibRx::LinkAdd(link.clone());
             if tx.send(msg).is_err() {
                 return;
@@ -3176,10 +3176,10 @@ impl Rib {
                     self.fib_handle.mdb_del(vni, group, None, 0).await;
                 }
                 self.vtep_table.clear();
-                for (_, bridge) in self.bridges.iter() {
+                for bridge in self.bridges.values() {
                     self.fib_handle.bridge_del(bridge).await;
                 }
-                for (_, vxlan) in self.vxlan.iter() {
+                for vxlan in self.vxlan.values() {
                     self.fib_handle.vxlan_del(vxlan).await;
                 }
                 // Tear down the VRF master devices this process created

--- a/zebra-rs/src/rib/link.rs
+++ b/zebra-rs/src/rib/link.rs
@@ -374,7 +374,7 @@ pub fn link_show(rib: &Rib, mut args: Args, json: bool) -> String {
         if json {
             return link_detailed_show_json(rib, None);
         } else {
-            for (_, link) in rib.links.iter() {
+            for link in rib.links.values() {
                 link_info_show(rib, link, &mut buf, &cb);
             }
         }
@@ -1217,7 +1217,7 @@ pub async fn link_config_exec(
 }
 
 pub fn link_lookup(rib: &Rib, name: String) -> Option<u32> {
-    for (_, link) in rib.links.iter() {
+    for link in rib.links.values() {
         if link.name == name {
             return Some(link.index);
         }

--- a/zebra-rs/src/rib/nexthop/map.rs
+++ b/zebra-rs/src/rib/nexthop/map.rs
@@ -331,7 +331,7 @@ impl NexthopMap {
         // Indirection groups first — a group must leave the kernel
         // before its members so member deletion can't cascade-empty
         // it behind our back.
-        for (_, id) in self.protect.iter() {
+        for id in self.protect.values() {
             let entry = self.get(*id);
             if let Some(grp) = entry
                 && grp.is_installed()
@@ -339,7 +339,7 @@ impl NexthopMap {
                 fib.nexthop_del(grp).await;
             }
         }
-        for (_, id) in self.set.iter() {
+        for id in self.set.values() {
             let entry = self.get(*id);
             if let Some(grp) = entry
                 && grp.is_installed()
@@ -347,7 +347,7 @@ impl NexthopMap {
                 fib.nexthop_del(grp).await;
             }
         }
-        for (_, id) in self.map.iter() {
+        for id in self.map.values() {
             let entry = self.get(*id);
             if let Some(grp) = entry
                 && grp.is_installed()
@@ -355,7 +355,7 @@ impl NexthopMap {
                 fib.nexthop_del(grp).await;
             }
         }
-        for (_, id) in self.mpls.iter() {
+        for id in self.mpls.values() {
             let entry = self.get(*id);
             if let Some(grp) = entry
                 && grp.is_installed()
@@ -363,7 +363,7 @@ impl NexthopMap {
                 fib.nexthop_del(grp).await;
             }
         }
-        for (_, id) in self.seg6.iter() {
+        for id in self.seg6.values() {
             let entry = self.get(*id);
             if let Some(grp) = entry
                 && grp.is_installed()
@@ -371,7 +371,7 @@ impl NexthopMap {
                 fib.nexthop_del(grp).await;
             }
         }
-        for (_, id) in self.seg6local.iter() {
+        for id in self.seg6local.values() {
             let entry = self.get(*id);
             if let Some(grp) = entry
                 && grp.is_installed()

--- a/zebra-rs/src/rib/show.rs
+++ b/zebra-rs/src/rib/show.rs
@@ -425,7 +425,7 @@ pub fn rib_entry_show(
     // their own arm (each repair path can carry a different metric),
     // so skip the shared route-level bracket for them.
     if !e.is_connected() && !matches!(e.nexthop, Nexthop::List(_) | Nexthop::Protect(_)) {
-        write!(buf, " [{}/{}]", &e.distance, &e.metric).unwrap();
+        write!(buf, " [{}/{}]", e.distance, e.metric).unwrap();
     }
 
     let offset = buf.len();
@@ -518,7 +518,7 @@ pub fn rib_entry_show_v6(
     // their own arm (each repair path can carry a different metric),
     // so skip the shared route-level bracket for them.
     if !e.is_connected() && !matches!(e.nexthop, Nexthop::List(_) | Nexthop::Protect(_)) {
-        write!(buf, " [{}/{}]", &e.distance, &e.metric).unwrap();
+        write!(buf, " [{}/{}]", e.distance, e.metric).unwrap();
     }
 
     let offset = buf.len();


### PR DESCRIPTION
## Summary
The GitHub runners advanced to **clippy 1.97**, whose stricter lints turned
`main`'s `cargo clippy --workspace --all-targets -- -D warnings` CI job red on
pre-existing code — the last main run is failing, blocking all PRs.

All 86 findings are machine-applicable and were auto-fixed with `cargo clippy
--fix` (no manual edits):
- `for_kv_map`: `for (_, v) in m.iter()` → `for v in m.values()` / `.keys()`
- `question_mark`: `if let … else { return None }` → `?`
- redundant reference in `write!` arguments

No behavioral change — semantically-equivalent rewrites only. Touches
`bgp-packet` + `zebra-rs` across bgp/isis/ospf/rib/config modules.

## Test plan
Under the matching toolchain (rustc/clippy 1.97) locally:
- `cargo clippy --workspace --all-targets -- -D warnings` → clean
- `cargo clippy -p zebra-rs --features lua --all-targets -- -D warnings` → clean
- `cargo fmt --all -- --check` → clean
- `cargo test --workspace --exclude bdd` → all pass

Generated with [Claude Code](https://claude.com/claude-code)
