### PR TITLE
cradle: resync installed routes when the tee enables after convergence

### DIFF
--- a/bdd/tests/features/cradle_spawn.feature
+++ b/bdd/tests/features/cradle_spawn.feature
@@ -70,6 +70,13 @@ Feature: system ebpf spawns and supervises the cradle eBPF engine
     Then show command "show ebpf" in namespace "crs1" should eventually contain "off (system ebpf disabled)"
     And daemon log in namespace "crs1" should eventually contain "engine stopped (system ebpf disabled)"
 
+  Scenario: Enabling ebpf after routes exist resyncs them into the engine
+    Given the test topology exists
+    When I apply command "set router static ipv4 route 10.222.0.0/24 nexthop 10.210.1.2" in namespace "crs1"
+    And I apply command "set system ebpf enabled true" in namespace "crs1"
+    Then daemon log in namespace "crs1" should eventually contain "cradle resync walked"
+    And show command "show ebpf ipv4" in namespace "crs1" should eventually contain "10.222.0.0/24"
+
   Scenario: Teardown topology
     Given the test topology exists
     When I stop zebra-rs in namespace "crs1"

--- a/zebra-rs/src/fib/netlink/handle.rs
+++ b/zebra-rs/src/fib/netlink/handle.rs
@@ -802,6 +802,57 @@ impl FibHandle {
     /// caller leaves the route's `fib` flag
     /// clear and forces the nexthop's recreation so the next resolve
     /// pass re-adds it.
+    /// Re-emit one v4 route's cradle tee only (no kernel side) — the
+    /// enable-after-routes resync unit. **Protocol routes only**: unlike
+    /// the inline tee (which also mirrors connected routes), the walk
+    /// skips `Connected`, because cradle derives a port's connected +
+    /// local routes itself from the kernel addresses when `SetPort`
+    /// attaches it (`kernel::derive_port`, with the real oif). The
+    /// stored connected `RibEntry` carries only `entry.ifindex` and a
+    /// `Nexthop::Link(0)`, so re-teeing it here would clobber cradle's
+    /// correct entry with an oif-0 one. A disabled tee is a no-op.
+    pub async fn cradle_route_resync_v4(
+        &self,
+        prefix: &Ipv4Net,
+        entry: &RibEntry,
+        table_id: u32,
+    ) -> bool {
+        if entry.is_protocol()
+            && let Some(cradle) = &self.cradle
+        {
+            let members = cradle_members(&entry.nexthop);
+            if !members.is_empty() {
+                cradle.route_install(*prefix, table_id, members).await;
+                return true;
+            }
+        }
+        false
+    }
+
+    /// v6 sibling of [`Self::cradle_route_resync_v4`].
+    pub async fn cradle_route_resync_v6(
+        &self,
+        prefix: &Ipv6Net,
+        entry: &RibEntry,
+        table_id: u32,
+    ) -> bool {
+        if entry.is_protocol()
+            && let Some(cradle) = &self.cradle
+        {
+            let members = cradle_members(&entry.nexthop);
+            if !members.is_empty() {
+                cradle.route_install6(*prefix, table_id, members).await;
+                return true;
+            }
+        }
+        false
+    }
+
+    /// Is the cradle eBPF tee currently attached?
+    pub fn cradle_active(&self) -> bool {
+        self.cradle.is_some()
+    }
+
     pub async fn route_ipv4_add(&self, prefix: &Ipv4Net, entry: &RibEntry, table_id: u32) -> bool {
         // Tee protocol AND connected routes — see the v6 sibling.
         if (entry.is_protocol() || matches!(entry.rtype, RibType::Connected))

--- a/zebra-rs/src/rib/inst.rs
+++ b/zebra-rs/src/rib/inst.rs
@@ -3287,7 +3287,12 @@ impl Rib {
                 self.cradle_fdb_age(vni, mac);
             }
             Message::CradleEngineUp => {
+                // Mirror replay first (everything the tee has seen —
+                // routes, ILM, SIDs, EVPN, GTP, neighbors), then the RIB
+                // walk to seed routes that predate the tee itself
+                // (enable-after-routes). Both are idempotent overwrites.
                 self.fib_handle.cradle_replay().await;
+                self.cradle_rib_walk().await;
             }
             Message::CradleReplAdd { vni, sid } => {
                 self.fib_handle.cradle_repl_add(vni, sid).await;
@@ -3874,6 +3879,71 @@ impl Rib {
     /// `WatchFdb` subscriber accordingly. Called on any change to either
     /// config knob.
     #[cfg(target_os = "linux")]
+    /// Enable-after-routes resync: re-emit every FIB-installed v4/v6
+    /// route — default and VRF tables — to the cradle tee. Runs from
+    /// `CradleEngineUp` alongside the mirror replay: the mirror covers
+    /// everything recorded since the tee existed; this walk seeds the
+    /// routes that predate it (the tee enabled on an already-converged
+    /// RIB). Label/SID and protocol-owned overlay state is not walked —
+    /// those producers are expected to start after the tee (and the
+    /// mirror carries them across engine restarts once seen).
+    #[cfg(target_os = "linux")]
+    async fn cradle_rib_walk(&self) {
+        if !self.fib_handle.cradle_active() {
+            return;
+        }
+        let mut v4 = 0usize;
+        let mut v6 = 0usize;
+        for (prefix, entries) in self.table.iter() {
+            if let Some(entry) = entries.iter().find(|e| e.is_fib())
+                && self
+                    .fib_handle
+                    .cradle_route_resync_v4(&prefix, entry, 0)
+                    .await
+            {
+                v4 += 1;
+            }
+        }
+        for (prefix, entries) in self.table_v6.iter() {
+            if let Some(entry) = entries.iter().find(|e| e.is_fib())
+                && self
+                    .fib_handle
+                    .cradle_route_resync_v6(&prefix, entry, 0)
+                    .await
+            {
+                v6 += 1;
+            }
+        }
+        for (table_id, tables) in self.vrf_tables.iter() {
+            for (prefix, entries) in tables.table.iter() {
+                if let Some(entry) = entries.iter().find(|e| e.is_fib())
+                    && self
+                        .fib_handle
+                        .cradle_route_resync_v4(&prefix, entry, *table_id)
+                        .await
+                {
+                    v4 += 1;
+                }
+            }
+            for (prefix, entries) in tables.table_v6.iter() {
+                if let Some(entry) = entries.iter().find(|e| e.is_fib())
+                    && self
+                        .fib_handle
+                        .cradle_route_resync_v6(&prefix, entry, *table_id)
+                        .await
+                {
+                    v6 += 1;
+                }
+            }
+        }
+        if v4 + v6 > 0 {
+            tracing::info!("rib: cradle resync walked {v4} v4 + {v6} v6 installed routes");
+        }
+    }
+
+    #[cfg(not(target_os = "linux"))]
+    async fn cradle_rib_walk(&self) {}
+
     fn cradle_apply(&mut self) {
         // Tear down any previous watcher before re-pointing/disabling.
         if let Some(watch) = self.cradle_fdb_watch.take() {
@@ -3884,6 +3954,13 @@ impl Rib {
             return;
         };
         self.fib_handle.set_cradle(Some(&endpoint));
+        // Enable-after-routes: a freshly-created tee has an empty mirror,
+        // so routes installed BEFORE this enable would never reach the
+        // engine until they churn. Queue a resync (mirror replay + RIB
+        // walk). For an external engine this fires immediately; for a
+        // managed one the RPCs warn-and-drop until it starts, and the
+        // supervisor re-fires `CradleEngineUp` on the real up-edge.
+        let _ = self.tx.send(Message::CradleEngineUp);
         // The reverse channel: subscribe to cradle's datapath MAC learning
         // and feed each entry back into this RIB as a `CradleFdbLearn`, which
         // re-emits it to EVPN subscribers. Reconnects with backoff for the


### PR DESCRIPTION
## Summary

Enabling the eBPF tee on a router with an already-populated RIB programmed nothing until routes churned — `CradleFib`'s mirror only records ops that happen *while* the tee exists, so routes installed before the enable were invisible (the last gap from the dynamic L2/L3 design's future list). Now `cradle_apply` queues a `Message::CradleEngineUp` on every (re)enable, whose handler runs the existing mirror replay **plus a new RIB walk** that re-emits every FIB-installed route to the tee.

- `FibHandle::cradle_route_resync_v4/v6` tee one route (no kernel side) + `cradle_active()`; `Rib::cradle_rib_walk` iterates the default v4/v6 tables and every VRF table, re-emitting `is_fib()` **protocol** entries.
- **Protocol routes only** — the walk skips `Connected`: cradle derives a port's connected+local routes itself from the kernel addresses when `SetPort` attaches it (`kernel::derive_port`, real oif). The stored connected `RibEntry` carries only `entry.ifindex` + a `Nexthop::Link(0)`, so re-teeing it would clobber cradle's correct entry with an oif-0 one (caught live).
- Fires immediately for external engines and via the supervisor's engine-up `CradleEngineUp` for managed ones (RPCs warn-and-drop until the engine answers, then the up-edge replays). Idempotent overwrites, so the double-trigger is harmless.

## Test plan

- `cargo fmt --all --check`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo test --workspace --exclude bdd` — green.
- Live netns: a plain daemon with a static route, **then** `set system ebpf enabled true` → `cradle resync walked 1 v4` and the static appears in `show ebpf ipv4 via 10.1.1.2 dev if3`; the connected route comes from cradle's own port derivation (correct oif), not the walk. Confirmed the walk correctly skips the kernel-echo case (a leftover `K` route outranking a static is not re-teed).
- `make -C bdd cradle_spawn`: **8/8 scenarios pass** (new enable-after-routes scenario: add static → enable ebpf → resync log + route in `show ebpf ipv4`).

Generated with [Claude Code](https://claude.com/claude-code)