### PR TITLE
pim: kernel dataplane, TIB and SSM (S,G) forwarding end to end

### DIFF
--- a/bdd/tests/configs/pim_ssm/r1.yaml
+++ b/bdd/tests/configs/pim_ssm/r1.yaml
@@ -1,0 +1,14 @@
+interface:
+- if-name: eth1
+  ipv4:
+    address: 10.1.13.1/24
+- if-name: eth3
+  ipv4:
+    address: 10.1.14.1/24
+router:
+  pim:
+    interface:
+    - if-name: eth1
+      dr-priority: 1
+    - if-name: eth3
+      dr-priority: 1

--- a/bdd/tests/configs/pim_ssm/r2.yaml
+++ b/bdd/tests/configs/pim_ssm/r2.yaml
@@ -1,0 +1,21 @@
+interface:
+- if-name: eth2
+  ipv4:
+    address: 10.1.13.2/24
+- if-name: eth5
+  ipv4:
+    address: 10.1.15.1/24
+router:
+  static:
+    ipv4:
+      route:
+      - prefix: 10.1.14.0/24
+        nexthop:
+        - address: 10.1.13.1
+  pim:
+    interface:
+    - if-name: eth2
+      dr-priority: 1
+    - if-name: eth5
+      igmp:
+        enabled: true

--- a/bdd/tests/features/pim_ssm.feature
+++ b/bdd/tests/features/pim_ssm.feature
@@ -1,0 +1,70 @@
+@serial
+@pim_ssm
+Feature: PIM SSM (S,G) forwarding end to end across two routers
+  As a network operator
+  I want an IGMPv3 source-specific join at the last-hop router to
+  build an (S,G) shortest-path tree back to the first-hop router and
+  program the kernel multicast forwarding cache on both, so real
+  traffic from the source reaches the receiver — the first complete
+  PIM-SM/SSM control-plane-to-dataplane slice.
+
+  h1 sends UDP to the SSM group 232.1.1.1. h2 issues a source-specific
+  join for (10.1.14.2, 232.1.1.1). r2 (LHR) must translate the IGMPv3
+  membership into a PIM (S,G) Join toward r1 (RPF via a static route),
+  r1 (FHR, source directly connected) must accept the Join into its
+  downstream state, and both must install kernel MFC entries that
+  forward h1's datagrams to h2.
+
+  Test Topology:
+  ```
+    h1 (10.1.14.2, sender) --- eth4/eth3 --- r1 --- eth1/eth2 --- r2 --- eth5/eth6 --- h2 (10.1.15.2, receiver)
+                                   10.1.14.1     10.1.13.1/.2       10.1.15.1
+  ```
+
+  Scenario: SSM join builds the (S,G) tree and traffic flows
+    Given a clean test environment
+    When I create namespace "r1"
+    And I create namespace "r2"
+    And I create namespace "h1"
+    And I create namespace "h2"
+    And I connect namespace "r1" interface "eth1" to namespace "r2" interface "eth2"
+    And I connect namespace "r1" interface "eth3" to namespace "h1" interface "eth4"
+    And I connect namespace "r2" interface "eth5" to namespace "h2" interface "eth6"
+    And I start zebra-rs in namespace "r1"
+    And I start zebra-rs in namespace "r2"
+    And I apply config "r1.yaml" to namespace "r1"
+    And I apply config "r2.yaml" to namespace "r2"
+    And I add address "10.1.14.2/24" to interface "eth4" in namespace "h1"
+    And I add address "10.1.15.2/24" to interface "eth6" in namespace "h2"
+
+    # PIM neighborship on the transit link first.
+    Then show command "show pim neighbor" in namespace "r2" should eventually contain "10.1.13.1"
+
+    # h2 source-specifically joins (10.1.14.2, 232.1.1.1): r2 turns the
+    # IGMPv3 membership into an (S,G) Join toward r1.
+    When I spawn "timeout 150 python3 tests/scripts/ssm_recv.py 232.1.1.1 10.1.14.2 10.1.15.2 5001 /tmp/pim_ssm_rx" in namespace "h2"
+    Then show command "show igmp groups" in namespace "r2" should eventually contain "232.1.1.1"
+    And show command "show pim upstream" in namespace "r2" should eventually contain "Joined"
+    And show command "show mroute" in namespace "r2" should eventually contain "232.1.1.1"
+    # r1 learned the (S,G) from r2's PIM Join — no IGMP on that path.
+    And show command "show mroute" in namespace "r1" should eventually contain "232.1.1.1"
+
+    # Kernel MFC on both routers, with the expected IIF/OIF split.
+    And command "ip mroute show" in namespace "r1" should eventually contain "Iif: eth3"
+    And command "ip mroute show" in namespace "r1" should eventually contain "eth1"
+    And command "ip mroute show" in namespace "r2" should eventually contain "Iif: eth2"
+    And command "ip mroute show" in namespace "r2" should eventually contain "eth5"
+
+    # The datapath proof: h1's datagrams arrive at h2's receiver.
+    When I spawn "timeout 120 python3 tests/scripts/mcast_send.py 232.1.1.1 5001 10.1.14.2 90" in namespace "h1"
+    Then command "cat /tmp/pim_ssm_rx" in namespace "h2" should eventually contain "ssm-hello"
+
+  Scenario: Teardown topology
+    When I execute "rm -f /tmp/pim_ssm_rx" in namespace "h2"
+    And I stop zebra-rs in namespace "r1"
+    And I stop zebra-rs in namespace "r2"
+    And I delete namespace "r1"
+    And I delete namespace "r2"
+    And I delete namespace "h1"
+    And I delete namespace "h2"
+    Then the test environment should be clean

--- a/bdd/tests/scripts/mcast_send.py
+++ b/bdd/tests/scripts/mcast_send.py
@@ -1,0 +1,22 @@
+#!/usr/bin/env python3
+"""Multicast UDP sender for BDD datapath tests.
+
+Usage: mcast_send.py GROUP PORT LOCAL_ADDR COUNT
+
+Sends one small datagram per second to GROUP:PORT from the interface
+owning LOCAL_ADDR, TTL 8 so it survives a router hop or two.
+"""
+
+import socket
+import sys
+import time
+
+group, port, local, count = sys.argv[1:5]
+
+sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+sock.setsockopt(socket.IPPROTO_IP, socket.IP_MULTICAST_IF, socket.inet_aton(local))
+sock.setsockopt(socket.IPPROTO_IP, socket.IP_MULTICAST_TTL, 8)
+
+for _ in range(int(count)):
+    sock.sendto(b"ssm-hello", (group, int(port)))
+    time.sleep(1)

--- a/bdd/tests/scripts/ssm_recv.py
+++ b/bdd/tests/scripts/ssm_recv.py
@@ -1,0 +1,34 @@
+#!/usr/bin/env python3
+"""SSM receiver: source-specific join + received-payload logging.
+
+Usage: ssm_recv.py GROUP SOURCE LOCAL_ADDR PORT OUTFILE
+
+Joins (SOURCE, GROUP) on the interface owning LOCAL_ADDR via
+IP_ADD_SOURCE_MEMBERSHIP (the kernel emits an IGMPv3 source-specific
+report), then appends every received UDP payload to OUTFILE — the
+end-to-end datapath proof for the PIM SSM BDD feature. OUTFILE is
+created immediately so pollers can `cat` it before traffic arrives.
+"""
+
+import socket
+import sys
+
+IP_ADD_SOURCE_MEMBERSHIP = 39
+
+group, source, local, port, outfile = sys.argv[1:6]
+
+sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+sock.bind((group, int(port)))
+
+# struct ip_mreq_source: imr_multiaddr, imr_interface, imr_sourceaddr.
+mreq = (
+    socket.inet_aton(group) + socket.inet_aton(local) + socket.inet_aton(source)
+)
+sock.setsockopt(socket.IPPROTO_IP, IP_ADD_SOURCE_MEMBERSHIP, mreq)
+
+with open(outfile, "w", buffering=1) as out:
+    out.write("joined\n")
+    while True:
+        data, _ = sock.recvfrom(2048)
+        out.write(data.decode(errors="replace") + "\n")

--- a/zebra-rs/src/config/manager.rs
+++ b/zebra-rs/src/config/manager.rs
@@ -1372,10 +1372,13 @@ fn is_ebpf(paths: &[CommandPath]) -> bool {
     paths.iter().any(|x| x.name == "ebpf")
 }
 
-/// `show pim ...` and `show igmp ...` — both served by the PIM task
-/// (IGMP membership tracking lives inside the PIM module).
+/// `show pim ...`, `show igmp ...` and `show mroute` — all served by
+/// the PIM task (IGMP membership tracking and the multicast routing
+/// table live inside the PIM module).
 fn is_pim(paths: &[CommandPath]) -> bool {
-    paths.iter().any(|x| x.name == "pim" || x.name == "igmp")
+    paths
+        .iter()
+        .any(|x| x.name == "pim" || x.name == "igmp" || x.name == "mroute")
 }
 
 fn is_policy(paths: &[CommandPath]) -> bool {

--- a/zebra-rs/src/config/pim.rs
+++ b/zebra-rs/src/config/pim.rs
@@ -1,5 +1,6 @@
 use crate::context::ProtoContext;
 use crate::pim::inst;
+use crate::pim::mroute::ForwardingPlane;
 use crate::pim::socket::{igmp_socket, pim_socket};
 use crate::rib;
 
@@ -34,9 +35,19 @@ pub fn spawn_pim(config: &ConfigManager) {
             return;
         }
     };
+    // The mroute socket claims the kernel's multicast-routing
+    // instance (MRT_INIT) — EADDRINUSE means another multicast
+    // daemon owns it on this host.
+    let fp = match ForwardingPlane::new(&probe) {
+        Ok(fp) => fp,
+        Err(e) => {
+            tracing::warn!("pim: not started (mroute socket: {e}); PIM disabled");
+            return;
+        }
+    };
     let (rib_client, rib_rx) = config.subscribe_to_rib("pim");
     let ctx = ProtoContext::default_table(rib_client);
-    let pim = inst::Pim::new(ctx, sock, igmp_sock, rib_rx);
+    let pim = inst::Pim::new(ctx, sock, igmp_sock, fp, rib_rx);
     config.subscribe("pim", pim.cm.tx.clone());
     config.subscribe_show("pim", pim.show.tx.clone());
     let task = inst::serve(pim);

