### PR TITLE
bgp: inherit SRv6 segments from the next-hop's covering route

### DIFF
--- a/bdd/Makefile
+++ b/bdd/Makefile
@@ -137,6 +137,10 @@ static_srv6_nht:
 	mkdir -p allure-results
 	cargo test --test cucumber -- --concurrency=1 --tags "@static_srv6_nht"
 
+bgp_srv6_nht:
+	mkdir -p allure-results
+	cargo test --test cucumber -- --concurrency=1 --tags "@bgp_srv6_nht"
+
 # Run all IS-IS tests.
 isis:
 	rm -rf allure-results
@@ -440,4 +444,4 @@ docs/%.md: tests/features/%.feature docs/feature2md.sh FORCE
 
 FORCE:
 
-.PHONY: ecmp_bfd_evict ospfv2_bfd_frr ospfv3_bfd_frr tilfa_bfd all run ibgp ebgp rr rib_static_ipv6 static_srv6_nht isis_ipv6 isis_srv6_base isis_fragmentation_ipv6 isis_fragmentation_ipv4 isis_l1p2p isis_tilfa isis_srmpls system_hostname isis_l1l2 isis_redist isis_hello_auth_keychain isis_passive isis_afi_enable isis_endx_ipv6 isis_bfd_ipv6_p2p isis_bfd_ipv6_p2p_echo isis_bfd_ipv6_lan isis_bfd_ipv6_lan_echo isis_bfd_ipv4_p2p isis_bfd_ipv4_p2p_echo isis_bfd_ipv4_lan isis_bfd_ipv4_lan_echo ospf_clear_neighbor ospfv2_nssa_base ospfv2_stub_base ospfv2_tilfa ospfv3_nssa ospfv3_tilfa stamp_te_metric stamp_v6_te_metric bgp_peer_down_cleanup bgp_ipv6_over_v4_session bgp_evpn_capability bgp_vrf_evpn_type5 bgp_evpn_outpolicy_undef bgp_route_map_match bgp_policy_dynamic_update bgp_table_map bgp_v6_table_map bgp_community bgp_neighbor_group bgp_unnumbered_neighbor nd_show cradle_spawn bgp_interas_option_c bgp_interas_option_a bgp_interas_option_b bgp_interas_option_ab bgp_port bgp_ip_transparent bgp_local_as bgp_unknown_attr_transitive bgp_fast_external_failover generate open docs FORCE
+.PHONY: ecmp_bfd_evict ospfv2_bfd_frr ospfv3_bfd_frr tilfa_bfd all run ibgp ebgp rr rib_static_ipv6 static_srv6_nht bgp_srv6_nht isis_ipv6 isis_srv6_base isis_fragmentation_ipv6 isis_fragmentation_ipv4 isis_l1p2p isis_tilfa isis_srmpls system_hostname isis_l1l2 isis_redist isis_hello_auth_keychain isis_passive isis_afi_enable isis_endx_ipv6 isis_bfd_ipv6_p2p isis_bfd_ipv6_p2p_echo isis_bfd_ipv6_lan isis_bfd_ipv6_lan_echo isis_bfd_ipv4_p2p isis_bfd_ipv4_p2p_echo isis_bfd_ipv4_lan isis_bfd_ipv4_lan_echo ospf_clear_neighbor ospfv2_nssa_base ospfv2_stub_base ospfv2_tilfa ospfv3_nssa ospfv3_tilfa stamp_te_metric stamp_v6_te_metric bgp_peer_down_cleanup bgp_ipv6_over_v4_session bgp_evpn_capability bgp_vrf_evpn_type5 bgp_evpn_outpolicy_undef bgp_route_map_match bgp_policy_dynamic_update bgp_table_map bgp_v6_table_map bgp_community bgp_neighbor_group bgp_unnumbered_neighbor nd_show cradle_spawn bgp_interas_option_c bgp_interas_option_a bgp_interas_option_b bgp_interas_option_ab bgp_port bgp_ip_transparent bgp_local_as bgp_unknown_attr_transitive bgp_fast_external_failover generate open docs FORCE

--- a/bdd/tests/configs/bgp_srv6_nht/z1.yaml
+++ b/bdd/tests/configs/bgp_srv6_nht/z1.yaml
@@ -1,0 +1,56 @@
+# z1 — SRv6 egress PE (AS 65000). Advertises locator LOC1 and enables
+# `segment-routing srv6 ipv6-unicast`, so redistributed connected
+# prefixes — the z1-z4 subnet 2001:db8:cafe::/64 among them — carry the
+# End.DT6 SID fcbb:bbbb:1:40:: on the transport session toward z3.
+# The 3001:db8:100::/64 static is the post-decap inner route toward the
+# service node z4; it is deliberately NOT redistributed (no
+# `redistribute static` here), so z3 learns that prefix only from z4's
+# own session, with next-hop cafe::4.
+interface:
+- if-name: i1
+  ipv6:
+    address: 2001:db8:12::1/64
+- if-name: i2
+  ipv6:
+    address: 2001:db8:cafe::1/64
+segment-routing:
+  locator:
+  - name: LOC1
+    prefix: fcbb:bbbb:1::/48
+    behavior: usid
+router:
+  static:
+    ipv6:
+      route:
+      - prefix: 2001:db8:23::/64
+        nexthop:
+        - address: 2001:db8:12::2
+      - prefix: 3001:db8:100::/64
+        nexthop:
+        - address: 2001:db8:cafe::4
+  bgp:
+    global:
+      as: 65000
+      router-id: 10.0.0.1
+    timer:
+      adv-interval:
+        ibgp: 1
+        ebgp: 1
+    segment-routing:
+      srv6:
+        locator: LOC1
+        ipv6-unicast: {}
+    neighbor:
+    - remote-address: 2001:db8:23::3
+      # 3s connect retry: a colliding initial connect under host load
+      # otherwise backs off the default 120s, past the assert budget.
+      timers: {connect-retry-time: 3}
+      remote-as: 65000
+      enabled: true
+      afi-safi:
+      - name: ipv6
+        enabled: true
+    afi-safi:
+    - name: ipv6
+      redistribute:
+        connected: {}

