### PR TITLE
PIM-SM/SSM: architecture plan and pim-packet wire codec crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ members = [
   "crates/isis-macros",
   "crates/ospf-packet",
   "crates/ospf-macros",
+  "crates/pim-packet",
   "crates/bfd-packet",
   "crates/nd-packet",
   "crates/stamp-packet",

--- a/crates/pim-packet/Cargo.toml
+++ b/crates/pim-packet/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "pim-packet"
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+license.workspace = true
+description = "Parser and encoder for PIM-SM (RFC 7761) and IGMP (RFC 2236/3376) packets"
+
+[dependencies]
+packet-utils = { path = "../packet-utils" }
+byteorder = "1.5"
+bytes = "1.9"
+internet-checksum = "0.2.1"
+nom = "8"
+
+[dev-dependencies]
+hex-literal = "1.0"
+
+[lints]
+workspace = true

--- a/crates/pim-packet/src/addr.rs
+++ b/crates/pim-packet/src/addr.rs
@@ -1,0 +1,241 @@
+//! RFC 7761 §4.9.1 encoded address formats, shared by Join/Prune,
+//! Assert, Register-Stop, Bootstrap and Candidate-RP messages.
+
+use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
+
+use bytes::{BufMut, BytesMut};
+use nom::error::{ErrorKind, make_error};
+use nom::number::complete::be_u8;
+use nom::{Err, IResult};
+use packet_utils::ParseBe;
+
+/// Address family numbers (IANA), the subset PIM uses.
+pub const PIM_AF_IPV4: u8 = 1;
+pub const PIM_AF_IPV6: u8 = 2;
+
+/// Native encoding — the only encoding type defined by RFC 7761.
+const PIM_ENC_NATIVE: u8 = 0;
+
+// Encoded-Source flag bits (Rsvd(5) | S | W | R).
+const SOURCE_FLAG_SPARSE: u8 = 0x04;
+const SOURCE_FLAG_WILDCARD: u8 = 0x02;
+const SOURCE_FLAG_RPT: u8 = 0x01;
+
+// Encoded-Group flag bits (B | Rsvd(6) | Z).
+const GROUP_FLAG_BIDIR: u8 = 0x80;
+const GROUP_FLAG_ZONE: u8 = 0x01;
+
+fn parse_pim_addr(input: &[u8], family: u8) -> IResult<&[u8], IpAddr> {
+    match family {
+        PIM_AF_IPV4 => {
+            let (input, addr) = Ipv4Addr::parse_be(input)?;
+            Ok((input, IpAddr::V4(addr)))
+        }
+        PIM_AF_IPV6 => {
+            let (input, addr) = Ipv6Addr::parse_be(input)?;
+            Ok((input, IpAddr::V6(addr)))
+        }
+        _ => Err(Err::Error(make_error(input, ErrorKind::Tag))),
+    }
+}
+
+fn family_of(addr: &IpAddr) -> u8 {
+    match addr {
+        IpAddr::V4(_) => PIM_AF_IPV4,
+        IpAddr::V6(_) => PIM_AF_IPV6,
+    }
+}
+
+fn put_pim_addr(buf: &mut BytesMut, addr: &IpAddr) {
+    match addr {
+        IpAddr::V4(v4) => buf.put(&v4.octets()[..]),
+        IpAddr::V6(v6) => buf.put(&v6.octets()[..]),
+    }
+}
+
+fn host_masklen(addr: &IpAddr) -> u8 {
+    match addr {
+        IpAddr::V4(_) => 32,
+        IpAddr::V6(_) => 128,
+    }
+}
+
+/// Encoded-Unicast address: family, encoding type, native address.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct EncodedUnicast {
+    pub addr: IpAddr,
+}
+
+impl EncodedUnicast {
+    pub fn new(addr: IpAddr) -> Self {
+        Self { addr }
+    }
+
+    pub fn wire_len(&self) -> usize {
+        2 + match self.addr {
+            IpAddr::V4(_) => 4,
+            IpAddr::V6(_) => 16,
+        }
+    }
+
+    pub fn parse_be(input: &[u8]) -> IResult<&[u8], Self> {
+        let (input, family) = be_u8(input)?;
+        let (input, enc) = be_u8(input)?;
+        if enc != PIM_ENC_NATIVE {
+            return Err(Err::Error(make_error(input, ErrorKind::Tag)));
+        }
+        let (input, addr) = parse_pim_addr(input, family)?;
+        Ok((input, Self { addr }))
+    }
+
+    pub fn emit(&self, buf: &mut BytesMut) {
+        buf.put_u8(family_of(&self.addr));
+        buf.put_u8(PIM_ENC_NATIVE);
+        put_pim_addr(buf, &self.addr);
+    }
+}
+
+/// Encoded-Group address: family, encoding type, B/Z flags, mask
+/// length, group address.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct EncodedGroup {
+    pub bidir: bool,
+    pub zone: bool,
+    pub masklen: u8,
+    pub addr: IpAddr,
+}
+
+impl EncodedGroup {
+    /// A single group (host mask length), the common case in
+    /// Join/Prune, Assert and Register-Stop.
+    pub fn new(addr: IpAddr) -> Self {
+        Self {
+            bidir: false,
+            zone: false,
+            masklen: host_masklen(&addr),
+            addr,
+        }
+    }
+
+    pub fn parse_be(input: &[u8]) -> IResult<&[u8], Self> {
+        let (input, family) = be_u8(input)?;
+        let (input, enc) = be_u8(input)?;
+        if enc != PIM_ENC_NATIVE {
+            return Err(Err::Error(make_error(input, ErrorKind::Tag)));
+        }
+        let (input, flags) = be_u8(input)?;
+        let (input, masklen) = be_u8(input)?;
+        let (input, addr) = parse_pim_addr(input, family)?;
+        Ok((
+            input,
+            Self {
+                bidir: flags & GROUP_FLAG_BIDIR != 0,
+                zone: flags & GROUP_FLAG_ZONE != 0,
+                masklen,
+                addr,
+            },
+        ))
+    }
+
+    pub fn emit(&self, buf: &mut BytesMut) {
+        buf.put_u8(family_of(&self.addr));
+        buf.put_u8(PIM_ENC_NATIVE);
+        let mut flags = 0u8;
+        if self.bidir {
+            flags |= GROUP_FLAG_BIDIR;
+        }
+        if self.zone {
+            flags |= GROUP_FLAG_ZONE;
+        }
+        buf.put_u8(flags);
+        buf.put_u8(self.masklen);
+        put_pim_addr(buf, &self.addr);
+    }
+}
+
+/// Encoded-Source address: family, encoding type, S/W/R flags, mask
+/// length, source address. The flag combinations map to the RFC 7761
+/// join/prune kinds: S alone = (S,G); S+W+R = (*,G) — the address is
+/// then the RP; S+R = (S,G,rpt).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct EncodedSource {
+    pub sparse: bool,
+    pub wildcard: bool,
+    pub rpt: bool,
+    pub masklen: u8,
+    pub addr: IpAddr,
+}
+
+impl EncodedSource {
+    /// (S,G) source: S bit only.
+    pub fn sg(addr: IpAddr) -> Self {
+        Self {
+            sparse: true,
+            wildcard: false,
+            rpt: false,
+            masklen: host_masklen(&addr),
+            addr,
+        }
+    }
+
+    /// (*,G) "source" — the RP address with S, W and R set.
+    pub fn star_g(rp: IpAddr) -> Self {
+        Self {
+            sparse: true,
+            wildcard: true,
+            rpt: true,
+            masklen: host_masklen(&rp),
+            addr: rp,
+        }
+    }
+
+    /// (S,G,rpt) source: S and R set.
+    pub fn sg_rpt(addr: IpAddr) -> Self {
+        Self {
+            sparse: true,
+            wildcard: false,
+            rpt: true,
+            masklen: host_masklen(&addr),
+            addr,
+        }
+    }
+
+    pub fn parse_be(input: &[u8]) -> IResult<&[u8], Self> {
+        let (input, family) = be_u8(input)?;
+        let (input, enc) = be_u8(input)?;
+        if enc != PIM_ENC_NATIVE {
+            return Err(Err::Error(make_error(input, ErrorKind::Tag)));
+        }
+        let (input, flags) = be_u8(input)?;
+        let (input, masklen) = be_u8(input)?;
+        let (input, addr) = parse_pim_addr(input, family)?;
+        Ok((
+            input,
+            Self {
+                sparse: flags & SOURCE_FLAG_SPARSE != 0,
+                wildcard: flags & SOURCE_FLAG_WILDCARD != 0,
+                rpt: flags & SOURCE_FLAG_RPT != 0,
+                masklen,
+                addr,
+            },
+        ))
+    }
+
+    pub fn emit(&self, buf: &mut BytesMut) {
+        buf.put_u8(family_of(&self.addr));
+        buf.put_u8(PIM_ENC_NATIVE);
+        let mut flags = 0u8;
+        if self.sparse {
+            flags |= SOURCE_FLAG_SPARSE;
+        }
+        if self.wildcard {
+            flags |= SOURCE_FLAG_WILDCARD;
+        }
+        if self.rpt {
+            flags |= SOURCE_FLAG_RPT;
+        }
+        buf.put_u8(flags);
+        buf.put_u8(self.masklen);
+        put_pim_addr(buf, &self.addr);
+    }
+}

--- a/crates/pim-packet/src/checksum.rs
+++ b/crates/pim-packet/src/checksum.rs
@@ -1,0 +1,66 @@
+//! Internet checksum (RFC 1071) helpers for PIM and IGMP.
+//!
+//! IPv4 PIM checksums the whole PIM message, except Register, whose
+//! checksum covers only the first 8 octets (header + flags word) so
+//! the encapsulated data packet is excluded (RFC 7761 §4.9). IGMP
+//! checksums the whole IGMP message. IPv6 PIM adds a pseudo-header —
+//! out of scope until the pim6 arc.
+
+use internet_checksum::Checksum;
+
+use crate::PimType;
+
+/// Register checksum coverage: PIM header (4) + flags word (4).
+const REGISTER_CHECKSUM_LEN: usize = 8;
+
+/// Compute the internet checksum over `data` (checksum field must be
+/// zero in the input). Returns the big-endian bytes to write into the
+/// checksum field.
+pub fn in_checksum(data: &[u8]) -> [u8; 2] {
+    let mut cksum = Checksum::new();
+    cksum.add_bytes(data);
+    cksum.checksum()
+}
+
+/// Verify a received PIM message's checksum. `packet` is the whole
+/// PIM message (IP payload) including the on-wire checksum field.
+/// Register messages are verified over the first 8 octets only.
+pub fn pim_verify_checksum(packet: &[u8]) -> bool {
+    if packet.len() < 4 {
+        return false;
+    }
+    let typ = PimType::from(packet[0] & 0x0f);
+    let region = if typ == PimType::Register && packet.len() >= REGISTER_CHECKSUM_LEN {
+        &packet[..REGISTER_CHECKSUM_LEN]
+    } else {
+        packet
+    };
+    in_checksum(region) == [0, 0]
+}
+
+/// Verify a received IGMP message's checksum over the whole message.
+pub fn igmp_verify_checksum(packet: &[u8]) -> bool {
+    if packet.len() < 4 {
+        return false;
+    }
+    in_checksum(packet) == [0, 0]
+}
+
+/// Fill the PIM checksum field (bytes 2..4) of an emitted message
+/// sitting at offset 0 of `buf`.
+pub(crate) fn pim_fill_checksum(typ: PimType, buf: &mut [u8]) {
+    let region_end = if typ == PimType::Register && buf.len() >= REGISTER_CHECKSUM_LEN {
+        REGISTER_CHECKSUM_LEN
+    } else {
+        buf.len()
+    };
+    let cksum = in_checksum(&buf[..region_end]);
+    buf[2..4].copy_from_slice(&cksum);
+}
+
+/// Fill the IGMP checksum field (bytes 2..4) of an emitted message
+/// sitting at offset 0 of `buf`.
+pub(crate) fn igmp_fill_checksum(buf: &mut [u8]) {
+    let cksum = in_checksum(buf);
+    buf[2..4].copy_from_slice(&cksum);
+}

