### PR TITLE
ospf-packet: fix three remote-DoS panics on malformed input

### DIFF
--- a/crates/ospf-packet/src/parser.rs
+++ b/crates/ospf-packet/src/parser.rs
@@ -398,7 +398,13 @@ pub struct OspfLsUpdate {
 /// checksum to match — so they don't need the cache.
 fn parse_lsas_with_raw(input: &[u8], n: usize) -> IResult<&[u8], Vec<OspfLsa>> {
     use nom_derive::Parse;
-    let mut out = Vec::with_capacity(n);
+    // `n` is a wire-supplied count; cap the pre-allocation so a forged count
+    // cannot force a huge eager allocation (each LSA is at least a header).
+    let mut out = Vec::with_capacity(packet_utils::bounded_capacity(
+        n,
+        input.len(),
+        LSA_HEADER_LEN as usize,
+    ));
     let mut rest = input;
     for _ in 0..n {
         let start = rest;
@@ -1602,6 +1608,12 @@ impl ExtPrefixTlv {
         let (tlv_data, prefix_len) = be_u8(tlv_data)?;
         let (tlv_data, af) = be_u8(tlv_data)?;
         let (tlv_data, flags) = be_u8(tlv_data)?;
+
+        // An IPv4 prefix length cannot exceed 32 bits; reject a malformed
+        // length before it overruns the 4-byte address buffer below.
+        if prefix_len > 32 {
+            return Err(Err::Error(make_error(tlv_data, ErrorKind::Verify)));
+        }
 
         // Prefix is padded to 4-byte boundary.
         let prefix_bytes = (prefix_len as usize).div_ceil(8);
@@ -2871,6 +2883,30 @@ mod tests {
         assert_eq!(parsed.auth_type, 0);
         assert!(matches!(parsed.auth, Ospfv2Auth::Null(_)));
         assert!(parsed.auth_trailer.is_empty());
+    }
+
+    #[test]
+    fn ext_prefix_tlv_valid_prefix_len_parses() {
+        // type=1, len=8; route_type=1, prefix_len=24, af=0, flags=0, 10.1.1.0.
+        let bytes = [0x00, 0x01, 0x00, 0x08, 0x01, 24, 0x00, 0x00, 10, 1, 1, 0];
+        let (_, tlv) = ExtPrefixTlv::parse_tlv(&bytes).expect("valid TLV must parse");
+        assert_eq!(tlv.prefix, "10.1.1.0/24".parse().unwrap());
+    }
+
+    #[test]
+    fn ext_prefix_tlv_rejects_oversized_prefix_len() {
+        // prefix_len = 255 would need 32 address bytes; must be rejected, not
+        // overrun the 4-byte buffer (regression for the parse panic).
+        let bytes = [0x00, 0x01, 0x00, 0x08, 0x01, 0xFF, 0x00, 0x00, 0, 0, 0, 0];
+        assert!(ExtPrefixTlv::parse_tlv(&bytes).is_err());
+    }
+
+    #[test]
+    fn parse_lsas_with_raw_clamps_hostile_count() {
+        // A 4-billion advertisement count with an empty body must error out
+        // gracefully rather than pre-allocate ~gigabytes (regression for the
+        // Vec::with_capacity DoS).
+        assert!(parse_lsas_with_raw(&[], 0xFFFF_FFFF).is_err());
     }
 
     /// RFC 2328 §D.4.1-D.4.2: the checksum excludes the 64-bit

--- a/crates/ospf-packet/src/v3.rs
+++ b/crates/ospf-packet/src/v3.rs
@@ -1074,7 +1074,13 @@ impl ParseBe<Ospfv3IntraAreaPrefixLsa> for Ospfv3IntraAreaPrefixLsa {
         let (input, referenced_ls_type) = be_u16(input)?;
         let (input, referenced_link_state_id) = be_u32(input)?;
         let (mut input, referenced_advertising_router) = Ipv4Addr::parse_be(input)?;
-        let mut prefixes = Vec::with_capacity(num_prefixes as usize);
+        // Cap the pre-allocation against a forged prefix count (each prefix
+        // entry is at least 4 octets on the wire).
+        let mut prefixes = Vec::with_capacity(packet_utils::bounded_capacity(
+            num_prefixes as usize,
+            input.len(),
+            4,
+        ));
         for _ in 0..num_prefixes {
             let (rest, p) = Ospfv3IntraAreaPrefix::parse_be(input)?;
             prefixes.push(p);
@@ -1514,7 +1520,13 @@ impl ParseBe<Ospfv3LinkLsa> for Ospfv3LinkLsa {
         let mut ll_arr = [0u8; 16];
         ll_arr.copy_from_slice(ll_bytes);
         let (mut input, num_prefixes) = be_u32(input)?;
-        let mut prefixes = Vec::with_capacity(num_prefixes as usize);
+        // Cap the pre-allocation against a forged prefix count (each prefix
+        // entry is at least 4 octets on the wire).
+        let mut prefixes = Vec::with_capacity(packet_utils::bounded_capacity(
+            num_prefixes as usize,
+            input.len(),
+            4,
+        ));
         for _ in 0..num_prefixes {
             let (rest, p) = Ospfv3LinkLsaPrefix::parse_be(input)?;
             prefixes.push(p);
@@ -2984,7 +2996,13 @@ impl Ospfv3LsUpdate {
 impl ParseBe<Ospfv3LsUpdate> for Ospfv3LsUpdate {
     fn parse_be(input: &[u8]) -> IResult<&[u8], Ospfv3LsUpdate> {
         let (mut input, num) = be_u32(input)?;
-        let mut lsas = Vec::with_capacity(num as usize);
+        // Cap the pre-allocation: `num` is wire-supplied and each LSA is at
+        // least a header, so a forged count cannot force a huge allocation.
+        let mut lsas = Vec::with_capacity(packet_utils::bounded_capacity(
+            num as usize,
+            input.len(),
+            OSPFV3_LSA_HEADER_LEN as usize,
+        ));
         for _ in 0..num {
             // Capture the slice this LSA consumes so transit floods
             // can re-emit it byte-for-byte — same rationale as the
@@ -3399,7 +3417,9 @@ impl Ospfv3Srv6LocatorTlv {
         buf.put_u8(self.locator_length);
         buf.put_u8(self.prefix_options);
         buf.put_u32(self.metric);
-        let wire = ospfv3_prefix_wire_len(self.locator_length);
+        // Clamp to the 16-byte IPv6 octet buffer; a well-formed locator_length
+        // (<= 128) never exceeds this, but guard a mis-constructed value.
+        let wire = ospfv3_prefix_wire_len(self.locator_length).min(16);
         buf.put_slice(&self.locator.octets()[..wire]);
         for sub in &self.subs {
             sub.emit(buf);
@@ -3412,6 +3432,14 @@ impl Ospfv3Srv6LocatorTlv {
         let (input, locator_length) = be_u8(input)?;
         let (input, prefix_options) = be_u8(input)?;
         let (input, metric) = be_u32(input)?;
+        // A locator is an IPv6 value; a length beyond 128 bits would overrun
+        // the 16-byte buffer below, so reject it as malformed.
+        if locator_length > 128 {
+            return Err(nom::Err::Error(nom::error::make_error(
+                input,
+                nom::error::ErrorKind::Verify,
+            )));
+        }
         let wire = ospfv3_prefix_wire_len(locator_length);
         let (mut input, raw) = take(wire)(input)?;
         let mut octets = [0u8; 16];
@@ -3523,6 +3551,33 @@ fn parse_ipv6_sid(input: &[u8]) -> IResult<&[u8], Ipv6Addr> {
 mod tests {
     use super::*;
     use crate::OspfType;
+
+    #[test]
+    fn srv6_locator_tlv_rejects_oversized_locator_length() {
+        // locator_length = 200 (> 128) would overrun the 16-byte IPv6 buffer;
+        // it must be rejected, not panic (regression for the parse panic).
+        let mut bytes = vec![0u8, 0u8, 200u8, 0u8]; // route_type, algo, loc_len, prefix_opts
+        bytes.extend_from_slice(&[0, 0, 0, 0]); // metric
+        bytes.extend_from_slice(&[0u8; 20]); // would-be locator bytes
+        assert!(Ospfv3Srv6LocatorTlv::parse_be(&bytes).is_err());
+    }
+
+    #[test]
+    fn ls_update_clamps_hostile_advertisement_count() {
+        // # Advertisements = 0xFFFFFFFF with an empty body must error out
+        // gracefully, not pre-allocate ~gigabytes (Vec::with_capacity DoS).
+        let bytes = [0xFFu8, 0xFF, 0xFF, 0xFF];
+        assert!(Ospfv3LsUpdate::parse_be(&bytes).is_err());
+    }
+
+    #[test]
+    fn link_lsa_clamps_hostile_prefix_count() {
+        // 20 header octets (priority + options + link-local) then a forged
+        // 4-billion prefix count and no prefixes: must error, not pre-allocate.
+        let mut bytes = vec![0u8; 20];
+        bytes.extend_from_slice(&[0xFF, 0xFF, 0xFF, 0xFF]);
+        assert!(Ospfv3LinkLsa::parse_be(&bytes).is_err());
+    }
 
     fn make_hello() -> Ospfv3Hello {
         let mut options = Ospfv3Options::new();

--- a/crates/packet-utils/src/bounded_capacity.rs
+++ b/crates/packet-utils/src/bounded_capacity.rs
@@ -1,0 +1,38 @@
+/// Cap a wire-supplied element count before using it as a `Vec::with_capacity`
+/// argument, so a forged count field cannot trigger a huge eager allocation.
+///
+/// A parser that reads an element count from the packet and then pre-allocates
+/// `Vec::with_capacity(count)` is exposed to a denial-of-service: a tiny packet
+/// can declare a 4-billion element count and force a multi-gigabyte reservation
+/// before the parse loop ever runs. Since each element occupies at least
+/// `min_entry` bytes on the wire, an input with `remaining` bytes left can hold
+/// at most `remaining / min_entry` elements; any larger `count` is clamped to
+/// that bound. Well-formed packets keep their exact-fit pre-allocation (their
+/// count never exceeds the bound); a hostile count only reserves what the packet
+/// could actually contain.
+pub fn bounded_capacity(count: usize, remaining: usize, min_entry: usize) -> usize {
+    count.min(remaining / min_entry.max(1))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::bounded_capacity;
+
+    #[test]
+    fn keeps_legitimate_count() {
+        // 3 elements, 30 bytes remaining, 4-byte minimum entry -> plenty of room.
+        assert_eq!(bounded_capacity(3, 30, 4), 3);
+    }
+
+    #[test]
+    fn clamps_hostile_count() {
+        // A forged u32 count with a near-empty body clamps to what fits.
+        assert_eq!(bounded_capacity(0xFFFF_FFFF, 8, 4), 2);
+        assert_eq!(bounded_capacity(0xFFFF_FFFF, 0, 20), 0);
+    }
+
+    #[test]
+    fn min_entry_zero_does_not_divide_by_zero() {
+        assert_eq!(bounded_capacity(5, 40, 0), 5);
+    }
+}

--- a/crates/packet-utils/src/lib.rs
+++ b/crates/packet-utils/src/lib.rs
@@ -1,5 +1,6 @@
 mod admin_group;
 mod algo;
+mod bounded_capacity;
 mod many0;
 mod safe_split_at;
 mod sid_label;
@@ -7,6 +8,7 @@ mod util;
 
 pub use admin_group::*;
 pub use algo::*;
+pub use bounded_capacity::*;
 pub use many0::*;
 pub use safe_split_at::*;
 pub use sid_label::*;


### PR DESCRIPTION
## Summary

The OSPFv2/v3 parsers in `ospf-packet` process untrusted network bytes, so a panic or an unbounded allocation on malformed input is a single-packet remote DoS. This fixes three such paths (found in the recent crate code review):

- **Extended-Prefix TLV** (`parser.rs`): a wire `prefix_len > 32` drove a copy loop past a fixed `[u8; 4]` buffer → index-out-of-bounds panic. Now rejected as malformed.
- **SRv6 Locator TLV** (`v3.rs`): a wire `locator_length > 128` made the prefix-wire-length exceed the 16-byte `Ipv6Addr` buffer on both parse and emit → panic. Parse now rejects `locator_length > 128`; emit clamps the slice to 16.
- **LS Update / Link-LSA / Intra-Area-Prefix-LSA** (`parser.rs`, `v3.rs`): a wire-supplied element count was passed straight to `Vec::with_capacity`, so a tiny packet declaring a ~4-billion count forced a multi-GB eager allocation and aborted the process. New `packet_utils::bounded_capacity()` caps the reservation at what the remaining input could actually hold; used at all four sites.

`bounded_capacity` lives in `packet-utils` next to its sibling `safe_split_at`, so the four call sites share one implementation.

## Test plan

- Added regression tests for each path (oversized `prefix_len` → `Err`, oversized `locator_length` → `Err`, hostile counts → graceful `Err` instead of allocation-abort), a valid-prefix round-trip, and unit tests for the helper.
- `cargo test -p ospf-packet -p packet-utils` — all pass.
- `cargo fmt` applied; `cargo clippy --workspace` — clean.

Generated with [Claude Code](https://claude.com/claude-code)