### PR TITLE
pim: IGMP v2/v3 membership tracking and querier election

### DIFF
--- a/bdd/tests/configs/pim_igmp/r1.yaml
+++ b/bdd/tests/configs/pim_igmp/r1.yaml
@@ -1,0 +1,16 @@
+interface:
+- if-name: eth1
+  ipv4:
+    address: 10.1.13.1/24
+- if-name: eth3
+  ipv4:
+    address: 10.1.14.1/24
+router:
+  pim:
+    interface:
+    - if-name: eth1
+      igmp:
+        enabled: true
+    - if-name: eth3
+      igmp:
+        enabled: true

--- a/bdd/tests/configs/pim_igmp/r2.yaml
+++ b/bdd/tests/configs/pim_igmp/r2.yaml
@@ -1,0 +1,10 @@
+interface:
+- if-name: eth2
+  ipv4:
+    address: 10.1.13.2/24
+router:
+  pim:
+    interface:
+    - if-name: eth2
+      igmp:
+        enabled: true

--- a/bdd/tests/cucumber.rs
+++ b/bdd/tests/cucumber.rs
@@ -811,6 +811,26 @@ async fn run_exec_command(world: &mut World, command: String, namespace: String)
 /// the vtyctl `clear` surface), this reaches the real `ip`/`bridge`
 /// tools — used to build the EVPN snooping bridge and inject IGMP/MLD
 /// membership for the SMET tests.
