### PR TITLE
playset: embed Option AB and C-RR topology diagrams in READMEs

### DIFF
--- a/playset/interas-option-ab/README.md
+++ b/playset/interas-option-ab/README.md
@@ -27,6 +27,8 @@ is, line for line, Cisco's Option AB route-distribution procedure:
 > it into VPN 1 as RD 7:N [and] advertises the route with the export RT
 > configured on the VRF rather than the originally received RTs.
 
+<img src="../images/InterASOptionAB.svg" alt="Inter-AS Option AB topology">
+
 ```
   ce1 ─┐                                                  ┌─ ce3   (cust1)
        pe1 ── p1 ── asbr1 ═══ one eBGP VPNv4 session ═══ asbr2 ── p2 ── pe2

--- a/playset/interas-option-c-rr/README.md
+++ b/playset/interas-option-c-rr/README.md
@@ -22,6 +22,8 @@ eBGP rewrite-to-self would pull traffic toward a router that does not
 forward it. The border ASBRs are unchanged from the direct-PE lab:
 labeled loopbacks (BGP-LU) only, zero VPN state.
 
+<img src="../images/InterASOptionCRR.svg" alt="Inter-AS Option C (RR-based) topology">
+
 ```
            rr1 ══ multihop eBGP VPNv4, next-hop-unchanged ══ rr2
             │                                                 │


### PR DESCRIPTION
## Summary

The `InterASOptionAB.{drawio,svg}` and `InterASOptionCRR.{drawio,svg}` topology graphs were committed alongside their playsets (PRs #1861 / #1860) and are render-verified — but their READMEs never actually referenced the SVG, so the diagrams shipped unshown. This adds the `<img>` embed above each README's ASCII diagram, matching the placement used in the option-a/b/c walkthroughs.

After this, all five Inter-AS labs render their topology:

| README | embed |
|:--|:--|
| interas-option-a | InterASOptionA.svg |
| interas-option-b | InterASOptionB.svg |
| **interas-option-ab** | **InterASOptionAB.svg** (added) |
| interas-option-c | InterASOptionC.svg |
| **interas-option-c-rr** | **InterASOptionCRR.svg** (added) |

Docs-only.

## Test plan

- Both SVGs re-rendered to PNG cleanly (cairosvg).
- Verified every Inter-AS README now contains exactly one `<img src="../images/InterASOption*.svg">`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)