### PR TITLE
ci: pin cargo-deb so packaging can't change without a commit

### DIFF
--- a/.github/workflows/build-debs.yaml
+++ b/.github/workflows/build-debs.yaml
@@ -12,6 +12,18 @@ on:
         type: boolean
         default: false
 
+# cargo-deb decides where a glob asset lands from the shape of the pattern, and
+# the rule changed in 3.x: with a `/`-terminated dest it now copies by basename
+# unless the pattern's last segment is itself a glob. That silently flattened the
+# playset tree the day an unpinned `cargo install` first picked up 3.7.0 — the
+# built package changed with no commit behind it. Pin the version so packaging
+# output moves only when we choose to move it; a bump is a deliberate, reviewable
+# change. When bumping, expect the asset globs in zebra-rs/Cargo.toml (the `[u]p.sh`
+# spelling, explained there) to need revisiting, and let the layout check in
+# packaging/Makefile — verify-playset-layout.sh — be the judge.
+env:
+  CARGO_DEB_VERSION: "3.7.0"
+
 jobs:
   # =====================================================================
   # Native runners: Ubuntu 22.04 and 24.04
@@ -44,7 +56,7 @@ jobs:
           sudo apt-get install -y protobuf-compiler bison xxd libpam0g-dev
 
       - name: Install cargo-deb
-        run: cargo install cargo-deb --locked
+        run: cargo install cargo-deb --version "$CARGO_DEB_VERSION" --locked
 
       - name: Build vty
         run: make -C vty
@@ -118,7 +130,7 @@ jobs:
           apt-get install -y protobuf-compiler bison xxd libpam0g-dev
 
       - name: Install cargo-deb
-        run: cargo install cargo-deb --locked
+        run: cargo install cargo-deb --version "$CARGO_DEB_VERSION" --locked
 
       - name: Build vty
         run: make -C vty


### PR DESCRIPTION
## Summary

The deb legs ran `cargo install cargo-deb --locked` **unpinned**, so they picked up whatever cargo-deb was newest at build time. That is how the playset flattening (#1945) reached us: cargo-deb 3.x changed where a glob asset lands — with a `/`-terminated dest it copies by basename unless the pattern's last segment is itself a glob — and the day 3.7.0 was published, **the built package changed with no commit behind it**.

This pins the version in a single workflow-level variable used by both the hosted legs and the minimal-container legs:

```yaml
env:
  CARGO_DEB_VERSION: "3.7.0"
```
```yaml
- name: Install cargo-deb
  run: cargo install cargo-deb --version "$CARGO_DEB_VERSION" --locked
```

Now packaging output moves only when we move it, and a cargo-deb bump arrives as a reviewable diff instead of overnight. The comment points whoever bumps it at the asset globs in `zebra-rs/Cargo.toml` (the `[u]p.sh` spelling) and at `verify-playset-layout.sh`, which adjudicates whether the bump is safe.

3.7.0 is the version the fix in #1945 was developed and verified against.

## Test plan

- Both install sites pinned; no other cargo-deb install exists in the tree (grepped workflows, Makefiles, docs).
- YAML parses; `env` resolves to `{CARGO_DEB_VERSION: 3.7.0}`. Workflow-level `env` reaches steps in both the hosted and `container: ubuntu:26.04` jobs.
- The command form is the one I ran locally to install 3.7.0 for #1945, so the flag syntax and version are known good. `cargo install` is idempotent — a matching version already present is skipped.
- Uses the `"$VAR"` shell form rather than `${{ }}` interpolation in `run:`, per the workflow-injection guidance. (The value is a static literal, so there is no untrusted input here either way.)

Note this is defence in depth, not the fix: #1945 corrects the globs, and `verify-playset-layout.sh` (#1944) fails the build if the layout ever breaks again. The pin removes the *surprise* — packaging behaviour no longer changes underneath us between identical commits.

Generated with [Claude Code](https://claude.com/claude-code)