### PR TITLE
bdd: live SR-MPLS -> SRv6 classic -> SRv6 uSID -> SR-MPLS switchover feature

### DIFF
--- a/bdd/Makefile
+++ b/bdd/Makefile
@@ -197,6 +197,14 @@ isis_srmpls:
 	mkdir -p allure-results
 	cargo test --test cucumber -- --concurrency=1 --tags "@isis_srmpls"
 
+# Live dataplane switchover: SR-MPLS -> SRv6 classic -> SRv6 uSID ->
+# SR-MPLS on the RFC 9855 playset topology, each phase applied as a
+# whole-config replace (vtyctl apply -f). ~10 namespaces, several
+# convergence waits — give it a few minutes.
+isis_sr_switchover:
+	mkdir -p allure-results
+	cargo test --test cucumber -- --concurrency=1 --tags "@isis_sr_switchover"
+
 system_hostname:
 	mkdir -p allure-results
 	cargo test --test cucumber -- --concurrency=1 --tags "@system_hostname"
@@ -444,4 +452,4 @@ docs/%.md: tests/features/%.feature docs/feature2md.sh FORCE
 
 FORCE:
 
-.PHONY: ecmp_bfd_evict ospfv2_bfd_frr ospfv3_bfd_frr tilfa_bfd all run ibgp ebgp rr rib_static_ipv6 static_srv6_nht bgp_srv6_nht isis_ipv6 isis_srv6_base isis_fragmentation_ipv6 isis_fragmentation_ipv4 isis_l1p2p isis_tilfa isis_srmpls system_hostname isis_l1l2 isis_redist isis_hello_auth_keychain isis_passive isis_afi_enable isis_endx_ipv6 isis_bfd_ipv6_p2p isis_bfd_ipv6_p2p_echo isis_bfd_ipv6_lan isis_bfd_ipv6_lan_echo isis_bfd_ipv4_p2p isis_bfd_ipv4_p2p_echo isis_bfd_ipv4_lan isis_bfd_ipv4_lan_echo ospf_clear_neighbor ospfv2_nssa_base ospfv2_stub_base ospfv2_tilfa ospfv3_nssa ospfv3_tilfa stamp_te_metric stamp_v6_te_metric bgp_peer_down_cleanup bgp_ipv6_over_v4_session bgp_evpn_capability bgp_vrf_evpn_type5 bgp_evpn_outpolicy_undef bgp_route_map_match bgp_policy_dynamic_update bgp_table_map bgp_v6_table_map bgp_community bgp_neighbor_group bgp_unnumbered_neighbor nd_show cradle_spawn bgp_interas_option_c bgp_interas_option_a bgp_interas_option_b bgp_interas_option_ab bgp_port bgp_ip_transparent bgp_local_as bgp_unknown_attr_transitive bgp_fast_external_failover generate open docs FORCE
+.PHONY: ecmp_bfd_evict ospfv2_bfd_frr ospfv3_bfd_frr tilfa_bfd all run ibgp ebgp rr rib_static_ipv6 static_srv6_nht bgp_srv6_nht isis_ipv6 isis_srv6_base isis_fragmentation_ipv6 isis_fragmentation_ipv4 isis_l1p2p isis_tilfa isis_srmpls isis_sr_switchover system_hostname isis_l1l2 isis_redist isis_hello_auth_keychain isis_passive isis_afi_enable isis_endx_ipv6 isis_bfd_ipv6_p2p isis_bfd_ipv6_p2p_echo isis_bfd_ipv6_lan isis_bfd_ipv6_lan_echo isis_bfd_ipv4_p2p isis_bfd_ipv4_p2p_echo isis_bfd_ipv4_lan isis_bfd_ipv4_lan_echo ospf_clear_neighbor ospfv2_nssa_base ospfv2_stub_base ospfv2_tilfa ospfv3_nssa ospfv3_tilfa stamp_te_metric stamp_v6_te_metric bgp_peer_down_cleanup bgp_ipv6_over_v4_session bgp_evpn_capability bgp_vrf_evpn_type5 bgp_evpn_outpolicy_undef bgp_route_map_match bgp_policy_dynamic_update bgp_table_map bgp_v6_table_map bgp_community bgp_neighbor_group bgp_unnumbered_neighbor nd_show cradle_spawn bgp_interas_option_c bgp_interas_option_a bgp_interas_option_b bgp_interas_option_ab bgp_port bgp_ip_transparent bgp_local_as bgp_unknown_attr_transitive bgp_fast_external_failover generate open docs FORCE

--- a/bdd/tests/configs/isis_sr_switchover/d-srmpls.yaml
+++ b/bdd/tests/configs/isis_sr_switchover/d-srmpls.yaml
@@ -1,0 +1,43 @@
+interface:
+- if-name: d-e2
+  ipv4:
+    address: 172.16.1.1/24
+- if-name: d-n1
+  ipv4:
+    address: 192.168.2.2/24
+- if-name: d-r3
+  ipv4:
+    address: 192.168.5.1/24
+- if-name: lo
+  ipv4:
+    address: 10.0.0.8/32
+system:
+  hostname: d
+router:
+  isis:
+    net: 49.0000.0000.0000.0008.00
+    hostname: d
+    is-type: level-2-only
+    segment-routing:
+      mpls: {}
+    te-router-id: 10.0.0.8
+    interface:
+    - if-name: d-n1
+      ipv4:
+        enabled: true
+      metric: 1
+    - if-name: d-r3
+      ipv4:
+        enabled: true
+      metric: 1
+    - if-name: lo
+      ipv4:
+        enabled: true
+        prefix-sid:
+          index: 800
+  static:
+    ipv4:
+      route:
+      - prefix: 172.16.0.0/24
+        nexthop:
+        - address: 10.0.0.1

--- a/bdd/tests/configs/isis_sr_switchover/d-srv6.yaml
+++ b/bdd/tests/configs/isis_sr_switchover/d-srv6.yaml
@@ -1,0 +1,66 @@
+interface:
+- if-name: lo
+  ipv6:
+    address: 2001:db8::8/128
+- if-name: d-n1
+  ipv6:
+    address: 2001:db8:0:10::2/64
+- if-name: d-r3
+  ipv6:
+    address: 2001:db8:0:11::2/64
+- if-name: d-e2
+  ipv6:
+    address: 2001:db8:200::1/64
+system:
+  hostname: d
+segment-routing:
+  locator:
+  - name: LOC8
+    prefix: fcbb:bbbb:8::/48
+router:
+  isis:
+    net: 49.0000.0000.0000.0008.00
+    hostname: d
+    is-type: level-2-only
+    segment-routing:
+      srv6:
+        locator: LOC8
+    interface:
+    - if-name: lo
+      ipv6:
+        enabled: true
+    - if-name: d-n1
+      network-type: point-to-point
+      metric: 1
+      ipv6:
+        enabled: true
+    - if-name: d-r3
+      network-type: point-to-point
+      metric: 1
+      ipv6:
+        enabled: true
+  bgp:
+    global:
+      as: 65000
+      router-id: 10.0.0.8
+    timer:
+      adv-interval:
+        ibgp: 1
+        ebgp: 1
+    segment-routing:
+      srv6:
+        locator: LOC8
+        ipv6-unicast: {}
+    neighbor:
+    - remote-address: 2001:db8::1
+      remote-as: 65000
+      update-source: 2001:db8::8
+      enabled: true
+      afi-safi:
+      - name: ipv6
+        enabled: true
+        encapsulation-type: srv6
+    afi-safi:
+    - name: ipv6
+      redistribute:
+        connected: {}

