### PR TITLE
BGP MUP: honor CP-allocated N3 F-TEID; free5GC e2e UE ping proven

### DIFF
--- a/bdd/mup-lab/README.md
+++ b/bdd/mup-lab/README.md
@@ -1,0 +1,150 @@
+# mup-lab — free5GC + free-ran-ue + zebra-rs/cradle single-box UPF
+
+The manual lab that first proved end-to-end UE ping through zebra-rs +
+cradle acting as the UPF (`afi-safi mup dataplane gtp`), against a real
+5G core (free5GC v4.0.1) and a real RAN/UE simulator (free-ran-ue), on
+2026-07-14 (issue #1930). The distilled, self-contained regression lives
+in cradle-rs as the `@cradle_mup_gtp_roundtrip` BDD feature; this lab is
+for reproducing the full free5GC stack by hand.
+
+```
+ host (root netns): free5GC CP on 127.0.0.x SBI, mongodb, webconsole
+  ├─ mrHost 10.0.1.1/24  ── veth ──  mupran: mrVeth 10.0.1.2/24   (N2 + N3 transit)
+  ├─ muHost 10.0.12.1/24 ── veth ──  mupupf: mun3  10.0.12.2/24   (N4 + N3)
+  └─ ip_forward=1 between the two /24s
+
+ mupran: free-ran-ue gNB (N2/N3 on 10.0.1.2; UE link on 127.0.0.1) + UE (ueTun0)
+ mupupf: zebra-rs + cradle
+          VRF mobile-dl (table 1): mudl 10.0.61.1/24 ── mupdn: dnd 10.0.61.2  (DL ingress)
+          VRF mobile-ul (table 2): muul 10.0.60.1/24 ── mupdn: dnu 10.0.60.2  (UL egress, ping target)
+ mupdn:  route 10.60.0.0/16 (the free5GC UE pool) via 10.0.61.1
+```
+
+Key design points
+
+- **N3 lives in the global table**; the MUP VRFs only anchor the st1/st2
+  routes. One VRF binds one direction, hence the two N6 legs: uplink
+  egresses the mobile-ul leg, the DN routes the UE pool back through the
+  mobile-dl leg.
+- **PFCP `listen-address` = the N3 address** (10.0.12.2): the
+  controller's N4 identity doubles as the F-TEID address fallback, so
+  one address keeps the tunnel endpoint consistent.
+- **`network-instance` = the DNN** free5GC puts in the PDI Network
+  Instance (`internet`); the same NI on both VRFs makes one PFCP session
+  fan out to both ST routes.
+- free5GC allocates the UPF's N3 TEID itself (Create PDR → PDI local
+  F-TEID, TS 29.244 CH=0) and ignores the Created-PDR F-TEID; mup-c
+  honors it as authoritative (commit `eb576cf9`).
+- The free-ran-ue gNB sends uplink GTP-U to `upfN3Ip` **from its config**
+  (it ignores the NGAP transport address), and its UE process needs root
+  for the TUN device.
+
+## Prerequisites
+
+```sh
+# zebra-rs (this repo, with the mup-c n3_local fix) + vtyctl
+cargo build -p zebra-rs -p vtyctl
+
+# cradle (branch with the GTP header-shape decap + address monitor, PR cradle-rs#147)
+cd ~/cradle-rs && cargo build
+
+# free5GC v4.0.1 CP NFs + webconsole backend (Go >= 1.21; no gtp5g needed — we ARE the UPF)
+cd ~/free5gc && make nrf smf udr udm ausf nssf pcf chf   # amf: use prebuilt bin/amf
+cd webconsole && go build -o bin/webconsole server.go
+
+# free-ran-ue (Go 1.26 via auto-toolchain; includes the N3 crash fix, PR free-ran-ue#326)
+cd ~/free-ran-ue && make bin
+
+# MongoDB (Ubuntu's 3.6 package works)
+sudo mkdir -p /var/log/mongodb /var/lib/mongodb
+sudo chown mongodb:mongodb /var/log/mongodb /var/lib/mongodb
+sudo systemctl start mongodb
+```
+
+Provision the default subscriber (matches `ue.yaml`: IMSI
+208930000000001, the classic free5GC demo K/OPc):
+
+```sh
+cd ~/free5gc/webconsole && ./bin/webconsole -c ../config/webuicfg.yaml &
+TOKEN=$(curl -s -X POST http://127.0.0.1:5000/api/login \
+  -H 'Content-Type: application/json' -d '{"username":"admin","password":"free5gc"}' \
+  | python3 -c 'import sys,json;print(json.load(sys.stdin)["access_token"])')
+curl -s -X POST "http://127.0.0.1:5000/api/subscriber/imsi-208930000000001/20893" \
+  -H "Token: $TOKEN" -H 'Content-Type: application/json' \
+  -d @/home/kunihiro/free-ran-ue/script/10k-test-script/free5gc-console-subscriber-data.json
+```
+
+## Bring-up (order matters)
+
+```sh
+LAB=$(pwd)   # this directory
+mkdir -p $LAB/logs
+
+# 1. topology
+sudo $LAB/setup-topo.sh
+
+# 2. cradle, then zebra-rs, in the UPF namespace (zebra tees to unix:cradle/grpc)
+sudo ip netns exec mupupf sh -c "RUST_LOG=info,cradle=debug exec ~/cradle-rs/target/debug/cradle \
+  serve --config $LAB/upf-ports.json --grpc unix:cradle/grpc \
+  --pid-file /tmp/mupupf_cradle.pid >> $LAB/logs/cradle.log 2>&1 &"
+sudo ip netns exec mupupf sh -c "RUST_LOG=info exec $(git rev-parse --show-toplevel)/target/debug/zebra-rs \
+  --yang-path $(git rev-parse --show-toplevel)/zebra-rs/yang --config-file $LAB/upf.yaml \
+  --log-output=file --log-file=$LAB/logs/zebra.log \
+  --pid-file /tmp/mupupf_zebra.pid >> $LAB/logs/zebra.stdout 2>&1 &"
+
+# 3. free5GC CP on the host (lab amfcfg/smfcfg; defaults for the rest)
+cd ~/free5gc
+for nf in nrf amf smf udr pcf udm nssf ausf; do
+  cfg=config/${nf}cfg.yaml
+  [ $nf = amf ] && cfg=$LAB/amfcfg.yaml
+  [ $nf = smf ] && cfg=$LAB/smfcfg.yaml
+  (./bin/$nf -c $cfg > $LAB/logs/$nf.log 2>&1 &); sleep 1
+done
+# SMF associates with the UPF within seconds:
+#   "UPF(10.0.12.2) setup association" in logs/smf.log
+
+# 4. gNB, then UE, in the RAN namespace (UE creates ueTun0; needs root)
+sudo ip netns exec mupran sh -c "exec ~/free-ran-ue/build/free-ran-ue gnb -c $LAB/gnb.yaml \
+  > $LAB/logs/gnb.log 2>&1 &"
+sleep 3
+sudo ip netns exec mupran sh -c "exec ~/free-ran-ue/build/free-ran-ue ue -c $LAB/ue.yaml \
+  > $LAB/logs/ue.log 2>&1 &"
+```
+
+Quirk: if the UE log stalls at "Processing PDU session establishment"
+(a stale SM context from a previous run racing its release), kill just
+the UE process and start it again — the second attach goes through.
+
+## Verify, then ping
+
+```sh
+V=$(git rev-parse --show-toplevel)/target/debug/vtyctl
+sudo ip netns exec mupupf $V show 'show bgp mup-c association'   # SMF peer
+sudo ip netns exec mupupf $V show 'show bgp mup-c session'       # UE addr, Access + Core F-TEIDs
+sudo ip netns exec mupupf $V show 'show bgp vrf mobile-dl mup'   # [ST1] ue=<UE>/32 -> gNB
+sudo ip netns exec mupupf $V show 'show bgp vrf mobile-ul mup'   # [ST2] ep=10.0.12.2, CP-allocated teid
+sudo ip netns exec mupupf bpftool map dump name GTP_PDR           # uplink decap key
+sudo ip netns exec mupupf ~/cradle-rs/target/debug/cradle dump ipv4 --grpc unix:cradle/grpc --vrf 1
+
+# seed ARP once, then the end-to-end ping
+sudo ip netns exec mupdn  ping -c1 -W1 10.0.61.1 >/dev/null
+sudo ip netns exec mupdn  ping -c1 -W1 10.0.60.1 >/dev/null
+sudo ip netns exec mupupf ping -c1 -W1 10.0.12.1 >/dev/null
+sudo ip netns exec mupran ping -I ueTun0 -c 5 10.0.60.2
+
+sudo ip netns exec mupupf ~/cradle-rs/target/debug/cradle stats --grpc unix:cradle/grpc | grep gtp
+```
+
+Expected: 0% loss, and `gtp_encap` / `gtp_decap` both counting.
+
+Known gap: if you restart *cradle* under a live zebra-rs, the tee does
+not replay its mirror (tonic reconnects transparently) — restart
+zebra-rs instead, wait for the SMF to re-associate, and re-attach the UE.
+
+## Teardown
+
+```sh
+sudo $LAB/teardown-topo.sh
+for nf in nrf amf smf udr pcf udm nssf ausf webconsole; do pkill -x $nf; done
+sudo systemctl stop mongodb
+```

