### PR TITLE
bdd: migrate bgp_evpn_srv6_p2mp to cradle-engine mode

### DIFF
--- a/bdd/Makefile
+++ b/bdd/Makefile
@@ -401,6 +401,11 @@ cradle_spawn:
 	mkdir -p allure-results
 	cargo test --test cucumber -- --concurrency=1 --tags "@cradle_spawn"
 
+# EVPN BUM over SRv6 P2MP, cradle-engine mode. Requires /usr/bin/cradle.
+bgp_evpn_srv6_p2mp:
+	mkdir -p allure-results
+	cargo test --test cucumber -- --concurrency=1 --tags "@bgp_evpn_srv6_p2mp"
+
 bgp_interas_option_c:
 	mkdir -p allure-results
 	cargo test --test cucumber -- --concurrency=1 --tags "@bgp_interas_option_c"
@@ -460,4 +465,4 @@ docs/%.md: tests/features/%.feature docs/feature2md.sh FORCE
 
 FORCE:
 
-.PHONY: ecmp_bfd_evict ospfv2_bfd_frr ospfv3_bfd_frr tilfa_bfd all run ibgp ebgp rr rib_static_ipv6 static_srv6_nht bgp_srv6_nht isis_ipv6 isis_srv6_base isis_fragmentation_ipv6 isis_fragmentation_ipv4 isis_l1p2p isis_tilfa isis_srmpls isis_sr_switchover isis_sr_dataplane_choice ospfv3_sr_dataplane_choice system_hostname isis_l1l2 isis_redist isis_hello_auth_keychain isis_passive isis_afi_enable isis_endx_ipv6 isis_bfd_ipv6_p2p isis_bfd_ipv6_p2p_echo isis_bfd_ipv6_lan isis_bfd_ipv6_lan_echo isis_bfd_ipv4_p2p isis_bfd_ipv4_p2p_echo isis_bfd_ipv4_lan isis_bfd_ipv4_lan_echo ospf_clear_neighbor ospfv2_nssa_base ospfv2_stub_base ospfv2_tilfa ospfv3_nssa ospfv3_tilfa stamp_te_metric stamp_v6_te_metric bgp_peer_down_cleanup bgp_ipv6_over_v4_session bgp_evpn_capability bgp_vrf_evpn_type5 bgp_evpn_outpolicy_undef bgp_route_map_match bgp_policy_dynamic_update bgp_table_map bgp_v6_table_map bgp_community bgp_neighbor_group bgp_unnumbered_neighbor nd_show cradle_spawn bgp_interas_option_c bgp_interas_option_a bgp_interas_option_b bgp_interas_option_ab bgp_port bgp_ip_transparent bgp_local_as bgp_unknown_attr_transitive bgp_fast_external_failover generate open docs FORCE
+.PHONY: ecmp_bfd_evict ospfv2_bfd_frr ospfv3_bfd_frr tilfa_bfd all run ibgp ebgp rr rib_static_ipv6 static_srv6_nht bgp_srv6_nht isis_ipv6 isis_srv6_base isis_fragmentation_ipv6 isis_fragmentation_ipv4 isis_l1p2p isis_tilfa isis_srmpls isis_sr_switchover isis_sr_dataplane_choice ospfv3_sr_dataplane_choice system_hostname isis_l1l2 isis_redist isis_hello_auth_keychain isis_passive isis_afi_enable isis_endx_ipv6 isis_bfd_ipv6_p2p isis_bfd_ipv6_p2p_echo isis_bfd_ipv6_lan isis_bfd_ipv6_lan_echo isis_bfd_ipv4_p2p isis_bfd_ipv4_p2p_echo isis_bfd_ipv4_lan isis_bfd_ipv4_lan_echo ospf_clear_neighbor ospfv2_nssa_base ospfv2_stub_base ospfv2_tilfa ospfv3_nssa ospfv3_tilfa stamp_te_metric stamp_v6_te_metric bgp_peer_down_cleanup bgp_ipv6_over_v4_session bgp_evpn_capability bgp_vrf_evpn_type5 bgp_evpn_outpolicy_undef bgp_route_map_match bgp_policy_dynamic_update bgp_table_map bgp_v6_table_map bgp_community bgp_neighbor_group bgp_unnumbered_neighbor nd_show cradle_spawn bgp_evpn_srv6_p2mp bgp_interas_option_c bgp_interas_option_a bgp_interas_option_b bgp_interas_option_ab bgp_port bgp_ip_transparent bgp_local_as bgp_unknown_attr_transitive bgp_fast_external_failover generate open docs FORCE

