### PR TITLE
srv6: operator replication-segment tees End.Replicate (RFC 9524) to cradle

### DIFF
--- a/bdd/tests/configs/cradle_srv6_replicate_zebra/crs1.yaml
+++ b/bdd/tests/configs/cradle_srv6_replicate_zebra/crs1.yaml
@@ -1,0 +1,19 @@
+# crs1 — a single PE running zebra-rs with the managed cradle engine. An
+# operator RFC 9524 replication-segment declares a local End.Replicate SID
+# and two downstream branches; zebra registers the SID (teed into cradle's
+# SRV6_LOCALSID) and tees the branch set to cradle's REPL_SEG.
+system:
+  ebpf:
+    enabled: true
+interface:
+- if-name: eth0
+  ebpf:
+    enabled: true
+segment-routing:
+  replication-segment:
+  - name: TREE1
+    sid: fd00:b::5
+    hop-limit-threshold: 0
+    branch:
+    - sid: fd00:1::100
+    - sid: fd00:2::100

--- a/bdd/tests/features/cradle_srv6_replicate_zebra.feature
+++ b/bdd/tests/features/cradle_srv6_replicate_zebra.feature
@@ -1,0 +1,51 @@
+@cradle_srv6_replicate_zebra
+Feature: zebra-rs operator replication-segment programs the cradle End.Replicate datapath (RFC 9524)
+  An operator `segment-routing replication-segment` declares a local SRv6
+  End.Replicate SID and its downstream branches. zebra-rs registers the SID —
+  which tees into the managed cradle engine's SRV6_LOCALSID, so the XDP stage
+  hands matching frames to the TC replication path — and tees the branch set to
+  cradle's REPL_SEG (SetReplSeg). This is the control-plane half of RFC 9524
+  SR-P2MP replication; the datapath fan-out itself is proven by the cradle-rs
+  `cradle_srv6_replicate` BDD.
+
+  Prerequisite: /usr/bin/cradle (the cradle-rs engine binary) with the
+  SetReplSeg RPC. Install from a cradle-rs checkout: `cargo build --release`
+  then `install -m755 target/release/cradle /usr/bin/cradle`.
+
+  Topology:
+  ```
+   crs1 [ zebra-rs + managed cradle, eth0 ebpf port ] ─ eth0 ── eth0 ─ crs2
+        segment-routing replication-segment TREE1
+          sid fd00:b::5  (End.Replicate)
+          branch fd00:1::100, fd00:2::100
+  ```
+
+  Scenario: A replication-segment registers an End.Replicate SID and tees its branches
+    Given a clean test environment
+    When I create namespace "crs1"
+    And I create namespace "crs2"
+    And I connect namespace "crs1" interface "eth0" to namespace "crs2" interface "eth0"
+    And I add address "10.211.1.1/24" to interface "eth0" in namespace "crs1"
+    And I add address "10.211.1.2/24" to interface "eth0" in namespace "crs2"
+    And I start zebra-rs in namespace "crs1"
+    And I apply config "crs1.yaml" to namespace "crs1"
+    # The managed cradle engine is up.
+    Then show command "show ebpf" in namespace "crs1" should eventually contain "managed"
+    # The End.Replicate SID reached cradle's local-SID table (the tee is live).
+    And show command "show ebpf srv6" in namespace "crs1" should eventually contain "End.Replicate"
+    And show command "show ebpf srv6" in namespace "crs1" should eventually contain "fd00:b::5"
+    # zebra teed the two downstream branches to cradle's REPL_SEG.
+    And daemon log in namespace "crs1" should eventually contain "repl seg TREE1"
+    And daemon log in namespace "crs1" should eventually contain "2 branch(es) teed to cradle"
+
+  Scenario: Deleting the replication-segment withdraws the End.Replicate SID
+    Given the test topology exists
+    When I apply command "delete segment-routing replication-segment TREE1" in namespace "crs1"
+    Then show command "show ebpf srv6" in namespace "crs1" should eventually not contain "End.Replicate"
+
+  Scenario: Teardown topology
+    Given the test topology exists
+    When I stop zebra-rs in namespace "crs1"
+    And I delete namespace "crs1"
+    And I delete namespace "crs2"
+    Then the test environment should be clean

--- a/proto/cradle.proto
+++ b/proto/cradle.proto
@@ -210,6 +210,24 @@ message ReplSlot {
   string remote_vtep = 3;   // VXLAN: remote VTEP IPv4 (VNI from the bd's SetVni)
 }
 
+// An RFC 9524 Replication segment: the local End.Replicate SID `sid` is an SR
+// P2MP tree node that fans a received copy out to each downstream branch. A
+// Head/Transit node lists remote branches (each a downstream Replication-SID);
+// a Bud additionally lists a `local` branch (cradle creates a leaf veth so the
+// copy is End.DT2M-decapped into the bridge domain). SetReplSeg replaces the
+// whole segment. Field numbers must match cradle-rs's proto/cradle.proto.
+message ReplSeg {
+  string sid = 1;                       // local End.Replicate SID (map key)
+  repeated ReplSegBranch branches = 2;
+  uint32 hop_limit_threshold = 3;       // RFC 9524 (0 = disabled)
+}
+message ReplSegBranch {
+  string sid        = 1; // downstream Replication-SID (own End.DT2M SID when local)
+  uint32 nexthop_id = 2; // remote branch: explicit underlay nexthop, 0 = FIB6-on-sid
+  bool   local      = 3; // Bud local delivery — cradle creates the leaf veth
+}
+message ReplSegDel { string sid = 1; }
+
 // An egress-protection mirror route (End.M context): traffic exposed by an
 // End.M decap whose destination falls in `prefix` (the FAILED egress PE's
 // SID space) is served locally with DT-style semantics — decap once more
