### PR TITLE
cradle: add show ebpf engine status, book chapter, packaging

### DIFF
--- a/book/src/ch-16-00-cradle.md
+++ b/book/src/ch-16-00-cradle.md
@@ -22,9 +22,109 @@ Some forwarding behaviours have **no mainline-kernel equivalent** and therefore
 *require* cradle — notably real GTP-U for [MUP](ch-02-35-bgp-mup.md)
 (`dataplane gtp`) and [EVPN VPWS](ch-02-38-bgp-evpn-vpws.md) egress.
 
-## Configuration
+The integration has two halves, on independent switches:
 
-The integration lives under the `system cradle` container. It is off by
+| Knob | Owns |
+|---|---|
+| `system ebpf enabled` | **The engine process**: zebra-rs spawns and supervises the cradle daemon itself. |
+| `system cradle enabled` | **The FIB tee**: zebra-rs programs whatever cradle answers the endpoint. |
+
+They compose: both on is the fully-managed data plane (the typical
+deployment); `system cradle` alone is the classic *external* mode (you run
+cradle yourself, e.g. the cradle-rs BDD harness); `system ebpf` alone runs
+the engine with ports but tees no routes — a pure eBPF L2 switch.
+
+## Managed engine (`system ebpf`)
+
+```
+system {
+  ebpf {
+    enabled true;
+  }
+  cradle {
+    enabled true;
+  }
+}
+interface enp0s6 {
+  ebpf {
+    enabled true;
+  }
+}
+```
+
+With `system ebpf enabled true`, zebra-rs launches
+`cradle serve --grpc <endpoint>` as a **managed child process** and keeps it
+healthy:
+
+- **Binary resolution**: `$ZEBRA_CRADLE_BIN`, else `~/.zebra/bin/cradle`,
+  else `/usr/bin/cradle` (where the `cradle-rs` Debian package installs it —
+  the zebra-rs package *recommends* it).
+- **Adopt-if-running**: if a cradle already answers the endpoint it is
+  adopted — monitored, never killed — so externally-started engines keep
+  working; if the adopted instance dies, the supervisor spawns its own.
+- **Crash recovery**: a dead engine is respawned with exponential backoff
+  (1 s → 30 s, reset after a healthy minute).
+- **Lifetime binding**: the child runs with `kill_on_drop` and
+  `PR_SET_PDEATHSIG=SIGTERM`, so no root engine process can outlive zebra-rs
+  — even a SIGKILLed daemon takes its engine down.
+- **Unified logs**: the engine's stdout/stderr are piped into zebra-rs
+  tracing under the `cradle` target.
+- Disabling (`delete system ebpf enabled true`) SIGTERMs the child (SIGKILL
+  after 5 s) and detaches everything.
+
+### Data-plane ports (`interface <name> ebpf`)
+
+`interface <name> ebpf enabled true` makes that interface a cradle
+data-plane port (the XDP + TC programs attach to it), replacing cradle's
+`-c` JSON `ports` array for zebra-driven deployments. The port set is
+**reconciled**: config before the link exists attaches the moment the device
+appears; a deleted-and-recreated link re-attaches under its new ifindex;
+disabling detaches (`DelPort`) and flushes the MACs learned on the port.
+Current scope: routed ports in the default VRF; VRF/bridge (L2) binding is
+follow-on work.
+
+### Restart behaviour: state replay
+
+A restarted engine starts with **empty maps**. Two mechanisms rebuild it
+with no operator action, on the same engine-ready edge:
+
+- the supervisor re-applies every configured **port**;
+- the FIB tee **replays** its mirrored state — routes (v4/v6), ILM, SRv6
+  SIDs, EVPN FDB/replication slots, VPWS cross-connects, GTP state, mirror
+  routes, neighbors — re-creating the underlying nexthops from scratch (the
+  tee's nexthop-id caches are reset, so post-restart route churn also
+  resolves correctly).
+
+The replay is driven by the supervisor's engine-up signal, so it covers
+managed respawns and adopted-instance takeovers. An *external* cradle
+restart has no such signal: external mode keeps today's behaviour (the tee's
+transport reconnects lazily; state repopulates on route churn).
+
+### `show ebpf`
+
+```
+zebra> show ebpf
+eBPF data plane (cradle engine)
+  System ebpf:     enabled
+  FIB tee:         enabled (system cradle)
+  Endpoint:        unix:cradle/grpc
+  Engine:          managed (pid 168157), up 42s
+  Engine restarts: 1
+  Engine v4 FIB:   mode lpm, 3 routes
+  Ports:           2 configured, 2 attached
+    eth0             ifindex 3      attached
+    veth9            ifindex 8      attached
+```
+
+Shows the supervisor state (managed / adopted / down / off, pid, uptime,
+restart count), the port reconcile status per interface, and — when the
+engine answers — its IPv4 FIB summary. A trailing `json` renders the
+machine-readable form. For deeper datapath inspection use cradle's own CLI
+(`cradle dump`, `cradle stats`) against the same endpoint.
+
+## The FIB tee (`system cradle`)
+
+The tee lives under the `system cradle` container. It is off by
 default; a single boolean turns it on:
 
 ```
@@ -56,9 +156,11 @@ set system cradle grpc-endpoint unix:/run/cradle.sock
 | `/system/cradle/enabled` | `boolean` | `false` | **The sole switch.** `true` enables the tee; `false` (or deleting it) disables it. |
 | `/system/cradle/grpc-endpoint` | `string` | `unix:cradle/grpc` | Optional endpoint override. Takes effect **only while the tee is enabled** — setting it on its own does *not* turn the tee on. |
 
-> **`enabled` is the only switch.** `grpc-endpoint` alone is inert: it just
-> re-points an already-enabled tee. To turn the integration on you must set
-> `system cradle enabled true`.
+> **`enabled` is the tee's only switch.** `grpc-endpoint` alone is inert: it
+> just re-points an already-enabled tee (and doubles as the `--grpc` argument
+> for a `system ebpf`-managed engine). To tee routes you must set
+> `system cradle enabled true`; to also run the engine, add
+> `system ebpf enabled true`.
 
 ## Endpoint forms
 

--- a/packaging/nfpm-amd64.yaml
+++ b/packaging/nfpm-amd64.yaml
@@ -16,6 +16,10 @@ replaces:
   - zebra-rs
 provides:
   - zebra-rs
+# The eBPF data-plane engine `system ebpf enabled` spawns (/usr/bin/cradle).
+# Optional: everything else works without it.
+recommends:
+  - cradle-rs
 maintainer: "Kunihiro Ishiguro <kunihiro@zebra.rs>"
 description: |
   zebra-rs is reincarnation of GNU zebra in Rust.

--- a/packaging/nfpm-arm64.yaml
+++ b/packaging/nfpm-arm64.yaml
@@ -16,6 +16,10 @@ replaces:
   - zebra-rs
 provides:
   - zebra-rs
+# The eBPF data-plane engine `system ebpf enabled` spawns (/usr/bin/cradle).
+# Optional: everything else works without it.
+recommends:
+  - cradle-rs
 maintainer: "Kunihiro Ishiguro <kunihiro@zebra.rs>"
 description: |
   zebra-rs is reincarnation of GNU zebra in Rust.

--- a/zebra-rs/src/config/cradle.rs
+++ b/zebra-rs/src/config/cradle.rs
@@ -26,6 +26,7 @@ pub fn spawn_cradle(config: &ConfigManager) {
         let (rib_client, rib_rx) = config.subscribe_to_rib("cradle");
         let cradle = crate::cradle::Cradle::new(rib_client, rib_rx);
         config.subscribe("cradle", cradle.cm.tx.clone());
+        config.subscribe_show("cradle", cradle.show.tx.clone());
         let task = crate::cradle::serve(cradle);
         config
             .protocol_tasks

--- a/zebra-rs/src/config/manager.rs
+++ b/zebra-rs/src/config/manager.rs
@@ -1265,6 +1265,11 @@ fn is_nd(paths: &[CommandPath]) -> bool {
     paths.iter().any(|x| x.name == "nd")
 }
 
+/// `show ebpf` — the cradle engine supervisor's status command.
+fn is_ebpf(paths: &[CommandPath]) -> bool {
+    paths.iter().any(|x| x.name == "ebpf")
+}
+
 fn is_policy(paths: &[CommandPath]) -> bool {
     // Every policy-object root the policy module registers a show
     // handler for. Missing roots fall through to the `"rib"` fallback
@@ -1304,6 +1309,8 @@ fn show_proto(paths: &[CommandPath]) -> &'static str {
         "stamp"
     } else if is_nd(paths) {
         "nd"
+    } else if is_ebpf(paths) {
+        "cradle"
     } else if is_policy(paths) {
         "policy"
     } else {

--- a/zebra-rs/src/cradle/inst.rs
+++ b/zebra-rs/src/cradle/inst.rs
@@ -11,7 +11,9 @@ use tokio::sync::mpsc::{self, UnboundedReceiver, UnboundedSender};
 use tokio::sync::watch;
 use tracing::{info, warn};
 
-use crate::config::{ConfigChannel, ConfigOp, ConfigRequest, path_from_command};
+use crate::config::{
+    ConfigChannel, ConfigOp, ConfigRequest, DisplayRequest, ShowChannel, path_from_command,
+};
 use crate::context::Task;
 use crate::fib::cradle::CradleFib;
 use crate::rib::api::RibRx;
@@ -37,11 +39,27 @@ struct Engine {
     task: Task<()>,
 }
 
+/// Last observed engine availability, tracked from [`EngineEvent`]s for
+/// `show ebpf`.
+#[derive(Default)]
+struct EngineStatus {
+    up: bool,
+    /// Spawned child's pid; `None` when adopted (or down).
+    pid: Option<u32>,
+    adopted: bool,
+    /// When the current up-edge happened.
+    since: Option<tokio::time::Instant>,
+    /// Up-edges seen; `ups - 1` = restarts/takeovers since the first start.
+    ups: u32,
+}
+
 /// Top-level supervisor instance, registered like the other modules
 /// (`spawn_cradle` in `config/cradle.rs`).
 pub struct Cradle {
     /// Config-manager subscription endpoints; drained by [`Self::event_loop`].
     pub cm: ConfigChannel,
+    /// `show ebpf` subscription endpoints; drained by [`Self::event_loop`].
+    pub show: ShowChannel,
     /// Sender half of the RIB subscription — carries
     /// `Message::CradleEngineUp` so the tee replays its mirrored FIB
     /// state into a fresh engine (`CradleFib::replay`).
@@ -64,8 +82,8 @@ pub struct Cradle {
     /// the link dump at subscribe time).
     links: HashMap<u32, String>,
     engine: Option<Engine>,
-    /// Is a managed engine currently answering (last [`EngineEvent`])?
-    engine_up: bool,
+    /// Last observed engine availability (from [`EngineEvent`]s).
+    status: EngineStatus,
     /// Ports applied to the current engine: if-name → the ifindex used.
     applied: HashMap<String, u32>,
     /// Port-programming client for [`Self::client_endpoint`].
@@ -78,6 +96,7 @@ impl Cradle {
         let (events_tx, events_rx) = mpsc::unbounded_channel();
         Self {
             cm: ConfigChannel::new(),
+            show: ShowChannel::new(),
             rib,
             rib_rx,
             events_tx,
@@ -88,7 +107,7 @@ impl Cradle {
             if_ebpf: BTreeMap::new(),
             links: HashMap::new(),
             engine: None,
-            engine_up: false,
+            status: EngineStatus::default(),
             applied: HashMap::new(),
             ports_client: None,
             client_endpoint: None,
@@ -111,6 +130,9 @@ impl Cradle {
                 Some(ev) = self.events_rx.recv() => {
                     self.process_engine_event(ev);
                     self.reconcile_ports().await;
+                }
+                Some(dmsg) = self.show.rx.recv() => {
+                    self.process_show_msg(dmsg).await;
                 }
                 _ = tick.tick() => self.reconcile_ports().await,
             }
@@ -165,13 +187,24 @@ impl Cradle {
     fn process_engine_event(&mut self, ev: EngineEvent) {
         // Both edges reset the applied set: a fresh (or vanished) engine
         // has no ports, so everything must be re-applied on the next Up.
-        self.engine_up = ev == EngineEvent::Up;
         self.applied.clear();
-        // Ports re-apply here (reconcile_ports); the FIB half — routes,
-        // ILM, SIDs, EVPN, GTP — is mirrored by the tee in the RIB task,
-        // so ask it to replay into the fresh engine.
-        if self.engine_up {
-            let _ = self.rib.send(crate::rib::Message::CradleEngineUp);
+        match ev {
+            EngineEvent::Up { pid, adopted } => {
+                self.status.up = true;
+                self.status.pid = pid;
+                self.status.adopted = adopted;
+                self.status.since = Some(tokio::time::Instant::now());
+                self.status.ups = self.status.ups.saturating_add(1);
+                // Ports re-apply here (reconcile_ports); the FIB half —
+                // routes, ILM, SIDs, EVPN, GTP — is mirrored by the tee in
+                // the RIB task, so ask it to replay into the fresh engine.
+                let _ = self.rib.send(crate::rib::Message::CradleEngineUp);
+            }
+            EngineEvent::Down => {
+                self.status.up = false;
+                self.status.pid = None;
+                self.status.since = None;
+            }
         }
     }
 
@@ -195,12 +228,150 @@ impl Cradle {
     /// enabled tee (`system cradle enabled`) dials. `None` = clear state.
     fn usable_endpoint(&self) -> Option<String> {
         if self.ebpf_enabled {
-            self.engine_up.then(|| self.endpoint())
+            self.status.up.then(|| self.endpoint())
         } else if self.cradle_enabled {
             Some(self.endpoint())
         } else {
             None
         }
+    }
+
+    /// `show ebpf` — supervisor and port status, plus the engine's FIB
+    /// summary when it answers. `json` renders the machine-readable form.
+    async fn process_show_msg(&self, msg: DisplayRequest) {
+        let (path, _args) = path_from_command(&msg.paths);
+        if path.as_str() != "/show/ebpf" {
+            return;
+        }
+        let _ = msg.resp.send(self.render_show(msg.json).await).await;
+    }
+
+    async fn render_show(&self, json: bool) -> String {
+        use std::fmt::Write;
+
+        let endpoint = self.endpoint();
+        let engine = if !self.ebpf_enabled {
+            "off (system ebpf disabled)".to_string()
+        } else if !self.status.up {
+            "down (supervisor retrying)".to_string()
+        } else if self.status.adopted {
+            "adopted (externally started; probed for liveness)".to_string()
+        } else {
+            match self.status.pid {
+                Some(pid) => format!("managed (pid {pid})"),
+                None => "managed".to_string(),
+            }
+        };
+        let up_secs = self.status.since.map(|t| t.elapsed().as_secs());
+        let restarts = self.status.ups.saturating_sub(1);
+        // The engine's own IPv4 FIB summary, when someone answers the
+        // endpoint (managed-and-up, or an external instance).
+        let fib = if self.status.up || self.cradle_enabled {
+            crate::fib::cradle::fib_summary(&endpoint).await
+        } else {
+            None
+        };
+
+        if json {
+            let ports: Vec<serde_json::Value> = self
+                .if_ebpf
+                .iter()
+                .filter(|(_, en)| **en)
+                .map(|(name, _)| {
+                    let ifindex = self.ifindex_of(name);
+                    serde_json::json!({
+                        "name": name,
+                        "ifindex": ifindex,
+                        "attached": ifindex.is_some()
+                            && self.applied.get(name) == ifindex.as_ref(),
+                    })
+                })
+                .collect();
+            return serde_json::json!({
+                "systemEbpfEnabled": self.ebpf_enabled,
+                "teeEnabled": self.cradle_enabled,
+                "endpoint": endpoint,
+                "engine": engine,
+                "engineUpSeconds": up_secs,
+                "engineRestarts": restarts,
+                "ports": ports,
+                "fib4Mode": fib.as_ref().map(|f| f.fib4_mode.clone()),
+                "fib4Routes": fib.as_ref().map(|f| f.routes4),
+            })
+            .to_string();
+        }
+
+        let mut out = String::new();
+        writeln!(out, "eBPF data plane (cradle engine)").unwrap();
+        writeln!(
+            out,
+            "  System ebpf:     {}",
+            if self.ebpf_enabled {
+                "enabled"
+            } else {
+                "disabled"
+            }
+        )
+        .unwrap();
+        writeln!(
+            out,
+            "  FIB tee:         {}",
+            if self.cradle_enabled {
+                "enabled (system cradle)"
+            } else {
+                "disabled"
+            }
+        )
+        .unwrap();
+        writeln!(out, "  Endpoint:        {endpoint}").unwrap();
+        match up_secs {
+            Some(secs) => writeln!(out, "  Engine:          {engine}, up {secs}s").unwrap(),
+            None => writeln!(out, "  Engine:          {engine}").unwrap(),
+        }
+        writeln!(out, "  Engine restarts: {restarts}").unwrap();
+        if let Some(f) = fib {
+            // `routes4` is the dir24 engine's shadow count; the lpm engine
+            // does not track one (always 0) — show it only when meaningful.
+            if f.fib4_mode == "dir24" {
+                writeln!(
+                    out,
+                    "  Engine v4 FIB:   mode dir24, {} routes (tbl8 {}/{})",
+                    f.routes4,
+                    f.tbl8_used,
+                    f.tbl8_used + f.tbl8_free
+                )
+                .unwrap();
+            } else {
+                writeln!(out, "  Engine v4 FIB:   mode {}", f.fib4_mode).unwrap();
+            }
+        }
+        let enabled: Vec<&String> = self
+            .if_ebpf
+            .iter()
+            .filter(|(_, en)| **en)
+            .map(|(name, _)| name)
+            .collect();
+        writeln!(
+            out,
+            "  Ports:           {} configured, {} attached",
+            enabled.len(),
+            self.applied.len()
+        )
+        .unwrap();
+        for name in enabled {
+            match (self.ifindex_of(name), self.applied.get(name)) {
+                (Some(ifindex), Some(applied)) if *applied == ifindex => {
+                    writeln!(out, "    {name:<16} ifindex {ifindex:<6} attached").unwrap();
+                }
+                (Some(ifindex), _) => {
+                    writeln!(out, "    {name:<16} ifindex {ifindex:<6} pending").unwrap();
+                }
+                (None, _) => {
+                    writeln!(out, "    {name:<16} {:<14} link absent", "-").unwrap();
+                }
+            }
+        }
+        out
     }
 
     /// Converge the running supervisor loop on the committed state. An

--- a/zebra-rs/src/cradle/supervisor.rs
+++ b/zebra-rs/src/cradle/supervisor.rs
@@ -22,7 +22,12 @@ use tracing::{info, warn};
 pub enum EngineEvent {
     /// The engine answers its gRPC API (spawned child became ready, or a
     /// running instance was adopted).
-    Up,
+    Up {
+        /// The child's pid when we spawned it; `None` for an adopted
+        /// instance (not ours — we only probe it).
+        pid: Option<u32>,
+        adopted: bool,
+    },
     /// The engine is gone (child exited, adopted instance stopped
     /// answering, or the supervisor is stopping).
     Down,
@@ -137,7 +142,10 @@ pub(crate) async fn run(
         // bind the endpoint). If it dies later, fall through and spawn.
         if probe(&endpoint).await {
             info!("cradle: adopting already-running engine at {endpoint}");
-            let _ = events.send(EngineEvent::Up);
+            let _ = events.send(EngineEvent::Up {
+                pid: None,
+                adopted: true,
+            });
             loop {
                 tokio::select! {
                     _ = shutdown.changed() => {
@@ -180,7 +188,10 @@ pub(crate) async fn run(
                             if probe(&endpoint).await {
                                 ready = true;
                                 info!("cradle: engine ready at {endpoint}");
-                                let _ = events.send(EngineEvent::Up);
+                                let _ = events.send(EngineEvent::Up {
+                                    pid: child.id(),
+                                    adopted: false,
+                                });
                             }
                         }
                     }

--- a/zebra-rs/src/fib/cradle.rs
+++ b/zebra-rs/src/fib/cradle.rs
@@ -204,6 +204,20 @@ async fn connect_abstract_cradle(name: &str) -> anyhow::Result<CradleClient<Chan
     Ok(CradleClient::new(channel))
 }
 
+/// Fetch the engine's IPv4 FIB summary (`GetFibSummary`) from `endpoint`
+/// with a 2 s budget — `None` when nothing answers. Used by `show ebpf`.
+pub(crate) async fn fib_summary(endpoint: &str) -> Option<pb::FibSummary> {
+    let attempt = async {
+        let mut client = connect_cradle(endpoint).await?;
+        let resp = client.get_fib_summary(pb::FibSummaryRequest {}).await?;
+        anyhow::Ok(resp.into_inner())
+    };
+    tokio::time::timeout(std::time::Duration::from_secs(2), attempt)
+        .await
+        .ok()
+        .and_then(|r| r.ok())
+}
+
 /// Probe whether a cradle gRPC server answers at `endpoint` (fresh connect +
 /// `GetStats`, 2 s budget). Used by the engine supervisor (`crate::cradle`)
 /// for the adopt-if-running check and adopted-instance liveness.

--- a/zebra-rs/yang/exec.yang
+++ b/zebra-rs/yang/exec.yang
@@ -288,6 +288,10 @@ module exec {
         type empty;
       }
     }
+    container ebpf {
+      ext:help "eBPF data-plane engine (managed cradle) status";
+      presence "Show the engine supervisor and port status";
+    }
     container bgp {
       ext:help "BGP information";
       // `show bgp` with no AFI keyword is IPv4 unicast. A bare address


### PR DESCRIPTION
## Summary

Phase 3 (operator surface) of the managed-cradle plan:

- **`show ebpf`** — new exec command routed to the cradle supervisor task: the system-ebpf/tee switches, endpoint, engine state (managed with pid/uptime, adopted, down, off), restart count, the engine's IPv4 FIB summary proxied over `GetFibSummary` when it answers (the dir24 shadow route count is shown only in dir24 mode — lpm doesn't track one), and the per-port reconcile status (attached / pending / link absent). Trailing `json` renders the machine-readable form. `EngineEvent::Up` now carries `(pid, adopted)` so the task can track this.
- **Book ch-16** rewritten for the two-switch model: managed engine (`system ebpf`) vs FIB tee (`system cradle`), the composition matrix, port membership (`interface … ebpf`), supervisor semantics (adopt-if-running, backoff, PDEATHSIG, unified logs), restart replay, and the `show ebpf` reference.
- **Packaging**: the zebra-rs deb now `recommends: cradle-rs` (the engine binary `system ebpf enabled` spawns; everything else works without it).

## Test plan

- `cargo fmt --all --check`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo test --workspace --exclude bdd` — all green.
- Live netns verification: `vtyctl show "show ebpf"` renders the managed engine (pid, uptime), tee state, engine FIB mode, and the attached port; after `kill -9` of the engine it shows the respawned pid, `Engine restarts: 1`, and the re-attached port; `show -j` returns the JSON form.

Generated with [Claude Code](https://claude.com/claude-code)