### PR TITLE
config: make ospfv3 segment-routing mpls/srv6 a YANG choice

### DIFF
--- a/zebra-rs/src/config/manager.rs
+++ b/zebra-rs/src/config/manager.rs
@@ -2171,6 +2171,83 @@ mod yang_load_tests {
         );
     }
 
+    /// `router ospfv3 segment-routing {mpls|srv6}` is the same YANG
+    /// `choice` as the IS-IS one (RFC 8666 SR-MPLS vs RFC 9513 SRv6 —
+    /// one instance advertises one dataplane). Checks both switch
+    /// directions, and that the purge is scoped to the choice's own
+    /// parent: OSPFv2's `segment-routing mpls` (same node names, no
+    /// choice — OSPFv2 has no SRv6 sibling) must survive an OSPFv3 case
+    /// switch untouched.
+    #[test]
+    fn ospfv3_sr_dataplane_choice_is_exclusive() {
+        use crate::config::ExecCode;
+        use crate::config::configs::set;
+        use crate::config::parse::{State, parse};
+        use crate::config::{Config, paths::path_try_trim};
+        use libyang::to_entry;
+        use std::rc::Rc;
+
+        let mut yang = YangStore::new();
+        yang.add_path(concat!(env!("CARGO_MANIFEST_DIR"), "/yang"));
+        yang.read_with_resolve("configure")
+            .unwrap_or_else(|e| panic!("configure failed to load: {e:#}"));
+        yang.identity_resolve();
+        let module = yang.find_module("configure").unwrap();
+        let entry = to_entry(&yang, module);
+        let set_entry = entry
+            .dir
+            .borrow()
+            .iter()
+            .find(|e| e.name == "set")
+            .cloned()
+            .expect("configure mode has a `set` entry");
+
+        let root = Rc::new(Config::new("".to_string(), None));
+        let run = |cmd: &str| {
+            let (code, _comps, state) = parse(cmd, set_entry.clone(), None, State::new());
+            assert_eq!(code, ExecCode::Success, "should parse: {cmd}");
+            set(path_try_trim("set", state.paths), root.clone());
+        };
+        let listing = || {
+            let mut out = String::new();
+            root.list(&mut out);
+            out
+        };
+
+        // The OSPFv2 sibling shares the container/case node names but
+        // lives under a different parent — the v3 case switches below
+        // must never reach it.
+        run("router ospf segment-routing mpls");
+        run("router ospfv3 segment-routing mpls");
+        assert!(listing().contains("router ospfv3 segment-routing mpls"));
+
+        // mpls -> srv6: the v3 mpls case is purged; v2 is untouched.
+        run("router ospfv3 segment-routing srv6 locator LOC1");
+        let out = listing();
+        assert!(
+            out.contains("router ospfv3 segment-routing srv6 locator LOC1"),
+            "{out}"
+        );
+        assert!(
+            !out.contains("router ospfv3 segment-routing mpls"),
+            "v3 mpls case must be auto-cleared by setting srv6, got:\n{out}"
+        );
+        assert!(
+            out.contains("router ospf segment-routing mpls"),
+            "OSPFv2's segment-routing mpls must survive the v3 case switch, got:\n{out}"
+        );
+
+        // srv6 -> mpls: the whole srv6 subtree (locator child included)
+        // must go.
+        run("router ospfv3 segment-routing mpls");
+        let out = listing();
+        assert!(out.contains("router ospfv3 segment-routing mpls"), "{out}");
+        assert!(
+            !out.contains("srv6"),
+            "v3 srv6 case (and its locator child) must be auto-cleared by setting mpls, got:\n{out}"
+        );
+    }
+
     /// `router static ipv4 route <prefix>` carries no forwarding info on its
     /// own, so the route list is tagged `ext:non-empty "nexthop"`: a bare
     /// entry is rejected at commit, and deleting its last child prunes it.

