### PR TITLE
fib: stamp SID owner protocol on uninstall; ospfv3 SR dataplane choice BDD

### DIFF
--- a/bdd/Makefile
+++ b/bdd/Makefile
@@ -209,6 +209,10 @@ isis_sr_dataplane_choice:
 	mkdir -p allure-results
 	cargo test --test cucumber -- --concurrency=1 --tags "@isis_sr_dataplane_choice"
 
+ospfv3_sr_dataplane_choice:
+	mkdir -p allure-results
+	cargo test --test cucumber -- --concurrency=1 --tags "@ospfv3_sr_dataplane_choice"
+
 system_hostname:
 	mkdir -p allure-results
 	cargo test --test cucumber -- --concurrency=1 --tags "@system_hostname"
@@ -456,4 +460,4 @@ docs/%.md: tests/features/%.feature docs/feature2md.sh FORCE
 
 FORCE:
 
-.PHONY: ecmp_bfd_evict ospfv2_bfd_frr ospfv3_bfd_frr tilfa_bfd all run ibgp ebgp rr rib_static_ipv6 static_srv6_nht bgp_srv6_nht isis_ipv6 isis_srv6_base isis_fragmentation_ipv6 isis_fragmentation_ipv4 isis_l1p2p isis_tilfa isis_srmpls isis_sr_switchover isis_sr_dataplane_choice system_hostname isis_l1l2 isis_redist isis_hello_auth_keychain isis_passive isis_afi_enable isis_endx_ipv6 isis_bfd_ipv6_p2p isis_bfd_ipv6_p2p_echo isis_bfd_ipv6_lan isis_bfd_ipv6_lan_echo isis_bfd_ipv4_p2p isis_bfd_ipv4_p2p_echo isis_bfd_ipv4_lan isis_bfd_ipv4_lan_echo ospf_clear_neighbor ospfv2_nssa_base ospfv2_stub_base ospfv2_tilfa ospfv3_nssa ospfv3_tilfa stamp_te_metric stamp_v6_te_metric bgp_peer_down_cleanup bgp_ipv6_over_v4_session bgp_evpn_capability bgp_vrf_evpn_type5 bgp_evpn_outpolicy_undef bgp_route_map_match bgp_policy_dynamic_update bgp_table_map bgp_v6_table_map bgp_community bgp_neighbor_group bgp_unnumbered_neighbor nd_show cradle_spawn bgp_interas_option_c bgp_interas_option_a bgp_interas_option_b bgp_interas_option_ab bgp_port bgp_ip_transparent bgp_local_as bgp_unknown_attr_transitive bgp_fast_external_failover generate open docs FORCE
+.PHONY: ecmp_bfd_evict ospfv2_bfd_frr ospfv3_bfd_frr tilfa_bfd all run ibgp ebgp rr rib_static_ipv6 static_srv6_nht bgp_srv6_nht isis_ipv6 isis_srv6_base isis_fragmentation_ipv6 isis_fragmentation_ipv4 isis_l1p2p isis_tilfa isis_srmpls isis_sr_switchover isis_sr_dataplane_choice ospfv3_sr_dataplane_choice system_hostname isis_l1l2 isis_redist isis_hello_auth_keychain isis_passive isis_afi_enable isis_endx_ipv6 isis_bfd_ipv6_p2p isis_bfd_ipv6_p2p_echo isis_bfd_ipv6_lan isis_bfd_ipv6_lan_echo isis_bfd_ipv4_p2p isis_bfd_ipv4_p2p_echo isis_bfd_ipv4_lan isis_bfd_ipv4_lan_echo ospf_clear_neighbor ospfv2_nssa_base ospfv2_stub_base ospfv2_tilfa ospfv3_nssa ospfv3_tilfa stamp_te_metric stamp_v6_te_metric bgp_peer_down_cleanup bgp_ipv6_over_v4_session bgp_evpn_capability bgp_vrf_evpn_type5 bgp_evpn_outpolicy_undef bgp_route_map_match bgp_policy_dynamic_update bgp_table_map bgp_v6_table_map bgp_community bgp_neighbor_group bgp_unnumbered_neighbor nd_show cradle_spawn bgp_interas_option_c bgp_interas_option_a bgp_interas_option_b bgp_interas_option_ab bgp_port bgp_ip_transparent bgp_local_as bgp_unknown_attr_transitive bgp_fast_external_failover generate open docs FORCE

