### PR TITLE
cradle: system ebpf mode {tc-only|xdp-only} benchmark knob

### DIFF
--- a/zebra-rs/src/cradle/inst.rs
+++ b/zebra-rs/src/cradle/inst.rs
@@ -33,6 +33,8 @@ const RETRY_TICK: std::time::Duration = std::time::Duration::from_secs(3);
 /// A running supervisor loop for one desired endpoint.
 struct Engine {
     endpoint: String,
+    /// The `--ebpf-mode` this engine was spawned with; a change restarts it.
+    mode: Option<String>,
     /// Flipping this to `true` asks the loop to stop: it SIGTERMs a child
     /// it spawned (never an adopted instance) and exits.
     shutdown: watch::Sender<bool>,
@@ -119,6 +121,10 @@ pub struct Cradle {
     events_rx: UnboundedReceiver<EngineEvent>,
     /// Staged `system ebpf enabled` (applied at `CommitEnd`).
     ebpf_enabled: bool,
+    /// Staged `system ebpf mode` — the single-hook benchmark mode
+    /// (`tc-only`/`xdp-only`) passed to the managed engine as `--ebpf-mode`.
+    /// `None` = full pipeline. A change restarts the engine (applied at spawn).
+    ebpf_mode: Option<String>,
     /// Staged `system cradle enabled` — in external mode (engine not
     /// managed) an enabled tee marks the endpoint usable for port pushes.
     cradle_enabled: bool,
@@ -180,6 +186,7 @@ impl Cradle {
             events_tx,
             events_rx,
             ebpf_enabled: false,
+            ebpf_mode: None,
             cradle_enabled: false,
             grpc_endpoint: None,
             if_ebpf: BTreeMap::new(),
@@ -233,6 +240,9 @@ impl Cradle {
                 match path.as_str() {
                     "/system/ebpf/enabled" => {
                         self.ebpf_enabled = msg.op.is_set() && args.boolean().unwrap_or(false);
+                    }
+                    "/system/ebpf/mode" => {
+                        self.ebpf_mode = if msg.op.is_set() { args.string() } else { None };
                     }
                     "/system/cradle/enabled" => {
                         self.cradle_enabled = msg.op.is_set() && args.boolean().unwrap_or(false);
@@ -629,6 +639,7 @@ impl Cradle {
                 .collect();
             return serde_json::json!({
                 "systemEbpfEnabled": self.ebpf_enabled,
+                "ebpfMode": self.ebpf_mode,
                 "teeEnabled": self.cradle_enabled || self.ebpf_enabled,
                 "endpoint": endpoint,
                 "engine": engine,
@@ -653,6 +664,10 @@ impl Cradle {
             }
         )
         .unwrap();
+        // Single-hook benchmark mode — shown only when set (unset = full pipeline).
+        if let Some(mode) = &self.ebpf_mode {
+            writeln!(out, "  Mode:            {mode} (single-hook L3-only benchmark)").unwrap();
+        }
         writeln!(
             out,
             "  FIB tee:         {}",
@@ -741,7 +756,14 @@ impl Cradle {
     /// disabling stops it gracefully.
     fn reconcile_engine(&mut self) {
         let desired = self.ebpf_enabled.then(|| self.endpoint());
-        if self.engine.as_ref().map(|e| e.endpoint.as_str()) == desired.as_deref() {
+        // Restart on endpoint OR mode change — the mode is applied to the child
+        // only at spawn (`--ebpf-mode`), so a live change must respawn it.
+        let unchanged = match (&self.engine, &desired) {
+            (Some(e), Some(ep)) => e.endpoint == *ep && e.mode == self.ebpf_mode,
+            (None, None) => true,
+            _ => false,
+        };
+        if unchanged {
             return;
         }
         if let Some(engine) = self.engine.take() {
@@ -752,15 +774,23 @@ impl Cradle {
             engine.task.detach();
         }
         if let Some(endpoint) = desired {
-            info!("cradle: starting engine supervisor for {endpoint}");
+            let mode = self.ebpf_mode.clone();
+            info!(
+                "cradle: starting engine supervisor for {endpoint}{}",
+                mode.as_deref()
+                    .map(|m| format!(" (ebpf-mode {m})"))
+                    .unwrap_or_default()
+            );
             let (shutdown, shutdown_rx) = watch::channel(false);
             let ep = endpoint.clone();
+            let spawn_mode = mode.clone();
             let events = self.events_tx.clone();
             let task = Task::spawn(async move {
-                supervisor::run(ep, shutdown_rx, events).await;
+                supervisor::run(ep, spawn_mode, shutdown_rx, events).await;
             });
             self.engine = Some(Engine {
                 endpoint,
+                mode,
                 shutdown,
                 task,
             });

--- a/zebra-rs/src/cradle/inst.rs
+++ b/zebra-rs/src/cradle/inst.rs
@@ -666,7 +666,11 @@ impl Cradle {
         .unwrap();
         // Single-hook benchmark mode — shown only when set (unset = full pipeline).
         if let Some(mode) = &self.ebpf_mode {
-            writeln!(out, "  Mode:            {mode} (single-hook L3-only benchmark)").unwrap();
+            writeln!(
+                out,
+                "  Mode:            {mode} (single-hook L3-only benchmark)"
+            )
+            .unwrap();
         }
         writeln!(
             out,

--- a/zebra-rs/src/cradle/supervisor.rs
+++ b/zebra-rs/src/cradle/supervisor.rs
@@ -114,10 +114,15 @@ fn strip_ansi(line: &str) -> std::borrow::Cow<'_, str> {
 /// `PR_SET_PDEATHSIG=SIGTERM` (the kernel signals the child even if zebra-rs
 /// is SIGKILLed), so no root engine process can leak past the daemon.
 /// stdout/stderr are piped into zebra-rs tracing under the `cradle` target.
-fn spawn_child(bin: &PathBuf, endpoint: &str) -> std::io::Result<Child> {
+fn spawn_child(bin: &PathBuf, endpoint: &str, ebpf_mode: Option<&str>) -> std::io::Result<Child> {
     let mut cmd = Command::new(bin);
-    cmd.args(["serve", "--grpc", endpoint])
-        .stdin(Stdio::null())
+    cmd.args(["serve", "--grpc", endpoint]);
+    // Single-hook benchmark mode: restrict the engine to plain IPv4 L3
+    // forwarding through one hook (docs/design/xdp-tc-fast-path.md).
+    if let Some(mode) = ebpf_mode {
+        cmd.args(["--ebpf-mode", mode]);
+    }
+    cmd.stdin(Stdio::null())
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())
         .kill_on_drop(true);
@@ -170,6 +175,7 @@ async fn graceful_stop(mut child: Child) {
 /// [`EngineEvent::Down`] (idempotently) so the port reconcile resets.
 pub(crate) async fn run(
     endpoint: String,
+    ebpf_mode: Option<String>,
     mut shutdown: watch::Receiver<bool>,
     events: UnboundedSender<EngineEvent>,
 ) {
@@ -206,7 +212,7 @@ pub(crate) async fn run(
         }
         let bin = resolve_bin();
         let started = Instant::now();
-        match spawn_child(&bin, &endpoint) {
+        match spawn_child(&bin, &endpoint, ebpf_mode.as_deref()) {
             Ok(mut child) => {
                 info!(
                     "cradle: spawned engine {} (pid {:?}) serving {endpoint}",

--- a/zebra-rs/yang/config.yang
+++ b/zebra-rs/yang/config.yang
@@ -558,6 +558,24 @@ module config {
              an externally-run cradle can still be teed to through
              `system cradle enabled`.";
         }
+        leaf mode {
+          ext:help "Single-hook datapath benchmark mode (tc-only|xdp-only)";
+          type enumeration {
+            enum tc-only;
+            enum xdp-only;
+          }
+          description
+            "Performance-investigation knob (docs/design/xdp-tc-fast-path.md):
+             restrict the managed cradle engine to plain IPv4 L3 forwarding
+             through a SINGLE eBPF hook, so each hook's cost can be measured in
+             isolation. `tc-only` attaches only the TC classifier (cradle_tc,
+             which then runs an L3-only fast path); `xdp-only` attaches only a
+             dedicated XDP forwarder (cradle_xdp_l3). Also defaults the IPv4 FIB
+             engine to DIR-24-8. Passed to the engine as `--ebpf-mode` at spawn,
+             so a change restarts the managed child. Non-L3 features (NAT,
+             policy, overlay, L2) are unsupported while set — do not use in
+             production. When unset the full XDP+TC pipeline runs as normal.";
+        }
       }
       container dhcp {
         ext:help "DHCP configuration";


### PR DESCRIPTION
The producer side of cradle's `--ebpf-mode`: a config knob to restrict the
managed cradle engine to plain IPv4 L3 forwarding through a SINGLE eBPF hook,
for root-causing the datapath cost in `xdp-tc-fast-path.md`.

## Changes
- YANG: `container system/ebpf` gains `leaf mode { enum tc-only; xdp-only; }`.
- The cradle supervisor task stages `ebpf_mode` and passes it to the child as
  `cradle serve --ebpf-mode <mode>`; `reconcile_engine` restarts the managed
  child on an endpoint OR mode change.
- `show ebpf` reports the mode (text + JSON) when set.

Non-L3 features are unsupported while set — benchmark only, not production.
Pairs with cradle-rs `ebpf-mode-single-hook`.

## Test plan
- `cargo build -p zebra-rs`, `cargo clippy -p zebra-rs` — clean.
- Verified end to end against a live daemon: `set system ebpf mode xdp-only`
  spawns `cradle serve --ebpf-mode xdp-only` and `show ebpf` reports the mode.

Generated with [Claude Code](https://claude.com/claude-code)