### PR TITLE
cradle: bind eBPF ports to their interface's VRF table

### DIFF
--- a/bdd/tests/features/cradle_spawn.feature
+++ b/bdd/tests/features/cradle_spawn.feature
@@ -35,6 +35,16 @@ Feature: system ebpf spawns and supervises the cradle eBPF engine
     And show command "show ebpf" in namespace "crs1" should eventually contain "Engine restarts: 1"
     And show command "show ebpf" in namespace "crs1" should eventually contain "attached"
 
+  Scenario: A VRF-enslaved port binds to the VRF's kernel table
+    Given the test topology exists
+    When I apply command "set vrf red" in namespace "crs1"
+    And I apply command "set interface eth0 vrf red" in namespace "crs1"
+    Then show command "show ebpf" in namespace "crs1" should eventually contain "vrf 1"
+    And show command "show ebpf" in namespace "crs1" should eventually contain "attached"
+    When I apply command "delete interface eth0 vrf red" in namespace "crs1"
+    Then show command "show ebpf" in namespace "crs1" should eventually not contain "vrf 1"
+    And show command "show ebpf" in namespace "crs1" should eventually contain "attached"
+
   Scenario: Disabling system ebpf stops the engine
     Given the test topology exists
     When I apply command "delete system ebpf enabled true" in namespace "crs1"

--- a/zebra-rs/src/bgp/config.rs
+++ b/zebra-rs/src/bgp/config.rs
@@ -7257,6 +7257,7 @@ mod neighbor_group_wiring_tests {
             addr6: Vec::new(),
             master: None,
             vni: None,
+            vrf_table: None,
             vxlan_local: None,
             mtu_error: None,
         };

--- a/zebra-rs/src/config/cradle.rs
+++ b/zebra-rs/src/config/cradle.rs
@@ -10,8 +10,9 @@ use super::ConfigManager;
 /// Mirrors `spawn_nd`: hosts that never touch these subtrees don't run the
 /// task. The FIB tee (`system cradle enabled`) stays with the RIB task and
 /// needs no spawn here; this task manages the engine process and its port