--- a/bdd/docs/bgp_evpn_srv6_p2mp.md
+++ b/bdd/docs/bgp_evpn_srv6_p2mp.md
@@ -1,27 +1,25 @@
-# BGP EVPN BUM over SRv6 P2MP replication (RFC 9524) — daemon-driven offload
+# BGP EVPN BUM over SRv6 P2MP replication (RFC 9524) — cradle engine
 
 ## Overview
 
 As a network operator
-I want the BGP control plane to drive the tc-evpn-replicate eBPF offload: two
-SRv6 EVPN PEs exchange their End.DT2M SIDs over an SR P2MP IMET, the root
-forms a replication segment, and the daemon spawns + feeds the ingress
-(End.Replicate / End.DT2M) and encap (root H.Encaps) children that move BUM.
-This proves the control-plane -> supervisor -> loader integration end to end
-(session, SID exchange, ReplSeg, child spawn). Each datapath's actual packet
-forwarding is proven standalone by the tc-evpn-replicate veth scripts in
-cradle-rs (crates/tc-evpn-replicate/scripts/veth-*.sh — End.Replicate, End.DT2M,
-H.Encaps); wiring the netns packet capture through all three is a follow-up.
+I want the BGP control plane to program EVPN BUM replication into the cradle
+eBPF engine: two SRv6 EVPN PEs exchange their End.DT2M SIDs over a Type-3 IMET,
+and each daemon (with `system ebpf enabled`) tees the datapath to cradle — its
+own End.DT2M leaf SID into the SRv6 table, and each remote PE's End.DT2M SID as
+a VNI-10 replication slot. This proves the control-plane -> cradle-tee
+integration end to end (session, SID exchange, engine programming). BUM
+forwarding is the cradle engine's job (the standalone tc-evpn-replicate offload
+is retired); its packet path is exercised by the veth scripts in cradle-rs
+(crates/tc-evpn-replicate/scripts/veth-*.sh). Requires /usr/bin/cradle.
+
 Test Topology — z1 and z2 are SRv6 EVPN PEs on a direct underlay link, each a
-root + leaf for VNI 10. z1 sources a BUM frame on its access port; the offload
-encaps it toward z2's End.DT2M SID; z2 decaps it onto its bridge.
-```
-```
+root + leaf for VNI 10, each running the cradle engine.
 
 ## Test Scenarios
 
 | Scenario | Result |
 |----------|--------|
 | Build the SRv6 EVPN topology and confirm the SR P2MP exchange | |
-| The daemon spawns the offload children and programs the tree | |
+| The cradle engine is programmed with the SRv6 EVPN replication datapath | |
 | Teardown topology | |

--- a/bdd/tests/configs/bgp_evpn_srv6_p2mp/z1-1.yaml
+++ b/bdd/tests/configs/bgp_evpn_srv6_p2mp/z1-1.yaml
@@ -1,9 +1,13 @@
 # z1 — an SRv6 EVPN PE (root + leaf) for VNI 10 over an SR P2MP (RFC 9524)
 # BUM-replication tree. Locator LOC1 (fcbb:bbbb:1::/48) carves its End.DT2M
 # SID; a static route reaches z2's locator (no IGP in this 2-node test).
-# bum-tunnel-type srv6-p2mp + sr-p2mp-dataplane drive the tc-evpn-replicate
-# offload: the encap child wraps bare BUM out z1z2; the leaf child decaps a
-# replicated copy addressed to z1's End.DT2M SID into br10.
+# `system ebpf enabled` spawns the cradle engine and enables the FIB tee, so
+# the BGP control plane programs the replication datapath into cradle: z1's
+# local End.DT2M SID (leaf decap) into the SRv6 table, and each remote PE's
+# End.DT2M SID as a VNI-10 replication slot (root fan-out).
+system:
+  ebpf:
+    enabled: true
 interface:
 - if-name: lo
   ipv6:
@@ -32,11 +36,6 @@ router:
     - name: evpn
       advertise-all-vni: true
       bum-tunnel-type: srv6-p2mp
-      sr-p2mp-dataplane:
-        overlay-interface: oport1
-        underlay-interface: z1z2
-        bridge-interface: iport1
-        next-hop-mac: "02:00:00:00:12:02"
     neighbor:
     - remote-address: 2001:db8:12::2
       enabled: true

