### PR TITLE
config: enforce YANG choice exclusivity; make isis SR dataplane a choice

### DIFF
--- a/bdd/Makefile
+++ b/bdd/Makefile
@@ -205,6 +205,10 @@ isis_sr_switchover:
 	mkdir -p allure-results
 	cargo test --test cucumber -- --concurrency=1 --tags "@isis_sr_switchover"
 
+isis_sr_dataplane_choice:
+	mkdir -p allure-results
+	cargo test --test cucumber -- --concurrency=1 --tags "@isis_sr_dataplane_choice"
+
 system_hostname:
 	mkdir -p allure-results
 	cargo test --test cucumber -- --concurrency=1 --tags "@system_hostname"
@@ -452,4 +456,4 @@ docs/%.md: tests/features/%.feature docs/feature2md.sh FORCE
 
 FORCE:
 
-.PHONY: ecmp_bfd_evict ospfv2_bfd_frr ospfv3_bfd_frr tilfa_bfd all run ibgp ebgp rr rib_static_ipv6 static_srv6_nht bgp_srv6_nht isis_ipv6 isis_srv6_base isis_fragmentation_ipv6 isis_fragmentation_ipv4 isis_l1p2p isis_tilfa isis_srmpls isis_sr_switchover system_hostname isis_l1l2 isis_redist isis_hello_auth_keychain isis_passive isis_afi_enable isis_endx_ipv6 isis_bfd_ipv6_p2p isis_bfd_ipv6_p2p_echo isis_bfd_ipv6_lan isis_bfd_ipv6_lan_echo isis_bfd_ipv4_p2p isis_bfd_ipv4_p2p_echo isis_bfd_ipv4_lan isis_bfd_ipv4_lan_echo ospf_clear_neighbor ospfv2_nssa_base ospfv2_stub_base ospfv2_tilfa ospfv3_nssa ospfv3_tilfa stamp_te_metric stamp_v6_te_metric bgp_peer_down_cleanup bgp_ipv6_over_v4_session bgp_evpn_capability bgp_vrf_evpn_type5 bgp_evpn_outpolicy_undef bgp_route_map_match bgp_policy_dynamic_update bgp_table_map bgp_v6_table_map bgp_community bgp_neighbor_group bgp_unnumbered_neighbor nd_show cradle_spawn bgp_interas_option_c bgp_interas_option_a bgp_interas_option_b bgp_interas_option_ab bgp_port bgp_ip_transparent bgp_local_as bgp_unknown_attr_transitive bgp_fast_external_failover generate open docs FORCE
+.PHONY: ecmp_bfd_evict ospfv2_bfd_frr ospfv3_bfd_frr tilfa_bfd all run ibgp ebgp rr rib_static_ipv6 static_srv6_nht bgp_srv6_nht isis_ipv6 isis_srv6_base isis_fragmentation_ipv6 isis_fragmentation_ipv4 isis_l1p2p isis_tilfa isis_srmpls isis_sr_switchover isis_sr_dataplane_choice system_hostname isis_l1l2 isis_redist isis_hello_auth_keychain isis_passive isis_afi_enable isis_endx_ipv6 isis_bfd_ipv6_p2p isis_bfd_ipv6_p2p_echo isis_bfd_ipv6_lan isis_bfd_ipv6_lan_echo isis_bfd_ipv4_p2p isis_bfd_ipv4_p2p_echo isis_bfd_ipv4_lan isis_bfd_ipv4_lan_echo ospf_clear_neighbor ospfv2_nssa_base ospfv2_stub_base ospfv2_tilfa ospfv3_nssa ospfv3_tilfa stamp_te_metric stamp_v6_te_metric bgp_peer_down_cleanup bgp_ipv6_over_v4_session bgp_evpn_capability bgp_vrf_evpn_type5 bgp_evpn_outpolicy_undef bgp_route_map_match bgp_policy_dynamic_update bgp_table_map bgp_v6_table_map bgp_community bgp_neighbor_group bgp_unnumbered_neighbor nd_show cradle_spawn bgp_interas_option_c bgp_interas_option_a bgp_interas_option_b bgp_interas_option_ab bgp_port bgp_ip_transparent bgp_local_as bgp_unknown_attr_transitive bgp_fast_external_failover generate open docs FORCE

