### PR TITLE
playset: rebuild interas-option-c-rr to the reference topology

### DIFF
--- a/playset/README.md
+++ b/playset/README.md
@@ -116,10 +116,10 @@ the same names first.
 Two providers, one VPN — the RFC 4364 §10 options (plus Cisco's AB
 hybrid) for handing L3VPN routes across an AS boundary. Options A and B
 build the full reference topology (three customers behind two PEs
-feeding one border); AB and C pare it to a ten-router variant with one
-PE and two customers per side (the RR lab adds two route reflectors).
-The customers and their overlapping addressing stay the same throughout;
-only the border model changes:
+feeding one border), and the RR lab extends it with a route reflector
+per AS; AB and C pare it to a ten-router variant with one PE and two
+customers per side. The customers and their overlapping addressing stay
+the same throughout; only the border model changes:
 
 |                                 | Option A       | Option B            | Option AB              | Option C       |
 |:--------------------------------|:---------------|:--------------------|:-----------------------|:---------------|

--- a/playset/images/InterASOptionCRR.drawio
+++ b/playset/images/InterASOptionCRR.drawio
@@ -5,32 +5,32 @@
         <mxCell id="0" />
         <mxCell id="1" parent="0" />
         <mxCell id="as1-box" parent="1" style="rounded=1;whiteSpace=wrap;html=1;fillColor=none;dashed=1;strokeColor=#999999;" value="" vertex="1">
-          <mxGeometry height="235" width="270" x="90" y="185" as="geometry" />
+          <mxGeometry height="290" width="300" x="75" y="160" as="geometry" />
         </mxCell>
         <mxCell id="as2-box" parent="1" style="rounded=1;whiteSpace=wrap;html=1;fillColor=none;dashed=1;strokeColor=#999999;" value="" vertex="1">
-          <mxGeometry height="235" width="270" x="480" y="185" as="geometry" />
+          <mxGeometry height="290" width="280" x="480" y="160" as="geometry" />
+        </mxCell>
+        <mxCell id="as1-cloud" parent="1" style="ellipse;shape=cloud;whiteSpace=wrap;html=1;flipV=1;flipH=1;strokeColor=#999999;" value="" vertex="1">
+          <mxGeometry height="230" width="240" x="110" y="200" as="geometry" />
+        </mxCell>
+        <mxCell id="as2-cloud" parent="1" style="ellipse;shape=cloud;whiteSpace=wrap;html=1;strokeColor=#999999;" value="" vertex="1">
+          <mxGeometry height="190" width="210" x="475" y="230" as="geometry" />
         </mxCell>
         <mxCell id="as1-label" parent="1" style="text;html=1;whiteSpace=wrap;strokeColor=none;fillColor=none;align=center;verticalAlign=middle;rounded=0;autosize=1;resizable=0;fontSize=11;" value="AS 65501" vertex="1">
-          <mxGeometry height="30" width="70" x="145" y="185" as="geometry" />
+          <mxGeometry height="30" width="70" x="125" y="160" as="geometry" />
         </mxCell>
         <mxCell id="as2-label" parent="1" style="text;html=1;whiteSpace=wrap;strokeColor=none;fillColor=none;align=center;verticalAlign=middle;rounded=0;autosize=1;resizable=0;fontSize=11;" value="AS 65502" vertex="1">
-          <mxGeometry height="30" width="70" x="625" y="185" as="geometry" />
+          <mxGeometry height="30" width="70" x="655" y="160" as="geometry" />
         </mxCell>
         <mxCell id="edge-rr-rr" edge="1" parent="1" source="rr1" style="endArrow=none;html=1;rounded=0;curved=1;dashed=1;strokeColor=#B8860B;exitX=0.5;exitY=0;exitDx=0;exitDy=0;entryX=0.5;entryY=0;entryDx=0;entryDy=0;" target="rr2" value="">
           <mxGeometry height="50" relative="1" width="50" as="geometry">
             <Array as="points">
-              <mxPoint x="415" y="140" />
+              <mxPoint x="422" y="120" />
             </Array>
           </mxGeometry>
         </mxCell>
         <mxCell id="rr-rr-label" parent="1" style="text;html=1;whiteSpace=wrap;strokeColor=none;fillColor=none;align=center;verticalAlign=middle;rounded=0;fontSize=9;fontColor=#B8860B;" value="multihop eBGP VPNv4, next-hop-unchanged" vertex="1">
-          <mxGeometry height="14" width="230" x="300" y="125" as="geometry" />
-        </mxCell>
-        <mxCell id="edge-pe1-rr1" edge="1" parent="1" source="pe1" style="endArrow=none;html=1;rounded=0;dashed=1;dashPattern=3 3;strokeColor=#B8860B;" target="rr1" value="iBGP VPNv4 (client)">
-          <mxGeometry height="50" relative="1" width="50" as="geometry" />
-        </mxCell>
-        <mxCell id="edge-pe2-rr2" edge="1" parent="1" source="pe2" style="endArrow=none;html=1;rounded=0;dashed=1;dashPattern=3 3;strokeColor=#B8860B;" target="rr2" value="iBGP VPNv4 (client)">
-          <mxGeometry height="50" relative="1" width="50" as="geometry" />
+          <mxGeometry height="14" width="230" x="307" y="108" as="geometry" />
         </mxCell>
         <mxCell id="edge-rr1-p1" edge="1" parent="1" source="rr1" style="endArrow=none;html=1;rounded=0;strokeColor=#A02C93;" target="p1" value="">
           <mxGeometry height="50" relative="1" width="50" as="geometry" />
@@ -44,7 +44,13 @@
         <mxCell id="edge-ce2-pe1" edge="1" parent="1" source="ce2" style="endArrow=none;html=1;rounded=0;strokeColor=#4DA72E;" target="pe1" value="">
           <mxGeometry height="50" relative="1" width="50" as="geometry" />
         </mxCell>
+        <mxCell id="edge-ce3-pe2" edge="1" parent="1" source="ce3" style="endArrow=none;html=1;rounded=0;strokeColor=#E97131;" target="pe2" value="">
+          <mxGeometry height="50" relative="1" width="50" as="geometry" />
+        </mxCell>
         <mxCell id="edge-pe1-p1" edge="1" parent="1" source="pe1" style="endArrow=none;html=1;rounded=0;strokeColor=#A02C93;" target="p1" value="">
+          <mxGeometry height="50" relative="1" width="50" as="geometry" />
+        </mxCell>
+        <mxCell id="edge-pe2-p1" edge="1" parent="1" source="pe2" style="endArrow=none;html=1;rounded=0;strokeColor=#A02C93;" target="p1" value="">
           <mxGeometry height="50" relative="1" width="50" as="geometry" />
         </mxCell>
         <mxCell id="edge-p1-asbr1" edge="1" parent="1" source="p1" style="endArrow=none;html=1;rounded=0;strokeColor=#A02C93;" target="asbr1" value="">
@@ -53,71 +59,77 @@
         <mxCell id="edge-asbr2-p2" edge="1" parent="1" source="asbr2" style="endArrow=none;html=1;rounded=0;strokeColor=#A02C93;" target="p2" value="">
           <mxGeometry height="50" relative="1" width="50" as="geometry" />
         </mxCell>
-        <mxCell id="edge-p2-pe2" edge="1" parent="1" source="p2" style="endArrow=none;html=1;rounded=0;strokeColor=#A02C93;" target="pe2" value="">
+        <mxCell id="edge-p2-pe3" edge="1" parent="1" source="p2" style="endArrow=none;html=1;rounded=0;strokeColor=#A02C93;" target="pe3" value="">
           <mxGeometry height="50" relative="1" width="50" as="geometry" />
         </mxCell>
-        <mxCell id="edge-pe2-ce3" edge="1" parent="1" source="pe2" style="endArrow=none;html=1;rounded=0;strokeColor=#0499D4;" target="ce3" value="">
+        <mxCell id="edge-pe3-ce4" edge="1" parent="1" source="pe3" style="endArrow=none;html=1;rounded=0;strokeColor=#0499D4;" target="ce4" value="">
           <mxGeometry height="50" relative="1" width="50" as="geometry" />
         </mxCell>
-        <mxCell id="edge-pe2-ce4" edge="1" parent="1" source="pe2" style="endArrow=none;html=1;rounded=0;strokeColor=#4DA72E;" target="ce4" value="">
+        <mxCell id="edge-pe3-ce5" edge="1" parent="1" source="pe3" style="endArrow=none;html=1;rounded=0;strokeColor=#4DA72E;" target="ce5" value="">
           <mxGeometry height="50" relative="1" width="50" as="geometry" />
         </mxCell>
-        <mxCell id="edge-interas" edge="1" parent="1" source="asbr1" style="endArrow=none;html=1;rounded=0;strokeColor=#E97131;strokeWidth=2;" target="asbr2" value="">
+        <mxCell id="edge-pe3-ce6" edge="1" parent="1" source="pe3" style="endArrow=none;html=1;rounded=0;strokeColor=#E97131;" target="ce6" value="">
           <mxGeometry height="50" relative="1" width="50" as="geometry" />
         </mxCell>
-        <mxCell id="interas-label" parent="1" style="text;html=1;whiteSpace=wrap;strokeColor=none;fillColor=none;align=center;verticalAlign=middle;rounded=0;fontSize=8;fontColor=#E97131;" value="eBGP labeled-unicast (BGP-LU)" vertex="1">
-          <mxGeometry height="14" width="160" x="335" y="307" as="geometry" />
+        <mxCell id="edge-interas" edge="1" parent="1" source="asbr1" style="endArrow=none;html=1;rounded=0;dashed=1;strokeColor=#9673A6;strokeWidth=2;" target="asbr2" value="">
+          <mxGeometry height="50" relative="1" width="50" as="geometry" />
+        </mxCell>
+        <mxCell id="interas-label" parent="1" style="text;html=1;whiteSpace=wrap;strokeColor=none;fillColor=none;align=center;verticalAlign=middle;rounded=0;fontSize=10;fontColor=#333333;" value="BGP LU" vertex="1">
+          <mxGeometry height="14" width="60" x="392" y="330" as="geometry" />
         </mxCell>
         <mxCell id="rr1" parent="1" style="ellipse;whiteSpace=wrap;html=1;aspect=fixed;strokeColor=#0E9ED5;fillColor=#FFFFFF;fontSize=8;" value="rr1" vertex="1">
