### PR TITLE
bgp/mup: AFI-aware multi-SID handling and handover re-export gate

### DIFF
--- a/crates/bgp-packet/src/attrs/prefix_sid.rs
+++ b/crates/bgp-packet/src/attrs/prefix_sid.rs
@@ -22,6 +22,41 @@ pub const SRV6_BEHAVIOR_END_DX2V: u16 = 0x0016;
 pub const SRV6_BEHAVIOR_END_DT2U: u16 = 0x0017;
 pub const SRV6_BEHAVIOR_END_DT2M: u16 = 0x0018;
 
+/// Pick the SRv6 L3 Service SID a destination of the given address
+/// family should be steered into, from a route's `(SID, behavior)`
+/// pairs in wire order (`BgpAttr::srv6_l3_sids`). An originator may
+/// advertise a split `End.DT4` + `End.DT6` pair instead of one
+/// `End.DT46`, so taking the first SID can encapsulate traffic toward
+/// a decap behavior of the wrong family (an `End.DT4` drops IPv6).
+/// Preference: the exact per-family decap behavior (`End.DT4` for v4,
+/// `End.DT6` for v6), then `End.DT46`. `None` when the SIDs carry
+/// known L3-decap behaviors but none is family-compatible — the route
+/// cannot service this destination. When no SID carries a known
+/// L3-decap behavior at all (unmodeled codepoints), fall back to the
+/// first SID rather than second-guessing semantics we don't know.
+pub fn srv6_l3_sid_for_dest(sids: &[(Ipv6Addr, u16)], dest_v4: bool) -> Option<(Ipv6Addr, u16)> {
+    let exact = if dest_v4 {
+        SRV6_BEHAVIOR_END_DT4
+    } else {
+        SRV6_BEHAVIOR_END_DT6
+    };
+    if let Some(hit) = sids.iter().find(|(_, b)| *b == exact) {
+        return Some(*hit);
+    }
+    if let Some(hit) = sids.iter().find(|(_, b)| *b == SRV6_BEHAVIOR_END_DT46) {
+        return Some(*hit);
+    }
+    const L3_DECAP: [u16; 3] = [
+        SRV6_BEHAVIOR_END_DT4,
+        SRV6_BEHAVIOR_END_DT6,
+        SRV6_BEHAVIOR_END_DT46,
+    ];
+    if sids.iter().any(|(_, b)| L3_DECAP.contains(b)) {
+        return None;
+    }
+    sids.first().copied()
+}
+
 /// BGP Prefix-SID TLV Types (IANA "BGP Prefix-SID TLV Types", RFC 8669 /
 /// RFC 9252 §8.1).
 const PREFIX_SID_TLV_LABEL_INDEX: u8 = 1;
