### PR TITLE
playset: rebuild interas-option-b to the reference topology

### DIFF
--- a/playset/README.md
+++ b/playset/README.md
@@ -114,11 +114,11 @@ the same names first.
 ## BGP Inter-AS L3VPN
 
 Two providers, one VPN — the RFC 4364 §10 options (plus Cisco's AB
-hybrid) for handing L3VPN routes across an AS boundary. Option A builds
-the full reference topology (two PEs and three customers feeding one
-border); B, AB, and C pare it to a ten-router variant with one PE and
-two customers per side (the RR lab adds two route reflectors). The
-customers and their overlapping addressing stay the same throughout;
+hybrid) for handing L3VPN routes across an AS boundary. Options A and B
+build the full reference topology (three customers behind two PEs
+feeding one border); AB and C pare it to a ten-router variant with one
+PE and two customers per side (the RR lab adds two route reflectors).
+The customers and their overlapping addressing stay the same throughout;
 only the border model changes:
 
 |                                 | Option A       | Option B            | Option AB              | Option C       |

--- a/playset/images/InterASOptionB.drawio
+++ b/playset/images/InterASOptionB.drawio
@@ -5,22 +5,22 @@
         <mxCell id="0" />
         <mxCell id="1" parent="0" />
         <mxCell id="as1-box" parent="1" style="rounded=1;whiteSpace=wrap;html=1;fillColor=none;dashed=1;strokeColor=#999999;" value="" vertex="1">
-          <mxGeometry height="230" width="270" x="90" y="180" as="geometry" />
+          <mxGeometry height="290" width="300" x="75" y="160" as="geometry" />
         </mxCell>
         <mxCell id="as2-box" parent="1" style="rounded=1;whiteSpace=wrap;html=1;fillColor=none;dashed=1;strokeColor=#999999;" value="" vertex="1">
-          <mxGeometry height="230" width="270" x="480" y="180" as="geometry" />
+          <mxGeometry height="290" width="280" x="480" y="160" as="geometry" />
         </mxCell>
         <mxCell id="as1-cloud" parent="1" style="ellipse;shape=cloud;whiteSpace=wrap;html=1;flipV=1;flipH=1;strokeColor=#999999;" value="" vertex="1">
-          <mxGeometry height="140" width="190" x="130" y="225" as="geometry" />
+          <mxGeometry height="230" width="240" x="110" y="200" as="geometry" />
         </mxCell>
         <mxCell id="as2-cloud" parent="1" style="ellipse;shape=cloud;whiteSpace=wrap;html=1;strokeColor=#999999;" value="" vertex="1">
-          <mxGeometry height="140" width="190" x="470" y="225" as="geometry" />
+          <mxGeometry height="190" width="210" x="475" y="230" as="geometry" />
         </mxCell>
         <mxCell id="as1-label" parent="1" style="text;html=1;whiteSpace=wrap;strokeColor=none;fillColor=none;align=center;verticalAlign=middle;rounded=0;autosize=1;resizable=0;fontSize=11;" value="AS 65501" vertex="1">
-          <mxGeometry height="30" width="70" x="190" y="180" as="geometry" />
+          <mxGeometry height="30" width="70" x="190" y="160" as="geometry" />
         </mxCell>
         <mxCell id="as2-label" parent="1" style="text;html=1;whiteSpace=wrap;strokeColor=none;fillColor=none;align=center;verticalAlign=middle;rounded=0;autosize=1;resizable=0;fontSize=11;" value="AS 65502" vertex="1">
-          <mxGeometry height="30" width="70" x="580" y="180" as="geometry" />
+          <mxGeometry height="30" width="70" x="585" y="160" as="geometry" />
         </mxCell>
         <mxCell id="edge-ce1-pe1" edge="1" parent="1" source="ce1" style="endArrow=none;html=1;rounded=0;strokeColor=#0499D4;" target="pe1" value="">
           <mxGeometry height="50" relative="1" width="50" as="geometry" />
@@ -28,7 +28,13 @@
         <mxCell id="edge-ce2-pe1" edge="1" parent="1" source="ce2" style="endArrow=none;html=1;rounded=0;strokeColor=#4DA72E;" target="pe1" value="">
           <mxGeometry height="50" relative="1" width="50" as="geometry" />
         </mxCell>
+        <mxCell id="edge-ce3-pe2" edge="1" parent="1" source="ce3" style="endArrow=none;html=1;rounded=0;strokeColor=#E97131;" target="pe2" value="">
+          <mxGeometry height="50" relative="1" width="50" as="geometry" />
+        </mxCell>
         <mxCell id="edge-pe1-p1" edge="1" parent="1" source="pe1" style="endArrow=none;html=1;rounded=0;strokeColor=#A02C93;" target="p1" value="">
+          <mxGeometry height="50" relative="1" width="50" as="geometry" />
+        </mxCell>
+        <mxCell id="edge-pe2-p1" edge="1" parent="1" source="pe2" style="endArrow=none;html=1;rounded=0;strokeColor=#A02C93;" target="p1" value="">
           <mxGeometry height="50" relative="1" width="50" as="geometry" />
         </mxCell>
         <mxCell id="edge-p1-asbr1" edge="1" parent="1" source="p1" style="endArrow=none;html=1;rounded=0;strokeColor=#A02C93;" target="asbr1" value="">
@@ -37,65 +43,77 @@
         <mxCell id="edge-asbr2-p2" edge="1" parent="1" source="asbr2" style="endArrow=none;html=1;rounded=0;strokeColor=#A02C93;" target="p2" value="">
           <mxGeometry height="50" relative="1" width="50" as="geometry" />
         </mxCell>
-        <mxCell id="edge-p2-pe2" edge="1" parent="1" source="p2" style="endArrow=none;html=1;rounded=0;strokeColor=#A02C93;" target="pe2" value="">
+        <mxCell id="edge-p2-pe3" edge="1" parent="1" source="p2" style="endArrow=none;html=1;rounded=0;strokeColor=#A02C93;" target="pe3" value="">
           <mxGeometry height="50" relative="1" width="50" as="geometry" />
         </mxCell>
-        <mxCell id="edge-pe2-ce3" edge="1" parent="1" source="pe2" style="endArrow=none;html=1;rounded=0;strokeColor=#0499D4;" target="ce3" value="">
+        <mxCell id="edge-pe3-ce4" edge="1" parent="1" source="pe3" style="endArrow=none;html=1;rounded=0;strokeColor=#0499D4;" target="ce4" value="">
           <mxGeometry height="50" relative="1" width="50" as="geometry" />
         </mxCell>
-        <mxCell id="edge-pe2-ce4" edge="1" parent="1" source="pe2" style="endArrow=none;html=1;rounded=0;strokeColor=#4DA72E;" target="ce4" value="">
+        <mxCell id="edge-pe3-ce5" edge="1" parent="1" source="pe3" style="endArrow=none;html=1;rounded=0;strokeColor=#4DA72E;" target="ce5" value="">
           <mxGeometry height="50" relative="1" width="50" as="geometry" />
         </mxCell>
-        <mxCell id="edge-interas" edge="1" parent="1" source="asbr1" style="endArrow=none;html=1;rounded=0;strokeColor=#E97131;strokeWidth=2;" target="asbr2" value="">
+        <mxCell id="edge-pe3-ce6" edge="1" parent="1" source="pe3" style="endArrow=none;html=1;rounded=0;strokeColor=#E97131;" target="ce6" value="">
           <mxGeometry height="50" relative="1" width="50" as="geometry" />
         </mxCell>
-        <mxCell id="interas-label" parent="1" style="text;html=1;whiteSpace=wrap;strokeColor=none;fillColor=none;align=center;verticalAlign=middle;rounded=0;fontSize=8;fontColor=#E97131;" value="eBGP VPNv4 (labeled)" vertex="1">
-          <mxGeometry height="14" width="110" x="360" y="272" as="geometry" />
+        <mxCell id="edge-interas" edge="1" parent="1" source="asbr1" style="endArrow=none;html=1;rounded=0;dashed=1;strokeColor=#9673A6;strokeWidth=2;" target="asbr2" value="">
+          <mxGeometry height="50" relative="1" width="50" as="geometry" />
+        </mxCell>
+        <mxCell id="interas-label" parent="1" style="text;html=1;whiteSpace=wrap;strokeColor=none;fillColor=none;align=center;verticalAlign=middle;rounded=0;fontSize=9;fontColor=#D79B00;" value="eBGP VPNv4 (labeled)" vertex="1">
+          <mxGeometry height="14" width="130" x="357" y="298" as="geometry" />
         </mxCell>
         <mxCell id="pe1" parent="1" style="ellipse;whiteSpace=wrap;html=1;aspect=fixed;strokeColor=#0E9ED5;fillColor=#FFFFFF;fontSize=8;" value="pe1" vertex="1">
-          <mxGeometry height="30" width="30" x="150" y="280" as="geometry" />
-        </mxCell>
-        <mxCell id="p1" parent="1" style="ellipse;whiteSpace=wrap;html=1;aspect=fixed;strokeColor=#0E9ED5;fillColor=#FFFFFF;fontSize=8;" value="p1" vertex="1">
-          <mxGeometry height="30" width="30" x="230" y="280" as="geometry" />
-        </mxCell>
-        <mxCell id="asbr1" parent="1" style="ellipse;whiteSpace=wrap;html=1;aspect=fixed;strokeColor=#0E9ED5;fillColor=#FFFFFF;fontSize=8;" value="asbr1" vertex="1">
-          <mxGeometry height="30" width="30" x="310" y="280" as="geometry" />
-        </mxCell>
-        <mxCell id="asbr2" parent="1" style="ellipse;whiteSpace=wrap;html=1;aspect=fixed;strokeColor=#0E9ED5;fillColor=#FFFFFF;fontSize=8;" value="asbr2" vertex="1">
-          <mxGeometry height="30" width="30" x="490" y="280" as="geometry" />
-        </mxCell>
-        <mxCell id="p2" parent="1" style="ellipse;whiteSpace=wrap;html=1;aspect=fixed;strokeColor=#0E9ED5;fillColor=#FFFFFF;fontSize=8;" value="p2" vertex="1">
-          <mxGeometry height="30" width="30" x="570" y="280" as="geometry" />
+          <mxGeometry height="30" width="30" x="155" y="245" as="geometry" />
         </mxCell>
         <mxCell id="pe2" parent="1" style="ellipse;whiteSpace=wrap;html=1;aspect=fixed;strokeColor=#0E9ED5;fillColor=#FFFFFF;fontSize=8;" value="pe2" vertex="1">