--- a/bdd/mup-lab/amfcfg.yaml
+++ b/bdd/mup-lab/amfcfg.yaml
@@ -1,0 +1,149 @@
+info:
+  version: 1.0.9
+  description: AMF initial local configuration
+
+configuration:
+  amfName: AMF # the name of this AMF
+  ngapIpList:  # the IP list of N2 interfaces on this AMF
+    - 10.0.1.1
+  ngapPort: 38412 # the SCTP port listened by NGAP
+
+  # Service-based Interface (SBI) Configuration
+  sbi:
+    scheme: http # the protocol for sbi (http or https)
+    registerIPv4: 127.0.0.18 # IP used to register to NRF
+    bindingIPv4: 127.0.0.18  # IP used to bind the service
+    port: 8000 # port used to bind the service
+    tls: # the local path of TLS key
+      pem: cert/amf.pem # AMF TLS Certificate
+      key: cert/amf.key # AMF TLS Private key
+
+  # SBI Services offered by this AMF, as per TS 29.518
+  serviceNameList:
+    - namf-comm # Namf_Communication service
+    - namf-evts # Namf_EventExposure service
+    - namf-mt   # Namf_MT service
+    - namf-loc  # Namf_Location service
+    - namf-oam  # OAM service
+
+  # Guami (Globally Unique AMF ID) list supported by this AMF
+  servedGuamiList:
+    # <GUAMI> = <MCC><MNC><AMF ID>
+    - plmnId: # Public Land Mobile Network ID, <PLMN ID> = <MCC><MNC>
+        mcc: 208 # Mobile Country Code (3 digits string, digit: 0~9)
+        mnc: 93 # Mobile Network Code (2 or 3 digits string, digit: 0~9)
+      amfId: cafe00 # AMF identifier (3 bytes hex string, range: 000000~FFFFFF)
+
+  # the TAI (Tracking Area Identifier) list supported by this AMF
+  supportTaiList:
+    - plmnId: # Public Land Mobile Network ID, <PLMN ID> = <MCC><MNC>
+        mcc: 208 # Mobile Country Code (3 digits string, digit: 0~9)
+        mnc: 93 # Mobile Network Code (2 or 3 digits string, digit: 0~9)
+      tac: 000001 # Tracking Area Code (3 bytes hex string, range: 000000~FFFFFF)
+
+  # the PLMNs (Public land mobile network) list supported by this AMF
+  plmnSupportList:
+    - plmnId: # Public Land Mobile Network ID, <PLMN ID> = <MCC><MNC>
+        mcc: 208 # Mobile Country Code (3 digits string, digit: 0~9)
+        mnc: 93 # Mobile Network Code (2 or 3 digits string, digit: 0~9)
+      snssaiList: # the S-NSSAI (Single Network Slice Selection Assistance Information) list supported by this AMF
+        - sst: 1 # Slice/Service Type (uinteger, range: 0~255)
+          sd: 010203 # Slice Differentiator (3 bytes hex string, range: 000000~FFFFFF)
+        - sst: 1 # Slice/Service Type (uinteger, range: 0~255)
+          sd: 112233 # Slice Differentiator (3 bytes hex string, range: 000000~FFFFFF)
+
+  # the DNN (Data Network Name) list supported by this AMF
+  supportDnnList:
+    - internet
+  nrfUri: http://127.0.0.10:8000 # a valid URI of NRF
+  nrfCertPem: cert/nrf.pem # NRF Certificate
+
+  # NAS Security Configuration
+  # the priority of integrity algorithms
+  # the priority of ciphering algorithms
+  security:
+    integrityOrder:
+      - NIA2
+      # - NIA0
+    cipheringOrder:
+      - NEA0
+      - NEA2
+
+  # Network Name Information
+  networkName:
+    full: free5GC
+    short: free
+
+  # Optional NGAP Information Elements (IE)
+  ngapIE:
+    mobilityRestrictionList: # Mobility Restriction List IE, refer to TS 38.413
+      enable: true # append this IE in related message or not
+    maskedIMEISV: # Masked IMEISV IE, refer to TS 38.413
+      enable: true # append this IE in related message or not
+    redirectionVoiceFallback: # Redirection Voice Fallback IE, refer to TS 38.413
+      enable: false # append this IE in related message or not
+
+  # Optional NAS Information Elements (IE)
+  nasIE:
+    networkFeatureSupport5GS: # 5gs Network Feature Support IE, refer to TS 24.501
+      enable: true # append this IE in Registration accept or not
+      length: 1 # IE content length (uinteger, range: 1~3)
+      imsVoPS: 0 # IMS voice over PS session indicator (uinteger, range: 0~1)
+      emc: 0 # Emergency service support indicator for 3GPP access (uinteger, range: 0~3)
+      emf: 0 # Emergency service fallback indicator for 3GPP access (uinteger, range: 0~3)
+      iwkN26: 0 # Interworking without N26 interface indicator (uinteger, range: 0~1)
+      mpsi: 0 # MPS indicator (uinteger, range: 0~1)
+      emcN3: 0 # Emergency service support indicator for Non-3GPP access (uinteger, range: 0~1)
+      mcsi: 0 # MCS indicator (uinteger, range: 0~1)
+  t3502Value: 720  # timer value (seconds) at UE side
+  t3512Value: 3600 # timer value (seconds) at UE side
+  non3gppDeregTimerValue: 3240 # timer value (seconds) at UE side
+  # retransmission timer for paging message
+  t3513:
+    enable: true     # true or false
+    expireTime: 6s   # default is 6 seconds
+    maxRetryTimes: 4 # the max number of retransmission
+  # retransmission timer for NAS Deregistration Request message
+  t3522:
+    enable: true     # true or false
+    expireTime: 6s   # default is 6 seconds
+    maxRetryTimes: 4 # the max number of retransmission
+  # retransmission timer for NAS Registration Accept message
+  t3550:
+    enable: true     # true or false
+    expireTime: 6s   # default is 6 seconds
+    maxRetryTimes: 4 # the max number of retransmission
+  # retransmission timer for NAS Configuration Update Command message
+  t3555:
+    enable: true     # true or false
+    expireTime: 6s   # default is 6 seconds
+    maxRetryTimes: 4 # the max number of retransmission
+  # retransmission timer for NAS Authentication Request/Security Mode Command message
+  t3560:
+    enable: true     # true or false
+    expireTime: 6s   # default is 6 seconds
+    maxRetryTimes: 4 # the max number of retransmission
+  # retransmission timer for NAS Notification message
+  t3565:
+    enable: true     # true or false
+    expireTime: 6s   # default is 6 seconds
+    maxRetryTimes: 4 # the max number of retransmission
+  # retransmission timer for NAS Identity Request message
+  t3570:
+    enable: true     # true or false
+    expireTime: 6s   # default is 6 seconds
+    maxRetryTimes: 4 # the max number of retransmission
+  locality: area1 # Name of the location where a set of AMF, SMF, PCF and UPFs are located
+
+  # set the sctp server setting <optinal>, once this field is set, please also add maxInputStream, maxOsStream, maxAttempts, maxInitTimeOut
+  sctp:
+    numOstreams: 3 # the maximum out streams of each sctp connection
+    maxInstreams: 5 # the maximum in streams of each sctp connection
+    maxAttempts: 2 # the maximum attempts of each sctp connection
+    maxInitTimeout: 2 # the maximum init timeout of each sctp connection
+  defaultUECtxReq: false # the default value of UE Context Request to decide when triggering Initial Context Setup procedure
+
+logger: # log output setting
+  enable: true # true or false
+  level: info # how detailed to output, value: trace, debug, info, warn, error, fatal, panic
+  reportCaller: false # enable the caller report or not, value: true or false