--- a/bdd/tests/configs/bgp_evpn_srv6_p2mp/z2-1.yaml
+++ b/bdd/tests/configs/bgp_evpn_srv6_p2mp/z2-1.yaml
@@ -1,7 +1,11 @@
 # z2 — the peer SRv6 EVPN PE (root + leaf) for VNI 10. Mirror of z1: locator
 # LOC2 (fcbb:bbbb:2::/48), a static route to z1's locator, and the same
-# srv6-p2mp + sr-p2mp-dataplane offload config. z1 sources BUM; z2 is the leaf
-# that receives the replicated copy and floods it into br10.
+# srv6-p2mp config. `system ebpf enabled` runs the cradle engine + FIB tee so
+# the BGP control plane programs the replication datapath (local End.DT2M SID +
+# remote replication slots) into cradle.
+system:
+  ebpf:
+    enabled: true
 interface:
 - if-name: lo
   ipv6:
@@ -30,11 +34,6 @@ router:
     - name: evpn
       advertise-all-vni: true
       bum-tunnel-type: srv6-p2mp
-      sr-p2mp-dataplane:
-        overlay-interface: oport2
-        underlay-interface: z2z1
-        bridge-interface: iport2
-        next-hop-mac: "02:00:00:00:12:01"
     neighbor:
     - remote-address: 2001:db8:12::1
       enabled: true

--- a/bdd/tests/features/bgp_evpn_srv6_p2mp.feature
+++ b/bdd/tests/features/bgp_evpn_srv6_p2mp.feature
@@ -1,27 +1,28 @@
 @serial
 @bgp_evpn_srv6_p2mp
-Feature: BGP EVPN BUM over SRv6 P2MP replication (RFC 9524) — daemon-driven offload
+Feature: BGP EVPN BUM over SRv6 P2MP replication (RFC 9524) — cradle engine
   As a network operator
-  I want the BGP control plane to drive the tc-evpn-replicate eBPF offload: two
-  SRv6 EVPN PEs exchange their End.DT2M SIDs over an SR P2MP IMET, the root
-  forms a replication segment, and the daemon spawns + feeds the ingress
-  (End.Replicate / End.DT2M) and encap (root H.Encaps) children that move BUM.
+  I want the BGP control plane to program EVPN BUM replication into the cradle
+  eBPF engine: two SRv6 EVPN PEs exchange their End.DT2M SIDs over a Type-3
+  IMET, and each daemon (with `system ebpf enabled`) tees the datapath to
+  cradle — its own End.DT2M leaf SID into the SRv6 table, and each remote PE's
+  End.DT2M SID as a VNI-10 replication slot.
 
-  This proves the control-plane -> supervisor -> loader integration end to end
-  (session, SID exchange, ReplSeg, child spawn). Each datapath's actual packet
-  forwarding is proven standalone by the tc-evpn-replicate veth scripts in
-  cradle-rs (crates/tc-evpn-replicate/scripts/veth-*.sh — End.Replicate,
-  End.DT2M, H.Encaps); wiring the netns packet capture through all three is a
-  follow-up.
+  This proves the control-plane -> cradle-tee integration end to end (session,
+  SID exchange, engine programming). BUM forwarding is the cradle engine's job
+  (the retired standalone tc-evpn-replicate offload is superseded); its packet
+  path is exercised by the veth scripts in cradle-rs
+  (crates/tc-evpn-replicate/scripts/veth-*.sh). Requires /usr/bin/cradle — see
+  the cradle_spawn feature header for install instructions.
 
   Test Topology — z1 and z2 are SRv6 EVPN PEs on a direct underlay link, each a
-  root + leaf for VNI 10. z1 sources a BUM frame on its access port; the offload
-  encaps it toward z2's End.DT2M SID; z2 decaps it onto its bridge.
+  root + leaf for VNI 10. Each runs the cradle engine, which encaps BUM toward
+  the remote End.DT2M SID and decaps a replicated copy onto its bridge.
   ```
-   z1 [br10: vxlan10 + oport1(encap) + host1]      z2 [br10: vxlan10 + iport2(leaf) + host2]
-        host1 ─(inject bare BUM)                              host2 ─(capture)
-          │                                                     ▲
-        br10 ─ oport1 ═encap═► z1z2 ═══════════ z2z1 ═decap═► iport2 ─ br10
+   z1 [br10: vxlan10 + oport1 + host1]      z2 [br10: vxlan10 + iport2 + host2]
+        host1 ─(inject bare BUM)                     host2 ─(capture)
+          │                                            ▲
+        br10 ─ cradle ═encap═► z1z2 ═════ z2z1 ═decap═ cradle ─ br10
   ```
 
   Scenario: Build the SRv6 EVPN topology and confirm the SR P2MP exchange
