### PR TITLE
bgp: add next-hop-unchanged; playset interas-option-c-rr

### DIFF
--- a/playset/README.md
+++ b/playset/README.md
@@ -120,6 +120,7 @@ customers, and overlapping addressing; only the border model changes:
 | [interas-option-a](interas-option-a/README.md) | Option A — back-to-back VRFs: a dedicated link and a plain eBGP IPv4 session per customer between the ASBRs, MPLS never crossing the boundary. Two ASes with independent RD/RT spaces, two customers with deliberately overlapping addressing, and a three-point capture of one ping riding MPLS → plain IP → MPLS |
 | [interas-option-b](interas-option-b/README.md) | Option B — one eBGP VPNv4 session between the ASBRs carries every customer, MPLS crossing the boundary as a single label switch. Same lab as Option A with only the border changed: no VRFs on the ASBRs, coordinated RTs (independent RDs), per-route swap ILMs, and the far AS's RDs relayed unchanged |
 | [interas-option-c](interas-option-c/README.md) | Option C — the ASBRs exchange only labeled PE loopbacks (BGP-LU) and hold zero VPN state; the PEs peer VPNv4 directly over a multihop eBGP session, and a three-label stack (SR transport, BGP-LU, VPN) rides from PE to PE — two labels crossing the boundary, completing the 0/1/2-label arc across A/B/C |
+| [interas-option-c-rr](interas-option-c-rr/README.md) | Option C, RR-based — Cisco's reference design: each AS adds a route reflector, the RRs exchange VPNv4 over a multihop eBGP session with `next-hop-unchanged`, and the PEs peer only with their local RR. Same data plane as the direct-PE lab; the RRs hold every VPN route and forward none of the traffic |
 
 ## Directory layout
 

--- a/playset/images/InterASOptionCRR.drawio
+++ b/playset/images/InterASOptionCRR.drawio
@@ -1,0 +1,125 @@
+<mxfile host="Electron">
+  <diagram name="ページ-1" id="wnrBHP6oeohz2G5kKjIC">
+    <mxGraphModel dx="854" dy="784" grid="1" gridSize="10" guides="1" tooltips="1" connect="1" arrows="1" fold="1" page="1" pageScale="1" pageWidth="827" pageHeight="1169" background="#FFFFFF" math="0" shadow="0">
+      <root>
+        <mxCell id="0" />
+        <mxCell id="1" parent="0" />
+        <mxCell id="as1-box" parent="1" style="rounded=1;whiteSpace=wrap;html=1;fillColor=none;dashed=1;strokeColor=#999999;" value="" vertex="1">
+          <mxGeometry height="235" width="270" x="90" y="185" as="geometry" />
+        </mxCell>
+        <mxCell id="as2-box" parent="1" style="rounded=1;whiteSpace=wrap;html=1;fillColor=none;dashed=1;strokeColor=#999999;" value="" vertex="1">
+          <mxGeometry height="235" width="270" x="480" y="185" as="geometry" />
+        </mxCell>
+        <mxCell id="as1-label" parent="1" style="text;html=1;whiteSpace=wrap;strokeColor=none;fillColor=none;align=center;verticalAlign=middle;rounded=0;autosize=1;resizable=0;fontSize=11;" value="AS 65501" vertex="1">
+          <mxGeometry height="30" width="70" x="145" y="185" as="geometry" />
+        </mxCell>
+        <mxCell id="as2-label" parent="1" style="text;html=1;whiteSpace=wrap;strokeColor=none;fillColor=none;align=center;verticalAlign=middle;rounded=0;autosize=1;resizable=0;fontSize=11;" value="AS 65502" vertex="1">
+          <mxGeometry height="30" width="70" x="625" y="185" as="geometry" />
+        </mxCell>
+        <mxCell id="edge-rr-rr" edge="1" parent="1" source="rr1" style="endArrow=none;html=1;rounded=0;curved=1;dashed=1;strokeColor=#B8860B;exitX=0.5;exitY=0;exitDx=0;exitDy=0;entryX=0.5;entryY=0;entryDx=0;entryDy=0;" target="rr2" value="">
+          <mxGeometry height="50" relative="1" width="50" as="geometry">
+            <Array as="points">
+              <mxPoint x="415" y="140" />
+            </Array>
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="rr-rr-label" parent="1" style="text;html=1;whiteSpace=wrap;strokeColor=none;fillColor=none;align=center;verticalAlign=middle;rounded=0;fontSize=9;fontColor=#B8860B;" value="multihop eBGP VPNv4, next-hop-unchanged" vertex="1">
+          <mxGeometry height="14" width="230" x="300" y="125" as="geometry" />
+        </mxCell>
+        <mxCell id="edge-pe1-rr1" edge="1" parent="1" source="pe1" style="endArrow=none;html=1;rounded=0;dashed=1;dashPattern=3 3;strokeColor=#B8860B;" target="rr1" value="iBGP VPNv4 (client)">
+          <mxGeometry height="50" relative="1" width="50" as="geometry" />
+        </mxCell>
+        <mxCell id="edge-pe2-rr2" edge="1" parent="1" source="pe2" style="endArrow=none;html=1;rounded=0;dashed=1;dashPattern=3 3;strokeColor=#B8860B;" target="rr2" value="iBGP VPNv4 (client)">
+          <mxGeometry height="50" relative="1" width="50" as="geometry" />
+        </mxCell>
+        <mxCell id="edge-rr1-p1" edge="1" parent="1" source="rr1" style="endArrow=none;html=1;rounded=0;strokeColor=#A02C93;" target="p1" value="">
+          <mxGeometry height="50" relative="1" width="50" as="geometry" />
+        </mxCell>
+        <mxCell id="edge-rr2-p2" edge="1" parent="1" source="rr2" style="endArrow=none;html=1;rounded=0;strokeColor=#A02C93;" target="p2" value="">
+          <mxGeometry height="50" relative="1" width="50" as="geometry" />
+        </mxCell>
+        <mxCell id="edge-ce1-pe1" edge="1" parent="1" source="ce1" style="endArrow=none;html=1;rounded=0;strokeColor=#0499D4;" target="pe1" value="">
+          <mxGeometry height="50" relative="1" width="50" as="geometry" />
+        </mxCell>
+        <mxCell id="edge-ce2-pe1" edge="1" parent="1" source="ce2" style="endArrow=none;html=1;rounded=0;strokeColor=#4DA72E;" target="pe1" value="">
+          <mxGeometry height="50" relative="1" width="50" as="geometry" />
+        </mxCell>
+        <mxCell id="edge-pe1-p1" edge="1" parent="1" source="pe1" style="endArrow=none;html=1;rounded=0;strokeColor=#A02C93;" target="p1" value="">
+          <mxGeometry height="50" relative="1" width="50" as="geometry" />
+        </mxCell>
+        <mxCell id="edge-p1-asbr1" edge="1" parent="1" source="p1" style="endArrow=none;html=1;rounded=0;strokeColor=#A02C93;" target="asbr1" value="">
+          <mxGeometry height="50" relative="1" width="50" as="geometry" />
+        </mxCell>
+        <mxCell id="edge-asbr2-p2" edge="1" parent="1" source="asbr2" style="endArrow=none;html=1;rounded=0;strokeColor=#A02C93;" target="p2" value="">
+          <mxGeometry height="50" relative="1" width="50" as="geometry" />
+        </mxCell>
+        <mxCell id="edge-p2-pe2" edge="1" parent="1" source="p2" style="endArrow=none;html=1;rounded=0;strokeColor=#A02C93;" target="pe2" value="">
+          <mxGeometry height="50" relative="1" width="50" as="geometry" />
+        </mxCell>
+        <mxCell id="edge-pe2-ce3" edge="1" parent="1" source="pe2" style="endArrow=none;html=1;rounded=0;strokeColor=#0499D4;" target="ce3" value="">
+          <mxGeometry height="50" relative="1" width="50" as="geometry" />
+        </mxCell>
+        <mxCell id="edge-pe2-ce4" edge="1" parent="1" source="pe2" style="endArrow=none;html=1;rounded=0;strokeColor=#4DA72E;" target="ce4" value="">
+          <mxGeometry height="50" relative="1" width="50" as="geometry" />
+        </mxCell>
+        <mxCell id="edge-interas" edge="1" parent="1" source="asbr1" style="endArrow=none;html=1;rounded=0;strokeColor=#E97131;strokeWidth=2;" target="asbr2" value="">
+          <mxGeometry height="50" relative="1" width="50" as="geometry" />
+        </mxCell>
+        <mxCell id="interas-label" parent="1" style="text;html=1;whiteSpace=wrap;strokeColor=none;fillColor=none;align=center;verticalAlign=middle;rounded=0;fontSize=8;fontColor=#E97131;" value="eBGP labeled-unicast (BGP-LU)" vertex="1">
+          <mxGeometry height="14" width="160" x="335" y="307" as="geometry" />
+        </mxCell>
+        <mxCell id="rr1" parent="1" style="ellipse;whiteSpace=wrap;html=1;aspect=fixed;strokeColor=#0E9ED5;fillColor=#FFFFFF;fontSize=8;" value="rr1" vertex="1">
+          <mxGeometry height="30" width="30" x="230" y="205" as="geometry" />
+        </mxCell>
+        <mxCell id="rr2" parent="1" style="ellipse;whiteSpace=wrap;html=1;aspect=fixed;strokeColor=#0E9ED5;fillColor=#FFFFFF;fontSize=8;" value="rr2" vertex="1">
+          <mxGeometry height="30" width="30" x="570" y="205" as="geometry" />
+        </mxCell>
+        <mxCell id="pe1" parent="1" style="ellipse;whiteSpace=wrap;html=1;aspect=fixed;strokeColor=#0E9ED5;fillColor=#FFFFFF;fontSize=8;" value="pe1" vertex="1">
+          <mxGeometry height="30" width="30" x="150" y="315" as="geometry" />
+        </mxCell>
+        <mxCell id="p1" parent="1" style="ellipse;whiteSpace=wrap;html=1;aspect=fixed;strokeColor=#0E9ED5;fillColor=#FFFFFF;fontSize=8;" value="p1" vertex="1">
+          <mxGeometry height="30" width="30" x="230" y="315" as="geometry" />
+        </mxCell>
+        <mxCell id="asbr1" parent="1" style="ellipse;whiteSpace=wrap;html=1;aspect=fixed;strokeColor=#0E9ED5;fillColor=#FFFFFF;fontSize=8;" value="asbr1" vertex="1">
+          <mxGeometry height="30" width="30" x="310" y="315" as="geometry" />
+        </mxCell>
+        <mxCell id="asbr2" parent="1" style="ellipse;whiteSpace=wrap;html=1;aspect=fixed;strokeColor=#0E9ED5;fillColor=#FFFFFF;fontSize=8;" value="asbr2" vertex="1">
+          <mxGeometry height="30" width="30" x="490" y="315" as="geometry" />
+        </mxCell>
+        <mxCell id="p2" parent="1" style="ellipse;whiteSpace=wrap;html=1;aspect=fixed;strokeColor=#0E9ED5;fillColor=#FFFFFF;fontSize=8;" value="p2" vertex="1">
+          <mxGeometry height="30" width="30" x="570" y="315" as="geometry" />
+        </mxCell>
+        <mxCell id="pe2" parent="1" style="ellipse;whiteSpace=wrap;html=1;aspect=fixed;strokeColor=#0E9ED5;fillColor=#FFFFFF;fontSize=8;" value="pe2" vertex="1">
+          <mxGeometry height="30" width="30" x="650" y="315" as="geometry" />
+        </mxCell>
+        <mxCell id="ce1" parent="1" style="rounded=1;whiteSpace=wrap;html=1;fillStyle=solid;fillColor=#0499D4;strokeColor=none;fontSize=8;fontColor=#FFFFFF;" value="ce1" vertex="1">
+          <mxGeometry height="25" width="40" x="20" y="280" as="geometry" />
+        </mxCell>
+        <mxCell id="ce2" parent="1" style="rounded=1;whiteSpace=wrap;html=1;fillStyle=solid;fillColor=#4DA72E;strokeColor=none;fontSize=8;fontColor=#FFFFFF;" value="ce2" vertex="1">
+          <mxGeometry height="25" width="40" x="20" y="355" as="geometry" />
+        </mxCell>
+        <mxCell id="ce3" parent="1" style="rounded=1;whiteSpace=wrap;html=1;fillStyle=solid;fillColor=#0499D4;strokeColor=none;fontSize=8;fontColor=#FFFFFF;" value="ce3" vertex="1">
+          <mxGeometry height="25" width="40" x="770" y="280" as="geometry" />
+        </mxCell>
+        <mxCell id="ce4" parent="1" style="rounded=1;whiteSpace=wrap;html=1;fillStyle=solid;fillColor=#4DA72E;strokeColor=none;fontSize=8;fontColor=#FFFFFF;" value="ce4" vertex="1">
+          <mxGeometry height="25" width="40" x="770" y="355" as="geometry" />
+        </mxCell>
+        <mxCell id="dp-ip-left" parent="1" style="rounded=0;whiteSpace=wrap;html=1;strokeColor=#999999;fontSize=11;" value="IP" vertex="1">
+          <mxGeometry height="20" width="110" x="25" y="443" as="geometry" />
+        </mxCell>
+        <mxCell id="dp-mpls-as1" parent="1" style="shape=cylinder3;whiteSpace=wrap;html=1;boundedLbl=1;backgroundOutline=1;size=3.285714285714164;direction=south;strokeColor=#808080;fillColor=light-dark(#99CCFF,#2566A8);fontColor=#000000;fontSize=11;" value="MPLS" vertex="1">
+          <mxGeometry height="20" width="190" x="150" y="443" as="geometry" />
+        </mxCell>
+        <mxCell id="dp-mpls-interas" parent="1" style="shape=cylinder3;whiteSpace=wrap;html=1;boundedLbl=1;backgroundOutline=1;size=3.285714285714164;direction=south;strokeColor=#808080;fillColor=light-dark(#FBE5D6,#7A4A21);fontColor=#000000;fontSize=11;" value="MPLS" vertex="1">
+          <mxGeometry height="20" width="135" x="352" y="443" as="geometry" />
+        </mxCell>
+        <mxCell id="dp-mpls-as2" parent="1" style="shape=cylinder3;whiteSpace=wrap;html=1;boundedLbl=1;backgroundOutline=1;size=3.285714285714164;direction=south;strokeColor=#808080;fillColor=light-dark(#A5E798,#003900);fontColor=#000000;fontSize=11;" value="MPLS" vertex="1">
+          <mxGeometry height="20" width="190" x="500" y="443" as="geometry" />
+        </mxCell>
+        <mxCell id="dp-ip-right" parent="1" style="rounded=0;whiteSpace=wrap;html=1;strokeColor=#999999;fontSize=11;" value="IP" vertex="1">
+          <mxGeometry height="20" width="110" x="702" y="443" as="geometry" />
+        </mxCell>
+      </root>
+    </mxGraphModel>
+  </diagram>
+</mxfile>