-/// set (default-VRF links — the RIB subscription is bound to the default
-/// VRF, matching the `SetPort` vrf 0 scope).
+/// set. The RIB subscription is `global_links` — the reconcile follows an
+/// `interface … ebpf enabled` interface across VRF enslavement and binds
+/// the port to the VRF's kernel table.
 ///
 /// [`commit_config`]: crate::config::ConfigManager::commit_config
 pub fn spawn_cradle(config: &ConfigManager) {
@@ -23,7 +24,7 @@ pub fn spawn_cradle(config: &ConfigManager) {
         if config.protocol_tasks.borrow().contains_key("cradle") {
             return;
         }
-        let (rib_client, rib_rx) = config.subscribe_to_rib("cradle");
+        let (rib_client, rib_rx) = config.subscribe_to_rib_global_links("cradle");
         let cradle = crate::cradle::Cradle::new(rib_client, rib_rx);
         config.subscribe("cradle", cradle.cm.tx.clone());
         config.subscribe_show("cradle", cradle.show.tx.clone());

--- a/zebra-rs/src/config/manager.rs
+++ b/zebra-rs/src/config/manager.rs
@@ -109,6 +109,7 @@ impl RibSubscriber {
             proto: proto.to_string(),
             tx: chan.tx.clone(),
             vrf_id,
+            global_links: false,
         });
 
         let client = crate::rib::client::RibClient::new(self.rib_inbound_tx.clone(), proto_id);
@@ -391,6 +392,36 @@ impl ConfigManager {
             proto: proto.to_string(),
             tx: chan.tx.clone(),
             vrf_id,
+            global_links: false,
+        });
+
+        let client = crate::rib::client::RibClient::new(self.rib_inbound_tx.clone(), proto_id);
+        (client, chan.rx)
+    }
+
+    /// Like [`Self::subscribe_to_rib`] (default-VRF installs) but the
+    /// subscriber additionally receives **link** events for every VRF
+    /// (`Subscriber::global_links`). Used by the cradle port
+    /// reconcile, which follows `interface … ebpf enabled` interfaces
+    /// across VRF enslavement.
+    pub fn subscribe_to_rib_global_links(
+        &self,
+        proto: &str,
+    ) -> (
+        crate::rib::client::RibClient,
+        tokio::sync::mpsc::UnboundedReceiver<crate::rib::api::RibRx>,
+    ) {
+        use std::sync::atomic::Ordering;
+        let id_raw = self.next_proto_id.fetch_add(1, Ordering::Relaxed);
+        let proto_id = crate::rib::client::ProtoId::from_raw(id_raw);
+
+        let chan = crate::rib::api::RibRxChannel::new();
+        let _ = self.rib_tx.send(crate::rib::Message::Subscribe {
+            proto_id,
+            proto: proto.to_string(),
+            tx: chan.tx.clone(),
+            vrf_id: 0,
+            global_links: true,
         });
 
         let client = crate::rib::client::RibClient::new(self.rib_inbound_tx.clone(), proto_id);

--- a/zebra-rs/src/cradle/inst.rs
+++ b/zebra-rs/src/cradle/inst.rs
@@ -39,6 +39,17 @@ struct Engine {
     task: Task<()>,
 }
 
+/// What the port reconcile needs to know about a kernel link, from
+/// `RibRx::LinkAdd` (the subscription is `global_links`, so links are
+/// visible wherever they are enslaved).
+struct LinkState {
+    name: String,
+    /// `IFLA_MASTER` — the bridge or VRF device this link is enslaved to.
+    master: Option<u32>,
+    /// `IFLA_VRF_TABLE` when this link IS a VRF master device.
+    vrf_table: Option<u32>,
+}
+
 /// Last observed engine availability, tracked from [`EngineEvent`]s for
 /// `show ebpf`.
 #[derive(Default)]
@@ -78,14 +89,16 @@ pub struct Cradle {
     grpc_endpoint: Option<String>,
     /// Staged `interface <name> ebpf enabled` leaves, keyed by if-name.
     if_ebpf: BTreeMap<String, bool>,
-    /// Kernel links, ifindex → name, from the RIB subscription (seeded by
-    /// the link dump at subscribe time).
-    links: HashMap<u32, String>,
+    /// Kernel links keyed by ifindex, from the RIB subscription (seeded
+    /// by the link dump at subscribe time; `global_links`, so VRF
+    /// enslavement never hides a link).
+    links: HashMap<u32, LinkState>,
     engine: Option<Engine>,
     /// Last observed engine availability (from [`EngineEvent`]s).
     status: EngineStatus,
-    /// Ports applied to the current engine: if-name → the ifindex used.
-    applied: HashMap<String, u32>,
+    /// Ports applied to the current engine:
+    /// if-name → (ifindex, VRF table) used in the `SetPort`.
+    applied: HashMap<String, (u32, u32)>,
     /// Port-programming client for [`Self::client_endpoint`].
     ports_client: Option<CradleFib>,
     client_endpoint: Option<String>,
@@ -175,7 +188,14 @@ impl Cradle {
     fn process_rib_msg(&mut self, msg: RibRx) {
         match msg {
             RibRx::LinkAdd(link) => {
-                self.links.insert(link.index, link.name);
+                self.links.insert(
+                    link.index,
+                    LinkState {
+                        name: link.name,
+                        master: link.master,
+                        vrf_table: link.vrf_table,
+                    },
+                );
             }
             RibRx::LinkDel(ifindex) => {
                 self.links.remove(&ifindex);
@@ -208,11 +228,20 @@ impl Cradle {
         }
     }
 
-    fn ifindex_of(&self, name: &str) -> Option<u32> {
-        self.links
-            .iter()
-            .find(|(_, n)| n.as_str() == name)
-            .map(|(ifindex, _)| *ifindex)
+    /// The `SetPort` binding for an interface: its ifindex plus the VRF
+    /// table it is enslaved to (0 = default). The table comes straight
+    /// from link state — the interface's `master` resolved to that
+    /// device's `IFLA_VRF_TABLE` — so config-driven (`interface X vrf`)
+    /// and externally-applied enslavement both bind the port. A bridge
+    /// master has no VRF table and yields 0.
+    fn port_binding(&self, name: &str) -> Option<(u32, u32)> {
+        let (ifindex, link) = self.links.iter().find(|(_, l)| l.name.as_str() == name)?;
+        let vrf = link
+            .master
+            .and_then(|m| self.links.get(&m))
+            .and_then(|m| m.vrf_table)
+            .unwrap_or(0);
+        Some((*ifindex, vrf))
     }
 
     /// The configured endpoint (override or default), independent of
@@ -278,12 +307,13 @@ impl Cradle {
                 .iter()
                 .filter(|(_, en)| **en)
                 .map(|(name, _)| {
-                    let ifindex = self.ifindex_of(name);
+                    let binding = self.port_binding(name);
                     serde_json::json!({
                         "name": name,
-                        "ifindex": ifindex,
-                        "attached": ifindex.is_some()
-                            && self.applied.get(name) == ifindex.as_ref(),
+                        "ifindex": binding.map(|(i, _)| i),
+                        "vrf": binding.map(|(_, v)| v),
+                        "attached": binding.is_some()
+                            && self.applied.get(name) == binding.as_ref(),
                     })
                 })
                 .collect();
@@ -359,15 +389,24 @@ impl Cradle {
         )
         .unwrap();
         for name in enabled {
-            match (self.ifindex_of(name), self.applied.get(name)) {
-                (Some(ifindex), Some(applied)) if *applied == ifindex => {
-                    writeln!(out, "    {name:<16} ifindex {ifindex:<6} attached").unwrap();
+            match (self.port_binding(name), self.applied.get(name)) {
+                (Some(binding), Some(applied)) if *applied == binding => {
+                    let (ifindex, vrf) = binding;
+                    writeln!(
+                        out,
+                        "    {name:<16} ifindex {ifindex:<6} vrf {vrf:<5} attached"
+                    )
+                    .unwrap();
                 }
-                (Some(ifindex), _) => {
-                    writeln!(out, "    {name:<16} ifindex {ifindex:<6} pending").unwrap();
+                (Some((ifindex, vrf)), _) => {
+                    writeln!(
+                        out,
+                        "    {name:<16} ifindex {ifindex:<6} vrf {vrf:<5} pending"
+                    )
+                    .unwrap();
                 }
                 (None, _) => {
-                    writeln!(out, "    {name:<16} {:<14} link absent", "-").unwrap();
+                    writeln!(out, "    {name:<16} {:<20} link absent", "-").unwrap();
                 }
             }
         }
@@ -429,10 +468,16 @@ impl Cradle {
         // 1) Detach ports that no longer match: disabled, link gone, or the
         //    device was re-created under a new ifindex. cradle resolves by
         //    attach-time name when the device is gone, so DelPort also
-        //    cleans up after deleted links.
-        for (name, applied_ifindex) in self.applied.clone() {
+        //    cleans up after deleted links. A VRF-binding change alone is
+        //    NOT a detach — step 2 re-SetPorts in place (cradle overwrites
+        //    the port entry and re-derives its routes under the new VRF).
+        for (name, (applied_ifindex, _)) in self.applied.clone() {
             let enabled = self.if_ebpf.get(&name).copied().unwrap_or(false);
-            if enabled && self.ifindex_of(&name) == Some(applied_ifindex) {
+            if enabled
+                && self
+                    .port_binding(&name)
+                    .is_some_and(|(ifindex, _)| ifindex == applied_ifindex)
+            {
                 continue;
             }
             match client.del_port(&name).await {
@@ -444,8 +489,9 @@ impl Cradle {
             }
         }
 
-        // 2) Attach enabled ports whose link exists and isn't applied yet
-        //    (or re-attach under a fresh ifindex after step 1 detached).
+        // 2) Attach enabled ports whose link exists and isn't applied with
+        //    the current (ifindex, VRF) binding — covers first attach,
+        //    re-attach after step 1, and in-place VRF moves.
         let wanted: Vec<String> = self
             .if_ebpf
             .iter()
@@ -453,16 +499,16 @@ impl Cradle {
             .map(|(name, _)| name.clone())
             .collect();
         for name in wanted {
-            let Some(ifindex) = self.ifindex_of(&name) else {
+            let Some((ifindex, vrf)) = self.port_binding(&name) else {
                 continue;
             };
-            if self.applied.get(&name) == Some(&ifindex) {
+            if self.applied.get(&name) == Some(&(ifindex, vrf)) {
                 continue;
             }
-            match client.set_port(&name).await {
+            match client.set_port(&name, vrf).await {
                 Ok(()) => {
-                    info!("cradle: attached port {name} (ifindex {ifindex})");
-                    self.applied.insert(name, ifindex);
+                    info!("cradle: attached port {name} (ifindex {ifindex}, vrf {vrf})");
+                    self.applied.insert(name, (ifindex, vrf));
                 }
                 Err(e) => warn!("cradle: SetPort {name} failed: {e} (will retry)"),
             }

--- a/zebra-rs/src/fib/cradle.rs
+++ b/zebra-rs/src/fib/cradle.rs
@@ -274,10 +274,14 @@ impl CradleFib {
 
     /// Attach `name` as a data-plane port (`SetPort`): cradle resolves the
     /// ifindex, attaches the TC/XDP programs, and derives the port's
-    /// local + connected routes. Scope for now: a routed port in the
-    /// global VRF (`l3`, vlan 0, vrf 0) — VRF/bridge binding follows with
-    /// the dynamic L2/L3 assignment work. Idempotent on cradle's side.
-    pub async fn set_port(&self, name: &str) -> anyhow::Result<()> {
+    /// local + connected routes — into VRF table `vrf_id` (0 = global)
+    /// when the interface is VRF-enslaved, so ingress lookups use the
+    /// per-VRF FIB. Routed ports only (`l3`, vlan 0) — bridge/L2 domain
+    /// binding follows with the dynamic L2/L3 assignment work. A repeat
+    /// `SetPort` on a live port is an in-place update on cradle's side
+    /// (the attach is idempotent; the port entry and derived routes are
+    /// re-reconciled under the new VRF).
+    pub async fn set_port(&self, name: &str, vrf_id: u32) -> anyhow::Result<()> {
         self.client()
             .await?
             .set_port(pb::Port {
@@ -285,7 +289,7 @@ impl CradleFib {
                 mac: String::new(),
                 l3: true,
                 vlan: 0,
-                vrf_id: 0,
+                vrf_id,
             })
             .await?;
         Ok(())

--- a/zebra-rs/src/fib/message.rs
+++ b/zebra-rs/src/fib/message.rs
@@ -45,6 +45,12 @@ pub struct FibLink {
     /// per RFC 8365 §5.1.3 (egress PE = local VTEP). None on
     /// non-VXLAN links and on VXLANs configured without a local IP.
     pub vxlan_local: Option<std::net::IpAddr>,
+    /// Kernel routing table from `IFLA_VRF_TABLE`
+    /// (`LinkInfo::Data(InfoData::Vrf(InfoVrf::TableId(_)))`) on VRF
+    /// master devices. None for every other link type. Lets an
+    /// all-VRF consumer (the cradle port reconcile) resolve a slave's
+    /// `master` to its VRF table without the RIB's registry.
+    pub vrf_table: Option<u32>,
 }
 
 impl FibLink {

--- a/zebra-rs/src/fib/netlink/handle.rs
+++ b/zebra-rs/src/fib/netlink/handle.rs
@@ -3772,8 +3772,10 @@ pub fn link_from_msg(msg: LinkMessage) -> FibLink {
             LinkAttribute::LinkInfo(infos) => {
                 // VXLAN link data carries both the VNI (`IFLA_VXLAN_ID`)
                 // and the local VTEP source IP (`IFLA_VXLAN_LOCAL` or
-                // `IFLA_VXLAN_LOCAL6`). Walk every Vxlan sub-attr and
-                // capture them. Non-VXLAN links contribute nothing.
+                // `IFLA_VXLAN_LOCAL6`); VRF master devices carry their
+                // kernel routing table (`IFLA_VRF_TABLE`). Walk every
+                // sub-attr and capture them. Other link types
+                // contribute nothing.
                 for info in infos {
                     if let LinkInfo::Data(InfoData::Vxlan(vxlan_attrs)) = info {
                         for v in vxlan_attrs {
@@ -3791,6 +3793,12 @@ pub fn link_from_msg(msg: LinkMessage) -> FibLink {
                                         Some(IpAddr::V6(std::net::Ipv6Addr::from(octets)));
                                 }
                                 _ => {}
+                            }
+                        }
+                    } else if let LinkInfo::Data(InfoData::Vrf(vrf_attrs)) = info {
+                        for v in vrf_attrs {
+                            if let InfoVrf::TableId(t) = v {
+                                link.vrf_table = Some(t);
                             }
                         }
                     }

--- a/zebra-rs/src/nd/engine.rs
+++ b/zebra-rs/src/nd/engine.rs
@@ -470,6 +470,7 @@ mod tests {
             addr6: Vec::new(),
             master: None,
             vni: None,
+            vrf_table: None,
             vxlan_local: None,
             mtu_error: None,
         }

--- a/zebra-rs/src/nd/show.rs
+++ b/zebra-rs/src/nd/show.rs
@@ -656,6 +656,7 @@ mod tests {
             addr6: Vec::new(),
             master: None,
             vni: None,
+            vrf_table: None,
             vxlan_local: None,
             mtu_error: None,
         }

--- a/zebra-rs/src/rib/api.rs
+++ b/zebra-rs/src/rib/api.rs
@@ -322,22 +322,27 @@ impl Rib {
     /// Used when an interface is re-enslaved across a VRF boundary:
     /// the link's `master` already points at the *new* VRF, so the
     /// target VRF must be named rather than re-derived.
+    ///
+    /// Link events additionally reach every `global_links` subscriber
+    /// (`iter_link_subs`); a cross-VRF move therefore appears to them
+    /// as a `LinkDel` + `LinkAdd` bounce of the same ifindex, with the
+    /// `LinkAdd` carrying the new `master`.
     pub fn api_link_add_vrf(&self, link: &Link, vrf_id: u32) {
-        for (_, sub) in self.client_registry.iter_vrf(vrf_id) {
+        for (_, sub) in self.client_registry.iter_link_subs(vrf_id) {
             let _ = sub.rib_rx_tx.send(RibRx::LinkAdd(link.clone()));
         }
     }
 
     pub fn api_link_up(&self, ifindex: u32) {
         let vrf_id = self.ifindex_vrf_id(ifindex);
-        for (_, sub) in self.client_registry.iter_vrf(vrf_id) {
+        for (_, sub) in self.client_registry.iter_link_subs(vrf_id) {
             let _ = sub.rib_rx_tx.send(RibRx::LinkUp(ifindex));
         }
     }
 
     pub fn api_link_down(&self, ifindex: u32) {
         let vrf_id = self.ifindex_vrf_id(ifindex);
-        for (_, sub) in self.client_registry.iter_vrf(vrf_id) {
+        for (_, sub) in self.client_registry.iter_link_subs(vrf_id) {
             let _ = sub.rib_rx_tx.send(RibRx::LinkDown(ifindex));
         }
     }
@@ -345,7 +350,7 @@ impl Rib {
     /// Push an MTU change to subscribers bound to this link's VRF.
     pub fn api_link_mtu(&self, ifindex: u32, mtu: u32) {
         let vrf_id = self.ifindex_vrf_id(ifindex);
-        for (_, sub) in self.client_registry.iter_vrf(vrf_id) {
+        for (_, sub) in self.client_registry.iter_link_subs(vrf_id) {
             let _ = sub.rib_rx_tx.send(RibRx::LinkMtu { ifindex, mtu });
         }
     }
@@ -363,7 +368,7 @@ impl Rib {
     /// link's `master` already names the *new* VRF, so the *old* VRF
     /// id must be passed in.
     pub fn api_link_del_vrf(&self, ifindex: u32, vrf_id: u32) {
-        for (_, sub) in self.client_registry.iter_vrf(vrf_id) {
+        for (_, sub) in self.client_registry.iter_link_subs(vrf_id) {
             let _ = sub.rib_rx_tx.send(RibRx::LinkDel(ifindex));
         }
     }

--- a/zebra-rs/src/rib/client.rs
+++ b/zebra-rs/src/rib/client.rs
@@ -169,6 +169,13 @@ pub struct Subscriber {
     pub proto: String,
     pub rib_rx_tx: UnboundedSender<RibRx>,
     pub vrf_id: u32,
+    /// Receive link lifecycle events (`LinkAdd`/`LinkDel`/`LinkUp`/
+    /// `LinkDown`/`LinkMtu`) for **every** VRF, not just `vrf_id`.
+    /// For consumers whose scope spans VRFs — the cradle eBPF port
+    /// reconcile follows interfaces wherever they are enslaved (the
+    /// port's `vrf_id` is derived from the link's master). Address
+    /// and route events stay VRF-scoped.
+    pub global_links: bool,
 }
 
 /// In-memory subscriber registry owned by `Rib`.
@@ -203,6 +210,7 @@ impl ClientRegistry {
         proto: &str,
         rib_rx_tx: UnboundedSender<RibRx>,
         vrf_id: u32,
+        global_links: bool,
     ) {
         self.subscribers.insert(
             id,
@@ -210,6 +218,7 @@ impl ClientRegistry {
                 proto: proto.to_string(),
                 rib_rx_tx,
                 vrf_id,
+                global_links,
             },
         );
         if id.0 >= self.next_proto_id {
@@ -263,6 +272,17 @@ impl ClientRegistry {
             .map(|(id, s)| (*id, s))
     }
 
+    /// Walk the subscribers that should see a **link** event from
+    /// `vrf_id`: the VRF's own subscribers plus every `global_links`
+    /// subscriber (each yielded once — a global subscriber bound to
+    /// the same VRF is not duplicated).
+    pub fn iter_link_subs(&self, vrf_id: u32) -> impl Iterator<Item = (ProtoId, &Subscriber)> {
+        self.subscribers
+            .iter()
+            .filter(move |(_, s)| s.vrf_id == vrf_id || s.global_links)
+            .map(|(id, s)| (*id, s))
+    }
+
     /// Remove a subscriber. Returns the removed entry so callers can
     /// clean up parallel maps keyed by the protocol name (e.g.
     /// `Rib::redist_filters`).
@@ -290,7 +310,7 @@ mod tests {
     fn register_with_id_records_subscriber_and_advances_next_id() {
         let mut reg = ClientRegistry::new();
         let (tx, _rx) = unbounded_channel();
-        reg.register_with_id(ProtoId::from_raw(5), "bgp", tx, 0);
+        reg.register_with_id(ProtoId::from_raw(5), "bgp", tx, 0, false);
         assert!(reg.contains(ProtoId::from_raw(5)));
         assert_eq!(reg.len(), 1);
         // next_proto_id is private but is exercised indirectly by the
@@ -303,7 +323,7 @@ mod tests {
         let (tx, _rx) = unbounded_channel();
         let id = ProtoId::from_raw(3);
 
-        reg.register_with_id(id, "bgp", tx, 0);
+        reg.register_with_id(id, "bgp", tx, 0, false);
         assert!(reg.contains(id));
 
         let sub = reg.unregister(id).expect("subscriber present");
@@ -316,7 +336,7 @@ mod tests {
         let mut reg = ClientRegistry::new();
         let (tx, _rx) = unbounded_channel();
         let real = ProtoId::from_raw(0);
-        reg.register_with_id(real, "bgp", tx, 0);
+        reg.register_with_id(real, "bgp", tx, 0, false);
         assert!(reg.unregister(ProtoId::from_raw(999)).is_none());
         assert!(reg.contains(real));
     }
@@ -326,8 +346,8 @@ mod tests {
         let mut reg = ClientRegistry::new();
         let (tx_a, _rx_a) = unbounded_channel();
         let (tx_b, _rx_b) = unbounded_channel();
-        reg.register_with_id(ProtoId::from_raw(0), "bgp", tx_a, 0);
-        reg.register_with_id(ProtoId::from_raw(1), "ospf", tx_b, 0);
+        reg.register_with_id(ProtoId::from_raw(0), "bgp", tx_a, 0, false);
+        reg.register_with_id(ProtoId::from_raw(1), "ospf", tx_b, 0, false);
 
         assert_eq!(reg.find_by_proto("bgp"), Some(ProtoId::from_raw(0)));
         assert_eq!(reg.find_by_proto("ospf"), Some(ProtoId::from_raw(1)));
@@ -349,8 +369,8 @@ mod tests {
         let mut reg = ClientRegistry::new();
         let (tx_a, _rx_a) = unbounded_channel();
         let (tx_b, _rx_b) = unbounded_channel();
-        reg.register_with_id(ProtoId::from_raw(0), "bgp", tx_a, 0);
-        reg.register_with_id(ProtoId::from_raw(1), "bgp:vrf:v1", tx_b, 10);
+        reg.register_with_id(ProtoId::from_raw(0), "bgp", tx_a, 0, false);
+        reg.register_with_id(ProtoId::from_raw(1), "bgp:vrf:v1", tx_b, 10, false);
 
         assert_eq!(reg.vrf_id_for(ProtoId::from_raw(0)), 0);
         assert_eq!(reg.vrf_id_for(ProtoId::from_raw(1)), 10);
@@ -365,9 +385,9 @@ mod tests {
         let (tx_default, _rx_a) = unbounded_channel();
         let (tx_vrf10, _rx_b) = unbounded_channel();
         let (tx_vrf20, _rx_c) = unbounded_channel();
-        reg.register_with_id(ProtoId::from_raw(0), "bgp", tx_default, 0);
-        reg.register_with_id(ProtoId::from_raw(1), "bgp:vrf:v1", tx_vrf10, 10);
-        reg.register_with_id(ProtoId::from_raw(2), "bgp:vrf:v2", tx_vrf20, 20);
+        reg.register_with_id(ProtoId::from_raw(0), "bgp", tx_default, 0, false);
+        reg.register_with_id(ProtoId::from_raw(1), "bgp:vrf:v1", tx_vrf10, 10, false);
+        reg.register_with_id(ProtoId::from_raw(2), "bgp:vrf:v2", tx_vrf20, 20, false);
 
         let default: Vec<_> = reg.iter_vrf(0).map(|(id, _)| id).collect();
         let v10: Vec<_> = reg.iter_vrf(10).map(|(id, _)| id).collect();
@@ -387,8 +407,8 @@ mod tests {
         let mut reg = ClientRegistry::new();
         let (tx_default, _rx_a) = unbounded_channel();
         let (tx_vrf10, _rx_b) = unbounded_channel();
-        reg.register_with_id(ProtoId::from_raw(0), "bgp", tx_default, 0);
-        reg.register_with_id(ProtoId::from_raw(1), "bgp:vrf:v1", tx_vrf10, 10);
+        reg.register_with_id(ProtoId::from_raw(0), "bgp", tx_default, 0, false);
+        reg.register_with_id(ProtoId::from_raw(1), "bgp:vrf:v1", tx_vrf10, 10, false);
 
         let ids: Vec<_> = reg.iter().map(|(id, _)| id).collect();
         assert_eq!(ids, vec![ProtoId::from_raw(0), ProtoId::from_raw(1)]);
@@ -402,8 +422,8 @@ mod tests {
         let mut reg = ClientRegistry::new();
         let (tx_a, _rx_a) = unbounded_channel();
         let (tx_b, _rx_b) = unbounded_channel();
-        reg.register_with_id(ProtoId::from_raw(0), "bgp", tx_a, 0);
-        reg.register_with_id(ProtoId::from_raw(1), "ospf", tx_b, 5);
+        reg.register_with_id(ProtoId::from_raw(0), "bgp", tx_a, 0, false);
+        reg.register_with_id(ProtoId::from_raw(1), "ospf", tx_b, 5, false);
 
         assert!(reg.subscriber_for_proto("bgp").is_some());
         assert_eq!(reg.subscriber_for_proto("ospf").map(|s| s.vrf_id), Some(5));

--- a/zebra-rs/src/rib/inst.rs
+++ b/zebra-rs/src/rib/inst.rs
@@ -497,6 +497,9 @@ pub enum Message {
         /// `Subscriber` row so the inbound dispatcher can pick the
         /// right per-VRF table without a name-based lookup.
         vrf_id: u32,
+        /// Receive link lifecycle events for every VRF, not just
+        /// `vrf_id` (see `Subscriber::global_links`).
+        global_links: bool,
     },
 
     // ---- redistribute subscription messages ----------------------
@@ -1836,6 +1839,7 @@ impl Rib {
         tx: UnboundedSender<RibRx>,
         proto: String,
         vrf_id: u32,
+        global_links: bool,
     ) {
         // A subscriber may have dropped its receiver before this
         // handler ran (e.g. its constructor failed after the
@@ -1960,7 +1964,7 @@ impl Rib {
             return;
         }
         self.client_registry
-            .register_with_id(proto_id, &proto, tx, vrf_id);
+            .register_with_id(proto_id, &proto, tx, vrf_id, global_links);
         // Redistribute registrations ride the inbound channel while this
         // Subscribe rides the message channel, and `event_loop`'s
         // `select!` gives the two no relative order. A RedistAdd /
@@ -3247,8 +3251,9 @@ impl Rib {
                 tx,
                 proto,
                 vrf_id,
+                global_links,
             } => {
-                self.subscribe(proto_id, tx, proto, vrf_id);
+                self.subscribe(proto_id, tx, proto, vrf_id, global_links);
             }
             Message::ProtoCleanup { proto } => {
                 self.proto_cleanup(proto).await;

--- a/zebra-rs/src/rib/link.rs
+++ b/zebra-rs/src/rib/link.rs
@@ -58,6 +58,12 @@ pub struct Link {
     /// on VXLAN links. Used as the BGP MP_REACH nexthop for EVPN
     /// advertisements per RFC 8365 §5.1.3.
     pub vxlan_local: Option<std::net::IpAddr>,
+    /// Kernel routing table from `IFLA_VRF_TABLE` on VRF master
+    /// devices; `None` for every other link type. Lets an all-VRF
+    /// consumer (the cradle port reconcile) resolve a slave's
+    /// `master` to its VRF table straight from link state.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub vrf_table: Option<u32>,
     /// Last failure reason from applying the operator-configured MTU
     /// (`mtu_config` keyed by name on `Rib`). `None` once a set
     /// succeeds. Rendered by `show interface` so a kernel rejection
@@ -85,6 +91,7 @@ impl Link {
             master: link.master,
             vni: link.vni,
             vxlan_local: link.vxlan_local,
+            vrf_table: link.vrf_table,
             mtu_error: None,
         }
     }
@@ -1326,6 +1333,7 @@ mod tests {
             addr6: Vec::new(),
             master: None,
             vni: None,
+            vrf_table: None,
             vxlan_local: None,
             mtu_error: None,
         }

--- a/zebra-rs/src/rib/redist.rs
+++ b/zebra-rs/src/rib/redist.rs
@@ -861,8 +861,8 @@ mod tests {
         let mut reg = ClientRegistry::new();
         let (tx_def, rx_def) = unbounded_channel();
         let (tx_vrf, rx_vrf) = unbounded_channel();
-        reg.register_with_id(ProtoId::from_raw(0), "bgp", tx_def, 0);
-        reg.register_with_id(ProtoId::from_raw(1), "bgp:vrf:N3", tx_vrf, 100);
+        reg.register_with_id(ProtoId::from_raw(0), "bgp", tx_def, 0, false);
+        reg.register_with_id(ProtoId::from_raw(1), "bgp:vrf:N3", tx_vrf, 100, false);
 
         let mut filters: HashMap<String, FilterMap> = HashMap::new();
         for proto in ["bgp", "bgp:vrf:N3"] {

--- a/zebra-rs/src/rib/router_id.rs
+++ b/zebra-rs/src/rib/router_id.rs
@@ -154,6 +154,7 @@ mod tests {
             addr6: Vec::new(),
             master,
             vni: None,
+            vrf_table: None,
             vxlan_local: None,
             mtu_error: None,
         }


### PR DESCRIPTION
## Summary

VRF-bound ports for the managed dataplane (follow-on to #1879–#1886, from the dynamic L2/L3 assignment design): an `interface <name> ebpf enabled` interface enslaved to a VRF — via `interface <name> vrf <v>` or externally — now attaches with `SetPort vrf_id = <the VRF's kernel table>`, so the engine's ingress lookups and derived local/connected routes land in the per-VRF FIB. A VRF move re-`SetPort`s in place (no detach; cradle overwrites the port entry and re-derives its routes under the new table).

Two small RIB extensions carry it:

- **`Subscriber::global_links`** — link lifecycle events (`LinkAdd/Del/Up/Down/Mtu`) fan out to a global-links subscriber for **every** VRF. Previously an interface moving into a VRF simply vanished from a default-VRF subscriber (`LinkDel` to the old scope, `LinkAdd` to the new), which would have silently detached the port. The subscribe-time dump was already global; a cross-VRF move reaches a global subscriber as a `LinkDel`+`LinkAdd` bounce of the same ifindex. Minted via the new `ConfigManager::subscribe_to_rib_global_links`; addr/route events stay VRF-scoped.
- **`Link::vrf_table`** — the kernel table from `IFLA_VRF_TABLE` on VRF master devices (parsed alongside the existing `InfoVxlan` attrs), so the reconcile resolves a slave's `master` to its table straight from link state.

The cradle task tracks `{name, master, vrf_table}` per link, keys its applied-set by `(ifindex, vrf)`, and re-attaches on binding changes; `show ebpf` gains a per-port `vrf` column (text + json).

## Test plan

- `cargo fmt --all --check`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo test --workspace --exclude bdd` — all green.
- Live netns: startup config binds `eth0` into `vrf red` (table 1) — `cradle dump ipv4 --vrf 1` shows the derived local `/32` + connected `/24` **in table 1**; runtime `delete interface eth0 vrf red` re-attaches with vrf 0; rebinding returns it to vrf 1 (attach log: vrf 0 → 1 → 0).
- `@cradle_spawn` gains a VRF-enslave scenario: **5/5 scenarios pass** via `make -C bdd cradle_spawn`.

Generated with [Claude Code](https://claude.com/claude-code)