### PR TITLE
bfd: auto-attach cradle_xdp on Echo/detect-offload interfaces

### DIFF
--- a/bdd/Makefile
+++ b/bdd/Makefile
@@ -303,6 +303,10 @@ isis_bfd_ipv4_p2p_echo:
 	mkdir -p allure-results
 	cargo test --test cucumber -- --concurrency=1 --tags "@isis_bfd_ipv4_p2p and @bfd_echo"
 
+isis_bfd_ipv4_p2p_autoattach:
+	mkdir -p allure-results
+	cargo test --test cucumber -- --concurrency=1 --tags "@isis_bfd_ipv4_p2p and @bfd_autoattach"
+
 isis_bfd_ipv4_lan:
 	mkdir -p allure-results
 	cargo test --test cucumber -- --concurrency=1 --tags "@isis_bfd_ipv4_lan and not @bfd_echo"

--- a/bdd/tests/configs/isis_bfd_ipv4_p2p/z1-echo-both-autoattach.yaml
+++ b/bdd/tests/configs/isis_bfd_ipv4_p2p/z1-echo-both-autoattach.yaml
@@ -1,0 +1,28 @@
+system:
+  ebpf:
+    enabled: true
+interface:
+- if-name: lo
+  ipv4:
+    address: 10.255.0.1/32
+- if-name: i1
+  ipv4:
+    address: 10.0.1.1/24
+router:
+  isis:
+    net: 49.0001.0000.0000.0001.00
+    is-type: level-2-only
+    hostname: z1
+    interface:
+    - if-name: lo
+      circuit-type: level-2-only
+      ipv4:
+        enabled: true
+    - if-name: i1
+      circuit-type: level-2-only
+      network-type: point-to-point
+      ipv4:
+        enabled: true
+      bfd:
+        enabled: true
+        echo-mode: both

--- a/bdd/tests/configs/isis_bfd_ipv4_p2p/z2-echo-both-autoattach.yaml
+++ b/bdd/tests/configs/isis_bfd_ipv4_p2p/z2-echo-both-autoattach.yaml
@@ -1,0 +1,28 @@
+system:
+  ebpf:
+    enabled: true
+interface:
+- if-name: lo
+  ipv4:
+    address: 10.255.0.2/32
+- if-name: i1
+  ipv4:
+    address: 10.0.1.2/24
+router:
+  isis:
+    net: 49.0001.0000.0000.0002.00
+    is-type: level-2-only
+    hostname: z2
+    interface:
+    - if-name: lo
+      circuit-type: level-2-only
+      ipv4:
+        enabled: true
+    - if-name: i1
+      circuit-type: level-2-only
+      network-type: point-to-point
+      ipv4:
+        enabled: true
+      bfd:
+        enabled: true
+        echo-mode: both

--- a/bdd/tests/features/isis_bfd_ipv4_p2p.feature
+++ b/bdd/tests/features/isis_bfd_ipv4_p2p.feature
@@ -118,6 +118,45 @@ Feature: IS-IS BFD over an IPv4 point-to-point link
     And I delete namespace "z2"
     Then the test environment should be clean
 
+  @bfd_echo @bfd_autoattach
+  Scenario: BFD Echo auto-attaches eBPF without an explicit interface ebpf line
+    # Same as "Echo in both directions" but the configs enable only
+    # `system ebpf enabled` — NOT `interface i1 ebpf enabled`. Echo reflection
+    # only works when cradle_xdp is attached to i1, so if the session comes up
+    # with echo both and survives a BFD-down/restore cycle, the interface was
+    # auto-attached purely because a single-hop echo session runs on it.
+    Given a clean test environment
+    When I create namespace "z1"
+    And I create namespace "z2"
+    And I connect namespace "z1" interface "i1" to namespace "z2" interface "i1"
+    And I start zebra-rs in namespace "z1"
+    And I start zebra-rs in namespace "z2"
+    And I apply config "z1-echo-both-autoattach.yaml" to namespace "z1"
+    And I apply config "z2-echo-both-autoattach.yaml" to namespace "z2"
+    And I wait 10 seconds
+    Then isis neighbor in namespace "z1" at level 2 on interface "i1" should be up
+    And bfd session in namespace "z1" on interface "i1" should be up
+    And bfd session in namespace "z1" on interface "i1" should have echo both
+    And bfd session in namespace "z2" on interface "i1" should have echo both
+    And ping from "z1" to "10.255.0.2" should succeed
+    # The port was attached with no `interface ebpf enabled` leaf: exactly one
+    # BFD-sourced port, zero config-sourced.
+    And show command "show ebpf" in namespace "z1" should eventually contain "0 config, 1 bfd"
+    And show command "show ebpf" in namespace "z2" should eventually contain "0 config, 1 bfd"
+    When I drop bfd control packets in namespace "z2"
+    Then bfd session in namespace "z1" on interface "i1" should be down
+    And isis neighbor in namespace "z1" at level 2 on interface "i1" should not be up
+    When I restore bfd control packets in namespace "z2"
+    And I wait 20 seconds
+    Then bfd session in namespace "z1" on interface "i1" should be up
+    And isis neighbor in namespace "z1" at level 2 on interface "i1" should be up
+    And ping from "z1" to "10.255.0.2" should succeed
+    When I stop zebra-rs in namespace "z1"
+    And I stop zebra-rs in namespace "z2"
+    And I delete namespace "z1"
+    And I delete namespace "z2"
+    Then the test environment should be clean
+
   @bfd_echo
   Scenario: BFD with Echo in both directions
     Given a clean test environment