-          <mxGeometry height="30" width="30" x="650" y="280" as="geometry" />
+          <mxGeometry height="30" width="30" x="155" y="365" as="geometry" />
+        </mxCell>
+        <mxCell id="p1" parent="1" style="ellipse;whiteSpace=wrap;html=1;aspect=fixed;strokeColor=#0E9ED5;fillColor=#FFFFFF;fontSize=8;" value="p1" vertex="1">
+          <mxGeometry height="30" width="30" x="240" y="305" as="geometry" />
+        </mxCell>
+        <mxCell id="asbr1" parent="1" style="ellipse;whiteSpace=wrap;html=1;aspect=fixed;strokeColor=#0E9ED5;fillColor=#FFFFFF;fontSize=8;" value="asbr1" vertex="1">
+          <mxGeometry height="30" width="30" x="325" y="305" as="geometry" />
+        </mxCell>
+        <mxCell id="asbr2" parent="1" style="ellipse;whiteSpace=wrap;html=1;aspect=fixed;strokeColor=#0E9ED5;fillColor=#FFFFFF;fontSize=8;" value="asbr2" vertex="1">
+          <mxGeometry height="30" width="30" x="490" y="305" as="geometry" />
+        </mxCell>
+        <mxCell id="p2" parent="1" style="ellipse;whiteSpace=wrap;html=1;aspect=fixed;strokeColor=#0E9ED5;fillColor=#FFFFFF;fontSize=8;" value="p2" vertex="1">
+          <mxGeometry height="30" width="30" x="570" y="305" as="geometry" />
+        </mxCell>
+        <mxCell id="pe3" parent="1" style="ellipse;whiteSpace=wrap;html=1;aspect=fixed;strokeColor=#0E9ED5;fillColor=#FFFFFF;fontSize=8;" value="pe3" vertex="1">
+          <mxGeometry height="30" width="30" x="650" y="305" as="geometry" />
         </mxCell>
         <mxCell id="ce1" parent="1" style="rounded=1;whiteSpace=wrap;html=1;fillStyle=solid;fillColor=#0499D4;strokeColor=none;fontSize=8;fontColor=#FFFFFF;" value="ce1" vertex="1">
-          <mxGeometry height="25" width="40" x="20" y="245" as="geometry" />
+          <mxGeometry height="25" width="40" x="15" y="210" as="geometry" />
         </mxCell>
         <mxCell id="ce2" parent="1" style="rounded=1;whiteSpace=wrap;html=1;fillStyle=solid;fillColor=#4DA72E;strokeColor=none;fontSize=8;fontColor=#FFFFFF;" value="ce2" vertex="1">
-          <mxGeometry height="25" width="40" x="20" y="315" as="geometry" />
+          <mxGeometry height="25" width="40" x="15" y="280" as="geometry" />
         </mxCell>
-        <mxCell id="ce3" parent="1" style="rounded=1;whiteSpace=wrap;html=1;fillStyle=solid;fillColor=#0499D4;strokeColor=none;fontSize=8;fontColor=#FFFFFF;" value="ce3" vertex="1">
-          <mxGeometry height="25" width="40" x="770" y="245" as="geometry" />
+        <mxCell id="ce3" parent="1" style="rounded=1;whiteSpace=wrap;html=1;fillStyle=solid;fillColor=#E97131;strokeColor=none;fontSize=8;fontColor=#FFFFFF;" value="ce3" vertex="1">
+          <mxGeometry height="25" width="40" x="15" y="385" as="geometry" />
         </mxCell>
-        <mxCell id="ce4" parent="1" style="rounded=1;whiteSpace=wrap;html=1;fillStyle=solid;fillColor=#4DA72E;strokeColor=none;fontSize=8;fontColor=#FFFFFF;" value="ce4" vertex="1">
-          <mxGeometry height="25" width="40" x="770" y="315" as="geometry" />
+        <mxCell id="ce4" parent="1" style="rounded=1;whiteSpace=wrap;html=1;fillStyle=solid;fillColor=#0499D4;strokeColor=none;fontSize=8;fontColor=#FFFFFF;" value="ce4" vertex="1">
+          <mxGeometry height="25" width="40" x="770" y="210" as="geometry" />
+        </mxCell>
+        <mxCell id="ce5" parent="1" style="rounded=1;whiteSpace=wrap;html=1;fillStyle=solid;fillColor=#4DA72E;strokeColor=none;fontSize=8;fontColor=#FFFFFF;" value="ce5" vertex="1">
+          <mxGeometry height="25" width="40" x="770" y="307.5" as="geometry" />
+        </mxCell>
+        <mxCell id="ce6" parent="1" style="rounded=1;whiteSpace=wrap;html=1;fillStyle=solid;fillColor=#E97131;strokeColor=none;fontSize=8;fontColor=#FFFFFF;" value="ce6" vertex="1">
+          <mxGeometry height="25" width="40" x="770" y="385" as="geometry" />
         </mxCell>
         <mxCell id="dp-ip-left" parent="1" style="rounded=0;whiteSpace=wrap;html=1;strokeColor=#999999;fontSize=11;" value="IP" vertex="1">
-          <mxGeometry height="20" width="110" x="25" y="433.62" as="geometry" />
+          <mxGeometry height="20" width="110" x="25" y="483" as="geometry" />
         </mxCell>
         <mxCell id="dp-mpls-as1" parent="1" style="shape=cylinder3;whiteSpace=wrap;html=1;boundedLbl=1;backgroundOutline=1;size=3.285714285714164;direction=south;strokeColor=#808080;fillColor=light-dark(#99CCFF,#2566A8);fontColor=#000000;fontSize=11;" value="MPLS" vertex="1">
-          <mxGeometry height="20" width="190" x="150" y="433.62" as="geometry" />
+          <mxGeometry height="20" width="205" x="150" y="483" as="geometry" />
         </mxCell>
-        <mxCell id="dp-mpls-interas" parent="1" style="shape=cylinder3;whiteSpace=wrap;html=1;boundedLbl=1;backgroundOutline=1;size=3.285714285714164;direction=south;strokeColor=#808080;fillColor=light-dark(#FBE5D6,#7A4A21);fontColor=#000000;fontSize=11;" value="MPLS" vertex="1">
-          <mxGeometry height="20" width="135" x="352" y="433.62" as="geometry" />
+        <mxCell id="dp-mpls-interas" parent="1" style="shape=cylinder3;whiteSpace=wrap;html=1;boundedLbl=1;backgroundOutline=1;size=3.285714285714164;direction=south;strokeColor=#9673A6;fillColor=light-dark(#E1D5E7,#59426B);fontColor=#000000;fontSize=11;" value="MPLS" vertex="1">
+          <mxGeometry height="20" width="120" x="367" y="483" as="geometry" />
         </mxCell>
         <mxCell id="dp-mpls-as2" parent="1" style="shape=cylinder3;whiteSpace=wrap;html=1;boundedLbl=1;backgroundOutline=1;size=3.285714285714164;direction=south;strokeColor=#808080;fillColor=light-dark(#A5E798,#003900);fontColor=#000000;fontSize=11;" value="MPLS" vertex="1">
-          <mxGeometry height="20" width="190" x="500" y="433.62" as="geometry" />
+          <mxGeometry height="20" width="190" x="500" y="483" as="geometry" />
         </mxCell>
         <mxCell id="dp-ip-right" parent="1" style="rounded=0;whiteSpace=wrap;html=1;strokeColor=#999999;fontSize=11;" value="IP" vertex="1">
-          <mxGeometry height="20" width="110" x="702" y="433.62" as="geometry" />
+          <mxGeometry height="20" width="110" x="702" y="483" as="geometry" />
         </mxCell>
       </root>
     </mxGraphModel>

--- a/playset/images/InterASOptionB.svg
+++ b/playset/images/InterASOptionB.svg
@@ -1,78 +1,88 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 830 310" font-family="Helvetica, Arial, sans-serif">
-  <!-- Inter-AS Option B (eBGP VPNv4 between ASBRs) — matches playset/interas-option-b.
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 830 400" font-family="Helvetica, Arial, sans-serif">
+  <!-- Inter-AS Option B (eBGP VPNv4 between ASBRs) — matches playset/interas-option-b:
+       three customers, two PEs in AS 65501, ONE labeled VPNv4 session at the border.
        Editable source: InterASOptionB.drawio (re-export from draw.io replaces this file). -->
-  <rect width="830" height="310" fill="#ffffff"/>
+  <rect width="830" height="400" fill="#ffffff"/>
 
   <!-- AS boxes -->
-  <rect x="90" y="20" width="270" height="230" rx="8" fill="none" stroke="#999999" stroke-dasharray="6,4"/>
-  <rect x="480" y="20" width="270" height="230" rx="8" fill="none" stroke="#999999" stroke-dasharray="6,4"/>
-  <text x="225" y="38" text-anchor="middle" font-size="12" fill="#333333">AS 65501</text>
-  <text x="615" y="38" text-anchor="middle" font-size="12" fill="#333333">AS 65502</text>
+  <rect x="75" y="30" width="300" height="290" rx="8" fill="none" stroke="#999999" stroke-dasharray="6,4"/>
+  <rect x="480" y="30" width="280" height="290" rx="8" fill="none" stroke="#999999" stroke-dasharray="6,4"/>
+  <text x="225" y="50" text-anchor="middle" font-size="12" fill="#333333">AS 65501</text>
+  <text x="620" y="50" text-anchor="middle" font-size="12" fill="#333333">AS 65502</text>
 
   <!-- provider clouds -->
   <path d="M 170,185 C 140,190 120,165 135,140 C 115,115 135,85 165,95 C 175,70 215,65 235,85 C 260,70 295,85 295,110 C 320,120 315,155 290,165 C 285,185 250,195 230,182 C 215,195 185,195 170,185 Z"
