### PR TITLE
playset: add EVPN VXLAN topology diagrams

### DIFF
--- a/playset/bgp-evpn-vxlan4-multi/README.md
+++ b/playset/bgp-evpn-vxlan4-multi/README.md
@@ -13,17 +13,7 @@ from the VNI, not from addressing — pings work inside a tenant and fail
 across tenants because the ARP broadcast never leaves the tenant's
 flood domain.
 
-```
-  h1 ──── vtep1 ═════ VNI 10 ═════ vtep2 ──── h2
- .1     ┌───┘ 192.168.0.1   192.168.0.2       .2
-  h4 ───┤
- .4     └─┐ 192.168.1.1
-          ║ VNI 20
-          ║ 192.168.1.2
-         vtep3 ──── h3
-                     .3
-        (hosts: 172.16.10.x/24, iBGP AS 65001, VXLAN UDP 4789)
-```
+<img src="../images/BgpEvpnVxlan4Multi.svg" alt="BGP EVPN VXLAN multi-tenant topology">
 
 ## Bring up all nodes
 

--- a/playset/bgp-evpn-vxlan4/README.md
+++ b/playset/bgp-evpn-vxlan4/README.md
@@ -7,11 +7,7 @@ build the BUM flood list and Type-2 MAC routes populate the remote FDB, so
 no flood-and-learn runs over the tunnel. Two hosts on the same IP subnet,
 each behind a different VTEP, talk as if they shared a switch.
 
-```
-  h1 ──── vtep1 ═════════════════ vtep2 ──── h2
- 172.16.10.1   192.168.0.1  192.168.0.2   172.16.10.2
-        (VNI 10 over UDP 4789, iBGP AS 65001)
-```
+<img src="../images/BgpEvpnVxlan4.svg" alt="BGP EVPN VXLAN (IPv4 transport) topology">
 
 Each VTEP runs zebra-rs with a bridge (`br10`), a VXLAN device
 (`vxlan10`, VNI 10) enslaved to it, and the host-facing interface enslaved