--- a/bdd/tests/configs/isis_sr_dataplane_choice/z1.yaml
+++ b/bdd/tests/configs/isis_sr_dataplane_choice/z1.yaml
@@ -1,0 +1,46 @@
+# z1 — the node whose SR dataplane is flipped at runtime. Dual-stack
+# IS-IS L2 with SR-MPLS enabled (loopback Prefix-SID index 100 ->
+# label 16100). The SRv6 locator LOC1 is pre-provisioned in the global
+# segment-routing block but NOT bound to IS-IS: the feature binds it
+# with a single `set router isis segment-routing srv6 locator LOC1`,
+# which must implicitly delete `segment-routing mpls` (YANG choice,
+# RFC 7950 §7.9.3).
+interface:
+- if-name: lo
+  ipv4:
+    address: 10.0.0.1/32
+  ipv6:
+    address: 2001:db8::1/128
+- if-name: z1-z2
+  ipv4:
+    address: 10.0.12.1/24
+  ipv6:
+    address: 2001:db8:0:12::1/64
+system:
+  hostname: z1
+segment-routing:
+  locator:
+  - name: LOC1
+    prefix: fcbb:bbbb:1::/48
+router:
+  isis:
+    net: 49.0000.0000.0000.0001.00
+    hostname: z1
+    is-type: level-2-only
+    segment-routing:
+      mpls: {}
+    interface:
+    - if-name: lo
+      ipv4:
+        enabled: true
+        prefix-sid:
+          index: 100
+      ipv6:
+        enabled: true
+    - if-name: z1-z2
+      network-type: point-to-point
+      metric: 1
+      ipv4:
+        enabled: true
+      ipv6:
+        enabled: true

--- a/bdd/tests/configs/isis_sr_dataplane_choice/z2.yaml
+++ b/bdd/tests/configs/isis_sr_dataplane_choice/z2.yaml
@@ -1,0 +1,39 @@
+# z2 — the control node: stays on SR-MPLS (Prefix-SID index 200 ->
+# label 16200) for the whole feature while z1's dataplane is flipped.
+# Its view of z1's advertisements (label 16100 appearing/disappearing
+# from the ILM) pins the LSP-level effect of the switch.
+interface:
+- if-name: lo
+  ipv4:
+    address: 10.0.0.2/32
+  ipv6:
+    address: 2001:db8::2/128
+- if-name: z2-z1
+  ipv4:
+    address: 10.0.12.2/24
+  ipv6:
+    address: 2001:db8:0:12::2/64
+system:
+  hostname: z2
+router:
+  isis:
+    net: 49.0000.0000.0000.0002.00
+    hostname: z2
+    is-type: level-2-only
+    segment-routing:
+      mpls: {}
+    interface:
+    - if-name: lo
+      ipv4:
+        enabled: true
+        prefix-sid:
+          index: 200
+      ipv6:
+        enabled: true
+    - if-name: z2-z1
+      network-type: point-to-point
+      metric: 1
+      ipv4:
+        enabled: true
+      ipv6:
+        enabled: true

