### PR TITLE
playset: OSPFv3 SRv6 (classic SID) & TI-LFA walkthrough with BGP service

### DIFF
--- a/playset/README.md
+++ b/playset/README.md
@@ -1,0 +1,93 @@
+# zebra-rs Playsets
+
+Playsets are self-contained demo labs for zebra-rs. Each one builds a small
+network out of Linux network namespaces connected by veth pairs, runs a
+zebra-rs daemon in every node, injects per-node YAML configuration with
+`vtyctl apply -f <node>.yaml`, and walks through a feature in its README
+with real command output captured from a live run.
+
+## Running a playset
+
+``` shell
+$ cd <playset-directory>
+$ ./up.sh        # create namespaces + links, start zebra-rs, apply configs
+$ ./down.sh      # stop the daemons and delete the namespaces
+```
+
+Log in to any node's industry-standard CLI shell:
+
+``` shell
+$ sudo ip netns exec <node> vty
+s>show ip route
+```
+
+Every node sets `system hostname`, so the vty prompt shows which node you
+are on (`s>`, `n1>`, `e1>`, ...; `#` when in admin/configure mode). Regular
+Linux tooling works inside the namespaces too — `ip route`, `tcpdump`,
+`ping` — and the READMEs use both views side by side.
+
+The daemon and CLI binaries are resolved from `target/debug/` when built,
+falling back to the installed ones on `PATH`. Each playset writes its
+runtime state (`*.log`, `*.pid`) into its own directory; those files are
+gitignored.
+
+> **One at a time**: the TI-LFA playsets share the same topology and
+> namespace names (`s`, `n1`..`n3`, `r1`..`r3`, `d`, `e1`, `e2`), so bring
+> up only one of them at once — `up.sh` tears down leftovers of the same
+> names first.
+
+## TI-LFA fast-reroute family
+
+Four labs, one topology — the RFC 9855 example network with two edge hosts
+attached — covering the IGP x data-plane matrix. Every walkthrough follows
+the same arc: examine SR routing at the source, enable
+`fast-reroute ti-lfa` at runtime, force the repair into use with
+`backup-as-primary`, and capture the repair on the wire, including the
+protected edge-to-edge traffic.
+
+| playset | IGP | data plane | edge service |
+|:--|:--|:--|:--|
+| [isis-srmpls](isis-srmpls/README.md) | IS-IS | SR-MPLS (SRGB 16000 / SRLB 15000) | recursive static routes inheriting the SR label stack |
+| [ospfv2-srmpls](ospfv2-srmpls/README.md) | OSPFv2 (area 0) | SR-MPLS (RFC 8665 extended LSAs) | recursive static routes inheriting the SR label stack |
+| [isis-srv6-classic](isis-srv6-classic/README.md) | IS-IS | SRv6, classic RFC 8986 SIDs (RFC 9352) | RFC 9252 iBGP IPv6-unicast with End.DT6 service SIDs |
+| [ospfv3-srv6-classic](ospfv3-srv6-classic/README.md) | OSPFv3 (area 0) | SRv6, classic RFC 8986 SIDs (RFC 9513) | RFC 9252 iBGP IPv6-unicast with End.DT6 service SIDs |
+
+Some cross-cutting themes to look for:
+
+* **SR-MPLS vs SRv6 repair encoding.** The MPLS repairs terminate at the
+  destination's own node SID (the label stacks end in e.g. `16800`), while
+  the SRv6 repairs are SRH insertions whose final segment is the packet's
+  original destination — the same guarantee, achieved two different ways.
+  Compare the `repair-list` outputs of `ospfv2-srmpls` and
+  `ospfv3-srv6-classic` side by side.
+* **How edge traffic gets protected.** Label inheritance through recursive
+  statics (SR-MPLS), versus a BGP service riding a protected locator
+  (SRv6) — both walkthroughs end with a wire capture of protected
+  edge-to-edge traffic (a 4-label stack in one world, a double SRH in the
+  other).
+* **`backup-as-primary`.** All four labs use this knob to pin live traffic
+  onto the TI-LFA repair while every link stays up, which makes the repair
+  path observable with plain `tcpdump`.
+
+## BGP Inter-AS L3VPN (templates)
+
+Topology templates for the Inter-AS VPN options; walkthroughs to follow.
+
+| playset | scheme |
+|:--|:--|
+| [interas-option-a](interas-option-a/README.md) | Option A — back-to-back VRFs |
+| [interas-option-b](interas-option-b/README.md) | Option B — eBGP VPNv4 between ASBRs |
+| [interas-option-c](interas-option-c/README.md) | Option C — multihop eBGP VPNv4 between route reflectors, labeled transport between ASes |
+
+## Directory layout
+
+```
+playset/
+├── lib/          # shared bash harness (namespaces, links, daemon lifecycle)
+├── images/       # topology diagrams referenced by the READMEs
+└── <playset>/    # topology.sh + per-node *.yaml + up.sh / down.sh + README.md
+```
+
+A playset directory only needs three things: a `topology.sh` declaring
+namespaces and veth links, one YAML config per node, and the two wrapper
+scripts sourcing `lib/`. Copy an existing playset as a starting point.