--- a/book/src/ch-16-00-ebpf.md
+++ b/book/src/ch-16-00-ebpf.md
@@ -50,6 +50,29 @@ link re-attaches under its new ifindex; moving the interface between VRFs
 re-binds the port in place; disabling detaches and flushes the MACs learned
 on the port.
 
+### Automatic port attach for BFD
+
+BFD's in-kernel datapaths — [Echo](ch-10-00-bfd.md) reflect/originate and the
+control-packet detection watchdog — run inside the same `cradle_xdp` program,
+so they only fire on interfaces the engine is attached to. To spare operators
+a redundant per-interface line, **a single-hop session that enables
+`echo-mode` or `detect-offload` auto-attaches its egress interface as a
+data-plane port** — no explicit `interface <name> ebpf enabled` is needed.
+
+The desired port set is the **union** of the config leaves and BFD's requests:
+a port stays attached while either side wants it, and BFD's auto-attach is
+released only when its last Echo/detect-offload session on that interface goes
+away *and* no `interface … ebpf enabled` leaf keeps it. Plain (control-packet)
+BFD needs no eBPF and does not trigger this. The engine itself must still be
+enabled with `system ebpf enabled true`. `show ebpf` labels each port's source
+(`config`, `bfd`, or `config,bfd`):
+
+```
+  Ports:           2 wanted (1 config, 1 bfd), 2 attached
+    enp0s6           ifindex 3      vrf 0     config      attached
+    enp0s7           ifindex 4      vrf 0     bfd         attached
+```
+
 ## Lifecycle
 
 The engine runs as a supervised child of zebra-rs:

--- a/docs/design/ebpf-offload-consolidation.md
+++ b/docs/design/ebpf-offload-consolidation.md
@@ -162,5 +162,16 @@ Phases 1–2 (`cradle-common` grows the shared types); wrong as an end state.
   release (≥ the Phase-0a import) is published and installed. Local dev/BDD keep
   working because `/usr/sbin/{xdp-bfd-echo,tc-evpn-replicate}` are already
   installed on this host.
