### PR TITLE
packaging: verify the playset layout inside the built .deb

### DIFF
--- a/packaging/Makefile
+++ b/packaging/Makefile
@@ -21,7 +21,13 @@ arm64 amd64: ../vty/vty playset changelog
 	# asset (GNU bash) it copies verbatim — strip it here so the .deb ships no
 	# debug symbols (smaller package; clears lintian unstripped-binary-or-object).
 	strip ../vty/vty
-	cargo deb --no-build -p zebra-rs --output . $(DEB_VERSION_ARG)
+	@# cargo-deb prints the built .deb path on stdout (its warnings go to stderr).
+	@# Capture it so the layout check targets exactly this build's artifact rather
+	@# than globbing zebra-rs_*.deb, which would also match stale debs left here by
+	@# an earlier version or arch.
+	deb=$$(cargo deb --no-build -p zebra-rs --output . $(DEB_VERSION_ARG)) || exit $$?; \
+	echo "$$deb"; \
+	./verify-playset-layout.sh "$$deb"
 
 # Regenerate the Debian-format changelog cargo-deb ships, from the
 # single-source CHANGELOG.yaml (see changelog-gen.sh). Written to out/changelog,
@@ -50,6 +56,8 @@ playset:
 	@# can be 0755 while the sourced helpers stay 0644. Fail the build if any file
 	@# falls outside that exact set, so nothing (a new extension OR a new .sh
 	@# basename) can silently go unpackaged.