--- a/playset/images/BgpEvpnVxlan4.drawio
+++ b/playset/images/BgpEvpnVxlan4.drawio
@@ -1,0 +1,86 @@
+<mxfile host="Electron">
+  <diagram name="bgp-evpn-vxlan4" id="evpnVxlan4Base">
+    <mxGraphModel dx="820" dy="560" grid="1" gridSize="10" guides="1" tooltips="1" connect="1" arrows="1" fold="1" page="1" pageScale="1" pageWidth="860" pageHeight="360" background="#FFFFFF" math="0" shadow="0">
+      <root>
+        <mxCell id="0" />
+        <mxCell id="1" parent="0" />
+        <mxCell id="domain-box" parent="1" style="rounded=1;whiteSpace=wrap;html=1;fillColor=none;dashed=1;strokeColor=#999999;" value="" vertex="1">
+          <mxGeometry height="138" width="830" x="15" y="112" as="geometry" />
+        </mxCell>
+        <mxCell id="domain-title" parent="1" style="text;html=1;whiteSpace=wrap;strokeColor=none;fillColor=none;align=left;verticalAlign=middle;rounded=0;fontSize=12;fontColor=#333333;" value="VNI 10 — one stretched L2 segment (172.16.10.0/24)" vertex="1">
+          <mxGeometry height="20" width="420" x="26" y="120" as="geometry" />
+        </mxCell>
+        <mxCell id="cp-edge" edge="1" parent="1" source="vtep1-box" target="vtep2-box" style="endArrow=none;html=1;curved=1;dashed=1;strokeColor=#A02C93;exitX=0.5;exitY=0;exitDx=0;exitDy=0;entryX=0.5;entryY=0;entryDx=0;entryDy=0;fontSize=10;fontColor=#A02C93;" value="iBGP AS 65001 · EVPN — Type-3 IMET + Type-2 MAC">
+          <mxGeometry height="50" relative="1" width="50" as="geometry">
+            <Array as="points">
+              <mxPoint x="430" y="60" />
+            </Array>
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="e-h1-br10" edge="1" parent="1" source="h1" target="br10-1" style="endArrow=none;html=1;rounded=0;strokeColor=#0499D4;" value="vtep1-h1">
+          <mxGeometry height="50" relative="1" width="50" as="geometry" />
+        </mxCell>
+        <mxCell id="e-inner1" edge="1" parent="1" source="br10-1" target="vxlan10-1" style="endArrow=none;html=1;rounded=0;strokeColor=#777777;" value="">
+          <mxGeometry height="50" relative="1" width="50" as="geometry" />
+        </mxCell>
+        <mxCell id="e-tunnel" edge="1" parent="1" source="vxlan10-1" target="vxlan10-2" style="endArrow=none;html=1;rounded=0;strokeColor=#E97131;strokeWidth=3;fontSize=9;fontColor=#E97131;" value="VXLAN tunnel · VNI 10 · UDP 4789">
+          <mxGeometry height="50" relative="1" width="50" as="geometry" />
+        </mxCell>
+        <mxCell id="e-inner2" edge="1" parent="1" source="vxlan10-2" target="br10-2" style="endArrow=none;html=1;rounded=0;strokeColor=#777777;" value="">
+          <mxGeometry height="50" relative="1" width="50" as="geometry" />
+        </mxCell>
+        <mxCell id="e-br10-h2" edge="1" parent="1" source="br10-2" target="h2" style="endArrow=none;html=1;rounded=0;strokeColor=#0499D4;" value="vtep2-h2">
+          <mxGeometry height="50" relative="1" width="50" as="geometry" />
+        </mxCell>
+        <mxCell id="vtep1-box" parent="1" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#F7FBFE;strokeColor=#0E9ED5;verticalAlign=top;spacingTop=4;fontSize=11;fontColor=#333333;" value="vtep1" vertex="1">
+          <mxGeometry height="84" width="170" x="200" y="138" as="geometry" />
+        </mxCell>
+        <mxCell id="vtep2-box" parent="1" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#F7FBFE;strokeColor=#0E9ED5;verticalAlign=top;spacingTop=4;fontSize=11;fontColor=#333333;" value="vtep2" vertex="1">
+          <mxGeometry height="84" width="170" x="490" y="138" as="geometry" />
+        </mxCell>
+        <mxCell id="br10-1" parent="1" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#E1E1E1;strokeColor=#999999;fontSize=9;fontColor=#333333;" value="br10" vertex="1">
+          <mxGeometry height="38" width="64" x="214" y="166" as="geometry" />
+        </mxCell>
+        <mxCell id="vxlan10-1" parent="1" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#FFF2CC;strokeColor=#D6B656;fontSize=9;fontColor=#333333;" value="vxlan10" vertex="1">
+          <mxGeometry height="38" width="64" x="294" y="166" as="geometry" />
+        </mxCell>
+        <mxCell id="vxlan10-2" parent="1" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#FFF2CC;strokeColor=#D6B656;fontSize=9;fontColor=#333333;" value="vxlan10" vertex="1">
+          <mxGeometry height="38" width="64" x="502" y="166" as="geometry" />
+        </mxCell>
+        <mxCell id="br10-2" parent="1" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#E1E1E1;strokeColor=#999999;fontSize=9;fontColor=#333333;" value="br10" vertex="1">
+          <mxGeometry height="38" width="64" x="582" y="166" as="geometry" />
+        </mxCell>
+        <mxCell id="h1" parent="1" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#0499D4;strokeColor=none;fontSize=10;fontColor=#FFFFFF;" value="h1" vertex="1">
+          <mxGeometry height="36" width="52" x="30" y="167" as="geometry" />
+        </mxCell>
+        <mxCell id="h2" parent="1" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#0499D4;strokeColor=none;fontSize=10;fontColor=#FFFFFF;" value="h2" vertex="1">
+          <mxGeometry height="36" width="52" x="778" y="167" as="geometry" />
+        </mxCell>
+        <mxCell id="addr-h1" parent="1" style="text;html=1;whiteSpace=wrap;strokeColor=none;fillColor=none;align=center;verticalAlign=middle;fontSize=9;fontColor=#333333;" value="172.16.10.1" vertex="1">
+          <mxGeometry height="16" width="100" x="6" y="226" as="geometry" />
+        </mxCell>
+        <mxCell id="addr-h2" parent="1" style="text;html=1;whiteSpace=wrap;strokeColor=none;fillColor=none;align=center;verticalAlign=middle;fontSize=9;fontColor=#333333;" value="172.16.10.2" vertex="1">
+          <mxGeometry height="16" width="100" x="754" y="226" as="geometry" />
+        </mxCell>
+        <mxCell id="addr-v1" parent="1" style="text;html=1;whiteSpace=wrap;strokeColor=none;fillColor=none;align=center;verticalAlign=middle;fontSize=9;fontColor=#8A6D00;" value="192.168.0.1" vertex="1">
+          <mxGeometry height="16" width="100" x="276" y="226" as="geometry" />
+        </mxCell>
+        <mxCell id="addr-v2" parent="1" style="text;html=1;whiteSpace=wrap;strokeColor=none;fillColor=none;align=center;verticalAlign=middle;fontSize=9;fontColor=#8A6D00;" value="192.168.0.2" vertex="1">
+          <mxGeometry height="16" width="100" x="484" y="226" as="geometry" />
+        </mxCell>
+        <mxCell id="band-l" parent="1" style="rounded=0;whiteSpace=wrap;html=1;fillColor=none;strokeColor=#999999;fontSize=10;fontColor=#333333;" value="Ethernet frame (host L2)" vertex="1">
+          <mxGeometry height="24" width="333" x="25" y="292" as="geometry" />
+        </mxCell>
+        <mxCell id="band-m" parent="1" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#DAE8FC;strokeColor=#6C8EBF;fontSize=10;fontColor=#1A3A6B;" value="VXLAN over IP" vertex="1">
+          <mxGeometry height="24" width="144" x="358" y="292" as="geometry" />
+        </mxCell>
+        <mxCell id="band-r" parent="1" style="rounded=0;whiteSpace=wrap;html=1;fillColor=none;strokeColor=#999999;fontSize=10;fontColor=#333333;" value="Ethernet frame (host L2)" vertex="1">
+          <mxGeometry height="24" width="333" x="502" y="292" as="geometry" />
+        </mxCell>
+        <mxCell id="caption" parent="1" style="text;html=1;whiteSpace=wrap;strokeColor=none;fillColor=none;align=center;verticalAlign=middle;fontSize=9;fontColor=#777777;" value="Host L2 frames ride VXLAN across the IP underlay (192.168.0.0/24); each VTEP encapsulates on egress and decapsulates on ingress." vertex="1">
+          <mxGeometry height="16" width="700" x="80" y="326" as="geometry" />
+        </mxCell>
+      </root>
+    </mxGraphModel>
+  </diagram>
+</mxfile>