--- a/bdd/tests/configs/bgp_srv6_nht/z2.yaml
+++ b/bdd/tests/configs/bgp_srv6_nht/z2.yaml
@@ -1,0 +1,20 @@
+# z2 — transit core. Knows the two link subnets (connected) and z1's
+# SRv6 locator — nothing else. Neither 2001:db8:cafe::/64 nor
+# 3001:db8:100::/64 appears here, so traffic for them can only cross
+# z2 inside an SRv6 encapsulation addressed to the locator. That makes
+# both the z4<->z3 BGP session (TCP through the tunnel) and the final
+# ping proof of the inherited encapsulation.
+interface:
+- if-name: i1
+  ipv6:
+    address: 2001:db8:12::2/64
+- if-name: i2
+  ipv6:
+    address: 2001:db8:23::2/64
+router:
+  static:
+    ipv6:
+      route:
+      - prefix: fcbb:bbbb:1::/48
+        nexthop:
+        - address: 2001:db8:12::1

--- a/bdd/tests/configs/bgp_srv6_nht/z3.yaml
+++ b/bdd/tests/configs/bgp_srv6_nht/z3.yaml
@@ -1,0 +1,48 @@
+# z3 — SRv6 ingress PE (AS 65000). Two iBGP sessions:
+#  - transport, to z1 over the plain link path, with
+#    `encapsulation-type srv6`: delivers 2001:db8:cafe::/64 (and the
+#    rest of z1's connected prefixes) as SRv6 service routes carrying
+#    z1's End.DT6 SID;
+#  - service, to the node z4 (2001:db8:cafe::4) *behind* z1 — the TCP
+#    session itself rides the SRv6 tunnel (encap at z3, decap at z1's
+#    uDT6, plain delivery to z4). z4's routes arrive with next-hop
+#    cafe::4, an address covered ONLY by the SRv6 transport route —
+#    NHT must resolve through it and inherit the segment list.
+interface:
+- if-name: i1
+  ipv6:
+    address: 2001:db8:23::3/64
+router:
+  static:
+    ipv6:
+      route:
+      - prefix: 2001:db8:12::/64
+        nexthop:
+        - address: 2001:db8:23::2
+      - prefix: fcbb:bbbb:1::/48
+        nexthop:
+        - address: 2001:db8:23::2
+  bgp:
+    global:
+      as: 65000
+      router-id: 10.0.0.3
+    timer:
+      adv-interval:
+        ibgp: 1
+        ebgp: 1
+    neighbor:
+    - remote-address: 2001:db8:12::1
+      timers: {connect-retry-time: 3}
+      remote-as: 65000
+      enabled: true
+      afi-safi:
+      - name: ipv6
+        enabled: true
+        encapsulation-type: srv6
+    - remote-address: 2001:db8:cafe::4
+      timers: {connect-retry-time: 3}
+      remote-as: 65000
+      enabled: true
+      afi-safi:
+      - name: ipv6
+        enabled: true

--- a/bdd/tests/configs/bgp_srv6_nht/z4.yaml
+++ b/bdd/tests/configs/bgp_srv6_nht/z4.yaml
@@ -1,0 +1,44 @@
+# z4 — service node behind z1 (AS 65000). Advertises the service
+# aggregate 3001:db8:100::/64 (a blackhole static, redistributed) to
+# z3; the ping responder 3001:db8:100::1 sits on lo, where the local
+# route beats the blackhole aggregate for delivery. `redistribute
+# static` (not connected) keeps the z1-z4 subnet out of this session —
+# z3 must learn 2001:db8:cafe::/64 only from z1's SRv6 transport
+# session, so z4's next-hop (cafe::4) resolves through it.
+interface:
+- if-name: lo
+  ipv6:
+    address: 3001:db8:100::1/128
+- if-name: i1
+  ipv6:
+    address: 2001:db8:cafe::4/64
+router:
+  static:
+    ipv6:
+      route:
+      - prefix: 2001:db8:23::/64
+        nexthop:
+        - address: 2001:db8:cafe::1
+      - prefix: 3001:db8:100::/64
+        nexthop:
+        - address: blackhole
+  bgp:
+    global:
+      as: 65000
+      router-id: 10.0.0.4
+    timer:
+      adv-interval:
+        ibgp: 1
+        ebgp: 1
+    neighbor:
+    - remote-address: 2001:db8:23::3
+      timers: {connect-retry-time: 3}
+      remote-as: 65000
+      enabled: true
+      afi-safi:
+      - name: ipv6
+        enabled: true
+    afi-safi:
+    - name: ipv6
+      redistribute:
+        static: {}

