### PR TITLE
bgp: EVPN Type-5 symmetric-IRB VXLAN tee to cradle

### DIFF
--- a/crates/bgp-packet/src/attrs/ext_com.rs
+++ b/crates/bgp-packet/src/attrs/ext_com.rs
@@ -236,6 +236,29 @@ impl ExtCommunityValue {
         })
     }
 
+    /// Build a Router's MAC Extended Community (RFC 9135 §6): EVPN high-type
+    /// (0x06) + Router's MAC sub-type (0x03), value = the 6-octet router MAC.
+    /// Attached to symmetric-IRB Type-2/Type-5 routes so a receiver can use
+    /// this PE's router MAC as the inner destination MAC when VXLAN-routing.
+    pub fn router_mac(mac: [u8; 6]) -> Self {
+        ExtCommunityValue {
+            high_type: ExtCommunityType::Evpn as u8,
+            low_type: EVPN_ROUTER_MAC_SUB_TYPE,
+            val: mac,
+        }
+    }
+
+    /// True iff this entry is a Router's MAC EC (EVPN 0x06 / sub-type 0x03).
+    pub fn is_router_mac(&self) -> bool {
+        self.high_type == ExtCommunityType::Evpn as u8 && self.low_type == EVPN_ROUTER_MAC_SUB_TYPE
+    }
+
+    /// Decode the Router's MAC EC (RFC 9135 §6): the 6-octet router MAC.
+    /// `None` for any non-matching EC.
+    pub fn as_router_mac(&self) -> Option<[u8; 6]> {
+        self.is_router_mac().then_some(self.val)
+    }
+
     /// Build an EVPN Layer-2 Attributes Extended Community (RFC 8214 §3.1):
     /// EVPN high-type (0x06) + Layer-2 Attributes sub-type (0x04). Carried on
     /// the **per-EVI** Ethernet A-D (Type-1) route of a VPWS service. The
@@ -361,6 +384,11 @@ const EVPN_ES_IMPORT_RT_SUB_TYPE: u8 = 0x02;
 /// ESI Label Extended Community sub-type (RFC 7432 §7.5), carried under the
 /// EVPN high-type (0x06).
 const EVPN_ESI_LABEL_SUB_TYPE: u8 = 0x01;
+
+/// Router's MAC Extended Community sub-type (RFC 9135 §6), carried under the
+/// EVPN high-type (0x06): the 6-octet value is the advertising PE's router
+/// MAC, used as the inner destination MAC for symmetric-IRB VXLAN routing.
+const EVPN_ROUTER_MAC_SUB_TYPE: u8 = 0x03;
 
 /// Layer-2 Attributes Extended Community sub-type (RFC 8214 §3.1), carried
 /// under the EVPN high-type (0x06).
@@ -672,6 +700,13 @@ impl fmt::Display for ExtCommunityValue {
                 f,
                 "es-import:{:02x}:{:02x}:{:02x}:{:02x}:{:02x}:{:02x}",
                 es[0], es[1], es[2], es[3], es[4], es[5]
+            )
+        } else if let Some(mac) = self.as_router_mac() {
+            // Router's MAC EC (RFC 9135 §6): the advertising PE's router MAC.
+            write!(
+                f,
+                "rmac:{:02x}:{:02x}:{:02x}:{:02x}:{:02x}:{:02x}",
+                mac[0], mac[1], mac[2], mac[3], mac[4], mac[5]
             )
         } else if let Some(es) = self.as_esi_label() {
             // ESI Label EC (RFC 7432 §7.5): redundancy mode + ESI label.
@@ -1346,6 +1381,32 @@ mod tests {
             val: [0; 6],
         };
         assert!(ExtCommunityValue::evi_rt_from_rt(&soo).is_none());
+    }
+
+    #[test]
+    fn router_mac_ec_round_trips() {
+        let mac = [0x02, 0x00, 0x00, 0x00, 0x01, 0xff];
+        let ec = ExtCommunityValue::router_mac(mac);
+        assert_eq!(ec.high_type, ExtCommunityType::Evpn as u8);
+        assert_eq!(ec.low_type, 0x03);
+        assert_eq!(ec.val, mac, "the 6-octet value is the MAC, no flags/pad");
+        assert!(ec.is_router_mac());
+        assert_eq!(ec.as_router_mac(), Some(mac));
+        assert_eq!(ec.to_string(), "rmac:02:00:00:00:01:ff");
+        // Wire round-trip: [0x06, 0x03, mac0..mac5].
+        let mut buf = BytesMut::new();
+        ec.encode(&mut buf);
+        assert_eq!(&buf[..], &[0x06, 0x03, 0x02, 0x00, 0x00, 0x00, 0x01, 0xff]);
+        let (_, parsed) = ExtCommunityValue::parse_be(&buf).expect("parse");
+        assert_eq!(parsed, ec);
+        assert_eq!(parsed.as_router_mac(), Some(mac));
+        // A standard RT is not a Router's MAC EC.
+        let rt = ExtCommunityValue {
+            high_type: 0x00,
+            low_type: 0x02,
+            val: [0; 6],
+        };
+        assert!(!rt.is_router_mac());
     }
 
     #[test]

--- a/proto/cradle.proto
+++ b/proto/cradle.proto
@@ -52,6 +52,13 @@ message Nexthop {
   string gtp_src = 13;   // outer IPv4 source (local N3/N9 tunnel address)
   string gtp_dst = 14;   // outer IPv4 destination (peer gNB / UPF address)
   uint32 gtp_teid = 15;  // GTP-U TEID
+  // EVPN symmetric-IRB VXLAN L3 encap: a non-empty vxlan_vtep makes this an
+  // NH_F_VXLAN nexthop that VXLAN-wraps the routed packet with vxlan_l3vni
+  // toward vxlan_vtep (inner dst MAC = vxlan_rmac, the remote PE's router
+  // MAC), over the v4 underlay gateway/oif. Mutually exclusive with segs/etc.
+  string vxlan_vtep = 16;
+  uint32 vxlan_l3vni = 17;
+  string vxlan_rmac = 18;
 }
 
 // A nexthop group for ECMP: ordered member nexthop ids. A route whose flags
@@ -131,7 +138,13 @@ message Srv6EncapSource { string addr = 1; }  // outer IPv6 SA for H.Encaps
 // domain by VNI).
 message Vni {
   uint32 vni  = 1;
-  uint32 vlan = 2;
+  uint32 vlan = 2;   // L2VNI bridge domain
+  // EVPN symmetric IRB (RFC 9135): an L3VNI binds the VNI to a VRF instead of
+  // a bridge domain — a received frame routes its inner IP in `vrf`, with this
+  // PE's router MAC `rmac`.
+  bool   l3   = 3;
+  uint32 vrf  = 4;
+  string rmac = 5;
 }
 
 message VniDel { uint32 vni = 1; }

--- a/zebra-rs/src/bgp/config.rs
+++ b/zebra-rs/src/bgp/config.rs
@@ -4509,6 +4509,14 @@ impl Bgp {
             super::vrf_config::config_vrf_evpn_advertise_ipv6,
         );
         self.callback_add(
+            "/router/bgp/vrf/evpn/l3vni",
+            super::vrf_config::config_vrf_evpn_l3vni,
+        );
+        self.callback_add(
+            "/router/bgp/vrf/evpn/router-mac",
+            super::vrf_config::config_vrf_evpn_router_mac,
+        );
+        self.callback_add(
             "/router/bgp/vrf/afi-safi/mup/dataplane",
             super::vrf_config::config_vrf_mup_dataplane,
         );

--- a/zebra-rs/src/bgp/inst.rs
+++ b/zebra-rs/src/bgp/inst.rs
@@ -5147,6 +5147,23 @@ impl Bgp {
         Some(nexthop)
     }
 
