### PR TITLE
playset: OSPFv3 SRv6 uSID (NEXT-C-SID) walkthrough

### DIFF
--- a/playset/README.md
+++ b/playset/README.md
@@ -39,7 +39,7 @@ gitignored.
 
 ## SRv6 & SR-MPLS with TI-LFA fast-reroute
 
-Six labs, one topology — the RFC 9855 example network with two edge hosts
+Seven labs, one topology — the RFC 9855 example network with two edge hosts
 attached — covering the IGP x data-plane matrix. Every walkthrough follows
 the same arc: examine SR routing at the source, enable
 `fast-reroute ti-lfa` at runtime, force the repair into use with
@@ -54,6 +54,7 @@ protected edge-to-edge traffic.
 | [isis-srv6-classic](isis-srv6-classic/README.md) | IS-IS | SRv6, classic RFC 8986 SIDs (RFC 9352) | RFC 9252 iBGP IPv6-unicast with End.DT6 service SIDs |
 | [isis-srv6-usid](isis-srv6-usid/README.md) | IS-IS | SRv6, uSID / NEXT-C-SID (RFC 9800) | RFC 9252 iBGP IPv6-unicast with End.DT6 service SIDs |
 | [ospfv3-srv6-classic](ospfv3-srv6-classic/README.md) | OSPFv3 (area 0) | SRv6, classic RFC 8986 SIDs (RFC 9513) | RFC 9252 iBGP IPv6-unicast with End.DT6 service SIDs |
+| [ospfv3-srv6-usid](ospfv3-srv6-usid/README.md) | OSPFv3 (area 0) | SRv6, uSID / NEXT-C-SID (RFC 9800) | RFC 9252 iBGP IPv6-unicast with End.DT6 service SIDs |
 
 Some cross-cutting themes to look for:
 

--- a/playset/README.md
+++ b/playset/README.md
@@ -39,7 +39,7 @@ gitignored.
 
 ## SRv6 & SR-MPLS with TI-LFA fast-reroute
 
-Five labs, one topology — the RFC 9855 example network with two edge hosts
+Six labs, one topology — the RFC 9855 example network with two edge hosts
 attached — covering the IGP x data-plane matrix. Every walkthrough follows
 the same arc: examine SR routing at the source, enable
 `fast-reroute ti-lfa` at runtime, force the repair into use with
@@ -52,6 +52,7 @@ protected edge-to-edge traffic.
 | [ospfv2-srmpls](ospfv2-srmpls/README.md) | OSPFv2 (area 0) | SR-MPLS (RFC 8665 extended LSAs) | recursive IPv4 statics inheriting the SR label stack |
 | [ospfv3-srmpls](ospfv3-srmpls/README.md) | OSPFv3 (area 0) | SR-MPLS over IPv6 (RFC 8666, NP-flag / no PHP) | recursive IPv6 statics inheriting the SR label stack |
 | [isis-srv6-classic](isis-srv6-classic/README.md) | IS-IS | SRv6, classic RFC 8986 SIDs (RFC 9352) | RFC 9252 iBGP IPv6-unicast with End.DT6 service SIDs |
+| [isis-srv6-usid](isis-srv6-usid/README.md) | IS-IS | SRv6, uSID / NEXT-C-SID (RFC 9800) | RFC 9252 iBGP IPv6-unicast with End.DT6 service SIDs |
 | [ospfv3-srv6-classic](ospfv3-srv6-classic/README.md) | OSPFv3 (area 0) | SRv6, classic RFC 8986 SIDs (RFC 9513) | RFC 9252 iBGP IPv6-unicast with End.DT6 service SIDs |
 
 Some cross-cutting themes to look for:

--- a/playset/isis-srv6-usid/README.md
+++ b/playset/isis-srv6-usid/README.md
@@ -1,0 +1,147 @@
+# IS-IS SRv6 (uSID) & TI-LFA
+
+This playset is the **uSID** (compressed SID, NEXT-C-SID flavor — RFC 9800)
+variant of the [IS-IS SRv6 classic playset](../isis-srv6-classic/README.md).
+The topology, addressing, locators, BGP End.DT6 service layer, and the
+entire walkthrough arc are identical — the *only* configuration difference
+is one line per node:
+
+``` yaml
+segment-routing:
+  locator:
+  - name: LOC1
+    prefix: fcbb:bbbb:1::/48
+    behavior: usid          # <-- this line
+```
+
+With `behavior: usid`, the locator's 48 bits split into a 32-bit uSID
+*block* (`fcbb:bbbb`) shared by the whole domain and a 16-bit *node id*
+(`0001`..`0008`), and every SID becomes a 16-bit micro-instruction that
+can be packed with others into a single 128-bit *carrier*. Where the
+classic lab needed one 128-bit SID per repair segment, this lab fits the
+whole TI-LFA repair into one address.
+
+## Bring up all nodes
+
+Same as the classic lab (`./up.sh`, shared namespace names — one playset
+at a time; OSPFv3 + iBGP need a minute or two to settle).
+
+## The uSID machinery in the kernel
+
+``` shell
+$ sudo ip netns exec s vty
+s>show ipv6 route
+...
+i  *> fcbb:bbbb:1::/48 [115/0] is directly connected, sr0, seg6local End, 00:01:00
+...
+```
+
+The node's own SID space looks different from the classic lab: instead of
+a /128 End SID, the **whole locator /48** installs as an End with the
+NEXT-C-SID flavor — the *uN* SID. In the kernel:
+
+``` shell
+s>ip -6 route show fcbb:bbbb:1::/48
+fcbb:bbbb:1::/48  encap seg6local action End flavors next-csid lblen 32 nflen 16 dev sr0 proto isis metric 1024
+```
+
+`lblen 32 nflen 16` is the uSID split: 32-bit block, 16-bit node
+function. Any packet whose destination starts `fcbb:bbbb:0001:...` is
+processed by `s`, which *shifts* the address 16 bits left (consuming its
+own id) and forwards on whatever micro-instruction surfaces next.
+
+The adjacency SIDs exist in two forms on every node — here on `r1`:
+
+``` shell
+r1>ip -6 route | grep seg6local
+fcbb:bbbb:5:e000::  encap seg6local action End.X nh6 2001:db8:0:4::1 dev r1-n1 proto isis metric 1024
+fcbb:bbbb:5:e003::  encap seg6local action End.X nh6 2001:db8:0:8::2 dev r1-r2 proto isis metric 1024
+fcbb:bbbb:5::/48  encap seg6local action End flavors next-csid lblen 32 nflen 16 dev sr0 proto isis metric 1024
+fcbb:bbbb:e000::/48  encap seg6local action End.X nh6 2001:db8:0:4::1 flavors next-csid lblen 32 nflen 16 dev r1-n1 proto isis metric 1024
+fcbb:bbbb:e003::/48  encap seg6local action End.X nh6 2001:db8:0:8::2 flavors next-csid lblen 32 nflen 16 dev r1-r2 proto isis metric 1024
+...
+```
+
+The *addressed* form (`fcbb:bbbb:5:e003::`, plain End.X) serves packets
+that name the SID explicitly; the *shifted* form
+(`fcbb:bbbb:e003::/48`, NEXT-C-SID flavored **uA**) is what a packet
+matches right after an upstream uSID consumed the node id — it executes
+the cross-connect and shifts again. This pair is the entire
+shift-and-forward pipeline of RFC 9800, visible as ordinary kernel
+routes.
+
+## TI-LFA: the whole repair in one carrier
+
+``` shell
+s>configure
+s#set router isis fast-reroute ti-lfa
+s#commit
+s#exit
+s>show ipv6 route
+...
+L2 *> 2001:db8::8/128 [115/12] via fe80::4471:d5ff:fe05:192e, s-n1, 00:00:00
+   *?                 [115/13] via seg6 [fcbb:bbbb:5:e003:e000::], s-n2, 00:00:00
+```
+
+Compare with the classic lab's backup for the same destination:
+
+```
+classic:  via seg6 [fcbb:bbbb:5::, fcbb:bbbb:5:e003::, fcbb:bbbb:6:e002::]
+uSID:     via seg6 [fcbb:bbbb:5:e003:e000::]
+```
+
+The same three repair instructions — reach `r1`, cross `r1->r2`, cross
+`r2->r3` — pack into a single carrier: block `fcbb:bbbb`, then the
+micro-instructions `0005` (uN of r1), `e003` (r1's uA toward r2), `e000`
+(r2's uA toward r3, renumbered into the shifted space). Each hop consumes
+its own 16 bits and forwards; when the carrier is spent, the SRH advances
+to its final segment — the original destination, exactly as in the
+classic lab (H.Insert keeps it as segment [0]).
+
+## Force the backup to become primary, and look at the wire
+
+``` shell
+s>configure
+s#set router isis fast-reroute backup-as-primary
+s#commit
+s#exit
+s>show ipv6 route
+...
+L2 *> 2001:db8::8/128 [115/12] via seg6 [fcbb:bbbb:5:e003:e000::], s-n2, 00:00:05
+   *?                 [115/13] via fe80::4471:d5ff:fe05:192e, s-n1, 00:00:05
+...
+B  *> 2001:db8:200::/64 [200/0] via seg6 [fcbb:bbbb:8:40::], s-n2, 00:01:31
+```
+
+(The BGP End.DT6 service route follows the promoted locator underneath,
+exactly as in the classic lab.)
+
+``` shell
+n2>tcpdump -nli n2-s ip6 proto 43
+tcpdump: verbose output suppressed, use -v[v]... for full protocol decode
+listening on n2-s, link-type EN10MB (Ethernet), snapshot length 262144 bytes
+10:23:45.360700 IP6 2001:db8:0:2::1 > fcbb:bbbb:5:e003:e000::: RT6 (len=4, type=4, segleft=1, last-entry=1, tag=0, [0]2001:db8::8, [1]fcbb:bbbb:5:e003:e000::) ICMP6, echo request, id 27686, seq 8, length 64
+```
+
+The inserted SRH is `len=4, segleft=1` — **two entries** (the carrier and
+the original destination), versus the classic lab's `len=8, segleft=3`
+four-entry header. Half the header for the same repair; that is the uSID
+value proposition on one line of tcpdump.
+
+The protected BGP service traffic stacks the same way — repair carrier
+over service SID over host packet, with the repair SRH shrunk to two
+entries:
+
+``` shell
+10:23:46.581677 IP6 2001:db8:0:1::1 > fcbb:bbbb:5:e003:e000::: RT6 (len=4, type=4, segleft=1, last-entry=1, tag=0, [0]fcbb:bbbb:8:40::, [1]fcbb:bbbb:5:e003:e000::) RT6 (len=2, type=4, segleft=0, last-entry=0, tag=0, [0]fcbb:bbbb:8:40::) IP6 2001:db8:100::100 > 2001:db8:200::100: ICMP6, echo request, id 27687, seq 11, length 64
+```
+
+## Everything else
+
+...is the classic lab, unchanged: the topology and appendix tables, the
+BGP IPv6-unicast service with End.DT6 SIDs (`fcbb:bbbb:X:40::` — carved
+from the same uSID locators), the edge hosts with plain default routes,
+and the walkthrough commands. See the
+[classic README](../isis-srv6-classic/README.md) for the full narrative;
+run this lab side by side (one at a time) to compare the SID tables,
+repair lists, and SRH sizes.

--- a/playset/isis-srv6-usid/d.yaml
+++ b/playset/isis-srv6-usid/d.yaml
@@ -1,0 +1,67 @@
+interface:
+- if-name: lo
+  ipv6:
+    address: 2001:db8::8/128
+- if-name: d-n1
+  ipv6:
+    address: 2001:db8:0:10::2/64
+- if-name: d-r3
+  ipv6:
+    address: 2001:db8:0:11::2/64
+- if-name: d-e2
+  ipv6:
+    address: 2001:db8:200::1/64
+system:
+  hostname: d
+segment-routing:
+  locator:
+  - name: LOC8
+    prefix: fcbb:bbbb:8::/48
+    behavior: usid
+router:
+  isis:
+    net: 49.0000.0000.0000.0008.00
+    hostname: d
+    is-type: level-2-only
+    segment-routing:
+      srv6:
+        locator: LOC8
+    interface:
+    - if-name: lo
+      ipv6:
+        enabled: true
+    - if-name: d-n1
+      network-type: point-to-point
+      metric: 1
+      ipv6:
+        enabled: true
+    - if-name: d-r3
+      network-type: point-to-point
+      metric: 1
+      ipv6:
+        enabled: true
+  bgp:
+    global:
+      as: 65000
+      router-id: 10.0.0.8
+    timer:
+      adv-interval:
+        ibgp: 1
+        ebgp: 1
+    segment-routing:
+      srv6:
+        locator: LOC8
+        ipv6-unicast: {}
+    neighbor:
+    - remote-address: 2001:db8::1
+      remote-as: 65000
+      update-source: 2001:db8::8
+      enabled: true
+      afi-safi:
+      - name: ipv6
+        enabled: true
+        encapsulation-type: srv6
+    afi-safi:
+    - name: ipv6
+      redistribute:
+        connected: {}

--- a/playset/isis-srv6-usid/down.sh
+++ b/playset/isis-srv6-usid/down.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+# Tear down the IS-IS SR-MPLS namespace demo.
+
+PLAYSET_DEMO_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=../lib/playset.sh
+source "${PLAYSET_DEMO_DIR}/../lib/playset.sh"
+# shellcheck source=topology.sh
+source "${PLAYSET_DEMO_DIR}/topology.sh"
+
+playset_teardown

--- a/playset/isis-srv6-usid/e1.yaml
+++ b/playset/isis-srv6-usid/e1.yaml
@@ -1,0 +1,13 @@
+interface:
+- if-name: e1-s
+  ipv6:
+    address: 2001:db8:100::100/64
+system:
+  hostname: e1
+router:
+  static:
+    ipv6:
+      route:
+      - prefix: ::/0
+        nexthop:
+        - address: 2001:db8:100::1

--- a/playset/isis-srv6-usid/e2.yaml
+++ b/playset/isis-srv6-usid/e2.yaml
@@ -1,0 +1,13 @@
+interface:
+- if-name: e2-d
+  ipv6:
+    address: 2001:db8:200::100/64
+system:
+  hostname: e2
+router:
+  static:
+    ipv6:
+      route:
+      - prefix: ::/0
+        nexthop:
+        - address: 2001:db8:200::1

--- a/playset/isis-srv6-usid/n1.yaml
+++ b/playset/isis-srv6-usid/n1.yaml
@@ -1,0 +1,55 @@
+interface:
+- if-name: lo
+  ipv6:
+    address: 2001:db8::2/128
+- if-name: n1-s
+  ipv6:
+    address: 2001:db8:0:1::2/64
+- if-name: n1-r1
+  ipv6:
+    address: 2001:db8:0:4::1/64
+- if-name: n1-r2
+  ipv6:
+    address: 2001:db8:0:7::1/64
+- if-name: n1-d
+  ipv6:
+    address: 2001:db8:0:10::1/64
+system:
+  hostname: n1
+segment-routing:
+  locator:
+  - name: LOC2
+    prefix: fcbb:bbbb:2::/48
+    behavior: usid
+router:
+  isis:
+    net: 49.0000.0000.0000.0002.00
+    hostname: n1
+    is-type: level-2-only
+    segment-routing:
+      srv6:
+        locator: LOC2
+    interface:
+    - if-name: lo
+      ipv6:
+        enabled: true
+    - if-name: n1-s
+      network-type: point-to-point
+      metric: 1
+      ipv6:
+        enabled: true
+    - if-name: n1-r1
+      network-type: point-to-point
+      metric: 1
+      ipv6:
+        enabled: true
+    - if-name: n1-r2
+      network-type: point-to-point
+      metric: 1
+      ipv6:
+        enabled: true
+    - if-name: n1-d
+      network-type: point-to-point
+      metric: 1
+      ipv6:
+        enabled: true

--- a/playset/isis-srv6-usid/n2.yaml
+++ b/playset/isis-srv6-usid/n2.yaml
@@ -1,0 +1,39 @@
+interface:
+- if-name: lo
+  ipv6:
+    address: 2001:db8::3/128
+- if-name: n2-s
+  ipv6:
+    address: 2001:db8:0:2::2/64
+- if-name: n2-r1
+  ipv6:
+    address: 2001:db8:0:5::1/64
+system:
+  hostname: n2
+segment-routing:
+  locator:
+  - name: LOC3
+    prefix: fcbb:bbbb:3::/48
+    behavior: usid
+router:
+  isis:
+    net: 49.0000.0000.0000.0003.00
+    hostname: n2
+    is-type: level-2-only
+    segment-routing:
+      srv6:
+        locator: LOC3
+    interface:
+    - if-name: lo
+      ipv6:
+        enabled: true
+    - if-name: n2-s
+      network-type: point-to-point
+      metric: 1
+      ipv6:
+        enabled: true
+    - if-name: n2-r1
+      network-type: point-to-point
+      metric: 1
+      ipv6:
+        enabled: true

--- a/playset/isis-srv6-usid/n3.yaml
+++ b/playset/isis-srv6-usid/n3.yaml
@@ -1,0 +1,39 @@
+interface:
+- if-name: lo
+  ipv6:
+    address: 2001:db8::4/128
+- if-name: n3-s
+  ipv6:
+    address: 2001:db8:0:3::2/64
+- if-name: n3-r1
+  ipv6:
+    address: 2001:db8:0:6::1/64
+system:
+  hostname: n3
+segment-routing:
+  locator:
+  - name: LOC4
+    prefix: fcbb:bbbb:4::/48
+    behavior: usid
+router:
+  isis:
+    net: 49.0000.0000.0000.0004.00
+    hostname: n3
+    is-type: level-2-only
+    segment-routing:
+      srv6:
+        locator: LOC4
+    interface:
+    - if-name: lo
+      ipv6:
+        enabled: true
+    - if-name: n3-s
+      network-type: point-to-point
+      metric: 1000
+      ipv6:
+        enabled: true
+    - if-name: n3-r1
+      network-type: point-to-point
+      metric: 1000
+      ipv6:
+        enabled: true

--- a/playset/isis-srv6-usid/r1.yaml
+++ b/playset/isis-srv6-usid/r1.yaml
@@ -1,0 +1,55 @@
+interface:
+- if-name: lo
+  ipv6:
+    address: 2001:db8::5/128
+- if-name: r1-n1
+  ipv6:
+    address: 2001:db8:0:4::2/64
+- if-name: r1-n2
+  ipv6:
+    address: 2001:db8:0:5::2/64
+- if-name: r1-n3
+  ipv6:
+    address: 2001:db8:0:6::2/64
+- if-name: r1-r2
+  ipv6:
+    address: 2001:db8:0:8::1/64
+system:
+  hostname: r1
+segment-routing:
+  locator:
+  - name: LOC5
+    prefix: fcbb:bbbb:5::/48
+    behavior: usid
+router:
+  isis:
+    net: 49.0000.0000.0000.0005.00
+    hostname: r1
+    is-type: level-2-only
+    segment-routing:
+      srv6:
+        locator: LOC5
+    interface:
+    - if-name: lo
+      ipv6:
+        enabled: true
+    - if-name: r1-n1
+      network-type: point-to-point
+      metric: 1
+      ipv6:
+        enabled: true
+    - if-name: r1-n2
+      network-type: point-to-point
+      metric: 1
+      ipv6:
+        enabled: true
+    - if-name: r1-n3
+      network-type: point-to-point
+      metric: 1000
+      ipv6:
+        enabled: true
+    - if-name: r1-r2
+      network-type: point-to-point
+      metric: 1000
+      ipv6:
+        enabled: true

--- a/playset/isis-srv6-usid/r2.yaml
+++ b/playset/isis-srv6-usid/r2.yaml
@@ -1,0 +1,47 @@
+interface:
+- if-name: lo
+  ipv6:
+    address: 2001:db8::6/128
+- if-name: r2-n1
+  ipv6:
+    address: 2001:db8:0:7::2/64
+- if-name: r2-r1
+  ipv6:
+    address: 2001:db8:0:8::2/64
+- if-name: r2-r3
+  ipv6:
+    address: 2001:db8:0:9::1/64
+system:
+  hostname: r2
+segment-routing:
+  locator:
+  - name: LOC6
+    prefix: fcbb:bbbb:6::/48
+    behavior: usid
+router:
+  isis:
+    net: 49.0000.0000.0000.0006.00
+    hostname: r2
+    is-type: level-2-only
+    segment-routing:
+      srv6:
+        locator: LOC6
+    interface:
+    - if-name: lo
+      ipv6:
+        enabled: true
+    - if-name: r2-n1
+      network-type: point-to-point
+      metric: 1
+      ipv6:
+        enabled: true
+    - if-name: r2-r1
+      network-type: point-to-point
+      metric: 1000
+      ipv6:
+        enabled: true
+    - if-name: r2-r3
+      network-type: point-to-point
+      metric: 1000
+      ipv6:
+        enabled: true

--- a/playset/isis-srv6-usid/r3.yaml
+++ b/playset/isis-srv6-usid/r3.yaml
@@ -1,0 +1,39 @@
+interface:
+- if-name: lo
+  ipv6:
+    address: 2001:db8::7/128
+- if-name: r3-r2
+  ipv6:
+    address: 2001:db8:0:9::2/64
+- if-name: r3-d
+  ipv6:
+    address: 2001:db8:0:11::1/64
+system:
+  hostname: r3
+segment-routing:
+  locator:
+  - name: LOC7
+    prefix: fcbb:bbbb:7::/48
+    behavior: usid
+router:
+  isis:
+    net: 49.0000.0000.0000.0007.00
+    hostname: r3
+    is-type: level-2-only
+    segment-routing:
+      srv6:
+        locator: LOC7
+    interface:
+    - if-name: lo
+      ipv6:
+        enabled: true
+    - if-name: r3-r2
+      network-type: point-to-point
+      metric: 1000
+      ipv6:
+        enabled: true
+    - if-name: r3-d
+      network-type: point-to-point
+      metric: 1
+      ipv6:
+        enabled: true

--- a/playset/isis-srv6-usid/s.yaml
+++ b/playset/isis-srv6-usid/s.yaml
@@ -1,0 +1,75 @@
+interface:
+- if-name: lo
+  ipv6:
+    address: 2001:db8::1/128
+- if-name: s-n1
+  ipv6:
+    address: 2001:db8:0:1::1/64
+- if-name: s-n2
+  ipv6:
+    address: 2001:db8:0:2::1/64
+- if-name: s-n3
+  ipv6:
+    address: 2001:db8:0:3::1/64
+- if-name: s-e1
+  ipv6:
+    address: 2001:db8:100::1/64
+system:
+  hostname: s
+segment-routing:
+  locator:
+  - name: LOC1
+    prefix: fcbb:bbbb:1::/48
+    behavior: usid
+router:
+  isis:
+    net: 49.0000.0000.0000.0001.00
+    hostname: s
+    is-type: level-2-only
+    segment-routing:
+      srv6:
+        locator: LOC1
+    interface:
+    - if-name: lo
+      ipv6:
+        enabled: true
+    - if-name: s-n1
+      network-type: point-to-point
+      metric: 1
+      ipv6:
+        enabled: true
+    - if-name: s-n2
+      network-type: point-to-point
+      metric: 1
+      ipv6:
+        enabled: true
+    - if-name: s-n3
+      network-type: point-to-point
+      metric: 1000
+      ipv6:
+        enabled: true
+  bgp:
+    global:
+      as: 65000
+      router-id: 10.0.0.1
+    timer:
+      adv-interval:
+        ibgp: 1
+        ebgp: 1
+    segment-routing:
+      srv6:
+        locator: LOC1
+        ipv6-unicast: {}
+    neighbor:
+    - remote-address: 2001:db8::8
+      remote-as: 65000
+      update-source: 2001:db8::1
+      enabled: true
+      afi-safi:
+      - name: ipv6
+        enabled: true
+        encapsulation-type: srv6
+    afi-safi:
+    - name: ipv6
+      redistribute:
+        connected: {}

--- a/playset/isis-srv6-usid/topology.sh
+++ b/playset/isis-srv6-usid/topology.sh
@@ -1,0 +1,26 @@
+# IS-IS SRv6 (uSID) demo topology.
+# Each PLAYSET_LINKS entry is "ns_a:iface_a:ns_b:iface_b".
+
+PLAYSET_NAMESPACES=(e1 e2 s n1 n2 n3 r1 r2 r3 d)
+
+PLAYSET_LINKS=(
+    e1:e1-s:s:s-e1
+    d:d-e2:e2:e2-d
+    s:s-n1:n1:n1-s
+    s:s-n2:n2:n2-s
+    s:s-n3:n3:n3-s
+    n1:n1-r1:r1:r1-n1
+    n2:n2-r1:r1:r1-n2
+    n3:n3-r1:r1:r1-n3
+    n1:n1-r2:r2:r2-n1
+    r1:r1-r2:r2:r2-r1
+    r2:r2-r3:r3:r3-r2
+    n1:n1-d:d:d-n1
+    r3:r3-d:d:d-r3
+)
+
+# All namespaces that run zebra-rs.
+PLAYSET_DAEMONS=(e1 e2 s n1 n2 n3 r1 r2 r3 d)
+
+# Routers with vtyctl YAML config (end hosts e1/e2 have no config).
+PLAYSET_ROUTERS=(e1 e2 s n1 n2 n3 r1 r2 r3 d)

--- a/playset/isis-srv6-usid/up.sh
+++ b/playset/isis-srv6-usid/up.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+# Bring up the IS-IS SR-MPLS namespace demo from scratch.
+
+PLAYSET_DEMO_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=../lib/playset.sh
+source "${PLAYSET_DEMO_DIR}/../lib/playset.sh"
+# shellcheck source=topology.sh
+source "${PLAYSET_DEMO_DIR}/topology.sh"
+
+playset_up

--- a/playset/ospfv3-srv6-usid/README.md
+++ b/playset/ospfv3-srv6-usid/README.md
@@ -1,0 +1,93 @@
+# OSPFv3 SRv6 (uSID) & TI-LFA
+
+This playset is the **uSID** (compressed SID, NEXT-C-SID flavor — RFC 9800)
+variant of the [OSPFv3 SRv6 classic playset](../ospfv3-srv6-classic/README.md),
+mirroring what the [IS-IS uSID playset](../isis-srv6-usid/README.md) does
+for its classic sibling. The topology, addressing, BGP End.DT6 service
+layer, and the walkthrough arc are identical to the OSPFv3 classic lab —
+the *only* configuration difference is one line per node:
+
+``` yaml
+segment-routing:
+  locator:
+  - name: LOC1
+    prefix: fcbb:bbbb:1::/48
+    behavior: usid          # <-- this line
+```
+
+The locator's 48 bits split into the domain-wide 32-bit uSID block
+(`fcbb:bbbb`) and a 16-bit node id; SIDs become 16-bit micro-instructions
+packed into 128-bit carriers. See the IS-IS uSID README for the full
+shift-and-forward mechanics (uN on the locator /48, dual addressed/shifted
+uA forms) — the kernel state here is the same, advertised through the
+OSPFv3 RFC 9513 extensions instead of IS-IS TLVs:
+
+``` shell
+s>ip -6 route show fcbb:bbbb:1::/48
+fcbb:bbbb:1::/48  encap seg6local action End flavors next-csid lblen 32 nflen 16 dev sr0 proto isis metric 1024
+```
+
+## TI-LFA: packed carriers in the v3 repair list
+
+``` shell
+s>configure
+s#set router ospfv3 fast-reroute ti-lfa
+s#commit
+s#exit
+s>show ipv6 route
+...
+O  *> 2001:db8::8/128 [110/2] via fe80::e0e9:7eff:fe20:d4d, s-n1, 00:00:00
+   *?                 [110/3] via seg6 [fcbb:bbbb:5:e001:e001::], s-n2, 00:00:00
+s>show ospfv3 repair-list
+Prefix                         Primary via                Repair via                 Segments
+2001:db8::6/128                fe80::e0e9:7eff:fe20:d4d   fe80::2cee:2dff:fed5:6ef2  [fcbb:bbbb:5:e001::]
+2001:db8::7/128                fe80::e0e9:7eff:fe20:d4d   fe80::2cee:2dff:fed5:6ef2  [fcbb:bbbb:5:e001:e001::]
+2001:db8::8/128                fe80::e0e9:7eff:fe20:d4d   fe80::2cee:2dff:fed5:6ef2  [fcbb:bbbb:5:e001:e001::]
+2001:db8:9::/64                fe80::e0e9:7eff:fe20:d4d   fe80::2cee:2dff:fed5:6ef2  [fcbb:bbbb:5:e001::]
+2001:db8:11::/64               fe80::e0e9:7eff:fe20:d4d   fe80::2cee:2dff:fed5:6ef2  [fcbb:bbbb:5:e001:e001::]
+fcbb:bbbb:6::/48               fe80::e0e9:7eff:fe20:d4d   fe80::2cee:2dff:fed5:6ef2  [fcbb:bbbb:5:e001::]
+...
+```
+
+Every repair is a **single carrier**: `fcbb:bbbb` + uN(r1) + one or two uA
+micro-instructions walking the expensive r-plane links (in the classic v3
+lab each of those was its own 128-bit SID; the exact uA function values
+are allocated per adjacency and differ between runs).
+
+## Promotion and the wire
+
+``` shell
+s>configure
+s#set router ospfv3 fast-reroute backup-as-primary
+s#commit
+s#exit
+s>show ipv6 route
+...
+O  *> 2001:db8::8/128 [110/2] via seg6 [fcbb:bbbb:5:e001:e001::], s-n2, 00:00:05
+   *?                 [110/3] via fe80::e0e9:7eff:fe20:d4d, s-n1, 00:00:05
+...
+B  *> 2001:db8:200::/64 [200/0] via seg6 [fcbb:bbbb:8:40::], s-n2, 00:00:49
+```
+
+The BGP service route follows the promoted locator underneath, and the
+protected edge-to-edge traffic (e1 → e2, still pinging fine) shows the
+compressed repair stacked over the service encapsulation — the repair SRH
+is two entries (`len=4, segleft=1`) instead of the classic lab's four:
+
+``` shell
+n1>tcpdump -nli n1-s ip6 proto 43
+tcpdump: verbose output suppressed, use -v[v]... for full protocol decode
+listening on n1-s, link-type EN10MB (Ethernet), snapshot length 262144 bytes
+10:31:53.771652 IP6 2001:db8:1::1 > fcbb:bbbb:5:e001:e001::: RT6 (len=4, type=4, segleft=1, last-entry=1, tag=0, [0]fcbb:bbbb:8:40::, [1]fcbb:bbbb:5:e001:e001::) RT6 (len=2, type=4, segleft=0, last-entry=0, tag=0, [0]fcbb:bbbb:8:40::) IP6 2001:db8:100::100 > 2001:db8:200::100: ICMP6, echo request, id 31973, seq 4, length 64
+```
+
+Read inside-out: the host packet, the End.DT6 service encapsulation
+(`segleft=0`), and the inserted TI-LFA repair whose single carrier steers
+the whole post-convergence path with the service SID as its final segment.
+
+## Everything else
+
+...is the OSPFv3 classic lab, unchanged: topology and appendix tables, the
+RFC 9252 service layer, the convergence notes, and the walkthrough
+commands. Run the two side by side (one at a time) and compare
+`show ospfv3 repair-list` and the SRH sizes on the wire.

--- a/playset/ospfv3-srv6-usid/d.yaml
+++ b/playset/ospfv3-srv6-usid/d.yaml
@@ -1,0 +1,64 @@
+interface:
+- if-name: lo
+  ipv6:
+    address: 2001:db8::8/128
+- if-name: d-n1
+  ipv6:
+    address: 2001:db8:10::2/64
+- if-name: d-r3
+  ipv6:
+    address: 2001:db8:11::2/64
+- if-name: d-e2
+  ipv6:
+    address: 2001:db8:200::1/64
+system:
+  hostname: d
+segment-routing:
+  locator:
+  - name: LOC8
+    prefix: fcbb:bbbb:8::/48
+    behavior: usid
+router:
+  ospfv3:
+    router-id: 10.0.0.8
+    segment-routing:
+      srv6:
+        locator: LOC8
+    area:
+    - area-id: 0.0.0.0
+      interface:
+      - if-name: lo
+        enabled: true
+      - if-name: d-n1
+        enabled: true
+        network-type: point-to-point
+        cost: 1
+      - if-name: d-r3
+        enabled: true
+        network-type: point-to-point
+        cost: 1
+  bgp:
+    global:
+      as: 65000
+      router-id: 10.0.0.8
+    timer:
+      adv-interval:
+        ibgp: 1
+        ebgp: 1
+    segment-routing:
+      srv6:
+        locator: LOC8
+        ipv6-unicast: {}
+    neighbor:
+    - remote-address: 2001:db8::1
+      remote-as: 65000
+      update-source: 2001:db8::8
+      enabled: true
+      afi-safi:
+      - name: ipv6
+        enabled: true
+        encapsulation-type: srv6
+    afi-safi:
+    - name: ipv6
+      redistribute:
+        connected: {}

--- a/playset/ospfv3-srv6-usid/down.sh
+++ b/playset/ospfv3-srv6-usid/down.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+# Tear down the IS-IS SR-MPLS namespace demo.
+
+PLAYSET_DEMO_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=../lib/playset.sh
+source "${PLAYSET_DEMO_DIR}/../lib/playset.sh"
+# shellcheck source=topology.sh
+source "${PLAYSET_DEMO_DIR}/topology.sh"
+
+playset_teardown

--- a/playset/ospfv3-srv6-usid/e1.yaml
+++ b/playset/ospfv3-srv6-usid/e1.yaml
@@ -1,0 +1,13 @@
+interface:
+- if-name: e1-s
+  ipv6:
+    address: 2001:db8:100::100/64
+system:
+  hostname: e1
+router:
+  static:
+    ipv6:
+      route:
+      - prefix: ::/0
+        nexthop:
+        - address: 2001:db8:100::1

--- a/playset/ospfv3-srv6-usid/e2.yaml
+++ b/playset/ospfv3-srv6-usid/e2.yaml
@@ -1,0 +1,13 @@
+interface:
+- if-name: e2-d
+  ipv6:
+    address: 2001:db8:200::100/64
+system:
+  hostname: e2
+router:
+  static:
+    ipv6:
+      route:
+      - prefix: ::/0
+        nexthop:
+        - address: 2001:db8:200::1

--- a/playset/ospfv3-srv6-usid/n1.yaml
+++ b/playset/ospfv3-srv6-usid/n1.yaml
@@ -1,0 +1,50 @@
+interface:
+- if-name: lo
+  ipv6:
+    address: 2001:db8::2/128
+- if-name: n1-s
+  ipv6:
+    address: 2001:db8:1::2/64
+- if-name: n1-r1
+  ipv6:
+    address: 2001:db8:4::1/64
+- if-name: n1-r2
+  ipv6:
+    address: 2001:db8:7::1/64
+- if-name: n1-d
+  ipv6:
+    address: 2001:db8:10::1/64
+system:
+  hostname: n1
+segment-routing:
+  locator:
+  - name: LOC2
+    prefix: fcbb:bbbb:2::/48
+    behavior: usid
+router:
+  ospfv3:
+    router-id: 10.0.0.2
+    segment-routing:
+      srv6:
+        locator: LOC2
+    area:
+    - area-id: 0.0.0.0
+      interface:
+      - if-name: lo
+        enabled: true
+      - if-name: n1-s
+        enabled: true
+        network-type: point-to-point
+        cost: 1
+      - if-name: n1-r1
+        enabled: true
+        network-type: point-to-point
+        cost: 1
+      - if-name: n1-r2
+        enabled: true
+        network-type: point-to-point
+        cost: 1
+      - if-name: n1-d
+        enabled: true
+        network-type: point-to-point
+        cost: 1

--- a/playset/ospfv3-srv6-usid/n2.yaml
+++ b/playset/ospfv3-srv6-usid/n2.yaml
@@ -1,0 +1,36 @@
+interface:
+- if-name: lo
+  ipv6:
+    address: 2001:db8::3/128
+- if-name: n2-s
+  ipv6:
+    address: 2001:db8:2::2/64
+- if-name: n2-r1
+  ipv6:
+    address: 2001:db8:5::1/64
+system:
+  hostname: n2
+segment-routing:
+  locator:
+  - name: LOC3
+    prefix: fcbb:bbbb:3::/48
+    behavior: usid
+router:
+  ospfv3:
+    router-id: 10.0.0.3
+    segment-routing:
+      srv6:
+        locator: LOC3
+    area:
+    - area-id: 0.0.0.0
+      interface:
+      - if-name: lo
+        enabled: true
+      - if-name: n2-s
+        enabled: true
+        network-type: point-to-point
+        cost: 1
+      - if-name: n2-r1
+        enabled: true
+        network-type: point-to-point
+        cost: 1

--- a/playset/ospfv3-srv6-usid/n3.yaml
+++ b/playset/ospfv3-srv6-usid/n3.yaml
@@ -1,0 +1,36 @@
+interface:
+- if-name: lo
+  ipv6:
+    address: 2001:db8::4/128
+- if-name: n3-s
+  ipv6:
+    address: 2001:db8:3::2/64
+- if-name: n3-r1
+  ipv6:
+    address: 2001:db8:6::1/64
+system:
+  hostname: n3
+segment-routing:
+  locator:
+  - name: LOC4
+    prefix: fcbb:bbbb:4::/48
+    behavior: usid
+router:
+  ospfv3:
+    router-id: 10.0.0.4
+    segment-routing:
+      srv6:
+        locator: LOC4
+    area:
+    - area-id: 0.0.0.0
+      interface:
+      - if-name: lo
+        enabled: true
+      - if-name: n3-s
+        enabled: true
+        network-type: point-to-point
+        cost: 1000
+      - if-name: n3-r1
+        enabled: true
+        network-type: point-to-point
+        cost: 1000

--- a/playset/ospfv3-srv6-usid/r1.yaml
+++ b/playset/ospfv3-srv6-usid/r1.yaml
@@ -1,0 +1,50 @@
+interface:
+- if-name: lo
+  ipv6:
+    address: 2001:db8::5/128
+- if-name: r1-n1
+  ipv6:
+    address: 2001:db8:4::2/64
+- if-name: r1-n2
+  ipv6:
+    address: 2001:db8:5::2/64
+- if-name: r1-n3
+  ipv6:
+    address: 2001:db8:6::2/64
+- if-name: r1-r2
+  ipv6:
+    address: 2001:db8:8::1/64
+system:
+  hostname: r1
+segment-routing:
+  locator:
+  - name: LOC5
+    prefix: fcbb:bbbb:5::/48
+    behavior: usid
+router:
+  ospfv3:
+    router-id: 10.0.0.5
+    segment-routing:
+      srv6:
+        locator: LOC5
+    area:
+    - area-id: 0.0.0.0
+      interface:
+      - if-name: lo
+        enabled: true
+      - if-name: r1-n1
+        enabled: true
+        network-type: point-to-point
+        cost: 1
+      - if-name: r1-n2
+        enabled: true
+        network-type: point-to-point
+        cost: 1
+      - if-name: r1-n3
+        enabled: true
+        network-type: point-to-point
+        cost: 1000
+      - if-name: r1-r2
+        enabled: true
+        network-type: point-to-point
+        cost: 1000

--- a/playset/ospfv3-srv6-usid/r2.yaml
+++ b/playset/ospfv3-srv6-usid/r2.yaml
@@ -1,0 +1,43 @@
+interface:
+- if-name: lo
+  ipv6:
+    address: 2001:db8::6/128
+- if-name: r2-n1
+  ipv6:
+    address: 2001:db8:7::2/64
+- if-name: r2-r1
+  ipv6:
+    address: 2001:db8:8::2/64
+- if-name: r2-r3
+  ipv6:
+    address: 2001:db8:9::1/64
+system:
+  hostname: r2
+segment-routing:
+  locator:
+  - name: LOC6
+    prefix: fcbb:bbbb:6::/48
+    behavior: usid
+router:
+  ospfv3:
+    router-id: 10.0.0.6
+    segment-routing:
+      srv6:
+        locator: LOC6
+    area:
+    - area-id: 0.0.0.0
+      interface:
+      - if-name: lo
+        enabled: true
+      - if-name: r2-n1
+        enabled: true
+        network-type: point-to-point
+        cost: 1
+      - if-name: r2-r1
+        enabled: true
+        network-type: point-to-point
+        cost: 1000
+      - if-name: r2-r3
+        enabled: true
+        network-type: point-to-point
+        cost: 1000

--- a/playset/ospfv3-srv6-usid/r3.yaml
+++ b/playset/ospfv3-srv6-usid/r3.yaml
@@ -1,0 +1,36 @@
+interface:
+- if-name: lo
+  ipv6:
+    address: 2001:db8::7/128
+- if-name: r3-r2
+  ipv6:
+    address: 2001:db8:9::2/64
+- if-name: r3-d
+  ipv6:
+    address: 2001:db8:11::1/64
+system:
+  hostname: r3
+segment-routing:
+  locator:
+  - name: LOC7
+    prefix: fcbb:bbbb:7::/48
+    behavior: usid
+router:
+  ospfv3:
+    router-id: 10.0.0.7
+    segment-routing:
+      srv6:
+        locator: LOC7
+    area:
+    - area-id: 0.0.0.0
+      interface:
+      - if-name: lo
+        enabled: true
+      - if-name: r3-r2
+        enabled: true
+        network-type: point-to-point
+        cost: 1000
+      - if-name: r3-d
+        enabled: true
+        network-type: point-to-point
+        cost: 1

--- a/playset/ospfv3-srv6-usid/s.yaml
+++ b/playset/ospfv3-srv6-usid/s.yaml
@@ -1,0 +1,71 @@
+interface:
+- if-name: lo
+  ipv6:
+    address: 2001:db8::1/128
+- if-name: s-n1
+  ipv6:
+    address: 2001:db8:1::1/64
+- if-name: s-n2
+  ipv6:
+    address: 2001:db8:2::1/64
+- if-name: s-n3
+  ipv6:
+    address: 2001:db8:3::1/64
+- if-name: s-e1
+  ipv6:
+    address: 2001:db8:100::1/64
+system:
+  hostname: s
+segment-routing:
+  locator:
+  - name: LOC1
+    prefix: fcbb:bbbb:1::/48
+    behavior: usid
+router:
+  ospfv3:
+    router-id: 10.0.0.1
+    segment-routing:
+      srv6:
+        locator: LOC1
+    area:
+    - area-id: 0.0.0.0
+      interface:
+      - if-name: lo
+        enabled: true
+      - if-name: s-n1
+        enabled: true
+        network-type: point-to-point
+        cost: 1
+      - if-name: s-n2
+        enabled: true
+        network-type: point-to-point
+        cost: 1
+      - if-name: s-n3
+        enabled: true
+        network-type: point-to-point
+        cost: 1000
+  bgp:
+    global:
+      as: 65000
+      router-id: 10.0.0.1
+    timer:
+      adv-interval:
+        ibgp: 1
+        ebgp: 1
+    segment-routing:
+      srv6:
+        locator: LOC1
+        ipv6-unicast: {}
+    neighbor:
+    - remote-address: 2001:db8::8
+      remote-as: 65000
+      update-source: 2001:db8::1
+      enabled: true
+      afi-safi:
+      - name: ipv6
+        enabled: true
+        encapsulation-type: srv6
+    afi-safi:
+    - name: ipv6
+      redistribute:
+        connected: {}

--- a/playset/ospfv3-srv6-usid/topology.sh
+++ b/playset/ospfv3-srv6-usid/topology.sh
@@ -1,0 +1,26 @@
+# OSPFv3 SRv6 (uSID) demo topology.
+# Each PLAYSET_LINKS entry is "ns_a:iface_a:ns_b:iface_b".
+
+PLAYSET_NAMESPACES=(e1 e2 s n1 n2 n3 r1 r2 r3 d)
+
+PLAYSET_LINKS=(
+    e1:e1-s:s:s-e1
+    d:d-e2:e2:e2-d
+    s:s-n1:n1:n1-s
+    s:s-n2:n2:n2-s
+    s:s-n3:n3:n3-s
+    n1:n1-r1:r1:r1-n1
+    n2:n2-r1:r1:r1-n2
+    n3:n3-r1:r1:r1-n3
+    n1:n1-r2:r2:r2-n1
+    r1:r1-r2:r2:r2-r1
+    r2:r2-r3:r3:r3-r2
+    n1:n1-d:d:d-n1
+    r3:r3-d:d:d-r3
+)
+
+# All namespaces that run zebra-rs.
+PLAYSET_DAEMONS=(e1 e2 s n1 n2 n3 r1 r2 r3 d)
+
+# Routers with vtyctl YAML config (end hosts e1/e2 have no config).
+PLAYSET_ROUTERS=(e1 e2 s n1 n2 n3 r1 r2 r3 d)

--- a/playset/ospfv3-srv6-usid/up.sh
+++ b/playset/ospfv3-srv6-usid/up.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+# Bring up the IS-IS SR-MPLS namespace demo from scratch.
+
+PLAYSET_DEMO_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=../lib/playset.sh
+source "${PLAYSET_DEMO_DIR}/../lib/playset.sh"
+# shellcheck source=topology.sh
+source "${PLAYSET_DEMO_DIR}/topology.sh"
+
+playset_up


### PR DESCRIPTION
## Summary

Seventh TI-LFA lab: the **uSID / NEXT-C-SID (RFC 9800)** variant of `ospfv3-srv6-classic` — the OSPFv3 mirror of `isis-srv6-usid`, with `behavior: usid` on each locator as the only configuration delta.

Live-captured highlights:

- uN on the locator /48 (`End flavors next-csid lblen 32 nflen 16`), advertised via the RFC 9513 OSPFv3 extensions.
- `show ospfv3 repair-list` with **single-carrier repairs** throughout — each entry that was 2–3 separate 128-bit SIDs in the classic v3 lab is one packed address.
- `backup-as-primary` promotion with the BGP End.DT6 service route following the promoted locator, and the protected service packet on the wire: a **two-entry repair SRH** (`len=4, segleft=1`) stacked over the service encapsulation.
- README kept deliberately referential to `ospfv3-srv6-classic` (arc, tables) and `isis-srv6-usid` (shift-and-forward mechanics) for side-by-side comparison.

Note: stacked on the `isis-srv6-usid` branch (#1845); once that merges this PR shows only the ospfv3 delta.

## Test plan

- [x] Live `./up.sh` run: OSPFv3 v6 convergence, uN/uA installs, iBGP End.DT6 service up, e1→e2 over the service path and over the promoted single-carrier repair
- [x] Wire capture verbatim: double-SRH protected service packet with the compressed repair header
- [x] New directory + index row only; no daemon code touched

🤖 Generated with [Claude Code](https://claude.com/claude-code)