### PR TITLE
docs: correct recursive static route prefix

### DIFF
--- a/book/src/ch-01-02-recursive-static-route.md
+++ b/book/src/ch-01-02-recursive-static-route.md
@@ -28,7 +28,7 @@ interfaces {
 }
 routing {
     static {
-        route 172.16.0.0/0 {
+        route 172.16.0.0/16 {
             nexthop 10.0.0.254;
 			recursive true;
         }


### PR DESCRIPTION
Fix a typo in the recursive static route example (/0 → /16).