--- a/bdd/tests/configs/isis_sr_switchover/d-usid.yaml
+++ b/bdd/tests/configs/isis_sr_switchover/d-usid.yaml
@@ -1,0 +1,67 @@
+interface:
+- if-name: lo
+  ipv6:
+    address: 2001:db8::8/128
+- if-name: d-n1
+  ipv6:
+    address: 2001:db8:0:10::2/64
+- if-name: d-r3
+  ipv6:
+    address: 2001:db8:0:11::2/64
+- if-name: d-e2
+  ipv6:
+    address: 2001:db8:200::1/64
+system:
+  hostname: d
+segment-routing:
+  locator:
+  - name: LOC8
+    prefix: fcbb:bbbb:8::/48
+    behavior: usid
+router:
+  isis:
+    net: 49.0000.0000.0000.0008.00
+    hostname: d
+    is-type: level-2-only
+    segment-routing:
+      srv6:
+        locator: LOC8
+    interface:
+    - if-name: lo
+      ipv6:
+        enabled: true
+    - if-name: d-n1
+      network-type: point-to-point
+      metric: 1
+      ipv6:
+        enabled: true
+    - if-name: d-r3
+      network-type: point-to-point
+      metric: 1
+      ipv6:
+        enabled: true
+  bgp:
+    global:
+      as: 65000
+      router-id: 10.0.0.8
+    timer:
+      adv-interval:
+        ibgp: 1
+        ebgp: 1
+    segment-routing:
+      srv6:
+        locator: LOC8
+        ipv6-unicast: {}
+    neighbor:
+    - remote-address: 2001:db8::1
+      remote-as: 65000
+      update-source: 2001:db8::8
+      enabled: true
+      afi-safi:
+      - name: ipv6
+        enabled: true
+        encapsulation-type: srv6
+    afi-safi:
+    - name: ipv6
+      redistribute:
+        connected: {}

--- a/bdd/tests/configs/isis_sr_switchover/n1-srmpls.yaml
+++ b/bdd/tests/configs/isis_sr_switchover/n1-srmpls.yaml
@@ -1,0 +1,48 @@
+interface:
+- if-name: lo
+  ipv4:
+    address: 10.0.0.2/32
+- if-name: n1-s
+  ipv4:
+    address: 192.168.0.2/24
+- if-name: n1-r1
+  ipv4:
+    address: 192.168.6.1/24
+- if-name: n1-r2
+  ipv4:
+    address: 192.168.8.1/24
+- if-name: n1-d
+  ipv4:
+    address: 192.168.2.1/24
+system:
+  hostname: n1
+router:
+  isis:
+    net: 49.0000.0000.0000.0002.00
+    hostname: n1
+    is-type: level-2-only
+    segment-routing:
+      mpls: {}
+    te-router-id: 10.0.0.2
+    interface:
+    - if-name: lo
+      ipv4:
+        enabled: true
+        prefix-sid:
+          index: 200
+    - if-name: n1-s
+      ipv4:
+        enabled: true
+      metric: 1
+    - if-name: n1-r1
+      ipv4:
+        enabled: true
+      metric: 1
+    - if-name: n1-r2
+      ipv4:
+        enabled: true
+      metric: 1
+    - if-name: n1-d
+      ipv4:
+        enabled: true
+      metric: 1

--- a/bdd/tests/configs/isis_sr_switchover/n1-srv6.yaml
+++ b/bdd/tests/configs/isis_sr_switchover/n1-srv6.yaml
@@ -1,0 +1,54 @@
+interface:
+- if-name: lo
+  ipv6:
+    address: 2001:db8::2/128
+- if-name: n1-s
+  ipv6:
+    address: 2001:db8:0:1::2/64
+- if-name: n1-r1
+  ipv6:
+    address: 2001:db8:0:4::1/64
+- if-name: n1-r2
+  ipv6:
+    address: 2001:db8:0:7::1/64
+- if-name: n1-d
+  ipv6:
+    address: 2001:db8:0:10::1/64
+system:
+  hostname: n1
+segment-routing:
+  locator:
+  - name: LOC2
+    prefix: fcbb:bbbb:2::/48
+router:
+  isis:
+    net: 49.0000.0000.0000.0002.00
+    hostname: n1
+    is-type: level-2-only
+    segment-routing:
+      srv6:
+        locator: LOC2
+    interface:
+    - if-name: lo
+      ipv6:
+        enabled: true
+    - if-name: n1-s
+      network-type: point-to-point
+      metric: 1
+      ipv6:
+        enabled: true
+    - if-name: n1-r1
+      network-type: point-to-point
+      metric: 1
+      ipv6:
+        enabled: true
+    - if-name: n1-r2
+      network-type: point-to-point
+      metric: 1
+      ipv6:
+        enabled: true
+    - if-name: n1-d
+      network-type: point-to-point
+      metric: 1
+      ipv6:
+        enabled: true

--- a/bdd/tests/configs/isis_sr_switchover/n1-usid.yaml
+++ b/bdd/tests/configs/isis_sr_switchover/n1-usid.yaml
@@ -1,0 +1,55 @@
+interface:
+- if-name: lo
+  ipv6:
+    address: 2001:db8::2/128
+- if-name: n1-s
+  ipv6:
+    address: 2001:db8:0:1::2/64
+- if-name: n1-r1
+  ipv6:
+    address: 2001:db8:0:4::1/64
+- if-name: n1-r2
+  ipv6:
+    address: 2001:db8:0:7::1/64
+- if-name: n1-d
+  ipv6:
+    address: 2001:db8:0:10::1/64
+system:
+  hostname: n1
+segment-routing:
+  locator:
+  - name: LOC2
+    prefix: fcbb:bbbb:2::/48
+    behavior: usid
+router:
+  isis:
+    net: 49.0000.0000.0000.0002.00
+    hostname: n1
+    is-type: level-2-only
+    segment-routing:
+      srv6:
+        locator: LOC2
+    interface:
+    - if-name: lo
+      ipv6:
+        enabled: true
+    - if-name: n1-s
+      network-type: point-to-point
+      metric: 1
+      ipv6:
+        enabled: true
+    - if-name: n1-r1
+      network-type: point-to-point
+      metric: 1
+      ipv6:
+        enabled: true
+    - if-name: n1-r2
+      network-type: point-to-point
+      metric: 1
+      ipv6:
+        enabled: true
+    - if-name: n1-d
+      network-type: point-to-point
+      metric: 1
+      ipv6:
+        enabled: true

