### PR TITLE
cradle: bridge-enslaved interfaces become eBPF L2 ports

### DIFF
--- a/bdd/tests/features/cradle_spawn.feature
+++ b/bdd/tests/features/cradle_spawn.feature
@@ -53,6 +53,17 @@ Feature: system ebpf spawns and supervises the cradle eBPF engine
     Then show command "show ebpf" in namespace "crs1" should eventually not contain "vrf 1"
     And show command "show ebpf" in namespace "crs1" should eventually contain "attached"
 
+  Scenario: A bridge-enslaved port becomes an L2 port in the bridge's flood domain
+    Given the test topology exists
+    When I apply command "set bridge br99" in namespace "crs1"
+    And I apply command "set interface eth0 bridge br99" in namespace "crs1"
+    Then show command "show ebpf" in namespace "crs1" should eventually contain "bd 1"
+    And show command "show ebpf" in namespace "crs1" should eventually contain "attached"
+    When I apply command "delete interface eth0 bridge br99" in namespace "crs1"
+    Then show command "show ebpf" in namespace "crs1" should eventually not contain "bd 1"
+    And show command "show ebpf" in namespace "crs1" should eventually contain "vrf 0"
+    And daemon log in namespace "crs1" should eventually contain "flushed learned MACs on eth0"
+
   Scenario: Disabling system ebpf stops the engine
     Given the test topology exists
     When I apply command "delete system ebpf enabled true" in namespace "crs1"

--- a/zebra-rs/src/bgp/config.rs
+++ b/zebra-rs/src/bgp/config.rs
@@ -7258,6 +7258,7 @@ mod neighbor_group_wiring_tests {
             master: None,
             vni: None,
             vrf_table: None,
+            bridge: false,
             vxlan_local: None,
             mtu_error: None,
         };

--- a/zebra-rs/src/cradle/inst.rs
+++ b/zebra-rs/src/cradle/inst.rs
@@ -48,6 +48,22 @@ struct LinkState {
     master: Option<u32>,
     /// `IFLA_VRF_TABLE` when this link IS a VRF master device.
     vrf_table: Option<u32>,
+    /// This link IS a kernel bridge (`IFLA_INFO_KIND == "bridge"`).
+    bridge: bool,
+    /// `IFLA_VXLAN_ID` when this link is a VXLAN device — a bridge's
+    /// VXLAN slave names the EVPN bridge domain (VNI) the bridge carries.
+    vni: Option<u32>,
+}
+
+/// How an `interface … ebpf enabled` port binds into the data plane,
+/// derived from the interface's `master` in link state.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+enum PortRole {
+    /// Routed port: ingress lookups (and derived local/connected routes)
+    /// use VRF table `vrf` (0 = global).
+    L3 { vrf: u32 },
+    /// Switched port: L2 learn/forward/flood in bridge domain `bd`.
+    L2 { bd: u16 },
 }
 
 /// Last observed engine availability, tracked from [`EngineEvent`]s for
