### PR TITLE
ospf-packet: correct Prefix-SID Sub-TLV flag bit positions

### DIFF
--- a/bdd/tests/configs/ospfv3_prefix_sid_flags/o1.yaml
+++ b/bdd/tests/configs/ospfv3_prefix_sid_flags/o1.yaml
@@ -1,0 +1,28 @@
+# o1 — OSPFv3 area 0 with SR-MPLS. Its loopback Prefix-SID (index 100 ->
+# label 16100, RFC 8666) is originated in an E-Intra-Area-Prefix LSA and
+# flooded to o2; o2's decode of the Prefix-SID sub-TLV flags is what this
+# feature pins.
+interface:
+- if-name: lo
+  ipv6:
+    address: 2001:db8::1/128
+- if-name: o1-o2
+  ipv6:
+    address: 2001:db8:12::1/64
+system:
+  hostname: o1
+router:
+  ospfv3:
+    router-id: 10.0.0.1
+    segment-routing:
+      mpls: {}
+    area:
+    - area-id: 0.0.0.0
+      interface:
+      - if-name: lo
+        enabled: true
+        prefix-sid:
+          index: 100
+      - if-name: o1-o2
+        enabled: true
+        network-type: point-to-point

--- a/bdd/tests/configs/ospfv3_prefix_sid_flags/o2.yaml
+++ b/bdd/tests/configs/ospfv3_prefix_sid_flags/o2.yaml
@@ -1,0 +1,28 @@
+# o2 — the peer that parses o1's advertisements. Runs OSPFv3 area 0 with
+# SR-MPLS and its own loopback Prefix-SID (index 200 -> label 16200). Its
+# `show ospfv3 database detail` renders the Prefix-SID sub-TLV it decoded
+# from o1's flooded E-Intra-Area-Prefix LSA, proving the on-wire flag byte.
+interface:
+- if-name: lo
+  ipv6:
+    address: 2001:db8::2/128
+- if-name: o2-o1
+  ipv6:
+    address: 2001:db8:12::2/64
+system:
+  hostname: o2
+router:
+  ospfv3:
+    router-id: 10.0.0.2
+    segment-routing:
+      mpls: {}
+    area:
+    - area-id: 0.0.0.0
+      interface:
+      - if-name: lo
+        enabled: true
+        prefix-sid:
+          index: 200
+      - if-name: o2-o1
+        enabled: true
+        network-type: point-to-point