--- a/bdd/tests/features/bgp_srv6_nht.feature
+++ b/bdd/tests/features/bgp_srv6_nht.feature
@@ -1,0 +1,88 @@
+@bgp_srv6_nht
+Feature: BGP route inherits SRv6 segments from its covering route
+  As a network operator
+  I want a BGP route whose next-hop is reachable only through a
+  BGP-over-SRv6 transport route to resolve recursively through it and
+  inherit the H.Encap segment list — the BGP twin of the static-route
+  inheritance in @static_srv6_nht, and the SRv6 analog of Inter-AS
+  Option C (service routes riding a BGP-learned transport tunnel).
+
+  Test Topology (three veth pairs, all AS 65000):
+  ```
+  ┌────────┐ i1 ── i2 ┌────────┐ i1 ──────── i1 ┌────────┐ i2 ─────── i1 ┌────────┐
+  │   z4   │──────────│   z1   │────────────────│   z2   │───────────────│   z3   │
+  │ service│ 2001:db8:│ egress │2001:db8:12::/64│  core  │2001:db8:23::/64 ingress│
+  │  node  │ cafe::/64│ LOC1   │                │        │               │        │
+  └────────┘          └────────┘                └────────┘               └────────┘
+   lo: 3001:db8:100::1     z2 knows ONLY the links and z1's locator
+   (service prefix          fcbb:bbbb:1::/48 — service prefixes cross
+    aggregate via BGP)      it exclusively inside SRv6 encapsulation
+  ```
+
+  - Transport: z1<->z3 iBGP with `encapsulation-type srv6`; z1
+    redistributes connected, so 2001:db8:cafe::/64 (the z1-z4 subnet)
+    arrives at z3 as an SRv6 service route carrying z1's End.DT6 SID
+    fcbb:bbbb:1:40::.
+  - Service: z4<->z3 iBGP. The TCP session itself crosses the core
+    inside the transport tunnel (encap at z3, decap at z1, plain
+    delivery to z4). z4 redistributes its blackhole aggregate
+    3001:db8:100::/64, which arrives at z3 with next-hop cafe::4 — an
+    address covered ONLY by the SRv6 transport route. NHT resolves the
+    next-hop through it and the installed route inherits the segment
+    list: `proto bgp ... encap seg6 segs [fcbb:bbbb:1:40::]`.
+  - The ping to z4's loopback proves the end-to-end datapath: z2
+    cannot route the service prefix, so only the inherited
+    encapsulation can carry the traffic.
+
+  Config files (in `bdd/tests/configs/bgp_srv6_nht/`):
+  - z1.yaml, z2.yaml, z3.yaml, z4.yaml
+
+  Scenario: Setup topology and converge the SRv6 transport
+    Given a clean test environment
+    When I create namespace "z1"
+    And I create namespace "z2"
+    And I create namespace "z3"
+    And I create namespace "z4"
+    And I connect namespace "z1" interface "i1" to namespace "z2" interface "i1"
+    And I connect namespace "z2" interface "i2" to namespace "z3" interface "i1"
+    And I connect namespace "z1" interface "i2" to namespace "z4" interface "i1"
+    And I start zebra-rs in namespace "z1"
+    And I start zebra-rs in namespace "z2"
+    And I start zebra-rs in namespace "z3"
+    And I start zebra-rs in namespace "z4"
+    And I apply config "z1.yaml" to namespace "z1"
+    And I apply config "z2.yaml" to namespace "z2"
+    And I apply config "z3.yaml" to namespace "z3"
+    And I apply config "z4.yaml" to namespace "z4"
+    And I wait 40 seconds
+    # The covering transport route arrived and installed as SRv6 H.Encaps.
+    Then show command "show ipv6 route 2001:db8:cafe::/64" in namespace "z3" should eventually contain "via seg6"
+    And show command "show ipv6 route 2001:db8:cafe::/64" in namespace "z3" should contain "fcbb:bbbb:1:40::"
+
+  Scenario: Service route resolves through the SRv6 transport and inherits its segments
+    Given the test topology exists
+    # The z4 session establishes through the tunnel and delivers the
+    # service aggregate; its next-hop cafe::4 is not on-link — NHT
+    # resolves it through the SRv6 transport route.
+    Then show command "show ipv6 route" in namespace "z3" should eventually contain "B  *> 3001:db8:100::/64"
+    # The kernel forwards the service prefix with the inherited H.Encap
+    # as a BGP route.
+    And kernel route "3001:db8:100::/64" in namespace "z3" should eventually contain "encap seg6"
+    And kernel route "3001:db8:100::/64" in namespace "z3" should eventually contain "fcbb:bbbb:1:40::"
+    And kernel route "3001:db8:100::/64" in namespace "z3" should eventually contain "proto bgp"
+    # End-to-end: z2 cannot route the inner destination, so a reply
+    # from z4's loopback proves the packet crossed the core inside the
+    # inherited SRv6 encapsulation and was decapsulated by z1.
+    And ping from "z3" to "3001:db8:100::1" should succeed
+
+  Scenario: Teardown topology
+    Given the test topology exists
+    When I stop zebra-rs in namespace "z1"
+    And I stop zebra-rs in namespace "z2"
+    And I stop zebra-rs in namespace "z3"
+    And I stop zebra-rs in namespace "z4"
+    And I delete namespace "z1"
+    And I delete namespace "z2"
+    And I delete namespace "z3"
+    And I delete namespace "z4"
+    Then the test environment should be clean

--- a/book/src/ch-01-04-srv6-static-route.md
+++ b/book/src/ch-01-04-srv6-static-route.md
@@ -215,11 +215,24 @@ Two boundaries of the inheritance are worth knowing:
   nexthop carries at most one encapsulation, so the route is withheld
   rather than installed half-encapsulated.
 
-The BDD feature `static_srv6_nht` runs this end to end: a three-router
-line where only the ingress and egress speak BGP, the middle router
-knows nothing but locators, and the ping to a host behind the egress
-succeeds only because the inherited encapsulation tunnels the packet
-across the core.
+The inheritance is not limited to static routes: a **BGP route** whose
+next-hop is covered by an SRv6-encapsulated route inherits the segment
+list the same way — the SRv6 analog of Inter-AS Option C, where
+service routes ride a BGP-learned transport tunnel. A service node
+behind the egress PE can peer iBGP with the ingress *through the
+tunnel itself* and advertise service prefixes with its own address as
+the next-hop; the ingress resolves that next-hop through the SRv6
+transport route and installs the service routes as
+`proto bgp … encap seg6` entries. (An MPLS-labelled route — LU or
+VPN — refuses SRv6 transport instead: a label stack cannot ride a
+seg6 encapsulation, so such a resolution withholds the route rather
+than installing it half-encapsulated.)
+
+The BDD features `static_srv6_nht` and `bgp_srv6_nht` run both
+variants end to end: a three-router line where only the ingress and
+egress speak BGP, the middle router knows nothing but locators, and
+the ping to a node behind the egress succeeds only because the
+inherited encapsulation tunnels the packet across the core.
 
 ## Notes
 

--- a/zebra-rs/src/bgp/inst.rs
+++ b/zebra-rs/src/bgp/inst.rs
@@ -3881,15 +3881,36 @@ impl Bgp {
         }
     }
 
