### PR TITLE
isis: interoperate with Cisco IOS legacy 1-octet P2P three-way TLV

### DIFF
--- a/crates/isis-packet/src/disp.rs
+++ b/crates/isis-packet/src/disp.rs
@@ -468,7 +468,7 @@ impl Display for IsisTlvP2p3Way {
             f,
             "  Three-Way Handshake : State:{}, Local circuit ID:{}, Neighbor System ID:{}",
             self.state,
-            self.circuit_id,
+            self.circuit_id.map(|id| id.to_string()).unwrap_or_default(),
             if let Some(neighbor_id) = &self.neighbor_id {
                 neighbor_id.to_string()
             } else {

--- a/crates/isis-packet/src/parser.rs
+++ b/crates/isis-packet/src/parser.rs
@@ -1154,10 +1154,13 @@ impl From<IsisTlvIpv6GlobalIfAddr> for IsisTlv {
     }
 }
 
+// RFC 5303 §3.2: only the Adjacency Three-Way State octet is mandatory;
+// every following field is "if known". Classic Cisco IOS sends the legacy
+// 1-octet form (state only), so each field below the state is optional.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct IsisTlvP2p3Way {
     pub state: u8,
-    pub circuit_id: u32,
+    pub circuit_id: Option<u32>,
     pub neighbor_id: Option<IsisSysId>,
     pub neighbor_circuit_id: Option<u32>,
 }
