### PR TITLE
OSPF TI-LFA: terminate repair stacks at the destination's node SID

### DIFF
--- a/bdd/tests/features/ospfv2_tilfa.feature
+++ b/bdd/tests/features/ospfv2_tilfa.feature
@@ -199,6 +199,13 @@ Feature: OSPFv2 TI-LFA fast-reroute over SR-MPLS
     # kernel entry, out the repair egress s-n2.
     Then kernel route "10.0.0.8" in namespace "s" should eventually contain "encap mpls"
     And kernel route "10.0.0.8" in namespace "s" should eventually contain "dev s-n2 proto ospf metric 2"
+    # The repair stack ends with d's own node-SID label (16800), so
+    # traffic tunneled through the route — a recursive static/BGP
+    # nexthop resolved onto it — label-switches all the way to d
+    # instead of being IP-routed (and possibly dropped) at the repair
+    # release point. "/16800 via" pins 16800 to the stack tail: the
+    # demoted plain-primary's "encap mpls 16800 via" has no slash.
+    And kernel route "10.0.0.8" in namespace "s" should eventually contain "/16800 via"
     # End-to-end over the repair: dies if any label hop on the repair
     # path fails to swap/pop/forward.
     And ping from "s" to "10.0.0.8" should succeed

--- a/bdd/tests/features/ospfv3_tilfa.feature
+++ b/bdd/tests/features/ospfv3_tilfa.feature
@@ -215,6 +215,13 @@ Feature: OSPFv3 TI-LFA fast-reroute over SR-MPLS
     Then kernel route "2001:db8::8" in namespace "s" should eventually contain "encap mpls"
     And kernel route "2001:db8::8" in namespace "s" should eventually contain "proto ospf metric 2"
     And kernel route "2001:db8::8" in namespace "s" should eventually contain "dev s-n2"
+    # The repair stack ends with d's own node-SID label (16800), so
+    # traffic tunneled through the route label-switches all the way
+    # to d instead of being IP-routed (and possibly dropped) at the
+    # repair release point. "/16800 via" pins 16800 to the stack
+    # tail: the demoted plain-primary's single-label "encap mpls
+    # 16800 via" has no slash.
+    And kernel route "2001:db8::8" in namespace "s" should eventually contain "/16800 via"
     # End-to-end over the repair: dies if any label hop on the
     # s-n2-r1-r2-r3-d repair path fails to swap/pop/forward.
     And ping from "s" to "2001:db8::8" should succeed

