### PR TITLE
rib: honest static-ILM rows in show mpls ilm

### DIFF
--- a/zebra-rs/src/rib/show.rs
+++ b/zebra-rs/src/rib/show.rs
@@ -1727,20 +1727,17 @@ fn write_ilm_entry(
             vrf_ifindex: _,
         } => format!("Mirror Ctx (tbl {:<3})", table_id),
         super::inst::IlmType::Swap => "LU Swap".to_string(),
-        super::inst::IlmType::None => {
-            // Try to find a matching route for this nexthop
-            if let Some((prefix, _)) = find_route_for_nexthop(rib, uni) {
-                prefix.to_string()
-            } else {
-                "Unknown".to_string()
-            }
-        }
+        // A static ILM (`router static mpls label ...`) is keyed by its
+        // incoming label and has no prefix or SID identity to show.
+        // (Guessing one from the RIB — any route sharing the gateway —
+        // rendered arbitrary unrelated prefixes here.)
+        super::inst::IlmType::None => "-".to_string(),
     };
 
     let interface = if uni.addr.is_unspecified() && uni.ifindex().is_none() {
         "default".to_string()
     } else {
-        rib.link_name(uni.ifindex().unwrap_or(0))
+        ilm_interface(rib, uni)
     };
 
     let next_hop = if uni.addr.is_unspecified() {
@@ -1786,19 +1783,14 @@ fn ilm_to_json(
             vrf_ifindex: _,
         } => format!("Mirror Ctx (tbl {})", table_id),
         super::inst::IlmType::Swap => "LU Swap".to_string(),
-        super::inst::IlmType::None => {
-            if let Some((prefix, _)) = find_route_for_nexthop(rib, uni) {
-                prefix.to_string()
-            } else {
-                "Unknown".to_string()
-            }
-        }
+        // See `write_ilm_entry`: no prefix/SID identity to show.
+        super::inst::IlmType::None => "-".to_string(),
     };
 
     let outgoing_interface = if uni.addr.is_unspecified() && uni.ifindex().is_none() {
         "default".to_string()
     } else {
-        rib.link_name(uni.ifindex().unwrap_or(0))
+        ilm_interface(rib, uni)
     };
 
     let next_hop = if uni.addr.is_unspecified() {
@@ -1819,29 +1811,24 @@ fn ilm_to_json(
     }
 }
 
-// Helper function to find a route that uses this nexthop
-fn find_route_for_nexthop<'a>(
-    rib: &'a Rib,
-    target_uni: &super::NexthopUni,
-) -> Option<(Ipv4Net, &'a RibEntry)> {
-    for (prefix, entries) in rib.table.iter() {
-        for entry in entries.iter() {
-            match &entry.nexthop {
-                Nexthop::Uni(uni) if uni.addr == target_uni.addr => {
-                    return Some((prefix, entry));
-                }
-                Nexthop::Multi(multi) => {
-                    for uni in &multi.nexthops {
-                        if uni.addr == target_uni.addr {
-                            return Some((prefix, entry));
-                        }
-                    }
-                }
-                _ => {}
-            }
+// Outgoing-interface name for an ILM nexthop. Most producers stamp an
+// ifindex; a static ILM (`router static mpls label ... nexthop <addr>`)
+// carries only the gateway address — the kernel resolves the `via` on
+// install — so resolve it against the RIB the same way for display
+// instead of rendering "unknown".
+fn ilm_interface(rib: &Rib, uni: &super::NexthopUni) -> String {
+    if let Some(ifindex) = uni.ifindex() {
+        return rib.link_name(ifindex);
+    }
+    if let std::net::IpAddr::V4(addr) = uni.addr {
+        let resolved =
+            super::resolve::rib_resolve(&rib.table, addr, &super::resolve::ResolveOpt::default())
+                .is_valid();
+        if resolved != 0 {
+            return rib.link_name(resolved);
         }
     }
-    None
+    rib.link_name(0)
 }
 
 #[derive(Serialize)]


### PR DESCRIPTION
## Summary

A static ILM (`router static mpls label …`) rendered with an arbitrary unrelated prefix and an unknown interface — found while writing the ospfv2-srmpls playset walkthrough (#1892):

```
*> S 1    200    Pop         10.0.0.7/32        unknown      192.168.2.2
```

Two display defects:

- **Prefix column**: static ILMs are the only producer of `IlmType::None`, whose show arm guessed a prefix via `find_route_for_nexthop` — the *first* RIB route sharing the gateway address (here r3's loopback, which merely routes via the same nexthop). An ILM is keyed by its incoming label and has no prefix identity; render `-` and delete the heuristic.
- **Interface column**: the static ILM nexthop carries only the gateway address (the kernel resolves the `via` itself at install), so the display fell through to `link_name(0)` = "unknown". New `ilm_interface` helper resolves the gateway against the RIB at display time, matching what the kernel did.

After (verified live on the ospfv2-srmpls playset, pop and swap variants, text and JSON):

```
*> S 1    200    Pop         -                  n1-d         192.168.2.2
*> S 1    201    16800       -                  n1-d         192.168.2.2
```

SR / VPN-decap / LU-swap rows are unchanged (their typed arms never used the heuristic).

## Test plan

- `cargo test --workspace --exclude bdd` all green (37 suites); clippy clean (forced re-lint on the touched file).
- Live verification on the ospfv2-srmpls playset: static pop ILM (no `outgoing-label`) and swap ILM (`outgoing-label 16800`) both render the new form in text and JSON; OSPF SR rows unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)