@@ -535,6 +570,58 @@ impl fmt::Display for PrefixSid {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn srv6_l3_sid_for_dest_prefers_exact_family_then_dt46() {
+        let dt4: Ipv6Addr = "fcbb:1::4".parse().unwrap();
+        let dt6: Ipv6Addr = "fcbb:1::6".parse().unwrap();
+        let dt46: Ipv6Addr = "fcbb:1::46".parse().unwrap();
+        // Split DT4+DT6 pair: each family gets its own SID regardless of
+        // wire order (DT6 listed first here).
+        let split = [(dt6, SRV6_BEHAVIOR_END_DT6), (dt4, SRV6_BEHAVIOR_END_DT4)];
+        assert_eq!(
+            srv6_l3_sid_for_dest(&split, true),
+            Some((dt4, SRV6_BEHAVIOR_END_DT4))
+        );
+        assert_eq!(
+            srv6_l3_sid_for_dest(&split, false),
+            Some((dt6, SRV6_BEHAVIOR_END_DT6))
+        );
+        // The exact-family SID wins over an also-present DT46; without an
+        // exact match, DT46 serves either family.
+        let mixed = [(dt46, SRV6_BEHAVIOR_END_DT46), (dt4, SRV6_BEHAVIOR_END_DT4)];
+        assert_eq!(
+            srv6_l3_sid_for_dest(&mixed, true),
+            Some((dt4, SRV6_BEHAVIOR_END_DT4))
+        );
+        assert_eq!(
+            srv6_l3_sid_for_dest(&mixed, false),
+            Some((dt46, SRV6_BEHAVIOR_END_DT46))
+        );
+    }
+
+    #[test]
+    fn srv6_l3_sid_for_dest_rejects_family_incompatible_decap() {
+        // A DT4-only segment cannot service an IPv6 destination (End.DT4
+        // decaps into the IPv4 table only) — and vice versa.
+        let dt4: Ipv6Addr = "fcbb:1::4".parse().unwrap();
+        let only_v4 = [(dt4, SRV6_BEHAVIOR_END_DT4)];
+        assert_eq!(srv6_l3_sid_for_dest(&only_v4, false), None);
+        let dt6: Ipv6Addr = "fcbb:1::6".parse().unwrap();
+        let only_v6 = [(dt6, SRV6_BEHAVIOR_END_DT6)];
+        assert_eq!(srv6_l3_sid_for_dest(&only_v6, true), None);
+    }
+
+    #[test]
+    fn srv6_l3_sid_for_dest_falls_back_to_first_for_unmodeled_behaviors() {
+        // No known L3-decap behavior at all → first SID (semantics we
+        // don't model, so keep the historical pick). Empty → None.
+        let odd: Ipv6Addr = "fcbb:1::99".parse().unwrap();
+        let vendor = [(odd, 0x7fff_u16)];
+        assert_eq!(srv6_l3_sid_for_dest(&vendor, true), Some((odd, 0x7fff)));
+        assert_eq!(srv6_l3_sid_for_dest(&vendor, false), Some((odd, 0x7fff)));
+        assert_eq!(srv6_l3_sid_for_dest(&[], true), None);
+    }
 
     fn round_trip(sid: PrefixSid) -> PrefixSid {
         let mut buf = BytesMut::new();

--- a/crates/bgp-packet/src/bgp_attr.rs
+++ b/crates/bgp-packet/src/bgp_attr.rs
@@ -150,11 +150,28 @@ impl BgpAttr {
     /// The first SRv6 L3 Service SID (value + endpoint behavior) carried
     /// in the Prefix-SID attribute — RFC 9252 L3VPN-over-SRv6. `None`
     /// when the attribute is absent or carries no SRv6 L3 Service TLV.
+    /// An originator may carry several service SIDs (e.g. a split
+    /// `End.DT4` + `End.DT6` pair instead of one `End.DT46`); consumers
+    /// that steer traffic should select by destination address family
+    /// ([`crate::srv6_l3_sid_for_dest`] over [`Self::srv6_l3_sids`])
+    /// rather than take the first.
     pub fn srv6_l3_sid(&self) -> Option<(std::net::Ipv6Addr, u16)> {
-        self.prefix_sid.as_ref()?.tlvs.iter().find_map(|t| match t {
-            PrefixSidTlv::Srv6L3Service(svc) => svc.sids.first().map(|s| (s.sid, s.behavior)),
-            _ => None,
-        })
+        self.srv6_l3_sids().next()
+    }
+
+    /// Every SRv6 L3 Service SID (value + endpoint behavior) carried in
+    /// the Prefix-SID attribute, in wire order across all SRv6 L3
+    /// Service TLVs and their SID Information sub-TLVs. Empty when the
+    /// attribute is absent or carries no SRv6 L3 Service TLV.
+    pub fn srv6_l3_sids(&self) -> impl Iterator<Item = (std::net::Ipv6Addr, u16)> + '_ {
+        self.prefix_sid
+            .iter()
+            .flat_map(|ps| ps.tlvs.iter())
+            .filter_map(|t| match t {
+                PrefixSidTlv::Srv6L3Service(svc) => Some(svc),
+                _ => None,
+            })
+            .flat_map(|svc| svc.sids.iter().map(|s| (s.sid, s.behavior)))
     }
 
     /// The first SRv6 L2 Service SID (value + endpoint behavior) carried
@@ -343,6 +360,65 @@ mod tests {
             ..Default::default()
         };
         assert_eq!(attr.prefix_sid_label_index(), Some(42));
+    }
+
+    #[test]
+    fn srv6_l3_sids_yields_every_sid_across_tlvs_in_wire_order() {
+        // A split End.DT4 + End.DT6 pair: one TLV carrying two SID
+        // Information sub-TLVs plus a second L3 Service TLV — all three
+        // SIDs must surface, in wire order, with the L2 TLV skipped.
+        let dt4: std::net::Ipv6Addr = "fcbb:1::4".parse().unwrap();
+        let dt6: std::net::Ipv6Addr = "fcbb:1::6".parse().unwrap();
+        let dt46: std::net::Ipv6Addr = "fcbb:1::46".parse().unwrap();
+        let l2: std::net::Ipv6Addr = "fcbb:1::2".parse().unwrap();
+        let attr = BgpAttr {
+            prefix_sid: Some(PrefixSid {
+                tlvs: vec![
+                    PrefixSidTlv::Srv6L3Service(Srv6ServiceTlv {
+                        sids: vec![
+                            Srv6SidInfo::new(dt4, 0, SRV6_BEHAVIOR_END_DT4, None),
+                            Srv6SidInfo::new(dt6, 0, SRV6_BEHAVIOR_END_DT6, None),
+                        ],
+                        ..Default::default()
+                    }),
+                    PrefixSidTlv::Srv6L2Service(Srv6ServiceTlv {
+                        sids: vec![Srv6SidInfo::new(l2, 0, SRV6_BEHAVIOR_END_DT2M, None)],
+                        ..Default::default()
+                    }),
+                    PrefixSidTlv::Srv6L3Service(Srv6ServiceTlv {
+                        sids: vec![Srv6SidInfo::new(dt46, 0, SRV6_BEHAVIOR_END_DT46, None)],
+                        ..Default::default()
+                    }),
+                ],
+            }),
+            ..Default::default()
+        };
+        let sids: Vec<_> = attr.srv6_l3_sids().collect();
+        assert_eq!(
+            sids,
+            vec![
+                (dt4, SRV6_BEHAVIOR_END_DT4),
+                (dt6, SRV6_BEHAVIOR_END_DT6),
+                (dt46, SRV6_BEHAVIOR_END_DT46),
+            ]
+        );
+        // The single-SID accessor stays the first-in-wire-order SID.
+        assert_eq!(attr.srv6_l3_sid(), Some((dt4, SRV6_BEHAVIOR_END_DT4)));
+    }
+
+    #[test]
+    fn srv6_l3_sids_empty_when_attr_absent_or_l3_free() {
+        assert_eq!(BgpAttr::default().srv6_l3_sids().count(), 0);
+        let attr = BgpAttr {
+            prefix_sid: Some(PrefixSid {
+                tlvs: vec![PrefixSidTlv::LabelIndex {
+                    flags: 0,
+                    label_index: 7,
+                }],
+            }),
+            ..Default::default()
+        };
+        assert_eq!(attr.srv6_l3_sids().count(), 0);
     }
 
     #[test]

--- a/zebra-rs/src/bgp/config.rs
+++ b/zebra-rs/src/bgp/config.rs
@@ -8355,10 +8355,124 @@ mod mup_dual_origination_tests {
     use std::str::FromStr;
 
     use bgp_packet::{MupPrefix, RouteDistinguisher};
+    use tokio::sync::mpsc;
 
+    use super::super::inst::Bgp;
     use super::super::route::build_mup_st_route;
     use super::super::vrf::inst::mup_session_targets;
     use super::super::vrf_config::{BgpVrfConfig, MupSrv6Direction, MupSrv6Mobile};
+
+    fn fresh_bgp() -> Bgp {
+        let (inbound_tx, _inbound_rx) = mpsc::unbounded_channel();
+        let (_rib_rx_tx, rib_rx) = mpsc::unbounded_channel();
+        let client = crate::rib::client::RibClient::new(
+            inbound_tx,
+            crate::rib::client::ProtoId::from_raw(0),
+        );
+        Box::leak(Box::new(_inbound_rx));
+        let ctx = crate::context::ProtoContext::default_table(client);
+
+        let (rib_tx, _rib_rx) = mpsc::unbounded_channel();
+        let (rib_inbound_tx, _sub_inbound_rx) = mpsc::unbounded_channel();
+        Box::leak(Box::new(_rib_rx));
+        Box::leak(Box::new(_sub_inbound_rx));
+        let next_proto_id = std::sync::Arc::new(std::sync::atomic::AtomicU32::new(1));
+        let subscriber =
+            crate::config::RibSubscriber::for_test(rib_tx, rib_inbound_tx, next_proto_id);
+
+        let (policy_tx, _policy_rx) = mpsc::unbounded_channel();
+        Box::leak(Box::new(_policy_rx));
+        Bgp::new(
+            ctx,
+            rib_rx,
+            subscriber,
+            policy_tx,
+            None,
+            None,
+            tokio::sync::mpsc::channel(1).0,
+        )
+    }
+
+    /// A handover Session-Modification re-dispatches `MupOriginate` to every
+    /// VRF the session targets, so the direction the modification didn't
+    /// touch (the ST2 — the core tunnel stays put while the gNB moves)
+    /// reaches `mup_export` rebuilt byte-identical. The export boundary must
+    /// drop it — peers used to see a spurious ST2 UPDATE on every handover —
+    /// while the genuinely-changed ST1 (moved endpoint/TEID, off the NLRI
+    /// key) still falls through and replaces in place.
+    #[tokio::test]
+    async fn mup_export_drops_identical_reexport() {
+        use bgp_packet::{BgpAttr, MupSt1Fields};
+
+        let mut bgp = fresh_bgp();
+        let rd: RouteDistinguisher = "65501:2".parse().unwrap();
+        bgp.vrfs.insert(
+            "N3".to_string(),
+            BgpVrfConfig {
+                rd: Some(rd),
+                ..Default::default()
+            },
+        );
+
+        let st2 = MupPrefix::T2st {
+            endpoint: "10.9.0.1".parse().unwrap(),
+            teid: 0x9999,
+        };
+        let attr = BgpAttr::new();
+        assert!(
+            bgp.mup_export("N3".into(), st2.clone(), None, attr.clone()),
+            "first ST2 export lands"
+        );
+        assert!(
+            !bgp.mup_export("N3".into(), st2.clone(), None, attr.clone()),
+            "an identical ST2 re-export (handover re-dispatch) is dropped"
+        );
+
+        let ue = MupPrefix::T1st {
+            prefix: "192.0.2.5/32".parse().unwrap(),
+        };
+        let mk = |endpoint: &str, teid| {
+            Some(MupSt1Fields {
+                teid,
+                qfi: 9,
+                endpoint: endpoint.parse().unwrap(),
+                source: None,
+            })
+        };
+        assert!(bgp.mup_export(
+            "N3".into(),
+            ue.clone(),
+            mk("10.0.0.1", 0x1234),
+            attr.clone()
+        ));
+        assert!(
+            !bgp.mup_export(
+                "N3".into(),
+                ue.clone(),
+                mk("10.0.0.1", 0x1234),
+                attr.clone()
+            ),
+            "an unchanged ST1 re-export is dropped too"
+        );
+        assert!(
+            bgp.mup_export(
+                "N3".into(),
+                ue.clone(),
+                mk("10.0.0.9", 0x5678),
+                attr.clone()
+            ),
+            "the handover's moved gNB endpoint/TEID (off-key ST1 fields) falls through"
+        );
+        // The in-place replace kept a single Originated candidate — the gate
+        // must not let duplicate rows accumulate across handovers.
+        let cands = bgp.local_rib.mup.get(&rd).unwrap().cands.get(&ue).unwrap();
+        assert_eq!(cands.len(), 1, "one Originated candidate after handover");
+        assert_eq!(
+            cands[0].mup_st1.map(|f| (f.teid, f.endpoint)),
+            Some((0x5678, "10.0.0.9".parse().unwrap())),
+            "the stored ST1 carries the post-handover tunnel"
+        );
+    }
 
     fn mup_vrf(rd: &str, direction: MupSrv6Direction, ni: &str, ext: Option<&str>) -> BgpVrfConfig {
         let mut cfg = BgpVrfConfig {

--- a/zebra-rs/src/bgp/route.rs
+++ b/zebra-rs/src/bgp/route.rs
@@ -13644,15 +13644,18 @@ impl Bgp {
     /// `Originated` and runs best-path → advertise + mirror (the mirror feeds
     /// the route back to the originating VRF, so its `show bgp vrf <name> mup`
     /// reflects the fully-stamped route). No-op when the VRF has no RD.
+    /// Returns whether the export landed — `false` when it was dropped, in
+    /// particular a re-export identical to the stored originated path (see
+    /// the identical-re-export gate below).
     pub fn mup_export(
         &mut self,
         vrf: String,
         prefix: MupPrefix,
         st1: Option<MupSt1Fields>,
         attr: BgpAttr,
-    ) {
+    ) -> bool {
         let Some(rd) = self.vrfs.get(&vrf).and_then(|c| c.rd) else {
-            return;
+            return false;
         };
         let rts = self
             .rib_known_vrfs
@@ -13684,10 +13687,10 @@ impl Bgp {
                     self.srv6_locator.as_ref(),
                     self.vrf_registry.get(&vrf).and_then(|h| h.srv6_sid),
                 ) else {
-                    return;
+                    return false;
                 };
                 let Some(node) = locator.node_sid_addr() else {
-                    return;
+                    return false;
                 };
                 attr.nexthop = Some(BgpNexthop::Ipv6(node));
                 attr.prefix_sid = Some(super::inst::srv6_l3_service_prefix_sid(
@@ -13696,9 +13699,30 @@ impl Bgp {
                     bgp_packet::SRV6_BEHAVIOR_END_DT46,
                 ));
             }
-            MupPrefix::Unknown { .. } => return,
+            MupPrefix::Unknown { .. } => return false,
         }
         let attr = super::inst::tag_attr_with_export_rts(attr, &rts);
+        let attr = self.attr_store.intern(attr);
+        // A PFCP Session Modification (handover) re-dispatches `MupOriginate`
+        // to every VRF the session targets, so the direction the modification
+        // didn't touch — typically the ST2: the core tunnel stays put while
+        // the gNB access tunnel moves — arrives here rebuilt identical to
+        // what the Loc-RIB already holds. Drop it: re-updating would re-run
+        // best-path and re-advertise, sending peers a spurious UPDATE for an
+        // unchanged route on every handover. A genuine change (NLRI key, ST1
+        // off-key fields, RTs, next-hop, SID) differs in `attr`/`st1`/key and
+        // falls through.
+        if self
+            .local_rib
+            .mup
+            .get(&rd)
+            .and_then(|t| t.cands.get(&prefix))
+            .into_iter()
+            .flatten()
+            .any(|r| r.typ == BgpRibType::Originated && r.attr == attr && r.mup_st1 == st1)
+        {
+            return false;
+        }
         let mut rib = BgpRib::new(
             ORIGINATED_PEER,
             Ipv4Addr::UNSPECIFIED,
@@ -13714,7 +13738,7 @@ impl Bgp {
         // mirror-back to the VRF, the re-advertise and the FIB reconcile see
         // the real TEID/QFI/endpoint. `None` for DSD/ISD/ST2 exports.
         rib.mup_st1 = st1;
-        rib.attr = self.attr_store.intern(attr);
+        rib.attr = attr;
         // A re-export for the same RD+Prefix key can move the ST1 GTP
         // endpoint in place (handover) — capture the pre-update endpoint so
         // its NHT registration is released when the new best no longer uses
@@ -13734,6 +13758,7 @@ impl Bgp {
             );
         }
         self.mup_apply_selected(rd, prefix, selected);
+        true
     }
 
     /// The GTP endpoint (gNB) of the currently-selected ST1 path for

--- a/zebra-rs/src/bgp/show.rs
+++ b/zebra-rs/src/bgp/show.rs
@@ -4507,9 +4507,15 @@ fn render_mup_table(
     // can be resolved to the End.DT46 Direct segment its uplink GTP tunnel
     // forwards into (draft-mpmz-bess-mup-safi §3.3.12). The forwarding FIB
     // (H.M.GTP4.D GTP decap) is VPP/eBPF — this is the control-plane bind.
+    // All service SIDs are kept (a DSD may split End.DT4 + End.DT6 instead
+    // of one End.DT46); the per-ST2 resolution picks by endpoint family.
     let dsd_index: std::collections::BTreeMap<
         [u8; 6],
-        (RouteDistinguisher, MupPrefix, std::net::Ipv6Addr, u16),
+        (
+            RouteDistinguisher,
+            MupPrefix,
+            Vec<(std::net::Ipv6Addr, u16)>,
+        ),
     > = if resolve_segments {
         tables
             .iter()
@@ -4524,8 +4530,11 @@ fn render_mup_table(
                     return None;
                 }
                 let seg = mup_direct_segment_id(&rib.attr)?;
-                let (sid, behavior) = rib.attr.srv6_l3_sid()?;
-                Some((seg, (*rd, prefix.clone(), sid, behavior)))
+                let sids: Vec<_> = rib.attr.srv6_l3_sids().collect();
+                if sids.is_empty() {
+                    return None;
+                }
+                Some((seg, (*rd, prefix.clone(), sids)))
             })
             .collect()
     } else {
@@ -4544,8 +4553,7 @@ fn render_mup_table(
         RouteDistinguisher,
         MupPrefix,
         IpNet,
-        std::net::Ipv6Addr,
-        u16,
+        Vec<(std::net::Ipv6Addr, u16)>,
     )> = if resolve_segments {
         tables
             .iter()
@@ -4559,8 +4567,11 @@ fn render_mup_table(
                 let MupPrefix::Isd { prefix: isd_prefix } = prefix else {
                     return None;
                 };
-                let (sid, behavior) = rib.attr.srv6_l3_sid()?;
-                Some((*rd, prefix.clone(), *isd_prefix, sid, behavior))
+                let sids: Vec<_> = rib.attr.srv6_l3_sids().collect();
+                if sids.is_empty() {
+                    return None;
+                }
+                Some((*rd, prefix.clone(), *isd_prefix, sids))
             })
             .collect()
     } else {
@@ -4587,14 +4598,16 @@ fn render_mup_table(
             let nexthop = show_nexthop(&rib.attr);
             writeln!(buf, "       next-hop {nexthop}  weight {}", rib.weight)?;
 
-            // SRv6 L3 Service SID (the segment a DSD/ISD route advertises, or
-            // an explicitly-pushed ST-route SID). "Local" when we originated it.
-            if let Some((sid, behavior)) = rib.attr.srv6_l3_sid() {
-                let kind = if rib.is_originated() {
-                    "Local SID"
-                } else {
-                    "Remote SID"
-                };
+            // SRv6 L3 Service SIDs (the segment a DSD/ISD route advertises,
+            // or an explicitly-pushed ST-route SID) — one line per SID, so a
+            // split End.DT4 + End.DT6 pair shows both. "Local" when we
+            // originated it.
+            let kind = if rib.is_originated() {
+                "Local SID"
+            } else {
+                "Remote SID"
+            };
+            for (sid, behavior) in rib.attr.srv6_l3_sids() {
                 writeln!(
                     buf,
                     "       {kind} {sid} ({})",
@@ -4610,17 +4623,19 @@ fn render_mup_table(
             // ST2 -> Direct-segment resolution on an interwork (SRGW) node:
             // the received ST2's Direct-segment id (MUP Extended Community) is
             // matched against a received DSD to find the End.DT46 segment the
-            // uplink (endpoint, TEID) tunnel forwards into.
+            // uplink (endpoint, TEID) tunnel forwards into. The SID is picked
+            // by the ST2 endpoint's family (the installed FIB destination).
             if resolve_segments
-                && matches!(prefix, MupPrefix::T2st { .. })
+                && let MupPrefix::T2st { endpoint, .. } = prefix
                 && let Some(seg) = mup_direct_segment_id(&rib.attr)
-                && let Some((dsd_rd, dsd, sid, behavior)) = dsd_index.get(&seg)
+                && let Some((dsd_rd, dsd, sids)) = dsd_index.get(&seg)
+                && let Some((sid, behavior)) = srv6_l3_sid_for_dest(sids, endpoint.is_ipv4())
             {
                 writeln!(
                     buf,
                     "       resolved {} -> {} {} (via {})",
                     fmt_direct_segment_id(&seg),
-                    srv6_behavior_name(*behavior),
+                    srv6_behavior_name(behavior),
                     sid,
                     mup_prefix_display(dsd_rd, dsd, None)
                 )?;
@@ -4635,20 +4650,29 @@ fn render_mup_table(
             // field, §3.1.3) — downlink traffic to the UE is steered toward
             // the gNB's segment. Matching by the endpoint also handles the
             // mixed-AFI case (an IPv6 UE route may carry an IPv4 gNB endpoint).
+            // The SID is picked by the UE prefix's family (the installed FIB
+            // destination); an ISD whose SIDs cannot service that family
+            // (e.g. End.DT4-only for an IPv6 UE) is skipped, letting a
+            // less-specific covering ISD with a compatible SID win.
             if resolve_segments
                 && let MupPrefix::T1st { prefix: ue } = prefix
                 && let Some(st1) = &rib.mup_st1
-                && let Some((isd_rd, isd, _, sid, behavior)) = isd_index
+                && let Some((isd_rd, isd, sid, behavior)) = isd_index
                     .iter()
-                    .filter(|(_, _, isd_prefix, _, _)| isd_prefix.contains(&st1.endpoint))
+                    .filter(|(_, _, isd_prefix, _)| isd_prefix.contains(&st1.endpoint))
+                    .filter_map(|(isd_rd, isd, isd_prefix, sids)| {
+                        srv6_l3_sid_for_dest(sids, matches!(ue, IpNet::V4(_)))
+                            .map(|(sid, behavior)| (isd_rd, isd, isd_prefix, sid, behavior))
+                    })
                     .max_by_key(|(_, _, isd_prefix, _, _)| isd_prefix.prefix_len())
+                    .map(|(isd_rd, isd, _, sid, behavior)| (isd_rd, isd, sid, behavior))
             {
                 writeln!(
                     buf,
                     "       resolved {} (endpoint {}) -> {} {} (via {})",
                     ue,
                     st1.endpoint,
-                    srv6_behavior_name(*behavior),
+                    srv6_behavior_name(behavior),
                     sid,
                     mup_prefix_display(isd_rd, isd, None)
                 )?;
@@ -6238,6 +6262,121 @@ mod detail_tests {
         // to nothing (10.70.0.9 still appears in its own [ST1] NLRI line, so
         // assert on the absence of a *resolved* line for its UE).
         assert!(!out.contains("resolved 10.60.2.5"), "{out}");
+    }
+
+    /// An ISD may carry a split End.DT4 + End.DT6 SID pair instead of one
+    /// End.DT46. Every SID gets its own display line, and the ST1→ISD
+    /// resolution picks the SID that can decap the UE prefix's family — an
+    /// ISD without a family-compatible SID is skipped even when it is the
+    /// most-specific covering one, letting a wider compatible ISD win.
+    #[test]
+    fn render_mup_table_multi_sid_isd_resolves_by_ue_family() {
+        use std::net::{IpAddr, Ipv4Addr};
+        let mut tables: std::collections::BTreeMap<
+            RouteDistinguisher,
+            super::super::route::LocalRibMupTable,
+        > = std::collections::BTreeMap::new();
+
+        let isd_rib_with = |sids: Vec<Srv6SidInfo>| {
+            let mut attr = BgpAttr::new();
+            attr.nexthop = Some(BgpNexthop::Ipv6("fcbb:bbbb:1::".parse().unwrap()));
+            attr.prefix_sid = Some(PrefixSid {
+                tlvs: vec![PrefixSidTlv::Srv6L3Service(Srv6ServiceTlv {
+                    sids,
+                    ..Default::default()
+                })],
+            });
+            BgpRib::new(
+                0,
+                Ipv4Addr::new(10, 0, 0, 1),
+                BgpRibType::IBGP,
+                0,
+                0,
+                &attr,
+                None,
+                None,
+                false,
+            )
+        };
+
+        // The wide ISD (10.0.0.0/24) carries the split DT4 + DT6 pair.
+        let wide = isd_rib_with(vec![
+            Srv6SidInfo::new(
+                "fcbb:aaaa::4".parse().unwrap(),
+                0,
+                SRV6_BEHAVIOR_END_DT4,
+                None,
+            ),
+            Srv6SidInfo::new(
+                "fcbb:aaaa::6".parse().unwrap(),
+                0,
+                SRV6_BEHAVIOR_END_DT6,
+                None,
+            ),
+        ]);
+        let (rd, p) = MupPrefix::from_route(&MupRoute::Isd {
+            id: 0,
+            arch: MupArchitectureType::Gpp5g,
+            rd: "65501:10".parse().unwrap(),
+            prefix: "10.0.0.0/24".parse().unwrap(),
+        });
+        let _ = tables.entry(rd).or_default().update(p, wide);
+
+        // The narrow ISD (10.0.0.8/29, more specific, covers the endpoint
+        // too) is DT4-only: it must win the v4 UE and lose the v6 UE.
+        let narrow = isd_rib_with(vec![Srv6SidInfo::new(
+            "fcbb:cccc::4".parse().unwrap(),
+            0,
+            SRV6_BEHAVIOR_END_DT4,
+            None,
+        )]);
+        let (rd, p) = MupPrefix::from_route(&MupRoute::Isd {
+            id: 0,
+            arch: MupArchitectureType::Gpp5g,
+            rd: "65501:11".parse().unwrap(),
+            prefix: "10.0.0.8/29".parse().unwrap(),
+        });
+        let _ = tables.entry(rd).or_default().update(p, narrow);
+
+        // A v4 UE and a v6 UE behind the same gNB endpoint (10.0.0.9 — in
+        // both ISD prefixes; the v6 UE with a v4 endpoint is the mixed-AFI
+        // shape).
+        for (ue, teid) in [("10.60.1.5/32", 1u32), ("2001:db8:cafe::5/128", 2)] {
+            let route = MupRoute::T1st {
+                id: 0,
+                arch: MupArchitectureType::Gpp5g,
+                rd: "65501:12".parse().unwrap(),
+                prefix: ue.parse().unwrap(),
+                teid,
+                qfi: 9,
+                endpoint: "10.0.0.9".parse().unwrap(),
+                source: None,
+            };
+            let mut rib = mup_rib("fc00::9".parse::<IpAddr>().unwrap(), 32768, &[]);
+            rib.mup_st1 = route.st1_fields();
+            let (rd, p) = MupPrefix::from_route(&route);
+            let _ = tables.entry(rd).or_default().update(p, rib);
+        }
+
+        let out = render_mup_table(&tables, true).unwrap();
+        // Both SIDs of the split pair are displayed, not just the first.
+        assert!(out.contains("Remote SID fcbb:aaaa::4 (End.DT4)"), "{out}");
+        assert!(out.contains("Remote SID fcbb:aaaa::6 (End.DT6)"), "{out}");
+        // v4 UE → the most-specific covering ISD's DT4.
+        assert!(
+            out.contains(
+                "resolved 10.60.1.5/32 (endpoint 10.0.0.9) -> End.DT4 fcbb:cccc::4 (via [ISD][65501:11][10.0.0.8/29])"
+            ),
+            "{out}"
+        );
+        // v6 UE → the DT4-only narrow ISD is skipped; the wide ISD's DT6
+        // wins instead of a family-mismatched install.
+        assert!(
+            out.contains(
+                "resolved 2001:db8:cafe::5/128 (endpoint 10.0.0.9) -> End.DT6 fcbb:aaaa::6 (via [ISD][65501:10][10.0.0.0/24])"
+            ),
+            "{out}"
+        );
     }
 
     #[test]

--- a/zebra-rs/src/bgp/vrf/inst.rs
+++ b/zebra-rs/src/bgp/vrf/inst.rs
@@ -728,25 +728,28 @@ impl BgpVrf {
     fn reconcile_mup_st1_isd(&mut self) {
         use std::net::Ipv6Addr;
         type Transport = Vec<crate::rib::nht::ResolvedNexthop>;
-        // Index imported ISDs by their advertised prefix → (SID, transport).
-        // Only an ISD with both a SID and a resolved underlay transport
-        // qualifies.
-        let mut isd_index: Vec<(ipnet::IpNet, Ipv6Addr, Transport)> = Vec::new();
+        // Index imported ISDs by their advertised prefix → (service SIDs,
+        // transport). Only an ISD with at least one SID and a resolved
+        // underlay transport qualifies. All SIDs are kept (an ISD may split
+        // End.DT4 + End.DT6 instead of one End.DT46); the per-ST1 pick
+        // below matches the UE prefix's family.
+        let mut isd_index: Vec<(ipnet::IpNet, Vec<(Ipv6Addr, u16)>, Transport)> = Vec::new();
         for (rd, table) in self.local_rib.mup.iter() {
             for (prefix, rib) in table.selected.iter() {
                 let bgp_packet::MupPrefix::Isd { prefix: isd_prefix } = prefix else {
                     continue;
                 };
-                let Some((sid, _behavior)) = rib.attr.srv6_l3_sid() else {
+                let sids: Vec<_> = rib.attr.srv6_l3_sids().collect();
+                if sids.is_empty() {
                     continue;
-                };
+                }
                 let Some(transport) = self.mup_segment_transport.get(&(*rd, prefix.clone())) else {
                     continue;
                 };
                 if transport.is_empty() {
                     continue;
                 }
-                isd_index.push((*isd_prefix, sid, transport.clone()));
+                isd_index.push((*isd_prefix, sids, transport.clone()));
             }
         }
         // Desired: each selected ST1 UE prefix → the most-specific covering
@@ -761,15 +764,27 @@ impl BgpVrf {
                 // IPv4-endpoint route) — but install the *UE prefix* as the
                 // FIB destination (§3.1.3): downlink traffic to the UE is
                 // steered toward the gNB's segment. The endpoint is off the
-                // ST1 route key (§3.2.1), so read it from the path.
+                // ST1 route key (§3.2.1), so read it from the path. The SID
+                // must be able to decap the UE family (End.DT4 for a v4 UE /
+                // End.DT6 for v6 / End.DT46 for either) — an ISD without a
+                // compatible SID is skipped, letting a less-specific covering
+                // ISD with one win rather than installing a blackhole.
                 if let bgp_packet::MupPrefix::T1st { prefix: ue } = prefix
                     && let Some(st1) = &rib.mup_st1
-                    && let Some((_p, sid, transport)) = isd_index
+                    && let Some((sid, transport)) = isd_index
                         .iter()
                         .filter(|(p, _, _)| p.contains(&st1.endpoint))
+                        .filter_map(|(p, sids, transport)| {
+                            bgp_packet::srv6_l3_sid_for_dest(
+                                sids,
+                                matches!(ue, ipnet::IpNet::V4(_)),
+                            )
+                            .map(|(sid, _behavior)| (p, sid, transport))
+                        })
                         .max_by_key(|(p, _, _)| p.prefix_len())
+                        .map(|(_p, sid, transport)| (sid, transport))
                 {
-                    desired.insert(*ue, (*sid, transport.clone()));
+                    desired.insert(*ue, (sid, transport.clone()));
                 }
             }
         }
@@ -833,9 +848,12 @@ impl BgpVrf {
     fn reconcile_mup_st2_dsd(&mut self) {
         use std::net::Ipv6Addr;
         type Transport = Vec<crate::rib::nht::ResolvedNexthop>;
-        // Index imported DSDs by Direct-segment id → (SID, transport). Only
-        // a DSD with both a SID and a resolved underlay transport qualifies.
-        let mut dsd_index: std::collections::BTreeMap<[u8; 6], (Ipv6Addr, Transport)> =
+        // Index imported DSDs by Direct-segment id → (service SIDs,
+        // transport). Only a DSD with at least one SID and a resolved
+        // underlay transport qualifies. All SIDs are kept (a DSD may split
+        // End.DT4 + End.DT6 instead of one End.DT46); the per-ST2 pick
+        // below matches the endpoint's family.
+        let mut dsd_index: std::collections::BTreeMap<[u8; 6], (Vec<(Ipv6Addr, u16)>, Transport)> =
             std::collections::BTreeMap::new();
         for (rd, table) in self.local_rib.mup.iter() {
             for (prefix, rib) in table.selected.iter() {
@@ -845,20 +863,23 @@ impl BgpVrf {
                 let Some(seg) = mup_direct_segment_id(&rib.attr) else {
                     continue;
                 };
-                let Some((sid, _behavior)) = rib.attr.srv6_l3_sid() else {
+                let sids: Vec<_> = rib.attr.srv6_l3_sids().collect();
+                if sids.is_empty() {
                     continue;
-                };
+                }
                 let Some(transport) = self.mup_segment_transport.get(&(*rd, prefix.clone())) else {
                     continue;
                 };
                 if transport.is_empty() {
                     continue;
                 }
-                dsd_index.insert(seg, (sid, transport.clone()));
+                dsd_index.insert(seg, (sids, transport.clone()));
             }
         }
         // Desired: each selected ST2 whose Direct-segment id matches a DSD →
-        // the ST2 endpoint host prefix → (SID, transport).
+        // the ST2 endpoint host prefix → (SID, transport). The SID must be
+        // able to decap the endpoint's family (the installed FIB
+        // destination); a DSD without a compatible SID yields no install.
         let mut desired: std::collections::BTreeMap<ipnet::IpNet, (Ipv6Addr, Transport)> =
             std::collections::BTreeMap::new();
         if !dsd_index.is_empty() {
@@ -866,9 +887,11 @@ impl BgpVrf {
                 for (prefix, rib) in table.selected.iter() {
                     if let bgp_packet::MupPrefix::T2st { endpoint, .. } = prefix
                         && let Some(seg) = mup_direct_segment_id(&rib.attr)
-                        && let Some((sid, transport)) = dsd_index.get(&seg)
+                        && let Some((sids, transport)) = dsd_index.get(&seg)
+                        && let Some((sid, _behavior)) =
+                            bgp_packet::srv6_l3_sid_for_dest(sids, endpoint.is_ipv4())
                     {
-                        desired.insert(host_net(*endpoint), (*sid, transport.clone()));
+                        desired.insert(host_net(*endpoint), (sid, transport.clone()));
                     }
                 }
             }
@@ -2495,6 +2518,138 @@ mod tests {
         assert!(
             vrf.mup_gtp_encap_installed.is_empty(),
             "the GTP4.E encap is withdrawn when its endpoint stops resolving"
+        );
+    }
+
+    /// An ISD carrying a split End.DT4 + End.DT6 SID pair (instead of one
+    /// End.DT46) must steer each ST1 UE prefix into the SID that can decap
+    /// its family — not blindly the first SID. When the ISD loses the
+    /// v6-capable SID, the v6 UE's encap is withdrawn rather than left (or
+    /// re-pointed) at the End.DT4 SID.
+    #[tokio::test]
+    async fn st1_isd_reconcile_picks_sid_by_ue_family() {
+        use crate::bgp::route::{BgpRib, BgpRibType};
+        use crate::rib::nht::ResolvedNexthop;
+        use bgp_packet::{
+            BgpAttr, MupPrefix, MupSt1Fields, PrefixSid, PrefixSidTlv, SRV6_BEHAVIOR_END_DT4,
+            SRV6_BEHAVIOR_END_DT6, Srv6ServiceTlv, Srv6SidInfo,
+        };
+        use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
+
+        let (global_tx, _global_rx) = unbounded_channel::<BgpGlobalMsg>();
+        let ctx = test_ctx_for_vrf(44, "vrf-isd");
+        let (_rib_tx, rib_rx) = mpsc::unbounded_channel();
+        let (mut vrf, _inbox) = BgpVrf::new(
+            "vrf-isd".to_string(),
+            ctx,
+            Ipv4Addr::UNSPECIFIED,
+            65000,
+            /* label */ 16,
+            global_tx,
+            rib_rx,
+        );
+
+        let dt4: Ipv6Addr = "fcbb:aaaa::4".parse().unwrap();
+        let dt6: Ipv6Addr = "fcbb:aaaa::6".parse().unwrap();
+        let isd_rib = |sids: Vec<Srv6SidInfo>| {
+            let mut attr = BgpAttr::new();
+            attr.prefix_sid = Some(PrefixSid {
+                tlvs: vec![PrefixSidTlv::Srv6L3Service(Srv6ServiceTlv {
+                    sids,
+                    ..Default::default()
+                })],
+            });
+            BgpRib::new(
+                1,
+                Ipv4Addr::UNSPECIFIED,
+                BgpRibType::EBGP,
+                0,
+                0,
+                &attr,
+                None,
+                None,
+                false,
+            )
+        };
+        let mk_st1 = |ue: ipnet::IpNet, endpoint: IpAddr| {
+            let attr = BgpAttr::new();
+            let mut rib = BgpRib::new(
+                1,
+                Ipv4Addr::UNSPECIFIED,
+                BgpRibType::EBGP,
+                0,
+                0,
+                &attr,
+                None,
+                None,
+                false,
+            );
+            rib.mup_st1 = Some(MupSt1Fields {
+                teid: 0x100,
+                qfi: 5,
+                endpoint,
+                source: None,
+            });
+            (MupPrefix::T1st { prefix: ue }, rib)
+        };
+
+        let rd: bgp_packet::RouteDistinguisher = "65000:1".parse().unwrap();
+        let isd_prefix = MupPrefix::Isd {
+            prefix: "10.0.12.0/24".parse().unwrap(),
+        };
+        let gnb = IpAddr::V4(Ipv4Addr::new(10, 0, 12, 1));
+        let ue_v4: ipnet::IpNet = "10.60.1.0/24".parse().unwrap();
+        let ue_v6: ipnet::IpNet = "2001:db8:cafe::/64".parse().unwrap();
+        {
+            let table = vrf.local_rib.mup.entry(rd).or_default();
+            table.selected.insert(
+                isd_prefix.clone(),
+                isd_rib(vec![
+                    Srv6SidInfo::new(dt4, 0, SRV6_BEHAVIOR_END_DT4, None),
+                    Srv6SidInfo::new(dt6, 0, SRV6_BEHAVIOR_END_DT6, None),
+                ]),
+            );
+            let (p, rib) = mk_st1(ue_v4, gnb);
+            table.selected.insert(p, rib);
+            let (p, rib) = mk_st1(ue_v6, gnb);
+            table.selected.insert(p, rib);
+        }
+        // The ISD's next-hop has a resolved underlay.
+        vrf.mup_segment_transport.insert(
+            (rd, isd_prefix.clone()),
+            vec![ResolvedNexthop {
+                addr: IpAddr::V4(Ipv4Addr::new(10, 0, 99, 1)),
+                ifindex: 7,
+                labels: Vec::new(),
+                segs: vec![],
+                seg_encap: None,
+            }],
+        );
+
+        vrf.reconcile_mup_st1_isd();
+        assert_eq!(
+            vrf.mup_st1_isd_installed.get(&ue_v4),
+            Some(&dt4),
+            "the v4 UE prefix is steered into the End.DT4 SID"
+        );
+        assert_eq!(
+            vrf.mup_st1_isd_installed.get(&ue_v6),
+            Some(&dt6),
+            "the v6 UE prefix is steered into the End.DT6 SID"
+        );
+
+        // The ISD drops to DT4-only → the v6 UE cannot be serviced: its
+        // entry is withdrawn, the v4 one stays put.
+        vrf.local_rib.mup.get_mut(&rd).unwrap().selected.insert(
+            isd_prefix.clone(),
+            isd_rib(vec![Srv6SidInfo::new(dt4, 0, SRV6_BEHAVIOR_END_DT4, None)]),
+        );
+        vrf.reconcile_mup_st1_isd();
+        assert_eq!(vrf.mup_st1_isd_installed.get(&ue_v4), Some(&dt4));
+        assert_eq!(
+            vrf.mup_st1_isd_installed.get(&ue_v6),
+            None,
+            "a DT4-only ISD must not carry an IPv6 UE prefix"
         );
     }
 


### PR DESCRIPTION
## Summary

Two BGP MUP fixes found while testing split End.DT4/End.DT6 ISDs and PFCP handover:

**Multi-SID ISD/DSD + AFI-aware SID selection** — an ISD/DSD may carry a split End.DT4 + End.DT6 SID pair instead of a single End.DT46, but every MUP consumer used `srv6_l3_sid()`, which collapses to the first SID of the first L3 Service TLV and ignores the behavior:
- `show bgp mup` displayed only the first SID line; it now prints one line per SID.
- `reconcile_mup_st1_isd` / `reconcile_mup_st2_dsd` steered the UE prefix / ST2 endpoint into whichever SID was first — an IPv6 UE behind a DT4(-first/-only) ISD was seg6-encapsulated toward an End.DT4 SID, blackholing the downlink. Both reconcilers (and the show-side resolution, so display matches forwarding) now select via the new `srv6_l3_sid_for_dest()`: exact per-family decap behavior first (End.DT4 for v4 / End.DT6 for v6), then End.DT46, and no install when the segment's known decap behaviors cannot service the family. The compatibility filter runs before longest-prefix-match, so an incompatible most-specific ISD loses to a wider compatible one instead of blackholing.

**Handover ST2 re-export gate** — a PFCP Session Modification (handover: gNB endpoint/TEID move, session stays up) re-dispatches `MupOriginate` to every VRF the session targets, so the untouched direction (the ST2 — the core tunnel doesn't move) was rebuilt identically and re-advertised, sending peers a spurious ST2 UPDATE on every handover. `Bgp::mup_export` now drops a re-export whose stamped attr, ST1 off-key fields and NLRI key all equal the stored originated path; a genuine change (the ST1's moved tunnel, an RT/next-hop/SID restamp, a changed key) still falls through to the in-place replace.

## Test plan

- `srv6_l3_sids_yields_every_sid_across_tlvs_in_wire_order`, `srv6_l3_sids_empty_when_attr_absent_or_l3_free` (bgp-packet)
- `srv6_l3_sid_for_dest_*` — exact-family preference, DT46 fallback, family-incompatible rejection, unmodeled-behavior fallback (bgp-packet)
- `render_mup_table_multi_sid_isd_resolves_by_ue_family` — both SID lines shown; v4 UE → narrow ISD's DT4, v6 UE skips the DT4-only narrow ISD and resolves via the wide ISD's DT6
- `st1_isd_reconcile_picks_sid_by_ue_family` — FIB installs per-family SIDs; ISD dropping to DT4-only withdraws the v6 UE's encap
- `mup_export_drops_identical_reexport` — identical ST2/ST1 re-exports dropped, handover ST1 falls through, single candidate row preserved
- `cargo test --workspace --exclude bdd`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo fmt` all green

Generated with [Claude Code](https://claude.com/claude-code)