### PR TITLE
bfd: drive absorbed Echo over cradle engine in BDD (Phase 2 S4)

### DIFF
--- a/bdd/tests/configs/isis_bfd_ipv4_lan/z1-echo-both.yaml
+++ b/bdd/tests/configs/isis_bfd_ipv4_lan/z1-echo-both.yaml
@@ -1,3 +1,6 @@
+system:
+  ebpf:
+    enabled: true
 interface:
 - if-name: lo
   ipv4:
@@ -5,6 +8,8 @@ interface:
 - if-name: vz1ns
   ipv4:
     address: 10.0.1.1/24
+  ebpf:
+    enabled: true
 router:
   isis:
     net: 49.0001.0000.0000.0001.00

--- a/bdd/tests/configs/isis_bfd_ipv4_lan/z1-echo-tx.yaml
+++ b/bdd/tests/configs/isis_bfd_ipv4_lan/z1-echo-tx.yaml
@@ -1,3 +1,6 @@
+system:
+  ebpf:
+    enabled: true
 interface:
 - if-name: lo
   ipv4:
@@ -5,6 +8,8 @@ interface:
 - if-name: vz1ns
   ipv4:
     address: 10.0.1.1/24
+  ebpf:
+    enabled: true
 router:
   isis:
     net: 49.0001.0000.0000.0001.00

--- a/bdd/tests/configs/isis_bfd_ipv4_lan/z2-echo-both.yaml
+++ b/bdd/tests/configs/isis_bfd_ipv4_lan/z2-echo-both.yaml
@@ -1,3 +1,6 @@
+system:
+  ebpf:
+    enabled: true
 interface:
 - if-name: lo
   ipv4:
@@ -5,6 +8,8 @@ interface:
 - if-name: vz2ns
   ipv4:
     address: 10.0.1.2/24
+  ebpf:
+    enabled: true
 router:
   isis:
     net: 49.0001.0000.0000.0002.00

--- a/bdd/tests/configs/isis_bfd_ipv4_lan/z2-echo-rx.yaml
+++ b/bdd/tests/configs/isis_bfd_ipv4_lan/z2-echo-rx.yaml
@@ -1,3 +1,6 @@
+system:
+  ebpf:
+    enabled: true
 interface:
 - if-name: lo
   ipv4:
@@ -5,6 +8,8 @@ interface:
 - if-name: vz2ns
   ipv4:
     address: 10.0.1.2/24
+  ebpf:
+    enabled: true
 router:
   isis:
     net: 49.0001.0000.0000.0002.00

--- a/bdd/tests/configs/isis_bfd_ipv4_p2p/z1-echo-both.yaml
+++ b/bdd/tests/configs/isis_bfd_ipv4_p2p/z1-echo-both.yaml
@@ -1,3 +1,6 @@
+system:
+  ebpf:
+    enabled: true
 interface:
 - if-name: lo
   ipv4:
@@ -5,6 +8,8 @@ interface:
 - if-name: i1
   ipv4:
     address: 10.0.1.1/24
+  ebpf:
+    enabled: true
 router:
   isis:
     net: 49.0001.0000.0000.0001.00

--- a/bdd/tests/configs/isis_bfd_ipv4_p2p/z1-echo-tx.yaml
+++ b/bdd/tests/configs/isis_bfd_ipv4_p2p/z1-echo-tx.yaml
@@ -1,3 +1,6 @@
+system:
+  ebpf:
+    enabled: true
 interface:
 - if-name: lo
   ipv4:
@@ -5,6 +8,8 @@ interface:
 - if-name: i1
   ipv4:
     address: 10.0.1.1/24
+  ebpf:
+    enabled: true
 router:
   isis:
     net: 49.0001.0000.0000.0001.00

--- a/bdd/tests/configs/isis_bfd_ipv4_p2p/z2-echo-both.yaml
+++ b/bdd/tests/configs/isis_bfd_ipv4_p2p/z2-echo-both.yaml
@@ -1,3 +1,6 @@
+system:
+  ebpf:
+    enabled: true
 interface:
 - if-name: lo
   ipv4:
@@ -5,6 +8,8 @@ interface:
 - if-name: i1
   ipv4:
     address: 10.0.1.2/24