@@ -93,12 +109,23 @@ pub struct Cradle {
     /// by the link dump at subscribe time; `global_links`, so VRF
     /// enslavement never hides a link).
     links: HashMap<u32, LinkState>,
+    /// Bridge-domain id per bridge device (ifindex), recomputed from link
+    /// state on every link change: a VXLAN slave's VNI when the bridge
+    /// carries one (EVPN — ports must share the bd the FDB tee uses),
+    /// else an id auto-allocated per bridge name.
+    bd_by_ifindex: HashMap<u32, u16>,
+    /// Stable auto-allocated bd ids, keyed by bridge name so a bridge
+    /// keeps its id across ifindex churn.
+    bd_alloc: BTreeMap<String, u16>,
     engine: Option<Engine>,
     /// Last observed engine availability (from [`EngineEvent`]s).
     status: EngineStatus,
     /// Ports applied to the current engine:
-    /// if-name → (ifindex, VRF table) used in the `SetPort`.
-    applied: HashMap<String, (u32, u32)>,
+    /// if-name → (ifindex, role) used in the `SetPort`.
+    applied: HashMap<String, (u32, PortRole)>,
+    /// Flood-member lists last sent per bridge domain (`SetL2Domain` is
+    /// replace-style); re-derived from `applied` and re-sent on drift.
+    applied_domains: HashMap<u16, Vec<String>>,
     /// Port-programming client for [`Self::client_endpoint`].
     ports_client: Option<CradleFib>,
     client_endpoint: Option<String>,
@@ -119,9 +146,12 @@ impl Cradle {
             grpc_endpoint: None,
             if_ebpf: BTreeMap::new(),
             links: HashMap::new(),
+            bd_by_ifindex: HashMap::new(),
+            bd_alloc: BTreeMap::new(),
             engine: None,
             status: EngineStatus::default(),
             applied: HashMap::new(),
+            applied_domains: HashMap::new(),
             ports_client: None,
             client_endpoint: None,
         }
@@ -194,13 +224,67 @@ impl Cradle {
                         name: link.name,
                         master: link.master,
                         vrf_table: link.vrf_table,
+                        bridge: link.bridge,
+                        vni: link.vni,
                     },
                 );
+                self.recompute_bds();
             }
             RibRx::LinkDel(ifindex) => {
                 self.links.remove(&ifindex);
+                self.recompute_bds();
             }
             _ => {}
+        }
+    }
+
+    /// Re-derive every bridge's domain id from link state. Preference
+    /// order per bridge: the VNI of a VXLAN slave when it fits a u16
+    /// (EVPN — the ports must land in the same bd the EVPN FDB tee
+    /// programs), else a stable auto-allocated id (smallest unused,
+    /// per bridge name, skipping ids claimed by any known VNI).
+    fn recompute_bds(&mut self) {
+        self.bd_by_ifindex.clear();
+        let vni_claimed: std::collections::HashSet<u16> = self
+            .links
+            .values()
+            .filter_map(|l| l.vni)
+            .filter_map(|v| u16::try_from(v).ok())
+            .collect();
+        let bridges: Vec<(u32, String)> = self
+            .links
+            .iter()
+            .filter(|(_, l)| l.bridge)
+            .map(|(ifindex, l)| (*ifindex, l.name.clone()))
+            .collect();
+        for (ifindex, name) in bridges {
+            let vni_bd = self
+                .links
+                .values()
+                .find(|l| l.master == Some(ifindex) && l.vni.is_some())
+                .and_then(|l| l.vni)
+                .and_then(|v| u16::try_from(v).ok());
+            let bd = match vni_bd {
+                Some(bd) => bd,
+                None => match self.bd_alloc.get(&name) {
+                    Some(bd) => *bd,
+                    None => {
+                        let used: std::collections::HashSet<u16> = self
+                            .bd_alloc
+                            .values()
+                            .copied()
+                            .chain(vni_claimed.iter().copied())
+                            .collect();
+                        let Some(bd) = (1..=4094u16).find(|id| !used.contains(id)) else {
+                            warn!("cradle: no free bridge-domain id for {name}");
+                            continue;
+                        };
+                        self.bd_alloc.insert(name.clone(), bd);
+                        bd
+                    }
+                },
+            };
+            self.bd_by_ifindex.insert(ifindex, bd);
         }
     }
 
@@ -228,20 +312,26 @@ impl Cradle {
         }
     }
 
