### PR TITLE
bdd: cradle_spawn — the managed eBPF engine end to end

### DIFF
--- a/bdd/Makefile
+++ b/bdd/Makefile
@@ -371,6 +371,12 @@ nd_show:
 	mkdir -p allure-results
 	cargo test --test cucumber -- --concurrency=1 --tags "@nd_show"
 
+# Requires /usr/bin/cradle (the cradle-rs engine binary) — see the
+# feature header for the install one-liner.
+cradle_spawn:
+	mkdir -p allure-results
+	cargo test --test cucumber -- --concurrency=1 --tags "@cradle_spawn"
+
 bgp_interas_option_c:
 	mkdir -p allure-results
 	cargo test --test cucumber -- --concurrency=1 --tags "@bgp_interas_option_c"
@@ -430,4 +436,4 @@ docs/%.md: tests/features/%.feature docs/feature2md.sh FORCE
 
 FORCE:
 
-.PHONY: ecmp_bfd_evict ospfv2_bfd_frr ospfv3_bfd_frr tilfa_bfd all run ibgp ebgp rr rib_static_ipv6 isis_ipv6 isis_srv6_base isis_fragmentation_ipv6 isis_fragmentation_ipv4 isis_l1p2p isis_tilfa isis_srmpls system_hostname isis_l1l2 isis_redist isis_hello_auth_keychain isis_passive isis_afi_enable isis_endx_ipv6 isis_bfd_ipv6_p2p isis_bfd_ipv6_p2p_echo isis_bfd_ipv6_lan isis_bfd_ipv6_lan_echo isis_bfd_ipv4_p2p isis_bfd_ipv4_p2p_echo isis_bfd_ipv4_lan isis_bfd_ipv4_lan_echo ospf_clear_neighbor ospfv2_nssa_base ospfv2_stub_base ospfv2_tilfa ospfv3_nssa ospfv3_tilfa stamp_te_metric stamp_v6_te_metric bgp_peer_down_cleanup bgp_ipv6_over_v4_session bgp_evpn_capability bgp_vrf_evpn_type5 bgp_evpn_outpolicy_undef bgp_route_map_match bgp_policy_dynamic_update bgp_table_map bgp_v6_table_map bgp_community bgp_neighbor_group bgp_unnumbered_neighbor nd_show bgp_interas_option_c bgp_interas_option_a bgp_interas_option_b bgp_interas_option_ab bgp_port bgp_ip_transparent bgp_local_as bgp_unknown_attr_transitive bgp_fast_external_failover generate open docs FORCE
+.PHONY: ecmp_bfd_evict ospfv2_bfd_frr ospfv3_bfd_frr tilfa_bfd all run ibgp ebgp rr rib_static_ipv6 isis_ipv6 isis_srv6_base isis_fragmentation_ipv6 isis_fragmentation_ipv4 isis_l1p2p isis_tilfa isis_srmpls system_hostname isis_l1l2 isis_redist isis_hello_auth_keychain isis_passive isis_afi_enable isis_endx_ipv6 isis_bfd_ipv6_p2p isis_bfd_ipv6_p2p_echo isis_bfd_ipv6_lan isis_bfd_ipv6_lan_echo isis_bfd_ipv4_p2p isis_bfd_ipv4_p2p_echo isis_bfd_ipv4_lan isis_bfd_ipv4_lan_echo ospf_clear_neighbor ospfv2_nssa_base ospfv2_stub_base ospfv2_tilfa ospfv3_nssa ospfv3_tilfa stamp_te_metric stamp_v6_te_metric bgp_peer_down_cleanup bgp_ipv6_over_v4_session bgp_evpn_capability bgp_vrf_evpn_type5 bgp_evpn_outpolicy_undef bgp_route_map_match bgp_policy_dynamic_update bgp_table_map bgp_v6_table_map bgp_community bgp_neighbor_group bgp_unnumbered_neighbor nd_show cradle_spawn bgp_interas_option_c bgp_interas_option_a bgp_interas_option_b bgp_interas_option_ab bgp_port bgp_ip_transparent bgp_local_as bgp_unknown_attr_transitive bgp_fast_external_failover generate open docs FORCE

--- a/bdd/tests/configs/cradle_spawn/z1.yaml
+++ b/bdd/tests/configs/cradle_spawn/z1.yaml
@@ -1,0 +1,16 @@
+system:
+  ebpf:
+    enabled: true
+  cradle:
+    enabled: true
+interface:
+- if-name: eth0
+  ebpf:
+    enabled: true
+router:
+  static:
+    ipv4:
+      route:
+      - prefix: 10.210.99.0/24
+        nexthop:
+        - address: 10.210.1.2

