### PR TITLE
bgp: RFC 6793 4-octet AS support with capability negotiation

### DIFF
--- a/bdd/tests/configs/bgp_as4/z1-1.yaml
+++ b/bdd/tests/configs/bgp_as4/z1-1.yaml
@@ -1,0 +1,16 @@
+router:
+  bgp:
+    global:
+      as: 70000
+      router-id: 192.168.0.1
+    neighbor:
+    - remote-address: 192.168.0.2
+      afi-safi:
+      - name: ipv4
+        enabled: true
+      enabled: true
+      remote-as: 65002
+    afi-safi:
+    - name: ipv4
+      network:
+      - prefix: 10.0.0.1/32

--- a/bdd/tests/configs/bgp_as4/z2-1.yaml
+++ b/bdd/tests/configs/bgp_as4/z2-1.yaml
@@ -1,0 +1,16 @@
+router:
+  bgp:
+    global:
+      as: 65002
+      router-id: 192.168.0.2
+    neighbor:
+    - remote-address: 192.168.0.1
+      afi-safi:
+      - name: ipv4
+        enabled: true
+      enabled: true
+      remote-as: 70000
+    afi-safi:
+    - name: ipv4
+      network:
+      - prefix: 10.1.0.1/32

--- a/bdd/tests/configs/bgp_as4/z2-2.yaml
+++ b/bdd/tests/configs/bgp_as4/z2-2.yaml
@@ -1,0 +1,18 @@
+router:
+  bgp:
+    global:
+      as: 65002
+      router-id: 192.168.0.2
+    neighbor:
+    - remote-address: 192.168.0.1
+      afi-safi:
+      - name: ipv4
+        enabled: true
+      capability:
+        four-octet: false
+      enabled: true
+      remote-as: 70000
+    afi-safi:
+    - name: ipv4
+      network:
+      - prefix: 10.1.0.1/32

--- a/bdd/tests/features/bgp_as4.feature
+++ b/bdd/tests/features/bgp_as4.feature
@@ -1,0 +1,75 @@
+@serial
+@bgp_as4
+Feature: BGP 4-octet AS support (RFC 6793)
+  As a network operator
+  I want sessions with 4-byte-ASN routers to establish and carry real AS paths,
+  including toward legacy 2-octet (OLD) speakers via AS_TRANS + AS4_PATH.
+
+  Test Topology:
+  ```
+  ┌─────────────────────────────────────────┐
+  │                   br0                   │
+  └─────────────┬───────────────┬───────────┘
+                │               │
+           ┌────┴────┐     ┌────┴────┐
+           │   z1    │     │   z2    │
+           │ AS70000 │     │ AS65002 │
+           │192.168. │     │192.168. │
+           │  0.1/24 │     │  0.2/24 │
+           └─────────┘     └─────────┘
+  ```
+
+  Config files:
+  - z1-1.yaml: AS 70000 (4-byte), peer to 192.168.0.2, network 10.0.0.1/32
+  - z2-1.yaml: AS 65002, peer to 192.168.0.1, network 10.1.0.1/32
+  - z2-2.yaml: z2-1 plus `capability four-octet false` — z2 presents
+    itself as an OLD (2-octet) speaker, so z1 must fall back to a
+    2-octet AS_PATH with AS_TRANS plus the AS4_PATH attribute.
+
+  AS 70000 renders as "1.4464" in asdot notation (RFC 5396).
+
+  Scenario: A 4-byte-ASN neighbor establishes via AS_TRANS + AS4 capability
+    Given a clean test environment
+    When I create bridge "br0"
+    And I create namespace "z1" with IP "192.168.0.1/24" on bridge "br0"
+    And I create namespace "z2" with IP "192.168.0.2/24" on bridge "br0"
+    And I start zebra-rs in namespace "z1"
+    And I start zebra-rs in namespace "z2"
+    And I apply config "z1-1.yaml" to namespace "z1"
+    And I apply config "z2-1.yaml" to namespace "z2"
+    And I wait 10 seconds for BGP to operate
+    Then BGP session in "z1" to "192.168.0.2" should be "Established"
+    And BGP session in "z2" to "192.168.0.1" should be "Established"
+
+  Scenario: Routes carry the real 4-byte AS path on an AS4 session
+    Given the test topology exists
+    When I wait 20 seconds for BGP to operate
+    Then show command "show bgp neighbor" in namespace "z1" should contain "4 Octet AS: advertised and received"
+    And BGP route in "z2" has "10.0.0.1/32" with "as_path" value "1.4464"
+    And BGP route in "z1" has "10.1.0.1/32" with "as_path" value "65002"
+
+  Scenario: OLD speaker recovers the 4-byte AS path via AS4_PATH
+    Given the test topology exists
+    When I apply config "z2-2.yaml" to namespace "z2"
+    And I wait 5 seconds for BGP to operate
+    # Hard reset (not the soft-out step): withholding the capability
+    # only takes effect at the next OPEN exchange.
+    And I run "clear bgp ipv4 neighbor 192.168.0.1" in namespace "z2"
+    And I wait 30 seconds for BGP to operate
+    Then BGP session in "z2" to "192.168.0.1" should be "Established"
+    # The session is genuinely OLD: z1 advertised the capability but z2
+    # withheld it. Route-level assertions alone can't tell the two
+    # apart — the AS4_PATH merge is designed to produce the same path.
+    And show command "show bgp neighbor" in namespace "z1" should not contain "4 Octet AS: advertised and received"
+    And show command "show bgp neighbor" in namespace "z1" should contain "4 Octet AS: advertised"
+    And BGP route in "z2" has "10.0.0.1/32" with "as_path" value "1.4464"
+    And BGP route in "z1" has "10.1.0.1/32" with "as_path" value "65002"
+
+  Scenario: Teardown topology
+    Given the test topology exists
+    When I stop zebra-rs in namespace "z1"
+    And I stop zebra-rs in namespace "z2"
+    And I delete namespace "z1"
+    And I delete namespace "z2"
+    And I delete bridge "br0"
+    Then the test environment should be clean

--- a/crates/bgp-packet/src/attrs/aggregator.rs
+++ b/crates/bgp-packet/src/attrs/aggregator.rs
@@ -74,7 +74,9 @@ impl Aggregator2 {
 
 impl AttrEmitter for Aggregator2 {
     fn attr_flags(&self) -> AttrFlags {
-        AttrFlags::new().with_transitive(true)
+        // AGGREGATOR is optional transitive (RFC 4271 §5.1.7) in both
+        // ASN widths.
+        AttrFlags::new().with_transitive(true).with_optional(true)
     }
 
     fn attr_type(&self) -> AttrType {
@@ -100,6 +102,65 @@ impl fmt::Display for Aggregator2 {
 impl fmt::Debug for Aggregator2 {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, " Aggregator: {}", self)
+    }
+}
+
+/// The AS4_AGGREGATOR attribute (type 18, RFC 6793 §3): the 4-octet
+/// aggregator identity an OLD (non-AS4) speaker tunnels while its
+/// AGGREGATOR carries AS_TRANS. Same value encoding as the 4-octet
+/// [`Aggregator`], but a distinct attribute type.
+#[derive(Clone, NomBE, PartialEq, Eq, Hash)]
+pub struct As4Aggregator {
+    pub asn: u32,
+    pub ip: Ipv4Addr,
+}
+
+impl AttrEmitter for As4Aggregator {
+    fn attr_flags(&self) -> AttrFlags {
+        AttrFlags::new().with_transitive(true).with_optional(true)
+    }
+
+    fn attr_type(&self) -> AttrType {
+        AttrType::As4Aggregator
+    }
+
+    fn len(&self) -> Option<usize> {
+        Some(8)
+    }
+
+    fn emit(&self, buf: &mut BytesMut) {
+        buf.put_u32(self.asn);
+        buf.put(&self.ip.octets()[..]);
+    }
+}
+
+impl fmt::Display for As4Aggregator {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.asn)
+    }
+}
+
+impl fmt::Debug for As4Aggregator {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, " As4Aggregator: {}", self)
+    }
+}
+
+impl From<&Aggregator> for As4Aggregator {
+    fn from(value: &Aggregator) -> Self {
+        Self {
+            asn: value.asn,
+            ip: value.ip,
+        }
+    }
+}
+
+impl From<As4Aggregator> for Aggregator {
+    fn from(value: As4Aggregator) -> Self {
+        Self {
+            asn: value.asn,
+            ip: value.ip,
+        }
     }
 }
 

--- a/crates/bgp-packet/src/attrs/aspath.rs
+++ b/crates/bgp-packet/src/attrs/aspath.rs
@@ -7,7 +7,7 @@ use std::collections::VecDeque;
 use std::fmt;
 use std::str::FromStr;
 
-use crate::{AttrType, ParseBe, many0_complete};
+use crate::{AttrType, ParseBe, parse_nlri_block};
 
 use super::aspath_token::{Token, tokenizer};
 use super::{AttrEmitter, AttrFlags};
@@ -23,7 +23,9 @@ pub const AS_CONFED_SET: u8 = 4;
 /// `AS_SEGMENT_MAX`.
 pub const AS_SEGMENT_MAX: usize = 255;
 
-#[allow(dead_code)]
+/// RFC 6793: the 2-octet placeholder an ASN above 65535 becomes in a
+/// message bound for an OLD (non-AS4) speaker. The real ASNs travel in
+/// AS4_PATH / AS4_AGGREGATOR alongside.
 pub const AS_TRANS: u16 = 23456;
 
 /// Inclusive bounds of the 16-bit private AS range (RFC 6996).