--- a/bdd/tests/configs/ospfv3_sr_dataplane_choice/z1.yaml
+++ b/bdd/tests/configs/ospfv3_sr_dataplane_choice/z1.yaml
@@ -1,0 +1,35 @@
+# z1 — the node whose OSPFv3 SR dataplane is flipped at runtime.
+# OSPFv3 area 0 with SR-MPLS enabled (loopback Prefix-SID index 100 ->
+# label 16100, RFC 8666). The SRv6 locator LOC1 is pre-provisioned in
+# the global segment-routing block but NOT bound to OSPFv3: the
+# feature binds it with a single `set router ospfv3 segment-routing
+# srv6 locator LOC1`, which must implicitly delete `segment-routing
+# mpls` (YANG choice, RFC 7950 §7.9.3).
+interface:
+- if-name: lo
+  ipv6:
+    address: 2001:db8::1/128
+- if-name: z1-z2
+  ipv6:
+    address: 2001:db8:12::1/64
+system:
+  hostname: z1
+segment-routing:
+  locator:
+  - name: LOC1
+    prefix: fcbb:bbbb:1::/48
+router:
+  ospfv3:
+    router-id: 10.0.0.1
+    segment-routing:
+      mpls: {}
+    area:
+    - area-id: 0.0.0.0
+      interface:
+      - if-name: lo
+        enabled: true
+        prefix-sid:
+          index: 100
+      - if-name: z1-z2
+        enabled: true
+        network-type: point-to-point

--- a/bdd/tests/configs/ospfv3_sr_dataplane_choice/z2.yaml
+++ b/bdd/tests/configs/ospfv3_sr_dataplane_choice/z2.yaml
@@ -1,0 +1,29 @@
+# z2 — the control node: stays on SR-MPLS (Prefix-SID index 200 ->
+# label 16200) for the whole feature while z1's dataplane is flipped.
+# Its view of z1's advertisements (label 16100 leaving/re-entering the
+# ILM, the SRv6 Locator LSA appearing/disappearing from the database)
+# pins the LSA-level effect of the switch.
+interface:
+- if-name: lo
+  ipv6:
+    address: 2001:db8::2/128
+- if-name: z2-z1
+  ipv6:
+    address: 2001:db8:12::2/64
+system:
+  hostname: z2
+router:
+  ospfv3:
+    router-id: 10.0.0.2
+    segment-routing:
+      mpls: {}
+    area:
+    - area-id: 0.0.0.0
+      interface:
+      - if-name: lo
+        enabled: true
+        prefix-sid:
+          index: 200
+      - if-name: z2-z1
+        enabled: true
+        network-type: point-to-point