--- a/playset/images/BgpEvpnVxlan4.svg
+++ b/playset/images/BgpEvpnVxlan4.svg
@@ -1,0 +1,76 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 860 360" font-family="Helvetica, Arial, sans-serif">
+  <!-- BGP EVPN VXLAN (IPv4 transport) — matches playset/bgp-evpn-vxlan4.
+       Editable source: BgpEvpnVxlan4.drawio (re-export from draw.io replaces this file). -->
+  <rect width="860" height="360" fill="#ffffff"/>
+
+  <!-- control plane: iBGP EVPN session between the two VTEPs -->
+  <path d="M 285,138 C 340,58 520,58 575,138" fill="none" stroke="#A02C93" stroke-width="1.5" stroke-dasharray="5,4"/>
+  <text x="430" y="46" text-anchor="middle" font-size="10" fill="#A02C93">iBGP AS 65001 · EVPN — Type-3 IMET (flood list) + Type-2 MAC (remote FDB)</text>
+
+  <!-- overlay L2 segment domain -->
+  <rect x="15" y="112" width="830" height="138" rx="8" fill="none" stroke="#999999" stroke-dasharray="6,4"/>
+  <text x="26" y="132" font-size="12" fill="#333333">VNI 10 — one stretched L2 segment (172.16.10.0/24)</text>
+
+  <!-- access links -->
+  <line x1="82" y1="185" x2="214" y2="185" stroke="#0499D4" stroke-width="1.5"/>
+  <line x1="646" y1="185" x2="778" y2="185" stroke="#0499D4" stroke-width="1.5"/>
+  <text x="148" y="178" text-anchor="middle" font-size="8" fill="#777777">vtep1-h1</text>
+  <text x="712" y="178" text-anchor="middle" font-size="8" fill="#777777">vtep2-h2</text>
+
+  <!-- inner VTEP wiring (bridge <-> vxlan device) -->
+  <line x1="278" y1="185" x2="294" y2="185" stroke="#777777" stroke-width="1.5"/>
+  <line x1="566" y1="185" x2="582" y2="185" stroke="#777777" stroke-width="1.5"/>
+
+  <!-- VXLAN tunnel over the IP underlay -->
+  <line x1="358" y1="185" x2="502" y2="185" stroke="#E97131" stroke-width="3"/>
+  <text x="430" y="173" text-anchor="middle" font-size="9" fill="#E97131">VXLAN tunnel</text>
+  <text x="430" y="207" text-anchor="middle" font-size="8" fill="#E97131">VNI 10 · UDP 4789</text>
+
+  <!-- VTEP boxes -->
+  <g>
+    <rect x="200" y="138" width="170" height="84" rx="6" fill="#F7FBFE" stroke="#0E9ED5"/>
+    <rect x="490" y="138" width="170" height="84" rx="6" fill="#F7FBFE" stroke="#0E9ED5"/>
+    <text x="285" y="154" text-anchor="middle" font-size="11" fill="#333333">vtep1</text>
+    <text x="575" y="154" text-anchor="middle" font-size="11" fill="#333333">vtep2</text>
+  </g>
+
+  <!-- bridges and vxlan devices inside the VTEPs -->
+  <g font-size="9" text-anchor="middle">
+    <rect x="214" y="166" width="64" height="38" rx="4" fill="#E1E1E1" stroke="#999999"/>
+    <text x="246" y="189" fill="#333333">br10</text>
+    <rect x="294" y="166" width="64" height="38" rx="4" fill="#FFF2CC" stroke="#D6B656"/>
+    <text x="326" y="189" fill="#333333">vxlan10</text>
+    <rect x="582" y="166" width="64" height="38" rx="4" fill="#E1E1E1" stroke="#999999"/>
+    <text x="614" y="189" fill="#333333">br10</text>
+    <rect x="502" y="166" width="64" height="38" rx="4" fill="#FFF2CC" stroke="#D6B656"/>
+    <text x="534" y="189" fill="#333333">vxlan10</text>
+  </g>
+
+  <!-- hosts -->
+  <g font-size="10" text-anchor="middle" fill="#ffffff">
+    <rect x="30" y="167" width="52" height="36" rx="6" fill="#0499D4"/>
+    <text x="56" y="189">h1</text>
+    <rect x="778" y="167" width="52" height="36" rx="6" fill="#0499D4"/>
+    <text x="804" y="189">h2</text>
+  </g>
+
+  <!-- addresses -->
+  <g font-size="9" text-anchor="middle" fill="#333333">
+    <text x="56" y="236">172.16.10.1</text>
+    <text x="804" y="236">172.16.10.2</text>
+    <text x="326" y="236" fill="#8a6d00">192.168.0.1</text>
+    <text x="534" y="236" fill="#8a6d00">192.168.0.2</text>
+  </g>
+
+  <!-- data plane: host L2 frame -> VXLAN over IP underlay -> host L2 frame -->
+  <g font-size="10" text-anchor="middle">
+    <rect x="25" y="292" width="333" height="24" fill="none" stroke="#999999"/>
+    <text x="191" y="308" fill="#333333">Ethernet frame (host L2)</text>
+    <rect x="358" y="292" width="144" height="24" rx="12" fill="#DAE8FC" stroke="#6C8EBF"/>
+    <text x="430" y="308" fill="#1a3a6b">VXLAN over IP</text>
+    <rect x="502" y="292" width="333" height="24" fill="none" stroke="#999999"/>
+    <text x="668" y="308" fill="#333333">Ethernet frame (host L2)</text>
+  </g>
+  <text x="430" y="340" text-anchor="middle" font-size="9" fill="#777777">Host L2 frames ride VXLAN across the IP underlay (192.168.0.0/24); each VTEP encapsulates on egress and decapsulates on ingress.</text>
+</svg>

