### PR TITLE
bdd: start daemons with -c /dev/null instead of deleting startup config

### DIFF
--- a/bdd/src/netns.rs
+++ b/bdd/src/netns.rs
@@ -29,30 +29,6 @@ async fn run_cmd(args: &[&str], error_msg: &str) -> Result<()> {
     }
 }
 
-/// Remove the shared daemon startup config, best effort.
-///
-/// A BDD daemon is launched without `--config-file`, so it falls back to
-/// loading `<yang-path>/../zebra-rs.conf` at startup — and under `sudo ip
-/// netns exec` (HOME=/root) the yang path resolves to `/etc/zebra-rs/yang`,
-/// so that file is `/etc/zebra-rs/zebra-rs.conf`. This path is host-global
-/// and shared by every namespace's daemon. A stale copy left there (e.g. a
-/// manual `save`, or a hand-run debug session) is loaded by EVERY BDD daemon
-/// before the feature applies its own config — and because `vtyctl apply`
-/// is a diff, any element that overlaps the leftover (a neighbor address, a
-/// VRF, an `interface lo` address, a global `as`) keeps the leftover's stale
-/// attributes, silently breaking dozens of unrelated features. BDD daemons
-/// must always start from an empty config, so sweep it here like the host
-/// loopback addresses above — it is only ever a leftover, never anything a
-/// live feature needs.
-pub async fn remove_stale_startup_config() {
-    let _ = Command::new("sudo")
-        .args(["rm", "-f", "/etc/zebra-rs/zebra-rs.conf"])
-        .stdout(Stdio::null())
-        .stderr(Stdio::null())
-        .status()
-        .await;
-}
-
 /// Execute a command in a network namespace
 pub async fn exec_in_netns(netns: &str, cmd: &str, args: &[&str]) -> Result<String> {
     let output = Command::new("sudo")
@@ -375,17 +351,33 @@ pub async fn spawn_in_netns_env(
     // restart, so graceful-restart resume still works; the daemon
     // create_dir_all's it on write.
     let ckpt = format!("ZEBRA_OSPF_CHECKPOINT_DIR=/tmp/zebra-rs-ckpt/{netns}");
-    let inject_ckpt = cmd == "zebra-rs";
-    if inject_ckpt || !env.is_empty() {
+    let is_zebra = cmd == "zebra-rs";
+    if is_zebra || !env.is_empty() {
         c.arg("env");
-        if inject_ckpt {
+        if is_zebra {
             c.arg(&ckpt);
         }
         for (k, v) in env {
             c.arg(format!("{k}={v}"));
         }
     }
-    c.arg(cmd).args(args);
+    c.arg(cmd);
+    // Force every BDD daemon to cold-start from an empty config. Without an
+    // explicit `--config-file`, zebra-rs falls back to loading
+    // `<yang-path>/../zebra-rs.conf`; under `sudo ip netns exec` (HOME=/root)
+    // that resolves to the host-global `/etc/zebra-rs/zebra-rs.conf`, which a
+    // netns does NOT isolate (it isolates the network, not the filesystem).
+    // A stale copy there (a manual `save`, a debug session) would be loaded by
+    // EVERY namespace's daemon before its feature config is applied, and since
+    // `vtyctl apply` is a diff, any overlapping element keeps the leftover's
+    // stale attributes — silently breaking dozens of unrelated features.
+    // Pointing `-c` at `/dev/null` reads as an empty document (skips the config
+    // parsers entirely) and leaves the operator's `/etc/zebra-rs/zebra-rs.conf`
+    // untouched, so we neither depend on nor delete it.
+    if is_zebra {
+        c.arg("-c").arg("/dev/null");
+    }
+    c.args(args);
     c.stdout(Stdio::null()).stderr(Stdio::null());
     c.spawn()
         .with_context(|| format!("Failed to spawn {} in netns {}", cmd, netns))

--- a/bdd/tests/cucumber.rs
+++ b/bdd/tests/cucumber.rs
@@ -125,12 +125,11 @@ async fn clean_test_environment(world: &mut World) {
     // loopback-peered sessions (see `sweep_host_loopback_addrs`).
     let _ = netns::sweep_host_loopback_addrs().await;
 
-    // 6. Remove the shared daemon startup config. BDD daemons launch without
-    // `--config-file` and would otherwise load `/etc/zebra-rs/zebra-rs.conf`
-    // at startup; a stale copy (from a manual `save` or a debug session)
-    // poisons every namespace's daemon before its feature config is applied.
-    // See `netns::remove_stale_startup_config` for the full mechanism.
-    netns::remove_stale_startup_config().await;
+    // Note: the shared daemon startup config `/etc/zebra-rs/zebra-rs.conf` is
+    // deliberately NOT swept here. BDD daemons are launched with `-c /dev/null`
+    // (see `netns::spawn_in_netns_env`), so each cold-starts from an empty
+    // config and never reads that host-global file — leaving the operator's
+    // copy untouched instead of deleting it.
 
     println!(
         "✓ Test environment cleaned for feature {}",


### PR DESCRIPTION
## Summary

BDD daemons were launched without `--config-file`, so each fell back to loading the host-global `/etc/zebra-rs/zebra-rs.conf` at startup (a netns isolates the network, not the filesystem). To stop a stale copy from poisoning every namespace's daemon, the `Given a clean test environment` step ran `rm -f` on that file — which deletes an operator's real config.

This switches the strategy: every `zebra-rs` daemon is now launched with **`-c /dev/null`**. `read_to_string("/dev/null")` yields an empty document, which `load_config` skips entirely, so each daemon cold-starts from an empty config. The fallback path to `/etc/zebra-rs/zebra-rs.conf` is never taken — the file is neither read nor deleted.

### Changes
- `bdd/src/netns.rs` — `spawn_in_netns_env` appends `-c /dev/null` for `cmd == "zebra-rs"` (same central gate as the OSPF-checkpoint env injection, so all 7 `start zebra-rs …` step variants are covered). Removed the now-unused `remove_stale_startup_config()`.
- `bdd/tests/cucumber.rs` — dropped the `remove_stale_startup_config()` call from the clean-env step; replaced with a note explaining the new approach.

## Test plan
- `cargo test -p bdd --no-run` — compiles clean.
- `bgp_basic_ibgp` — passes (9 scenarios / 51 steps).
- **Poison test**: with a bogus `/etc/zebra-rs/zebra-rs.conf` (`hostname POISONED`, bogus neighbor) present, `bgp_basic_ibgp` still passes (file ignored) **and** the file survives the run unchanged (identical md5) — proving it is neither read nor deleted.

Generated with [Claude Code](https://claude.com/claude-code)