+  ebpf:
+    enabled: true
 router:
   isis:
     net: 49.0001.0000.0000.0002.00

--- a/bdd/tests/configs/isis_bfd_ipv4_p2p/z2-echo-rx.yaml
+++ b/bdd/tests/configs/isis_bfd_ipv4_p2p/z2-echo-rx.yaml
@@ -1,3 +1,6 @@
+system:
+  ebpf:
+    enabled: true
 interface:
 - if-name: lo
   ipv4:
@@ -5,6 +8,8 @@ interface:
 - if-name: i1
   ipv4:
     address: 10.0.1.2/24
+  ebpf:
+    enabled: true
 router:
   isis:
     net: 49.0001.0000.0000.0002.00

--- a/bdd/tests/configs/isis_bfd_ipv6_lan/z1-echo-both.yaml
+++ b/bdd/tests/configs/isis_bfd_ipv6_lan/z1-echo-both.yaml
@@ -1,3 +1,6 @@
+system:
+  ebpf:
+    enabled: true
 interface:
 - if-name: lo
   ipv6:
@@ -5,6 +8,8 @@ interface:
 - if-name: vz1ns
   ipv6:
     address: 2001:db8:1::1/64
+  ebpf:
+    enabled: true
 router:
   isis:
     net: 49.0001.0000.0000.0001.00

--- a/bdd/tests/configs/isis_bfd_ipv6_lan/z1-echo-tx.yaml
+++ b/bdd/tests/configs/isis_bfd_ipv6_lan/z1-echo-tx.yaml
@@ -1,3 +1,6 @@
+system:
+  ebpf:
+    enabled: true
 interface:
 - if-name: lo
   ipv6:
@@ -5,6 +8,8 @@ interface:
 - if-name: vz1ns
   ipv6:
     address: 2001:db8:1::1/64
+  ebpf:
+    enabled: true
 router:
   isis:
     net: 49.0001.0000.0000.0001.00

--- a/bdd/tests/configs/isis_bfd_ipv6_lan/z2-echo-both.yaml
+++ b/bdd/tests/configs/isis_bfd_ipv6_lan/z2-echo-both.yaml
@@ -1,3 +1,6 @@
+system:
+  ebpf:
+    enabled: true
 interface:
 - if-name: lo
   ipv6:
@@ -5,6 +8,8 @@ interface:
 - if-name: vz2ns
   ipv6:
     address: 2001:db8:1::2/64
+  ebpf:
+    enabled: true
 router:
   isis:
     net: 49.0001.0000.0000.0002.00

--- a/bdd/tests/configs/isis_bfd_ipv6_lan/z2-echo-rx.yaml
+++ b/bdd/tests/configs/isis_bfd_ipv6_lan/z2-echo-rx.yaml
@@ -1,3 +1,6 @@
+system:
+  ebpf:
+    enabled: true
 interface:
 - if-name: lo
   ipv6:
@@ -5,6 +8,8 @@ interface:
 - if-name: vz2ns
   ipv6:
     address: 2001:db8:1::2/64
+  ebpf:
+    enabled: true
 router:
   isis:
     net: 49.0001.0000.0000.0002.00

--- a/bdd/tests/configs/isis_bfd_ipv6_p2p/z1-echo-both.yaml
+++ b/bdd/tests/configs/isis_bfd_ipv6_p2p/z1-echo-both.yaml
@@ -1,3 +1,6 @@
+system:
+  ebpf:
+    enabled: true
 interface:
 - if-name: lo
   ipv6:
@@ -5,6 +8,8 @@ interface:
 - if-name: i1
   ipv6:
     address: 2001:db8:1::1/64
+  ebpf:
+    enabled: true
 router:
   isis:
     net: 49.0001.0000.0000.0001.00

--- a/bdd/tests/configs/isis_bfd_ipv6_p2p/z1-echo-tx.yaml
+++ b/bdd/tests/configs/isis_bfd_ipv6_p2p/z1-echo-tx.yaml
@@ -1,3 +1,6 @@
+system:
+  ebpf:
+    enabled: true
 interface:
 - if-name: lo
   ipv6:
@@ -5,6 +8,8 @@ interface:
 - if-name: i1
   ipv6:
     address: 2001:db8:1::1/64
+  ebpf:
+    enabled: true
 router:
   isis:
     net: 49.0001.0000.0000.0001.00

--- a/bdd/tests/configs/isis_bfd_ipv6_p2p/z2-echo-both.yaml
+++ b/bdd/tests/configs/isis_bfd_ipv6_p2p/z2-echo-both.yaml
@@ -1,3 +1,6 @@
+system:
+  ebpf:
+    enabled: true
 interface:
 - if-name: lo
   ipv6:
@@ -5,6 +8,8 @@ interface:
 - if-name: i1
   ipv6:
     address: 2001:db8:1::2/64
+  ebpf:
+    enabled: true
 router:
   isis:
     net: 49.0001.0000.0000.0002.00

--- a/bdd/tests/configs/isis_bfd_ipv6_p2p/z2-echo-rx.yaml
+++ b/bdd/tests/configs/isis_bfd_ipv6_p2p/z2-echo-rx.yaml
@@ -1,3 +1,6 @@
+system:
+  ebpf:
+    enabled: true
 interface:
 - if-name: lo
   ipv6:
@@ -5,6 +8,8 @@ interface:
 - if-name: i1
   ipv6:
     address: 2001:db8:1::2/64
+  ebpf:
+    enabled: true
 router:
   isis:
     net: 49.0001.0000.0000.0002.00