--- a/playset/ospfv3-srv6-classic/README.md
+++ b/playset/ospfv3-srv6-classic/README.md
@@ -1,0 +1,356 @@
+# OSPFv3 SRv6 (classic SID) & TI-LFA
+
+This playset demonstrates OSPFv3 SRv6 with TI-LFA fast reroute and a BGP L3
+service layer, using classic full-length SIDs (RFC 8986 — no
+uSID/compression). It is the OSPFv3 sibling of the
+[IS-IS SRv6 playset](../isis-srv6-classic/README.md): the same RFC 9855
+topology on a pure IPv6 data plane, with the routing expressed as a single
+OSPFv3 area 0 carrying the SRv6 extensions (RFC 9513 over the RFC 8362
+extended LSAs) instead of IS-IS TLVs. Every core node owns an SRv6
+*locator* (`fcbb:bbbb:X::/48`) instantiating an **End** SID, one **End.X**
+SID per adjacency, and — on the edge routers — an **End.DT6** service SID.
+The edge LANs are carried by iBGP between `s` and `d` as an SRv6
+IPv6-unicast service (RFC 9252); the core carries no edge state. All core
+and edge nodes run in separate network namespaces; each node runs zebra-rs
+and its YAML configuration is injected with `vtyctl apply`.
+
+## Topology
+
+<img src="../images/TI-LFA.svg" alt="OSPFv3 SRv6 TI-LFA topology">
+
+Loopbacks are `2001:db8::X/128`, locators `fcbb:bbbb:X::/48`, link networks
+`2001:db8:N::/64`, and the two edge LANs are `2001:db8:100::/64` (e1 behind
+s) and `2001:db8:200::/64` (e2 behind d). This playset shares namespace
+names with the other SR playsets — bring up one of them at a time.
+
+## Bring up all nodes
+
+``` shell
+$ ./up.sh
+bring up
+...
+apply config: r3
+applied
+apply config: d
+applied
+```
+
+OSPFv3 full-mesh convergence plus the iBGP session take a little while —
+the session rides loopback reachability and retries its connection, so give
+the lab a minute or two before expecting the service route.
+
+## Examine routes on node `s`
+
+``` shell
+$ sudo ip netns exec s vty
+s>show ipv6 route
+Codes: K - kernel, D - DHCP route, C - connected, S - static
+       O - OSPF, IA - OSPF inter area, N1/N2 - OSPF NSSA external type 1/2
+       E1/E2 - OSPF external type 1/2
+       L1/L2 - IS-IS level-1/2, ia - IS-IS inter area, B - BGP
+       > - selected route, * - FIB route, S - Stale route, ? - backup route
+
+C  *> 2001:db8::1/128 is directly connected, lo, 00:02:50
+O     2001:db8::1/128 [110/0] via ::, lo, 00:02:50
+O  *> 2001:db8::2/128 [110/1] via fe80::9461:feff:fe12:9ee9, s-n1, 00:02:34
+O  *> 2001:db8::3/128 [110/1] via fe80::8c26:f1ff:fe37:472c, s-n2, 00:02:34
+O  *> 2001:db8::4/128 [110/1000] via fe80::ec58:22ff:fe66:3d20, s-n3, 00:02:34
+O  *> 2001:db8::5/128 [110/2] via fe80::8c26:f1ff:fe37:472c, s-n2, weight 1, 00:02:28
+                              via fe80::9461:feff:fe12:9ee9, s-n1, weight 1, 00:02:28
+O  *> 2001:db8::6/128 [110/2] via fe80::9461:feff:fe12:9ee9, s-n1, 00:02:28
+O  *> 2001:db8::7/128 [110/3] via fe80::9461:feff:fe12:9ee9, s-n1, 00:02:22
+O  *> 2001:db8::8/128 [110/2] via fe80::9461:feff:fe12:9ee9, s-n1, 00:02:22
+B     2001:db8::8/128 [200/0] via seg6 [fcbb:bbbb:8:40::], s-n1, 00:00:45
+...
+C  *> 2001:db8:100::/64 is directly connected, s-e1, 00:02:50
+B  *> 2001:db8:200::/64 [200/0] via seg6 [fcbb:bbbb:8:40::], s-n1, 00:00:45
+i  *> fcbb:bbbb:1::/128 [115/0] is directly connected, sr0, seg6local End, 00:02:50
+i  *> fcbb:bbbb:1:40::/128 [115/0] is directly connected, sr0, seg6local End.DT6, 00:02:50
+i  *> fcbb:bbbb:1:e000::/128 [115/0] is directly connected, s-n1, seg6local End.X nh6 2001:db8:1::2, s-n1, 00:02:40
+i  *> fcbb:bbbb:1:e001::/128 [115/0] is directly connected, s-n2, seg6local End.X nh6 2001:db8:2::2, s-n2, 00:02:40
+i  *> fcbb:bbbb:1:e002::/128 [115/0] is directly connected, s-n3, seg6local End.X nh6 2001:db8:3::2, s-n3, 00:02:40
+O  *> fcbb:bbbb:2::/48 [110/1] via fe80::9461:feff:fe12:9ee9, s-n1, 00:02:34
+O  *> fcbb:bbbb:3::/48 [110/1] via fe80::8c26:f1ff:fe37:472c, s-n2, 00:02:34
+O  *> fcbb:bbbb:4::/48 [110/1000] via fe80::ec58:22ff:fe66:3d20, s-n3, 00:02:34
+O  *> fcbb:bbbb:5::/48 [110/2] via fe80::8c26:f1ff:fe37:472c, s-n2, weight 1, 00:02:28
+                               via fe80::9461:feff:fe12:9ee9, s-n1, weight 1, 00:02:28
+O  *> fcbb:bbbb:6::/48 [110/2] via fe80::9461:feff:fe12:9ee9, s-n1, 00:02:28
+O  *> fcbb:bbbb:7::/48 [110/3] via fe80::9461:feff:fe12:9ee9, s-n1, 00:02:22
+O  *> fcbb:bbbb:8::/48 [110/2] via fe80::9461:feff:fe12:9ee9, s-n1, 00:02:22
+...
+```
+
+The picture matches the IS-IS SRv6 playset with the OSPFv3 flavor: routes
+are code `O` at distance 110, locators are advertised through the RFC 9513
+SRv6 extensions and routed as plain `/48`s, and the node's own SIDs (End,
+End.DT6, End.X) are `seg6local` /128 routes on `sr0` / the adjacency
+interfaces. The unselected `O ... via ::, lo` lines are OSPFv3's
+self-originated prefixes losing to their connected counterparts. The remote
+edge LAN `2001:db8:200::/64` is a **BGP** route toward d's End.DT6 service
+SID, and the unselected `B` copies of core prefixes show the same
+advertisement losing to the IGP by distance.
+
+``` shell
+s>show bgp ipv6 summary
+IPv6 Unicast Summary:
+BGP router identifier 10.0.0.1, local AS number 65000 VRF default vrf-id 0
+RIB entries 9
+Peers 1
+
+Neighbor        V         AS   MsgRcvd   MsgSent   TblVer  InQ OutQ  Up/Down State       PfxRcd/Snt Hostname
+2001:db8::8     4      65000         5         2        0    0    0 00:00:45 Established        4/5 s
+```
+
+## Take a look at the YAML configuration
+
+Node `s`'s configuration (`s.yaml`). The `segment-routing locator` and
+`router bgp` blocks are identical to the IS-IS SRv6 playset — the service
+layer is IGP-agnostic; only the IGP section differs (OSPFv3 area 0,
+point-to-point interfaces with explicit costs):
+
+``` yaml
+system:
+  hostname: s
+segment-routing:
+  locator:
+  - name: LOC1
+    prefix: fcbb:bbbb:1::/48
+router:
+  ospfv3:
+    router-id: 10.0.0.1
+    segment-routing:
+      srv6:
+        locator: LOC1
+    area:
+    - area-id: 0.0.0.0
+      interface:
+      - if-name: lo
+        enabled: true
+      - if-name: s-n1
+        enabled: true
+        network-type: point-to-point
+        cost: 1
+      - if-name: s-n2
+        enabled: true
+        network-type: point-to-point
+        cost: 1
+      - if-name: s-n3
+        enabled: true
+        network-type: point-to-point
+        cost: 1000
+  bgp:
+    global:
+      as: 65000
+      router-id: 10.0.0.1
+    timer:
+      adv-interval:
+        ibgp: 1
+        ebgp: 1
+    segment-routing:
+      srv6:
+        locator: LOC1
+        ipv6-unicast: {}
+    neighbor:
+    - remote-address: 2001:db8::8
+      remote-as: 65000
+      update-source: 2001:db8::1
+      enabled: true
+      afi-safi:
+      - name: ipv6
+        enabled: true
+        encapsulation-type: srv6
+    afi-safi:
+    - name: ipv6
+      redistribute:
+        connected: {}
+```
+
+`router ospfv3 segment-routing srv6 locator LOC1` advertises the locator
+and instantiates the End / End.X SIDs; `router bgp segment-routing srv6 ...
+ipv6-unicast` carves the End.DT6 service SID from the same locator and
+`redistribute connected` + `encapsulation-type: srv6` export the edge LAN
+with it. No static routes anywhere; the edge hosts carry only an IPv6
+default route.
+
+## `ping` node `d`'s loopback — plain IPv6 on the wire
+
+``` shell
+s>ping 2001:db8::8
+PING 2001:db8::8 (2001:db8::8) 56 data bytes
+64 bytes from 2001:db8::8: icmp_seq=1 ttl=63 time=0.050 ms
+64 bytes from 2001:db8::8: icmp_seq=2 ttl=63 time=0.127 ms
+```
+
+``` shell
+n1>tcpdump -li n1-s ip6 and icmp6
+tcpdump: verbose output suppressed, use -v[v]... for full protocol decode
+listening on n1-s, link-type EN10MB (Ethernet), snapshot length 262144 bytes
+09:25:02.229484 IP6 2001:db8:1::1 > 2001:db8::8: ICMP6, echo request, id 55791, seq 4, length 64
+```
+
+Core forwarding is plain IPv6 — no labels, no encapsulation.
+
+## The BGP service path — IPv6-in-IPv6 on the wire
+
+Edge-to-edge traffic is different: `s` has no IGP route for
+`2001:db8:200::/64`, so the BGP service route encapsulates it toward d's
+End.DT6 SID (H.Encaps), and the core forwards it by the locator route:
+
+``` shell
+n1>tcpdump -li n1-s ip6 and dst net fcbb:bbbb:8::/48
+tcpdump: verbose output suppressed, use -v[v]... for full protocol decode
+listening on n1-s, link-type EN10MB (Ethernet), snapshot length 262144 bytes
+09:25:03.903410 IP6 2001:db8:1::1 > fcbb:bbbb:8:40::: RT6 (len=2, type=4, segleft=0, last-entry=0, tag=0, [0]fcbb:bbbb:8:40::) IP6 2001:db8:100::100 > 2001:db8:200::100: ICMP6, echo request, id 55809, seq 4, length 64
+```
+
+At `d`, the End.DT6 SID decapsulates and delivers the inner packet to `e2`.
+
+## Enable TI-LFA
+
+``` shell
+s>configure
+s#set router ospfv3 fast-reroute ti-lfa
+s#commit
+s#exit
+s>show ipv6 route
+...
+O  *> 2001:db8::8/128 [110/2] via fe80::9461:feff:fe12:9ee9, s-n1, 00:00:00
+   *?                 [110/3] via seg6 [fcbb:bbbb:5::, fcbb:bbbb:5:e003::, fcbb:bbbb:6:e001::], s-n2, 00:00:00
+```
+
+The `?` backup is an SRH-insertion repair along the post-convergence path
+`s -> n2 -> r1 -> r2 -> r3 -> d` (P-space / Q-space, node protection of the
+first hop `n1`): End of `r1`, End.X `r1 -> r2`, End.X `r2 -> r3` — and, as
+in the IS-IS SRv6 playset, **no destination SID**: H.Insert keeps the
+packet's current destination as the SRH's final segment. (The End.X
+suffixes are allocated at adjacency bring-up and can differ between runs.)
+
+OSPFv3 offers both the graph view and the per-prefix repair-list summary:
+
+``` shell
+s>show ospfv3 ti-lfa
+OSPFv3 TI-LFA repair paths:
+  Destination 10.0.0.6 (vertex 5)
+    [0] first-hop 10.0.0.3 (vertex 2, link_id 4)
+        segments:
+          Node-SID 10.0.0.5 (vertex 4)
+          Adj-SID 10.0.0.5 -> 10.0.0.6 (vertex 4 -> 5)
+  Destination 10.0.0.7 (vertex 6)
+    [0] first-hop 10.0.0.3 (vertex 2, link_id 4)
+        segments:
+          Node-SID 10.0.0.5 (vertex 4)
+          Adj-SID 10.0.0.5 -> 10.0.0.6 (vertex 4 -> 5)
+          Adj-SID 10.0.0.6 -> 10.0.0.7 (vertex 5 -> 6)
+  Destination 10.0.0.8 (vertex 7)
+    [0] first-hop 10.0.0.3 (vertex 2, link_id 4)
+        segments:
+          Node-SID 10.0.0.5 (vertex 4)
+          Adj-SID 10.0.0.5 -> 10.0.0.6 (vertex 4 -> 5)
+          Adj-SID 10.0.0.6 -> 10.0.0.7 (vertex 5 -> 6)
+s>show ospfv3 repair-list
+Prefix                         Primary via                Repair via                 Segments
+2001:db8::6/128                fe80::9461:feff:fe12:9ee9  fe80::8c26:f1ff:fe37:472c  [fcbb:bbbb:5::, fcbb:bbbb:5:e003::]
+2001:db8::7/128                fe80::9461:feff:fe12:9ee9  fe80::8c26:f1ff:fe37:472c  [fcbb:bbbb:5::, fcbb:bbbb:5:e003::, fcbb:bbbb:6:e001::]
+2001:db8::8/128                fe80::9461:feff:fe12:9ee9  fe80::8c26:f1ff:fe37:472c  [fcbb:bbbb:5::, fcbb:bbbb:5:e003::, fcbb:bbbb:6:e001::]
+2001:db8:9::/64                fe80::9461:feff:fe12:9ee9  fe80::8c26:f1ff:fe37:472c  [fcbb:bbbb:5::, fcbb:bbbb:5:e003::]
+2001:db8:11::/64               fe80::9461:feff:fe12:9ee9  fe80::8c26:f1ff:fe37:472c  [fcbb:bbbb:5::, fcbb:bbbb:5:e003::, fcbb:bbbb:6:e001::]
+fcbb:bbbb:6::/48               fe80::9461:feff:fe12:9ee9  fe80::8c26:f1ff:fe37:472c  [fcbb:bbbb:5::, fcbb:bbbb:5:e003::]
+fcbb:bbbb:7::/48               fe80::9461:feff:fe12:9ee9  fe80::8c26:f1ff:fe37:472c  [fcbb:bbbb:5::, fcbb:bbbb:5:e003::, fcbb:bbbb:6:e001::]
+fcbb:bbbb:8::/48               fe80::9461:feff:fe12:9ee9  fe80::8c26:f1ff:fe37:472c  [fcbb:bbbb:5::, fcbb:bbbb:5:e003::, fcbb:bbbb:6:e001::]
+```
+
+Compare with the [OSPFv2 SR-MPLS repair-list](../ospfv2-srmpls/README.md):
+there the labeled /32 repairs ended with the destination's own Prefix-SID,
+while these SRv6 segment lists never name the destination — the H.Insert
+encoding carries the original destination in the packet itself. Note also
+that the protected set includes the remote **locators** (`fcbb:bbbb:8::/48`
+et al.) — that is what will keep the BGP service alive below.
+
+## Force the backup to become primary
+
+``` shell
+s>configure
+s#set router ospfv3 fast-reroute backup-as-primary
+s#commit
+s#exit
+s>show ipv6 route
+...
+O  *> 2001:db8::8/128 [110/2] via seg6 [fcbb:bbbb:5::, fcbb:bbbb:5:e003::, fcbb:bbbb:6:e001::], s-n2, 00:00:04
+   *?                 [110/3] via fe80::9461:feff:fe12:9ee9, s-n1, 00:00:04
+...
+B  *> 2001:db8:200::/64 [200/0] via seg6 [fcbb:bbbb:8:40::], s-n2, 00:01:15
+...
+O  *> fcbb:bbbb:8::/48 [110/2] via seg6 [fcbb:bbbb:5::, fcbb:bbbb:5:e003::, fcbb:bbbb:6:e001::], s-n2, 00:00:04
+```
+
+The IGP primaries and backups swap. The BGP service route still says
+"encapsulate toward `fcbb:bbbb:8:40::`" — but notice its rendered egress
+followed the promotion to `s-n2`: nexthop tracking re-resolved the service
+SID through the promoted **locator** route underneath. The service layer
+composes with protection by routing the outer destination.
+
+## The repair on the wire — and two SRHs on the service packet
+
+With the backup promoted, ping `d`'s loopback from `s`, ping `e2` from
+`e1`, and capture on `n2`:
+
+``` shell
+n2>tcpdump -li n2-s ip6 proto 43
+tcpdump: verbose output suppressed, use -v[v]... for full protocol decode
+listening on n2-s, link-type EN10MB (Ethernet), snapshot length 262144 bytes
+09:25:34.606796 IP6 2001:db8:2::1 > fcbb:bbbb:5::: RT6 (len=8, type=4, segleft=3, last-entry=3, tag=0, [0]2001:db8::8, [1]fcbb:bbbb:6:e001::, [2]fcbb:bbbb:5:e003::, [3]fcbb:bbbb:5::) ICMP6, echo request, id 56589, seq 10, length 64
+09:25:34.606460 IP6 2001:db8:1::1 > fcbb:bbbb:5::: RT6 (len=8, type=4, segleft=3, last-entry=3, tag=0, [0]fcbb:bbbb:8:40::, [1]fcbb:bbbb:6:e001::, [2]fcbb:bbbb:5:e003::, [3]fcbb:bbbb:5::) RT6 (len=2, type=4, segleft=0, last-entry=0, tag=0, [0]fcbb:bbbb:8:40::) IP6 2001:db8:100::100 > 2001:db8:200::100: ICMP6, echo request, id 56590, seq 10, length 64
+```
+
+The first packet is the router-originated ping: one inserted SRH
+(`segleft=3`) whose final segment `[0]` is the original destination
+`2001:db8::8`. The second is the protected service flow, read inside-out:
+the plain host packet (`2001:db8:100::100 > 2001:db8:200::100`), the
+**service** encapsulation toward d's End.DT6 SID (`segleft=0`), and the
+**TI-LFA repair** SRH spliced on top (`segleft=3`) with the service SID as
+*its* final segment. Each layer only ever routes the destination of the
+layer below.
+
+(As in the IS-IS SRv6 playset: after insertion the packet is routed by its
+first segment, and r1's locator is ECMP from `s`, so which of `n1`/`n2`
+carries a given flow depends on the flow hash.)
+
+## Appendix: Loopbacks, locators & links
+
+| name | loopback        | locator            | End SID        |
+|:-----|:----------------|:-------------------|:---------------|
+| s    | 2001:db8::1/128 | fcbb:bbbb:1::/48   | fcbb:bbbb:1::  |
+| n1   | 2001:db8::2/128 | fcbb:bbbb:2::/48   | fcbb:bbbb:2::  |
+| n2   | 2001:db8::3/128 | fcbb:bbbb:3::/48   | fcbb:bbbb:3::  |
+| n3   | 2001:db8::4/128 | fcbb:bbbb:4::/48   | fcbb:bbbb:4::  |
+| r1   | 2001:db8::5/128 | fcbb:bbbb:5::/48   | fcbb:bbbb:5::  |
+| r2   | 2001:db8::6/128 | fcbb:bbbb:6::/48   | fcbb:bbbb:6::  |
+| r3   | 2001:db8::7/128 | fcbb:bbbb:7::/48   | fcbb:bbbb:7::  |
+| d    | 2001:db8::8/128 | fcbb:bbbb:8::/48   | fcbb:bbbb:8::  |
+
+End.X SIDs (one per adjacency) and the BGP End.DT6 service SIDs (e.g.
+`s`: `fcbb:bbbb:1:40::`, `d`: `fcbb:bbbb:8:40::`) are carved dynamically
+from each node's locator; suffix assignment depends on allocation order and
+can differ between runs. OSPFv3 router-ids are `10.0.0.X` (a v3 router-id
+is a 32-bit value even in an IPv6-only network).
+
+| name | address              |
+|:-----|:---------------------|
+| e1   | 2001:db8:100::100/64 |
+| e2   | 2001:db8:200::100/64 |
+
+| link  | network           |
+|:------|:------------------|
+| s-e1  | 2001:db8:100::/64 |
+| s-n1  | 2001:db8:1::/64   |
+| s-n2  | 2001:db8:2::/64   |
+| s-n3  | 2001:db8:3::/64   |
+| n1-r1 | 2001:db8:4::/64   |
+| n2-r1 | 2001:db8:5::/64   |
+| r1-n3 | 2001:db8:6::/64   |
+| n1-r2 | 2001:db8:7::/64   |
+| r1-r2 | 2001:db8:8::/64   |
+| r2-r3 | 2001:db8:9::/64   |
+| n1-d  | 2001:db8:10::/64  |
+| d-r3  | 2001:db8:11::/64  |
+| d-e2  | 2001:db8:200::/64 |

