### PR TITLE
BGP EVPN VXLAN: single-device kernel datapath + playset walkthrough

### DIFF
--- a/playset/README.md
+++ b/playset/README.md
@@ -69,6 +69,12 @@ Some cross-cutting themes to look for:
   onto the TI-LFA repair while every link stays up, which makes the repair
   path observable with plain `tcpdump`.
 
+## BGP EVPN
+
+| playset | scheme |
+|:--|:--|
+| [bgp-evpn-vxlan](bgp-evpn-vxlan/README.md) | one L2 segment stretched across two VTEPs — Type-2/Type-3 EVPN control plane driving the kernel's single-VXLAN-device data plane, hosts pinging at `ttl=64` |
+
 ## BGP Inter-AS L3VPN (templates)
 
 Topology templates for the Inter-AS VPN options; walkthroughs to follow.

--- a/playset/README.md
+++ b/playset/README.md
@@ -36,7 +36,7 @@ gitignored.
 > up only one of them at once — `up.sh` tears down leftovers of the same
 > names first.
 
-## TI-LFA fast-reroute family
+## SRv6 & SR-MPLS with TI-LFA fast-reroute
 
 Four labs, one topology — the RFC 9855 example network with two edge hosts
 attached — covering the IGP x data-plane matrix. Every walkthrough follows

--- a/playset/README.md
+++ b/playset/README.md
@@ -1,10 +1,11 @@
-# zebra-rs Playsets
+# Playsets
 
-Playsets are self-contained demo labs for zebra-rs. Each one builds a small
-network out of Linux network namespaces connected by veth pairs, runs a
-zebra-rs daemon in every node, injects per-node YAML configuration with
-`vtyctl apply -f <node>.yaml`, and walks through a feature in its README
-with real command output captured from a live run.
+Playsets are self-contained demo labs for zebra-rs — a simple, easy way to
+experience cutting-edge routing technology. Each one builds a small network out
+of Linux network namespaces connected by veth pairs, runs a zebra-rs daemon in
+every node, injects per-node YAML configuration with `vtyctl apply -f
+<node>.yaml`, and walks through a feature in its README with real command output
+captured from a live run.
 
 ## Running a playset
 