--- a/bdd/mup-lab/gnb.yaml
+++ b/bdd/mup-lab/gnb.yaml
@@ -1,0 +1,40 @@
+gnb:
+  amfN2Ip: "10.0.1.1" # AMF N2 IP at core network
+  ranN2Ip: "10.0.1.2" # RAN N2 IP for connecting to AMF
+  upfN3Ip: "10.0.12.2" # UPF N3 IP at core network
+  ranN3Ip: "10.0.1.2" # RAN N3 IP for connecting to UPF
+
+  ranControlPlaneIp: "127.0.0.1"
+  ranDataPlaneIp: "127.0.0.1"
+
+  amfN2Port: 38412 # AMF N2 SCTP port at core network
+  ranN2Port: 38413 # RAN N2 SCTP port for connecting to AMF
+  upfN3Port: 2152 # UPF N3 GTP-U port at core network
+  ranN3Port: 2152 # RAN N3 GTP-U port for connecting to UPF
+
+  ranControlPlanePort: 31413 # RAN Control Plane port open for UE connection
+  ranDataPlanePort: 31414 # RAN Data Plane port open for UE connection
+
+  gnbId: "000314" # gNB ID
+  gnbName: "gNB" # gNB name
+
+  plmnId:
+    mcc: "208" # Mobile Country Code
+    mnc: "93" # Mobile Network Code
+
+  tai:
+    tac: "000001" # Tracking Area Code
+    broadcastPlmnId:
+      mcc: "208" # Mobile Country Code
+      mnc: "93" # Mobile Network Code
+
+  snssai:
+    sst: "1" # Slice/Service Type
+    sd: "010203" # Slice Differentiator
+
+  api:
+    ip: "10.0.1.2" # API for console usage
+    port: 40104 # API port for console usage
+
+logger:
+  level: "info" # error, warn, info, debug, trace, test

--- a/bdd/mup-lab/setup-topo.sh
+++ b/bdd/mup-lab/setup-topo.sh
@@ -1,0 +1,54 @@
+#!/bin/bash
+# Single-box free5GC + free-ran-ue + zebra-rs/cradle UPF lab topology.
+#
+#  host (root ns): free5GC CP on 127.0.0.x, mongodb, webconsole
+#   |- mrHost 10.0.1.1/24  <-veth->  mupran:mrVeth 10.0.1.2/24   (N2 + N3 transit)
+#   |- muHost 10.0.12.1/24 <-veth->  mupupf:mun3  10.0.12.2/24   (N4 + N3)
+#  mupran: free-ran-ue gNB (N2/N3 on 10.0.1.2, UE link on 127.0.0.1) + UE (TUN)
+#  mupupf: zebra-rs + cradle; VRF mobile-dl(table 1): mudl 10.0.61.1/24
+#                             VRF mobile-ul(table 2): muul 10.0.60.1/24
+#  mupdn:  mdnd 10.0.61.2/24 (downlink ingress), mdnu 10.0.60.2/24 (ping target)
+#          route 10.60.0.0/16 via 10.0.61.1
+set -ex
+
+ip netns add mupran
+ip netns add mupupf
+ip netns add mupdn
+
+ip link add mrHost type veth peer name mrVeth netns mupran
+ip link add muHost type veth peer name mun3 netns mupupf
+ip link add mudl netns mupupf type veth peer name mdnd netns mupdn
+ip link add muul netns mupupf type veth peer name mdnu netns mupdn
+
+# host side
+ip addr add 10.0.1.1/24 dev mrHost
+ip addr add 10.0.12.1/24 dev muHost
+ip link set mrHost up
+ip link set muHost up
+sysctl -wq net.ipv4.ip_forward=1
+
+# ran ns: gNB N2/N3 address; loopback for the gNB<->UE link
+ip netns exec mupran ip link set lo up
+ip netns exec mupran ip addr add 10.0.1.2/24 dev mrVeth
+ip netns exec mupran ip link set mrVeth up
+ip netns exec mupran ip route add default via 10.0.1.1
+
+# upf ns: only mun3 gets a kernel address here; mudl/muul are addressed and
+# VRF-enslaved by zebra-rs from upf.yaml. Kernel forwarding OFF: eBPF forwards.
+ip netns exec mupupf ip link set lo up
+ip netns exec mupupf ip addr add 10.0.12.2/24 dev mun3
+ip netns exec mupupf ip link set mun3 up
+ip netns exec mupupf ip link set mudl up
+ip netns exec mupupf ip link set muul up
+ip netns exec mupupf ip route add default via 10.0.12.1
+ip netns exec mupupf sysctl -wq net.ipv4.ip_forward=0
+
+# dn ns
+ip netns exec mupdn ip link set lo up
+ip netns exec mupdn ip addr add 10.0.61.2/24 dev mdnd
+ip netns exec mupdn ip addr add 10.0.60.2/24 dev mdnu
+ip netns exec mupdn ip link set mdnd up
+ip netns exec mupdn ip link set mdnu up
+ip netns exec mupdn ip route add 10.60.0.0/16 via 10.0.61.1
+
+echo "topology up"