--- a/playset/ospfv3-srv6-classic/d.yaml
+++ b/playset/ospfv3-srv6-classic/d.yaml
@@ -1,0 +1,63 @@
+interface:
+- if-name: lo
+  ipv6:
+    address: 2001:db8::8/128
+- if-name: d-n1
+  ipv6:
+    address: 2001:db8:10::2/64
+- if-name: d-r3
+  ipv6:
+    address: 2001:db8:11::2/64
+- if-name: d-e2
+  ipv6:
+    address: 2001:db8:200::1/64
+system:
+  hostname: d
+segment-routing:
+  locator:
+  - name: LOC8
+    prefix: fcbb:bbbb:8::/48
+router:
+  ospfv3:
+    router-id: 10.0.0.8
+    segment-routing:
+      srv6:
+        locator: LOC8
+    area:
+    - area-id: 0.0.0.0
+      interface:
+      - if-name: lo
+        enabled: true
+      - if-name: d-n1
+        enabled: true
+        network-type: point-to-point
+        cost: 1
+      - if-name: d-r3
+        enabled: true
+        network-type: point-to-point
+        cost: 1
+  bgp:
+    global:
+      as: 65000
+      router-id: 10.0.0.8
+    timer:
+      adv-interval:
+        ibgp: 1
+        ebgp: 1
+    segment-routing:
+      srv6:
+        locator: LOC8
+        ipv6-unicast: {}
+    neighbor:
+    - remote-address: 2001:db8::1
+      remote-as: 65000
+      update-source: 2001:db8::8
+      enabled: true
+      afi-safi:
+      - name: ipv6
+        enabled: true
+        encapsulation-type: srv6
+    afi-safi:
+    - name: ipv6
+      redistribute:
+        connected: {}