-    /// Re-install the dataplane for a VPN dep after its PE next-hop's
-    /// transport rerouted (reachability unchanged). Re-dispatches the
-    /// per-VRF import with the freshly-resolved transport, so each
-    /// importing VRF re-programs its `{transport,service}`-labelled FIB
-    /// entry. Unicast deps are a no-op: BGP installs the BGP next-hop
-    /// and the RIB recursively re-resolves it, so there's nothing here
-    /// to refresh.
+    /// Re-install the dataplane for a dep after its next-hop's
+    /// transport rerouted (reachability unchanged). VPN deps
+    /// re-dispatch the per-VRF import with the freshly-resolved
+    /// transport, so each importing VRF re-programs its
+    /// `{transport,service}`-labelled FIB entry. Unicast deps re-run
+    /// the FIB install: an entry whose next-hop resolution carries
+    /// SRv6 segments embeds them (inherited encapsulation), so it must
+    /// be re-programmed — a plain entry (bare BGP next-hop, RIB
+    /// re-resolves recursively) makes the re-install an idempotent
+    /// re-send. No re-advertise anywhere here: best-path is unchanged.
     fn nht_reinstall_transport(&mut self, nh: std::net::IpAddr, dep: super::nht::NhtDep) {
         use super::nht::NhtDep;
+        // Unicast arms first — they need a `BgpTop` carrying the NHT
+        // cache, which conflicts with the shared `transport` borrow
+        // the VPN arms use below.
+        match dep {
+            NhtDep::V4(p) => {
+                let selected = self.shard.v4.select_best_path(p);
+                let top = self.nht_install_top();
+                super::route::fib_install_v4(&top, p, &selected);
+                return;
+            }
+            NhtDep::V6(p) => {
+                let selected = self.shard.v6.select_best_path(p);
+                let top = self.nht_install_top();
+                super::route::fib_install_v6(&top, p, &selected);
+                return;
+            }
+            _ => {}
+        }
         let dispatcher = super::vrf::VrfImportDispatcher {
             rib_known_vrfs: &self.rib_known_vrfs,
             vrf_registry: &self.vrf_registry,
@@ -4009,7 +4030,37 @@ impl Bgp {
             NhtDep::MupEndpoint(rd, prefix) => {
                 self.mup_redispatch_endpoint(nh, rd, prefix, true);
             }
+            // Handled by the early match above.
             NhtDep::V4(_) | NhtDep::V6(_) => {}
+        }
+    }
+
+    /// Build the `BgpTop` for a transport-only unicast re-install: the
+    /// same shape `nht_reeval_dep` uses, carrying the NHT cache so
+    /// `fib_install_v4/v6` can re-derive inherited SRv6 transport. A
+    /// method (whole-`self` borrow) is fine here — the re-install path
+    /// touches nothing else on `self` while the top is alive.
+    fn nht_install_top(&mut self) -> super::peer::BgpTop<'_> {
+        super::peer::BgpTop {
+            router_id: &self.router_id,
+            srv6_ipv6_export: self.srv6_ipv6_export.as_ref(),
+            local_rib: &mut self.local_rib,
+            shard: &mut self.shard,
+            tx: &self.tx,
+            rib_client: &self.ctx.rib,
+            attr_store: &mut self.attr_store,
+            update_groups: &mut self.update_groups,
+            interface_addrs: &self.interface_addrs,
+            color_policy: Some(&self.color_policy),
+            flex_algo_routes: Some(&self.flex_algo_routes),
+            flex_algo_srv6_routes: Some(&self.flex_algo_srv6_routes),
+            vrf_export: None,
+            vrf_import: None,
+            nexthop_cache: Some(&mut self.nexthop_cache),
+            vrf_transport_v4: None,
+            vrf_transport_v6: None,
+            central_label_alloc: None,
+            as_sets_withdraw: self.as_sets_withdraw,
         }
     }
 