--- a/playset/images/InterASOptionCRR.svg
+++ b/playset/images/InterASOptionCRR.svg
@@ -1,0 +1,93 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 830 350" font-family="Helvetica, Arial, sans-serif">
+  <!-- Inter-AS Option C, RR-based (Cisco reference design)
+       — matches playset/interas-option-c-rr.
+       Editable source: InterASOptionCRR.drawio (re-export from draw.io replaces this file). -->
+  <rect width="830" height="350" fill="#ffffff"/>
+
+  <!-- inter-RR multihop eBGP VPNv4 session with next-hop-unchanged -->
+  <path d="M 245,85 Q 415,-45 585,85" fill="none" stroke="#B8860B" stroke-width="1.5" stroke-dasharray="6,4"/>
+  <text x="415" y="16" text-anchor="middle" font-size="9" fill="#B8860B">multihop eBGP VPNv4, next-hop-unchanged</text>
+
+  <!-- AS boxes -->
+  <rect x="90" y="55" width="270" height="235" rx="8" fill="none" stroke="#999999" stroke-dasharray="6,4"/>
+  <rect x="480" y="55" width="270" height="235" rx="8" fill="none" stroke="#999999" stroke-dasharray="6,4"/>
+  <text x="180" y="73" text-anchor="middle" font-size="12" fill="#333333">AS 65501</text>
+  <text x="660" y="73" text-anchor="middle" font-size="12" fill="#333333">AS 65502</text>
+
+  <!-- PE-RR iBGP VPNv4 client sessions -->
+  <line x1="172" y1="186" x2="238" y2="112" stroke="#B8860B" stroke-width="1.2" stroke-dasharray="3,3"/>
+  <line x1="658" y1="186" x2="592" y2="112" stroke="#B8860B" stroke-width="1.2" stroke-dasharray="3,3"/>
+  <text x="166" y="140" text-anchor="middle" font-size="8" fill="#B8860B">iBGP VPNv4</text>
+  <text x="164" y="150" text-anchor="middle" font-size="8" fill="#B8860B">(RR client)</text>
+  <text x="664" y="140" text-anchor="middle" font-size="8" fill="#B8860B">iBGP VPNv4</text>
+  <text x="666" y="150" text-anchor="middle" font-size="8" fill="#B8860B">(RR client)</text>
+
+  <!-- RR attachment links -->
+  <line x1="245" y1="100" x2="245" y2="200" stroke="#A02C93" stroke-width="1.5"/>
+  <line x1="585" y1="100" x2="585" y2="200" stroke="#A02C93" stroke-width="1.5"/>
+
+  <!-- CE-PE links -->
+  <line x1="60" y1="162" x2="165" y2="200" stroke="#0499D4" stroke-width="1.5"/>
+  <line x1="60" y1="238" x2="165" y2="200" stroke="#4DA72E" stroke-width="1.5"/>
+  <line x1="665" y1="200" x2="770" y2="162" stroke="#0499D4" stroke-width="1.5"/>
+  <line x1="665" y1="200" x2="770" y2="238" stroke="#4DA72E" stroke-width="1.5"/>
+
+  <!-- intra-AS core links -->
+  <line x1="165" y1="200" x2="245" y2="200" stroke="#A02C93" stroke-width="1.5"/>
+  <line x1="245" y1="200" x2="325" y2="200" stroke="#A02C93" stroke-width="1.5"/>
+  <line x1="505" y1="200" x2="585" y2="200" stroke="#A02C93" stroke-width="1.5"/>
+  <line x1="585" y1="200" x2="665" y2="200" stroke="#A02C93" stroke-width="1.5"/>
+
+  <!-- inter-AS link: BGP-LU only, PE + RR loopbacks with labels -->
+  <line x1="340" y1="200" x2="490" y2="200" stroke="#E97131" stroke-width="2.5"/>
+  <text x="415" y="190" text-anchor="middle" font-size="9" fill="#E97131">eBGP labeled-unicast (BGP-LU)</text>
+
+  <!-- routers -->
+  <g stroke="#0E9ED5" stroke-width="1.5" fill="#ffffff">
+    <circle cx="245" cy="90" r="15"/>
+    <circle cx="585" cy="90" r="15"/>
+    <circle cx="165" cy="200" r="15"/>
+    <circle cx="245" cy="200" r="15"/>
+    <circle cx="325" cy="200" r="15"/>
+    <circle cx="505" cy="200" r="15"/>
+    <circle cx="585" cy="200" r="15"/>
+    <circle cx="665" cy="200" r="15"/>
+  </g>
+  <g text-anchor="middle" font-size="8" fill="#333333">
+    <text x="245" y="93">rr1</text>
+    <text x="585" y="93">rr2</text>
+    <text x="165" y="203">pe1</text>
+    <text x="245" y="203">p1</text>
+    <text x="325" y="203">asbr1</text>
+    <text x="505" y="203">asbr2</text>
+    <text x="585" y="203">p2</text>
+    <text x="665" y="203">pe2</text>
+  </g>
+
+  <!-- customer edges -->
+  <g font-size="9" text-anchor="middle" fill="#ffffff">
+    <rect x="20" y="150" width="40" height="25" rx="5" fill="#0499D4"/>
+    <text x="40" y="166">ce1</text>
+    <rect x="20" y="225" width="40" height="25" rx="5" fill="#4DA72E"/>
+    <text x="40" y="241">ce2</text>
+    <rect x="770" y="150" width="40" height="25" rx="5" fill="#0499D4"/>
+    <text x="790" y="166">ce3</text>
+    <rect x="770" y="225" width="40" height="25" rx="5" fill="#4DA72E"/>
+    <text x="790" y="241">ce4</text>
+  </g>
+
+  <!-- data plane bands: identical to the direct-PE Option C lab -->
+  <g font-size="11" text-anchor="middle">
+    <rect x="25" y="313" width="110" height="20" fill="none" stroke="#999999"/>
+    <text x="80" y="327" fill="#333333">IP</text>
+    <rect x="150" y="313" width="190" height="20" rx="10" fill="#99CCFF" stroke="#808080"/>
+    <text x="245" y="327" fill="#000000">MPLS</text>
+    <rect x="352" y="313" width="135" height="20" rx="10" fill="#FBE5D6" stroke="#808080"/>
+    <text x="419" y="327" fill="#000000">MPLS</text>
+    <rect x="500" y="313" width="190" height="20" rx="10" fill="#A5E798" stroke="#808080"/>
+    <text x="595" y="327" fill="#000000">MPLS</text>
+    <rect x="702" y="313" width="110" height="20" fill="none" stroke="#999999"/>
+    <text x="757" y="327" fill="#333333">IP</text>
+  </g>
+</svg>

