### PR TITLE
rib: mpls ttl propagate (pipe/uniform) producer for the cradle tee

### DIFF
--- a/CHANGELOG.yaml
+++ b/CHANGELOG.yaml
@@ -26,6 +26,11 @@
         * `show ebpf {status,l2,ipv4,ipv6,mpls,srv6,nexthop,stats}`
           with per-VRF `show ebpf {ipv4,ipv6} vrf <name>`; ANSI escapes
           are stripped from relayed engine log lines
+        * `mpls ttl propagate {pipe|uniform}` selects the RFC 3443 MPLS
+          label-TTL model teed to cradle (pipe hides the LSP, the
+          default; uniform exposes the hop count end to end) via
+          `Nexthop.mpls_pipe_ttl` at imposition and `Ilm.ttl_uniform`
+          at pop-to-IP disposition
 
     - note: |
         ### EVPN

--- a/proto/cradle.proto
+++ b/proto/cradle.proto
@@ -59,6 +59,11 @@ message Nexthop {
   string vxlan_vtep = 16;
   uint32 vxlan_l3vni = 17;
   string vxlan_rmac = 18;
+  // MPLS TTL propagation at imposition (RFC 3443). false (default) = uniform:
+  // seed the outer label TTL from the inner IP TTL. true = pipe: seed a fixed
+  // 255, hiding the LSP hop count. Only meaningful with labels. Field number
+  // must match cradle-rs's proto/cradle.proto.
+  bool mpls_pipe_ttl = 19;
 }
 
 // A nexthop group for ECMP: ordered member nexthop ids. A route whose flags
@@ -325,6 +330,11 @@ message Ilm {
   uint32 nexthop_id = 2;    // resolved nexthop; its labels are the swap stack
   uint32 action = 3;        // MPLS_OP_SWAP | POP_L3 | POP
   uint32 vrf_table_id = 4;  // for POP_L3 into a VRF (0 = global)
+  // MPLS TTL propagation at disposition (RFC 3443). false (default) = pipe:
+  // discard the label TTL, preserve the inner IP TTL. true = uniform: when this
+  // ILM pops the last label to IP, copy the popped label TTL into the inner IP
+  // header. Field number must match cradle-rs's proto/cradle.proto.
+  bool ttl_uniform = 5;
 }
 
 message IlmDel {

--- a/zebra-rs/src/fib/cradle.rs
+++ b/zebra-rs/src/fib/cradle.rs
@@ -191,6 +191,11 @@ pub struct CradleFib {
     next_id: Arc<AtomicU32>,
     /// The SRv6 H.Encaps source is pushed once (best-effort).
     encap_src_set: Arc<std::sync::atomic::AtomicBool>,
+    /// RFC 3443 MPLS label-TTL model (`set mpls ttl propagate`). `true` = pipe
+    /// (the default): imposition seeds the label TTL 255 (`mpls_pipe_ttl`) and
+    /// disposition preserves the inner IP TTL. `false` = uniform: imposition
+    /// seeds from the inner TTL and pop-to-IP writes it back (`ttl_uniform`).
+    mpls_pipe: Arc<std::sync::atomic::AtomicBool>,
     /// Everything this tee has programmed, for [`Self::replay`].
     mirror: Arc<Mutex<CradleMirror>>,
 }
@@ -331,8 +336,26 @@ impl CradleFib {
             nh_ids_vxlan: Arc::new(Mutex::new(HashMap::new())),
             next_id: Arc::new(AtomicU32::new(1)),
             encap_src_set: Arc::new(std::sync::atomic::AtomicBool::new(false)),
+            // Default pipe (RFC 3443): preserves the payload TTL across the LSP,
+            // matching zebra-rs's prior behavior. `set mpls ttl propagate
+            // uniform` flips it via `set_mpls_pipe`.
+            mpls_pipe: Arc::new(std::sync::atomic::AtomicBool::new(true)),
             mirror: Arc::new(Mutex::new(CradleMirror::default())),
         }
+    }
+
+    /// Set the RFC 3443 MPLS TTL model for subsequently-programmed labeled
+    /// nexthops and pop-to-IP ILMs. `true` = pipe, `false` = uniform. Cheap
+    /// interior mutation (no reconnect); existing entries re-derive on the next
+    /// resync/replay.
+    pub fn set_mpls_pipe(&self, pipe: bool) {
+        self.mpls_pipe.store(pipe, Ordering::Relaxed);
+    }
+
+    /// The current RFC 3443 model: `true` = pipe (seed 255 / preserve inner),
+    /// `false` = uniform (seed from inner / write back on pop).
+    fn mpls_pipe(&self) -> bool {
+        self.mpls_pipe.load(Ordering::Relaxed)
     }
 
     /// The normalized gRPC endpoint this tee dials (as stored by `new`).
