### PR TITLE
bdd: end-to-end forwarding test for SR Policy Binding-SID steering

### DIFF
--- a/bdd/tests/configs/bgp_sr_policy_bsid_forwarding/crs1.yaml
+++ b/bdd/tests/configs/bgp_sr_policy_bsid_forwarding/crs1.yaml
@@ -1,0 +1,44 @@
+# crs1 — headend PE (iBGP AS 65000) with binding-sid SR-Policy steering.
+# Receives from crs2 (a) the service route 10.99.0.0/24 and (b) the SR
+# Policy for <color 100, endpoint 192.168.12.2> over SAFI 73, and consumes
+# the policy (route-target == our router-id 10.0.0.1).
+#
+# The COLOR100 route-map (`set color 100`) is DEFINED here but NOT attached
+# to the neighbor in the initial config: `route_sync` dumps unicast before
+# SAFI-73, so the service route arrives before the policy, and consuming a
+# policy does not re-evaluate already-installed routes. The feature attaches
+# the inbound policy AFTER convergence — an inbound-policy change auto-
+# re-evaluates received routes — so the colour (and thus the steer) is
+# applied with the policy already present. Deterministic ordering.
+policy:
+- name: COLOR100
+  entry:
+  - number: 10
+    action: permit
+    set:
+      color: 100
+interface:
+- if-name: i1
+  ipv4:
+    address: 192.168.12.1/24
+router:
+  bgp:
+    global:
+      as: 65000
+      router-id: 10.0.0.1
+    timer:
+      adv-interval:
+        ibgp: 1
+        ebgp: 1
+    sr-policy:
+      steering-mode: binding-sid
+    neighbor:
+    - remote-address: 192.168.12.2
+      timers: {connect-retry-time: 3}
+      remote-as: 65000
+      enabled: true
+      afi-safi:
+      - name: ipv4
+        enabled: true
+      - name: sr-policy-v4
+        enabled: true

--- a/bdd/tests/configs/bgp_sr_policy_bsid_forwarding/crs2.yaml
+++ b/bdd/tests/configs/bgp_sr_policy_bsid_forwarding/crs2.yaml
@@ -1,0 +1,54 @@
+# crs2 — SR-TE controller + service-route origin (iBGP AS 65000).
+# Originates:
+#  - an SR-MPLS SR Policy (SAFI 73) for <color 100, endpoint 192.168.12.2>
+#    with an MPLS Binding SID 16100 and a one-hop segment list {16002}, plus
+#    route-target 10.0.0.1 (crs1's router-id) so crs1 CONSUMES it locally
+#    (RFC 9830 §4.2 — an IPv4-address RT == the receiver's BGP Identifier);
+#  - the service prefix 10.99.0.0/24 (a blackhole static, redistributed),
+#    which crs1 colours on ingress and steers onto the policy.
+# The endpoint 192.168.12.2 is crs2's own peering address, which is exactly
+# the BGP next-hop crs1 sees for 10.99.0.0/24 — so the steer matches
+# <color 100, next-hop 192.168.12.2> with CO=00.
+interface:
+- if-name: i1
+  ipv4:
+    address: 192.168.12.2/24
+router:
+  static:
+    ipv4:
+      route:
+      - prefix: 10.99.0.0/24
+        nexthop:
+        - address: blackhole
+  bgp:
+    global:
+      as: 65000
+      router-id: 10.0.0.2
+    timer:
+      adv-interval:
+        ibgp: 1
+        ebgp: 1
+    sr-policy:
+      policy:
+      - name: P1
+        color: 100
+        endpoint: 192.168.12.2
+        binding-sid-label: 16100
+        route-target: 10.0.0.1
+        segment:
+        - index: 1
+          mpls-label: 16002
+    neighbor:
+    - remote-address: 192.168.12.1
+      timers: {connect-retry-time: 3}
+      remote-as: 65000
+      enabled: true
+      afi-safi:
+      - name: ipv4
+        enabled: true
+      - name: sr-policy-v4
+        enabled: true
+    afi-safi:
+    - name: ipv4
+      redistribute:
+        static: {}