@@ -86,7 +88,11 @@ impl As2Path {
 
 impl ParseBe<As2Path> for As2Path {
     fn parse_be(input: &[u8]) -> IResult<&[u8], As2Path> {
-        let (input, segs) = many0_complete(parse_bgp_attr_as2_segment).parse(input)?;
+        // Exact consumption: a segment list that stops short of the
+        // attribute value leaves trailing octets, which means a segment
+        // failed to parse — a malformed AS_PATH (RFC 7606 §7.4), not a
+        // shorter one.
+        let (input, segs) = parse_nlri_block(input, parse_bgp_attr_as2_segment)?;
         let mut path = As2Path { segs, length: 0 };
         path.update_length();
         Ok((input, path))
@@ -108,10 +114,11 @@ impl From<As2Path> for As4Path {
     /// crate works in (RFC 6793 §4.2.2), zero-extending each AS number. Segment
     /// types and order carry over unchanged, so the hop count is identical.
     ///
-    /// This does not recover the 4-octet AS numbers that an OLD (non-AS4) peer
-    /// replaces with AS_TRANS (23456): those live in the AS4_PATH attribute
-    /// (type 17), which this crate does not implement, so an AS_TRANS widens to
-    /// a literal 23456.
+    /// This alone does not recover the 4-octet AS numbers an OLD (non-AS4)
+    /// peer replaces with AS_TRANS (23456): those live in the AS4_PATH
+    /// attribute (type 17), reconciled by [`As4Path::merge_as4_path`] in
+    /// `parse_bgp_update_attribute`. An AS_TRANS therefore widens to a
+    /// literal 23456 here, to be substituted by the merge.
     fn from(from: As2Path) -> Self {
         let mut path = As4Path {
             segs: from
@@ -126,6 +133,117 @@ impl From<As2Path> for As4Path {
         };
         path.update_length();
         path
+    }
+}
+
+impl As2Segment {
+    pub fn emit(&self, buf: &mut BytesMut) {
+        // Same 1-octet Path Segment Length handling as
+        // [`As4Segment::emit`]: preserve empty segments, split runs
+        // longer than 255 into consecutive segments of the same type.
+        if self.asn.is_empty() {
+            buf.put_u8(self.typ);
+            buf.put_u8(0);
+            return;
+        }
+        for chunk in self.asn.chunks(AS_SEGMENT_MAX) {
+            buf.put_u8(self.typ);
+            buf.put_u8(chunk.len() as u8);
+            chunk.iter().for_each(|x| buf.put_u16(*x));
+        }
+    }
+}
+
+impl AttrEmitter for As2Path {
+    fn attr_flags(&self) -> AttrFlags {
+        AttrFlags::new().with_transitive(true)
+    }
+
+    fn attr_type(&self) -> AttrType {
+        AttrType::AsPath
+    }
+
+    fn len(&self) -> Option<usize> {
+        None
+    }
+
+    fn emit(&self, buf: &mut BytesMut) {
+        self.segs.iter().for_each(|x| x.emit(buf));
+    }
+}
+
+impl From<&As4Path> for As2Path {
+    /// Narrow to the 2-octet wire form for an OLD (non-AS4) peer
+    /// (RFC 6793 §4.2.1): each ASN that fits in two octets carries
+    /// over, anything larger becomes AS_TRANS. The real ASNs must
+    /// travel alongside in AS4_PATH ([`As4PathAttr`]) whenever this
+    /// substitution fired ([`As4Path::has_four_octet_asn`]).
+    fn from(from: &As4Path) -> Self {
+        let mut path = As2Path {
+            segs: from
+                .segs
+                .iter()
+                .map(|seg| As2Segment {
+                    typ: seg.typ,
+                    asn: seg
+                        .asn
+                        .iter()
+                        .map(|&asn| u16::try_from(asn).unwrap_or(AS_TRANS))
+                        .collect(),
+                })
+                .collect(),
+            length: 0,
+        };
+        path.update_length();
+        path
+    }
+}
+
+/// The AS4_PATH attribute (type 17, RFC 6793 §3): the 4-octet AS path an
+/// OLD (non-AS4) speaker tunnels transparently while its AS_PATH carries
+/// AS_TRANS placeholders. Same wire encoding as a 4-octet AS_PATH, but a
+/// distinct attribute type and optional-transitive flags — hence the
+/// wrapper rather than reusing [`As4Path`]'s [`AttrEmitter`].
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+pub struct As4PathAttr(pub As4Path);
+
+impl As4PathAttr {
+    /// AS4_PATH content for `path` (RFC 6793 §4.2.2): the full 4-octet
+    /// path minus confederation segments, which MUST NOT be carried in
+    /// AS4_PATH (§6).
+    pub fn from_path(path: &As4Path) -> Self {
+        Self(path.strip_confed_segments())
+    }
+}
+
+impl ParseBe<As4PathAttr> for As4PathAttr {
+    fn parse_be(input: &[u8]) -> IResult<&[u8], As4PathAttr> {
+        let (input, path) = As4Path::parse_be(input)?;
+        Ok((input, As4PathAttr(path)))
+    }
+}
+
+impl AttrEmitter for As4PathAttr {
+    fn attr_flags(&self) -> AttrFlags {
+        AttrFlags::new().with_optional(true).with_transitive(true)
+    }
+
+    fn attr_type(&self) -> AttrType {
+        AttrType::As4Path
+    }
+
+    fn len(&self) -> Option<usize> {
+        None
+    }
+
+    fn emit(&self, buf: &mut BytesMut) {
+        self.0.segs.iter().for_each(|x| x.emit(buf));
+    }
+}
+
+impl fmt::Display for As4PathAttr {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.0)
     }
 }
 
@@ -312,7 +430,8 @@ impl AttrEmitter for As4Path {
 
 impl ParseBe<As4Path> for As4Path {
     fn parse_be(input: &[u8]) -> IResult<&[u8], As4Path> {
-        let (input, segs) = many0_complete(parse_bgp_attr_as4_segment).parse(input)?;
+        // Exact consumption — see the As2Path parse for why.
+        let (input, segs) = parse_nlri_block(input, parse_bgp_attr_as4_segment)?;
         let mut path = As4Path {
             segs: segs.into(),
             length: 0,
@@ -477,6 +596,85 @@ impl As4Path {
         self.segs
             .iter()
             .any(|seg| seg.typ == AS_SET || seg.typ == AS_CONFED_SET)
+    }
+
+    /// True when any ASN needs more than two octets — the condition
+    /// under which a message to an OLD (non-AS4) peer loses information
+    /// to AS_TRANS substitution and must carry AS4_PATH alongside
+    /// (RFC 6793 §4.2.2).
+    pub fn has_four_octet_asn(&self) -> bool {
+        self.segs
+            .iter()
+            .any(|seg| seg.asn.iter().any(|&asn| asn > u16::MAX as u32))
+    }
+
+    /// This path minus AS_CONFED_SEQUENCE / AS_CONFED_SET segments.
+    /// AS4_PATH MUST NOT carry confederation segments (RFC 6793 §6):
+    /// applied when building one to emit, and to a received AS4_PATH
+    /// before the §4.2.3 merge (the RFC says to discard such segments
+    /// and continue).
+    pub fn strip_confed_segments(&self) -> As4Path {
+        let mut path = As4Path {
+            segs: self
+                .segs
+                .iter()
+                .filter(|seg| seg.typ != AS_CONFED_SEQ && seg.typ != AS_CONFED_SET)
+                .cloned()
+                .collect(),
+            length: 0,
+        };
+        path.update_length();
+        path
+    }
+
+    /// RFC 6793 §4.2.3: reconcile the AS_PATH received from an OLD
+    /// (non-AS4) peer (`as_path`, already widened, AS_TRANS in place of
+    /// every 4-octet ASN) with the AS4_PATH it tunneled (`as4_path`,
+    /// confederation segments already stripped).
+    ///
+    /// AS numbers are counted with the RFC 4271 §9.1.2.2 / RFC 5065
+    /// hop-count rules (each AS_SEQUENCE member counts 1, a whole
+    /// AS_SET counts 1, confederation segments count 0) — the counts
+    /// [`Self::length`] maintains. If AS_PATH counts fewer hops than
+    /// AS4_PATH, the AS4_PATH is ignored (an OLD speaker shortened the
+    /// path — e.g. by aggregation — after the AS4_PATH was attached).
+    /// Otherwise the merged path is the leading `AS_PATH − AS4_PATH`
+    /// hops of AS_PATH followed by the whole AS4_PATH.
+    pub fn merge_as4_path(as_path: &As4Path, as4_path: &As4Path) -> As4Path {
+        let n_as = as_path.length;
+        let n_as4 = as4_path.length;
+        if n_as < n_as4 {
+            return as_path.clone();
+        }
+
+        let mut need = n_as - n_as4;
+        let mut merged = As4Path::new();
+        for seg in &as_path.segs {
+            if need == 0 {
+                break;
+            }
+            match seg.typ {
+                AS_SEQ => {
+                    let take = (need as usize).min(seg.asn.len());
+                    merged.segs.push_back(As4Segment {
+                        typ: AS_SEQ,
+                        asn: seg.asn[..take].to_vec(),
+                    });
+                    need -= take as u32;
+                }
+                AS_SET => {
+                    merged.segs.push_back(seg.clone());
+                    need -= 1;
+                }
+                // Hop count 0: ride along with the leading part they
+                // are attached to (a confederation boundary prepends
+                // them ahead of the plain sequence).
+                _ => merged.segs.push_back(seg.clone()),
+            }
+        }
+        merged.segs.extend(as4_path.segs.iter().cloned());
+        merged.update_length();
+        merged
     }
 
     /// Returns the count of distinct ASes across all segments
@@ -1309,6 +1507,133 @@ mod tests {
         let mut aspath: As4Path = As4Path::from_str("65001 65002").unwrap();
         aspath.replace_private_as_mut(500, 65002);
         assert_eq!(aspath.to_string(), "500 65002");
+    }
+
+    // ---- RFC 6793 narrowing / AS4_PATH / merge ------------------------
+
+    /// Narrowing to the 2-octet form substitutes AS_TRANS for every ASN
+    /// above 65535, preserving segment types, order and hop count.
+    #[test]
+    fn as4_path_narrows_to_as2_with_as_trans() {
+        let p4 = As4Path::from_str("70000 65001 {4200000000 100}").unwrap();
+        assert!(p4.has_four_octet_asn());
+        let p2: As2Path = (&p4).into();
+        assert_eq!(p2.segs.len(), 2);
+        assert_eq!(p2.segs[0].typ, AS_SEQ);
+        assert_eq!(p2.segs[0].asn, vec![AS_TRANS, 65001]);
+        assert_eq!(p2.segs[1].typ, AS_SET);
+        assert_eq!(p2.segs[1].asn, vec![AS_TRANS, 100]);
+        assert_eq!(p2.length, 3, "hop count preserved");
+
+        let mappable = As4Path::from_str("65001 65002").unwrap();
+        assert!(!mappable.has_four_octet_asn());
+    }
+
+    /// The 2-octet emit round-trips through the 2-octet parser,
+    /// including the >255 segment split.
+    #[test]
+    fn as2_path_emit_round_trips() {
+        let p4 = As4Path::from((1..=300u32).collect::<Vec<u32>>());
+        let p2: As2Path = (&p4).into();
+        let mut buf = BytesMut::new();
+        p2.segs.iter().for_each(|s| s.emit(&mut buf));
+        let (rest, parsed) = As2Path::parse_be(&buf).unwrap();
+        assert!(rest.is_empty());
+        assert_eq!(parsed.segs.len(), 2, "split at the 255 limit");
+        let flat: Vec<u16> = parsed
+            .segs
+            .iter()
+            .flat_map(|s| s.asn.iter().copied())
+            .collect();
+        assert_eq!(flat, (1..=300u32).map(|v| v as u16).collect::<Vec<u16>>());
+    }
+
+    /// Flatten a path into its ASN sequence for value comparison
+    /// (display renders asdot for 4-octet ASNs).
+    fn flat_asns(path: &As4Path) -> Vec<u32> {
+        path.segs
+            .iter()
+            .flat_map(|s| s.asn.iter().copied())
+            .collect()
+    }
+
+    /// AS4_PATH content excludes confederation segments (RFC 6793 §6).
+    #[test]
+    fn as4_path_attr_strips_confed_segments() {
+        let p4 = As4Path::from_str("(65100 65101) 70000 65001 [65102]").unwrap();
+        let attr = As4PathAttr::from_path(&p4);
+        assert_eq!(flat_asns(&attr.0), vec![70000, 65001]);
+        assert_eq!(attr.0.length, 2);
+    }
+
+    /// The attribute framing of AS4_PATH: optional + transitive, type 17.
+    #[test]
+    fn as4_path_attr_framing() {
+        let attr = As4PathAttr::from_path(&As4Path::from_str("70000").unwrap());
+        let mut buf = BytesMut::new();
+        attr.attr_emit(&mut buf);
+        assert_eq!(buf[0], 0xC0, "optional + transitive");
+        assert_eq!(buf[1], 17, "AS4_PATH type code");
+        let (_, reparsed) = As4PathAttr::parse_be(&buf[3..]).unwrap();
+        assert_eq!(reparsed.0, attr.0);
+    }
+
+    /// RFC 6793 §4.2.3: an OLD speaker prepended its 2-octet AS after
+    /// the AS4_PATH was attached, so AS_PATH counts one more hop; the
+    /// merge takes that leading hop and appends the whole AS4_PATH.
+    #[test]
+    fn merge_takes_leading_hops_then_as4_path() {
+        let as_path = As4Path::from_str(&format!("65001 {AS_TRANS}")).unwrap();
+        let as4_path = As4Path::from_str("70000").unwrap();
+        let merged = As4Path::merge_as4_path(&as_path, &as4_path);
+        assert_eq!(flat_asns(&merged), vec![65001, 70000]);
+        assert_eq!(merged.length, 2);
+    }
+
+    /// Equal hop counts: the AS4_PATH wholly replaces the placeholder
+    /// path.
+    #[test]
+    fn merge_equal_counts_takes_as4_path() {
+        let as_path = As4Path::from_str(&format!("{AS_TRANS} 65001")).unwrap();
+        let as4_path = As4Path::from_str("70000 65001").unwrap();
+        let merged = As4Path::merge_as4_path(&as_path, &as4_path);
+        assert_eq!(flat_asns(&merged), vec![70000, 65001]);
+    }
+
+    /// AS_PATH shorter than AS4_PATH (an OLD speaker shortened the path,
+    /// e.g. by aggregation): the AS4_PATH is stale — ignore it.
+    #[test]
+    fn merge_ignores_longer_as4_path() {
+        let as_path = As4Path::from_str("65001").unwrap();
+        let as4_path = As4Path::from_str("70000 70001").unwrap();
+        let merged = As4Path::merge_as4_path(&as_path, &as4_path);
+        assert_eq!(flat_asns(&merged), vec![65001]);
+    }
+
+    /// Hop counting follows RFC 4271 §9.1.2.2: a whole AS_SET is one
+    /// hop, so a leading AS_SET is carried over as a unit.
+    #[test]
+    fn merge_counts_as_set_as_one_hop() {
+        // AS_PATH: {65001 65002} AS_TRANS → 2 hops. AS4_PATH: 70000 → 1.
+        let as_path = As4Path::from_str(&format!("{{65001 65002}} {AS_TRANS}")).unwrap();
+        let as4_path = As4Path::from_str("70000").unwrap();
+        let merged = As4Path::merge_as4_path(&as_path, &as4_path);
+        assert_eq!(merged.segs.len(), 2);
+        assert_eq!(merged.segs[0].typ, AS_SET);
+        assert_eq!(merged.segs[0].asn, vec![65001, 65002]);
+        assert_eq!(merged.segs[1].asn, vec![70000]);
+        assert_eq!(merged.length, 2);
+    }
+
+    /// A leading AS_SEQUENCE longer than the needed hops is split
+    /// mid-segment: only the leading ASNs carry over.
+    #[test]
+    fn merge_splits_leading_sequence() {
+        let as_path = As4Path::from_str(&format!("65003 65002 {AS_TRANS} {AS_TRANS}")).unwrap();
+        let as4_path = As4Path::from_str("70000 70001").unwrap();
+        let merged = As4Path::merge_as4_path(&as_path, &as4_path);
+        assert_eq!(flat_asns(&merged), vec![65003, 65002, 70000, 70001]);
+        assert_eq!(merged.length, 4);
     }
 
     #[test]

--- a/crates/bgp-packet/src/attrs/attr.rs
+++ b/crates/bgp-packet/src/attrs/attr.rs
@@ -25,6 +25,11 @@ pub enum AttrType {
     MpReachNlri = 14,
     MpUnreachNlri = 15,
     ExtendedCom = 16,
+    // RFC 6793: the 4-octet AS path / aggregator an OLD (non-AS4)
+    // speaker tunnels alongside its AS_TRANS-substituted AS_PATH /
+    // AGGREGATOR.
+    As4Path = 17,
+    As4Aggregator = 18,
     PmsiTunnel = 22,
     // 25 — RFC 5701 IPv6 Address Specific Extended Community — is deliberately
     // absent, and must only be re-added together with an
@@ -62,6 +67,8 @@ impl From<u8> for AttrType {
             14 => MpReachNlri,
             15 => MpUnreachNlri,
             16 => ExtendedCom,
+            17 => As4Path,
+            18 => As4Aggregator,
             22 => PmsiTunnel,
             26 => Aigp,
             32 => LargeCom,
@@ -90,6 +97,8 @@ impl From<AttrType> for u8 {
             MpReachNlri => 14,
             MpUnreachNlri => 15,
             ExtendedCom => 16,
+            As4Path => 17,
+            As4Aggregator => 18,
             PmsiTunnel => 22,
             Aigp => 26,
             LargeCom => 32,
@@ -136,6 +145,10 @@ pub enum Attr {
     MpUnreachNlri(MpUnreachAttr),
     #[nom(Selector = "AttrSelector(AttrType::ExtendedCom, None)")]
     ExtendedCom(ExtCommunity),
+    #[nom(Selector = "AttrSelector(AttrType::As4Path, None)")]
+    As4PathTrans(As4PathAttr),
+    #[nom(Selector = "AttrSelector(AttrType::As4Aggregator, None)")]
+    As4Aggregator(As4Aggregator),
     #[nom(Selector = "AttrSelector(AttrType::PmsiTunnel, None)")]
     PmsiTunnel(PmsiTunnel),
     #[nom(Selector = "AttrSelector(AttrType::Aigp, None)")]
@@ -161,6 +174,8 @@ impl Attr {
             Attr::AtomicAggregate(v) => v.attr_emit(buf),
             Attr::Aggregator(v) => v.attr_emit(buf),
             Attr::Aggregator2(v) => v.attr_emit(buf),
+            Attr::As4PathTrans(v) => v.attr_emit(buf),
+            Attr::As4Aggregator(v) => v.attr_emit(buf),
             Attr::OriginatorId(v) => v.attr_emit(buf),
             Attr::ClusterList(v) => v.attr_emit(buf),
             // Attr::MpReachNlri(v) => v.attr_emit(buf),
@@ -190,6 +205,8 @@ impl fmt::Display for Attr {
             Attr::AtomicAggregate(v) => write!(f, "{}", v),
             Attr::Aggregator(v) => write!(f, "{}", v),
             Attr::Aggregator2(v) => write!(f, "{}", v),
+            Attr::As4PathTrans(v) => write!(f, "{}", v),
+            Attr::As4Aggregator(v) => write!(f, "{}", v),
             Attr::OriginatorId(v) => write!(f, "{}", v),
             Attr::ClusterList(v) => write!(f, "{}", v),
             Attr::MpReachNlri(v) => write!(f, "{}", v),
@@ -218,6 +235,8 @@ impl fmt::Debug for Attr {
             Attr::AtomicAggregate(v) => write!(f, "{:?}", v),
             Attr::Aggregator(v) => write!(f, "{:?}", v),
             Attr::Aggregator2(v) => write!(f, "{:?}", v),
+            Attr::As4PathTrans(v) => write!(f, "{:?}", v),
+            Attr::As4Aggregator(v) => write!(f, "{:?}", v),
             Attr::OriginatorId(v) => write!(f, "{:?}", v),
             Attr::ClusterList(v) => write!(f, "{:?}", v),
             Attr::MpReachNlri(v) => write!(f, "{:?}", v),
@@ -343,7 +362,24 @@ fn attr_malformation_is_withdraw(attr_type: AttrType) -> bool {
             // length is not a non-zero multiple of 12.
             | AttrType::LargeCom
             | AttrType::PrefixSid
+            // RFC 7606 §7.4: a malformed AS_PATH "SHALL be handled using the
+            // approach of 'treat-as-withdraw'". The width mismatch a
+            // mis-negotiated AS4 session produces lands here rather than
+            // resetting the session.
+            | AttrType::AsPath
+            // RFC 7606 §7.5: same for AGGREGATOR (wrong length for the
+            // session's negotiated ASN width).
+            | AttrType::Aggregator
     )
+}
+
+/// Whether a malformed instance of `attr_type` is handled by the RFC 7606
+/// "attribute discard" action: drop just the attribute and keep the UPDATE.
+/// AS4_PATH and AS4_AGGREGATOR use it per RFC 7606 §7.10 / §7.11 — they
+/// only refine AS_PATH / AGGREGATOR, so losing one degrades to the
+/// AS_TRANS view rather than losing the route.
+fn attr_malformation_is_discard(attr_type: AttrType) -> bool {
+    matches!(attr_type, AttrType::As4Path | AttrType::As4Aggregator)
 }
 
 type ParsedAttributes<'a> = Result<
@@ -373,6 +409,10 @@ pub fn parse_bgp_update_attribute(
     let mut mp_update: Option<MpReachAttr> = None;
     let mut mp_withdraw: Option<MpUnreachAttr> = None;
     let mut treat_as_withdraw = false;
+    // RFC 6793 transitional attributes, parked until every attribute is
+    // in (wire order is arbitrary) and reconciled after the loop.
+    let mut as4_path: Option<As4Path> = None;
+    let mut as4_aggregator: Option<Aggregator> = None;
 
     while !remaining.is_empty() {
         // Parse the framing first so a Value-parse error stays recoverable:
@@ -418,6 +458,11 @@ pub fn parse_bgp_update_attribute(
                     remaining = new_remaining;
                     continue;
                 }
+                if attr_malformation_is_discard(attr_type) {
+                    // RFC 7606 §7.10 / §7.11: drop just the attribute.
+                    remaining = new_remaining;
+                    continue;
+                }
                 return Err(e);
             }
         };
@@ -427,19 +472,9 @@ pub fn parse_bgp_update_attribute(
             }
             Attr::As2Path(v) => {
                 // Widen the 2-octet AS_PATH into the 4-octet form the rest of
-                // the crate uses (RFC 6793 §4.2.2). Discarding it left
-                // `bgp_attr.aspath` at None, so the route would be accepted with
-                // no AS_PATH at all — no loop detection, no path-length
-                // comparison — and re-advertised without a well-known mandatory
-                // attribute.
-                //
-                // Not reachable today: `peer_packet_parse` passes a hardcoded
-                // `as4 = true`, so AS_PATH always parses as `As4Path` and this
-                // arm runs only from tests. It is wired up so that sourcing
-                // `as4` from the negotiated capability cannot silently lose
-                // AS_PATHs. Doing that properly also needs AS4_PATH (type 17)
-                // to recover the 4-octet ASNs an OLD peer hides behind
-                // AS_TRANS; neither attribute is implemented here.
+                // the crate uses (RFC 6793 §4.2.2). The AS_TRANS placeholders
+                // it may carry are substituted with the real ASNs from
+                // AS4_PATH by the reconciliation after this loop.
                 bgp_attr.aspath = Some(v.into());
             }
             Attr::As4Path(v) => {
@@ -460,8 +495,17 @@ pub fn parse_bgp_update_attribute(
             Attr::Aggregator(v) => {
                 bgp_attr.aggregator = Some(v);
             }
-            Attr::Aggregator2(_v) => {
-                // TODO
+            Attr::Aggregator2(v) => {
+                // 2-octet AGGREGATOR from an OLD (non-AS4) peer: widen.
+                // An AS_TRANS placeholder is substituted from
+                // AS4_AGGREGATOR by the reconciliation after this loop.
+                bgp_attr.aggregator = Some(v.into());
+            }
+            Attr::As4PathTrans(v) => {
+                as4_path = Some(v.0);
+            }
+            Attr::As4Aggregator(v) => {
+                as4_aggregator = Some(v.into());
             }
             Attr::Community(v) => {
                 bgp_attr.com = Some(v);
@@ -558,6 +602,29 @@ pub fn parse_bgp_update_attribute(
             }
         }
         remaining = new_remaining;
+    }
+
+    // RFC 6793 §4.2.3 reconciliation. Only an OLD (non-AS4) session
+    // carries information in AS4_PATH / AS4_AGGREGATOR; on an AS4
+    // session the AS_PATH is already 4-octet and a stray AS4_PATH from
+    // a NEW peer is discarded.
+    if !as4 {
+        // AGGREGATOR gate first: an AGGREGATOR whose AS is NOT AS_TRANS
+        // was attached by an OLD speaker *after* the AS4 attributes, so
+        // everything they say about the path is stale — ignore both.
+        if let (Some(aggregator), Some(_)) = (&bgp_attr.aggregator, &as4_aggregator) {
+            if aggregator.asn == u32::from(AS_TRANS) {
+                bgp_attr.aggregator = as4_aggregator;
+            } else {
+                as4_path = None;
+            }
+        }
+        if let (Some(aspath), Some(as4p)) = (&bgp_attr.aspath, &as4_path) {
+            // §6: confederation segments must not appear in AS4_PATH;
+            // discard just those segments and continue.
+            let as4p = as4p.strip_confed_segments();
+            bgp_attr.aspath = Some(As4Path::merge_as4_path(aspath, &as4p));
+        }
     }
 
     Ok((
@@ -809,6 +876,191 @@ mod tests {
             .collect();
         assert_eq!(flat, vec![65000u32, 65001], "ASNs widened to 4 octets");
         assert_eq!(aspath.length, 2, "hop count preserved");
+    }
+
+    // ---- RFC 6793 AS4_PATH / AS4_AGGREGATOR reconciliation ------------
+
+    use crate::attrs::aspath::AS_TRANS;
+
+    fn flat_asns(path: &crate::As4Path) -> Vec<u32> {
+        path.segs
+            .iter()
+            .flat_map(|s| s.asn.iter().copied())
+            .collect()
+    }
+
+    /// The OLD-speaker tunnel: a 2-octet AS_PATH carrying AS_TRANS plus
+    /// an AS4_PATH with the real 4-octet path. The merged `aspath` must
+    /// recover the real ASNs (RFC 6793 §4.2.3).
+    #[test]
+    fn as4_path_merges_into_aspath_on_old_session() {
+        // ORIGIN, then AS_PATH (2-octet): AS_SEQ [65001, AS_TRANS] —
+        // the OLD middle speaker 65001 prepended itself after AS 70000
+        // (behind AS_TRANS) originated.
+        let mut block = vec![0x40, 0x01, 0x01, 0x00];
+        block.extend_from_slice(&[0x40, 0x02, 0x06, 0x02, 0x02, 0xfd, 0xe9, 0x5b, 0xa0]);
+        // AS4_PATH (type 17, optional transitive): AS_SEQ [70000].
+        block.extend_from_slice(&[0xC0, 17, 0x06, 0x02, 0x01, 0x00, 0x01, 0x11, 0x70]);
+
+        let len = block.len() as u16;
+        let (_, bgp_attr, _, _, taw) =
+            parse_bgp_update_attribute(&block, len, false, None).expect("must parse");
+        assert!(!taw);
+        let aspath = bgp_attr.expect("attrs").aspath.expect("aspath present");
+        assert_eq!(flat_asns(&aspath), vec![65001, 70000]);
+        assert_eq!(aspath.length, 2);
+    }
+
+    /// On an AS4 session a stray AS4_PATH from a NEW peer is discarded:
+    /// the wire AS_PATH stands.
+    #[test]
+    fn as4_path_from_new_peer_is_ignored() {
+        let mut block = vec![0x40, 0x01, 0x01, 0x00];
+        // AS_PATH (4-octet): AS_SEQ [65001].
+        block.extend_from_slice(&[0x40, 0x02, 0x06, 0x02, 0x01, 0x00, 0x00, 0xfd, 0xe9]);
+        // AS4_PATH claiming something else entirely.
+        block.extend_from_slice(&[0xC0, 17, 0x06, 0x02, 0x01, 0x00, 0x01, 0x11, 0x70]);
+
+        let len = block.len() as u16;
+        let (_, bgp_attr, _, _, _) =
+            parse_bgp_update_attribute(&block, len, true, None).expect("must parse");
+        let aspath = bgp_attr.expect("attrs").aspath.expect("aspath present");
+        assert_eq!(flat_asns(&aspath), vec![65001]);
+    }
+
+    /// A 2-octet AGGREGATOR of AS_TRANS is replaced by AS4_AGGREGATOR
+    /// (RFC 6793 §4.2.3); the 6-octet AGGREGATOR itself must widen
+    /// rather than vanish (the old arm was an empty TODO).
+    #[test]
+    fn aggregator2_widens_and_as4_aggregator_substitutes() {
+        let mut block = vec![0x40, 0x01, 0x01, 0x00];
+        // AGGREGATOR (2-octet, 6 bytes): AS_TRANS, 10.0.0.1.
+        block.extend_from_slice(&[0xC0, 7, 0x06, 0x5b, 0xa0, 10, 0, 0, 1]);
+        // AS4_AGGREGATOR (type 18, 8 bytes): 4200000000, 10.0.0.1.
+        let mut v = vec![0xC0u8, 18, 0x08];
+        v.extend_from_slice(&4200000000u32.to_be_bytes());
+        v.extend_from_slice(&[10, 0, 0, 1]);
+        block.extend_from_slice(&v);
+
+        let len = block.len() as u16;
+        let (_, bgp_attr, _, _, _) =
+            parse_bgp_update_attribute(&block, len, false, None).expect("must parse");
+        let agg = bgp_attr.expect("attrs").aggregator.expect("widened");
+        assert_eq!(agg.asn, 4200000000);
+        assert_eq!(agg.ip, std::net::Ipv4Addr::new(10, 0, 0, 1));
+    }
+
+    /// An AGGREGATOR whose AS is NOT AS_TRANS was attached by an OLD
+    /// speaker after the AS4 attributes: both AS4_AGGREGATOR and
+    /// AS4_PATH are stale and must be ignored (RFC 6793 §4.2.3).
+    #[test]
+    fn non_trans_aggregator_invalidates_as4_attrs() {
+        let mut block = vec![0x40, 0x01, 0x01, 0x00];
+        // AS_PATH (2-octet): AS_SEQ [65001, AS_TRANS].
+        block.extend_from_slice(&[0x40, 0x02, 0x06, 0x02, 0x02, 0xfd, 0xe9, 0x5b, 0xa0]);
+        // AGGREGATOR (2-octet): 65001 (a real AS, not AS_TRANS).
+        block.extend_from_slice(&[0xC0, 7, 0x06, 0xfd, 0xe9, 10, 0, 0, 2]);
+        // AS4_PATH + AS4_AGGREGATOR, both now stale.
+        block.extend_from_slice(&[0xC0, 17, 0x06, 0x02, 0x01, 0x00, 0x01, 0x11, 0x70]);
+        let mut v = vec![0xC0u8, 18, 0x08];
+        v.extend_from_slice(&4200000000u32.to_be_bytes());
+        v.extend_from_slice(&[10, 0, 0, 1]);
+        block.extend_from_slice(&v);
+
+        let len = block.len() as u16;
+        let (_, bgp_attr, _, _, _) =
+            parse_bgp_update_attribute(&block, len, false, None).expect("must parse");
+        let bgp_attr = bgp_attr.expect("attrs");
+        let agg = bgp_attr.aggregator.expect("aggregator");
+        assert_eq!(agg.asn, 65001, "AGGREGATOR wins over stale AS4_AGGREGATOR");
+        let aspath = bgp_attr.aspath.expect("aspath");
+        assert_eq!(
+            flat_asns(&aspath),
+            vec![65001, u32::from(AS_TRANS)],
+            "stale AS4_PATH must not merge"
+        );
+    }
+
+    /// RFC 7606 §7.10: a malformed AS4_PATH is discarded — the UPDATE
+    /// survives with the placeholder path, no withdraw, no reset.
+    #[test]
+    fn malformed_as4_path_is_attribute_discard() {
+        let mut block = vec![0x40, 0x01, 0x01, 0x00];
+        block.extend_from_slice(&[0x40, 0x02, 0x06, 0x02, 0x02, 0xfd, 0xe9, 0x5b, 0xa0]);
+        // AS4_PATH declaring 2 ASNs but carrying only 1 octet of data.
+        block.extend_from_slice(&[0xC0, 17, 0x03, 0x02, 0x02, 0x00]);
+
+        let len = block.len() as u16;
+        let (_, bgp_attr, _, _, taw) =
+            parse_bgp_update_attribute(&block, len, false, None).expect("must not reset");
+        assert!(!taw, "attribute discard, not treat-as-withdraw");
+        let aspath = bgp_attr.expect("attrs").aspath.expect("aspath survives");
+        assert_eq!(flat_asns(&aspath), vec![65001, u32::from(AS_TRANS)]);
+    }
+
+    /// RFC 7606 §7.4: a malformed AS_PATH is treat-as-withdraw, not a
+    /// session reset. (The width mismatch of a mis-negotiated AS4
+    /// session lands exactly here.)
+    #[test]
+    fn malformed_as_path_is_treat_as_withdraw() {
+        let mut block = vec![0x40, 0x01, 0x01, 0x00];
+        // AS_PATH: segment declares 2 ASNs, carries 1 octet.
+        block.extend_from_slice(&[0x40, 0x02, 0x03, 0x02, 0x02, 0xfd]);
+
+        let len = block.len() as u16;
+        let (_, bgp_attr, _, _, taw) =
+            parse_bgp_update_attribute(&block, len, true, None).expect("must not reset");
+        assert!(taw, "malformed AS_PATH must treat-as-withdraw");
+        assert!(bgp_attr.expect("attrs").aspath.is_none());
+    }
+
+    /// End-to-end NEW→OLD→NEW tunnel: attributes emitted for an OLD
+    /// peer (2-octet AS_PATH + AS4_PATH, AGGREGATOR + AS4_AGGREGATOR)
+    /// parse back on the OLD side into the original 4-octet values.
+    #[test]
+    fn old_peer_emit_round_trips_real_asns() {
+        use std::str::FromStr;
+        let mut attr = crate::BgpAttr::new();
+        attr.aspath = Some(crate::As4Path::from_str("70000 65001").unwrap());
+        attr.aggregator = Some(crate::Aggregator::new(
+            4200000000,
+            std::net::Ipv4Addr::new(10, 0, 0, 1),
+        ));
+
+        let mut buf = BytesMut::new();
+        attr.attr_emit_opt(&mut buf, false);
+        // The wire AS_PATH is the 2-octet form: flags 0x40, type 2,
+        // then AS_TRANS where 70000 was.
+        assert_eq!(&buf[4..7], &[0x40, 0x02, 0x06]);
+        assert_eq!(&buf[7..13], &[0x02, 0x02, 0x5b, 0xa0, 0xfd, 0xe9]);
+
+        let len = buf.len() as u16;
+        let (_, parsed, _, _, taw) =
+            parse_bgp_update_attribute(&buf, len, false, None).expect("must parse");
+        assert!(!taw);
+        let parsed = parsed.expect("attrs");
+        let aspath = parsed.aspath.expect("aspath");
+        assert_eq!(flat_asns(&aspath), vec![70000, 65001]);
+        let agg = parsed.aggregator.expect("aggregator");
+        assert_eq!(agg.asn, 4200000000);
+    }
+
+    /// The same attributes on an AS4 session stay 4-octet with no
+    /// transitional attributes at all.
+    #[test]
+    fn as4_session_emits_no_transitional_attrs() {
+        use std::str::FromStr;
+        let mut attr = crate::BgpAttr::new();
+        attr.aspath = Some(crate::As4Path::from_str("70000 65001").unwrap());
+
+        let mut buf = BytesMut::new();
+        attr.attr_emit_opt(&mut buf, true);
+        // No type-17 attribute anywhere in the block.
+        let len = buf.len() as u16;
+        let (_, parsed, _, _, _) =
+            parse_bgp_update_attribute(&buf, len, true, None).expect("must parse");
+        let aspath = parsed.expect("attrs").aspath.expect("aspath");
+        assert_eq!(flat_asns(&aspath), vec![70000, 65001]);
     }
 
     // ---- RFC 4271 §9 unrecognized attribute handling -----------------

--- a/crates/bgp-packet/src/bgp_attr.rs
+++ b/crates/bgp-packet/src/bgp_attr.rs
@@ -3,9 +3,10 @@ use std::fmt;
 use bytes::BytesMut;
 
 use crate::{
-    Aggregator, Aigp, As4Path, AtomicAggregate, AttrEmitter, BgpLsAttr, BgpNexthop, ClusterList,
-    Color, Community, ExtCommunity, LargeCommunity, LocalPref, Med, NexthopAttr, Origin,
-    OriginatorId, PmsiTunnel, PrefixSid, PrefixSidTlv, TunnelEncap, UnknownAttr,
+    Aggregator, Aggregator2, Aigp, As2Path, As4Aggregator, As4Path, As4PathAttr, AtomicAggregate,
+    AttrEmitter, BgpLsAttr, BgpNexthop, ClusterList, Color, Community, ExtCommunity,
+    LargeCommunity, LocalPref, Med, NexthopAttr, Origin, OriginatorId, PmsiTunnel, PrefixSid,
+    PrefixSidTlv, TunnelEncap, UnknownAttr,
 };
 
 // BGP Attribute for quick access to each attribute. This would be used for
@@ -70,11 +71,29 @@ impl BgpAttr {
     }
 
     pub fn attr_emit(&self, buf: &mut BytesMut) {
+        self.attr_emit_opt(buf, true);
+    }
+
+    /// Emit the path attributes for a session whose 4-octet-AS support
+    /// is `as4` (RFC 6793). An AS4 session carries AS_PATH / AGGREGATOR
+    /// with 4-octet ASNs. Toward an OLD (non-AS4) peer they narrow to
+    /// the 2-octet forms with AS_TRANS substituted, and whenever that
+    /// substitution loses an ASN the real path / aggregator rides
+    /// alongside in AS4_PATH / AS4_AGGREGATOR.
+    pub fn attr_emit_opt(&self, buf: &mut BytesMut, as4: bool) {
         if let Some(v) = &self.origin {
             v.attr_emit(buf);
         }
         if let Some(v) = &self.aspath {
-            v.attr_emit(buf);
+            if as4 {
+                v.attr_emit(buf);
+            } else {
+                let as2: As2Path = v.into();
+                as2.attr_emit(buf);
+                if v.has_four_octet_asn() {
+                    As4PathAttr::from_path(v).attr_emit(buf);
+                }
+            }
         }
         if let Some(v) = &self.nexthop
             && let BgpNexthop::Ipv4(addr) = v
@@ -92,7 +111,15 @@ impl BgpAttr {
             v.attr_emit(buf);
         }
         if let Some(v) = &self.aggregator {
-            v.attr_emit(buf);
+            if as4 {
+                v.attr_emit(buf);
+            } else {
+                let as2: Aggregator2 = v.clone().into();
+                as2.attr_emit(buf);
+                if v.asn > u16::MAX as u32 {
+                    As4Aggregator::from(v).attr_emit(buf);
+                }
+            }
         }
         // An empty set would emit a zero-length attribute, which RFC 7606 §7.8
         // makes malformed (the length must be a *non-zero* multiple of 4) and

--- a/crates/bgp-packet/src/update.rs
+++ b/crates/bgp-packet/src/update.rs
@@ -50,6 +50,13 @@ pub struct UpdatePacket {
     pub treat_as_withdraw: bool,
     #[nom(Ignore)]
     max_packet_size: usize,
+    /// Whether the session this UPDATE is bound for negotiated 4-octet
+    /// AS support (RFC 6793). Egress only: `true` (the default) emits
+    /// AS_PATH / AGGREGATOR with 4-octet ASNs; `false` narrows them to
+    /// the 2-octet forms with AS_TRANS substitution plus AS4_PATH /
+    /// AS4_AGGREGATOR when needed. Not a wire field.
+    #[nom(Ignore)]
+    pub as4: bool,
 }
 
 impl UpdatePacket {
@@ -76,6 +83,7 @@ impl Default for UpdatePacket {
             mp_withdraw: None,
             treat_as_withdraw: false,
             max_packet_size: BGP_PACKET_LEN,
+            as4: true,
         }
     }
 }
@@ -99,7 +107,7 @@ impl UpdatePacket {
 
         // Attributes emit.
         if let Some(bgp_attr) = &self.bgp_attr {
-            bgp_attr.attr_emit(&mut buf);
+            bgp_attr.attr_emit_opt(&mut buf, self.as4);
         }
 
         // No MP reach/unreach emit at this moment.
@@ -184,7 +192,7 @@ impl UpdatePacket {
         let attr_pos: std::ops::Range<usize> = attr_len_pos..attr_len_pos + 2;
 
         if let Some(bgp_attr) = &self.bgp_attr {
-            bgp_attr.attr_emit(&mut buf);
+            bgp_attr.attr_emit_opt(&mut buf, self.as4);
         }
 
         // MP_REACH attribute header — Optional + Extended Length.
@@ -295,7 +303,7 @@ impl UpdatePacket {
         let _ = buf.put_u16(0u16); // placeholder
 
         if let Some(bgp_attr) = &self.bgp_attr {
-            bgp_attr.attr_emit(buf.get_mut());
+            bgp_attr.attr_emit_opt(buf.get_mut(), self.as4);
         }
 
         super::attrs::mp_reach::evpn_attr_emit(snpa, &nhop, &updates, buf.get_mut());
@@ -341,7 +349,7 @@ impl UpdatePacket {
         let _ = buf.put_u16(0u16); // placeholder
 
         if let Some(bgp_attr) = &self.bgp_attr {
-            bgp_attr.attr_emit(buf.get_mut());
+            bgp_attr.attr_emit_opt(buf.get_mut(), self.as4);
         }
         super::attrs::mp_reach::srpolicy_attr_emit(afi, snpa, &nhop, &updates, buf.get_mut());
 
@@ -406,7 +414,7 @@ impl UpdatePacket {
         let _ = buf.put_u16(0u16);
 
         if let Some(bgp_attr) = &self.bgp_attr {
-            bgp_attr.attr_emit(buf.get_mut());
+            bgp_attr.attr_emit_opt(buf.get_mut(), self.as4);
         }
 
         // MP reach (dispatches to Vpnv6Reach::attr_emit_mut, which
@@ -442,7 +450,7 @@ impl UpdatePacket {
 
         // Attributes emit.
         if let Some(bgp_attr) = &self.bgp_attr {
-            bgp_attr.attr_emit(buf.get_mut());
+            bgp_attr.attr_emit_opt(buf.get_mut(), self.as4);
         }
 
         // MP reach.
@@ -528,7 +536,7 @@ impl UpdatePacket {
 
         // Attributes emit.
         if let Some(bgp_attr) = self.bgp_attr {
-            bgp_attr.attr_emit(&mut buf);
+            bgp_attr.attr_emit_opt(&mut buf, self.as4);
         }
 
         // MP reach.

--- a/zebra-rs/src/bgp/config.rs
+++ b/zebra-rs/src/bgp/config.rs
@@ -812,6 +812,20 @@ fn config_soft_reconfig_in(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Optio
     Some(())
 }
 
+/// `set router bgp neighbor X capability four-octet <bool>`
+/// (zebra-bgp-capability.yang) — whether the OPEN we send advertises
+/// the RFC 6793 4-octet AS capability. Default true; false presents an
+/// OLD (2-octet) speaker for interop testing. A local AS above 65535
+/// overrides false at OPEN-build time (the real AS has no other
+/// encoding). Takes effect at the next session establishment.
+fn config_capability_four_octet(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Option<()> {
+    let addr = args.addr()?;
+    let flag = args.boolean()?;
+    let peer = bgp.peers.get_mut(&addr)?;
+    peer.config.four_octet = !op.is_set() || flag;
+    Some(())
+}
+
 /// `/router/bgp/neighbor/<addr>/pic-retention` — presence container, so
 /// presence means "on". Opt-in NHT-gated route retention on session-down.
 fn config_pic_retention(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Option<()> {
@@ -4839,6 +4853,11 @@ impl Bgp {
         // (eBGP only).
         self.callback_peer("/enforce-first-as", config_enforce_first_as);
         self.callback_peer("/pic-retention", config_pic_retention);
+
+        // Per-neighbor capability advertisement (zebra-bgp-capability.yang):
+        // `capability four-octet false` withholds the RFC 6793 4-octet AS
+        // capability from the OPEN, presenting an OLD (2-octet) speaker.
+        self.callback_peer("/capability/four-octet", config_capability_four_octet);
 
         // Debug/test knob (zebra-bgp-unknown-attr.yang): attach a synthetic
         // unrecognized path attribute to routes advertised to this

--- a/zebra-rs/src/bgp/group_egress.rs
+++ b/zebra-rs/src/bgp/group_egress.rs
@@ -277,7 +277,8 @@ impl Engine {
         let prev = self.adj_out.add(prefix, rib);
         let already_sent = prev.is_some_and(|p| Arc::ptr_eq(&p.attr, &arc));
         if !already_sent {
-            let bytes_list = encode_ipv4_update(&arc, &[nlri], ctx.max_packet_size(), None);
+            let bytes_list =
+                encode_ipv4_update(&arc, &[nlri], ctx.max_packet_size(), ctx.as4, None);
             self.fan(&bytes_list, source);
         }
     }

--- a/zebra-rs/src/bgp/peer.rs
+++ b/zebra-rs/src/bgp/peer.rs
@@ -19,7 +19,6 @@ use super::peer_map::PeerMap;
 
 use caps::CapAs4;
 use caps::CapRefresh;
-use caps::CapabilityPacket;
 
 use crate::bfd::session::{EchoMode, SessionKey, SessionParams};
 use crate::bgp::cap::cap_register_recv;
@@ -1235,6 +1234,17 @@ impl Peer {
         }
     }
 
+    /// An egress [`UpdatePacket`] sized and encoded for this session:
+    /// the negotiated max message length and the RFC 6793 ASN width.
+    /// Every per-peer UPDATE build must come through here (or copy the
+    /// `as4` stamp) — a site that forgets sends 4-octet AS_PATHs to an
+    /// OLD (non-AS4) peer, which misparses them.
+    pub fn update_packet(&self) -> UpdatePacket {
+        let mut update = UpdatePacket::with_max_packet_size(self.max_packet_size());
+        update.as4 = self.as4;
+        update
+    }
+
     pub fn start(&mut self) {
         if self.remote_as != 0 && !self.address.is_unspecified() && !self.active {
             timer::update_timers(self);
@@ -1481,6 +1491,7 @@ impl Peer {
             packet_tx: self.packet_tx.clone(),
             egress_depth: self.egress_depth.clone(),
             extended_message: self.opt.extended_message,
+            as4: self.as4,
             attach_unknown_attr: self.config.attach_unknown_attr.clone(),
             as_sets_withdraw,
         }
@@ -1972,15 +1983,6 @@ pub fn fsm_stop(_peer: &mut Peer) -> State {
     State::Idle
 }
 
-pub fn capability_as4(caps: &[CapabilityPacket]) -> Option<u32> {
-    for cap in caps.iter() {
-        if let CapabilityPacket::As4(m) = cap {
-            return Some(m.asn);
-        }
-    }
-    None
-}
-
 pub fn open_asn(packet: &OpenPacket) -> u32 {
     if let Some(as4) = &packet.bgp_cap.as4 {
         as4.asn
@@ -2061,11 +2063,28 @@ fn promote_collision_to_primary(peer: &mut Peer, collision: CollisionConn) {
 pub fn fsm_bgp_open(peer: &mut Peer, conn: ConnTag, packet: OpenPacket) -> State {
     peer.counter[BgpType::Open as usize].rcvd += 1;
 
-    // Peer ASN.
+    // Peer ASN — from the 4-octet AS capability when present, else the
+    // 2-octet My-AS field (RFC 6793 §4.1).
     let asn = open_asn(&packet);
 
+    // RFC 6793 §4.2 internal consistency of the peer's OPEN: the
+    // capability must not name the AS_TRANS placeholder as a real AS,
+    // and the My-AS field must be either AS_TRANS or the capability
+    // value itself. (A 4-octet ASN has no 2-octet form, so AS_TRANS in
+    // My-AS with the real ASN in the capability is the one legal way to
+    // announce it — the check the old code failed: it re-compared the
+    // raw 2-octet field against `remote_as` and sent every 4-byte-ASN
+    // peer back to Idle.)
+    let open_consistent = match &packet.bgp_cap.as4 {
+        Some(cap) => {
+            cap.asn != u32::from(AS_TRANS)
+                && (packet.asn == AS_TRANS || u32::from(packet.asn) == cap.asn)
+        }
+        None => true,
+    };
+
     // Compare with configured asn.
-    if peer.remote_as != asn {
+    if peer.remote_as != asn || !open_consistent {
         // The OPEN that fails this check came on `conn`. For Primary
         // this matches today's behaviour. For Collision we just tear
         // the collision conn down and stay in our current state — the
@@ -2092,10 +2111,6 @@ pub fn fsm_bgp_open(peer: &mut Peer, conn: ConnTag, packet: OpenPacket) -> State
     if peer.state != State::OpenSent && peer.state != State::OpenConfirm {
         // OPEN in an unexpected state — discard.
         return peer.state;
-    }
-    if packet.asn as u32 != peer.remote_as {
-        // Send notification.
-        return State::Idle;
     }
     if packet.hold_time > 0 && packet.hold_time < 3 {
         return State::Idle;
@@ -2167,6 +2182,14 @@ pub fn fsm_bgp_open(peer: &mut Peer, conn: ConnTag, packet: OpenPacket) -> State
 
     // Register add path caps.
     cap_addpath_recv(&packet.bgp_cap, &mut peer.opt, &peer.config.addpath);
+
+    // RFC 6793: the session runs 4-octet AS encoding iff both sides
+    // advertised the capability. `peer.as4` feeds the update-group
+    // signature and the egress encode; `peer.opt.as4` mirrors it for
+    // the parse option. (Our half was recorded when the OPEN we sent
+    // was built.)
+    peer.opt.as4.recv = packet.bgp_cap.as4.is_some();
+    peer.as4 = peer.opt.is_as4();
 
     // Extended message negotiation (RFC 8654).
     if peer.cap_send.extended.is_some() && packet.bgp_cap.extended.is_some() {
@@ -2479,7 +2502,7 @@ pub async fn peer_packet_parse(
     config: &mut PeerConfig,
     opt: &mut ParseOption,
 ) -> Result<(), String> {
-    match BgpPacket::parse_packet(rx, true, Some(opt.clone())) {
+    match BgpPacket::parse_packet(rx, opt.is_as4(), Some(opt.clone())) {
         Ok((_, p)) => {
             match p {
                 BgpPacket::Open(p) => {
@@ -2487,6 +2510,12 @@ pub async fn peer_packet_parse(
                     if config.extended_message && p.bgp_cap.extended.is_some() {
                         opt.extended_message = true;
                     }
+                    // RFC 6793: every UPDATE after this OPEN decodes
+                    // AS_PATH / AGGREGATOR at the negotiated width —
+                    // 4-octet iff both sides advertised the capability.
+                    // (Our own half was stamped on `opt` when this
+                    // reader was spawned, in `peer_start_reader`.)
+                    opt.as4.recv = p.bgp_cap.as4.is_some();
                     let _ = tx
                         .send(Message::Event(ident, Event::BGPOpen(conn, *p)))
                         .await;
@@ -2592,7 +2621,13 @@ pub fn peer_start_reader(peer: &Peer, conn: ConnId, read_half: OwnedReadHalf) ->
     let ident = peer.ident;
     let tx = peer.tx.clone();
     let config = peer.config.clone();
-    let opt = peer.opt.clone();
+    let mut opt = peer.opt.clone();
+    // Our half of the RFC 6793 negotiation is fixed before the OPEN
+    // exchange: it is what `build_open_packet` advertises (the knob, or
+    // forced by a local AS with no 2-octet form). Stamp it here rather
+    // than inherit whatever the previous session negotiated.
+    opt.as4.send = peer.config.four_octet || peer.open_local_as() > u16::MAX as u32;
+    opt.as4.recv = false;
     Task::spawn(async move {
         peer_read(ident, conn, tx.clone(), read_half, config, opt).await;
     })
@@ -2852,7 +2887,11 @@ fn build_open_packet(peer: &mut Peer) -> BytesMut {
         let cap = CapMultiProtocol::new(&afi_safi.afi, &afi_safi.safi);
         bgp_cap.mp.insert(*afi_safi, cap);
     }
-    if peer.config.four_octet {
+    // A local AS above 65535 is only expressible through the 4-octet AS
+    // capability (the My-AS field carries AS_TRANS), so it overrides a
+    // disabled `capability four-octet` knob — without the capability the
+    // peer could never learn our real AS (RFC 6793 §4.1).
+    if peer.config.four_octet || peer.open_local_as() > u16::MAX as u32 {
         let cap = CapAs4::new(peer.open_local_as());
         bgp_cap.as4 = Some(cap);
     }
@@ -2945,6 +2984,7 @@ fn build_open_packet(peer: &mut Peer) -> BytesMut {
     }
 
     cap_register_send(&bgp_cap, &mut peer.cap_map);
+    peer.opt.as4.send = bgp_cap.as4.is_some();
     peer.cap_send = bgp_cap.clone();
 
     // Remember sent hold time.
@@ -2952,13 +2992,13 @@ fn build_open_packet(peer: &mut Peer) -> BytesMut {
     peer.param_tx.hold_time = hold_time;
     peer.param_tx.keepalive = hold_time / 3;
 
-    let open = OpenPacket::new(
-        header,
-        peer.open_local_as() as u16,
-        hold_time,
-        &router_id,
-        bgp_cap,
-    );
+    // RFC 6793 §4.1: a local AS above 65535 has no 2-octet encoding —
+    // the My Autonomous System field carries AS_TRANS and the real ASN
+    // travels in the 4-octet AS capability set above. Truncating with
+    // `as u16` sent a garbage AS the peer rejected with Bad Peer AS.
+    let local_as = peer.open_local_as();
+    let my_as = u16::try_from(local_as).unwrap_or(AS_TRANS);
+    let open = OpenPacket::new(header, my_as, hold_time, &router_id, bgp_cap);
     let bytes: BytesMut = open.into();
     bytes
 }
@@ -4102,5 +4142,131 @@ mod fsm_removed_slot_tests {
         );
         fsm(&mut top, &mut peers, ident, Event::Stop, None);
         assert!(peers.get_by_idx(ident).is_none());
+    }
+}
+
+#[cfg(test)]
+mod as4_negotiation_tests {
+    use super::*;
+
+    /// Peer in OpenSent with a parked event channel, ready to receive
+    /// an OPEN. `remote_as` is what the operator configured.
+    fn opensent_peer(remote_as: u32) -> Peer {
+        let (tx, rx) = mpsc::channel::<Message>(64);
+        Box::leak(Box::new(rx));
+        let mut peer = Peer::new(
+            1,
+            65001,
+            Ipv4Addr::new(10, 0, 0, 1),
+            remote_as,
+            "10.0.0.2".parse().unwrap(),
+            None,
+            tx,
+            crate::context::ProtoContext::default_table_no_rib(),
+        );
+        peer.state = State::OpenSent;
+        peer
+    }
+
+    fn open_packet(my_as: u16, as4_cap: Option<u32>) -> OpenPacket {
+        let header = BgpHeader::new(BgpType::Open, BGP_HEADER_LEN + 10);
+        let mut bgp_cap = BgpCap::default();
+        if let Some(asn) = as4_cap {
+            bgp_cap.as4 = Some(CapAs4::new(asn));
+        }
+        OpenPacket::new(header, my_as, 180, &Ipv4Addr::new(2, 2, 2, 2), bgp_cap)
+    }
+
+    /// Review finding #2 regression: a 4-byte-ASN neighbor announces
+    /// itself with AS_TRANS in My-AS and the real ASN in the 4-octet AS
+    /// capability (RFC 6793 §4.1). The old code re-compared the raw
+    /// 2-octet field against `remote_as` and sent the session to Idle
+    /// on every attempt — such a peer could never establish.
+    #[tokio::test]
+    async fn four_byte_asn_peer_establishes_via_as_trans() {
+        let mut peer = opensent_peer(4_200_000_000);
+        // Build (and discard) our own OPEN so cap_send / opt.as4.send
+        // record what we advertised, as they would on a live session.
+        let _ = build_open_packet(&mut peer);
+
+        let next = fsm_bgp_open(
+            &mut peer,
+            ConnTag::Primary,
+            open_packet(AS_TRANS, Some(4_200_000_000)),
+        );
+        assert_eq!(next, State::OpenConfirm);
+        assert!(peer.as4, "both sides advertised the capability");
+        assert!(peer.opt.is_as4());
+    }
+
+    /// RFC 6793 §4.2 consistency: a My-AS field that is neither
+    /// AS_TRANS nor the capability value is a Bad Peer AS.
+    #[tokio::test]
+    async fn my_as_disagreeing_with_as4_cap_is_rejected() {
+        let mut peer = opensent_peer(4_200_000_000);
+        let _ = build_open_packet(&mut peer);
+
+        let next = fsm_bgp_open(
+            &mut peer,
+            ConnTag::Primary,
+            open_packet(65009, Some(4_200_000_000)),
+        );
+        assert_eq!(next, State::Idle);
+    }
+
+    /// AS_TRANS itself is not a real AS: a capability naming it leaves
+    /// the peer's AS unknowable and must be rejected.
+    #[tokio::test]
+    async fn as_trans_in_capability_is_rejected() {
+        let mut peer = opensent_peer(u32::from(AS_TRANS));
+        let _ = build_open_packet(&mut peer);
+
+        let next = fsm_bgp_open(
+            &mut peer,
+            ConnTag::Primary,
+            open_packet(AS_TRANS, Some(u32::from(AS_TRANS))),
+        );
+        assert_eq!(next, State::Idle);
+    }
+
+    /// A 2-byte peer that advertised no 4-octet AS capability leaves
+    /// the session OLD: it still establishes, with `as4` off, so every
+    /// UPDATE both ways uses the 2-octet encoding.
+    #[tokio::test]
+    async fn peer_without_as4_cap_negotiates_old_session() {
+        let mut peer = opensent_peer(65002);
+        let _ = build_open_packet(&mut peer);
+
+        let next = fsm_bgp_open(&mut peer, ConnTag::Primary, open_packet(65002, None));
+        assert_eq!(next, State::OpenConfirm);
+        assert!(!peer.as4, "one-sided capability is not a negotiation");
+        assert!(peer.opt.as4.send && !peer.opt.as4.recv);
+    }
+
+    /// The OPEN we send for a >65535 local AS: AS_TRANS in My-AS (the
+    /// old code truncated with `as u16`) and the real ASN in the
+    /// capability — forced even when `capability four-octet` is off.
+    #[tokio::test]
+    async fn open_for_four_byte_local_as_carries_as_trans() {
+        let (tx, rx) = mpsc::channel::<Message>(64);
+        Box::leak(Box::new(rx));
+        let mut peer = Peer::new(
+            1,
+            4_200_000_001,
+            Ipv4Addr::new(10, 0, 0, 1),
+            65002,
+            "10.0.0.2".parse().unwrap(),
+            None,
+            tx,
+            crate::context::ProtoContext::default_table_no_rib(),
+        );
+        peer.config.four_octet = false;
+
+        let bytes = build_open_packet(&mut peer);
+        let (_, open) = OpenPacket::parse_packet(&bytes).expect("our OPEN must parse");
+        assert_eq!(open.asn, AS_TRANS, "My-AS carries the placeholder");
+        let cap = open.bgp_cap.as4.expect("capability forced by 4-byte AS");
+        assert_eq!(cap.asn, 4_200_000_001);
+        assert!(peer.opt.as4.send);
     }
 }

--- a/zebra-rs/src/bgp/route.rs
+++ b/zebra-rs/src/bgp/route.rs
@@ -199,6 +199,10 @@ pub struct SyncCtx {
     pub packet_tx: Option<tokio::sync::mpsc::UnboundedSender<BytesMut>>,
     pub egress_depth: Arc<std::sync::atomic::AtomicUsize>,
     pub extended_message: bool,
+    /// The session negotiated 4-octet AS encoding (RFC 6793) — drives
+    /// the AS_PATH / AGGREGATOR width of every UPDATE built through
+    /// this ctx.
+    pub as4: bool,
     /// Debug/test knob: a synthetic unrecognized path attribute to attach
     /// to every IPv4-unicast route advertised on this session (RFC 4271
     /// §9 origination test). `None` = off. See
@@ -305,6 +309,7 @@ impl SyncCtx {
             packet_tx: None,
             egress_depth: Arc::new(std::sync::atomic::AtomicUsize::new(0)),
             extended_message: false,
+            as4: true,
             attach_unknown_attr: None,
             as_sets_withdraw: true,
         }
@@ -5230,7 +5235,7 @@ pub fn route_update_evpn(
 /// peer triggers `route_evpn_export_selected` which sends
 /// `Message::MacDel` / `MdbDel` and the kernel FDB row goes away.
 fn route_withdraw_evpn(peer: &mut Peer, route: EvpnRoute) {
-    let mut update = UpdatePacket::with_max_packet_size(peer.max_packet_size());
+    let mut update = peer.update_packet();
     update.mp_withdraw = Some(MpUnreachAttr::Evpn(vec![route]));
     peer.send_update(update);
 }
@@ -5508,7 +5513,7 @@ pub(super) fn route_withdraw_ipv4(
     prefix: Ipv4Net,
     id: u32,
 ) {
-    let mut update = UpdatePacket::with_max_packet_size(peer.max_packet_size());
+    let mut update = peer.update_packet();
 
     match rd {
         Some(rd) => {
@@ -8351,7 +8356,7 @@ fn route_update_mup(
 
 /// Emit one MUP route to a peer as a single-NLRI MP_REACH UPDATE.
 fn mup_send_one(peer: &mut Peer, afi: Afi, route: MupRoute, attr: &Arc<BgpAttr>, nhop: IpAddr) {
-    let mut update = UpdatePacket::with_max_packet_size(peer.max_packet_size());
+    let mut update = peer.update_packet();
     update.mp_update = Some(MpReachAttr::Mup {
         afi,
         snpa: 0,
@@ -8453,7 +8458,7 @@ fn mup_withdraw_one(peer: &mut Peer, rd: RouteDistinguisher, prefix: &MupPrefix)
     let Some(route) = mup_withdraw_route(&mut peer.adj_out, rd, prefix) else {
         return;
     };
-    let mut update = UpdatePacket::with_max_packet_size(peer.max_packet_size());
+    let mut update = peer.update_packet();
     update.mp_withdraw = Some(MpUnreachAttr::Mup {
         afi: prefix.afi(),
         withdraws: vec![route],
@@ -8630,7 +8635,7 @@ pub fn route_sync_mup(peer: &mut Peer, bgp: &mut BgpTop) {
     // RFC 4724 / RFC 7606 §3 EoR: empty MP_UNREACH per negotiated MUP AFI.
     for afi in [Afi::Ip, Afi::Ip6] {
         if peer.is_afi_safi(afi, Safi::Mup) {
-            let mut update = UpdatePacket::with_max_packet_size(peer.max_packet_size());
+            let mut update = peer.update_packet();
             update.mp_withdraw = Some(MpUnreachAttr::Mup {
                 afi,
                 withdraws: vec![],
@@ -8890,7 +8895,7 @@ fn srpolicy_reflect(
         ) else {
             continue;
         };
-        let mut update = UpdatePacket::with_max_packet_size(peer.max_packet_size());
+        let mut update = peer.update_packet();
         update.mp_update = Some(MpReachAttr::SrPolicy {
             afi,
             snpa: 0,
@@ -8926,7 +8931,7 @@ fn srpolicy_reflect_withdraw(source_ident: usize, nlri: &SrPolicyNlri, peers: &m
         ) {
             continue;
         }
-        let mut update = UpdatePacket::with_max_packet_size(peer.max_packet_size());
+        let mut update = peer.update_packet();
         update.mp_withdraw = Some(MpUnreachAttr::SrPolicy {
             afi,
             withdraws: vec![nlri.clone()],
@@ -9167,7 +9172,7 @@ pub(super) fn srpolicy_origin_reach(bgp: &mut Bgp, nlri: SrPolicyNlri, attr: Bgp
         let Some(peer) = bgp.peers.get_mut_by_idx(ident) else {
             continue;
         };
-        let mut update = UpdatePacket::with_max_packet_size(peer.max_packet_size());
+        let mut update = peer.update_packet();
         update.mp_update = Some(MpReachAttr::SrPolicy {
             afi,
             snpa: 0,
@@ -9190,7 +9195,7 @@ pub(super) fn srpolicy_origin_withdraw(bgp: &mut Bgp, nlri: SrPolicyNlri) {
         let Some(peer) = bgp.peers.get_mut_by_idx(ident) else {
             continue;
         };
-        let mut update = UpdatePacket::with_max_packet_size(peer.max_packet_size());
+        let mut update = peer.update_packet();
         update.mp_withdraw = Some(MpUnreachAttr::SrPolicy {
             afi,
             withdraws: vec![nlri.clone()],
@@ -9207,7 +9212,6 @@ pub(super) fn srpolicy_origin_withdraw(bgp: &mut Bgp, nlri: SrPolicyNlri) {
 /// the new peer (the SAFI-73 analogue of `route_sync_evpn`).
 pub fn route_sync_srpolicy(peer: &mut Peer, bgp: &BgpTop) {
     let router_id = *bgp.router_id;
-    let max = peer.max_packet_size();
     let adverts: Vec<(Afi, SrPolicyNlri, BgpAttr)> = bgp
         .local_rib
         .sr_policy_local
@@ -9222,7 +9226,7 @@ pub fn route_sync_srpolicy(peer: &mut Peer, bgp: &BgpTop) {
         if !peer.is_afi_safi(afi, Safi::SrTePolicy) {
             continue;
         }
-        let mut update = UpdatePacket::with_max_packet_size(max);
+        let mut update = peer.update_packet();
         update.mp_update = Some(MpReachAttr::SrPolicy {
             afi,
             snpa: 0,
@@ -9476,7 +9480,7 @@ pub fn route_update_flowspec(
 }
 
 fn send_flowspec_one(peer: &mut Peer, afi: Afi, nlri: FlowspecNlri, attr: Arc<BgpAttr>) {
-    let mut update = UpdatePacket::with_max_packet_size(peer.max_packet_size());
+    let mut update = peer.update_packet();
     update.mp_update = Some(MpReachAttr::Flowspec {
         afi,
         updates: vec![nlri],
@@ -9538,7 +9542,7 @@ pub fn route_withdraw_flowspec_to_peers(afi: Afi, nlri: &FlowspecNlri, peers: &m
         }
         peer.adj_out.remove_flowspec(afi, nlri, 0);
 
-        let mut update = UpdatePacket::with_max_packet_size(peer.max_packet_size());
+        let mut update = peer.update_packet();
         update.mp_withdraw = Some(MpUnreachAttr::Flowspec {
             afi,
             withdraws: vec![nlri.clone()],
@@ -11403,7 +11407,7 @@ pub fn route_update_ipv6(
 /// for `prefix`. The v6 counterpart of [`route_withdraw_ipv4`]'s
 /// unicast arm; v6 has no legacy withdraw field.
 pub(super) fn route_withdraw_ipv6(peer: &mut Peer, prefix: Ipv6Net, id: u32) {
-    let mut update = UpdatePacket::with_max_packet_size(peer.max_packet_size());
+    let mut update = peer.update_packet();
     update.mp_withdraw = Some(MpUnreachAttr::Ipv6Nlri(vec![Ipv6Nlri { id, prefix }]));
     peer.send_update(update);
 }
@@ -11542,7 +11546,7 @@ pub(super) fn route_advertise_to_peers_v6(
 /// `(rd, prefix)`. The v6 counterpart of the VPNv4 withdraw arm of
 /// [`route_withdraw_ipv4`].
 fn route_withdraw_vpnv6(peer: &mut Peer, rd: RouteDistinguisher, prefix: Ipv6Net, id: u32) {
-    let mut update = UpdatePacket::with_max_packet_size(peer.max_packet_size());
+    let mut update = peer.update_packet();
     let vpnv6_nlri = Vpnv6Nlri {
         label: Label::default(),
         rd,
@@ -12001,14 +12005,14 @@ fn route_advertise_labeled<A: LabeledAfi>(
         match to_advertise {
             Some((nlri, attr, nhop, label, best)) => {
                 A::adj_out_add(peer, prefix, best);
-                let mut update = UpdatePacket::with_max_packet_size(peer.max_packet_size());
+                let mut update = peer.update_packet();
                 update.bgp_attr = Some(attr);
                 update.mp_update = Some(A::reach(nhop, label, nlri));
                 peer.send_update(update);
             }
             None => {
                 if A::adj_out_contains(peer, &prefix) {
-                    let mut update = UpdatePacket::with_max_packet_size(peer.max_packet_size());
+                    let mut update = peer.update_packet();
                     update.mp_withdraw = Some(A::unreach(prefix, 0));
                     peer.send_update(update);
                     A::adj_out_remove(peer, prefix, 0);
@@ -12052,7 +12056,7 @@ fn route_advertise_labeled<A: LabeledAfi>(
             let Some(decision) = A::apply_policy_out(peer, &nlri, attr, cand.weight) else {
                 continue;
             };
-            let mut update = UpdatePacket::with_max_packet_size(peer.max_packet_size());
+            let mut update = peer.update_packet();
             update.bgp_attr = Some(decision.attr);
             update.mp_update = Some(A::reach(nhop, label, nlri));
             peer.send_update(update);
@@ -12063,7 +12067,7 @@ fn route_advertise_labeled<A: LabeledAfi>(
             if newly.contains(&id) {
                 continue;
             }
-            let mut update = UpdatePacket::with_max_packet_size(peer.max_packet_size());
+            let mut update = peer.update_packet();
             update.mp_withdraw = Some(A::unreach(prefix, id));
             peer.send_update(update);
             A::adj_out_remove(peer, prefix, id);
@@ -12184,8 +12188,10 @@ impl Peer {
     pub fn flush_evpn(&mut self) {
         let packet_tx = self.packet_tx.clone();
         let max_size = self.max_packet_size();
+        let as4 = self.as4;
         for (attr, routes) in self.cache_evpn.drain() {
             let mut update = UpdatePacket::with_max_packet_size(max_size);
+            update.as4 = as4;
 
             // Nexthop comes from the cached attribute. EVPN allows
             // either an IPv4 or IPv6 nexthop; if neither was set on
@@ -12218,6 +12224,7 @@ impl Peer {
         let max_size = self.max_packet_size();
         for (attr, nlris) in self.cache_vpnv4.drain() {
             let mut update = UpdatePacket::with_max_packet_size(max_size);
+            update.as4 = self.as4;
 
             if let Some(BgpNexthop::Vpnv4(nhop)) = attr.nexthop.as_ref() {
                 let vpnv4reach = Vpnv4Reach {
@@ -12272,6 +12279,7 @@ impl Peer {
         let max_size = self.max_packet_size();
         for (attr, nlris) in self.cache_vpnv6.drain() {
             let mut update = UpdatePacket::with_max_packet_size(max_size);
+            update.as4 = self.as4;
 
             if let Some(BgpNexthop::Vpnv6(nhop)) = attr.nexthop.as_ref() {
                 let vpnv6reach = Vpnv6Reach {
@@ -13323,28 +13331,28 @@ pub fn route_sync_vpnv6(peer: &mut Peer, bgp: &mut BgpTop) {
 
 // Send End-of-RIB marker for IPv6 VPN.
 fn send_eor_vpnv6_vpn(peer: &mut Peer) {
-    let mut update = UpdatePacket::with_max_packet_size(peer.max_packet_size());
+    let mut update = peer.update_packet();
     update.mp_withdraw = Some(MpUnreachAttr::Vpnv6Eor);
     peer.send_update(update);
 }
 
 // Send End-of-RIB marker for IPv4 Unicast.
 pub(super) fn send_eor_ipv4_unicast(peer: &mut Peer) {
-    let update = UpdatePacket::with_max_packet_size(peer.max_packet_size());
+    let update = peer.update_packet();
     peer.send_update(update);
 }
 
 // Send End-of-RIB marker for IPv6 Unicast: an empty MP_UNREACH(AFI=2,
 // SAFI=1), per RFC 4724 §2 (only IPv4 unicast uses the bare empty UPDATE).
 fn send_eor_ipv6_unicast(peer: &mut Peer) {
-    let mut update = UpdatePacket::with_max_packet_size(peer.max_packet_size());
+    let mut update = peer.update_packet();
     update.mp_withdraw = Some(MpUnreachAttr::Ipv6Eor);
     peer.send_update(update);
 }
 
 // Send End-of-RIB marker for VPNv4 Unicast.
 fn send_eor_vpnv4_unicast(peer: &mut Peer) {
-    let mut update = UpdatePacket::with_max_packet_size(peer.max_packet_size());
+    let mut update = peer.update_packet();
     update.mp_withdraw = Some(MpUnreachAttr::Vpnv4Eor);
     peer.send_update(update);
 }
@@ -13374,7 +13382,7 @@ fn send_rtcv4_membership(peer: &mut Peer, bgp: &BgpTop) {
         }
     }
 
-    let mut update = UpdatePacket::with_max_packet_size(peer.max_packet_size());
+    let mut update = peer.update_packet();
     let mut attrs = BgpAttr::new();
     if peer.is_ibgp() {
         attrs.local_pref = Some(LocalPref::default());
@@ -13390,7 +13398,7 @@ fn send_rtcv4_membership(peer: &mut Peer, bgp: &BgpTop) {
 
 // Send End-of-RIB marker for RTCv4.
 fn send_eor_rtcv4_unicast(peer: &mut Peer) {
-    let mut update = UpdatePacket::with_max_packet_size(peer.max_packet_size());
+    let mut update = peer.update_packet();
     update.mp_withdraw = Some(MpUnreachAttr::Rtcv4Eor);
     peer.send_update(update);
 }
@@ -13414,7 +13422,7 @@ fn send_rtcv6_membership(peer: &mut Peer, bgp: &BgpTop) {
         }
     }
 
-    let mut update = UpdatePacket::with_max_packet_size(peer.max_packet_size());
+    let mut update = peer.update_packet();
     let mut attrs = BgpAttr::new();
     if peer.is_ibgp() {
         attrs.local_pref = Some(LocalPref::default());
@@ -13430,7 +13438,7 @@ fn send_rtcv6_membership(peer: &mut Peer, bgp: &BgpTop) {
 
 // Send End-of-RIB marker for RTCv6.
 fn send_eor_rtcv6_unicast(peer: &mut Peer) {
-    let mut update = UpdatePacket::with_max_packet_size(peer.max_packet_size());
+    let mut update = peer.update_packet();
     update.mp_withdraw = Some(MpUnreachAttr::Rtcv6Eor);
     peer.send_update(update);
 }
@@ -13439,7 +13447,7 @@ fn send_eor_rtcv6_unicast(peer: &mut Peer) {
 // as an empty UPDATE; the multiprotocol form (RFC 7606 §3) carries
 // it as an MP_UNREACH with empty NLRI for the AFI/SAFI in question.
 fn send_eor_evpn(peer: &mut Peer) {
-    let mut update = UpdatePacket::with_max_packet_size(peer.max_packet_size());
+    let mut update = peer.update_packet();
     update.mp_withdraw = Some(MpUnreachAttr::EvpnEor);
     peer.send_update(update);
 }
@@ -13548,7 +13556,7 @@ pub fn route_sync_labelv4(peer: &mut Peer, bgp: &mut BgpTop) {
         ) else {
             continue;
         };
-        let mut update = UpdatePacket::with_max_packet_size(peer.max_packet_size());
+        let mut update = peer.update_packet();
         update.bgp_attr = Some(decision.attr);
         update.mp_update = Some(MpReachAttr::Labelv4 {
             snpa: 0,
@@ -13596,7 +13604,7 @@ pub fn route_sync_labelv6(peer: &mut Peer, bgp: &mut BgpTop) {
         ) else {
             continue;
         };
-        let mut update = UpdatePacket::with_max_packet_size(peer.max_packet_size());
+        let mut update = peer.update_packet();
         update.bgp_attr = Some(decision.attr);
         update.mp_update = Some(MpReachAttr::Labelv6 {
             snpa: 0,
@@ -20763,6 +20771,7 @@ mod as_sets_withdraw_tests {
             packet_tx: None,
             egress_depth: Arc::new(std::sync::atomic::AtomicUsize::new(0)),
             extended_message: false,
+            as4: true,
             attach_unknown_attr: None,
             as_sets_withdraw: true,
         };
@@ -20817,6 +20826,7 @@ mod as_sets_withdraw_tests {
             packet_tx: None,
             egress_depth: Arc::new(std::sync::atomic::AtomicUsize::new(0)),
             extended_message: false,
+            as4: true,
             attach_unknown_attr: None,
             as_sets_withdraw: false,
         };

--- a/zebra-rs/src/bgp/shard/dispatch.rs
+++ b/zebra-rs/src/bgp/shard/dispatch.rs
@@ -228,9 +228,13 @@ impl BgpShard {
             while ctx.egress_depth.load(Ordering::Relaxed) > params.egress_high_water {
                 std::thread::sleep(std::time::Duration::from_millis(DUMP_PARK_MS));
             }
-            for buf in
-                super::super::update_group::encode_ipv4_update(&attr, &nlris, max, params.enhe_v6)
-            {
+            for buf in super::super::update_group::encode_ipv4_update(
+                &attr,
+                &nlris,
+                max,
+                ctx.as4,
+                params.enhe_v6,
+            ) {
                 ctx.send_packet(buf);
                 sent += 1;
             }

--- a/zebra-rs/src/bgp/update_group.rs
+++ b/zebra-rs/src/bgp/update_group.rs
@@ -685,6 +685,7 @@ pub(super) trait FlushNlri: Clone {
         attr: &Arc<BgpAttr>,
         nlris: &[Self],
         max_packet_size: usize,
+        as4: bool,
         enhe_v6: Option<Ipv4MpReachNextHop>,
     ) -> Vec<bytes::BytesMut>;
 }
@@ -694,9 +695,10 @@ impl FlushNlri for Ipv4Nlri {
         attr: &Arc<BgpAttr>,
         nlris: &[Self],
         max_packet_size: usize,
+        as4: bool,
         enhe_v6: Option<Ipv4MpReachNextHop>,
     ) -> Vec<bytes::BytesMut> {
-        encode_ipv4_update(attr, nlris, max_packet_size, enhe_v6)
+        encode_ipv4_update(attr, nlris, max_packet_size, as4, enhe_v6)
     }
 }
 
@@ -705,9 +707,10 @@ impl FlushNlri for Ipv6Nlri {
         attr: &Arc<BgpAttr>,
         nlris: &[Self],
         max_packet_size: usize,
+        as4: bool,
         _enhe_v6: Option<Ipv4MpReachNextHop>,
     ) -> Vec<bytes::BytesMut> {
-        encode_ipv6_update(attr, nlris, max_packet_size)
+        encode_ipv6_update(attr, nlris, max_packet_size, as4)
     }
 }
 
@@ -722,6 +725,9 @@ pub(super) struct FlushJob<N> {
     pub buckets: Vec<(Arc<BgpAttr>, Vec<(N, usize)>)>,
     pub members: Vec<FlushMember>,
     pub max_packet_size: usize,
+    /// Group negotiated 4-octet AS encoding (RFC 6793) — sig field, so
+    /// it is uniform across members by construction.
+    pub as4: bool,
     /// Group negotiated RFC 8950 ENHE (IPv4 unicast only): every
     /// bucket is encoded per-member with that member's v6 next-hop.
     pub enhe: bool,
@@ -796,7 +802,8 @@ impl<N: FlushNlri> FlushJob<N> {
                         }
                         continue;
                     }
-                    let bytes_list = N::encode(&attr, &nlris, self.max_packet_size, Some(nh));
+                    let bytes_list =
+                        N::encode(&attr, &nlris, self.max_packet_size, self.as4, Some(nh));
                     let byte_total: usize = bytes_list.iter().map(|b| b.len()).sum();
                     for bytes in &bytes_list {
                         let _ = tx.send(bytes.clone());
@@ -813,7 +820,8 @@ impl<N: FlushNlri> FlushJob<N> {
 
             // Canonical UPDATE: every NLRI in the bucket.
             let canonical: Vec<N> = entries.iter().map(|(n, _)| n.clone()).collect();
-            let canonical_bytes = N::encode(&attr, &canonical, self.max_packet_size, None);
+            let canonical_bytes =
+                N::encode(&attr, &canonical, self.max_packet_size, self.as4, None);
             let canonical_byte_total: usize = canonical_bytes.iter().map(|b| b.len()).sum();
 
             // Bump per-attr-bucket counters: one formatted variant
@@ -860,7 +868,7 @@ impl<N: FlushNlri> FlushJob<N> {
                     counters.split_horizon_excluded += 1;
                     continue;
                 }
-                let pruned_bytes = N::encode(&attr, &nlris, self.max_packet_size, None);
+                let pruned_bytes = N::encode(&attr, &nlris, self.max_packet_size, self.as4, None);
                 let pruned_byte_total: usize = pruned_bytes.iter().map(|b| b.len()).sum();
                 counters.messages_formatted += pruned_bytes.len() as u64;
                 counters.bytes_formatted += pruned_byte_total as u64;
@@ -931,6 +939,7 @@ pub(super) fn build_flush_job_ipv4(
         buckets,
         members,
         max_packet_size,
+        as4: group.sig.as4_negotiated,
         enhe,
     })
 }
@@ -1063,7 +1072,13 @@ pub(super) fn send_ipv4_direct(
     }
     let max_packet_size = ctx.max_packet_size();
     for (attr, nlris) in buckets {
-        let bytes_list = encode_ipv4_update(&attr, &nlris, max_packet_size, extended_next_hop_v6);
+        let bytes_list = encode_ipv4_update(
+            &attr,
+            &nlris,
+            max_packet_size,
+            ctx.as4,
+            extended_next_hop_v6,
+        );
         for buf in bytes_list {
             ctx.send_packet(buf);
         }
@@ -1082,9 +1097,11 @@ pub(super) fn encode_ipv4_update(
     attr: &Arc<BgpAttr>,
     nlris: &[Ipv4Nlri],
     max_packet_size: usize,
+    as4: bool,
     extended_next_hop_v6: Option<Ipv4MpReachNextHop>,
 ) -> Vec<bytes::BytesMut> {
     let mut update = UpdatePacket::with_max_packet_size(max_packet_size);
+    update.as4 = as4;
     update.bgp_attr = Some((**attr).clone());
     update.ipv4_update = nlris.to_vec();
     let mut out = Vec::new();
@@ -1198,6 +1215,7 @@ pub(super) fn build_flush_job_ipv6(
         buckets,
         members,
         max_packet_size,
+        as4: group.sig.as4_negotiated,
         enhe: false,
     })
 }
@@ -1280,6 +1298,7 @@ fn encode_ipv6_update(
     attr: &Arc<BgpAttr>,
     nlris: &[Ipv6Nlri],
     max_packet_size: usize,
+    as4: bool,
 ) -> Vec<bytes::BytesMut> {
     if nlris.is_empty() {
         return Vec::new();
@@ -1301,6 +1320,7 @@ fn encode_ipv6_update(
     let mut out = Vec::new();
     for nlri_chunk in nlris.chunks(chunk) {
         let mut update = UpdatePacket::with_max_packet_size(max_packet_size);
+        update.as4 = as4;
         update.bgp_attr = Some((**attr).clone());
         update.mp_update = Some(MpReachAttr::Ipv6 {
             snpa: 0,
@@ -1340,7 +1360,7 @@ pub(super) fn send_ipv6_direct(peer: &Peer, entries: Vec<(Arc<BgpAttr>, Ipv6Nlri
         bgp_packet::BGP_PACKET_LEN
     };
     for (attr, nlris) in buckets {
-        let bytes_list = encode_ipv6_update(&attr, &nlris, max_packet_size);
+        let bytes_list = encode_ipv6_update(&attr, &nlris, max_packet_size, peer.as4);
         for buf in bytes_list {
             peer.send_packet(buf);
         }
@@ -1867,13 +1887,14 @@ mod tests {
         let job = FlushJob {
             buckets: vec![(attr.clone(), entries.clone())],
             members: vec![m1, m2],
+            as4: true,
             max_packet_size: bgp_packet::BGP_PACKET_LEN,
             enhe: false,
         };
         let counters = job.run();
 
         let nlris: Vec<Ipv4Nlri> = entries.iter().map(|(n, _)| n.clone()).collect();
-        let golden = encode_ipv4_update(&attr, &nlris, bgp_packet::BGP_PACKET_LEN, None);
+        let golden = encode_ipv4_update(&attr, &nlris, bgp_packet::BGP_PACKET_LEN, true, None);
         assert!(!golden.is_empty());
         assert_eq!(recv_all(&mut rx1), golden);
         assert_eq!(recv_all(&mut rx2), golden);
@@ -1900,6 +1921,7 @@ mod tests {
         let job = FlushJob {
             buckets: vec![(attr.clone(), entries)],
             members: vec![m1, m2],
+            as4: true,
             max_packet_size: bgp_packet::BGP_PACKET_LEN,
             enhe: false,
         };
@@ -1909,12 +1931,14 @@ mod tests {
             &attr,
             &[nlri("10.0.0.1/32"), nlri("10.0.0.2/32")],
             bgp_packet::BGP_PACKET_LEN,
+            true,
             None,
         );
         let pruned = encode_ipv4_update(
             &attr,
             &[nlri("10.0.0.2/32")],
             bgp_packet::BGP_PACKET_LEN,
+            true,
             None,
         );
         assert_eq!(recv_all(&mut rx1), pruned);
@@ -1947,6 +1971,7 @@ mod tests {
         let job = FlushJob {
             buckets: vec![(attr.clone(), vec![(nlri("10.0.0.1/32"), 99)])],
             members: vec![capable, incapable],
+            as4: true,
             max_packet_size: bgp_packet::BGP_PACKET_LEN,
             enhe: false,
         };
@@ -1979,14 +2004,17 @@ mod tests {
         let job = FlushJob {
             buckets: vec![(attr.clone(), entries.clone())],
             members: vec![m1, m2, m3],
+            as4: true,
             max_packet_size: bgp_packet::BGP_PACKET_LEN,
             enhe: true,
         };
         let counters = job.run();
 
         let nlris: Vec<Ipv4Nlri> = entries.iter().map(|(n, _)| n.clone()).collect();
-        let golden1 = encode_ipv4_update(&attr, &nlris, bgp_packet::BGP_PACKET_LEN, Some(nh1));
-        let golden2 = encode_ipv4_update(&attr, &nlris, bgp_packet::BGP_PACKET_LEN, Some(nh2));
+        let golden1 =
+            encode_ipv4_update(&attr, &nlris, bgp_packet::BGP_PACKET_LEN, true, Some(nh1));
+        let golden2 =
+            encode_ipv4_update(&attr, &nlris, bgp_packet::BGP_PACKET_LEN, true, Some(nh2));
         assert_ne!(golden1, golden2);
         assert_eq!(recv_all(&mut rx1), golden1);
         assert_eq!(recv_all(&mut rx2), golden2);
@@ -2018,12 +2046,13 @@ mod tests {
         let job = FlushJob {
             buckets: vec![(attr.clone(), entries.clone())],
             members: vec![m1],
+            as4: true,
             max_packet_size: bgp_packet::BGP_PACKET_LEN,
             enhe: false,
         };
         let counters = job.run();
         let nlris: Vec<Ipv6Nlri> = entries.iter().map(|(n, _)| n.clone()).collect();
-        let golden = encode_ipv6_update(&attr, &nlris, bgp_packet::BGP_PACKET_LEN);
+        let golden = encode_ipv6_update(&attr, &nlris, bgp_packet::BGP_PACKET_LEN, true);
         assert_eq!(recv_all(&mut rx1), golden);
         assert_eq!(counters.messages_formatted, golden.len() as u64);
     }

--- a/zebra-rs/src/config/manager.rs
+++ b/zebra-rs/src/config/manager.rs
@@ -1843,6 +1843,38 @@ mod yang_load_tests {
         }
     }
 
+    /// Grammar-rot guard for the per-neighbor `capability four-octet`
+    /// knob (zebra-bgp-capability.yang). The augment reaches the schema
+    /// only through config.yang's import list — dropping the import
+    /// makes the YAML apply fail with `unknown key \`capability\``
+    /// while everything else still compiles, so pin it here.
+    #[test]
+    fn bgp_neighbor_capability_four_octet_parses() {
+        use crate::config::ExecCode;
+        use crate::config::parse::{State, parse};
+        use libyang::to_entry;
+
+        let mut yang = YangStore::new();
+        yang.add_path(concat!(env!("CARGO_MANIFEST_DIR"), "/yang"));
+        yang.read_with_resolve("configure")
+            .unwrap_or_else(|e| panic!("configure failed to load: {e:#}"));
+        yang.identity_resolve();
+        let module = yang.find_module("configure").unwrap();
+        let entry = to_entry(&yang, module);
+
+        for cmd in [
+            "set router bgp neighbor 192.168.1.3 capability four-octet false",
+            "set router bgp neighbor 192.168.1.3 capability four-octet true",
+        ] {
+            let (code, _comps, _state) = parse(cmd, entry.clone(), None, State::new());
+            assert_eq!(
+                code,
+                ExecCode::Success,
+                "should parse as a settable path: {cmd}"
+            );
+        }
+    }
+
     /// Regression guard for the per-neighbor `attach-unknown-attribute`
     /// debug knob (zebra-bgp-unknown-attr.yang). The string-valued leaf —
     /// whose `<type>:<flags>:<value-hex>` value contains colons — must

--- a/zebra-rs/yang/config.yang
+++ b/zebra-rs/yang/config.yang
@@ -136,6 +136,9 @@ module config {
   import zebra-bgp-enforce-first-as {
     prefix zbef;
   }
+  import zebra-bgp-capability {
+    prefix zbcap;
+  }
   import zebra-bgp-unknown-attr {
     prefix zbua;
   }

--- a/zebra-rs/yang/zebra-bgp-capability.yang
+++ b/zebra-rs/yang/zebra-bgp-capability.yang
@@ -1,0 +1,101 @@
+module zebra-bgp-capability {
+  yang-version "1";
+
+  namespace "urn:ietf:params:xml:ns:yang:zebra-bgp-capability";
+  prefix "zbcap";
+
+  import ietf-bgp {
+    prefix bgp;
+  }
+
+  import config {
+    prefix config;
+  }
+
+  import configure {
+    prefix configure;
+  }
+
+  import extension {
+    prefix ext;
+  }
+
+  organization
+    "zebra-rs";
+
+  contact
+    "https://github.com/zebra-rs";
+
+  description
+    "Per-neighbor capability-advertisement knobs.
+
+     `capability four-octet <bool>` controls whether the OPEN sent to
+     this neighbor advertises the 4-octet AS capability (RFC 6793).
+     It defaults to true; setting false makes zebra-rs present itself
+     as an OLD (2-octet) speaker on this session, so the negotiated
+     encoding falls back to 2-octet AS_PATH / AGGREGATOR with AS_TRANS
+     substitution and the AS4_PATH / AS4_AGGREGATOR transitional
+     attributes:
+
+       router bgp {
+         neighbor 10.0.0.5 {
+           remote-as 65501;
+           capability {
+             four-octet false;   // present as an OLD (2-octet) speaker
+           }
+         }
+       }
+
+     Mirrors JunOS `disable-4byte-as`; mostly useful for interop
+     testing against RFC 6793 transition code paths. Ignored (the
+     capability is always advertised) when the local AS itself is above
+     65535 — without the capability the real AS would be unrecoverable.
+     Takes effect at the next session establishment.";
+
+  revision 2026-07-17 {
+    description "Initial revision.";
+    reference "RFC 6793: BGP Support for Four-Octet AS Number Space.";
+  }
+
+  grouping bgp-neighbor-capability-extension {
+    description
+      "Capability-advertisement knobs on a BGP neighbor.";
+
+    container capability {
+      ext:help "Capability advertisement knobs";
+      description
+        "Which optional capabilities the OPEN sent to this neighbor
+         advertises.";
+
+      leaf four-octet {
+        ext:help "Advertise the 4-octet AS capability (RFC 6793)";
+        type boolean;
+        description
+          "Advertise the 4-octet AS capability. Default true; false
+           presents zebra-rs as an OLD (2-octet) speaker on this
+           session. Forced on when the local AS is above 65535.";
+      }
+    }
+  }
+
+  /* =========================================================
+   * Augments into the zebra-rs configure tree
+   * ========================================================= */
+
+  augment "/configure:set/config:router"
+        + "/bgp:bgp/bgp:neighbor" {
+    description
+      "Attach the capability knobs to BGP neighbors in the
+       candidate-set subtree.";
+    uses bgp-neighbor-capability-extension;
+  }
+
+  augment "/configure:delete/config:router"
+        + "/bgp:bgp/bgp:neighbor" {
+    description
+      "Same attachment for the delete subtree so
+       `delete router bgp neighbor X capability four-octet` is
+       path-valid.";
+    uses bgp-neighbor-capability-extension;
+  }
+}


### PR DESCRIPTION
## Summary
Fixes review finding #2 of `docs/design/bgp-code-review-findings.md` (4-byte-ASN peers can never establish) together with bgp-packet finding O1 (`as4` hardcoded true) as one complete RFC 6793 feature.

**bgp-packet**
- AS4_PATH (type 17) / AS4_AGGREGATOR (type 18): parse, emit, and the RFC 6793 §4.2.3 reconciliation in `parse_bgp_update_attribute` (AGGREGATOR AS_TRANS gate, confederation-segment strip, hop-count-aware merge).
- 2-octet egress: `As2Path`/`Aggregator2` emit with AS_TRANS substitution, plus AS4_PATH/AS4_AGGREGATOR alongside whenever an ASN needs four octets; `UpdatePacket` grows an egress-only `as4` flag (default true).
- Received 2-octet AGGREGATOR is widened instead of dropped (old TODO arm); `Aggregator2` emit gains the missing OPTIONAL flag.
- RFC 7606 classes: malformed AS_PATH/AGGREGATOR → treat-as-withdraw (§7.4/§7.5); malformed AS4_PATH/AS4_AGGREGATOR → attribute-discard (§7.10/§7.11); AS_PATH parse now requires exact consumption.

**zebra-rs**
- OPEN emit: My-AS carries AS_TRANS when the local AS exceeds 65535 (was truncated with `as u16`); the 4-octet AS capability is forced on for such an AS.
- OPEN receive: the redundant raw 2-octet My-AS re-comparison that bounced every 4-byte-ASN peer to Idle is gone; RFC 6793 §4.2 consistency checks (AS_TRANS in the capability, My-AS vs capability agreement) → Bad Peer AS.
- `peer.as4` / `peer.opt.as4` now come from the capability negotiation; the reader parses UPDATEs at the negotiated width; every egress build stamps the session's `as4` (`Peer::update_packet`, `SyncCtx`, `FlushJob`, group/shard encode paths — `as4_negotiated` was already an `UpdateGroupSig` field, so OLD and NEW peers shard update-groups correctly).
- New `neighbor X capability four-octet <bool>` knob (zebra-bgp-capability.yang; the augment loads through config.yang's import list, pinned by a grammar test).
- Removed dead `capability_as4()`.

## Test plan
- 17 new bgp-packet unit tests (narrowing, merge cases, OLD-emit→parse round trip, RFC 7606 actions); 5 new zebra-rs OPEN-negotiation tests (incl. the finding #2 regression).
- New `bgp_as4.feature`, run live and passing: AS 70000 ↔ AS 65002 establishes and carries as-path `1.4464`; with `capability four-octet false` and a hard reset, the session provably re-negotiates as OLD (asserted via `show bgp neighbor` capability lines) and the far side still recovers `1.4464` through the AS4_PATH tunnel.
- Full workspace suite (`--exclude bdd`) 39/39 green; workspace clippy clean.

Generated with [Claude Code](https://claude.com/claude-code)