### PR TITLE
pim: ASM with static RP — shared tree, register FSM, SPT switchover

### DIFF
--- a/bdd/tests/configs/pim_asm/r1.yaml
+++ b/bdd/tests/configs/pim_asm/r1.yaml
@@ -1,0 +1,17 @@
+interface:
+- if-name: eth1
+  ipv4:
+    address: 10.1.21.1/24
+- if-name: eth2
+  ipv4:
+    address: 10.1.22.1/24
+router:
+  pim:
+    rp:
+      static:
+      - address: 10.1.22.2
+    interface:
+    - if-name: eth1
+      dr-priority: 1
+    - if-name: eth2
+      dr-priority: 1

--- a/bdd/tests/configs/pim_asm/r2.yaml
+++ b/bdd/tests/configs/pim_asm/r2.yaml
@@ -1,0 +1,23 @@
+interface:
+- if-name: eth3
+  ipv4:
+    address: 10.1.22.2/24
+- if-name: eth4
+  ipv4:
+    address: 10.1.23.1/24
+router:
+  static:
+    ipv4:
+      route:
+      - prefix: 10.1.21.0/24
+        nexthop:
+        - address: 10.1.22.1
+  pim:
+    rp:
+      static:
+      - address: 10.1.22.2
+    interface:
+    - if-name: eth3
+      dr-priority: 1
+    - if-name: eth4
+      dr-priority: 1

--- a/bdd/tests/configs/pim_asm/r3.yaml
+++ b/bdd/tests/configs/pim_asm/r3.yaml
@@ -1,0 +1,27 @@
+interface:
+- if-name: eth5
+  ipv4:
+    address: 10.1.23.2/24
+- if-name: eth6
+  ipv4:
+    address: 10.1.24.1/24
+router:
+  static:
+    ipv4:
+      route:
+      - prefix: 10.1.22.0/24
+        nexthop:
+        - address: 10.1.23.1
+      - prefix: 10.1.21.0/24
+        nexthop:
+        - address: 10.1.23.1
+  pim:
+    rp:
+      static:
+      - address: 10.1.22.2
+    interface:
+    - if-name: eth5
+      dr-priority: 1
+    - if-name: eth6
+      igmp:
+        enabled: true

--- a/bdd/tests/features/pim_asm.feature
+++ b/bdd/tests/features/pim_asm.feature
@@ -1,0 +1,86 @@
+@serial
+@pim_asm
+Feature: PIM ASM with a static RP — register, shared tree and SPT
+  As a network operator
+  I want an any-source IGMP join at the last-hop router to build a
+  shared tree to the static RP, a new source's first-hop router to
+  register it with the RP, the RP to join the source tree and stop
+  the registers, and traffic to flow natively source→RP→receiver —
+  the complete PIM-SM ASM control loop over three routers.
+
+  r2 is the RP (10.1.22.2, its own interface address, configured
+  statically on all three routers). h2 issues an any-source join for
+  239.2.2.2 (IGMPv3 EXCLUDE{}); r3 (LHR) builds (*,G) toward the RP.
+  h1 then sends: r1 (FHR/DR for the source subnet) registers with the
+  RP, the RP joins (S,G) back toward r1 and answers Register-Stop —
+  r1's register state must settle in suppression (RegPrune) — and
+  h1's datagrams must arrive at h2 through the kernel MFCs of all
+  three routers.
+
+  Test Topology:
+  ```
+    h1 (10.1.21.2, sender) -- eth0/eth1 -- r1 -- eth2/eth3 -- r2(RP) -- eth4/eth5 -- r3 -- eth6/eth7 -- h2 (10.1.24.2, receiver)
+                                 10.1.21.1    10.1.22.1/.2       10.1.23.1/.2          10.1.24.1
+  ```
+
+  Scenario: Register, shared tree and SPT converge and traffic flows
+    Given a clean test environment
+    When I create namespace "r1"
+    And I create namespace "r2"
+    And I create namespace "r3"
+    And I create namespace "h1"
+    And I create namespace "h2"
+    And I connect namespace "h1" interface "eth0" to namespace "r1" interface "eth1"
+    And I connect namespace "r1" interface "eth2" to namespace "r2" interface "eth3"
+    And I connect namespace "r2" interface "eth4" to namespace "r3" interface "eth5"
+    And I connect namespace "r3" interface "eth6" to namespace "h2" interface "eth7"
+    And I start zebra-rs in namespace "r1"
+    And I start zebra-rs in namespace "r2"
+    And I start zebra-rs in namespace "r3"
+    And I apply config "r1.yaml" to namespace "r1"
+    And I apply config "r2.yaml" to namespace "r2"
+    And I apply config "r3.yaml" to namespace "r3"
+    And I add address "10.1.21.2/24" to interface "eth0" in namespace "h1"
+    And I add address "10.1.24.2/24" to interface "eth7" in namespace "h2"
+
+    # Control plane up: neighbors on both transit links, RP mapping known.
+    Then show command "show pim neighbor" in namespace "r1" should eventually contain "10.1.22.2"
+    And show command "show pim neighbor" in namespace "r3" should eventually contain "10.1.23.1"
+    And show command "show pim rp-info" in namespace "r2" should contain "yes"
+
+    # h2's any-source join builds the shared tree: (*,G) at the LHR,
+    # joined toward the RP; the RP holds the (*,G) downstream state.
+    When I spawn "timeout 150 python3 tests/scripts/asm_recv.py 239.2.2.2 10.1.24.2 5001 /tmp/pim_asm_rx" in namespace "h2"
+    Then show command "show igmp groups" in namespace "r3" should eventually contain "239.2.2.2"
+    And show command "show pim upstream" in namespace "r3" should eventually contain "(*, 239.2.2.2)"
+    And show command "show pim upstream" in namespace "r3" should eventually contain "Joined"
+    And show command "show mroute" in namespace "r2" should eventually contain "(*, 239.2.2.2)"
+
+    # h1 starts sending: r1 registers, the RP builds (S,G) back toward
+    # r1 and stops the registers; r1 settles in suppression.
+    When I spawn "timeout 120 python3 tests/scripts/mcast_send.py 239.2.2.2 5001 10.1.21.2 90" in namespace "h1"
+    Then show command "show mroute" in namespace "r2" should eventually contain "(10.1.21.2, 239.2.2.2)"
+    And show command "show pim upstream" in namespace "r2" should eventually contain "(10.1.21.2, 239.2.2.2)"
+    And show command "show pim upstream" in namespace "r1" should eventually contain "RegPrune"
+
+    # Kernel MFCs along the native path.
+    And command "ip mroute show" in namespace "r1" should eventually contain "Iif: eth1"
+    And command "ip mroute show" in namespace "r2" should eventually contain "Iif: eth3"
+    And command "ip mroute show" in namespace "r2" should eventually contain "eth4"
+    And command "ip mroute show" in namespace "r3" should eventually contain "Iif: eth5"
+
+    # The datapath proof: h1's datagrams arrive at h2 through all
+    # three routers.
+    And command "cat /tmp/pim_asm_rx" in namespace "h2" should eventually contain "ssm-hello"
+
+  Scenario: Teardown topology
+    When I execute "rm -f /tmp/pim_asm_rx" in namespace "h2"
+    And I stop zebra-rs in namespace "r1"
+    And I stop zebra-rs in namespace "r2"
+    And I stop zebra-rs in namespace "r3"
+    And I delete namespace "r1"
+    And I delete namespace "r2"
+    And I delete namespace "r3"
+    And I delete namespace "h1"
+    And I delete namespace "h2"
+    Then the test environment should be clean

--- a/bdd/tests/scripts/asm_recv.py
+++ b/bdd/tests/scripts/asm_recv.py
@@ -1,0 +1,29 @@
+#!/usr/bin/env python3
+"""ASM (any-source) receiver: IP_ADD_MEMBERSHIP join + payload log.
+
+Usage: asm_recv.py GROUP LOCAL_ADDR PORT OUTFILE
+
+Joins GROUP on the interface owning LOCAL_ADDR (the kernel emits an
+IGMPv3 EXCLUDE{} report), then appends every received UDP payload to
+OUTFILE — the end-to-end proof for the PIM ASM BDD feature. OUTFILE
+is created immediately so pollers can `cat` it before traffic
+arrives.
+"""
+
+import socket
+import sys
+
+group, local, port, outfile = sys.argv[1:5]
+
+sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+sock.bind((group, int(port)))
+
+mreq = socket.inet_aton(group) + socket.inet_aton(local)
+sock.setsockopt(socket.IPPROTO_IP, socket.IP_ADD_MEMBERSHIP, mreq)
+
+with open(outfile, "w", buffering=1) as out:
+    out.write("joined\n")
+    while True:
+        data, _ = sock.recvfrom(2048)
+        out.write(data.decode(errors="replace") + "\n")

--- a/zebra-rs/src/pim/config.rs
+++ b/zebra-rs/src/pim/config.rs
@@ -32,6 +32,8 @@ impl Pim {
             "/router/pim/interface/igmp/query-max-response-time",
             config_igmp_query_max_resp,
         );
+        self.callback_add("/router/pim/rp/static", config_rp_static);
+        self.callback_add("/router/pim/rp/static/group", config_rp_static_group);
     }
 
     fn callback_add(&mut self, path: &str, cb: Callback) {
@@ -141,6 +143,32 @@ fn config_igmp_query_interval(pim: &mut Pim, mut args: Args, op: ConfigOp) -> Op
         config.igmp.query_interval = None;
     }
     pim.reconcile_by_name(&name);
+    Some(())
+}
+
+fn config_rp_static(pim: &mut Pim, mut args: Args, op: ConfigOp) -> Option<()> {
+    let address = args.v4addr()?;
+    if op.is_set() {
+        pim.rp_set
+            .statics
+            .entry(address)
+            .or_insert_with(|| "224.0.0.0/4".parse().unwrap());
+    } else {
+        pim.rp_set.statics.remove(&address);
+    }
+    pim.rp_reevaluate();
+    Some(())
+}
+
+fn config_rp_static_group(pim: &mut Pim, mut args: Args, op: ConfigOp) -> Option<()> {
+    let address = args.v4addr()?;
+    if op.is_set() {
+        let range = args.string()?.parse().ok()?;
+        pim.rp_set.statics.insert(address, range);
+    } else if let Some(range) = pim.rp_set.statics.get_mut(&address) {
+        *range = "224.0.0.0/4".parse().unwrap();
+    }
+    pim.rp_reevaluate();
     Some(())
 }
 

--- a/zebra-rs/src/pim/igmp/mod.rs
+++ b/zebra-rs/src/pim/igmp/mod.rs
@@ -16,7 +16,7 @@ use tokio::sync::mpsc::UnboundedSender;
 use super::inst::{IgmpSend, Pim};
 use super::link::LinkConfig;
 use super::socket::IGMP_ALL_HOSTS;
-use super::tib::Sg;
+use super::tib::SgKey;
 
 /// Robustness Variable (RFC 3376 §8.1). Fixed at the protocol
 /// default; a config knob can arrive later.