@@ -506,6 +524,8 @@ service Cradle {
   rpc DelXconnect(XconnectDel) returns (Empty);
   rpc AddReplSlot(ReplSlot) returns (Empty);
   rpc DelReplSlot(ReplSlot) returns (Empty);
+  rpc SetReplSeg(ReplSeg) returns (Empty);
+  rpc DelReplSeg(ReplSegDel) returns (Empty);
   rpc AddMirrorRoute(MirrorRoute) returns (Empty);
   rpc DelMirrorRoute(MirrorRouteDel) returns (Empty);
   rpc AddService(Service) returns (Empty);

--- a/zebra-rs/src/config/manager.rs
+++ b/zebra-rs/src/config/manager.rs
@@ -1788,6 +1788,42 @@ mod yang_load_tests {
         }
     }
 
+    /// Regression guard for the RFC 9524 SR-P2MP `replication-segment` grammar
+    /// (config.yang `segment-routing replication-segment`). Pins the segment
+    /// leaves and the nested `branch` list (key + `nexthop-id` leaf) so a
+    /// broken list key or a stale callback path fails in the unit suite, not
+    /// only in the `@cradle_srv6_replicate*` BDDs. Mirrors the tee wired in
+    /// `rib/segment_routing/repl_seg.rs`.
+    #[test]
+    fn srv6_replication_segment_paths_parse() {
+        use crate::config::ExecCode;
+        use crate::config::parse::{State, parse};
+        use libyang::to_entry;
+
+        let mut yang = YangStore::new();
+        yang.add_path(concat!(env!("CARGO_MANIFEST_DIR"), "/yang"));
+        yang.read_with_resolve("configure")
+            .unwrap_or_else(|e| panic!("configure failed to load: {e:#}"));
+        yang.identity_resolve();
+        let module = yang.find_module("configure").unwrap();
+        let entry = to_entry(&yang, module);
+
+        for cmd in [
+            "set segment-routing replication-segment TREE1",
+            "set segment-routing replication-segment TREE1 sid fd00:b::5",
+            "set segment-routing replication-segment TREE1 hop-limit-threshold 0",
+            "set segment-routing replication-segment TREE1 branch fd00:1::100",
+            "set segment-routing replication-segment TREE1 branch fd00:2::100 nexthop-id 7",
+        ] {
+            let (code, _comps, _state) = parse(cmd, entry.clone(), None, State::new());
+            assert_eq!(
+                code,
+                ExecCode::Success,
+                "should parse as a settable path: {cmd}"
+            );
+        }
+    }
+
     /// Regression guard for the per-VRF redistribute grammar
     /// (zebra-bgp-vrf.yang `afi-safi {ipv4,ipv6} redistribute
     /// {connected,static}`). Pins the new bare-presence paths so a

