### PR TITLE
bgp-packet: fix 15 codec correctness findings from a whole-crate review

### DIFF
--- a/crates/bgp-packet/CODE_REVIEW_FINDINGS.md
+++ b/crates/bgp-packet/CODE_REVIEW_FINDINGS.md
@@ -377,9 +377,36 @@ silently resolves to the wrong function; use `.into()`.
   Not part of the preserved-verbatim unknown-TLV passthrough, so the loss is
   uncaught.
 
-### 10. Received NOTIFICATION data is always discarded — CONFIRMED
+### 10. Received NOTIFICATION data is always discarded — CONFIRMED — ✅ FIXED
 - **File:** `src/notification.rs:450` (field at line 15)
 - **Category:** correctness
+- **Status:** Fixed on branch `fix-bgp-cap-unknown-header`. `parse_packet` now
+  assigns the octets it reads to `packet.data` instead of a discarded binding.
+
+  Populating the field alone would have been invisible, and the finding's point
+  is that the operator never learns *why* the peer tore the session down. Nothing
+  in zebra-rs read `.data`; `Display` rendered only Code and Sub Code; and the
+  one `tracing::info!("{p}")` on the receive path was **commented out**, with
+  `fsm_bgp_notification` logging only its Bad-Peer-AS special case. So the fix
+  spans three layers:
+  1. `parse_packet` keeps the Data field.
+  2. `NotificationPacket::shutdown_communication()` decodes the RFC 9003
+     Shutdown Communication and `Display` renders it, falling back to a hex dump
+     for Data with no subcode-specific decoder (RFC 4486 Maximum Prefixes'
+     AFI/SAFI and count, or the offending octets of a rejected attribute) rather
+     than dropping it again.
+  3. `fsm_bgp_notification` logs every received NOTIFICATION with its code,
+     sub-code name, and any shutdown communication.
+- **RFC 9003 conformance** (checked against the RFC, not assumed): the Data is a
+  1-octet length then that many octets of UTF-8, carried only by Cease subcodes
+  **2** (Administrative Shutdown) and **4** (Administrative Reset); RFC 9003
+  raised the cap from RFC 8203's 128 to 255, so any length fits the octet. §4
+  says a receiver finding invalid UTF-8 SHOULD log it and MUST NOT interpret the
+  malformed sequence, but must **not** reject the NOTIFICATION — so decoding is
+  lossy, a length disagreeing with the octets present is left uninterpreted, and
+  the packet still parses with its Data shown raw.
+- **Also fixed in passing:** `Display` used `writeln!(..).unwrap()`, which would
+  panic on a formatter error; now `?`.
 - **Bug:** `NotificationPacket.data` is `#[nom(Ignore)]`, so the derived parse
   leaves it empty, and `parse_packet` reads the data bytes into a discarded
   `_data`. `packet.data` is always empty after parse.

--- a/crates/bgp-packet/CODE_REVIEW_FINDINGS.md
+++ b/crates/bgp-packet/CODE_REVIEW_FINDINGS.md
@@ -118,9 +118,41 @@ source; **PLAUSIBLE** = mechanism is real, trigger depends on config/peer/timing
   receiving peer reads a 0-length AS_SEQ then reparses the 256 ASNs as bogus
   segment headers → malformed AS_PATH → NOTIFICATION / session reset.
 
-### 4. RTC parser rejects the `plen=0` default membership it emits — CONFIRMED
+### 4. RTC parser rejects the `plen=0` default membership it emits — CONFIRMED — ✅ FIXED
 - **File:** `src/attrs/nlri_rtcv4.rs:24` (and `src/attrs/nlri_rtcv6.rs:29`)
 - **Category:** correctness
+- **Status:** Fixed on branch `fix-bgp-cap-unknown-header`, together with
+  finding 8 (below), which is the same emit/parse asymmetry in the same file.
+  Reproduced first: `plen=0` and `plen=32` both returned `Err(LengthValue)`
+  while `plen=96` parsed, and a default membership ahead of an exact RT killed
+  the whole list.
+
+  **Severity correction:** the original failure scenario was wrong. Because the
+  parse error left `updates` empty and nothing was inserted into `peer.rtcv4`,
+  and every filter site is gated on `!peer.rtcv4.is_empty()`, a received default
+  membership actually resulted in advertising *everything* — accidentally the
+  correct outcome. The real defects were (a) a default membership ahead of other
+  NLRI discarded them via `many0_complete`, and (b) partial prefixes (32..95,
+  legal per RFC 4684 §4) were rejected outright, which over-advertises when the
+  partial comes first and under-advertises when it comes later.
+
+  `parse_nlri` now accepts `0` and `32..=96`, consuming exactly `ceil(plen/8)`
+  octets, and records `plen`; `rt` is only populated for a full 96-bit prefix
+  (mirroring GoBGP, which leaves `RouteTarget` nil below 96). v4 and v6 now
+  share one `parse_rtc_membership`/`emit_rtc_membership` pair, since the NLRI is
+  byte-identical across families.
+
+  Consumer guarded against regression: `route_ipv4_rtc_update` inserts only
+  fully specified (`is_exact()`) RTs. Naively inserting a default membership's
+  zero RT would have made the set non-empty and flipped us from advertising
+  everything to advertising **nothing**. Failing open is the safe direction —
+  RTC is an optimisation, so over-advertising costs bandwidth while
+  under-advertising blackholes VPN routes.
+- **Known gap (documented in code, not fixed):** a peer mixing an exact RT with
+  a default or partial membership is still filtered to the exact one, because
+  "wants everything" has no representation distinct from "said nothing".
+  Expressing it needs a flag threaded through all seven filter sites; no
+  implementation sends that combination.
 - **Bug:** `Rtcv4::parse_nlri` rejects any `plen != 96`, including the RFC 4684
   default membership `plen=0` that `Rtcv4Reach::emit` itself produces (line 69).
 - **Failure scenario:** `send_rtcv4_membership` / `send_rtcv6_membership` emit the
@@ -172,9 +204,14 @@ source; **PLAUSIBLE** = mechanism is real, trigger depends on config/peer/timing
   matches different traffic than intended (potential filter bypass). Bounded by
   the NLRI length so no over-read.
 
-### 8. RTC withdraw emitter omits prefix-length and origin-AS — CONFIRMED (latent)
+### 8. RTC withdraw emitter omits prefix-length and origin-AS — CONFIRMED (latent) — ✅ FIXED
 - **File:** `src/attrs/nlri_rtcv4.rs:116` (and `src/attrs/nlri_rtcv6.rs:121`)
 - **Category:** correctness
+- **Status:** Fixed alongside finding 4 (same file, same emit/parse asymmetry).
+  Both Unreach emitters now call the shared `emit_rtc_membership`, so a withdraw
+  is encoded exactly as the parser reads it. No behaviour change today — the
+  path stays dormant until a non-empty RTC withdraw is wired — but the hand-
+  rolled encoder could not be left beside the shared one.
 - **Bug:** `Rtcv4Unreach::emit` writes only the 8-byte Route Target per withdraw,
   omitting the `plen(96)` and 4-byte origin-AS that `Rtcv4::parse_nlri` requires;
   the comment even mislabels the RT as "RD".

--- a/crates/bgp-packet/CODE_REVIEW_FINDINGS.md
+++ b/crates/bgp-packet/CODE_REVIEW_FINDINGS.md
@@ -93,10 +93,20 @@ source; **PLAUSIBLE** = mechanism is real, trigger depends on config/peer/timing
   `many0_complete` silently drops that route. Type-2-RD VPN routes are never
   installed.
 
-### 3. AS_SEQ segment count truncated by `as u8` — CONFIRMED
+### 3. AS_SEQ segment count truncated by `as u8` — CONFIRMED — ✅ FIXED
 - **File:** `src/attrs/aspath.rs:126` (with `prepend_mut` at 447-462,
   `consolidate` at 579)
 - **Category:** correctness
+- **Status:** Fixed on branch `fix-bgp-cap-unknown-header`. Reproduced first: a
+  256-ASN AS_SEQ emitted `count = 0` followed by 1024 ASN bytes, and
+  `prepend_mut` on a 255-ASN path was confirmed to produce exactly that
+  (`1 segment, 256 ASNs -> count byte = 0`). `As4Segment::emit` now splits at
+  the new `AS_SEGMENT_MAX` (255) into consecutive segments of the same type,
+  mirroring FRR's `aspath_put`, so 256 ASNs emit as `255 + 1` and the peer
+  reconstructs the identical ASN sequence. The empty-segment encoding is
+  preserved explicitly (`chunks` yields nothing for an empty slice). Fixed in
+  the emitter rather than in `prepend_mut`/`consolidate` so every producer is
+  covered and the in-memory path stays one logical segment.
 - **Bug:** `As4Segment::emit` writes the ASN count as `self.asn.len() as u8`, and
   `prepend_mut`/`consolidate` merge AS_SEQ segments with **no 255-ASN split**, so
   a segment holding > 255 ASNs emits a count byte that wraps and no longer matches

--- a/crates/bgp-packet/CODE_REVIEW_FINDINGS.md
+++ b/crates/bgp-packet/CODE_REVIEW_FINDINGS.md
@@ -472,10 +472,42 @@ silently resolves to the wrong function; use `.into()`.
   `FlowspecNlri` mis-sorts under the `Ord` used as the BTreeMap precedence key,
   letting a crafted route shadow or reorder higher-precedence dataplane rules.
 
-### 15. UPDATE / attribute length truncated by `as u16` on emit — PLAUSIBLE
+### 15. UPDATE / attribute length truncated by `as u16` on emit — CONFIRMED — ✅ FIXED (UPDATE-level)
 - **File:** `src/update.rs:518` (also 504; MP_REACH/MP_UNREACH and BGP-LS emit
   helpers)
 - **Category:** correctness
+- **Status:** Fixed on branch `fix-bgp-cap-unknown-header`. Upgraded from
+  PLAUSIBLE to CONFIRMED — the wrap is constructible through the public API:
+
+  ```
+  serialized bytes = 70023
+  declared length  = 4487    <-- header says this many
+  ```
+
+  A frame whose header contradicts its body desynchronises the peer's framing
+  for every message after it. `From<UpdatePacket> for BytesMut` is infallible by
+  contract yet has no correct output here: the header Length is a u16 and
+  RFC 8654 caps a message at 65535 octets, so an over-long UPDATE simply has no
+  encoding. Replaced it with `UpdatePacket::try_emit()` and
+  `TryFrom<UpdatePacket> for BytesMut`, returning `UpdateEmitError::TooLong`
+  and naming which of the three lengths overflowed (withdrawn-routes,
+  total-path-attribute, message).
+
+  All 27 call sites were converted; the compiler found every one. 24 were
+  `peer.send_packet(update.into())`, so `Peer::send_update` / `SyncCtx::send_update`
+  keep them one-liners while logging and dropping an unencodable UPDATE — a
+  local batching bug, so the log is the useful part. The other three
+  (`update_group.rs`, `group_egress.rs`, `peer_egress.rs`) handle it inline.
+- **Scope deliberately limited:** only the *encodable* limit is enforced, not the
+  session's `max_packet_size`. An UPDATE between the budget and 65535 octets is
+  emitted today, and rejecting it would be a behaviour change well beyond
+  removing the silent corruption — see the deferred item below.
+- **Still open (same class, not fixed):** the attribute-level `len as u16` casts
+  in the MP_REACH/MP_UNREACH and BGP-LS emit helpers. Fixing those means making
+  the `AttrEmitter` trait fallible, which cascades much further. They are bounded
+  in practice by the callers' chunking. `pop_ipv4`/`pop_ipv4_mp_reach` keep their
+  casts and are safe by construction: both bound `buf.len()` to
+  `max_packet_size`, which never exceeds 65535.
 - **Bug:** `From<UpdatePacket> for BytesMut` writes the header length and attr-len
   as `as u16` with no cap or pagination (unlike the paginating `pop_ipv4` path), so
   an UPDATE that serializes past 65535 bytes truncates the on-wire length. The same

--- a/crates/bgp-packet/CODE_REVIEW_FINDINGS.md
+++ b/crates/bgp-packet/CODE_REVIEW_FINDINGS.md
@@ -461,9 +461,43 @@ silently resolves to the wrong function; use `.into()`.
   prefixes and discards the rest and any trailing bytes, instead of RFC 7606
   treat-as-withdraw → route loss and smuggled hidden bytes with no error.
 
-### 14. Flow-spec components accepted out-of-order / duplicated — PLAUSIBLE
+### 14. Flow-spec components accepted out-of-order / duplicated — CONFIRMED — ✅ FIXED
 - **File:** `src/attrs/nlri_flowspec.rs:562`
 - **Category:** robustness
+- **Status:** Fixed on branch `fix-bgp-cap-unknown-header`. Upgraded to
+  CONFIRMED — the shadowing risk is concrete. The same rule in two encodings:
+
+  ```
+  canonical [3,4] -> ACCEPTED   a = proto =6,port =80
+  reversed  [4,3] -> ACCEPTED   b = port =80,proto =6
+    a == b ?  false     <-- one rule, two BTreeMap keys
+    a.cmp(b) = Less     <-- at different precedence
+  duplicate [3,3] -> ACCEPTED
+  ```
+
+  This is load-bearing because `flow_cmp` walks the two component lists
+  *positionally* to compute RFC 8955 §5.1 precedence, and `Ord` keys the
+  BTreeMap the dataplane iterates in apply order. So a crafted encoding of an
+  existing rule occupies a second key and can sit ahead of the rule it
+  duplicates.
+- **The two halves of RFC 8955 §4.2 want different answers**, and the fix
+  reflects that rather than applying one policy to both:
+  - **Order → canonicalise.** A spec is the *conjunction* of its components, so
+    `[port, proto]` matches exactly what `[proto, port]` matches — the intent is
+    unambiguous and nothing is lost by sorting. Rejecting would drop a
+    well-meant rule, and for a filter meant to shed attack traffic, failing to
+    install is the worse failure. Sorting also makes what we re-emit compliant.
+    GoBGP normalises identically, with the same stated reason: otherwise "the
+    unordered rules are determined different" (bgp.go:4590).
+  - **Duplicate type → reject.** Genuinely ambiguous (two operator lists
+    conjoined over one field, e.g. `proto =6` and `proto =17`, which no packet
+    satisfies), so there is nothing to recover. §4.2 allows each type "exactly
+    once".
+- **Note on the contrast with finding 7:** that one rejects rather than repairs,
+  because a missing end-of-list bit makes the *framing* a guess. Here the framing
+  is unambiguous and only the canonical form differs, so repairing is safe. The
+  distinction is "is the sender's intent recoverable", not a blanket
+  strict-vs-lenient stance.
 - **Bug:** The component loop accepts components in any order and with duplicate
   types; RFC 8955 §4.1 requires strictly ascending, non-repeating component types
   and mandates treating a violation as error/withdraw.

--- a/crates/bgp-packet/CODE_REVIEW_FINDINGS.md
+++ b/crates/bgp-packet/CODE_REVIEW_FINDINGS.md
@@ -299,9 +299,42 @@ silently resolves to the wrong function; use `.into()`.
   inconsistent with the 20-octet layout `new()` writes, so the value renders as
   garbage.
 
-### 7. Flow-spec op-list overruns into the next component — PLAUSIBLE
+### 7. Flow-spec op-list overruns into the next component — PLAUSIBLE — ✅ FIXED (as far as the encoding allows)
 - **File:** `src/attrs/nlri_flowspec.rs:168`
 - **Category:** correctness
+- **Status:** Fixed on branch `fix-bgp-cap-unknown-header`. The comment was
+  indeed false: `FlowspecNlri::parse` hands `parse_component` (and so
+  `parse_op_list`) the **whole remaining NLRI value**, not a per-component
+  slice, so "the component slice is exhausted, so a missing end bit can't run
+  into the next component" claimed a guarantee that does not exist. There is no
+  per-component length anywhere in the flow-spec encoding — the end-of-list bit
+  is the only delimiter.
+
+  Split the problem in two. **Detectable:** a term list reaching the end of the
+  NLRI without ever setting the end bit. RFC 8955 §4.2 makes the bit mandatory
+  on the final term, and `parse_op_list` also terminated on exhaustion, so such
+  a list was silently accepted. Reproduced:
+
+  ```
+  [03 03 01 06]  (op 0x01, no end bit) -> ACCEPTED, parsed "proto =6"
+  re-emit        [03 03 81 06]          -> end bit silently added
+  ```
+
+  Because `emit_op_list` re-derives the bit from position, a route reflector
+  would propagate octets it never received. Now rejected, matching GoBGP, whose
+  `FlowSpecComponent` decoder only ever breaks on the end bit and errors when
+  the data runs out without it. **Undetectable:** a list missing the bit
+  mid-NLRI whose stolen octets happen to decode as further terms, one of which
+  sets the bit. No parser can tell — the components silently mis-frame. This is
+  inherent to the encoding and is now documented rather than wrongly claimed
+  impossible.
+- **Trade-off accepted:** strictness rejects an NLRI that the lenient path
+  recovered the correct meaning from (the end-of-NLRI case above), and finding
+  13's `many0_complete` then silently drops it *and every NLRI after it*. That
+  is the right layering — the parser reports malformed input; the caller's
+  RFC 7606 handling is separately broken — but it means finding 13 makes this
+  bite harder than it should. Accepting octets the RFC forbids is the wrong
+  default for a filter that decides which traffic gets dropped.
 - **Bug:** `parse_op_list` is given the entire remaining NLRI value with no
   per-component length delimiter, relying solely on the end-of-list bit. A
   component whose op-list omits that bit consumes the following components' bytes.

--- a/crates/bgp-packet/CODE_REVIEW_FINDINGS.md
+++ b/crates/bgp-packet/CODE_REVIEW_FINDINGS.md
@@ -365,9 +365,30 @@ silently resolves to the wrong function; use `.into()`.
   loop does not execute yet — but it is wrong the moment a real RTC withdraw is
   wired.
 
-### 9. SR-MPLS Binding SID flags dropped on re-emit — PLAUSIBLE
+### 9. SR-MPLS Binding SID flags dropped on re-emit — CONFIRMED — ✅ FIXED
 - **File:** `src/attrs/srpolicy.rs:267` (emit at 478)
 - **Category:** correctness
+- **Status:** Fixed on branch `fix-bgp-cap-unknown-header`. Not an oversight but
+  a *documented* limitation — the type's own doc said "The S/I flags are not
+  modelled in v1; they are emitted as zero" — and `emit_binding_sid` opened with
+  `vec![0u8, 0u8] // Flags, RESERVED`. So a reflector silently turned
+  Specified-BSID-Only and Drop-Upon-Invalid **off** on every policy it passed on.
+  Every pre-existing test used Flags=0, which is why the `round_trip` helper
+  never caught it.
+- **The correct pattern was 15 lines away:** `parse_srv6_binding_sid` /
+  `emit_srv6_binding_sid` (sub-TLV 20) already keep `flags: v[0]` and re-emit
+  them. Only the plain Binding SID (sub-TLV 13) dropped them — the same
+  neighbouring-arm inconsistency as finding 12's Type-2 vs Type-3.
+- **`BindingSid` became `{ flags: u8, value: BindingSidValue }`**, mirroring
+  `Srv6BindingSid`'s shape, with `specified_bsid_only()` / `drop_upon_invalid()`
+  accessors and named `BSID_FLAG_S` / `BSID_FLAG_I` constants.
+- **Verbatim preservation would have been wrong**, which is why the RFC was worth
+  reading rather than assuming. RFC 9830 §2.4.2 defines S (bit 0,
+  Specified-BSID-Only, RFC 9256 §6.2.3) and I (bit 1, Drop-Upon-Invalid,
+  RFC 9256 §8.2), and says the unassigned bits "MUST be set to zero upon
+  transmission and MUST be ignored upon receipt". So unassigned bits are masked
+  off in **both** directions — carrying them through would violate the
+  transmission MUST — while the two assigned bits survive the round trip.
 - **Bug:** `parse_binding_sid` keeps only the 20-bit label from an SR-MPLS Binding
   SID and discards the flag octet (S/I flags); `emit_binding_sid` re-emits
   `Flags=0`.