-        fill="none" stroke="#bbbbbb"/>
-  <path d="M 510,185 C 480,190 460,165 475,140 C 455,115 475,85 505,95 C 515,70 555,65 575,85 C 600,70 635,85 635,110 C 660,120 655,155 630,165 C 625,185 590,195 570,182 C 555,195 525,195 510,185 Z"
-        fill="none" stroke="#bbbbbb"/>
+        fill="none" stroke="#bbbbbb" stroke-width="0.7" transform="matrix(1.24,0,0,1.69,-32,-24)"/>
+  <path d="M 170,185 C 140,190 120,165 135,140 C 115,115 135,85 165,95 C 175,70 215,65 235,85 C 260,70 295,85 295,110 C 320,120 315,155 290,165 C 285,185 250,195 230,182 C 215,195 185,195 170,185 Z"
+        fill="none" stroke="#bbbbbb" stroke-width="0.8" transform="matrix(1.10,0,0,1.46,362,3)"/>
 
   <!-- CE-PE links -->
-  <line x1="60" y1="97.5" x2="165" y2="135" stroke="#0499D4" stroke-width="1.5"/>
-  <line x1="60" y1="167.5" x2="165" y2="135" stroke="#4DA72E" stroke-width="1.5"/>
-  <line x1="665" y1="135" x2="770" y2="97.5" stroke="#0499D4" stroke-width="1.5"/>
-  <line x1="665" y1="135" x2="770" y2="167.5" stroke="#4DA72E" stroke-width="1.5"/>
+  <line x1="55" y1="92.5" x2="170" y2="130" stroke="#0499D4" stroke-width="1.5"/>
+  <line x1="55" y1="162.5" x2="170" y2="130" stroke="#4DA72E" stroke-width="1.5"/>
+  <line x1="55" y1="267.5" x2="170" y2="250" stroke="#E97131" stroke-width="1.5"/>
+  <line x1="665" y1="190" x2="770" y2="92.5" stroke="#0499D4" stroke-width="1.5"/>
+  <line x1="665" y1="190" x2="770" y2="190" stroke="#4DA72E" stroke-width="1.5"/>
+  <line x1="665" y1="190" x2="770" y2="267.5" stroke="#E97131" stroke-width="1.5"/>
 
   <!-- intra-AS core links -->
-  <line x1="165" y1="135" x2="245" y2="135" stroke="#A02C93" stroke-width="1.5"/>
-  <line x1="245" y1="135" x2="325" y2="135" stroke="#A02C93" stroke-width="1.5"/>
-  <line x1="505" y1="135" x2="585" y2="135" stroke="#A02C93" stroke-width="1.5"/>
-  <line x1="585" y1="135" x2="665" y2="135" stroke="#A02C93" stroke-width="1.5"/>
+  <line x1="170" y1="130" x2="255" y2="190" stroke="#A02C93" stroke-width="1.5"/>
+  <line x1="170" y1="250" x2="255" y2="190" stroke="#A02C93" stroke-width="1.5"/>
+  <line x1="255" y1="190" x2="340" y2="190" stroke="#A02C93" stroke-width="1.5"/>
+  <line x1="505" y1="190" x2="585" y2="190" stroke="#A02C93" stroke-width="1.5"/>
+  <line x1="585" y1="190" x2="665" y2="190" stroke="#A02C93" stroke-width="1.5"/>
 
-  <!-- inter-AS link: ONE session, labeled VPNv4 for every customer -->
-  <line x1="340" y1="135" x2="490" y2="135" stroke="#E97131" stroke-width="2.5"/>
-  <text x="415" y="125" text-anchor="middle" font-size="9" fill="#E97131">eBGP VPNv4 (labeled)</text>
+  <!-- inter-AS: ONE session, labeled VPNv4 for every customer -->
+  <line x1="355" y1="190" x2="490" y2="190" stroke="#9673A6" stroke-width="2" stroke-dasharray="6,4"/>
+  <text x="422" y="178" text-anchor="middle" font-size="9" fill="#D79B00">eBGP VPNv4 (labeled)</text>
 
   <!-- routers -->
   <g stroke="#0E9ED5" stroke-width="1.5" fill="#ffffff">
-    <circle cx="165" cy="135" r="15"/>
-    <circle cx="245" cy="135" r="15"/>
-    <circle cx="325" cy="135" r="15"/>
-    <circle cx="505" cy="135" r="15"/>
-    <circle cx="585" cy="135" r="15"/>
-    <circle cx="665" cy="135" r="15"/>
+    <circle cx="170" cy="130" r="15"/>
+    <circle cx="170" cy="250" r="15"/>
+    <circle cx="255" cy="190" r="15"/>
+    <circle cx="340" cy="190" r="15"/>
+    <circle cx="505" cy="190" r="15"/>
+    <circle cx="585" cy="190" r="15"/>
+    <circle cx="665" cy="190" r="15"/>
   </g>
   <g text-anchor="middle" font-size="8" fill="#333333">
-    <text x="165" y="138">pe1</text>
-    <text x="245" y="138">p1</text>
-    <text x="325" y="138">asbr1</text>
-    <text x="505" y="138">asbr2</text>
-    <text x="585" y="138">p2</text>
-    <text x="665" y="138">pe2</text>
+    <text x="170" y="133">pe1</text>
+    <text x="170" y="253">pe2</text>
+    <text x="255" y="193">p1</text>
+    <text x="340" y="193">asbr1</text>
+    <text x="505" y="193">asbr2</text>
+    <text x="585" y="193">p2</text>
+    <text x="665" y="193">pe3</text>
   </g>
 
   <!-- customer edges -->
   <g font-size="9" text-anchor="middle" fill="#ffffff">
-    <rect x="20" y="85" width="40" height="25" rx="5" fill="#0499D4"/>
-    <text x="40" y="101">ce1</text>
-    <rect x="20" y="155" width="40" height="25" rx="5" fill="#4DA72E"/>
-    <text x="40" y="171">ce2</text>
-    <rect x="770" y="85" width="40" height="25" rx="5" fill="#0499D4"/>
-    <text x="790" y="101">ce3</text>
-    <rect x="770" y="155" width="40" height="25" rx="5" fill="#4DA72E"/>
-    <text x="790" y="171">ce4</text>
+    <rect x="15" y="80" width="40" height="25" rx="5" fill="#0499D4"/>
+    <text x="35" y="96">ce1</text>
+    <rect x="15" y="150" width="40" height="25" rx="5" fill="#4DA72E"/>
+    <text x="35" y="166">ce2</text>
+    <rect x="15" y="255" width="40" height="25" rx="5" fill="#E97131"/>
+    <text x="35" y="271">ce3</text>
+    <rect x="770" y="80" width="40" height="25" rx="5" fill="#0499D4"/>
+    <text x="790" y="96">ce4</text>
+    <rect x="770" y="177.5" width="40" height="25" rx="5" fill="#4DA72E"/>
+    <text x="790" y="193.5">ce5</text>
+    <rect x="770" y="255" width="40" height="25" rx="5" fill="#E97131"/>
+    <text x="790" y="271">ce6</text>
   </g>
 
-  <!-- data plane bands: MPLS end to end across the border -->
+  <!-- data plane bands: labeled across the border -->
   <g font-size="11" text-anchor="middle">
-    <rect x="25" y="273" width="110" height="20" fill="none" stroke="#999999"/>
-    <text x="80" y="287" fill="#333333">IP</text>
-    <rect x="150" y="273" width="190" height="20" rx="10" fill="#99CCFF" stroke="#808080"/>
-    <text x="245" y="287" fill="#000000">MPLS</text>
-    <rect x="352" y="273" width="135" height="20" rx="10" fill="#FBE5D6" stroke="#808080"/>
-    <text x="419" y="287" fill="#000000">MPLS</text>
-    <rect x="500" y="273" width="190" height="20" rx="10" fill="#A5E798" stroke="#808080"/>
-    <text x="595" y="287" fill="#000000">MPLS</text>
-    <rect x="702" y="273" width="110" height="20" fill="none" stroke="#999999"/>
-    <text x="757" y="287" fill="#333333">IP</text>
+    <rect x="25" y="353" width="110" height="20" fill="none" stroke="#999999"/>
+    <text x="80" y="367" fill="#333333">IP</text>
+    <rect x="150" y="353" width="205" height="20" rx="10" fill="#99CCFF" stroke="#808080"/>
+    <text x="252" y="367" fill="#000000">MPLS</text>
+    <rect x="367" y="353" width="120" height="20" rx="10" fill="#E1D5E7" stroke="#9673A6"/>
+    <text x="427" y="367" fill="#000000">MPLS</text>
+    <rect x="500" y="353" width="190" height="20" rx="10" fill="#A5E798" stroke="#808080"/>
+    <text x="595" y="367" fill="#000000">MPLS</text>
+    <rect x="702" y="353" width="110" height="20" fill="none" stroke="#999999"/>
+    <text x="757" y="367" fill="#333333">IP</text>
   </g>
 </svg>

