### PR TITLE
rib: show ip route takes a positional address/prefix; drop the prefix keyword

### DIFF
--- a/bdd/tests/features/isis_srmpls.feature
+++ b/bdd/tests/features/isis_srmpls.feature
@@ -103,12 +103,12 @@ Feature: IS-IS SR-MPLS static-route recursive nexthop tracking with TI-LFA
   Scenario: Static route resolves recursively through the SR-MPLS underlay
     Given the test topology exists
     # s's IS-IS route to d's loopback carries d's node-SID label.
-    Then show command "show ip route prefix 10.0.0.8/32" in namespace "s" should eventually contain "[115/12] via 192.168.10.2, s-n1, label 16800"
+    Then show command "show ip route 10.0.0.8/32" in namespace "s" should eventually contain "[115/12] via 192.168.10.2, s-n1, label 16800"
     # The static 172.168.1.0/24 via 10.0.0.8 is not on-link: NHT
     # resolves the gateway through that IS-IS route and inherits its
     # transport label — rendered FRR-style as a recursive two-liner.
-    And show command "show ip route prefix 172.168.1.0/24" in namespace "s" should eventually contain "via 10.0.0.8 (recursive)"
-    And show command "show ip route prefix 172.168.1.0/24" in namespace "s" should contain "via 192.168.10.2, s-n1, label 16800"
+    And show command "show ip route 172.168.1.0/24" in namespace "s" should eventually contain "via 10.0.0.8 (recursive)"
+    And show command "show ip route 172.168.1.0/24" in namespace "s" should contain "via 192.168.10.2, s-n1, label 16800"
     # The kernel forwards the static prefix with the inherited label
     # push toward n1 — the proof the resolution reached the FIB.
     And kernel route "172.168.1.0/24" in namespace "s" should eventually contain "encap mpls"
@@ -129,8 +129,8 @@ Feature: IS-IS SR-MPLS static-route recursive nexthop tracking with TI-LFA
     Then show command "show isis route detail" in namespace "s" should contain "Backup path: TI-LFA, via 192.168.3.2"
     # d's loopback route: primary unchanged, repair standby at
     # metric+1 out s-n2.
-    And show command "show ip route prefix 10.0.0.8/32" in namespace "s" should contain "[115/12] via 192.168.10.2, s-n1, label 16800"
-    And show command "show ip route prefix 10.0.0.8/32" in namespace "s" should contain "[115/13] via 192.168.3.2, s-n2, label 16500"
+    And show command "show ip route 10.0.0.8/32" in namespace "s" should contain "[115/12] via 192.168.10.2, s-n1, label 16800"
+    And show command "show ip route 10.0.0.8/32" in namespace "s" should contain "[115/13] via 192.168.3.2, s-n2, label 16500"
     # Negative control: a standby repair must NOT move the static —
     # NHT resolves through the active (primary) member only.
     And kernel route "172.168.1.0/24" in namespace "s" should eventually contain "16800"
@@ -145,7 +145,7 @@ Feature: IS-IS SR-MPLS static-route recursive nexthop tracking with TI-LFA
     When I apply command "set router isis fast-reroute backup-as-primary" in namespace "s"
     And I wait 5 seconds
     # d's loopback now forwards over the repair label stack.
-    Then show command "show ip route prefix 10.0.0.8/32" in namespace "s" should eventually contain "[115/12] via 192.168.3.2, s-n2, label 16500"
+    Then show command "show ip route 10.0.0.8/32" in namespace "s" should eventually contain "[115/12] via 192.168.3.2, s-n2, label 16500"
     And kernel route "10.0.0.8" in namespace "s" should eventually contain "dev s-n2 proto isis metric 12"
     And kernel route "10.0.0.8" in namespace "s" should eventually contain "16500/"
 
@@ -158,8 +158,8 @@ Feature: IS-IS SR-MPLS static-route recursive nexthop tracking with TI-LFA
     # forwarding via the demoted path.
     Then kernel route "172.168.1.0/24" in namespace "s" should eventually contain "16500/"
     And kernel route "172.168.1.0/24" in namespace "s" should eventually contain "via 192.168.3.2"
-    And show command "show ip route prefix 172.168.1.0/24" in namespace "s" should contain "via 10.0.0.8 (recursive)"
-    And show command "show ip route prefix 172.168.1.0/24" in namespace "s" should contain "via 192.168.3.2, s-n2, label 16500"
+    And show command "show ip route 172.168.1.0/24" in namespace "s" should contain "via 10.0.0.8 (recursive)"
+    And show command "show ip route 172.168.1.0/24" in namespace "s" should contain "via 192.168.3.2, s-n2, label 16500"
     # End-to-end over the promoted repair: e1 -> s (push 16500/adj/adj)
     # -> n2 -> r1 -> n1 -> d -> e2. Dies if any hop mis-forwards.
     And ping from "e1" to "172.168.1.2" should succeed

--- a/book/src/ch-14-01-show-system-rib.md
+++ b/book/src/ch-14-01-show-system-rib.md
@@ -124,8 +124,9 @@ The full IPv4 (resp. IPv6) routing table.
 
 - `… detail` — IOS-XR-style routing-descriptor blocks: distance, metric,
   age, and per-nexthop detail (labels, weight, protection).
-- `… prefix <A.B.C.D/M>` (`<X::Y/M>` for v6) `[detail]` — just the one
-  prefix.
+- `… {<A.B.C.D>|<A.B.C.D/M>}` (`<X::X>`/`<X::Y/M>` for v6) `[detail]` —
+  just the one route: a bare address shows the longest match (the route
+  that contains it), a prefix matches exactly.
 - `… vrf [<name>] [detail]` — the table for one VRF, or every VRF when
   `<name>` is omitted.
 
@@ -138,7 +139,7 @@ Codes: K - kernel, C - connected, S - static, O - OSPF,
 O   *> 10.0.0.0/24 [110/100] via 10.1.1.1, eth0, 00:12:34
 C   *> 10.1.1.0/24 is directly connected, eth0, 00:05:43
 
-r1> show ip route prefix 10.0.0.0/24 detail
+r1> show ip route 10.0.0.0/24 detail
 Routing entry for 10.0.0.0/24
   Known via "ospf", distance 110, metric 100
   Last update 00:12:34 ago

--- a/book/src/ch-14-01-show-system-rib.md
+++ b/book/src/ch-14-01-show-system-rib.md
@@ -124,9 +124,9 @@ The full IPv4 (resp. IPv6) routing table.
 
 - `… detail` — IOS-XR-style routing-descriptor blocks: distance, metric,
   age, and per-nexthop detail (labels, weight, protection).
