### PR TITLE
Reflect 'set system hostname' in the vty prompt (n1> / n1#)

### DIFF
--- a/bdd/Makefile
+++ b/bdd/Makefile
@@ -189,6 +189,10 @@ isis_srmpls:
 	mkdir -p allure-results
 	cargo test --test cucumber -- --concurrency=1 --tags "@isis_srmpls"
 
+system_hostname:
+	mkdir -p allure-results
+	cargo test --test cucumber -- --concurrency=1 --tags "@system_hostname"
+
 isis_l1l2:
 	mkdir -p allure-results
 	cargo test --test cucumber -- --concurrency=1 --tags "@isis_l1l2"
@@ -426,4 +430,4 @@ docs/%.md: tests/features/%.feature docs/feature2md.sh FORCE
 
 FORCE:
 
-.PHONY: ecmp_bfd_evict ospfv2_bfd_frr ospfv3_bfd_frr tilfa_bfd all run ibgp ebgp rr rib_static_ipv6 isis_ipv6 isis_srv6_base isis_fragmentation_ipv6 isis_fragmentation_ipv4 isis_l1p2p isis_tilfa isis_srmpls isis_l1l2 isis_redist isis_hello_auth_keychain isis_passive isis_afi_enable isis_endx_ipv6 isis_bfd_ipv6_p2p isis_bfd_ipv6_p2p_echo isis_bfd_ipv6_lan isis_bfd_ipv6_lan_echo isis_bfd_ipv4_p2p isis_bfd_ipv4_p2p_echo isis_bfd_ipv4_lan isis_bfd_ipv4_lan_echo ospf_clear_neighbor ospfv2_nssa_base ospfv2_stub_base ospfv2_tilfa ospfv3_nssa ospfv3_tilfa stamp_te_metric stamp_v6_te_metric bgp_peer_down_cleanup bgp_ipv6_over_v4_session bgp_evpn_capability bgp_vrf_evpn_type5 bgp_evpn_outpolicy_undef bgp_route_map_match bgp_policy_dynamic_update bgp_table_map bgp_v6_table_map bgp_community bgp_neighbor_group bgp_unnumbered_neighbor nd_show bgp_interas_option_c bgp_interas_option_a bgp_interas_option_b bgp_interas_option_ab bgp_port bgp_ip_transparent bgp_local_as bgp_unknown_attr_transitive bgp_fast_external_failover generate open docs FORCE
+.PHONY: ecmp_bfd_evict ospfv2_bfd_frr ospfv3_bfd_frr tilfa_bfd all run ibgp ebgp rr rib_static_ipv6 isis_ipv6 isis_srv6_base isis_fragmentation_ipv6 isis_fragmentation_ipv4 isis_l1p2p isis_tilfa isis_srmpls system_hostname isis_l1l2 isis_redist isis_hello_auth_keychain isis_passive isis_afi_enable isis_endx_ipv6 isis_bfd_ipv6_p2p isis_bfd_ipv6_p2p_echo isis_bfd_ipv6_lan isis_bfd_ipv6_lan_echo isis_bfd_ipv4_p2p isis_bfd_ipv4_p2p_echo isis_bfd_ipv4_lan isis_bfd_ipv4_lan_echo ospf_clear_neighbor ospfv2_nssa_base ospfv2_stub_base ospfv2_tilfa ospfv3_nssa ospfv3_tilfa stamp_te_metric stamp_v6_te_metric bgp_peer_down_cleanup bgp_ipv6_over_v4_session bgp_evpn_capability bgp_vrf_evpn_type5 bgp_evpn_outpolicy_undef bgp_route_map_match bgp_policy_dynamic_update bgp_table_map bgp_v6_table_map bgp_community bgp_neighbor_group bgp_unnumbered_neighbor nd_show bgp_interas_option_c bgp_interas_option_a bgp_interas_option_b bgp_interas_option_ab bgp_port bgp_ip_transparent bgp_local_as bgp_unknown_attr_transitive bgp_fast_external_failover generate open docs FORCE

--- a/bdd/tests/features/system_hostname.feature
+++ b/bdd/tests/features/system_hostname.feature
@@ -1,0 +1,34 @@
+@system_hostname
+Feature: system hostname configuration
+  As a network operator
+  I want `set system hostname <name>` to define the device's name so
+  that `show hostname` (and the interactive vty prompt, which tracks
+  the same running-config leaf via vtyhelper -H) reflects the
+  configured identity instead of the OS hostname, and falls back to
+  the OS hostname when the leaf is deleted.
+
+  Scenario: Build a single-node topology
+    Given a clean test environment
+    When I create namespace "z1"
+    And I start zebra-rs in namespace "z1"
+    And I wait 2 seconds
+    Then show command "show version" in namespace "z1" should contain "zebra-rs"
+
+  Scenario: Configured hostname wins over the OS hostname
+    Given the test topology exists
+    # Before any config, show hostname reports the OS hostname —
+    # whatever it is, it is not our marker name.
+    Then show command "show hostname" in namespace "z1" should not contain "bdd-host-n1"
+    When I apply command "set system hostname bdd-host-n1" in namespace "z1"
+    Then show command "show hostname" in namespace "z1" should eventually contain "bdd-host-n1"
+
+  Scenario: Deleting the hostname falls back to the OS hostname
+    Given the test topology exists
+    When I apply command "delete system hostname bdd-host-n1" in namespace "z1"
+    Then show command "show hostname" in namespace "z1" should eventually not contain "bdd-host-n1"
+
+  Scenario: Teardown topology
+    Given the test topology exists
+    When I stop zebra-rs in namespace "z1"
+    And I delete namespace "z1"
+    Then the test environment should be clean

--- a/proto/vty.proto
+++ b/proto/vty.proto
@@ -91,6 +91,11 @@ message ExecReply {
   uint32 port = 3;
   repeated string candidates = 4;
   repeated CommandPath paths = 5;
+  // Running-config `system hostname`, empty when unconfigured. Set on
+  // ExecType.EXEC replies; the vty shell tracks it in CLI_HOSTNAME so
+  // the prompt renders the configured name (falling back to the OS
+  // hostname when empty).
+  string hostname = 6;
 }
 
 // The Command register.

--- a/vty/additions/vty.sh
+++ b/vty/additions/vty.sh
@@ -45,6 +45,13 @@ _cli_in_config_group ()
 }
 
 declare -x CLI_PRIVILEGE=1