--- a/crates/bgp-packet/CODE_REVIEW_FINDINGS.md
+++ b/crates/bgp-packet/CODE_REVIEW_FINDINGS.md
@@ -1,0 +1,304 @@
+# bgp-packet Code Review Findings
+
+**Review date:** 2026-07-16
+**Scope:** whole-crate review of `crates/bgp-packet/` (committed tree; no pending diff)
+**Effort:** xhigh recall — 10 finder angles fanned across every file, candidates
+adversarially verified, ranked most-severe first.
+
+## Summary
+
+The crate's **parse paths are well hardened against memory-safety bugs**. Every
+angle that hunted for panics / over-reads on malicious input (EVPN, MUP,
+MP_REACH, flowspec, prefix-SID, BGP-LS, VPN NLRI) confirmed the same thing:
+bounded `packet_utils::safe_split_at` / nom `take` throughout, fixed-array copies
+guarded by exact-width checks, and `saturating_sub` on the underflow paths. The
+claims in `SECURITY_AUDIT.md` hold up.
+
+The findings below are therefore **functional / interop correctness** issues, not
+crashes. Two systemic themes recur:
+
+1. **Length / consumption asymmetry with parsing.** `many0_complete` plus a
+   caller that discards the leftover slice means a malformed NLRI (or a
+   non-multiple-of-width community list) silently truncates the rest of the list
+   instead of RFC 7606 treat-as-withdraw.
+2. **Emit-side `as u8` / `as u16` length casts** with no split/clamp (aspath,
+   update, MP_REACH, BGP-LS, flowspec). Mostly latent behind message-size caps —
+   but the AS_PATH one is live.
+
+Verdicts: **CONFIRMED** = inputs/state and wrong output identified against the
+source; **PLAUSIBLE** = mechanism is real, trigger depends on config/peer/timing.
+
+---
+
+## Findings (ranked)
+
+### 1. Unknown capability with a 0/1-octet body breaks session establishment — CONFIRMED — ✅ FIXED
+- **File:** `src/caps/unknown.rs:10` (with `src/caps/packet.rs:63-71`)
+- **Category:** correctness
+- **Status:** Fixed on branch `fix-bgp-cap-unknown-header`. `CapUnknown` no longer
+  parses a `CapabilityHeader` from the value slice — it now holds `#[nom(Ignore)]
+  code: u8` + `data: Vec<u8>`, and `parse_cap` stamps the real code (already in
+  `cap_header`) into the Unknown variant. Regression tests in `caps/packet.rs`
+  cover the RFC 9234 Role capability (code 9, len 1), a zero-length unknown
+  capability, and a still-typed known capability.
+- **Bug:** `CapUnknown` derives `NomBE` with a leading `header: CapabilityHeader`
+  field, but `parse_cap` has already consumed the 2-byte cap header and
+  `safe_split_at`-sliced the body to exactly `length` bytes before dispatching to
+  the variant. The Unknown arm then re-parses a 2-octet header that isn't there.
+- **Failure scenario:** A peer includes the RFC 9234 BGP Role capability (code 9,
+  length 1 — now common on Cisco/Juniper/FRR) in its OPEN. The 1-byte body can't
+  satisfy `CapabilityHeader::parse_be` (needs 2 bytes) → `parse_cap` →
+  `parse_caps` → `OpenPacket::parse_packet` all fail → zebra-rs rejects the OPEN
+  and the session never establishes. RFC 5492 requires *ignoring* unknown
+  capabilities. Every unknown capability with body < 2 octets triggers it; longer
+  ones silently mis-store header/data.
+
+### 2. Type-2 (4-octet-AS) Route Distinguisher fails to parse — CONFIRMED
+- **File:** `src/attrs/rd.rs:8`
+- **Category:** correctness
+- **Bug:** `RouteDistinguisherType` models only `ASN = 0` and `IP = 1` with no
+  catch-all variant, so the derived `NomBE` parser errors on any other RD type.
+- **Failure scenario:** A peer advertises a VPNv4/VPNv6/EVPN/MUP route whose RD is
+  type 2 (4-byte AS : 2-byte number, RFC 4364 — standard whenever the AS is
+  4-byte). `RouteDistinguisher::parse_be` reads `typ=2`, finds no matching enum
+  variant → nom error → the enclosing `Vpnv4Nlri`/`Vpnv6Nlri` parse fails →
+  `many0_complete` silently drops that route. Type-2-RD VPN routes are never
+  installed.
+
+### 3. AS_SEQ segment count truncated by `as u8` — CONFIRMED
+- **File:** `src/attrs/aspath.rs:126` (with `prepend_mut` at 447-462,
+  `consolidate` at 579)
+- **Category:** correctness
+- **Bug:** `As4Segment::emit` writes the ASN count as `self.asn.len() as u8`, and
+  `prepend_mut`/`consolidate` merge AS_SEQ segments with **no 255-ASN split**, so
+  a segment holding > 255 ASNs emits a count byte that wraps and no longer matches
+  the ASNs written.
+- **Failure scenario:** A route arrives with a single AS_SEQ segment of the max
+  255 AS4 numbers; on eBGP re-advertisement `prepend_mut` concatenates the local
+  AS into that segment → 256 ASNs in one segment → `emit` writes `count = 256 as
+  u8 = 0` followed by 256 u32 ASNs. The attribute length is correct, but a
+  receiving peer reads a 0-length AS_SEQ then reparses the 256 ASNs as bogus
+  segment headers → malformed AS_PATH → NOTIFICATION / session reset.
+
+### 4. RTC parser rejects the `plen=0` default membership it emits — CONFIRMED
+- **File:** `src/attrs/nlri_rtcv4.rs:24` (and `src/attrs/nlri_rtcv6.rs:29`)
+- **Category:** correctness
+- **Bug:** `Rtcv4::parse_nlri` rejects any `plen != 96`, including the RFC 4684
+  default membership `plen=0` that `Rtcv4Reach::emit` itself produces (line 69).
+- **Failure scenario:** `send_rtcv4_membership` / `send_rtcv6_membership` emit the
+  zero-length default "all Route Targets" NLRI whenever the local import-RT set is
+  empty (route.rs comment: *"Empty membership emits the zero-length default
+  NLRI"*). A peer running zebra-rs receives `plen=0`, `parse_nlri` returns
+  `Err(LengthValue)`, `many0_complete` stops with zero memberships → the peer
+  treats us as wanting no Route Targets and never advertises VPN routes. Our own
+  encoder produces packets our own parser rejects; partial-length (1..95) RTC
+  prefixes are rejected too.
+
+### 5. Non-AS4 peer's AS_PATH silently discarded — CONFIRMED
+- **File:** `src/attrs/attr.rs:410`
+- **Category:** correctness
+- **Bug:** The `Attr::As2Path(_v) => { // TODO }` arm drops a parsed 2-octet
+  AS_PATH, leaving `bgp_attr.aspath = None`.
+- **Failure scenario:** A legacy peer that did not negotiate the AS4 capability
+  sends a normal UPDATE; `parse_attr_value` runs with `as4=false`, so the AS_PATH
+  is parsed as `As2Path` and then dropped. The route is installed with **no
+  AS_PATH** (loop detection and AS-path-length best-path comparison broken) and is
+  re-advertised without one, instead of being converted to 4-byte form or rejected
+  as a missing well-known-mandatory attribute.
+
+### 6. IPv6 extended community local-admin emitted native-endian — CONFIRMED
+- **File:** `src/attrs/ext_ipv6_com.rs:68`
+- **Category:** correctness
+- **Bug:** `ExtIpv6CommunityValue::new` writes the 2-octet local-admin value with
+  `to_ne_bytes()` (native endian) instead of `to_be_bytes()`; every other field in
+  the file uses big-endian.
+- **Failure scenario:** On x86_64/aarch64, `ExtIpv6Community::from_str("rt
+  2001:db8::1:100")` → `new(addr, 0x0064)` stores `val[16..18] = [0x64, 0x00]`;
+  `encode()` emits the swapped local-admin, so a remote peer decodes the RT/SoO
+  value as `0x6400` (25600) instead of 100 → IPv6 route-target import/export
+  matching fails. `Display` (lines 48-56) also reads an 8-octet-EC layout
+  inconsistent with the 20-octet layout `new()` writes, so the value renders as
+  garbage.
+
+### 7. Flow-spec op-list overruns into the next component — PLAUSIBLE
+- **File:** `src/attrs/nlri_flowspec.rs:168`
+- **Category:** correctness
+- **Bug:** `parse_op_list` is given the entire remaining NLRI value with no
+  per-component length delimiter, relying solely on the end-of-list bit. A
+  component whose op-list omits that bit consumes the following components' bytes.
+  The doc comment claiming it "can't run into the next component" is false.
+- **Failure scenario:** A crafted NLRI encodes a type-3 (IP-protocol) op with the
+  end-of-list bit cleared followed by a type-4 (port) component. `parse_op_list`
+  reads the next component's type/op bytes as further `{op,value}` terms → merges
+  the two components or fails the whole NLRI → the installed flow-spec filter
+  matches different traffic than intended (potential filter bypass). Bounded by
+  the NLRI length so no over-read.
+
+### 8. RTC withdraw emitter omits prefix-length and origin-AS — CONFIRMED (latent)
+- **File:** `src/attrs/nlri_rtcv4.rs:116` (and `src/attrs/nlri_rtcv6.rs:121`)
+- **Category:** correctness
+- **Bug:** `Rtcv4Unreach::emit` writes only the 8-byte Route Target per withdraw,
+  omitting the `plen(96)` and 4-byte origin-AS that `Rtcv4::parse_nlri` requires;
+  the comment even mislabels the RT as "RD".
+- **Failure scenario:** If a non-empty `Rtcv4Unreach` is emitted, the receiver's
+  `parse_nlri` reads `plen` from the RT's first byte (typically `0x00`) `!= 96` →
+  error → the withdrawal is dropped and stale VPN routes persist. **Currently
+  latent:** `mp_unreach.rs` only builds `Rtcv4Unreach`/`Rtcv6Unreach` with an empty
+  `withdraw` vec (the `Rtcv4Eor`/`Rtcv6Eor` End-of-RIB cases), so the malformed
+  loop does not execute yet — but it is wrong the moment a real RTC withdraw is
+  wired.
+
+### 9. SR-MPLS Binding SID flags dropped on re-emit — PLAUSIBLE
+- **File:** `src/attrs/srpolicy.rs:267` (emit at 478)
+- **Category:** correctness
+- **Bug:** `parse_binding_sid` keeps only the 20-bit label from an SR-MPLS Binding
+  SID and discards the flag octet (S/I flags); `emit_binding_sid` re-emits
+  `Flags=0`.
+- **Failure scenario:** A router receives a Binding SID sub-TLV (type 13) with the
+  S or I flag set and re-advertises it (route reflector or eBGP); the re-encoded
+  sub-TLV zeroes the flag octet, changing the binding-SID semantics downstream.
+  Not part of the preserved-verbatim unknown-TLV passthrough, so the loss is
+  uncaught.
+
+### 10. Received NOTIFICATION data is always discarded — CONFIRMED
+- **File:** `src/notification.rs:450` (field at line 15)
+- **Category:** correctness
+- **Bug:** `NotificationPacket.data` is `#[nom(Ignore)]`, so the derived parse
+  leaves it empty, and `parse_packet` reads the data bytes into a discarded
+  `_data`. `packet.data` is always empty after parse.
+- **Failure scenario:** A peer sends NOTIFICATION Cease/Administrative-Shutdown
+  (code 6, subcode 2, RFC 9003) with a shutdown-communication string, or a
+  header/OPEN/UPDATE error carrying the offending bytes. `take(len)` consumes them
+  into `_data` and drops them → the operator/logs never see the diagnostic. A
+  `NotificationPacket` built with data and re-parsed comes back with empty data.
+
+### 11. COMMUNITIES / LARGE_COMMUNITY width not enforced — PLAUSIBLE
+- **File:** `src/attrs/com.rs:54` (and `src/attrs/large_com.rs:68`)
+- **Category:** robustness
+- **Bug:** Both decode the payload as a nom `many0` of fixed-width values with no
+  multiple-of-width check, and the attribute path discards the parser's leftover,
+  so a non-multiple-of-4 (resp. 12) payload is accepted with trailing bytes
+  silently dropped. `ClusterList` (`cluster_list.rs:28`) enforces its width; these
+  do not.
+- **Failure scenario:** A crafted UPDATE with a COMMUNITIES attribute of length 6
+  parses one 4-byte community and silently discards the trailing 2 bytes; the
+  malformed attribute is accepted and the route installed instead of RFC 7606
+  treat-as-withdraw.
+
+### 12. EVPN MAC/IP length fields validated leniently — PLAUSIBLE
+- **File:** `src/attrs/nlri_evpn.rs:805` (also 810, 1076)
+- **Category:** correctness
+- **Bug:** EVPN Type-2 MAC/IP length fields are validated via
+  `nlri_psize()==6/4/16` (a `div_ceil` on the bit count) rather than an exact
+  bit-count; SMET/IGMP-sync source/group lengths accept any `nlri_psize`-consistent
+  value.
+- **Failure scenario:** A Type-2 route with `mac_len=41` has `nlri_psize()==6` and
+  passes the `==6` check, reading 6 octets as the MAC; an `ip_len` of 200 gives
+  `ip_size=25`, read-and-discarded so the route parses as MAC-only; a Type-6 SMET
+  `group-len=25` is accepted as a 4-octet IPv4 group. No over-read (bounded by
+  `take`), but malformed NLRI enters the RIB. (Type-3 at line 838 correctly
+  hard-checks 32/128.)
+
+### 13. `many0_complete` silently truncates the NLRI list — PLAUSIBLE
+- **File:** `src/attrs/mp_reach.rs:435` (pattern also at `nlri_evpn.rs:758`,
+  `aspath.rs:233`, and `mp_unreach.rs`)
+- **Category:** robustness
+- **Bug:** MP_REACH/MP_UNREACH NLRI lists are parsed with `many0_complete` and the
+  caller discards the leftover, so an inner NLRI parse error — or an over-claimed
+  length octet yielding `Err::Incomplete` — silently stops the list and drops the
+  malformed route plus every valid route after it, with no full-consumption check.
+- **Failure scenario:** A peer sends an MP_REACH whose NLRI block is
+  `[valid][malformed][more valid]`; the parser returns `Ok` with only the leading
+  prefixes and discards the rest and any trailing bytes, instead of RFC 7606
+  treat-as-withdraw → route loss and smuggled hidden bytes with no error.
+
+### 14. Flow-spec components accepted out-of-order / duplicated — PLAUSIBLE
+- **File:** `src/attrs/nlri_flowspec.rs:562`
+- **Category:** robustness
+- **Bug:** The component loop accepts components in any order and with duplicate
+  types; RFC 8955 §4.1 requires strictly ascending, non-repeating component types
+  and mandates treating a violation as error/withdraw.
+- **Failure scenario:** An attacker sends an NLRI whose components are descending
+  (type 5 then type 3) or repeat a type; `parse()` accepts it and the resulting
+  `FlowspecNlri` mis-sorts under the `Ord` used as the BTreeMap precedence key,
+  letting a crafted route shadow or reorder higher-precedence dataplane rules.
+
+### 15. UPDATE / attribute length truncated by `as u16` on emit — PLAUSIBLE
+- **File:** `src/update.rs:518` (also 504; MP_REACH/MP_UNREACH and BGP-LS emit
+  helpers)
+- **Category:** correctness
+- **Bug:** `From<UpdatePacket> for BytesMut` writes the header length and attr-len
+  as `as u16` with no cap or pagination (unlike the paginating `pop_ipv4` path), so
+  an UPDATE that serializes past 65535 bytes truncates the on-wire length. The same
+  `len as u16` cast recurs across the MP emit helpers.
+- **Failure scenario:** An UPDATE built via `update.into::<BytesMut>()`
+  (`update_group.rs`, `peer_egress.rs`, `group_egress.rs`) with enough withdrawn
+  routes/NLRIs to exceed 65535 serialized bytes wraps `buf.len() as u16`, emitting
+  a bogus header length that desyncs the receiver's framing. Reachability depends
+  on callers bounding message size — but there is no guard here.
+
+---
+
+## Below the cut (verified but not in the top 15)
+
+**Lower-severity correctness**
+
+- `src/attrs/flowspec_action.rs:71` — traffic-rate decoded as a raw `f32` from
+  attacker bytes with no finite-value check; NaN/Inf rates decode as valid and
+  reach the policer, and NaN breaks `PartialEq` for any dedup/compare.
+- `src/attrs/srpolicy.rs:405` — Weight sub-TLV accepts `weight=0`, though the doc
+  notes RFC 9256 makes it invalid; a `share = weight/total` consumer can divide by
+  zero.
+- `src/attrs/prefix_sid.rs:434` — `decode_srv6_service` splits SIDs and
+  unknown-sub-TLVs into separate vecs and `emit_srv6_service` writes all SIDs
+  first, so interleaved sub-TLV order is not preserved despite the "bit-exact
+  round-trip" doc claim.
+- `src/attrs/nlri_mup.rs:305` — `MupRoute::parse` never verifies the body consumed
+  exactly the outer `Length` byte; trailing bytes inside the declared length are
+  silently dropped (parse ambiguity).
+- `src/attrs/mp_reach.rs:320` — the RFC 4760 "Number of SNPAs" octet is read as a
+  reserved byte; a nonzero SNPA count misparses the following bytes as NLRI (no
+  compliant peer sends nonzero, so robustness only).
+- `src/parser.rs:66` — `peek_bgp_length` returns `Some(length)` without validating
+  `>= 19` / `<= 4096`; the sole current caller re-checks, so latent.
+- `src/route_refresh.rs:36` — `parse_packet` never validates `header.length` nor
+  rejects trailing in-message bytes.
+- Emit `as u8`/`as u16` truncation, latent behind message-size caps:
+  `nlri_bgpls.rs:675`, `bgpls_attr.rs:153`, `nlri_evpn.rs:1361` (LeafAd),
+  `nlri_mup.rs:663`, `prefix_sid.rs:407`, `srpolicy.rs:537`, `nlri_flowspec.rs:772`.
+
+**Cleanup / altitude (reuse & duplication)**
+
+- `RouteDistinguisher` has a centralized `parse_be` but its wire encoding is
+  hand-rolled at ~22 sites across 5 files (no `RouteDistinguisher::emit`) —
+  `nlri_evpn.rs` (12), `nlri_mup.rs` (4), `nlri_vpnv4.rs`/`nlri_vpnv6.rs` (3 each).
+  The two halves of the codec live at different altitudes.
+- The MP_REACH/MP_UNREACH attribute trailer (buffer value → compute extended flag
+  → put flags/type/len/value) is copy-pasted ~16 times across `mp_reach.rs` /
+  `mp_unreach.rs`; `AttrEmitter::attr_emit` in `src/attrs/emitter.rs` already does
+  it. A missed copy silently emits a malformed attribute for one SAFI.
+- The labeled/VPN prefix parse body (plen floor check, 3-byte label, `plen -= hdr`,
+  `psize` guards, copy into `[0u8;N]`) is copy-pasted ~9 times across
+  `nlri_labeled_unicast.rs`, `nlri_vpnv4.rs`, `nlri_vpnv6.rs`, `nlri_ipv4.rs`,
+  `nlri_ipv6.rs`, `nlri_mup.rs`; add shared `parse_v4_prefix`/`parse_v6_prefix`.
+- The per-AFI/SAFI MP next-hop framing (`match nhop_len {4/16/32}`) is copy-pasted
+  ~10 times in one `parse_nlri_opt` if-chain, and behavior already drifts between
+  copies (EVPN/RTC/LinkState reject the RFC 8950 32-octet form the others accept).
+- `src/update.rs` — `pop_evpn`/`pop_srpolicy`/`pop_vpnv6`/`pop_vpnv4` repeat the
+  same ~25-line UPDATE framing scaffold.
+- `src/util.rs` `u32_u24` duplicates `packet_utils::u32_u8_3`; `src/parse_be.rs`
+  re-declares `packet-utils`' `ParseBe` trait + `Ipv4Addr` impl; `prefix_sid.rs`
+  `parse_be_u24`/`put_be_u24` re-implement `nom::number::complete::be_u24` /
+  `crate::u32_u24`.
+
+---
+
+## Notes on method
+
+- No pending diff existed; this reviews the committed crate as of 2026-07-16.
+- Memory-safety/panic hunting across the parsers came back clean — the residual
+  issues are validation leniency, encode/parse asymmetry, and emit-side length
+  casts, not over-reads.
+- CONFIRMED findings were checked directly against the source; PLAUSIBLE findings
+  have a real mechanism whose trigger depends on peer capability, config, or
+  message size.

--- a/crates/bgp-packet/CODE_REVIEW_FINDINGS.md
+++ b/crates/bgp-packet/CODE_REVIEW_FINDINGS.md
@@ -65,6 +65,16 @@ source; **PLAUSIBLE** = mechanism is real, trigger depends on config/peer/timing
   maps ASN4 → high_type 0x02 (RFC 5668); and `inst.rs`'s reverse extcomm → RD
   mapping now sends high_type 0x02 → ASN4 so a configured 4-byte-AS RT actually
   intersects the same RT on the wire.
+
+  Follow-up (same branch): 4-byte-AS text notation reconciled with RFC 5396.
+  `FromStr` now accepts **both** asplain (`4200000000:1`, IOS-XR's default and
+  RFC 5396's recommendation) and asdot (`64086.59904:1`, IOS-XR under
+  `as-format asdot`, and the only form GoBGP emits); a dotted AS selects type 2
+  explicitly, mirroring GoBGP's `ParseRouteDistinguisher`. `Display` renders
+  asdot via the existing `asn_to_string`, so a 4-byte AS is now spelled the same
+  way in RD/RT and AS_PATH show output — previously `asn_to_string` used asdot
+  while the RD `Display` used asplain. A shared `asn_from_string` in
+  `attrs/aspath.rs` pairs with `asn_to_string`.
 - **Bug:** `RouteDistinguisherType` models only `ASN = 0` and `IP = 1` with no
   catch-all variant, so the derived `NomBE` parser errors on any other RD type.
 - **Failure scenario:** A peer advertises a VPNv4/VPNv6/EVPN/MUP route whose RD is

--- a/crates/bgp-packet/CODE_REVIEW_FINDINGS.md
+++ b/crates/bgp-packet/CODE_REVIEW_FINDINGS.md
@@ -53,9 +53,18 @@ source; **PLAUSIBLE** = mechanism is real, trigger depends on config/peer/timing
   capabilities. Every unknown capability with body < 2 octets triggers it; longer
   ones silently mis-store header/data.
 
-### 2. Type-2 (4-octet-AS) Route Distinguisher fails to parse — CONFIRMED
+### 2. Type-2 (4-octet-AS) Route Distinguisher fails to parse — CONFIRMED — ✅ FIXED
 - **File:** `src/attrs/rd.rs:8`
 - **Category:** correctness
+- **Status:** Fixed on branch `fix-bgp-cap-unknown-header`. Reproduced first: a
+  type-2 RD returned `Err(Error { code: Switch })` while types 0/1 parsed.
+  `RouteDistinguisherType` gained an `ASN4 = 2` variant; `Display` became an
+  exhaustive match (the old `if ASN {..} else {..}` would have rendered a type-2
+  RD as IPv4); `FromStr` now accepts the 4-byte-AS text form (type 0 still wins
+  when the AS fits in 16 bits); `From<RouteDistinguisher> for ExtCommunityValue`
+  maps ASN4 → high_type 0x02 (RFC 5668); and `inst.rs`'s reverse extcomm → RD
+  mapping now sends high_type 0x02 → ASN4 so a configured 4-byte-AS RT actually
+  intersects the same RT on the wire.
 - **Bug:** `RouteDistinguisherType` models only `ASN = 0` and `IP = 1` with no
   catch-all variant, so the derived `NomBE` parser errors on any other RD type.
 - **Failure scenario:** A peer advertises a VPNv4/VPNv6/EVPN/MUP route whose RD is

--- a/crates/bgp-packet/CODE_REVIEW_FINDINGS.md
+++ b/crates/bgp-packet/CODE_REVIEW_FINDINGS.md
@@ -416,10 +416,42 @@ silently resolves to the wrong function; use `.into()`.
   `take`), but malformed NLRI enters the RIB. (Type-3 at line 838 correctly
   hard-checks 32/128.)
 
-### 13. `many0_complete` silently truncates the NLRI list — PLAUSIBLE
+### 13. `many0_complete` silently truncates the NLRI list — CONFIRMED — ✅ FIXED
 - **File:** `src/attrs/mp_reach.rs:435` (pattern also at `nlri_evpn.rs:758`,
   `aspath.rs:233`, and `mp_unreach.rs`)
 - **Category:** robustness
+- **Status:** Fixed on branch `fix-bgp-cap-unknown-header`. Upgraded from
+  PLAUSIBLE to CONFIRMED: demonstrated by stashing the fix and re-running the
+  same probe against an MP_REACH whose NLRI block is
+  `[10.0.0.0/24, <prefix length 33>]`:
+
+  ```
+  before: ACCEPTED (routes silently dropped): 0:10.0.0.0/24 => 192.0.2.1
+  after:  REJECTED
+  well-formed block parses identically either way
+  ```
+
+  All **25** NLRI-block sites (13 in `mp_reach.rs`, 12 in `mp_unreach.rs`) read
+  their list with a bare `many0_complete` and discarded the leftover, so a
+  malformed NLRI yielded the routes *before* it and silently dropped it and
+  everything after — with no error raised anywhere. The peer believes it
+  advertised routes that were never installed.
+
+  Replaced all 25 with one shared `parse_nlri_block` in `src/parser.rs` (beside
+  `nlri_psize`), which parses to exhaustion and rejects a block that does not
+  consume exactly. Fixing it in a helper rather than 25 copies also removes the
+  duplication the cleanup pass flagged, and means a future SAFI cannot
+  reintroduce the bug by copy-paste.
+- **Why erroring is correct, not merely stricter:** RFC 7606 §3(j) permits
+  treat-as-withdraw only when the affected routes can be determined — "if this
+  is not possible ... the 'session reset' approach (or the 'AFI/SAFI disable'
+  approach) MUST be followed". Once an NLRI fails to parse, the remaining routes
+  cannot be located, so they are exactly what cannot be determined.
+  `attr_malformation_is_withdraw` already excludes MP_REACH/MP_UNREACH, so the
+  error reaches the session-reset path the RFC asks for. Silently keeping a
+  prefix of the list is the one outcome the RFC never permits.
+- **Note:** this also makes finding 7's strictness land correctly — a rejected
+  flow-spec NLRI now fails its block loudly instead of silently truncating it.
 - **Bug:** MP_REACH/MP_UNREACH NLRI lists are parsed with `many0_complete` and the
   caller discards the leftover, so an inner NLRI parse error — or an over-claimed
   length octet yielding `Err::Incomplete` — silently stops the list and drops the

--- a/crates/bgp-packet/CODE_REVIEW_FINDINGS.md
+++ b/crates/bgp-packet/CODE_REVIEW_FINDINGS.md
@@ -251,9 +251,43 @@ silently resolves to the wrong function; use `.into()`.
   re-advertised without one, instead of being converted to 4-byte form or rejected
   as a missing well-known-mandatory attribute.
 
-### 6. IPv6 extended community local-admin emitted native-endian — CONFIRMED
+### 6. IPv6 extended community local-admin emitted native-endian — CONFIRMED (code) / NOT REACHABLE (scenario) — ✅ FIXED
 - **File:** `src/attrs/ext_ipv6_com.rs:68`
 - **Category:** correctness
+- **Status / verdict correction:** The coding defects are all real and are fixed,
+  but the stated failure scenario **cannot happen**: `ExtIpv6Community` has no
+  references outside its own module, so nothing ever calls `from_str`, `new()` or
+  `encode()`. The whole module is unwired. Fixed as trap removal, exactly as
+  finding 5 was: `to_ne_bytes` → `to_be_bytes`; `Display` rewritten to the
+  RFC 5701 §2 layout `new()` actually writes (16-octet IPv6 Global Administrator
+  + 2-octet Local Administrator) instead of the 8-octet AS/IPv4 layouts it was
+  reading; and `from_str`'s `tokenizer(..).unwrap()` → `map_err(|_| ())?` so it
+  honours its declared `Err(())` instead of panicking.
+- **The live bug this investigation exposed — ✅ FIXED, and far more severe:**
+  `AttrType` named `ExtendedIpv6Com = 25` with **no matching `Attr` variant** —
+  the only such code in the enum. A recognized-but-unhandled type does not match
+  `AttrType::Unknown`, so it skipped the RFC 4271 §9 handling, reached
+  `parse_attr_value`, failed the derived Switch with no arm to select, and — not
+  being a treat-as-withdraw attribute — propagated the error out as a **session
+  reset**. Any peer sending an RFC 5701 IPv6 extended community tore the session
+  down. Proven before the fix:
+
+  ```
+  type 25  (IPv6 ext-community, optional+transitive) -> ERR (session reset)
+  type 200 (unallocated,        optional+transitive) -> OK, unknown_attrs=1
+  ```
+
+  An attribute zebra-rs half-recognized was strictly worse than one it did not
+  recognize at all. Code 25 is now unnamed, so it decodes as `Unknown(25)` and
+  takes the §9 optional-transitive path: retained with the Partial bit and
+  propagated. A comment where the variant used to sit records the invariant —
+  every code named in `AttrType` must have a matching `Attr` variant — so it is
+  not naively re-added.
+- **Deferred:** real RFC 5701 support (an `Attr::ExtendedIpv6Com` variant, a
+  `BgpAttr` field, an `AttrEmitter`, and RT matching against IPv6 route-targets)
+  is a feature, not a bug fix. The `ext_ipv6_com` module is the skeleton for it
+  and is now correct; passing the attribute through per §9 is the right
+  behaviour until then.
 - **Bug:** `ExtIpv6CommunityValue::new` writes the 2-octet local-admin value with
   `to_ne_bytes()` (native endian) instead of `to_be_bytes()`; every other field in
   the file uses big-endian.

--- a/crates/bgp-packet/CODE_REVIEW_FINDINGS.md
+++ b/crates/bgp-packet/CODE_REVIEW_FINDINGS.md
@@ -70,11 +70,20 @@ source; **PLAUSIBLE** = mechanism is real, trigger depends on config/peer/timing
   `FromStr` now accepts **both** asplain (`4200000000:1`, IOS-XR's default and
   RFC 5396's recommendation) and asdot (`64086.59904:1`, IOS-XR under
   `as-format asdot`, and the only form GoBGP emits); a dotted AS selects type 2
-  explicitly, mirroring GoBGP's `ParseRouteDistinguisher`. `Display` renders
-  asdot via the existing `asn_to_string`, so a 4-byte AS is now spelled the same
-  way in RD/RT and AS_PATH show output — previously `asn_to_string` used asdot
-  while the RD `Display` used asplain. A shared `asn_from_string` in
-  `attrs/aspath.rs` pairs with `asn_to_string`.
+  explicitly, mirroring GoBGP's `ParseRouteDistinguisher`. A 4-byte AS is now
+  spelled the same way in RD/RT and AS_PATH show output — previously
+  `asn_to_string` used asdot while the RD `Display` used asplain. A shared
+  `asn_from_string` in `attrs/aspath.rs` pairs with `asn_to_string`.
+
+  Type-2 `Display` uses **asdot+** (always dotted), not plain asdot. In the
+  overlap where both the AS and the assigned number fit in 16 bits, the dot is
+  the only thing distinguishing type 2 from type 0, so it has to survive
+  display: plain asdot drops it below 65536, which made `0.100:1` print as
+  `100:1` and read back as type 0 — the type silently flipped. asdot+ is
+  byte-identical to asdot for any AS >= 65536 (every real 4-byte AS), and
+  matches GoBGP's `RouteDistinguisherFourOctetAS.String()`.
+  `asn_to_asdot_plus` sits beside `asn_to_string`, and
+  `display_round_trips_preserving_type` pins every type against regression.
 - **Bug:** `RouteDistinguisherType` models only `ASN = 0` and `IP = 1` with no
   catch-all variant, so the derived `NomBE` parser errors on any other RD type.
 - **Failure scenario:** A peer advertises a VPNv4/VPNv6/EVPN/MUP route whose RD is

--- a/crates/bgp-packet/CODE_REVIEW_FINDINGS.md
+++ b/crates/bgp-packet/CODE_REVIEW_FINDINGS.md
@@ -30,6 +30,56 @@ source; **PLAUSIBLE** = mechanism is real, trigger depends on config/peer/timing
 
 ---
 
+## Deferred work
+
+### Drive `as4` from capability negotiation (RFC 6793) — AGREED, DEFERRED
+
+**Decision:** agreed to do this, deliberately not now. Recorded here so the
+context found while fixing finding 5 is not lost.
+
+**What is wrong today.** `peer_packet_parse`
+(`zebra-rs/src/bgp/peer.rs:2459`) calls
+`BgpPacket::parse_packet(rx, true, Some(opt.clone()))` — the `as4` argument is a
+hardcoded `true`, never sourced from what the peer actually negotiated.
+`Peer::as4` (`peer.rs:909`) exists but is set `true` at construction
+(`peer.rs:1120`) and never assigned anywhere. So zebra-rs always decodes AS_PATH
+as 4-octet, whatever the peer advertised.
+
+**Consequence.** A genuine OLD (non-AS4) speaker sends 2-octet AS_PATHs per
+RFC 6793. zebra-rs would read the segment header and then consume 4 octets per
+ASN, overrunning the attribute — a misparse, not a clean rejection. Rare in
+practice (AS4 is effectively universal), which is why this is deferred rather
+than urgent.
+
+**Why it is a feature, not a one-line change.** Setting `as4 = false` for such a
+peer is necessary but *not sufficient*, and on its own would lose information:
+
+1. `as4` must come from the negotiated capability, per peer/connection — the
+   value has to reach `peer_packet_parse`, which currently has no peer context
+   at that call site.
+2. **AS4_PATH (type 17)** and **AS4_AGGREGATOR (type 18)** must be implemented.
+   Neither exists in `AttrType` (`attrs/attr.rs:14`) today. An OLD peer puts
+   AS_TRANS (23456) in the 2-octet AS_PATH as a placeholder and carries the real
+   4-octet ASNs in AS4_PATH; without it the true AS numbers are unrecoverable.
+3. The RFC 6793 §4.2.3 **merge algorithm** (reconcile AS_PATH with AS4_PATH,
+   preferring AS_PATH's hop count) must be implemented.
+4. The **emit** side needs the mirror: `Attr::emit` has no `As2Path` arm, so
+   advertising a 2-octet AS_PATH (with AS_TRANS substitution) to an OLD peer is
+   also unimplemented.
+
+**Already in place.** `From<As2Path> for As4Path` (`attrs/aspath.rs`) and the
+`Attr::As2Path` arm (`attrs/attr.rs`) now widen a 2-octet AS_PATH into the
+4-octet form instead of dropping it, so step 1 above cannot silently lose
+AS_PATHs the moment `as4` starts varying. `AS_TRANS` is already defined
+(`aspath.rs:21`, currently `#[allow(dead_code)]`). Widening keeps AS_TRANS
+literal until AS4_PATH lands.
+
+**Trap to remember.** `As4Path` has an inherent `pub fn from(asn: Vec<u32>)`
+(`aspath.rs:452`) that shadows `From::from`, so `As4Path::from(as2_path)`
+silently resolves to the wrong function; use `.into()`.
+
+---
+
 ## Findings (ranked)
 
 ### 1. Unknown capability with a 0/1-octet body breaks session establishment — CONFIRMED — ✅ FIXED
@@ -182,14 +232,13 @@ source; **PLAUSIBLE** = mechanism is real, trigger depends on config/peer/timing
   ASN, hop count preserved). Wiring `as4` to the negotiated capability would
   otherwise have silently started dropping AS_PATHs. Zero runtime behaviour
   change today.
-- **The real latent bug this exposed (NOT fixed, worth its own entry):** `as4` is
-  hardcoded `true`, so a genuine OLD (non-AS4) peer's 2-octet AS_PATH would be
-  misparsed as 4-octet — reading a segment count and then overrunning the
-  attribute. Fixing that properly is an RFC 6793 feature, not a bug fix: it needs
-  `as4` driven by the negotiated capability *plus* AS4_PATH (type 17) and
-  AS4_AGGREGATOR (type 18) to recover the 4-octet ASNs an OLD peer hides behind
-  AS_TRANS (23456). Neither attribute exists in `AttrType`. Until then the
-  widening keeps AS_TRANS literal.
+- **The real latent bug this exposed — agreed and deferred:** `as4` is hardcoded
+  `true`, so a genuine OLD (non-AS4) peer's 2-octet AS_PATH would be misparsed as
+  4-octet. Driving `as4` from capability negotiation is agreed as future work;
+  see **[Deferred work → Drive `as4` from capability negotiation
+  (RFC 6793)](#drive-as4-from-capability-negotiation-rfc-6793--agreed-deferred)**
+  at the top of this document for the full scope (AS4_PATH type 17,
+  AS4_AGGREGATOR type 18, the §4.2.3 merge, and the emit side).
 - **Also noted:** `As4Path` has an inherent `pub fn from(asn: Vec<u32>)`
   (`aspath.rs:452`) that shadows `From::from`, so `As4Path::from(as2_path)`
   silently resolves to the wrong function and callers must use `.into()`.

--- a/crates/bgp-packet/CODE_REVIEW_FINDINGS.md
+++ b/crates/bgp-packet/CODE_REVIEW_FINDINGS.md
@@ -429,9 +429,39 @@ silently resolves to the wrong function; use `.into()`.
   malformed attribute is accepted and the route installed instead of RFC 7606
   treat-as-withdraw.
 
-### 12. EVPN MAC/IP length fields validated leniently — PLAUSIBLE
+### 12. EVPN MAC/IP length fields validated leniently — CONFIRMED — ✅ FIXED
 - **File:** `src/attrs/nlri_evpn.rs:805` (also 810, 1076)
 - **Category:** correctness
+- **Status:** Fixed on branch `fix-bgp-cap-unknown-header`. Upgraded to
+  CONFIRMED — every out-of-spec value was accepted:
+
+  ```
+  before: mac_len=48 ACCEPTED  mac_len=41 ACCEPTED  mac_len=47 ACCEPTED
+          ip_len=0/32/128 ACCEPTED  ip_len=200 ACCEPTED  ip_len=25 ACCEPTED
+  after:  only 48, and only 0/32/128, are accepted
+  ```
+
+  RFC 7432 §7.2, quoted: "The MAC Address Length field is in bits, and it is set
+  to 48" and "the IP Address Length field is in bits, and it is set to 32 or 128
+  bits". Other values are explicitly "outside the scope of this document" — there
+  is no defined way to read them, so rejecting is the only defensible action.
+
+  The root cause is one idiom: rounding a bit-count to octets with `nlri_psize`
+  *before* comparing. That silently widens each legal value into a span of eight
+  — `nlri_psize(mac_len) == 6` accepts 41..=48, and `nlri_psize(len)` in
+  `parse_len_prefixed_ip` reads 25..=32 as IPv4 and 121..=128 as IPv6. All three
+  sites now match on the bit count itself, against named `MAC_LEN_BITS` /
+  `IP4_LEN_BITS` / `IP6_LEN_BITS` constants carrying the RFC quotes.
+  `nlri_psize` no longer appears in the file outside comments.
+- **The correct pattern already existed two arms away:** the `IncMulticast`
+  (Type-3) arm hard-checks its address length against 32/128 with an RFC 7432
+  §7.3 citation. Type-2 simply never matched it.
+- **`parse_len_prefixed_ip` had the same false-comment problem as finding 7:** its
+  doc always claimed "any other length fails the parse", which the `nlri_psize`
+  match made untrue. The code now does what the comment said.
+- **Note:** Type-2's IP address is still parsed and discarded — `EvpnMac` has no
+  `ip` field. That is a modelling gap, not a validation one, and is left alone;
+  the length is now validated and exactly that many octets are stepped over.
 - **Bug:** EVPN Type-2 MAC/IP length fields are validated via
   `nlri_psize()==6/4/16` (a `div_ceil` on the bit count) rather than an exact
   bit-count; SMET/IGMP-sync source/group lengths accept any `nlri_psize`-consistent

--- a/crates/bgp-packet/CODE_REVIEW_FINDINGS.md
+++ b/crates/bgp-packet/CODE_REVIEW_FINDINGS.md
@@ -437,9 +437,46 @@ silently resolves to the wrong function; use `.into()`.
   into `_data` and drops them → the operator/logs never see the diagnostic. A
   `NotificationPacket` built with data and re-parsed comes back with empty data.
 
-### 11. COMMUNITIES / LARGE_COMMUNITY width not enforced — PLAUSIBLE
+### 11. COMMUNITIES / LARGE_COMMUNITY width not enforced — CONFIRMED — ✅ FIXED
 - **File:** `src/attrs/com.rs:54` (and `src/attrs/large_com.rs:68`)
 - **Category:** robustness
+- **Status:** Fixed on branch `fix-bgp-cap-unknown-header`. Upgraded to
+  CONFIRMED:
+
+  ```
+  before: COMMUNITIES len=6  -> ACCEPTED  com=Some({65538})  treat_as_withdraw=false
+          COMMUNITIES len=0  -> ACCEPTED  com=Some({})
+          LARGE_COM   len=14 -> ACCEPTED                     treat_as_withdraw=false
+  after:  all three -> treat_as_withdraw=true, attribute discarded, session up
+  ```
+
+  Both RFCs are explicit, and both were quoted rather than assumed:
+  - **RFC 7606 §7.8**: "The Community attribute SHALL be considered malformed if
+    its length is not a non-zero multiple of 4. An UPDATE message with a
+    malformed Community attribute SHALL be handled using the approach of
+    'treat-as-withdraw'."
+  - **RFC 8092 §3**: the same for a Large Communities attribute whose length is
+    not a non-zero multiple of 12.
+
+  Note **non-zero**: a zero-length attribute is malformed too, and used to parse
+  into an empty set.
+- **Detection alone would have been a regression, which is the whole point of
+  this one.** `attr_malformation_is_withdraw` listed only `PrefixSid`, so making
+  the parsers reject would have turned a silently-accepted attribute into a
+  **session reset** — exactly what both RFCs forbid. `AttrType::Community` and
+  `AttrType::LargeCom` are now in that set, so the malformed attribute is
+  discarded, the UPDATE's NLRI is withdrawn, and the session stays up.
+- **Contrast with finding 13:** there, session reset was correct because a failed
+  NLRI parse leaves the affected routes undeterminable (RFC 7606 §3(j)). Here the
+  NLRI is intact and only an attribute is malformed, so treat-as-withdraw is both
+  possible and mandated. Same detection, opposite action — which is why each
+  needed its RFC checked rather than a blanket "be strict" rule.
+- **Emit guarded too:** `BgpAttr::attr_emit` emitted whatever was in `com`/`lcom`,
+  so an emptied set would have produced a zero-length attribute — malformed by
+  the same clause, and now rejected by our own parser. That is finding 4's
+  self-inconsistency, so both sites skip an empty set.
+- **The correct pattern already existed:** `ClusterList::parse_be` enforces its
+  4-octet width with an RFC 4456 citation. Only these two didn't.
 - **Bug:** Both decode the payload as a nom `many0` of fixed-width values with no
   multiple-of-width check, and the attribute path discards the parser's leftover,
   so a non-multiple-of-4 (resp. 12) payload is accepted with trailing bytes

--- a/crates/bgp-packet/CODE_REVIEW_FINDINGS.md
+++ b/crates/bgp-packet/CODE_REVIEW_FINDINGS.md
@@ -164,9 +164,35 @@ source; **PLAUSIBLE** = mechanism is real, trigger depends on config/peer/timing
   encoder produces packets our own parser rejects; partial-length (1..95) RTC
   prefixes are rejected too.
 
-### 5. Non-AS4 peer's AS_PATH silently discarded — CONFIRMED
+### 5. Non-AS4 peer's AS_PATH silently discarded — ⚠️ NOT REACHABLE (verdict corrected) — ✅ arm fixed anyway
 - **File:** `src/attrs/attr.rs:410`
 - **Category:** correctness
+- **Status / verdict correction:** The code defect is real — the arm was an empty
+  `// TODO` that dropped a parsed AS_PATH — but the **stated failure scenario
+  cannot happen**, and the CONFIRMED verdict was wrong. `peer_packet_parse`
+  (`zebra-rs/src/bgp/peer.rs:2459`) calls `BgpPacket::parse_packet(rx, true, ..)`
+  with `as4` **hardcoded to `true`**, never sourced from capability negotiation.
+  `peer.as4` exists but is set `true` at construction and never assigned. So
+  AS_PATH always parses as `As4Path`, `Attr::As2Path` is never constructed at
+  runtime (only tests pass `as4=false`), and `Attr::emit` has no `As2Path` arm
+  either. No route has ever lost its AS_PATH this way.
+
+  Fixed regardless, as trap removal: `Attr::As2Path` now widens into `As4Path`
+  via a new `From<As2Path> for As4Path` (RFC 6793 §4.2.2, zero-extending each
+  ASN, hop count preserved). Wiring `as4` to the negotiated capability would
+  otherwise have silently started dropping AS_PATHs. Zero runtime behaviour
+  change today.
+- **The real latent bug this exposed (NOT fixed, worth its own entry):** `as4` is
+  hardcoded `true`, so a genuine OLD (non-AS4) peer's 2-octet AS_PATH would be
+  misparsed as 4-octet — reading a segment count and then overrunning the
+  attribute. Fixing that properly is an RFC 6793 feature, not a bug fix: it needs
+  `as4` driven by the negotiated capability *plus* AS4_PATH (type 17) and
+  AS4_AGGREGATOR (type 18) to recover the 4-octet ASNs an OLD peer hides behind
+  AS_TRANS (23456). Neither attribute exists in `AttrType`. Until then the
+  widening keeps AS_TRANS literal.
+- **Also noted:** `As4Path` has an inherent `pub fn from(asn: Vec<u32>)`
+  (`aspath.rs:452`) that shadows `From::from`, so `As4Path::from(as2_path)`
+  silently resolves to the wrong function and callers must use `.into()`.
 - **Bug:** The `Attr::As2Path(_v) => { // TODO }` arm drops a parsed 2-octet
   AS_PATH, leaving `bgp_attr.aspath = None`.
 - **Failure scenario:** A legacy peer that did not negotiate the AS4 capability

--- a/crates/bgp-packet/src/attrs/aspath.rs
+++ b/crates/bgp-packet/src/attrs/aspath.rs
@@ -17,6 +17,12 @@ pub const AS_SEQ: u8 = 2;
 pub const AS_CONFED_SEQ: u8 = 3;
 pub const AS_CONFED_SET: u8 = 4;
 
+/// Most AS numbers expressible in one AS_PATH segment: the segment header's
+/// Path Segment Length is a single octet (RFC 4271 §4.3). A longer run has to be
+/// emitted as consecutive segments of the same type. Mirrors FRR's
+/// `AS_SEGMENT_MAX`.
+pub const AS_SEGMENT_MAX: usize = 255;
+
 #[allow(dead_code)]
 pub const AS_TRANS: u16 = 23456;
 
@@ -122,9 +128,29 @@ impl As4Segment {
     }
 
     pub fn emit(&self, buf: &mut BytesMut) {
-        buf.put_u8(self.typ);
-        buf.put_u8(self.asn.len() as u8);
-        self.asn.iter().for_each(|x| buf.put_u32(*x));
+        // Split at the 1-octet Path Segment Length limit rather than letting
+        // `len() as u8` wrap. `prepend_mut` and `consolidate` both merge into a
+        // single segment without bounding it, so an inbound path whose segment
+        // already held the maximum 255 reaches 256 after one prepend; the count
+        // octet then wrapped to 0 while 256 ASNs were still written, and the
+        // peer reparsed those ASN bytes as segment headers -> malformed AS_PATH
+        // -> NOTIFICATION. Consecutive segments of the same type are equivalent
+        // for AS_SEQUENCE (the hop counts add up); an AS_SET over 255 has no
+        // single-segment encoding at all, so splitting is the only option there
+        // too, at the cost of the receiver counting it as more than one hop.
+        // Matches FRR's `aspath_put`.
+        if self.asn.is_empty() {
+            // Preserve the empty-segment encoding: `chunks` yields nothing for
+            // an empty slice, which would emit no header at all.
+            buf.put_u8(self.typ);
+            buf.put_u8(0);
+            return;
+        }
+        for chunk in self.asn.chunks(AS_SEGMENT_MAX) {
+            buf.put_u8(self.typ);
+            buf.put_u8(chunk.len() as u8);
+            chunk.iter().for_each(|x| buf.put_u32(*x));
+        }
     }
 }
 