-- `… {<A.B.C.D>|<A.B.C.D/M>}` (`<X::X>`/`<X::Y/M>` for v6) `[detail]` —
-  just the one route: a bare address shows the longest match (the route
-  that contains it), a prefix matches exactly.
+- `… {<A.B.C.D>|<A.B.C.D/M>}` (`<X::X>`/`<X::Y/M>` for v6) — just the
+  one route: a bare address shows the longest match (the route that
+  contains it), a prefix matches exactly.
 - `… vrf [<name>] [detail]` — the table for one VRF, or every VRF when
   `<name>` is omitted.
 
@@ -139,7 +139,7 @@ Codes: K - kernel, C - connected, S - static, O - OSPF,
 O   *> 10.0.0.0/24 [110/100] via 10.1.1.1, eth0, 00:12:34
 C   *> 10.1.1.0/24 is directly connected, eth0, 00:05:43
 
-r1> show ip route 10.0.0.0/24 detail
+r1> show ip route detail
 Routing entry for 10.0.0.0/24
   Known via "ospf", distance 110, metric 100
   Last update 00:12:34 ago

--- a/book/src/ch-14-01-show-system-rib.md
+++ b/book/src/ch-14-01-show-system-rib.md
@@ -128,7 +128,8 @@ The full IPv4 (resp. IPv6) routing table.
   one route: a bare address shows the longest match (the route that
   contains it), a prefix matches exactly.
 - `… vrf [<name>] [detail]` — the table for one VRF, or every VRF when
-  `<name>` is omitted.
+  `<name>` is omitted. `vrf <name>` also takes the positional
+  address/prefix filter: `show ip route vrf <name> <A.B.C.D>`.
 
 ```
 r1> show ip route

--- a/docs/design/show-commands-json-output.md
+++ b/docs/design/show-commands-json-output.md
@@ -76,10 +76,12 @@ its non-VRF sibling** in the tables below.
 | `show ip route detail` | IPv4 RIB, IOS-XR detail blocks | ✅ |
 | `show ip route {<A.B.C.D>\|<A.B.C.D/M>}` | One IPv4 route (address = longest match) | ✅ |
 | `show ip route vrf [<name>] [detail]` | IPv4 RIB per VRF | ✅ |
+| `show ip route vrf <name> {<A.B.C.D>\|<A.B.C.D/M>}` | One IPv4 route in a VRF (address = longest match) | ✅ |
 | `show ipv6 route` | IPv6 routing table | ✅ |
 | `show ipv6 route detail` | IPv6 RIB, IOS-XR detail blocks | ✅ |
 | `show ipv6 route {<X::X>\|<X::Y/M>}` | One IPv6 route (address = longest match) | ✅ |
 | `show ipv6 route vrf [<name>] [detail]` | IPv6 RIB per VRF | ✅ |
+| `show ipv6 route vrf <name> {<X::X>\|<X::Y/M>}` | One IPv6 route in a VRF (address = longest match) | ✅ |
 | `show nexthop` | Nexthop groups | ✅ |
 | `show mpls ilm` | MPLS incoming-label map | ✅ |
 | `show l2 mac table` | Bridge MAC table (EVPN VNI-keyed) | ✅ |

--- a/docs/design/show-commands-json-output.md
+++ b/docs/design/show-commands-json-output.md
@@ -74,11 +74,11 @@ its non-VRF sibling** in the tables below.
 | `show interface [<name>] [detail]` | Interface state | ✅ |
 | `show ip route` | IPv4 routing table | ✅ |
 | `show ip route detail` | IPv4 RIB, IOS-XR detail blocks | ✅ |
-| `show ip route prefix <A.B.C.D/M> [detail]` | One IPv4 prefix | ✅ |
+| `show ip route {<A.B.C.D>\|<A.B.C.D/M>} [detail]` | One IPv4 route (address = longest match) | ✅ |
 | `show ip route vrf [<name>] [detail]` | IPv4 RIB per VRF | ✅ |
 | `show ipv6 route` | IPv6 routing table | ✅ |
 | `show ipv6 route detail` | IPv6 RIB, IOS-XR detail blocks | ✅ |
-| `show ipv6 route prefix <X::Y/M> [detail]` | One IPv6 prefix | ✅ |
+| `show ipv6 route {<X::X>\|<X::Y/M>} [detail]` | One IPv6 route (address = longest match) | ✅ |
 | `show ipv6 route vrf [<name>] [detail]` | IPv6 RIB per VRF | ✅ |
 | `show nexthop` | Nexthop groups | ✅ |
 | `show mpls ilm` | MPLS incoming-label map | ✅ |

--- a/docs/design/show-commands-json-output.md
+++ b/docs/design/show-commands-json-output.md
@@ -74,11 +74,11 @@ its non-VRF sibling** in the tables below.
 | `show interface [<name>] [detail]` | Interface state | ✅ |
 | `show ip route` | IPv4 routing table | ✅ |
 | `show ip route detail` | IPv4 RIB, IOS-XR detail blocks | ✅ |
-| `show ip route {<A.B.C.D>\|<A.B.C.D/M>} [detail]` | One IPv4 route (address = longest match) | ✅ |
+| `show ip route {<A.B.C.D>\|<A.B.C.D/M>}` | One IPv4 route (address = longest match) | ✅ |
 | `show ip route vrf [<name>] [detail]` | IPv4 RIB per VRF | ✅ |
 | `show ipv6 route` | IPv6 routing table | ✅ |
 | `show ipv6 route detail` | IPv6 RIB, IOS-XR detail blocks | ✅ |
-| `show ipv6 route {<X::X>\|<X::Y/M>} [detail]` | One IPv6 route (address = longest match) | ✅ |
+| `show ipv6 route {<X::X>\|<X::Y/M>}` | One IPv6 route (address = longest match) | ✅ |
 | `show ipv6 route vrf [<name>] [detail]` | IPv6 RIB per VRF | ✅ |
 | `show nexthop` | Nexthop groups | ✅ |
 | `show mpls ilm` | MPLS incoming-label map | ✅ |

--- a/zebra-rs/src/config/comps.rs
+++ b/zebra-rs/src/config/comps.rs
@@ -1,6 +1,6 @@
 use super::Config;
 use super::parse::State;
-use super::parse::{entry_is_key, ymatch_complete, ytype_from_typedef};
+use super::parse::{entry_is_key, is_positional, ymatch_complete, ytype_from_typedef};
 use super::vty::YangMatch;
 use libyang::{Entry, TypeNode, YangType};
 use std::collections::HashSet;
@@ -271,14 +271,18 @@ pub fn comps_add_all(
     let mut no_sort = false;
     match ymatch {
         YangMatch::Dir | YangMatch::DirMatched => {
+            // `ext:positional` children have no typeable keyword — their
+            // key's type hints surface via comps_default_child_key.
             for entry in entry.dir.borrow().iter() {
-                comps.push(centry(entry));
+                if !is_positional(entry) {
+                    comps.push(centry(entry));
+                }
             }
             comps_default_child_key(comps, entry);
         }
         YangMatch::KeyMatched => {
             for e in entry.dir.borrow().iter() {
-                if !entry_is_key(&e.name, &entry.key) {
+                if !entry_is_key(&e.name, &entry.key) && !is_positional(e) {
                     comps.push(centry(e));
                 }
             }

--- a/zebra-rs/src/config/parse.rs
+++ b/zebra-rs/src/config/parse.rs
@@ -434,6 +434,9 @@ fn entry_match_dir(entry: &Rc<Entry>, str: &str, m: &mut Match, state: &State) {
                 continue; // Skip inactive choice case
             }
         }
+        if is_positional(entry) {
+            continue;
+        }
         m.match_entry(entry, str);
     }
 }
@@ -469,10 +472,19 @@ pub fn entry_is_key(name: &String, keys: &[String]) -> bool {
 
 fn entry_match_key_matched(entry: &Rc<Entry>, str: &str, m: &mut Match) {
     for e in entry.dir.borrow().iter() {
-        if !entry_is_key(&e.name, &entry.key) {
+        if !entry_is_key(&e.name, &entry.key) && !is_positional(e) {
             m.match_entry(e, str);
         }
     }
+}
+
+/// A node tagged `ext:positional` is reachable only through its
+/// parent's `ext:default-child`: the keyword itself is neither matched
+/// against input nor offered in completion, so only the positional
+/// spelling exists (`show ip route A.B.C.D/M`, never `show ip route
+/// prefix A.B.C.D/M`).
+pub fn is_positional(entry: &Rc<Entry>) -> bool {
+    entry.extension.contains_key("ext:positional")
 }
 
 /// Resolve a container's `ext:default-child` to the child entry it