--- a/bdd/tests/configs/isis_sr_switchover/n2-srmpls.yaml
+++ b/bdd/tests/configs/isis_sr_switchover/n2-srmpls.yaml
@@ -1,0 +1,34 @@
+interface:
+- if-name: lo
+  ipv4:
+    address: 10.0.0.3/32
+- if-name: n2-s
+  ipv4:
+    address: 192.168.3.2/24
+- if-name: n2-r1
+  ipv4:
+    address: 192.168.7.1/24
+system:
+  hostname: n2
+router:
+  isis:
+    net: 49.0000.0000.0000.0003.00
+    hostname: n2
+    is-type: level-2-only
+    segment-routing:
+      mpls: {}
+    te-router-id: 10.0.0.3
+    interface:
+    - if-name: lo
+      ipv4:
+        enabled: true
+        prefix-sid:
+          index: 300
+    - if-name: n2-s
+      ipv4:
+        enabled: true
+      metric: 1
+    - if-name: n2-r1
+      ipv4:
+        enabled: true
+      metric: 1

--- a/bdd/tests/configs/isis_sr_switchover/n2-srv6.yaml
+++ b/bdd/tests/configs/isis_sr_switchover/n2-srv6.yaml
@@ -1,0 +1,38 @@
+interface:
+- if-name: lo
+  ipv6:
+    address: 2001:db8::3/128
+- if-name: n2-s
+  ipv6:
+    address: 2001:db8:0:2::2/64
+- if-name: n2-r1
+  ipv6:
+    address: 2001:db8:0:5::1/64
+system:
+  hostname: n2
+segment-routing:
+  locator:
+  - name: LOC3
+    prefix: fcbb:bbbb:3::/48
+router:
+  isis:
+    net: 49.0000.0000.0000.0003.00
+    hostname: n2
+    is-type: level-2-only
+    segment-routing:
+      srv6:
+        locator: LOC3
+    interface:
+    - if-name: lo
+      ipv6:
+        enabled: true
+    - if-name: n2-s
+      network-type: point-to-point
+      metric: 1
+      ipv6:
+        enabled: true
+    - if-name: n2-r1
+      network-type: point-to-point
+      metric: 1
+      ipv6:
+        enabled: true

--- a/bdd/tests/configs/isis_sr_switchover/n2-usid.yaml
+++ b/bdd/tests/configs/isis_sr_switchover/n2-usid.yaml
@@ -1,0 +1,39 @@
+interface:
+- if-name: lo
+  ipv6:
+    address: 2001:db8::3/128
+- if-name: n2-s
+  ipv6:
+    address: 2001:db8:0:2::2/64
+- if-name: n2-r1
+  ipv6:
+    address: 2001:db8:0:5::1/64
+system:
+  hostname: n2
+segment-routing:
+  locator:
+  - name: LOC3
+    prefix: fcbb:bbbb:3::/48
+    behavior: usid
+router:
+  isis:
+    net: 49.0000.0000.0000.0003.00
+    hostname: n2
+    is-type: level-2-only
+    segment-routing:
+      srv6:
+        locator: LOC3
+    interface:
+    - if-name: lo
+      ipv6:
+        enabled: true
+    - if-name: n2-s
+      network-type: point-to-point
+      metric: 1
+      ipv6:
+        enabled: true
+    - if-name: n2-r1
+      network-type: point-to-point
+      metric: 1
+      ipv6:
+        enabled: true

--- a/bdd/tests/configs/isis_sr_switchover/n3-srmpls.yaml
+++ b/bdd/tests/configs/isis_sr_switchover/n3-srmpls.yaml
@@ -1,0 +1,34 @@
+interface:
+- if-name: lo
+  ipv4:
+    address: 10.0.0.4/32
+- if-name: n3-s
+  ipv4:
+    address: 192.168.1.2/24
+- if-name: n3-r1
+  ipv4:
+    address: 192.168.10.1/24
+system:
+  hostname: n3
+router:
+  isis:
+    net: 49.0000.0000.0000.0004.00
+    hostname: n3
+    interface:
+    - if-name: lo
+      ipv4:
+        enabled: true
+        prefix-sid:
+          index: 400
+    - if-name: n3-s
+      ipv4:
+        enabled: true
+      metric: 1000
+    - if-name: n3-r1
+      ipv4:
+        enabled: true
+      metric: 1000
+    is-type: level-2-only
+    segment-routing:
+      mpls: {}
+    te-router-id: 10.0.0.4

--- a/bdd/tests/configs/isis_sr_switchover/n3-srv6.yaml
+++ b/bdd/tests/configs/isis_sr_switchover/n3-srv6.yaml
@@ -1,0 +1,38 @@
+interface:
+- if-name: lo
+  ipv6:
+    address: 2001:db8::4/128
+- if-name: n3-s
+  ipv6:
+    address: 2001:db8:0:3::2/64
+- if-name: n3-r1
+  ipv6:
+    address: 2001:db8:0:6::1/64
+system:
+  hostname: n3
+segment-routing:
+  locator:
+  - name: LOC4
+    prefix: fcbb:bbbb:4::/48
+router:
+  isis:
+    net: 49.0000.0000.0000.0004.00
+    hostname: n3
+    is-type: level-2-only
+    segment-routing:
+      srv6:
+        locator: LOC4
+    interface:
+    - if-name: lo
+      ipv6:
+        enabled: true
+    - if-name: n3-s
+      network-type: point-to-point
+      metric: 1000
+      ipv6:
+        enabled: true
+    - if-name: n3-r1
+      network-type: point-to-point
+      metric: 1000
+      ipv6:
+        enabled: true

--- a/bdd/tests/configs/isis_sr_switchover/n3-usid.yaml
+++ b/bdd/tests/configs/isis_sr_switchover/n3-usid.yaml
@@ -1,0 +1,39 @@
+interface:
+- if-name: lo
+  ipv6:
+    address: 2001:db8::4/128
+- if-name: n3-s
+  ipv6:
+    address: 2001:db8:0:3::2/64
+- if-name: n3-r1
+  ipv6:
+    address: 2001:db8:0:6::1/64
+system:
+  hostname: n3
+segment-routing:
+  locator:
+  - name: LOC4
+    prefix: fcbb:bbbb:4::/48
+    behavior: usid
+router:
+  isis:
+    net: 49.0000.0000.0000.0004.00
+    hostname: n3
+    is-type: level-2-only
+    segment-routing:
+      srv6:
+        locator: LOC4
+    interface:
+    - if-name: lo
+      ipv6:
+        enabled: true
+    - if-name: n3-s
+      network-type: point-to-point
+      metric: 1000
+      ipv6:
+        enabled: true
+    - if-name: n3-r1
+      network-type: point-to-point
+      metric: 1000
+      ipv6:
+        enabled: true

--- a/bdd/tests/configs/isis_sr_switchover/r1-srmpls.yaml
+++ b/bdd/tests/configs/isis_sr_switchover/r1-srmpls.yaml
@@ -1,0 +1,48 @@
+interface:
+- if-name: lo
+  ipv4:
+    address: 10.0.0.5/32
+- if-name: r1-n1
+  ipv4:
+    address: 192.168.6.2/24
+- if-name: r1-n2
+  ipv4:
+    address: 192.168.7.2/24
+- if-name: r1-n3
+  ipv4:
+    address: 192.168.10.2/24
+- if-name: r1-r2
+  ipv4:
+    address: 192.168.4.1/24
+system:
+  hostname: r1
+router:
+  isis:
+    net: 49.0000.0000.0000.0005.00
+    hostname: r1
+    interface:
+    - if-name: lo
+      ipv4:
+        enabled: true
+        prefix-sid:
+          index: 500
+    - if-name: r1-n1
+      ipv4:
+        enabled: true
+      metric: 1
+    - if-name: r1-n2
+      ipv4:
+        enabled: true
+      metric: 1
+    - if-name: r1-n3
+      ipv4:
+        enabled: true
+      metric: 1000
+    - if-name: r1-r2
+      ipv4:
+        enabled: true
+      metric: 1000
+    is-type: level-2-only
+    segment-routing:
+      mpls: {}
+    te-router-id: 10.0.0.5

