### PR TITLE
bdd/mup-lab: ship free-ran-ue N3 crash-fix patch + apply steps

### DIFF
--- a/bdd/mup-lab/README.md
+++ b/bdd/mup-lab/README.md
@@ -42,18 +42,24 @@ Key design points
 ## Prerequisites
 
 ```sh
-# zebra-rs (this repo, with the mup-c n3_local fix) + vtyctl
-cargo build -p zebra-rs -p vtyctl
+# zebra-rs (install nightly)
+# URL: https://github.com/zebra-rs/zebra-rs/releases/tag/nightly
 
-# cradle (branch with the GTP header-shape decap + address monitor, PR cradle-rs#147)
-cd ~/cradle-rs && cargo build
+# cradle (install nightly)
+# URL: https://github.com/cradle-rs/cradle-rs/releases/tag/nightly
 
 # free5GC v4.0.1 CP NFs + webconsole backend (Go >= 1.21; no gtp5g needed — we ARE the UPF)
 cd ~/free5gc && make nrf smf udr udm ausf nssf pcf chf   # amf: use prebuilt bin/amf
 cd webconsole && go build -o bin/webconsole server.go
 
-# free-ran-ue (Go 1.26 via auto-toolchain; includes the N3 crash fix, PR free-ran-ue#326)
-cd ~/free-ran-ue && make bin
+# free-ran-ue (Go 1.26 via auto-toolchain; needs the N3 crash fix, PR free-ran-ue#326)
+# Until #326 merges upstream, apply the bundled patch to a vanilla checkout.
+# PATCH points at this lab directory (bdd/mup-lab), which ships the .patch:
+PATCH=/path/to/zebra-rs/bdd/mup-lab/free-ran-ue-0001-gnb-n3-read-error-crash-fix.patch
+cd ~/free-ran-ue
+git am "$PATCH"                       # or: patch -p1 < "$PATCH" for a non-git tree
+# (already have the fix — e.g. commit 4d9a793 on your branch — skip the patch)
+make bin
 
 # MongoDB (Ubuntu's 3.6 package works)
 sudo mkdir -p /var/log/mongodb /var/lib/mongodb

--- a/bdd/mup-lab/free-ran-ue-0001-gnb-n3-read-error-crash-fix.patch
+++ b/bdd/mup-lab/free-ran-ue-0001-gnb-n3-read-error-crash-fix.patch
@@ -1,0 +1,43 @@
+From 4d9a793b2c7f779250e01d6c22018bbf345f51d8 Mon Sep 17 00:00:00 2001
+From: Kunihiro Ishiguro <kunihiro@zebra.rs>
+Date: Tue, 14 Jul 2026 16:01:59 -0700
+Subject: [PATCH] fix(gnb): don't crash on an N3 read error or short GTP packet
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+receiveGtpPacketFromN3Conn logged a read error but fell through with
+n=0, so parseGtpPacket sliced gtpPacket[:8] on an empty buffer and the
+gNB died with an index-out-of-range panic. A connected UDP socket
+surfaces ICMP port-unreachable as exactly such a read error — one
+unmatched uplink packet at the UPF (e.g. while its PDRs are still being
+installed) kills the whole gNB.
+
+Skip the iteration on a read error, and drop datagrams shorter than
+the 8-byte GTP-U header instead of parsing them.
+---
+ gnb/gtp.go | 7 +++++++
+ 1 file changed, 7 insertions(+)
+
+diff --git a/gnb/gtp.go b/gnb/gtp.go
+index 8783753..6e0efd1 100644
+--- a/gnb/gtp.go
++++ b/gnb/gtp.go
+@@ -103,7 +103,14 @@ func receiveGtpPacketFromN3Conn(ctx context.Context, n3Conn *net.UDPConn, ranDat
+ 			if errors.Is(err, net.ErrClosed) {
+ 				return
+ 			}
++			// e.g. an ICMP port-unreachable surfaced on the connected
++			// socket; there is no packet to process.
+ 			gnbLogger.GtpLog.Warnf("Error reading GTP packet from N3 connection: %v", err)
++			continue
++		}
++		if n < 8 {
++			gnbLogger.GtpLog.Warnf("Short GTP packet (%d bytes) from N3 connection, dropping", n)
++			continue
+ 		}
+ 		gnbLogger.GtpLog.Tracef("Received %d bytes of GTP packet from N3 connection: %+v", n, buffer[:n])
+ 		gnbLogger.GtpLog.Tracef("Received %d bytes of GTP packet from N3 connection", n)
+-- 
+2.43.0
+


### PR DESCRIPTION
## What

Adds the free-ran-ue gNB N3 crash fix (PR free-ran-ue#326) as a bundled patch under `bdd/mup-lab/`, plus instructions to apply it to a vanilla free-ran-ue checkout.

## Why

The mup-lab UPF lab drives a real free-ran-ue gNB. That gNB panics with a `slice bounds out of range [:8]` when its N3 **connected** UDP socket surfaces an ICMP port-unreachable as a read error — e.g. an uplink G-PDU sent before the UPF's PDR is installed. free-ran-ue#326 fixes it (skip the receive iteration on a read error; drop sub-8-byte datagrams) but is not merged upstream yet, so a fresh `free-ran-ue/free-ran-ue` clone crashes mid bring-up.

## How

- `bdd/mup-lab/free-ran-ue-0001-gnb-n3-read-error-crash-fix.patch` — the fix as a `git format-patch` file (one hunk in `gnb/gtp.go`).
- `README.md` Prerequisites — document `git am`-ing the patch onto a vanilla checkout (with a `patch -p1` fallback), and refresh the zebra-rs/cradle prereqs to the nightly installs.

## Tests

- Patch validity: reverse-applies cleanly against the fixed tree, so it applies forward to a vanilla checkout (`git apply --reverse --check` passes).
- Docs-only change to a manual-lab directory; no code or BDD suite affected.

Generated with [Claude Code](https://claude.com/claude-code)