--- a/bdd/mup-lab/smfcfg.yaml
+++ b/bdd/mup-lab/smfcfg.yaml
@@ -1,0 +1,125 @@
+info:
+  version: 1.0.7
+  description: SMF initial local configuration
+
+configuration:
+  smfName: SMF # the name of this SMF
+
+  # Service-based interface information
+  sbi:
+    scheme: http # the protocol for sbi (http or https)
+    registerIPv4: 127.0.0.2 # IP used to register to NRF
+    bindingIPv4: 127.0.0.2 # IP used to bind the service
+    port: 8000 # Port used to bind the service
+    tls: # the local path of TLS key
+      key: cert/smf.key # SMF TLS Certificate
+      pem: cert/smf.pem # SMF TLS Private key
+
+  # the SBI services provided by this SMF, refer to TS 29.502
+  serviceNameList:
+    - nsmf-pdusession # Nsmf_PDUSession service
+    - nsmf-event-exposure # Nsmf_EventExposure service
+    - nsmf-oam # OAM service
+
+  # the S-NSSAI (Single Network Slice Selection Assistance Information) list supported by this AMF
+  snssaiInfos:
+    - sNssai: # S-NSSAI (Single Network Slice Selection Assistance Information)
+        sst: 1 # Slice/Service Type (uinteger, range: 0~255)
+        sd: 010203 # Slice Differentiator (3 bytes hex string, range: 000000~FFFFFF)
+      dnnInfos: # DNN information list
+        - dnn: internet # Data Network Name
+          dns: # the IP address of DNS
+            ipv4: 8.8.8.8
+            ipv6: 2001:4860:4860::8888
+    - sNssai: # S-NSSAI (Single Network Slice Selection Assistance Information)
+        sst: 1 # Slice/Service Type (uinteger, range: 0~255)
+        sd: 112233 # Slice Differentiator (3 bytes hex string, range: 000000~FFFFFF)
+      dnnInfos: # DNN information list
+        - dnn: internet # Data Network Name
+          dns: # the IP address of DNS
+            ipv4: 8.8.8.8
+            ipv6: 2001:4860:4860::8888
+
+  # Optional: PLMN IDs configuration.
+  plmnList:
+    - mcc: 208 # Mobile Country Code (3 digits string, digit: 0~9)
+      mnc: 93 # Mobile Network Code (2 or 3 digits string, digit: 0~9)
+  locality: area1 # Name of the location where a set of AMF, SMF, PCF and UPFs are located
+
+  # PFCP (Packet Forwarding Control Protocol) configuration for N4 interface.
+  pfcp:
+    # addr config is deprecated in smf config v1.0.3, please use the following config
+    nodeID: 10.0.12.1 # the Node ID of this SMF
+    listenAddr: 10.0.12.1 # the IP/FQDN of N4 interface on this SMF (PFCP)
+    externalAddr: 10.0.12.1 # the IP/FQDN of N4 interface on this SMF (PFCP)
+    assocFailAlertInterval: 10s
+    assocFailRetryInterval: 30s
+    heartbeatInterval: 10s
+
+  # Userplane nodes information, specifying details for AN and UPF.
+  userplaneInformation:
+    upNodes: # information of userplane node (AN or UPF)
+      gNB1: # the name of the node
+        type: AN # the type of the node (AN or UPF)
+      UPF: # the name of the node
+        type: UPF # the type of the node (AN or UPF)
+        nodeID: 10.0.12.2 # the Node ID of this UPF
+        addr: 10.0.12.2 # the IP/FQDN of N4 interface on this UPF (PFCP)
+        sNssaiUpfInfos: # S-NSSAI information list for this UPF
+          - sNssai: # S-NSSAI (Single Network Slice Selection Assistance Information)
+              sst: 1 # Slice/Service Type (uinteger, range: 0~255)
+              sd: 010203 # Slice Differentiator (3 bytes hex string, range: 000000~FFFFFF)
+            dnnUpfInfoList: # DNN information list for this S-NSSAI
+              - dnn: internet
+                pools:
+                  - cidr: 10.60.0.0/16
+                staticPools:
+                  - cidr: 10.60.100.0/24
+          - sNssai: # S-NSSAI (Single Network Slice Selection Assistance Information)
+              sst: 1 # Slice/Service Type (uinteger, range: 0~255)
+              sd: 112233 # Slice Differentiator (3 bytes hex string, range: 000000~FFFFFF)
+            dnnUpfInfoList: # DNN information list for this S-NSSAI
+              - dnn: internet
+                pools:
+                  - cidr: 10.61.0.0/16
+                staticPools:
+                  - cidr: 10.61.100.0/24
+        # The IP address for the N3 interface must match the IP bound in the UPF N3 interface.
+        # If UPF binds to a specific IP, set that same IP here.
+        # If UPF binds to all IPs (0.0.0.0), you can set any of the available UPF IPs here.
+        # Do NOT set 0.0.0.0 as this is not a valid routable address.
+        interfaces: # Interface list for this UPF
+          - interfaceType: N3 # the type of the interface (N3 or N9)
+            endpoints: # the IP address of this N3/N9 interface on this UPF
+              - 10.0.12.2
+            networkInstances: # Data Network Name (DNN)
+              - internet
+
+    # the topology graph of userplane, A and B represent the two nodes of each link
+    links:
+      - A: gNB1
+        B: UPF
+
+  # retransmission timer for PDU session modification command
+  t3591:
+    enable: true # true or false
+    expireTime: 16s # default is 6 seconds
+    maxRetryTimes: 3 # the max number of retransmission
+
+  # retransmission timer for PDU session release command
+  t3592:
+    enable: true # true or false
+    expireTime: 16s # default is 6 seconds
+    maxRetryTimes: 3 # the max number of retransmission
+
+  nrfUri: http://127.0.0.10:8000 # a valid URI of NRF
+  nrfCertPem: cert/nrf.pem # NRF Certificate
+  urrPeriod: 30 # default usage report period in seconds
+  urrThreshold: 500000 # default usage report threshold in bytes
+  requestedUnit: 1000
+
+# Logging Configuration
+logger:
+  enable: true # true or false
+  level: info # how detailed to output, value: trace, debug, info, warn, error, fatal, panic
+  reportCaller: false # enable the caller report or not, value: true or false

--- a/bdd/mup-lab/teardown-topo.sh
+++ b/bdd/mup-lab/teardown-topo.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+# Tear down the mup-lab topology and processes.
+set -x
+pkill -x free-ran-ue || true
+[ -f /tmp/mupupf_zebra.pid ] && kill "$(cat /tmp/mupupf_zebra.pid)" 2>/dev/null
+[ -f /tmp/mupupf_cradle.pid ] && kill "$(cat /tmp/mupupf_cradle.pid)" 2>/dev/null
+sleep 1
+ip netns del mupran 2>/dev/null
+ip netns del mupupf 2>/dev/null
+ip netns del mupdn 2>/dev/null
+ip link del mrHost 2>/dev/null
+ip link del muHost 2>/dev/null
+echo "topology down"

--- a/bdd/mup-lab/ue.yaml
+++ b/bdd/mup-lab/ue.yaml
@@ -1,0 +1,45 @@
+ue:
+  ranControlPlaneIp: "127.0.0.1"
+  ranDataPlaneIp: "127.0.0.1"
+
+  ranControlPlanePort: 31413 # RAN Control Plane port open for UE connection
+  ranDataPlanePort: 31414 # RAN Data Plane port open for UE connection
+
+  plmnId:
+    mcc: "208" # Mobile Country Code
+    mnc: "93" # Mobile Network Code
+  msin: "0000000001" # MSIN
+
+  authenticationSubscription:
+    encPermanentKey: "8baf473f2f8fd09487cccbd7097c6862" # Encrypted Permanent Key
+    encOpcKey: "8e27b6af0e692e750f32667a3b14605d" # Encrypted OPC Key
+    authenticationManagementField: "8000" # Authentication Management Field
+    sequenceNumber: "000000000023" # Sequence Number
+
+  integrityAlgorithm:
+    nia0: false # Integrity Algorithm 0
+    nia1: false # Integrity Algorithm 1
+    nia2: true # Integrity Algorithm 2
+    nia3: false # Integrity Algorithm 3
+  cipheringAlgorithm:
+    nea0: true # Ciphering Algorithm 0
+    nea1: false # Ciphering Algorithm 1
+    nea2: false # Ciphering Algorithm 2
+    nea3: false # Ciphering Algorithm 3
+
+  pduSession:
+    dnn: "internet" # DNN
+    snssai:
+      sst: "1" # Slice/Service Type
+      sd: "010203" # Slice Differentiator
+
+  accessType: "3GPP_ACCESS" # 3GPP_ACCESS, NON_3GPP_ACCESS
+
+  nrdc:
+    enable: false # Enable NRDC
+
+  ueTunnelDevice: "ueTun" # UE Tunnel Device Name
+  ignoreSetupTunnel: false # Ignore Setup Tunnel
+
+logger:
+  level: "info" # error, warn, info, debug, trace

--- a/bdd/mup-lab/upf-ports.json
+++ b/bdd/mup-lab/upf-ports.json
@@ -1,0 +1,7 @@
+{
+  "ports": [
+    { "name": "mun3", "l3": true },
+    { "name": "mudl", "l3": true, "vrf": 1 },
+    { "name": "muul", "l3": true, "vrf": 2 }
+  ]
+}

