### PR TITLE
playset: uppercase node names in the Option AB diagram

### DIFF
--- a/playset/images/InterASOptionAB.drawio
+++ b/playset/images/InterASOptionAB.drawio
@@ -91,43 +91,43 @@
         <mxCell id="interas-label" parent="1" style="text;html=1;whiteSpace=wrap;strokeColor=none;fillColor=none;align=center;verticalAlign=middle;rounded=0;fontSize=9;fontColor=#E97131;" value="eBGP VPNv4 (one session)" vertex="1">
           <mxGeometry height="14" width="150" x="347" y="298" as="geometry" />
         </mxCell>
-        <mxCell id="pe1" parent="1" style="ellipse;whiteSpace=wrap;html=1;aspect=fixed;strokeColor=#0E9ED5;fillColor=#FFFFFF;fontSize=8;" value="pe1" vertex="1">
+        <mxCell id="pe1" parent="1" style="ellipse;whiteSpace=wrap;html=1;aspect=fixed;strokeColor=#0E9ED5;fillColor=#FFFFFF;fontSize=8;" value="PE1" vertex="1">
           <mxGeometry height="30" width="30" x="155" y="245" as="geometry" />
         </mxCell>
-        <mxCell id="pe2" parent="1" style="ellipse;whiteSpace=wrap;html=1;aspect=fixed;strokeColor=#0E9ED5;fillColor=#FFFFFF;fontSize=8;" value="pe2" vertex="1">
+        <mxCell id="pe2" parent="1" style="ellipse;whiteSpace=wrap;html=1;aspect=fixed;strokeColor=#0E9ED5;fillColor=#FFFFFF;fontSize=8;" value="PE2" vertex="1">
           <mxGeometry height="30" width="30" x="155" y="365" as="geometry" />
         </mxCell>
-        <mxCell id="p1" parent="1" style="ellipse;whiteSpace=wrap;html=1;aspect=fixed;strokeColor=#0E9ED5;fillColor=#FFFFFF;fontSize=8;" value="p1" vertex="1">
+        <mxCell id="p1" parent="1" style="ellipse;whiteSpace=wrap;html=1;aspect=fixed;strokeColor=#0E9ED5;fillColor=#FFFFFF;fontSize=8;" value="P1" vertex="1">
           <mxGeometry height="30" width="30" x="240" y="305" as="geometry" />
         </mxCell>
-        <mxCell id="asbr1" parent="1" style="ellipse;whiteSpace=wrap;html=1;aspect=fixed;strokeColor=#0E9ED5;fillColor=#FFFFFF;fontSize=8;" value="asbr1" vertex="1">
+        <mxCell id="asbr1" parent="1" style="ellipse;whiteSpace=wrap;html=1;aspect=fixed;strokeColor=#0E9ED5;fillColor=#FFFFFF;fontSize=8;" value="ASBR1" vertex="1">
           <mxGeometry height="30" width="30" x="325" y="305" as="geometry" />
         </mxCell>
-        <mxCell id="asbr2" parent="1" style="ellipse;whiteSpace=wrap;html=1;aspect=fixed;strokeColor=#0E9ED5;fillColor=#FFFFFF;fontSize=8;" value="asbr2" vertex="1">
+        <mxCell id="asbr2" parent="1" style="ellipse;whiteSpace=wrap;html=1;aspect=fixed;strokeColor=#0E9ED5;fillColor=#FFFFFF;fontSize=8;" value="ASBR2" vertex="1">
           <mxGeometry height="30" width="30" x="490" y="305" as="geometry" />
         </mxCell>
-        <mxCell id="p2" parent="1" style="ellipse;whiteSpace=wrap;html=1;aspect=fixed;strokeColor=#0E9ED5;fillColor=#FFFFFF;fontSize=8;" value="p2" vertex="1">
+        <mxCell id="p2" parent="1" style="ellipse;whiteSpace=wrap;html=1;aspect=fixed;strokeColor=#0E9ED5;fillColor=#FFFFFF;fontSize=8;" value="P2" vertex="1">
           <mxGeometry height="30" width="30" x="570" y="305" as="geometry" />
         </mxCell>
-        <mxCell id="pe3" parent="1" style="ellipse;whiteSpace=wrap;html=1;aspect=fixed;strokeColor=#0E9ED5;fillColor=#FFFFFF;fontSize=8;" value="pe3" vertex="1">
+        <mxCell id="pe3" parent="1" style="ellipse;whiteSpace=wrap;html=1;aspect=fixed;strokeColor=#0E9ED5;fillColor=#FFFFFF;fontSize=8;" value="PE3" vertex="1">
           <mxGeometry height="30" width="30" x="650" y="305" as="geometry" />
         </mxCell>
-        <mxCell id="ce1" parent="1" style="rounded=1;whiteSpace=wrap;html=1;fillStyle=solid;fillColor=#0499D4;strokeColor=none;fontSize=8;fontColor=#FFFFFF;" value="ce1" vertex="1">
+        <mxCell id="ce1" parent="1" style="rounded=1;whiteSpace=wrap;html=1;fillStyle=solid;fillColor=#0499D4;strokeColor=none;fontSize=8;fontColor=#FFFFFF;" value="CE1" vertex="1">
           <mxGeometry height="25" width="40" x="15" y="210" as="geometry" />
         </mxCell>
-        <mxCell id="ce2" parent="1" style="rounded=1;whiteSpace=wrap;html=1;fillStyle=solid;fillColor=#4DA72E;strokeColor=none;fontSize=8;fontColor=#FFFFFF;" value="ce2" vertex="1">
+        <mxCell id="ce2" parent="1" style="rounded=1;whiteSpace=wrap;html=1;fillStyle=solid;fillColor=#4DA72E;strokeColor=none;fontSize=8;fontColor=#FFFFFF;" value="CE2" vertex="1">
           <mxGeometry height="25" width="40" x="15" y="280" as="geometry" />
         </mxCell>