--- a/zebra-rs/src/pim/igmp/mod.rs
+++ b/zebra-rs/src/pim/igmp/mod.rs
@@ -6,7 +6,7 @@
 //! per-source timer tasks. Membership feeds the TIB bridge from the
 //! SSM phase on.
 
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet};
 use std::net::Ipv4Addr;
 use std::time::{Duration, Instant};
 
@@ -16,6 +16,7 @@ use tokio::sync::mpsc::UnboundedSender;
 use super::inst::{IgmpSend, Pim};
 use super::link::LinkConfig;
 use super::socket::IGMP_ALL_HOSTS;
+use super::tib::Sg;
 
 /// Robustness Variable (RFC 3376 §8.1). Fixed at the protocol
 /// default; a config knob can arrive later.
@@ -91,6 +92,9 @@ pub struct IgmpGroup {
     pub v2_host_until: Option<Instant>,
     pub last_reporter: Option<Ipv4Addr>,
     pub uptime: Instant,
+    /// Sources currently reflected into the TIB as local (S,G)
+    /// membership — the diff base for [`Pim::igmp_tib_sync`].
+    pub synced: BTreeSet<Ipv4Addr>,
 }
 
 impl IgmpGroup {
@@ -102,6 +106,7 @@ impl IgmpGroup {
             v2_host_until: None,
             last_reporter: None,
             uptime: now,
+            synced: BTreeSet::new(),
         }
     }
 }
@@ -241,13 +246,16 @@ impl Pim {
             }
 
             let mut expired: Vec<Ipv4Addr> = vec![];
+            let mut sync: Vec<Ipv4Addr> = vec![];
             for (group_addr, group) in igmp.groups.iter_mut() {
                 if let Some(t) = group.v2_host_until
                     && t <= now
                 {
                     group.v2_host_until = None;
                 }
+                let sources_before = group.sources.len();
                 group.sources.retain(|_, exp| *exp > now);
+                let mut changed = group.sources.len() != sources_before;
                 if group.filter_mode == FilterMode::Exclude
                     && let Some(exp) = group.expires
                     && exp <= now
@@ -260,15 +268,61 @@ impl Pim {
                     // sources reverts the group to INCLUDE.
                     group.filter_mode = FilterMode::Include;
                     group.expires = None;
+                    changed = true;
                 }
                 if group.filter_mode == FilterMode::Include && group.sources.is_empty() {
                     expired.push(*group_addr);
+                    continue;
+                }
+                if changed {
+                    sync.push(*group_addr);
                 }
             }
+            let mut prune: Vec<(Ipv4Addr, Ipv4Addr)> = vec![];
             for group_addr in expired {
-                igmp.groups.remove(&group_addr);
+                if let Some(group) = igmp.groups.remove(&group_addr) {
+                    for source in group.synced {
+                        prune.push((group_addr, source));
+                    }
+                }
                 tracing::info!("igmp: group {} expired on {}", group_addr, name);
             }
+            for group_addr in sync {
+                self.igmp_tib_sync(ifindex, group_addr);
+            }
+            for (grp, src) in prune {
+                self.tib_local_prune(Sg { src, grp }, ifindex);
+            }
+        }
+    }
+
+    /// Reflect a group's INCLUDE source set into the TIB as local
+    /// (S,G) membership, diffing against what was previously synced.
+    /// EXCLUDE (any-source) membership stays out of the TIB until the
+    /// ASM phase brings (*,G) state.
+    pub(crate) fn igmp_tib_sync(&mut self, ifindex: u32, grp: Ipv4Addr) {
+        let Some(link) = self.links.get_mut(&ifindex) else {
+            return;
+        };
+        let Some(igmp) = link.igmp.as_mut() else {
+            return;
+        };
+        let Some(group) = igmp.groups.get_mut(&grp) else {
+            return;
+        };
+        let current: BTreeSet<Ipv4Addr> = if group.filter_mode == FilterMode::Include {
+            group.sources.keys().copied().collect()
+        } else {
+            BTreeSet::new()
+        };
+        let added: Vec<Ipv4Addr> = current.difference(&group.synced).copied().collect();
+        let removed: Vec<Ipv4Addr> = group.synced.difference(&current).copied().collect();
+        group.synced = current;
+        for src in added {
+            self.tib_local_join(Sg { src, grp }, ifindex);
+        }
+        for src in removed {
+            self.tib_local_prune(Sg { src, grp }, ifindex);
         }
     }
 
