### PR TITLE
bgp: tag redistribute presence containers ext:non-empty

### DIFF
--- a/zebra-rs/src/config/configs.rs
+++ b/zebra-rs/src/config/configs.rs
@@ -565,6 +565,19 @@ impl Config {
                     errors.push(format!("'{}' requires {}", parents, self.non_empty));
                 }
             }
+            // `ext:non-empty` on a presence container checks the node
+            // itself: a bare `... redistribute` enables nothing, the same
+            // dead config as a key-only list entry. A list node carrying
+            // the tag never has `presence` set, so the two arms are
+            // disjoint.
+            if self.presence && !self.has_dir() && self.list.borrow().is_empty() {
+                let mut parents = VecDeque::<String>::new();
+                self.parents(&mut parents);
+                parents.push_back(self.name.clone());
+                let parents = Vec::from(parents);
+                let parents = parents.join(" ");
+                errors.push(format!("'{}' requires {}", parents, self.non_empty));
+            }
         }
         for key in self.keys.borrow().iter() {
             key.validate(errors);
@@ -771,13 +784,16 @@ pub fn delete(paths: Vec<CommandPath>, mut config: Rc<Config>) {
             // cascading to prune the entry (and the list node, if it too
             // becomes empty) instead of leaving the bare key behind. Gated on
             // the parent list carrying the marker, so ordinary key entries
-            // still stop the cascade as before.
+            // still stop the cascade as before. An `ext:non-empty` presence
+            // container carries the marker on itself (e.g. a `redistribute`
+            // whose last source was deleted) — prune it the same way.
             let prunable_empty_entry = !config.has_dir()
                 && config.list.borrow().is_empty()
-                && config
+                && (config
                     .parent
                     .as_ref()
-                    .is_some_and(|p| !p.non_empty.is_empty());
+                    .is_some_and(|p| !p.non_empty.is_empty())
+                    || (config.presence && !config.non_empty.is_empty()));
             if !prunable_empty_entry {
                 break;
             }

--- a/zebra-rs/src/config/manager.rs
+++ b/zebra-rs/src/config/manager.rs
@@ -2232,6 +2232,107 @@ mod yang_load_tests {
         }
     }
 
+    /// The BGP `redistribute` presence containers (global per-AFI and
+    /// per-VRF per-family) are dead config when bare — presence alone
+    /// redistributes nothing; the source children (`connected` / `static` /
+    /// `ospf` / `isis`) carry the intent. Both are tagged `ext:non-empty`,
+    /// exercising the presence-container arm of the machinery (the list
+    /// cases above ride the key-entry arm): a bare container is rejected at
+    /// commit and pruned when its last source is deleted. Drives the real
+    /// schema.
+    #[test]
+    fn bgp_redistribute_bare_container_rejected_and_pruned() {
+        use crate::config::ExecCode;
+        use crate::config::configs::{delete, set};
+        use crate::config::parse::{State, parse};
+        use crate::config::{Config, paths::path_try_trim};
+        use libyang::to_entry;
+        use std::rc::Rc;
+
+        let mut yang = YangStore::new();
+        yang.add_path(concat!(env!("CARGO_MANIFEST_DIR"), "/yang"));
+        yang.read_with_resolve("configure")
+            .unwrap_or_else(|e| panic!("configure failed to load: {e:#}"));
+        yang.identity_resolve();
+        let module = yang.find_module("configure").unwrap();
+        let entry = to_entry(&yang, module);
+        let set_entry = entry
+            .dir
+            .borrow()
+            .iter()
+            .find(|e| e.name == "set")
+            .cloned()
+            .expect("configure mode has a `set` entry");
+        let paths = |cmd: &str| {
+            let (code, _comps, state) = parse(cmd, set_entry.clone(), None, State::new());
+            assert_eq!(code, ExecCode::Success, "should parse: {cmd}");
+            path_try_trim("set", state.paths)
+        };
+        let validate_errors = |line: &[crate::config::CommandPath]| -> Vec<String> {
+            let root = Rc::new(Config::new("".to_string(), None));
+            set(line.to_vec(), root.clone());
+            let mut errors = Vec::new();
+            root.validate(&mut errors);
+            errors
+        };
+
+        for (bare, with_child) in [
+            (
+                "router bgp afi-safi ipv4 redistribute",
+                "router bgp afi-safi ipv4 redistribute connected",
+            ),
+            (
+                "router bgp vrf blue afi-safi ipv4 redistribute",
+                "router bgp vrf blue afi-safi ipv4 redistribute static",
+            ),
+        ] {
+            // Bare `redistribute` → rejected with the source hint.
+            let errors = validate_errors(&paths(bare));
+            assert!(
+                errors
+                    .iter()
+                    .any(|e| e.contains("redistribute")
+                        && e.contains("connected, static, ospf or isis")),
+                "bare `{bare}` must be rejected, got: {errors:?}"
+            );
+
+            // With a source child → validates clean.
+            let errors = validate_errors(&paths(with_child));
+            assert!(
+                errors.is_empty(),
+                "`{with_child}` must validate clean, got: {errors:?}"
+            );
+
+            // set + delete of the only source → the container is pruned,
+            // leaving no bare `redistribute` to fail the next commit.
+            let root = Rc::new(Config::new("".to_string(), None));
+            let line = paths(with_child);
+            set(line.clone(), root.clone());
+            delete(line, root.clone());
+            let mut errors = Vec::new();
+            root.validate(&mut errors);
+            assert!(
+                errors.is_empty(),
+                "tree must validate clean after set+delete of `{with_child}`, got: {errors:?}"
+            );
+            // Walk down from `router bgp` and assert no `redistribute`
+            // node survives anywhere on the path (global: under the
+            // afi-safi entry; VRF: under the family container — both
+            // subtrees cascade away entirely once emptied).
+            fn find_redistribute(c: &Rc<Config>) -> bool {
+                if c.name == "redistribute" {
+                    return true;
+                }
+                c.configs.borrow().iter().any(find_redistribute)
+                    || c.keys.borrow().iter().any(find_redistribute)
+            }
+            assert!(
+                !find_redistribute(&root),
+                "redistribute container must be pruned after its last source is deleted"
+            );
+        }
+    }
+
     /// Mirror SID egress-protection config paths
     /// (`draft-ietf-rtgwg-srv6-egress-protection`, config.yang). vtyctl
     /// apply is garbage-tolerant, so an unwired list / key / leaf would

--- a/zebra-rs/yang/zebra-bgp-redistribute.yang
+++ b/zebra-rs/yang/zebra-bgp-redistribute.yang
@@ -136,6 +136,10 @@ module zebra-bgp-redistribute {
        filters at commit time.";
     container redistribute {
       ext:help "Redistribute routes into BGP";
+      // A bare `redistribute` with no source child enables nothing:
+      // reject it at commit and prune the container when its last
+      // source is deleted (ext:non-empty on a presence container).
+      ext:non-empty "connected, static, ospf or isis";
       presence "Enable route redistribution into BGP for this AFI";
       container connected {
         ext:help "Redistribute connected routes";

--- a/zebra-rs/yang/zebra-bgp-vrf.yang
+++ b/zebra-rs/yang/zebra-bgp-vrf.yang
@@ -234,6 +234,10 @@ module zebra-bgp-vrf {
        modifiers).";
     container redistribute {
       ext:help "Redistribute RIB routes into this VRF's BGP";
+      // A bare `redistribute` with no source child enables nothing:
+      // reject it at commit and prune the container when its last
+      // source is deleted (ext:non-empty on a presence container).
+      ext:non-empty "connected, static, ospf or isis";
       presence "Enable route redistribution into this VRF's BGP table";
       container connected {
         ext:help "Redistribute this VRF's connected routes";


### PR DESCRIPTION
## Summary

A bare `redistribute` presence container — `/router/bgp/afi-safi/redistribute` and `/router/bgp/vrf/afi-safi/{ipv4,ipv6}/redistribute` — enables nothing: the source children (`connected` / `static` / `ospf` / `isis`) carry all the intent, so presence alone is dead config. Both are now tagged `ext:non-empty "connected, static, ospf or isis"`: a bare container is **rejected at commit** and **pruned when its last source is deleted**.

`ext:non-empty` so far only covered YANG lists (key-only entries), so this extends the generic machinery to presence containers:

- **`configs.rs` `validate()`**: a presence container carrying the marker must itself have ≥1 child. A list node carrying the marker never has `presence` set, so the list-entry and container arms are disjoint.
- **`configs.rs` delete-cascade**: prune an emptied marker-carrying presence container (the list arm gates on the *parent's* marker; a container carries its *own*), so deleting the last source cannot leave behind a bare `redistribute` that fails the next commit.
- **YANG**: tag in `zebra-bgp-redistribute.yang` (global; the grouping is shared by the set/delete augments) and `zebra-bgp-vrf.yang` (grouping used by both the ipv4 and ipv6 families).

No handler changes needed: the bare global container has no callback, and the bare VRF callback only acts on Delete. No fixture in the repo commits a bare redistribute.

## Test plan

- New schema-driven test `bgp_redistribute_bare_container_rejected_and_pruned` (parse → set → validate → delete for both the global and VRF paths, against the real YANG).
- Full workspace tests and `cargo clippy --workspace --all-targets -- -D warnings` green; `cargo fmt --all` applied.
- Verified live on a fresh daemon: both bare forms rejected with `'… redistribute' requires connected, static, ospf or isis`; sources apply; deleting the last source prunes the container and the follow-up commit stays clean.

Generated with [Claude Code](https://claude.com/claude-code)