### PR TITLE
bgp: restore neighbor description with handler and show output

### DIFF
--- a/docs/orphan-report.txt
+++ b/docs/orphan-report.txt
@@ -14,8 +14,8 @@ ORPHAN leaf         /router/bgp/sharding/peer-sharding
   /router/bgp/color-policy  [p-container]
   /router/bgp/vrf/neighbor/afi-safi  [list]
 
-Total settable schema nodes: 283
-Handled: 271
+Total settable schema nodes: 284
+Handled: 272
 Orphans: 3
 
 Note: these orphans have no config callback but are kept intentionally.
@@ -26,7 +26,10 @@ IETF/OpenConfig/FRR idiom (`neighbor X enabled true`, present in ~418 test
 configs); it is accepted and inert (a neighbor is enabled by configuring
 remote-as) and the schema must accept it so those configs load. The other
 42 handler-less neighbor nodes were removed from the BGP YANG (vendored
-ietf leftovers / duplicates of handled zebra knobs).
+ietf leftovers / duplicates of handled zebra knobs); of those,
+neighbor/description has since been restored WITH a config handler
+(stored on the peer, echoed by `show bgp neighbors`), so it counts as
+handled above.
 
 == Handler paths with no schema node (stale/other) ==
   /router/bgp/neighbor/flowspec/validation

--- a/zebra-rs/src/bgp/config.rs
+++ b/zebra-rs/src/bgp/config.rs
@@ -802,6 +802,20 @@ fn config_pic_retention(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Option<(
     Some(())
 }
 
+/// `set router bgp neighbor X description <TEXT>` — free-form operator
+/// note stored on the peer and echoed under the header line of
+/// `show bgp neighbors`.
+fn config_peer_description(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Option<()> {
+    let addr = args.addr()?;
+    let peer = bgp.peers.get_mut(&addr)?;
+    match op {
+        ConfigOp::Set => peer.config.description = Some(args.string()?),
+        ConfigOp::Delete => peer.config.description = None,
+        _ => {}
+    }
+    Some(())
+}
+
 /// `set router bgp neighbor X flowspec validation true|false` — per
 /// RFC 9117, toggle whether flow specs received from this neighbor are
 /// validated against the unicast RIB before re-advertising. Defaults to
@@ -4168,6 +4182,9 @@ impl Bgp {
         // back-reference and resolves the inheritable attributes
         // (remote-as, afi-safi).
         self.callback_peer("/neighbor-group", config_peer_neighbor_group);
+        // Free-form operator note; storage-only, shown by
+        // `show bgp neighbors`.
+        self.callback_peer("/description", config_peer_description);
         // `set router bgp neighbor-group <name> [...]`.
         self.callback_add(
             "/router/bgp/neighbor-group",
@@ -8166,6 +8183,102 @@ mod afi_safi_next_hop_self_tests {
                 .unwrap()
                 .next_hop_self(Afi::Ip, Safi::MplsLabel),
             "delete clears the flag",
+        );
+    }
+}
+
+#[cfg(test)]
+mod neighbor_description_tests {
+    //! `neighbor <addr> description <text>` callback wiring.
+    //! `yang_load_tests` validates that the restored leaf loads; this
+    //! asserts the callback actually records the note on the peer.
+    //! Independent test module with its own mock channels, mirroring
+    //! `bfd_wiring_tests`.
+
+    use std::collections::VecDeque;
+    use std::net::{IpAddr, Ipv4Addr};
+
+    use tokio::sync::mpsc;
+
+    use super::*;
+
+    fn arg_words(parts: &[&str]) -> Args {
+        Args(
+            parts
+                .iter()
+                .map(|s| (*s).to_string())
+                .collect::<VecDeque<_>>(),
+        )
+    }
+
+    fn fresh_bgp() -> Bgp {
+        let (inbound_tx, _inbound_rx) = mpsc::unbounded_channel();
+        let (_rib_rx_tx, rib_rx) = mpsc::unbounded_channel();
+        let client = crate::rib::client::RibClient::new(
+            inbound_tx,
+            crate::rib::client::ProtoId::from_raw(0),
+        );
+        Box::leak(Box::new(_inbound_rx));
+        let ctx = crate::context::ProtoContext::default_table(client);
+
+        let (rib_tx, _rib_rx) = mpsc::unbounded_channel();
+        let (rib_inbound_tx, _sub_inbound_rx) = mpsc::unbounded_channel();
+        Box::leak(Box::new(_rib_rx));
+        Box::leak(Box::new(_sub_inbound_rx));
+        let next_proto_id = std::sync::Arc::new(std::sync::atomic::AtomicU32::new(1));
+        let subscriber =
+            crate::config::RibSubscriber::for_test(rib_tx, rib_inbound_tx, next_proto_id);
+
+        let (policy_tx, _policy_rx) = mpsc::unbounded_channel();
+        Box::leak(Box::new(_policy_rx));
+        Bgp::new(
+            ctx,
+            rib_rx,
+            subscriber,
+            policy_tx,
+            None,
+            None,
+            tokio::sync::mpsc::channel(1).0,
+        )
+    }
+
+    /// `neighbor X description <text>` records the note on the peer;
+    /// a re-set overwrites it and `delete` clears it.
+    #[tokio::test]
+    async fn description_set_overwrite_delete() {
+        let mut bgp = fresh_bgp();
+        config_peer(&mut bgp, arg_words(&["10.0.0.2"]), ConfigOp::Set).unwrap();
+        let addr = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 2));
+
+        assert!(bgp.peers.get(&addr).unwrap().config.description.is_none());
+
+        config_peer_description(
+            &mut bgp,
+            arg_words(&["10.0.0.2", "core uplink"]),
+            ConfigOp::Set,
+        )
+        .unwrap();
+        assert_eq!(
+            bgp.peers.get(&addr).unwrap().config.description.as_deref(),
+            Some("core uplink"),
+        );
+
+        config_peer_description(
+            &mut bgp,
+            arg_words(&["10.0.0.2", "lab peer"]),
+            ConfigOp::Set,
+        )
+        .unwrap();
+        assert_eq!(
+            bgp.peers.get(&addr).unwrap().config.description.as_deref(),
+            Some("lab peer"),
+            "re-set overwrites",
+        );
+
+        config_peer_description(&mut bgp, arg_words(&["10.0.0.2"]), ConfigOp::Delete).unwrap();
+        assert!(
+            bgp.peers.get(&addr).unwrap().config.description.is_none(),
+            "delete clears the note",
         );
     }
 }