--- a/bdd/tests/configs/isis_sr_switchover/r1-srv6.yaml
+++ b/bdd/tests/configs/isis_sr_switchover/r1-srv6.yaml
@@ -1,0 +1,54 @@
+interface:
+- if-name: lo
+  ipv6:
+    address: 2001:db8::5/128
+- if-name: r1-n1
+  ipv6:
+    address: 2001:db8:0:4::2/64
+- if-name: r1-n2
+  ipv6:
+    address: 2001:db8:0:5::2/64
+- if-name: r1-n3
+  ipv6:
+    address: 2001:db8:0:6::2/64
+- if-name: r1-r2
+  ipv6:
+    address: 2001:db8:0:8::1/64
+system:
+  hostname: r1
+segment-routing:
+  locator:
+  - name: LOC5
+    prefix: fcbb:bbbb:5::/48
+router:
+  isis:
+    net: 49.0000.0000.0000.0005.00
+    hostname: r1
+    is-type: level-2-only
+    segment-routing:
+      srv6:
+        locator: LOC5
+    interface:
+    - if-name: lo
+      ipv6:
+        enabled: true
+    - if-name: r1-n1
+      network-type: point-to-point
+      metric: 1
+      ipv6:
+        enabled: true
+    - if-name: r1-n2
+      network-type: point-to-point
+      metric: 1
+      ipv6:
+        enabled: true
+    - if-name: r1-n3
+      network-type: point-to-point
+      metric: 1000
+      ipv6:
+        enabled: true
+    - if-name: r1-r2
+      network-type: point-to-point
+      metric: 1000
+      ipv6:
+        enabled: true

--- a/bdd/tests/configs/isis_sr_switchover/r1-usid.yaml
+++ b/bdd/tests/configs/isis_sr_switchover/r1-usid.yaml
@@ -1,0 +1,55 @@
+interface:
+- if-name: lo
+  ipv6:
+    address: 2001:db8::5/128
+- if-name: r1-n1
+  ipv6:
+    address: 2001:db8:0:4::2/64
+- if-name: r1-n2
+  ipv6:
+    address: 2001:db8:0:5::2/64
+- if-name: r1-n3
+  ipv6:
+    address: 2001:db8:0:6::2/64
+- if-name: r1-r2
+  ipv6:
+    address: 2001:db8:0:8::1/64
+system:
+  hostname: r1
+segment-routing:
+  locator:
+  - name: LOC5
+    prefix: fcbb:bbbb:5::/48
+    behavior: usid
+router:
+  isis:
+    net: 49.0000.0000.0000.0005.00
+    hostname: r1
+    is-type: level-2-only
+    segment-routing:
+      srv6:
+        locator: LOC5
+    interface:
+    - if-name: lo
+      ipv6:
+        enabled: true
+    - if-name: r1-n1
+      network-type: point-to-point
+      metric: 1
+      ipv6:
+        enabled: true
+    - if-name: r1-n2
+      network-type: point-to-point
+      metric: 1
+      ipv6:
+        enabled: true
+    - if-name: r1-n3
+      network-type: point-to-point
+      metric: 1000
+      ipv6:
+        enabled: true
+    - if-name: r1-r2
+      network-type: point-to-point
+      metric: 1000
+      ipv6:
+        enabled: true

--- a/bdd/tests/configs/isis_sr_switchover/r2-srmpls.yaml
+++ b/bdd/tests/configs/isis_sr_switchover/r2-srmpls.yaml
@@ -1,0 +1,41 @@
+interface:
+- if-name: lo
+  ipv4:
+    address: 10.0.0.6/32
+- if-name: r2-n1
+  ipv4:
+    address: 192.168.8.2/24
+- if-name: r2-r1
+  ipv4:
+    address: 192.168.4.2/24
+- if-name: r2-r3
+  ipv4:
+    address: 192.168.9.1/24
+system:
+  hostname: r2
+router:
+  isis:
+    net: 49.0000.0000.0000.0006.00
+    hostname: r2
+    interface:
+    - if-name: lo
+      ipv4:
+        enabled: true
+        prefix-sid:
+          index: 600
+    - if-name: r2-n1
+      ipv4:
+        enabled: true
+      metric: 1
+    - if-name: r2-r1
+      ipv4:
+        enabled: true
+      metric: 1000
+    - if-name: r2-r3
+      ipv4:
+        enabled: true
+      metric: 1000
+    is-type: level-2-only
+    segment-routing:
+      mpls: {}
+    te-router-id: 10.0.0.6

--- a/bdd/tests/configs/isis_sr_switchover/r2-srv6.yaml
+++ b/bdd/tests/configs/isis_sr_switchover/r2-srv6.yaml
@@ -1,0 +1,46 @@
+interface:
+- if-name: lo
+  ipv6:
+    address: 2001:db8::6/128
+- if-name: r2-n1
+  ipv6:
+    address: 2001:db8:0:7::2/64
+- if-name: r2-r1
+  ipv6:
+    address: 2001:db8:0:8::2/64
+- if-name: r2-r3
+  ipv6:
+    address: 2001:db8:0:9::1/64
+system:
+  hostname: r2
+segment-routing:
+  locator:
+  - name: LOC6
+    prefix: fcbb:bbbb:6::/48
+router:
+  isis:
+    net: 49.0000.0000.0000.0006.00
+    hostname: r2
+    is-type: level-2-only
+    segment-routing:
+      srv6:
+        locator: LOC6
+    interface:
+    - if-name: lo
+      ipv6:
+        enabled: true
+    - if-name: r2-n1
+      network-type: point-to-point
+      metric: 1
+      ipv6:
+        enabled: true
+    - if-name: r2-r1
+      network-type: point-to-point
+      metric: 1000
+      ipv6:
+        enabled: true
+    - if-name: r2-r3
+      network-type: point-to-point
+      metric: 1000
+      ipv6:
+        enabled: true

--- a/bdd/tests/configs/isis_sr_switchover/r2-usid.yaml
+++ b/bdd/tests/configs/isis_sr_switchover/r2-usid.yaml
@@ -1,0 +1,47 @@
+interface:
+- if-name: lo
+  ipv6:
+    address: 2001:db8::6/128
+- if-name: r2-n1
+  ipv6:
+    address: 2001:db8:0:7::2/64
+- if-name: r2-r1
+  ipv6:
+    address: 2001:db8:0:8::2/64
+- if-name: r2-r3
+  ipv6:
+    address: 2001:db8:0:9::1/64
+system:
+  hostname: r2
+segment-routing:
+  locator:
+  - name: LOC6
+    prefix: fcbb:bbbb:6::/48
+    behavior: usid
+router:
+  isis:
+    net: 49.0000.0000.0000.0006.00
+    hostname: r2
+    is-type: level-2-only
+    segment-routing:
+      srv6:
+        locator: LOC6
+    interface:
+    - if-name: lo
+      ipv6:
+        enabled: true
+    - if-name: r2-n1
+      network-type: point-to-point
+      metric: 1
+      ipv6:
+        enabled: true
+    - if-name: r2-r1
+      network-type: point-to-point
+      metric: 1000
+      ipv6:
+        enabled: true
+    - if-name: r2-r3
+      network-type: point-to-point
+      metric: 1000
+      ipv6:
+        enabled: true