--- a/playset/interas-option-c-rr/README.md
+++ b/playset/interas-option-c-rr/README.md
@@ -1,0 +1,305 @@
+# Inter-AS L3VPN Option C with Route Reflectors — Cisco's reference design
+
+The [direct-PE Option C playset](../interas-option-c/README.md) wires the
+two PEs' multihop VPNv4 session straight to each other. That is legitimate
+RFC 4364 §10c — but it is not how Cisco's configuration guide (*MPLS VPN
+Inter-AS with ASBRs Exchanging IPv4 Routes and MPLS Labels*) draws the
+design. Cisco's reference topology puts a **route reflector in each AS**:
+
+> Route reflectors (RRs) exchange VPN-IPv4 routes by using multihop,
+> multiprotocol, external Border Gateway Protocol (eBGP). […] Using the
+> route reflectors to store the VPN-IPv4 routes and forward them to the
+> PE routers results in improved scalability compared with configurations
+> where the ASBR holds all of the VPN-IPv4 routes.
+
+This playset builds exactly that: the PEs peer VPNv4 **only with their
+local RR**; the RRs peer **multihop eBGP VPNv4 with each other** across
+the ASes; and — the design's load-bearing detail — the inter-RR session
+runs with **`next-hop-unchanged`**, because the RRs sit *outside* the
+forwarding path. A reflected route must keep the originating PE (the true
+LSP endpoint) as its next hop, and keep that PE's VPN label; the default
+eBGP rewrite-to-self would pull traffic toward a router that does not
+forward it. The border ASBRs are unchanged from the direct-PE lab:
+labeled loopbacks (BGP-LU) only, zero VPN state.
+
+```
+           rr1 ══ multihop eBGP VPNv4, next-hop-unchanged ══ rr2
+            │                                                 │
+  ce1 ─┐   iBGP VPNv4 (client)                (client) iBGP  │   ┌─ ce3   cust1
+       pe1 ─┴─ p1 ── asbr1 ═══ eBGP BGP-LU ═══ asbr2 ── p2 ──┴─ pe2
+  ce2 ─┘         AS 65501    (PE + RR loopbacks)  AS 65502       └─ ce4   cust2
+```
+
+The data plane is **byte-for-byte the one from the direct-PE lab** — a
+three-label stack at ingress, two labels crossing the border, the ASBRs
+switching the middle label. Only the control plane changed; the
+walkthrough proves both halves.
+
+## Bring up all nodes
+
+``` shell
+$ ./up.sh
+bring up
+...
+apply config: ce3
+applied
+apply config: ce4
+applied
+```
+
+Twelve namespaces — the ten from the Option A/B/C labs plus `rr1` and
+`rr2` (one per AS, attached to the P router, loopbacks `1.1.1.9` /
+`2.2.2.9`). Bring up only one Inter-AS lab at a time. Convergence is
+layered: IGP → BGP-LU → the inter-RR session (its TCP rides the LU
+routes) → VPNv4 — allow a minute.
+
+## The route reflector
+
+`rr1.yaml`'s BGP section carries the whole design:
+
+``` yaml
+  bgp:
+    global:
+      as: 65501
+      router-id: 1.1.1.9
+    neighbor:
+    - remote-address: 1.1.1.1        # PE1 — VPNv4 route-reflector client
+      remote-as: 65501
+      update-source: 1.1.1.9
+      route-reflector:
+        client: true
+      afi-safi:
+      - name: vpnv4
+        enabled: true
+    - remote-address: 1.1.1.3        # ASBR1 — labeled-unicast only
+      remote-as: 65501
+      update-source: 1.1.1.9
+      afi-safi:
+      - name: label-v4
+        enabled: true
+    - remote-address: 2.2.2.9        # RR2 — multihop eBGP VPNv4
+      remote-as: 65502
+      ebgp-multihop: 10
+      update-source: 1.1.1.9
+      afi-safi:
+      - name: vpnv4
+        enabled: true
+        next-hop-unchanged: true     # <- THE RR-based Option C knob
+    afi-safi:
+    - name: label-v4
+      network:
+      - prefix: 1.1.1.9/32           # the RR loopback joins BGP-LU too
+```
+
+Three things to read out of it:
+
+* **`route-reflector: client: true`** on the PE session — the RR reflects
+  between its iBGP clients (with one PE per AS this lab never needs an
+  actual iBGP-to-iBGP reflection, but the marking is the Cisco design,
+  and adding a second PE would need nothing else).
+* **`next-hop-unchanged: true`** on the inter-RR eBGP session. Without
+  it, eBGP rewrites the next hop to the advertising RR — a router with
+  no VRFs, no customer FIB, and no intention of forwarding. With it, the
+  route crosses carrying the originating PE's loopback *and the
+  originating PE's VPN label* untouched.
+* **The RR loopback is originated into BGP-LU** exactly like a PE
+  loopback: RR2 can only establish (and route the TCP of) the multihop
+  session if `1.1.1.9/32` is reachable — as a labeled route — from
+  inside AS 65502. The ASBRs relay it with the same next-hop-self +
+  swap-label machinery as the PE loopbacks; their state grows from two
+  loopbacks to four, still zero VPN routes.
+
+In classic Cisco IOS terms:
+
+```
+router bgp 65501
+ neighbor 1.1.1.1 remote-as 65501           ! PE1
+ neighbor 2.2.2.9 remote-as 65502           ! RR2, two IGPs away
+ neighbor 2.2.2.9 ebgp-multihop 10
+ neighbor 2.2.2.9 update-source Loopback0
+ address-family vpnv4
+  neighbor 1.1.1.1 activate
+  neighbor 1.1.1.1 route-reflector-client
+  neighbor 2.2.2.9 activate
+  neighbor 2.2.2.9 next-hop-unchanged       ! the knob
+```
+
+The PEs shrink accordingly — `pe1.yaml`'s VPNv4 session now points at
+`1.1.1.9` (iBGP, local RR) instead of the far PE; it never learns the
+other provider exists. The CEs, P routers, and ASBRs are byte-identical
+in role to the direct-PE lab (the ASBRs gain one more iBGP-LU neighbor —
+the RR).
+
+## Control plane: the RR holds everything, forwards nothing
+
+``` shell
+$ sudo ip netns exec rr1 vty
+rr1>show bgp summary
+...
+IPv4 Labeled Unicast Summary:
+Neighbor        V         AS   MsgRcvd   MsgSent   TblVer  InQ OutQ  Up/Down State       PfxRcd/Snt Hostname
+1.1.1.3         4      65501         5         3        0    0    0 00:00:57 Established        2/1 s
+
+VPNv4 Unicast Summary:
+Neighbor        V         AS   MsgRcvd   MsgSent   TblVer  InQ OutQ  Up/Down State       PfxRcd/Snt Hostname
+1.1.1.1         4      65501         6         2        0    0    0 00:00:57 Established        4/4 s
+2.2.2.9         4      65502         6         2        0    0    0 00:00:54 Established        4/4 s
+
+rr1>show bgp vpnv4
+     Network          Next Hop            Metric LocPrf Weight Path
+Route Distinguisher: 65501:1
+ *>i [1] 10.11.0.0/30       1.1.1.1                  0    100      0 65511 i
+     rt:65501:100 label=16,
+ *>i [1] 172.16.1.1/32      1.1.1.1                  0    100      0 65511 i
+     rt:65501:100 label=16,
+Route Distinguisher: 65501:2
+ *>i [1] 10.12.0.0/30       1.1.1.1                  0    100      0 65512 i
+     rt:65501:200 label=17,
+ *>i [1] 172.16.1.1/32      1.1.1.1                  0    100      0 65512 i
+     rt:65501:200 label=17,
+Route Distinguisher: 65502:1
+ *>  [1] 10.13.0.0/30       2.2.2.3                  0             0 65502 65513 i
+     rt:65501:100 label=16,
+ *>  [1] 172.16.2.1/32      2.2.2.3                  0             0 65502 65513 i
+     rt:65501:100 label=16,
+Route Distinguisher: 65502:2
+ *>  [1] 10.14.0.0/30       2.2.2.3                  0             0 65502 65514 i
+     rt:65501:200 label=17,
+ *>  [1] 172.16.2.1/32      2.2.2.3                  0             0 65502 65514 i
+     rt:65501:200 label=17,
+```
+
+The RR holds all eight VPN routes — that is Cisco's point, the VPN state
+lives here instead of on the border — but look at the **Next Hop
+column: the RR's own address appears nowhere.** The local rows carry PE1
+(`1.1.1.1`, iBGP from the client); the far rows arrived over the *eBGP*
+session from RR2, yet still carry PE2 (`2.2.2.3`) — that is
+`next-hop-unchanged` doing its one job. The labels (`16`/`17`) are the
+PEs' per-VRF labels, relayed untouched; nobody along the reflection path
+allocated a transit label.
+
+PE1 receives the reflection with nothing rewritten, and resolves the far
+PE over BGP-LU exactly as in the direct-PE lab:
+
+``` shell
+pe1>show bgp vpnv4
+Route Distinguisher: 65502:1
+ *>i [1] 10.13.0.0/30       2.2.2.3                  0    100      0 65502 65513 i
+     rt:65501:100 label=16,
+ *>i [1] 172.16.2.1/32      2.2.2.3                  0    100      0 65502 65513 i
+     rt:65501:100 label=16,
+
+pe1>show ip route vrf cust1
+...
+B  *> 172.16.2.1/32 [200/0] via 10.1.0.2, pe1-p1, label 16013 19 16, 00:01:12
+```
+
+The same three-label program — SR transport to ASBR1 (`16013`), ASBR1's
+BGP-LU label for PE2's loopback (`19`), PE2's VPN label (`16`). And the
+ASBR's whole service footprint is still a handful of loopback swaps, now
+four instead of two because the RR loopbacks joined the exchange:
+
+``` shell
+asbr1>ip -f mpls route | grep bgp
+16 as to 16011 via inet 10.1.0.5 dev asbr1-p1 proto bgp
+17 as to 16019 via inet 10.1.0.5 dev asbr1-p1 proto bgp
+18 as to 16 via inet 192.168.100.2 dev asbr1-asbr2 proto bgp
+19 as to 19 via inet 192.168.100.2 dev asbr1-asbr2 proto bgp
+```
+
+(`16`/`17` → the SR labels of PE1 and RR1 inward; `18`/`19` → ASBR2's
+labels for PE2 and RR2 outward. Still O(routers), still zero VPN.)
+
+## Data plane: unchanged — and the RRs prove it by silence
+
+``` shell
+$ sudo ip netns exec ce1 vty
+ce1>ping 172.16.2.1
+PING 172.16.2.1 (172.16.2.1) 56(84) bytes of data.
+64 bytes from 172.16.2.1: icmp_seq=1 ttl=62 time=0.061 ms
+64 bytes from 172.16.2.1: icmp_seq=2 ttl=62 time=0.211 ms
+```
+
+Same `ttl=62` as the direct-PE lab. On the border, the same two-label
+crossing (ASBR1's `19 as to 19` swap feeding ASBR2, PE2's VPN label
+inside):
+
+``` shell
+asbr1>tcpdump -nli asbr1-asbr2 mpls
+MPLS (label 19, tc 0, ttl 62) (label 16, tc 0, [S], ttl 63) IP 10.11.0.1 > 172.16.2.1: ICMP echo request ...
+MPLS (label 16, tc 0, ttl 62) (label 16, tc 0, [S], ttl 63) IP 172.16.2.1 > 10.11.0.1: ICMP echo reply ...
+```
+
+And the capture that defines the design — sniffing the RR's only link
+**while the ping runs**:
+
+``` shell
+rr1>tcpdump -nli rr1-p1 icmp
+0 packets captured
+```
+
+Not one customer packet. The routers that hold every VPN route forward
+none of the VPN traffic; the routers that forward all of it hold none of
+the routes. That separation of control and forwarding is what
+`next-hop-unchanged` preserves, and why the knob is mandatory here.
+
+## Why Cisco draws it this way
+
+* **The full-mesh problem.** Direct PE-to-PE multihop VPNv4 means every
+  PE pair across both providers must peer — N×M sessions crossing the
+  boundary, each one inter-provider coordination. With RRs it is
+  *exactly one* inter-provider VPNv4 session, total, regardless of PE
+  count; new PEs touch only their own AS's RR.
+* **VPN state concentrates on two boxes** whose only job is BGP — the
+  ASBRs stay lean (Cisco: "improved scalability compared with
+  configurations where the ASBR holds all of the VPN-IPv4 routes" —
+  i.e., versus Option B), and the PEs hold what they import, as always.
+* The cost is the knob this playset exists to demonstrate: an eBGP
+  session that must **not** do the most eBGP thing there is. Forgetting
+  `next-hop-unchanged` on either RR is the classic Option C lab failure
+  — sessions up, routes present, next hop pointing at a router that
+  will never forward a customer packet.
+* The trust surface is Option C's, unchanged: PE (and now RR) loopbacks
+  are reachable as labeled destinations from the neighbor provider —
+  which is why this design typically interconnects ASes of the *same*
+  operator.
+
+## Tear down
+
+``` shell
+$ ./down.sh
+```
+
+## Appendix: Addressing & sessions
+
+As the [direct-PE Option C lab](../interas-option-c/README.md#appendix-addressing--sessions),
+plus one RR per AS:
+
+| node | role | AS | loopback | SR SID (label) |
+|:-----|:-----|:---|:---------|:---------------|
+| rr1  | route reflector | 65501 | 1.1.1.9/32 | 19 (16019) |
+| rr2  | route reflector | 65502 | 2.2.2.9/32 | 29 (16029) |
+
+New links: p1–rr1 `10.1.0.8/30`, p2–rr2 `10.2.0.8/30`.
+
+BGP sessions: 4× PE-CE eBGP IPv4 (in VRF), 4× iBGP labeled-unicast over
+loopbacks (asbr1–{pe1,rr1}, asbr2–{pe2,rr2}; ASBR side `next-hop-self`),
+1× ASBR-ASBR eBGP labeled-unicast, 2× iBGP VPNv4 PE–RR (PE as
+`route-reflector client`), and 1× **multihop eBGP VPNv4 RR1–RR2 with
+`next-hop-unchanged`** — the Cisco-style Option C control plane.
+
+## Sources
+
+* Cisco, *MPLS VPN Inter-AS with ASBRs Exchanging IPv4 Routes and MPLS
+  Labels* — the RR-based reference design this lab reproduces, including
+  "Configuring the Route Reflectors to Exchange VPN-IPv4 Routes":
+  <https://www.cisco.com/c/en/us/td/docs/routers/ios/config/17-x/mpls/b-mpls/m_mp-vpn-connect-ipv4.html>
+* RFC 4364, *BGP/MPLS IP Virtual Private Networks*, §10(c) — permits the
+  VPN-IPv4 exchange "between route reflectors" with next-hop
+  preservation; RFC 4456 (route reflection); RFC 8277 (labeled NLRI).
+* netquirks, *Inter-AS Option C* (also RR-based, IOS vs IOS-XR):
+  <https://netquirks.co.uk/ios-vs-xr/option-c/>
+* QuistED, *Inter-AS MPLS L3VPN Options (A, B, C)*:
+  <https://www.quisted.net/index.php/2025/09/12/inter-as-mpls-l3vpn-options-a-b-c/>
+* Juniper, *Interprovider VPNs*:
+  <https://www.juniper.net/documentation/us/en/software/junos/vpn-l3/topics/topic-map/l3-vpns-interprovider.html>

--- a/playset/interas-option-c-rr/asbr1.yaml
+++ b/playset/interas-option-c-rr/asbr1.yaml
@@ -1,0 +1,69 @@
+# ASBR1 — autonomous system border router of AS 65501. Identical role
+# to the direct-PE Option C playset — labeled loopbacks only, no VPN
+# state — with one addition: RR1 is a second iBGP labeled-unicast
+# neighbor (also next-hop-self), because the RRs' loopbacks must cross
+# the boundary too for the inter-RR multihop session to establish.
+interface:
+- if-name: lo
+  ipv4:
+    address: 1.1.1.3/32
+- if-name: asbr1-p1
+  ipv4:
+    address: 10.1.0.6/30
+- if-name: asbr1-asbr2
+  ipv4:
+    address: 192.168.100.1/30
+system:
+  hostname: asbr1
+router:
+  isis:
+    net: 49.0001.0000.0000.0003.00
+    hostname: asbr1
+    is-type: level-2-only
+    segment-routing: mpls
+    te-router-id: 1.1.1.3
+    interface:
+    - if-name: lo
+      ipv4:
+        enabled: true
+        prefix-sid:
+          index: 13
+    - if-name: asbr1-p1
+      network-type: point-to-point
+      metric: 10
+      ipv4:
+        enabled: true
+  bgp:
+    global:
+      as: 65501
+      router-id: 1.1.1.3
+    timer:
+      adv-interval:
+        ibgp: 1
+        ebgp: 1
+    neighbor:
+    - remote-address: 1.1.1.1        # PE1 — iBGP labeled-unicast
+      remote-as: 65501
+      timers: {connect-retry-time: 3}
+      update-source: 1.1.1.3
+      enabled: true
+      afi-safi:
+      - name: label-v4
+        enabled: true
+        next-hop-self: true
+    - remote-address: 1.1.1.9        # RR1 — iBGP labeled-unicast
+      remote-as: 65501
+      timers: {connect-retry-time: 3}
+      update-source: 1.1.1.3
+      enabled: true
+      afi-safi:
+      - name: label-v4
+        enabled: true
+        next-hop-self: true
+    - remote-address: 192.168.100.2  # ASBR2 — eBGP labeled-unicast
+      remote-as: 65502
+      timers: {connect-retry-time: 3}
+      enabled: true
+      afi-safi:
+      - name: label-v4
+        enabled: true

--- a/playset/interas-option-c-rr/asbr2.yaml
+++ b/playset/interas-option-c-rr/asbr2.yaml
@@ -1,0 +1,67 @@
+# ASBR2 — autonomous system border router of AS 65502. Mirror of ASBR1:
+# labeled-unicast only (PE2 + RR2 inside with next-hop-self, ASBR1
+# across), no VRFs, no VPNv4, no customer routes.
+interface:
+- if-name: lo
+  ipv4:
+    address: 2.2.2.1/32
+- if-name: asbr2-asbr1
+  ipv4:
+    address: 192.168.100.2/30
+- if-name: asbr2-p2
+  ipv4:
+    address: 10.2.0.1/30
+system:
+  hostname: asbr2
+router:
+  isis:
+    net: 49.0002.0000.0000.0001.00
+    hostname: asbr2
+    is-type: level-2-only
+    segment-routing: mpls
+    te-router-id: 2.2.2.1
+    interface:
+    - if-name: lo
+      ipv4:
+        enabled: true
+        prefix-sid:
+          index: 21
+    - if-name: asbr2-p2
+      network-type: point-to-point
+      metric: 10
+      ipv4:
+        enabled: true
+  bgp:
+    global:
+      as: 65502
+      router-id: 2.2.2.1
+    timer:
+      adv-interval:
+        ibgp: 1
+        ebgp: 1
+    neighbor:
+    - remote-address: 2.2.2.3        # PE2 — iBGP labeled-unicast
+      remote-as: 65502
+      timers: {connect-retry-time: 3}
+      update-source: 2.2.2.1
+      enabled: true
+      afi-safi:
+      - name: label-v4
+        enabled: true
+        next-hop-self: true
+    - remote-address: 2.2.2.9        # RR2 — iBGP labeled-unicast
+      remote-as: 65502
+      timers: {connect-retry-time: 3}
+      update-source: 2.2.2.1
+      enabled: true
+      afi-safi:
+      - name: label-v4
+        enabled: true
+        next-hop-self: true
+    - remote-address: 192.168.100.1  # ASBR1 — eBGP labeled-unicast
+      remote-as: 65501
+      timers: {connect-retry-time: 3}
+      enabled: true
+      afi-safi:
+      - name: label-v4
+        enabled: true

--- a/playset/interas-option-c-rr/ce1.yaml
+++ b/playset/interas-option-c-rr/ce1.yaml
@@ -1,0 +1,32 @@
+# CE1 — customer "cust1", site A (AS 65511). Identical to the Option A
+# playset: plain eBGP to PE1, loopback originated via `redistribute
+# connected`. The customer cannot tell which Inter-AS option carries it.
+interface:
+- if-name: lo
+  ipv4:
+    address: 172.16.1.1/32
+- if-name: ce1-pe1
+  ipv4:
+    address: 10.11.0.1/30
+system:
+  hostname: ce1
+router:
+  bgp:
+    global:
+      as: 65511
+      router-id: 10.11.0.1
+    timer:
+      adv-interval:
+        ebgp: 3
+    neighbor:
+    - remote-address: 10.11.0.2
+      remote-as: 65501
+      timers: {connect-retry-time: 3}
+      enabled: true
+      afi-safi:
+      - name: ipv4
+        enabled: true
+    afi-safi:
+    - name: ipv4
+      redistribute:
+        connected: {}

--- a/playset/interas-option-c-rr/ce2.yaml
+++ b/playset/interas-option-c-rr/ce2.yaml
@@ -1,0 +1,32 @@
+# CE2 — customer "cust2", site A (AS 65512). Same loopback address as
+# CE1 (172.16.1.1/32) on purpose: in Option C both customers' overlapping
+# routes cross ONE PE-to-PE VPNv4 session, kept apart only by their RDs.
+interface:
+- if-name: lo
+  ipv4:
+    address: 172.16.1.1/32
+- if-name: ce2-pe1
+  ipv4:
+    address: 10.12.0.1/30
+system:
+  hostname: ce2
+router:
+  bgp:
+    global:
+      as: 65512
+      router-id: 10.12.0.1
+    timer:
+      adv-interval:
+        ebgp: 3
+    neighbor:
+    - remote-address: 10.12.0.2
+      remote-as: 65501
+      timers: {connect-retry-time: 3}
+      enabled: true
+      afi-safi:
+      - name: ipv4
+        enabled: true
+    afi-safi:
+    - name: ipv4
+      redistribute:
+        connected: {}

--- a/playset/interas-option-c-rr/ce3.yaml
+++ b/playset/interas-option-c-rr/ce3.yaml
@@ -1,0 +1,31 @@
+# CE3 — customer "cust1", site B (AS 65513). The far end of cust1:
+# ce1 pings this router's loopback 172.16.2.1/32 across both ASes.
+interface:
+- if-name: lo
+  ipv4:
+    address: 172.16.2.1/32
+- if-name: ce3-pe2
+  ipv4:
+    address: 10.13.0.1/30
+system:
+  hostname: ce3
+router:
+  bgp:
+    global:
+      as: 65513
+      router-id: 10.13.0.1
+    timer:
+      adv-interval:
+        ebgp: 3
+    neighbor:
+    - remote-address: 10.13.0.2
+      remote-as: 65502
+      timers: {connect-retry-time: 3}
+      enabled: true
+      afi-safi:
+      - name: ipv4
+        enabled: true
+    afi-safi:
+    - name: ipv4
+      redistribute:
+        connected: {}

--- a/playset/interas-option-c-rr/ce4.yaml
+++ b/playset/interas-option-c-rr/ce4.yaml
@@ -1,0 +1,32 @@
+# CE4 — customer "cust2", site B (AS 65514). Same loopback address as
+# CE3 (172.16.2.1/32) on purpose: ce2 pinging 172.16.2.1 must land here,
+# not on cust1's ce3 — even though both customers cross ONE PE-to-PE session.
+interface:
+- if-name: lo
+  ipv4:
+    address: 172.16.2.1/32
+- if-name: ce4-pe2
+  ipv4:
+    address: 10.14.0.1/30
+system:
+  hostname: ce4
+router:
+  bgp:
+    global:
+      as: 65514
+      router-id: 10.14.0.1
+    timer:
+      adv-interval:
+        ebgp: 3
+    neighbor:
+    - remote-address: 10.14.0.2
+      remote-as: 65502
+      timers: {connect-retry-time: 3}
+      enabled: true
+      afi-safi:
+      - name: ipv4
+        enabled: true
+    afi-safi:
+    - name: ipv4
+      redistribute:
+        connected: {}

--- a/playset/interas-option-c-rr/down.sh
+++ b/playset/interas-option-c-rr/down.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+# Tear down the RR-based Inter-AS Option C namespace demo.
+
+PLAYSET_DEMO_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=../lib/playset.sh
+source "${PLAYSET_DEMO_DIR}/../lib/playset.sh"
+# shellcheck source=topology.sh
+source "${PLAYSET_DEMO_DIR}/topology.sh"
+
+playset_teardown

--- a/playset/interas-option-c-rr/p1.yaml
+++ b/playset/interas-option-c-rr/p1.yaml
@@ -1,0 +1,45 @@
+# P1 — provider core transit LSR of AS 65501 (runs no BGP, knows no
+# VPN). Pure IS-IS L2 + SR-MPLS between PE1, RR1, and ASBR1.
+interface:
+- if-name: lo
+  ipv4:
+    address: 1.1.1.2/32
+- if-name: p1-pe1
+  ipv4:
+    address: 10.1.0.2/30
+- if-name: p1-asbr1
+  ipv4:
+    address: 10.1.0.5/30
+- if-name: p1-rr1
+  ipv4:
+    address: 10.1.0.9/30
+system:
+  hostname: p1
+router:
+  isis:
+    net: 49.0001.0000.0000.0002.00
+    hostname: p1
+    is-type: level-2-only
+    segment-routing: mpls
+    te-router-id: 1.1.1.2
+    interface:
+    - if-name: lo
+      ipv4:
+        enabled: true
+        prefix-sid:
+          index: 12
+    - if-name: p1-pe1
+      network-type: point-to-point
+      metric: 10
+      ipv4:
+        enabled: true
+    - if-name: p1-asbr1
+      network-type: point-to-point
+      metric: 10
+      ipv4:
+        enabled: true
+    - if-name: p1-rr1
+      network-type: point-to-point
+      metric: 10
+      ipv4:
+        enabled: true

--- a/playset/interas-option-c-rr/p2.yaml
+++ b/playset/interas-option-c-rr/p2.yaml
@@ -1,0 +1,45 @@
+# P2 — provider core transit LSR of AS 65502 (runs no BGP, knows no
+# VPN). Pure IS-IS L2 + SR-MPLS between ASBR2, RR2, and PE2.
+interface:
+- if-name: lo
+  ipv4:
+    address: 2.2.2.2/32
+- if-name: p2-asbr2
+  ipv4:
+    address: 10.2.0.2/30
+- if-name: p2-pe2
+  ipv4:
+    address: 10.2.0.5/30
+- if-name: p2-rr2
+  ipv4:
+    address: 10.2.0.9/30
+system:
+  hostname: p2
+router:
+  isis:
+    net: 49.0002.0000.0000.0002.00
+    hostname: p2
+    is-type: level-2-only
+    segment-routing: mpls
+    te-router-id: 2.2.2.2
+    interface:
+    - if-name: lo
+      ipv4:
+        enabled: true
+        prefix-sid:
+          index: 22
+    - if-name: p2-asbr2
+      network-type: point-to-point
+      metric: 10
+      ipv4:
+        enabled: true
+    - if-name: p2-pe2
+      network-type: point-to-point
+      metric: 10
+      ipv4:
+        enabled: true
+    - if-name: p2-rr2
+      network-type: point-to-point
+      metric: 10
+      ipv4:
+        enabled: true

--- a/playset/interas-option-c-rr/pe1.yaml
+++ b/playset/interas-option-c-rr/pe1.yaml
@@ -1,0 +1,101 @@
+# PE1 — provider edge, AS 65501. Unlike the direct-PE Option C playset,
+# the VPNv4 session goes to the LOCAL route reflector (RR1, iBGP) — the
+# PE never talks to the far AS at all. Everything else is unchanged:
+# own loopback originated into label-v4, VRFs with PE-CE eBGP, RTs
+# coordinated with AS 65502.
+vrf:
+- name: cust1
+  ipv4:
+    route-target:
+      import:
+      - 65501:100
+      export:
+      - 65501:100
+- name: cust2
+  ipv4:
+    route-target:
+      import:
+      - 65501:200
+      export:
+      - 65501:200
+interface:
+- if-name: lo
+  ipv4:
+    address: 1.1.1.1/32
+- if-name: pe1-ce1
+  vrf: cust1
+  ipv4:
+    address: 10.11.0.2/30
+- if-name: pe1-ce2
+  vrf: cust2
+  ipv4:
+    address: 10.12.0.2/30
+- if-name: pe1-p1
+  ipv4:
+    address: 10.1.0.1/30
+system:
+  hostname: pe1
+router:
+  isis:
+    net: 49.0001.0000.0000.0001.00
+    hostname: pe1
+    is-type: level-2-only
+    segment-routing: mpls
+    te-router-id: 1.1.1.1
+    interface:
+    - if-name: lo
+      ipv4:
+        enabled: true
+        prefix-sid:
+          index: 11
+    - if-name: pe1-p1
+      network-type: point-to-point
+      metric: 10
+      ipv4:
+        enabled: true
+  bgp:
+    global:
+      as: 65501
+      router-id: 1.1.1.1
+    timer:
+      adv-interval:
+        ibgp: 1
+        ebgp: 3
+    neighbor:
+    - remote-address: 1.1.1.3        # ASBR1 — labeled-unicast
+      remote-as: 65501
+      timers: {connect-retry-time: 3}
+      update-source: 1.1.1.1
+      enabled: true
+      afi-safi:
+      - name: label-v4
+        enabled: true
+    - remote-address: 1.1.1.9        # RR1 — iBGP VPNv4 (the RR reflects)
+      remote-as: 65501
+      timers: {connect-retry-time: 3}
+      update-source: 1.1.1.1
+      enabled: true
+      afi-safi:
+      - name: vpnv4
+        enabled: true
+    afi-safi:
+    - name: label-v4
+      network:
+      - prefix: 1.1.1.1/32
+    vrf:
+    - name: cust1
+      rd: 65501:1
+      neighbor:
+      - remote-address: 10.11.0.1
+        remote-as: 65511
+        afi-safi:
+        - name: ipv4
+          enabled: true
+    - name: cust2
+      rd: 65501:2
+      neighbor:
+      - remote-address: 10.12.0.1
+        remote-as: 65512
+        afi-safi:
+        - name: ipv4
+          enabled: true

--- a/playset/interas-option-c-rr/pe2.yaml
+++ b/playset/interas-option-c-rr/pe2.yaml
@@ -1,0 +1,98 @@
+# PE2 — provider edge, AS 65502. Mirror of PE1: VPNv4 to the local RR2
+# only, loopback into label-v4, RTs matching AS 65501's.
+vrf:
+- name: cust1
+  ipv4:
+    route-target:
+      import:
+      - 65501:100
+      export:
+      - 65501:100
+- name: cust2
+  ipv4:
+    route-target:
+      import:
+      - 65501:200
+      export:
+      - 65501:200
+interface:
+- if-name: lo
+  ipv4:
+    address: 2.2.2.3/32
+- if-name: pe2-p2
+  ipv4:
+    address: 10.2.0.6/30
+- if-name: pe2-ce3
+  vrf: cust1
+  ipv4:
+    address: 10.13.0.2/30
+- if-name: pe2-ce4
+  vrf: cust2
+  ipv4:
+    address: 10.14.0.2/30
+system:
+  hostname: pe2
+router:
+  isis:
+    net: 49.0002.0000.0000.0003.00
+    hostname: pe2
+    is-type: level-2-only
+    segment-routing: mpls
+    te-router-id: 2.2.2.3
+    interface:
+    - if-name: lo
+      ipv4:
+        enabled: true
+        prefix-sid:
+          index: 23
+    - if-name: pe2-p2
+      network-type: point-to-point
+      metric: 10
+      ipv4:
+        enabled: true
+  bgp:
+    global:
+      as: 65502
+      router-id: 2.2.2.3
+    timer:
+      adv-interval:
+        ibgp: 1
+        ebgp: 3
+    neighbor:
+    - remote-address: 2.2.2.1        # ASBR2 — labeled-unicast
+      remote-as: 65502
+      timers: {connect-retry-time: 3}
+      update-source: 2.2.2.3
+      enabled: true
+      afi-safi:
+      - name: label-v4
+        enabled: true
+    - remote-address: 2.2.2.9        # RR2 — iBGP VPNv4 (the RR reflects)
+      remote-as: 65502
+      timers: {connect-retry-time: 3}
+      update-source: 2.2.2.3
+      enabled: true
+      afi-safi:
+      - name: vpnv4
+        enabled: true
+    afi-safi:
+    - name: label-v4
+      network:
+      - prefix: 2.2.2.3/32
+    vrf:
+    - name: cust1
+      rd: 65502:1
+      neighbor:
+      - remote-address: 10.13.0.1
+        remote-as: 65513
+        afi-safi:
+        - name: ipv4
+          enabled: true
+    - name: cust2
+      rd: 65502:2
+      neighbor:
+      - remote-address: 10.14.0.1
+        remote-as: 65514
+        afi-safi:
+        - name: ipv4
+          enabled: true

--- a/playset/interas-option-c-rr/rr1.yaml
+++ b/playset/interas-option-c-rr/rr1.yaml
@@ -1,0 +1,80 @@
+# RR1 — the route reflector of AS 65501 (Cisco's RR-based Option C).
+# Holds every VPN route but forwards NO customer traffic:
+#  - iBGP VPNv4 with PE1, PE1 marked `route-reflector client` — the RR
+#    reflects between its clients and relays to/from the far AS.
+#  - Multihop eBGP VPNv4 to RR2 (2.2.2.9, two IGPs away) with
+#    `next-hop-unchanged`: the reflected routes must keep the
+#    originating PE — the true LSP endpoint — as next-hop (and keep the
+#    PE's VPN label). Without the knob, eBGP would rewrite the next-hop
+#    to the RR, which is not in the forwarding path.
+#  - iBGP labeled-unicast to ASBR1: originates its own loopback into
+#    BGP-LU (so RR2 can reach it) and learns the far AS's loopbacks
+#    (so the multihop session and its TCP path resolve).
+interface:
+- if-name: lo
+  ipv4:
+    address: 1.1.1.9/32
+- if-name: rr1-p1
+  ipv4:
+    address: 10.1.0.10/30
+system:
+  hostname: rr1
+router:
+  isis:
+    net: 49.0001.0000.0000.0009.00
+    hostname: rr1
+    is-type: level-2-only
+    segment-routing: mpls
+    te-router-id: 1.1.1.9
+    interface:
+    - if-name: lo
+      ipv4:
+        enabled: true
+        prefix-sid:
+          index: 19
+    - if-name: rr1-p1
+      network-type: point-to-point
+      metric: 10
+      ipv4:
+        enabled: true
+  bgp:
+    global:
+      as: 65501
+      router-id: 1.1.1.9
+    timer:
+      adv-interval:
+        ibgp: 1
+        ebgp: 1
+    neighbor:
+    - remote-address: 1.1.1.1        # PE1 — VPNv4 route-reflector client
+      remote-as: 65501
+      timers: {connect-retry-time: 3}
+      update-source: 1.1.1.9
+      enabled: true
+      route-reflector:
+        client: true
+      afi-safi:
+      - name: vpnv4
+        enabled: true
+    - remote-address: 1.1.1.3        # ASBR1 — labeled-unicast only
+      remote-as: 65501
+      timers: {connect-retry-time: 3}
+      update-source: 1.1.1.9
+      enabled: true
+      afi-safi:
+      - name: label-v4
+        enabled: true
+    - remote-address: 2.2.2.9        # RR2 — multihop eBGP VPNv4
+      remote-as: 65502
+      ebgp-multihop: 10
+      timers: {connect-retry-time: 3}
+      update-source: 1.1.1.9
+      enabled: true
+      afi-safi:
+      - name: vpnv4
+        enabled: true
+        next-hop-unchanged: true     # <- THE RR-based Option C knob
+    afi-safi:
+    - name: label-v4
+      network:
+      - prefix: 1.1.1.9/32

--- a/playset/interas-option-c-rr/rr2.yaml
+++ b/playset/interas-option-c-rr/rr2.yaml
@@ -1,0 +1,71 @@
+# RR2 — the route reflector of AS 65502. Mirror of RR1: PE2 as a VPNv4
+# route-reflector client, multihop eBGP VPNv4 to RR1 with
+# `next-hop-unchanged`, labeled-unicast to ASBR2 for loopback exchange.
+interface:
+- if-name: lo
+  ipv4:
+    address: 2.2.2.9/32
+- if-name: rr2-p2
+  ipv4:
+    address: 10.2.0.10/30
+system:
+  hostname: rr2
+router:
+  isis:
+    net: 49.0002.0000.0000.0009.00
+    hostname: rr2
+    is-type: level-2-only
+    segment-routing: mpls
+    te-router-id: 2.2.2.9
+    interface:
+    - if-name: lo
+      ipv4:
+        enabled: true
+        prefix-sid:
+          index: 29
+    - if-name: rr2-p2
+      network-type: point-to-point
+      metric: 10
+      ipv4:
+        enabled: true
+  bgp:
+    global:
+      as: 65502
+      router-id: 2.2.2.9
+    timer:
+      adv-interval:
+        ibgp: 1
+        ebgp: 1
+    neighbor:
+    - remote-address: 2.2.2.3        # PE2 — VPNv4 route-reflector client
+      remote-as: 65502
+      timers: {connect-retry-time: 3}
+      update-source: 2.2.2.9
+      enabled: true
+      route-reflector:
+        client: true
+      afi-safi:
+      - name: vpnv4
+        enabled: true
+    - remote-address: 2.2.2.1        # ASBR2 — labeled-unicast only
+      remote-as: 65502
+      timers: {connect-retry-time: 3}
+      update-source: 2.2.2.9
+      enabled: true
+      afi-safi:
+      - name: label-v4
+        enabled: true
+    - remote-address: 1.1.1.9        # RR1 — multihop eBGP VPNv4
+      remote-as: 65501
+      ebgp-multihop: 10
+      timers: {connect-retry-time: 3}
+      update-source: 2.2.2.9
+      enabled: true
+      afi-safi:
+      - name: vpnv4
+        enabled: true
+        next-hop-unchanged: true     # <- THE RR-based Option C knob
+    afi-safi:
+    - name: label-v4
+      network:
+      - prefix: 2.2.2.9/32

--- a/playset/interas-option-c-rr/topology.sh
+++ b/playset/interas-option-c-rr/topology.sh
@@ -1,0 +1,30 @@
+# Inter-AS Option C, RR-based (Cisco reference design) demo topology.
+# Each PLAYSET_LINKS entry is "ns_a:iface_a:ns_b:iface_b".
+#
+#            rr1 ═══ multihop eBGP VPNv4 (next-hop-unchanged) ═══ rr2
+#             │                                                    │
+#   ce1 ─┐    │                                                    │    ┌─ ce3   (cust1)
+#        pe1 ─┴ p1 ── asbr1 ═══ BGP-LU loopbacks ═══ asbr2 ── p2 ──┴─ pe2
+#   ce2 ─┘        AS 65501                            AS 65502          └─ ce4   (cust2)
+
+PLAYSET_NAMESPACES=(ce1 ce2 pe1 p1 rr1 asbr1 asbr2 rr2 p2 pe2 ce3 ce4)
+
+PLAYSET_LINKS=(
+    ce1:ce1-pe1:pe1:pe1-ce1
+    ce2:ce2-pe1:pe1:pe1-ce2
+    pe1:pe1-p1:p1:p1-pe1
+    p1:p1-rr1:rr1:rr1-p1
+    p1:p1-asbr1:asbr1:asbr1-p1
+    asbr1:asbr1-asbr2:asbr2:asbr2-asbr1
+    asbr2:asbr2-p2:p2:p2-asbr2
+    p2:p2-rr2:rr2:rr2-p2
+    p2:p2-pe2:pe2:pe2-p2
+    pe2:pe2-ce3:ce3:ce3-pe2
+    pe2:pe2-ce4:ce4:ce4-pe2
+)
+
+# All namespaces that run zebra-rs.
+PLAYSET_DAEMONS=(ce1 ce2 pe1 p1 rr1 asbr1 asbr2 rr2 p2 pe2 ce3 ce4)
+
+# Routers with vtyctl YAML config.
+PLAYSET_ROUTERS=(ce1 ce2 pe1 p1 rr1 asbr1 asbr2 rr2 p2 pe2 ce3 ce4)

--- a/playset/interas-option-c-rr/up.sh
+++ b/playset/interas-option-c-rr/up.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+# Bring up the RR-based Inter-AS Option C namespace demo.
+
+PLAYSET_DEMO_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=../lib/playset.sh
+source "${PLAYSET_DEMO_DIR}/../lib/playset.sh"
+# shellcheck source=topology.sh
+source "${PLAYSET_DEMO_DIR}/topology.sh"
+
+playset_up

--- a/playset/interas-option-c/README.md
+++ b/playset/interas-option-c/README.md
@@ -292,8 +292,9 @@ What it costs:
   the *same* operator and B between different ones.
 * **Multihop eBGP mesh among PEs.** Every PE pair (or, in production, a
   route-reflector pair per AS with `next-hop-unchanged`) must peer
-  across the boundary. This lab wires the two PEs directly; an RR-based
-  variant trades the mesh for reflector configuration.
+  across the boundary. This lab wires the two PEs directly; Cisco's
+  reference design uses the RR form — built as the sibling playset
+  [interas-option-c-rr](../interas-option-c-rr/README.md).
 * Route-target coordination, as in B.
 
 ## Tear down

--- a/zebra-rs/src/bgp/config.rs
+++ b/zebra-rs/src/bgp/config.rs
@@ -3077,6 +3077,20 @@ fn config_next_hop_self(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Option<(
     Some(())
 }
 
+fn config_next_hop_unchanged(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Option<()> {
+    let addr = args.addr()?;
+    let afi_safi: AfiSafi = args.afi_safi()?;
+    let peer = bgp.peers.get_mut(&addr)?;
+
+    let value = op.is_set() && args.boolean()?;
+    peer.config
+        .sub
+        .entry(afi_safi)
+        .or_default()
+        .next_hop_unchanged = value;
+    Some(())
+}
+
 fn config_llgr(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Option<()> {
     let addr = args.addr()?;
     let afi_safi: AfiSafi = args.afi_safi()?;
@@ -4611,6 +4625,7 @@ impl Bgp {
         self.callback_peer("/afi-safi/add-path", config_add_path);
         self.callback_peer("/afi-safi/encapsulation-type", config_encapsulation_type);
         self.callback_peer("/afi-safi/next-hop-self", config_next_hop_self);
+        self.callback_peer("/afi-safi/next-hop-unchanged", config_next_hop_unchanged);
         self.callback_peer("/afi-safi/graceful-restart/enabled", config_restart);
         self.callback_peer("/afi-safi/long-lived-graceful-restart/enabled", config_llgr);
         self.callback_peer(

--- a/zebra-rs/src/bgp/peer.rs
+++ b/zebra-rs/src/bgp/peer.rs
@@ -700,6 +700,16 @@ pub struct PeerSubConfig {
     /// and forward via the ASBR's swap label. Honored on the labeled-
     /// unicast advertise paths (`route_update_labelv4` / `…v6`).
     pub next_hop_self: bool,
+    /// `afi-safi <name> next-hop-unchanged` (ietf-bgp-neighbor). When
+    /// `true`, VPN routes re-advertised to this eBGP neighbor keep their
+    /// received next-hop (and their received VPN label) instead of the
+    /// default eBGP rewrite to self. Required on the multihop eBGP VPNv4
+    /// session between the route reflectors of an RR-based Inter-AS
+    /// Option C — the RRs are outside the forwarding path, so the
+    /// reflected route must keep the originating PE as the LSP endpoint.
+    /// Locally-originated routes still rewrite. Honored on the VPNv4
+    /// advertise path (`route_update_ipv4` / `vpnv4_service_label`).
+    pub next_hop_unchanged: bool,
 }
 
 #[derive(Debug, Eq, PartialEq, PartialOrd, Ord, Hash, Clone, Copy)]
@@ -1467,6 +1477,7 @@ impl Peer {
             remote_id: self.remote_id,
             remote_address: self.address,
             vpnv4_next_hop_self: self.next_hop_self(Afi::Ip, Safi::MplsVpn),
+            vpnv4_next_hop_unchanged: self.next_hop_unchanged(Afi::Ip, Safi::MplsVpn),
             egress_as: self.egress_as(),
             out_policy: self.out_policy.clone(),
             packet_tx: self.packet_tx.clone(),
@@ -1500,6 +1511,18 @@ impl Peer {
             .sub
             .get(&AfiSafi::new(afi, safi))
             .map(|c| c.next_hop_self)
+            .unwrap_or(false)
+    }
+
+    /// Whether `afi-safi <name> next-hop-unchanged` is set for this
+    /// neighbor in the given address family. Keeps the received next-hop
+    /// (and VPN label) on eBGP advertisement of forwarded VPN routes —
+    /// see [`PeerSubConfig::next_hop_unchanged`].
+    pub fn next_hop_unchanged(&self, afi: Afi, safi: Safi) -> bool {
+        self.config
+            .sub
+            .get(&AfiSafi::new(afi, safi))
+            .map(|c| c.next_hop_unchanged)
             .unwrap_or(false)
     }
 

--- a/zebra-rs/src/bgp/route.rs
+++ b/zebra-rs/src/bgp/route.rs
@@ -184,6 +184,10 @@ pub struct SyncCtx {
     #[cfg_attr(not(feature = "lua"), allow(dead_code))]
     pub remote_address: IpAddr,
     pub vpnv4_next_hop_self: bool,
+    /// `afi-safi vpnv4 next-hop-unchanged` — keep the received next-hop
+    /// (and VPN label) when advertising forwarded VPN routes to this
+    /// eBGP peer. The inter-RR session of an RR-based Inter-AS Option C.
+    pub vpnv4_next_hop_unchanged: bool,
     pub egress_as: EgressAs,
     pub out_policy: Arc<super::policy::OutPolicy>,
     /// Egress sink (Tier 1b): the peer's writer channel, the shared
@@ -277,6 +281,7 @@ impl SyncCtx {
             remote_id: Ipv4Addr::UNSPECIFIED,
             remote_address: IpAddr::V4(Ipv4Addr::UNSPECIFIED),
             vpnv4_next_hop_self: false,
+            vpnv4_next_hop_unchanged: false,
             egress_as: EgressAs {
                 is_ebgp: true,
                 local_as: 65000,
@@ -10687,7 +10692,13 @@ pub fn stale_route_withdraw(peer_id: usize, bgp: &mut BgpTop, peers: &mut PeerMa
 /// passes through unchanged. Mirrors the Labeled-Unicast rule in
 /// [`route_update_labelv4`].
 fn vpnv4_service_label(peer: &Peer, rib: &BgpRib) -> Label {
-    let rewrites_nh = peer.is_ebgp() || peer.next_hop_self(Afi::Ip, Safi::MplsVpn);
+    // `next-hop-unchanged` keeps the received label with the received
+    // next-hop: the label was allocated by (and only means anything to)
+    // the next-hop router, so rewriting one without the other would
+    // black-hole. Locally-originated rows are exempt — the originator's
+    // own local label belongs with its own address.
+    let unchanged = !rib.is_originated() && peer.next_hop_unchanged(Afi::Ip, Safi::MplsVpn);
+    let rewrites_nh = (peer.is_ebgp() && !unchanged) || peer.next_hop_self(Afi::Ip, Safi::MplsVpn);
     match (rewrites_nh, rib.local_label) {
         (true, Some(l)) => Label::new(l, 0, true),
         _ => rib.label.unwrap_or_default(),
@@ -10870,8 +10881,16 @@ pub fn route_update_ipv4(
     // `afi-safi vpnv4 next-hop-self` — an Inter-AS Option B ASBR sets it on
     // the iBGP session to its PE so a re-advertised eBGP-VPNv4 route carries
     // the ASBR (a resolvable next-hop) instead of the unreachable foreign
-    // PE. eBGP and self-originated routes rewrite unconditionally as before.
-    let needs_v4_rewrite = ctx.peer_type.is_ebgp()
+    // PE. eBGP and self-originated routes rewrite unconditionally as before —
+    // except a forwarded VPN row toward an eBGP peer with `afi-safi vpnv4
+    // next-hop-unchanged`: the inter-RR session of an RR-based Inter-AS
+    // Option C reflects routes for PEs it does not forward for, so the
+    // received next-hop (the originating PE, the true LSP endpoint) must
+    // survive. Locally-originated rows still rewrite (the originator IS
+    // the correct next-hop).
+    let vpn_nh_unchanged =
+        rib.nexthop.is_some() && !rib.is_originated() && ctx.vpnv4_next_hop_unchanged;
+    let needs_v4_rewrite = (ctx.peer_type.is_ebgp() && !vpn_nh_unchanged)
         || rib.is_originated()
         || rib.enhe_egress.is_some()
         || (rib.nexthop.is_some() && ctx.vpnv4_next_hop_self);
@@ -20394,6 +20413,7 @@ mod as_sets_withdraw_tests {
             remote_id: Ipv4Addr::new(2, 2, 2, 2),
             remote_address: "10.0.0.2".parse().unwrap(),
             vpnv4_next_hop_self: false,
+            vpnv4_next_hop_unchanged: false,
             egress_as: EgressAs {
                 is_ebgp: true,
                 local_as: 65000,
@@ -20426,5 +20446,93 @@ mod as_sets_withdraw_tests {
             route_update_ipv4(&ctx, &prefix, &rib, false).is_none(),
             "RFC 9774 must suppress egress of AS_SET paths",
         );
+    }
+
+    /// `afi-safi vpnv4 next-hop-unchanged`: a forwarded VPN row advertised
+    /// to an eBGP peer keeps its received next-hop (the RR-to-RR session
+    /// of an RR-based Inter-AS Option C); without the knob the default
+    /// eBGP rewrite to self applies.
+    #[test]
+    fn vpnv4_next_hop_unchanged_preserves_forwarded_next_hop() {
+        use super::VpnNexthop;
+        use bgp_packet::{BgpNexthop, Label, RouteDistinguisher, Vpnv4Nexthop};
+        use std::net::IpAddr;
+
+        let ctx = |unchanged: bool| SyncCtx {
+            ident: 1,
+            peer_type: PeerType::EBGP,
+            reflector_client: false,
+            local_addr_v4: Some(Ipv4Addr::new(9, 9, 9, 1)),
+            router_id: Ipv4Addr::new(9, 9, 9, 1),
+            remote_id: Ipv4Addr::new(9, 9, 9, 2),
+            remote_address: "9.9.9.2".parse().unwrap(),
+            vpnv4_next_hop_self: false,
+            vpnv4_next_hop_unchanged: unchanged,
+            egress_as: EgressAs {
+                is_ebgp: true,
+                local_as: 65501,
+                remote_as: 65502,
+                as_override: false,
+                remove_private_as: None,
+                local_as_substitute: None,
+                local_as_replace: false,
+            },
+            out_policy: Arc::new(crate::bgp::policy::OutPolicy::default()),
+            packet_tx: None,
+            egress_depth: Arc::new(std::sync::atomic::AtomicUsize::new(0)),
+            extended_message: false,
+            attach_unknown_attr: None,
+            as_sets_withdraw: false,
+        };
+
+        // A VPNv4 row learned from an iBGP RR client: the originating PE
+        // (2.2.2.3) is the next-hop and its VRF label rides the row.
+        let rd: RouteDistinguisher = "65502:1".parse().unwrap();
+        let pe = Ipv4Addr::new(2, 2, 2, 3);
+        let mut attr = attr_with_path("65513");
+        attr.nexthop = Some(BgpNexthop::Vpnv4(Vpnv4Nexthop {
+            rd,
+            nhop: IpAddr::V4(pe),
+        }));
+        let rib = BgpRib::new(
+            2,
+            Ipv4Addr::new(2, 2, 2, 9),
+            BgpRibType::IBGP,
+            0,
+            0,
+            &attr,
+            Some(Label::new(16, 0, true)),
+            Some(VpnNexthop::V4(Vpnv4Nexthop {
+                rd,
+                nhop: IpAddr::V4(pe),
+            })),
+            false,
+        );
+        let prefix = "172.16.2.1/32".parse().unwrap();
+
+        // Knob on: the received next-hop survives the eBGP advertisement.
+        let (_, attrs) =
+            route_update_ipv4(&ctx(true), &prefix, &rib, false).expect("route must advertise");
+        match attrs.nexthop {
+            Some(BgpNexthop::Vpnv4(ref nh)) => {
+                assert_eq!(nh.nhop, IpAddr::V4(pe), "next-hop must be preserved");
+                assert_eq!(nh.rd, rd);
+            }
+            ref other => panic!("expected preserved VPNv4 next-hop, got {other:?}"),
+        }
+
+        // Knob off: the default eBGP rewrite to self applies.
+        let (_, attrs) =
+            route_update_ipv4(&ctx(false), &prefix, &rib, false).expect("route must advertise");
+        match attrs.nexthop {
+            Some(BgpNexthop::Vpnv4(ref nh)) => {
+                assert_eq!(
+                    nh.nhop,
+                    IpAddr::V4(Ipv4Addr::new(9, 9, 9, 1)),
+                    "default eBGP advertisement must next-hop-self"
+                );
+            }
+            ref other => panic!("expected rewritten VPNv4 next-hop, got {other:?}"),
+        }
     }
 }

--- a/zebra-rs/yang/ietf-bgp-neighbor@2023-07-05.yang
+++ b/zebra-rs/yang/ietf-bgp-neighbor@2023-07-05.yang
@@ -245,6 +245,27 @@ submodule ietf-bgp-neighbor {
            next-hop carried across the inter-AS eBGP link. Honored on the
            Labeled-Unicast (SAFI 4) and VPNv4 (SAFI 128) advertise paths.";
       }
+      leaf next-hop-unchanged {
+        ext:help "Keep the received next hop on eBGP advertisement";
+        ext:sort "31";
+        type boolean;
+        description
+          "Advertise routes of this address family to this eBGP neighbor
+           with their received next-hop preserved, instead of the default
+           eBGP rewrite to self. Equivalent to `neighbor X
+           next-hop-unchanged` (per address-family) in FRR / Cisco IOS.
+
+           Required on the multihop eBGP VPNv4 session between the route
+           reflectors of an RR-based Inter-AS MPLS/VPN Option C (RFC 4364
+           §10c): the RRs sit outside the forwarding path, so the
+           reflected route must keep the originating PE — the true LSP
+           endpoint — as its next-hop (and its original VPN label). The
+           receiving PE resolves that PE loopback over BGP-LU.
+
+           Honored for VPN routes on the VPNv4 (SAFI 128) advertise path;
+           locally-originated routes still advertise with self as the
+           next-hop.";
+      }
       container policy {
         ext:sort "40";
         ext:help "Per-family route-policy references";


### PR DESCRIPTION
## Summary

Two halves, one purpose — reproduce **Cisco's reference design for Inter-AS Option C** (RR-based, per their *MPLS VPN Inter-AS with ASBRs Exchanging IPv4 Routes and MPLS Labels* guide):

**1. New BGP knob: per-neighbor `afi-safi <name> next-hop-unchanged`** (ietf-bgp-neighbor, alongside `next-hop-self`). A forwarded VPN route advertised to an eBGP peer keeps its received next-hop **and its received VPN label** instead of the default eBGP rewrite-to-self (locally-originated routes still rewrite). Honored on the VPNv4 advertise path — `needs_v4_rewrite` in `route_update_ipv4` plus `vpnv4_service_label` (the label must travel with the next-hop that allocated it). Follows the `vpnv4 next-hop-self` precedent exactly (per-peer VPNv4 advertisement; not part of `UpdateGroupSig`). Unit test covers both knob states.

**2. New playset `interas-option-c-rr`** — the direct-PE Option C lab plus a route reflector per AS (12 namespaces): PEs peer VPNv4 only with their local RR (`route-reflector: client: true`), the RRs exchange VPNv4 over **multihop eBGP with `next-hop-unchanged`**, RR loopbacks join the BGP-LU exchange, ASBRs unchanged (labeled loopbacks only, zero VPN state). README in the house walkthrough style with all captures verbatim, an IOS-equivalent RR config, Cisco's scalability rationale quoted, and the failure mode explained (forget the knob → next hop points at a router that never forwards). New diagram pair `InterASOptionCRR.{drawio,svg}` (render-verified) with the inter-RR arc; index row + direct-PE README cross-link added.

## Test plan

- Unit: `vpnv4_next_hop_unchanged_preserves_forwarded_next_hop` (knob on → received NH/RD preserved across eBGP advertisement; knob off → default rewrite-to-self).
- `cargo fmt` / `clippy --workspace --all-targets` / `cargo test --workspace --exclude bdd` all clean; `make install` run.
- Live lab, all captures verbatim:
  - Both VPNs converge CE-to-CE at `ttl=62` (same as direct-PE — RRs add no hops).
  - rr1's VPNv4 table: all 8 routes, far rows keep next-hop `2.2.2.3` **across the eBGP session** with the PEs' per-VRF labels untouched; the RR's own address appears in no next-hop.
  - pe1: same three-label stack (`label 16013 19 16`); asbr1: four loopback swap ILMs, empty VPNv4 table.
  - Border: still exactly two labels crossing.
  - **Out-of-path proof**: tcpdump on rr1's only link during a CE-to-CE ping — `0 packets captured` (ICMP).

🤖 Generated with [Claude Code](https://claude.com/claude-code)