### PR TITLE
playset: rebuild interas-option-ab on the reference topology

### DIFF
--- a/playset/README.md
+++ b/playset/README.md
@@ -114,12 +114,12 @@ the same names first.
 ## BGP Inter-AS L3VPN
 
 Two providers, one VPN — the RFC 4364 §10 options (plus Cisco's AB
-hybrid) for handing L3VPN routes across an AS boundary. Options A and B
-build the full reference topology (three customers behind two PEs
-feeding one border), and the RR lab extends it with a route reflector
-per AS; AB and C pare it to a ten-router variant with one PE and two
-customers per side. The customers and their overlapping addressing stay
-the same throughout; only the border model changes:
+hybrid) for handing L3VPN routes across an AS boundary. Options A, B,
+and AB build the full reference topology (three customers behind two
+PEs feeding one border), and the RR lab extends it with a route
+reflector per AS; Option C pares it to a ten-router variant with one PE
+and two customers per side. The customers and their overlapping
+addressing stay the same throughout; only the border model changes:
 
 |                                 | Option A       | Option B            | Option AB              | Option C       |
 |:--------------------------------|:---------------|:--------------------|:-----------------------|:---------------|

--- a/playset/images/InterASOptionAB.drawio
+++ b/playset/images/InterASOptionAB.drawio
@@ -5,39 +5,51 @@
         <mxCell id="0" />
         <mxCell id="1" parent="0" />
         <mxCell id="as1-box" parent="1" style="rounded=1;whiteSpace=wrap;html=1;fillColor=none;dashed=1;strokeColor=#999999;" value="" vertex="1">
-          <mxGeometry height="230" width="270" x="90" y="170" as="geometry" />
+          <mxGeometry height="290" width="300" x="75" y="160" as="geometry" />
         </mxCell>
         <mxCell id="as2-box" parent="1" style="rounded=1;whiteSpace=wrap;html=1;fillColor=none;dashed=1;strokeColor=#999999;" value="" vertex="1">
-          <mxGeometry height="230" width="270" x="480" y="170" as="geometry" />
+          <mxGeometry height="290" width="280" x="480" y="160" as="geometry" />
+        </mxCell>
+        <mxCell id="as1-cloud" parent="1" style="ellipse;shape=cloud;whiteSpace=wrap;html=1;flipV=1;flipH=1;strokeColor=#999999;" value="" vertex="1">
+          <mxGeometry height="230" width="240" x="110" y="200" as="geometry" />
+        </mxCell>
+        <mxCell id="as2-cloud" parent="1" style="ellipse;shape=cloud;whiteSpace=wrap;html=1;strokeColor=#999999;" value="" vertex="1">
+          <mxGeometry height="190" width="210" x="475" y="230" as="geometry" />
         </mxCell>
         <mxCell id="as1-label" parent="1" style="text;html=1;whiteSpace=wrap;strokeColor=none;fillColor=none;align=center;verticalAlign=middle;rounded=0;autosize=1;resizable=0;fontSize=11;" value="AS 65501" vertex="1">
-          <mxGeometry height="30" width="70" x="145" y="170" as="geometry" />
+          <mxGeometry height="30" width="70" x="125" y="160" as="geometry" />
         </mxCell>
         <mxCell id="as2-label" parent="1" style="text;html=1;whiteSpace=wrap;strokeColor=none;fillColor=none;align=center;verticalAlign=middle;rounded=0;autosize=1;resizable=0;fontSize=11;" value="AS 65502" vertex="1">
-          <mxGeometry height="30" width="70" x="625" y="170" as="geometry" />
+          <mxGeometry height="30" width="70" x="655" y="160" as="geometry" />
         </mxCell>
         <mxCell id="asbr1-vrf-label" parent="1" style="text;html=1;whiteSpace=wrap;strokeColor=none;fillColor=none;align=center;verticalAlign=middle;rounded=0;fontSize=8;fontColor=#666666;" value="transit VRFs" vertex="1">
-          <mxGeometry height="12" width="70" x="279" y="192" as="geometry" />
+          <mxGeometry height="12" width="70" x="287" y="178" as="geometry" />
         </mxCell>
         <mxCell id="asbr2-vrf-label" parent="1" style="text;html=1;whiteSpace=wrap;strokeColor=none;fillColor=none;align=center;verticalAlign=middle;rounded=0;fontSize=8;fontColor=#666666;" value="transit VRFs" vertex="1">
-          <mxGeometry height="12" width="70" x="481" y="192" as="geometry" />
+          <mxGeometry height="12" width="70" x="481" y="178" as="geometry" />
         </mxCell>
         <mxCell id="asbr1-vrf1" parent="1" style="rounded=1;whiteSpace=wrap;html=1;fillStyle=solid;fillColor=#0499D4;strokeColor=none;fontSize=8;fontColor=#FFFFFF;" value="cust1" vertex="1">
-          <mxGeometry height="18" width="46" x="291" y="210" as="geometry" />
+          <mxGeometry height="16" width="46" x="299" y="194" as="geometry" />
         </mxCell>
         <mxCell id="asbr1-vrf2" parent="1" style="rounded=1;whiteSpace=wrap;html=1;fillStyle=solid;fillColor=#4DA72E;strokeColor=none;fontSize=8;fontColor=#FFFFFF;" value="cust2" vertex="1">
-          <mxGeometry height="18" width="46" x="291" y="233" as="geometry" />
+          <mxGeometry height="16" width="46" x="299" y="214" as="geometry" />
+        </mxCell>
+        <mxCell id="asbr1-vrf3" parent="1" style="rounded=1;whiteSpace=wrap;html=1;fillStyle=solid;fillColor=#E97131;strokeColor=none;fontSize=8;fontColor=#FFFFFF;" value="cust3" vertex="1">
+          <mxGeometry height="16" width="46" x="299" y="234" as="geometry" />
         </mxCell>
         <mxCell id="asbr2-vrf1" parent="1" style="rounded=1;whiteSpace=wrap;html=1;fillStyle=solid;fillColor=#0499D4;strokeColor=none;fontSize=8;fontColor=#FFFFFF;" value="cust1" vertex="1">
-          <mxGeometry height="18" width="46" x="493" y="210" as="geometry" />
+          <mxGeometry height="16" width="46" x="493" y="194" as="geometry" />
         </mxCell>
         <mxCell id="asbr2-vrf2" parent="1" style="rounded=1;whiteSpace=wrap;html=1;fillStyle=solid;fillColor=#4DA72E;strokeColor=none;fontSize=8;fontColor=#FFFFFF;" value="cust2" vertex="1">
-          <mxGeometry height="18" width="46" x="493" y="233" as="geometry" />
+          <mxGeometry height="16" width="46" x="493" y="214" as="geometry" />
         </mxCell>
-        <mxCell id="asbr1-vrf-link" edge="1" parent="1" source="asbr1-vrf2" style="endArrow=none;html=1;rounded=0;dashed=1;dashPattern=2 2;strokeColor=#999999;" target="asbr1" value="">
+        <mxCell id="asbr2-vrf3" parent="1" style="rounded=1;whiteSpace=wrap;html=1;fillStyle=solid;fillColor=#E97131;strokeColor=none;fontSize=8;fontColor=#FFFFFF;" value="cust3" vertex="1">
+          <mxGeometry height="16" width="46" x="493" y="234" as="geometry" />
+        </mxCell>
+        <mxCell id="asbr1-vrf-link" edge="1" parent="1" source="asbr1-vrf3" style="endArrow=none;html=1;rounded=0;dashed=1;dashPattern=2 2;strokeColor=#999999;" target="asbr1" value="">
           <mxGeometry height="50" relative="1" width="50" as="geometry" />
         </mxCell>
-        <mxCell id="asbr2-vrf-link" edge="1" parent="1" source="asbr2-vrf2" style="endArrow=none;html=1;rounded=0;dashed=1;dashPattern=2 2;strokeColor=#999999;" target="asbr2" value="">
+        <mxCell id="asbr2-vrf-link" edge="1" parent="1" source="asbr2-vrf3" style="endArrow=none;html=1;rounded=0;dashed=1;dashPattern=2 2;strokeColor=#999999;" target="asbr2" value="">
           <mxGeometry height="50" relative="1" width="50" as="geometry" />
         </mxCell>
         <mxCell id="edge-ce1-pe1" edge="1" parent="1" source="ce1" style="endArrow=none;html=1;rounded=0;strokeColor=#0499D4;" target="pe1" value="">
@@ -46,7 +58,13 @@
         <mxCell id="edge-ce2-pe1" edge="1" parent="1" source="ce2" style="endArrow=none;html=1;rounded=0;strokeColor=#4DA72E;" target="pe1" value="">
           <mxGeometry height="50" relative="1" width="50" as="geometry" />
         </mxCell>
+        <mxCell id="edge-ce3-pe2" edge="1" parent="1" source="ce3" style="endArrow=none;html=1;rounded=0;strokeColor=#E97131;" target="pe2" value="">
+          <mxGeometry height="50" relative="1" width="50" as="geometry" />
+        </mxCell>
         <mxCell id="edge-pe1-p1" edge="1" parent="1" source="pe1" style="endArrow=none;html=1;rounded=0;strokeColor=#A02C93;" target="p1" value="">
+          <mxGeometry height="50" relative="1" width="50" as="geometry" />
+        </mxCell>
+        <mxCell id="edge-pe2-p1" edge="1" parent="1" source="pe2" style="endArrow=none;html=1;rounded=0;strokeColor=#A02C93;" target="p1" value="">
           <mxGeometry height="50" relative="1" width="50" as="geometry" />
         </mxCell>
         <mxCell id="edge-p1-asbr1" edge="1" parent="1" source="p1" style="endArrow=none;html=1;rounded=0;strokeColor=#A02C93;" target="asbr1" value="">
@@ -55,65 +73,77 @@
         <mxCell id="edge-asbr2-p2" edge="1" parent="1" source="asbr2" style="endArrow=none;html=1;rounded=0;strokeColor=#A02C93;" target="p2" value="">
           <mxGeometry height="50" relative="1" width="50" as="geometry" />
         </mxCell>
