### PR TITLE
fib: warn on missing-module sysctls instead of bailing early

### DIFF
--- a/zebra-rs/src/fib/netlink/handle.rs
+++ b/zebra-rs/src/fib/netlink/handle.rs
@@ -33,7 +33,6 @@ use rtnetlink::{
 use tokio::sync::mpsc::UnboundedSender;
 
 use crate::fib::cradle::CradleFib;
-use crate::fib::sysctl::sysctl_enable;
 use crate::fib::{FibAddr, FibLink, FibMdbEntry, FibMessage, FibNeighbor, FibRoute};
 use crate::rib::entry::RibEntry;
 use crate::rib::inst::{IlmEntry, IlmType};
@@ -473,8 +472,10 @@ enum FdbOp {
 
 impl FibHandle {
     pub fn new(rib_tx: UnboundedSender<FibMessage>, no_nhid: bool) -> anyhow::Result<Self> {
-        let _ = sysctl_enable();
-
+        // Baseline sysctls are applied (and any per-knob failures warned
+        // about) by `Rib::event_loop`, which runs right after `Rib::new`
+        // constructs this handle and before any FIB interaction — so there
+        // is no need to enable them here too.
         let (mut connection, handle, mut messages) = new_connection()?;
 
         let mgroup_flags = RTMGRP_LINK

--- a/zebra-rs/src/fib/netlink/sysctl.rs
+++ b/zebra-rs/src/fib/netlink/sysctl.rs
@@ -30,19 +30,38 @@ const CTLNAMES: &[(&str, &str)] = &[
     ("net.mpls.platform_labels", "1048575"),
 ];
 
-pub fn sysctl_enable() -> anyhow::Result<()> {
-    for (ctlname, value) in CTLNAMES.iter() {
-        let ctl = sysctl::Ctl::new(ctlname)?;
-        let _ = ctl.set_value_string(value)?;
-    }
+/// Set a single sysctl node to `value`. Fails when the node is absent —
+/// the module backing it isn't loaded (e.g. `mpls_router` for the
+/// `net.mpls.*` tree, the `vrf` module for `net.vrf.*`) or the kernel
+/// lacks the feature entirely — or when the write is rejected.
+fn sysctl_set(ctlname: &str, value: &str) -> anyhow::Result<()> {
+    let ctl = sysctl::Ctl::new(ctlname)?;
+    let _ = ctl.set_value_string(value)?;
     Ok(())
 }
 
+/// Apply the router's baseline sysctls, returning one human-readable
+/// message per knob that could not be set.
+///
+/// Kernel features are optional: a sysctl node is missing when its module
+/// isn't loaded or the kernel was built without it. Bailing at the first
+/// failure would leave every later knob in `CTLNAMES` unset, so we try
+/// each independently and accumulate the failures instead of returning
+/// early. The caller surfaces the collected messages via `tracing::warn!`
+/// so the operator knows which feature isn't active — an empty vector
+/// means everything applied.
+pub fn sysctl_enable() -> Vec<String> {
+    let mut errors = Vec::new();
+    for (ctlname, value) in CTLNAMES.iter() {
+        if let Err(e) = sysctl_set(ctlname, value) {
+            errors.push(format!("sysctl {ctlname} = {value}: {e}"));
+        }
+    }
+    errors
+}
+
 pub fn sysctl_mpls_enable(ifname: &String) -> anyhow::Result<()> {
-    let ctlname = format!("net.mpls.conf.{}.input", ifname);
-    let ctl = sysctl::Ctl::new(ctlname.as_str())?;
-    let _ = ctl.set_value_string("1")?;
-    Ok(())
+    sysctl_set(&format!("net.mpls.conf.{}.input", ifname), "1")
 }
 
 /// Set the global kernel MPLS→IP TTL propagation for locally-originated
@@ -55,21 +74,16 @@ pub fn sysctl_mpls_enable(ifname: &String) -> anyhow::Result<()> {
 /// traffic, so the forwarded half is teed there instead. The sysctl exists
 /// once the mpls_router module is loaded (`net.mpls.platform_labels`).
 pub fn sysctl_mpls_ip_ttl_propagate(propagate: bool) -> anyhow::Result<()> {
-    let ctl = sysctl::Ctl::new("net.mpls.ip_ttl_propagate")?;
-    let _ = ctl.set_value_string(if propagate { "1" } else { "0" })?;
-    Ok(())
+    sysctl_set(
+        "net.mpls.ip_ttl_propagate",
+        if propagate { "1" } else { "0" },
+    )
 }
 
 pub fn sysctl_seg6_enable(ifname: &String) -> anyhow::Result<()> {
-    let ctlname = format!("net.ipv6.conf.{}.seg6_enabled", ifname);
-    let ctl = sysctl::Ctl::new(ctlname.as_str())?;
-    let _ = ctl.set_value_string("1")?;
-    Ok(())
+    sysctl_set(&format!("net.ipv6.conf.{}.seg6_enabled", ifname), "1")
 }
 
 pub fn sysctl_keep_addr_on_down(ifname: &String) -> anyhow::Result<()> {
-    let ctlname = format!("net.ipv6.conf.{}.keep_addr_on_down", ifname);
-    let ctl = sysctl::Ctl::new(ctlname.as_str())?;
-    let _ = ctl.set_value_string("1")?;
-    Ok(())
+    sysctl_set(&format!("net.ipv6.conf.{}.keep_addr_on_down", ifname), "1")
 }

--- a/zebra-rs/src/rib/inst.rs
+++ b/zebra-rs/src/rib/inst.rs
@@ -4422,8 +4422,20 @@ impl Rib {
     }
 
     pub async fn event_loop(&mut self) {
-        // Before get into FIB interaction, we enable sysctl.
-        let _ = sysctl_enable();
+        // Before FIB interaction, apply the baseline sysctls. A knob that
+        // can't be set (its backing module isn't loaded, or this kernel
+        // lacks the feature) is reported rather than fatal, so the operator
+        // knows which feature is inactive.
+        let errs = sysctl_enable();
+        if !errs.is_empty() {
+            tracing::warn!(
+                "some baseline sysctls could not be set; a required kernel \
+                 module may not be loaded (e.g. `vrf`, `mpls_router`)"
+            );
+            for err in errs {
+                tracing::warn!("{err}");
+            }
+        }
 
         if let Err(_err) = fib_dump(self).await {
             // warn!("FIB dump error {}", err);


### PR DESCRIPTION
## Summary

`sysctl_enable` returned at the first knob it could not set. When a sysctl node is absent — because its backing kernel module isn't loaded (`vrf`, `mpls_router`) or the kernel was built without the feature — every *later* knob in `CTLNAMES` was silently left unapplied, and the caller swallowed the error (`let _ = sysctl_enable()`), so the operator had no signal that a feature was inactive.

This changes the behavior to:

- **Accumulate, don't bail.** `sysctl_enable()` now tries each knob independently and returns one human-readable message per knob that couldn't be set (`Vec<String>`; empty means all applied).
- **Surface warnings.** `Rib::event_loop` logs each failure via `tracing::warn!` before FIB interaction, preceded by a summary line hinting at the likely-missing modules (`vrf`, `mpls_router`).
- **De-duplicate.** A shared `sysctl_set` helper replaces the repeated `Ctl::new` + `set_value_string` boilerplate across all the single-knob functions.
- **Drop a redundant call.** `FibHandle::new` no longer calls `sysctl_enable()` — its sole caller (`Rib::new`) is always immediately followed by `serve` → `event_loop`, which re-applies the same knobs idempotently before any FIB interaction and is now the single place that warns.

## Test plan

- `cargo build -p zebra-rs` — clean.
- `cargo fmt --check -p zebra-rs` — clean.
- `cargo clippy --workspace` — clean.
- Behavior is a superset of before: on a kernel with all modules present, the knob set is unchanged; on a kernel missing e.g. `mpls_router`, the remaining knobs still get applied and the operator sees a warning per missing knob instead of a silent partial apply.

Generated with [Claude Code](https://claude.com/claude-code)