--- a/bdd/tests/features/isis_sr_dataplane_choice.feature
+++ b/bdd/tests/features/isis_sr_dataplane_choice.feature
@@ -1,0 +1,109 @@
+@isis_sr_dataplane_choice
+@isis
+Feature: IS-IS segment-routing mpls/srv6 are mutually exclusive (YANG choice)
+  As a network operator
+  I want `router isis segment-routing mpls` and `router isis
+  segment-routing srv6` to be a YANG choice, so committing one
+  dataplane implicitly deletes the other (RFC 7950 §7.9.3) — a single
+  `set router isis segment-routing srv6 locator LOC1` migrates a
+  running SR-MPLS node to SRv6 without a separate `delete`, and the
+  implicit delete tears the old dataplane's forwarding state down
+  exactly as an explicit one would.
+
+  z1 and z2 run dual-stack IS-IS L2 over one point-to-point link, both
+  starting on SR-MPLS (Prefix-SID indexes 100/200 -> labels
+  16100/16200 against the default SRGB base 16000). z1 additionally
+  pre-provisions the global SRv6 locator LOC1 (fcbb:bbbb:1::/48)
+  without binding it to IS-IS. The feature flips z1's dataplane to
+  SRv6 and back with one `set` each way and checks three layers every
+  time:
+  - config: `show running-config formal` holds exactly one dataplane
+    case (and the unrelated global `segment-routing locator` block
+    survives the sibling purge);
+  - local forwarding: the MPLS ILM empties and the locator's End SID
+    appears as a kernel seg6local route (then the reverse);
+  - the peer: z2 stays on SR-MPLS throughout, and label 16100 leaves
+    and re-enters its ILM as z1 stops/resumes advertising a
+    Prefix-SID.
+
+  Test Topology:
+  ```
+   z1 ──────────────── z2
+   10.0.12.1/24        10.0.12.2/24
+   2001:db8:0:12::1/64 2001:db8:0:12::2/64
+   lo 10.0.0.1, 2001:db8::1, SID 100, LOC1 fcbb:bbbb:1::/48 (unbound)
+   lo 10.0.0.2, 2001:db8::2, SID 200 (SR-MPLS for the whole feature)
+  ```
+
+  Scenario: Build the dual-stack SR-MPLS topology
+    Given a clean test environment
+    When I create namespace "z1"
+    And I create namespace "z2"
+    And I connect namespace "z1" interface "z1-z2" to namespace "z2" interface "z2-z1"
+    And I start zebra-rs in namespace "z1"
+    And I start zebra-rs in namespace "z2"
+    And I apply config "z1.yaml" to namespace "z1"
+    And I apply config "z2.yaml" to namespace "z2"
+    Then ping from "z1" to "10.0.0.2" should eventually succeed
+    And ping from "z1" to "2001:db8::2" should eventually succeed
+    # Both nodes advertise a Prefix-SID: z1's ILM holds its own label
+    # (16100, local pop) and z2's (16200, pop — adjacent PHP).
+    And show command "show mpls ilm" in namespace "z1" should eventually contain "16100"
+    And show command "show mpls ilm" in namespace "z1" should eventually contain "16200"
+    And show command "show running-config formal" in namespace "z1" should contain "router isis segment-routing mpls"
+    # The pre-provisioned locator is present but unbound — no SRv6
+    # SIDs exist yet.
+    And show command "show running-config formal" in namespace "z1" should contain "segment-routing locator LOC1 prefix fcbb:bbbb:1::/48"
+    And show command "show segment-routing srv6 sid" in namespace "z1" should not contain "fcbb"
+
+  Scenario: Setting srv6 implicitly deletes mpls and swaps the dataplane
+    Given the test topology exists
+    # No `delete router isis segment-routing mpls` anywhere — the
+    # choice makes the set below carry the delete implicitly.
+    When I apply command "set router isis segment-routing srv6 locator LOC1" in namespace "z1"
+    # Config level: exactly one case remains, and the purge removed
+    # only the sibling case — the global segment-routing block (same
+    # node name, different parent) is untouched.
+    Then show command "show running-config formal" in namespace "z1" should contain "router isis segment-routing srv6 locator LOC1"
+    And show command "show running-config formal" in namespace "z1" should not contain "segment-routing mpls"
+    And show command "show running-config formal" in namespace "z1" should contain "segment-routing locator LOC1 prefix fcbb:bbbb:1::/48"
+    # Dataplane level: the locator's End SID installs as a seg6local
+    # kernel route, and the SR-MPLS ILM is torn down by the implicit
+    # delete — the commit dispatches it exactly like an explicit one.
+    And show command "show segment-routing srv6 sid" in namespace "z1" should eventually contain "End"
+    And kernel route "fcbb:bbbb:1::" in namespace "z1" should eventually contain "seg6local"
+    And show command "show mpls ilm" in namespace "z1" should eventually not contain "16200"
+    And mpls ilm in namespace "z1" should be empty
+    # LSP level: z1 stopped advertising a Prefix-SID, so its label
+    # leaves the SR-MPLS peer's ILM; the adjacency itself is
+    # unaffected and both address families still forward.
+    And show command "show mpls ilm" in namespace "z2" should eventually not contain "16100"
+    And ping from "z1" to "10.0.0.2" should eventually succeed
+    And ping from "z1" to "2001:db8::2" should succeed
+
+  Scenario: Setting mpls implicitly deletes srv6 and restores the labels
+    Given the test topology exists
+    When I apply command "set router isis segment-routing mpls" in namespace "z1"
+    # Config level: the srv6 case (locator binding included) is gone;
+    # the global locator definition survives again.
+    Then show command "show running-config formal" in namespace "z1" should contain "router isis segment-routing mpls"
+    And show command "show running-config formal" in namespace "z1" should not contain "srv6"
+    And show command "show running-config formal" in namespace "z1" should contain "segment-routing locator LOC1 prefix fcbb:bbbb:1::/48"
+    # Dataplane level: labels come back, the End SID route goes.
+    And show command "show mpls ilm" in namespace "z1" should eventually contain "16100"
+    And show command "show mpls ilm" in namespace "z1" should eventually contain "16200"
+    And kernel route "fcbb:bbbb:1::" in namespace "z1" should eventually be gone
+    And show command "show segment-routing srv6 sid" in namespace "z1" should not contain "fcbb"
+    # LSP level: z1 advertises its Prefix-SID again and the peer's ILM
+    # relearns label 16100.
+    And show command "show mpls ilm" in namespace "z2" should eventually contain "16100"
+    And ping from "z1" to "10.0.0.2" should eventually succeed
+    And ping from "z1" to "2001:db8::2" should succeed
+
+  Scenario: Teardown topology
+    Given the test topology exists
+    When I stop zebra-rs in namespace "z1"
+    And I stop zebra-rs in namespace "z2"
+    And I delete namespace "z1"
+    And I delete namespace "z2"
+    Then the test environment should be clean

