### PR TITLE
ci: install rsync in the resolute build container

### DIFF
--- a/.github/workflows/build-debs.yaml
+++ b/.github/workflows/build-debs.yaml
@@ -117,9 +117,11 @@ jobs:
 
     steps:
       - name: Install container base tools
+        # rsync: the packaging Makefile stages playset/ with it (hosted
+        # runners ship rsync; this minimal container does not).
         run: |
           apt-get update
-          apt-get install -y curl git ca-certificates sudo build-essential pkg-config xxd
+          apt-get install -y curl git ca-certificates sudo build-essential pkg-config xxd rsync
 
       - name: Checkout code
         uses: actions/checkout@v5


### PR DESCRIPTION
## Summary
The packaging Makefile (since #1874) stages `playset/` with `rsync --filter=':- .gitignore'` before nfpm runs. GitHub-hosted runners ship rsync, but the minimal `ubuntu:26.04` container used for the resolute legs does not — both `Build resolute-*` jobs failed on the v26.7.3 Stable Release run (29139220795) while the jammy/noble hosted legs were unaffected. Add `rsync` to the container base tools.

## Test plan
- CI on this PR exercises fmt/clippy/test (unaffected).
- The real proof is the next Stable Release / nightly run building the resolute legs green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)