### PR TITLE
playset: IS-IS SRv6 (classic SID) & TI-LFA walkthrough

### DIFF
--- a/playset/isis-srv6-classic/README.md
+++ b/playset/isis-srv6-classic/README.md
@@ -1,0 +1,351 @@
+# IS-IS SRv6 (classic SID) & TI-LFA
+
+This playset demonstrates IS-IS SRv6 with TI-LFA fast reroute, using
+classic full-length SIDs (RFC 8986 — no uSID/compression). It is the SRv6
+sibling of the [IS-IS SR-MPLS playset](../isis-srmpls/README.md): the same
+RFC 9855 topology and metrics, but the data plane is pure IPv6. Every core
+node owns an SRv6 *locator* (`fcbb:bbbb:X::/48`) from which it instantiates
+its SIDs — an **End** SID (the SRv6 analog of a node SID) and one **End.X**
+SID per IS-IS adjacency (the analog of an adjacency SID). There are no
+labels anywhere: steady-state forwarding is plain IPv6, and the TI-LFA
+repair is an SRH (Segment Routing Header) *inserted* into the packet in
+flight. All core and edge nodes run in separate network namespaces; each
+node runs zebra-rs and its YAML configuration is injected with `vtyctl
+apply`.
+
+## Topology
+
+<img src="../images/TI-LFA.svg" alt="IS-IS SRv6 TI-LFA topology">
+
+Loopbacks are `2001:db8::X/128`, locators `fcbb:bbbb:X::/48`, and the two
+edge LANs are `2001:db8:100::/64` (e1 behind s) and `2001:db8:200::/64`
+(e2 behind d). This playset shares namespace names with the other SR
+playsets — bring up one of them at a time.
+
+## Bring up all nodes
+
+``` shell
+$ ./up.sh
+bring up
+...
+apply config: r3
+applied
+apply config: d
+applied
+```
+
+## Examine routes on node `s`
+
+``` shell
+$ sudo ip netns exec s vty
+s>show ipv6 route
+Codes: K - kernel, D - DHCP route, C - connected, S - static
+       O - OSPF, IA - OSPF inter area, N1/N2 - OSPF NSSA external type 1/2
+       E1/E2 - OSPF external type 1/2
+       L1/L2 - IS-IS level-1/2, ia - IS-IS inter area, B - BGP
+       > - selected route, * - FIB route, S - Stale route, ? - backup route
+
+C  *> ::1/128 is directly connected, lo, 00:00:47
+C  *> 2001:db8::1/128 is directly connected, lo, 00:00:44
+L2 *> 2001:db8::2/128 [115/11] via fe80::4f6:dff:fedb:16d6, s-n1, 00:00:43
+L2 *> 2001:db8::3/128 [115/11] via fe80::385b:79ff:fef0:7528, s-n2, 00:00:43
+L2 *> 2001:db8::4/128 [115/1010] via fe80::8e6:14ff:fe3e:b841, s-n3, 00:00:43
+L2 *> 2001:db8::5/128 [115/12] via fe80::4f6:dff:fedb:16d6, s-n1, weight 1, 00:00:42
+                               via fe80::385b:79ff:fef0:7528, s-n2, weight 1, 00:00:42
+L2 *> 2001:db8::6/128 [115/12] via fe80::4f6:dff:fedb:16d6, s-n1, 00:00:42
+L2 *> 2001:db8::7/128 [115/13] via fe80::4f6:dff:fedb:16d6, s-n1, 00:00:38
+L2 *> 2001:db8::8/128 [115/12] via fe80::4f6:dff:fedb:16d6, s-n1, 00:00:38
+...
+C  *> 2001:db8:100::/64 is directly connected, s-e1, 00:00:44
+L2 *> 2001:db8:200::/64 [115/12] via fe80::4f6:dff:fedb:16d6, s-n1, 00:00:38
+i  *> fcbb:bbbb:1::/128 [115/0] is directly connected, sr0, seg6local End, 00:00:44
+i  *> fcbb:bbbb:1:e000::/128 [115/0] is directly connected, s-n2, seg6local End.X nh6 2001:db8:0:2::2, s-n2, 00:00:44
+i  *> fcbb:bbbb:1:e001::/128 [115/0] is directly connected, s-n1, seg6local End.X nh6 2001:db8:0:1::2, s-n1, 00:00:44
+i  *> fcbb:bbbb:1:e002::/128 [115/0] is directly connected, s-n3, seg6local End.X nh6 2001:db8:0:3::2, s-n3, 00:00:44
+L2 *> fcbb:bbbb:2::/48 [115/1] via fe80::4f6:dff:fedb:16d6, s-n1, 00:00:43
+L2 *> fcbb:bbbb:3::/48 [115/1] via fe80::385b:79ff:fef0:7528, s-n2, 00:00:43
+L2 *> fcbb:bbbb:4::/48 [115/1000] via fe80::8e6:14ff:fe3e:b841, s-n3, 00:00:43
+L2 *> fcbb:bbbb:5::/48 [115/2] via fe80::4f6:dff:fedb:16d6, s-n1, weight 1, 00:00:42
+                               via fe80::385b:79ff:fef0:7528, s-n2, weight 1, 00:00:42
+L2 *> fcbb:bbbb:6::/48 [115/2] via fe80::4f6:dff:fedb:16d6, s-n1, 00:00:42
+L2 *> fcbb:bbbb:7::/48 [115/3] via fe80::4f6:dff:fedb:16d6, s-n1, 00:00:38
+L2 *> fcbb:bbbb:8::/48 [115/2] via fe80::4f6:dff:fedb:16d6, s-n1, 00:00:38
+...
+```
+
+Compared with the SR-MPLS playsets, three things stand out:
+
+* Steady-state routes carry **no encapsulation at all** — remote loopbacks
+  are plain IPv6 routes via link-local nexthops. In SRv6 the "label" only
+  appears when a path must be steered (TI-LFA below); the common case is
+  ordinary IPv6 forwarding.
+* `s`'s own SIDs are installed as `seg6local` /128 routes carved from its
+  locator `fcbb:bbbb:1::/48`: the **End** SID (`fcbb:bbbb:1::`, on the
+  dedicated `sr0` device) and one **End.X** per adjacency
+  (`...:e000::`–`...:e002::`), each bound to a specific neighbor. These are
+  the SRv6 equivalents of the MPLS ILM entries.
+* Every remote locator is a routed `/48` — reaching `fcbb:bbbb:5::` (r1's
+  End SID) is just longest-prefix matching, no label distribution needed.
+* The edge LANs (`2001:db8:100::/64`, `2001:db8:200::/64`) are ordinary
+  IS-IS prefixes: `s` and `d` advertise them as *passive* IS-IS interfaces,
+  so no static routes are required at all (see below).
+
+## Take a look at the YAML configuration
+
+Node `s`'s configuration (`s.yaml`), applied with `vtyctl apply -f s.yaml`:
+
+``` yaml
+system:
+  hostname: s
+segment-routing:
+  locator:
+  - name: LOC1
+    prefix: fcbb:bbbb:1::/48
+router:
+  isis:
+    net: 49.0000.0000.0000.0001.00
+    hostname: s
+    is-type: level-2-only
+    segment-routing:
+      srv6:
+        locator: LOC1
+    interface:
+    - if-name: lo
+      ipv6:
+        enabled: true
+    - if-name: s-n1
+      network-type: point-to-point
+      metric: 1
+      ipv6:
+        enabled: true
+    - if-name: s-n2
+      network-type: point-to-point
+      metric: 1
+      ipv6:
+        enabled: true
+    - if-name: s-n3
+      network-type: point-to-point
+      metric: 1000
+      ipv6:
+        enabled: true
+    - if-name: s-e1
+      passive: true
+      ipv6:
+        enabled: true
+```
+
+The `segment-routing locator` block defines the node's SID space, and
+`router isis segment-routing srv6 locator LOC1` hands it to IS-IS, which
+advertises it (SRv6 Locator TLV, RFC 9352) and dynamically instantiates the
+End / End.X SIDs seen above. Because the locator has no `behavior: usid`,
+the SIDs use the classic RFC 8986 full-SID layout.
+
+Note the edge model difference from the SR-MPLS playsets: there is **no
+static route**. The LAN toward `e1` is simply a passive IS-IS interface —
+the prefix is flooded into the IGP and routed natively, and (as we will see)
+TI-LFA protects it like any other prefix. The edge hosts `e1`/`e2` still
+carry only a plain IPv6 default route toward their first-hop router.
+
+## `ping` node `d`'s loopback — plain IPv6 on the wire
+
+``` shell
+s>ping 2001:db8::8
+PING 2001:db8::8 (2001:db8::8) 56 data bytes
+64 bytes from 2001:db8::8: icmp_seq=1 ttl=63 time=0.060 ms
+64 bytes from 2001:db8::8: icmp_seq=2 ttl=63 time=0.244 ms
+64 bytes from 2001:db8::8: icmp_seq=3 ttl=63 time=0.067 ms
+```
+
+Capturing on `n1` shows the contrast with SR-MPLS: no labels, no headers —
+just the ICMPv6 packet itself:
+
+``` shell
+n1>tcpdump -li n1-s ip6 and icmp6
+tcpdump: verbose output suppressed, use -v[v]... for full protocol decode
+listening on n1-s, link-type EN10MB (Ethernet), snapshot length 262144 bytes
+08:58:23.944697 IP6 2001:db8:0:1::1 > 2001:db8::8: ICMP6, echo request, id 42218, seq 4, length 64
+```
+
+## Enable TI-LFA
+
+``` shell
+s>configure
+s#set router isis fast-reroute ti-lfa
+s#commit
+s#exit
+s>show ipv6 route
+...
+L2 *> 2001:db8::8/128 [115/12] via fe80::4f6:dff:fedb:16d6, s-n1, 00:00:00
+   *?                 [115/13] via seg6 [fcbb:bbbb:5::, fcbb:bbbb:5:e003::, fcbb:bbbb:6:e002::], s-n2, 00:00:00
+```
+
+The `?` backup line is a **seg6** path: the repair is an SRH carrying the
+post-convergence path `s -> n2 -> r1 -> r2 -> r3 -> d` as a list of SRv6
+SIDs, computed exactly as in the SR-MPLS playsets (P-space / Q-space, node
+protection of the first hop `n1`):
+
+| segment              | SID                  | meaning                                  |
+|:---------------------|:---------------------|:------------------------------------------|
+| End of `r1`          | `fcbb:bbbb:5::`      | shortest-path to the P/Q node `r1`         |
+| End.X `r1 -> r2`     | `fcbb:bbbb:5:e003::` | force the expensive `r1-r2` link           |
+| End.X `r2 -> r3`     | `fcbb:bbbb:6:e002::` | force the expensive `r2-r3` link           |
+
+Unlike SR-MPLS, **no destination SID is appended**: the repair is applied
+by *SRH insertion* (H.Insert), which keeps the packet's original
+destination address as the SRH's final segment. When the last repair SID
+has been consumed, the destination address simply reverts to the original
+one and normal IPv6 forwarding finishes the job — the "get all the way to
+`d`" guarantee that the MPLS repair needs a trailing Prefix-SID for is
+built into the encoding here.
+
+``` shell
+s>show isis ti-lfa
+TI-LFA: enabled (sr-mpls: off, srv6: on)
+SPF stats:
+  L1: never run, inflight=false, pending=false
+  L2: last 22ms ago, took 515μs, inflight=false, pending=false
+      ti-lfa: targets=6 mode=serial workers=1 spf{q=6 pc=6 dedup-saved=0} took 423μs
+
+L2 TI-LFA repair paths:
+  Destination r2 (vertex 5)
+    [0] first-hop n2 (vertex 1, link_id 4)
+        segments:
+          NodeSid(r1)
+          AdjSid(r1, r2)
+  Destination r3 (vertex 6)
+    [0] first-hop n2 (vertex 1, link_id 4)
+        segments:
+          NodeSid(r1)
+          AdjSid(r1, r2)
+          AdjSid(r2, r3)
+  Destination d (vertex 7)
+    [0] first-hop n2 (vertex 1, link_id 4)
+        segments:
+          NodeSid(r1)
+          AdjSid(r1, r2)
+          AdjSid(r2, r3)
+```
+
+## Force the backup to become primary
+
+``` shell
+s>configure
+s#set router isis fast-reroute backup-as-primary
+s#commit
+s#exit
+s>show ipv6 route
+...
+L2 *> 2001:db8::8/128 [115/12] via seg6 [fcbb:bbbb:5::, fcbb:bbbb:5:e003::, fcbb:bbbb:6:e002::], s-n2, 00:00:04
+   *?                 [115/13] via fe80::4f6:dff:fedb:16d6, s-n1, 00:00:04
+...
+L2 *> 2001:db8:200::/64 [115/12] via seg6 [fcbb:bbbb:5::, fcbb:bbbb:5:e003::, fcbb:bbbb:6:e002::], s-n2, 00:00:04
+   *?                   [115/13] via fe80::4f6:dff:fedb:16d6, s-n1, 00:00:04
+```
+
+The primary and backup swap, so the repair can be exercised with live
+traffic while everything stays up. Note that `e2`'s LAN prefix
+`2001:db8:200::/64` is promoted right along with `d`'s loopback — as an
+ordinary IS-IS prefix it received its own first-class TI-LFA repair, no
+recursive-static indirection required.
+
+## Examine the SRH on the repair path
+
+Ping `d` from `s` and capture on node `n2`:
+
+``` shell
+s>ping 2001:db8::8
+PING 2001:db8::8 (2001:db8::8) 56 data bytes
+64 bytes from 2001:db8::8: icmp_seq=1 ttl=63 time=0.223 ms
+64 bytes from 2001:db8::8: icmp_seq=2 ttl=63 time=0.109 ms
+```
+
+``` shell
+n2>tcpdump -li n2-s ip6 proto 43
+tcpdump: verbose output suppressed, use -v[v]... for full protocol decode
+listening on n2-s, link-type EN10MB (Ethernet), snapshot length 262144 bytes
+08:58:49.763802 IP6 2001:db8:0:2::1 > fcbb:bbbb:5::: RT6 (len=8, type=4, segleft=3, last-entry=3, tag=0, [0]2001:db8::8, [1]fcbb:bbbb:6:e002::, [2]fcbb:bbbb:5:e003::, [3]fcbb:bbbb:5::) ICMP6, echo request, id 42954, seq 4, length 64
+```
+
+This is the whole repair in one line: a type-4 routing header (SRH) has
+been *inserted* into the ICMPv6 packet. The destination is currently the
+first segment (`fcbb:bbbb:5::`, r1's End SID, `segleft=3`), the repair
+SIDs sit at indices [3]..[1], and index **[0] is the original destination
+`2001:db8::8`** — the final segment the packet returns to once the repair
+is done. Each SID owner processes its segment: `r1` executes End, then its
+own End.X toward `r2`; `r2` executes its End.X toward `r3`; at that point
+`segleft` reaches 0 with the destination back to `2001:db8::8`, and `r3`
+forwards it to `d` as plain IPv6.
+
+## Edge-to-edge traffic over the protected path
+
+With the backup still promoted, ping from `e1` to `e2`:
+
+``` shell
+$ sudo ip netns exec e1 vty
+e1>ping 2001:db8:200::100
+PING 2001:db8:200::100 (2001:db8:200::100) 56 data bytes
+64 bytes from 2001:db8:200::100: icmp_seq=1 ttl=61 time=0.115 ms
+64 bytes from 2001:db8:200::100: icmp_seq=2 ttl=61 time=0.100 ms
+64 bytes from 2001:db8:200::100: icmp_seq=3 ttl=61 time=0.220 ms
+```
+
+``` shell
+n1>tcpdump -li n1-s ip6 proto 43
+tcpdump: verbose output suppressed, use -v[v]... for full protocol decode
+listening on n1-s, link-type EN10MB (Ethernet), snapshot length 262144 bytes
+09:02:28.101440 IP6 2001:db8:100::100 > fcbb:bbbb:5::: RT6 (len=8, type=4, segleft=3, last-entry=3, tag=0, [0]2001:db8:200::100, [1]fcbb:bbbb:6:e002::, [2]fcbb:bbbb:5:e003::, [3]fcbb:bbbb:5::) ICMP6, echo request, id 44539, seq 5, length 64
+```
+
+Two things are worth savoring here:
+
+* The source and final segment are the **plain edge host addresses**
+  (`2001:db8:100::100 -> [0]2001:db8:200::100`). The host's ordinary IPv6
+  packet had the repair SRH spliced into it in flight at `s` — no static
+  route, no service configuration, no encapsulation state anywhere. In the
+  SR-MPLS playsets the same protection required the recursive static
+  routes plus the trailing Prefix-SID; with SRv6 insertion it falls out of
+  the IGP for free.
+* This capture is from `n1`, not `n2`. After the SRH is inserted, the
+  packet is routed by its *current* destination — the first segment,
+  `fcbb:bbbb:5::` — and r1's locator is ECMP-reachable from `s` (cost 2
+  via both `n1` and `n2`). This flow hashed onto the `n1` leg, while the
+  earlier `s -> d` ping hashed onto `n2`. The repair intent lives in the
+  SRH itself, not in the first physical hop.
+
+## Appendix: Loopbacks, locators & links
+
+| name | loopback        | locator            | End SID        |
+|:-----|:----------------|:-------------------|:---------------|
+| s    | 2001:db8::1/128 | fcbb:bbbb:1::/48   | fcbb:bbbb:1::  |
+| n1   | 2001:db8::2/128 | fcbb:bbbb:2::/48   | fcbb:bbbb:2::  |
+| n2   | 2001:db8::3/128 | fcbb:bbbb:3::/48   | fcbb:bbbb:3::  |
+| n3   | 2001:db8::4/128 | fcbb:bbbb:4::/48   | fcbb:bbbb:4::  |
+| r1   | 2001:db8::5/128 | fcbb:bbbb:5::/48   | fcbb:bbbb:5::  |
+| r2   | 2001:db8::6/128 | fcbb:bbbb:6::/48   | fcbb:bbbb:6::  |
+| r3   | 2001:db8::7/128 | fcbb:bbbb:7::/48   | fcbb:bbbb:7::  |
+| d    | 2001:db8::8/128 | fcbb:bbbb:8::/48   | fcbb:bbbb:8::  |
+
+End.X SIDs are carved dynamically from each node's locator (e.g. `s`'s
+`fcbb:bbbb:1:e000::`–`e002::`), one per adjacency; the suffix assignment
+depends on adjacency bring-up order and can differ between runs.
+
+| name | address              |
+|:-----|:---------------------|
+| e1   | 2001:db8:100::100/64 |
+| e2   | 2001:db8:200::100/64 |
+
+| link  | network            |
+|:------|:-------------------|
+| s-e1  | 2001:db8:100::/64  |
+| s-n1  | 2001:db8:0:1::/64  |
+| s-n2  | 2001:db8:0:2::/64  |
+| s-n3  | 2001:db8:0:3::/64  |
+| n1-r1 | 2001:db8:0:4::/64  |
+| n2-r1 | 2001:db8:0:5::/64  |
+| r1-n3 | 2001:db8:0:6::/64  |
+| n1-r2 | 2001:db8:0:7::/64  |
+| r1-r2 | 2001:db8:0:8::/64  |
+| r2-r3 | 2001:db8:0:9::/64  |
+| n1-d  | 2001:db8:0:10::/64 |
+| d-r3  | 2001:db8:0:11::/64 |
+| d-e2  | 2001:db8:200::/64  |