+
+# Daemon-configured `system hostname` for the prompt; empty means
+# unconfigured and the prompt falls back to the OS hostname. Seeded
+# at startup via `vtyhelper -H` and re-synced by
+# _cli_hostname_refresh after every executed command, so a committed
+# `set system hostname` shows up on the very next prompt.
+declare -x CLI_HOSTNAME=""
 declare -a _cli_array_completions
 declare -A _cli_array_helps
 declare -A _cli_array_pre
@@ -70,8 +77,10 @@ _cli_prompt_setup ()
 
   # Mode tag (e.g. "(config)") follows the mode character so the user
   # sees `host#(config)` in configure mode and a plain `host>` /
-  # `host#` in exec mode (where CLI_MODE_PROMPT is empty).
-  export PS1="$(hostname)${CLI_MODE_CHAR}${CLI_MODE_PROMPT}"
+  # `host#` in exec mode (where CLI_MODE_PROMPT is empty). The name is
+  # the daemon-configured `system hostname` when set, else the OS
+  # hostname.
+  export PS1="${CLI_HOSTNAME:-$(hostname)}${CLI_MODE_CHAR}${CLI_MODE_PROMPT}"
 }
 
 _cli_pager_setup ()
@@ -317,6 +326,26 @@ _cli_exec ()
         eval "$line"
       fi ;;
   esac
+
+  # A committed `set/delete system hostname` (possibly by another
+  # session) must show on the next prompt; config commands come back
+  # as silent Show replies with nothing eval-able, so re-ask the
+  # daemon after every executed command.
+  _cli_hostname_refresh
+}
+
+# Sync CLI_HOSTNAME (and the prompt) with the daemon's running-config
+# `system hostname`. A failed query (daemon down) leaves the current
+# value untouched.
+_cli_hostname_refresh ()
+{
+  local name
+  if name=$(${cli_command} -H 2>/dev/null); then
+    if [[ ${name} != "${CLI_HOSTNAME}" ]]; then
+      CLI_HOSTNAME=${name}
+      _cli_prompt_setup
+    fi
+  fi
 }
 
 # bash calls this when a typed word matches no alias / function /
@@ -495,6 +524,10 @@ disable ()
 if [[ $interactive ]]; then
   _cli_pager_setup
   _cli_bind_key
+  # Seed the prompt hostname from the daemon's running config; a down
+  # daemon yields an empty value and the OS-hostname fallback (the
+  # next successful exec self-heals it, like _cli_maybe_register).
+  CLI_HOSTNAME=$(${cli_command} -H 2>/dev/null)
   _cli_prompt_setup
   # Tell the daemon to drop our session as soon as the shell exits.
   # The kernel pidfd watcher also catches this case; the explicit