@@ -633,6 +659,121 @@ impl Default for As4Path {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// Flatten an emitted AS_PATH back into its ASN sequence.
+    fn emit_and_reparse(path: &As4Path) -> (usize, Vec<u32>) {
+        let mut buf = BytesMut::new();
+        path.segs.iter().for_each(|s| s.emit(&mut buf));
+        let (rest, parsed) = As4Path::parse_be(&buf).unwrap();
+        assert!(rest.is_empty(), "emitted AS_PATH must parse fully");
+        let flat = parsed
+            .segs
+            .iter()
+            .flat_map(|s| s.asn.iter().copied())
+            .collect();
+        (parsed.segs.len(), flat)
+    }
+
+    /// A segment longer than the 1-octet count splits into consecutive segments
+    /// of the same type instead of wrapping. Regression: 256 ASNs emitted
+    /// `count = 0` followed by 256 ASNs, so a peer read a 0-length AS_SEQ and
+    /// reparsed the ASN bytes as segment headers — a malformed AS_PATH.
+    #[test]
+    fn oversized_segment_splits_at_limit() {
+        let seg = As4Segment {
+            typ: AS_SEQ,
+            asn: (1..=256u32).collect(),
+        };
+        let mut buf = BytesMut::new();
+        seg.emit(&mut buf);
+
+        // Two headers, not one: 2 + 255*4 + 2 + 1*4.
+        assert_eq!(buf.len(), 2 + 255 * 4 + 2 + 4);
+        assert_eq!(
+            (buf[0], buf[1]),
+            (AS_SEQ, 255),
+            "first segment fills the limit"
+        );
+        let second = 2 + 255 * 4;
+        assert_eq!(
+            (buf[second], buf[second + 1]),
+            (AS_SEQ, 1),
+            "remainder carries the same segment type"
+        );
+
+        // The ASN sequence a peer reconstructs is unchanged.
+        let (_, parsed) = As4Path::parse_be(&buf).unwrap();
+        let flat: Vec<u32> = parsed
+            .segs
+            .iter()
+            .flat_map(|s| s.asn.iter().copied())
+            .collect();
+        assert_eq!(flat, (1..=256u32).collect::<Vec<u32>>());
+    }
+
+    /// Exactly at the limit still emits a single segment.
+    #[test]
+    fn segment_at_limit_emits_one_segment() {
+        let seg = As4Segment {
+            typ: AS_SEQ,
+            asn: (1..=255u32).collect(),
+        };
+        let mut buf = BytesMut::new();
+        seg.emit(&mut buf);
+        assert_eq!(buf.len(), 2 + 255 * 4);
+        assert_eq!((buf[0], buf[1]), (AS_SEQ, 255));
+    }
+
+    /// An empty segment keeps emitting its header (`chunks` yields nothing for
+    /// an empty slice, which would otherwise drop the segment entirely).
+    #[test]
+    fn empty_segment_still_emits_header() {
+        let seg = As4Segment::new(AS_SEQ);
+        let mut buf = BytesMut::new();
+        seg.emit(&mut buf);
+        assert_eq!(&buf[..], &[AS_SEQ, 0]);
+    }
+
+    /// The realistic trigger: an inbound path whose single AS_SEQ already holds
+    /// the maximum 255, re-advertised over eBGP so `prepend_mut` merges the
+    /// local AS in, reaching 256 in one segment.
+    #[test]
+    fn prepend_past_limit_round_trips() {
+        let mut path = As4Path::from((1..=255u32).collect::<Vec<u32>>());
+        path.prepend_mut(As4Path::from(vec![65000u32]));
+        assert_eq!(path.segs.len(), 1, "prepend_mut merges into one segment");
+        assert_eq!(
+            path.segs[0].asn.len(),
+            256,
+            "which now exceeds the wire limit"
+        );
+
+        let (segs, flat) = emit_and_reparse(&path);
+        assert_eq!(segs, 2, "emit splits it for the wire");
+        assert_eq!(flat.len(), 256, "no ASN lost or invented");
+        assert_eq!(flat[0], 65000, "prepended AS stays leftmost");
+        assert_eq!(flat[1..], (1..=255u32).collect::<Vec<u32>>()[..]);
+    }
+
+    /// An AS_SET over the limit also splits, keeping its type on every piece.
+    #[test]
+    fn oversized_as_set_splits_keeping_type() {
+        let seg = As4Segment {
+            typ: AS_SET,
+            asn: (1..=300u32).collect(),
+        };
+        let mut buf = BytesMut::new();
+        seg.emit(&mut buf);
+        let (_, parsed) = As4Path::parse_be(&buf).unwrap();
+        assert_eq!(parsed.segs.len(), 2);
+        assert!(parsed.segs.iter().all(|s| s.typ == AS_SET));
+        let flat: Vec<u32> = parsed
+            .segs
+            .iter()
+            .flat_map(|s| s.asn.iter().copied())
+            .collect();
+        assert_eq!(flat, (1..=300u32).collect::<Vec<u32>>());
+    }
 
     /// `asn_from_string` accepts both RFC 5396 notations and round-trips
     /// `asn_to_string` (which renders asdot).

--- a/crates/bgp-packet/src/attrs/aspath.rs
+++ b/crates/bgp-packet/src/attrs/aspath.rs
@@ -140,6 +140,18 @@ pub fn asn_to_string(val: u32) -> String {
     }
 }
 
+/// Render an AS number in asdot+ notation (RFC 5396): always `<high16>.<low16>`,
+/// including below 65536, where it yields `0.65526` rather than `65526`.
+///
+/// Prefer [`asn_to_string`] (asdot) for display. This form exists for callers
+/// where the dot itself carries meaning rather than being cosmetic — a type-2
+/// Route Distinguisher, where the dot is what separates the 4-octet-AS encoding
+/// from the 2-octet one in the overlap where both the AS and the assigned number
+/// fit in 16 bits. Identical to asdot for any AS >= 65536.
+pub fn asn_to_asdot_plus(val: u32) -> String {
+    format!("{}.{}", val >> 16, val & 0xFFFF)
+}
+
 /// Inverse of [`asn_to_string`]: accept an AS number written in either asplain
 /// (`"65546"`) or asdot/asdot+ (`"1.10"`, `"0.65526"`) notation (RFC 5396), so
 /// text copied from a peer running either convention parses. Both dotted halves
@@ -640,6 +652,30 @@ mod tests {
         }
         // asdot+ spells a 2-byte AS with an explicit zero high half.
         assert_eq!(asn_from_string("0.65526"), Some(65526));
+    }
+
+    /// asdot+ always dots, including below 65536 where asdot does not, and
+    /// agrees with asdot everywhere at/above it. `asn_from_string` reads both.
+    #[test]
+    fn asdot_plus_always_dots_and_round_trips() {
+        let cases = [
+            (100u32, "0.100"),
+            (65526, "0.65526"),
+            (65536, "1.0"),
+            (65546, "1.10"),
+            (4200000000, "64086.59904"),
+        ];
+        for (asn, asdot_plus) in cases {
+            assert_eq!(asn_to_asdot_plus(asn), asdot_plus, "asdot+ of {asn}");
+            assert_eq!(asn_from_string(asdot_plus), Some(asn), "parse {asdot_plus}");
+        }
+        // At or above 65536 asdot+ and asdot are the same string.
+        for asn in [65536u32, 65546, 4200000000] {
+            assert_eq!(asn_to_asdot_plus(asn), asn_to_string(asn), "asn {asn}");
+        }
+        // Below 65536 they differ: that dot is what marks a type-2 RD.
+        assert_eq!(asn_to_string(100), "100");
+        assert_eq!(asn_to_asdot_plus(100), "0.100");
     }
 
     /// Both dotted halves are 16-bit; anything wider or malformed is rejected

--- a/crates/bgp-packet/src/attrs/aspath.rs
+++ b/crates/bgp-packet/src/attrs/aspath.rs
@@ -103,6 +103,32 @@ fn parse_bgp_attr_as2_segment(input: &[u8]) -> IResult<&[u8], As2Segment> {
     Ok((input, segment))
 }
 