--- a/bdd/mup-lab/upf.yaml
+++ b/bdd/mup-lab/upf.yaml
@@ -1,0 +1,54 @@
+system:
+  cradle:
+    enabled: true
+vrf:
+- name: mobile-dl
+- name: mobile-ul
+interface:
+- if-name: lo
+  ipv6:
+    address: 2001:db8::1/128
+- if-name: mun3
+  ipv4:
+    address: 10.0.12.2/24
+- if-name: mudl
+  vrf: mobile-dl
+  ipv4:
+    address: 10.0.61.1/24
+- if-name: muul
+  vrf: mobile-ul
+  ipv4:
+    address: 10.0.60.1/24
+router:
+  static:
+    ipv4:
+      route:
+      - prefix: 10.0.1.0/24
+        nexthop:
+        - address: 10.0.12.1
+  bgp:
+    global:
+      as: 65000
+      router-id: 1.1.1.1
+    vrf:
+    - name: mobile-dl
+      rd: "65000:1"
+      afi-safi:
+        mup:
+          dataplane: gtp
+          route:
+          - type: st1
+            network-instance: internet
+    - name: mobile-ul
+      rd: "65000:2"
+      afi-safi:
+        mup:
+          dataplane: gtp
+          route:
+          - type: st2
+            network-instance: internet
+    mup-c:
+      enabled: true
+      controller-address: 2001:db8::1
+      pfcp:
+        listen-address: 10.0.12.2

--- a/tools/pfcp-inject/src/main.rs
+++ b/tools/pfcp-inject/src/main.rs
@@ -24,6 +24,7 @@ use rs_pfcp::ie::apply_action::ApplyAction;
 use rs_pfcp::ie::create_far::CreateFar;
 use rs_pfcp::ie::create_pdr::CreatePdrBuilder;
 use rs_pfcp::ie::destination_interface::{DestinationInterface, Interface};
+use rs_pfcp::ie::f_teid::FteidBuilder;
 use rs_pfcp::ie::far_id::FarId;
 use rs_pfcp::ie::forwarding_parameters::ForwardingParameters;
 use rs_pfcp::ie::fseid::Fseid;
