### PR TITLE
isis-packet: enforce prefix-closed emit for P2p3Way/Restart optionals

### DIFF
--- a/crates/isis-packet/src/parser.rs
+++ b/crates/isis-packet/src/parser.rs
@@ -1255,30 +1255,43 @@ impl TlvEmitter for IsisTlvP2p3Way {
     }
 
     fn len(&self) -> u8 {
+        // Positional wire format: the parser assigns trailing bytes in
+        // this fixed order, so a field can only be present when every
+        // field before it is. Stop at the first None — matching emit()
+        // — so a gapped struct (e.g. neighbor_id set with circuit_id
+        // None) can never emit a byte layout the parser would
+        // misassign (the system-id's first 4 bytes read as circuit id).
         let mut len = 1;
-        if self.circuit_id.is_some() {
-            len += 4;
+        if self.circuit_id.is_none() {
+            return len;
         }
-        if self.neighbor_id.is_some() {
-            len += 6;
+        len += 4;
+        if self.neighbor_id.is_none() {
+            return len;
         }
-        if self.neighbor_circuit_id.is_some() {
-            len += 4;
+        len += 6;
+        if self.neighbor_circuit_id.is_none() {
+            return len;
         }
-        len
+        len + 4
     }
 
     fn emit(&self, buf: &mut BytesMut) {
         buf.put_u8(self.state);
-        if let Some(circuit_id) = self.circuit_id {
-            buf.put_u32(circuit_id);
-        }
-        if let Some(neighbor_id) = &self.neighbor_id {
-            buf.put(&neighbor_id.id[..]);
-        }
-        if let Some(neighbor_circuit_id) = self.neighbor_circuit_id {
-            buf.put_u32(neighbor_circuit_id);
-        }
+        // See len(): stop at the first None to keep the positional
+        // layout parseable.
+        let Some(circuit_id) = self.circuit_id else {
+            return;
+        };
+        buf.put_u32(circuit_id);
+        let Some(neighbor_id) = &self.neighbor_id else {
+            return;
+        };
+        buf.put(&neighbor_id.id[..]);
+        let Some(neighbor_circuit_id) = self.neighbor_circuit_id else {
+            return;
+        };
+        buf.put_u32(neighbor_circuit_id);
     }
 }
 
@@ -1445,6 +1458,68 @@ pub fn parse(input: &[u8]) -> IsisIResult<&[u8], IsisPacket> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// Finding #12: TLV 240's wire format is positional (state, then
+    /// circuit id, then neighbor id, then neighbor circuit id), so emit
+    /// must stop at the first None. A gapped struct (neighbor_id set,
+    /// circuit_id None) used to emit state + 6 bytes, which re-parsed
+    /// with the system-id's first 4 bytes as the circuit id — the
+    /// three-way handshake would compare the wrong neighbor identity.
+    #[test]
+    fn p2p3way_gapped_optionals_emit_prefix_closed() {
+        let gapped = IsisTlvP2p3Way {
+            state: 1,
+            circuit_id: None,
+            neighbor_id: Some(IsisSysId {
+                id: [1, 2, 3, 4, 5, 6],
+            }),
+            neighbor_circuit_id: Some(7),
+        };
+        assert_eq!(gapped.len(), 1);
+        let mut buf = BytesMut::new();
+        gapped.emit(&mut buf);
+        assert_eq!(&buf[..], &[1]);
+
+        // Every prefix-closed form round-trips exactly.
+        let forms = [
+            IsisTlvP2p3Way {
+                state: 2,
+                circuit_id: None,
+                neighbor_id: None,
+                neighbor_circuit_id: None,
+            },
+            IsisTlvP2p3Way {
+                state: 2,
+                circuit_id: Some(9),
+                neighbor_id: None,
+                neighbor_circuit_id: None,
+            },
+            IsisTlvP2p3Way {
+                state: 2,
+                circuit_id: Some(9),
+                neighbor_id: Some(IsisSysId {
+                    id: [1, 2, 3, 4, 5, 6],
+                }),
+                neighbor_circuit_id: None,
+            },
+            IsisTlvP2p3Way {
+                state: 2,
+                circuit_id: Some(9),
+                neighbor_id: Some(IsisSysId {
+                    id: [1, 2, 3, 4, 5, 6],
+                }),
+                neighbor_circuit_id: Some(7),
+            },
+        ];
+        for form in forms {
+            let mut buf = BytesMut::new();
+            form.emit(&mut buf);
+            assert_eq!(buf.len() as u8, form.len());
+            let (rest, parsed) = IsisTlvP2p3Way::parse_be(&buf).expect("parse");
+            assert!(rest.is_empty());
+            assert_eq!(parsed, form);
+        }
+    }
 
     /// RFC 8667: the 3-octet SID/Label form carries the MPLS label in
     /// the 20 rightmost bits; the top 4 are reserved and must be masked

--- a/crates/isis-packet/src/sub/restart.rs
+++ b/crates/isis-packet/src/sub/restart.rs
@@ -116,24 +116,35 @@ impl TlvEmitter for IsisTlvRestart {
     }
 
     fn len(&self) -> u8 {
+        // Positional wire format: the parser assigns trailing bytes in
+        // fixed order (remaining time, then neighbor id), so the
+        // neighbor can only be present when the time is. Stop at the
+        // first None — matching emit() — so a gapped struct can never
+        // emit a layout the parser would misassign (the system-id's
+        // first 2 bytes read as a bogus hold time during GR).
         let mut len: u8 = 1;
-        if self.remaining_time.is_some() {
-            len += 2;
+        if self.remaining_time.is_none() {
+            return len;
         }
-        if self.restarting_neighbor.is_some() {
-            len += 6;
+        len += 2;
+        if self.restarting_neighbor.is_none() {
+            return len;
         }
-        len
+        len + 6
     }
 
     fn emit(&self, buf: &mut BytesMut) {
         buf.put_u8(self.flags);
-        if let Some(t) = self.remaining_time {
-            buf.put_u16(t);
-        }
-        if let Some(id) = &self.restarting_neighbor {
-            buf.put(&id.id[..]);
-        }
+        // See len(): stop at the first None to keep the positional
+        // layout parseable.
+        let Some(t) = self.remaining_time else {
+            return;
+        };
+        buf.put_u16(t);
+        let Some(id) = &self.restarting_neighbor else {
+            return;
+        };
+        buf.put(&id.id[..]);
     }
 }
 
@@ -217,6 +228,29 @@ mod tests {
         let (rest, decoded) = IsisTlvRestart::parse_be(&buf[2..]).unwrap();
         assert!(rest.is_empty());
         assert_eq!(decoded, tlv);
+    }
+
+    /// Finding #12: the wire format is positional, so a gapped struct
+    /// (neighbor set, time None) must not emit the neighbor — the
+    /// parser would read the system-id's first 2 bytes as a bogus
+    /// remaining time during graceful restart.
+    #[test]
+    fn gapped_optionals_emit_prefix_closed() {
+        let tlv = IsisTlvRestart {
+            flags: ISIS_RESTART_FLAG_RA,
+            remaining_time: None,
+            restarting_neighbor: Some(IsisSysId {
+                id: [0x10, 0x20, 0x30, 0x40, 0x50, 0x60],
+            }),
+        };
+        let mut buf = BytesMut::new();
+        tlv.tlv_emit(&mut buf);
+        // Only the flags byte is emitted and the length agrees.
+        assert_eq!(&buf[..], &[211, 1, 0x02]);
+        let (rest, decoded) = IsisTlvRestart::parse_be(&buf[2..]).unwrap();
+        assert!(rest.is_empty());
+        assert_eq!(decoded.remaining_time, None);
+        assert_eq!(decoded.restarting_neighbor, None);
     }
 
     /// Starting router (fresh boot, RFC 5306 §3.4): SA=1, RR=0. The

--- a/docs/design/isis-packet-code-review.md
+++ b/docs/design/isis-packet-code-review.md
@@ -287,7 +287,7 @@ bookkeeping remains valid but is no longer load-bearing. Unit tests pin the
 parsed S=1/sublen=0 re-emit and the hand-built subs-without-flag round-trip
 for both TLV 135 and TLV 236.
 
-### 12. 🟡 `P2p3Way` / `Restart` parse optionals by remaining length but emit by `Option` — PLAUSIBLE
+### 12. 🟡 `P2p3Way` / `Restart` parse optionals by remaining length but emit by `Option` — PLAUSIBLE — ✅ FIXED
 `crates/isis-packet/src/parser.rs:1168`; `crates/isis-packet/src/sub/restart.rs:83`/`:129`
 
 `IsisTlvP2p3Way::parse_be` assigns optional trailing fields purely by remaining
@@ -303,8 +303,12 @@ parser reads the first 2 as `remaining_time` and honors a bogus hold-time during
 graceful restart. Currently latent because callers set the fields together, but
 nothing enforces it.
 
-**Fix:** make emit/parse agree on an explicit presence rule (e.g. all-or-nothing
-tied to a flag), or encode the optional group as a single `Option<struct>`.
+**Fixed:** both `len()`/`emit()` now enforce prefix-closure — fields are
+emitted in wire order and emission stops at the first `None`, so a gapped
+struct can never produce a byte layout the length-driven parser would
+misassign. All daemon builders were already prefix-closed, so no wire output
+changes. Unit tests pin the gapped-struct emit (only the leading fields) and
+every prefix-closed `P2p3Way` form round-tripping exactly.
 
 ### 13. 🟡 `admin_group()` doc claims sub-TLV 3 but reads sub-TLV 14; sub-TLV 3 undispatched — PLAUSIBLE
 `crates/isis-packet/src/sub/neigh.rs:154`


### PR DESCRIPTION
## Summary

Fixes finding #12 of the isis-packet code review
(`docs/design/isis-packet-code-review.md`).

TLV 240 (P2P Three-Way Adjacency) and TLV 211 (Restart) have positional
wire formats: the parser assigns trailing optional fields by remaining
length in fixed order, but `emit()` wrote whichever `Option`s were
`Some`. A gapped struct therefore desynced its own wire form:

- A `P2p3Way` with `circuit_id=None` but `neighbor_id=Some` emitted
  state + 6 bytes that re-parsed with the system-id's first 4 bytes as
  the circuit id — the three-way handshake compares the wrong neighbor
  identity.
- A `Restart` with `remaining_time=None` but `restarting_neighbor=Some`
  re-parsed the system-id's first 2 bytes as a bogus hold time during
  graceful restart.

`len()` and `emit()` now enforce prefix-closure: fields are emitted in
wire order and emission stops at the first `None`, so no gapped struct
can produce a layout the length-driven parser would misassign. All
daemon builders were already prefix-closed (the only gapped construction
in the tree is an in-memory test helper that is never emitted), so no
wire output changes.

Review doc: finding #12 marked fixed.

## Test plan

- New unit tests pin the gapped-struct emit for both TLVs (only the
  leading fields appear, length byte agrees) and all four prefix-closed
  `P2p3Way` forms round-tripping exactly with `len()` == emitted bytes.
- `cargo test --workspace --exclude bdd` green locally.

Generated with [Claude Code](https://claude.com/claude-code)