-        <mxCell id="edge-p2-pe2" edge="1" parent="1" source="p2" style="endArrow=none;html=1;rounded=0;strokeColor=#A02C93;" target="pe2" value="">
+        <mxCell id="edge-p2-pe3" edge="1" parent="1" source="p2" style="endArrow=none;html=1;rounded=0;strokeColor=#A02C93;" target="pe3" value="">
           <mxGeometry height="50" relative="1" width="50" as="geometry" />
         </mxCell>
-        <mxCell id="edge-pe2-ce3" edge="1" parent="1" source="pe2" style="endArrow=none;html=1;rounded=0;strokeColor=#0499D4;" target="ce3" value="">
+        <mxCell id="edge-pe3-ce4" edge="1" parent="1" source="pe3" style="endArrow=none;html=1;rounded=0;strokeColor=#0499D4;" target="ce4" value="">
           <mxGeometry height="50" relative="1" width="50" as="geometry" />
         </mxCell>
-        <mxCell id="edge-pe2-ce4" edge="1" parent="1" source="pe2" style="endArrow=none;html=1;rounded=0;strokeColor=#4DA72E;" target="ce4" value="">
+        <mxCell id="edge-pe3-ce5" edge="1" parent="1" source="pe3" style="endArrow=none;html=1;rounded=0;strokeColor=#4DA72E;" target="ce5" value="">
+          <mxGeometry height="50" relative="1" width="50" as="geometry" />
+        </mxCell>
+        <mxCell id="edge-pe3-ce6" edge="1" parent="1" source="pe3" style="endArrow=none;html=1;rounded=0;strokeColor=#E97131;" target="ce6" value="">
           <mxGeometry height="50" relative="1" width="50" as="geometry" />
         </mxCell>
         <mxCell id="edge-interas" edge="1" parent="1" source="asbr1" style="endArrow=none;html=1;rounded=0;strokeColor=#E97131;strokeWidth=2;" target="asbr2" value="">
           <mxGeometry height="50" relative="1" width="50" as="geometry" />
         </mxCell>
-        <mxCell id="interas-label" parent="1" style="text;html=1;whiteSpace=wrap;strokeColor=none;fillColor=none;align=center;verticalAlign=middle;rounded=0;fontSize=8;fontColor=#E97131;" value="eBGP VPNv4 (one session)" vertex="1">
-          <mxGeometry height="14" width="150" x="340" y="282" as="geometry" />
+        <mxCell id="interas-label" parent="1" style="text;html=1;whiteSpace=wrap;strokeColor=none;fillColor=none;align=center;verticalAlign=middle;rounded=0;fontSize=9;fontColor=#E97131;" value="eBGP VPNv4 (one session)" vertex="1">
+          <mxGeometry height="14" width="150" x="347" y="298" as="geometry" />
         </mxCell>
         <mxCell id="pe1" parent="1" style="ellipse;whiteSpace=wrap;html=1;aspect=fixed;strokeColor=#0E9ED5;fillColor=#FFFFFF;fontSize=8;" value="pe1" vertex="1">
-          <mxGeometry height="30" width="30" x="150" y="295" as="geometry" />
-        </mxCell>
-        <mxCell id="p1" parent="1" style="ellipse;whiteSpace=wrap;html=1;aspect=fixed;strokeColor=#0E9ED5;fillColor=#FFFFFF;fontSize=8;" value="p1" vertex="1">
-          <mxGeometry height="30" width="30" x="230" y="295" as="geometry" />
-        </mxCell>
-        <mxCell id="asbr1" parent="1" style="ellipse;whiteSpace=wrap;html=1;aspect=fixed;strokeColor=#0E9ED5;fillColor=#FFFFFF;fontSize=8;" value="asbr1" vertex="1">
-          <mxGeometry height="30" width="30" x="310" y="295" as="geometry" />
-        </mxCell>
-        <mxCell id="asbr2" parent="1" style="ellipse;whiteSpace=wrap;html=1;aspect=fixed;strokeColor=#0E9ED5;fillColor=#FFFFFF;fontSize=8;" value="asbr2" vertex="1">
-          <mxGeometry height="30" width="30" x="490" y="295" as="geometry" />
-        </mxCell>
-        <mxCell id="p2" parent="1" style="ellipse;whiteSpace=wrap;html=1;aspect=fixed;strokeColor=#0E9ED5;fillColor=#FFFFFF;fontSize=8;" value="p2" vertex="1">
-          <mxGeometry height="30" width="30" x="570" y="295" as="geometry" />
+          <mxGeometry height="30" width="30" x="155" y="245" as="geometry" />
         </mxCell>
         <mxCell id="pe2" parent="1" style="ellipse;whiteSpace=wrap;html=1;aspect=fixed;strokeColor=#0E9ED5;fillColor=#FFFFFF;fontSize=8;" value="pe2" vertex="1">
-          <mxGeometry height="30" width="30" x="650" y="295" as="geometry" />
+          <mxGeometry height="30" width="30" x="155" y="365" as="geometry" />
+        </mxCell>
+        <mxCell id="p1" parent="1" style="ellipse;whiteSpace=wrap;html=1;aspect=fixed;strokeColor=#0E9ED5;fillColor=#FFFFFF;fontSize=8;" value="p1" vertex="1">
+          <mxGeometry height="30" width="30" x="240" y="305" as="geometry" />
+        </mxCell>
+        <mxCell id="asbr1" parent="1" style="ellipse;whiteSpace=wrap;html=1;aspect=fixed;strokeColor=#0E9ED5;fillColor=#FFFFFF;fontSize=8;" value="asbr1" vertex="1">
+          <mxGeometry height="30" width="30" x="325" y="305" as="geometry" />
+        </mxCell>
+        <mxCell id="asbr2" parent="1" style="ellipse;whiteSpace=wrap;html=1;aspect=fixed;strokeColor=#0E9ED5;fillColor=#FFFFFF;fontSize=8;" value="asbr2" vertex="1">
+          <mxGeometry height="30" width="30" x="490" y="305" as="geometry" />
+        </mxCell>
+        <mxCell id="p2" parent="1" style="ellipse;whiteSpace=wrap;html=1;aspect=fixed;strokeColor=#0E9ED5;fillColor=#FFFFFF;fontSize=8;" value="p2" vertex="1">
+          <mxGeometry height="30" width="30" x="570" y="305" as="geometry" />
+        </mxCell>
+        <mxCell id="pe3" parent="1" style="ellipse;whiteSpace=wrap;html=1;aspect=fixed;strokeColor=#0E9ED5;fillColor=#FFFFFF;fontSize=8;" value="pe3" vertex="1">
+          <mxGeometry height="30" width="30" x="650" y="305" as="geometry" />
         </mxCell>
         <mxCell id="ce1" parent="1" style="rounded=1;whiteSpace=wrap;html=1;fillStyle=solid;fillColor=#0499D4;strokeColor=none;fontSize=8;fontColor=#FFFFFF;" value="ce1" vertex="1">
-          <mxGeometry height="25" width="40" x="20" y="260" as="geometry" />
+          <mxGeometry height="25" width="40" x="15" y="210" as="geometry" />
         </mxCell>
         <mxCell id="ce2" parent="1" style="rounded=1;whiteSpace=wrap;html=1;fillStyle=solid;fillColor=#4DA72E;strokeColor=none;fontSize=8;fontColor=#FFFFFF;" value="ce2" vertex="1">
-          <mxGeometry height="25" width="40" x="20" y="330" as="geometry" />
+          <mxGeometry height="25" width="40" x="15" y="280" as="geometry" />
         </mxCell>
-        <mxCell id="ce3" parent="1" style="rounded=1;whiteSpace=wrap;html=1;fillStyle=solid;fillColor=#0499D4;strokeColor=none;fontSize=8;fontColor=#FFFFFF;" value="ce3" vertex="1">
-          <mxGeometry height="25" width="40" x="770" y="260" as="geometry" />
+        <mxCell id="ce3" parent="1" style="rounded=1;whiteSpace=wrap;html=1;fillStyle=solid;fillColor=#E97131;strokeColor=none;fontSize=8;fontColor=#FFFFFF;" value="ce3" vertex="1">
+          <mxGeometry height="25" width="40" x="15" y="385" as="geometry" />
         </mxCell>
-        <mxCell id="ce4" parent="1" style="rounded=1;whiteSpace=wrap;html=1;fillStyle=solid;fillColor=#4DA72E;strokeColor=none;fontSize=8;fontColor=#FFFFFF;" value="ce4" vertex="1">
-          <mxGeometry height="25" width="40" x="770" y="330" as="geometry" />
+        <mxCell id="ce4" parent="1" style="rounded=1;whiteSpace=wrap;html=1;fillStyle=solid;fillColor=#0499D4;strokeColor=none;fontSize=8;fontColor=#FFFFFF;" value="ce4" vertex="1">
+          <mxGeometry height="25" width="40" x="770" y="210" as="geometry" />
+        </mxCell>
+        <mxCell id="ce5" parent="1" style="rounded=1;whiteSpace=wrap;html=1;fillStyle=solid;fillColor=#4DA72E;strokeColor=none;fontSize=8;fontColor=#FFFFFF;" value="ce5" vertex="1">
+          <mxGeometry height="25" width="40" x="770" y="307.5" as="geometry" />
+        </mxCell>
+        <mxCell id="ce6" parent="1" style="rounded=1;whiteSpace=wrap;html=1;fillStyle=solid;fillColor=#E97131;strokeColor=none;fontSize=8;fontColor=#FFFFFF;" value="ce6" vertex="1">
+          <mxGeometry height="25" width="40" x="770" y="385" as="geometry" />
         </mxCell>
         <mxCell id="dp-ip-left" parent="1" style="rounded=0;whiteSpace=wrap;html=1;strokeColor=#999999;fontSize=11;" value="IP" vertex="1">
