### PR TITLE
rib: recursive SRv6 segment inheritance in the nexthop resolver

### DIFF
--- a/bdd/Makefile
+++ b/bdd/Makefile
@@ -133,6 +133,10 @@ rib_static_ipv6:
 	mkdir -p allure-results
 	cargo test --test cucumber -- --concurrency=1 --tags "@rib_static_ipv6"
 
+static_srv6_nht:
+	mkdir -p allure-results
+	cargo test --test cucumber -- --concurrency=1 --tags "@static_srv6_nht"
+
 # Run all IS-IS tests.
 isis:
 	rm -rf allure-results
@@ -436,4 +440,4 @@ docs/%.md: tests/features/%.feature docs/feature2md.sh FORCE
 
 FORCE:
 
-.PHONY: ecmp_bfd_evict ospfv2_bfd_frr ospfv3_bfd_frr tilfa_bfd all run ibgp ebgp rr rib_static_ipv6 isis_ipv6 isis_srv6_base isis_fragmentation_ipv6 isis_fragmentation_ipv4 isis_l1p2p isis_tilfa isis_srmpls system_hostname isis_l1l2 isis_redist isis_hello_auth_keychain isis_passive isis_afi_enable isis_endx_ipv6 isis_bfd_ipv6_p2p isis_bfd_ipv6_p2p_echo isis_bfd_ipv6_lan isis_bfd_ipv6_lan_echo isis_bfd_ipv4_p2p isis_bfd_ipv4_p2p_echo isis_bfd_ipv4_lan isis_bfd_ipv4_lan_echo ospf_clear_neighbor ospfv2_nssa_base ospfv2_stub_base ospfv2_tilfa ospfv3_nssa ospfv3_tilfa stamp_te_metric stamp_v6_te_metric bgp_peer_down_cleanup bgp_ipv6_over_v4_session bgp_evpn_capability bgp_vrf_evpn_type5 bgp_evpn_outpolicy_undef bgp_route_map_match bgp_policy_dynamic_update bgp_table_map bgp_v6_table_map bgp_community bgp_neighbor_group bgp_unnumbered_neighbor nd_show cradle_spawn bgp_interas_option_c bgp_interas_option_a bgp_interas_option_b bgp_interas_option_ab bgp_port bgp_ip_transparent bgp_local_as bgp_unknown_attr_transitive bgp_fast_external_failover generate open docs FORCE
+.PHONY: ecmp_bfd_evict ospfv2_bfd_frr ospfv3_bfd_frr tilfa_bfd all run ibgp ebgp rr rib_static_ipv6 static_srv6_nht isis_ipv6 isis_srv6_base isis_fragmentation_ipv6 isis_fragmentation_ipv4 isis_l1p2p isis_tilfa isis_srmpls system_hostname isis_l1l2 isis_redist isis_hello_auth_keychain isis_passive isis_afi_enable isis_endx_ipv6 isis_bfd_ipv6_p2p isis_bfd_ipv6_p2p_echo isis_bfd_ipv6_lan isis_bfd_ipv6_lan_echo isis_bfd_ipv4_p2p isis_bfd_ipv4_p2p_echo isis_bfd_ipv4_lan isis_bfd_ipv4_lan_echo ospf_clear_neighbor ospfv2_nssa_base ospfv2_stub_base ospfv2_tilfa ospfv3_nssa ospfv3_tilfa stamp_te_metric stamp_v6_te_metric bgp_peer_down_cleanup bgp_ipv6_over_v4_session bgp_evpn_capability bgp_vrf_evpn_type5 bgp_evpn_outpolicy_undef bgp_route_map_match bgp_policy_dynamic_update bgp_table_map bgp_v6_table_map bgp_community bgp_neighbor_group bgp_unnumbered_neighbor nd_show cradle_spawn bgp_interas_option_c bgp_interas_option_a bgp_interas_option_b bgp_interas_option_ab bgp_port bgp_ip_transparent bgp_local_as bgp_unknown_attr_transitive bgp_fast_external_failover generate open docs FORCE

--- a/bdd/tests/configs/static_srv6_nht/z1.yaml
+++ b/bdd/tests/configs/static_srv6_nht/z1.yaml
@@ -1,0 +1,54 @@
+# z1 — SRv6 egress (AS 65000). Advertises locator LOC1 and enables
+# `segment-routing srv6 ipv6-unicast`, so redistributed connected
+# prefixes are originated into BGP with an End.DT6 SID carved from
+# LOC1 — deterministically fcbb:bbbb:1:40:: (first carve). Behind i2
+# sits the plain host h1 (3001:db8::1); its subnet rides BGP like any
+# other connected route. The cust0 dummy added by the feature provides
+# the gateway-anchor prefix 2001:db8:cafe::/64 for the static route
+# under test on z3. The static route reaches z3's link subnet through
+# the z2 core for iBGP peering and ping replies.
+interface:
+- if-name: i1
+  ipv6:
+    address: 2001:db8:12::1/64
+- if-name: i2
+  ipv6:
+    address: 3001:db8::2/64
+segment-routing:
+  locator:
+  - name: LOC1
+    prefix: fcbb:bbbb:1::/48
+    behavior: usid
+router:
+  static:
+    ipv6:
+      route:
+      - prefix: 2001:db8:23::/64
+        nexthop:
+        - address: 2001:db8:12::2
+  bgp:
+    global:
+      as: 65000
+      router-id: 10.0.0.1
+    timer:
+      adv-interval:
+        ibgp: 1
+        ebgp: 1
+    segment-routing:
+      srv6:
+        locator: LOC1
+        ipv6-unicast: {}
+    neighbor:
+    - remote-address: 2001:db8:23::3
+      # 3s connect retry: a colliding initial connect under host load
+      # otherwise backs off the default 120s, past the assert budget.
+      timers: {connect-retry-time: 3}
+      remote-as: 65000
+      enabled: true
+      afi-safi:
+      - name: ipv6
+        enabled: true
+    afi-safi:
+    - name: ipv6
+      redistribute:
+        connected: {}

--- a/bdd/tests/configs/static_srv6_nht/z2.yaml
+++ b/bdd/tests/configs/static_srv6_nht/z2.yaml
@@ -1,0 +1,21 @@
+# z2 — transit core. Knows the two link subnets (connected) and z1's
+# SRv6 locator — and deliberately NOTHING else. The service prefixes
+# (2001:db8:cafe::/64, 3001:db8::1) never appear here, so traffic for
+# them can only cross z2 inside an SRv6 encapsulation addressed to the
+# locator. This is what makes the ping assert meaningful: a static
+# route on z3 that failed to inherit the H.Encap would send a plain
+# packet that dies right here.
+interface:
+- if-name: i1
+  ipv6:
+    address: 2001:db8:12::2/64
+- if-name: i2
+  ipv6:
+    address: 2001:db8:23::2/64
+router:
+  static:
+    ipv6:
+      route:
+      - prefix: fcbb:bbbb:1::/48
+        nexthop:
+        - address: 2001:db8:12::1