--- a/bdd/tests/configs/isis_sr_switchover/r3-srmpls.yaml
+++ b/bdd/tests/configs/isis_sr_switchover/r3-srmpls.yaml
@@ -1,0 +1,34 @@
+interface:
+- if-name: lo
+  ipv4:
+    address: 10.0.0.7/32
+- if-name: r3-r2
+  ipv4:
+    address: 192.168.9.2/24
+- if-name: r3-d
+  ipv4:
+    address: 192.168.5.2/24
+system:
+  hostname: r3
+router:
+  isis:
+    net: 49.0000.0000.0000.0007.00
+    hostname: r3
+    interface:
+    - if-name: lo
+      ipv4:
+        enabled: true
+        prefix-sid:
+          index: 700
+    - if-name: r3-r2
+      ipv4:
+        enabled: true
+      metric: 1000
+    - if-name: r3-d
+      ipv4:
+        enabled: true
+      metric: 1
+    is-type: level-2-only
+    segment-routing:
+      mpls: {}
+    te-router-id: 10.0.0.7

--- a/bdd/tests/configs/isis_sr_switchover/r3-srv6.yaml
+++ b/bdd/tests/configs/isis_sr_switchover/r3-srv6.yaml
@@ -1,0 +1,38 @@
+interface:
+- if-name: lo
+  ipv6:
+    address: 2001:db8::7/128
+- if-name: r3-r2
+  ipv6:
+    address: 2001:db8:0:9::2/64
+- if-name: r3-d
+  ipv6:
+    address: 2001:db8:0:11::1/64
+system:
+  hostname: r3
+segment-routing:
+  locator:
+  - name: LOC7
+    prefix: fcbb:bbbb:7::/48
+router:
+  isis:
+    net: 49.0000.0000.0000.0007.00
+    hostname: r3
+    is-type: level-2-only
+    segment-routing:
+      srv6:
+        locator: LOC7
+    interface:
+    - if-name: lo
+      ipv6:
+        enabled: true
+    - if-name: r3-r2
+      network-type: point-to-point
+      metric: 1000
+      ipv6:
+        enabled: true
+    - if-name: r3-d
+      network-type: point-to-point
+      metric: 1
+      ipv6:
+        enabled: true

--- a/bdd/tests/configs/isis_sr_switchover/r3-usid.yaml
+++ b/bdd/tests/configs/isis_sr_switchover/r3-usid.yaml
@@ -1,0 +1,39 @@
+interface:
+- if-name: lo
+  ipv6:
+    address: 2001:db8::7/128
+- if-name: r3-r2
+  ipv6:
+    address: 2001:db8:0:9::2/64
+- if-name: r3-d
+  ipv6:
+    address: 2001:db8:0:11::1/64
+system:
+  hostname: r3
+segment-routing:
+  locator:
+  - name: LOC7
+    prefix: fcbb:bbbb:7::/48
+    behavior: usid
+router:
+  isis:
+    net: 49.0000.0000.0000.0007.00
+    hostname: r3
+    is-type: level-2-only
+    segment-routing:
+      srv6:
+        locator: LOC7
+    interface:
+    - if-name: lo
+      ipv6:
+        enabled: true
+    - if-name: r3-r2
+      network-type: point-to-point
+      metric: 1000
+      ipv6:
+        enabled: true
+    - if-name: r3-d
+      network-type: point-to-point
+      metric: 1
+      ipv6:
+        enabled: true

--- a/bdd/tests/configs/isis_sr_switchover/s-srmpls.yaml
+++ b/bdd/tests/configs/isis_sr_switchover/s-srmpls.yaml
@@ -1,0 +1,50 @@
+interface:
+- if-name: lo
+  ipv4:
+    address: 10.0.0.1/32
+- if-name: s-e1
+  ipv4:
+    address: 172.16.0.2/24
+- if-name: s-n1
+  ipv4:
+    address: 192.168.0.1/24
+- if-name: s-n2
+  ipv4:
+    address: 192.168.3.1/24
+- if-name: s-n3
+  ipv4:
+    address: 192.168.1.1/24
+system:
+  hostname: s
+router:
+  isis:
+    net: 49.0000.0000.0000.0001.00
+    hostname: s
+    is-type: level-2-only
+    segment-routing:
+      mpls: {}
+    te-router-id: 10.0.0.1
+    interface:
+    - if-name: lo
+      ipv4:
+        enabled: true
+        prefix-sid:
+          index: 100
+    - if-name: s-n1
+      ipv4:
+        enabled: true
+      metric: 1
+    - if-name: s-n2
+      ipv4:
+        enabled: true
+      metric: 1
+    - if-name: s-n3
+      ipv4:
+        enabled: true
+      metric: 1000
+  static:
+    ipv4:
+      route:
+      - prefix: 172.16.1.0/24
+        nexthop:
+        - address: 10.0.0.8

--- a/bdd/tests/configs/isis_sr_switchover/s-srv6.yaml
+++ b/bdd/tests/configs/isis_sr_switchover/s-srv6.yaml
@@ -1,0 +1,74 @@
+interface:
+- if-name: lo
+  ipv6:
+    address: 2001:db8::1/128
+- if-name: s-n1
+  ipv6:
+    address: 2001:db8:0:1::1/64
+- if-name: s-n2
+  ipv6:
+    address: 2001:db8:0:2::1/64
+- if-name: s-n3
+  ipv6:
+    address: 2001:db8:0:3::1/64
+- if-name: s-e1
+  ipv6:
+    address: 2001:db8:100::1/64
+system:
+  hostname: s
+segment-routing:
+  locator:
+  - name: LOC1
+    prefix: fcbb:bbbb:1::/48
+router:
+  isis:
+    net: 49.0000.0000.0000.0001.00
+    hostname: s
+    is-type: level-2-only
+    segment-routing:
+      srv6:
+        locator: LOC1
+    interface:
+    - if-name: lo
+      ipv6:
+        enabled: true
+    - if-name: s-n1
+      network-type: point-to-point
+      metric: 1
+      ipv6:
+        enabled: true
+    - if-name: s-n2
+      network-type: point-to-point
+      metric: 1
+      ipv6:
+        enabled: true
+    - if-name: s-n3
+      network-type: point-to-point
+      metric: 1000
+      ipv6:
+        enabled: true
+  bgp:
+    global:
+      as: 65000
+      router-id: 10.0.0.1
+    timer:
+      adv-interval:
+        ibgp: 1
+        ebgp: 1
+    segment-routing:
+      srv6:
+        locator: LOC1
+        ipv6-unicast: {}
+    neighbor:
+    - remote-address: 2001:db8::8
+      remote-as: 65000
+      update-source: 2001:db8::1
+      enabled: true
+      afi-safi:
+      - name: ipv6
+        enabled: true
+        encapsulation-type: srv6
+    afi-safi:
+    - name: ipv6
+      redistribute:
+        connected: {}

