### PR TITLE
bgp: steer colour-matched routes to an SR Policy Binding SID (RFC 9256 §8.5)

### DIFF
--- a/bdd/tests/configs/bgp_sr_policy_bsid_steering/crs1.yaml
+++ b/bdd/tests/configs/bgp_sr_policy_bsid_steering/crs1.yaml
@@ -1,0 +1,21 @@
+# crs1 — a headend consumer with binding-sid SR-Policy steering enabled.
+# No peer: this feature validates the `steering-mode` config surface live
+# (YANG parse -> callback -> Loc-RIB SR Policy DB -> `show bgp sr-policy`).
+# A local (originator) policy is configured alongside the mode to prove
+# the two coexist under the same `sr-policy` container; the steering
+# *decision* logic is unit-tested in src/bgp/sr_policy.rs.
+router:
+  bgp:
+    global:
+      as: 65001
+      router-id: 10.0.0.1
+    sr-policy:
+      steering-mode: binding-sid
+      policy:
+      - name: GREEN
+        color: 100
+        endpoint: 10.0.0.9
+        binding-sid-label: 16100
+        segment:
+        - index: 1
+          mpls-label: 16002

--- a/bdd/tests/features/bgp_sr_policy_bsid_steering.feature
+++ b/bdd/tests/features/bgp_sr_policy_bsid_steering.feature
@@ -1,0 +1,49 @@
+@bgp_sr_policy_bsid_steering
+Feature: BGP SR Policy Binding-SID steering mode (RFC 9256 §8.5)
+  An operator selects how colour-matched service routes are steered onto
+  an SR Policy: the whole SID list imposed inline (`segment-list`, the
+  historical default) or just the policy's Binding SID (`binding-sid`,
+  which the BSID's own forwarding entry — an SR-MPLS ILM or an SRv6
+  End.B6.Encaps SID — expands). This feature validates the new
+  `steering-mode` config surface end to end in a running daemon: the YANG
+  parses, the callback stages the mode onto the Loc-RIB SR Policy DB, and
+  `show bgp sr-policy` reflects it (both values). The steering *decision*
+  logic — BSID selection, the RFC 9256 §8.8.1 CO-bit endpoint fallback,
+  and the SR-MPLS ILM-installed gate — is covered by the unit tests in
+  `zebra-rs/src/bgp/sr_policy.rs`.
+
+  Topology:
+  ```
+   crs1 [ zebra-rs headend ]
+        router bgp 65001
+          sr-policy
+            steering-mode binding-sid   (toggled to segment-list below)
+            policy GREEN color 100 endpoint 10.0.0.9 binding-sid-label 16100
+  ```
+
+  Scenario: The binding-sid steering mode is configured and shown
+    Given a clean test environment
+    When I create namespace "crs1"
+    And I start zebra-rs in namespace "crs1"
+    And I apply config "crs1.yaml" to namespace "crs1"
+    # The new `steering-mode` leaf reached the Loc-RIB SR Policy DB and the
+    # show path renders it.
+    Then show command "show bgp sr-policy" in namespace "crs1" should eventually contain "Steering mode: binding-sid"
+
+  Scenario: Flipping the mode back to segment-list takes effect live
+    Given the test topology exists
+    When I apply command "set router bgp sr-policy steering-mode segment-list" in namespace "crs1"
+    Then show command "show bgp sr-policy" in namespace "crs1" should eventually contain "Steering mode: segment-list"
+
+  Scenario: Deleting the mode restores the segment-list default
+    Given the test topology exists
+    When I apply command "set router bgp sr-policy steering-mode binding-sid" in namespace "crs1"
+    Then show command "show bgp sr-policy" in namespace "crs1" should eventually contain "Steering mode: binding-sid"
+    When I apply command "delete router bgp sr-policy steering-mode binding-sid" in namespace "crs1"
+    Then show command "show bgp sr-policy" in namespace "crs1" should eventually contain "Steering mode: segment-list"
+
+  Scenario: Teardown topology
+    Given the test topology exists
+    When I stop zebra-rs in namespace "crs1"
+    And I delete namespace "crs1"
+    Then the test environment should be clean