--- a/playset/isis-srv6-classic/README.md
+++ b/playset/isis-srv6-classic/README.md
@@ -1,17 +1,21 @@
 # IS-IS SRv6 (classic SID) & TI-LFA
 
-This playset demonstrates IS-IS SRv6 with TI-LFA fast reroute, using
-classic full-length SIDs (RFC 8986 — no uSID/compression). It is the SRv6
-sibling of the [IS-IS SR-MPLS playset](../isis-srmpls/README.md): the same
-RFC 9855 topology and metrics, but the data plane is pure IPv6. Every core
-node owns an SRv6 *locator* (`fcbb:bbbb:X::/48`) from which it instantiates
-its SIDs — an **End** SID (the SRv6 analog of a node SID) and one **End.X**
-SID per IS-IS adjacency (the analog of an adjacency SID). There are no
-labels anywhere: steady-state forwarding is plain IPv6, and the TI-LFA
-repair is an SRH (Segment Routing Header) *inserted* into the packet in
-flight. All core and edge nodes run in separate network namespaces; each
-node runs zebra-rs and its YAML configuration is injected with `vtyctl
-apply`.
+This playset demonstrates IS-IS SRv6 with TI-LFA fast reroute and a BGP L3
+service layer, using classic full-length SIDs (RFC 8986 — no
+uSID/compression). It is the SRv6 sibling of the
+[IS-IS SR-MPLS playset](../isis-srmpls/README.md): the same RFC 9855
+topology and metrics, but the data plane is pure IPv6. Every core node owns
+an SRv6 *locator* (`fcbb:bbbb:X::/48`) from which it instantiates its SIDs —
+an **End** SID (the SRv6 analog of a node SID) and one **End.X** SID per
+IS-IS adjacency (the analog of an adjacency SID). The edge LANs are carried
+by an iBGP session between `s` and `d` as an SRv6 L3 service (RFC 9252):
+each edge router advertises its connected prefixes with an **End.DT6**
+service SID, and the remote side encapsulates edge traffic toward that SID.
+There are no labels anywhere: steady-state core forwarding is plain IPv6,
+service traffic is IPv6-in-IPv6 (H.Encaps), and the TI-LFA repair is an SRH
+(Segment Routing Header) *inserted* into the packet in flight. All core and
+edge nodes run in separate network namespaces; each node runs zebra-rs and
+its YAML configuration is injected with `vtyctl apply`.
 
 ## Topology
 