+    /// The `(l3vni, vtep, rmac)` for an EVPN symmetric-IRB (`encapsulation
+    /// vxlan`) VRF export, or `None` for a non-VXLAN VRF or one missing its
+    /// L3VNI / router-MAC / VTEP. The VTEP is the L3VNI vxlan device's local
+    /// address, registered in `local_vxlans` by `api_vxlan_add`.
+    fn vxlan_type5(&self, vrf: &str) -> Option<(u32, std::net::Ipv4Addr, [u8; 6])> {
+        let cfg = self.vrfs.get(vrf)?;
+        if cfg.encapsulation != super::vrf_config::BgpVrfEncapsulation::Vxlan {
+            return None;
+        }
+        let l3vni = cfg.l3vni?;
+        let rmac = cfg.router_mac?;
+        let std::net::IpAddr::V4(vtep) = self.local_vxlans.get(&l3vni)? else {
+            return None;
+        };
+        Some((l3vni, *vtep, rmac))
+    }
+
     fn process_vrf_global_msg(&mut self, msg: super::vrf::BgpGlobalMsg) {
         match msg {
             super::vrf::BgpGlobalMsg::Export {
@@ -5337,12 +5354,17 @@ impl Bgp {
                 // service label and (SRv6) Prefix-SID. Peer-gated by the
                 // L2VPN/EVPN AFI/SAFI, so it composes with the VPNv4 above.
                 if let Some(attr) = evpn_attr {
+                    let (t5_label, vxlan) = match self.vxlan_type5(&vrf) {
+                        Some((l3vni, vtep, rmac)) => (l3vni, Some((vtep, rmac))),
+                        None => (label, None),
+                    };
                     self.evpn_originate_type5(
                         rd,
                         ipnet::IpNet::V4(prefix),
                         attr,
-                        label,
+                        t5_label,
                         srv6_nexthop,
+                        vxlan,
                     );
                 }
             }
@@ -5609,12 +5631,17 @@ impl Bgp {
 
                 // EVPN Type-5 (IPv6 prefix) — composes with VPNv6 above.
                 if let Some(attr) = evpn_attr {
+                    let (t5_label, vxlan) = match self.vxlan_type5(&vrf) {
+                        Some((l3vni, vtep, rmac)) => (l3vni, Some((vtep, rmac))),
+                        None => (label, None),
+                    };
                     self.evpn_originate_type5(
                         rd,
                         ipnet::IpNet::V6(prefix),
                         attr,
-                        label,
+                        t5_label,
                         srv6_nexthop,
+                        vxlan,
                     );
                 }
             }

--- a/zebra-rs/src/bgp/inst.rs
+++ b/zebra-rs/src/bgp/inst.rs
@@ -3287,6 +3287,17 @@ impl Bgp {
                     .collect()
             })
             .unwrap_or_default();
+        // The EVPN Type-5 origination reads the same export RTs at emit time
+        // and lands them in `local_rib.evpn`, NOT `shard.v4vpn` — so the VPNv4
+        // retag below misses it. Re-originate each row's Type-5 too when the
+        // VRF advertises it, or a peer that only negotiated L2VPN/EVPN keeps a
+        // stale RT-less Type-5 and never imports the prefix.
+        let advertise_type5 = self
+            .vrfs
+            .get(vrf)
+            .map(|c| c.evpn_advertise_v4)
+            .unwrap_or(false);
+        let mut type5_work: Vec<(ipnet::Ipv4Net, bgp_packet::BgpAttr, u32)> = Vec::new();
         for (prefix, mut rib) in rows {
             let mut attr = (*rib.attr).clone();
             // Strip existing Route-Target ecoms (RFC 4360 sub-type 0x02)
@@ -3299,6 +3310,13 @@ impl Bgp {
             }
             let tagged = tag_attr_with_export_rts(attr, &export_rts);
             rib.attr = self.shard.intern(tagged);
+            if advertise_type5 {
+                type5_work.push((
+                    prefix,
+                    (*rib.attr).clone(),
+                    rib.label.map(|l| l.label).unwrap_or(0),
+                ));
+            }
             let (_, selected, _) = self.shard.update(Some(rd), prefix, rib);
             let mut top = super::peer::BgpTop {
                 router_id: &self.router_id,
@@ -3328,6 +3346,22 @@ impl Bgp {
                 super::route::ORIGINATED_PEER,
                 &mut top,
                 &mut self.peers,
+            );
+        }
+        // Re-originate the Type-5 rows now that the VPNv4 borrow is released.
+        for (prefix, mut attr, label) in type5_work {
+            let srv6_nexthop = self.srv6_export_nexthop(vrf, &mut attr);
+            let (t5_label, vxlan) = match self.vxlan_type5(vrf) {
+                Some((l3vni, vtep, rmac)) => (l3vni, Some((vtep, rmac))),
+                None => (label, None),
+            };
+            self.evpn_originate_type5(
+                rd,
+                ipnet::IpNet::V4(prefix),
+                attr,
+                t5_label,
+                srv6_nexthop,
+                vxlan,
             );
         }
     }
@@ -3363,6 +3397,15 @@ impl Bgp {
                     .collect()
             })
             .unwrap_or_default();
+        // Re-originate each row's EVPN Type-5 (v6) too — the VPNv6 retag below
+        // misses the Type-5 rows in `local_rib.evpn` (same reason as the v4
+        // path in `retag_vrf_exports_v4`).
+        let advertise_type5 = self
+            .vrfs
+            .get(vrf)
+            .map(|c| c.evpn_advertise_v6)
+            .unwrap_or(false);
+        let mut type5_work: Vec<(ipnet::Ipv6Net, bgp_packet::BgpAttr, u32)> = Vec::new();
         for (prefix, mut rib) in rows {
             let mut attr = (*rib.attr).clone();
             // Strip existing Route-Target ecoms (RFC 4360 sub-type 0x02)
@@ -3375,6 +3418,13 @@ impl Bgp {
             }
             let tagged = tag_attr_with_export_rts(attr, &export_rts);
             rib.attr = self.shard.intern(tagged);
+            if advertise_type5 {
+                type5_work.push((
+                    prefix,
+                    (*rib.attr).clone(),
+                    rib.label.map(|l| l.label).unwrap_or(0),
+                ));
+            }
             let (_, selected, _) = self.shard.update_v6vpn(rd, prefix, rib);
             let mut top = super::peer::BgpTop {
                 router_id: &self.router_id,
@@ -3403,6 +3453,22 @@ impl Bgp {
                 &selected,
                 &mut top,
                 &mut self.peers,
+            );
+        }
+        // Re-originate the Type-5 (v6 inner) rows now that the borrow ended.
+        for (prefix, mut attr, label) in type5_work {
+            let srv6_nexthop = self.srv6_export_nexthop(vrf, &mut attr);
+            let (t5_label, vxlan) = match self.vxlan_type5(vrf) {
+                Some((l3vni, vtep, rmac)) => (l3vni, Some((vtep, rmac))),
+                None => (label, None),
+            };
+            self.evpn_originate_type5(
+                rd,
+                ipnet::IpNet::V6(prefix),
+                attr,
+                t5_label,
+                srv6_nexthop,
+                vxlan,
             );
         }
     }
@@ -3516,6 +3582,25 @@ impl Bgp {
                     .collect();
                 for entry in stale {
                     self.evpn_originate_macip(&entry);
+                }
+                // A VRF may use this VNI as its EVPN symmetric-IRB L3VNI.
+                // Its Type-5 routes were originated with a router-id (not
+                // VTEP) next-hop if they raced ahead of this device; re-
+                // originate them now that the VTEP resolves.
+                // `retag_vrf_exports_*` re-emits the Type-5 with the current
+                // `vxlan_type5` (VTEP + RMAC).
+                let vxlan_vrfs: Vec<String> = self
+                    .vrfs
+                    .iter()
+                    .filter(|(_, c)| {
+                        c.encapsulation == super::vrf_config::BgpVrfEncapsulation::Vxlan
+                            && c.l3vni == Some(vni)
+                    })
+                    .map(|(n, _)| n.clone())
+                    .collect();
+                for vrf in vxlan_vrfs {
+                    self.retag_vrf_exports_v4(&vrf);
+                    self.retag_vrf_exports_v6(&vrf);
                 }
             }
             RibRx::VxlanDel { vni } => {
@@ -5268,6 +5353,7 @@ impl Bgp {
                     igmp_max_resp_time: 0,
                     ingress_region: None,
                     mup_st1: None,
+                    vxlan_vtep: None,
                 };
 
                 let (_, selected, _gen) = self.shard.update(Some(rd), prefix, rib);
@@ -5561,6 +5647,7 @@ impl Bgp {
                     igmp_max_resp_time: 0,
                     ingress_region: None,
                     mup_st1: None,
+                    vxlan_vtep: None,
                 };
 
                 let (_, selected, _gen) = self.shard.update_v6vpn(rd, prefix, rib);

--- a/zebra-rs/src/bgp/route.rs
+++ b/zebra-rs/src/bgp/route.rs
@@ -7146,9 +7146,7 @@ pub(crate) fn extract_router_mac_from_attr(attr: &BgpAttr) -> Option<[u8; 6]> {
 /// can build the VXLAN L3 encap toward the right outer destination. `None`
 /// for a plain VPN route (no VXLAN encap).
 pub(crate) fn attr_vxlan_vtep(attr: &BgpAttr) -> Option<Ipv4Addr> {
-    if extract_router_mac_from_attr(attr).is_none() {
-        return None;
-    }
+    extract_router_mac_from_attr(attr)?;
     match attr.nexthop {
         Some(BgpNexthop::Evpn(IpAddr::V4(vtep))) => Some(vtep),
         _ => None,

--- a/zebra-rs/src/bgp/route.rs
+++ b/zebra-rs/src/bgp/route.rs
@@ -593,9 +593,9 @@ fn vxlan_vpn_entry(
         return None;
     }
     let rmac = extract_router_mac_from_attr(&best.attr)?;
-    let IpAddr::V4(vtep) = extract_tunnel_endpoint(best)? else {
-        return None;
-    };
+    // The VTEP was captured from the EVPN next-hop at import time
+    // (`handle_import_v4`/`…v6`) before the next-hop was rewritten to self.
+    let vtep = best.vxlan_vtep?;
     let l3vni = best.label.map(|l| l.label).unwrap_or(0);
     transport
         .filter(|t| !t.is_empty())
@@ -1437,6 +1437,12 @@ pub struct BgpRib {
     /// helpers (`to_route_with`) and the SRv6 ST1→ISD FIB reconcile re-read
     /// them from the selected path. `None` on every non-ST1 row.
     pub mup_st1: Option<MupSt1Fields>,
+    /// EVPN symmetric-IRB (VXLAN) Type-5: the remote PE's VTEP, captured by
+    /// the VRF import (`handle_import_v4`/`…v6`) from the route's EVPN
+    /// next-hop before that next-hop is rewritten to self. The VRF FIB
+    /// install (`vxlan_vpn_entry`) reads it to build the VXLAN L3 encap's
+    /// outer destination. `None` on every non-VXLAN-IRB row.
+    pub vxlan_vtep: Option<Ipv4Addr>,
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -1538,6 +1544,7 @@ impl BgpRib {
             igmp_max_resp_time: 0,
             ingress_region: None,
             mup_st1: None,
+            vxlan_vtep: None,
         }
     }
 
@@ -7126,10 +7133,26 @@ fn evpn_l2_attr_mtu(attr: &BgpAttr) -> u16 {
 /// The Router's MAC of a received EVPN route (RFC 9135 §6): the advertising
 /// PE's router MAC, used as the inner destination MAC when VXLAN-routing to
 /// it (symmetric IRB). `None` when the EC is absent.
-fn extract_router_mac_from_attr(attr: &BgpAttr) -> Option<[u8; 6]> {
+pub(crate) fn extract_router_mac_from_attr(attr: &BgpAttr) -> Option<[u8; 6]> {
     attr.ecom
         .as_ref()
         .and_then(|ecom| ecom.0.iter().find_map(|v| v.as_router_mac()))
+}
+
+/// The remote VTEP of an EVPN symmetric-IRB (VXLAN) Type-5: present only
+/// when `attr` carries a Router's-MAC extended community AND an EVPN
+/// next-hop holding an IPv4 VTEP. The VRF import captures this before it
+/// rewrites the next-hop to self, so the FIB install (`vxlan_vpn_entry`)
+/// can build the VXLAN L3 encap toward the right outer destination. `None`
+/// for a plain VPN route (no VXLAN encap).
+pub(crate) fn attr_vxlan_vtep(attr: &BgpAttr) -> Option<Ipv4Addr> {
+    if extract_router_mac_from_attr(attr).is_none() {
+        return None;
+    }
+    match attr.nexthop {
+        Some(BgpNexthop::Evpn(IpAddr::V4(vtep))) => Some(vtep),
+        _ => None,
+    }
 }
 
 fn extract_tunnel_endpoint(rib: &BgpRib) -> Option<IpAddr> {

--- a/zebra-rs/src/bgp/route.rs
+++ b/zebra-rs/src/bgp/route.rs
@@ -534,6 +534,74 @@ pub(crate) fn build_srv6_vpn_fib_entry(
     Some(entry)
 }
 
+/// Build the FIB entry for an imported EVPN symmetric-IRB Type-5: a VXLAN L3
+/// encap toward the remote PE's VTEP with the L3VNI, inner dst MAC = the
+/// remote PE's router MAC — routed in the tenant VRF. The `transport` (the
+/// resolved underlay egress toward the VTEP) supplies `addr`/`ifindex`; the
+/// VTEP/L3VNI/RMAC ride the `NexthopUni.vxlan` field. Structural twin of
+/// `build_srv6_vpn_fib_entry`.
+pub(crate) fn build_vxlan_vpn_fib_entry(
+    vtep: std::net::Ipv4Addr,
+    l3vni: u32,
+    rmac: [u8; 6],
+    transport: &[rib::nht::ResolvedNexthop],
+) -> Option<rib::entry::RibEntry> {
+    if transport.is_empty() {
+        return None;
+    }
+    let mk_uni = |egress: &rib::nht::ResolvedNexthop| {
+        let mut uni = rib::NexthopUni::new(egress.addr, 0, Vec::new());
+        uni.vxlan = Some(rib::VxlanL3Encap {
+            remote_vtep: vtep,
+            l3vni,
+            remote_rmac: rmac,
+        });
+        if egress.ifindex != 0 {
+            uni.ifindex_origin = Some(egress.ifindex);
+        }
+        uni.valid = true;
+        uni
+    };
+    let nexthop = if transport.len() == 1 {
+        rib::Nexthop::Uni(mk_uni(&transport[0]))
+    } else {
+        let mut multi = rib::NexthopMulti::default();
+        for egress in transport {
+            multi.nexthops.push(mk_uni(egress));
+        }
+        rib::Nexthop::Multi(multi)
+    };
+    let mut entry = rib::entry::RibEntry::new(rib::RibType::Bgp);
+    entry.distance = 200;
+    entry.metric = 0;
+    entry.valid = true;
+    entry.nexthop = nexthop;
+    Some(entry)
+}
+
+/// The VXLAN symmetric-IRB FIB entry for an imported Type-5, or `None` if
+/// this isn't one. Keyed entirely on `best`: an imported (`Originated`)
+/// route carrying a Router's-MAC EC and an EVPN (VTEP) next-hop — only
+/// symmetric-IRB routes carry the RMAC EC, so this is mutually exclusive
+/// with the SRv6-SID and MPLS-label paths. Family-agnostic (the inner may
+/// be v4 or v6; the outer VTEP is always IPv4).
+fn vxlan_vpn_entry(
+    best: &BgpRib,
+    transport: Option<&[rib::nht::ResolvedNexthop]>,
+) -> Option<rib::entry::RibEntry> {
+    if best.typ != BgpRibType::Originated {
+        return None;
+    }
+    let rmac = extract_router_mac_from_attr(&best.attr)?;
+    let IpAddr::V4(vtep) = extract_tunnel_endpoint(best)? else {
+        return None;
+    };
+    let l3vni = best.label.map(|l| l.label).unwrap_or(0);
+    transport
+        .filter(|t| !t.is_empty())
+        .and_then(|t| build_vxlan_vpn_fib_entry(vtep, l3vni, rmac, t))
+}
+
 /// Whether `best` should install as a labelled VPN tunnel entry: an
 /// imported route (`Originated`) for which the VRF holds a resolved
 /// `transport`. `transport` is `None` outside a VRF (global instance),
@@ -610,6 +678,11 @@ fn select_fib_entry_v4(
     transport: Option<&[rib::nht::ResolvedNexthop]>,
     nht_transport: Option<&[rib::nht::ResolvedNexthop]>,
 ) -> Option<rib::entry::RibEntry> {
+    // EVPN/VXLAN symmetric IRB: an imported Type-5 carrying a Router's-MAC EC
+    // installs a VXLAN L3 encap entry toward the remote VTEP with the L3VNI.
+    if let Some(entry) = vxlan_vpn_entry(best, transport) {
+        return Some(entry);
+    }
     // SRv6 L3VPN: an imported route carrying an SRv6 L3 Service SID
     // installs an H.Encap entry toward that SID instead of an MPLS
     // label stack — gated on the underlay next-hop resolving, like the
@@ -848,6 +921,10 @@ fn select_fib_entry_v6(
     transport: Option<&[rib::nht::ResolvedNexthop]>,
     nht_transport: Option<&[rib::nht::ResolvedNexthop]>,
 ) -> Option<rib::entry::RibEntry> {
+    // EVPN/VXLAN symmetric IRB (v6 inner over an IPv4 VXLAN underlay).
+    if let Some(entry) = vxlan_vpn_entry(best, transport) {
+        return Some(entry);
+    }
     // SRv6 L3VPN (VPNv6 over an SRv6 underlay) — see `select_fib_entry_v4`.
     if best.typ == BgpRibType::Originated
         && let Some((sid, _behavior)) = best.attr.srv6_l3_sid()
@@ -7044,6 +7121,15 @@ fn evpn_l2_attr_mtu(attr: &BgpAttr) -> u16 {
         .and_then(|ecom| ecom.0.iter().find_map(|v| v.as_l2_attr()))
         .map(|a| a.mtu)
         .unwrap_or(0)
+}
+
+/// The Router's MAC of a received EVPN route (RFC 9135 §6): the advertising
+/// PE's router MAC, used as the inner destination MAC when VXLAN-routing to
+/// it (symmetric IRB). `None` when the EC is absent.
+fn extract_router_mac_from_attr(attr: &BgpAttr) -> Option<[u8; 6]> {
+    attr.ecom
+        .as_ref()
+        .and_then(|ecom| ecom.0.iter().find_map(|v| v.as_router_mac()))
 }
 
 fn extract_tunnel_endpoint(rib: &BgpRib) -> Option<IpAddr> {
@@ -15143,14 +15229,22 @@ impl Bgp {
         mut attr: BgpAttr,
         label: u32,
         srv6_nexthop: Option<std::net::Ipv6Addr>,
+        vxlan: Option<(Ipv4Addr, [u8; 6])>,
     ) {
         let prefix = EvpnPrefix::IpPrefix {
             eth_tag: 0,
             prefix: net,
         };
-        let nexthop = match srv6_nexthop {
-            Some(v6) => IpAddr::V6(v6),
-            None => IpAddr::V4(self.router_id),
+        // EVPN symmetric IRB (RFC 9135): the nexthop is this PE's VTEP and a
+        // Router's-MAC EC carries its router MAC; the label (=L3VNI) rides the
+        // NLRI. Otherwise SRv6 (v6 SID nexthop) or MPLS/VXLAN-L2 (router-id).
+        let nexthop = match (vxlan, srv6_nexthop) {
+            (Some((vtep, rmac)), _) => {
+                attr_add_ecom(&mut attr, ExtCommunityValue::router_mac(rmac));
+                IpAddr::V4(vtep)
+            }
+            (None, Some(v6)) => IpAddr::V6(v6),
+            (None, None) => IpAddr::V4(self.router_id),
         };
         attr.nexthop = Some(BgpNexthop::Evpn(nexthop));
         // MPLS: the service label rides on the BgpRib (mirrored by the

--- a/zebra-rs/src/bgp/vrf/inst.rs
+++ b/zebra-rs/src/bgp/vrf/inst.rs
@@ -1286,6 +1286,12 @@ impl BgpVrf {
         label: u32,
         transport: &[crate::rib::nht::ResolvedNexthop],
     ) {
+        // Capture an EVPN symmetric-IRB (VXLAN) route's remote VTEP from its
+        // EVPN next-hop BEFORE the rewrite below drops it — the FIB install
+        // (`vxlan_vpn_entry`) reads it back to build the VXLAN L3 encap. The
+        // next-hop itself is still rewritten to self so v4-unicast best-path
+        // and CE re-advertise see a plain reachable address.
+        let vxlan_vtep = super::super::route::attr_vxlan_vtep(&attr);
         // Rewrite the next-hop to "self" (the VRF's router-id)
         // so CE peers receive a reachable v4 address.
         attr.nexthop = Some(bgp_packet::BgpNexthop::Ipv4(self.router_id));
@@ -1339,6 +1345,7 @@ impl BgpVrf {
             igmp_max_resp_time: 0,
             ingress_region: None,
             mup_st1: None,
+            vxlan_vtep,
         };
 
         let (_, selected, _gen) = self.shard.update(None, prefix, rib);
@@ -1524,6 +1531,10 @@ impl BgpVrf {
         label: u32,
         transport: &[crate::rib::nht::ResolvedNexthop],
     ) {
+        // Capture an EVPN symmetric-IRB (VXLAN) route's remote VTEP (always
+        // IPv4, even for a v6 inner prefix) before clearing the next-hop; the
+        // FIB install reads it back to build the VXLAN L3 encap.
+        let vxlan_vtep = super::super::route::attr_vxlan_vtep(&attr);
         attr.nexthop = None;
         let interned = self.shard.intern(attr);
 
@@ -1572,6 +1583,7 @@ impl BgpVrf {
             igmp_max_resp_time: 0,
             ingress_region: None,
             mup_st1: None,
+            vxlan_vtep,
         };
 
         let (_, selected, _gen) = self.shard.update_v6(prefix, rib);
@@ -1992,6 +2004,7 @@ impl BgpVrf {
             igmp_max_resp_time: 0,
             ingress_region: None,
             mup_st1: None,
+            vxlan_vtep: None,
         }
     }
 

--- a/zebra-rs/src/bgp/vrf_config.rs
+++ b/zebra-rs/src/bgp/vrf_config.rs
@@ -69,6 +69,9 @@ pub enum BgpVrfEncapsulation {
     #[default]
     Mpls,
     Srv6,
+    /// EVPN symmetric IRB (RFC 9135): a Type-5 carries an L3VNI (the NLRI
+    /// label) + this PE's router MAC (a Router's-MAC EC), routed over VXLAN.
+    Vxlan,
 }
 
 impl BgpVrfEncapsulation {
@@ -76,6 +79,7 @@ impl BgpVrfEncapsulation {
         match s {
             "mpls" => Some(Self::Mpls),
             "srv6" => Some(Self::Srv6),
+            "vxlan" => Some(Self::Vxlan),
             _ => None,
         }
     }
@@ -253,6 +257,12 @@ pub struct BgpVrfConfig {
     pub evpn_advertise_v4: bool,
     /// Advertise this VRF's IPv6 routes as EVPN Type-5 (RFC 9136).
     pub evpn_advertise_v6: bool,
+    /// EVPN symmetric-IRB L3VNI for this VRF (RFC 9135): stamped as the
+    /// Type-5 NLRI label. Mirrors `evpn l3vni` in zebra-bgp-vrf.yang.
+    pub l3vni: Option<u32>,
+    /// This PE's router MAC for the L3VNI — attached to originated Type-5
+    /// routes as a Router's-MAC EC. Mirrors `evpn router-mac`.
+    pub router_mac: Option<[u8; 6]>,
     /// Inter-AS MPLS/VPN Option AB (RFC 4364 hybrid of §10a/§10b).
     /// Mirrors `inter-as-hybrid` in zebra-bgp-vrf.yang. When set, the
     /// VRF re-exports the VPNv4 routes it *imports* (not only `network`/
@@ -976,6 +986,33 @@ pub fn config_vrf_evpn_advertise_ipv6(bgp: &mut Bgp, mut args: Args, op: ConfigO
     match op {
         ConfigOp::Set => cfg.evpn_advertise_v6 = args.boolean()?,
         ConfigOp::Delete => cfg.evpn_advertise_v6 = false,
+        _ => {}
+    }
+    Some(())
+}
+
+/// `set router bgp vrf <NAME> evpn l3vni <VNI>`.
+pub fn config_vrf_evpn_l3vni(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Option<()> {
+    let name = args.string()?;
+    let cfg = vrf_entry(bgp, name);
+    match op {
+        ConfigOp::Set => cfg.l3vni = Some(args.u32()?),
+        ConfigOp::Delete => cfg.l3vni = None,
+        _ => {}
+    }
+    Some(())
+}
+
+/// `set router bgp vrf <NAME> evpn router-mac <MAC>` (symmetric IRB).
+pub fn config_vrf_evpn_router_mac(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Option<()> {
+    let name = args.string()?;
+    let cfg = vrf_entry(bgp, name);
+    match op {
+        ConfigOp::Set => {
+            let mac: crate::rib::MacAddr = args.string()?.parse().ok()?;
+            cfg.router_mac = Some(mac.octets());
+        }
+        ConfigOp::Delete => cfg.router_mac = None,
         _ => {}
     }
     Some(())

--- a/zebra-rs/src/fib/cradle.rs
+++ b/zebra-rs/src/fib/cradle.rs
@@ -29,11 +29,25 @@ const FIB_F_ECMP: u32 = 1 << 3;
 pub const MPLS_OP_SWAP: u32 = 0;
 pub const MPLS_OP_POP_L3: u32 = 1;
 
+/// An EVPN symmetric-IRB VXLAN L3 encap leg: `(remote VTEP, L3VNI, remote
+/// router MAC)`. `Some` on a member marks it a VXLAN-encapsulated nexthop
+/// (the underlay adjacency rides in the leg's `gateway`/`oif`); mutually
+/// exclusive with `segs`/`labels`.
+pub type VxlanLeg = (std::net::Ipv4Addr, u32, [u8; 6]);
+
 /// A teed nexthop leaf: `(link gateway, oif, MPLS out-labels, SRv6 segment
-/// list, SRv6 encap mode)`. A non-empty `segs` makes it an SRv6 (v6-underlay)
-/// nexthop regardless of the route's family; `labels` and `segs` are mutually
-/// exclusive.
-pub type Leaf = (Option<IpAddr>, u32, Vec<u32>, Vec<Ipv6Addr>, u32);
+/// list, SRv6 encap mode, VXLAN L3 encap)`. A non-empty `segs` makes it an
+/// SRv6 (v6-underlay) nexthop regardless of the route's family; a `Some`
+/// VXLAN leg makes it a symmetric-IRB VXLAN nexthop; `labels`/`segs`/`vxlan`
+/// are mutually exclusive.
+pub type Leaf = (
+    Option<IpAddr>,
+    u32,
+    Vec<u32>,
+    Vec<Ipv6Addr>,
+    u32,
+    Option<VxlanLeg>,
+);
 
 /// A teed route member: a leaf plus an optional fast-reroute backup leaf
 /// (`Nexthop::Protect` — the backup carries the TI-LFA repair: packed uSID
@@ -45,6 +59,7 @@ type Member = (
     Vec<u32>,
     Vec<Ipv6Addr>,
     u32,
+    Option<VxlanLeg>,
     Option<Leaf>,
 );
 
@@ -83,6 +98,8 @@ struct CradleMirror {
     /// L2VNI ↔ bridge-domain bindings (bd == vni today) for `SetVni` replay,
     /// and the fabric-wide local VTEP source for `SetVtepSource`.
     vnis: HashMap<u32, u32>,
+    /// L3VNI ↔ VRF bindings (symmetric IRB): vni → (vrf_table_id, rmac).
+    vnis_l3: HashMap<u32, (u32, [u8; 6])>,
     vtep_source: Option<Ipv4Addr>,
     /// (AC port, vid, dx2v table) → (remote SID, local decap SID).
     xconnects: HashMap<(String, u16, u32), (Ipv6Addr, Option<Ipv6Addr>)>,
@@ -163,6 +180,9 @@ pub struct CradleFib {
     /// GTP-U encap nexthop dedup:
     /// `(gtp_src, gtp_dst, teid, underlay gateway, oif) -> id`.
     nh_ids_gtp: Arc<Mutex<HashMap<([u8; 4], [u8; 4], u32, u32, u32), u32>>>,
+    /// EVPN symmetric-IRB VXLAN L3 nexthop dedup:
+    /// `(underlay gateway, oif, vtep, l3vni, rmac) -> id`.
+    nh_ids_vxlan: Arc<Mutex<HashMap<([u8; 4], u32, [u8; 4], u32, [u8; 6]), u32>>>,
     next_id: Arc<AtomicU32>,
     /// The SRv6 H.Encaps source is pushed once (best-effort).
     encap_src_set: Arc<std::sync::atomic::AtomicBool>,
@@ -303,6 +323,7 @@ impl CradleFib {
             nh_ids6: Arc::new(Mutex::new(HashMap::new())),
             nh_ids_srv6: Arc::new(Mutex::new(HashMap::new())),
             nh_ids_gtp: Arc::new(Mutex::new(HashMap::new())),
+            nh_ids_vxlan: Arc::new(Mutex::new(HashMap::new())),
             next_id: Arc::new(AtomicU32::new(1)),
             encap_src_set: Arc::new(std::sync::atomic::AtomicBool::new(false)),
             mirror: Arc::new(Mutex::new(CradleMirror::default())),
@@ -408,6 +429,7 @@ impl CradleFib {
         self.nh_ids6.lock().await.clear();
         self.nh_ids_srv6.lock().await.clear();
         self.nh_ids_gtp.lock().await.clear();
+        self.nh_ids_vxlan.lock().await.clear();
         self.encap_src_set.store(false, Ordering::Relaxed);
         // Snapshot, then replay without holding the lock — the methods
         // below re-record into the mirror as they run (same values).
@@ -449,6 +471,9 @@ impl CradleFib {
         }
         for (vni, vlan) in &m.vnis {
             self.set_vni(*vni, *vlan).await;
+        }
+        for (vni, (vrf, rmac)) in &m.vnis_l3 {
+            self.set_vni_l3(*vni, *vrf, *rmac).await;
         }
         for ((vni, mac), vtep) in &m.fdb_vxlan {
             self.fdb_add_vxlan(*vni, *mac, *vtep).await;
@@ -540,6 +565,9 @@ impl CradleFib {
                 gtp_src: String::new(),
                 gtp_dst: String::new(),
                 gtp_teid: 0,
+                vxlan_vtep: String::new(),
+                vxlan_l3vni: 0,
+                vxlan_rmac: String::new(),
             })
             .await?;
         self.nh_ids.lock().await.insert(key, id);
@@ -582,9 +610,65 @@ impl CradleFib {
                 gtp_src: String::new(),
                 gtp_dst: String::new(),
                 gtp_teid: 0,
+                vxlan_vtep: String::new(),
+                vxlan_l3vni: 0,
+                vxlan_rmac: String::new(),
             })
             .await?;
         self.nh_ids_srv6.lock().await.insert(key, id);
+        Ok(id)
+    }
+
+    /// Resolve (creating if needed) an EVPN symmetric-IRB VXLAN L3 nexthop id:
+    /// a v4 underlay adjacency (`gw`/`oif`) that VXLAN-encapsulates the routed
+    /// packet with `l3vni` toward `vtep`, inner dst MAC = `rmac`.
+    async fn vxlan_nexthop_id(
+        &self,
+        gw: Option<Ipv4Addr>,
+        oif: u32,
+        vtep: Ipv4Addr,
+        l3vni: u32,
+        rmac: [u8; 6],
+    ) -> anyhow::Result<u32> {
+        let key = (
+            gw.map(|a| a.octets()).unwrap_or([0; 4]),
+            oif,
+            vtep.octets(),
+            l3vni,
+            rmac,
+        );
+        {
+            let ids = self.nh_ids_vxlan.lock().await;
+            if let Some(id) = ids.get(&key) {
+                return Ok(*id);
+            }
+        }
+        let id = self.next_id.fetch_add(1, Ordering::Relaxed);
+        let rmac_str = format!(
+            "{:02x}:{:02x}:{:02x}:{:02x}:{:02x}:{:02x}",
+            rmac[0], rmac[1], rmac[2], rmac[3], rmac[4], rmac[5]
+        );
+        self.client()
+            .await?
+            .set_nexthop(pb::Nexthop {
+                id,
+                gateway: gw.map(|a| a.to_string()).unwrap_or_default(),
+                oif: String::new(),
+                oif_index: oif,
+                v6: false,
+                labels: Vec::new(),
+                segs: Vec::new(),
+                encap_mode: 0,
+                backup_id: 0,
+                gtp_src: String::new(),
+                gtp_dst: String::new(),
+                gtp_teid: 0,
+                vxlan_vtep: vtep.to_string(),
+                vxlan_l3vni: l3vni,
+                vxlan_rmac: rmac_str,
+            })
+            .await?;
+        self.nh_ids_vxlan.lock().await.insert(key, id);
         Ok(id)
     }
 
@@ -592,18 +676,28 @@ impl CradleFib {
     /// `segs`) are always v6-underlay; otherwise the family follows the
     /// gateway, or `route_v6` for an on-link (gateway-less) member.
     async fn member_nexthop_id(&self, m: &Member, route_v6: bool) -> anyhow::Result<u32> {
-        let (gw, oif, labels, segs, encap_mode, backup) = m;
+        let (gw, oif, labels, segs, encap_mode, vxlan, backup) = m;
         // Fast-reroute: resolve the backup leaf first (the TI-LFA repair —
         // packed carriers + H.Insert for SRv6, the repair label stack for
         // SR-MPLS), then hang its id off the primary so the datapath fails
         // over on link-down.
         let backup_id = match backup {
-            Some((bgw, boif, blabels, bsegs, bmode)) => {
+            Some((bgw, boif, blabels, bsegs, bmode, _bvxlan)) => {
                 self.leaf_nexthop_id(bgw, *boif, blabels, bsegs, *bmode, route_v6)
                     .await?
             }
             None => 0,
         };
+        // EVPN symmetric-IRB VXLAN L3 nexthop: the underlay adjacency
+        // (`gw`/`oif`) carries the VXLAN-wrapped inner packet toward the
+        // remote VTEP with the L3VNI + remote router MAC.
+        if let Some((vtep, l3vni, rmac)) = vxlan {
+            let gw4 = match gw {
+                Some(IpAddr::V4(a)) => Some(*a),
+                _ => None,
+            };
+            return self.vxlan_nexthop_id(gw4, *oif, *vtep, *l3vni, *rmac).await;
+        }
         if !segs.is_empty() {
             let gw6 = match gw {
                 Some(IpAddr::V6(a)) => Some(*a),
@@ -762,6 +856,9 @@ impl CradleFib {
                 gtp_src: String::new(),
                 gtp_dst: String::new(),
                 gtp_teid: 0,
+                vxlan_vtep: String::new(),
+                vxlan_l3vni: 0,
+                vxlan_rmac: String::new(),
             })
             .await?;
         self.nh_ids6.lock().await.insert(key, id);
@@ -1157,6 +1254,9 @@ impl CradleFib {
                 gtp_src: gtp_src.to_string(),
                 gtp_dst: gtp_dst.to_string(),
                 gtp_teid: teid,
+                vxlan_vtep: String::new(),
+                vxlan_l3vni: 0,
+                vxlan_rmac: String::new(),
             })
             .await?;
         self.nh_ids_gtp.lock().await.insert(key, id);
@@ -1498,7 +1598,16 @@ impl CradleFib {
     pub async fn set_vni(&self, vni: u32, vlan: u32) {
         self.mirror.lock().await.vnis.insert(vni, vlan);
         let result = async {
-            self.client().await?.set_vni(pb::Vni { vni, vlan }).await?;
+            self.client()
+                .await?
+                .set_vni(pb::Vni {
+                    vni,
+                    vlan,
+                    l3: false,
+                    vrf: 0,
+                    rmac: String::new(),
+                })
+                .await?;
             anyhow::Ok(())
         }
         .await;
@@ -1507,10 +1616,41 @@ impl CradleFib {
         }
     }
 
+    /// Bind an L3VNI to a VRF with this PE's router MAC (EVPN symmetric IRB):
+    /// a received VXLAN frame with `vni` routes its inner IP in `vrf`.
+    pub async fn set_vni_l3(&self, vni: u32, vrf: u32, rmac: [u8; 6]) {
+        self.mirror.lock().await.vnis_l3.insert(vni, (vrf, rmac));
+        let rmac_str = format!(
+            "{:02x}:{:02x}:{:02x}:{:02x}:{:02x}:{:02x}",
+            rmac[0], rmac[1], rmac[2], rmac[3], rmac[4], rmac[5]
+        );
+        let result = async {
+            self.client()
+                .await?
+                .set_vni(pb::Vni {
+                    vni,
+                    vlan: 0,
+                    l3: true,
+                    vrf,
+                    rmac: rmac_str,
+                })
+                .await?;
+            anyhow::Ok(())
+        }
+        .await;
+        if let Err(e) = result {
+            tracing::warn!("fib: cradle set_vni_l3 {vni} vrf {vrf} failed: {e}");
+        }
+    }
+
     /// Remove an L2VNI binding (the VXLAN device is gone). The fabric VTEP
     /// source is left as-is — it is fabric-wide, not per-VNI.
     pub async fn del_vni(&self, vni: u32) {
-        self.mirror.lock().await.vnis.remove(&vni);
+        {
+            let mut m = self.mirror.lock().await;
+            m.vnis.remove(&vni);
+            m.vnis_l3.remove(&vni);
+        }
         let result = async {
             self.client().await?.del_vni(pb::VniDel { vni }).await?;
             anyhow::Ok(())

--- a/zebra-rs/src/fib/netlink/handle.rs
+++ b/zebra-rs/src/fib/netlink/handle.rs
@@ -381,6 +381,7 @@ type CradleMember = (
     Vec<u32>,
     Vec<std::net::Ipv6Addr>,
     u32,
+    Option<crate::fib::cradle::VxlanLeg>,
     Option<crate::fib::cradle::Leaf>,
 );
 
@@ -396,11 +397,19 @@ fn cradle_members(nexthop: &Nexthop) -> Vec<CradleMember> {
             a => Some(a),
         };
         let encap_mode = crate::fib::cradle::srv6_encap_mode(u.encap_type);
-        (gw, oif, u.mpls_label.clone(), u.segs.clone(), encap_mode)
+        let vxlan = u.vxlan.map(|v| (v.remote_vtep, v.l3vni, v.remote_rmac));
+        (
+            gw,
+            oif,
+            u.mpls_label.clone(),
+            u.segs.clone(),
+            encap_mode,
+            vxlan,
+        )
     }
     fn member(u: &NexthopUni) -> CradleMember {
-        let (gw, oif, labels, segs, encap_mode) = leaf(u);
-        (gw, oif, labels, segs, encap_mode, None)
+        let (gw, oif, labels, segs, encap_mode, vxlan) = leaf(u);
+        (gw, oif, labels, segs, encap_mode, vxlan, None)
     }
     match nexthop {
         Nexthop::Uni(u) => vec![member(u)],
@@ -408,7 +417,7 @@ fn cradle_members(nexthop: &Nexthop) -> Vec<CradleMember> {
         // eBPF forward falls back to `bpf_redirect_neigh` on the
         // destination itself, which also drives kernel ND — so delivery
         // to directly-connected hosts needs no pinned neighbors.
-        Nexthop::Link(ifindex) => vec![(None, *ifindex, vec![], vec![], 0, None)],
+        Nexthop::Link(ifindex) => vec![(None, *ifindex, vec![], vec![], 0, None, None)],
         Nexthop::Multi(m) => m.nexthops.iter().map(member).collect(),
         Nexthop::List(l) => l
             .nexthops
@@ -430,7 +439,7 @@ fn cradle_members(nexthop: &Nexthop) -> Vec<CradleMember> {
             match &pro.primary {
                 NexthopMember::Uni(u) => {
                     let mut m = member(u);
-                    m.5 = backup;
+                    m.6 = backup;
                     vec![m]
                 }
                 NexthopMember::Multi(mm) => mm.nexthops.iter().map(member).collect(),
@@ -585,6 +594,27 @@ impl FibHandle {
             && let IpAddr::V4(v4) = local
         {
             cradle.set_vni(vni, vni).await;
+            cradle.set_vtep_source(v4).await;
+        }
+    }
+
+    /// Declare an EVPN/VXLAN L3VNI (symmetric IRB, RFC 9135) to the cradle
+    /// data plane: bind the VNI to a tenant `vrf_table_id` with this PE's
+    /// router-MAC so a received VXLAN frame on `vni` routes its inner IP in
+    /// that VRF, and set the fabric-wide local VTEP source. Only an IPv4
+    /// VTEP is a cradle datapath capability today; an IPv6-local device is a
+    /// no-op here. No-op when cradle is disabled.
+    pub async fn cradle_vni_register_l3(
+        &self,
+        vni: u32,
+        local: IpAddr,
+        vrf_table_id: u32,
+        rmac: [u8; 6],
+    ) {
+        if let Some(cradle) = &self.cradle
+            && let IpAddr::V4(v4) = local
+        {
+            cradle.set_vni_l3(vni, vrf_table_id, rmac).await;
             cradle.set_vtep_source(v4).await;
         }
     }

--- a/zebra-rs/src/rib/inst.rs
+++ b/zebra-rs/src/rib/inst.rs
@@ -2641,6 +2641,8 @@ impl Rib {
                     local_addr: config.local_addr,
                     dport: config.dport,
                     addr_gen_mode: config.addr_gen_mode,
+                    vrf: config.vrf.clone(),
+                    router_mac: config.router_mac,
                 };
                 self.vxlan.insert(name.clone(), vxlan.clone());
                 self.fib_handle.vxlan_add(&vxlan).await;

--- a/zebra-rs/src/rib/inst.rs
+++ b/zebra-rs/src/rib/inst.rs
@@ -2815,6 +2815,32 @@ impl Rib {
                 for (ifname, vrf) in to_replay {
                     let _ = self.tx.send(Message::LinkVrfBind { ifname, vrf });
                 }
+                // Re-tee any EVPN symmetric-IRB L3VNI vxlan device bound to
+                // this VRF. Its cradle SetVni-L3 was deferred (not registered
+                // as an L2VNI) when the device's link appeared before this
+                // VRF was known (config-order race); now that the VRF
+                // resolves, register the L3 binding.
+                let l3_devs: Vec<(String, u32, IpAddr)> = self
+                    .vxlan
+                    .values()
+                    .filter(|v| v.vrf.as_deref() == Some(name.as_str()))
+                    .filter_map(|v| {
+                        let vni = v.vni?;
+                        let local = self
+                            .links
+                            .values()
+                            .find(|l| l.name == v.name)
+                            .and_then(|l| l.vxlan_local)?;
+                        Some((v.name.clone(), vni, local))
+                    })
+                    .collect();
+                for (dev, vni, local) in l3_devs {
+                    if let Some((vrf_table_id, rmac)) = self.vxlan_l3_binding(&dev) {
+                        self.fib_handle
+                            .cradle_vni_register_l3(vni, local, vrf_table_id, rmac)
+                            .await;
+                    }
+                }
                 // Compute the new VRF's effective router-id (members
                 // may already be enslaved when adopting a pre-existing
                 // kernel VRF) — and re-evaluate the global pick, which

--- a/zebra-rs/src/rib/link.rs
+++ b/zebra-rs/src/rib/link.rs
@@ -470,7 +470,7 @@ impl Rib {
     /// is the explicit `router-mac` leaf, else the VRF master device's MAC.
     /// Returns `None` for a plain L2VNI device (no VRF binding), an
     /// unresolved VRF, or when no MAC is available yet.
-    fn vxlan_l3_binding(&self, name: &str) -> Option<(u32, [u8; 6])> {
+    pub(crate) fn vxlan_l3_binding(&self, name: &str) -> Option<(u32, [u8; 6])> {
         let dev = self.vxlan.get(name)?;
         let vrf_name = dev.vrf.as_ref()?;
         let vrf = self.vrfs.get(vrf_name)?;
@@ -777,9 +777,14 @@ impl Rib {
                     self.fib_handle
                         .cradle_vni_register_l3(new, local, vrf_table_id, rmac)
                         .await;
-                } else {
+                } else if self.vxlan.get(&name).is_none_or(|v| v.vrf.is_none()) {
+                    // Plain L2VNI: no tenant-VRF binding configured.
                     self.fib_handle.cradle_vni_register(new, local).await;
                 }
+                // else: configured as an L3VNI but the VRF isn't resolved
+                // yet (config-order race). Don't register it as an L2VNI;
+                // the VrfAdd handler re-tees the L3 binding when the VRF
+                // appears.
             }
         }
 

--- a/zebra-rs/src/rib/link.rs
+++ b/zebra-rs/src/rib/link.rs
@@ -464,6 +464,22 @@ pub fn link_addr_del(link: &mut Link, addr: LinkAddr) -> Option<()> {
 }
 
 impl Rib {
+    /// Resolve the EVPN symmetric-IRB L3VNI binding for a VXLAN device by
+    /// name: if the operator bound it to a tenant VRF (`vxlan <name> vrf
+    /// <vrf>`), return that VRF's `(table_id, router_mac)`. The router-MAC
+    /// is the explicit `router-mac` leaf, else the VRF master device's MAC.
+    /// Returns `None` for a plain L2VNI device (no VRF binding), an
+    /// unresolved VRF, or when no MAC is available yet.
+    fn vxlan_l3_binding(&self, name: &str) -> Option<(u32, [u8; 6])> {
+        let dev = self.vxlan.get(name)?;
+        let vrf_name = dev.vrf.as_ref()?;
+        let vrf = self.vrfs.get(vrf_name)?;
+        let rmac = dev
+            .router_mac
+            .or_else(|| self.links.get(&vrf.ifindex).and_then(|l| l.mac))?;
+        Some((vrf.table_id, rmac.octets()))
+    }
+
     pub async fn link_add(&mut self, fib_link: FibLink) {
         // `external vnifilter` VXLAN devices (the EVPN model) carry no
         // fixed kernel VNI — `IFLA_VXLAN_ID` is 0. Source the real VNI
@@ -746,10 +762,24 @@ impl Rib {
             self.fib_handle.register_vxlan_ifindex(new, ifindex);
             if let Some(local) = self.links.get(&ifindex).and_then(|l| l.vxlan_local) {
                 self.api_vxlan_add(new, local);
+                let name = self
+                    .links
+                    .get(&ifindex)
+                    .map(|l| l.name.clone())
+                    .unwrap_or_default();
                 // Tee the VNI binding + local VTEP source to the cradle eBPF
                 // data plane (VXLAN only; an SRv6 device's IPv6-local is a
-                // no-op there).
-                self.fib_handle.cradle_vni_register(new, local).await;
+                // no-op there). A device the operator bound to a tenant VRF
+                // is an EVPN symmetric-IRB L3VNI — route the inner IP in
+                // that VRF with a router-MAC rewrite; a plain device is an
+                // L2VNI (bridge domain).
+                if let Some((vrf_table_id, rmac)) = self.vxlan_l3_binding(&name) {
+                    self.fib_handle
+                        .cradle_vni_register_l3(new, local, vrf_table_id, rmac)
+                        .await;
+                } else {
+                    self.fib_handle.cradle_vni_register(new, local).await;
+                }
             }
         }
 

--- a/zebra-rs/src/rib/nexthop/inst.rs
+++ b/zebra-rs/src/rib/nexthop/inst.rs
@@ -52,8 +52,23 @@ pub struct NexthopUni {
     // sr0 dummy and `addr` is unused.
     pub seg6local_action: Option<SidBehavior>,
 
+    // EVPN symmetric-IRB VXLAN L3 encap (RFC 9135) — `Some` marks this
+    // nexthop as VXLAN-encapsulated: the routed inner packet is wrapped with
+    // `l3vni` toward `remote_vtep`, inner dst MAC = `remote_rmac`. `addr` /
+    // `ifindex_origin` carry the underlay adjacency. Mutually exclusive with
+    // `segs`/`mpls` (one encapsulation per nexthop).
+    pub vxlan: Option<VxlanL3Encap>,
+
     // Action.
     pub gid: usize,
+}
+
+/// EVPN symmetric-IRB VXLAN L3 encapsulation carried on a [`NexthopUni`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize)]
+pub struct VxlanL3Encap {
+    pub remote_vtep: Ipv4Addr,
+    pub l3vni: u32,
+    pub remote_rmac: [u8; 6],
 }
 
 impl NexthopUni {
@@ -111,6 +126,7 @@ impl Default for NexthopUni {
             segs: vec![],
             encap_type: None,
             seg6local_action: None,
+            vxlan: None,
             gid: 0,
             valid: false,
         }

--- a/zebra-rs/src/rib/vxlan/builder.rs
+++ b/zebra-rs/src/rib/vxlan/builder.rs
@@ -5,7 +5,7 @@ use anyhow::{Context, Result};
 use tokio::sync::mpsc::UnboundedSender;
 
 use crate::config::{Args, ConfigOp};
-use crate::rib::{AddrGenMode, Message};
+use crate::rib::{AddrGenMode, MacAddr, Message};
 
 use super::VxlanConfig;
 
@@ -117,6 +117,8 @@ impl ConfigBuilder {
         const DPORT_ERR: &str = "destination port format error";
         const ADDR_ERR: &str = "local address format error";
         const ADDR_GEN_MODE_ERR: &str = "address gen mode format error";
+        const VRF_ERR: &str = "vrf name format error";
+        const RMAC_ERR: &str = "router-mac format error";
 
         ConfigBuilder::default()
             .path("")
@@ -191,6 +193,37 @@ impl ConfigBuilder {
             .del(|config, cache, name, _args| {
                 let s = cache_lookup(config, cache, name).context(CONFIG_ERR)?;
                 s.addr_gen_mode = None;
+                Ok(())
+            })
+            .path("/vrf")
+            .set(|config, cache, name, args| {
+                let vrf = args.string().context(VRF_ERR)?;
+
+                let s = cache_get(config, cache, name).context(CONFIG_ERR)?;
+                s.vrf = Some(vrf);
+                Ok(())
+            })
+            .del(|config, cache, name, _args| {
+                let s = cache_lookup(config, cache, name).context(CONFIG_ERR)?;
+                s.vrf = None;
+                Ok(())
+            })
+            .path("/router-mac")
+            .set(|config, cache, name, args| {
+                let mac: MacAddr = args
+                    .string()
+                    .context(RMAC_ERR)?
+                    .parse()
+                    .ok()
+                    .context(RMAC_ERR)?;
+
+                let s = cache_get(config, cache, name).context(CONFIG_ERR)?;
+                s.router_mac = Some(mac);
+                Ok(())
+            })
+            .del(|config, cache, name, _args| {
+                let s = cache_lookup(config, cache, name).context(CONFIG_ERR)?;
+                s.router_mac = None;
                 Ok(())
             })
     }

--- a/zebra-rs/src/rib/vxlan/config.rs
+++ b/zebra-rs/src/rib/vxlan/config.rs
@@ -1,6 +1,6 @@
 use std::net::IpAddr;
 
-use crate::rib::AddrGenMode;
+use crate::rib::{AddrGenMode, MacAddr};
 
 #[derive(Default, Debug, Clone)]
 pub struct VxlanConfig {
@@ -18,4 +18,10 @@ pub struct VxlanConfig {
 
     // Address generation mode.
     pub addr_gen_mode: Option<AddrGenMode>,
+
+    // Tenant VRF (EVPN symmetric-IRB L3VNI). See `Vxlan::vrf`.
+    pub vrf: Option<String>,
+
+    // Router-MAC for this L3VNI. See `Vxlan::router_mac`.
+    pub router_mac: Option<MacAddr>,
 }

--- a/zebra-rs/src/rib/vxlan/mod.rs
+++ b/zebra-rs/src/rib/vxlan/mod.rs
@@ -6,7 +6,7 @@ pub use builder::*;
 
 use std::net::IpAddr;
 
-use super::AddrGenMode;
+use super::{AddrGenMode, MacAddr};
 
 #[derive(Debug, Default, Clone)]
 pub struct Vxlan {
@@ -23,4 +23,13 @@ pub struct Vxlan {
 
     // Address generation mode.
     pub addr_gen_mode: Option<AddrGenMode>,
+
+    // Tenant VRF this device is an L3VNI for (EVPN symmetric IRB). When
+    // set, the VNI binds to the VRF's FIB in the cradle data plane instead
+    // of an L2 bridge domain.
+    pub vrf: Option<String>,
+
+    // Router-MAC advertised/rewritten for this L3VNI. Defaults to the VRF
+    // master device MAC when unset.
+    pub router_mac: Option<MacAddr>,
 }

--- a/zebra-rs/yang/config.yang
+++ b/zebra-rs/yang/config.yang
@@ -401,6 +401,30 @@ module config {
            the VXLAN gains a master). Omitted means the VXLAN is not a
            bridge port.";
       }
+      leaf vrf {
+        ext:help "Tenant VRF this device is an L3VNI for (EVPN IRB)";
+        ext:dynamic "rib:vrf";
+        type leafref {
+          path "/vrf/name";
+        }
+        description
+          "Bind this VXLAN device to a tenant VRF as an EVPN symmetric-IRB
+           L3VNI (RFC 9135 / RFC 8365). A VXLAN frame received on this VNI
+           routes its inner IP in the VRF's FIB (instead of bridging into
+           an L2 domain), and the VRF's Type-5 routes are VXLAN-encapsulated
+           toward the remote VTEP. Requires `router bgp vrf <name> evpn
+           advertise-ipv4/ipv6` and matching `encapsulation vxlan`.";
+      }
+      leaf router-mac {
+        ext:help "Router-MAC for this L3VNI (EVPN IRB inner rewrite)";
+        type yang:mac-address;
+        description
+          "This PE's router-MAC for the L3VNI. On ingress the inner
+           Ethernet is rewritten with the remote PE's router-MAC before
+           encapsulation; on egress a frame whose inner destination matches
+           this MAC is routed in the bound VRF. Defaults to the VRF master
+           device MAC when unset.";
+      }
     }
 
     container system {

--- a/zebra-rs/yang/zebra-bgp-vrf.yang
+++ b/zebra-rs/yang/zebra-bgp-vrf.yang
@@ -8,6 +8,10 @@ module zebra-bgp-vrf {
     prefix inet;
   }
 
+  import ietf-yang-types {
+    prefix yang;
+  }
+
   import ietf-bgp {
     prefix bgp;
   }
@@ -537,6 +541,16 @@ module zebra-bgp-vrf {
                the PE decapsulates into the VRF table via seg6local.
                Requires a resolved global `srv6 locator`.";
           }
+          enum vxlan {
+            description
+              "VXLAN symmetric-IRB encapsulation (RFC 9135 / RFC 8365).
+               EVPN Type-5 routes carry the tenant L3VNI in the NLRI
+               label field and this PE's router-MAC in the Router's-MAC
+               extended community; the ingress PE VXLAN-encapsulates the
+               inner IP toward the egress VTEP and rewrites the inner
+               Ethernet with the remote router-MAC. Requires the VRF's
+               `evpn l3vni` and `evpn router-mac` to be set.";
+          }
         }
         default "mpls";
         description
@@ -588,6 +602,27 @@ module zebra-bgp-vrf {
           description
             "Advertise this VRF's IPv6 unicast routes as EVPN Type-5
              (IP Prefix) routes. Requires `rd` to be set.";
+        }
+        leaf l3vni {
+          ext:help "Tenant L3VNI for VXLAN symmetric-IRB Type-5";
+          type uint32 {
+            range "1..16777215";
+          }
+          description
+            "L3VNI carried in the EVPN Type-5 NLRI label field when
+             `encapsulation vxlan` is set. Identifies the tenant VRF
+             on the egress PE for symmetric IRB (RFC 8365). Must match
+             an `l3vni` on a local `vxlan` device bound to this VRF.";
+        }
+        leaf router-mac {
+          ext:help "Router-MAC advertised in EVPN Type-5 (VXLAN IRB)";
+          type yang:mac-address;
+          description
+            "This PE's router-MAC, advertised in the Router's-MAC
+             extended community (RFC 9135) on VXLAN Type-5 routes. The
+             ingress PE rewrites the inner Ethernet destination with the
+             egress PE's router-MAC before VXLAN encapsulation. Defaults
+             to the VRF master device MAC when unset.";
         }
       }
       uses bgp-vrf-neighbor;


### PR DESCRIPTION
## Summary

EVPN/VXLAN Phase 3 slice 2 — makes a real iBGP L2VPN-EVPN session drive the symmetric-IRB VXLAN datapath that cradle-rs slice 1 proved standalone (cradle-rs #118). Each PE originates a **Type-5** for its tenant CE subnet carrying the tenant **L3VNI** (NLRI label) and its **router-MAC** (Router's-MAC extended community, RFC 9135); the ingress PE imports the remote Type-5 into the tenant VRF as an `NH_F_VXLAN` route and tees it — plus the L3VNI↔VRF binding — into cradle.

Scope: Type-5-based inter-subnet routing. Type-2-with-RMAC host routes and ARP/ND suppression are a later slice.

## What's in it

- **bgp-packet**: Router's-MAC extended community (EVPN sub-type 0x03) — builder/accessors/Display + round-trip test. Additive; no codec/NLRI change (the L3VNI already rides the Type-5 label field).
- **rib::NexthopUni** gains a `vxlan: Option<VxlanL3Encap>` FIELD (not a `Nexthop` enum variant) — keeps every construction site compiling and avoids a ~327-site match sweep. Threaded through the cradle tee (Leaf/Member/CradleMember tuples + `vxlan_nexthop_id` + `nh_ids_vxlan`).
- **route.rs**: import keys the VXLAN VRF FIB entry on the imported best (RMAC EC present + Evpn VTEP next-hop + L3VNI label), mirroring the SRv6 L3VPN branch. Origination sets the next-hop to this PE's VTEP and attaches the Router's-MAC EC, gated on `encapsulation vxlan`.
- **config**: `BgpVrfEncapsulation::Vxlan` + `router bgp vrf X evpn l3vni` / `router-mac`; `vxlan <dev> vrf <vrf>` / `router-mac` bind a VXLAN device to a tenant VRF as an L3VNI. `link.rs` tees the L3VNI binding {vrf table-id, router-MAC} to cradle `set_vni_l3` + `set_vtep_source`.
- **proto**: re-sync vendored `cradle.proto` with slice-1's `Vni {l3,vrf,rmac}` and `Nexthop {vxlan_vtep,vxlan_l3vni,vxlan_rmac}`.

### Convergence fixes (found by the e2e)

- Preserve the remote VTEP through the VRF import (new `BgpRib.vxlan_vtep`, captured before the next-hop is rewritten to self).
- Re-originate the Type-5 when export RTs / the L3VNI VTEP arrive late (`retag_vrf_exports_*` + `RibRx::VxlanAdd`) — otherwise a peer that only negotiated EVPN keeps a stale route and never imports.
- Fix the L3VNI-binding config-order race (defer the L2 fallback for a VRF-bound device; re-tee from `VrfAdd`).

## Test plan

- `cargo fmt --all`, workspace clippy (`--all-targets` and `--features lua`, both `-D warnings`), `cargo test --workspace --exclude bdd` — all green.
- New cradle-rs e2e `@cradle_evpn_vxlan_irb_zebra` passes reliably (2 PEs cradle+zebra, tenant VRF + L3VNI, Type-5 inter-subnet routing; asserts BGP Established + ping across subnets both ways + vxlan_encap/vxlan_decap/fib4_vrf_hit nonzero). Filed as a companion cradle-rs PR.
- Regressions green: `@cradle_l3vpn_zebra`, `@cradle_srv6_l3vpn_zebra`, `@cradle_evpn_vxlan_zebra`, `@cradle_evpn_vxlan`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)