--- a/bdd/tests/configs/static_srv6_nht/z3.yaml
+++ b/bdd/tests/configs/static_srv6_nht/z3.yaml
@@ -1,0 +1,36 @@
+# z3 — SRv6 ingress (AS 65000). Peers iBGP with z1 across the z2 core
+# with `encapsulation-type srv6`, so z1's redistributed prefixes arrive
+# as SRv6 service routes and install as H.Encaps entries toward the
+# End.DT6 SID. The statics are the underlay stand-in: reach z1's link
+# (peering) and locator (SID resolution + encapped traffic) through z2.
+interface:
+- if-name: i1
+  ipv6:
+    address: 2001:db8:23::3/64
+router:
+  static:
+    ipv6:
+      route:
+      - prefix: 2001:db8:12::/64
+        nexthop:
+        - address: 2001:db8:23::2
+      - prefix: fcbb:bbbb:1::/48
+        nexthop:
+        - address: 2001:db8:23::2
+  bgp:
+    global:
+      as: 65000
+      router-id: 10.0.0.3
+    timer:
+      adv-interval:
+        ibgp: 1
+        ebgp: 1
+    neighbor:
+    - remote-address: 2001:db8:12::1
+      timers: {connect-retry-time: 3}
+      remote-as: 65000
+      enabled: true
+      afi-safi:
+      - name: ipv6
+        enabled: true
+        encapsulation-type: srv6

