### PR TITLE
isis-packet: multi-area TLV 1, 20-bit label mask, malformed-element skip

### DIFF
--- a/crates/isis-packet/src/disp.rs
+++ b/crates/isis-packet/src/disp.rs
@@ -287,10 +287,12 @@ impl Display for IsisLspId {
 impl Display for IsisTlvAreaAddr {
     fn fmt(&self, f: &mut Formatter<'_>) -> Result {
         write!(f, "  Area address:")?;
-        if !self.area_addr.is_empty() {
-            write!(f, " {:02x}", self.area_addr[0])?;
-
-            for (index, id) in self.area_addr.iter().enumerate() {
+        for addr in &self.area_addrs {
+            if addr.is_empty() {
+                continue;
+            }
+            write!(f, " {:02x}", addr[0])?;
+            for (index, id) in addr.iter().enumerate() {
                 if index == 0 {
                     continue;
                 }

--- a/crates/isis-packet/src/parser.rs
+++ b/crates/isis-packet/src/parser.rs
@@ -624,9 +624,13 @@ impl IsisTlv {
     }
 }
 
+/// Area Addresses TLV (type 1). The value is a *sequence* of
+/// {length, area-address} pairs — ISO 10589 allows up to
+/// maxAreaAddresses (3) per IS — so the field is a list; a received
+/// TLV packing several areas keeps every one, not just the first.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct IsisTlvAreaAddr {
-    pub area_addr: Vec<u8>,
+    pub area_addrs: Vec<Vec<u8>>,
 }
 
 impl TlvEmitter for IsisTlvAreaAddr {
@@ -635,25 +639,44 @@ impl TlvEmitter for IsisTlvAreaAddr {
     }
 
     fn len(&self) -> u8 {
-        // Length(1) + Area Address, capped to 255.
-        (self.area_addr.len() + 1).min(255) as u8
+        // Mirror emit(): each pair is 1 length byte + up to 254 area
+        // octets; stop before the pair that would overflow the TLV's
+        // one-octet length budget.
+        let mut total = 0usize;
+        for addr in &self.area_addrs {
+            let pair = 1 + addr.len().min(254);
+            if total + pair > 255 {
+                break;
+            }
+            total += pair;
+        }
+        total as u8
     }
 
     fn emit(&self, buf: &mut BytesMut) {
-        let max_addr_len = self.area_addr.len().min(254);
-        buf.put_u8(max_addr_len as u8);
-        buf.put(&self.area_addr[..max_addr_len]);
+        let mut total = 0usize;
+        for addr in &self.area_addrs {
+            let alen = addr.len().min(254);
+            if total + 1 + alen > 255 {
+                break;
+            }
+            total += 1 + alen;
+            buf.put_u8(alen as u8);
+            buf.put(&addr[..alen]);
+        }
     }
 }
 
 impl ParseBe<IsisTlvAreaAddr> for IsisTlvAreaAddr {
     fn parse_be(input: &[u8]) -> IResult<&[u8], Self> {
-        let (input, len) = be_u8(input)?;
-        let (input, addr) = take(len)(input)?;
-        let area_addr = Self {
-            area_addr: addr.to_vec(),
-        };
-        Ok((input, area_addr))
+        let (input, area_addrs) = many0_complete(|i| {
+            let (i, len) = be_u8(i)?;
+            let (i, addr) = take(len)(i)?;
+            let addr: &[u8] = addr;
+            Ok((i, addr.to_vec()))
+        })
+        .parse(input)?;
+        Ok((input, Self { area_addrs }))
     }
 }
 
@@ -1334,6 +1357,13 @@ pub enum SidLabelValue {
 }
 
 impl SidLabelValue {
+    /// RFC 8667 §2.1.1.1: in the 3-octet form the 20 rightmost bits are
+    /// the MPLS label; the top 4 are reserved. Mask on both parse and
+    /// emit (FRR: `sid &= MPLS_LABEL_VALUE_MASK`) so a peer setting a
+    /// reserved bit — or a mis-scaled local value — can't yield an
+    /// illegal label ≥ 2^20 that gets re-advertised or programmed.
+    pub const LABEL_MASK: u32 = 0x000F_FFFF;
+
     pub fn len(&self) -> u8 {
         use SidLabelValue::*;
         match self {
@@ -1349,7 +1379,7 @@ impl SidLabelValue {
     pub fn emit(&self, buf: &mut BytesMut) {
         use SidLabelValue::*;
         match self {
-            Label(v) => buf.put(&u32_u8_3(*v)[..]),
+            Label(v) => buf.put(&u32_u8_3(*v & Self::LABEL_MASK)[..]),
             Index(v) => buf.put_u32(*v),
         }
     }
@@ -1368,7 +1398,10 @@ impl ParseBe<SidLabelValue> for SidLabelValue {
         match input.len() {
             3 => {
                 let (input, label) = be_u24(input)?;
-                Ok((input, SidLabelValue::Label(label)))
+                Ok((
+                    input,
+                    SidLabelValue::Label(label & SidLabelValue::LABEL_MASK),
+                ))
             }
             4 => {
                 let (input, index) = be_u32(input)?;
@@ -1412,6 +1445,27 @@ pub fn parse(input: &[u8]) -> IsisIResult<&[u8], IsisPacket> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// RFC 8667: the 3-octet SID/Label form carries the MPLS label in
+    /// the 20 rightmost bits; the top 4 are reserved and must be masked
+    /// on parse (a peer setting them) and on emit (a mis-scaled local
+    /// value) so an illegal label ≥ 2^20 never propagates.
+    #[test]
+    fn sid_label_value_masks_label_to_20_bits() {
+        let raw = [0xFFu8, 0xFF, 0xFF];
+        let (rest, v) = SidLabelValue::parse_be(&raw).expect("parse");
+        assert!(rest.is_empty());
+        assert_eq!(v, SidLabelValue::Label(0x000F_FFFF));
+
+        let mut buf = BytesMut::new();
+        SidLabelValue::Label(0xFFFF_FFFF).emit(&mut buf);
+        assert_eq!(&buf[..], &[0x0F, 0xFF, 0xFF]);
+
+        // A 4-octet index is not a label and passes through unmasked.
+        let raw = [0x00u8, 0x20, 0x00, 0x00];
+        let (_, v) = SidLabelValue::parse_be(&raw).expect("parse");
+        assert_eq!(v, SidLabelValue::Index(0x0020_0000));
+    }
 
     /// TLV 6 (IS Neighbors) — `len` and `emit` truncate consistently at
     /// MAX_NEIGHBORS. 43 neighbors used to wrap the length byte to 2
@@ -1554,34 +1608,58 @@ mod tests {
     #[test]
     fn area_addr_len_truncates_at_255() {
         let short = IsisTlvAreaAddr {
-            area_addr: vec![0x49, 0x00, 0x01],
+            area_addrs: vec![vec![0x49, 0x00, 0x01]],
         };
         // 1 (length byte) + 3 (address) = 4.
         assert_eq!(short.len(), 4);
 
         let exact = IsisTlvAreaAddr {
-            area_addr: vec![0xAA; 254],
+            area_addrs: vec![vec![0xAA; 254]],
         };
         // 1 + 254 = 255.
         assert_eq!(exact.len(), 255);
 
+        // A single over-long address is capped at 254 octets, and a
+        // second address that no longer fits the 255-byte TLV budget
+        // is dropped from the length — mirroring emit().
         let long = IsisTlvAreaAddr {
-            area_addr: vec![0xAA; 300],
+            area_addrs: vec![vec![0xAA; 300], vec![0x49, 0x00, 0x01]],
         };
-        // Capped to 255.
         assert_eq!(long.len(), 255);
     }
 
     #[test]
     fn area_addr_emit_truncates_at_255() {
         let long = IsisTlvAreaAddr {
-            area_addr: vec![0xAA; 300],
+            area_addrs: vec![vec![0xAA; 300], vec![0x49, 0x00, 0x01]],
         };
         let mut buf = BytesMut::new();
         long.emit(&mut buf);
-        // 1 (length byte) + 254 (address data) = 255.
+        // 1 (length byte) + 254 (address data) = 255; the second
+        // address doesn't fit and is dropped, matching len().
         assert_eq!(buf.len(), 255);
         assert_eq!(buf[0], 254);
+    }
+
+    /// Finding #6: the TLV 1 value is a sequence of {len, area} pairs
+    /// (maxAreaAddresses = 3); the parser used to keep only the first
+    /// pair, so a neighbor packing two areas into one TLV lost its
+    /// second area and L1 area matching failed.
+    #[test]
+    fn area_addr_parses_all_areas() {
+        let raw = [3u8, 0x49, 0x00, 0x01, 3, 0x49, 0x00, 0x02];
+        let (rest, tlv) = IsisTlvAreaAddr::parse_be(&raw).expect("parse");
+        assert!(rest.is_empty());
+        assert_eq!(
+            tlv.area_addrs,
+            vec![vec![0x49, 0x00, 0x01], vec![0x49, 0x00, 0x02]]
+        );
+
+        // Round-trip: emit reproduces both pairs and len() agrees.
+        let mut buf = BytesMut::new();
+        tlv.emit(&mut buf);
+        assert_eq!(&buf[..], &raw[..]);
+        assert_eq!(tlv.len() as usize, raw.len());
     }
 
     #[test]

--- a/crates/isis-packet/src/sub/cap.rs
+++ b/crates/isis-packet/src/sub/cap.rs
@@ -37,7 +37,17 @@ impl IsisSubTlv {
     pub fn parse_subs(input: &[u8]) -> IResult<&[u8], Self> {
         let (input, cl) = IsisCodeLen::parse_be(input)?;
         let (input, sub) = packet_utils::safe_split_at(input, cl.len as usize)?;
-        let (_, mut val) = Self::parse_be(sub, cl.code.into())?;
+        // A malformed *known* sub-TLV must not truncate the list —
+        // degrade it to Unknown with its bytes preserved (mirroring the
+        // top-level TLV loop) so the sub-TLVs after it still parse.
+        let mut val = match Self::parse_be(sub, cl.code.into()) {
+            Ok((_, val)) => val,
+            Err(_) => IsisSubTlv::Unknown(IsisSubTlvUnknown {
+                code: cl.code,
+                len: cl.len,
+                data: sub.to_vec(),
+            }),
+        };
         if let IsisSubTlv::Unknown(ref mut v) = val {
             v.code = cl.code;
             v.len = cl.len;
@@ -551,7 +561,15 @@ impl FadSubTlv {
     pub fn parse_subs(input: &[u8]) -> IResult<&[u8], Self> {
         let (input, cl) = IsisCodeLen::parse_be(input)?;
         let (input, sub) = packet_utils::safe_split_at(input, cl.len as usize)?;
-        let (_, mut val) = Self::parse_be(sub, cl.code.into())?;
+        // Malformed known sub-TLV → Unknown, so followers still parse.
+        let mut val = match Self::parse_be(sub, cl.code.into()) {
+            Ok((_, val)) => val,
+            Err(_) => FadSubTlv::Unknown(IsisSubTlvUnknown {
+                code: cl.code,
+                len: cl.len,
+                data: sub.to_vec(),
+            }),
+        };
         if let FadSubTlv::Unknown(ref mut v) = val {
             v.code = cl.code;
             v.len = cl.len;

--- a/crates/isis-packet/src/sub/neigh.rs
+++ b/crates/isis-packet/src/sub/neigh.rs
@@ -255,7 +255,17 @@ impl IsisSubTlv {
     pub fn parse_subs(input: &[u8]) -> IResult<&[u8], Self> {
         let (input, cl) = IsisCodeLen::parse_be(input)?;
         let (input, sub) = safe_split_at(input, cl.len as usize)?;
-        let (_, mut val) = Self::parse_be(sub, cl.code.into())?;
+        // A malformed *known* sub-TLV must not truncate the list —
+        // degrade it to Unknown with its bytes preserved (mirroring the
+        // top-level TLV loop) so the sub-TLVs after it still parse.
+        let mut val = match Self::parse_be(sub, cl.code.into()) {
+            Ok((_, val)) => val,
+            Err(_) => IsisSubTlv::Unknown(IsisSubTlvUnknown {
+                code: cl.code,
+                len: cl.len,
+                data: sub.to_vec(),
+            }),
+        };
         if let IsisSubTlv::Unknown(ref mut v) = val {
             v.code = cl.code;
             v.len = cl.len;

--- a/crates/isis-packet/src/sub/prefix.rs
+++ b/crates/isis-packet/src/sub/prefix.rs
@@ -242,7 +242,15 @@ impl IsisMirrorSub2Tlv {
     pub fn parse_subs(input: &[u8]) -> IResult<&[u8], Self> {
         let (input, cl) = IsisCodeLen::parse_be(input)?;
         let (input, sub) = safe_split_at(input, cl.len as usize)?;
-        let (_, mut val) = Self::parse_be(sub, cl.code.into())?;
+        // Malformed known sub-TLV → Unknown, so followers still parse.
+        let mut val = match Self::parse_be(sub, cl.code.into()) {
+            Ok((_, val)) => val,
+            Err(_) => IsisMirrorSub2Tlv::Unknown(IsisSubTlvUnknown {
+                code: cl.code,
+                len: cl.len,
+                data: sub.to_vec(),
+            }),
+        };
         if let IsisMirrorSub2Tlv::Unknown(ref mut v) = val {
             v.code = cl.code;
             v.len = cl.len;
@@ -310,7 +318,15 @@ impl IsisSub2Tlv {
     pub fn parse_subs(input: &[u8]) -> IResult<&[u8], Self> {
         let (input, cl) = IsisCodeLen::parse_be(input)?;
         let (input, sub) = safe_split_at(input, cl.len as usize)?;
-        let (_, mut val) = Self::parse_be(sub, cl.code.into())?;
+        // Malformed known sub-TLV → Unknown, so followers still parse.
+        let mut val = match Self::parse_be(sub, cl.code.into()) {
+            Ok((_, val)) => val,
+            Err(_) => IsisSub2Tlv::Unknown(IsisSubTlvUnknown {
+                code: cl.code,
+                len: cl.len,
+                data: sub.to_vec(),
+            }),
+        };
         if let IsisSub2Tlv::Unknown(ref mut v) = val {
             v.code = cl.code;
             v.len = cl.len;
@@ -343,7 +359,17 @@ impl IsisSubTlv {
     pub fn parse_subs(input: &[u8]) -> IResult<&[u8], Self> {
         let (input, cl) = IsisCodeLen::parse_be(input)?;
         let (input, sub) = safe_split_at(input, cl.len as usize)?;
-        let (_, mut val) = Self::parse_be(sub, cl.code.into())?;
+        // A malformed *known* sub-TLV must not truncate the list —
+        // degrade it to Unknown with its bytes preserved (mirroring the
+        // top-level TLV loop) so the sub-TLVs after it still parse.
+        let mut val = match Self::parse_be(sub, cl.code.into()) {
+            Ok((_, val)) => val,
+            Err(_) => IsisSubTlv::Unknown(IsisSubTlvUnknown {
+                code: cl.code,
+                len: cl.len,
+                data: sub.to_vec(),
+            }),
+        };
         if let IsisSubTlv::Unknown(ref mut v) = val {
             v.code = cl.code;
             v.len = cl.len;
@@ -460,7 +486,11 @@ pub struct IsisTlvExtIpReach {
 
 impl ParseBe<IsisTlvExtIpReach> for IsisTlvExtIpReach {
     fn parse_be(input: &[u8]) -> IResult<&[u8], Self> {
-        let (input, entries) = many0_complete(IsisTlvExtIpReachEntry::parse_be).parse(input)?;
+        let (input, entries) = parse_reach_entries(
+            input,
+            IsisTlvExtIpReachEntry::parse_be,
+            ext_ip_reach_entry_span,
+        )?;
         Ok((input, Self { entries }))
     }
 }
@@ -500,7 +530,11 @@ pub struct IsisTlvMtIpReach {
 impl ParseBe<IsisTlvMtIpReach> for IsisTlvMtIpReach {
     fn parse_be(input: &[u8]) -> IResult<&[u8], Self> {
         let (input, mt) = be_u16(input)?;
-        let (input, entries) = many0_complete(IsisTlvExtIpReachEntry::parse_be).parse(input)?;
+        let (input, entries) = parse_reach_entries(
+            input,
+            IsisTlvExtIpReachEntry::parse_be,
+            ext_ip_reach_entry_span,
+        )?;
         Ok((
             input,
             Self {
@@ -592,7 +626,11 @@ pub struct IsisTlvIpv6Reach {
 
 impl ParseBe<IsisTlvIpv6Reach> for IsisTlvIpv6Reach {
     fn parse_be(input: &[u8]) -> IResult<&[u8], Self> {
-        let (input, entries) = many0_complete(IsisTlvIpv6ReachEntry::parse_be).parse(input)?;
+        let (input, entries) = parse_reach_entries(
+            input,
+            IsisTlvIpv6ReachEntry::parse_be,
+            ipv6_reach_entry_span,
+        )?;
         Ok((input, Self { entries }))
     }
 }
@@ -688,7 +726,11 @@ pub struct IsisTlvMtIpv6Reach {
 impl ParseBe<IsisTlvMtIpv6Reach> for IsisTlvMtIpv6Reach {
     fn parse_be(input: &[u8]) -> IResult<&[u8], Self> {
         let (input, mt) = be_u16(input)?;
-        let (input, entries) = many0_complete(IsisTlvIpv6ReachEntry::parse_be).parse(input)?;
+        let (input, entries) = parse_reach_entries(
+            input,
+            IsisTlvIpv6ReachEntry::parse_be,
+            ipv6_reach_entry_span,
+        )?;
         Ok((
             input,
             Self {
@@ -1046,6 +1088,72 @@ pub fn ptakev6(input: &[u8], prefixlen: u8) -> IResult<&[u8], Ipv6Net> {
     Ok((input, prefix))
 }
 
+/// Byte span of one TLV 135 entry computed from its header fields
+/// alone, so a semantically invalid entry (e.g. control-byte prefixlen
+/// 33..63) can be skipped without desyncing the entries that follow.
+/// Returns `None` when the claimed span overruns `input` — that tail is
+/// unframeable garbage.
+fn ext_ip_reach_entry_span(input: &[u8]) -> Option<usize> {
+    // Metric(4) + Control(1).
+    if input.len() < 5 {
+        return None;
+    }
+    let flags: Ipv4ControlInfo = input[4].into();
+    let mut span = 5 + psize(flags.prefixlen() as u8);
+    if flags.sub_tlv() {
+        span += 1 + *input.get(span)? as usize;
+    }
+    (input.len() >= span).then_some(span)
+}
+
+/// TLV 236 sibling of [`ext_ip_reach_entry_span`] (prefixlen is an
+/// explicit octet, invalid when > 128).
+fn ipv6_reach_entry_span(input: &[u8]) -> Option<usize> {
+    // Metric(4) + Flags(1) + PrefixLen(1).
+    if input.len() < 6 {
+        return None;
+    }
+    let flags: Ipv6ControlInfo = input[4].into();
+    let mut span = 6 + psize(input[5]);
+    if flags.sub_tlv() {
+        span += 1 + *input.get(span)? as usize;
+    }
+    (input.len() >= span).then_some(span)
+}
+
+/// Parse a reach-entry list, *skipping* a malformed entry instead of
+/// truncating the list at it (`many0` treats an entry error as
+/// end-of-list, which silently dropped every valid entry after a bad
+/// one). `parse` reads one entry; `span` frames one entry from raw
+/// bytes. An unframeable tail returns an error so the enclosing TLV
+/// degrades to Unknown at the top-level loop rather than silently
+/// discarding bytes.
+fn parse_reach_entries<T>(
+    mut input: &[u8],
+    parse: impl Fn(&[u8]) -> IResult<&[u8], T>,
+    span: impl Fn(&[u8]) -> Option<usize>,
+) -> IResult<&[u8], Vec<T>> {
+    let mut entries = Vec::new();
+    while !input.is_empty() {
+        match parse(input) {
+            Ok((rest, entry)) => {
+                entries.push(entry);
+                input = rest;
+            }
+            Err(_) => match span(input) {
+                Some(n) => input = &input[n..],
+                None => {
+                    return Err(nom::Err::Error(nom::error::make_error(
+                        input,
+                        nom::error::ErrorKind::Verify,
+                    )));
+                }
+            },
+        }
+    }
+    Ok((input, entries))
+}
+
 impl ParseBe<IsisTlvExtIpReachEntry> for IsisTlvExtIpReachEntry {
     fn parse_be(input: &[u8]) -> IResult<&[u8], Self> {
         let (input, metric) = be_u32(input)?;
@@ -1222,6 +1330,59 @@ impl TlvEmitter for IsisTlvSrv6 {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// Finding #10 (v4): a semantically invalid entry (control-byte
+    /// prefixlen 33, illegal for IPv4) used to stop `many0` and
+    /// silently drop every valid entry after it. It is now framed from
+    /// its header and skipped alone.
+    #[test]
+    fn malformed_v4_reach_entry_is_skipped_not_truncating() {
+        #[rustfmt::skip]
+        let raw = [
+            // Entry 1 (malformed): metric 10, control 0x21 = prefixlen
+            // 33 (no subs), ceil(33/8) = 5 prefix octets.
+            0, 0, 0, 10, 0x21, 1, 2, 3, 4, 5,
+            // Entry 2 (valid): metric 20, control 0x18 = /24, 10.1.1/24.
+            0, 0, 0, 20, 0x18, 10, 1, 1,
+        ];
+        let (rest, tlv) = IsisTlvExtIpReach::parse_be(&raw).expect("parse");
+        assert!(rest.is_empty());
+        assert_eq!(tlv.entries.len(), 1);
+        assert_eq!(tlv.entries[0].prefix, "10.1.1.0/24".parse().unwrap());
+    }
+
+    /// Finding #10 (v6): prefixlen 200 (> 128) in the first entry must
+    /// not swallow the valid /64 entry after it.
+    #[test]
+    fn malformed_v6_reach_entry_is_skipped_not_truncating() {
+        let mut raw = vec![0u8, 0, 0, 10, 0x00, 200];
+        raw.extend(vec![0xEE; psize(200)]); // ceil(200/8) = 25
+        // Valid entry: metric 20, flags 0, 2001:db8::/64.
+        raw.extend([0, 0, 0, 20, 0x00, 64, 0x20, 0x01, 0x0d, 0xb8, 0, 0, 0, 0]);
+        let (rest, tlv) = IsisTlvIpv6Reach::parse_be(&raw).expect("parse");
+        assert!(rest.is_empty());
+        assert_eq!(tlv.entries.len(), 1);
+        assert_eq!(tlv.entries[0].prefix, "2001:db8::/64".parse().unwrap());
+    }
+
+    /// Finding #10 (sub-TLVs): a malformed *known* sub-TLV degrades to
+    /// Unknown with its bytes preserved instead of truncating the list.
+    #[test]
+    fn malformed_known_sub_tlv_degrades_to_unknown() {
+        #[rustfmt::skip]
+        let raw = [
+            3u8, 1, 0xFF,        // PrefixSid (code 3) with a 1-byte body: malformed.
+            11, 4, 10, 0, 0, 1,  // Ipv4SourceRouterId (code 11): valid.
+        ];
+        let (rest, first) = IsisSubTlv::parse_subs(&raw).expect("first");
+        let IsisSubTlv::Unknown(u) = &first else {
+            panic!("expected Unknown, got {first:?}");
+        };
+        assert_eq!((u.code, u.len, u.data.as_slice()), (3, 1, &[0xFF][..]));
+        let (rest, second) = IsisSubTlv::parse_subs(rest).expect("second");
+        assert!(matches!(second, IsisSubTlv::Ipv4SourceRouterId(_)));
+        assert!(rest.is_empty());
+    }
 
     #[test]
     fn srv6_tlv_mtid_bit_positions() {

--- a/crates/isis-packet/tests/json.rs
+++ b/crates/isis-packet/tests/json.rs
@@ -91,7 +91,7 @@ pub fn json_round_trip_test() {
 
     // Test complex structure: IsisTlvAreaAddr
     let area_addr = IsisTlvAreaAddr {
-        area_addr: vec![0x49, 0x00, 0x01],
+        area_addrs: vec![vec![0x49, 0x00, 0x01]],
     };
     let serialized = serde_json::to_string(&area_addr).unwrap();
     let deserialized: IsisTlvAreaAddr = serde_json::from_str(&serialized).unwrap();

--- a/docs/design/isis-packet-code-review.md
+++ b/docs/design/isis-packet-code-review.md
@@ -147,7 +147,7 @@ declared first, `resvd(4)` second — and the field is named `mtid` (also in the
 serde helper). A unit test pins wire `0x0002` ⇄ MT 2 and the reserved top
 nibble, plus a full `IsisTlvSrv6` round-trip.
 
-### 6. 🟠 `IsisTlvAreaAddr::parse_be` drops all but the first area address — CONFIRMED
+### 6. 🟠 `IsisTlvAreaAddr::parse_be` drops all but the first area address — CONFIRMED — ✅ FIXED
 `crates/isis-packet/src/parser.rs:649`
 
 The Area Address TLV (type 1) value is a sequence of `{length, area}` pairs, but
@@ -161,8 +161,11 @@ matching against a multi-area neighbor fails and adjacencies that should form on
 the secondary area are rejected. `emit()` is symmetric-single, so zebra→zebra
 round-trips hide it — only *received* multi-area TLVs lose data.
 
-**Fix:** model `area_addr` as a `Vec<Vec<u8>>` (or loop until the value slice is
-exhausted) and emit each length-prefixed address.
+**Fixed:** the field is now `area_addrs: Vec<Vec<u8>>`; parse loops over every
+`{length, area}` pair and emit writes each one back (len/emit truncate
+consistently at the 255-byte TLV budget). The daemon's L1 area gate
+(`l1_area_compatible`) matches against *any* advertised area. Unit test pins
+the two-area round-trip.
 
 ### 7. 🟠 Per-entry sub-TLV length uses panicking/wrapping `u8` arithmetic — CONFIRMED — ✅ FIXED
 `crates/isis-packet/src/sub/neigh.rs:176` (and siblings)
@@ -217,7 +220,7 @@ bytes so the length byte always matches the bytes present — the truncated tail
 parses as one malformed sub-TLV instead of desyncing the rest of the PDU into
 phantom entries. A `should_panic` unit test pins the assert.
 
-### 9. 🟠 3-octet SID/Label value is never masked to 20 bits — CONFIRMED
+### 9. 🟠 3-octet SID/Label value is never masked to 20 bits — CONFIRMED — ✅ FIXED
 `crates/isis-packet/src/parser.rs:1336` (`SidLabelValue::parse_be` / `emit`)
 
 A 3-byte label field is read with `be_u24` into the full 24-bit value. RFC 8667
@@ -229,10 +232,11 @@ zebra masks on neither parse nor emit.
 a mis-scaled value — yields an illegal MPLS label (≥ 2²⁰) that zebra accepts,
 re-advertises verbatim, and can program into the FIB.
 
-**Fix:** mask `Label` values to the low 20 bits (`& 0x000F_FFFF`) on parse and on
-emit.
+**Fixed:** `SidLabelValue::LABEL_MASK` (`0x000F_FFFF`) is applied on both parse
+and emit of the 3-octet `Label` form, matching FRR; the 4-octet `Index` form is
+untouched. Unit test pins both directions.
 
-### 10. 🟠 One malformed reach entry / sub-TLV silently truncates all that follow — CONFIRMED
+### 10. 🟠 One malformed reach entry / sub-TLV silently truncates all that follow — CONFIRMED — ✅ FIXED
 `crates/isis-packet/src/sub/prefix.rs:1048` (v4) and `:1072` (v6); sub-TLV `parse_subs` sites
 
 Unlike the top-level TLV loop (which degrades a malformed known TLV to `Unknown`),
@@ -248,9 +252,15 @@ for v4) followed by a valid /24 entry: `ptake` returns `ErrorKind::Verify`,
 Same for TLV 236 (v6 prefixlen > 128) and for a malformed known sub-TLV in any
 sub-TLV block.
 
-**Fix:** apply the top-level degrade-to-Unknown policy inside the shared sub-TLV /
-entry loop so a bad element is preserved-or-skipped without truncating its
-followers.
+**Fixed:** two mechanisms. (1) All six sub-TLV registries (`parse_subs` in
+`neigh`, `prefix` ×3, `cap` ×2) now degrade a malformed *known* sub-TLV to
+`Unknown` with its bytes preserved, mirroring the top-level TLV loop, so
+followers still parse. (2) TLV 135/235/236/237 entry lists go through
+`parse_reach_entries`, which frames a semantically invalid entry from its
+header fields (`ext_ip_reach_entry_span` / `ipv6_reach_entry_span`) and skips
+it alone; an unframeable tail errors so the whole TLV degrades to `Unknown`
+instead of silently discarding bytes. Unit tests pin the v4 (prefixlen 33) and
+v6 (prefixlen 200) skip cases and the sub-TLV degrade.
 
 ### 11. 🟡 Reach-entry emit keys the sub-TLV block on `subs.is_empty()` but writes the stored S-flag — PLAUSIBLE
 `crates/isis-packet/src/sub/prefix.rs:559` (and `:760` for IPv6)

--- a/zebra-rs/src/isis/auth.rs
+++ b/zebra-rs/src/isis/auth.rs
@@ -527,7 +527,7 @@ mod tests {
             lan_id: IsisNeighborId::default(),
             tlvs: vec![
                 IsisTlv::AreaAddr(IsisTlvAreaAddr {
-                    area_addr: vec![0x49, 0x00, 0x01],
+                    area_addrs: vec![vec![0x49, 0x00, 0x01]],
                 }),
                 IsisTlv::Auth(IsisTlvAuth::placeholder(
                     ISIS_AUTH_TYPE_HMAC_MD5,
@@ -814,7 +814,7 @@ mod tests {
             types: Default::default(),
             tlvs: vec![
                 IsisTlv::AreaAddr(IsisTlvAreaAddr {
-                    area_addr: vec![0x49, 0x00, 0x01],
+                    area_addrs: vec![vec![0x49, 0x00, 0x01]],
                 }),
                 IsisTlv::Auth(IsisTlvAuth::placeholder(
                     ISIS_AUTH_TYPE_HMAC_MD5,
@@ -1023,7 +1023,7 @@ mod tests {
             key_chain: None,
         };
         let mut tlvs = vec![IsisTlv::AreaAddr(IsisTlvAreaAddr {
-            area_addr: vec![0x49, 0x00, 0x01],
+            area_addrs: vec![vec![0x49, 0x00, 0x01]],
         })];
         let chains = std::collections::BTreeMap::new();
         let resolved = resolve_send(&cfg, &chains, chrono::Utc::now());
@@ -1098,7 +1098,7 @@ mod tests {
             key_chain: None,
         };
         let mut tlvs = vec![IsisTlv::AreaAddr(IsisTlvAreaAddr {
-            area_addr: vec![0x49, 0x00, 0x01],
+            area_addrs: vec![vec![0x49, 0x00, 0x01]],
         })];
         let chains = std::collections::BTreeMap::new();
         let resolved = resolve_send(&cfg, &chains, chrono::Utc::now());

--- a/zebra-rs/src/isis/ifsm.rs
+++ b/zebra-rs/src/isis/ifsm.rs
@@ -155,7 +155,9 @@ pub fn hello_generate(link: &LinkTop, level: Level) -> IsisHello {
     hello.tlvs.push(tlv.into());
 
     let area_addr = link.up_config.net.area_id();
-    let tlv = IsisTlvAreaAddr { area_addr };
+    let tlv = IsisTlvAreaAddr {
+        area_addrs: vec![area_addr],
+    };
     hello.tlvs.push(tlv.into());
 
     push_if_addr_tlvs(&mut hello.tlvs, link);
@@ -231,7 +233,9 @@ pub fn hello_p2p_generate(link: &LinkTop, level: Level) -> IsisP2pHello {
 
     // Add area address TLV
     let area_addr = link.up_config.net.area_id();
-    let tlv = IsisTlvAreaAddr { area_addr };
+    let tlv = IsisTlvAreaAddr {
+        area_addrs: vec![area_addr],
+    };
     hello.tlvs.push(tlv.into());
 
     push_if_addr_tlvs(&mut hello.tlvs, link);

--- a/zebra-rs/src/isis/lsp.rs
+++ b/zebra-rs/src/isis/lsp.rs
@@ -754,7 +754,12 @@ pub fn lsp_generate(top: &mut IsisTop, level: Level, seq_floor: Option<u32>) -> 
     // already uses the AFI-prefixed form, so this keeps the LSP's Area
     // Address TLV consistent with the Hello's.
     let area_addr = top.config.net.area_id();
-    anchors.push(IsisTlvAreaAddr { area_addr }.into());
+    anchors.push(
+        IsisTlvAreaAddr {
+            area_addrs: vec![area_addr],
+        }
+        .into(),
+    );
 
     // Supported protocol.
     let mut nlpids = vec![];
@@ -2065,7 +2070,7 @@ mod tests {
     #[test]
     fn pack_keeps_anchors_in_fragment_zero() {
         let area = IsisTlv::AreaAddr(IsisTlvAreaAddr {
-            area_addr: vec![0x49, 0x00, 0x01],
+            area_addrs: vec![vec![0x49, 0x00, 0x01]],
         });
         let hostname = IsisTlv::Hostname(IsisTlvHostname {
             hostname: "r1".to_string(),
@@ -2098,7 +2103,7 @@ mod tests {
     #[test]
     fn pack_spills_into_fragment_one_when_budget_tight() {
         let area = IsisTlv::AreaAddr(IsisTlvAreaAddr {
-            area_addr: vec![0x49, 0x00, 0x01],
+            area_addrs: vec![vec![0x49, 0x00, 0x01]],
         });
         // ~30 entries × ~9 bytes ≈ 270B value — already exceeds
         // 255, so the splitter will produce two TLV 135 instances.
@@ -2173,7 +2178,7 @@ mod tests {
     #[test]
     fn placement_memory_preserves_survivors_after_removal() {
         let area = IsisTlv::AreaAddr(IsisTlvAreaAddr {
-            area_addr: vec![0x49, 0x00, 0x01],
+            area_addrs: vec![vec![0x49, 0x00, 0x01]],
         });
         let tlvs: Vec<IsisTlv> = (1..=5).map(ext_is_reach_for).collect();
         let base = IsisNeighborId::from_sys_id(&IsisSysId::default(), 0);

--- a/zebra-rs/src/isis/packet.rs
+++ b/zebra-rs/src/isis/packet.rs
@@ -306,8 +306,10 @@ pub fn nbr_hello_interpret(
 /// never call this. Returns false when the neighbour advertises no area we
 /// hold — the caller then refuses the L1 adjacency.
 fn l1_area_compatible(our_area: &[u8], tlvs: &[IsisTlv]) -> bool {
-    tlvs.iter()
-        .any(|tlv| matches!(tlv, IsisTlv::AreaAddr(a) if a.area_addr.as_slice() == our_area))
+    tlvs.iter().any(|tlv| {
+        matches!(tlv, IsisTlv::AreaAddr(a)
+            if a.area_addrs.iter().any(|addr| addr.as_slice() == our_area))
+    })
 }
 
 #[isis_pdu_handler(Hello, Recv)]


### PR DESCRIPTION
## Summary

Fixes findings #6, #9, #10 of the isis-packet code review
(`docs/design/isis-packet-code-review.md`).

**#6 — Area Addresses TLV drops all but the first area.** The TLV 1
value is a sequence of `{length, area}` pairs (maxAreaAddresses = 3),
but `parse_be` read exactly one pair and the dispatcher discarded the
rest — a neighbor packing two areas into one TLV lost its second area
and L1 area matching against it failed. `IsisTlvAreaAddr` now models
`area_addrs: Vec<Vec<u8>>`: parse loops over every pair, emit writes
each one back (len/emit truncate consistently at the 255-byte budget),
and the daemon's `l1_area_compatible` gate matches any advertised area.

**#9 — 3-octet SID/Label never masked to 20 bits.** RFC 8667 reserves
the top 4 bits of the 3-octet form; unmasked, a peer's reserved bit or a
mis-scaled local value became an illegal MPLS label ≥ 2²⁰ that zebra
accepted, re-advertised, and could program. `SidLabelValue::LABEL_MASK`
(`0x000F_FFFF`) is now applied on both parse and emit, matching FRR.

**#10 — one malformed element silently truncated its followers.**
`many0` treats an element error as end-of-list, so a single bad reach
entry or known sub-TLV dropped every valid element after it with no
trace. Two mechanisms fix this: all six sub-TLV registries degrade a
malformed *known* sub-TLV to `Unknown` with bytes preserved (the
top-level TLV loop's existing policy), and TLV 135/235/236/237 entry
lists go through `parse_reach_entries`, which frames a semantically
invalid entry from its header fields alone and skips just that entry —
an unframeable tail errors so the whole TLV degrades to `Unknown`
instead of silently discarding bytes.

Review doc: findings #6/#9/#10 marked fixed.

## Test plan

- New unit tests pin: the two-area TLV 1 round-trip, label masking on
  parse and emit (Index untouched), the v4 (prefixlen 33) and v6
  (prefixlen 200) entry-skip cases, and sub-TLV degrade-to-Unknown with
  the following valid sub-TLV surviving.
- `cargo test --workspace --exclude bdd` green locally (the
  `area_addrs` rename was compiler-swept across the daemon).

Generated with [Claude Code](https://claude.com/claude-code)