--- a/crates/pim-packet/src/disp.rs
+++ b/crates/pim-packet/src/disp.rs
@@ -1,0 +1,119 @@
+use std::fmt::{Display, Formatter, Result};
+
+use crate::addr::{EncodedGroup, EncodedSource, EncodedUnicast};
+use crate::hello::HelloTlv;
+use crate::parser::{PimPacket, PimPayload};
+
+impl Display for EncodedUnicast {
+    fn fmt(&self, f: &mut Formatter<'_>) -> Result {
+        write!(f, "{}", self.addr)
+    }
+}
+
+impl Display for EncodedGroup {
+    fn fmt(&self, f: &mut Formatter<'_>) -> Result {
+        write!(f, "{}/{}", self.addr, self.masklen)
+    }
+}
+
+impl Display for EncodedSource {
+    fn fmt(&self, f: &mut Formatter<'_>) -> Result {
+        write!(f, "{}/{}", self.addr, self.masklen)?;
+        if self.sparse {
+            write!(f, " S")?;
+        }
+        if self.wildcard {
+            write!(f, " W")?;
+        }
+        if self.rpt {
+            write!(f, " R")?;
+        }
+        Ok(())
+    }
+}
+
+impl Display for HelloTlv {
+    fn fmt(&self, f: &mut Formatter<'_>) -> Result {
+        match self {
+            Self::Holdtime(v) => write!(f, " Holdtime: {v}"),
+            Self::LanPruneDelay {
+                t_bit,
+                propagation_delay,
+                override_interval,
+            } => write!(
+                f,
+                " LAN Prune Delay: delay {propagation_delay}ms override {override_interval}ms T={}",
+                *t_bit as u8
+            ),
+            Self::DrPriority(v) => write!(f, " DR Priority: {v}"),
+            Self::GenerationId(v) => write!(f, " Generation ID: {v:#010x}"),
+            Self::AddressList(addrs) => {
+                write!(f, " Address List:")?;
+                for addr in addrs {
+                    write!(f, " {addr}")?;
+                }
+                Ok(())
+            }
+            Self::Unknown { typ, data } => write!(f, " Unknown({typ}): {} bytes", data.len()),
+        }
+    }
+}
+
+impl Display for PimPacket {
+    fn fmt(&self, f: &mut Formatter<'_>) -> Result {
+        writeln!(f, "PIMv{} {}", self.version, self.typ)?;
+        match &self.payload {
+            PimPayload::Hello(hello) => {
+                for tlv in &hello.tlvs {
+                    writeln!(f, "{tlv}")?;
+                }
+            }
+            PimPayload::Register(register) => {
+                writeln!(
+                    f,
+                    " B={} N={} data {} bytes",
+                    register.border as u8,
+                    register.null_register as u8,
+                    register.data.len()
+                )?;
+            }
+            PimPayload::RegisterStop(stop) => {
+                writeln!(f, " Group: {} Source: {}", stop.group, stop.source)?;
+            }
+            PimPayload::JoinPrune(jp) => {
+                writeln!(
+                    f,
+                    " Upstream neighbor: {} holdtime {}",
+                    jp.upstream_neighbor, jp.holdtime
+                )?;
+                for group in &jp.groups {
+                    writeln!(f, " Group: {}", group.group)?;
+                    for join in &group.joins {
+                        writeln!(f, "  Join: {join}")?;
+                    }
+                    for prune in &group.prunes {
+                        writeln!(f, "  Prune: {prune}")?;
+                    }
+                }
+            }
+            PimPayload::Assert(assert) => {
+                writeln!(
+                    f,
+                    " Group: {} Source: {} R={} pref {} metric {}",
+                    assert.group,
+                    assert.source,
+                    assert.rpt_bit as u8,
+                    assert.metric_preference,
+                    assert.metric
+                )?;
+            }
+            PimPayload::Bootstrap(data) | PimPayload::CandRpAdv(data) => {
+                writeln!(f, " {} bytes", data.len())?;
+            }
+            PimPayload::Unknown { data, .. } => {
+                writeln!(f, " {} bytes", data.len())?;
+            }
+        }
+        Ok(())
+    }
+}

