### PR TITLE
bgp: color steering to a Binding SID reaches the data plane

### DIFF
--- a/zebra-rs/src/bgp/inst.rs
+++ b/zebra-rs/src/bgp/inst.rs
@@ -4090,13 +4090,19 @@ impl Bgp {
             // SR Policy: the endpoint's transport rerouted; re-install
             // the Binding-SID ILM toward the fresh next-hop.
             NhtDep::SrPolicy { color, endpoint } => {
-                super::route::sr_policy_reconcile_mpls(
+                let activated = super::route::sr_policy_reconcile_mpls(
                     &self.ctx.rib,
                     &self.nexthop_cache,
                     &mut self.local_rib.sr_policy,
                     color,
                     endpoint,
                 );
+                // BSID activation edge: re-install colour-matched service
+                // routes so they steer onto the now-installed BSID.
+                if activated {
+                    let top = self.nht_install_top();
+                    super::route::sr_policy_steer_resync(&top, color);
+                }
             }
             // MUP: a received segment route (DSD/ISD) next-hop rerouted →
             // re-dispatch it to importing VRFs with the fresh transport so
@@ -4523,7 +4529,7 @@ impl Bgp {
             // SR Policy reachability flip: (re)install or tear down the
             // Binding-SID ILM via the endpoint's NHT resolution.
             NhtDep::SrPolicy { color, endpoint } => {
-                super::route::sr_policy_reconcile_mpls(
+                let activated = super::route::sr_policy_reconcile_mpls(
                     top.rib_client,
                     top.nexthop_cache
                         .as_deref()
@@ -4532,6 +4538,11 @@ impl Bgp {
                     *color,
                     *endpoint,
                 );
+                // BSID activation edge: re-install colour-matched service
+                // routes so they steer onto the now-installed BSID.
+                if activated {
+                    super::route::sr_policy_steer_resync(&top, *color);
+                }
             }
             // MUP reachability flip: (re)dispatch the received DSD to
             // importing VRFs with its resolved transport (empty when

--- a/zebra-rs/src/bgp/route.rs
+++ b/zebra-rs/src/bgp/route.rs
@@ -9220,14 +9220,20 @@ fn sr_policy_mpls_sync(bgp: &mut BgpTop, color: u32, endpoint: IpAddr) {
         }
     }
 
+    let mut activated = false;
     if let Some(cache) = bgp.nexthop_cache.as_deref() {
-        sr_policy_reconcile_mpls(
+        activated = sr_policy_reconcile_mpls(
             bgp.rib_client,
             cache,
             &mut bgp.local_rib.sr_policy,
             color,
             endpoint,
         );
+    }
+    // The BSID just came up: re-install any colour-matched service route
+    // received before this policy so it steers onto the fresh BSID.
+    if activated {
+        sr_policy_steer_resync(bgp, color);
     }
 
     if !wants
@@ -9245,13 +9251,19 @@ fn sr_policy_mpls_sync(bgp: &mut BgpTop, color: u32, endpoint: IpAddr) {
 /// the active path and the endpoint's NHT resolution. Callable from the
 /// receive path and from the NHT re-eval in `inst.rs`, so it takes the
 /// RIB client + cache directly rather than a `BgpTop`.
+///
+/// Returns `true` on the activation edge (the Binding-SID label just
+/// appeared or swapped to a different value) so the caller can re-install
+/// colour-matched service routes onto the now-active BSID via
+/// [`sr_policy_steer_resync`]. A service route received before its SAFI-73
+/// policy would otherwise sit unsteered until an unrelated re-eval.
 pub(super) fn sr_policy_reconcile_mpls(
     rib_client: &crate::rib::client::RibClient,
     cache: &super::nht::NexthopCache,
     db: &mut super::sr_policy::SrPolicyDb,
     color: u32,
     endpoint: IpAddr,
-) {
+) -> bool {
     let reachable = !cache.transport_for(endpoint).is_empty();
     let action = db.mpls_reconcile(color, endpoint, reachable);
     if let Some(label) = action.remove {
@@ -9264,6 +9276,41 @@ pub(super) fn sr_policy_reconcile_mpls(
             &install.segments,
             cache.transport_for(endpoint),
         );
+    }
+    action.activated
+}
+
+/// Re-install every unicast Loc-RIB winner carrying `color` so a service
+/// route re-derives its SR-Policy steer now that the colour's Binding-SID
+/// ILM is installed (`steer_mpls_bsid` / `steer_srv6_bsid` only match an
+/// installed BSID). Install-only, mirroring `table_map_resync`: best-path
+/// selection and advertised attributes are untouched, so nothing is
+/// re-advertised. Colour-filtered — a strict subset of `table_map_resync`'s
+/// all-winners sweep — so it never re-installs uncoloured routes. Snapshot
+/// the winners first; `fib_install_v4/v6` borrows `bgp` immutably.
+pub(super) fn sr_policy_steer_resync(bgp: &super::peer::BgpTop, color: u32) {
+    let colored = |best: &BgpRib| best.attr.colors().any(|c| c.color == color);
+    let v4: Vec<(ipnet::Ipv4Net, BgpRib)> = bgp
+        .shard
+        .v4
+        .1
+        .iter()
+        .filter(|&(_, best)| colored(best))
+        .map(|(p, best)| (p, best.clone()))
+        .collect();
+    let v6: Vec<(ipnet::Ipv6Net, BgpRib)> = bgp
+        .shard
+        .v6
+        .1
+        .iter()
+        .filter(|&(_, best)| colored(best))
+        .map(|(p, best)| (p, best.clone()))
+        .collect();
+    for (prefix, best) in &v4 {
+        fib_install_v4(bgp, *prefix, std::slice::from_ref(best));
+    }
+    for (prefix, best) in &v6 {
+        fib_install_v6(bgp, *prefix, std::slice::from_ref(best));
     }
 }
 

--- a/zebra-rs/src/bgp/route.rs
+++ b/zebra-rs/src/bgp/route.rs
@@ -823,6 +823,21 @@ pub(super) fn fib_install_v4(bgp: &super::peer::BgpTop, prefix: Ipv4Net, selecte
                     uni.segs = vec![sid];
                     uni.encap_type = Some(isis_packet::srv6::EncapType::HEncap);
                 }
+                // The FIB install — both the kernel nexthop group
+                // (`GroupUni::new`) and the cradle tee (`cradle_members`) —
+                // reads `mpls_label`, not `mpls`, but the MPLS steer branches
+                // above push only into `mpls`. Re-derive `mpls_label` so a
+                // steered label reaches the data plane, not just `show`
+                // (mirrors the L3VPN path through `NexthopUni::new`). The SRv6
+                // steer branches leave `mpls` empty, so this is a no-op there.
+                uni.mpls_label = uni
+                    .mpls
+                    .iter()
+                    .filter_map(|label| match label {
+                        rib::Label::Explicit(v) => Some(*v),
+                        rib::Label::Implicit(_) => None,
+                    })
+                    .collect();
             }
             // SRv6 service-route steering: prepend the algo-N End SID
             // before an existing End.DT4 service SID. Mutually exclusive

--- a/zebra-rs/src/bgp/route.rs
+++ b/zebra-rs/src/bgp/route.rs
@@ -8795,7 +8795,7 @@ pub fn route_srpolicy_update(
         endpoint: nlri.endpoint,
     };
     let delta = bgp.local_rib.sr_policy.insert(key, cp);
-    apply_srpolicy_fib(delta, bgp);
+    apply_srpolicy_fib(delta, nlri.color, bgp);
     sr_policy_mpls_sync(bgp, nlri.color, nlri.endpoint);
 }
 
@@ -8819,7 +8819,7 @@ pub fn route_srpolicy_withdraw(
     if removed {
         srpolicy_reflect_withdraw(ident, nlri, peers);
     }
-    apply_srpolicy_fib(delta, bgp);
+    apply_srpolicy_fib(delta, nlri.color, bgp);
     sr_policy_mpls_sync(bgp, nlri.color, nlri.endpoint);
 }
 
@@ -9046,10 +9046,11 @@ pub fn route_bgpls_withdraw_originated(nlri: &BgpLsNlri, local_rib: &mut LocalRi
 /// segment list, plus tear down an SR-MPLS Binding-SID ILM when a whole
 /// policy is withdrawn. (The live SR-MPLS install/update is driven by
 /// `sr_policy_mpls_sync` / `sr_policy_reconcile_mpls`, gated on NHT.)
-fn apply_srpolicy_fib(delta: super::sr_policy::SrPolicyFibDelta, bgp: &mut BgpTop) {
+fn apply_srpolicy_fib(delta: super::sr_policy::SrPolicyFibDelta, color: u32, bgp: &mut BgpTop) {
     if let Some(addr) = delta.remove {
         let _ = bgp.rib_client.send(rib::Message::SidDel { addr });
     }
+    let activated = delta.activated;
     if let Some(install) = delta.install {
         let sid = rib::Sid {
             addr: install.bsid,
@@ -9069,6 +9070,13 @@ fn apply_srpolicy_fib(delta: super::sr_policy::SrPolicyFibDelta, bgp: &mut BgpTo
     }
     if let Some(label) = delta.mpls_remove {
         srpolicy_ilm_remove(bgp.rib_client, label);
+    }
+    // The End.B6 BSID just came up: re-install any colour-matched service
+    // route received before this policy so it re-derives its H.Encap steer
+    // onto the fresh BSID (the SRv6 twin of `sr_policy_reconcile_mpls`'s
+    // activation-edge resync).
+    if activated {
+        sr_policy_steer_resync(bgp, color);
     }
 }
 

--- a/zebra-rs/src/bgp/sr_policy.rs
+++ b/zebra-rs/src/bgp/sr_policy.rs
@@ -124,6 +124,9 @@ impl SrPolicy {
             (prev, new) => {
                 delta.remove = prev.as_ref().map(|b| b.bsid);
                 delta.install = new.clone();
+                // A fresh or changed BSID address is the steer-activation
+                // edge; a teardown (new is None) is not.
+                delta.activated = new.is_some();
             }
         }
         self.installed = desired;
@@ -149,6 +152,14 @@ pub struct SrPolicyFibDelta {
     pub remove: Option<Ipv6Addr>,
     pub install: Option<Srv6Bsid>,
     pub mpls_remove: Option<u32>,
+    /// The SRv6 Binding-SID *address* just appeared or changed, so a
+    /// colour-matched service route received before the policy must
+    /// re-derive its H.Encap steer onto it. Unlike the SR-MPLS ILM (see
+    /// [`MplsIlmAction::activated`]) the End.B6 SID installs immediately,
+    /// but the same route-before-policy gap applies. A same-address install
+    /// (only the segment list changed) leaves this `false` — the steer
+    /// target is unchanged.
+    pub activated: bool,
 }
 
 /// An SR-MPLS Binding SID install: the incoming BSID label and the
@@ -317,6 +328,7 @@ impl SrPolicyDb {
                     remove,
                     install: None,
                     mpls_remove,
+                    activated: false,
                 },
             )
         } else {

--- a/zebra-rs/src/bgp/sr_policy.rs
+++ b/zebra-rs/src/bgp/sr_policy.rs
@@ -202,6 +202,12 @@ fn mpls_bsid(cp: &CandidatePath) -> Option<MplsBsid> {
 pub struct MplsIlmAction {
     pub remove: Option<u32>,
     pub install: Option<MplsBsid>,
+    /// The steering label just appeared or changed (`None`→`Some`, or a
+    /// candidate-path swap to a different BSID). Level-triggered install
+    /// alone can't tell a fresh activation from a steady-state re-eval, so
+    /// the caller re-installs colour-matched service routes only on this
+    /// edge — a route received before the policy re-derives its steer.
+    pub activated: bool,
 }
 
 /// The SRv6 Binding-SID install an active candidate path realizes, or
@@ -452,16 +458,19 @@ impl SrPolicyDb {
             Some(bsid) if reachable => {
                 // Replace whenever reachable (the resolved next-hop or the
                 // label stack may have changed); drop a stale label first.
-                let remove = policy.installed_mpls.filter(|old| *old != bsid.bsid);
+                let prev = policy.installed_mpls;
+                let remove = prev.filter(|old| *old != bsid.bsid);
                 policy.installed_mpls = Some(bsid.bsid);
                 MplsIlmAction {
                     remove,
+                    activated: prev != Some(bsid.bsid),
                     install: Some(bsid),
                 }
             }
             _ => MplsIlmAction {
                 remove: policy.installed_mpls.take(),
                 install: None,
+                activated: false,
             },
         }
     }


### PR DESCRIPTION
Fixes so RFC 9256 §8.5 BGP color steering onto an SR-Policy Binding SID
actually programs the forwarding plane (kernel nexthop group and the cradle
eBPF FIB tee), not just `show`. Covers both the SR-MPLS and SRv6 Binding SID.

## 1. The steered label reaches the FIB, not just `show`
The MPLS steer branches pushed the BSID only into `NexthopUni.mpls` (the
display field), while both the kernel nexthop group (`GroupUni::new`) and
the cradle tee (`cradle_members`) read the raw `mpls_label` stack — a
steered route displayed the label but forwarded plain. Re-derive
`mpls_label` from `mpls` on the FIB install path (mirroring the L3VPN path
through `NexthopUni::new`); a no-op for the SRv6 steer branches.

## 2. Re-steer colour-matched routes when the BSID activates
A colored service route received *before* its SR-Policy SAFI-73 update
installs plain — the steer helpers only match an already-installed Binding
SID. When the policy later arrives, nothing re-visited the already-selected
route, so it stayed unsteered.

- **SR-MPLS** (NHT-gated ILM): `mpls_reconcile` reports the activation edge
  (`MplsIlmAction::activated`); `sr_policy_reconcile_mpls`'s three callers
  run `sr_policy_steer_resync` on that edge.
- **SRv6** (immediate End.B6 install): `reconcile_fib` reports the edge
  (`SrPolicyFibDelta::activated` — fresh/changed BSID address);
  `apply_srpolicy_fib` runs the same resync.

`sr_policy_steer_resync` is an install-only, colour-filtered winner sweep
(a strict subset of `table_map_resync`) — no re-advertise, no uncoloured
routes touched.

## Test plan
- `cargo build`/`clippy -p zebra-rs` — clean; `cargo test -p zebra-rs bgp::`
  — 613 passed, 0 failed.
- End to end, two cradle datapath BDDs (route arrives before its policy):
  - `cradle_color_bsid_zebra` — SR-MPLS BSID 16100 reaches cradle's eBPF FIB
    (nexthop `[16100]`, LFIB `16100 swap [16002]`).
  - `cradle_color_bsid_srv6_zebra` — SRv6 End.B6 BSID: the steered route
    H.Encaps toward `fd00:b::b6` (`segs=[fd00:b::b6]`, `localsid fd00:b::b6
    End.B6.Encaps`).
  Each passes only with these fixes; removing the resync makes the datapath
  assertion fail (route stays plain after the BSID activates).

Generated with [Claude Code](https://claude.com/claude-code)