+- 2026-07-13: **BFD auto-attach implemented** (branch `bfd-ebpf-enable`) —
+  realises the Phase-2 "a port whose only role is BFD gets `SetPort`" unlock on
+  the *zebra* side. A single-hop `echo-mode`/`detect-offload` session now
+  auto-enrols its egress interface as a cradle port, so `interface … ebpf
+  enabled` is no longer required alongside `system ebpf enabled` for BFD
+  offload (which S4 called out as datapath gap #3). Mechanism: an eager
+  `ConfigManager` channel carries `cradle::PortRequest::{Acquire,Release}`
+  edges from `EchoReflectors`' per-ifindex refcount to the cradle port
+  supervisor, which folds them into `reconcile_ports` as a **union** with
+  `if_ebpf`. Engine still gated on `system ebpf enabled` (chosen scope).
+  `show ebpf` labels each port `config`/`bfd`/`config,bfd`.
 </content>
 </invoke>

--- a/zebra-rs/src/bfd/inst.rs
+++ b/zebra-rs/src/bfd/inst.rs
@@ -339,6 +339,14 @@ impl Bfd {
         self.client_req.tx.clone()
     }
 
+    /// Wire the BFD → cradle auto-attach channel (from `ConfigManager`). The
+    /// Echo/detect-offload refcount then drives `Acquire`/`Release` edges so
+    /// the cradle port supervisor attaches `cradle_xdp` on each single-hop
+    /// session's interface without an explicit `interface … ebpf enabled`.
+    pub fn set_cradle_port_tx(&mut self, tx: UnboundedSender<crate::cradle::PortRequest>) {
+        self.reflectors.set_cradle_port_tx(tx);
+    }
+
     /// Apply a [`ClientReq`]. Public so pre-`serve` callers (notably
     /// the integration test) can drive the API directly without going
     /// through the channel; production callers go through

--- a/zebra-rs/src/bfd/reflector.rs
+++ b/zebra-rs/src/bfd/reflector.rs
@@ -17,6 +17,17 @@
 //! Echo to `system ebpf enabled` — the datapath that reflects/originates Echo
 //! is the cradle engine.
 //!
+//! `cradle_xdp` only runs on interfaces cradle has attached (its port set), so
+//! a single-hop Echo/detect-offload session must make its egress interface a
+//! cradle port. Rather than force an explicit `interface … ebpf enabled` line,
+//! the per-ifindex refcount here doubles as an **auto-attach signal**: the 0→1
+//! edge sends [`crate::cradle::PortRequest::Acquire`] and the last release
+//! sends `Release` down the channel wired by `config::bfd::spawn_bfd`, and the
+//! cradle port supervisor folds those ifindexes into its attach set (a union
+//! with the config leaves). The datapath itself is still keyed by
+//! discriminator, not interface — this signal only governs *where cradle_xdp
+//! is attached*.
+//!
 //! Reachability is soft: on a lost stream (engine restart) sessions revert to
 //! userspace detection (the stretched backstop timer), and re-arm on the next
 //! reconcile once the engine is back.
@@ -30,6 +41,7 @@ use std::time::Duration;
 use tokio::sync::mpsc::{self, UnboundedReceiver, UnboundedSender};
 
 use crate::context::Task;
+use crate::cradle::PortRequest;
 use crate::fib::cradle::CradleFib;
 
 use super::inst::Message;
@@ -78,6 +90,13 @@ pub struct EchoReflectors {
     /// path (no tokio runtime), so spawning the driver in `new` would silently
     /// no-op; the event loop runs on the runtime, so we spawn it there.
     pending: Option<(UnboundedReceiver<BfdCmd>, UnboundedSender<Message>)>,
+    /// BFD → cradle auto-attach channel (from `ConfigManager`, wired at
+    /// spawn). On the first Echo/detect-offload session for an ifindex we send
+    /// [`PortRequest::Acquire`]; on the last we send `Release` — so the cradle
+    /// port supervisor attaches / detaches `cradle_xdp` on that interface
+    /// without an explicit `interface … ebpf enabled` line. `None` when no
+    /// cradle stream was wired (e.g. unit tests) — then it is pure bookkeeping.
+    cradle_port_tx: Option<UnboundedSender<PortRequest>>,
     /// The driver task (arm/disarm + WatchBfd consumer). Aborts when dropped.
     /// `None` until [`Self::ensure_driver`] runs (or outside a runtime).
     _task: Option<Task<()>>,
@@ -103,9 +122,16 @@ impl EchoReflectors {
             connected,
             pending: Some((cmd_rx, main_tx)),
             _task: None,
+            cradle_port_tx: None,
             #[cfg(test)]
             ready_override: std::collections::HashSet::new(),
         }
+    }
+
+    /// Wire the BFD → cradle auto-attach channel. Called once at spawn (see
+    /// `config::bfd::spawn_bfd`); tests leave it unset.
+    pub fn set_cradle_port_tx(&mut self, tx: UnboundedSender<PortRequest>) {
+        self.cradle_port_tx = Some(tx);
     }
 
     /// Spawn the cradle gRPC driver task if it has not started yet. Idempotent;
@@ -137,18 +163,35 @@ impl EchoReflectors {
         }
     }
 
-    /// Note one more single-hop Echo/detect session on `ifindex`.
+    /// Note one more single-hop Echo/detect session on `ifindex`. On the 0→1
+    /// edge, ask the cradle port supervisor to attach `cradle_xdp` there.
     pub fn acquire(&mut self, ifindex: u32) {
-        *self.by_ifindex.entry(ifindex).or_insert(0) += 1;
+        let count = self.by_ifindex.entry(ifindex).or_insert(0);
+        *count += 1;
+        if *count == 1 {
+            self.send_port_request(PortRequest::Acquire(ifindex));
+        }
     }
 
     /// Drop one reference; forget the ifindex when its last session goes away.
+    /// On the →0 edge, ask the cradle port supervisor to detach (unless the
+    /// operator also enabled the port via config — cradle keeps it while
+    /// either side wants it).
     pub fn release(&mut self, ifindex: u32) {
         if let Some(r) = self.by_ifindex.get_mut(&ifindex) {
             *r = r.saturating_sub(1);
             if *r == 0 {
                 self.by_ifindex.remove(&ifindex);
+                self.send_port_request(PortRequest::Release(ifindex));
             }
+        }
+    }
+
+    /// Forward a port request to the cradle supervisor when the channel is
+    /// wired (a no-op otherwise, e.g. in unit tests).
+    fn send_port_request(&self, req: PortRequest) {
+        if let Some(tx) = &self.cradle_port_tx {
+            let _ = tx.send(req);
         }
     }
 
