### PR TITLE
Gate cradle tee on system/cradle/enabled; move endpoint under it

### DIFF
--- a/book/src/ch-02-35-bgp-mup.md
+++ b/book/src/ch-02-35-bgp-mup.md
@@ -213,7 +213,7 @@ dataplane`:
   rest of this chapter describes, and it runs on stock Linux.
 * **`gtp`** — real **GTP-U**. The tunnel is programmed from the ST route's own
   endpoint and TEID (`GTP4.E` downlink / `H.M.GTP4.D` uplink) by the **cradle**
-  eBPF forwarder, which zebra-rs drives over gRPC (`system cradle-grpc`). The
+  eBPF forwarder, which zebra-rs drives over gRPC (`system cradle grpc-endpoint`). The
   mainline kernel has no GTP action, so this mode requires cradle. The uplink
   decap is wired: each Type-2 ST route's `(endpoint, TEID)` becomes a cradle
   GTP-U PDR (`H.M.GTP4.D`) that strips a matching G-PDU into the VRF. The

--- a/book/src/ch-02-38-bgp-evpn-vpws.md
+++ b/book/src/ch-02-38-bgp-evpn-vpws.md
@@ -112,6 +112,6 @@ configured (or re-pointed) is found without waiting for a route churn.
 
 Single-homed only (all-zero ESI): no multihoming, DF election, or
 primary/backup signalling yet — the L2-Attributes P/B bits are fixed at
-P=1/B=0. The data plane is cradle eBPF (`system cradle-grpc`); the
+P=1/B=0. The data plane is cradle eBPF (`system cradle grpc-endpoint`); the
 kernel has no End.DX2/DX2V seg6local action, so these SIDs are never
 installed via netlink.

--- a/zebra-rs/src/config/manager.rs
+++ b/zebra-rs/src/config/manager.rs
@@ -2697,12 +2697,12 @@ mod yang_load_tests {
         );
     }
 
-    /// The cradle eBPF integration exposes two settable knobs under the
-    /// `system` container: the `system cradle enabled <bool>` master switch
+    /// The cradle eBPF integration exposes two settable leaves under the
+    /// `system cradle` container: the `system cradle enabled <bool>` switch
     /// (dispatched in `rib/inst.rs` at the literal `/system/cradle/enabled`
-    /// path) and the optional `system cradle-grpc <endpoint>` override. Pin
-    /// both at the grammar level so a typo in the container/leaf naming
-    /// (which `load_mode` would not catch) fails loudly.
+    /// path) and the optional `system cradle grpc-endpoint <endpoint>`
+    /// override. Pin both at the grammar level so a typo in the container/leaf
+    /// naming (which `load_mode` would not catch) fails loudly.
     #[test]
     fn cradle_knobs_are_settable() {
         use crate::config::ExecCode;
@@ -2721,7 +2721,7 @@ mod yang_load_tests {
 
         for cmd in [
             "set system cradle enabled true",
-            "set system cradle-grpc unix:cradle/grpc",
+            "set system cradle grpc-endpoint unix:cradle/grpc",
         ] {
             let (code, _comps, _state) = parse(cmd, entry.clone(), None, State::new());
             assert_eq!(code, ExecCode::Success, "must be a settable path: {cmd}");

--- a/zebra-rs/src/fib/cradle.rs
+++ b/zebra-rs/src/fib/cradle.rs
@@ -1,6 +1,6 @@
 //! Optional tee of FIB route installs into the **cradle** eBPF data plane.
 //!
-//! Enabled by the `system cradle-grpc <endpoint>` config leaf (or the
+//! Enabled by the `system cradle grpc-endpoint <endpoint>` config leaf (or the
 //! `CRADLE_GRPC` env var as a fallback). When set, the protocol routes the RIB
 //! installs are also pushed to a running `cradle` via its gRPC control API, so
 //! zebra-rs-computed routes (static, BGP, OSPF, IS-IS, …) program the eBPF FIB
@@ -191,7 +191,7 @@ impl CradleFib {
     }
 
     /// Construct from `CRADLE_GRPC` if set (env fallback; the primary control is
-    /// the `system cradle-grpc` config leaf). Returns `None` when unset.
+    /// the `system cradle grpc-endpoint` config leaf). Returns `None` when unset.
     pub fn from_env() -> Option<Self> {
         std::env::var("CRADLE_GRPC").ok().map(|ep| Self::new(&ep))
     }

--- a/zebra-rs/src/fib/netlink/handle.rs
+++ b/zebra-rs/src/fib/netlink/handle.rs
@@ -351,7 +351,7 @@ pub struct FibHandle {
     /// Used to resolve VNI to the correct VXLAN device for FDB operations
     pub vni_ifindex_map: BTreeMap<u32, u32>,
     /// Optional tee of route installs into the cradle eBPF data plane. Driven by
-    /// the `system cradle-grpc <endpoint>` config leaf (`set_cradle`, dispatched
+    /// the `system cradle grpc-endpoint <endpoint>` config leaf (`set_cradle`, dispatched
     /// from `Rib::cradle_grpc_config_exec`), with `CRADLE_GRPC` as an env
     /// fallback.
     pub cradle: Option<CradleFib>,
@@ -528,7 +528,7 @@ impl FibHandle {
     }
 
     /// Enable/re-point (`Some`) or disable (`None`) the cradle eBPF tee at
-    /// runtime. Driven by the `system cradle-grpc` config leaf.
+    /// runtime. Driven by the `system cradle grpc-endpoint` config leaf.
     pub fn set_cradle(&mut self, endpoint: Option<&str>) {
         self.cradle = endpoint.map(CradleFib::new);
         if self.cradle.is_none() {

--- a/zebra-rs/src/rib/inst.rs
+++ b/zebra-rs/src/rib/inst.rs
@@ -740,11 +740,11 @@ pub enum NeighborKey {
 pub struct Rib {
     /// The cradle `WatchFdb` subscriber task (datapath MAC learning →
     /// EVPN Type-2 origination); aborted and respawned when the
-    /// `system cradle-grpc` endpoint changes.
+    /// `system cradle grpc-endpoint` endpoint changes.
     pub cradle_fdb_watch: Option<tokio::task::JoinHandle<()>>,
     /// `system cradle enabled` — master switch for the cradle eBPF tee.
     pub cradle_enabled: bool,
-    /// `system cradle-grpc <endpoint>` override. When the tee is enabled
+    /// `system cradle grpc-endpoint <endpoint>` override. When the tee is enabled
     /// but this is unset, the endpoint defaults to `unix:cradle/grpc`.
     pub cradle_grpc: Option<String>,
     pub cm: ConfigChannel,
@@ -3756,9 +3756,9 @@ impl Rib {
         Some((vni, vtep_local))
     }
 
-    /// `set system cradle enabled <bool>` — master switch for the cradle
+    /// `set system cradle enabled <bool>` — the sole switch for the cradle
     /// eBPF data-plane tee. Deleting it (or setting false) disables the tee
-    /// unless a `system cradle-grpc` endpoint keeps it on.
+    /// regardless of any `system cradle grpc-endpoint` endpoint.
     #[cfg(target_os = "linux")]
     pub(crate) fn cradle_enabled_config_exec(
         &mut self,
@@ -3770,11 +3770,12 @@ impl Rib {
         Some(())
     }
 
-    /// `set system cradle-grpc <endpoint>` overrides (or re-points) the cradle
-    /// tee endpoint; deleting it falls back to the `unix:cradle/grpc` default
-    /// (when the tee is otherwise enabled). Setting it also enables the tee on
-    /// its own. The endpoint is `unix:NAME` / `unix:/path`, `http://host:port`
-    /// or a bare `host:port` (treated as TCP).
+    /// `set system cradle grpc-endpoint <endpoint>` overrides (or re-points) the cradle
+    /// tee endpoint; deleting it falls back to the `unix:cradle/grpc` default.
+    /// This only takes effect while the tee is enabled (`system cradle
+    /// enabled`); on its own it does not enable the tee. The endpoint is
+    /// `unix:NAME` / `unix:/path`, `http://host:port` or a bare `host:port`
+    /// (treated as TCP).
     #[cfg(target_os = "linux")]
     pub(crate) fn cradle_grpc_config_exec(
         &mut self,
@@ -3791,13 +3792,13 @@ impl Rib {
     }
 
     /// Effective cradle tee endpoint: `None` when disabled, else the
-    /// `system cradle-grpc` override or the `unix:cradle/grpc` default.
+    /// `system cradle grpc-endpoint` override or the `unix:cradle/grpc` default.
     #[cfg(target_os = "linux")]
     fn cradle_endpoint(&self) -> Option<String> {
         cradle_effective_endpoint(self.cradle_enabled, self.cradle_grpc.as_deref())
     }
 
-    /// Re-derive the cradle tee from the current `enabled` / `cradle-grpc`
+    /// Re-derive the cradle tee from the current `enabled` / `grpc-endpoint`
     /// state and (re)start or stop the forward tee plus the reverse
     /// `WatchFdb` subscriber accordingly. Called on any change to either
     /// config knob.
@@ -3904,7 +3905,7 @@ impl Rib {
                 } else if path.as_str() == "/system/cradle/enabled" {
                     #[cfg(target_os = "linux")]
                     let _ = self.cradle_enabled_config_exec(args, msg.op);
-                } else if path.as_str() == "/system/cradle-grpc" {
+                } else if path.as_str() == "/system/cradle/grpc-endpoint" {
                     #[cfg(target_os = "linux")]
                     let _ = self.cradle_grpc_config_exec(args, msg.op);
                 } else if path.as_str().starts_with("/router/static/vrf/ipv4/route") {
@@ -4286,11 +4287,12 @@ fn neighbor_key(nbr: &FibNeighbor) -> Option<NeighborKey> {
 }
 
 /// Resolve the effective cradle tee endpoint from the two `system cradle`
-/// knobs. `None` disables the tee. The tee is active when `enabled` is true,
-/// or (for backward compatibility) when a `cradle-grpc` override is set on its
-/// own; the endpoint is that override, else the `unix:cradle/grpc` default.
+/// knobs. The tee is active only when `system cradle enabled` is true; the
+/// endpoint is the `system cradle grpc-endpoint` override if set, else the
+/// `unix:cradle/grpc` default. `system cradle grpc-endpoint` on its own does not enable
+/// the tee — it only points an already-enabled tee somewhere else.
 fn cradle_effective_endpoint(enabled: bool, grpc: Option<&str>) -> Option<String> {
-    if enabled || grpc.is_some() {
+    if enabled {
         Some(grpc.unwrap_or("unix:cradle/grpc").to_string())
     } else {
         None
@@ -4342,10 +4344,11 @@ mod cradle_endpoint_tests {
     }
 
     #[test]
-    fn override_alone_enables_tee_for_backward_compat() {
+    fn override_alone_does_not_enable_tee() {
+        // `system cradle grpc-endpoint` without `system cradle enabled` is inert.
         assert_eq!(
-            cradle_effective_endpoint(false, Some("127.0.0.1:50151")).as_deref(),
-            Some("127.0.0.1:50151"),
+            cradle_effective_endpoint(false, Some("127.0.0.1:50151")),
+            None
         );
     }
 }

--- a/zebra-rs/yang/config.yang
+++ b/zebra-rs/yang/config.yang
@@ -424,30 +424,29 @@ module config {
         type inet:ipv4-address;
       }
       // The zebra-rs side of the cradle-rs eBPF data-plane integration:
-      // when active, every route zebra-rs installs is teed to cradle in
+      // when enabled, every route zebra-rs installs is teed to cradle in
       // addition to the kernel, and cradle's datapath MAC learning is fed
       // back into EVPN (see `rib/inst.rs cradle_apply`). The tee is active
-      // when `system cradle enabled true` is set, or (for backward
-      // compatibility) when `system cradle-grpc` is set on its own.
+      // only when `system cradle enabled true` is set.
       container cradle {
         ext:help "cradle eBPF data-plane integration";
         leaf enabled {
           ext:help "Enable the cradle eBPF data-plane tee";
           type boolean;
           description
-            "Enables the cradle eBPF data-plane tee. The endpoint is
-             `system cradle-grpc` when set, otherwise the default
-             `unix:cradle/grpc` (a Linux abstract socket, matching
+            "The sole switch for the cradle eBPF data-plane tee. When true,
+             the endpoint is `system cradle grpc-endpoint` if set, otherwise
+             the default `unix:cradle/grpc` (a Linux abstract socket, matching
              cradle's own default).";
         }
-      }
-      // gRPC endpoint of the cradle eBPF data plane to tee FIB route
-      // installs to (e.g. `unix:/run/cradle.sock` or `127.0.0.1:50151`).
-      // Optional override for the `system cradle enabled` default endpoint
-      // `unix:cradle/grpc`; setting it also enables the tee on its own.
-      leaf cradle-grpc {
-        ext:help "cradle eBPF data-plane gRPC endpoint";
-        type string;
+        // gRPC endpoint of the cradle eBPF data plane to tee FIB route
+        // installs to (e.g. `unix:/run/cradle.sock` or `127.0.0.1:50151`).
+        // Optional override for the default `unix:cradle/grpc`; it only takes
+        // effect while the tee is enabled — on its own it does not enable it.
+        leaf grpc-endpoint {
+          ext:help "cradle eBPF data-plane gRPC endpoint";
+          type string;
+        }
       }
       container dhcp {
         ext:help "DHCP configuration";

--- a/zebra-rs/yang/zebra-bgp-evpn.yang
+++ b/zebra-rs/yang/zebra-bgp-evpn.yang
@@ -94,7 +94,7 @@ module zebra-bgp-evpn {
              (IMET) routes, carved from the BGP SRv6 locator, and
              install received MACs against the peer's L2 service SIDs.
              Requires `segment-routing srv6 locator`; the L2 data
-             plane is the cradle eBPF tee (`system cradle-grpc`) —
+             plane is the cradle eBPF tee (`system cradle grpc-endpoint`) —
              the kernel has no End.DT2U/DT2M seg6local actions.";
         }
       }

--- a/zebra-rs/yang/zebra-bgp-vrf.yang
+++ b/zebra-rs/yang/zebra-bgp-vrf.yang
@@ -319,7 +319,7 @@ module zebra-bgp-vrf {
               description
                 "Real GTP-U: install the tunnel from the ST route's endpoint
                  and TEID via the cradle eBPF forwarder (GTP4.E downlink /
-                 H.M.GTP4.D uplink). Requires `system cradle-grpc` to point at
+                 H.M.GTP4.D uplink). Requires `system cradle grpc-endpoint` to point at
                  the forwarder; the mainline kernel has no GTP action.";
             }
           }


### PR DESCRIPTION
## Summary
Two related changes to the cradle eBPF data-plane tee config:

- **`system cradle enabled true` is now the sole switch.** Removed the
  backward-compat clause where `system cradle-grpc` set on its own also enabled
  the tee. `cradle_effective_endpoint` drops `|| grpc.is_some()`; the endpoint
  leaf now only re-points an already-enabled tee.
- **Endpoint leaf moved `/system/cradle-grpc` → `/system/cradle/grpc-endpoint`**,
  so both knobs live under the `/system/cradle/` container. Dispatch match and
  the grammar test updated; prose (`system cradle-grpc` → `system cradle
  grpc-endpoint`) updated across rib/fib, the other YANG modules, and the book.

⚠️ **Breaking config change**: `system cradle-grpc <ep>` → `system cradle
grpc-endpoint <ep>`, and configs relying on `cradle-grpc` alone to enable the
tee must now also set `system cradle enabled true`.

## Test plan
Under the CI toolchain (rustc/clippy 1.97) locally:
- `cargo clippy --workspace --all-targets -- -D warnings` → clean
- `cargo fmt --all -- --check` → clean
- `cradle_knobs_are_settable` (new `grpc-endpoint` path parses) → pass
- `cradle_endpoint_tests` incl. `override_alone_does_not_enable_tee` → 4/4
- config module 292, rib module 217 → pass

Generated with [Claude Code](https://claude.com/claude-code)