+	@# This guard only checks that each staged file is *claimed* by a glob; where
+	@# cargo-deb then puts it is checked after the build by verify-playset-layout.sh.
 	@bad=`find out/playset -type f ! \( \
 		-name '*.yaml' -o -name '*.md' -o -name '*.drawio' -o -name '*.png' -o -name '*.svg' \
 		-o -name 'up.sh' -o -name 'down.sh' -o -name 'topology.sh' \

--- a/packaging/verify-playset-layout.sh
+++ b/packaging/verify-playset-layout.sh
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+#
+# verify-playset-layout.sh — assert the playset labs landed in the .deb with
+# their staged directory structure and modes intact.
+#
+# The Makefile's `playset` target already guards the *staged* file set: it fails
+# the build if a file under out/playset matches none of the cargo-deb asset
+# globs. What that guard cannot see is where cargo-deb ultimately *places* each
+# file — glob destinations are resolved inside cargo-deb, so a mistaken pattern
+# could flatten a scenario tree or collide same-named scripts (every up.sh
+# landing on one path) and still produce a .deb the staging guard accepts,
+# because the files themselves were all present in the staging set.
+#
+# This closes that gap: after `cargo deb` runs, diff the packaged layout against
+# the staged tree, file for file, so a misplaced or dropped asset fails the
+# build instead of shipping.
+#
+# Dependency-free by design: bash + coreutils + awk + dpkg — all already needed
+# to build the package — so it runs unchanged on the minimal CI build container.
+
+set -euo pipefail
+
+deb="${1:-}"
+if [ -z "$deb" ]; then
+	echo "usage: verify-playset-layout.sh <path-to-deb>" >&2
+	exit 2
+fi
+
+here="$(cd "$(dirname "$0")" && pwd)"
+staged="$here/out/playset"
+prefix="usr/share/zebra-rs/playset"
+
+if [ ! -d "$staged" ]; then
+	echo "verify-playset-layout: no staged tree at $staged (run: make playset)" >&2
+	exit 1
+fi
+
+# Expected: every staged regular file, at the mirrored path under $prefix.
+# up.sh/down.sh are the operator entry points and ship executable; every other
+# asset (the sourced lib/ helpers and the data files) ships 0644. This mirrors
+# the mode column of the asset table in ../zebra-rs/Cargo.toml.
+expected="$(
+	cd "$staged"
+	find . -type f | sed 's|^\./||' | while IFS= read -r f; do
+		case "${f##*/}" in
+		up.sh | down.sh) mode=755 ;;
+		*) mode=644 ;;
+		esac
+		printf '%s %s/%s\n' "$mode" "$prefix" "$f"
+	done | sort
+)"
+
+# Actual: the same view rendered from the archive. dpkg -c prints an ls-style
+# permission string, so fold it back to octal — that way a mode regression (a
+# helper shipped executable, an up.sh shipped non-executable) is caught too, not
+# just a misplaced path. Regular files only: `$1 ~ /^-/` drops the directory
+# entries, and with them the "name -> target" rows symlinks would produce.
+actual="$(
+	dpkg -c "$deb" | awk -v prefix="$prefix" '
+		function octal(perm,   i, v, r) {
+			r = ""
+			for (i = 0; i < 3; i++) {
+				v = 0
+				if (substr(perm, 2 + i * 3, 1) == "r") v += 4
+				if (substr(perm, 3 + i * 3, 1) == "w") v += 2
+				if (substr(perm, 4 + i * 3, 1) == "x") v += 1
+				r = r v
+			}
+			return r
+		}
+		$1 ~ /^-/ {
+			path = $6
+			for (i = 7; i <= NF; i++) path = path " " $i
+			sub(/^\.\//, "", path)
+			if (index(path, prefix "/") == 1) print octal($1), path
+		}
+	' | sort
+)"
+
+if [ "$expected" = "$actual" ]; then
+	echo "verify-playset-layout: OK — $(printf '%s\n' "$expected" | wc -l | tr -d ' ') playset files packaged at their staged paths"
+	exit 0
+fi
+
+{
+	echo "verify-playset-layout: packaged playset layout does not match the staged tree."
+	echo "  deb:    $deb"
+	echo "  staged: $staged"
+	echo
+	echo "  -  staged, but not in the .deb at this path/mode (dropped or flattened)"
+	echo "  +  in the .deb, but not staged at this path/mode (misplaced or stale)"
+	echo
+	diff <(printf '%s\n' "$expected") <(printf '%s\n' "$actual") |
+		sed -n 's/^</  -/p; s/^>/  +/p'
+	echo
+	echo "Fix the asset globs in ../zebra-rs/Cargo.toml ([package.metadata.deb] assets)."
+} >&2
+exit 1


### PR DESCRIPTION
## Summary

The `playset` target guards the **staged** file set — it fails the build if a file under `out/playset` is claimed by none of the cargo-deb asset globs. What it cannot see is where cargo-deb then **places** each file: glob destinations are resolved inside cargo-deb, so a mistaken pattern could flatten a scenario tree or collide same-named scripts (every `up.sh` landing on one path) and still produce a `.deb` the staging guard happily accepts, because every file *was* present in staging.

This closes that gap with `packaging/verify-playset-layout.sh`, run right after `cargo deb`:

- Diffs the packaged layout against the staged tree, file for file. Expected paths mirror `out/playset` under `/usr/share/zebra-rs/playset`.
- Folds `dpkg -c`'s ls-style permission string back to octal, so a **mode** regression (a sourced helper shipped executable, an `up.sh` shipped without `+x`) is caught too — not just a misplaced path.
- On mismatch, prints a `-`/`+` diff naming the offending paths and fails the build.

The Makefile captures cargo-deb's stdout — which is exactly the built `.deb` path, its warnings go to stderr — rather than globbing `zebra-rs_*.deb`, which would also match stale debs left in the directory by an earlier version or arch.

No new container dependency: `dpkg` is essential and `dpkg-dev` arrives with `build-essential`, both already in the minimal `ubuntu:26.04` build image.

## Context

This came out of investigating a report that `**/up.sh`-style literal-tail globs were flattening the playset tree. **That bug does not reproduce** — `dpkg -c` on the current build shows every scenario's `up.sh`/`down.sh`/`topology.sh` in its own directory and `lib/` intact with all five helpers, so no asset globs are changed here. But the investigation surfaced a real blind spot: nothing verified the packaged layout at all. Hence this check rather than a fix to the globs.

## Test plan

- **Positive:** passes on the real build — `OK — 249 playset files packaged at their staged paths`. All 249 comparisons include modes, which also proves the octal folding is correct for both `755` and `644`.
- **Negative** (a check that cannot fail is worthless): perturbing the staged tree against an unchanged `.deb` catches both directions and exits 1:
  ```
  - 644 usr/share/zebra-rs/playset/lib/zzz-newhelper.sh   (staged, not packaged)
  + 755 usr/share/zebra-rs/playset/isis-srmpls/up.sh      (packaged, not staged)
  ```
  The hypothesized flattening would surface exactly this way: every scenario's `up.sh` as `-`, plus one `+ usr/share/zebra-rs/playset/up.sh`.
- Full `make` in `packaging/` passes end-to-end with the check wired in.
- `bash -n` clean; `cargo fmt --all --check` clean (no `.rs` touched).

Generated with [Claude Code](https://claude.com/claude-code)