--- a/zebra-rs/src/ospf/inst.rs
+++ b/zebra-rs/src/ospf/inst.rs
@@ -12860,9 +12860,23 @@ fn build_rib_from_spf(
             let Some(repair) = tilfa_result.get(&dest).and_then(|paths| paths.first()) else {
                 continue;
             };
-            let Some(backup) = build_repair_path_mpls(top, area, repair) else {
+            let Some(mut backup) = build_repair_path_mpls(top, area, repair) else {
                 continue;
             };
+            // A repair list only steers the packet to its release
+            // point; from there the inner packet is IP-routed. That
+            // suffices for traffic addressed inside the protected
+            // prefix, but traffic tunneled through this route (a
+            // recursive static/BGP nexthop resolved onto it) carries
+            // an inner destination the release point may not know.
+            // Append the prefix's own node-SID label below the repair
+            // segments so the repair label-switches all the way to
+            // the destination node — mirrors IS-IS
+            // (`backup_append_prefix_sid`). `add_prefix_sids` ran
+            // above, so `route.sid` is already resolved here.
+            if let Some(sid) = route.sid {
+                backup.labels.push(rib::Label::Explicit(sid));
+            }
             if let Some(nhop) = route.nhops.values_mut().next() {
                 nhop.backup = Some(backup);
             }
@@ -13891,6 +13905,7 @@ fn apply_v3_spf_result(top: &mut Ospf<Ospfv3>, output: SpfOutput) {
     // below.
     let mut area_rib = build_rib6_from_spf(top, area_id, source, &spf_result, &tilfa_result);
     add_prefix_sids_v3(top, area_id, &mut area_rib);
+    append_repair_tail_sids_v3(&mut area_rib);
     top.rib6_areas.insert(area_id, area_rib);
     top.spf_results.insert(area_id, spf_result.clone());
     let merged = merge_area_ribs6(top);
@@ -14813,6 +14828,32 @@ fn add_prefix_sids_v3(
                 route.prefix_sid = Some((value, label_config.clone()));
                 route.sid = sid_label;
                 break;
+            }
+        }
+    }
+}
+
+/// Close each stamped SR-MPLS TI-LFA repair into a full SR path by
+/// appending the prefix's own node-SID label below the repair
+/// segments — the v3 sibling of the append in v2's TI-LFA second
+/// pass (and IS-IS's `backup_append_prefix_sid`). A repair list only
+/// steers the packet to its release point; traffic tunneled through
+/// the route (a recursive static/BGP nexthop resolved onto it) needs
+/// the tail label to reach the destination node. This runs as its
+/// own pass because v3 resolves Prefix-SIDs (`add_prefix_sids_v3`)
+/// only after the repair stamping inside `build_rib6_from_spf`; the
+/// area slice is rebuilt from scratch every SPF run, so the append
+/// happens exactly once per stack. SRv6 repairs are SRH-inserted and
+/// keep the original destination as the SRH's final segment, so they
+/// need no tail.
+fn append_repair_tail_sids_v3(rib: &mut PrefixMap<ipnet::Ipv6Net, SpfRouteV3>) {
+    for (_, route) in rib.iter_mut() {
+        let Some(label) = route.sid else {
+            continue;
+        };
+        for nhop in route.nhops.values_mut() {
+            if let Some(super::tilfa::RepairBackupV3::Mpls(b)) = nhop.backup.as_mut() {
+                b.labels.push(rib::Label::Explicit(label));
             }
         }
     }
@@ -16163,6 +16204,90 @@ mod multi_area_tests {
         rib_insert(&mut rib, p, route(20, RouteType::InterArea));
         rib_insert(&mut rib, p, route(40, RouteType::InterArea));
         assert_eq!(rib.get(&p).unwrap().metric, 20);
+    }
+}
+
+#[cfg(test)]
+mod repair_tail_sid_tests {
+    use super::{RouteType, SpfNexthopV3, SpfRouteV3, append_repair_tail_sids_v3};
+    use crate::ospf::tilfa::{RepairBackupV3, RepairPathMplsV3};
+    use crate::rib::Label;
+    use ipnet::Ipv6Net;
+    use prefix_trie::PrefixMap;
+    use std::collections::BTreeMap;
+
+    fn route_v3(sid: Option<u32>, backup: Option<RepairBackupV3>) -> SpfRouteV3 {
+        let mut nhops = BTreeMap::new();
+        nhops.insert(
+            "fe80::1".parse().unwrap(),
+            SpfNexthopV3 {
+                ifindex: 3,
+                adjacency: false,
+                backup,
+            },
+        );
+        SpfRouteV3 {
+            metric: 12,
+            path_type: RouteType::IntraArea,
+            nhops,
+            sid,
+            prefix_sid: None,
+            dest_vertex: Some(1),
+            backup_as_primary: false,
+        }
+    }
+
+    fn mpls_backup(labels: Vec<u32>) -> RepairBackupV3 {
+        RepairBackupV3::Mpls(RepairPathMplsV3 {
+            ifindex: 3,
+            addr: "fe80::2".parse().unwrap(),
+            labels: labels.into_iter().map(Label::Explicit).collect(),
+        })
+    }
+
+    #[test]
+    fn appends_prefix_sid_below_repair_segments() {
+        let mut rib: PrefixMap<Ipv6Net, SpfRouteV3> = PrefixMap::new();
+        rib.insert(
+            "2001:db8::8/128".parse().unwrap(),
+            route_v3(Some(16800), Some(mpls_backup(vec![16500, 15003]))),
+        );
+        append_repair_tail_sids_v3(&mut rib);
+        let route = rib.get(&"2001:db8::8/128".parse().unwrap()).unwrap();
+        let Some(RepairBackupV3::Mpls(b)) = &route.nhops.values().next().unwrap().backup else {
+            panic!("Mpls backup preserved");
+        };
+        assert_eq!(
+            b.labels,
+            vec![
+                Label::Explicit(16500),
+                Label::Explicit(15003),
+                Label::Explicit(16800)
+            ]
+        );
+    }
+
+    #[test]
+    fn no_sid_or_no_backup_is_a_no_op() {
+        let mut rib: PrefixMap<Ipv6Net, SpfRouteV3> = PrefixMap::new();
+        // Repair but no resolved Prefix-SID: stack must stay as built.
+        rib.insert(
+            "2001:db8::7/128".parse().unwrap(),
+            route_v3(None, Some(mpls_backup(vec![16500]))),
+        );
+        // SID but no repair: nothing to append to.
+        rib.insert(
+            "2001:db8::6/128".parse().unwrap(),
+            route_v3(Some(16600), None),
+        );
+        append_repair_tail_sids_v3(&mut rib);
+        let r7 = rib.get(&"2001:db8::7/128".parse().unwrap()).unwrap();
+        let Some(RepairBackupV3::Mpls(b)) = &r7.nhops.values().next().unwrap().backup else {
+            panic!("Mpls backup preserved");
+        };
+        assert_eq!(b.labels, vec![Label::Explicit(16500)]);
+        let r6 = rib.get(&"2001:db8::6/128".parse().unwrap()).unwrap();
+        assert!(r6.nhops.values().next().unwrap().backup.is_none());
     }
 }
 


