### PR TITLE
cradle: reconcile engine ports from interface ebpf enabled

### DIFF
--- a/zebra-rs/src/config/cradle.rs
+++ b/zebra-rs/src/config/cradle.rs
@@ -1,15 +1,17 @@
 use super::ConfigManager;
 
 /// Spawn the cradle engine-supervisor task. Triggered by [`commit_config`]
-/// on the first config line under `system ebpf` or `system cradle`, so the
-/// task sees every relevant leaf of that same commit — including a
-/// `system cradle grpc-endpoint` committed before (or without) the
-/// `system ebpf enabled` switch itself.
+/// on the first config line under `system ebpf`, `system cradle`, or an
+/// `interface … ebpf` leaf, so the task sees every relevant leaf of that
+/// same commit — including a `system cradle grpc-endpoint` or a port
+/// membership committed before (or without) the `system ebpf enabled`
+/// switch itself.
 ///
-/// Mirrors `spawn_nd`: hosts that never touch either subtree don't run the
-/// task. The task is idle until `system ebpf enabled true` commits; the FIB
-/// tee (`system cradle enabled`) stays with the RIB task and needs no
-/// spawn here.
+/// Mirrors `spawn_nd`: hosts that never touch these subtrees don't run the
+/// task. The FIB tee (`system cradle enabled`) stays with the RIB task and
+/// needs no spawn here; this task manages the engine process and its port
+/// set (default-VRF links — the RIB subscription is bound to the default
+/// VRF, matching the `SetPort` vrf 0 scope).
 ///
 /// [`commit_config`]: crate::config::ConfigManager::commit_config
 pub fn spawn_cradle(config: &ConfigManager) {
@@ -21,7 +23,8 @@ pub fn spawn_cradle(config: &ConfigManager) {
         if config.protocol_tasks.borrow().contains_key("cradle") {
             return;
         }
-        let cradle = crate::cradle::Cradle::new();
+        let (_rib_client, rib_rx) = config.subscribe_to_rib("cradle");
+        let cradle = crate::cradle::Cradle::new(rib_rx);
         config.subscribe("cradle", cradle.cm.tx.clone());
         let task = crate::cradle::serve(cradle);
         config

--- a/zebra-rs/src/config/manager.rs
+++ b/zebra-rs/src/config/manager.rs
@@ -630,12 +630,15 @@ impl ConfigManager {
                 spawn_nd(self);
             }
             // The cradle engine supervisor consumes `system ebpf` (its own
-            // knob) and `system cradle grpc-endpoint` (shared with the FIB
-            // tee, which stays in the RIB task) — spawn on the first line
-            // under either subtree so it sees this commit's leaves.
+            // knob), `system cradle grpc-endpoint` (shared with the FIB
+            // tee, which stays in the RIB task), and the per-interface
+            // `ebpf` port-membership leaves — spawn on the first line
+            // under any of the three so it sees this commit's leaves.
             if !cradle
                 && op == ConfigOp::Set
-                && (line.starts_with("system ebpf") || line.starts_with("system cradle"))
+                && (line.starts_with("system ebpf")
+                    || line.starts_with("system cradle")
+                    || (line.starts_with("interface ") && line.contains(" ebpf ")))
             {
                 cradle = true;
                 spawn_cradle(self);

--- a/zebra-rs/src/cradle/inst.rs
+++ b/zebra-rs/src/cradle/inst.rs
@@ -1,19 +1,31 @@
-//! The cradle supervisor task: consumes `/system/ebpf/*` (its own knob) and
-//! `/system/cradle/grpc-endpoint` (shared with the tee) from the config
-//! broadcast, and reconciles a running [`supervisor`] loop against the
-//! committed state at each `CommitEnd`.
+//! The cradle supervisor task: consumes `/system/ebpf/*` (its own knob),
+//! `/system/cradle/*` (shared with the tee) and `/interface/ebpf/*` (port
+//! membership) from the config broadcast, watches link lifecycle through a
+//! RIB subscription, and reconciles both the engine process (via
+//! [`supervisor`]) and the engine's port set (`SetPort`/`DelPort` over the
+//! gRPC control API) against the committed state.
 
+use std::collections::{BTreeMap, HashMap};
+
+use tokio::sync::mpsc::{self, UnboundedReceiver, UnboundedSender};
 use tokio::sync::watch;
-use tracing::info;
+use tracing::{info, warn};
 
 use crate::config::{ConfigChannel, ConfigOp, ConfigRequest, path_from_command};
 use crate::context::Task;
+use crate::fib::cradle::CradleFib;
+use crate::rib::api::RibRx;
 
-use super::supervisor;
+use super::supervisor::{self, EngineEvent};
 
 /// The tee's default endpoint (`fib/cradle.rs` / `rib`), which is also
 /// cradle's own `--grpc` default: a Linux abstract socket, per-netns.
 const DEFAULT_ENDPOINT: &str = "unix:cradle/grpc";
+
+/// Retry cadence for ports that could not be applied yet (engine still
+/// coming up, transient RPC failure, …). The reconcile is diff-based, so a
+/// quiet tick is a no-op.
+const RETRY_TICK: std::time::Duration = std::time::Duration::from_secs(3);
 
 /// A running supervisor loop for one desired endpoint.
 struct Engine {
@@ -29,30 +41,77 @@ struct Engine {
 pub struct Cradle {
     /// Config-manager subscription endpoints; drained by [`Self::event_loop`].
     pub cm: ConfigChannel,
+    rib_rx: UnboundedReceiver<RibRx>,
+    /// Engine availability events from the supervisor loop(s); one
+    /// persistent channel shared by every engine generation.
+    events_tx: UnboundedSender<EngineEvent>,
+    events_rx: UnboundedReceiver<EngineEvent>,
     /// Staged `system ebpf enabled` (applied at `CommitEnd`).
     ebpf_enabled: bool,
+    /// Staged `system cradle enabled` — in external mode (engine not
+    /// managed) an enabled tee marks the endpoint usable for port pushes.
+    cradle_enabled: bool,
     /// Staged `system cradle grpc-endpoint` override.
     grpc_endpoint: Option<String>,
+    /// Staged `interface <name> ebpf enabled` leaves, keyed by if-name.
+    if_ebpf: BTreeMap<String, bool>,
+    /// Kernel links, ifindex → name, from the RIB subscription (seeded by
+    /// the link dump at subscribe time).
+    links: HashMap<u32, String>,
     engine: Option<Engine>,
+    /// Is a managed engine currently answering (last [`EngineEvent`])?
+    engine_up: bool,
+    /// Ports applied to the current engine: if-name → the ifindex used.
+    applied: HashMap<String, u32>,
+    /// Port-programming client for [`Self::client_endpoint`].
+    ports_client: Option<CradleFib>,
+    client_endpoint: Option<String>,
 }
 
 impl Cradle {
-    pub fn new() -> Self {
+    pub fn new(rib_rx: UnboundedReceiver<RibRx>) -> Self {
+        let (events_tx, events_rx) = mpsc::unbounded_channel();
         Self {
             cm: ConfigChannel::new(),
+            rib_rx,
+            events_tx,
+            events_rx,
             ebpf_enabled: false,
+            cradle_enabled: false,
             grpc_endpoint: None,
+            if_ebpf: BTreeMap::new(),
+            links: HashMap::new(),
             engine: None,
+            engine_up: false,
+            applied: HashMap::new(),
+            ports_client: None,
+            client_endpoint: None,
         }
     }
 
     pub async fn event_loop(&mut self) {
-        while let Some(msg) = self.cm.rx.recv().await {
-            self.process_cm_msg(msg);
+        let mut tick = tokio::time::interval(RETRY_TICK);
+        tick.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+        loop {
+            tokio::select! {
+                msg = self.cm.rx.recv() => {
+                    let Some(msg) = msg else { return };
+                    self.process_cm_msg(msg).await;
+                }
+                Some(msg) = self.rib_rx.recv() => {
+                    self.process_rib_msg(msg);
+                    self.reconcile_ports().await;
+                }
+                Some(ev) = self.events_rx.recv() => {
+                    self.process_engine_event(ev);
+                    self.reconcile_ports().await;
+                }
+                _ = tick.tick() => self.reconcile_ports().await,
+            }
         }
     }
 
-    fn process_cm_msg(&mut self, msg: ConfigRequest) {
+    async fn process_cm_msg(&mut self, msg: ConfigRequest) {
         match msg.op {
             ConfigOp::Set | ConfigOp::Delete => {
                 let (path, mut args) = path_from_command(&msg.paths);
@@ -60,32 +119,83 @@ impl Cradle {
                     "/system/ebpf/enabled" => {
                         self.ebpf_enabled = msg.op.is_set() && args.boolean().unwrap_or(false);
                     }
+                    "/system/cradle/enabled" => {
+                        self.cradle_enabled = msg.op.is_set() && args.boolean().unwrap_or(false);
+                    }
                     "/system/cradle/grpc-endpoint" => {
                         self.grpc_endpoint = if msg.op.is_set() { args.string() } else { None };
+                    }
+                    "/interface/ebpf/enabled" => {
+                        let Some(if_name) = args.string() else { return };
+                        if msg.op.is_set() && args.boolean().unwrap_or(false) {
+                            self.if_ebpf.insert(if_name, true);
+                        } else {
+                            self.if_ebpf.remove(&if_name);
+                        }
                     }
                     _ => {}
                 }
             }
-            ConfigOp::CommitEnd => self.reconcile(),
+            ConfigOp::CommitEnd => {
+                self.reconcile_engine();
+                self.reconcile_ports().await;
+            }
             _ => {}
         }
     }
 
-    /// Desired engine endpoint: `None` when `system ebpf` is off, else the
-    /// `system cradle grpc-endpoint` override or the shared default.
-    fn desired(&self) -> Option<String> {
-        self.ebpf_enabled.then(|| {
-            self.grpc_endpoint
-                .clone()
-                .unwrap_or_else(|| DEFAULT_ENDPOINT.to_string())
-        })
+    fn process_rib_msg(&mut self, msg: RibRx) {
+        match msg {
+            RibRx::LinkAdd(link) => {
+                self.links.insert(link.index, link.name);
+            }
+            RibRx::LinkDel(ifindex) => {
+                self.links.remove(&ifindex);
+            }
+            _ => {}
+        }
+    }
+
+    fn process_engine_event(&mut self, ev: EngineEvent) {
+        // Both edges reset the applied set: a fresh (or vanished) engine
+        // has no ports, so everything must be re-applied on the next Up.
+        self.engine_up = ev == EngineEvent::Up;
+        self.applied.clear();
+    }
+
+    fn ifindex_of(&self, name: &str) -> Option<u32> {
+        self.links
+            .iter()
+            .find(|(_, n)| n.as_str() == name)
+            .map(|(ifindex, _)| *ifindex)
+    }
+
+    /// The configured endpoint (override or default), independent of
+    /// whether anything answers there.
+    fn endpoint(&self) -> String {
+        self.grpc_endpoint
+            .clone()
+            .unwrap_or_else(|| DEFAULT_ENDPOINT.to_string())
+    }
+
+    /// Endpoint to push ports to, when one is expected to answer: the
+    /// managed engine once it is up, or — external mode — whatever the
+    /// enabled tee (`system cradle enabled`) dials. `None` = clear state.
+    fn usable_endpoint(&self) -> Option<String> {
+        if self.ebpf_enabled {
+            self.engine_up.then(|| self.endpoint())
+        } else if self.cradle_enabled {
+            Some(self.endpoint())
+        } else {
+            None
+        }
     }
 
     /// Converge the running supervisor loop on the committed state. An
     /// endpoint change restarts the loop (the engine must re-listen there);
     /// disabling stops it gracefully.
-    fn reconcile(&mut self) {
-        let desired = self.desired();
+    fn reconcile_engine(&mut self) {
+        let desired = self.ebpf_enabled.then(|| self.endpoint());
         if self.engine.as_ref().map(|e| e.endpoint.as_str()) == desired.as_deref() {
             return;
         }
@@ -100,14 +210,79 @@ impl Cradle {
             info!("cradle: starting engine supervisor for {endpoint}");
             let (shutdown, shutdown_rx) = watch::channel(false);
             let ep = endpoint.clone();
+            let events = self.events_tx.clone();
             let task = Task::spawn(async move {
-                supervisor::run(ep, shutdown_rx).await;
+                supervisor::run(ep, shutdown_rx, events).await;
             });
             self.engine = Some(Engine {
                 endpoint,
                 shutdown,
                 task,
             });
+        }
+    }
+
+    /// Diff-based port reconcile: make the engine's port set match the
+    /// `interface <name> ebpf enabled` config for the links that currently
+    /// exist. Failures stay pending and are retried on [`RETRY_TICK`].
+    async fn reconcile_ports(&mut self) {
+        let Some(endpoint) = self.usable_endpoint() else {
+            // No engine to program (disabled, or managed engine not up):
+            // its state is gone or not ours — just reset ours.
+            self.applied.clear();
+            self.ports_client = None;
+            self.client_endpoint = None;
+            return;
+        };
+        if self.client_endpoint.as_deref() != Some(endpoint.as_str()) {
+            // (Re)pointed: the previously-applied state belongs to another
+            // engine instance; start over against the new endpoint.
+            self.ports_client = Some(CradleFib::new(&endpoint));
+            self.client_endpoint = Some(endpoint.clone());
+            self.applied.clear();
+        }
+        let client = self.ports_client.as_ref().expect("set above").clone();
+
+        // 1) Detach ports that no longer match: disabled, link gone, or the
+        //    device was re-created under a new ifindex. cradle resolves by
+        //    attach-time name when the device is gone, so DelPort also
+        //    cleans up after deleted links.
+        for (name, applied_ifindex) in self.applied.clone() {
+            let enabled = self.if_ebpf.get(&name).copied().unwrap_or(false);
+            if enabled && self.ifindex_of(&name) == Some(applied_ifindex) {
+                continue;
+            }
+            match client.del_port(&name).await {
+                Ok(()) => {
+                    info!("cradle: detached port {name}");
+                    self.applied.remove(&name);
+                }
+                Err(e) => warn!("cradle: DelPort {name} failed: {e} (will retry)"),
+            }
+        }
+
+        // 2) Attach enabled ports whose link exists and isn't applied yet
+        //    (or re-attach under a fresh ifindex after step 1 detached).
+        let wanted: Vec<String> = self
+            .if_ebpf
+            .iter()
+            .filter(|(_, enabled)| **enabled)
+            .map(|(name, _)| name.clone())
+            .collect();
+        for name in wanted {
+            let Some(ifindex) = self.ifindex_of(&name) else {
+                continue;
+            };
+            if self.applied.get(&name) == Some(&ifindex) {
+                continue;
+            }
+            match client.set_port(&name).await {
+                Ok(()) => {
+                    info!("cradle: attached port {name} (ifindex {ifindex})");
+                    self.applied.insert(name, ifindex);
+                }
+                Err(e) => warn!("cradle: SetPort {name} failed: {e} (will retry)"),
+            }
         }
     }
 }

--- a/zebra-rs/src/cradle/supervisor.rs
+++ b/zebra-rs/src/cradle/supervisor.rs
@@ -1,5 +1,8 @@
 //! Child-process lifecycle for the managed cradle engine: adopt-or-spawn,
-//! restart with backoff, graceful stop, and log forwarding.
+//! restart with backoff, graceful stop, and log forwarding. Engine
+//! availability transitions are reported to the [`super::inst`] task as
+//! [`EngineEvent`]s, which drive the port reconcile (a fresh engine has
+//! empty maps, so every port must be re-applied).
 
 use std::path::PathBuf;
 use std::process::Stdio;
@@ -7,14 +10,31 @@ use std::time::Duration;
 
 use tokio::io::{AsyncBufReadExt, BufReader};
 use tokio::process::{Child, Command};
+use tokio::sync::mpsc::UnboundedSender;
 use tokio::sync::watch;
 use tokio::time::Instant;
 use tracing::{info, warn};
+
+/// Engine availability, as observed by the supervisor loop. Consumers must
+/// treat both as idempotent (`Down` may arrive for an engine that never
+/// went `Up`).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum EngineEvent {
+    /// The engine answers its gRPC API (spawned child became ready, or a
+    /// running instance was adopted).
+    Up,
+    /// The engine is gone (child exited, adopted instance stopped
+    /// answering, or the supervisor is stopping).
+    Down,
+}
 
 /// Binary resolution override (mirrors `ZEBRA_XDP_BFD_ECHO_BIN`).
 const BIN_ENV: &str = "ZEBRA_CRADLE_BIN";
 /// Liveness-probe cadence for an adopted (externally-started) engine.
 const PROBE_INTERVAL: Duration = Duration::from_secs(5);
+/// Readiness-probe cadence for a just-spawned child (it loads the eBPF
+/// object before serving gRPC).
+const READY_INTERVAL: Duration = Duration::from_millis(500);
 /// Respawn backoff bounds; reset after a run this long counts as healthy.
 const BACKOFF_MIN: Duration = Duration::from_secs(1);
 const BACKOFF_MAX: Duration = Duration::from_secs(30);
@@ -98,9 +118,15 @@ async fn graceful_stop(mut child: Child) {
 
 /// The supervisor loop for one endpoint. Adopt-or-spawn, then hold: an
 /// adopted engine is probed for liveness (and never killed — it isn't
-/// ours); a spawned child is waited on and respawned with backoff. Exits
-/// when `shutdown` flips, stopping only a child we spawned.
-pub(crate) async fn run(endpoint: String, mut shutdown: watch::Receiver<bool>) {
+/// ours); a spawned child is probed until ready, then waited on and
+/// respawned with backoff. Exits when `shutdown` flips, stopping only a
+/// child we spawned. Every path that leaves the engine unusable sends
+/// [`EngineEvent::Down`] (idempotently) so the port reconcile resets.
+pub(crate) async fn run(
+    endpoint: String,
+    mut shutdown: watch::Receiver<bool>,
+    events: UnboundedSender<EngineEvent>,
+) {
     let mut backoff = BACKOFF_MIN;
     loop {
         if *shutdown.borrow() {
@@ -111,12 +137,17 @@ pub(crate) async fn run(endpoint: String, mut shutdown: watch::Receiver<bool>) {
         // bind the endpoint). If it dies later, fall through and spawn.
         if probe(&endpoint).await {
             info!("cradle: adopting already-running engine at {endpoint}");
+            let _ = events.send(EngineEvent::Up);
             loop {
                 tokio::select! {
-                    _ = shutdown.changed() => return,
+                    _ = shutdown.changed() => {
+                        let _ = events.send(EngineEvent::Down);
+                        return;
+                    }
                     _ = tokio::time::sleep(PROBE_INTERVAL) => {
                         if !probe(&endpoint).await {
                             warn!("cradle: adopted engine at {endpoint} stopped answering");
+                            let _ = events.send(EngineEvent::Down);
                             break;
                         }
                     }
@@ -133,16 +164,29 @@ pub(crate) async fn run(endpoint: String, mut shutdown: watch::Receiver<bool>) {
                     bin.display(),
                     child.id()
                 );
-                tokio::select! {
-                    _ = shutdown.changed() => {
-                        graceful_stop(child).await;
-                        info!("cradle: engine stopped (system ebpf disabled)");
-                        return;
+                // Probe until the engine serves its API (readiness), then
+                // hold until it exits or we are asked to stop.
+                let mut ready = false;
+                let status = loop {
+                    tokio::select! {
+                        _ = shutdown.changed() => {
+                            graceful_stop(child).await;
+                            let _ = events.send(EngineEvent::Down);
+                            info!("cradle: engine stopped (system ebpf disabled)");
+                            return;
+                        }
+                        status = child.wait() => break status,
+                        _ = tokio::time::sleep(READY_INTERVAL), if !ready => {
+                            if probe(&endpoint).await {
+                                ready = true;
+                                info!("cradle: engine ready at {endpoint}");
+                                let _ = events.send(EngineEvent::Up);
+                            }
+                        }
                     }
-                    status = child.wait() => {
-                        warn!("cradle: engine exited ({status:?}); respawning in {backoff:?}");
-                    }
-                }
+                };
+                let _ = events.send(EngineEvent::Down);
+                warn!("cradle: engine exited ({status:?}); respawning in {backoff:?}");
                 if started.elapsed() >= HEALTHY_RESET {
                     backoff = BACKOFF_MIN;
                 }

--- a/zebra-rs/src/fib/cradle.rs
+++ b/zebra-rs/src/fib/cradle.rs
@@ -220,6 +220,40 @@ impl CradleFib {
         })
     }
 
+    /// Attach `name` as a data-plane port (`SetPort`): cradle resolves the
+    /// ifindex, attaches the TC/XDP programs, and derives the port's
+    /// local + connected routes. Scope for now: a routed port in the
+    /// global VRF (`l3`, vlan 0, vrf 0) — VRF/bridge binding follows with
+    /// the dynamic L2/L3 assignment work. Idempotent on cradle's side.
+    pub async fn set_port(&self, name: &str) -> anyhow::Result<()> {
+        self.client()
+            .await?
+            .set_port(pb::Port {
+                name: name.to_string(),
+                mac: String::new(),
+                l3: true,
+                vlan: 0,
+                vrf_id: 0,
+            })
+            .await?;
+        Ok(())
+    }
+
+    /// Inverse of [`Self::set_port`]: detach the programs and drop the
+    /// port's map entries, derived routes, and learned FDB entries.
+    /// cradle resolves by current ifindex with a fallback to the
+    /// attach-time name, so this also cleans up after the device itself
+    /// is gone. Idempotent (an unknown port is a no-op).
+    pub async fn del_port(&self, name: &str) -> anyhow::Result<()> {
+        self.client()
+            .await?
+            .del_port(pb::PortDel {
+                name: name.to_string(),
+            })
+            .await?;
+        Ok(())
+    }
+
     /// Lazily connect (and cache) the gRPC client.
     async fn client(&self) -> anyhow::Result<CradleClient<Channel>> {
         let mut guard = self.client.lock().await;


### PR DESCRIPTION
## Summary

Phase 1b of the managed-cradle plan: the per-interface `ebpf` knob (#1879) becomes behavior — enabled interfaces are pushed to the engine as data-plane ports (`SetPort`) and detached (`DelPort`, from cradle-rs#106) when disabled or gone. This replaces cradle's `-c fwd.json` `ports` array for the zebra-driven workflow.

- **`CradleFib::set_port`/`del_port`** wrappers. Scope: routed port in the global VRF (`l3`, vlan 0, vrf 0) — `Link` carries no VRF table id and `subscribe_to_rib` is default-VRF-scoped; VRF/bridge binding follows with the dynamic L2/L3 assignment design.
- **Diff-based reconcile** in the cradle task: desired = `interface … ebpf enabled` × link present (new RIB subscription, seeded by the subscribe-time link dump) × usable endpoint (managed engine up, or an enabled external tee). Detach-first ordering covers disable, deleted links (DelPort's name-fallback cleans up after dead devices), and ifindex changes; failures retry on a 3s tick.
- **`EngineEvent::Up/Down`**: the supervisor probes a spawned child until its gRPC API answers, and both event edges clear the applied set — a fresh engine (respawn or adopted takeover) gets every port re-applied automatically. This is the same hook the Phase-2 FIB replay will use.
- `spawn_cradle` also triggers on `interface … ebpf` lines.

## Test plan

- `cargo fmt --all --check`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo test --workspace --exclude bdd` — all green.
- Live netns verification (debug zebra-rs + real cradle), six scenarios all passing:
  1. startup config → engine ready → `SetPort eth0`, `xdp` visible in `ip link`;
  2. `vtyctl` disable → detach, XDP removed from the device;
  3. re-enable → re-attach;
  4. `ip link del eth0` → detached by name; recreate → auto re-attach under the new ifindex;
  5. `kill -9` the engine → respawn → port re-applied with no operator action;
  6. config-before-link: interface enabled while nonexistent → attached the moment the device appears.

Generated with [Claude Code](https://claude.com/claude-code)