--- a/bdd/tests/configs/isis_sr_switchover/s-usid.yaml
+++ b/bdd/tests/configs/isis_sr_switchover/s-usid.yaml
@@ -1,0 +1,75 @@
+interface:
+- if-name: lo
+  ipv6:
+    address: 2001:db8::1/128
+- if-name: s-n1
+  ipv6:
+    address: 2001:db8:0:1::1/64
+- if-name: s-n2
+  ipv6:
+    address: 2001:db8:0:2::1/64
+- if-name: s-n3
+  ipv6:
+    address: 2001:db8:0:3::1/64
+- if-name: s-e1
+  ipv6:
+    address: 2001:db8:100::1/64
+system:
+  hostname: s
+segment-routing:
+  locator:
+  - name: LOC1
+    prefix: fcbb:bbbb:1::/48
+    behavior: usid
+router:
+  isis:
+    net: 49.0000.0000.0000.0001.00
+    hostname: s
+    is-type: level-2-only
+    segment-routing:
+      srv6:
+        locator: LOC1
+    interface:
+    - if-name: lo
+      ipv6:
+        enabled: true
+    - if-name: s-n1
+      network-type: point-to-point
+      metric: 1
+      ipv6:
+        enabled: true
+    - if-name: s-n2
+      network-type: point-to-point
+      metric: 1
+      ipv6:
+        enabled: true
+    - if-name: s-n3
+      network-type: point-to-point
+      metric: 1000
+      ipv6:
+        enabled: true
+  bgp:
+    global:
+      as: 65000
+      router-id: 10.0.0.1
+    timer:
+      adv-interval:
+        ibgp: 1
+        ebgp: 1
+    segment-routing:
+      srv6:
+        locator: LOC1
+        ipv6-unicast: {}
+    neighbor:
+    - remote-address: 2001:db8::8
+      remote-as: 65000
+      update-source: 2001:db8::1
+      enabled: true
+      afi-safi:
+      - name: ipv6
+        enabled: true
+        encapsulation-type: srv6
+    afi-safi:
+    - name: ipv6
+      redistribute:
+        connected: {}

