### PR TITLE
book: document the cradle eBPF data-plane integration

### DIFF
--- a/book/src/SUMMARY.md
+++ b/book/src/SUMMARY.md
@@ -127,6 +127,10 @@
 
 - [Fast Failover](ch-12-00-nexthop-protect.md)
 
+## Data Plane
+
+- [cradle eBPF Integration](ch-16-00-cradle.md)
+
 ## Performance Measurement
 
 - [STAMP](ch-09-00-twamp-stamp.md)

--- a/book/src/ch-16-00-cradle.md
+++ b/book/src/ch-16-00-cradle.md
@@ -1,0 +1,106 @@
+# cradle eBPF Data Plane
+
+[cradle](https://github.com/cradle-rs/cradle-rs) is a separate project: an
+**eBPF/XDP data plane** (L2–L7) that programs its forwarding state from a
+control plane over a gRPC API. zebra-rs is that control plane. When the cradle
+integration is enabled, every route zebra-rs computes — static, BGP, OSPF,
+IS-IS, plus the SR-MPLS / SRv6 / EVPN / MUP forwarding state — is **teed** to a
+running cradle in addition to the kernel FIB, so the eBPF datapath forwards it.
+
+The tee is bidirectional:
+
+- **Forward** (zebra-rs → cradle): each RIB install is mirrored to cradle over
+  its gRPC control API (`SetNexthop` / route / ILM / SID / GTP-PDR / … calls).
+  The kernel install still happens as usual, so the two planes stay in sync.
+- **Reverse** (cradle → zebra-rs): zebra-rs subscribes to cradle's datapath
+  **MAC learning** (`WatchFdb`); each learned/aged MAC is fed back into the RIB
+  and re-originated as an **EVPN Type-2** route,
+  exactly as a kernel-bridge learn would be. The subscriber reconnects with
+  backoff for the daemon's lifetime.
+
+Some forwarding behaviours have **no mainline-kernel equivalent** and therefore
+*require* cradle — notably real GTP-U for [MUP](ch-02-35-bgp-mup.md)
+(`dataplane gtp`) and [EVPN VPWS](ch-02-38-bgp-evpn-vpws.md) egress.
+
+## Configuration
+
+The integration lives under the `system cradle` container. It is off by
+default; a single boolean turns it on:
+
+```
+system {
+  cradle {
+    enabled true;
+  }
+}
+```
+
+or, in command form:
+
+```
+set system cradle enabled true
+```
+
+That is all a typical deployment needs — with no endpoint set, zebra-rs dials
+cradle's own default control socket, the Linux abstract socket
+`unix:cradle/grpc` (namespace-scoped, no filesystem path to coordinate). To
+point the tee somewhere else, add the `grpc-endpoint` override:
+
+```
+set system cradle enabled true
+set system cradle grpc-endpoint unix:/run/cradle.sock
+```
+
+| YANG leaf | Type | Default | Notes |
+|---|---|---|---|
+| `/system/cradle/enabled` | `boolean` | `false` | **The sole switch.** `true` enables the tee; `false` (or deleting it) disables it. |
+| `/system/cradle/grpc-endpoint` | `string` | `unix:cradle/grpc` | Optional endpoint override. Takes effect **only while the tee is enabled** — setting it on its own does *not* turn the tee on. |
+
+> **`enabled` is the only switch.** `grpc-endpoint` alone is inert: it just
+> re-points an already-enabled tee. To turn the integration on you must set
+> `system cradle enabled true`.
+
+## Endpoint forms
+
+`grpc-endpoint` accepts:
+
+| Form | Meaning |
+|---|---|
+| `unix:NAME` | **Linux abstract socket** (no leading `/`), scoped to the network namespace. The default `unix:cradle/grpc` is this form. |
+| `unix:/path/to.sock` | Filesystem unix-domain socket (leading `/`). |
+| `http://host:port` | TCP. |
+| `host:port` | A bare address is treated as TCP (`http://host:port`). |
+
+The abstract-socket form is the default because it needs no shared filesystem
+path and is unique per network namespace, which is how per-netns cradle
+deployments (and the BDD topologies) keep instances isolated. tonic cannot dial
+an abstract socket natively, so zebra-rs uses a custom connector for the
+`unix:NAME` case; the other forms use tonic's built-in support.
+
+## Runtime behaviour
+
+All of `system cradle` is a **runtime toggle** — no restart is needed:
+
+- `set system cradle enabled true` starts the forward tee and the reverse
+  `WatchFdb` subscriber immediately.
+- `set system cradle grpc-endpoint …` (while enabled) re-points both channels:
+  the previous subscriber is torn down and a new client dials the new endpoint.
+- `delete system cradle enabled` (or `set … false`) stops the tee and the
+  subscriber. Kernel installs are unaffected either way.
+
+## Environment fallback
+
+For quick experiments and test harnesses, the forward tee can also be
+bootstrapped from the **`CRADLE_GRPC`** environment variable at startup (same
+endpoint forms as above). This is a fallback only: it does not start the
+reverse EVPN MAC-learning subscriber, and any `system cradle` config change
+takes over from it. Prefer the config leaves for anything other than a
+throwaway run.
+
+## Related
+
+- [Mobile User Plane (MUP)](ch-02-35-bgp-mup.md) — `dataplane gtp` programs real
+  GTP-U via cradle.
+- [EVPN VPWS](ch-02-38-bgp-evpn-vpws.md) — E-Line egress runs on the cradle
+  datapath.
+- The cradle project itself: <https://github.com/cradle-rs/cradle-rs>.

--- a/zebra-rs/src/fib/cradle.rs
+++ b/zebra-rs/src/fib/cradle.rs
@@ -1,7 +1,8 @@
 //! Optional tee of FIB route installs into the **cradle** eBPF data plane.
 //!
-//! Enabled by the `system cradle grpc-endpoint <endpoint>` config leaf (or the
-//! `CRADLE_GRPC` env var as a fallback). When set, the protocol routes the RIB
+//! Enabled by `system cradle enabled true`; the endpoint is the
+//! `system cradle grpc-endpoint` override or the default `unix:cradle/grpc`
+//! (the `CRADLE_GRPC` env var is a startup fallback). When active, the RIB
 //! installs are also pushed to a running `cradle` via its gRPC control API, so
 //! zebra-rs-computed routes (static, BGP, OSPF, IS-IS, …) program the eBPF FIB
 //! in addition to the kernel. This is the zebra-rs side of the cradle-rs


### PR DESCRIPTION
## Summary
Adds a **cradle eBPF Data Plane** chapter (`ch-16-00-cradle`) under a new *Data Plane* TOC section. It documents:

- What the integration is: zebra-rs tees its computed FIB (static/BGP/OSPF/IS-IS + SR-MPLS/SRv6/EVPN/MUP) to the cradle eBPF datapath over gRPC, in addition to the kernel; plus the reverse `WatchFdb` MAC-learning → EVPN Type-2 channel.
- Configuration: `system cradle enabled` (the sole switch) and the optional `system cradle grpc-endpoint` override (default `unix:cradle/grpc`), with a YANG-leaf table.
- Accepted endpoint forms (`unix:NAME` abstract / `unix:/path` / `http://host:port` / bare `host:port`), runtime-toggle semantics, and the `CRADLE_GRPC` env fallback.

Also fixes a now-stale `fib/cradle.rs` module doc that still said the tee was enabled by the grpc-endpoint leaf (it is enabled by `system cradle enabled`).

## Test plan
- `mdbook build` succeeds with no warnings; the new chapter renders, the TOC entry appears, and cross-links (ch-02-35, ch-02-38) resolve.
- `cargo fmt --all -- --check` clean (doc-comment edit).

Generated with [Claude Code](https://claude.com/claude-code)