--- a/playset/bgp-evpn-vxlan/README.md
+++ b/playset/bgp-evpn-vxlan/README.md
@@ -1,0 +1,240 @@
+# BGP EVPN VXLAN
+
+This playset demonstrates BGP EVPN with a VXLAN data plane: two VTEPs
+stretch one L2 segment across an IP underlay, with BGP's EVPN address
+family (RFC 7432 / RFC 8365) as the control plane — Type-3 IMET routes
+build the BUM flood list and Type-2 MAC routes populate the remote FDB, so
+no flood-and-learn runs over the tunnel. Two hosts on the same IP subnet,
+each behind a different VTEP, talk as if they shared a switch.
+
+```
+  h1 ──── vtep1 ═════════════════ vtep2 ──── h2
+ 172.16.10.1   192.168.0.1  192.168.0.2   172.16.10.2
+        (VNI 10 over UDP 4789, iBGP AS 65001)
+```
+
+Each VTEP runs zebra-rs with a bridge (`br10`), a VXLAN device
+(`vxlan10`, VNI 10) enslaved to it, and the host-facing interface enslaved
+alongside. zebra-rs drives the whole kernel datapath: it creates the
+devices, enslaves them, and programs the single-VXLAN-device forwarding
+plumbing (VLAN-aware bridge, per-port tunnel mapping) plus every FDB entry
+— the kernel's own MAC learning is disabled on the tunnel port
+(`learning off`); BGP owns the table.
+
+## Bring up all nodes
+
+``` shell
+$ ./up.sh
+bring up
+...
+apply config: h2
+applied
+```
+
+## Take a look at the YAML configuration
+
+`vtep1.yaml` — the entire VTEP definition:
+
+``` yaml
+interface:
+- if-name: vtep1-vtep2
+  ipv4:
+    address: 192.168.0.1/24
+- if-name: vtep1-h1
+  bridge: br10
+system:
+  hostname: vtep1
+bridge:
+- name: br10
+vxlan:
+- name: vxlan10
+  vni: 10
+  local-address: 192.168.0.1
+  bridge: br10
+router:
+  bgp:
+    global:
+      as: 65001
+      router-id: 192.168.0.1
+    afi-safi:
+    - name: evpn
+      advertise-all-vni: true
+    neighbor:
+    - remote-address: 192.168.0.2
+      enabled: true
+      remote-as: 65001
+      afi-safi:
+      - name: ipv4
+        enabled: true
+      - name: evpn
+        enabled: true
+```
+
+Three pieces build the L2 service:
+
+* `bridge br10` + `interface vtep1-h1 bridge br10` — the local switch and
+  its access port.
+* `vxlan vxlan10 vni 10 local-address ... bridge br10` — the VTEP. The
+  daemon creates it as a modern single-device (external / vnifilter)
+  VXLAN, registers VNI 10, enslaves it, and applies the EVPN bridge-port
+  defaults (`neigh_suppress on`, `learning off`, `vlan_tunnel on`) plus
+  the VLAN→VNI tunnel mapping that makes the kernel encapsulate bridged
+  frames.
+* `router bgp ... afi-safi evpn advertise-all-vni` — the control plane:
+  every local VNI originates a Type-3 IMET route, and every MAC the kernel
+  learns on the bridge originates a Type-2 route.
+
+The hosts (`h1.yaml` / `h2.yaml`) are just an address on the same subnet —
+they know nothing about VXLAN or BGP:
+
+``` yaml
+interface:
+- if-name: h1-vtep1
+  ipv4:
+    address: 172.16.10.1/24
+system:
+  hostname: h1
+```
+
+## The EVPN session and RIB
+
+``` shell
+$ sudo ip netns exec vtep1 vty
+vtep1>show bgp summary
+...
+L2VPN EVPN Summary:
+BGP router identifier 192.168.0.1, local AS number 65001 VRF default vrf-id 0
+RIB entries 6
+Peers 1
+
+Neighbor        V         AS   MsgRcvd   MsgSent   TblVer  InQ OutQ  Up/Down State       PfxRcd/Snt Hostname
+192.168.0.2     4      65001         9         5        0    0    0 00:02:15 Established        3/3 s
+```
+
+After the hosts have talked once (see the ping below), the EVPN RIB holds
+each side's Type-2 MAC routes and Type-3 IMET, tagged with the
+route-target derived from the VNI and the ingress-replication PMSI
+attribute:
+
+``` shell
+vtep1>show bgp evpn
+...
+   Network          Next Hop            Metric LocPrf Weight Path
+Route Distinguisher: 192.168.0.1:10
+ *>  [2]:[0]:[48]:[3a:87:be:73:77:2a]
+                    192.168.0.1                0         32768 i
+                    Extended community: RT:65001:10 ET:8
+ *>  [2]:[0]:[48]:[fe:51:16:05:86:f7]
+                    192.168.0.1                0         32768 i
+                    Extended community: RT:65001:10 ET:8
+ *>  [3]:[0]:[32]:[192.168.0.1]
+                    192.168.0.1                0         32768 i
+                    Extended community: RT:65001:10 ET:8
+                    PMSI: ingress-replication endpoint:192.168.0.1 vni:10
+Route Distinguisher: 192.168.0.2:10
+ *>  [2]:[0]:[48]:[0e:30:c1:7c:aa:a1]
+                    192.168.0.2                0    100      0 i
+                    Extended community: RT:65001:10 ET:8
+ *>  [2]:[0]:[48]:[f6:78:12:ae:21:d5]
+                    192.168.0.2                0    100      0 i
+                    Extended community: RT:65001:10 ET:8
+ *>  [3]:[0]:[32]:[192.168.0.2]
+                    192.168.0.2                0    100      0 i
+                    Extended community: RT:65001:10 ET:8
+                    PMSI: ingress-replication endpoint:192.168.0.2 vni:10
+```
+
+(The MAC addresses are the hosts' and bridges' randomly generated ones and
+differ per run.)
+
+## How the routes land in the kernel
+
+The vty shell is a full shell, so the standard `bridge` tooling works
+inside it. The VXLAN FDB shows EVPN driving the data plane:
+
+``` shell
+vtep1>bridge fdb show dev vxlan10
+f6:78:12:ae:21:d5 vlan 1 extern_learn master br10
+0e:30:c1:7c:aa:a1 vlan 1 extern_learn master br10
+0a:f0:55:9d:50:c2 vlan 1 master br10 permanent
+00:00:00:00:00:00 dst 192.168.0.2 vni 10 src_vni 10 self extern_learn permanent
+f6:78:12:ae:21:d5 dst 192.168.0.2 vni 10 src_vni 10 self extern_learn permanent
+0e:30:c1:7c:aa:a1 dst 192.168.0.2 vni 10 src_vni 10 self extern_learn permanent
+vtep1>bridge vni
+dev               vni                group/remote
+vxlan10           10
+vtep1>bridge vlan tunnelshow
+port              vlan-id    tunnel-id
+vxlan10           1          10
+```
+
+* The **all-zeros entry** is the BUM flood list built from the peer's
+  Type-3 IMET: broadcast/unknown traffic ingress-replicates to
+  `192.168.0.2`.
+* The **per-MAC entries** come from the peer's Type-2 routes
+  (`extern_learn` marks them as control-plane-installed): known unicast to
+  h2 goes straight to the right VTEP, no flooding.
+* `bridge vni` shows the VNI registered on the single VXLAN device, and
+  `tunnelshow` the VLAN 1 → VNI 10 mapping the daemon programs so the
+  bridge hands frames to the tunnel with the right VNI.
+
+## `ping` across the stretched segment
+
+``` shell
+$ sudo ip netns exec h1 vty
+h1>ping 172.16.10.2
+PING 172.16.10.2 (172.16.10.2) 56(84) bytes of data.
+64 bytes from 172.16.10.2: icmp_seq=1 ttl=64 time=0.052 ms
+64 bytes from 172.16.10.2: icmp_seq=2 ttl=64 time=0.144 ms
+```
+
+`ttl=64` — no router hop anywhere: this is one L2 segment. On the underlay
+link the same packets ride VXLAN (UDP 4789, VNI 10) with the host frames
+inside:
+
+``` shell
+vtep1>tcpdump -nli vtep1-vtep2 udp port 4789
+tcpdump: verbose output suppressed, use -v[v]... for full protocol decode
+listening on vtep1-vtep2, link-type EN10MB (Ethernet), snapshot length 262144 bytes
+10:03:01.908531 IP 192.168.0.1.39940 > 192.168.0.2.4789: VXLAN, flags [I] (0x08), vni 10
+IP 172.16.10.1 > 172.16.10.2: ICMP echo request, id 12124, seq 4, length 64
+10:03:01.908652 IP 192.168.0.2.39940 > 192.168.0.1.4789: VXLAN, flags [I] (0x08), vni 10
+IP 172.16.10.2 > 172.16.10.1: ICMP echo reply, id 12124, seq 4, length 64
+```
+
+The very first ARP from `h1` takes the ingress-replication flood entry to
+`vtep2`; once each side's kernel learns the local MACs, the Type-2 routes
+convert everything to targeted unicast.
+
+## Under the hood: the single-VXLAN-device datapath
+
+zebra-rs uses the kernel's modern single-VXLAN-device model (one
+`external` + `vnifilter` device carries any number of VNIs). For bridged
+traffic to encapsulate, the daemon programs — automatically, when a VXLAN
+with a VNI joins a bridge:
+
+* `vlan_filtering 1` on the bridge (per-VLAN machinery on; other ports
+  keep the default PVID-1-untagged behaviour, so a flat bridge forwards as
+  before),
+* `vlan_tunnel on` on the VXLAN bridge port,
+* VLAN 1 as a **tagged** member on that port with a
+  `tunnel_info id <vni>` mapping — the bridge egress hook swaps the VLAN
+  tag for tunnel metadata, which is exactly what a metadata-mode VXLAN
+  device requires to transmit (without it the kernel drops every bridged
+  frame with `SKB_DROP_REASON_TUNNEL_TXINFO`).
+
+You can see all of it with `bridge -d link show dev vxlan10`,
+`bridge vlan tunnelshow`, and `ip -d link show vxlan10` inside the VTEP's
+vty shell.
+
+## Appendix: Addresses
+
+| node  | role | underlay      | overlay        |
+|:------|:-----|:--------------|:---------------|
+| vtep1 | VTEP | 192.168.0.1/24 | —             |
+| vtep2 | VTEP | 192.168.0.2/24 | —             |
+| h1    | host | —             | 172.16.10.1/24 |
+| h2    | host | —             | 172.16.10.2/24 |
+
+VNI 10, UDP port 4789, iBGP AS 65001; RD `<router-id>:10`, RT `65001:10`
+(auto-derived from the VNI).

