### PR TITLE
bgp-packet: model the Graceful Restart capability per RFC 4724

### DIFF
--- a/crates/bgp-packet/src/bgp_cap.rs
+++ b/crates/bgp-packet/src/bgp_cap.rs
@@ -7,7 +7,6 @@ use crate::{
     AddPathValue, AfiSafi, CapAddPath, CapAs4, CapDynamic, CapEmit, CapEnhancedRefresh,
     CapExtended, CapExtendedNextHop, CapFqdn, CapLlgr, CapMultiProtocol, CapPathLimit, CapRefresh,
     CapRefreshCisco, CapRestart, CapVersion, CapabilityPacket, LlgrValue, PathLimitValue,
-    RestartValue,
 };
 
 #[derive(Default, Debug, PartialEq, Clone)]
@@ -18,7 +17,7 @@ pub struct BgpCap {
     pub enhanced_refresh: Option<CapEnhancedRefresh>,
     pub extended: Option<CapExtended>,
     pub extended_nexthop: Option<CapExtendedNextHop>,
-    pub restart: BTreeMap<AfiSafi, RestartValue>,
+    pub restart: Option<CapRestart>,
     pub as4: Option<CapAs4>,
     pub dynamic: Option<CapDynamic>,
     pub addpath: BTreeMap<AfiSafi, AddPathValue>,
@@ -48,11 +47,7 @@ impl BgpCap {
         if let Some(v) = &self.extended_nexthop {
             v.emit(buf, false);
         }
-        if !self.restart.is_empty() {
-            let mut v = CapRestart::default();
-            for val in self.restart.values() {
-                v.values.push(val.clone());
-            }
+        if let Some(v) = &self.restart {
             v.emit(buf, false);
         }
         if let Some(v) = &self.as4 {
@@ -112,10 +107,7 @@ impl BgpCap {
                         bgp_cap.extended_nexthop = Some(v);
                     }
                     CapabilityPacket::GracefulRestart(v) => {
-                        for restart in v.values.into_iter() {
-                            let key = AfiSafi::new(restart.afi, restart.safi);
-                            bgp_cap.restart.insert(key, restart);
-                        }
+                        bgp_cap.restart = Some(v);
                     }
                     CapabilityPacket::DynamicCapability(v) => {
                         bgp_cap.dynamic = Some(v);
@@ -183,11 +175,7 @@ impl fmt::Display for BgpCap {
         if let Some(v) = &self.extended {
             writeln!(f, " {}", v)?;
         }
-        if !self.restart.is_empty() {
-            let mut v = CapRestart::default();
-            for val in self.restart.values() {
-                v.values.push(val.clone());
-            }
+        if let Some(v) = &self.restart {
             writeln!(f, " {}", v)?;
         }
         if let Some(v) = &self.as4 {

--- a/crates/bgp-packet/src/caps/graceful.rs
+++ b/crates/bgp-packet/src/caps/graceful.rs
@@ -23,21 +23,21 @@ pub struct RestartFlagTime {
 pub struct RestartFlags {
     #[bits(7)]
     pub resvd: u8,
-    pub p_flag: bool,
+    pub f_flag: bool,
 }
 
+/// One per-AFI/SAFI tuple of the Graceful Restart capability: AFI (2) +
+/// SAFI (1) + per-AF Flags (1) — 4 octets on the wire (RFC 4724 §3).
 #[derive(Debug, PartialEq, Clone, NomBE)]
-pub struct RestartValue {
-    pub flag_time: RestartFlagTime,
+pub struct RestartEntry {
     pub afi: Afi,
     pub safi: Safi,
     pub flags: RestartFlags,
 }
 
-impl RestartValue {
-    pub fn new(restart_time: u16, afi: Afi, safi: Safi) -> Self {
+impl RestartEntry {
+    pub fn new(afi: Afi, safi: Safi) -> Self {
         Self {
-            flag_time: RestartFlagTime::new().with_restart_time(restart_time),
             afi,
             safi,
             flags: RestartFlags::default(),
@@ -45,27 +45,52 @@ impl RestartValue {
     }
 }
 
+/// RFC 4724 §3 Graceful Restart capability: one 2-octet Restart Flags +
+/// Restart Time field followed by zero or more 4-octet [`RestartEntry`]
+/// tuples, so a valid value length is `2 + 4n`. The flags/time field is
+/// not repeated per tuple, and `n = 0` (length 2) is the common
+/// helper-only form.
 #[derive(Debug, Default, PartialEq, NomBE, Clone)]
 pub struct CapRestart {
-    pub values: Vec<RestartValue>,
+    pub flag_time: RestartFlagTime,
+    pub entries: Vec<RestartEntry>,
 }
 
 impl CapRestart {
-    /// Each Graceful-Restart entry is 6 octets on the wire (Restart Flags +
-    /// Time u16 + AFI u16 + SAFI u8 + per-AF Flags u8). A capability value is at
-    /// most 253 octets — the BGP optional-parameter that carries it has a single
-    /// length octet covering `code(1) + length(1) + value` (`emit.rs` writes
-    /// `put_u8(len() + 2)`), so `value <= 255 - 2` — which fits at most 42
-    /// entries (252 octets).
-    const ENTRY_LEN: usize = 6;
-    const MAX_ENTRIES: usize = 253 / Self::ENTRY_LEN; // 42
+    /// Restart Flags + Restart Time header, always present on the wire.
+    const HEADER_LEN: usize = 2;
+    /// Each AFI/SAFI tuple is 4 octets. A capability value is at most 253
+    /// octets — the BGP optional parameter that carries it has a single
+    /// length octet covering `code(1) + length(1) + value` (`emit.rs`
+    /// writes `put_u8(len() + 2)`), so `value <= 255 - 2` — which fits at
+    /// most 62 tuples (2 + 248 = 250 octets).
+    const ENTRY_LEN: usize = 4;
+    const MAX_ENTRIES: usize = (253 - Self::HEADER_LEN) / Self::ENTRY_LEN; // 62
+
+    /// Restart Time is a 12-bit field; clamp instead of letting the
+    /// bitfield setter truncate or panic on out-of-range input.
+    const MAX_RESTART_TIME: u16 = 0xfff;
+
+    pub fn new(restart_time: u16) -> Self {
+        Self {
+            flag_time: RestartFlagTime::new()
+                .with_restart_time(restart_time.min(Self::MAX_RESTART_TIME)),
+            entries: Vec::new(),
+        }
+    }
+
+    pub fn set_restart_time(&mut self, restart_time: u16) {
+        self.flag_time
+            .set_restart_time(restart_time.min(Self::MAX_RESTART_TIME));
+    }
 
     /// Number of entries actually written on the wire. `len()` and
     /// `emit_value()` both derive from this so the declared length always
-    /// matches the bytes emitted and the `as u8` cast cannot truncate; entries
-    /// beyond the budget are dropped rather than wrapping the length octet.
+    /// matches the bytes emitted and the `as u8` cast cannot truncate;
+    /// entries beyond the budget are dropped rather than wrapping the
+    /// length octet.
     fn wire_count(&self) -> usize {
-        self.values.len().min(Self::MAX_ENTRIES)
+        self.entries.len().min(Self::MAX_ENTRIES)
     }
 }
 
@@ -75,14 +100,14 @@ impl CapEmit for CapRestart {
     }
 
     fn len(&self) -> u8 {
-        // wire_count() <= 42, so wire_count() * 6 <= 252 fits a u8 and
+        // wire_count() <= 62, so 2 + wire_count() * 4 <= 250 fits a u8 and
         // `len() + 2` stays within a u8 for the optional-parameter framing.
-        (self.wire_count() * Self::ENTRY_LEN) as u8
+        (Self::HEADER_LEN + self.wire_count() * Self::ENTRY_LEN) as u8
     }
 
     fn emit_value(&self, buf: &mut BytesMut) {
-        for val in self.values.iter().take(self.wire_count()) {
-            buf.put_u16(val.flag_time.into());
+        buf.put_u16(self.flag_time.into());
+        for val in self.entries.iter().take(self.wire_count()) {
             buf.put_u16(val.afi.into());
             buf.put_u8(val.safi.into());
             buf.put_u8(val.flags.into());
@@ -92,21 +117,21 @@ impl CapEmit for CapRestart {
 
 impl fmt::Display for CapRestart {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let _ = write!(f, "GracefulRestart: ");
-        for (i, value) in self.values.iter().enumerate() {
-            if i > 0 {
-                let _ = write!(f, ", ");
-            }
-            let _ = write!(
+        write!(
+            f,
+            "GracefulRestart: restart time:{} R:{} N:{}",
+            self.flag_time.restart_time(),
+            self.flag_time.r_flag(),
+            self.flag_time.n_flag(),
+        )?;
+        for entry in self.entries.iter() {
+            write!(
                 f,
-                "{}/{} restart time:{} R:{} N:{} P:{}",
-                value.afi,
-                value.safi,
-                value.flag_time.restart_time(),
-                value.flag_time.r_flag(),
-                value.flag_time.n_flag(),
-                value.flags.p_flag(),
-            );
+                ", {}/{} F:{}",
+                entry.afi,
+                entry.safi,
+                entry.flags.f_flag()
+            )?;
         }
         Ok(())
     }
@@ -115,11 +140,13 @@ impl fmt::Display for CapRestart {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::CapabilityPacket;
 
     fn cap_with_entries(n: usize) -> CapRestart {
         CapRestart {
-            values: (0..n)
-                .map(|_| RestartValue::new(120, Afi::Ip, Safi::Unicast))
+            flag_time: RestartFlagTime::new().with_restart_time(120),
+            entries: (0..n)
+                .map(|_| RestartEntry::new(Afi::Ip, Safi::Unicast))
                 .collect(),
         }
     }
@@ -150,27 +177,79 @@ mod tests {
     fn normal_round_trip() {
         let cap = cap_with_entries(2);
         let (len, parsed) = emit_and_parse(&cap);
-        assert_eq!(len, 12, "2 entries * 6");
-        assert_eq!(parsed.values.len(), 2);
+        assert_eq!(len, 10, "2 octets flags/time + 2 entries * 4");
+        assert_eq!(parsed.entries.len(), 2);
         assert_eq!(parsed, cap);
     }
 
     #[test]
-    fn empty_round_trips() {
-        let cap = CapRestart::default();
+    fn helper_only_round_trips() {
+        // No AFI/SAFI tuples — the helper-only form is just the 2-octet
+        // flags/time header, the most common shape on the wire.
+        let cap = CapRestart::new(120);
         let (len, parsed) = emit_and_parse(&cap);
-        assert_eq!(len, 0);
+        assert_eq!(len, 2);
         assert_eq!(parsed, cap);
+    }
+
+    #[test]
+    fn parses_helper_only_wire_form() {
+        // 0x4078: N-bit set, restart time 120, zero tuples (e.g. FRR in
+        // helper mode).
+        let buf = [0x40, 0x78];
+        let (rest, parsed) = CapRestart::parse_be(&buf).expect("length-2 value must parse");
+        assert!(rest.is_empty());
+        assert_eq!(parsed.flag_time.restart_time(), 120);
+        assert!(parsed.flag_time.n_flag());
+        assert!(!parsed.flag_time.r_flag());
+        assert!(parsed.entries.is_empty());
+    }
+
+    #[test]
+    fn parses_multi_afi_wire_form() {
+        // R-bit set, time 120, IPv4/Unicast with F-bit + IPv6/Unicast
+        // without — length 10 = 2 + 2 * 4.
+        let buf = [
+            0x80, 0x78, // flags/time
+            0x00, 0x01, 0x01, 0x80, // IPv4 / Unicast, F=1
+            0x00, 0x02, 0x01, 0x00, // IPv6 / Unicast, F=0
+        ];
+        let (rest, parsed) = CapRestart::parse_be(&buf).expect("length-10 value must parse");
+        assert!(rest.is_empty());
+        assert!(parsed.flag_time.r_flag());
+        assert_eq!(parsed.flag_time.restart_time(), 120);
+        assert_eq!(parsed.entries.len(), 2);
+        assert_eq!(parsed.entries[0].afi, Afi::Ip);
+        assert!(parsed.entries[0].flags.f_flag());
+        assert_eq!(parsed.entries[1].afi, Afi::Ip6);
+        assert!(!parsed.entries[1].flags.f_flag());
+    }
+
+    #[test]
+    fn rejects_length_not_2_plus_4n() {
+        // Capability code 64, declared length 4: flags/time plus a 2-octet
+        // stub that is not a whole 4-octet tuple. `parse_cap` must reject
+        // the trailing bytes instead of silently dropping them.
+        let buf = [0x40, 0x04, 0x40, 0x78, 0x00, 0x01];
+        assert!(CapabilityPacket::parse_cap(&buf).is_err());
+    }
+
+    #[test]
+    fn restart_time_clamped_to_12_bits() {
+        let mut cap = CapRestart::new(u16::MAX);
+        assert_eq!(cap.flag_time.restart_time(), 0xfff);
+        cap.set_restart_time(u16::MAX);
+        assert_eq!(cap.flag_time.restart_time(), 0xfff);
     }
 
     #[test]
     fn too_many_entries_clamped_to_budget() {
-        // 50 entries * 6 = 300 octets would wrap the length octet; clamp to 42
-        // entries (252 octets).
-        let cap = cap_with_entries(50);
+        // 70 tuples * 4 + 2 = 282 octets would wrap the length octet; clamp
+        // to 62 tuples (250 octets).
+        let cap = cap_with_entries(70);
         let (len, parsed) = emit_and_parse(&cap);
-        assert_eq!(len, 252, "42 entries * 6");
-        assert_eq!(parsed.values.len(), 42);
-        assert_eq!(len + 2, 254, "optional-parameter length stays within a u8");
+        assert_eq!(len, 250, "2 + 62 entries * 4");
+        assert_eq!(parsed.entries.len(), 62);
+        assert_eq!(len + 2, 252, "optional-parameter length stays within a u8");
     }
 }

--- a/crates/bgp-packet/src/caps/mod.rs
+++ b/crates/bgp-packet/src/caps/mod.rs
@@ -17,7 +17,7 @@ pub mod extended_nexthop;
 pub use extended_nexthop::{CapExtendedNextHop, ExtendedNextHopValue};
 
 pub mod graceful;
-pub use graceful::{CapRestart, RestartValue};
+pub use graceful::{CapRestart, RestartEntry, RestartFlagTime, RestartFlags};
 
 pub mod as4;
 pub use as4::CapAs4;

--- a/crates/bgp-packet/tests/parser.rs
+++ b/crates/bgp-packet/tests/parser.rs
@@ -33,6 +33,47 @@ fn test2(buf: &[u8]) {
 }
 
 #[test]
+pub fn parse_open() {
+    // OPEN from a peer with a helper-only Graceful Restart capability
+    // (code 64, length 2: flags/time only, no AFI/SAFI tuples) followed
+    // by an LLGR capability — the RFC 4724 `2 + 4n` shape that a
+    // per-entry-flag-time model cannot parse.
+    const PACKET: &[u8] = &hex!(
+        "
+ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff
+00 7b 01 04 ff dd 00 b4 0a 00 00 02 5e 02 06 01
+04 00 01 00 01 02 06 01 04 00 02 00 01 02 02 02
+00 02 02 46 00 02 06 41 04 00 00 ff dd 02 02 06
+00 02 0a 45 08 00 01 01 01 00 02 01 01 02 0c 4c
+0a 00 01 01 00 00 00 02 01 00 00 02 06 49 04 02
+6e 31 00 02 04 40 02 40 78 02 10 47 0e 00 01 01
+80 00 00 00 00 02 01 80 00 00 00
+"
+    );
+    let packet = BgpPacket::parse_packet(PACKET, true, None);
+    assert!(packet.is_ok());
+
+    let (_, packet) = packet.unwrap();
+    let BgpPacket::Open(open) = packet else {
+        panic!("Packet must be Open");
+    };
+    assert_eq!(open.asn, 65501);
+    assert_eq!(open.hold_time, 180);
+
+    let restart = open
+        .bgp_cap
+        .restart
+        .as_ref()
+        .expect("Graceful Restart capability must be present");
+    assert_eq!(restart.flag_time.restart_time(), 120);
+    assert!(restart.flag_time.n_flag());
+    assert!(!restart.flag_time.r_flag());
+    assert!(restart.entries.is_empty(), "helper-only form has no tuples");
+
+    assert_eq!(open.bgp_cap.llgr.len(), 2, "LLGR for two families");
+}
+
+#[test]
 pub fn parse_evpn_test_1() {
     const PACKET: &[u8] = &hex!(
         "

--- a/zebra-rs/src/bgp/peer.rs
+++ b/zebra-rs/src/bgp/peer.rs
@@ -532,7 +532,6 @@ pub struct PeerConfig {
     /// [`super::neighbor_group::resolve_knob`] whenever either side
     /// changes.
     pub knobs_explicit: super::neighbor_group::InheritableKnobs,
-    pub restart: AfiSafis<RestartValue>,
     pub llgr: AfiSafis<LlgrValue>,
     pub addpath: AfiSafis<AddPathValue>,
     pub route_refresh: bool,
@@ -619,7 +618,6 @@ impl Default for PeerConfig {
             mp_explicit: BTreeMap::new(),
             nhs_explicit: BTreeMap::new(),
             knobs_explicit: Default::default(),
-            restart: AfiSafis::new(),
             llgr: AfiSafis::new(),
             addpath: AfiSafis::new(),
             route_refresh: Default::default(),
@@ -2918,9 +2916,17 @@ fn build_open_packet(peer: &mut Peer) -> BytesMut {
         bgp_cap.addpath.insert(*key, value);
     }
     for (key, sub) in peer.config.sub.iter() {
-        if let Some(_restart_time) = sub.graceful_restart {
-            let restart = RestartValue::new(1, key.afi, key.safi);
-            bgp_cap.restart.insert(*key, restart);
+        if let Some(restart_time) = sub.graceful_restart {
+            // RFC 4724 carries a single Restart Time for the whole
+            // capability; advertise the largest configured per-family
+            // value (the config callback stores an enabled marker of 1
+            // today), clamped to the 12-bit field.
+            let time = restart_time.min(0xfff) as u16;
+            let cap = bgp_cap.restart.get_or_insert_with(CapRestart::default);
+            if time > cap.flag_time.restart_time() {
+                cap.set_restart_time(time);
+            }
+            cap.entries.push(RestartEntry::new(key.afi, key.safi));
         }
         if let Some(llgr_time) = sub.llgr {
             let llgr = LlgrValue::new(key.afi, key.safi, llgr_time);

--- a/zebra-rs/src/bgp/show.rs
+++ b/zebra-rs/src/bgp/show.rs
@@ -3497,16 +3497,17 @@ fn render(out: &mut String, neighbor: &Neighbor) -> std::fmt::Result {
             }
         }
 
-        if !neighbor.cap_send.restart.is_empty() || !neighbor.cap_recv.restart.is_empty() {
+        let send_restart = neighbor.cap_send.restart.as_ref();
+        let recv_restart = neighbor.cap_recv.restart.as_ref();
+        if send_restart.is_some() || recv_restart.is_some() {
             writeln!(out, "    Graceful Restart:")?;
 
             // Collect all AFI/SAFI pairs from both send and recv
             let mut all_afi_safis = std::collections::BTreeSet::new();
-            for key in neighbor.cap_send.restart.keys() {
-                all_afi_safis.insert(key);
-            }
-            for key in neighbor.cap_recv.restart.keys() {
-                all_afi_safis.insert(key);
+            for cap in send_restart.iter().chain(recv_restart.iter()) {
+                for entry in cap.entries.iter() {
+                    all_afi_safis.insert(AfiSafi::new(entry.afi, entry.safi));
+                }
             }
 
             // Display each AFI/SAFI pair
@@ -3522,8 +3523,15 @@ fn render(out: &mut String, neighbor: &Neighbor) -> std::fmt::Result {
                     _ => continue, // Skip unknown combinations
                 };
 
-                let send_val = neighbor.cap_send.restart.get(afi_safi);
-                let recv_val = neighbor.cap_recv.restart.get(afi_safi);
+                // The restart time is capability-level (RFC 4724), so each
+                // side's value applies to every family it listed.
+                let lists_family = |cap: &&CapRestart| {
+                    cap.entries
+                        .iter()
+                        .any(|e| e.afi == afi_safi.afi && e.safi == afi_safi.safi)
+                };
+                let send_val = send_restart.filter(lists_family);
+                let recv_val = recv_restart.filter(lists_family);
 
                 write!(out, "      {}: ", afi_safi_str)?;
 


### PR DESCRIPTION
## Summary

`CapRestart` modeled the Graceful Restart capability as 6-octet entries that each repeated the Restart Flags + Restart Time field. RFC 4724 §3 defines the value as **one** 2-octet flags/time header followed by zero or more 4-octet (AFI, SAFI, Flags) tuples, so valid lengths are `2 + 4n`. The two layouts coincide only at exactly one tuple — which is why single-family interop never noticed.

Consequences fixed here:

- **Receive:** a peer sending the common helper-only form (length 2, e.g. FRR/Cisco with GR helper mode) or GR for ≥2 families (length 10, 14, …) failed capability parse, and since that aborts the optional-parameter walk, the **entire OPEN was rejected** and the session could not establish.
- **Send:** with GR configured on ≥2 families, zebra-rs emitted a malformed capability (duplicated flags/time per entry); with zero families it emitted length 0 (minimum is 2).

## Changes

- `CapRestart` is now `{ flag_time, entries: Vec<RestartEntry> }` with 4-octet tuples; emit/parse the `2 + 4n` layout, reject other lengths, clamp the 12-bit restart time, budget 62 tuples. Per-AF `p_flag` renamed `f_flag` (RFC's Forwarding-state bit).
- `BgpCap.restart` became `Option<CapRestart>` so the helper-only form survives negotiation.
- OPEN builder assembles one capability with a shared header (largest configured per-family time, wire behavior unchanged today); dropped the never-read `PeerConfig::restart` map.
- `show bgp neighbors` prints the capability-level restart time per listed family; output format unchanged.

## Test plan

- New integration test replays a real OPEN capture (helper-only GR + LLGR for two families) through `BgpPacket::parse_packet`.
- New unit tests: helper-only and multi-AFI wire forms, emit/parse round-trips, `2 + 4n` length rejection, 12-bit clamp, entry-budget clamp.
- `cargo test --workspace --exclude bdd`: all pass. `cargo clippy --workspace --all-targets -- -D warnings`: clean. `cargo fmt --all`: applied.

Generated with [Claude Code](https://claude.com/claude-code)