--- a/playset/ospfv3-srv6-classic/down.sh
+++ b/playset/ospfv3-srv6-classic/down.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+# Tear down the IS-IS SR-MPLS namespace demo.
+
+PLAYSET_DEMO_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=../lib/playset.sh
+source "${PLAYSET_DEMO_DIR}/../lib/playset.sh"
+# shellcheck source=topology.sh
+source "${PLAYSET_DEMO_DIR}/topology.sh"
+
+playset_teardown

--- a/playset/ospfv3-srv6-classic/e1.yaml
+++ b/playset/ospfv3-srv6-classic/e1.yaml
@@ -1,0 +1,13 @@
+interface:
+- if-name: e1-s
+  ipv6:
+    address: 2001:db8:100::100/64
+system:
+  hostname: e1
+router:
+  static:
+    ipv6:
+      route:
+      - prefix: ::/0
+        nexthop:
+        - address: 2001:db8:100::1

--- a/playset/ospfv3-srv6-classic/e2.yaml
+++ b/playset/ospfv3-srv6-classic/e2.yaml
@@ -1,0 +1,13 @@
+interface:
+- if-name: e2-d
+  ipv6:
+    address: 2001:db8:200::100/64
+system:
+  hostname: e2
+router:
+  static:
+    ipv6:
+      route:
+      - prefix: ::/0
+        nexthop:
+        - address: 2001:db8:200::1