-          <mxGeometry height="30" width="30" x="230" y="205" as="geometry" />
+          <mxGeometry height="30" width="30" x="285" y="200" as="geometry" />
         </mxCell>
         <mxCell id="rr2" parent="1" style="ellipse;whiteSpace=wrap;html=1;aspect=fixed;strokeColor=#0E9ED5;fillColor=#FFFFFF;fontSize=8;" value="rr2" vertex="1">
-          <mxGeometry height="30" width="30" x="570" y="205" as="geometry" />
+          <mxGeometry height="30" width="30" x="530" y="200" as="geometry" />
         </mxCell>
         <mxCell id="pe1" parent="1" style="ellipse;whiteSpace=wrap;html=1;aspect=fixed;strokeColor=#0E9ED5;fillColor=#FFFFFF;fontSize=8;" value="pe1" vertex="1">
-          <mxGeometry height="30" width="30" x="150" y="315" as="geometry" />
-        </mxCell>
-        <mxCell id="p1" parent="1" style="ellipse;whiteSpace=wrap;html=1;aspect=fixed;strokeColor=#0E9ED5;fillColor=#FFFFFF;fontSize=8;" value="p1" vertex="1">
-          <mxGeometry height="30" width="30" x="230" y="315" as="geometry" />
-        </mxCell>
-        <mxCell id="asbr1" parent="1" style="ellipse;whiteSpace=wrap;html=1;aspect=fixed;strokeColor=#0E9ED5;fillColor=#FFFFFF;fontSize=8;" value="asbr1" vertex="1">
-          <mxGeometry height="30" width="30" x="310" y="315" as="geometry" />
-        </mxCell>
-        <mxCell id="asbr2" parent="1" style="ellipse;whiteSpace=wrap;html=1;aspect=fixed;strokeColor=#0E9ED5;fillColor=#FFFFFF;fontSize=8;" value="asbr2" vertex="1">
-          <mxGeometry height="30" width="30" x="490" y="315" as="geometry" />
-        </mxCell>
-        <mxCell id="p2" parent="1" style="ellipse;whiteSpace=wrap;html=1;aspect=fixed;strokeColor=#0E9ED5;fillColor=#FFFFFF;fontSize=8;" value="p2" vertex="1">
-          <mxGeometry height="30" width="30" x="570" y="315" as="geometry" />
+          <mxGeometry height="30" width="30" x="155" y="245" as="geometry" />
         </mxCell>
         <mxCell id="pe2" parent="1" style="ellipse;whiteSpace=wrap;html=1;aspect=fixed;strokeColor=#0E9ED5;fillColor=#FFFFFF;fontSize=8;" value="pe2" vertex="1">
-          <mxGeometry height="30" width="30" x="650" y="315" as="geometry" />
+          <mxGeometry height="30" width="30" x="155" y="365" as="geometry" />
+        </mxCell>
+        <mxCell id="p1" parent="1" style="ellipse;whiteSpace=wrap;html=1;aspect=fixed;strokeColor=#0E9ED5;fillColor=#FFFFFF;fontSize=8;" value="p1" vertex="1">
+          <mxGeometry height="30" width="30" x="240" y="305" as="geometry" />
+        </mxCell>
+        <mxCell id="asbr1" parent="1" style="ellipse;whiteSpace=wrap;html=1;aspect=fixed;strokeColor=#0E9ED5;fillColor=#FFFFFF;fontSize=8;" value="asbr1" vertex="1">
+          <mxGeometry height="30" width="30" x="325" y="305" as="geometry" />
+        </mxCell>
+        <mxCell id="asbr2" parent="1" style="ellipse;whiteSpace=wrap;html=1;aspect=fixed;strokeColor=#0E9ED5;fillColor=#FFFFFF;fontSize=8;" value="asbr2" vertex="1">
+          <mxGeometry height="30" width="30" x="490" y="305" as="geometry" />
+        </mxCell>
+        <mxCell id="p2" parent="1" style="ellipse;whiteSpace=wrap;html=1;aspect=fixed;strokeColor=#0E9ED5;fillColor=#FFFFFF;fontSize=8;" value="p2" vertex="1">
+          <mxGeometry height="30" width="30" x="570" y="305" as="geometry" />
+        </mxCell>
+        <mxCell id="pe3" parent="1" style="ellipse;whiteSpace=wrap;html=1;aspect=fixed;strokeColor=#0E9ED5;fillColor=#FFFFFF;fontSize=8;" value="pe3" vertex="1">
+          <mxGeometry height="30" width="30" x="650" y="305" as="geometry" />
         </mxCell>
         <mxCell id="ce1" parent="1" style="rounded=1;whiteSpace=wrap;html=1;fillStyle=solid;fillColor=#0499D4;strokeColor=none;fontSize=8;fontColor=#FFFFFF;" value="ce1" vertex="1">
-          <mxGeometry height="25" width="40" x="20" y="280" as="geometry" />
+          <mxGeometry height="25" width="40" x="15" y="210" as="geometry" />
         </mxCell>
         <mxCell id="ce2" parent="1" style="rounded=1;whiteSpace=wrap;html=1;fillStyle=solid;fillColor=#4DA72E;strokeColor=none;fontSize=8;fontColor=#FFFFFF;" value="ce2" vertex="1">
-          <mxGeometry height="25" width="40" x="20" y="355" as="geometry" />
+          <mxGeometry height="25" width="40" x="15" y="280" as="geometry" />
         </mxCell>
-        <mxCell id="ce3" parent="1" style="rounded=1;whiteSpace=wrap;html=1;fillStyle=solid;fillColor=#0499D4;strokeColor=none;fontSize=8;fontColor=#FFFFFF;" value="ce3" vertex="1">
-          <mxGeometry height="25" width="40" x="770" y="280" as="geometry" />
+        <mxCell id="ce3" parent="1" style="rounded=1;whiteSpace=wrap;html=1;fillStyle=solid;fillColor=#E97131;strokeColor=none;fontSize=8;fontColor=#FFFFFF;" value="ce3" vertex="1">
+          <mxGeometry height="25" width="40" x="15" y="385" as="geometry" />
         </mxCell>
-        <mxCell id="ce4" parent="1" style="rounded=1;whiteSpace=wrap;html=1;fillStyle=solid;fillColor=#4DA72E;strokeColor=none;fontSize=8;fontColor=#FFFFFF;" value="ce4" vertex="1">
-          <mxGeometry height="25" width="40" x="770" y="355" as="geometry" />
+        <mxCell id="ce4" parent="1" style="rounded=1;whiteSpace=wrap;html=1;fillStyle=solid;fillColor=#0499D4;strokeColor=none;fontSize=8;fontColor=#FFFFFF;" value="ce4" vertex="1">
+          <mxGeometry height="25" width="40" x="770" y="210" as="geometry" />
+        </mxCell>
+        <mxCell id="ce5" parent="1" style="rounded=1;whiteSpace=wrap;html=1;fillStyle=solid;fillColor=#4DA72E;strokeColor=none;fontSize=8;fontColor=#FFFFFF;" value="ce5" vertex="1">
+          <mxGeometry height="25" width="40" x="770" y="307.5" as="geometry" />
+        </mxCell>
+        <mxCell id="ce6" parent="1" style="rounded=1;whiteSpace=wrap;html=1;fillStyle=solid;fillColor=#E97131;strokeColor=none;fontSize=8;fontColor=#FFFFFF;" value="ce6" vertex="1">
+          <mxGeometry height="25" width="40" x="770" y="385" as="geometry" />
         </mxCell>
         <mxCell id="dp-ip-left" parent="1" style="rounded=0;whiteSpace=wrap;html=1;strokeColor=#999999;fontSize=11;" value="IP" vertex="1">
-          <mxGeometry height="20" width="110" x="25" y="443" as="geometry" />
+          <mxGeometry height="20" width="110" x="25" y="493" as="geometry" />
         </mxCell>
-        <mxCell id="dp-mpls-as1" parent="1" style="shape=cylinder3;whiteSpace=wrap;html=1;boundedLbl=1;backgroundOutline=1;size=3.285714285714164;direction=south;strokeColor=#808080;fillColor=light-dark(#99CCFF,#2566A8);fontColor=#000000;fontSize=11;" value="MPLS" vertex="1">
-          <mxGeometry height="20" width="190" x="150" y="443" as="geometry" />
-        </mxCell>
-        <mxCell id="dp-mpls-interas" parent="1" style="shape=cylinder3;whiteSpace=wrap;html=1;boundedLbl=1;backgroundOutline=1;size=3.285714285714164;direction=south;strokeColor=#808080;fillColor=light-dark(#FBE5D6,#7A4A21);fontColor=#000000;fontSize=11;" value="MPLS" vertex="1">
-          <mxGeometry height="20" width="135" x="352" y="443" as="geometry" />
-        </mxCell>
-        <mxCell id="dp-mpls-as2" parent="1" style="shape=cylinder3;whiteSpace=wrap;html=1;boundedLbl=1;backgroundOutline=1;size=3.285714285714164;direction=south;strokeColor=#808080;fillColor=light-dark(#A5E798,#003900);fontColor=#000000;fontSize=11;" value="MPLS" vertex="1">
-          <mxGeometry height="20" width="190" x="500" y="443" as="geometry" />
+        <mxCell id="dp-mpls" parent="1" style="shape=cylinder3;whiteSpace=wrap;html=1;boundedLbl=1;backgroundOutline=1;size=3.285714285714164;direction=south;strokeColor=#808080;fillColor=light-dark(#99CCFF,#2566A8);fontColor=#000000;fontSize=11;" value="MPLS" vertex="1">
+          <mxGeometry height="20" width="540" x="150" y="493" as="geometry" />
         </mxCell>
         <mxCell id="dp-ip-right" parent="1" style="rounded=0;whiteSpace=wrap;html=1;strokeColor=#999999;fontSize=11;" value="IP" vertex="1">