+impl From<As2Path> for As4Path {
+    /// Widen a 2-octet AS_PATH into the 4-octet representation the rest of the
+    /// crate works in (RFC 6793 §4.2.2), zero-extending each AS number. Segment
+    /// types and order carry over unchanged, so the hop count is identical.
+    ///
+    /// This does not recover the 4-octet AS numbers that an OLD (non-AS4) peer
+    /// replaces with AS_TRANS (23456): those live in the AS4_PATH attribute
+    /// (type 17), which this crate does not implement, so an AS_TRANS widens to
+    /// a literal 23456.
+    fn from(from: As2Path) -> Self {
+        let mut path = As4Path {
+            segs: from
+                .segs
+                .iter()
+                .map(|seg| As4Segment {
+                    typ: seg.typ,
+                    asn: seg.asn.iter().map(|asn| u32::from(*asn)).collect(),
+                })
+                .collect(),
+            length: 0,
+        };
+        path.update_length();
+        path
+    }
+}
+
 fn parse_bgp_attr_as4_segment(input: &[u8]) -> IResult<&[u8], As4Segment> {
     let (input, header) = AsSegmentHeader::parse_be(input)?;
     let (input, asns) = count(be_u32, header.length as usize).parse(input)?;
@@ -659,6 +685,37 @@ impl Default for As4Path {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// Widening a 2-octet AS_PATH preserves segment types, order, ASN values
+    /// and hop count. AS_TRANS stays literal: recovering the real 4-octet AS
+    /// behind it needs AS4_PATH (type 17), which this crate does not implement.
+    #[test]
+    fn as2_path_widens_to_as4_path() {
+        let p2 = As2Path {
+            segs: vec![
+                As2Segment {
+                    typ: AS_SEQ,
+                    asn: vec![65000, AS_TRANS],
+                },
+                As2Segment {
+                    typ: AS_SET,
+                    asn: vec![100, 200],
+                },
+            ],
+            length: 0,
+        };
+        // `.into()`, not `As4Path::from`: the inherent `As4Path::from(Vec<u32>)`
+        // shadows the `From` trait's method.
+        let p4: As4Path = p2.into();
+
+        assert_eq!(p4.segs.len(), 2);
+        assert_eq!(p4.segs[0].typ, AS_SEQ);
+        assert_eq!(p4.segs[0].asn, vec![65000u32, 23456]);
+        assert_eq!(p4.segs[1].typ, AS_SET);
+        assert_eq!(p4.segs[1].asn, vec![100u32, 200]);
+        // AS_SEQ contributes one hop per ASN, AS_SET one in total.
+        assert_eq!(p4.length, 3);
+    }
 
     /// Flatten an emitted AS_PATH back into its ASN sequence.
     fn emit_and_reparse(path: &As4Path) -> (usize, Vec<u32>) {

--- a/crates/bgp-packet/src/attrs/aspath.rs
+++ b/crates/bgp-packet/src/attrs/aspath.rs
@@ -128,6 +128,8 @@ impl As4Segment {
     }
 }
 
+/// Render an AS number in asdot notation (RFC 5396): values below 65536 in
+/// plain decimal, values at or above it as `<high16>.<low16>`.
 pub fn asn_to_string(val: u32) -> String {
     if val > 65535 {
         let hval: u32 = (val & 0xFFFF0000) >> 16;
@@ -135,6 +137,22 @@ pub fn asn_to_string(val: u32) -> String {
         hval.to_string() + "." + &lval.to_string()
     } else {
         val.to_string()
+    }
+}
+
+/// Inverse of [`asn_to_string`]: accept an AS number written in either asplain
+/// (`"65546"`) or asdot/asdot+ (`"1.10"`, `"0.65526"`) notation (RFC 5396), so
+/// text copied from a peer running either convention parses. Both dotted halves
+/// are 16-bit, so `"169031.1"` and `"1.2.3"` are rejected rather than silently
+/// truncated. Returns `None` when the text is not a valid AS number.
+pub fn asn_from_string(s: &str) -> Option<u32> {
+    match s.split_once('.') {
+        Some((high, low)) => {
+            let high: u16 = high.parse().ok()?;
+            let low: u16 = low.parse().ok()?;
+            Some(((high as u32) << 16) | low as u32)
+        }
+        None => s.parse::<u32>().ok(),
     }
 }
 
@@ -603,6 +621,38 @@ impl Default for As4Path {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// `asn_from_string` accepts both RFC 5396 notations and round-trips
+    /// `asn_to_string` (which renders asdot).
+    #[test]
+    fn asn_string_notations_round_trip() {
+        // (asplain, asdot) for the same AS.
+        let cases = [
+            (65526u32, "65526", "65526"),
+            (65546, "65546", "1.10"),
+            (65536, "65536", "1.0"),
+            (4200000000, "4200000000", "64086.59904"),
+        ];
+        for (asn, asplain, asdot) in cases {
+            assert_eq!(asn_to_string(asn), asdot, "asn_to_string({asn})");
+            assert_eq!(asn_from_string(asplain), Some(asn), "asplain {asplain}");
+            assert_eq!(asn_from_string(asdot), Some(asn), "asdot {asdot}");
+        }
+        // asdot+ spells a 2-byte AS with an explicit zero high half.
+        assert_eq!(asn_from_string("0.65526"), Some(65526));
+    }
+
+    /// Both dotted halves are 16-bit; anything wider or malformed is rejected
+    /// rather than silently truncated.
+    #[test]
+    fn asn_from_string_rejects_malformed() {
+        for s in ["169031.1", "1.65536", "1.2.3", "", ".", "1.", ".1", "abc"] {
+            assert_eq!(asn_from_string(s), None, "must reject {s:?}");
+        }
+        // u32::MAX is the largest valid asplain AS.
+        assert_eq!(asn_from_string("4294967295"), Some(u32::MAX));
+        assert_eq!(asn_from_string("4294967296"), None);
+    }
 
     #[test]
     fn parse() {

--- a/crates/bgp-packet/src/attrs/attr.rs
+++ b/crates/bgp-packet/src/attrs/attr.rs
@@ -26,7 +26,17 @@ pub enum AttrType {
     MpUnreachNlri = 15,
     ExtendedCom = 16,
     PmsiTunnel = 22,
-    ExtendedIpv6Com = 25,
+    // 25 — RFC 5701 IPv6 Address Specific Extended Community — is deliberately
+    // absent, and must only be re-added together with an
+    // `Attr::ExtendedIpv6Com` variant.
+    //
+    // Every code named here must have a matching `Attr` variant. Naming one
+    // without it is strictly worse than not recognising the code at all: the
+    // type stops matching `AttrType::Unknown`, so it skips the RFC 4271 §9
+    // handling below, reaches `parse_attr_value`, fails the derived Switch with
+    // no arm to select, and — not being a treat-as-withdraw attribute — resets
+    // the session. Left unnamed it decodes as `Unknown(25)` and takes the §9
+    // optional-transitive path: retained with the Partial bit and propagated.
     Aigp = 26,
     LargeCom = 32,
     PrefixSid = 40,
@@ -53,7 +63,6 @@ impl From<u8> for AttrType {
             15 => MpUnreachNlri,
             16 => ExtendedCom,
             22 => PmsiTunnel,
-            25 => ExtendedIpv6Com,
             26 => Aigp,
             32 => LargeCom,
             40 => PrefixSid,
@@ -82,7 +91,6 @@ impl From<AttrType> for u8 {
             MpUnreachNlri => 15,
             ExtendedCom => 16,
             PmsiTunnel => 22,
-            ExtendedIpv6Com => 25,
             Aigp => 26,
             LargeCom => 32,
             PrefixSid => 40,
@@ -641,6 +649,45 @@ mod tests {
             }
             other => panic!("Flowspec MP_REACH must surface as mp_update, got {other:?}"),
         }
+    }
+
+    /// An RFC 5701 IPv6 Address Specific Extended Community (type 25) must not
+    /// tear the session down. Regression: `AttrType` named the code without an
+    /// `Attr` variant to select, so it skipped the RFC 4271 §9 handling, failed
+    /// the derived Switch in `parse_attr_value`, and — not being a
+    /// treat-as-withdraw attribute — propagated the error out as a session
+    /// reset. Unnamed, it is `Unknown(25)`: optional+transitive, so retained
+    /// with the Partial bit and propagated.
+    #[test]
+    fn ipv6_ext_community_is_passed_through_not_session_reset() {
+        let mut block = ORIGIN_IGP.to_vec();
+        // flags 0xC0 (optional+transitive), type 25, length 20:
+        // type/sub-type 0x00/0x02 (RT), 2001:db8::1, local admin 100.
+        let mut v = vec![0xC0u8, 25, 20, 0x00, 0x02];
+        v.extend_from_slice(
+            &"2001:db8::1"
+                .parse::<std::net::Ipv6Addr>()
+                .unwrap()
+                .octets(),
+        );
+        v.extend_from_slice(&100u16.to_be_bytes());
+        block.extend_from_slice(&v);
+
+        let len = block.len() as u16;
+        let (_, bgp_attr, _, _, treat_as_withdraw) =
+            parse_bgp_update_attribute(&block, len, true, None)
+                .expect("an IPv6 ext-community must not reset the session");
+        assert!(!treat_as_withdraw);
+
+        let bgp_attr = bgp_attr.expect("bgp_attr present");
+        assert!(bgp_attr.origin.is_some(), "well-known attributes survive");
+        assert_eq!(bgp_attr.unknown.len(), 1, "retained for propagation");
+        let u = &bgp_attr.unknown[0];
+        assert_eq!(u.type_code, 25);
+        assert!(
+            AttributeFlags::from_bits_truncate(u.flags).contains(AttributeFlags::PARTIAL),
+            "RFC 4271 §9: Partial set on an unrecognized optional-transitive attribute"
+        );
     }
 
     // ---- 2-octet AS_PATH (RFC 6793 OLD-speaker encoding) --------------

--- a/crates/bgp-packet/src/attrs/attr.rs
+++ b/crates/bgp-packet/src/attrs/attr.rs
@@ -661,14 +661,9 @@ mod tests {
         }
     }
 
-    /// An RFC 5701 IPv6 Address Specific Extended Community (type 25) must not
-    /// tear the session down. Regression: `AttrType` named the code without an
-    /// `Attr` variant to select, so it skipped the RFC 4271 §9 handling, failed
-    /// the derived Switch in `parse_attr_value`, and — not being a
-    /// treat-as-withdraw attribute — propagated the error out as a session
-    /// reset. Unnamed, it is `Unknown(25)`: optional+transitive, so retained
-    /// with the Partial bit and propagated.
-    #[test]
+    /// A Community attribute whose length is not a non-zero multiple of 4 is
+    /// malformed, and RFC 7606 §7.8 requires treat-as-withdraw rather than a
+    /// session reset.
     #[test]
     fn community_width_violations_are_treat_as_withdraw() {
         // RFC 7606 §7.8: a Community attribute is malformed unless its length is
@@ -744,6 +739,13 @@ mod tests {
         assert!(com.is_no_export());
     }
 
+    /// An RFC 5701 IPv6 Address Specific Extended Community (type 25) must not
+    /// tear the session down. Regression: `AttrType` named the code without an
+    /// `Attr` variant to select, so it skipped the RFC 4271 §9 handling, failed
+    /// the derived Switch in `parse_attr_value`, and — not being a
+    /// treat-as-withdraw attribute — propagated the error out as a session
+    /// reset. Unnamed, it is `Unknown(25)`: optional+transitive, so retained
+    /// with the Partial bit and propagated.
     #[test]
     fn ipv6_ext_community_is_passed_through_not_session_reset() {
         let mut block = ORIGIN_IGP.to_vec();

--- a/crates/bgp-packet/src/attrs/attr.rs
+++ b/crates/bgp-packet/src/attrs/attr.rs
@@ -407,8 +407,22 @@ pub fn parse_bgp_update_attribute(
             Attr::Origin(v) => {
                 bgp_attr.origin = Some(v);
             }
-            Attr::As2Path(_v) => {
-                // TODO.
+            Attr::As2Path(v) => {
+                // Widen the 2-octet AS_PATH into the 4-octet form the rest of
+                // the crate uses (RFC 6793 §4.2.2). Discarding it left
+                // `bgp_attr.aspath` at None, so the route would be accepted with
+                // no AS_PATH at all — no loop detection, no path-length
+                // comparison — and re-advertised without a well-known mandatory
+                // attribute.
+                //
+                // Not reachable today: `peer_packet_parse` passes a hardcoded
+                // `as4 = true`, so AS_PATH always parses as `As4Path` and this
+                // arm runs only from tests. It is wired up so that sourcing
+                // `as4` from the negotiated capability cannot silently lose
+                // AS_PATHs. Doing that properly also needs AS4_PATH (type 17)
+                // to recover the 4-octet ASNs an OLD peer hides behind
+                // AS_TRANS; neither attribute is implemented here.
+                bgp_attr.aspath = Some(v.into());
             }
             Attr::As4Path(v) => {
                 bgp_attr.aspath = Some(v);
@@ -627,6 +641,39 @@ mod tests {
             }
             other => panic!("Flowspec MP_REACH must surface as mp_update, got {other:?}"),
         }
+    }
+
+    // ---- 2-octet AS_PATH (RFC 6793 OLD-speaker encoding) --------------
+
+    /// A 2-octet AS_PATH must reach `bgp_attr.aspath`, widened to the 4-octet
+    /// form. Regression: the `Attr::As2Path` arm was an empty `// TODO`, so the
+    /// well-known mandatory AS_PATH was parsed and then silently dropped,
+    /// leaving `aspath` at None.
+    ///
+    /// Only reachable with `as4 = false`; `peer_packet_parse` hardcodes `true`
+    /// today, so this guards the wiring rather than live behaviour.
+    #[test]
+    fn as2_path_reaches_bgp_attr_widened() {
+        // ORIGIN = IGP, then AS_PATH (type 2, len 6): AS_SEQ of 65000 65001.
+        let mut block = vec![0x40, 0x01, 0x01, 0x00];
+        block.extend_from_slice(&[0x40, 0x02, 0x06, 0x02, 0x02, 0xfd, 0xe8, 0xfd, 0xe9]);
+
+        let len = block.len() as u16;
+        let (_, bgp_attr, _, _, treat_as_withdraw) =
+            parse_bgp_update_attribute(&block, len, false, None).expect("attrs must parse");
+        assert!(!treat_as_withdraw);
+
+        let aspath = bgp_attr
+            .expect("bgp_attr present")
+            .aspath
+            .expect("2-octet AS_PATH must not be dropped");
+        let flat: Vec<u32> = aspath
+            .segs
+            .iter()
+            .flat_map(|s| s.asn.iter().copied())
+            .collect();
+        assert_eq!(flat, vec![65000u32, 65001], "ASNs widened to 4 octets");
+        assert_eq!(aspath.length, 2, "hop count preserved");
     }
 
     // ---- RFC 4271 §9 unrecognized attribute handling -----------------

--- a/crates/bgp-packet/src/attrs/attr.rs
+++ b/crates/bgp-packet/src/attrs/attr.rs
@@ -333,7 +333,17 @@ impl Attr {
 /// tear the session down). Other attributes keep their existing
 /// (session-reset) handling.
 fn attr_malformation_is_withdraw(attr_type: AttrType) -> bool {
-    matches!(attr_type, AttrType::PrefixSid)
+    matches!(
+        attr_type,
+        // RFC 7606 §7.8: a Community attribute whose length is not a non-zero
+        // multiple of 4 is malformed and "SHALL be handled using the approach of
+        // 'treat-as-withdraw'".
+        AttrType::Community
+            // RFC 8092 §3 says the same of a Large Communities attribute whose
+            // length is not a non-zero multiple of 12.
+            | AttrType::LargeCom
+            | AttrType::PrefixSid
+    )
 }
 
 type ParsedAttributes<'a> = Result<
@@ -658,6 +668,82 @@ mod tests {
     /// treat-as-withdraw attribute — propagated the error out as a session
     /// reset. Unnamed, it is `Unknown(25)`: optional+transitive, so retained
     /// with the Partial bit and propagated.
+    #[test]
+    #[test]
+    fn community_width_violations_are_treat_as_withdraw() {
+        // RFC 7606 §7.8: a Community attribute is malformed unless its length is
+        // a non-zero multiple of 4, and a malformed one "SHALL be handled using
+        // the approach of 'treat-as-withdraw'".
+        //
+        // Regression: the `Vec<u32>` decode stopped at the last whole value and
+        // the leftover was discarded, so a 6-octet payload parsed as one
+        // community, the two stray octets vanished, and the route installed.
+        for value in [
+            vec![0x00u8, 0x01, 0x00, 0x02, 0xAA, 0xBB], // 6: one value + 2 stray
+            vec![],                                     // 0: must be non-zero
+            vec![0x00, 0x01, 0x00],                     // 3: short of one value
+        ] {
+            let mut block = ORIGIN_IGP.to_vec();
+            block.extend_from_slice(&[0xC0, 8, value.len() as u8]);
+            block.extend_from_slice(&value);
+            let len = block.len() as u16;
+
+            let (_, bgp_attr, _, _, treat_as_withdraw) =
+                parse_bgp_update_attribute(&block, len, true, None)
+                    .expect("must not reset the session");
+            assert!(
+                treat_as_withdraw,
+                "COMMUNITIES length {} must be treat-as-withdraw",
+                value.len()
+            );
+            let bgp_attr = bgp_attr.expect("bgp_attr present");
+            assert!(
+                bgp_attr.com.is_none(),
+                "the malformed attribute is discarded"
+            );
+            assert!(bgp_attr.origin.is_some(), "other attributes still parse");
+        }
+    }
+
+    /// RFC 8092 §3: the same, for a Large Communities attribute whose length is
+    /// not a non-zero multiple of 12.
+    #[test]
+    fn large_community_width_violations_are_treat_as_withdraw() {
+        for n in [14usize, 0, 11] {
+            let mut block = ORIGIN_IGP.to_vec();
+            block.extend_from_slice(&[0xC0, 32, n as u8]);
+            block.extend(std::iter::repeat_n(0u8, n));
+            let len = block.len() as u16;
+
+            let (_, bgp_attr, _, _, treat_as_withdraw) =
+                parse_bgp_update_attribute(&block, len, true, None)
+                    .expect("must not reset the session");
+            assert!(
+                treat_as_withdraw,
+                "LARGE_COMMUNITY length {n} must be treat-as-withdraw"
+            );
+            assert!(bgp_attr.expect("bgp_attr").lcom.is_none());
+        }
+    }
+
+    /// Well-formed widths still parse, so the check rejects only real
+    /// violations.
+    #[test]
+    fn well_formed_community_widths_still_parse() {
+        let mut block = ORIGIN_IGP.to_vec();
+        block.extend_from_slice(&[0xC0, 8, 8, 0x00, 0x01, 0x00, 0x02, 0xFF, 0xFF, 0xFF, 0x01]);
+        let len = block.len() as u16;
+        let (_, bgp_attr, _, _, treat_as_withdraw) =
+            parse_bgp_update_attribute(&block, len, true, None).expect("must parse");
+        assert!(!treat_as_withdraw);
+        let com = bgp_attr
+            .expect("bgp_attr")
+            .com
+            .expect("communities present");
+        assert_eq!(com.0.len(), 2);
+        assert!(com.is_no_export());
+    }
+
     #[test]
     fn ipv6_ext_community_is_passed_through_not_session_reset() {
         let mut block = ORIGIN_IGP.to_vec();

--- a/crates/bgp-packet/src/attrs/com.rs
+++ b/crates/bgp-packet/src/attrs/com.rs
@@ -1,5 +1,6 @@
 use bytes::{BufMut, BytesMut};
 use nom::IResult;
+use nom::error::{ErrorKind, make_error};
 use nom_derive::Parse;
 use std::collections::{BTreeSet, HashMap};
 use std::fmt;
@@ -52,6 +53,16 @@ impl<'a> Parse<&'a [u8]> for Community {
         Self::parse_be(input)
     }
     fn parse_be(input: &'a [u8]) -> IResult<&'a [u8], Self> {
+        // RFC 7606 §7.8: "The Community attribute SHALL be considered malformed
+        // if its length is not a non-zero multiple of 4." Without this the
+        // `Vec<u32>` decode simply stopped at the last whole value and the
+        // attribute path discarded the remainder, so a 6-octet payload yielded
+        // one community and silently dropped two octets — the route installed as
+        // though the sender had never written them. `ClusterList` already
+        // enforces its own width this way.
+        if input.is_empty() || !input.len().is_multiple_of(4) {
+            return Err(nom::Err::Error(make_error(input, ErrorKind::LengthValue)));
+        }
         let (input, values) = <Vec<u32>>::parse_be(input)?;
         Ok((input, values.into_iter().collect()))
     }

--- a/crates/bgp-packet/src/attrs/ext_com.rs
+++ b/crates/bgp-packet/src/attrs/ext_com.rs
@@ -851,6 +851,12 @@ impl From<RouteDistinguisher> for ExtCommunityValue {
             RouteDistinguisherType::IP => {
                 to.high_type = 0x01;
             }
+            // Four-Octet AS Specific extended community (RFC 5668): the 6-octet
+            // value is a 4-octet AS followed by a 2-octet local administrator,
+            // the same layout as a type-2 RD.
+            RouteDistinguisherType::ASN4 => {
+                to.high_type = 0x02;
+            }
         }
         to
     }
@@ -859,6 +865,27 @@ impl From<RouteDistinguisher> for ExtCommunityValue {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// Each RD type maps onto the extended-community high_type that carries the
+    /// same 6-octet value layout: 0x00 Two-Octet AS, 0x01 IPv4, 0x02 Four-Octet
+    /// AS (RFC 5668). The type-2 arm matters because `matching_import_vrfs`
+    /// compares configured RTs against RDs rebuilt from the wire, and
+    /// `RouteDistinguisher`'s Eq includes `typ`.
+    #[test]
+    fn rd_type_maps_to_ext_community_high_type() {
+        let cases = [
+            (RouteDistinguisherType::ASN, 0x00u8),
+            (RouteDistinguisherType::IP, 0x01),
+            (RouteDistinguisherType::ASN4, 0x02),
+        ];
+        for (typ, high_type) in cases {
+            let mut rd = RouteDistinguisher::new(typ);
+            rd.val = [0xfa, 0x56, 0xea, 0x00, 0x00, 0x01];
+            let ecom: ExtCommunityValue = rd.into();
+            assert_eq!(ecom.high_type, high_type, "RD type {typ:?}");
+            assert_eq!(ecom.val, rd.val, "value carried verbatim");
+        }
+    }
 
     #[test]
     fn parse() {

--- a/crates/bgp-packet/src/attrs/ext_ipv6_com.rs
+++ b/crates/bgp-packet/src/attrs/ext_ipv6_com.rs
@@ -1,7 +1,7 @@
 use bytes::{BufMut, BytesMut};
 use nom_derive::NomBE;
 use std::fmt;
-use std::net::{Ipv4Addr, Ipv6Addr};
+use std::net::Ipv6Addr;
 use std::str::FromStr;
 
 use crate::ExtCommunitySubType;
@@ -45,15 +45,19 @@ fn sub_type_str(sub_type: u8) -> &'static str {
 
 impl fmt::Display for ExtIpv6CommunityValue {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        if self.high_type == 0 {
-            let asn = u16::from_be_bytes([self.val[0], self.val[1]]);
-            let val = u32::from_be_bytes([self.val[2], self.val[3], self.val[4], self.val[5]]);
-            write!(f, "{} {asn}:{val}", sub_type_str(self.low_type))
-        } else {
-            let ip = Ipv4Addr::new(self.val[0], self.val[1], self.val[2], self.val[3]);
-            let val = u16::from_be_bytes([self.val[4], self.val[5]]);
-            write!(f, "{} {ip}:{val}", sub_type_str(self.low_type))
-        }
+        // RFC 5701 §2: type, sub-type, a 16-octet IPv6 Global Administrator and
+        // a 2-octet Local Administrator — 20 octets, the layout `new()` writes.
+        // This previously read the 8-octet AS/IPv4-specific layouts instead
+        // (`val[0..2]` as an ASN, or `val[0..4]` as an IPv4 address), branching
+        // on `high_type == 0`, which for this attribute distinguishes
+        // transitive from non-transitive rather than naming an address family.
+        // It rendered the first octets of the IPv6 address as an unrelated
+        // number and never showed the Local Administrator at all.
+        let mut addr = [0u8; 16];
+        addr.copy_from_slice(&self.val[0..16]);
+        let ip = Ipv6Addr::from(addr);
+        let local = u16::from_be_bytes([self.val[16], self.val[17]]);
+        write!(f, "{} {ip}:{local}", sub_type_str(self.low_type))
     }
 }
 
@@ -65,7 +69,11 @@ impl ExtIpv6CommunityValue {
             val: [0u8; 18],
         };
         com.val[0..16].copy_from_slice(&addr.octets());
-        com.val[16..18].copy_from_slice(val.to_ne_bytes().as_slice());
+        // Big-endian: BGP is a network-byte-order protocol, and `encode()`
+        // copies `val` to the wire verbatim. `to_ne_bytes` byte-swapped the
+        // Local Administrator on every little-endian host, so a peer decoded
+        // e.g. 100 as 25600.
+        com.val[16..18].copy_from_slice(val.to_be_bytes().as_slice());
         com
     }
 }
@@ -82,12 +90,94 @@ impl fmt::Display for ExtIpv6Community {
     }
 }
 
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use bytes::BytesMut;
+
+    /// The Local Administrator must reach the wire big-endian. Regression:
+    /// `new()` used `to_ne_bytes`, so on any little-endian host the two octets
+    /// were swapped and a peer read 100 as 25600.
+    #[test]
+    fn local_admin_is_big_endian_on_the_wire() {
+        let addr: Ipv6Addr = "2001:db8::1".parse().unwrap();
+        let com = ExtIpv6CommunityValue::new(addr, 100);
+        assert_eq!(
+            &com.val[16..18],
+            &100u16.to_be_bytes(),
+            "Local Administrator is network byte order"
+        );
+
+        // RFC 5701 §2: 20 octets — type, sub-type, 16-octet IPv6, 2-octet local.
+        let mut buf = BytesMut::new();
+        com.encode(&mut buf);
+        assert_eq!(buf.len(), 20);
+        assert_eq!(&buf[2..18], &addr.octets(), "Global Administrator");
+        assert_eq!(&buf[18..20], &[0x00, 0x64], "Local Administrator = 100");
+    }
+
+    /// Display renders the RFC 5701 layout `new()` actually writes. Regression:
+    /// it read the 8-octet AS/IPv4-specific layouts, so a value built by `new()`
+    /// printed a number made of the IPv6 address's leading octets and never
+    /// showed the Local Administrator.
+    #[test]
+    fn display_uses_the_rfc5701_layout() {
+        let addr: Ipv6Addr = "2001:db8::1".parse().unwrap();
+        let mut com = ExtIpv6CommunityValue::new(addr, 100);
+        com.low_type = 0x02;
+        assert_eq!(com.to_string(), "rt 2001:db8::1:100");
+
+        com.low_type = 0x03;
+        assert_eq!(com.to_string(), "soo 2001:db8::1:100");
+    }
+
+    /// `from_str` round-trips through the tokenizer for both keywords.
+    #[test]
+    fn from_str_round_trips() {
+        let ecom: ExtIpv6Community = "rt [2001:db8::1]:100".parse().unwrap();
+        assert_eq!(ecom.0.len(), 1);
+        assert_eq!(ecom.0[0].low_type, 0x02);
+        assert_eq!(ecom.0[0].to_string(), "rt 2001:db8::1:100");
+
+        let ecom: ExtIpv6Community = "soo [2001:db8::1]:100".parse().unwrap();
+        assert_eq!(ecom.0[0].low_type, 0x03);
+    }
+
+    /// Malformed input returns the declared `Err(())`. Regression: `from_str`
+    /// called `tokenizer(..).unwrap()`, panicking the thread on any tokenizer
+    /// error instead of honouring the `FromStr` contract.
+    #[test]
+    fn from_str_rejects_malformed_without_panicking() {
+        for s in [
+            "@@bad@@",               // unexpected character
+            "bogus [2001:db8::1]:1", // unknown keyword
+            "rt [zzzz]:1",           // unparseable address
+            "rt [2001:db8::1]",      // no local administrator
+            "[2001:db8::1]:1",       // value with no rt/soo keyword
+        ] {
+            assert!(
+                s.parse::<ExtIpv6Community>().is_err(),
+                "must return Err, not panic: {s:?}"
+            );
+        }
+        // A bare keyword with no value tokenizes cleanly and yields an empty
+        // list rather than an error — pre-existing behaviour, pinned here so the
+        // distinction from the malformed cases above is deliberate.
+        let ecom: ExtIpv6Community = "rt".parse().expect("bare keyword is not an error");
+        assert!(ecom.0.is_empty());
+    }
+}
+
 impl FromStr for ExtIpv6Community {
     type Err = ();
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         let mut ecom = ExtIpv6Community::default();
-        let tokens = tokenizer(String::from(s)).unwrap();
+        // Return the declared `Err(())` rather than panicking: the tokenizer
+        // rejects an unknown keyword, an unexpected character or a malformed
+        // address, all of which are reachable from operator input. `ExtCommunity`
+        // already handles the same call this way.
+        let tokens = tokenizer(String::from(s)).map_err(|_| ())?;
         let mut state = State::Unspec;
 
         for token in tokens.into_iter() {

--- a/crates/bgp-packet/src/attrs/ext_ipv6_com.rs
+++ b/crates/bgp-packet/src/attrs/ext_ipv6_com.rs
@@ -90,6 +90,47 @@ impl fmt::Display for ExtIpv6Community {
     }
 }
 
+impl FromStr for ExtIpv6Community {
+    type Err = ();
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let mut ecom = ExtIpv6Community::default();
+        // Return the declared `Err(())` rather than panicking: the tokenizer
+        // rejects an unknown keyword, an unexpected character or a malformed
+        // address, all of which are reachable from operator input. `ExtCommunity`
+        // already handles the same call this way.
+        let tokens = tokenizer(String::from(s)).map_err(|_| ())?;
+        let mut state = State::Unspec;
+
+        for token in tokens.into_iter() {
+            match token {
+                Token::Rd(rd, num) => {
+                    let mut val = ExtIpv6CommunityValue::new(rd, num);
+                    match state {
+                        State::Unspec => {
+                            return Err(());
+                        }
+                        State::Rt => {
+                            val.low_type = 0x02;
+                        }
+                        State::Soo => {
+                            val.low_type = 0x03;
+                        }
+                    }
+                    ecom.0.push(val);
+                }
+                Token::Rt => {
+                    state = State::Rt;
+                }
+                Token::Soo => {
+                    state = State::Soo;
+                }
+            }
+        }
+        Ok(ecom)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -165,46 +206,5 @@ mod tests {
         // distinction from the malformed cases above is deliberate.
         let ecom: ExtIpv6Community = "rt".parse().expect("bare keyword is not an error");
         assert!(ecom.0.is_empty());
-    }
-}
-
-impl FromStr for ExtIpv6Community {
-    type Err = ();
-
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        let mut ecom = ExtIpv6Community::default();
-        // Return the declared `Err(())` rather than panicking: the tokenizer
-        // rejects an unknown keyword, an unexpected character or a malformed
-        // address, all of which are reachable from operator input. `ExtCommunity`
-        // already handles the same call this way.
-        let tokens = tokenizer(String::from(s)).map_err(|_| ())?;
-        let mut state = State::Unspec;
-
-        for token in tokens.into_iter() {
-            match token {
-                Token::Rd(rd, num) => {
-                    let mut val = ExtIpv6CommunityValue::new(rd, num);
-                    match state {
-                        State::Unspec => {
-                            return Err(());
-                        }
-                        State::Rt => {
-                            val.low_type = 0x02;
-                        }
-                        State::Soo => {
-                            val.low_type = 0x03;
-                        }
-                    }
-                    ecom.0.push(val);
-                }
-                Token::Rt => {
-                    state = State::Rt;
-                }
-                Token::Soo => {
-                    state = State::Soo;
-                }
-            }
-        }
-        Ok(ecom)
     }
 }

--- a/crates/bgp-packet/src/attrs/large_com.rs
+++ b/crates/bgp-packet/src/attrs/large_com.rs
@@ -1,5 +1,6 @@
 use bytes::{BufMut, BytesMut};
 use nom::IResult;
+use nom::error::{ErrorKind, make_error};
 use nom_derive::{NomBE, Parse};
 use std::collections::BTreeSet;
 use std::fmt;
@@ -66,6 +67,15 @@ impl<'a> Parse<&'a [u8]> for LargeCommunity {
         Self::parse_be(input)
     }
     fn parse_be(input: &'a [u8]) -> IResult<&'a [u8], Self> {
+        // RFC 8092 §3: "A BGP Large Communities attribute SHALL be considered
+        // malformed if the length of the BGP Large Communities Attribute value,
+        // expressed in octets, is not a non-zero multiple of 12." Without this
+        // the `Vec<LargeCommunityValue>` decode stopped at the last whole value
+        // and the attribute path dropped the remainder, so a 14-octet payload
+        // yielded one value and discarded two octets.
+        if input.is_empty() || !input.len().is_multiple_of(12) {
+            return Err(nom::Err::Error(make_error(input, ErrorKind::LengthValue)));
+        }
         let (input, values) = <Vec<LargeCommunityValue>>::parse_be(input)?;
         Ok((input, values.into_iter().collect()))
     }

--- a/crates/bgp-packet/src/attrs/mp_reach.rs
+++ b/crates/bgp-packet/src/attrs/mp_reach.rs
@@ -12,7 +12,7 @@ use bytes::BufMut;
 use crate::{
     Afi, AttrFlags, AttrType, BgpLsNlri, EvpnRoute, FlowspecNlri, Ipv4Nlri, Ipv6Nlri, Labelv4Nlri,
     Labelv6Nlri, MupRoute, ParseBe, ParseNlri, ParseOption, Rtcv4, Rtcv6, Safi, SrPolicyNlri,
-    Vpnv4Nexthop, Vpnv4Nlri, Vpnv6Nexthop, Vpnv6Nlri, esi_display, many0_complete,
+    Vpnv4Nexthop, Vpnv4Nlri, Vpnv6Nexthop, Vpnv6Nlri, esi_display, parse_nlri_block,
 };
 
 use super::{AttrEmitter, RouteDistinguisher, Rtcv4Reach, Rtcv6Reach, Vpnv4Reach, Vpnv6Reach};
@@ -236,8 +236,7 @@ impl MpReachAttr {
                 _ => return Err(nom::Err::Error(make_error(input, ErrorKind::LengthValue))),
             };
             let (input, snpa) = be_u8(input)?;
-            let (_, updates) =
-                many0_complete(|i| Vpnv4Nlri::parse_nlri(i, add_path)).parse(input)?;
+            let (_, updates) = parse_nlri_block(input, |i| Vpnv4Nlri::parse_nlri(i, add_path))?;
             let nlri = Vpnv4Reach {
                 snpa,
                 nhop,
@@ -279,8 +278,7 @@ impl MpReachAttr {
                 _ => return Err(nom::Err::Error(make_error(input, ErrorKind::LengthValue))),
             };
             let (input, snpa) = be_u8(input)?;
-            let (_, updates) =
-                many0_complete(|i| Vpnv6Nlri::parse_nlri(i, add_path)).parse(input)?;
+            let (_, updates) = parse_nlri_block(input, |i| Vpnv6Nlri::parse_nlri(i, add_path))?;
             let nlri = Vpnv6Reach {
                 snpa,
                 nhop,
@@ -318,8 +316,7 @@ impl MpReachAttr {
                 _ => return Err(nom::Err::Error(make_error(input, ErrorKind::LengthValue))),
             };
             let (input, snpa) = be_u8(input)?;
-            let (_, updates) =
-                many0_complete(|i| Ipv4Nlri::parse_nlri(i, add_path)).parse(input)?;
+            let (_, updates) = parse_nlri_block(input, |i| Ipv4Nlri::parse_nlri(i, add_path))?;
             let mp_nlri = MpReachAttr::Ipv4 {
                 snpa,
                 nhop,
@@ -348,8 +345,7 @@ impl MpReachAttr {
             };
             let nhop = IpAddr::V6(nhop);
             let (input, snpa) = be_u8(input)?;
-            let (_, updates) =
-                many0_complete(|i| Ipv6Nlri::parse_nlri(i, add_path)).parse(input)?;
+            let (_, updates) = parse_nlri_block(input, |i| Ipv6Nlri::parse_nlri(i, add_path))?;
             let mp_nlri = MpReachAttr::Ipv6 {
                 snpa,
                 nhop,
@@ -379,8 +375,7 @@ impl MpReachAttr {
                 _ => return Err(nom::Err::Error(make_error(input, ErrorKind::LengthValue))),
             };
             let (input, snpa) = be_u8(input)?;
-            let (_, updates) =
-                many0_complete(|i| Labelv4Nlri::parse_nlri(i, add_path)).parse(input)?;
+            let (_, updates) = parse_nlri_block(input, |i| Labelv4Nlri::parse_nlri(i, add_path))?;
             let mp_nlri = MpReachAttr::Labelv4 {
                 snpa,
                 nhop,
@@ -405,8 +400,7 @@ impl MpReachAttr {
                 _ => return Err(nom::Err::Error(make_error(input, ErrorKind::LengthValue))),
             };
             let (input, snpa) = be_u8(input)?;
-            let (_, updates) =
-                many0_complete(|i| Labelv6Nlri::parse_nlri(i, add_path)).parse(input)?;
+            let (_, updates) = parse_nlri_block(input, |i| Labelv6Nlri::parse_nlri(i, add_path))?;
             let mp_nlri = MpReachAttr::Labelv6 {
                 snpa,
                 nhop,
@@ -431,8 +425,7 @@ impl MpReachAttr {
             let (input, snpa) = be_u8(input)?;
 
             // EVPN
-            let (input, updates) =
-                many0_complete(|i| EvpnRoute::parse_nlri(i, add_path)).parse(input)?;
+            let (input, updates) = parse_nlri_block(input, |i| EvpnRoute::parse_nlri(i, add_path))?;
 
             let mp_nlri = MpReachAttr::Evpn {
                 snpa,
@@ -464,7 +457,7 @@ impl MpReachAttr {
             };
             let (input, snpa) = be_u8(input)?;
             let (input, updates) =
-                many0_complete(|i| MupRoute::parse(i, add_path, header.afi)).parse(input)?;
+                parse_nlri_block(input, |i| MupRoute::parse(i, add_path, header.afi))?;
             let mp_nlri = MpReachAttr::Mup {
                 afi: header.afi,
                 snpa,
@@ -488,8 +481,7 @@ impl MpReachAttr {
                 (input, nhop)
             };
             let (input, snpa) = be_u8(input)?;
-            let (input, updates) =
-                many0_complete(|i| Rtcv4::parse_nlri(i, add_path)).parse(input)?;
+            let (input, updates) = parse_nlri_block(input, |i| Rtcv4::parse_nlri(i, add_path))?;
             let nlri = Rtcv4Reach {
                 snpa,
                 nhop,
@@ -508,7 +500,7 @@ impl MpReachAttr {
             let (input, _nhop) = take(header.nhop_len as usize).parse(input)?;
             let (input, _snpa) = be_u8(input)?;
             let (input, updates) =
-                many0_complete(|i| FlowspecNlri::parse(i, add_path, header.afi)).parse(input)?;
+                parse_nlri_block(input, |i| FlowspecNlri::parse(i, add_path, header.afi))?;
             let mp_nlri = MpReachAttr::Flowspec {
                 afi: header.afi,
                 updates,
@@ -530,8 +522,7 @@ impl MpReachAttr {
                 (input, nhop)
             };
             let (input, snpa) = be_u8(input)?;
-            let (input, updates) =
-                many0_complete(|i| Rtcv6::parse_nlri(i, add_path)).parse(input)?;
+            let (input, updates) = parse_nlri_block(input, |i| Rtcv6::parse_nlri(i, add_path))?;
             let nlri = Rtcv6Reach {
                 snpa,
                 nhop,
@@ -563,7 +554,7 @@ impl MpReachAttr {
             };
             let (input, snpa) = be_u8(input)?;
             let (input, updates) =
-                many0_complete(|i| SrPolicyNlri::parse(i, add_path, header.afi)).parse(input)?;
+                parse_nlri_block(input, |i| SrPolicyNlri::parse(i, add_path, header.afi))?;
             let mp_nlri = MpReachAttr::SrPolicy {
                 afi: header.afi,
                 snpa,
@@ -585,8 +576,7 @@ impl MpReachAttr {
                 (input, IpAddr::V6(Ipv6Addr::from(addr)))
             };
             let (input, _snpa) = be_u8(input)?;
-            let (input, updates) =
-                many0_complete(|i| BgpLsNlri::parse(i, add_path)).parse(input)?;
+            let (input, updates) = parse_nlri_block(input, |i| BgpLsNlri::parse(i, add_path))?;
             return Ok((input, MpReachAttr::LinkState { nhop, updates }));
         }
         Err(nom::Err::Error(make_error(input, ErrorKind::NoneOf)))
@@ -1202,6 +1192,40 @@ pub(crate) fn linkstate_attr_emit(nhop: &IpAddr, updates: &[BgpLsNlri], buf: &mu
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// A malformed NLRI must fail the whole block rather than silently
+    /// truncating it. Regression: every arm read its NLRI with a bare
+    /// `many0_complete` and discarded the leftover, so `[valid, malformed]`
+    /// parsed as `Ok([valid])` — the peer believed it advertised routes we
+    /// never installed, and nothing anywhere raised an error. RFC 7606 §3(j)
+    /// requires the session-reset approach when the affected routes cannot be
+    /// determined, which is exactly the case once an NLRI fails to parse.
+    #[test]
+    fn malformed_nlri_fails_the_block_instead_of_truncating_it() {
+        // afi=1 safi=1, nhop_len=4, nhop 192.0.2.1, snpa=0, then the NLRI:
+        //   [24, 10,0,0]    -> 10.0.0.0/24, valid
+        //   [33, 1,2,3,4,5] -> prefix length 33 exceeds 32, malformed
+        let payload = [
+            0x00u8, 0x01, 0x01, 0x04, 0xC0, 0x00, 0x02, 0x01, 0x00, //
+            24, 10, 0, 0, //
+            33, 1, 2, 3, 4, 5,
+        ];
+        assert!(
+            MpReachAttr::parse_nlri_opt(&payload, None).is_err(),
+            "a malformed NLRI must not be swallowed with the rest of the block"
+        );
+
+        // The same block without the malformed entry still parses, so the check
+        // rejects only genuinely short-stopping blocks.
+        let ok = [
+            0x00u8, 0x01, 0x01, 0x04, 0xC0, 0x00, 0x02, 0x01, 0x00, 24, 10, 0, 0,
+        ];
+        let (_, attr) = MpReachAttr::parse_nlri_opt(&ok, None).expect("well-formed must parse");
+        match attr {
+            MpReachAttr::Ipv4 { updates, .. } => assert_eq!(updates.len(), 1),
+            other => panic!("expected Ipv4, got {other:?}"),
+        }
+    }
 
     /// Hand-rolled MP_REACH value (no attr header — `parse_nlri_opt`
     /// reads just the inner value): AFI + SAFI + nhop_len + nhop +

--- a/crates/bgp-packet/src/attrs/mp_unreach.rs
+++ b/crates/bgp-packet/src/attrs/mp_unreach.rs
@@ -7,7 +7,7 @@ use nom_derive::*;
 use crate::{
     Afi, AttrFlags, AttrType, BgpLsNlri, EvpnRoute, FlowspecNlri, Ipv6Nlri, Labelv4Nlri,
     Labelv6Nlri, MupRoute, ParseBe, ParseNlri, ParseOption, Rtcv4, Rtcv4Unreach, Rtcv6,
-    Rtcv6Unreach, Safi, SrPolicyNlri, Vpnv4Nlri, Vpnv6Nlri, many0_complete,
+    Rtcv6Unreach, Safi, SrPolicyNlri, Vpnv4Nlri, Vpnv6Nlri, parse_nlri_block,
 };
 
 use super::{AttrEmitter, Vpnv4Unreach, Vpnv6Unreach};
@@ -425,7 +425,7 @@ impl MpUnreachAttr {
                 return Ok((input, mp_nlri));
             }
             let (input, withdrawal) =
-                many0_complete(|i| Vpnv4Nlri::parse_nlri(i, add_path)).parse(input)?;
+                parse_nlri_block(input, |i| Vpnv4Nlri::parse_nlri(i, add_path))?;
             let mp_nlri = MpUnreachAttr::Vpnv4(withdrawal);
             return Ok((input, mp_nlri));
         }
@@ -435,7 +435,7 @@ impl MpUnreachAttr {
                 return Ok((input, mp_nlri));
             }
             let (input, withdrawal) =
-                many0_complete(|i| Vpnv6Nlri::parse_nlri(i, add_path)).parse(input)?;
+                parse_nlri_block(input, |i| Vpnv6Nlri::parse_nlri(i, add_path))?;
             let mp_nlri = MpUnreachAttr::Vpnv6(withdrawal);
             return Ok((input, mp_nlri));
         }
@@ -445,7 +445,7 @@ impl MpUnreachAttr {
                 return Ok((input, mp_nlri));
             }
             let (input, withdrawal) =
-                many0_complete(|i| Ipv6Nlri::parse_nlri(i, add_path)).parse(input)?;
+                parse_nlri_block(input, |i| Ipv6Nlri::parse_nlri(i, add_path))?;
             let mp_nlri = MpUnreachAttr::Ipv6Nlri(withdrawal);
             return Ok((input, mp_nlri));
         }
@@ -454,7 +454,7 @@ impl MpUnreachAttr {
                 return Ok((input, MpUnreachAttr::Labelv4Eor));
             }
             let (input, withdrawal) =
-                many0_complete(|i| Labelv4Nlri::parse_nlri(i, add_path)).parse(input)?;
+                parse_nlri_block(input, |i| Labelv4Nlri::parse_nlri(i, add_path))?;
             return Ok((input, MpUnreachAttr::Labelv4(withdrawal)));
         }
         if header.afi == Afi::Ip6 && header.safi == Safi::MplsLabel {
@@ -462,7 +462,7 @@ impl MpUnreachAttr {
                 return Ok((input, MpUnreachAttr::Labelv6Eor));
             }
             let (input, withdrawal) =
-                many0_complete(|i| Labelv6Nlri::parse_nlri(i, add_path)).parse(input)?;
+                parse_nlri_block(input, |i| Labelv6Nlri::parse_nlri(i, add_path))?;
             return Ok((input, MpUnreachAttr::Labelv6(withdrawal)));
         }
         if header.afi == Afi::L2vpn && header.safi == Safi::Evpn {
@@ -470,8 +470,7 @@ impl MpUnreachAttr {
                 let mp_nlri = MpUnreachAttr::EvpnEor;
                 return Ok((input, mp_nlri));
             }
-            let (input, evpns) =
-                many0_complete(|i| EvpnRoute::parse_nlri(i, add_path)).parse(input)?;
+            let (input, evpns) = parse_nlri_block(input, |i| EvpnRoute::parse_nlri(i, add_path))?;
             let mp_nlri = MpUnreachAttr::Evpn(evpns);
             return Ok((input, mp_nlri));
         }
@@ -486,7 +485,7 @@ impl MpUnreachAttr {
                 ));
             }
             let (input, withdraws) =
-                many0_complete(|i| MupRoute::parse(i, add_path, header.afi)).parse(input)?;
+                parse_nlri_block(input, |i| MupRoute::parse(i, add_path, header.afi))?;
             return Ok((
                 input,
                 MpUnreachAttr::Mup {
@@ -500,7 +499,7 @@ impl MpUnreachAttr {
                 let mp_nlri = MpUnreachAttr::Rtcv4Eor;
                 return Ok((input, mp_nlri));
             }
-            let (input, rtcv4) = many0_complete(|i| Rtcv4::parse_nlri(i, add_path)).parse(input)?;
+            let (input, rtcv4) = parse_nlri_block(input, |i| Rtcv4::parse_nlri(i, add_path))?;
             let mp_nlri = MpUnreachAttr::Rtcv4(rtcv4);
             return Ok((input, mp_nlri));
         }
@@ -515,7 +514,7 @@ impl MpUnreachAttr {
                 ));
             }
             let (input, withdraws) =
-                many0_complete(|i| FlowspecNlri::parse(i, add_path, header.afi)).parse(input)?;
+                parse_nlri_block(input, |i| FlowspecNlri::parse(i, add_path, header.afi))?;
             return Ok((
                 input,
                 MpUnreachAttr::Flowspec {
@@ -529,7 +528,7 @@ impl MpUnreachAttr {
                 let mp_nlri = MpUnreachAttr::Rtcv6Eor;
                 return Ok((input, mp_nlri));
             }
-            let (input, rtcv6) = many0_complete(|i| Rtcv6::parse_nlri(i, add_path)).parse(input)?;
+            let (input, rtcv6) = parse_nlri_block(input, |i| Rtcv6::parse_nlri(i, add_path))?;
             let mp_nlri = MpUnreachAttr::Rtcv6(rtcv6);
             return Ok((input, mp_nlri));
         }
@@ -544,7 +543,7 @@ impl MpUnreachAttr {
                 ));
             }
             let (input, withdraws) =
-                many0_complete(|i| SrPolicyNlri::parse(i, add_path, header.afi)).parse(input)?;
+                parse_nlri_block(input, |i| SrPolicyNlri::parse(i, add_path, header.afi))?;
             return Ok((
                 input,
                 MpUnreachAttr::SrPolicy {
@@ -557,8 +556,7 @@ impl MpUnreachAttr {
             if input.is_empty() {
                 return Ok((input, MpUnreachAttr::LinkState { withdraws: vec![] }));
             }
-            let (input, withdraws) =
-                many0_complete(|i| BgpLsNlri::parse(i, add_path)).parse(input)?;
+            let (input, withdraws) = parse_nlri_block(input, |i| BgpLsNlri::parse(i, add_path))?;
             return Ok((input, MpUnreachAttr::LinkState { withdraws }));
         }
         Err(nom::Err::Error(make_error(input, ErrorKind::NoneOf)))

--- a/crates/bgp-packet/src/attrs/nlri_evpn.rs
+++ b/crates/bgp-packet/src/attrs/nlri_evpn.rs
@@ -9,7 +9,19 @@ use nom::error::{ErrorKind, make_error};
 use nom::number::complete::{be_u8, be_u24, be_u32};
 use nom_derive::*;
 
-use crate::{ParseNlri, RouteDistinguisher, nlri_psize};
+use crate::{ParseNlri, RouteDistinguisher};
+
+// EVPN address-length fields are counts of *bits*, and RFC 7432 fixes each to a
+// single legal value per family rather than a range. Match on these directly:
+// rounding a length to octets first (`nlri_psize`) silently widens each into a
+// span of eight bit-counts that all round the same way.
+//
+/// RFC 7432 §7.2: "The MAC Address Length field is in bits, and it is set to 48."
+const MAC_LEN_BITS: u8 = 48;
+/// RFC 7432 §7.2 / §7.3: an IPv4 address length "is set to 32 ... bits".
+const IP4_LEN_BITS: u8 = 32;
+/// RFC 7432 §7.2 / §7.3: an IPv6 address length "is set to ... 128 bits".
+const IP6_LEN_BITS: u8 = 128;
 
 #[derive(Debug, Clone)]
 pub enum EvpnRouteType {
@@ -801,18 +813,32 @@ impl ParseNlri<EvpnRoute> for EvpnRoute {
                 let (input, ether_tag) = be_u32(input)?;
 
                 let (input, mac_len) = be_u8(input)?;
-                let mac_size = nlri_psize(mac_len);
-                if mac_size != 6 {
+                // RFC 7432 §7.2: "The MAC Address Length field is in bits, and
+                // it is set to 48." Anything else is explicitly outside the
+                // RFC's scope, so there is no defined way to read it. Testing
+                // `nlri_psize(mac_len) == 6` instead accepted every length that
+                // happens to round up to six octets — 41 through 48 — and then
+                // read six octets regardless. The IncMulticast arm below already
+                // checks its address length exactly; this now matches it.
+                if mac_len != MAC_LEN_BITS {
                     return Err(nom::Err::Error(make_error(input, ErrorKind::LengthValue)));
                 }
                 let (input, mac) = take(6usize).parse(input)?;
+
                 let (input, ip_len) = be_u8(input)?;
-                let ip_size = nlri_psize(ip_len);
-                let (input, _) = if ip_size != 0 {
-                    take(ip_size).parse(input)?
-                } else {
-                    (input, &[] as &[u8])
+                // RFC 7432 §7.2: absent, or "set to 32 or 128 bits". Passing
+                // this through `nlri_psize` accepted any value at all: an
+                // ip_len of 200 read and discarded 25 octets and the route still
+                // parsed, MAC-only, as though no IP had been sent.
+                let ip_size = match ip_len {
+                    0 => 0usize,
+                    IP4_LEN_BITS => 4,
+                    IP6_LEN_BITS => 16,
+                    _ => return Err(nom::Err::Error(make_error(input, ErrorKind::LengthValue))),
                 };
+                // The address itself is not modelled by `EvpnMac` yet; validate
+                // its length and step over exactly that many octets.
+                let (input, _ip) = take(ip_size).parse(input)?;
                 let (input, vni) = be_u24(input)?;
 
                 let mut evpn = EvpnMac {
@@ -1071,17 +1097,21 @@ impl ParseNlri<EvpnRoute> for EvpnRoute {
 /// length-in-bits followed by the address. Length 0 yields `None`
 /// (the `(*,G)` wildcard source); 32 → IPv4, 128 → IPv6; any other
 /// length fails the parse (RFC 7606 treat-as-withdraw at the caller).
+///
+/// The match is on the bit count itself, not on `nlri_psize` of it. Rounding
+/// first made the sentence above untrue: 25..=32 all round up to four octets
+/// and were read as IPv4, 121..=128 as IPv6.
 fn parse_len_prefixed_ip(input: &[u8]) -> IResult<&[u8], Option<IpAddr>> {
     let (input, len) = be_u8(input)?;
-    match nlri_psize(len) {
+    match len {
         0 => Ok((input, None)),
-        4 => {
+        IP4_LEN_BITS => {
             let (input, v) = take(4usize).parse(input)?;
             let mut o = [0u8; 4];
             o.copy_from_slice(v);
             Ok((input, Some(IpAddr::V4(Ipv4Addr::from(o)))))
         }
-        16 => {
+        IP6_LEN_BITS => {
             let (input, v) = take(16usize).parse(input)?;
             let mut o = [0u8; 16];
             o.copy_from_slice(v);
@@ -1379,6 +1409,94 @@ fn emit_len_prefixed_ip(payload: &mut BytesMut, ip: Option<IpAddr>) {
         Some(IpAddr::V6(v6)) => {
             payload.put_u8(128);
             payload.put(&v6.octets()[..]);
+        }
+    }
+}
+
+#[cfg(test)]
+mod evpn_length_tests {
+    use super::*;
+
+    /// A Type-2 MAC/IP Advertisement NLRI with the given length fields.
+    fn type2(mac_len: u8, ip_len: u8, ip_octets: usize) -> Vec<u8> {
+        let mut body = Vec::new();
+        body.extend_from_slice(&[0x00, 0x00, 0x00, 0x00, 0xfd, 0xe8, 0x00, 0x01]); // RD
+        body.extend_from_slice(&[0u8; 10]); // ESI
+        body.extend_from_slice(&100u32.to_be_bytes()); // Ethernet tag
+        body.push(mac_len);
+        body.extend_from_slice(&[0x00, 0x11, 0x22, 0x33, 0x44, 0x55]); // MAC
+        body.push(ip_len);
+        body.extend(std::iter::repeat_n(0xAAu8, ip_octets));
+        body.extend_from_slice(&[0x00, 0x00, 0x0a]); // VNI
+        let mut nlri = vec![2u8, body.len() as u8];
+        nlri.extend_from_slice(&body);
+        nlri
+    }
+
+    /// RFC 7432 §7.2: the MAC Address Length "is set to 48"; other values are
+    /// outside the RFC's scope. Regression: the check was
+    /// `nlri_psize(mac_len) == 6`, so every bit-count rounding up to six octets
+    /// — 41 through 48 — was accepted and read as a 48-bit MAC.
+    #[test]
+    fn type2_mac_length_must_be_exactly_48_bits() {
+        assert!(
+            EvpnRoute::parse_nlri(&type2(48, 0, 0), false).is_ok(),
+            "the one legal MAC length must parse"
+        );
+        for mac_len in [0u8, 41, 47, 49, 255] {
+            assert!(
+                EvpnRoute::parse_nlri(&type2(mac_len, 0, 0), false).is_err(),
+                "MAC length {mac_len} bits must be rejected"
+            );
+        }
+    }
+
+    /// RFC 7432 §7.2: the IP Address Length is absent (0) or "set to 32 or 128
+    /// bits". Regression: it went through `nlri_psize`, which accepted anything
+    /// — an ip_len of 200 read and discarded 25 octets and the route still
+    /// parsed as MAC-only, as though no IP had been sent.
+    #[test]
+    fn type2_ip_length_must_be_0_32_or_128_bits() {
+        for (ip_len, octets) in [(0u8, 0usize), (32, 4), (128, 16)] {
+            assert!(
+                EvpnRoute::parse_nlri(&type2(48, ip_len, octets), false).is_ok(),
+                "IP length {ip_len} bits is legal"
+            );
+        }
+        // 25 rounds to 4 octets and 200 to 25; both used to pass.
+        for (ip_len, octets) in [(25u8, 4usize), (200, 25), (31, 4), (127, 16), (129, 17)] {
+            assert!(
+                EvpnRoute::parse_nlri(&type2(48, ip_len, octets), false).is_err(),
+                "IP length {ip_len} bits must be rejected"
+            );
+        }
+    }
+
+    /// `parse_len_prefixed_ip` backs the SMET / IGMP-sync source and group
+    /// addresses. Its doc always claimed "any other length fails the parse";
+    /// matching on `nlri_psize(len)` made that untrue for 25..=32 and 121..=128.
+    #[test]
+    fn len_prefixed_ip_matches_on_bits_not_rounded_octets() {
+        assert_eq!(parse_len_prefixed_ip(&[0]).unwrap().1, None);
+        assert!(
+            parse_len_prefixed_ip(&[32, 10, 0, 0, 1])
+                .unwrap()
+                .1
+                .is_some()
+        );
+        assert!(
+            parse_len_prefixed_ip(&[128, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1])
+                .unwrap()
+                .1
+                .is_some()
+        );
+        for len in [25u8, 31, 121, 127] {
+            let mut wire = vec![len];
+            wire.extend_from_slice(&[0u8; 16]);
+            assert!(
+                parse_len_prefixed_ip(&wire).is_err(),
+                "length {len} bits must be rejected, not rounded"
+            );
         }
     }
 }

--- a/crates/bgp-packet/src/attrs/nlri_flowspec.rs
+++ b/crates/bgp-packet/src/attrs/nlri_flowspec.rs
@@ -583,6 +583,41 @@ impl FlowspecNlri {
             components.push(comp);
             value = next;
         }
+
+        // RFC 8955 §4.2: "Components MUST follow strict type ordering by
+        // increasing numerical order. A given component type MAY (exactly once)
+        // be present ... If present, it MUST precede any component of higher
+        // numeric type value." The two halves of that rule want different
+        // answers.
+        //
+        // A repeated type is genuinely ambiguous — two operator lists conjoined
+        // over one field, e.g. `proto =6` and `proto =17`, which no packet
+        // satisfies — so there is nothing to recover and it is rejected.
+        let mut seen: Vec<u8> = Vec::with_capacity(components.len());
+        for c in components.iter() {
+            let typ = c.component_type();
+            if seen.contains(&typ) {
+                return Err(nom::Err::Error(make_error(value, ErrorKind::Verify)));
+            }
+            seen.push(typ);
+        }
+
+        // Order, by contrast, carries no meaning: a spec is the conjunction of
+        // its components, so [port, proto] matches exactly what [proto, port]
+        // matches. Canonicalise rather than reject — dropping a rule whose
+        // intent is unambiguous is the worse failure for a filter meant to shed
+        // attack traffic, and sorting makes what we re-emit RFC-compliant.
+        // GoBGP normalises here too, for the same stated reason: otherwise "the
+        // unordered rules are determined different".
+        //
+        // This is load-bearing, not cosmetic. `flow_cmp` walks the two lists
+        // positionally to compute §5.1 precedence, and `Ord` keys the BTreeMap
+        // the dataplane iterates in apply order. Left unsorted,
+        // [proto=6, port=80] and [port=80, proto=6] — one rule — compare unequal
+        // and occupy two keys at different precedence, so a crafted encoding can
+        // sit ahead of the rule it duplicates.
+        components.sort_by_key(|c| c.component_type());
+
         Ok((
             rest,
             FlowspecNlri {
@@ -804,6 +839,53 @@ mod tests {
         let (rest, parsed) = FlowspecNlri::parse(&buf, nlri.id != 0, nlri.afi).expect("must parse");
         assert!(rest.is_empty(), "trailing bytes after parse");
         assert_eq!(&parsed, nlri);
+    }
+
+    /// Component order carries no meaning — a spec is the conjunction of its
+    /// components — so a non-ascending encoding is canonicalised rather than
+    /// rejected, as GoBGP also does. Only the canonical form may reach `Ord`,
+    /// which keys the BTreeMap the dataplane iterates.
+    #[test]
+    fn component_order_is_canonicalised_not_trusted() {
+        // The same rule (IP protocol 6 AND port 80) in both encodings: the
+        // RFC 8955 §4.2 ascending order, and the reverse.
+        let canonical = [0x06u8, 0x03, 0x81, 0x06, 0x04, 0x81, 0x50];
+        let reversed = [0x06u8, 0x04, 0x81, 0x50, 0x03, 0x81, 0x06];
+
+        let (_, a) = FlowspecNlri::parse(&canonical, false, Afi::Ip).expect("must parse");
+        let (_, b) = FlowspecNlri::parse(&reversed, false, Afi::Ip).expect("must parse");
+
+        // Regression: parsed as given, these were unequal and compared `Less`,
+        // so one rule occupied two BTreeMap keys at different precedence and a
+        // crafted encoding could sit ahead of the rule it duplicates.
+        assert_eq!(a, b, "one rule must yield one key whatever the wire order");
+        assert_eq!(a.cmp(&b), Ordering::Equal, "and one precedence");
+        assert_eq!(
+            b.components
+                .iter()
+                .map(|c| c.component_type())
+                .collect::<Vec<_>>(),
+            vec![3, 4],
+            "components canonicalised into ascending type order"
+        );
+
+        // Re-emitting the normalised spec produces the RFC-compliant ordering.
+        let mut buf = BytesMut::new();
+        b.nlri_emit(&mut buf);
+        assert_eq!(&buf[..], &canonical[..]);
+    }
+
+    /// RFC 8955 §4.2 allows each component type "exactly once". A repeat is
+    /// ambiguous — two operator lists conjoined over one field — so unlike
+    /// ordering there is nothing to canonicalise.
+    #[test]
+    fn duplicate_component_type_is_rejected() {
+        // [type 3 proto =6][type 3 proto =17]
+        let dup = [0x06u8, 0x03, 0x81, 0x06, 0x03, 0x81, 0x11];
+        assert!(
+            FlowspecNlri::parse(&dup, false, Afi::Ip).is_err(),
+            "a repeated component type is malformed"
+        );
     }
 
     /// RFC 8955 §4.2 makes the end-of-list bit mandatory on the final term.

--- a/crates/bgp-packet/src/attrs/nlri_flowspec.rs
+++ b/crates/bgp-packet/src/attrs/nlri_flowspec.rs
@@ -147,14 +147,25 @@ fn parse_op(input: &[u8]) -> IResult<&[u8], FlowspecOp> {
     Ok((input, FlowspecOp { op, value }))
 }
 
-/// Parse a list of operator terms, stopping after the term whose
-/// end-of-list bit is set (or when the component slice is exhausted, so
-/// a missing end bit can't run into the next component).
+/// Parse a list of operator terms, stopping after the term whose end-of-list
+/// bit is set. RFC 8955 §4.2 makes that bit mandatory on the final term, so a
+/// list that runs out of input without it is malformed and rejected.
 ///
-/// The end bit is positional — it only ever marks the final term — so
-/// it is stripped from the stored ops to keep the in-memory form
-/// canonical (`emit_op_list` re-derives it from position). This makes
-/// equality independent of how the sender flagged the terminator.
+/// There is no per-component length anywhere in the flow-spec encoding: the
+/// end-of-list bit is the *only* delimiter, and `input` here runs to the end of
+/// the whole NLRI value rather than to the end of this component. So a term list
+/// missing the end bit reads straight on into the components that follow. Where
+/// that is detectable — the list reaching the end of the NLRI having never set
+/// the bit — reject it. Where it is not — the stolen octets happening to decode
+/// as further terms, one of which does set the bit — no parser can tell, and the
+/// components silently mis-frame. (An earlier version of this function claimed
+/// the opposite, that exhausting the slice meant a missing end bit "can't run
+/// into the next component"; the slice is not per-component, so it can.)
+///
+/// The end bit is positional — it only ever marks the final term — so it is
+/// stripped from the stored ops to keep the in-memory form canonical
+/// (`emit_op_list` re-derives it from position). This makes equality
+/// independent of how the sender flagged the terminator.
 fn parse_op_list(mut input: &[u8]) -> IResult<&[u8], Vec<FlowspecOp>> {
     let mut ops = Vec::new();
     loop {
@@ -165,8 +176,16 @@ fn parse_op_list(mut input: &[u8]) -> IResult<&[u8], Vec<FlowspecOp>> {
             value: op.value,
         });
         input = rest;
-        if end || input.is_empty() {
+        if end {
             break;
+        }
+        if input.is_empty() {
+            // Terminating here instead would accept a list the RFC forbids and
+            // then, because `emit_op_list` re-derives the bit from position,
+            // silently re-emit it in a repaired form that no longer matches the
+            // octets received. GoBGP's FlowSpecComponent decoder likewise only
+            // ever breaks on the end bit.
+            return Err(nom::Err::Error(make_error(input, ErrorKind::Eof)));
         }
     }
     Ok((input, ops))
@@ -785,6 +804,42 @@ mod tests {
         let (rest, parsed) = FlowspecNlri::parse(&buf, nlri.id != 0, nlri.afi).expect("must parse");
         assert!(rest.is_empty(), "trailing bytes after parse");
         assert_eq!(&parsed, nlri);
+    }
+
+    /// RFC 8955 §4.2 makes the end-of-list bit mandatory on the final term.
+    /// Regression: `parse_op_list` also terminated when the input ran out, so a
+    /// list that never set the bit was accepted, and `emit_op_list` then added
+    /// the bit back — a reflector would propagate octets it never received.
+    /// GoBGP's decoder likewise only breaks on the end bit.
+    #[test]
+    fn op_list_without_end_of_list_bit_is_rejected() {
+        // len=3, value = [type 3 (IP protocol), op 0x01 (1-octet value, eq, NO
+        // end bit), value 0x06].
+        let missing_end = [0x03u8, 0x03, 0x01, 0x06];
+        assert!(
+            FlowspecNlri::parse(&missing_end, false, Afi::Ip).is_err(),
+            "a term list that never sets the end bit is malformed"
+        );
+
+        // The same component with the end bit (0x81) parses and round-trips.
+        let well_formed = [0x03u8, 0x03, 0x81, 0x06];
+        let (rest, nlri) = FlowspecNlri::parse(&well_formed, false, Afi::Ip).expect("must parse");
+        assert!(rest.is_empty());
+        let mut buf = BytesMut::new();
+        nlri.nlri_emit(&mut buf);
+        assert_eq!(&buf[..], &well_formed[..], "byte-identical round trip");
+    }
+
+    /// The end bit terminates the list even when octets follow, so a
+    /// well-formed multi-component NLRI is framed on the bit alone — there is
+    /// no per-component length to fall back on.
+    #[test]
+    fn end_of_list_bit_delimits_one_component_from_the_next() {
+        // len=6: [type 3, op 0x81 end, value 0x06][type 4, op 0x81 end, value 0x50]
+        let wire = [0x06u8, 0x03, 0x81, 0x06, 0x04, 0x81, 0x50];
+        let (rest, nlri) = FlowspecNlri::parse(&wire, false, Afi::Ip).expect("must parse");
+        assert!(rest.is_empty());
+        assert_eq!(nlri.components.len(), 2, "end bit split the two components");
     }
 
     #[test]

--- a/crates/bgp-packet/src/attrs/nlri_rtcv4.rs
+++ b/crates/bgp-packet/src/attrs/nlri_rtcv4.rs
@@ -10,24 +10,128 @@ use crate::{Afi, ExtCommunityValue, ParseNlri, Safi};
 
 use super::{AttrEmitter, AttrFlags, AttrType};
 
+/// Longest RTC membership prefix: a 4-octet origin AS followed by an 8-octet
+/// Route Target (RFC 4684 §4).
+pub const RTC_PLEN_MAX: u8 = 96;
+
+/// Shortest non-default RTC membership prefix: enough to carry the 4-octet
+/// origin AS. Anything between 1 and 31 cannot, and is malformed.
+pub const RTC_PLEN_MIN: u8 = 32;
+
+/// One Route Target Constraint membership NLRI (RFC 4684 §4).
 #[derive(Debug, Clone)]
 pub struct Rtcv4 {
     pub id: u32,
+    /// Prefix length in bits, `0..=96`. Zero is the RFC 4684 §3.2 default
+    /// membership — "interested in all Route Targets" — and carries neither an
+    /// origin AS nor a Route Target. `96` fully specifies both. A length in
+    /// `32..96` specifies the origin AS and only a prefix of the Route Target,
+    /// constraining a range rather than naming one target.
+    pub plen: u8,
     pub asn: u32,
     pub rt: ExtCommunityValue,
 }
 
+impl Rtcv4 {
+    /// A fully specified membership naming one exact Route Target.
+    pub fn new(asn: u32, rt: ExtCommunityValue) -> Self {
+        Self {
+            id: 0,
+            plen: RTC_PLEN_MAX,
+            asn,
+            rt,
+        }
+    }
+
+    /// The RFC 4684 §3.2 default membership: a zero-length prefix asking for
+    /// every Route Target.
+    pub fn default_membership() -> Self {
+        Self {
+            id: 0,
+            plen: 0,
+            asn: 0,
+            rt: ExtCommunityValue::default(),
+        }
+    }
+
+    /// True only for a full 96-bit prefix, i.e. the one case where both `asn`
+    /// and `rt` are fully specified and `rt` names an exact Route Target.
+    pub fn is_exact(&self) -> bool {
+        self.plen == RTC_PLEN_MAX
+    }
+
+    /// True for the RFC 4684 §3.2 default membership ("send me everything").
+    pub fn is_default(&self) -> bool {
+        self.plen == 0
+    }
+}
+
+/// Parse one RTC membership NLRI. The wire encoding is identical for the IPv4
+/// and IPv6 families (RFC 4684 §4), so [`Rtcv4`] and [`Rtcv6`](crate::Rtcv6)
+/// share this.
+pub(crate) fn parse_rtc_membership(
+    input: &[u8],
+    addpath: bool,
+) -> IResult<&[u8], (u32, u8, u32, ExtCommunityValue)> {
+    let (input, id) = if addpath { be_u32(input)? } else { (input, 0) };
+    let (input, plen) = be_u8(input)?;
+    // RFC 4684 §4: the prefix runs over a 4-octet origin AS followed by an
+    // 8-octet Route Target, so 96 bits is the maximum, and §3.2 gives a
+    // zero-length prefix the special meaning "interested in all Route Targets".
+    // Rejecting anything but 96 dropped that default membership — which
+    // `Rtcv4Reach::emit` itself originates — and, because the NLRI list is read
+    // with `many0_complete`, took every membership after it down as well.
+    if plen > RTC_PLEN_MAX || (plen > 0 && plen < RTC_PLEN_MIN) {
+        return Err(nom::Err::Error(make_error(input, ErrorKind::LengthValue)));
+    }
+    // Consume exactly the octets the prefix length advertises, so a default or
+    // partial membership stops short of the next NLRI instead of eating it.
+    let (input, body) = packet_utils::safe_split_at(input, plen.div_ceil(8) as usize)?;
+    if plen == 0 {
+        return Ok((input, (id, plen, 0, ExtCommunityValue::default())));
+    }
+    let (body, asn) = be_u32(body)?;
+    // Only a full 96-bit prefix names an exact Route Target. A shorter prefix
+    // constrains a range, so leave `rt` unset rather than invent one out of
+    // truncated octets — GoBGP likewise leaves its RouteTarget nil below 96.
+    let rt = if plen == RTC_PLEN_MAX {
+        ExtCommunityValue::parse_be(body)?.1
+    } else {
+        ExtCommunityValue::default()
+    };
+    Ok((input, (id, plen, asn, rt)))
+}
+
+/// Emit one RTC membership NLRI, the shared counterpart of
+/// [`parse_rtc_membership`].
+pub(crate) fn emit_rtc_membership(
+    buf: &mut BytesMut,
+    id: u32,
+    plen: u8,
+    asn: u32,
+    rt: &ExtCommunityValue,
+) {
+    if id != 0 {
+        buf.put_u32(id);
+    }
+    buf.put_u8(plen);
+    if plen == 0 {
+        // The default membership is the length octet and nothing else.
+        return;
+    }
+    // The prefix is origin-AS(4) || RT(8) truncated to ceil(plen/8) octets, so
+    // one path covers both an exact 96-bit membership and a partial one.
+    let mut prefix = BytesMut::with_capacity(12);
+    prefix.put_u32(asn);
+    rt.encode(&mut prefix);
+    let nbytes = (plen.div_ceil(8) as usize).min(prefix.len());
+    buf.put(&prefix[..nbytes]);
+}
+
 impl ParseNlri<Rtcv4> for Rtcv4 {
     fn parse_nlri(input: &[u8], addpath: bool) -> IResult<&[u8], Rtcv4> {
-        let (input, id) = if addpath { be_u32(input)? } else { (input, 0) };
-        let (input, plen) = be_u8(input)?;
-        if plen != 96 {
-            return Err(nom::Err::Error(make_error(input, ErrorKind::LengthValue)));
-        }
-        let (input, asn) = be_u32(input)?;
-        let (input, rt) = ExtCommunityValue::parse_be(input)?;
-        let nlri = Rtcv4 { id, asn, rt };
-        Ok((input, nlri))
+        let (input, (id, plen, asn, rt)) = parse_rtc_membership(input, addpath)?;
+        Ok((input, Rtcv4 { id, plen, asn, rt }))
     }
 }
 
@@ -66,20 +170,14 @@ impl AttrEmitter for Rtcv4Reach {
         if self.updates.is_empty() {
             // Zero prefix length: the default RT membership of
             // RFC 4684 §3.2 — "interested in all Route Targets".
-            buf.put_u8(0);
+            emit_rtc_membership(buf, 0, 0, 0, &ExtCommunityValue::default());
         } else {
-            // Each membership NLRI is a 96-bit prefix: the 4-octet
-            // origin-AS followed by the 8-octet Route Target extended
-            // community (RFC 4684 §4). Mirrors `Rtcv4::parse_nlri`,
-            // which reads the AddPath id (when negotiated), the
-            // prefix length, the AS, then the RT.
+            // Each membership NLRI is the AddPath id (when negotiated), the
+            // prefix length, and that many bits of 4-octet origin-AS followed
+            // by 8-octet Route Target (RFC 4684 §4). Shares its encoder with
+            // `Rtcv4::parse_nlri`'s reader so the two cannot drift.
             for update in self.updates.iter() {
-                if update.id != 0 {
-                    buf.put_u32(update.id);
-                }
-                buf.put_u8(96);
-                buf.put_u32(update.asn);
-                update.rt.encode(buf);
+                emit_rtc_membership(buf, update.id, update.plen, update.asn, &update.rt);
             }
         }
     }
@@ -106,14 +204,15 @@ impl AttrEmitter for Rtcv4Unreach {
         // AFI/SAFI.
         buf.put_u16(u16::from(Afi::Ip));
         buf.put_u8(u8::from(Safi::Rtc));
-        // Prefix.
+        // A withdrawn membership uses the same NLRI encoding as MP_REACH
+        // (RFC 4684 §4), so it shares the encoder. The hand-rolled loop this
+        // replaces wrote only the 8-octet Route Target — mislabelled "RD" —
+        // omitting the prefix length and origin AS that `Rtcv4::parse_nlri`
+        // reads back, so a receiver would have read the RT's first octet as the
+        // prefix length and rejected it. Dormant so far: `mp_unreach.rs` only
+        // ever builds this with an empty `withdraw` (the End-of-RIB marker).
         for withdraw in self.withdraw.iter() {
-            // AddPath
-            if withdraw.id != 0 {
-                buf.put_u32(withdraw.id);
-            }
-            // RD
-            withdraw.rt.encode(buf);
+            emit_rtc_membership(buf, withdraw.id, withdraw.plen, withdraw.asn, &withdraw.rt);
         }
     }
 }
@@ -137,11 +236,7 @@ mod tests {
         let reach = Rtcv4Reach {
             snpa: 0,
             nhop: IpAddr::V4(Ipv4Addr::UNSPECIFIED),
-            updates: vec![Rtcv4 {
-                id: 0,
-                asn: 65001,
-                rt: rt.clone(),
-            }],
+            updates: vec![Rtcv4::new(65001, rt.clone())],
         };
 
         let mut buf = BytesMut::new();
@@ -149,8 +244,91 @@ mod tests {
 
         let (rest, parsed) = Rtcv4::parse_nlri(&buf[HEADER_LEN..], false).unwrap();
         assert!(rest.is_empty());
+        assert_eq!(parsed.plen, RTC_PLEN_MAX);
         assert_eq!(parsed.asn, 65001);
         assert_eq!(parsed.rt, rt);
+        assert!(parsed.is_exact());
+    }
+
+    /// The zero-length default membership (RFC 4684 §3.2) that
+    /// `Rtcv4Reach::emit` originates must parse back. Regression: `parse_nlri`
+    /// rejected every `plen != 96`, so our own default membership was
+    /// unreadable, and because the NLRI list is read with `many0_complete` the
+    /// error also discarded every membership following it.
+    #[test]
+    fn default_membership_round_trips() {
+        let reach = Rtcv4Reach {
+            snpa: 0,
+            nhop: IpAddr::V4(Ipv4Addr::UNSPECIFIED),
+            updates: vec![],
+        };
+        let mut buf = BytesMut::new();
+        reach.emit(&mut buf);
+
+        let (rest, parsed) = Rtcv4::parse_nlri(&buf[HEADER_LEN..], false).unwrap();
+        assert!(rest.is_empty());
+        assert!(
+            parsed.is_default(),
+            "zero-length prefix is the default membership"
+        );
+        assert!(!parsed.is_exact(), "it names no specific Route Target");
+        assert_eq!(parsed.plen, 0);
+    }
+
+    /// A default membership no longer stops the parse, so memberships after it
+    /// still arrive.
+    #[test]
+    fn default_membership_does_not_swallow_following_nlri() {
+        let rt = ExtCommunityValue {
+            high_type: 0x00,
+            low_type: 0x02,
+            val: [0x00, 0x64, 0x00, 0x00, 0x00, 0x01],
+        };
+        let mut buf = BytesMut::new();
+        emit_rtc_membership(&mut buf, 0, 0, 0, &ExtCommunityValue::default());
+        emit_rtc_membership(&mut buf, 0, RTC_PLEN_MAX, 65001, &rt);
+
+        let (rest, first) = Rtcv4::parse_nlri(&buf, false).unwrap();
+        assert!(first.is_default());
+        let (rest, second) = Rtcv4::parse_nlri(rest, false).unwrap();
+        assert!(rest.is_empty(), "both NLRI consumed");
+        assert_eq!(second.asn, 65001);
+        assert_eq!(second.rt, rt);
+    }
+
+    /// RFC 4684 §4 allows any prefix length in 0..=96. A partial prefix carries
+    /// the origin AS but only part of the Route Target, so it must consume
+    /// exactly ceil(plen/8) octets and leave `rt` unset rather than invent one.
+    #[test]
+    fn partial_prefix_parses_and_consumes_its_octets() {
+        // plen=32: origin AS only.
+        let wire = [32u8, 0x00, 0x00, 0xfd, 0xe9];
+        let (rest, rd) = Rtcv4::parse_nlri(&wire, false).unwrap();
+        assert!(rest.is_empty(), "consumed exactly ceil(32/8) = 4 octets");
+        assert_eq!(rd.plen, 32);
+        assert_eq!(rd.asn, 65001);
+        assert!(!rd.is_exact(), "no Route Target is named");
+
+        // plen=48: origin AS plus two RT octets.
+        let wire = [48u8, 0x00, 0x00, 0xfd, 0xe9, 0x00, 0x02];
+        let (rest, rd) = Rtcv4::parse_nlri(&wire, false).unwrap();
+        assert!(rest.is_empty(), "consumed exactly ceil(48/8) = 6 octets");
+        assert_eq!(rd.plen, 48);
+        assert!(!rd.is_exact());
+    }
+
+    /// Lengths beyond the 96-bit prefix, or too short to hold the origin AS,
+    /// are malformed.
+    #[test]
+    fn out_of_range_prefix_lengths_rejected() {
+        for plen in [1u8, 31, 97, 255] {
+            let mut wire = vec![plen];
+            wire.extend_from_slice(&[0u8; 16]);
+            assert!(
+                Rtcv4::parse_nlri(&wire, false).is_err(),
+                "plen {plen} must be rejected"
+            );
+        }
     }
 
     #[test]

--- a/crates/bgp-packet/src/attrs/nlri_rtcv6.rs
+++ b/crates/bgp-packet/src/attrs/nlri_rtcv6.rs
@@ -2,37 +2,65 @@ use std::net::{IpAddr, Ipv6Addr};
 
 use bytes::{BufMut, BytesMut};
 use nom::IResult;
-use nom::error::{ErrorKind, make_error};
-use nom::number::complete::{be_u8, be_u32};
-use nom_derive::*;
 
 use crate::{Afi, ExtCommunityValue, ParseNlri, Safi};
 
+use super::nlri_rtcv4::{RTC_PLEN_MAX, emit_rtc_membership, parse_rtc_membership};
 use super::{AttrEmitter, AttrFlags, AttrType};
 
 /// One IPv6 Route Target Constraint membership NLRI. The on-wire NLRI
 /// is identical to the IPv4 form ([`crate::Rtcv4`], RFC 4684 §4): a
-/// 96-bit prefix of 4-octet origin-AS + 8-octet Route Target. zebra-rs
+/// prefix of at most 96 bits over a 4-octet origin-AS + 8-octet Route
+/// Target, so both families share one reader and writer. zebra-rs
 /// models the v6 family as its own `(Ip6, Rtc)` capability so VPNv6
 /// import-RTs are advertised independently of VPNv4's.
 #[derive(Debug, Clone)]
 pub struct Rtcv6 {
     pub id: u32,
+    /// Prefix length in bits, `0..=96`; see [`Rtcv4::plen`](crate::Rtcv4).
+    pub plen: u8,
     pub asn: u32,
     pub rt: ExtCommunityValue,
 }
 
+impl Rtcv6 {
+    /// A fully specified membership naming one exact Route Target.
+    pub fn new(asn: u32, rt: ExtCommunityValue) -> Self {
+        Self {
+            id: 0,
+            plen: RTC_PLEN_MAX,
+            asn,
+            rt,
+        }
+    }
+
+    /// The RFC 4684 §3.2 default membership: a zero-length prefix asking for
+    /// every Route Target.
+    pub fn default_membership() -> Self {
+        Self {
+            id: 0,
+            plen: 0,
+            asn: 0,
+            rt: ExtCommunityValue::default(),
+        }
+    }
+
+    /// True only for a full 96-bit prefix, i.e. the one case where `rt` names an
+    /// exact Route Target.
+    pub fn is_exact(&self) -> bool {
+        self.plen == RTC_PLEN_MAX
+    }
+
+    /// True for the RFC 4684 §3.2 default membership ("send me everything").
+    pub fn is_default(&self) -> bool {
+        self.plen == 0
+    }
+}
+
 impl ParseNlri<Rtcv6> for Rtcv6 {
     fn parse_nlri(input: &[u8], addpath: bool) -> IResult<&[u8], Rtcv6> {
-        let (input, id) = if addpath { be_u32(input)? } else { (input, 0) };
-        let (input, plen) = be_u8(input)?;
-        if plen != 96 {
-            return Err(nom::Err::Error(make_error(input, ErrorKind::LengthValue)));
-        }
-        let (input, asn) = be_u32(input)?;
-        let (input, rt) = ExtCommunityValue::parse_be(input)?;
-        let nlri = Rtcv6 { id, asn, rt };
-        Ok((input, nlri))
+        let (input, (id, plen, asn, rt)) = parse_rtc_membership(input, addpath)?;
+        Ok((input, Rtcv6 { id, plen, asn, rt }))
     }
 }
 
@@ -71,20 +99,14 @@ impl AttrEmitter for Rtcv6Reach {
         if self.updates.is_empty() {
             // Zero prefix length: the default RT membership of
             // RFC 4684 §3.2 — "interested in all Route Targets".
-            buf.put_u8(0);
+            emit_rtc_membership(buf, 0, 0, 0, &ExtCommunityValue::default());
         } else {
-            // Each membership NLRI is a 96-bit prefix: the 4-octet
-            // origin-AS followed by the 8-octet Route Target extended
-            // community (RFC 4684 §4). Mirrors `Rtcv6::parse_nlri`,
-            // which reads the AddPath id (when negotiated), the
-            // prefix length, the AS, then the RT.
+            // Each membership NLRI is the AddPath id (when negotiated), the
+            // prefix length, and that many bits of 4-octet origin-AS followed
+            // by 8-octet Route Target (RFC 4684 §4). Shares its encoder with
+            // `Rtcv6::parse_nlri`'s reader so the two cannot drift.
             for update in self.updates.iter() {
-                if update.id != 0 {
-                    buf.put_u32(update.id);
-                }
-                buf.put_u8(96);
-                buf.put_u32(update.asn);
-                update.rt.encode(buf);
+                emit_rtc_membership(buf, update.id, update.plen, update.asn, &update.rt);
             }
         }
     }
@@ -111,14 +133,15 @@ impl AttrEmitter for Rtcv6Unreach {
         // AFI/SAFI.
         buf.put_u16(u16::from(Afi::Ip6));
         buf.put_u8(u8::from(Safi::Rtc));
-        // Prefix.
+        // A withdrawn membership uses the same NLRI encoding as MP_REACH
+        // (RFC 4684 §4), so it shares the encoder. The hand-rolled loop this
+        // replaces wrote only the 8-octet Route Target, omitting the prefix
+        // length and origin AS that `Rtcv6::parse_nlri` reads back — a receiver
+        // would have read the RT's first octet as the prefix length and
+        // rejected it. Dormant so far: `mp_unreach.rs` only ever builds this
+        // with an empty `withdraw` (the End-of-RIB marker).
         for withdraw in self.withdraw.iter() {
-            // AddPath
-            if withdraw.id != 0 {
-                buf.put_u32(withdraw.id);
-            }
-            // RD
-            withdraw.rt.encode(buf);
+            emit_rtc_membership(buf, withdraw.id, withdraw.plen, withdraw.asn, &withdraw.rt);
         }
     }
 }
@@ -142,11 +165,7 @@ mod tests {
         let reach = Rtcv6Reach {
             snpa: 0,
             nhop: IpAddr::V6(Ipv6Addr::UNSPECIFIED),
-            updates: vec![Rtcv6 {
-                id: 0,
-                asn: 65001,
-                rt: rt.clone(),
-            }],
+            updates: vec![Rtcv6::new(65001, rt.clone())],
         };
 
         let mut buf = BytesMut::new();
@@ -154,8 +173,28 @@ mod tests {
 
         let (rest, parsed) = Rtcv6::parse_nlri(&buf[HEADER_LEN..], false).unwrap();
         assert!(rest.is_empty());
+        assert_eq!(parsed.plen, RTC_PLEN_MAX);
         assert_eq!(parsed.asn, 65001);
         assert_eq!(parsed.rt, rt);
+        assert!(parsed.is_exact());
+    }
+
+    /// The IPv6 default membership round-trips too — the v6 NLRI shares the
+    /// v4 reader and writer, so this pins that the sharing holds.
+    #[test]
+    fn default_membership_round_trips() {
+        let reach = Rtcv6Reach {
+            snpa: 0,
+            nhop: IpAddr::V6(Ipv6Addr::UNSPECIFIED),
+            updates: vec![],
+        };
+        let mut buf = BytesMut::new();
+        reach.emit(&mut buf);
+
+        let (rest, parsed) = Rtcv6::parse_nlri(&buf[HEADER_LEN..], false).unwrap();
+        assert!(rest.is_empty());
+        assert!(parsed.is_default());
+        assert!(!parsed.is_exact());
     }
 
     #[test]

--- a/crates/bgp-packet/src/attrs/rd.rs
+++ b/crates/bgp-packet/src/attrs/rd.rs
@@ -3,6 +3,8 @@ use std::fmt;
 use std::net::Ipv4Addr;
 use std::str::FromStr;
 
+use super::{asn_from_string, asn_to_string};
+
 #[allow(clippy::upper_case_acronyms)]
 #[repr(u16)]
 #[derive(Default, NomBE, PartialEq, Debug, Clone, Ord, PartialOrd, Eq, Copy, Hash)]
@@ -44,7 +46,8 @@ impl FromStr for RouteDistinguisher {
             return Err(());
         }
         // Type 1: a 32-bit IP address, a colon, and a 16-bit number, for
-        // example: 192.168.1.2:51
+        // example: 192.168.1.2:51. Tried first because an IPv4 address is also
+        // dot-separated integers and must not be mistaken for asdot.
         if let Ok(addr) = strs[0].parse::<Ipv4Addr>()
             && let Ok(val) = strs[1].parse::<u16>()
         {
@@ -53,9 +56,26 @@ impl FromStr for RouteDistinguisher {
             rd.val[4..6].copy_from_slice(&val.to_be_bytes());
             return Ok(rd);
         }
+        // Type 2 in asdot notation: <high16>.<low16>, a colon, and a 16-bit
+        // number, for example 1.10:3 or 64086.59904:1 (RFC 5396) — the form
+        // IOS-XR emits under `as-format asdot`, and the only form GoBGP emits.
+        // The dot makes the 4-octet-AS encoding explicit, so it selects type 2
+        // whatever the AS magnitude; this mirrors GoBGP's
+        // `ParseRouteDistinguisher` and is the only way to spell a type-2 RD
+        // whose AS happens to fit in 16 bits.
+        if strs[0].contains('.')
+            && let Some(asn) = asn_from_string(strs[0])
+            && let Ok(val) = strs[1].parse::<u16>()
+        {
+            let mut rd = RouteDistinguisher::new(RouteDistinguisherType::ASN4);
+            rd.val[0..4].copy_from_slice(&asn.to_be_bytes());
+            rd.val[4..6].copy_from_slice(&val.to_be_bytes());
+            return Ok(rd);
+        }
         // Type 0: a 16-bit autonomous system number, a colon, and a 32-bit
-        // number, for example: 65000:3. Tried before type 2 so an AS that fits
-        // in 16 bits keeps the conventional 2-octet-AS encoding.
+        // number, for example: 65000:3. Tried before the asplain type-2 form so
+        // an AS that fits in 16 bits keeps the conventional 2-octet-AS
+        // encoding.
         if let Ok(asn) = strs[0].parse::<u16>()
             && let Ok(val) = strs[1].parse::<u32>()
         {
@@ -64,11 +84,10 @@ impl FromStr for RouteDistinguisher {
             rd.val[2..6].copy_from_slice(&val.to_be_bytes());
             return Ok(rd);
         }
-        // Type 2: a 32-bit autonomous system number, a colon, and a 16-bit
-        // number, for example: 4200000000:1. Only an AS above 65535 reaches
-        // here, so the text form of a type-2 RD whose AS fits in 16 bits parses
-        // back as type 0 — the textual encoding is inherently ambiguous, while
-        // the wire parse preserves `typ` exactly.
+        // Type 2 in asplain notation: a 32-bit autonomous system number above
+        // 65535, a colon, and a 16-bit number, for example 4200000000:1 — the
+        // form IOS-XR emits by default (`as-format asplain`, RFC 5396's
+        // recommended notation).
         if let Ok(asn) = strs[0].parse::<u32>()
             && let Ok(val) = strs[1].parse::<u16>()
         {
@@ -95,9 +114,14 @@ impl fmt::Display for RouteDistinguisher {
                 write!(f, "{ip}:{val}")
             }
             RouteDistinguisherType::ASN4 => {
+                // asdot, matching `asn_to_string`'s AS_PATH rendering so the
+                // same 4-byte AS is spelled identically everywhere in show
+                // output. A type-2 AS below 65536 therefore prints undotted and
+                // reads back as type 0 — the text form is inherently ambiguous,
+                // while the wire parse preserves `typ` exactly.
                 let asn = u32::from_be_bytes([self.val[0], self.val[1], self.val[2], self.val[3]]);
                 let val = u16::from_be_bytes([self.val[4], self.val[5]]);
-                write!(f, "{asn}:{val}")
+                write!(f, "{}:{}", asn_to_string(asn), val)
             }
         }
     }
@@ -128,7 +152,8 @@ mod tests {
         assert!(rest.is_empty());
         assert_eq!(rd.typ, RouteDistinguisherType::ASN4);
         assert_eq!(rd.val, [0xfa, 0x56, 0xea, 0x00, 0x00, 0x01]);
-        assert_eq!(rd.to_string(), "4200000000:1");
+        // asdot: 0xFA56 = 64086, 0xEA00 = 59904.
+        assert_eq!(rd.to_string(), "64086.59904:1");
     }
 
     /// The pre-existing types keep parsing and rendering exactly as before.
@@ -145,24 +170,52 @@ mod tests {
         assert_eq!(rd.to_string(), "192.168.1.2:51");
     }
 
-    /// A 4-byte AS is now expressible in the text form (it previously failed
-    /// `from_str`, so such an RT could not be configured at all).
+    /// Both vendor notations for the same 4-byte AS parse to the identical RD:
+    /// asplain (IOS-XR's default, RFC 5396's recommendation) and asdot (IOS-XR
+    /// under `as-format asdot`, and the only form GoBGP emits). A 4-byte AS
+    /// previously failed `from_str` entirely, so such an RD/RT could not be
+    /// configured at all.
     #[test]
-    fn type2_rd_text_round_trip() {
-        let rd = RouteDistinguisher::from_str("4200000000:1").unwrap();
-        assert_eq!(rd.typ, RouteDistinguisherType::ASN4);
-        assert_eq!(rd.val, [0xfa, 0x56, 0xea, 0x00, 0x00, 0x01]);
-        assert_eq!(rd.to_string(), "4200000000:1");
+    fn type2_rd_accepts_asplain_and_asdot() {
+        let expect = [0xfa, 0x56, 0xea, 0x00, 0x00, 0x01];
+        for s in ["4200000000:1", "64086.59904:1"] {
+            let rd = RouteDistinguisher::from_str(s).unwrap();
+            assert_eq!(rd.typ, RouteDistinguisherType::ASN4, "input {s}");
+            assert_eq!(rd.val, expect, "input {s}");
+            // Display is asdot regardless of the notation used on input.
+            assert_eq!(rd.to_string(), "64086.59904:1", "input {s}");
+        }
     }
 
     /// An AS that fits in 16 bits keeps the conventional type-0 encoding, so
-    /// existing configs are unaffected by the new type-2 branch.
+    /// existing configs are unaffected by the new type-2 branches.
     #[test]
     fn sixteen_bit_as_still_prefers_type0() {
         let rd = RouteDistinguisher::from_str("65000:3").unwrap();
         assert_eq!(rd.typ, RouteDistinguisherType::ASN);
-        // 65536 does not fit a u16 AS, so it takes the type-2 branch.
+        // 65536 does not fit a u16 AS, so asplain takes the type-2 branch.
         let rd = RouteDistinguisher::from_str("65536:3").unwrap();
         assert_eq!(rd.typ, RouteDistinguisherType::ASN4);
+        assert_eq!(rd.to_string(), "1.0:3");
+    }
+
+    /// The dot makes the 4-octet-AS form explicit, so asdot selects type 2 even
+    /// when the AS would fit in 16 bits — the only way to spell such an RD.
+    #[test]
+    fn asdot_selects_type2_even_for_small_as() {
+        let rd = RouteDistinguisher::from_str("0.100:1").unwrap();
+        assert_eq!(rd.typ, RouteDistinguisherType::ASN4);
+        assert_eq!(rd.val, [0x00, 0x00, 0x00, 0x64, 0x00, 0x01]);
+    }
+
+    /// An IPv4 RD must not be mistaken for asdot, and a malformed asdot half
+    /// must be rejected rather than silently truncated.
+    #[test]
+    fn ipv4_rd_and_malformed_asdot_are_not_confused() {
+        let rd = RouteDistinguisher::from_str("192.168.1.2:51").unwrap();
+        assert_eq!(rd.typ, RouteDistinguisherType::IP);
+        // 169031 exceeds a 16-bit asdot half.
+        assert!(RouteDistinguisher::from_str("169031.1:1").is_err());
+        assert!(RouteDistinguisher::from_str("1.2.3:1").is_err());
     }
 }

--- a/crates/bgp-packet/src/attrs/rd.rs
+++ b/crates/bgp-packet/src/attrs/rd.rs
@@ -7,9 +7,17 @@ use std::str::FromStr;
 #[repr(u16)]
 #[derive(Default, NomBE, PartialEq, Debug, Clone, Ord, PartialOrd, Eq, Copy, Hash)]
 pub enum RouteDistinguisherType {
+    /// Type 0: 2-octet AS number : 4-octet assigned number.
     #[default]
     ASN = 0,
+    /// Type 1: 4-octet IPv4 address : 2-octet assigned number.
     IP = 1,
+    /// Type 2: 4-octet AS number : 2-octet assigned number (RFC 4364 §4.2),
+    /// standard wherever the AS is 4-byte. The derived `NomBE` parser has no
+    /// catch-all, so without this variant a type-2 RD fails to parse and the
+    /// enclosing VPNv4/VPNv6/EVPN/MUP NLRI is silently dropped by
+    /// `many0_complete`.
+    ASN4 = 2,
 }
 
 #[derive(Default, NomBE, PartialEq, Debug, Clone, Ord, Eq, PartialOrd, Copy, Hash)]
@@ -35,8 +43,8 @@ impl FromStr for RouteDistinguisher {
         if strs.len() != 2 {
             return Err(());
         }
-        // A 16-bit autonomous system number, a colon, and a 32-bit number, for
-        // example: 65000:3
+        // Type 1: a 32-bit IP address, a colon, and a 16-bit number, for
+        // example: 192.168.1.2:51
         if let Ok(addr) = strs[0].parse::<Ipv4Addr>()
             && let Ok(val) = strs[1].parse::<u16>()
         {
@@ -45,8 +53,9 @@ impl FromStr for RouteDistinguisher {
             rd.val[4..6].copy_from_slice(&val.to_be_bytes());
             return Ok(rd);
         }
-        // A 32-bit IP address, a colon, and a 16-bit number, for example:
-        // 192.168.1.2:51
+        // Type 0: a 16-bit autonomous system number, a colon, and a 32-bit
+        // number, for example: 65000:3. Tried before type 2 so an AS that fits
+        // in 16 bits keeps the conventional 2-octet-AS encoding.
         if let Ok(asn) = strs[0].parse::<u16>()
             && let Ok(val) = strs[1].parse::<u32>()
         {
@@ -55,20 +64,41 @@ impl FromStr for RouteDistinguisher {
             rd.val[2..6].copy_from_slice(&val.to_be_bytes());
             return Ok(rd);
         }
+        // Type 2: a 32-bit autonomous system number, a colon, and a 16-bit
+        // number, for example: 4200000000:1. Only an AS above 65535 reaches
+        // here, so the text form of a type-2 RD whose AS fits in 16 bits parses
+        // back as type 0 — the textual encoding is inherently ambiguous, while
+        // the wire parse preserves `typ` exactly.
+        if let Ok(asn) = strs[0].parse::<u32>()
+            && let Ok(val) = strs[1].parse::<u16>()
+        {
+            let mut rd = RouteDistinguisher::new(RouteDistinguisherType::ASN4);
+            rd.val[0..4].copy_from_slice(&asn.to_be_bytes());
+            rd.val[4..6].copy_from_slice(&val.to_be_bytes());
+            return Ok(rd);
+        }
         Err(())
     }
 }
 
 impl fmt::Display for RouteDistinguisher {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        if self.typ == RouteDistinguisherType::ASN {
-            let asn = u16::from_be_bytes([self.val[0], self.val[1]]);
-            let val = u32::from_be_bytes([self.val[2], self.val[3], self.val[4], self.val[5]]);
-            write!(f, "{asn}:{val}")
-        } else {
-            let ip = Ipv4Addr::new(self.val[0], self.val[1], self.val[2], self.val[3]);
-            let val = u16::from_be_bytes([self.val[4], self.val[5]]);
-            write!(f, "{ip}:{val}")
+        match self.typ {
+            RouteDistinguisherType::ASN => {
+                let asn = u16::from_be_bytes([self.val[0], self.val[1]]);
+                let val = u32::from_be_bytes([self.val[2], self.val[3], self.val[4], self.val[5]]);
+                write!(f, "{asn}:{val}")
+            }
+            RouteDistinguisherType::IP => {
+                let ip = Ipv4Addr::new(self.val[0], self.val[1], self.val[2], self.val[3]);
+                let val = u16::from_be_bytes([self.val[4], self.val[5]]);
+                write!(f, "{ip}:{val}")
+            }
+            RouteDistinguisherType::ASN4 => {
+                let asn = u32::from_be_bytes([self.val[0], self.val[1], self.val[2], self.val[3]]);
+                let val = u16::from_be_bytes([self.val[4], self.val[5]]);
+                write!(f, "{asn}:{val}")
+            }
         }
     }
 }
@@ -84,5 +114,55 @@ mod tests {
 
         let rd: RouteDistinguisher = RouteDistinguisher::from_str("192.168.1.2:51").unwrap();
         assert_eq!(rd.to_string(), "192.168.1.2:51");
+    }
+
+    /// A type-2 RD (4-octet AS : 2-octet number, RFC 4364 §4.2) must parse off
+    /// the wire. Regression: the enum previously had no type-2 variant and no
+    /// catch-all, so the derived parser returned a `Switch` error and the
+    /// enclosing VPN NLRI was silently dropped by `many0_complete`.
+    #[test]
+    fn type2_rd_parses_from_wire() {
+        // typ = 2, AS = 4200000000 (0xFA56EA00), assigned number = 1.
+        let wire = [0x00u8, 0x02, 0xfa, 0x56, 0xea, 0x00, 0x00, 0x01];
+        let (rest, rd) = RouteDistinguisher::parse_be(&wire).unwrap();
+        assert!(rest.is_empty());
+        assert_eq!(rd.typ, RouteDistinguisherType::ASN4);
+        assert_eq!(rd.val, [0xfa, 0x56, 0xea, 0x00, 0x00, 0x01]);
+        assert_eq!(rd.to_string(), "4200000000:1");
+    }
+
+    /// The pre-existing types keep parsing and rendering exactly as before.
+    #[test]
+    fn type0_and_type1_parse_from_wire() {
+        let t0 = [0x00u8, 0x00, 0xfd, 0xe8, 0x00, 0x00, 0x00, 0x03];
+        let (_, rd) = RouteDistinguisher::parse_be(&t0).unwrap();
+        assert_eq!(rd.typ, RouteDistinguisherType::ASN);
+        assert_eq!(rd.to_string(), "65000:3");
+
+        let t1 = [0x00u8, 0x01, 0xc0, 0xa8, 0x01, 0x02, 0x00, 0x33];
+        let (_, rd) = RouteDistinguisher::parse_be(&t1).unwrap();
+        assert_eq!(rd.typ, RouteDistinguisherType::IP);
+        assert_eq!(rd.to_string(), "192.168.1.2:51");
+    }
+
+    /// A 4-byte AS is now expressible in the text form (it previously failed
+    /// `from_str`, so such an RT could not be configured at all).
+    #[test]
+    fn type2_rd_text_round_trip() {
+        let rd = RouteDistinguisher::from_str("4200000000:1").unwrap();
+        assert_eq!(rd.typ, RouteDistinguisherType::ASN4);
+        assert_eq!(rd.val, [0xfa, 0x56, 0xea, 0x00, 0x00, 0x01]);
+        assert_eq!(rd.to_string(), "4200000000:1");
+    }
+
+    /// An AS that fits in 16 bits keeps the conventional type-0 encoding, so
+    /// existing configs are unaffected by the new type-2 branch.
+    #[test]
+    fn sixteen_bit_as_still_prefers_type0() {
+        let rd = RouteDistinguisher::from_str("65000:3").unwrap();
+        assert_eq!(rd.typ, RouteDistinguisherType::ASN);
+        // 65536 does not fit a u16 AS, so it takes the type-2 branch.
+        let rd = RouteDistinguisher::from_str("65536:3").unwrap();
+        assert_eq!(rd.typ, RouteDistinguisherType::ASN4);
     }
 }

--- a/crates/bgp-packet/src/attrs/rd.rs
+++ b/crates/bgp-packet/src/attrs/rd.rs
@@ -3,7 +3,7 @@ use std::fmt;
 use std::net::Ipv4Addr;
 use std::str::FromStr;
 
-use super::{asn_from_string, asn_to_string};
+use super::{asn_from_string, asn_to_asdot_plus};
 
 #[allow(clippy::upper_case_acronyms)]
 #[repr(u16)]
@@ -114,14 +114,18 @@ impl fmt::Display for RouteDistinguisher {
                 write!(f, "{ip}:{val}")
             }
             RouteDistinguisherType::ASN4 => {
-                // asdot, matching `asn_to_string`'s AS_PATH rendering so the
-                // same 4-byte AS is spelled identically everywhere in show
-                // output. A type-2 AS below 65536 therefore prints undotted and
-                // reads back as type 0 — the text form is inherently ambiguous,
-                // while the wire parse preserves `typ` exactly.
+                // asdot+ (always dotted), not asdot: in the overlap where both
+                // the AS and the assigned number fit in 16 bits, the dot is the
+                // only thing distinguishing this from a type-0 RD, so it has to
+                // survive display. Plain asdot drops it below 65536, which made
+                // `0.100:1` print as `100:1` and read back as type 0 — the type
+                // silently flipped. For any AS >= 65536 (every real 4-byte AS)
+                // this is byte-identical to asdot, so it stays consistent with
+                // `asn_to_string`'s AS_PATH rendering. Matches GoBGP's
+                // `RouteDistinguisherFourOctetAS.String()`.
                 let asn = u32::from_be_bytes([self.val[0], self.val[1], self.val[2], self.val[3]]);
                 let val = u16::from_be_bytes([self.val[4], self.val[5]]);
-                write!(f, "{}:{}", asn_to_string(asn), val)
+                write!(f, "{}:{}", asn_to_asdot_plus(asn), val)
             }
         }
     }
@@ -201,11 +205,37 @@ mod tests {
 
     /// The dot makes the 4-octet-AS form explicit, so asdot selects type 2 even
     /// when the AS would fit in 16 bits — the only way to spell such an RD.
+    /// Regression: `Display` used plain asdot, which dropped the dot below
+    /// 65536, so this printed as `100:1` and read back as type 0 — the type
+    /// silently flipped. Type 2 is now always dotted (asdot+).
     #[test]
     fn asdot_selects_type2_even_for_small_as() {
         let rd = RouteDistinguisher::from_str("0.100:1").unwrap();
         assert_eq!(rd.typ, RouteDistinguisherType::ASN4);
         assert_eq!(rd.val, [0x00, 0x00, 0x00, 0x64, 0x00, 0x01]);
+        assert_eq!(rd.to_string(), "0.100:1", "type 2 must stay dotted");
+    }
+
+    /// Every RD type survives a display → parse round-trip with its `typ`
+    /// intact: the dot is what tells type 2 from type 0 in the overlap where
+    /// both the AS and the assigned number fit in 16 bits.
+    #[test]
+    fn display_round_trips_preserving_type() {
+        let cases = [
+            "65000:3",        // type 0, ambiguous overlap
+            "65000:70000",    // type 0, forced by the 4-byte number
+            "1.4464:3",       // type 2, AS 70000
+            "64086.59904:1",  // type 2, AS 4200000000
+            "0.100:1",        // type 2, AS that would fit in 16 bits
+            "192.168.1.2:51", // type 1
+        ];
+        for s in cases {
+            let rd = RouteDistinguisher::from_str(s).unwrap();
+            assert_eq!(rd.to_string(), s, "display must reproduce {s}");
+            let again = RouteDistinguisher::from_str(&rd.to_string()).unwrap();
+            assert_eq!(again.typ, rd.typ, "typ must survive round-trip of {s}");
+            assert_eq!(again.val, rd.val, "val must survive round-trip of {s}");
+        }
     }
 
     /// An IPv4 RD must not be mistaken for asdot, and a malformed asdot half

--- a/crates/bgp-packet/src/attrs/srpolicy.rs
+++ b/crates/bgp-packet/src/attrs/srpolicy.rs
@@ -54,12 +54,58 @@ pub struct SrPolicyTlvs {
     pub unknown: Vec<TunnelSubTlv>,
 }
 
-/// Binding SID (sub-TLV 13). The S/I flags are not modelled in v1; they
-/// are emitted as zero. An SRv6 SID may also arrive in the dedicated
-/// SRv6 Binding SID sub-TLV (20) — see [`Srv6BindingSid`].
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
-pub enum BindingSid {
+/// S-Flag (RFC 9830 §2.4.2, bit 0): the Specified-BSID-Only behaviour of
+/// RFC 9256 §6.2.3.
+pub const BSID_FLAG_S: u8 = 0x80;
+/// I-Flag (RFC 9830 §2.4.2, bit 1): the Drop-Upon-Invalid behaviour of
+/// RFC 9256 §8.2.
+pub const BSID_FLAG_I: u8 = 0x40;
+/// The flag bits RFC 9830 assigns. Everything else is unassigned and "MUST be
+/// set to zero upon transmission and MUST be ignored upon receipt", so it is
+/// masked off in both directions rather than carried.
+const BSID_FLAGS_DEFINED: u8 = BSID_FLAG_S | BSID_FLAG_I;
+
+/// Binding SID (sub-TLV 13): `Flags(1) RESERVED(1) BSID(0 | 4 SR-MPLS | 16 SRv6)`.
+///
+/// The flags change how the receiver treats the policy — S selects
+/// Specified-BSID-Only and I selects Drop-Upon-Invalid — so they have to survive
+/// a decode/re-encode. They previously were not modelled and were emitted as
+/// zero, which silently turned both behaviours off on anything this speaker
+/// re-advertised.
+///
+/// An SRv6 SID may also arrive in the dedicated SRv6 Binding SID sub-TLV (20) —
+/// see [`Srv6BindingSid`].
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Default)]
+pub struct BindingSid {
+    /// The assigned flag bits, as received. Unassigned bits are dropped on
+    /// receipt and never transmitted, per RFC 9830 §2.4.2.
+    pub flags: u8,
+    pub value: BindingSidValue,
+}
+
+impl BindingSid {
+    /// A Binding SID with no flags set.
+    pub fn new(value: BindingSidValue) -> Self {
+        Self { flags: 0, value }
+    }
+
+    /// RFC 9256 §6.2.3 Specified-BSID-Only.
+    pub fn specified_bsid_only(&self) -> bool {
+        self.flags & BSID_FLAG_S != 0
+    }
+
+    /// RFC 9256 §8.2 Drop-Upon-Invalid.
+    pub fn drop_upon_invalid(&self) -> bool {
+        self.flags & BSID_FLAG_I != 0
+    }
+}
+
+/// The BSID a [`BindingSid`] carries, if any. The length of the sub-TLV selects
+/// the variant: 2, 6, or 18 octets (RFC 9830 §2.4.2).
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Default)]
+pub enum BindingSidValue {
     /// Length 2: Flags+RESERVED only, no BSID value.
+    #[default]
     None,
     /// Length 6: a 20-bit SR-MPLS label.
     MplsLabel(u32),
@@ -260,19 +306,29 @@ fn parse_preference(v: &[u8]) -> Result<u32, SrPolicyError> {
 
 fn parse_binding_sid(v: &[u8]) -> Result<BindingSid, SrPolicyError> {
     // Flags(1) RESERVED(1) BSID(0 | 4 SR-MPLS | 16 SRv6).
-    match v.len() {
-        2 => Ok(BindingSid::None),
+    let value = match v.len() {
+        2 => BindingSidValue::None,
         6 => {
             let word = u32::from_be_bytes([v[2], v[3], v[4], v[5]]);
-            Ok(BindingSid::MplsLabel(word >> MPLS_LABEL_SHIFT))
+            BindingSidValue::MplsLabel(word >> MPLS_LABEL_SHIFT)
         }
-        18 => Ok(BindingSid::Srv6(read_v6(&v[2..18]))),
-        _ => Err(SrPolicyError::BadLength {
-            typ: BINDING_SID,
-            len: v.len(),
-            expected: "2, 6, or 18",
-        }),
-    }
+        18 => BindingSidValue::Srv6(read_v6(&v[2..18])),
+        _ => {
+            return Err(SrPolicyError::BadLength {
+                typ: BINDING_SID,
+                len: v.len(),
+                expected: "2, 6, or 18",
+            });
+        }
+    };
+    // The flags octet was read and thrown away here, so S and I were lost and
+    // re-emitted as zero. Keep the assigned bits; RFC 9830 §2.4.2 says the
+    // unassigned ones "MUST be ignored upon receipt", so drop them now rather
+    // than carry a value we would not be allowed to transmit.
+    Ok(BindingSid {
+        flags: v[0] & BSID_FLAGS_DEFINED,
+        value,
+    })
 }
 
 fn parse_srv6_binding_sid(v: &[u8]) -> Result<Srv6BindingSid, SrPolicyError> {
@@ -475,13 +531,15 @@ fn emit_preference(pref: u32) -> Vec<u8> {
 }
 
 fn emit_binding_sid(bsid: &BindingSid) -> Vec<u8> {
-    let mut v = vec![0u8, 0u8]; // Flags, RESERVED
-    match bsid {
-        BindingSid::None => {}
-        BindingSid::MplsLabel(label) => {
+    // Flags, RESERVED. The mask keeps a locally-built value from transmitting
+    // unassigned bits, which RFC 9830 §2.4.2 requires be zero on the wire.
+    let mut v = vec![bsid.flags & BSID_FLAGS_DEFINED, 0u8];
+    match &bsid.value {
+        BindingSidValue::None => {}
+        BindingSidValue::MplsLabel(label) => {
             v.extend_from_slice(&((label & MPLS_LABEL_MASK) << MPLS_LABEL_SHIFT).to_be_bytes());
         }
-        BindingSid::Srv6(sid) => v.extend_from_slice(&sid.octets()),
+        BindingSidValue::Srv6(sid) => v.extend_from_slice(&sid.octets()),
     }
     v
 }
@@ -587,7 +645,10 @@ mod tests {
         value.extend_from_slice(&word.to_be_bytes());
         let t = tlv(vec![sub(BINDING_SID, value.clone())]);
         let v = round_trip(t.clone(), &t);
-        assert_eq!(v.binding_sid, Some(BindingSid::MplsLabel(16001)));
+        assert_eq!(
+            v.binding_sid,
+            Some(BindingSid::new(BindingSidValue::MplsLabel(16001)))
+        );
         // Wire bytes: Flags=0, RESERVED=0, then the 4-octet label entry.
         assert_eq!(v.to_tunnel().sub_tlvs[0].value, value);
     }
@@ -597,7 +658,7 @@ mod tests {
         let none = tlv(vec![sub(BINDING_SID, vec![0, 0])]);
         assert_eq!(
             round_trip(none.clone(), &none).binding_sid,
-            Some(BindingSid::None)
+            Some(BindingSid::new(BindingSidValue::None))
         );
 
         let sid: Ipv6Addr = "fc00:0:9::100".parse().unwrap();
@@ -606,7 +667,54 @@ mod tests {
         let t = tlv(vec![sub(BINDING_SID, value)]);
         assert_eq!(
             round_trip(t.clone(), &t).binding_sid,
-            Some(BindingSid::Srv6(sid))
+            Some(BindingSid::new(BindingSidValue::Srv6(sid)))
+        );
+    }
+
+    /// The S and I flags must survive a decode/re-encode. Regression: the flags
+    /// octet was read and dropped, and re-emitted as zero — a reflector silently
+    /// turned Specified-BSID-Only and Drop-Upon-Invalid *off* on every policy it
+    /// passed on. Every pre-existing test used Flags=0, which is why the loss
+    /// went unseen.
+    #[test]
+    fn binding_sid_flags_round_trip() {
+        let word: u32 = 16001 << 12;
+        for flags in [0u8, BSID_FLAG_S, BSID_FLAG_I, BSID_FLAG_S | BSID_FLAG_I] {
+            let mut value = vec![flags, 0u8];
+            value.extend_from_slice(&word.to_be_bytes());
+            let t = tlv(vec![sub(BINDING_SID, value.clone())]);
+            let v = round_trip(t.clone(), &t);
+
+            let bsid = v.binding_sid.clone().expect("binding sid present");
+            assert_eq!(bsid.flags, flags, "flags survive the decode");
+            assert_eq!(bsid.specified_bsid_only(), flags & BSID_FLAG_S != 0);
+            assert_eq!(bsid.drop_upon_invalid(), flags & BSID_FLAG_I != 0);
+            // `round_trip` already asserts the re-emit equals the input, so the
+            // flags octet is back on the wire unchanged.
+            assert_eq!(v.to_tunnel().sub_tlvs[0].value[0], flags);
+        }
+    }
+
+    /// RFC 9830 §2.4.2: unassigned flag bits "MUST be set to zero upon
+    /// transmission and MUST be ignored upon receipt" — so they are dropped on
+    /// receipt rather than preserved, and never re-transmitted.
+    #[test]
+    fn binding_sid_unassigned_flag_bits_are_dropped() {
+        let mut value = vec![0xFFu8, 0u8]; // every bit set
+        value.extend_from_slice(&(16001u32 << 12).to_be_bytes());
+        let t = tlv(vec![sub(BINDING_SID, value)]);
+        let v = SrPolicyTlvs::from_tunnel(&t).expect("decode");
+
+        let bsid = v.binding_sid.clone().expect("binding sid present");
+        assert_eq!(
+            bsid.flags,
+            BSID_FLAG_S | BSID_FLAG_I,
+            "only the assigned bits are kept"
+        );
+        assert_eq!(
+            v.to_tunnel().sub_tlvs[0].value[0],
+            BSID_FLAG_S | BSID_FLAG_I,
+            "unassigned bits are not transmitted"
         );
     }
 
@@ -754,7 +862,7 @@ mod tests {
         // Emit order matches input order, so it round-trips byte-equal.
         let v = round_trip(input.clone(), &input);
         assert_eq!(v.preference, Some(200));
-        assert_eq!(v.binding_sid, Some(BindingSid::None));
+        assert_eq!(v.binding_sid, Some(BindingSid::new(BindingSidValue::None)));
         assert_eq!(v.segment_lists.len(), 2);
         assert_eq!(v.policy_name.as_deref(), Some("red"));
     }

--- a/crates/bgp-packet/src/bgp_attr.rs
+++ b/crates/bgp-packet/src/bgp_attr.rs
@@ -94,7 +94,12 @@ impl BgpAttr {
         if let Some(v) = &self.aggregator {
             v.attr_emit(buf);
         }
-        if let Some(v) = &self.com {
+        // An empty set would emit a zero-length attribute, which RFC 7606 §7.8
+        // makes malformed (the length must be a *non-zero* multiple of 4) and
+        // our own parser now rejects. An emptied set means "no attribute".
+        if let Some(v) = &self.com
+            && !v.0.is_empty()
+        {
             v.attr_emit(buf);
         }
         if let Some(v) = &self.originator_id {
@@ -112,7 +117,10 @@ impl BgpAttr {
         if let Some(v) = &self.aigp {
             v.attr_emit(buf);
         }
-        if let Some(v) = &self.lcom {
+        // Likewise RFC 8092 §3: a non-zero multiple of 12.
+        if let Some(v) = &self.lcom
+            && !v.0.is_empty()
+        {
             v.attr_emit(buf);
         }
         if let Some(v) = &self.prefix_sid {

--- a/crates/bgp-packet/src/caps/packet.rs
+++ b/crates/bgp-packet/src/caps/packet.rs
@@ -64,9 +64,15 @@ impl CapabilityPacket {
         let (input, cap_header) = CapabilityHeader::parse_be(input)?;
         let len = cap_header.length as usize;
         let (input, cap) = packet_utils::safe_split_at(input, len)?;
-        let (remaining, cap) = CapabilityPacket::parse_be(cap, cap_header.code.into())?;
+        let (remaining, mut cap) = CapabilityPacket::parse_be(cap, cap_header.code.into())?;
         if !remaining.is_empty() {
             return Err(nom::Err::Error(make_error(input, ErrorKind::LengthValue)));
+        }
+        // The opaque `Unknown` passthrough parses only the value bytes, so carry
+        // the real capability code (already consumed into `cap_header`) across so
+        // display and re-emit preserve it.
+        if let CapabilityPacket::Unknown(unknown) = &mut cap {
+            unknown.code = cap_header.code;
         }
         Ok((input, cap))
     }
@@ -145,5 +151,61 @@ impl fmt::Display for CapabilityPacket {
             Self::LlgrOld(v) => write!(f, "{}", v),
             Self::Unknown(v) => write!(f, "{}", v),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::CapEmit;
+
+    // RFC 9234 Role capability: code 9, length 1, one value octet. zebra-rs has
+    // no explicit `CapabilityPacket` arm for it, so it must fall through to the
+    // opaque `Unknown` passthrough and parse without error (RFC 5492 requires
+    // ignoring unknown capabilities). Regression: the old `CapUnknown` re-read a
+    // 2-byte header from the 1-byte value and failed the whole OPEN.
+    #[test]
+    fn unknown_short_capability_parses_and_round_trips() {
+        let wire = [9u8, 1, 0x03]; // code=9 (Role), len=1, value=0x03
+        let (rest, cap) = CapabilityPacket::parse_cap(&wire).unwrap();
+        assert!(rest.is_empty());
+        let CapabilityPacket::Unknown(u) = &cap else {
+            panic!("expected Unknown, got {cap:?}");
+        };
+        assert_eq!(u.code, 9);
+        assert_eq!(u.data, vec![0x03]);
+
+        // Grouped re-emit (code + length + value) preserves the code and value.
+        let mut buf = BytesMut::new();
+        u.emit(&mut buf, true);
+        assert_eq!(&buf[..], &wire[..]);
+    }
+
+    // A zero-length unknown capability (code with no value) must also parse
+    // rather than error on the missing header.
+    #[test]
+    fn unknown_zero_length_capability_parses() {
+        let wire = [9u8, 0]; // code=9, len=0, no value
+        let (rest, cap) = CapabilityPacket::parse_cap(&wire).unwrap();
+        assert!(rest.is_empty());
+        let CapabilityPacket::Unknown(u) = &cap else {
+            panic!("expected Unknown");
+        };
+        assert_eq!(u.code, 9);
+        assert!(u.data.is_empty());
+    }
+
+    // A known capability still routes to its typed variant, and the Unknown
+    // stamping does not disturb it.
+    #[test]
+    fn known_capability_still_parses() {
+        // As4 capability: code 65, length 4, ASN 0x0000FDE8 (65000).
+        let wire = [65u8, 4, 0x00, 0x00, 0xfd, 0xe8];
+        let (rest, cap) = CapabilityPacket::parse_cap(&wire).unwrap();
+        assert!(rest.is_empty());
+        let CapabilityPacket::As4(a) = &cap else {
+            panic!("expected As4, got {cap:?}");
+        };
+        assert_eq!(a.asn, 65000);
     }
 }

--- a/crates/bgp-packet/src/caps/unknown.rs
+++ b/crates/bgp-packet/src/caps/unknown.rs
@@ -3,21 +3,20 @@ use std::fmt;
 use bytes::{BufMut, BytesMut};
 use nom_derive::*;
 
-use super::{CapCode, CapEmit, CapabilityHeader};
+use super::{CapCode, CapEmit};
 
-#[derive(Debug, PartialEq, NomBE, Clone)]
+#[derive(Debug, PartialEq, NomBE, Clone, Default)]
 pub struct CapUnknown {
-    pub header: CapabilityHeader,
+    /// Capability code, stamped in by `CapabilityPacket::parse_cap` after it has
+    /// stripped the code/length header. It is deliberately NOT parsed from the
+    /// value: the slice handed to this parser already has the 2-byte header
+    /// removed, so parsing a `CapabilityHeader` here would re-read two value
+    /// octets and fail on any capability (e.g. RFC 9234 Role, code 9 len 1)
+    /// whose value is shorter than two bytes — rejecting the whole OPEN instead
+    /// of ignoring the unknown capability as RFC 5492 requires.
+    #[nom(Ignore)]
+    pub code: u8,
     pub data: Vec<u8>,
-}
-
-impl Default for CapUnknown {
-    fn default() -> Self {
-        Self {
-            header: CapabilityHeader::new(CapCode::AddPath, 0),
-            data: Vec::new(),
-        }
-    }
 }
 
 impl CapUnknown {
@@ -38,7 +37,7 @@ impl CapUnknown {
 
 impl CapEmit for CapUnknown {
     fn code(&self) -> CapCode {
-        CapCode::Unknown(100)
+        CapCode::Unknown(self.code)
     }
 
     fn len(&self) -> u8 {
@@ -55,7 +54,7 @@ impl CapEmit for CapUnknown {
 
 impl fmt::Display for CapUnknown {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "Unknown: Code {}", self.header.code)
+        write!(f, "Unknown: Code {}", self.code)
     }
 }
 
@@ -65,7 +64,7 @@ mod tests {
 
     fn cap_with_data(n: usize) -> CapUnknown {
         CapUnknown {
-            header: CapabilityHeader::new(CapCode::Unknown(100), 0),
+            code: 100,
             data: vec![0xab; n],
         }
     }

--- a/crates/bgp-packet/src/notification.rs
+++ b/crates/bgp-packet/src/notification.rs
@@ -18,14 +18,23 @@ pub struct NotificationPacket {
 
 impl Display for NotificationPacket {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        writeln!(f, "Notification").unwrap();
-        writeln!(f, " Code: {}", self.code).unwrap();
+        writeln!(f, "Notification")?;
+        writeln!(f, " Code: {}", self.code)?;
         writeln!(
             f,
             " Sub Code: {}",
             notify_sub_code_str(self.code, self.sub_code)
-        )
-        .unwrap();
+        )?;
+        if let Some(msg) = self.shutdown_communication() {
+            // The operator's own words for why the session went down
+            // (RFC 9003) — the whole reason the Data field is worth keeping.
+            writeln!(f, " Shutdown Communication: {msg}")?;
+        } else if !self.data.is_empty() {
+            // Everything else — RFC 4486 Maximum Prefixes' AFI/SAFI and count,
+            // or the offending octets of the attribute the peer objected to —
+            // has no decoder here, so show it raw rather than drop it again.
+            writeln!(f, " Data: {}", data_hex(&self.data))?;
+        }
         Ok(())
     }
 }
@@ -104,7 +113,8 @@ impl Display for NotifyCode {
     }
 }
 
-fn notify_sub_code_str(code: NotifyCode, sub_code: u8) -> String {
+/// Human-readable sub-code name for `code`, e.g. "Administrative Shutdown".
+pub fn notify_sub_code_str(code: NotifyCode, sub_code: u8) -> String {
     use NotifyCode::*;
     match code {
         MsgHeaderError => sub_header_error_str(sub_code.into()),
@@ -441,20 +451,149 @@ impl From<NotificationPacket> for BytesMut {
 
 impl NotificationPacket {
     pub fn parse_packet(input: &[u8]) -> IResult<&[u8], NotificationPacket> {
-        let (input, packet) = NotificationPacket::parse_be(input)?;
+        let (input, mut packet) = NotificationPacket::parse_be(input)?;
         let len = packet
             .header
             .length
             .saturating_sub(BGP_HEADER_LEN)
             .saturating_sub(2);
-        let (input, _data) = take(len as usize).parse(input)?;
+        let (input, data) = take(len as usize).parse(input)?;
+        // Keep the Data field. `data` is `#[nom(Ignore)]`, so the derived parse
+        // leaves it empty and these octets used to be read into a discarded
+        // binding — a peer's RFC 9003 shutdown message, or the offending bytes
+        // of the attribute it objected to, reached the process and were dropped
+        // before anyone could see them.
+        packet.data = data.to_vec();
         Ok((input, packet))
     }
+
+    /// The RFC 9003 Shutdown Communication, if this is one and it is well
+    /// formed.
+    ///
+    /// Only Cease subcodes 2 (Administrative Shutdown) and 4 (Administrative
+    /// Reset) may carry it. The Data field is a 1-octet length followed by that
+    /// many octets of UTF-8 — RFC 9003 raised the cap from RFC 8203's 128 to
+    /// 255, so any length fits the octet.
+    ///
+    /// RFC 9003 §4 says a receiver finding invalid UTF-8 SHOULD log the fact and
+    /// MUST NOT interpret the malformed sequence, but must not reject the
+    /// NOTIFICATION over it — so this renders lossily and only declines when the
+    /// length field disagrees with the octets present.
+    pub fn shutdown_communication(&self) -> Option<String> {
+        if self.code != NotifyCode::Cease {
+            return None;
+        }
+        if !matches!(
+            CeaseError::from(self.sub_code),
+            CeaseError::AdministrativeShutdown | CeaseError::AdministrativeReset
+        ) {
+            return None;
+        }
+        let (&len, rest) = self.data.split_first()?;
+        let len = len as usize;
+        if len == 0 || rest.len() < len {
+            return None;
+        }
+        Some(String::from_utf8_lossy(&rest[..len]).into_owned())
+    }
+}
+
+/// Render the NOTIFICATION Data octets for a human, used when no subcode-
+/// specific decoder applies.
+fn data_hex(data: &[u8]) -> String {
+    data.iter()
+        .map(|b| format!("{b:02x}"))
+        .collect::<Vec<_>>()
+        .join(" ")
 }
 
 #[cfg(test)]
 mod tests {
     use super::CeaseError;
+    use super::*;
+
+    /// Build the wire form of a NOTIFICATION with the given Data.
+    fn wire(code: u8, sub_code: u8, data: &[u8]) -> BytesMut {
+        let packet = NotificationPacket::new(NotifyCode::from(code), sub_code, data.to_vec());
+        packet.into()
+    }
+
+    /// The Data field must survive parsing. Regression: `data` is
+    /// `#[nom(Ignore)]`, so the derived parse left it empty and `parse_packet`
+    /// read the octets into a discarded binding — every NOTIFICATION arrived
+    /// with `data` empty, whatever the peer sent.
+    #[test]
+    fn notification_data_survives_round_trip() {
+        let buf = wire(6, 2, &[0x04, b'b', b'y', b'e', b'!']);
+        let (rest, parsed) = NotificationPacket::parse_packet(&buf).expect("must parse");
+        assert!(rest.is_empty());
+        assert_eq!(parsed.code, NotifyCode::Cease);
+        assert_eq!(parsed.sub_code, 2);
+        assert_eq!(
+            parsed.data,
+            vec![0x04, b'b', b'y', b'e', b'!'],
+            "Data must not be dropped"
+        );
+    }
+
+    /// RFC 9003: a Cease/Administrative Shutdown (2) or Administrative Reset (4)
+    /// carries a 1-octet length then that many octets of UTF-8.
+    #[test]
+    fn shutdown_communication_is_decoded() {
+        for sub in [2u8, 4] {
+            let msg = "maintenance window";
+            let mut data = vec![msg.len() as u8];
+            data.extend_from_slice(msg.as_bytes());
+            let buf = wire(6, sub, &data);
+            let (_, parsed) = NotificationPacket::parse_packet(&buf).expect("must parse");
+            assert_eq!(parsed.shutdown_communication().as_deref(), Some(msg));
+            assert!(parsed.to_string().contains(msg), "Display surfaces it");
+        }
+    }
+
+    /// The shutdown communication is only defined for those two Cease subcodes;
+    /// elsewhere the Data means something else and must not be read as text.
+    #[test]
+    fn shutdown_communication_only_for_its_subcodes() {
+        let data = [0x03, b'a', b'b', b'c'];
+        // Cease, but subcode 1 (Maximum Number of Prefixes Reached).
+        let buf = wire(6, 1, &data);
+        let (_, parsed) = NotificationPacket::parse_packet(&buf).unwrap();
+        assert_eq!(parsed.shutdown_communication(), None);
+        assert!(
+            parsed.to_string().contains("Data: 03 61 62 63"),
+            "shown raw"
+        );
+
+        // Not a Cease at all.
+        let buf = wire(3, 2, &data);
+        let (_, parsed) = NotificationPacket::parse_packet(&buf).unwrap();
+        assert_eq!(parsed.shutdown_communication(), None);
+    }
+
+    /// A length field disagreeing with the octets present is not interpreted.
+    /// RFC 9003 §4 still forbids rejecting the NOTIFICATION over it, so the
+    /// packet parses and the Data is shown raw.
+    #[test]
+    fn inconsistent_shutdown_length_is_not_interpreted() {
+        // Claims 9 octets, carries 3.
+        let buf = wire(6, 2, &[0x09, b'a', b'b', b'c']);
+        let (_, parsed) = NotificationPacket::parse_packet(&buf).expect("must still parse");
+        assert_eq!(parsed.shutdown_communication(), None);
+        assert_eq!(parsed.data, vec![0x09, b'a', b'b', b'c'], "kept verbatim");
+    }
+
+    /// Invalid UTF-8 is rendered lossily rather than rejected (RFC 9003 §4:
+    /// log it, do not interpret the malformed sequence, do not reject).
+    #[test]
+    fn invalid_utf8_shutdown_is_lossy_not_fatal() {
+        let buf = wire(6, 2, &[0x02, 0xff, 0xfe]);
+        let (_, parsed) = NotificationPacket::parse_packet(&buf).expect("must still parse");
+        assert!(
+            parsed.shutdown_communication().is_some(),
+            "rendered lossily, not dropped"
+        );
+    }
 
     /// Every Cease sub-code round-trips u8 → CeaseError → u8, including
     /// the Unknown passthrough.

--- a/crates/bgp-packet/src/parser.rs
+++ b/crates/bgp-packet/src/parser.rs
@@ -58,6 +58,40 @@ pub fn nlri_psize(plen: u8) -> usize {
     plen.div_ceil(8).into()
 }
 
+/// Parse an MP_REACH / MP_UNREACH NLRI block to exhaustion, rejecting a block
+/// that does not consume exactly.
+///
+/// `many0_complete` alone stops at the first element that fails to parse and
+/// hands back whatever it accumulated, so a malformed NLRI silently yields "the
+/// routes before it, and nothing after" — the peer believes it advertised routes
+/// we never installed, and no error is raised anywhere. That is the one outcome
+/// RFC 7606 never permits.
+///
+/// Erroring here is the correct action, not merely a stricter one: §3(j)
+/// requires that treat-as-withdraw be used only when the affected routes can be
+/// determined, and "if this is not possible ... the 'session reset' approach (or
+/// the 'AFI/SAFI disable' approach) MUST be followed". Once an NLRI fails to
+/// parse, the rest of the block cannot be located, so the affected routes are
+/// exactly what cannot be determined. `attr_malformation_is_withdraw` already
+/// leaves MP_REACH/MP_UNREACH out of the treat-as-withdraw set, so this error
+/// reaches the session-reset path the RFC asks for.
+pub fn parse_nlri_block<'a, O, F>(input: &'a [u8], parser: F) -> nom::IResult<&'a [u8], Vec<O>>
+where
+    F: nom::Parser<&'a [u8], Output = O, Error = nom::error::Error<&'a [u8]>>,
+{
+    use nom::Parser as _;
+    let (rest, items) = crate::many0_complete(parser).parse(input)?;
+    if !rest.is_empty() {
+        // Unconsumed octets mean an element stopped the list early: the block is
+        // malformed, not merely finished.
+        return Err(nom::Err::Error(nom::error::make_error(
+            rest,
+            nom::error::ErrorKind::LengthValue,
+        )));
+    }
+    Ok((rest, items))
+}
+
 pub fn peek_bgp_length(input: &[u8]) -> Option<usize> {
     if input.len() < BGP_HEADER_LEN.into() {
         return None;

--- a/crates/bgp-packet/src/update.rs
+++ b/crates/bgp-packet/src/update.rs
@@ -7,9 +7,9 @@ use nom::number::complete::be_u16;
 use nom_derive::*;
 
 use crate::{
-    Afi, AttrFlags, AttrType, BGP_HEADER_LEN, BGP_PACKET_LEN, BgpAttr, BgpHeader, BgpParseError,
-    BgpType, Ipv4Nlri, MpReachAttr, MpUnreachAttr, ParseOption, Safi, nlri_psize,
-    parse_bgp_nlri_ipv4, parse_bgp_update_attribute,
+    Afi, AttrFlags, AttrType, BGP_EXTENDED_PACKET_LEN, BGP_HEADER_LEN, BGP_PACKET_LEN, BgpAttr,
+    BgpHeader, BgpParseError, BgpType, Ipv4Nlri, MpReachAttr, MpUnreachAttr, ParseOption, Safi,
+    nlri_psize, parse_bgp_nlri_ipv4, parse_bgp_update_attribute,
 };
 
 /// IPv6 next-hop that an RFC 8950 IPv4-over-IPv6 advertisement carries
@@ -460,17 +460,57 @@ impl UpdatePacket {
     }
 }
 
-impl From<UpdatePacket> for BytesMut {
-    fn from(update: UpdatePacket) -> Self {
+/// Why an [`UpdatePacket`] could not be serialised.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, thiserror::Error)]
+pub enum UpdateEmitError {
+    /// A length field could not hold the octet count it had to describe. Always
+    /// a local construction bug: the caller must chunk to the session's message
+    /// budget, as `pop_ipv4` and the update-group emitters do.
+    #[error(
+        "BGP UPDATE {field} is {len} octets, over the {} the 2-octet length field can describe",
+        BGP_EXTENDED_PACKET_LEN
+    )]
+    TooLong {
+        /// Which length field overflowed.
+        field: &'static str,
+        /// The octet count that could not be encoded.
+        len: usize,
+    },
+}
+
+/// Narrow an octet count to the u16 a BGP length field carries, refusing rather
+/// than wrapping.
+fn fit_len(field: &'static str, len: usize) -> Result<u16, UpdateEmitError> {
+    u16::try_from(len).map_err(|_| UpdateEmitError::TooLong { field, len })
+}
+
+impl UpdatePacket {
+    /// Serialise this UPDATE, refusing one whose length fields cannot describe
+    /// it.
+    ///
+    /// The BGP header's Length is a single u16 and RFC 8654 caps a message at
+    /// [`BGP_EXTENDED_PACKET_LEN`] octets, so an over-long UPDATE has no correct
+    /// encoding at all. Casting with `as u16` silently wrapped instead — a
+    /// 70023-octet UPDATE declared itself as 4487 — putting a frame on the wire
+    /// whose header disagreed with its body and desynchronising the peer's
+    /// framing for everything after it. The withdrawn-routes and
+    /// total-path-attribute lengths wrapped the same way.
+    ///
+    /// Only the encodable limit is enforced here, not the session's
+    /// `max_packet_size`: an UPDATE between that budget and 65535 octets is
+    /// already emitted today, and rejecting it would be a behaviour change
+    /// beyond removing the silent corruption. Callers that batch an unbounded
+    /// number of NLRI are still responsible for chunking to `max_packet_size`.
+    pub fn try_emit(self) -> Result<BytesMut, UpdateEmitError> {
         let mut buf = BytesMut::new();
-        let header: BytesMut = update.header.into();
+        let header: BytesMut = self.header.into();
         buf.put(&header[..]);
 
         // IPv4 unicast withdraw.
         let withdraw_len_pos = buf.len();
         buf.put_u16(0u16); // Placeholder.
         let withdraw_pos: std::ops::Range<usize> = withdraw_len_pos..withdraw_len_pos + 2;
-        for ip in update.ipv4_withdraw.iter() {
+        for ip in self.ipv4_withdraw.iter() {
             if ip.id != 0 {
                 buf.put_u32(ip.id);
             }
@@ -478,7 +518,7 @@ impl From<UpdatePacket> for BytesMut {
             let plen = nlri_psize(ip.prefix.prefix_len());
             buf.put(&ip.prefix.addr().octets()[0..plen]);
         }
-        let withdraw_len: u16 = (buf.len() - withdraw_len_pos - 2) as u16;
+        let withdraw_len = fit_len("withdrawn routes length", buf.len() - withdraw_len_pos - 2)?;
         buf[withdraw_pos].copy_from_slice(&withdraw_len.to_be_bytes());
 
         // Attributes length.
@@ -487,25 +527,25 @@ impl From<UpdatePacket> for BytesMut {
         let attr_pos: std::ops::Range<usize> = attr_len_pos..attr_len_pos + 2;
 
         // Attributes emit.
-        if let Some(bgp_attr) = update.bgp_attr {
+        if let Some(bgp_attr) = self.bgp_attr {
             bgp_attr.attr_emit(&mut buf);
         }
 
         // MP reach.
-        if let Some(mp_update) = update.mp_update {
+        if let Some(mp_update) = self.mp_update {
             mp_update.attr_emit(&mut buf);
         }
 
         // MP unreach.
-        if let Some(mp_withdraw) = update.mp_withdraw {
+        if let Some(mp_withdraw) = self.mp_withdraw {
             mp_withdraw.attr_emit(&mut buf);
         }
 
-        let attr_len: u16 = (buf.len() - attr_len_pos - 2) as u16;
+        let attr_len = fit_len("total path attribute length", buf.len() - attr_len_pos - 2)?;
         buf[attr_pos].copy_from_slice(&attr_len.to_be_bytes());
 
         // IPv4 unicast update.
-        for ip in update.ipv4_update.iter() {
+        for ip in self.ipv4_update.iter() {
             if ip.id != 0 {
                 buf.put_u32(ip.id);
             }
@@ -515,10 +555,18 @@ impl From<UpdatePacket> for BytesMut {
         }
 
         const LENGTH_POS: std::ops::Range<usize> = 16..18;
-        let length: u16 = buf.len() as u16;
+        let length = fit_len("message length", buf.len())?;
         buf[LENGTH_POS].copy_from_slice(&length.to_be_bytes());
 
-        buf
+        Ok(buf)
+    }
+}
+
+impl TryFrom<UpdatePacket> for BytesMut {
+    type Error = UpdateEmitError;
+
+    fn try_from(update: UpdatePacket) -> Result<Self, Self::Error> {
+        update.try_emit()
     }
 }
 
@@ -610,6 +658,51 @@ mod tests {
     use ipnet::Ipv4Net;
 
     use super::*;
+
+    /// An UPDATE too long for the 2-octet header Length must be refused, not
+    /// wrapped. Regression: `buf.len() as u16` silently truncated, so a
+    /// 70023-octet UPDATE went out declaring itself 4487 octets — the peer
+    /// framed 4487 bytes as one message and then mis-framed everything after.
+    #[test]
+    fn oversized_update_is_refused_not_wrapped() {
+        // Each inline NLRI is 1 (prefix length) + 4 (prefix) = 5 octets;
+        // 14000 * 5 = 70000, past what the Length field can describe.
+        let mut update = UpdatePacket::default();
+        for i in 0..14000u32 {
+            let addr = std::net::Ipv4Addr::from(0x0A00_0000u32 + i * 256);
+            update.ipv4_update.push(Ipv4Nlri {
+                id: 0,
+                prefix: Ipv4Net::new(addr, 32).unwrap(),
+            });
+        }
+        match update.try_emit() {
+            Err(UpdateEmitError::TooLong { field, len }) => {
+                assert_eq!(field, "message length");
+                assert!(len > u16::MAX as usize, "reported the real octet count");
+            }
+            Ok(buf) => panic!(
+                "oversized UPDATE must not encode (got {} octets)",
+                buf.len()
+            ),
+        }
+    }
+
+    /// An UPDATE that fits still encodes, and its header Length matches the
+    /// octets actually produced.
+    #[test]
+    fn encodable_update_reports_its_true_length() {
+        let mut update = UpdatePacket::default();
+        for i in 0..10u32 {
+            let addr = std::net::Ipv4Addr::from(0x0A00_0000u32 + i * 256);
+            update.ipv4_update.push(Ipv4Nlri {
+                id: 0,
+                prefix: Ipv4Net::new(addr, 32).unwrap(),
+            });
+        }
+        let buf = update.try_emit().expect("must encode");
+        let declared = u16::from_be_bytes([buf[16], buf[17]]) as usize;
+        assert_eq!(declared, buf.len(), "header Length matches the body");
+    }
 
     fn nlri(prefix: &str) -> Ipv4Nlri {
         Ipv4Nlri {

--- a/zebra-rs/src/bgp/group_egress.rs
+++ b/zebra-rs/src/bgp/group_egress.rs
@@ -312,7 +312,13 @@ impl Engine {
                 .unwrap_or(4096);
             let mut update = UpdatePacket::with_max_packet_size(max);
             update.ipv4_withdraw.push(Ipv4Nlri { id, prefix });
-            self.fan(&[update.into()], source_ident);
+            // One withdrawn prefix cannot overflow a length field, but encode
+            // through the checked path anyway so no emit site can put a frame on
+            // the wire whose header contradicts its body.
+            match update.try_emit() {
+                Ok(bytes) => self.fan(&[bytes], source_ident),
+                Err(e) => tracing::warn!("dropping IPv4 withdraw for {}: {}", prefix, e),
+            }
         }
     }
 

--- a/zebra-rs/src/bgp/inst.rs
+++ b/zebra-rs/src/bgp/inst.rs
@@ -355,16 +355,19 @@ fn route_rts_from_ecom(
         .filter(|v| v.low_type == 0x02)
         .map(|v| {
             use bgp_packet::RouteDistinguisherType;
-            // high_type 0x00 = Two-Octet AS, 0x01 = IPv4. Anything
-            // else (0x02 = 4-byte AS, future types) maps onto ASN
-            // by default — `RouteDistinguisher::PartialEq` is per-
-            // byte so a 4-byte ASN extcomm just won't intersect
-            // any configured RT (the config builder rejects 4-byte
-            // ASN strings today).
-            let typ = if v.high_type == 0x01 {
-                RouteDistinguisherType::IP
-            } else {
-                RouteDistinguisherType::ASN
+            // high_type 0x00 = Two-Octet AS, 0x01 = IPv4, 0x02 =
+            // Four-Octet AS (RFC 5668). Each carries the same
+            // 6-octet value layout as the matching RD type, so map
+            // them across directly: `RouteDistinguisher`'s Eq/Ord
+            // include `typ`, and the configured RTs come from
+            // `RouteDistinguisher::from_str`, so a mismatched `typ`
+            // here would make a 4-byte-AS RT silently fail to
+            // intersect the identical configured RT. Future/unknown
+            // high_types keep the historical ASN default.
+            let typ = match v.high_type {
+                0x01 => RouteDistinguisherType::IP,
+                0x02 => RouteDistinguisherType::ASN4,
+                _ => RouteDistinguisherType::ASN,
             };
             let mut rd = bgp_packet::RouteDistinguisher::new(typ);
             rd.val = v.val;

--- a/zebra-rs/src/bgp/peer.rs
+++ b/zebra-rs/src/bgp/peer.rs
@@ -2178,6 +2178,21 @@ pub fn fsm_bgp_open(peer: &mut Peer, conn: ConnTag, packet: OpenPacket) -> State
 
 pub fn fsm_bgp_notification(peer: &mut Peer, conn: ConnTag, packet: NotificationPacket) -> State {
     peer.counter[BgpType::Notification as usize].rcvd += 1;
+    // A NOTIFICATION is the peer telling us why it is tearing the session down,
+    // and it was never surfaced anywhere: the only log here was the Bad Peer AS
+    // case below. Record it, including any RFC 9003 shutdown communication —
+    // an operator's "maintenance window, back at 03:00" is worth exactly as much
+    // as the numeric subcode next to it.
+    tracing::info!(
+        peer = %peer.display_name(),
+        "bgp: NOTIFICATION received: {} / {}{}",
+        packet.code,
+        bgp_packet::notify_sub_code_str(packet.code, packet.sub_code),
+        packet
+            .shutdown_communication()
+            .map(|m| format!(" — \"{m}\""))
+            .unwrap_or_default(),
+    );
     // `local-as … dual-as` (RFC 7705 migration aid): a Bad Peer AS
     // means the neighbor's `remote-as` expects the other one of our
     // two AS numbers — flip which one the next OPEN presents. FRR

--- a/zebra-rs/src/bgp/peer_egress.rs
+++ b/zebra-rs/src/bgp/peer_egress.rs
@@ -252,7 +252,7 @@ impl Engine {
         if self.adj_out.0.remove(&prefix).is_some() {
             let mut update = UpdatePacket::with_max_packet_size(self.ctx.max_packet_size());
             update.ipv4_withdraw.push(Ipv4Nlri { id, prefix });
-            self.ctx.send_packet(update.into());
+            self.ctx.send_update(update);
         }
     }
 }

--- a/zebra-rs/src/bgp/route.rs
+++ b/zebra-rs/src/bgp/route.rs
@@ -6816,17 +6816,41 @@ pub fn route_labelv6_withdraw(
     route_advertise_to_peers_labelv6(nlri.prefix, &selected, bgp, peers);
 }
 
+/// Record one RTC membership advertised by `peer_id`.
+///
+/// Only a fully specified 96-bit prefix names an exact Route Target, and only
+/// those go in the set. The RFC 4684 §3.2 default membership (prefix length 0)
+/// asks for *every* RT, and a partial prefix constrains a range that
+/// `rtc_match`'s exact-equality set cannot express. Adding nothing for either
+/// leaves `peer.rtcv4` empty, which every filter site reads as "this peer
+/// declared no RT constraint" and advertises everything — the behaviour the
+/// default membership asks for, and the safe direction for a partial one: RTC
+/// is an optimisation, so over-advertising only costs bandwidth while
+/// under-advertising blackholes VPN routes.
+///
+/// Known gap: a peer that mixes an exact RT with a default or partial
+/// membership is still filtered to just the exact one, because "wants
+/// everything" has no representation separate from "said nothing". No
+/// implementation sends that combination, and expressing it would need a
+/// distinct flag threaded through all seven filter sites.
 pub fn route_ipv4_rtc_update(peer_id: usize, rtcv4: &Rtcv4, peers: &mut PeerMap) {
     let Some(peer) = peers.get_mut_by_idx(peer_id) else {
         return;
     };
+    if !rtcv4.is_exact() {
+        return;
+    }
     peer.rtcv4.insert(rtcv4.rt.clone());
 }
 
+/// IPv6 counterpart of [`route_ipv4_rtc_update`]; same membership semantics.
 pub fn route_ipv6_rtc_update(peer_id: usize, rtcv6: &Rtcv6, peers: &mut PeerMap) {
     let Some(peer) = peers.get_mut_by_idx(peer_id) else {
         return;
     };
+    if !rtcv6.is_exact() {
+        return;
+    }
     peer.rtcv6.insert(rtcv6.rt.clone());
 }
 
@@ -13323,11 +13347,7 @@ fn send_rtcv4_membership(peer: &mut Peer, bgp: &BgpTop) {
             // mark it as a Route Target (RFC 4360 §4, sub-type 0x02).
             let mut val: ExtCommunityValue = rt.into();
             val.low_type = 0x02;
-            updates.push(Rtcv4 {
-                id: 0,
-                asn: peer.local_as,
-                rt: val,
-            });
+            updates.push(Rtcv4::new(peer.local_as, val));
         }
     }
 
@@ -13367,11 +13387,7 @@ fn send_rtcv6_membership(peer: &mut Peer, bgp: &BgpTop) {
         for rt in rts {
             let mut val: ExtCommunityValue = rt.into();
             val.low_type = 0x02;
-            updates.push(Rtcv6 {
-                id: 0,
-                asn: peer.local_as,
-                rt: val,
-            });
+            updates.push(Rtcv6::new(peer.local_as, val));
         }
     }
 

--- a/zebra-rs/src/bgp/route.rs
+++ b/zebra-rs/src/bgp/route.rs
@@ -215,6 +215,15 @@ impl SyncCtx {
         enqueue_update(&self.packet_tx, &self.egress_depth, self.ident, bytes);
     }
 
+    /// Serialise and enqueue one UPDATE, dropping it with a log if its length
+    /// fields cannot describe it. See [`Peer::send_update`].
+    pub fn send_update(&self, update: UpdatePacket) {
+        match update.try_emit() {
+            Ok(bytes) => self.send_packet(bytes),
+            Err(e) => tracing::warn!("dropping UPDATE to {}: {}", self.ident, e),
+        }
+    }
+
     /// Max on-wire UPDATE size for this session (RFC 8654 extended).
     pub fn max_packet_size(&self) -> usize {
         if self.extended_message {
@@ -5223,7 +5232,7 @@ pub fn route_update_evpn(
 fn route_withdraw_evpn(peer: &mut Peer, route: EvpnRoute) {
     let mut update = UpdatePacket::with_max_packet_size(peer.max_packet_size());
     update.mp_withdraw = Some(MpUnreachAttr::Evpn(vec![route]));
-    peer.send_packet(update.into());
+    peer.send_update(update);
 }
 
 /// Fan out a withdraw to every peer with `(L2vpn, Evpn)` Established.
@@ -5517,7 +5526,7 @@ pub(super) fn route_withdraw_ipv4(
         }
     }
 
-    peer.send_packet(update.into());
+    peer.send_update(update);
 }
 
 /// Send — or, while the peer's update-group has a flush job in
@@ -8350,7 +8359,7 @@ fn mup_send_one(peer: &mut Peer, afi: Afi, route: MupRoute, attr: &Arc<BgpAttr>,
         updates: vec![route],
     });
     update.bgp_attr = Some(attr.as_ref().clone());
-    peer.send_packet(update.into());
+    peer.send_update(update);
 }
 
 /// Build the Adj-RIB-Out entry recording one advertised MUP route. MUP
@@ -8449,7 +8458,7 @@ fn mup_withdraw_one(peer: &mut Peer, rd: RouteDistinguisher, prefix: &MupPrefix)
         afi: prefix.afi(),
         withdraws: vec![route],
     });
-    peer.send_packet(update.into());
+    peer.send_update(update);
 }
 
 /// Withdraw a MUP prefix from every Established `(afi, Mup)` peer. The
@@ -8626,7 +8635,7 @@ pub fn route_sync_mup(peer: &mut Peer, bgp: &mut BgpTop) {
                 afi,
                 withdraws: vec![],
             });
-            peer.send_packet(update.into());
+            peer.send_update(update);
         }
     }
 }
@@ -9473,7 +9482,7 @@ fn send_flowspec_one(peer: &mut Peer, afi: Afi, nlri: FlowspecNlri, attr: Arc<Bg
         updates: vec![nlri],
     });
     update.bgp_attr = Some((*attr).clone());
-    peer.send_packet(update.into());
+    peer.send_update(update);
 }
 
 /// Advertise a flow spec's best path to every Established peer that has
@@ -9534,7 +9543,7 @@ pub fn route_withdraw_flowspec_to_peers(afi: Afi, nlri: &FlowspecNlri, peers: &m
             afi,
             withdraws: vec![nlri.clone()],
         });
-        peer.send_packet(update.into());
+        peer.send_update(update);
     }
 }
 
@@ -11396,7 +11405,7 @@ pub fn route_update_ipv6(
 pub(super) fn route_withdraw_ipv6(peer: &mut Peer, prefix: Ipv6Net, id: u32) {
     let mut update = UpdatePacket::with_max_packet_size(peer.max_packet_size());
     update.mp_withdraw = Some(MpUnreachAttr::Ipv6Nlri(vec![Ipv6Nlri { id, prefix }]));
-    peer.send_packet(update.into());
+    peer.send_update(update);
 }
 
 /// v6 twin of [`withdraw_ipv4_deferrable`] — defer the per-peer
@@ -11540,7 +11549,7 @@ fn route_withdraw_vpnv6(peer: &mut Peer, rd: RouteDistinguisher, prefix: Ipv6Net
         nlri: Ipv6Nlri { id, prefix },
     };
     update.mp_withdraw = Some(MpUnreachAttr::Vpnv6(vec![vpnv6_nlri]));
-    peer.send_packet(update.into());
+    peer.send_update(update);
 }
 
 /// VPNv6 advertise — the v6 counterpart of the `rd.is_some()` branch
@@ -11995,13 +12004,13 @@ fn route_advertise_labeled<A: LabeledAfi>(
                 let mut update = UpdatePacket::with_max_packet_size(peer.max_packet_size());
                 update.bgp_attr = Some(attr);
                 update.mp_update = Some(A::reach(nhop, label, nlri));
-                peer.send_packet(update.into());
+                peer.send_update(update);
             }
             None => {
                 if A::adj_out_contains(peer, &prefix) {
                     let mut update = UpdatePacket::with_max_packet_size(peer.max_packet_size());
                     update.mp_withdraw = Some(A::unreach(prefix, 0));
-                    peer.send_packet(update.into());
+                    peer.send_update(update);
                     A::adj_out_remove(peer, prefix, 0);
                 }
             }
@@ -12046,7 +12055,7 @@ fn route_advertise_labeled<A: LabeledAfi>(
             let mut update = UpdatePacket::with_max_packet_size(peer.max_packet_size());
             update.bgp_attr = Some(decision.attr);
             update.mp_update = Some(A::reach(nhop, label, nlri));
-            peer.send_packet(update.into());
+            peer.send_update(update);
             A::adj_out_add(peer, prefix, cand.clone());
             newly.insert(cand.local_id);
         }
@@ -12056,7 +12065,7 @@ fn route_advertise_labeled<A: LabeledAfi>(
             }
             let mut update = UpdatePacket::with_max_packet_size(peer.max_packet_size());
             update.mp_withdraw = Some(A::unreach(prefix, id));
-            peer.send_packet(update.into());
+            peer.send_update(update);
             A::adj_out_remove(peer, prefix, id);
         }
     }
@@ -12110,6 +12119,20 @@ fn enqueue_update(
 impl Peer {
     pub fn send_packet(&self, bytes: BytesMut) {
         enqueue_update(&self.packet_tx, &self.egress_depth, self.address, bytes);
+    }
+
+    /// Serialise and enqueue one UPDATE.
+    ///
+    /// An UPDATE whose length fields cannot describe it has no valid encoding,
+    /// so it is dropped and logged rather than put on the wire: emitting it
+    /// would wrap the header Length and desynchronise the peer's framing for
+    /// every message after it. Reaching this is a local batching bug — callers
+    /// must chunk to `max_packet_size` — so the log is the useful part.
+    pub fn send_update(&self, update: UpdatePacket) {
+        match update.try_emit() {
+            Ok(bytes) => self.send_packet(bytes),
+            Err(e) => tracing::warn!("dropping UPDATE to {}: {}", self.address, e),
+        }
     }
 
     pub fn send_vpnv4(&mut self, nlri: Vpnv4Nlri, attr: Arc<BgpAttr>, timer: bool) {
@@ -13302,13 +13325,13 @@ pub fn route_sync_vpnv6(peer: &mut Peer, bgp: &mut BgpTop) {
 fn send_eor_vpnv6_vpn(peer: &mut Peer) {
     let mut update = UpdatePacket::with_max_packet_size(peer.max_packet_size());
     update.mp_withdraw = Some(MpUnreachAttr::Vpnv6Eor);
-    peer.send_packet(update.into());
+    peer.send_update(update);
 }
 
 // Send End-of-RIB marker for IPv4 Unicast.
 pub(super) fn send_eor_ipv4_unicast(peer: &mut Peer) {
     let update = UpdatePacket::with_max_packet_size(peer.max_packet_size());
-    peer.send_packet(update.into());
+    peer.send_update(update);
 }
 
 // Send End-of-RIB marker for IPv6 Unicast: an empty MP_UNREACH(AFI=2,
@@ -13316,14 +13339,14 @@ pub(super) fn send_eor_ipv4_unicast(peer: &mut Peer) {
 fn send_eor_ipv6_unicast(peer: &mut Peer) {
     let mut update = UpdatePacket::with_max_packet_size(peer.max_packet_size());
     update.mp_withdraw = Some(MpUnreachAttr::Ipv6Eor);
-    peer.send_packet(update.into());
+    peer.send_update(update);
 }
 
 // Send End-of-RIB marker for VPNv4 Unicast.
 fn send_eor_vpnv4_unicast(peer: &mut Peer) {
     let mut update = UpdatePacket::with_max_packet_size(peer.max_packet_size());
     update.mp_withdraw = Some(MpUnreachAttr::Vpnv4Eor);
-    peer.send_packet(update.into());
+    peer.send_update(update);
 }
 
 // Advertise our Route Target Constraint membership (RFC 4684): one
@@ -13362,14 +13385,14 @@ fn send_rtcv4_membership(peer: &mut Peer, bgp: &BgpTop) {
         nhop: IpAddr::V4(Ipv4Addr::UNSPECIFIED),
         updates,
     }));
-    peer.send_packet(update.into());
+    peer.send_update(update);
 }
 
 // Send End-of-RIB marker for RTCv4.
 fn send_eor_rtcv4_unicast(peer: &mut Peer) {
     let mut update = UpdatePacket::with_max_packet_size(peer.max_packet_size());
     update.mp_withdraw = Some(MpUnreachAttr::Rtcv4Eor);
-    peer.send_packet(update.into());
+    peer.send_update(update);
 }
 
 // IPv6 counterpart of `send_rtcv4_membership`: advertise our Route
@@ -13402,14 +13425,14 @@ fn send_rtcv6_membership(peer: &mut Peer, bgp: &BgpTop) {
         nhop: IpAddr::V6(std::net::Ipv6Addr::UNSPECIFIED),
         updates,
     }));
-    peer.send_packet(update.into());
+    peer.send_update(update);
 }
 
 // Send End-of-RIB marker for RTCv6.
 fn send_eor_rtcv6_unicast(peer: &mut Peer) {
     let mut update = UpdatePacket::with_max_packet_size(peer.max_packet_size());
     update.mp_withdraw = Some(MpUnreachAttr::Rtcv6Eor);
-    peer.send_packet(update.into());
+    peer.send_update(update);
 }
 
 // Send End-of-RIB marker for L2VPN/EVPN. RFC 4724 §2 represents EoR
@@ -13418,7 +13441,7 @@ fn send_eor_rtcv6_unicast(peer: &mut Peer) {
 fn send_eor_evpn(peer: &mut Peer) {
     let mut update = UpdatePacket::with_max_packet_size(peer.max_packet_size());
     update.mp_withdraw = Some(MpUnreachAttr::EvpnEor);
-    peer.send_packet(update.into());
+    peer.send_update(update);
 }
 
 /// Replay every selected EVPN route from the local-RIB to a peer
@@ -13532,7 +13555,7 @@ pub fn route_sync_labelv4(peer: &mut Peer, bgp: &mut BgpTop) {
             nhop,
             updates: vec![Labelv4Nlri { label, nlri }],
         });
-        peer.send_packet(update.into());
+        peer.send_update(update);
         // Register the dump in the per-peer LU Adj-RIB-Out so a later
         // withdraw reaches a peer that learned the prefix only via this
         // session-up dump (the event-driven LU withdraw gates on
@@ -13580,7 +13603,7 @@ pub fn route_sync_labelv6(peer: &mut Peer, bgp: &mut BgpTop) {
             nhop,
             updates: vec![Labelv6Nlri { label, nlri }],
         });
-        peer.send_packet(update.into());
+        peer.send_update(update);
         // See route_sync_labelv4: register so a later withdraw reaches a
         // peer that learned the prefix only via this session-up dump.
         peer.adj_out.v6lu.add(prefix, best);

--- a/zebra-rs/src/bgp/show.rs
+++ b/zebra-rs/src/bgp/show.rs
@@ -4991,10 +4991,10 @@ fn show_sr_binding_sid(cp: &super::sr_policy::CandidatePath) -> Option<String> {
     if let Some(s) = &cp.srv6_binding_sid {
         return Some(format!("SRv6 {}", s.sid));
     }
-    match &cp.binding_sid {
-        Some(BindingSid::MplsLabel(l)) => Some(format!("MPLS {l}")),
-        Some(BindingSid::Srv6(s)) => Some(format!("SRv6 {s}")),
-        Some(BindingSid::None) | None => None,
+    match cp.binding_sid.as_ref().map(|b| &b.value) {
+        Some(BindingSidValue::MplsLabel(l)) => Some(format!("MPLS {l}")),
+        Some(BindingSidValue::Srv6(s)) => Some(format!("SRv6 {s}")),
+        Some(BindingSidValue::None) | None => None,
     }
 }
 

--- a/zebra-rs/src/bgp/sr_policy.rs
+++ b/zebra-rs/src/bgp/sr_policy.rs
@@ -20,9 +20,9 @@ use std::collections::BTreeMap;
 use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
 
 use bgp_packet::{
-    BgpAttr, BindingSid, ClusterList, Community, CommunityValue, ExtCommunity, ExtCommunitySubType,
-    ExtCommunityValue, Origin, OriginatorId, Segment, SegmentList, SrPolicyNlri, SrPolicyTlvs,
-    Srv6BindingSid, TunnelEncap,
+    BgpAttr, BindingSid, BindingSidValue, ClusterList, Community, CommunityValue, ExtCommunity,
+    ExtCommunitySubType, ExtCommunityValue, Origin, OriginatorId, Segment, SegmentList,
+    SrPolicyNlri, SrPolicyTlvs, Srv6BindingSid, TunnelEncap,
 };
 
 use crate::config::{Args, ConfigOp};
@@ -198,8 +198,8 @@ fn mpls_segments(cp: &CandidatePath) -> Option<Vec<u32>> {
 /// `None` if it isn't an installable SR-MPLS policy (not valid, no MPLS
 /// Binding SID, or its first segment list isn't an all-Type-A list).
 fn mpls_bsid(cp: &CandidatePath) -> Option<MplsBsid> {
-    let bsid = match &cp.binding_sid {
-        Some(BindingSid::MplsLabel(label)) => *label,
+    let bsid = match cp.binding_sid.as_ref().map(|b| &b.value) {
+        Some(BindingSidValue::MplsLabel(label)) => *label,
         _ => return None,
     };
     let segments = mpls_segments(cp)?;
@@ -228,14 +228,12 @@ fn srv6_bsid(cp: &CandidatePath) -> Option<Srv6Bsid> {
     if !cp.valid {
         return None;
     }
-    let bsid = cp
-        .srv6_binding_sid
-        .as_ref()
-        .map(|s| s.sid)
-        .or(match &cp.binding_sid {
-            Some(BindingSid::Srv6(addr)) => Some(*addr),
+    let bsid = cp.srv6_binding_sid.as_ref().map(|s| s.sid).or(
+        match cp.binding_sid.as_ref().map(|b| &b.value) {
+            Some(BindingSidValue::Srv6(addr)) => Some(*addr),
             _ => None,
-        })?;
+        },
+    )?;
     let first = cp.segment_lists.first()?;
     let segments: Vec<Ipv6Addr> = first
         .segments
@@ -686,7 +684,9 @@ impl LocalSrPolicy {
 
         let tlvs = SrPolicyTlvs {
             preference: Some(self.preference.unwrap_or(DEFAULT_PREFERENCE)),
-            binding_sid: self.binding_sid_label.map(BindingSid::MplsLabel),
+            binding_sid: self
+                .binding_sid_label
+                .map(|l| BindingSid::new(BindingSidValue::MplsLabel(l))),
             srv6_binding_sid: self.binding_sid_sid.map(|sid| Srv6BindingSid {
                 flags: 0,
                 sid,
@@ -1220,7 +1220,7 @@ mod tests {
     fn mpls_cp(disc: u32, pref: u32, peer: usize, bsid: u32, label: u32) -> CandidatePath {
         let mut c = cp(20, "10.0.0.1", disc, pref, true);
         c.peer = peer;
-        c.binding_sid = Some(BindingSid::MplsLabel(bsid));
+        c.binding_sid = Some(BindingSid::new(BindingSidValue::MplsLabel(bsid)));
         c.segment_lists = vec![SegmentList {
             weight: None,
             segments: vec![Segment::TypeA { flags: 0, label }],
@@ -1453,7 +1453,10 @@ mod tests {
             .expect("type 15")
             .expect("decode");
         assert_eq!(tlvs.preference, Some(200));
-        assert_eq!(tlvs.binding_sid, Some(BindingSid::MplsLabel(16100)));
+        assert_eq!(
+            tlvs.binding_sid,
+            Some(BindingSid::new(BindingSidValue::MplsLabel(16100)))
+        );
         assert_eq!(tlvs.segment_lists.len(), 1);
         assert_eq!(
             tlvs.segment_lists[0].segments,

--- a/zebra-rs/src/bgp/update_group.rs
+++ b/zebra-rs/src/bgp/update_group.rs
@@ -1307,7 +1307,14 @@ fn encode_ipv6_update(
             nhop,
             updates: nlri_chunk.to_vec(),
         });
-        out.push(update.into());
+        // The chunking above keeps each PDU inside the budget, so a length
+        // overflow here would mean the reserve no longer covers the attributes.
+        // Drop that chunk rather than emit a frame whose header contradicts its
+        // body.
+        match update.try_emit() {
+            Ok(bytes) => out.push(bytes),
+            Err(e) => tracing::warn!("dropping IPv6 UPDATE chunk: {}", e),
+        }
     }
     out
 }


### PR DESCRIPTION
Fixes every finding from an xhigh-recall review of `crates/bgp-packet/`, one
commit per finding, each reproduced before the fix and pinned by a regression
test afterwards. Findings are recorded in `crates/bgp-packet/CODE_REVIEW_FINDINGS.md`.

The parsers turned out to be well hardened against panics and over-reads — the
`SECURITY_AUDIT.md` claims hold. Every finding here is functional/interop
correctness instead.

## The three that mattered most

* **An unrecognized capability tore down the session.** `CapUnknown` re-parsed a
  2-byte header that `parse_cap` had already stripped, so any capability with a
  0/1-octet body — e.g. the RFC 9234 Role capability (code 9, len 1), now common
  on Cisco/Juniper/FRR — failed OPEN parsing and the session never established.
* **An IPv6 extended community tore down the session.** `AttrType` named
  `ExtendedIpv6Com = 25` with no matching `Attr` variant, so it skipped the
  RFC 4271 §9 unknown-attribute path and propagated a Switch failure out as a
  reset. An attribute we half-recognized was strictly worse than one we did not
  recognize at all.
* **A malformed NLRI silently truncated its block.** All 25 MP_REACH/MP_UNREACH
  sites read their list with a bare `many0_complete` and discarded the leftover,
  so a bad NLRI dropped itself *and every route after it* with no error raised —
  the one outcome RFC 7606 never permits.

## Also fixed

Type-2 (4-octet-AS) RDs failing to parse; AS_SEQ segment counts wrapping at 256;
the RFC 4684 RTC default membership our own emitter produced but our parser
rejected; flow-spec op-lists and component ordering; EVPN address lengths checked
after rounding to octets; SR Policy Binding SID S/I flags dropped on re-emit;
NOTIFICATION Data discarded (now decoded per RFC 9003 and logged); COMMUNITIES /
LARGE_COMMUNITY widths; and UPDATE length fields wrapping `as u16`
(`From<UpdatePacket>` → `TryFrom`, since an over-long UPDATE has no valid
encoding).

## Notes for the reviewer

* **Two verdicts were corrected, not fixed as claimed.** Findings 5 (non-AS4
  AS_PATH) and 6 (IPv6 ext-community endianness) are real code defects but are
  **not reachable** — `as4` is hardcoded `true`, and the `ext_ipv6_com` module is
  unwired. Both were fixed anyway as trap removal, and the doc says so.
* **Detection and action were decided separately, per RFC, and they differ.** A
  malformed NLRI block resets the session (RFC 7606 §3(j): the affected routes
  cannot be determined), while a malformed COMMUNITIES is treat-as-withdraw
  (RFC 7606 §7.8 / RFC 8092 §3). A blanket "be strict" rule would have gotten one
  of them wrong — and for the communities, detection alone would have been a
  regression.
* **A recurring shape:** the correct pattern usually already existed beside the
  wrong one — EVPN Type-3 vs Type-2, SRv6 Binding SID vs Binding SID,
  `ClusterList` vs `Community`.

## Deferred, deliberately (recorded in the doc)

* Driving `as4` from capability negotiation — needs AS4_PATH (17) and
  AS4_AGGREGATOR (18); a feature, not a fix.
* Enforcing `max_packet_size` on emit — would newly reject 4096–65535 octet
  UPDATEs that ship today; a behaviour change worth its own decision.
* The attribute-level `as u16` casts in the MP/BGP-LS emit helpers — needs a
  fallible `AttrEmitter`.

## Test plan

* `cargo test --workspace --exclude bdd` — green (37 test binaries); bgp-packet
  459 tests, up from 410.
* `cargo clippy --workspace --exclude bdd` — clean.
* `cargo fmt --all --check` — clean.
* **Not run: BDD / any live peer.** Every fix is verified at unit level only.
  The session-establishment and NLRI-truncation fixes in particular deserve a
  BDD run before release.

Generated with [Claude Code](https://claude.com/claude-code)