### PR TITLE
yang: add system/interface ebpf knobs for managed cradle

### DIFF
--- a/zebra-rs/src/config/manager.rs
+++ b/zebra-rs/src/config/manager.rs
@@ -2887,6 +2887,39 @@ mod yang_load_tests {
         }
     }
 
+    /// The managed-cradle integration adds two `ebpf` containers: the
+    /// `system ebpf enabled <bool>` spawn/supervise switch and the
+    /// per-interface `interface <if-name> ebpf enabled <bool>` port
+    /// attachment (both dispatched by the cradle supervisor task at the
+    /// literal `/system/ebpf/enabled` and `/interface/ebpf/enabled`
+    /// paths). Pin both at the grammar level so a typo in the
+    /// container/leaf naming (which `load_mode` would not catch) fails
+    /// loudly.
+    #[test]
+    fn ebpf_knobs_are_settable() {
+        use crate::config::ExecCode;
+        use crate::config::parse::{State, parse};
+        use libyang::to_entry;
+
+        let mut yang = YangStore::new();
+        yang.add_path(concat!(env!("CARGO_MANIFEST_DIR"), "/yang"));
+        yang.read_with_resolve("configure")
+            .expect("configure mode loads");
+        yang.identity_resolve();
+        let module = yang
+            .find_module("configure")
+            .expect("configure module present");
+        let entry = to_entry(&yang, module);
+
+        for cmd in [
+            "set system ebpf enabled true",
+            "set interface enp0s6 ebpf enabled true",
+        ] {
+            let (code, _comps, _state) = parse(cmd, entry.clone(), None, State::new());
+            assert_eq!(code, ExecCode::Success, "must be a settable path: {cmd}");
+        }
+    }
+
     /// A new BGP-neighbor YANG knob must be a *settable* path, not just a
     /// loadable module. Naming it the same as a leaf already present via
     /// `uses ietf-bgp:bgp` makes the augment silently dropped (RFC 7950

--- a/zebra-rs/yang/config.yang
+++ b/zebra-rs/yang/config.yang
@@ -453,9 +453,35 @@ module config {
         // installs to (e.g. `unix:/run/cradle.sock` or `127.0.0.1:50151`).
         // Optional override for the default `unix:cradle/grpc`; it only takes
         // effect while the tee is enabled — on its own it does not enable it.
+        // Shared with `system ebpf`: a spawned engine serves its gRPC API on
+        // this same endpoint.
         leaf grpc-endpoint {
           ext:help "cradle eBPF data-plane gRPC endpoint";
           type string;
+        }
+      }
+      // The engine-lifecycle half of the eBPF data-plane integration:
+      // when enabled, zebra-rs spawns the cradle daemon as a managed,
+      // supervised child process (adopting an instance already listening
+      // on the endpoint instead of spawning a second one). This knob
+      // only manages the process — the FIB tee stays under
+      // `system cradle enabled`, and interfaces join the data plane via
+      // `interface <if-name> ebpf enabled` — so `system ebpf` alone
+      // yields a pure eBPF L2 switch with no routes teed.
+      container ebpf {
+        ext:help "eBPF data-plane engine (managed cradle process)";
+        leaf enabled {
+          ext:help "Spawn and supervise the cradle eBPF data-plane engine";
+          type boolean;
+          description
+            "When true, zebra-rs launches the cradle eBPF data plane as a
+             managed child process and restarts it on failure. The child
+             serves its gRPC API on `system cradle grpc-endpoint` if set,
+             otherwise on the default `unix:cradle/grpc` abstract socket;
+             a cradle instance already listening there is adopted rather
+             than duplicated. When false or unset no process is managed —
+             an externally-run cradle can still be teed to through
+             `system cradle enabled`.";
         }
       }
       container dhcp {
@@ -4166,6 +4192,25 @@ module config {
            observed value. The IPv6 minimum is 1280, so setting a smaller
            MTU on an interface with IPv6 enabled is rejected by the
            kernel and reported by `show interface`.";
+      }
+      // Data-plane port membership for the cradle/eBPF integration:
+      // attaches this interface to the eBPF forwarding plane (the XDP
+      // and TC programs) once an engine is reachable — spawned via
+      // `system ebpf enabled` or external via `system cradle`. The
+      // port's VRF binding follows this interface's `vrf` leaf.
+      container ebpf {
+        ext:help "eBPF data-plane attachment";
+        leaf enabled {
+          ext:help "Attach this interface to the eBPF data plane";
+          type boolean;
+          description
+            "When true, this interface is programmed as a cradle data-plane
+             port: the XDP and TC forwarding programs attach to it and it
+             participates in eBPF forwarding. When false or unset the
+             interface is detached. Inert unless a cradle engine is
+             managed (`system ebpf enabled`) or reachable
+             (`system cradle enabled`).";
+        }
       }
       container ipv4 {
         ext:help "IPv4 configuration";


### PR DESCRIPTION
## Summary

Phase 1 (YANG) of the managed-cradle sidecar plan: zebra-rs will spawn and supervise the cradle eBPF data plane, replacing the externally-launched daemon + `-c fwd.json` workflow. This PR adds the schema only; no handler consumes the paths yet (the cradle supervisor task lands next).

- `system ebpf { enabled }` — engine-lifecycle knob: spawn + supervise the cradle child process, adopting an instance already listening on the endpoint instead of spawning a second one. The FIB tee stays under `system cradle enabled` and the two compose: cradle-only = today's external tee, ebpf-only = pure eBPF L2 switch, both = fully managed dataplane. A spawned engine serves its gRPC API on `system cradle grpc-endpoint` (default `unix:cradle/grpc`).
- `interface <if-name> ebpf { enabled }` — data-plane port membership; will drive `SetPort`/`DelPort` over the tee, with the port's VRF binding following the interface's `vrf` leaf.
- `ebpf_knobs_are_settable` yang_load guard pins `set system ebpf enabled true` and `set interface enp0s6 ebpf enabled true` at the grammar level.

## Test plan

- `cargo test -p zebra-rs manager` — new guard test + all existing yang_load guards pass (74/74).
- `cargo test --workspace --exclude bdd` — green (1542 passed in zebra-rs, 0 failures workspace-wide).
- `cargo clippy --workspace --all-targets -- -D warnings` — clean; `cargo fmt --all --check` — clean.

Generated with [Claude Code](https://claude.com/claude-code)