### PR TITLE
bgp: RFC 9774 as-sets-withdraw global toggle

### DIFF
--- a/book/src/SUMMARY.md
+++ b/book/src/SUMMARY.md
@@ -34,6 +34,7 @@
   - [allowas-in (Inbound AS_PATH Loop Relaxation)](ch-02-13-bgp-allowas-in.md)
   - [Remove Private AS](ch-02-14-bgp-remove-private-as.md)
   - [Enforce First AS](ch-02-15-bgp-enforce-first-as.md)
+  - [AS_SET / AS_CONFED_SET Withdrawal (RFC 9774)](ch-02-39-bgp-as-sets-withdraw.md)
   - [Well-Known Communities](ch-02-24-bgp-well-known-communities.md)
   - [Table-Map (Policy at the BGP→RIB Install Point)](ch-02-28-bgp-table-map.md)
   - [disable-connected-check](ch-02-16-bgp-disable-connected-check.md)

--- a/book/src/appendix-b-supported-rfcs.md
+++ b/book/src/appendix-b-supported-rfcs.md
@@ -31,6 +31,7 @@ implementation; the corresponding features track the referenced draft revision.
 | RFC 9012 | Tunnel Encapsulation Attribute, including the Color extended community. |
 | RFC 7311 | The Accumulated IGP Metric Attribute for BGP (AIGP). |
 | RFC 7606 | Revised Error Handling for BGP UPDATE messages (treat-as-withdraw / attribute discard). |
+| RFC 9774 | Deprecation of AS_SET and AS_CONFED_SET in BGP (`as-sets-withdraw`, on by default). |
 | RFC 4456 | BGP Route Reflection — an alternative to full IBGP mesh. |
 | RFC 7947 | Internet Exchange BGP Route Server behaviour. |
 | RFC 2385 | Protection of BGP Sessions via the TCP MD5 Signature Option. |

--- a/book/src/ch-02-15-bgp-enforce-first-as.md
+++ b/book/src/ch-02-15-bgp-enforce-first-as.md
@@ -31,6 +31,12 @@ AS, so an iBGP UPDATE legitimately starts with whatever AS originated or
 last-prepended the route; the knob is a no-op on iBGP peers and is
 ignored.
 