--- a/bdd/tests/features/ospfv3_prefix_sid_flags.feature
+++ b/bdd/tests/features/ospfv3_prefix_sid_flags.feature
@@ -1,0 +1,66 @@
+@serial
+@ospfv3_prefix_sid_flags
+@ospf
+Feature: OSPFv3 Prefix-SID Sub-TLV flag bit positions (RFC 8666 §7.1)
+  As a network operator
+  I want zebra-rs to encode the OSPFv3 Prefix-SID Sub-TLV Flags octet at
+  the bit positions RFC 8666 §7.1 assigns (shared with RFC 8665 §6 for
+  OSPFv2 and matching FRR EXT_SUBTLV_PREFIX_SID_*FLG): NP = 0x40,
+  M = 0x20, E = 0x10, V = 0x08, L = 0x04, with the MSB and the low two
+  bits reserved — so a Prefix-SID advertised by one router is decoded
+  with the correct flags by an interoperable peer.
+
+  Regression coverage for the flag-placement bug where every flag sat
+  one bit too high (NP = 0x80, ...): zebra-to-zebra flooding is
+  symmetric, so the wire encoding is only observable by rendering the
+  Prefix-SID sub-TLV a *peer* decoded from the flooded LSA. o1 and o2
+  run OSPFv3 area 0 over one point-to-point link, both on SR-MPLS with a
+  loopback Prefix-SID (index 100 / 200 -> labels 16100 / 16200 against
+  the default SRGB base 16000). The index form carries NP (no-PHP), so
+  each peer must render the other's Prefix-SID flags as exactly
+  "0x40 : NP".
+
+  Test Topology:
+  ```
+   o1 ──────────────── o2
+   2001:db8:12::1/64   2001:db8:12::2/64
+   lo 2001:db8::1 SID 100   lo 2001:db8::2 SID 200
+  ```
+
+  Scenario: Build the OSPFv3 SR-MPLS topology
+    Given a clean test environment
+    When I create namespace "o1"
+    And I create namespace "o2"
+    And I connect namespace "o1" interface "o1-o2" to namespace "o2" interface "o2-o1"
+    And I start zebra-rs in namespace "o1"
+    And I start zebra-rs in namespace "o2"
+    And I apply config "o1.yaml" to namespace "o1"
+    And I apply config "o2.yaml" to namespace "o2"
+    And I wait 10 seconds
+    Then ping from "o1" to "2001:db8::2" should eventually succeed
+    # Both nodes advertise a Prefix-SID and resolve the peer's label.
+    And show command "show mpls ilm" in namespace "o1" should eventually contain "16100"
+    And show command "show mpls ilm" in namespace "o1" should eventually contain "16200"
+
+  Scenario: Prefix-SID flags decode at RFC 8666 bit positions on the peer
+    Given the test topology exists
+    # o2 has parsed o1's flooded E-Intra-Area-Prefix LSA; its Prefix-SID
+    # sub-TLV must decode with NP at bit 1 of the octet (0x40, RFC 8666
+    # §7.1) — not the old one-bit-high 0x80 placement.
+    Then show command "show ospfv3 database detail" in namespace "o2" should contain "Prefix-SID Sub-TLV:"
+    And show command "show ospfv3 database detail" in namespace "o2" should contain "Flags: 0x40 : NP"
+    And show command "show ospfv3 database detail" in namespace "o2" should contain "SID/Label: Index: 100"
+    # The buggy one-bit-high encoding would render NP as 0x80; assert it
+    # never appears.
+    And show command "show ospfv3 database detail" in namespace "o2" should not contain "0x80 : NP"
+    # Symmetric: o1's decode of o2's Prefix-SID (index 200) is identical.
+    And show command "show ospfv3 database detail" in namespace "o1" should contain "Flags: 0x40 : NP"
+    And show command "show ospfv3 database detail" in namespace "o1" should contain "SID/Label: Index: 200"
+
+  Scenario: Teardown topology
+    Given the test topology exists
+    When I stop zebra-rs in namespace "o1"
+    And I stop zebra-rs in namespace "o2"
+    And I delete namespace "o1"
+    And I delete namespace "o2"
+    Then the test environment should be clean

--- a/crates/ospf-packet/src/parser.rs
+++ b/crates/ospf-packet/src/parser.rs
@@ -1697,17 +1697,21 @@ impl ExtPrefixSubTlv {
     }
 }
 
