### PR TITLE
packaging: ship playset labs in the deb at /usr/share/zebra-rs/playset

### DIFF
--- a/packaging/Makefile
+++ b/packaging/Makefile
@@ -1,14 +1,23 @@
 all: arm64
 
-arm64: ../vty/vty
+arm64: ../vty/vty playset
 	cargo build --release
 	$(MAKE) -C .. xdp-bfd-echo
 	nfpm package --packager=deb --config=nfpm-arm64.yaml
 
-amd64: ../vty/vty
+amd64: ../vty/vty playset
 	cargo build --release
 	$(MAKE) -C .. xdp-bfd-echo
 	nfpm package --packager=deb --config=nfpm-amd64.yaml
+
+# Stage a clean copy of the playset labs for packaging. nfpm has no exclude
+# globs, so copying ../playset directly would sweep in runtime artifacts
+# (*.log, *.pid) left over from local lab runs; the rsync filter honors
+# playset/.gitignore instead.
+.PHONY: playset
+playset:
+	mkdir -p out
+	rsync -a --delete --filter=':- .gitignore' --exclude='.gitignore' ../playset/ out/playset/
 
 # The XDP BFD Echo helper lives in the excluded offload/ workspace and needs
 # a nightly bpfel toolchain + bpf-linker (see offload/xdp-bfd-echo/README.md),

--- a/packaging/nfpm-amd64.yaml
+++ b/packaging/nfpm-amd64.yaml
@@ -52,6 +52,11 @@ contents:
   # `router bgp { lua-script <name> { source-path ... } }`.
   - src: ../etc/zebra-rs/lua
     dst: /etc/zebra-rs/lua
+  # Playset lab topologies (netns-based example networks). Read-only data,
+  # so they live under /usr/share rather than /etc. Staged into out/ by the
+  # Makefile `playset` target to filter out runtime artifacts (*.log, *.pid).
+  - src: ./out/playset
+    dst: /usr/share/zebra-rs/playset
   - src: ./modules-load.d/zebra-rs.conf
     dst: /etc/modules-load.d/zebra-rs.conf
   - src: ./patch/usr/lib/systemd/system/zebra-rs.service
@@ -60,4 +65,5 @@ overrides:
   deb:
     scripts:
       postinstall: ./scripts/postinstall.sh
+      preremove: ./scripts/prerm.sh
       postremove: ./scripts/postrm.sh

--- a/packaging/nfpm-arm64.yaml
+++ b/packaging/nfpm-arm64.yaml
@@ -52,6 +52,11 @@ contents:
   # `router bgp { lua-script <name> { source-path ... } }`.
   - src: ../etc/zebra-rs/lua
     dst: /etc/zebra-rs/lua
+  # Playset lab topologies (netns-based example networks). Read-only data,
+  # so they live under /usr/share rather than /etc. Staged into out/ by the
+  # Makefile `playset` target to filter out runtime artifacts (*.log, *.pid).
+  - src: ./out/playset
+    dst: /usr/share/zebra-rs/playset
   - src: ./modules-load.d/zebra-rs.conf
     dst: /etc/modules-load.d/zebra-rs.conf
   - src: ./patch/usr/lib/systemd/system/zebra-rs.service
@@ -60,4 +65,5 @@ overrides:
   deb:
     scripts:
       postinstall: ./scripts/postinstall.sh
+      preremove: ./scripts/prerm.sh
       postremove: ./scripts/postrm.sh

--- a/packaging/scripts/prerm.sh
+++ b/packaging/scripts/prerm.sh
@@ -1,0 +1,14 @@
+#!/bin/sh
+set -e
+
+case "$1" in
+    remove)
+        # Stop the daemon before dpkg deletes the unit file — postrm runs
+        # too late (systemd can no longer resolve the unit), which used to
+        # leave an orphaned zebra-rs running with a deleted binary. Skip on
+        # upgrade: the new package's postinstall restarts the service.
+        if command -v systemctl >/dev/null 2>&1; then
+            systemctl stop zebra-rs >/dev/null 2>&1 || true
+        fi
+        ;;
+esac

--- a/playset/README.md
+++ b/playset/README.md
@@ -37,8 +37,9 @@ Linux tooling works inside the namespaces too — `ip route`, `tcpdump`,
 
 The daemon and CLI binaries are resolved from `target/debug/` when built,
 falling back to the installed ones on `PATH`. Each playset writes its