@@ -86,6 +87,17 @@ struct Args {
     /// `--core-endpoint` is set.
     #[arg(long, default_value_t = 0x8765_4321, value_parser = parse_u32)]
     core_teid: u32,
+
+    /// The UPF's own uplink *receive* F-TEID address, CP-allocated
+    /// (TS 29.244 CH=0): sent in the Access PDR's PDI local F-TEID, the way
+    /// free5GC programs a UPF's N3 tunnel. Authoritative for the Type-2 ST
+    /// on the controller. Requires `--n3-teid`.
+    #[arg(long, requires = "n3_teid")]
+    n3_endpoint: Option<IpAddr>,
+
+    /// TEID paired with `--n3-endpoint` (decimal, or `0x`-prefixed hex).
+    #[arg(long, value_parser = parse_u32)]
+    n3_teid: Option<u32>,
 
     /// Network Instance (APN/DNN) — matched against a VRF `mup`
     /// config on the controller.
@@ -164,11 +176,20 @@ fn main() -> Result<()> {
     // Type-1 ST route, an optional core-facing tunnel for the Type-2 ST route.
     // This mirrors the real 5G model (the gNB F-TEID is programmed in the
     // downlink FAR, not the PDI), which the controller extracts from.
-    let pdi = PdiBuilder::new(SourceInterface::new(SourceInterfaceValue::Access))
+    let mut pdi_builder = PdiBuilder::new(SourceInterface::new(SourceInterfaceValue::Access))
         .ue_ip_address(UeIpAddress::new(args.ue_ipv4, args.ue_ipv6))
-        .network_instance(NetworkInstance::new(&args.network_instance))
-        .build()
-        .context("build PDI")?;
+        .network_instance(NetworkInstance::new(&args.network_instance));
+    // The CP-allocated local N3 F-TEID (free5GC style): the uplink tunnel
+    // the UPF must terminate, carried in the Access PDR's PDI.
+    if let (Some(ep), Some(teid)) = (args.n3_endpoint, args.n3_teid) {
+        let b = FteidBuilder::new().teid(teid);
+        let b = match ep {
+            IpAddr::V4(v4) => b.ipv4(v4),
+            IpAddr::V6(v6) => b.ipv6(v6),
+        };
+        pdi_builder = pdi_builder.f_teid(b.build().context("build PDI F-TEID")?);
+    }
+    let pdi = pdi_builder.build().context("build PDI")?;
     let pdr = CreatePdrBuilder::new(PdrId::new(1))
         .precedence(Precedence::new(100))
         .pdi(pdi)

--- a/zebra-rs/src/config/manager.rs
+++ b/zebra-rs/src/config/manager.rs
@@ -1867,9 +1867,7 @@ mod yang_load_tests {
 
         for cmd in [
             "set router bgp vrf N3 afi-safi mup dataplane end-dt46",
-            // `dataplane gtp` is commented out in zebra-bgp-vrf.yang (the
-            // real GTP-U path needs the cradle eBPF forwarder, not yet
-            // wired), so it is intentionally not a settable path here.
+            "set router bgp vrf N3 afi-safi mup dataplane gtp",
             "set router bgp vrf N3 afi-safi mup segment direct",
             "set router bgp vrf N3 afi-safi mup segment interwork",
             "set router bgp vrf N3 afi-safi mup segment direct mup-ext-comm 1:20",

--- a/zebra-rs/src/mup-c/pfcp.rs
+++ b/zebra-rs/src/mup-c/pfcp.rs
@@ -26,6 +26,7 @@ use rs_pfcp::ie::fseid::Fseid;
 use rs_pfcp::ie::node_id::NodeId;
 use rs_pfcp::ie::outer_header_creation::OuterHeaderCreation;
 use rs_pfcp::ie::pdr_id::PdrId;
+use rs_pfcp::ie::source_interface::SourceInterfaceValue;
 use rs_pfcp::ie::update_far::UpdateFar;
 use rs_pfcp::message::association_release_response::AssociationReleaseResponseBuilder;
 use rs_pfcp::message::association_setup_response::AssociationSetupResponseBuilder;
@@ -272,47 +273,67 @@ impl MupC {
             network_instance: ex.network_instance,
             qfi: None,
         };
-        // Core (N9) tunnel for the ST2 (decapsulation / uplink) route. Its
-        // endpoint + TEID identify the *core* GTP-U tunnel uplink traffic is
-        // decapsulated toward; the access/gNB tunnel is never borrowed (wrong
-        // direction). Resolved in three tiers, most-specific first, endpoint
-        // and TEID independently:
+        // Core tunnel for the ST2 (decapsulation / uplink) route: the GTP-U
+        // tunnel the mobile system sends uplink into, i.e. the tunnel this
+        // UPF terminates (the datapath keys the uplink decap PDR on it). The
+        // access/gNB tunnel is never borrowed (wrong direction). Resolved in
+        // four tiers, most-specific first:
+        //   0. CP-allocated (TS 29.244 CH=0) — the Access PDR's PDI local
+        //      F-TEID. The SMF hands this same TEID to the gNB as the uplink
+        //      target (free5GC allocates every UPF N3 TEID this way and
+        //      ignores the Created PDR), so when present nothing else may
+        //      key the tunnel.
         //   1. learned over PFCP — a Dest = Core FAR Outer Header Creation, a
         //      real N9 tunnel to a downstream anchor. Already on the session.
         //   2. the statically configured anchor: `upf-address` + `upf-teid`.
         //   3. self-allocated — MUP-U *is* the anchor UPF, so it owns the core
-        //      receive F-TEID: its own address (`local_ip`) plus a fresh TEID
-        //      from the same pool as the N3 F-TEID. A real UPF allocates the
-        //      TEIDs of the tunnels it terminates; today (control-plane only)
-        //      this is a nominal value like the N3 one, and a real datapath
-        //      must install it. `local_ip` mirrors the N3 F-TEID's address; a
-        //      full deployment would use the interwork gateway's N9 endpoint
-        //      (a future config knob).
+        //      receive F-TEID: its own address (`local_ip`) plus a fresh
+        //      TEID. A real UPF allocates the TEIDs of the tunnels it
+        //      terminates.
         // teid 0 is the null TEID and never a valid tunnel, so a learned or
         // configured 0 self-allocates too — an ST2 always carries a non-zero
         // core TEID.
-        session.core_endpoint = session
-            .core_endpoint
-            .or(self.config.upf_address)
-            .or(Some(self.local_ip()));
-        if session.core_teid == 0 {
-            session.core_teid = match self.config.upf_teid {
-                Some(teid) if teid != 0 => teid,
-                _ => self.sessions.alloc_teid(),
-            };
+        let cp_allocated = ex.n3_local;
+        // Non-zero only when learned over PFCP (a Dest = Core FAR OHC).
+        let learned_core = session.core_teid != 0;
+        if let Some((teid, addr)) = cp_allocated {
+            session.core_teid = teid;
+            session.core_endpoint = Some(addr);
+        } else {
+            session.core_endpoint = session
+                .core_endpoint
+                .or(self.config.upf_address)
+                .or(Some(self.local_ip()));
+            if !learned_core {
+                session.core_teid = match self.config.upf_teid {
+                    Some(teid) if teid != 0 => teid,
+                    _ => self.sessions.alloc_teid(),
+                };
+            }
         }
         self.sessions.insert(session.clone());
 
         let local_ip = self.local_ip();
-        // UPF role: allocate our N3 F-TEID and return it in a Created PDR (PDR
-        // id 1). The SMF reads the UP-side N3 F-TEID from the establishment
-        // response's Created PDR (TS 29.244 §7.5.3) and hands it to the gNB as
-        // the uplink tunnel target — without it the CP cannot complete the PDU
-        // session. The address is the controller's own (`local_ip`); a full
-        // MUP deployment would advertise the interwork gateway's N3 endpoint
-        // here (a future config knob).
-        let n3_teid = self.sessions.alloc_teid();
-        let reply = build_establishment_response(cp_seid, seq, seid, local_ip, n3_teid);
+        // UPF role: return our N3 F-TEID in a Created PDR (PDR id 1). The SMF
+        // reads the UP-side N3 F-TEID from the establishment response's
+        // Created PDR (TS 29.244 §7.5.3) and hands it to the gNB as the
+        // uplink tunnel target — without it the CP cannot complete the PDU
+        // session. When the core F-TEID is ours (CP-allocated, configured
+        // anchor, or self-anchored — the UPF itself terminates the uplink
+        // tunnel), the N3 F-TEID must be the SAME tunnel the ST2 describes:
+        // the datapath keys the uplink decap PDR (`H.M.GTP4.D`) on the ST2's
+        // endpoint+TEID, so a gNB handed anything else sends uplink into a
+        // tunnel no PDR matches. Only a core F-TEID learned over PFCP (a
+        // downstream anchor's N9 tunnel, not a tunnel we terminate) keeps a
+        // separate nominal N3 allocation.
+        let (n3_ip, n3_teid) = if let Some((teid, addr)) = cp_allocated {
+            (addr, teid)
+        } else if learned_core {
+            (local_ip, self.sessions.alloc_teid())
+        } else {
+            (session.core_endpoint.unwrap_or(local_ip), session.core_teid)
+        };
+        let reply = build_establishment_response(cp_seid, seq, seid, local_ip, n3_ip, n3_teid);
         (reply, vec![MupCEvent::SessionUp(session)])
     }
 
@@ -376,7 +397,12 @@ impl MupC {
             session.teid = 0;
             session.endpoint = None;
         }
-        if let Some((t, e)) = ex.core {
+        if let Some((t, e)) = ex.n3_local {
+            // CP-(re)allocated uplink receive F-TEID — authoritative (see
+            // the establishment tiers).
+            session.core_teid = t;
+            session.core_endpoint = Some(e);
+        } else if let Some((t, e)) = ex.core {
             session.core_teid = t;
             session.core_endpoint = Some(e);
         }
@@ -421,21 +447,24 @@ impl MupC {
     }
 }
 
-/// Build an accepted Session Establishment Response carrying our allocated N3
-/// F-TEID in a Created PDR (PDR id 1). The SMF reads the UP-side N3 F-TEID
-/// from here to give the gNB an uplink target. The response header SEID = the
-/// CP's F-SEID (so the SMF correlates it); our own SEID rides only in the
-/// F-SEID IE. Returns `None` if the codec fails to build the message.
+/// Build an accepted Session Establishment Response carrying our N3 F-TEID
+/// (`n3_ip` + `n3_teid` — the uplink tunnel we terminate) in a Created PDR
+/// (PDR id 1). The SMF reads the UP-side N3 F-TEID from here to give the gNB
+/// an uplink target. `node_ip` is the N4 identity (Node ID + F-SEID address)
+/// and may differ from `n3_ip`. The response header SEID = the CP's F-SEID
+/// (so the SMF correlates it); our own SEID rides only in the F-SEID IE.
+/// Returns `None` if the codec fails to build the message.
 fn build_establishment_response(
     cp_seid: u64,
     seq: SequenceNumber,
     up_seid: u64,
     node_ip: IpAddr,
+    n3_ip: IpAddr,
     n3_teid: u32,
 ) -> Option<Vec<u8>> {
     let fteid = {
         let b = FteidBuilder::new().teid(n3_teid);
-        let b = match node_ip {
+        let b = match n3_ip {
             IpAddr::V4(v4) => b.ipv4(v4),
             IpAddr::V6(v6) => b.ipv6(v6),
         };
@@ -531,6 +560,14 @@ struct PfcpExtract {
     /// tunnel (e.g. an N9 to an anchor UPF). Drives the Type-2 ST route.
     /// Absent for a plain N6 breakout, which has no core-side GTP tunnel.
     core: Option<(u32, IpAddr)>,
+    /// The UPF's own uplink *receive* F-TEID when the CP allocated it
+    /// (TS 29.244 CH=0): the Access-side PDR's PDI local F-TEID. The SMF
+    /// hands this same TEID to the gNB as the uplink target (free5GC
+    /// allocates all UPF N3 TEIDs this way and ignores the Created PDR), so
+    /// when present it is authoritative for the Type-2 ST route / uplink
+    /// decap PDR. Absent when the CP asks the UP to choose (CH=1) or sends
+    /// no PDI F-TEID.
+    n3_local: Option<(u32, IpAddr)>,
     /// The message deactivated the downlink: an Update FAR switched to
     /// BUFF/DROP with no new Outer Header Creation (the AN-release / UE-idle
     /// flow). The gNB tunnel is torn down, so the Type-1 ST route must be
@@ -585,20 +622,22 @@ fn apply_far_ohc(
 /// Modification message.
 ///
 /// UE IP and Network Instance come from the Create PDRs (matched by UE
-/// address / carried per-PDI). The GTP-U tunnel endpoints come from the
-/// **FARs' Outer Header Creation**, *not* the PDI F-TEIDs — this is the key
-/// correctness point (draft-ietf-bess-mup-safi §3.2.1 / TS 29.244):
+/// address / carried per-PDI). The *remote* GTP-U tunnel endpoints come from
+/// the **FARs' Outer Header Creation** (draft-ietf-bess-mup-safi §3.2.1 /
+/// TS 29.244):
 ///
 ///   * The Type-1 ST route's endpoint is the **gNB** (the access-side tunnel
 ///     the PE encapsulates downlink traffic toward). In PFCP that gNB F-TEID
 ///     lives in the **downlink FAR's Outer Header Creation** (Destination
 ///     Interface = Access), which the SMF programs from the N2 setup — often
-///     only in a later Session Modification. The Access-side PDI F-TEID is the
-///     UPF's *own* N3 receive endpoint (where the gNB sends uplink), which is
-///     neither the gNB nor the core anchor, so it is deliberately ignored.
-///   * The Type-2 ST route's endpoint is the **core**-side GTP tunnel, from a
-///     FAR bound for the Core interface — present only when the UPF has a
-///     core-facing GTP tunnel (N9 / interworking), absent for N6 breakout.
+///     only in a later Session Modification. It never comes from a PDI
+///     F-TEID (that is the UPF's own side, not the gNB).
+///   * The Type-2 ST route's endpoint is the tunnel this UPF *terminates*
+///     for uplink. When the CP allocates the UPF's N3 F-TEID itself
+///     (TS 29.244 CH=0 — free5GC always does), it arrives in the
+///     **Access-side PDR's PDI local F-TEID** and is authoritative
+///     (`n3_local`). A FAR bound for the Core interface instead carries a
+///     core-facing tunnel (N9 / interworking) toward a downstream anchor.
 fn extract_pfcp(msg: &dyn PfcpMessage) -> PfcpExtract {
     let mut ex = PfcpExtract::default();
     // UE IP + Network Instance from the PDRs (source-interface-agnostic).
@@ -619,6 +658,21 @@ fn extract_pfcp(msg: &dyn PfcpMessage) -> PfcpExtract {
             && let Some(ni) = &pdi.network_instance
         {
             ex.network_instance = Some(ni.instance.clone());
+        }
+        // The Access PDR's PDI local F-TEID: the CP-allocated (CH=0) uplink
+        // receive tunnel. The remote tunnels stay FAR-OHC-only (below); this
+        // one is *ours* and keys the uplink decap.
+        if ex.n3_local.is_none()
+            && pdi.source_interface.value == SourceInterfaceValue::Access
+            && let Some(f) = &pdi.f_teid
+            && !f.ch
+            && f.teid.value() != 0
+            && let Some(addr) = f
+                .ipv4_address
+                .map(IpAddr::V4)
+                .or(f.ipv6_address.map(IpAddr::V6))
+        {
+            ex.n3_local = Some((f.teid.value(), addr));
         }
     }
     // GTP-U tunnel endpoints from the FARs' Outer Header Creation.
@@ -730,12 +784,12 @@ mod tests {
             .unwrap()
     }
 
-    /// A Session Establishment Request carrying UE IPv4 + Network Instance in a
-    /// PDR, the UPF's *own* N3 F-TEID in that PDR's PDI (a red herring the
-    /// controller must IGNORE — it is the UPF address, not the gNB), and the
-    /// gNB tunnel in a downlink FAR's Outer Header Creation (Destination
-    /// Interface = Access) — the endpoint the controller must pick for the
-    /// Type-1 ST route.
+    /// A Session Establishment Request carrying UE IPv4 + Network Instance in
+    /// a PDR, the UPF's *own* CP-allocated N3 receive F-TEID in that PDR's
+    /// PDI (TS 29.244 CH=0 — authoritative for the uplink tunnel: free5GC
+    /// hands this same TEID to the gNB), and the gNB tunnel in a downlink
+    /// FAR's Outer Header Creation (Destination Interface = Access) — the
+    /// endpoint the controller must pick for the Type-1 ST route.
     fn establishment_bytes() -> Vec<u8> {
         let upf_n3 = FteidBuilder::new()
             .teid(0xDEAD_BEEFu32)
@@ -744,6 +798,37 @@ mod tests {
             .unwrap();
         let pdi = PdiBuilder::new(SourceInterface::new(SourceInterfaceValue::Access))
             .f_teid(upf_n3)
+            .ue_ip_address(UeIpAddress::new(Some(Ipv4Addr::new(192, 0, 2, 5)), None))
+            .network_instance(NetworkInstance::new("internet.apn"))
+            .build()
+            .unwrap();
+        let pdr = CreatePdrBuilder::new(PdrId::new(1))
+            .precedence(Precedence::new(100))
+            .pdi(pdi)
+            .far_id(FarId::new(1))
+            .build()
+            .unwrap();
+        let far = gtpu_far(
+            1,
+            Interface::Access,
+            0x1234_5678,
+            Ipv4Addr::new(10, 0, 0, 1),
+        );
+        SessionEstablishmentRequestBuilder::new(0u64, 1u32)
+            .node_id(Ipv4Addr::new(10, 0, 0, 2))
+            .fseid(0x1111u64, Ipv4Addr::new(10, 0, 0, 2))
+            .create_pdrs(vec![pdr.to_ie()])
+            .create_fars(vec![far.to_ie()])
+            .build()
+            .unwrap()
+            .marshal()
+    }
+
+    /// Like [`establishment_bytes`] but with no PDI F-TEID: the CP left the
+    /// uplink F-TEID allocation to the UP (or omitted it), so the lower
+    /// resolution tiers (configured anchor / self-allocation) apply.
+    fn establishment_no_local_fteid_bytes() -> Vec<u8> {
+        let pdi = PdiBuilder::new(SourceInterface::new(SourceInterfaceValue::Access))
             .ue_ip_address(UeIpAddress::new(Some(Ipv4Addr::new(192, 0, 2, 5)), None))
             .network_instance(NetworkInstance::new("internet.apn"))
             .build()
@@ -808,7 +893,7 @@ mod tests {
         associate(&mut mupc);
         let bytes = establishment_two_endpoints_bytes();
         let msg = message::parse(&bytes).unwrap();
-        let (_reply, events) = mupc.handle_session_establishment(msg.as_ref(), peer());
+        let (reply, events) = mupc.handle_session_establishment(msg.as_ref(), peer());
         let MupCEvent::SessionUp(session) = &events[0] else {
             panic!("expected SessionUp, got {:?}", events[0]);
         };
@@ -823,6 +908,20 @@ mod tests {
         assert_eq!(
             session.core_endpoint,
             Some(IpAddr::V4(Ipv4Addr::new(10, 9, 0, 1)))
+        );
+        // A learned core F-TEID is a downstream anchor's N9 tunnel, not one
+        // we terminate — the N3 F-TEID stays a separate own allocation.
+        let resp = message::parse(&reply.expect("a response")).unwrap();
+        let created = resp
+            .ies(IeType::CreatedPdr)
+            .next()
+            .and_then(|ie| CreatedPdr::unmarshal(&ie.payload).ok())
+            .expect("establishment response must carry a Created PDR");
+        assert_ne!(created.f_teid.teid.value(), 0);
+        assert_ne!(
+            created.f_teid.teid.value(),
+            0x8765_4321,
+            "learned N9 core TEID must not be echoed as our N3 F-TEID"
         );
     }
 
@@ -1014,10 +1113,54 @@ mod tests {
             .and_then(|ie| CreatedPdr::unmarshal(&ie.payload).ok())
             .expect("establishment response must carry a Created PDR");
         assert_ne!(created.f_teid.teid.value(), 0, "N3 F-TEID must be non-zero");
+        // The CP allocated the uplink F-TEID (PDI local F-TEID, CH=0): it is
+        // authoritative — the SMF hands that same TEID to the gNB — so both
+        // the ST2 core tunnel and the echoed Created PDR must carry it.
+        assert_eq!(session.core_teid, 0xDEAD_BEEF);
+        assert_eq!(
+            session.core_endpoint,
+            Some(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 8)))
+        );
+        assert_eq!(created.f_teid.teid.value(), 0xDEAD_BEEF);
         assert_eq!(
             created.f_teid.ipv4_address,
-            Some(Ipv4Addr::LOCALHOST),
-            "N3 F-TEID address = controller local_ip (default 127.0.0.1)"
+            Some(Ipv4Addr::new(127, 0, 0, 8)),
+            "Created PDR echoes the CP-allocated N3 F-TEID"
+        );
+        // The N3 F-TEID handed to the SMF IS the tunnel the ST2 describes —
+        // the gNB sends uplink with this TEID, and the datapath keys the
+        // decap PDR on the ST2's endpoint+TEID. Anything else sends every
+        // uplink packet into an unmatched tunnel.
+        assert_eq!(
+            created.f_teid.teid.value(),
+            session.core_teid,
+            "Created PDR N3 TEID must equal the ST2 core TEID"
+        );
+    }
+
+    /// The self-anchored tiers (Created-PDR allocation) apply only when the
+    /// CP did not allocate the uplink F-TEID itself. When it did (PDI local
+    /// F-TEID, CH=0), that tunnel wins over a configured `upf-address` /
+    /// `upf-teid` too.
+    #[test]
+    fn cp_allocated_n3_fteid_beats_configured_anchor() {
+        let cfg = MupCConfig {
+            upf_address: Some(IpAddr::V4(Ipv4Addr::new(10, 100, 0, 1))),
+            upf_teid: Some(0x0102_0304),
+            ..Default::default()
+        };
+        let (mut mupc, _bgp_rx) = MupC::new_for_test(cfg);
+        associate(&mut mupc);
+        let est = message::parse(&establishment_bytes()).unwrap();
+        let (_reply, events) = mupc.handle_session_establishment(est.as_ref(), peer());
+        let MupCEvent::SessionUp(session) = &events[0] else {
+            panic!("expected SessionUp");
+        };
+        assert_eq!(session.core_teid, 0xDEAD_BEEF);
+        assert_eq!(
+            session.core_endpoint,
+            Some(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 8))),
+            "CP-allocated local F-TEID beats the configured anchor"
         );
     }
 
@@ -1033,10 +1176,10 @@ mod tests {
         };
         let (mut mupc, _bgp_rx) = MupC::new_for_test(cfg);
         associate(&mut mupc);
-        // establishment_bytes carries a gNB tunnel (Access FAR OHC) but no
-        // core-side tunnel.
-        let est = message::parse(&establishment_bytes()).unwrap();
-        let (_reply, events) = mupc.handle_session_establishment(est.as_ref(), peer());
+        // A gNB tunnel (Access FAR OHC) but no core-side tunnel and no
+        // CP-allocated local F-TEID.
+        let est = message::parse(&establishment_no_local_fteid_bytes()).unwrap();
+        let (reply, events) = mupc.handle_session_establishment(est.as_ref(), peer());
         let MupCEvent::SessionUp(session) = &events[0] else {
             panic!("expected SessionUp");
         };
@@ -1053,6 +1196,21 @@ mod tests {
         assert_eq!(
             session.endpoint,
             Some(IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1)))
+        );
+        // The configured anchor is a tunnel WE terminate, so the N3 F-TEID
+        // handed to the SMF must be that same tunnel, not a fresh allocation
+        // at the N4 address.
+        let resp = message::parse(&reply.expect("a response")).unwrap();
+        let created = resp
+            .ies(IeType::CreatedPdr)
+            .next()
+            .and_then(|ie| CreatedPdr::unmarshal(&ie.payload).ok())
+            .expect("establishment response must carry a Created PDR");
+        assert_eq!(created.f_teid.teid.value(), 0x0102_0304);
+        assert_eq!(
+            created.f_teid.ipv4_address,
+            Some(Ipv4Addr::new(10, 100, 0, 1)),
+            "Created PDR F-TEID address = configured upf-address"
         );
     }
 
@@ -1087,9 +1245,9 @@ mod tests {
     fn anchor_upf_self_allocates_core_teid() {
         let (mut mupc, _bgp_rx) = MupC::new_for_test(MupCConfig::default());
         associate(&mut mupc);
-        // A gNB tunnel (access teid 0x1234_5678) but no core tunnel, and no
-        // upf-address / upf-teid configured.
-        let est = message::parse(&establishment_bytes()).unwrap();
+        // A gNB tunnel (access teid 0x1234_5678) but no core tunnel, no
+        // CP-allocated local F-TEID, and no upf-address / upf-teid configured.
+        let est = message::parse(&establishment_no_local_fteid_bytes()).unwrap();
         let (_reply, events) = mupc.handle_session_establishment(est.as_ref(), peer());
         let MupCEvent::SessionUp(session) = &events[0] else {
             panic!("expected SessionUp");

--- a/zebra-rs/yang/zebra-bgp-vrf.yang
+++ b/zebra-rs/yang/zebra-bgp-vrf.yang
@@ -330,13 +330,13 @@ module zebra-bgp-vrf {
                  control plane only. Works on stock Linux. This is the
                  default.";
             }
-            // enum gtp {
-            //   description
-            //     "Real GTP-U: install the tunnel from the ST route's endpoint
-            //      and TEID via the cradle eBPF forwarder (GTP4.E downlink /
-            //      H.M.GTP4.D uplink). Requires `system cradle grpc-endpoint` to point at
-            //      the forwarder; the mainline kernel has no GTP action.";
-            // }
+            enum gtp {
+              description
+                "Real GTP-U: install the tunnel from the ST route's endpoint
+                 and TEID via the cradle eBPF forwarder (GTP4.E downlink /
+                 H.M.GTP4.D uplink). Requires `system cradle grpc-endpoint` to point at
+                 the forwarder; the mainline kernel has no GTP action.";
+            }
           }
           default end-dt46;
           description


### PR DESCRIPTION
Takes the MUP `dataplane gtp` UPF from synthetic-proven to a real end-to-end UE ping against **free5GC + free-ran-ue** on a single box (issue #1930). Together with cradle-rs#147 (GTP header-shape decap + address-monitor route re-derivation, merged), a UE's `ueTun0` pings the data network through real N3 GTP-U with 0% loss.

## mup-c: honor the CP-allocated N3 F-TEID (TS 29.244 CH=0)

free5GC's SMF allocates the UPF's uplink receive F-TEID itself, sends it in the Access PDR's **PDI local F-TEID**, and hands the same TEID to the gNB over NGAP — ignoring the Created-PDR F-TEID the UP returns. We treated the PDI F-TEID as a red herring and keyed the ST2 (and so the uplink `H.M.GTP4.D` decap PDR) on a self-allocated TEID, so no uplink G-PDU could ever match: on the wire the gNB used TEID 6 while the PDR was keyed on TEID 2 — the reporter's "0 decaps". `extract_pfcp` now captures it as `n3_local`, tier 0 of the core-tunnel resolution (above a learned Core FAR OHC, the configured `upf-address`/`upf-teid`, and self-allocation), honored on Modification too. The self-allocated tier now returns the SAME tunnel in the Created PDR instead of a second unrelated allocation.

## Also here

- **`dataplane gtp` YANG enum re-enabled** (was commented out while the datapath landed; it is proven now).
- **pfcp-inject `--n3-endpoint/--n3-teid`**: reproduces free5GC's PDI-local-F-TEID wire shape; drives cradle-rs's new `@cradle_mup_gtp_roundtrip` BDD feature (one PFCP session fanning out to both ST routes, real round-trip ICMP through the GTP tunnel).
- **`bdd/mup-lab/`**: the manual free5GC + free-ran-ue lab (topology scripts, all configs, README with the full bring-up/verify/teardown recipe) that first proved the ping.

## Test plan

- `cargo test --workspace --exclude bdd`: 2235 passed, 0 failed (includes new/updated mup-c unit tests: CP-allocated tier beats the configured anchor, Created-PDR echo, self-anchored unification; 46 mup tests).
- `cargo clippy --workspace --exclude bdd`: clean.
- Live: cradle-rs `@cradle_mup_gtp_roundtrip` 4/4 and pre-existing `@cradle_mup_gtp_zebra` 4/4 against this branch's zebra-rs + pfcp-inject.
- Live: full free5GC v4.0.1 + free-ran-ue stack — PFCP association/session, ST1/ST2 origination, UE ping 20/20 (0% loss), `gtp_encap`/`gtp_decap` counting on both directions.

Generated with [Claude Code](https://claude.com/claude-code)