--- a/playset/interas-option-ab/README.md
+++ b/playset/interas-option-ab/README.md
@@ -39,8 +39,8 @@ is, line for line, Cisco's Option AB route-distribution procedure:
                               and a fresh label goes on
 ```
 
-The lab is the same ten routers, two customers, and overlapping
-addressing as the B/C playsets — only the ASBRs change. One honest
+The lab is the same pared ten-router variant as the Option C playset
+(two customers, overlapping addressing) — only the ASBRs change. One honest
 note: classic Cisco AB forwards the customer *data* unlabeled over
 per-VRF subinterfaces (that is where the per-customer QoS attaches),
 with only the control session shared. This lab implements the
@@ -273,7 +273,7 @@ $ ./down.sh
 
 ## Appendix: Addressing & sessions
 
-Identical to the [Option B playset](../interas-option-b/README.md)
+Identical to the [Option C playset](../interas-option-c/README.md#appendix-addressing--sessions)
 except the ASBRs' VRFs: nodes, AS numbers, loopbacks, SR SIDs, links,
 customer addressing, and the single global inter-AS link
 (`192.168.100.0/30`) are unchanged.

--- a/playset/interas-option-b/README.md
+++ b/playset/interas-option-b/README.md
@@ -3,13 +3,12 @@
 This playset builds the second of RFC 4364 §10's multi-AS methods —
 **Option B (§10b)**, *EBGP redistribution of labeled VPN-IPv4 routes from
 AS to neighboring AS*. It is the direct sequel to
-[interas-option-a](../interas-option-a/README.md), paring that lab's
-reference topology down to one PE and two customers per side (enough to
-make this border's point) while keeping the same deliberately
-overlapping addressing — only the AS boundary changes in kind. Where
-Option A needed one dedicated link and
-one plain-IP eBGP session **per customer**, Option B collapses the border
-to **one link and one MP-eBGP VPNv4 session carrying every customer**, and
+[interas-option-a](../interas-option-a/README.md): the same reference
+topology — three customers with deliberately overlapping addressing,
+two PEs in AS 65501, one PE serving all three in AS 65502 — and only the
+AS boundary changes. Where Option A needed one dedicated link and one
+plain-IP eBGP session **per customer**, Option B collapses the border to
+**one link and one MP-eBGP VPNv4 session carrying every customer**, and
 the traffic that crosses it is **MPLS-labeled**.
 
 In Cisco's terms: the ASBRs use eBGP to advertise labeled VPNv4 routes to
@@ -24,18 +23,19 @@ provider boundary as a single label switch.
 Deliberate choices, mirrored from the Option A lab so the two walkthroughs
 diff cleanly:
 
-* **Two customers** (`cust1`: ce1↔ce3, `cust2`: ce2↔ce4) — this time to
-  show both of them sharing the *single* inter-AS session and link.
-* **Overlapping customer addressing** — both customers use the same plan
+* **Three customers** (`cust1`: ce1↔ce4, `cust2`: ce2↔ce5, `cust3`:
+  ce3↔ce6) — this time all sharing the *single* inter-AS session and
+  link, where Option A's border grew a link per customer.
+* **Overlapping customer addressing** — all three use the same plan
   (site A loopback `172.16.1.1/32`, site B `172.16.2.1/32`). In Option A,
   separate per-VRF links kept the overlap apart at the boundary; here the
   overlapping routes cross **the same session**, kept apart only by their
   route distinguishers.
 * **Coordinated route-targets, independent RDs** — the exact inverse of
   Option A's independence. VPNv4 attributes now cross the boundary intact,
-  so both providers must agree on the RTs (`65501:100` / `65501:200`,
-  owned by AS 65501 and honored by AS 65502). The RDs stay AS-local
-  (`65501:x` vs `65502:x`) — only the RT drives VRF import.
+  so both providers must agree on the RTs (`65501:100`/`200`/`300`, owned
+  by AS 65501 and honored by AS 65502). The RDs stay AS-local (`65501:x`
+  vs `65502:x`) — only the RT drives VRF import.
 
 ## Bring up all nodes
 
@@ -43,25 +43,24 @@ diff cleanly:
 $ ./up.sh
 bring up
 ...
-apply config: ce3
+apply config: ce5
 applied
-apply config: ce4
+apply config: ce6
 applied
 ```
 
-Same ten namespaces as Option A (`ce1 ce2 pe1 p1 asbr1` + `asbr2 p2 pe2
-ce3 ce4`) — bring up only one of the Inter-AS labs at a time; they share
-namespace names.
+Same thirteen namespaces as Option A (`ce1 ce2 ce3 pe1 pe2 p1 asbr1` +
+`asbr2 p2 pe3 ce4 ce5 ce6`) — bring up only one of the Inter-AS labs at a
+time; they share namespace names.
 
 ## What changed since Option A: only the border
 
-The CEs are the same plain eBGP speakers as in Option A — a customer cannot
-tell which option carries it. The P routers are identical. The PEs differ
-in exactly one thing: `pe2`'s VRFs now import/export **AS 65501's**
-route-targets:
+The CEs are the same plain eBGP speakers — a customer cannot tell which
+option carries it. The P routers are identical. The PEs differ in exactly
+one thing: `pe3`'s VRFs now import/export **AS 65501's** route-targets:
 
 ``` yaml
-# pe2.yaml — RTs coordinated across the ASes (RDs still 65502:x)
+# pe3.yaml — RTs coordinated across the ASes (RDs still 65502:x)
 vrf:
 - name: cust1
   ipv4:
@@ -108,13 +107,20 @@ router:
       as: 65501
       router-id: 1.1.1.3
     neighbor:
-    - remote-address: 1.1.1.1        # iBGP VPNv4 into the AS core
+    - remote-address: 1.1.1.1        # iBGP VPNv4 to PE1
       remote-as: 65501
       update-source: 1.1.1.3
       afi-safi:
       - name: vpnv4
         enabled: true
         next-hop-self: true          # <- the Option B knob
+    - remote-address: 1.1.1.4        # iBGP VPNv4 to PE2, same knob
+      remote-as: 65501
+      update-source: 1.1.1.3
+      afi-safi:
+      - name: vpnv4
+        enabled: true
+        next-hop-self: true
     - remote-address: 192.168.100.2  # eBGP VPNv4 to ASBR2 — ALL customers
       remote-as: 65502
       afi-safi:
@@ -133,11 +139,12 @@ Three things to read out of it:
     (no VRFs configured)
   ```
 
-* **`next-hop-self: true` on the iBGP VPNv4 leg.** A route re-advertised
-  from AS 65502 would otherwise reach PE1 with ASBR2's inter-AS link
-  address as its next hop — an address AS 65501's IGP cannot resolve.
-  With next-hop-self, PE1 sees ASBR1's loopback (reachable via SR) and
-  ASBR1's own label, making ASBR1 the label-swap point.
+* **`next-hop-self: true` on the iBGP VPNv4 legs** (one per PE). A route
+  re-advertised from AS 65502 would otherwise reach the PEs with ASBR2's
+  inter-AS link address as its next hop — an address AS 65501's IGP
+  cannot resolve. With next-hop-self, the PEs see ASBR1's loopback
+  (reachable via SR) and ASBR1's own label, making ASBR1 the label-swap
+  point.
 * **The inter-AS link is in the global table and not in the IGP** — yet it
   carries MPLS, because labeled VPNv4 packets, not IP, cross it.
 
@@ -146,34 +153,41 @@ For orientation, the same node in classic Cisco IOS terms:
 ```
 router bgp 65501
  neighbor 1.1.1.1 remote-as 65501          ! iBGP to PE1
+ neighbor 1.1.1.4 remote-as 65501          ! iBGP to PE2
  neighbor 192.168.100.2 remote-as 65502    ! eBGP to ASBR2
  address-family vpnv4
   neighbor 1.1.1.1 activate
   neighbor 1.1.1.1 send-community extended
   neighbor 1.1.1.1 next-hop-self
+  neighbor 1.1.1.4 activate
+  neighbor 1.1.1.4 send-community extended
+  neighbor 1.1.1.4 next-hop-self
   neighbor 192.168.100.2 activate
   neighbor 192.168.100.2 send-community extended
 ! no "ip vrf" anywhere; IOS enables "mpls bgp forwarding" on the
 ! inter-AS interface when the VPNv4 session comes up over it
 ```
 
-## Control plane: four RDs on one session
+## Control plane: six RDs on one session
 
 ``` shell
 asbr1>show bgp summary
 ...
 VPNv4 Unicast Summary:
 BGP router identifier 1.1.1.3, local AS number 65501 VRF default vrf-id 0
-RIB entries 8
-Peers 2
+RIB entries 12
+Peers 3
 
 Neighbor        V         AS   MsgRcvd   MsgSent   TblVer  InQ OutQ  Up/Down State       PfxRcd/Snt Hostname
-1.1.1.1         4      65501         6         2        0    0    0 00:00:56 Established        4/4 s
-192.168.100.2   4      65502         6         3        0    0    0 00:00:56 Established        4/4 s
+1.1.1.1         4      65501         6         2        0    0    0 00:00:51 Established        4/6 s
+1.1.1.4         4      65501         5         2        0    0    0 00:00:51 Established        2/6 s
+192.168.100.2   4      65502         7         3        0    0    0 00:00:51 Established        6/6 s
 ```
 