--- a/bdd/tests/features/isis_sr_switchover.feature
+++ b/bdd/tests/features/isis_sr_switchover.feature
@@ -1,0 +1,270 @@
+@isis_sr_switchover
+@isis
+Feature: Live switchover IS-IS SR-MPLS -> SRv6 (classic) -> SRv6 uSID -> SR-MPLS via vtyctl apply
+  As a network operator
+  I want to migrate a running IS-IS Segment Routing network between
+  dataplanes by applying each node's ENTIRE configuration with
+  `vtyctl apply -f` (the BDD `I apply config` step — a declarative
+  whole-config replace: everything the new file omits is deleted), so
+  an SR-MPLS domain can be moved to SRv6 classic SIDs, compressed to
+  NEXT-C-SID micro-SIDs, and rolled back to SR-MPLS, with each
+  transition tearing down the previous dataplane completely and
+  bringing up the next one end to end.
+
+  The per-node configurations are the playset trios (playset/
+  isis-srmpls, isis-srv6-classic, isis-srv6-usid) on the RFC 9855
+  topology: 8 core routers in IS-IS level-2-only. The three phases
+  observably differ on node s:
+  - SR-MPLS: v4 addressing; remote loopbacks carry Prefix-SID labels
+    (d = index 800 -> 16800 against SRGB base 16000); the edge subnet
+    rides a recursive static via d's loopback, inheriting the label
+    stack into the kernel (`encap mpls`); the ILM holds the SR
+    entries.
+  - SRv6 classic: v6 addressing; locators fcbb:bbbb:X::/48 are plain
+    routed prefixes; s owns a /128 End SID (seg6local) plus per-
+    adjacency End.X SIDs; the edge LANs become an iBGP (s<->d,
+    loopback-to-loopback) IPv6-unicast service with End.DT6 SIDs and
+    H.Encaps ingress routes (`via seg6`).
+  - SRv6 uSID: identical except `behavior: usid` on every locator —
+    the End SID becomes a locator-wide /48 uN with the NEXT-C-SID
+    flavor (`next-csid` in the kernel route) and the classic /128
+    disappears; the BGP service layer is untouched by the diff and
+    must survive the transition without a session flap.
+
+  e1 (behind s) and e2 (behind d) are plain dual-stack host
+  namespaces (no routing daemon) provisioned once with both edge
+  addressings and default routes; whichever edge family the routers
+  currently serve decides which of their pings forwards, so
+  edge-to-edge reachability doubles as the phase's end-to-end proof
+  and the retired family's ping must go dark.
+
+  Test Topology (playset/isis-srmpls; metric shown where != 1;
+  loopbacks 10.0.0.X / 2001:db8::X, Prefix-SID index X00, locators
+  fcbb:bbbb:X::/48):
+  ```
+   e1 --- s
+       1 / 1 \      \ 1000
+        n1    n2     n3
+    1 / |1 \1  \1     \1000
+ d ─┘ 1 |   \    \      \
+        |    \1000\      \
+        r2    r1───────── (r1-n3 1000)
+    1000 \   /1   \(r1-r2 1000)
+          \ /      \
+           r2 ──────┘
+             \1000
+              r3 (r3-d 1)   d --- e2
+  ```
+
+  Scenario: Build the topology, dual-stack edge hosts, and the SR-MPLS baseline
+    Given a clean test environment
+    When I create namespace "e1"
+    And I create namespace "e2"
+    And I create namespace "s"
+    And I create namespace "n1"
+    And I create namespace "n2"
+    And I create namespace "n3"
+    And I create namespace "r1"
+    And I create namespace "r2"
+    And I create namespace "r3"
+    And I create namespace "d"
+    And I connect namespace "e1" interface "e1-s" to namespace "s" interface "s-e1"
+    And I connect namespace "d" interface "d-e2" to namespace "e2" interface "e2-d"
+    And I connect namespace "s" interface "s-n1" to namespace "n1" interface "n1-s"
+    And I connect namespace "s" interface "s-n2" to namespace "n2" interface "n2-s"
+    And I connect namespace "s" interface "s-n3" to namespace "n3" interface "n3-s"
+    And I connect namespace "n1" interface "n1-r1" to namespace "r1" interface "r1-n1"
+    And I connect namespace "n2" interface "n2-r1" to namespace "r1" interface "r1-n2"
+    And I connect namespace "n3" interface "n3-r1" to namespace "r1" interface "r1-n3"
+    And I connect namespace "n1" interface "n1-r2" to namespace "r2" interface "r2-n1"
+    And I connect namespace "r1" interface "r1-r2" to namespace "r2" interface "r2-r1"
+    And I connect namespace "r2" interface "r2-r3" to namespace "r3" interface "r3-r2"
+    And I connect namespace "n1" interface "n1-d" to namespace "d" interface "d-n1"
+    And I connect namespace "r3" interface "r3-d" to namespace "d" interface "d-r3"
+    # The edge hosts carry BOTH edge addressings for the whole feature;
+    # the routers' current phase decides which family forwards.
+    And I add address "172.16.0.1/24" to interface "e1-s" in namespace "e1"
+    And I add address "2001:db8:100::100/64" to interface "e1-s" in namespace "e1"
+    And I add route "0.0.0.0/0" via "172.16.0.2" in namespace "e1"
+    And I add route "::/0" via "2001:db8:100::1" in namespace "e1"
+    And I add address "172.16.1.2/24" to interface "e2-d" in namespace "e2"
+    And I add address "2001:db8:200::100/64" to interface "e2-d" in namespace "e2"
+    And I add route "0.0.0.0/0" via "172.16.1.1" in namespace "e2"
+    And I add route "::/0" via "2001:db8:200::1" in namespace "e2"
+    And I start zebra-rs in namespace "s"
+    And I start zebra-rs in namespace "n1"
+    And I start zebra-rs in namespace "n2"
+    And I start zebra-rs in namespace "n3"
+    And I start zebra-rs in namespace "r1"
+    And I start zebra-rs in namespace "r2"
+    And I start zebra-rs in namespace "r3"
+    And I start zebra-rs in namespace "d"
+    And I apply config "s-srmpls.yaml" to namespace "s"
+    And I apply config "n1-srmpls.yaml" to namespace "n1"
+    And I apply config "n2-srmpls.yaml" to namespace "n2"
+    And I apply config "n3-srmpls.yaml" to namespace "n3"
+    And I apply config "r1-srmpls.yaml" to namespace "r1"
+    And I apply config "r2-srmpls.yaml" to namespace "r2"
+    And I apply config "r3-srmpls.yaml" to namespace "r3"
+    And I apply config "d-srmpls.yaml" to namespace "d"
+    And I wait 10 seconds
+    Then ping from "s" to "10.0.0.2" should eventually succeed
+    And ping from "e1" to "172.16.0.2" should eventually succeed
+    And ping from "e2" to "172.16.1.1" should eventually succeed
+
+  Scenario: SR-MPLS phase forwards labeled traffic end to end
+    Given the test topology exists
+    # d's loopback rides its Prefix-SID: index 800 against SRGB base
+    # 16000 = label 16800, single path out s-n1 at metric 12.
+    Then show command "show ip route 10.0.0.8/32" in namespace "s" should eventually contain "[115/12] via 192.168.0.2, s-n1, label 16800"
+    And show command "show mpls ilm" in namespace "s" should eventually contain "16800"
+    # The edge subnet's static nexthop 10.0.0.8 is not on-link: it
+    # resolves recursively through the IS-IS SR route and inherits the
+    # label stack all the way into the kernel FIB.
+    And show command "show ip route 172.16.1.0/24" in namespace "s" should eventually contain "via 10.0.0.8 (recursive)"
+    And show command "show ip route 172.16.1.0/24" in namespace "s" should contain "label 16800"
+    And kernel route "172.16.1.0/24" in namespace "s" should eventually contain "encap mpls"
+    And kernel route "172.16.1.0/24" in namespace "s" should eventually contain "16800"
+    # End to end: e1 -> s (push 16800) -> n1 (PHP) -> d -> e2, return
+    # over d's mirrored static (label 16100 toward s).
+    And ping from "s" to "10.0.0.8" should eventually succeed
+    And ping from "e1" to "172.16.1.2" should eventually succeed
+    And ping from "e2" to "172.16.0.1" should succeed
+
+  Scenario: Switch over to SRv6 classic — whole-config replace swaps the dataplane
+    Given the test topology exists
+    # One `vtyctl apply -f` per node: the SRv6 file omits every v4
+    # interface address, the SR-MPLS enable, and the statics, so the
+    # replace deletes them and configures locators/BGP in one commit.
+    When I apply config "s-srv6.yaml" to namespace "s"
+    And I apply config "n1-srv6.yaml" to namespace "n1"
+    And I apply config "n2-srv6.yaml" to namespace "n2"
+    And I apply config "n3-srv6.yaml" to namespace "n3"
+    And I apply config "r1-srv6.yaml" to namespace "r1"
+    And I apply config "r2-srv6.yaml" to namespace "r2"
+    And I apply config "r3-srv6.yaml" to namespace "r3"
+    And I apply config "d-srv6.yaml" to namespace "d"
+    And I wait 10 seconds
+    # The v6 IGP converges: d's loopback is a plain IPv6 route (no
+    # encapsulation — SRv6 encapsulates only where a SID says so), and
+    # d's locator is an ordinary routed /48.
+    Then show command "show ipv6 route 2001:db8::8/128" in namespace "s" should eventually contain "[115/12]"
+    And show command "show ipv6 route 2001:db8::8/128" in namespace "s" should contain "s-n1"
+    And show command "show ipv6 route fcbb:bbbb:8::/48" in namespace "s" should eventually contain "[115/2]"
+    # s instantiates classic full-length SIDs from its locator: the
+    # /128 End SID as a kernel seg6local route, End.X per adjacency —
+    # and never the micro-SID forms.
+    And show command "show segment-routing srv6 sid" in namespace "s" should eventually contain "End.X"
+    And show command "show segment-routing srv6 sid" in namespace "s" should not contain "uN"
+    And kernel route "fcbb:bbbb:1::" in namespace "s" should eventually contain "seg6local"
+    # The SR-MPLS dataplane is fully torn down by the replace: the
+    # labeled static and the v4 loopback route leave the kernel and
+    # the ILM empties.
+    And kernel route "172.16.1.0/24" in namespace "s" should eventually be gone
+    And kernel route "10.0.0.8" in namespace "s" should eventually be gone
+    And mpls ilm in namespace "s" should be empty
+    And ping from "s" to "2001:db8::8" should eventually succeed
+    # The retired v4 edge goes dark — s no longer serves 172.16.0.0/24.
+    And ping from "e1" to "172.16.1.2" should fail
+
+  Scenario: The BGP SRv6 service layer carries the edge LANs after the switchover
+    Given the test topology exists
+    # The s<->d iBGP session dials loopback-to-loopback. Each side's
+    # first connect raced its own IGP convergence and a failed dial
+    # parks the FSM in ConnectRetry — clear both now that the previous
+    # scenario proved the loopback routes, so the session re-dials
+    # immediately.
+    When I run "clear bgp ipv6 neighbor 2001:db8::8" in namespace "s"
+    And I run "clear bgp ipv6 neighbor 2001:db8::1" in namespace "d"
+    Then BGP session in "s" to "2001:db8::8" should eventually be "Established"
+    And BGP session in "d" to "2001:db8::1" should eventually be "Established"
+    # d redistributes its connected LAN with an End.DT6 SID carved
+    # from its locator; s installs the H.Encaps ingress route.
+    And show command "show bgp ipv6 2001:db8:200::/64" in namespace "s" should eventually contain "End.DT6"
+    And show command "show ipv6 route 2001:db8:200::/64" in namespace "s" should eventually contain "via seg6"
+    # Edge-to-edge over the SRv6 service: e1 -> s (H.Encaps toward d's
+    # End.DT6) -> locator routing -> d (decap) -> e2, and the reply
+    # mirrors it via s's End.DT6.
+    And ping from "e1" to "2001:db8:200::100" should eventually succeed
+    And ping from "e2" to "2001:db8:100::100" should succeed
+
+  Scenario: Switch over to SRv6 uSID — locators recompress, the service layer never flaps
+    Given the test topology exists
+    # The uSID files differ from classic by exactly one line per node:
+    # `behavior: usid` on the locator. The replace diff touches only
+    # the locator — BGP is identical, so the session must survive.
+    When I apply config "s-usid.yaml" to namespace "s"
+    And I apply config "n1-usid.yaml" to namespace "n1"
+    And I apply config "n2-usid.yaml" to namespace "n2"
+    And I apply config "n3-usid.yaml" to namespace "n3"
+    And I apply config "r1-usid.yaml" to namespace "r1"
+    And I apply config "r2-usid.yaml" to namespace "r2"
+    And I apply config "r3-usid.yaml" to namespace "r3"
+    And I apply config "d-usid.yaml" to namespace "d"
+    And I wait 10 seconds
+    # Micro-SID forms replace the classic ones: the End SID becomes a
+    # locator-wide /48 uN with the NEXT-C-SID flavor and the classic
+    # /128 End route disappears from the kernel.
+    Then show command "show segment-routing srv6 sid" in namespace "s" should eventually contain "uN"
+    And show command "show segment-routing srv6 sid" in namespace "s" should contain "uA"
+    And kernel route "fcbb:bbbb:1::/48" in namespace "s" should eventually contain "next-csid"
+    And kernel route "fcbb:bbbb:1::" in namespace "s" should eventually be gone
+    And show command "show ipv6 route fcbb:bbbb:8::/48" in namespace "s" should eventually contain "[115/2]"
+    # Service continuity: the iBGP session is still up (not re-
+    # established) and the End.DT6 ingress route still forwards.
+    And BGP session in "s" to "2001:db8::8" should be "Established"
+    And show command "show ipv6 route 2001:db8:200::/64" in namespace "s" should eventually contain "via seg6"
+    And ping from "s" to "2001:db8::8" should eventually succeed
+    And ping from "e1" to "2001:db8:200::100" should eventually succeed
+
+  Scenario: Roll back to SR-MPLS — labels return, SRv6 and BGP are torn down
+    Given the test topology exists
+    When I apply config "s-srmpls.yaml" to namespace "s"
+    And I apply config "n1-srmpls.yaml" to namespace "n1"
+    And I apply config "n2-srmpls.yaml" to namespace "n2"
+    And I apply config "n3-srmpls.yaml" to namespace "n3"
+    And I apply config "r1-srmpls.yaml" to namespace "r1"
+    And I apply config "r2-srmpls.yaml" to namespace "r2"
+    And I apply config "r3-srmpls.yaml" to namespace "r3"
+    And I apply config "d-srmpls.yaml" to namespace "d"
+    And I wait 10 seconds
+    # The original SR-MPLS state is fully restored: labeled loopback
+    # route, ILM entries, and the recursive static's inherited label
+    # stack back in the kernel.
+    Then show command "show ip route 10.0.0.8/32" in namespace "s" should eventually contain "[115/12] via 192.168.0.2, s-n1, label 16800"
+    And show command "show mpls ilm" in namespace "s" should eventually contain "16800"
+    And show command "show ip route 172.16.1.0/24" in namespace "s" should eventually contain "via 10.0.0.8 (recursive)"
+    And kernel route "172.16.1.0/24" in namespace "s" should eventually contain "encap mpls"
+    # The SRv6 dataplane and the BGP service layer are gone: the uN
+    # /48 leaves the kernel, no SIDs remain, and the BGP instance
+    # itself is deconfigured by the replace.
+    And kernel route "fcbb:bbbb:1::/48" in namespace "s" should eventually be gone
+    And show command "show segment-routing srv6 sid" in namespace "s" should not contain "fcbb"
+    And show command "show bgp ipv6 summary" in namespace "s" should eventually contain "BGP is not configured or running"
+    And ping from "s" to "10.0.0.8" should eventually succeed
+    And ping from "e1" to "172.16.1.2" should eventually succeed
+    And ping from "e2" to "172.16.0.1" should succeed
+    # The v6 edge service went dark with the rollback.
+    And ping from "e1" to "2001:db8:200::100" should fail
+
+  Scenario: Teardown topology
+    Given the test topology exists
+    When I stop zebra-rs in namespace "s"
+    And I stop zebra-rs in namespace "n1"
+    And I stop zebra-rs in namespace "n2"
+    And I stop zebra-rs in namespace "n3"
+    And I stop zebra-rs in namespace "r1"
+    And I stop zebra-rs in namespace "r2"
+    And I stop zebra-rs in namespace "r3"
+    And I stop zebra-rs in namespace "d"
+    And I delete namespace "e1"
+    And I delete namespace "e2"
+    And I delete namespace "s"
+    And I delete namespace "n1"
+    And I delete namespace "n2"
+    And I delete namespace "n3"
+    And I delete namespace "r1"
+    And I delete namespace "r2"
+    And I delete namespace "r3"
+    And I delete namespace "d"
+    Then the test environment should be clean