--- a/bdd/tests/features/cradle_spawn.feature
+++ b/bdd/tests/features/cradle_spawn.feature
@@ -1,0 +1,49 @@
+@cradle_spawn
+Feature: system ebpf spawns and supervises the cradle eBPF engine
+  `system ebpf enabled true` makes zebra-rs run the cradle data-plane
+  daemon as a managed child: spawn it, attach `interface <name> ebpf
+  enabled` ports, respawn it with backoff when it dies (re-attaching the
+  ports and replaying the mirrored FIB tee), and stop it when disabled.
+
+  Prerequisite: /usr/bin/cradle (the cradle-rs engine binary). Install it
+  from a cradle-rs checkout: `cargo build --release` then
+  `install -m755 target/release/cradle /usr/bin/cradle`.
+
+  Topology:
+  ```
+   crs1 [ zebra-rs + managed cradle, eth0 ebpf port ] ─ eth0 ── eth0 ─ crs2
+  ```
+
+  Scenario: Managed engine spawns with a data-plane port
+    Given a clean test environment
+    When I create namespace "crs1"
+    And I create namespace "crs2"
+    And I connect namespace "crs1" interface "eth0" to namespace "crs2" interface "eth0"
+    And I add address "10.210.1.1/24" to interface "eth0" in namespace "crs1"
+    And I add address "10.210.1.2/24" to interface "eth0" in namespace "crs2"
+    And I start zebra-rs in namespace "crs1"
+    And I apply config "z1.yaml" to namespace "crs1"
+    Then show command "show ebpf" in namespace "crs1" should eventually contain "managed"
+    And show command "show ebpf" in namespace "crs1" should eventually contain "attached"
+    And daemon log in namespace "crs1" should eventually contain "cradle: engine ready"
+
+  Scenario: A crashed engine respawns, re-attaches the port, and replays the FIB
+    Given the test topology exists
+    When I execute "pkill -9 -x cradle" in namespace "crs1"
+    Then daemon log in namespace "crs1" should eventually contain "cradle: engine exited"
+    And daemon log in namespace "crs1" should eventually contain "fib: cradle replay:"
+    And show command "show ebpf" in namespace "crs1" should eventually contain "Engine restarts: 1"
+    And show command "show ebpf" in namespace "crs1" should eventually contain "attached"
+
+  Scenario: Disabling system ebpf stops the engine
+    Given the test topology exists
+    When I apply command "delete system ebpf enabled true" in namespace "crs1"
+    Then show command "show ebpf" in namespace "crs1" should eventually contain "off (system ebpf disabled)"
+    And daemon log in namespace "crs1" should eventually contain "engine stopped (system ebpf disabled)"
+
+  Scenario: Teardown topology
+    Given the test topology exists
+    When I stop zebra-rs in namespace "crs1"
+    And I delete namespace "crs1"
+    And I delete namespace "crs2"
+    Then the test environment should be clean

--- a/book/src/SUMMARY.md
+++ b/book/src/SUMMARY.md
@@ -18,6 +18,7 @@
   - [Floating Static Route](ch-01-01-floating-static-route.md)
   - [Recursive Static Route](ch-01-02-recursive-static-route.md)
   - [Blackhole (Discard) Static Route](ch-01-03-blackhole-static-route.md)
+  - [SRv6 Static Routes](ch-01-04-srv6-static-route.md)
 
 ## Routing Protocols
 

--- a/book/src/ch-01-00-what-is-static-route.md
+++ b/book/src/ch-01-00-what-is-static-route.md
@@ -76,8 +76,8 @@ Points worth knowing:
   `router static vrf <name> { ... }` and install into that VRF's
   kernel routing table.
 - IPv6 routes additionally accept SRv6 attributes (`segments`,
-  `encap-type`, seg6local `action`, …); see the
-  [SRv6 chapter](ch-04-00-srv6.md).
+  `encap-type`, seg6local `action`, …); see
+  [SRv6 Static Routes](ch-01-04-srv6-static-route.md).
 
 ## Example
 

--- a/book/src/ch-01-00-what-is-static-route.md
+++ b/book/src/ch-01-00-what-is-static-route.md
@@ -28,6 +28,59 @@ The key characteristics of static routes are:
    path, as long as the configured next-hop router or interface remains
    available and the network topology does not change.
 