--- a/playset/ospfv3-srv6-classic/n1.yaml
+++ b/playset/ospfv3-srv6-classic/n1.yaml
@@ -1,0 +1,49 @@
+interface:
+- if-name: lo
+  ipv6:
+    address: 2001:db8::2/128
+- if-name: n1-s
+  ipv6:
+    address: 2001:db8:1::2/64
+- if-name: n1-r1
+  ipv6:
+    address: 2001:db8:4::1/64
+- if-name: n1-r2
+  ipv6:
+    address: 2001:db8:7::1/64
+- if-name: n1-d
+  ipv6:
+    address: 2001:db8:10::1/64
+system:
+  hostname: n1
+segment-routing:
+  locator:
+  - name: LOC2
+    prefix: fcbb:bbbb:2::/48
+router:
+  ospfv3:
+    router-id: 10.0.0.2
+    segment-routing:
+      srv6:
+        locator: LOC2
+    area:
+    - area-id: 0.0.0.0
+      interface:
+      - if-name: lo
+        enabled: true
+      - if-name: n1-s
+        enabled: true
+        network-type: point-to-point
+        cost: 1
+      - if-name: n1-r1
+        enabled: true
+        network-type: point-to-point
+        cost: 1
+      - if-name: n1-r2
+        enabled: true
+        network-type: point-to-point
+        cost: 1
+      - if-name: n1-d
+        enabled: true
+        network-type: point-to-point
+        cost: 1

