### PR TITLE
playset: fix dead source links in the Inter-AS READMEs

### DIFF
--- a/playset/README.md
+++ b/playset/README.md
@@ -37,7 +37,7 @@ gitignored.
 > up only one of them at once — `up.sh` tears down leftovers of the same
 > names first.
 
-## SRv6 & SR-MPLS with TI-LFA fast-reroute
+## SR-MPLS & SRv6 with TI-LFA fast-reroute
 
 Seven labs, one topology — the RFC 9855 example network with two edge hosts
 attached — covering the IGP x data-plane matrix. Every walkthrough follows
@@ -50,9 +50,9 @@ Rows are the data plane, columns the IGP:
 
 | | IS-IS | OSPFv2 | OSPFv3 |
 |:--|:--|:--|:--|
+| **SR-MPLS** | [isis-srmpls](isis-srmpls/README.md) | [ospfv2-srmpls](ospfv2-srmpls/README.md) | [ospfv3-srmpls](ospfv3-srmpls/README.md) |
 | **SRv6 (classic)** | [isis-srv6-classic](isis-srv6-classic/README.md) | — | [ospfv3-srv6-classic](ospfv3-srv6-classic/README.md) |
 | **SRv6 (uSID)** | [isis-srv6-usid](isis-srv6-usid/README.md) | — | [ospfv3-srv6-usid](ospfv3-srv6-usid/README.md) |
-| **SR-MPLS** | [isis-srmpls](isis-srmpls/README.md) | [ospfv2-srmpls](ospfv2-srmpls/README.md) | [ospfv3-srmpls](ospfv3-srmpls/README.md) |
 
 The two **SRv6** rows differ only in SID encoding — **classic** RFC 8986
 (RFC 9352 for IS-IS, RFC 9513 for OSPFv3) versus **uSID** / NEXT-C-SID

--- a/playset/interas-option-a/README.md
+++ b/playset/interas-option-a/README.md
@@ -543,11 +543,8 @@ Option A boundary).
 
 ## Sources
 
-* Cisco, *MPLS VPN Inter-AS Option AB* (defines Options A/B/AB and the
-  back-to-back VRF model):
-  <https://www.cisco.com/c/en/us/td/docs/routers/ios/config/17-x/mpls/b-mpls/m_mp-vpn-ias-optab.html>
-* Cisco, *Configuring MPLS VPN Inter-AS Options* (Catalyst switch
-  configuration guide):
+* Cisco, *Configuring MPLS VPN Inter-AS Options* (defines Options A/B/C,
+  including the back-to-back VRF model, with configuration examples):
   <https://www.cisco.com/c/en/us/td/docs/switches/lan/catalyst9400/software/release/17-16/configuration_guide/mpls/b_1716_mpls_9400_cg/configuring_mpls_vpn_interas_options.html>
 * netquirks, *Inter-AS Option A* (IOS vs IOS-XR configuration
   walkthrough): <https://netquirks.co.uk/ios-vs-xr/inter-as-option-a/>

--- a/playset/interas-option-b/README.md
+++ b/playset/interas-option-b/README.md
@@ -355,9 +355,9 @@ ASBR-ASBR eBGP VPNv4 session — the Option B boundary.
 * RFC 4364, *BGP/MPLS IP Virtual Private Networks*, §10 — "Multi-AS
   Backbones", method (b); RFC 8277, *Using BGP to Bind MPLS Labels to
   Address Prefixes*.
-* Cisco, *MPLS VPN Inter-AS Option AB* (defines Options A/B and the
-  ASBR-to-ASBR labeled VPNv4 model):
-  <https://www.cisco.com/c/en/us/td/docs/routers/ios/config/17-x/mpls/b-mpls/m_mp-vpn-ias-optab.html>
+* Cisco, *MPLS VPN Inter-AS with ASBRs Exchanging VPN-IPv4 Addresses*
+  (the Option B configuration guide):
+  <https://www.cisco.com/c/en/us/td/docs/routers/ios/config/17-x/mpls/b-mpls/m_mp-vpn-connect-asbr.html>
 * Cisco, *Configuring MPLS VPN Inter-AS Options*:
   <https://www.cisco.com/c/en/us/td/docs/switches/lan/catalyst9400/software/release/17-16/configuration_guide/mpls/b_1716_mpls_9400_cg/configuring_mpls_vpn_interas_options.html>
 * netquirks, *Inter-AS Option B*:

--- a/playset/interas-option-c/README.md
+++ b/playset/interas-option-c/README.md
@@ -327,11 +327,11 @@ directly between pe1 and pe2** — the Option C control plane.
   Address Prefixes*.
 * Cisco, *MPLS VPN Inter-AS with ASBRs Exchanging IPv4 Routes and MPLS
   Labels* (the Option C configuration guide):
-  <https://www.cisco.com/c/en/us/td/docs/ios-xml/ios/mp_ias_and_csc/configuration/xe-16/mp-ias-and-csc-xe-16-book/mp-vpn-ias-ipv4-mpls.html>
+  <https://www.cisco.com/c/en/us/td/docs/routers/ios/config/17-x/mpls/b-mpls/m_mp-vpn-connect-ipv4.html>
 * Cisco, *Configuring MPLS VPN Inter-AS Options*:
   <https://www.cisco.com/c/en/us/td/docs/switches/lan/catalyst9400/software/release/17-16/configuration_guide/mpls/b_1716_mpls_9400_cg/configuring_mpls_vpn_interas_options.html>
 * netquirks, *Inter-AS Option C*:
-  <https://netquirks.co.uk/ios-vs-xr/inter-as-option-c/>
+  <https://netquirks.co.uk/ios-vs-xr/option-c/>
 * QuistED, *Inter-AS MPLS L3VPN Options (A, B, C)*:
   <https://www.quisted.net/index.php/2025/09/12/inter-as-mpls-l3vpn-options-a-b-c/>
 * Juniper, *Interprovider VPNs*:


### PR DESCRIPTION
## Summary

Three source links across the Inter-AS READMEs were unreachable (thanks for the catch):

| broken | replacement | why |
|:--|:--|:--|
| Cisco *MPLS VPN Inter-AS Option AB* (`m_mp-vpn-ias-optab.html`, in A + B) | A: rely on the Catalyst *Configuring MPLS VPN Inter-AS Options* guide (already cited, verified 200); B: cite its exact feature guide *MPLS VPN Inter-AS with ASBRs Exchanging VPN-IPv4 Addresses* (`m_mp-vpn-connect-asbr.html`) | hard 403 — sibling pages in the same book return 200 to the same client, so the page is gone, not bot-blocked |
| Cisco Option C link (`mp-vpn-ias-ipv4-mpls.html`) | *MPLS VPN Inter-AS with ASBRs Exchanging IPv4 Routes and MPLS Labels* (`m_mp-vpn-connect-ipv4.html`, IOS XE 17.x) | the original URL was pattern-guessed and wrong |
| `netquirks.co.uk/ios-vs-xr/inter-as-option-c/` | `netquirks.co.uk/ios-vs-xr/option-c/` | 404 — netquirks' Option C page uses a shorter slug |

## Test plan

- Every link now present in the three READMEs verified: HTTP 200 via browser-UA curl (Cisco ×3 incl. a cooldown retest for WAF flakiness, Juniper, QuistED), or existence/content-verified fetch for the netquirks pages (their site rate-limits repeated automated requests, but all three pages load and match their titles).
- Docs-only change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)