--- a/playset/images/BgpEvpnVxlan4Multi.drawio
+++ b/playset/images/BgpEvpnVxlan4Multi.drawio
@@ -1,0 +1,118 @@
+<mxfile host="Electron">
+  <diagram name="bgp-evpn-vxlan4-multi" id="evpnVxlan4Multi">
+    <mxGraphModel dx="900" dy="620" grid="1" gridSize="10" guides="1" tooltips="1" connect="1" arrows="1" fold="1" page="1" pageScale="1" pageWidth="920" pageHeight="470" background="#FFFFFF" math="0" shadow="0">
+      <root>
+        <mxCell id="0" />
+        <mxCell id="1" parent="0" />
+        <mxCell id="domain-vni10" parent="1" style="rounded=1;whiteSpace=wrap;html=1;fillColor=none;dashed=1;strokeColor=#0499D4;" value="" vertex="1">
+          <mxGeometry height="117" width="878" x="20" y="145" as="geometry" />
+        </mxCell>
+        <mxCell id="domain-vni20" parent="1" style="rounded=1;whiteSpace=wrap;html=1;fillColor=none;dashed=1;strokeColor=#4DA72E;" value="" vertex="1">
+          <mxGeometry height="156" width="878" x="20" y="262" as="geometry" />
+        </mxCell>
+        <mxCell id="title" parent="1" style="text;html=1;whiteSpace=wrap;strokeColor=none;fillColor=none;align=center;verticalAlign=middle;fontSize=15;fontColor=#333333;" value="BGP EVPN VXLAN — multi-tenant" vertex="1">
+          <mxGeometry height="22" width="400" x="260" y="14" as="geometry" />
+        </mxCell>
+        <mxCell id="subtitle" parent="1" style="text;html=1;whiteSpace=wrap;strokeColor=none;fillColor=none;align=center;verticalAlign=middle;fontSize=10;fontColor=#777777;" value="iBGP AS 65001 · VXLAN UDP 4789 · vtep1 serves both tenants (br10 = VNI 10, br20 = VNI 20)" vertex="1">
+          <mxGeometry height="16" width="620" x="150" y="38" as="geometry" />
+        </mxCell>
+        <mxCell id="vni10-title" parent="1" style="text;html=1;whiteSpace=wrap;strokeColor=none;fillColor=none;align=left;verticalAlign=middle;fontSize=12;fontColor=#0499D4;" value="VNI 10 flood domain · RT 65001:10" vertex="1">
+          <mxGeometry height="18" width="300" x="28" y="152" as="geometry" />
+        </mxCell>
+        <mxCell id="vni20-title" parent="1" style="text;html=1;whiteSpace=wrap;strokeColor=none;fillColor=none;align=left;verticalAlign=middle;fontSize=12;fontColor=#4DA72E;" value="VNI 20 flood domain · RT 65001:20" vertex="1">
+          <mxGeometry height="18" width="300" x="28" y="401" as="geometry" />
+        </mxCell>
+        <mxCell id="e-h1" edge="1" parent="1" source="h1" target="br10-1" style="endArrow=none;html=1;rounded=0;strokeColor=#0499D4;" value="">
+          <mxGeometry height="50" relative="1" width="50" as="geometry" />
+        </mxCell>
+        <mxCell id="e-h4" edge="1" parent="1" source="h4" target="br20-1" style="endArrow=none;html=1;rounded=0;strokeColor=#4DA72E;" value="">
+          <mxGeometry height="50" relative="1" width="50" as="geometry" />
+        </mxCell>
+        <mxCell id="e-h2" edge="1" parent="1" source="br10-2" target="h2" style="endArrow=none;html=1;rounded=0;strokeColor=#0499D4;" value="">
+          <mxGeometry height="50" relative="1" width="50" as="geometry" />
+        </mxCell>
+        <mxCell id="e-h3" edge="1" parent="1" source="br20-3" target="h3" style="endArrow=none;html=1;rounded=0;strokeColor=#4DA72E;" value="">
+          <mxGeometry height="50" relative="1" width="50" as="geometry" />
+        </mxCell>
+        <mxCell id="e-tun10" edge="1" parent="1" source="br10-1" target="br10-2" style="endArrow=none;html=1;rounded=0;strokeColor=#0499D4;strokeWidth=3;exitX=1;exitY=0.5;exitDx=0;exitDy=0;entryX=0;entryY=0.5;entryDx=0;entryDy=0;" value="">
+          <mxGeometry height="50" relative="1" width="50" as="geometry" />
+        </mxCell>
+        <mxCell id="e-tun20" edge="1" parent="1" source="br20-1" target="br20-3" style="endArrow=none;html=1;rounded=0;strokeColor=#4DA72E;strokeWidth=3;exitX=1;exitY=0.5;exitDx=0;exitDy=0;entryX=0;entryY=0.5;entryDx=0;entryDy=0;" value="">
+          <mxGeometry height="50" relative="1" width="50" as="geometry" />
+        </mxCell>
+        <mxCell id="tun10-a" parent="1" style="text;html=1;whiteSpace=wrap;strokeColor=none;fillColor=none;align=center;verticalAlign=middle;fontSize=9;fontColor=#0499D4;" value="VXLAN · VNI 10" vertex="1">
+          <mxGeometry height="14" width="120" x="452" y="172" as="geometry" />
+        </mxCell>
+        <mxCell id="tun10-b" parent="1" style="text;html=1;whiteSpace=wrap;strokeColor=none;fillColor=none;align=center;verticalAlign=middle;fontSize=8;fontColor=#0499D4;" value="192.168.0.0/24" vertex="1">
+          <mxGeometry height="12" width="120" x="452" y="186" as="geometry" />
+        </mxCell>
+        <mxCell id="tun20-a" parent="1" style="text;html=1;whiteSpace=wrap;strokeColor=none;fillColor=none;align=center;verticalAlign=middle;fontSize=9;fontColor=#4DA72E;" value="VXLAN · VNI 20" vertex="1">
+          <mxGeometry height="14" width="120" x="452" y="344" as="geometry" />
+        </mxCell>
+        <mxCell id="tun20-b" parent="1" style="text;html=1;whiteSpace=wrap;strokeColor=none;fillColor=none;align=center;verticalAlign=middle;fontSize=8;fontColor=#4DA72E;" value="192.168.1.0/24" vertex="1">
+          <mxGeometry height="12" width="120" x="452" y="358" as="geometry" />
+        </mxCell>
+        <mxCell id="vtep1-box" parent="1" style="rounded=1;whiteSpace=wrap;html=1;fillColor=none;strokeColor=#0E9ED5;verticalAlign=top;spacingTop=4;fontSize=11;fontColor=#333333;" value="vtep1" vertex="1">
+          <mxGeometry height="170" width="150" x="250" y="175" as="geometry" />
+        </mxCell>
+        <mxCell id="vtep2-box" parent="1" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#F7FBFE;strokeColor=#0E9ED5;verticalAlign=top;spacingTop=4;fontSize=11;fontColor=#333333;" value="vtep2" vertex="1">
+          <mxGeometry height="64" width="118" x="640" y="155" as="geometry" />
+        </mxCell>
+        <mxCell id="vtep3-box" parent="1" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#F7FBFE;strokeColor=#0E9ED5;verticalAlign=top;spacingTop=4;fontSize=11;fontColor=#333333;" value="vtep3" vertex="1">
+          <mxGeometry height="64" width="118" x="640" y="340" as="geometry" />
+        </mxCell>
+        <mxCell id="br10-1" parent="1" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#EAF6FC;strokeColor=#0499D4;fontSize=9;fontColor=#333333;" value="br10 · VNI 10" vertex="1">
+          <mxGeometry height="48" width="118" x="266" y="205" as="geometry" />
+        </mxCell>
+        <mxCell id="br20-1" parent="1" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#EEF7E9;strokeColor=#4DA72E;fontSize=9;fontColor=#333333;" value="br20 · VNI 20" vertex="1">
+          <mxGeometry height="48" width="118" x="266" y="282" as="geometry" />
+        </mxCell>
+        <mxCell id="br10-2" parent="1" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#EAF6FC;strokeColor=#0499D4;fontSize=9;fontColor=#333333;" value="br10 · VNI 10" vertex="1">
+          <mxGeometry height="30" width="92" x="653" y="180" as="geometry" />
+        </mxCell>
+        <mxCell id="br20-3" parent="1" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#EEF7E9;strokeColor=#4DA72E;fontSize=9;fontColor=#333333;" value="br20 · VNI 20" vertex="1">
+          <mxGeometry height="30" width="92" x="653" y="365" as="geometry" />
+        </mxCell>
+        <mxCell id="h1" parent="1" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#0499D4;strokeColor=none;fontSize=10;fontColor=#FFFFFF;" value="h1" vertex="1">
+          <mxGeometry height="34" width="54" x="40" y="212" as="geometry" />
+        </mxCell>
+        <mxCell id="h4" parent="1" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#4DA72E;strokeColor=none;fontSize=10;fontColor=#FFFFFF;" value="h4" vertex="1">
+          <mxGeometry height="34" width="54" x="40" y="289" as="geometry" />
+        </mxCell>
+        <mxCell id="h2" parent="1" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#0499D4;strokeColor=none;fontSize=10;fontColor=#FFFFFF;" value="h2" vertex="1">
+          <mxGeometry height="34" width="54" x="822" y="178" as="geometry" />
+        </mxCell>
+        <mxCell id="h3" parent="1" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#4DA72E;strokeColor=none;fontSize=10;fontColor=#FFFFFF;" value="h3" vertex="1">
+          <mxGeometry height="34" width="54" x="822" y="363" as="geometry" />
+        </mxCell>
+        <mxCell id="addr-h1" parent="1" style="text;html=1;whiteSpace=wrap;strokeColor=none;fillColor=none;align=center;verticalAlign=middle;fontSize=8;fontColor=#333333;" value="172.16.10.1" vertex="1">
+          <mxGeometry height="12" width="90" x="22" y="250" as="geometry" />
+        </mxCell>
+        <mxCell id="addr-h4" parent="1" style="text;html=1;whiteSpace=wrap;strokeColor=none;fillColor=none;align=center;verticalAlign=middle;fontSize=8;fontColor=#333333;" value="172.16.10.4" vertex="1">
+          <mxGeometry height="12" width="90" x="22" y="329" as="geometry" />
+        </mxCell>
+        <mxCell id="addr-h2" parent="1" style="text;html=1;whiteSpace=wrap;strokeColor=none;fillColor=none;align=center;verticalAlign=middle;fontSize=8;fontColor=#333333;" value="172.16.10.2" vertex="1">
+          <mxGeometry height="12" width="90" x="804" y="218" as="geometry" />
+        </mxCell>
+        <mxCell id="addr-h3" parent="1" style="text;html=1;whiteSpace=wrap;strokeColor=none;fillColor=none;align=center;verticalAlign=middle;fontSize=8;fontColor=#333333;" value="172.16.10.3" vertex="1">
+          <mxGeometry height="12" width="90" x="804" y="403" as="geometry" />
+        </mxCell>
+        <mxCell id="addr-v1a" parent="1" style="text;html=1;whiteSpace=wrap;strokeColor=none;fillColor=none;align=center;verticalAlign=middle;fontSize=8;fontColor=#8A6D00;" value="192.168.0.1" vertex="1">
+          <mxGeometry height="12" width="90" x="387" y="203" as="geometry" />
+        </mxCell>
+        <mxCell id="addr-v1b" parent="1" style="text;html=1;whiteSpace=wrap;strokeColor=none;fillColor=none;align=center;verticalAlign=middle;fontSize=8;fontColor=#8A6D00;" value="192.168.1.1" vertex="1">
+          <mxGeometry height="12" width="90" x="387" y="330" as="geometry" />
+        </mxCell>
+        <mxCell id="addr-v2" parent="1" style="text;html=1;whiteSpace=wrap;strokeColor=none;fillColor=none;align=center;verticalAlign=middle;fontSize=8;fontColor=#8A6D00;" value="192.168.0.2" vertex="1">
+          <mxGeometry height="12" width="90" x="654" y="225" as="geometry" />
+        </mxCell>
+        <mxCell id="addr-v3" parent="1" style="text;html=1;whiteSpace=wrap;strokeColor=none;fillColor=none;align=center;verticalAlign=middle;fontSize=8;fontColor=#8A6D00;" value="192.168.1.2" vertex="1">
+          <mxGeometry height="12" width="90" x="654" y="324" as="geometry" />
+        </mxCell>
+        <mxCell id="caption" parent="1" style="text;html=1;whiteSpace=wrap;strokeColor=none;fillColor=none;align=center;verticalAlign=middle;fontSize=9;fontColor=#777777;" value="All four hosts share 172.16.10.0/24 — isolation is by VNI / route-target, not addressing; a ping succeeds only within its tenant." vertex="1">
+          <mxGeometry height="16" width="760" x="80" y="442" as="geometry" />
+        </mxCell>
+      </root>
+    </mxGraphModel>
+  </diagram>
+</mxfile>