--- a/playset/bgp-evpn-vxlan/down.sh
+++ b/playset/bgp-evpn-vxlan/down.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+# Tear down the IS-IS SR-MPLS namespace demo.
+
+PLAYSET_DEMO_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=../lib/playset.sh
+source "${PLAYSET_DEMO_DIR}/../lib/playset.sh"
+# shellcheck source=topology.sh
+source "${PLAYSET_DEMO_DIR}/topology.sh"
+
+playset_teardown

--- a/playset/bgp-evpn-vxlan/h1.yaml
+++ b/playset/bgp-evpn-vxlan/h1.yaml
@@ -1,0 +1,6 @@
+interface:
+- if-name: h1-vtep1
+  ipv4:
+    address: 172.16.10.1/24
+system:
+  hostname: h1

--- a/playset/bgp-evpn-vxlan/h2.yaml
+++ b/playset/bgp-evpn-vxlan/h2.yaml
@@ -1,0 +1,6 @@
+interface:
+- if-name: h2-vtep2
+  ipv4:
+    address: 172.16.10.2/24
+system:
+  hostname: h2

--- a/playset/bgp-evpn-vxlan/topology.sh
+++ b/playset/bgp-evpn-vxlan/topology.sh
@@ -1,0 +1,16 @@
+# BGP EVPN VXLAN demo topology.
+# Each PLAYSET_LINKS entry is "ns_a:iface_a:ns_b:iface_b".
+
+PLAYSET_NAMESPACES=(vtep1 vtep2 h1 h2)
+
+PLAYSET_LINKS=(
+    vtep1:vtep1-vtep2:vtep2:vtep2-vtep1
+    h1:h1-vtep1:vtep1:vtep1-h1
+    h2:h2-vtep2:vtep2:vtep2-h2
+)
+
+# All namespaces that run zebra-rs.
+PLAYSET_DAEMONS=(vtep1 vtep2 h1 h2)
+
+# Routers with vtyctl YAML config.
+PLAYSET_ROUTERS=(vtep1 vtep2 h1 h2)