@@ -288,6 +342,9 @@ impl Pim {
             }
             IgmpPacket::ReportV1(msg) | IgmpPacket::ReportV2(msg) => {
                 self.igmp_v2_report(ifindex, src, msg.group, &cfg, now);
+                // A v2 report flips the group to EXCLUDE — any
+                // previously synced INCLUDE sources leave the TIB.
+                self.igmp_tib_sync(ifindex, msg.group);
             }
             IgmpPacket::LeaveV2(msg) => {
                 self.igmp_leave(ifindex, msg.group, &cfg, now);
@@ -295,6 +352,7 @@ impl Pim {
             IgmpPacket::ReportV3(report) => {
                 for record in report.records {
                     self.igmp_apply_record(ifindex, src, &record, &cfg, now);
+                    self.igmp_tib_sync(ifindex, record.group);
                 }
             }
             IgmpPacket::Unknown { typ, .. } => {

--- a/zebra-rs/src/pim/inst.rs
+++ b/zebra-rs/src/pim/inst.rs
@@ -27,8 +27,11 @@ use crate::rib::api::RibRx;
 
 use super::config::Callback;
 use super::link::{LinkConfig, PIM_OVERRIDE_INTERVAL_MSEC, PIM_PROPAGATION_DELAY_MSEC, PimLink};
-use super::network::{igmp_read_packet, igmp_write_packet, read_packet, write_packet};
+use super::mroute::{ForwardingPlane, Upcall};
+use super::network::{igmp_read_packet, igmp_write_packet, mroute_read, read_packet, write_packet};
+use super::rpf::RpfEntry;
 use super::socket::ALL_PIM_ROUTERS;
+use super::tib::{Sg, TibEntry};
 
 /// `show pim ...` dispatch handler, mirroring
 /// [`crate::nd::inst::ShowCallback`].
@@ -49,6 +52,7 @@ pub enum Message {
         src: Ipv4Addr,
         ifindex: u32,
     },
+    Upcall(Upcall),
     HelloTimer(u32),
     NeighborExpiry(u32, Ipv4Addr),
 }
@@ -79,6 +83,14 @@ pub struct Pim {
     /// Desired per-interface config keyed by interface name — the
     /// source of truth the reconciler compares runtime state against.
     pub if_config: BTreeMap<String, LinkConfig>,
+    /// The Tree Information Base: (S,G) forwarding state.
+    pub tib: BTreeMap<Sg, TibEntry>,
+    /// RPF cache keyed by source address (NHT-backed).
+    pub rpf: BTreeMap<Ipv4Addr, RpfEntry>,
+    /// Kernel dataplane: mroute socket, VIFs, MFC.
+    pub(crate) fp: ForwardingPlane,
+    /// Periodic J/P refresh deadlines per (ifindex, upstream nbr).
+    pub(crate) jp_refresh: BTreeMap<(u32, Ipv4Addr), std::time::Instant>,
     pub(crate) send_tx: UnboundedSender<PimSend>,
     pub(crate) igmp_send_tx: UnboundedSender<IgmpSend>,
     rib_rx: UnboundedReceiver<RibRx>,
@@ -88,14 +100,13 @@ pub struct Pim {
     pub callbacks: HashMap<String, Callback>,
     pub(crate) sock: Arc<AsyncFd<Socket>>,
     pub(crate) igmp_sock: Arc<AsyncFd<Socket>>,
-    /// RIB client context — unused until the RPF/NHT phase, kept so
-    /// the spawn contract already matches the other protocols.
-    #[allow(dead_code)]
-    ctx: ProtoContext,
+    /// RIB client context — carries the NHT registrations for RPF.
+    pub(crate) ctx: ProtoContext,
     _read_task: Task<()>,
     _write_task: Task<()>,
     _igmp_read_task: Task<()>,
     _igmp_write_task: Task<()>,
+    _mroute_read_task: Task<()>,
 }
 
 impl Pim {
@@ -103,6 +114,7 @@ impl Pim {
         ctx: ProtoContext,
         sock: AsyncFd<Socket>,
         igmp_sock: AsyncFd<Socket>,
+        fp: ForwardingPlane,
         rib_rx: UnboundedReceiver<RibRx>,
     ) -> Self {
         let sock = Arc::new(sock);
@@ -129,12 +141,21 @@ impl Pim {
         let igmp_write_task = Task::spawn(async move {
             igmp_write_packet(igmp_write_sock, igmp_send_rx).await;
         });
+        let mroute_sock = fp.sock.clone();
+        let mroute_tx = tx.clone();
+        let mroute_read_task = Task::spawn(async move {
+            mroute_read(mroute_sock, mroute_tx).await;
+        });
 
         let mut pim = Self {
             tx,
             rx,
             links: BTreeMap::new(),
             if_config: BTreeMap::new(),
+            tib: BTreeMap::new(),
+            rpf: BTreeMap::new(),
+            fp,
+            jp_refresh: BTreeMap::new(),
             send_tx,
             igmp_send_tx,
             rib_rx,
@@ -149,6 +170,7 @@ impl Pim {
             _write_task: write_task,
             _igmp_read_task: igmp_read_task,
             _igmp_write_task: igmp_write_task,
+            _mroute_read_task: mroute_read_task,
         };
         pim.callback_build();
         pim.show_build();
@@ -166,7 +188,10 @@ impl Pim {
             self.process_rib_msg(msg);
         }
         loop {
-            let wakeup = self.igmp_next_wakeup();
+            let wakeup = match (self.igmp_next_wakeup(), self.tib_next_wakeup()) {
+                (Some(a), Some(b)) => Some(a.min(b)),
+                (a, b) => a.or(b),
+            };
             tokio::select! {
                 Some(msg) = self.rx.recv() => {
                     self.process_msg(msg);
@@ -181,7 +206,9 @@ impl Pim {
                     self.process_show_msg(msg).await;
                 }
                 _ = sleep_until_opt(wakeup) => {
-                    self.igmp_tick(Instant::now());
+                    let now = Instant::now();
+                    self.igmp_tick(now);
+                    self.tib_tick(now);
                 }
             }
         }
@@ -199,6 +226,7 @@ impl Pim {
                 src,
                 ifindex,
             } => self.igmp_recv(ifindex, src, packet),
+            Message::Upcall(upcall) => self.process_upcall(upcall),
             Message::HelloTimer(ifindex) => self.hello_send(ifindex),
             Message::NeighborExpiry(ifindex, addr) => self.neighbor_expiry(ifindex, addr),
         }
@@ -212,8 +240,15 @@ impl Pim {
             RibRx::LinkDel(ifindex) => self.link_del(ifindex),
             RibRx::AddrAdd(addr) => self.addr_add(addr),
             RibRx::AddrDel(addr) => self.addr_del(addr),
-            _ => {}
+            RibRx::NexthopUpdate { nh, resolution } => {
+                self.rpf_nexthop_update(nh, resolution);
+                return;
+            }
+            _ => return,
         }
+        // Any link/address change can flip on-link-ness of tracked
+        // sources; re-derive the RPF states.
+        self.rpf_recompute_all();
     }
 
     fn process_cm_msg(&mut self, msg: ConfigRequest) {
@@ -237,9 +272,10 @@ impl Pim {
     fn packet_recv(&mut self, packet: PimPacket, src: Ipv4Addr, ifindex: u32) {
         match &packet.payload {
             PimPayload::Hello(hello) => self.hello_recv(ifindex, src, hello),
+            PimPayload::JoinPrune(jp) => self.jp_recv(ifindex, src, jp),
             other => {
-                // Join/Prune, Assert, Register handling arrives with
-                // the TIB phases.
+                // Assert / Register handling arrives with later
+                // phases.
                 tracing::debug!(
                     "pim: ignoring {} from {} on ifindex {} (not yet implemented)",
                     packet.typ,

--- a/zebra-rs/src/pim/jp.rs
+++ b/zebra-rs/src/pim/jp.rs
@@ -1,0 +1,152 @@
+//! Join/Prune message handling: the receive walk feeding the
+//! downstream FSM, triggered single-entry sends, and the periodic
+//! per-RPF-neighbor refresh that re-advertises every Joined entry
+//! (RFC 7761 §4.5 — the aggregation unit is the upstream neighbor).
+
+use std::collections::BTreeMap;
+use std::net::{IpAddr, Ipv4Addr};
+use std::time::{Duration, Instant};
+
+use pim_packet::{
+    EncodedGroup, EncodedSource, EncodedUnicast, JpGroup, PimJoinPrune, PimPacket, PimPayload,
+};
+
+use super::inst::{Pim, PimSend};
+use super::rpf::RpfState;
+use super::socket::ALL_PIM_ROUTERS;
+use super::tib::{JP_HOLDTIME, JoinState, Sg};
+
+/// Periodic J/P refresh interval (t_periodic, RFC 7761 §4.11).
+pub const JP_PERIOD: Duration = Duration::from_secs(60);
+
+impl Pim {
+    // ---- RX ----
+
+    pub(crate) fn jp_recv(&mut self, ifindex: u32, src: Ipv4Addr, jp: &PimJoinPrune) {
+        let Some(link) = self.links.get(&ifindex) else {
+            return;
+        };
+        if !link.enabled {
+            return;
+        }
+        // Process J/P entries addressed to one of our addresses on
+        // this interface; messages targeting another upstream router
+        // only matter for suppression/override (later phase).
+        let IpAddr::V4(upstream) = jp.upstream_neighbor.addr else {
+            return;
+        };
+        if !link.is_my_addr(&upstream) {
+            tracing::debug!(
+                "pim: J/P from {} on {} targets {} (not us) — ignored",
+                src,
+                link.name,
+                upstream
+            );
+            return;
+        }
+        let holdtime = jp.holdtime;
+        for group in &jp.groups {
+            let IpAddr::V4(grp) = group.group.addr else {
+                continue;
+            };
+            for join in &group.joins {
+                if join.wildcard || join.rpt {
+                    // (*,G) / (S,G,rpt) arrive with the ASM phase.
+                    tracing::debug!("pim: (*,G)/rpt join for {} ignored (ASM phase)", grp);
+                    continue;
+                }
+                let IpAddr::V4(src_addr) = join.addr else {
+                    continue;
+                };
+                self.downstream_join(ifindex, Sg { src: src_addr, grp }, holdtime);
+            }
+            for prune in &group.prunes {
+                if prune.wildcard || prune.rpt {
+                    continue;
+                }
+                let IpAddr::V4(src_addr) = prune.addr else {
+                    continue;
+                };
+                self.downstream_prune(ifindex, Sg { src: src_addr, grp });
+            }
+        }
+    }
+
+    // ---- TX ----
+
+    /// Triggered single-entry Join (`join == true`) or Prune toward
+    /// `nbr` out `ifindex`.
+    pub(crate) fn jp_send_single(&self, ifindex: u32, nbr: Ipv4Addr, sg: Sg, join: bool) {
+        let source = EncodedSource::sg(IpAddr::V4(sg.src));
+        let group = JpGroup {
+            group: EncodedGroup::new(IpAddr::V4(sg.grp)),
+            joins: if join { vec![source] } else { vec![] },
+            prunes: if join { vec![] } else { vec![source] },
+        };
+        self.jp_send(ifindex, nbr, vec![group]);
+    }
+
+    fn jp_send(&self, ifindex: u32, nbr: Ipv4Addr, groups: Vec<JpGroup>) {
+        let mut jp = PimJoinPrune::new(EncodedUnicast::new(IpAddr::V4(nbr)), JP_HOLDTIME);
+        jp.groups = groups;
+        let packet = PimPacket::new(PimPayload::JoinPrune(jp));
+        let _ = self.send_tx.send(PimSend {
+            packet,
+            ifindex,
+            dst: ALL_PIM_ROUTERS,
+        });
+    }
+
+    /// Make sure a periodic refresh is scheduled for this upstream
+    /// neighbor.
+    pub(crate) fn jp_refresh_arm(&mut self, ifindex: u32, nbr: Ipv4Addr) {
+        self.jp_refresh
+            .entry((ifindex, nbr))
+            .or_insert_with(|| Instant::now() + JP_PERIOD);
+    }
+
+    /// Periodic refresh: for each due (interface, neighbor) bucket,
+    /// re-send a Join for every entry currently joined through it;
+    /// drop the bucket when nothing uses that neighbor anymore.
+    pub(crate) fn jp_tick(&mut self, now: Instant) {
+        let due: Vec<(u32, Ipv4Addr)> = self
+            .jp_refresh
+            .iter()
+            .filter(|(_, t)| **t <= now)
+            .map(|(k, _)| *k)
+            .collect();
+        for (ifindex, nbr) in due {
+            // Aggregate all joined entries for this neighbor into one
+            // message, group records keyed by group address.
+            let mut by_group: BTreeMap<Ipv4Addr, Vec<EncodedSource>> = BTreeMap::new();
+            for (sg, entry) in self.tib.iter() {
+                if entry.join_state == JoinState::Joined
+                    && entry.rpf
+                        == (RpfState::Gateway {
+                            ifindex,
+                            nexthop: nbr,
+                        })
+                {
+                    by_group
+                        .entry(sg.grp)
+                        .or_default()
+                        .push(EncodedSource::sg(IpAddr::V4(sg.src)));
+                }
+            }
+            if by_group.is_empty() {
+                self.jp_refresh.remove(&(ifindex, nbr));
+                continue;
+            }
+            let groups: Vec<JpGroup> = by_group
+                .into_iter()
+                .map(|(grp, joins)| JpGroup {
+                    group: EncodedGroup::new(IpAddr::V4(grp)),
+                    joins,
+                    prunes: vec![],
+                })
+                .collect();
+            self.jp_send(ifindex, nbr, groups);
+            self.jp_refresh.insert((ifindex, nbr), now + JP_PERIOD);
+        }
+    }
+}

--- a/zebra-rs/src/pim/link.rs
+++ b/zebra-rs/src/pim/link.rs
@@ -165,8 +165,20 @@ impl Pim {
         let Some(link) = self.links.get_mut(&ifindex) else {
             return;
         };
-        link.igmp = None;
+        // Withdraw every local membership this interface fed into
+        // the TIB before dropping the state.
+        let mut prune: Vec<(Ipv4Addr, Ipv4Addr)> = vec![];
+        if let Some(igmp) = link.igmp.take() {
+            for (grp, group) in igmp.groups {
+                for src in group.synced {
+                    prune.push((grp, src));
+                }
+            }
+        }
         tracing::info!("igmp: interface {} disabled", link.name);
+        for (grp, src) in prune {
+            self.tib_local_prune(super::tib::Sg { src, grp }, ifindex);
+        }
     }
 
     /// Re-arm a running interface's hello timer after a hello-interval
@@ -209,6 +221,7 @@ impl Pim {
             self.link_config(&link.name).hello_interval()
         };
         pim_join_if(&self.sock, ifindex);
+        self.fp.vif_add(ifindex);
         let timer = hello_timer(&self.tx, ifindex, interval);
         let link = self.links.get_mut(&ifindex).unwrap();
         link.enabled = true;
@@ -233,6 +246,10 @@ impl Pim {
         link.nbrs.clear();
         link.dr = None;
         tracing::info!("pim: interface {} disabled", link.name);
+        // Drop every TIB facet on this interface, then the VIF (MFC
+        // entries referencing it were just rewritten).
+        self.tib_iface_purge(ifindex);
+        self.fp.vif_del(ifindex);
     }
 
     /// Effective config for an interface: the configured entry, or

--- a/zebra-rs/src/pim/macros.rs
+++ b/zebra-rs/src/pim/macros.rs
@@ -43,18 +43,14 @@ pub fn mfc_oifs(entry: &TibEntry, rpf_ifindex: Option<u32>) -> BTreeSet<u32> {
 
 #[cfg(test)]
 mod tests {
-    use std::net::Ipv4Addr;
     use std::time::{Duration, Instant};
 
     use super::*;
     use crate::pim::rpf::RpfState;
-    use crate::pim::tib::{Downstream, Sg, TibEntry};
+    use crate::pim::tib::{Downstream, TibEntry};
 
     fn entry() -> TibEntry {
-        TibEntry::new(Sg {
-            src: Ipv4Addr::new(10, 0, 0, 2),
-            grp: Ipv4Addr::new(232, 1, 1, 1),
-        })
+        TibEntry::new()
     }
 
     #[test]

--- a/zebra-rs/src/pim/macros.rs
+++ b/zebra-rs/src/pim/macros.rs
@@ -1,0 +1,105 @@
+//! RFC 7761 state-summarization predicates as named pure functions
+//! over a TIB entry (the ZebOS `pim_route.c` pattern). This phase
+//! carries the (S,G) subset the SSM slice needs; the rpt/star
+//! variants arrive with the ASM phase.
+
+use std::collections::BTreeSet;
+
+use super::tib::{DsState, TibEntry};
+
+/// `immediate_olist(S,G)`: interfaces with local (IGMP) membership or
+/// downstream Join state. A PrunePending interface still forwards
+/// until its timer fires (RFC 7761 §4.5.2 — the downstream state
+/// machine stays in the forwarding set during PrunePending).
+pub fn immediate_olist(entry: &TibEntry) -> BTreeSet<u32> {
+    let mut olist: BTreeSet<u32> = entry.local.iter().copied().collect();
+    for (ifindex, ds) in entry.downstream.iter() {
+        match ds.state {
+            DsState::Join | DsState::PrunePending { .. } => {
+                olist.insert(*ifindex);
+            }
+        }
+    }
+    olist
+}
+
+/// `JoinDesired(S,G)`: someone downstream (or local) wants the
+/// traffic. Whether a Join can actually be *sent* additionally
+/// requires an upstream PIM neighbor — that gate lives in the
+/// upstream FSM, not here.
+pub fn join_desired(entry: &TibEntry) -> bool {
+    !immediate_olist(entry).is_empty()
+}
+
+/// The MFC outgoing set: the olist minus the incoming interface
+/// (loop-free guard — never emit OIF == IIF).
+pub fn mfc_oifs(entry: &TibEntry, rpf_ifindex: Option<u32>) -> BTreeSet<u32> {
+    let mut oifs = immediate_olist(entry);
+    if let Some(iif) = rpf_ifindex {
+        oifs.remove(&iif);
+    }
+    oifs
+}
+
+#[cfg(test)]
+mod tests {
+    use std::net::Ipv4Addr;
+    use std::time::{Duration, Instant};
+
+    use super::*;
+    use crate::pim::rpf::RpfState;
+    use crate::pim::tib::{Downstream, Sg, TibEntry};
+
+    fn entry() -> TibEntry {
+        TibEntry::new(Sg {
+            src: Ipv4Addr::new(10, 0, 0, 2),
+            grp: Ipv4Addr::new(232, 1, 1, 1),
+        })
+    }
+
+    #[test]
+    fn olist_combines_local_and_downstream() {
+        let mut e = entry();
+        assert!(!join_desired(&e));
+        e.local.insert(3);
+        e.downstream.insert(
+            5,
+            Downstream {
+                state: DsState::Join,
+                expires: Instant::now() + Duration::from_secs(210),
+            },
+        );
+        assert_eq!(
+            immediate_olist(&e).into_iter().collect::<Vec<_>>(),
+            vec![3, 5]
+        );
+        assert!(join_desired(&e));
+    }
+
+    #[test]
+    fn prune_pending_still_forwards() {
+        let mut e = entry();
+        e.downstream.insert(
+            5,
+            Downstream {
+                state: DsState::PrunePending {
+                    until: Instant::now() + Duration::from_secs(3),
+                },
+                expires: Instant::now() + Duration::from_secs(210),
+            },
+        );
+        assert!(join_desired(&e));
+        assert_eq!(immediate_olist(&e).len(), 1);
+    }
+
+    #[test]
+    fn mfc_excludes_iif() {
+        let mut e = entry();
+        e.local.insert(3);
+        e.local.insert(7);
+        e.rpf = RpfState::Connected { ifindex: 7 };
+        let oifs = mfc_oifs(&e, e.rpf.ifindex());
+        assert!(oifs.contains(&3));
+        assert!(!oifs.contains(&7));
+    }
+}

--- a/zebra-rs/src/pim/mod.rs
+++ b/zebra-rs/src/pim/mod.rs
@@ -4,8 +4,13 @@
 pub mod config;
 pub mod igmp;
 pub mod inst;
+pub mod jp;
 pub mod link;
+pub mod macros;
+pub mod mroute;
 pub mod neighbor;
 pub mod network;
+pub mod rpf;
 pub mod show;
 pub mod socket;
+pub mod tib;

--- a/zebra-rs/src/pim/mroute.rs
+++ b/zebra-rs/src/pim/mroute.rs
@@ -1,0 +1,265 @@
+//! Kernel multicast-forwarding plane: the mroute socket
+//! (`MRT_INIT`/`MRT_PIM`), VIF allocation and MFC programming, and
+//! upcall parsing. All `MRT_*` interaction is confined here — the
+//! protocol engine only sees typed [`Upcall`] messages and the
+//! [`ForwardingPlane`] methods, mirroring the ZebOS pimd/mribd
+//! boundary inside one process.
+//!
+//! Linux delivers upcalls on the mroute socket disguised as IP
+//! packets whose protocol field is zero (`struct igmpmsg` overlays
+//! the IP header). Real IGMP packets also arrive here once
+//! interfaces are VIFs; those are ignored — the dedicated IGMP
+//! socket (`super::socket::igmp_socket`) is the IGMP RX path.
+
+use std::collections::BTreeMap;
+use std::net::Ipv4Addr;
+use std::os::fd::AsRawFd;
+
+use libc::c_int;
+use socket2::{Domain, Protocol, Socket};
+use std::sync::Arc;
+use tokio::io::unix::AsyncFd;
+
+use crate::context::ProtoContext;
+
+// linux/mroute.h — not exposed by the libc crate.
+const MRT_INIT: c_int = 200;
+const MRT_ADD_VIF: c_int = 202;
+const MRT_DEL_VIF: c_int = 203;
+const MRT_ADD_MFC: c_int = 204;
+const MRT_DEL_MFC: c_int = 205;
+const MRT_PIM: c_int = 208;
+
+const VIFF_USE_IFINDEX: u8 = 0x8;
+
+pub const MAXVIFS: usize = 32;
+
+const IGMPMSG_NOCACHE: u8 = 1;
+const IGMPMSG_WRONGVIF: u8 = 2;
+const IGMPMSG_WHOLEPKT: u8 = 3;
+const IGMPMSG_WRVIFWHOLE: u8 = 4;
+
+#[repr(C)]
+struct Vifctl {
+    vifc_vifi: u16,
+    vifc_flags: u8,
+    vifc_threshold: u8,
+    vifc_rate_limit: u32,
+    /// Union of `vifc_lcl_addr` / `vifc_lcl_ifindex`; with
+    /// `VIFF_USE_IFINDEX` this carries the ifindex.
+    vifc_lcl: u32,
+    vifc_rmt_addr: u32,
+}
+
+#[repr(C)]
+struct Mfcctl {
+    mfcc_origin: u32,
+    mfcc_mcastgrp: u32,
+    mfcc_parent: u16,
+    mfcc_ttls: [u8; MAXVIFS],
+    mfcc_pkt_cnt: u32,
+    mfcc_byte_cnt: u32,
+    mfcc_wrong_if: u32,
+    mfcc_expire: c_int,
+}
+
+/// A kernel upcall, parsed from the igmpmsg overlay.
+#[derive(Debug, Clone, Copy)]
+pub enum UpcallKind {
+    /// First packet of an unknown (S,G) — create forwarding state.
+    Nocache,
+    /// Data arrived on a non-IIF interface — assert trigger (later
+    /// phase).
+    WrongVif,
+    /// Full packet punt for Register encapsulation (ASM phase).
+    WholePkt,
+    /// Wrong-VIF with full packet — SPT switchover driver (ASM
+    /// phase).
+    WrVifWhole,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub struct Upcall {
+    pub kind: UpcallKind,
+    pub vif: u16,
+    pub src: Ipv4Addr,
+    pub grp: Ipv4Addr,
+}
+
+/// Parse one datagram read from the mroute socket. `None` for
+/// anything that is not an upcall (real IGMP traffic, runts).
+pub fn parse_upcall(buf: &[u8]) -> Option<Upcall> {
+    if buf.len() < 20 || buf[9] != 0 {
+        // buf[9] is ip->protocol alias im_mbz: nonzero ⇒ a genuine
+        // IGMP packet, handled on the IGMP socket.
+        return None;
+    }
+    let kind = match buf[8] {
+        IGMPMSG_NOCACHE => UpcallKind::Nocache,
+        IGMPMSG_WRONGVIF => UpcallKind::WrongVif,
+        IGMPMSG_WHOLEPKT => UpcallKind::WholePkt,
+        IGMPMSG_WRVIFWHOLE => UpcallKind::WrVifWhole,
+        other => {
+            tracing::debug!("mroute: unknown upcall type {other}");
+            return None;
+        }
+    };
+    Some(Upcall {
+        kind,
+        vif: buf[10] as u16 | ((buf[11] as u16) << 8),
+        src: Ipv4Addr::new(buf[12], buf[13], buf[14], buf[15]),
+        grp: Ipv4Addr::new(buf[16], buf[17], buf[18], buf[19]),
+    })
+}
+
+fn mrt_setsockopt<T>(sock: &Socket, opt: c_int, val: &T) -> std::io::Result<()> {
+    let ret = unsafe {
+        libc::setsockopt(
+            sock.as_raw_fd(),
+            libc::IPPROTO_IP,
+            opt,
+            val as *const T as *const libc::c_void,
+            std::mem::size_of::<T>() as libc::socklen_t,
+        )
+    };
+    if ret != 0 {
+        return Err(std::io::Error::last_os_error());
+    }
+    Ok(())
+}
+
+/// Owner of the mroute socket, the VIF table and the kernel MFC.
+/// Dropping it closes the socket, which makes the kernel run the
+/// implicit `MRT_DONE` cleanup (VIFs and MFC entries flushed).
+pub struct ForwardingPlane {
+    pub sock: Arc<AsyncFd<Socket>>,
+    /// ifindex → VIF. Index 0 stays reserved for the register VIF
+    /// (ASM phase).
+    vifs: BTreeMap<u32, u16>,
+}
+
+impl ForwardingPlane {
+    pub fn new(ctx: &ProtoContext) -> std::io::Result<Self> {
+        // The mroute socket must be a raw IGMP socket. MRT_INIT
+        // claims the (per-table) multicast-routing instance — EADDRINUSE
+        // means another daemon owns it.
+        let sock = ctx.raw_socket(Domain::IPV4, Protocol::from(super::socket::IGMP_IP_PROTO))?;
+        sock.set_nonblocking(true)?;
+        // Upcalls burst with traffic; keep a deep receive buffer.
+        let _ = sock.set_recv_buffer_size(1024 * 1024);
+        let one: c_int = 1;
+        mrt_setsockopt(&sock, MRT_INIT, &one)?;
+        // PIM mode: enables register decapsulation and the
+        // WRVIFWHOLE upcall used by the ASM phase.
+        if let Err(e) = mrt_setsockopt(&sock, MRT_PIM, &one) {
+            tracing::warn!("mroute: MRT_PIM failed ({e}); register handling degraded");
+        }
+        Ok(Self {
+            sock: Arc::new(AsyncFd::new(sock)?),
+            vifs: BTreeMap::new(),
+        })
+    }
+
+    pub fn vif(&self, ifindex: u32) -> Option<u16> {
+        self.vifs.get(&ifindex).copied()
+    }
+
+    pub fn ifindex_of(&self, vif: u16) -> Option<u32> {
+        self.vifs
+            .iter()
+            .find(|(_, v)| **v == vif)
+            .map(|(ifindex, _)| *ifindex)
+    }
+
+    pub fn vif_add(&mut self, ifindex: u32) {
+        if self.vifs.contains_key(&ifindex) {
+            return;
+        }
+        // VIF 0 is reserved for the future register VIF.
+        let mut vif: u16 = 1;
+        while self.vifs.values().any(|v| *v == vif) {
+            vif += 1;
+        }
+        if vif as usize >= MAXVIFS {
+            tracing::warn!("mroute: out of VIFs for ifindex {ifindex}");
+            return;
+        }
+        let vc = Vifctl {
+            vifc_vifi: vif,
+            vifc_flags: VIFF_USE_IFINDEX,
+            vifc_threshold: 1,
+            vifc_rate_limit: 0,
+            vifc_lcl: ifindex,
+            vifc_rmt_addr: 0,
+        };
+        match mrt_setsockopt(self.sock.get_ref(), MRT_ADD_VIF, &vc) {
+            Ok(()) => {
+                self.vifs.insert(ifindex, vif);
+                tracing::info!("mroute: VIF {vif} added for ifindex {ifindex}");
+            }
+            Err(e) => tracing::warn!("mroute: MRT_ADD_VIF ifindex {ifindex} failed: {e}"),
+        }
+    }
+
+    pub fn vif_del(&mut self, ifindex: u32) {
+        let Some(vif) = self.vifs.remove(&ifindex) else {
+            return;
+        };
+        let vc = Vifctl {
+            vifc_vifi: vif,
+            vifc_flags: VIFF_USE_IFINDEX,
+            vifc_threshold: 1,
+            vifc_rate_limit: 0,
+            vifc_lcl: ifindex,
+            vifc_rmt_addr: 0,
+        };
+        if let Err(e) = mrt_setsockopt(self.sock.get_ref(), MRT_DEL_VIF, &vc) {
+            tracing::debug!("mroute: MRT_DEL_VIF ifindex {ifindex} failed: {e}");
+        } else {
+            tracing::info!("mroute: VIF {vif} deleted for ifindex {ifindex}");
+        }
+    }
+
+    /// Install or replace the (S,G) MFC entry. `MRT_ADD_MFC` on an
+    /// existing (origin, group) updates it in place.
+    pub fn mfc_add(&self, src: Ipv4Addr, grp: Ipv4Addr, iif: u16, oifs: &[u16]) {
+        let mut mc = Mfcctl {
+            mfcc_origin: u32::from_ne_bytes(src.octets()),
+            mfcc_mcastgrp: u32::from_ne_bytes(grp.octets()),
+            mfcc_parent: iif,
+            mfcc_ttls: [0; MAXVIFS],
+            mfcc_pkt_cnt: 0,
+            mfcc_byte_cnt: 0,
+            mfcc_wrong_if: 0,
+            mfcc_expire: 0,
+        };
+        for oif in oifs {
+            if (*oif as usize) < MAXVIFS && *oif != iif {
+                mc.mfcc_ttls[*oif as usize] = 1;
+            }
+        }
+        if let Err(e) = mrt_setsockopt(self.sock.get_ref(), MRT_ADD_MFC, &mc) {
+            tracing::warn!("mroute: MRT_ADD_MFC ({src},{grp}) failed: {e}");
+        } else {
+            tracing::debug!("mroute: MFC ({src},{grp}) iif {iif} oifs {oifs:?}");
+        }
+    }
+
+    pub fn mfc_del(&self, src: Ipv4Addr, grp: Ipv4Addr) {
+        let mc = Mfcctl {
+            mfcc_origin: u32::from_ne_bytes(src.octets()),
+            mfcc_mcastgrp: u32::from_ne_bytes(grp.octets()),
+            mfcc_parent: 0,
+            mfcc_ttls: [0; MAXVIFS],
+            mfcc_pkt_cnt: 0,
+            mfcc_byte_cnt: 0,
+            mfcc_wrong_if: 0,
+            mfcc_expire: 0,
+        };
+        if let Err(e) = mrt_setsockopt(self.sock.get_ref(), MRT_DEL_MFC, &mc) {
+            tracing::debug!("mroute: MRT_DEL_MFC ({src},{grp}) failed: {e}");
+        } else {
+            tracing::debug!("mroute: MFC ({src},{grp}) deleted");
+        }
+    }
+}

--- a/zebra-rs/src/pim/neighbor.rs
+++ b/zebra-rs/src/pim/neighbor.rs
@@ -106,6 +106,9 @@ impl Pim {
             // Triggered hello so a newly-heard neighbor learns us
             // without waiting out our hello period (RFC 7761 §4.3.1).
             self.hello_send(ifindex);
+            // Entries parked for lack of this upstream neighbor can
+            // join now.
+            self.tib_neighbor_up(ifindex, src);
         } else if bounced {
             tracing::info!(
                 "pim: neighbor {} on {} restarted (GenID change)",
@@ -127,6 +130,7 @@ impl Pim {
         if link.nbrs.remove(&addr).is_some() {
             tracing::info!("pim: neighbor {} down on {} ({})", addr, link.name, reason);
             self.dr_election(ifindex);
+            self.tib_neighbor_down(ifindex, addr);
         }
     }
 }

--- a/zebra-rs/src/pim/network.rs
+++ b/zebra-rs/src/pim/network.rs
@@ -17,6 +17,7 @@ use tokio::io::unix::AsyncFd;
 use tokio::sync::mpsc::{UnboundedReceiver, UnboundedSender};
 
 use super::inst::{IgmpSend, Message, PimSend};
+use super::mroute::parse_upcall;
 
 pub async fn read_packet(sock: Arc<AsyncFd<Socket>>, tx: UnboundedSender<Message>) {
     let mut buf = [0u8; 1024 * 16];
@@ -150,6 +151,38 @@ pub async fn igmp_read_packet(sock: Arc<AsyncFd<Socket>>, tx: UnboundedSender<Me
                     ifindex,
                 });
 
+                Ok(())
+            })
+            .await;
+        if tx.is_closed() {
+            return;
+        }
+    }
+}
+
+/// Drain the mroute socket: kernel upcalls (protocol field zero)
+/// become [`Message::Upcall`]; genuine IGMP packets that the kernel
+/// also delivers here are dropped — the IGMP socket is their RX path.
+pub async fn mroute_read(sock: Arc<AsyncFd<Socket>>, tx: UnboundedSender<Message>) {
+    let mut buf = [0u8; 1024 * 16];
+
+    loop {
+        let _ = sock
+            .async_io(Interest::READABLE, |sock| {
+                let n = unsafe {
+                    libc::recv(
+                        sock.as_raw_fd(),
+                        buf.as_mut_ptr() as *mut libc::c_void,
+                        buf.len(),
+                        0,
+                    )
+                };
+                if n < 0 {
+                    return Err(std::io::Error::last_os_error());
+                }
+                if let Some(upcall) = parse_upcall(&buf[..n as usize]) {
+                    let _ = tx.send(Message::Upcall(upcall));
+                }
                 Ok(())
             })
             .await;

--- a/zebra-rs/src/pim/rpf.rs
+++ b/zebra-rs/src/pim/rpf.rs
@@ -1,0 +1,176 @@
+//! RPF cache: per-source resolution backed by the RIB's next-hop
+//! tracking (register-then-gate — state parks while unresolved).
+//! Directly-connected sources resolve against the interface table
+//! first; everything else follows the tracked RIB resolution.
+
+use std::collections::BTreeMap;
+use std::net::{IpAddr, Ipv4Addr};
+
+use crate::rib;
+use crate::rib::nht::NexthopResolution;
+
+use super::inst::Pim;
+use super::tib::Sg;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RpfState {
+    Unresolved,
+    /// The source is on-link: no upstream neighbor, no Join to send.
+    Connected {
+        ifindex: u32,
+    },
+    /// Remote source: Joins go to `nexthop` out `ifindex` — if that
+    /// address is a live PIM neighbor there.
+    Gateway {
+        ifindex: u32,
+        nexthop: Ipv4Addr,
+    },
+}
+
+impl RpfState {
+    pub fn ifindex(&self) -> Option<u32> {
+        match self {
+            RpfState::Unresolved => None,
+            RpfState::Connected { ifindex } | RpfState::Gateway { ifindex, .. } => Some(*ifindex),
+        }
+    }
+}
+
+pub struct RpfEntry {
+    pub state: RpfState,
+    refs: usize,
+    resolution: Option<NexthopResolution>,
+}
+
+impl Pim {
+    /// Take a reference on the RPF state for `src`, registering NHT
+    /// interest on first use. The immediate `NexthopUpdate` echo from
+    /// RIB refines the state asynchronously.
+    pub(crate) fn rpf_acquire(&mut self, src: Ipv4Addr) -> RpfState {
+        if let Some(entry) = self.rpf.get_mut(&src) {
+            entry.refs += 1;
+            return entry.state;
+        }
+        let state = compute_rpf(&self.links, src, None);
+        let _ = self.ctx.rib.send(rib::Message::NexthopRegister {
+            proto: "pim".to_string(),
+            nh: IpAddr::V4(src),
+        });
+        self.rpf.insert(
+            src,
+            RpfEntry {
+                state,
+                refs: 1,
+                resolution: None,
+            },
+        );
+        state
+    }
+
+    pub(crate) fn rpf_release(&mut self, src: Ipv4Addr) {
+        let Some(entry) = self.rpf.get_mut(&src) else {
+            return;
+        };
+        entry.refs -= 1;
+        if entry.refs == 0 {
+            self.rpf.remove(&src);
+            let _ = self.ctx.rib.send(rib::Message::NexthopUnregister {
+                proto: "pim".to_string(),
+                nh: IpAddr::V4(src),
+            });
+        }
+    }
+
+    /// RIB pushed a new resolution for a tracked address.
+    pub(crate) fn rpf_nexthop_update(&mut self, nh: IpAddr, resolution: NexthopResolution) {
+        let IpAddr::V4(src) = nh else {
+            return;
+        };
+        let Some(entry) = self.rpf.get_mut(&src) else {
+            return;
+        };
+        entry.resolution = Some(resolution);
+        let state = compute_rpf(&self.links, src, entry.resolution.as_ref());
+        if entry.state != state {
+            entry.state = state;
+            self.rpf_changed(src, state);
+        }
+    }
+
+    /// Interface/address topology changed: recompute every tracked
+    /// source (connected-ness may have flipped even without a RIB
+    /// resolution change).
+    pub(crate) fn rpf_recompute_all(&mut self) {
+        let sources: Vec<Ipv4Addr> = self.rpf.keys().copied().collect();
+        for src in sources {
+            let Some(entry) = self.rpf.get_mut(&src) else {
+                continue;
+            };
+            let state = compute_rpf(&self.links, src, entry.resolution.as_ref());
+            if entry.state != state {
+                entry.state = state;
+                self.rpf_changed(src, state);
+            }
+        }
+    }
+
+    /// Propagate an RPF change into every TIB entry for that source:
+    /// prune off the old upstream, adopt the new state, re-evaluate.
+    fn rpf_changed(&mut self, src: Ipv4Addr, state: RpfState) {
+        let sgs: Vec<Sg> = self
+            .tib
+            .keys()
+            .filter(|sg| sg.src == src)
+            .copied()
+            .collect();
+        for sg in sgs {
+            self.tib_rpf_change(sg, state);
+        }
+    }
+
+    pub(crate) fn rpf_state(&self, src: Ipv4Addr) -> RpfState {
+        self.rpf
+            .get(&src)
+            .map(|e| e.state)
+            .unwrap_or(RpfState::Unresolved)
+    }
+}
+
+fn compute_rpf(
+    links: &BTreeMap<u32, super::link::PimLink>,
+    src: Ipv4Addr,
+    resolution: Option<&NexthopResolution>,
+) -> RpfState {
+    // On-link check first: a directly-connected source needs no
+    // upstream neighbor regardless of what the RIB says.
+    for link in links.values() {
+        if link.link_up && link.addrs.iter().any(|p| p.contains(&src)) {
+            return RpfState::Connected {
+                ifindex: link.ifindex,
+            };
+        }
+    }
+    let Some(resolution) = resolution else {
+        return RpfState::Unresolved;
+    };
+    if !resolution.reachable {
+        return RpfState::Unresolved;
+    }
+    // ECMP: take the RIB's first resolved nexthop as-is (no PIM-side
+    // hashing in this phase).
+    let Some(nexthop) = resolution.nexthops.first() else {
+        return RpfState::Unresolved;
+    };
+    let IpAddr::V4(gw) = nexthop.addr else {
+        return RpfState::Unresolved;
+    };
+    if gw == src {
+        return RpfState::Connected {
+            ifindex: nexthop.ifindex,
+        };
+    }
+    RpfState::Gateway {
+        ifindex: nexthop.ifindex,
+        nexthop: gw,
+    }
+}

--- a/zebra-rs/src/pim/rpf.rs
+++ b/zebra-rs/src/pim/rpf.rs
@@ -127,13 +127,6 @@ impl Pim {
             self.tib_rpf_change(sg, state);
         }
     }
-
-    pub(crate) fn rpf_state(&self, src: Ipv4Addr) -> RpfState {
-        self.rpf
-            .get(&src)
-            .map(|e| e.state)
-            .unwrap_or(RpfState::Unresolved)
-    }
 }
 
 fn compute_rpf(

--- a/zebra-rs/src/pim/show.rs
+++ b/zebra-rs/src/pim/show.rs
@@ -35,7 +35,7 @@ impl Pim {
             .map();
     }
 
-    fn ifname(&self, ifindex: u32) -> String {
+    pub(crate) fn ifname(&self, ifindex: u32) -> String {
         self.links
             .get(&ifindex)
             .map(|l| l.name.clone())

--- a/zebra-rs/src/pim/show.rs
+++ b/zebra-rs/src/pim/show.rs
@@ -11,6 +11,9 @@ use crate::config::{Args, Builder};
 
 use super::igmp::{FilterMode, QuerierState};
 use super::inst::{Pim, ShowCallback};
+use super::macros::mfc_oifs;
+use super::rpf::RpfState;
+use super::tib::JoinState;
 
 impl Pim {
     pub fn show_build(&mut self) {
@@ -25,7 +28,18 @@ impl Pim {
             .set(show_igmp_interface)
             .path("/show/igmp/groups")
             .set(show_igmp_groups)
+            .path("/show/pim/upstream")
+            .set(show_pim_upstream)
+            .path("/show/mroute")
+            .set(show_mroute)
             .map();
+    }
+
+    fn ifname(&self, ifindex: u32) -> String {
+        self.links
+            .get(&ifindex)
+            .map(|l| l.name.clone())
+            .unwrap_or_else(|| format!("if{}", ifindex))
     }
 }
 
@@ -277,6 +291,126 @@ fn show_igmp_groups(pim: &Pim, _args: Args, json: bool) -> Result<String, std::f
             row.expires,
             row.uptime,
             row.last_reporter,
+        )?;
+    }
+    Ok(buf)
+}
+
+#[derive(Serialize)]
+struct UpstreamBrief {
+    sg: String,
+    iif: String,
+    rpf_neighbor: String,
+    state: String,
+    uptime: String,
+}
+
+fn show_pim_upstream(pim: &Pim, _args: Args, json: bool) -> Result<String, std::fmt::Error> {
+    let mut rows: Vec<UpstreamBrief> = vec![];
+
+    for (sg, entry) in pim.tib.iter() {
+        let (iif, rpf_neighbor) = match entry.rpf {
+            RpfState::Unresolved => ("-".to_string(), "-".to_string()),
+            RpfState::Connected { ifindex } => (pim.ifname(ifindex), "connected".to_string()),
+            RpfState::Gateway { ifindex, nexthop } => (pim.ifname(ifindex), nexthop.to_string()),
+        };
+        rows.push(UpstreamBrief {
+            sg: sg.to_string(),
+            iif,
+            rpf_neighbor,
+            state: match entry.join_state {
+                JoinState::Joined => "Joined".to_string(),
+                JoinState::NotJoined => "NotJoined".to_string(),
+            },
+            uptime: uptime_string(entry.uptime.elapsed().as_secs()),
+        });
+    }
+
+    if json {
+        return Ok(serde_json::to_string(&rows).unwrap());
+    }
+
+    let mut buf = String::new();
+    buf.push_str(
+        "Source           Group            Iif          RPF Nbr          State      Uptime\n",
+    );
+    for (sg, row) in pim.tib.keys().zip(rows.iter()) {
+        writeln!(
+            buf,
+            "{:<17}{:<17}{:<13}{:<17}{:<11}{}",
+            sg.src, sg.grp, row.iif, row.rpf_neighbor, row.state, row.uptime,
+        )?;
+    }
+    Ok(buf)
+}
+
+#[derive(Serialize)]
+struct MrouteBrief {
+    sg: String,
+    iif: String,
+    oifs: Vec<String>,
+    flags: String,
+    installed: bool,
+    uptime: String,
+}
+
+fn show_mroute(pim: &Pim, _args: Args, json: bool) -> Result<String, std::fmt::Error> {
+    let mut rows: Vec<MrouteBrief> = vec![];
+
+    for (sg, entry) in pim.tib.iter() {
+        let iif = entry
+            .rpf
+            .ifindex()
+            .map_or_else(|| "-".to_string(), |i| pim.ifname(i));
+        let oifs: Vec<String> = mfc_oifs(entry, entry.rpf.ifindex())
+            .iter()
+            .map(|i| pim.ifname(*i))
+            .collect();
+        let mut flags = String::new();
+        if entry.join_state == JoinState::Joined {
+            flags.push('J');
+        }
+        if !entry.local.is_empty() {
+            flags.push('L');
+        }
+        if entry.stream_expires.is_some() {
+            flags.push('S');
+        }
+        if entry.installed.is_some() {
+            flags.push('I');
+        }
+        rows.push(MrouteBrief {
+            sg: sg.to_string(),
+            iif,
+            oifs,
+            flags,
+            installed: entry.installed.is_some(),
+            uptime: uptime_string(entry.uptime.elapsed().as_secs()),
+        });
+    }
+
+    if json {
+        return Ok(serde_json::to_string(&rows).unwrap());
+    }
+
+    let mut buf = String::new();
+    buf.push_str("IP Multicast Routing Table\n");
+    buf.push_str(
+        "Flags: J - Joined upstream, L - Local members, S - Stream (KAT), I - Installed\n\n",
+    );
+    for row in &rows {
+        writeln!(
+            buf,
+            "{}  Iif: {}  Oifs: {}  Flags: {}  Uptime: {}",
+            row.sg,
+            row.iif,
+            if row.oifs.is_empty() {
+                "-".to_string()
+            } else {
+                row.oifs.join(" ")
+            },
+            row.flags,
+            row.uptime,
         )?;
     }
     Ok(buf)

--- a/zebra-rs/src/pim/tib.rs
+++ b/zebra-rs/src/pim/tib.rs
@@ -1,0 +1,432 @@
+//! The Tree Information Base: (S,G) entries combining upstream
+//! Join/Prune state, downstream per-interface state, local (IGMP)
+//! membership, and the installed-MFC shadow. `tib_update` is the
+//! single reconvergence point: every input event mutates one facet
+//! and calls it; it re-evaluates the RFC 7761 predicates
+//! (`super::macros`) and diffs the result against the running
+//! upstream state and the kernel MFC.
+
+use std::collections::{BTreeMap, BTreeSet};
+use std::fmt;
+use std::net::Ipv4Addr;
+use std::time::{Duration, Instant};
+
+use super::inst::Pim;
+use super::macros::{join_desired, mfc_oifs};
+use super::mroute::{Upcall, UpcallKind};
+use super::rpf::RpfState;
+
+/// Join/Prune holdtime we advertise and the downstream expiry we run
+/// (3.5 × the 60 s J/P period).
+pub const JP_HOLDTIME: u16 = 210;
+
+/// (S,G) keepalive for traffic-created (NOCACHE) state without
+/// receivers.
+pub const KEEPALIVE_PERIOD: Duration = Duration::from_secs(210);
+
+/// Prune-pending delay on a LAN with other neighbors: propagation
+/// delay (500 ms) + override interval (2500 ms).
+pub const PRUNE_PENDING_DELAY: Duration = Duration::from_millis(3000);
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub struct Sg {
+    pub src: Ipv4Addr,
+    pub grp: Ipv4Addr,
+}
+
+impl fmt::Display for Sg {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "({}, {})", self.src, self.grp)
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum JoinState {
+    NotJoined,
+    Joined,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DsState {
+    Join,
+    PrunePending { until: Instant },
+}
+
+#[derive(Debug, Clone, Copy)]
+pub struct Downstream {
+    pub state: DsState,
+    /// Expiry Timer (ET): holdtime from the last Join.
+    pub expires: Instant,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct InstalledMfc {
+    pub iif: u16,
+    pub oifs: Vec<u16>,
+}
+
+pub struct TibEntry {
+    pub sg: Sg,
+    pub join_state: JoinState,
+    /// RPF snapshot this entry currently operates on; refreshed by
+    /// `tib_rpf_change` so a change can prune the old upstream first.
+    pub rpf: RpfState,
+    /// Interfaces with local IGMP (S,G) membership.
+    pub local: BTreeSet<u32>,
+    /// Downstream per-interface Join/Prune state, keyed by ifindex.
+    pub downstream: BTreeMap<u32, Downstream>,
+    /// Kernel MFC shadow — `Some` while installed.
+    pub installed: Option<InstalledMfc>,
+    /// Keepalive deadline for traffic-created state (NOCACHE); the
+    /// entry survives without receivers until this passes.
+    pub stream_expires: Option<Instant>,
+    pub uptime: Instant,
+}
+
+impl TibEntry {
+    pub fn new(sg: Sg) -> Self {
+        Self {
+            sg,
+            join_state: JoinState::NotJoined,
+            rpf: RpfState::Unresolved,
+            local: BTreeSet::new(),
+            downstream: BTreeMap::new(),
+            installed: None,
+            stream_expires: None,
+            uptime: Instant::now(),
+        }
+    }
+}
+
+impl Pim {
+    fn tib_get_or_create(&mut self, sg: Sg) -> &mut TibEntry {
+        if !self.tib.contains_key(&sg) {
+            let rpf = self.rpf_acquire(sg.src);
+            let mut entry = TibEntry::new(sg);
+            entry.rpf = rpf;
+            self.tib.insert(sg, entry);
+            tracing::info!("pim: {} created", sg);
+        }
+        self.tib.get_mut(&sg).unwrap()
+    }
+
+    // ---- TIB bridge (IGMP membership → PIM state) ----
+
+    pub(crate) fn tib_local_join(&mut self, sg: Sg, ifindex: u32) {
+        self.tib_get_or_create(sg).local.insert(ifindex);
+        self.tib_update(sg);
+    }
+
+    pub(crate) fn tib_local_prune(&mut self, sg: Sg, ifindex: u32) {
+        if let Some(entry) = self.tib.get_mut(&sg) {
+            entry.local.remove(&ifindex);
+            self.tib_update(sg);
+        }
+    }
+
+    // ---- downstream Join/Prune RX (per-interface FSM) ----
+
+    pub(crate) fn downstream_join(&mut self, ifindex: u32, sg: Sg, holdtime: u16) {
+        let now = Instant::now();
+        let entry = self.tib_get_or_create(sg);
+        entry.downstream.insert(
+            ifindex,
+            Downstream {
+                state: DsState::Join,
+                expires: now + Duration::from_secs(holdtime as u64),
+            },
+        );
+        self.tib_update(sg);
+    }
+
+    pub(crate) fn downstream_prune(&mut self, ifindex: u32, sg: Sg) {
+        let Some(entry) = self.tib.get_mut(&sg) else {
+            return;
+        };
+        let Some(ds) = entry.downstream.get_mut(&ifindex) else {
+            return;
+        };
+        if !matches!(ds.state, DsState::Join) {
+            return;
+        }
+        // With other PIM routers on the LAN, hold the prune open for
+        // the override window so another receiver's Join can cancel
+        // it; on a point-to-point-ish link (no other neighbors would
+        // override their own prune) act on the next tick.
+        let others = self
+            .links
+            .get(&ifindex)
+            .map(|l| l.nbrs.len() > 1)
+            .unwrap_or(false);
+        let until = if others {
+            Instant::now() + PRUNE_PENDING_DELAY
+        } else {
+            Instant::now()
+        };
+        ds.state = DsState::PrunePending { until };
+        // Forwarding is unchanged until the timer fires (tick).
+    }
+
+    // ---- upcalls from the kernel dataplane ----
+
+    pub(crate) fn process_upcall(&mut self, upcall: Upcall) {
+        match upcall.kind {
+            UpcallKind::Nocache => {
+                if !upcall.grp.is_multicast() || upcall.grp.octets()[..3] == [224, 0, 0] {
+                    return;
+                }
+                let sg = Sg {
+                    src: upcall.src,
+                    grp: upcall.grp,
+                };
+                let entry = self.tib_get_or_create(sg);
+                // Traffic keeps punting until an MFC entry exists;
+                // stamp/refresh the keepalive and (re)install — with
+                // no receivers this is a "negative" empty-OIL entry
+                // that silences the punts until KAT expiry.
+                entry.stream_expires = Some(Instant::now() + KEEPALIVE_PERIOD);
+                self.tib_update(sg);
+            }
+            UpcallKind::WrongVif | UpcallKind::WrVifWhole => {
+                // Assert machinery arrives in a later phase.
+                tracing::debug!(
+                    "pim: wrong-vif upcall for ({}, {}) on vif {} (assert not yet implemented)",
+                    upcall.src,
+                    upcall.grp,
+                    upcall.vif
+                );
+            }
+            UpcallKind::WholePkt => {
+                tracing::debug!(
+                    "pim: wholepkt upcall for ({}, {}) (register not yet implemented)",
+                    upcall.src,
+                    upcall.grp
+                );
+            }
+        }
+    }
+
+    // ---- RPF change propagation ----
+
+    pub(crate) fn tib_rpf_change(&mut self, sg: Sg, state: RpfState) {
+        let Some(entry) = self.tib.get_mut(&sg) else {
+            return;
+        };
+        let old = entry.rpf;
+        if old == state {
+            return;
+        }
+        // Prune off the old upstream before adopting the new path.
+        if entry.join_state == JoinState::Joined
+            && let RpfState::Gateway { ifindex, nexthop } = old
+        {
+            entry.join_state = JoinState::NotJoined;
+            self.jp_send_single(ifindex, nexthop, sg, false);
+        }
+        if let Some(entry) = self.tib.get_mut(&sg) {
+            entry.rpf = state;
+        }
+        tracing::info!("pim: {} RPF change {:?} -> {:?}", sg, old, state);
+        self.tib_update(sg);
+    }
+
+    // ---- neighbor hooks ----
+
+    /// A new PIM neighbor appeared: entries parked for lack of an
+    /// upstream neighbor on that (interface, address) can join now.
+    pub(crate) fn tib_neighbor_up(&mut self, ifindex: u32, addr: Ipv4Addr) {
+        let sgs: Vec<Sg> = self
+            .tib
+            .iter()
+            .filter(|(_, e)| {
+                e.join_state == JoinState::NotJoined
+                    && e.rpf
+                        == RpfState::Gateway {
+                            ifindex,
+                            nexthop: addr,
+                        }
+            })
+            .map(|(sg, _)| *sg)
+            .collect();
+        for sg in sgs {
+            self.tib_update(sg);
+        }
+    }
+
+    /// A PIM neighbor vanished: entries joined through it fall back
+    /// to NotJoined (no prune TX — the peer is gone).
+    pub(crate) fn tib_neighbor_down(&mut self, ifindex: u32, addr: Ipv4Addr) {
+        let sgs: Vec<Sg> = self
+            .tib
+            .iter()
+            .filter(|(_, e)| {
+                e.rpf
+                    == RpfState::Gateway {
+                        ifindex,
+                        nexthop: addr,
+                    }
+            })
+            .map(|(sg, _)| *sg)
+            .collect();
+        for sg in sgs {
+            if let Some(entry) = self.tib.get_mut(&sg) {
+                entry.join_state = JoinState::NotJoined;
+            }
+            self.tib_update(sg);
+        }
+    }
+
+    /// PIM stopped on an interface: drop every per-interface facet
+    /// that references it.
+    pub(crate) fn tib_iface_purge(&mut self, ifindex: u32) {
+        let sgs: Vec<Sg> = self.tib.keys().copied().collect();
+        for sg in sgs {
+            if let Some(entry) = self.tib.get_mut(&sg) {
+                let touched = entry.local.remove(&ifindex)
+                    | entry.downstream.remove(&ifindex).is_some()
+                    | (entry.rpf.ifindex() == Some(ifindex));
+                if touched {
+                    self.tib_update(sg);
+                }
+            }
+        }
+    }
+
+    // ---- the reconvergence point ----
+
+    /// Re-evaluate one entry end-to-end: lifetime, upstream
+    /// Join/Prune state, kernel MFC. Every mutation path funnels
+    /// through here.
+    pub(crate) fn tib_update(&mut self, sg: Sg) {
+        let Some(entry) = self.tib.get(&sg) else {
+            return;
+        };
+
+        // Lifetime: no receivers, no live traffic keepalive → delete.
+        let now = Instant::now();
+        let stream_alive = entry.stream_expires.map(|t| t > now).unwrap_or(false);
+        if entry.local.is_empty() && entry.downstream.is_empty() && !stream_alive {
+            let was = entry.join_state;
+            let rpf = entry.rpf;
+            let installed = entry.installed.is_some();
+            if installed {
+                self.fp.mfc_del(sg.src, sg.grp);
+            }
+            if was == JoinState::Joined
+                && let RpfState::Gateway { ifindex, nexthop } = rpf
+            {
+                self.jp_send_single(ifindex, nexthop, sg, false);
+            }
+            self.tib.remove(&sg);
+            self.rpf_release(sg.src);
+            tracing::info!("pim: {} deleted", sg);
+            return;
+        }
+
+        // Upstream FSM: Joined iff JoinDesired and the RPF gateway is
+        // a live PIM neighbor. Connected sources need no Join.
+        let entry = self.tib.get(&sg).unwrap();
+        let jd = join_desired(entry);
+        let upstream_nbr = match entry.rpf {
+            RpfState::Gateway { ifindex, nexthop } => self
+                .links
+                .get(&ifindex)
+                .filter(|l| l.enabled && l.nbrs.contains_key(&nexthop))
+                .map(|_| (ifindex, nexthop)),
+            _ => None,
+        };
+        let want_joined = jd && upstream_nbr.is_some();
+        let is_joined = entry.join_state == JoinState::Joined;
+        if want_joined && !is_joined {
+            let (ifindex, nexthop) = upstream_nbr.unwrap();
+            self.tib.get_mut(&sg).unwrap().join_state = JoinState::Joined;
+            self.jp_send_single(ifindex, nexthop, sg, true);
+            self.jp_refresh_arm(ifindex, nexthop);
+            tracing::info!("pim: {} joined toward {}", sg, nexthop);
+        } else if !want_joined && is_joined {
+            self.tib.get_mut(&sg).unwrap().join_state = JoinState::NotJoined;
+            if let Some((ifindex, nexthop)) = upstream_nbr {
+                self.jp_send_single(ifindex, nexthop, sg, false);
+                tracing::info!("pim: {} pruned toward {}", sg, nexthop);
+            }
+        }
+
+        // Kernel MFC: (iif, oifs) from the current predicates; install
+        // when the IIF resolves and there is either an OIF or live
+        // traffic state (negative cache), else uninstall.
+        let entry = self.tib.get(&sg).unwrap();
+        let iif_vif = entry.rpf.ifindex().and_then(|ifindex| self.fp.vif(ifindex));
+        let desired = match iif_vif {
+            Some(iif) => {
+                let oifs: Vec<u16> = mfc_oifs(entry, entry.rpf.ifindex())
+                    .iter()
+                    .filter_map(|ifindex| self.fp.vif(*ifindex))
+                    .collect();
+                if !oifs.is_empty() || stream_alive {
+                    Some(InstalledMfc { iif, oifs })
+                } else {
+                    None
+                }
+            }
+            None => None,
+        };
+        if entry.installed != desired {
+            match &desired {
+                Some(mfc) => self.fp.mfc_add(sg.src, sg.grp, mfc.iif, &mfc.oifs),
+                None => self.fp.mfc_del(sg.src, sg.grp),
+            }
+            self.tib.get_mut(&sg).unwrap().installed = desired;
+        }
+    }
+
+    // ---- deadline plumbing ----
+
+    pub(crate) fn tib_next_wakeup(&self) -> Option<Instant> {
+        let mut earliest: Option<Instant> = None;
+        let mut consider = |t: Instant| {
+            earliest = Some(earliest.map_or(t, |e| e.min(t)));
+        };
+        for entry in self.tib.values() {
+            if let Some(t) = entry.stream_expires {
+                consider(t);
+            }
+            for ds in entry.downstream.values() {
+                consider(ds.expires);
+                if let DsState::PrunePending { until } = ds.state {
+                    consider(until);
+                }
+            }
+        }
+        for t in self.jp_refresh.values() {
+            consider(*t);
+        }
+        earliest
+    }
+
+    pub(crate) fn tib_tick(&mut self, now: Instant) {
+        let mut touched: Vec<Sg> = vec![];
+        for (sg, entry) in self.tib.iter_mut() {
+            let before = entry.downstream.len();
+            entry.downstream.retain(|_, ds| {
+                if ds.expires <= now {
+                    return false;
+                }
+                !matches!(ds.state, DsState::PrunePending { until } if until <= now)
+            });
+            let mut changed = entry.downstream.len() != before;
+            if let Some(t) = entry.stream_expires
+                && t <= now
+            {
+                entry.stream_expires = None;
+                changed = true;
+            }
+            if changed {
+                touched.push(*sg);
+            }
+        }
+        for sg in touched {
+            self.tib_update(sg);
+        }
+        self.jp_tick(now);
+    }
+}

--- a/zebra-rs/src/pim/tib.rs
+++ b/zebra-rs/src/pim/tib.rs
@@ -66,7 +66,6 @@ pub struct InstalledMfc {
 }
 
 pub struct TibEntry {
-    pub sg: Sg,
     pub join_state: JoinState,
     /// RPF snapshot this entry currently operates on; refreshed by
     /// `tib_rpf_change` so a change can prune the old upstream first.
@@ -84,9 +83,8 @@ pub struct TibEntry {
 }
 
 impl TibEntry {
-    pub fn new(sg: Sg) -> Self {
+    pub fn new() -> Self {
         Self {
-            sg,
             join_state: JoinState::NotJoined,
             rpf: RpfState::Unresolved,
             local: BTreeSet::new(),
@@ -102,7 +100,7 @@ impl Pim {
     fn tib_get_or_create(&mut self, sg: Sg) -> &mut TibEntry {
         if !self.tib.contains_key(&sg) {
             let rpf = self.rpf_acquire(sg.src);
-            let mut entry = TibEntry::new(sg);
+            let mut entry = TibEntry::new();
             entry.rpf = rpf;
             self.tib.insert(sg, entry);
             tracing::info!("pim: {} created", sg);
@@ -189,11 +187,15 @@ impl Pim {
             }
             UpcallKind::WrongVif | UpcallKind::WrVifWhole => {
                 // Assert machinery arrives in a later phase.
+                let iface = self
+                    .fp
+                    .ifindex_of(upcall.vif)
+                    .map_or_else(|| format!("vif {}", upcall.vif), |i| self.ifname(i));
                 tracing::debug!(
-                    "pim: wrong-vif upcall for ({}, {}) on vif {} (assert not yet implemented)",
+                    "pim: wrong-vif upcall for ({}, {}) on {} (assert not yet implemented)",
                     upcall.src,
                     upcall.grp,
-                    upcall.vif
+                    iface
                 );
             }
             UpcallKind::WholePkt => {

--- a/zebra-rs/yang/exec.yang
+++ b/zebra-rs/yang/exec.yang
@@ -1009,6 +1009,15 @@ module exec {
         ext:help "PIM neighbor";
         presence "PIM neighbor";
       }
+      container upstream {
+        ext:help "PIM upstream (S,G) join state";
+        presence "PIM upstream";
+      }
+    }
+
+    container mroute {
+      ext:help "IP multicast routing table";
+      presence "Multicast routes";
     }
 
     container ospfv3 {


### PR DESCRIPTION
## Summary

Phase 4 of the PIM-SM/SSM arc (architecture: `docs/design/pim-sm-ssm-architecture.md`; Phases 1–3: #1951 / #1956 / #1960) — the first complete control-plane-to-dataplane slice:

- **`mroute.rs`** — kernel forwarding plane behind one module boundary: mroute socket (`MRT_INIT`/`MRT_PIM`; `vifctl`/`mfcctl`/`MRT_*` declared locally since libc lacks them), VIF allocation (slot 0 reserved for the future register VIF), MFC add/del, `igmpmsg` upcall parsing. NOCACHE creates keepalive-bounded negative-cache entries; WRONGVIF/WHOLEPKT/WRVIFWHOLE wait for the assert/register phases.
- **`tib.rs`** — the (S,G) Tree Information Base: upstream Join state, per-interface downstream Join/PrunePending (ET/PPT deadlines), local IGMP membership, installed-MFC shadow. `tib_update` is the single reconvergence point (lifetime → upstream FSM → kernel-MFC diff).
- **`macros.rs`** — RFC 7761 predicates as named pure functions (`immediate_olist`, `join_desired`, `mfc_oifs` with the OIF≠IIF guard), unit-tested (incl. prune-pending-still-forwards).
- **`rpf.rs`** — NHT-backed RPF cache (register-then-gate, refcounted, connected-source detection first); RPF change prunes the old upstream before joining the new.
- **`jp.rs`** — J/P RX walk (must target one of our addresses; (\*,G)/rpt deferred to ASM), triggered sends, periodic 60 s per-RPF-neighbor aggregated refresh.
- **IGMP→TIB bridge** — INCLUDE source sets diffed against a per-group `synced` set on every mutation.
- `show pim upstream`, `show mroute` (flags J/L/S/I); all new timers ride the shared deadline-driven sleep arm.

## Test plan

- Live BDD under sudo (fresh binary + YANG, md5-checked): `--tags @pim_ssm` — 4 namespaces; real IGMPv3 source-specific join → `show igmp groups` → `show pim upstream` Joined → `show mroute` on both routers → kernel `ip mroute` IIF/OIF on both → **UDP payload from the sender confirmed in the receiver's log across two zebra-rs-programmed kernel MFCs**. All steps ✔.
- Regressions: `@pim_adjacency` + `@pim_igmp` re-run, both pass.
- `cargo test --workspace --exclude bdd`: green (1,590 zebra-rs tests incl. new macro tests). `cargo clippy --workspace --all-targets`: clean. `cargo fmt --all --check`: clean.

Generated with [Claude Code](https://claude.com/claude-code)