-          <mxGeometry height="20" width="110" x="702" y="443" as="geometry" />
+          <mxGeometry height="20" width="110" x="702" y="493" as="geometry" />
         </mxCell>
       </root>
     </mxGraphModel>

--- a/playset/images/InterASOptionCRR.svg
+++ b/playset/images/InterASOptionCRR.svg
@@ -1,93 +1,97 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 830 350" font-family="Helvetica, Arial, sans-serif">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 830 410" font-family="Helvetica, Arial, sans-serif">
   <!-- Inter-AS Option C, RR-based (Cisco reference design)
-       — matches playset/interas-option-c-rr.
+       — matches playset/interas-option-c-rr: three customers, two PEs in
+       AS 65501, a route reflector per AS, BGP-LU at the border.
        Editable source: InterASOptionCRR.drawio (re-export from draw.io replaces this file). -->
-  <rect width="830" height="350" fill="#ffffff"/>
+  <rect width="830" height="410" fill="#ffffff"/>
 
   <!-- inter-RR multihop eBGP VPNv4 session with next-hop-unchanged -->
-  <path d="M 245,85 Q 415,-45 585,85" fill="none" stroke="#B8860B" stroke-width="1.5" stroke-dasharray="6,4"/>
-  <text x="415" y="16" text-anchor="middle" font-size="9" fill="#B8860B">multihop eBGP VPNv4, next-hop-unchanged</text>
+  <path d="M 300,70 Q 422,-30 545,70" fill="none" stroke="#B8860B" stroke-width="1.5" stroke-dasharray="6,4"/>
+  <text x="422" y="16" text-anchor="middle" font-size="9" fill="#B8860B">multihop eBGP VPNv4, next-hop-unchanged</text>
 
   <!-- AS boxes -->
-  <rect x="90" y="55" width="270" height="235" rx="8" fill="none" stroke="#999999" stroke-dasharray="6,4"/>
-  <rect x="480" y="55" width="270" height="235" rx="8" fill="none" stroke="#999999" stroke-dasharray="6,4"/>
-  <text x="180" y="73" text-anchor="middle" font-size="12" fill="#333333">AS 65501</text>
-  <text x="660" y="73" text-anchor="middle" font-size="12" fill="#333333">AS 65502</text>
+  <rect x="75" y="30" width="300" height="290" rx="8" fill="none" stroke="#999999" stroke-dasharray="6,4"/>
+  <rect x="480" y="30" width="280" height="290" rx="8" fill="none" stroke="#999999" stroke-dasharray="6,4"/>
+  <text x="160" y="50" text-anchor="middle" font-size="12" fill="#333333">AS 65501</text>
+  <text x="690" y="50" text-anchor="middle" font-size="12" fill="#333333">AS 65502</text>
 
-  <!-- PE-RR iBGP VPNv4 client sessions -->
-  <line x1="172" y1="186" x2="238" y2="112" stroke="#B8860B" stroke-width="1.2" stroke-dasharray="3,3"/>
-  <line x1="658" y1="186" x2="592" y2="112" stroke="#B8860B" stroke-width="1.2" stroke-dasharray="3,3"/>
-  <text x="166" y="140" text-anchor="middle" font-size="8" fill="#B8860B">iBGP VPNv4</text>
-  <text x="164" y="150" text-anchor="middle" font-size="8" fill="#B8860B">(RR client)</text>
-  <text x="664" y="140" text-anchor="middle" font-size="8" fill="#B8860B">iBGP VPNv4</text>
-  <text x="666" y="150" text-anchor="middle" font-size="8" fill="#B8860B">(RR client)</text>
+  <!-- provider clouds -->
+  <path d="M 170,185 C 140,190 120,165 135,140 C 115,115 135,85 165,95 C 175,70 215,65 235,85 C 260,70 295,85 295,110 C 320,120 315,155 290,165 C 285,185 250,195 230,182 C 215,195 185,195 170,185 Z"
+        fill="none" stroke="#bbbbbb" stroke-width="0.7" transform="matrix(1.24,0,0,1.69,-32,-24)"/>
+  <path d="M 170,185 C 140,190 120,165 135,140 C 115,115 135,85 165,95 C 175,70 215,65 235,85 C 260,70 295,85 295,110 C 320,120 315,155 290,165 C 285,185 250,195 230,182 C 215,195 185,195 170,185 Z"
+        fill="none" stroke="#bbbbbb" stroke-width="0.8" transform="matrix(1.10,0,0,1.46,362,3)"/>
 
   <!-- RR attachment links -->
-  <line x1="245" y1="100" x2="245" y2="200" stroke="#A02C93" stroke-width="1.5"/>
-  <line x1="585" y1="100" x2="585" y2="200" stroke="#A02C93" stroke-width="1.5"/>
+  <line x1="300" y1="85" x2="255" y2="190" stroke="#A02C93" stroke-width="1.5"/>
+  <line x1="545" y1="85" x2="585" y2="190" stroke="#A02C93" stroke-width="1.5"/>
 
   <!-- CE-PE links -->
-  <line x1="60" y1="162" x2="165" y2="200" stroke="#0499D4" stroke-width="1.5"/>
-  <line x1="60" y1="238" x2="165" y2="200" stroke="#4DA72E" stroke-width="1.5"/>
-  <line x1="665" y1="200" x2="770" y2="162" stroke="#0499D4" stroke-width="1.5"/>
-  <line x1="665" y1="200" x2="770" y2="238" stroke="#4DA72E" stroke-width="1.5"/>
+  <line x1="55" y1="92.5" x2="170" y2="130" stroke="#0499D4" stroke-width="1.5"/>
+  <line x1="55" y1="162.5" x2="170" y2="130" stroke="#4DA72E" stroke-width="1.5"/>
+  <line x1="55" y1="267.5" x2="170" y2="250" stroke="#E97131" stroke-width="1.5"/>
+  <line x1="665" y1="190" x2="770" y2="92.5" stroke="#0499D4" stroke-width="1.5"/>
+  <line x1="665" y1="190" x2="770" y2="190" stroke="#4DA72E" stroke-width="1.5"/>
+  <line x1="665" y1="190" x2="770" y2="267.5" stroke="#E97131" stroke-width="1.5"/>
 
   <!-- intra-AS core links -->
-  <line x1="165" y1="200" x2="245" y2="200" stroke="#A02C93" stroke-width="1.5"/>
-  <line x1="245" y1="200" x2="325" y2="200" stroke="#A02C93" stroke-width="1.5"/>
-  <line x1="505" y1="200" x2="585" y2="200" stroke="#A02C93" stroke-width="1.5"/>
-  <line x1="585" y1="200" x2="665" y2="200" stroke="#A02C93" stroke-width="1.5"/>
+  <line x1="170" y1="130" x2="255" y2="190" stroke="#A02C93" stroke-width="1.5"/>
+  <line x1="170" y1="250" x2="255" y2="190" stroke="#A02C93" stroke-width="1.5"/>
+  <line x1="255" y1="190" x2="340" y2="190" stroke="#A02C93" stroke-width="1.5"/>
+  <line x1="505" y1="190" x2="585" y2="190" stroke="#A02C93" stroke-width="1.5"/>
+  <line x1="585" y1="190" x2="665" y2="190" stroke="#A02C93" stroke-width="1.5"/>
 
   <!-- inter-AS link: BGP-LU only, PE + RR loopbacks with labels -->
-  <line x1="340" y1="200" x2="490" y2="200" stroke="#E97131" stroke-width="2.5"/>
-  <text x="415" y="190" text-anchor="middle" font-size="9" fill="#E97131">eBGP labeled-unicast (BGP-LU)</text>
+  <line x1="355" y1="190" x2="490" y2="190" stroke="#9673A6" stroke-width="2" stroke-dasharray="6,4"/>
+  <text x="422" y="210" text-anchor="middle" font-size="10" fill="#333333">BGP LU</text>
 
   <!-- routers -->
   <g stroke="#0E9ED5" stroke-width="1.5" fill="#ffffff">
-    <circle cx="245" cy="90" r="15"/>
-    <circle cx="585" cy="90" r="15"/>
-    <circle cx="165" cy="200" r="15"/>
-    <circle cx="245" cy="200" r="15"/>
-    <circle cx="325" cy="200" r="15"/>
-    <circle cx="505" cy="200" r="15"/>
-    <circle cx="585" cy="200" r="15"/>
-    <circle cx="665" cy="200" r="15"/>
+    <circle cx="300" cy="85" r="15"/>
+    <circle cx="545" cy="85" r="15"/>
+    <circle cx="170" cy="130" r="15"/>
+    <circle cx="170" cy="250" r="15"/>
+    <circle cx="255" cy="190" r="15"/>
+    <circle cx="340" cy="190" r="15"/>
+    <circle cx="505" cy="190" r="15"/>
+    <circle cx="585" cy="190" r="15"/>
+    <circle cx="665" cy="190" r="15"/>
   </g>
   <g text-anchor="middle" font-size="8" fill="#333333">