@@ -179,6 +222,21 @@ impl EchoReflectors {
     #[cfg(test)]
     pub fn clear_ready_for_test(&mut self, ifindex: u32) {
         self.ready_override.remove(&ifindex);
+    }
+}
+
+impl Drop for EchoReflectors {
+    /// On teardown (BFD despawn / process exit) release every held ifindex, so
+    /// the cradle port supervisor detaches any port it auto-attached for BFD
+    /// rather than leaving `cradle_xdp` on it. A no-op when the channel was
+    /// never wired, or when cradle is already gone (the send just fails).
+    fn drop(&mut self) {
+        if self.cradle_port_tx.is_none() {
+            return;
+        }
+        for ifindex in self.by_ifindex.keys() {
+            self.send_port_request(PortRequest::Release(*ifindex));
+        }
     }
 }
 
@@ -356,6 +414,55 @@ mod tests {
         let mut r = EchoReflectors::new(tx);
         r.release(12345); // must not panic / underflow
         assert_eq!(r.refcount(12345), 0);
+    }
+
+    #[test]
+    fn acquire_release_emit_cradle_port_edges() {
+        let (tx, _rx) = mpsc::unbounded_channel();
+        let (port_tx, mut port_rx) = mpsc::unbounded_channel();
+        let mut r = EchoReflectors::new(tx);
+        r.set_cradle_port_tx(port_tx);
+
+        // First session on an ifindex asks cradle to attach it.
+        r.acquire(10);
+        assert!(matches!(port_rx.try_recv(), Ok(PortRequest::Acquire(10))));
+
+        // A second session on the same ifindex is a no-op edge.
+        r.acquire(10);
+        assert!(port_rx.try_recv().is_err());
+
+        // Dropping one of two references keeps the port attached (no edge).
+        r.release(10);
+        assert!(port_rx.try_recv().is_err());
+
+        // The last release asks cradle to detach.
+        r.release(10);
+        assert!(matches!(port_rx.try_recv(), Ok(PortRequest::Release(10))));
+    }
+
+    #[test]
+    fn drop_releases_held_ifindexes() {
+        let (tx, _rx) = mpsc::unbounded_channel();
+        let (port_tx, mut port_rx) = mpsc::unbounded_channel();
+        let mut r = EchoReflectors::new(tx);
+        r.set_cradle_port_tx(port_tx);
+        r.acquire(7);
+        assert!(matches!(port_rx.try_recv(), Ok(PortRequest::Acquire(7))));
+        // Teardown must detach anything still held (BFD despawn / exit).
+        drop(r);
+        assert!(matches!(port_rx.try_recv(), Ok(PortRequest::Release(7))));
+    }
+
+    #[test]
+    fn no_cradle_channel_is_pure_bookkeeping() {
+        // Without a wired channel, acquire/release must not panic and just
+        // maintain the refcount (the unit-test / no-cradle path).
+        let (tx, _rx) = mpsc::unbounded_channel();
+        let mut r = EchoReflectors::new(tx);
+        r.acquire(3);
+        assert_eq!(r.refcount(3), 1);
+        r.release(3);
+        assert_eq!(r.refcount(3), 0);
     }
 
     #[test]

