### PR TITLE
packaging: ship Lua sample scripts under /usr/share, not /etc

### DIFF
--- a/bdd/tests/features/bgp_lua_gbp.feature
+++ b/bdd/tests/features/bgp_lua_gbp.feature
@@ -36,7 +36,7 @@ Feature: BGP EVPN Group-Based Policy via Lua scripting
   (-> tag 100) and stamps a Group-Policy-ID extended community. z2's
   import Lua hook recovers the tag and runs `nft add element` to put the
   MAC in set `tag_100`; the withdraw hook removes it. The scripts are the
-  shipped /etc/zebra-rs/lua/gbp-example.lua.
+  shipped /usr/share/zebra-rs/lua/gbp-example.lua.
 
   Scenario: Setup topology, EVPN iBGP, GBP scripts, and the enforcement table
     Given a clean test environment

--- a/book/src/ch-05-04-lua-scripting.md
+++ b/book/src/ch-05-04-lua-scripting.md
@@ -82,8 +82,8 @@ Define named scripts (and optional lookup tables), then bind them:
 
 ```
 router bgp 65000 {
-  lua-script GBP { source-path /etc/zebra-rs/lua/gbp-example.lua; }
-  lua-map sgt    { source-path /etc/zebra-rs/lua/sgt.json; }      // MAC -> tag JSON
+  lua-script GBP { source-path /usr/share/zebra-rs/lua/gbp-example.lua; }
+  lua-map sgt    { source-path /usr/share/zebra-rs/lua/sgt.json; }      // MAC -> tag JSON
 
   loc-rib-hook {
     ipv4-unicast { import GBP; withdraw GBP; }
@@ -110,7 +110,7 @@ into a `map.get` namespace.
 ## Example: GBP over EVPN
 
 The package ships a complete example at
-`/etc/zebra-rs/lua/gbp-example.lua` implementing Group-Based Policy over
+`/usr/share/zebra-rs/lua/gbp-example.lua` implementing Group-Based Policy over
 EVPN: the `export` hook stamps the EVPN Type-2 (MAC) route with the
 endpoint's group tag (looked up MAC → tag via `map.get`) as a GPI
 extended community; the `import` hook recovers the tag and programs an
@@ -169,9 +169,9 @@ end
 The three scripts from the FRR-scripting talk are shipped as ports you can
 read and adapt:
 
-- `/etc/zebra-rs/lua/metric.lua` — the basic MED-rewrite example.
-- `/etc/zebra-rs/lua/gbp-export.lua` — the advertise side (above).
-- `/etc/zebra-rs/lua/gbp-import.lua` — the receive side, plus the withdraw
+- `/usr/share/zebra-rs/lua/metric.lua` — the basic MED-rewrite example.
+- `/usr/share/zebra-rs/lua/gbp-export.lua` — the advertise side (above).
+- `/usr/share/zebra-rs/lua/gbp-import.lua` — the receive side, plus the withdraw
   teardown FRR cannot express.
 
 Because zebra-rs is Lua 5.4, the raw FRR idioms (`string.pack`/`unpack` on

--- a/etc/zebra-rs/lua/gbp-example.lua
+++ b/etc/zebra-rs/lua/gbp-example.lua
@@ -4,8 +4,8 @@
 -- a hook from BGP config, e.g.:
 --
 --   router bgp 65000 {
---     lua-script GBP { source-path /etc/zebra-rs/lua/gbp-example.lua; }
---     lua-map sgt   { source-path /etc/zebra-rs/lua/sgt.json; }   -- MAC -> tag
+--     lua-script GBP { source-path /usr/share/zebra-rs/lua/gbp-example.lua; }
+--     lua-map sgt   { source-path /usr/share/zebra-rs/lua/sgt.json; }   -- MAC -> tag
 --     loc-rib-hook l2vpn-evpn {
 --       import GBP;     -- on receive: program nftables from the GPI tag
 --       withdraw GBP;   -- on withdraw: tear the nftables element down

--- a/etc/zebra-rs/lua/gbp-export.lua
+++ b/etc/zebra-rs/lua/gbp-export.lua
@@ -7,8 +7,8 @@
 --
 -- Bind:
 --   router bgp 65000 {
---     lua-script gbp { source-path /etc/zebra-rs/lua/gbp-export.lua; }
---     lua-map sgt    { source-path /etc/zebra-rs/lua/sgt.json; }   // {"aa:bb:..":"100"}
+--     lua-script gbp { source-path /usr/share/zebra-rs/lua/gbp-export.lua; }
+--     lua-map sgt    { source-path /usr/share/zebra-rs/lua/sgt.json; }   // {"aa:bb:..":"100"}
 --     adj-rib-out-hook l2vpn-evpn { export gbp; }
 --   }
 --

--- a/etc/zebra-rs/lua/gbp-import.lua
+++ b/etc/zebra-rs/lua/gbp-import.lua
@@ -8,7 +8,7 @@
 --
 -- Bind:
 --   router bgp 65000 {
---     lua-script gbp { source-path /etc/zebra-rs/lua/gbp-import.lua; }
+--     lua-script gbp { source-path /usr/share/zebra-rs/lua/gbp-import.lua; }
 --     loc-rib-hook l2vpn-evpn { import gbp; withdraw gbp; }
 --   }
 --

--- a/zebra-rs/Cargo.toml
+++ b/zebra-rs/Cargo.toml
@@ -61,9 +61,11 @@ assets = [
   # here on a package install (see main.rs), so the unit needs no --yang-path.
   ["yang/*",                                     "usr/share/zebra-rs/yang/",        "644"],
   # Example Lua policy scripts for the embedded scripting engine (on by
-  # default). Operators drop their own here and bind them from
-  # `router bgp { lua-script <name> { source-path ... } }`.
-  ["../etc/zebra-rs/lua/*",                      "etc/zebra-rs/lua/",               "644"],
+  # default). Read-only reference examples (like the YANG tree), so they live
+  # under /usr/share rather than /etc — operators bind them from
+  # `router bgp { lua-script <name> { source-path /usr/share/zebra-rs/lua/... } }`,
+  # or point source-path at their own scripts elsewhere.
+  ["../etc/zebra-rs/lua/*",                      "usr/share/zebra-rs/lua/",         "644"],
   # Documented empty default config (see conf-files above).
   ["../packaging/zebra-rs.conf",                 "etc/zebra-rs/zebra-rs.conf",      "644"],
   # Playset lab topologies (netns example networks). Read-only data under

--- a/zebra-rs/src/script/engine.rs
+++ b/zebra-rs/src/script/engine.rs
@@ -1168,7 +1168,7 @@ mod tests {
 
     #[test]
     fn shipped_gbp_example_loads_and_runs() {
-        // The example script packaged at /etc/zebra-rs/lua/gbp-example.lua
+        // The example script packaged at /usr/share/zebra-rs/lua/gbp-example.lua
         // must stay valid: `include_str!` pins the path at compile time,
         // and exercising the egress path (map.get → ecom.gpi →
         // MATCH_AND_CHANGE) proves it actually loaded and ran (a syntax
@@ -1219,7 +1219,7 @@ mod tests {
 
     #[test]
     fn packaged_lua_scripts_load() {
-        // The other example scripts shipped to /etc/zebra-rs/lua must stay
+        // The other example scripts shipped to /usr/share/zebra-rs/lua must stay
         // valid (they are packaged): `include_str!` pins each path at
         // compile time, and the positive transforms below prove each one
         // actually loaded and ran.

--- a/zebra-rs/yang/zebra-bgp-lua.yang
+++ b/zebra-rs/yang/zebra-bgp-lua.yang
@@ -35,7 +35,7 @@ module zebra-bgp-lua {
 
        router bgp {
          lua-script GBP {
-           source-path /etc/zebra-rs/lua/gbp.lua;
+           source-path /usr/share/zebra-rs/lua/gbp.lua;
          }
          loc-rib-hook {
            ipv4-unicast {


### PR DESCRIPTION
## Summary

Follow-up to #1938. cargo-deb auto-marks everything under `/etc` as a conffile, so the shipped Lua example scripts became conffiles — the same problem that moved the YANG tree to `/usr/share`. They are read-only reference examples the operator opts into (the daemon has no default Lua directory; it only reads the `source-path` configured per `lua-script`/`lua-map`), so relocate them to `/usr/share/zebra-rs/lua` alongside the YANG schemas and playset labs. `/etc` now holds only genuine operator config.

Updates the install destination plus the operator-facing references: the sample scripts' own header comments, the book Lua chapter, the `zebra-bgp-lua.yang` description example, the `bgp_lua_gbp` feature prose, and two `engine.rs` test comments that name the packaged location.

The BDD configs and `engine.rs include_str!` tests keep their relative `../etc/zebra-rs/lua/...` paths — those read the repo source tree, whose location is unchanged; only the `.deb` install destination moved.

## Test plan

- `.deb` ships the samples under `/usr/share/zebra-rs/lua` with **no lua conffiles**.
- `--features lua` engine tests (25) pass, including the two that `include_str!` the edited samples.
- `cargo fmt`/`clippy` (incl. the lua lane) clean; lintian unchanged.

Generated with [Claude Code](https://claude.com/claude-code)