### PR TITLE
packaging: render GitHub release notes from CHANGELOG.yaml

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -59,26 +59,44 @@ jobs:
                 gh release delete-asset nightly "$asset" --yes
               done || echo "No existing nightly release yet; nothing to clean."
 
+      # Render the body from CHANGELOG.yaml's newest (in-progress) entry, so the
+      # nightly Releases page previews the changes accumulating for the next
+      # version — the same prose the .deb changelog ships. No arg = top entry.
+      - name: Build nightly release notes
+        env:
+          SHA: ${{ github.sha }}
+        run: |
+          {
+            echo "Nightly build from commit ${SHA}"
+            echo
+            echo "## Changes accumulating for the next release"
+            echo
+            packaging/release-notes.sh
+            cat <<'EOF'
+
+          ## Downloads
+
+          Choose the file matching your Ubuntu version and architecture:
+
+          | Ubuntu             | x86_64                   | ARM64                    |
+          |--------------------|--------------------------|--------------------------|
+          | 22.04 (jammy)      | `*-jammy_amd64.deb`      | `*-jammy_arm64.deb`      |
+          | 24.04 (noble)      | `*-noble_amd64.deb`      | `*-noble_arm64.deb`      |
+          | 26.04 (resolute)   | `*-resolute_amd64.deb`   | `*-resolute_arm64.deb`   |
+
+          Or install via apt (nightly channel): https://zebra.rs/apt/
+          EOF
+          } > release-notes.md
+          echo "----- rendered release-notes.md -----"
+          cat release-notes.md
+
       - name: Publish to GitHub Releases
         uses: softprops/action-gh-release@v3
         with:
           tag_name: nightly
           name: "Nightly Build"
           prerelease: true
