### PR TITLE
rib: per-VRF mpls ttl propagate override for the cradle tee

### DIFF
--- a/CHANGELOG.yaml
+++ b/CHANGELOG.yaml
@@ -30,7 +30,10 @@
           label-TTL model teed to cradle (pipe hides the LSP, the
           default; uniform exposes the hop count end to end) via
           `Nexthop.mpls_pipe_ttl` at imposition and `Ilm.ttl_uniform`
-          at pop-to-IP disposition
+          at pop-to-IP disposition; a per-VRF `vrf <name> mpls ttl
+          propagate {inherit|pipe|uniform}` override applies to that
+          VRF's L3VPN LSPs at both ends (e.g. uniform in the global
+          table, pipe per VPN)
 
     - note: |
         ### EVPN

--- a/zebra-rs/src/fib/cradle.rs
+++ b/zebra-rs/src/fib/cradle.rs
@@ -176,10 +176,12 @@ fn cradle_vrf(table_id: u32) -> u32 {
 pub struct CradleFib {
     endpoint: String,
     client: Arc<Mutex<Option<CradleClient<Channel>>>>,
-    /// Dedup `(gateway, oif, out-label stack, backup id) -> nexthop id` so we
-    /// `SetNexthop` once per distinct nexthop.
-    nh_ids: Arc<Mutex<HashMap<(u32, u32, Vec<u32>, u32), u32>>>,
-    nh_ids6: Arc<Mutex<HashMap<([u8; 16], u32, Vec<u32>, u32), u32>>>,
+    /// Dedup `(gateway, oif, out-label stack, backup id, pipe) -> nexthop id`
+    /// so we `SetNexthop` once per distinct nexthop. `pipe` (the RFC 3443 TTL
+    /// model) is in the key so two VRFs with different models never alias the
+    /// same imposition nexthop.
+    nh_ids: Arc<Mutex<HashMap<(u32, u32, Vec<u32>, u32, bool), u32>>>,
+    nh_ids6: Arc<Mutex<HashMap<([u8; 16], u32, Vec<u32>, u32, bool), u32>>>,
     /// SRv6 nexthop dedup: `(underlay gateway, oif, segment list) -> id`.
     nh_ids_srv6: Arc<Mutex<HashMap<([u8; 16], u32, Vec<[u8; 16]>), u32>>>,
     /// GTP-U encap nexthop dedup:
@@ -196,6 +198,12 @@ pub struct CradleFib {
     /// disposition preserves the inner IP TTL. `false` = uniform: imposition
     /// seeds from the inner TTL and pop-to-IP writes it back (`ttl_uniform`).
     mpls_pipe: Arc<std::sync::atomic::AtomicBool>,
+    /// Per-VRF MPLS TTL-model overrides (`vrf <name> mpls ttl propagate`),
+    /// keyed by the cradle VRF table id (`cradle_vrf`). `true` = pipe, `false`
+    /// = uniform; an absent entry inherits the global `mpls_pipe`. Applied at
+    /// both ends of a VRF's LSPs (imposition seed and pop-to-IP writeback) so
+    /// they stay consistent.
+    mpls_pipe_vrf: Arc<std::sync::Mutex<HashMap<u32, bool>>>,
     /// Everything this tee has programmed, for [`Self::replay`].
     mirror: Arc<Mutex<CradleMirror>>,
 }
@@ -340,21 +348,46 @@ impl CradleFib {
             // matching zebra-rs's prior behavior. `set mpls ttl propagate
             // uniform` flips it via `set_mpls_pipe`.
             mpls_pipe: Arc::new(std::sync::atomic::AtomicBool::new(true)),
+            mpls_pipe_vrf: Arc::new(std::sync::Mutex::new(HashMap::new())),
             mirror: Arc::new(Mutex::new(CradleMirror::default())),
         }
     }
 
-    /// Set the RFC 3443 MPLS TTL model for subsequently-programmed labeled
-    /// nexthops and pop-to-IP ILMs. `true` = pipe, `false` = uniform. Cheap
-    /// interior mutation (no reconnect); existing entries re-derive on the next
-    /// resync/replay.
+    /// Set the global RFC 3443 MPLS TTL model for subsequently-programmed
+    /// labeled nexthops and pop-to-IP ILMs. `true` = pipe, `false` = uniform.
+    /// Cheap interior mutation (no reconnect); existing entries re-derive on
+    /// the next resync/replay.
     pub fn set_mpls_pipe(&self, pipe: bool) {
         self.mpls_pipe.store(pipe, Ordering::Relaxed);
     }
 
-    /// The current RFC 3443 model: `true` = pipe (seed 255 / preserve inner),
-    /// `false` = uniform (seed from inner / write back on pop).
-    fn mpls_pipe(&self) -> bool {
+    /// Set (or clear, with `None`) a per-VRF MPLS TTL-model override
+    /// (`vrf <name> mpls ttl propagate`). `table_id` is the kernel table id;
+    /// it is normalized to the cradle VRF convention.
+    pub fn set_vrf_mpls_pipe(&self, table_id: u32, pipe: Option<bool>) {
+        let t = cradle_vrf(table_id);
+        let mut map = self.mpls_pipe_vrf.lock().unwrap();
+        match pipe {
+            Some(p) => {
+                map.insert(t, p);
+            }
+            None => {
+                map.remove(&t);
+            }
+        }
+    }
+
+    /// The RFC 3443 model in effect for `table_id`: the per-VRF override if
+    /// set, else the global model. `true` = pipe (seed 255 / preserve inner),
+    /// `false` = uniform (seed from inner / write back on pop). The global
+    /// table (`0`/`254`) always takes the global model.
+    fn effective_pipe(&self, table_id: u32) -> bool {
+        let t = cradle_vrf(table_id);
+        if t != 0
+            && let Some(p) = self.mpls_pipe_vrf.lock().unwrap().get(&t)
+        {
+            return *p;
+        }
         self.mpls_pipe.load(Ordering::Relaxed)
     }
 
@@ -571,12 +604,14 @@ impl CradleFib {
         oif: u32,
         labels: &[u32],
         backup_id: u32,
+        pipe: bool,
     ) -> anyhow::Result<u32> {
         let key = (
             gw.map(u32::from).unwrap_or(0),
             oif,
             labels.to_vec(),
             backup_id,
+            pipe,
         );
         {
             let ids = self.nh_ids.lock().await;
@@ -603,7 +638,7 @@ impl CradleFib {
                 vxlan_vtep: String::new(),
                 vxlan_l3vni: 0,
                 vxlan_rmac: String::new(),
-                mpls_pipe_ttl: self.mpls_pipe() && !labels.is_empty(),
+                mpls_pipe_ttl: pipe && !labels.is_empty(),
             })
             .await?;
         self.nh_ids.lock().await.insert(key, id);
@@ -713,7 +748,12 @@ impl CradleFib {
     /// Resolve a teed member to a cradle nexthop id. SRv6 members (non-empty
     /// `segs`) are always v6-underlay; otherwise the family follows the
     /// gateway, or `route_v6` for an on-link (gateway-less) member.
-    async fn member_nexthop_id(&self, m: &Member, route_v6: bool) -> anyhow::Result<u32> {
+    async fn member_nexthop_id(
+        &self,
+        m: &Member,
+        route_v6: bool,
+        pipe: bool,
+    ) -> anyhow::Result<u32> {
         let (gw, oif, labels, segs, encap_mode, vxlan, backup) = m;
         // Fast-reroute: resolve the backup leaf first (the TI-LFA repair —
         // packed carriers + H.Insert for SRv6, the repair label stack for
@@ -721,7 +761,7 @@ impl CradleFib {
         // over on link-down.
         let backup_id = match backup {
             Some((bgw, boif, blabels, bsegs, bmode, _bvxlan)) => {
-                self.leaf_nexthop_id(bgw, *boif, blabels, bsegs, *bmode, route_v6)
+                self.leaf_nexthop_id(bgw, *boif, blabels, bsegs, *bmode, route_v6, pipe)
                     .await?
             }
             None => 0,
@@ -744,10 +784,16 @@ impl CradleFib {
             return self.srv6_nexthop_id(gw6, *oif, segs, *encap_mode).await;
         }
         match gw {
-            Some(IpAddr::V4(a)) => self.nexthop_id(Some(*a), *oif, labels, backup_id).await,
-            Some(IpAddr::V6(a)) => self.nexthop_id6(Some(*a), *oif, labels, backup_id).await,
-            None if route_v6 => self.nexthop_id6(None, *oif, labels, backup_id).await,
-            None => self.nexthop_id(None, *oif, labels, backup_id).await,
+            Some(IpAddr::V4(a)) => {
+                self.nexthop_id(Some(*a), *oif, labels, backup_id, pipe)
+                    .await
+            }
+            Some(IpAddr::V6(a)) => {
+                self.nexthop_id6(Some(*a), *oif, labels, backup_id, pipe)
+                    .await
+            }
+            None if route_v6 => self.nexthop_id6(None, *oif, labels, backup_id, pipe).await,
+            None => self.nexthop_id(None, *oif, labels, backup_id, pipe).await,
         }
     }
 
@@ -760,6 +806,7 @@ impl CradleFib {
         segs: &[Ipv6Addr],
         encap_mode: u32,
         route_v6: bool,
+        pipe: bool,
     ) -> anyhow::Result<u32> {
         if !segs.is_empty() {
             let gw6 = match gw {
@@ -769,10 +816,10 @@ impl CradleFib {
             return self.srv6_nexthop_id(gw6, oif, segs, encap_mode).await;
         }
         match gw {
-            Some(IpAddr::V4(a)) => self.nexthop_id(Some(*a), oif, labels, 0).await,
-            Some(IpAddr::V6(a)) => self.nexthop_id6(Some(*a), oif, labels, 0).await,
-            None if route_v6 => self.nexthop_id6(None, oif, labels, 0).await,
-            None => self.nexthop_id(None, oif, labels, 0).await,
+            Some(IpAddr::V4(a)) => self.nexthop_id(Some(*a), oif, labels, 0, pipe).await,
+            Some(IpAddr::V6(a)) => self.nexthop_id6(Some(*a), oif, labels, 0, pipe).await,
+            None if route_v6 => self.nexthop_id6(None, oif, labels, 0, pipe).await,
+            None => self.nexthop_id(None, oif, labels, 0, pipe).await,
         }
     }
 
@@ -800,8 +847,10 @@ impl CradleFib {
             return Ok(());
         }
         let vrf_table_id = cradle_vrf(table_id);
+        // RFC 3443 model for this route's VRF (per-VRF override or the global).
+        let pipe = self.effective_pipe(table_id);
         if members.len() == 1 {
-            let id = self.member_nexthop_id(&members[0], false).await?;
+            let id = self.member_nexthop_id(&members[0], false, pipe).await?;
             self.client()
                 .await?
                 .add_route4(pb::Route4 {
@@ -816,7 +865,7 @@ impl CradleFib {
         // ECMP: one nexthop per member, then a group the route points at.
         let mut ids = Vec::with_capacity(members.len());
         for m in &members {
-            ids.push(self.member_nexthop_id(m, false).await?);
+            ids.push(self.member_nexthop_id(m, false, pipe).await?);
         }
         let gid = self.next_id.fetch_add(1, Ordering::Relaxed);
         let mut client = self.client().await?;
@@ -865,12 +914,14 @@ impl CradleFib {
         oif: u32,
         labels: &[u32],
         backup_id: u32,
+        pipe: bool,
     ) -> anyhow::Result<u32> {
         let key = (
             gw.map(|a| a.octets()).unwrap_or([0; 16]),
             oif,
             labels.to_vec(),
             backup_id,
+            pipe,
         );
         {
             let ids = self.nh_ids6.lock().await;
@@ -897,7 +948,7 @@ impl CradleFib {
                 vxlan_vtep: String::new(),
                 vxlan_l3vni: 0,
                 vxlan_rmac: String::new(),
-                mpls_pipe_ttl: self.mpls_pipe() && !labels.is_empty(),
+                mpls_pipe_ttl: pipe && !labels.is_empty(),
             })
             .await?;
         self.nh_ids6.lock().await.insert(key, id);
@@ -928,8 +979,10 @@ impl CradleFib {
             return Ok(());
         }
         let vrf_table_id = cradle_vrf(table_id);
+        // RFC 3443 model for this route's VRF (per-VRF override or the global).
+        let pipe = self.effective_pipe(table_id);
         if members.len() == 1 {
-            let id = self.member_nexthop_id(&members[0], true).await?;
+            let id = self.member_nexthop_id(&members[0], true, pipe).await?;
             self.client()
                 .await?
                 .add_route6(pb::Route6 {
@@ -943,7 +996,7 @@ impl CradleFib {
         }
         let mut ids = Vec::with_capacity(members.len());
         for m in &members {
-            ids.push(self.member_nexthop_id(m, true).await?);
+            ids.push(self.member_nexthop_id(m, true, pipe).await?);
         }
         let gid = self.next_id.fetch_add(1, Ordering::Relaxed);
         let mut client = self.client().await?;
@@ -999,11 +1052,17 @@ impl CradleFib {
             in_label,
             (action, vrf_table_id, gw, oif, out_labels.to_vec()),
         );
+        // RFC 3443 model for this ILM's VRF (per-VRF override or the global).
+        // For POP_L3 the out stack is empty, so the imposition seed is moot;
+        // for a swap it governs the swapped stack's label TTL.
+        let pipe = self.effective_pipe(vrf_table_id);
         let result = async {
             let nexthop_id = match gw {
-                Some(IpAddr::V6(v6)) => self.nexthop_id6(Some(v6), oif, out_labels, 0).await?,
-                Some(IpAddr::V4(v4)) => self.nexthop_id(Some(v4), oif, out_labels, 0).await?,
-                None => self.nexthop_id(None, oif, out_labels, 0).await?,
+                Some(IpAddr::V6(v6)) => {
+                    self.nexthop_id6(Some(v6), oif, out_labels, 0, pipe).await?
+                }
+                Some(IpAddr::V4(v4)) => self.nexthop_id(Some(v4), oif, out_labels, 0, pipe).await?,
+                None => self.nexthop_id(None, oif, out_labels, 0, pipe).await?,
             };
             self.client()
                 .await?
@@ -1014,7 +1073,8 @@ impl CradleFib {
                     vrf_table_id,
                     // Uniform disposition only bites at a pop-to-IP (POP_L3):
                     // copy the popped label TTL into the exposed IP header.
-                    ttl_uniform: action == MPLS_OP_POP_L3 && !self.mpls_pipe(),
+                    // The per-VRF model must match this ILM's imposition end.
+                    ttl_uniform: action == MPLS_OP_POP_L3 && !pipe,
                 })
                 .await?;
             anyhow::Ok(())
@@ -1065,11 +1125,12 @@ impl CradleFib {
             .insert(prefix, (behavior, adj, oif));
         let result = async {
             let nexthop_id = match adj {
+                // Adjacency SID (no imposed labels) — the TTL model is moot.
                 Some(IpAddr::V6(a)) if !a.is_unspecified() => {
-                    self.nexthop_id6(Some(a), oif, &[], 0).await?
+                    self.nexthop_id6(Some(a), oif, &[], 0, false).await?
                 }
                 Some(IpAddr::V4(a)) if !a.is_unspecified() => {
-                    self.nexthop_id(Some(a), oif, &[], 0).await?
+                    self.nexthop_id(Some(a), oif, &[], 0, false).await?
                 }
                 _ => 0,
             };
@@ -1135,7 +1196,7 @@ impl CradleFib {
                     self.srv6_nexthop_id(None, ifindex, &sid.segs, 0).await?
                 } else {
                     match sid.nh6 {
-                        Some(nh6) => self.nexthop_id6(Some(nh6), ifindex, &[], 0).await?,
+                        Some(nh6) => self.nexthop_id6(Some(nh6), ifindex, &[], 0, false).await?,
                         None => 0,
                     }
                 };

--- a/zebra-rs/src/fib/netlink/handle.rs
+++ b/zebra-rs/src/fib/netlink/handle.rs
@@ -571,6 +571,15 @@ impl FibHandle {
         }
     }
 
+    /// Set (or clear, with `None`) a per-VRF MPLS TTL-model override
+    /// (`vrf <name> mpls ttl propagate`) on the live tee, keyed by kernel
+    /// `table_id`. A no-op when the tee is off; re-applied by `cradle_apply`.
+    pub fn set_cradle_vrf_mpls_pipe(&self, table_id: u32, pipe: Option<bool>) {
+        if let Some(cradle) = &self.cradle {
+            cradle.set_vrf_mpls_pipe(table_id, pipe);
+        }
+    }
+
     /// Replay the tee's entire mirrored state into a freshly-(re)started
     /// cradle engine (see `CradleFib::replay`). Triggered by the
     /// `system ebpf` supervisor's `Message::CradleEngineUp`; a no-op when

--- a/zebra-rs/src/rib/inst.rs
+++ b/zebra-rs/src/rib/inst.rs
@@ -298,6 +298,12 @@ pub enum Message {
         name: String,
         router_id: Option<Ipv4Addr>,
     },
+    /// Per-VRF RFC 3443 MPLS TTL model (`vrf <name> mpls ttl propagate`).
+    /// `None` = inherit the global model. Emitted after `VrfAdd`.
+    VrfMplsTtl {
+        name: String,
+        model: Option<TtlModel>,
+    },
     /// Bind / unbind an interface to a VRF master device.
     /// `vrf == Some(name)` enslaves; `vrf == None` clears the binding
     /// (sets IFLA_MASTER = 0). The handler tolerates the interface or
@@ -723,7 +729,7 @@ pub enum NeighborKey {
 /// LSP hop count end to end. Only the cradle eBPF data plane honors it today
 /// (via `Nexthop.mpls_pipe_ttl` / `Ilm.ttl_uniform`); the kernel FIB ignores
 /// it. Keep the `#[default]` in sync with the YANG `default "pipe"`.
-#[derive(Debug, Default, PartialEq, Clone, Copy)]
+#[derive(Debug, Default, PartialEq, Eq, Clone, Copy)]
 pub enum TtlModel {
     #[default]
     Pipe,
@@ -2777,6 +2783,9 @@ impl Rib {
                         // the row exists.
                         router_id: Ipv4Addr::UNSPECIFIED,
                         router_id_config: None,
+                        // Per-VRF MPLS TTL model arrives separately via
+                        // `Message::VrfMplsTtl`; `None` inherits the global.
+                        mpls_ttl_propagate: None,
                         owned,
                         // RT sets arrive separately via
                         // `Message::VrfRouteTargets` once the VRF
@@ -2991,6 +3000,27 @@ impl Rib {
                         vrf = %name,
                         "rib: VrfRouterId for unknown VRF; dropping",
                     );
+                }
+            }
+            Message::VrfMplsTtl { name, model } => {
+                // Same VrfAdd-first ordering contract as `VrfRouterId`.
+                let table_id = if let Some(vrf) = self.vrfs.get_mut(&name) {
+                    vrf.mpls_ttl_propagate = model;
+                    Some(vrf.table_id)
+                } else {
+                    tracing::debug!(
+                        vrf = %name,
+                        "rib: VrfMplsTtl for unknown VRF; dropping",
+                    );
+                    None
+                };
+                // Push the effective per-VRF model into the cradle tee (keyed
+                // by table id). `None` clears the override so the tee falls
+                // back to the global model.
+                #[cfg(target_os = "linux")]
+                if let Some(table_id) = table_id {
+                    self.fib_handle
+                        .set_cradle_vrf_mpls_pipe(table_id, model.map(|m| m.is_pipe()));
                 }
             }
             Message::LinkVrfBind { ifname, vrf } => {
@@ -4034,6 +4064,13 @@ impl Rib {
         // RFC 3443 model so `set mpls ttl propagate` survives tee (re)creation.
         self.fib_handle
             .set_cradle_mpls_pipe(self.mpls_ttl_propagate.is_pipe());
+        // Re-apply every per-VRF override too — the fresh tee's map is empty.
+        for vrf in self.vrfs.values() {
+            if let Some(model) = vrf.mpls_ttl_propagate {
+                self.fib_handle
+                    .set_cradle_vrf_mpls_pipe(vrf.table_id, Some(model.is_pipe()));
+            }
+        }
         // Enable-after-routes: a freshly-created tee has an empty mirror,
         // so routes installed BEFORE this enable would never reach the
         // engine until they churn. Queue a resync (mirror replay + RIB

--- a/zebra-rs/src/rib/vrf/builder.rs
+++ b/zebra-rs/src/rib/vrf/builder.rs
@@ -62,6 +62,7 @@ impl VrfBuilder {
                 let mup_import_rts = config.mup_import_rts.clone();
                 let mup_export_rts = config.mup_export_rts.clone();
                 let router_id = config.router_id;
+                let mpls_ttl_propagate = config.mpls_ttl_propagate;
                 self.config.insert(name.clone(), config);
                 let _ = tx.send(Message::VrfAdd { name: name.clone() });
                 let _ = tx.send(Message::VrfRouteTargets {
@@ -76,7 +77,16 @@ impl VrfBuilder {
                 // Router-id snapshot follows the same VrfAdd-first
                 // ordering contract as the RT message; `None` (leaf
                 // absent or deleted this commit) clears the override.
-                let _ = tx.send(Message::VrfRouterId { name, router_id });
+                let _ = tx.send(Message::VrfRouterId {
+                    name: name.clone(),
+                    router_id,
+                });
+                // Per-VRF MPLS TTL model, same VrfAdd-first ordering; `None`
+                // inherits the global model.
+                let _ = tx.send(Message::VrfMplsTtl {
+                    name,
+                    model: mpls_ttl_propagate,
+                });
             }
         }
     }
@@ -133,6 +143,7 @@ impl ConfigBuilder {
         const RT_PARSE_ERR: &str =
             "route-target must parse as ASN:value, IPv4:value, or 4byteASN:value";
         const ROUTER_ID_ERR: &str = "missing or invalid router-id argument";
+        const MPLS_TTL_ERR: &str = "mpls ttl propagate must be inherit, pipe, or uniform";
 
         ConfigBuilder::default()
             .path("")
@@ -165,6 +176,27 @@ impl ConfigBuilder {
                 cache_get(config, cache, name)
                     .context(CONFIG_ERR)?
                     .router_id = None;
+                Ok(())
+            })
+            // /vrf/<name>/mpls-ttl-propagate — per-VRF RFC 3443 model.
+            // `inherit` (and delete) clear the override, falling back to the
+            // global `mpls ttl propagate`.
+            .path("/mpls-ttl-propagate")
+            .set(|config, cache, name, args| {
+                let raw = args.string().context(MPLS_TTL_ERR)?;
+                let model = match raw.as_str() {
+                    "inherit" => None,
+                    s => Some(crate::rib::inst::TtlModel::from_yang(s).context(MPLS_TTL_ERR)?),
+                };
+                cache_get(config, cache, name)
+                    .context(CONFIG_ERR)?
+                    .mpls_ttl_propagate = model;
+                Ok(())
+            })
+            .del(|config, cache, name, _args| {
+                cache_get(config, cache, name)
+                    .context(CONFIG_ERR)?
+                    .mpls_ttl_propagate = None;
                 Ok(())
             })
             // /vrf/<name>/ipv4/route-target/import — leaf-list, one
@@ -401,7 +433,16 @@ mod tests {
         };
         assert_eq!(name, "v1");
         assert_eq!(router_id, None);
-        assert!(rx.try_recv().is_err(), "no fourth message expected");
+
+        // The per-VRF MPLS TTL snapshot trails router-id — `None` (inherit)
+        // here because the operator never set `vrf v1 mpls ttl propagate`.
+        let fourth = rx.try_recv().expect("VrfMplsTtl present");
+        let Message::VrfMplsTtl { name, model } = fourth else {
+            panic!("fourth message is not VrfMplsTtl");
+        };
+        assert_eq!(name, "v1");
+        assert_eq!(model, None);
+        assert!(rx.try_recv().is_err(), "no fifth message expected");
     }
 
     #[test]
@@ -449,6 +490,80 @@ mod tests {
             }
         }
         assert_eq!(router_ids, vec![None]);
+    }
+
+    #[test]
+    fn commit_carries_configured_mpls_ttl_and_inherit_clears_it() {
+        use crate::rib::inst::TtlModel;
+        let drain_model = |rx: &mut mpsc::UnboundedReceiver<Message>| {
+            let mut models = Vec::new();
+            while let Ok(msg) = rx.try_recv() {
+                if let Message::VrfMplsTtl { name, model } = msg {
+                    assert_eq!(name, "v1");
+                    models.push(model);
+                }
+            }
+            models
+        };
+
+        // set vrf v1 mpls ttl propagate uniform
+        let mut builder = VrfBuilder::new();
+        builder
+            .exec("/vrf".into(), args(&["v1"]), ConfigOp::Set)
+            .expect("create vrf");
+        builder
+            .exec(
+                "/vrf/mpls-ttl-propagate".into(),
+                args(&["v1", "uniform"]),
+                ConfigOp::Set,
+            )
+            .expect("set mpls ttl propagate");
+        let (tx, mut rx) = mpsc::unbounded_channel();
+        builder.commit(tx);
+        assert_eq!(drain_model(&mut rx), vec![Some(TtlModel::Uniform)]);
+
+        // Overwrite with pipe.
+        builder
+            .exec(
+                "/vrf/mpls-ttl-propagate".into(),
+                args(&["v1", "pipe"]),
+                ConfigOp::Set,
+            )
+            .expect("set pipe");
+        let (tx, mut rx) = mpsc::unbounded_channel();
+        builder.commit(tx);
+        assert_eq!(drain_model(&mut rx), vec![Some(TtlModel::Pipe)]);
+
+        // `inherit` clears the override back to None (use the global model).
+        builder
+            .exec(
+                "/vrf/mpls-ttl-propagate".into(),
+                args(&["v1", "inherit"]),
+                ConfigOp::Set,
+            )
+            .expect("set inherit");
+        let (tx, mut rx) = mpsc::unbounded_channel();
+        builder.commit(tx);
+        assert_eq!(drain_model(&mut rx), vec![None]);
+    }
+
+    #[test]
+    fn invalid_mpls_ttl_value_returns_an_error() {
+        let mut builder = VrfBuilder::new();
+        builder
+            .exec("/vrf".into(), args(&["v1"]), ConfigOp::Set)
+            .expect("create vrf");
+        let err = builder
+            .exec(
+                "/vrf/mpls-ttl-propagate".into(),
+                args(&["v1", "bogus"]),
+                ConfigOp::Set,
+            )
+            .expect_err("garbage TTL model must be rejected");
+        assert!(
+            err.to_string().contains("mpls ttl propagate"),
+            "expected TTL-specific error, got: {err}",
+        );
     }
 
     #[test]

--- a/zebra-rs/src/rib/vrf/config.rs
+++ b/zebra-rs/src/rib/vrf/config.rs
@@ -19,6 +19,10 @@ pub struct VrfConfig {
     /// `None` lets the RIB derive one from the VRF's member
     /// interfaces (falling back to the global effective value).
     pub router_id: Option<std::net::Ipv4Addr>,
+    /// Per-VRF RFC 3443 MPLS TTL model — `set vrf X mpls ttl propagate
+    /// {pipe|uniform}`. `None` = inherit the global `mpls ttl propagate`
+    /// (the YANG `inherit` value and leaf-absent both map here).
+    pub mpls_ttl_propagate: Option<crate::rib::inst::TtlModel>,
     /// IPv4-unicast RT import set —
     /// `set vrf X ipv4 route-target import …`.
     pub ipv4_import_rts: std::collections::BTreeSet<bgp_packet::RouteDistinguisher>,

--- a/zebra-rs/src/rib/vrf/inst.rs
+++ b/zebra-rs/src/rib/vrf/inst.rs
@@ -32,6 +32,11 @@ pub struct Vrf {
     /// `Message::VrfRouterId`. Wins over the derived values; `None`
     /// falls back.
     pub router_id_config: Option<std::net::Ipv4Addr>,
+    /// Per-VRF RFC 3443 MPLS TTL model (`vrf <name> mpls ttl propagate`),
+    /// delivered via [`Message::VrfMplsTtl`]. `None` = inherit the global
+    /// `mpls ttl propagate`. Teed to cradle so this VRF's LSP imposition and
+    /// pop-to-IP disposition use it.
+    pub mpls_ttl_propagate: Option<crate::rib::inst::TtlModel>,
     /// `true` when this process created the kernel VRF master device,
     /// `false` when it adopted a pre-existing one (operator-created, or
     /// a leftover from a prior run). The shutdown path only deletes the

--- a/zebra-rs/yang/config.yang
+++ b/zebra-rs/yang/config.yang
@@ -4380,6 +4380,23 @@ module config {
            RouterIdUpdate, like the global `system router-id`.";
         type inet:ipv4-address;
       }
+      leaf mpls-ttl-propagate {
+        ext:help "Per-VRF MPLS TTL model (overrides the global mpls ttl propagate)";
+        description
+          "Per-VRF RFC 3443 MPLS label-TTL model for this VRF's L3VPN
+           LSPs (imposition of the VPN label and pop-to-IP disposition).
+           `inherit` (default) uses the global `mpls ttl propagate`;
+           `pipe` hides the LSP; `uniform` exposes the hop count. Honored
+           by the cradle eBPF data plane; the kernel FIB is unaffected.
+           Configure the same model on the ingress and egress PEs of a
+           VRF, since the two ends of an LSP must agree.";
+        type enumeration {
+          enum inherit;
+          enum pipe;
+          enum uniform;
+        }
+        default "inherit";
+      }
       container ipv4 {
         ext:help "IPv4 unicast (VPNv4) route policy";
         description


### PR DESCRIPTION
## Summary

Adds `vrf <name> mpls ttl propagate {inherit|pipe|uniform}` — a **per-VRF override** of the global `mpls ttl propagate` (RFC 3443), the last follow-up from the [MPLS TTL-propagation design](https://github.com/cradle-rs/cradle-rs/blob/main/docs/design/mpls-ttl-propagation.md). So e.g. the global table can run `uniform` (expose hops) while each L3VPN VRF runs `pipe` (hide the core), or vice versa.

### Why both ends
The model is applied at **both** ends of a VRF's LSPs, and they must agree: under `uniform` the delivered TTL *is* the popped label TTL, which depends on the imposition seed — a `pipe` seed (255) under a `uniform` pop would write ~253 into the inner header. So the override drives imposition (`Nexthop.mpls_pipe_ttl`) and disposition (`Ilm.ttl_uniform`) together. Configure the same model on the ingress and egress PEs of a VRF (like RD/RT consistency).

### Changes
- **`fib/cradle.rs`** — `CradleFib` gains a per-table override map (`table_id → pipe`) beside the global atomic; `effective_pipe(table_id)` resolves override-else-global. Resolved once at the two tee entry points that already carry `table_id` (`route_install`, `ilm_install`) and threaded as a `pipe: bool` through `member_nexthop_id` / `leaf_nexthop_id` / `nexthop_id{,6}`. The bool joins the nexthop **dedup key** so two VRFs with different models never alias the same imposition nexthop.
- **`fib/netlink/handle.rs`** — `set_cradle_vrf_mpls_pipe(table_id, Option<bool>)`.
- **`rib`** — `Vrf` / `VrfConfig` gain `mpls_ttl_propagate: Option<TtlModel>`; a `/vrf/<name>/mpls-ttl-propagate` builder handler + `Message::VrfMplsTtl` (VrfAdd-first ordering, mirroring `VrfRouterId`) push the override into the tee, re-applied in `cradle_apply` after any tee (re)creation.
- **`config.yang`** — `leaf mpls-ttl-propagate { inherit | pipe | uniform }` under `list vrf`, default `inherit`.

The **cradle datapath needs no change** — it already reads the per-entry `mpls_pipe_ttl` / `ttl_uniform` flags; the producer just stamps per-VRF values.

## Test plan
- `cargo build -p zebra-rs` ✓
- `cargo fmt --all -- --check` ✓
- `cargo clippy --workspace --all-targets -- -D warnings` ✓ and `--features lua` ✓
- `cargo test --workspace --exclude bdd` ✓ — incl. new `vrf::builder` tests: `commit_carries_configured_mpls_ttl_and_inherit_clears_it` (pipe/uniform/inherit round-trip) and `invalid_mpls_ttl_value_returns_an_error`; the existing message-count test was extended for the new `VrfMplsTtl`.
- **YANG**: a live `zebra-rs` daemon loads the full tree with the new `vrf mpls-ttl-propagate` leaf (no libyang parse error).

Generated with [Claude Code](https://claude.com/claude-code)