### PR TITLE
bdd: per-namespace ZEBRA_OSPF_CHECKPOINT_DIR for each daemon

### DIFF
--- a/bdd/src/netns.rs
+++ b/bdd/src/netns.rs
@@ -360,8 +360,27 @@ pub async fn spawn_in_netns_env(
 ) -> Result<tokio::process::Child> {
     let mut c = Command::new("sudo");
     c.arg("ip").arg("netns").arg("exec").arg(netns);
-    if !env.is_empty() {
+
+    // Give each zebra-rs daemon a per-namespace OSPF graceful-restart
+    // checkpoint dir. The daemon otherwise reads/writes the fixed
+    // host-global /var/lib/zebra-rs/checkpoint/<proto>.cbor, but a netns
+    // isolates the network, NOT the filesystem — so under concurrency an
+    // OSPF daemon can restore a checkpoint written by a DIFFERENT
+    // namespace's daemon on startup (e.g. ospfv2_auth's node inheriting
+    // ospfv2_graceful_restart's node-b router-id 10.0.0.2 + LSDB), enter
+    // graceful-restart over a cold start, and mis-converge — the route to
+    // the peer's loopback never lands and a non-retrying ping fails.
+    // Keying the dir by the scoped namespace makes each daemon's
+    // checkpoint private while staying STABLE across a same-namespace
+    // restart, so graceful-restart resume still works; the daemon
+    // create_dir_all's it on write.
+    let ckpt = format!("ZEBRA_OSPF_CHECKPOINT_DIR=/tmp/zebra-rs-ckpt/{netns}");
+    let inject_ckpt = cmd == "zebra-rs";
+    if inject_ckpt || !env.is_empty() {
         c.arg("env");
+        if inject_ckpt {
+            c.arg(&ckpt);
+        }
         for (k, v) in env {
             c.arg(format!("{k}={v}"));
         }


### PR DESCRIPTION
## Summary

Fixes a cross-namespace test-isolation bug that flaked `@ospfv2_auth` in both concurrency=8 full-suite runs (clean at c=1).

The OSPF graceful-restart checkpoint defaults to the fixed host-global path `/var/lib/zebra-rs/checkpoint/<proto>.cbor`. A netns isolates the network but **not the filesystem**, so every BDD daemon across all namespaces and all concurrently-running features shares that one file. On startup the default OSPF instance unconditionally restores a fresh (<~90s) checkpoint if present — overwriting its own router-id with the file's and loading the foreign LSDB.

Under c=8, `ospfv2_auth`'s node `a` (router-id 10.0.0.1) booted while `ospfv2_graceful_restart`'s committed checkpoint (node `b`, router-id 10.0.0.2) was on disk, restored it, entered graceful-restart over a cold start, and mis-converged — the route to `b`'s loopback `10.0.0.2/32` never landed within the 30s wait and the non-retrying `ping a → 10.0.0.2` failed (then scenario 5 cascaded on the leaked daemon). `I stop zebra-rs` is `kill -9`, so a non-GR feature never has its own checkpoint — any file it restores is foreign.

**Fix:** inject a per-namespace `ZEBRA_OSPF_CHECKPOINT_DIR=/tmp/zebra-rs-ckpt/<scoped-ns>` (the env override the daemon already honours) at the single spawn choke point `spawn_in_netns_env`, gated on `cmd == "zebra-rs"`. Keyed by the scoped namespace so each daemon's checkpoint is private yet **stable across a same-namespace restart**, so graceful-restart resume still works (the daemon `create_dir_all`s it on write).

## Test plan

- `ospfv2_graceful_restart` / `ospfv3_graceful_restart` pass at c=1 — verified they resume from their own per-ns dir (`/tmp/zebra-rs-ckpt/<ns>/ospf.cbor`), not the shared path.
- **3× concurrent runs** of `@ospfv2_auth or @ospfv2_graceful_restart` at c=2: all pass 2/2, with **zero** `restored from checkpoint` entries in `ospfv2_auth`'s logs (the failing run had `restored … router-id=10.0.0.2`).
- `cargo fmt --check` clean. (BDD harness change only; not covered by the PR CI gates.)

Generated with [Claude Code](https://claude.com/claude-code)