@@ -1583,6 +1595,88 @@ mod tests {
             let got: Vec<&str> = args.0.iter().map(|s| s.as_str()).collect();
             assert_eq!(&got, want_args, "args for `{cmd}`");
         }
+    }
+
+    /// `show ip route {<A.B.C.D>|<A.B.C.D/M>}` — the route filter is
+    /// typed positionally, mirroring `show bgp`: the `prefix` list is
+    /// `ext:positional`, reachable only via the route container's
+    /// `ext:default-child`. The old `show ip route prefix …` keyword
+    /// spelling is gone and the internal node name must not leak into
+    /// completion.
+    #[test]
+    fn show_ip_route_positional_prefix() {
+        use crate::config::path_from_command;
+        let entry = exec_entry();
+
+        let cases: Vec<(&str, &str, Vec<&str>)> = vec![
+            ("show ip route", "/show/ip/route", vec![]),
+            ("show ip route detail", "/show/ip/route/detail", vec![]),
+            (
+                "show ip route 10.0.0.1",
+                "/show/ip/route/prefix",
+                vec!["10.0.0.1"],
+            ),
+            (
+                "show ip route 10.0.0.0/24",
+                "/show/ip/route/prefix",
+                vec!["10.0.0.0/24"],
+            ),
+            (
+                "show ip route 10.0.0.1 detail",
+                "/show/ip/route/prefix/detail",
+                vec!["10.0.0.1"],
+            ),
+            (
+                "show ip route 10.0.0.0/24 detail",
+                "/show/ip/route/prefix/detail",
+                vec!["10.0.0.0/24"],
+            ),
+            ("show ip route vrf blue", "/show/ip/route/vrf", vec!["blue"]),
+            ("show ipv6 route", "/show/ipv6/route", vec![]),
+            (
+                "show ipv6 route 2001:db8::1",
+                "/show/ipv6/route/prefix",
+                vec!["2001:db8::1"],
+            ),
+            (
+                "show ipv6 route 2001:db8::/48",
+                "/show/ipv6/route/prefix",
+                vec!["2001:db8::/48"],
+            ),
+            (
+                "show ipv6 route 2001:db8::/48 detail",
+                "/show/ipv6/route/prefix/detail",
+                vec!["2001:db8::/48"],
+            ),
+        ];
+
+        for &(cmd, want_path, ref want_args) in &cases {
+            let (code, _comps, state) = parse(cmd, entry.clone(), None, State::new());
+            assert_eq!(code, ExecCode::Success, "parse `{cmd}`");
+            let (path, args) = path_from_command(&state.paths);
+            assert_eq!(path, want_path, "path for `{cmd}`");
+            let got: Vec<&str> = args.0.iter().map(|s| s.as_str()).collect();
+            assert_eq!(&got, want_args, "args for `{cmd}`");
+        }
+
+        // The keyword spelling was removed with the move to positional.
+        for cmd in [
+            "show ip route prefix 10.0.0.0/24",
+            "show ipv6 route prefix 2001:db8::/48",
+        ] {
+            let (code, _comps, _state) = parse(cmd, entry.clone(), None, State::new());
+            assert_ne!(code, ExecCode::Success, "`{cmd}` must not be a command");
+        }
+
+        // Completion advertises the value hints and the real keyword
+        // children, but never the hidden `prefix` node itself.
+        let (_code, comps, _state) = parse("show ip route ", entry, None, State::new());
+        let names: Vec<&str> = comps.iter().map(|c| c.name.as_str()).collect();
+        assert!(names.contains(&"<A.B.C.D>"), "comps: {names:?}");
+        assert!(names.contains(&"<A.B.C.D/M>"), "comps: {names:?}");
+        assert!(names.contains(&"detail"), "comps: {names:?}");
+        assert!(names.contains(&"vrf"), "comps: {names:?}");
+        assert!(!names.contains(&"prefix"), "comps: {names:?}");
     }
 
     /// After the manager strips the `vrf <name>` selector, the per-VRF

--- a/zebra-rs/src/config/parse.rs
+++ b/zebra-rs/src/config/parse.rs
@@ -1621,16 +1621,6 @@ mod tests {
                 "/show/ip/route/prefix",
                 vec!["10.0.0.0/24"],
             ),