-    /// The `SetPort` binding for an interface: its ifindex plus the VRF
-    /// table it is enslaved to (0 = default). The table comes straight
-    /// from link state — the interface's `master` resolved to that
-    /// device's `IFLA_VRF_TABLE` — so config-driven (`interface X vrf`)
-    /// and externally-applied enslavement both bind the port. A bridge
-    /// master has no VRF table and yields 0.
-    fn port_binding(&self, name: &str) -> Option<(u32, u32)> {
+    /// The `SetPort` binding for an interface: its ifindex plus the role
+    /// its `master` implies, straight from link state — so config-driven
+    /// (`interface X vrf|bridge …`) and externally-applied enslavement
+    /// both bind the port:
+    /// - master is a bridge  ⇒ `L2` in the bridge's domain
+    ///   (`bd_by_ifindex`),
+    /// - master is a VRF     ⇒ `L3` in that kernel table,
+    /// - no master           ⇒ `L3` in the global table.
+    fn port_binding(&self, name: &str) -> Option<(u32, PortRole)> {
         let (ifindex, link) = self.links.iter().find(|(_, l)| l.name.as_str() == name)?;
-        let vrf = link
-            .master
-            .and_then(|m| self.links.get(&m))
-            .and_then(|m| m.vrf_table)
-            .unwrap_or(0);
-        Some((*ifindex, vrf))
+        let role = match link.master.and_then(|m| self.links.get(&m).map(|l| (m, l))) {
+            Some((m, master)) if master.bridge => PortRole::L2 {
+                bd: *self.bd_by_ifindex.get(&m)?,
+            },
+            Some((_, master)) => PortRole::L3 {
+                vrf: master.vrf_table.unwrap_or(0),
+            },
+            None => PortRole::L3 { vrf: 0 },
+        };
+        Some((*ifindex, role))
     }
 
     /// The configured endpoint (override or default), independent of
@@ -425,7 +515,14 @@ impl Cradle {
                     serde_json::json!({
                         "name": name,
                         "ifindex": binding.map(|(i, _)| i),
-                        "vrf": binding.map(|(_, v)| v),
+                        "vrf": binding.and_then(|(_, role)| match role {
+                            PortRole::L3 { vrf } => Some(vrf),
+                            PortRole::L2 { .. } => None,
+                        }),
+                        "bd": binding.and_then(|(_, role)| match role {
+                            PortRole::L2 { bd } => Some(bd),
+                            PortRole::L3 { .. } => None,
+                        }),
                         "attached": binding.is_some()
                             && self.applied.get(name) == binding.as_ref(),
                     })
@@ -507,18 +604,20 @@ impl Cradle {
         .unwrap();
         for name in enabled {
             match (self.port_binding(name), self.applied.get(name)) {
-                (Some(binding), Some(applied)) if *applied == binding => {
-                    let (ifindex, vrf) = binding;
+                (Some(binding), applied) => {
+                    let (ifindex, role) = binding;
+                    let role_col = match role {
+                        PortRole::L3 { vrf } => format!("vrf {vrf}"),
+                        PortRole::L2 { bd } => format!("bd {bd}"),
+                    };
+                    let state = if applied == Some(&binding) {
+                        "attached"
+                    } else {
+                        "pending"
+                    };
                     writeln!(
                         out,
-                        "    {name:<16} ifindex {ifindex:<6} vrf {vrf:<5} attached"
-                    )
-                    .unwrap();
-                }
-                (Some((ifindex, vrf)), _) => {
-                    writeln!(
-                        out,
-                        "    {name:<16} ifindex {ifindex:<6} vrf {vrf:<5} pending"
+                        "    {name:<16} ifindex {ifindex:<6} {role_col:<9} {state}"
                     )
                     .unwrap();
                 }
@@ -561,14 +660,63 @@ impl Cradle {
         }
     }
 
-    /// Diff-based port reconcile: make the engine's port set match the
-    /// `interface <name> ebpf enabled` config for the links that currently
-    /// exist. Failures stay pending and are retried on [`RETRY_TICK`].
+    /// Flood-member list for bridge domain `bd`, derived from the applied
+    /// ports (single source of truth — `SetL2Domain` is replace-style).
+    fn domain_members(&self, bd: u16) -> Vec<String> {
+        let mut members: Vec<String> = self
+            .applied
+            .iter()
+            .filter(|(_, (_, role))| *role == (PortRole::L2 { bd }))
+            .map(|(name, _)| name.clone())
+            .collect();
+        members.sort();
+        members
+    }
+
+    /// Re-send every bridge domain whose derived flood-member list drifted
+    /// from the last successful `SetL2Domain` (including down to empty).
+    async fn sync_domains(&mut self, client: &CradleFib) {
+        let bds: std::collections::BTreeSet<u16> = self
+            .applied_domains
+            .keys()
+            .copied()
+            .chain(self.applied.values().filter_map(|(_, role)| match role {
+                PortRole::L2 { bd } => Some(*bd),
+                PortRole::L3 { .. } => None,
+            }))
+            .collect();
+        for bd in bds {
+            let members = self.domain_members(bd);
+            if self.applied_domains.get(&bd).map(|m| m.as_slice()) == Some(members.as_slice()) {
+                continue;
+            }
+            match client.set_l2_domain(bd, members.clone()).await {
+                Ok(()) => {
+                    info!("cradle: bd {bd} flood members {members:?}");
+                    if members.is_empty() {
+                        self.applied_domains.remove(&bd);
+                    } else {
+                        self.applied_domains.insert(bd, members);
+                    }
+                }
+                Err(e) => warn!("cradle: SetL2Domain bd {bd} failed: {e} (will retry)"),
+            }
+        }
+    }
+
+    /// Diff-based port reconcile: make the engine's port set — and the L2
+    /// flood domains — match the `interface <name> ebpf enabled` config
+    /// for the links that currently exist. Three phases keep the design
+    /// invariant "a port is never reachable by the flood path while its
+    /// PORTS entry says L3": domain removals land before role flips, and
+    /// domain additions after. Failures stay pending and are retried on
+    /// [`RETRY_TICK`].
     async fn reconcile_ports(&mut self) {
         let Some(endpoint) = self.usable_endpoint() else {
             // No engine to program (disabled, or managed engine not up):
             // its state is gone or not ours — just reset ours.
             self.applied.clear();
+            self.applied_domains.clear();
             self.ports_client = None;
             self.client_endpoint = None;
             return;
@@ -579,36 +727,51 @@ impl Cradle {
             self.ports_client = Some(CradleFib::new(&endpoint));
             self.client_endpoint = Some(endpoint.clone());
             self.applied.clear();
+            self.applied_domains.clear();
         }
         let client = self.ports_client.as_ref().expect("set above").clone();
 
-        // 1) Detach ports that no longer match: disabled, link gone, or the
-        //    device was re-created under a new ifindex. cradle resolves by
-        //    attach-time name when the device is gone, so DelPort also
-        //    cleans up after deleted links. A VRF-binding change alone is
-        //    NOT a detach — step 2 re-SetPorts in place (cradle overwrites
-        //    the port entry and re-derives its routes under the new VRF).
-        for (name, (applied_ifindex, _)) in self.applied.clone() {
+        // Phase A — take leavers out of their flood domains first: ports
+        // being detached, and ports staying attached but leaving a bd
+        // (L2→L3 or a bridge move). Dropping them from `applied` makes
+        // `domain_members` exclude them; `sync_domains` pushes the
+        // shrunken lists. The ports re-enter `applied` in phase B with
+        // their new binding; those that left a bd but stay attached also
+        // get their learned MACs flushed at the end.
+        let mut flush_after: Vec<String> = Vec::new();
+        for (name, (applied_ifindex, applied_role)) in self.applied.clone() {
             let enabled = self.if_ebpf.get(&name).copied().unwrap_or(false);
-            if enabled
-                && self
-                    .port_binding(&name)
-                    .is_some_and(|(ifindex, _)| ifindex == applied_ifindex)
-            {
+            let binding = self.port_binding(&name);
+            let same_device =
+                enabled && binding.is_some_and(|(ifindex, _)| ifindex == applied_ifindex);
+            let same_binding = same_device && binding.is_some_and(|(_, role)| role == applied_role);
+            if same_binding {
                 continue;
             }
-            match client.del_port(&name).await {
-                Ok(()) => {
-                    info!("cradle: detached port {name}");
-                    self.applied.remove(&name);
+            if matches!(applied_role, PortRole::L2 { .. }) {
+                // Out of the flood list before anything else changes.
+                self.applied.remove(&name);
+                if same_device {
+                    flush_after.push(name.clone());
                 }
-                Err(e) => warn!("cradle: DelPort {name} failed: {e} (will retry)"),
+            }
+            if !same_device {
+                // Disabled, link gone, or re-created under a new ifindex:
+                // full detach (DelPort flushes the port's MACs engine-side
+                // and tolerates already-gone devices).
+                self.applied.remove(&name);
+                match client.del_port(&name).await {
+                    Ok(()) => info!("cradle: detached port {name}"),
+                    Err(e) => warn!("cradle: DelPort {name} failed: {e} (will retry)"),
+                }
             }
         }
+        self.sync_domains(&client).await;
 
-        // 2) Attach enabled ports whose link exists and isn't applied with
-        //    the current (ifindex, VRF) binding — covers first attach,
-        //    re-attach after step 1, and in-place VRF moves.
+        // Phase B — apply `SetPort` for every enabled port whose (ifindex,
+        // role) isn't current: first attach, re-attach after a detach, and
+        // in-place role/VRF/bd moves (cradle overwrites the port entry and
+        // re-reconciles its derived routes).
         let wanted: Vec<String> = self
             .if_ebpf
             .iter()
@@ -616,18 +779,42 @@ impl Cradle {
             .map(|(name, _)| name.clone())
             .collect();
         for name in wanted {
-            let Some((ifindex, vrf)) = self.port_binding(&name) else {
+            let Some((ifindex, role)) = self.port_binding(&name) else {
                 continue;
             };
-            if self.applied.get(&name) == Some(&(ifindex, vrf)) {
+            if self.applied.get(&name) == Some(&(ifindex, role)) {
                 continue;
             }
-            match client.set_port(&name, vrf).await {
+            let (l3, vlan, vrf) = match role {
+                PortRole::L3 { vrf } => (true, 0, vrf),
+                PortRole::L2 { bd } => (false, bd, 0),
+            };
+            match client.set_port(&name, l3, vlan, vrf).await {
                 Ok(()) => {
-                    info!("cradle: attached port {name} (ifindex {ifindex}, vrf {vrf})");
-                    self.applied.insert(name, (ifindex, vrf));
+                    match role {
+                        PortRole::L3 { vrf } => {
+                            info!("cradle: attached port {name} (ifindex {ifindex}, vrf {vrf})");
+                        }
+                        PortRole::L2 { bd } => {
+                            info!("cradle: attached port {name} (ifindex {ifindex}, bd {bd})");
+                        }
+                    }
+                    self.applied.insert(name, (ifindex, role));
                 }
                 Err(e) => warn!("cradle: SetPort {name} failed: {e} (will retry)"),
+            }
+        }
+
+        // Phase C — grow the flood domains to include the newly-applied L2
+        // ports (their mode is already switched), then flush the learned
+        // MACs of ports that left a bd but stayed attached.
+        self.sync_domains(&client).await;
+        for name in flush_after {
+            match client.flush_fdb_port(&name).await {
+                Ok(()) => {
+                    info!("cradle: flushed learned MACs on {name} (left its bridge domain)");
+                }
+                Err(e) => warn!("cradle: FlushFdb {name} failed: {e}"),
             }
         }
     }

--- a/zebra-rs/src/fib/cradle.rs
+++ b/zebra-rs/src/fib/cradle.rs
@@ -315,23 +315,56 @@ impl CradleFib {
     }
 
     /// Attach `name` as a data-plane port (`SetPort`): cradle resolves the
-    /// ifindex, attaches the TC/XDP programs, and derives the port's
-    /// local + connected routes — into VRF table `vrf_id` (0 = global)
-    /// when the interface is VRF-enslaved, so ingress lookups use the
-    /// per-VRF FIB. Routed ports only (`l3`, vlan 0) — bridge/L2 domain
-    /// binding follows with the dynamic L2/L3 assignment work. A repeat
-    /// `SetPort` on a live port is an in-place update on cradle's side
-    /// (the attach is idempotent; the port entry and derived routes are
-    /// re-reconciled under the new VRF).
-    pub async fn set_port(&self, name: &str, vrf_id: u32) -> anyhow::Result<()> {
+    /// ifindex and attaches the TC/XDP programs. A routed port (`l3`)
+    /// derives its local + connected routes into VRF table `vrf_id`
+    /// (0 = global); an L2 port (`!l3`) switches in bridge domain `vlan`
+    /// (flood membership is programmed separately — [`Self::set_l2_domain`]).
+    /// A repeat `SetPort` on a live port is an in-place update on cradle's
+    /// side (the attach is idempotent; the port entry and derived routes
+    /// are re-reconciled under the new role/VRF).
+    pub async fn set_port(
+        &self,
+        name: &str,
+        l3: bool,
+        vlan: u16,
+        vrf_id: u32,
+    ) -> anyhow::Result<()> {
         self.client()
             .await?
             .set_port(pb::Port {
                 name: name.to_string(),
                 mac: String::new(),
-                l3: true,
-                vlan: 0,
+                l3,
+                vlan: vlan as u32,
                 vrf_id,
+            })
+            .await?;
+        Ok(())
+    }
+
+    /// Replace bridge domain `vlan`'s flood-member list (the ports BUM /
+    /// unknown-unicast frames replicate to, minus the ingress).
+    pub async fn set_l2_domain(&self, vlan: u16, members: Vec<String>) -> anyhow::Result<()> {
+        self.client()
+            .await?
+            .set_l2_domain(pb::L2Domain {
+                vlan: vlan as u32,
+                members,
+            })
+            .await?;
+        Ok(())
+    }
+
+    /// Flush the locally-learned FDB entries on `port` (control-plane
+    /// remote entries are untouched; `WatchFdb` reports the removals as
+    /// age events). Used when a port leaves a bridge domain but stays
+    /// attached — a detach (`DelPort`) flushes on the engine side already.
+    pub async fn flush_fdb_port(&self, port: &str) -> anyhow::Result<()> {
+        self.client()
+            .await?
+            .flush_fdb(pb::FdbFlush {
+                port: port.to_string(),
+                vlan: 0,
             })
             .await?;
         Ok(())

--- a/zebra-rs/src/fib/message.rs
+++ b/zebra-rs/src/fib/message.rs
@@ -51,6 +51,11 @@ pub struct FibLink {
     /// all-VRF consumer (the cradle port reconcile) resolve a slave's
     /// `master` to its VRF table without the RIB's registry.
     pub vrf_table: Option<u32>,
+    /// This device is a kernel bridge (`LinkInfo::Kind(InfoKind::Bridge)`).
+    /// The cradle port reconcile uses it to classify a slave's `master`:
+    /// bridge ⇒ L2 port in the bridge's flood domain, VRF ⇒ routed port
+    /// in that table.
+    pub bridge: bool,
 }
 
 impl FibLink {

--- a/zebra-rs/src/fib/netlink/handle.rs
+++ b/zebra-rs/src/fib/netlink/handle.rs
@@ -3801,6 +3801,8 @@ pub fn link_from_msg(msg: LinkMessage) -> FibLink {
                                 link.vrf_table = Some(t);
                             }
                         }
+                    } else if let LinkInfo::Kind(InfoKind::Bridge) = info {
+                        link.bridge = true;
                     }
                 }
             }

--- a/zebra-rs/src/nd/engine.rs
+++ b/zebra-rs/src/nd/engine.rs
@@ -471,6 +471,7 @@ mod tests {
             master: None,
             vni: None,
             vrf_table: None,
+            bridge: false,
             vxlan_local: None,
             mtu_error: None,
         }

--- a/zebra-rs/src/nd/show.rs
+++ b/zebra-rs/src/nd/show.rs
@@ -657,6 +657,7 @@ mod tests {
             master: None,
             vni: None,
             vrf_table: None,
+            bridge: false,
             vxlan_local: None,
             mtu_error: None,
         }

--- a/zebra-rs/src/rib/link.rs
+++ b/zebra-rs/src/rib/link.rs
@@ -64,6 +64,11 @@ pub struct Link {
     /// `master` to its VRF table straight from link state.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub vrf_table: Option<u32>,
+    /// This device is a kernel bridge (`IFLA_INFO_KIND == "bridge"`).
+    /// The cradle port reconcile classifies a slave's `master` with it:
+    /// bridge ⇒ L2 port in the bridge's flood domain, VRF ⇒ routed port.
+    #[serde(skip)]
+    pub bridge: bool,
     /// Last failure reason from applying the operator-configured MTU
     /// (`mtu_config` keyed by name on `Rib`). `None` once a set
     /// succeeds. Rendered by `show interface` so a kernel rejection
@@ -92,6 +97,7 @@ impl Link {
             vni: link.vni,
             vxlan_local: link.vxlan_local,
             vrf_table: link.vrf_table,
+            bridge: link.bridge,
             mtu_error: None,
         }
     }
@@ -692,6 +698,16 @@ impl Rib {
                 // pick, which excludes VRF members) may now derive a
                 // different Router-ID.
                 self.router_id_update();
+            } else if prev_master != now_master
+                && let Some(link) = self.links.get(&ifindex).cloned()
+            {
+                // A master change that stays within one VRF id — bridge
+                // enslave/release, or a move between bridges — migrates
+                // no subscriber set, but the link's `master` is
+                // load-bearing for `global_links` consumers (the cradle
+                // port reconcile classifies a port L2/L3 from it).
+                // Re-announce the updated link as an upsert.
+                self.api_link_add_vrf(&link, now_vrf_id);
             }
         }
 
@@ -1334,6 +1350,7 @@ mod tests {
             master: None,
             vni: None,
             vrf_table: None,
+            bridge: false,
             vxlan_local: None,
             mtu_error: None,
         }

--- a/zebra-rs/src/rib/router_id.rs
+++ b/zebra-rs/src/rib/router_id.rs
@@ -155,6 +155,7 @@ mod tests {
             master,
             vni: None,
             vrf_table: None,
+            bridge: false,
             vxlan_local: None,
             mtu_error: None,
         }


### PR DESCRIPTION
## Summary

The last piece of the dynamic L2/L3 assignment design: an `interface <name> ebpf enabled` interface enslaved to a kernel bridge attaches as an **L2 port** (`SetPort l3:false`) in the bridge's flood domain, switching entirely in the eBPF datapath (learn/forward/flood). Flood membership rides `SetL2Domain` replace-lists derived from the applied ports; roles flip in place as masters change, honoring the design-table ordering — a port **leaves its flood domain before its mode changes and joins after**, and a port that leaves a bridge domain but stays attached gets its learned MACs **flushed** (`FlushFdb`, cradle-rs#106).

- `PortRole {L3{vrf}, L2{bd}}` derived per port from link state; bridge masters recognized via a new `Link`/`FibLink` `bridge` flag (`IFLA_INFO_KIND == "bridge"`, parsed like the vxlan/vrf attrs).
- **Bridge-domain ids**: a VXLAN slave's VNI when the bridge carries one (EVPN alignment — ports must share the bd the FDB tee programs), else a stable per-bridge-name auto-allocation skipping VNI-claimed ids.
- **RIB fix the live test surfaced**: a master change staying within one VRF id (bridge enslave/release) emitted *no* link event — the cross-VRF bounce was the only re-announce path — so `global_links` subscribers never saw bridge enslavement. Same-VRF master changes now re-announce the link as an upsert.
- `show ebpf` renders the role per port (`bd N` / `vrf N`; json gains `bd`); `@cradle_spawn` gains a bridge scenario.

## Test plan

- `cargo fmt --all --check`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo test --workspace --exclude bdd` — all green.
- Live netns, two hosts through a zebra-managed eBPF bridge: ports `bd 1 attached`, ping forwards, and **both host MACs appear as datapath-learned entries in `show ebpf l2`** (the XDP path did the switching); unbinding one port flips it to `vrf 0` with the flood list shrinking *first* (`["p1","p2"]` → `["p2"]`) and only that port's MACs flushed.
- `make -C bdd cradle_spawn`: **7/7 scenarios pass**.

Generated with [Claude Code](https://claude.com/claude-code)