### PR TITLE
playset: refresh SRv6 SID renderings in READMEs after #1847

### DIFF
--- a/playset/isis-srv6-classic/README.md
+++ b/playset/isis-srv6-classic/README.md
@@ -64,7 +64,7 @@ L2 *> 2001:db8::8/128 [115/12] via fe80::d093:4fff:fee7:d2fa, s-n1, 00:00:45
 C  *> 2001:db8:100::/64 is directly connected, s-e1, 00:00:51
 B  *> 2001:db8:200::/64 [200/0] via seg6 [fcbb:bbbb:8:40::], s-n1, 00:00:46
 i  *> fcbb:bbbb:1::/128 [115/0] is directly connected, sr0, seg6local End, 00:00:51
-i  *> fcbb:bbbb:1:40::/128 [115/0] is directly connected, sr0, seg6local End.DT6, 00:00:51
+B  *> fcbb:bbbb:1:40::/128 [200/0] is directly connected, sr0, seg6local End.DT6, 00:00:51
 i  *> fcbb:bbbb:1:e000::/128 [115/0] is directly connected, s-n2, seg6local End.X nh6 2001:db8:0:2::2, s-n2, 00:00:51
 i  *> fcbb:bbbb:1:e001::/128 [115/0] is directly connected, s-n1, seg6local End.X nh6 2001:db8:0:1::2, s-n1, 00:00:51
 i  *> fcbb:bbbb:1:e002::/128 [115/0] is directly connected, s-n3, seg6local End.X nh6 2001:db8:0:3::2, s-n3, 00:00:51
@@ -88,7 +88,8 @@ Compared with the SR-MPLS playsets, several things stand out:
   locator `fcbb:bbbb:1::/48`: the **End** SID (`fcbb:bbbb:1::`, on the
   dedicated `sr0` device), the **End.DT6** service SID
   (`fcbb:bbbb:1:40::` — decapsulate and look the inner packet up in the
-  IPv6 table), and one **End.X** per adjacency
+  IPv6 table; BGP carves it, so the entry renders `B` [200/0]), and one
+  **End.X** per adjacency
   (`...:e000::`–`...:e002::`). These are the SRv6 equivalents of the MPLS
   ILM entries.
 * Every remote locator is a routed `/48` — reaching another node's SIDs is

--- a/playset/ospfv3-srv6-classic/README.md
+++ b/playset/ospfv3-srv6-classic/README.md
@@ -64,11 +64,11 @@ B     2001:db8::8/128 [200/0] via seg6 [fcbb:bbbb:8:40::], s-n1, 00:00:45
 ...
 C  *> 2001:db8:100::/64 is directly connected, s-e1, 00:02:50
 B  *> 2001:db8:200::/64 [200/0] via seg6 [fcbb:bbbb:8:40::], s-n1, 00:00:45
-i  *> fcbb:bbbb:1::/128 [115/0] is directly connected, sr0, seg6local End, 00:02:50
-i  *> fcbb:bbbb:1:40::/128 [115/0] is directly connected, sr0, seg6local End.DT6, 00:02:50
-i  *> fcbb:bbbb:1:e000::/128 [115/0] is directly connected, s-n1, seg6local End.X nh6 2001:db8:1::2, s-n1, 00:02:40
-i  *> fcbb:bbbb:1:e001::/128 [115/0] is directly connected, s-n2, seg6local End.X nh6 2001:db8:2::2, s-n2, 00:02:40
-i  *> fcbb:bbbb:1:e002::/128 [115/0] is directly connected, s-n3, seg6local End.X nh6 2001:db8:3::2, s-n3, 00:02:40
+O  *> fcbb:bbbb:1::/128 [110/0] is directly connected, sr0, seg6local End, 00:02:50
+B  *> fcbb:bbbb:1:40::/128 [200/0] is directly connected, sr0, seg6local End.DT6, 00:02:50
+O  *> fcbb:bbbb:1:e000::/128 [110/0] is directly connected, s-n1, seg6local End.X nh6 2001:db8:1::2, s-n1, 00:02:40
+O  *> fcbb:bbbb:1:e001::/128 [110/0] is directly connected, s-n2, seg6local End.X nh6 2001:db8:2::2, s-n2, 00:02:40
+O  *> fcbb:bbbb:1:e002::/128 [110/0] is directly connected, s-n3, seg6local End.X nh6 2001:db8:3::2, s-n3, 00:02:40
 O  *> fcbb:bbbb:2::/48 [110/1] via fe80::9461:feff:fe12:9ee9, s-n1, 00:02:34
 O  *> fcbb:bbbb:3::/48 [110/1] via fe80::8c26:f1ff:fe37:472c, s-n2, 00:02:34
 O  *> fcbb:bbbb:4::/48 [110/1000] via fe80::ec58:22ff:fe66:3d20, s-n3, 00:02:34
