### PR TITLE
packaging: drop XDP/eBPF toolchain from setup-build-env.sh

### DIFF
--- a/packaging/setup-build-env.sh
+++ b/packaging/setup-build-env.sh
@@ -2,33 +2,28 @@
 #
 # setup-build-env.sh — prepare a build host for zebra-rs.
 #
-# Installs everything needed to build the Rust workspace, the `vty` shell, the
-# XDP/eBPF BFD Echo helper, and the Debian package, mirroring the steps in
-# README.md and the CI workflows under .github/workflows/ (ci.yaml,
-# build-amd64.yaml, build-arm64.yaml).
+# Installs everything needed to build the Rust workspace, the `vty` shell, and
+# the Debian package, mirroring the steps in README.md and the CI workflows
+# under .github/workflows/ (ci.yaml, build-amd64.yaml, build-arm64.yaml).
+#
+# The XDP/eBPF data-plane helpers (BFD Echo, TC EVPN replication) moved to
+# cradle-rs and ship in the cradle-rs .deb (zebra-rs Recommends: cradle-rs), so
+# this build needs only the stable Rust toolchain — no nightly, LLVM, or
+# bpf-linker.
 #
 # What it installs:
 #   * APT system packages (build-essential, protobuf-compiler, libpam0g-dev,
 #     bison, xxd, ...) for the workspace and the `vty` build.
 #   * The stable Rust toolchain via rustup (if cargo is not already present).
-#   * The nightly Rust toolchain + rust-src for the bpfel-unknown-none target.
-#   * LLVM (default 18) from apt.llvm.org, required to link bpf-linker.
-#   * bpf-linker (default 0.10.3, the locally validated combo with LLVM 18.1).
 #   * nfpm from the goreleaser APT repo, the Debian package builder.
 #
 # Usage:
 #   packaging/setup-build-env.sh [options]
 #
 # Options:
-#   --no-xdp     Skip the XDP/eBPF toolchain (nightly rust-src, LLVM, bpf-linker).
-#                Use this if you only build with `make all` / `cargo test`.
 #   --no-nfpm    Skip nfpm (only needed to build the .deb package).
 #   --no-rust    Do not install rustup/Rust (assume a toolchain is present).
 #   -h, --help   Show this help and exit.
-#
-# Environment overrides:
-#   LLVM_VERSION        LLVM major version to install (default: 18).
-#   BPF_LINKER_VERSION  bpf-linker version to install (default: 0.10.3).
 #
 # The script is idempotent: re-running it skips work that is already done.
 
@@ -36,23 +31,17 @@ set -euo pipefail
 
 # ---- configuration -----------------------------------------------------------
 
-LLVM_VERSION="${LLVM_VERSION:-18}"
-BPF_LINKER_VERSION="${BPF_LINKER_VERSION:-0.10.3}"
-
-INSTALL_XDP=1
 INSTALL_NFPM=1
 INSTALL_RUST=1
 
 # System packages. build-essential/pkg-config/curl drive the `vty` C build (GNU
 # bash compiled from source); protobuf-compiler + libpam0g-dev are the only ones
-# the plain `cargo build`/`cargo test` needs; bison/xxd complete
-# the `vty` shell build. wget is used to fetch the LLVM installer; git/make round
-# out the build.
+# the plain `cargo build`/`cargo test` needs; bison/xxd complete the `vty` shell
+# build. git/make round out the build.
 APT_PACKAGES=(
     build-essential
     pkg-config
     curl
-    wget
     git
     make
     protobuf-compiler
@@ -85,7 +74,6 @@ need_cmd() { command -v "$1" >/dev/null 2>&1; }
 
 while [ $# -gt 0 ]; do
     case "$1" in
-        --no-xdp)   INSTALL_XDP=0 ;;
         --no-nfpm)  INSTALL_NFPM=0 ;;
         --no-rust)  INSTALL_RUST=0 ;;
         -h|--help)  usage; exit 0 ;;
@@ -137,41 +125,7 @@ fi
 
 need_cmd cargo || die "cargo not found on PATH. Install Rust (rustup) or drop --no-rust, then re-run."
 