--- a/zebra-rs/src/bgp/peer.rs
+++ b/zebra-rs/src/bgp/peer.rs
@@ -604,6 +604,9 @@ pub struct PeerConfig {
     /// handling (transitive-retain + Partial / non-transitive-drop /
     /// well-known NOTIFICATION) can be exercised end to end. `None` = off.
     pub attach_unknown_attr: Option<UnknownAttr>,
+    /// Free-form operator note (`neighbor <addr> description <text>`),
+    /// echoed under the header line of `show bgp neighbors`.
+    pub description: Option<String>,
 }
 
 impl Default for PeerConfig {
@@ -634,6 +637,7 @@ impl Default for PeerConfig {
             enforce_first_as: false,
             local_as: None,
             attach_unknown_attr: None,
+            description: None,
         }
     }
 }

--- a/zebra-rs/src/bgp/show.rs
+++ b/zebra-rs/src/bgp/show.rs
@@ -2693,6 +2693,11 @@ struct Neighbor<'a> {
     /// unnumbered peer from an address-configured one.
     #[serde(skip_serializing_if = "Option::is_none")]
     interface: Option<&'a str>,
+    /// Free-form operator note (`neighbor <addr> description <text>`);
+    /// rendered as `Description: <text>` directly under the header
+    /// line, FRR-style.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    description: Option<&'a str>,
     peer_type: &'a str,
     local_as: u32,
     remote_as: u32,