-runtime state (`*.log`, `*.pid`) into its own directory; those files are
-gitignored.
+runtime state (`*.log`, `*.pid`) into `/tmp/zebra-rs-playset/<playset-name>/`
+(override with `PLAYSET_RUN_DIR`), so the labs also run from a read-only
+install location such as `/usr/share/zebra-rs/playset`.
 
 > **One at a time**: the TI-LFA playsets share the same topology and
 > namespace names (`s`, `n1`..`n3`, `r1`..`r3`, `d`, `e1`, `e2`), so bring

--- a/playset/lib/common.sh
+++ b/playset/lib/common.sh
@@ -7,6 +7,12 @@ set -euo pipefail
 
 PLAYSET_ROOT="$(cd "${PLAYSET_DEMO_DIR}/.." && pwd)"
 
+# Runtime state (*.pid, *.log) lives outside the demo directory so the labs
+# also run from a read-only install location such as
+# /usr/share/zebra-rs/playset. Override with PLAYSET_RUN_DIR.
+: "${PLAYSET_RUN_DIR:=/tmp/zebra-rs-playset/$(basename "${PLAYSET_DEMO_DIR}")}"
+mkdir -p "${PLAYSET_RUN_DIR}"
+
 run() {
     sudo "$@"
 }
@@ -18,5 +24,5 @@ run_in_netns() {
 }
 
 playset_cleanup_logs() {
-    rm -f "${PLAYSET_DEMO_DIR}"/*.log "${PLAYSET_DEMO_DIR}"/*.pid "${PLAYSET_DEMO_DIR}"/nohup.out
+    rm -f "${PLAYSET_RUN_DIR}"/*.log "${PLAYSET_RUN_DIR}"/*.pid "${PLAYSET_RUN_DIR}"/nohup.out
 }

--- a/playset/lib/topology.sh
+++ b/playset/lib/topology.sh
@@ -47,6 +47,7 @@ playset_apply_configs() {
 
 playset_up() {
     echo "bring up"
+    echo "runtime dir: ${PLAYSET_RUN_DIR}"
     playset_teardown
     echo "cleanup logs"
     playset_cleanup_logs

--- a/playset/lib/zebra-rs.sh
+++ b/playset/lib/zebra-rs.sh
@@ -28,7 +28,7 @@ playset_vtyctl_bin() {
 
 playset_pid_file() {
     local netns=$1
-    echo "${PLAYSET_DEMO_DIR}/${netns}.pid"
+    echo "${PLAYSET_RUN_DIR}/${netns}.pid"
 }
 
 playset_stop_zebra_daemon() {
@@ -55,7 +55,7 @@ playset_stop_zebra() {
 playset_start_zebra() {
     local netns=$1
     local log_file pid_file
-    log_file="${PLAYSET_DEMO_DIR}/${netns}.log"
+    log_file="${PLAYSET_RUN_DIR}/${netns}.log"
     pid_file="$(playset_pid_file "$netns")"
     run_in_netns "$netns" "$(playset_zebra_rs_bin)" \
         --daemon \


### PR DESCRIPTION
## Summary
- Ship the `playset/` lab topologies in the Debian package at `/usr/share/zebra-rs/playset`. nfpm has no exclude globs, so the packaging Makefile stages a clean copy under `packaging/out/playset/` via `rsync --filter=':- .gitignore'`, keeping runtime artifacts (`*.log`, `*.pid`) from local lab runs out of the package.
- Make the labs runnable from a read-only install location: runtime state (pid + log files) moves from the demo directory to `PLAYSET_RUN_DIR`, defaulting to `/tmp/zebra-rs-playset/<lab>/`. The run dir is created by the invoking user, so teardown can unlink the root-owned pid files without sudo (`down.sh` previously died with `rm: cannot remove '…/e1.pid': Permission denied` under `/usr/share`), and the packaged tree stays pristine.
- Add `packaging/scripts/prerm.sh` to stop the zebra-rs service on package removal. postrm runs after dpkg deletes the unit file, so removal used to leave an orphaned daemon running with a deleted `/usr/bin/zebra-rs`. Upgrades are unaffected (postinstall restarts the service).

## Testing
- Built the arm64 deb and installed it; verified all 18 labs plus `lib/` and `images/` land under `/usr/share/zebra-rs/playset` with no `*.log`/`*.pid`/`.gitignore` files and preserved script permissions.
- Ran `isis-srmpls` `up.sh`/`down.sh` end-to-end from `/usr/share` as an unprivileged user: 10 nodes up with configs applied, runtime state in `/tmp/zebra-rs-playset/isis-srmpls/`, zero writes under `/usr/share`, teardown exits 0 with all namespaces and daemons cleaned up.
- Verified `dpkg -r zebra-rs` now stops the service (previously the daemon survived removal), and install-over-same-version keeps the daemon running until postinstall restarts it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)