+## Configuration model
+
+Static routes live under the top-level `router static` block, split by
+address family. Each `route` entry is keyed by its destination prefix
+and carries one or more `nexthop` entries plus optional route-level
+attributes:
+
+```
+router static {
+  ipv4 {
+    route <prefix> {
+      nexthop <address | blackhole> {
+        metric <metric>;        # per-nexthop metric (primary/backup)
+        weight <1-255>;         # ECMP weight
+        label <label> ...;      # MPLS labels to push
+      }
+      distance <1-255>;         # administrative distance (default 1)
+      metric <metric>;          # route metric
+    }
+  }
+  ipv6 {
+    route <prefix> {
+      ...                       # same shape, IPv6 addresses
+    }
+  }
+}
+```
+
+Points worth knowing:
+
+- A bare `route <prefix>` with no nexthop carries no forwarding
+  information and is rejected at commit — every route needs at least
+  one `nexthop` (an IP address, or the `blackhole` keyword — see
+  [Blackhole (Discard) Static Route](ch-01-03-blackhole-static-route.md)).
+- Configuring several nexthops on one route gives ECMP; unequal
+  `weight` values give weighted (UCMP) load-sharing, and unequal
+  per-nexthop `metric` values give a primary/backup pair — see
+  [Floating Static Route](ch-01-01-floating-static-route.md).
+- The default administrative distance for a static route is **1**, so
+  a static route normally wins over any dynamic protocol. Raise it
+  with the `distance` leaf to make the static route a fallback.
+- The nexthop does not need to be on a directly connected subnet —
+  zebra-rs resolves it through the routing table automatically; see
+  [Recursive Static Route](ch-01-02-recursive-static-route.md).
+- Per-VRF static routes use the same shape nested under
+  `router static vrf <name> { ... }` and install into that VRF's
+  kernel routing table.
+- IPv6 routes additionally accept SRv6 attributes (`segments`,
+  `encap-type`, seg6local `action`, …); see the
+  [SRv6 chapter](ch-04-00-srv6.md).
+
+## Example
+
 Suppose you have a small office network with the following setup:
 
 The main office has a router (Router A) with the IP address 192.168.1.1 on the
@@ -35,62 +88,60 @@ local network. There is a remote branch office that needs to be accessed from
 the main office network. The remote branch office has a router (Router B) with
 the IP address 10.0.0.1 on its local network. The network between the main
 office and the remote branch office is a wide-area network (WAN) with the IP
-subnet 172.16.0.0/24. In this scenario, you would need to configure a static
-route on Router A to reach the remote branch office network. The steps would be
-as follows:
+subnet 172.16.0.0/24.
 
-On Router A, you would configure a static route for the remote branch office
-network, which is 10.0.0.0/24. The command to add the static route would be
-something like:
+On Router A, you would configure a static route for the remote branch
+office network, 10.0.0.0/24:
 
-``` console
-interfaces {
-    interface eth0 {
-	    ip {
-		    address 172.16.0.1/24;
-		}
-	}
-    interface eth1 {
-	    ip {
-		    address 192.168.1.1/24;
-		}
-	}
+```
+interface eth0 {
+  ipv4 {
+    address 172.16.0.1/24;
+  }
 }