@@ -29,7 +30,7 @@ Feature: BGP EVPN BUM over SRv6 P2MP replication (RFC 9524) — daemon-driven of
     When I create namespace "z1"
     And I create namespace "z2"
     And I connect namespace "z1" interface "z1z2" to namespace "z2" interface "z2z1"
-    # Fixed underlay MACs so each side's sr-p2mp-dataplane next-hop-mac is known.
+    # Deterministic underlay MACs (the cradle engine resolves the next hop itself).
     And I execute "ip link set z1z2 address 02:00:00:00:12:01" in namespace "z1"
     And I execute "ip link set z2z1 address 02:00:00:00:12:02" in namespace "z2"
     And I start zebra-rs in namespace "z1"
@@ -65,12 +66,20 @@ Feature: BGP EVPN BUM over SRv6 P2MP replication (RFC 9524) — daemon-driven of
     # z1 learns z2's per-PE IMET carrying z2's End.DT2M SID (SRv6 L2 Prefix-SID).
     And show command "show bgp evpn" in namespace "z1" should eventually contain "[3]:[0]:[128]:[2001:db8::2]"
 
-  Scenario: The daemon spawns the offload children and programs the tree
+  Scenario: The cradle engine is programmed with the SRv6 EVPN replication datapath
     Given the test topology exists
-    # The control plane forms an SR P2MP ReplSeg and feeds the tc-evpn-replicate
-    # ingress + encap children (root H.Encaps toward z2's leaf SID, leaf decap).
-    Then daemon log in namespace "z1" should eventually contain "spawned"
-    And daemon log in namespace "z1" should eventually contain "ReplSeg add"
+    # Both PEs spawned + attached the managed cradle engine under `system ebpf`.
+    Then show command "show ebpf" in namespace "z1" should eventually contain "managed"
+    And show command "show ebpf" in namespace "z2" should eventually contain "managed"
+    # Each PE installed its own End.DT2M leaf SID into the engine's SRv6 table
+    # (leaf decap; teed via AddLocalSid — the datapath the retired offload's
+    # End.DT2M child used to provide).
+    And show command "show ebpf srv6" in namespace "z1" should eventually contain "fcbb:bbbb:1:"
+    And show command "show ebpf srv6" in namespace "z2" should eventually contain "fcbb:bbbb:2:"
+    # And z1 programmed z2's remote End.DT2M SID as a VNI-10 replication slot —
+    # the root fan-out (CradleReplAdd -> AddReplSlot) the offload's H.Encaps
+    # child used to do.
+    And daemon log in namespace "z1" should eventually contain "repl slot"
 
   Scenario: Teardown topology
     Given the test topology exists


### PR DESCRIPTION
Phase 1 S3 (follows #1916). The `bgp_evpn_srv6_p2mp` feature asserted the
now-deleted `tc-evpn-replicate` supervisor logs (`spawned`, `ReplSeg add`).
Rewrite it to prove the converged datapath — the BGP control plane programming
EVPN BUM replication into the cradle engine.

## Changes

- `z1-1.yaml` / `z2-1.yaml`: drop the `sr-p2mp-dataplane` block (its YANG was
  removed in #1916, so the config would no longer load) and add
  `system: ebpf: enabled: true` (spawns the engine + enables the FIB tee).
- Feature scenario 2 now asserts: both PEs' engine is `managed`; each installed
  its own End.DT2M leaf SID into the engine SRv6 table (`show ebpf srv6`); and
  z1 programmed z2's remote End.DT2M SID as a VNI-10 replication slot (daemon
  log `repl slot`) — the root fan-out.
- Updated the feature/doc prose; added a `bgp_evpn_srv6_p2mp` bdd Makefile
  target (+ `.PHONY`).

Requires `/usr/bin/cradle` (already a BDD-suite prerequisite).

## Test plan

Live-validated against cradle 0.9.3 (built + installed zebra-rs with the clean
YANG, `make -C bdd bgp_evpn_srv6_p2mp`): **3 scenarios pass, clean teardown.**
The engine log confirms the datapath: `cradle: engine ready`, 1 local SID teed,
and `repl slot crs0a/crs0b: bd 10 -> fcbb:bbbb:2:40::` (z2's leaf SID).
BDD is not part of the PR CI gate (fmt/clippy/test); those pass unchanged (no
src touched).

Generated with [Claude Code](https://claude.com/claude-code)