-# ---- 3. XDP/eBPF toolchain: nightly rust-src, LLVM, bpf-linker ---------------
-
-if [ "$INSTALL_XDP" -eq 1 ]; then
-    log "Installing nightly Rust toolchain with rust-src (for bpfel-unknown-none)"
-    rustup toolchain install nightly --component rust-src
-
-    LLVM_BIN="/usr/lib/llvm-${LLVM_VERSION}/bin"
-    if [ -x "${LLVM_BIN}/llvm-config" ] || [ -x "${LLVM_BIN}/clang" ]; then
-        log "LLVM ${LLVM_VERSION} already installed at ${LLVM_BIN}; skipping"
-    else
-        log "Installing LLVM ${LLVM_VERSION} from apt.llvm.org"
-        tmp_llvm="$(mktemp --suffix=.sh)"
-        wget -qO "$tmp_llvm" https://apt.llvm.org/llvm.sh
-        chmod +x "$tmp_llvm"
-        $SUDO "$tmp_llvm" "${LLVM_VERSION}"
-        rm -f "$tmp_llvm"
-    fi
-
-    # bpf-linker links against the LLVM we just installed, so put it on PATH for
-    # the build. This export lives only for this script's lifetime.
-    export PATH="${LLVM_BIN}:$PATH"
-
-    installed_bpf_linker="$(cargo install --list 2>/dev/null \
-        | awk '/^bpf-linker /{gsub(/[v:()]/,""); print $2}')"
-    if [ "$installed_bpf_linker" = "$BPF_LINKER_VERSION" ]; then
-        log "bpf-linker ${BPF_LINKER_VERSION} already installed; skipping"
-    else
-        log "Installing bpf-linker ${BPF_LINKER_VERSION} (linked against LLVM ${LLVM_VERSION})"
-        cargo install bpf-linker --version "${BPF_LINKER_VERSION}" --locked
-    fi
-else
-    info "Skipping XDP/eBPF toolchain (--no-xdp). 'make xdp-bfd-echo' and the .deb build need it."
-fi
-
-# ---- 4. nfpm (Debian package builder) ---------------------------------------
+# ---- 3. nfpm (Debian package builder) ---------------------------------------
 
 if [ "$INSTALL_NFPM" -eq 1 ]; then
     if need_cmd nfpm; then
@@ -193,12 +147,6 @@ log "Build environment ready."
 echo
 info "Next steps:"
 info "  make all                 # build the workspace + vty shell"
-if [ "$INSTALL_XDP" -eq 1 ]; then
-    info "  make xdp-bfd-echo        # build the XDP BFD Echo helper"
-    info ""
-    info "  If a shell can't find bpf-linker's LLVM, add it to PATH:"
-    info "      export PATH=\"/usr/lib/llvm-${LLVM_VERSION}/bin:\$PATH\""
-fi
 if [ "$INSTALL_NFPM" -eq 1 ]; then
     info "  cd packaging && make ${ARCH}   # build the .deb package"
 fi


### PR DESCRIPTION
## Summary

The XDP/eBPF data-plane helpers (BFD Echo, TC EVPN replication) moved to cradle-rs and ship in the cradle-rs `.deb` (`zebra-rs Recommends: cradle-rs`). The zebra-rs build therefore no longer needs the nightly Rust toolchain, LLVM, or bpf-linker. This aligns `setup-build-env.sh` with the note already in `packaging/Makefile`.

Removed everything that only served the XDP toolchain:
- The nightly Rust + `rust-src`, LLVM-from-apt.llvm.org, and `bpf-linker` install step.
- The `--no-xdp` flag, `INSTALL_XDP`, and its arg-parsing branch.
- The `LLVM_VERSION` / `BPF_LINKER_VERSION` config vars and env overrides.
- `wget` from the apt dependency list (used only to fetch the LLVM installer).
- The `make xdp-bfd-echo` / LLVM-PATH hints in "Next steps".

Updated the header comments to reflect the cradle-rs handoff. Net: build needs only the stable toolchain.

## Test plan

- `bash -n packaging/setup-build-env.sh` — passes.
- `packaging/setup-build-env.sh --help` — renders updated usage.
- `.deb` build path unaffected: `packaging/Makefile` no longer builds the XDP/TC helpers, so dropping the toolchain doesn't break `cd packaging && make`.

Generated with [Claude Code](https://claude.com/claude-code)