--- a/bdd/tests/features/static_srv6_nht.feature
+++ b/bdd/tests/features/static_srv6_nht.feature
@@ -1,0 +1,98 @@
+@static_srv6_nht
+Feature: Static route inherits SRv6 segments from its covering route
+  As a network operator
+  I want a static route whose gateway is reachable only through a
+  BGP-over-SRv6 service route to resolve recursively through it and
+  inherit the H.Encap segment list — the SRv6 analog of the SR-MPLS
+  label inheritance in @isis_srmpls.
+
+  Test Topology (three veth pairs, iBGP z1<->z3 across a transit core):
+  ```
+  ┌────┐ eth0 ── i2 ┌────────┐ i1 ──────── i1 ┌────────┐ i2 ─────── i1 ┌────────┐
+  │ h1 │────────────│   z1   │────────────────│   z2   │───────────────│   z3   │
+  └────┘3001:db8::/64 egress │2001:db8:12::/64│  core  │2001:db8:23::/64 ingress│
+   3001:db8::1      │ LOC1   │                │        │               │        │
+                    └────────┘                └────────┘               └────────┘
+   cust0 on z1: 2001:db8:cafe::1/64      z2 knows ONLY the two links
+   (dummy — the gateway anchor)          and z1's locator fcbb:bbbb:1::/48
+  ```
+
+  - z1 advertises locator LOC1 (fcbb:bbbb:1::/48) and redistributes
+    connected into BGP with `segment-routing srv6 ipv6-unicast`, so its
+    prefixes (h1's subnet, the cust0 anchor) carry the End.DT6 SID
+    fcbb:bbbb:1:40::.
+  - z3 receives them over `encapsulation-type srv6` and installs
+    H.Encaps service routes.
+  - The static under test on z3, `3001:db8::1/128 via 2001:db8:cafe::1`,
+    has a gateway covered ONLY by the 2001:db8:cafe::/64 SRv6 route:
+    NHT must resolve through it and inherit that route's segment list.
+    The transit core z2 knows nothing about the service prefixes, so
+    the end-to-end ping to the host h1 behind z1 proves the inherited
+    encapsulation carried the traffic (decap at z1's End.DT6, plain
+    IPv6 delivery to h1).
+  - Deleting the static releases its seg6 nexthop group and forwarding
+    falls back to the BGP /64 covering h1's subnet.
+
+  Config files (in `bdd/tests/configs/static_srv6_nht/`):
+  - z1.yaml, z2.yaml, z3.yaml
+
+  Scenario: Setup topology and converge BGP over SRv6
+    Given a clean test environment
+    When I create namespace "z1"
+    And I create namespace "z2"
+    And I create namespace "z3"
+    And I create namespace "h1"
+    And I connect namespace "z1" interface "i1" to namespace "z2" interface "i1"
+    And I connect namespace "z2" interface "i2" to namespace "z3" interface "i1"
+    And I connect namespace "z1" interface "i2" to namespace "h1" interface "eth0"
+    And I add address "3001:db8::1/64" to interface "eth0" in namespace "h1"
+    And I add route "2001:db8:23::/64" via "3001:db8::2" in namespace "h1"
+    And I start zebra-rs in namespace "z1"
+    And I start zebra-rs in namespace "z2"
+    And I start zebra-rs in namespace "z3"
+    And I apply config "z1.yaml" to namespace "z1"
+    And I apply config "z2.yaml" to namespace "z2"
+    And I apply config "z3.yaml" to namespace "z3"
+    And I create dummy interface "cust0" with address "2001:db8:cafe::1/64" in namespace "z1"
+    And I wait 40 seconds
+    # The covering service route arrived and installed as SRv6 H.Encaps.
+    Then show command "show ipv6 route 2001:db8:cafe::/64" in namespace "z3" should eventually contain "via seg6"
+    And show command "show ipv6 route 2001:db8:cafe::/64" in namespace "z3" should contain "fcbb:bbbb:1:40::"
+
+  Scenario: Static route resolves through the SRv6 route and inherits its segments
+    Given the test topology exists
+    When I apply command "set router static ipv6 route 3001:db8::1/128 nexthop 2001:db8:cafe::1" in namespace "z3"
+    # The gateway is not on-link: NHT resolves it through the SRv6
+    # service route — rendered FRR-style as a recursive two-liner with
+    # the inherited segment list on the resolved line.
+    Then show command "show ipv6 route 3001:db8::1/128" in namespace "z3" should eventually contain "via 2001:db8:cafe::1 (recursive)"
+    # The kernel forwards the static prefix with the inherited H.Encap.
+    And kernel route "3001:db8::1" in namespace "z3" should eventually contain "encap seg6"
+    And kernel route "3001:db8::1" in namespace "z3" should eventually contain "fcbb:bbbb:1:40::"
+    And kernel route "3001:db8::1" in namespace "z3" should eventually contain "proto static"
+    # End-to-end: z2 cannot route the inner destination, so a reply
+    # from h1 proves the packet crossed the core inside the inherited
+    # SRv6 encapsulation and was decapsulated by z1's End.DT6 SID.
+    And ping from "z3" to "3001:db8::1" should succeed
+
+  Scenario: Deleting the static falls back to the covering BGP route
+    Given the test topology exists
+    When I apply command "delete router static ipv6 route 3001:db8::1/128" in namespace "z3"
+    # The /128 leaves the kernel (its seg6 nexthop-group reference is
+    # released); forwarding falls back to the BGP /64 for h1's subnet,
+    # still SRv6-encapsulated.
+    Then kernel route "3001:db8::1" in namespace "z3" should eventually be gone
+    And kernel route "3001:db8::/64" in namespace "z3" should eventually contain "proto bgp"
+    And kernel route "3001:db8::/64" in namespace "z3" should eventually contain "encap seg6"
+    And ping from "z3" to "3001:db8::1" should succeed
+
+  Scenario: Teardown topology
+    Given the test topology exists
+    When I stop zebra-rs in namespace "z1"
+    And I stop zebra-rs in namespace "z2"
+    And I stop zebra-rs in namespace "z3"
+    And I delete namespace "z1"
+    And I delete namespace "z2"
+    And I delete namespace "z3"
+    And I delete namespace "h1"
+    Then the test environment should be clean

--- a/book/src/ch-01-02-recursive-static-route.md
+++ b/book/src/ch-01-02-recursive-static-route.md
@@ -101,14 +101,21 @@ onto the full repair label stack with no configuration change.
 
 ## Recursive resolution and SRv6
 
-The label inheritance above is an SR-MPLS behavior. Over an **SRv6**
-underlay, recursive resolution still works — the gateway is resolved
-and the route installs with the flattened plain-IPv6 nexthop — but the
-resolution does **not** inherit any SRv6 encapsulation from the
-covering route. When the destination prefix is unknown to the core
-(the usual reason for tunneling), a recursive static route alone will
-not deliver the traffic; steer it into an SRv6 encapsulation
-explicitly with the `segments` leaf instead — see
+Resolution inherits SRv6 transport the same way: when the covering
+route carries an H.Encap segment list — a BGP-over-SRv6 service route
+(`encapsulation-type srv6`) — the static route inherits the segment
+list and installs as a seg6-encapsulated kernel route:
+
+```
+S  *> 3001:db8::1/128 [1/0] via 2001:db8:cafe::1 (recursive), 00:00:03
+                            via seg6 [fcbb:bbbb:1:40::], i1
+```
+
+One difference from SR-MPLS is worth knowing: an IGP-SRv6 route to a
+remote loopback is a *plain* IPv6 route (SRv6 encapsulates only where
+a policy or a service SID says so), so resolving through it inherits
+nothing — reaching a destination the core cannot route still needs
+explicit `segments` steering. Both patterns are covered in
 [SRv6 Static Routes](ch-01-04-srv6-static-route.md).
 
 ## Tracking topology changes

--- a/book/src/ch-01-04-srv6-static-route.md
+++ b/book/src/ch-01-04-srv6-static-route.md
@@ -70,11 +70,11 @@ S  *> 2001:db8:200::/64 [1/0] via 2001:db8::8 (recursive), 00:00:02
                               via fe80::f86f:61ff:fecf:b69a, s-n1
 ```
 
-But unlike the SR-MPLS case, nothing is inherited from the underlay
-beyond the plain IPv6 nexthop — the packet leaves `s`
-unencapsulated, still addressed to its final destination. The first
-core router has no route for that destination (only `s` and `d` know
-the edge prefixes), so the traffic dies one hop in:
+But the covering route here — the IGP route to `d`'s loopback — is a
+*plain* IPv6 route, so there is no transport to inherit: the packet
+leaves `s` unencapsulated, still addressed to its final destination.
+The first core router has no route for that destination (only `s` and
+`d` know the edge prefixes), so the traffic dies one hop in:
 
 ```
 $ sudo ip netns exec e1 ping 2001:db8:200::100
@@ -165,6 +165,61 @@ n1>tcpdump -li n1-s ip6 dst net fcbb:bbbb:8::/48
 packet to `e2`. The reverse direction can be built the same way — a
 static End.DT6 SID on `s` and a `segments` route on `d` (in the lab,
 the return path is already covered by BGP over SRv6).
+
+## Inheriting segments from a covering SRv6 route
+
+Explicit `segments` are only needed when nothing in the routing table
+carries the encapsulation already. When the static route's gateway is
+itself covered by an **SRv6-encapsulated route** — a BGP-over-SRv6
+service route learned with `encapsulation-type srv6` — recursive
+resolution inherits that route's segment list, exactly the way an
+SR-MPLS covering route donates its label stack.
+
+Consider an ingress router that learned `2001:db8:cafe::/64` from BGP
+over SRv6 (installed as `via seg6 [fcbb:bbbb:1:40::]`, the egress PE's
+End.DT6 SID), and a static route whose gateway lives inside that
+prefix:
+
+```
+set router static ipv6 route 3001:db8::1/128 nexthop 2001:db8:cafe::1
+```
+
+The gateway is not on-link; NHT resolves it through the BGP route and
+the static comes out carrying the inherited encapsulation:
+
+```
+z3>show ipv6 route 3001:db8::1/128
+S  *> 3001:db8::1/128 [1/0] via 2001:db8:cafe::1 (recursive), 00:00:03
+                            via seg6 [fcbb:bbbb:1:40::], i1
+
+z3$ ip -6 route show 3001:db8::1
+3001:db8::1 nhid 2  encap seg6 mode encap segs 1 [ fcbb:bbbb:1:40:: ] via fcbb:bbbb:1:: dev i1 proto static metric 1024 onlink pref medium
+```
+
+The kernel nexthop is shared with the covering BGP route (same
+`nhid`) — the nexthop group dedupes on the segment list. Traffic to
+the static prefix is encapsulated to the egress PE, decapsulated by
+its End.DT6 SID, and routed onward there — so, as with recursive
+SR-MPLS statics, the egress node must know the inner prefix. The
+resolution is tracked: if the covering BGP route moves or is
+withdrawn, the static is re-resolved or pulled from the FIB, and
+deleting the static releases its shared seg6 nexthop group.
+
+Two boundaries of the inheritance are worth knowing:
+
+- Plain IGP-SRv6 routes (a remote loopback reachable natively) carry
+  no encapsulation, so there is nothing to inherit — that is the
+  explicit-`segments` case above.
+- A resolution chain that would need *both* an MPLS label stack and an
+  SRv6 segment list (mixed transport) does not resolve: a kernel
+  nexthop carries at most one encapsulation, so the route is withheld
+  rather than installed half-encapsulated.
+
+The BDD feature `static_srv6_nht` runs this end to end: a three-router
+line where only the ingress and egress speak BGP, the middle router
+knows nothing but locators, and the ping to a host behind the egress
+succeeds only because the inherited encapsulation tunnels the packet
+across the core.
 
 ## Notes
 

--- a/zebra-rs/src/bgp/nht.rs
+++ b/zebra-rs/src/bgp/nht.rs
@@ -231,6 +231,8 @@ mod tests {
                 addr: "172.16.0.2".parse().unwrap(),
                 ifindex: 3,
                 labels,
+                segs: vec![],
+                seg_encap: None,
             }],
         }
     }

