### PR TITLE
cradle: supervise the eBPF engine under system ebpf enabled

### DIFF
--- a/proto/cradle.proto
+++ b/proto/cradle.proto
@@ -23,6 +23,17 @@ message L2Domain {
   repeated string members = 2;  // interface names flooded within the domain
 }
 
+message PortDel {
+  string name = 1;  // interface name (matched against the attach-time name
+                    // when the device is already gone)
+}
+
+message FdbFlush {
+  // Both filters optional and ANDed; no filter = every learned entry.
+  string port = 1;  // only entries learned on this port (empty = any)
+  uint32 vlan = 2;  // only entries in this bridge domain (0 = any)
+}
+
 message Nexthop {
   uint32 id = 1;
   string gateway = 2;     // empty => on-link / connected
@@ -288,7 +299,15 @@ message GtpPdrDel {
 
 service Cradle {
   rpc SetPort(Port) returns (Empty);
+  // Inverse of SetPort: detach the datapath programs, drop the PORTS entry
+  // and the port's derived routes, and flush the MACs learned on it. The
+  // caller updates any L2 domain membership itself (SetL2Domain replaces
+  // the full member list).
+  rpc DelPort(PortDel) returns (Empty);
   rpc SetL2Domain(L2Domain) returns (Empty);
+  // Flush locally-learned FDB entries (never control-plane-installed remote
+  // entries). WatchFdb subscribers observe the removals as age events.
+  rpc FlushFdb(FdbFlush) returns (Empty);
   rpc SetNexthop(Nexthop) returns (Empty);
   rpc SetNexthopGroup(NexthopGroup) returns (Empty);
   rpc AddRoute4(Route4) returns (Empty);

--- a/zebra-rs/src/config/cradle.rs
+++ b/zebra-rs/src/config/cradle.rs
@@ -1,0 +1,34 @@
+use super::ConfigManager;
+
+/// Spawn the cradle engine-supervisor task. Triggered by [`commit_config`]
+/// on the first config line under `system ebpf` or `system cradle`, so the
+/// task sees every relevant leaf of that same commit — including a
+/// `system cradle grpc-endpoint` committed before (or without) the
+/// `system ebpf enabled` switch itself.
+///
+/// Mirrors `spawn_nd`: hosts that never touch either subtree don't run the
+/// task. The task is idle until `system ebpf enabled true` commits; the FIB
+/// tee (`system cradle enabled`) stays with the RIB task and needs no
+/// spawn here.
+///
+/// [`commit_config`]: crate::config::ConfigManager::commit_config
+pub fn spawn_cradle(config: &ConfigManager) {
+    #[cfg(target_os = "linux")]
+    {
+        // Idempotent — commit_config seeds its `cradle` flag from
+        // `protocol_tasks`, and re-spawning would drop the live supervisor
+        // (killing a managed engine with it).
+        if config.protocol_tasks.borrow().contains_key("cradle") {
+            return;
+        }
+        let cradle = crate::cradle::Cradle::new();
+        config.subscribe("cradle", cradle.cm.tx.clone());
+        let task = crate::cradle::serve(cradle);
+        config
+            .protocol_tasks
+            .borrow_mut()
+            .insert("cradle".to_string(), task);
+    }
+    #[cfg(not(target_os = "linux"))]
+    let _ = config;
+}

--- a/zebra-rs/src/config/manager.rs
+++ b/zebra-rs/src/config/manager.rs
@@ -6,6 +6,7 @@ use super::bgp::{despawn_bgp, spawn_bgp};
 use super::commands::Mode;
 use super::commands::{configure_mode_create, exec_mode_create};
 use super::configs::{carbon_copy, delete, set};
+use super::cradle::spawn_cradle;
 use super::files::load_config_file;
 use super::isis::{despawn_isis, spawn_isis};
 use super::json::json_read;
@@ -475,6 +476,7 @@ impl ConfigManager {
         let mut bfd = false;
         let mut stamp = false;
         let mut nd = false;
+        let mut cradle = false;
         for (proto, tx) in self.cm_clients.borrow().iter() {
             tx.send(ConfigRequest::new(Vec::new(), ConfigOp::CommitStart))
                 .unwrap();
@@ -495,6 +497,9 @@ impl ConfigManager {
             }
             if proto == "nd" {
                 nd = true;
+            }
+            if proto == "cradle" {
+                cradle = true;
             }
         }
         // Same by-value capture problem for the IS-IS→BGP BGP-LS producer
@@ -623,6 +628,17 @@ impl ConfigManager {
             if !nd && op == ConfigOp::Set && line.contains("ipv6 router-advertisements") {
                 nd = true;
                 spawn_nd(self);
+            }
+            // The cradle engine supervisor consumes `system ebpf` (its own
+            // knob) and `system cradle grpc-endpoint` (shared with the FIB
+            // tee, which stays in the RIB task) — spawn on the first line
+            // under either subtree so it sees this commit's leaves.
+            if !cradle
+                && op == ConfigOp::Set
+                && (line.starts_with("system ebpf") || line.starts_with("system cradle"))
+            {
+                cradle = true;
+                spawn_cradle(self);
             }
             // Handle logging configuration changes
             if op == ConfigOp::Set && line.starts_with("logging output") {

--- a/zebra-rs/src/config/mod.rs
+++ b/zebra-rs/src/config/mod.rs
@@ -39,6 +39,7 @@ pub use api::{ConfigChannel, ConfigOp, ConfigRequest, DisplayRequest, Message, S
 mod bfd;
 mod bgp;
 mod commands;
+mod cradle;
 mod files;
 mod ip;
 mod isis;

--- a/zebra-rs/src/cradle/inst.rs
+++ b/zebra-rs/src/cradle/inst.rs
@@ -1,0 +1,119 @@
+//! The cradle supervisor task: consumes `/system/ebpf/*` (its own knob) and
+//! `/system/cradle/grpc-endpoint` (shared with the tee) from the config
+//! broadcast, and reconciles a running [`supervisor`] loop against the
+//! committed state at each `CommitEnd`.
+
+use tokio::sync::watch;
+use tracing::info;
+
+use crate::config::{ConfigChannel, ConfigOp, ConfigRequest, path_from_command};
+use crate::context::Task;
+
+use super::supervisor;
+
+/// The tee's default endpoint (`fib/cradle.rs` / `rib`), which is also
+/// cradle's own `--grpc` default: a Linux abstract socket, per-netns.
+const DEFAULT_ENDPOINT: &str = "unix:cradle/grpc";
+
+/// A running supervisor loop for one desired endpoint.
+struct Engine {
+    endpoint: String,
+    /// Flipping this to `true` asks the loop to stop: it SIGTERMs a child
+    /// it spawned (never an adopted instance) and exits.
+    shutdown: watch::Sender<bool>,
+    task: Task<()>,
+}
+
+/// Top-level supervisor instance, registered like the other modules
+/// (`spawn_cradle` in `config/cradle.rs`).
+pub struct Cradle {
+    /// Config-manager subscription endpoints; drained by [`Self::event_loop`].
+    pub cm: ConfigChannel,
+    /// Staged `system ebpf enabled` (applied at `CommitEnd`).
+    ebpf_enabled: bool,
+    /// Staged `system cradle grpc-endpoint` override.
+    grpc_endpoint: Option<String>,
+    engine: Option<Engine>,
+}
+
+impl Cradle {
+    pub fn new() -> Self {
+        Self {
+            cm: ConfigChannel::new(),
+            ebpf_enabled: false,
+            grpc_endpoint: None,
+            engine: None,
+        }
+    }
+
+    pub async fn event_loop(&mut self) {
+        while let Some(msg) = self.cm.rx.recv().await {
+            self.process_cm_msg(msg);
+        }
+    }
+
+    fn process_cm_msg(&mut self, msg: ConfigRequest) {
+        match msg.op {
+            ConfigOp::Set | ConfigOp::Delete => {
+                let (path, mut args) = path_from_command(&msg.paths);
+                match path.as_str() {
+                    "/system/ebpf/enabled" => {
+                        self.ebpf_enabled = msg.op.is_set() && args.boolean().unwrap_or(false);
+                    }
+                    "/system/cradle/grpc-endpoint" => {
+                        self.grpc_endpoint = if msg.op.is_set() { args.string() } else { None };
+                    }
+                    _ => {}
+                }
+            }
+            ConfigOp::CommitEnd => self.reconcile(),
+            _ => {}
+        }
+    }
+
+    /// Desired engine endpoint: `None` when `system ebpf` is off, else the
+    /// `system cradle grpc-endpoint` override or the shared default.
+    fn desired(&self) -> Option<String> {
+        self.ebpf_enabled.then(|| {
+            self.grpc_endpoint
+                .clone()
+                .unwrap_or_else(|| DEFAULT_ENDPOINT.to_string())
+        })
+    }
+
+    /// Converge the running supervisor loop on the committed state. An
+    /// endpoint change restarts the loop (the engine must re-listen there);
+    /// disabling stops it gracefully.
+    fn reconcile(&mut self) {
+        let desired = self.desired();
+        if self.engine.as_ref().map(|e| e.endpoint.as_str()) == desired.as_deref() {
+            return;
+        }
+        if let Some(engine) = self.engine.take() {
+            info!("cradle: stopping engine supervisor for {}", engine.endpoint);
+            let _ = engine.shutdown.send(true);
+            // Let the loop run its graceful SIGTERM path instead of
+            // aborting it (Task aborts on drop).
+            engine.task.detach();
+        }
+        if let Some(endpoint) = desired {
+            info!("cradle: starting engine supervisor for {endpoint}");
+            let (shutdown, shutdown_rx) = watch::channel(false);
+            let ep = endpoint.clone();
+            let task = Task::spawn(async move {
+                supervisor::run(ep, shutdown_rx).await;
+            });
+            self.engine = Some(Engine {
+                endpoint,
+                shutdown,
+                task,
+            });
+        }
+    }
+}
+
+pub fn serve(mut cradle: Cradle) -> Task<()> {
+    Task::spawn(async move {
+        cradle.event_loop().await;
+    })
+}

--- a/zebra-rs/src/cradle/mod.rs
+++ b/zebra-rs/src/cradle/mod.rs
@@ -1,0 +1,22 @@
+//! Supervisor for the **cradle** eBPF data-plane engine.
+//!
+//! `system ebpf enabled true` makes zebra-rs run the cradle daemon as a
+//! managed child process: spawn it, restart it with backoff when it dies,
+//! and stop it (SIGTERM, SIGKILL fallback) when the knob is deleted or the
+//! daemon exits (`kill_on_drop` + `PR_SET_PDEATHSIG` cover crashes). An
+//! instance already listening on the endpoint is **adopted** — monitored,
+//! never killed — so externally-started engines keep working; if an adopted
+//! engine dies, the supervisor spawns its own.
+//!
+//! This knob only manages the *process*. The FIB tee stays under
+//! `system cradle enabled` (handled by the RIB task — see
+//! `fib/cradle.rs`), and both sides share the `system cradle grpc-endpoint`
+//! leaf: the child serves its gRPC API on the same endpoint the tee dials
+//! (default `unix:cradle/grpc`, a per-netns Linux abstract socket). The
+//! forward tee reconnects lazily and the `WatchFdb` subscriber retries with
+//! backoff, so a supervised restart heals without extra wiring here.
+
+pub mod inst;
+pub mod supervisor;
+
+pub use inst::{Cradle, serve};

--- a/zebra-rs/src/cradle/supervisor.rs
+++ b/zebra-rs/src/cradle/supervisor.rs
@@ -1,0 +1,164 @@
+//! Child-process lifecycle for the managed cradle engine: adopt-or-spawn,
+//! restart with backoff, graceful stop, and log forwarding.
+
+use std::path::PathBuf;
+use std::process::Stdio;
+use std::time::Duration;
+
+use tokio::io::{AsyncBufReadExt, BufReader};
+use tokio::process::{Child, Command};
+use tokio::sync::watch;
+use tokio::time::Instant;
+use tracing::{info, warn};
+
+/// Binary resolution override (mirrors `ZEBRA_XDP_BFD_ECHO_BIN`).
+const BIN_ENV: &str = "ZEBRA_CRADLE_BIN";
+/// Liveness-probe cadence for an adopted (externally-started) engine.
+const PROBE_INTERVAL: Duration = Duration::from_secs(5);
+/// Respawn backoff bounds; reset after a run this long counts as healthy.
+const BACKOFF_MIN: Duration = Duration::from_secs(1);
+const BACKOFF_MAX: Duration = Duration::from_secs(30);
+const HEALTHY_RESET: Duration = Duration::from_secs(60);
+/// Grace period between SIGTERM and SIGKILL on stop.
+const STOP_GRACE: Duration = Duration::from_secs(5);
+
+/// Resolve the cradle binary: `$ZEBRA_CRADLE_BIN`, else the dev install
+/// (`~/.zebra/bin/cradle`), else the packaged location (`/usr/bin/cradle`,
+/// where the cradle-rs deb installs it).
+fn resolve_bin() -> PathBuf {
+    if let Some(p) = std::env::var_os(BIN_ENV) {
+        return PathBuf::from(p);
+    }
+    if let Some(home) = std::env::var_os("HOME") {
+        let dev = PathBuf::from(home).join(".zebra/bin/cradle");
+        if dev.exists() {
+            return dev;
+        }
+    }
+    PathBuf::from("/usr/bin/cradle")
+}
+
+/// Is a cradle gRPC server answering on `endpoint`?
+async fn probe(endpoint: &str) -> bool {
+    crate::fib::cradle::probe_endpoint(endpoint).await
+}
+
+/// Spawn `cradle serve --grpc <endpoint>` with its lifetime bound to ours:
+/// `kill_on_drop` (SIGKILL if the handle is dropped) plus
+/// `PR_SET_PDEATHSIG=SIGTERM` (the kernel signals the child even if zebra-rs
+/// is SIGKILLed), so no root engine process can leak past the daemon.
+/// stdout/stderr are piped into zebra-rs tracing under the `cradle` target.
+fn spawn_child(bin: &PathBuf, endpoint: &str) -> std::io::Result<Child> {
+    let mut cmd = Command::new(bin);
+    cmd.args(["serve", "--grpc", endpoint])
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .kill_on_drop(true);
+    unsafe {
+        cmd.pre_exec(|| {
+            libc::prctl(libc::PR_SET_PDEATHSIG, libc::SIGTERM);
+            Ok(())
+        });
+    }
+    let mut child = cmd.spawn()?;
+    if let Some(out) = child.stdout.take() {
+        tokio::spawn(async move {
+            let mut lines = BufReader::new(out).lines();
+            while let Ok(Some(line)) = lines.next_line().await {
+                info!(target: "cradle", "{line}");
+            }
+        });
+    }
+    if let Some(err) = child.stderr.take() {
+        tokio::spawn(async move {
+            let mut lines = BufReader::new(err).lines();
+            while let Ok(Some(line)) = lines.next_line().await {
+                warn!(target: "cradle", "{line}");
+            }
+        });
+    }
+    Ok(child)
+}
+
+/// SIGTERM the child (cradle handles it and detaches cleanly), escalate to
+/// SIGKILL after [`STOP_GRACE`], and reap it.
+async fn graceful_stop(mut child: Child) {
+    if let Some(pid) = child.id() {
+        unsafe {
+            libc::kill(pid as libc::pid_t, libc::SIGTERM);
+        }
+        if tokio::time::timeout(STOP_GRACE, child.wait()).await.is_ok() {
+            return;
+        }
+        warn!("cradle: engine ignored SIGTERM for {STOP_GRACE:?}; killing");
+    }
+    let _ = child.kill().await;
+}
+
+/// The supervisor loop for one endpoint. Adopt-or-spawn, then hold: an
+/// adopted engine is probed for liveness (and never killed — it isn't
+/// ours); a spawned child is waited on and respawned with backoff. Exits
+/// when `shutdown` flips, stopping only a child we spawned.
+pub(crate) async fn run(endpoint: String, mut shutdown: watch::Receiver<bool>) {
+    let mut backoff = BACKOFF_MIN;
+    loop {
+        if *shutdown.borrow() {
+            return;
+        }
+        // Adopt an engine already listening there (an operator- or
+        // harness-started cradle; spawning a second one would just fail to
+        // bind the endpoint). If it dies later, fall through and spawn.
+        if probe(&endpoint).await {
+            info!("cradle: adopting already-running engine at {endpoint}");
+            loop {
+                tokio::select! {
+                    _ = shutdown.changed() => return,
+                    _ = tokio::time::sleep(PROBE_INTERVAL) => {
+                        if !probe(&endpoint).await {
+                            warn!("cradle: adopted engine at {endpoint} stopped answering");
+                            break;
+                        }
+                    }
+                }
+            }
+            backoff = BACKOFF_MIN;
+        }
+        let bin = resolve_bin();
+        let started = Instant::now();
+        match spawn_child(&bin, &endpoint) {
+            Ok(mut child) => {
+                info!(
+                    "cradle: spawned engine {} (pid {:?}) serving {endpoint}",
+                    bin.display(),
+                    child.id()
+                );
+                tokio::select! {
+                    _ = shutdown.changed() => {
+                        graceful_stop(child).await;
+                        info!("cradle: engine stopped (system ebpf disabled)");
+                        return;
+                    }
+                    status = child.wait() => {
+                        warn!("cradle: engine exited ({status:?}); respawning in {backoff:?}");
+                    }
+                }
+                if started.elapsed() >= HEALTHY_RESET {
+                    backoff = BACKOFF_MIN;
+                }
+            }
+            Err(e) => {
+                warn!(
+                    "cradle: spawning {} failed: {e}; retrying in {backoff:?} \
+                     (set {BIN_ENV} or install cradle)",
+                    bin.display()
+                );
+            }
+        }
+        tokio::select! {
+            _ = shutdown.changed() => return,
+            _ = tokio::time::sleep(backoff) => {}
+        }
+        backoff = (backoff * 2).min(BACKOFF_MAX);
+    }
+}

--- a/zebra-rs/src/fib/cradle.rs
+++ b/zebra-rs/src/fib/cradle.rs
@@ -167,6 +167,21 @@ async fn connect_abstract_cradle(name: &str) -> anyhow::Result<CradleClient<Chan
     Ok(CradleClient::new(channel))
 }
 
+/// Probe whether a cradle gRPC server answers at `endpoint` (fresh connect +
+/// `GetStats`, 2 s budget). Used by the engine supervisor (`crate::cradle`)
+/// for the adopt-if-running check and adopted-instance liveness.
+pub(crate) async fn probe_endpoint(endpoint: &str) -> bool {
+    let attempt = async {
+        let mut client = connect_cradle(endpoint).await?;
+        client.get_stats(pb::StatsRequest::default()).await?;
+        anyhow::Ok(())
+    };
+    matches!(
+        tokio::time::timeout(std::time::Duration::from_secs(2), attempt).await,
+        Ok(Ok(()))
+    )
+}
+
 impl CradleFib {
     /// Build a tee to the cradle gRPC endpoint `ep`. `unix:/path` (filesystem
     /// UDS), `unix:NAME` (Linux abstract socket, e.g. the default

--- a/zebra-rs/src/main.rs
+++ b/zebra-rs/src/main.rs
@@ -17,6 +17,10 @@ mod bgp;
 mod config;
 mod context;
 use config::{Cli, ConfigManager};
+// The cradle eBPF-engine supervisor rides on the Linux-only gRPC tee
+// (`fib::cradle`) and Linux process semantics (PR_SET_PDEATHSIG).
+#[cfg(target_os = "linux")]
+mod cradle;
 mod fib;
 mod flex_algo;
 mod fmt;


### PR DESCRIPTION
## Summary

Phase 1a of the managed-cradle plan (follows #1879's YANG knobs and cradle-rs#106's DelPort/FlushFdb): `system ebpf enabled true` now makes zebra-rs run the cradle eBPF data-plane daemon as a **managed child process** — spawn, restart with backoff, graceful stop — instead of requiring an operator-started engine.

- **`src/cradle/`** — a supervisor task registered like the other modules, spawned by `commit_config` on the first `system ebpf` *or* `system cradle` line (so a pre-committed `grpc-endpoint` is seen). It stages `/system/ebpf/enabled` + `/system/cradle/grpc-endpoint` and reconciles at `CommitEnd`; disable stops via watch-channel shutdown + `Task::detach` so the graceful SIGTERM path runs instead of an abort.
- **Supervisor loop**: adopts an engine already answering on the endpoint (GetStats probe; never kills what it didn't spawn, takes over if it dies), else spawns `cradle serve --grpc <endpoint>` — binary resolved `$ZEBRA_CRADLE_BIN` → `~/.zebra/bin/cradle` → `/usr/bin/cradle` — with `kill_on_drop` + `PR_SET_PDEATHSIG=SIGTERM` (no root engine can outlive the daemon, even on SIGKILL), stdout/stderr piped into zebra tracing under the `cradle` target, exponential respawn backoff (1s→30s, reset after a healthy 60s).
- **FIB tee untouched**: `system cradle enabled` stays with the RIB task; its lazy tonic reconnect + WatchFdb backoff already self-heal across supervised engine restarts.
- **`proto/cradle.proto`**: sync `DelPort`/`FlushFdb` from cradle-rs#106 (consumed by the upcoming `interface <name> ebpf enabled` port reconcile).

## Test plan

- `cargo fmt --all --check`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo test --workspace --exclude bdd` — all green.
- Live netns verification (debug zebra-rs + real cradle debug binary), five scenarios all passing:
  1. startup config `system ebpf enabled true` → engine spawned, cradle logs visible in zebra tracing;
  2. `kill -9` engine → respawned after the 1s backoff;
  3. `vtyctl apply -c "delete system ebpf enabled true"` → graceful SIGTERM stop, zero processes left; re-enable respawns;
  4. `kill -9` zebra-rs → PDEATHSIG takes the engine down (no leaked root daemon);
  5. a manually-started cradle is **adopted** (not duplicated); killing it triggers takeover with a supervisor-spawned replacement.

Generated with [Claude Code](https://claude.com/claude-code)