### PR TITLE
isis-packet: fix Srv6TlvFlags MTID bit order; Nsap::from_str panic

### DIFF
--- a/crates/isis-packet/src/flags_serde.rs
+++ b/crates/isis-packet/src/flags_serde.rs
@@ -98,7 +98,7 @@ bitfield_serde!(Ipv6ControlInfo {
     dist_up: bool,
 } reserved { resvd: usize });
 
-bitfield_serde!(Srv6TlvFlags { v_flag: u16 } reserved { resvd: u8 });
+bitfield_serde!(Srv6TlvFlags { mtid: u16 } reserved { resvd: u8 });
 
 bitfield_serde!(IsisLspTypes {
     is_bits: u8,

--- a/crates/isis-packet/src/nsap.rs
+++ b/crates/isis-packet/src/nsap.rs
@@ -107,22 +107,27 @@ impl FromStr for Nsap {
         let afi = u8::from_str_radix(parts[0], 16)?;
         parts.remove(0);
 
-        // Parse SysId (6 octets).
+        // Parse SysId (6 octets). The leading validation accepts 2- or
+        // 4-char groups (area parts may be either), but the three
+        // system-id groups must each decode to exactly 2 octets — a
+        // 2-char group here would index out of bounds below.
+        fn sys_id_pair(part: &str) -> Result<[u8; 2], NsapParseError> {
+            let val = hex::decode(part).map_err(|_| NsapParseError(()))?;
+            val.try_into().map_err(|_| NsapParseError(()))
+        }
+
         let mut sys_id = IsisSysId::default();
         let parts_len = parts.len();
 
-        let sys_id_str = parts[parts_len - 4];
-        let sys_id_val = hex::decode(sys_id_str).map_err(|_| NsapParseError(()))?;
+        let sys_id_val = sys_id_pair(parts[parts_len - 4])?;
         sys_id.id[0] = sys_id_val[0];
         sys_id.id[1] = sys_id_val[1];
 
-        let sys_id_str = parts[parts_len - 3];
-        let sys_id_val = hex::decode(sys_id_str).map_err(|_| NsapParseError(()))?;
+        let sys_id_val = sys_id_pair(parts[parts_len - 3])?;
         sys_id.id[2] = sys_id_val[0];
         sys_id.id[3] = sys_id_val[1];
 
-        let sys_id_str = parts[parts_len - 2];
-        let sys_id_val = hex::decode(sys_id_str).map_err(|_| NsapParseError(()))?;
+        let sys_id_val = sys_id_pair(parts[parts_len - 2])?;
         sys_id.id[4] = sys_id_val[0];
         sys_id.id[5] = sys_id_val[1];
 
@@ -181,6 +186,17 @@ mod tests {
         is_valid_nsap("49.5678.0123.4567.0002.01");
         is_valid_nsap("49.5678.01.0123.4567.0002.01");
         is_valid_nsap("49.0102.0304.0506.0708.090a.0b0c.0d.0000.0000.0001.00");
+    }
+
+    #[test]
+    fn two_char_sys_id_group_is_error_not_panic() {
+        // A 2-char group in any of the three system-id positions passes
+        // the leading 2-or-4-char validation but decodes to a single
+        // octet; indexing it at [1] used to panic. Reached from operator
+        // config via `net`, so it must be a parse error, not a crash.
+        is_invalid_nsap("49.0000.0000.00.0000.00");
+        is_invalid_nsap("49.0000.00.0000.0000.00");
+        is_invalid_nsap("49.0000.0000.0000.00.00");
     }
 
     #[test]

--- a/crates/isis-packet/src/sub/prefix.rs
+++ b/crates/isis-packet/src/sub/prefix.rs
@@ -1087,13 +1087,20 @@ impl ParseBe<IsisTlvIpv6ReachEntry> for IsisTlvIpv6ReachEntry {
     }
 }
 
+// RFC 9352 §7.1: the SRv6 Locator TLV (type 27) opens with the same
+// 2-octet MT header as RFC 5120 — 4 reserved bits in the MSBs, then a
+// 12-bit MT ID. `bitfield(u16)` is LSB-first (see `MultiTopologyId`
+// above): declare `mtid` first to land at bits 0-11 and `resvd` second
+// at bits 12-15. The previous order (`resvd` first, MT ID misnamed
+// `v_flag`) read the MT ID out of the reserved bits, so an MT-2 locator
+// parsed as MT-0 and a locally-built MTID=2 emitted 0x0020.
 #[bitfield(u16, debug = true)]
 #[derive(PartialEq)]
 pub struct Srv6TlvFlags {
+    #[bits(12)]
+    pub mtid: u16,
     #[bits(4)]
     pub resvd: u8,
-    #[bits(12)]
-    pub v_flag: u16,
 }
 
 impl ParseBe<Srv6TlvFlags> for Srv6TlvFlags {
@@ -1197,5 +1204,39 @@ impl TlvEmitter for IsisTlvSrv6 {
         for locator in &self.locators {
             locator.emit(buf);
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn srv6_tlv_mtid_bit_positions() {
+        // RFC 9352 §7.1 / RFC 5120 §7.2: 4 reserved MSBs, 12-bit MT ID
+        // in the LSBs — wire 0x0002 is MT 2, and MT 2 emits 0x0002.
+        let flags = Srv6TlvFlags::from(0x0002u16);
+        assert_eq!(flags.mtid(), 2);
+        assert_eq!(flags.resvd(), 0);
+
+        let emitted: u16 = Srv6TlvFlags::new().with_mtid(2).into();
+        assert_eq!(emitted, 0x0002);
+
+        // Reserved bits stay in the top nibble.
+        let flags = Srv6TlvFlags::from(0xF002u16);
+        assert_eq!(flags.mtid(), 2);
+        assert_eq!(flags.resvd(), 0xF);
+
+        // Full TLV round-trip keeps the MT ID.
+        let tlv = IsisTlvSrv6 {
+            flags: Srv6TlvFlags::new().with_mtid(2),
+            locators: vec![],
+        };
+        let mut buf = BytesMut::new();
+        tlv.emit(&mut buf);
+        assert_eq!(&buf[..], &[0x00, 0x02]);
+        let (rest, parsed) = IsisTlvSrv6::parse_be(&buf).expect("parse");
+        assert!(rest.is_empty());
+        assert_eq!(parsed.flags.mtid(), 2);
     }
 }

--- a/docs/design/isis-packet-code-review.md
+++ b/docs/design/isis-packet-code-review.md
@@ -91,7 +91,7 @@ copied the MSB-aligned convention when it needed the LSB-aligned one.
 each direction. `flags_serde.rs` and `cap_disp.rs` go through the accessors, so
 they were corrected by the same change.
 
-### 3. 🔴 `Nsap::from_str` panics (index OOB) on a malformed `net` — CONFIRMED
+### 3. 🔴 `Nsap::from_str` panics (index OOB) on a malformed `net` — CONFIRMED — ✅ FIXED
 `crates/isis-packet/src/nsap.rs:116` (also `:122`, `:127`)
 
 The three system-id groups are decoded assuming each is 4 hex chars (2 bytes) and
@@ -105,9 +105,9 @@ is 1`). Reached from operator config via `.parse::<Nsap>()` in
 `zebra-rs/src/isis/config.rs` — a malformed `net` value **crashes the IS-IS
 daemon**.
 
-**Fix:** after `hex::decode`, verify the decoded group is exactly 2 bytes (return
-`NsapParseError`) before indexing; or restrict the sys-id-position parts to
-length 4 in the validation loop.
+**Fixed:** a `sys_id_pair` helper `hex::decode`s each system-id group and
+`try_into`s it to `[u8; 2]`, returning `NsapParseError` on any other length; a
+unit test covers a 2-char group in each of the three system-id positions.
 
 ### 4. 🟠 `IsisTlvIsNeighbor::len()` wraps at ≥43 neighbors — CONFIRMED
 `crates/isis-packet/src/parser.rs:682`
@@ -123,7 +123,7 @@ TLVs (Auth, Protocols Supported) are lost and adjacencies flap on a large LAN.
 **Fix:** cap consistently with `emit()` (`.min(255)` / `.min(252)` for a
 multiple of 6), or shard TLV 6 across instances.
 
-### 5. 🟠 `Srv6TlvFlags` MTID bitfield declared in inverted order — CONFIRMED
+### 5. 🟠 `Srv6TlvFlags` MTID bitfield declared in inverted order — CONFIRMED — ✅ FIXED
 `crates/isis-packet/src/sub/prefix.rs:1090`
 
 The 2-octet header of the SRv6 Locator TLV (type 27) is **4 reserved MSBs +
@@ -139,8 +139,10 @@ from MT-0, and a locally-built MTID=2 emits `0x0020`, which a peer reads as MTID
 32. MTID=0 (single-topology SRv6) round-trips by luck, so this only breaks
 multi-topology SRv6. FRR carries an explicit `uint16_t mtid` for this TLV.
 
-**Fix:** mirror the `MultiTopologyId` layout — declare the 12-bit MTID first,
-`resvd(4)` second — and rename the field `mtid`.
+**Fixed:** the layout now mirrors `MultiTopologyId` — the 12-bit `mtid` is
+declared first, `resvd(4)` second — and the field is named `mtid` (also in the
+serde helper). A unit test pins wire `0x0002` ⇄ MT 2 and the reserved top
+nibble, plus a full `IsisTlvSrv6` round-trip.
 
 ### 6. 🟠 `IsisTlvAreaAddr::parse_be` drops all but the first area address — CONFIRMED
 `crates/isis-packet/src/parser.rs:649`
@@ -410,10 +412,10 @@ Correctness outranks these for the ranked list, but they're worth scheduling:
 
 1. ~~Fix #1 (LspEntries wrap) first~~ — **done** (PR #1952): builders capped at
    15 entries per TLV; unit + BDD regression coverage in place.
-2. ~~Fix #2 (RouterCap S/D)~~ — **done**: flags declared LSB-first, S=`0x01` /
-   D=`0x02` pinned by unit test. **#5 (Srv6TlvFlags MTID)** remains — an
-   RFC/FRR-confirmed interop break with a trivial one-line fix.
-3. **Fix #3 (nsap panic)** — a one-line guard that removes a config-input crash.
+2. ~~Fix #2 (RouterCap S/D) and #5 (Srv6TlvFlags MTID)~~ — **done**: both
+   bitfields declared LSB-first with the bit positions pinned by unit tests.
+3. ~~Fix #3 (nsap panic)~~ — **done**: system-id groups are length-checked
+   before indexing; malformed `net` config now returns `NsapParseError`.
 4. Work through the emit-side length cluster (#4, #7, #8) with a shared
    `usize`-based length policy; that also naturally addresses several of the
    cleanup items.


### PR DESCRIPTION
## Summary

Fixes findings #5 and #3 of the isis-packet code review
(`docs/design/isis-packet-code-review.md`).

**#5 — `Srv6TlvFlags` MTID bitfield inverted.** The SRv6 Locator TLV
(type 27) opens with the RFC 5120-style MT header — 4 reserved MSBs and
a 12-bit MT ID (RFC 9352 §7.1). The bitfield declared `resvd` first,
which is LSB-first in `bitfield(u16)`, so the MT ID was read out of the
reserved bits: an MT-2 locator parsed as MT-0 and a locally-built
MTID=2 emitted `0x0020` (MT 32 on the wire). The MT ID was also
misnamed `v_flag`. Now the 12-bit `mtid` is declared first and
`resvd(4)` second, mirroring the earlier `MultiTopologyId` fix, with
the field renamed `mtid` (also in the serde helper). MTID=0
single-topology SRv6 round-tripped by luck, which is why this never
surfaced.

**#3 — `Nsap::from_str` panic on malformed `net`.** The leading
validation accepts 2- or 4-char dotted groups, but the three system-id
groups were indexed at `[0]`/`[1]` assuming 2 decoded octets — a 2-char
group in a system-id position (e.g. `49.0000.0000.00.0000.00`) panicked
with index out of bounds. Reached from operator config via the `net`
leaf, so a malformed value crashed the daemon. A `sys_id_pair` helper
now `try_into`s each decoded group to `[u8; 2]` and returns
`NsapParseError` otherwise.

Review doc: findings #3 and #5 marked fixed.

## Test plan

- New unit test `srv6_tlv_mtid_bit_positions` pins wire `0x0002` ⇄ MT 2,
  the reserved top nibble, and a full `IsisTlvSrv6` round-trip.
- New unit test `two_char_sys_id_group_is_error_not_panic` covers a
  2-char group in each of the three system-id positions.
- `cargo test --workspace --exclude bdd` green locally.

Generated with [Claude Code](https://claude.com/claude-code)