-          <mxGeometry height="20" width="110" x="25" y="423" as="geometry" />
+          <mxGeometry height="20" width="110" x="25" y="483" as="geometry" />
         </mxCell>
         <mxCell id="dp-mpls-as1" parent="1" style="shape=cylinder3;whiteSpace=wrap;html=1;boundedLbl=1;backgroundOutline=1;size=3.285714285714164;direction=south;strokeColor=#808080;fillColor=light-dark(#99CCFF,#2566A8);fontColor=#000000;fontSize=11;" value="MPLS" vertex="1">
-          <mxGeometry height="20" width="190" x="150" y="423" as="geometry" />
+          <mxGeometry height="20" width="205" x="150" y="483" as="geometry" />
         </mxCell>
-        <mxCell id="dp-mpls-interas" parent="1" style="shape=cylinder3;whiteSpace=wrap;html=1;boundedLbl=1;backgroundOutline=1;size=3.285714285714164;direction=south;strokeColor=#808080;fillColor=light-dark(#FBE5D6,#7A4A21);fontColor=#000000;fontSize=11;" value="MPLS" vertex="1">
-          <mxGeometry height="20" width="135" x="352" y="423" as="geometry" />
+        <mxCell id="dp-mpls-interas" parent="1" style="shape=cylinder3;whiteSpace=wrap;html=1;boundedLbl=1;backgroundOutline=1;size=3.285714285714164;direction=south;strokeColor=#E97131;fillColor=light-dark(#FBE5D6,#7A4A21);fontColor=#000000;fontSize=11;" value="MPLS" vertex="1">
+          <mxGeometry height="20" width="120" x="367" y="483" as="geometry" />
         </mxCell>
         <mxCell id="dp-mpls-as2" parent="1" style="shape=cylinder3;whiteSpace=wrap;html=1;boundedLbl=1;backgroundOutline=1;size=3.285714285714164;direction=south;strokeColor=#808080;fillColor=light-dark(#A5E798,#003900);fontColor=#000000;fontSize=11;" value="MPLS" vertex="1">
-          <mxGeometry height="20" width="190" x="500" y="423" as="geometry" />
+          <mxGeometry height="20" width="190" x="500" y="483" as="geometry" />
         </mxCell>
         <mxCell id="dp-ip-right" parent="1" style="rounded=0;whiteSpace=wrap;html=1;strokeColor=#999999;fontSize=11;" value="IP" vertex="1">
-          <mxGeometry height="20" width="110" x="702" y="423" as="geometry" />
+          <mxGeometry height="20" width="110" x="702" y="483" as="geometry" />
         </mxCell>
       </root>
     </mxGraphModel>

--- a/playset/images/InterASOptionAB.svg
+++ b/playset/images/InterASOptionAB.svg
@@ -1,89 +1,109 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 830 330" font-family="Helvetica, Arial, sans-serif">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 830 400" font-family="Helvetica, Arial, sans-serif">
   <!-- Inter-AS Option AB (per-VPN VRFs + one VPNv4 session)
-       — matches playset/interas-option-ab.
+       — matches playset/interas-option-ab: three customers, two PEs in
+       AS 65501, per-customer transit VRFs at both borders.
        Editable source: InterASOptionAB.drawio (re-export from draw.io replaces this file). -->
-  <rect width="830" height="330" fill="#ffffff"/>
+  <rect width="830" height="400" fill="#ffffff"/>
 
   <!-- AS boxes -->
-  <rect x="90" y="40" width="270" height="230" rx="8" fill="none" stroke="#999999" stroke-dasharray="6,4"/>
-  <rect x="480" y="40" width="270" height="230" rx="8" fill="none" stroke="#999999" stroke-dasharray="6,4"/>
-  <text x="180" y="58" text-anchor="middle" font-size="12" fill="#333333">AS 65501</text>
-  <text x="660" y="58" text-anchor="middle" font-size="12" fill="#333333">AS 65502</text>
+  <rect x="75" y="30" width="300" height="290" rx="8" fill="none" stroke="#999999" stroke-dasharray="6,4"/>
+  <rect x="480" y="30" width="280" height="290" rx="8" fill="none" stroke="#999999" stroke-dasharray="6,4"/>
+  <text x="160" y="50" text-anchor="middle" font-size="12" fill="#333333">AS 65501</text>
+  <text x="690" y="50" text-anchor="middle" font-size="12" fill="#333333">AS 65502</text>
+
+  <!-- provider clouds -->
+  <path d="M 170,185 C 140,190 120,165 135,140 C 115,115 135,85 165,95 C 175,70 215,65 235,85 C 260,70 295,85 295,110 C 320,120 315,155 290,165 C 285,185 250,195 230,182 C 215,195 185,195 170,185 Z"
+        fill="none" stroke="#bbbbbb" stroke-width="0.7" transform="matrix(1.24,0,0,1.69,-32,-24)"/>
+  <path d="M 170,185 C 140,190 120,165 135,140 C 115,115 135,85 165,95 C 175,70 215,65 235,85 C 260,70 295,85 295,110 C 320,120 315,155 290,165 C 285,185 250,195 230,182 C 215,195 185,195 170,185 Z"
+        fill="none" stroke="#bbbbbb" stroke-width="0.8" transform="matrix(1.10,0,0,1.46,362,3)"/>
 
   <!-- per-customer transit VRFs on the ASBRs (the Option A half) -->
+  <text x="322" y="58" text-anchor="middle" font-size="8" fill="#666666">transit VRFs</text>
+  <text x="516" y="58" text-anchor="middle" font-size="8" fill="#666666">transit VRFs</text>
   <g font-size="8" text-anchor="middle" fill="#ffffff">
-    <rect x="291" y="80" width="46" height="18" rx="4" fill="#0499D4"/>
-    <text x="314" y="92">cust1</text>
-    <rect x="291" y="103" width="46" height="18" rx="4" fill="#4DA72E"/>
-    <text x="314" y="115">cust2</text>
-    <rect x="493" y="80" width="46" height="18" rx="4" fill="#0499D4"/>
-    <text x="516" y="92">cust1</text>
-    <rect x="493" y="103" width="46" height="18" rx="4" fill="#4DA72E"/>
-    <text x="516" y="115">cust2</text>
+    <rect x="299" y="64" width="46" height="16" rx="4" fill="#0499D4"/>
+    <text x="322" y="75">cust1</text>
+    <rect x="299" y="84" width="46" height="16" rx="4" fill="#4DA72E"/>
+    <text x="322" y="95">cust2</text>
+    <rect x="299" y="104" width="46" height="16" rx="4" fill="#E97131"/>
+    <text x="322" y="115">cust3</text>
+    <rect x="493" y="64" width="46" height="16" rx="4" fill="#0499D4"/>
+    <text x="516" y="75">cust1</text>
+    <rect x="493" y="84" width="46" height="16" rx="4" fill="#4DA72E"/>
+    <text x="516" y="95">cust2</text>
+    <rect x="493" y="104" width="46" height="16" rx="4" fill="#E97131"/>
+    <text x="516" y="115">cust3</text>
   </g>
-  <text x="314" y="72" text-anchor="middle" font-size="8" fill="#666666">transit VRFs</text>
-  <text x="516" y="72" text-anchor="middle" font-size="8" fill="#666666">transit VRFs</text>
-  <line x1="322" y1="121" x2="325" y2="165" stroke="#999999" stroke-width="1" stroke-dasharray="2,2"/>
-  <line x1="508" y1="121" x2="505" y2="165" stroke="#999999" stroke-width="1" stroke-dasharray="2,2"/>
+  <line x1="330" y1="122" x2="340" y2="175" stroke="#999999" stroke-width="1" stroke-dasharray="2,2"/>
+  <line x1="508" y1="122" x2="505" y2="175" stroke="#999999" stroke-width="1" stroke-dasharray="2,2"/>
 
   <!-- CE-PE links -->
-  <line x1="60" y1="142.5" x2="165" y2="180" stroke="#0499D4" stroke-width="1.5"/>
-  <line x1="60" y1="212.5" x2="165" y2="180" stroke="#4DA72E" stroke-width="1.5"/>
-  <line x1="665" y1="180" x2="770" y2="142.5" stroke="#0499D4" stroke-width="1.5"/>
-  <line x1="665" y1="180" x2="770" y2="212.5" stroke="#4DA72E" stroke-width="1.5"/>
+  <line x1="55" y1="92.5" x2="170" y2="130" stroke="#0499D4" stroke-width="1.5"/>
+  <line x1="55" y1="162.5" x2="170" y2="130" stroke="#4DA72E" stroke-width="1.5"/>
+  <line x1="55" y1="267.5" x2="170" y2="250" stroke="#E97131" stroke-width="1.5"/>
+  <line x1="665" y1="190" x2="770" y2="92.5" stroke="#0499D4" stroke-width="1.5"/>
+  <line x1="665" y1="190" x2="770" y2="190" stroke="#4DA72E" stroke-width="1.5"/>
+  <line x1="665" y1="190" x2="770" y2="267.5" stroke="#E97131" stroke-width="1.5"/>
 
   <!-- intra-AS core links -->
-  <line x1="165" y1="180" x2="245" y2="180" stroke="#A02C93" stroke-width="1.5"/>
-  <line x1="245" y1="180" x2="325" y2="180" stroke="#A02C93" stroke-width="1.5"/>
-  <line x1="505" y1="180" x2="585" y2="180" stroke="#A02C93" stroke-width="1.5"/>
-  <line x1="585" y1="180" x2="665" y2="180" stroke="#A02C93" stroke-width="1.5"/>
+  <line x1="170" y1="130" x2="255" y2="190" stroke="#A02C93" stroke-width="1.5"/>
+  <line x1="170" y1="250" x2="255" y2="190" stroke="#A02C93" stroke-width="1.5"/>
+  <line x1="255" y1="190" x2="340" y2="190" stroke="#A02C93" stroke-width="1.5"/>
+  <line x1="505" y1="190" x2="585" y2="190" stroke="#A02C93" stroke-width="1.5"/>
+  <line x1="585" y1="190" x2="665" y2="190" stroke="#A02C93" stroke-width="1.5"/>
 