### PR DESCRIPTION
## Summary

OSPFv2/v3 sibling of the IS-IS fix merged in #1836. A TI-LFA repair list only steers the packet to its release point (Q node); from there the inner packet is IP-routed. That is sound for traffic addressed inside the protected prefix (the Q-space guarantee is per destination), but traffic **tunneled through** the route — a recursive static/BGP nexthop resolved onto it — carries an inner destination the release point may not know, and blackholes there.

Fix: append the protected prefix's own node-SID label below the repair segments so the repair label-switches all the way to the destination node, per RFC 9855 §6.1 (the active segment MUST be kept beneath the inserted repair list) and the RFC 7490 §8 Remote-LFA precedent.

- **v2**: append inline in `build_rib_from_spf`'s TI-LFA second pass (`add_prefix_sids` has already resolved `route.sid` there).
- **v3**: Prefix-SIDs resolve only *after* the repair stamping (`add_prefix_sids_v3` runs on the freshly built area slice), so a dedicated `append_repair_tail_sids_v3` pass runs right after it; the slice is rebuilt every SPF run, so the append is exactly once per stack.
- **SRv6 repairs unchanged**: they are SRH-inserted (H.Insert) and keep the original destination as the SRH's final segment — no tail needed; the append applies to the `Mpls` arm only.
- BDD: the v2/v3 promoted-backup scenarios now assert `/16800 via` — the slash pins d's node-SID to the tail of a multi-label stack, so the assert fails on a release-point-terminated repair.

## Test plan

- [x] New unit tests: `repair_tail_sid_tests` (append below repair segments; no-op without SID or without repair)
- [x] `cargo test --workspace --exclude bdd` — all 37 suites pass; clippy `-D warnings`; fmt
- [x] `make -C bdd ospfv2_tilfa` — 10/10 incl. the new tail-label assert + ping over the repair
- [x] `make -C bdd ospfv3_tilfa` — 10/10 incl. the new tail-label assert + ping over the repair
- [x] SRv6 regression: `ospfv3_tilfa_srv6` 5/5, `ospfv3_tilfa_srv6_classic` 5/5 (unaffected by design)

🤖 Generated with [Claude Code](https://claude.com/claude-code)