--- a/playset/ospfv3-srv6-classic/n2.yaml
+++ b/playset/ospfv3-srv6-classic/n2.yaml
@@ -1,0 +1,35 @@
+interface:
+- if-name: lo
+  ipv6:
+    address: 2001:db8::3/128
+- if-name: n2-s
+  ipv6:
+    address: 2001:db8:2::2/64
+- if-name: n2-r1
+  ipv6:
+    address: 2001:db8:5::1/64
+system:
+  hostname: n2
+segment-routing:
+  locator:
+  - name: LOC3
+    prefix: fcbb:bbbb:3::/48
+router:
+  ospfv3:
+    router-id: 10.0.0.3
+    segment-routing:
+      srv6:
+        locator: LOC3
+    area:
+    - area-id: 0.0.0.0
+      interface:
+      - if-name: lo
+        enabled: true
+      - if-name: n2-s
+        enabled: true
+        network-type: point-to-point
+        cost: 1
+      - if-name: n2-r1
+        enabled: true
+        network-type: point-to-point
+        cost: 1

--- a/playset/ospfv3-srv6-classic/n3.yaml
+++ b/playset/ospfv3-srv6-classic/n3.yaml
@@ -1,0 +1,35 @@
+interface:
+- if-name: lo
+  ipv6:
+    address: 2001:db8::4/128
+- if-name: n3-s
+  ipv6:
+    address: 2001:db8:3::2/64
+- if-name: n3-r1
+  ipv6:
+    address: 2001:db8:6::1/64
+system:
+  hostname: n3
+segment-routing:
+  locator:
+  - name: LOC4
+    prefix: fcbb:bbbb:4::/48
+router:
+  ospfv3:
+    router-id: 10.0.0.4
+    segment-routing:
+      srv6:
+        locator: LOC4
+    area:
+    - area-id: 0.0.0.0
+      interface:
+      - if-name: lo
+        enabled: true
+      - if-name: n3-s
+        enabled: true
+        network-type: point-to-point
+        cost: 1000
+      - if-name: n3-r1
+        enabled: true
+        network-type: point-to-point
+        cost: 1000