-            (
-                "show ip route 10.0.0.1 detail",
-                "/show/ip/route/prefix/detail",
-                vec!["10.0.0.1"],
-            ),
-            (
-                "show ip route 10.0.0.0/24 detail",
-                "/show/ip/route/prefix/detail",
-                vec!["10.0.0.0/24"],
-            ),
             ("show ip route vrf blue", "/show/ip/route/vrf", vec!["blue"]),
             ("show ipv6 route", "/show/ipv6/route", vec![]),
             (
@@ -1641,11 +1631,6 @@ mod tests {
             (
                 "show ipv6 route 2001:db8::/48",
                 "/show/ipv6/route/prefix",
-                vec!["2001:db8::/48"],
-            ),
-            (
-                "show ipv6 route 2001:db8::/48 detail",
-                "/show/ipv6/route/prefix/detail",
                 vec!["2001:db8::/48"],
             ),
         ];
@@ -1659,10 +1644,14 @@ mod tests {
             assert_eq!(&got, want_args, "args for `{cmd}`");
         }
 
-        // The keyword spelling was removed with the move to positional.
+        // The keyword spelling was removed with the move to positional,
+        // and the single-route form carries no `detail` suffix (the
+        // whole-table `show ip route detail` keeps it).
         for cmd in [
             "show ip route prefix 10.0.0.0/24",
             "show ipv6 route prefix 2001:db8::/48",
+            "show ip route 10.0.0.0/24 detail",
+            "show ipv6 route 2001:db8::/48 detail",
         ] {
             let (code, _comps, _state) = parse(cmd, entry.clone(), None, State::new());
             assert_ne!(code, ExecCode::Success, "`{cmd}` must not be a command");

--- a/zebra-rs/src/config/parse.rs
+++ b/zebra-rs/src/config/parse.rs
@@ -1622,6 +1622,24 @@ mod tests {
                 vec!["10.0.0.0/24"],
             ),
             ("show ip route vrf blue", "/show/ip/route/vrf", vec!["blue"]),
+            // The `vrf` list carries its own positional filter (the
+            // matcher applies the default-child shortcut after a list
+            // key too), and its keyword children still win over it.
+            (
+                "show ip route vrf blue 10.0.0.1",
+                "/show/ip/route/vrf/prefix",
+                vec!["blue", "10.0.0.1"],
+            ),
+            (
+                "show ip route vrf blue 10.0.0.0/24",
+                "/show/ip/route/vrf/prefix",
+                vec!["blue", "10.0.0.0/24"],
+            ),
+            (
+                "show ip route vrf blue detail",
+                "/show/ip/route/vrf/detail",
+                vec!["blue"],
+            ),
             ("show ipv6 route", "/show/ipv6/route", vec![]),
             (
                 "show ipv6 route 2001:db8::1",
@@ -1632,6 +1650,16 @@ mod tests {
                 "show ipv6 route 2001:db8::/48",
                 "/show/ipv6/route/prefix",
                 vec!["2001:db8::/48"],
+            ),
+            (
+                "show ipv6 route vrf blue 2001:db8::1",
+                "/show/ipv6/route/vrf/prefix",
+                vec!["blue", "2001:db8::1"],
+            ),
+            (
+                "show ipv6 route vrf blue 2001:db8::/48",
+                "/show/ipv6/route/vrf/prefix",
+                vec!["blue", "2001:db8::/48"],
             ),
         ];
 
@@ -1652,6 +1680,8 @@ mod tests {
             "show ipv6 route prefix 2001:db8::/48",
             "show ip route 10.0.0.0/24 detail",
             "show ipv6 route 2001:db8::/48 detail",
+            "show ip route vrf blue prefix 10.0.0.0/24",
+            "show ip route vrf blue 10.0.0.0/24 detail",
         ] {
             let (code, _comps, _state) = parse(cmd, entry.clone(), None, State::new());
             assert_ne!(code, ExecCode::Success, "`{cmd}` must not be a command");

--- a/zebra-rs/src/rib/show.rs
+++ b/zebra-rs/src/rib/show.rs
@@ -1155,13 +1155,7 @@ pub fn rib_show_detail(rib: &Rib, args: Args, json: bool) -> String {
 /// longest match (the route that contains it); a prefix shows that
 /// exact entry. One-line layout.
 pub fn rib_show_prefix(rib: &Rib, mut args: Args, json: bool) -> String {
-    rib_show_one(rib, args.string(), json, false)
-}
-
-/// `show ip route {A.B.C.D | A.B.C.D/M} detail` — the same route
-/// selection in detail-block format.
-pub fn rib_show_prefix_detail(rib: &Rib, mut args: Args, json: bool) -> String {
-    rib_show_one(rib, args.string(), json, true)
+    rib_show_one(rib, args.string(), json)
 }
 
 /// Resolve the positional `show ip route` selector — a bare address
@@ -1202,7 +1196,7 @@ fn rib_lookup_one<'a>(
     }
 }
 
-fn rib_show_one(rib: &Rib, tok: Option<String>, json: bool, detail: bool) -> String {
+fn rib_show_one(rib: &Rib, tok: Option<String>, json: bool) -> String {
     let (prefix, entries) = match rib_lookup_one(rib, &tok, json) {
         Ok(found) => found,
         Err(out) => return out,
@@ -1219,15 +1213,9 @@ fn rib_show_one(rib: &Rib, tok: Option<String>, json: bool, detail: bool) -> Str
     }
 
     let mut buf = String::new();
-    if detail {
-        for entry in entries.iter() {
-            buf.push_str(&rib_entry_show_detail(rib, prefix, entry));
-        }
-    } else {
-        buf.push_str(SHOW_HEADER);
-        for entry in entries.iter() {
-            let _ = write!(buf, "{}", rib_entry_show(rib, prefix, entry, json).unwrap());
-        }
+    buf.push_str(SHOW_HEADER);
+    for entry in entries.iter() {
+        let _ = write!(buf, "{}", rib_entry_show(rib, prefix, entry, json).unwrap());
     }
     buf
 }
@@ -1437,13 +1425,7 @@ pub fn rib6_show_detail(rib: &Rib, args: Args, json: bool) -> String {
 /// [`rib_show_prefix`]: address does a longest-match lookup, prefix
 /// matches exactly. One-line layout.
 pub fn rib6_show_prefix(rib: &Rib, mut args: Args, json: bool) -> String {
-    rib6_show_one(rib, args.string(), json, false)
-}
-
-/// `show ipv6 route {X:X::X:X | X:X::X:X/M} detail` — the same route
-/// selection in detail-block format.
-pub fn rib6_show_prefix_detail(rib: &Rib, mut args: Args, json: bool) -> String {
-    rib6_show_one(rib, args.string(), json, true)
+    rib6_show_one(rib, args.string(), json)
 }
 
 /// V6 twin of [`rib_lookup_one`].
@@ -1481,7 +1463,7 @@ fn rib6_lookup_one<'a>(
     }
 }
 
-fn rib6_show_one(rib: &Rib, tok: Option<String>, json: bool, detail: bool) -> String {
+fn rib6_show_one(rib: &Rib, tok: Option<String>, json: bool) -> String {
     let (prefix, entries) = match rib6_lookup_one(rib, &tok, json) {
         Ok(found) => found,
         Err(out) => return out,
@@ -1498,19 +1480,13 @@ fn rib6_show_one(rib: &Rib, tok: Option<String>, json: bool, detail: bool) -> St
     }
 
     let mut buf = String::new();
-    if detail {
-        for entry in entries.iter() {
-            buf.push_str(&rib_entry_show_v6_detail(rib, prefix, entry));
-        }
-    } else {
-        buf.push_str(SHOW_HEADER);
-        for entry in entries.iter() {
-            let _ = write!(
-                buf,
-                "{}",
-                rib_entry_show_v6(rib, prefix, entry, json).unwrap()
-            );
-        }
+    buf.push_str(SHOW_HEADER);
+    for entry in entries.iter() {
+        let _ = write!(
+            buf,
+            "{}",
+            rib_entry_show_v6(rib, prefix, entry, json).unwrap()
+        );
     }
     buf
 }
@@ -1890,8 +1866,6 @@ impl Rib {
             .set(rib_show_detail)
             .path("/show/ip/route/prefix")
             .set(rib_show_prefix)
-            .path("/show/ip/route/prefix/detail")
-            .set(rib_show_prefix_detail)
             .path("/show/ip/route/vrf")
             .set(rib_show_vrf)
             .path("/show/ip/route/vrf/detail")
@@ -1902,8 +1876,6 @@ impl Rib {
             .set(rib6_show_detail)
             .path("/show/ipv6/route/prefix")
             .set(rib6_show_prefix)
-            .path("/show/ipv6/route/prefix/detail")
-            .set(rib6_show_prefix_detail)
             .path("/show/ipv6/route/vrf")
             .set(rib6_show_vrf)
             .path("/show/ipv6/route/vrf/detail")

--- a/zebra-rs/src/rib/show.rs
+++ b/zebra-rs/src/rib/show.rs
@@ -1,4 +1,5 @@
 use ipnet::{Ipv4Net, Ipv6Net};
+use prefix_trie::PrefixMap;
 use serde::Serialize;
 use serde_json::Value;
 
@@ -13,7 +14,7 @@ use crate::{
 
 use super::{
     Group, Rib, entry::RibEntry, inst::ShowCallback, link::link_show, nexthop_show,
-    types::RibSubType, types::RibType, vrf::Vrf,
+    types::RibSubType, types::RibType, vrf::Vrf, vrf::VrfRibTables,
 };
 use std::fmt::Write;
 use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
@@ -1160,10 +1161,10 @@ pub fn rib_show_prefix(rib: &Rib, mut args: Args, json: bool) -> String {
 
 /// Resolve the positional `show ip route` selector — a bare address
 /// does a longest-match lookup, a prefix matches exactly — to the
-/// entry it names. `Err` carries the already-formatted response for
-/// malformed input or a lookup miss.
+/// entry it names in `table`. `Err` carries the already-formatted
+/// response for malformed input or a lookup miss.
 fn rib_lookup_one<'a>(
-    rib: &'a Rib,
+    table: &'a PrefixMap<Ipv4Net, RibEntries>,
     tok: &Option<String>,
     json: bool,
 ) -> Result<(Ipv4Net, &'a RibEntries), String> {
@@ -1181,7 +1182,7 @@ fn rib_lookup_one<'a>(
         let Ok(prefix) = tok.parse::<Ipv4Net>() else {
             return Err(format!("% Malformed IPv4 prefix: {tok}\n"));
         };
-        match rib.table.get(&prefix) {
+        match table.get(&prefix) {
             Some(entries) => Ok((prefix, entries)),
             None => Err(miss(&prefix)),
         }
@@ -1189,20 +1190,16 @@ fn rib_lookup_one<'a>(
         let Ok(addr) = tok.parse::<Ipv4Addr>() else {
             return Err(format!("% Malformed IPv4 address: {tok}\n"));
         };
-        match rib.table.get_lpm(&addr.to_host_prefix()) {
+        match table.get_lpm(&addr.to_host_prefix()) {
             Some((prefix, entries)) => Ok((prefix, entries)),
             None => Err(miss(&addr)),
         }
     }
 }
 
-fn rib_show_one(rib: &Rib, tok: Option<String>, json: bool) -> String {
-    let (prefix, entries) = match rib_lookup_one(rib, &tok, json) {
-        Ok(found) => found,
-        Err(out) => return out,
-    };
-    let prefix = &prefix;
-
+/// Render one resolved route: the JSON routes array, or the one-line
+/// layout under the codes header.
+fn rib_render_one(rib: &Rib, prefix: &Ipv4Net, entries: &RibEntries, json: bool) -> String {
     if json {
         let routes: Vec<RouteEntry> = entries
             .iter()
@@ -1212,12 +1209,18 @@ fn rib_show_one(rib: &Rib, tok: Option<String>, json: bool) -> String {
             .unwrap_or_else(|e| format!("{{\"error\": \"Failed to serialize routes: {}\"}}", e));
     }
 
-    let mut buf = String::new();
-    buf.push_str(SHOW_HEADER);
+    let mut buf = String::from(SHOW_HEADER);
     for entry in entries.iter() {
         let _ = write!(buf, "{}", rib_entry_show(rib, prefix, entry, json).unwrap());
     }
     buf
+}
+
+fn rib_show_one(rib: &Rib, tok: Option<String>, json: bool) -> String {
+    match rib_lookup_one(&rib.table, &tok, json) {
+        Ok((prefix, entries)) => rib_render_one(rib, &prefix, entries, json),
+        Err(out) => out,
+    }
 }
 
 /// Resolve the VRFs a `... route vrf [NAME]` command targets: a single
@@ -1355,6 +1358,73 @@ fn rib6_vrf_render(rib: &Rib, name: Option<String>, json: bool, detail: bool) ->
     buf
 }
 
+/// Resolve the `vrf <name>` selector of a positional single-route
+/// show to the VRF and its RIB tables. `Err` carries the formatted
+/// response (`% No such VRF: …`); a VRF with no tables yet resolves to
+/// an empty default so the route lookup renders its own miss.
+fn vrf_route_target<'a>(
+    rib: &'a Rib,
+    name: &Option<String>,
+    json: bool,
+    empty: &'a VrfRibTables,
+) -> Result<(&'a Vrf, &'a VrfRibTables), String> {
+    if name.is_none() {
+        return Err("% Specify a VRF name\n".to_string());
+    }
+    let selected = vrf_targets(rib, name, json)?;
+    let Some(vrf) = selected.first() else {
+        return Err("% No VRFs configured\n".to_string());
+    };
+    let tables = rib.vrf_tables.get(&vrf.table_id).unwrap_or(empty);
+    Ok((vrf, tables))
+}
+
+/// `show ip route vrf NAME {A.B.C.D | A.B.C.D/M}` — the positional
+/// single-route filter scoped to one VRF: address = longest match,
+/// prefix = exact. One-line layout under the VRF banner.
+pub fn rib_show_vrf_prefix(rib: &Rib, mut args: Args, json: bool) -> String {
+    let name = args.string();
+    let tok = args.string();
+    let empty = VrfRibTables::new();
+    let (vrf, tables) = match vrf_route_target(rib, &name, json, &empty) {
+        Ok(found) => found,
+        Err(out) => return out,
+    };
+    match rib_lookup_one(&tables.table, &tok, json) {
+        Ok((prefix, entries)) => {
+            let mut buf = String::new();
+            if !json {
+                let _ = writeln!(buf, "VRF {} (table {}):", vrf.name, vrf.table_id);
+            }
+            buf.push_str(&rib_render_one(rib, &prefix, entries, json));
+            buf
+        }
+        Err(out) => out,
+    }
+}
+
+/// V6 twin of [`rib_show_vrf_prefix`].
+pub fn rib6_show_vrf_prefix(rib: &Rib, mut args: Args, json: bool) -> String {
+    let name = args.string();
+    let tok = args.string();
+    let empty = VrfRibTables::new();
+    let (vrf, tables) = match vrf_route_target(rib, &name, json, &empty) {
+        Ok(found) => found,
+        Err(out) => return out,
+    };
+    match rib6_lookup_one(&tables.table_v6, &tok, json) {
+        Ok((prefix, entries)) => {
+            let mut buf = String::new();
+            if !json {
+                let _ = writeln!(buf, "VRF {} (table {}):", vrf.name, vrf.table_id);
+            }
+            buf.push_str(&rib6_render_one(rib, &prefix, entries, json));
+            buf
+        }
+        Err(out) => out,
+    }
+}
+
 /// `show ip route vrf [NAME]` — one-line layout.
 pub fn rib_show_vrf(rib: &Rib, mut args: Args, json: bool) -> String {
     rib_vrf_render(rib, args.string(), json, false)
@@ -1430,7 +1500,7 @@ pub fn rib6_show_prefix(rib: &Rib, mut args: Args, json: bool) -> String {
 
 /// V6 twin of [`rib_lookup_one`].
 fn rib6_lookup_one<'a>(
-    rib: &'a Rib,
+    table: &'a PrefixMap<Ipv6Net, RibEntries>,
     tok: &Option<String>,
     json: bool,
 ) -> Result<(Ipv6Net, &'a RibEntries), String> {
@@ -1448,7 +1518,7 @@ fn rib6_lookup_one<'a>(
         let Ok(prefix) = tok.parse::<Ipv6Net>() else {
             return Err(format!("% Malformed IPv6 prefix: {tok}\n"));
         };
-        match rib.table_v6.get(&prefix) {
+        match table.get(&prefix) {
             Some(entries) => Ok((prefix, entries)),
             None => Err(miss(&prefix)),
         }
@@ -1456,20 +1526,15 @@ fn rib6_lookup_one<'a>(
         let Ok(addr) = tok.parse::<Ipv6Addr>() else {
             return Err(format!("% Malformed IPv6 address: {tok}\n"));
         };
-        match rib.table_v6.get_lpm(&addr.to_host_prefix()) {
+        match table.get_lpm(&addr.to_host_prefix()) {
             Some((prefix, entries)) => Ok((prefix, entries)),
             None => Err(miss(&addr)),
         }
     }
 }
 
-fn rib6_show_one(rib: &Rib, tok: Option<String>, json: bool) -> String {
-    let (prefix, entries) = match rib6_lookup_one(rib, &tok, json) {
-        Ok(found) => found,
-        Err(out) => return out,
-    };
-    let prefix = &prefix;
-
+/// V6 twin of [`rib_render_one`].
+fn rib6_render_one(rib: &Rib, prefix: &Ipv6Net, entries: &RibEntries, json: bool) -> String {
     if json {
         let routes: Vec<RouteEntry> = entries
             .iter()
@@ -1479,8 +1544,7 @@ fn rib6_show_one(rib: &Rib, tok: Option<String>, json: bool) -> String {
             .unwrap_or_else(|e| format!("{{\"error\": \"Failed to serialize routes: {}\"}}", e));
     }
 
-    let mut buf = String::new();
-    buf.push_str(SHOW_HEADER);
+    let mut buf = String::from(SHOW_HEADER);
     for entry in entries.iter() {
         let _ = write!(
             buf,
@@ -1489,6 +1553,13 @@ fn rib6_show_one(rib: &Rib, tok: Option<String>, json: bool) -> String {
         );
     }
     buf
+}
+
+fn rib6_show_one(rib: &Rib, tok: Option<String>, json: bool) -> String {
+    match rib6_lookup_one(&rib.table_v6, &tok, json) {
+        Ok((prefix, entries)) => rib6_render_one(rib, &prefix, entries, json),
+        Err(out) => out,
+    }
 }
 
 // JSON structures for MPLS ILM display
@@ -1870,6 +1941,8 @@ impl Rib {
             .set(rib_show_vrf)
             .path("/show/ip/route/vrf/detail")
             .set(rib_show_vrf_detail)
+            .path("/show/ip/route/vrf/prefix")
+            .set(rib_show_vrf_prefix)
             .path("/show/ipv6/route")
             .set(rib6_show)
             .path("/show/ipv6/route/detail")
@@ -1880,6 +1953,8 @@ impl Rib {
             .set(rib6_show_vrf)
             .path("/show/ipv6/route/vrf/detail")
             .set(rib6_show_vrf_detail)
+            .path("/show/ipv6/route/vrf/prefix")
+            .set(rib6_show_vrf_prefix)
             .path("/show/nexthop")
             .set(nexthop_show)
             .path("/show/mpls/ilm")

--- a/zebra-rs/src/rib/show.rs
+++ b/zebra-rs/src/rib/show.rs
@@ -5,8 +5,9 @@ use serde_json::Value;
 use crate::{
     config::{Args, Builder},
     rib::{
-        Label, Nexthop,
+        Label, Nexthop, RibEntries,
         nexthop::{NexthopList, NexthopMember, NexthopProtect, NexthopUni},
+        util::IpAddrExt,
     },
 };
 
@@ -15,7 +16,7 @@ use super::{
     types::RibSubType, types::RibType, vrf::Vrf,
 };
 use std::fmt::Write;
-use std::net::IpAddr;
+use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
 use std::time::Duration;
 
 // Two-char tag column used in `show ip route` lines. When the route has
@@ -1150,31 +1151,63 @@ pub fn rib_show_detail(rib: &Rib, args: Args, json: bool) -> String {
     buf
 }
 
-/// `show ip route prefix A.B.C.D/N` — single-prefix filter, one-line
-/// layout.
+/// `show ip route {A.B.C.D | A.B.C.D/M}` — an address shows the
+/// longest match (the route that contains it); a prefix shows that
+/// exact entry. One-line layout.
 pub fn rib_show_prefix(rib: &Rib, mut args: Args, json: bool) -> String {
-    let Some(prefix) = args.v4net() else {
-        return "% Invalid IPv4 prefix\n".to_string();
-    };
-    rib_show_one(rib, &prefix, json, false)
+    rib_show_one(rib, args.string(), json, false)
 }
 
-/// `show ip route prefix A.B.C.D/N detail` — single-prefix block.
+/// `show ip route {A.B.C.D | A.B.C.D/M} detail` — the same route
+/// selection in detail-block format.
 pub fn rib_show_prefix_detail(rib: &Rib, mut args: Args, json: bool) -> String {
-    let Some(prefix) = args.v4net() else {
-        return "% Invalid IPv4 prefix\n".to_string();
-    };
-    rib_show_one(rib, &prefix, json, true)
+    rib_show_one(rib, args.string(), json, true)
 }
 
-fn rib_show_one(rib: &Rib, prefix: &Ipv4Net, json: bool, detail: bool) -> String {
-    let Some(entries) = rib.table.get(prefix) else {
-        return if json {
+/// Resolve the positional `show ip route` selector — a bare address
+/// does a longest-match lookup, a prefix matches exactly — to the
+/// entry it names. `Err` carries the already-formatted response for
+/// malformed input or a lookup miss.
+fn rib_lookup_one<'a>(
+    rib: &'a Rib,
+    tok: &Option<String>,
+    json: bool,
+) -> Result<(Ipv4Net, &'a RibEntries), String> {
+    let miss = |what: &dyn std::fmt::Display| {
+        if json {
             "{\"routes\": []}\n".to_string()
         } else {
-            format!("% No route for {prefix}\n")
-        };
+            format!("% No route for {what}\n")
+        }
     };
+    let Some(tok) = tok else {
+        return Err("% Specify an IPv4 address or prefix\n".to_string());
+    };
+    if tok.contains('/') {
+        let Ok(prefix) = tok.parse::<Ipv4Net>() else {
+            return Err(format!("% Malformed IPv4 prefix: {tok}\n"));
+        };
+        match rib.table.get(&prefix) {
+            Some(entries) => Ok((prefix, entries)),
+            None => Err(miss(&prefix)),
+        }
+    } else {
+        let Ok(addr) = tok.parse::<Ipv4Addr>() else {
+            return Err(format!("% Malformed IPv4 address: {tok}\n"));
+        };
+        match rib.table.get_lpm(&addr.to_host_prefix()) {
+            Some((prefix, entries)) => Ok((prefix, entries)),
+            None => Err(miss(&addr)),
+        }
+    }
+}
+
+fn rib_show_one(rib: &Rib, tok: Option<String>, json: bool, detail: bool) -> String {
+    let (prefix, entries) = match rib_lookup_one(rib, &tok, json) {
+        Ok(found) => found,
+        Err(out) => return out,
+    };
+    let prefix = &prefix;
 
     if json {
         let routes: Vec<RouteEntry> = entries
@@ -1400,30 +1433,60 @@ pub fn rib6_show_detail(rib: &Rib, args: Args, json: bool) -> String {
     buf
 }
 
-/// `show ipv6 route prefix X::Y/N` — single-prefix, one-line layout.
+/// `show ipv6 route {X:X::X:X | X:X::X:X/M}` — the v6 twin of
+/// [`rib_show_prefix`]: address does a longest-match lookup, prefix
+/// matches exactly. One-line layout.
 pub fn rib6_show_prefix(rib: &Rib, mut args: Args, json: bool) -> String {
-    let Some(prefix) = args.v6net() else {
-        return "% Invalid IPv6 prefix\n".to_string();
-    };
-    rib6_show_one(rib, &prefix, json, false)
+    rib6_show_one(rib, args.string(), json, false)
 }
 
-/// `show ipv6 route prefix X::Y/N detail` — single-prefix block.
+/// `show ipv6 route {X:X::X:X | X:X::X:X/M} detail` — the same route
+/// selection in detail-block format.
 pub fn rib6_show_prefix_detail(rib: &Rib, mut args: Args, json: bool) -> String {
-    let Some(prefix) = args.v6net() else {
-        return "% Invalid IPv6 prefix\n".to_string();
-    };
-    rib6_show_one(rib, &prefix, json, true)
+    rib6_show_one(rib, args.string(), json, true)
 }
 
-fn rib6_show_one(rib: &Rib, prefix: &Ipv6Net, json: bool, detail: bool) -> String {
-    let Some(entries) = rib.table_v6.get(prefix) else {
-        return if json {
+/// V6 twin of [`rib_lookup_one`].
+fn rib6_lookup_one<'a>(
+    rib: &'a Rib,
+    tok: &Option<String>,
+    json: bool,
+) -> Result<(Ipv6Net, &'a RibEntries), String> {
+    let miss = |what: &dyn std::fmt::Display| {
+        if json {
             "{\"routes\": []}\n".to_string()
         } else {
-            format!("% No route for {prefix}\n")
-        };
+            format!("% No route for {what}\n")
+        }
     };
+    let Some(tok) = tok else {
+        return Err("% Specify an IPv6 address or prefix\n".to_string());
+    };
+    if tok.contains('/') {
+        let Ok(prefix) = tok.parse::<Ipv6Net>() else {
+            return Err(format!("% Malformed IPv6 prefix: {tok}\n"));
+        };
+        match rib.table_v6.get(&prefix) {
+            Some(entries) => Ok((prefix, entries)),
+            None => Err(miss(&prefix)),
+        }
+    } else {
+        let Ok(addr) = tok.parse::<Ipv6Addr>() else {
+            return Err(format!("% Malformed IPv6 address: {tok}\n"));
+        };
+        match rib.table_v6.get_lpm(&addr.to_host_prefix()) {
+            Some((prefix, entries)) => Ok((prefix, entries)),
+            None => Err(miss(&addr)),
+        }
+    }
+}
+
+fn rib6_show_one(rib: &Rib, tok: Option<String>, json: bool, detail: bool) -> String {
+    let (prefix, entries) = match rib6_lookup_one(rib, &tok, json) {
+        Ok(found) => found,
+        Err(out) => return out,
+    };
+    let prefix = &prefix;
 
     if json {
         let routes: Vec<RouteEntry> = entries

--- a/zebra-rs/yang/exec.yang
+++ b/zebra-rs/yang/exec.yang
@@ -540,20 +540,28 @@ module exec {
       container route {
         ext:help "IPv4 routing table";
         presence "Show IPv4 routes";
+        // A bare address or prefix typed straight after `route` lands
+        // in the positional-only `prefix` list below — the `show bgp
+        // A.B.C.D` UX. There is no keyword spelling: the old `show ip
+        // route prefix A.B.C.D/M` form was removed.
+        ext:default-child "prefix";
         leaf detail {
           ext:help "Show all routes in detail format (IOS-XR style)";
           type empty;
         }
         list prefix {
-          ext:help "Filter to a specific IPv4 prefix";
-          ext:presence "Show one IPv4 prefix";
+          ext:help "Filter to one route";
+          ext:positional "show ip route {<A.B.C.D>|<A.B.C.D/M>}";
           key value;
           leaf value {
-            ext:help "IPv4 prefix (A.B.C.D/M)";
-            type inet:ipv4-prefix;
+            ext:help "Address (longest match) or prefix (exact match)";
+            type union {
+              type inet:ipv4-address;
+              type inet:ipv4-prefix;
+            }
           }
           leaf detail {
-            ext:help "Show this prefix in detail format";
+            ext:help "Show this route in detail format";
             type empty;
           }
         }
@@ -859,20 +867,26 @@ module exec {
       container route {
         ext:help "IPv6 routing table";
         presence "Show IPv6 routes";
+        // Positional address/prefix filter — the v6 twin of `show ip
+        // route` above.
+        ext:default-child "prefix";
         leaf detail {
           ext:help "Show all routes in detail format (IOS-XR style)";
           type empty;
         }
         list prefix {
-          ext:help "Filter to a specific IPv6 prefix";
-          ext:presence "Show one IPv6 prefix";
+          ext:help "Filter to one route";
+          ext:positional "show ipv6 route {<X:X::X:X>|<X:X::X:X/M>}";
           key value;
           leaf value {
-            ext:help "IPv6 prefix (X:X::X:X/M)";
-            type inet:ipv6-prefix;
+            ext:help "Address (longest match) or prefix (exact match)";
+            type union {
+              type inet:ipv6-address;
+              type inet:ipv6-prefix;
+            }
           }
           leaf detail {
-            ext:help "Show this prefix in detail format";
+            ext:help "Show this route in detail format";
             type empty;
           }
         }

--- a/zebra-rs/yang/exec.yang
+++ b/zebra-rs/yang/exec.yang
@@ -564,6 +564,9 @@ module exec {
         list vrf {
           ext:help "IPv4 routing table for a VRF";
           ext:presence "Show every VRF's IPv4 routes";
+          // A bare address or prefix after the VRF name filters to one
+          // route — the same positional UX as `show ip route <value>`.
+          ext:default-child "prefix";
           key name;
           leaf name {
             ext:help "VRF name";
@@ -573,6 +576,18 @@ module exec {
           leaf detail {
             ext:help "Show this VRF's routes in detail format";
             type empty;
+          }
+          list prefix {
+            ext:help "Filter to one route";
+            ext:positional "show ip route vrf <name> {<A.B.C.D>|<A.B.C.D/M>}";
+            key value;
+            leaf value {
+              ext:help "Address (longest match) or prefix (exact match)";
+              type union {
+                type inet:ipv4-address;
+                type inet:ipv4-prefix;
+              }
+            }
           }
         }
       }
@@ -885,6 +900,9 @@ module exec {
         list vrf {
           ext:help "IPv6 routing table for a VRF";
           ext:presence "Show every VRF's IPv6 routes";
+          // Positional single-route filter — the v6 twin of the
+          // `show ip route vrf` list above.
+          ext:default-child "prefix";
           key name;
           leaf name {
             ext:help "VRF name";
@@ -894,6 +912,18 @@ module exec {
           leaf detail {
             ext:help "Show this VRF's routes in detail format";
             type empty;
+          }
+          list prefix {
+            ext:help "Filter to one route";
+            ext:positional "show ipv6 route vrf <name> {<X:X::X:X>|<X:X::X:X/M>}";
+            key value;
+            leaf value {
+              ext:help "Address (longest match) or prefix (exact match)";
+              type union {
+                type inet:ipv6-address;
+                type inet:ipv6-prefix;
+              }
+            }
           }
         }
       }

--- a/zebra-rs/yang/exec.yang
+++ b/zebra-rs/yang/exec.yang
@@ -560,10 +560,6 @@ module exec {
               type inet:ipv4-prefix;
             }
           }
-          leaf detail {
-            ext:help "Show this route in detail format";
-            type empty;
-          }
         }
         list vrf {
           ext:help "IPv4 routing table for a VRF";
@@ -884,10 +880,6 @@ module exec {
               type inet:ipv6-address;
               type inet:ipv6-prefix;
             }
-          }
-          leaf detail {
-            ext:help "Show this route in detail format";
-            type empty;
           }
         }
         list vrf {

--- a/zebra-rs/yang/extension.yang
+++ b/zebra-rs/yang/extension.yang
@@ -42,6 +42,17 @@ module extension {
     argument "default-child";
   }
 
+  extension positional {
+    description
+      "Marks a list as reachable only through its parent's
+       `ext:default-child`: the list's own keyword is neither matched
+       against input nor offered in completion, so the key value must be
+       typed positionally (e.g. `show ip route A.B.C.D/M` — there is no
+       `show ip route prefix …` spelling). The argument documents the
+       positional spelling.";
+    argument "positional";
+  }
+
   extension non-empty {
     description
       "Forbids key-only entries on this `list`: every entry must carry at


### PR DESCRIPTION
## Summary

`show ip route {<A.B.C.D>|<A.B.C.D/M>}` (and the `show ipv6 route` twin) now filters to one route the same way `show bgp {<A.B.C.D>|<A.B.C.D/M>}` does:

- a bare **address** does a longest-match lookup (the route that contains it),
- a **prefix** matches exactly,
- one-line layout; like `show bgp`, the single-route form carries no `detail` suffix (the whole-table `show ip route detail` and `… vrf <name> detail` forms are untouched),
- the same positional filter works inside a VRF: `show ip route vrf <name> {<A.B.C.D>|<A.B.C.D/M>}` (rendered under the VRF banner).

The old `show ip route prefix A.B.C.D/M [detail]` / `show ipv6 route prefix …` spelling is **removed**.

## Mechanism

`show bgp`'s positional value lands in the real `ipv4` keyword list via `ext:default-child`, but `show ip route` has no natural keyword for the filter — no other router CLI spells one. So this adds `ext:positional`: a list reachable **only** through its parent's `ext:default-child`, whose keyword is neither matched against input nor offered in completion. Completion for `show ip route ` advertises `<A.B.C.D>` / `<A.B.C.D/M>` (plus `detail`, `vrf`) and never the internal node name. The `vrf` lists carry their own `ext:default-child` positional list, mirroring `show bgp vrf <name> <addr>`.

Handler paths keep the internal node name (`/show/ip/route/prefix`, `/show/ip/route/vrf/prefix`); the handlers gain the address arm (LPM via the RIB's prefix trie) and BGP-style malformed-input messages. The single-route lookup/render helpers are shared between the default-VRF and per-VRF forms.

## Testing

- `show_ip_route_positional_prefix` parse() test pins the positional forms (v4+v6, default VRF + `vrf <name>`), pins the removed keyword spelling and the removed single-route `detail` suffix as Nomatch, and asserts the hidden node never leaks into completion.
- Live-verified against a throwaway daemon: address→LPM (`8.8.8.8` → default route, `10.211.55.99` → covering /24), exact prefix, miss (`% No route for …`), JSON, v6 forms, and the VRF dispatch path (`% No such VRF` end-to-end).
- BDD `isis_srmpls.feature` spellings swept (`show ip route prefix X` → `show ip route X`); docs/book updated.
- `cargo test --workspace --exclude bdd`, workspace clippy `-D warnings`, `cargo fmt --check` all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)