@@ -1165,7 +1168,12 @@ pub struct IsisTlvP2p3Way {
 impl ParseBe<IsisTlvP2p3Way> for IsisTlvP2p3Way {
     fn parse_be(input: &[u8]) -> IResult<&[u8], Self> {
         let (input, state) = be_u8(input)?;
-        let (input, circuit_id) = be_u32(input)?;
+        let (input, circuit_id) = if input.len() >= 4 {
+            let (input, circuit_id) = be_u32(input)?;
+            (input, Some(circuit_id))
+        } else {
+            (input, None)
+        };
         let (input, neighbor_id) = if input.len() >= 6 {
             let (input, neighbor_id) = IsisSysId::parse_be(input)?;
             (input, Some(neighbor_id))
@@ -1194,7 +1202,10 @@ impl TlvEmitter for IsisTlvP2p3Way {
     }
 
     fn len(&self) -> u8 {
-        let mut len = 1 + 4;
+        let mut len = 1;
+        if self.circuit_id.is_some() {
+            len += 4;
+        }
         if self.neighbor_id.is_some() {
             len += 6;
         }
@@ -1206,7 +1217,9 @@ impl TlvEmitter for IsisTlvP2p3Way {
 
     fn emit(&self, buf: &mut BytesMut) {
         buf.put_u8(self.state);
-        buf.put_u32(self.circuit_id);
+        if let Some(circuit_id) = self.circuit_id {
+            buf.put_u32(circuit_id);
+        }
         if let Some(neighbor_id) = &self.neighbor_id {
             buf.put(&neighbor_id.id[..]);
         }
@@ -1344,12 +1357,16 @@ impl IsisTlv {
         let (input, tl) = IsisTypeLen::parse_be(input)?;
         let (input, tlv) = packet_utils::safe_split_at(input, tl.len as usize)?;
         if tl.typ.is_known() {
-            let (_, val) = Self::parse_be(tlv, tl.typ)?;
-            Ok((input, val))
-        } else {
-            let (_, val) = IsisTlvUnknown::parse_tlv(tlv, tl)?;
-            Ok((input, Self::Unknown(val)))
+            // A malformed value in a known TLV must not abort the PDU:
+            // parse_tlvs runs under many0, which would silently stop here
+            // and drop every TLV after this one. Degrade to Unknown so the
+            // bytes are preserved and the rest of the PDU still parses.
+            if let Ok((_, val)) = Self::parse_be(tlv, tl.typ) {
+                return Ok((input, val));
+            }
         }
+        let (_, val) = IsisTlvUnknown::parse_tlv(tlv, tl)?;
+        Ok((input, Self::Unknown(val)))
     }
 
     pub fn parse_tlvs(input: &[u8]) -> IResult<&[u8], Vec<Self>> {

--- a/crates/isis-packet/tests/parser.rs
+++ b/crates/isis-packet/tests/parser.rs
@@ -567,3 +567,147 @@ pub fn parse_p2p_hello() {
     );
     parse_emit(PACKET);
 }
+
+/// Classic Cisco IOS sends the P2P three-way TLV (240) in the legacy
+/// 1-octet form: only the Adjacency Three-Way State, no Extended Local
+/// Circuit ID and no neighbor fields (all optional per RFC 5303 §3.2).
+/// This P2P IIH mirrors a real IOS capture, including the TLV order —
+/// Restart(211), P2p3Way(240), ProtSupported(129), AreaAddr(1),
+/// Ipv4IfAddr(132). Every TLV after 240 must survive: a parse failure
+/// on 240 used to make many0-based parse_tlvs stop there and silently
+/// drop the rest of the PDU's TLVs.
+#[test]
+pub fn parse_p2p_hello_cisco_state_only_three_way() {
+    const PACKET: &[u8] = &hex!(
+        "
+        83 14 01 00 11 01 00 00
+        02
+        00 00 00 00 00 01
+        00 1e
+        00 2b
+        00
+        d3 03 00 00 00
+        f0 01 00
+        81 01 cc
+        01 04 03 49 00 00
+        84 04 c0 a8 00 02
+        "
+    );
+    let (_, packet) = parse(PACKET).expect("Cisco IOS P2P IIH must parse");
+    let IsisPdu::P2pHello(hello) = &packet.pdu else {
+        panic!("expected P2P Hello, got {:?}", packet.pdu_type);
+    };
+
+    assert_eq!(
+        hello.tlvs.len(),
+        5,
+        "no TLV may be dropped: {:?}",
+        hello.tlvs
+    );
+
+    let three_way = hello
+        .tlvs
+        .iter()
+        .find_map(|tlv| match tlv {
+            IsisTlv::P2p3Way(v) => Some(v),
+            _ => None,
+        })
+        .expect("1-octet three-way TLV must parse as P2p3Way");
+    assert_eq!(three_way.state, 0); // Up
+    assert_eq!(three_way.circuit_id, None);
+    assert_eq!(three_way.neighbor_id, None);
+    assert_eq!(three_way.neighbor_circuit_id, None);
+
+    // TLVs after 240 must be present.
+    assert!(
+        hello.tlvs.iter().any(
+            |tlv| matches!(tlv, IsisTlv::Ipv4IfAddr(v) if v.addr.octets() == [192, 168, 0, 2])
+        )
+    );
+    assert!(
+        hello
+            .tlvs
+            .iter()
+            .any(|tlv| matches!(tlv, IsisTlv::ProtoSupported(_)))
+    );
+
+    // And the whole PDU still round-trips.
+    let mut buf = BytesMut::new();
+    packet.emit(&mut buf);
+    assert_eq!(&buf[..], PACKET);
+}
+
+/// RFC 5303 allows TLV 240 at value lengths 1 (state only), 5 (+ circuit
+/// id), 11 (+ neighbor sys-id) and 15 (+ neighbor circuit id). Each form
+/// must round-trip emit -> parse unchanged.
+#[test]
+pub fn three_way_tlv_round_trips_all_lengths() {
+    let sys_id = IsisSysId {
+        id: [0, 0, 0, 0, 0, 0x10],
+    };
+    let cases = [
+        (
+            IsisTlvP2p3Way {
+                state: 2,
+                circuit_id: None,
+                neighbor_id: None,
+                neighbor_circuit_id: None,
+            },
+            3usize, // TL header + 1
+        ),
+        (
+            IsisTlvP2p3Way {
+                state: 1,
+                circuit_id: Some(2),
+                neighbor_id: None,
+                neighbor_circuit_id: None,
+            },
+            7,
+        ),
+        (
+            IsisTlvP2p3Way {
+                state: 1,
+                circuit_id: Some(2),
+                neighbor_id: Some(sys_id),
+                neighbor_circuit_id: None,
+            },
+            13,
+        ),
+        (
+            IsisTlvP2p3Way {
+                state: 0,
+                circuit_id: Some(2),
+                neighbor_id: Some(sys_id),
+                neighbor_circuit_id: Some(3),
+            },
+            17,
+        ),
+    ];
+    for (original, wire_len) in cases {
+        let tlv: IsisTlv = original.clone().into();
+        let mut buf = BytesMut::new();
+        tlv.emit(&mut buf);
+        assert_eq!(buf.len(), wire_len);
+        let (rest, parsed) = IsisTlv::parse_tlvs(&buf).expect("round-trip parse");
+        assert!(rest.is_empty());
+        assert_eq!(parsed, vec![IsisTlv::P2p3Way(original)]);
+    }
+}
+
+/// A known TLV whose value fails its inner parser must degrade to
+/// IsisTlvUnknown (bytes preserved) instead of aborting the TLV stream:
+/// under many0 an inner error silently truncates every following TLV.
+#[test]
+pub fn malformed_known_tlv_degrades_to_unknown() {
+    // Ipv4IfAddr (132) with a 3-byte value: too short for an IPv4
+    // address, so the typed parser fails. Followed by ProtSupported.
+    const TLVS: &[u8] = &hex!("84 03 c0 a8 00  81 01 cc");
+    let (rest, tlvs) = IsisTlv::parse_tlvs(TLVS).expect("stream must parse");
+    assert!(rest.is_empty());
+    assert_eq!(tlvs.len(), 2);
+    let IsisTlv::Unknown(unknown) = &tlvs[0] else {
+        panic!("malformed TLV must become Unknown, got {:?}", tlvs[0]);
+    };
+    assert_eq!(unknown.values, vec![0xc0, 0xa8, 0x00]);
+    assert!(matches!(tlvs[1], IsisTlv::ProtoSupported(_)));
+}

--- a/zebra-rs/src/isis/ifsm.rs
+++ b/zebra-rs/src/isis/ifsm.rs
@@ -244,14 +244,14 @@ pub fn hello_p2p_generate(link: &LinkTop, level: Level) -> IsisP2pHello {
     let tlv = if let Some((_, nbr)) = nbr {
         IsisTlvP2p3Way {
             state: nbr.state.into(),
-            circuit_id: link.ifindex,
+            circuit_id: Some(link.ifindex),
             neighbor_id: Some(nbr.sys_id),
             neighbor_circuit_id: nbr.circuit_id,
         }
     } else {
         IsisTlvP2p3Way {
             state: NfsmState::Down.into(),
-            circuit_id: link.ifindex,
+            circuit_id: Some(link.ifindex),
             neighbor_id: None,
             neighbor_circuit_id: None,
         }

--- a/zebra-rs/src/isis/packet.rs
+++ b/zebra-rs/src/isis/packet.rs
@@ -211,9 +211,25 @@ pub fn nbr_hello_interpret(
                 }
             }
             IsisTlv::P2p3Way(tlv) => {
-                nbr.circuit_id = Some(tlv.circuit_id);
-                if let Some(neighbor_id) = tlv.neighbor_id {
-                    has_my_sys_id = sys_id == neighbor_id;
+                nbr.circuit_id = tlv.circuit_id;
+                match tlv.neighbor_id {
+                    Some(neighbor_id) => has_my_sys_id = sys_id == neighbor_id,
+                    // RFC 5303 §3.2: the neighbor fields are "if known";
+                    // classic Cisco IOS always sends the legacy 1-octet
+                    // form (state only). Drive the handshake from the
+                    // received state instead: on a p2p circuit, the peer
+                    // reporting Initializing or Up means it has heard our
+                    // IIH — only we are on the link to be heard. Received
+                    // Up while we still have no adjacency record is not
+                    // trusted (mirror FRR): let the peer regress to
+                    // Initializing against our next IIH first.
+                    None => {
+                        has_my_sys_id = match tlv.state {
+                            s if s == NfsmState::Up as u8 => nbr.state != NfsmState::Down,
+                            s if s == NfsmState::Init as u8 => true,
+                            _ => false,
+                        };
+                    }
                 }
             }
             IsisTlv::Ipv4IfAddr(ifaddr) => {
@@ -1743,5 +1759,95 @@ mod poi_forward_tests {
         // (no auth configured), so we expect zero. The pre-existing
         // stale Auth must be gone.
         assert_eq!(auth_count, 0, "stale Auth TLV must be stripped");
+    }
+}
+
+#[cfg(test)]
+mod three_way_state_only_tests {
+    use super::*;
+
+    fn sys(b: u8) -> IsisSysId {
+        IsisSysId {
+            id: [0, 0, 0, 0, 0, b],
+        }
+    }
+
+    /// Our own system-id, as passed to nbr_hello_interpret.
+    fn my_sys_id() -> IsisSysId {
+        sys(0x10)
+    }
+
+    fn nbr_in(state: NfsmState) -> Neighbor {
+        let (tx, _rx) = tokio::sync::mpsc::unbounded_channel::<Message>();
+        let mut nbr = Neighbor::new(tx, 2, NetworkType::P2p, sys(0x01), None);
+        nbr.state = state;
+        nbr
+    }
+
+    fn three_way(state: NfsmState, neighbor_id: Option<IsisSysId>) -> Vec<IsisTlv> {
+        vec![IsisTlv::P2p3Way(IsisTlvP2p3Way {
+            state: state.into(),
+            circuit_id: None,
+            neighbor_id,
+            neighbor_circuit_id: None,
+        })]
+    }
+
+    fn interpret(nbr: &mut Neighbor, tlvs: &[IsisTlv]) -> bool {
+        let mut pool = None;
+        let (_, has_my_sys_id, _) = nbr_hello_interpret(nbr, tlvs, None, my_sys_id(), &mut pool);
+        has_my_sys_id
+    }
+
+    /// Classic Cisco IOS sends TLV 240 with only the state octet. When
+    /// the peer reports Initializing it has heard our IIH (p2p circuit:
+    /// nobody else is on the link), so the handshake may complete.
+    #[test]
+    fn state_only_initializing_completes_handshake() {
+        let mut nbr = nbr_in(NfsmState::Init);
+        assert!(interpret(&mut nbr, &three_way(NfsmState::Init, None)));
+    }
+
+    /// Peer reporting Up state-only keeps an established adjacency up
+    /// (this is what IOS steady-state sends: TLV 240, length 1, Up).
+    #[test]
+    fn state_only_up_with_local_adjacency_completes_handshake() {
+        let mut nbr = nbr_in(NfsmState::Init);
+        assert!(interpret(&mut nbr, &three_way(NfsmState::Up, None)));
+        let mut nbr = nbr_in(NfsmState::Up);
+        assert!(interpret(&mut nbr, &three_way(NfsmState::Up, None)));
+    }
+
+    /// Received Up while we have no adjacency record yet is not trusted
+    /// (mirror FRR): stay one-way until the peer regresses against our
+    /// next IIH and walks up through Initializing.
+    #[test]
+    fn state_only_up_from_scratch_is_not_trusted() {
+        let mut nbr = nbr_in(NfsmState::Down);
+        assert!(!interpret(&mut nbr, &three_way(NfsmState::Up, None)));
+    }
+
+    /// Received Down means the peer has not heard us — one-way only.
+    /// From local Up this drives the RFC 5303 §6.1 Up -> Init regression.
+    #[test]
+    fn state_only_down_stays_one_way() {
+        let mut nbr = nbr_in(NfsmState::Up);
+        assert!(!interpret(&mut nbr, &three_way(NfsmState::Down, None)));
+    }
+
+    /// RFC 5303 form with the neighbor system-id present keeps the
+    /// existing semantics: ours listed -> complete, another system's
+    /// listed -> one-way, regardless of the reported state.
+    #[test]
+    fn neighbor_id_match_still_decides_when_present() {
+        let mut nbr = nbr_in(NfsmState::Init);
+        assert!(interpret(
+            &mut nbr,
+            &three_way(NfsmState::Init, Some(my_sys_id()))
+        ));
+        assert!(!interpret(
+            &mut nbr,
+            &three_way(NfsmState::Up, Some(sys(0x99)))
+        ));
     }
 }


### PR DESCRIPTION
## Summary

Classic Cisco IOS sends the P2P adjacency TLV (240) in the legacy 1-octet form: only the Adjacency Three-Way State, with no Extended Local Circuit ID and no neighbor fields (RFC 5303 §3.2 marks everything after the state octet optional, "if known"). Against such a peer zebra-rs never left `Initializing`, for two stacked reasons that this PR fixes across three layers:

- **Parser rejected the 1-octet TLV.** `IsisTlvP2p3Way::parse_be` unconditionally consumed a 4-byte circuit id, so the length-1 TLV failed to parse. Because TLV 240 is a *known* type, `parse_tlv` propagated the error and the `many0`-based `parse_tlvs` silently stopped there — dropping the three-way TLV and every TLV after it (Protocols Supported, Area Address, IPv4 Interface Address) from the IIH.
- **Handshake required the optional neighbor sys-id.** The `Init → Up` transition was gated solely on our sys-id appearing in the TLV's neighbor field, which a state-only sender never includes.

## Changes

- `circuit_id` is now `Option<u32>` in `IsisTlvP2p3Way`; the parser/emitter accept and round-trip all four RFC 5303 value lengths (1 / 5 / 11 / 15).
- When the neighbor sys-id field is absent, the handshake is driven from the received three-way state (FRR semantics): `Initializing`, or `Up` with an existing adjacency record, completes it; `Down` keeps it one-way and drives the RFC 5303 §6.1 `Up → Init` regression; `Up` from a brand-new neighbor is not trusted for one exchange. The sys-id match rule is unchanged when the field is present.
- `parse_tlv` now degrades a known TLV whose value fails its inner parser to `IsisTlvUnknown` (bytes preserved) instead of silently truncating the rest of the PDU's TLVs.

## Test plan

- New integration test replays a P2P IIH modeled byte-for-byte on a real IOS capture (TLV order Restart → 240 → Protocols → Area → IPv4-If), asserting all 5 TLVs survive and the PDU round-trips.
- Round-trip tests for each TLV-240 length, plus a truncation-regression test for the malformed-known-TLV degrade path.
- 5 FSM unit tests covering the state-only handshake table.
- `cargo test --workspace --exclude bdd` green (37 suites); `cargo clippy --workspace --all-targets -- -D warnings` clean; `cargo fmt` applied.

Generated with [Claude Code](https://claude.com/claude-code)