--- a/zebra-rs/src/bgp/route.rs
+++ b/zebra-rs/src/bgp/route.rs
@@ -19681,6 +19681,8 @@ mod tests {
             addr: "172.16.0.2".parse().unwrap(),
             ifindex: 5,
             labels: vec![16800],
+            segs: vec![],
+            seg_encap: None,
         }];
         let entry = super::select_fib_entry_v4(&rib, Some(&transport)).expect("labelled");
         match entry.nexthop {
@@ -19707,6 +19709,8 @@ mod tests {
             addr: "172.16.0.2".parse().unwrap(),
             ifindex: 5,
             labels: vec![16800],
+            segs: vec![],
+            seg_encap: None,
         }];
         let entry = super::select_fib_entry_v4(&rib, Some(&transport)).expect("plain");
         match entry.nexthop {
@@ -19768,6 +19772,8 @@ mod tests {
             addr: "fe80::1".parse().unwrap(),
             ifindex: 7,
             labels: vec![],
+            segs: vec![],
+            seg_encap: None,
         }];
         let entry = super::build_srv6_vpn_fib_entry(sid, &transport).expect("srv6 entry");
         match entry.nexthop {
@@ -19812,6 +19818,8 @@ mod tests {
             addr: "fe80::1".parse().unwrap(),
             ifindex: 7,
             labels: vec![],
+            segs: vec![],
+            seg_encap: None,
         }];
         let entry = super::select_fib_entry_v4(&rib, Some(&transport)).expect("srv6 entry");
         match entry.nexthop {
@@ -19832,6 +19840,8 @@ mod tests {
             addr: "172.16.0.2".parse().unwrap(),
             ifindex: 5,
             labels: vec![16800],
+            segs: vec![],
+            seg_encap: None,
         }];
         let entry = super::build_vpn_fib_entry(24001, &transport).expect("installable");
         assert_eq!(entry.distance, 200, "imported VPN routes arrive via iBGP");
@@ -19853,6 +19863,8 @@ mod tests {
             addr: "172.16.0.2".parse().unwrap(),
             ifindex: 5,
             labels: vec![],
+            segs: vec![],
+            seg_encap: None,
         }];
         let entry = super::build_vpn_fib_entry(24001, &transport).expect("installable");
         match entry.nexthop {
@@ -19870,11 +19882,15 @@ mod tests {
                 addr: "172.16.0.2".parse().unwrap(),
                 ifindex: 5,
                 labels: vec![16800],
+                segs: vec![],
+                seg_encap: None,
             },
             ResolvedNexthop {
                 addr: "172.16.1.2".parse().unwrap(),
                 ifindex: 6,
                 labels: vec![16801],
+                segs: vec![],
+                seg_encap: None,
             },
         ];
         let entry = super::build_vpn_fib_entry(24001, &transport).expect("installable");
@@ -19895,6 +19911,8 @@ mod tests {
             addr: "2001:db8::2".parse().unwrap(),
             ifindex: 7,
             labels: vec![16900],
+            segs: vec![],
+            seg_encap: None,
         }];
         let entry = super::build_vpn_fib_entry(24002, &transport).expect("installable");
         match entry.nexthop {
@@ -20095,6 +20113,8 @@ mod tests {
             addr: "fe80::1".parse().unwrap(),
             ifindex: 7,
             labels: vec![],
+            segs: vec![],
+            seg_encap: None,
         }];
         let entry = super::build_srv6_vpn_fib_entry(sid, &transport).expect("installable");
         assert_eq!(entry.distance, 200, "imported VPN routes arrive via iBGP");

--- a/zebra-rs/src/bgp/vrf/inst.rs
+++ b/zebra-rs/src/bgp/vrf/inst.rs
@@ -2466,6 +2466,8 @@ mod tests {
                 addr: IpAddr::V4(Ipv4Addr::new(10, 0, 99, 1)),
                 ifindex: 7,
                 labels: Vec::new(),
+                segs: vec![],
+                seg_encap: None,
             }],
         );
 

--- a/zebra-rs/src/rib/nht.rs
+++ b/zebra-rs/src/rib/nht.rs
@@ -34,6 +34,7 @@ use std::collections::{BTreeSet, HashMap};
 use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
 
 use ipnet::{Ipv4Net, Ipv6Net};
+use isis_packet::srv6::EncapType;
 use prefix_trie::PrefixMap;
 
 use super::Nexthop;
@@ -46,13 +47,79 @@ use super::types::RibType;
 /// per-branch visited-set lands. Matches `resolve.rs`'s default.
 const RESOLVE_DEPTH: u8 = 4;
 
-/// One resolved egress for a tracked nexthop. `labels` is the
-/// transport label stack to push (empty for plain IP forwarding).
+/// One resolved egress for a tracked nexthop. `labels` is the MPLS
+/// transport label stack to push and `segs` the SRv6 H.Encap segment
+/// list to encapsulate with (both empty for plain IP forwarding; never
+/// both non-empty — a mixed-transport chain does not resolve).
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ResolvedNexthop {
     pub addr: IpAddr,
     pub ifindex: u32,
     pub labels: Vec<u32>,
+    /// SRv6 segment list inherited from the covering route(s), in SRH
+    /// visit order (`segs[0]` is the outer destination).
+    pub segs: Vec<Ipv6Addr>,
+    /// Encap flavor for `segs` (H.Encap / H.Encap.Red). None when
+    /// `segs` is empty.
+    pub seg_encap: Option<EncapType>,
+}
+
+/// Transport state gathered from the covering routes above the current
+/// recursion level: the MPLS label stack and/or SRv6 segment list a
+/// packet must carry once the on-link egress is found.
+#[derive(Clone, Default)]
+struct Transport {
+    labels: Vec<u32>,
+    segs: Vec<Ipv6Addr>,
+    seg_encap: Option<EncapType>,
+}
+
+impl Transport {
+    /// Fold one covering route's nexthop into the accumulated
+    /// transport before descending (or emitting).
+    ///
+    /// MPLS labels append (the historical order; in practice only one
+    /// recursion level carries labels). SRv6 segments *prepend*: this
+    /// level's segments are the transport used to reach everything
+    /// accumulated so far, and SRH visit order is `segs[0]` outward —
+    /// so the deeper level's segments must come first. The encap
+    /// flavor keeps the shallowest (service-route) choice when levels
+    /// disagree.
+    fn fold(&self, uni: &NexthopUni) -> Transport {
+        let mut next = self.clone();
+        next.labels.extend_from_slice(&uni_transport_labels(uni));
+        if !uni.segs.is_empty() {
+            let mut segs = uni.segs.clone();
+            segs.extend_from_slice(&next.segs);
+            next.segs = segs;
+            next.seg_encap = self.seg_encap.or(uni.encap_type);
+        }
+        next
+    }
+
+    /// A kernel nexthop carries at most one lwtunnel encap, so a chain
+    /// that accumulates both MPLS labels and SRv6 segments cannot be
+    /// installed — refuse the egress instead of programming garbage.
+    fn mixed(&self) -> bool {
+        !self.labels.is_empty() && !self.segs.is_empty()
+    }
+
+    fn egress(&self, addr: IpAddr, ifindex: u32) -> Option<ResolvedNexthop> {
+        if self.mixed() {
+            return None;
+        }
+        Some(ResolvedNexthop {
+            addr,
+            ifindex,
+            labels: self.labels.clone(),
+            segs: self.segs.clone(),
+            seg_encap: if self.segs.is_empty() {
+                None
+            } else {
+                self.seg_encap
+            },
+        })
+    }
 }
 
 /// The result of resolving a tracked nexthop against the RIB.