@@ -580,6 +603,7 @@ impl CradleFib {
                 vxlan_vtep: String::new(),
                 vxlan_l3vni: 0,
                 vxlan_rmac: String::new(),
+                mpls_pipe_ttl: self.mpls_pipe() && !labels.is_empty(),
             })
             .await?;
         self.nh_ids.lock().await.insert(key, id);
@@ -625,6 +649,7 @@ impl CradleFib {
                 vxlan_vtep: String::new(),
                 vxlan_l3vni: 0,
                 vxlan_rmac: String::new(),
+                mpls_pipe_ttl: false,
             })
             .await?;
         self.nh_ids_srv6.lock().await.insert(key, id);
@@ -678,6 +703,7 @@ impl CradleFib {
                 vxlan_vtep: vtep.to_string(),
                 vxlan_l3vni: l3vni,
                 vxlan_rmac: rmac_str,
+                mpls_pipe_ttl: false,
             })
             .await?;
         self.nh_ids_vxlan.lock().await.insert(key, id);
@@ -871,6 +897,7 @@ impl CradleFib {
                 vxlan_vtep: String::new(),
                 vxlan_l3vni: 0,
                 vxlan_rmac: String::new(),
+                mpls_pipe_ttl: self.mpls_pipe() && !labels.is_empty(),
             })
             .await?;
         self.nh_ids6.lock().await.insert(key, id);
@@ -985,6 +1012,9 @@ impl CradleFib {
                     nexthop_id,
                     action,
                     vrf_table_id,
+                    // Uniform disposition only bites at a pop-to-IP (POP_L3):
+                    // copy the popped label TTL into the exposed IP header.
+                    ttl_uniform: action == MPLS_OP_POP_L3 && !self.mpls_pipe(),
                 })
                 .await?;
             anyhow::Ok(())
@@ -1269,6 +1299,7 @@ impl CradleFib {
                 vxlan_vtep: String::new(),
                 vxlan_l3vni: 0,
                 vxlan_rmac: String::new(),
+                mpls_pipe_ttl: false,
             })
             .await?;
         self.nh_ids_gtp.lock().await.insert(key, id);

--- a/zebra-rs/src/fib/netlink/handle.rs
+++ b/zebra-rs/src/fib/netlink/handle.rs
@@ -561,6 +561,16 @@ impl FibHandle {
         }
     }
 
+    /// Push the RFC 3443 MPLS TTL model (`set mpls ttl propagate`) into the
+    /// live tee. `pipe` = true (default) hides the LSP; `false` = uniform.
+    /// A no-op when the tee is off; re-applied by `cradle_apply` after any tee
+    /// (re)creation since a fresh `CradleFib` starts at the pipe default.
+    pub fn set_cradle_mpls_pipe(&self, pipe: bool) {
+        if let Some(cradle) = &self.cradle {
+            cradle.set_mpls_pipe(pipe);
+        }
+    }
+
     /// Replay the tee's entire mirrored state into a freshly-(re)started
     /// cradle engine (see `CradleFib::replay`). Triggered by the
     /// `system ebpf` supervisor's `Message::CradleEngineUp`; a no-op when

--- a/zebra-rs/src/rib/inst.rs
+++ b/zebra-rs/src/rib/inst.rs
@@ -718,6 +718,34 @@ pub enum NeighborKey {
     },
 }
 