--- a/bdd/tests/features/ospfv3_sr_dataplane_choice.feature
+++ b/bdd/tests/features/ospfv3_sr_dataplane_choice.feature
@@ -1,0 +1,119 @@
+@ospfv3_sr_dataplane_choice
+@ospf
+Feature: OSPFv3 segment-routing mpls/srv6 are mutually exclusive (YANG choice)
+  As a network operator
+  I want `router ospfv3 segment-routing mpls` and `router ospfv3
+  segment-routing srv6` to be a YANG choice, so committing one
+  dataplane implicitly deletes the other (RFC 7950 §7.9.3) — a single
+  `set router ospfv3 segment-routing srv6 locator LOC1` migrates a
+  running RFC 8666 SR-MPLS node to RFC 9513 SRv6 without a separate
+  `delete`, and the implicit delete tears the old dataplane's
+  forwarding state down exactly as an explicit one would.
+
+  This is the OSPFv3 sibling of @isis_sr_dataplane_choice — the choice
+  enforcement is the same generic candidate-store purge, but the
+  daemon-side effects it must drive are OSPFv3's own: the Prefix-SID
+  sub-TLVs leave the E-LSAs and the ILM empties, while the SRv6
+  Locator LSA is originated and the locator's End SID installs as a
+  kernel seg6local route.
+
+  z1 and z2 run OSPFv3 area 0 over one point-to-point link, both
+  starting on SR-MPLS (Prefix-SID indexes 100/200 -> labels
+  16100/16200 against the default SRGB base 16000). z1 additionally
+  pre-provisions the global SRv6 locator LOC1 (fcbb:bbbb:1::/48,
+  classic full-length SIDs) without binding it to OSPFv3. The feature
+  flips z1's dataplane to SRv6 and back with one `set` each way and
+  checks three layers every time:
+  - config: `show running-config formal` holds exactly one dataplane
+    case (and the unrelated global `segment-routing locator` block
+    survives the sibling purge);
+  - local forwarding: the MPLS ILM empties and the locator's End SID
+    appears as a kernel seg6local route (then the reverse);
+  - the peer: z2 stays on SR-MPLS throughout; label 16100 leaves and
+    re-enters its ILM, and the SRv6 Locator LSA appears in and is
+    flushed from its database as z1 switches over and back.
+
+  Test Topology:
+  ```
+   z1 ──────────────── z2
+   2001:db8:12::1/64   2001:db8:12::2/64
+   lo 2001:db8::1, SID 100, LOC1 fcbb:bbbb:1::/48 (unbound)
+   lo 2001:db8::2, SID 200 (SR-MPLS for the whole feature)
+  ```
+
+  Scenario: Build the OSPFv3 SR-MPLS topology
+    Given a clean test environment
+    When I create namespace "z1"
+    And I create namespace "z2"
+    And I connect namespace "z1" interface "z1-z2" to namespace "z2" interface "z2-z1"
+    And I start zebra-rs in namespace "z1"
+    And I start zebra-rs in namespace "z2"
+    And I apply config "z1.yaml" to namespace "z1"
+    And I apply config "z2.yaml" to namespace "z2"
+    And I wait 10 seconds
+    Then ping from "z1" to "2001:db8::2" should eventually succeed
+    # Both nodes advertise a Prefix-SID: z1's ILM holds its own label
+    # (16100, local pop) and z2's (16200, pop — adjacent PHP).
+    And show command "show mpls ilm" in namespace "z1" should eventually contain "16100"
+    And show command "show mpls ilm" in namespace "z1" should eventually contain "16200"
+    And show command "show running-config formal" in namespace "z1" should contain "router ospfv3 segment-routing mpls"
+    # The pre-provisioned locator is present but unbound — no SRv6
+    # SIDs exist and no Locator LSA is originated yet.
+    And show command "show running-config formal" in namespace "z1" should contain "segment-routing locator LOC1 prefix fcbb:bbbb:1::/48"
+    And show command "show segment-routing srv6 sid" in namespace "z1" should not contain "fcbb"
+    And show command "show ospfv3 database" in namespace "z2" should not contain "SRv6-Locator-LSA"
+
+  Scenario: Setting srv6 implicitly deletes mpls and swaps the dataplane
+    Given the test topology exists
+    # No `delete router ospfv3 segment-routing mpls` anywhere — the
+    # choice makes the set below carry the delete implicitly.
+    When I apply command "set router ospfv3 segment-routing srv6 locator LOC1" in namespace "z1"
+    # Config level: exactly one case remains, and the purge removed
+    # only the sibling case — the global segment-routing block (same
+    # node name, different parent) is untouched.
+    Then show command "show running-config formal" in namespace "z1" should contain "router ospfv3 segment-routing srv6 locator LOC1"
+    And show command "show running-config formal" in namespace "z1" should not contain "segment-routing mpls"
+    And show command "show running-config formal" in namespace "z1" should contain "segment-routing locator LOC1 prefix fcbb:bbbb:1::/48"
+    # Dataplane level: the locator's End SID installs as a seg6local
+    # kernel route (classic full-length SID -> /128 at the locator
+    # base), and the SR-MPLS ILM is torn down by the implicit delete.
+    And show command "show segment-routing srv6 sid" in namespace "z1" should eventually contain "End"
+    And show command "show segment-routing srv6 sid" in namespace "z1" should contain "ospfv3"
+    And kernel route "fcbb:bbbb:1::" in namespace "z1" should eventually contain "seg6local"
+    And show command "show mpls ilm" in namespace "z1" should eventually not contain "16200"
+    And mpls ilm in namespace "z1" should be empty
+    # LSA level: z1 originates the SRv6 Locator LSA and stops
+    # advertising a Prefix-SID, so its label leaves the SR-MPLS peer's
+    # ILM; the adjacency itself is unaffected and plain v6 forwarding
+    # continues.
+    And show command "show ospfv3 database" in namespace "z2" should eventually contain "SRv6-Locator-LSA"
+    And show command "show mpls ilm" in namespace "z2" should eventually not contain "16100"
+    And ping from "z1" to "2001:db8::2" should eventually succeed
+
+  Scenario: Setting mpls implicitly deletes srv6 and restores the labels
+    Given the test topology exists
+    When I apply command "set router ospfv3 segment-routing mpls" in namespace "z1"
+    # Config level: the srv6 case (locator binding included) is gone;
+    # the global locator definition survives again.
+    Then show command "show running-config formal" in namespace "z1" should contain "router ospfv3 segment-routing mpls"
+    And show command "show running-config formal" in namespace "z1" should not contain "srv6"
+    And show command "show running-config formal" in namespace "z1" should contain "segment-routing locator LOC1 prefix fcbb:bbbb:1::/48"
+    # Dataplane level: labels come back, the End SID route goes.
+    And show command "show mpls ilm" in namespace "z1" should eventually contain "16100"
+    And show command "show mpls ilm" in namespace "z1" should eventually contain "16200"
+    And kernel route "fcbb:bbbb:1::" in namespace "z1" should eventually be gone
+    And show command "show segment-routing srv6 sid" in namespace "z1" should not contain "fcbb"
+    # LSA level: z1 advertises its Prefix-SID again and flushes the
+    # SRv6 Locator LSA; the peer's ILM relearns label 16100 and its
+    # database drops the locator.
+    And show command "show mpls ilm" in namespace "z2" should eventually contain "16100"
+    And show command "show ospfv3 database" in namespace "z2" should eventually not contain "SRv6-Locator-LSA"
+    And ping from "z1" to "2001:db8::2" should eventually succeed
+
+  Scenario: Teardown topology
+    Given the test topology exists
+    When I stop zebra-rs in namespace "z1"
+    And I stop zebra-rs in namespace "z2"
+    And I delete namespace "z1"
+    And I delete namespace "z2"
+    Then the test environment should be clean