+/// Spawn a long-running command inside a namespace WITHOUT waiting for
+/// it (whitespace argv, no shell) — background traffic sources and
+/// receivers for multicast tests (e.g. a socat IGMP joiner). The child
+/// is detached and namespace deletion does not kill it, so wrap it in
+/// `timeout N` sized to the scenario. A short pause lets the process
+/// start (and e.g. emit its IGMP join) before the next step asserts.
+#[when(expr = "I spawn {string} in namespace {string}")]
+async fn spawn_background_command(world: &mut World, command: String, namespace: String) {
+    let scoped = world.ns(&namespace);
+    let parts: Vec<&str> = command.split_whitespace().collect();
+    let (cmd, args) = parts
+        .split_first()
+        .unwrap_or_else(|| panic!("empty command in 'I spawn' for {}", scoped));
+    let _child = netns::spawn_in_netns(&scoped, cmd, args)
+        .await
+        .unwrap_or_else(|e| panic!("Failed to spawn '{}' in {}: {}", command, scoped, e));
+    tokio::time::sleep(tokio::time::Duration::from_millis(500)).await;
+    println!("✓ Spawned '{}' in namespace {}", command, scoped);
+}
+
 #[when(expr = "I execute {string} in namespace {string}")]
 async fn execute_command(world: &mut World, command: String, namespace: String) {
     let scoped = world.ns(&namespace);

--- a/bdd/tests/features/pim_igmp.feature
+++ b/bdd/tests/features/pim_igmp.feature
@@ -1,0 +1,52 @@
+@serial
+@pim_igmp
+Feature: IGMP membership tracking and querier election
+  As a network operator
+  I want a zebra-rs router to learn IGMP group membership from
+  attached hosts and to elect a single querier per LAN, so the
+  receiver side of the multicast control plane works before PIM
+  trees are built on top of it.
+
+  r1 runs IGMP on two links: toward r2 (router-to-router, exercising
+  querier election — the lower address 10.1.13.1 must win and r2 must
+  step down to Non-Querier) and toward host h1, which joins group
+  239.1.1.1 with a socat receiver (the kernel emits an IGMPv3 report);
+  r1 must show the group in EXCLUDE mode.
+
+  Test Topology:
+  ```
+    r2 (10.1.13.2) --- eth2/eth1 --- r1 (10.1.13.1)
+                                     r1 (10.1.14.1) --- eth3/eth4 --- h1 (10.1.14.2, receiver)
+  ```
+
+  Scenario: Querier election and receiver join
+    Given a clean test environment
+    When I create namespace "r1"
+    And I create namespace "r2"
+    And I create namespace "h1"
+    And I connect namespace "r1" interface "eth1" to namespace "r2" interface "eth2"
+    And I connect namespace "r1" interface "eth3" to namespace "h1" interface "eth4"
+    And I start zebra-rs in namespace "r1"
+    And I start zebra-rs in namespace "r2"
+    And I apply config "r1.yaml" to namespace "r1"
+    And I apply config "r2.yaml" to namespace "r2"
+    And I add address "10.1.14.2/24" to interface "eth4" in namespace "h1"
+
+    # Querier election on the r1-r2 link: the lower address wins.
+    Then show command "show igmp interface" in namespace "r1" should eventually contain "Querier"
+    And show command "show igmp interface" in namespace "r1" should not contain "Non-Querier"
+    And show command "show igmp interface" in namespace "r2" should eventually contain "Non-Querier"
+
+    # h1 joins 239.1.1.1 (kernel sends an IGMPv3 report to 224.0.0.22);
+    # r1 learns the group in EXCLUDE (any-source) mode.
+    When I spawn "timeout 120 socat -u UDP4-RECV:5001,ip-add-membership=239.1.1.1:eth4 /dev/null" in namespace "h1"
+    Then show command "show igmp groups" in namespace "r1" should eventually contain "239.1.1.1"
+    And show command "show igmp groups" in namespace "r1" should contain "EXCLUDE"
+
+  Scenario: Teardown topology
+    When I stop zebra-rs in namespace "r1"
+    And I stop zebra-rs in namespace "r2"
+    And I delete namespace "r1"
+    And I delete namespace "r2"
+    And I delete namespace "h1"
+    Then the test environment should be clean

--- a/zebra-rs/src/config/manager.rs
+++ b/zebra-rs/src/config/manager.rs
@@ -1372,8 +1372,10 @@ fn is_ebpf(paths: &[CommandPath]) -> bool {
     paths.iter().any(|x| x.name == "ebpf")
 }
 
+/// `show pim ...` and `show igmp ...` — both served by the PIM task
+/// (IGMP membership tracking lives inside the PIM module).
 fn is_pim(paths: &[CommandPath]) -> bool {
-    paths.iter().any(|x| x.name == "pim")
+    paths.iter().any(|x| x.name == "pim" || x.name == "igmp")
 }
 
 fn is_policy(paths: &[CommandPath]) -> bool {

--- a/zebra-rs/src/config/pim.rs
+++ b/zebra-rs/src/config/pim.rs
@@ -1,6 +1,6 @@
 use crate::context::ProtoContext;
 use crate::pim::inst;
-use crate::pim::socket::pim_socket;
+use crate::pim::socket::{igmp_socket, pim_socket};
 use crate::rib;
 
 use super::ConfigManager;
@@ -14,20 +14,29 @@ pub fn spawn_pim(config: &ConfigManager) {
     if config.protocol_tasks.borrow().contains_key("pim") {
         return;
     }
-    // Open the raw protocol-103 socket before `subscribe_to_rib` so a
-    // socket failure (missing CAP_NET_RAW) doesn't leave a dead RibRx
-    // receiver queued in RIB's inbox — see `spawn_nd`. The probe
-    // context is default-table, so no VRF binding is involved.
-    let sock = match pim_socket(&ProtoContext::default_table_no_rib()) {
+    // Open both raw sockets (protocol 103 + IGMP) before
+    // `subscribe_to_rib` so a socket failure (missing CAP_NET_RAW)
+    // doesn't leave a dead RibRx receiver queued in RIB's inbox — see
+    // `spawn_nd`. The probe context is default-table, so no VRF
+    // binding is involved.
+    let probe = ProtoContext::default_table_no_rib();
+    let sock = match pim_socket(&probe) {
         Ok(sock) => sock,
         Err(e) => {
             tracing::warn!("pim: not started ({e}); PIM disabled");
             return;
         }
     };
+    let igmp_sock = match igmp_socket(&probe) {
+        Ok(sock) => sock,
+        Err(e) => {
+            tracing::warn!("pim: not started (igmp socket: {e}); PIM disabled");
+            return;
+        }
+    };
     let (rib_client, rib_rx) = config.subscribe_to_rib("pim");
     let ctx = ProtoContext::default_table(rib_client);
-    let pim = inst::Pim::new(ctx, sock, rib_rx);
+    let pim = inst::Pim::new(ctx, sock, igmp_sock, rib_rx);
     config.subscribe("pim", pim.cm.tx.clone());
     config.subscribe_show("pim", pim.show.tx.clone());
     let task = inst::serve(pim);

--- a/zebra-rs/src/pim/config.rs
+++ b/zebra-rs/src/pim/config.rs
@@ -22,6 +22,16 @@ impl Pim {
             config_hello_holdtime,
         );
         self.callback_add("/router/pim/interface/passive", config_passive);
+        self.callback_add("/router/pim/interface/igmp/enabled", config_igmp_enabled);
+        self.callback_add("/router/pim/interface/igmp/version", config_igmp_version);
+        self.callback_add(
+            "/router/pim/interface/igmp/query-interval",
+            config_igmp_query_interval,
+        );
+        self.callback_add(
+            "/router/pim/interface/igmp/query-max-response-time",
+            config_igmp_query_max_resp,
+        );
     }
 
     fn callback_add(&mut self, path: &str, cb: Callback) {
@@ -89,6 +99,62 @@ fn config_passive(pim: &mut Pim, mut args: Args, op: ConfigOp) -> Option<()> {
         pim.if_config.entry(name.clone()).or_default().passive = Some(passive);
     } else if let Some(config) = pim.if_config.get_mut(&name) {
         config.passive = None;
+    }
+    pim.reconcile_by_name(&name);
+    Some(())
+}
+
+fn config_igmp_enabled(pim: &mut Pim, mut args: Args, op: ConfigOp) -> Option<()> {
+    let name = args.string()?;
+    if op.is_set() {
+        let enabled = args.boolean()?;
+        pim.if_config.entry(name.clone()).or_default().igmp.enabled = Some(enabled);
+    } else if let Some(config) = pim.if_config.get_mut(&name) {
+        config.igmp.enabled = None;
+    }
+    pim.reconcile_by_name(&name);
+    Some(())
+}
+
+fn config_igmp_version(pim: &mut Pim, mut args: Args, op: ConfigOp) -> Option<()> {
+    let name = args.string()?;
+    if op.is_set() {
+        let version = args.u8()?;
+        pim.if_config.entry(name.clone()).or_default().igmp.version = Some(version);
+    } else if let Some(config) = pim.if_config.get_mut(&name) {
+        config.igmp.version = None;
+    }
+    pim.reconcile_by_name(&name);
+    Some(())
+}
+
+fn config_igmp_query_interval(pim: &mut Pim, mut args: Args, op: ConfigOp) -> Option<()> {
+    let name = args.string()?;
+    if op.is_set() {
+        let interval = args.u16()?;
+        pim.if_config
+            .entry(name.clone())
+            .or_default()
+            .igmp
+            .query_interval = Some(interval);
+    } else if let Some(config) = pim.if_config.get_mut(&name) {
+        config.igmp.query_interval = None;
+    }
+    pim.reconcile_by_name(&name);
+    Some(())
+}
+
+fn config_igmp_query_max_resp(pim: &mut Pim, mut args: Args, op: ConfigOp) -> Option<()> {
+    let name = args.string()?;
+    if op.is_set() {
+        let max_resp = args.u16()?;
+        pim.if_config
+            .entry(name.clone())
+            .or_default()
+            .igmp
+            .query_max_resp = Some(max_resp);
+    } else if let Some(config) = pim.if_config.get_mut(&name) {
+        config.igmp.query_max_resp = None;
     }
     pim.reconcile_by_name(&name);
     Some(())

--- a/zebra-rs/src/pim/igmp/mod.rs
+++ b/zebra-rs/src/pim/igmp/mod.rs
@@ -1,0 +1,493 @@
+//! IGMP v2/v3 router-side membership tracking (RFC 2236 / RFC 3376):
+//! querier election, per-interface group and source tables, query
+//! transmission. Expiry is deadline-driven: every timed state stores
+//! an `Instant`, [`Pim::igmp_next_wakeup`] feeds the event loop's
+//! sleep arm, and [`Pim::igmp_tick`] processes everything due — no
+//! per-source timer tasks. Membership feeds the TIB bridge from the
+//! SSM phase on.
+
+use std::collections::BTreeMap;
+use std::net::Ipv4Addr;
+use std::time::{Duration, Instant};
+
+use pim_packet::{IgmpGroupMessage, IgmpGroupRecord, IgmpPacket, IgmpRecordType, IgmpV3Query};
+use tokio::sync::mpsc::UnboundedSender;
+
+use super::inst::{IgmpSend, Pim};
+use super::link::LinkConfig;
+use super::socket::IGMP_ALL_HOSTS;
+
+/// Robustness Variable (RFC 3376 §8.1). Fixed at the protocol
+/// default; a config knob can arrive later.
+pub const IGMP_ROBUSTNESS: u32 = 2;
+
+/// Last Member Query Time: LMQC (= robustness) × LMQI (1 s).
+const LAST_MEMBER_QUERY_TIME: Duration = Duration::from_secs(2);
+
+/// Per-interface IGMP configuration, carried inside
+/// [`super::link::LinkConfig`].
+#[derive(Debug, Clone, Default)]
+pub struct IgmpConfig {
+    pub enabled: Option<bool>,
+    pub version: Option<u8>,
+    pub query_interval: Option<u16>,
+    pub query_max_resp: Option<u16>,
+}
+
+impl IgmpConfig {
+    pub fn enabled(&self) -> bool {
+        self.enabled.unwrap_or(false)
+    }
+
+    pub fn version(&self) -> u8 {
+        self.version.unwrap_or(3)
+    }
+
+    /// Query Interval, seconds (RFC 3376 §8.2).
+    pub fn query_interval(&self) -> u16 {
+        self.query_interval.unwrap_or(125)
+    }
+
+    /// Query Response Interval, seconds (RFC 3376 §8.3).
+    pub fn query_max_resp(&self) -> u16 {
+        self.query_max_resp.unwrap_or(10)
+    }
+
+    /// Group Membership Interval: RV × QI + QRI (RFC 3376 §8.4).
+    pub fn gmi(&self) -> Duration {
+        Duration::from_secs(
+            IGMP_ROBUSTNESS as u64 * self.query_interval() as u64 + self.query_max_resp() as u64,
+        )
+    }
+
+    /// Other Querier Present Interval: RV × QI + QRI/2 (RFC 3376 §8.5).
+    pub fn oqpi(&self) -> Duration {
+        Duration::from_secs(
+            IGMP_ROBUSTNESS as u64 * self.query_interval() as u64
+                + self.query_max_resp() as u64 / 2,
+        )
+    }
+
+    /// Startup Query Interval: QI/4 (RFC 3376 §8.6).
+    pub fn startup_interval(&self) -> Duration {
+        Duration::from_secs((self.query_interval() as u64 / 4).max(1))
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum FilterMode {
+    Include,
+    Exclude,
+}
+
+pub struct IgmpGroup {
+    pub filter_mode: FilterMode,
+    /// Group timer — EXCLUDE mode only (RFC 3376 §6.5).
+    pub expires: Option<Instant>,
+    /// INCLUDE sources with their source timers.
+    pub sources: BTreeMap<Ipv4Addr, Instant>,
+    /// Older-version-host-present: a v1/v2 report was heard; while
+    /// running, v3 source semantics are suspended for the group.
+    pub v2_host_until: Option<Instant>,
+    pub last_reporter: Option<Ipv4Addr>,
+    pub uptime: Instant,
+}
+
+impl IgmpGroup {
+    fn new(now: Instant, filter_mode: FilterMode) -> Self {
+        Self {
+            filter_mode,
+            expires: None,
+            sources: BTreeMap::new(),
+            v2_host_until: None,
+            last_reporter: None,
+            uptime: now,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum QuerierState {
+    Querier,
+    NonQuerier { querier: Ipv4Addr, until: Instant },
+}
+
+/// Runtime IGMP state for one interface, present while IGMP is
+/// enabled and the interface is usable.
+pub struct IgmpIf {
+    pub querier: QuerierState,
+    /// Startup general queries left to send at the startup interval.
+    startup_remaining: u8,
+    /// Next general-query transmission (meaningful as Querier only).
+    next_query: Instant,
+    pub groups: BTreeMap<Ipv4Addr, IgmpGroup>,
+}
+
+impl IgmpIf {
+    pub fn new(now: Instant) -> Self {
+        Self {
+            querier: QuerierState::Querier,
+            startup_remaining: IGMP_ROBUSTNESS as u8,
+            next_query: now,
+            groups: BTreeMap::new(),
+        }
+    }
+}
+
+/// Build and queue a general (group `None`) or group-specific query.
+fn send_query(
+    tx: &UnboundedSender<IgmpSend>,
+    cfg: &LinkConfig,
+    ifindex: u32,
+    group: Option<Ipv4Addr>,
+) {
+    // Max Resp is in units of 1/10 s in both v2 and v3; group-specific
+    // queries use the Last Member Query Interval (1 s).
+    let max_resp = match group {
+        None => (cfg.igmp.query_max_resp() as u32 * 10).min(250) as u8,
+        Some(_) => 10,
+    };
+    let dst = group.unwrap_or(IGMP_ALL_HOSTS);
+    let packet = if cfg.igmp.version() == 2 {
+        IgmpPacket::QueryV2(IgmpGroupMessage {
+            max_resp,
+            group: group.unwrap_or(Ipv4Addr::UNSPECIFIED),
+        })
+    } else {
+        IgmpPacket::QueryV3(IgmpV3Query {
+            max_resp_code: max_resp,
+            group: group.unwrap_or(Ipv4Addr::UNSPECIFIED),
+            suppress: false,
+            qrv: IGMP_ROBUSTNESS as u8,
+            // QQIC values >= 128 use exponential encoding; clamp
+            // instead until large intervals are needed.
+            qqic: cfg.igmp.query_interval().min(127) as u8,
+            sources: vec![],
+        })
+    };
+    let _ = tx.send(IgmpSend {
+        packet,
+        ifindex,
+        dst,
+    });
+}
+
+impl Pim {
+    /// Earliest IGMP deadline across all interfaces — the event
+    /// loop's sleep target. `None` parks the arm forever.
+    pub(crate) fn igmp_next_wakeup(&self) -> Option<Instant> {
+        let mut earliest: Option<Instant> = None;
+        let mut consider = |t: Instant| {
+            earliest = Some(earliest.map_or(t, |e| e.min(t)));
+        };
+        for link in self.links.values() {
+            let Some(igmp) = link.igmp.as_ref() else {
+                continue;
+            };
+            match igmp.querier {
+                QuerierState::Querier => consider(igmp.next_query),
+                QuerierState::NonQuerier { until, .. } => consider(until),
+            }
+            for group in igmp.groups.values() {
+                if let Some(t) = group.expires {
+                    consider(t);
+                }
+                if let Some(t) = group.v2_host_until {
+                    consider(t);
+                }
+                for t in group.sources.values() {
+                    consider(*t);
+                }
+            }
+        }
+        earliest
+    }
+
+    /// Process every deadline that is due. Must leave no deadline at
+    /// or before `now` behind, or the sleep arm busy-loops.
+    pub(crate) fn igmp_tick(&mut self, now: Instant) {
+        let targets: Vec<(u32, String)> = self
+            .links
+            .values()
+            .filter(|l| l.igmp.is_some())
+            .map(|l| (l.ifindex, l.name.clone()))
+            .collect();
+        for (ifindex, name) in targets {
+            let cfg = self.link_config(&name);
+            let Some(link) = self.links.get_mut(&ifindex) else {
+                continue;
+            };
+            let Some(igmp) = link.igmp.as_mut() else {
+                continue;
+            };
+
+            if let QuerierState::NonQuerier { until, .. } = igmp.querier
+                && until <= now
+            {
+                tracing::info!("igmp: {} other querier expired, taking over", name);
+                igmp.querier = QuerierState::Querier;
+                igmp.next_query = now;
+            }
+
+            if igmp.querier == QuerierState::Querier && igmp.next_query <= now {
+                send_query(&self.igmp_send_tx, &cfg, ifindex, None);
+                let interval = if igmp.startup_remaining > 0 {
+                    igmp.startup_remaining -= 1;
+                    cfg.igmp.startup_interval()
+                } else {
+                    Duration::from_secs(cfg.igmp.query_interval() as u64)
+                };
+                igmp.next_query = now + interval;
+            }
+
+            let mut expired: Vec<Ipv4Addr> = vec![];
+            for (group_addr, group) in igmp.groups.iter_mut() {
+                if let Some(t) = group.v2_host_until
+                    && t <= now
+                {
+                    group.v2_host_until = None;
+                }
+                group.sources.retain(|_, exp| *exp > now);
+                if group.filter_mode == FilterMode::Exclude
+                    && let Some(exp) = group.expires
+                    && exp <= now
+                {
+                    if group.sources.is_empty() {
+                        expired.push(*group_addr);
+                        continue;
+                    }
+                    // RFC 3376 §6.5: EXCLUDE timer expiry with live
+                    // sources reverts the group to INCLUDE.
+                    group.filter_mode = FilterMode::Include;
+                    group.expires = None;
+                }
+                if group.filter_mode == FilterMode::Include && group.sources.is_empty() {
+                    expired.push(*group_addr);
+                }
+            }
+            for group_addr in expired {
+                igmp.groups.remove(&group_addr);
+                tracing::info!("igmp: group {} expired on {}", group_addr, name);
+            }
+        }
+    }
+
+    pub(crate) fn igmp_recv(&mut self, ifindex: u32, src: Ipv4Addr, packet: IgmpPacket) {
+        let Some(link) = self.links.get(&ifindex) else {
+            return;
+        };
+        if link.igmp.is_none() || link.is_my_addr(&src) {
+            return;
+        }
+        let name = link.name.clone();
+        let cfg = self.link_config(&name);
+        let now = Instant::now();
+        match packet {
+            IgmpPacket::QueryV2(_) | IgmpPacket::QueryV3(_) => {
+                self.igmp_other_querier(ifindex, &name, src, &cfg, now);
+            }
+            IgmpPacket::ReportV1(msg) | IgmpPacket::ReportV2(msg) => {
+                self.igmp_v2_report(ifindex, src, msg.group, &cfg, now);
+            }
+            IgmpPacket::LeaveV2(msg) => {
+                self.igmp_leave(ifindex, msg.group, &cfg, now);
+            }
+            IgmpPacket::ReportV3(report) => {
+                for record in report.records {
+                    self.igmp_apply_record(ifindex, src, &record, &cfg, now);
+                }
+            }
+            IgmpPacket::Unknown { typ, .. } => {
+                tracing::debug!("igmp: unknown type {:#04x} from {} ignored", typ, src);
+            }
+        }
+    }
+
+    /// Querier election (RFC 3376 §6.6.2): a query from a lower
+    /// address demotes us / refreshes the other-querier timer.
+    fn igmp_other_querier(
+        &mut self,
+        ifindex: u32,
+        name: &str,
+        src: Ipv4Addr,
+        cfg: &LinkConfig,
+        now: Instant,
+    ) {
+        let Some(link) = self.links.get_mut(&ifindex) else {
+            return;
+        };
+        let Some(my_addr) = link.primary_addr() else {
+            return;
+        };
+        if src.is_unspecified() || src >= my_addr {
+            return;
+        }
+        let Some(igmp) = link.igmp.as_mut() else {
+            return;
+        };
+        if igmp.querier == QuerierState::Querier {
+            tracing::info!("igmp: {} lost querier election to {}", name, src);
+        }
+        igmp.querier = QuerierState::NonQuerier {
+            querier: src,
+            until: now + cfg.igmp.oqpi(),
+        };
+    }
+
+    /// v1/v2 membership report: EXCLUDE {} semantics plus the
+    /// older-version-host-present marker.
+    fn igmp_v2_report(
+        &mut self,
+        ifindex: u32,
+        src: Ipv4Addr,
+        group_addr: Ipv4Addr,
+        cfg: &LinkConfig,
+        now: Instant,
+    ) {
+        if !group_addr.is_multicast() {
+            return;
+        }
+        let Some(igmp) = self.link_igmp_mut(ifindex) else {
+            return;
+        };
+        let group = igmp
+            .groups
+            .entry(group_addr)
+            .or_insert_with(|| IgmpGroup::new(now, FilterMode::Exclude));
+        group.filter_mode = FilterMode::Exclude;
+        group.expires = Some(now + cfg.igmp.gmi());
+        group.v2_host_until = Some(now + cfg.igmp.gmi());
+        if !src.is_unspecified() {
+            group.last_reporter = Some(src);
+        }
+    }
+
+    /// v2 Leave (RFC 2236 §4): as querier, lower the group timer to
+    /// LMQT and send a group-specific query.
+    fn igmp_leave(&mut self, ifindex: u32, group_addr: Ipv4Addr, cfg: &LinkConfig, now: Instant) {
+        let mut query = false;
+        {
+            let Some(igmp) = self.link_igmp_mut(ifindex) else {
+                return;
+            };
+            let is_querier = igmp.querier == QuerierState::Querier;
+            let Some(group) = igmp.groups.get_mut(&group_addr) else {
+                return;
+            };
+            if group.filter_mode == FilterMode::Exclude {
+                let lmqt = now + LAST_MEMBER_QUERY_TIME;
+                group.expires = Some(group.expires.map_or(lmqt, |e| e.min(lmqt)));
+                query = is_querier;
+            }
+        }
+        if query {
+            send_query(&self.igmp_send_tx, cfg, ifindex, Some(group_addr));
+        }
+    }
+
+    /// Apply one IGMPv3 group record (RFC 3376 §6.4, reduced to the
+    /// state this phase tracks: membership presence and INCLUDE
+    /// sources; retransmission schedules are simplified to a single
+    /// group-specific query).
+    fn igmp_apply_record(
+        &mut self,
+        ifindex: u32,
+        src: Ipv4Addr,
+        record: &IgmpGroupRecord,
+        cfg: &LinkConfig,
+        now: Instant,
+    ) {
+        if !record.group.is_multicast() {
+            return;
+        }
+        let gmi = cfg.igmp.gmi();
+        let lmqt = now + LAST_MEMBER_QUERY_TIME;
+        let mut query = false;
+        {
+            let Some(igmp) = self.link_igmp_mut(ifindex) else {
+                return;
+            };
+            let is_querier = igmp.querier == QuerierState::Querier;
+            use IgmpRecordType::*;
+            match record.rec_type {
+                ModeIsExclude | ChangeToExclude => {
+                    let group = igmp
+                        .groups
+                        .entry(record.group)
+                        .or_insert_with(|| IgmpGroup::new(now, FilterMode::Exclude));
+                    group.filter_mode = FilterMode::Exclude;
+                    group.expires = Some(now + gmi);
+                    if !src.is_unspecified() {
+                        group.last_reporter = Some(src);
+                    }
+                }
+                ModeIsInclude | AllowNewSources => {
+                    if record.sources.is_empty() {
+                        return;
+                    }
+                    let group = igmp
+                        .groups
+                        .entry(record.group)
+                        .or_insert_with(|| IgmpGroup::new(now, FilterMode::Include));
+                    for source in &record.sources {
+                        group.sources.insert(*source, now + gmi);
+                    }
+                    if !src.is_unspecified() {
+                        group.last_reporter = Some(src);
+                    }
+                }
+                ChangeToInclude => {
+                    let group = igmp
+                        .groups
+                        .entry(record.group)
+                        .or_insert_with(|| IgmpGroup::new(now, FilterMode::Include));
+                    for source in &record.sources {
+                        group.sources.insert(*source, now + gmi);
+                    }
+                    if !src.is_unspecified() {
+                        group.last_reporter = Some(src);
+                    }
+                    if record.sources.is_empty() {
+                        // TO_IN {} is the v3 leave. In EXCLUDE mode
+                        // lower the group timer; in INCLUDE mode age
+                        // the remaining sources out at LMQT.
+                        match group.filter_mode {
+                            FilterMode::Exclude => {
+                                group.expires = Some(group.expires.map_or(lmqt, |e| e.min(lmqt)));
+                            }
+                            FilterMode::Include => {
+                                for exp in group.sources.values_mut() {
+                                    *exp = (*exp).min(lmqt);
+                                }
+                            }
+                        }
+                        query = is_querier;
+                    }
+                }
+                BlockOldSources => {
+                    let Some(group) = igmp.groups.get_mut(&record.group) else {
+                        return;
+                    };
+                    if group.filter_mode == FilterMode::Include {
+                        for source in &record.sources {
+                            if let Some(exp) = group.sources.get_mut(source) {
+                                *exp = (*exp).min(lmqt);
+                            }
+                        }
+                        query = is_querier;
+                    }
+                }
+                Unknown(t) => {
+                    tracing::debug!("igmp: unknown v3 record type {} ignored", t);
+                }
+            }
+        }
+        if query {
+            send_query(&self.igmp_send_tx, cfg, ifindex, Some(record.group));
+        }
+    }
+
+    fn link_igmp_mut(&mut self, ifindex: u32) -> Option<&mut IgmpIf> {
+        self.links.get_mut(&ifindex)?.igmp.as_mut()
+    }
+}

--- a/zebra-rs/src/pim/inst.rs
+++ b/zebra-rs/src/pim/inst.rs
@@ -11,11 +11,13 @@
 use std::collections::{BTreeMap, HashMap};
 use std::net::Ipv4Addr;
 use std::sync::Arc;
+use std::time::Instant;
 
-use pim_packet::{HelloTlv, PimHello, PimPacket, PimPayload};
+use pim_packet::{HelloTlv, IgmpPacket, PimHello, PimPacket, PimPayload};
 use socket2::Socket;
 use tokio::io::unix::AsyncFd;
 use tokio::sync::mpsc::{self, UnboundedReceiver, UnboundedSender};
+use tokio::time::sleep_until;
 
 use crate::config::{
     Args, ConfigChannel, ConfigRequest, DisplayRequest, ShowChannel, path_from_command,
@@ -25,7 +27,7 @@ use crate::rib::api::RibRx;
 
 use super::config::Callback;
 use super::link::{LinkConfig, PIM_OVERRIDE_INTERVAL_MSEC, PIM_PROPAGATION_DELAY_MSEC, PimLink};
-use super::network::{read_packet, write_packet};
+use super::network::{igmp_read_packet, igmp_write_packet, read_packet, write_packet};
 use super::socket::ALL_PIM_ROUTERS;
 
 /// `show pim ...` dispatch handler, mirroring
@@ -42,6 +44,11 @@ pub enum Message {
         src: Ipv4Addr,
         ifindex: u32,
     },
+    Igmp {
+        packet: IgmpPacket,
+        src: Ipv4Addr,
+        ifindex: u32,
+    },
     HelloTimer(u32),
     NeighborExpiry(u32, Ipv4Addr),
 }
@@ -51,6 +58,14 @@ pub enum Message {
 #[derive(Debug)]
 pub struct PimSend {
     pub packet: PimPacket,
+    pub ifindex: u32,
+    pub dst: Ipv4Addr,
+}
+
+/// Outbound IGMP message (queries) for the IGMP write task.
+#[derive(Debug)]
+pub struct IgmpSend {
+    pub packet: IgmpPacket,
     pub ifindex: u32,
     pub dst: Ipv4Addr,
 }
@@ -65,25 +80,36 @@ pub struct Pim {
     /// source of truth the reconciler compares runtime state against.
     pub if_config: BTreeMap<String, LinkConfig>,
     pub(crate) send_tx: UnboundedSender<PimSend>,
+    pub(crate) igmp_send_tx: UnboundedSender<IgmpSend>,
     rib_rx: UnboundedReceiver<RibRx>,
     pub cm: ConfigChannel,
     pub show: ShowChannel,
     pub show_cb: HashMap<String, ShowCallback>,
     pub callbacks: HashMap<String, Callback>,
     pub(crate) sock: Arc<AsyncFd<Socket>>,
+    pub(crate) igmp_sock: Arc<AsyncFd<Socket>>,
     /// RIB client context — unused until the RPF/NHT phase, kept so
     /// the spawn contract already matches the other protocols.
     #[allow(dead_code)]
     ctx: ProtoContext,
     _read_task: Task<()>,
     _write_task: Task<()>,
+    _igmp_read_task: Task<()>,
+    _igmp_write_task: Task<()>,
 }
 
 impl Pim {
-    pub fn new(ctx: ProtoContext, sock: AsyncFd<Socket>, rib_rx: UnboundedReceiver<RibRx>) -> Self {
+    pub fn new(
+        ctx: ProtoContext,
+        sock: AsyncFd<Socket>,
+        igmp_sock: AsyncFd<Socket>,
+        rib_rx: UnboundedReceiver<RibRx>,
+    ) -> Self {
         let sock = Arc::new(sock);
+        let igmp_sock = Arc::new(igmp_sock);
         let (tx, rx) = mpsc::unbounded_channel();
         let (send_tx, send_rx) = mpsc::unbounded_channel();
+        let (igmp_send_tx, igmp_send_rx) = mpsc::unbounded_channel();
 
         let read_sock = sock.clone();
         let read_tx = tx.clone();
@@ -94,6 +120,15 @@ impl Pim {
         let write_task = Task::spawn(async move {
             write_packet(write_sock, send_rx).await;
         });
+        let igmp_read_sock = igmp_sock.clone();
+        let igmp_read_tx = tx.clone();
+        let igmp_read_task = Task::spawn(async move {
+            igmp_read_packet(igmp_read_sock, igmp_read_tx).await;
+        });
+        let igmp_write_sock = igmp_sock.clone();
+        let igmp_write_task = Task::spawn(async move {
+            igmp_write_packet(igmp_write_sock, igmp_send_rx).await;
+        });
 
         let mut pim = Self {
             tx,
@@ -101,15 +136,19 @@ impl Pim {
             links: BTreeMap::new(),
             if_config: BTreeMap::new(),
             send_tx,
+            igmp_send_tx,
             rib_rx,
             cm: ConfigChannel::new(),
             show: ShowChannel::new(),
             show_cb: HashMap::new(),
             callbacks: HashMap::new(),
             sock,
+            igmp_sock,
             ctx,
             _read_task: read_task,
             _write_task: write_task,
+            _igmp_read_task: igmp_read_task,
+            _igmp_write_task: igmp_write_task,
         };
         pim.callback_build();
         pim.show_build();
@@ -127,6 +166,7 @@ impl Pim {
             self.process_rib_msg(msg);
         }
         loop {
+            let wakeup = self.igmp_next_wakeup();
             tokio::select! {
                 Some(msg) = self.rx.recv() => {
                     self.process_msg(msg);
@@ -140,6 +180,9 @@ impl Pim {
                 Some(msg) = self.show.rx.recv() => {
                     self.process_show_msg(msg).await;
                 }
+                _ = sleep_until_opt(wakeup) => {
+                    self.igmp_tick(Instant::now());
+                }
             }
         }
     }
@@ -151,6 +194,11 @@ impl Pim {
                 src,
                 ifindex,
             } => self.packet_recv(packet, src, ifindex),
+            Message::Igmp {
+                packet,
+                src,
+                ifindex,
+            } => self.igmp_recv(ifindex, src, packet),
             Message::HelloTimer(ifindex) => self.hello_send(ifindex),
             Message::NeighborExpiry(ifindex, addr) => self.neighbor_expiry(ifindex, addr),
         }
@@ -264,4 +312,13 @@ pub fn serve(mut pim: Pim) -> Task<()> {
     Task::spawn(async move {
         pim.event_loop().await;
     })
+}
+
+/// Sleep until `when`, or forever when there is no deadline — parks
+/// the select arm without waking (same helper as `crate::nd::inst`).
+async fn sleep_until_opt(when: Option<Instant>) {
+    match when {
+        Some(t) => sleep_until(t.into()).await,
+        None => std::future::pending::<()>().await,
+    }
 }

--- a/zebra-rs/src/pim/link.rs
+++ b/zebra-rs/src/pim/link.rs
@@ -11,9 +11,10 @@ use crate::context::Timer;
 use crate::rib::Link;
 use crate::rib::link::LinkAddr;
 
+use super::igmp::{IgmpConfig, IgmpIf};
 use super::inst::{Message, Pim};
 use super::neighbor::Neighbor;
-use super::socket::{pim_join_if, pim_leave_if};
+use super::socket::{igmp_join_if, igmp_leave_if, pim_join_if, pim_leave_if};
 
 pub const PIM_HELLO_PERIOD: u16 = 30;
 pub const PIM_DEFAULT_DR_PRIORITY: u32 = 1;
@@ -29,6 +30,7 @@ pub struct LinkConfig {
     pub hello_interval: Option<u16>,
     pub holdtime: Option<u16>,
     pub passive: Option<bool>,
+    pub igmp: IgmpConfig,
 }
 
 impl LinkConfig {
@@ -66,6 +68,8 @@ pub struct PimLink {
     pub dr: Option<Ipv4Addr>,
     pub nbrs: BTreeMap<Ipv4Addr, Neighbor>,
     pub hello_timer: Option<Timer>,
+    /// IGMP runtime state — `Some` while IGMP runs on this interface.
+    pub igmp: Option<IgmpIf>,
 }
 
 impl PimLink {
@@ -88,6 +92,7 @@ impl PimLink {
             dr: None,
             nbrs: BTreeMap::new(),
             hello_timer: None,
+            igmp: None,
         }
     }
 
@@ -120,8 +125,11 @@ impl Pim {
         let Some(link) = self.links.get(&ifindex) else {
             return;
         };
-        let desired =
-            self.if_config.contains_key(&link.name) && link.link_up && !link.addrs.is_empty();
+        let usable = link.link_up && !link.addrs.is_empty();
+        let entry = self.if_config.get(&link.name);
+        let desired = entry.is_some() && usable;
+        let igmp_desired = entry.map(|c| c.igmp.enabled()).unwrap_or(false) && usable;
+        let igmp_running = link.igmp.is_some();
         match (desired, link.enabled) {
             (true, false) => self.link_enable(ifindex),
             (false, true) => self.link_disable(ifindex),
@@ -134,6 +142,31 @@ impl Pim {
             }
             (false, false) => {}
         }
+        match (igmp_desired, igmp_running) {
+            (true, false) => self.igmp_enable(ifindex),
+            (false, true) => self.igmp_disable(ifindex),
+            _ => {}
+        }
+    }
+
+    fn igmp_enable(&mut self, ifindex: u32) {
+        igmp_join_if(&self.igmp_sock, ifindex);
+        let Some(link) = self.links.get_mut(&ifindex) else {
+            return;
+        };
+        link.igmp = Some(IgmpIf::new(std::time::Instant::now()));
+        tracing::info!("igmp: interface {} enabled", link.name);
+        // The startup general query goes out on the next event-loop
+        // pass — IgmpIf::new schedules it at `now`.
+    }
+
+    fn igmp_disable(&mut self, ifindex: u32) {
+        igmp_leave_if(&self.igmp_sock, ifindex);
+        let Some(link) = self.links.get_mut(&ifindex) else {
+            return;
+        };
+        link.igmp = None;
+        tracing::info!("igmp: interface {} disabled", link.name);
     }
 
     /// Re-arm a running interface's hello timer after a hello-interval

--- a/zebra-rs/src/pim/mod.rs
+++ b/zebra-rs/src/pim/mod.rs
@@ -2,6 +2,7 @@
 //! DR election. Architecture: docs/design/pim-sm-ssm-architecture.md.
 
 pub mod config;
+pub mod igmp;
 pub mod inst;
 pub mod link;
 pub mod neighbor;

--- a/zebra-rs/src/pim/network.rs
+++ b/zebra-rs/src/pim/network.rs
@@ -10,13 +10,13 @@ use std::sync::Arc;
 
 use bytes::BytesMut;
 use nix::sys::socket::{self, ControlMessageOwned, SockaddrIn};
-use pim_packet::{PimPacket, pim_verify_checksum};
+use pim_packet::{IgmpPacket, PimPacket, igmp_verify_checksum, pim_verify_checksum};
 use socket2::Socket;
 use tokio::io::Interest;
 use tokio::io::unix::AsyncFd;
 use tokio::sync::mpsc::{UnboundedReceiver, UnboundedSender};
 
-use super::inst::{Message, PimSend};
+use super::inst::{IgmpSend, Message, PimSend};
 
 pub async fn read_packet(sock: Arc<AsyncFd<Socket>>, tx: UnboundedSender<Message>) {
     let mut buf = [0u8; 1024 * 16];
@@ -87,6 +87,105 @@ pub async fn read_packet(sock: Arc<AsyncFd<Socket>>, tx: UnboundedSender<Message
         if tx.is_closed() {
             return;
         }
+    }
+}
+
+pub async fn igmp_read_packet(sock: Arc<AsyncFd<Socket>>, tx: UnboundedSender<Message>) {
+    let mut buf = [0u8; 1024 * 16];
+    let mut iov = [IoSliceMut::new(&mut buf)];
+    let mut cmsgspace = nix::cmsg_space!(libc::in_pktinfo);
+
+    loop {
+        let _ = sock
+            .async_io(Interest::READABLE, |sock| {
+                let msg = socket::recvmsg::<SockaddrIn>(
+                    sock.as_raw_fd(),
+                    &mut iov,
+                    Some(&mut cmsgspace),
+                    socket::MsgFlags::empty(),
+                )?;
+
+                let mut cmsgs = msg.cmsgs()?;
+
+                let Some(src) = msg.address else {
+                    return Err(ErrorKind::AddrNotAvailable.into());
+                };
+
+                let Some(ControlMessageOwned::Ipv4PacketInfo(pktinfo)) = cmsgs.next() else {
+                    return Err(ErrorKind::AddrNotAvailable.into());
+                };
+
+                let ifindex = pktinfo.ipi_ifindex as u32;
+
+                let Some(input) = msg.iovs().next() else {
+                    return Err(ErrorKind::UnexpectedEof.into());
+                };
+
+                // IGMP always carries the Router Alert IP option, so
+                // the IHL is essential here.
+                if input.is_empty() {
+                    return Err(ErrorKind::UnexpectedEof.into());
+                }
+                let ihl = ((input[0] & 0x0f) as usize) * 4;
+                if ihl < 20 || input.len() <= ihl {
+                    return Err(ErrorKind::InvalidData.into());
+                }
+                let igmp_input = &input[ihl..];
+
+                if !igmp_verify_checksum(igmp_input) {
+                    tracing::debug!("igmp: bad checksum from {} on ifindex {ifindex}", src.ip());
+                    return Err(ErrorKind::InvalidData.into());
+                }
+                let Ok((_, packet)) = IgmpPacket::parse_be(igmp_input) else {
+                    tracing::debug!(
+                        "igmp: malformed packet from {} on ifindex {ifindex}",
+                        src.ip()
+                    );
+                    return Err(ErrorKind::InvalidData.into());
+                };
+
+                let _ = tx.send(Message::Igmp {
+                    packet,
+                    src: src.ip(),
+                    ifindex,
+                });
+
+                Ok(())
+            })
+            .await;
+        if tx.is_closed() {
+            return;
+        }
+    }
+}
+
+pub async fn igmp_write_packet(sock: Arc<AsyncFd<Socket>>, mut rx: UnboundedReceiver<IgmpSend>) {
+    while let Some(send) = rx.recv().await {
+        let mut buf = BytesMut::new();
+        send.packet.emit(&mut buf);
+
+        let iov = [IoSlice::new(&buf)];
+        let sockaddr: SockaddrIn = SocketAddrV4::new(send.dst, 0).into();
+        let pktinfo = libc::in_pktinfo {
+            ipi_ifindex: send.ifindex as i32,
+            ipi_spec_dst: libc::in_addr { s_addr: 0 },
+            ipi_addr: libc::in_addr { s_addr: 0 },
+        };
+        let cmsg = [socket::ControlMessage::Ipv4PacketInfo(&pktinfo)];
+
+        let _ = sock
+            .async_io(Interest::WRITABLE, |sock| {
+                socket::sendmsg(
+                    sock.as_raw_fd(),
+                    &iov,
+                    &cmsg,
+                    socket::MsgFlags::empty(),
+                    Some(&sockaddr),
+                )
+                .map_err(std::io::Error::from)?;
+                Ok(())
+            })
+            .await;
     }
 }
 

--- a/zebra-rs/src/pim/show.rs
+++ b/zebra-rs/src/pim/show.rs
@@ -5,8 +5,11 @@ use std::fmt::Write;
 
 use serde::Serialize;
 
+use std::time::Instant;
+
 use crate::config::{Args, Builder};
 
+use super::igmp::{FilterMode, QuerierState};
 use super::inst::{Pim, ShowCallback};
 
 impl Pim {
@@ -18,6 +21,10 @@ impl Pim {
             .set(show_pim_interface)
             .path("/show/pim/neighbor")
             .set(show_pim_neighbor)
+            .path("/show/igmp/interface")
+            .set(show_igmp_interface)
+            .path("/show/igmp/groups")
+            .set(show_igmp_groups)
             .map();
     }
 }
@@ -134,6 +141,145 @@ struct NeighborBrief {
     generation_id: Option<u32>,
     uptime: String,
     holdtime: u64,
+}
+
+#[derive(Serialize)]
+struct IgmpInterfaceBrief {
+    interface: String,
+    state: String,
+    querier: String,
+    address: String,
+    version: u8,
+    query_interval: u16,
+    groups: usize,
+}
+
+fn show_igmp_interface(pim: &Pim, _args: Args, json: bool) -> Result<String, std::fmt::Error> {
+    let mut rows: Vec<IgmpInterfaceBrief> = vec![];
+
+    for (name, config) in pim.if_config.iter() {
+        if !config.igmp.enabled() {
+            continue;
+        }
+        let link = pim.links.values().find(|l| l.name == *name);
+        let address = link
+            .and_then(|l| l.primary_addr())
+            .map_or_else(|| "-".to_string(), |a| a.to_string());
+        let (state, querier, groups) = match link.and_then(|l| l.igmp.as_ref()) {
+            Some(igmp) => match igmp.querier {
+                QuerierState::Querier => {
+                    ("Querier".to_string(), address.clone(), igmp.groups.len())
+                }
+                QuerierState::NonQuerier { querier, .. } => (
+                    "Non-Querier".to_string(),
+                    querier.to_string(),
+                    igmp.groups.len(),
+                ),
+            },
+            None => ("Down".to_string(), "-".to_string(), 0),
+        };
+        rows.push(IgmpInterfaceBrief {
+            interface: name.clone(),
+            state,
+            querier,
+            address,
+            version: config.igmp.version(),
+            query_interval: config.igmp.query_interval(),
+            groups,
+        });
+    }
+
+    if json {
+        return Ok(serde_json::to_string(&rows).unwrap());
+    }
+
+    let mut buf = String::new();
+    buf.push_str(
+        "Interface    State        Querier          Address          Ver  Query  Groups\n",
+    );
+    for row in &rows {
+        writeln!(
+            buf,
+            "{:<13}{:<13}{:<17}{:<17}{:<5}{:<7}{}",
+            row.interface,
+            row.state,
+            row.querier,
+            row.address,
+            row.version,
+            row.query_interval,
+            row.groups,
+        )?;
+    }
+    Ok(buf)
+}
+
+#[derive(Serialize)]
+struct IgmpGroupBrief {
+    interface: String,
+    group: String,
+    mode: String,
+    sources: usize,
+    expires: String,
+    last_reporter: String,
+    uptime: String,
+}
+
+fn show_igmp_groups(pim: &Pim, _args: Args, json: bool) -> Result<String, std::fmt::Error> {
+    let now = Instant::now();
+    let mut rows: Vec<IgmpGroupBrief> = vec![];
+
+    for link in pim.links.values() {
+        let Some(igmp) = link.igmp.as_ref() else {
+            continue;
+        };
+        for (group_addr, group) in igmp.groups.iter() {
+            let expires = match group.filter_mode {
+                FilterMode::Exclude => group.expires.map_or_else(
+                    || "never".to_string(),
+                    |t| t.saturating_duration_since(now).as_secs().to_string(),
+                ),
+                FilterMode::Include => group.sources.values().max().map_or_else(
+                    || "never".to_string(),
+                    |t| t.saturating_duration_since(now).as_secs().to_string(),
+                ),
+            };
+            rows.push(IgmpGroupBrief {
+                interface: link.name.clone(),
+                group: group_addr.to_string(),
+                mode: match group.filter_mode {
+                    FilterMode::Exclude => "EXCLUDE".to_string(),
+                    FilterMode::Include => "INCLUDE".to_string(),
+                },
+                sources: group.sources.len(),
+                expires,
+                last_reporter: group
+                    .last_reporter
+                    .map_or_else(|| "-".to_string(), |a| a.to_string()),
+                uptime: uptime_string(group.uptime.elapsed().as_secs()),
+            });
+        }
+    }
+
+    if json {
+        return Ok(serde_json::to_string(&rows).unwrap());
+    }
+
+    let mut buf = String::new();
+    buf.push_str("Interface    Group            Mode     Sources  Expires  Uptime    Reporter\n");
+    for row in &rows {
+        writeln!(
+            buf,
+            "{:<13}{:<17}{:<9}{:<9}{:<9}{:<10}{}",
+            row.interface,
+            row.group,
+            row.mode,
+            row.sources,
+            row.expires,
+            row.uptime,
+            row.last_reporter,
+        )?;
+    }
+    Ok(buf)
 }
 
 fn show_pim_neighbor(pim: &Pim, _args: Args, json: bool) -> Result<String, std::fmt::Error> {

--- a/zebra-rs/src/pim/socket.rs
+++ b/zebra-rs/src/pim/socket.rs
@@ -18,6 +18,18 @@ pub const ALL_PIM_ROUTERS: Ipv4Addr = Ipv4Addr::new(224, 0, 0, 13);
 /// PIM is IP protocol 103.
 pub const PIM_IP_PROTO: i32 = 103;
 
+/// IGMP is IP protocol 2.
+pub const IGMP_IP_PROTO: i32 = 2;
+
+/// All-hosts group — general queries go here.
+pub const IGMP_ALL_HOSTS: Ipv4Addr = Ipv4Addr::new(224, 0, 0, 1);
+
+/// All-routers group — IGMPv2 Leaves are sent here.
+pub const IGMP_ALL_ROUTERS: Ipv4Addr = Ipv4Addr::new(224, 0, 0, 2);
+
+/// IGMPv3 membership reports are sent here (RFC 3376 §4.2.14).
+pub const IGMP_V3_REPORT_GROUP: Ipv4Addr = Ipv4Addr::new(224, 0, 0, 22);
+
 pub fn pim_socket(ctx: &ProtoContext) -> Result<AsyncFd<Socket>, std::io::Error> {
     // Through the context so VRF binding via `SO_BINDTODEVICE`
     // applies automatically once per-VRF instances exist.
@@ -43,6 +55,46 @@ fn set_ipv4_pktinfo(socket: &Socket) -> Result<(), std::io::Error> {
             libc::IP_PKTINFO,
             &optval as *const _ as *const libc::c_void,
             std::mem::size_of::<i32>() as libc::socklen_t,
+        )
+    };
+    if ret != 0 {
+        return Err(std::io::Error::last_os_error());
+    }
+    Ok(())
+}
+
+/// The IGMP socket: queries out, reports/leaves in. Until the mroute
+/// socket exists (SSM phase), reception relies on per-interface joins
+/// of the fixed report destinations (224.0.0.22, 224.0.0.2) — v3
+/// receivers are fully covered; v2 reports (addressed to the reported
+/// group itself) arrive once mroute VIFs put interfaces in
+/// multicast-forwarding mode.
+pub fn igmp_socket(ctx: &ProtoContext) -> Result<AsyncFd<Socket>, std::io::Error> {
+    let socket = ctx.raw_socket(Domain::IPV4, Protocol::from(IGMP_IP_PROTO))?;
+
+    socket.set_nonblocking(true)?;
+    socket.set_reuse_address(true)?;
+    socket.set_multicast_loop_v4(false)?;
+    socket.set_multicast_ttl_v4(1)?;
+    socket.set_tos_v4(libc::IPTOS_PREC_INTERNETCONTROL as u32)?;
+    set_ipv4_pktinfo(&socket)?;
+    set_ipv4_router_alert(&socket)?;
+
+    AsyncFd::new(socket)
+}
+
+/// RFC 3376 §4: IGMP messages are sent with the IP Router Alert
+/// option. Applied socket-wide via `IP_OPTIONS` — this socket only
+/// ever transmits IGMP.
+fn set_ipv4_router_alert(socket: &Socket) -> Result<(), std::io::Error> {
+    let ra: [u8; 4] = [148, 4, 0, 0];
+    let ret = unsafe {
+        libc::setsockopt(
+            socket.as_raw_fd(),
+            libc::IPPROTO_IP,
+            libc::IP_OPTIONS,
+            ra.as_ptr() as *const libc::c_void,
+            ra.len() as libc::socklen_t,
         )
     };
     if ret != 0 {
@@ -81,6 +133,30 @@ pub fn pim_leave_if(socket: &AsyncFd<Socket>, ifindex: u32) {
             tracing::debug!("pim: AllPIMRouters not joined on ifindex {ifindex}");
         } else {
             tracing::warn!("pim: leave AllPIMRouters on ifindex {ifindex} failed: {e}");
+        }
+    }
+}
+
+pub fn igmp_join_if(socket: &AsyncFd<Socket>, ifindex: u32) {
+    for maddr in [IGMP_V3_REPORT_GROUP, IGMP_ALL_ROUTERS] {
+        if let Err(e) = socket
+            .get_ref()
+            .join_multicast_v4_n(&maddr, &InterfaceIndexOrAddress::Index(ifindex))
+            && !is_eaddrinuse(&e)
+        {
+            tracing::warn!("igmp: join {maddr} on ifindex {ifindex} failed: {e}");
+        }
+    }
+}
+
+pub fn igmp_leave_if(socket: &AsyncFd<Socket>, ifindex: u32) {
+    for maddr in [IGMP_V3_REPORT_GROUP, IGMP_ALL_ROUTERS] {
+        if let Err(e) = socket
+            .get_ref()
+            .leave_multicast_v4_n(&maddr, &InterfaceIndexOrAddress::Index(ifindex))
+            && !is_not_member(&e)
+        {
+            tracing::warn!("igmp: leave {maddr} on ifindex {ifindex} failed: {e}");
         }
     }
 }

--- a/zebra-rs/yang/config.yang
+++ b/zebra-rs/yang/config.yang
@@ -4021,6 +4021,37 @@ module config {
             type boolean;
             default false;
           }
+          container igmp {
+            ext:help "IGMP on this interface";
+            leaf enabled {
+              ext:help "Enable IGMP membership tracking";
+              type boolean;
+              default false;
+            }
+            leaf version {
+              ext:help "IGMP version to run";
+              type uint8 {
+                range "2..3";
+              }
+              default 3;
+            }
+            leaf query-interval {
+              ext:help "General query transmit interval (seconds)";
+              type uint16 {
+                range "1..1800";
+              }
+              units "seconds";
+              default 125;
+            }
+            leaf query-max-response-time {
+              ext:help "Max response time advertised in queries (seconds)";
+              type uint16 {
+                range "1..25";
+              }
+              units "seconds";
+              default 10;
+            }
+          }
         }
       }
       container static {

--- a/zebra-rs/yang/exec.yang
+++ b/zebra-rs/yang/exec.yang
@@ -985,6 +985,19 @@ module exec {
       }
     }
 
+    container igmp {
+      ext:help "IGMP commands";
+      presence "IGMP status";
+      container interface {
+        ext:help "IGMP interface and querier state";
+        presence "IGMP interface";
+      }
+      container groups {
+        ext:help "IGMP group membership";
+        presence "IGMP groups";
+      }
+    }
+
     container pim {
       ext:help "PIM commands";
       presence "PIM instance";


### PR DESCRIPTION
## Summary

Phase 3 of the PIM-SM/SSM arc (architecture: `docs/design/pim-sm-ssm-architecture.md`; Phases 1–2 were #1951 / #1956):

- New `zebra-rs/src/pim/igmp/` engine: querier election per RFC 3376 §6.6 (startup queries at QI/4, demotion to a lower-address querier, Other-Querier-Present takeover on expiry) and group/source tracking per §6.4, reduced to what the Phase-4 TIB bridge consumes — EXCLUDE groups with group timer (GMI), INCLUDE sources with per-source timers, EXCLUDE→INCLUDE fallback on group-timer expiry, v1/v2 reports as EXCLUDE{} with an older-version-host marker, v2 Leave / v3 TO_IN{} / BLOCK lowering timers to LMQT plus a group-specific query when querier.
- Expiry is deadline-driven: timed state stores `Instant`s, a `next_wakeup` sleep arm in the event loop (the `nd` pattern) drives `igmp_tick` — no per-source timer tasks.
- Second raw socket (IGMP, proto 2) with Router Alert (`IP_OPTIONS`) on queries and per-interface joins of 224.0.0.22 + 224.0.0.2. Documented limit: v3 receivers fully covered now; v2 group-addressed reports arrive once the SSM phase's mroute VIFs enable per-interface multicast forwarding.
- Config under the `router pim` interface list (`igmp { enabled, version, query-interval, query-max-response-time }`), same desired-vs-running reconciler, IGMP independent of PIM hello operation. `show igmp interface` / `show igmp groups` (text + JSON), routed by extending `is_pim` to the `igmp` token.
- BDD: new generic `I spawn {cmd} in namespace {ns}` step for detached background processes, and the `pim_igmp` feature — r2 demotes to Non-Querier against r1's lower address (r1 provably never demotes), and a live socat receiver's kernel-emitted IGMPv3 report is learned as `239.1.1.1 EXCLUDE`.

## Test plan

- Live BDD under sudo with fresh binary + YANG installed (md5-checked): `--tags @pim_igmp` → all steps passed; `--tags @pim_adjacency` re-run as regression after the reconciler change → passed.
- `cargo test --workspace --exclude bdd`: green. `cargo clippy --workspace --all-targets`: clean. `cargo fmt --all --check`: clean.

Generated with [Claude Code](https://claude.com/claude-code)