--- a/bdd/tests/cucumber.rs
+++ b/bdd/tests/cucumber.rs
@@ -387,11 +387,20 @@ async fn start_zebra_rs(world: &mut World, namespace: String) {
     let log_file = format!("logs/{}.log", scoped);
     let pid_file = world.pid_file(&namespace);
 
+    // BFD Echo reflection off a bridge-enslaved veth needs generic (SKB) XDP:
+    // cradle's native `XDP_TX` only delivers to a peer that also has XDP, which
+    // the LAN topology's host bridge port does not. `CRADLE_XDP_MODE=skb` (read
+    // by the cradle child, which inherits this env) forces generic attach.
+    // Scoped to the BFD features so the SRv6/EVPN datapaths keep native XDP —
+    // generic mode skips the XDP pop/decap for TC-redirected skbs.
+    let env: &[(&str, &str)] = if world.feature_tag.starts_with("isis_bfd") {
+        &[("CRADLE_XDP_MODE", "skb")]
+    } else {
+        &[]
+    };
     let _child = netns::spawn_in_netns_env(
         &scoped,
-        // veth interfaces (used in all BDD topologies) need SKB mode: native
-        // XDP attaches without error on veth but does not loop packets back.
-        &[("ZEBRA_XDP_BFD_ECHO_MODE", "skb")],
+        env,
         "zebra-rs",
         &[
             // --daemon double-forks + setsid so the daemon leaves the cargo-test
@@ -426,13 +435,10 @@ async fn start_zebra_rs_sharded(world: &mut World, namespace: String, shards: us
 
     let _child = netns::spawn_in_netns_env(
         &scoped,
-        // Same SKB note as `start zebra-rs`; ZEBRA_BGP_SHARDS runs the BGP
-        // RIB sharded (N>1) so inbound policy flows through the shard
-        // workers + PolicyReplace rather than the synchronous N=1 path.
-        &[
-            ("ZEBRA_XDP_BFD_ECHO_MODE", "skb"),
-            ("ZEBRA_BGP_SHARDS", shards.as_str()),
-        ],
+        // ZEBRA_BGP_SHARDS runs the BGP RIB sharded (N>1) so inbound policy
+        // flows through the shard workers + PolicyReplace rather than the
+        // synchronous N=1 path.
+        &[("ZEBRA_BGP_SHARDS", shards.as_str())],
         "zebra-rs",
         &[
             "--daemon",
@@ -466,7 +472,6 @@ async fn start_zebra_rs_sharded_peer_task(world: &mut World, namespace: String, 
         // the main task. Combined with ZEBRA_BGP_SHARDS>1 this exercises
         // both axes — sharded ingest + per-peer egress.
         &[
-            ("ZEBRA_XDP_BFD_ECHO_MODE", "skb"),
             ("ZEBRA_BGP_SHARDS", shards.as_str()),
             ("ZEBRA_BGP_PEER_TASK", "1"),
         ],
@@ -501,10 +506,7 @@ async fn start_zebra_rs_egress_group_task(world: &mut World, namespace: String) 
         // egress task per update-group. Phase 0 is idle (it tracks members and
         // routes no egress yet), so this exercises the spawn/teardown lifecycle
         // without changing egress.
-        &[
-            ("ZEBRA_XDP_BFD_ECHO_MODE", "skb"),
-            ("ZEBRA_BGP_EGRESS_GROUP_TASK", "1"),
-        ],
+        &[("ZEBRA_BGP_EGRESS_GROUP_TASK", "1")],
         "zebra-rs",
         &[
             "--daemon",
@@ -542,7 +544,6 @@ async fn start_zebra_rs_sharded_egress_group_task(
         // (ZEBRA_BGP_EGRESS_GROUP_TASK), exercising the DumpV4 session-up
         // sync recording into the group adj_out (Phase 5b / N>1 DumpV4 ③).
         &[
-            ("ZEBRA_XDP_BFD_ECHO_MODE", "skb"),
             ("ZEBRA_BGP_SHARDS", shards.as_str()),
             ("ZEBRA_BGP_EGRESS_GROUP_TASK", "1"),
         ],
@@ -578,10 +579,7 @@ async fn start_zebra_rs_sync_chunk(world: &mut World, namespace: String, chunk: 
         // cursor: the session-up dump runs `chunk` prefixes per main-loop
         // tick instead of one uninterruptible pass. A small chunk forces
         // many ticks so the chunked path is actually exercised.
-        &[
-            ("ZEBRA_XDP_BFD_ECHO_MODE", "skb"),
-            ("ZEBRA_BGP_SYNC_CHUNK", chunk.as_str()),
-        ],
+        &[("ZEBRA_BGP_SYNC_CHUNK", chunk.as_str())],
         "zebra-rs",
         &[
             "--daemon",
@@ -625,7 +623,6 @@ async fn start_zebra_rs_sync_chunk_egress(
         // DELAY_MS slows the egress writer so the pending-UPDATE queue
         // backs up deterministically (no kernel-buffer / tc dependence).
         &[
-            ("ZEBRA_XDP_BFD_ECHO_MODE", "skb"),
             ("ZEBRA_BGP_SYNC_CHUNK", chunk.as_str()),
             ("ZEBRA_BGP_SYNC_EGRESS_HIGH", egress_high.as_str()),
             ("ZEBRA_BGP_WRITER_DELAY_MS", writer_delay.as_str()),

--- a/zebra-rs/src/bfd/inst.rs
+++ b/zebra-rs/src/bfd/inst.rs
@@ -175,6 +175,11 @@ pub enum Message {
     /// evaluated in XDP/`bpf_timer`). Drives the same transition as the
     /// userspace detection timer.
     DetectDown { discr: u32 },
+    /// The cradle BFD engine became reachable (its `WatchBfd` stream
+    /// connected). Sessions created before the async connection advertised
+    /// echo-rx 0 and left the watchdog unarmed (readiness was false at
+    /// creation); re-evaluate them now that the engine is confirmed up.
+    HelperReady,
     /// The cradle BFD engine became unreachable (its `WatchBfd` stream
     /// dropped). Sessions still counting on the in-kernel watchdog revert to
     /// userspace detection.
@@ -585,6 +590,11 @@ impl Bfd {
     }
 
     pub async fn event_loop(&mut self) {
+        // `Bfd::new` runs on the sync config-commit path, so the Echo/detect
+        // driver could not be spawned there. The event loop runs on the tokio
+        // runtime, so start it now — this is the point cradle's WatchBfd stream
+        // begins and readiness can flip on.
+        self.reflectors.ensure_driver();
         loop {
             tokio::select! {
                 Some(msg) = self.rx.recv() => match msg {
@@ -594,6 +604,7 @@ impl Bfd {
                     Message::DetectExpired { key } => self.on_detect_expired(key),
                     Message::EchoDown { discr } => self.on_echo_down(discr),
                     Message::DetectDown { discr } => self.on_detect_down(discr),
+                    Message::HelperReady => self.on_helper_ready(),
                     Message::HelperGone => self.on_helper_gone(),
                 },
                 // BFD's only config is the top-level `bfd { tracing }` flag;
@@ -874,6 +885,33 @@ impl Bfd {
         }
         self.echo_originate_reconcile(key);
         self.detect_offload_reconcile(key);
+    }
+
+    /// The cradle BFD engine became reachable (its `WatchBfd` stream connected).
+    /// Unlike the old per-interface child — which spawned synchronously in
+    /// `add_session`, so `is_ready` was already true when a session was created
+    /// — the gRPC engine connects *asynchronously* after zebra starts. Sessions
+    /// created in that window captured `echo_ready = false` and left the
+    /// watchdog unarmed. Re-evaluate every single-hop Echo/detect session now:
+    /// refresh `echo_ready` (so the honest non-zero echo-rx advertisement goes
+    /// out on the next control Tx and the peer starts looping Echo back) and
+    /// re-run the originate / detect reconciles (arming the watchdog). Runs on
+    /// every (re)connect; idempotent — a no-op once sessions are already ready.
+    fn on_helper_ready(&mut self) {
+        let active: Vec<SessionKey> = self
+            .sessions
+            .iter()
+            .filter(|(k, s)| (!s.echo_mode.is_off() || s.detect_offload) && !k.multihop)
+            .map(|(k, _)| *k)
+            .collect();
+        for key in active {
+            let ready = self.reflectors.is_ready(key.ifindex);
+            if let Some(s) = self.sessions.get_by_key_mut(&key) {
+                s.echo_ready = ready;
+            }
+            self.echo_originate_reconcile(key);
+            self.detect_offload_reconcile(key);
+        }
     }
 
     /// The cradle BFD engine became unreachable (its `WatchBfd` stream dropped).

--- a/zebra-rs/src/bfd/reflector.rs
+++ b/zebra-rs/src/bfd/reflector.rs
@@ -73,8 +73,13 @@ pub struct EchoReflectors {
     /// the honest-advertise / arm gate. Global (engine reachability), not
     /// per-interface.
     connected: Arc<AtomicBool>,
+    /// Deferred driver-task inputs, taken by [`Self::ensure_driver`] at BFD
+    /// event-loop start. The instance is constructed on the *sync* config-commit
+    /// path (no tokio runtime), so spawning the driver in `new` would silently
+    /// no-op; the event loop runs on the runtime, so we spawn it there.
+    pending: Option<(UnboundedReceiver<BfdCmd>, UnboundedSender<Message>)>,
     /// The driver task (arm/disarm + WatchBfd consumer). Aborts when dropped.
-    /// `None` when constructed outside a tokio runtime (sync unit tests).
+    /// `None` until [`Self::ensure_driver`] runs (or outside a runtime).
     _task: Option<Task<()>>,
     /// Test-only readiness override: unit tests have no cradle engine, so the
     /// readiness-gated paths would be untestable without it.
@@ -86,26 +91,40 @@ impl EchoReflectors {
     pub fn new(main_tx: UnboundedSender<Message>) -> Self {
         let (cmd_tx, cmd_rx) = mpsc::unbounded_channel();
         let connected = Arc::new(AtomicBool::new(false));
-        // Spawn the driver only when a runtime is present. Sync unit tests have
-        // none — and no engine to reach — so they exercise the bookkeeping with
-        // `connected == false` (plus the test-only readiness override).
-        let _task = if tokio::runtime::Handle::try_current().is_ok() {
-            Some(Task::spawn(bfd_driver(
-                resolve_endpoint(),
-                cmd_rx,
-                main_tx,
-                connected.clone(),
-            )))
-        } else {
-            None
-        };
+        // Defer the driver spawn to [`Self::ensure_driver`]: `new` runs on the
+        // *sync* config-commit path (no tokio runtime), where `Task::spawn`
+        // would panic / no-op and the driver would never connect. The BFD event
+        // loop calls `ensure_driver` on the runtime. Sync unit tests never call
+        // it, so they exercise the bookkeeping with `connected == false` (plus
+        // the test-only readiness override).
         Self {
             by_ifindex: HashMap::new(),
             cmd_tx,
             connected,
-            _task,
+            pending: Some((cmd_rx, main_tx)),
+            _task: None,
             #[cfg(test)]
             ready_override: std::collections::HashSet::new(),
+        }
+    }
+
+    /// Spawn the cradle gRPC driver task if it has not started yet. Idempotent;
+    /// must be called from within a tokio runtime (the BFD event loop). A no-op
+    /// outside a runtime, so the deferred inputs survive for a later call.
+    pub fn ensure_driver(&mut self) {
+        if self._task.is_some() {
+            return;
+        }
+        if tokio::runtime::Handle::try_current().is_err() {
+            return;
+        }
+        if let Some((cmd_rx, main_tx)) = self.pending.take() {
+            self._task = Some(Task::spawn(bfd_driver(
+                resolve_endpoint(),
+                cmd_rx,
+                main_tx,
+                self.connected.clone(),
+            )));
         }
     }
 
@@ -180,6 +199,11 @@ async fn bfd_driver(
             Ok(mut stream) => {
                 connected.store(true, Ordering::Relaxed);
                 bfd_info!("bfd: cradle BFD stream connected ({endpoint})");
+                // The engine connects asynchronously after zebra starts, so
+                // sessions created before now captured `echo_ready = false` and
+                // left the watchdog unarmed. Nudge the FSM to re-evaluate them
+                // (refresh the honest echo-rx advertisement + arm detection).
+                let _ = main_tx.send(Message::HelperReady);
                 loop {
                     tokio::select! {
                         cmd = cmd_rx.recv() => match cmd {


### PR DESCRIPTION
Phase 2 Slice 4 of the eBPF offload consolidation: migrate the `isis_bfd` Echo BDDs onto the cradle-engine datapath (Slices 1–3) and fix two ordering gaps the end-to-end run surfaced. Completes the absorption — `xdp-bfd-echo` is retired in cradle-rs#128.

## reflector.rs / inst.rs
- **Driver never spawned:** the gRPC driver was spawned in `EchoReflectors::new`, which runs on the *sync* config-commit path (no tokio runtime), so `Handle::try_current()` was always `Err` and it never connected. Defer the spawn to a new `ensure_driver()` called at `event_loop()` start (on the runtime).
- **Stale `echo_ready`:** the old per-interface child spawned synchronously in `add_session`, so `is_ready` was already true at session creation; the gRPC engine connects *asynchronously* after zebra starts, so sessions created in that window captured `echo_ready = false` and never re-evaluated → advertised echo-rx 0 forever. The driver now sends a new `Message::HelperReady` on connect; `on_helper_ready()` refreshes `echo_ready` + re-runs the originate/detect reconciles for every active session.

## BDD
- `isis_bfd_{ipv4,ipv6}_{p2p,lan}` echo configs: add `system ebpf enabled` (spawn the engine) + `interface <if> ebpf enabled` (SetPort → attach `cradle_xdp`, where the absorbed reflect/detect runs).
- `cucumber.rs`: remove the dead `ZEBRA_XDP_BFD_ECHO_MODE` env (the retired child helper's XDP mode; zebra no longer reads it) from all 7 start sites. `start_zebra_rs` sets `CRADLE_XDP_MODE=skb` for `isis_bfd*` features only — the cradle child inherits it and attaches generic XDP so Echo reflects off a bridge-enslaved veth (native `XDP_TX` needs the peer to have XDP; a bridge port doesn't). Scoped so SRv6/EVPN features keep native XDP.

Requires cradle with `CRADLE_XDP_MODE` support (cradle-rs#128, merged).

## Test plan
- `cargo test -p zebra-rs` — 1559 pass (67 BFD); workspace clippy `-D warnings` + `cargo fmt --check` clean.
- Live BDD vs zebra 26.7.4 + cradle 0.9.3 (post-#128): `isis_bfd_ipv4_p2p` (4), `isis_bfd_ipv6_p2p` (3), `isis_bfd_ipv4_lan` (3), `isis_bfd_ipv6_lan` (3) — all pass, clean teardown.

Generated with [Claude Code](https://claude.com/claude-code)