--- a/playset/ospfv3-srv6-classic/r1.yaml
+++ b/playset/ospfv3-srv6-classic/r1.yaml
@@ -1,0 +1,49 @@
+interface:
+- if-name: lo
+  ipv6:
+    address: 2001:db8::5/128
+- if-name: r1-n1
+  ipv6:
+    address: 2001:db8:4::2/64
+- if-name: r1-n2
+  ipv6:
+    address: 2001:db8:5::2/64
+- if-name: r1-n3
+  ipv6:
+    address: 2001:db8:6::2/64
+- if-name: r1-r2
+  ipv6:
+    address: 2001:db8:8::1/64
+system:
+  hostname: r1
+segment-routing:
+  locator:
+  - name: LOC5
+    prefix: fcbb:bbbb:5::/48
+router:
+  ospfv3:
+    router-id: 10.0.0.5
+    segment-routing:
+      srv6:
+        locator: LOC5
+    area:
+    - area-id: 0.0.0.0
+      interface:
+      - if-name: lo
+        enabled: true
+      - if-name: r1-n1
+        enabled: true
+        network-type: point-to-point
+        cost: 1
+      - if-name: r1-n2
+        enabled: true
+        network-type: point-to-point
+        cost: 1
+      - if-name: r1-n3
+        enabled: true
+        network-type: point-to-point
+        cost: 1000
+      - if-name: r1-r2
+        enabled: true
+        network-type: point-to-point
+        cost: 1000

--- a/playset/ospfv3-srv6-classic/r2.yaml
+++ b/playset/ospfv3-srv6-classic/r2.yaml
@@ -1,0 +1,42 @@
+interface:
+- if-name: lo
+  ipv6:
+    address: 2001:db8::6/128
+- if-name: r2-n1
+  ipv6:
+    address: 2001:db8:7::2/64
+- if-name: r2-r1
+  ipv6:
+    address: 2001:db8:8::2/64
+- if-name: r2-r3
+  ipv6:
+    address: 2001:db8:9::1/64
+system:
+  hostname: r2
+segment-routing:
+  locator:
+  - name: LOC6
+    prefix: fcbb:bbbb:6::/48
+router:
+  ospfv3:
+    router-id: 10.0.0.6
+    segment-routing:
+      srv6:
+        locator: LOC6
+    area:
+    - area-id: 0.0.0.0
+      interface:
+      - if-name: lo
+        enabled: true
+      - if-name: r2-n1
+        enabled: true
+        network-type: point-to-point
+        cost: 1
+      - if-name: r2-r1
+        enabled: true
+        network-type: point-to-point
+        cost: 1000
+      - if-name: r2-r3
+        enabled: true
+        network-type: point-to-point
+        cost: 1000

--- a/playset/ospfv3-srv6-classic/r3.yaml
+++ b/playset/ospfv3-srv6-classic/r3.yaml
@@ -1,0 +1,35 @@
+interface:
+- if-name: lo
+  ipv6:
+    address: 2001:db8::7/128
+- if-name: r3-r2
+  ipv6:
+    address: 2001:db8:9::2/64
+- if-name: r3-d
+  ipv6:
+    address: 2001:db8:11::1/64
+system:
+  hostname: r3
+segment-routing:
+  locator:
+  - name: LOC7
+    prefix: fcbb:bbbb:7::/48
+router:
+  ospfv3:
+    router-id: 10.0.0.7
+    segment-routing:
+      srv6:
+        locator: LOC7
+    area:
+    - area-id: 0.0.0.0
+      interface:
+      - if-name: lo
+        enabled: true
+      - if-name: r3-r2
+        enabled: true
+        network-type: point-to-point
+        cost: 1000
+      - if-name: r3-d
+        enabled: true
+        network-type: point-to-point
+        cost: 1

