### PR TITLE
isis: emit AFI-prefixed area address in the self-LSP

### DIFF
--- a/crates/isis-packet/src/nsap.rs
+++ b/crates/isis-packet/src/nsap.rs
@@ -192,4 +192,25 @@ mod tests {
         is_invalid_nsap("49.0102.0304.0506.0708.090a.0b0c.0d0e.0000.0000.0001.00");
         // 14 octet area id.
     }
+
+    /// The `area_id` field holds only the area octets; the `area_id()`
+    /// accessor prepends the AFI to form the full area address. IS-IS
+    /// Area Address TLVs (Hello type 1 and LSP anchor) carry the
+    /// AFI-prefixed form — emitting the bare field drops the AFI and
+    /// advertises e.g. `00.00` instead of `49.0000`. Guarding both here
+    /// keeps every Area TLV producer consistent.
+    #[test]
+    fn area_id_accessor_prepends_afi() {
+        let nsap: Nsap = "49.0000.0000.0000.0001.00".parse().unwrap();
+        assert_eq!(nsap.afi, 0x49);
+        // Field: area octets only, no AFI.
+        assert_eq!(nsap.area_id, vec![0x00, 0x00]);
+        // Accessor: AFI + area octets = the full area address.
+        assert_eq!(nsap.area_id(), vec![0x49, 0x00, 0x00]);
+
+        // A different AFI with a non-zero area exercises the same rule.
+        let nsap: Nsap = "47.0023.0000.0000.00b1.00".parse().unwrap();
+        assert_eq!(nsap.area_id, vec![0x00, 0x23]);
+        assert_eq!(nsap.area_id(), vec![0x47, 0x00, 0x23]);
+    }
 }

--- a/zebra-rs/src/isis/lsp.rs
+++ b/zebra-rs/src/isis/lsp.rs
@@ -747,8 +747,13 @@ pub fn lsp_generate(top: &mut IsisTop, level: Level, seq_floor: Option<u32>) -> 
     let mut anchors: Vec<IsisTlv> = Vec::new();
     let mut distributable: Vec<IsisTlv> = Vec::new();
 
-    // Area address.
-    let area_addr = top.config.net.area_id.clone();
+    // Area address. Use `area_id()` (AFI-prefixed) rather than the raw
+    // `area_id` field: the field holds only the area bytes, so emitting it
+    // directly drops the AFI and advertises e.g. `00.00` instead of
+    // `49.0000` for NET `49.0000...`. The Hello (`ifsm::hello_generate`)
+    // already uses the AFI-prefixed form, so this keeps the LSP's Area
+    // Address TLV consistent with the Hello's.
+    let area_addr = top.config.net.area_id();
     anchors.push(IsisTlvAreaAddr { area_addr }.into());
 
     // Supported protocol.


### PR DESCRIPTION
## Summary

`lsp_generate` built the LSP's Area Address TLV from the raw `net.area_id` field, which holds only the area octets. That drops the AFI: for NET `49.0000.0000.0000.xxxx.00` the self-LSP advertised area **`00.00`** instead of **`49.0000`**, while the Hello — which uses the `net.area_id()` accessor — correctly advertised `49.0000`.

For an L2-only adjacency the mismatch is harmless (L2 is area-independent), but it is wrong on the wire, would break an L1 adjacency, and pollutes the L2 database with a bogus area for the node. Found while interop-testing against Cisco IOS: the neighbour's `tcpdump` showed our LSP carrying `Area address (length: 2): 00.00` next to a Hello carrying `49.0000`.

## Change

Use the `net.area_id()` accessor (AFI + area octets) so the LSP's Area Address TLV matches the Hello's.

## Test plan

- New `nsap` unit test pins the field-vs-accessor distinction: `area_id` field = area octets only; `area_id()` = AFI-prefixed (`49.0000` / `47.0023`).
- **Verified live** on a single node (point-to-point circuit, to bypass LAN DIS-election gating that stalls single-node LSP origination): `show isis database detail` now reports `Area address: 49.0000` for NET `49.0000.0000.0000.00aa.00`.
- `cargo test --workspace --exclude bdd` green (37 suites); `cargo clippy --workspace --all-targets -- -D warnings` clean; `cargo fmt` applied.

Generated with [Claude Code](https://claude.com/claude-code)