--- a/playset/bgp-evpn-vxlan/up.sh
+++ b/playset/bgp-evpn-vxlan/up.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+# Bring up the IS-IS SR-MPLS namespace demo from scratch.
+
+PLAYSET_DEMO_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=../lib/playset.sh
+source "${PLAYSET_DEMO_DIR}/../lib/playset.sh"
+# shellcheck source=topology.sh
+source "${PLAYSET_DEMO_DIR}/topology.sh"
+
+playset_up

--- a/playset/bgp-evpn-vxlan/vtep1.yaml
+++ b/playset/bgp-evpn-vxlan/vtep1.yaml
@@ -1,0 +1,32 @@
+interface:
+- if-name: vtep1-vtep2
+  ipv4:
+    address: 192.168.0.1/24
+- if-name: vtep1-h1
+  bridge: br10
+system:
+  hostname: vtep1
+bridge:
+- name: br10
+vxlan:
+- name: vxlan10
+  vni: 10
+  local-address: 192.168.0.1
+  bridge: br10
+router:
+  bgp:
+    global:
+      as: 65001
+      router-id: 192.168.0.1
+    afi-safi:
+    - name: evpn
+      advertise-all-vni: true
+    neighbor:
+    - remote-address: 192.168.0.2
+      enabled: true
+      remote-as: 65001
+      afi-safi:
+      - name: ipv4
+        enabled: true
+      - name: evpn
+        enabled: true

