### PR TITLE
isis: fix emit-side TLV length cluster (review findings #4, #7, #8)

### DIFF
--- a/crates/isis-packet/src/parser.rs
+++ b/crates/isis-packet/src/parser.rs
@@ -673,17 +673,28 @@ pub struct IsisTlvIsNeighbor {
     pub neighbors: Vec<NeighborAddr>,
 }
 
+impl IsisTlvIsNeighbor {
+    /// Maximum number of neighbors that fit in a single TLV 6: the
+    /// one-octet Length field spans 255 bytes and each neighbor SNPA
+    /// is 6 bytes, so 255 / 6 = 42. `len`/`emit` truncate consistently
+    /// at this bound (a 43rd neighbor used to wrap the length byte
+    /// mod-256 while every neighbor was still emitted); Hello builders
+    /// shard larger adjacency sets across multiple TLV 6 instances so
+    /// no neighbor is silently dropped.
+    pub const MAX_NEIGHBORS: usize = 42;
+}
+
 impl TlvEmitter for IsisTlvIsNeighbor {
     fn typ(&self) -> u8 {
         IsisTlvType::IsNeighbor.into()
     }
 
     fn len(&self) -> u8 {
-        (self.neighbors.len() * 6) as u8
+        (self.neighbors.len().min(Self::MAX_NEIGHBORS) * 6) as u8
     }
 
     fn emit(&self, buf: &mut BytesMut) {
-        for neighbor in self.neighbors.iter() {
+        for neighbor in self.neighbors.iter().take(Self::MAX_NEIGHBORS) {
             buf.put(&neighbor.octets[..]);
         }
     }
@@ -1401,6 +1412,35 @@ pub fn parse(input: &[u8]) -> IsisIResult<&[u8], IsisPacket> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// TLV 6 (IS Neighbors) — `len` and `emit` truncate consistently at
+    /// MAX_NEIGHBORS. 43 neighbors used to wrap the length byte to 2
+    /// (43*6 = 258 mod 256) while emit still wrote all 258 bytes,
+    /// desyncing the receiver's TLV walk; Hello builders shard larger
+    /// sets across multiple TLV 6 instances instead.
+    #[test]
+    fn is_neighbor_len_and_emit_truncate_at_max() {
+        let over = IsisTlvIsNeighbor {
+            neighbors: vec![NeighborAddr { octets: [0xAA; 6] }; 43],
+        };
+        assert_eq!(over.len() as usize, IsisTlvIsNeighbor::MAX_NEIGHBORS * 6);
+        let mut buf = BytesMut::new();
+        over.emit(&mut buf);
+        assert_eq!(buf.len(), IsisTlvIsNeighbor::MAX_NEIGHBORS * 6);
+
+        // At the bound everything fits and len/emit agree exactly.
+        let full = IsisTlvIsNeighbor {
+            neighbors: (0..IsisTlvIsNeighbor::MAX_NEIGHBORS)
+                .map(|i| NeighborAddr {
+                    octets: [i as u8; 6],
+                })
+                .collect(),
+        };
+        assert_eq!(full.len(), 252);
+        let mut buf = BytesMut::new();
+        full.emit(&mut buf);
+        assert_eq!(buf.len(), 252);
+    }
 
     /// Sanity-check `IsisTlv::wire_len` for a small fixed-size TLV.
     /// The packer relies on this returning a stable 4 bytes (2-byte

--- a/crates/isis-packet/src/sub/cap.rs
+++ b/crates/isis-packet/src/sub/cap.rs
@@ -258,8 +258,8 @@ impl ParseBe<IsisTlvRouterCap> for IsisTlvRouterCap {
 }
 
 impl IsisTlvRouterCap {
-    fn sub_len(&self) -> u8 {
-        self.subs.iter().map(|sub| sub.len() + 2).sum()
+    fn sub_len(&self) -> usize {
+        self.subs.iter().map(|sub| sub.len() as usize + 2).sum()
     }
 }
 
@@ -269,7 +269,7 @@ impl TlvEmitter for IsisTlvRouterCap {
     }
 
     fn len(&self) -> u8 {
-        5 + self.sub_len()
+        (5 + self.sub_len()).min(255) as u8
     }
 
     fn emit(&self, buf: &mut bytes::BytesMut) {

--- a/crates/isis-packet/src/sub/neigh.rs
+++ b/crates/isis-packet/src/sub/neigh.rs
@@ -169,20 +169,24 @@ impl IsisTlvExtIsReachEntry {
     }
 
     fn len(&self) -> u8 {
-        11 + self.sub_len() // 11 is TLV length without sub TLVs.
+        // 11 is the entry length without sub-TLVs. usize + min keeps the
+        // packer's wire_len() probe of an over-full entry debug-safe
+        // (see `IsisTlvExtIsReach::len`).
+        (11 + self.sub_len()).min(255) as u8
     }
 
-    fn sub_len(&self) -> u8 {
-        self.subs.iter().map(|sub| sub.len() + 2).sum()
+    fn sub_len(&self) -> usize {
+        self.subs.iter().map(|sub| sub.len() as usize + 2).sum()
     }
 
     fn emit(&self, buf: &mut BytesMut) {
         buf.put(&self.neighbor_id.id[..]);
         buf.put(&u32_u8_3(self.metric)[..]);
-        buf.put_u8(self.sub_len());
-        for sub in self.subs.iter() {
-            sub.emit(buf);
-        }
+        emit_sub_tlvs(buf, |buf| {
+            for sub in self.subs.iter() {
+                sub.emit(buf);
+            }
+        });
     }
 }
 
@@ -789,8 +793,8 @@ impl TlvEmitter for IsisSubAsla {
     }
 
     fn len(&self) -> u8 {
-        let sub_len: u8 = self.subs.iter().map(|sub| sub.len() + 2).sum();
-        2 + self.sabm.len() as u8 + self.udabm.len() as u8 + sub_len
+        let sub_len: usize = self.subs.iter().map(|sub| sub.len() as usize + 2).sum();
+        (2 + self.sabm.len() + self.udabm.len() + sub_len).min(255) as u8
     }
 
     fn emit(&self, buf: &mut BytesMut) {
@@ -965,8 +969,8 @@ impl TlvEmitter for IsisSubSrv6EndXSid {
 
     fn len(&self) -> u8 {
         // Flags(1)+Algo(1)+Weight(1)+Behavior(2)+Sid(16)+Sub2Len(1)+Sub2
-        let len: u8 = self.sub2s.iter().map(|sub| sub.len() + 2).sum();
-        1 + 1 + 1 + 2 + 16 + 1 + len
+        let len: usize = self.sub2s.iter().map(|sub| sub.len() as usize + 2).sum();
+        (1 + 1 + 1 + 2 + 16 + 1 + len).min(255) as u8
     }
 
     fn emit(&self, buf: &mut BytesMut) {
@@ -1030,8 +1034,8 @@ impl TlvEmitter for IsisSubSrv6LanEndXSid {
 
     fn len(&self) -> u8 {
         // SystemID(6)+Flags(1)+Algo(1)+Weight(1)+Behavior(2)+Sid(16)+Sub2Len(1)+Sub2
-        let len: u8 = self.sub2s.iter().map(|sub| sub.len() + 2).sum();
-        6 + 1 + 1 + 1 + 2 + 16 + 1 + len
+        let len: usize = self.sub2s.iter().map(|sub| sub.len() as usize + 2).sum();
+        (6 + 1 + 1 + 1 + 2 + 16 + 1 + len).min(255) as u8
     }
 
     fn emit(&self, buf: &mut BytesMut) {
@@ -1052,6 +1056,64 @@ impl TlvEmitter for IsisSubSrv6LanEndXSid {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn oversized_entry() -> IsisTlvExtIsReachEntry {
+        // 50 IPv4 interface-address sub-TLVs = 50 * (4+2) = 300 bytes,
+        // more than the one-octet sub-TLV-length field can express.
+        IsisTlvExtIsReachEntry {
+            subs: (0..50)
+                .map(|_| {
+                    IsisSubTlv::Ipv4IfAddr(IsisSubIpv4IfAddr {
+                        addr: Ipv4Addr::UNSPECIFIED,
+                    })
+                })
+                .collect(),
+            ..Default::default()
+        }
+    }
+
+    /// The old `sum::<u8>()` in `sub_len` panicked in debug builds
+    /// ("attempt to add with overflow") when the packer's wire_len()
+    /// probe measured an over-full entry, and wrapped the length in
+    /// release; `len()` now saturates at 255.
+    #[test]
+    fn ext_is_reach_entry_oversized_subs_saturate() {
+        assert_eq!(oversized_entry().len(), 255);
+    }
+
+    /// Emitting an over-full sub-TLV block is a builder bug — the
+    /// emit_sub_tlvs debug assert trips instead of a length byte being
+    /// written that disagrees with the bytes emitted.
+    #[cfg(debug_assertions)]
+    #[test]
+    #[should_panic(expected = "sub-TLV block overflows")]
+    fn ext_is_reach_entry_oversized_subs_emit_asserts() {
+        let mut buf = BytesMut::new();
+        oversized_entry().emit(&mut buf);
+    }
+
+    /// The back-patched sub-TLV length byte must equal the bytes
+    /// actually emitted, and the entry must round-trip.
+    #[test]
+    fn ext_is_reach_entry_sub_block_backpatch_round_trip() {
+        let entry = IsisTlvExtIsReachEntry {
+            metric: 10,
+            subs: vec![
+                IsisSubTlv::Ipv4IfAddr(IsisSubIpv4IfAddr {
+                    addr: "10.0.0.1".parse().unwrap(),
+                }),
+                IsisSubTlv::TeMetric(IsisSubTeMetric { metric: 100 }),
+            ],
+            ..Default::default()
+        };
+        let mut buf = BytesMut::new();
+        entry.emit(&mut buf);
+        // neighbor_id(7) + metric(3) + sublen(1) + subs.
+        assert_eq!(buf[10] as usize, buf.len() - 11);
+        let (rest, parsed) = IsisTlvExtIsReachEntry::parse_be(&buf).expect("parse");
+        assert!(rest.is_empty());
+        assert_eq!(parsed, entry);
+    }
 
     #[test]
     fn admin_grp_len_truncates_at_63_groups() {

--- a/crates/isis-packet/src/sub/prefix.rs
+++ b/crates/isis-packet/src/sub/prefix.rs
@@ -117,8 +117,8 @@ impl TlvEmitter for IsisSubSrv6EndSid {
 
     fn len(&self) -> u8 {
         // Flags(1)+Behavior(2)+Sid(16)+Sub2Len(1)+Sub2
-        let len: u8 = self.sub2s.iter().map(|sub| sub.len() + 2).sum();
-        1 + 2 + 16 + 1 + len
+        let len: usize = self.sub2s.iter().map(|sub| sub.len() as usize + 2).sum();
+        (1 + 2 + 16 + 1 + len).min(255) as u8
     }
 
     fn emit(&self, buf: &mut BytesMut) {
@@ -177,8 +177,8 @@ impl TlvEmitter for IsisSubSrv6MirrorSid {
 
     fn len(&self) -> u8 {
         // Flags(1)+Behavior(2)+Sid(16)+Sub2Len(1)+Sub2
-        let len: u8 = self.sub2s.iter().map(|sub| sub.len() + 2).sum();
-        1 + 2 + 16 + 1 + len
+        let len: usize = self.sub2s.iter().map(|sub| sub.len() as usize + 2).sum();
+        (1 + 2 + 16 + 1 + len).min(255) as u8
     }
 
     fn emit(&self, buf: &mut BytesMut) {
@@ -545,15 +545,17 @@ impl IsisTlvExtIpReachEntry {
     fn len(&self) -> u8 {
         if self.subs.is_empty() {
             // Metric:4 + Flags:1 + Prefix.
-            4 + 1 + (psize(self.prefix.prefix_len()) as u8)
+            (4 + 1 + psize(self.prefix.prefix_len())) as u8
         } else {
             // Metric:4 + Flags:1 + Prefix + Sub TLV length + Sub TLV.
-            4 + 1 + (psize(self.prefix.prefix_len()) as u8) + 1 + self.sub_len()
+            // usize + min keeps the packer's wire_len() probe of an
+            // over-full entry debug-safe (see `IsisTlvExtIsReach::len`).
+            (4 + 1 + psize(self.prefix.prefix_len()) + 1 + self.sub_len()).min(255) as u8
         }
     }
 
-    fn sub_len(&self) -> u8 {
-        self.subs.iter().map(|sub| sub.len() + 2).sum()
+    fn sub_len(&self) -> usize {
+        self.subs.iter().map(|sub| sub.len() as usize + 2).sum()
     }
 
     fn emit(&self, buf: &mut BytesMut) {
@@ -566,10 +568,11 @@ impl IsisTlvExtIpReachEntry {
         if self.subs.is_empty() {
             return;
         }
-        buf.put_u8(self.sub_len());
-        for sub in self.subs.iter() {
-            sub.emit(buf);
-        }
+        emit_sub_tlvs(buf, |buf| {
+            for sub in self.subs.iter() {
+                sub.emit(buf);
+            }
+        });
     }
 
     pub fn prefix_sid(&self) -> Option<IsisSubPrefixSid> {
@@ -746,15 +749,17 @@ impl IsisTlvIpv6ReachEntry {
     fn len(&self) -> u8 {
         if self.subs.is_empty() {
             // Metric:4 + Flags:1 + Prefixlen:1.
-            4 + 1 + 1 + (psize(self.prefix.prefix_len()) as u8)
+            (4 + 1 + 1 + psize(self.prefix.prefix_len())) as u8
         } else {
             // Metric:4 + Flags:1 + Prefix len:1 + Sub TLV length + Sub TLV.
-            4 + 1 + 1 + (psize(self.prefix.prefix_len()) as u8) + 1 + self.sub_len()
+            // usize + min keeps the packer's wire_len() probe of an
+            // over-full entry debug-safe (see `IsisTlvExtIsReach::len`).
+            (4 + 1 + 1 + psize(self.prefix.prefix_len()) + 1 + self.sub_len()).min(255) as u8
         }
     }
 
-    fn sub_len(&self) -> u8 {
-        self.subs.iter().map(|sub| sub.len() + 2).sum()
+    fn sub_len(&self) -> usize {
+        self.subs.iter().map(|sub| sub.len() as usize + 2).sum()
     }
 
     fn emit(&self, buf: &mut BytesMut) {
@@ -768,10 +773,11 @@ impl IsisTlvIpv6ReachEntry {
         if self.subs.is_empty() {
             return;
         }
-        buf.put_u8(self.sub_len());
-        for sub in &self.subs {
-            sub.emit(buf);
-        }
+        emit_sub_tlvs(buf, |buf| {
+            for sub in &self.subs {
+                sub.emit(buf);
+            }
+        });
     }
 }
 
@@ -1122,9 +1128,9 @@ pub struct Srv6Locator {
 
 impl Srv6Locator {
     fn len(&self) -> u8 {
-        // Metric(4)+Flags(1)+Algo(1)+Locator(16)+SubLen(1)+Subs
-        let sub_len: u8 = self.subs.iter().map(|sub| sub.len() + 2).sum();
-        4 + 1 + 1 + 1 + (psize(self.locator.prefix_len()) as u8) + 1 + sub_len
+        // Metric(4)+Flags(1)+Algo(1)+PrefixLen(1)+Locator+SubLen(1)+Subs
+        let sub_len: usize = self.subs.iter().map(|sub| sub.len() as usize + 2).sum();
+        (4 + 1 + 1 + 1 + psize(self.locator.prefix_len()) + 1 + sub_len).min(255) as u8
     }
 
     fn emit(&self, buf: &mut BytesMut) {
@@ -1195,8 +1201,14 @@ impl TlvEmitter for IsisTlvSrv6 {
     }
 
     fn len(&self) -> u8 {
-        let len: u8 = self.locators.iter().map(|locator| locator.len()).sum();
-        len + 2
+        // See note on `IsisTlvExtIsReach::len` — saturate so the packer's
+        // wire_len() probe of a not-yet-split TLV stays debug-safe.
+        let len: usize = self
+            .locators
+            .iter()
+            .map(|locator| locator.len() as usize)
+            .sum();
+        (len + 2).min(255) as u8
     }
 
     fn emit(&self, buf: &mut BytesMut) {

--- a/crates/isis-packet/src/util.rs
+++ b/crates/isis-packet/src/util.rs
@@ -5,10 +5,22 @@ pub use packet_utils::{ParseBe, TlvEmitter, u32_u8_3, write_hold_time};
 /// Emit sub-TLVs with a back-patched length byte.
 ///
 /// Writes a placeholder `0u8`, calls `emit_fn` to write sub-TLV data, then
-/// patches the placeholder with the actual length (capped to 255).
+/// patches the placeholder with the actual length. A block larger than the
+/// one-octet length field can express (255 bytes) is a builder bug — no
+/// single entry may carry more sub-TLV bytes than fit — so it trips a debug
+/// assert; in release the block is truncated to 255 bytes so the length
+/// byte still matches the bytes present and the receiver's TLV walk stays
+/// framed (the truncated tail parses as one malformed sub-TLV instead of
+/// desyncing the rest of the PDU into phantom entries).
 pub fn emit_sub_tlvs(buf: &mut BytesMut, emit_fn: impl FnOnce(&mut BytesMut)) {
     buf.put_u8(0);
     let pp = buf.len();
     emit_fn(buf);
-    buf[pp - 1] = (buf.len() - pp).min(255) as u8;
+    let block = buf.len() - pp;
+    debug_assert!(
+        block <= 255,
+        "sub-TLV block overflows its one-octet length field: {block} bytes"
+    );
+    buf.truncate(pp + block.min(255));
+    buf[pp - 1] = (buf.len() - pp) as u8;
 }

--- a/docs/design/isis-packet-code-review.md
+++ b/docs/design/isis-packet-code-review.md
@@ -109,7 +109,7 @@ daemon**.
 `try_into`s it to `[u8; 2]`, returning `NsapParseError` on any other length; a
 unit test covers a 2-char group in each of the three system-id positions.
 
-### 4. 🟠 `IsisTlvIsNeighbor::len()` wraps at ≥43 neighbors — CONFIRMED
+### 4. 🟠 `IsisTlvIsNeighbor::len()` wraps at ≥43 neighbors — CONFIRMED — ✅ FIXED
 `crates/isis-packet/src/parser.rs:682`
 
 `len()` is `(self.neighbors.len() * 6) as u8` with no cap; `emit()` writes every
@@ -120,8 +120,11 @@ neighbor. TLV 6 is built from all adjacencies in `zebra-rs/src/isis/ifsm.rs:173`
 256 bytes early, reading neighbor MAC bytes as TLV headers; the Hello's following
 TLVs (Auth, Protocols Supported) are lost and adjacencies flap on a large LAN.
 
-**Fix:** cap consistently with `emit()` (`.min(255)` / `.min(252)` for a
-multiple of 6), or shard TLV 6 across instances.
+**Fixed:** both — `IsisTlvIsNeighbor::MAX_NEIGHBORS` (42) caps `len()` and
+`emit()` consistently, and the Hello builder shards larger adjacency sets
+across multiple TLV 6 instances so no neighbor is dropped. The receive path's
+`has_mac` now ORs across instances (it previously let a later instance clobber
+a match from an earlier one). Unit test pins the 43-neighbor truncation.
 
 ### 5. 🟠 `Srv6TlvFlags` MTID bitfield declared in inverted order — CONFIRMED — ✅ FIXED
 `crates/isis-packet/src/sub/prefix.rs:1090`
@@ -161,7 +164,7 @@ round-trips hide it — only *received* multi-area TLVs lose data.
 **Fix:** model `area_addr` as a `Vec<Vec<u8>>` (or loop until the value slice is
 exhausted) and emit each length-prefixed address.
 
-### 7. 🟠 Per-entry sub-TLV length uses panicking/wrapping `u8` arithmetic — CONFIRMED
+### 7. 🟠 Per-entry sub-TLV length uses panicking/wrapping `u8` arithmetic — CONFIRMED — ✅ FIXED
 `crates/isis-packet/src/sub/neigh.rs:176` (and siblings)
 
 `IsisTlvExtIsReachEntry::sub_len()` is `.map(|s| s.len()+2).sum::<u8>()` and
@@ -183,10 +186,17 @@ reads the remaining 256 as phantom neighbor entries. A single oversized entry
 can't be sharded by the packer (which shards at entry boundaries), so it hits this
 per-entry length directly.
 
-**Fix:** use `usize` internally and `saturating`/checked conversion to `u8` at the
-boundary, matching the reach-TLV-level `len()` policy.
+**Fixed:** every listed site (plus the same pattern in `IsisSubSrv6EndSid`,
+`IsisSubSrv6MirrorSid`, `IsisSubSrv6EndXSid`, `IsisSubSrv6LanEndXSid`) now
+computes in `usize` and saturates once at the `u8` boundary with `.min(255)`,
+mirroring the pre-existing `IsisSubFlexAlgoDef` idiom, so the packer's
+`wire_len()` probe of an over-full entry is debug-safe. The three reach entries
+additionally emit their sub-TLV block through `emit_sub_tlvs`, so the sub-length
+byte is back-patched from the bytes actually written instead of computed twice.
+Unit tests pin a 300-byte sub block saturating to 255 and the back-patch
+round-trip.
 
-### 8. 🟠 `emit_sub_tlvs` silently caps the sub-TLV block length at 255 — CONFIRMED
+### 8. 🟠 `emit_sub_tlvs` silently caps the sub-TLV block length at 255 — CONFIRMED — ✅ FIXED
 `crates/isis-packet/src/util.rs:13`
 
 `buf[pp - 1] = (buf.len() - pp).min(255) as u8` — a sub-TLV block larger than 255
@@ -201,9 +211,11 @@ byte is clamped to 255 but 276 bytes follow. `Srv6Locator::parse_be` does
 `Unknown` and the leftover ~21 bytes are consumed as the metric/flags of a
 phantom second locator, injecting a bogus SRv6 route at every receiver.
 
-**Fix:** return an error (or assert) when the block exceeds 255 instead of
-clamping, so an over-full block is caught at emit time rather than corrupting the
-wire.
+**Fixed:** an over-full block now trips a `debug_assert` at emit time (a
+builder bug is caught in dev/test); in release the block is truncated to 255
+bytes so the length byte always matches the bytes present — the truncated tail
+parses as one malformed sub-TLV instead of desyncing the rest of the PDU into
+phantom entries. A `should_panic` unit test pins the assert.
 
 ### 9. 🟠 3-octet SID/Label value is never masked to 20 bits — CONFIRMED
 `crates/isis-packet/src/parser.rs:1336` (`SidLabelValue::parse_be` / `emit`)
@@ -416,6 +428,7 @@ Correctness outranks these for the ranked list, but they're worth scheduling:
    bitfields declared LSB-first with the bit positions pinned by unit tests.
 3. ~~Fix #3 (nsap panic)~~ — **done**: system-id groups are length-checked
    before indexing; malformed `net` config now returns `NsapParseError`.
-4. Work through the emit-side length cluster (#4, #7, #8) with a shared
-   `usize`-based length policy; that also naturally addresses several of the
-   cleanup items.
+4. ~~Work through the emit-side length cluster (#4, #7, #8)~~ — **done**:
+   TLV 6 capped + sharded, all per-entry length sums are `usize`-with-`min(255)`,
+   and `emit_sub_tlvs` asserts/truncates instead of mislabeling an over-full
+   block.

--- a/zebra-rs/src/isis/ifsm.rs
+++ b/zebra-rs/src/isis/ifsm.rs
@@ -170,7 +170,22 @@ pub fn hello_generate(link: &LinkTop, level: Level) -> IsisHello {
             })
         }
     }
-    hello.tlvs.push(IsisTlvIsNeighbor { neighbors }.into());
+    // TLV 6 holds at most MAX_NEIGHBORS (42) 6-octet SNPAs; shard a
+    // larger adjacency set across multiple instances so no neighbor is
+    // silently dropped. An empty set still emits one empty TLV so the
+    // wire stays identical to the pre-shard form.
+    if neighbors.is_empty() {
+        hello.tlvs.push(IsisTlvIsNeighbor { neighbors }.into());
+    } else {
+        for chunk in neighbors.chunks(IsisTlvIsNeighbor::MAX_NEIGHBORS) {
+            hello.tlvs.push(
+                IsisTlvIsNeighbor {
+                    neighbors: chunk.to_vec(),
+                }
+                .into(),
+            );
+        }
+    }
 
     // RFC 5306 §3.1 RR for this instance, if we're the staged
     // restarter. Empty for normal operation.

--- a/zebra-rs/src/isis/packet.rs
+++ b/zebra-rs/src/isis/packet.rs
@@ -206,8 +206,11 @@ pub fn nbr_hello_interpret(
     for tlv in tlvs.iter() {
         match tlv {
             IsisTlv::IsNeighbor(neigh) => {
+                // |= : an IIH may carry several TLV 6 instances (the
+                // sender shards at MAX_NEIGHBORS); our SNPA counts as
+                // heard if ANY instance lists it.
                 if let Some(mac) = mac {
-                    has_mac = neigh.neighbors.iter().any(|n| mac.octets() == n.octets);
+                    has_mac |= neigh.neighbors.iter().any(|n| mac.octets() == n.octets);
                 }
             }
             IsisTlv::P2p3Way(tlv) => {


### PR DESCRIPTION
## Summary

Fixes the emit-side length cluster — findings #4, #7, #8 of the
isis-packet code review (`docs/design/isis-packet-code-review.md`):
length fields that could disagree with the bytes actually written,
desyncing the receiver's TLV walk.

**#4 — TLV 6 (IS Neighbors) length wrap.** `len()` was
`(neighbors * 6) as u8`, wrapping mod-256 at 43 neighbors while `emit()`
wrote all 258 bytes, so a large LAN's IIH desynced and its trailing TLVs
(Auth, Protocols Supported) were lost. `IsisTlvIsNeighbor` now carries
`MAX_NEIGHBORS` (42 = 255/6) with `len()`/`emit()` truncating
consistently; the Hello builder shards larger adjacency sets across
multiple TLV 6 instances so no neighbor is dropped. The receive path's
`has_mac` check now ORs across instances — it previously let a later
TLV 6 instance clobber a match from an earlier one.

**#7 — panicking/wrapping `u8` length sums.** Per-entry sub-TLV sums
(`.map(|s| s.len() + 2).sum::<u8>()`) panicked in debug builds when the
LSP packer's `wire_len()` probe measured an over-full entry, and wrapped
in release. All eleven sites (the review's seven plus the same pattern
in the four SRv6 SID sub-TLVs) now compute in `usize` and saturate once
at the `u8` boundary, mirroring the pre-existing `IsisSubFlexAlgoDef`
idiom. The three reach entries additionally emit their sub-TLV block via
`emit_sub_tlvs`, so the sub-length byte is back-patched from the bytes
actually written instead of computed twice.

**#8 — `emit_sub_tlvs` silent 255 clamp.** An over-255-byte block was
labeled 255 while every byte stayed in the stream, so receivers sliced
mid-sub-TLV and consumed the overflow as phantom entries (bogus SRv6
routes). It now debug-asserts on an over-full block and truncates to 255
in release so the length byte always matches the bytes present.

Review doc: findings #4/#7/#8 marked fixed; priority list fully done.

## Test plan

- New unit tests pin: 43-neighbor TLV 6 truncation at `MAX_NEIGHBORS`,
  a 300-byte sub block saturating `len()` to 255 (previously a debug
  panic), the emit-time debug assert (`should_panic`), and the
  back-patched sub-length byte matching emitted bytes on a round-trip.
- `cargo test --workspace --exclude bdd` green locally.

Generated with [Claude Code](https://claude.com/claude-code)