--- a/zebra-rs/src/config/bfd.rs
+++ b/zebra-rs/src/config/bfd.rs
@@ -23,7 +23,13 @@ pub fn spawn_bfd(config: &ConfigManager) {
     // a `rib` field for uniformity with the other protocols.
     let _ = config; // borrow ConfigManager only when needed.
     match inst::Bfd::new(ProtoContext::default_table_no_rib()) {
-        Ok(bfd) => {
+        Ok(mut bfd) => {
+            // Let the BFD Echo/detect-offload driver auto-attach cradle_xdp on
+            // the interfaces its single-hop sessions run over, so those ports
+            // need no explicit `interface … ebpf enabled`. Created eagerly in
+            // `ConfigManager::new`, so it is valid whether or not cradle has
+            // spawned yet.
+            bfd.set_cradle_port_tx(config.cradle_port_tx.clone());
             config.subscribe("bfd", bfd.cm.tx.clone());
             config.subscribe_show("bfd", bfd.show.tx.clone());
             // Publish the inbound client-request handle on the

--- a/zebra-rs/src/config/cradle.rs
+++ b/zebra-rs/src/config/cradle.rs
@@ -25,7 +25,13 @@ pub fn spawn_cradle(config: &ConfigManager) {
             return;
         }
         let (rib_client, rib_rx) = config.subscribe_to_rib_global_links("cradle");
-        let cradle = crate::cradle::Cradle::new(rib_client, rib_rx);
+        // Take the BFD → cradle auto-attach stream (created eagerly in
+        // `ConfigManager::new`, so it exists regardless of spawn order). BFD
+        // may have already queued `Acquire` edges before this task started;
+        // the unbounded channel buffers them and the event loop drains them on
+        // the first poll.
+        let port_rx = config.cradle_port_rx.borrow_mut().take();
+        let cradle = crate::cradle::Cradle::new(rib_client, rib_rx, port_rx);
         config.subscribe("cradle", cradle.cm.tx.clone());
         config.subscribe_show("cradle", cradle.show.tx.clone());
         let task = crate::cradle::serve(cradle);

--- a/zebra-rs/src/config/manager.rs
+++ b/zebra-rs/src/config/manager.rs
@@ -29,7 +29,7 @@ use std::cell::RefCell;
 use std::collections::{HashMap, HashSet};
 use std::path::PathBuf;
 use std::rc::Rc;
-use tokio::sync::mpsc::{self, Receiver, Sender, UnboundedSender};
+use tokio::sync::mpsc::{self, Receiver, Sender, UnboundedReceiver, UnboundedSender};
 use tokio::sync::oneshot;
 
 pub struct ConfigStore {
@@ -271,6 +271,20 @@ pub struct ConfigManager {
     /// pre-spawns BGP before IS-IS when both appear in one commit (same
     /// by-value contract as `bfd_client_tx`).
     pub bgp_tx: RefCell<Option<mpsc::Sender<crate::bgp::inst::Message>>>,
+    /// Sender side of the BFD → cradle auto-attach stream. Unlike the
+    /// `*_client_tx` handles above this is created eagerly in [`Self::new`] and
+    /// never cleared, so it is valid regardless of BFD/cradle spawn order: BFD
+    /// clones it at spawn and emits [`crate::cradle::PortRequest`] edges as
+    /// single-hop Echo / detect-offload sessions come and go, and the cradle
+    /// port supervisor folds those ifindexes into its attach set (union with
+    /// `interface … ebpf enabled`). Unbounded so edges buffer harmlessly until
+    /// the cradle task (if any) takes the receiver.
+    pub cradle_port_tx: UnboundedSender<crate::cradle::PortRequest>,
+    /// Receiver half of [`Self::cradle_port_tx`], taken by
+    /// [`super::cradle::spawn_cradle`] the first time the cradle task starts.
+    /// `None` after it has been taken (or if cradle never spawns — the sender
+    /// then just buffers into a channel nobody drains, which is harmless).
+    pub(super) cradle_port_rx: RefCell<Option<UnboundedReceiver<crate::cradle::PortRequest>>>,
     pub protocol_tasks: RefCell<HashMap<String, Task<()>>>,
 }
 
@@ -297,6 +311,7 @@ impl ConfigManager {
         };
 
         let (tx, rx) = mpsc::channel(255);
+        let (cradle_port_tx, cradle_port_rx) = mpsc::unbounded_channel();
         let mut cm = Self {
             yang_path,
             config_path,
@@ -315,6 +330,8 @@ impl ConfigManager {
             bfd_client_tx: RefCell::new(None),
             stamp_client_tx: RefCell::new(None),
             nd_client_tx: RefCell::new(None),
+            cradle_port_tx,
+            cradle_port_rx: RefCell::new(Some(cradle_port_rx)),
             protocol_tasks: RefCell::new(HashMap::new()),
         };
         cm.init()?;

--- a/zebra-rs/src/cradle/inst.rs
+++ b/zebra-rs/src/cradle/inst.rs
@@ -55,6 +55,27 @@ struct LinkState {
     vni: Option<u32>,
 }
 
+/// A request from another subsystem for the cradle port supervisor to
+/// attach/detach `cradle_xdp` on an interface, *independent* of the
+/// operator's `interface … ebpf enabled` config. Today the only source is
+/// BFD: a single-hop Echo / detect-offload session needs its egress port to
+/// be a cradle port so the in-kernel `cradle_xdp` reflect / `bpf_timer`
+/// watchdog actually runs (otherwise the arm RPCs fire but nothing is
+/// attached). Keyed by ifindex — the [`Cradle`] instance resolves the name
+/// from its own link state, so it survives interface renames and needs no
+/// name plumbing on the BFD side.
+///
+/// The desired port set is the *union* of these requests and the config
+/// leaves: a port stays attached while either side wants it.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub enum PortRequest {
+    /// This ifindex now needs the eBPF datapath (first Echo/detect-offload
+    /// session on it appeared).
+    Acquire(u32),
+    /// This ifindex no longer needs it (its last such session went away).
+    Release(u32),
+}
+
 /// How an `interface … ebpf enabled` port binds into the data plane,
 /// derived from the interface's `master` in link state.
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
@@ -105,6 +126,15 @@ pub struct Cradle {
     grpc_endpoint: Option<String>,
     /// Staged `interface <name> ebpf enabled` leaves, keyed by if-name.
     if_ebpf: BTreeMap<String, bool>,
+    /// Ifindexes another subsystem (BFD) has asked to attach automatically —
+    /// see [`PortRequest`]. Folded into the port reconcile as a union with
+    /// `if_ebpf`, so a BFD Echo/detect-offload interface becomes a cradle
+    /// port without an explicit `interface … ebpf enabled` line.
+    bfd_ports: std::collections::HashSet<u32>,
+    /// Inbound [`PortRequest`] stream (from BFD). Always present: when no
+    /// producer is wired the receiver is a dropped-sender channel that never
+    /// fires, so the event-loop branch stays uniform with the others.
+    port_rx: UnboundedReceiver<PortRequest>,
     /// Kernel links keyed by ifindex, from the RIB subscription (seeded
     /// by the link dump at subscribe time; `global_links`, so VRF
     /// enslavement never hides a link).
@@ -132,8 +162,16 @@ pub struct Cradle {
 }
 
 impl Cradle {
-    pub fn new(rib: RibClient, rib_rx: UnboundedReceiver<RibRx>) -> Self {
+    pub fn new(
+        rib: RibClient,
+        rib_rx: UnboundedReceiver<RibRx>,
+        port_rx: Option<UnboundedReceiver<PortRequest>>,
+    ) -> Self {
         let (events_tx, events_rx) = mpsc::unbounded_channel();
+        // No producer wired (e.g. a direct test construction): a channel whose
+        // sender is immediately dropped resolves `recv()` to `None` forever, so
+        // the select branch simply never fires.
+        let port_rx = port_rx.unwrap_or_else(|| mpsc::unbounded_channel().1);
         Self {
             cm: ConfigChannel::new(),
             show: ShowChannel::new(),
@@ -145,6 +183,8 @@ impl Cradle {
             cradle_enabled: false,
             grpc_endpoint: None,
             if_ebpf: BTreeMap::new(),
+            bfd_ports: std::collections::HashSet::new(),
+            port_rx,
             links: HashMap::new(),
             bd_by_ifindex: HashMap::new(),
             bd_alloc: BTreeMap::new(),
@@ -168,6 +208,10 @@ impl Cradle {
                 }
                 Some(msg) = self.rib_rx.recv() => {
                     self.process_rib_msg(msg);
+                    self.reconcile_ports().await;
+                }
+                Some(req) = self.port_rx.recv() => {
+                    self.process_port_request(req);
                     self.reconcile_ports().await;
                 }
                 Some(ev) = self.events_rx.recv() => {
@@ -236,6 +280,58 @@ impl Cradle {
             }
             _ => {}
         }
+    }
+
+    /// Record a BFD auto-attach request. The set drives the port reconcile
+    /// (union with `if_ebpf`); the caller re-reconciles right after. Edges are
+    /// idempotent — a duplicate Acquire/Release just leaves the set unchanged.
+    fn process_port_request(&mut self, req: PortRequest) {
+        match req {
+            PortRequest::Acquire(ifindex) => {
+                self.bfd_ports.insert(ifindex);
+            }
+            PortRequest::Release(ifindex) => {
+                self.bfd_ports.remove(&ifindex);
+            }
+        }
+    }
+
+    /// Whether `name` should carry the eBPF datapath: the operator enabled it
+    /// (`interface … ebpf enabled`) *or* a BFD session on its ifindex requested
+    /// it. Union semantics — a port stays wanted while either side wants it.
+    fn is_port_wanted(&self, name: &str) -> bool {
+        if self.if_ebpf.get(name).copied().unwrap_or(false) {
+            return true;
+        }
+        self.links
+            .iter()
+            .any(|(ifindex, l)| l.name == name && self.bfd_ports.contains(ifindex))
+    }
+
+    /// Whether a BFD auto-attach request currently covers `name` (used only to
+    /// label the source in `show ebpf`).
+    fn is_bfd_port(&self, name: &str) -> bool {
+        self.links
+            .iter()
+            .any(|(ifindex, l)| l.name == name && self.bfd_ports.contains(ifindex))
+    }
+
+    /// The full set of interface names that should be attached: the enabled
+    /// `if_ebpf` leaves plus every BFD-requested ifindex that resolves to a
+    /// known link. Sorted/deduped so the reconcile order is stable.
+    fn wanted_port_names(&self) -> Vec<String> {
+        let mut names: std::collections::BTreeSet<String> = self
+            .if_ebpf
+            .iter()
+            .filter(|(_, en)| **en)
+            .map(|(name, _)| name.clone())
+            .collect();
+        for ifindex in &self.bfd_ports {
+            if let Some(l) = self.links.get(ifindex) {
+                names.insert(l.name.clone());
+            }
+        }
+        names.into_iter().collect()
     }
 
     /// Re-derive every bridge's domain id from link state. Preference
@@ -507,14 +603,17 @@ impl Cradle {
 
         if json {
             let ports: Vec<serde_json::Value> = self
-                .if_ebpf
+                .wanted_port_names()
                 .iter()
-                .filter(|(_, en)| **en)
-                .map(|(name, _)| {
+                .map(|name| {
                     let binding = self.port_binding(name);
+                    let config = self.if_ebpf.get(name).copied().unwrap_or(false);
+                    let bfd = self.is_bfd_port(name);
                     serde_json::json!({
                         "name": name,
                         "ifindex": binding.map(|(i, _)| i),
+                        "config": config,
+                        "bfd": bfd,
                         "vrf": binding.and_then(|(_, role)| match role {
                             PortRole::L3 { vrf } => Some(vrf),
                             PortRole::L2 { .. } => None,
@@ -589,20 +688,28 @@ impl Cradle {
                 writeln!(out, "  Engine v4 FIB:   mode {}", f.fib4_mode).unwrap();
             }
         }
-        let enabled: Vec<&String> = self
-            .if_ebpf
-            .iter()
-            .filter(|(_, en)| **en)
-            .map(|(name, _)| name)
-            .collect();
+        let wanted = self.wanted_port_names();
+        let config_count = self.if_ebpf.values().filter(|en| **en).count();
+        let bfd_count = wanted.iter().filter(|n| self.is_bfd_port(n)).count();
         writeln!(
             out,
-            "  Ports:           {} configured, {} attached",
-            enabled.len(),
+            "  Ports:           {} wanted ({config_count} config, {bfd_count} bfd), {} attached",
+            wanted.len(),
             self.applied.len()
         )
         .unwrap();
-        for name in enabled {
+        for name in &wanted {
+            // How this port was requested: operator config, BFD auto-attach,
+            // or both.
+            let src = match (
+                self.if_ebpf.get(name).copied().unwrap_or(false),
+                self.is_bfd_port(name),
+            ) {
+                (true, true) => "config,bfd",
+                (true, false) => "config",
+                (false, true) => "bfd",
+                (false, false) => "-",
+            };
             match (self.port_binding(name), self.applied.get(name)) {
                 (Some(binding), applied) => {
                     let (ifindex, role) = binding;
@@ -617,12 +724,12 @@ impl Cradle {
                     };
                     writeln!(
                         out,
-                        "    {name:<16} ifindex {ifindex:<6} {role_col:<9} {state}"
+                        "    {name:<16} ifindex {ifindex:<6} {role_col:<9} {src:<11} {state}"
                     )
                     .unwrap();
                 }
                 (None, _) => {
-                    writeln!(out, "    {name:<16} {:<20} link absent", "-").unwrap();
+                    writeln!(out, "    {name:<16} {:<20} {src:<11} link absent", "-").unwrap();
                 }
             }
         }
@@ -740,7 +847,7 @@ impl Cradle {
         // get their learned MACs flushed at the end.
         let mut flush_after: Vec<String> = Vec::new();
         for (name, (applied_ifindex, applied_role)) in self.applied.clone() {
-            let enabled = self.if_ebpf.get(&name).copied().unwrap_or(false);
+            let enabled = self.is_port_wanted(&name);
             let binding = self.port_binding(&name);
             let same_device =
                 enabled && binding.is_some_and(|(ifindex, _)| ifindex == applied_ifindex);
@@ -768,16 +875,11 @@ impl Cradle {
         }
         self.sync_domains(&client).await;
 
-        // Phase B — apply `SetPort` for every enabled port whose (ifindex,
-        // role) isn't current: first attach, re-attach after a detach, and
-        // in-place role/VRF/bd moves (cradle overwrites the port entry and
-        // re-reconciles its derived routes).
-        let wanted: Vec<String> = self
-            .if_ebpf
-            .iter()
-            .filter(|(_, enabled)| **enabled)
-            .map(|(name, _)| name.clone())
-            .collect();
+        // Phase B — apply `SetPort` for every wanted port (config leaf or BFD
+        // auto-attach) whose (ifindex, role) isn't current: first attach,
+        // re-attach after a detach, and in-place role/VRF/bd moves (cradle
+        // overwrites the port entry and re-reconciles its derived routes).
+        let wanted = self.wanted_port_names();
         for name in wanted {
             let Some((ifindex, role)) = self.port_binding(&name) else {
                 continue;
@@ -824,4 +926,83 @@ pub fn serve(mut cradle: Cradle) -> Task<()> {
     Task::spawn(async move {
         cradle.event_loop().await;
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::rib::client::ProtoId;
+
+    /// A bare `Cradle` with dead RIB/port channels — enough to exercise the
+    /// pure port-selection helpers (`process_port_request`, `is_port_wanted`,
+    /// `wanted_port_names`) by poking `links`/`if_ebpf` directly.
+    fn test_cradle() -> Cradle {
+        let (rib_in_tx, _rib_in_rx) = mpsc::unbounded_channel();
+        let rib_client = RibClient::new(rib_in_tx, ProtoId::from_raw(0));
+        let (_rib_tx, rib_rx) = mpsc::unbounded_channel();
+        Cradle::new(rib_client, rib_rx, None)
+    }
+
+    fn add_link(c: &mut Cradle, ifindex: u32, name: &str) {
+        c.links.insert(
+            ifindex,
+            LinkState {
+                name: name.to_string(),
+                master: None,
+                vrf_table: None,
+                bridge: false,
+                vni: None,
+            },
+        );
+    }
+
+    #[test]
+    fn bfd_request_makes_port_wanted() {
+        let mut c = test_cradle();
+        add_link(&mut c, 5, "eth0");
+        assert!(!c.is_port_wanted("eth0"));
+
+        // A BFD Acquire on the ifindex enrolls the port, no config leaf.
+        c.process_port_request(PortRequest::Acquire(5));
+        assert!(c.is_port_wanted("eth0"));
+        assert!(c.is_bfd_port("eth0"));
+        assert_eq!(c.wanted_port_names(), vec!["eth0".to_string()]);
+
+        // Releasing the last session drops it (config never wanted it).
+        c.process_port_request(PortRequest::Release(5));
+        assert!(!c.is_port_wanted("eth0"));
+        assert!(c.wanted_port_names().is_empty());
+    }
+
+    #[test]
+    fn config_and_bfd_union() {
+        let mut c = test_cradle();
+        add_link(&mut c, 5, "eth0");
+
+        // Operator config alone wants it.
+        c.if_ebpf.insert("eth0".to_string(), true);
+        assert!(c.is_port_wanted("eth0"));
+        assert!(!c.is_bfd_port("eth0"));
+
+        // BFD also wants it — still one name, source is both.
+        c.process_port_request(PortRequest::Acquire(5));
+        assert!(c.is_bfd_port("eth0"));
+        assert_eq!(c.wanted_port_names(), vec!["eth0".to_string()]);
+
+        // BFD releasing does NOT detach while config still wants it.
+        c.process_port_request(PortRequest::Release(5));
+        assert!(c.is_port_wanted("eth0"));
+    }
+
+    #[test]
+    fn bfd_request_for_unknown_link_is_pending() {
+        let mut c = test_cradle();
+        // No link learned for ifindex 9 yet: recorded but not yet nameable, so
+        // it contributes nothing to the wanted set until the link appears.
+        c.process_port_request(PortRequest::Acquire(9));
+        assert!(c.wanted_port_names().is_empty());
+
+        add_link(&mut c, 9, "eth9");
+        assert_eq!(c.wanted_port_names(), vec!["eth9".to_string()]);
+    }
 }

--- a/zebra-rs/src/cradle/mod.rs
+++ b/zebra-rs/src/cradle/mod.rs
@@ -20,4 +20,4 @@ pub mod inst;
 mod show;
 pub mod supervisor;
 
-pub use inst::{Cradle, serve};
+pub use inst::{Cradle, PortRequest, serve};


### PR DESCRIPTION
## Summary

For BFD Echo / detect-offload to actually run in-kernel, the session's egress interface must be a cradle port so `cradle_xdp` (Echo reflect + `bpf_timer` watchdog) is attached to it. Until now that meant configuring **two** knobs — `system ebpf enabled` **and** `interface <if> ebpf enabled` — the latter being a redundant per-interface step.

This makes the per-interface attach **automatic**: a single-hop `echo-mode`/`detect-offload` session auto-enrols its egress interface as a cradle port. `interface <if> ebpf enabled` is no longer needed for BFD offload. The engine is still enabled globally via `system ebpf enabled` (unchanged); plain (control-packet) BFD needs no eBPF and does not trigger this.

## Mechanism

- `EchoReflectors`' existing per-ifindex Echo/detect refcount now doubles as an auto-attach signal: the 0→1 edge sends `cradle::PortRequest::Acquire(ifindex)`, the last release sends `Release`, plus a `Drop` sweep on teardown.
- The signal rides an **eager** `ConfigManager` channel created in `ConfigManager::new`, so it is valid regardless of BFD/cradle spawn order (unbounded → edges buffer until the cradle task drains them).
- The cradle port supervisor keeps a `bfd_ports` set and folds it into `reconcile_ports` and `show ebpf` as a **union** with the `interface … ebpf enabled` config leaves — a port stays attached while either side wants it; ifindex→name resolves from cradle's own link state.
- `show ebpf` labels each port `config` / `bfd` / `config,bfd`, and the count line reads `(N config, M bfd)`.

## Test plan

- `cargo clippy --workspace --all-targets -- -D warnings` and `cargo fmt --all --check`: clean.
- `cargo test -p zebra-rs`: **1565 passed, 0 failed** — includes new unit tests for the acquire/release edge emission + Drop (`bfd/reflector.rs`) and the config∪bfd union (`cradle/inst.rs`).
- **End-to-end BDD** (`make -C bdd isis_bfd_ipv4_p2p_autoattach`): new `@bfd_autoattach` scenario with configs enabling only `system ebpf enabled` (no `interface ebpf` line). Echo-both comes up on both ends, `show ebpf` reads `0 config, 1 bfd` on both, the session survives a BFD-down/restore cycle, and the topology tears down clean. Validated against cradle 0.9.4.

Realises the "a port whose only role is BFD gets attached" unlock from `docs/design/ebpf-offload-consolidation.md` and closes the Phase-2 S4 datapath gap.

Generated with [Claude Code](https://claude.com/claude-code)