@@ -45,50 +49,71 @@ Codes: K - kernel, D - DHCP route, C - connected, S - static
        L1/L2 - IS-IS level-1/2, ia - IS-IS inter area, B - BGP
        > - selected route, * - FIB route, S - Stale route, ? - backup route
 
-C  *> ::1/128 is directly connected, lo, 00:00:47
-C  *> 2001:db8::1/128 is directly connected, lo, 00:00:44
-L2 *> 2001:db8::2/128 [115/11] via fe80::4f6:dff:fedb:16d6, s-n1, 00:00:43
-L2 *> 2001:db8::3/128 [115/11] via fe80::385b:79ff:fef0:7528, s-n2, 00:00:43
-L2 *> 2001:db8::4/128 [115/1010] via fe80::8e6:14ff:fe3e:b841, s-n3, 00:00:43
-L2 *> 2001:db8::5/128 [115/12] via fe80::4f6:dff:fedb:16d6, s-n1, weight 1, 00:00:42
-                               via fe80::385b:79ff:fef0:7528, s-n2, weight 1, 00:00:42
-L2 *> 2001:db8::6/128 [115/12] via fe80::4f6:dff:fedb:16d6, s-n1, 00:00:42
-L2 *> 2001:db8::7/128 [115/13] via fe80::4f6:dff:fedb:16d6, s-n1, 00:00:38
-L2 *> 2001:db8::8/128 [115/12] via fe80::4f6:dff:fedb:16d6, s-n1, 00:00:38
+C  *> ::1/128 is directly connected, lo, 00:00:54
+C  *> 2001:db8::1/128 is directly connected, lo, 00:00:51
+L2 *> 2001:db8::2/128 [115/11] via fe80::d093:4fff:fee7:d2fa, s-n1, 00:00:50
+L2 *> 2001:db8::3/128 [115/11] via fe80::b812:f7ff:fe1e:fdf7, s-n2, 00:00:50
+L2 *> 2001:db8::4/128 [115/1010] via fe80::485f:fff:fe9e:7084, s-n3, 00:00:50
+L2 *> 2001:db8::5/128 [115/12] via fe80::b812:f7ff:fe1e:fdf7, s-n2, weight 1, 00:00:49
+                               via fe80::d093:4fff:fee7:d2fa, s-n1, weight 1, 00:00:49
+L2 *> 2001:db8::6/128 [115/12] via fe80::d093:4fff:fee7:d2fa, s-n1, 00:00:49
+L2 *> 2001:db8::7/128 [115/13] via fe80::d093:4fff:fee7:d2fa, s-n1, 00:00:45
+B     2001:db8::8/128 [200/0] via seg6 [fcbb:bbbb:8:40::], s-n1, 00:00:46
+L2 *> 2001:db8::8/128 [115/12] via fe80::d093:4fff:fee7:d2fa, s-n1, 00:00:45
 ...