@@ -95,6 +95,9 @@ pub struct IgmpGroup {
     /// Sources currently reflected into the TIB as local (S,G)
     /// membership — the diff base for [`Pim::igmp_tib_sync`].
     pub synced: BTreeSet<Ipv4Addr>,
+    /// Any-source (EXCLUDE) membership currently reflected into the
+    /// TIB as local (*,G) state.
+    pub asm_synced: bool,
 }
 
 impl IgmpGroup {
@@ -107,6 +110,7 @@ impl IgmpGroup {
             last_reporter: None,
             uptime: now,
             synced: BTreeSet::new(),
+            asm_synced: false,
         }
     }
 }
@@ -278,11 +282,17 @@ impl Pim {
                     sync.push(*group_addr);
                 }
             }
-            let mut prune: Vec<(Ipv4Addr, Ipv4Addr)> = vec![];
+            let mut prune: Vec<SgKey> = vec![];
             for group_addr in expired {
                 if let Some(group) = igmp.groups.remove(&group_addr) {
-                    for source in group.synced {
-                        prune.push((group_addr, source));
+                    for src in group.synced {
+                        prune.push(SgKey::Sg {
+                            src,
+                            grp: group_addr,
+                        });
+                    }
+                    if group.asm_synced {
+                        prune.push(SgKey::StarG { grp: group_addr });
                     }
                 }
                 tracing::info!("igmp: group {} expired on {}", group_addr, name);
@@ -290,16 +300,16 @@ impl Pim {
             for group_addr in sync {
                 self.igmp_tib_sync(ifindex, group_addr);
             }
-            for (grp, src) in prune {
-                self.tib_local_prune(Sg { src, grp }, ifindex);
+            for key in prune {
+                self.tib_local_prune(key, ifindex);
             }
         }
     }
 
-    /// Reflect a group's INCLUDE source set into the TIB as local
-    /// (S,G) membership, diffing against what was previously synced.
-    /// EXCLUDE (any-source) membership stays out of the TIB until the
-    /// ASM phase brings (*,G) state.
+    /// Reflect a group's membership into the TIB, diffing against
+    /// what was previously synced: INCLUDE source sets become local
+    /// (S,G) state; EXCLUDE (any-source) membership becomes local
+    /// (*,G) state (SSM-range groups never get (*,G)).
     pub(crate) fn igmp_tib_sync(&mut self, ifindex: u32, grp: Ipv4Addr) {
         let Some(link) = self.links.get_mut(&ifindex) else {
             return;
@@ -318,11 +328,19 @@ impl Pim {
         let added: Vec<Ipv4Addr> = current.difference(&group.synced).copied().collect();
         let removed: Vec<Ipv4Addr> = group.synced.difference(&current).copied().collect();
         group.synced = current;
+        let asm_desired = group.filter_mode == FilterMode::Exclude && !super::rp::is_ssm(grp);
+        let asm_was = group.asm_synced;
+        group.asm_synced = asm_desired;
         for src in added {
-            self.tib_local_join(Sg { src, grp }, ifindex);
+            self.tib_local_join(SgKey::Sg { src, grp }, ifindex);
         }
         for src in removed {
-            self.tib_local_prune(Sg { src, grp }, ifindex);
+            self.tib_local_prune(SgKey::Sg { src, grp }, ifindex);
+        }
+        match (asm_desired, asm_was) {
+            (true, false) => self.tib_local_join(SgKey::StarG { grp }, ifindex),
+            (false, true) => self.tib_local_prune(SgKey::StarG { grp }, ifindex),
+            _ => {}
         }
     }
 

--- a/zebra-rs/src/pim/inst.rs
+++ b/zebra-rs/src/pim/inst.rs
@@ -29,9 +29,10 @@ use super::config::Callback;
 use super::link::{LinkConfig, PIM_OVERRIDE_INTERVAL_MSEC, PIM_PROPAGATION_DELAY_MSEC, PimLink};
 use super::mroute::{ForwardingPlane, Upcall};
 use super::network::{igmp_read_packet, igmp_write_packet, mroute_read, read_packet, write_packet};
+use super::rp::RpSet;
 use super::rpf::RpfEntry;
 use super::socket::ALL_PIM_ROUTERS;
-use super::tib::{Sg, TibEntry};
+use super::tib::{SgKey, TibEntry};
 
 /// `show pim ...` dispatch handler, mirroring
 /// [`crate::nd::inst::ShowCallback`].
@@ -83,10 +84,12 @@ pub struct Pim {
     /// Desired per-interface config keyed by interface name — the
     /// source of truth the reconciler compares runtime state against.
     pub if_config: BTreeMap<String, LinkConfig>,
-    /// The Tree Information Base: (S,G) forwarding state.
-    pub tib: BTreeMap<Sg, TibEntry>,
-    /// RPF cache keyed by source address (NHT-backed).
+    /// The Tree Information Base: (*,G) / (S,G) / (S,G,rpt) state.
+    pub tib: BTreeMap<SgKey, TibEntry>,
+    /// RPF cache keyed by tracked address (sources and RPs).
     pub rpf: BTreeMap<Ipv4Addr, RpfEntry>,
+    /// Static RP mappings.
+    pub rp_set: RpSet,
     /// Kernel dataplane: mroute socket, VIFs, MFC.
     pub(crate) fp: ForwardingPlane,
     /// Periodic J/P refresh deadlines per (ifindex, upstream nbr).
@@ -154,6 +157,7 @@ impl Pim {
             if_config: BTreeMap::new(),
             tib: BTreeMap::new(),
             rpf: BTreeMap::new(),
+            rp_set: RpSet::default(),
             fp,
             jp_refresh: BTreeMap::new(),
             send_tx,
@@ -273,8 +277,10 @@ impl Pim {
         match &packet.payload {
             PimPayload::Hello(hello) => self.hello_recv(ifindex, src, hello),
             PimPayload::JoinPrune(jp) => self.jp_recv(ifindex, src, jp),
+            PimPayload::Register(register) => self.register_recv(src, register),
+            PimPayload::RegisterStop(stop) => self.register_stop_recv(stop),
             other => {
-                // Assert / Register handling arrives with later
+                // Assert / Bootstrap handling arrives with later
                 // phases.
                 tracing::debug!(
                     "pim: ignoring {} from {} on ifindex {} (not yet implemented)",

--- a/zebra-rs/src/pim/jp.rs
+++ b/zebra-rs/src/pim/jp.rs
@@ -1,7 +1,8 @@
 //! Join/Prune message handling: the receive walk feeding the
-//! downstream FSM, triggered single-entry sends, and the periodic
-//! per-RPF-neighbor refresh that re-advertises every Joined entry
-//! (RFC 7761 §4.5 — the aggregation unit is the upstream neighbor).
+//! downstream FSMs ((*,G), (S,G) and (S,G,rpt)), triggered
+//! single-entry sends, and the periodic per-RPF-neighbor refresh
+//! that re-advertises every Joined entry — with the (S,G,rpt) prunes
+//! riding the (*,G) refresh toward the RP (RFC 7761 §4.5.7).
 
 use std::collections::BTreeMap;
 use std::net::{IpAddr, Ipv4Addr};
@@ -14,7 +15,7 @@ use pim_packet::{
 use super::inst::{Pim, PimSend};
 use super::rpf::RpfState;
 use super::socket::ALL_PIM_ROUTERS;
-use super::tib::{JP_HOLDTIME, JoinState, Sg};
+use super::tib::{JP_HOLDTIME, JoinState, SgKey};
 
 /// Periodic J/P refresh interval (t_periodic, RFC 7761 §4.11).
 pub const JP_PERIOD: Duration = Duration::from_secs(60);
@@ -50,36 +51,75 @@ impl Pim {
                 continue;
             };
             for join in &group.joins {
-                if join.wildcard || join.rpt {
-                    // (*,G) / (S,G,rpt) arrive with the ASM phase.
-                    tracing::debug!("pim: (*,G)/rpt join for {} ignored (ASM phase)", grp);
-                    continue;
-                }
-                let IpAddr::V4(src_addr) = join.addr else {
+                let IpAddr::V4(addr) = join.addr else {
                     continue;
                 };
-                self.downstream_join(ifindex, Sg { src: src_addr, grp }, holdtime);
+                match (join.wildcard, join.rpt) {
+                    // (*,G): the encoded address names the sender's
+                    // RP(G) — validated only by our own mapping.
+                    (true, true) => {
+                        self.downstream_join(ifindex, SgKey::StarG { grp }, holdtime);
+                    }
+                    (false, false) => {
+                        self.downstream_join(ifindex, SgKey::Sg { src: addr, grp }, holdtime);
+                    }
+                    // (S,G,rpt) join: cancels a recorded rpt prune.
+                    (false, true) => {
+                        self.downstream_rpt_join(ifindex, SgKey::SgRpt { src: addr, grp });
+                    }
+                    (true, false) => {}
+                }
             }
             for prune in &group.prunes {
-                if prune.wildcard || prune.rpt {
-                    continue;
-                }
-                let IpAddr::V4(src_addr) = prune.addr else {
+                let IpAddr::V4(addr) = prune.addr else {
                     continue;
                 };
-                self.downstream_prune(ifindex, Sg { src: src_addr, grp });
+                match (prune.wildcard, prune.rpt) {
+                    (true, true) => {
+                        self.downstream_prune(ifindex, SgKey::StarG { grp });
+                    }
+                    (false, false) => {
+                        self.downstream_prune(ifindex, SgKey::Sg { src: addr, grp });
+                    }
+                    (false, true) => {
+                        self.downstream_rpt_prune(
+                            ifindex,
+                            SgKey::SgRpt { src: addr, grp },
+                            holdtime,
+                        );
+                    }
+                    (true, false) => {}
+                }
             }
         }
     }
 
     // ---- TX ----
 
+    fn encode_key(&self, key: SgKey) -> Option<EncodedSource> {
+        match key {
+            SgKey::Sg { src, .. } => Some(EncodedSource::sg(IpAddr::V4(src))),
+            SgKey::SgRpt { src, .. } => Some(EncodedSource::sg_rpt(IpAddr::V4(src))),
+            SgKey::StarG { grp } => {
+                // The (*,G) "source" is RP(G).
+                let rp = self
+                    .tib
+                    .get(&key)
+                    .and_then(|e| e.rpf_target)
+                    .or_else(|| self.rp_lookup(grp))?;
+                Some(EncodedSource::star_g(IpAddr::V4(rp)))
+            }
+        }
+    }
+
     /// Triggered single-entry Join (`join == true`) or Prune toward
     /// `nbr` out `ifindex`.
-    pub(crate) fn jp_send_single(&self, ifindex: u32, nbr: Ipv4Addr, sg: Sg, join: bool) {
-        let source = EncodedSource::sg(IpAddr::V4(sg.src));
+    pub(crate) fn jp_send_entry(&self, ifindex: u32, nbr: Ipv4Addr, key: SgKey, join: bool) {
+        let Some(source) = self.encode_key(key) else {
+            return;
+        };
         let group = JpGroup {
-            group: EncodedGroup::new(IpAddr::V4(sg.grp)),
+            group: EncodedGroup::new(IpAddr::V4(key.grp())),
             joins: if join { vec![source] } else { vec![] },
             prunes: if join { vec![] } else { vec![source] },
         };
@@ -106,8 +146,10 @@ impl Pim {
     }
 
     /// Periodic refresh: for each due (interface, neighbor) bucket,
-    /// re-send a Join for every entry currently joined through it;
-    /// drop the bucket when nothing uses that neighbor anymore.
+    /// re-send a Join for every entry currently joined through it,
+    /// with (S,G,rpt) prunes attached to the (*,G) records whose
+    /// sources switched to a diverging SPT; drop the bucket when
+    /// nothing uses that neighbor anymore.
     pub(crate) fn jp_tick(&mut self, now: Instant) {
         let due: Vec<(u32, Ipv4Addr)> = self
             .jp_refresh
@@ -116,21 +158,45 @@ impl Pim {
             .map(|(k, _)| *k)
             .collect();
         for (ifindex, nbr) in due {
-            // Aggregate all joined entries for this neighbor into one
-            // message, group records keyed by group address.
-            let mut by_group: BTreeMap<Ipv4Addr, Vec<EncodedSource>> = BTreeMap::new();
-            for (sg, entry) in self.tib.iter() {
-                if entry.join_state == JoinState::Joined
-                    && entry.rpf
-                        == (RpfState::Gateway {
-                            ifindex,
-                            nexthop: nbr,
-                        })
-                {
-                    by_group
-                        .entry(sg.grp)
-                        .or_default()
-                        .push(EncodedSource::sg(IpAddr::V4(sg.src)));
+            let bucket = RpfState::Gateway {
+                ifindex,
+                nexthop: nbr,
+            };
+            let mut by_group: BTreeMap<Ipv4Addr, (Vec<EncodedSource>, Vec<EncodedSource>)> =
+                BTreeMap::new();
+            let mut star_groups: Vec<Ipv4Addr> = vec![];
+            for (key, entry) in self.tib.iter() {
+                if entry.join_state != JoinState::Joined || entry.rpf != bucket {
+                    continue;
+                }
+                let Some(source) = self.encode_key(*key) else {
+                    continue;
+                };
+                by_group.entry(key.grp()).or_default().0.push(source);
+                if matches!(key, SgKey::StarG { .. }) {
+                    star_groups.push(key.grp());
+                }
+            }
+            // The (*,G) refresh carries the rpt prunes for sources
+            // whose SPT diverged from this shared-tree neighbor.
+            for grp in star_groups {
+                let prunes: Vec<EncodedSource> = self
+                    .tib
+                    .iter()
+                    .filter_map(|(k, e)| match k {
+                        SgKey::Sg { src, grp: g }
+                            if *g == grp
+                                && e.spt_bit
+                                && e.join_state == JoinState::Joined
+                                && e.rpf != bucket =>
+                        {
+                            Some(EncodedSource::sg_rpt(IpAddr::V4(*src)))
+                        }
+                        _ => None,
+                    })
+                    .collect();
+                if !prunes.is_empty() {
+                    by_group.entry(grp).or_default().1.extend(prunes);
                 }
             }
             if by_group.is_empty() {
@@ -139,10 +205,10 @@ impl Pim {
             }
             let groups: Vec<JpGroup> = by_group
                 .into_iter()
-                .map(|(grp, joins)| JpGroup {
+                .map(|(grp, (joins, prunes))| JpGroup {
                     group: EncodedGroup::new(IpAddr::V4(grp)),
                     joins,
-                    prunes: vec![],
+                    prunes,
                 })
                 .collect();
             self.jp_send(ifindex, nbr, groups);

--- a/zebra-rs/src/pim/link.rs
+++ b/zebra-rs/src/pim/link.rs
@@ -167,17 +167,32 @@ impl Pim {
         };
         // Withdraw every local membership this interface fed into
         // the TIB before dropping the state.
-        let mut prune: Vec<(Ipv4Addr, Ipv4Addr)> = vec![];
+        let mut prune: Vec<super::tib::SgKey> = vec![];
         if let Some(igmp) = link.igmp.take() {
             for (grp, group) in igmp.groups {
                 for src in group.synced {
-                    prune.push((grp, src));
+                    prune.push(super::tib::SgKey::Sg { src, grp });
+                }
+                if group.asm_synced {
+                    prune.push(super::tib::SgKey::StarG { grp });
                 }
             }
         }
         tracing::info!("igmp: interface {} disabled", link.name);
-        for (grp, src) in prune {
-            self.tib_local_prune(super::tib::Sg { src, grp }, ifindex);
+        for key in prune {
+            self.tib_local_prune(key, ifindex);
+        }
+    }
+
+    /// Are we the Designated Router on this interface? (RFC 7761
+    /// §4.3.2 — gates first-hop register duty.)
+    pub(crate) fn i_am_dr(&self, ifindex: u32) -> bool {
+        let Some(link) = self.links.get(&ifindex) else {
+            return false;
+        };
+        match (link.dr, link.primary_addr()) {
+            (Some(dr), Some(me)) => dr == me,
+            _ => false,
         }
     }
 

--- a/zebra-rs/src/pim/macros.rs
+++ b/zebra-rs/src/pim/macros.rs
@@ -1,17 +1,19 @@
 //! RFC 7761 state-summarization predicates as named pure functions
-//! over a TIB entry (the ZebOS `pim_route.c` pattern). This phase
-//! carries the (S,G) subset the SSM slice needs; the rpt/star
-//! variants arrive with the ASM phase.
+//! over the TIB (the ZebOS `pim_route.c` pattern). They take the
+//! whole table because the (S,G) inherited olist folds in same-group
+//! (*,G) and (S,G,rpt) state.
 
-use std::collections::BTreeSet;
+use std::collections::{BTreeMap, BTreeSet};
 
-use super::tib::{DsState, TibEntry};
+use super::tib::{DsState, SgKey, TibEntry};
 
-/// `immediate_olist(S,G)`: interfaces with local (IGMP) membership or
-/// downstream Join state. A PrunePending interface still forwards
-/// until its timer fires (RFC 7761 §4.5.2 — the downstream state
-/// machine stays in the forwarding set during PrunePending).
-pub fn immediate_olist(entry: &TibEntry) -> BTreeSet<u32> {
+/// `immediate_olist(key)`: interfaces with local (IGMP) membership
+/// or downstream Join state on this entry. A PrunePending interface
+/// still forwards until its timer fires (RFC 7761 §4.5.2).
+pub fn immediate_olist(tib: &BTreeMap<SgKey, TibEntry>, key: SgKey) -> BTreeSet<u32> {
+    let Some(entry) = tib.get(&key) else {
+        return BTreeSet::new();
+    };
     let mut olist: BTreeSet<u32> = entry.local.iter().copied().collect();
     for (ifindex, ds) in entry.downstream.iter() {
         match ds.state {
@@ -23,19 +25,38 @@ pub fn immediate_olist(entry: &TibEntry) -> BTreeSet<u32> {
     olist
 }
 
-/// `JoinDesired(S,G)`: someone downstream (or local) wants the
-/// traffic. Whether a Join can actually be *sent* additionally
-/// requires an upstream PIM neighbor — that gate lives in the
-/// upstream FSM, not here.
-pub fn join_desired(entry: &TibEntry) -> bool {
-    !immediate_olist(entry).is_empty()
+/// `inherited_olist(S,G)`: the source tree's effective forwarding
+/// set — immediate (S,G) state plus the shared tree's olist minus
+/// interfaces holding an (S,G,rpt) prune. For non-(S,G) keys it is
+/// the immediate olist.
+pub fn inherited_olist(tib: &BTreeMap<SgKey, TibEntry>, key: SgKey) -> BTreeSet<u32> {
+    let SgKey::Sg { src, grp } = key else {
+        return immediate_olist(tib, key);
+    };
+    let mut olist = immediate_olist(tib, key);
+    let mut shared = immediate_olist(tib, SgKey::StarG { grp });
+    if let Some(rpt) = tib.get(&SgKey::SgRpt { src, grp }) {
+        for ifindex in rpt.downstream.keys() {
+            shared.remove(ifindex);
+        }
+    }
+    olist.extend(shared);
+    olist
 }
 
-/// The MFC outgoing set: the olist minus the incoming interface
-/// (loop-free guard — never emit OIF == IIF).
-pub fn mfc_oifs(entry: &TibEntry, rpf_ifindex: Option<u32>) -> BTreeSet<u32> {
-    let mut oifs = immediate_olist(entry);
-    if let Some(iif) = rpf_ifindex {
+/// `JoinDesired(key)` — someone wants the traffic on this tree.
+/// Whether a Join can actually be *sent* additionally requires an
+/// upstream PIM neighbor (and, for (*,G), a known RP) — those gates
+/// live in the upstream FSM, not here.
+pub fn join_desired(tib: &BTreeMap<SgKey, TibEntry>, key: SgKey) -> bool {
+    !immediate_olist(tib, key).is_empty()
+}
+
+/// The (S,G) MFC outgoing set: the inherited olist minus the
+/// incoming interface (loop-free guard — never emit OIF == IIF).
+pub fn mfc_oifs(tib: &BTreeMap<SgKey, TibEntry>, key: SgKey) -> BTreeSet<u32> {
+    let mut oifs = inherited_olist(tib, key);
+    if let Some(iif) = tib.get(&key).and_then(|e| e.rpf.ifindex()) {
         oifs.remove(&iif);
     }
     oifs
@@ -43,38 +64,59 @@ pub fn mfc_oifs(entry: &TibEntry, rpf_ifindex: Option<u32>) -> BTreeSet<u32> {
 
 #[cfg(test)]
 mod tests {
+    use std::net::Ipv4Addr;
     use std::time::{Duration, Instant};
 
     use super::*;
     use crate::pim::rpf::RpfState;
-    use crate::pim::tib::{Downstream, TibEntry};
+    use crate::pim::tib::Downstream;
 
-    fn entry() -> TibEntry {
-        TibEntry::new()
+    fn sg() -> SgKey {
+        SgKey::Sg {
+            src: Ipv4Addr::new(10, 0, 0, 2),
+            grp: Ipv4Addr::new(239, 1, 1, 1),
+        }
+    }
+
+    fn star() -> SgKey {
+        SgKey::StarG {
+            grp: Ipv4Addr::new(239, 1, 1, 1),
+        }
+    }
+
+    fn rpt() -> SgKey {
+        SgKey::SgRpt {
+            src: Ipv4Addr::new(10, 0, 0, 2),
+            grp: Ipv4Addr::new(239, 1, 1, 1),
+        }
+    }
+
+    fn ds_join() -> Downstream {
+        Downstream {
+            state: DsState::Join,
+            expires: Instant::now() + Duration::from_secs(210),
+        }
     }
 
     #[test]
     fn olist_combines_local_and_downstream() {
-        let mut e = entry();
-        assert!(!join_desired(&e));
+        let mut tib = BTreeMap::new();
+        let mut e = TibEntry::new();
         e.local.insert(3);
-        e.downstream.insert(
-            5,
-            Downstream {
-                state: DsState::Join,
-                expires: Instant::now() + Duration::from_secs(210),
-            },
-        );
+        e.downstream.insert(5, ds_join());
+        tib.insert(sg(), e);
         assert_eq!(
-            immediate_olist(&e).into_iter().collect::<Vec<_>>(),
+            immediate_olist(&tib, sg()).into_iter().collect::<Vec<_>>(),
             vec![3, 5]
         );
-        assert!(join_desired(&e));
+        assert!(join_desired(&tib, sg()));
+        assert!(!join_desired(&tib, star()));
     }
 
     #[test]
     fn prune_pending_still_forwards() {
-        let mut e = entry();
+        let mut tib = BTreeMap::new();
+        let mut e = TibEntry::new();
         e.downstream.insert(
             5,
             Downstream {
@@ -84,17 +126,42 @@ mod tests {
                 expires: Instant::now() + Duration::from_secs(210),
             },
         );
-        assert!(join_desired(&e));
-        assert_eq!(immediate_olist(&e).len(), 1);
+        tib.insert(sg(), e);
+        assert!(join_desired(&tib, sg()));
+    }
+
+    #[test]
+    fn inherited_folds_shared_tree_minus_rpt_prunes() {
+        let mut tib = BTreeMap::new();
+        // (S,G): downstream on 5.
+        let mut e = TibEntry::new();
+        e.downstream.insert(5, ds_join());
+        tib.insert(sg(), e);
+        // (*,G): downstream on 6 and 7.
+        let mut se = TibEntry::new();
+        se.downstream.insert(6, ds_join());
+        se.downstream.insert(7, ds_join());
+        tib.insert(star(), se);
+        // (S,G,rpt): pruned on 7.
+        let mut re = TibEntry::new();
+        re.downstream.insert(7, ds_join());
+        tib.insert(rpt(), re);
+
+        let inherited = inherited_olist(&tib, sg());
+        assert!(inherited.contains(&5));
+        assert!(inherited.contains(&6));
+        assert!(!inherited.contains(&7));
     }
 
     #[test]
     fn mfc_excludes_iif() {
-        let mut e = entry();
+        let mut tib = BTreeMap::new();
+        let mut e = TibEntry::new();
         e.local.insert(3);
         e.local.insert(7);
         e.rpf = RpfState::Connected { ifindex: 7 };
-        let oifs = mfc_oifs(&e, e.rpf.ifindex());
+        tib.insert(sg(), e);
+        let oifs = mfc_oifs(&tib, sg());
         assert!(oifs.contains(&3));
         assert!(!oifs.contains(&7));
     }

--- a/zebra-rs/src/pim/mod.rs
+++ b/zebra-rs/src/pim/mod.rs
@@ -10,6 +10,8 @@ pub mod macros;
 pub mod mroute;
 pub mod neighbor;
 pub mod network;
+pub mod register;
+pub mod rp;
 pub mod rpf;
 pub mod show;
 pub mod socket;

--- a/zebra-rs/src/pim/mroute.rs
+++ b/zebra-rs/src/pim/mroute.rs
@@ -31,8 +31,15 @@ const MRT_DEL_MFC: c_int = 205;
 const MRT_PIM: c_int = 208;
 
 const VIFF_USE_IFINDEX: u8 = 0x8;
+const VIFF_REGISTER: u8 = 0x4;
 
 pub const MAXVIFS: usize = 32;
+
+/// The register VIF: slot 0, created at init. The kernel materializes
+/// it as the `pimreg` device; putting it in an (S,G) OIL makes the
+/// kernel punt full packets (WHOLEPKT) for Register encapsulation at
+/// the DR.
+pub const REG_VIF: u16 = 0;
 
 const IGMPMSG_NOCACHE: u8 = 1;
 const IGMPMSG_WRONGVIF: u8 = 2;
@@ -78,12 +85,15 @@ pub enum UpcallKind {
     WrVifWhole,
 }
 
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone)]
 pub struct Upcall {
     pub kind: UpcallKind,
     pub vif: u16,
     pub src: Ipv4Addr,
     pub grp: Ipv4Addr,
+    /// The punted original IP packet — populated for WHOLEPKT (the
+    /// Register encapsulation payload), empty otherwise.
+    pub payload: Vec<u8>,
 }
 
 /// Parse one datagram read from the mroute socket. `None` for
@@ -104,11 +114,17 @@ pub fn parse_upcall(buf: &[u8]) -> Option<Upcall> {
             return None;
         }
     };
+    let payload = if matches!(kind, UpcallKind::WholePkt | UpcallKind::WrVifWhole) {
+        buf[20..].to_vec()
+    } else {
+        Vec::new()
+    };
     Some(Upcall {
         kind,
         vif: buf[10] as u16 | ((buf[11] as u16) << 8),
         src: Ipv4Addr::new(buf[12], buf[13], buf[14], buf[15]),
         grp: Ipv4Addr::new(buf[16], buf[17], buf[18], buf[19]),
+        payload,
     })
 }
 
@@ -153,6 +169,19 @@ impl ForwardingPlane {
         // WRVIFWHOLE upcall used by the ASM phase.
         if let Err(e) = mrt_setsockopt(&sock, MRT_PIM, &one) {
             tracing::warn!("mroute: MRT_PIM failed ({e}); register handling degraded");
+        }
+        // The register VIF (slot 0) — kernel creates `pimreg`. Needed
+        // in an (S,G) OIL for WHOLEPKT punts at the DR.
+        let vc = Vifctl {
+            vifc_vifi: REG_VIF,
+            vifc_flags: VIFF_REGISTER,
+            vifc_threshold: 1,
+            vifc_rate_limit: 0,
+            vifc_lcl: 0,
+            vifc_rmt_addr: 0,
+        };
+        if let Err(e) = mrt_setsockopt(&sock, MRT_ADD_VIF, &vc) {
+            tracing::warn!("mroute: register VIF add failed ({e}); registers degraded");
         }
         Ok(Self {
             sock: Arc::new(AsyncFd::new(sock)?),

--- a/zebra-rs/src/pim/register.rs
+++ b/zebra-rs/src/pim/register.rs
@@ -1,0 +1,227 @@
+//! PIM Register machinery (RFC 7761 §4.4): the DR-side register FSM
+//! (encapsulate source traffic toward the RP until a Register-Stop,
+//! then suppression with Null-Register probes) and the RP side
+//! (Register RX creates (S,G) state, triggers the SPT join, answers
+//! with Register-Stop once the source tree is being joined or nobody
+//! is listening).
+//!
+//! Dataplane note: kernel decapsulation at the RP (register VIF as
+//! MFC IIF) is not used — the brief pre-SPT data window is dropped,
+//! matching the "switch to SPT immediately" policy. Native traffic
+//! takes over as soon as the (S,G) join propagates.
+
+use std::net::{IpAddr, Ipv4Addr};
+use std::time::{Duration, Instant};
+
+use pim_packet::{
+    EncodedGroup, EncodedUnicast, PimPacket, PimPayload, PimRegister, PimRegisterStop,
+};
+
+use super::inst::{Pim, PimSend};
+use super::mroute::Upcall;
+use super::rp::is_ssm;
+use super::tib::{JoinState, KEEPALIVE_PERIOD, RegState, SgKey};
+
+/// Register suppression: how long a Register-Stop silences the DR.
+const REGISTER_SUPPRESS: Duration = Duration::from_secs(55);
+
+/// Probe window: the Null-Register goes out this long before
+/// suppression would lapse.
+const REGISTER_PROBE: Duration = Duration::from_secs(5);
+
+impl Pim {
+    /// First-hop-router check on NOCACHE: start registering when we
+    /// are the DR on the directly-connected source's interface, the
+    /// group is ASM with a known RP, and we are not the RP ourselves.
+    pub(crate) fn register_check_fhr(&mut self, key: SgKey, vif: u16) {
+        let SgKey::Sg { src, grp } = key else {
+            return;
+        };
+        if is_ssm(grp) || self.i_am_rp(grp) || self.rp_lookup(grp).is_none() {
+            return;
+        }
+        let Some(ifindex) = self.fp.ifindex_of(vif) else {
+            return;
+        };
+        let directly_connected = self
+            .links
+            .get(&ifindex)
+            .map(|l| l.enabled && l.addrs.iter().any(|p| p.contains(&src)))
+            .unwrap_or(false);
+        if !directly_connected || !self.i_am_dr(ifindex) {
+            return;
+        }
+        let entry = self.tib.get_mut(&key).unwrap();
+        if entry.reg_state == RegState::NoInfo {
+            entry.reg_state = RegState::Join;
+            tracing::info!("pim: {} registering toward the RP (FHR)", key);
+        }
+    }
+
+    /// WHOLEPKT upcall: the kernel punted a full packet through the
+    /// register VIF — encapsulate and unicast it to RP(G).
+    pub(crate) fn register_wholepkt(&mut self, upcall: Upcall) {
+        let key = SgKey::Sg {
+            src: upcall.src,
+            grp: upcall.grp,
+        };
+        let Some(entry) = self.tib.get_mut(&key) else {
+            return;
+        };
+        if entry.reg_state != RegState::Join {
+            return;
+        }
+        // Traffic is flowing: refresh the keepalive alongside.
+        entry.stream_expires = Some(Instant::now() + KEEPALIVE_PERIOD);
+        let Some(rp) = self.rp_lookup(upcall.grp) else {
+            return;
+        };
+        self.register_send(rp, upcall.payload, false);
+    }
+
+    fn register_send(&self, rp: Ipv4Addr, data: Vec<u8>, null: bool) {
+        let packet = PimPacket::new(PimPayload::Register(PimRegister {
+            border: false,
+            null_register: null,
+            data,
+        }));
+        // ifindex 0: egress selection by the kernel FIB toward the RP.
+        let _ = self.send_tx.send(PimSend {
+            packet,
+            ifindex: 0,
+            dst: rp,
+        });
+    }
+
+    /// A minimal inner IPv4 header naming (S,G) — the Null-Register
+    /// payload (RFC 7761 §4.4.1).
+    fn null_register_payload(src: Ipv4Addr, grp: Ipv4Addr) -> Vec<u8> {
+        let mut header = vec![0u8; 20];
+        header[0] = 0x45;
+        header[3] = 20; // total length
+        header[8] = 64; // ttl
+        header[12..16].copy_from_slice(&src.octets());
+        header[16..20].copy_from_slice(&grp.octets());
+        header
+    }
+
+    // ---- RP side ----
+
+    /// Register RX at the RP: (re)create the (S,G), keep it alive,
+    /// let `tib_update` fire the SPT join (KAT + inherited olist),
+    /// and answer Register-Stop once the source tree is joined — or
+    /// immediately when nobody is listening.
+    pub(crate) fn register_recv(&mut self, outer_src: Ipv4Addr, register: &PimRegister) {
+        // The inner packet (or Null-Register dummy header) names (S,G).
+        let data = &register.data;
+        if data.len() < 20 || data[0] >> 4 != 4 {
+            tracing::debug!("pim: malformed register from {}", outer_src);
+            return;
+        }
+        let src = Ipv4Addr::new(data[12], data[13], data[14], data[15]);
+        let grp = Ipv4Addr::new(data[16], data[17], data[18], data[19]);
+        if !grp.is_multicast() || is_ssm(grp) {
+            return;
+        }
+        if !self.i_am_rp(grp) {
+            tracing::debug!(
+                "pim: register for {} from {} but we are not its RP",
+                grp,
+                outer_src
+            );
+            return;
+        }
+        let key = SgKey::Sg { src, grp };
+        let entry = self.tib_get_or_create(key);
+        entry.stream_expires = Some(Instant::now() + KEEPALIVE_PERIOD);
+        self.tib_update(key);
+
+        let Some(entry) = self.tib.get(&key) else {
+            return;
+        };
+        let receivers = !super::macros::inherited_olist(&self.tib, key).is_empty();
+        let spt_underway = entry.join_state == JoinState::Joined;
+        if !receivers || spt_underway {
+            self.register_stop_send(outer_src, src, grp);
+        }
+    }
+
+    fn register_stop_send(&self, dr: Ipv4Addr, src: Ipv4Addr, grp: Ipv4Addr) {
+        let packet = PimPacket::new(PimPayload::RegisterStop(PimRegisterStop {
+            group: EncodedGroup::new(IpAddr::V4(grp)),
+            source: EncodedUnicast::new(IpAddr::V4(src)),
+        }));
+        let _ = self.send_tx.send(PimSend {
+            packet,
+            ifindex: 0,
+            dst: dr,
+        });
+    }
+
+    /// Register-Stop RX at the DR: suppress.
+    pub(crate) fn register_stop_recv(&mut self, stop: &PimRegisterStop) {
+        let (IpAddr::V4(grp), IpAddr::V4(src)) = (stop.group.addr, stop.source.addr) else {
+            return;
+        };
+        let key = SgKey::Sg { src, grp };
+        let Some(entry) = self.tib.get_mut(&key) else {
+            return;
+        };
+        match entry.reg_state {
+            RegState::Join | RegState::JoinPending { .. } => {
+                entry.reg_state = RegState::Prune {
+                    until: Instant::now() + REGISTER_SUPPRESS,
+                };
+                tracing::info!("pim: {} register suppressed (Register-Stop)", key);
+                self.tib_update(key);
+            }
+            RegState::Prune { .. } => {
+                entry.reg_state = RegState::Prune {
+                    until: Instant::now() + REGISTER_SUPPRESS,
+                };
+            }
+            RegState::NoInfo => {}
+        }
+    }
+
+    /// Register FSM deadlines: suppression lapse → Null-Register
+    /// probe; probe unanswered → resume registering.
+    pub(crate) fn register_tick(&mut self, now: Instant) {
+        let due: Vec<(SgKey, RegState)> = self
+            .tib
+            .iter()
+            .filter_map(|(key, e)| match e.reg_state {
+                RegState::Prune { until } if until <= now => Some((*key, e.reg_state)),
+                RegState::JoinPending { until } if until <= now => Some((*key, e.reg_state)),
+                _ => None,
+            })
+            .collect();
+        for (key, state) in due {
+            let SgKey::Sg { src, grp } = key else {
+                continue;
+            };
+            match state {
+                RegState::Prune { .. } => {
+                    // Probe: Null-Register; a live RP answers with
+                    // another Stop before the window closes.
+                    if let Some(rp) = self.rp_lookup(grp) {
+                        self.register_send(rp, Self::null_register_payload(src, grp), true);
+                    }
+                    if let Some(entry) = self.tib.get_mut(&key) {
+                        entry.reg_state = RegState::JoinPending {
+                            until: now + REGISTER_PROBE,
+                        };
+                    }
+                }
+                RegState::JoinPending { .. } => {
+                    if let Some(entry) = self.tib.get_mut(&key) {
+                        entry.reg_state = RegState::Join;
+                        tracing::info!("pim: {} register probe unanswered — registering", key);
+                    }
+                    self.tib_update(key);
+                }
+                _ => {}
+            }
+        }
+    }
+}

--- a/zebra-rs/src/pim/rp.rs
+++ b/zebra-rs/src/pim/rp.rs
@@ -1,0 +1,75 @@
+//! RP set: static RP configuration with group-prefix longest-match,
+//! the SSM range predicate, and re-targeting of (*,G) state when the
+//! mapping changes. Provenance is static-only until the BSR phase.
+
+use std::collections::BTreeMap;
+use std::net::Ipv4Addr;
+
+use ipnet::Ipv4Net;
+
+use super::inst::Pim;
+use super::tib::SgKey;
+
+/// Default SSM range (RFC 4607): no RP, no register, (S,G) only.
+fn ssm_range() -> Ipv4Net {
+    Ipv4Net::new(Ipv4Addr::new(232, 0, 0, 0), 8).unwrap()
+}
+
+pub fn is_ssm(grp: Ipv4Addr) -> bool {
+    ssm_range().contains(&grp)
+}
+
+/// Static RP table: RP address → served group range.
+#[derive(Debug, Clone, Default)]
+pub struct RpSet {
+    pub statics: BTreeMap<Ipv4Addr, Ipv4Net>,
+}
+
+impl Pim {
+    /// RP(G): longest-prefix match across the static entries. SSM
+    /// groups never map to an RP.
+    pub(crate) fn rp_lookup(&self, grp: Ipv4Addr) -> Option<Ipv4Addr> {
+        if is_ssm(grp) || !grp.is_multicast() {
+            return None;
+        }
+        self.rp_set
+            .statics
+            .iter()
+            .filter(|(_, range)| range.contains(&grp))
+            .max_by_key(|(_, range)| range.prefix_len())
+            .map(|(rp, _)| *rp)
+    }
+
+    /// I_am_RP(G): the mapped RP address is one of our interface
+    /// addresses.
+    pub(crate) fn i_am_rp(&self, grp: Ipv4Addr) -> bool {
+        let Some(rp) = self.rp_lookup(grp) else {
+            return false;
+        };
+        self.links.values().any(|l| l.is_my_addr(&rp))
+    }
+
+    /// The static RP table changed: every (*,G) whose mapped RP
+    /// differs from the one it is built on gets re-targeted — prune
+    /// the old upstream, move the RPF tracking, re-evaluate.
+    pub(crate) fn rp_reevaluate(&mut self) {
+        let stars: Vec<(SgKey, Option<Ipv4Addr>)> = self
+            .tib
+            .iter()
+            .filter_map(|(key, entry)| match key {
+                SgKey::StarG { grp } => {
+                    let want = self.rp_lookup(*grp);
+                    if want != entry.rpf_target {
+                        Some((*key, want))
+                    } else {
+                        None
+                    }
+                }
+                _ => None,
+            })
+            .collect();
+        for (key, want) in stars {
+            self.tib_retarget(key, want);
+        }
+    }
+}

--- a/zebra-rs/src/pim/rpf.rs
+++ b/zebra-rs/src/pim/rpf.rs
@@ -10,7 +10,7 @@ use crate::rib;
 use crate::rib::nht::NexthopResolution;
 
 use super::inst::Pim;
-use super::tib::Sg;
+use super::tib::SgKey;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum RpfState {
@@ -114,17 +114,18 @@ impl Pim {
         }
     }
 
-    /// Propagate an RPF change into every TIB entry for that source:
-    /// prune off the old upstream, adopt the new state, re-evaluate.
-    fn rpf_changed(&mut self, src: Ipv4Addr, state: RpfState) {
-        let sgs: Vec<Sg> = self
+    /// Propagate an RPF change into every TIB entry tracking that
+    /// address ((S,G) sources and (*,G) RPs alike): prune off the old
+    /// upstream, adopt the new state, re-evaluate.
+    fn rpf_changed(&mut self, addr: Ipv4Addr, state: RpfState) {
+        let keys: Vec<SgKey> = self
             .tib
-            .keys()
-            .filter(|sg| sg.src == src)
-            .copied()
+            .iter()
+            .filter(|(_, e)| e.rpf_target == Some(addr))
+            .map(|(key, _)| *key)
             .collect();
-        for sg in sgs {
-            self.tib_rpf_change(sg, state);
+        for key in keys {
+            self.tib_rpf_change(key, state);
         }
     }
 }

--- a/zebra-rs/src/pim/show.rs
+++ b/zebra-rs/src/pim/show.rs
@@ -13,7 +13,7 @@ use super::igmp::{FilterMode, QuerierState};
 use super::inst::{Pim, ShowCallback};
 use super::macros::mfc_oifs;
 use super::rpf::RpfState;
-use super::tib::JoinState;
+use super::tib::{JoinState, RegState};
 
 impl Pim {
     pub fn show_build(&mut self) {
@@ -30,6 +30,8 @@ impl Pim {
             .set(show_igmp_groups)
             .path("/show/pim/upstream")
             .set(show_pim_upstream)
+            .path("/show/pim/rp-info")
+            .set(show_pim_rp_info)
             .path("/show/mroute")
             .set(show_mroute)
             .map();
@@ -302,25 +304,32 @@ struct UpstreamBrief {
     iif: String,
     rpf_neighbor: String,
     state: String,
+    reg: String,
     uptime: String,
 }
 
 fn show_pim_upstream(pim: &Pim, _args: Args, json: bool) -> Result<String, std::fmt::Error> {
     let mut rows: Vec<UpstreamBrief> = vec![];
 
-    for (sg, entry) in pim.tib.iter() {
+    for (key, entry) in pim.tib.iter() {
         let (iif, rpf_neighbor) = match entry.rpf {
             RpfState::Unresolved => ("-".to_string(), "-".to_string()),
             RpfState::Connected { ifindex } => (pim.ifname(ifindex), "connected".to_string()),
             RpfState::Gateway { ifindex, nexthop } => (pim.ifname(ifindex), nexthop.to_string()),
         };
         rows.push(UpstreamBrief {
-            sg: sg.to_string(),
+            sg: key.to_string(),
             iif,
             rpf_neighbor,
             state: match entry.join_state {
                 JoinState::Joined => "Joined".to_string(),
                 JoinState::NotJoined => "NotJoined".to_string(),
+            },
+            reg: match entry.reg_state {
+                RegState::NoInfo => "-".to_string(),
+                RegState::Join => "RegJoin".to_string(),
+                RegState::Prune { .. } => "RegPrune".to_string(),
+                RegState::JoinPending { .. } => "RegProbe".to_string(),
             },
             uptime: uptime_string(entry.uptime.elapsed().as_secs()),
         });
@@ -332,13 +341,51 @@ fn show_pim_upstream(pim: &Pim, _args: Args, json: bool) -> Result<String, std::
 
     let mut buf = String::new();
     buf.push_str(
-        "Source           Group            Iif          RPF Nbr          State      Uptime\n",
+        "Entry                              Iif          RPF Nbr          State      Reg        Uptime\n",
     );
-    for (sg, row) in pim.tib.keys().zip(rows.iter()) {
+    for row in rows.iter() {
         writeln!(
             buf,
-            "{:<17}{:<17}{:<13}{:<17}{:<11}{}",
-            sg.src, sg.grp, row.iif, row.rpf_neighbor, row.state, row.uptime,
+            "{:<35}{:<13}{:<17}{:<11}{:<11}{}",
+            row.sg, row.iif, row.rpf_neighbor, row.state, row.reg, row.uptime,
+        )?;
+    }
+    Ok(buf)
+}
+
+#[derive(Serialize)]
+struct RpInfoBrief {
+    rp: String,
+    group_range: String,
+    source: String,
+    is_self: bool,
+}
+
+fn show_pim_rp_info(pim: &Pim, _args: Args, json: bool) -> Result<String, std::fmt::Error> {
+    let mut rows: Vec<RpInfoBrief> = vec![];
+    for (rp, range) in pim.rp_set.statics.iter() {
+        rows.push(RpInfoBrief {
+            rp: rp.to_string(),
+            group_range: range.to_string(),
+            source: "static".to_string(),
+            is_self: pim.links.values().any(|l| l.is_my_addr(rp)),
+        });
+    }
+
+    if json {
+        return Ok(serde_json::to_string(&rows).unwrap());
+    }
+
+    let mut buf = String::new();
+    buf.push_str("RP address       Group range        Source   Self\n");
+    for row in &rows {
+        writeln!(
+            buf,
+            "{:<17}{:<19}{:<9}{}",
+            row.rp,
+            row.group_range,
+            row.source,
+            if row.is_self { "yes" } else { "no" },
         )?;
     }
     Ok(buf)
@@ -357,12 +404,12 @@ struct MrouteBrief {
 fn show_mroute(pim: &Pim, _args: Args, json: bool) -> Result<String, std::fmt::Error> {
     let mut rows: Vec<MrouteBrief> = vec![];
 
-    for (sg, entry) in pim.tib.iter() {
+    for (key, entry) in pim.tib.iter() {
         let iif = entry
             .rpf
             .ifindex()
             .map_or_else(|| "-".to_string(), |i| pim.ifname(i));
-        let oifs: Vec<String> = mfc_oifs(entry, entry.rpf.ifindex())
+        let oifs: Vec<String> = mfc_oifs(&pim.tib, *key)
             .iter()
             .map(|i| pim.ifname(*i))
             .collect();
@@ -376,11 +423,14 @@ fn show_mroute(pim: &Pim, _args: Args, json: bool) -> Result<String, std::fmt::E
         if entry.stream_expires.is_some() {
             flags.push('S');
         }
+        if entry.spt_bit {
+            flags.push('T');
+        }
         if entry.installed.is_some() {
             flags.push('I');
         }
         rows.push(MrouteBrief {
-            sg: sg.to_string(),
+            sg: key.to_string(),
             iif,
             oifs,
             flags,

--- a/zebra-rs/src/pim/tib.rs
+++ b/zebra-rs/src/pim/tib.rs
@@ -1,10 +1,17 @@
-//! The Tree Information Base: (S,G) entries combining upstream
-//! Join/Prune state, downstream per-interface state, local (IGMP)
-//! membership, and the installed-MFC shadow. `tib_update` is the
-//! single reconvergence point: every input event mutates one facet
-//! and calls it; it re-evaluates the RFC 7761 predicates
+//! The Tree Information Base: (*,G), (S,G) and (S,G,rpt) entries in
+//! one table with typed keys (the ZebOS unified-TIB shape). Each
+//! entry combines upstream Join/Prune state, downstream
+//! per-interface state, local (IGMP) membership, register state and
+//! the installed-MFC shadow. `tib_update` is the single
+//! reconvergence point: every input event mutates one facet and
+//! calls it; it re-evaluates the RFC 7761 predicates
 //! (`super::macros`) and diffs the result against the running
 //! upstream state and the kernel MFC.
+//!
+//! Kernel note: no (*,G) MFC entries are installed — shared-tree
+//! traffic is handled by NOCACHE-created (S,G) entries whose OIL is
+//! the *inherited* olist, so every active source gets its own MFC
+//! row. This sidesteps the kernel's (*,G) IIF∈OIF quirk entirely.
 
 use std::collections::{BTreeMap, BTreeSet};
 use std::fmt;
@@ -12,16 +19,15 @@ use std::net::Ipv4Addr;
 use std::time::{Duration, Instant};
 
 use super::inst::Pim;
-use super::macros::{join_desired, mfc_oifs};
-use super::mroute::{Upcall, UpcallKind};
+use super::macros::{inherited_olist, join_desired, mfc_oifs};
+use super::mroute::{REG_VIF, Upcall, UpcallKind};
 use super::rpf::RpfState;
 
 /// Join/Prune holdtime we advertise and the downstream expiry we run
 /// (3.5 × the 60 s J/P period).
 pub const JP_HOLDTIME: u16 = 210;
 
-/// (S,G) keepalive for traffic-created (NOCACHE) state without
-/// receivers.
+/// (S,G) keepalive for traffic-created (NOCACHE / register) state.
 pub const KEEPALIVE_PERIOD: Duration = Duration::from_secs(210);
 
 /// Prune-pending delay on a LAN with other neighbors: propagation
@@ -29,14 +35,31 @@ pub const KEEPALIVE_PERIOD: Duration = Duration::from_secs(210);
 pub const PRUNE_PENDING_DELAY: Duration = Duration::from_millis(3000);
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
-pub struct Sg {
-    pub src: Ipv4Addr,
-    pub grp: Ipv4Addr,
+pub enum SgKey {
+    /// Shared-tree state rooted at RP(G).
+    StarG { grp: Ipv4Addr },
+    /// Source-tree state.
+    Sg { src: Ipv4Addr, grp: Ipv4Addr },
+    /// Source pruned off the shared tree (downstream prune records;
+    /// the upstream side rides the (*,G) refresh).
+    SgRpt { src: Ipv4Addr, grp: Ipv4Addr },
 }
 
-impl fmt::Display for Sg {
+impl SgKey {
+    pub fn grp(&self) -> Ipv4Addr {
+        match self {
+            SgKey::StarG { grp } | SgKey::Sg { grp, .. } | SgKey::SgRpt { grp, .. } => *grp,
+        }
+    }
+}
+
+impl fmt::Display for SgKey {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "({}, {})", self.src, self.grp)
+        match self {
+            SgKey::StarG { grp } => write!(f, "(*, {})", grp),
+            SgKey::Sg { src, grp } => write!(f, "({}, {})", src, grp),
+            SgKey::SgRpt { src, grp } => write!(f, "({}, {}, rpt)", src, grp),
+        }
     }
 }
 
@@ -55,8 +78,27 @@ pub enum DsState {
 #[derive(Debug, Clone, Copy)]
 pub struct Downstream {
     pub state: DsState,
-    /// Expiry Timer (ET): holdtime from the last Join.
+    /// Expiry Timer (ET): holdtime from the last Join (for SgRpt
+    /// entries: from the last rpt-Prune).
     pub expires: Instant,
+}
+
+/// DR-side register FSM per (S,G) (RFC 7761 §4.4.1).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RegState {
+    NoInfo,
+    /// Registering: the register VIF sits in the OIL, WHOLEPKT punts
+    /// become unicast Registers to the RP.
+    Join,
+    /// Register-Stop received: suppressed until `until`.
+    Prune {
+        until: Instant,
+    },
+    /// Suppression about to lapse: Null-Register sent, waiting out
+    /// the probe window.
+    JoinPending {
+        until: Instant,
+    },
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -70,15 +112,26 @@ pub struct TibEntry {
     /// RPF snapshot this entry currently operates on; refreshed by
     /// `tib_rpf_change` so a change can prune the old upstream first.
     pub rpf: RpfState,
-    /// Interfaces with local IGMP (S,G) membership.
+    /// Address the RPF tracking follows: the source for (S,G), RP(G)
+    /// for (*,G). `None` for (S,G,rpt) (no upstream of its own) and
+    /// for (*,G) without a known RP.
+    pub rpf_target: Option<Ipv4Addr>,
+    /// Interfaces with local IGMP membership ((S,G) INCLUDE sources
+    /// on Sg entries; EXCLUDE/any-source membership on StarG).
     pub local: BTreeSet<u32>,
-    /// Downstream per-interface Join/Prune state, keyed by ifindex.
+    /// Downstream per-interface state, keyed by ifindex. On SgRpt
+    /// entries presence means "rpt-pruned on this interface".
     pub downstream: BTreeMap<u32, Downstream>,
-    /// Kernel MFC shadow — `Some` while installed.
+    /// Kernel MFC shadow — `Some` while installed (Sg entries only).
     pub installed: Option<InstalledMfc>,
-    /// Keepalive deadline for traffic-created state (NOCACHE); the
-    /// entry survives without receivers until this passes.
+    /// Keepalive deadline for traffic-created state (NOCACHE at any
+    /// router, Register/Null-Register RX at the RP).
     pub stream_expires: Option<Instant>,
+    /// Register FSM (Sg at the DR only).
+    pub reg_state: RegState,
+    /// SPT bit: native traffic has been seen on the source tree —
+    /// arms the (S,G,rpt) prune toward the RP.
+    pub spt_bit: bool,
     pub uptime: Instant,
 }
 
@@ -87,46 +140,62 @@ impl TibEntry {
         Self {
             join_state: JoinState::NotJoined,
             rpf: RpfState::Unresolved,
+            rpf_target: None,
             local: BTreeSet::new(),
             downstream: BTreeMap::new(),
             installed: None,
             stream_expires: None,
+            reg_state: RegState::NoInfo,
+            spt_bit: false,
             uptime: Instant::now(),
         }
     }
 }
 
+impl Default for TibEntry {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl Pim {
-    fn tib_get_or_create(&mut self, sg: Sg) -> &mut TibEntry {
-        if !self.tib.contains_key(&sg) {
-            let rpf = self.rpf_acquire(sg.src);
+    pub(crate) fn tib_get_or_create(&mut self, key: SgKey) -> &mut TibEntry {
+        if !self.tib.contains_key(&key) {
+            let target = match key {
+                SgKey::Sg { src, .. } => Some(src),
+                SgKey::StarG { grp } => self.rp_lookup(grp),
+                SgKey::SgRpt { .. } => None,
+            };
             let mut entry = TibEntry::new();
-            entry.rpf = rpf;
-            self.tib.insert(sg, entry);
-            tracing::info!("pim: {} created", sg);
+            entry.rpf_target = target;
+            if let Some(addr) = target {
+                entry.rpf = self.rpf_acquire(addr);
+            }
+            self.tib.insert(key, entry);
+            tracing::info!("pim: {} created", key);
         }
-        self.tib.get_mut(&sg).unwrap()
+        self.tib.get_mut(&key).unwrap()
     }
 
     // ---- TIB bridge (IGMP membership → PIM state) ----
 
-    pub(crate) fn tib_local_join(&mut self, sg: Sg, ifindex: u32) {
-        self.tib_get_or_create(sg).local.insert(ifindex);
-        self.tib_update(sg);
+    pub(crate) fn tib_local_join(&mut self, key: SgKey, ifindex: u32) {
+        self.tib_get_or_create(key).local.insert(ifindex);
+        self.tib_update(key);
     }
 
-    pub(crate) fn tib_local_prune(&mut self, sg: Sg, ifindex: u32) {
-        if let Some(entry) = self.tib.get_mut(&sg) {
+    pub(crate) fn tib_local_prune(&mut self, key: SgKey, ifindex: u32) {
+        if let Some(entry) = self.tib.get_mut(&key) {
             entry.local.remove(&ifindex);
-            self.tib_update(sg);
+            self.tib_update(key);
         }
     }
 
     // ---- downstream Join/Prune RX (per-interface FSM) ----
 
-    pub(crate) fn downstream_join(&mut self, ifindex: u32, sg: Sg, holdtime: u16) {
+    pub(crate) fn downstream_join(&mut self, ifindex: u32, key: SgKey, holdtime: u16) {
         let now = Instant::now();
-        let entry = self.tib_get_or_create(sg);
+        let entry = self.tib_get_or_create(key);
         entry.downstream.insert(
             ifindex,
             Downstream {
@@ -134,11 +203,11 @@ impl Pim {
                 expires: now + Duration::from_secs(holdtime as u64),
             },
         );
-        self.tib_update(sg);
+        self.tib_update(key);
     }
 
-    pub(crate) fn downstream_prune(&mut self, ifindex: u32, sg: Sg) {
-        let Some(entry) = self.tib.get_mut(&sg) else {
+    pub(crate) fn downstream_prune(&mut self, ifindex: u32, key: SgKey) {
+        let Some(entry) = self.tib.get_mut(&key) else {
             return;
         };
         let Some(ds) = entry.downstream.get_mut(&ifindex) else {
@@ -149,8 +218,7 @@ impl Pim {
         }
         // With other PIM routers on the LAN, hold the prune open for
         // the override window so another receiver's Join can cancel
-        // it; on a point-to-point-ish link (no other neighbors would
-        // override their own prune) act on the next tick.
+        // it; point-to-point acts on the next tick.
         let others = self
             .links
             .get(&ifindex)
@@ -165,6 +233,29 @@ impl Pim {
         // Forwarding is unchanged until the timer fires (tick).
     }
 
+    /// (S,G,rpt) prune RX: record the pruned interface on the SgRpt
+    /// entry — it drops out of the (S,G) inherited olist.
+    pub(crate) fn downstream_rpt_prune(&mut self, ifindex: u32, key: SgKey, holdtime: u16) {
+        let now = Instant::now();
+        let entry = self.tib_get_or_create(key);
+        entry.downstream.insert(
+            ifindex,
+            Downstream {
+                state: DsState::Join,
+                expires: now + Duration::from_secs(holdtime as u64),
+            },
+        );
+        self.tib_update(key);
+    }
+
+    /// (S,G,rpt) join RX cancels a recorded prune.
+    pub(crate) fn downstream_rpt_join(&mut self, ifindex: u32, key: SgKey) {
+        if let Some(entry) = self.tib.get_mut(&key) {
+            entry.downstream.remove(&ifindex);
+            self.tib_update(key);
+        }
+    }
+
     // ---- upcalls from the kernel dataplane ----
 
     pub(crate) fn process_upcall(&mut self, upcall: Upcall) {
@@ -173,45 +264,43 @@ impl Pim {
                 if !upcall.grp.is_multicast() || upcall.grp.octets()[..3] == [224, 0, 0] {
                     return;
                 }
-                let sg = Sg {
+                let key = SgKey::Sg {
                     src: upcall.src,
                     grp: upcall.grp,
                 };
-                let entry = self.tib_get_or_create(sg);
+                let entry = self.tib_get_or_create(key);
                 // Traffic keeps punting until an MFC entry exists;
                 // stamp/refresh the keepalive and (re)install — with
                 // no receivers this is a "negative" empty-OIL entry
                 // that silences the punts until KAT expiry.
                 entry.stream_expires = Some(Instant::now() + KEEPALIVE_PERIOD);
-                self.tib_update(sg);
+                // First-hop router duty: register toward the RP when
+                // we are the DR for the directly-connected source.
+                self.register_check_fhr(key, upcall.vif);
+                self.tib_update(key);
             }
             UpcallKind::WrongVif | UpcallKind::WrVifWhole => {
-                // Assert machinery arrives in a later phase.
-                let iface = self
-                    .fp
-                    .ifindex_of(upcall.vif)
-                    .map_or_else(|| format!("vif {}", upcall.vif), |i| self.ifname(i));
-                tracing::debug!(
-                    "pim: wrong-vif upcall for ({}, {}) on {} (assert not yet implemented)",
-                    upcall.src,
-                    upcall.grp,
-                    iface
-                );
+                // Data on a non-IIF interface. Full assert machinery
+                // is a later phase; here it serves as the SPT-bit
+                // signal at routers that joined the source tree: the
+                // shared-tree copy still arriving proves the SPT is
+                // live, so the (S,G,rpt) prune can go out.
+                let key = SgKey::Sg {
+                    src: upcall.src,
+                    grp: upcall.grp,
+                };
+                self.spt_bit_set(key);
             }
             UpcallKind::WholePkt => {
-                tracing::debug!(
-                    "pim: wholepkt upcall for ({}, {}) (register not yet implemented)",
-                    upcall.src,
-                    upcall.grp
-                );
+                self.register_wholepkt(upcall);
             }
         }
     }
 
     // ---- RPF change propagation ----
 
-    pub(crate) fn tib_rpf_change(&mut self, sg: Sg, state: RpfState) {
-        let Some(entry) = self.tib.get_mut(&sg) else {
+    pub(crate) fn tib_rpf_change(&mut self, key: SgKey, state: RpfState) {
+        let Some(entry) = self.tib.get_mut(&key) else {
             return;
         };
         let old = entry.rpf;
@@ -223,13 +312,44 @@ impl Pim {
             && let RpfState::Gateway { ifindex, nexthop } = old
         {
             entry.join_state = JoinState::NotJoined;
-            self.jp_send_single(ifindex, nexthop, sg, false);
+            self.jp_send_entry(ifindex, nexthop, key, false);
         }
-        if let Some(entry) = self.tib.get_mut(&sg) {
+        if let Some(entry) = self.tib.get_mut(&key) {
             entry.rpf = state;
         }
-        tracing::info!("pim: {} RPF change {:?} -> {:?}", sg, old, state);
-        self.tib_update(sg);
+        tracing::info!("pim: {} RPF change {:?} -> {:?}", key, old, state);
+        self.tib_update(key);
+    }
+
+    /// Re-point an entry at a different RPF target (RP mapping
+    /// changed for a (*,G)).
+    pub(crate) fn tib_retarget(&mut self, key: SgKey, target: Option<Ipv4Addr>) {
+        let Some(entry) = self.tib.get(&key) else {
+            return;
+        };
+        let old_target = entry.rpf_target;
+        if old_target == target {
+            return;
+        }
+        // Leave the old tree.
+        if entry.join_state == JoinState::Joined
+            && let RpfState::Gateway { ifindex, nexthop } = entry.rpf
+        {
+            self.jp_send_entry(ifindex, nexthop, key, false);
+        }
+        let new_rpf = match target {
+            Some(addr) => self.rpf_acquire(addr),
+            None => RpfState::Unresolved,
+        };
+        if let Some(old) = old_target {
+            self.rpf_release(old);
+        }
+        let entry = self.tib.get_mut(&key).unwrap();
+        entry.join_state = JoinState::NotJoined;
+        entry.rpf_target = target;
+        entry.rpf = new_rpf;
+        tracing::info!("pim: {} re-targeted to {:?}", key, target);
+        self.tib_update(key);
     }
 
     // ---- neighbor hooks ----
@@ -237,7 +357,7 @@ impl Pim {
     /// A new PIM neighbor appeared: entries parked for lack of an
     /// upstream neighbor on that (interface, address) can join now.
     pub(crate) fn tib_neighbor_up(&mut self, ifindex: u32, addr: Ipv4Addr) {
-        let sgs: Vec<Sg> = self
+        let keys: Vec<SgKey> = self
             .tib
             .iter()
             .filter(|(_, e)| {
@@ -248,17 +368,17 @@ impl Pim {
                             nexthop: addr,
                         }
             })
-            .map(|(sg, _)| *sg)
+            .map(|(key, _)| *key)
             .collect();
-        for sg in sgs {
-            self.tib_update(sg);
+        for key in keys {
+            self.tib_update(key);
         }
     }
 
     /// A PIM neighbor vanished: entries joined through it fall back
     /// to NotJoined (no prune TX — the peer is gone).
     pub(crate) fn tib_neighbor_down(&mut self, ifindex: u32, addr: Ipv4Addr) {
-        let sgs: Vec<Sg> = self
+        let keys: Vec<SgKey> = self
             .tib
             .iter()
             .filter(|(_, e)| {
@@ -268,27 +388,27 @@ impl Pim {
                         nexthop: addr,
                     }
             })
-            .map(|(sg, _)| *sg)
+            .map(|(key, _)| *key)
             .collect();
-        for sg in sgs {
-            if let Some(entry) = self.tib.get_mut(&sg) {
+        for key in keys {
+            if let Some(entry) = self.tib.get_mut(&key) {
                 entry.join_state = JoinState::NotJoined;
             }
-            self.tib_update(sg);
+            self.tib_update(key);
         }
     }
 
     /// PIM stopped on an interface: drop every per-interface facet
     /// that references it.
     pub(crate) fn tib_iface_purge(&mut self, ifindex: u32) {
-        let sgs: Vec<Sg> = self.tib.keys().copied().collect();
-        for sg in sgs {
-            if let Some(entry) = self.tib.get_mut(&sg) {
+        let keys: Vec<SgKey> = self.tib.keys().copied().collect();
+        for key in keys {
+            if let Some(entry) = self.tib.get_mut(&key) {
                 let touched = entry.local.remove(&ifindex)
                     | entry.downstream.remove(&ifindex).is_some()
                     | (entry.rpf.ifindex() == Some(ifindex));
                 if touched {
-                    self.tib_update(sg);
+                    self.tib_update(key);
                 }
             }
         }
@@ -297,38 +417,60 @@ impl Pim {
     // ---- the reconvergence point ----
 
     /// Re-evaluate one entry end-to-end: lifetime, upstream
-    /// Join/Prune state, kernel MFC. Every mutation path funnels
-    /// through here.
-    pub(crate) fn tib_update(&mut self, sg: Sg) {
-        let Some(entry) = self.tib.get(&sg) else {
+    /// Join/Prune state, kernel MFC. (*,G)/(S,G,rpt) changes cascade
+    /// into the same-group (S,G) entries whose inherited olist they
+    /// feed.
+    pub(crate) fn tib_update(&mut self, key: SgKey) {
+        let Some(entry) = self.tib.get(&key) else {
             return;
         };
 
-        // Lifetime: no receivers, no live traffic keepalive → delete.
+        // Lifetime: nothing local, nothing downstream, no live
+        // traffic keepalive, register idle → delete.
         let now = Instant::now();
         let stream_alive = entry.stream_expires.map(|t| t > now).unwrap_or(false);
-        if entry.local.is_empty() && entry.downstream.is_empty() && !stream_alive {
+        if entry.local.is_empty()
+            && entry.downstream.is_empty()
+            && !stream_alive
+            && entry.reg_state == RegState::NoInfo
+        {
             let was = entry.join_state;
             let rpf = entry.rpf;
-            let installed = entry.installed.is_some();
-            if installed {
-                self.fp.mfc_del(sg.src, sg.grp);
+            let target = entry.rpf_target;
+            if entry.installed.is_some()
+                && let SgKey::Sg { src, grp } = key
+            {
+                self.fp.mfc_del(src, grp);
             }
             if was == JoinState::Joined
                 && let RpfState::Gateway { ifindex, nexthop } = rpf
             {
-                self.jp_send_single(ifindex, nexthop, sg, false);
+                self.jp_send_entry(ifindex, nexthop, key, false);
             }
-            self.tib.remove(&sg);
-            self.rpf_release(sg.src);
-            tracing::info!("pim: {} deleted", sg);
+            self.tib.remove(&key);
+            if let Some(addr) = target {
+                self.rpf_release(addr);
+            }
+            tracing::info!("pim: {} deleted", key);
+            self.tib_cascade(key);
             return;
         }
 
-        // Upstream FSM: Joined iff JoinDesired and the RPF gateway is
-        // a live PIM neighbor. Connected sources need no Join.
-        let entry = self.tib.get(&sg).unwrap();
-        let jd = join_desired(entry);
+        // Upstream FSM. JoinDesired:
+        //   (*,G): immediate olist non-empty, RP known, not the RP.
+        //   (S,G): immediate non-empty, or KAT running with a
+        //          non-empty inherited olist (the RP / LHR SPT-join
+        //          clause).
+        // Sending additionally requires a live PIM gateway neighbor.
+        let jd = match key {
+            SgKey::StarG { grp } => join_desired(&self.tib, key) && !self.i_am_rp(grp),
+            SgKey::Sg { .. } => {
+                join_desired(&self.tib, key)
+                    || (stream_alive && !inherited_olist(&self.tib, key).is_empty())
+            }
+            SgKey::SgRpt { .. } => false,
+        };
+        let entry = self.tib.get(&key).unwrap();
         let upstream_nbr = match entry.rpf {
             RpfState::Gateway { ifindex, nexthop } => self
                 .links
@@ -341,43 +483,105 @@ impl Pim {
         let is_joined = entry.join_state == JoinState::Joined;
         if want_joined && !is_joined {
             let (ifindex, nexthop) = upstream_nbr.unwrap();
-            self.tib.get_mut(&sg).unwrap().join_state = JoinState::Joined;
-            self.jp_send_single(ifindex, nexthop, sg, true);
+            self.tib.get_mut(&key).unwrap().join_state = JoinState::Joined;
+            self.jp_send_entry(ifindex, nexthop, key, true);
             self.jp_refresh_arm(ifindex, nexthop);
-            tracing::info!("pim: {} joined toward {}", sg, nexthop);
+            tracing::info!("pim: {} joined toward {}", key, nexthop);
         } else if !want_joined && is_joined {
-            self.tib.get_mut(&sg).unwrap().join_state = JoinState::NotJoined;
+            self.tib.get_mut(&key).unwrap().join_state = JoinState::NotJoined;
             if let Some((ifindex, nexthop)) = upstream_nbr {
-                self.jp_send_single(ifindex, nexthop, sg, false);
-                tracing::info!("pim: {} pruned toward {}", sg, nexthop);
+                self.jp_send_entry(ifindex, nexthop, key, false);
+                tracing::info!("pim: {} pruned toward {}", key, nexthop);
             }
         }
 
-        // Kernel MFC: (iif, oifs) from the current predicates; install
-        // when the IIF resolves and there is either an OIF or live
-        // traffic state (negative cache), else uninstall.
-        let entry = self.tib.get(&sg).unwrap();
-        let iif_vif = entry.rpf.ifindex().and_then(|ifindex| self.fp.vif(ifindex));
-        let desired = match iif_vif {
-            Some(iif) => {
-                let oifs: Vec<u16> = mfc_oifs(entry, entry.rpf.ifindex())
-                    .iter()
-                    .filter_map(|ifindex| self.fp.vif(*ifindex))
-                    .collect();
-                if !oifs.is_empty() || stream_alive {
-                    Some(InstalledMfc { iif, oifs })
-                } else {
-                    None
+        // Kernel MFC — (S,G) entries only. OIL = inherited olist
+        // (immediate + shared-tree minus rpt-pruned) minus IIF, plus
+        // the register VIF while actively registering.
+        if let SgKey::Sg { src, grp } = key {
+            let entry = self.tib.get(&key).unwrap();
+            let iif_vif = entry.rpf.ifindex().and_then(|ifindex| self.fp.vif(ifindex));
+            let registering = entry.reg_state == RegState::Join;
+            let desired = match iif_vif {
+                Some(iif) => {
+                    let mut oifs: Vec<u16> = mfc_oifs(&self.tib, key)
+                        .iter()
+                        .filter_map(|ifindex| self.fp.vif(*ifindex))
+                        .collect();
+                    if registering {
+                        oifs.push(REG_VIF);
+                    }
+                    if !oifs.is_empty() || stream_alive {
+                        Some(InstalledMfc { iif, oifs })
+                    } else {
+                        None
+                    }
                 }
+                None => None,
+            };
+            let entry = self.tib.get(&key).unwrap();
+            if entry.installed != desired {
+                match &desired {
+                    Some(mfc) => self.fp.mfc_add(src, grp, mfc.iif, &mfc.oifs),
+                    None => self.fp.mfc_del(src, grp),
+                }
+                self.tib.get_mut(&key).unwrap().installed = desired;
             }
-            None => None,
+        } else {
+            self.tib_cascade(key);
+        }
+    }
+
+    /// A (*,G) or (S,G,rpt) change feeds the inherited olists of the
+    /// same-group (S,G) entries — re-evaluate them.
+    fn tib_cascade(&mut self, key: SgKey) {
+        if matches!(key, SgKey::Sg { .. }) {
+            return;
+        }
+        let grp = key.grp();
+        let sgs: Vec<SgKey> = self
+            .tib
+            .keys()
+            .filter(|k| matches!(k, SgKey::Sg { .. }) && k.grp() == grp)
+            .copied()
+            .collect();
+        for sg in sgs {
+            self.tib_update(sg);
+        }
+    }
+
+    /// Native source-tree traffic confirmed for a joined (S,G): mark
+    /// the SPT bit and send the triggered (S,G,rpt) prune toward the
+    /// shared tree when the paths diverge.
+    fn spt_bit_set(&mut self, key: SgKey) {
+        let SgKey::Sg { src, grp } = key else {
+            return;
         };
-        if entry.installed != desired {
-            match &desired {
-                Some(mfc) => self.fp.mfc_add(sg.src, sg.grp, mfc.iif, &mfc.oifs),
-                None => self.fp.mfc_del(sg.src, sg.grp),
-            }
-            self.tib.get_mut(&sg).unwrap().installed = desired;
+        let Some(entry) = self.tib.get_mut(&key) else {
+            return;
+        };
+        if entry.spt_bit || entry.join_state != JoinState::Joined {
+            return;
+        }
+        entry.spt_bit = true;
+        let sg_rpf = entry.rpf;
+        // The prune goes toward RPF'(*,G) — only when it differs from
+        // RPF'(S,G) (same path ⇒ no duplicates to cut).
+        let star = SgKey::StarG { grp };
+        let Some(star_entry) = self.tib.get(&star) else {
+            return;
+        };
+        if star_entry.rpf == sg_rpf {
+            return;
+        }
+        if let RpfState::Gateway { ifindex, nexthop } = star_entry.rpf {
+            tracing::info!(
+                "pim: {} SPT bit set — pruning ({}, {}) off the RPT",
+                key,
+                src,
+                grp
+            );
+            self.jp_send_entry(ifindex, nexthop, SgKey::SgRpt { src, grp }, false);
         }
     }
 
@@ -391,6 +595,10 @@ impl Pim {
         for entry in self.tib.values() {
             if let Some(t) = entry.stream_expires {
                 consider(t);
+            }
+            match entry.reg_state {
+                RegState::Prune { until } | RegState::JoinPending { until } => consider(until),
+                _ => {}
             }
             for ds in entry.downstream.values() {
                 consider(ds.expires);
@@ -406,8 +614,8 @@ impl Pim {
     }
 
     pub(crate) fn tib_tick(&mut self, now: Instant) {
-        let mut touched: Vec<Sg> = vec![];
-        for (sg, entry) in self.tib.iter_mut() {
+        let mut touched: Vec<SgKey> = vec![];
+        for (key, entry) in self.tib.iter_mut() {
             let before = entry.downstream.len();
             entry.downstream.retain(|_, ds| {
                 if ds.expires <= now {
@@ -423,12 +631,13 @@ impl Pim {
                 changed = true;
             }
             if changed {
-                touched.push(*sg);
+                touched.push(*key);
             }
         }
-        for sg in touched {
-            self.tib_update(sg);
+        for key in touched {
+            self.tib_update(key);
         }
+        self.register_tick(now);
         self.jp_tick(now);
     }
 }

--- a/zebra-rs/yang/config.yang
+++ b/zebra-rs/yang/config.yang
@@ -3985,6 +3985,22 @@ module config {
       container pim {
         ext:help "PIM-SM routing protocol configuration";
         presence "Enables configuration of PIM-SM";
+        container rp {
+          ext:help "Rendezvous Point configuration";
+          list static {
+            ext:help "Static RP address for a group range";
+            key "address";
+            leaf address {
+              ext:help "RP address";
+              type inet:ipv4-address;
+            }
+            leaf group {
+              ext:help "Multicast group prefix served by this RP";
+              type inet:ipv4-prefix;
+              default "224.0.0.0/4";
+            }
+          }
+        }
         list interface {
           ext:help "Per-interface PIM configuration";
           key "if-name";

--- a/zebra-rs/yang/exec.yang
+++ b/zebra-rs/yang/exec.yang
@@ -1013,6 +1013,10 @@ module exec {
         ext:help "PIM upstream (S,G) join state";
         presence "PIM upstream";
       }
+      container rp-info {
+        ext:help "PIM group-to-RP mappings";
+        presence "PIM RP info";
+      }
     }
 
     container mroute {


### PR DESCRIPTION
## Summary

Phase 5 of the PIM-SM/SSM arc (architecture: `docs/design/pim-sm-ssm-architecture.md`; Phases 1–4: #1951 / #1956 / #1960 / #1965) — the ASM control loop closes end to end:

- **Unified TIB**: `SgKey::{StarG, Sg, SgRpt}` per the design doc; `tib_update` handles per-kind lifetime/upstream/MFC and cascades (\*,G)/(S,G,rpt) changes into same-group (S,G) inherited olists.
- **`macros.rs`**: predicates over the whole TIB — `inherited_olist(S,G)` folds the shared tree minus rpt-pruned interfaces (unit-tested); (S,G) JoinDesired gains the RFC's KAT∧inherited clause (what makes the RP/LHR join the SPT).
- **`rp.rs`**: static RP set with group-prefix LPM, `i_am_rp`, SSM-range predicate (232/8), (\*,G) re-targeting on mapping changes.
- **`register.rs`**: FHR duty on NOCACHE (DR + connected source + ASM + RP known); register VIF 0 (created at init) in the OIL turns WHOLEPKT punts into unicast Registers; RP-side RX creates/keeps-alive the (S,G) and answers Register-Stop once its SPT join is out or nobody listens; DR-side suppression with Null-Register probes (55 s / 5 s).
- **SPT switchover**: WRONGVIF doubles as the SPT-bit signal; the (S,G,rpt) prune fires toward RPF′(\*,G) only when the trees diverge, then rides the periodic (\*,G) refresh.
- **IGMP bridge**: EXCLUDE (any-source) membership → local (\*,G) state.
- **Documented simplifications**: no kernel (\*,G) MFC (per-source NOCACHE entries with inherited OILs — sidesteps the kernel IIF∈OIF quirk) and no kernel register decap at the RP (brief pre-SPT window dropped; switch-to-SPT-immediately policy).
- Management: `router pim rp static` YANG + callbacks, `show pim rp-info`, register state in `show pim upstream`, `T` flag in `show mroute`.

## Test plan

- Live BDD under sudo (fresh binary + YANG, md5-checked): `--tags @pim_asm` — 5 namespaces, 3 routers with r2 as static RP: shared tree at LHR and RP, register cycle settling in **RegPrune** at the FHR (Register → RP SPT-join → Register-Stop proven), kernel MFCs on all three routers, and the sender's payload delivered to the receiver across the whole path. All 45 steps ✔.
- Regressions: `@pim_adjacency` + `@pim_igmp` + `@pim_ssm` re-run — all pass.
- `cargo test --workspace --exclude bdd`: green (1,592 zebra-rs tests). Forced-fresh `cargo clean -p zebra-rs && cargo clippy --workspace --all-targets -- -D warnings`: exit 0. `cargo fmt --all --check`: clean.

Generated with [Claude Code](https://claude.com/claude-code)