### PR TITLE
config: report source line numbers for schema-rejected config files

### DIFF
--- a/zebra-rs/Cargo.toml
+++ b/zebra-rs/Cargo.toml
@@ -43,6 +43,7 @@ syslog = "7"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = { version = "1.0", features = ["preserve_order"] }
 serde_yaml = "0.9"
+marked-yaml = "0.7"
 ciborium = "0.2"
 clap = { version = "4", features = ["derive"] }
 alphanumeric-sort = "1.5.3"

--- a/zebra-rs/src/config/configs.rs
+++ b/zebra-rs/src/config/configs.rs
@@ -406,8 +406,8 @@ impl Config {
             // emitted only a dangling `"name":` so far. A presence
             // container closes as `{}` (it is a container in the YANG
             // data tree); a `type empty` leaf closes as null. Both
-            // shapes round-trip: json_to_list() restores each as the
-            // bare `set <path>`.
+            // shapes round-trip: the config-document walk restores each
+            // as the bare `set <path>`.
             if !has_configs && self.value.borrow().is_empty() && self.list.borrow().is_empty() {
                 if self.presence {
                     out.push_str("{}");
@@ -1488,8 +1488,9 @@ mod tests {
     fn test_presence_container_json_empty_object() {
         // A childless presence container (e.g. `set router bgp
         // segment-routing srv6 ipv6-unicast`) marshals as `{}`, not
-        // null — null is reserved for `type empty` leaves. json_to_list()
-        // restores an empty object as the bare `set <path>` on re-apply.
+        // null — null is reserved for `type empty` leaves. The
+        // config-document walk restores an empty object as the bare
+        // `set <path>` on re-apply.
         let root = Rc::new(Config::new("".to_string(), None));
 
         let paths = vec![

--- a/zebra-rs/src/config/json.rs
+++ b/zebra-rs/src/config/json.rs
@@ -1,10 +1,105 @@
 use libyang::Entry;
 use serde_json::Value;
+use std::fmt;
 use std::rc::Rc;
 
-/// Translate a JSON (or YAML-converted-to-JSON) config document into
-/// flat `set …` command lines by walking it against the YANG `set`
-/// subtree.
+/// A single schema-rejection error found while walking a config
+/// document, carrying the 1-based source line it was found on when the
+/// front-end could preserve it (YAML does, JSON does not).
+#[derive(Debug, Clone)]
+pub struct DocError {
+    pub line: Option<usize>,
+    pub message: String,
+}
+
+impl DocError {
+    pub fn new(line: Option<usize>, message: String) -> Self {
+        Self { line, message }
+    }
+}
+
+impl fmt::Display for DocError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self.line {
+            Some(line) => write!(f, "line {}: {}", line, self.message),
+            None => write!(f, "{}", self.message),
+        }
+    }
+}
+
+/// A config-document value with source line information preserved.
+///
+/// Both the JSON and YAML front-ends lower into this so a single walk
+/// ([`spanned_to_list`]) turns any document into flat `set …` command
+/// lines and reports the parts the schema refuses. The YAML front-end
+/// additionally attaches the source line of each key so an error can
+/// point the operator at the exact line in their config file; the JSON
+/// front-end leaves every line `None`.
+pub enum SpannedValue {
+    /// YAML `null`/`~`/empty, or JSON `null`: a bare `set <path>` line
+    /// (the empty-leaf / `type empty` convention).
+    Null,
+    /// A scalar leaf value (string, number, or bool — all stringified).
+    Scalar(String),
+    /// A YANG list body: a sequence of entries walked against the same
+    /// schema node.
+    Sequence(Vec<SpannedValue>),
+    /// A container or list entry. `line` is the mapping's own source
+    /// line (used to locate a "missing key" error); each entry carries
+    /// the source line of its own key.
+    Mapping {
+        line: Option<usize>,
+        entries: Vec<MapEntry>,
+    },
+}
+
+/// One `key: value` pair of a [`SpannedValue::Mapping`], with the source
+/// line of the key.
+pub struct MapEntry {
+    pub key: String,
+    pub line: Option<usize>,
+    pub value: SpannedValue,
+}
+
+impl SpannedValue {
+    /// The value used when this node is a list entry's key field. List
+    /// keys are always scalars in practice; the other shapes are
+    /// defensive fallbacks matching the pre-`SpannedValue` behavior.
+    fn key_value(&self) -> String {
+        match self {
+            SpannedValue::Scalar(s) => s.clone(),
+            SpannedValue::Null => "null".to_string(),
+            _ => String::new(),
+        }
+    }
+}
+
+/// Lower a `serde_json` value into a [`SpannedValue`]. JSON carries no
+/// source markers, so every line is `None`. The `preserve_order`
+/// feature keeps the object key order, matching document order.
+fn from_json(v: &Value) -> SpannedValue {
+    match v {
+        Value::Null => SpannedValue::Null,
+        Value::Bool(b) => SpannedValue::Scalar(b.to_string()),
+        Value::Number(n) => SpannedValue::Scalar(n.to_string()),
+        Value::String(s) => SpannedValue::Scalar(s.clone()),
+        Value::Array(vec) => SpannedValue::Sequence(vec.iter().map(from_json).collect()),
+        Value::Object(map) => SpannedValue::Mapping {
+            line: None,
+            entries: map
+                .iter()
+                .map(|(k, v)| MapEntry {
+                    key: k.clone(),
+                    line: None,
+                    value: from_json(v),
+                })
+                .collect(),
+        },
+    }
+}
+
+/// Translate a JSON config document into flat `set …` command lines by
+/// walking it against the YANG `set` subtree.
 ///
 /// Returns the command lines plus a list of errors for every part of
 /// the document that does NOT correspond to the schema. Errors must
@@ -13,90 +108,94 @@ use std::rc::Rc;
 /// which let a misspelled key (e.g. `med-eq:` for the nested
 /// `med: { eq: … }`) produce a partial config that *applied* cleanly
 /// while testing nothing.
-pub fn json_read(e: Rc<Entry>, str: &str) -> (Vec<String>, Vec<String>) {
+pub fn json_read(e: Rc<Entry>, str: &str) -> (Vec<String>, Vec<DocError>) {
     let mut lines: Vec<String> = Vec::new();
-    let mut errors: Vec<String> = Vec::new();
+    let mut errors: Vec<DocError> = Vec::new();
     match serde_json::from_str::<Value>(str) {
         Ok(json) => {
-            json_to_list(e, Vec::new(), &json, &mut lines, &mut errors);
+            spanned_to_list(e, Vec::new(), &from_json(&json), &mut lines, &mut errors);
         }
         Err(err) => {
-            errors.push(format!("invalid document: {err}"));
+            errors.push(DocError::new(None, format!("invalid document: {err}")));
         }
     }
     (lines, errors)
 }
 
-pub fn json_to_list(
+/// Walk a [`SpannedValue`] against the YANG `set` subtree, emitting flat
+/// `set …` command lines and recording a [`DocError`] (with the source
+/// line, when known) for every node the schema refuses.
+pub fn spanned_to_list(
     entry: Rc<Entry>,
     p: Vec<String>,
-    v: &Value,
+    v: &SpannedValue,
     lines: &mut Vec<String>,
-    errors: &mut Vec<String>,
+    errors: &mut Vec<DocError>,
 ) {
     match v {
-        Value::Null => {
+        SpannedValue::Null => {
             lines.push(format!("set {}", p.join(" ")));
         }
-        Value::Bool(v) => {
-            lines.push(format!("set {} {}", p.join(" "), v));
+        SpannedValue::Scalar(s) => {
+            lines.push(format!("set {} {}", p.join(" "), s));
         }
-        Value::Number(v) => {
-            lines.push(format!("set {} {}", p.join(" "), v));
-        }
-        Value::String(v) => {
-            lines.push(format!("set {} {}", p.join(" "), v));
-        }
-        Value::Array(vec) => {
+        SpannedValue::Sequence(vec) => {
             for v in vec.iter() {
                 let p = p.clone();
-                json_to_list(entry.clone(), p, v, lines, errors);
+                spanned_to_list(entry.clone(), p, v, lines, errors);
             }
         }
-        Value::Object(map) => {
+        SpannedValue::Mapping { line, entries } => {
             // A childless presence container marshals as `{}`; restore
             // it as the bare `set <path>` (a presence container exists
             // on its own, unlike a plain container which only exists
             // through its children — an empty `{}` there is a no-op).
-            if map.is_empty() && entry.presence {
+            if entries.is_empty() && entry.presence {
                 lines.push(format!("set {}", p.join(" ")));
                 return;
             }
             let mut p = p.clone();
             if !entry.key.is_empty() {
-                if let Some(value) = map.get(&entry.key[0]) {
-                    p.push(value_without_quotes(value));
+                if let Some(me) = entries.iter().find(|e| e.key == entry.key[0]) {
+                    p.push(me.value.key_value());
                     lines.push(format!("set {}", p.join(" ")));
                 } else {
                     // A list entry without its key field can't be
                     // addressed at all — report it instead of silently
                     // dropping the whole object.
-                    errors.push(format!(
-                        "{}: list entry is missing its key `{}`",
-                        display_path(&p, &entry.name),
-                        entry.key[0]
+                    errors.push(DocError::new(
+                        *line,
+                        format!(
+                            "{}: list entry is missing its key `{}`",
+                            display_path(&p, &entry.name),
+                            entry.key[0]
+                        ),
                     ));
                     return;
                 }
             }
-            for (key, value) in map.iter() {
-                if !entry.key.is_empty() && key == &entry.key[0] {
+            for me in entries.iter() {
+                if !entry.key.is_empty() && me.key == entry.key[0] {
                     continue;
                 }
-                match entry_dir(entry.clone(), key) {
-                    Some(entry) => {
+                match entry_dir(entry.clone(), &me.key) {
+                    Some(child) => {
                         let mut p = p.clone();
-                        p.push(key.clone());
-                        json_to_list(entry.clone(), p, value, lines, errors);
+                        p.push(me.key.clone());
+                        spanned_to_list(child, p, &me.value, lines, errors);
                     }
                     None => {
-                        // Unknown key: record it and KEEP walking the
-                        // remaining siblings — aborting here used to
-                        // drop everything after the first typo.
-                        errors.push(format!(
-                            "{}: unknown key `{}`",
-                            display_path(&p, &entry.name),
-                            key
+                        // Unknown key: record it (with its source line)
+                        // and KEEP walking the remaining siblings —
+                        // aborting here used to drop everything after
+                        // the first typo.
+                        errors.push(DocError::new(
+                            me.line,
+                            format!(
+                                "{}: unknown key `{}`",
+                                display_path(&p, &entry.name),
+                                me.key
+                            ),
                         ));
                     }
                 }
@@ -115,14 +214,7 @@ fn display_path(p: &[String], entry_name: &str) -> String {
     }
 }
 
-fn value_without_quotes(value: &Value) -> String {
-    match value {
-        Value::String(s) => s.clone(),
-        _ => value.to_string(),
-    }
-}
-
-fn entry_dir(entry: Rc<Entry>, name: &String) -> Option<Rc<Entry>> {
+fn entry_dir(entry: Rc<Entry>, name: &str) -> Option<Rc<Entry>> {
     for e in entry.dir.borrow().iter() {
         if e.name == *name {
             return Some(e.clone());
@@ -180,11 +272,15 @@ mod tests {
         let doc = r#"{"policy":[{"name":"IN-MED","entry":[{"number":10,"a-bogus":1,"action":"permit","match":{"med-eq":999}}]}]}"#;
         let (lines, errors) = json_read(set_entry(), doc);
         assert!(
-            errors.iter().any(|e| e.contains("unknown key `med-eq`")),
+            errors
+                .iter()
+                .any(|e| e.message.contains("unknown key `med-eq`")),
             "errors: {errors:?}"
         );
         assert!(
-            errors.iter().any(|e| e.contains("unknown key `a-bogus`")),
+            errors
+                .iter()
+                .any(|e| e.message.contains("unknown key `a-bogus`")),
             "errors: {errors:?}"
         );
         assert!(
@@ -239,8 +335,24 @@ mod tests {
         let doc = r#"{"policy":[{"entry":[{"number":10}]}]}"#;
         let (_lines, errors) = json_read(set_entry(), doc);
         assert!(
-            errors.iter().any(|e| e.contains("missing its key `name`")),
+            errors
+                .iter()
+                .any(|e| e.message.contains("missing its key `name`")),
             "errors: {errors:?}"
+        );
+    }
+
+    /// `DocError` renders its source line when known, and omits the
+    /// `line N:` prefix when unknown (the JSON path).
+    #[test]
+    fn doc_error_display_includes_line() {
+        assert_eq!(
+            DocError::new(Some(42), "unknown key `foo`".to_string()).to_string(),
+            "line 42: unknown key `foo`"
+        );
+        assert_eq!(
+            DocError::new(None, "unknown key `foo`".to_string()).to_string(),
+            "unknown key `foo`"
         );
     }
 }

--- a/zebra-rs/src/config/manager.rs
+++ b/zebra-rs/src/config/manager.rs
@@ -9,7 +9,7 @@ use super::configs::{carbon_copy, delete, set};
 use super::cradle::spawn_cradle;
 use super::files::load_config_file;
 use super::isis::{despawn_isis, spawn_isis};
-use super::json::json_read;
+use super::json::{DocError, json_read};
 use super::nd::spawn_nd;
 use super::ospf::{despawn_ospf, despawn_ospfv3, spawn_ospf, spawn_ospfv3};
 use super::parse::State;
@@ -19,7 +19,7 @@ use super::stamp::{despawn_stamp, spawn_stamp};
 use super::util::trim_first_line;
 use super::vrf_redirect_split;
 use super::vty::CommandPath;
-use super::yaml::yaml_parse;
+use super::yaml::yaml_read;
 use super::{ApplyCode, Completion, Config, ConfigRequest, DisplayRequest, ExecCode};
 
 use crate::context::Task;
@@ -27,7 +27,7 @@ use libyang::{Entry, YangStore, to_entry};
 use similar::TextDiff;
 use std::cell::RefCell;
 use std::collections::{HashMap, HashSet};
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::rc::Rc;
 use tokio::sync::mpsc::{self, Receiver, Sender, UnboundedSender};
 use tokio::sync::oneshot;
@@ -781,7 +781,10 @@ impl ConfigManager {
     /// permit-all). Reject the document instead, returning the offending
     /// keys as `Err`, so the operator sees exactly which keys the schema
     /// refused.
-    fn config_to_commands(&self, config: &str) -> Result<(ConfigFormat, Vec<String>), Vec<String>> {
+    fn config_to_commands(
+        &self,
+        config: &str,
+    ) -> Result<(ConfigFormat, Vec<String>), Vec<DocError>> {
         let mode = self.modes.get("configure").unwrap();
         let mut entry: Option<Rc<Entry>> = None;
         for e in mode.entry.dir.borrow().iter() {
@@ -795,10 +798,7 @@ impl ConfigManager {
         let (cmds, doc_errors) = match format_type {
             ConfigFormat::Cli => (load_config_file(config.to_string()), Vec::new()),
             ConfigFormat::Json => json_read(entry, config),
-            ConfigFormat::Yaml => {
-                let json = yaml_parse(config);
-                json_read(entry, json.as_str())
-            }
+            ConfigFormat::Yaml => yaml_read(entry, config),
             ConfigFormat::SetDelete => (
                 config
                     .lines()
@@ -817,12 +817,11 @@ impl ConfigManager {
     pub fn load_config(&self) {
         if let Ok(output) = std::fs::read_to_string(&self.config_path) {
             // An empty (or comment/whitespace-only) config file carries no
-            // commands. Skip the format parsers entirely: the YAML default
-            // would otherwise `yaml_parse("")` → `null` → a bogus bare
-            // `set` line. (Done here, not in `config_to_commands`, so the
-            // `vtyctl apply` path keeps its existing empty-document
-            // behavior — an empty apply must not clear+commit the running
-            // config.)
+            // commands. Skip the format parsers entirely so the YAML
+            // default doesn't parse `""` into a spurious command. (Done
+            // here, not in `config_to_commands`, so the `vtyctl apply`
+            // path keeps its existing empty-document behavior — an empty
+            // apply must not clear+commit the running config.)
             if !output.trim().is_empty() {
                 match self.config_to_commands(&output) {
                     Ok((_format, cmds)) => {
@@ -833,11 +832,7 @@ impl ConfigManager {
                         }
                     }
                     Err(doc_errors) => {
-                        tracing::error!(
-                            "config file {}: rejected by schema: {}",
-                            self.config_path.display(),
-                            doc_errors.join("; ")
-                        );
+                        tracing::error!("{}", render_config_errors(&self.config_path, &doc_errors));
                     }
                 }
             }
@@ -1020,10 +1015,17 @@ impl ConfigManager {
                 let (format_type, cmds) = match self.config_to_commands(&req.config) {
                     Ok(parsed) => parsed,
                     Err(doc_errors) => {
+                        // No filename here (the config was streamed in via
+                        // `vtyctl apply`), so each error carries its own
+                        // `line N:` prefix when the format preserved it.
                         let resp = DeployResponse {
                             apply_code: ApplyCode::ParseError,
                             exec_code: ExecCode::Nomatch,
-                            cmd: doc_errors.join("; "),
+                            cmd: doc_errors
+                                .iter()
+                                .map(DocError::to_string)
+                                .collect::<Vec<_>>()
+                                .join("; "),
                         };
                         let _ = req.resp.send(resp);
                         return;
@@ -1423,6 +1425,26 @@ fn collect_dynamics(entry: &Entry, set: &mut HashSet<String>) {
     }
 }
 
+/// Render a startup config-load rejection into a single loggable
+/// message. Each schema error is prefixed with `<file>:<line>:` (a
+/// clickable location) when the format preserved a source line, or just
+/// `<file>:` otherwise (e.g. the JSON front-end, which carries none).
+fn render_config_errors(config_path: &Path, errors: &[DocError]) -> String {
+    let detail = errors
+        .iter()
+        .map(|e| match e.line {
+            Some(line) => format!("{}:{}: {}", config_path.display(), line, e.message),
+            None => format!("{}: {}", config_path.display(), e.message),
+        })
+        .collect::<Vec<_>>()
+        .join("\n  ");
+    format!(
+        "config file {} rejected by schema:\n  {}",
+        config_path.display(),
+        detail
+    )
+}
+
 #[derive(Debug, PartialEq)]
 pub enum ConfigFormat {
     Cli,
@@ -1552,6 +1574,63 @@ mod config_format_tests {
     fn yaml_mapping() {
         assert_eq!(config_format_type("vrf:\n- name: N3\n"), ConfigFormat::Yaml);
         assert_eq!(config_format_type("router:\n  bgp:\n"), ConfigFormat::Yaml);
+    }
+}
+
+#[cfg(test)]
+mod config_error_render_tests {
+    use super::*;
+    use libyang::{YangStore, to_entry};
+    use std::path::PathBuf;
+    use std::rc::Rc;
+
+    fn set_entry() -> Rc<Entry> {
+        let mut yang = YangStore::new();
+        yang.add_path(concat!(env!("CARGO_MANIFEST_DIR"), "/yang"));
+        yang.read_with_resolve("configure")
+            .expect("configure mode loads");
+        yang.identity_resolve();
+        let module = yang
+            .find_module("configure")
+            .expect("configure module present");
+        to_entry(&yang, module)
+            .dir
+            .borrow()
+            .iter()
+            .find(|e| e.name == "set")
+            .cloned()
+            .expect("set subtree")
+    }
+
+    /// End-to-end reproduction of the reported failure: a YAML config
+    /// with an unknown `community-set` leaf under a policy match is
+    /// rejected AND the logged message names the exact source line of
+    /// the offending key as a clickable `<file>:<line>:` location.
+    #[test]
+    fn yaml_unknown_key_renders_clickable_source_line() {
+        let config = "\
+policy:
+- name: 198.19.14.192/28
+  entry:
+  - number: 10
+    action: permit
+    match:
+      community-set: FOO
+";
+        assert_eq!(config_format_type(config), ConfigFormat::Yaml);
+
+        let (_lines, errors) = yaml_read(set_entry(), config);
+        let message = render_config_errors(&PathBuf::from("zebra.yaml"), &errors);
+
+        // `community-set:` sits on line 7 (1-based) of the document.
+        assert!(
+            message.contains("zebra.yaml:7:"),
+            "expected a clickable file:line location; message: {message}"
+        );
+        assert!(
+            message.contains("unknown key `community-set`"),
+            "message: {message}"
+        );
     }
 }
 

--- a/zebra-rs/src/config/yaml.rs
+++ b/zebra-rs/src/config/yaml.rs
@@ -1,4 +1,202 @@
-pub fn yaml_parse(str: &str) -> String {
-    let yaml_value: serde_yaml::Value = serde_yaml::from_str(str).unwrap();
-    serde_json::to_string(&yaml_value).unwrap()
+use libyang::Entry;
+use marked_yaml::types::{MarkedScalarNode, Node};
+use marked_yaml::{LoaderOptions, parse_yaml_with_options};
+use std::rc::Rc;
+
+use super::json::{DocError, MapEntry, SpannedValue, spanned_to_list};
+
+/// Walk a YAML config document against the YANG `set` subtree,
+/// preserving the source line of every key so a schema-rejection error
+/// can point the operator at the exact line in their config file.
+///
+/// Replaces the old `yaml_parse` → JSON-string → `serde_json` round
+/// trip, which discarded every source marker (and `.unwrap()`ed on
+/// malformed YAML, panicking the daemon). This parses the original YAML
+/// with `marked-yaml`, lowers it into a line-annotated [`SpannedValue`],
+/// and shares the JSON [`spanned_to_list`] walk.
+pub fn yaml_read(e: Rc<Entry>, source: &str) -> (Vec<String>, Vec<DocError>) {
+    let mut lines: Vec<String> = Vec::new();
+    let mut errors: Vec<DocError> = Vec::new();
+    // `prevent_coercion` so a *quoted* "null"/"true" scalar keeps its
+    // string identity — only plain scalars coerce, matching the old
+    // serde_yaml semantics. `error_on_duplicate_keys` so a repeated key
+    // is reported (with its line) rather than silently last-wins.
+    let options = LoaderOptions::default()
+        .prevent_coercion(true)
+        .error_on_duplicate_keys(true);
+    match parse_yaml_with_options(0, source, options) {
+        Ok(node) => {
+            spanned_to_list(e, Vec::new(), &from_yaml(&node), &mut lines, &mut errors);
+        }
+        Err(err) => {
+            // marked-yaml renders the offending marker as `line:column`
+            // inside the message, so the operator still gets a location.
+            errors.push(DocError::new(None, format!("invalid document: {err}")));
+        }
+    }
+    (lines, errors)
+}
+
+/// Lower a `marked-yaml` node into a line-annotated [`SpannedValue`].
+fn from_yaml(node: &Node) -> SpannedValue {
+    match node {
+        Node::Scalar(s) => {
+            if is_null_scalar(s) {
+                SpannedValue::Null
+            } else {
+                SpannedValue::Scalar(s.as_str().to_string())
+            }
+        }
+        Node::Sequence(seq) => SpannedValue::Sequence(seq.iter().map(from_yaml).collect()),
+        Node::Mapping(map) => {
+            let line = map.span().start().map(|m| m.line());
+            let entries = map
+                .iter()
+                .map(|(key, value)| MapEntry {
+                    key: key.as_str().to_string(),
+                    line: key.span().start().map(|m| m.line()),
+                    value: from_yaml(value),
+                })
+                .collect();
+            SpannedValue::Mapping { line, entries }
+        }
+    }
+}
+
+/// A plain (coerceable) `null`/`~`/empty scalar is YAML null — lowered
+/// to [`SpannedValue::Null`] so it emits a bare `set <path>` (the
+/// empty-leaf / `type empty` convention). A quoted `"null"` is a real
+/// string and is left alone.
+fn is_null_scalar(s: &MarkedScalarNode) -> bool {
+    s.may_coerce() && matches!(s.as_str(), "" | "~" | "null" | "Null" | "NULL")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use libyang::{YangStore, to_entry};
+
+    fn set_entry() -> Rc<Entry> {
+        let mut yang = YangStore::new();
+        yang.add_path(concat!(env!("CARGO_MANIFEST_DIR"), "/yang"));
+        yang.read_with_resolve("configure")
+            .expect("configure mode loads");
+        yang.identity_resolve();
+        let module = yang
+            .find_module("configure")
+            .expect("configure module present");
+        let entry = to_entry(&yang, module);
+        entry
+            .dir
+            .borrow()
+            .iter()
+            .find(|e| e.name == "set")
+            .cloned()
+            .expect("set subtree")
+    }
+
+    /// The reported failure: an unknown `community-set` leaf under a
+    /// policy match must be rejected AND carry the line it sits on.
+    #[test]
+    fn unknown_key_reports_source_line() {
+        let doc = "\
+policy:
+- name: 198.19.14.192/28
+  entry:
+  - number: 10
+    action: permit
+    match:
+      community-set: FOO
+";
+        let (_lines, errors) = yaml_read(set_entry(), doc);
+        let err = errors
+            .iter()
+            .find(|e| e.message.contains("unknown key `community-set`"))
+            .unwrap_or_else(|| panic!("expected unknown-key error; errors: {errors:?}"));
+        // `community-set:` is on line 7 (1-based) of the document above.
+        assert_eq!(err.line, Some(7), "errors: {errors:?}");
+    }
+
+    /// A plain `key: null` and a bare `key:` both lower to a bare
+    /// `set <path>` line (the `type empty` / empty-leaf convention),
+    /// matching the pre-marked-yaml serde_yaml behavior.
+    #[test]
+    fn null_and_empty_scalar_emit_bare_set() {
+        let doc = "\
+router:
+  bgp:
+    neighbor:
+    - remote-address: 10.0.0.1
+      as-override: null
+";
+        let (lines, errors) = yaml_read(set_entry(), doc);
+        assert!(errors.is_empty(), "errors: {errors:?}");
+        assert!(
+            lines
+                .iter()
+                .any(|l| l == "set router bgp neighbor 10.0.0.1 as-override"),
+            "`key: null` must emit a bare set; lines: {lines:?}"
+        );
+
+        let doc = "\
+router:
+  bgp:
+    neighbor:
+    - remote-address: 10.0.0.1
+      as-override:
+";
+        let (lines, errors) = yaml_read(set_entry(), doc);
+        assert!(errors.is_empty(), "errors: {errors:?}");
+        assert!(
+            lines
+                .iter()
+                .any(|l| l == "set router bgp neighbor 10.0.0.1 as-override"),
+            "bare `key:` must emit a bare set; lines: {lines:?}"
+        );
+    }
+
+    /// A presence container written as `key: {}` restores the bare
+    /// `set <path>` line, just like the JSON path.
+    #[test]
+    fn empty_mapping_restores_presence_container() {
+        let doc = "\
+router:
+  bgp:
+    neighbor:
+    - remote-address: 10.0.0.1
+      as-override: {}
+";
+        let (lines, errors) = yaml_read(set_entry(), doc);
+        assert!(errors.is_empty(), "errors: {errors:?}");
+        assert!(
+            lines
+                .iter()
+                .any(|l| l == "set router bgp neighbor 10.0.0.1 as-override"),
+            "`key: {{}}` must emit a bare set; lines: {lines:?}"
+        );
+    }
+
+    /// Numeric and nested values flatten to the same commands the JSON
+    /// path produces.
+    #[test]
+    fn nested_shape_emits_command() {
+        let doc = "\
+policy:
+- name: IN-MED
+  entry:
+  - number: 10
+    action: permit
+    match:
+      med:
+        eq: 999
+";
+        let (lines, errors) = yaml_read(set_entry(), doc);
+        assert!(errors.is_empty(), "errors: {errors:?}");
+        assert!(
+            lines
+                .iter()
+                .any(|l| l == "set policy IN-MED entry 10 match med eq 999"),
+            "lines: {lines:?}"
+        );
+    }
 }


### PR DESCRIPTION
## What

When a config file is rejected by the YANG schema, the error now names the exact **source line** of the offending key so the operator gets a clickable location instead of a flat, location-free message:

```
config file zebra.yaml rejected by schema:
  zebra.yaml:7: policy 198.19.14.192/28 entry 10 match: unknown key `community-set`
```

## Why

The old YAML path did `yaml_parse` → JSON string → `serde_json`, which **discarded every source marker** and `.unwrap()`ed on malformed YAML — a bad config file could *panic the daemon*. There was no way to tell the operator which line the schema refused.

## How

- **`json.rs`** — add a line-annotated `SpannedValue` / `MapEntry` intermediate and a `DocError { line, message }`. Both front-ends lower into `SpannedValue`, and the single schema walk (`json_to_list` → `spanned_to_list`) carries each key's source line. JSON keeps working (lines are `None`, so no `line N:` prefix).
- **`yaml.rs`** — new `yaml_read` parses the original YAML with `marked-yaml` (keeping a line marker on every key) and lowers into `SpannedValue`. `prevent_coercion` keeps a quoted `"null"` a string; `error_on_duplicate_keys` reports duplicate keys with their line. No more panic on malformed YAML.
- **`manager.rs`** — YAML arm calls `yaml_read`; new testable `render_config_errors` formats the clickable `<file>:<line>:` message on startup load; the `vtyctl apply` path emits per-error `line N:` prefixes.
- **`Cargo.toml`** — add `marked-yaml = "0.7"`.

## Tests

New unit tests cover: source-line reporting for an unknown key, `key: null` / bare `key:` / `key: {}` → bare `set` (empty-leaf & presence-container conventions), nested-value flattening, `DocError` display with/without a line, and an end-to-end render of the reported `community-set` failure as a clickable `zebra.yaml:7:` location.

Verified locally: `cargo fmt --check`, `cargo clippy --workspace --all-targets -D warnings`, `cargo clippy -p zebra-rs --features lua`, and the config module tests (308 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