-          body: |
-            Nightly build from commit ${{ github.sha }}
-
-            ## Downloads
-
-            Choose the file matching your Ubuntu version and architecture:
-
-            | Ubuntu             | x86_64                   | ARM64                    |
-            |--------------------|--------------------------|--------------------------|
-            | 22.04 (jammy)      | `*-jammy_amd64.deb`      | `*-jammy_arm64.deb`      |
-            | 24.04 (noble)      | `*-noble_amd64.deb`      | `*-noble_arm64.deb`      |
-            | 26.04 (resolute)   | `*-resolute_amd64.deb`   | `*-resolute_arm64.deb`   |
-
-            Or install via apt (nightly channel): https://zebra.rs/apt/
+          body_path: release-notes.md
           files: artifacts/*.deb
 
   # =====================================================================

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -5,8 +5,11 @@ name: Stable Release
 # per-codename `apt-<codename>` flat APT repositories (when APT_PUBLISH_ENABLED).
 #
 # Release flow:
-#   1. Bump the `version` file, then `packaging/version-update.sh`
-#   2. Commit, then `git tag "v$(cat version)" && git push origin "v$(cat version)"`
+#   1. Add a newest-first CHANGELOG.yaml entry whose `semver` is the new version
+#      (it renders both the shipped .deb changelog and this GitHub release body;
+#      the `check` job below fails the release if it's missing or mismatched)
+#   2. Bump the `version` file, then `packaging/version-update.sh`
+#   3. Commit, then `git tag "v$(cat version)" && git push origin "v$(cat version)"`
 
 on:
   push:
@@ -32,6 +35,19 @@ jobs:
             echo "::error::Release ref '$GITHUB_REF_NAME' must be tag 'v$ver' (the version file). Bump the version file first, then tag."
             exit 1
           fi
+      - name: CHANGELOG.yaml top entry matches version
+        run: |
+          # The release body is rendered from CHANGELOG.yaml's newest entry
+          # (packaging/release-notes.sh). Fail loudly if the changelog wasn't
+          # updated for this release, so the Releases page never gets an empty
+          # or stale summary — and so the shipped .deb changelog matches too.
+          ver="$(cat version)"
+          top="$(sed -n 's/^- semver: //p' CHANGELOG.yaml | head -n1)"
+          echo "changelog-top=$top  version-file=$ver"
+          if [ "$top" != "$ver" ]; then
+            echo "::error::CHANGELOG.yaml top entry ('$top') must match the version file ('$ver'). Add the release entry to CHANGELOG.yaml (newest first)."
+            exit 1
+          fi
 
   build:
     needs: check
@@ -47,6 +63,11 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
     steps:
+      # Needed for CHANGELOG.yaml + packaging/release-notes.sh (the release body
+      # is rendered from the curated changelog, not hand-written here).
+      - name: Checkout code
+        uses: actions/checkout@v5
+
       - name: Download all build artifacts
         uses: actions/download-artifact@v8
         with:
@@ -57,25 +78,39 @@ jobs:
       - name: List collected .deb files
         run: ls -la artifacts/
 
+      # Render the release body from CHANGELOG.yaml's entry for this tag (the
+      # `check` job already verified it matches the version file), then append
+      # the fixed downloads table. body_path below feeds this to the release.
+      - name: Build release notes
+        env:
+          TAG: ${{ github.ref_name }}
+        run: |
+          {
+            packaging/release-notes.sh "${TAG#v}"
+            cat <<'EOF'
+
+          ## Downloads
+
+          Choose the file matching your Ubuntu version and architecture:
+
+          | Ubuntu             | x86_64                   | ARM64                    |
+          |--------------------|--------------------------|--------------------------|
+          | 22.04 (jammy)      | `*-jammy_amd64.deb`      | `*-jammy_arm64.deb`      |
+          | 24.04 (noble)      | `*-noble_amd64.deb`      | `*-noble_arm64.deb`      |
+          | 26.04 (resolute)   | `*-resolute_amd64.deb`   | `*-resolute_arm64.deb`   |
+
+          Or install via apt: https://zebra.rs/apt/
+          EOF
+          } > release-notes.md
+          echo "----- rendered release-notes.md -----"
+          cat release-notes.md
+
       - name: Publish to GitHub Releases
         uses: softprops/action-gh-release@v3
         with:
           tag_name: ${{ github.ref_name }}
           name: ${{ github.ref_name }}
-          body: |
-            zebra-rs ${{ github.ref_name }}
-
-            ## Downloads
-
-            Choose the file matching your Ubuntu version and architecture:
-
-            | Ubuntu             | x86_64                   | ARM64                    |
-            |--------------------|--------------------------|--------------------------|
-            | 22.04 (jammy)      | `*-jammy_amd64.deb`      | `*-jammy_arm64.deb`      |
-            | 24.04 (noble)      | `*-noble_amd64.deb`      | `*-noble_arm64.deb`      |
-            | 26.04 (resolute)   | `*-resolute_amd64.deb`   | `*-resolute_arm64.deb`   |
-
-            Or install via apt: https://zebra.rs/apt/
+          body_path: release-notes.md
           files: artifacts/*.deb
 
   # =====================================================================

--- a/CHANGELOG.yaml
+++ b/CHANGELOG.yaml
@@ -1,6 +1,11 @@
 # CHANGELOG.yaml – the single source of truth for the project changelog.
-# packaging/changelog-gen.sh converts this file into the Debian-format changelog
-# that cargo-deb ships (see zebra-rs/Cargo.toml [package.metadata.deb] changelog).
+# Two consumers render from this one file, so there is no second place to edit:
+#   * packaging/changelog-gen.sh -> the Debian-format changelog cargo-deb ships
+#     (see zebra-rs/Cargo.toml [package.metadata.deb] changelog)
+#   * packaging/release-notes.sh -> the GitHub release body (nightly.yaml uses
+#     the top entry; release.yaml uses the entry matching the v<X.Y.Z> tag)
+# The note bodies below are written in Markdown (### headings, * bullets) so
+# they render directly on the GitHub Releases page.
 # Keep newest entry first.
 # All timestamps must be in full ISO-8601 format.
 # Fields "distribution" and "urgency" are optional per-entry; if you omit them,

--- a/packaging/Makefile
+++ b/packaging/Makefile
@@ -30,6 +30,14 @@ arm64 amd64: ../vty/vty playset changelog
 changelog:
 	./changelog-gen.sh
 
+# Preview the GitHub release body rendered from CHANGELOG.yaml's newest entry
+# (what nightly.yaml/release.yaml publish, minus the fixed downloads table).
+# Pass VERSION=<X.Y.Z> to preview a specific past entry instead of the top one.
+# Not part of the .deb build — this feeds the GitHub Releases page, not the package.
+.PHONY: release-notes
+release-notes:
+	./release-notes.sh $(VERSION)
+
 # Stage a clean copy of the playset labs for packaging. Copying ../playset
 # directly would sweep in runtime artifacts (*.log, *.pid) left over from local
 # lab runs; the rsync filter honors playset/.gitignore instead.

--- a/packaging/release-notes.sh
+++ b/packaging/release-notes.sh
@@ -1,0 +1,96 @@
+#!/usr/bin/env bash
+#
+# release-notes.sh — extract one CHANGELOG.yaml entry as GitHub-flavored Markdown.
+#
+# Prints the curated release notes for a single version to stdout, so the GitHub
+# release body (nightly.yaml / release.yaml) renders the SAME prose that ships in
+# the Debian changelog (packaging/changelog-gen.sh writes that from the same
+# file). CHANGELOG.yaml is the single source of truth: edit it, and both the
+# .deb changelog and the Releases-page summary follow — no second place to keep
+# in sync.
+#
+# Usage:
+#   release-notes.sh [SEMVER]
+# With no argument, emits the newest (top) entry — used by the nightly release,
+# which previews the notes accumulating for the next version. With a SEMVER
+# (e.g. 26.7.5) emits that entry — the stable release passes the tag. Exits
+# non-zero if the requested version is absent, so a release fails loudly rather
+# than publishing an empty body.
+#
+# The notes in CHANGELOG.yaml are already written in Markdown (`### heading`,
+# `* bullet`), so extraction is just: find the entry, print its `- note:` block
+# bodies verbatim with the 8-space YAML block-scalar indent stripped, one blank
+# line between blocks.
+#
+# Dependency-free by design: bash + coreutils only — no python/PyYAML/perl — so
+# it runs unchanged on the minimal CI build container (mirrors changelog-gen.sh).
+
+set -euo pipefail
+
+here="$(cd "$(dirname "$0")" && pwd)"
+src="$here/../CHANGELOG.yaml"
+want="${1:-}"
+
+[ -f "$src" ] || { echo "release-notes: $src not found" >&2; exit 1; }
+
+in_entry=0        # inside the requested entry's body
+in_note=0         # inside a `- note: |` block scalar
+found=0           # emitted at least one non-blank line
+pending_blank=0   # a blank line is buffered, flushed before the next content
+
+# Print one Markdown line. Runs of blank lines collapse to one, and a blank
+# never leads the output (so blocks are cleanly separated, no top/bottom pad).
+emit() {
+    if [ -z "$1" ]; then
+        [ "$found" = 1 ] && pending_blank=1
+        return 0
+    fi
+    [ "$pending_blank" = 1 ] && printf '\n'
+    pending_blank=0
+    found=1
+    printf '%s\n' "$1"
+    return 0        # never let a short-circuited `&&` above leak rc=1 under set -e
+}
+
+while IFS= read -r line || [ -n "$line" ]; do
+    line="${line%$'\r'}"
+
+    # Entry boundary (column-0 `- semver:`); never an 8-space note-body line.
+    case "$line" in
+        '- semver: '*)
+            [ "$in_entry" = 1 ] && break          # next entry reached; done
+            ver="${line#- semver: }"
+            if [ -z "$want" ] || [ "$ver" = "$want" ]; then
+                in_entry=1
+            fi
+            in_note=0
+            continue
+            ;;
+    esac
+
+    [ "$in_entry" = 1 ] || continue
+
+    # Note block-scalar body: >= 8-space indent, or a blank line within the block.
+    if [ "$in_note" = 1 ]; then
+        if [ -z "$line" ]; then
+            emit ""
+            continue
+        fi
+        if [ "${line:0:8}" = "        " ]; then
+            emit "${line:8}"
+            continue
+        fi
+        in_note=0                                 # dedented out of the block
+    fi
+
+    case "$line" in
+        '    - note: |'*) in_note=1; emit "" ;;    # blank line between blocks
+        '    - note: '*)  emit "${line#    - note: }" ;;
+        *) ;;                                      # date/distribution/changes/...
+    esac
+done < "$src"
+
+if [ "$found" != 1 ]; then
+    echo "release-notes: no entry for '${want:-<top>}' in $src" >&2
+    exit 1
+fi


### PR DESCRIPTION
## Problem

Since the nfpm→cargo-deb migration, `CHANGELOG.yaml` is the single source of truth for the **Debian changelog** (via `packaging/changelog-gen.sh`). But the **GitHub Releases page** body was a separate, hand-written static string — `zebra-rs vX.Y.Z` plus a downloads table — with no summary of what actually changed. Two sources, one of them effectively empty.

## Approach

One source, two renderers. `CHANGELOG.yaml` notes are already authored in Markdown (`### headings`, `* bullets`), so the release body can be rendered from the same file with no extra authoring.

- **`packaging/release-notes.sh`** (new) — extracts one `CHANGELOG.yaml` entry as Markdown. No arg → newest entry; `SEMVER` arg → that entry. Dependency-free bash (mirrors `changelog-gen.sh`), just strips the 8-space YAML block-scalar indent. Fails loudly if the requested version is absent.
- **`release.yaml`** — renders the body from the entry matching the `v<X.Y.Z>` tag (+ the fixed downloads table) via `body_path`. The `check` job now also asserts `CHANGELOG.yaml`'s top `semver` == the `version` file, so a release can't publish an empty/stale summary and the shipped `.deb` changelog can't drift from the page.
- **`nightly.yaml`** — renders the top (in-progress) entry under "Changes accumulating for the next release".
- **`Makefile`** — `make release-notes [VERSION=X.Y.Z]` previews the body locally.

## Notes

- Packaging/CI only — **zero Rust changes**.
- Untrusted-input-safe: the tag / commit SHA are passed to `run:` via `env:`, never interpolated inline.
- Verified locally: extraction over every `CHANGELOG.yaml` entry (top / explicit / last-at-EOF / missing→non-zero), both workflow bodies assembled end-to-end, both YAMLs parse, and the `check` guard passes on match / blocks on mismatch.

Follow-up: mirror the same script + wiring to cradle-rs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)