--- a/docs/design/bgp-sr-policy-plan.md
+++ b/docs/design/bgp-sr-policy-plan.md
@@ -545,3 +545,43 @@ before each; CI is source of truth (don't run bdd locally).
 - **Originator scope** — confirm whether a real controller/PCE is in the
   test topology, or whether the originator phase is purely for self-interop.
 ```
+
+## 14. Binding-SID steering mode (post-series follow-up)
+
+PR6 automated steering imposes the matched policy's **whole SID list**
+inline on every steered service route. A follow-up adds a headend
+`steering-mode` knob so an operator can instead steer to the policy's
+**Binding SID** (RFC 9256 §8.5): the route imposes only the BSID — one
+MPLS label, or one SRv6 SID to H.Encap toward — and the BSID's own
+forwarding entry (the SR-MPLS ILM from PR5, or the SRv6 End.B6.Encaps SID
+from PR4, both already installed) expands it into the real segment list.
+
+- **Why:** label-stack compression, and — the headline benefit —
+  decoupling. When a policy's candidate path or segment list changes, only
+  the single BSID entry reprograms; the (potentially many thousands of)
+  colour-steered routes never touch the FIB. Inline mode reprograms every
+  steered route on any path change.
+- **Config:** `router bgp … sr-policy steering-mode {segment-list |
+  binding-sid}` (default `segment-list`, preserving PR6). Global (consumed
+  policies have no local config), consumer-side; the SAFI-73 / Color
+  extcomm wire is unchanged, so IOS-XR interop is unaffected. Cisco IOS-XR
+  has no equivalent per-headend toggle — it uses the BSID structurally
+  (hierarchical / inter-domain recursion, BGP-CT), so this is a zebra-rs
+  simplification.
+- **Scope (one slice):** SR-MPLS (IPv4 unicast) + SRv6 (IPv4 **and** IPv6
+  unicast — SRv6 BSID encap covers both AFs; `fib_install_v6` had no SR-MPLS
+  hook). SR-MPLS BSID steering gates on the ILM actually being installed
+  (`installed_mpls`, NHT-gated) so a steered route never pushes a label
+  with no LFIB entry; a not-yet-installed BSID falls back to inline
+  steering (reachable, just uncompressed) until the next re-eval. SRv6 has
+  no such gate (End.B6.Encaps installs immediately).
+- **Deferred:** VPN service-route BSID steering; IPv6-unicast SR-MPLS;
+  CO=10 cross-endpoint reinstall (route NHT tracks a different address than
+  the policy endpoint); per-colour steering-map; weighted-ECMP across
+  seglists.
+- **Validation:** unit tests in `src/bgp/sr_policy.rs` cover the BSID
+  selection, the CO-bit fallback, and the ILM-installed gate for both
+  dataplanes; the `@bgp_sr_policy_bsid_steering` BDD proves the config
+  surface (YANG → callback → Loc-RIB → `show bgp sr-policy`) live. A
+  full 2-node received-policy forwarding BDD is the same gap the whole
+  series carries (unit-test-only dataplane) — a further follow-up.

--- a/zebra-rs/src/bgp/config.rs
+++ b/zebra-rs/src/bgp/config.rs
@@ -4275,6 +4275,11 @@ impl Bgp {
         // (zebra-bgp-sr-policy.yang). Locally-originated SR Policies,
         // advertised as SAFI 73; callbacks stage onto
         // `Bgp::local_rib.sr_policy_local` and re-advertise.
+        // Headend steering mode (consumer-side): whole SID list vs BSID.
+        self.callback_add(
+            "/router/bgp/sr-policy/steering-mode",
+            super::sr_policy::config_srp_steering_mode,
+        );
         self.callback_add(
             "/router/bgp/sr-policy/policy",
             super::sr_policy::config_srp_policy,

--- a/zebra-rs/src/bgp/route.rs
+++ b/zebra-rs/src/bgp/route.rs
@@ -788,7 +788,25 @@ pub(super) fn fib_install_v4(bgp: &super::peer::BgpTop, prefix: Ipv4Net, selecte
                 && let rib::Nexthop::Uni(ref mut uni) = rib_entry.nexthop
                 && uni.segs.is_empty()
             {
-                if let Some(stack) = sr_policy_steer_mpls(bgp, &best.attr, IpAddr::V4(*nh)) {
+                // `binding-sid` steering mode (RFC 9256 §8.5): impose only
+                // the matched policy's Binding SID — a single MPLS label
+                // the BSID ILM expands, or a single SRv6 SID to H.Encap
+                // toward the End.B6.Encaps BSID — instead of the whole SID
+                // list. Falls through to the inline SID list below when the
+                // matched policy advertises no BSID (or the ILM isn't yet
+                // installed), so steering is never lost.
+                let bsid_mode =
+                    bgp.local_rib.sr_policy.steer_mode == super::sr_policy::SteerMode::BindingSid;
+                if bsid_mode
+                    && let Some(bsid) = sr_policy_steer_mpls_bsid(bgp, &best.attr, IpAddr::V4(*nh))
+                {
+                    uni.mpls.push(rib::Label::Explicit(bsid));
+                } else if bsid_mode
+                    && let Some(sid) = sr_policy_steer_srv6_bsid(bgp, &best.attr, IpAddr::V4(*nh))
+                {
+                    uni.segs = vec![sid];
+                    uni.encap_type = Some(isis_packet::srv6::EncapType::HEncap);
+                } else if let Some(stack) = sr_policy_steer_mpls(bgp, &best.attr, IpAddr::V4(*nh)) {
                     for label in stack {
                         uni.mpls.push(rib::Label::Explicit(label));
                     }
@@ -984,10 +1002,24 @@ pub(super) fn fib_install_v6(bgp: &super::peer::BgpTop, prefix: Ipv6Net, selecte
                 && let Some(BgpNexthop::Ipv6(nh)) = best.attr.nexthop.as_ref()
                 && let rib::Nexthop::Uni(ref mut uni) = rib_entry.nexthop
                 && uni.segs.is_empty()
-                && let Some(sid) = resolve_flex_algo_srv6(bgp, &best.attr, IpAddr::V6(*nh))
             {
-                uni.segs = vec![sid];
-                uni.encap_type = Some(isis_packet::srv6::EncapType::HEncap);
+                // `binding-sid` steering mode (RFC 9256 §8.5): impose the
+                // matched SRv6 policy's Binding SID (H.Encap toward its
+                // End.B6.Encaps SID) instead of the flex-algo End SID.
+                // Falls through to Flex-Algo when no BSID policy matches.
+                // (SR-MPLS Binding-SID steering on IPv6 unicast is a
+                // follow-up — `fib_install_v6` has no MPLS-push hook.)
+                let bsid = (bgp.local_rib.sr_policy.steer_mode
+                    == super::sr_policy::SteerMode::BindingSid)
+                    .then(|| sr_policy_steer_srv6_bsid(bgp, &best.attr, IpAddr::V6(*nh)))
+                    .flatten();
+                if let Some(sid) = bsid {
+                    uni.segs = vec![sid];
+                    uni.encap_type = Some(isis_packet::srv6::EncapType::HEncap);
+                } else if let Some(sid) = resolve_flex_algo_srv6(bgp, &best.attr, IpAddr::V6(*nh)) {
+                    uni.segs = vec![sid];
+                    uni.encap_type = Some(isis_packet::srv6::EncapType::HEncap);
+                }
             }
             // SRv6 service-route steering: prepend the algo-N End SID
             // before an existing End.DT6 service SID. Effective today for
@@ -1221,6 +1253,46 @@ fn sr_policy_steer_mpls(bgp: &super::peer::BgpTop, attr: &BgpAttr, nh: IpAddr) -
             .steer_mpls(color.color, nh, color.co_bits())
         {
             return Some(stack);
+        }
+    }
+    None
+}
+
+/// SR Policy *Binding-SID* steering (RFC 9256 §8.5) for a plain unicast
+/// service route, used in the `binding-sid` steering mode: if one of the
+/// route's colours maps to an active SR-MPLS policy whose Binding-SID ILM
+/// is installed for `<color, next-hop>` (CO-bit fallback honoured), return
+/// that single BSID label to push (the ILM expands it into the real
+/// stack). Colours tried in ascending order.
+fn sr_policy_steer_mpls_bsid(bgp: &super::peer::BgpTop, attr: &BgpAttr, nh: IpAddr) -> Option<u32> {
+    for color in attr.colors() {
+        if let Some(bsid) =
+            bgp.local_rib
+                .sr_policy
+                .steer_mpls_bsid(color.color, nh, color.co_bits())
+        {
+            return Some(bsid);
+        }
+    }
+    None
+}
+
+/// SRv6 twin of [`sr_policy_steer_mpls_bsid`]: return the SRv6 Binding SID
+/// (the End.B6.Encaps local-SID address) to H.Encap toward, for a colour
+/// matching an active SRv6 policy. Covers both IPv4 and IPv6 service
+/// routes (v4-over-v6 H.Encap for the former).
+fn sr_policy_steer_srv6_bsid(
+    bgp: &super::peer::BgpTop,
+    attr: &BgpAttr,
+    nh: IpAddr,
+) -> Option<std::net::Ipv6Addr> {
+    for color in attr.colors() {
+        if let Some(bsid) =
+            bgp.local_rib
+                .sr_policy
+                .steer_srv6_bsid(color.color, nh, color.co_bits())
+        {
+            return Some(bsid);
         }
     }
     None

--- a/zebra-rs/src/bgp/show.rs
+++ b/zebra-rs/src/bgp/show.rs
@@ -4922,6 +4922,11 @@ fn show_bgp_sr_policy(
     let family = if afi == Afi::Ip6 { "IPv6" } else { "IPv4" };
     let mut buf = String::new();
     writeln!(buf, "{family} SR Policy (SAFI 73):")?;
+    let mode = match bgp.local_rib.sr_policy.steer_mode {
+        super::sr_policy::SteerMode::BindingSid => "binding-sid",
+        super::sr_policy::SteerMode::SegmentList => "segment-list",
+    };
+    writeln!(buf, " Steering mode: {mode}")?;
 
     let mut shown = 0usize;
     for (key, policy) in bgp.local_rib.sr_policy.policies.iter() {

--- a/zebra-rs/src/bgp/sr_policy.rs
+++ b/zebra-rs/src/bgp/sr_policy.rs
@@ -237,10 +237,31 @@ fn srv6_bsid(cp: &CandidatePath) -> Option<Srv6Bsid> {
     Some(Srv6Bsid { bsid, segments })
 }
 
+/// How the headend imposes an SR Policy on a colour-matched service
+/// route (the `steering-mode` knob, zebra-bgp-sr-policy.yang). The wire
+/// (SAFI 73 / Color extcomm) is unchanged either way; this only selects
+/// the local forwarding encoding.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub enum SteerMode {
+    /// Impose the policy's explicit SID list inline on every steered
+    /// route (RFC 9256 §8; the original behaviour, kept as the default).
+    #[default]
+    SegmentList,
+    /// Impose only the policy's Binding SID; its own forwarding entry
+    /// (the SR-MPLS ILM / SRv6 End.B6.Encaps SID) expands it into the
+    /// segment list (RFC 9256 §8.5). Compresses the label stack and
+    /// decouples steered routes from policy-path churn. Falls back to the
+    /// inline SID list for a matched policy that advertises no BSID.
+    BindingSid,
+}
+
 /// The SR Policy database (one per BGP instance, lives on the Loc-RIB).
 #[derive(Clone, Debug, Default)]
 pub struct SrPolicyDb {
     pub policies: BTreeMap<SrPolicyKey, SrPolicy>,
+    /// Headend steering mode (`steering-mode` config). Applies to all
+    /// colour steering; default keeps the inline SID-list behaviour.
+    pub steer_mode: SteerMode,
 }
 
 impl SrPolicyDb {
@@ -320,8 +341,58 @@ impl SrPolicyDb {
     /// treated as `00`. The same-AF / any-AF sub-ordering of §8.8.1 is
     /// simplified to "same-family null endpoint, then any endpoint".
     pub fn steer_mpls(&self, color: u32, endpoint: IpAddr, co_bits: u8) -> Option<Vec<u32>> {
-        if let Some(stack) = self.steer_at(color, endpoint) {
-            return Some(stack);
+        self.steer_lookup(color, endpoint, co_bits, |p| {
+            p.active_cp().and_then(mpls_segments)
+        })
+    }
+
+    /// Steer to an SR-MPLS policy's *Binding SID* (a single label) instead
+    /// of its expanded SID list — the `binding-sid` steering mode. The
+    /// BSID's ILM (installed, NHT-gated, by [`Self::mpls_reconcile`])
+    /// swaps the single label for the real stack. Returns the BSID label
+    /// only when that ILM is actually installed for the active path, so a
+    /// steered route never pushes a label with no LFIB entry (a not-yet-
+    /// installed BSID falls through to inline steering — reachable, just
+    /// uncompressed — until the next re-eval). Same CO-bit endpoint
+    /// fallback as [`Self::steer_mpls`].
+    pub fn steer_mpls_bsid(&self, color: u32, endpoint: IpAddr, co_bits: u8) -> Option<u32> {
+        self.steer_lookup(color, endpoint, co_bits, |p| {
+            let active = p.active_cp().and_then(mpls_bsid)?.bsid;
+            p.installed_mpls.filter(|inst| *inst == active)
+        })
+    }
+
+    /// Steer to an SRv6 policy's *Binding SID* (a single SID to H.Encap
+    /// toward) instead of its expanded segment list — the `binding-sid`
+    /// steering mode. The BSID's End.B6.Encaps local SID (installed
+    /// immediately by [`SrPolicy::reconcile_fib`]) expands it. Returns the
+    /// currently-installed BSID address, so it tracks the dataplane state.
+    /// Same CO-bit endpoint fallback as [`Self::steer_mpls`].
+    pub fn steer_srv6_bsid(&self, color: u32, endpoint: IpAddr, co_bits: u8) -> Option<Ipv6Addr> {
+        self.steer_lookup(color, endpoint, co_bits, |p| {
+            p.installed.as_ref().map(|b| b.bsid)
+        })
+    }
+
+    /// Shared CO-bit endpoint-fallback ladder (RFC 9256 §8.8.1 / RFC 9830
+    /// §3) for the steer helpers. Try the exact `<color, endpoint>`, then
+    /// (CO≥01) the same-family null-endpoint colour-only policy, then
+    /// (CO≥10) any endpoint of the colour; `11` is reserved and treated as
+    /// `00`. `f` extracts the steering target from a matched policy; the
+    /// first policy that yields `Some` wins.
+    fn steer_lookup<T>(
+        &self,
+        color: u32,
+        endpoint: IpAddr,
+        co_bits: u8,
+        f: impl Fn(&SrPolicy) -> Option<T>,
+    ) -> Option<T> {
+        if let Some(v) = self
+            .policies
+            .get(&SrPolicyKey { color, endpoint })
+            .and_then(&f)
+        {
+            return Some(v);
         }
         let co = if co_bits == 0b11 { 0 } else { co_bits };
         if co >= 0b01 {
@@ -329,8 +400,15 @@ impl SrPolicyDb {
                 IpAddr::V4(_) => IpAddr::V4(Ipv4Addr::UNSPECIFIED),
                 IpAddr::V6(_) => IpAddr::V6(Ipv6Addr::UNSPECIFIED),
             };
-            if let Some(stack) = self.steer_at(color, null) {
-                return Some(stack);
+            if let Some(v) = self
+                .policies
+                .get(&SrPolicyKey {
+                    color,
+                    endpoint: null,
+                })
+                .and_then(&f)
+            {
+                return Some(v);
             }
         }
         if co >= 0b10 {
@@ -344,19 +422,12 @@ impl SrPolicyDb {
                 if key.color != color {
                     break;
                 }
-                if let Some(stack) = policy.active_cp().and_then(mpls_segments) {
-                    return Some(stack);
+                if let Some(v) = f(policy) {
+                    return Some(v);
                 }
             }
         }
         None
-    }
-
-    fn steer_at(&self, color: u32, endpoint: IpAddr) -> Option<Vec<u32>> {
-        self.policies
-            .get(&SrPolicyKey { color, endpoint })
-            .and_then(|p| p.active_cp())
-            .and_then(mpls_segments)
     }
 
     /// Reconcile the SR-MPLS Binding-SID ILM for a *live* policy against
@@ -648,6 +719,25 @@ fn local_policy<'a>(bgp: &'a mut Bgp, name: &str) -> &'a mut LocalSrPolicy {
         .policies
         .entry(name.to_string())
         .or_default()
+}
+
+/// `set router bgp sr-policy steering-mode segment-list|binding-sid` —
+/// choose how colour-matched service routes are steered onto a policy:
+/// the whole SID list imposed inline (`segment-list`, the default), or
+/// just the policy's Binding SID (`binding-sid`, RFC 9256 §8.5). This is
+/// a consumer-side headend behaviour; it takes effect as steered routes
+/// are (re)installed. `delete` restores the default.
+pub fn config_srp_steering_mode(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Option<()> {
+    let mode = match op {
+        ConfigOp::Set => match args.string()?.as_str() {
+            "binding-sid" => SteerMode::BindingSid,
+            _ => SteerMode::SegmentList,
+        },
+        ConfigOp::Delete => SteerMode::SegmentList,
+        _ => return Some(()),
+    };
+    bgp.local_rib.sr_policy.steer_mode = mode;
+    Some(())
 }
 
 /// `set router bgp sr-policy policy <NAME>` — ensure the entry exists;
@@ -1225,6 +1315,76 @@ mod tests {
         assert_eq!(db.steer_mpls(200, nh, 0b01), None);
         // CO=11 is reserved → treated as 00 (exact only) → no match.
         assert_eq!(db.steer_mpls(100, nh, 0b11), None);
+    }
+
+    #[test]
+    fn steer_mode_defaults_to_segment_list() {
+        assert_eq!(SrPolicyDb::default().steer_mode, SteerMode::SegmentList);
+    }
+
+    #[test]
+    fn steer_mpls_bsid_gated_on_installed_ilm() {
+        let mut db = SrPolicyDb::default();
+        let ep = endpoint("10.0.0.9");
+        db.insert(
+            SrPolicyKey {
+                color: 100,
+                endpoint: ep,
+            },
+            mpls_cp(1, 100, 1, 1000, 16001),
+        );
+        // The BSID ILM isn't installed yet (NHT-gated) → nothing to steer
+        // to; the caller falls back to inline SID-list steering.
+        assert_eq!(db.steer_mpls_bsid(100, ep, 0), None);
+        // Once the endpoint resolves and the ILM installs, steer to the
+        // single BSID label instead of the {16001} SID list.
+        assert!(db.mpls_reconcile(100, ep, true).install.is_some());
+        assert_eq!(db.steer_mpls_bsid(100, ep, 0), Some(1000));
+        // The inline steer still yields the full stack (mode is a caller
+        // choice; the DB exposes both).
+        assert_eq!(db.steer_mpls(100, ep, 0), Some(vec![16001]));
+        // Endpoint goes unreachable → ILM torn down → no BSID again.
+        db.mpls_reconcile(100, ep, false);
+        assert_eq!(db.steer_mpls_bsid(100, ep, 0), None);
+    }
+
+    #[test]
+    fn steer_mpls_bsid_co_bit_fallback() {
+        let mut db = SrPolicyDb::default();
+        let nh = endpoint("10.0.0.9");
+        let null = endpoint("0.0.0.0");
+        db.insert(
+            SrPolicyKey {
+                color: 100,
+                endpoint: null,
+            },
+            mpls_cp(1, 100, 1, 1000, 17001),
+        );
+        db.mpls_reconcile(100, null, true);
+        // No exact <100, nh>: CO=00 → none; CO=01 → the null-endpoint BSID.
+        assert_eq!(db.steer_mpls_bsid(100, nh, 0), None);
+        assert_eq!(db.steer_mpls_bsid(100, nh, 0b01), Some(1000));
+    }
+
+    #[test]
+    fn steer_srv6_bsid_returns_installed_bsid() {
+        let mut db = SrPolicyDb::default();
+        let ep = endpoint("10.0.0.9");
+        // A valid SRv6 policy installs its End.B6.Encaps BSID immediately
+        // (NHT-independent), so it is steerable at once — no reconcile.
+        db.insert(
+            SrPolicyKey {
+                color: 100,
+                endpoint: ep,
+            },
+            srv6_cp(1, 100, 1, "fc00:0:9::100", "fc00:0:2::"),
+        );
+        assert_eq!(db.steer_srv6_bsid(100, ep, 0), Some(v6("fc00:0:9::100")));
+        // Wrong colour with CO=00 → none.
+        assert_eq!(db.steer_srv6_bsid(200, ep, 0), None);
+        // Withdrawing the policy removes the BSID → no steer.
+        db.withdraw(100, ep, 1, 1);
+        assert_eq!(db.steer_srv6_bsid(100, ep, 0), None);
     }
 
     #[test]

--- a/zebra-rs/src/config/manager.rs
+++ b/zebra-rs/src/config/manager.rs
@@ -1824,6 +1824,40 @@ mod yang_load_tests {
         }
     }
 
+    /// Regression guard for the BGP SR Policy `steering-mode` grammar
+    /// (zebra-bgp-sr-policy.yang). Pins the enum leaf so a broken
+    /// enumeration or a stale callback path is caught in the unit suite,
+    /// not only in the `@bgp_sr_policy_bsid_steering` BDD. Also re-pins a
+    /// couple of the existing policy leaves alongside it.
+    #[test]
+    fn bgp_sr_policy_steering_mode_paths_parse() {
+        use crate::config::ExecCode;
+        use crate::config::parse::{State, parse};
+        use libyang::to_entry;
+
+        let mut yang = YangStore::new();
+        yang.add_path(concat!(env!("CARGO_MANIFEST_DIR"), "/yang"));
+        yang.read_with_resolve("configure")
+            .unwrap_or_else(|e| panic!("configure failed to load: {e:#}"));
+        yang.identity_resolve();
+        let module = yang.find_module("configure").unwrap();
+        let entry = to_entry(&yang, module);
+
+        for cmd in [
+            "set router bgp sr-policy steering-mode segment-list",
+            "set router bgp sr-policy steering-mode binding-sid",
+            "set router bgp sr-policy policy GREEN color 100",
+            "set router bgp sr-policy policy GREEN binding-sid-label 16100",
+        ] {
+            let (code, _comps, _state) = parse(cmd, entry.clone(), None, State::new());
+            assert_eq!(
+                code,
+                ExecCode::Success,
+                "should parse as a settable path: {cmd}"
+            );
+        }
+    }
+
     /// Regression guard for the per-VRF redistribute grammar
     /// (zebra-bgp-vrf.yang `afi-safi {ipv4,ipv6} redistribute
     /// {connected,static}`). Pins the new bare-presence paths so a

--- a/zebra-rs/yang/zebra-bgp-sr-policy.yang
+++ b/zebra-rs/yang/zebra-bgp-sr-policy.yang
@@ -76,6 +76,27 @@ module zebra-bgp-sr-policy {
       ext:help "Locally-originated BGP SR Policies (SAFI 73)";
       presence "Configure local SR Policies";
 
+      leaf steering-mode {
+        ext:help "How a colour-matched route is steered onto a policy";
+        type enumeration {
+          enum segment-list {
+            description
+              "Impose the policy's explicit SID list inline on every
+               steered route (RFC 9256 §8). The default.";
+          }
+          enum binding-sid {
+            description
+              "Impose only the policy's Binding SID; its own forwarding
+               entry (the SR-MPLS ILM / SRv6 End.B6.Encaps SID) expands
+               it into the segment list (RFC 9256 §8.5). Compresses the
+               stack and decouples steered routes from policy-path churn.
+               Falls back to the inline SID list when the matched policy
+               advertises no Binding SID.";
+          }
+        }
+        default "segment-list";
+      }
+
       list policy {
         ext:help "A local SR Policy, advertised as SAFI 73";
         key name;


### PR DESCRIPTION
## What

Adds a headend **`steering-mode {segment-list | binding-sid}`** knob to BGP SR Policy colour steering. The existing series (PR6) steers a colour-matched service route by imposing the policy's **whole SID list inline**. In `binding-sid` mode the route imposes only the policy's **Binding SID** — one MPLS label the BSID ILM expands, or one SRv6 SID to H.Encap toward the End.B6.Encaps BSID — and the BSID's own forwarding entry (already installed by PR4/PR5) expands it (RFC 9256 §8.5).

Default is `segment-list`, so existing deployments are unchanged.

### Why
- **Stack compression** — one label/SID per steered route instead of N.
- **Decoupling (the headline benefit)** — when a policy's candidate path or segment list changes, only the single BSID entry reprograms; the (potentially thousands of) colour-steered routes never touch the FIB. Inline mode reprograms every steered route on any path change.
- **Coverage** — SRv6 BSID encap covers **both IPv4 and IPv6** unicast; `fib_install_v6` had no SR-MPLS steering hook at all.

## Scope (one slice, both dataplanes)
- **SR-MPLS** — IPv4 unicast. Gates on the BSID ILM actually being installed (`installed_mpls`, NHT-gated) so a steered route never pushes a label with no LFIB entry; a not-yet-installed BSID falls back to inline steering (reachable, just uncompressed) until the next re-eval.
- **SRv6** — IPv4 **and** IPv6 unicast. End.B6.Encaps BSID installs immediately (no NHT gate).

## Changes
- `sr_policy.rs`: `SteerMode` enum + `SrPolicyDb.steer_mode`; `steer_mpls_bsid` / `steer_srv6_bsid` sharing a refactored CO-bit endpoint-fallback helper; `config_srp_steering_mode` callback.
- `route.rs`: mode-aware steering in `fib_install_v4` / `fib_install_v6`.
- `zebra-bgp-sr-policy.yang`: `steering-mode` enum leaf (default `segment-list`); `show bgp sr-policy` renders `Steering mode:`.
- Config-registration + YANG pin test.

## Validation
- **Unit tests** (`src/bgp/sr_policy.rs`) — BSID selection, CO-bit fallback, and the ILM-installed gate, for both dataplanes. Full `zebra-rs` suite: **1565 passed**.
- **Live BDD** `@bgp_sr_policy_bsid_steering` — proves the config surface end to end in a running daemon (YANG parse → callback → Loc-RIB → `show bgp sr-policy`), both mode values + the delete-restores-default path. **4 scenarios / 17 steps pass.**
- `cargo fmt` + workspace clippy clean.

## Interop
The SAFI-73 / Color extended-community wire is unchanged, so Cisco IOS-XR interop is unaffected. IOS-XR has no equivalent per-headend toggle — it uses the BSID structurally (hierarchical / inter-domain recursion, BGP-CT) — so this is a zebra-rs simplification (see design-doc §14).

## Deferred (noted in design-doc §14)
VPN service-route BSID steering; IPv6-unicast SR-MPLS; CO=10 cross-endpoint reinstall; per-colour steering-map; weighted-ECMP across seglists; a full 2-node received-policy forwarding BDD (the same dataplane-validation gap the whole SR Policy series carries).

🤖 Generated with [Claude Code](https://claude.com/claude-code)