--- a/zebra-rs/src/fib/netlink/handle.rs
+++ b/zebra-rs/src/fib/netlink/handle.rs
@@ -239,6 +239,20 @@ fn set_route_table(msg: &mut RouteMessage, table_id: u32) {
     }
 }
 
+/// The `rtm_protocol` a SID host route carries — the SID's owning
+/// protocol. Shared by install and uninstall: the kernel matches
+/// RTM_DELROUTE on the protocol when it is set, so a delete built with
+/// a different protocol than the install returns ESRCH and the
+/// seg6local route leaks in the FIB (an OSPFv3 SID uninstall did
+/// exactly that while this was hard-coded to Isis on the delete side).
+fn sid_route_protocol(sid: &crate::rib::Sid) -> RouteProtocol {
+    match sid.owner.rib_type() {
+        crate::rib::RibType::Ospf => RouteProtocol::Ospf,
+        crate::rib::RibType::Bgp => RouteProtocol::Bgp,
+        _ => RouteProtocol::Isis,
+    }
+}
+
 fn sid_route_target(
     behavior: crate::rib::SidBehavior,
     addr: std::net::Ipv6Addr,
@@ -2037,11 +2051,7 @@ impl FibHandle {
         msg.header.destination_prefix_length = prefix_len;
         // Stamp the SID's owning protocol (an OSPFv3 SID used to land
         // as `proto isis` in the kernel regardless of owner).
-        msg.header.protocol = match sid.owner.rib_type() {
-            crate::rib::RibType::Ospf => RouteProtocol::Ospf,
-            crate::rib::RibType::Bgp => RouteProtocol::Bgp,
-            _ => RouteProtocol::Isis,
-        };
+        msg.header.protocol = sid_route_protocol(sid);
         msg.header.scope = RouteScope::Universe;
         msg.header.kind = kind;
 
@@ -2212,7 +2222,10 @@ impl FibHandle {
         }
         msg.header.table = table;
         msg.header.destination_prefix_length = prefix_len;
-        msg.header.protocol = RouteProtocol::Isis;
+        // Same owner-protocol stamp as the install: the kernel matches
+        // RTM_DELROUTE on rtm_protocol, so a hard-coded Isis here left
+        // OSPFv3/BGP-owned seg6local routes behind (ESRCH on delete).
+        msg.header.protocol = sid_route_protocol(sid);
         msg.header.scope = RouteScope::Universe;
         msg.header.kind = kind;
 


### PR DESCRIPTION
## Summary

Two things, found together:

**Bug fix — SID uninstall protocol mismatch (regression from fd954bec).** `route_sid_install` stamps the SID's owning protocol on the seg6local kernel route (`proto ospf`/`bgp`/`isis`), but `route_sid_uninstall` kept the hard-coded `RouteProtocol::Isis`. The kernel matches `RTM_DELROUTE` on `rtm_protocol`, so every OSPFv3- or BGP-owned SID uninstall since fd954bec returned ESRCH and **leaked the seg6local route in the FIB** — a locator unbind cleared the SID registry (`show segment-routing srv6 sid` empty) while the End/End.X routes kept forwarding. The daemon log shows it plainly:

```
DelRoute SID uninstall error: addr=fcbb:bbbb:1:: behavior=End err=No such process (os error 3)
```

Fixed by extracting the owner-protocol match into `sid_route_protocol()`, shared by install and uninstall so the two sides can't drift again. The existing `ospfv3_srv6` feature's "Removing the locator flushes the LSA and withdraws the SID" scenario was silently broken by this — it passes again.

**New BDD feature — `ospfv3_sr_dataplane_choice`.** The OSPFv3 sibling of `isis_sr_dataplane_choice` (#1901), exercising the #1903 YANG choice live: flip a running node's dataplane `mpls` ↔ `srv6` with one `set` each way, asserting
- running-config exclusivity (exactly one case; the same-named global `segment-routing locator` block survives the purge),
- the ILM emptying and refilling, the End SID seg6local kernel route appearing and — the regression above — actually leaving,
- peer-visible effects on an SR-MPLS-only neighbor: label 16100 leaving/re-entering its ILM, and the SRv6 Locator LSA appearing in and being flushed from its database.

## Testing

- `ospfv3_sr_dataplane_choice`: 47/47 steps green locally (fails 42/43 without the fib fix — the leaked route is the one failing step).
- `ospfv3_srv6`: 65/65 green (was broken by the leak).
- `isis_sr_dataplane_choice`: 45/45 green (shared uninstall path, isis owner unchanged).
- `cargo test --workspace --exclude bdd`, `cargo test -p bdd --lib` (tag guard), `cargo clippy --workspace --all-targets -- -D warnings`, `cargo fmt` — all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)