--- a/proto/vty.proto
+++ b/proto/vty.proto
@@ -220,6 +220,11 @@ message CommandPath {
   // readable requirement (e.g. "network or redistribute") surfaced in the
   // commit-time error. Driven by the `ext:non-empty` YANG extension.
   string non_empty = 6;
+  // When this node belongs to a `case` of a YANG `choice`, the names of
+  // the sibling nodes contributed by the choice's OTHER cases. Setting
+  // this node implicitly deletes them from the candidate store
+  // (RFC 7950 §7.9.3) — `config_set_dir` performs the purge.
+  repeated string choice_exclude = 7;
 }
 
 // Show service.

--- a/vtyctl/src/mcp/client.rs
+++ b/vtyctl/src/mcp/client.rs
@@ -72,9 +72,7 @@ impl ZebraClient {
                 name: cmd.to_string(),
                 key: "".to_string(),
                 ymatch: ymatch.into(),
-                mandatory: vec![],
-                sort_priority: 0,
-                non_empty: String::new(),
+                ..Default::default()
             };
             paths.push(path);
         }

--- a/zebra-rs/src/config/commands.rs
+++ b/zebra-rs/src/config/commands.rs
@@ -229,7 +229,7 @@ fn show_running_yaml(config: &ConfigManager) -> (ExecCode, String) {
 /// enabled at the workspace level so key order survives the round-trip.
 /// Falls back to the compact form on parse/serialize failure (empty
 /// config, etc.).
-fn prettify_json(compact: String) -> String {
+pub(super) fn prettify_json(compact: String) -> String {
     serde_json::from_str::<serde_json::Value>(&compact)
         .and_then(|v| serde_json::to_string_pretty(&v))
         .map(|mut s| {

--- a/zebra-rs/src/config/configs.rs
+++ b/zebra-rs/src/config/configs.rs
@@ -620,6 +620,15 @@ fn compare_configs(a: &Rc<Config>, b: &Rc<Config>) -> std::cmp::Ordering {
 
 // Config set.
 fn config_set_dir(config: &Rc<Config>, cpath: &CommandPath) -> Rc<Config> {
+    // Choice exclusivity (RFC 7950 §7.9.3): setting a node from one
+    // `case` implicitly deletes the sibling nodes contributed by the
+    // choice's other cases. The parser stamps those sibling names on the
+    // path element (`choice_exclude`), so purge them from this parent
+    // before creating/entering the node — the commit diff then emits the
+    // corresponding delete events to the protocol daemons.
+    for name in cpath.choice_exclude.iter() {
+        config_delete(config.clone(), name);
+    }
     let find = config.lookup(&cpath.name);
     match find {
         Some(find) => find,

--- a/zebra-rs/src/config/manager.rs
+++ b/zebra-rs/src/config/manager.rs
@@ -1088,6 +1088,38 @@ impl ConfigManager {
                     reply_static_show(req, v.format_version(), v.format_json());
                     return;
                 }
+                // `show running-config [formal|json|yaml]` is owned by the
+                // manager — the config store lives here, not in any
+                // protocol daemon, so the per-proto routing below could
+                // only produce the not-running fallback. Serving it here
+                // gives `vtyctl show` (and MCP) the same view the
+                // interactive vty shell gets from its exec-mode handler.
+                if req.paths.iter().any(|p| p.name == "running-config") {
+                    let running = || self.store.running.borrow();
+                    let render_json = || {
+                        let mut compact = String::new();
+                        running().json(&mut compact);
+                        super::commands::prettify_json(compact)
+                    };
+                    let text = if req.paths.iter().any(|p| p.name == "formal") {
+                        let mut out = String::new();
+                        running().list(&mut out);
+                        out
+                    } else if req.paths.iter().any(|p| p.name == "yaml") {
+                        let mut out = String::new();
+                        running().yaml(&mut out);
+                        out
+                    } else if req.paths.iter().any(|p| p.name == "json") {
+                        render_json()
+                    } else {
+                        let mut out = String::new();
+                        running().format(&mut out);
+                        out
+                    };
+                    let json = render_json();
+                    reply_static_show(req, text, json);
+                    return;
+                }
                 // Generic per-VRF instance redirect: `show <proto> vrf
                 // <name> …` is rewritten to `show <proto> …` and routed
                 // to the instance task's show channel when that instance
@@ -2070,6 +2102,72 @@ mod yang_load_tests {
         assert!(
             leftover.is_none(),
             "afi-safi node must be pruned after its last child is deleted"
+        );
+    }
+
+    /// `router isis segment-routing {mpls|srv6}` is a YANG `choice`:
+    /// setting one dataplane case must implicitly delete the other from
+    /// the candidate store (RFC 7950 §7.9.3). Drives the real schema end
+    /// to end — choice/case metadata flows YANG -> Entry ->
+    /// CommandPath.choice_exclude -> the `config_set_dir` purge — and
+    /// checks both switch directions, including a child-bearing case
+    /// (srv6 + locator) being fully removed.
+    #[test]
+    fn isis_sr_dataplane_choice_is_exclusive() {
+        use crate::config::ExecCode;
+        use crate::config::configs::set;
+        use crate::config::parse::{State, parse};
+        use crate::config::{Config, paths::path_try_trim};
+        use libyang::to_entry;
+        use std::rc::Rc;
+
+        let mut yang = YangStore::new();
+        yang.add_path(concat!(env!("CARGO_MANIFEST_DIR"), "/yang"));
+        yang.read_with_resolve("configure")
+            .unwrap_or_else(|e| panic!("configure failed to load: {e:#}"));
+        yang.identity_resolve();
+        let module = yang.find_module("configure").unwrap();
+        let entry = to_entry(&yang, module);
+        let set_entry = entry
+            .dir
+            .borrow()
+            .iter()
+            .find(|e| e.name == "set")
+            .cloned()
+            .expect("configure mode has a `set` entry");
+
+        let root = Rc::new(Config::new("".to_string(), None));
+        let run = |cmd: &str| {
+            let (code, _comps, state) = parse(cmd, set_entry.clone(), None, State::new());
+            assert_eq!(code, ExecCode::Success, "should parse: {cmd}");
+            set(path_try_trim("set", state.paths), root.clone());
+        };
+        let listing = || {
+            let mut out = String::new();
+            root.list(&mut out);
+            out
+        };
+
+        run("router isis segment-routing mpls");
+        assert!(listing().contains("segment-routing mpls"));
+
+        // mpls -> srv6: the mpls case must be purged by the set.
+        run("router isis segment-routing srv6 locator LOC1");
+        let out = listing();
+        assert!(out.contains("segment-routing srv6 locator LOC1"), "{out}");
+        assert!(
+            !out.contains("segment-routing mpls"),
+            "mpls case must be auto-cleared by setting srv6, got:\n{out}"
+        );
+
+        // srv6 -> mpls: the whole srv6 subtree (locator child included)
+        // must go, not just the container line.
+        run("router isis segment-routing mpls");
+        let out = listing();
+        assert!(out.contains("segment-routing mpls"), "{out}");
+        assert!(
+            !out.contains("srv6"),
+            "srv6 case (and its locator child) must be auto-cleared by setting mpls, got:\n{out}"
         );
     }
 

--- a/zebra-rs/src/config/parse.rs
+++ b/zebra-rs/src/config/parse.rs
@@ -734,6 +734,29 @@ pub fn parse(
         .get("ext:non-empty")
         .cloned()
         .unwrap_or_default();
+    // Choice exclusivity (RFC 7950 §7.9.3): when the matched node was
+    // contributed by a `case`, carry the names of the siblings from the
+    // choice's other cases so `config_set_dir` deletes them when this
+    // node is set. Siblings live in `entry.dir` — libyang flattens every
+    // case's children into the choice's parent. In value states
+    // (Leaf/Key) `entry` is the leaf itself with an empty `dir`, so this
+    // resolves to no exclusions there; the exclusion was already stamped
+    // on the element that named the case member.
+    let choice_exclude: Vec<String> = match (
+        mx.matched_entry.choice.borrow().as_ref(),
+        mx.matched_entry.case.borrow().as_ref(),
+    ) {
+        (Some(choice), Some(case)) => entry
+            .dir
+            .borrow()
+            .iter()
+            .filter(|e| {
+                e.choice.borrow().as_ref() == Some(choice) && e.case.borrow().as_ref() != Some(case)
+            })
+            .map(|e| e.name.clone())
+            .collect(),
+        _ => Vec::new(),
+    };
 
     let path = if ymatch_complete(s.ymatch, mx.matched_entry.presence, s.delete) {
         // KeyMatched / LeafMatched / LeafListMatched carry the user-
@@ -756,6 +779,7 @@ pub fn parse(
             mandatory,
             sort_priority,
             non_empty,
+            choice_exclude,
         }
     } else {
         CommandPath {
@@ -765,6 +789,7 @@ pub fn parse(
             mandatory,
             sort_priority,
             non_empty,
+            choice_exclude,
         }
     };
 

--- a/zebra-rs/src/isis/config.rs
+++ b/zebra-rs/src/isis/config.rs
@@ -1459,10 +1459,11 @@ fn apply_ti_lfa_compute_mode(isis: &mut Isis, mode: TilfaComputeModeConfig) {
 /// Body shared by the `serial` / `conservative` / `aggressive`
 /// `compute-mode` cases (each an empty leaf under the `mode` choice).
 /// Setting the case selects `mode`; deleting it reverts to the default
-/// mode — but only when *this* case is the active one, so a stale
-/// delete of a non-active case node (the candidate store does not
-/// auto-clear sibling choice cases) is a no-op rather than clobbering a
-/// newer selection.
+/// mode — but only when *this* case is the active one. A case switch
+/// commits as delete(old case) + set(new case) (the candidate store
+/// auto-clears sibling choice cases, RFC 7950 §7.9.3), and the guard
+/// makes the delete order-independent: arriving after the set, it is a
+/// no-op rather than clobbering the newer selection.
 fn config_ti_lfa_compute_mode_case(
     isis: &mut Isis,
     op: ConfigOp,

--- a/zebra-rs/src/ospf/config.rs
+++ b/zebra-rs/src/ospf/config.rs
@@ -2259,10 +2259,11 @@ fn apply_ospf_ti_lfa_compute_mode(ospf: &mut Ospf, mode: crate::spf::TilfaComput
 /// Body shared by the `serial` / `conservative` / `aggressive`
 /// `compute-mode` cases (each an empty leaf under the `mode` choice).
 /// Setting the case selects `mode`; deleting it reverts to the default
-/// mode — but only when *this* case is the active one, so a stale
-/// delete of a non-active case node (the candidate store does not
-/// auto-clear sibling choice cases) is a no-op rather than clobbering a
-/// newer selection.
+/// mode — but only when *this* case is the active one. A case switch
+/// commits as delete(old case) + set(new case) (the candidate store
+/// auto-clears sibling choice cases, RFC 7950 §7.9.3), and the guard
+/// makes the delete order-independent: arriving after the set, it is a
+/// no-op rather than clobbering the newer selection.
 fn config_ospf_ti_lfa_compute_mode_case(
     ospf: &mut Ospf,
     op: ConfigOp,

--- a/zebra-rs/src/ospf/config_v3.rs
+++ b/zebra-rs/src/ospf/config_v3.rs
@@ -387,9 +387,10 @@ fn apply_ospfv3_ti_lfa_compute_mode(
 
 /// Body shared by the v3 `serial` / `conservative` / `aggressive`
 /// `compute-mode` cases. Setting selects `mode`; deleting reverts to
-/// the default mode only when *this* case is the active one (the
-/// candidate store does not auto-clear sibling choice cases, so a stale
-/// delete of an inactive case is a no-op).
+/// the default mode only when *this* case is the active one — a case
+/// switch commits as delete(old) + set(new) (the candidate store
+/// auto-clears sibling choice cases, RFC 7950 §7.9.3), and the guard
+/// makes the delete order-independent.
 fn config_ospfv3_ti_lfa_compute_mode_case(
     ospf: &mut Ospf<Ospfv3>,
     op: ConfigOp,

--- a/zebra-rs/yang/config.yang
+++ b/zebra-rs/yang/config.yang
@@ -2542,52 +2542,65 @@ module config {
 
         container segment-routing {
           ext:help "Segment Routing (SR-MPLS / SRv6) configuration";
-          container mpls {
-            ext:help "Segment Routing over MPLS dataplane";
-            presence "Enable Segment Routing over MPLS dataplane";
-            leaf no-local-prefix-sid {
-              ext:help "Skip the local Prefix-SID label";
-              type empty;
-              description
-                "Suppress installing the local (self-originated)
-                 Prefix-SID label into the MPLS forwarding table (LFIB).
-                 By default (leaf absent) the local node-SID is installed
-                 as a pop entry so traffic arriving with this node's own
-                 node-SID label is delivered locally, matching IOS-XR /
-                 SR-OS. When present, only remote prefix-SIDs and
-                 adjacency-SIDs are installed. Only effective while
-                 SR-MPLS is enabled.";
-            }
-          }
-          container srv6 {
-            ext:help "Segment Routing over IPv6 dataplane (SRv6)";
-            presence "Enable Segment Routing over IPv6 dataplane";
-            leaf locator {
-              ext:help "Global SRv6 locator name for this instance";
-              // Name of a locator defined under the global
-              // /segment-routing/locator list. Held as a string (not a
-              // leafref) so an IS-IS config can be staged before the
-              // global locator is committed.
-              type string;
-            }
-            list flex-algo-locator {
-              ext:help "Per-flex-algo SRv6 locator binding";
-              // Per-Flex-Algorithm SRv6 locator binding. The named
-              // locator is advertised in SRv6 Locator TLV 27 with the
-              // Algorithm field set to `algo` (RFC 9352 §7.1). The
-              // base `locator` leaf above carries algorithm 0 (regular
-              // SPF); flex-algos (128..255) bind here. As with the
-              // base leaf, the locator name is a plain string so the
-              // IS-IS config can be staged before the matching
-              // /segment-routing/locator entry is committed.
-              key "algo";
-              leaf algo {
-                ext:help "Flex-Algorithm identifier (128..255)";
-                type uint8 { range "128..255"; }
+          // The two dataplanes are mutually exclusive: one IS-IS
+          // instance advertises either SR-MPLS SIDs or an SRv6 locator,
+          // never both. Modelled as a `choice`, so committing
+          // `segment-routing srv6 ...` implicitly deletes a configured
+          // `segment-routing mpls` (and vice versa) per RFC 7950
+          // §7.9.3 — the commit diff then tears the old dataplane down
+          // exactly as an explicit delete would.
+          choice dataplane {
+            case mpls {
+              container mpls {
+                ext:help "Segment Routing over MPLS dataplane";
+                presence "Enable Segment Routing over MPLS dataplane";
+                leaf no-local-prefix-sid {
+                  ext:help "Skip the local Prefix-SID label";
+                  type empty;
+                  description
+                    "Suppress installing the local (self-originated)
+                     Prefix-SID label into the MPLS forwarding table (LFIB).
+                     By default (leaf absent) the local node-SID is installed
+                     as a pop entry so traffic arriving with this node's own
+                     node-SID label is delivered locally, matching IOS-XR /
+                     SR-OS. When present, only remote prefix-SIDs and
+                     adjacency-SIDs are installed. Only effective while
+                     SR-MPLS is enabled.";
+                }
               }
-              leaf locator {
-                ext:help "SRv6 locator name for this algorithm";
-                type string;
+            }
+            case srv6 {
+              container srv6 {
+                ext:help "Segment Routing over IPv6 dataplane (SRv6)";
+                presence "Enable Segment Routing over IPv6 dataplane";
+                leaf locator {
+                  ext:help "Global SRv6 locator name for this instance";
+                  // Name of a locator defined under the global
+                  // /segment-routing/locator list. Held as a string (not a
+                  // leafref) so an IS-IS config can be staged before the
+                  // global locator is committed.
+                  type string;
+                }
+                list flex-algo-locator {
+                  ext:help "Per-flex-algo SRv6 locator binding";
+                  // Per-Flex-Algorithm SRv6 locator binding. The named
+                  // locator is advertised in SRv6 Locator TLV 27 with the
+                  // Algorithm field set to `algo` (RFC 9352 §7.1). The
+                  // base `locator` leaf above carries algorithm 0 (regular
+                  // SPF); flex-algos (128..255) bind here. As with the
+                  // base leaf, the locator name is a plain string so the
+                  // IS-IS config can be staged before the matching
+                  // /segment-routing/locator entry is committed.
+                  key "algo";
+                  leaf algo {
+                    ext:help "Flex-Algorithm identifier (128..255)";
+                    type uint8 { range "128..255"; }
+                  }
+                  leaf locator {
+                    ext:help "SRv6 locator name for this algorithm";
+                    type string;
+                  }
+                }
               }
             }
           }
@@ -2739,12 +2752,12 @@ module config {
               //
               // Modelled as a `choice` of one keyword per mode (the
               // shard count nests under `sharding`, the only mode it
-              // applies to). The cases are mutually exclusive. The
-              // default mode (serial) is applied by the Rust handler —
-              // a choice/case carries no YANG default, and switching
-              // cases does not auto-clear the previous case node from
-              // the candidate store (same cosmetic as
-              // `allowas-in {count|origin}`).
+              // applies to). The cases are mutually exclusive: setting
+              // one case auto-clears its siblings from the candidate
+              // store (RFC 7950 §7.9.3), so a case switch commits as
+              // delete(old) + set(new). The default mode (serial) is
+              // applied by the Rust handler — a choice/case carries no
+              // YANG default.
               choice mode {
                 case serial {
                   leaf serial {


### PR DESCRIPTION
## Summary

- **Choice exclusivity (RFC 7950 §7.9.3)**: setting a node from one `case` of a YANG `choice` now implicitly deletes the sibling nodes of the other cases from the candidate store. libyang already tags flattened case children with `(choice, case)` metadata; this PR carries the excluded sibling names on `CommandPath` (new repeated `choice_exclude` proto field, stamped in `parse.rs` alongside `mandatory`/`non_empty`) and purges them in `config_set_dir`. The commit diff then emits the deletes to protocol daemons exactly like an explicit `delete` (deletes precede sets within the hunk). All ingestion paths — interactive `set`, `vtyctl apply -c`/`-f`, JSON/YAML, startup load — funnel through the same parser, so all get the exclusivity.
- **`router isis segment-routing {mpls|srv6}` becomes `choice dataplane`**: one IS-IS instance advertises either SR-MPLS SIDs or an SRv6 locator, never both. `set router isis segment-routing srv6 locator LOC1` migrates a running SR-MPLS node in a single command; setting `mpls` migrates back. CLI surface and existing YAML configs are unchanged (cases flatten; no config anywhere sets both).
- **Existing choices are order-safe**: TI-LFA compute-mode (isis/ospf/ospfv3) and BGP allowas-in case-delete callbacks already guard on the active case, so the newly emitted sibling deletes are no-ops when they arrive after the new case's set. Stale comments describing the old "does not auto-clear" behavior updated.
- **`show running-config [formal|json|yaml]` now served over the Show gRPC** (config-manager DisplayTx arm, like `show version`) — it previously returned an empty stream via `vtyctl show`, since the config store isn't a protocol daemon. Needed by the new BDD feature to pin config-level exclusivity; also useful for automation/MCP.

## Testing

- New unit test `isis_sr_dataplane_choice_is_exclusive` drives the real schema end to end (choice/case flows YANG → Entry → CommandPath → purge), both switch directions, including a child-bearing case being fully removed.
- New BDD feature `isis_sr_dataplane_choice` (run locally, 45/45 steps green): dual-stack two-node SR-MPLS topology; flips z1 to SRv6 and back with one `set` each way, asserting the running config holds exactly one case (the same-named global `segment-routing locator` block survives the purge), the MPLS ILM empties/refills, the End SID seg6local kernel route appears/goes, and the SR-MPLS peer's ILM loses/relearns z1's Prefix-SID label.
- `cargo test --workspace --exclude bdd`, `cargo test -p bdd --lib` (tag guard), `cargo clippy --workspace --all-targets -- -D warnings`, `cargo fmt` — all clean.

Follow-ups (separate PRs): the mirrored `router ospf/ospfv3 segment-routing` blocks can get the same choice treatment; a BDD feature exercising the full playset SR-MPLS → SRv6-classic → uSID → SR-MPLS switchover via `vtyctl apply` is in progress.

🤖 Generated with [Claude Code](https://claude.com/claude-code)