-  <!-- inter-AS link: ONE session, per-VPN VRF lookup at each end -->
-  <line x1="340" y1="180" x2="490" y2="180" stroke="#E97131" stroke-width="2.5"/>
-  <text x="415" y="170" text-anchor="middle" font-size="9" fill="#E97131">eBGP VPNv4 (one session)</text>
+  <!-- inter-AS: ONE session, per-VPN VRF lookup at each end -->
+  <line x1="355" y1="190" x2="490" y2="190" stroke="#E97131" stroke-width="2.5"/>
+  <text x="422" y="180" text-anchor="middle" font-size="9" fill="#E97131">eBGP VPNv4 (one session)</text>
 
   <!-- routers -->
   <g stroke="#0E9ED5" stroke-width="1.5" fill="#ffffff">
-    <circle cx="165" cy="180" r="15"/>
-    <circle cx="245" cy="180" r="15"/>
-    <circle cx="325" cy="180" r="15"/>
-    <circle cx="505" cy="180" r="15"/>
-    <circle cx="585" cy="180" r="15"/>
-    <circle cx="665" cy="180" r="15"/>
+    <circle cx="170" cy="130" r="15"/>
+    <circle cx="170" cy="250" r="15"/>
+    <circle cx="255" cy="190" r="15"/>
+    <circle cx="340" cy="190" r="15"/>
+    <circle cx="505" cy="190" r="15"/>
+    <circle cx="585" cy="190" r="15"/>
+    <circle cx="665" cy="190" r="15"/>
   </g>
   <g text-anchor="middle" font-size="8" fill="#333333">
-    <text x="165" y="183">pe1</text>
-    <text x="245" y="183">p1</text>
-    <text x="325" y="183">asbr1</text>
-    <text x="505" y="183">asbr2</text>
-    <text x="585" y="183">p2</text>
-    <text x="665" y="183">pe2</text>
+    <text x="170" y="133">pe1</text>
+    <text x="170" y="253">pe2</text>
+    <text x="255" y="193">p1</text>
+    <text x="340" y="193">asbr1</text>
+    <text x="505" y="193">asbr2</text>
+    <text x="585" y="193">p2</text>
+    <text x="665" y="193">pe3</text>
   </g>
 
   <!-- customer edges -->
   <g font-size="9" text-anchor="middle" fill="#ffffff">
-    <rect x="20" y="130" width="40" height="25" rx="5" fill="#0499D4"/>
-    <text x="40" y="146">ce1</text>
-    <rect x="20" y="200" width="40" height="25" rx="5" fill="#4DA72E"/>
-    <text x="40" y="216">ce2</text>
-    <rect x="770" y="130" width="40" height="25" rx="5" fill="#0499D4"/>
-    <text x="790" y="146">ce3</text>
-    <rect x="770" y="200" width="40" height="25" rx="5" fill="#4DA72E"/>
-    <text x="790" y="216">ce4</text>
+    <rect x="15" y="80" width="40" height="25" rx="5" fill="#0499D4"/>
+    <text x="35" y="96">ce1</text>
+    <rect x="15" y="150" width="40" height="25" rx="5" fill="#4DA72E"/>
+    <text x="35" y="166">ce2</text>
+    <rect x="15" y="255" width="40" height="25" rx="5" fill="#E97131"/>
+    <text x="35" y="271">ce3</text>
+    <rect x="770" y="80" width="40" height="25" rx="5" fill="#0499D4"/>
+    <text x="790" y="96">ce4</text>
+    <rect x="770" y="177.5" width="40" height="25" rx="5" fill="#4DA72E"/>
+    <text x="790" y="193.5">ce5</text>
+    <rect x="770" y="255" width="40" height="25" rx="5" fill="#E97131"/>
+    <text x="790" y="271">ce6</text>
   </g>
 
-  <!-- data plane bands -->
+  <!-- data plane bands: labeled across the border -->
   <g font-size="11" text-anchor="middle">
-    <rect x="25" y="293" width="110" height="20" fill="none" stroke="#999999"/>
-    <text x="80" y="307" fill="#333333">IP</text>
-    <rect x="150" y="293" width="190" height="20" rx="10" fill="#99CCFF" stroke="#808080"/>
-    <text x="245" y="307" fill="#000000">MPLS</text>
-    <rect x="352" y="293" width="135" height="20" rx="10" fill="#FBE5D6" stroke="#808080"/>
-    <text x="419" y="307" fill="#000000">MPLS</text>
-    <rect x="500" y="293" width="190" height="20" rx="10" fill="#A5E798" stroke="#808080"/>
-    <text x="595" y="307" fill="#000000">MPLS</text>
-    <rect x="702" y="293" width="110" height="20" fill="none" stroke="#999999"/>
-    <text x="757" y="307" fill="#333333">IP</text>
+    <rect x="25" y="353" width="110" height="20" fill="none" stroke="#999999"/>
+    <text x="80" y="367" fill="#333333">IP</text>
+    <rect x="150" y="353" width="205" height="20" rx="10" fill="#99CCFF" stroke="#808080"/>
+    <text x="252" y="367" fill="#000000">MPLS</text>
+    <rect x="367" y="353" width="120" height="20" rx="10" fill="#FBE5D6" stroke="#E97131"/>
+    <text x="427" y="367" fill="#000000">MPLS</text>
+    <rect x="500" y="353" width="190" height="20" rx="10" fill="#A5E798" stroke="#808080"/>
+    <text x="595" y="367" fill="#000000">MPLS</text>
+    <rect x="702" y="353" width="110" height="20" fill="none" stroke="#999999"/>
+    <text x="757" y="367" fill="#333333">IP</text>
   </g>
 </svg>

--- a/playset/interas-option-ab/README.md
+++ b/playset/interas-option-ab/README.md
@@ -7,7 +7,7 @@ the per-customer policy point disappeared). Cisco's **Option AB** — a
 vendor hybrid beyond RFC 4364 §10's three letters — recombines them:
 
 > The MPLS VPN Inter-AS Option AB feature combines the best functionality
-> of an Inter-AS Option (10) A and Inter-AS Option (10) B network […]
+> of an Inter-AS Option (10) A and Option (10) B network […]
 > the different autonomous systems interconnect by using a single MP-BGP
 > session in the global routing table to carry control plane traffic,
 > [while the network] maintains IP quality of service functions between
@@ -29,26 +29,17 @@ is, line for line, Cisco's Option AB route-distribution procedure:
 
 <img src="../images/InterASOptionAB.svg" alt="Inter-AS Option AB topology">
 
-```
-  ce1 ─┐                                                  ┌─ ce3   (cust1)
-       pe1 ── p1 ── asbr1 ═══ one eBGP VPNv4 session ═══ asbr2 ── p2 ── pe2
-  ce2 ─┘        AS 65501     [cust1][cust2] transit VRFs   AS 65502      └─ ce4   (cust2)
-                              at BOTH borders — the VPN
-                              label terminates, an IP
-                              lookup happens per customer,
-                              and a fresh label goes on
-```
-
-The lab is the same pared ten-router variant as the Option C playset
-(two customers, overlapping addressing) — only the ASBRs change. One honest
-note: classic Cisco AB forwards the customer *data* unlabeled over
-per-VRF subinterfaces (that is where the per-customer QoS attaches),
-with only the control session shared. This lab implements the
-labeled-data-path flavor (Cisco documents it as Option AB+): data rides
-the same shared link as the session, one label deep — but each ASBR
-still terminates the VPN into the customer's own VRF, makes an IP
-routing decision there, and re-imposes; the per-VPN state and policy
-point that Option B lost is restored at both borders.
+The lab is the Option A/B reference topology — three customers with
+overlapping addressing, two PEs in AS 65501, one PE serving all three in
+AS 65502 — with only the ASBRs changed. One honest note: classic Cisco
+AB forwards the customer *data* unlabeled over per-VRF subinterfaces
+(that is where the per-customer QoS attaches), with only the control
+session shared. This lab implements the labeled-data-path flavor (Cisco
+documents it as Option AB+): data rides the same shared link as the
+session, one label deep — but each ASBR still terminates the VPN into
+the customer's own VRF, makes an IP routing decision there, and
+re-imposes; the per-VPN state and policy point that Option B lost is
+restored at both borders.
 
 ## Bring up all nodes
 
@@ -56,13 +47,16 @@ point that Option B lost is restored at both borders.
 $ ./up.sh
 bring up
 ...
-apply config: ce3
+apply config: ce5
 applied
-apply config: ce4
+apply config: ce6
 applied
 ```
 
-## The ASBR: two VRFs, no VRF anything else
+Same thirteen namespaces as the A/B labs — bring up only one Inter-AS
+lab at a time.
+
+## The ASBR: three VRFs, no VRF anything else
 
 `asbr1.yaml`'s BGP shape — compare all three siblings at the same spot:
 Option A had per-VRF *sessions*, B had *no VRFs at all*, AB has VRFs
@@ -77,13 +71,7 @@ vrf:
       - 65501:100
       export:
       - 65501:100
-- name: cust2
-  ipv4:
-    route-target:
-      import:
-      - 65501:200
-      export:
-      - 65501:200
+# ... cust2 (65501:200) and cust3 (65501:300) repeat the pattern
 router:
   bgp:
     global:
@@ -91,6 +79,12 @@ router:
       router-id: 1.1.1.3
     neighbor:
     - remote-address: 1.1.1.1        # PE1 — iBGP VPNv4 (no next-hop-self!)
+      remote-as: 65501
+      update-source: 1.1.1.3
+      afi-safi:
+      - name: vpnv4
+        enabled: true
+    - remote-address: 1.1.1.4        # PE2 — same, one session per PE
       remote-as: 65501
       update-source: 1.1.1.3
       afi-safi:
@@ -108,17 +102,21 @@ router:
     - name: cust2
       rd: 65501:12
       inter-as-hybrid: true
+    - name: cust3
+      rd: 65501:13
+      inter-as-hybrid: true
 ```
 
 * **`inter-as-hybrid: true`** turns each VRF into the AB relay: the
   VPNv4 routes its RT imports are re-exported — re-originated under the