### PR DESCRIPTION
## Summary

New `isis_sr_switchover` BDD feature: migrates a running 8-router IS-IS SR network (the RFC 9855 playset topology) between dataplanes by applying each node's **entire configuration** with `vtyctl apply -f` — a declarative whole-config replace, so every transition's deletes come purely from what the next file omits. The per-node configs are the playset trios (`playset/isis-srmpls`, `isis-srv6-classic`, `isis-srv6-usid`); the edge hosts e1/e2 are plain dual-stack namespaces provisioned once with both edge addressings, so whichever family the routers currently serve decides which edge-to-edge ping forwards.

Phases, each pinned at the route/kernel/end-to-end layers on node `s`:

1. **SR-MPLS baseline** — d's loopback carries Prefix-SID label 16800; the edge subnet's recursive static inherits the label stack into the kernel (`encap mpls`); e1↔e2 forwards over v4.
2. **→ SRv6 classic** — plain-IPv6 IGP routes and routed locator /48s; the /128 End SID installs as a kernel `seg6local` route with End.X per adjacency (never uN/uA); the MPLS ILM empties and the v4 routes leave the kernel; the retired v4 edge goes dark.
3. **BGP SRv6 service layer** — s↔d iBGP (loopback-to-loopback) carries the edge LANs as an End.DT6 IPv6-unicast service; H.Encaps ingress route (`via seg6`); e1↔e2 forwards over the service.
4. **→ SRv6 uSID** — one `behavior: usid` line per node: the locator-wide /48 uN with the NEXT-C-SID kernel flavor (`next-csid`) replaces the classic /128 End route, uN/uA appear in the SID table, and the **BGP session survives without a flap** (the replace diff touches only the locator).
5. **→ back to SR-MPLS** — labels, ILM and the recursive static return; the uN /48, all SIDs, and the whole BGP instance are torn down by the replace; the v6 edge service goes dark while v4 edge-to-edge resumes.

## Testing

- Run locally against this branch's binary: **7 scenarios, 152/152 steps green** (`make -C bdd isis_sr_switchover`, needs root).
- `cargo test -p bdd --lib` (tag-prefix guard) clean; `cargo fmt` clean.

Related: #1901 makes `router isis segment-routing {mpls|srv6}` a YANG choice so the *incremental* (`set`-based) migration is also a single command; this feature exercises the declarative whole-replace path and does not depend on it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)