-C  *> 2001:db8:100::/64 is directly connected, s-e1, 00:00:44
-L2 *> 2001:db8:200::/64 [115/12] via fe80::4f6:dff:fedb:16d6, s-n1, 00:00:38
-i  *> fcbb:bbbb:1::/128 [115/0] is directly connected, sr0, seg6local End, 00:00:44
-i  *> fcbb:bbbb:1:e000::/128 [115/0] is directly connected, s-n2, seg6local End.X nh6 2001:db8:0:2::2, s-n2, 00:00:44
-i  *> fcbb:bbbb:1:e001::/128 [115/0] is directly connected, s-n1, seg6local End.X nh6 2001:db8:0:1::2, s-n1, 00:00:44
-i  *> fcbb:bbbb:1:e002::/128 [115/0] is directly connected, s-n3, seg6local End.X nh6 2001:db8:0:3::2, s-n3, 00:00:44
-L2 *> fcbb:bbbb:2::/48 [115/1] via fe80::4f6:dff:fedb:16d6, s-n1, 00:00:43
-L2 *> fcbb:bbbb:3::/48 [115/1] via fe80::385b:79ff:fef0:7528, s-n2, 00:00:43
-L2 *> fcbb:bbbb:4::/48 [115/1000] via fe80::8e6:14ff:fe3e:b841, s-n3, 00:00:43
-L2 *> fcbb:bbbb:5::/48 [115/2] via fe80::4f6:dff:fedb:16d6, s-n1, weight 1, 00:00:42
-                               via fe80::385b:79ff:fef0:7528, s-n2, weight 1, 00:00:42
-L2 *> fcbb:bbbb:6::/48 [115/2] via fe80::4f6:dff:fedb:16d6, s-n1, 00:00:42
-L2 *> fcbb:bbbb:7::/48 [115/3] via fe80::4f6:dff:fedb:16d6, s-n1, 00:00:38
-L2 *> fcbb:bbbb:8::/48 [115/2] via fe80::4f6:dff:fedb:16d6, s-n1, 00:00:38
+C  *> 2001:db8:100::/64 is directly connected, s-e1, 00:00:51
+B  *> 2001:db8:200::/64 [200/0] via seg6 [fcbb:bbbb:8:40::], s-n1, 00:00:46
+i  *> fcbb:bbbb:1::/128 [115/0] is directly connected, sr0, seg6local End, 00:00:51
+i  *> fcbb:bbbb:1:40::/128 [115/0] is directly connected, sr0, seg6local End.DT6, 00:00:51
+i  *> fcbb:bbbb:1:e000::/128 [115/0] is directly connected, s-n2, seg6local End.X nh6 2001:db8:0:2::2, s-n2, 00:00:51
+i  *> fcbb:bbbb:1:e001::/128 [115/0] is directly connected, s-n1, seg6local End.X nh6 2001:db8:0:1::2, s-n1, 00:00:51
+i  *> fcbb:bbbb:1:e002::/128 [115/0] is directly connected, s-n3, seg6local End.X nh6 2001:db8:0:3::2, s-n3, 00:00:51
+L2 *> fcbb:bbbb:2::/48 [115/1] via fe80::d093:4fff:fee7:d2fa, s-n1, 00:00:50
+L2 *> fcbb:bbbb:3::/48 [115/1] via fe80::b812:f7ff:fe1e:fdf7, s-n2, 00:00:50
+L2 *> fcbb:bbbb:4::/48 [115/1000] via fe80::485f:fff:fe9e:7084, s-n3, 00:00:50
+L2 *> fcbb:bbbb:5::/48 [115/2] via fe80::b812:f7ff:fe1e:fdf7, s-n2, weight 1, 00:00:49
+                               via fe80::d093:4fff:fee7:d2fa, s-n1, weight 1, 00:00:49
+L2 *> fcbb:bbbb:6::/48 [115/2] via fe80::d093:4fff:fee7:d2fa, s-n1, 00:00:49
+L2 *> fcbb:bbbb:7::/48 [115/3] via fe80::d093:4fff:fee7:d2fa, s-n1, 00:00:45
+L2 *> fcbb:bbbb:8::/48 [115/2] via fe80::d093:4fff:fee7:d2fa, s-n1, 00:00:45
 ...
 ```
 
-Compared with the SR-MPLS playsets, three things stand out:
+Compared with the SR-MPLS playsets, several things stand out:
 
-* Steady-state routes carry **no encapsulation at all** — remote loopbacks
-  are plain IPv6 routes via link-local nexthops. In SRv6 the "label" only
-  appears when a path must be steered (TI-LFA below); the common case is
-  ordinary IPv6 forwarding.
+* Steady-state core routes carry **no encapsulation at all** — remote
+  loopbacks are plain IPv6 routes via link-local nexthops. In SRv6 an
+  encapsulation appears only where a path must be steered.
 * `s`'s own SIDs are installed as `seg6local` /128 routes carved from its
   locator `fcbb:bbbb:1::/48`: the **End** SID (`fcbb:bbbb:1::`, on the
-  dedicated `sr0` device) and one **End.X** per adjacency
-  (`...:e000::`–`...:e002::`), each bound to a specific neighbor. These are
-  the SRv6 equivalents of the MPLS ILM entries.
-* Every remote locator is a routed `/48` — reaching `fcbb:bbbb:5::` (r1's
-  End SID) is just longest-prefix matching, no label distribution needed.
-* The edge LANs (`2001:db8:100::/64`, `2001:db8:200::/64`) are ordinary
-  IS-IS prefixes: `s` and `d` advertise them as *passive* IS-IS interfaces,
-  so no static routes are required at all (see below).
+  dedicated `sr0` device), the **End.DT6** service SID
+  (`fcbb:bbbb:1:40::` — decapsulate and look the inner packet up in the
+  IPv6 table), and one **End.X** per adjacency
+  (`...:e000::`–`...:e002::`). These are the SRv6 equivalents of the MPLS
+  ILM entries.
+* Every remote locator is a routed `/48` — reaching another node's SIDs is
+  just longest-prefix matching, no label distribution needed.
+* The remote edge LAN `2001:db8:200::/64` is a **BGP** route whose nexthop
+  is rendered `via seg6 [fcbb:bbbb:8:40::]` — d's End.DT6 service SID.
+  d redistributes its connected prefixes into iBGP with SRv6 encapsulation,
+  and `s` steers matching traffic into an IPv6-in-IPv6 tunnel toward that
+  SID. The unselected `B` copies of the core prefixes (e.g.
+  `2001:db8::8/128`) show the same advertisement losing to the IGP route
+  by administrative distance — only the prefixes the IGP does not carry
+  (the edge LANs) actually use the service path.
+
+The iBGP session runs between the two loopbacks:
+
+``` shell
+s>show bgp ipv6 summary
+IPv6 Unicast Summary:
+BGP router identifier 10.0.0.1, local AS number 65000 VRF default vrf-id 0
+RIB entries 9
+Peers 1
+
+Neighbor        V         AS   MsgRcvd   MsgSent   TblVer  InQ OutQ  Up/Down State       PfxRcd/Snt Hostname
+2001:db8::8     4      65000         6         4        0    0    0 00:01:58 Established        4/5 s
+```
 
 ## Take a look at the YAML configuration
 
@@ -128,43 +153,92 @@ router:
       metric: 1000
       ipv6:
         enabled: true
-    - if-name: s-e1
-      passive: true
-      ipv6:
+  bgp:
+    global:
+      as: 65000
+      router-id: 10.0.0.1
+    timer:
+      adv-interval:
+        ibgp: 1
+        ebgp: 1
+    segment-routing:
+      srv6:
+        locator: LOC1
+        ipv6-unicast: {}
+    neighbor:
+    - remote-address: 2001:db8::8
+      remote-as: 65000
+      update-source: 2001:db8::1
+      enabled: true
+      afi-safi:
+      - name: ipv6
         enabled: true
+        encapsulation-type: srv6
+    afi-safi:
+    - name: ipv6
+      redistribute:
+        connected: {}
 ```
 
-The `segment-routing locator` block defines the node's SID space, and
-`router isis segment-routing srv6 locator LOC1` hands it to IS-IS, which
-advertises it (SRv6 Locator TLV, RFC 9352) and dynamically instantiates the
-End / End.X SIDs seen above. Because the locator has no `behavior: usid`,
-the SIDs use the classic RFC 8986 full-SID layout.
+Two layers share the same locator:
 
-Note the edge model difference from the SR-MPLS playsets: there is **no
-static route**. The LAN toward `e1` is simply a passive IS-IS interface —
-the prefix is flooded into the IGP and routed natively, and (as we will see)
-TI-LFA protects it like any other prefix. The edge hosts `e1`/`e2` still
-carry only a plain IPv6 default route toward their first-hop router.
+* The `segment-routing locator` block defines the node's SID space, and
+  `router isis segment-routing srv6 locator LOC1` hands it to IS-IS, which
+  advertises it (SRv6 Locator TLV, RFC 9352) and instantiates the
+  End / End.X SIDs.
+* `router bgp segment-routing srv6 ... ipv6-unicast` carves the **End.DT6**
+  service SID from the same locator (RFC 9252 IPv6-unicast service).
+  `redistribute connected` exports the node's connected prefixes — the only
+  ones that matter are the edge LANs, since the IGP already carries the
+  core links — and `encapsulation-type: srv6` on the neighbor attaches the
+  SRv6 SID to the advertisements. Note there is no static route anywhere:
+  the edge reachability is a BGP service riding the SRv6 transport, the
+  IPv6 analog of the recursive statics in the SR-MPLS playsets.
+
+The edge hosts `e1`/`e2` still carry only a plain IPv6 default route toward
+their first-hop router.
 
 ## `ping` node `d`'s loopback — plain IPv6 on the wire
 
 ``` shell
 s>ping 2001:db8::8
 PING 2001:db8::8 (2001:db8::8) 56 data bytes
-64 bytes from 2001:db8::8: icmp_seq=1 ttl=63 time=0.060 ms
-64 bytes from 2001:db8::8: icmp_seq=2 ttl=63 time=0.244 ms
-64 bytes from 2001:db8::8: icmp_seq=3 ttl=63 time=0.067 ms
+64 bytes from 2001:db8::8: icmp_seq=1 ttl=63 time=0.053 ms
+64 bytes from 2001:db8::8: icmp_seq=2 ttl=63 time=0.091 ms
 ```
 