+/// RFC 3443 MPLS label-TTL processing model (`set mpls ttl propagate`).
+/// `Pipe` (the default) hides the LSP from the payload; `Uniform` exposes the
+/// LSP hop count end to end. Only the cradle eBPF data plane honors it today
+/// (via `Nexthop.mpls_pipe_ttl` / `Ilm.ttl_uniform`); the kernel FIB ignores
+/// it. Keep the `#[default]` in sync with the YANG `default "pipe"`.
+#[derive(Debug, Default, PartialEq, Clone, Copy)]
+pub enum TtlModel {
+    #[default]
+    Pipe,
+    Uniform,
+}
+
+impl TtlModel {
+    pub fn from_yang(s: &str) -> Option<Self> {
+        match s {
+            "pipe" => Some(Self::Pipe),
+            "uniform" => Some(Self::Uniform),
+            _ => None,
+        }
+    }
+
+    /// `true` for pipe (seed the label TTL 255, preserve the inner IP TTL);
+    /// `false` for uniform (seed from the inner TTL, write it back on pop).
+    pub fn is_pipe(self) -> bool {
+        matches!(self, Self::Pipe)
+    }
+}
+
 pub struct Rib {
     /// The cradle `WatchFdb` subscriber task (datapath MAC learning →
     /// EVPN Type-2 origination); aborted and respawned when the
@@ -734,6 +762,9 @@ pub struct Rib {
     /// `system cradle grpc-endpoint <endpoint>` override. When the tee is enabled
     /// but this is unset, the endpoint defaults to `unix:cradle/grpc`.
     pub cradle_grpc: Option<String>,
+    /// `mpls ttl propagate {pipe|uniform}` — the RFC 3443 label-TTL model teed
+    /// to cradle's MPLS imposition/disposition. Defaults to `Pipe`.
+    pub mpls_ttl_propagate: TtlModel,
     pub cm: ConfigChannel,
     pub show: ShowChannel,
     pub show_cb: HashMap<String, ShowCallback>,
@@ -974,6 +1005,7 @@ impl Rib {
             cradle_enabled: false,
             ebpf_enabled: false,
             cradle_grpc: None,
+            mpls_ttl_propagate: TtlModel::default(),
             cm: ConfigChannel::new(),
             show: ShowChannel::new(),
             show_cb: HashMap::new(),
@@ -3887,6 +3919,25 @@ impl Rib {
         Some(())
     }
 
+    /// `set mpls ttl propagate {pipe|uniform}` — the RFC 3443 label-TTL model.
+    /// Deleting it restores the `Pipe` default. Pushed straight into the live
+    /// cradle tee (no reconnect); a disabled tee simply ignores it.
+    #[cfg(target_os = "linux")]
+    pub(crate) fn mpls_ttl_propagate_config_exec(
+        &mut self,
+        mut args: crate::config::Args,
+        op: ConfigOp,
+    ) -> Option<()> {
+        self.mpls_ttl_propagate = if op.is_set() {
+            TtlModel::from_yang(&args.string()?)?
+        } else {
+            TtlModel::default()
+        };
+        self.fib_handle
+            .set_cradle_mpls_pipe(self.mpls_ttl_propagate.is_pipe());
+        Some(())
+    }
+
     /// Effective eBPF tee endpoint: `None` when neither switch is on, else
     /// the `system cradle grpc-endpoint` override or the
     /// `unix:cradle/grpc` default. `system ebpf enabled` (managed engine)
@@ -3979,6 +4030,10 @@ impl Rib {
             return;
         };
         self.fib_handle.set_cradle(Some(&endpoint));
+        // A fresh tee starts at the pipe default; re-apply the configured
+        // RFC 3443 model so `set mpls ttl propagate` survives tee (re)creation.
+        self.fib_handle
+            .set_cradle_mpls_pipe(self.mpls_ttl_propagate.is_pipe());
         // Enable-after-routes: a freshly-created tee has an empty mirror,
         // so routes installed BEFORE this enable would never reach the
         // engine until they churn. Queue a resync (mirror replay + RIB
@@ -4086,6 +4141,9 @@ impl Rib {
                 } else if path.as_str() == "/system/cradle/grpc-endpoint" {
                     #[cfg(target_os = "linux")]
                     let _ = self.cradle_grpc_config_exec(args, msg.op);
+                } else if path.as_str() == "/mpls/ttl/propagate" {
+                    #[cfg(target_os = "linux")]
+                    let _ = self.mpls_ttl_propagate_config_exec(args, msg.op);
                 } else if path.as_str().starts_with("/router/static/vrf/ipv4/route") {
                     let _ = self.static_vrf_v4.exec(path, args, msg.op);
                 } else if path.as_str().starts_with("/router/static/vrf/ipv6/route") {
@@ -4542,5 +4600,31 @@ mod cradle_endpoint_tests {
             cradle_effective_endpoint(false, Some("127.0.0.1:50151")),
             None
         );
+    }
+}
+
+#[cfg(test)]
+mod ttl_model_tests {
+    use super::TtlModel;
+
+    #[test]
+    fn from_yang_maps_both_models() {
+        assert_eq!(TtlModel::from_yang("pipe"), Some(TtlModel::Pipe));
+        assert_eq!(TtlModel::from_yang("uniform"), Some(TtlModel::Uniform));
+        assert_eq!(TtlModel::from_yang("bogus"), None);
+    }
+
+    #[test]
+    fn default_is_pipe() {
+        // Must mirror the YANG `default "pipe"` and preserve prior behavior.
+        assert_eq!(TtlModel::default(), TtlModel::Pipe);
+    }
+
+    #[test]
+    fn is_pipe_reflects_the_model() {
+        // pipe -> mpls_pipe_ttl=true / ttl_uniform=false at the tee;
+        // uniform -> the inverse.
+        assert!(TtlModel::Pipe.is_pipe());
+        assert!(!TtlModel::Uniform.is_pipe());
     }
 }

--- a/zebra-rs/yang/config.yang
+++ b/zebra-rs/yang/config.yang
@@ -427,6 +427,34 @@ module config {
       }
     }
 
+    container mpls {
+      ext:help "MPLS forwarding configuration";
+      description
+        "Global MPLS forwarding attributes.";
+      container ttl {
+        ext:help "MPLS label TTL processing";
+        // RFC 3443 label-stack TTL model. `pipe` (default) hides the LSP
+        // from the payload: imposition seeds the outer label TTL with 255
+        // and disposition discards it, leaving the inner IP TTL untouched.
+        // `uniform` exposes the LSP end to end: imposition seeds the label
+        // TTL from the inner IP TTL and disposition copies the (decremented)
+        // label TTL back into the inner IP header on pop-to-IP. Honored by
+        // the cradle eBPF data plane (Nexthop.mpls_pipe_ttl at imposition,
+        // Ilm.ttl_uniform at disposition); the kernel FIB is unaffected.
+        leaf propagate {
+          ext:help "MPLS TTL propagation model (pipe hides the LSP, uniform exposes it)";
+          type enumeration {
+            enum pipe;
+            enum uniform;
+          }
+          default "pipe";
+          description
+            "RFC 3443 label TTL model. `pipe` (default) hides the LSP hop
+             count from the payload; `uniform` propagates it end to end.";
+        }
+      }
+    }
+
     container system {
       ext:help "System configuration";
       description


### PR DESCRIPTION
## Summary

Adds the zebra-rs control-plane producer for **`mpls ttl propagate {pipe|uniform}`** (RFC 3443) — the follow-up flagged in cradle-rs's [`docs/design/mpls-ttl-propagation.md`](https://github.com/cradle-rs/cradle-rs/blob/main/docs/design/mpls-ttl-propagation.md). A single global YANG knob selects the MPLS label-TTL model zebra-rs tees to the cradle eBPF data plane; one enum drives both cradle flags:

| model | imposition (`Nexthop.mpls_pipe_ttl`) | pop-to-IP disposition (`Ilm.ttl_uniform`) | effect |
|---|---|---|---|
| **pipe** (default) | `true` (seed label TTL 255) | `false` (preserve inner IP TTL) | LSP hidden from the payload |
| **uniform** | `false` (seed from inner TTL) | `true` (write popped label TTL back) | LSP hop count exposed end to end |

**Default is `pipe`** — it preserves zebra-rs's prior end-to-end behavior and matches cradle's per-entry default, so upgrades are a no-op until the knob is set. (This deliberately picks `pipe` over the design note's earlier "uniform default" musing: defaulting to a behavior change for every existing L3VPN/IS-IS-SR deployment is the wrong call.)

### Changes
- **`proto/cradle.proto`** — sync the two fields cradle-rs added (`Nexthop.mpls_pipe_ttl = 19`, `Ilm.ttl_uniform = 5`; tags match cradle-rs for wire-compat).
- **`zebra-rs/yang/config.yang`** — top-level `container mpls { ttl { propagate } }` (enum `pipe|uniform`, default `pipe`).
- **`rib/inst.rs`** — `TtlModel` enum (`from_yang`/`is_pipe`), a `Rib` field, the `/mpls/ttl/propagate` config handler + dispatch, re-applied in `cradle_apply` so it survives tee (re)creation.
- **`fib/cradle.rs`** — `CradleFib` carries the model (`Arc<AtomicBool>`, pipe default) set via `FibHandle::set_cradle_mpls_pipe`; read at the labeled-nexthop imposition sites (v4/v6) and the pop-to-IP ILM. SRv6/VXLAN/GTP nexthops send `false`.
- **`CHANGELOG.yaml`** — note under the cradle section.

### Scope notes
- `propagate-local` (the IOS forwarded/local split) and a per-VRF override are **not** included — the cradle datapath has no forwarded/local distinction yet, so that leaf would be a silent no-op. Left as documented follow-ups.

## Test plan
- `cargo build -p zebra-rs` ✓
- `cargo fmt --all -- --check` ✓
- `cargo clippy --workspace --all-targets -- -D warnings` ✓
- `cargo test --workspace --exclude bdd` ✓ (1573 tests + 3 new `ttl_model_tests`)
- **YANG validated**: syntax via `yanglint`, and a live `zebra-rs` daemon loads the full tree with the new `mpls` container (no libyang parse error).
- **End-to-end datapath behavior** is already BDD-proven on the cradle side (`cradle_mpls_ttl`: uniform delivers TTL 62 / pipe TTL 63 / pipe label 255 on the wire). A zebra-driven end-to-end MPLS-TTL BDD would need a full LSP-over-cradle topology plus a way to observe the flag (extending cradle's nexthop/ILM dump) — a reasonable follow-up, not duplicated here.

Generated with [Claude Code](https://claude.com/claude-code)