-    <text x="245" y="93">rr1</text>
-    <text x="585" y="93">rr2</text>
-    <text x="165" y="203">pe1</text>
-    <text x="245" y="203">p1</text>
-    <text x="325" y="203">asbr1</text>
-    <text x="505" y="203">asbr2</text>
-    <text x="585" y="203">p2</text>
-    <text x="665" y="203">pe2</text>
+    <text x="300" y="88">rr1</text>
+    <text x="545" y="88">rr2</text>
+    <text x="170" y="133">pe1</text>
+    <text x="170" y="253">pe2</text>
+    <text x="255" y="193">p1</text>
+    <text x="340" y="193">asbr1</text>
+    <text x="505" y="193">asbr2</text>
+    <text x="585" y="193">p2</text>
+    <text x="665" y="193">pe3</text>
   </g>
 
   <!-- customer edges -->
   <g font-size="9" text-anchor="middle" fill="#ffffff">
-    <rect x="20" y="150" width="40" height="25" rx="5" fill="#0499D4"/>
-    <text x="40" y="166">ce1</text>
-    <rect x="20" y="225" width="40" height="25" rx="5" fill="#4DA72E"/>
-    <text x="40" y="241">ce2</text>
-    <rect x="770" y="150" width="40" height="25" rx="5" fill="#0499D4"/>
-    <text x="790" y="166">ce3</text>
-    <rect x="770" y="225" width="40" height="25" rx="5" fill="#4DA72E"/>
-    <text x="790" y="241">ce4</text>
+    <rect x="15" y="80" width="40" height="25" rx="5" fill="#0499D4"/>
+    <text x="35" y="96">ce1</text>
+    <rect x="15" y="150" width="40" height="25" rx="5" fill="#4DA72E"/>
+    <text x="35" y="166">ce2</text>
+    <rect x="15" y="255" width="40" height="25" rx="5" fill="#E97131"/>
+    <text x="35" y="271">ce3</text>
+    <rect x="770" y="80" width="40" height="25" rx="5" fill="#0499D4"/>
+    <text x="790" y="96">ce4</text>
+    <rect x="770" y="177.5" width="40" height="25" rx="5" fill="#4DA72E"/>
+    <text x="790" y="193.5">ce5</text>
+    <rect x="770" y="255" width="40" height="25" rx="5" fill="#E97131"/>
+    <text x="790" y="271">ce6</text>
   </g>
 
-  <!-- data plane bands: identical to the direct-PE Option C lab -->
+  <!-- data plane bands: one labeled path end to end -->
   <g font-size="11" text-anchor="middle">
-    <rect x="25" y="313" width="110" height="20" fill="none" stroke="#999999"/>
-    <text x="80" y="327" fill="#333333">IP</text>
-    <rect x="150" y="313" width="190" height="20" rx="10" fill="#99CCFF" stroke="#808080"/>
-    <text x="245" y="327" fill="#000000">MPLS</text>
-    <rect x="352" y="313" width="135" height="20" rx="10" fill="#FBE5D6" stroke="#808080"/>
-    <text x="419" y="327" fill="#000000">MPLS</text>
-    <rect x="500" y="313" width="190" height="20" rx="10" fill="#A5E798" stroke="#808080"/>
-    <text x="595" y="327" fill="#000000">MPLS</text>
-    <rect x="702" y="313" width="110" height="20" fill="none" stroke="#999999"/>
-    <text x="757" y="327" fill="#333333">IP</text>
+    <rect x="25" y="363" width="110" height="20" fill="none" stroke="#999999"/>
+    <text x="80" y="377" fill="#333333">IP</text>
+    <rect x="150" y="363" width="540" height="20" rx="10" fill="#99CCFF" stroke="#808080"/>
+    <text x="420" y="377" fill="#000000">MPLS</text>
+    <rect x="702" y="363" width="110" height="20" fill="none" stroke="#999999"/>
+    <text x="757" y="377" fill="#333333">IP</text>
   </g>
 </svg>

--- a/playset/interas-option-c-rr/README.md
+++ b/playset/interas-option-c-rr/README.md
@@ -12,7 +12,9 @@ design. Cisco's reference topology puts a **route reflector in each AS**:
 > PE routers results in improved scalability compared with configurations
 > where the ASBR holds all of the VPN-IPv4 routes.
 
-This playset builds exactly that: the PEs peer VPNv4 **only with their
+This playset builds exactly that, on the full reference topology of the
+Option A and B labs — three customers, two PEs in AS 65501, one PE
+serving all three in AS 65502. The PEs peer VPNv4 **only with their
 local RR**; the RRs peer **multihop eBGP VPNv4 with each other** across
 the ASes; and — the design's load-bearing detail — the inter-RR session
 runs with **`next-hop-unchanged`**, because the RRs sit *outside* the
@@ -24,13 +26,11 @@ labeled loopbacks (BGP-LU) only, zero VPN state.
 
 <img src="../images/InterASOptionCRR.svg" alt="Inter-AS Option C (RR-based) topology">
 
-```
-           rr1 ══ multihop eBGP VPNv4, next-hop-unchanged ══ rr2
-            │                                                 │
-  ce1 ─┐   iBGP VPNv4 (client)                (client) iBGP  │   ┌─ ce3   cust1
-       pe1 ─┴─ p1 ── asbr1 ═══ eBGP BGP-LU ═══ asbr2 ── p2 ──┴─ pe2
-  ce2 ─┘         AS 65501    (PE + RR loopbacks)  AS 65502       └─ ce4   cust2
-```
+With two PEs behind RR1, this lab also exercises what the direct-PE
+design never can: **real RFC 4456 client-to-client reflection** — RR1
+reflects PE1's routes to PE2 and vice versa (each ignores the other's by
+route-target, since they share no customer), on top of relaying both
+PEs' routes to and from the far AS.
 
 The data plane is **byte-for-byte the one from the direct-PE lab** — a
 three-label stack at ingress, two labels crossing the border, the ASBRs
@@ -43,13 +43,13 @@ walkthrough proves both halves.
 $ ./up.sh
 bring up
 ...
-apply config: ce3
+apply config: ce5
 applied
-apply config: ce4
+apply config: ce6
 applied
 ```
 
-Twelve namespaces — the ten from the Option A/B/C labs plus `rr1` and
+Fifteen namespaces — the thirteen from the Option A/B labs plus `rr1` and
 `rr2` (one per AS, attached to the P router, loopbacks `1.1.1.9` /
 `2.2.2.9`). Bring up only one Inter-AS lab at a time. Convergence is
 layered: IGP → BGP-LU → the inter-RR session (its TCP rides the LU
@@ -66,6 +66,14 @@ routes) → VPNv4 — allow a minute.
       router-id: 1.1.1.9
     neighbor:
     - remote-address: 1.1.1.1        # PE1 — VPNv4 route-reflector client
+      remote-as: 65501
+      update-source: 1.1.1.9
+      route-reflector:
+        client: true
+      afi-safi:
+      - name: vpnv4
+        enabled: true
+    - remote-address: 1.1.1.4        # PE2 — VPNv4 route-reflector client
       remote-as: 65501
       update-source: 1.1.1.9
       route-reflector:
@@ -95,10 +103,9 @@ routes) → VPNv4 — allow a minute.
 
 Three things to read out of it:
 
-* **`route-reflector: client: true`** on the PE session — the RR reflects
-  between its iBGP clients (with one PE per AS this lab never needs an
-  actual iBGP-to-iBGP reflection, but the marking is the Cisco design,
-  and adding a second PE would need nothing else).
+* **`route-reflector: client: true`** on both PE sessions — the RR
+  reflects between its iBGP clients (RFC 4456), and adding a third PE
+  to this AS would need nothing but one more client stanza here.
 * **`next-hop-unchanged: true`** on the inter-RR eBGP session. Without
   it, eBGP rewrites the next hop to the advertising RR — a router with
   no VRFs, no customer FIB, and no intention of forwarding. With it, the
@@ -108,29 +115,32 @@ Three things to read out of it:
   loopback: RR2 can only establish (and route the TCP of) the multihop
   session if `1.1.1.9/32` is reachable — as a labeled route — from
   inside AS 65502. The ASBRs relay it with the same next-hop-self +
-  swap-label machinery as the PE loopbacks; their state grows from two
-  loopbacks to four, still zero VPN routes.
+  swap-label machinery as the PE loopbacks; their state grows to five
+  loopbacks (two PEs + one RR inward, one PE + one RR outward), still
+  zero VPN routes.
 
 In classic Cisco IOS terms:
 
 ```
 router bgp 65501
  neighbor 1.1.1.1 remote-as 65501           ! PE1
+ neighbor 1.1.1.4 remote-as 65501           ! PE2
  neighbor 2.2.2.9 remote-as 65502           ! RR2, two IGPs away
  neighbor 2.2.2.9 ebgp-multihop 10
  neighbor 2.2.2.9 update-source Loopback0
  address-family vpnv4
   neighbor 1.1.1.1 activate
   neighbor 1.1.1.1 route-reflector-client
