### PR TITLE
ospf-packet: fix OSPFv3 Adj-SID Weight field width and offset

### DIFF
--- a/crates/ospf-packet/src/v3.rs
+++ b/crates/ospf-packet/src/v3.rs
@@ -1698,20 +1698,21 @@ impl Ospfv3PrefixSidSubTlv {
 
 /// Adj-SID Sub-TLV (RFC 8666 §6.1).
 ///
-/// Wire layout: flags(1) + reserved(1) + weight(2) + SID(3 or 4).
+/// Wire layout: flags(1) + weight(1) + reserved(2) + SID(3 or 4) — the
+/// Weight is a single octet at offset 1 (Flags | Weight | Reserved).
 /// `AdjSidFlags` reused verbatim — the same B / V / L / G / P bit
 /// assignments as the OSPFv2 Adj-SID Sub-TLV (RFC 8665 §5); only the
-/// surrounding wire layout (16-bit Weight, no MT-ID) differs.
+/// surrounding wire layout (no MT-ID) differs.
 #[derive(Debug, Clone, PartialEq)]
 pub struct Ospfv3AdjSidSubTlv {
     pub flags: AdjSidFlags,
-    pub weight: u16,
+    pub weight: u8,
     pub sid: SidLabelTlv,
 }
 
 impl Ospfv3AdjSidSubTlv {
     fn value_len(&self) -> u16 {
-        // flags(1) + reserved(1) + weight(2) + sid(3 or 4)
+        // flags(1) + weight(1) + reserved(2) + sid(3 or 4)
         4 + match &self.sid {
             SidLabelTlv::Label(_) => 3,
             SidLabelTlv::Index(_) => 4,
@@ -1720,8 +1721,8 @@ impl Ospfv3AdjSidSubTlv {
 
     fn emit(&self, buf: &mut BytesMut) {
         buf.put_u8(self.flags.into());
-        buf.put_u8(0); // reserved
-        buf.put_u16(self.weight);
+        buf.put_u8(self.weight);
+        buf.put_u16(0); // reserved
         match &self.sid {
             SidLabelTlv::Label(v) => buf.put(&packet_utils::u32_u8_3(*v)[..]),
             SidLabelTlv::Index(v) => buf.put_u32(*v),
@@ -1730,8 +1731,8 @@ impl Ospfv3AdjSidSubTlv {
 
     fn parse_be(input: &[u8]) -> IResult<&[u8], Self> {
         let (input, flags) = be_u8(input)?;
-        let (input, _reserved) = be_u8(input)?;
-        let (input, weight) = be_u16(input)?;
+        let (input, weight) = be_u8(input)?;
+        let (input, _reserved) = be_u16(input)?;
         let sid_len = input.len();
         let (input, sid) = match sid_len {
             3 => {
@@ -1765,14 +1766,14 @@ impl Ospfv3AdjSidSubTlv {
 #[derive(Debug, Clone, PartialEq)]
 pub struct Ospfv3LanAdjSidSubTlv {
     pub flags: AdjSidFlags,
-    pub weight: u16,
+    pub weight: u8,
     pub neighbor_router_id: Ipv4Addr,
     pub sid: SidLabelTlv,
 }
 
 impl Ospfv3LanAdjSidSubTlv {
     fn value_len(&self) -> u16 {
-        // flags(1) + reserved(1) + weight(2) + neighbor_router_id(4) + sid(3 or 4)
+        // flags(1) + weight(1) + reserved(2) + neighbor_router_id(4) + sid(3 or 4)
         8 + match &self.sid {
             SidLabelTlv::Label(_) => 3,
             SidLabelTlv::Index(_) => 4,
@@ -1781,8 +1782,8 @@ impl Ospfv3LanAdjSidSubTlv {
 
     fn emit(&self, buf: &mut BytesMut) {
         buf.put_u8(self.flags.into());
-        buf.put_u8(0); // reserved
-        buf.put_u16(self.weight);
+        buf.put_u8(self.weight);
+        buf.put_u16(0); // reserved
         buf.put(&self.neighbor_router_id.octets()[..]);
         match &self.sid {
             SidLabelTlv::Label(v) => buf.put(&packet_utils::u32_u8_3(*v)[..]),
@@ -1792,8 +1793,8 @@ impl Ospfv3LanAdjSidSubTlv {
 
     fn parse_be(input: &[u8]) -> IResult<&[u8], Self> {
         let (input, flags) = be_u8(input)?;
-        let (input, _reserved) = be_u8(input)?;
-        let (input, weight) = be_u16(input)?;
+        let (input, weight) = be_u8(input)?;
+        let (input, _reserved) = be_u16(input)?;
         let (input, neighbor_router_id) = Ipv4Addr::parse_be(input)?;
         let sid_len = input.len();
         let (input, sid) = match sid_len {
@@ -3590,6 +3591,41 @@ mod tests {
         assert!(o.at());
         // A compliant peer's AT bit parses back to at() == true.
         assert!(Ospfv3Options::from_bits(0x0000_0400).at());
+    }
+
+    #[test]
+    fn adj_sid_weight_at_rfc8666_offset() {
+        // RFC 8666 §6.1: Flags(8) | Weight(8) | Reserved(16) | SID. Weight is
+        // a single octet at offset 1, not a u16 at offsets 2-3.
+        let tlv = Ospfv3AdjSidSubTlv {
+            flags: AdjSidFlags::new().with_v_flag(true).with_l_flag(true),
+            weight: 200,
+            sid: SidLabelTlv::Label(15003),
+        };
+        let mut buf = BytesMut::new();
+        tlv.emit(&mut buf);
+        assert_eq!(buf[1], 200, "weight octet at offset 1");
+        assert_eq!(&buf[2..4], &[0, 0], "reserved 16 bits at offsets 2-3");
+        let (_, back) = Ospfv3AdjSidSubTlv::parse_be(&buf[..]).unwrap();
+        assert_eq!(back, tlv);
+    }
+
+    #[test]
+    fn lan_adj_sid_weight_at_rfc8666_offset() {
+        // RFC 8666 §6.2: same Flags | Weight | Reserved head before the
+        // Neighbor Router ID.
+        let tlv = Ospfv3LanAdjSidSubTlv {
+            flags: AdjSidFlags::new().with_v_flag(true).with_l_flag(true),
+            weight: 100,
+            neighbor_router_id: "10.0.0.2".parse().unwrap(),
+            sid: SidLabelTlv::Label(15100),
+        };
+        let mut buf = BytesMut::new();
+        tlv.emit(&mut buf);
+        assert_eq!(buf[1], 100, "weight octet at offset 1");
+        assert_eq!(&buf[2..4], &[0, 0], "reserved 16 bits at offsets 2-3");
+        let (_, back) = Ospfv3LanAdjSidSubTlv::parse_be(&buf[..]).unwrap();
+        assert_eq!(back, tlv);
     }
 
     fn make_hello() -> Ospfv3Hello {


### PR DESCRIPTION
## Summary

`Ospfv3AdjSidSubTlv` and `Ospfv3LanAdjSidSubTlv` emitted the Weight as a 16-bit field at octets 2-3, with a 1-octet reserved at offset 1. RFC 8666 §6.1/§6.2 define the head as `Flags(8) | Weight(8) | Reserved(16)` — Weight is a single octet at offset 1 and the 16 reserved bits follow.

Against a conforming peer the old layout put `Weight=0` in the reserved slot and read a non-zero weight from octets 2-3 as reserved, so weighted-ECMP over adjacency SIDs was silently lost in both directions. The total sub-TLV length is unchanged (4-byte head), so nothing else shifts.

Found in the ospf-packet crate code review (`docs/design/ospf-packet-code-review.md`, finding #6).

## Changes
- `weight` is now a `u8`; emit `flags(1) | weight(1) | reserved(2)` and parse to match, in both the Adj-SID and LAN-Adj-SID sub-TLVs.

## Test plan
- New unit tests pin the weight octet at offset 1 with a non-zero value and round-trip through parse (the pre-existing round-trip tests all used `weight=0`, which is why the misplacement went unnoticed).
- `cargo test -p ospf-packet`: 73 pass. `cargo test -p zebra-rs ospf::`: 84 pass (the `u16→u8` change compiles cleanly; the daemon originates these with `weight: 0`).
- `cargo fmt` applied; `cargo clippy --workspace`: clean.

No BDD: the daemon always originates Adj-SIDs with `weight: 0` and exposes no weight knob, so a `show`-based feature would render `Weight: 0` under either layout and could not distinguish the bug. The byte-offset unit tests are the meaningful regression lock.

Generated with [Claude Code](https://claude.com/claude-code)