--- a/zebra-rs/src/fib/cradle.rs
+++ b/zebra-rs/src/fib/cradle.rs
@@ -95,6 +95,10 @@ struct CradleMirror {
     /// `fdb_vxlan` depending on the received route's encap.
     fdb_vxlan: HashMap<(u32, [u8; 6]), Ipv4Addr>,
     repl_slots_vxlan: HashSet<(u32, Ipv4Addr)>,
+    /// RFC 9524 Replication segments (operator `replication-segment` config):
+    /// local End.Replicate SID → (hop-limit threshold, downstream branches
+    /// `(sid, nexthop_id, local)`). Replayed as `SetReplSeg` on engine restart.
+    repl_segs: HashMap<Ipv6Addr, (u8, Vec<(Ipv6Addr, u32, bool)>)>,
     /// L2VNI ↔ bridge-domain bindings (bd == vni today) for `SetVni` replay,
     /// and the fabric-wide local VTEP source for `SetVtepSource`.
     vnis: HashMap<u32, u32>,
@@ -124,18 +128,19 @@ fn srv6_behavior(b: crate::rib::SidBehavior) -> u32 {
         EndDT46 => 4,
         EndB6Encap => 5,
         UN => 6,
-        UA => 7,       // classic End.X at /128 (no shift)
-        UALib => 8,    // compressed carrier: shift + adjacency
-        EndDT2U => 9,  // EVPN L2 unicast decap+bridge
-        EndDT2M => 10, // EVPN L2 BUM decap+flood
-        EndM => 11,    // egress-protection mirror (decap + mirror-context lookup)
-        EndRep => 12,  // RFC 9800 REPLACE-C-SID (C-SID rewrite from containers)
-        EndXRep => 13, // REPLACE-C-SID + adjacency cross-connect
-        EndT => 14,    // End walk + table-scoped egress lookup (vrf_table_id)
-        EndDX4 => 15,  // decap + IPv4 cross-connect (per-CE VPN egress)
-        EndDX6 => 16,  // decap + IPv6 cross-connect
-        EndDX2 => 17,  // decap + raw L2 emit on the AC (EVPN VPWS egress)
-        EndDX2V => 18, // decap + VLAN-table AC demux (VLAN-scoped VPWS egress)
+        UA => 7,            // classic End.X at /128 (no shift)
+        UALib => 8,         // compressed carrier: shift + adjacency
+        EndDT2U => 9,       // EVPN L2 unicast decap+bridge
+        EndDT2M => 10,      // EVPN L2 BUM decap+flood
+        EndM => 11,         // egress-protection mirror (decap + mirror-context lookup)
+        EndRep => 12,       // RFC 9800 REPLACE-C-SID (C-SID rewrite from containers)
+        EndXRep => 13,      // REPLACE-C-SID + adjacency cross-connect
+        EndT => 14,         // End walk + table-scoped egress lookup (vrf_table_id)
+        EndDX4 => 15,       // decap + IPv4 cross-connect (per-CE VPN egress)
+        EndDX6 => 16,       // decap + IPv6 cross-connect
+        EndDX2 => 17,       // decap + raw L2 emit on the AC (EVPN VPWS egress)
+        EndDX2V => 18,      // decap + VLAN-table AC demux (VLAN-scoped VPWS egress)
+        EndReplicate => 19, // RFC 9524 SR-P2MP replication segment (REPL_SEG)
         // uT = a uN whose end-of-carrier lookup is table-scoped: cradle
         // models it as UN with a non-zero vrf_id (vrf_table_id below).
         UT => 6,
@@ -463,6 +468,12 @@ impl CradleFib {
         for (vni, sid) in &m.repl_slots {
             self.repl_slot_add(*vni, *sid).await;
         }
+        // RFC 9524 Replication segments (the local End.Replicate SID is
+        // replayed above with the other local SIDs, so SRV6_LOCALSID is
+        // populated before its REPL_SEG fan-out state).
+        for (sid, (hlt, branches)) in &m.repl_segs {
+            self.repl_seg_set(*sid, *hlt, branches.clone()).await;
+        }
         // VXLAN L2: the VTEP source and VNI bindings first (a VXLAN repl slot
         // resolves its VNI from the SetVni binding), then the overlay FDB and
         // flood slots.
@@ -496,8 +507,8 @@ impl CradleFib {
         }
         tracing::info!(
             "fib: cradle replay: {} v4 + {} v6 routes, {} ILM, {} SIDs (+{} static), \
-             {} FDB (+{} vxlan), {} repl slots (+{} vxlan), {} vnis, {} xconnects, \
-             {} GTP PDRs + {} encaps, {} mirror routes, {} neighbors re-applied",
+             {} FDB (+{} vxlan), {} repl slots (+{} vxlan), {} repl segs, {} vnis, \
+             {} xconnects, {} GTP PDRs + {} encaps, {} mirror routes, {} neighbors re-applied",
             m.routes4.len(),
             m.routes6.len(),
             m.ilm.len(),
@@ -507,6 +518,7 @@ impl CradleFib {
             m.fdb_vxlan.len(),
             m.repl_slots.len(),
             m.repl_slots_vxlan.len(),
+            m.repl_segs.len(),
             m.vnis.len(),
             m.xconnects.len(),
             m.gtp_pdrs.len(),
@@ -1538,6 +1550,63 @@ impl CradleFib {
         .await;
         if let Err(e) = result {
             tracing::warn!("fib: cradle repl_slot_add vni {vni} {sid} failed: {e}");
+        }
+    }
+
+    /// Install / replace an RFC 9524 Replication segment (`SetReplSeg`): the
+    /// local End.Replicate SID `sid` fans a received copy out to `branches`
+    /// (each `(downstream Replication-SID, nexthop_id, local)`). Replaces any
+    /// prior segment for the SID; recorded for replay on engine restart.
+    pub async fn repl_seg_set(
+        &self,
+        sid: std::net::Ipv6Addr,
+        hop_limit_threshold: u8,
+        branches: Vec<(std::net::Ipv6Addr, u32, bool)>,
+    ) {
+        self.mirror
+            .lock()
+            .await
+            .repl_segs
+            .insert(sid, (hop_limit_threshold, branches.clone()));
+        let result = async {
+            self.client()
+                .await?
+                .set_repl_seg(pb::ReplSeg {
+                    sid: sid.to_string(),
+                    hop_limit_threshold: hop_limit_threshold as u32,
+                    branches: branches
+                        .iter()
+                        .map(|(bsid, nh, local)| pb::ReplSegBranch {
+                            sid: bsid.to_string(),
+                            nexthop_id: *nh,
+                            local: *local,
+                        })
+                        .collect(),
+                })
+                .await?;
+            anyhow::Ok(())
+        }
+        .await;
+        if let Err(e) = result {
+            tracing::warn!("fib: cradle repl_seg_set {sid} failed: {e}");
+        }
+    }
+
+    /// Remove a Replication segment (`DelReplSeg`).
+    pub async fn repl_seg_del(&self, sid: std::net::Ipv6Addr) {
+        self.mirror.lock().await.repl_segs.remove(&sid);
+        let result = async {
+            self.client()
+                .await?
+                .del_repl_seg(pb::ReplSegDel {
+                    sid: sid.to_string(),
+                })
+                .await?;
+            anyhow::Ok(())
+        }
+        .await;
+        if let Err(e) = result {
+            tracing::warn!("fib: cradle repl_seg_del {sid} failed: {e}");
         }
     }
 

--- a/zebra-rs/src/fib/netlink/handle.rs
+++ b/zebra-rs/src/fib/netlink/handle.rs
@@ -326,7 +326,8 @@ fn sid_route_target(
         SidBehavior::EndDT2U
         | SidBehavior::EndDT2M
         | SidBehavior::EndDX2
-        | SidBehavior::EndDX2V => (RouteHeader::RT_TABLE_MAIN, RouteType::Unicast, 128, addr),
+        | SidBehavior::EndDX2V
+        | SidBehavior::EndReplicate => (RouteHeader::RT_TABLE_MAIN, RouteType::Unicast, 128, addr),
         // End.B6.Encaps (SR Policy Binding SID): a /128 host route in
         // table=main; the SRH it pushes rides inside the seg6local
         // encap, not in the route header.
@@ -581,6 +582,29 @@ impl FibHandle {
     pub async fn cradle_repl_del(&self, vni: u32, sid: std::net::Ipv6Addr) {
         if let Some(cradle) = &self.cradle {
             cradle.repl_slot_del(vni, sid).await;
+        }
+    }
+
+    /// Tee an RFC 9524 Replication segment (operator `replication-segment`
+    /// config) to cradle: the local End.Replicate SID and its downstream
+    /// branches. No kernel counterpart — cradle's `REPL_SEG` is the SR-P2MP
+    /// replication data plane.
+    pub async fn cradle_repl_seg_set(
+        &self,
+        sid: std::net::Ipv6Addr,
+        hop_limit_threshold: u8,
+        branches: Vec<(std::net::Ipv6Addr, u32, bool)>,
+    ) {
+        if let Some(cradle) = &self.cradle {
+            cradle
+                .repl_seg_set(sid, hop_limit_threshold, branches)
+                .await;
+        }
+    }
+
+    pub async fn cradle_repl_seg_del(&self, sid: std::net::Ipv6Addr) {
+        if let Some(cradle) = &self.cradle {
+            cradle.repl_seg_del(sid).await;
         }
     }
 
@@ -2096,6 +2120,7 @@ impl FibHandle {
                 | crate::rib::SidBehavior::EndDX2V
                 | crate::rib::SidBehavior::EndRep
                 | crate::rib::SidBehavior::EndXRep
+                | crate::rib::SidBehavior::EndReplicate
                 | crate::rib::SidBehavior::UT
         ) {
             return;
@@ -2269,6 +2294,7 @@ impl FibHandle {
                 | crate::rib::SidBehavior::EndDX2V
                 | crate::rib::SidBehavior::EndRep
                 | crate::rib::SidBehavior::EndXRep
+                | crate::rib::SidBehavior::EndReplicate
                 | crate::rib::SidBehavior::UT
         ) {
             return;

--- a/zebra-rs/src/fib/netlink/srv6.rs
+++ b/zebra-rs/src/fib/netlink/srv6.rs
@@ -134,7 +134,10 @@ fn seg6local_action(behavior: SidBehavior) -> Seg6LocalAction {
         SidBehavior::EndDT2U
         | SidBehavior::EndDT2M
         | SidBehavior::EndDX2
-        | SidBehavior::EndDX2V => Seg6LocalAction::End,
+        | SidBehavior::EndDX2V
+        // End.Replicate is cradle-tee-only (RFC 9524 SR-P2MP; no kernel
+        // seg6local action) — map to End so a stray call is a visible no-op.
+        | SidBehavior::EndReplicate => Seg6LocalAction::End,
         SidBehavior::EndX | SidBehavior::UA | SidBehavior::UALib => Seg6LocalAction::EndX,
         // REPLACE-C-SID never reaches the kernel (route_sid_install
         // returns after the cradle tee — no kernel flavor op exists);

--- a/zebra-rs/src/rib/inst.rs
+++ b/zebra-rs/src/rib/inst.rs
@@ -5,8 +5,9 @@ use super::link::{LinkConfig, link_config_exec};
 use super::{
     Block, BlockBuilder, BlockConfig, BridgeBuilder, BridgeConfig, DEFAULT_BLOCK_NAME, GroupTrait,
     Link, Locator, LocatorBuilder, LocatorConfig, MacAddr, MplsConfig, Nexthop, NexthopMap,
-    NexthopUni, RibSrRx, RibType, Sid, SidBehavior, StaticConfig, V4, V6, Vrf, VrfBuilder,
-    VrfIdAllocator, VrfRibTables, VrfStaticConfig, Vxlan, VxlanBuilder, VxlanConfig,
+    NexthopUni, ReplSegBuilder, ReplSegConfig, RibSrRx, RibType, Sid, SidBehavior, SidContext,
+    SidOwner, StaticConfig, V4, V6, Vrf, VrfBuilder, VrfIdAllocator, VrfRibTables, VrfStaticConfig,
+    Vxlan, VxlanBuilder, VxlanConfig,
 };
 
 use crate::config::{Args, path_from_command};
@@ -130,6 +131,16 @@ pub enum Message {
         config: LocatorConfig,
     },
     LocatorDel {
+        name: String,
+    },
+    /// RFC 9524 Replication segment (operator `replication-segment` config):
+    /// register the local `End.Replicate` SID and tee its branch set to
+    /// cradle's `REPL_SEG`. `ReplSegAdd` replaces any prior segment of `name`.
+    ReplSegAdd {
+        name: String,
+        config: ReplSegConfig,
+    },
+    ReplSegDel {
         name: String,
     },
     /// One-time per-protocol registration of the SR return channel. The
@@ -839,11 +850,16 @@ pub struct Rib {
     pub vrf_config: VrfBuilder,
     pub block_config: BlockBuilder,
     pub locator_config: LocatorBuilder,
+    pub repl_seg_config: ReplSegBuilder,
     /// Applied snapshots, populated by Block/Locator Add/Del messages.
     /// Other modules read these by name to resolve their `mpls/block` or
     /// `srv6/locator` reference.
     pub blocks: BTreeMap<String, Block>,
     pub locators: BTreeMap<String, Locator>,
+    /// Applied RFC 9524 Replication segments by name → the local
+    /// `End.Replicate` SID installed for it, so a config change/delete can
+    /// uninstall the old SID and withdraw the cradle `REPL_SEG` entry.
+    pub repl_segs: BTreeMap<String, Ipv6Addr>,
     /// Allocated SRv6 SIDs across all owners. Keyed by SID address so
     /// inserts collide naturally on duplicate allocations; the show
     /// callback iterates this in address order.
@@ -999,6 +1015,7 @@ impl Rib {
             vrf_config: VrfBuilder::new(),
             block_config: BlockBuilder::new(),
             locator_config: LocatorBuilder::new(),
+            repl_seg_config: ReplSegBuilder::new(),
             blocks: {
                 // Seed the canonical default block at startup so protocols can
                 // subscribe to "default" without anyone having configured one.
@@ -1007,6 +1024,7 @@ impl Rib {
                 m
             },
             locators: BTreeMap::new(),
+            repl_segs: BTreeMap::new(),
             sids: BTreeMap::new(),
             egress_protect: BTreeMap::new(),
             redirected_sids: BTreeMap::new(),
@@ -1475,6 +1493,64 @@ impl Rib {
             if let Some(g) = self.nmap.get_mut(gid) {
                 g.set_installed(false);
             }
+        }
+    }
+
+    /// Apply an operator RFC 9524 Replication segment (`replication-segment`
+    /// config): register its local `End.Replicate` SID (which tees into
+    /// cradle's `SRV6_LOCALSID`, so the XDP stage hands matching frames to the
+    /// TC replication path) and tee its downstream branch set to cradle's
+    /// `REPL_SEG`. Replaces any prior segment of `name`; a missing `sid`
+    /// tears the segment down. Branches are all remote today — operator
+    /// Bud/local delivery is a follow-up.
+    async fn repl_seg_apply(&mut self, name: String, config: ReplSegConfig) {
+        let Some(sid_addr) = config.sid else {
+            self.repl_seg_remove(name).await;
+            return;
+        };
+        // A changed SID for the same segment name: retire the old one first.
+        if let Some(&old) = self.repl_segs.get(&name)
+            && old != sid_addr
+        {
+            self.fib_handle.cradle_repl_seg_del(old).await;
+            self.sid_uninstall(old).await;
+        }
+        let sid = Sid {
+            addr: sid_addr,
+            behavior: SidBehavior::EndReplicate,
+            context: SidContext::None,
+            owner: SidOwner::new("srv6", 0),
+            locator: String::new(),
+            allocation_type: crate::rib::SidAllocationType::Dynamic,
+            ifindex: 0,
+            nh6: None,
+            structure: None,
+            table_id: 0,
+            segs: Vec::new(),
+            flavors: 0,
+        };
+        self.sid_install(sid).await;
+        let branches: Vec<(Ipv6Addr, u32, bool)> = config
+            .branches
+            .iter()
+            .map(|(bsid, nh)| (*bsid, *nh, false))
+            .collect();
+        let n_branches = branches.len();
+        self.fib_handle
+            .cradle_repl_seg_set(sid_addr, config.hop_limit_threshold, branches)
+            .await;
+        tracing::info!(
+            "repl seg {name}: End.Replicate SID {sid_addr}, {n_branches} branch(es) teed to cradle"
+        );
+        self.repl_segs.insert(name, sid_addr);
+    }
+
+    /// Remove an operator Replication segment: withdraw its cradle `REPL_SEG`
+    /// entry and uninstall its `End.Replicate` SID.
+    async fn repl_seg_remove(&mut self, name: String) {
+        if let Some(sid_addr) = self.repl_segs.remove(&name) {
+            self.fib_handle.cradle_repl_seg_del(sid_addr).await;
+            self.sid_uninstall(sid_addr).await;
         }
     }
 
@@ -3073,6 +3149,12 @@ impl Rib {
                 self.locators.remove(&name);
                 self.notify_locator_watchers(&name);
             }
+            Message::ReplSegAdd { name, config } => {
+                self.repl_seg_apply(name, config).await;
+            }
+            Message::ReplSegDel { name } => {
+                self.repl_seg_remove(name).await;
+            }
             Message::SrSubscribe { proto, tx } => {
                 self.sr_clients.insert(proto, tx);
             }
@@ -4055,6 +4137,11 @@ impl Rib {
                     let _ = self.block_config.exec(path, args, msg.op);
                 } else if path.as_str().starts_with("/segment-routing/locator") {
                     let _ = self.locator_config.exec(path, args, msg.op);
+                } else if path
+                    .as_str()
+                    .starts_with("/segment-routing/replication-segment")
+                {
+                    let _ = self.repl_seg_config.exec(path, args, msg.op);
                 } else if path.as_str().starts_with("/system/tracing") {
                     crate::rib::tracing::config_dispatch(&path, args, msg.op);
                 }
@@ -4071,6 +4158,7 @@ impl Rib {
                 self.mpls_config.commit(self.tx.clone());
                 self.block_config.commit(self.tx.clone());
                 self.locator_config.commit(self.tx.clone());
+                self.repl_seg_config.commit(self.tx.clone());
             }
             ConfigOp::Completion => {
                 // `comps_dynamic` passes the dynamic handler name

--- a/zebra-rs/src/rib/segment_routing/mod.rs
+++ b/zebra-rs/src/rib/segment_routing/mod.rs
@@ -15,6 +15,9 @@ pub use locator::{
 pub mod sid;
 pub use sid::{Sid, SidAllocationType, SidBehavior, SidContext, SidOwner, SidStructure};
 
+pub mod repl_seg;
+pub use repl_seg::{ReplSegBuilder, ReplSegConfig};
+
 /// Subscription-channel return type from RIB to a protocol module.
 /// `block: None` / `locator: None` signals deletion (or "doesn't exist
 /// yet" if the protocol asked for a name that hasn't been configured).

--- a/zebra-rs/src/rib/segment_routing/repl_seg.rs
+++ b/zebra-rs/src/rib/segment_routing/repl_seg.rs
@@ -1,0 +1,228 @@
+//! RFC 9524 SR-P2MP Replication segment configuration
+//! (`segment-routing/replication-segment`). An operator declares a local
+//! `End.Replicate` SID and its downstream branches; the RIB registers the SID
+//! and tees the branch set to the cradle eBPF data plane (`REPL_SEG`). There
+//! is no kernel seg6local action for replication — cradle is the data plane.
+
+use std::collections::BTreeMap;
+use std::net::Ipv6Addr;
+
+use anyhow::{Context, Result};
+use tokio::sync::mpsc::UnboundedSender;
+
+use crate::config::{Args, ConfigOp};
+use crate::rib::Message;
+
+/// In-flight Replication-segment configuration, mirroring the YANG list:
+///
+/// ```yang
+/// list replication-segment {
+///   key "name";
+///   leaf name { type string; }
+///   leaf sid  { type inet:ipv6-address; }        // the End.Replicate SID
+///   leaf hop-limit-threshold { type uint8; }     // RFC 9524 (0 = disabled)
+///   list branch {
+///     key "sid";
+///     leaf sid { type inet:ipv6-address; }        // downstream Replication-SID
+///     leaf nexthop-id { type uint32; }            // 0 = FIB6-on-sid
+///   }
+/// }
+/// ```
+#[derive(Debug, Default, Clone)]
+pub struct ReplSegConfig {
+    pub delete: bool,
+    /// The local `End.Replicate` SID (the `REPL_SEG` map key).
+    pub sid: Option<Ipv6Addr>,
+    /// RFC 9524 Hop-Limit Threshold.
+    pub hop_limit_threshold: u8,
+    /// Downstream branches: branch (downstream Replication-)SID → nexthop id
+    /// (0 = resolve by a FIB6 lookup on the branch SID).
+    pub branches: BTreeMap<Ipv6Addr, u32>,
+}
+
+pub struct ReplSegBuilder {
+    pub config: BTreeMap<String, ReplSegConfig>,
+    pub cache: BTreeMap<String, ReplSegConfig>,
+    builder: ConfigBuilder,
+}
+
+impl ReplSegBuilder {
+    pub fn new() -> Self {
+        ReplSegBuilder {
+            config: BTreeMap::new(),
+            cache: BTreeMap::new(),
+            builder: ConfigBuilder::new(),
+        }
+    }
+
+    pub fn exec(&mut self, path: String, mut args: Args, op: ConfigOp) -> Result<()> {
+        const CONFIG_ERR: &str = "missing config handler";
+        const NAME_ERR: &str = "missing replication-segment name argument";
+
+        let func = self
+            .builder
+            .map
+            .get(&(path.to_string(), op))
+            .context(CONFIG_ERR)?;
+
+        let name: String = args.string().context(NAME_ERR)?;
+
+        func(&mut self.config, &mut self.cache, &name, &mut args)
+    }
+
+    pub fn commit(&mut self, tx: UnboundedSender<Message>) {
+        while let Some((name, config)) = self.cache.pop_first() {
+            if config.delete {
+                self.config.remove(&name);
+                let _ = tx.send(Message::ReplSegDel { name });
+            } else {
+                self.config.insert(name.clone(), config.clone());
+                let _ = tx.send(Message::ReplSegAdd { name, config });
+            }
+        }
+    }
+}
+
+type Handler = fn(
+    config: &mut BTreeMap<String, ReplSegConfig>,
+    cache: &mut BTreeMap<String, ReplSegConfig>,
+    name: &String,
+    args: &mut Args,
+) -> Result<()>;
+
+fn config_get(config: &BTreeMap<String, ReplSegConfig>, name: &String) -> ReplSegConfig {
+    config.get(name).cloned().unwrap_or_default()
+}
+
+fn config_lookup(config: &BTreeMap<String, ReplSegConfig>, name: &String) -> Option<ReplSegConfig> {
+    config.get(name).cloned()
+}
+
+fn cache_get<'a>(
+    config: &'a BTreeMap<String, ReplSegConfig>,
+    cache: &'a mut BTreeMap<String, ReplSegConfig>,
+    name: &'a String,
+) -> Option<&'a mut ReplSegConfig> {
+    if cache.get(name).is_none() {
+        cache.insert(name.to_string(), config_get(config, name));
+    }
+    cache.get_mut(name)
+}
+
+fn cache_lookup<'a>(
+    config: &'a BTreeMap<String, ReplSegConfig>,
+    cache: &'a mut BTreeMap<String, ReplSegConfig>,
+    name: &'a String,
+) -> Option<&'a mut ReplSegConfig> {
+    if cache.get(name).is_none() {
+        cache.insert(name.clone(), config_lookup(config, name)?);
+    }
+    let cache = cache.get_mut(name)?;
+    if cache.delete { None } else { Some(cache) }
+}
+
+#[derive(Default)]
+struct ConfigBuilder {
+    path: String,
+    map: BTreeMap<(String, ConfigOp), Handler>,
+}
+
+impl ConfigBuilder {
+    pub fn new() -> Self {
+        const CONFIG_ERR: &str = "missing config";
+        const SID_ERR: &str = "expected ipv6 address";
+        const HLT_ERR: &str = "expected uint8 hop-limit-threshold";
+        const BRANCH_ERR: &str = "expected ipv6 branch SID";
+        const NH_ERR: &str = "expected uint32 nexthop-id";
+
+        ConfigBuilder::default()
+            .path("")
+            .set(|config, cache, name, _args| {
+                let _ = cache_get(config, cache, name).context(CONFIG_ERR)?;
+                Ok(())
+            })
+            .del(|config, cache, name, _args| {
+                if let Some(s) = cache.get_mut(name) {
+                    s.delete = true;
+                } else {
+                    let mut s = config_lookup(config, name).context(CONFIG_ERR)?;
+                    s.delete = true;
+                    cache.insert(name.clone(), s);
+                }
+                Ok(())
+            })
+            .path("/sid")
+            .set(|config, cache, name, args| {
+                let sid = args.v6addr().context(SID_ERR)?;
+                let s = cache_get(config, cache, name).context(CONFIG_ERR)?;
+                s.sid = Some(sid);
+                Ok(())
+            })
+            .del(|config, cache, name, _args| {
+                let s = cache_lookup(config, cache, name).context(CONFIG_ERR)?;
+                s.sid = None;
+                Ok(())
+            })
+            .path("/hop-limit-threshold")
+            .set(|config, cache, name, args| {
+                let hlt = args.u8().context(HLT_ERR)?;
+                let s = cache_get(config, cache, name).context(CONFIG_ERR)?;
+                s.hop_limit_threshold = hlt;
+                Ok(())
+            })
+            .del(|config, cache, name, _args| {
+                let s = cache_lookup(config, cache, name).context(CONFIG_ERR)?;
+                s.hop_limit_threshold = 0;
+                Ok(())
+            })
+            // Nested `branch` list, keyed by the branch SID (the second key
+            // after the segment name, read from `args` here). The list-entry
+            // set/del adds/removes the branch; `/branch/nexthop-id` sets its
+            // explicit underlay nexthop (0 = FIB6-on-sid).
+            .path("/branch")
+            .set(|config, cache, name, args| {
+                let bsid = args.v6addr().context(BRANCH_ERR)?;
+                let s = cache_get(config, cache, name).context(CONFIG_ERR)?;
+                s.branches.entry(bsid).or_insert(0);
+                Ok(())
+            })
+            .del(|config, cache, name, args| {
+                let bsid = args.v6addr().context(BRANCH_ERR)?;
+                let s = cache_lookup(config, cache, name).context(CONFIG_ERR)?;
+                s.branches.remove(&bsid);
+                Ok(())
+            })
+            .path("/branch/nexthop-id")
+            .set(|config, cache, name, args| {
+                let bsid = args.v6addr().context(BRANCH_ERR)?;
+                let nh = args.u32().context(NH_ERR)?;
+                let s = cache_get(config, cache, name).context(CONFIG_ERR)?;
+                s.branches.insert(bsid, nh);
+                Ok(())
+            })
+            .del(|config, cache, name, args| {
+                let bsid = args.v6addr().context(BRANCH_ERR)?;
+                let s = cache_lookup(config, cache, name).context(CONFIG_ERR)?;
+                if let Some(v) = s.branches.get_mut(&bsid) {
+                    *v = 0;
+                }
+                Ok(())
+            })
+    }
+
+    pub fn path(mut self, path: &str) -> Self {
+        let prefix = "/segment-routing/replication-segment";
+        self.path = format!("{prefix}{path}");
+        self
+    }
+
+    pub fn set(mut self, func: Handler) -> Self {
+        self.map.insert((self.path.clone(), ConfigOp::Set), func);
+        self
+    }
+
+    pub fn del(mut self, func: Handler) -> Self {
+        self.map.insert((self.path.clone(), ConfigOp::Delete), func);
+        self
+    }
+}

--- a/zebra-rs/src/rib/segment_routing/sid.rs
+++ b/zebra-rs/src/rib/segment_routing/sid.rs
@@ -87,6 +87,14 @@ pub enum SidBehavior {
     /// the SID's VLAN table ([`Sid::table_id`]). Cradle-tee-only, like
     /// End.DX2.
     EndDX2V,
+    /// End.Replicate — RFC 9524 §5.2 SR-P2MP replication segment. The SID is
+    /// a replication-tree node: an arriving copy is cloned to each downstream
+    /// branch (outer DA rewritten to the branch's downstream Replication-SID,
+    /// Hop Limit decremented), and a Bud also delivers a copy locally. The
+    /// kernel has no such seg6local action — the cradle eBPF tee is the data
+    /// plane (`REPL_SEG`), so the FIB skips the netlink install like the EVPN
+    /// L2 SIDs. Installed by an operator `replication-segment` config.
+    EndReplicate,
     /// End.M — Mirroring Context segment (IANA codepoint 74,
     /// draft-ietf-rtgwg-srv6-egress-protection). A variant of End.DT6:
     /// the protector decapsulates the outer IPv6/SRH and looks the inner
@@ -148,6 +156,7 @@ impl fmt::Display for SidBehavior {
             Self::EndDX6 => write!(f, "End.DX6"),
             Self::EndDX2 => write!(f, "End.DX2"),
             Self::EndDX2V => write!(f, "End.DX2V"),
+            Self::EndReplicate => write!(f, "End.Replicate"),
         }
     }
 }
@@ -347,7 +356,10 @@ impl Sid {
             | SidBehavior::EndDX4
             | SidBehavior::EndDX6
             | SidBehavior::EndDX2
-            | SidBehavior::EndDX2V => Ipv6Net::new(self.addr, 128).expect("/128 is always valid"),
+            | SidBehavior::EndDX2V
+            | SidBehavior::EndReplicate => {
+                Ipv6Net::new(self.addr, 128).expect("/128 is always valid")
+            }
             SidBehavior::UALib => {
                 let plen = self
                     .structure

--- a/zebra-rs/yang/config.yang
+++ b/zebra-rs/yang/config.yang
@@ -4062,6 +4062,57 @@ module config {
              at the ultimate segment, usd decapsulates there.";
         }
       }
+
+      list replication-segment {
+        ext:help "RFC 9524 SR-P2MP replication segment (End.Replicate)";
+        key "name";
+        description
+          "An SRv6 RFC 9524 replication-tree node. 'sid' is the local
+           End.Replicate SID; each 'branch' names a downstream
+           Replication-SID a received copy is cloned toward. Programmed
+           into the cradle eBPF data plane (REPL_SEG) — there is no kernel
+           seg6local action for replication.";
+        leaf name {
+          ext:help "Replication-segment name";
+          type string;
+        }
+        leaf sid {
+          ext:help "Local End.Replicate SID";
+          type inet:ipv6-address;
+          description
+            "The replication segment's SID — the arriving outer IPv6
+             destination of a copy. Registered as a local End.Replicate
+             SID so the data plane fans matching frames out to the
+             branches.";
+        }
+        leaf hop-limit-threshold {
+          ext:help "RFC 9524 Hop-Limit threshold (0 = disabled)";
+          type uint8;
+          description
+            "Discard a copy whose arriving IPv6 Hop Limit is below this
+             value (RFC 9524 5.2). 0 disables the check.";
+        }
+        list branch {
+          ext:help "Downstream replication branch";
+          key "sid";
+          description
+            "One downstream branch: a received copy is steered to 'sid'
+             (a remote leaf's End.DT2M SID, or the next tier's
+             End.Replicate SID).";
+          leaf sid {
+            ext:help "Downstream Replication-SID";
+            type inet:ipv6-address;
+          }
+          leaf nexthop-id {
+            ext:help "Explicit underlay nexthop id (0 = FIB6 on the SID)";
+            type uint32;
+            description
+              "Underlay adjacency for this branch. 0 (default) resolves
+               it by a FIB6 lookup on the branch SID (the IGP locator
+               route), like the EVPN End.DT2M encap.";
+          }
+        }
+      }
     }
 
     list community-set {


### PR DESCRIPTION
## What

Adds an operator-configured `segment-routing replication-segment`: declare a
local SRv6 **End.Replicate** SID (RFC 9524 SR-P2MP replication) and its
downstream branches, and zebra tees it to the cradle eBPF data plane over gRPC.
This is the control-plane half; the datapath fan-out lives in cradle-rs
(`cradle-rs#131`, `cradle_srv6_replicate`).

zebra registers the End.Replicate SID (which reaches cradle's `SRV6_LOCALSID`, so
the XDP stage hands matching frames to the TC replication path) and tees the
branch set to cradle's `REPL_SEG` via a new `SetReplSeg` RPC.

## How

- **`SidBehavior::EndReplicate`** + every exhaustive-match site (Display,
  `prefix()` → /128, cradle behavior map → 19, `route_sid_install` cradle-only
  return gate, `seg6local_action` no-op). Cradle-tee-only — no kernel seg6local
  action, same shape as the EVPN L2 service SIDs.
- **proto**: `SetReplSeg`/`DelReplSeg` (`ReplSeg` + `ReplSegBranch`), field
  numbers matched to cradle-rs's `proto/cradle.proto`.
- **`fib/cradle.rs`**: `repl_seg_set`/`repl_seg_del` tee methods,
  `CradleMirror.repl_segs` + replay loop, behavior arm; `FibHandle`
  `cradle_repl_seg_set/del` delegators.
- **RIB**: `Message::ReplSegAdd/Del`, `repl_seg_apply`/`repl_seg_remove` (register
  the SID via `sid_install`, then tee the branches), `repl_segs` registry.
- **config**: new `rib/segment_routing/repl_seg.rs` builder (nested `branch`
  list), dispatch + commit; YANG `segment-routing replication-segment
  { sid; hop-limit-threshold; branch <sid> { nexthop-id } }`.

## Testing

- Compiles; `clippy -p zebra-rs` clean; `fmt --all --check` clean.
- YANG loads (64 yang-load tests); new settable-path pin test
  `srv6_replication_segment_paths_parse` (incl. the nested `branch` list).
- **Full 1560-test zebra-rs unit suite passes.**
- **BDD `cradle_srv6_replicate_zebra` (3 scenarios / 21 steps) passes live**
  against the cradle engine: a `replication-segment` config →
  `show ebpf srv6` shows the `End.Replicate` SID (the tee reached cradle's
  local-SID table) → daemon log shows `repl seg TREE1 … 2 branch(es) teed to
  cradle`; the delete path withdraws it.

## Notes

- Runtime pairs with **cradle-rs#131** (the `SetReplSeg` RPC + `REPL_SEG`
  datapath). zebra vendors its own trimmed `proto/cradle.proto`, so this
  compiles independently; deploy the matching cradle engine for it to take
  effect.
- **Scope**: Head/Transit (remote) branches. Operator Bud/local delivery — which
  needs a standalone `End.DT2M` SID declared in operator config — is a follow-up;
  the cradle datapath already supports the Bud role.

🤖 Generated with [Claude Code](https://claude.com/claude-code)