-Capturing on `n1` shows the contrast with SR-MPLS: no labels, no headers —
-just the ICMPv6 packet itself:
+Capturing on `n1` shows the contrast with SR-MPLS: no labels, no extra
+headers — just the ICMPv6 packet, routed hop by hop on the IGP path:
 
 ``` shell
 n1>tcpdump -li n1-s ip6 and icmp6
 tcpdump: verbose output suppressed, use -v[v]... for full protocol decode
 listening on n1-s, link-type EN10MB (Ethernet), snapshot length 262144 bytes
-08:58:23.944697 IP6 2001:db8:0:1::1 > 2001:db8::8: ICMP6, echo request, id 42218, seq 4, length 64
+09:11:03.963785 IP6 2001:db8:0:1::1 > 2001:db8::8: ICMP6, echo request, id 48941, seq 4, length 64
 ```
+
+## The BGP service path — IPv6-in-IPv6 on the wire
+
+Edge-to-edge traffic looks different: `s` has no IGP route for
+`2001:db8:200::/64`, so the BGP service route encapsulates it toward d's
+End.DT6 SID. Ping from `e1` and capture on `n1`:
+
+``` shell
+$ sudo ip netns exec e1 vty
+e1>ping 2001:db8:200::100
+```
+
+``` shell
+n1>tcpdump -li n1-s ip6 and dst net fcbb:bbbb:8::/48
+tcpdump: verbose output suppressed, use -v[v]... for full protocol decode
+listening on n1-s, link-type EN10MB (Ethernet), snapshot length 262144 bytes
+09:09:05.524230 IP6 2001:db8:0:1::1 > fcbb:bbbb:8:40::: RT6 (len=2, type=4, segleft=0, last-entry=0, tag=0, [0]fcbb:bbbb:8:40::) IP6 2001:db8:100::100 > 2001:db8:200::100: ICMP6, echo request, id 47808, seq 5, length 64
+```
+
+The host's packet rides *inside* a fresh IPv6 header addressed to
+`fcbb:bbbb:8:40::` (H.Encaps). The core routers forward it by the locator
+route `fcbb:bbbb:8::/48` — they know nothing about the edge prefixes. At
+`d`, the End.DT6 SID decapsulates and delivers the inner packet to `e2`.
 
 ## Enable TI-LFA
 
@@ -175,11 +249,11 @@ s#commit
 s#exit
 s>show ipv6 route
 ...
-L2 *> 2001:db8::8/128 [115/12] via fe80::4f6:dff:fedb:16d6, s-n1, 00:00:00
-   *?                 [115/13] via seg6 [fcbb:bbbb:5::, fcbb:bbbb:5:e003::, fcbb:bbbb:6:e002::], s-n2, 00:00:00
+L2 *> 2001:db8::8/128 [115/12] via fe80::d093:4fff:fee7:d2fa, s-n1, 00:00:00
+   *?                 [115/13] via seg6 [fcbb:bbbb:5::, fcbb:bbbb:5:e000::, fcbb:bbbb:6:e002::], s-n2, 00:00:00
 ```
 
-The `?` backup line is a **seg6** path: the repair is an SRH carrying the
+The `?` backup line is a **seg6** path: an SRH carrying the
 post-convergence path `s -> n2 -> r1 -> r2 -> r3 -> d` as a list of SRv6
 SIDs, computed exactly as in the SR-MPLS playsets (P-space / Q-space, node
 protection of the first hop `n1`):
@@ -187,39 +261,41 @@ protection of the first hop `n1`):
 | segment              | SID                  | meaning                                  |
 |:---------------------|:---------------------|:------------------------------------------|
 | End of `r1`          | `fcbb:bbbb:5::`      | shortest-path to the P/Q node `r1`         |
-| End.X `r1 -> r2`     | `fcbb:bbbb:5:e003::` | force the expensive `r1-r2` link           |
+| End.X `r1 -> r2`     | `fcbb:bbbb:5:e000::` | force the expensive `r1-r2` link           |
 | End.X `r2 -> r3`     | `fcbb:bbbb:6:e002::` | force the expensive `r2-r3` link           |
 
+(The End.X suffixes are allocated per adjacency at bring-up and can differ
+between runs.)
+
 Unlike SR-MPLS, **no destination SID is appended**: the repair is applied
-by *SRH insertion* (H.Insert), which keeps the packet's original
-destination address as the SRH's final segment. When the last repair SID
-has been consumed, the destination address simply reverts to the original
-one and normal IPv6 forwarding finishes the job — the "get all the way to
-`d`" guarantee that the MPLS repair needs a trailing Prefix-SID for is
-built into the encoding here.
+by *SRH insertion* (H.Insert), which keeps the packet's current destination
+address as the SRH's final segment. When the last repair SID has been
+consumed, the destination reverts and normal IPv6 forwarding finishes the
+job — the "get all the way to the destination" guarantee that the MPLS
+repair needs a trailing Prefix-SID for is built into the encoding here.
 
 ``` shell
 s>show isis ti-lfa
 TI-LFA: enabled (sr-mpls: off, srv6: on)
 SPF stats:
   L1: never run, inflight=false, pending=false
-  L2: last 22ms ago, took 515μs, inflight=false, pending=false
-      ti-lfa: targets=6 mode=serial workers=1 spf{q=6 pc=6 dedup-saved=0} took 423μs
+  L2: last 22ms ago, took 502μs, inflight=false, pending=false
+      ti-lfa: targets=6 mode=serial workers=1 spf{q=6 pc=6 dedup-saved=0} took 412μs
 
 L2 TI-LFA repair paths:
   Destination r2 (vertex 5)
-    [0] first-hop n2 (vertex 1, link_id 4)
+    [0] first-hop n2 (vertex 2, link_id 4)
         segments:
           NodeSid(r1)
           AdjSid(r1, r2)
   Destination r3 (vertex 6)
-    [0] first-hop n2 (vertex 1, link_id 4)
+    [0] first-hop n2 (vertex 2, link_id 4)
         segments:
           NodeSid(r1)
           AdjSid(r1, r2)
           AdjSid(r2, r3)
   Destination d (vertex 7)
-    [0] first-hop n2 (vertex 1, link_id 4)
+    [0] first-hop n2 (vertex 2, link_id 4)
         segments:
           NodeSid(r1)
           AdjSid(r1, r2)
@@ -235,82 +311,83 @@ s#commit
 s#exit
 s>show ipv6 route
 ...
-L2 *> 2001:db8::8/128 [115/12] via seg6 [fcbb:bbbb:5::, fcbb:bbbb:5:e003::, fcbb:bbbb:6:e002::], s-n2, 00:00:04
-   *?                 [115/13] via fe80::4f6:dff:fedb:16d6, s-n1, 00:00:04
+L2 *> 2001:db8::8/128 [115/12] via seg6 [fcbb:bbbb:5::, fcbb:bbbb:5:e000::, fcbb:bbbb:6:e002::], s-n2, 00:00:00
+   *?                 [115/13] via fe80::d093:4fff:fee7:d2fa, s-n1, 00:00:00
 ...
-L2 *> 2001:db8:200::/64 [115/12] via seg6 [fcbb:bbbb:5::, fcbb:bbbb:5:e003::, fcbb:bbbb:6:e002::], s-n2, 00:00:04
-   *?                   [115/13] via fe80::4f6:dff:fedb:16d6, s-n1, 00:00:04
+B  *> 2001:db8:200::/64 [200/0] via seg6 [fcbb:bbbb:8:40::], s-n1, 00:01:10
+...
+L2 *> fcbb:bbbb:8::/48 [115/2] via seg6 [fcbb:bbbb:5::, fcbb:bbbb:5:e000::, fcbb:bbbb:6:e002::], s-n2, 00:00:00
 ```
 
-The primary and backup swap, so the repair can be exercised with live
-traffic while everything stays up. Note that `e2`'s LAN prefix
-`2001:db8:200::/64` is promoted right along with `d`'s loopback — as an
-ordinary IS-IS prefix it received its own first-class TI-LFA repair, no
-recursive-static indirection required.
+The IGP primaries and backups swap, so the repair can be exercised with
+live traffic while everything stays up. Look closely at the service chain:
+the BGP route for `2001:db8:200::/64` is **unchanged** — it still says
+"encapsulate toward `fcbb:bbbb:8:40::`" — but the **locator route**
+`fcbb:bbbb:8::/48` underneath it is now promoted onto the TI-LFA repair.
+The service layer never needs to know: protection composes by routing the
+outer destination.
 
 ## Examine the SRH on the repair path
 
-Ping `d` from `s` and capture on node `n2`:
+Ping `d`'s loopback from `s` and capture the repair in flight:
 
 ``` shell
 s>ping 2001:db8::8
 PING 2001:db8::8 (2001:db8::8) 56 data bytes