--- a/crates/pim-packet/src/hello.rs
+++ b/crates/pim-packet/src/hello.rs
@@ -1,0 +1,194 @@
+//! PIM Hello message (RFC 7761 §4.9.2): a sequence of option TLVs
+//! with 16-bit type and length fields.
+
+use bytes::{BufMut, BytesMut};
+use nom::IResult;
+use nom::bytes::complete::take;
+use nom::error::{ErrorKind, make_error};
+use nom::number::complete::{be_u16, be_u32};
+use nom::{Err, Parser};
+use packet_utils::many0_complete;
+
+use crate::addr::EncodedUnicast;
+
+pub const PIM_HELLO_TLV_HOLDTIME: u16 = 1;
+pub const PIM_HELLO_TLV_LAN_PRUNE_DELAY: u16 = 2;
+pub const PIM_HELLO_TLV_DR_PRIORITY: u16 = 19;
+pub const PIM_HELLO_TLV_GENERATION_ID: u16 = 20;
+pub const PIM_HELLO_TLV_ADDRESS_LIST: u16 = 24;
+
+/// LAN Prune Delay: T bit is the top bit of the propagation delay
+/// field (RFC 7761 §4.3.3 — "can disable join suppression").
+const LAN_PRUNE_DELAY_T_BIT: u16 = 0x8000;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum HelloTlv {
+    Holdtime(u16),
+    LanPruneDelay {
+        t_bit: bool,
+        propagation_delay: u16,
+        override_interval: u16,
+    },
+    DrPriority(u32),
+    GenerationId(u32),
+    AddressList(Vec<EncodedUnicast>),
+    Unknown {
+        typ: u16,
+        data: Vec<u8>,
+    },
+}
+
+impl HelloTlv {
+    /// Parse one TLV. A known option whose value has an unexpected
+    /// length is preserved as `Unknown` rather than failing the whole
+    /// Hello — receivers must ignore options they cannot use.
+    pub fn parse_be(input: &[u8]) -> IResult<&[u8], Self> {
+        let (input, typ) = be_u16(input)?;
+        let (input, len) = be_u16(input)?;
+        let (input, value) = take(len as usize)(input)?;
+        let tlv = match (typ, value.len()) {
+            (PIM_HELLO_TLV_HOLDTIME, 2) => {
+                let (_, holdtime) = be_u16(value)?;
+                Self::Holdtime(holdtime)
+            }
+            (PIM_HELLO_TLV_LAN_PRUNE_DELAY, 4) => {
+                let (value, delay) = be_u16(value)?;
+                let (_, override_interval) = be_u16(value)?;
+                Self::LanPruneDelay {
+                    t_bit: delay & LAN_PRUNE_DELAY_T_BIT != 0,
+                    propagation_delay: delay & !LAN_PRUNE_DELAY_T_BIT,
+                    override_interval,
+                }
+            }
+            (PIM_HELLO_TLV_DR_PRIORITY, 4) => {
+                let (_, priority) = be_u32(value)?;
+                Self::DrPriority(priority)
+            }
+            (PIM_HELLO_TLV_GENERATION_ID, 4) => {
+                let (_, gen_id) = be_u32(value)?;
+                Self::GenerationId(gen_id)
+            }
+            (PIM_HELLO_TLV_ADDRESS_LIST, _) => {
+                let (rest, addrs) = many0_complete(EncodedUnicast::parse_be).parse(value)?;
+                if !rest.is_empty() {
+                    return Err(Err::Error(make_error(rest, ErrorKind::LengthValue)));
+                }
+                Self::AddressList(addrs)
+            }
+            _ => Self::Unknown {
+                typ,
+                data: value.to_vec(),
+            },
+        };
+        Ok((input, tlv))
+    }
+
+    pub fn emit(&self, buf: &mut BytesMut) {
+        match self {
+            Self::Holdtime(holdtime) => {
+                buf.put_u16(PIM_HELLO_TLV_HOLDTIME);
+                buf.put_u16(2);
+                buf.put_u16(*holdtime);
+            }
+            Self::LanPruneDelay {
+                t_bit,
+                propagation_delay,
+                override_interval,
+            } => {
+                buf.put_u16(PIM_HELLO_TLV_LAN_PRUNE_DELAY);
+                buf.put_u16(4);
+                let mut delay = propagation_delay & !LAN_PRUNE_DELAY_T_BIT;
+                if *t_bit {
+                    delay |= LAN_PRUNE_DELAY_T_BIT;
+                }
+                buf.put_u16(delay);
+                buf.put_u16(*override_interval);
+            }
+            Self::DrPriority(priority) => {
+                buf.put_u16(PIM_HELLO_TLV_DR_PRIORITY);
+                buf.put_u16(4);
+                buf.put_u32(*priority);
+            }
+            Self::GenerationId(gen_id) => {
+                buf.put_u16(PIM_HELLO_TLV_GENERATION_ID);
+                buf.put_u16(4);
+                buf.put_u32(*gen_id);
+            }
+            Self::AddressList(addrs) => {
+                buf.put_u16(PIM_HELLO_TLV_ADDRESS_LIST);
+                let len: usize = addrs.iter().map(|a| a.wire_len()).sum();
+                buf.put_u16(len as u16);
+                for addr in addrs {
+                    addr.emit(buf);
+                }
+            }
+            Self::Unknown { typ, data } => {
+                buf.put_u16(*typ);
+                buf.put_u16(data.len() as u16);
+                buf.put(&data[..]);
+            }
+        }
+    }
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct PimHello {
+    pub tlvs: Vec<HelloTlv>,
+}
+
+impl PimHello {
+    pub fn parse_be(input: &[u8]) -> IResult<&[u8], Self> {
+        let (rest, tlvs) = many0_complete(HelloTlv::parse_be).parse(input)?;
+        if !rest.is_empty() {
+            // Trailing bytes that do not form a TLV header.
+            return Err(Err::Error(make_error(rest, ErrorKind::LengthValue)));
+        }
+        Ok((rest, Self { tlvs }))
+    }
+
+    pub fn emit(&self, buf: &mut BytesMut) {
+        for tlv in &self.tlvs {
+            tlv.emit(buf);
+        }
+    }
+
+    pub fn holdtime(&self) -> Option<u16> {
+        self.tlvs.iter().find_map(|tlv| match tlv {
+            HelloTlv::Holdtime(v) => Some(*v),
+            _ => None,
+        })
+    }
+
+    pub fn dr_priority(&self) -> Option<u32> {
+        self.tlvs.iter().find_map(|tlv| match tlv {
+            HelloTlv::DrPriority(v) => Some(*v),
+            _ => None,
+        })
+    }
+
+    pub fn generation_id(&self) -> Option<u32> {
+        self.tlvs.iter().find_map(|tlv| match tlv {
+            HelloTlv::GenerationId(v) => Some(*v),
+            _ => None,
+        })
+    }
+
+    /// (t_bit, propagation_delay_ms, override_interval_ms).
+    pub fn lan_prune_delay(&self) -> Option<(bool, u16, u16)> {
+        self.tlvs.iter().find_map(|tlv| match tlv {
+            HelloTlv::LanPruneDelay {
+                t_bit,
+                propagation_delay,
+                override_interval,
+            } => Some((*t_bit, *propagation_delay, *override_interval)),
+            _ => None,
+        })
+    }
+
+    pub fn address_list(&self) -> Option<&[EncodedUnicast]> {
+        self.tlvs.iter().find_map(|tlv| match tlv {
+            HelloTlv::AddressList(v) => Some(v.as_slice()),
+            _ => None,
+        })
+    }
+}

--- a/crates/pim-packet/src/igmp.rs
+++ b/crates/pim-packet/src/igmp.rs
@@ -1,0 +1,404 @@
+//! IGMP wire formats: v2 (RFC 2236) and v3 (RFC 3376) — queries,
+//! reports and leaves as needed by the PIM module's querier and
+//! membership tracking. IGMPv1 reports (RFC 1112) parse into the
+//! same 8-octet shape as v2.
+
+use std::net::Ipv4Addr;
+
+use bytes::{BufMut, BytesMut};
+use nom::Err;
+use nom::IResult;
+use nom::bytes::complete::take;
+use nom::error::{ErrorKind, make_error};
+use nom::number::complete::{be_u8, be_u16};
+use packet_utils::ParseBe;
+
+use crate::checksum::igmp_fill_checksum;
+
+pub const IGMP_MEMBERSHIP_QUERY: u8 = 0x11;
+pub const IGMP_V1_REPORT: u8 = 0x12;
+pub const IGMP_V2_REPORT: u8 = 0x16;
+pub const IGMP_V2_LEAVE: u8 = 0x17;
+pub const IGMP_V3_REPORT: u8 = 0x22;
+
+/// An 8-octet query is v2 (or v1 when max_resp is zero); 12 octets or
+/// more is a v3 query.
+const IGMP_V2_QUERY_LEN: usize = 8;
+
+// V3 query S/QRV octet: Resv(4) | S | QRV(3).
+const V3_QUERY_S_FLAG: u8 = 0x08;
+const V3_QUERY_QRV_MASK: u8 = 0x07;
+
+/// The common 8-octet IGMP message: v2 query/report/leave and the v1
+/// report. `max_resp` is only meaningful for queries (in v1 reports
+/// it is zero on the wire).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct IgmpGroupMessage {
+    pub max_resp: u8,
+    pub group: Ipv4Addr,
+}
+
+impl IgmpGroupMessage {
+    fn parse_be(input: &[u8]) -> IResult<&[u8], Self> {
+        let (input, max_resp) = be_u8(input)?;
+        let (input, _checksum) = be_u16(input)?;
+        let (input, group) = Ipv4Addr::parse_be(input)?;
+        Ok((input, Self { max_resp, group }))
+    }
+}
+
+/// IGMPv3 membership query (RFC 3376 §4.1).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct IgmpV3Query {
+    pub max_resp_code: u8,
+    pub group: Ipv4Addr,
+    pub suppress: bool,
+    pub qrv: u8,
+    pub qqic: u8,
+    pub sources: Vec<Ipv4Addr>,
+}
+
+impl IgmpV3Query {
+    fn parse_be(input: &[u8]) -> IResult<&[u8], Self> {
+        let (input, max_resp_code) = be_u8(input)?;
+        let (input, _checksum) = be_u16(input)?;
+        let (input, group) = Ipv4Addr::parse_be(input)?;
+        let (input, s_qrv) = be_u8(input)?;
+        let (input, qqic) = be_u8(input)?;
+        let (mut input, num_sources) = be_u16(input)?;
+        let mut sources = Vec::with_capacity(num_sources as usize);
+        for _ in 0..num_sources {
+            let (rest, source) = Ipv4Addr::parse_be(input)?;
+            sources.push(source);
+            input = rest;
+        }
+        Ok((
+            input,
+            Self {
+                max_resp_code,
+                group,
+                suppress: s_qrv & V3_QUERY_S_FLAG != 0,
+                qrv: s_qrv & V3_QUERY_QRV_MASK,
+                qqic,
+                sources,
+            },
+        ))
+    }
+}
+
+/// IGMPv3 group record type (RFC 3376 §4.2.12).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum IgmpRecordType {
+    ModeIsInclude,
+    ModeIsExclude,
+    ChangeToInclude,
+    ChangeToExclude,
+    AllowNewSources,
+    BlockOldSources,
+    Unknown(u8),
+}
+
+impl From<u8> for IgmpRecordType {
+    fn from(val: u8) -> Self {
+        use IgmpRecordType::*;
+        match val {
+            1 => ModeIsInclude,
+            2 => ModeIsExclude,
+            3 => ChangeToInclude,
+            4 => ChangeToExclude,
+            5 => AllowNewSources,
+            6 => BlockOldSources,
+            v => Unknown(v),
+        }
+    }
+}
+
+impl From<IgmpRecordType> for u8 {
+    fn from(typ: IgmpRecordType) -> Self {
+        use IgmpRecordType::*;
+        match typ {
+            ModeIsInclude => 1,
+            ModeIsExclude => 2,
+            ChangeToInclude => 3,
+            ChangeToExclude => 4,
+            AllowNewSources => 5,
+            BlockOldSources => 6,
+            Unknown(v) => v,
+        }
+    }
+}
+
+/// IGMPv3 group record (RFC 3376 §4.2.4).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct IgmpGroupRecord {
+    pub rec_type: IgmpRecordType,
+    pub group: Ipv4Addr,
+    pub sources: Vec<Ipv4Addr>,
+    /// Auxiliary data, preserved for round-trip (RFC 3376 says
+    /// receivers must ignore it). Length must be a multiple of 4.
+    pub aux: Vec<u8>,
+}
+
+impl IgmpGroupRecord {
+    pub fn parse_be(input: &[u8]) -> IResult<&[u8], Self> {
+        let (input, rec_type) = be_u8(input)?;
+        let (input, aux_len) = be_u8(input)?;
+        let (input, num_sources) = be_u16(input)?;
+        let (mut input, group) = Ipv4Addr::parse_be(input)?;
+        let mut sources = Vec::with_capacity(num_sources as usize);
+        for _ in 0..num_sources {
+            let (rest, source) = Ipv4Addr::parse_be(input)?;
+            sources.push(source);
+            input = rest;
+        }
+        let (input, aux) = take(aux_len as usize * 4)(input)?;
+        Ok((
+            input,
+            Self {
+                rec_type: rec_type.into(),
+                group,
+                sources,
+                aux: aux.to_vec(),
+            },
+        ))
+    }
+
+    pub fn emit(&self, buf: &mut BytesMut) {
+        buf.put_u8(self.rec_type.into());
+        buf.put_u8((self.aux.len() / 4) as u8);
+        buf.put_u16(self.sources.len() as u16);
+        buf.put(&self.group.octets()[..]);
+        for source in &self.sources {
+            buf.put(&source.octets()[..]);
+        }
+        buf.put(&self.aux[..]);
+    }
+}
+
+/// IGMPv3 membership report (RFC 3376 §4.2).
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct IgmpV3Report {
+    pub records: Vec<IgmpGroupRecord>,
+}
+
+impl IgmpV3Report {
+    fn parse_be(input: &[u8]) -> IResult<&[u8], Self> {
+        let (input, _reserved8) = be_u8(input)?;
+        let (input, _checksum) = be_u16(input)?;
+        let (input, _reserved16) = be_u16(input)?;
+        let (mut input, num_records) = be_u16(input)?;
+        let mut records = Vec::with_capacity(num_records as usize);
+        for _ in 0..num_records {
+            let (rest, record) = IgmpGroupRecord::parse_be(input)?;
+            records.push(record);
+            input = rest;
+        }
+        Ok((input, Self { records }))
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum IgmpPacket {
+    QueryV2(IgmpGroupMessage),
+    QueryV3(IgmpV3Query),
+    ReportV1(IgmpGroupMessage),
+    ReportV2(IgmpGroupMessage),
+    LeaveV2(IgmpGroupMessage),
+    ReportV3(IgmpV3Report),
+    Unknown { typ: u8, data: Vec<u8> },
+}
+
+impl IgmpPacket {
+    pub fn typ(&self) -> u8 {
+        use IgmpPacket::*;
+        match self {
+            QueryV2(_) | QueryV3(_) => IGMP_MEMBERSHIP_QUERY,
+            ReportV1(_) => IGMP_V1_REPORT,
+            ReportV2(_) => IGMP_V2_REPORT,
+            LeaveV2(_) => IGMP_V2_LEAVE,
+            ReportV3(_) => IGMP_V3_REPORT,
+            Unknown { typ, .. } => *typ,
+        }
+    }
+
+    /// Parse a whole IGMP message (IP payload). Checksum
+    /// verification is a separate step (`igmp_verify_checksum`) done
+    /// on the raw bytes.
+    pub fn parse_be(input: &[u8]) -> IResult<&[u8], Self> {
+        let total_len = input.len();
+        let (rest, typ) = be_u8(input)?;
+        let (rest, packet) = match typ {
+            IGMP_MEMBERSHIP_QUERY if total_len == IGMP_V2_QUERY_LEN => {
+                let (rest, msg) = IgmpGroupMessage::parse_be(rest)?;
+                (rest, Self::QueryV2(msg))
+            }
+            IGMP_MEMBERSHIP_QUERY if total_len > IGMP_V2_QUERY_LEN => {
+                let (rest, query) = IgmpV3Query::parse_be(rest)?;
+                (rest, Self::QueryV3(query))
+            }
+            IGMP_MEMBERSHIP_QUERY => {
+                return Err(Err::Error(make_error(input, ErrorKind::LengthValue)));
+            }
+            IGMP_V1_REPORT => {
+                let (rest, msg) = IgmpGroupMessage::parse_be(rest)?;
+                (rest, Self::ReportV1(msg))
+            }
+            IGMP_V2_REPORT => {
+                let (rest, msg) = IgmpGroupMessage::parse_be(rest)?;
+                (rest, Self::ReportV2(msg))
+            }
+            IGMP_V2_LEAVE => {
+                let (rest, msg) = IgmpGroupMessage::parse_be(rest)?;
+                (rest, Self::LeaveV2(msg))
+            }
+            IGMP_V3_REPORT => {
+                let (rest, report) = IgmpV3Report::parse_be(rest)?;
+                (rest, Self::ReportV3(report))
+            }
+            typ => (
+                &rest[rest.len()..],
+                Self::Unknown {
+                    typ,
+                    data: rest.to_vec(),
+                },
+            ),
+        };
+        Ok((rest, packet))
+    }
+
+    /// Emit the message into an empty buffer and fill in the
+    /// checksum. The message must start at offset 0 of `buf`.
+    pub fn emit(&self, buf: &mut BytesMut) {
+        use IgmpPacket::*;
+        buf.put_u8(self.typ());
+        match self {
+            QueryV2(msg) | ReportV1(msg) | ReportV2(msg) | LeaveV2(msg) => {
+                buf.put_u8(msg.max_resp);
+                buf.put_u16(0);
+                buf.put(&msg.group.octets()[..]);
+            }
+            QueryV3(query) => {
+                buf.put_u8(query.max_resp_code);
+                buf.put_u16(0);
+                buf.put(&query.group.octets()[..]);
+                let mut s_qrv = query.qrv & V3_QUERY_QRV_MASK;
+                if query.suppress {
+                    s_qrv |= V3_QUERY_S_FLAG;
+                }
+                buf.put_u8(s_qrv);
+                buf.put_u8(query.qqic);
+                buf.put_u16(query.sources.len() as u16);
+                for source in &query.sources {
+                    buf.put(&source.octets()[..]);
+                }
+            }
+            ReportV3(report) => {
+                buf.put_u8(0);
+                buf.put_u16(0);
+                buf.put_u16(0);
+                buf.put_u16(report.records.len() as u16);
+                for record in &report.records {
+                    record.emit(buf);
+                }
+            }
+            Unknown { data, .. } => {
+                buf.put(&data[..]);
+            }
+        }
+        igmp_fill_checksum(buf);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use hex_literal::hex;
+
+    use super::*;
+    use crate::checksum::igmp_verify_checksum;
+
+    fn round_trip(wire: &[u8]) -> IgmpPacket {
+        assert!(igmp_verify_checksum(wire), "fixture checksum invalid");
+        let (rest, packet) = IgmpPacket::parse_be(wire).expect("parse");
+        assert!(rest.is_empty(), "trailing bytes after parse");
+        let mut buf = BytesMut::new();
+        packet.emit(&mut buf);
+        assert_eq!(&buf[..], wire, "emit does not round-trip");
+        packet
+    }
+
+    #[test]
+    fn v2_general_query_round_trip() {
+        // General query, max resp 10.0s, group 0.0.0.0.
+        let wire = hex!("11 64 ee 9b 00 00 00 00");
+        let packet = round_trip(&wire);
+        let IgmpPacket::QueryV2(query) = packet else {
+            panic!("not a v2 query");
+        };
+        assert_eq!(query.max_resp, 0x64);
+        assert_eq!(query.group, Ipv4Addr::UNSPECIFIED);
+    }
+
+    #[test]
+    fn v3_general_query_round_trip() {
+        // General query: QRV=2, QQIC=125, no sources.
+        let wire = hex!("11 64 ec 1e 00 00 00 00 02 7d 00 00");
+        let packet = round_trip(&wire);
+        let IgmpPacket::QueryV3(query) = packet else {
+            panic!("not a v3 query");
+        };
+        assert!(!query.suppress);
+        assert_eq!(query.qrv, 2);
+        assert_eq!(query.qqic, 125);
+        assert!(query.sources.is_empty());
+    }
+
+    #[test]
+    fn v3_report_change_to_include_round_trip() {
+        // SSM join: CHANGE_TO_INCLUDE {10.0.0.2} for 232.1.1.1.
+        let wire = hex!(
+            "22 00 e7 f8 00 00 00 01" // v3 report, 1 record
+            "03 00 00 01 e8 01 01 01" // CHANGE_TO_INCLUDE, 1 source
+            "0a 00 00 02"
+        );
+        let packet = round_trip(&wire);
+        let IgmpPacket::ReportV3(report) = packet else {
+            panic!("not a v3 report");
+        };
+        assert_eq!(report.records.len(), 1);
+        let record = &report.records[0];
+        assert_eq!(record.rec_type, IgmpRecordType::ChangeToInclude);
+        assert_eq!(record.group, Ipv4Addr::new(232, 1, 1, 1));
+        assert_eq!(record.sources, vec![Ipv4Addr::new(10, 0, 0, 2)]);
+        assert!(record.aux.is_empty());
+    }
+
+    #[test]
+    fn v2_report_and_leave() {
+        let report = IgmpPacket::ReportV2(IgmpGroupMessage {
+            max_resp: 0,
+            group: Ipv4Addr::new(239, 1, 1, 1),
+        });
+        let mut buf = BytesMut::new();
+        report.emit(&mut buf);
+        assert!(igmp_verify_checksum(&buf));
+        let (_, reparsed) = IgmpPacket::parse_be(&buf).expect("parse");
+        assert_eq!(reparsed, report);
+
+        let leave = IgmpPacket::LeaveV2(IgmpGroupMessage {
+            max_resp: 0,
+            group: Ipv4Addr::new(239, 1, 1, 1),
+        });
+        let mut buf = BytesMut::new();
+        leave.emit(&mut buf);
+        assert!(igmp_verify_checksum(&buf));
+        let (_, reparsed) = IgmpPacket::parse_be(&buf).expect("parse");
+        assert_eq!(reparsed, leave);
+    }
+
+    #[test]
+    fn corrupted_checksum_detected() {
+        let mut wire = hex!("11 64 ee 9b 00 00 00 00").to_vec();
+        wire[7] = 0x01;
+        assert!(!igmp_verify_checksum(&wire));
+    }
+}

--- a/crates/pim-packet/src/joinprune.rs
+++ b/crates/pim-packet/src/joinprune.rs
@@ -1,0 +1,108 @@
+//! PIM Join/Prune message (RFC 7761 §4.9.5).
+
+use bytes::{BufMut, BytesMut};
+use nom::IResult;
+use nom::number::complete::{be_u8, be_u16};
+
+use crate::addr::{EncodedGroup, EncodedSource, EncodedUnicast};
+
+/// One group record: the group plus its joined and pruned source
+/// lists. The (*,G) join is an `EncodedSource` carrying the RP with
+/// the S/W/R bits set (`EncodedSource::star_g`).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct JpGroup {
+    pub group: EncodedGroup,
+    pub joins: Vec<EncodedSource>,
+    pub prunes: Vec<EncodedSource>,
+}
+
+impl JpGroup {
+    pub fn parse_be(input: &[u8]) -> IResult<&[u8], Self> {
+        let (input, group) = EncodedGroup::parse_be(input)?;
+        let (input, num_joins) = be_u16(input)?;
+        let (mut input, num_prunes) = be_u16(input)?;
+        let mut joins = Vec::with_capacity(num_joins as usize);
+        for _ in 0..num_joins {
+            let (rest, source) = EncodedSource::parse_be(input)?;
+            joins.push(source);
+            input = rest;
+        }
+        let mut prunes = Vec::with_capacity(num_prunes as usize);
+        for _ in 0..num_prunes {
+            let (rest, source) = EncodedSource::parse_be(input)?;
+            prunes.push(source);
+            input = rest;
+        }
+        Ok((
+            input,
+            Self {
+                group,
+                joins,
+                prunes,
+            },
+        ))
+    }
+
+    pub fn emit(&self, buf: &mut BytesMut) {
+        self.group.emit(buf);
+        buf.put_u16(self.joins.len() as u16);
+        buf.put_u16(self.prunes.len() as u16);
+        for source in &self.joins {
+            source.emit(buf);
+        }
+        for source in &self.prunes {
+            source.emit(buf);
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PimJoinPrune {
+    /// The upstream neighbor the message is addressed to (RFC 7761:
+    /// the RPF neighbor; other routers on the LAN process it for
+    /// suppression/override).
+    pub upstream_neighbor: EncodedUnicast,
+    pub holdtime: u16,
+    pub groups: Vec<JpGroup>,
+}
+
+impl PimJoinPrune {
+    pub fn new(upstream_neighbor: EncodedUnicast, holdtime: u16) -> Self {
+        Self {
+            upstream_neighbor,
+            holdtime,
+            groups: Vec::new(),
+        }
+    }
+
+    pub fn parse_be(input: &[u8]) -> IResult<&[u8], Self> {
+        let (input, upstream_neighbor) = EncodedUnicast::parse_be(input)?;
+        let (input, _reserved) = be_u8(input)?;
+        let (input, num_groups) = be_u8(input)?;
+        let (mut input, holdtime) = be_u16(input)?;
+        let mut groups = Vec::with_capacity(num_groups as usize);
+        for _ in 0..num_groups {
+            let (rest, group) = JpGroup::parse_be(input)?;
+            groups.push(group);
+            input = rest;
+        }
+        Ok((
+            input,
+            Self {
+                upstream_neighbor,
+                holdtime,
+                groups,
+            },
+        ))
+    }
+
+    pub fn emit(&self, buf: &mut BytesMut) {
+        self.upstream_neighbor.emit(buf);
+        buf.put_u8(0);
+        buf.put_u8(self.groups.len() as u8);
+        buf.put_u16(self.holdtime);
+        for group in &self.groups {
+            group.emit(buf);
+        }
+    }
+}

--- a/crates/pim-packet/src/lib.rs
+++ b/crates/pim-packet/src/lib.rs
@@ -1,0 +1,22 @@
+mod addr;
+mod checksum;
+mod disp;
+mod hello;
+mod igmp;
+mod joinprune;
+mod parser;
+mod typ;
+
+pub use addr::{EncodedGroup, EncodedSource, EncodedUnicast, PIM_AF_IPV4, PIM_AF_IPV6};
+pub use checksum::{igmp_verify_checksum, in_checksum, pim_verify_checksum};
+pub use hello::{
+    HelloTlv, PIM_HELLO_TLV_ADDRESS_LIST, PIM_HELLO_TLV_DR_PRIORITY, PIM_HELLO_TLV_GENERATION_ID,
+    PIM_HELLO_TLV_HOLDTIME, PIM_HELLO_TLV_LAN_PRUNE_DELAY, PimHello,
+};
+pub use igmp::{
+    IGMP_MEMBERSHIP_QUERY, IGMP_V1_REPORT, IGMP_V2_LEAVE, IGMP_V2_REPORT, IGMP_V3_REPORT,
+    IgmpGroupMessage, IgmpGroupRecord, IgmpPacket, IgmpRecordType, IgmpV3Query, IgmpV3Report,
+};
+pub use joinprune::{JpGroup, PimJoinPrune};
+pub use parser::{PIM_VERSION, PimAssert, PimPacket, PimPayload, PimRegister, PimRegisterStop};
+pub use typ::PimType;

--- a/crates/pim-packet/src/parser.rs
+++ b/crates/pim-packet/src/parser.rs
@@ -1,0 +1,424 @@
+//! PIM message header and per-type payloads (RFC 7761 §4.9).
+
+use bytes::{BufMut, BytesMut};
+use nom::error::{ErrorKind, make_error};
+use nom::number::complete::{be_u8, be_u16, be_u32};
+use nom::{Err, IResult};
+
+use crate::addr::{EncodedGroup, EncodedUnicast};
+use crate::checksum::pim_fill_checksum;
+use crate::hello::PimHello;
+use crate::joinprune::PimJoinPrune;
+use crate::typ::PimType;
+
+pub const PIM_VERSION: u8 = 2;
+
+// Register flags word (RFC 7761 §4.9.3).
+const REGISTER_FLAG_BORDER: u32 = 0x8000_0000;
+const REGISTER_FLAG_NULL: u32 = 0x4000_0000;
+
+// Assert metric-preference field: top bit is the RPT bit
+// (RFC 7761 §4.9.6).
+const ASSERT_RPT_BIT: u32 = 0x8000_0000;
+
+/// Register: flags word + the encapsulated data packet (a full IP
+/// packet, or nothing for a Null-Register probe). The PIM checksum
+/// covers only the header and flags word, so `data` round-trips
+/// byte-exact.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PimRegister {
+    pub border: bool,
+    pub null_register: bool,
+    pub data: Vec<u8>,
+}
+
+impl PimRegister {
+    pub fn parse_be(input: &[u8]) -> IResult<&[u8], Self> {
+        let (input, flags) = be_u32(input)?;
+        Ok((
+            &input[input.len()..],
+            Self {
+                border: flags & REGISTER_FLAG_BORDER != 0,
+                null_register: flags & REGISTER_FLAG_NULL != 0,
+                data: input.to_vec(),
+            },
+        ))
+    }
+
+    pub fn emit(&self, buf: &mut BytesMut) {
+        let mut flags = 0u32;
+        if self.border {
+            flags |= REGISTER_FLAG_BORDER;
+        }
+        if self.null_register {
+            flags |= REGISTER_FLAG_NULL;
+        }
+        buf.put_u32(flags);
+        buf.put(&self.data[..]);
+    }
+}
+
+/// Register-Stop (RFC 7761 §4.9.4).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PimRegisterStop {
+    pub group: EncodedGroup,
+    pub source: EncodedUnicast,
+}
+
+impl PimRegisterStop {
+    pub fn parse_be(input: &[u8]) -> IResult<&[u8], Self> {
+        let (input, group) = EncodedGroup::parse_be(input)?;
+        let (input, source) = EncodedUnicast::parse_be(input)?;
+        Ok((input, Self { group, source }))
+    }
+
+    pub fn emit(&self, buf: &mut BytesMut) {
+        self.group.emit(buf);
+        self.source.emit(buf);
+    }
+}
+
+/// Assert (RFC 7761 §4.9.6). For a (*,G) assert the source address is
+/// zero and the RPT bit is set.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PimAssert {
+    pub group: EncodedGroup,
+    pub source: EncodedUnicast,
+    pub rpt_bit: bool,
+    pub metric_preference: u32,
+    pub metric: u32,
+}
+
+impl PimAssert {
+    pub fn parse_be(input: &[u8]) -> IResult<&[u8], Self> {
+        let (input, group) = EncodedGroup::parse_be(input)?;
+        let (input, source) = EncodedUnicast::parse_be(input)?;
+        let (input, pref) = be_u32(input)?;
+        let (input, metric) = be_u32(input)?;
+        Ok((
+            input,
+            Self {
+                group,
+                source,
+                rpt_bit: pref & ASSERT_RPT_BIT != 0,
+                metric_preference: pref & !ASSERT_RPT_BIT,
+                metric,
+            },
+        ))
+    }
+
+    pub fn emit(&self, buf: &mut BytesMut) {
+        self.group.emit(buf);
+        self.source.emit(buf);
+        let mut pref = self.metric_preference & !ASSERT_RPT_BIT;
+        if self.rpt_bit {
+            pref |= ASSERT_RPT_BIT;
+        }
+        buf.put_u32(pref);
+        buf.put_u32(self.metric);
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum PimPayload {
+    Hello(PimHello),
+    Register(PimRegister),
+    RegisterStop(PimRegisterStop),
+    JoinPrune(PimJoinPrune),
+    Assert(PimAssert),
+    /// Kept as raw bytes until the BSR phase adds structured parsing.
+    Bootstrap(Vec<u8>),
+    /// Kept as raw bytes until the BSR phase adds structured parsing.
+    CandRpAdv(Vec<u8>),
+    Unknown {
+        typ: PimType,
+        data: Vec<u8>,
+    },
+}
+
+impl PimPayload {
+    pub fn typ(&self) -> PimType {
+        use PimPayload::*;
+        match self {
+            Hello(_) => PimType::Hello,
+            Register(_) => PimType::Register,
+            RegisterStop(_) => PimType::RegisterStop,
+            JoinPrune(_) => PimType::JoinPrune,
+            Assert(_) => PimType::Assert,
+            Bootstrap(_) => PimType::Bootstrap,
+            CandRpAdv(_) => PimType::CandRpAdv,
+            Unknown { typ, .. } => *typ,
+        }
+    }
+
+    fn parse_be(input: &[u8], typ: PimType) -> IResult<&[u8], Self> {
+        match typ {
+            PimType::Hello => {
+                let (input, hello) = PimHello::parse_be(input)?;
+                Ok((input, Self::Hello(hello)))
+            }
+            PimType::Register => {
+                let (input, register) = PimRegister::parse_be(input)?;
+                Ok((input, Self::Register(register)))
+            }
+            PimType::RegisterStop => {
+                let (input, stop) = PimRegisterStop::parse_be(input)?;
+                Ok((input, Self::RegisterStop(stop)))
+            }
+            PimType::JoinPrune => {
+                let (input, jp) = PimJoinPrune::parse_be(input)?;
+                Ok((input, Self::JoinPrune(jp)))
+            }
+            PimType::Assert => {
+                let (input, assert) = PimAssert::parse_be(input)?;
+                Ok((input, Self::Assert(assert)))
+            }
+            PimType::Bootstrap => Ok((&input[input.len()..], Self::Bootstrap(input.to_vec()))),
+            PimType::CandRpAdv => Ok((&input[input.len()..], Self::CandRpAdv(input.to_vec()))),
+            typ => Ok((
+                &input[input.len()..],
+                Self::Unknown {
+                    typ,
+                    data: input.to_vec(),
+                },
+            )),
+        }
+    }
+
+    fn emit(&self, buf: &mut BytesMut) {
+        use PimPayload::*;
+        match self {
+            Hello(v) => v.emit(buf),
+            Register(v) => v.emit(buf),
+            RegisterStop(v) => v.emit(buf),
+            JoinPrune(v) => v.emit(buf),
+            Assert(v) => v.emit(buf),
+            Bootstrap(data) | CandRpAdv(data) | Unknown { data, .. } => buf.put(&data[..]),
+        }
+    }
+}
+
+/// A PIM message: 4-octet header (version/type, reserved, checksum)
+/// followed by the type-specific payload. `parse_be` takes the whole
+/// IP payload; checksum verification is a separate step
+/// (`pim_verify_checksum`) done on the raw bytes before parsing.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PimPacket {
+    pub version: u8,
+    pub typ: PimType,
+    pub checksum: u16,
+    pub payload: PimPayload,
+}
+
+impl PimPacket {
+    pub fn new(payload: PimPayload) -> Self {
+        Self {
+            version: PIM_VERSION,
+            typ: payload.typ(),
+            checksum: 0,
+            payload,
+        }
+    }
+
+    pub fn parse_be(input: &[u8]) -> IResult<&[u8], Self> {
+        let (input, ver_type) = be_u8(input)?;
+        let version = ver_type >> 4;
+        if version != PIM_VERSION {
+            return Err(Err::Error(make_error(input, ErrorKind::Tag)));
+        }
+        let typ = PimType::from(ver_type & 0x0f);
+        let (input, _reserved) = be_u8(input)?;
+        let (input, checksum) = be_u16(input)?;
+        let (input, payload) = PimPayload::parse_be(input, typ)?;
+        Ok((
+            input,
+            Self {
+                version,
+                typ,
+                checksum,
+                payload,
+            },
+        ))
+    }
+
+    /// Emit the message into an empty buffer and fill in the
+    /// checksum. The message must start at offset 0 of `buf`.
+    pub fn emit(&self, buf: &mut BytesMut) {
+        buf.put_u8((self.version << 4) | u8::from(self.typ));
+        buf.put_u8(0);
+        buf.put_u16(0);
+        self.payload.emit(buf);
+        pim_fill_checksum(self.typ, buf);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::net::{IpAddr, Ipv4Addr};
+
+    use hex_literal::hex;
+
+    use super::*;
+    use crate::addr::EncodedSource;
+    use crate::checksum::pim_verify_checksum;
+    use crate::hello::HelloTlv;
+
+    fn round_trip(wire: &[u8]) -> PimPacket {
+        assert!(pim_verify_checksum(wire), "fixture checksum invalid");
+        let (rest, packet) = PimPacket::parse_be(wire).expect("parse");
+        assert!(rest.is_empty(), "trailing bytes after parse");
+        let mut buf = BytesMut::new();
+        packet.emit(&mut buf);
+        assert_eq!(&buf[..], wire, "emit does not round-trip");
+        packet
+    }
+
+    #[test]
+    fn hello_round_trip() {
+        let wire = hex!(
+            "20 00 6a f9"             // v2 Hello, checksum
+            "00 01 00 02 00 69"       // Holdtime 105
+            "00 13 00 04 00 00 00 01" // DR Priority 1
+            "00 14 00 04 12 34 56 78" // Generation ID
+            "00 02 00 04 01 f4 09 c4" // LAN Prune Delay 500/2500
+        );
+        let packet = round_trip(&wire);
+        assert_eq!(packet.typ, PimType::Hello);
+        let PimPayload::Hello(hello) = &packet.payload else {
+            panic!("not a hello");
+        };
+        assert_eq!(hello.holdtime(), Some(105));
+        assert_eq!(hello.dr_priority(), Some(1));
+        assert_eq!(hello.generation_id(), Some(0x12345678));
+        assert_eq!(hello.lan_prune_delay(), Some((false, 500, 2500)));
+        assert_eq!(hello.address_list(), None);
+    }
+
+    #[test]
+    fn hello_unknown_tlv_preserved() {
+        // Unknown option 65001 with 2 bytes of data must survive a
+        // parse/emit round-trip byte-exact.
+        let hello = PimHello {
+            tlvs: vec![
+                HelloTlv::Holdtime(105),
+                HelloTlv::Unknown {
+                    typ: 65001,
+                    data: vec![0xde, 0xad],
+                },
+            ],
+        };
+        let packet = PimPacket::new(PimPayload::Hello(hello));
+        let mut buf = BytesMut::new();
+        packet.emit(&mut buf);
+        assert!(pim_verify_checksum(&buf));
+        let (_, reparsed) = PimPacket::parse_be(&buf).expect("parse");
+        assert_eq!(reparsed.payload, packet.payload);
+    }
+
+    #[test]
+    fn join_prune_round_trip() {
+        // (*,G) join for 239.1.1.1 toward RP 10.0.0.1, upstream
+        // neighbor 10.0.0.1, holdtime 210.
+        let wire = hex!(
+            "23 00 cd e6"             // v2 Join/Prune, checksum
+            "01 00 0a 00 00 01"       // upstream neighbor 10.0.0.1
+            "00 01"                   // reserved, num groups 1
+            "00 d2"                   // holdtime 210
+            "01 00 00 20 ef 01 01 01" // group 239.1.1.1/32
+            "00 01 00 00"             // 1 join, 0 prunes
+            "01 00 07 20 0a 00 00 01" // (*,G) join source: RP, S|W|R
+        );
+        let packet = round_trip(&wire);
+        let PimPayload::JoinPrune(jp) = &packet.payload else {
+            panic!("not a join/prune");
+        };
+        assert_eq!(
+            jp.upstream_neighbor.addr,
+            IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1))
+        );
+        assert_eq!(jp.holdtime, 210);
+        assert_eq!(jp.groups.len(), 1);
+        let group = &jp.groups[0];
+        assert_eq!(group.group.addr, IpAddr::V4(Ipv4Addr::new(239, 1, 1, 1)));
+        assert_eq!(group.group.masklen, 32);
+        assert_eq!(
+            group.joins,
+            vec![EncodedSource::star_g(IpAddr::V4(Ipv4Addr::new(
+                10, 0, 0, 1
+            )))]
+        );
+        assert!(group.prunes.is_empty());
+    }
+
+    #[test]
+    fn register_checksum_covers_first_8_bytes_only() {
+        // Null bit set, 4 bytes of encapsulated data excluded from
+        // the checksum.
+        let wire = hex!(
+            "21 00 9e ff"  // v2 Register, checksum over first 8 bytes
+            "40 00 00 00"  // B=0 N=1
+            "de ad be ef"  // encapsulated data (not checksummed)
+        );
+        let packet = round_trip(&wire);
+        let PimPayload::Register(register) = &packet.payload else {
+            panic!("not a register");
+        };
+        assert!(!register.border);
+        assert!(register.null_register);
+        assert_eq!(register.data, vec![0xde, 0xad, 0xbe, 0xef]);
+    }
+
+    #[test]
+    fn register_stop_round_trip() {
+        let wire = hex!(
+            "22 00 e1 da"             // v2 Register-Stop, checksum
+            "01 00 00 20 ef 01 01 01" // group 239.1.1.1/32
+            "01 00 0a 00 00 02"       // source 10.0.0.2
+        );
+        let packet = round_trip(&wire);
+        let PimPayload::RegisterStop(stop) = &packet.payload else {
+            panic!("not a register-stop");
+        };
+        assert_eq!(stop.group.addr, IpAddr::V4(Ipv4Addr::new(239, 1, 1, 1)));
+        assert_eq!(stop.source.addr, IpAddr::V4(Ipv4Addr::new(10, 0, 0, 2)));
+    }
+
+    #[test]
+    fn assert_round_trip() {
+        let wire = hex!(
+            "25 00 de 62"             // v2 Assert, checksum
+            "01 00 00 20 ef 01 01 01" // group 239.1.1.1/32
+            "01 00 0a 00 00 02"       // source 10.0.0.2
+            "00 00 00 64"             // R=0, preference 100
+            "00 00 00 14"             // metric 20
+        );
+        let packet = round_trip(&wire);
+        let PimPayload::Assert(assert_msg) = &packet.payload else {
+            panic!("not an assert");
+        };
+        assert!(!assert_msg.rpt_bit);
+        assert_eq!(assert_msg.metric_preference, 100);
+        assert_eq!(assert_msg.metric, 20);
+    }
+
+    #[test]
+    fn bad_version_rejected() {
+        // Version 1 in the top nibble.
+        let wire = hex!("10 00 ef ff");
+        assert!(PimPacket::parse_be(&wire).is_err());
+    }
+
+    #[test]
+    fn corrupted_checksum_detected() {
+        let mut wire = hex!(
+            "20 00 6a f9"
+            "00 01 00 02 00 69"
+            "00 13 00 04 00 00 00 01"
+            "00 14 00 04 12 34 56 78"
+            "00 02 00 04 01 f4 09 c4"
+        )
+        .to_vec();
+        wire[5] ^= 0x01;
+        assert!(!pim_verify_checksum(&wire));
+    }
+}

--- a/crates/pim-packet/src/typ.rs
+++ b/crates/pim-packet/src/typ.rs
@@ -1,0 +1,74 @@
+use std::fmt::Display;
+
+/// PIM message type, the low nibble of the first header octet
+/// (RFC 7761 §4.9, RFC 8736 registry).
+#[repr(u8)]
+#[derive(Debug, Default, PartialEq, Eq, Clone, Copy)]
+pub enum PimType {
+    #[default]
+    Hello = 0,
+    Register = 1,
+    RegisterStop = 2,
+    JoinPrune = 3,
+    Bootstrap = 4,
+    Assert = 5,
+    Graft = 6,
+    GraftAck = 7,
+    CandRpAdv = 8,
+    Unknown(u8),
+}
+
+impl Display for PimType {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        use PimType::*;
+        let str = match self {
+            Hello => "Hello",
+            Register => "Register",
+            RegisterStop => "Register-Stop",
+            JoinPrune => "Join/Prune",
+            Bootstrap => "Bootstrap",
+            Assert => "Assert",
+            Graft => "Graft",
+            GraftAck => "Graft-Ack",
+            CandRpAdv => "Candidate-RP-Advertisement",
+            Unknown(_) => "Unknown",
+        };
+        write!(f, "{str}")
+    }
+}
+
+impl From<PimType> for u8 {
+    fn from(typ: PimType) -> Self {
+        use PimType::*;
+        match typ {
+            Hello => 0,
+            Register => 1,
+            RegisterStop => 2,
+            JoinPrune => 3,
+            Bootstrap => 4,
+            Assert => 5,
+            Graft => 6,
+            GraftAck => 7,
+            CandRpAdv => 8,
+            Unknown(v) => v,
+        }
+    }
+}
+
+impl From<u8> for PimType {
+    fn from(val: u8) -> Self {
+        use PimType::*;
+        match val {
+            0 => Hello,
+            1 => Register,
+            2 => RegisterStop,
+            3 => JoinPrune,
+            4 => Bootstrap,
+            5 => Assert,
+            6 => Graft,
+            7 => GraftAck,
+            8 => CandRpAdv,
+            v => Unknown(v),
+        }
+    }
+}

--- a/docs/design/pim-sm-ssm-architecture.md
+++ b/docs/design/pim-sm-ssm-architecture.md
@@ -1,0 +1,623 @@
+# PIM-SM/SSM — Overall Architecture & Phasing Plan
+
+Status: **proposal — no code yet** (branch `pim`). This document defines the architecture for
+a new PIM-SM/SSM protocol module in zebra-rs, based on a survey of two prior-art
+implementations (FRR `pimd`, ZebOS `pimd`/`mribd`) and of zebra-rs's own protocol-module
+conventions. It is written so a contributor can resume without the conversation history.
+
+PIM is genuinely greenfield in this tree: there is no mroute socket, no VIF/MFC handling,
+no IGMP host-side code, and no `RouteType::Multicast` path anywhere today. The only
+adjacent code is EVPN's bridge-MDB/IGMP-*snooping* watch (`RTNLGRP_MDB`), which is L2 and
+stays separate.
+
+---
+
+## 1. Goal & scope
+
+Deliver an RFC 7761 PIM Sparse Mode implementation with SSM (RFC 4607) support for IPv4,
+integrated as a first-class zebra-rs protocol module:
+
+**In scope (this arc)**
+
+- PIM-SM protocol engine: Hello/neighbors/DR election, Join/Prune (upstream + downstream
+  FSMs), Assert, Register/Register-Stop, SPT switchover, (S,G,rpt) prune.
+- SSM: `232.0.0.0/8` default range (configurable), (S,G)-only, no RP/register logic.
+- IGMPv2/IGMPv3 querier + group/source membership on PIM interfaces.
+- Static RP with group-prefix longest-match; BSR (RFC 5059) as a late phase.
+- Kernel dataplane: mroute socket (`MRT_INIT`/`MRT_ADD_VIF`/`MRT_ADD_MFC`), upcall
+  handling (`NOCACHE`/`WRONGVIF`/`WHOLEPKT`), `pimreg` register VIF.
+- RPF via the existing RIB NHT API; VRF support in a late phase (per-VRF instance +
+  `MRT_TABLE`).
+- YANG config + show commands + tracing subtree + BDD features, per house conventions.
+
+**Out of scope (deferred, see §12)**
+
+IPv6/MLD (pim6), MSDP, AutoRP, PIM-DM/State-Refresh, BFD-for-PIM, MLAG/VxLAN BUM,
+mtrace/ssmpingd, IGMP proxy, ECMP rebalance, (\*,\*,RP) state.
+
+---
+
+## 2. RFC surface
+
+| RFC | Role |
+|---|---|
+| RFC 7761 | PIM-SM (obsoletes 4601) — the core protocol engine |
+| RFC 4607 | Source-Specific Multicast (232/8, ff3x::/32) |
+| RFC 3376 | IGMPv3 (source-specific membership; required for SSM) |
+| RFC 2236 | IGMPv2 |
+| RFC 5059 | Bootstrap Router (BSR) — late phase |
+| RFC 6226 | PIM group-to-RP mapping rules |
+| RFC 3973 | PIM-DM — **non-goal** |
+| RFC 4610 / 3618 | Anycast-RP / MSDP — **non-goal** |
+
+---
+
+## 3. Prior art — what we take from whom
+
+Two reference implementations were surveyed in depth: FRR `pimd`
+(`../frr/pimd`, monolithic, dual-compiled v4/v6) and ZebOS
+(`../Z1/pimd` + `../Z1/mribd`, a three-daemon split where `pimd` is a pure protocol
+engine, `mribd` owns kernel MFC/VIF/IGMP, and `nsm` serves RPF lookups over IPC).
+
+**From FRR (behavioral reference — closest to Linux, actively maintained):**
+
+- The kernel dataplane recipe: mroute socket setup (`MRT_TABLE` before `MRT_INIT`,
+  `MRT_PIM` for upcalls incl. `WRVIFWHOLE`), VIF-index-vs-ifindex mapping,
+  `mfcctl`-shaped OIL shadow, and the four upcalls that drive protocol events
+  (`IGMPMSG_NOCACHE` → FHR/first-packet, `WHOLEPKT` → register encapsulation,
+  `WRONGVIF` → assert trigger, `WRVIFWHOLE` → SPT switchover at RP/LHR).
+  Linux quirks already learned by FRR: (\*,G) MFC requires IIF ∈ OIF list; unresolved
+  (S,G) installed with IIF=pimreg so traffic punts until RPF resolves; introspection via
+  `/proc/net/ip_mr_vif` and `/proc/net/ip_mr_cache`.
+- Timer defaults and FSM behavior details (§10 table below).
+- J/P aggregation model: joins/prunes accumulate per RPF-neighbor and flush on the
+  periodic J/P timer as one message (FRR `pim_jp_agg.c`).
+- The TIB bridge idea (`pim_tib.c`): a thin, explicit seam where IGMP membership becomes
+  PIM state — "someone wants G ⇒ add OIF + create local-membership + ref upstream".
+- Scope guidance: FRR's own MVP core is instance + interface + neighbor + upstream +
+  ifchannel + channel_oil + rpf/nht + tib + IGMP + mroute + static RP + ssm. Everything
+  else in pimd (MSDP, MLAG, VxLAN, AutoRP…) is separable.
+
+**From ZebOS (structural reference — cleaner factoring):**
+
+- **Protocol engine isolated from the dataplane.** ZebOS pimd contains zero
+  `setsockopt(MRT_*)`; data-plane triggers arrive as typed messages (NoCache, WrongVif,
+  WholePkt, StatUpdate). We keep zebra-rs single-process, but reproduce this as a module
+  boundary: all kernel mroute I/O lives in `pim/mroute.rs` and talks to the FSM core only
+  via the actor's `Message` enum. The FSM core becomes unit-testable without a kernel.
+- **RFC macros as named functions.** ZebOS `pim_route.c` implements the RFC 4601/7761
+  predicate macros literally (`immediate_olist_sg()`, `inherited_olist_sgrpt()`,
+  `join_desired_xg()`, `prune_desired_sgrpt()`…), with cached results in a per-entry
+  `macro_state` bitfield. Far more traceable to the spec than FRR's inlined logic. We
+  adopt this: `pim/macros.rs` holds pure functions over the TIB, one per RFC macro, and
+  each TIB entry caches the last evaluation so state transitions fire on value *change*.
+- **Unified TIB.** ZebOS keys (\*,G), (S,G), (S,G,rpt) into one table with typed keys,
+  and hangs per-interface downstream state off the entry (vector + VIF bitmaps for
+  joined/inherited/pruned/local olists). This maps far better onto Rust ownership than
+  FRR's web of back-pointers (`upstream ↔ ifchannel ↔ channel_oil` cross-links), so we
+  follow ZebOS here (§6).
+- **Explicit FSM tables.** ZebOS assert actions A1–A6 and its DM FSMs are explicit
+  state×event dispatch — the template for `match (state, event)` in Rust.
+- **Anti-patterns to avoid:** synchronous blocking request/reply toward the dataplane
+  (stalls the event loop); `#ifdef`-driven v4/v6 duplication (we keep an AF-clean core
+  and add v6 later); management-plane code dwarfing the protocol core.
+
+---
+
+## 4. Position in zebra-rs — process & actor model
+
+PIM is one more actor in the existing single-binary architecture. No new process, no IPC.
+
+- **Spawn:** `ConfigManager::commit_config` gets a `spawn_pim` / `despawn_pim` arm
+  (`zebra-rs/src/config/pim.rs`), copied from the `spawn_isis` template
+  (`zebra-rs/src/config/isis.rs:7`): idempotency check → `subscribe_to_rib("pim")` →
+  `ProtoContext::default_table(rib_client)` → `Pim::new(...)` → `config.subscribe("pim",
+  pim.cm.tx)` + `config.subscribe_show("pim", pim.show.tx)` → `inst::serve(pim)` into
+  `protocol_tasks`. Despawn sends `rib::Message::ProtoCleanup` (harmless for PIM — we
+  install no unicast routes — but keeps the contract) and must also tear down the mroute
+  socket (`MRT_DONE`) so the kernel flushes VIFs/MFC.
+- **Actor:** top struct `Pim` in `zebra-rs/src/pim/inst.rs` owns `tx/rx:
+  mpsc::Unbounded*<Message>`, `cm: ConfigChannel`, `show: ShowChannel`, `rib_rx:
+  UnboundedReceiver<RibRx>`, `ctx: ProtoContext`, plus all protocol state. `event_loop()`
+  follows the house shape: prime by draining `rib_rx` until `RibRx::EoR` (replays
+  links/addresses), then `tokio::select!` over `rib_rx` / `cm.rx` / `show.rx` / `rx`.
+- **Sockets feed the channel.** Two reader tasks (house `Task<T>` wrappers, abort-on-drop)
+  forward parsed input into the actor as `Message` variants:
+  - the per-VRF **PIM socket** (raw IPPROTO_103) → `Message::PimPacket { ifindex, src, dst, packet }`;
+  - the per-VRF **mroute socket** (raw IPPROTO_IGMP + `MRT_INIT`) → `Message::Igmp { ... }`
+    for IGMP packets and `Message::Upcall(Upcall)` for `struct igmpmsg` kernel upcalls
+    (`Upcall::Nocache/Wholepkt/Wrongvif/WrVifWhole { vif, sg, payload }`).
+  All FSM work then happens single-threaded inside the actor — no locks.
+- **Timers:** every FSM timer is a `context::Timer` (drop-cancels) whose callback sends a
+  `Message` (e.g. `Message::JoinTimerExpiry(SgKey)`, `Message::NeighborExpiry(ifindex,
+  addr)`, `Message::KeepaliveExpiry(SgKey)`). Never bare `tokio::time` in FSMs.
+
+Message-enum sketch (internal event vocabulary):
+
+```rust
+pub enum Message {
+    // sockets
+    PimPacket { ifindex: u32, src: Ipv4Addr, dst: Ipv4Addr, packet: PimPacket },
+    Igmp { ifindex: u32, src: Ipv4Addr, packet: IgmpPacket },
+    Upcall(Upcall),                       // kernel igmpmsg, parsed in mroute.rs
+    // timers
+    HelloTimerExpiry(u32),                // per-interface hello TX
+    NeighborExpiry(u32, Ipv4Addr),
+    JpPeriodic(Ipv4Addr),                 // per-RPF-neighbor J/P flush
+    JoinTimerExpiry(SgKey),
+    PrunePendingExpiry(SgKey, u32),
+    ExpiryTimer(SgKey, u32),              // downstream ET
+    AssertTimerExpiry(SgKey, u32),
+    KeepaliveExpiry(SgKey),
+    RegisterStopExpiry(SgKey),
+    QuerierTimerExpiry(u32),
+    // internal recomputation triggers
+    RpfUpdate(Ipv4Addr),                  // from RibRx::NexthopUpdate
+}
+```
+
+---
+
+## 5. Module & crate layout
+
+```
+crates/pim-packet/            # new workspace member, modeled on ospf-packet
+  src/lib.rs                  # re-exports
+  src/parser.rs               # PimPacket + per-type structs (nom-derive, NomBE)
+  src/typ.rs                  # PimType: Hello=0 Register=1 RegisterStop=2 JoinPrune=3
+                              #          Bootstrap=4 Assert=5 CandRpAdv=8
+  src/hello.rs                # Hello TLVs: Holdtime(1) LanPruneDelay(2) DrPriority(19)
+                              #             GenerationId(20) AddressList(24)
+  src/joinprune.rs            # encoded-unicast/group/source addrs, group records,
+                              #   WC/RPT bits — shared by JP + Assert + BSR
+  src/checksum.rs             # standard IP checksum; Register checksums header-only
+  src/igmp.rs                 # IGMPv2/v3 wire formats (query, v2/v3 reports)
+  src/disp.rs                 # Display impls
+
+zebra-rs/src/pim/
+  mod.rs
+  inst.rs                     # Pim actor: Message enum, new(), event_loop(), serve()
+  config.rs                   # callback_build(): "/routing/pim/..." handlers
+  show.rs                     # show_build(): show callbacks (text + JSON)
+  tracing.rs                  # PimTracing block driven by zebra-pim-tracing.yang
+  link.rs                     # PimInterface: per-ifindex state, VIF allocation,
+                              #   enable/disable, addr tracking from RibRx
+  neighbor.rs                 # hello RX/TX, neighbor table, holdtime, GenID, DR election
+  tib.rs                      # SgKey, TibEntry, Tib (the unified table, §6)
+  macros.rs                   # RFC 7761 predicates as pure fns over the Tib
+  upstream.rs                 # upstream J/P FSM (NotJoined/Joined), join timer,
+                              #   RPF′ change / GenID-change handling, SPT-bit logic
+  downstream.rs               # per-interface downstream FSM (NoInfo/Join/PrunePending)
+                              #   + (S,G,rpt) downstream variant
+  jp.rs                       # J/P RX walk + per-RPF-neighbor TX aggregation
+  assert_fsm.rs               # NoInfo/Winner/Loser, metric compare, actions A1–A6
+  register.rs                 # DR-side register FSM (NoInfo/Join/JoinPending/Prune),
+                              #   RP-side register RX / register-stop TX
+  rp.rs                       # RpSet: static RP config + group-prefix LPM (+BSR later)
+  ssm.rs                      # ssm range predicate (default 232/8, prefix override)
+  rpf.rs                      # RPF cache keyed by source/RP addr, backed by RIB NHT
+  oil.rs                      # Oil: kernel MFC shadow (iif VIF + oif bitmap + flags)
+  mroute.rs                   # ForwardingPlane: mroute socket, MRT_* setsockopts,
+                              #   VIF add/del, MFC install/uninstall, upcall parse,
+                              #   register encap TX / pimreg handling
+  igmp/
+    mod.rs                    # per-interface querier state + group/source tables
+    v2.rs / v3.rs             # version-specific RX/compat handling
+  vrf.rs                      # (late phase) per-VRF spawn, mirroring isis/vrf.rs
+```
+
+`crates/pim-packet` follows the `ospf-packet` conventions: `nom = 8` + `nom-derive`
+(`NomBE`, `#[nom(Verify)]`, custom `ParseBe`), hand-rolled emitters over
+`bytes::BytesMut`, helpers from `crates/packet-utils`. IGMP wire formats live in the same
+crate (they share encoded-address helpers and it avoids a second tiny crate).
+
+---
+
+## 6. Core data model
+
+### 6.1 Instance / interface / neighbor
+
+```rust
+pub struct Pim {                       // one per VRF (VRF-0 first)
+    // actor plumbing: tx/rx, cm, show, rib_rx, ctx, callbacks, show_cb ...
+    links: BTreeMap<u32, PimInterface>,        // by ifindex
+    tib: Tib,                                  // §6.2
+    rp_set: RpSet,                             // static RP LPM (+ BSR later)
+    ssm: SsmRange,
+    rpf: RpfCache,                             // §8
+    fp: ForwardingPlane,                       // mroute socket + VIF/MFC shadow
+    jp_agg: BTreeMap<Ipv4Addr, JpBucket>,      // per-RPF-neighbor J/P aggregation
+    // timers config (globals): jp_period, keepalive, register_suppress, ...
+}
+
+pub struct PimInterface {
+    ifindex: u32,
+    enabled: bool,                 // config: pim enable
+    passive: bool,
+    primary: Option<Ipv4Addr>,
+    vif: Option<u16>,              // kernel VIF index — allocated, NOT ifindex
+    dr: Option<Ipv4Addr>,          // election result; i_am_dr()
+    dr_priority: u32,              // default 1
+    hello_period: u16,             // default 30s
+    holdtime: u16,                 // default 3.5 × hello = 105s
+    gen_id: u32,
+    neighbors: BTreeMap<Ipv4Addr, Neighbor>,
+    hello_timer: Option<Timer>,
+    propagation_delay_ms: u16,     // 500
+    override_interval_ms: u16,     // 2500
+    igmp: IgmpIf,                  // querier + membership state (§9)
+}
+
+pub struct Neighbor {
+    addr: Ipv4Addr,
+    holdtime: u16,
+    dr_priority: Option<u32>,      // None ⇒ address-based DR election on this LAN
+    gen_id: Option<u32>,
+    lan_prune_delay: Option<(u16, u16, bool)>,  // (delay, override, T-bit)
+    secondary: Vec<IpAddr>,
+    expiry: Timer,
+}
+```
+
+DR election per RFC 7761 §4.3.2, as in FRR `pim_if_dr_election`: if any neighbor omits
+the DR-Priority option, elect by highest address; else highest (priority, address).
+A GenID change on an existing neighbor is treated as neighbor bounce: refresh all
+upstream state toward that neighbor (triggered J/P) and re-run DR election.
+
+### 6.2 TIB — one table, typed keys (ZebOS-style)
+
+```rust
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub enum SgKey {
+    StarG { grp: Ipv4Addr },                      // (*,G)
+    Sg    { src: Ipv4Addr, grp: Ipv4Addr },       // (S,G)
+    SgRpt { src: Ipv4Addr, grp: Ipv4Addr },       // (S,G,rpt)
+}
+
+pub struct Tib {
+    entries: BTreeMap<SgKey, TibEntry>,
+    // secondary index: group → members, for "walk all state for G" operations
+    by_group: BTreeMap<Ipv4Addr, BTreeSet<SgKey>>,
+}
+
+pub struct TibEntry {
+    key: SgKey,
+    // ---- upstream (toward RPF′) ----
+    upstream_addr: Option<Ipv4Addr>,  // RP for (*,G); S for (S,G); None if RP unknown
+    join_state: JoinState,            // NotJoined | Joined
+    join_timer: Option<Timer>,
+    reg_state: Option<RegState>,      // (S,G) at DR only: NoInfo|Join|JoinPending|Prune
+    spt_bit: bool,                    // (S,G) only
+    keepalive: Option<Timer>,         // (S,G): traffic-driven lifetime (KAT)
+    // ---- downstream (per interface) ----
+    downstream: BTreeMap<u32, Downstream>,   // by ifindex
+    // ---- local membership (from IGMP via the TIB bridge) ----
+    local: BTreeSet<u32>,                    // ifindexes with IGMP include state
+    // ---- cached macro results (fire transitions on change only) ----
+    cached: MacroState,               // JoinDesired, PruneDesired(rpt), CouldRegister,
+                                      // immediate/inherited olist hash
+    // ---- dataplane shadow ----
+    oil: Option<Oil>,                 // installed MFC mirror; None = not installed
+}
+
+pub struct Downstream {
+    state: DsState,                   // NoInfo | Join | PrunePending  (+ rpt variants)
+    expiry: Option<Timer>,            // ET
+    prune_pending: Option<Timer>,     // PPT
+    assert_: AssertState,             // NoInfo | Winner{metric} | Loser{winner, metric}
+    assert_timer: Option<Timer>,
+    could_assert: bool,               // cached macro
+    assert_tracking: bool,            // cached macro
+}
+```
+
+Design points:
+
+- **No back-pointer web.** The `Tib` is the single owner. (S,G) finds its (\*,G) parent
+  by key (`SgKey::StarG { grp }`) at use time — a `BTreeMap` lookup instead of a stored
+  reference; this sidesteps every borrow-checker fight that FRR's
+  upstream↔ifchannel↔oil graph would cause in Rust.
+- **(S,G,rpt) is a real entry** (as in ZebOS), not a flag on (S,G) — downstream rpt-prune
+  state and upstream rpt-override behavior differ enough to warrant it.
+- **No (\*,\*,RP)** — optional in RFC 7761, absent in FRR, negligible demand.
+- **OIL is computed, not maintained incrementally at first.** `macros.rs` implements
+  `immediate_olist(sg)`, `inherited_olist(sg)`, `inherited_olist_sgrpt(...)`,
+  `join_desired(...)`, `prune_desired_sgrpt(...)` as pure functions; after any input
+  event we recompute for the touched entry (and its group siblings), diff against
+  `cached`, and fire FSM transitions / MFC updates only on change. This is the ZebOS
+  `macro_state` pattern, and it keeps the spec-to-code mapping 1:1. Optimize later if
+  profiling demands it.
+- **Kernel MFC shadow (`Oil`)** — mirrors `struct mfcctl`: `iif: u16` (VIF), `oifs:
+  [u8; MAXVIFS]` TTL array, plus per-OIF provenance flags (`PROTO_PIM`, `PROTO_IGMP`,
+  `STAR`) so removing one contributor doesn't strip an OIF another still wants
+  (FRR's `oif_flags` lesson).
+
+### 6.3 State machines (all in-actor, `match (state, event)` style)
+
+| FSM | States | Module |
+|---|---|---|
+| Upstream (\*,G)/(S,G) | NotJoined, Joined (+ JT, override/suppression) | `upstream.rs` |
+| Upstream (S,G,rpt) | RPTNotJoined, Pruned, NotPruned (+ OT) | `upstream.rs` |
+| Downstream per-if | NoInfo, Join, PrunePending (+ ET, PPT) | `downstream.rs` |
+| Downstream (S,G,rpt) | NoInfo, Prune, PrunePending, PruneTmp… | `downstream.rs` |
+| Assert per-(entry,if) | NoInfo, IAmWinner, IAmLoser — actions A1–A6 | `assert_fsm.rs` |
+| Register (DR, per (S,G)) | NoInfo, Join, JoinPending, Prune | `register.rs` |
+
+Each FSM is a plain function `fn step(state, event, ctx) -> (state, Vec<Action>)` where
+`Action` is a small enum (send packet X, start/stop timer Y, update MFC). This keeps
+them unit-testable with zero I/O — the direct payoff of the ZebOS-style separation.
+
+---
+
+## 7. Kernel dataplane — `mroute.rs` (`ForwardingPlane`)
+
+All `MRT_*` interaction is confined to this module; the FSM core only sees `Upcall`
+messages and calls `fp.install(sg, oil)` / `fp.uninstall(sg)` / `fp.vif_add(ifindex)` /
+`fp.vif_del(ifindex)`.
+
+- **Socket:** `socket(AF_INET, SOCK_RAW, IPPROTO_IGMP)` per VRF. Order matters:
+  `MRT_TABLE <table_id>` (VRF phase only) **before** `MRT_INIT`; then `MRT_PIM 1` to
+  enable PIM-mode upcalls; large recv buffer (FRR uses 8 MB). Wrapped in
+  `AsyncFd`, read by a `Task` that forwards into the actor. `MRT_DONE` on despawn.
+  This socket also receives all IGMP packets (kernel behavior once `MRT_INIT` is done) —
+  it *is* the IGMP RX path; the separate per-interface IGMP concerns are TX + group joins.
+- **VIFs:** allocated indices (bitmap allocator), **not** ifindexes; `vifc.vifc_flags =
+  VIFF_USE_IFINDEX` with `vifc_lcl_ifindex`. Map both directions
+  (`ifindex → vif`, `vif → ifindex`). VIF 0 is reserved for the register VIF
+  (`VIFF_REGISTER`, the kernel `pimreg` device), added at instance start.
+- **MFC:** `MRT_ADD_MFC` / `MRT_DEL_MFC` with the entry's `Oil` shadow. Known Linux
+  quirks to reproduce from FRR:
+  - (\*,G) entries (origin `0.0.0.0`) require the IIF to also appear in the OIF list —
+    set it in a scratch copy at install time;
+  - an (S,G) whose RPF is still unresolved is installed with IIF = register VIF so the
+    first packets punt to userspace instead of looping;
+  - `PIM_ENFORCE_LOOPFREE_MFC`-style guard: never emit OIF == IIF.
+- **Upcalls** (`struct igmpmsg` on the mroute socket, `im_mbz == 0` distinguishes them
+  from real IGMP):
+  - `IGMPMSG_NOCACHE` — first packet of an unknown (S,G) arrived. If we are DR for the
+    source subnet (FHR): create (S,G) with `CouldRegister` evaluation → register FSM.
+    For SSM groups: install (S,G) with empty/inherited OIL (join-driven, no register).
+  - `IGMPMSG_WHOLEPKT` — full packet punt for register encapsulation: unicast a
+    Register (outer IP proto 103, checksum over header only) to RP(G) from the DR.
+  - `IGMPMSG_WRONGVIF` — data arrived on a non-IIF interface: assert trigger on that
+    interface (§6.3 assert FSM).
+  - `IGMPMSG_WRVIFWHOLE` — wrong-VIF **with** full packet: drives Register-Stop TX and
+    SPT-bit setting at RP/LHR (SPT switchover). Availability depends on `MRT_PIM`; keep
+    FRR's compat path (derive the same events from WRONGVIF + state) if absent.
+- **Register decapsulation at the RP is kernel-side:** with `MRT_PIM` on, the kernel's
+  PIM code decapsulates Registers and forwards the inner packet through the MFC with
+  IIF = register VIF. Userspace (us) only parses the Register copy delivered on the PIM
+  socket for protocol actions (create (S,G), send Register-Stop, switch to SPT).
+- **Introspection for tests:** `/proc/net/ip_mr_vif`, `/proc/net/ip_mr_cache`,
+  `ip mroute show` — BDD assertions will read these.
+
+No `RibType::Pim` / netlink `RouteProtocol` addition is needed for the MVP: PIM installs
+MFC entries via the mroute socket, not unicast routes, so `fib/netlink` is untouched.
+(If a multicast "MRIB" route type is ever wanted for RPF policy, that's a separate,
+later decision — see Open Questions.)
+
+## 7.1 PIM control socket
+
+One raw socket per VRF for IP protocol 103, created via `ctx.raw_socket(...)` — the OSPF
+pattern (`zebra-rs/src/ospf/socket.rs`) transfers directly: non-blocking, `IP_PKTINFO`
+for ifindex demux, `set_multicast_loop_v4(false)`, TTL 1, TOS internet-control, and a
+`join_multicast_v4_n(224.0.0.13, Index(ifindex))` per PIM-enabled interface
+(ALL-PIM-ROUTERS). Register/Register-Stop are unicast on the same socket. A single
+socket with PKTINFO (house style) replaces FRR's per-interface socket fan-out.
+
+---
+
+## 8. RPF & nexthop tracking
+
+RPF reuses the existing RIB NHT contract — the register-then-gate pattern already proven
+by the NHT series:
+
+- `RpfCache` keyed by looked-up address (source S or RP). On first need:
+  `ctx.rib.send(rib::Message::NexthopRegister { proto, nh })`; resolution arrives as
+  `RibRx::NexthopUpdate { nh, resolution }` and is cached. Entries are refcounted by the
+  TIB entries depending on them; `NexthopUnregister` on last drop.
+- From a resolution we derive `RpfResult { ifindex, rpf_addr }`:
+  - `RPF_interface(S)` = resolved egress ifindex;
+  - `RPF′(S,G)` = the resolved nexthop address **if it is a PIM neighbor on that
+    interface**; a directly-connected source yields "no upstream neighbor" (FHR case);
+    while unresolved or neighbor-less, JoinDesired is gated off (state parks, no J/P).
+  - Assert interaction: if the entry is assert-loser on the RPF interface, RPF′ is the
+    assert winner (RFC 7761 §4.6) — applied in `macros.rs`, not in the cache.
+- On `NexthopUpdate` change: re-run RPF for all dependent TIB entries — this is the
+  "RPF′ changed" event: move the entry between per-neighbor J/P buckets (prune old
+  neighbor path / join new), update MFC IIF, re-evaluate asserts. Same flow serves
+  interface-down and neighbor-loss.
+- **URIB only for now.** zebra-rs has no separate multicast RIB; FRR's
+  MRIB/URIB lookup-mode matrix is out of scope until a multicast-table feature exists.
+- ECMP: take the RIB's selected nexthop as-is (no PIM-side ECMP hash) in the MVP; note
+  FRR caveat C3 — the kernel MFC cannot load-split anyway.
+
+---
+
+## 9. IGMP (v2/v3) and the TIB bridge
+
+Lives inside the PIM module (`pim/igmp/`), per interface, FRR-style — *not* in rib. The
+existing EVPN `SnoopJoin/SnoopLeave` RibRx events are a different animal (bridge MDB
+snooping for VXLAN BUM) and stay untouched.
+
+- **RX:** IGMP packets arrive on the mroute socket (§7). **TX:** queries are sent from a
+  small per-interface raw IGMP socket path (router-alert option, TTL 1), joining
+  `224.0.0.2` / `224.0.0.22` for querier duties.
+- **Querier election:** lowest address wins; other-querier-present timer; startup =
+  general query burst. Robustness variable, query-interval, max-response-time
+  configurable per interface.
+- **State:** per interface, `groups: BTreeMap<Ipv4Addr, GmGroup>` where `GmGroup` holds
+  filter mode (INCLUDE/EXCLUDE), per-source entries with source timers, group timer,
+  and v2-compat mode (v2 report on the wire demotes the group to EXCLUDE{} handling).
+- **The TIB bridge** (one narrow API, FRR `pim_tib.c` distilled):
+  - `tib.local_join(sg_or_star_g, ifindex)` — called by IGMP when a group/source becomes
+    forwarding-desired on an interface. Creates/refs the TIB entry, sets `local`,
+    re-evaluates macros (which may set JoinDesired → upstream Join, add OIF → MFC).
+  - `tib.local_prune(sg_or_star_g, ifindex)` — the mirror.
+  - SSM enforcement lives at this bridge: an IGMPv3 (S,G) report in the SSM range maps
+    to `SgKey::Sg`; an any-source (v2 or v3 EXCLUDE{}) report for an SSM-range group is
+    rejected with a rate-limited warning (FRR caveat C19); ASM group reports map to
+    `SgKey::StarG`.
+- DR gating: only the DR (or sole router) on a downstream LAN adds the OIF/upstream
+  state for IGMP-learned membership; non-DR keeps membership state ready for DR
+  failover.
+
+---
+
+## 10. RP set & SSM
+
+- `RpSet`: static config entries `{ rp_addr, group_prefix | prefix-list (later) }` in a
+  prefix trie; `rp(g) -> Option<Ipv4Addr>` = longest-prefix match; `i_am_rp(g)` checks
+  the RP address against local addresses. Provenance field (`Static | Bsr`) from day
+  one so BSR (late phase) merges instead of restructuring: static beats BSR for the
+  same range (FRR rule); within BSR, RFC 5059 priority + hash.
+- `SsmRange`: default `232.0.0.0/8`, overridable by prefix. `is_ssm(g)` is consulted at
+  every decision point where SSM semantics diverge: reject (\*,G) join RX, reject
+  Register RX, skip register FSM at FHR, no RP resolution, NOCACHE installs join-driven
+  state only.
+- No RP known for an ASM group ⇒ (\*,G)/(S,G) state can exist (IGMP-driven) but stays
+  inactive: nothing installed upstream, MFC parked — mirrors FRR's "dummy OIL" behavior,
+  expressed here as `upstream_addr: None` gating JoinDesired.
+
+---
+
+## 11. Config, show, tracing (management surface)
+
+**YANG (config.yang + `zebra-pim.yang` feature module):**
+
+```
+routing:                                interface <name>:
+  router pim {                            pim {
+    rp {                                    enable;            # presence
+      static { address A.B.C.D               dr-priority <u32>;
+               group <prefix>; ... }          hello-interval <sec>;
+    }                                         passive;
+    ssm { range <prefix>; }                 }
+    join-prune-interval <sec>;              igmp {
+    keep-alive-timer <sec>;                   enable;
+    register-suppress-time <sec>;             version <2|3>;
+    spt-switchover { immediate | never; }     query-interval <sec>;
+  }                                         }
+```
+
+(Exact shape to be finalized against `config.yang` conventions in the skeleton PR —
+the split is the decided part: global knobs under `router pim`, interface enablement
+under the interface node, matching how IS-IS/OSPF hang per-interface config.)
+
+- **Callbacks:** `config.rs` `callback_build()` registering `"/routing/pim/..."` and the
+  interface-subtree paths, dispatched from `process_cm_msg` exactly like
+  `isis/config.rs:48`. React to `Set/Delete`; reconcile at `CommitEnd` (e.g. interface
+  set diffing → VIF add/del, socket group joins).
+- **Spawn wiring:** `config/manager.rs` gets the `spawn_pim` arm; `show_proto()` gets an
+  `is_pim` matcher; `exec.yang` gets `container pim` under show.
+- **Show commands** (text + `json` flag threaded per house convention):
+  `show ip pim interface`, `show ip pim neighbor`, `show ip pim rp-info`,
+  `show ip pim upstream`, `show ip pim join` (downstream state), `show ip pim state`,
+  `show ip mroute` (TIB + kernel MFC counters via `MRT` stats / `/proc`),
+  `show ip igmp interface`, `show ip igmp groups [detail]`.
+- **Tracing:** `zebra-pim-tracing.yang` + `pim/tracing.rs` with the house presence-
+  container pattern: categories `hello`, `join-prune`, `register`, `assert`, `igmp`,
+  `mroute` (upcalls/MFC), `rp`, each with direction/level, plus `all`.
+
+**Cross-cutting touchpoint checklist** (the complete out-of-module diff):
+workspace `Cargo.toml` member + `zebra-rs/Cargo.toml` dep (`pim-packet`);
+`main.rs` `mod pim;`; `config/manager.rs` spawn/despawn + `show_proto` + `is_pim`;
+`config/pim.rs`; `config.yang` + `exec.yang` + `zebra-pim.yang` + `zebra-pim-tracing.yang`.
+Nothing in `rib/` or `fib/` changes for the MVP.
+
+---
+
+## 12. Timers & defaults (RFC 7761 / FRR-aligned)
+
+| Timer / constant | Default | Notes |
+|---|---|---|
+| Hello period | 30 s | triggered-hello delay 5 s; hello before first J/P on a new iface |
+| Neighbor holdtime | 105 s | 3.5 × hello |
+| DR priority | 1 | option omitted ⇒ LAN falls back to address election |
+| Propagation delay / override interval | 500 ms / 2500 ms | LAN Prune Delay option; J/P override window |
+| J/P period | 60 s | per-RPF-neighbor aggregated send |
+| J/P holdtime | 210 s | 3.5 × period; drives downstream ET |
+| Keepalive (KAT) | 210 s | (S,G) traffic-driven lifetime; RP variant 3×suppress+probe |
+| Register suppress / probe | 60 s / 5 s | probe randomized ~0.5–1.5× in FRR |
+| Assert time / override | 180 s / 3 s | |
+| IGMP query interval / max response | 125 s / 10 s | robustness 2 |
+
+All defaults become YANG-configurable knobs under `router pim` (global) or the
+interface subtree, but ship with these values.
+
+---
+
+## 13. End-to-end flows (sanity walkthroughs)
+
+**Receiver joins (ASM, we are LHR/DR):** IGMPv3 report for G → `igmp/` updates group
+state → `tib.local_join(StarG{g}, if)` → macros: JoinDesired(\*,G) false→true →
+upstream FSM NotJoined→Joined → RPF(RP(G)) via NHT → Join(\*,G) queued in the RPF
+neighbor's `JpBucket`, JT started → OIL gains the receiver OIF → MFC (\*,G) installed
+(IIF = RPF(RP) VIF, IIF forced into OIF per kernel quirk).
+
+**Source starts (we are FHR/DR):** first packet → kernel `NOCACHE` upcall → (S,G)
+entry, `CouldRegister` true → register FSM Join: MFC (S,G) installed with register VIF
+in OIL → kernel punts `WHOLEPKT` per packet → Register unicast to RP → RP creates
+(S,G), joins SPT toward S → native traffic reaches RP → RP sends Register-Stop → FHR
+register FSM → Prune (suppression timer, NULL-registers as probes).
+
+**SPT switchover (LHR):** first native packet down the RPT for (S,G) with local
+receivers → LHR policy `spt-switchover immediate` → (S,G) JoinDesired → join SPT;
+when traffic arrives on the SPT IIF, SPT-bit set (Update_SPTbit rules) → (S,G,rpt)
+PruneDesired → SGrpt prune rides the next (\*,G) J/P toward the RP.
+
+---
+
+## 14. Phasing (smallest meaningful PR each; one branch/PR at a time)
+
+| Phase | Deliverable | Proof |
+|---|---|---|
+| 1 | `crates/pim-packet`: header, Hello TLVs, Join/Prune, Assert, Register/Register-Stop, IGMP v2/v3 formats; checksums | unit tests with wire fixtures (FRR pcap-derived) |
+| 2 | Module skeleton: spawn arm, YANG (`router pim` + interface `pim enable`), actor, PIM socket, Hello TX/RX, neighbor table, DR election, `show ip pim interface/neighbor`, tracing | BDD: 2-ns neighbor-up, DR election, holdtime expiry, GenID bounce |
+| 3 | IGMP v2/v3: querier election, group/source state, `show ip igmp ...` (no PIM coupling yet) | BDD: ns receiver joins group (socat/python), `show ip igmp groups` asserts |
+| 4 | Dataplane + SSM slice: mroute socket, VIF/MFC, upcalls, TIB + macros, upstream/downstream J/P FSMs, RPF via NHT, J/P aggregation. SSM (S,G) end-to-end | BDD: 3-ns chain, IGMPv3 (S,G) join at LHR, sender pings 232.x — receiver sees traffic; `ip mroute` shows (S,G) on transit |
+| 5 | ASM with static RP: RP LPM, (\*,G), register FSM both sides, Register-Stop, KAT, SPT switchover + SGrpt prune | BDD: 4-ns (src—FHR—RP—LHR—rcv): register path, native path after switchover, `show ip pim upstream` SPT-bit |
+| 6 | Assert FSM + WRONGVIF; LAN behaviors: join suppression, prune override (LAN Prune Delay) | BDD: LAN topology (bridge ns) with two upstream routers, assert winner/loser converges |
+| 7 | VRF: per-VRF instance (`MRT_TABLE`), `vrf.rs` mirroring `isis/vrf.rs`, `show ... vrf` | BDD: VRF-scoped SSM forwarding |
+| 8 | BSR (RFC 5059): C-BSR election, BSM flood/RPF check, C-RP advertisement, RP-set merge under static-beats-dynamic | BDD: BSR-elected RP serves ASM joins |
+
+Every BDD feature ends with the mandatory `Scenario: Teardown topology`. Traffic
+verification uses namespace-local senders (`ping -I <if> 232.x.y.z`) and IGMP-joining
+receivers (socat/python) plus `/proc/net/ip_mr_cache` / `ip mroute` assertions —
+mirroring how existing features assert kernel state.
+
+Follow-the-house-rules note: confirm direction with the smallest PR first (Phase 1 crate
+is intentionally standalone and risk-free), `cargo fmt` before every commit, workspace
+clippy, full test suite before push.
+
+---
+
+## 15. Deferred / non-goals (explicit)
+
+| Item | Why deferred |
+|---|---|
+| IPv6 PIM + MLD | Core is AF-clean (SgKey/oil/macros generic-ready) but v4 ships first; v6 needs MRT6, MLDv2, embedded-RP — its own arc (IS-IS v4/v6 dedup showed retrofit is tractable) |
+| MSDP / Anycast-RP | Inter-domain ASM; TCP peering, SA caches — separate arc |
+| AutoRP | Cisco-proprietary; BSR is the standards-track mechanism |
+| PIM-DM / State-Refresh | Different protocol personality; SM/SSM covers deployments we target |
+| BFD for PIM neighbors | House BFD client pattern exists (`ClientReq::Subscribe`); bolt-on later |
+| MLAG / VxLAN BUM / EVPN coupling | Interacts with cradle/EVPN work; revisit after core lands |
+| mtrace, ssmpingd, IGMP proxy | Diagnostics/edge features |
+| ECMP rebalance, MRIB lookup modes | Needs multicast-table support zebra-rs lacks |
+
+---
+
+## 16. Open questions (to settle in the Phase-2 PR review)
+
+1. **Interface config spelling** — `interface e0 { pim { enable } igmp { enable } }` vs
+   `ip pim`/`ip igmp` prefixes: match whichever per-interface protocol convention
+   `config.yang` uses at the time of the skeleton PR.
+2. **`show ip mroute` counters** — poll `MRT` stats via `SIOCGETSGCNT`/`/proc` on demand
+   (show-time) vs periodic stat timer updating the TIB. Proposal: on-demand at show
+   time; add a poller only if KAT accuracy needs it (FRR polls via its timer wheel —
+   revisit when implementing KAT: KAT refresh needs *some* traffic signal, either
+   `SIOCGETSGCNT` polling or upcall-driven; decide with measurements in Phase 5).
+3. **IGMP TX socket** — reuse the mroute socket for query TX vs a dedicated TX socket
+   with router-alert; decide at Phase 3 based on what the kernel permits cleanly.
+4. **SPT switchover policy surface** — `immediate | never` first (FRR effectively does
+   immediate); packet/byte-threshold policies later if requested.


### PR DESCRIPTION
## Summary

Phase 0 + Phase 1 of the PIM-SM/SSM arc:

- `docs/design/pim-sm-ssm-architecture.md` — overall architecture from a survey of FRR pimd and ZebOS pimd/mribd prior art: actor model, unified TIB keyed by typed `SgKey` with RFC 7761 macros as named pure functions, mroute dataplane isolated in one module, RPF via RIB NHT, IGMP inside the PIM module, and an 8-phase PR plan (SSM end-to-end before ASM).
- `crates/pim-packet` — standalone codec crate (no zebra-rs dependency yet), mirroring ospf-packet conventions: PIM header, Hello TLVs, Join/Prune, Assert, Register/Register-Stop with the RFC 7761 register checksum rule (first 8 octets only), encoded unicast/group/source addresses (S/W/R, B/Z flags), IGMPv2 + IGMPv3 query/report formats. Bootstrap/Cand-RP-Adv carried as raw bytes until the BSR phase.

## Test plan

- `cargo test -p pim-packet`: 13 wire-fixture round-trip tests with independently hand-computed checksums, plus negative tests (bad version, corrupted checksum, unknown-TLV preservation).
- `cargo test --workspace --exclude bdd`: all green.
- `cargo clippy --workspace --all-targets`: clean. `cargo fmt --all --check`: clean.

Generated with [Claude Code](https://claude.com/claude-code)