@@ -3028,6 +3033,7 @@ fn fetch(peer: &Peer) -> Neighbor<'_> {
     let mut n = Neighbor {
         address: peer.address,
         interface: peer.ifname.as_deref(),
+        description: peer.config.description.as_deref(),
         remote_as: peer.remote_as,
         // The AS this session presents — the `local-as` substitute when
         // one is active (FRR prints change_local_as here too).
@@ -3161,17 +3167,22 @@ fn render(out: &mut String, neighbor: &Neighbor) -> std::fmt::Result {
 
     writeln!(
         out,
-        r#"BGP neighbor {}, remote AS {}, local AS {}, {} link
-{}  BGP version 4, remote router ID {}, local router ID {}
+        "BGP neighbor {}, remote AS {}, local AS {}, {} link",
+        identity, neighbor.remote_as, neighbor.local_as, neighbor.peer_type,
+    )?;
+    // FRR prints the operator's free-form description directly under
+    // the header line.
+    if let Some(description) = neighbor.description {
+        writeln!(out, "  Description: {}", description)?;
+    }
+    writeln!(
+        out,
+        r#"{}  BGP version 4, remote router ID {}, local router ID {}
   BGP state = {}, up for {}
   Last read 00:00:00, Last write 00:00:00
   Hold time {} seconds, keepalive {} seconds
   Sent Hold time {} seconds, sent keepalive {} seconds
   Recv Hold time {} seconds, Recieved keepalive {} seconds"#,
-        identity,
-        neighbor.remote_as,
-        neighbor.local_as,
-        neighbor.peer_type,
         host_info,
         neighbor.remote_router_id,
         neighbor.local_router_id,
@@ -5517,6 +5528,28 @@ Neighbor        V         AS   MsgRcvd   MsgSent   TblVer  InQ OutQ  Up/Down Sta
         );
     }
 
+    /// `neighbor X description <text>` renders FRR-style directly
+    /// under the header line; a peer without one gets no line.
+    #[test]
+    fn description_line_rendered_only_when_present() {
+        let mut out = String::new();
+        let n = minimal_neighbor(None);
+        render(&mut out, &n).unwrap();
+        assert!(
+            !out.contains("Description:"),
+            "no Description line without config:\n{out}"
+        );
+
+        let mut out = String::new();
+        let mut n = minimal_neighbor(None);
+        n.description = Some("core uplink");
+        render(&mut out, &n).unwrap();
+        assert!(
+            out.contains("internal link\n  Description: core uplink\n"),
+            "Description line missing or misplaced:\n{out}"
+        );
+    }
+
     /// Build a `Neighbor` DTO directly (all-`None` ND fields) and
     /// verify that `render` does NOT emit any ND block — address-keyed
     /// peers must be unaffected.
@@ -5647,6 +5680,7 @@ Neighbor        V         AS   MsgRcvd   MsgSent   TblVer  InQ OutQ  Up/Down Sta
         Neighbor {
             address: "10.0.0.1".parse().unwrap(),
             interface,
+            description: None,
             peer_type: "internal",
             local_as: 65001,
             remote_as: 65002,

--- a/zebra-rs/yang/ietf-bgp-common@2023-07-05.yang
+++ b/zebra-rs/yang/ietf-bgp-common@2023-07-05.yang
@@ -233,6 +233,13 @@ submodule ietf-bgp-common {
     // route-flap-damping was removed from neighbor-group-config: it was an
     // unhandled orphan (no config handler) on every consumer of this
     // grouping and has been dropped.
+    leaf description {
+      ext:help "Free-form neighbor description";
+      type string;
+      description
+        "Free-form description string echoed in `show bgp neighbors`
+         output.";
+    }
     container timers {
       ext:help "Per-neighbor BGP timers";
       description

--- a/zebra-rs/yang/ietf-bgp-common@2023-07-05.yang
+++ b/zebra-rs/yang/ietf-bgp-common@2023-07-05.yang
@@ -235,10 +235,17 @@ submodule ietf-bgp-common {
     // grouping and has been dropped.
     leaf description {
       ext:help "Free-form neighbor description";
-      type string;
+      // The pattern makes the value consume the rest of the command
+      // line, whitespace included (`match_regexp` in config/parse.rs)
+      // — FRR's `neighbor X description LINE`. A pattern-less string
+      // would stop at the first space.
+      type string {
+        pattern '.*';
+      }
       description
         "Free-form description string echoed in `show bgp neighbors`
-         output.";
+         output. May contain spaces: the value is the rest of the
+         line.";
     }
     container timers {
       ext:help "Per-neighbor BGP timers";

--- a/zebra-rs/yang/zebra-bgp-vrf.yang
+++ b/zebra-rs/yang/zebra-bgp-vrf.yang
@@ -170,10 +170,17 @@ module zebra-bgp-vrf {
       }
       leaf description {
         ext:help "Free-form neighbor description";
-        type string;
+        // The pattern makes the value consume the rest of the command
+        // line, whitespace included (`match_regexp` in config/parse.rs)
+        // — same rest-of-line semantics as the global neighbor's
+        // description leaf in ietf-bgp-common.
+        type string {
+          pattern '.*';
+        }
         description
           "Free-form description string echoed in `show bgp vrf X
-           neighbors` output.";
+           neighbors` output. May contain spaces: the value is the
+           rest of the line.";
       }
       list afi-safi {
         ext:help "Per-address-family activation for this CE peer";


### PR DESCRIPTION
## Summary

Commit ee9b79fb removed `/router/bgp/neighbor/description` as one of the 43 handler-less orphan YANG nodes. This restores the command, wired end to end instead of as an inert schema leaf:

- **yang**: re-add `leaf description` (with `ext:help`) to `neighbor-group-config` in `ietf-bgp-common`; the grouping's only consumer is the global neighbor list, so exactly the one path returns.
- **config**: new `config_peer_description` callback at `/router/bgp/neighbor/description` stores the note on `PeerConfig::description`; Set overwrites, Delete clears. Matches the per-VRF neighbor's existing `config_vrf_neighbor_description`.
- **show**: `show bgp neighbor X` prints `Description: <text>` directly under the header line (FRR position); the JSON form carries a `description` field. Both are omitted when unset.
- **docs**: orphan-report counts refreshed (284 settable / 272 handled) with a note that description returned with a handler.

## Test plan

- New wiring test `description_set_overwrite_delete` (set → overwrite → delete on a mock `Bgp`) and render test `description_line_rendered_only_when_present`.
- Full `cargo test -p zebra-rs` (1525 passed) and workspace suite green; `cargo clippy --workspace --all-targets -- -D warnings` clean; `cargo fmt --all` applied.
- Verified on a live daemon (repo YANG, abstract vty socket): set renders the line in text + JSON, delete (with the leaf value in the path) removes it.

Generated with [Claude Code](https://claude.com/claude-code)