@@ -68,7 +135,13 @@ pub struct NexthopResolution {
 /// Resolve an IPv4 nexthop against the global IPv4 table.
 pub fn resolve_v4(table: &PrefixMap<Ipv4Net, RibEntries>, target: Ipv4Addr) -> NexthopResolution {
     let mut nexthops = Vec::new();
-    let metric = resolve_v4_inner(table, target, RESOLVE_DEPTH, &[], &mut nexthops);
+    let metric = resolve_v4_inner(
+        table,
+        target,
+        RESOLVE_DEPTH,
+        &Transport::default(),
+        &mut nexthops,
+    );
     NexthopResolution {
         reachable: !nexthops.is_empty(),
         metric: metric.unwrap_or(0),
@@ -79,7 +152,13 @@ pub fn resolve_v4(table: &PrefixMap<Ipv4Net, RibEntries>, target: Ipv4Addr) -> N
 /// Resolve an IPv6 nexthop against the global IPv6 table.
 pub fn resolve_v6(table: &PrefixMap<Ipv6Net, RibEntries>, target: Ipv6Addr) -> NexthopResolution {
     let mut nexthops = Vec::new();
-    let metric = resolve_v6_inner(table, target, RESOLVE_DEPTH, &[], &mut nexthops);
+    let metric = resolve_v6_inner(
+        table,
+        target,
+        RESOLVE_DEPTH,
+        &Transport::default(),
+        &mut nexthops,
+    );
     NexthopResolution {
         reachable: !nexthops.is_empty(),
         metric: metric.unwrap_or(0),
@@ -94,7 +173,7 @@ fn resolve_v4_inner(
     table: &PrefixMap<Ipv4Net, RibEntries>,
     target: Ipv4Addr,
     depth: u8,
-    accum: &[u32],
+    accum: &Transport,
     out: &mut Vec<ResolvedNexthop>,
 ) -> Option<u32> {
     if depth == 0 {
@@ -111,28 +190,20 @@ fn resolve_v4_inner(
     // Connected: `target` is directly on-link via this entry.
     if entry.is_connected() {
         if entry.ifindex != 0 {
-            out.push(ResolvedNexthop {
-                addr: IpAddr::V4(target),
-                ifindex: entry.ifindex,
-                labels: accum.to_vec(),
-            });
+            out.extend(accum.egress(IpAddr::V4(target), entry.ifindex));
         }
         return Some(entry.metric);
     }
     // Protocol route: resolve each (ECMP) nexthop, accumulating
-    // labels and recursing on not-yet-on-link addresses.
+    // transport (MPLS labels / SRv6 segments) and recursing on
+    // not-yet-on-link addresses.
     for uni in entry_unis(&entry.nexthop) {
-        let mut labels = accum.to_vec();
-        labels.extend_from_slice(&uni_transport_labels(uni));
+        let transport = accum.fold(uni);
         match uni.ifindex() {
-            Some(ifindex) => out.push(ResolvedNexthop {
-                addr: uni.addr,
-                ifindex,
-                labels,
-            }),
+            Some(ifindex) => out.extend(transport.egress(uni.addr, ifindex)),
             None => {
                 if let IpAddr::V4(next) = uni.addr {
-                    resolve_v4_inner(table, next, depth - 1, &labels, out);
+                    resolve_v4_inner(table, next, depth - 1, &transport, out);
                 }
             }
         }
@@ -144,7 +215,7 @@ fn resolve_v6_inner(
     table: &PrefixMap<Ipv6Net, RibEntries>,
     target: Ipv6Addr,
     depth: u8,
-    accum: &[u32],
+    accum: &Transport,
     out: &mut Vec<ResolvedNexthop>,
 ) -> Option<u32> {
     if depth == 0 {
@@ -159,26 +230,17 @@ fn resolve_v6_inner(
     let entry = nht_best_entry(entries)?;
     if entry.is_connected() {
         if entry.ifindex != 0 {
-            out.push(ResolvedNexthop {
-                addr: IpAddr::V6(target),
-                ifindex: entry.ifindex,
-                labels: accum.to_vec(),
-            });
+            out.extend(accum.egress(IpAddr::V6(target), entry.ifindex));
         }
         return Some(entry.metric);
     }
     for uni in entry_unis(&entry.nexthop) {
-        let mut labels = accum.to_vec();
-        labels.extend_from_slice(&uni_transport_labels(uni));
+        let transport = accum.fold(uni);
         match uni.ifindex() {
-            Some(ifindex) => out.push(ResolvedNexthop {
-                addr: uni.addr,
-                ifindex,
-                labels,
-            }),
+            Some(ifindex) => out.extend(transport.egress(uni.addr, ifindex)),
             None => {
                 if let IpAddr::V6(next) = uni.addr {
-                    resolve_v6_inner(table, next, depth - 1, &labels, out);
+                    resolve_v6_inner(table, next, depth - 1, &transport, out);
                 }
             }
         }
@@ -499,6 +561,157 @@ mod tests {
         );
         assert_eq!(after.nexthops[0].labels, vec![16500, 15003, 15002]);
         assert_ne!(before, after);
+    }
+
+    fn table6(rows: Vec<(&str, RibEntry)>) -> PrefixMap<Ipv6Net, RibEntries> {
+        let mut t: PrefixMap<Ipv6Net, RibEntries> = PrefixMap::new();
+        for (p, e) in rows {
+            t.insert(p.parse().unwrap(), vec![e]);
+        }
+        t
+    }
+
+    // A BGP-over-SRv6 service route: the nexthop is the remote SID with
+    // an H.Encap segment list (the shape `encapsulation-type srv6`
+    // installs). `ifindex` None models a not-yet-flattened nexthop that
+    // needs another recursion level.
+    fn bgp_srv6_via(sid: &str, ifindex: Option<u32>) -> RibEntry {
+        let mut e = RibEntry::new(RibType::Bgp);
+        e.valid = true;
+        e.distance = 200;
+        let uni = NexthopUni {
+            addr: sid.parse::<IpAddr>().unwrap(),
+            segs: vec![sid.parse().unwrap()],
+            encap_type: Some(EncapType::HEncap),
+            ifindex_origin: ifindex,
+            valid: true,
+            ..Default::default()
+        };
+        e.nexthop = Nexthop::Uni(uni);
+        e
+    }
+
+    fn static6_via(addr: &str, ifindex: Option<u32>) -> RibEntry {
+        let mut e = RibEntry::new(RibType::Static);
+        e.valid = true;
+        e.metric = 5;
+        let mut uni = NexthopUni::new(addr.parse::<IpAddr>().unwrap(), 0, vec![]);
+        uni.ifindex_origin = ifindex;
+        e.nexthop = Nexthop::Uni(uni);
+        e
+    }
+
+    #[test]
+    fn srv6_segs_inherited_from_covering_route() {
+        // Gateway 2001:db8:200::1 is covered by a BGP-over-SRv6 route
+        // whose nexthop carries an H.Encap segment list — the resolved
+        // egress must inherit it.
+        let sid = "fcbb:bbbb:3:40::";
+        let t = table6(vec![("2001:db8:200::/64", bgp_srv6_via(sid, Some(2)))]);
+        let r = resolve_v6(&t, "2001:db8:200::1".parse().unwrap());
+        assert!(r.reachable);
+        assert_eq!(r.nexthops.len(), 1);
+        assert_eq!(r.nexthops[0].addr, sid.parse::<IpAddr>().unwrap());
+        assert_eq!(r.nexthops[0].ifindex, 2);
+        assert_eq!(r.nexthops[0].segs, vec![sid.parse::<Ipv6Addr>().unwrap()]);
+        assert_eq!(r.nexthops[0].seg_encap, Some(EncapType::HEncap));
+        assert!(r.nexthops[0].labels.is_empty());
+    }
+
+    #[test]
+    fn srv6_segs_survive_deeper_recursion() {
+        // The SRv6 route's SID nexthop is itself not flattened: the SID
+        // resolves through a plain route to the locator prefix. The
+        // final egress is the locator route's gateway, still carrying
+        // the inherited segment list.
+        let sid = "fcbb:bbbb:3:40::";
+        let t = table6(vec![
+            ("2001:db8:200::/64", bgp_srv6_via(sid, None)),
+            ("fcbb:bbbb:3::/48", static6_via("2001:db8:12::2", Some(5))),
+        ]);
+        let r = resolve_v6(&t, "2001:db8:200::1".parse().unwrap());
+        assert!(r.reachable);
+        assert_eq!(r.nexthops.len(), 1);
+        assert_eq!(
+            r.nexthops[0].addr,
+            "2001:db8:12::2".parse::<IpAddr>().unwrap()
+        );
+        assert_eq!(r.nexthops[0].ifindex, 5);
+        assert_eq!(r.nexthops[0].segs, vec![sid.parse::<Ipv6Addr>().unwrap()]);
+        assert_eq!(r.nexthops[0].seg_encap, Some(EncapType::HEncap));
+    }
+
+    #[test]
+    fn srv6_multi_level_segments_prepend_deeper_transport() {
+        // Two SRv6 levels compose into one SRH: the deeper level's
+        // segments are the transport used to reach the shallower
+        // level's first segment, so they are visited first.
+        let outer_sid = "fcbb:bbbb:2:40::";
+        let inner_sid = "fcbb:bbbb:3:40::";
+        let t = table6(vec![
+            ("2001:db8:200::/64", bgp_srv6_via(inner_sid, None)),
+            ("fcbb:bbbb:3::/48", bgp_srv6_via(outer_sid, Some(5))),
+        ]);
+        let r = resolve_v6(&t, "2001:db8:200::1".parse().unwrap());
+        assert!(r.reachable);
+        assert_eq!(
+            r.nexthops[0].segs,
+            vec![
+                outer_sid.parse::<Ipv6Addr>().unwrap(),
+                inner_sid.parse::<Ipv6Addr>().unwrap(),
+            ]
+        );
+    }
+
+    #[test]
+    fn mixed_label_and_seg_transport_is_refused() {
+        // An SRv6 service route whose SID resolves through an SR-MPLS
+        // labeled path would need both a seg6 encap and a label push on
+        // one kernel nexthop — impossible; the chain must not resolve.
+        let sid = "fcbb:bbbb:3:40::";
+        let mut labeled = RibEntry::new(RibType::Isis);
+        labeled.valid = true;
+        labeled.distance = 115;
+        let mut uni = NexthopUni::new(
+            "2001:db8:12::2".parse::<IpAddr>().unwrap(),
+            13,
+            vec![Label::Explicit(16600)],
+        );
+        uni.ifindex_origin = Some(11);
+        labeled.nexthop = Nexthop::Uni(uni);
+
+        let t = table6(vec![
+            ("2001:db8:200::/64", bgp_srv6_via(sid, None)),
+            ("fcbb:bbbb:3::/48", labeled),
+        ]);
+        let r = resolve_v6(&t, "2001:db8:200::1".parse().unwrap());
+        assert!(!r.reachable);
+        assert!(r.nexthops.is_empty());
+    }
+
+    #[test]
+    fn srv6_segs_inherited_v4_service_route() {
+        // IPv4-over-SRv6 (RFC 8950-style): a v4 service route whose
+        // nexthop is a v6 SID with segments. The v4 resolver inherits
+        // the segment list the same way.
+        let sid = "fcbb:bbbb:3:40::";
+        let mut e = RibEntry::new(RibType::Bgp);
+        e.valid = true;
+        e.distance = 200;
+        let uni = NexthopUni {
+            addr: sid.parse::<IpAddr>().unwrap(),
+            segs: vec![sid.parse().unwrap()],
+            encap_type: Some(EncapType::HEncap),
+            ifindex_origin: Some(2),
+            valid: true,
+            ..Default::default()
+        };
+        e.nexthop = Nexthop::Uni(uni);
+        let t = table(vec![("10.2.0.0/24", e)]);
+        let r = resolve_v4(&t, "10.2.0.1".parse().unwrap());
+        assert!(r.reachable);
+        assert_eq!(r.nexthops[0].segs, vec![sid.parse::<Ipv6Addr>().unwrap()]);
+        assert_eq!(r.nexthops[0].seg_encap, Some(EncapType::HEncap));
     }
 
     #[test]

--- a/zebra-rs/src/rib/resolve.rs
+++ b/zebra-rs/src/rib/resolve.rs
@@ -108,18 +108,33 @@ fn entry_has_mpls(entry: &RibEntry) -> bool {
     }
 }
 
+// Whether `entry`'s nexthop carries an SRv6 H.Encap segment list — i.e. it
+// is a BGP-over-SRv6 service route (`encapsulation-type srv6`). Like an LU
+// label stack, the encapsulation makes the route legitimate transport for
+// recursive resolution: dependents inherit the segment list instead of
+// resolving over plain BGP.
+fn entry_has_segs(entry: &RibEntry) -> bool {
+    match &entry.nexthop {
+        Nexthop::Uni(uni) => !uni.segs.is_empty(),
+        Nexthop::Multi(multi) => multi.nexthops.iter().any(|u| !u.segs.is_empty()),
+        _ => false,
+    }
+}
+
 // Whether an entry is allowed to act as a resolver target during recursive
 // nexthop lookup. Connected and IGP routes are always trusted; static is
 // trusted up to the depth cap. Plain BGP unicast is excluded — BGP
 // next-hops should resolve over the underlay (IGP / connected), not over
-// BGP itself, and allowing it would risk recursive loops. The one BGP
-// exception is a *labeled* (BGP Labeled-Unicast, SAFI 4) route: Inter-AS
-// MPLS/VPN Option C (RFC 4364 §10c) resolves a VPN next-hop — the remote
-// PE loopback — over the BGP-LU LSP that carries it across the AS boundary,
-// stacking the LU + transport labels under the VPN service label. The
-// recursion depth cap still bounds any loop. The validity check skips
-// entries that are still in the table but no longer reachable — e.g. an
-// IS-IS route whose group went invalid because its egress link is down.
+// BGP itself, and allowing it would risk recursive loops. The BGP
+// exceptions are *tunneled* routes, which provide their own transport:
+// a labeled (BGP Labeled-Unicast, SAFI 4) route — Inter-AS MPLS/VPN
+// Option C (RFC 4364 §10c) resolves a VPN next-hop over the BGP-LU LSP,
+// stacking the LU + transport labels under the VPN service label — and
+// an SRv6-encapsulated route (`encapsulation-type srv6`), whose H.Encap
+// segment list dependents inherit the same way. The recursion depth cap
+// still bounds any loop. The validity check skips entries that are still
+// in the table but no longer reachable — e.g. an IS-IS route whose group
+// went invalid because its egress link is down.
 // Without this filter a recursive static would resolve through the dead
 // route and look reachable when it isn't.
 pub(crate) fn entry_resolvable(entry: &RibEntry) -> bool {
@@ -127,7 +142,7 @@ pub(crate) fn entry_resolvable(entry: &RibEntry) -> bool {
         && (matches!(
             entry.rtype,
             RibType::Connected | RibType::Static | RibType::Ospf | RibType::Isis
-        ) || (entry.rtype == RibType::Bgp && entry_has_mpls(entry)))
+        ) || (entry.rtype == RibType::Bgp && (entry_has_mpls(entry) || entry_has_segs(entry))))
 }
 
 pub fn rib_resolve(

--- a/zebra-rs/src/rib/route.rs
+++ b/zebra-rs/src/rib/route.rs
@@ -1129,7 +1129,7 @@ impl Rib {
 
 /// Re-resolve one recursive static nexthop. Returns `true` when the
 /// resolution moved — a different egress gateway, transport label
-/// stack, or nexthop group than before.
+/// stack, SRv6 segment list, or nexthop group than before.
 fn static_reresolve_uni_v4(
     uni: &mut NexthopUni,
     nmap: &mut NexthopMap,
@@ -1139,10 +1139,10 @@ fn static_reresolve_uni_v4(
     if uni.addr_origin.is_none() {
         return false;
     }
-    let before = (uni.gid, uni.addr, uni.mpls_label.clone());
+    let before = (uni.gid, uni.addr, uni.mpls_label.clone(), uni.segs.clone());
     super::r#static::resolve::release_nexthop_gid(uni, nmap);
     let _ = resolve_nexthop_uni(uni, nmap, table, table_id);
-    before != (uni.gid, uni.addr, uni.mpls_label.clone())
+    before != (uni.gid, uni.addr, uni.mpls_label.clone(), uni.segs.clone())
 }
 
 fn static_reresolve_entry_v4(
@@ -1204,10 +1204,10 @@ fn static_reresolve_uni_v6(
     if uni.addr_origin.is_none() {
         return false;
     }
-    let before = (uni.gid, uni.addr, uni.mpls_label.clone());
+    let before = (uni.gid, uni.addr, uni.mpls_label.clone(), uni.segs.clone());
     super::r#static::resolve::release_nexthop_gid(uni, nmap);
     let _ = resolve_nexthop_uni_v6(uni, nmap, table, table_id);
-    before != (uni.gid, uni.addr, uni.mpls_label.clone())
+    before != (uni.gid, uni.addr, uni.mpls_label.clone(), uni.segs.clone())
 }
 
 fn static_reresolve_entry_v6(

--- a/zebra-rs/src/rib/show.rs
+++ b/zebra-rs/src/rib/show.rs
@@ -92,17 +92,23 @@ fn via_addr(uni: &NexthopUni) -> String {
 // A recursively-resolved nexthop: NHT rewrote the configured gateway
 // (`addr_origin`, e.g. a static route's `via 10.0.0.8`) to an on-link
 // egress that differs from it. Only static routes populate
-// `addr_origin`, so this is exactly the recursive-static case.
+// `addr_origin`, so this is exactly the recursive-static case. A
+// non-empty `segs` on such a nexthop is SRv6 transport *inherited*
+// from the covering route (explicit `segments` routes never set
+// `addr_origin`, so they keep the single-line seg6 rendering).
 fn uni_is_recursive(uni: &NexthopUni) -> bool {
-    uni.segs.is_empty() && uni.addr_origin.is_some_and(|origin| origin != uni.addr)
+    uni.addr_origin.is_some_and(|origin| origin != uni.addr)
 }
 
 // Render a recursive nexthop as two lines, FRR-style: the configured
 // gateway tagged `(recursive)`, then the resolved egress with its
-// inherited transport label stack underneath:
+// inherited transport (MPLS label stack or SRv6 segment list)
+// underneath:
 //
 //   S  *> 172.168.1.0/24 [1/0] via 10.0.0.8 (recursive), 00:00:12
 //                        via 192.168.10.2, s-n1, label 16800
+//   S  *> 3001:db8::1/128 [1/0] via 2001:db8:200::1 (recursive), 00:00:12
+//                         via seg6 [fcbb:bbbb:3:40::], z1-z2
 fn write_uni_recursive(
     buf: &mut String,
     uni: &NexthopUni,
@@ -112,8 +118,13 @@ fn write_uni_recursive(
 ) {
     writeln!(buf, " via {} (recursive), {}", uni.display_addr(), uptime).unwrap();
     buf.push_str(&" ".repeat(offset));
-    write!(buf, " via {}, {}", uni.addr, ifname).unwrap();
-    write_mpls_labels(buf, uni);
+    if uni.segs.is_empty() {
+        write!(buf, " via {}, {}", uni.addr, ifname).unwrap();
+        write_mpls_labels(buf, uni);
+    } else {
+        let parts: Vec<String> = uni.segs.iter().map(|s| s.to_string()).collect();
+        write!(buf, " via seg6 [{}], {}", parts.join(", "), ifname).unwrap();
+    }
     buf.push('\n');
 }
 

--- a/zebra-rs/src/rib/static/resolve.rs
+++ b/zebra-rs/src/rib/static/resolve.rs
@@ -1,13 +1,16 @@
 //! Recursive nexthop resolution for static routes (NHT).
 //!
 //! A static route configured as `via 10.0.0.1` must forward through the
-//! underlay's SR-MPLS transport label stack, not as a plain IP nexthop to
-//! the remote loopback. BGP already solves this via `rib::nht`; static
+//! underlay's transport — the SR-MPLS label stack, or the SRv6 H.Encap
+//! segment list when the covering route is SRv6-encapsulated (e.g. a
+//! BGP-over-SRv6 service route) — not as a plain IP nexthop to the
+//! remote address. BGP already solves this via `rib::nht`; static
 //! applies the same resolver at FIB-install time.
 
 use std::net::IpAddr;
 
 use ipnet::{Ipv4Net, Ipv6Net};
+use isis_packet::srv6::EncapType;
 use prefix_trie::PrefixMap;
 
 use crate::rib::entry::RibEntries;
@@ -61,6 +64,14 @@ fn apply_resolved(uni: &mut NexthopUni, egresses: &[ResolvedNexthop]) -> bool {
     uni.addr = egress.addr;
     uni.mpls_label = egress.labels.clone();
     uni.mpls = egress.labels.iter().copied().map(Label::Explicit).collect();
+    // SRv6 transport inherited from the covering route (a BGP-over-SRv6
+    // service route, an SRv6 TI-LFA promoted repair, ...). Mirrors the
+    // explicit `route <prefix> segments ...` shape — the nexthop group
+    // installs the same seg6 H.Encap — with the H.Encap default applied
+    // here the same way `StaticRoute::to_entry` applies it.
+    uni.segs = egress.segs.clone();
+    uni.encap_type =
+        (!egress.segs.is_empty()).then(|| egress.seg_encap.unwrap_or(EncapType::HEncap));
     uni.ifindex_origin = (egress.ifindex != 0).then_some(egress.ifindex);
     uni.ifindex_resolved = None;
     true
@@ -118,5 +129,43 @@ mod tests {
             ..Default::default()
         };
         assert!(!apply_nht_v4(&mut uni, &table));
+    }
+
+    #[test]
+    fn static_gateway_inherits_srv6_segs() {
+        use std::net::Ipv6Addr;
+
+        // The gateway is covered by a BGP-over-SRv6 service route; the
+        // static nexthop must come out shaped like an explicit
+        // `segments` route — SID address, inherited segment list, and
+        // the H.Encap default.
+        let sid: Ipv6Addr = "fcbb:bbbb:3:40::".parse().unwrap();
+        let mut e = RibEntry::new(RibType::Bgp);
+        e.valid = true;
+        e.nexthop = Nexthop::Uni(NexthopUni {
+            addr: IpAddr::V6(sid),
+            segs: vec![sid],
+            encap_type: Some(EncapType::HEncap),
+            ifindex_origin: Some(2),
+            valid: true,
+            ..Default::default()
+        });
+        let mut table: PrefixMap<Ipv6Net, RibEntries> = PrefixMap::new();
+        table.insert("2001:db8:200::/64".parse().unwrap(), vec![e]);
+
+        let gw: IpAddr = "2001:db8:200::1".parse().unwrap();
+        let mut uni = NexthopUni {
+            addr: gw,
+            addr_origin: Some(gw),
+            ..Default::default()
+        };
+        assert!(apply_nht_v6(&mut uni, &table));
+        assert_eq!(uni.addr, IpAddr::V6(sid));
+        assert_eq!(uni.segs, vec![sid]);
+        assert_eq!(uni.encap_type, Some(EncapType::HEncap));
+        assert_eq!(uni.ifindex_origin, Some(2));
+        assert!(uni.mpls_label.is_empty());
+        // The configured gateway is preserved for display.
+        assert_eq!(uni.display_addr(), gw);
     }
 }


### PR DESCRIPTION
## Summary

A static route whose gateway is covered by an SRv6-encapsulated route (a BGP-over-SRv6 service route, `encapsulation-type srv6`) previously resolved to a plain IPv6 nexthop — the covering route's H.Encap segment list was dropped, so traffic left unencapsulated and died in a core that routes only on locators. SR-MPLS label stacks were already inherited by recursive resolution; this brings SRv6 to parity.

- **nht**: `ResolvedNexthop` grows `segs` + `seg_encap`; recursion accumulates transport in a `Transport` struct. Segments prepend (deeper level = visited first, SRH order). A chain that would need both MPLS labels and SRv6 segments is refused — a kernel nexthop carries at most one encap.
- **resolve**: `entry_resolvable` accepts BGP routes carrying segs alongside the existing BGP-LU (MPLS) arm — an SRv6-encapsulated BGP route is legitimate transport for recursion, same as a labeled one.
- **static**: `apply_resolved` stamps `segs`/`encap_type` (H.Encap default); the resolved uni comes out shaped like an explicit-`segments` route, so the nexthop group dedupes with the covering route's group and the FIB install path is unchanged.
- **show**: the recursive two-liner renders inherited SRv6 transport as `via seg6 [...]` on the resolved line:

```
S  *> 3001:db8::1/128 [1/0] via 2001:db8:cafe::1 (recursive), 00:00:03
                            via seg6 [fcbb:bbbb:1:40::], i1
```

- **Book**: the recursive-static and SRv6-static chapters now document the inheritance and its boundaries (plain IGP-SRv6 routes carry nothing to inherit; mixed MPLS+SRv6 chains refuse).

## Test plan

- Unit: new resolver tests (inheritance, deeper-recursion survival, multi-level prepend order, mixed-transport refusal, v4-over-SRv6) + static resolver stamping test; `cargo test --workspace --exclude bdd` all green; `cargo clippy --workspace --all-targets` clean.
- BDD: new `@static_srv6_nht` — three-router line (ingress/egress iBGP over SRv6, locator-only core) + host behind the egress; asserts recursive rendering, kernel `proto static … encap seg6`, end-to-end ping through the inherited encapsulation (the core cannot route the inner prefix, so the ping proves the tunnel), and fallback to the covering BGP route on delete.
- BDD regressions over shared resolver paths: `isis_srmpls`, `bgp_srv6_redistribute`, `rib_static_ipv6`, `bgp_interas_option_c` (BGP-LU arm), `static_vrf` — all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)