-// RFC 8665 §4 Prefix SID Sub-TLV flags.
+// RFC 8665 §6 (OSPFv2) / RFC 8666 §7.1 (OSPFv3) Prefix-SID Sub-TLV flags.
+// Wire bit values (matching FRR EXT_SUBTLV_PREFIX_SID_*FLG): NP = 0x40,
+// M = 0x20, E = 0x10, V = 0x08, L = 0x04; the MSB and the low two bits are
+// reserved. Fields are declared LSB-first for the bitfield macro.
 #[bitfield(u8, debug = true)]
 #[derive(PartialEq)]
 pub struct PrefixSidFlags {
-    #[bits(3)]
-    pub resvd: u8,
+    #[bits(2)]
+    pub resvd_lo: u8,
     pub l_flag: bool,
     pub v_flag: bool,
     pub e_flag: bool,
     pub m_flag: bool,
     pub np_flag: bool,
+    pub resvd_hi: bool,
 }
 
 impl ParseBe<PrefixSidFlags> for PrefixSidFlags {
@@ -2907,6 +2911,19 @@ mod tests {
         // gracefully rather than pre-allocate ~gigabytes (regression for the
         // Vec::with_capacity DoS).
         assert!(parse_lsas_with_raw(&[], 0xFFFF_FFFF).is_err());
+    }
+
+    #[test]
+    fn prefix_sid_flags_rfc8665_bit_positions() {
+        // RFC 8665 §6 / RFC 8666 §7.1 (and FRR EXT_SUBTLV_PREFIX_SID_*FLG).
+        assert_eq!(PrefixSidFlags::new().with_np_flag(true).into_bits(), 0x40);
+        assert_eq!(PrefixSidFlags::new().with_m_flag(true).into_bits(), 0x20);
+        assert_eq!(PrefixSidFlags::new().with_e_flag(true).into_bits(), 0x10);
+        assert_eq!(PrefixSidFlags::new().with_v_flag(true).into_bits(), 0x08);
+        assert_eq!(PrefixSidFlags::new().with_l_flag(true).into_bits(), 0x04);
+        // A received NP flag (0x40) decodes as NP, not M.
+        let f = PrefixSidFlags::from_bits(0x40);
+        assert!(f.np_flag() && !f.m_flag());
     }
 
     /// RFC 2328 §D.4.1-D.4.2: the checksum excludes the 64-bit

--- a/zebra-rs/src/ospf/show_v3.rs
+++ b/zebra-rs/src/ospf/show_v3.rs
@@ -1101,7 +1101,7 @@ fn format_adj_sid_flags(flags: &ospf_packet::AdjSidFlags) -> String {
     format!("0x{:02x} : {}", u8::from(*flags), joined)
 }
 
-/// Hex byte plus decoded letters, e.g. "0x20 : NP" (RFC 8666 §5).
+/// Hex byte plus decoded letters, e.g. "0x40 : NP" (RFC 8666 §7.1).
 fn format_prefix_sid_flags(flags: &ospf_packet::PrefixSidFlags) -> String {
     let mut names = Vec::new();
     if flags.np_flag() {
@@ -2446,9 +2446,9 @@ mod tests {
             "{out}"
         );
         assert!(out.contains("Prefix-SID Sub-TLV:"), "{out}");
-        // Index form carries NP (no-PHP) per the v3 origination
-        // path; NP is the top bit of the flags octet.
-        assert!(out.contains("Flags: 0x80 : NP"), "{out}");
+        // Index form carries NP (no-PHP) per the v3 origination path;
+        // NP is bit 1 of the flags octet (0x40) per RFC 8666 §7.1.
+        assert!(out.contains("Flags: 0x40 : NP"), "{out}");
         assert!(out.contains("Algorithm: 0 (SPF)"), "{out}");
         assert!(out.contains("SID/Label: Index: 100"), "{out}");
     }


### PR DESCRIPTION
## Summary

`PrefixSidFlags` placed every flag one bit too high: `NP=0x80, M=0x40, E=0x20, V=0x10, L=0x08`. RFC 8665 §6 (OSPFv2) and RFC 8666 §7.1 (OSPFv3), matching FRR `EXT_SUBTLV_PREFIX_SID_*FLG`, define `NP=0x40, M=0x20, E=0x10, V=0x08, L=0x04` with the MSB and low two bits reserved.

Against a compliant peer this made every flag misdecode by one position (a received `NP=0x40` read as `M`, etc.) and put reserved bit `0x80` on the wire for a locally-set `NP`. The struct is shared by the OSPFv2 and OSPFv3 Prefix-SID sub-TLVs, so both are corrected. All accessors are name-based, so callers (srmpls origination, show renderers) are unchanged.

Found in the ospf-packet crate code review (`docs/design/ospf-packet-code-review.md`, finding #5).

## Changes
- Shift the flags to their assigned bit positions (2-bit low reserved, flags at bits 2..6, MSB reserved).
- Update the `show_v3` detail test/doc that asserted the old `0x80` NP byte to the correct `0x40`.
- Add a BDD feature (`ospfv3_prefix_sid_flags`) that floods a Prefix-SID between two OSPFv3 SR-MPLS nodes and asserts each peer *decodes* the flags as `Flags: 0x40 : NP`, never `0x80 : NP`.

## Test plan
- `cargo test -p ospf-packet`: new unit test pins each flag's on-wire byte (`NP→0x40`, …, `L→0x04`) and that a received `0x40` decodes as NP, not M. All pass.
- `cargo test -p zebra-rs ospf::`: 84 pass (includes the corrected show-detail test).
- BDD `@ospfv3_prefix_sid_flags`: ran locally against the rebuilt binary — 3 scenarios pass, environment clean. (BDD is not run in CI.)
- `cargo fmt` applied; `cargo clippy --workspace`: clean.

Generated with [Claude Code](https://claude.com/claude-code)