-routing {
-    static {
-        route 10.0.0.0/24 {
-            nexthop 172.16.0.2;
-        }
+interface eth1 {
+  ipv4 {
+    address 192.168.1.1/24;
+  }
+}
+router static {
+  ipv4 {
+    route 10.0.0.0/24 {
+      nexthop 172.16.0.2;
     }
+  }
 }
 ```
 
-ip route 10.0.0.0 255.255.255.0 172.16.0.2
+In the CLI the same route is one `set` command from configure mode,
+followed by `commit`:
 
-This command tells Router A that to reach the 10.0.0.0/24 network, it should
+```
+set router static ipv4 route 10.0.0.0/24 nexthop 172.16.0.2
+```
+
+This tells Router A that to reach the 10.0.0.0/24 network, it should
 forward the traffic to the next-hop router at 172.16.0.2, which is the WAN
-interface of Router B. On Router B, you would need to configure a static route
-for the main office network, 192.168.1.0/24. The command would be:
+interface of Router B. On Router B, you would configure the mirror-image
+static route for the main office network, 192.168.1.0/24:
 
-``` console
-interfaces {
-    interface eth0 {
-	    ip {
-		    address 172.16.0.2/24;
-		}
-	}
-    interface eth1 {
-	    ip {
-		    address 10.0.0.1/24;
-		}
-	}
+```
+interface eth0 {
+  ipv4 {
+    address 172.16.0.2/24;
+  }
 }
-routing {
-    static {
-        route 192.168.0.0/24 {
-            nexthop 172.16.0.1;
-        }
+interface eth1 {
+  ipv4 {
+    address 10.0.0.1/24;
+  }
+}
+router static {
+  ipv4 {
+    route 192.168.1.0/24 {
+      nexthop 172.16.0.1;
     }
+  }
 }
 ```
 
@@ -101,7 +152,45 @@ to communicate with a device on the remote branch office network (10.0.0.0/24),
 the traffic will be forwarded to Router A, which will then use the static route
 to send the traffic to Router B, and vice versa.
 
-This static route configuration ensures that the two networks can communicate
-with each other, even though they are physically separate and connected through
-a WAN link. The static routes provide a fixed and predictable path for the
-traffic to flow between the two networks.
+IPv6 static routes follow exactly the same shape under the `ipv6`
+container:
+
+```
+router static {
+  ipv6 {
+    route 2001:db8:100::/48 {
+      nexthop 2001:db8:1::2;
+    }
+  }
+}
+```
+
+## ECMP
+
+A route with several nexthops at the same metric load-balances across
+them. The optional `weight` leaf makes the split unequal (UCMP):
+
+```
+router static {
+  ipv4 {
+    route 10.0.0.0/24 {
+      nexthop 172.16.0.2 {
+        weight 2;
+      }
+      nexthop 172.16.1.2 {
+        weight 1;
+      }
+    }
+  }
+}
+```
+
+## Verifying
+
+Installed static routes appear in `show ip route` (or
+`show ipv6 route`) with the `S` marker, and can be looked up
+individually:
+
+```
+show ip route 10.0.0.0/24
+```

--- a/book/src/ch-01-01-floating-static-route.md
+++ b/book/src/ch-01-01-floating-static-route.md
@@ -1,65 +1,107 @@
 # Floating Static Route
 
-Floating static routes, also known as backup static routes, are a type of static
-routing configuration that provides an alternative path for network traffic in
-the event of a primary route failure. These routes are considered "floating"
-because they have a higher administrative distance than the primary route, which
-means they are only used when the primary route becomes unavailable.
+Floating static routes, also known as backup static routes, provide an
+alternative path for network traffic in the event of a primary route
+failure. The route is considered "floating" because it is deliberately
+made *less preferred* than the primary path, so it carries traffic only
+when the primary becomes unavailable.
 
-The purpose of floating static routes is to provide redundancy and improve
-network reliability. When the primary route becomes unavailable, the floating
-static route is used as a backup, ensuring that network traffic can still reach
-its destination.
+zebra-rs expresses this in two ways, depending on what the backup is
+backing up:
 
-Let's consider a scenario where a router has two uplink interfaces, one
-connected to an Internet Service Provider (ISP) and the other connected to a
-backup ISP. The primary route to the internet is through the primary ISP, while
-the floating static route is configured to use the backup ISP.
+1. **Backing up a dynamic protocol route** — raise the static route's
+   *administrative distance* above the protocol's.
+2. **Backing up another static path to the same prefix** — give one
+   route two nexthops with different *per-nexthop metrics*.
 
-``` console
-interfaces {
-    interface eth0 {
-	    ip {
-		    address 192.168.1.1/24;
-		}
-	}
-    interface eth1 {
-	    ip {
-		    address 10.0.0.1/24;
-		}
-	}
-}
-routing {
-    static {
-        route 0.0.0.0/0 {
-            distance 100;
-            nexthop 192.168.1.254;
-        }
-        route 0.0.0.0/0 {
-            distance 200;
-            nexthop 10.0.0.254;
-        }
+## Floating above a dynamic protocol (distance)
+
+The `distance` leaf sets the route's administrative distance. The RIB
+selects the entry with the lowest distance for each prefix, so the
+distance decides which *protocol* wins. A static route defaults to
+distance **1**, which beats every dynamic protocol — to turn it into a
+backup, raise its distance above the protocol's default:
+
+| Protocol | Default distance |
+|---|---|
+| Static | 1 |
+| OSPF | 110 |
+| IS-IS | 115 |
+| BGP | 200 |
+
+For example, a default route normally learned from the IGP, with a
+static escape hatch toward a fallback gateway that only takes over when
+the IGP route disappears:
+
+```
+router static {
+  ipv4 {
+    route 0.0.0.0/0 {
+      distance 250;
+      nexthop 10.0.0.254;
     }
+  }
 }
 ```
 
-The primary route to the internet is configured with a destination of 0.0.0.0/0
-(default route) and a next-hop of 192.168.1.254, which is the gateway to the
-primary ISP. This route has an administrative distance of 100. The floating
-static route is also configured with a destination of 0.0.0.0/0 (default route)
-and a next-hop of 10.0.0.254, which is the gateway to the backup ISP. This route
-has an administrative distance of 200. The administrative distance of the
-floating static route (200) is higher than the administrative distance of the
-primary route (100). This means that the primary route will be preferred and
-used for forwarding network traffic as long as it is available.
+While OSPF holds a default route (distance 110), the static route at
+distance 250 stays unselected. When the OSPF route is withdrawn, the
+floating static is installed into the kernel FIB; when the OSPF route
+returns, it preempts the static again.
 
-If the primary route becomes unavailable (e.g., the link to the primary ISP
-fails), the router will automatically start using the floating static route with
-the higher administrative distance (200) as the backup path to the internet.
-This ensures that network connectivity is maintained, even in the event of a
-primary route failure.
+## Floating between two static nexthops (per-nexthop metric)
 
-It's important to note that the administrative distance can be adjusted based on
-the specific requirements of your network. A lower administrative distance
-indicates a preferred route, while a higher administrative distance indicates a
-less preferred route.
+The `route` list is keyed by the destination prefix, so the classic
+"configure the same prefix twice at two distances" pattern from other
+CLIs does not apply — there is exactly one static `route` entry per
+prefix. Instead, the primary and backup paths are two `nexthop`
+entries of that one route, distinguished by per-nexthop `metric`.
+
+Consider a router with two uplinks: the primary ISP on eth0 and a
+backup ISP on eth1.
+
+```
+interface eth0 {
+  ipv4 {
+    address 192.168.1.1/24;
+  }
+}
+interface eth1 {
+  ipv4 {
+    address 10.0.0.1/24;
+  }
+}
+router static {
+  ipv4 {
+    route 0.0.0.0/0 {
+      nexthop 192.168.1.254 {
+        metric 100;
+      }
+      nexthop 10.0.0.254 {
+        metric 200;
+      }
+    }
+  }
+}
+```
+
+zebra-rs installs each nexthop as its own kernel route at its own
+metric:
+
+```
+$ ip route show
+default via 192.168.1.254 dev eth0 proto static metric 100
+default via 10.0.0.254 dev eth1 proto static metric 200
+```
+
+The kernel forwards along the lowest-metric route, so traffic uses the
+primary ISP while it is healthy. zebra-rs tracks each nexthop's
+resolvability: when eth0 goes down (or 192.168.1.254 otherwise becomes
+unreachable), the metric-100 route is withdrawn from the FIB and the
+metric-200 route carries the traffic. When the primary link recovers,
+its route is reinstalled and preempts the backup automatically.
+
+Nexthops that share the *same* metric load-balance as ECMP instead —
+metrics separate failover tiers, weights shape the split within a tier
+(see the ECMP section of the [Static Route](ch-01-00-what-is-static-route.md)
+chapter).

--- a/book/src/ch-01-02-recursive-static-route.md
+++ b/book/src/ch-01-02-recursive-static-route.md
@@ -1,62 +1,81 @@
 # Recursive Static Route
 
-Recursive static routes are a type of static routing configuration where the
-next-hop address is not directly connected to the router, but is instead
-resolved through another routing table entry.
+A recursive static route is a static route whose next-hop address is
+not on a directly connected subnet. The configured gateway is instead
+*resolved through the routing table*: zebra-rs looks the gateway up in
+the RIB, finds the route that covers it, and installs the static route
+with that covering route's actual on-link nexthop and egress
+interface.
 
-The purpose of recursive static routes is to simplify the routing configuration
-and provide a more efficient way to reach remote networks. Instead of
-configuring a static route for every possible destination, you can use a
-recursive static route to reach those destinations through an intermediate
-router or gateway.
+In zebra-rs recursion is automatic — there is no `recursive` knob to
+enable. Every static nexthop is resolved through the RIB at
+FIB-install time (the same next-hop tracking machinery the routing
+protocols use), whether the gateway is one hop away or several.
 
-Let's consider a scenario where a router has a direct connection to a local
-network and needs to reach a remote network through an intermediate router.
+## Example
 
-``` console
-interfaces {
-    interface eth0 {
-	    ip {
-		    address 192.168.1.1/24;
-		}
-	}
-    interface eth1 {
-	    ip {
-		    address 10.0.0.1/24;
-		}
-	}
+The router below reaches the remote network 172.16.0.0/16 via the
+gateway 10.1.1.1, but 10.1.1.1 is itself not directly connected — it
+is reachable through the on-link router 10.0.0.254:
+
+```
+interface eth0 {
+  ipv4 {
+    address 10.0.0.1/24;
+  }
 }
-routing {
-    static {
-        route 172.16.0.0/16 {
-            nexthop 10.0.0.254;
-			recursive true;
-        }
+router static {
+  ipv4 {
+    route 10.1.1.1/32 {
+      nexthop 10.0.0.254;
     }
+    route 172.16.0.0/16 {
+      nexthop 10.1.1.1;
+    }
+  }
 }
 ```
 
-In this example:
+When the route to 172.16.0.0/16 is committed, zebra-rs resolves its
+gateway 10.1.1.1 through the RIB: the lookup matches the
+10.1.1.1/32 route, whose nexthop 10.0.0.254 is on-link on eth0. The
+recursive route is installed into the kernel already flattened to the
+resolved adjacency:
 
-The router has a direct connection to the local network 192.168.1.0/24 on the
-Ethernet0/0 interface. The router needs to reach the remote network
-172.16.0.0/16, which is not directly connected. Instead of configuring a static
-route for every possible destination within the 172.16.0.0/16 network, a
-recursive static route is configured. The recursive static route has a
-destination of 172.16.0.0/16 and a next-hop of 10.0.0.254, which is the address
-of the intermediate router. When the router receives a packet destined for the
-172.16.0.0/16 network, it will first look up the recursive static route. The
-router will then use the routing table to determine how to reach the next-hop
-address of 10.0.0.254, which is the intermediate router. The packet will then be
-forwarded to the intermediate router, which will be responsible for forwarding
-the packet to the final destination within the 172.16.0.0/16 network.
+```
+$ ip route show
+10.1.1.1 via 10.0.0.254 dev eth0 proto static
+172.16.0.0/16 via 10.0.0.254 dev eth0 proto static
+```
 
-This approach simplifies the routing configuration and reduces the number of
-static routes that need to be configured on the router. It also allows the
-routing table to be more efficient, as the router only needs to maintain a
-single entry for the remote network instead of multiple entries.
+The resolving route does not have to be another static route — a
+gateway learned from OSPF, IS-IS, or BGP works the same way. When the
+gateway sits behind an SR-MPLS underlay (an IS-IS route carrying a
+prefix-SID, say), the resolution also inherits the underlay's
+transport label stack, so the static route forwards through the
+labeled path rather than as a plain IP hop.
 
-Recursive static routes can be particularly useful in scenarios where the
-network topology is complex, or when the remote networks are subject to frequent
-changes. By using recursive static routes, the router can adapt to these changes
-without requiring extensive modifications to the routing configuration.
+## Tracking topology changes
+
+Resolution is not a one-shot operation. zebra-rs re-resolves static
+nexthops whenever the underlying routes change:
+
+- If the route covering the gateway moves to a different path (a link
+  fails and the IGP reconverges), the static route is reinstalled with
+  the new egress.
+- If the gateway becomes unreachable — no route covers it anymore —
+  the static route is withdrawn from the kernel FIB until the gateway
+  resolves again.
+
+This is what makes recursive static routes useful: you can pin *what*
+the traffic should reach (the remote prefix and its logical gateway)
+while leaving *how to get to the gateway* to the rest of the routing
+table. A single recursive route toward an intermediate router replaces
+per-destination routes, and it adapts to topology changes underneath
+it without any configuration change.
+
+Verify the resolution with a scoped lookup:
+
+```
+show ip route 172.16.0.0/16
+```

--- a/book/src/ch-01-02-recursive-static-route.md
+++ b/book/src/ch-01-02-recursive-static-route.md
@@ -49,11 +49,67 @@ $ ip route show
 ```
 
 The resolving route does not have to be another static route — a
-gateway learned from OSPF, IS-IS, or BGP works the same way. When the
-gateway sits behind an SR-MPLS underlay (an IS-IS route carrying a
-prefix-SID, say), the resolution also inherits the underlay's
-transport label stack, so the static route forwards through the
-labeled path rather than as a plain IP hop.
+gateway learned from OSPF, IS-IS, or BGP works the same way.
+
+## Resolution over an SR-MPLS underlay
+
+When the gateway sits behind an SR-MPLS underlay, resolution inherits
+more than the egress: the static route also picks up the covering
+route's **transport label stack**, so its traffic is label-switched
+through the core rather than forwarded as a plain IP hop.
+
+The [`playset/isis-srmpls`](https://github.com/zebra-rs/zebra-rs/tree/main/playset/isis-srmpls)
+lab is a runnable demonstration (`./up.sh` and walk through its
+README). Its ingress node `s` runs IS-IS with `segment-routing mpls`
+and carries exactly one piece of static configuration — a route to the
+far edge subnet `172.16.1.0/24` (host `e2`, behind node `d`, not part
+of IS-IS at all) via `d`'s loopback:
+
+```yaml
+router:
+  static:
+    ipv4:
+      route:
+      - prefix: 172.16.1.0/24
+        nexthop:
+        - address: 10.0.0.8
+```
+
+`10.0.0.8` is not on any of `s`'s connected subnets. NHT resolves it
+through the IS-IS SR-MPLS route to `10.0.0.8/32`, which carries `d`'s
+Prefix-SID label:
+
+```
+s>show ip route
+...
+L2 *> 10.0.0.8/32 [115/12] via 192.168.0.2, s-n1, label 16800, 00:00:43
+S  *> 172.16.1.0/24 [1/0] via 10.0.0.8 (recursive), 00:00:50
+                          via 192.168.0.2, s-n1, label 16800
+```
+
+The static route displays as the recursive two-liner — the configured
+gateway marked `(recursive)`, and underneath it the resolved nexthop
+with the **inherited label** `16800`. The kernel route carries the
+matching `encap mpls 16800` push, so traffic to the edge subnet is
+label-switched all the way to `d`.
+
+Because the resolution re-runs whenever the covering route changes,
+the static route follows the underlay through IGP reconvergence — the
+playset walks this further: with TI-LFA enabled, promoting the
+repair path (`fast-reroute backup-as-primary`) moves the static route
+onto the full repair label stack with no configuration change.
+
+## Recursive resolution and SRv6
+
+The label inheritance above is an SR-MPLS behavior. Over an **SRv6**
+underlay, recursive resolution still works — the gateway is resolved
+and the route installs with the flattened plain-IPv6 nexthop — but the
+resolution does **not** inherit any SRv6 encapsulation from the
+covering route. When the destination prefix is unknown to the core
+(the usual reason for tunneling), a recursive static route alone will
+not deliver the traffic; steer it into an SRv6 encapsulation
+explicitly with the `segments` leaf instead — see
+[SRv6 Static Routes](ch-01-04-srv6-static-route.md).
 
 ## Tracking topology changes
 

--- a/book/src/ch-01-04-srv6-static-route.md
+++ b/book/src/ch-01-04-srv6-static-route.md
@@ -1,0 +1,182 @@
+# SRv6 Static Routes
+
+Static routes can both *steer traffic into* an SRv6 encapsulation
+(ingress) and *terminate* SRv6 traffic with a local endpoint behavior
+(egress). Together the two sides build a complete SRv6 path out of
+nothing but static configuration — no BGP or IGP signaling of the
+service prefix required.
+
+On the ingress side, the IPv6 `route` entry takes a `segments`
+segment list instead of a nexthop:
+
+```
+router static {
+  ipv6 {
+    route <prefix> {
+      segments <sid> [<sid> ...];   # H.Encap segment list
+      encap-type H.Encap.Red;       # optional; default H.Encap
+    }
+  }
+}
+```
+
+On the egress side, a `route` entry whose prefix *is the SID* takes an
+`action` — the seg6local endpoint behavior installed for that SID:
+
+```
+router static {
+  ipv6 {
+    route <sid>/128 {
+      action End.DT6;     # End | uN | End.DT4/DT6/DT46 | End.DX4/DX6 | End.X | uA
+      vrf <name>;         # for End.DT*: VRF table for the inner lookup
+      nh6 <address>;      # for End.DX6 / End.X / uA: cross-connect adjacency
+      nh4 <address>;      # for End.DX4
+    }
+  }
+}
+```
+
+`End.DT4` / `End.DT6` / `End.DT46` decapsulate the outer IPv6 header
+and look the inner packet up in the VRF named by `vrf` — omit it to
+look up in the default (main) table. The `End.DX*` cross-connect
+variants forward the decapsulated packet straight to the `nh6`/`nh4`
+adjacency instead of doing a lookup (RFC 8986 §4.4/§4.5).
+
+## Worked example
+
+The walkthrough below runs on the
+[`playset/isis-srv6-usid`](https://github.com/zebra-rs/zebra-rs/tree/main/playset/isis-srv6-usid)
+lab (`./up.sh`): an IS-IS SRv6 core between ingress `s` (locator
+`fcbb:bbbb:1::/48`) and egress `d` (locator `fcbb:bbbb:8::/48`), with
+edge hosts `e1` (`2001:db8:100::/64` behind `s`) and `e2`
+(`2001:db8:200::/64` behind `d`). In the lab those edge prefixes are
+carried by BGP over SRv6; here we reach `e2`'s subnet with static
+routes instead — the static route wins the RIB selection over BGP
+(distance 1 vs 200), so the commands below can be applied to the
+running lab as-is.
+
+### Why recursion alone is not enough
+
+A [recursive static route](ch-01-02-recursive-static-route.md) via
+`d`'s loopback resolves fine over the SRv6 core:
+
+```
+s#set router static ipv6 route 2001:db8:200::/64 nexthop 2001:db8::8
+s#commit
+s#exit
+s>show ipv6 route
+...
+S  *> 2001:db8:200::/64 [1/0] via 2001:db8::8 (recursive), 00:00:02
+                              via fe80::f86f:61ff:fecf:b69a, s-n1
+```
+
+But unlike the SR-MPLS case, nothing is inherited from the underlay
+beyond the plain IPv6 nexthop — the packet leaves `s`
+unencapsulated, still addressed to its final destination. The first
+core router has no route for that destination (only `s` and `d` know
+the edge prefixes), so the traffic dies one hop in:
+
+```
+$ sudo ip netns exec e1 ping 2001:db8:200::100
+...
+3 packets transmitted, 0 received, 100% packet loss
+
+n1$ ip -6 route get 2001:db8:200::100
+RTNETLINK answers: Network is unreachable
+```
+
+To tunnel through a core that routes only on locators, the SRv6
+encapsulation must be configured explicitly.
+
+### Egress: pin a static End.DT6 SID on `d`
+
+Give `d` a decapsulation endpoint at an operator-pinned SID under its
+locator (the E064+ function range is reserved for exactly this — see
+[SRv6 SID allocation](ch-04-00-srv6.md)):
+
+```
+d#set router static ipv6 route fcbb:bbbb:8:e064::/128 action End.DT6
+d#commit
+```
+
+zebra-rs installs the SID as a kernel `seg6local` route on the `sr0`
+dummy interface:
+
+```
+d>show ipv6 route
+...
+S  *> fcbb:bbbb:8:e064::/128 [1/0] is directly connected, sr0, seg6local End.DT6, 00:01:58
+
+d$ ip -6 route show | grep e064
+fcbb:bbbb:8:e064::  encap seg6local action End.DT6 table main dev sr0 proto static metric 1024 pref medium
+```
+
+Packets arriving for this SID are decapsulated and the inner IPv6
+destination looked up in the main table — where `e2`'s subnet is a
+connected route.
+
+### Ingress: steer the prefix into the SID on `s`
+
+Replace the plain-nexthop static with a `segments` route pointing at
+the pinned SID:
+
+```
+s#delete router static ipv6 route 2001:db8:200::/64
+s#set router static ipv6 route 2001:db8:200::/64 segments fcbb:bbbb:8:e064::
+s#commit
+s#exit
+s>show ipv6 route
+...
+S  *> 2001:db8:200::/64 [1/0] via seg6 [fcbb:bbbb:8:e064::], s-n1, 00:00:02
+```
+
+The kernel route carries the H.Encap:
+
+```
+s$ ip -6 route show | grep 2001:db8:200
+2001:db8:200::/64 nhid 14  encap seg6 mode encap segs 1 [ fcbb:bbbb:8:e064:: ] via fcbb:bbbb:8:e064:: dev s-n1 proto static metric 1024 onlink pref medium
+```
+
+Note the `via fcbb:bbbb:8:e064:: dev s-n1`: the *first segment* is
+itself resolved recursively — the SID is covered by the IS-IS route to
+`d`'s locator `fcbb:bbbb:8::/48`, and the encapsulated packet follows
+whatever path the IGP currently has for it. The core never sees the
+inner destination, only the locator.
+
+### End-to-end
+
+```
+$ sudo ip netns exec e1 ping 2001:db8:200::100
+...
+3 packets transmitted, 3 received, 0% packet loss
+```
+
+Capturing on core node `n1` shows the outer IPv6 header addressed to
+the SID, the SRH, and the untouched inner packet:
+
+```
+n1>tcpdump -li n1-s ip6 dst net fcbb:bbbb:8::/48
+11:14:17.317221 IP6 2001:db8:0:1::1 > fcbb:bbbb:8:e064::: RT6 (len=2, type=4, segleft=0,
+  last-entry=0, tag=0, [0]fcbb:bbbb:8:e064::) IP6 2001:db8:100::100 > 2001:db8:200::100:
+  ICMP6, echo request, id 59564, seq 1, length 64
+```
+
+`d` decapsulates at the static End.DT6 SID and delivers the inner
+packet to `e2`. The reverse direction can be built the same way — a
+static End.DT6 SID on `s` and a `segments` route on `d` (in the lab,
+the return path is already covered by BGP over SRv6).
+
+## Notes
+
+- With more than one segment, `segments <s1> <s2> ...` installs the
+  full SRH; the default encapsulation is `H.Encap` (RFC 8986 §5.1),
+  so the kernel carries every configured segment. Opt into the
+  SRH-reduced form with `encap-type H.Encap.Red`.
+- `segments` and `nexthop` are alternative forwarding models on the
+  same route; when both are configured, the segment list wins.
+- The `distance` and `metric` leaves work on SRv6-steered routes the
+  same as on ordinary static routes, so an SRv6 path can also serve as
+  a [floating backup](ch-01-01-floating-static-route.md).
+- Static `segments` steering is IPv6-only today. IPv4 service
+  prefixes ride SRv6 through the BGP machinery (L3VPN over SRv6 with
+  `End.DT4`/`End.DT46` SIDs) rather than through static routes.


### PR DESCRIPTION
## Summary

The last piece of the managed-cradle arc (#1879–#1884): a BDD feature driving the supervisor through the real harness (`/usr/bin/zebra-rs` + `/usr/bin/cradle`). The cradle engine binary is a **suite prerequisite** on BDD hosts now — install one-liner documented in the feature header and the Makefile comment (it's installed on this BDD host).

Scenarios (netns pair, config applied at runtime via `vtyctl`):

1. **Managed spawn** — `system ebpf enabled` + `interface eth0 ebpf enabled` → `show ebpf` reports the engine `managed` and the port `attached`; daemon log shows `cradle: engine ready`.
2. **Crash recovery** — `pkill -9 -x cradle` → log shows the exit and `fib: cradle replay:`; `show ebpf` reports `Engine restarts: 1` and the port re-attached.
3. **Disable** — `delete system ebpf enabled true` → `show ebpf` reports `off (system ebpf disabled)`; log shows the graceful engine stop.
4. **Teardown** — stop daemon, delete namespaces, clean-environment assertion.

## Test plan

- `make install` then `make -C bdd cradle_spawn`: **1 feature, 4 scenarios, all passing**.
- `cargo test -p bdd --lib` (tag-prefix guard) green; no Rust source changes (feature + config YAML + Makefile target only).

Generated with [Claude Code](https://claude.com/claude-code)