### PR TITLE
fib: tee BGP-EVPN over VXLAN into the cradle eBPF data plane

### DIFF
--- a/proto/cradle.proto
+++ b/proto/cradle.proto
@@ -126,16 +126,31 @@ message LocalSidDel {
 
 message Srv6EncapSource { string addr = 1; }  // outer IPv6 SA for H.Encaps
 
+// EVPN/VXLAN L2VNI: bind VNI `vni` to bridge domain `vlan` (both datapath
+// directions — encap picks the VNI by bridge domain, decap picks the bridge
+// domain by VNI).
+message Vni {
+  uint32 vni  = 1;
+  uint32 vlan = 2;
+}
+
+message VniDel { uint32 vni = 1; }
+
+// Local VTEP source IPv4 — the VXLAN outer source address, and the decap
+// match for received VXLAN traffic.
+message VtepSource { string addr = 1; }
+
 // EVPN-over-SRv6 overlay FDB entry: MAC `mac` in bridge domain `bd` sits
 // behind the remote PE's End.DT2U/DT2M service SID. `nexthop_id` selects the
 // underlay adjacency; 0 = resolve by a FIB6 lookup on `remote_sid` in the
 // datapath (the control plane doesn't need to pre-resolve). The all-ones MAC
 // is the per-BD BUM sentinel (remote End.DT2M).
 message FdbRemote {
-  string mac        = 1;
-  uint32 bd         = 2;
-  string remote_sid = 3;
-  uint32 nexthop_id = 4;
+  string mac         = 1;
+  uint32 bd          = 2;
+  string remote_sid  = 3;   // SRv6: remote End.DT2U/DT2M service SID
+  uint32 nexthop_id  = 4;   // 0 = FIB lookup on the SID/VTEP in the datapath
+  string remote_vtep = 5;   // VXLAN: remote VTEP IPv4 (exactly one of sid/vtep)
 }
 
 message FdbRemoteDel {
@@ -177,8 +192,9 @@ message XconnectDel {
 // (bd, remote_sid). The EVPN Type-3 tee drives these; a bridge domain using
 // slots must not also program the all-ones-MAC sentinel.
 message ReplSlot {
-  uint32 bd         = 1;
-  string remote_sid = 2;
+  uint32 bd          = 1;
+  string remote_sid  = 2;   // SRv6: remote End.DT2M SID
+  string remote_vtep = 3;   // VXLAN: remote VTEP IPv4 (VNI from the bd's SetVni)
 }
 
 // An egress-protection mirror route (End.M context): traffic exposed by an
@@ -421,6 +437,9 @@ service Cradle {
   rpc AddGtpPdr(GtpPdr) returns (Empty);
   rpc DelGtpPdr(GtpPdrDel) returns (Empty);
   rpc SetSrv6EncapSource(Srv6EncapSource) returns (Empty);
+  rpc SetVni(Vni) returns (Empty);
+  rpc DelVni(VniDel) returns (Empty);
+  rpc SetVtepSource(VtepSource) returns (Empty);
   rpc AddFdbRemote(FdbRemote) returns (Empty);
   rpc DelFdbRemote(FdbRemoteDel) returns (Empty);
   rpc WatchFdb(WatchFdbRequest) returns (stream FdbEvent);

--- a/zebra-rs/src/bgp/inst.rs
+++ b/zebra-rs/src/bgp/inst.rs
@@ -3501,6 +3501,22 @@ impl Bgp {
             RibRx::VxlanAdd { vni, vtep_local } => {
                 self.local_vxlans.insert(vni, vtep_local);
                 self.evpn_originate_imet(vni, vtep_local);
+                // Re-originate any MAC learned before this VXLAN device was
+                // observed: cradle's WatchFdb replays already-learned CE MACs
+                // the instant zebra subscribes, which can beat the device's
+                // RTM_NEWLINK, so their Type-2 was originated with a stale
+                // (router-id) nexthop. `evpn_originate_macip` now resolves the
+                // VTEP from `local_vxlans`, so re-running it fixes the nexthop.
+                // Idempotent (same prefix replaces).
+                let stale: Vec<FdbEntry> = self
+                    .local_fdb
+                    .values()
+                    .filter(|e| e.vni == vni)
+                    .cloned()
+                    .collect();
+                for entry in stale {
+                    self.evpn_originate_macip(&entry);
+                }
             }
             RibRx::VxlanDel { vni } => {
                 if let Some(vtep_local) = self.local_vxlans.remove(&vni) {

--- a/zebra-rs/src/bgp/route.rs
+++ b/zebra-rs/src/bgp/route.rs
@@ -15016,8 +15016,18 @@ impl Bgp {
             ecom.0.insert(evpn_mac_mobility(seq));
         }
         attr.ecom = Some(ecom);
-        let nexthop = entry.vxlan_local.unwrap_or(IpAddr::V4(self.router_id));
-        if entry.vxlan_local.is_none() {
+        // Prefer the current VNI→VTEP binding over the entry's cached
+        // `vxlan_local`: a MAC learned before its VXLAN device was observed
+        // (a cradle WatchFdb replay racing device creation) cached `None`,
+        // and the `RibRx::VxlanAdd` handler re-originates it once the VTEP
+        // is known — this lookup is what makes that re-origination correct.
+        let nexthop = self
+            .local_vxlans
+            .get(&entry.vni)
+            .copied()
+            .or(entry.vxlan_local)
+            .unwrap_or(IpAddr::V4(self.router_id));
+        if !self.local_vxlans.contains_key(&entry.vni) && entry.vxlan_local.is_none() {
             tracing::warn!(
                 "evpn_originate_macip: VXLAN for VNI {} has no local IP; \
                  falling back to router-id {} as nexthop",

--- a/zebra-rs/src/fib/cradle.rs
+++ b/zebra-rs/src/fib/cradle.rs
@@ -74,6 +74,16 @@ struct CradleMirror {
     fdb: HashMap<(u32, [u8; 6]), Ipv6Addr>,
     /// (bridge domain, remote End.DT2M SID) flood-set memberships.
     repl_slots: HashSet<(u32, Ipv6Addr)>,
+    /// EVPN/VXLAN counterparts of `fdb`/`repl_slots`: (bridge domain, mac) →
+    /// remote VTEP IPv4 (Type-2), and (bridge domain, remote VTEP) flood-set
+    /// memberships (Type-3). A `(vni, mac)` key is in exactly one of `fdb` /
+    /// `fdb_vxlan` depending on the received route's encap.
+    fdb_vxlan: HashMap<(u32, [u8; 6]), Ipv4Addr>,
+    repl_slots_vxlan: HashSet<(u32, Ipv4Addr)>,
+    /// L2VNI ↔ bridge-domain bindings (bd == vni today) for `SetVni` replay,
+    /// and the fabric-wide local VTEP source for `SetVtepSource`.
+    vnis: HashMap<u32, u32>,
+    vtep_source: Option<Ipv4Addr>,
     /// (AC port, vid, dx2v table) → (remote SID, local decap SID).
     xconnects: HashMap<(String, u16, u32), (Ipv6Addr, Option<Ipv6Addr>)>,
     /// (mirror context, protected prefix) → reproduction VRF table.
@@ -431,6 +441,21 @@ impl CradleFib {
         for (vni, sid) in &m.repl_slots {
             self.repl_slot_add(*vni, *sid).await;
         }
+        // VXLAN L2: the VTEP source and VNI bindings first (a VXLAN repl slot
+        // resolves its VNI from the SetVni binding), then the overlay FDB and
+        // flood slots.
+        if let Some(src) = m.vtep_source {
+            self.set_vtep_source(src).await;
+        }
+        for (vni, vlan) in &m.vnis {
+            self.set_vni(*vni, *vlan).await;
+        }
+        for ((vni, mac), vtep) in &m.fdb_vxlan {
+            self.fdb_add_vxlan(*vni, *mac, *vtep).await;
+        }
+        for (vni, vtep) in &m.repl_slots_vxlan {
+            self.repl_slot_add_vxlan(*vni, *vtep).await;
+        }
         for ((port, vid, table), (remote, local)) in &m.xconnects {
             self.xconnect_add(port, *remote, *local, *vid, *table).await;
         }
@@ -446,15 +471,18 @@ impl CradleFib {
         }
         tracing::info!(
             "fib: cradle replay: {} v4 + {} v6 routes, {} ILM, {} SIDs (+{} static), \
-             {} FDB, {} repl slots, {} xconnects, {} GTP PDRs + {} encaps, \
-             {} mirror routes, {} neighbors re-applied",
+             {} FDB (+{} vxlan), {} repl slots (+{} vxlan), {} vnis, {} xconnects, \
+             {} GTP PDRs + {} encaps, {} mirror routes, {} neighbors re-applied",
             m.routes4.len(),
             m.routes6.len(),
             m.ilm.len(),
             m.local_sids.len(),
             m.static_sids.len(),
             m.fdb.len(),
+            m.fdb_vxlan.len(),
             m.repl_slots.len(),
+            m.repl_slots_vxlan.len(),
+            m.vnis.len(),
             m.xconnects.len(),
             m.gtp_pdrs.len(),
             m.gtp_encaps.len(),
@@ -1217,6 +1245,7 @@ impl CradleFib {
                     bd: vni,
                     remote_sid: sid.to_string(),
                     nexthop_id: 0,
+                    remote_vtep: String::new(),
                 })
                 .await?;
             anyhow::Ok(())
@@ -1227,9 +1256,43 @@ impl CradleFib {
         }
     }
 
-    /// Remove an overlay FDB entry.
+    /// EVPN/VXLAN overlay FDB entry (Type-2): `mac` in bridge domain `vni`
+    /// sits behind the remote VTEP `vtep`. The VNI stamped on encap comes
+    /// from the bridge domain's `SetVni` binding; `nexthop_id: 0` — cradle
+    /// resolves the underlay adjacency with a FIB4 lookup on the VTEP.
+    pub async fn fdb_add_vxlan(&self, vni: u32, mac: [u8; 6], vtep: std::net::Ipv4Addr) {
+        self.mirror.lock().await.fdb_vxlan.insert((vni, mac), vtep);
+        let mac_str = format!(
+            "{:02x}:{:02x}:{:02x}:{:02x}:{:02x}:{:02x}",
+            mac[0], mac[1], mac[2], mac[3], mac[4], mac[5]
+        );
+        let result = async {
+            self.client()
+                .await?
+                .add_fdb_remote(pb::FdbRemote {
+                    mac: mac_str.clone(),
+                    bd: vni,
+                    remote_sid: String::new(),
+                    nexthop_id: 0,
+                    remote_vtep: vtep.to_string(),
+                })
+                .await?;
+            anyhow::Ok(())
+        }
+        .await;
+        if let Err(e) = result {
+            tracing::warn!("fib: cradle fdb_add_vxlan {mac_str} vni {vni} failed: {e}");
+        }
+    }
+
+    /// Remove an overlay FDB entry (works for either encap — the datapath
+    /// keys the delete by `(mac, bd)` regardless of flavor).
     pub async fn fdb_del(&self, vni: u32, mac: [u8; 6]) {
-        self.mirror.lock().await.fdb.remove(&(vni, mac));
+        {
+            let mut m = self.mirror.lock().await;
+            m.fdb.remove(&(vni, mac));
+            m.fdb_vxlan.remove(&(vni, mac));
+        }
         let mac_str = format!(
             "{:02x}:{:02x}:{:02x}:{:02x}:{:02x}:{:02x}",
             mac[0], mac[1], mac[2], mac[3], mac[4], mac[5]
@@ -1275,6 +1338,7 @@ impl CradleFib {
                 .add_repl_slot(pb::ReplSlot {
                     bd: vni,
                     remote_sid: sid.to_string(),
+                    remote_vtep: String::new(),
                 })
                 .await?;
             anyhow::Ok(())
@@ -1366,6 +1430,7 @@ impl CradleFib {
                 .del_repl_slot(pb::ReplSlot {
                     bd: vni,
                     remote_sid: sid.to_string(),
+                    remote_vtep: String::new(),
                 })
                 .await?;
             anyhow::Ok(())
@@ -1373,6 +1438,91 @@ impl CradleFib {
         .await;
         if let Err(e) = result {
             tracing::warn!("fib: cradle repl_slot_del vni {vni} {sid} failed: {e}");
+        }
+    }
+
+    /// EVPN/VXLAN BUM replication slot (Type-3 tee): the remote VTEP `vtep`
+    /// joins VNI `vni`'s flood set. The VNI resolves from the bridge
+    /// domain's `SetVni` binding, so a `cradle_vni_register` must have run
+    /// first (it does — the VXLAN device is declared before any Type-3).
+    pub async fn repl_slot_add_vxlan(&self, vni: u32, vtep: std::net::Ipv4Addr) {
+        self.mirror
+            .lock()
+            .await
+            .repl_slots_vxlan
+            .insert((vni, vtep));
+        let result = async {
+            self.client()
+                .await?
+                .add_repl_slot(pb::ReplSlot {
+                    bd: vni,
+                    remote_sid: String::new(),
+                    remote_vtep: vtep.to_string(),
+                })
+                .await?;
+            anyhow::Ok(())
+        }
+        .await;
+        if let Err(e) = result {
+            tracing::warn!("fib: cradle repl_slot_add_vxlan vni {vni} {vtep} failed: {e}");
+        }
+    }
+
+    /// Remove a `(vni, vtep)` VXLAN replication slot.
+    pub async fn repl_slot_del_vxlan(&self, vni: u32, vtep: std::net::Ipv4Addr) {
+        self.mirror
+            .lock()
+            .await
+            .repl_slots_vxlan
+            .remove(&(vni, vtep));
+        let result = async {
+            self.client()
+                .await?
+                .del_repl_slot(pb::ReplSlot {
+                    bd: vni,
+                    remote_sid: String::new(),
+                    remote_vtep: vtep.to_string(),
+                })
+                .await?;
+            anyhow::Ok(())
+        }
+        .await;
+        if let Err(e) = result {
+            tracing::warn!("fib: cradle repl_slot_del_vxlan vni {vni} {vtep} failed: {e}");
+        }
+    }
+
+    /// Bind an L2VNI to its bridge domain in the cradle datapath (both
+    /// directions). Today `bd == vni`, matching the `bd` field the Type-2/3
+    /// tees send.
+    pub async fn set_vni(&self, vni: u32, vlan: u32) {
+        self.mirror.lock().await.vnis.insert(vni, vlan);
+        let result = async {
+            self.client().await?.set_vni(pb::Vni { vni, vlan }).await?;
+            anyhow::Ok(())
+        }
+        .await;
+        if let Err(e) = result {
+            tracing::warn!("fib: cradle set_vni {vni} vlan {vlan} failed: {e}");
+        }
+    }
+
+    /// Set the fabric-wide local VTEP source (VXLAN outer source + decap
+    /// match). Idempotent; last write wins.
+    pub async fn set_vtep_source(&self, addr: std::net::Ipv4Addr) {
+        self.mirror.lock().await.vtep_source = Some(addr);
+        let result = async {
+            self.client()
+                .await?
+                .set_vtep_source(pb::VtepSource {
+                    addr: addr.to_string(),
+                })
+                .await?;
+            anyhow::Ok(())
+        }
+        .await;
+        if let Err(e) = result {
+            tracing::warn!("fib: cradle set_vtep_source {addr} failed: {e}");
         }
     }
 

--- a/zebra-rs/src/fib/netlink/handle.rs
+++ b/zebra-rs/src/fib/netlink/handle.rs
@@ -575,6 +575,20 @@ impl FibHandle {
         }
     }
 
+    /// Declare an EVPN/VXLAN L2VNI to the cradle data plane when its VXLAN
+    /// device appears: bind the VNI to its bridge domain (`bd == vni`) and
+    /// set the fabric-wide local VTEP source. Only an IPv4 VTEP is a cradle
+    /// datapath capability today; an IPv6-local (SRv6) device is a no-op
+    /// here (it needs neither map). No-op when cradle is disabled.
+    pub async fn cradle_vni_register(&self, vni: u32, local: IpAddr) {
+        if let Some(cradle) = &self.cradle
+            && let IpAddr::V4(v4) = local
+        {
+            cradle.set_vni(vni, vni).await;
+            cradle.set_vtep_source(v4).await;
+        }
+    }
+
     /// Install a GTP-U decap PDR (`H.M.GTP4.D`) into the cradle data plane: a
     /// G-PDU on (`dst`, `teid`) is stripped and its inner packet forwarded in
     /// VRF `table_id`. No kernel counterpart — the mainline kernel has no GTP
@@ -3350,6 +3364,18 @@ impl FibHandle {
             }
             return;
         }
+        // EVPN over VXLAN + cradle: the MAC sits behind a remote IPv4 VTEP,
+        // and the eBPF datapath is the forwarder — install the overlay FDB
+        // entry there and skip the kernel VXLAN FDB (cradle owns it). Fires
+        // whether or not a kernel VXLAN device exists. An IPv6 VTEP is not
+        // yet a cradle datapath capability, so it falls through to the
+        // kernel path below.
+        if let Some(cradle) = &self.cradle
+            && let Some(IpAddr::V4(vtep)) = tunnel_endpoint
+        {
+            cradle.fdb_add_vxlan(vni, mac.octets(), vtep).await;
+            return;
+        }
         let Some(&vxlan_ifindex) = self.vni_ifindex_map.get(&vni) else {
             if fib_l2_fdb() {
                 tracing::info!(
@@ -3721,6 +3747,15 @@ impl FibHandle {
         _ifindex: u32,
         _seq: u32,
     ) {
+        // EVPN over VXLAN + cradle: the remote VTEP `group` joins the VNI's
+        // eBPF flood set (ingress replication); cradle owns the datapath, so
+        // skip the kernel zero-MAC FDB. An IPv6 VTEP falls through to kernel.
+        if let Some(cradle) = &self.cradle
+            && let IpAddr::V4(vtep) = group
+        {
+            cradle.repl_slot_add_vxlan(vni, vtep).await;
+            return;
+        }
         let Some(&vxlan_ifindex) = self.vni_ifindex_map.get(&vni) else {
             if fib_l2_mdb() {
                 tracing::info!(
@@ -3767,6 +3802,12 @@ impl FibHandle {
     /// Remove a remote VTEP from VXLAN BUM ingress replication.
     /// Counterpart of `mdb_add`; same rationale on naming.
     pub async fn mdb_del(&self, vni: u32, group: IpAddr, _source: Option<IpAddr>, _ifindex: u32) {
+        if let Some(cradle) = &self.cradle
+            && let IpAddr::V4(vtep) = group
+        {
+            cradle.repl_slot_del_vxlan(vni, vtep).await;
+            return;
+        }
         let Some(&vxlan_ifindex) = self.vni_ifindex_map.get(&vni) else {
             if fib_l2_mdb() {
                 tracing::info!(

--- a/zebra-rs/src/rib/link.rs
+++ b/zebra-rs/src/rib/link.rs
@@ -467,14 +467,28 @@ impl Rib {
     pub async fn link_add(&mut self, fib_link: FibLink) {
         // `external vnifilter` VXLAN devices (the EVPN model) carry no
         // fixed kernel VNI — `IFLA_VXLAN_ID` is 0. Source the real VNI
-        // from our own config (keyed by device name) so the VNI→ifindex
-        // map, EVPN VTEP discovery and `vni_for_bridge` all observe the
-        // true L2VPN VNI instead of 0.
+        // (and the local VTEP address) from our own config, keyed by
+        // device name, whenever the kernel message doesn't carry them.
+        // A later partial RTM_NEWLINK — e.g. the one the kernel emits when
+        // the device is enslaved to a bridge — carries `IFLA_MASTER` but
+        // NOT the nested `IFLA_VXLAN_*` block, so `link_from_msg` rebuilds
+        // the link with `vni: None` / `vxlan_local: None`. Refilling from
+        // config here keeps both stable across such updates, which the EVPN
+        // Type-2 origination depends on for the VTEP nexthop (an SRv6 Type-2
+        // rides its End.DT2U SID and tolerated the loss; a VXLAN Type-2 has
+        // only the nexthop).
         let mut fib_link = fib_link;
-        if fib_link.vni == Some(0)
-            && let Some(cfg_vni) = self.vxlan.get(&fib_link.name).and_then(|v| v.vni)
-        {
-            fib_link.vni = Some(cfg_vni);
+        if let Some(cfg) = self.vxlan.get(&fib_link.name) {
+            if (fib_link.vni.is_none() || fib_link.vni == Some(0))
+                && let Some(cfg_vni) = cfg.vni
+            {
+                fib_link.vni = Some(cfg_vni);
+            }
+            if fib_link.vxlan_local.is_none()
+                && let Some(local) = cfg.local_addr
+            {
+                fib_link.vxlan_local = Some(local);
+            }
         }
 
         if rib_interface() {
@@ -732,6 +746,10 @@ impl Rib {
             self.fib_handle.register_vxlan_ifindex(new, ifindex);
             if let Some(local) = self.links.get(&ifindex).and_then(|l| l.vxlan_local) {
                 self.api_vxlan_add(new, local);
+                // Tee the VNI binding + local VTEP source to the cradle eBPF
+                // data plane (VXLAN only; an SRv6 device's IPv6-local is a
+                // no-op there).
+                self.fib_handle.cradle_vni_register(new, local).await;
             }
         }
 


### PR DESCRIPTION
## Summary

EVPN/VXLAN Phase 2: a real iBGP L2VPN-EVPN session (default VXLAN encapsulation) now programs the cradle eBPF data plane, mirroring the existing EVPN-over-SRv6 tee.

- **mac_add (Type-2)**: when cradle is active and the tunnel endpoint is an IPv4 VTEP, install a VXLAN overlay FDB entry (`AddFdbRemote{remote_vtep}`) and skip the kernel VXLAN FDB — cradle owns the datapath. An IPv6 VTEP falls through to the kernel path.
- **mdb_add/mdb_del (Type-3)**: each peer VTEP becomes a BUM replication slot (`Add/DelReplSlot{remote_vtep}`).
- **cradle_vni_register**, called when a VXLAN device appears: `SetVni` (bd==vni) + `SetVtepSource`, gated on an IPv4 local (SRv6's IPv6-local is a no-op).
- `CradleFib` gains the VXLAN FDB/slot/VNI/VTEP methods, a mirror of that state, and a replay that re-emits the VTEP source + VNI bindings before the slots. Vendored `proto/cradle.proto` synced with cradle-rs.

Three latent bugs surfaced, all masked for SRv6 because its Type-2 receiver resolves the MAC against the End.DT2U SID rather than the nexthop — VXLAN has only the nexthop:
- **rib/link.rs**: a partial `RTM_NEWLINK` (bridge enslavement — `IFLA_MASTER` without the nested `IFLA_VXLAN_*` block) reset `vni`/`vxlan_local` to None. Refill both from the vxlan config on every `link_add`.
- **Startup race**: cradle's WatchFdb replays already-learned CE MACs the instant zebra subscribes, beating the device's `link_add`, so the Type-2 got a router-id nexthop and was never refreshed. `evpn_originate_macip` now resolves from `local_vxlans[vni]` first, and the `RibRx::VxlanAdd` handler re-originates cached local FDB entries for the VNI (idempotent).

## Test plan

- `cargo fmt` / workspace clippy `--all-targets` / `cargo test --workspace --exclude bdd` — all clean.
- New `cradle_evpn_vxlan_zebra` BDD (in cradle-rs): fully dynamic (no static ARP/FDB); asserts unicast `vxlan_encap`, BUM `vxlan_flood`, `vxlan_decap` — passes.
- `cradle_evpn_srv6_zebra` regression still passes (the shared EVPN-origination changes are safe).

Generated with [Claude Code](https://claude.com/claude-code)