### PR TITLE
isis-packet: fix RouterCapFlags S/D flags at wrong bit positions

### DIFF
--- a/crates/isis-packet/src/sub/cap.rs
+++ b/crates/isis-packet/src/sub/cap.rs
@@ -211,13 +211,21 @@ impl TlvEmitter for IsisSubNodeMaxSidDepth {
     }
 }
 
+// RFC 7981 §2 flags octet:
+//   0 1 2 3 4 5 6 7
+//  +-+-+-+-+-+-+-+-+
+//  | Reserved  |D|S|
+//  +-+-+-+-+-+-+-+-+
+// IETF bit 7 is the least-significant bit, so S = 0x01 and D = 0x02
+// (FRR: ISIS_ROUTER_CAP_FLAG_S/_D). `bitfield(u8)` is LSB-first —
+// declare S first to land at bit 0, then D, then the 6 reserved MSBs.
 #[bitfield(u8, debug = true)]
 #[derive(PartialEq)]
 pub struct RouterCapFlags {
+    pub s_flag: bool,
+    pub d_flag: bool,
     #[bits(6)]
     pub resvd: u8,
-    pub d_flag: bool,
-    pub s_flag: bool,
 }
 
 impl ParseBe<RouterCapFlags> for RouterCapFlags {
@@ -666,6 +674,26 @@ impl From<IsisSubFlexAlgoDef> for IsisSubTlv {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn router_cap_flags_s_and_d_bit_positions() {
+        // RFC 7981 §2: S (flood entire domain) = 0x01, D (down) = 0x02,
+        // reserved bits in the six MSBs.
+        let s_only = RouterCapFlags::from(0x01);
+        assert!(s_only.s_flag());
+        assert!(!s_only.d_flag());
+        assert_eq!(s_only.resvd(), 0);
+
+        let d_only = RouterCapFlags::from(0x02);
+        assert!(d_only.d_flag());
+        assert!(!d_only.s_flag());
+        assert_eq!(d_only.resvd(), 0);
+
+        let emitted: u8 = RouterCapFlags::new().with_s_flag(true).into();
+        assert_eq!(emitted, 0x01);
+        let emitted: u8 = RouterCapFlags::new().with_d_flag(true).into();
+        assert_eq!(emitted, 0x02);
+    }
 
     #[test]
     fn sr_algo_len_truncates_at_255() {

--- a/docs/design/isis-packet-code-review.md
+++ b/docs/design/isis-packet-code-review.md
@@ -35,7 +35,7 @@ source, not left as guesses.
 Severity legend: 🔴 high · 🟠 medium · 🟡 low. Verdict: **CONFIRMED** (inputs +
 wrong output identified) · **PLAUSIBLE** (mechanism real, trigger conditional).
 
-### 1. 🔴 `IsisTlvLspEntries::len()` wraps at ≥16 entries → corrupt CSNP/PSNP — CONFIRMED
+### 1. 🔴 `IsisTlvLspEntries::len()` wraps at ≥16 entries → corrupt CSNP/PSNP — CONFIRMED — ✅ FIXED (PR #1952)
 `crates/isis-packet/src/parser.rs:755`
 
 `len()` is `(self.entries.len() * 16) as u8`, which wraps mod-256, but `emit()`
@@ -55,10 +55,11 @@ TLV header — the whole CSNP/PSNP desyncs and **LSDB synchronization breaks on 
 network with more than 15 LSPs per level**. Small BDD topologies stay under 16
 LSPs, which is why it has not surfaced in testing.
 
-**Fix:** cap the builders at 15 entries per TLV (`available_len/16` → `min(15)`),
-or add `LspEntries` to the packer's `split_distributable_at_255` set, or make the
-codec's `len()`/`emit()` consistent (both truncate at 15) so an over-full TLV
-can't be silently mis-framed.
+**Fixed in PR #1952:** added `IsisTlvLspEntries::MAX_ENTRIES` (15) and capped
+`entry_size_max` in both `csnp_generate` and the PSNP builder, so larger LSDBs
+span more SNP PDUs. Unit tests pin the exact-length round-trip at 15 entries and
+the mod-256 wrap beyond it; BDD scenario `isis_csnp_large_lsdb` drives a >15-LSP
+LSDB through DIS CSNP sync.
 
 ### 2. 🔴 `RouterCapFlags` S/D flags at the wrong bit positions — CONFIRMED
 `crates/isis-packet/src/sub/cap.rs:214`
@@ -405,8 +406,8 @@ Correctness outranks these for the ranked list, but they're worth scheduling:
 
 ## Suggested priority
 
-1. **Fix #1 (LspEntries wrap)** first — it silently breaks LSDB sync on any
-   production-sized network and is entirely invisible in small test topologies.
+1. ~~Fix #1 (LspEntries wrap) first~~ — **done** (PR #1952): builders capped at
+   15 entries per TLV; unit + BDD regression coverage in place.
 2. **Fix #2 (RouterCap S/D) and #5 (Srv6TlvFlags MTID)** next — both are
    RFC/FRR-confirmed interop breaks with trivial one-line fixes.
 3. **Fix #3 (nsap panic)** — a one-line guard that removes a config-input crash.

--- a/docs/design/isis-packet-code-review.md
+++ b/docs/design/isis-packet-code-review.md
@@ -61,7 +61,7 @@ span more SNP PDUs. Unit tests pin the exact-length round-trip at 15 entries and
 the mod-256 wrap beyond it; BDD scenario `isis_csnp_large_lsdb` drives a >15-LSP
 LSDB through DIS CSNP sync.
 
-### 2. 🔴 `RouterCapFlags` S/D flags at the wrong bit positions — CONFIRMED
+### 2. 🔴 `RouterCapFlags` S/D flags at the wrong bit positions — CONFIRMED — ✅ FIXED
 `crates/isis-packet/src/sub/cap.rs:214`
 
 ```rust
@@ -86,8 +86,10 @@ Note the sibling `SegmentRoutingCapFlags` (I=`0x80`/V=`0x40`) *is* correct and
 matches FRR (`ISIS_SUBTLV_SRGB_FLAG_I 0x80` / `_V 0x40`) — RouterCap simply
 copied the MSB-aligned convention when it needed the LSB-aligned one.
 
-**Fix:** declare `s_flag` and `d_flag` first (LSB) and `resvd(6)` last, so
-S=`0x01`, D=`0x02`.
+**Fixed:** `s_flag` and `d_flag` are now declared first (LSB-first) with
+`resvd(6)` last, so S=`0x01`, D=`0x02`; a unit test pins both bit positions in
+each direction. `flags_serde.rs` and `cap_disp.rs` go through the accessors, so
+they were corrected by the same change.
 
 ### 3. 🔴 `Nsap::from_str` panics (index OOB) on a malformed `net` — CONFIRMED
 `crates/isis-packet/src/nsap.rs:116` (also `:122`, `:127`)
@@ -408,8 +410,9 @@ Correctness outranks these for the ranked list, but they're worth scheduling:
 
 1. ~~Fix #1 (LspEntries wrap) first~~ — **done** (PR #1952): builders capped at
    15 entries per TLV; unit + BDD regression coverage in place.
-2. **Fix #2 (RouterCap S/D) and #5 (Srv6TlvFlags MTID)** next — both are
-   RFC/FRR-confirmed interop breaks with trivial one-line fixes.
+2. ~~Fix #2 (RouterCap S/D)~~ — **done**: flags declared LSB-first, S=`0x01` /
+   D=`0x02` pinned by unit test. **#5 (Srv6TlvFlags MTID)** remains — an
+   RFC/FRR-confirmed interop break with a trivial one-line fix.
 3. **Fix #3 (nsap panic)** — a one-line guard that removes a config-input crash.
 4. Work through the emit-side length cluster (#4, #7, #8) with a shared
    `usize`-based length policy; that also naturally addresses several of the


### PR DESCRIPTION
## Summary

Fixes finding #2 of the isis-packet code review
(`docs/design/isis-packet-code-review.md`).

- RFC 7981 puts the TLV 242 (Router Capability) S flag at `0x01` and D
  flag at `0x02` with the six reserved bits in the MSBs (FRR:
  `ISIS_ROUTER_CAP_FLAG_S/_D`). The bitfield declared `resvd` first,
  which is LSB-first in `bitfield(u8)`, so S landed at `0x80` and D at
  `0x40`: an `S=0x01` from FRR/Cisco parsed as `s_flag()=false`, and a
  locally set `s_flag` emitted `0x80`, turning a domain-wide capability
  into an area-local one at conformant receivers.
- `RouterCapFlags` now declares `s_flag`/`d_flag` first and `resvd(6)`
  last, mirroring the `MultiTopologyId` LSB-first fix.
  `flags_serde.rs`/`cap_disp.rs` read through the accessors, so they are
  corrected by the same change; the daemon only builds this TLV with
  `flags: 0`, so nothing else shifts.
- Review doc: finding #2 marked fixed; finding #1 marked fixed by #1952.

## Test plan

- New unit test `router_cap_flags_s_and_d_bit_positions` pins `S=0x01` /
  `D=0x02` in both the parse and emit directions.
- `cargo test --workspace --exclude bdd` green locally.

Generated with [Claude Code](https://claude.com/claude-code)