--- a/vtyhelper/src/main.rs
+++ b/vtyhelper/src/main.rs
@@ -62,6 +62,14 @@ struct Cli {
     disable: bool,
 
     #[arg(
+        short = 'H',
+        long = "hostname",
+        help = "Print the daemon's configured `system hostname` (empty when unset); \
+                used once at vty startup to seed CLI_HOSTNAME for the prompt"
+    )]
+    hostname: bool,
+
+    #[arg(
         long,
         help = "Deprecated and ignored; the daemon always authenticates enable against root."
     )]
@@ -197,6 +205,24 @@ async fn redirect(cli: Cli, port: u32) -> Result<()> {
     Ok(())
 }
 
+/// Print the daemon's configured `system hostname` (empty when
+/// unset). Invoked as `vtyhelper -H` by the vty shell — once at
+/// startup to seed `CLI_HOSTNAME`, and after every executed command
+/// (`_cli_hostname_refresh`) so the prompt tracks `set system
+/// hostname` / `delete system hostname` as soon as they commit.
+async fn hostname_fetch(cli: Cli) -> Result<()> {
+    let channel = endpoint::connect(&endpoint_uri(&cli.base, cli.port)).await?;
+    let mut client = ExecClient::new(channel);
+    let request = tonic::Request::new(exec_request(
+        ExecType::Exec as i32,
+        &String::from("exec"),
+        &Vec::new(),
+    ));
+    let reply = client.do_exec(request).await?.into_inner();
+    println!("{}", reply.hostname);
+    Ok(())
+}
+
 async fn exec(cli: Cli) -> Result<()> {
     let channel = endpoint::connect(&endpoint_uri(&cli.base, cli.port)).await?;
     let mut client = ExecClient::new(channel);
@@ -308,6 +334,8 @@ async fn disable(cli: Cli) -> i32 {
 async fn run(cli: Cli) -> Result<()> {
     if cli.logout {
         logout(cli).await?;
+    } else if cli.hostname {
+        hostname_fetch(cli).await?;
     } else if cli.show {
         show(cli, None, Vec::new()).await?;
     } else if cli.completion || cli.trailing || cli.first {

--- a/zebra-rs/src/config/api.rs
+++ b/zebra-rs/src/config/api.rs
@@ -61,6 +61,14 @@ pub struct ExecuteResponse {
     pub code: ExecCode,
     pub output: String,
     pub paths: Vec<CommandPath>,
+    /// The running-config `system hostname` value, or `None` when
+    /// unconfigured. Carried on every Execute reply; the vty shell
+    /// queries it via `vtyhelper -H` (startup seed + the
+    /// post-command `_cli_hostname_refresh`) to keep the prompt in
+    /// sync. Read from the running store, so the reply to the very
+    /// `commit` that changes the hostname already carries the new
+    /// name.
+    pub hostname: Option<String>,
 }
 
 #[derive(Debug)]

--- a/zebra-rs/src/config/manager.rs
+++ b/zebra-rs/src/config/manager.rs
@@ -926,6 +926,14 @@ impl ConfigManager {
         (code, comps)
     }
 
+    /// The running-config `system hostname` value, or `None` when
+    /// unconfigured. Every Execute reply carries this so the vty
+    /// shell's prompt tracks the configured name (see
+    /// `ExecuteResponse::hostname`).
+    fn running_hostname(&self) -> Option<String> {
+        hostname_from_config(&self.store.running.borrow())
+    }
+
     pub async fn process_message(&mut self, m: Message) {
         match m {
             Message::Execute(req) => {
@@ -938,6 +946,9 @@ impl ConfigManager {
                         resp.code = ExecCode::Nomatch;
                     }
                 }
+                // Stamped after `execute` so a `commit` that changed
+                // the hostname reports the just-promoted value.
+                resp.hostname = self.running_hostname();
                 let _ = req.resp.send(resp);
             }
             Message::Completion(req) => {
@@ -1355,6 +1366,53 @@ pub fn config_format_type(config_str: &str) -> ConfigFormat {
         ConfigFormat::SetDelete
     } else {
         ConfigFormat::Yaml
+    }
+}
+
+/// Extract the `system hostname` leaf value from a config tree, or
+/// `None` when the leaf is absent or empty. Free function so the
+/// lookup is unit-testable without a full `ConfigManager`.
+fn hostname_from_config(config: &Config) -> Option<String> {
+    let system = config.lookup(&"system".to_string())?;
+    let hostname = system.lookup(&"hostname".to_string())?;
+    let value = hostname.value.borrow().clone();
+    (!value.is_empty()).then_some(value)
+}
+
+#[cfg(test)]
+mod hostname_lookup_tests {
+    use super::*;
+    use std::rc::Rc;
+
+    fn tree(children: &[(&str, &str)]) -> Rc<Config> {
+        let root = Rc::new(Config::new("".to_string(), None));
+        let system = Rc::new(Config::new("system".to_string(), Some(root.clone())));
+        for (name, value) in children {
+            let leaf = Rc::new(Config::new(name.to_string(), Some(system.clone())));
+            *leaf.value.borrow_mut() = value.to_string();
+            system.configs.borrow_mut().push(leaf);
+        }
+        root.configs.borrow_mut().push(system);
+        root
+    }
+
+    #[test]
+    fn configured_hostname_is_found() {
+        let root = tree(&[("hostname", "n1")]);
+        assert_eq!(hostname_from_config(&root), Some("n1".to_string()));
+    }
+
+    #[test]
+    fn absent_or_empty_hostname_is_none() {
+        // No system container at all.
+        let bare = Rc::new(Config::new("".to_string(), None));
+        assert_eq!(hostname_from_config(&bare), None);
+        // system present, hostname leaf absent.
+        let root = tree(&[("router-id", "10.0.0.1")]);
+        assert_eq!(hostname_from_config(&root), None);
+        // hostname leaf present but empty value.
+        let root = tree(&[("hostname", "")]);
+        assert_eq!(hostname_from_config(&root), None);
     }
 }
 

--- a/zebra-rs/src/config/serve.rs
+++ b/zebra-rs/src/config/serve.rs
@@ -125,6 +125,7 @@ impl ExecService {
             lines,
             port: 2666,
             paths: Vec::new(),
+            hostname: String::new(),
         };
         Ok(Response::new(reply))
     }
@@ -134,6 +135,7 @@ impl ExecService {
         code: ExecCode,
         lines: String,
         paths: Vec<CommandPath>,
+        hostname: String,
     ) -> Result<Response<ExecReply>, tonic::Status> {
         let reply = ExecReply {
             code: code as i32,
@@ -141,6 +143,7 @@ impl ExecService {
             lines,
             port: 2666,
             paths,
+            hostname,
         };
         Ok(Response::new(reply))
     }
@@ -183,8 +186,9 @@ impl Exec for ExecService {
         match request.r#type {
             x if x == ExecType::Exec as i32 => {
                 let resp = self.execute_request(&request.mode, &request.line).await;
+                let hostname = resp.hostname.clone().unwrap_or_default();
                 let (code, output, paths) = exec_commands(&resp);
-                self.reply_exec(code, output, paths)
+                self.reply_exec(code, output, paths, hostname)
             }
             x if x == ExecType::CompleteFirstCommands as i32 => {
                 let resp = self

--- a/zebra-rs/src/rib/inst.rs
+++ b/zebra-rs/src/rib/inst.rs
@@ -925,6 +925,12 @@ pub struct Rib {
     /// pick; `None` falls back to it.
     pub router_id_config: Option<Ipv4Addr>,
 
+    /// Operator-configured `system hostname`. Preferred by
+    /// `show hostname` over the OS hostname; `None` falls back to it.
+    /// The vty prompt tracks the same config through the Execute
+    /// reply path in the config manager, so the two stay consistent.
+    pub hostname_config: Option<String>,
+
     /// Single-shot timer that fires Message::Resolve after a debounce when
     /// the FIB has changed. None when no resolve is pending. Set by
     /// schedule_rib_sync(), cleared by the Message::Resolve handler.
@@ -1042,6 +1048,7 @@ impl Rib {
             nmap: NexthopMap::default(),
             router_id: Ipv4Addr::UNSPECIFIED,
             router_id_config: None,
+            hostname_config: None,
             rib_sync_timer: None,
             rib_sync_interval: DEFAULT_RIB_SYNC_INTERVAL_SEC,
             sr0_owned: false,
@@ -3756,6 +3763,24 @@ impl Rib {
         Some((vni, vtep_local))
     }
 
+    /// `set system hostname <name>` — store the configured hostname so
+    /// `show hostname` prefers it over the OS hostname. Deleting falls
+    /// back to the OS hostname. Purely daemon-internal (FRR-style): no
+    /// `sethostname(2)`, no OS side effects; the vty prompt tracks the
+    /// same leaf via the config manager's Execute-reply path.
+    pub(crate) fn hostname_config_exec(
+        &mut self,
+        mut args: crate::config::Args,
+        op: ConfigOp,
+    ) -> Option<()> {
+        if op.is_set() {
+            self.hostname_config = Some(args.string()?);
+        } else {
+            self.hostname_config = None;
+        }
+        Some(())
+    }
+
     /// `set system cradle enabled <bool>` — the sole switch for the cradle
     /// eBPF data-plane tee. Deleting it (or setting false) disables the tee
     /// regardless of any `system cradle grpc-endpoint` endpoint.
@@ -3902,6 +3927,8 @@ impl Rib {
                 let (path, mut args) = path_from_command(&msg.paths);
                 if path.as_str() == "/system/router-id" {
                     let _ = self.router_id_config_exec(args, msg.op);
+                } else if path.as_str() == "/system/hostname" {
+                    let _ = self.hostname_config_exec(args, msg.op);
                 } else if path.as_str() == "/system/cradle/enabled" {
                     #[cfg(target_os = "linux")]
                     let _ = self.cradle_enabled_config_exec(args, msg.op);

--- a/zebra-rs/src/rib/show.rs
+++ b/zebra-rs/src/rib/show.rs
@@ -1889,11 +1889,15 @@ pub fn router_id_show(rib: &Rib, _args: Args, json: bool) -> String {
     format!("Router ID: {} ({})\n", rib.router_id, source)
 }
 
-pub fn hostname_show(_rib: &Rib, _args: Args, json: bool) -> String {
-    let name = hostname::get()
-        .ok()
-        .and_then(|s| s.into_string().ok())
-        .filter(|s| !s.is_empty());
+pub fn hostname_show(rib: &Rib, _args: Args, json: bool) -> String {
+    // Configured `system hostname` wins; the OS hostname is the
+    // fallback — the same precedence the vty prompt applies.
+    let name = rib.hostname_config.clone().or_else(|| {
+        hostname::get()
+            .ok()
+            .and_then(|s| s.into_string().ok())
+            .filter(|s| !s.is_empty())
+    });
     if json {
         // `name` is `Option<String>`: a resolved hostname or JSON `null`.
         return serde_json::to_string_pretty(&serde_json::json!({ "hostname": name }))

--- a/zebra-rs/yang/config.yang
+++ b/zebra-rs/yang/config.yang
@@ -406,7 +406,13 @@ module config {
 
       leaf hostname {
         ext:help "System host name";
-        type string;
+        // RFC 1123-ish charset. Deliberately strict: the value is
+        // surfaced to the vty shell and interpolated into the prompt
+        // eval line (see vtyhelper), so quotes / spaces / shell
+        // metacharacters must be impossible by construction.
+        type string {
+          pattern "[A-Za-z0-9][A-Za-z0-9.-]*";
+        }
         description
           "The name of the host. This name can be a single domain label or the
            fully qualified domain name of the host.";


### PR DESCRIPTION
## Summary

`set system hostname n1` was dead config — the leaf parsed but nothing consumed it. This wires it up FRR-style (daemon-internal; no `sethostname(2)`, no OS side effects, no new capabilities):

- **Daemon**: the running-config hostname rides on every Execute reply (`ExecuteResponse::hostname` → new `ExecReply.hostname` proto field), read from the running store so the reply to the very `commit` that changes it already reports the new name. The RIB stores the committed value (router-id pattern) and `show hostname` now prefers it over the OS hostname. The YANG leaf gets an RFC 1123-ish `pattern` so the value is shell-safe by construction.
- **vty shell**: the prompt renders `${CLI_HOSTNAME:-$(hostname)}` + the existing mode char. `CLI_HOSTNAME` is seeded at startup via a new `vtyhelper -H` and re-synced by `_cli_hostname_refresh` after every executed command — config commands come back as silent Show replies with nothing eval-able, so a post-command query is the only channel that catches a committed change (including one made by another session). Daemon down → OS-hostname fallback, self-heals on the next successful command.
- **BDD**: new `system_hostname` feature asserting `show hostname` follows set/delete.

## Test plan

- [x] Unit: `hostname_lookup_tests` (configured / absent / empty); all 37 workspace suites pass; clippy `-D warnings`; fmt
- [x] `make -C bdd system_hostname` — 4/4 scenarios
- [x] Live interactive verification through a pty against a real daemon:
  ```
  s>configure
  s#set system hostname n1
  s#commit
  n1#set system hostname n2
  n1#commit
  n2#delete system hostname n2
  n2#commit
  s#set system hostname n1
  s#commit
  n1#exit
  n1>exit
  ```
  Also verified: fresh session against a configured daemon starts at `n1>` (startup seed), non-root (View role) sessions seed correctly, and a stopped daemon falls back to the OS hostname without hanging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)