--- a/bdd/tests/features/bgp_sr_policy_bsid_forwarding.feature
+++ b/bdd/tests/features/bgp_sr_policy_bsid_forwarding.feature
@@ -1,0 +1,67 @@
+@bgp_sr_policy_bsid_forwarding
+Feature: BGP SR Policy Binding-SID steering — end-to-end forwarding (RFC 9256 §8.5)
+  A headend (crs1) receives a service route AND an SR Policy over SAFI 73
+  from a controller (crs2), colours the route on ingress, and steers it
+  onto the policy. With `steering-mode binding-sid` the installed route
+  pushes only the policy's Binding SID (label 16100); with
+  `steering-mode segment-list` it pushes the policy's whole SID list
+  (label 16002). The two labels are distinct, so `show ip route` proves,
+  at the FIB, both that steering fires on *received* SR-policy state and
+  that the mode selects the Binding SID vs the inline segment list.
+
+  This is the forwarding-plane companion to @bgp_sr_policy_bsid_steering
+  (which covers the config/show surface). It exercises the real receive →
+  consume → colour → steer path, not just config.
+
+  Topology (single link, iBGP AS 65000):
+  ```
+   crs1 [ headend, steering-mode binding-sid ] i1 ── i1 [ crs2 controller ]
+        192.168.12.1/24                            192.168.12.2/24
+        consumes SR Policy <color 100, endpoint 192.168.12.2>:
+          binding-sid-label 16100, segment {16002}, route-target 10.0.0.1
+        colours received 10.99.0.0/24 with colour 100 and steers it
+  ```
+
+  Scenario: crs1 consumes the received SR Policy and installs the service route
+    Given a clean test environment
+    When I create namespace "crs1"
+    And I create namespace "crs2"
+    And I connect namespace "crs1" interface "i1" to namespace "crs2" interface "i1"
+    And I start zebra-rs in namespace "crs1"
+    And I start zebra-rs in namespace "crs2"
+    And I apply config "crs1.yaml" to namespace "crs1"
+    And I apply config "crs2.yaml" to namespace "crs2"
+    And I wait 15 seconds
+    # The SR Policy advertised by crs2 was consumed into crs1's headend DB.
+    Then show command "show bgp sr-policy" in namespace "crs1" should eventually contain "endpoint 192.168.12.2"
+    And show command "show bgp sr-policy" in namespace "crs1" should contain "Steering mode: binding-sid"
+    # The service route is installed via crs2 — not yet coloured, so not steered.
+    And show command "show ip route 10.99.0.0/24" in namespace "crs1" should eventually contain "192.168.12.2"
+
+  Scenario: Colouring the route inbound steers it onto the Binding SID
+    Given the test topology exists
+    # Attaching the inbound route-map re-evaluates received routes, so
+    # 10.99.0.0/24 is now coloured 100 with the policy already consumed.
+    When I apply command "set router bgp neighbor 192.168.12.2 afi-safi ipv4 policy in COLOR100" in namespace "crs1"
+    # binding-sid mode: the route pushes the policy's Binding SID (16100),
+    # NOT the inline segment list (16002).
+    Then show command "show ip route 10.99.0.0/24" in namespace "crs1" should eventually contain "label 16100"
+
+  Scenario: Switching to segment-list mode pushes the inline SID list instead
+    Given the test topology exists
+    When I apply command "set router bgp sr-policy steering-mode segment-list" in namespace "crs1"
+    # Re-trigger the inbound re-evaluation (detach + re-attach the colour
+    # route-map) so the route re-installs under the new mode.
+    And I apply command "delete router bgp neighbor 192.168.12.2 afi-safi ipv4 policy in COLOR100" in namespace "crs1"
+    And I apply command "set router bgp neighbor 192.168.12.2 afi-safi ipv4 policy in COLOR100" in namespace "crs1"
+    # segment-list mode: the route now pushes the policy's SID list (16002),
+    # not the Binding SID.
+    Then show command "show ip route 10.99.0.0/24" in namespace "crs1" should eventually contain "label 16002"
+
+  Scenario: Teardown topology
+    Given the test topology exists
+    When I stop zebra-rs in namespace "crs1"
+    And I stop zebra-rs in namespace "crs2"
+    And I delete namespace "crs1"
+    And I delete namespace "crs2"
+    Then the test environment should be clean


### PR DESCRIPTION
## What

A 2-node iBGP BDD proving the **receive → consume → colour → steer** path for `steering-mode binding-sid` (the feature merged in #1927), not just the config/show surface that `@bgp_sr_policy_bsid_steering` covers. This is the forwarding-plane gap the whole SR Policy series carried (dataplane was unit-test-only).

## Topology
```
 crs1 [ headend, steering-mode binding-sid ] i1 ── i1 [ crs2 controller ]
      192.168.12.1/24                            192.168.12.2/24
```
crs2 advertises over SAFI 73 an SR-MPLS SR Policy for `<color 100, endpoint 192.168.12.2>` (Binding-SID label **16100**, segment list **{16002}**, `route-target 10.0.0.1` = crs1's router-id so crs1 consumes it per RFC 9830 §4.2) plus the service prefix `10.99.0.0/24`. crs1 colours the received route inbound and steers it.

## Why it's a real forwarding proof
The Binding SID (16100) and the inline segment list (16002) are **distinct labels**, so `show ip route 10.99.0.0/24` at the FIB proves both that steering fires on *received* SR-policy state and that the mode selects the BSID vs the inline list:

- **consume** — `show bgp sr-policy` shows the received `<color 100, endpoint 192.168.12.2>`.
- **binding-sid mode** — the route pushes **label 16100** (the Binding SID).
- **segment-list mode** — the route pushes **label 16002** (the inline SID list).

## Determinism
`route_sync` dumps unicast *before* SAFI-73, and consuming a policy does not re-evaluate already-installed routes — so the colour route-map is defined-but-detached in the initial config and **attached after convergence**; an inbound-policy change auto-re-evaluates received routes with the policy already consumed. (This also documents a genuine product nuance: an SR policy that arrives after its service routes won't steer them until they churn — a candidate follow-up.)

## Result
**4 scenarios / 26 steps pass** locally (`@bgp_sr_policy_bsid_forwarding`). BDD-only; no code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)