-        <mxCell id="ce3" parent="1" style="rounded=1;whiteSpace=wrap;html=1;fillStyle=solid;fillColor=#E97131;strokeColor=none;fontSize=8;fontColor=#FFFFFF;" value="ce3" vertex="1">
+        <mxCell id="ce3" parent="1" style="rounded=1;whiteSpace=wrap;html=1;fillStyle=solid;fillColor=#E97131;strokeColor=none;fontSize=8;fontColor=#FFFFFF;" value="CE3" vertex="1">
           <mxGeometry height="25" width="40" x="15" y="385" as="geometry" />
         </mxCell>
-        <mxCell id="ce4" parent="1" style="rounded=1;whiteSpace=wrap;html=1;fillStyle=solid;fillColor=#0499D4;strokeColor=none;fontSize=8;fontColor=#FFFFFF;" value="ce4" vertex="1">
+        <mxCell id="ce4" parent="1" style="rounded=1;whiteSpace=wrap;html=1;fillStyle=solid;fillColor=#0499D4;strokeColor=none;fontSize=8;fontColor=#FFFFFF;" value="CE4" vertex="1">
           <mxGeometry height="25" width="40" x="770" y="210" as="geometry" />
         </mxCell>
-        <mxCell id="ce5" parent="1" style="rounded=1;whiteSpace=wrap;html=1;fillStyle=solid;fillColor=#4DA72E;strokeColor=none;fontSize=8;fontColor=#FFFFFF;" value="ce5" vertex="1">
+        <mxCell id="ce5" parent="1" style="rounded=1;whiteSpace=wrap;html=1;fillStyle=solid;fillColor=#4DA72E;strokeColor=none;fontSize=8;fontColor=#FFFFFF;" value="CE5" vertex="1">
           <mxGeometry height="25" width="40" x="770" y="307.5" as="geometry" />
         </mxCell>
-        <mxCell id="ce6" parent="1" style="rounded=1;whiteSpace=wrap;html=1;fillStyle=solid;fillColor=#E97131;strokeColor=none;fontSize=8;fontColor=#FFFFFF;" value="ce6" vertex="1">
+        <mxCell id="ce6" parent="1" style="rounded=1;whiteSpace=wrap;html=1;fillStyle=solid;fillColor=#E97131;strokeColor=none;fontSize=8;fontColor=#FFFFFF;" value="CE6" vertex="1">
           <mxGeometry height="25" width="40" x="770" y="385" as="geometry" />
         </mxCell>
         <mxCell id="dp-ip-left" parent="1" style="rounded=0;whiteSpace=wrap;html=1;strokeColor=#999999;fontSize=11;" value="IP" vertex="1">

--- a/playset/images/InterASOptionAB.svg
+++ b/playset/images/InterASOptionAB.svg
@@ -68,29 +68,29 @@
     <circle cx="665" cy="190" r="15"/>
   </g>
   <g text-anchor="middle" font-size="8" fill="#333333">
-    <text x="170" y="133">pe1</text>
-    <text x="170" y="253">pe2</text>
-    <text x="255" y="193">p1</text>
-    <text x="340" y="193">asbr1</text>
-    <text x="505" y="193">asbr2</text>
-    <text x="585" y="193">p2</text>
-    <text x="665" y="193">pe3</text>
+    <text x="170" y="133">PE1</text>
+    <text x="170" y="253">PE2</text>
+    <text x="255" y="193">P1</text>
+    <text x="340" y="193" font-size="7">ASBR1</text>
+    <text x="505" y="193" font-size="7">ASBR2</text>
+    <text x="585" y="193">P2</text>
+    <text x="665" y="193">PE3</text>
   </g>
 
   <!-- customer edges -->
   <g font-size="9" text-anchor="middle" fill="#ffffff">
     <rect x="15" y="80" width="40" height="25" rx="5" fill="#0499D4"/>
-    <text x="35" y="96">ce1</text>
+    <text x="35" y="96">CE1</text>
     <rect x="15" y="150" width="40" height="25" rx="5" fill="#4DA72E"/>
-    <text x="35" y="166">ce2</text>
+    <text x="35" y="166">CE2</text>
     <rect x="15" y="255" width="40" height="25" rx="5" fill="#E97131"/>
-    <text x="35" y="271">ce3</text>
+    <text x="35" y="271">CE3</text>
     <rect x="770" y="80" width="40" height="25" rx="5" fill="#0499D4"/>
-    <text x="790" y="96">ce4</text>
+    <text x="790" y="96">CE4</text>
     <rect x="770" y="177.5" width="40" height="25" rx="5" fill="#4DA72E"/>
-    <text x="790" y="193.5">ce5</text>
+    <text x="790" y="193.5">CE5</text>
     <rect x="770" y="255" width="40" height="25" rx="5" fill="#E97131"/>
-    <text x="790" y="271">ce6</text>
+    <text x="790" y="271">CE6</text>
   </g>
 
   <!-- data plane bands: labeled across the border -->


### PR DESCRIPTION
## Summary
- Uppercase the node names in `InterASOptionAB.drawio` and `InterASOptionAB.svg` (`pe1` → `PE1`, `asbr1` → `ASBR1`, `ce1` → `CE1`, ...) to match the Option A/B/C diagrams.
- The `cust1/2/3` transit-VRF chips stay lowercase — they name the configured VRFs in the lab yamls.

## Test plan
- SVG render-verified via cairosvg: all labels uppercase and fitting their shapes (ASBR labels sized down one point to fit the router circles), layout unchanged.
- Diagram-only change.

Generated with [Claude Code](https://claude.com/claude-code)