--- a/playset/bgp-evpn-vxlan/vtep2.yaml
+++ b/playset/bgp-evpn-vxlan/vtep2.yaml
@@ -1,0 +1,32 @@
+interface:
+- if-name: vtep2-vtep1
+  ipv4:
+    address: 192.168.0.2/24
+- if-name: vtep2-h2
+  bridge: br10
+system:
+  hostname: vtep2
+bridge:
+- name: br10
+vxlan:
+- name: vxlan10
+  vni: 10
+  local-address: 192.168.0.2
+  bridge: br10
+router:
+  bgp:
+    global:
+      as: 65001
+      router-id: 192.168.0.2
+    afi-safi:
+    - name: evpn
+      advertise-all-vni: true
+    neighbor:
+    - remote-address: 192.168.0.1
+      enabled: true
+      remote-as: 65001
+      afi-safi:
+      - name: ipv4
+        enabled: true
+      - name: evpn
+        enabled: true

--- a/zebra-rs/src/fib/netlink/handle.rs
+++ b/zebra-rs/src/fib/netlink/handle.rs
@@ -2453,9 +2453,12 @@ impl FibHandle {
 
     /// Apply the VXLAN bridge-slave defaults to the port at `ifindex`:
     /// neighbour suppression on (ARP/ND answered locally from the FDB
-    /// instead of flooded) and bridge-port MAC learning off (EVPN's BGP
-    /// control plane owns the FDB). Equivalent to:
-    ///   ip link set <dev> type bridge_slave neigh_suppress on learning off
+    /// instead of flooded), bridge-port MAC learning off (EVPN's BGP
+    /// control plane owns the FDB), and per-VLAN tunnel mapping enabled
+    /// (required for the single-VXLAN-device egress path — see
+    /// `vxlan_svd_datapath`). Equivalent to:
+    ///   ip link set <dev> type bridge_slave \
+    ///     neigh_suppress on learning off vlan_tunnel on
     /// Called when the RIB observes a VXLAN device gaining a bridge
     /// master; a no-op error is logged if the master is not a bridge.
     pub async fn vxlan_bridge_port_defaults(&self, ifindex: u32) {
@@ -2465,6 +2468,7 @@ impl FibHandle {
         let port_data = InfoPortData::BridgePort(vec![
             InfoBridgePort::NeighSupress(true),
             InfoBridgePort::Learning(false),
+            InfoBridgePort::VlanTunnel(true),
         ]);
         let link_info = LinkAttribute::LinkInfo(vec![
             LinkInfo::PortKind(InfoPortKind::Bridge),
@@ -2479,6 +2483,105 @@ impl FibHandle {
         while let Some(msg) = response.next().await {
             if let NetlinkPayload::Error(e) = msg.payload {
                 tracing::info!("SetLink bridge-port defaults error: {e}");
+            }
+        }
+    }
+
+    /// Wire the single-VXLAN-device (external / vnifilter) kernel
+    /// datapath for a VXLAN port that joined a bridge, so bridged
+    /// traffic actually encapsulates:
+    ///
+    ///   1. enable `vlan_filtering` on the bridge master — the per-VLAN
+    ///      machinery (and thus the tunnel mapping) is dormant without
+    ///      it; other ports keep the kernel's `default_pvid 1` untagged
+    ///      behaviour, so a flat bridge forwards exactly as before;
+    ///   2. add VLAN 1 on the VXLAN port as a TAGGED member (deliberately
+    ///      NOT `untagged`: `br_handle_vlan` strips the tag *before* the
+    ///      egress tunnel hook runs, and a tag-less frame makes
+    ///      `br_handle_egress_vlan_tunnel` bail without attaching the
+    ///      tunnel metadata — the hook itself pops the tag);
+    ///   3. map VLAN 1 -> the VNI (`bridge vlan add dev <vxlan> vid 1
+    ///      tunnel_info id <vni>`), which the bridge egress hook turns
+    ///      into `IP_TUNNEL_INFO_BRIDGE|TX` dst-metadata. Without that
+    ///      metadata a COLLECT_METADATA device drops every bridged frame
+    ///      in `vxlan_xmit` with SKB_DROP_REASON_TUNNEL_TXINFO.
+    ///
+    /// The decap direction needs no PVID: `br_handle_ingress_vlan_tunnel`
+    /// maps the received tunnel id back to VLAN 1 through the same table.
+    /// `vlan_tunnel on` for the port is set by
+    /// `vxlan_bridge_port_defaults`.
+    pub async fn vxlan_svd_datapath(&self, ifindex: u32, bridge_ifindex: u32, vni: u32) {
+        use netlink_packet_route::AddressFamily;
+        use netlink_packet_route::link::{AfSpecBridge, BridgeVlanInfo, InfoBridge, InfoData};
+        use netlink_packet_utils::nla::DefaultNla;
+
+        // 1. vlan_filtering on the bridge master.
+        let mut msg = LinkMessage::default();
+        msg.header.index = bridge_ifindex;
+        msg.attributes.push(LinkAttribute::LinkInfo(vec![
+            LinkInfo::Kind(InfoKind::Bridge),
+            LinkInfo::Data(InfoData::Bridge(vec![InfoBridge::VlanFiltering(true)])),
+        ]));
+        let mut req = NetlinkMessage::from(RouteNetlinkMessage::NewLink(msg));
+        req.header.flags = NLM_F_REQUEST | NLM_F_ACK;
+        let mut response = self.handle.clone().request(req).unwrap();
+        while let Some(msg) = response.next().await {
+            if let NetlinkPayload::Error(e) = msg.payload {
+                tracing::info!("SetLink bridge vlan_filtering error: {e}");
+            }
+        }
+
+        // 2. VLAN 1 on the VXLAN port, tagged (flags = 0).
+        let mut vinfo = BridgeVlanInfo::default();
+        vinfo.flags = 0;
+        vinfo.vid = 1;
+        let mut msg = LinkMessage::default();
+        msg.header.interface_family = AddressFamily::Bridge;
+        msg.header.index = ifindex;
+        msg.attributes
+            .push(LinkAttribute::AfSpecBridge(vec![AfSpecBridge::VlanInfo(
+                vinfo,
+            )]));
+        let mut req = NetlinkMessage::from(RouteNetlinkMessage::SetLink(msg));
+        req.header.flags = NLM_F_REQUEST | NLM_F_ACK;
+        let mut response = self.handle.clone().request(req).unwrap();
+        while let Some(msg) = response.next().await {
+            if let NetlinkPayload::Error(e) = msg.payload {
+                tracing::info!("SetLink vxlan port vlan error: {e}");
+            }
+        }
+
+        // 3. VLAN 1 -> VNI tunnel mapping. The crate has no typed
+        // IFLA_BRIDGE_VLAN_TUNNEL_INFO (3) support, so hand-encode the
+        // nest exactly as iproute2 does:
+        //   IFLA_BRIDGE_VLAN_TUNNEL_ID   (1): u32 vni
+        //   IFLA_BRIDGE_VLAN_TUNNEL_VID  (2): u16 1
+        const NLA_F_NESTED: u16 = 0x8000;
+        const IFLA_BRIDGE_VLAN_TUNNEL_INFO: u16 = 3;
+        let mut nest: Vec<u8> = Vec::new();
+        // TUNNEL_ID: nla_len 8, type 1, u32 payload.
+        nest.extend_from_slice(&8u16.to_ne_bytes());
+        nest.extend_from_slice(&1u16.to_ne_bytes());
+        nest.extend_from_slice(&vni.to_ne_bytes());
+        // TUNNEL_VID: nla_len 6, type 2, u16 payload + 2 pad bytes.
+        nest.extend_from_slice(&6u16.to_ne_bytes());
+        nest.extend_from_slice(&2u16.to_ne_bytes());
+        nest.extend_from_slice(&1u16.to_ne_bytes());
+        nest.extend_from_slice(&[0u8; 2]);
+
+        let mut msg = LinkMessage::default();
+        msg.header.interface_family = AddressFamily::Bridge;
+        msg.header.index = ifindex;
+        msg.attributes
+            .push(LinkAttribute::AfSpecBridge(vec![AfSpecBridge::Other(
+                DefaultNla::new(IFLA_BRIDGE_VLAN_TUNNEL_INFO | NLA_F_NESTED, nest),
+            )]));
+        let mut req = NetlinkMessage::from(RouteNetlinkMessage::SetLink(msg));
+        req.header.flags = NLM_F_REQUEST | NLM_F_ACK;
+        let mut response = self.handle.clone().request(req).unwrap();
+        while let Some(msg) = response.next().await {
+            if let NetlinkPayload::Error(e) = msg.payload {
+                tracing::info!("SetLink vxlan vlan-tunnel map error: {e}");
             }
         }
     }

--- a/zebra-rs/src/rib/link.rs
+++ b/zebra-rs/src/rib/link.rs
@@ -725,8 +725,16 @@ impl Rib {
             && prev_evpn_bridge != Some(bridge)
         {
             // The VXLAN just joined a bridge: apply the EVPN bridge-slave
-            // defaults on its port (`neigh_suppress on`, `learning off`).
+            // defaults on its port (`neigh_suppress on`, `learning off`,
+            // `vlan_tunnel on`), and wire the single-VXLAN-device kernel
+            // datapath (bridge vlan_filtering + the VLAN 1 -> VNI tunnel
+            // mapping) so bridged traffic actually encapsulates.
             self.fib_handle.vxlan_bridge_port_defaults(ifindex).await;
+            if let Some(vni) = now_vni {
+                self.fib_handle
+                    .vxlan_svd_datapath(ifindex, bridge, vni)
+                    .await;
+            }
             self.rescan_fdb_for_bridge(bridge);
         }
 


### PR DESCRIPTION
## Summary

Building an EVPN VXLAN playset exposed a real datapath gap, fixed here alongside the playset itself.

**The gap**: zebra-rs creates VTEPs as modern single-VXLAN-device (external + vnifilter) devices and programs the EVPN FDB correctly, but bridged traffic never encapsulated — a COLLECT_METADATA device drops every frame arriving without tunnel metadata (`SKB_DROP_REASON_TUNNEL_TXINFO`, confirmed with kfree_skb/kprobe/bpftrace tracing), and nothing attached that metadata. The EVPN BDD suites only assert FDB *decisions*, so forwarding was never exercised.

**The fix** (`fib`): when a VXLAN with a VNI joins a bridge, the daemon now also programs `vlan_filtering` on the bridge, `vlan_tunnel on` on the VXLAN port, and VLAN 1 as a **tagged** member with a `vid 1 → VNI` `tunnel_info` mapping. Tagged is load-bearing and was the subtle part: `br_handle_vlan` strips the tag *before* the egress tunnel hook runs, and the hook bails on tag-less frames — an `Egress Untagged` membership silently disables the mapping (the hook itself pops the tag and swaps it for `IP_TUNNEL_INFO_BRIDGE|TX` metadata). Decap needs no PVID: the ingress hook maps tunnel id → VLAN through the same table. The `IFLA_BRIDGE_VLAN_TUNNEL_INFO` nest is hand-encoded (no typed support in the netlink crate), mirroring iproute2.

**The playset** (`playset/bgp-evpn-vxlan/`): two VTEPs, two hosts on one stretched subnet, iBGP EVPN. The walkthrough shows the L2VPN EVPN summary, the EVPN RIB (Type-2 MAC routes + Type-3 IMETs with RT/ET and ingress-replication PMSI), the control-plane-installed FDB (`extern_learn`, flood entry from the IMET), `bridge vni`/`tunnelshow`, host-to-host ping at `ttl=64`, and the VXLAN VNI-10 frames with the inner host packets on the wire — plus an under-the-hood section documenting the SVD plumbing. Index updated.

## Test plan

- [x] End-to-end forwarding on a live lab: h1↔h2 ping across the stretch (`ttl=64`), VXLAN frames captured on the underlay, first-contact BUM via the IMET flood entry then Type-2-targeted unicast
- [x] EVPN BDD regression, all green: `bgp_evpn_ar` 7/7, `bgp_evpn_df_election` 5/5, `bgp_evpn_smet` 6/6, `bgp_evpn_gateway_df` 4/4, `bgp_vrf_evpn_type5` 4/4, `bgp_evpn_segmentation` 7/7, `bgp_evpn_vpws` 6/6
- [x] `cargo test --workspace --exclude bdd` (37 suites), clippy `-D warnings`, fmt

🤖 Generated with [Claude Code](https://claude.com/claude-code)