@@ -4177,7 +4228,10 @@ impl Bgp {
             flex_algo_srv6_routes: Some(&self.flex_algo_srv6_routes),
             vrf_export: None,
             vrf_import: None,
-            nexthop_cache: None,
+            // The re-eval installs unicast winners, whose entry shape
+            // depends on the next-hop's resolved transport (SRv6
+            // segment inheritance) — the install path needs the cache.
+            nexthop_cache: Some(&mut self.nexthop_cache),
             vrf_transport_v4: None,
             vrf_transport_v6: None,
             central_label_alloc: None,
@@ -4201,12 +4255,11 @@ impl Bgp {
             }
             // Labeled-Unicast reachability flip: re-install the FIB
             // label-push entry (or withdraw) and re-advertise. The cache
-            // is passed directly (not via `top`, whose `nexthop_cache` is
-            // `None`) — `top`'s borrows don't include it.
+            // is read through `top`, which holds the borrow.
             NhtDep::V4lu(p) => {
                 super::route::fib_install_labelv4(
                     top.rib_client,
-                    Some(&self.nexthop_cache),
+                    top.nexthop_cache.as_deref(),
                     *p,
                     &selected,
                 );
@@ -4220,7 +4273,7 @@ impl Bgp {
             NhtDep::V6lu(p) => {
                 super::route::fib_install_labelv6(
                     top.rib_client,
-                    Some(&self.nexthop_cache),
+                    top.nexthop_cache.as_deref(),
                     *p,
                     &selected,
                 );
@@ -4252,7 +4305,10 @@ impl Bgp {
                 };
                 if reachable && let Some(winner) = selected.first() {
                     let label = winner.label.map(|l| l.label).unwrap_or(0);
-                    let transport = self.nexthop_cache.transport_for(nh);
+                    let transport = top
+                        .nexthop_cache
+                        .as_deref()
+                        .map_or(&[][..], |c| c.transport_for(nh));
                     super::vrf::dispatch_import_v4(
                         &dispatcher,
                         *rd,
@@ -4263,7 +4319,7 @@ impl Bgp {
                         None,
                     );
                 } else if let Some(attr) =
-                    self.shard.v4vpn.get(rd).and_then(|t| t.candidate_attr(*p))
+                    top.shard.v4vpn.get(rd).and_then(|t| t.candidate_attr(*p))
                 {
                     super::vrf::dispatch_withdraw_import_v4(&dispatcher, *rd, *p, &attr, None);
                 }
@@ -4272,7 +4328,7 @@ impl Bgp {
                 // transport resolved, or tear it down if it went away.
                 super::route::reconcile_swap_ilm(
                     &self.ctx.rib,
-                    Some(&self.nexthop_cache),
+                    top.nexthop_cache.as_deref(),
                     selected.first(),
                 );
             }
@@ -4293,7 +4349,10 @@ impl Bgp {
                 };
                 if reachable && let Some(winner) = selected.first() {
                     let label = winner.label.map(|l| l.label).unwrap_or(0);
-                    let transport = self.nexthop_cache.transport_for(nh);
+                    let transport = top
+                        .nexthop_cache
+                        .as_deref()
+                        .map_or(&[][..], |c| c.transport_for(nh));
                     super::vrf::dispatch_import_v6(
                         &dispatcher,
                         *rd,
@@ -4304,7 +4363,7 @@ impl Bgp {
                         None,
                     );
                 } else if let Some(attr) =
-                    self.shard.v6vpn.get(rd).and_then(|t| t.candidate_attr(*p))
+                    top.shard.v6vpn.get(rd).and_then(|t| t.candidate_attr(*p))
                 {
                     super::vrf::dispatch_withdraw_import_v6(&dispatcher, *rd, *p, &attr, None);
                 }
@@ -4330,7 +4389,10 @@ impl Bgp {
                     && let Some(winner) = selected.last()
                 {
                     let label = winner.label.map(|l| l.label).unwrap_or(0);
-                    let transport = self.nexthop_cache.transport_for(nh);
+                    let transport = top
+                        .nexthop_cache
+                        .as_deref()
+                        .map_or(&[][..], |c| c.transport_for(nh));
                     match net {
                         ipnet::IpNet::V4(p) => {
                             if reachable {
@@ -4382,7 +4444,9 @@ impl Bgp {
             NhtDep::SrPolicy { color, endpoint } => {
                 super::route::sr_policy_reconcile_mpls(
                     top.rib_client,
-                    &self.nexthop_cache,
+                    top.nexthop_cache
+                        .as_deref()
+                        .expect("global task owns the NHT cache"),
                     &mut top.local_rib.sr_policy,
                     *color,
                     *endpoint,
@@ -4397,7 +4461,9 @@ impl Bgp {
                 let selected = top.local_rib.select_best_path_mup(rd, prefix);
                 if let Some(winner) = selected.first() {
                     let transport = if reachable {
-                        self.nexthop_cache.transport_for(nh).to_vec()
+                        top.nexthop_cache
+                            .as_deref()
+                            .map_or(Vec::new(), |c| c.transport_for(nh).to_vec())
                     } else {
                         Vec::new()
                     };
@@ -4436,7 +4502,9 @@ impl Bgp {
                         None
                     };
                     let endpoint_transport = if reachable {
-                        self.nexthop_cache.transport_for(nh).to_vec()
+                        top.nexthop_cache
+                            .as_deref()
+                            .map_or(Vec::new(), |c| c.transport_for(nh).to_vec())
                     } else {
                         Vec::new()
                     };
@@ -4784,7 +4852,11 @@ impl Bgp {
             flex_algo_srv6_routes: Some(&self.flex_algo_srv6_routes),
             vrf_export: None,
             vrf_import: None,
-            nexthop_cache: None,
+            // The re-install must see the NHT cache: a winner whose
+            // next-hop resolution carries SRv6 segments re-derives its
+            // inherited encapsulation here — without the cache it
+            // would degrade to a plain (unencapsulated) entry.
+            nexthop_cache: Some(&mut self.nexthop_cache),
             vrf_transport_v4: None,
             vrf_transport_v6: None,
             central_label_alloc: None,

--- a/zebra-rs/src/bgp/route.rs
+++ b/zebra-rs/src/bgp/route.rs
@@ -548,9 +548,9 @@ fn is_vpn_fib_winner(best: &BgpRib, transport: Option<&[rib::nht::ResolvedNextho
 /// route (typically another BGP-over-SRv6 service route). Plain and
 /// MPLS-labelled resolutions return `None` (labels are the LU/VPN
 /// paths' business; a plain unicast route doesn't consume them).
-fn inherited_seg6_egress<'a>(
-    nht_transport: Option<&'a [rib::nht::ResolvedNexthop]>,
-) -> Option<&'a rib::nht::ResolvedNexthop> {
+fn inherited_seg6_egress(
+    nht_transport: Option<&[rib::nht::ResolvedNexthop]>,
+) -> Option<&rib::nht::ResolvedNexthop> {
     nht_transport
         .and_then(|t| t.first())
         .filter(|egress| !egress.segs.is_empty())

--- a/zebra-rs/src/bgp/route.rs
+++ b/zebra-rs/src/bgp/route.rs
@@ -431,6 +431,14 @@ fn build_vpn_fib_entry(
     service_label: u32,
     transport: &[rib::nht::ResolvedNexthop],
 ) -> Option<rib::entry::RibEntry> {
+    // An MPLS service label cannot ride SRv6 transport: a kernel
+    // nexthop carries at most one encapsulation, so an egress whose
+    // resolution came back with an SRv6 segment list (the PE next-hop
+    // is covered by a BGP-over-SRv6 route) is unusable here. Refuse
+    // rather than installing an unencapsulated (or seg6-only) entry
+    // that would drop the service label.
+    let transport: Vec<&rib::nht::ResolvedNexthop> =
+        transport.iter().filter(|e| e.segs.is_empty()).collect();
     if transport.is_empty() {
         return None;
     }
@@ -452,10 +460,10 @@ fn build_vpn_fib_entry(
         uni
     };
     let nexthop = if transport.len() == 1 {
-        rib::Nexthop::Uni(mk_uni(&transport[0]))
+        rib::Nexthop::Uni(mk_uni(transport[0]))
     } else {
         let mut multi = rib::NexthopMulti::default();
-        for egress in transport {
+        for &egress in &transport {
             multi.nexthops.push(mk_uni(egress));
         }
         rib::Nexthop::Multi(multi)
@@ -534,14 +542,73 @@ fn is_vpn_fib_winner(best: &BgpRib, transport: Option<&[rib::nht::ResolvedNextho
     best.typ == BgpRibType::Originated && transport.is_some_and(|t| !t.is_empty())
 }
 
+/// The NHT egress a plain unicast winner should inherit SRv6 transport
+/// from: the first resolved egress, when it carries an H.Encap segment
+/// list — i.e. the BGP next-hop is covered by an SRv6-encapsulated
+/// route (typically another BGP-over-SRv6 service route). Plain and
+/// MPLS-labelled resolutions return `None` (labels are the LU/VPN
+/// paths' business; a plain unicast route doesn't consume them).
+fn inherited_seg6_egress<'a>(
+    nht_transport: Option<&'a [rib::nht::ResolvedNexthop]>,
+) -> Option<&'a rib::nht::ResolvedNexthop> {
+    nht_transport
+        .and_then(|t| t.first())
+        .filter(|egress| !egress.segs.is_empty())
+}
+
+/// Build the FIB entry for a plain unicast winner whose next-hop
+/// resolved through an SRv6-encapsulated covering route: the dependent
+/// inherits the covering route's H.Encap segment list, the BGP-side
+/// twin of the static-route inheritance in `rib::static::resolve`.
+/// `addr`/`ifindex_origin` are the *resolved* underlay egress (the BGP
+/// next-hop itself is not natively routable — that's why the segments
+/// are needed), `segs`/`encap_type` the inherited transport. Same
+/// shape as an explicit-SID entry, so the nexthop group dedupes with
+/// the covering route's group. Address-family-agnostic.
+fn make_bgp_inherited_seg6_entry(
+    best: &BgpRib,
+    egress: &rib::nht::ResolvedNexthop,
+) -> Option<rib::entry::RibEntry> {
+    let distance = match best.typ {
+        BgpRibType::EBGP => 20,
+        BgpRibType::IBGP | BgpRibType::Originated => 200,
+    };
+    let metric = best.attr.med.as_ref().map(|m| m.med).unwrap_or(0);
+
+    let mut uni = rib::NexthopUni::new(egress.addr, 0, Vec::new());
+    uni.segs = egress.segs.clone();
+    uni.encap_type = Some(
+        egress
+            .seg_encap
+            .unwrap_or(isis_packet::srv6::EncapType::HEncap),
+    );
+    if egress.ifindex != 0 {
+        uni.ifindex_origin = Some(egress.ifindex);
+    }
+    uni.metric = metric;
+    uni.weight = 1;
+    uni.valid = true;
+
+    let mut entry = rib::entry::RibEntry::new(rib::RibType::Bgp);
+    entry.distance = distance;
+    entry.metric = metric;
+    entry.valid = true;
+    entry.nexthop = rib::Nexthop::Uni(uni);
+    Some(entry)
+}
+
 /// Choose the IPv4 FIB entry for a best-path winner in a (possibly VRF)
 /// context. An imported VPN winner installs the `{transport,service}`
 /// labelled tunnel entry; a CE-learned / locally-originated / global
-/// route installs the plain next-hop entry. `transport` is `None`
-/// outside a VRF, so this reduces to `make_bgp_rib_entry_v4`.
+/// route installs the plain next-hop entry — unless its next-hop
+/// resolved through an SRv6-encapsulated covering route
+/// (`nht_transport` carries segments), in which case it inherits that
+/// encapsulation. `transport` is `None` outside a VRF, so this
+/// reduces to the inherit-or-plain choice there.
 fn select_fib_entry_v4(
     best: &BgpRib,
     transport: Option<&[rib::nht::ResolvedNexthop]>,
+    nht_transport: Option<&[rib::nht::ResolvedNexthop]>,
 ) -> Option<rib::entry::RibEntry> {
     // SRv6 L3VPN: an imported route carrying an SRv6 L3 Service SID
     // installs an H.Encap entry toward that SID instead of an MPLS
@@ -557,6 +624,8 @@ fn select_fib_entry_v4(
     }
     if is_vpn_fib_winner(best, transport) {
         build_vpn_fib_entry(best.label.map(|l| l.label).unwrap_or(0), transport.unwrap())
+    } else if let Some(egress) = inherited_seg6_egress(nht_transport) {
+        make_bgp_inherited_seg6_entry(best, egress)
     } else {
         make_bgp_rib_entry_v4(best)
     }
@@ -623,17 +692,28 @@ pub(super) fn fib_install_v4(bgp: &super::peer::BgpTop, prefix: Ipv4Net, selecte
         selected.first(),
     );
     let best = best.as_deref();
-    let entry = best.and_then(|b| select_fib_entry_v4(b, transport));
+    // The winner's NHT resolution (global instance only): carries the
+    // SRv6 segment list to inherit when the next-hop is covered by an
+    // SRv6-encapsulated route.
+    let nht_transport = bgp.nexthop_cache.as_deref().and_then(|cache| {
+        best.and_then(|b| super::nht::bgp_nexthop_ip(&b.attr))
+            .map(|nh| cache.transport_for(nh))
+    });
+    let entry = best.and_then(|b| select_fib_entry_v4(b, transport, nht_transport));
     match entry {
         Some(mut rib_entry) => {
             // Colour-aware steering — plain-path only; a VPN tunnel
-            // entry already carries its full label stack. An SR Policy
-            // match (RFC 9256 §8) takes precedence over a Flex-Algo
-            // binding; Flex-Algo is the fallback.
+            // entry already carries its full label stack, and an entry
+            // with inherited SRv6 transport (segs non-empty) is already
+            // tunneled — pushing steering labels on it would mix
+            // encapsulations. An SR Policy match (RFC 9256 §8) takes
+            // precedence over a Flex-Algo binding; Flex-Algo is the
+            // fallback.
             if let Some(best) = best
                 && !is_vpn_fib_winner(best, transport)
                 && let Some(BgpNexthop::Ipv4(nh)) = best.attr.nexthop.as_ref()
                 && let rib::Nexthop::Uni(ref mut uni) = rib_entry.nexthop
+                && uni.segs.is_empty()
             {
                 if let Some(stack) = sr_policy_steer_mpls(bgp, &best.attr, IpAddr::V4(*nh)) {
                     for label in stack {
@@ -766,6 +846,7 @@ fn make_bgp_srv6_encap_entry_v6(
 fn select_fib_entry_v6(
     best: &BgpRib,
     transport: Option<&[rib::nht::ResolvedNexthop]>,
+    nht_transport: Option<&[rib::nht::ResolvedNexthop]>,
 ) -> Option<rib::entry::RibEntry> {
     // SRv6 L3VPN (VPNv6 over an SRv6 underlay) — see `select_fib_entry_v4`.
     if best.typ == BgpRibType::Originated
@@ -783,8 +864,11 @@ fn select_fib_entry_v6(
         // of a plain next-hop entry, so matched traffic is SRv6-
         // encapsulated to the egress PE. (The `Originated` + SID case is
         // VPNv6-over-SRv6, handled above; this is the global-table,
-        // non-VPN ingress.)
+        // non-VPN ingress.) A service SID wins over inherited transport
+        // — the route's own encapsulation is authoritative.
         make_bgp_srv6_encap_entry_v6(best, sid)
+    } else if let Some(egress) = inherited_seg6_egress(nht_transport) {
+        make_bgp_inherited_seg6_entry(best, egress)
     } else {
         make_bgp_rib_entry_v6(best)
     }
@@ -805,7 +889,13 @@ pub(super) fn fib_install_v6(bgp: &super::peer::BgpTop, prefix: Ipv6Net, selecte
         selected.first(),
     );
     let best = best.as_deref();
-    let entry = best.and_then(|b| select_fib_entry_v6(b, transport));
+    // The winner's NHT resolution (global instance only) — see
+    // `fib_install_v4`.
+    let nht_transport = bgp.nexthop_cache.as_deref().and_then(|cache| {
+        best.and_then(|b| super::nht::bgp_nexthop_ip(&b.attr))
+            .map(|nh| cache.transport_for(nh))
+    });
+    let entry = best.and_then(|b| select_fib_entry_v6(b, transport, nht_transport));
     match entry {
         Some(mut rib_entry) => {
             // Colour-aware SRv6 steering — plain-path only. A VPN tunnel
@@ -927,6 +1017,15 @@ fn ilm_swap_install(
     service_label: u32,
     transport: &[rib::nht::ResolvedNexthop],
 ) {
+    // Same refusal as `build_vpn_fib_entry`: a label swap cannot ride
+    // SRv6 transport, so egresses whose resolution carries a segment
+    // list are unusable for the ILM.
+    let transport: Vec<&rib::nht::ResolvedNexthop> =
+        transport.iter().filter(|e| e.segs.is_empty()).collect();
+    if transport.is_empty() {
+        ilm_swap_remove(rib_client, local_label);
+        return;
+    }
     let mk_uni = |egress: &rib::nht::ResolvedNexthop| {
         let mut uni = rib::NexthopUni::new(egress.addr, 0, Vec::new());
         let mut labels = egress.labels.clone();
@@ -941,10 +1040,10 @@ fn ilm_swap_install(
         uni
     };
     let nexthop = if transport.len() == 1 {
-        rib::Nexthop::Uni(mk_uni(&transport[0]))
+        rib::Nexthop::Uni(mk_uni(transport[0]))
     } else {
         let mut multi = rib::NexthopMulti::default();
-        for egress in transport {
+        for &egress in &transport {
             multi.nexthops.push(mk_uni(egress));
         }
         rib::Nexthop::Multi(multi)
@@ -19684,7 +19783,7 @@ mod tests {
             segs: vec![],
             seg_encap: None,
         }];
-        let entry = super::select_fib_entry_v4(&rib, Some(&transport)).expect("labelled");
+        let entry = super::select_fib_entry_v4(&rib, Some(&transport), None).expect("labelled");
         match entry.nexthop {
             crate::rib::Nexthop::Uni(uni) => {
                 assert_eq!(uni.addr, "172.16.0.2".parse::<IpAddr>().unwrap());
@@ -19712,7 +19811,7 @@ mod tests {
             segs: vec![],
             seg_encap: None,
         }];
-        let entry = super::select_fib_entry_v4(&rib, Some(&transport)).expect("plain");
+        let entry = super::select_fib_entry_v4(&rib, Some(&transport), None).expect("plain");
         match entry.nexthop {
             crate::rib::Nexthop::Uni(uni) => {
                 assert_eq!(uni.addr, IpAddr::V4(Ipv4Addr::new(192, 0, 2, 1)));
@@ -19730,7 +19829,7 @@ mod tests {
             Some(BgpNexthop::Ipv4(Ipv4Addr::new(192, 0, 2, 9))),
             super::BgpRibType::Originated,
         );
-        let entry = super::select_fib_entry_v4(&rib, None).expect("plain");
+        let entry = super::select_fib_entry_v4(&rib, None, None).expect("plain");
         match entry.nexthop {
             crate::rib::Nexthop::Uni(uni) => {
                 assert_eq!(uni.addr, IpAddr::V4(Ipv4Addr::new(192, 0, 2, 9)));
@@ -19821,7 +19920,7 @@ mod tests {
             segs: vec![],
             seg_encap: None,
         }];
-        let entry = super::select_fib_entry_v4(&rib, Some(&transport)).expect("srv6 entry");
+        let entry = super::select_fib_entry_v4(&rib, Some(&transport), None).expect("srv6 entry");
         match entry.nexthop {
             crate::rib::Nexthop::Uni(uni) => {
                 assert_eq!(uni.segs, vec![sid]);
@@ -19831,7 +19930,146 @@ mod tests {
         }
     }
 
+    #[test]
+    fn select_fib_entry_v6_inherits_srv6_transport_from_nht() {
+        use crate::rib::nht::ResolvedNexthop;
+        // A plain iBGP v6 route whose next-hop resolved through an
+        // SRv6-encapsulated covering route inherits the segment list:
+        // the entry carries the resolved egress + segs, not the bare
+        // (natively unroutable) BGP next-hop.
+        let sid: std::net::Ipv6Addr = "fcbb:bbbb:1:40::".parse().unwrap();
+        let rib = bgp_rib_with_nexthop(
+            Some(BgpNexthop::Ipv6("2001:db8:cafe::4".parse().unwrap())),
+            super::BgpRibType::IBGP,
+        );
+        let nht = vec![ResolvedNexthop {
+            addr: "fcbb:bbbb:1::".parse().unwrap(),
+            ifindex: 3,
+            labels: vec![],
+            segs: vec![sid],
+            seg_encap: Some(isis_packet::srv6::EncapType::HEncap),
+        }];
+        let entry = super::select_fib_entry_v6(&rib, None, Some(&nht)).expect("inherited");
+        assert_eq!(entry.distance, 200);
+        match entry.nexthop {
+            crate::rib::Nexthop::Uni(uni) => {
+                assert_eq!(uni.addr, "fcbb:bbbb:1::".parse::<IpAddr>().unwrap());
+                assert_eq!(uni.ifindex(), Some(3));
+                assert_eq!(uni.segs, vec![sid]);
+                assert_eq!(uni.encap_type, Some(isis_packet::srv6::EncapType::HEncap));
+                assert!(uni.mpls_label.is_empty());
+            }
+            other => panic!("expected Uni nexthop, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn select_fib_entry_v4_inherits_srv6_transport_from_nht() {
+        use crate::rib::nht::ResolvedNexthop;
+        // v4 sibling (RFC 8950-style v4 service over an SRv6-covered
+        // next-hop): same inheritance, v6 egress under a v4 prefix.
+        let sid: std::net::Ipv6Addr = "fcbb:bbbb:1:40::".parse().unwrap();
+        let rib = bgp_rib_with_nexthop(
+            Some(BgpNexthop::Ipv4(Ipv4Addr::new(10, 2, 0, 1))),
+            super::BgpRibType::IBGP,
+        );
+        let nht = vec![ResolvedNexthop {
+            addr: "fcbb:bbbb:1::".parse().unwrap(),
+            ifindex: 3,
+            labels: vec![],
+            segs: vec![sid],
+            seg_encap: Some(isis_packet::srv6::EncapType::HEncap),
+        }];
+        let entry = super::select_fib_entry_v4(&rib, None, Some(&nht)).expect("inherited");
+        match entry.nexthop {
+            crate::rib::Nexthop::Uni(uni) => {
+                assert_eq!(uni.segs, vec![sid]);
+                assert_eq!(uni.encap_type, Some(isis_packet::srv6::EncapType::HEncap));
+            }
+            other => panic!("expected Uni nexthop, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn select_fib_entry_v6_plain_when_nht_carries_labels_only() {
+        use crate::rib::nht::ResolvedNexthop;
+        // An MPLS-labelled resolution does NOT rewrite a plain unicast
+        // entry — labels are the LU/VPN paths' business. The entry
+        // keeps the bare BGP next-hop for the RIB to resolve.
+        let nh: std::net::Ipv6Addr = "2001:db8::8".parse().unwrap();
+        let rib = bgp_rib_with_nexthop(Some(BgpNexthop::Ipv6(nh)), super::BgpRibType::IBGP);
+        let nht = vec![ResolvedNexthop {
+            addr: "2001:db8:12::2".parse().unwrap(),
+            ifindex: 3,
+            labels: vec![16800],
+            segs: vec![],
+            seg_encap: None,
+        }];
+        let entry = super::select_fib_entry_v6(&rib, None, Some(&nht)).expect("plain");
+        match entry.nexthop {
+            crate::rib::Nexthop::Uni(uni) => {
+                assert_eq!(uni.addr, IpAddr::V6(nh));
+                assert!(uni.segs.is_empty());
+                assert!(uni.mpls_label.is_empty());
+            }
+            other => panic!("expected Uni nexthop, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn select_fib_entry_v6_service_sid_wins_over_inherited_transport() {
+        use crate::rib::nht::ResolvedNexthop;
+        // A route carrying its own SRv6 L3 service SID keeps it — the
+        // route's encapsulation is authoritative over anything the
+        // next-hop resolution would donate.
+        let own_sid: std::net::Ipv6Addr = "fcbb:bbbb:8:40::".parse().unwrap();
+        let transport_sid: std::net::Ipv6Addr = "fcbb:bbbb:1:40::".parse().unwrap();
+        let mut attr = srv6_l3_attr(own_sid);
+        attr.nexthop = Some(BgpNexthop::Ipv6("2001:db8::8".parse().unwrap()));
+        let rib = super::BgpRib::new(
+            0,
+            Ipv4Addr::new(10, 0, 0, 1),
+            super::BgpRibType::IBGP,
+            0,
+            0,
+            &attr,
+            None,
+            None,
+            false,
+        );
+        let nht = vec![ResolvedNexthop {
+            addr: "fcbb:bbbb:1::".parse().unwrap(),
+            ifindex: 3,
+            labels: vec![],
+            segs: vec![transport_sid],
+            seg_encap: Some(isis_packet::srv6::EncapType::HEncap),
+        }];
+        let entry = super::select_fib_entry_v6(&rib, None, Some(&nht)).expect("service entry");
+        match entry.nexthop {
+            crate::rib::Nexthop::Uni(uni) => {
+                assert_eq!(uni.segs, vec![own_sid]);
+            }
+            other => panic!("expected Uni nexthop, got {other:?}"),
+        }
+    }
+
     // --- build_vpn_fib_entry (moved from bgp/vrf/inst.rs) ----------------
+
+    #[test]
+    fn vpn_fib_entry_refuses_srv6_transport() {
+        use crate::rib::nht::ResolvedNexthop;
+        // An MPLS service label cannot ride SRv6 transport: an egress
+        // whose resolution carries a segment list is filtered, and with
+        // no usable egress left the entry is refused (→ withdraw).
+        let transport = vec![ResolvedNexthop {
+            addr: "fcbb:bbbb:1::".parse().unwrap(),
+            ifindex: 5,
+            labels: vec![],
+            segs: vec!["fcbb:bbbb:1:40::".parse().unwrap()],
+            seg_encap: Some(isis_packet::srv6::EncapType::HEncap),
+        }];
+        assert!(super::build_vpn_fib_entry(24001, &transport).is_none());
+    }
 
     #[test]
     fn vpn_fib_entry_pushes_service_label_below_transport() {


### PR DESCRIPTION
## Summary

The BGP twin of #1887: a plain unicast route whose next-hop resolves through an SRv6-encapsulated covering route (a BGP-over-SRv6 transport route) previously installed the bare BGP next-hop — natively unroutable when the next-hop sits behind the tunnel. The route now inherits the covering route's H.Encap segment list — the SRv6 analog of Inter-AS Option C (service routes recursing over a BGP-learned transport tunnel).

- `select_fib_entry_v4/v6` consume the winner's NHT resolution: a segs-carrying egress builds an inherited-seg6 entry (resolved egress + segment list, same shape as an explicit-SID entry → nexthop group dedupes with the covering route's). A route carrying its own SRv6 service SID keeps it; an MPLS-labelled resolution changes nothing for plain unicast.
- `build_vpn_fib_entry` / `ilm_swap_install` **refuse** egresses whose resolution carries segments — an MPLS service label or swap cannot ride SRv6 transport, so the entry/ILM is withheld rather than installed half-encapsulated.
- The NHT re-eval and table-map resync `BgpTop`s now carry the NHT cache, so re-installs re-derive the inherited encapsulation instead of degrading to plain entries; transport-only reroutes re-install unicast deps (previously a no-op).
- Colour/SR-policy MPLS steering skips entries carrying segments (one encapsulation per kernel nexthop).

## Test plan

- Unit: 5 new tests (v4/v6 inheritance, labels-only no-op, own-service-SID precedence, VPN refusal); `cargo test --workspace --exclude bdd` all green; workspace clippy clean.
- BDD: new `@bgp_srv6_nht` — z4—z1—z2—z3 line where the service node z4 peers iBGP with the ingress **through the SRv6 tunnel itself** (TCP encap at z3, decap at z1's End.DT6) and advertises a blackhole service aggregate; z3 installs it `proto bgp … encap seg6 segs [fcbb:bbbb:1:40::]` and the ping to z4's loopback crosses the locator-only core inside the inherited encapsulation.
- BDD regressions over every touched path: `static_srv6_nht`, `bgp_srv6_redistribute`, `bgp_interas_option_b`, `bgp_interas_option_c` (LU + swap ILM), `bgp_table_map`, `bgp_v6_table_map` (table-map resync), `bgp_mup_peerdown`, `bgp_vrf_evpn_type5` — all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)