-Two sessions total — where the Option A ASBR needed one per customer, and
-would need one more for every customer added. Its VPNv4 table:
+One iBGP session per PE inward, and **one eBGP session outward carrying
+all six far prefixes** — where the Option A ASBR needed a session per
+customer, and would need one more for every customer added. Its VPNv4
+table:
 
 ``` shell
 asbr1>show bgp vpnv4
@@ -188,78 +202,93 @@ Route Distinguisher: 65501:2
      rt:65501:200 label=17,
  *>i [1] 172.16.1.1/32      1.1.1.1                  0    100      0 65512 i
      rt:65501:200 label=17,
+Route Distinguisher: 65501:3
+ *>i [1] 10.13.0.0/30       1.1.1.4                  0    100      0 65513 i
+     rt:65501:300 label=16,
+ *>i [1] 172.16.1.1/32      1.1.1.4                  0    100      0 65513 i
+     rt:65501:300 label=16,
 Route Distinguisher: 65502:1
- *>  [1] 10.13.0.0/30       192.168.100.2            0             0 65502 65513 i
+ *>  [1] 10.14.0.0/30       192.168.100.2            0             0 65502 65514 i
      rt:65501:100 label=22,
- *>  [1] 172.16.2.1/32      192.168.100.2            0             0 65502 65513 i
+ *>  [1] 172.16.2.1/32      192.168.100.2            0             0 65502 65514 i
      rt:65501:100 label=23,
 Route Distinguisher: 65502:2
- *>  [1] 10.14.0.0/30       192.168.100.2            0             0 65502 65514 i
-     rt:65501:200 label=20,
- *>  [1] 172.16.2.1/32      192.168.100.2            0             0 65502 65514 i
-     rt:65501:200 label=21,
+ *>  [1] 10.15.0.0/30       192.168.100.2            0             0 65502 65515 i
+     rt:65501:200 label=25,
+ *>  [1] 172.16.2.1/32      192.168.100.2            0             0 65502 65515 i
+     rt:65501:200 label=24,
+Route Distinguisher: 65502:3
+ *>  [1] 10.16.0.0/30       192.168.100.2            0             0 65502 65516 i
+     rt:65501:300 label=26,
+ *>  [1] 172.16.2.1/32      192.168.100.2            0             0 65502 65516 i
+     rt:65501:300 label=27,
 ```
 
 Compare this against the same command in the Option A walkthrough:
 
-* **The far AS's RDs cross unchanged.** `65502:1` and `65502:2` appear
+* **The far AS's RDs cross unchanged.** `65502:1`/`2`/`3` appear
   verbatim — Option B relays VPNv4 routes; it does not re-originate them
-  under the local RD the way an Option A ASBR (being a PE) does. Both
-  customers' overlapping `172.16.2.1/32` arrived over *one* session,
-  distinguished purely by RD.
-* **Per-prefix labels, not per-VRF.** The far routes carry the labels
-  ASBR2 advertised (`20`–`23`, one per (RD, prefix)); the local AS's
-  routes carry PE1's per-VRF labels (`16`/`17`). No VRF exists here to
-  terminate a label, so labels must be swapped route-by-route.
-* The AS path (`65502 65513`) records the same eBGP crossing as Option A —
-  the transport mechanics differ, the BGP loop protection is identical.
+  under the local RD the way an Option A ASBR (being a PE) does. All
+  three customers' overlapping `172.16.2.1/32` arrived over *one*
+  session, distinguished purely by RD.
+* **The iBGP rows name their PE**: cust1/cust2 from `1.1.1.1`,
+  cust3 from `1.1.1.4` — the border aggregates every PE's exports over
+  one session per PE.
+* **Per-prefix labels on the far routes** (`22`–`27`, one per
+  (RD, prefix)); the local AS's routes carry the PEs' per-VRF labels.
+  No VRF exists here to terminate a label, so labels must be swapped
+  route-by-route.
 
 The kernel MPLS table is the whole forwarding story in one screen — every
-`proto bgp` line an incoming-label → outgoing-label swap:
+`proto bgp` line an incoming-label → outgoing-label swap, and the inward
+swaps name the owning PE (`16011` = pe1, `16014` = pe2):
 
 ``` shell
-asbr1>ip -f mpls route
-16 as to 16011/16 via inet 10.1.0.5 dev asbr1-p1 proto bgp
-17 as to 16011/16 via inet 10.1.0.5 dev asbr1-p1 proto bgp
+asbr1>ip -f mpls route | grep bgp
+16 as to 16014/16 via inet 10.1.0.5 dev asbr1-p1 proto bgp
+17 as to 16014/16 via inet 10.1.0.5 dev asbr1-p1 proto bgp
 18 as to 16011/17 via inet 10.1.0.5 dev asbr1-p1 proto bgp
 19 as to 16011/17 via inet 10.1.0.5 dev asbr1-p1 proto bgp
-20 as to 21 via inet 192.168.100.2 dev asbr1-asbr2 proto bgp
-21 as to 20 via inet 192.168.100.2 dev asbr1-asbr2 proto bgp
-22 as to 23 via inet 192.168.100.2 dev asbr1-asbr2 proto bgp
-23 as to 22 via inet 192.168.100.2 dev asbr1-asbr2 proto bgp
-15000 via inet 10.1.0.5 dev asbr1-p1 proto isis
-16011 as to 16011 via inet 10.1.0.5 dev asbr1-p1 proto isis
-16012 via inet 10.1.0.5 dev asbr1-p1 proto isis
-16013 via inet 1.1.1.3 dev lo proto isis
+20 as to 16011/16 via inet 10.1.0.5 dev asbr1-p1 proto bgp
+21 as to 16011/16 via inet 10.1.0.5 dev asbr1-p1 proto bgp
+22 as to 26 via inet 192.168.100.2 dev asbr1-asbr2 proto bgp
+23 as to 27 via inet 192.168.100.2 dev asbr1-asbr2 proto bgp
+24 as to 25 via inet 192.168.100.2 dev asbr1-asbr2 proto bgp
+25 as to 24 via inet 192.168.100.2 dev asbr1-asbr2 proto bgp
+26 as to 22 via inet 192.168.100.2 dev asbr1-asbr2 proto bgp
+27 as to 23 via inet 192.168.100.2 dev asbr1-asbr2 proto bgp
 ```
 
 Two swap families:
 
