### PR TITLE
fib: log cradle tee "enabled" once, not per CradleFib

### DIFF
--- a/zebra-rs/src/fib/cradle.rs
+++ b/zebra-rs/src/fib/cradle.rs
@@ -178,7 +178,6 @@ impl CradleFib {
         } else {
             format!("http://{ep}")
         };
-        tracing::info!("fib: cradle eBPF tee enabled -> {endpoint}");
         Self {
             endpoint,
             client: Arc::new(Mutex::new(None)),
@@ -191,10 +190,19 @@ impl CradleFib {
         }
     }
 
+    /// The normalized gRPC endpoint this tee dials (as stored by `new`).
+    pub(crate) fn endpoint(&self) -> &str {
+        &self.endpoint
+    }
+
     /// Construct from `CRADLE_GRPC` if set (env fallback; the primary control is
     /// the `system cradle grpc-endpoint` config leaf). Returns `None` when unset.
     pub fn from_env() -> Option<Self> {
-        std::env::var("CRADLE_GRPC").ok().map(|ep| Self::new(&ep))
+        std::env::var("CRADLE_GRPC").ok().map(|ep| {
+            let fib = Self::new(&ep);
+            tracing::info!("fib: cradle eBPF tee enabled -> {}", fib.endpoint());
+            fib
+        })
     }
 
     /// Lazily connect (and cache) the gRPC client.

--- a/zebra-rs/src/fib/netlink/handle.rs
+++ b/zebra-rs/src/fib/netlink/handle.rs
@@ -531,8 +531,9 @@ impl FibHandle {
     /// runtime. Driven by the `system cradle grpc-endpoint` config leaf.
     pub fn set_cradle(&mut self, endpoint: Option<&str>) {
         self.cradle = endpoint.map(CradleFib::new);
-        if self.cradle.is_none() {
-            tracing::info!("fib: cradle eBPF tee disabled");
+        match &self.cradle {
+            Some(cradle) => tracing::info!("fib: cradle eBPF tee enabled -> {}", cradle.endpoint()),
+            None => tracing::info!("fib: cradle eBPF tee disabled"),
         }
     }
 


### PR DESCRIPTION
## Summary
Enabling `system/cradle/enabled` printed the `fib: cradle eBPF tee enabled -> …` line **twice** at startup. `cradle_apply()` constructs two `CradleFib` instances — the forward tee (`set_cradle`) and the reverse `WatchFdb` subscriber (`inst.rs`) — and the log lived in `CradleFib::new()`, so it fired per construction.

The fix moves the "enabled" announcement out of the constructor to the forward-tee ownership points:
- `set_cradle` — config path, now symmetric with the existing "disabled" log.
- `from_env` — the `CRADLE_GRPC` env fallback.

The reverse-watcher instance now stays silent. A `pub(crate) endpoint()` accessor keeps the log reporting the normalized endpoint (`new()` rewrites bare `host:port` → `http://host:port`), so the output is byte-for-byte identical to before — just once.

## Test plan
- `cargo build -p zebra-rs` — clean.
- `cargo fmt --all --check` — clean.
- Manual: `make run` with cradle enabled now prints the "enabled" line exactly once.

Generated with [Claude Code](https://claude.com/claude-code)