--- a/playset/images/BgpEvpnVxlan4Multi.svg
+++ b/playset/images/BgpEvpnVxlan4Multi.svg
@@ -1,0 +1,77 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 920 470" font-family="Helvetica, Arial, sans-serif">
+  <!-- BGP EVPN VXLAN multi-tenant (IPv4 transport) — matches playset/bgp-evpn-vxlan4-multi.
+       Editable source: BgpEvpnVxlan4Multi.drawio (re-export from draw.io replaces this file). -->
+  <rect width="920" height="470" fill="#ffffff"/>
+
+  <!-- title -->
+  <text x="460" y="28" text-anchor="middle" font-size="15" fill="#333333">BGP EVPN VXLAN — multi-tenant</text>
+  <text x="460" y="46" text-anchor="middle" font-size="10" fill="#777777">iBGP AS 65001 · VXLAN UDP 4789 · vtep1 serves both tenants (br10 = VNI 10, br20 = VNI 20)</text>
+
+  <!-- tenant flood domains (VLAN IDs scoped per bridge: two separate broadcast domains) -->
+  <rect x="20" y="145" width="878" height="117" rx="8" fill="none" stroke="#0499D4" stroke-dasharray="6,4"/>
+  <rect x="20" y="262" width="878" height="156" rx="8" fill="none" stroke="#4DA72E" stroke-dasharray="6,4"/>
+  <text x="30" y="161" font-size="12" fill="#0499D4">VNI 10 flood domain · RT 65001:10</text>
+  <text x="30" y="410" font-size="12" fill="#4DA72E">VNI 20 flood domain · RT 65001:20</text>
+
+  <!-- access links -->
+  <line x1="94" y1="229" x2="266" y2="229" stroke="#0499D4" stroke-width="1.5"/>
+  <line x1="94" y1="306" x2="266" y2="306" stroke="#4DA72E" stroke-width="1.5"/>
+  <line x1="758" y1="195" x2="822" y2="195" stroke="#0499D4" stroke-width="1.5"/>
+  <line x1="758" y1="380" x2="822" y2="380" stroke="#4DA72E" stroke-width="1.5"/>
+
+  <!-- VXLAN tunnels, one per tenant, each on its own underlay link -->
+  <line x1="384" y1="229" x2="640" y2="195" stroke="#0499D4" stroke-width="3"/>
+  <line x1="384" y1="306" x2="640" y2="380" stroke="#4DA72E" stroke-width="3"/>
+  <text x="512" y="181" text-anchor="middle" font-size="9" fill="#0499D4">VXLAN · VNI 10</text>
+  <text x="512" y="194" text-anchor="middle" font-size="8" fill="#0499D4">192.168.0.0/24</text>
+  <text x="512" y="353" text-anchor="middle" font-size="9" fill="#4DA72E">VXLAN · VNI 20</text>
+  <text x="512" y="366" text-anchor="middle" font-size="8" fill="#4DA72E">192.168.1.0/24</text>
+
+  <!-- VTEP boxes (vtep1 unfilled so the tenant boundary shows through) -->
+  <rect x="250" y="175" width="150" height="170" rx="6" fill="none" stroke="#0E9ED5"/>
+  <rect x="640" y="155" width="118" height="64" rx="6" fill="#F7FBFE" stroke="#0E9ED5"/>
+  <rect x="640" y="340" width="118" height="64" rx="6" fill="#F7FBFE" stroke="#0E9ED5"/>
+  <text x="325" y="192" text-anchor="middle" font-size="11" fill="#333333">vtep1</text>
+  <text x="699" y="170" text-anchor="middle" font-size="11" fill="#333333">vtep2</text>
+  <text x="699" y="355" text-anchor="middle" font-size="11" fill="#333333">vtep3</text>
+
+  <!-- bridges (per tenant, colour-coded) -->
+  <g font-size="9" text-anchor="middle" fill="#333333">
+    <rect x="266" y="205" width="118" height="48" rx="4" fill="#EAF6FC" stroke="#0499D4"/>
+    <text x="325" y="232">br10 · VNI 10</text>
+    <rect x="266" y="282" width="118" height="48" rx="4" fill="#EEF7E9" stroke="#4DA72E"/>
+    <text x="325" y="309">br20 · VNI 20</text>
+    <rect x="653" y="180" width="92" height="30" rx="4" fill="#EAF6FC" stroke="#0499D4"/>
+    <text x="699" y="199">br10 · VNI 10</text>
+    <rect x="653" y="365" width="92" height="30" rx="4" fill="#EEF7E9" stroke="#4DA72E"/>
+    <text x="699" y="384">br20 · VNI 20</text>
+  </g>
+
+  <!-- hosts -->
+  <g font-size="10" text-anchor="middle" fill="#ffffff">
+    <rect x="40" y="212" width="54" height="34" rx="6" fill="#0499D4"/>
+    <text x="67" y="233">h1</text>
+    <rect x="40" y="289" width="54" height="34" rx="6" fill="#4DA72E"/>
+    <text x="67" y="310">h4</text>
+    <rect x="822" y="178" width="54" height="34" rx="6" fill="#0499D4"/>
+    <text x="849" y="199">h2</text>
+    <rect x="822" y="363" width="54" height="34" rx="6" fill="#4DA72E"/>
+    <text x="849" y="384">h3</text>
+  </g>
+
+  <!-- addresses -->
+  <g font-size="8" text-anchor="middle">
+    <text x="67" y="258" fill="#333333">172.16.10.1</text>
+    <text x="67" y="337" fill="#333333">172.16.10.4</text>
+    <text x="849" y="226" fill="#333333">172.16.10.2</text>
+    <text x="849" y="411" fill="#333333">172.16.10.3</text>
+    <text x="432" y="210" fill="#8a6d00">192.168.0.1</text>
+    <text x="432" y="337" fill="#8a6d00">192.168.1.1</text>
+    <text x="699" y="232" fill="#8a6d00">192.168.0.2</text>
+    <text x="699" y="331" fill="#8a6d00">192.168.1.2</text>
+  </g>
+
+  <!-- caption -->
+  <text x="460" y="450" text-anchor="middle" font-size="9" fill="#777777">All four hosts share 172.16.10.0/24 — isolation is by VNI / route-target, not addressing; a ping succeeds only within its tenant.</text>
+</svg>