-  VRF's own RD (`65501:11`/`12`, deliberately distinct from the PEs'
-  `65501:1`/`2`), next-hop-self, the VRF's per-VRF label, single clean
-  RT. The transparent Option-B-style relay of the received route is
-  suppressed; each router sees every prefix under exactly one RD.
-* **No `next-hop-self` knob anywhere** — Option B needed it on the iBGP
-  leg; here the re-export is a local origination, so both legs get
-  self as next hop for free.
+  VRF's own RD (`65501:11`/`12`/`13`, deliberately distinct from the
+  PEs' `65501:1`/`2`/`3`), next-hop-self, the VRF's per-VRF label,
+  single clean RT. The transparent Option-B-style relay of the received
+  route is suppressed; each router sees every prefix under exactly one
+  RD.
+* **No `next-hop-self` knob anywhere** — Option B needed it on both
+  iBGP legs; here the re-export is a local origination, so every leg
+  (toward PE1, PE2, and ASBR2 alike) gets self as next hop for free.
 * The top-level `vrf:` block alone creates the kernel VRF devices, which
   is what the data path hangs off (below).
 
@@ -129,45 +127,55 @@ asbr1>show bgp vrf
 VRF                  RD                Label  TableID  Peers State
 cust1                65501:11             16        1      0 running
 cust2                65501:12             17        2      0 running
+cust3                65501:13             18        3      0 running
 ```
 
-Two customers, two labels, **zero peers** — the VRFs are pure policy
+Three customers, three labels, **zero peers** — the VRFs are pure policy
 anchors (Option A showed `1` in that Peers column per VRF, and its label
-terminated into a session; B showed `(no VRFs configured)`).
+terminated into a session; B showed `(no VRFs configured)`). The border
+sessions:
+
+``` shell
+asbr1>show bgp summary
+...
+Neighbor        V         AS   MsgRcvd   MsgSent   TblVer  InQ OutQ  Up/Down State       PfxRcd/Snt Hostname
+1.1.1.1         4      65501         6         2        0    0    0 00:00:53 Established       4/12 s
+1.1.1.4         4      65501         5         2        0    0    0 00:00:53 Established       2/12 s
+192.168.100.2   4      65502        10         3        0    0    0 00:00:55 Established       6/12 s
+```
+
+One iBGP session per PE, one eBGP session for every customer — and
+twelve sent everywhere, because the hybrid VRFs re-export all they
+import to every peer. Follow cust3 through the table (its PE is `pe2`,
+so the chain starts at `1.1.1.4`):
 
 ``` shell
 asbr1>show bgp vpnv4
-     Network          Next Hop            Metric LocPrf Weight Path
-Route Distinguisher: 65501:1
- *>i [1] 10.11.0.0/30       1.1.1.1                  0    100      0 65511 i
-     rt:65501:100 label=16,
- *>i [1] 172.16.1.1/32      1.1.1.1                  0    100      0 65511 i
-     rt:65501:100 label=16,
-Route Distinguisher: 65501:11
- *>  [1] 10.11.0.0/30       1.1.1.3                  0    100      0 65511 i
-     rt:65501:100 label=16,
- *>  [1] 172.16.1.1/32      1.1.1.3                  0    100      0 65511 i
-     rt:65501:100 label=16,
- *>  [1] 10.13.0.0/30       1.1.1.3                  0             0 65502 65513 i
-     rt:65501:100 label=16,
- *>  [1] 172.16.2.1/32      1.1.1.3                  0             0 65502 65513 i
-     rt:65501:100 label=16,
-Route Distinguisher: 65502:11
- *>  [1] 10.13.0.0/30       192.168.100.2            0             0 65502 65513 i
-     rt:65501:100 label=16,
- *>  [1] 172.16.2.1/32      192.168.100.2            0             0 65502 65513 i
-     rt:65501:100 label=16,
 ...
+Route Distinguisher: 65501:3
+ *>i [1] 10.13.0.0/30       1.1.1.4                  0    100      0 65513 i
+     rt:65501:300 label=16,
+ *>i [1] 172.16.1.1/32      1.1.1.4                  0    100      0 65513 i
+     rt:65501:300 label=16,
+Route Distinguisher: 65501:13
+ *>  [1] 10.13.0.0/30       1.1.1.3                  0    100      0 65513 i
+     rt:65501:300 label=18,
+ *>  [1] 10.16.0.0/30       1.1.1.3                  0             0 65502 65516 i
+     rt:65501:300 label=18,
+ *>  [1] 172.16.1.1/32      1.1.1.3                  0    100      0 65513 i
+     rt:65501:300 label=18,
+ *>  [1] 172.16.2.1/32      1.1.1.3                  0             0 65502 65516 i
+     rt:65501:300 label=18,
 ```
 
-(cust2 mirrors under `65501:2` / `65501:12` / `65502:12`.) Read it as
-Cisco's procedure executing: PE1's originals under `65501:1`; the hybrid
-VRF's re-originations under **`65501:11`** — next-hop rewritten to
-`1.1.1.3` (self), the VRF's own label `16`, one clean `rt:65501:100`
-whether the source was PE1 (iBGP) or ASBR2 (the `65502:11` rows below,
-kept for import but never transparently relayed). The far ASBR's own
-re-originations arrive under *its* RD — a prefix's RD changes at every
-border, unlike B where RDs crossed untouched.
+Read it as Cisco's procedure executing: PE2's originals under
+`65501:3`, next hop `1.1.1.4`; the hybrid VRF's re-originations under
+**`65501:13`** — next hop rewritten to `1.1.1.3` (self), the VRF's own
+label `18`, one clean `rt:65501:300` whether the source was PE2 (iBGP)
+or ASBR2 (the `65502:13` rows, kept for import but never transparently
+relayed). A prefix's RD changes at every border — unlike B, where RDs
+crossed untouched — and cust1/cust2 run the same chain from PE1
+(`65501:1`/`2` → `65501:11`/`12` → …).
 
 ## Data plane: label in, IP lookup, label out — per customer
 
@@ -175,77 +183,78 @@ border, unlike B where RDs crossed untouched.
 asbr1>ip -f mpls route | grep "dev cust"
 16 dev cust1 proto bgp
 17 dev cust2 proto bgp
+18 dev cust3 proto bgp
 
 asbr1>show ip route vrf cust1
 ...
-B  *> 10.11.0.0/30 [200/0] via 10.1.0.5, asbr1-p1, label 16011 16, 00:00:52
-B  *> 10.13.0.0/30 [200/0] via 192.168.100.2, asbr1-asbr2, label 16, 00:00:50
-B  *> 172.16.1.1/32 [200/0] via 10.1.0.5, asbr1-p1, label 16011 16, 00:00:52
-B  *> 172.16.2.1/32 [200/0] via 192.168.100.2, asbr1-asbr2, label 16, 00:00:50
+B  *> 172.16.1.1/32 [200/0] via 10.1.0.5, asbr1-p1, label 16011 16, 00:00:53
+B  *> 172.16.2.1/32 [20/0] via 192.168.100.2, asbr1-asbr2, label 16, 00:00:53
+
+asbr1>show ip route vrf cust3
+...
+B  *> 172.16.1.1/32 [200/0] via 10.1.0.5, asbr1-p1, label 16014 16, 00:00:53
+B  *> 172.16.2.1/32 [20/0] via 192.168.100.2, asbr1-asbr2, label 18, 00:00:53
 ```
 