-64 bytes from 2001:db8::8: icmp_seq=1 ttl=63 time=0.223 ms
-64 bytes from 2001:db8::8: icmp_seq=2 ttl=63 time=0.109 ms
-```
-
-``` shell
-n2>tcpdump -li n2-s ip6 proto 43
-tcpdump: verbose output suppressed, use -v[v]... for full protocol decode
-listening on n2-s, link-type EN10MB (Ethernet), snapshot length 262144 bytes
-08:58:49.763802 IP6 2001:db8:0:2::1 > fcbb:bbbb:5::: RT6 (len=8, type=4, segleft=3, last-entry=3, tag=0, [0]2001:db8::8, [1]fcbb:bbbb:6:e002::, [2]fcbb:bbbb:5:e003::, [3]fcbb:bbbb:5::) ICMP6, echo request, id 42954, seq 4, length 64
-```
-
-This is the whole repair in one line: a type-4 routing header (SRH) has
-been *inserted* into the ICMPv6 packet. The destination is currently the
-first segment (`fcbb:bbbb:5::`, r1's End SID, `segleft=3`), the repair
-SIDs sit at indices [3]..[1], and index **[0] is the original destination
-`2001:db8::8`** — the final segment the packet returns to once the repair
-is done. Each SID owner processes its segment: `r1` executes End, then its
-own End.X toward `r2`; `r2` executes its End.X toward `r3`; at that point
-`segleft` reaches 0 with the destination back to `2001:db8::8`, and `r3`
-forwards it to `d` as plain IPv6.
-
-## Edge-to-edge traffic over the protected path
-
-With the backup still promoted, ping from `e1` to `e2`:
-
-``` shell
-$ sudo ip netns exec e1 vty
-e1>ping 2001:db8:200::100
-PING 2001:db8:200::100 (2001:db8:200::100) 56 data bytes
-64 bytes from 2001:db8:200::100: icmp_seq=1 ttl=61 time=0.115 ms
-64 bytes from 2001:db8:200::100: icmp_seq=2 ttl=61 time=0.100 ms
-64 bytes from 2001:db8:200::100: icmp_seq=3 ttl=61 time=0.220 ms
+64 bytes from 2001:db8::8: icmp_seq=1 ttl=63 time=0.058 ms
+64 bytes from 2001:db8::8: icmp_seq=2 ttl=63 time=0.199 ms
 ```
 
 ``` shell
 n1>tcpdump -li n1-s ip6 proto 43
 tcpdump: verbose output suppressed, use -v[v]... for full protocol decode
 listening on n1-s, link-type EN10MB (Ethernet), snapshot length 262144 bytes