--- a/playset/ospfv3-srv6-classic/s.yaml
+++ b/playset/ospfv3-srv6-classic/s.yaml
@@ -1,0 +1,70 @@
+interface:
+- if-name: lo
+  ipv6:
+    address: 2001:db8::1/128
+- if-name: s-n1
+  ipv6:
+    address: 2001:db8:1::1/64
+- if-name: s-n2
+  ipv6:
+    address: 2001:db8:2::1/64
+- if-name: s-n3
+  ipv6:
+    address: 2001:db8:3::1/64
+- if-name: s-e1
+  ipv6:
+    address: 2001:db8:100::1/64
+system:
+  hostname: s
+segment-routing:
+  locator:
+  - name: LOC1
+    prefix: fcbb:bbbb:1::/48
+router:
+  ospfv3:
+    router-id: 10.0.0.1
+    segment-routing:
+      srv6:
+        locator: LOC1
+    area:
+    - area-id: 0.0.0.0
+      interface:
+      - if-name: lo
+        enabled: true
+      - if-name: s-n1
+        enabled: true
+        network-type: point-to-point
+        cost: 1
+      - if-name: s-n2
+        enabled: true
+        network-type: point-to-point
+        cost: 1
+      - if-name: s-n3
+        enabled: true
+        network-type: point-to-point
+        cost: 1000
+  bgp:
+    global:
+      as: 65000
+      router-id: 10.0.0.1
+    timer:
+      adv-interval:
+        ibgp: 1
+        ebgp: 1
+    segment-routing:
+      srv6:
+        locator: LOC1
+        ipv6-unicast: {}
+    neighbor:
+    - remote-address: 2001:db8::8
+      remote-as: 65000
+      update-source: 2001:db8::1
+      enabled: true
+      afi-safi:
+      - name: ipv6
+        enabled: true
+        encapsulation-type: srv6
+    afi-safi:
+    - name: ipv6
+      redistribute:
+        connected: {}

--- a/playset/ospfv3-srv6-classic/topology.sh
+++ b/playset/ospfv3-srv6-classic/topology.sh
@@ -1,0 +1,26 @@
+# OSPFv3 SRv6 (classic SID) demo topology.
+# Each PLAYSET_LINKS entry is "ns_a:iface_a:ns_b:iface_b".
+
+PLAYSET_NAMESPACES=(e1 e2 s n1 n2 n3 r1 r2 r3 d)
+
+PLAYSET_LINKS=(
+    e1:e1-s:s:s-e1
+    d:d-e2:e2:e2-d
+    s:s-n1:n1:n1-s
+    s:s-n2:n2:n2-s
+    s:s-n3:n3:n3-s
+    n1:n1-r1:r1:r1-n1
+    n2:n2-r1:r1:r1-n2
+    n3:n3-r1:r1:r1-n3
+    n1:n1-r2:r2:r2-n1
+    r1:r1-r2:r2:r2-r1
+    r2:r2-r3:r3:r3-r2
+    n1:n1-d:d:d-n1
+    r3:r3-d:d:d-r3
+)
+
+# All namespaces that run zebra-rs.
+PLAYSET_DAEMONS=(e1 e2 s n1 n2 n3 r1 r2 r3 d)
+
+# Routers with vtyctl YAML config (end hosts e1/e2 have no config).
+PLAYSET_ROUTERS=(e1 e2 s n1 n2 n3 r1 r2 r3 d)

--- a/playset/ospfv3-srv6-classic/up.sh
+++ b/playset/ospfv3-srv6-classic/up.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+# Bring up the IS-IS SR-MPLS namespace demo from scratch.
+
+PLAYSET_DEMO_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=../lib/playset.sh
+source "${PLAYSET_DEMO_DIR}/../lib/playset.sh"
+# shellcheck source=topology.sh
+source "${PLAYSET_DEMO_DIR}/topology.sh"
+
+playset_up


### PR DESCRIPTION
## Summary

Fourth member of the TI-LFA playset family — the OSPFv3 SRv6 sibling of `isis-srv6-classic`: the same RFC 9855 topology on a pure IPv6 data plane with **classic RFC 8986 full-length SIDs**, the IGP expressed as a single OSPFv3 area 0 carrying the **RFC 9513 SRv6 extensions**, and the identical **RFC 9252 iBGP End.DT6 service layer** (the service config is IGP-agnostic and reused verbatim — a point the README makes explicitly).

Highlights, all captured live from one run:

- Locator /48s routed by OSPFv3; End / End.X / End.DT6 as `seg6local` routes.
- `show ospfv3 repair-list`: SRv6 segment lists that **never name the destination** — contrasted in-text with the OSPFv2 SR-MPLS repair-list's trailing Prefix-SID (H.Insert carries the original destination in the packet itself).
- `backup-as-primary`: the promotion excerpt shows the BGP service route's rendered egress following the promoted **locator** route (NHT re-resolution) while the route itself is unchanged.
- The double-SRH protected service packet (repair `segleft=3` with the service SID at [0], over service `segleft=0`, over the host packet) — captured alongside the single-SRH router-originated repair in the same tcpdump.
- A convergence note: OSPFv3 full-mesh + the iBGP connect-retry need a minute or two after `up.sh`.

Core configs derive from the proven `bdd/tests/configs/classic_tilfa_v3` plan; `fast-reroute` left to the interactive walkthrough; `system hostname` everywhere; shares namespace names with the other playsets (one at a time, documented).

## Test plan

- [x] Full walkthrough on a live `./up.sh` run: OSPFv3 v6 convergence (loopback at cost 2), locator/SID installs, iBGP Established (4 SRv6-encap prefixes), service path e1→e2 over H.Encaps, TI-LFA seg6 backup, backup-as-primary swap, e1→e2 over the promoted repair
- [x] Wire captures verbatim: plain-IPv6 core ping, IPv6-in-IPv6 service packet, single-SRH repair, double-SRH protected service packet
- [x] New directory only; no daemon code touched

🤖 Generated with [Claude Code](https://claude.com/claude-code)