-`16 dev cust1` is the whole Option AB data plane in one line: MPLS label
-16 arrives → **deliver into the cust1 VRF** for an IP routing decision.
-The VRF's table then re-imposes: toward PE1 a two-label stack
-(`16011 16`), toward ASBR2 a single label (`16`, ASBR2's cust1 label).
+`18 dev cust3` is the whole Option AB data plane in one line: MPLS label
+18 arrives → **deliver into the cust3 VRF** for an IP routing decision.
+The VRF's table then re-imposes — and the transport label names the
+owning PE: cust1 rides `16011` back to pe1, cust3 rides `16014` to pe2.
 Contrast the same spot in Option B — a flat list of per-prefix
 `X as to Y` label swaps with no IP lookup and no per-customer anything.
 
 ``` shell
 $ sudo ip netns exec ce1 vty
 ce1>ping 172.16.2.1
-64 bytes from 172.16.2.1: icmp_seq=1 ttl=60 time=0.077 ms
+64 bytes from 172.16.2.1: icmp_seq=1 ttl=60 time=0.044 ms
 ```
 
-`ttl=60` — four IP routing decisions: pe1, **asbr1 (in cust1)**,
-**asbr2 (in cust1)**, pe2. Option B also showed 60, but its border
-decrements came from MPLS TTL on label swaps; here they are genuine
-per-customer IP lookups (Option C, which does neither, showed 62). On
-the wire, one label crosses — same as B — but watch the TTL inside:
+`ttl=60` — four IP routing decisions: the ingress PE, **asbr1 (in the
+customer's VRF)**, **asbr2 (likewise)**, pe3. Option B also showed 60,
+but its border decrements came from MPLS TTL on label swaps; here they
+are genuine per-customer IP lookups (Option C, which does neither,
+shows 62). On the wire — cust3's ping captured entering and leaving
+asbr1:
 
 ``` shell
 asbr1>tcpdump -nli asbr1-p1 mpls        # arriving from the core
-MPLS (label 16, tc 0, [S], ttl 63) IP 10.11.0.1 > 172.16.2.1: ICMP echo request ...
+MPLS (label 18, tc 0, [S], ttl 63) IP 10.13.0.1 > 172.16.2.1: ICMP echo request ...
 asbr1>tcpdump -nli asbr1-asbr2 mpls     # leaving across the border
-MPLS (label 16, tc 0, [S], ttl 62) IP 10.11.0.1 > 172.16.2.1: ICMP echo request ...
+MPLS (label 18, tc 0, [S], ttl 62) IP 10.13.0.1 > 172.16.2.1: ICMP echo request ...
 ```
 
-The label value happens to be 16 on both sides (each router's first
-per-VRF label), but they are different labels from different spaces —
-and the decremented TTL between them is the IP lookup in `cust1`
-happening. The overlap proof holds as in every lab in this series:
-ce1's and ce2's pings to the same `172.16.2.1` land on ce3 and ce4
-respectively, zero leakage — here because each customer's traffic
-threads its own VRF at both borders.
+The label value happens to be 18 on both sides (each router's cust3
+label), but they are different labels from different spaces — and the
+decremented TTL between them is the IP lookup in `cust3` happening. The
+overlap proof runs three customers deep, each ping to the shared
+`172.16.2.1` landing only on its own site-B router:
+
+|                  | arrives at ce4 | arrives at ce5 | arrives at ce6 |
+|:-----------------|:---------------|:---------------|:---------------|
+| ce1 (cust1) pings | **yes**       | —              | —              |
+| ce2 (cust2) pings | —             | **yes**        | —              |
+| ce3 (cust3) pings | —             | —              | **yes**        |
+
+— here because each customer's traffic threads its own VRF at both
+borders.
 
 ## A best-path fix this lab flushed out
 
 Option AB's hybrid re-export has an echo: ASBR2 re-originates everything
-its VRFs import — *including PE2's own prefixes* — and PE2 imports the
-echo back (the RTs match; iBGP carries no AS-path loop protection for
-it). Building this playset exposed a zebra-rs best-path bug: VRF rows
-imported from the VPN table carried the locally-originated route type
-(the tunnel FIB-install path keys on it), so at PE2 the echo **beat the
-CE's direct eBGP route** at the locally-originated tiebreak, and
-customer traffic looped back into the core.
+its VRFs import — *including the PEs' own prefixes* — and each PE
+imports the echo back (the RTs match; iBGP carries no AS-path loop
+protection for it). Building this playset exposed a zebra-rs best-path
+bug: VRF rows imported from the VPN table carried the locally-originated
+route type (the tunnel FIB-install path keys on it), so at the PEs the
+echo **beat the CE's direct eBGP route** at the locally-originated
+tiebreak, and customer traffic looped back into the core.
 
-The fix (in this playset's PR) marks imported rows `vrf_imported` and
-teaches best-path two things: an import is not a local origination, and
-it ranks as iBGP — so RFC 4271's prefer-external step picks the direct
-CE route. The result is visible on PE2:
-
-``` shell
-pe2>show bgp vrf cust1
-    Network            Next Hop            Metric LocPrf Weight Path
- *>  172.16.2.1/32      10.13.0.1                0             0 65513 i
- *   172.16.2.1/32      2.2.2.3                  0    100      0 65513 i
-
-pe2>show ip route vrf cust1
-B  *> 172.16.2.1/32 [20/0] via 10.13.0.1, pe2-ce3, 00:00:50
-```
-
-The direct CE route wins (`*>`); the echo stays in the table, valid but
-not best (`*`) — present, harmless, and a nice fingerprint of how AB's
+The fix (in this playset's original PR) marks imported rows
+`vrf_imported` and teaches best-path two things: an import is not a
+local origination, and it ranks as iBGP — so RFC 4271's prefer-external
+step picks the direct CE route. The result is visible on every PE: the
+CE route stays best (`*>`), the echo stays in the table, valid but not
+best (`*`) — present, harmless, and a nice fingerprint of how AB's
 re-origination machinery works.
 
 ## The quadrant, completed
@@ -273,19 +282,20 @@ $ ./down.sh
 
 ## Appendix: Addressing & sessions
 
-Identical to the [Option C playset](../interas-option-c/README.md#appendix-addressing--sessions)
-except the ASBRs' VRFs: nodes, AS numbers, loopbacks, SR SIDs, links,
-customer addressing, and the single global inter-AS link
-(`192.168.100.0/30`) are unchanged.
+Identical to the [Option B playset](../interas-option-b/README.md#appendix-addressing--sessions)
+(the A/B reference topology with the single global inter-AS link
+`192.168.100.0/30`) except the ASBRs' hybrid VRFs:
 
-| VPN   | RT (coordinated) | RD on pe1 | RD on asbr1 | RD on asbr2 | RD on pe2 |
-|:------|:-----------------|:----------|:------------|:------------|:----------|
-| cust1 | 65501:100        | 65501:1   | 65501:11    | 65502:11    | 65502:1   |
-| cust2 | 65501:200        | 65501:2   | 65501:12    | 65502:12    | 65502:2   |
+| VPN   | RT (coordinated) | RD at origin       | RD on asbr1 | RD on asbr2 | RD on pe3 |
+|:------|:-----------------|:-------------------|:------------|:------------|:----------|
+| cust1 | 65501:100        | 65501:1 (pe1)      | 65501:11    | 65502:11    | 65502:1   |
+| cust2 | 65501:200        | 65501:2 (pe1)      | 65501:12    | 65502:12    | 65502:2   |
+| cust3 | 65501:300        | 65501:3 (pe2)      | 65501:13    | 65502:13    | 65502:3   |
 
-BGP sessions: 4× PE-CE eBGP IPv4 (in VRF), 2× iBGP VPNv4 over loopbacks
-(no next-hop-self needed), and **one** ASBR-ASBR eBGP VPNv4 session —
-with the per-customer VRFs riding on `inter-as-hybrid` at both borders.
+BGP sessions: 6× PE-CE eBGP IPv4 (in VRF), 3× iBGP VPNv4 over loopbacks
+(pe1–asbr1, pe2–asbr1, asbr2–pe3 — no next-hop-self needed), and **one**
+ASBR-ASBR eBGP VPNv4 session — with the per-customer VRFs riding on
+`inter-as-hybrid` at both borders.
 
 ## Sources
 

--- a/playset/interas-option-ab/asbr1.yaml
+++ b/playset/interas-option-ab/asbr1.yaml
@@ -11,7 +11,8 @@
 #    hop, a freshly allocated per-VRF label, and the VRF's export RT
 #    replacing the received RTs — exactly Cisco's Option AB route
 #    distribution. The re-export is locally originated, so
-#    next-hop-self is automatic on both legs (no knob, unlike B).
+#    next-hop-self is automatic on both legs (no knob, unlike B) —
+#    including toward both PEs, each on its own iBGP session.
 vrf:
 - name: cust1
   ipv4:
@@ -27,6 +28,13 @@ vrf:
       - 65501:200
       export:
       - 65501:200
+- name: cust3
+  ipv4:
+    route-target:
+      import:
+      - 65501:300
+      export:
+      - 65501:300
 interface:
 - if-name: lo
   ipv4:
@@ -66,7 +74,7 @@ router:
         ibgp: 1
         ebgp: 1
     neighbor:
-    - remote-address: 1.1.1.1        # PE1 — iBGP VPNv4 (no next-hop-self needed)
+    - remote-address: 1.1.1.1        # PE1 — iBGP VPNv4 (no next-hop-self!)
       remote-as: 65501
       timers: {connect-retry-time: 3}
       update-source: 1.1.1.3
@@ -74,7 +82,15 @@ router:
       afi-safi:
       - name: vpnv4
         enabled: true
-    - remote-address: 192.168.100.2  # ASBR2 — single eBGP VPNv4, ALL customers
+    - remote-address: 1.1.1.4        # PE2 — iBGP VPNv4 (no next-hop-self!)
+      remote-as: 65501
+      timers: {connect-retry-time: 3}
+      update-source: 1.1.1.3
+      enabled: true
+      afi-safi:
+      - name: vpnv4
+        enabled: true
+    - remote-address: 192.168.100.2  # ASBR2 — ONE eBGP VPNv4, all customers
       remote-as: 65502
       timers: {connect-retry-time: 3}
       enabled: true
@@ -84,7 +100,10 @@ router:
     vrf:
     - name: cust1
       rd: 65501:11
-      inter-as-hybrid: true
+      inter-as-hybrid: true          # <- THE Option AB knob
     - name: cust2
       rd: 65501:12
+      inter-as-hybrid: true
+    - name: cust3
+      rd: 65501:13
       inter-as-hybrid: true

--- a/playset/interas-option-ab/asbr2.yaml
+++ b/playset/interas-option-ab/asbr2.yaml
@@ -1,6 +1,6 @@
 # ASBR2 — autonomous system border router of AS 65502. Mirror of ASBR1:
 # per-customer transit VRFs (no interfaces, no per-VRF sessions) marked
-# inter-as-hybrid, one eBGP VPNv4 session to ASBR1, iBGP VPNv4 to PE2.
+# inter-as-hybrid, one eBGP VPNv4 session to ASBR1, iBGP VPNv4 to PE3.
 vrf:
 - name: cust1
   ipv4:
@@ -16,6 +16,13 @@ vrf:
       - 65501:200
       export:
       - 65501:200
+- name: cust3
+  ipv4:
+    route-target:
+      import:
+      - 65501:300
+      export:
+      - 65501:300
 interface:
 - if-name: lo
   ipv4:
@@ -55,7 +62,7 @@ router:
         ibgp: 1
         ebgp: 1
     neighbor:
-    - remote-address: 2.2.2.3        # PE2 — iBGP VPNv4 (no next-hop-self needed)
+    - remote-address: 2.2.2.3        # PE3 — iBGP VPNv4 (no next-hop-self!)
       remote-as: 65502
       timers: {connect-retry-time: 3}
       update-source: 2.2.2.1
@@ -63,7 +70,7 @@ router:
       afi-safi:
       - name: vpnv4
         enabled: true
-    - remote-address: 192.168.100.1  # ASBR1 — single eBGP VPNv4, ALL customers
+    - remote-address: 192.168.100.1  # ASBR1 — ONE eBGP VPNv4, all customers
       remote-as: 65501
       timers: {connect-retry-time: 3}
       enabled: true
@@ -76,4 +83,7 @@ router:
       inter-as-hybrid: true
     - name: cust2
       rd: 65502:12
+      inter-as-hybrid: true
+    - name: cust3
+      rd: 65502:13
       inter-as-hybrid: true

--- a/playset/interas-option-ab/ce1.yaml
+++ b/playset/interas-option-ab/ce1.yaml
@@ -1,6 +1,7 @@
-# CE1 — customer "cust1", site A (AS 65511). Identical to the Option A
-# playset: plain eBGP to PE1, loopback originated via `redistribute
-# connected`. The customer cannot tell which Inter-AS option carries it.
+# CE1 — customer "cust1", site A (AS 65511). Plain eBGP to PE1; the
+# loopback 172.16.1.1/32 is originated via `redistribute connected` and
+# is the ping source toward site B. cust2's CE2 uses the *same* loopback
+# address — the VPNs keep the overlap apart.
 interface:
 - if-name: lo
   ipv4:

--- a/playset/interas-option-ab/ce2.yaml
+++ b/playset/interas-option-ab/ce2.yaml
@@ -1,6 +1,6 @@
 # CE2 — customer "cust2", site A (AS 65512). Same loopback address as
-# CE1 (172.16.1.1/32) on purpose: in Option B both customers' overlapping
-# routes cross ONE inter-AS session, kept apart only by their RDs.
+# CE1 (172.16.1.1/32) on purpose: the two customers run overlapping
+# address plans and never notice each other.
 interface:
 - if-name: lo
   ipv4:

--- a/playset/interas-option-ab/ce3.yaml
+++ b/playset/interas-option-ab/ce3.yaml
@@ -1,9 +1,11 @@
-# CE3 — customer "cust1", site B (AS 65513). The far end of cust1:
-# ce1 pings this router's loopback 172.16.2.1/32 across both ASes.
+# CE3 — customer "cust3", site A (AS 65513), attached to PE2. Same
+# loopback address as CE1 and CE2 (172.16.1.1/32) on purpose: all three
+# customers run the same overlapping address plan and never notice each
+# other.
 interface:
 - if-name: lo
   ipv4:
-    address: 172.16.2.1/32
+    address: 172.16.1.1/32
 - if-name: ce3-pe2
   ipv4:
     address: 10.13.0.1/30
@@ -19,7 +21,7 @@ router:
         ebgp: 3
     neighbor:
     - remote-address: 10.13.0.2
-      remote-as: 65502
+      remote-as: 65501
       timers: {connect-retry-time: 3}
       enabled: true
       afi-safi:

--- a/playset/interas-option-ab/ce5.yaml
+++ b/playset/interas-option-ab/ce5.yaml
@@ -1,26 +1,25 @@
-# CE4 — customer "cust1", site B (AS 65514), attached to PE3. The far
-# end of cust1: ce1 pings this router's loopback 172.16.2.1/32 across
-# both ASes. CE5 and CE6 answer to the same address for their own
-# customers.
+# CE5 — customer "cust2", site B (AS 65515), attached to PE3. Same
+# loopback address as CE4 and CE6 (172.16.2.1/32): ce2 pinging
+# 172.16.2.1 must land here and nowhere else.
 interface:
 - if-name: lo
   ipv4:
     address: 172.16.2.1/32
-- if-name: ce4-pe3
+- if-name: ce5-pe3
   ipv4:
-    address: 10.14.0.1/30
+    address: 10.15.0.1/30
 system:
-  hostname: ce4
+  hostname: ce5
 router:
   bgp:
     global:
-      as: 65514
-      router-id: 10.14.0.1
+      as: 65515
+      router-id: 10.15.0.1
     timer:
       adv-interval:
         ebgp: 3
     neighbor:
-    - remote-address: 10.14.0.2
+    - remote-address: 10.15.0.2
       remote-as: 65502
       timers: {connect-retry-time: 3}
       enabled: true

--- a/playset/interas-option-ab/ce6.yaml
+++ b/playset/interas-option-ab/ce6.yaml
@@ -1,26 +1,25 @@
-# CE4 — customer "cust1", site B (AS 65514), attached to PE3. The far
-# end of cust1: ce1 pings this router's loopback 172.16.2.1/32 across
-# both ASes. CE5 and CE6 answer to the same address for their own
-# customers.
+# CE6 — customer "cust3", site B (AS 65516), attached to PE3. Same
+# loopback address as CE4 and CE5 (172.16.2.1/32): ce3 pinging
+# 172.16.2.1 must land here and nowhere else.
 interface:
 - if-name: lo
   ipv4:
     address: 172.16.2.1/32
-- if-name: ce4-pe3
+- if-name: ce6-pe3
   ipv4:
-    address: 10.14.0.1/30
+    address: 10.16.0.1/30
 system:
-  hostname: ce4
+  hostname: ce6
 router:
   bgp:
     global:
-      as: 65514
-      router-id: 10.14.0.1
+      as: 65516
+      router-id: 10.16.0.1
     timer:
       adv-interval:
         ebgp: 3
     neighbor:
-    - remote-address: 10.14.0.2
+    - remote-address: 10.16.0.2
       remote-as: 65502
       timers: {connect-retry-time: 3}
       enabled: true

--- a/playset/interas-option-ab/p1.yaml
+++ b/playset/interas-option-ab/p1.yaml
@@ -1,6 +1,6 @@
 # P1 — provider core transit LSR of AS 65501 (runs no BGP, knows no
-# VPN). Pure IS-IS L2 + SR-MPLS; swaps / PHPs the transport label
-# between PE1 (sid 11 -> 16011) and ASBR1 (sid 13 -> 16013).
+# VPN). Pure IS-IS L2 + SR-MPLS; label-switches between PE1 (sid 11 ->
+# 16011), PE2 (sid 14 -> 16014), and ASBR1 (sid 13 -> 16013).
 interface:
 - if-name: lo
   ipv4:
@@ -8,6 +8,9 @@ interface:
 - if-name: p1-pe1
   ipv4:
     address: 10.1.0.2/30
+- if-name: p1-pe2
+  ipv4:
+    address: 10.1.0.10/30
 - if-name: p1-asbr1
   ipv4:
     address: 10.1.0.5/30
@@ -27,6 +30,11 @@ router:
         prefix-sid:
           index: 12
     - if-name: p1-pe1
+      network-type: point-to-point
+      metric: 10
+      ipv4:
+        enabled: true
+    - if-name: p1-pe2
       network-type: point-to-point
       metric: 10
       ipv4:

--- a/playset/interas-option-ab/p2.yaml
+++ b/playset/interas-option-ab/p2.yaml
@@ -1,6 +1,6 @@
 # P2 — provider core transit LSR of AS 65502 (runs no BGP, knows no
 # VPN). Pure IS-IS L2 + SR-MPLS; swaps / PHPs the transport label
-# between ASBR2 (sid 21 -> 16021) and PE2 (sid 23 -> 16023).
+# between ASBR2 (sid 21 -> 16021) and PE3 (sid 23 -> 16023).
 interface:
 - if-name: lo
   ipv4:
@@ -8,7 +8,7 @@ interface:
 - if-name: p2-asbr2
   ipv4:
     address: 10.2.0.2/30
-- if-name: p2-pe2
+- if-name: p2-pe3
   ipv4:
     address: 10.2.0.5/30
 system:
@@ -31,7 +31,7 @@ router:
       metric: 10
       ipv4:
         enabled: true
-    - if-name: p2-pe2
+    - if-name: p2-pe3
       network-type: point-to-point
       metric: 10
       ipv4:

--- a/playset/interas-option-ab/pe1.yaml
+++ b/playset/interas-option-ab/pe1.yaml
@@ -1,6 +1,7 @@
-# PE1 — provider edge, AS 65501. Same shape as the Option A playset with
-# one crucial difference: the route-targets are COORDINATED with AS 65502
-# (both providers import/export 65501:100 / 65501:200) — in Option B the
+# PE1 — provider edge, AS 65501, serving cust1 (CE1) and cust2 (CE2).
+# Same shape as the Option A playset with one crucial difference: the
+# route-targets are COORDINATED with AS 65502 (both providers
+# import/export 65501:100 / 65501:200 / 65501:300) — in Option B the
 # VPNv4 routes cross the boundary with their attributes intact, so the
 # far PE imports by the same RT.
 vrf:

--- a/playset/interas-option-ab/pe2.yaml
+++ b/playset/interas-option-ab/pe2.yaml
@@ -1,88 +1,68 @@
-# PE2 — provider edge, AS 65502. Note: the route-targets match AS
-# 65501's (65501:100 / 65501:200) — Option B carries VPNv4 attributes
-# across the boundary, so the providers must agree on RTs. The RDs stay
-# AS-local (65502:1 / 65502:2): only the RT drives import.
+# PE2 — second provider edge of AS 65501, serving cust3 (CE3). Same
+# pattern as PE1: coordinated RT (65501:300), its own iBGP VPNv4
+# session to ASBR1.
 vrf:
-- name: cust1
+- name: cust3
   ipv4:
     route-target:
       import:
-      - 65501:100
+      - 65501:300
       export:
-      - 65501:100
-- name: cust2
-  ipv4:
-    route-target:
-      import:
-      - 65501:200
-      export:
-      - 65501:200
+      - 65501:300
 interface:
 - if-name: lo
   ipv4:
-    address: 2.2.2.3/32
-- if-name: pe2-p2
-  ipv4:
-    address: 10.2.0.6/30
+    address: 1.1.1.4/32
 - if-name: pe2-ce3
-  vrf: cust1
+  vrf: cust3
   ipv4:
     address: 10.13.0.2/30
-- if-name: pe2-ce4
-  vrf: cust2
+- if-name: pe2-p1
   ipv4:
-    address: 10.14.0.2/30
+    address: 10.1.0.9/30
 system:
   hostname: pe2
 router:
   isis:
-    net: 49.0002.0000.0000.0003.00
+    net: 49.0001.0000.0000.0004.00
     hostname: pe2
     is-type: level-2-only
     segment-routing: mpls
-    te-router-id: 2.2.2.3
+    te-router-id: 1.1.1.4
     interface:
     - if-name: lo
       ipv4:
         enabled: true
         prefix-sid:
-          index: 23
-    - if-name: pe2-p2
+          index: 14
+    - if-name: pe2-p1
       network-type: point-to-point
       metric: 10
       ipv4:
         enabled: true
   bgp:
     global:
-      as: 65502
-      router-id: 2.2.2.3
+      as: 65501
+      router-id: 1.1.1.4
     timer:
       adv-interval:
         ibgp: 1
         ebgp: 3
     neighbor:
-    - remote-address: 2.2.2.1
-      remote-as: 65502
+    - remote-address: 1.1.1.3
+      remote-as: 65501
       timers: {connect-retry-time: 3}
-      update-source: 2.2.2.3
+      update-source: 1.1.1.4
       enabled: true
       afi-safi:
       - name: vpnv4
         enabled: true
     vrf:
-    - name: cust1
-      rd: 65502:1
+    - name: cust3
+      rd: 65501:3
       neighbor:
       - remote-address: 10.13.0.1
         remote-as: 65513
-        afi-safi:
-        - name: ipv4
-          enabled: true
-    - name: cust2
-      rd: 65502:2
-      neighbor:
-      - remote-address: 10.14.0.1
-        remote-as: 65514
         afi-safi:
         - name: ipv4
           enabled: true

--- a/playset/interas-option-ab/pe3.yaml
+++ b/playset/interas-option-ab/pe3.yaml
@@ -1,0 +1,108 @@
+# PE3 — the provider edge of AS 65502, serving all three customers
+# (CE4/CE5/CE6). Note: the route-targets match AS 65501's (65501:100 /
+# 65501:200 / 65501:300) — Option B carries VPNv4 attributes across the
+# boundary, so the providers must agree on RTs. The RDs stay AS-local
+# (65502:1/2/3): only the RT drives import.
+vrf:
+- name: cust1
+  ipv4:
+    route-target:
+      import:
+      - 65501:100
+      export:
+      - 65501:100
+- name: cust2
+  ipv4:
+    route-target:
+      import:
+      - 65501:200
+      export:
+      - 65501:200
+- name: cust3
+  ipv4:
+    route-target:
+      import:
+      - 65501:300
+      export:
+      - 65501:300
+interface:
+- if-name: lo
+  ipv4:
+    address: 2.2.2.3/32
+- if-name: pe3-p2
+  ipv4:
+    address: 10.2.0.6/30
+- if-name: pe3-ce4
+  vrf: cust1
+  ipv4:
+    address: 10.14.0.2/30
+- if-name: pe3-ce5
+  vrf: cust2
+  ipv4:
+    address: 10.15.0.2/30
+- if-name: pe3-ce6
+  vrf: cust3
+  ipv4:
+    address: 10.16.0.2/30
+system:
+  hostname: pe3
+router:
+  isis:
+    net: 49.0002.0000.0000.0003.00
+    hostname: pe3
+    is-type: level-2-only
+    segment-routing: mpls
+    te-router-id: 2.2.2.3
+    interface:
+    - if-name: lo
+      ipv4:
+        enabled: true
+        prefix-sid:
+          index: 23
+    - if-name: pe3-p2
+      network-type: point-to-point
+      metric: 10
+      ipv4:
+        enabled: true
+  bgp:
+    global:
+      as: 65502
+      router-id: 2.2.2.3
+    timer:
+      adv-interval:
+        ibgp: 1
+        ebgp: 3
+    neighbor:
+    - remote-address: 2.2.2.1
+      remote-as: 65502
+      timers: {connect-retry-time: 3}
+      update-source: 2.2.2.3
+      enabled: true
+      afi-safi:
+      - name: vpnv4
+        enabled: true
+    vrf:
+    - name: cust1
+      rd: 65502:1
+      neighbor:
+      - remote-address: 10.14.0.1
+        remote-as: 65514
+        afi-safi:
+        - name: ipv4
+          enabled: true
+    - name: cust2
+      rd: 65502:2
+      neighbor:
+      - remote-address: 10.15.0.1
+        remote-as: 65515
+        afi-safi:
+        - name: ipv4
+          enabled: true
+    - name: cust3
+      rd: 65502:3
+      neighbor:
+      - remote-address: 10.16.0.1
+        remote-as: 65516
+        afi-safi:
+        - name: ipv4
+          enabled: true

--- a/playset/interas-option-ab/topology.sh
+++ b/playset/interas-option-ab/topology.sh
@@ -1,27 +1,34 @@
 # Inter-AS Option AB (Cisco hybrid: per-VPN VRFs + one VPNv4 session)
-# demo topology. Each PLAYSET_LINKS entry is "ns_a:iface_a:ns_b:iface_b".
+# demo topology — the reference diagram (images/InterASOptionAB.svg):
+# three customers, two PEs in AS 65501, per-customer transit VRFs at
+# both borders riding ONE eBGP VPNv4 session.
+# Each PLAYSET_LINKS entry is "ns_a:iface_a:ns_b:iface_b".
 #
-#   ce1 ─┐                                                ┌─ ce3   (cust1)
-#        pe1 ── p1 ── asbr1 ═══ one VPNv4 session ═══ asbr2 ── p2 ── pe2
-#   ce2 ─┘        AS 65501   (per-VPN VRF lookup at    AS 65502     └─ ce4   (cust2)
-#                             each ASBR, like Option A)
+#   ce1 ─┐                                                     ┌─ ce4  (cust1)
+#   ce2 ─┴ pe1 ─┐                                              ├─ ce5  (cust2)
+#               p1 ── asbr1 ═══ one VPNv4 session ═══ asbr2 ── p2 ── pe3
+#   ce3 ── pe2 ┘        AS 65501  [cust1][cust2][cust3] AS 65502   └─ ce6  (cust3)
+#                                  transit VRFs at BOTH borders
 
-PLAYSET_NAMESPACES=(ce1 ce2 pe1 p1 asbr1 asbr2 p2 pe2 ce3 ce4)
+PLAYSET_NAMESPACES=(ce1 ce2 ce3 pe1 pe2 p1 asbr1 asbr2 p2 pe3 ce4 ce5 ce6)
 
 PLAYSET_LINKS=(
     ce1:ce1-pe1:pe1:pe1-ce1
     ce2:ce2-pe1:pe1:pe1-ce2
+    ce3:ce3-pe2:pe2:pe2-ce3
     pe1:pe1-p1:p1:p1-pe1
+    pe2:pe2-p1:p1:p1-pe2
     p1:p1-asbr1:asbr1:asbr1-p1
     asbr1:asbr1-asbr2:asbr2:asbr2-asbr1
     asbr2:asbr2-p2:p2:p2-asbr2
-    p2:p2-pe2:pe2:pe2-p2
-    pe2:pe2-ce3:ce3:ce3-pe2
-    pe2:pe2-ce4:ce4:ce4-pe2
+    p2:p2-pe3:pe3:pe3-p2
+    pe3:pe3-ce4:ce4:ce4-pe3
+    pe3:pe3-ce5:ce5:ce5-pe3
+    pe3:pe3-ce6:ce6:ce6-pe3
 )
 
 # All namespaces that run zebra-rs.
-PLAYSET_DAEMONS=(ce1 ce2 pe1 p1 asbr1 asbr2 p2 pe2 ce3 ce4)
+PLAYSET_DAEMONS=(ce1 ce2 ce3 pe1 pe2 p1 asbr1 asbr2 p2 pe3 ce4 ce5 ce6)
 
 # Routers with vtyctl YAML config.
-PLAYSET_ROUTERS=(ce1 ce2 pe1 p1 asbr1 asbr2 p2 pe2 ce3 ce4)
+PLAYSET_ROUTERS=(ce1 ce2 ce3 pe1 pe2 p1 asbr1 asbr2 p2 pe3 ce4 ce5 ce6)

--- a/playset/interas-option-c/README.md
+++ b/playset/interas-option-c/README.md
@@ -306,8 +306,7 @@ $ ./down.sh
 
 ## Appendix: Addressing & sessions
 
-This lab (and its AB and C-RR siblings) uses the pared ten-node variant
-of the reference topology:
+This lab uses the pared ten-node variant of the reference topology:
 
 | node  | role             | AS    | loopback     | SR SID (label)  |
 |:------|:-----------------|:------|:-------------|:----------------|


### PR DESCRIPTION
## Summary
- Rebuild `playset/interas-option-ab` from the pared ten-node variant onto the full 13-node reference topology shared with Options A and B: three customers (ce1↔ce4, ce2↔ce5, ce3↔ce6) with overlapping site addressing, pe1 (cust1+cust2) and pe2 (cust3) in AS 65501, pe3 serving all three customers in AS 65502.
- Each ASBR now holds **three** interface-less transit VRFs (`inter-as-hybrid: true`) with per-customer RDs (65501:11/12/13 ↔ 65502:11/12/13), all riding the single eBGP VPNv4 border session; no `next-hop-self` anywhere.
- README rewritten with live captures: the three DecapVrf ILMs (`16/17/18 dev cust1/2/3`), the cust3 RD re-origination chain (65501:3 → 65501:13), per-owning-PE transport stacks (16011 vs 16014), the one-label wire capture (ttl 63 → 62), and the 3×3 cross-customer isolation matrix.
- `InterASOptionAB.svg` / `.drawio` redrawn to the 13-node layout with stacked transit-VRF chips on both ASBRs.
- Consistency fixes: the playset index now says only Option C uses the ten-node variant, and the Option C appendix note no longer claims AB/C-RR share it.

## Test plan
- Lab brought up live: all three VPNs converged (ce1↔ce4, ce2↔ce5, ce3↔ce6 at ttl=60), pe2's re-export echo demoted below the direct CE route, perfect 3×3 landing diagonal (no cross-customer leakage); torn down clean.
- SVG render-verified via cairosvg.
- Playset-only change — no daemon code touched.

Generated with [Claude Code](https://claude.com/claude-code)