-09:02:28.101440 IP6 2001:db8:100::100 > fcbb:bbbb:5::: RT6 (len=8, type=4, segleft=3, last-entry=3, tag=0, [0]2001:db8:200::100, [1]fcbb:bbbb:6:e002::, [2]fcbb:bbbb:5:e003::, [3]fcbb:bbbb:5::) ICMP6, echo request, id 44539, seq 5, length 64
+09:11:12.180217 IP6 2001:db8:0:2::1 > fcbb:bbbb:5::: RT6 (len=8, type=4, segleft=3, last-entry=3, tag=0, [0]2001:db8::8, [1]fcbb:bbbb:6:e002::, [2]fcbb:bbbb:5:e000::, [3]fcbb:bbbb:5::) ICMP6, echo request, id 49474, seq 4, length 64
 ```
 
-Two things are worth savoring here:
+A type-4 routing header (SRH) has been *inserted* into the ICMPv6 packet.
+The destination is currently the first segment (`fcbb:bbbb:5::`, r1's End
+SID, `segleft=3`), the repair SIDs sit at indices [3]..[1], and index
+**[0] is the original destination `2001:db8::8`** — the final segment the
+packet returns to once the repair is done. Each SID owner processes its
+segment: `r1` executes End, then its own End.X toward `r2`; `r2` executes
+its End.X toward `r3`; at that point the destination is back to
+`2001:db8::8` and `r3` forwards plain IPv6 to `d`.
 
-* The source and final segment are the **plain edge host addresses**
-  (`2001:db8:100::100 -> [0]2001:db8:200::100`). The host's ordinary IPv6
-  packet had the repair SRH spliced into it in flight at `s` — no static
-  route, no service configuration, no encapsulation state anywhere. In the
-  SR-MPLS playsets the same protection required the recursive static
-  routes plus the trailing Prefix-SID; with SRv6 insertion it falls out of
-  the IGP for free.
-* This capture is from `n1`, not `n2`. After the SRH is inserted, the
-  packet is routed by its *current* destination — the first segment,
-  `fcbb:bbbb:5::` — and r1's locator is ECMP-reachable from `s` (cost 2
-  via both `n1` and `n2`). This flow hashed onto the `n1` leg, while the
-  earlier `s -> d` ping hashed onto `n2`. The repair intent lives in the
-  SRH itself, not in the first physical hop.
+One subtlety: this capture is from `n1`, even though the route says the
+repair egresses `s-n2`. After the SRH is inserted the packet is routed by
+its *current* destination — the first segment — and r1's locator
+`fcbb:bbbb:5::/48` is ECMP-reachable from `s` (cost 2 via both `n1` and
+`n2`), so each flow hashes onto one of the legs. The repair intent lives in
+the SRH itself, not in the first physical hop.
+
+## Protected service traffic — two SRHs on one packet
+
+The best packet in the playset: with the backup still promoted, ping from
+`e1` to `e2` and capture the *protected service* traffic:
+
+``` shell
+e1>ping 2001:db8:200::100
+PING 2001:db8:200::100 (2001:db8:200::100) 56 data bytes
+64 bytes from 2001:db8:200::100: icmp_seq=1 ttl=63 time=0.187 ms
+64 bytes from 2001:db8:200::100: icmp_seq=2 ttl=63 time=0.111 ms
+```
+
+``` shell
+n1>tcpdump -li n1-s ip6 proto 43
+tcpdump: verbose output suppressed, use -v[v]... for full protocol decode
+listening on n1-s, link-type EN10MB (Ethernet), snapshot length 262144 bytes
+09:09:33.819965 IP6 2001:db8:0:1::1 > fcbb:bbbb:5::: RT6 (len=8, type=4, segleft=3, last-entry=3, tag=0, [0]fcbb:bbbb:8:40::, [1]fcbb:bbbb:6:e002::, [2]fcbb:bbbb:5:e000::, [3]fcbb:bbbb:5::) RT6 (len=2, type=4, segleft=0, last-entry=0, tag=0, [0]fcbb:bbbb:8:40::) IP6 2001:db8:100::100 > 2001:db8:200::100: ICMP6, echo request, id 48291, seq 5, length 64
+```
+
+Read it inside-out: the innermost packet is the plain host flow
+(`2001:db8:100::100 > 2001:db8:200::100`); around it, the **service**
+encapsulation toward d's End.DT6 SID (`segleft=0`,
+`[0]fcbb:bbbb:8:40::`); and spliced on top, the **TI-LFA repair** SRH
+(`segleft=3`) steering the outer packet along the post-convergence path,
+with the service SID itself as *its* final segment. Service and protection
+compose cleanly because each layer only ever routes the destination of the
+layer below.
 
 ## Appendix: Loopbacks, locators & links
 
@@ -325,9 +402,10 @@ Two things are worth savoring here:
 | r3   | 2001:db8::7/128 | fcbb:bbbb:7::/48   | fcbb:bbbb:7::  |
 | d    | 2001:db8::8/128 | fcbb:bbbb:8::/48   | fcbb:bbbb:8::  |
 
-End.X SIDs are carved dynamically from each node's locator (e.g. `s`'s
-`fcbb:bbbb:1:e000::`–`e002::`), one per adjacency; the suffix assignment
-depends on adjacency bring-up order and can differ between runs.
+End.X SIDs (one per adjacency) and the BGP End.DT6 service SIDs (e.g.
+`s`: `fcbb:bbbb:1:40::`, `d`: `fcbb:bbbb:8:40::`) are carved dynamically
+from each node's locator; the suffix assignment depends on allocation order
+and can differ between runs.
 
 | name | address              |
 |:-----|:---------------------|

--- a/playset/isis-srv6-classic/d.yaml
+++ b/playset/isis-srv6-classic/d.yaml
@@ -39,7 +39,28 @@ router:
       metric: 1
       ipv6:
         enabled: true
-    - if-name: d-e2
-      passive: true
-      ipv6:
+  bgp:
+    global:
+      as: 65000
+      router-id: 10.0.0.8
+    timer:
+      adv-interval:
+        ibgp: 1
+        ebgp: 1
+    segment-routing:
+      srv6:
+        locator: LOC8
+        ipv6-unicast: {}
+    neighbor:
+    - remote-address: 2001:db8::1
+      remote-as: 65000
+      update-source: 2001:db8::8
+      enabled: true
+      afi-safi:
+      - name: ipv6
         enabled: true
+        encapsulation-type: srv6
+    afi-safi:
+    - name: ipv6
+      redistribute:
+        connected: {}

--- a/playset/isis-srv6-classic/d.yaml
+++ b/playset/isis-srv6-classic/d.yaml
@@ -1,0 +1,45 @@
+interface:
+- if-name: lo
+  ipv6:
+    address: 2001:db8::8/128
+- if-name: d-n1
+  ipv6:
+    address: 2001:db8:0:10::2/64
+- if-name: d-r3
+  ipv6:
+    address: 2001:db8:0:11::2/64
+- if-name: d-e2
+  ipv6:
+    address: 2001:db8:200::1/64
+system:
+  hostname: d
+segment-routing:
+  locator:
+  - name: LOC8
+    prefix: fcbb:bbbb:8::/48
+router:
+  isis:
+    net: 49.0000.0000.0000.0008.00
+    hostname: d
+    is-type: level-2-only
+    segment-routing:
+      srv6:
+        locator: LOC8
+    interface:
+    - if-name: lo
+      ipv6:
+        enabled: true
+    - if-name: d-n1
+      network-type: point-to-point
+      metric: 1
+      ipv6:
+        enabled: true
+    - if-name: d-r3
+      network-type: point-to-point
+      metric: 1
+      ipv6:
+        enabled: true
+    - if-name: d-e2
+      passive: true
+      ipv6:
+        enabled: true

--- a/playset/isis-srv6-classic/down.sh
+++ b/playset/isis-srv6-classic/down.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+# Tear down the IS-IS SR-MPLS namespace demo.
+
+PLAYSET_DEMO_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=../lib/playset.sh
+source "${PLAYSET_DEMO_DIR}/../lib/playset.sh"
+# shellcheck source=topology.sh
+source "${PLAYSET_DEMO_DIR}/topology.sh"
+
+playset_teardown

--- a/playset/isis-srv6-classic/e1.yaml
+++ b/playset/isis-srv6-classic/e1.yaml
@@ -1,0 +1,13 @@
+interface:
+- if-name: e1-s
+  ipv6:
+    address: 2001:db8:100::100/64
+system:
+  hostname: e1
+router:
+  static:
+    ipv6:
+      route:
+      - prefix: ::/0
+        nexthop:
+        - address: 2001:db8:100::1

--- a/playset/isis-srv6-classic/e2.yaml
+++ b/playset/isis-srv6-classic/e2.yaml
@@ -1,0 +1,13 @@
+interface:
+- if-name: e2-d
+  ipv6:
+    address: 2001:db8:200::100/64
+system:
+  hostname: e2
+router:
+  static:
+    ipv6:
+      route:
+      - prefix: ::/0
+        nexthop:
+        - address: 2001:db8:200::1

--- a/playset/isis-srv6-classic/n1.yaml
+++ b/playset/isis-srv6-classic/n1.yaml
@@ -1,0 +1,54 @@
+interface:
+- if-name: lo
+  ipv6:
+    address: 2001:db8::2/128
+- if-name: n1-s
+  ipv6:
+    address: 2001:db8:0:1::2/64
+- if-name: n1-r1
+  ipv6:
+    address: 2001:db8:0:4::1/64
+- if-name: n1-r2
+  ipv6:
+    address: 2001:db8:0:7::1/64
+- if-name: n1-d
+  ipv6:
+    address: 2001:db8:0:10::1/64
+system:
+  hostname: n1
+segment-routing:
+  locator:
+  - name: LOC2
+    prefix: fcbb:bbbb:2::/48
+router:
+  isis:
+    net: 49.0000.0000.0000.0002.00
+    hostname: n1
+    is-type: level-2-only
+    segment-routing:
+      srv6:
+        locator: LOC2
+    interface:
+    - if-name: lo
+      ipv6:
+        enabled: true
+    - if-name: n1-s
+      network-type: point-to-point
+      metric: 1
+      ipv6:
+        enabled: true
+    - if-name: n1-r1
+      network-type: point-to-point
+      metric: 1
+      ipv6:
+        enabled: true
+    - if-name: n1-r2
+      network-type: point-to-point
+      metric: 1
+      ipv6:
+        enabled: true
+    - if-name: n1-d
+      network-type: point-to-point
+      metric: 1
+      ipv6:
+        enabled: true

--- a/playset/isis-srv6-classic/n2.yaml
+++ b/playset/isis-srv6-classic/n2.yaml
@@ -1,0 +1,38 @@
+interface:
+- if-name: lo
+  ipv6:
+    address: 2001:db8::3/128
+- if-name: n2-s
+  ipv6:
+    address: 2001:db8:0:2::2/64
+- if-name: n2-r1
+  ipv6:
+    address: 2001:db8:0:5::1/64
+system:
+  hostname: n2
+segment-routing:
+  locator:
+  - name: LOC3
+    prefix: fcbb:bbbb:3::/48
+router:
+  isis:
+    net: 49.0000.0000.0000.0003.00
+    hostname: n2
+    is-type: level-2-only
+    segment-routing:
+      srv6:
+        locator: LOC3
+    interface:
+    - if-name: lo
+      ipv6:
+        enabled: true
+    - if-name: n2-s
+      network-type: point-to-point
+      metric: 1
+      ipv6:
+        enabled: true
+    - if-name: n2-r1
+      network-type: point-to-point
+      metric: 1
+      ipv6:
+        enabled: true

--- a/playset/isis-srv6-classic/n3.yaml
+++ b/playset/isis-srv6-classic/n3.yaml
@@ -1,0 +1,38 @@
+interface:
+- if-name: lo
+  ipv6:
+    address: 2001:db8::4/128
+- if-name: n3-s
+  ipv6:
+    address: 2001:db8:0:3::2/64
+- if-name: n3-r1
+  ipv6:
+    address: 2001:db8:0:6::1/64
+system:
+  hostname: n3
+segment-routing:
+  locator:
+  - name: LOC4
+    prefix: fcbb:bbbb:4::/48
+router:
+  isis:
+    net: 49.0000.0000.0000.0004.00
+    hostname: n3
+    is-type: level-2-only
+    segment-routing:
+      srv6:
+        locator: LOC4
+    interface:
+    - if-name: lo
+      ipv6:
+        enabled: true
+    - if-name: n3-s
+      network-type: point-to-point
+      metric: 1000
+      ipv6:
+        enabled: true
+    - if-name: n3-r1
+      network-type: point-to-point
+      metric: 1000
+      ipv6:
+        enabled: true

--- a/playset/isis-srv6-classic/r1.yaml
+++ b/playset/isis-srv6-classic/r1.yaml
@@ -1,0 +1,54 @@
+interface:
+- if-name: lo
+  ipv6:
+    address: 2001:db8::5/128
+- if-name: r1-n1
+  ipv6:
+    address: 2001:db8:0:4::2/64
+- if-name: r1-n2
+  ipv6:
+    address: 2001:db8:0:5::2/64
+- if-name: r1-n3
+  ipv6:
+    address: 2001:db8:0:6::2/64
+- if-name: r1-r2
+  ipv6:
+    address: 2001:db8:0:8::1/64
+system:
+  hostname: r1
+segment-routing:
+  locator:
+  - name: LOC5
+    prefix: fcbb:bbbb:5::/48
+router:
+  isis:
+    net: 49.0000.0000.0000.0005.00
+    hostname: r1
+    is-type: level-2-only
+    segment-routing:
+      srv6:
+        locator: LOC5
+    interface:
+    - if-name: lo
+      ipv6:
+        enabled: true
+    - if-name: r1-n1
+      network-type: point-to-point
+      metric: 1
+      ipv6:
+        enabled: true
+    - if-name: r1-n2
+      network-type: point-to-point
+      metric: 1
+      ipv6:
+        enabled: true
+    - if-name: r1-n3
+      network-type: point-to-point
+      metric: 1000
+      ipv6:
+        enabled: true
+    - if-name: r1-r2
+      network-type: point-to-point
+      metric: 1000
+      ipv6:
+        enabled: true

--- a/playset/isis-srv6-classic/r2.yaml
+++ b/playset/isis-srv6-classic/r2.yaml
@@ -1,0 +1,46 @@
+interface:
+- if-name: lo
+  ipv6:
+    address: 2001:db8::6/128
+- if-name: r2-n1
+  ipv6:
+    address: 2001:db8:0:7::2/64
+- if-name: r2-r1
+  ipv6:
+    address: 2001:db8:0:8::2/64
+- if-name: r2-r3
+  ipv6:
+    address: 2001:db8:0:9::1/64
+system:
+  hostname: r2
+segment-routing:
+  locator:
+  - name: LOC6
+    prefix: fcbb:bbbb:6::/48
+router:
+  isis:
+    net: 49.0000.0000.0000.0006.00
+    hostname: r2
+    is-type: level-2-only
+    segment-routing:
+      srv6:
+        locator: LOC6
+    interface:
+    - if-name: lo
+      ipv6:
+        enabled: true
+    - if-name: r2-n1
+      network-type: point-to-point
+      metric: 1
+      ipv6:
+        enabled: true
+    - if-name: r2-r1
+      network-type: point-to-point
+      metric: 1000
+      ipv6:
+        enabled: true
+    - if-name: r2-r3
+      network-type: point-to-point
+      metric: 1000
+      ipv6:
+        enabled: true

--- a/playset/isis-srv6-classic/r3.yaml
+++ b/playset/isis-srv6-classic/r3.yaml
@@ -1,0 +1,38 @@
+interface:
+- if-name: lo
+  ipv6:
+    address: 2001:db8::7/128
+- if-name: r3-r2
+  ipv6:
+    address: 2001:db8:0:9::2/64
+- if-name: r3-d
+  ipv6:
+    address: 2001:db8:0:11::1/64
+system:
+  hostname: r3
+segment-routing:
+  locator:
+  - name: LOC7
+    prefix: fcbb:bbbb:7::/48
+router:
+  isis:
+    net: 49.0000.0000.0000.0007.00
+    hostname: r3
+    is-type: level-2-only
+    segment-routing:
+      srv6:
+        locator: LOC7
+    interface:
+    - if-name: lo
+      ipv6:
+        enabled: true
+    - if-name: r3-r2
+      network-type: point-to-point
+      metric: 1000
+      ipv6:
+        enabled: true
+    - if-name: r3-d
+      network-type: point-to-point
+      metric: 1
+      ipv6:
+        enabled: true

--- a/playset/isis-srv6-classic/s.yaml
+++ b/playset/isis-srv6-classic/s.yaml
@@ -1,0 +1,53 @@
+interface:
+- if-name: lo
+  ipv6:
+    address: 2001:db8::1/128
+- if-name: s-n1
+  ipv6:
+    address: 2001:db8:0:1::1/64
+- if-name: s-n2
+  ipv6:
+    address: 2001:db8:0:2::1/64
+- if-name: s-n3
+  ipv6:
+    address: 2001:db8:0:3::1/64
+- if-name: s-e1
+  ipv6:
+    address: 2001:db8:100::1/64
+system:
+  hostname: s
+segment-routing:
+  locator:
+  - name: LOC1
+    prefix: fcbb:bbbb:1::/48
+router:
+  isis:
+    net: 49.0000.0000.0000.0001.00
+    hostname: s
+    is-type: level-2-only
+    segment-routing:
+      srv6:
+        locator: LOC1
+    interface:
+    - if-name: lo
+      ipv6:
+        enabled: true
+    - if-name: s-n1
+      network-type: point-to-point
+      metric: 1
+      ipv6:
+        enabled: true
+    - if-name: s-n2
+      network-type: point-to-point
+      metric: 1
+      ipv6:
+        enabled: true
+    - if-name: s-n3
+      network-type: point-to-point
+      metric: 1000
+      ipv6:
+        enabled: true
+    - if-name: s-e1
+      passive: true
+      ipv6:
+        enabled: true

--- a/playset/isis-srv6-classic/s.yaml
+++ b/playset/isis-srv6-classic/s.yaml
@@ -47,7 +47,28 @@ router:
       metric: 1000
       ipv6:
         enabled: true
-    - if-name: s-e1
-      passive: true
-      ipv6:
+  bgp:
+    global:
+      as: 65000
+      router-id: 10.0.0.1
+    timer:
+      adv-interval:
+        ibgp: 1
+        ebgp: 1
+    segment-routing:
+      srv6:
+        locator: LOC1
+        ipv6-unicast: {}
+    neighbor:
+    - remote-address: 2001:db8::8
+      remote-as: 65000
+      update-source: 2001:db8::1
+      enabled: true
+      afi-safi:
+      - name: ipv6
         enabled: true
+        encapsulation-type: srv6
+    afi-safi:
+    - name: ipv6
+      redistribute:
+        connected: {}

--- a/playset/isis-srv6-classic/topology.sh
+++ b/playset/isis-srv6-classic/topology.sh
@@ -1,0 +1,26 @@
+# IS-IS SRv6 (classic SID) demo topology.
+# Each PLAYSET_LINKS entry is "ns_a:iface_a:ns_b:iface_b".
+
+PLAYSET_NAMESPACES=(e1 e2 s n1 n2 n3 r1 r2 r3 d)
+
+PLAYSET_LINKS=(
+    e1:e1-s:s:s-e1
+    d:d-e2:e2:e2-d
+    s:s-n1:n1:n1-s
+    s:s-n2:n2:n2-s
+    s:s-n3:n3:n3-s
+    n1:n1-r1:r1:r1-n1
+    n2:n2-r1:r1:r1-n2
+    n3:n3-r1:r1:r1-n3
+    n1:n1-r2:r2:r2-n1
+    r1:r1-r2:r2:r2-r1
+    r2:r2-r3:r3:r3-r2
+    n1:n1-d:d:d-n1
+    r3:r3-d:d:d-r3
+)
+
+# All namespaces that run zebra-rs.
+PLAYSET_DAEMONS=(e1 e2 s n1 n2 n3 r1 r2 r3 d)
+
+# Routers with vtyctl YAML config (end hosts e1/e2 have no config).
+PLAYSET_ROUTERS=(e1 e2 s n1 n2 n3 r1 r2 r3 d)

--- a/playset/isis-srv6-classic/up.sh
+++ b/playset/isis-srv6-classic/up.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+# Bring up the IS-IS SR-MPLS namespace demo from scratch.
+
+PLAYSET_DEMO_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=../lib/playset.sh
+source "${PLAYSET_DEMO_DIR}/../lib/playset.sh"
+# shellcheck source=topology.sh
+source "${PLAYSET_DEMO_DIR}/topology.sh"
+
+playset_up


### PR DESCRIPTION
## Summary

SRv6 sibling of the `isis-srmpls` and `ospfv2-srmpls` playsets — the same RFC 9855 topology on a pure IPv6 data plane with **classic RFC 8986 full-length SIDs** (no uSID compression), plus an **RFC 9252 BGP service layer**. Each core node owns a `fcbb:bbbb:X::/48` locator instantiating an End SID, dynamic End.X SIDs per adjacency, and (on the edge routers) an End.DT6 service SID — all visible as `seg6local` routes, the SRv6 analog of the MPLS ILM.

The edge LANs are carried by iBGP between s and d (`redistribute connected`, per-neighbor `encapsulation-type: srv6`): edge traffic is H.Encaps'd toward the remote End.DT6 SID and forwarded by the locator route, so the core carries no edge state — the IPv6 analog of the SR-MPLS playsets' recursive statics.

The walkthrough mirrors the SR-MPLS ones (routes, TI-LFA enable, `backup-as-primary`, wire captures) and leans into the data-plane contrasts:

- Steady-state core forwarding is **plain IPv6**; the service path is IPv6-in-IPv6 toward the service SID.
- The TI-LFA repair is an **SRH inserted in flight** (H.Insert): `RT6 type=4` with the repair SIDs and the packet's original destination as segment [0] — the property that makes the MPLS tail-Prefix-SID unnecessary here.
- The showcase capture: **protected service traffic carrying two SRHs** — the TI-LFA repair (`segleft=3`, service SID as its final segment) spliced over the service encapsulation (`segleft=0`) over the plain host packet. The promotion excerpt shows why: the BGP route is unchanged while the locator route underneath rides the repair — service and protection compose by routing the outer destination.
- A note explains that the repair's first physical hop follows the (ECMP) route to the first segment — the SRH, not the first hop, encodes the repair.

Configs derive from the proven `bdd/tests/configs/tilfa_classic_srv6` plan, with `fast-reroute` left to the interactive walkthrough and `system hostname` on every node for per-node vty prompts. Shares namespace names with the other playsets (one up at a time, documented).

## Test plan

- [x] Full walkthrough executed against a live `./up.sh` run: IS-IS v6 convergence, locator/End/End.X/End.DT6 installs, iBGP Established with 4 SRv6-encap prefixes received, TI-LFA seg6 backup, backup-as-primary swap (loopback + locator /48), e1→e2 ping over both the plain service path and the promoted repair
- [x] Wire captures verbatim from a single live run: plain-IPv6 core ping, IPv6-in-IPv6 service packet, single-SRH repair, and the double-SRH protected service packet
- [x] New directory only; no daemon code touched

🤖 Generated with [Claude Code](https://claude.com/claude-code)