### PR TITLE
fib: withdraw the cradle VNI binding on VXLAN device removal

### DIFF
--- a/zebra-rs/src/fib/cradle.rs
+++ b/zebra-rs/src/fib/cradle.rs
@@ -1507,6 +1507,20 @@ impl CradleFib {
         }
     }
 
+    /// Remove an L2VNI binding (the VXLAN device is gone). The fabric VTEP
+    /// source is left as-is — it is fabric-wide, not per-VNI.
+    pub async fn del_vni(&self, vni: u32) {
+        self.mirror.lock().await.vnis.remove(&vni);
+        let result = async {
+            self.client().await?.del_vni(pb::VniDel { vni }).await?;
+            anyhow::Ok(())
+        }
+        .await;
+        if let Err(e) = result {
+            tracing::warn!("fib: cradle del_vni {vni} failed: {e}");
+        }
+    }
+
     /// Set the fabric-wide local VTEP source (VXLAN outer source + decap
     /// match). Idempotent; last write wins.
     pub async fn set_vtep_source(&self, addr: std::net::Ipv4Addr) {

--- a/zebra-rs/src/fib/netlink/handle.rs
+++ b/zebra-rs/src/fib/netlink/handle.rs
@@ -589,6 +589,15 @@ impl FibHandle {
         }
     }
 
+    /// Withdraw an L2VNI binding from cradle when its VXLAN device is
+    /// removed (the counterpart of `cradle_vni_register`). Harmless for an
+    /// SRv6 device, which never registered one. No-op when cradle is off.
+    pub async fn cradle_vni_unregister(&self, vni: u32) {
+        if let Some(cradle) = &self.cradle {
+            cradle.del_vni(vni).await;
+        }
+    }
+
     /// Install a GTP-U decap PDR (`H.M.GTP4.D`) into the cradle data plane: a
     /// G-PDU on (`dst`, `teid`) is stripped and its inner packet forwarded in
     /// VRF `table_id`. No kernel counterpart — the mainline kernel has no GTP

--- a/zebra-rs/src/rib/inst.rs
+++ b/zebra-rs/src/rib/inst.rs
@@ -3628,7 +3628,7 @@ impl Rib {
                 self.link_add(link).await;
             }
             FibMessage::DelLink(link) => {
-                self.link_delete(link);
+                self.link_delete(link).await;
             }
             FibMessage::NewAddr(addr) => {
                 // Kernel netlink path: from_config=false. If a configured

--- a/zebra-rs/src/rib/link.rs
+++ b/zebra-rs/src/rib/link.rs
@@ -822,7 +822,7 @@ impl Rib {
         }
     }
 
-    pub fn link_delete(&mut self, oslink: FibLink) {
+    pub async fn link_delete(&mut self, oslink: FibLink) {
         // Unregister via the VNI we resolved when the link was added
         // (config-sourced for `external vnifilter` devices, whose kernel
         // `IFLA_VXLAN_ID` is 0). Fall back to the netlink value for a
@@ -836,6 +836,9 @@ impl Rib {
         if let Some(vni) = del_vni {
             self.fib_handle.unregister_vxlan_ifindex(vni);
             self.api_vxlan_del(vni);
+            // Withdraw the VNI binding from the cradle eBPF data plane
+            // (no-op for an SRv6 device / when cradle is off).
+            self.fib_handle.cradle_vni_unregister(vni).await;
         }
         // Notify subscribers BEFORE removing the link entry, so the
         // VRF lookup in `api_link_del` still resolves to the right


### PR DESCRIPTION
## Summary

Phase-2 consolidation follow-up: wire the `DelVni` tee that Phase 2 left unconnected.

Phase 2 added the `SetVni`/`DelVni` RPCs and `cradle_vni_register` on VXLAN device creation, but `DelVni` had no caller — a removed VXLAN device left a stale VNI/VTEP binding in the cradle data plane (idempotent and swept on cradle restart, but incomplete). This wires the counterpart:

- `link_delete` becomes async and tees `cradle_vni_unregister` → `DelVni` after `unregister_vxlan_ifindex`.
- `CradleFib::del_vni` removes the mirror entry so a replay does not re-add it.
- No-op for an SRv6 device (which never registered a VNI) and when cradle is disabled.

## Test plan

- `cargo fmt` / workspace clippy `--all-targets -- -D warnings` (default + `--features lua`) / `cargo test -p zebra-rs` — all clean.
- Exercised by the `cradle_evpn_vxlan_zebra{,_age,_mob,_multi}` BDD teardowns (clean environment after device/namespace removal); the SRv6 tee is unaffected (`cradle_evpn_srv6_zebra` still passes).

Generated with [Claude Code](https://claude.com/claude-code)