--- a/zebra-rs/yang/config.yang
+++ b/zebra-rs/yang/config.yang
@@ -2172,24 +2172,34 @@ module config {
           ext:help "Segment Routing (SR-MPLS / SRv6) configuration";
           // Mirrors `router isis / segment-routing` (config.yang L516).
           // OSPFv3 carries SR over both dataplanes: MPLS (RFC 8666 via
-          // E-LSAs) and SRv6 (RFC 9513). The `mpls` and `srv6` sibling
-          // containers match the IS-IS shape so operators see a uniform
-          // CLI surface across protocols.
-          container mpls {
-            ext:help "Segment Routing over MPLS dataplane";
-            presence "Enable Segment Routing over MPLS dataplane";
-          }
-          container srv6 {
-            ext:help "Segment Routing over IPv6 dataplane (SRv6)";
-            presence "Enable Segment Routing over IPv6 dataplane";
-            leaf locator {
-              ext:help "Global SRv6 locator name for this instance";
-              // Name of a locator defined under the global
-              // /segment-routing/locator list. Held as a string (not a
-              // leafref) so an OSPFv3 config can be staged before the
-              // global locator is committed — matches the IS-IS
-              // staging convention (config.yang L524).
-              type string;
+          // E-LSAs) and SRv6 (RFC 9513). As with IS-IS, the two are
+          // mutually exclusive — one instance advertises either SR-MPLS
+          // SIDs or an SRv6 locator, never both — so they form a
+          // `choice`: committing `srv6` implicitly deletes a configured
+          // `mpls` (and vice versa) per RFC 7950 §7.9.3, and the commit
+          // diff tears the old dataplane down exactly as an explicit
+          // delete would.
+          choice dataplane {
+            case mpls {
+              container mpls {
+                ext:help "Segment Routing over MPLS dataplane";
+                presence "Enable Segment Routing over MPLS dataplane";
+              }
+            }
+            case srv6 {
+              container srv6 {
+                ext:help "Segment Routing over IPv6 dataplane (SRv6)";
+                presence "Enable Segment Routing over IPv6 dataplane";
+                leaf locator {
+                  ext:help "Global SRv6 locator name for this instance";
+                  // Name of a locator defined under the global
+                  // /segment-routing/locator list. Held as a string (not a
+                  // leafref) so an OSPFv3 config can be staged before the
+                  // global locator is committed — matches the IS-IS
+                  // staging convention (config.yang L524).
+                  type string;
+                }
+              }
             }
           }
         }


### PR DESCRIPTION
## Summary

Extends the choice exclusivity introduced for IS-IS in #1901 to OSPFv3: `router ospfv3 segment-routing {mpls|srv6}` becomes `choice dataplane`, so committing one dataplane implicitly deletes the other (RFC 7950 §7.9.3) — one instance advertises either RFC 8666 SR-MPLS SIDs or an RFC 9513 SRv6 locator, never both.

- **Schema + tests only.** The enforcement is the generic `CommandPath.choice_exclude` purge already on main. Daemon handlers need no changes: the SR-MPLS mode enum (`ospf.segment_routing`) and the SRv6 locator name (`ospf.srv6_locator_name`) are independent fields, so the `delete(old) + set(new)` commit sequence is order-independent.
- **OSPFv2 untouched** — its `segment-routing` block carries only `mpls` (OSPFv2 is IPv4-only on the wire; there is no OSPFv2 SRv6), so there is no sibling case to exclude.
- CLI surface and existing configs unchanged (cases flatten; no config or feature sets both on ospfv3 — checked BDD configs, playsets, and runtime `apply command` steps).

## Testing

- New unit test `ospfv3_sr_dataplane_choice_is_exclusive`: both switch directions through the real schema, plus a scoping check — OSPFv2's `segment-routing mpls` (same node names, different parent, no choice) must survive an OSPFv3 case switch untouched.
- `cargo test --workspace --exclude bdd`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo fmt` — all clean.
- End-to-end (config → commit diff → daemon teardown/bring-up) behavior of the shared mechanism is covered by the `isis_sr_dataplane_choice` BDD feature from #1901.

🤖 Generated with [Claude Code](https://claude.com/claude-code)