+  neighbor 1.1.1.4 activate
+  neighbor 1.1.1.4 route-reflector-client
   neighbor 2.2.2.9 activate
   neighbor 2.2.2.9 next-hop-unchanged       ! the knob
 ```
 
-The PEs shrink accordingly — `pe1.yaml`'s VPNv4 session now points at
-`1.1.1.9` (iBGP, local RR) instead of the far PE; it never learns the
-other provider exists. The CEs, P routers, and ASBRs are byte-identical
-in role to the direct-PE lab (the ASBRs gain one more iBGP-LU neighbor —
-the RR).
+The PEs peer VPNv4 only with `1.1.1.9` (their local RR) — they never
+learn the other provider exists. The CEs and P routers are as in the
+Option A/B labs; the ASBRs are the direct-PE Option C nodes with the
+extra iBGP-LU neighbors (PE2 and the RR).
 
 ## Control plane: the RR holds everything, forwards nothing
 
@@ -138,16 +148,23 @@ the RR).
 $ sudo ip netns exec rr1 vty
 rr1>show bgp summary
 ...
-IPv4 Labeled Unicast Summary:
-Neighbor        V         AS   MsgRcvd   MsgSent   TblVer  InQ OutQ  Up/Down State       PfxRcd/Snt Hostname
-1.1.1.3         4      65501         5         3        0    0    0 00:00:57 Established        2/1 s
-
 VPNv4 Unicast Summary:
-Neighbor        V         AS   MsgRcvd   MsgSent   TblVer  InQ OutQ  Up/Down State       PfxRcd/Snt Hostname
-1.1.1.1         4      65501         6         2        0    0    0 00:00:57 Established        4/4 s
-2.2.2.9         4      65502         6         2        0    0    0 00:00:54 Established        4/4 s
+BGP router identifier 1.1.1.9, local AS number 65501 VRF default vrf-id 0
+RIB entries 12
+Peers 3
 
-rr1>show bgp vpnv4
+Neighbor        V         AS   MsgRcvd   MsgSent   TblVer  InQ OutQ  Up/Down State       PfxRcd/Snt Hostname
+1.1.1.1         4      65501         6         2        0    0    0 00:00:54 Established        4/8 s
+1.1.1.4         4      65501         5         2        0    0    0 00:00:52 Established       2/10 s
+2.2.2.9         4      65502         7         2        0    0    0 00:00:51 Established        6/6 s
+```
+
+Read the Sent column: PE2 received **10** routes — RR2's six far routes
+*plus PE1's four, reflected client-to-client*. The proof sits in PE2's
+own table, which holds routes for customers it does not serve:
+
+``` shell
+pe2>show bgp vpnv4
      Network          Next Hop            Metric LocPrf Weight Path
 Route Distinguisher: 65501:1
  *>i [1] 10.11.0.0/30       1.1.1.1                  0    100      0 65511 i
@@ -157,60 +174,61 @@ Route Distinguisher: 65501:1
 Route Distinguisher: 65501:2
  *>i [1] 10.12.0.0/30       1.1.1.1                  0    100      0 65512 i
      rt:65501:200 label=17,
- *>i [1] 172.16.1.1/32      1.1.1.1                  0    100      0 65512 i
-     rt:65501:200 label=17,
-Route Distinguisher: 65502:1
- *>  [1] 10.13.0.0/30       2.2.2.3                  0             0 65502 65513 i
-     rt:65501:100 label=16,
- *>  [1] 172.16.2.1/32      2.2.2.3                  0             0 65502 65513 i
-     rt:65501:100 label=16,
-Route Distinguisher: 65502:2
- *>  [1] 10.14.0.0/30       2.2.2.3                  0             0 65502 65514 i
-     rt:65501:200 label=17,
- *>  [1] 172.16.2.1/32      2.2.2.3                  0             0 65502 65514 i
-     rt:65501:200 label=17,
+...
 ```
 
-The RR holds all eight VPN routes — that is Cisco's point, the VPN state
-lives here instead of on the border — but look at the **Next Hop
-column: the RR's own address appears nowhere.** The local rows carry PE1
-(`1.1.1.1`, iBGP from the client); the far rows arrived over the *eBGP*
-session from RR2, yet still carry PE2 (`2.2.2.3`) — that is
-`next-hop-unchanged` doing its one job. The labels (`16`/`17`) are the
-PEs' per-VRF labels, relayed untouched; nobody along the reflection path
-allocated a transit label.
+PE1's cust1/cust2 routes, next hop `1.1.1.1`, arrived at PE2 via RR1's
+reflection — present, valid, and ignored (PE2 imports only `65501:300`).
+That is RFC 4456 doing quietly what a full iBGP mesh would need three
+sessions to do, and what scales to N PEs with one client stanza each.
 
-PE1 receives the reflection with nothing rewritten, and resolves the far
-PE over BGP-LU exactly as in the direct-PE lab:
+RR1's own table holds all twelve routes — and **its address appears in
+no next-hop column**. The far rows arrived over the *eBGP* session from
+RR2, yet still carry PE3 (`2.2.2.3`) with PE3's per-VRF labels
+untouched — `next-hop-unchanged` doing its one job:
 
 ``` shell
-pe1>show bgp vpnv4
-Route Distinguisher: 65502:1
- *>i [1] 10.13.0.0/30       2.2.2.3                  0    100      0 65502 65513 i
-     rt:65501:100 label=16,
- *>i [1] 172.16.2.1/32      2.2.2.3                  0    100      0 65502 65513 i
-     rt:65501:100 label=16,
-
-pe1>show ip route vrf cust1
+rr1>show bgp vpnv4
 ...
-B  *> 172.16.2.1/32 [200/0] via 10.1.0.2, pe1-p1, label 16013 19 16, 00:01:12
+Route Distinguisher: 65502:1
+ *>  [1] 10.14.0.0/30       2.2.2.3                  0             0 65502 65514 i
+     rt:65501:100 label=16,
+ *>  [1] 172.16.2.1/32      2.2.2.3                  0             0 65502 65514 i
+     rt:65501:100 label=16,
+Route Distinguisher: 65502:2
+ *>  [1] 172.16.2.1/32      2.2.2.3                  0             0 65502 65515 i
+     rt:65501:200 label=17,
+Route Distinguisher: 65502:3
+ *>  [1] 172.16.2.1/32      2.2.2.3                  0             0 65502 65516 i
+     rt:65501:300 label=18,
 ```
 
-The same three-label program — SR transport to ASBR1 (`16013`), ASBR1's
-BGP-LU label for PE2's loopback (`19`), PE2's VPN label (`16`). And the
-ASBR's whole service footprint is still a handful of loopback swaps, now
-four instead of two because the RR loopbacks joined the exchange:
+Both PEs resolve `2.2.2.3` over BGP-LU and compose the same three-label
+program as the direct-PE lab — sharing ASBR1's LU label `19` for PE3's
+loopback, with their own customers' VPN labels inside:
+
+``` shell
+pe1>show ip route vrf cust1
+B  *> 172.16.2.1/32 [200/0] via 10.1.0.2, pe1-p1, label 16013 19 16, 00:01:09
+
+pe2>show ip route vrf cust3
+B  *> 172.16.2.1/32 [200/0] via 10.1.0.10, pe2-p1, label 16013 19 18, 00:01:09
+```
+
+And the ASBR's whole service footprint is five loopback swaps — two PEs
+and the RR inward, PE3 and RR2 outward — with an **empty VPNv4 table**:
 
 ``` shell
 asbr1>ip -f mpls route | grep bgp
 16 as to 16011 via inet 10.1.0.5 dev asbr1-p1 proto bgp
 17 as to 16019 via inet 10.1.0.5 dev asbr1-p1 proto bgp
-18 as to 16 via inet 192.168.100.2 dev asbr1-asbr2 proto bgp
+20 as to 16014 via inet 10.1.0.5 dev asbr1-p1 proto bgp
+18 as to 17 via inet 192.168.100.2 dev asbr1-asbr2 proto bgp
 19 as to 19 via inet 192.168.100.2 dev asbr1-asbr2 proto bgp
 ```
 
-(`16`/`17` → the SR labels of PE1 and RR1 inward; `18`/`19` → ASBR2's
-labels for PE2 and RR2 outward. Still O(routers), still zero VPN.)
+(Still O(routers), still zero VPN — three customers changed nothing at
+the border.)
 
 ## Data plane: unchanged — and the RRs prove it by silence
 
@@ -218,13 +236,12 @@ labels for PE2 and RR2 outward. Still O(routers), still zero VPN.)
 $ sudo ip netns exec ce1 vty
 ce1>ping 172.16.2.1
 PING 172.16.2.1 (172.16.2.1) 56(84) bytes of data.
-64 bytes from 172.16.2.1: icmp_seq=1 ttl=62 time=0.061 ms
-64 bytes from 172.16.2.1: icmp_seq=2 ttl=62 time=0.211 ms
+64 bytes from 172.16.2.1: icmp_seq=1 ttl=62 time=0.031 ms
+64 bytes from 172.16.2.1: icmp_seq=2 ttl=62 time=0.155 ms
 ```
 
-Same `ttl=62` as the direct-PE lab. On the border, the same two-label
-crossing (ASBR1's `19 as to 19` swap feeding ASBR2, PE2's VPN label
-inside):
+Same `ttl=62` as the direct-PE lab (ce3's ping through pe2 shows it
+too). On the border, the same two-label crossing:
 
 ``` shell
 asbr1>tcpdump -nli asbr1-asbr2 mpls
@@ -242,16 +259,22 @@ rr1>tcpdump -nli rr1-p1 icmp
 
 Not one customer packet. The routers that hold every VPN route forward
 none of the VPN traffic; the routers that forward all of it hold none of
-the routes. That separation of control and forwarding is what
-`next-hop-unchanged` preserves, and why the knob is mandatory here.
+the routes. The overlap proof runs three customers deep, each ping to
+the shared `172.16.2.1` landing only on its own site-B router:
+
+|                  | arrives at ce4 | arrives at ce5 | arrives at ce6 |
+|:-----------------|:---------------|:---------------|:---------------|
+| ce1 (cust1) pings | **yes**       | —              | —              |
+| ce2 (cust2) pings | —             | **yes**        | —              |
+| ce3 (cust3) pings | —             | —              | **yes**        |
 
 ## Why Cisco draws it this way
 
 * **The full-mesh problem.** Direct PE-to-PE multihop VPNv4 means every