+Globally, [AS_SET / AS_CONFED_SET withdrawal (RFC
+9774)](ch-02-39-bgp-as-sets-withdraw.md) applies treat-as-withdraw to
+any inbound UPDATE whose path contains `{…}` or `[…]` segments when
+`as-sets-withdraw` is enabled (the default). That is separate from this
+per-neighbor check.
+
 ## The problem it catches
 
 ```

--- a/book/src/ch-02-39-bgp-as-sets-withdraw.md
+++ b/book/src/ch-02-39-bgp-as-sets-withdraw.md
@@ -1,0 +1,104 @@
+# AS_SET / AS_CONFED_SET Withdrawal (RFC 9774)
+
+[RFC 9774](https://www.rfc-editor.org/rfc/rfc9774.html) deprecates
+`AS_SET` and `AS_CONFED_SET` path-segment types in BGP. Unless a
+network operator explicitly opts out during a transition period, a BGP
+speaker must:
+
+- **not originate** UPDATEs whose `AS_PATH` (or `AS4_PATH`) contains
+  those segment types, and
+- **treat-as-withdraw** (RFC 7606) any received UPDATE that carries
+  them.
+
+zebra-rs enforces this by default. The global boolean
+`as-sets-withdraw` controls the behavior; it is **on by default**
+(`true`). Set it to `false` only when you deliberately need legacy
+`AS_SET` / `AS_CONFED_SET` handling — for example while migrating away
+from an old aggregator.
+
+FRR names the same feature `bgp reject-as-sets` (enabled by default
+since FRR 10.5). The mapping is:
+
+| zebra-rs | FRR |
+|----------|-----|
+| default (`as-sets-withdraw true`, or unset) | `bgp reject-as-sets` |
+| `as-sets-withdraw false` | `no bgp reject-as-sets` |
+
+## What it does
+
+### Ingress
+
+When `as-sets-withdraw` is enabled, an inbound UPDATE whose decoded
+`AS_PATH` contains an `AS_SET` (`{…}`) or `AS_CONFED_SET` (`[…]`)
+segment is handled like a malformed attribute under RFC 7606: the
+reachable NLRI in that UPDATE are **treat-as-withdraw** — any copy of
+those prefixes previously learned from this peer is removed, nothing
+new is installed, explicit withdrawals in the same UPDATE are still
+honoured, and the session stays up.
+
+This is independent of per-neighbor knobs such as
+[`enforce-first-as`](ch-02-15-bgp-enforce-first-as.md), which also
+rejects routes whose path starts with an `AS_SET` but does so by
+dropping the update before Adj-RIB-In processing rather than via the
+RFC 7606 withdraw path.
+
+### Egress
+
+When enabled, a route whose post-egress `AS_PATH` would still contain
+`AS_SET` or `AS_CONFED_SET` is **not advertised** to any peer (v4/v6
+unicast, labeled unicast, VPN, EVPN, MUP, Flowspec). Locally
+originated paths and normal eBGP prepends use `AS_SEQUENCE` only, so
+this gate mainly blocks re-advertisement of legacy paths still present
+in the Loc-RIB.
+
+## Configuration
+
+The knob is a global boolean under `router bgp`, on by default. To opt
+out during a transition:
+
+```yaml
+router:
+  bgp:
+    global:
+      as: 65001
+      router-id: 10.255.0.1
+    as-sets-withdraw: false
+```
+
+CLI form:
+
+```
+set router bgp as-sets-withdraw false
+```
+
+Deleting the line restores the default (enabled):
+
+```
+delete router bgp as-sets-withdraw
+```
+
+Flipping the knob does not reset established sessions; it applies to
+the next received UPDATE and the next advertisement decision.
+
+| Path | Default | Meaning |
+|------|---------|---------|
+| `/router/bgp/as-sets-withdraw` | `true` | RFC 9774 enforcement: withdraw on receive, do not advertise on send. |
+
+## When to disable it
+
+Rarely, and only temporarily. `AS_SET` and `AS_CONFED_SET` are
+effectively absent on the public Internet; RFC 9774 standardizes the
+deprecation because they complicate origin validation (RPKI-ROV,
+BGPsec) and aggregation semantics.
+
+Disable `as-sets-withdraw` only when you must interoperate with a
+legacy speaker that still originates or expects `AS_SET` paths during
+a controlled migration. Plan to re-enable the default once the
+transition completes.
+
+## Related reading
+
+- [Enforce First AS](ch-02-15-bgp-enforce-first-as.md) — another
+  inbound AS_PATH guard, scoped per neighbor and eBGP-only.
+- Appendix B — [RFC 9774](appendix-b-supported-rfcs.md) and RFC
+  7606 treat-as-withdraw handling.

--- a/crates/bgp-packet/src/attrs/aspath.rs
+++ b/crates/bgp-packet/src/attrs/aspath.rs
@@ -389,6 +389,14 @@ impl As4Path {
         self.length
     }
 
+    /// True when the path carries an AS_SET or AS_CONFED_SET segment
+    /// (RFC 9774 deprecated types).
+    pub fn contains_as_set_or_confed_set(&self) -> bool {
+        self.segs
+            .iter()
+            .any(|seg| seg.typ == AS_SET || seg.typ == AS_CONFED_SET)
+    }
+
     /// Returns the count of distinct ASes across all segments
     /// (sequences, sets, confederation segments). Used by the
     /// policy engine for `match as-path-len-uniq`.
@@ -740,6 +748,22 @@ mod tests {
         // AS_SET: Entire set counts as 1
         let aspath: As4Path = As4Path::from_str("1 2 {3 4 5}").unwrap();
         assert_eq!(aspath.length(), 3); // 2 from sequence + 1 from set
+        assert!(aspath.contains_as_set_or_confed_set());
+    }
+
+    #[test]
+    fn contains_as_set_or_confed_set_detects_deprecated_segments() {
+        let seq = As4Path::from_str("65001 65002").unwrap();
+        assert!(!seq.contains_as_set_or_confed_set());
+
+        let as_set = As4Path::from_str("65001 {65010 65011}").unwrap();
+        assert!(as_set.contains_as_set_or_confed_set());
+
+        let confed_set = As4Path::from_str("65001 [65010 65011]").unwrap();
+        assert!(confed_set.contains_as_set_or_confed_set());
+
+        let confed_seq = As4Path::from_str("65001 (65010)").unwrap();
+        assert!(!confed_seq.contains_as_set_or_confed_set());
     }
 
     #[test]

--- a/docs/schema-paths.txt
+++ b/docs/schema-paths.txt
@@ -10,6 +10,7 @@
 /router/bgp/global/hostname	leaf
 /router/bgp/global/no-fib-install	leaf
 /router/bgp/global/fast-external-failover	leaf
+/router/bgp/as-sets-withdraw	leaf
 /router/bgp/segment-routing	container
 /router/bgp/segment-routing/srv6	container
 /router/bgp/segment-routing/srv6/ipv6-unicast	p-container

--- a/zebra-rs/src/bgp/config.rs
+++ b/zebra-rs/src/bgp/config.rs
@@ -90,6 +90,18 @@ fn config_global_fast_external_failover(bgp: &mut Bgp, mut args: Args, op: Confi
     Some(())
 }
 
+/// `set router bgp as-sets-withdraw <true|false>` — RFC 9774 global
+/// toggle (zebra-bgp-as-sets-withdraw.yang). On by default: received
+/// UPDATEs whose AS_PATH or AS4_PATH carry AS_SET / AS_CONFED_SET are
+/// treat-as-withdraw, and such segments are not originated on egress.
+/// Set `false` to opt out during a transition period. Delete restores
+/// the default (`true`).
+fn config_as_sets_withdraw(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Option<()> {
+    let flag = args.boolean().unwrap_or(true);
+    bgp.as_sets_withdraw = !op.is_set() || flag;
+    Some(())
+}
+
 /// `set router bgp lua-script <name> source-path <path>` — load a named
 /// Lua script from a file into the global script registry. With the `lua`
 /// build feature off the registry is still populated (so a config
@@ -188,7 +200,13 @@ fn reassign_all_update_groups(bgp: &mut Bgp) {
         .collect();
     for ident in idents {
         super::update_group::detach(&mut bgp.update_groups, &mut bgp.peers, ident);
-        super::update_group::attach(&mut bgp.update_groups, &mut bgp.peers, ident, router_id);
+        super::update_group::attach(
+            &mut bgp.update_groups,
+            &mut bgp.peers,
+            ident,
+            router_id,
+            bgp.as_sets_withdraw,
+        );
     }
 }
 
@@ -347,6 +365,7 @@ fn config_peer(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Option<()> {
             vrf_transport_v4: None,
             vrf_transport_v6: None,
             central_label_alloc: None,
+            as_sets_withdraw: bgp.as_sets_withdraw,
         };
         route_clean(peer_idx, &mut bgp_ref, &mut bgp.peers, bgp.shards.as_ref());
         // Update-groups live outside `PeerMap`: removal below purges
@@ -4129,6 +4148,7 @@ impl Bgp {
             "/router/bgp/fast-external-failover",
             config_global_fast_external_failover,
         );
+        self.callback_add("/router/bgp/as-sets-withdraw", config_as_sets_withdraw);
         // `router bgp port <0-65535>` (zebra-bgp-transport.yang): the
         // listener port; 0 disables listening.
         self.callback_add("/router/bgp/port", config_global_port);
@@ -5897,6 +5917,28 @@ mod neighbor_group_wiring_tests {
             }
         }
         out
+    }
+
+    /// `as-sets-withdraw` is a default-ON global boolean (RFC 9774):
+    /// Set false opts out, Set true re-enables, and Delete restores the
+    /// default (true).
+    #[tokio::test]
+    async fn as_sets_withdraw_knob_transitions() {
+        let mut bgp = fresh_bgp();
+        assert!(bgp.as_sets_withdraw, "must default to enabled");
+
+        config_as_sets_withdraw(&mut bgp, arg_words(&["false"]), ConfigOp::Set).unwrap();
+        assert!(!bgp.as_sets_withdraw, "set false must opt out");
+
+        config_as_sets_withdraw(&mut bgp, arg_words(&["true"]), ConfigOp::Set).unwrap();
+        assert!(bgp.as_sets_withdraw, "set true must re-enable");
+
+        config_as_sets_withdraw(&mut bgp, arg_words(&["false"]), ConfigOp::Set).unwrap();
+        config_as_sets_withdraw(&mut bgp, arg_words(&["false"]), ConfigOp::Delete).unwrap();
+        assert!(
+            bgp.as_sets_withdraw,
+            "delete must restore the default (true)",
+        );
     }
 
     /// `fast-external-failover` is a default-ON global boolean (IOS-XR

--- a/zebra-rs/src/bgp/inst.rs
+++ b/zebra-rs/src/bgp/inst.rs
@@ -759,6 +759,11 @@ pub struct Bgp {
     /// single-hop eBGP session riding the downed interface instead of
     /// waiting out the hold timer. See [`Self::link_down_failover`].
     pub fast_external_failover: bool,
+    /// `router bgp as-sets-withdraw` (zebra-bgp-as-sets-withdraw.yang).
+    /// When true (default), enforce RFC 9774: treat received UPDATEs
+    /// whose AS_PATH carries AS_SET or AS_CONFED_SET as withdraw, and
+    /// do not advertise such segments on egress.
+    pub as_sets_withdraw: bool,
     pub peers: PeerMap,
     /// Instance-level BFD defaults (`router bgp { bfd {} }`), inherited by
     /// every neighbor and overridden per neighbor (see
@@ -1173,6 +1178,7 @@ impl Bgp {
             hostname: None,
             no_fib_install: false,
             fast_external_failover: true,
+            as_sets_withdraw: true,
             peers: PeerMap::new(),
             bfd: PeerBfdConfig::default(),
             tx,
@@ -2061,6 +2067,7 @@ impl Bgp {
             vrf_transport_v4: None,
             vrf_transport_v6: None,
             central_label_alloc: self.vrf_label_alloc.as_mut(),
+            as_sets_withdraw: self.as_sets_withdraw,
         };
         let Some(peer) = self.peers.get_mut_by_idx(ident) else {
             return;
@@ -2152,6 +2159,7 @@ impl Bgp {
                     vrf_transport_v4: None,
                     vrf_transport_v6: None,
                     central_label_alloc: self.vrf_label_alloc.as_mut(),
+                    as_sets_withdraw: self.as_sets_withdraw,
                 };
 
                 fsm(
@@ -3311,6 +3319,7 @@ impl Bgp {
                 vrf_transport_v4: None,
                 vrf_transport_v6: None,
                 central_label_alloc: None,
+                as_sets_withdraw: self.as_sets_withdraw,
             };
             super::route::route_advertise_to_peers(
                 Some(rd),
@@ -3386,6 +3395,7 @@ impl Bgp {
                 vrf_transport_v4: None,
                 vrf_transport_v6: None,
                 central_label_alloc: None,
+                as_sets_withdraw: self.as_sets_withdraw,
             };
             super::route::route_advertise_to_peers_vpnv6(
                 rd,
@@ -4171,6 +4181,7 @@ impl Bgp {
             vrf_transport_v4: None,
             vrf_transport_v6: None,
             central_label_alloc: None,
+            as_sets_withdraw: self.as_sets_withdraw,
         };
         match &dep {
             NhtDep::V4(p) => {
@@ -4777,6 +4788,7 @@ impl Bgp {
             vrf_transport_v4: None,
             vrf_transport_v6: None,
             central_label_alloc: None,
+            as_sets_withdraw: self.as_sets_withdraw,
         };
         for (prefix, best) in &winners_v4 {
             super::route::fib_install_v4(&top, *prefix, std::slice::from_ref(best));
@@ -4980,6 +4992,7 @@ impl Bgp {
             vrf_transport_v4: None,
             vrf_transport_v6: None,
             central_label_alloc: self.vrf_label_alloc.as_mut(),
+            as_sets_withdraw: self.as_sets_withdraw,
         };
         super::route::route_apply_bestpath_v4_batch(&mut bgp_ref, &mut self.peers, deltas);
     }
@@ -5011,7 +5024,7 @@ impl Bgp {
                 .flatten(),
             egress_high_water: high_water,
         };
-        let ctx = std::sync::Arc::new(peer.sync_ctx(self.router_id));
+        let ctx = std::sync::Arc::new(peer.sync_ctx(self.router_id, self.as_sets_withdraw));
         let req_id = self.pending_dumps_v4.start(ident, n);
         self.shards
             .as_ref()
@@ -5208,6 +5221,7 @@ impl Bgp {
                     vrf_transport_v4: None,
                     vrf_transport_v6: None,
                     central_label_alloc: None,
+                    as_sets_withdraw: self.as_sets_withdraw,
                 };
                 super::route::route_advertise_to_peers(
                     Some(rd),
@@ -5319,6 +5333,7 @@ impl Bgp {
                     vrf_transport_v4: None,
                     vrf_transport_v6: None,
                     central_label_alloc: None,
+                    as_sets_withdraw: self.as_sets_withdraw,
                 };
                 super::route::route_advertise_to_peers(
                     Some(rd),
@@ -5481,6 +5496,7 @@ impl Bgp {
                     vrf_transport_v4: None,
                     vrf_transport_v6: None,
                     central_label_alloc: None,
+                    as_sets_withdraw: self.as_sets_withdraw,
                 };
                 super::route::route_advertise_to_peers_vpnv6(
                     rd,
@@ -5570,6 +5586,7 @@ impl Bgp {
                     vrf_transport_v4: None,
                     vrf_transport_v6: None,
                     central_label_alloc: None,
+                    as_sets_withdraw: self.as_sets_withdraw,
                 };
                 super::route::route_advertise_to_peers_vpnv6(
                     rd,

--- a/zebra-rs/src/bgp/interface_neighbor.rs
+++ b/zebra-rs/src/bgp/interface_neighbor.rs
@@ -285,6 +285,7 @@ pub fn config_interface_neighbor(bgp: &mut Bgp, mut args: Args, op: ConfigOp) ->
                         vrf_transport_v4: None,
                         vrf_transport_v6: None,
                         central_label_alloc: None,
+                        as_sets_withdraw: bgp.as_sets_withdraw,
                     };
                     super::route::route_clean(
                         peer_idx,

--- a/zebra-rs/src/bgp/peer.rs
+++ b/zebra-rs/src/bgp/peer.rs
@@ -1454,7 +1454,7 @@ impl Peer {
     /// next-hop fallback and the cluster-id. Cheap (all-`Copy`); the
     /// egress build (`route_update_ipv4`) takes this instead of `&Peer`
     /// so the same build can run in a shard worker that has no `Peer`.
-    pub fn sync_ctx(&self, router_id: Ipv4Addr) -> super::route::SyncCtx {
+    pub fn sync_ctx(&self, router_id: Ipv4Addr, as_sets_withdraw: bool) -> super::route::SyncCtx {
         super::route::SyncCtx {
             ident: self.ident,
             peer_type: self.peer_type,
@@ -1473,6 +1473,7 @@ impl Peer {
             egress_depth: self.egress_depth.clone(),
             extended_message: self.opt.extended_message,
             attach_unknown_attr: self.config.attach_unknown_attr.clone(),
+            as_sets_withdraw,
         }
     }
 
@@ -1665,6 +1666,9 @@ pub struct BgpTop<'a> {
     /// locally-originated routes with its End.DT6 Prefix-SID + locator
     /// next-hop. `None` on per-VRF tasks and whenever origination is off.
     pub srv6_ipv6_export: Option<&'a super::inst::Srv6Ipv6Export>,
+    /// RFC 9774 global toggle (`router bgp as-sets-withdraw`). Borrowed
+    /// from the owning [`super::inst::Bgp`].
+    pub as_sets_withdraw: bool,
 }
 
 /// Resolve a connection identity against the peer's current slots.
@@ -1828,7 +1832,7 @@ pub fn fsm(
             // A2 ⑥ (gate-on): spawn the per-peer egress task. For now it
             // is idle (lifecycle only); routing the v4 egress to it comes later.
             if super::peer_egress::peer_egress_task_enabled() {
-                let ctx = peer.sync_ctx(*bgp_ref.router_id);
+                let ctx = peer.sync_ctx(*bgp_ref.router_id, bgp_ref.as_sets_withdraw);
                 let add_path = peer.opt.is_add_path_send(Afi::Ip, Safi::Unicast);
                 peer.pet = Some(super::peer_egress::PeerEgressTask::spawn(ctx, add_path));
             }
@@ -1865,7 +1869,13 @@ pub fn fsm(
         if prev_state.is_established() && !now_established {
             super::update_group::detach(bgp_ref.update_groups, peer_map, id);
         } else if !prev_state.is_established() && now_established {
-            super::update_group::attach(bgp_ref.update_groups, peer_map, id, *bgp_ref.router_id);
+            super::update_group::attach(
+                bgp_ref.update_groups,
+                peer_map,
+                id,
+                *bgp_ref.router_id,
+                bgp_ref.as_sets_withdraw,
+            );
         }
         peer_map.debug_verify_membership();
     }
@@ -3243,6 +3253,7 @@ pub fn apply_soft_in_peer(bgp: &mut Bgp, peer_idx: usize) {
             vrf_transport_v4: None,
             vrf_transport_v6: None,
             central_label_alloc: None,
+            as_sets_withdraw: bgp.as_sets_withdraw,
         };
         super::route::route_soft_in_peer(
             peer_idx,
@@ -3288,6 +3299,7 @@ pub fn apply_soft_out_peer(bgp: &mut Bgp, peer_idx: usize) {
         vrf_transport_v4: None,
         vrf_transport_v6: None,
         central_label_alloc: None,
+        as_sets_withdraw: bgp.as_sets_withdraw,
     };
     super::route::route_soft_out_peer(peer_idx, &mut bgp_ref, &mut bgp.peers);
 }

--- a/zebra-rs/src/bgp/route.rs
+++ b/zebra-rs/src/bgp/route.rs
@@ -199,6 +199,8 @@ pub struct SyncCtx {
     /// §9 origination test). `None` = off. See
     /// [`super::peer::PeerConfig::attach_unknown_attr`].
     pub attach_unknown_attr: Option<bgp_packet::UnknownAttr>,
+    /// RFC 9774 global toggle (`router bgp as-sets-withdraw`).
+    pub as_sets_withdraw: bool,
 }
 
 impl SyncCtx {
@@ -289,6 +291,7 @@ impl SyncCtx {
             egress_depth: Arc::new(std::sync::atomic::AtomicUsize::new(0)),
             extended_message: false,
             attach_unknown_attr: None,
+            as_sets_withdraw: true,
         }
     }
 }
@@ -4100,7 +4103,7 @@ fn compute_advertise_outcome(
     bgp: &BgpTop,
     add_path: bool,
 ) -> AdvertiseOutcome<Ipv4Nlri> {
-    let ctx = peer.sync_ctx(*bgp.router_id);
+    let ctx = peer.sync_ctx(*bgp.router_id, bgp.as_sets_withdraw);
     if let Some((nlri, attr)) = route_update_ipv4(&ctx, prefix, best, add_path) {
         // v4-unicast reads the cached `SyncCtx` snapshot (the egress can run
         // off-main in a shard worker); VPNv4 reads its own per-AFI Output
@@ -4340,7 +4343,7 @@ fn soft_out_v4_to_pet(peer_idx: usize, bgp: &BgpTop, peers: &PeerMap) {
         return;
     };
     let add_path = peer.opt.is_add_path_send(Afi::Ip, Safi::Unicast);
-    let ctx = peer.sync_ctx(*bgp.router_id);
+    let ctx = peer.sync_ctx(*bgp.router_id, bgp.as_sets_withdraw);
     let _ = pet
         .delta_tx
         .send(super::peer_egress::EgressDeltaV4::Refresh {
@@ -4400,7 +4403,7 @@ fn soft_out_v4_to_group(peer_idx: usize, bgp: &BgpTop, peers: &PeerMap) {
         if let Some(m) = peers.get_by_idx(ident) {
             task.send(super::group_egress::GroupEgressDeltaV4::AddMember {
                 ident,
-                ctx: Box::new(m.sync_ctx(*bgp.router_id)),
+                ctx: Box::new(m.sync_ctx(*bgp.router_id, bgp.as_sets_withdraw)),
                 add_path: m.opt.is_add_path_send(Afi::Ip, Safi::Unicast),
             });
         }
@@ -4584,7 +4587,7 @@ impl BatchAfi for V4Batch {
         rib: &BgpRib,
         bgp: &mut BgpTop,
     ) {
-        let ctx = peer.sync_ctx(*bgp.router_id);
+        let ctx = peer.sync_ctx(*bgp.router_id, bgp.as_sets_withdraw);
         let Some((nlri, attr)) = route_update_ipv4(&ctx, &prefix, rib, true) else {
             return;
         };
@@ -5085,6 +5088,9 @@ pub fn route_update_evpn(
     let mut attrs = (*rib.attr).clone();
 
     ebgp_egress_aspath(&peer.egress_as(), &mut attrs);
+    if as_sets_withdraw_suppresses_egress(bgp.as_sets_withdraw, &attrs) {
+        return None;
+    }
 
     if peer.is_ebgp() || rib.is_originated() {
         let nexthop: IpAddr = if let Some(ref local_addr) = peer.param.local_addr {
@@ -5561,7 +5567,7 @@ fn route_soft_out_peer_table(
         if llgr_blocks_advertisement(rib.stale, &peer.cap_recv, afi, safi) {
             continue;
         }
-        let ctx = peer.sync_ctx(*bgp.router_id);
+        let ctx = peer.sync_ctx(*bgp.router_id, bgp.as_sets_withdraw);
         let Some((nlri, attr)) = route_update_ipv4(&ctx, prefix, rib, add_path) else {
             continue;
         };
@@ -5613,7 +5619,7 @@ fn route_soft_out_peer_table(
             .then(|| super::update_group::compose_enhe_next_hop(peer, bgp.interface_addrs))
             .flatten();
         super::update_group::send_ipv4_direct(
-            &peer.sync_ctx(*bgp.router_id),
+            &peer.sync_ctx(*bgp.router_id, bgp.as_sets_withdraw),
             ipv4_entries,
             enhe_v6,
         );
@@ -8182,6 +8188,9 @@ fn route_update_mup(
     let route = prefix.to_route_with(rd, rib.mup_st1.as_ref());
     let mut attrs = (*rib.attr).clone();
     ebgp_egress_aspath(&peer.egress_as(), &mut attrs);
+    if as_sets_withdraw_suppresses_egress(bgp.as_sets_withdraw, &attrs) {
+        return None;
+    }
 
     // MP_REACH next-hop: an SRv6 segment route we originate (a DSD or ISD
     // carrying an End.DT46 Prefix-SID) advertises the PE locator node carried
@@ -9217,6 +9226,7 @@ pub fn route_update_flowspec(
     nlri: &FlowspecNlri,
     rib: &BgpRib,
     add_path: bool,
+    as_sets_withdraw: bool,
 ) -> Option<(FlowspecNlri, BgpAttr)> {
     if rib.ident == peer.ident {
         return None;
@@ -9233,6 +9243,9 @@ pub fn route_update_flowspec(
 
     let mut attrs = (*rib.attr).clone();
     ebgp_egress_aspath(&peer.egress_as(), &mut attrs);
+    if as_sets_withdraw_suppresses_egress(as_sets_withdraw, &attrs) {
+        return None;
+    }
     if peer.is_ibgp() && attrs.local_pref.is_none() {
         attrs.local_pref = Some(LocalPref::default());
     }
@@ -9274,7 +9287,9 @@ pub fn route_advertise_flowspec_to_peers(
         let peer = peers.get_mut_by_idx(ident).expect("peer exists");
         let add_path = peer.opt.is_add_path_send(afi, Safi::Flowspec);
 
-        let Some((out_nlri, attr)) = route_update_flowspec(peer, nlri, best, add_path) else {
+        let Some((out_nlri, attr)) =
+            route_update_flowspec(peer, nlri, best, add_path, bgp.as_sets_withdraw)
+        else {
             continue;
         };
 
@@ -9441,7 +9456,10 @@ pub fn route_from_peer(
     // remove any installed copy from this peer instead of installing —
     // while the UPDATE's explicit withdrawals are still honoured and the
     // session stays up.
-    let treat_as_withdraw = packet.treat_as_withdraw;
+    let mut treat_as_withdraw = packet.treat_as_withdraw;
+    if as_sets_withdraw_treat_as_withdraw(bgp.as_sets_withdraw, packet.bgp_attr.as_ref()) {
+        treat_as_withdraw = true;
+    }
 
     if treat_as_withdraw {
         for update in packet.ipv4_update.iter() {
@@ -10705,6 +10723,26 @@ fn community_suppresses_advertisement(attr: &BgpAttr, peer_type: PeerType) -> bo
             || com.contains(&CommunityValue::NO_EXPORT_SUBCONFED.value()))
 }
 
+/// RFC 9774 §3 ingress: treat-as-withdraw when the AS_PATH carries
+/// AS_SET or AS_CONFED_SET and the global knob is enabled.
+fn as_sets_withdraw_treat_as_withdraw(as_sets_withdraw: bool, attr: Option<&BgpAttr>) -> bool {
+    as_sets_withdraw
+        && attr
+            .and_then(|a| a.aspath.as_ref())
+            .is_some_and(|p| p.contains_as_set_or_confed_set())
+}
+
+/// RFC 9774 §3 egress: when enabled, routes whose post-transform AS_PATH
+/// still carries AS_SET or AS_CONFED_SET must not be advertised. Call
+/// after `ebgp_egress_aspath`.
+fn as_sets_withdraw_suppresses_egress(as_sets_withdraw: bool, attrs: &BgpAttr) -> bool {
+    as_sets_withdraw
+        && attrs
+            .aspath
+            .as_ref()
+            .is_some_and(|p| p.contains_as_set_or_confed_set())
+}
+
 /// RFC 9494 §4.3/§4.4 ingest side: a route received with the
 /// LLGR_STALE community is depreferenced exactly like a route we
 /// stale-marked ourselves — the ingest paths OR this into the
@@ -10813,6 +10851,9 @@ pub fn route_update_ipv4(
 
     // 2. AS_PATH
     ebgp_egress_aspath(&ctx.egress_as, &mut attrs);
+    if as_sets_withdraw_suppresses_egress(ctx.as_sets_withdraw, &attrs) {
+        return None;
+    }
 
     // 3. NEXT_HOP
     //
@@ -10976,6 +11017,9 @@ pub fn route_update_ipv6(
 
     // AS_PATH prepend for eBGP.
     ebgp_egress_aspath(&peer.egress_as(), &mut attrs);
+    if as_sets_withdraw_suppresses_egress(bgp.as_sets_withdraw, &attrs) {
+        return None;
+    }
 
     // NEXT_HOP: next-hop-self for eBGP / locally-originated routes.
     // RFC 2545 §2 requires the MP_REACH next-hop be one of OUR IPv6
@@ -11376,6 +11420,9 @@ fn route_update_labelv4(
     let mut attrs = (*rib.attr).clone();
 
     ebgp_egress_aspath(&peer.egress_as(), &mut attrs);
+    if as_sets_withdraw_suppresses_egress(bgp.as_sets_withdraw, &attrs) {
+        return None;
+    }
 
     // Next-hop-self for eBGP / locally-originated, or when the neighbor
     // has `afi-safi label-v4 next-hop-self` (Inter-AS Option C ASBR → PE);
@@ -11455,6 +11502,9 @@ fn route_update_labelv6(
     let mut attrs = (*rib.attr).clone();
 
     ebgp_egress_aspath(&peer.egress_as(), &mut attrs);
+    if as_sets_withdraw_suppresses_egress(bgp.as_sets_withdraw, &attrs) {
+        return None;
+    }
 
     let needs_self =
         peer.is_ebgp() || rib.is_originated() || peer.next_hop_self(Afi::Ip6, Safi::MplsLabel);
@@ -12683,7 +12733,7 @@ pub(super) fn route_sync_v4_chunk(peer: &mut Peer, bgp: &mut BgpTop, chunk: usiz
             if llgr_blocks_advertisement(rib.stale, &peer.cap_recv, Afi::Ip, Safi::Unicast) {
                 continue;
             }
-            let ctx = peer.sync_ctx(*bgp.router_id);
+            let ctx = peer.sync_ctx(*bgp.router_id, bgp.as_sets_withdraw);
             let Some((nlri, attr)) = route_update_ipv4(&ctx, &prefix, &rib, add_path) else {
                 continue;
             };
@@ -12708,7 +12758,11 @@ pub(super) fn route_sync_v4_chunk(peer: &mut Peer, bgp: &mut BgpTop, chunk: usiz
         .is_enhe_v4_negotiated()
         .then(|| super::update_group::compose_enhe_next_hop(peer, bgp.interface_addrs))
         .flatten();
-    super::update_group::send_ipv4_direct(&peer.sync_ctx(*bgp.router_id), entries, enhe_v6);
+    super::update_group::send_ipv4_direct(
+        &peer.sync_ctx(*bgp.router_id, bgp.as_sets_withdraw),
+        entries,
+        enhe_v6,
+    );
 
     if done {
         send_eor_ipv4_unicast(peer);
@@ -12749,7 +12803,7 @@ pub fn route_sync_ipv4(peer: &mut Peer, bgp: &mut BgpTop) {
         if llgr_blocks_advertisement(rib.stale, &peer.cap_recv, Afi::Ip, Safi::Unicast) {
             continue;
         }
-        let ctx = peer.sync_ctx(*bgp.router_id);
+        let ctx = peer.sync_ctx(*bgp.router_id, bgp.as_sets_withdraw);
         let Some((nlri, attr)) = route_update_ipv4(&ctx, &prefix, &rib, add_path) else {
             continue;
         };
@@ -12785,7 +12839,11 @@ pub fn route_sync_ipv4(peer: &mut Peer, bgp: &mut BgpTop) {
         .is_enhe_v4_negotiated()
         .then(|| super::update_group::compose_enhe_next_hop(peer, bgp.interface_addrs))
         .flatten();
-    super::update_group::send_ipv4_direct(&peer.sync_ctx(*bgp.router_id), entries, enhe_v6);
+    super::update_group::send_ipv4_direct(
+        &peer.sync_ctx(*bgp.router_id, bgp.as_sets_withdraw),
+        entries,
+        enhe_v6,
+    );
 
     // Send End-of-RIB marker for IPv4 Unicast
     send_eor_ipv4_unicast(peer);
@@ -12897,7 +12955,7 @@ pub fn route_sync_vpnv4(peer: &mut Peer, bgp: &mut BgpTop) {
             if llgr_blocks_advertisement(rib.stale, &peer.cap_recv, Afi::Ip, Safi::MplsVpn) {
                 continue;
             }
-            let ctx = peer.sync_ctx(*bgp.router_id);
+            let ctx = peer.sync_ctx(*bgp.router_id, bgp.as_sets_withdraw);
             let Some((nlri, attr)) = route_update_ipv4(&ctx, &prefix, &rib, add_path) else {
                 continue;
             };
@@ -13681,6 +13739,7 @@ impl Bgp {
             vrf_transport_v4: None,
             vrf_transport_v6: None,
             central_label_alloc: None,
+            as_sets_withdraw: self.as_sets_withdraw,
         };
         route_advertise_mup_to_peers(rd, prefix, &selected, &mut bgp_ref, &mut self.peers);
     }
@@ -13837,6 +13896,7 @@ impl Bgp {
             vrf_transport_v4: None,
             vrf_transport_v6: None,
             central_label_alloc: None,
+            as_sets_withdraw: self.as_sets_withdraw,
         };
 
         // An originated route lacks a v4 NEXT_HOP attribute, so when
@@ -13895,6 +13955,7 @@ impl Bgp {
             vrf_transport_v4: None,
             vrf_transport_v6: None,
             central_label_alloc: None,
+            as_sets_withdraw: self.as_sets_withdraw,
         };
 
         let selected = bgp_ref.shard.select_best_path(prefix);
@@ -13962,6 +14023,7 @@ impl Bgp {
             vrf_transport_v4: None,
             vrf_transport_v6: None,
             central_label_alloc: None,
+            as_sets_withdraw: self.as_sets_withdraw,
         };
 
         fib_install_v6(&bgp_ref, prefix, &selected);
@@ -13995,6 +14057,7 @@ impl Bgp {
             vrf_transport_v4: None,
             vrf_transport_v6: None,
             central_label_alloc: None,
+            as_sets_withdraw: self.as_sets_withdraw,
         };
 
         let selected = bgp_ref.shard.select_best_path_v6(prefix);
@@ -14047,6 +14110,7 @@ impl Bgp {
             vrf_transport_v4: None,
             vrf_transport_v6: None,
             central_label_alloc: None,
+            as_sets_withdraw: self.as_sets_withdraw,
         };
 
         // Reconcile the FIB: a self-originated winner withdraws any BGP
@@ -14085,6 +14149,7 @@ impl Bgp {
             vrf_transport_v4: None,
             vrf_transport_v6: None,
             central_label_alloc: None,
+            as_sets_withdraw: self.as_sets_withdraw,
         };
 
         let selected = bgp_ref.shard.select_best_path_v4lu(prefix);
@@ -14142,6 +14207,7 @@ impl Bgp {
             vrf_transport_v4: None,
             vrf_transport_v6: None,
             central_label_alloc: None,
+            as_sets_withdraw: self.as_sets_withdraw,
         };
 
         fib_install_labelv6(
@@ -14178,6 +14244,7 @@ impl Bgp {
             vrf_transport_v4: None,
             vrf_transport_v6: None,
             central_label_alloc: None,
+            as_sets_withdraw: self.as_sets_withdraw,
         };
 
         let selected = bgp_ref.shard.select_best_path_v6lu(prefix);
@@ -14267,6 +14334,7 @@ impl Bgp {
             vrf_transport_v4: None,
             vrf_transport_v6: None,
             central_label_alloc: None,
+            as_sets_withdraw: self.as_sets_withdraw,
         };
 
         // Same logic as `route_add`: the redistributed BGP route has
@@ -14311,6 +14379,7 @@ impl Bgp {
             vrf_transport_v4: None,
             vrf_transport_v6: None,
             central_label_alloc: None,
+            as_sets_withdraw: self.as_sets_withdraw,
         };
 
         let selected = bgp_ref.shard.select_best_path(prefix);
@@ -14387,6 +14456,7 @@ impl Bgp {
             vrf_transport_v4: None,
             vrf_transport_v6: None,
             central_label_alloc: None,
+            as_sets_withdraw: self.as_sets_withdraw,
         };
 
         fib_install_v6(&bgp_ref, prefix, &selected);
@@ -14428,6 +14498,7 @@ impl Bgp {
             vrf_transport_v4: None,
             vrf_transport_v6: None,
             central_label_alloc: None,
+            as_sets_withdraw: self.as_sets_withdraw,
         };
 
         let selected = bgp_ref.shard.select_best_path_v6(prefix);
@@ -14487,6 +14558,7 @@ impl Bgp {
             vrf_transport_v4: None,
             vrf_transport_v6: None,
             central_label_alloc: None,
+            as_sets_withdraw: self.as_sets_withdraw,
         };
 
         // Reconcile the FIB: a self-originated winner withdraws any BGP
@@ -14526,6 +14598,7 @@ impl Bgp {
             vrf_transport_v4: None,
             vrf_transport_v6: None,
             central_label_alloc: None,
+            as_sets_withdraw: self.as_sets_withdraw,
         };
 
         let selected = bgp_ref.shard.select_best_path_v4lu(prefix);
@@ -14587,6 +14660,7 @@ impl Bgp {
             vrf_transport_v4: None,
             vrf_transport_v6: None,
             central_label_alloc: None,
+            as_sets_withdraw: self.as_sets_withdraw,
         };
 
         fib_install_labelv6(
@@ -14624,6 +14698,7 @@ impl Bgp {
             vrf_transport_v4: None,
             vrf_transport_v6: None,
             central_label_alloc: None,
+            as_sets_withdraw: self.as_sets_withdraw,
         };
 
         let selected = bgp_ref.shard.select_best_path_v6lu(prefix);
@@ -14786,6 +14861,7 @@ impl Bgp {
             vrf_transport_v4: None,
             vrf_transport_v6: None,
             central_label_alloc: None,
+            as_sets_withdraw: self.as_sets_withdraw,
         };
 
         if !selected.is_empty() {
@@ -14906,6 +14982,7 @@ impl Bgp {
             vrf_transport_v4: None,
             vrf_transport_v6: None,
             central_label_alloc: None,
+            as_sets_withdraw: self.as_sets_withdraw,
         };
 
         if !selected.is_empty() {
@@ -15050,6 +15127,7 @@ impl Bgp {
             vrf_transport_v4: None,
             vrf_transport_v6: None,
             central_label_alloc: None,
+            as_sets_withdraw: self.as_sets_withdraw,
         };
 
         if !selected.is_empty() {
@@ -15162,6 +15240,7 @@ impl Bgp {
             vrf_transport_v4: None,
             vrf_transport_v6: None,
             central_label_alloc: None,
+            as_sets_withdraw: self.as_sets_withdraw,
         };
 
         if !selected.is_empty() {
@@ -15744,6 +15823,7 @@ impl Bgp {
             vrf_transport_v4: None,
             vrf_transport_v6: None,
             central_label_alloc: None,
+            as_sets_withdraw: self.as_sets_withdraw,
         };
 
         if !selected.is_empty() {
@@ -15869,6 +15949,7 @@ impl Bgp {
             vrf_transport_v4: None,
             vrf_transport_v6: None,
             central_label_alloc: None,
+            as_sets_withdraw: self.as_sets_withdraw,
         };
         if !selected.is_empty() {
             route_advertise_evpn_to_peers(rd, prefix, &selected, &mut bgp_ref, &mut self.peers);
@@ -20259,5 +20340,91 @@ mod llgr_tests {
             Afi::Ip,
             Safi::MplsVpn
         ));
+    }
+}
+
+#[cfg(test)]
+mod as_sets_withdraw_tests {
+    use std::str::FromStr;
+
+    use bgp_packet::{As4Path, BgpAttr};
+
+    use super::{
+        SyncCtx, as_sets_withdraw_suppresses_egress, as_sets_withdraw_treat_as_withdraw,
+        route_update_ipv4,
+    };
+    use crate::bgp::peer::PeerType;
+    use crate::bgp::route::{BgpRib, BgpRibType, EgressAs};
+    use std::net::Ipv4Addr;
+    use std::sync::Arc;
+
+    fn attr_with_path(path: &str) -> BgpAttr {
+        BgpAttr {
+            aspath: Some(As4Path::from_str(path).unwrap()),
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn ingress_treat_as_withdraw_when_enabled_and_path_has_as_set() {
+        let attr = attr_with_path("65001 {65010 65011}");
+        assert!(as_sets_withdraw_treat_as_withdraw(true, Some(&attr)));
+        assert!(!as_sets_withdraw_treat_as_withdraw(false, Some(&attr)));
+        assert!(!as_sets_withdraw_treat_as_withdraw(
+            true,
+            Some(&attr_with_path("65001 65002"))
+        ));
+    }
+
+    #[test]
+    fn egress_suppresses_when_enabled_and_path_has_as_set() {
+        let attr = attr_with_path("65001 {65010 65011}");
+        assert!(as_sets_withdraw_suppresses_egress(true, &attr));
+        assert!(!as_sets_withdraw_suppresses_egress(false, &attr));
+    }
+
+    #[test]
+    fn route_update_ipv4_returns_none_when_as_set_present() {
+        let ctx = SyncCtx {
+            ident: 1,
+            peer_type: PeerType::EBGP,
+            reflector_client: false,
+            local_addr_v4: None,
+            router_id: Ipv4Addr::new(1, 1, 1, 1),
+            remote_id: Ipv4Addr::new(2, 2, 2, 2),
+            remote_address: "10.0.0.2".parse().unwrap(),
+            vpnv4_next_hop_self: false,
+            egress_as: EgressAs {
+                is_ebgp: true,
+                local_as: 65000,
+                remote_as: 65001,
+                as_override: false,
+                remove_private_as: None,
+                local_as_substitute: None,
+                local_as_replace: false,
+            },
+            out_policy: Arc::new(crate::bgp::policy::OutPolicy::default()),
+            packet_tx: None,
+            egress_depth: Arc::new(std::sync::atomic::AtomicUsize::new(0)),
+            extended_message: false,
+            attach_unknown_attr: None,
+            as_sets_withdraw: true,
+        };
+        let rib = BgpRib::new(
+            2,
+            Ipv4Addr::new(3, 3, 3, 3),
+            BgpRibType::EBGP,
+            0,
+            0,
+            &attr_with_path("65002 {65010}"),
+            None,
+            None,
+            false,
+        );
+        let prefix = "10.0.0.0/24".parse().unwrap();
+        assert!(
+            route_update_ipv4(&ctx, &prefix, &rib, false).is_none(),
+            "RFC 9774 must suppress egress of AS_SET paths",
+        );
     }
 }

--- a/zebra-rs/src/bgp/update_group.rs
+++ b/zebra-rs/src/bgp/update_group.rs
@@ -467,6 +467,7 @@ pub fn attach(
     peers: &mut PeerMap,
     peer_idx: usize,
     router_id: Ipv4Addr,
+    as_sets_withdraw: bool,
 ) {
     let Some(peer) = peers.get_by_idx(peer_idx) else {
         return;
@@ -528,7 +529,7 @@ pub fn attach(
             let add_path = peer.opt.is_add_path_send(afi_safi.afi, afi_safi.safi);
             t.send(super::group_egress::GroupEgressDeltaV4::AddMember {
                 ident: peer_idx,
-                ctx: Box::new(peer.sync_ctx(router_id)),
+                ctx: Box::new(peer.sync_ctx(router_id, as_sets_withdraw)),
                 add_path,
             });
         }
@@ -1634,8 +1635,8 @@ mod tests {
 
         let mut groups = empty_map();
         let rid = "1.1.1.1".parse().unwrap();
-        attach(&mut groups, &mut peers, dual_idx, rid);
-        attach(&mut groups, &mut peers, v4only_idx, rid);
+        attach(&mut groups, &mut peers, dual_idx, rid, true);
+        attach(&mut groups, &mut peers, v4only_idx, rid, true);
 
         let v4_key = AfiSafi::new(Afi::Ip, Safi::Unicast);
         let v6_key = AfiSafi::new(Afi::Ip6, Safi::Unicast);

--- a/zebra-rs/src/bgp/vrf/inst.rs
+++ b/zebra-rs/src/bgp/vrf/inst.rs
@@ -1166,6 +1166,7 @@ impl BgpVrf {
                     vrf_transport_v4: Some(&self.transport_v4),
                     vrf_transport_v6: Some(&self.transport_v6),
                     central_label_alloc: None,
+                    as_sets_withdraw: true,
                 };
                 // Per-VRF tasks don't drive the global shard pool (their
                 // RIB is the VRF's own); ingest stays synchronous.
@@ -1346,6 +1347,7 @@ impl BgpVrf {
             vrf_transport_v4: Some(&self.transport_v4),
             vrf_transport_v6: Some(&self.transport_v6),
             central_label_alloc: None,
+            as_sets_withdraw: true,
         };
         super::super::route::route_advertise_to_peers(
             None,
@@ -1433,6 +1435,7 @@ impl BgpVrf {
             vrf_transport_v4: Some(&self.transport_v4),
             vrf_transport_v6: Some(&self.transport_v6),
             central_label_alloc: None,
+            as_sets_withdraw: true,
         };
         super::super::route::route_advertise_to_peers(
             None,
@@ -1567,6 +1570,7 @@ impl BgpVrf {
             vrf_transport_v4: Some(&self.transport_v4),
             vrf_transport_v6: Some(&self.transport_v6),
             central_label_alloc: None,
+            as_sets_withdraw: true,
         };
         super::super::route::route_advertise_to_peers_v6(
             prefix,
@@ -1638,6 +1642,7 @@ impl BgpVrf {
             vrf_transport_v4: Some(&self.transport_v4),
             vrf_transport_v6: Some(&self.transport_v6),
             central_label_alloc: None,
+            as_sets_withdraw: true,
         };
         super::super::route::route_advertise_to_peers_v6(
             prefix,

--- a/zebra-rs/src/config/manager.rs
+++ b/zebra-rs/src/config/manager.rs
@@ -3037,6 +3037,47 @@ mod yang_load_tests {
         }
     }
 
+    /// `router bgp as-sets-withdraw <true|false>` — RFC 9774 global toggle
+    /// (`zebra-bgp-as-sets-withdraw.yang`). Default-on; `false` opts out
+    /// during a transition period. Pinned because vtyctl apply is
+    /// garbage-tolerant — an unwired grammar silently no-ops.
+    #[test]
+    fn bgp_as_sets_withdraw_grammar() {
+        use crate::config::ExecCode;
+        use crate::config::parse::{State, parse};
+        use libyang::to_entry;
+
+        let mut yang = YangStore::new();
+        yang.add_path(concat!(env!("CARGO_MANIFEST_DIR"), "/yang"));
+        yang.read_with_resolve("configure")
+            .expect("configure mode loads");
+        yang.identity_resolve();
+        let module = yang
+            .find_module("configure")
+            .expect("configure module present");
+        let entry = to_entry(&yang, module);
+
+        for cmd in [
+            "set router bgp as-sets-withdraw true",
+            "set router bgp as-sets-withdraw false",
+        ] {
+            let (code, _comps, _state) = parse(cmd, entry.clone(), None, State::new());
+            assert_eq!(code, ExecCode::Success, "`{cmd}` must be a valid path",);
+        }
+
+        let (code, _comps, _state) = parse(
+            "set router bgp as-sets-withdraw",
+            entry.clone(),
+            None,
+            State::new(),
+        );
+        assert_ne!(
+            code,
+            ExecCode::Success,
+            "boolean leaf — the value-less spelling must not parse",
+        );
+    }
+
     /// `neighbor X ip-transparent` (zebra-bgp-transport.yang) must be a
     /// settable path on the neighbor and on the neighbor-group (the
     /// group reuses the transport grouping via `uses`). Guards against

--- a/zebra-rs/yang/config.yang
+++ b/zebra-rs/yang/config.yang
@@ -125,6 +125,10 @@ module config {
     prefix zbao;
   }
 
+  import zebra-bgp-as-sets-withdraw {
+    prefix zbasw;
+  }
+
   import zebra-bgp-remove-private-as {
     prefix zbrpa;
   }

--- a/zebra-rs/yang/zebra-bgp-as-sets-withdraw.yang
+++ b/zebra-rs/yang/zebra-bgp-as-sets-withdraw.yang
@@ -1,0 +1,91 @@
+module zebra-bgp-as-sets-withdraw {
+  yang-version "1";
+
+  namespace "urn:ietf:params:xml:ns:yang:zebra-bgp-as-sets-withdraw";
+  prefix "zbasw";
+
+  import ietf-bgp {
+    prefix bgp;
+  }
+
+  import config {
+    prefix config;
+  }
+
+  import configure {
+    prefix configure;
+  }
+
+  import extension {
+    prefix ext;
+  }
+
+  organization
+    "zebra-rs";
+
+  contact
+    "https://github.com/zebra-rs";
+
+  description
+    "Global BGP knob for RFC 9774 deprecation of AS_SET and
+     AS_CONFED_SET in the AS_PATH.
+
+     Unless opted out, a BGP speaker must not originate UPDATEs
+     containing AS_SET or AS_CONFED_SET path segments and must apply
+     treat-as-withdraw (RFC 7606) when such segments appear in a
+     received AS_PATH or AS4_PATH.
+
+       router bgp {
+         as-sets-withdraw false;   // transition: permit legacy AS_SETs
+       }
+
+     The knob is on by default (`as-sets-withdraw true`). Setting it
+     to false opts out during a transition period. Equivalent to FRR
+     `no bgp reject-as-sets`; the enabled default matches FRR
+     `bgp reject-as-sets` (on by default since FRR 10.5).";
+
+  revision 2026-07-08 {
+    description "Initial revision: global as-sets-withdraw toggle.";
+    reference
+      "RFC 9774: Deprecation of AS_SET and AS_CONFED_SET in BGP.
+       RFC 7606: Revised Error Handling for BGP UPDATE Messages.";
+  }
+
+  grouping bgp-as-sets-withdraw-extension {
+    description
+      "RFC 9774 global toggle on the BGP top-level.";
+
+    leaf as-sets-withdraw {
+      ext:help "Treat AS_SET/AS_CONFED_SET per RFC 9774 (withdraw on receive)";
+      type boolean;
+      default "true";
+      description
+        "When true (default), enforce RFC 9774: received UPDATEs whose
+         AS_PATH or AS4_PATH contain AS_SET or AS_CONFED_SET segments
+         are handled with treat-as-withdraw (RFC 7606), and such
+         segments are not originated on egress.
+
+         When false, opt out during a transition period and permit
+         legacy AS_SET / AS_CONFED_SET handling. Equivalent to FRR
+         `no bgp reject-as-sets`.";
+    }
+  }
+
+  /* =========================================================
+   * Augments into the zebra-rs configure tree
+   * ========================================================= */
+
+  augment "/configure:set/config:router/bgp:bgp" {
+    description
+      "Attach as-sets-withdraw to the BGP top-level in the
+       candidate-set subtree.";
+    uses bgp-as-sets-withdraw-extension;
+  }
+
+  augment "/configure:delete/config:router/bgp:bgp" {
+    description
+      "Same attachment for the delete subtree so
+       `delete router bgp as-sets-withdraw` is path-valid.";
+    uses bgp-as-sets-withdraw-extension;
+  }
+}


### PR DESCRIPTION
## Summary

Implements [RFC 9774](https://www.rfc-editor.org/rfc/rfc9774.html) deprecation of `AS_SET` / `AS_CONFED_SET` in the BGP `AS_PATH`, exposed as a **default-on** global boolean `router bgp as-sets-withdraw`.

- **Ingress** — an inbound UPDATE whose `AS_PATH`/`AS4_PATH` carries an `AS_SET` (`{…}`) or `AS_CONFED_SET` (`[…]`) segment is **treat-as-withdraw** (RFC 7606): any prior copy from that peer is removed, nothing new is installed, explicit withdrawals are still honoured, session stays up.
- **Egress** — a route whose post-transform `AS_PATH` still contains those segments is **not advertised** to any peer (v4/v6 unicast, labeled unicast, VPN, EVPN, MUP, Flowspec).
- Setting the knob to `false` opts out during a transition period; `delete` restores the default (`true`). Equivalent to FRR `bgp reject-as-sets` (on by default since FRR 10.5).

The toggle threads through `SyncCtx` / `BgpTop` so the egress build can run off-main in a shard worker. Two new gate helpers (`as_sets_withdraw_treat_as_withdraw`, `as_sets_withdraw_suppresses_egress`) sit on top of a new `As4Path::contains_as_set_or_confed_set()`.

New `zebra-bgp-as-sets-withdraw.yang` module (augments the configure set/delete subtrees), a book chapter, an appendix-B RFC entry, and a cross-link from the enforce-first-as chapter.

## Test plan

- `cargo test -p bgp-packet contains_as_set` — `As4Path` segment detection (sequence / AS_SET / AS_CONFED_SET / AS_CONFED_SEQUENCE).
- `cargo test -p zebra-rs as_sets_withdraw` — ingress treat-as-withdraw, egress suppression, `route_update_ipv4` returns `None` on AS_SET, knob Set/Set/Delete transitions, and the vtyctl grammar guard (`bgp_as_sets_withdraw_grammar`).
- `cargo fmt --all --check` clean; `cargo clippy --workspace --all-targets -- -D warnings` clean.

Generated with [Claude Code](https://claude.com/claude-code)