### PR TITLE
packaging: keep playset subdirectories under cargo-deb 3.x

### DIFF
--- a/zebra-rs/Cargo.toml
+++ b/zebra-rs/Cargo.toml
@@ -77,13 +77,26 @@ assets = [
   # are 0755; the sourced helper scripts and all data are 0644. The Makefile
   # `playset` target fails the build if any file outside this set appears, so
   # a new file/script can never silently go unpackaged.
-  ["../packaging/out/playset/**/up.sh",          "usr/share/zebra-rs/playset/",     "755"],
-  ["../packaging/out/playset/**/down.sh",        "usr/share/zebra-rs/playset/",     "755"],
-  ["../packaging/out/playset/**/topology.sh",    "usr/share/zebra-rs/playset/",     "644"],
-  ["../packaging/out/playset/**/common.sh",      "usr/share/zebra-rs/playset/",     "644"],
-  ["../packaging/out/playset/**/netns.sh",       "usr/share/zebra-rs/playset/",     "644"],
-  ["../packaging/out/playset/**/playset.sh",     "usr/share/zebra-rs/playset/",     "644"],
-  ["../packaging/out/playset/**/zebra-rs.sh",    "usr/share/zebra-rs/playset/",     "644"],
+  #
+  # The `[u]p.sh` spelling is load-bearing, not a typo. For a `/`-terminated
+  # dest, cargo-deb keeps a match's path relative to the first globbed component
+  # only when the *last* segment of the source pattern is itself a glob; when it
+  # is a literal name it copies by basename alone (assets.rs `file_name_is_glob`,
+  # where is_glob_pattern means "contains one of * [ ] !"). So `**/up.sh` lands
+  # every scenario's script on the single path playset/up.sh — 12 files colliding
+  # into 1, and lib/ flattened away. Wrapping one character in a class makes the
+  # segment a glob that still matches exactly the one file. cargo-deb 2.x kept
+  # the subdirectories either way; 3.x is what made this bite (fixed for v26.7.6,
+  # first shipped broken by the cargo-deb 3.7.0 bump). packaging/Makefile runs
+  # verify-playset-layout.sh over the built .deb so this can't regress silently
+  # again — that check is what caught it.
+  ["../packaging/out/playset/**/[u]p.sh",        "usr/share/zebra-rs/playset/",     "755"],
+  ["../packaging/out/playset/**/[d]own.sh",      "usr/share/zebra-rs/playset/",     "755"],
+  ["../packaging/out/playset/**/[t]opology.sh",  "usr/share/zebra-rs/playset/",     "644"],
+  ["../packaging/out/playset/**/[c]ommon.sh",    "usr/share/zebra-rs/playset/",     "644"],
+  ["../packaging/out/playset/**/[n]etns.sh",     "usr/share/zebra-rs/playset/",     "644"],
+  ["../packaging/out/playset/**/[p]layset.sh",   "usr/share/zebra-rs/playset/",     "644"],
+  ["../packaging/out/playset/**/[z]ebra-rs.sh",  "usr/share/zebra-rs/playset/",     "644"],
   ["../packaging/out/playset/**/*.yaml",         "usr/share/zebra-rs/playset/",     "644"],
   ["../packaging/out/playset/**/*.md",           "usr/share/zebra-rs/playset/",     "644"],
   ["../packaging/out/playset/**/*.drawio",       "usr/share/zebra-rs/playset/",     "644"],


### PR DESCRIPTION
## Summary

cargo-deb 3.x resolves a glob asset's destination differently from 2.x, and the change silently flattened most of the playset tree. This restores the structure.

**Mechanism** (`cargo-deb-3.7.0/src/assets.rs:308`): for a dest ending in `/`, cargo-deb keeps a match's path relative to the first globbed component **only when the last segment of the source pattern is itself a glob**. When it's a literal name, it copies by basename alone:

```rust
let file_name_is_glob = source_path.file_name().is_some_and(is_glob_pattern);
if file_name_is_glob {
    // skip to the component before the glob  → relative path preserved
} else {
    source_path.iter().count().saturating_sub(1)  // → basename only = flattened
}
```

`is_glob_pattern` (`config.rs:24`) means "contains one of `*` `[` `]` `!`". So `**/up.sh` resolved every scenario's script onto the single path `playset/up.sh` — 12 files colliding into 1 — and flattened `lib/`'s helpers beside it, while `**/*.yaml` and the other extension globs kept their subdirectories because their last segment *is* a glob.

**Fix:** wrap one character of each literal name in a class (`[u]p.sh`). The segment is then a glob, so the relative path is preserved, and the class still matches exactly the one file. Dests and modes are unchanged, the globs stay disjoint, `up.sh`/`down.sh` stay 0755 and the sourced helpers 0644.

## Why now

cargo-deb 2.x preserved the subdirectories either way. This only started biting when CI's **unpinned** `cargo install cargo-deb --locked` picked up **3.7.0**.

No published release carries the flattening: v26.7.5 predates the bump (I verified its published `.deb` — layout correct), and the one v26.7.6 build that hit it was withdrawn.

## Test plan

Verified against **cargo-deb 3.7.0**, the same version CI installs (local default was 2.11.3, which does not exhibit the bug — that version skew is why it initially looked like a non-issue).

- **Before** (3.7.0, unfixed) — reproduced locally, identical to CI:
  ```
  - 755 usr/share/zebra-rs/playset/isis-srmpls/up.sh      (x12 scenarios)
  + 755 usr/share/zebra-rs/playset/up.sh                  (one survivor)
  + 644 usr/share/zebra-rs/playset/playset.sh             (lib/ flattened)
  ```
- **After** (3.7.0, fixed): `verify-playset-layout: OK — 249 playset files packaged at their staged paths`
- Independently confirmed with `dpkg -c`: every scenario's `up.sh`/`down.sh` at 0755 in its own directory, `lib/` intact with all five helpers at 0644, and **no** `.sh` at the playset top level.

Caught by `verify-playset-layout.sh` (#1944) on its first CI run.

## Follow-up (not in this PR)

`build-debs.yaml` installs cargo-deb unpinned, so packaging can break overnight with zero commits — exactly what happened here. Worth pinning.

Generated with [Claude Code](https://claude.com/claude-code)