-  PE pair across both providers must peer — N×M sessions crossing the
-  boundary, each one inter-provider coordination. With RRs it is
-  *exactly one* inter-provider VPNv4 session, total, regardless of PE
-  count; new PEs touch only their own AS's RR.
+  PE pair across both providers must peer — with this lab's two-and-one
+  PEs that is already two inter-provider sessions, and N×M in general.
+  With RRs it is *exactly one* inter-provider VPNv4 session, total,
+  regardless of PE count; new PEs touch only their own AS's RR.
 * **VPN state concentrates on two boxes** whose only job is BGP — the
   ASBRs stay lean (Cisco: "improved scalability compared with
   configurations where the ASBR holds all of the VPN-IPv4 routes" —
@@ -274,21 +297,25 @@ $ ./down.sh
 
 ## Appendix: Addressing & sessions
 
-As the [direct-PE Option C lab](../interas-option-c/README.md#appendix-addressing--sessions),
-plus one RR per AS:
+The base is the Option A/B reference topology (see
+[interas-option-a](../interas-option-a/README.md#appendix-addressing--sessions)
+for the thirteen shared nodes and links; the border is Option B/C's one
+global-table link `asbr1-asbr2` = `192.168.100.0/30`), plus one RR per
+AS:
 
 | node | role | AS | loopback | SR SID (label) |
 |:-----|:-----|:---|:---------|:---------------|
 | rr1  | route reflector | 65501 | 1.1.1.9/32 | 19 (16019) |
 | rr2  | route reflector | 65502 | 2.2.2.9/32 | 29 (16029) |
 
-New links: p1–rr1 `10.1.0.8/30`, p2–rr2 `10.2.0.8/30`.
+New links: p1–rr1 `10.1.0.12/30`, p2–rr2 `10.2.0.8/30`.
 
-BGP sessions: 4× PE-CE eBGP IPv4 (in VRF), 4× iBGP labeled-unicast over
-loopbacks (asbr1–{pe1,rr1}, asbr2–{pe2,rr2}; ASBR side `next-hop-self`),
-1× ASBR-ASBR eBGP labeled-unicast, 2× iBGP VPNv4 PE–RR (PE as
-`route-reflector client`), and 1× **multihop eBGP VPNv4 RR1–RR2 with
-`next-hop-unchanged`** — the Cisco-style Option C control plane.
+BGP sessions: 6× PE-CE eBGP IPv4 (in VRF), 5× iBGP labeled-unicast over
+loopbacks (asbr1–{pe1,pe2,rr1}, asbr2–{pe3,rr2}; ASBR side
+`next-hop-self`), 1× ASBR-ASBR eBGP labeled-unicast, 3× iBGP VPNv4
+PE–RR (rr1–{pe1,pe2} and rr2–pe3, PEs as `route-reflector client`), and
+1× **multihop eBGP VPNv4 RR1–RR2 with `next-hop-unchanged`** — the
+Cisco-style Option C control plane.
 
 ## Sources
 

--- a/playset/interas-option-c-rr/asbr1.yaml
+++ b/playset/interas-option-c-rr/asbr1.yaml
@@ -1,8 +1,8 @@
-# ASBR1 — autonomous system border router of AS 65501. Identical role
-# to the direct-PE Option C playset — labeled loopbacks only, no VPN
-# state — with one addition: RR1 is a second iBGP labeled-unicast
-# neighbor (also next-hop-self), because the RRs' loopbacks must cross
-# the boundary too for the inter-RR multihop session to establish.
+# ASBR1 — autonomous system border router of AS 65501. Labeled
+# loopbacks only, zero VPN state: iBGP labeled-unicast to PE1, PE2, and
+# RR1 (each with next-hop-self — THE Option C knob on this leg), eBGP
+# labeled-unicast to ASBR2. The RR loopbacks cross the boundary too, so
+# the inter-RR multihop session can establish.
 interface:
 - if-name: lo
   ipv4:
@@ -43,6 +43,15 @@ router:
         ebgp: 1
     neighbor:
     - remote-address: 1.1.1.1        # PE1 — iBGP labeled-unicast
+      remote-as: 65501
+      timers: {connect-retry-time: 3}
+      update-source: 1.1.1.3
+      enabled: true
+      afi-safi:
+      - name: label-v4
+        enabled: true
+        next-hop-self: true
+    - remote-address: 1.1.1.4        # PE2 — iBGP labeled-unicast
       remote-as: 65501
       timers: {connect-retry-time: 3}
       update-source: 1.1.1.3

--- a/playset/interas-option-c-rr/asbr2.yaml
+++ b/playset/interas-option-c-rr/asbr2.yaml
@@ -1,5 +1,5 @@
 # ASBR2 — autonomous system border router of AS 65502. Mirror of ASBR1:
-# labeled-unicast only (PE2 + RR2 inside with next-hop-self, ASBR1
+# labeled-unicast only (PE3 + RR2 inside with next-hop-self, ASBR1
 # across), no VRFs, no VPNv4, no customer routes.
 interface:
 - if-name: lo
@@ -40,7 +40,7 @@ router:
         ibgp: 1
         ebgp: 1
     neighbor:
-    - remote-address: 2.2.2.3        # PE2 — iBGP labeled-unicast
+    - remote-address: 2.2.2.3        # PE3 — iBGP labeled-unicast
       remote-as: 65502
       timers: {connect-retry-time: 3}
       update-source: 2.2.2.1

--- a/playset/interas-option-c-rr/ce1.yaml
+++ b/playset/interas-option-c-rr/ce1.yaml
@@ -1,6 +1,7 @@
-# CE1 — customer "cust1", site A (AS 65511). Identical to the Option A
-# playset: plain eBGP to PE1, loopback originated via `redistribute
-# connected`. The customer cannot tell which Inter-AS option carries it.
+# CE1 — customer "cust1", site A (AS 65511). Plain eBGP to PE1; the
+# loopback 172.16.1.1/32 is originated via `redistribute connected` and
+# is the ping source toward site B. cust2's CE2 uses the *same* loopback
+# address — the VPNs keep the overlap apart.
 interface:
 - if-name: lo
   ipv4:

--- a/playset/interas-option-c-rr/ce2.yaml
+++ b/playset/interas-option-c-rr/ce2.yaml
@@ -1,6 +1,6 @@
 # CE2 — customer "cust2", site A (AS 65512). Same loopback address as
-# CE1 (172.16.1.1/32) on purpose: in Option C both customers' overlapping
-# routes cross ONE PE-to-PE VPNv4 session, kept apart only by their RDs.
+# CE1 (172.16.1.1/32) on purpose: the two customers run overlapping
+# address plans and never notice each other.
 interface:
 - if-name: lo
   ipv4:

--- a/playset/interas-option-c-rr/ce3.yaml
+++ b/playset/interas-option-c-rr/ce3.yaml
@@ -1,9 +1,11 @@
-# CE3 — customer "cust1", site B (AS 65513). The far end of cust1:
-# ce1 pings this router's loopback 172.16.2.1/32 across both ASes.
+# CE3 — customer "cust3", site A (AS 65513), attached to PE2. Same
+# loopback address as CE1 and CE2 (172.16.1.1/32) on purpose: all three
+# customers run the same overlapping address plan and never notice each
+# other.
 interface:
 - if-name: lo
   ipv4:
-    address: 172.16.2.1/32
+    address: 172.16.1.1/32
 - if-name: ce3-pe2
   ipv4:
     address: 10.13.0.1/30
@@ -19,7 +21,7 @@ router:
         ebgp: 3
     neighbor:
     - remote-address: 10.13.0.2
-      remote-as: 65502
+      remote-as: 65501
       timers: {connect-retry-time: 3}
       enabled: true
       afi-safi:

--- a/playset/interas-option-c-rr/ce5.yaml
+++ b/playset/interas-option-c-rr/ce5.yaml
@@ -1,26 +1,25 @@
-# CE4 — customer "cust1", site B (AS 65514), attached to PE3. The far
-# end of cust1: ce1 pings this router's loopback 172.16.2.1/32 across
-# both ASes. CE5 and CE6 answer to the same address for their own
-# customers.
+# CE5 — customer "cust2", site B (AS 65515), attached to PE3. Same
+# loopback address as CE4 and CE6 (172.16.2.1/32): ce2 pinging
+# 172.16.2.1 must land here and nowhere else.
 interface:
 - if-name: lo
   ipv4:
     address: 172.16.2.1/32
-- if-name: ce4-pe3
+- if-name: ce5-pe3
   ipv4:
-    address: 10.14.0.1/30
+    address: 10.15.0.1/30
 system:
-  hostname: ce4
+  hostname: ce5
 router:
   bgp:
     global:
-      as: 65514
-      router-id: 10.14.0.1
+      as: 65515
+      router-id: 10.15.0.1
     timer:
       adv-interval:
         ebgp: 3
     neighbor:
-    - remote-address: 10.14.0.2
+    - remote-address: 10.15.0.2
       remote-as: 65502
       timers: {connect-retry-time: 3}
       enabled: true

--- a/playset/interas-option-c-rr/ce6.yaml
+++ b/playset/interas-option-c-rr/ce6.yaml
@@ -1,26 +1,25 @@
-# CE4 — customer "cust1", site B (AS 65514), attached to PE3. The far
-# end of cust1: ce1 pings this router's loopback 172.16.2.1/32 across
-# both ASes. CE5 and CE6 answer to the same address for their own
-# customers.
+# CE6 — customer "cust3", site B (AS 65516), attached to PE3. Same
+# loopback address as CE4 and CE5 (172.16.2.1/32): ce3 pinging
+# 172.16.2.1 must land here and nowhere else.
 interface:
 - if-name: lo
   ipv4:
     address: 172.16.2.1/32
-- if-name: ce4-pe3
+- if-name: ce6-pe3
   ipv4:
-    address: 10.14.0.1/30
+    address: 10.16.0.1/30
 system:
-  hostname: ce4
+  hostname: ce6
 router:
   bgp:
     global:
-      as: 65514
-      router-id: 10.14.0.1
+      as: 65516
+      router-id: 10.16.0.1
     timer:
       adv-interval:
         ebgp: 3
     neighbor:
-    - remote-address: 10.14.0.2
+    - remote-address: 10.16.0.2
       remote-as: 65502
       timers: {connect-retry-time: 3}
       enabled: true

--- a/playset/interas-option-c-rr/p1.yaml
+++ b/playset/interas-option-c-rr/p1.yaml
@@ -1,5 +1,5 @@
 # P1 — provider core transit LSR of AS 65501 (runs no BGP, knows no
-# VPN). Pure IS-IS L2 + SR-MPLS between PE1, RR1, and ASBR1.
+# VPN). Pure IS-IS L2 + SR-MPLS between PE1, PE2, RR1, and ASBR1.
 interface:
 - if-name: lo
   ipv4:
@@ -7,12 +7,15 @@ interface:
 - if-name: p1-pe1
   ipv4:
     address: 10.1.0.2/30
+- if-name: p1-pe2
+  ipv4:
+    address: 10.1.0.10/30
+- if-name: p1-rr1
+  ipv4:
+    address: 10.1.0.13/30
 - if-name: p1-asbr1
   ipv4:
     address: 10.1.0.5/30
-- if-name: p1-rr1
-  ipv4:
-    address: 10.1.0.9/30
 system:
   hostname: p1
 router:
@@ -33,12 +36,17 @@ router:
       metric: 10
       ipv4:
         enabled: true
-    - if-name: p1-asbr1
+    - if-name: p1-pe2
       network-type: point-to-point
       metric: 10
       ipv4:
         enabled: true
     - if-name: p1-rr1
+      network-type: point-to-point
+      metric: 10
+      ipv4:
+        enabled: true
+    - if-name: p1-asbr1
       network-type: point-to-point
       metric: 10
       ipv4:

--- a/playset/interas-option-c-rr/p2.yaml
+++ b/playset/interas-option-c-rr/p2.yaml
@@ -1,5 +1,5 @@
 # P2 — provider core transit LSR of AS 65502 (runs no BGP, knows no
-# VPN). Pure IS-IS L2 + SR-MPLS between ASBR2, RR2, and PE2.
+# VPN). Pure IS-IS L2 + SR-MPLS between ASBR2, RR2, and PE3.
 interface:
 - if-name: lo
   ipv4:
@@ -7,12 +7,12 @@ interface:
 - if-name: p2-asbr2
   ipv4:
     address: 10.2.0.2/30
-- if-name: p2-pe2
-  ipv4:
-    address: 10.2.0.5/30
 - if-name: p2-rr2
   ipv4:
     address: 10.2.0.9/30
+- if-name: p2-pe3
+  ipv4:
+    address: 10.2.0.5/30
 system:
   hostname: p2
 router:
@@ -33,12 +33,12 @@ router:
       metric: 10
       ipv4:
         enabled: true
-    - if-name: p2-pe2
+    - if-name: p2-rr2
       network-type: point-to-point
       metric: 10
       ipv4:
         enabled: true
-    - if-name: p2-rr2
+    - if-name: p2-pe3
       network-type: point-to-point
       metric: 10
       ipv4:

--- a/playset/interas-option-c-rr/pe1.yaml
+++ b/playset/interas-option-c-rr/pe1.yaml
@@ -1,8 +1,10 @@
-# PE1 — provider edge, AS 65501. Unlike the direct-PE Option C playset,
-# the VPNv4 session goes to the LOCAL route reflector (RR1, iBGP) — the
-# PE never talks to the far AS at all. Everything else is unchanged:
-# own loopback originated into label-v4, VRFs with PE-CE eBGP, RTs
-# coordinated with AS 65502.
+# PE1 — provider edge, AS 65501, serving cust1 (CE1) and cust2 (CE2).
+# The RR-based Option C PE peers VPNv4 ONLY with the local route
+# reflector (RR1) — it never talks to the far AS. Its own loopback is
+# originated into BGP labeled-unicast (label-v4) so the ASBR chain can
+# export it to AS 65502; the far PE loopback learned the same way is
+# what makes the reflected VPN routes' next hops resolvable, as a
+# labeled path. RTs are coordinated with AS 65502.
 vrf:
 - name: cust1
   ipv4:
@@ -62,7 +64,7 @@ router:
         ibgp: 1
         ebgp: 3
     neighbor:
-    - remote-address: 1.1.1.3        # ASBR1 — labeled-unicast
+    - remote-address: 1.1.1.3        # ASBR1 — iBGP labeled-unicast
       remote-as: 65501
       timers: {connect-retry-time: 3}
       update-source: 1.1.1.1

--- a/playset/interas-option-c-rr/pe2.yaml
+++ b/playset/interas-option-c-rr/pe2.yaml
@@ -1,76 +1,67 @@
-# PE2 — provider edge, AS 65502. Mirror of PE1: VPNv4 to the local RR2
-# only, loopback into label-v4, RTs matching AS 65501's.
+# PE2 — second provider edge of AS 65501, serving cust3 (CE3). Same
+# pattern as PE1: loopback into label-v4, VPNv4 only to the local RR1
+# — which now has two clients, so RFC 4456 client-to-client reflection
+# actually runs in this lab.
 vrf:
-- name: cust1
+- name: cust3
   ipv4:
     route-target:
       import:
-      - 65501:100
+      - 65501:300
       export:
-      - 65501:100
-- name: cust2
-  ipv4:
-    route-target:
-      import:
-      - 65501:200
-      export:
-      - 65501:200
+      - 65501:300
 interface:
 - if-name: lo
   ipv4:
-    address: 2.2.2.3/32
-- if-name: pe2-p2
-  ipv4:
-    address: 10.2.0.6/30
+    address: 1.1.1.4/32
 - if-name: pe2-ce3
-  vrf: cust1
+  vrf: cust3
   ipv4:
     address: 10.13.0.2/30
-- if-name: pe2-ce4
-  vrf: cust2
+- if-name: pe2-p1
   ipv4:
-    address: 10.14.0.2/30
+    address: 10.1.0.9/30
 system:
   hostname: pe2
 router:
   isis:
-    net: 49.0002.0000.0000.0003.00
+    net: 49.0001.0000.0000.0004.00
     hostname: pe2
     is-type: level-2-only
     segment-routing: mpls
-    te-router-id: 2.2.2.3
+    te-router-id: 1.1.1.4
     interface:
     - if-name: lo
       ipv4:
         enabled: true
         prefix-sid:
-          index: 23
-    - if-name: pe2-p2
+          index: 14
+    - if-name: pe2-p1
       network-type: point-to-point
       metric: 10
       ipv4:
         enabled: true
   bgp:
     global:
-      as: 65502
-      router-id: 2.2.2.3
+      as: 65501
+      router-id: 1.1.1.4
     timer:
       adv-interval:
         ibgp: 1
         ebgp: 3
     neighbor:
-    - remote-address: 2.2.2.1        # ASBR2 — labeled-unicast
-      remote-as: 65502
+    - remote-address: 1.1.1.3        # ASBR1 — iBGP labeled-unicast
+      remote-as: 65501
       timers: {connect-retry-time: 3}
-      update-source: 2.2.2.3
+      update-source: 1.1.1.4
       enabled: true
       afi-safi:
       - name: label-v4
         enabled: true
-    - remote-address: 2.2.2.9        # RR2 — iBGP VPNv4 (the RR reflects)
-      remote-as: 65502
+    - remote-address: 1.1.1.9        # RR1 — iBGP VPNv4
+      remote-as: 65501
       timers: {connect-retry-time: 3}
-      update-source: 2.2.2.3
+      update-source: 1.1.1.4
       enabled: true
       afi-safi:
       - name: vpnv4
@@ -78,21 +69,13 @@ router:
     afi-safi:
     - name: label-v4
       network:
-      - prefix: 2.2.2.3/32
+      - prefix: 1.1.1.4/32
     vrf:
-    - name: cust1
-      rd: 65502:1
+    - name: cust3
+      rd: 65501:3
       neighbor:
       - remote-address: 10.13.0.1
         remote-as: 65513
-        afi-safi:
-        - name: ipv4
-          enabled: true
-    - name: cust2
-      rd: 65502:2
-      neighbor:
-      - remote-address: 10.14.0.1
-        remote-as: 65514
         afi-safi:
         - name: ipv4
           enabled: true

--- a/playset/interas-option-c-rr/pe3.yaml
+++ b/playset/interas-option-c-rr/pe3.yaml
@@ -1,0 +1,118 @@
+# PE3 — the provider edge of AS 65502, serving all three customers
+# (CE4/CE5/CE6). VPNv4 only to the local RR2; loopback into label-v4;
+# RTs matching AS 65501's (65501:100/200/300); RDs stay AS-local.
+vrf:
+- name: cust1
+  ipv4:
+    route-target:
+      import:
+      - 65501:100
+      export:
+      - 65501:100
+- name: cust2
+  ipv4:
+    route-target:
+      import:
+      - 65501:200
+      export:
+      - 65501:200
+- name: cust3
+  ipv4:
+    route-target:
+      import:
+      - 65501:300
+      export:
+      - 65501:300
+interface:
+- if-name: lo
+  ipv4:
+    address: 2.2.2.3/32
+- if-name: pe3-p2
+  ipv4:
+    address: 10.2.0.6/30
+- if-name: pe3-ce4
+  vrf: cust1
+  ipv4:
+    address: 10.14.0.2/30
+- if-name: pe3-ce5
+  vrf: cust2
+  ipv4:
+    address: 10.15.0.2/30
+- if-name: pe3-ce6
+  vrf: cust3
+  ipv4:
+    address: 10.16.0.2/30
+system:
+  hostname: pe3
+router:
+  isis:
+    net: 49.0002.0000.0000.0003.00
+    hostname: pe3
+    is-type: level-2-only
+    segment-routing: mpls
+    te-router-id: 2.2.2.3
+    interface:
+    - if-name: lo
+      ipv4:
+        enabled: true
+        prefix-sid:
+          index: 23
+    - if-name: pe3-p2
+      network-type: point-to-point
+      metric: 10
+      ipv4:
+        enabled: true
+  bgp:
+    global:
+      as: 65502
+      router-id: 2.2.2.3
+    timer:
+      adv-interval:
+        ibgp: 1
+        ebgp: 3
+    neighbor:
+    - remote-address: 2.2.2.1        # ASBR2 — iBGP labeled-unicast
+      remote-as: 65502
+      timers: {connect-retry-time: 3}
+      update-source: 2.2.2.3
+      enabled: true
+      afi-safi:
+      - name: label-v4
+        enabled: true
+    - remote-address: 2.2.2.9        # RR2 — iBGP VPNv4
+      remote-as: 65502
+      timers: {connect-retry-time: 3}
+      update-source: 2.2.2.3
+      enabled: true
+      afi-safi:
+      - name: vpnv4
+        enabled: true
+    afi-safi:
+    - name: label-v4
+      network:
+      - prefix: 2.2.2.3/32
+    vrf:
+    - name: cust1
+      rd: 65502:1
+      neighbor:
+      - remote-address: 10.14.0.1
+        remote-as: 65514
+        afi-safi:
+        - name: ipv4
+          enabled: true
+    - name: cust2
+      rd: 65502:2
+      neighbor:
+      - remote-address: 10.15.0.1
+        remote-as: 65515
+        afi-safi:
+        - name: ipv4
+          enabled: true
+    - name: cust3
+      rd: 65502:3
+      neighbor:
+      - remote-address: 10.16.0.1
+        remote-as: 65516
+        afi-safi:
+        - name: ipv4
+          enabled: true

--- a/playset/interas-option-c-rr/rr1.yaml
+++ b/playset/interas-option-c-rr/rr1.yaml
@@ -1,7 +1,9 @@
 # RR1 — the route reflector of AS 65501 (Cisco's RR-based Option C).
 # Holds every VPN route but forwards NO customer traffic:
-#  - iBGP VPNv4 with PE1, PE1 marked `route-reflector client` — the RR
-#    reflects between its clients and relays to/from the far AS.
+#  - iBGP VPNv4 with PE1 and PE2, both marked `route-reflector client`
+#    — with two clients, RFC 4456 client-to-client reflection actually
+#    runs here (each PE receives the other's routes and ignores them by
+#    RT, since they share no customer).
 #  - Multihop eBGP VPNv4 to RR2 (2.2.2.9, two IGPs away) with
 #    `next-hop-unchanged`: the reflected routes must keep the
 #    originating PE — the true LSP endpoint — as next-hop (and keep the
@@ -16,7 +18,7 @@ interface:
     address: 1.1.1.9/32
 - if-name: rr1-p1
   ipv4:
-    address: 10.1.0.10/30
+    address: 10.1.0.14/30
 system:
   hostname: rr1
 router:
@@ -47,6 +49,16 @@ router:
         ebgp: 1
     neighbor:
     - remote-address: 1.1.1.1        # PE1 — VPNv4 route-reflector client
+      remote-as: 65501
+      timers: {connect-retry-time: 3}
+      update-source: 1.1.1.9
+      enabled: true
+      route-reflector:
+        client: true
+      afi-safi:
+      - name: vpnv4
+        enabled: true
+    - remote-address: 1.1.1.4        # PE2 — VPNv4 route-reflector client
       remote-as: 65501
       timers: {connect-retry-time: 3}
       update-source: 1.1.1.9

--- a/playset/interas-option-c-rr/rr2.yaml
+++ b/playset/interas-option-c-rr/rr2.yaml
@@ -1,4 +1,4 @@
-# RR2 — the route reflector of AS 65502. Mirror of RR1: PE2 as a VPNv4
+# RR2 — the route reflector of AS 65502. Mirror of RR1: PE3 as a VPNv4
 # route-reflector client, multihop eBGP VPNv4 to RR1 with
 # `next-hop-unchanged`, labeled-unicast to ASBR2 for loopback exchange.
 interface:
@@ -37,7 +37,7 @@ router:
         ibgp: 1
         ebgp: 1
     neighbor:
-    - remote-address: 2.2.2.3        # PE2 — VPNv4 route-reflector client
+    - remote-address: 2.2.2.3        # PE3 — VPNv4 route-reflector client
       remote-as: 65502
       timers: {connect-retry-time: 3}
       update-source: 2.2.2.9

--- a/playset/interas-option-c-rr/topology.sh
+++ b/playset/interas-option-c-rr/topology.sh
@@ -1,30 +1,36 @@
-# Inter-AS Option C, RR-based (Cisco reference design) demo topology.
+# Inter-AS Option C, RR-based (Cisco reference design) demo topology —
+# the reference diagram (images/InterASOptionCRR.svg): three customers,
+# two PEs in AS 65501, a route reflector per AS, BGP-LU at the border.
 # Each PLAYSET_LINKS entry is "ns_a:iface_a:ns_b:iface_b".
 #
-#            rr1 ═══ multihop eBGP VPNv4 (next-hop-unchanged) ═══ rr2
-#             │                                                    │
-#   ce1 ─┐    │                                                    │    ┌─ ce3   (cust1)
-#        pe1 ─┴ p1 ── asbr1 ═══ BGP-LU loopbacks ═══ asbr2 ── p2 ──┴─ pe2
-#   ce2 ─┘        AS 65501                            AS 65502          └─ ce4   (cust2)
+#            rr1 ══ multihop eBGP VPNv4 (next-hop-unchanged) ══ rr2
+#             │                                                  │
+#   ce1 ─┐    │                                                  │    ┌─ ce4  (cust1)
+#   ce2 ─┴ pe1├                                                  │    ├─ ce5  (cust2)
+#             p1 ── asbr1 ═══════ eBGP BGP-LU ═══════ asbr2 ── p2┴─ pe3
+#   ce3 ── pe2┘          AS 65501                       AS 65502      └─ ce6  (cust3)
 
-PLAYSET_NAMESPACES=(ce1 ce2 pe1 p1 rr1 asbr1 asbr2 rr2 p2 pe2 ce3 ce4)
+PLAYSET_NAMESPACES=(ce1 ce2 ce3 pe1 pe2 p1 rr1 asbr1 asbr2 rr2 p2 pe3 ce4 ce5 ce6)
 
 PLAYSET_LINKS=(
     ce1:ce1-pe1:pe1:pe1-ce1
     ce2:ce2-pe1:pe1:pe1-ce2
+    ce3:ce3-pe2:pe2:pe2-ce3
     pe1:pe1-p1:p1:p1-pe1
+    pe2:pe2-p1:p1:p1-pe2
     p1:p1-rr1:rr1:rr1-p1
     p1:p1-asbr1:asbr1:asbr1-p1
     asbr1:asbr1-asbr2:asbr2:asbr2-asbr1
     asbr2:asbr2-p2:p2:p2-asbr2
     p2:p2-rr2:rr2:rr2-p2
-    p2:p2-pe2:pe2:pe2-p2
-    pe2:pe2-ce3:ce3:ce3-pe2
-    pe2:pe2-ce4:ce4:ce4-pe2
+    p2:p2-pe3:pe3:pe3-p2
+    pe3:pe3-ce4:ce4:ce4-pe3
+    pe3:pe3-ce5:ce5:ce5-pe3
+    pe3:pe3-ce6:ce6:ce6-pe3
 )
 
 # All namespaces that run zebra-rs.
-PLAYSET_DAEMONS=(ce1 ce2 pe1 p1 rr1 asbr1 asbr2 rr2 p2 pe2 ce3 ce4)
+PLAYSET_DAEMONS=(ce1 ce2 ce3 pe1 pe2 p1 rr1 asbr1 asbr2 rr2 p2 pe3 ce4 ce5 ce6)
 
 # Routers with vtyctl YAML config.
-PLAYSET_ROUTERS=(ce1 ce2 pe1 p1 rr1 asbr1 asbr2 rr2 p2 pe2 ce3 ce4)
+PLAYSET_ROUTERS=(ce1 ce2 ce3 pe1 pe2 p1 rr1 asbr1 asbr2 rr2 p2 pe3 ce4 ce5 ce6)


### PR DESCRIPTION
## Summary

Conforms the RR-based Option C lab to the reference diagram (`optioncrr.png` → `images/InterASOptionCRR.*`); the direct-PE Option C lab stays as-is per the reference set.

- **Fifteen namespaces**: the A/B reference topology (three customers, pe1+pe2 in AS 65501, pe3 in AS 65502) plus one route reflector per AS.
- **Real RFC 4456 client-to-client reflection**: rr1 now has two clients — pe2's table holds pe1's RDs (NH `1.1.1.1`, ignored by RT), and rr1's Snt counters show it (pe2 received 10 = pe1's 4 reflected + rr2's 6). The previous single-client lab could only configure reflection; this one exercises it.
- ASBRs relay **five loopbacks** (pe1/pe2/rr1 inward, pe3/rr2 outward) with an **empty VPNv4 table** — three customers changed nothing at the border.
- Diagram pair redrawn per the reference layout: RRs at the cloud tops with the gold inter-RR arc, purple dashed "BGP LU" border, one continuous MPLS band end to end (render-verified).
- Index reframed: A, B, and the RR lab share the full reference topology; AB and C remain the pared ten-node variant.

## Test plan

Full live run; every README capture re-taken verbatim:
- All three VPNs converge at `ttl=62` (cust3 via pe2's own stack `16013 19 18`, sharing asbr1's LU label 19 with pe1's `16013 19 16`).
- rr1's far rows keep next-hop `2.2.2.3` across the eBGP session (`next-hop-unchanged` at work); its own address in no next-hop column.
- Border: exactly two labels crossing (`19|16` fwd, `16|16` rev).
- Out-of-path proof: `0 packets captured` for ICMP on rr1's only link during a CE-to-CE ping.
- 3×3 landing matrix: perfect diagonal (ce1→ce4, ce2→ce5, ce3→ce6 only).
- Config/docs-only change; no daemon code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)