### PR DESCRIPTION
## Summary

Adds draw.io topology diagrams for the two IPv4-transport EVPN VXLAN
playsets and embeds them in each README, replacing the ASCII diagrams —
mirroring how `interas-option-a` swapped its ASCII art for a rendered SVG.

Each diagram ships as an editable `.drawio` source plus a rendered `.svg`,
reusing the palette and node / dashed-domain / data-plane-band idiom of the
existing `InterASOptionA` / `InterASOptionB` images in `playset/images/`.

- **`BgpEvpnVxlan4`** (`bgp-evpn-vxlan4`): `h1 — vtep1 ═ VXLAN tunnel ═ vtep2 — h2`
  over one stretched L2 segment (VNI 10, 172.16.10.0/24). VTEPs expose their
  `br10` bridge + `vxlan10` device; the iBGP EVPN control-plane session
  (Type-3 IMET / Type-2 MAC) is drawn separately from the orange data-plane
  tunnel, with an `Ethernet | VXLAN over IP | Ethernet` encapsulation band.
- **`BgpEvpnVxlan4Multi`** (`bgp-evpn-vxlan4-multi`): two stacked flood
  domains (VNI 10 / VNI 20, RT 65001:10 / :20) whose shared boundary bisects
  the multi-tenant `vtep1` (`br10` above, `br20` below), colour-coded per
  tenant, each tenant on its own underlay link (192.168.0.0/24 / .1.0/24).
  Caption reinforces the demo: all hosts share 172.16.10.0/24; isolation is
  by VNI/route-target, not addressing.

## Files

- `playset/images/BgpEvpnVxlan4.{drawio,svg}` (new)
- `playset/images/BgpEvpnVxlan4Multi.{drawio,svg}` (new)
- `playset/bgp-evpn-vxlan4/README.md` — ASCII block → `<img>`
- `playset/bgp-evpn-vxlan4-multi/README.md` — ASCII block → `<img>`

## Test plan

- Both SVGs rasterized with `cairosvg` and visually inspected against the
  playset topology / addressing in each README and `topology.sh`.
- All four XML files pass well-formedness checks; draw.io edges verified to
  have no dangling vertex references.
- Docs/images only — no code changes.

Generated with [Claude Code](https://claude.com/claude-code)