### PR TITLE
ci: bump action-gh-release v2 -> v3 (Node 24)

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -60,7 +60,7 @@ jobs:
               done || echo "No existing nightly release yet; nothing to clean."
 
       - name: Publish to GitHub Releases
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           tag_name: nightly
           name: "Nightly Build"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -58,7 +58,7 @@ jobs:
         run: ls -la artifacts/
 
       - name: Publish to GitHub Releases
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           tag_name: ${{ github.ref_name }}
           name: ${{ github.ref_name }}


### PR DESCRIPTION
## Summary

`softprops/action-gh-release@v2` (v2.6.2) still ships a Node 20 entrypoint, which GitHub now force-runs on Node 24 with a deprecation warning. Bump to `@v3` (native Node 24) in both the nightly and release publish steps. Our inputs (`tag_name`/`name`/`body`/`prerelease`/`files`) are unchanged, so it's a drop-in.

## Test plan

No functional change; the next nightly/release publish step runs on Node 24 without the deprecation warning.

Generated with [Claude Code](https://claude.com/claude-code)