@@ -84,7 +84,9 @@ The picture matches the IS-IS SRv6 playset with the OSPFv3 flavor: routes
 are code `O` at distance 110, locators are advertised through the RFC 9513
 SRv6 extensions and routed as plain `/48`s, and the node's own SIDs (End,
 End.DT6, End.X) are `seg6local` /128 routes on `sr0` / the adjacency
-interfaces. The unselected `O ... via ::, lo` lines are OSPFv3's
+interfaces — each attributed to its owning protocol: the locator End and
+the End.X entries are `O` [110/0], while the BGP-carved End.DT6 service
+SID is `B` [200/0]. The unselected `O ... via ::, lo` lines are OSPFv3's
 self-originated prefixes losing to their connected counterparts. The remote
 edge LAN `2001:db8:200::/64` is a **BGP** route toward d's End.DT6 service
 SID, and the unselected `B` copies of core prefixes show the same

--- a/playset/ospfv3-srv6-usid/README.md
+++ b/playset/ospfv3-srv6-usid/README.md
@@ -19,12 +19,13 @@ The locator's 48 bits split into the domain-wide 32-bit uSID block
 (`fcbb:bbbb`) and a 16-bit node id; SIDs become 16-bit micro-instructions
 packed into 128-bit carriers. See the IS-IS uSID README for the full
 shift-and-forward mechanics (uN on the locator /48, dual addressed/shifted
-uA forms) — the kernel state here is the same, advertised through the
-OSPFv3 RFC 9513 extensions instead of IS-IS TLVs:
+uA forms) — the kernel state here is identical apart from the `proto ospf`
+attribution, advertised through the OSPFv3 RFC 9513 extensions instead of
+IS-IS TLVs:
 
 ``` shell
 s>ip -6 route show fcbb:bbbb:1::/48
-fcbb:bbbb:1::/48  encap seg6local action End flavors next-csid lblen 32 nflen 16 dev sr0 proto isis metric 1024
+fcbb:bbbb:1::/48  encap seg6local action End flavors next-csid lblen 32 nflen 16 dev sr0 proto ospf metric 1024
 ```
 
 ## TI-LFA: packed carriers in the v3 repair list


### PR DESCRIPTION
## Summary

PR #1847 attributed SRv6 SID routes to their owning protocol; three playset READMEs still showed the old hardcoded-IS-IS captures. Updated:

- **ospfv3-srv6-classic**: locator End + three End.X lines `i [115/0]` → `O [110/0]`; the BGP End.DT6 service SID → `B [200/0]`; prose now explains the per-owner attribution.
- **ospfv3-srv6-usid**: kernel locator line `proto isis` → `proto ospf` (+ prose tweak).
- **isis-srv6-classic**: the BGP-carved End.DT6 line → `B [200/0]` (it was equally swept up by the old hardcoding); IS-IS-owned SID lines stay `i [115/0]`.
- **isis-srv6-usid**: no changes needed — its captures show only IS-IS-owned SIDs.

## Test plan

- Live verification: brought up ospfv3-srv6-classic on current main+fix, `show ipv6 route` on `s` — all five updated lines match the live output byte-for-byte (modulo uptimes). The usid kernel line matches the live capture from the #1847 verification run.
- Docs-only change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)