-* `16`–`19` are ASBR1's local labels for **AS 65501's own routes** (the
+* `16`–`21` are ASBR1's local labels for **AS 65501's own routes** (the
   labels it advertised to ASBR2). Each swaps to a two-label stack —
-  transport `16011` to PE1's loopback plus PE1's VRF label `16`/`17` —
-  and heads into the SR core.
-* `20`–`23` are ASBR1's local labels for the **far AS's routes** (the
-  labels it advertised to PE1, thanks to next-hop-self). Each swaps to
-  the label ASBR2 advertised and heads out the inter-AS link — a
+  transport to the owning PE's loopback plus that PE's VRF label — and
+  heads into the SR core.
+* `22`–`27` are ASBR1's local labels for the **far AS's routes** (the
+  labels it advertised to the PEs, thanks to next-hop-self). Each swaps
+  to the label ASBR2 advertised and heads out the inter-AS link — a
   single-label switch across the provider boundary.
 
-PE1's view closes the loop — the far route's next hop has been rewritten
-to ASBR1's loopback carrying ASBR1's local label, and the VRF route
-resolves to a two-label stack over the SR core:
+The PEs' views close the loop — the far routes' next hop has been
+rewritten to ASBR1's loopback carrying ASBR1's local label, and each
+VRF route resolves to a two-label stack over the SR core:
 
 ``` shell
 pe1>show bgp vpnv4
 Route Distinguisher: 65502:1
- *>i [1] 10.13.0.0/30       1.1.1.3                  0    100      0 65502 65513 i
-     rt:65501:100 label=23,
- *>i [1] 172.16.2.1/32      1.1.1.3                  0    100      0 65502 65513 i
-     rt:65501:100 label=22,
+ *>i [1] 10.14.0.0/30       1.1.1.3                  0    100      0 65502 65514 i
+     rt:65501:100 label=26,
+ *>i [1] 172.16.2.1/32      1.1.1.3                  0    100      0 65502 65514 i
+     rt:65501:100 label=27,
 
 pe1>show ip route vrf cust1
 ...
-B  *> 10.13.0.0/30 [200/0] via 10.1.0.2, pe1-p1, label 16013 23, 00:01:16
-B  *> 172.16.2.1/32 [200/0] via 10.1.0.2, pe1-p1, label 16013 22, 00:01:16
+B  *> 172.16.2.1/32 [200/0] via 10.1.0.2, pe1-p1, label 16013 27, 00:01:15
+
+pe2>show ip route vrf cust3
+...
+B  *> 172.16.2.1/32 [200/0] via 10.1.0.10, pe2-p1, label 16013 23, 00:01:16
 ```
 
 ## Data plane: labeled all the way across
@@ -268,34 +297,41 @@ B  *> 172.16.2.1/32 [200/0] via 10.1.0.2, pe1-p1, label 16013 22, 00:01:16
 $ sudo ip netns exec ce1 vty
 ce1>ping 172.16.2.1
 PING 172.16.2.1 (172.16.2.1) 56(84) bytes of data.
-64 bytes from 172.16.2.1: icmp_seq=1 ttl=60 time=0.042 ms
-64 bytes from 172.16.2.1: icmp_seq=2 ttl=60 time=0.281 ms
+64 bytes from 172.16.2.1: icmp_seq=1 ttl=60 time=0.073 ms
+64 bytes from 172.16.2.1: icmp_seq=2 ttl=60 time=0.265 ms
 ```
 
 Capturing the same ping inside AS 65501 and on the inter-AS link:
 
 ``` shell
-p1>tcpdump -nli p1-pe1 mpls                       # pe1 -> p1 segment
-MPLS (label 16013, tc 0, ttl 63) (label 22, tc 0, [S], ttl 63) IP 10.11.0.1 > 172.16.2.1: ICMP echo request ...
-MPLS (label 16, tc 0, [S], ttl 61) IP 172.16.2.1 > 10.11.0.1: ICMP echo reply ...
+p1>tcpdump -nli p1-pe1 'mpls 16013'               # pe1 -> p1 segment
+MPLS (label 16013, tc 0, ttl 63) (label 27, tc 0, [S], ttl 63) IP 10.11.0.1 > 172.16.2.1: ICMP echo request ...
 
 asbr1>tcpdump -nli asbr1-asbr2 mpls               # between the ASes
 MPLS (label 23, tc 0, [S], ttl 62) IP 10.11.0.1 > 172.16.2.1: ICMP echo request ...
-MPLS (label 16, tc 0, [S], ttl 62) IP 172.16.2.1 > 10.11.0.1: ICMP echo reply ...
+MPLS (label 21, tc 0, [S], ttl 62) IP 172.16.2.1 > 10.11.0.1: ICMP echo reply ...
 ```
 
 Follow the request's labels against the tables above: PE1 imposed
-`[16013 | 22]` (transport to ASBR1 + ASBR1's transit label); P1 popped the
-PHP'd transport; ASBR1 executed `22 as to 23` — and the packet crossed the
-provider boundary carrying **exactly one MPLS label**, ASBR2's `23`. No
-transport label is needed on the border hop (the ASBRs are directly
-connected), and the VPN label never disappears the way it did in Option A
-— where this same capture point showed plain IP. The reply rides the
-mirror chain (ASBR2 swaps toward ASBR1's `16`).
+`[16013 | 27]` (transport to ASBR1 + ASBR1's transit label for
+172.16.2.1 in cust1); P1 popped the PHP'd transport; ASBR1 executed
+`27 as to 23` — and the packet crossed the provider boundary carrying
+**exactly one MPLS label**, ASBR2's `23`. No transport label is needed
+on the border hop (the ASBRs are directly connected), and the VPN label
+never disappears the way it did in Option A — where this same capture
+point showed plain IP. The reply rides the mirror chain (ASBR2 swaps
+toward ASBR1's `21`, cust1's route back to pe1).
 
-The overlap proof from Option A holds unchanged — ce1's and ce2's pings to
-the same `172.16.2.1` land on ce3 and ce4 respectively, zero leakage —
-but note what carries them now: the same wire, the same session, two
+The overlap proof from Option A holds unchanged — each customer's ping
+to the same `172.16.2.1` lands only on its own site-B router:
+
+|                  | arrives at ce4 | arrives at ce5 | arrives at ce6 |
+|:-----------------|:---------------|:---------------|:---------------|
+| ce1 (cust1) pings | **yes**       | —              | —              |
+| ce2 (cust2) pings | —             | **yes**        | —              |
+| ce3 (cust3) pings | —             | —              | **yes**        |
+
+— but note what carries them now: the same wire, the same session, three
 different label chains selected by RD.
 
 ## The trade, in both directions
@@ -337,33 +373,22 @@ $ ./down.sh
 
 ## Appendix: Addressing & sessions
 
-| node  | role             | AS    | loopback     | SR SID (label)  |
-|:------|:-----------------|:------|:-------------|:----------------|
-| ce1   | CE, cust1 site A | 65511 | 172.16.1.1/32 | —              |
-| ce2   | CE, cust2 site A | 65512 | 172.16.1.1/32 | —              |
-| pe1   | PE               | 65501 | 1.1.1.1/32   | 11 (16011)      |
-| p1    | P                | 65501 | 1.1.1.2/32   | 12 (16012)      |
-| asbr1 | ASBR             | 65501 | 1.1.1.3/32   | 13 (16013)      |
-| asbr2 | ASBR             | 65502 | 2.2.2.1/32   | 21 (16021)      |
-| p2    | P                | 65502 | 2.2.2.2/32   | 22 (16022)      |
-| pe2   | PE               | 65502 | 2.2.2.3/32   | 23 (16023)      |
-| ce3   | CE, cust1 site B | 65513 | 172.16.2.1/32 | —              |
-| ce4   | CE, cust2 site B | 65514 | 172.16.2.1/32 | —              |
+Identical to the [Option A playset](../interas-option-a/README.md#appendix-addressing--sessions)
+except the border: nodes, AS numbers, loopbacks, SR SIDs, PE-CE links,
+and customer addressing are unchanged; the three per-VRF inter-AS links
+are replaced by one global-table link, `asbr1-asbr2` =
+`192.168.100.0/30` (.1/.2).
 
-Links: ce1–pe1 `10.11.0.0/30`, ce2–pe1 `10.12.0.0/30`, pe1–p1
-`10.1.0.0/30`, p1–asbr1 `10.1.0.4/30`, asbr2–p2 `10.2.0.0/30`, p2–pe2
-`10.2.0.4/30`, pe2–ce3 `10.13.0.0/30`, pe2–ce4 `10.14.0.0/30`; the
-border is one global-table link, `asbr1-asbr2` = `192.168.100.0/30`
-(.1/.2).
+| VPN   | RT (coordinated)  | RD on pe1/pe2 | RD on pe3 |
+|:------|:------------------|:--------------|:----------|
+| cust1 | 65501:100         | 65501:1 (pe1) | 65502:1   |
+| cust2 | 65501:200         | 65501:2 (pe1) | 65502:2   |
+| cust3 | 65501:300         | 65501:3 (pe2) | 65502:3   |
 
-| VPN   | RT (coordinated)  | RD on pe1 | RD on pe2 |
-|:------|:------------------|:----------|:----------|
-| cust1 | 65501:100         | 65501:1   | 65502:1   |
-| cust2 | 65501:200         | 65501:2   | 65502:2   |
-
-BGP sessions: 4× PE-CE eBGP IPv4 (in VRF), 2× iBGP VPNv4 over loopbacks
-(pe1–asbr1 and asbr2–pe2, ASBR side with `next-hop-self`), and **one**
-ASBR-ASBR eBGP VPNv4 session — the Option B boundary.
+BGP sessions: 6× PE-CE eBGP IPv4 (in VRF), 3× iBGP VPNv4 over loopbacks
+(pe1–asbr1 and pe2–asbr1 with `next-hop-self` on the ASBR side,
+asbr2–pe3 likewise), and **one** ASBR-ASBR eBGP VPNv4 session — the
+Option B boundary.
 
 ## Sources
 

--- a/playset/interas-option-b/asbr1.yaml
+++ b/playset/interas-option-b/asbr1.yaml
@@ -3,10 +3,11 @@
 #  - eBGP VPNv4 directly to ASBR2 over the inter-AS link — labeled VPNv4
 #    NLRI (RFC 8277) crosses the boundary; the link is in the GLOBAL
 #    table and not in the IGP, and it carries MPLS.
-#  - iBGP VPNv4 to PE1 with `next-hop-self`: a route re-advertised from
-#    AS 65502 must reach PE1 carrying ASBR1's IGP-reachable loopback (and
-#    ASBR1's freshly allocated swap label), not the inter-AS link address
-#    ASBR2 set as next hop.
+#  - iBGP VPNv4 to PE1 and PE2 (one session per PE) with
+#    `next-hop-self`: a route re-advertised from AS 65502 must reach the
+#    PEs carrying ASBR1's IGP-reachable loopback (and ASBR1's freshly
+#    allocated swap label), not the inter-AS link address ASBR2 set as
+#    next hop.
 #  - For each re-advertised route the ASBR allocates a local label and
 #    installs a swap ILM (local label -> received label, toward the
 #    original next hop) — the VPN crosses the border as a label switch.
@@ -50,6 +51,15 @@ router:
         ebgp: 1
     neighbor:
     - remote-address: 1.1.1.1
+      remote-as: 65501
+      timers: {connect-retry-time: 3}
+      update-source: 1.1.1.3
+      enabled: true
+      afi-safi:
+      - name: vpnv4
+        enabled: true
+        next-hop-self: true
+    - remote-address: 1.1.1.4
       remote-as: 65501
       timers: {connect-retry-time: 3}
       update-source: 1.1.1.3

--- a/playset/interas-option-b/asbr2.yaml
+++ b/playset/interas-option-b/asbr2.yaml
@@ -1,6 +1,6 @@
 # ASBR2 — autonomous system border router of AS 65502. Mirror of ASBR1:
 # no VRFs, eBGP VPNv4 to ASBR1 over the global inter-AS link, iBGP VPNv4
-# with next-hop-self toward PE2, per-route swap ILMs.
+# with next-hop-self toward PE3, per-route swap ILMs.
 interface:
 - if-name: lo
   ipv4:

--- a/playset/interas-option-b/ce1.yaml
+++ b/playset/interas-option-b/ce1.yaml
@@ -1,6 +1,7 @@
-# CE1 — customer "cust1", site A (AS 65511). Identical to the Option A
-# playset: plain eBGP to PE1, loopback originated via `redistribute
-# connected`. The customer cannot tell which Inter-AS option carries it.
+# CE1 — customer "cust1", site A (AS 65511). Plain eBGP to PE1; the
+# loopback 172.16.1.1/32 is originated via `redistribute connected` and
+# is the ping source toward site B. cust2's CE2 uses the *same* loopback
+# address — the VPNs keep the overlap apart.
 interface:
 - if-name: lo
   ipv4:

--- a/playset/interas-option-b/ce2.yaml
+++ b/playset/interas-option-b/ce2.yaml
@@ -1,6 +1,6 @@
 # CE2 — customer "cust2", site A (AS 65512). Same loopback address as
-# CE1 (172.16.1.1/32) on purpose: in Option B both customers' overlapping
-# routes cross ONE inter-AS session, kept apart only by their RDs.
+# CE1 (172.16.1.1/32) on purpose: the two customers run overlapping
+# address plans and never notice each other.
 interface:
 - if-name: lo
   ipv4:

--- a/playset/interas-option-b/ce3.yaml
+++ b/playset/interas-option-b/ce3.yaml
@@ -1,9 +1,11 @@
-# CE3 — customer "cust1", site B (AS 65513). The far end of cust1:
-# ce1 pings this router's loopback 172.16.2.1/32 across both ASes.
+# CE3 — customer "cust3", site A (AS 65513), attached to PE2. Same
+# loopback address as CE1 and CE2 (172.16.1.1/32) on purpose: all three
+# customers run the same overlapping address plan and never notice each
+# other.
 interface:
 - if-name: lo
   ipv4:
-    address: 172.16.2.1/32
+    address: 172.16.1.1/32
 - if-name: ce3-pe2
   ipv4:
     address: 10.13.0.1/30
@@ -19,7 +21,7 @@ router:
         ebgp: 3
     neighbor:
     - remote-address: 10.13.0.2
-      remote-as: 65502
+      remote-as: 65501
       timers: {connect-retry-time: 3}
       enabled: true
       afi-safi:

--- a/playset/interas-option-b/ce5.yaml
+++ b/playset/interas-option-b/ce5.yaml
@@ -1,26 +1,25 @@
-# CE4 — customer "cust1", site B (AS 65514), attached to PE3. The far
-# end of cust1: ce1 pings this router's loopback 172.16.2.1/32 across
-# both ASes. CE5 and CE6 answer to the same address for their own
-# customers.
+# CE5 — customer "cust2", site B (AS 65515), attached to PE3. Same
+# loopback address as CE4 and CE6 (172.16.2.1/32): ce2 pinging
+# 172.16.2.1 must land here and nowhere else.
 interface:
 - if-name: lo
   ipv4:
     address: 172.16.2.1/32
-- if-name: ce4-pe3
+- if-name: ce5-pe3
   ipv4:
-    address: 10.14.0.1/30
+    address: 10.15.0.1/30
 system:
-  hostname: ce4
+  hostname: ce5
 router:
   bgp:
     global:
-      as: 65514
-      router-id: 10.14.0.1
+      as: 65515
+      router-id: 10.15.0.1
     timer:
       adv-interval:
         ebgp: 3
     neighbor:
-    - remote-address: 10.14.0.2
+    - remote-address: 10.15.0.2
       remote-as: 65502
       timers: {connect-retry-time: 3}
       enabled: true

--- a/playset/interas-option-b/ce6.yaml
+++ b/playset/interas-option-b/ce6.yaml
@@ -1,26 +1,25 @@
-# CE4 — customer "cust1", site B (AS 65514), attached to PE3. The far
-# end of cust1: ce1 pings this router's loopback 172.16.2.1/32 across
-# both ASes. CE5 and CE6 answer to the same address for their own
-# customers.
+# CE6 — customer "cust3", site B (AS 65516), attached to PE3. Same
+# loopback address as CE4 and CE5 (172.16.2.1/32): ce3 pinging
+# 172.16.2.1 must land here and nowhere else.
 interface:
 - if-name: lo
   ipv4:
     address: 172.16.2.1/32
-- if-name: ce4-pe3
+- if-name: ce6-pe3
   ipv4:
-    address: 10.14.0.1/30
+    address: 10.16.0.1/30
 system:
-  hostname: ce4
+  hostname: ce6
 router:
   bgp:
     global:
-      as: 65514
-      router-id: 10.14.0.1
+      as: 65516
+      router-id: 10.16.0.1
     timer:
       adv-interval:
         ebgp: 3
     neighbor:
-    - remote-address: 10.14.0.2
+    - remote-address: 10.16.0.2
       remote-as: 65502
       timers: {connect-retry-time: 3}
       enabled: true

--- a/playset/interas-option-b/p1.yaml
+++ b/playset/interas-option-b/p1.yaml
@@ -1,6 +1,6 @@
 # P1 — provider core transit LSR of AS 65501 (runs no BGP, knows no
-# VPN). Pure IS-IS L2 + SR-MPLS; swaps / PHPs the transport label
-# between PE1 (sid 11 -> 16011) and ASBR1 (sid 13 -> 16013).
+# VPN). Pure IS-IS L2 + SR-MPLS; label-switches between PE1 (sid 11 ->
+# 16011), PE2 (sid 14 -> 16014), and ASBR1 (sid 13 -> 16013).
 interface:
 - if-name: lo
   ipv4:
@@ -8,6 +8,9 @@ interface:
 - if-name: p1-pe1
   ipv4:
     address: 10.1.0.2/30
+- if-name: p1-pe2
+  ipv4:
+    address: 10.1.0.10/30
 - if-name: p1-asbr1
   ipv4:
     address: 10.1.0.5/30
@@ -27,6 +30,11 @@ router:
         prefix-sid:
           index: 12
     - if-name: p1-pe1
+      network-type: point-to-point
+      metric: 10
+      ipv4:
+        enabled: true
+    - if-name: p1-pe2
       network-type: point-to-point
       metric: 10
       ipv4:

--- a/playset/interas-option-b/p2.yaml
+++ b/playset/interas-option-b/p2.yaml
@@ -1,6 +1,6 @@
 # P2 — provider core transit LSR of AS 65502 (runs no BGP, knows no
 # VPN). Pure IS-IS L2 + SR-MPLS; swaps / PHPs the transport label
-# between ASBR2 (sid 21 -> 16021) and PE2 (sid 23 -> 16023).
+# between ASBR2 (sid 21 -> 16021) and PE3 (sid 23 -> 16023).
 interface:
 - if-name: lo
   ipv4:
@@ -8,7 +8,7 @@ interface:
 - if-name: p2-asbr2
   ipv4:
     address: 10.2.0.2/30
-- if-name: p2-pe2
+- if-name: p2-pe3
   ipv4:
     address: 10.2.0.5/30
 system:
@@ -31,7 +31,7 @@ router:
       metric: 10
       ipv4:
         enabled: true
-    - if-name: p2-pe2
+    - if-name: p2-pe3
       network-type: point-to-point
       metric: 10
       ipv4:

--- a/playset/interas-option-b/pe1.yaml
+++ b/playset/interas-option-b/pe1.yaml
@@ -1,6 +1,7 @@
-# PE1 — provider edge, AS 65501. Same shape as the Option A playset with
-# one crucial difference: the route-targets are COORDINATED with AS 65502
-# (both providers import/export 65501:100 / 65501:200) — in Option B the
+# PE1 — provider edge, AS 65501, serving cust1 (CE1) and cust2 (CE2).
+# Same shape as the Option A playset with one crucial difference: the
+# route-targets are COORDINATED with AS 65502 (both providers
+# import/export 65501:100 / 65501:200 / 65501:300) — in Option B the
 # VPNv4 routes cross the boundary with their attributes intact, so the
 # far PE imports by the same RT.
 vrf:

--- a/playset/interas-option-b/pe2.yaml
+++ b/playset/interas-option-b/pe2.yaml
@@ -1,88 +1,68 @@
-# PE2 — provider edge, AS 65502. Note: the route-targets match AS
-# 65501's (65501:100 / 65501:200) — Option B carries VPNv4 attributes
-# across the boundary, so the providers must agree on RTs. The RDs stay
-# AS-local (65502:1 / 65502:2): only the RT drives import.
+# PE2 — second provider edge of AS 65501, serving cust3 (CE3). Same
+# pattern as PE1: coordinated RT (65501:300), its own iBGP VPNv4
+# session to ASBR1.
 vrf:
-- name: cust1
+- name: cust3
   ipv4:
     route-target:
       import:
-      - 65501:100
+      - 65501:300
       export:
-      - 65501:100
-- name: cust2
-  ipv4:
-    route-target:
-      import:
-      - 65501:200
-      export:
-      - 65501:200
+      - 65501:300
 interface:
 - if-name: lo
   ipv4:
-    address: 2.2.2.3/32
-- if-name: pe2-p2
-  ipv4:
-    address: 10.2.0.6/30
+    address: 1.1.1.4/32
 - if-name: pe2-ce3
-  vrf: cust1
+  vrf: cust3
   ipv4:
     address: 10.13.0.2/30
-- if-name: pe2-ce4
-  vrf: cust2
+- if-name: pe2-p1
   ipv4:
-    address: 10.14.0.2/30
+    address: 10.1.0.9/30
 system:
   hostname: pe2
 router:
   isis:
-    net: 49.0002.0000.0000.0003.00
+    net: 49.0001.0000.0000.0004.00
     hostname: pe2
     is-type: level-2-only
     segment-routing: mpls
-    te-router-id: 2.2.2.3
+    te-router-id: 1.1.1.4
     interface:
     - if-name: lo
       ipv4:
         enabled: true
         prefix-sid:
-          index: 23
-    - if-name: pe2-p2
+          index: 14
+    - if-name: pe2-p1
       network-type: point-to-point
       metric: 10
       ipv4:
         enabled: true
   bgp:
     global:
-      as: 65502
-      router-id: 2.2.2.3
+      as: 65501
+      router-id: 1.1.1.4
     timer:
       adv-interval:
         ibgp: 1
         ebgp: 3
     neighbor:
-    - remote-address: 2.2.2.1
-      remote-as: 65502
+    - remote-address: 1.1.1.3
+      remote-as: 65501
       timers: {connect-retry-time: 3}
-      update-source: 2.2.2.3
+      update-source: 1.1.1.4
       enabled: true
       afi-safi:
       - name: vpnv4
         enabled: true
     vrf:
-    - name: cust1
-      rd: 65502:1
+    - name: cust3
+      rd: 65501:3
       neighbor:
       - remote-address: 10.13.0.1
         remote-as: 65513
-        afi-safi:
-        - name: ipv4
-          enabled: true
-    - name: cust2
-      rd: 65502:2
-      neighbor:
-      - remote-address: 10.14.0.1
-        remote-as: 65514
         afi-safi:
         - name: ipv4
           enabled: true

--- a/playset/interas-option-b/pe3.yaml
+++ b/playset/interas-option-b/pe3.yaml
@@ -1,0 +1,108 @@
+# PE3 — the provider edge of AS 65502, serving all three customers
+# (CE4/CE5/CE6). Note: the route-targets match AS 65501's (65501:100 /
+# 65501:200 / 65501:300) — Option B carries VPNv4 attributes across the
+# boundary, so the providers must agree on RTs. The RDs stay AS-local
+# (65502:1/2/3): only the RT drives import.
+vrf:
+- name: cust1
+  ipv4:
+    route-target:
+      import:
+      - 65501:100
+      export:
+      - 65501:100
+- name: cust2
+  ipv4:
+    route-target:
+      import:
+      - 65501:200
+      export:
+      - 65501:200
+- name: cust3
+  ipv4:
+    route-target:
+      import:
+      - 65501:300
+      export:
+      - 65501:300
+interface:
+- if-name: lo
+  ipv4:
+    address: 2.2.2.3/32
+- if-name: pe3-p2
+  ipv4:
+    address: 10.2.0.6/30
+- if-name: pe3-ce4
+  vrf: cust1
+  ipv4:
+    address: 10.14.0.2/30
+- if-name: pe3-ce5
+  vrf: cust2
+  ipv4:
+    address: 10.15.0.2/30
+- if-name: pe3-ce6
+  vrf: cust3
+  ipv4:
+    address: 10.16.0.2/30
+system:
+  hostname: pe3
+router:
+  isis:
+    net: 49.0002.0000.0000.0003.00
+    hostname: pe3
+    is-type: level-2-only
+    segment-routing: mpls
+    te-router-id: 2.2.2.3
+    interface:
+    - if-name: lo
+      ipv4:
+        enabled: true
+        prefix-sid:
+          index: 23
+    - if-name: pe3-p2
+      network-type: point-to-point
+      metric: 10
+      ipv4:
+        enabled: true
+  bgp:
+    global:
+      as: 65502
+      router-id: 2.2.2.3
+    timer:
+      adv-interval:
+        ibgp: 1
+        ebgp: 3
+    neighbor:
+    - remote-address: 2.2.2.1
+      remote-as: 65502
+      timers: {connect-retry-time: 3}
+      update-source: 2.2.2.3
+      enabled: true
+      afi-safi:
+      - name: vpnv4
+        enabled: true
+    vrf:
+    - name: cust1
+      rd: 65502:1
+      neighbor:
+      - remote-address: 10.14.0.1
+        remote-as: 65514
+        afi-safi:
+        - name: ipv4
+          enabled: true
+    - name: cust2
+      rd: 65502:2
+      neighbor:
+      - remote-address: 10.15.0.1
+        remote-as: 65515
+        afi-safi:
+        - name: ipv4
+          enabled: true
+    - name: cust3
+      rd: 65502:3
+      neighbor:
+      - remote-address: 10.16.0.1
+        remote-as: 65516
+        afi-safi:
+        - name: ipv4
+          enabled: true

--- a/playset/interas-option-b/topology.sh
+++ b/playset/interas-option-b/topology.sh
@@ -1,26 +1,33 @@
-# Inter-AS Option B (eBGP VPNv4 between ASBRs) demo topology.
+# Inter-AS Option B (eBGP VPNv4 between ASBRs) demo topology — the
+# reference diagram (images/InterASOptionB.svg): three customers, two
+# PEs in AS 65501, ONE labeled inter-AS link carrying every customer.
 # Each PLAYSET_LINKS entry is "ns_a:iface_a:ns_b:iface_b".
 #
-#   ce1 ─┐                                             ┌─ ce3   (cust1)
-#        pe1 ── p1 ── asbr1 ═══ one labeled link ═══ asbr2 ── p2 ── pe2
-#   ce2 ─┘        AS 65501     (all VPNs, MPLS!)      AS 65502      └─ ce4   (cust2)
+#   ce1 ─┐                                                     ┌─ ce4  (cust1)
+#   ce2 ─┴ pe1 ─┐                                              ├─ ce5  (cust2)
+#               p1 ── asbr1 ═══ one VPNv4 session ═══ asbr2 ── p2 ── pe3
+#   ce3 ── pe2 ┘        AS 65501   (labeled, all      AS 65502    └─ ce6  (cust3)
+#                                   customers)
 
-PLAYSET_NAMESPACES=(ce1 ce2 pe1 p1 asbr1 asbr2 p2 pe2 ce3 ce4)
+PLAYSET_NAMESPACES=(ce1 ce2 ce3 pe1 pe2 p1 asbr1 asbr2 p2 pe3 ce4 ce5 ce6)
 
 PLAYSET_LINKS=(
     ce1:ce1-pe1:pe1:pe1-ce1
     ce2:ce2-pe1:pe1:pe1-ce2
+    ce3:ce3-pe2:pe2:pe2-ce3
     pe1:pe1-p1:p1:p1-pe1
+    pe2:pe2-p1:p1:p1-pe2
     p1:p1-asbr1:asbr1:asbr1-p1
     asbr1:asbr1-asbr2:asbr2:asbr2-asbr1
     asbr2:asbr2-p2:p2:p2-asbr2
-    p2:p2-pe2:pe2:pe2-p2
-    pe2:pe2-ce3:ce3:ce3-pe2
-    pe2:pe2-ce4:ce4:ce4-pe2
+    p2:p2-pe3:pe3:pe3-p2
+    pe3:pe3-ce4:ce4:ce4-pe3
+    pe3:pe3-ce5:ce5:ce5-pe3
+    pe3:pe3-ce6:ce6:ce6-pe3
 )
 
 # All namespaces that run zebra-rs.
-PLAYSET_DAEMONS=(ce1 ce2 pe1 p1 asbr1 asbr2 p2 pe2 ce3 ce4)
+PLAYSET_DAEMONS=(ce1 ce2 ce3 pe1 pe2 p1 asbr1 asbr2 p2 pe3 ce4 ce5 ce6)
 
 # Routers with vtyctl YAML config.
-PLAYSET_ROUTERS=(ce1 ce2 pe1 p1 asbr1 asbr2 p2 pe2 ce3 ce4)
+PLAYSET_ROUTERS=(ce1 ce2 ce3 pe1 pe2 p1 asbr1 asbr2 p2 pe3 ce4 ce5 ce6)

--- a/playset/interas-option-c/README.md
+++ b/playset/interas-option-c/README.md
@@ -10,10 +10,10 @@ to egress PE — the border ASBRs just switch the middle label.
 
 This playset completes the arc begun by
 [interas-option-a](../interas-option-a/README.md) and
-[interas-option-b](../interas-option-b/README.md) — the same pared
-ten-router lab as Option B (one PE and two customers per side, with the
-same overlapping addressing), and only the border model changed a third
-time. The headline numbers to watch:
+[interas-option-b](../interas-option-b/README.md) — a pared ten-router
+variant of their reference topology (one PE and two customers per side,
+with the same overlapping addressing), and only the border model changed
+a third time. The headline numbers to watch:
 
 |                                | Option A | Option B | Option C |
 |:-------------------------------|:---------|:---------|:---------|
@@ -306,11 +306,26 @@ $ ./down.sh
 
 ## Appendix: Addressing & sessions
 
-Nodes, AS numbers, loopbacks, SR SIDs, PE-CE links, and customer
-addressing are identical to
-[interas-option-b](../interas-option-b/README.md#appendix-addressing--sessions),
-including the one global-table border link `asbr1-asbr2` =
-`192.168.100.0/30`.
+This lab (and its AB and C-RR siblings) uses the pared ten-node variant
+of the reference topology:
+
+| node  | role             | AS    | loopback     | SR SID (label)  |
+|:------|:-----------------|:------|:-------------|:----------------|
+| ce1   | CE, cust1 site A | 65511 | 172.16.1.1/32 | —              |
+| ce2   | CE, cust2 site A | 65512 | 172.16.1.1/32 | —              |
+| pe1   | PE               | 65501 | 1.1.1.1/32   | 11 (16011)      |
+| p1    | P                | 65501 | 1.1.1.2/32   | 12 (16012)      |
+| asbr1 | ASBR             | 65501 | 1.1.1.3/32   | 13 (16013)      |
+| asbr2 | ASBR             | 65502 | 2.2.2.1/32   | 21 (16021)      |
+| p2    | P                | 65502 | 2.2.2.2/32   | 22 (16022)      |
+| pe2   | PE               | 65502 | 2.2.2.3/32   | 23 (16023)      |
+| ce3   | CE, cust1 site B | 65513 | 172.16.2.1/32 | —              |
+| ce4   | CE, cust2 site B | 65514 | 172.16.2.1/32 | —              |
+
+Links: ce1–pe1 `10.11.0.0/30`, ce2–pe1 `10.12.0.0/30`, pe1–p1
+`10.1.0.0/30`, p1–asbr1 `10.1.0.4/30`, asbr2–p2 `10.2.0.0/30`, p2–pe2
+`10.2.0.4/30`, pe2–ce3 `10.13.0.0/30`, pe2–ce4 `10.14.0.0/30`; the
+border is one global-table link `asbr1-asbr2` = `192.168.100.0/30`.
 
 | VPN   | RT (coordinated)  | RD on pe1 | RD on pe2 |
 |:------|:------------------|:----------|:----------|


### PR DESCRIPTION
## Summary

Conforms the Option B lab to the reference diagram (`optionb.png` → `images/InterASOptionB.*`), matching the reworked Option A's thirteen-node topology with only the border differing:

- **Three customers** (cust1 ce1↔ce4, cust2 ce2↔ce5, cust3 ce3↔ce6), **two PEs in AS 65501** (pe1 → ce1/ce2, pe2 → ce3), pe3 serving all three in AS 65502 — all riding **one** global-table link and **one** eBGP VPNv4 session, labeled.
- ASBR1 runs an iBGP VPNv4 session per PE, each with `next-hop-self`; RTs coordinated across the ASes (`65501:100/200/300`), RDs AS-local.
- Diagram pair redrawn to the reference layout: purple dashed "eBGP VPNv4 (labeled)" session, MPLS middle band (render-verified).
- **Sibling consistency**: with A and B both on the reference topology, Option C's appendix now owns the pared ten-node table (AB references C instead of B); C/AB intros describe themselves as the pared variant; the index frames A+B as the full topology that AB/C pare down.

## Test plan

Full live run; every README capture re-taken verbatim:
- All three VPNs converge end-to-end at `ttl=60` (converged first try).
- asbr1: 3 VPNv4 sessions (pe1 4/6, pe2 2/6, asbr2 6/6); `(no VRFs configured)`; **six RDs on one session** with far RDs relayed unchanged and iBGP rows naming their PE.
- Kernel ILM: twelve per-prefix swaps — inward stacks name the owning PE (`16 as to 16014/16` → pe2, `20 as to 16011/16` → pe1), outward swaps to asbr2's labels.
- Wire: `[16013|27]` at ingress; **single label** crossing the border (`27 as to 23` visible against the tables).
- 3×3 landing matrix: perfect diagonal (ce1→ce4, ce2→ce5, ce3→ce6 only).
- Config/docs-only change; no daemon code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)